### PR TITLE
Strip and rewrite all DoltLite comments

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -1,35 +1,4 @@
-/*
-** Implementation of the file-backed content-addressed chunk store.
-**
-** Single-file architecture with appended WAL region:
-**
-** Main file (filename):
-**   [Manifest header: 168 bytes]
-**   [Chunk data region: variable]  — chunks: length(4) + data(length) each
-**   [Chunk index: variable]        — sorted (hash(20) + offset(8) + size(4))
-**
-** WAL region (appended to same file):
-**   Append-only log of new chunks and root hash records.
-**   [Record]*  where each record is:
-**     Chunk record:  tag(1)=0x01 + hash(20) + length(4) + data(length)
-**     Root record:   tag(1)=0x02 + manifest(168)
-**
-** Commit protocol (O(new_chunks), not O(total_chunks)):
-**   1. Append new chunk records to WAL region
-**   2. Append root record with updated manifest
-**   3. fsync — this is the durability point
-**
-** Recovery (on open):
-**   1. Read main file (manifest + index)
-**   2. Replay WAL region: add chunk records to in-memory index,
-**      use last root record as the current manifest state
-**   3. If WAL region is non-empty, main file manifest may be stale — that's OK
-**
-** GC / Checkpoint:
-**   Rewrite main file with all chunks compacted (WAL region becomes empty).
-**
-** All multi-byte integers are little-endian.
-*/
+
 #ifdef DOLTLITE_PROLLY
 
 #include "chunk_store.h"
@@ -41,10 +10,6 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 
-/* Portable flock helpers for concurrent writer serialization in
-** csCommitToFile.  Uses raw POSIX flock (not VFS xLock) because the
-** VFS per-inode lock tracker conflicts with other VFS handles to the
-** same file within the process.  All data I/O routes through the VFS. */
 #ifdef _WIN32
 # include <io.h>
 # include <windows.h>
@@ -84,14 +49,9 @@
     return 0;
   }
   static void csFileUnlock(int fd){
-    if( fd >= 0 ) close(fd);  /* close releases flock */
+    if( fd >= 0 ) close(fd);  
   }
 #endif
-
-/* --------------------------------------------------------------------
-** Little-endian helper macros for reading/writing integers from byte
-** buffers. These work on any alignment and any host byte order.
-** -------------------------------------------------------------------- */
 
 #define CS_READ_U32(p) (             \
   (u32)(((const u8*)(p))[0])       | \
@@ -129,9 +89,6 @@
   ((u8*)(p))[7] = (u8)((u64)(v) >> 56);   \
 } while(0)
 
-/* --------------------------------------------------------------------
-** Forward declarations for internal helpers.
-** -------------------------------------------------------------------- */
 static int csOpenFile(sqlite3_vfs *pVfs, const char *zPath,
                       sqlite3_file **ppFile, int flags);
 static void csCloseFile(sqlite3_file *pFile);
@@ -153,22 +110,13 @@ static int csGrowWriteBuf(ChunkStore *cs, int nNeeded);
 static int csReplayWalRegion(ChunkStore *cs, int updateManifest);
 static int csReplayWal(ChunkStore *cs){ return csReplayWalRegion(cs, 1); }
 
-/* Journal record tags */
-#define CS_WAL_TAG_CHUNK  0x01   /* Chunk record: tag(1)+hash(20)+len(4)+data */
-#define CS_WAL_TAG_ROOT   0x02   /* Root record: tag(1)+manifest(168) */
+#define CS_WAL_TAG_CHUNK  0x01   
+#define CS_WAL_TAG_ROOT   0x02   
 
-/*
-** WAL offset encoding: file offsets are stored as-is (>= 0).
-** WAL-region offsets are stored as -(walPos) - 1 (always < 0).
-** This distinguishes file-resident chunks from WAL-resident chunks.
-*/
 static i64 csEncodeWalOffset(i64 walPos){ return -(walPos) - 1; }
 static i64 csDecodeWalOffset(i64 encoded){ return -(encoded + 1); }
 static int csIsWalOffset(i64 offset){ return offset < 0; }
 
-/*
-** Helper functions to free branch and tag arrays, used in multiple places.
-*/
 static void csFreeBranches(ChunkStore *cs){
   int k;
   for(k=0; k<cs->nBranches; k++) sqlite3_free(cs->aBranches[k].zName);
@@ -204,14 +152,10 @@ static void csFreeTracking(ChunkStore *cs){
   cs->nTracking = 0;
 }
 
-/* Initial allocation sizes */
 #define CS_INIT_INDEX_ALLOC   64
 #define CS_INIT_PENDING_ALLOC 16
 #define CS_INIT_WRITEBUF_SIZE 4096
 
-/* --------------------------------------------------------------------
-** csOpenFile -- allocate and open a sqlite3_file via the VFS layer.
-** -------------------------------------------------------------------- */
 static int csOpenFile(
   sqlite3_vfs *pVfs,
   const char *zPath,
@@ -224,19 +168,12 @@ static int csOpenFile(
   return rc;
 }
 
-/* --------------------------------------------------------------------
-** csCloseFile -- close and free a sqlite3_file.
-** -------------------------------------------------------------------- */
 static void csCloseFile(sqlite3_file *pFile){
   if( pFile ){
     sqlite3OsCloseFree(pFile);
   }
 }
 
-/* --------------------------------------------------------------------
-** csSearchIndex -- binary search the sorted index for a hash.
-** Returns the index if found, or -1 if not found.
-** -------------------------------------------------------------------- */
 static int csSearchIndex(
   const ChunkIndexEntry *aIdx,
   int nIdx,
@@ -257,13 +194,8 @@ static int csSearchIndex(
   return -1;
 }
 
-/* --------------------------------------------------------------------
-** csSearchPending -- O(1) hash table lookup for pending chunks.
-** Uses an incrementally-built hash table with dynamic resizing.
-** Starts at 4K buckets and doubles when load factor exceeds 4.
-** -------------------------------------------------------------------- */
 #define CS_PEND_HT_INIT_BITS 12
-#define CS_PEND_HT_MAX_LOAD  4   /* Rebuild when nPending/nBuckets > this */
+#define CS_PEND_HT_MAX_LOAD  4   
 
 static u32 csPendBucket(const ProllyHash *h, int nHTMask){
   return ((u32)h->data[0] | ((u32)h->data[1]<<8)
@@ -279,9 +211,6 @@ static void csPendHTClear(ChunkStore *cs){
   cs->nPendingHTSize = 0;
 }
 
-/*
-** Rebuild the entire hash table at the current size.
-*/
 static int csPendHTRebuild(ChunkStore *cs){
   int i;
   memset(cs->aPendingHT, 0xff, cs->nPendingHTSize * sizeof(int));
@@ -305,14 +234,14 @@ static int csPendHTEnsure(ChunkStore *cs){
     cs->nPendingHTSize = initSize;
     cs->nPendingHTBuilt = 0;
   }
-  /* Grow hash table when load factor exceeds threshold */
+  
   if( cs->nPending > cs->nPendingHTSize * CS_PEND_HT_MAX_LOAD ){
     int newSize = cs->nPendingHTSize * 4;
     int *aNew = sqlite3_realloc(cs->aPendingHT, newSize * (int)sizeof(int));
     if( aNew ){
       cs->aPendingHT = aNew;
       cs->nPendingHTSize = newSize;
-      /* Must rebuild chains with new mask */
+      
       if( !cs->aPendingHTNext || cs->nPendingAlloc > cs->nPendingHTNextAlloc ){
         int nAlloc = cs->nPendingAlloc > 0 ? cs->nPendingAlloc : 64;
         int *aNew2 = sqlite3_realloc(cs->aPendingHTNext, nAlloc*(int)sizeof(int));
@@ -322,7 +251,7 @@ static int csPendHTEnsure(ChunkStore *cs){
       }
       return csPendHTRebuild(cs);
     }
-    /* On OOM, continue with existing table (degraded perf, not incorrect) */
+    
   }
   if( !cs->aPendingHTNext || cs->nPendingAlloc > cs->nPendingHTNextAlloc ){
     int nAlloc = cs->nPendingAlloc > 0 ? cs->nPendingAlloc : 64;
@@ -344,7 +273,7 @@ static int csSearchPending(ChunkStore *cs, const ProllyHash *pHash){
   int i; u32 b;
   if( cs->nPending==0 ) return -1;
   if( csPendHTEnsure(cs)!=SQLITE_OK ){
-    /* Fallback to linear scan on OOM */
+    
     for(i=0; i<cs->nPending; i++){
       if( prollyHashCompare(&cs->aPending[i].hash, pHash)==0 ) return i;
     }
@@ -359,24 +288,6 @@ static int csSearchPending(ChunkStore *cs, const ProllyHash *pHash){
   return -1;
 }
 
-/* --------------------------------------------------------------------
-** csSerializeManifest -- write the 168-byte manifest header into aBuf.
-** -------------------------------------------------------------------- */
-/*
-** V6 manifest layout (168 bytes):
-**   0-3:   magic (DLTC)
-**   4-7:   version (6)
-**   8-27:  root hash
-**   28-31: nChunks
-**   32-39: iIndexOffset
-**   40-43: nIndexSize
-**   44-63: catalog hash
-**   64-83: headCommit hash
-**   84-91: iWalOffset (new in V6 — where WAL region starts)
-**   92-103: reserved (zero)
-**   104-123: refsHash
-**   124-167: reserved (zero)
-*/
 void csSerializeManifest(const ChunkStore *cs, u8 *aBuf){
   memset(aBuf, 0, CHUNK_MANIFEST_SIZE);
   CS_WRITE_U32(aBuf + 0, CHUNK_STORE_MAGIC);
@@ -391,29 +302,18 @@ void csSerializeManifest(const ChunkStore *cs, u8 *aBuf){
   memcpy(aBuf + 104, cs->refsHash.data, PROLLY_HASH_SIZE);
 }
 
-/* --------------------------------------------------------------------
-** csSerializeIndexEntry -- write one 32-byte index entry.
-** -------------------------------------------------------------------- */
 static void csSerializeIndexEntry(const ChunkIndexEntry *e, u8 *aBuf){
   memcpy(aBuf, e->hash.data, PROLLY_HASH_SIZE);
   CS_WRITE_I64(aBuf + PROLLY_HASH_SIZE, e->offset);
   CS_WRITE_U32(aBuf + PROLLY_HASH_SIZE + 8, (u32)e->size);
 }
 
-/* --------------------------------------------------------------------
-** csDeserializeIndexEntry -- read one 32-byte index entry.
-** -------------------------------------------------------------------- */
 static void csDeserializeIndexEntry(const u8 *aBuf, ChunkIndexEntry *e){
   memcpy(e->hash.data, aBuf, PROLLY_HASH_SIZE);
   e->offset = CS_READ_I64(aBuf + PROLLY_HASH_SIZE);
   e->size = (int)CS_READ_U32(aBuf + PROLLY_HASH_SIZE + 8);
 }
 
-/* --------------------------------------------------------------------
-** csReadManifest -- read and validate the 168-byte manifest from an
-** already-open file. Populates cs->root, cs->nChunks, cs->iIndexOffset,
-** cs->nIndexSize.  Returns SQLITE_OK or error.
-** -------------------------------------------------------------------- */
 static int csReadManifest(ChunkStore *cs){
   u8 aBuf[CHUNK_MANIFEST_SIZE];
   u32 magic, version;
@@ -439,10 +339,6 @@ static int csReadManifest(ChunkStore *cs){
   return SQLITE_OK;
 }
 
-/* --------------------------------------------------------------------
-** csReadIndex -- read the chunk index from the file into cs->aIndex.
-** Must be called after csReadManifest populates iIndexOffset/nIndexSize.
-** -------------------------------------------------------------------- */
 static int csReadIndex(ChunkStore *cs){
   int rc;
   int nEntries;
@@ -450,7 +346,7 @@ static int csReadIndex(ChunkStore *cs){
   int i;
 
   if( cs->nIndexSize == 0 || cs->nChunks == 0 ){
-    /* Empty store: no index to read */
+    
     cs->nIndex = 0;
     return SQLITE_OK;
   }
@@ -460,7 +356,7 @@ static int csReadIndex(ChunkStore *cs){
     return SQLITE_CORRUPT;
   }
 
-  /* Allocate the in-memory index array */
+  
   cs->aIndex = (ChunkIndexEntry *)sqlite3_malloc(
     nEntries * (int)sizeof(ChunkIndexEntry)
   );
@@ -468,7 +364,7 @@ static int csReadIndex(ChunkStore *cs){
   cs->nIndex = nEntries;
   cs->nIndexAlloc = nEntries;
 
-  /* Read raw bytes */
+  
   aBuf = (u8 *)sqlite3_malloc(cs->nIndexSize);
   if( aBuf == 0 ){
     sqlite3_free(cs->aIndex);
@@ -486,7 +382,7 @@ static int csReadIndex(ChunkStore *cs){
     return rc;
   }
 
-  /* Deserialize each entry */
+  
   for( i = 0; i < nEntries; i++ ){
     csDeserializeIndexEntry(aBuf + i * CHUNK_INDEX_ENTRY_SIZE, &cs->aIndex[i]);
   }
@@ -495,9 +391,6 @@ static int csReadIndex(ChunkStore *cs){
   return SQLITE_OK;
 }
 
-/* --------------------------------------------------------------------
-** csGrowPending -- ensure space for at least one more pending entry.
-** -------------------------------------------------------------------- */
 static int csGrowPending(ChunkStore *cs){
   if( cs->nPending >= cs->nPendingAlloc ){
     int nNew = cs->nPendingAlloc ? cs->nPendingAlloc * 2 : CS_INIT_PENDING_ALLOC;
@@ -511,15 +404,11 @@ static int csGrowPending(ChunkStore *cs){
   return SQLITE_OK;
 }
 
-/* --------------------------------------------------------------------
-** csGrowWriteBuf -- ensure the write buffer can hold nNeeded more bytes.
-** -------------------------------------------------------------------- */
 static int csGrowWriteBuf(ChunkStore *cs, int nNeeded){
   i64 nRequired = cs->nWriteBuf + (i64)nNeeded;
   if( nRequired > cs->nWriteBufAlloc ){
     i64 nNew = cs->nWriteBufAlloc ? cs->nWriteBufAlloc : CS_INIT_WRITEBUF_SIZE;
-    /* Double for small buffers; grow by 50% once past 64 MB to avoid
-    ** excessive over-allocation for long-lived in-memory stores. */
+    
     while( nNew < nRequired ){
       if( nNew < 64*1024*1024 ){
         nNew *= 2;
@@ -535,12 +424,6 @@ static int csGrowWriteBuf(ChunkStore *cs, int nNeeded){
   return SQLITE_OK;
 }
 
-/*
-** Read and replay the WAL region from the main file.
-** The WAL region starts at cs->iWalOffset and extends to EOF.
-** Reads the WAL data into cs->pWalData, parses chunk and root records,
-** and merges new entries into the in-memory index.
-*/
 static int csReplayWalRegion(ChunkStore *cs, int updateManifest){
   i64 walSize;
   u8 *walData;
@@ -548,7 +431,7 @@ static int csReplayWalRegion(ChunkStore *cs, int updateManifest){
 
   if( cs->iWalOffset <= 0 || !cs->pFile ) return SQLITE_OK;
 
-  /* Get file size to determine WAL region size */
+  
   {
     i64 fileSize = 0;
     int rc = sqlite3OsFileSize(cs->pFile, &fileSize);
@@ -556,9 +439,9 @@ static int csReplayWalRegion(ChunkStore *cs, int updateManifest){
     walSize = fileSize - cs->iWalOffset;
     cs->iFileSize = fileSize;
   }
-  if( walSize <= 0 ) return SQLITE_OK;  /* Empty WAL region */
+  if( walSize <= 0 ) return SQLITE_OK;  
 
-  /* Read WAL region into memory */
+  
   walData = (u8*)sqlite3_malloc64(walSize);
   if( !walData ) return SQLITE_NOMEM;
   {
@@ -569,12 +452,12 @@ static int csReplayWalRegion(ChunkStore *cs, int updateManifest){
     }
   }
 
-  /* Store WAL data for chunk reads */
+  
   sqlite3_free(cs->pWalData);
   cs->pWalData = walData;
   cs->nWalData = walSize;
 
-  /* Parse WAL records */
+  
   pos = 0;
   while( pos < walSize ){
     u8 tag = walData[pos];
@@ -618,8 +501,7 @@ static int csReplayWalRegion(ChunkStore *cs, int updateManifest){
           memcpy(cs->catalog.data, m + 44, PROLLY_HASH_SIZE);
           memcpy(cs->headCommit.data, m + 64, PROLLY_HASH_SIZE);
           memcpy(cs->refsHash.data, m + 104, PROLLY_HASH_SIZE);
-          /* Note: iIndexOffset/nIndexSize from WAL root records refer to
-          ** the compacted region, which hasn't changed. Keep existing values. */
+          
         }
       }
       pos += CHUNK_MANIFEST_SIZE;
@@ -629,7 +511,7 @@ static int csReplayWalRegion(ChunkStore *cs, int updateManifest){
     }
   }
 
-  /* Merge WAL entries into main index */
+  
   if( cs->nPending > 0 ){
     ChunkIndexEntry *aMerged = 0;
     int nMerged = 0;
@@ -647,7 +529,7 @@ static int csReplayWalRegion(ChunkStore *cs, int updateManifest){
     csPendHTClear(cs);
   }
 
-  /* Reload refs from the WAL-updated refsHash */
+  
   if( !prollyHashIsEmpty(&cs->refsHash) ){
     u8 *refsData = 0; int nRefsData = 0;
     int rc2 = chunkStoreGet(cs, &cs->refsHash, &refsData, &nRefsData);
@@ -668,19 +550,12 @@ static int csReplayWalRegion(ChunkStore *cs, int updateManifest){
   return SQLITE_OK;
 }
 
-/* --------------------------------------------------------------------
-** Comparison function for qsort of ChunkIndexEntry by hash.
-** -------------------------------------------------------------------- */
 static int csIndexEntryCmp(const void *a, const void *b){
   const ChunkIndexEntry *ea = (const ChunkIndexEntry *)a;
   const ChunkIndexEntry *eb = (const ChunkIndexEntry *)b;
   return prollyHashCompare(&ea->hash, &eb->hash);
 }
 
-/* --------------------------------------------------------------------
-** csMergeIndex -- merge aIndex and aPending into a single sorted array.
-** Caller must sqlite3_free *ppMerged.
-** -------------------------------------------------------------------- */
 static int csMergeIndex(
   ChunkStore *cs,
   ChunkIndexEntry **ppMerged,
@@ -699,17 +574,17 @@ static int csMergeIndex(
   );
   if( aMerged == 0 ) return SQLITE_NOMEM;
 
-  /* Merge two sorted arrays. aPending may not be sorted yet. */
-  /* Sort aPending first. */
+  
+  
   if( cs->nPending > 1 ){
     qsort(cs->aPending, cs->nPending, sizeof(ChunkIndexEntry),
           csIndexEntryCmp);
   }
 
-  /* Standard merge of two sorted arrays */
-  idxPos = 0;   /* index into aIndex */
-  pendPos = 0;  /* index into aPending */
-  outPos = 0;   /* index into aMerged */
+  
+  idxPos = 0;   
+  pendPos = 0;  
+  outPos = 0;   
   while( idxPos < cs->nIndex && pendPos < cs->nPending ){
     int cmp = prollyHashCompare(&cs->aIndex[idxPos].hash, &cs->aPending[pendPos].hash);
     if( cmp < 0 ){
@@ -717,7 +592,7 @@ static int csMergeIndex(
     }else if( cmp > 0 ){
       aMerged[outPos++] = cs->aPending[pendPos++];
     }else{
-      /* Duplicate hash: pending wins (shouldn't normally happen) */
+      
       aMerged[outPos++] = cs->aPending[pendPos++];
       idxPos++;
     }
@@ -730,17 +605,6 @@ static int csMergeIndex(
   return SQLITE_OK;
 }
 
-/* ====================================================================
-** Public API implementation
-** ==================================================================== */
-
-/*
-** Open or create a chunk store at the given path.
-**
-** If the file exists, its manifest and index are loaded into memory.
-** If it does not exist and flags include SQLITE_OPEN_CREATE, an empty
-** store is initialized (no file is written until commit).
-*/
 int chunkStoreOpen(
   ChunkStore *cs,
   sqlite3_vfs *pVfs,
@@ -754,7 +618,7 @@ int chunkStoreOpen(
   memset(cs, 0, sizeof(*cs));
   cs->pVfs = pVfs;
 
-  /* Detect in-memory databases: NULL, empty string, or ":memory:" */
+  
   if( zFilename==0 || zFilename[0]=='\0'
    || strcmp(zFilename, ":memory:")==0 ){
     cs->isMemory = 1;
@@ -769,15 +633,13 @@ int chunkStoreOpen(
     return SQLITE_OK;
   }
 
-  /* Copy the filename */
+  
   n = (int)strlen(zFilename);
   cs->zFilename = (char *)sqlite3_malloc(n + 1);
   if( cs->zFilename == 0 ) return SQLITE_NOMEM;
   memcpy(cs->zFilename, zFilename, n + 1);
 
-  /* Check if the file already exists.
-  ** Use cs->zFilename (our persistent copy) not the caller's zFilename
-  ** which may be freed after this function returns. */
+  
   rc = sqlite3OsAccess(pVfs, cs->zFilename, SQLITE_ACCESS_EXISTS, &exists);
   if( rc != SQLITE_OK ){
     sqlite3_free(cs->zFilename);
@@ -785,7 +647,7 @@ int chunkStoreOpen(
     return rc;
   }
 
-  /* Treat zero-byte placeholder as non-existent */
+  
   if( exists ){
     struct stat mainStat;
     if( stat(cs->zFilename, &mainStat)==0 && mainStat.st_size==0 ){
@@ -794,7 +656,7 @@ int chunkStoreOpen(
   }
 
   if( exists ){
-    /* Open the existing single file */
+    
     int openFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB;
     rc = csOpenFile(pVfs, cs->zFilename, &cs->pFile, openFlags);
     if( rc != SQLITE_OK ){
@@ -808,7 +670,7 @@ int chunkStoreOpen(
       cs->readOnly = 1;
     }
 
-    /* Read manifest */
+    
     rc = csReadManifest(cs);
     if( rc != SQLITE_OK ){
       csCloseFile(cs->pFile);
@@ -818,7 +680,7 @@ int chunkStoreOpen(
       return rc;
     }
 
-    /* Read chunk index from compacted region */
+    
     rc = csReadIndex(cs);
     if( rc != SQLITE_OK ){
       csCloseFile(cs->pFile);
@@ -828,7 +690,7 @@ int chunkStoreOpen(
       return rc;
     }
 
-    /* Replay WAL region (iWalOffset to EOF) */
+    
     rc = csReplayWal(cs);
     if( rc != SQLITE_OK ){
       csCloseFile(cs->pFile);
@@ -838,7 +700,7 @@ int chunkStoreOpen(
       return rc;
     }
 
-    /* Load refs chunk (may be in compacted or WAL region) */
+    
     if( !prollyHashIsEmpty(&cs->refsHash) ){
       u8 *refsData = 0; int nRefsData = 0;
       rc = chunkStoreGet(cs, &cs->refsHash, &refsData, &nRefsData);
@@ -856,7 +718,7 @@ int chunkStoreOpen(
     }
     if( !cs->zDefaultBranch ) cs->zDefaultBranch = sqlite3_mprintf("main");
   }else{
-    /* File doesn't exist — create new */
+    
     if( !(flags & SQLITE_OPEN_CREATE) ){
       sqlite3_free(cs->zFilename);
       cs->zFilename = 0;
@@ -866,7 +728,7 @@ int chunkStoreOpen(
     cs->nChunks = 0;
     cs->iIndexOffset = 0;
     cs->nIndexSize = 0;
-    cs->iWalOffset = CHUNK_MANIFEST_SIZE;  /* WAL starts right after manifest */
+    cs->iWalOffset = CHUNK_MANIFEST_SIZE;  
     cs->iFileSize = 0;
     cs->pFile = 0;
   }
@@ -874,9 +736,6 @@ int chunkStoreOpen(
   return SQLITE_OK;
 }
 
-/*
-** Close the chunk store.  Any uncommitted pending data is discarded.
-*/
 int chunkStoreClose(ChunkStore *cs){
   if( cs->pFile ){
     csCloseFile(cs->pFile);
@@ -897,16 +756,10 @@ int chunkStoreClose(ChunkStore *cs){
   return SQLITE_OK;
 }
 
-/*
-** Get the current root hash.
-*/
 void chunkStoreGetRoot(ChunkStore *cs, ProllyHash *pRoot){
   memcpy(pRoot, &cs->root, sizeof(ProllyHash));
 }
 
-/*
-** Set the root hash. This is staged and not persisted until commit.
-*/
 void chunkStoreSetRoot(ChunkStore *cs, const ProllyHash *pRoot){
   memcpy(&cs->root, pRoot, sizeof(ProllyHash));
 }
@@ -934,8 +787,6 @@ void chunkStoreGetStagedCatalog(ChunkStore *cs, ProllyHash *pStaged){
 void chunkStoreSetStagedCatalog(ChunkStore *cs, const ProllyHash *pStaged){
   memcpy(&cs->stagedCatalog, pStaged, sizeof(ProllyHash));
 }
-
-/* --- Branch management --- */
 
 const char *chunkStoreGetDefaultBranch(ChunkStore *cs){
   return cs->zDefaultBranch ? cs->zDefaultBranch : "main";
@@ -998,8 +849,6 @@ int chunkStoreDeleteBranch(ChunkStore *cs, const char *zName){
   return SQLITE_NOTFOUND;
 }
 
-/* --- Per-branch WorkingSet --- */
-
 int chunkStoreGetBranchWorkingSet(ChunkStore *cs, const char *zBranch, ProllyHash *pHash){
   int i;
   for(i=0; i<cs->nBranches; i++){
@@ -1022,8 +871,6 @@ int chunkStoreSetBranchWorkingSet(ChunkStore *cs, const char *zBranch, const Pro
   }
   return SQLITE_NOTFOUND;
 }
-
-/* --- Tag management --- */
 
 int chunkStoreFindTag(ChunkStore *cs, const char *zName, ProllyHash *pCommit){
   int i;
@@ -1062,8 +909,6 @@ int chunkStoreDeleteTag(ChunkStore *cs, const char *zName){
   return SQLITE_NOTFOUND;
 }
 
-/* --- Remote management --- */
-
 int chunkStoreFindRemote(ChunkStore *cs, const char *zName, const char **pzUrl){
   int i;
   for(i=0; i<cs->nRemotes; i++){
@@ -1100,7 +945,7 @@ int chunkStoreDeleteRemote(ChunkStore *cs, const char *zName){
       sqlite3_free(cs->aRemotes[i].zUrl);
       cs->aRemotes[i] = cs->aRemotes[cs->nRemotes-1];
       cs->nRemotes--;
-      /* Also delete all tracking branches for this remote */
+      
       for(j=cs->nTracking-1; j>=0; j--){
         if( strcmp(cs->aTracking[j].zRemote, zName)==0 ){
           sqlite3_free(cs->aTracking[j].zRemote);
@@ -1114,8 +959,6 @@ int chunkStoreDeleteRemote(ChunkStore *cs, const char *zName){
   }
   return SQLITE_NOTFOUND;
 }
-
-/* --- Tracking branch management --- */
 
 int chunkStoreFindTracking(ChunkStore *cs, const char *zRemote,
                            const char *zBranch, ProllyHash *pCommit){
@@ -1133,7 +976,7 @@ int chunkStoreFindTracking(ChunkStore *cs, const char *zRemote,
 int chunkStoreUpdateTracking(ChunkStore *cs, const char *zRemote,
                              const char *zBranch, const ProllyHash *pCommit){
   int i;
-  /* Try to find existing entry first */
+  
   for(i=0; i<cs->nTracking; i++){
     if( strcmp(cs->aTracking[i].zRemote, zRemote)==0
      && strcmp(cs->aTracking[i].zBranch, zBranch)==0 ){
@@ -1141,7 +984,7 @@ int chunkStoreUpdateTracking(ChunkStore *cs, const char *zRemote,
       return SQLITE_OK;
     }
   }
-  /* Create new entry */
+  
   {
     struct TrackingBranch *aNew;
     aNew = sqlite3_realloc(cs->aTracking, (cs->nTracking+1)*(int)sizeof(struct TrackingBranch));
@@ -1176,8 +1019,6 @@ int chunkStoreDeleteTracking(ChunkStore *cs, const char *zRemote,
   return SQLITE_NOTFOUND;
 }
 
-/* --- Bulk has-check --- */
-
 int chunkStoreHasMany(ChunkStore *cs, const ProllyHash *aHash, int nHash, u8 *aResult){
   int i;
   for(i=0; i<nHash; i++){
@@ -1186,17 +1027,10 @@ int chunkStoreHasMany(ChunkStore *cs, const ProllyHash *aHash, int nHash, u8 *aR
   return SQLITE_OK;
 }
 
-/*
-** Serialize refs v4: [version:1=4][default_branch_len:2][default_branch:var]
-**   [num_branches:2] per branch: [name_len:2][name:var][commitHash:20][workingSetHash:20]
-**   [num_tags:2] per tag: [name_len:2][name:var][hash:20]
-**   [num_remotes:2] per remote: [name_len:2][name:var][url_len:2][url:var]
-**   [num_tracking:2] per tracking: [remote_len:2][remote:var][branch_len:2][branch:var][commitHash:20]
-*/
 int chunkStoreSerializeRefs(ChunkStore *cs){
   const char *def = cs->zDefaultBranch ? cs->zDefaultBranch : "main";
   int defLen = (int)strlen(def);
-  /* version + default + num_branches + num_tags + num_remotes + num_tracking */
+  
   int sz = 1 + 2 + defLen + 2 + 2 + 2 + 2;
   int i, rc;
   u8 *buf, *bufCur;
@@ -1233,10 +1067,10 @@ int chunkStoreSerializeRefs(ChunkStore *cs){
   buf = sqlite3_malloc(sz);
   if( !buf ) return SQLITE_NOMEM;
   bufCur = buf;
-  *bufCur++ = 4;  /* version 4: branches + tags + remotes + tracking */
+  *bufCur++ = 4;  
   PROLLY_PUT_U16(bufCur,defLen); bufCur+=2;
   memcpy(bufCur, def, defLen); bufCur+=defLen;
-  /* Branches: name + commitHash + workingSetHash */
+  
   PROLLY_PUT_U16(bufCur,cs->nBranches); bufCur+=2;
   for(i=0; i<cs->nBranches; i++){
     int nameLen = (int)strlen(cs->aBranches[i].zName);
@@ -1245,7 +1079,7 @@ int chunkStoreSerializeRefs(ChunkStore *cs){
     memcpy(bufCur, cs->aBranches[i].commitHash.data, PROLLY_HASH_SIZE); bufCur+=PROLLY_HASH_SIZE;
     memcpy(bufCur, cs->aBranches[i].workingSetHash.data, PROLLY_HASH_SIZE); bufCur+=PROLLY_HASH_SIZE;
   }
-  /* Tags */
+  
   PROLLY_PUT_U16(bufCur,cs->nTags); bufCur+=2;
   for(i=0; i<cs->nTags; i++){
     int nameLen = (int)strlen(cs->aTags[i].zName);
@@ -1253,7 +1087,7 @@ int chunkStoreSerializeRefs(ChunkStore *cs){
     memcpy(bufCur, cs->aTags[i].zName, nameLen); bufCur+=nameLen;
     memcpy(bufCur, cs->aTags[i].commitHash.data, PROLLY_HASH_SIZE); bufCur+=PROLLY_HASH_SIZE;
   }
-  /* Remotes */
+  
   PROLLY_PUT_U16(bufCur,cs->nRemotes); bufCur+=2;
   for(i=0; i<cs->nRemotes; i++){
     int nameLen = (int)strlen(cs->aRemotes[i].zName);
@@ -1263,7 +1097,7 @@ int chunkStoreSerializeRefs(ChunkStore *cs){
     PROLLY_PUT_U16(bufCur,urlLen); bufCur+=2;
     memcpy(bufCur, cs->aRemotes[i].zUrl, urlLen); bufCur+=urlLen;
   }
-  /* Tracking branches */
+  
   PROLLY_PUT_U16(bufCur,cs->nTracking); bufCur+=2;
   for(i=0; i<cs->nTracking; i++){
     int remoteLen = (int)strlen(cs->aTracking[i].zRemote);
@@ -1314,7 +1148,7 @@ static int csDeserializeRefs(ChunkStore *cs, const u8 *data, int nData){
     }
   }
 
-  /* Tags (version 2+) */
+  
   csFreeTags(cs);
   if( version>=2 && bufCur+2<=data+nData ){
     nTags = PROLLY_GET_U16(bufCur); bufCur+=2;
@@ -1334,7 +1168,7 @@ static int csDeserializeRefs(ChunkStore *cs, const u8 *data, int nData){
     }
   }
 
-  /* Remotes and tracking branches (version 4+) */
+  
   csFreeRemotes(cs);
   csFreeTracking(cs);
   if( version>=4 && bufCur+2<=data+nData ){
@@ -1386,11 +1220,6 @@ static int csDeserializeRefs(ChunkStore *cs, const u8 *data, int nData){
   return SQLITE_OK;
 }
 
-/*
-** Public wrapper around csDeserializeRefs: parse a refs blob into the
-** ChunkStore's in-memory branch/tag/remote/tracking arrays, without
-** any file I/O.  Existing arrays are freed first.
-*/
 int chunkStoreLoadRefsFromBlob(ChunkStore *cs, const u8 *data, int nData){
   csFreeBranches(cs);
   csFreeTags(cs);
@@ -1399,12 +1228,6 @@ int chunkStoreLoadRefsFromBlob(ChunkStore *cs, const u8 *data, int nData){
   return csDeserializeRefs(cs, data, nData);
 }
 
-/*
-** Serialize the in-memory branches/tags/remotes/tracking into a newly-
-** allocated blob.  Caller must sqlite3_free(*ppOut).
-** This is the serialization half of chunkStoreSerializeRefs (which
-** additionally stores the blob into the chunk store).
-*/
 int chunkStoreSerializeRefsToBlob(ChunkStore *cs, u8 **ppOut, int *pnOut){
   const char *def = cs->zDefaultBranch ? cs->zDefaultBranch : "main";
   int defLen = (int)strlen(def);
@@ -1440,11 +1263,11 @@ int chunkStoreSerializeRefsToBlob(ChunkStore *cs, u8 **ppOut, int *pnOut){
   if( !buf ) return SQLITE_NOMEM;
   bufCur = buf;
 
-  *bufCur++ = 4;  /* version 4 */
+  *bufCur++ = 4;  
   PROLLY_PUT_U16(bufCur,defLen); bufCur+=2;
   memcpy(bufCur, def, defLen); bufCur+=defLen;
 
-  /* Branches */
+  
   PROLLY_PUT_U16(bufCur,cs->nBranches); bufCur+=2;
   for(i=0; i<cs->nBranches; i++){
     int nameLen = (int)strlen(cs->aBranches[i].zName);
@@ -1454,7 +1277,7 @@ int chunkStoreSerializeRefsToBlob(ChunkStore *cs, u8 **ppOut, int *pnOut){
     memcpy(bufCur, cs->aBranches[i].workingSetHash.data, PROLLY_HASH_SIZE); bufCur+=PROLLY_HASH_SIZE;
   }
 
-  /* Tags */
+  
   PROLLY_PUT_U16(bufCur,cs->nTags); bufCur+=2;
   for(i=0; i<cs->nTags; i++){
     int nameLen = (int)strlen(cs->aTags[i].zName);
@@ -1463,7 +1286,7 @@ int chunkStoreSerializeRefsToBlob(ChunkStore *cs, u8 **ppOut, int *pnOut){
     memcpy(bufCur, cs->aTags[i].commitHash.data, PROLLY_HASH_SIZE); bufCur+=PROLLY_HASH_SIZE;
   }
 
-  /* Remotes */
+  
   PROLLY_PUT_U16(bufCur,cs->nRemotes); bufCur+=2;
   for(i=0; i<cs->nRemotes; i++){
     int nameLen = (int)strlen(cs->aRemotes[i].zName);
@@ -1474,7 +1297,7 @@ int chunkStoreSerializeRefsToBlob(ChunkStore *cs, u8 **ppOut, int *pnOut){
     memcpy(bufCur, cs->aRemotes[i].zUrl, urlLen); bufCur+=urlLen;
   }
 
-  /* Tracking branches */
+  
   PROLLY_PUT_U16(bufCur,cs->nTracking); bufCur+=2;
   for(i=0; i<cs->nTracking; i++){
     int remoteLen = (int)strlen(cs->aTracking[i].zRemote);
@@ -1491,26 +1314,12 @@ int chunkStoreSerializeRefsToBlob(ChunkStore *cs, u8 **ppOut, int *pnOut){
   return SQLITE_OK;
 }
 
-/*
-** Check whether a chunk with the given hash exists in the store
-** (committed index or pending buffer).  Returns 1 if found, 0 if not.
-*/
 int chunkStoreHas(ChunkStore *cs, const ProllyHash *hash){
   if( csSearchIndex(cs->aIndex, cs->nIndex, hash) >= 0 ) return 1;
   if( csSearchPending(cs, hash) >= 0 ) return 1;
   return 0;
 }
 
-/*
-** Read a chunk by hash.
-**
-** On success, *ppData is set to a sqlite3_malloc'd buffer holding the
-** chunk data and *pnData is its length.  The caller must sqlite3_free
-** *ppData.
-**
-** Returns SQLITE_OK on success, SQLITE_NOTFOUND if the hash is not
-** in the store, or an I/O error code.
-*/
 int chunkStoreGet(
   ChunkStore *cs,
   const ProllyHash *hash,
@@ -1523,30 +1332,29 @@ int chunkStoreGet(
   *ppData = 0;
   *pnData = 0;
 
-  /* Check pending buffer first (most recent writes) */
+  
   idx = csSearchPending(cs, hash);
   if( idx >= 0 ){
     ChunkIndexEntry *e = &cs->aPending[idx];
-    /* e->offset is the byte offset within pWriteBuf where we stored
-    ** the 4-byte length prefix + data. */
+    
     i64 off = e->offset;
     int sz = e->size;
     u8 *pCopy = (u8 *)sqlite3_malloc(sz);
     if( pCopy == 0 ) return SQLITE_NOMEM;
-    /* Skip the 4-byte length prefix */
+    
     memcpy(pCopy, cs->pWriteBuf + off + 4, sz);
     *ppData = pCopy;
     *pnData = sz;
     return SQLITE_OK;
   }
 
-  /* Check committed index */
+  
   idx = csSearchIndex(cs->aIndex, cs->nIndex, hash);
   if( idx < 0 ){
     return SQLITE_NOTFOUND;
   }
 
-  /* WAL chunk: negative offset means data is in pWalData */
+  
   {
     ChunkIndexEntry *e = &cs->aIndex[idx];
     if( csIsWalOffset(e->offset) && cs->pWalData ){
@@ -1564,7 +1372,7 @@ int chunkStoreGet(
     }
   }
 
-  /* For in-memory stores, chunks in the index may reference pWriteBuf */
+  
   if( cs->pFile == 0 ){
     ChunkIndexEntry *e = &cs->aIndex[idx];
     if( cs->pWriteBuf && e->offset >= 0
@@ -1587,7 +1395,7 @@ int chunkStoreGet(
     u8 *pBuf;
     u32 storedLen;
 
-    /* Read the 4-byte length prefix */
+    
     rc = sqlite3OsRead(cs->pFile, lenBuf, 4, fileOff);
     if( rc != SQLITE_OK ) return rc;
 
@@ -1612,17 +1420,6 @@ int chunkStoreGet(
   return SQLITE_OK;
 }
 
-/*
-** Stage a new chunk for writing.
-**
-** The chunk's hash is computed from pData using prollyHashCompute and
-** returned in *pHash.  If the chunk already exists (committed or
-** pending), this is a no-op that just fills in *pHash.
-**
-** Otherwise the data is appended to the in-memory write buffer and a
-** new pending index entry is created.  Nothing is written to disk until
-** chunkStoreCommit is called.
-*/
 int chunkStorePut(
   ChunkStore *cs,
   const u8 *pData,
@@ -1632,33 +1429,33 @@ int chunkStorePut(
   int rc;
   ProllyHash h;
 
-  /* Compute hash */
+  
   prollyHashCompute(pData, nData, &h);
   if( pHash ) memcpy(pHash, &h, sizeof(ProllyHash));
 
-  /* Already exists? */
+  
   if( csSearchIndex(cs->aIndex, cs->nIndex, &h) >= 0 ) return SQLITE_OK;
   if( csSearchPending(cs, &h) >= 0 ) return SQLITE_OK;
 
-  /* Grow pending array if needed */
+  
   rc = csGrowPending(cs);
   if( rc != SQLITE_OK ) return rc;
 
-  /* Grow write buffer: 4 bytes for length prefix + nData */
+  
   rc = csGrowWriteBuf(cs, 4 + nData);
   if( rc != SQLITE_OK ) return rc;
 
-  /* Append to pending array. Lookup is via hash table (csSearchPending). */
+  
   {
     ChunkIndexEntry *e = &cs->aPending[cs->nPending];
     e->hash = h;
     e->offset = (i64)cs->nWriteBuf;
     e->size = nData;
     cs->nPending++;
-    /* Hash table will be incrementally updated on next csSearchPending call */
+    
   }
 
-  /* Append length + data to write buffer */
+  
   CS_WRITE_U32(cs->pWriteBuf + cs->nWriteBuf, (u32)nData);
   cs->nWriteBuf += 4;
   memcpy(cs->pWriteBuf + cs->nWriteBuf, pData, nData);
@@ -1667,11 +1464,6 @@ int chunkStorePut(
   return SQLITE_OK;
 }
 
-/*
-** csCommitToMemory -- handle the in-memory-only commit path.
-** Merges pending entries into the committed index and marks the
-** write buffer as committed.
-*/
 static int csCommitToMemory(ChunkStore *cs){
   if( cs->nPending > 0 ){
     ChunkIndexEntry *aMem = 0;
@@ -1689,12 +1481,6 @@ static int csCommitToMemory(ChunkStore *cs){
   return SQLITE_OK;
 }
 
-/*
-** csCommitToFile -- handle the file-based commit path.
-** Locks the file, writes WAL records for pending chunks, appends a
-** root record with the updated manifest, fsyncs, then updates the
-** in-memory index and WAL cache.
-*/
 static int csCommitToFile(ChunkStore *cs){
   int rc;
   int i;
@@ -1703,13 +1489,9 @@ static int csCommitToFile(ChunkStore *cs){
   int lockFd = -1;
   int hadFile = (cs->pFile != 0);
 
-  /* Single-file commit: append WAL records to the main file at EOF.
-  ** All data I/O routes through the SQLite VFS layer so that encryption
-  ** extensions, compression plugins, and custom I/O backends see
-  ** every byte written.  Concurrent writer serialization still uses
-  ** POSIX flock to avoid conflicts with the VFS per-inode lock tracker. */
+  
 
-  /* If we don't have a VFS file handle yet (first commit), create/open */
+  
   if( cs->pFile == 0 ){
     int openFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE
                   | SQLITE_OPEN_MAIN_DB;
@@ -1717,23 +1499,23 @@ static int csCommitToFile(ChunkStore *cs){
     if( rc != SQLITE_OK ) return SQLITE_CANTOPEN;
   }
 
-  /* Exclusive flock for concurrent writer serialization */
+  
   if( csFileLock(cs->zFilename, &lockFd) != 0 ){
     return SQLITE_BUSY;
   }
 
-  /* Under lock: get current file size via VFS */
+  
   rc = cs->pFile->pMethods->xFileSize(cs->pFile, &fileSize);
   if( rc != SQLITE_OK ) goto commit_done;
 
-  /* Check if file grew (another writer appended) */
+  
   if( fileSize > cs->iFileSize && hadFile ){
     ProllyHash rootBefore = cs->root;
-    /* Re-read WAL region to pick up other writer's chunks */
+    
     sqlite3_free(cs->pWalData);
     cs->pWalData = 0;
     cs->nWalData = 0;
-    /* Temporarily reset pending count so replay doesn't conflict */
+    
     {
       int savePending = cs->nPending;
       cs->nPending = 0;
@@ -1741,16 +1523,14 @@ static int csCommitToFile(ChunkStore *cs){
       csReplayWalRegion(cs, 1);
       cs->nPending = savePending;
     }
-    /* Detect concurrent writer conflict: if the root hash changed,
-    ** another connection committed while we were building our changes.
-    ** Reject to prevent silent data loss. */
+    
     if( prollyHashCompare(&rootBefore, &cs->root) != 0 ){
       rc = SQLITE_BUSY_SNAPSHOT;
       goto commit_done;
     }
   }
 
-  /* If file is empty/new, write the manifest header first */
+  
   if( fileSize == 0 ){
     u8 manifest[CHUNK_MANIFEST_SIZE];
     cs->iWalOffset = CHUNK_MANIFEST_SIZE;
@@ -1760,10 +1540,10 @@ static int csCommitToFile(ChunkStore *cs){
     fileSize = CHUNK_MANIFEST_SIZE;
   }
 
-  /* Append WAL records at end of file */
+  
   writeOff = fileSize;
 
-  /* Write chunk records: tag(1) + hash(20) + length(4) + data */
+  
   for( i = 0; i < cs->nPending; i++ ){
     ChunkIndexEntry *pe = &cs->aPending[i];
     u8 recHdr[25];
@@ -1771,14 +1551,12 @@ static int csCommitToFile(ChunkStore *cs){
     memcpy(recHdr + 1, &pe->hash, 20);
     CS_WRITE_U32(recHdr + 21, (u32)pe->size);
 
-    i64 bufOff = pe->offset + 4;  /* skip length prefix */
+    i64 bufOff = pe->offset + 4;  
     rc = sqlite3OsWrite(cs->pFile, recHdr, 25, writeOff);
     if( rc != SQLITE_OK ) goto commit_done;
     writeOff += 25;
 
-    /* Write chunk data in bounded pieces — the VFS xWrite interface
-    ** uses int for the size parameter and some implementations impose
-    ** per-call limits smaller than the maximum int value. */
+    
     {
       const u8 *pSrc = cs->pWriteBuf + bufOff;
       int remaining = pe->size;
@@ -1793,7 +1571,7 @@ static int csCommitToFile(ChunkStore *cs){
     if( rc != SQLITE_OK ) goto commit_done;
   }
 
-  /* Write root record: tag(1) + manifest(168) */
+  
   {
     u8 rootRec[1 + CHUNK_MANIFEST_SIZE];
     rootRec[0] = CS_WAL_TAG_ROOT;
@@ -1803,20 +1581,20 @@ static int csCommitToFile(ChunkStore *cs){
     writeOff += sizeof(rootRec);
   }
 
-  /* fsync via VFS — durability point */
+  
   rc = sqlite3OsSync(cs->pFile, SQLITE_SYNC_NORMAL);
   if( rc != SQLITE_OK ) goto commit_done;
 
-  /* Track file size */
+  
   cs->iFileSize = writeOff;
 
 commit_done:
-  /* Release flock (close releases the lock) */
+  
   csFileUnlock(lockFd);
 
   if( rc != SQLITE_OK ) return rc;
 
-  /* Update in-memory index: move chunk data into WAL cache */
+  
   for( i = 0; i < cs->nPending; i++ ){
     ChunkIndexEntry *pe = &cs->aPending[i];
     i64 bufOff = pe->offset + 4;
@@ -1834,7 +1612,7 @@ commit_done:
     }
   }
 
-  /* Merge pending into main index */
+  
   {
     ChunkIndexEntry *aMerged = 0;
     int nMerged = 0;
@@ -1849,7 +1627,7 @@ commit_done:
     cs->nIndexAlloc = nMerged;
   }
 
-  /* Clear pending state */
+  
   sqlite3_free(cs->pWriteBuf);
   cs->pWriteBuf = 0;
   cs->nWriteBuf = 0;
@@ -1860,50 +1638,28 @@ commit_done:
   return SQLITE_OK;
 }
 
-/*
-** Commit all pending chunks and the current root hash atomically.
-**
-** Protocol (file-based, see csCommitToFile):
-**   1. Append WAL chunk records for each pending chunk to end of file.
-**   2. Append WAL root record with updated manifest.
-**   3. fsync — this is the durability point.
-**   4. Update in-memory index with new entries.
-*/
 int chunkStoreCommit(ChunkStore *cs){
   if( cs->readOnly ) return SQLITE_READONLY;
   if( cs->isMemory ) return csCommitToMemory(cs);
   return csCommitToFile(cs);
 }
 
-/*
-** Discard all pending (uncommitted) chunks and reset the write buffer.
-** The root hash is NOT reverted -- the caller is responsible for that
-** if desired.
-*/
 void chunkStoreRollback(ChunkStore *cs){
   cs->nPending = 0;
     csPendHTClear(cs);
   if( cs->isMemory ){
-    /* For in-memory stores, committed chunks live in pWriteBuf.
-    ** Only discard the uncommitted portion. */
+    
     cs->nWriteBuf = cs->nCommittedWriteBuf;
   }else{
     cs->nWriteBuf = 0;
   }
-  /* Buffers are kept allocated for potential reuse */
+  
 }
 
-/*
-** Return 1 if the store is empty (root hash is all zeros), 0 otherwise.
-*/
 int chunkStoreIsEmpty(ChunkStore *cs){
   return prollyHashIsEmpty(&cs->root);
 }
 
-/*
-** Reload refs (branches, tags, remotes, tracking) from the current refsHash.
-** Used after clone to populate in-memory ref arrays from the copied refs chunk.
-*/
 int chunkStoreReloadRefs(ChunkStore *cs){
   u8 *refsData = 0;
   int nRefsData = 0;
@@ -1924,13 +1680,9 @@ int chunkStoreReloadRefs(ChunkStore *cs){
   return rc;
 }
 
-/*
-** Return the filename of this chunk store.
-*/
 const char *chunkStoreFilename(ChunkStore *cs){
   return cs->zFilename;
 }
-
 
 int chunkStoreRefreshIfChanged(ChunkStore *cs, int *pChanged){
   int bMoved = 0;
@@ -1938,13 +1690,11 @@ int chunkStoreRefreshIfChanged(ChunkStore *cs, int *pChanged){
   *pChanged = 0;
   if( cs->isMemory ) return SQLITE_OK;
 
-  /* Snapshot isolation: while a read transaction is active, don't pick up
-  ** changes from other connections.  The caller sees a consistent view
-  ** pinned at the root hash captured when the transaction began. */
+  
   if( cs->snapshotPinned ) return SQLITE_OK;
 
   if( cs->pFile==0 ){
-    /* No file handle yet — check if file was created by another connection */
+    
     int exists = 0;
     rc = sqlite3OsAccess(cs->pVfs, cs->zFilename,
                          SQLITE_ACCESS_EXISTS, &exists);
@@ -1952,7 +1702,7 @@ int chunkStoreRefreshIfChanged(ChunkStore *cs, int *pChanged){
     if( exists ){
       struct stat mainStat;
       if( stat(cs->zFilename, &mainStat)==0 && mainStat.st_size > 0 ){
-        /* File appeared with data — open and load */
+        
         int openFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB;
         rc = csOpenFile(cs->pVfs, cs->zFilename, &cs->pFile, openFlags);
         if( rc!=SQLITE_OK ) return rc;
@@ -1968,17 +1718,17 @@ int chunkStoreRefreshIfChanged(ChunkStore *cs, int *pChanged){
     return SQLITE_OK;
   }
 
-  /* Check if file was replaced (GC) */
+  
   rc = sqlite3OsFileControl(cs->pFile, SQLITE_FCNTL_HAS_MOVED, &bMoved);
   if( rc!=SQLITE_OK ) return SQLITE_OK;
 
   if( !bMoved ){
-    /* File not replaced — check if it grew (another writer appended WAL records) */
+    
     i64 fileSize = 0;
     rc = sqlite3OsFileSize(cs->pFile, &fileSize);
     if( rc!=SQLITE_OK ) return SQLITE_OK;
     if( fileSize > cs->iFileSize ){
-      /* File grew — re-read WAL region */
+      
       sqlite3_free(cs->pWalData);
       cs->pWalData = 0;
       cs->nWalData = 0;
@@ -1992,7 +1742,7 @@ int chunkStoreRefreshIfChanged(ChunkStore *cs, int *pChanged){
     return SQLITE_OK;
   }
 
-  /* File was replaced (GC happened) — full reload */
+  
   csCloseFile(cs->pFile);
   cs->pFile = 0;
   sqlite3_free(cs->aIndex);
@@ -2030,11 +1780,6 @@ int chunkStoreRefreshIfChanged(ChunkStore *cs, int *pChanged){
   return SQLITE_OK;
 }
 
-/* --- Merge state accessors --- */
-
-/*
-** Get the current merge state.  Any output pointer may be NULL.
-*/
 int chunkStoreGetMergeState(
   ChunkStore *cs,
   u8 *pIsMerging,
@@ -2047,10 +1792,6 @@ int chunkStoreGetMergeState(
   return SQLITE_OK;
 }
 
-/*
-** Set the merge state.  Pass isMerging=1 to begin a merge, 0 to clear.
-** pMergeCommit and pConflictsCatalog may be NULL (treated as all-zeros).
-*/
 void chunkStoreSetMergeState(
   ChunkStore *cs,
   u8 isMerging,
@@ -2070,9 +1811,6 @@ void chunkStoreSetMergeState(
   }
 }
 
-/*
-** Clear all merge state (isMerging=0, hashes zeroed).
-*/
 void chunkStoreClearMergeState(ChunkStore *cs){
   cs->isMerging = 0;
   memset(&cs->mergeCommitHash, 0, sizeof(ProllyHash));
@@ -2087,4 +1825,4 @@ void chunkStoreSetConflictsCatalog(ChunkStore *cs, const ProllyHash *pHash){
   memcpy(&cs->conflictsCatalogHash, pHash, sizeof(ProllyHash));
 }
 
-#endif /* DOLTLITE_PROLLY */
+#endif 

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -1,3 +1,7 @@
+/*
+** Implementation of the single-file content-addressed chunk store.
+** See chunk_store.h for the file layout. All integers on disk are little-endian.
+*/
 
 #ifdef DOLTLITE_PROLLY
 
@@ -49,7 +53,7 @@
     return 0;
   }
   static void csFileUnlock(int fd){
-    if( fd >= 0 ) close(fd);  
+    if( fd >= 0 ) close(fd);
   }
 #endif
 
@@ -110,9 +114,16 @@ static int csGrowWriteBuf(ChunkStore *cs, int nNeeded);
 static int csReplayWalRegion(ChunkStore *cs, int updateManifest);
 static int csReplayWal(ChunkStore *cs){ return csReplayWalRegion(cs, 1); }
 
-#define CS_WAL_TAG_CHUNK  0x01   
-#define CS_WAL_TAG_ROOT   0x02   
+#define CS_WAL_TAG_CHUNK  0x01
+#define CS_WAL_TAG_ROOT   0x02
 
+/*
+** WAL offsets are stored as negative values in ChunkIndexEntry.offset to
+** distinguish them from regular file offsets. The encoding maps walPos 0
+** to -1, 1 to -2, etc., so that 0 remains available as "no offset."
+** A negative offset means the chunk data lives in the in-memory pWalData
+** buffer rather than at a direct file position.
+*/
 static i64 csEncodeWalOffset(i64 walPos){ return -(walPos) - 1; }
 static i64 csDecodeWalOffset(i64 encoded){ return -(encoded + 1); }
 static int csIsWalOffset(i64 offset){ return offset < 0; }
@@ -195,7 +206,7 @@ static int csSearchIndex(
 }
 
 #define CS_PEND_HT_INIT_BITS 12
-#define CS_PEND_HT_MAX_LOAD  4   
+#define CS_PEND_HT_MAX_LOAD  4   /* max entries per bucket before resize */
 
 static u32 csPendBucket(const ProllyHash *h, int nHTMask){
   return ((u32)h->data[0] | ((u32)h->data[1]<<8)
@@ -211,6 +222,7 @@ static void csPendHTClear(ChunkStore *cs){
   cs->nPendingHTSize = 0;
 }
 
+/* Fill aPendingHT with 0xff (-1 as int) to mark all buckets empty. */
 static int csPendHTRebuild(ChunkStore *cs){
   int i;
   memset(cs->aPendingHT, 0xff, cs->nPendingHTSize * sizeof(int));
@@ -234,14 +246,12 @@ static int csPendHTEnsure(ChunkStore *cs){
     cs->nPendingHTSize = initSize;
     cs->nPendingHTBuilt = 0;
   }
-  
   if( cs->nPending > cs->nPendingHTSize * CS_PEND_HT_MAX_LOAD ){
     int newSize = cs->nPendingHTSize * 4;
     int *aNew = sqlite3_realloc(cs->aPendingHT, newSize * (int)sizeof(int));
     if( aNew ){
       cs->aPendingHT = aNew;
       cs->nPendingHTSize = newSize;
-      
       if( !cs->aPendingHTNext || cs->nPendingAlloc > cs->nPendingHTNextAlloc ){
         int nAlloc = cs->nPendingAlloc > 0 ? cs->nPendingAlloc : 64;
         int *aNew2 = sqlite3_realloc(cs->aPendingHTNext, nAlloc*(int)sizeof(int));
@@ -251,7 +261,7 @@ static int csPendHTEnsure(ChunkStore *cs){
       }
       return csPendHTRebuild(cs);
     }
-    
+    /* realloc failed; fall through to incremental insert with old table size */
   }
   if( !cs->aPendingHTNext || cs->nPendingAlloc > cs->nPendingHTNextAlloc ){
     int nAlloc = cs->nPendingAlloc > 0 ? cs->nPendingAlloc : 64;
@@ -260,6 +270,7 @@ static int csPendHTEnsure(ChunkStore *cs){
     cs->aPendingHTNext = aNew;
     cs->nPendingHTNextAlloc = nAlloc;
   }
+  /* Incrementally insert only the entries added since the last ensure. */
   for(i=cs->nPendingHTBuilt; i<cs->nPending; i++){
     u32 b = csPendBucket(&cs->aPending[i].hash, cs->nPendingHTSize - 1);
     cs->aPendingHTNext[i] = cs->aPendingHT[b];
@@ -273,7 +284,7 @@ static int csSearchPending(ChunkStore *cs, const ProllyHash *pHash){
   int i; u32 b;
   if( cs->nPending==0 ) return -1;
   if( csPendHTEnsure(cs)!=SQLITE_OK ){
-    
+    /* Hash table alloc failed; fall back to linear scan. */
     for(i=0; i<cs->nPending; i++){
       if( prollyHashCompare(&cs->aPending[i].hash, pHash)==0 ) return i;
     }
@@ -288,6 +299,13 @@ static int csSearchPending(ChunkStore *cs, const ProllyHash *pHash){
   return -1;
 }
 
+/*
+** Manifest layout (168 bytes, all little-endian):
+**   0: magic(4) | 4: version(4) | 8: root_hash(20) | 28: nChunks(4)
+**   32: indexOffset(8) | 40: indexSize(4) | 44: catalog_hash(20)
+**   64: headCommit_hash(20) | 84: walOffset(8) | 104: refs_hash(20)
+**   124..167: reserved (zero)
+*/
 void csSerializeManifest(const ChunkStore *cs, u8 *aBuf){
   memset(aBuf, 0, CHUNK_MANIFEST_SIZE);
   CS_WRITE_U32(aBuf + 0, CHUNK_STORE_MAGIC);
@@ -346,7 +364,6 @@ static int csReadIndex(ChunkStore *cs){
   int i;
 
   if( cs->nIndexSize == 0 || cs->nChunks == 0 ){
-    
     cs->nIndex = 0;
     return SQLITE_OK;
   }
@@ -356,7 +373,6 @@ static int csReadIndex(ChunkStore *cs){
     return SQLITE_CORRUPT;
   }
 
-  
   cs->aIndex = (ChunkIndexEntry *)sqlite3_malloc(
     nEntries * (int)sizeof(ChunkIndexEntry)
   );
@@ -364,7 +380,6 @@ static int csReadIndex(ChunkStore *cs){
   cs->nIndex = nEntries;
   cs->nIndexAlloc = nEntries;
 
-  
   aBuf = (u8 *)sqlite3_malloc(cs->nIndexSize);
   if( aBuf == 0 ){
     sqlite3_free(cs->aIndex);
@@ -382,7 +397,6 @@ static int csReadIndex(ChunkStore *cs){
     return rc;
   }
 
-  
   for( i = 0; i < nEntries; i++ ){
     csDeserializeIndexEntry(aBuf + i * CHUNK_INDEX_ENTRY_SIZE, &cs->aIndex[i]);
   }
@@ -408,7 +422,7 @@ static int csGrowWriteBuf(ChunkStore *cs, int nNeeded){
   i64 nRequired = cs->nWriteBuf + (i64)nNeeded;
   if( nRequired > cs->nWriteBufAlloc ){
     i64 nNew = cs->nWriteBufAlloc ? cs->nWriteBufAlloc : CS_INIT_WRITEBUF_SIZE;
-    
+    /* Double below 64MB, then grow by 1.5x to limit wasted memory. */
     while( nNew < nRequired ){
       if( nNew < 64*1024*1024 ){
         nNew *= 2;
@@ -424,6 +438,14 @@ static int csGrowWriteBuf(ChunkStore *cs, int nNeeded){
   return SQLITE_OK;
 }
 
+/*
+** Replay the WAL region (everything from iWalOffset to EOF).
+** WAL records are: [tag:1][payload...].
+**   CHUNK record: tag(0x01) + hash(20) + len_le32(4) + data(len)
+**   ROOT record:  tag(0x02) + manifest_snapshot(168)
+** Chunks found here are merged into the in-memory index with WAL-encoded
+** (negative) offsets pointing into the cached pWalData buffer.
+*/
 static int csReplayWalRegion(ChunkStore *cs, int updateManifest){
   i64 walSize;
   u8 *walData;
@@ -431,7 +453,6 @@ static int csReplayWalRegion(ChunkStore *cs, int updateManifest){
 
   if( cs->iWalOffset <= 0 || !cs->pFile ) return SQLITE_OK;
 
-  
   {
     i64 fileSize = 0;
     int rc = sqlite3OsFileSize(cs->pFile, &fileSize);
@@ -439,9 +460,8 @@ static int csReplayWalRegion(ChunkStore *cs, int updateManifest){
     walSize = fileSize - cs->iWalOffset;
     cs->iFileSize = fileSize;
   }
-  if( walSize <= 0 ) return SQLITE_OK;  
+  if( walSize <= 0 ) return SQLITE_OK;
 
-  
   walData = (u8*)sqlite3_malloc64(walSize);
   if( !walData ) return SQLITE_NOMEM;
   {
@@ -452,12 +472,10 @@ static int csReplayWalRegion(ChunkStore *cs, int updateManifest){
     }
   }
 
-  
   sqlite3_free(cs->pWalData);
   cs->pWalData = walData;
   cs->nWalData = walSize;
 
-  
   pos = 0;
   while( pos < walSize ){
     u8 tag = walData[pos];
@@ -501,7 +519,8 @@ static int csReplayWalRegion(ChunkStore *cs, int updateManifest){
           memcpy(cs->catalog.data, m + 44, PROLLY_HASH_SIZE);
           memcpy(cs->headCommit.data, m + 64, PROLLY_HASH_SIZE);
           memcpy(cs->refsHash.data, m + 104, PROLLY_HASH_SIZE);
-          
+          /* Don't update iWalOffset/iIndexOffset from WAL root records --
+          ** those fields describe the compacted region and only change on GC. */
         }
       }
       pos += CHUNK_MANIFEST_SIZE;
@@ -511,7 +530,6 @@ static int csReplayWalRegion(ChunkStore *cs, int updateManifest){
     }
   }
 
-  
   if( cs->nPending > 0 ){
     ChunkIndexEntry *aMerged = 0;
     int nMerged = 0;
@@ -529,7 +547,6 @@ static int csReplayWalRegion(ChunkStore *cs, int updateManifest){
     csPendHTClear(cs);
   }
 
-  
   if( !prollyHashIsEmpty(&cs->refsHash) ){
     u8 *refsData = 0; int nRefsData = 0;
     int rc2 = chunkStoreGet(cs, &cs->refsHash, &refsData, &nRefsData);
@@ -574,17 +591,15 @@ static int csMergeIndex(
   );
   if( aMerged == 0 ) return SQLITE_NOMEM;
 
-  
-  
+  /* aIndex is already sorted; sort aPending before merge. */
   if( cs->nPending > 1 ){
     qsort(cs->aPending, cs->nPending, sizeof(ChunkIndexEntry),
           csIndexEntryCmp);
   }
 
-  
-  idxPos = 0;   
-  pendPos = 0;  
-  outPos = 0;   
+  idxPos = 0;
+  pendPos = 0;
+  outPos = 0;
   while( idxPos < cs->nIndex && pendPos < cs->nPending ){
     int cmp = prollyHashCompare(&cs->aIndex[idxPos].hash, &cs->aPending[pendPos].hash);
     if( cmp < 0 ){
@@ -592,7 +607,7 @@ static int csMergeIndex(
     }else if( cmp > 0 ){
       aMerged[outPos++] = cs->aPending[pendPos++];
     }else{
-      
+      /* Duplicate hash: pending entry wins (it may carry a WAL offset). */
       aMerged[outPos++] = cs->aPending[pendPos++];
       idxPos++;
     }
@@ -618,7 +633,6 @@ int chunkStoreOpen(
   memset(cs, 0, sizeof(*cs));
   cs->pVfs = pVfs;
 
-  
   if( zFilename==0 || zFilename[0]=='\0'
    || strcmp(zFilename, ":memory:")==0 ){
     cs->isMemory = 1;
@@ -633,13 +647,11 @@ int chunkStoreOpen(
     return SQLITE_OK;
   }
 
-  
   n = (int)strlen(zFilename);
   cs->zFilename = (char *)sqlite3_malloc(n + 1);
   if( cs->zFilename == 0 ) return SQLITE_NOMEM;
   memcpy(cs->zFilename, zFilename, n + 1);
 
-  
   rc = sqlite3OsAccess(pVfs, cs->zFilename, SQLITE_ACCESS_EXISTS, &exists);
   if( rc != SQLITE_OK ){
     sqlite3_free(cs->zFilename);
@@ -647,7 +659,7 @@ int chunkStoreOpen(
     return rc;
   }
 
-  
+  /* Treat a zero-byte file as non-existent (leftover from a failed create). */
   if( exists ){
     struct stat mainStat;
     if( stat(cs->zFilename, &mainStat)==0 && mainStat.st_size==0 ){
@@ -656,7 +668,6 @@ int chunkStoreOpen(
   }
 
   if( exists ){
-    
     int openFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB;
     rc = csOpenFile(pVfs, cs->zFilename, &cs->pFile, openFlags);
     if( rc != SQLITE_OK ){
@@ -670,7 +681,6 @@ int chunkStoreOpen(
       cs->readOnly = 1;
     }
 
-    
     rc = csReadManifest(cs);
     if( rc != SQLITE_OK ){
       csCloseFile(cs->pFile);
@@ -680,7 +690,6 @@ int chunkStoreOpen(
       return rc;
     }
 
-    
     rc = csReadIndex(cs);
     if( rc != SQLITE_OK ){
       csCloseFile(cs->pFile);
@@ -690,7 +699,6 @@ int chunkStoreOpen(
       return rc;
     }
 
-    
     rc = csReplayWal(cs);
     if( rc != SQLITE_OK ){
       csCloseFile(cs->pFile);
@@ -700,7 +708,6 @@ int chunkStoreOpen(
       return rc;
     }
 
-    
     if( !prollyHashIsEmpty(&cs->refsHash) ){
       u8 *refsData = 0; int nRefsData = 0;
       rc = chunkStoreGet(cs, &cs->refsHash, &refsData, &nRefsData);
@@ -718,7 +725,6 @@ int chunkStoreOpen(
     }
     if( !cs->zDefaultBranch ) cs->zDefaultBranch = sqlite3_mprintf("main");
   }else{
-    
     if( !(flags & SQLITE_OPEN_CREATE) ){
       sqlite3_free(cs->zFilename);
       cs->zFilename = 0;
@@ -728,7 +734,8 @@ int chunkStoreOpen(
     cs->nChunks = 0;
     cs->iIndexOffset = 0;
     cs->nIndexSize = 0;
-    cs->iWalOffset = CHUNK_MANIFEST_SIZE;  
+    /* File not yet created; WAL starts right after the manifest. */
+    cs->iWalOffset = CHUNK_MANIFEST_SIZE;
     cs->iFileSize = 0;
     cs->pFile = 0;
   }
@@ -945,7 +952,7 @@ int chunkStoreDeleteRemote(ChunkStore *cs, const char *zName){
       sqlite3_free(cs->aRemotes[i].zUrl);
       cs->aRemotes[i] = cs->aRemotes[cs->nRemotes-1];
       cs->nRemotes--;
-      
+      /* Also remove all tracking branches for this remote. */
       for(j=cs->nTracking-1; j>=0; j--){
         if( strcmp(cs->aTracking[j].zRemote, zName)==0 ){
           sqlite3_free(cs->aTracking[j].zRemote);
@@ -976,7 +983,6 @@ int chunkStoreFindTracking(ChunkStore *cs, const char *zRemote,
 int chunkStoreUpdateTracking(ChunkStore *cs, const char *zRemote,
                              const char *zBranch, const ProllyHash *pCommit){
   int i;
-  
   for(i=0; i<cs->nTracking; i++){
     if( strcmp(cs->aTracking[i].zRemote, zRemote)==0
      && strcmp(cs->aTracking[i].zBranch, zBranch)==0 ){
@@ -984,7 +990,7 @@ int chunkStoreUpdateTracking(ChunkStore *cs, const char *zRemote,
       return SQLITE_OK;
     }
   }
-  
+  /* Not found: create a new tracking entry. */
   {
     struct TrackingBranch *aNew;
     aNew = sqlite3_realloc(cs->aTracking, (cs->nTracking+1)*(int)sizeof(struct TrackingBranch));
@@ -1027,10 +1033,18 @@ int chunkStoreHasMany(ChunkStore *cs, const ProllyHash *aHash, int nHash, u8 *aR
   return SQLITE_OK;
 }
 
+/*
+** Refs blob format (version 4):
+**   [version:1][default_branch_len:2][default_branch:N]
+**   [nBranches:2] { [name_len:2][name:N][commit_hash:20][ws_hash:20] }...
+**   [nTags:2]     { [name_len:2][name:N][commit_hash:20] }...
+**   [nRemotes:2]  { [name_len:2][name:N][url_len:2][url:N] }...
+**   [nTracking:2] { [remote_len:2][remote:N][branch_len:2][branch:N][commit_hash:20] }...
+** All length fields are little-endian u16.
+*/
 int chunkStoreSerializeRefs(ChunkStore *cs){
   const char *def = cs->zDefaultBranch ? cs->zDefaultBranch : "main";
   int defLen = (int)strlen(def);
-  
   int sz = 1 + 2 + defLen + 2 + 2 + 2 + 2;
   int i, rc;
   u8 *buf, *bufCur;
@@ -1067,10 +1081,9 @@ int chunkStoreSerializeRefs(ChunkStore *cs){
   buf = sqlite3_malloc(sz);
   if( !buf ) return SQLITE_NOMEM;
   bufCur = buf;
-  *bufCur++ = 4;  
+  *bufCur++ = 4;  /* refs format version */
   PROLLY_PUT_U16(bufCur,defLen); bufCur+=2;
   memcpy(bufCur, def, defLen); bufCur+=defLen;
-  
   PROLLY_PUT_U16(bufCur,cs->nBranches); bufCur+=2;
   for(i=0; i<cs->nBranches; i++){
     int nameLen = (int)strlen(cs->aBranches[i].zName);
@@ -1079,7 +1092,6 @@ int chunkStoreSerializeRefs(ChunkStore *cs){
     memcpy(bufCur, cs->aBranches[i].commitHash.data, PROLLY_HASH_SIZE); bufCur+=PROLLY_HASH_SIZE;
     memcpy(bufCur, cs->aBranches[i].workingSetHash.data, PROLLY_HASH_SIZE); bufCur+=PROLLY_HASH_SIZE;
   }
-  
   PROLLY_PUT_U16(bufCur,cs->nTags); bufCur+=2;
   for(i=0; i<cs->nTags; i++){
     int nameLen = (int)strlen(cs->aTags[i].zName);
@@ -1087,7 +1099,6 @@ int chunkStoreSerializeRefs(ChunkStore *cs){
     memcpy(bufCur, cs->aTags[i].zName, nameLen); bufCur+=nameLen;
     memcpy(bufCur, cs->aTags[i].commitHash.data, PROLLY_HASH_SIZE); bufCur+=PROLLY_HASH_SIZE;
   }
-  
   PROLLY_PUT_U16(bufCur,cs->nRemotes); bufCur+=2;
   for(i=0; i<cs->nRemotes; i++){
     int nameLen = (int)strlen(cs->aRemotes[i].zName);
@@ -1097,7 +1108,6 @@ int chunkStoreSerializeRefs(ChunkStore *cs){
     PROLLY_PUT_U16(bufCur,urlLen); bufCur+=2;
     memcpy(bufCur, cs->aRemotes[i].zUrl, urlLen); bufCur+=urlLen;
   }
-  
   PROLLY_PUT_U16(bufCur,cs->nTracking); bufCur+=2;
   for(i=0; i<cs->nTracking; i++){
     int remoteLen = (int)strlen(cs->aTracking[i].zRemote);
@@ -1148,7 +1158,6 @@ static int csDeserializeRefs(ChunkStore *cs, const u8 *data, int nData){
     }
   }
 
-  
   csFreeTags(cs);
   if( version>=2 && bufCur+2<=data+nData ){
     nTags = PROLLY_GET_U16(bufCur); bufCur+=2;
@@ -1168,7 +1177,6 @@ static int csDeserializeRefs(ChunkStore *cs, const u8 *data, int nData){
     }
   }
 
-  
   csFreeRemotes(cs);
   csFreeTracking(cs);
   if( version>=4 && bufCur+2<=data+nData ){
@@ -1263,11 +1271,10 @@ int chunkStoreSerializeRefsToBlob(ChunkStore *cs, u8 **ppOut, int *pnOut){
   if( !buf ) return SQLITE_NOMEM;
   bufCur = buf;
 
-  *bufCur++ = 4;  
+  *bufCur++ = 4;  /* refs format version */
   PROLLY_PUT_U16(bufCur,defLen); bufCur+=2;
   memcpy(bufCur, def, defLen); bufCur+=defLen;
 
-  
   PROLLY_PUT_U16(bufCur,cs->nBranches); bufCur+=2;
   for(i=0; i<cs->nBranches; i++){
     int nameLen = (int)strlen(cs->aBranches[i].zName);
@@ -1277,7 +1284,6 @@ int chunkStoreSerializeRefsToBlob(ChunkStore *cs, u8 **ppOut, int *pnOut){
     memcpy(bufCur, cs->aBranches[i].workingSetHash.data, PROLLY_HASH_SIZE); bufCur+=PROLLY_HASH_SIZE;
   }
 
-  
   PROLLY_PUT_U16(bufCur,cs->nTags); bufCur+=2;
   for(i=0; i<cs->nTags; i++){
     int nameLen = (int)strlen(cs->aTags[i].zName);
@@ -1286,7 +1292,6 @@ int chunkStoreSerializeRefsToBlob(ChunkStore *cs, u8 **ppOut, int *pnOut){
     memcpy(bufCur, cs->aTags[i].commitHash.data, PROLLY_HASH_SIZE); bufCur+=PROLLY_HASH_SIZE;
   }
 
-  
   PROLLY_PUT_U16(bufCur,cs->nRemotes); bufCur+=2;
   for(i=0; i<cs->nRemotes; i++){
     int nameLen = (int)strlen(cs->aRemotes[i].zName);
@@ -1297,7 +1302,6 @@ int chunkStoreSerializeRefsToBlob(ChunkStore *cs, u8 **ppOut, int *pnOut){
     memcpy(bufCur, cs->aRemotes[i].zUrl, urlLen); bufCur+=urlLen;
   }
 
-  
   PROLLY_PUT_U16(bufCur,cs->nTracking); bufCur+=2;
   for(i=0; i<cs->nTracking; i++){
     int remoteLen = (int)strlen(cs->aTracking[i].zRemote);
@@ -1320,6 +1324,14 @@ int chunkStoreHas(ChunkStore *cs, const ProllyHash *hash){
   return 0;
 }
 
+/*
+** Retrieve a chunk by hash. The lookup order matters:
+**   1. Pending (uncommitted) chunks in pWriteBuf
+**   2. Committed index -- WAL-encoded offsets read from pWalData cache
+**   3. Committed index -- in-memory pWriteBuf (memory-only stores)
+**   4. Committed index -- read from file (offset + 4 skips length prefix)
+** Caller must sqlite3_free(*ppData).
+*/
 int chunkStoreGet(
   ChunkStore *cs,
   const ProllyHash *hash,
@@ -1332,29 +1344,27 @@ int chunkStoreGet(
   *ppData = 0;
   *pnData = 0;
 
-  
+  /* 1. Check pending (uncommitted) chunks first. */
   idx = csSearchPending(cs, hash);
   if( idx >= 0 ){
     ChunkIndexEntry *e = &cs->aPending[idx];
-    
     i64 off = e->offset;
     int sz = e->size;
     u8 *pCopy = (u8 *)sqlite3_malloc(sz);
     if( pCopy == 0 ) return SQLITE_NOMEM;
-    
+    /* offset points at the 4-byte length prefix; data starts at offset+4 */
     memcpy(pCopy, cs->pWriteBuf + off + 4, sz);
     *ppData = pCopy;
     *pnData = sz;
     return SQLITE_OK;
   }
 
-  
   idx = csSearchIndex(cs->aIndex, cs->nIndex, hash);
   if( idx < 0 ){
     return SQLITE_NOTFOUND;
   }
 
-  
+  /* 2. WAL-cached chunk (negative offset). */
   {
     ChunkIndexEntry *e = &cs->aIndex[idx];
     if( csIsWalOffset(e->offset) && cs->pWalData ){
@@ -1372,7 +1382,7 @@ int chunkStoreGet(
     }
   }
 
-  
+  /* 3. Memory-only store: read from pWriteBuf. */
   if( cs->pFile == 0 ){
     ChunkIndexEntry *e = &cs->aIndex[idx];
     if( cs->pWriteBuf && e->offset >= 0
@@ -1387,6 +1397,7 @@ int chunkStoreGet(
     return SQLITE_NOTFOUND;
   }
 
+  /* 4. Read from file. Verify stored length matches index for corruption check. */
   {
     ChunkIndexEntry *e = &cs->aIndex[idx];
     i64 fileOff = e->offset;
@@ -1395,7 +1406,6 @@ int chunkStoreGet(
     u8 *pBuf;
     u32 storedLen;
 
-    
     rc = sqlite3OsRead(cs->pFile, lenBuf, 4, fileOff);
     if( rc != SQLITE_OK ) return rc;
 
@@ -1429,33 +1439,28 @@ int chunkStorePut(
   int rc;
   ProllyHash h;
 
-  
   prollyHashCompute(pData, nData, &h);
   if( pHash ) memcpy(pHash, &h, sizeof(ProllyHash));
 
-  
+  /* Content-addressed: skip if chunk already exists. */
   if( csSearchIndex(cs->aIndex, cs->nIndex, &h) >= 0 ) return SQLITE_OK;
   if( csSearchPending(cs, &h) >= 0 ) return SQLITE_OK;
 
-  
   rc = csGrowPending(cs);
   if( rc != SQLITE_OK ) return rc;
 
-  
   rc = csGrowWriteBuf(cs, 4 + nData);
   if( rc != SQLITE_OK ) return rc;
 
-  
   {
     ChunkIndexEntry *e = &cs->aPending[cs->nPending];
     e->hash = h;
-    e->offset = (i64)cs->nWriteBuf;
+    e->offset = (i64)cs->nWriteBuf;  /* points at the length prefix in pWriteBuf */
     e->size = nData;
     cs->nPending++;
-    
   }
 
-  
+  /* Write [length_le32][data] into pWriteBuf. */
   CS_WRITE_U32(cs->pWriteBuf + cs->nWriteBuf, (u32)nData);
   cs->nWriteBuf += 4;
   memcpy(cs->pWriteBuf + cs->nWriteBuf, pData, nData);
@@ -1481,6 +1486,18 @@ static int csCommitToMemory(ChunkStore *cs){
   return SQLITE_OK;
 }
 
+/*
+** Commit pending chunks to file. The protocol is crash-safe:
+**   1. Acquire exclusive file lock
+**   2. Check for concurrent writes (file grew since last known size)
+**   3. Append WAL chunk records: tag(0x01) + hash(20) + len(4) + data
+**   4. Append WAL root record: tag(0x02) + manifest_snapshot(168)
+**   5. fsync -- this is the durability point
+**   6. Release lock
+** After fsync, copy newly-committed chunks into the in-memory pWalData
+** cache and merge pending entries into the sorted aIndex.
+** If another writer changed the root since we opened, return SQLITE_BUSY_SNAPSHOT.
+*/
 static int csCommitToFile(ChunkStore *cs){
   int rc;
   int i;
@@ -1489,9 +1506,6 @@ static int csCommitToFile(ChunkStore *cs){
   int lockFd = -1;
   int hadFile = (cs->pFile != 0);
 
-  
-
-  
   if( cs->pFile == 0 ){
     int openFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE
                   | SQLITE_OPEN_MAIN_DB;
@@ -1499,23 +1513,19 @@ static int csCommitToFile(ChunkStore *cs){
     if( rc != SQLITE_OK ) return SQLITE_CANTOPEN;
   }
 
-  
   if( csFileLock(cs->zFilename, &lockFd) != 0 ){
     return SQLITE_BUSY;
   }
 
-  
   rc = cs->pFile->pMethods->xFileSize(cs->pFile, &fileSize);
   if( rc != SQLITE_OK ) goto commit_done;
 
-  
+  /* Detect concurrent writer: if file grew, re-read WAL and check for conflict. */
   if( fileSize > cs->iFileSize && hadFile ){
     ProllyHash rootBefore = cs->root;
-    
     sqlite3_free(cs->pWalData);
     cs->pWalData = 0;
     cs->nWalData = 0;
-    
     {
       int savePending = cs->nPending;
       cs->nPending = 0;
@@ -1523,14 +1533,12 @@ static int csCommitToFile(ChunkStore *cs){
       csReplayWalRegion(cs, 1);
       cs->nPending = savePending;
     }
-    
     if( prollyHashCompare(&rootBefore, &cs->root) != 0 ){
       rc = SQLITE_BUSY_SNAPSHOT;
       goto commit_done;
     }
   }
 
-  
   if( fileSize == 0 ){
     u8 manifest[CHUNK_MANIFEST_SIZE];
     cs->iWalOffset = CHUNK_MANIFEST_SIZE;
@@ -1540,10 +1548,9 @@ static int csCommitToFile(ChunkStore *cs){
     fileSize = CHUNK_MANIFEST_SIZE;
   }
 
-  
   writeOff = fileSize;
 
-  
+  /* Write WAL chunk records. */
   for( i = 0; i < cs->nPending; i++ ){
     ChunkIndexEntry *pe = &cs->aPending[i];
     u8 recHdr[25];
@@ -1551,12 +1558,11 @@ static int csCommitToFile(ChunkStore *cs){
     memcpy(recHdr + 1, &pe->hash, 20);
     CS_WRITE_U32(recHdr + 21, (u32)pe->size);
 
-    i64 bufOff = pe->offset + 4;  
+    i64 bufOff = pe->offset + 4;  /* skip length prefix to get to data */
     rc = sqlite3OsWrite(cs->pFile, recHdr, 25, writeOff);
     if( rc != SQLITE_OK ) goto commit_done;
     writeOff += 25;
 
-    
     {
       const u8 *pSrc = cs->pWriteBuf + bufOff;
       int remaining = pe->size;
@@ -1571,7 +1577,7 @@ static int csCommitToFile(ChunkStore *cs){
     if( rc != SQLITE_OK ) goto commit_done;
   }
 
-  
+  /* Write WAL root record (manifest snapshot for crash recovery). */
   {
     u8 rootRec[1 + CHUNK_MANIFEST_SIZE];
     rootRec[0] = CS_WAL_TAG_ROOT;
@@ -1581,20 +1587,18 @@ static int csCommitToFile(ChunkStore *cs){
     writeOff += sizeof(rootRec);
   }
 
-  
+  /* fsync is the durability point -- all data is recoverable after this. */
   rc = sqlite3OsSync(cs->pFile, SQLITE_SYNC_NORMAL);
   if( rc != SQLITE_OK ) goto commit_done;
 
-  
   cs->iFileSize = writeOff;
 
 commit_done:
-  
   csFileUnlock(lockFd);
 
   if( rc != SQLITE_OK ) return rc;
 
-  
+  /* Move pending chunks into the WAL data cache with encoded offsets. */
   for( i = 0; i < cs->nPending; i++ ){
     ChunkIndexEntry *pe = &cs->aPending[i];
     i64 bufOff = pe->offset + 4;
@@ -1612,7 +1616,6 @@ commit_done:
     }
   }
 
-  
   {
     ChunkIndexEntry *aMerged = 0;
     int nMerged = 0;
@@ -1627,7 +1630,6 @@ commit_done:
     cs->nIndexAlloc = nMerged;
   }
 
-  
   sqlite3_free(cs->pWriteBuf);
   cs->pWriteBuf = 0;
   cs->nWriteBuf = 0;
@@ -1648,12 +1650,11 @@ void chunkStoreRollback(ChunkStore *cs){
   cs->nPending = 0;
     csPendHTClear(cs);
   if( cs->isMemory ){
-    
+    /* Truncate pWriteBuf back to the last committed point. */
     cs->nWriteBuf = cs->nCommittedWriteBuf;
   }else{
     cs->nWriteBuf = 0;
   }
-  
 }
 
 int chunkStoreIsEmpty(ChunkStore *cs){
@@ -1690,11 +1691,9 @@ int chunkStoreRefreshIfChanged(ChunkStore *cs, int *pChanged){
   *pChanged = 0;
   if( cs->isMemory ) return SQLITE_OK;
 
-  
   if( cs->snapshotPinned ) return SQLITE_OK;
 
   if( cs->pFile==0 ){
-    
     int exists = 0;
     rc = sqlite3OsAccess(cs->pVfs, cs->zFilename,
                          SQLITE_ACCESS_EXISTS, &exists);
@@ -1702,7 +1701,6 @@ int chunkStoreRefreshIfChanged(ChunkStore *cs, int *pChanged){
     if( exists ){
       struct stat mainStat;
       if( stat(cs->zFilename, &mainStat)==0 && mainStat.st_size > 0 ){
-        
         int openFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB;
         rc = csOpenFile(cs->pVfs, cs->zFilename, &cs->pFile, openFlags);
         if( rc!=SQLITE_OK ) return rc;
@@ -1718,17 +1716,15 @@ int chunkStoreRefreshIfChanged(ChunkStore *cs, int *pChanged){
     return SQLITE_OK;
   }
 
-  
   rc = sqlite3OsFileControl(cs->pFile, SQLITE_FCNTL_HAS_MOVED, &bMoved);
   if( rc!=SQLITE_OK ) return SQLITE_OK;
 
   if( !bMoved ){
-    
     i64 fileSize = 0;
     rc = sqlite3OsFileSize(cs->pFile, &fileSize);
     if( rc!=SQLITE_OK ) return SQLITE_OK;
     if( fileSize > cs->iFileSize ){
-      
+      /* File grew from another writer; re-read WAL to pick up new chunks. */
       sqlite3_free(cs->pWalData);
       cs->pWalData = 0;
       cs->nWalData = 0;
@@ -1742,7 +1738,7 @@ int chunkStoreRefreshIfChanged(ChunkStore *cs, int *pChanged){
     return SQLITE_OK;
   }
 
-  
+  /* File was moved/replaced (e.g., by GC). Reopen and reload everything. */
   csCloseFile(cs->pFile);
   cs->pFile = 0;
   sqlite3_free(cs->aIndex);
@@ -1825,4 +1821,4 @@ void chunkStoreSetConflictsCatalog(ChunkStore *cs, const ProllyHash *pHash){
   memcpy(&cs->conflictsCatalogHash, pHash, sizeof(ProllyHash));
 }
 
-#endif 
+#endif /* DOLTLITE_PROLLY */

--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -1,3 +1,21 @@
+/*
+** Content-addressed chunk store backed by a single file.
+**
+** File layout:
+**   [Manifest: 168 bytes at offset 0]
+**     magic(4) + version(4) + root_hash(20) + nChunks(4) +
+**     index_offset(8) + index_size(4) + catalog_hash(20) +
+**     head_commit_hash(20) + wal_offset(8) + reserved(12) +
+**     refs_hash(20) + reserved(44)
+**   [Chunk data region: after manifest, before index]
+**     Each chunk stored as: length_le32(4) + data(length)
+**   [Sorted index: nChunks * 32-byte entries]
+**     Each entry: hash(20) + file_offset(8) + data_size(4)
+**   [WAL region: iWalOffset to EOF]
+**     Append-only log of chunk and root records for crash safety.
+**     chunk record: tag(0x01) + hash(20) + len_le32(4) + data(len)
+**     root record:  tag(0x02) + manifest_snapshot(168)
+*/
 
 #ifndef SQLITE_CHUNK_STORE_H
 #define SQLITE_CHUNK_STORE_H
@@ -5,11 +23,13 @@
 #include "sqliteInt.h"
 #include "prolly_hash.h"
 
-#define CHUNK_STORE_MAGIC 0x444C5443  
+#define CHUNK_STORE_MAGIC 0x444C5443  /* "DLTC" in little-endian */
 #define CHUNK_STORE_VERSION 6
 #define CHUNK_MANIFEST_SIZE 168
-#define CHUNK_INDEX_ENTRY_SIZE 32     
+#define CHUNK_INDEX_ENTRY_SIZE 32     /* 20-byte hash + 8-byte offset + 4-byte size */
 
+/* Working set blob layout:
+**   [version:1][staged_hash:20][is_merging:1][merge_commit:20][conflicts:20] */
 #define WS_VERSION_SIZE     1
 #define WS_STAGED_OFF       WS_VERSION_SIZE
 #define WS_MERGING_OFF      (WS_STAGED_OFF + PROLLY_HASH_SIZE)
@@ -21,100 +41,95 @@ typedef struct ChunkStore ChunkStore;
 typedef struct ChunkIndexEntry ChunkIndexEntry;
 typedef struct ConflictEntry ConflictEntry;
 
+/* Three-way merge conflict. "Ours" is the current working row, not stored here. */
 struct ConflictEntry {
-  u8 *pKey;           
-  int nKey;           
-  u8 *pBaseVal;       
-  int nBaseVal;       
-  u8 *pTheirVal;      
-  int nTheirVal;      
+  u8 *pKey;
+  int nKey;
+  u8 *pBaseVal;       /* Ancestor value (NULL if row didn't exist in base) */
+  int nBaseVal;
+  u8 *pTheirVal;      /* Their value (NULL if deleted by theirs) */
+  int nTheirVal;
 };
 
 struct ChunkIndexEntry {
   ProllyHash hash;
-  i64 offset;     
-  int size;       
+  i64 offset;      /* File offset of the 4-byte length prefix, or negative for WAL-encoded offset */
+  int size;        /* Data size (excludes the 4-byte length prefix) */
 };
 
 struct ChunkStore {
-  char *zFilename;           
-  sqlite3_file *pFile;       
-  sqlite3_vfs *pVfs;         
-  ProllyHash root;           
-  ProllyHash catalog;        
-  ProllyHash headCommit;     
-  ProllyHash refsHash;       
+  char *zFilename;
+  sqlite3_file *pFile;
+  sqlite3_vfs *pVfs;
+  ProllyHash root;
+  ProllyHash catalog;
+  ProllyHash headCommit;
+  ProllyHash refsHash;
 
-  
+  /* These fields come from the per-branch WorkingSet, not from the manifest. */
   ProllyHash stagedCatalog;
   u8 isMerging;
   ProllyHash mergeCommitHash;
   ProllyHash conflictsCatalogHash;
 
-  
   struct BranchRef {
     char *zName;
     ProllyHash commitHash;
     ProllyHash workingSetHash;
   } *aBranches;
   int nBranches;
-  char *zDefaultBranch;      
+  char *zDefaultBranch;
 
-  
   struct TagRef {
     char *zName;
     ProllyHash commitHash;
   } *aTags;
   int nTags;
 
-  
   struct RemoteRef {
-    char *zName;    
-    char *zUrl;     
+    char *zName;
+    char *zUrl;
   } *aRemotes;
   int nRemotes;
 
-  
   struct TrackingBranch {
-    char *zRemote;  
-    char *zBranch;  
+    char *zRemote;
+    char *zBranch;
     ProllyHash commitHash;
   } *aTracking;
   int nTracking;
 
-  
-  int nChunks;               
-  i64 iIndexOffset;          
-  int nIndexSize;            
-  i64 iWalOffset;            
-  i64 iFileSize;             
+  int nChunks;
+  i64 iIndexOffset;
+  int nIndexSize;
+  i64 iWalOffset;
+  i64 iFileSize;             /* Last-known file size; used to detect concurrent writers */
 
-  
-  ChunkIndexEntry *aIndex;   
+  ChunkIndexEntry *aIndex;   /* Committed index, sorted by hash for binary search */
   int nIndex;
   int nIndexAlloc;
 
-  
+  /* Pending (uncommitted) chunks. Offsets point into pWriteBuf at the length prefix. */
   ChunkIndexEntry *aPending;
   int nPending;
   int nPendingAlloc;
-  int *aPendingHT;           
-  int *aPendingHTNext;       
-  int nPendingHTBuilt;       
-  int nPendingHTNextAlloc;   
-  int nPendingHTSize;        
-  u8 *pWriteBuf;
+  int *aPendingHT;           /* Hash table buckets: bucket -> aPending index, -1 = empty */
+  int *aPendingHTNext;       /* Collision chains: aPending index -> next index, -1 = end */
+  int nPendingHTBuilt;       /* How many aPending entries are indexed in the hash table */
+  int nPendingHTNextAlloc;
+  int nPendingHTSize;        /* Bucket count (always a power of 2) */
+  u8 *pWriteBuf;             /* Serialized pending chunks: [4-byte LE length][data]... */
   i64 nWriteBuf;
   i64 nWriteBufAlloc;
 
   u8 readOnly;
   u8 isMemory;
-  u8 snapshotPinned;         
-  i64 nCommittedWriteBuf;
+  u8 snapshotPinned;         /* When set, RefreshIfChanged becomes a no-op */
+  i64 nCommittedWriteBuf;    /* In-memory mode: committed portion of pWriteBuf (survives rollback) */
 
-  
-  u8 *pWalData;              
-  i64 nWalData;              
+  /* Cached copy of the on-disk WAL region so chunk reads don't hit the file */
+  u8 *pWalData;
+  i64 nWalData;
 };
 
 int chunkStoreOpen(ChunkStore *cs, sqlite3_vfs *pVfs,
@@ -171,9 +186,11 @@ int chunkStoreHasMany(ChunkStore *cs, const ProllyHash *aHash, int nHash, u8 *aR
 
 int chunkStoreHas(ChunkStore *cs, const ProllyHash *hash);
 
+/* Caller must sqlite3_free(*ppData). Returns SQLITE_NOTFOUND if not present. */
 int chunkStoreGet(ChunkStore *cs, const ProllyHash *hash,
                   u8 **ppData, int *pnData);
 
+/* Data is buffered in memory until chunkStoreCommit. */
 int chunkStorePut(ChunkStore *cs, const u8 *pData, int nData,
                   ProllyHash *pHash);
 
@@ -198,4 +215,4 @@ void chunkStoreClearMergeState(ChunkStore *cs);
 void chunkStoreGetConflictsCatalog(ChunkStore *cs, ProllyHash *pHash);
 void chunkStoreSetConflictsCatalog(ChunkStore *cs, const ProllyHash *pHash);
 
-#endif 
+#endif /* SQLITE_CHUNK_STORE_H */

--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -1,180 +1,142 @@
-/*
-** Single-file content-addressed chunk store.
-**
-** File layout:
-**   [Manifest header: 168 bytes at offset 0]
-**     magic(4) + version(4) + root_hash(20) + chunk_count(4) +
-**     index_offset(8) + index_size(4) + catalog_hash(20) +
-**     head_commit(20) + wal_offset(8) + reserved(12) + refs_hash(20) +
-**     reserved(64)
-**   [Compacted chunk data: offset 168 to iWalOffset]
-**     length(4) + data(length), with sorted index
-**   [WAL region: iWalOffset to EOF]
-**     Append-only journal of chunk and root records
-**     chunk record: tag(0x01) + hash(20) + len(4) + data
-**     root record:  tag(0x02) + manifest(168)
-**
-** GC rewrites the file with all chunks compacted (empty WAL region).
-** Normal commits append to the WAL region at EOF.
-*/
+
 #ifndef SQLITE_CHUNK_STORE_H
 #define SQLITE_CHUNK_STORE_H
 
 #include "sqliteInt.h"
 #include "prolly_hash.h"
 
-/* Manifest magic */
-#define CHUNK_STORE_MAGIC 0x444C5443  /* "DLTC" */
+#define CHUNK_STORE_MAGIC 0x444C5443  
 #define CHUNK_STORE_VERSION 6
 #define CHUNK_MANIFEST_SIZE 168
-#define CHUNK_INDEX_ENTRY_SIZE 32
+#define CHUNK_INDEX_ENTRY_SIZE 32     
 
-/* WorkingSet layout constants */
 #define WS_VERSION_SIZE     1
-#define WS_STAGED_OFF       WS_VERSION_SIZE                           /* 1  */
-#define WS_MERGING_OFF      (WS_STAGED_OFF + PROLLY_HASH_SIZE)       /* 21 */
-#define WS_MERGE_COMMIT_OFF (WS_MERGING_OFF + 1)                     /* 22 */
-#define WS_CONFLICTS_OFF    (WS_MERGE_COMMIT_OFF + PROLLY_HASH_SIZE) /* 42 */
-#define WS_TOTAL_SIZE       (WS_CONFLICTS_OFF + PROLLY_HASH_SIZE)    /* 62 */
+#define WS_STAGED_OFF       WS_VERSION_SIZE
+#define WS_MERGING_OFF      (WS_STAGED_OFF + PROLLY_HASH_SIZE)
+#define WS_MERGE_COMMIT_OFF (WS_MERGING_OFF + 1)
+#define WS_CONFLICTS_OFF    (WS_MERGE_COMMIT_OFF + PROLLY_HASH_SIZE)
+#define WS_TOTAL_SIZE       (WS_CONFLICTS_OFF + PROLLY_HASH_SIZE)
 
 typedef struct ChunkStore ChunkStore;
 typedef struct ChunkIndexEntry ChunkIndexEntry;
 typedef struct ConflictEntry ConflictEntry;
 
-/*
-** A single row-level conflict from a three-way merge.
-** Stored inline: the key (rowid or PK blob), the base (ancestor) value,
-** and the "their" value.  "Ours" is already the working row.
-** Conflicts for each table are collected into a prolly tree keyed by
-** the conflict key.  The conflict catalog maps table name → conflict
-** tree root hash.
-*/
 struct ConflictEntry {
-  u8 *pKey;           /* Primary key blob */
-  int nKey;           /* Size of pKey */
-  u8 *pBaseVal;       /* Ancestor row value (NULL if row didn't exist) */
-  int nBaseVal;       /* Size of pBaseVal */
-  u8 *pTheirVal;      /* Their row value (NULL if row was deleted) */
-  int nTheirVal;      /* Size of pTheirVal */
+  u8 *pKey;           
+  int nKey;           
+  u8 *pBaseVal;       
+  int nBaseVal;       
+  u8 *pTheirVal;      
+  int nTheirVal;      
 };
 
 struct ChunkIndexEntry {
   ProllyHash hash;
-  i64 offset;     /* Byte offset in file */
-  int size;       /* Chunk data size */
+  i64 offset;     
+  int size;       
 };
 
 struct ChunkStore {
-  char *zFilename;           /* Database file path */
-  sqlite3_file *pFile;       /* OS file handle */
-  sqlite3_vfs *pVfs;         /* VFS for file operations */
-  ProllyHash root;           /* Current root hash */
-  ProllyHash catalog;        /* Catalog hash (table registry) */
-  ProllyHash headCommit;     /* HEAD commit hash */
-  ProllyHash refsHash;       /* Hash of refs chunk (branch mapping) */
+  char *zFilename;           
+  sqlite3_file *pFile;       
+  sqlite3_vfs *pVfs;         
+  ProllyHash root;           
+  ProllyHash catalog;        
+  ProllyHash headCommit;     
+  ProllyHash refsHash;       
 
-  /* Legacy fields — kept in struct for code that still reads them,
-  ** but no longer persisted in manifest. Values come from WorkingSet. */
+  
   ProllyHash stagedCatalog;
   u8 isMerging;
   ProllyHash mergeCommitHash;
   ProllyHash conflictsCatalogHash;
 
-  /* Branch refs (in-memory, loaded from refs chunk) */
+  
   struct BranchRef {
     char *zName;
     ProllyHash commitHash;
     ProllyHash workingSetHash;
   } *aBranches;
   int nBranches;
-  char *zDefaultBranch;      /* Default branch for new connections */
+  char *zDefaultBranch;      
 
-  /* Tag refs */
+  
   struct TagRef {
     char *zName;
     ProllyHash commitHash;
   } *aTags;
   int nTags;
 
-  /* Remote refs */
+  
   struct RemoteRef {
-    char *zName;    /* e.g., "origin" */
-    char *zUrl;     /* file path or URL */
+    char *zName;    
+    char *zUrl;     
   } *aRemotes;
   int nRemotes;
 
-  /* Remote tracking branches (e.g., origin/main) */
+  
   struct TrackingBranch {
-    char *zRemote;  /* Remote name */
-    char *zBranch;  /* Branch name */
+    char *zRemote;  
+    char *zBranch;  
     ProllyHash commitHash;
   } *aTracking;
   int nTracking;
 
-  /* File layout */
-  int nChunks;               /* Number of compacted chunks */
-  i64 iIndexOffset;          /* File offset of chunk index */
-  int nIndexSize;            /* Size of chunk index in bytes */
-  i64 iWalOffset;            /* File offset where WAL region starts */
-  i64 iFileSize;             /* Last known total file size */
+  
+  int nChunks;               
+  i64 iIndexOffset;          
+  int nIndexSize;            
+  i64 iWalOffset;            
+  i64 iFileSize;             
 
-  /* In-memory index (loaded on open) */
-  ChunkIndexEntry *aIndex;   /* Sorted array of index entries */
+  
+  ChunkIndexEntry *aIndex;   
   int nIndex;
   int nIndexAlloc;
 
-  /* Write buffer for pending chunks */
+  
   ChunkIndexEntry *aPending;
   int nPending;
   int nPendingAlloc;
-  int *aPendingHT;           /* Hash table buckets for pending lookup */
-  int *aPendingHTNext;       /* Next-chain for hash table */
-  int nPendingHTBuilt;       /* Entries indexed so far */
-  int nPendingHTNextAlloc;   /* Allocated size of aPendingHTNext */
-  int nPendingHTSize;        /* Number of hash table buckets */
+  int *aPendingHT;           
+  int *aPendingHTNext;       
+  int nPendingHTBuilt;       
+  int nPendingHTNextAlloc;   
+  int nPendingHTSize;        
   u8 *pWriteBuf;
   i64 nWriteBuf;
   i64 nWriteBufAlloc;
 
   u8 readOnly;
   u8 isMemory;
-  u8 snapshotPinned;         /* True while a read transaction holds a snapshot */
+  u8 snapshotPinned;         
   i64 nCommittedWriteBuf;
 
-  /* WAL region cache (read from file on open, updated on commit) */
-  u8 *pWalData;              /* In-memory copy of WAL region */
-  i64 nWalData;              /* Size of WAL region data */
+  
+  u8 *pWalData;              
+  i64 nWalData;              
 };
 
-/* Open or create a chunk store at the given path */
 int chunkStoreOpen(ChunkStore *cs, sqlite3_vfs *pVfs,
                    const char *zFilename, int flags);
 
-/* Close the chunk store */
 int chunkStoreClose(ChunkStore *cs);
 
-/* Get the current root hash */
 void chunkStoreGetRoot(ChunkStore *cs, ProllyHash *pRoot);
 
-/* Set the root hash (staged, not committed until chunkStoreCommit) */
 void chunkStoreSetRoot(ChunkStore *cs, const ProllyHash *pRoot);
 
-/* Get/set the catalog hash (table registry + meta values) */
 void chunkStoreGetCatalog(ChunkStore *cs, ProllyHash *pCat);
 void chunkStoreSetCatalog(ChunkStore *cs, const ProllyHash *pCat);
 
-/* Get/set the HEAD commit hash */
 void chunkStoreGetHeadCommit(ChunkStore *cs, ProllyHash *pHead);
 void chunkStoreSetHeadCommit(ChunkStore *cs, const ProllyHash *pHead);
 
-/* Get/set the staged catalog hash */
 void chunkStoreGetStagedCatalog(ChunkStore *cs, ProllyHash *pStaged);
 void chunkStoreSetStagedCatalog(ChunkStore *cs, const ProllyHash *pStaged);
 
-/* Reload refs (branches, tags, remotes, tracking) from the current refsHash */
 int chunkStoreReloadRefs(ChunkStore *cs);
 
-/* Branch management */
 const char *chunkStoreGetDefaultBranch(ChunkStore *cs);
 int chunkStoreSetDefaultBranch(ChunkStore *cs, const char *zName);
 int chunkStoreAddBranch(ChunkStore *cs, const char *zName, const ProllyHash *pCommit);
@@ -183,21 +145,17 @@ int chunkStoreFindBranch(ChunkStore *cs, const char *zName, ProllyHash *pCommit)
 int chunkStoreUpdateBranch(ChunkStore *cs, const char *zName, const ProllyHash *pCommit);
 int chunkStoreSerializeRefs(ChunkStore *cs);
 
-/* Per-branch WorkingSet management */
 int chunkStoreGetBranchWorkingSet(ChunkStore *cs, const char *zBranch, ProllyHash *pHash);
 int chunkStoreSetBranchWorkingSet(ChunkStore *cs, const char *zBranch, const ProllyHash *pHash);
 
-/* Tag management */
 int chunkStoreAddTag(ChunkStore *cs, const char *zName, const ProllyHash *pCommit);
 int chunkStoreDeleteTag(ChunkStore *cs, const char *zName);
 int chunkStoreFindTag(ChunkStore *cs, const char *zName, ProllyHash *pCommit);
 
-/* Remote management */
 int chunkStoreAddRemote(ChunkStore *cs, const char *zName, const char *zUrl);
 int chunkStoreDeleteRemote(ChunkStore *cs, const char *zName);
 int chunkStoreFindRemote(ChunkStore *cs, const char *zName, const char **pzUrl);
 
-/* Tracking branch management */
 int chunkStoreUpdateTracking(ChunkStore *cs, const char *zRemote,
                              const char *zBranch, const ProllyHash *pCommit);
 int chunkStoreFindTracking(ChunkStore *cs, const char *zRemote,
@@ -205,44 +163,30 @@ int chunkStoreFindTracking(ChunkStore *cs, const char *zRemote,
 int chunkStoreDeleteTracking(ChunkStore *cs, const char *zRemote,
                              const char *zBranch);
 
-/* Parse a refs blob into cs->aBranches/aTags/aRemotes/aTracking (no file I/O) */
 int chunkStoreLoadRefsFromBlob(ChunkStore *cs, const u8 *data, int nData);
 
-/* Serialize cs->aBranches/aTags/aRemotes/aTracking into a blob (caller frees) */
 int chunkStoreSerializeRefsToBlob(ChunkStore *cs, u8 **ppOut, int *pnOut);
 
-/* Bulk has-check for sync (check multiple hashes at once) */
 int chunkStoreHasMany(ChunkStore *cs, const ProllyHash *aHash, int nHash, u8 *aResult);
 
-/* Check if a chunk exists */
 int chunkStoreHas(ChunkStore *cs, const ProllyHash *hash);
 
-/* Read a chunk by hash. Caller must sqlite3_free(*ppData).
-** Returns SQLITE_OK, SQLITE_NOTFOUND, or error. */
 int chunkStoreGet(ChunkStore *cs, const ProllyHash *hash,
                   u8 **ppData, int *pnData);
 
-/* Stage a new chunk for writing. Hash is computed from data.
-** Returns the hash in *pHash. Data is buffered until commit. */
 int chunkStorePut(ChunkStore *cs, const u8 *pData, int nData,
                   ProllyHash *pHash);
 
-/* Commit all pending chunks and new root atomically.
-** Writes chunks + updated index, fsyncs, updates manifest. */
 int chunkStoreCommit(ChunkStore *cs);
 
-/* Discard all pending chunks (rollback) */
 void chunkStoreRollback(ChunkStore *cs);
 
-/* Return 1 if store is empty (no root) */
 int chunkStoreIsEmpty(ChunkStore *cs);
 
-/* Get the filename */
 const char *chunkStoreFilename(ChunkStore *cs);
 
 int chunkStoreRefreshIfChanged(ChunkStore *cs, int *pChanged);
 
-/* Merge state accessors */
 int chunkStoreGetMergeState(ChunkStore *cs, u8 *pIsMerging,
                             ProllyHash *pMergeCommit,
                             ProllyHash *pConflictsCatalog);
@@ -251,8 +195,7 @@ void chunkStoreSetMergeState(ChunkStore *cs, u8 isMerging,
                              const ProllyHash *pConflictsCatalog);
 void chunkStoreClearMergeState(ChunkStore *cs);
 
-/* Get/set the conflicts catalog hash independently */
 void chunkStoreGetConflictsCatalog(ChunkStore *cs, ProllyHash *pHash);
 void chunkStoreSetConflictsCatalog(ChunkStore *cs, const ProllyHash *pHash);
 
-#endif /* SQLITE_CHUNK_STORE_H */
+#endif 

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -377,7 +377,10 @@ static void doltliteCommitFunc(
     }
   }
 
-  
+  /* Optimistic concurrency: reject if another connection committed to this
+  ** branch since our session last read it. Session HEAD was captured at
+  ** checkout/open; if it no longer matches the branch tip in shared refs,
+  ** someone else committed and our staged catalog is based on stale state. */
   {
     const char *branch = doltliteGetSessionBranch(db);
     ProllyHash branchTip;
@@ -831,7 +834,7 @@ static void doltliteMergeFunc(
       char msg[256];
 
       memset(&mergeCommit, 0, sizeof(mergeCommit));
-      
+      /* Merge commit has two parents: ours (index 0) and theirs (index 1) */
       mergeCommit.aParents[0] = ourHead;
       mergeCommit.aParents[1] = theirHead;
       mergeCommit.nParents = 2;

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -1,13 +1,4 @@
-/*
-** Doltlite version control features.
-**
-** SQL interface:
-**   SELECT dolt_add('tablename');       -- stage a table
-**   SELECT dolt_add('-A');              -- stage all changes
-**   SELECT dolt_commit('-m', 'msg');    -- commit staged changes
-**   SELECT * FROM dolt_log;             -- commit history
-**   SELECT * FROM dolt_status;          -- working/staged changes
-*/
+
 #ifdef DOLTLITE_PROLLY
 
 #include "sqliteInt.h"
@@ -34,19 +25,12 @@ extern void doltliteRegisterAtTables(sqlite3 *db);
 extern void doltliteRegisterHistoryTables(sqlite3 *db);
 extern int doltliteSchemaDiffRegister(sqlite3 *db);
 
-/* From doltlite_ancestor.c */
 extern int doltliteFindAncestor(sqlite3 *db, const ProllyHash *h1,
                                  const ProllyHash *h2, ProllyHash *pAnc);
-/* From doltlite_merge.c */
+
 extern int doltliteMergeCatalogs(sqlite3 *db, const ProllyHash *ancestor,
                                   const ProllyHash *ours, const ProllyHash *theirs,
                                   ProllyHash *pMergedHash, int *pnConflicts);
-
-/* --------------------------------------------------------------------------
-** Schema hash update: query sqlite_master for CREATE TABLE SQL and hash it.
-** This lives in the doltlite layer (not prolly_btree) because it uses
-** sqlite3_prepare_v2 which is a high-level SQL API.
-** -------------------------------------------------------------------------- */
 
 extern const char *doltliteNextTableForSchema(sqlite3 *db, int *pIdx, Pgno *piTable);
 extern void doltliteSetTableSchemaHash(sqlite3 *db, Pgno iTable, const ProllyHash *pH);
@@ -76,12 +60,6 @@ void doltliteUpdateSchemaHashes(sqlite3 *db){
   }
 }
 
-/* --------------------------------------------------------------------------
-** dolt_add('tablename') or dolt_add('-A')
-**
-** Stages table changes for the next dolt_commit.
-** -------------------------------------------------------------------------- */
-
 static void doltliteAddFunc(
   sqlite3_context *context,
   int argc,
@@ -102,7 +80,7 @@ static void doltliteAddFunc(
     return;
   }
 
-  /* Check for -A flag */
+  
   for(i=0; i<argc; i++){
     const char *arg = (const char*)sqlite3_value_text(argv[i]);
     if( arg && (strcmp(arg, "-A")==0 || strcmp(arg, "-a")==0 || strcmp(arg, ".")==0) ){
@@ -111,7 +89,7 @@ static void doltliteAddFunc(
     }
   }
 
-  /* Flush pending mutations and serialize working catalog */
+  
   {
     u8 *catData = 0;
     int nCatData = 0;
@@ -130,15 +108,15 @@ static void doltliteAddFunc(
     }
 
     if( stageAll ){
-      /* Stage everything: staged = working */
+      
       doltliteSetSessionStaged(db, &workingHash);
     }else{
-      /* Stage specific tables */
+      
       struct TableEntry *aWorking = 0, *aStaged = 0;
       int nWorking = 0, nStaged = 0;
       ProllyHash stagedHash;
 
-      /* Load working and staged catalogs */
+      
       rc = doltliteLoadCatalog(db, &workingHash, &aWorking, &nWorking, 0);
       if( rc!=SQLITE_OK ){
         sqlite3_result_error(context, "failed to load working catalog", -1);
@@ -147,7 +125,7 @@ static void doltliteAddFunc(
 
       doltliteGetSessionStaged(db, &stagedHash);
       if( prollyHashIsEmpty(&stagedHash) ){
-        /* No staged state yet — start from HEAD */
+        
         ProllyHash headCat;
         rc = doltliteGetHeadCatalogHash(db, &headCat);
         if( rc==SQLITE_OK && !prollyHashIsEmpty(&headCat) ){
@@ -162,7 +140,7 @@ static void doltliteAddFunc(
         return;
       }
 
-      /* For each named table, copy its root hash from working to staged */
+      
       for(i=0; i<argc; i++){
         const char *zTable = (const char*)sqlite3_value_text(argv[i]);
         Pgno iTable;
@@ -172,10 +150,10 @@ static void doltliteAddFunc(
         rc = doltliteResolveTableName(db, zTable, &iTable);
         if( rc!=SQLITE_OK ) continue;
 
-        /* Find in working */
+        
         for(j=0; j<nWorking; j++){
           if( aWorking[j].iTable==iTable ){
-            /* Update or add in staged */
+            
             int k;
             int updated = 0;
             for(k=0; k<nStaged; k++){
@@ -188,7 +166,7 @@ static void doltliteAddFunc(
               }
             }
             if( !updated ){
-              /* Add new entry to staged */
+              
               struct TableEntry *aNew = sqlite3_realloc(aStaged,
                   (nStaged+1)*(int)sizeof(struct TableEntry));
               if( aNew ){
@@ -202,10 +180,10 @@ static void doltliteAddFunc(
         }
       }
 
-      /* Re-serialize the modified staged catalog (V2 format) */
+      
       {
         Pgno iNextTable = 2;
-        /* Get iNextTable from working catalog */
+        
         {
           u8 *wData = 0; int wn = 0;
           rc = chunkStoreGet(cs, &workingHash, &wData, &wn);
@@ -215,7 +193,7 @@ static void doltliteAddFunc(
           sqlite3_free(wData);
         }
         {
-          int sz = 1 + 4 + 4;  /* V2: version + iNextTable + nTables */
+          int sz = 1 + 4 + 4;  
           u8 *buf, *p;
           ProllyHash newStagedHash;
           int j;
@@ -232,7 +210,7 @@ static void doltliteAddFunc(
             return;
           }
           p = buf;
-          *p++ = 0x43;  /* CATALOG_FORMAT_V2 = 'C' */
+          *p++ = 0x43;  
           p[0]=(u8)iNextTable; p[1]=(u8)(iNextTable>>8);
           p[2]=(u8)(iNextTable>>16); p[3]=(u8)(iNextTable>>24);
           p += 4;
@@ -267,16 +245,15 @@ static void doltliteAddFunc(
       sqlite3_free(aStaged);
     }
 
-    /* Persist — if commit fails, revert session state to avoid
-    ** inconsistency between in-memory session and on-disk store. */
+    
     {
       ProllyHash savedStaged;
-      doltliteGetSessionStaged(db, &savedStaged);  /* Save before commit */
+      doltliteGetSessionStaged(db, &savedStaged);  
       doltliteSaveWorkingSet(db);
       chunkStoreSerializeRefs(cs);
       rc = chunkStoreCommit(cs);
       if( rc!=SQLITE_OK ){
-        /* Rollback session staged state to pre-commit value */
+        
         doltliteSetSessionStaged(db, &savedStaged);
         sqlite3_result_error_code(context, rc);
         return;
@@ -286,12 +263,6 @@ static void doltliteAddFunc(
 
   sqlite3_result_int(context, 0);
 }
-
-/* --------------------------------------------------------------------------
-** dolt_commit('-m', 'message' [, '--author', 'Name <email>'] [, '-A'])
-**
-** Commits the staged catalog. If -A is passed, stages everything first.
-** -------------------------------------------------------------------------- */
 
 static void doltliteCommitFunc(
   sqlite3_context *context,
@@ -318,27 +289,24 @@ static void doltliteCommitFunc(
     return;
   }
 
-  /* Parse arguments.  Supports compound short flags like "-am" which
-  ** expands to "-a" + "-m".  The last flag in a compound group can
-  ** consume the next argv element as its value (e.g. "-am" "msg"). */
+  
   for(i=0; i<argc; i++){
     const char *arg = (const char*)sqlite3_value_text(argv[i]);
     if( !arg ) continue;
     if( arg[0]=='-' && arg[1]!='-' && arg[1]!=0 && arg[2]!=0 ){
-      /* Compound short flags, e.g. "-am", "-Am" */
+      
       int j;
       for(j=1; arg[j]; j++){
         if( arg[j]=='a' || arg[j]=='A' ){
           addAll = 1;
         }else if( arg[j]=='m' ){
-          /* -m takes a value: remaining chars in compound (e.g. "-mfoo")
-          ** or the next argv element (e.g. "-am" "foo"). */
+          
           if( arg[j+1]!=0 ){
             zMessage = &arg[j+1];
           }else if( i+1<argc ){
             zMessage = (const char*)sqlite3_value_text(argv[++i]);
           }
-          break;  /* -m must be last in compound group (takes a value) */
+          break;  
         }
       }
     }else if( strcmp(arg, "-m")==0 && i+1<argc ){
@@ -356,7 +324,7 @@ static void doltliteCommitFunc(
     return;
   }
 
-  /* If -A, stage everything first */
+  
   if( addAll ){
     u8 *catData = 0;
     int nCatData = 0;
@@ -374,7 +342,7 @@ static void doltliteCommitFunc(
     doltliteSetSessionStaged(db, &catalogHash);
   }
 
-  /* Block commit while merge conflicts exist */
+  
   {
     ProllyHash cfHash;
     doltliteGetSessionConflictsCatalog(db, &cfHash);
@@ -385,7 +353,7 @@ static void doltliteCommitFunc(
     }
   }
 
-  /* Get the staged catalog hash — this is what we commit */
+  
   doltliteGetSessionStaged(db, &catalogHash);
   if( prollyHashIsEmpty(&catalogHash) ){
     sqlite3_result_error(context,
@@ -393,9 +361,7 @@ static void doltliteCommitFunc(
     return;
   }
 
-  /* Check if staged == HEAD (nothing actually changed).
-  ** Skip this check during a merge — committing a merge is always valid
-  ** even if the resolved state matches HEAD (e.g. kept all "ours" values). */
+  
   {
     u8 isMerging = 0;
     doltliteGetSessionMergeState(db, &isMerging, 0, 0);
@@ -411,9 +377,7 @@ static void doltliteCommitFunc(
     }
   }
 
-  /* Detect concurrent commit conflict: check if this connection's HEAD
-  ** still matches the branch tip in the shared refs. If another connection
-  ** committed to the same branch since we last saw it, reject. */
+  
   {
     const char *branch = doltliteGetSessionBranch(db);
     ProllyHash branchTip;
@@ -429,7 +393,7 @@ static void doltliteCommitFunc(
     }
   }
 
-  /* Build commit object — use session HEAD as parent */
+  
   memset(&commit, 0, sizeof(commit));
   doltliteGetSessionHead(db, &commit.parentHash);
   chunkStoreGetRoot(cs, &rootHash);
@@ -437,7 +401,7 @@ static void doltliteCommitFunc(
   memcpy(&commit.catalogHash, &catalogHash, sizeof(ProllyHash));
   commit.timestamp = (i64)time(0);
 
-  /* Parse author */
+  
   if( zAuthor ){
     const char *lt = strchr(zAuthor, '<');
     const char *gt = lt ? strchr(lt, '>') : 0;
@@ -456,7 +420,7 @@ static void doltliteCommitFunc(
   }
   commit.zMessage = sqlite3_mprintf("%s", zMessage);
 
-  /* Serialize and store commit */
+  
   rc = doltliteCommitSerialize(&commit, &commitData, &nCommitData);
   if( rc!=SQLITE_OK ){
     doltliteCommitClear(&commit);
@@ -472,15 +436,15 @@ static void doltliteCommitFunc(
     return;
   }
 
-  /* Update session HEAD and staged */
+  
   doltliteSetSessionHead(db, &commitHash);
   doltliteSetSessionStaged(db, &catalogHash);
 
-  /* Update shared state too (for manifest persistence) */
+  
   chunkStoreSetHeadCommit(cs, &commitHash);
   doltliteSetSessionStaged(db, &catalogHash);
 
-  /* Update branch refs — bootstrap "main" on first commit */
+  
   {
     const char *branch = doltliteGetSessionBranch(db);
     if( cs->nBranches==0 ){
@@ -492,7 +456,7 @@ static void doltliteCommitFunc(
     chunkStoreSerializeRefs(cs);
   }
 
-  /* Clear merge state if we were in a merge (commit concludes it) */
+  
   {
     u8 wasMerging = 0;
     doltliteGetSessionMergeState(db, &wasMerging, 0, 0);
@@ -517,20 +481,13 @@ static void doltliteCommitFunc(
 
   doltliteHashToHex(&commitHash, hexBuf);
 
-  /* Register per-table modules for newly created tables */
+  
   doltliteRegisterDiffTables(db);
   doltliteRegisterHistoryTables(db);
   doltliteRegisterAtTables(db);
 
   sqlite3_result_text(context, hexBuf, -1, SQLITE_TRANSIENT);
 }
-
-/* --------------------------------------------------------------------------
-** dolt_reset('--soft') or dolt_reset('--hard')
-**
-** --soft: unstage everything (staged = HEAD catalog), keep working changes
-** --hard: reset working state to HEAD, discard all uncommitted changes
-** -------------------------------------------------------------------------- */
 
 static void doltliteResetFunc(
   sqlite3_context *context,
@@ -550,23 +507,23 @@ static void doltliteResetFunc(
     return;
   }
 
-  /* Parse args: flags (--hard, --soft) and optional commit ref */
+  
   for(i=0; i<argc; i++){
     const char *arg = (const char*)sqlite3_value_text(argv[i]);
     if( !arg ) continue;
     if( strcmp(arg, "--hard")==0 ){ isHard = 1; }
-    else if( strcmp(arg, "--soft")==0 ){ /* default */ }
+    else if( strcmp(arg, "--soft")==0 ){  }
     else{ zRef = arg; }
   }
 
   if( zRef ){
-    /* Reset to a specific commit — resolve ref, load its catalog */
+    
     ProllyHash targetCommit;
     DoltliteCommit commit;
     u8 *data = 0;
     int nData = 0;
 
-    /* Try hex hash first, then branch, then tag */
+    
     rc = SQLITE_NOTFOUND;
     if( zRef && strlen(zRef)==PROLLY_HASH_SIZE*2 ){
       rc = doltliteHexToHash(zRef, &targetCommit);
@@ -583,7 +540,7 @@ static void doltliteResetFunc(
       return;
     }
 
-    /* Load the target commit to get its catalog hash */
+    
     rc = chunkStoreGet(cs, &targetCommit, &data, &nData);
     if( rc!=SQLITE_OK ){
       sqlite3_result_error(context, "failed to load commit", -1);
@@ -598,16 +555,16 @@ static void doltliteResetFunc(
     memcpy(&targetCatHash, &commit.catalogHash, sizeof(ProllyHash));
     doltliteCommitClear(&commit);
 
-    /* Move HEAD and branch ref to the target commit */
+    
     doltliteSetSessionHead(db, &targetCommit);
     chunkStoreSetHeadCommit(cs, &targetCommit);
     chunkStoreUpdateBranch(cs, doltliteGetSessionBranch(db), &targetCommit);
     chunkStoreSerializeRefs(cs);
 
-    /* Clear any merge state */
+    
     doltliteClearSessionMergeState(db);
   }else{
-    /* No ref: reset to current HEAD */
+    
     rc = doltliteGetHeadCatalogHash(db, &targetCatHash);
     if( rc!=SQLITE_OK ){
       sqlite3_result_error(context, "failed to read HEAD", -1);
@@ -615,12 +572,12 @@ static void doltliteResetFunc(
     }
   }
 
-  /* Soft reset: staged = target catalog (unstage everything) */
+  
   doltliteSetSessionStaged(db, &targetCatHash);
-  /* WorkingSet: staged already set in session */
+  
 
   if( isHard ){
-    /* Hard reset: also reset working state */
+    
     if( prollyHashIsEmpty(&targetCatHash) ){
       sqlite3_result_error(context, "no commit to reset to", -1);
       return;
@@ -633,7 +590,7 @@ static void doltliteResetFunc(
       return;
     }
   }else{
-    /* Persist soft reset */
+    
     doltliteSaveWorkingSet(db);
     chunkStoreSerializeRefs(cs);
     rc = chunkStoreCommit(cs);
@@ -645,14 +602,6 @@ static void doltliteResetFunc(
 
   sqlite3_result_int(context, 0);
 }
-
-/* --------------------------------------------------------------------------
-** dolt_merge('branch_name')
-**
-** Three-way merge of another branch into the current branch.
-** Finds common ancestor, merges catalogs, creates merge commit.
-** Fails if both branches modified the same table (conflict).
-** -------------------------------------------------------------------------- */
 
 static void doltliteMergeFunc(
   sqlite3_context *context,
@@ -674,14 +623,14 @@ static void doltliteMergeFunc(
   memset(&theirCommit, 0, sizeof(theirCommit));
   memset(&ancCommit, 0, sizeof(ancCommit));
 
-  /* --- Phase 1: Argument parsing and ref resolution --- */
+  
   if( !cs ){ sqlite3_result_error(context, "no database", -1); return; }
   if( argc<1 ){ sqlite3_result_error(context, "usage: dolt_merge('branch')", -1); return; }
 
   zBranch = (const char*)sqlite3_value_text(argv[0]);
   if( !zBranch ){ sqlite3_result_error(context, "branch name required", -1); return; }
 
-  /* Handle --abort: discard a conflicted merge, restore to HEAD */
+  
   if( strcmp(zBranch, "--abort")==0 ){
     u8 isMerging = 0;
     ProllyHash headCatHash;
@@ -692,7 +641,7 @@ static void doltliteMergeFunc(
       return;
     }
 
-    /* Reset working set back to HEAD (merge didn't commit) */
+    
     rc = doltliteGetHeadCatalogHash(db, &headCatHash);
     if( rc!=SQLITE_OK ){
       sqlite3_result_error(context, "failed to read HEAD", -1);
@@ -704,11 +653,11 @@ static void doltliteMergeFunc(
       return;
     }
 
-    /* Restore staged to HEAD catalog */
+    
     doltliteSetSessionStaged(db, &headCatHash);
-    /* WorkingSet: staged already set in session */
+    
 
-    /* Clear merge state and conflicts */
+    
     doltliteClearSessionMergeState(db);
     doltliteSaveWorkingSet(db);
     chunkStoreSerializeRefs(cs);
@@ -718,14 +667,14 @@ static void doltliteMergeFunc(
     return;
   }
 
-  /* Get our HEAD */
+  
   doltliteGetSessionHead(db, &ourHead);
   if( prollyHashIsEmpty(&ourHead) ){
     sqlite3_result_error(context, "no commits on current branch", -1);
     return;
   }
 
-  /* Get their HEAD */
+  
   rc = chunkStoreFindBranch(cs, zBranch, &theirHead);
   if( rc!=SQLITE_OK ){
     sqlite3_result_error(context, "branch not found", -1);
@@ -736,27 +685,26 @@ static void doltliteMergeFunc(
     return;
   }
 
-  /* Already up to date? */
+  
   if( prollyHashCompare(&ourHead, &theirHead)==0 ){
     sqlite3_result_text(context, "Already up to date", -1, SQLITE_STATIC);
     return;
   }
 
-  /* Find common ancestor */
+  
   rc = doltliteFindAncestor(db, &ourHead, &theirHead, &ancestorHash);
   if( rc!=SQLITE_OK || prollyHashIsEmpty(&ancestorHash) ){
     sqlite3_result_error(context, "no common ancestor found", -1);
     return;
   }
 
-
-  /* Already up to date: their HEAD is an ancestor of ours */
+  
   if( prollyHashCompare(&ancestorHash, &theirHead)==0 ){
     sqlite3_result_text(context, "Already up to date", -1, SQLITE_STATIC);
     return;
   }
 
-  /* Fast-forward: ancestor == our HEAD, create merge commit on their tip */
+  
   if( prollyHashCompare(&ancestorHash, &ourHead)==0 ){
     rc = chunkStoreGet(cs, &theirHead, &data, &nData);
     if( rc!=SQLITE_OK ){ sqlite3_result_error(context, "failed to load commit", -1); return; }
@@ -803,7 +751,7 @@ static void doltliteMergeFunc(
       doltliteSetSessionHead(db, &ch2);
       doltliteSetSessionStaged(db, &sc2);
       chunkStoreSetHeadCommit(cs, &ch2);
-      /* WorkingSet: staged already set in session */
+      
       chunkStoreUpdateBranch(cs, doltliteGetSessionBranch(db), &ch2);
       doltliteSaveWorkingSet(db);
       chunkStoreSerializeRefs(cs);
@@ -815,7 +763,7 @@ static void doltliteMergeFunc(
     }
   }
 
-  /* --- Phase 2: Load ancestor, ours, theirs catalogs --- */
+  
   rc = chunkStoreGet(cs, &ourHead, &data, &nData);
   if( rc!=SQLITE_OK ){ sqlite3_result_error(context, "failed to load our commit", -1); return; }
   rc = doltliteCommitDeserialize(data, nData, &ourCommit);
@@ -838,7 +786,7 @@ static void doltliteMergeFunc(
   memcpy(&ancCatHash, &ancCommit.catalogHash, sizeof(ProllyHash));
   doltliteCommitClear(&ancCommit);
 
-  /* --- Phase 3: Table-level and row-level merge --- */
+  
   rc = doltliteMergeCatalogs(db, &ancCatHash, &ourCatHash, &theirCatHash, &mergedCatHash, &nMergeConflicts);
   if( rc!=SQLITE_OK ){
     doltliteCommitClear(&ourCommit);
@@ -847,7 +795,7 @@ static void doltliteMergeFunc(
     return;
   }
 
-  /* --- Phase 4: Apply merge result and commit --- */
+  
   rc = doltliteHardReset(db, &mergedCatHash);
   doltliteCommitClear(&ourCommit);
   doltliteCommitClear(&theirCommit);
@@ -857,8 +805,7 @@ static void doltliteMergeFunc(
   }
 
   if( nMergeConflicts > 0 ){
-    /* Conflicts: leave working set dirty, don't commit.
-    ** User resolves conflicts then runs dolt_commit. */
+    
     doltliteRegisterConflictTables(db);
     doltliteSaveWorkingSet(db);
     chunkStoreSerializeRefs(cs);
@@ -871,9 +818,9 @@ static void doltliteMergeFunc(
       sqlite3_result_text(context, msg, -1, SQLITE_TRANSIENT);
     }
   }else{
-    /* Clean merge: create merge commit automatically */
+    
     doltliteSetSessionStaged(db, &mergedCatHash);
-    /* WorkingSet: staged already set in session */
+    
 
     {
       DoltliteCommit mergeCommit;
@@ -884,11 +831,11 @@ static void doltliteMergeFunc(
       char msg[256];
 
       memset(&mergeCommit, 0, sizeof(mergeCommit));
-      /* Merge commit has TWO parents: ours (first) and theirs (second) */
+      
       mergeCommit.aParents[0] = ourHead;
       mergeCommit.aParents[1] = theirHead;
       mergeCommit.nParents = 2;
-      mergeCommit.parentHash = ourHead;  /* convenience field */
+      mergeCommit.parentHash = ourHead;  
       memcpy(&mergeCommit.catalogHash, &mergedCatHash, sizeof(ProllyHash));
       mergeCommit.timestamp = (i64)time(0);
       sqlite3_snprintf(sizeof(msg), msg, "Merge branch '%s'", zBranch);
@@ -908,7 +855,7 @@ static void doltliteMergeFunc(
       doltliteSetSessionHead(db, &commitHash);
       doltliteSetSessionStaged(db, &mergedCatHash);
       chunkStoreSetHeadCommit(cs, &commitHash);
-      /* WorkingSet: staged already set in session */
+      
       chunkStoreUpdateBranch(cs, doltliteGetSessionBranch(db), &commitHash);
       doltliteSaveWorkingSet(db);
       chunkStoreSerializeRefs(cs);
@@ -920,9 +867,6 @@ static void doltliteMergeFunc(
   }
 }
 
-/* --------------------------------------------------------------------------
-** Helper: load a commit by hash, returning its deserialized form.
-** -------------------------------------------------------------------------- */
 static int loadCommitByHash(
   ChunkStore *cs,
   const ProllyHash *pHash,
@@ -939,9 +883,6 @@ static int loadCommitByHash(
   return rc;
 }
 
-/* --------------------------------------------------------------------------
-** Helper: resolve a commit reference (40-char hex hash) to a ProllyHash.
-** -------------------------------------------------------------------------- */
 static int resolveCommitRef(
   ChunkStore *cs,
   const char *zRef,
@@ -951,15 +892,6 @@ static int resolveCommitRef(
   return doltliteHexToHash(zRef, pHash);
 }
 
-/* --------------------------------------------------------------------------
-** Helper: apply a three-way merge result and create a new commit.
-**
-** Performs doltliteMergeCatalogs, hard-resets, creates a commit object,
-** and updates HEAD/branch refs.  Used by cherry-pick and revert.
-**
-** Returns SQLITE_OK on success; sets *pnConflicts.
-** On success, writes the new commit hash hex to hexBuf (>= 41 bytes).
-** -------------------------------------------------------------------------- */
 static int applyMergedCatalogAndCommit(
   sqlite3 *db,
   sqlite3_context *context,
@@ -982,11 +914,11 @@ static int applyMergedCatalogAndCommit(
   rc = doltliteHardReset(db, &mergedCatHash);
   if( rc!=SQLITE_OK ) return rc;
 
-  /* Stage the merged catalog */
+  
   doltliteSetSessionStaged(db, &mergedCatHash);
-  /* WorkingSet: staged already set in session */
+  
 
-  /* Build and store the new commit */
+  
   {
     DoltliteCommit newCommit;
     u8 *commitData = 0;
@@ -1007,11 +939,11 @@ static int applyMergedCatalogAndCommit(
     doltliteCommitClear(&newCommit);
     if( rc!=SQLITE_OK ) return rc;
 
-    /* Update HEAD and branch ref */
+    
     doltliteSetSessionHead(db, &commitHash);
     doltliteSetSessionStaged(db, &mergedCatHash);
     chunkStoreSetHeadCommit(cs, &commitHash);
-    /* WorkingSet: staged already set in session */
+    
     chunkStoreUpdateBranch(cs, doltliteGetSessionBranch(db), &commitHash);
     chunkStoreSerializeRefs(cs);
     chunkStoreCommit(cs);
@@ -1021,19 +953,6 @@ static int applyMergedCatalogAndCommit(
 
   return SQLITE_OK;
 }
-
-/* --------------------------------------------------------------------------
-** dolt_cherry_pick('commit_hash')
-**
-** Apply the changes from a specific commit onto the current branch.
-** This is a three-way merge where:
-**   ancestor = commit's parent catalog
-**   ours     = current HEAD catalog
-**   theirs   = the cherry-picked commit's catalog
-**
-** Creates a new commit with message "Cherry-pick: <original message>".
-** Returns the new commit hash, or conflict info if conflicts arise.
-** -------------------------------------------------------------------------- */
 
 static void doltliteCherryPickFunc(
   sqlite3_context *context,
@@ -1065,21 +984,21 @@ static void doltliteCherryPickFunc(
     return;
   }
 
-  /* Resolve the commit hash */
+  
   rc = resolveCommitRef(cs, zRef, &pickHash);
   if( rc!=SQLITE_OK ){
     sqlite3_result_error(context, "invalid commit hash", -1);
     return;
   }
 
-  /* Load the cherry-pick commit */
+  
   rc = loadCommitByHash(cs, &pickHash, &pickCommit);
   if( rc!=SQLITE_OK ){
     sqlite3_result_error(context, "commit not found", -1);
     return;
   }
 
-  /* Load the cherry-pick commit's parent */
+  
   if( prollyHashIsEmpty(&pickCommit.parentHash) ){
     doltliteCommitClear(&pickCommit);
     sqlite3_result_error(context, "cannot cherry-pick the initial commit", -1);
@@ -1093,7 +1012,7 @@ static void doltliteCherryPickFunc(
     return;
   }
 
-  /* Load our HEAD */
+  
   doltliteGetSessionHead(db, &ourHead);
   if( prollyHashIsEmpty(&ourHead) ){
     doltliteCommitClear(&pickCommit);
@@ -1110,7 +1029,7 @@ static void doltliteCherryPickFunc(
     return;
   }
 
-  /* Three-way merge: ancestor=parent, ours=HEAD, theirs=pick */
+  
   {
     char msg[512];
     sqlite3_snprintf(sizeof(msg), msg, "Cherry-pick: %s",
@@ -1145,19 +1064,6 @@ static void doltliteCherryPickFunc(
   }
 }
 
-/* --------------------------------------------------------------------------
-** dolt_revert('commit_hash')
-**
-** Create a new commit that undoes the changes introduced by a specific
-** commit.  This is a three-way merge where:
-**   ancestor = the commit being reverted (its catalog)
-**   ours     = current HEAD catalog
-**   theirs   = the reverted commit's parent catalog
-**
-** Creates a new commit with message "Revert '<original message>'".
-** Returns the new commit hash, or conflict info if conflicts arise.
-** -------------------------------------------------------------------------- */
-
 static void doltliteRevertFunc(
   sqlite3_context *context,
   int argc,
@@ -1188,21 +1094,21 @@ static void doltliteRevertFunc(
     return;
   }
 
-  /* Resolve the commit hash */
+  
   rc = resolveCommitRef(cs, zRef, &revertHash);
   if( rc!=SQLITE_OK ){
     sqlite3_result_error(context, "invalid commit hash", -1);
     return;
   }
 
-  /* Load the commit to revert */
+  
   rc = loadCommitByHash(cs, &revertHash, &revertCommit);
   if( rc!=SQLITE_OK ){
     sqlite3_result_error(context, "commit not found", -1);
     return;
   }
 
-  /* Load the reverted commit's parent */
+  
   if( prollyHashIsEmpty(&revertCommit.parentHash) ){
     doltliteCommitClear(&revertCommit);
     sqlite3_result_error(context, "cannot revert the initial commit", -1);
@@ -1216,7 +1122,7 @@ static void doltliteRevertFunc(
     return;
   }
 
-  /* Load our HEAD */
+  
   doltliteGetSessionHead(db, &ourHead);
   if( prollyHashIsEmpty(&ourHead) ){
     doltliteCommitClear(&revertCommit);
@@ -1233,7 +1139,7 @@ static void doltliteRevertFunc(
     return;
   }
 
-  /* Three-way merge: ancestor=revert commit, ours=HEAD, theirs=parent */
+  
   {
     char msg[512];
     sqlite3_snprintf(sizeof(msg), msg, "Revert '%s'",
@@ -1268,13 +1174,6 @@ static void doltliteRevertFunc(
   }
 }
 
-/* --------------------------------------------------------------------------
-** dolt_config('key' [, 'value']) — get or set per-session configuration.
-**
-** Supported keys:
-**   user.name  — author name for commits (default: "doltlite")
-**   user.email — author email for commits (default: "")
-** -------------------------------------------------------------------------- */
 static void doltliteConfigFunc(sqlite3_context *context, int argc, sqlite3_value **argv){
   sqlite3 *db = sqlite3_context_db_handle(context);
   const char *zKey;
@@ -1290,7 +1189,7 @@ static void doltliteConfigFunc(sqlite3_context *context, int argc, sqlite3_value
   }
 
   if( argc==1 ){
-    /* GET */
+    
     if( strcmp(zKey, "user.name")==0 ){
       sqlite3_result_text(context, doltliteGetAuthorName(db), -1, SQLITE_TRANSIENT);
     }else if( strcmp(zKey, "user.email")==0 ){
@@ -1299,7 +1198,7 @@ static void doltliteConfigFunc(sqlite3_context *context, int argc, sqlite3_value
       sqlite3_result_error(context, "unknown config key (valid: user.name, user.email)", -1);
     }
   }else{
-    /* SET */
+    
     const char *zVal = (const char*)sqlite3_value_text(argv[1]);
     if( strcmp(zKey, "user.name")==0 ){
       doltliteSetAuthorName(db, zVal);
@@ -1312,10 +1211,6 @@ static void doltliteConfigFunc(sqlite3_context *context, int argc, sqlite3_value
     }
   }
 }
-
-/* --------------------------------------------------------------------------
-** Registration
-** -------------------------------------------------------------------------- */
 
 void doltliteRegister(sqlite3 *db){
   sqlite3_create_function(db, "dolt_commit", -1, SQLITE_UTF8, 0,
@@ -1350,4 +1245,4 @@ void doltliteRegister(sqlite3 *db){
   }
 }
 
-#endif /* DOLTLITE_PROLLY */
+#endif 

--- a/src/doltlite_ancestor.c
+++ b/src/doltlite_ancestor.c
@@ -1,10 +1,4 @@
-/*
-** Find the common ancestor (merge base) of two commits.
-**
-** Algorithm: collect all ancestors of commit1 (including itself) into a
-** hash set, then walk commit2's chain until finding one in the set.
-** This is the simplest correct approach for single-parent commit chains.
-*/
+
 #ifdef DOLTLITE_PROLLY
 
 #include "doltlite_ancestor.h"
@@ -13,17 +7,12 @@
 #include "doltlite_internal.h"
 #include <string.h>
 
-/* --------------------------------------------------------------------------
-** Simple hash set for ProllyHash values.
-** Open-addressing with linear probing. Sized to a power of 2.
-** -------------------------------------------------------------------------- */
-
 typedef struct HashSet HashSet;
 struct HashSet {
-  ProllyHash *aSlot;   /* Array of slots */
-  u8 *aUsed;           /* 1 if slot occupied, 0 if empty */
-  int nSlot;           /* Number of slots (power of 2) */
-  int nUsed;           /* Number of occupied slots */
+  ProllyHash *aSlot;   
+  u8 *aUsed;           
+  int nSlot;           
+  int nUsed;           
 };
 
 static int hashSetInit(HashSet *hs, int nInitial){
@@ -49,7 +38,6 @@ static void hashSetFree(HashSet *hs){
   memset(hs, 0, sizeof(*hs));
 }
 
-/* Hash a ProllyHash to a slot index. Use first 4 bytes as a u32. */
 static int hashSetIndex(const HashSet *hs, const ProllyHash *h){
   u32 v = (u32)h->data[0] | ((u32)h->data[1]<<8)
         | ((u32)h->data[2]<<16) | ((u32)h->data[3]<<24);
@@ -87,7 +75,6 @@ static int hashSetGrow(HashSet *hs){
   return SQLITE_OK;
 }
 
-/* Insert a hash. Returns SQLITE_OK or SQLITE_NOMEM. */
 static int hashSetInsert(HashSet *hs, const ProllyHash *h){
   int idx;
   if( hs->nUsed * 2 >= hs->nSlot ){
@@ -96,7 +83,7 @@ static int hashSetInsert(HashSet *hs, const ProllyHash *h){
   }
   idx = hashSetIndex(hs, h);
   while( hs->aUsed[idx] ){
-    if( prollyHashCompare(&hs->aSlot[idx], h)==0 ) return SQLITE_OK; /* dup */
+    if( prollyHashCompare(&hs->aSlot[idx], h)==0 ) return SQLITE_OK; 
     idx = (idx + 1) & (hs->nSlot - 1);
   }
   hs->aSlot[idx] = *h;
@@ -105,7 +92,6 @@ static int hashSetInsert(HashSet *hs, const ProllyHash *h){
   return SQLITE_OK;
 }
 
-/* Check if a hash is in the set. Returns 1 if found, 0 if not. */
 static int hashSetContains(const HashSet *hs, const ProllyHash *h){
   int idx = hashSetIndex(hs, h);
   while( hs->aUsed[idx] ){
@@ -114,10 +100,6 @@ static int hashSetContains(const HashSet *hs, const ProllyHash *h){
   }
   return 0;
 }
-
-/* --------------------------------------------------------------------------
-** Load a commit by hash from the chunk store (same pattern as doltlite_log.c)
-** -------------------------------------------------------------------------- */
 
 static int loadCommitByHash(sqlite3 *db, const ProllyHash *hash,
                             DoltliteCommit *pCommit){
@@ -136,10 +118,6 @@ static int loadCommitByHash(sqlite3 *db, const ProllyHash *hash,
   sqlite3_free(data);
   return rc;
 }
-
-/* --------------------------------------------------------------------------
-** BFS from one commit, populating the visited set with all ancestors.
-** -------------------------------------------------------------------------- */
 
 static int ancestorBfsCollect(
   sqlite3 *db,
@@ -165,7 +143,7 @@ static int ancestorBfsCollect(
     if( rc!=SQLITE_OK ) break;
     memset(&commit, 0, sizeof(commit));
     rc = loadCommitByHash(db, &current, &commit);
-    if( rc!=SQLITE_OK ){ rc = SQLITE_OK; continue; } /* end of chain */
+    if( rc!=SQLITE_OK ){ rc = SQLITE_OK; continue; } 
     for(i=0; i<commit.nParents; i++){
       if( qTail >= qAlloc ){
         qAlloc *= 2;
@@ -182,10 +160,6 @@ static int ancestorBfsCollect(
   sqlite3_free(queue);
   return rc;
 }
-
-/* --------------------------------------------------------------------------
-** doltliteFindAncestor
-** -------------------------------------------------------------------------- */
 
 int doltliteFindAncestor(
   sqlite3 *db,
@@ -207,7 +181,7 @@ int doltliteFindAncestor(
     return SQLITE_OK;
   }
 
-  /* Step 1: Collect all ancestors of commit1 via BFS */
+  
   rc = hashSetInit(&ancestors, 64);
   if( rc!=SQLITE_OK ) return rc;
 
@@ -217,7 +191,7 @@ int doltliteFindAncestor(
     return rc;
   }
 
-  /* Step 2: BFS commit2's ancestors, checking against the set */
+  
   {
     ProllyHash *queue = 0;
     int qHead = 0, qTail = 0, qAlloc = 64;
@@ -268,29 +242,22 @@ int doltliteFindAncestor(
   return SQLITE_NOTFOUND;
 }
 
-/* --------------------------------------------------------------------------
-** dolt_merge_base(hash1, hash2) SQL function
-**
-** Returns the hex hash of the common ancestor commit, or NULL if none.
-** Arguments can be commit hashes (40-char hex) or branch names.
-** -------------------------------------------------------------------------- */
-
 extern int chunkStoreFindBranch(ChunkStore *cs, const char *zName, ProllyHash *pCommit);
 extern int chunkStoreFindTag(ChunkStore *cs, const char *zName, ProllyHash *pCommit);
 
 static int resolveCommitRef(sqlite3 *db, const char *zRef, ProllyHash *pHash){
   ChunkStore *cs;
-  /* Try as hex hash first */
+  
   if( zRef && strlen(zRef)==PROLLY_HASH_SIZE*2 ){
     if( doltliteHexToHash(zRef, pHash)==SQLITE_OK ) return SQLITE_OK;
   }
   cs = doltliteGetChunkStore(db);
   if( !cs ) return SQLITE_ERROR;
-  /* Try as branch name */
+  
   if( chunkStoreFindBranch(cs, zRef, pHash)==SQLITE_OK ){
     return SQLITE_OK;
   }
-  /* Try as tag name */
+  
   if( chunkStoreFindTag(cs, zRef, pHash)==SQLITE_OK ){
     return SQLITE_OK;
   }
@@ -347,4 +314,4 @@ int doltliteAncestorRegister(sqlite3 *db){
                                  doltMergeBaseFunc, 0, 0);
 }
 
-#endif /* DOLTLITE_PROLLY */
+#endif 

--- a/src/doltlite_ancestor.h
+++ b/src/doltlite_ancestor.h
@@ -1,24 +1,10 @@
-/*
-** Find the common ancestor (merge base) of two commits.
-**
-** Walks both commit chains via parent_hash to find the first shared
-** ancestor. Used by dolt_merge for three-way merge.
-*/
+
 #ifndef DOLTLITE_ANCESTOR_H
 #define DOLTLITE_ANCESTOR_H
 
 #include "sqliteInt.h"
 #include "prolly_hash.h"
 
-/*
-** Find the common ancestor of two commits identified by their hashes.
-** Collects all ancestors of commitHash1 into a set, then walks commitHash2's
-** chain until finding one in the set.
-**
-** On success, writes the ancestor hash to *pAncestor and returns SQLITE_OK.
-** Returns SQLITE_NOTFOUND if no common ancestor exists (disjoint histories).
-** Returns SQLITE_ERROR or SQLITE_NOMEM on failure.
-*/
 int doltliteFindAncestor(
   sqlite3 *db,
   const ProllyHash *commitHash1,
@@ -26,4 +12,4 @@ int doltliteFindAncestor(
   ProllyHash *pAncestor
 );
 
-#endif /* DOLTLITE_ANCESTOR_H */
+#endif 

--- a/src/doltlite_at.c
+++ b/src/doltlite_at.c
@@ -1,18 +1,4 @@
-/*
-** dolt_at_<tablename>(commit_ref) — point-in-time table query with real columns.
-**
-** Returns the table as it existed at a specific commit, with the actual
-** table column names (not generic rowid_val/value):
-**
-**   SELECT * FROM dolt_at_users('v1.0');
-**   -- id | name | email
-**
-**   SELECT * FROM dolt_at_users('main');
-**   SELECT * FROM dolt_at_users('abc123...');
-**
-** This is the SQLite equivalent of Dolt's AS OF clause.
-** One eponymous virtual table is registered per user table.
-*/
+
 #ifdef DOLTLITE_PROLLY
 
 #include "sqliteInt.h"
@@ -26,10 +12,6 @@
 
 #include <string.h>
 #include <time.h>
-
-/* --------------------------------------------------------------------------
-** Record field parser and result setter (same approach as dolt_history)
-** -------------------------------------------------------------------------- */
 
 #define AT_MAX_COLS 64
 
@@ -76,8 +58,6 @@ static void atResultField(sqlite3_context *ctx, const u8 *pData, int nData, int 
   sqlite3_result_null(ctx);
 }
 
-
-
 static char *atBuildSchema(DoltliteColInfo *ci){
   int i, sz=256;
   char *z;
@@ -92,19 +72,11 @@ static char *atBuildSchema(DoltliteColInfo *ci){
   return z;
 }
 
-/* --------------------------------------------------------------------------
-** Buffered row
-** -------------------------------------------------------------------------- */
-
 typedef struct AtRow AtRow;
 struct AtRow {
   i64 intKey;
   u8 *pVal; int nVal;
 };
-
-/* --------------------------------------------------------------------------
-** Virtual table structures
-** -------------------------------------------------------------------------- */
 
 typedef struct AtVtab AtVtab;
 struct AtVtab {
@@ -127,10 +99,6 @@ static void freeAtRows(AtCursor *c){
   int i; for(i=0;i<c->nRows;i++) sqlite3_free(c->aRows[i].pVal);
   sqlite3_free(c->aRows); c->aRows=0; c->nRows=0; c->nAlloc=0;
 }
-
-/* --------------------------------------------------------------------------
-** Resolve ref and scan table
-** -------------------------------------------------------------------------- */
 
 static int atResolveRef(ChunkStore *cs, const char *zRef, ProllyHash *pCommit){
   int rc;
@@ -182,10 +150,6 @@ static int atScanTree(AtCursor *pCur, ChunkStore *cs, ProllyCache *pCache,
   prollyCursorClose(&cur); return SQLITE_OK;
 }
 
-/* --------------------------------------------------------------------------
-** Virtual table methods
-** -------------------------------------------------------------------------- */
-
 static int atConnect(sqlite3 *db, void *pAux, int argc,
     const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){
   AtVtab *v; int rc; const char *zMod; char *zSchema;
@@ -225,7 +189,7 @@ static int atBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
   AtVtab *v=(AtVtab*)pVtab;
   int nCols=v->cols.nCol;
   int iRef=-1, i, argvIdx=1;
-  /* The commit_ref is the last column (HIDDEN) */
+  
   int refCol = nCols > 0 ? nCols : 2;
   (void)pVtab;
 
@@ -317,7 +281,7 @@ static int atColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
   int nCols=v->cols.nCol;
 
   if(nCols>0 && col<nCols){
-    /* Table column */
+    
     if(col==v->cols.iPkCol){
       sqlite3_result_int64(ctx,r->intKey);
     }else{
@@ -328,7 +292,7 @@ static int atColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
       }else sqlite3_result_null(ctx);
     }
   }
-  /* commit_ref is HIDDEN — not returned by SELECT * */
+  
   return SQLITE_OK;
 }
 
@@ -341,10 +305,6 @@ static sqlite3_module atModule = {
   atOpen, atClose, atFilter, atNext, atEof, atColumn, atRowid,
   0,0,0,0,0,0,0,0,0,0,0,0
 };
-
-/* --------------------------------------------------------------------------
-** Registration: register dolt_at_<tablename> for each user table.
-** -------------------------------------------------------------------------- */
 
 void doltliteRegisterAtTables(sqlite3 *db){
   ChunkStore *cs=doltliteGetChunkStore(db);
@@ -369,10 +329,10 @@ void doltliteRegisterAtTables(sqlite3 *db){
 }
 
 int doltliteAtRegister(sqlite3 *db){
-  /* Also register the generic dolt_at TVF for backwards compatibility */
-  /* (kept as a separate simpler module — not reimplemented here) */
+  
+  
   doltliteRegisterAtTables(db);
   return SQLITE_OK;
 }
 
-#endif /* DOLTLITE_PROLLY */
+#endif 

--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -1,12 +1,4 @@
-/*
-** Doltlite branch management with per-session branch state.
-**
-** Each connection tracks its own active branch. The chunk store holds
-** the refs (branch → commit mapping) shared across all connections.
-** When dolt_checkout is called, the session's branch pointer is updated
-** AND the shared BtShared working state is reloaded (safe because
-** SQLite serializes writers).
-*/
+
 #ifdef DOLTLITE_PROLLY
 
 #include "sqliteInt.h"
@@ -16,13 +8,6 @@
 #include "doltlite_internal.h"
 #include <string.h>
 
-/*
-** Check whether there are uncommitted working changes by doing a deep
-** per-table comparison (roots + schema hashes) between the working state
-** and HEAD.  This is the same approach dolt_status uses.
-**
-** Returns 1 if dirty, 0 if clean, or -1 on error.
-*/
 static int checkWorkingDirty(sqlite3 *db){
   ChunkStore *cs = doltliteGetChunkStore(db);
   ProllyHash headCatHash, workingCatHash;
@@ -30,14 +15,12 @@ static int checkWorkingDirty(sqlite3 *db){
 
   if( !cs ) return -1;
 
-  /* Get HEAD catalog hash */
+  
   rc = doltliteGetHeadCatalogHash(db, &headCatHash);
   if( rc!=SQLITE_OK ) return -1;
   if( prollyHashIsEmpty(&headCatHash) ) return 0;
 
-  /* Get working catalog hash — serialize current state to a chunk.
-  ** With V2 catalog format, the hash is purely data-derived (no aMeta),
-  ** so this comparison is reliable: equal hashes ↔ identical data. */
+  
   {
     u8 *catData = 0; int nCatData = 0;
     rc = doltliteFlushAndSerializeCatalog(db, &catData, &nCatData);
@@ -47,23 +30,16 @@ static int checkWorkingDirty(sqlite3 *db){
     if( rc!=SQLITE_OK ) return -1;
   }
 
-  /* O(1) dirty check: compare catalog hashes */
+  
   return prollyHashCompare(&headCatHash, &workingCatHash) != 0;
 }
 
-/* --------------------------------------------------------------------------
-** active_branch() — returns this session's current branch name
-** -------------------------------------------------------------------------- */
 static void activeBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
   (void)argc; (void)argv;
   sqlite3_result_text(ctx, doltliteGetSessionBranch(db), -1, SQLITE_TRANSIENT);
 }
 
-/* --------------------------------------------------------------------------
-** dolt_branch('name') — create branch at this session's HEAD
-** dolt_branch('-d', 'name') — delete branch
-** -------------------------------------------------------------------------- */
 static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
   ChunkStore *cs = doltliteGetChunkStore(db);
@@ -87,7 +63,7 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
     rc = chunkStoreDeleteBranch(cs, zName);
     if( rc!=SQLITE_OK ){ sqlite3_result_error(ctx, "branch not found", -1); return; }
   }else{
-    /* Create branch at this session's HEAD */
+    
     doltliteGetSessionHead(db, &head);
     if( prollyHashIsEmpty(&head) ){
       sqlite3_result_error(ctx, "no commits yet — commit first", -1);
@@ -103,11 +79,6 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
   sqlite3_result_int(ctx, 0);
 }
 
-/*
-** Load the target commit, deserialize it, and perform a hard reset to its
-** catalog state. On success, writes the commit hash's catalog hash to
-** *pCatHash so the caller can use it for session state updates.
-*/
 static int checkoutLoadAndApply(
   sqlite3 *db,
   ChunkStore *cs,
@@ -129,7 +100,7 @@ static int checkoutLoadAndApply(
   memcpy(pCatHash, &commit.catalogHash, sizeof(ProllyHash));
   doltliteCommitClear(&commit);
 
-  /* Save current branch's WorkingSet BEFORE hard reset overwrites session */
+  
   {
     extern int doltliteSaveWorkingSet(sqlite3*);
     doltliteSaveWorkingSet(db);
@@ -139,9 +110,6 @@ static int checkoutLoadAndApply(
   return rc;
 }
 
-/* --------------------------------------------------------------------------
-** dolt_checkout('branch') — switch this session's active branch
-** -------------------------------------------------------------------------- */
 static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
   ChunkStore *cs = doltliteGetChunkStore(db);
@@ -153,7 +121,7 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
   const char *zBranch = (const char*)sqlite3_value_text(argv[0]);
   if( !zBranch ){ sqlite3_result_error(ctx, "branch name required", -1); return; }
 
-  /* Handle -b flag: create branch then check it out */
+  
   if( strcmp(zBranch, "-b")==0 ){
     ProllyHash head;
     if( argc<2 ){ sqlite3_result_error(ctx, "branch name required after -b", -1); return; }
@@ -176,7 +144,7 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
       sqlite3_result_error_code(ctx, rc);
       return;
     }
-    /* Fall through to checkout the newly created branch */
+    
   }
 
   if( strcmp(zBranch, doltliteGetSessionBranch(db))==0 ){
@@ -187,8 +155,7 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
   rc = chunkStoreFindBranch(cs, zBranch, &targetCommit);
   if( rc!=SQLITE_OK ){ sqlite3_result_error(ctx, "branch not found", -1); return; }
 
-  /* Check for uncommitted changes via catalog hash comparison.
-  ** With V2 catalogs (no aMeta), hash comparison is reliable. */
+  
   {
     int dirty = checkWorkingDirty(db);
     if( dirty>0 ){
@@ -202,7 +169,7 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
     return;
   }
 
-  /* Load target commit's catalog and hard reset */
+  
   {
     ProllyHash catHash;
     rc = checkoutLoadAndApply(db, cs, zBranch, &targetCommit, &catHash);
@@ -211,17 +178,15 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
       return;
     }
 
-    /* Update this session's branch state */
+    
     doltliteSetSessionBranch(db, zBranch);
     doltliteSetSessionHead(db, &targetCommit);
 
-    /* Load the target branch's WorkingSet (staged + merge state).
-    ** If the target branch has no saved WorkingSet, defaults to
-    ** staged = empty (which means "same as HEAD" = clean). */
+    
     {
       extern int doltliteLoadWorkingSet(sqlite3*, const char*);
       doltliteLoadWorkingSet(db, zBranch);
-      /* If no WorkingSet was loaded (staged is empty), set staged = HEAD catalog */
+      
       {
         ProllyHash staged;
         doltliteGetSessionStaged(db, &staged);
@@ -231,7 +196,7 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
       }
     }
 
-    /* Update the default branch in the store (for next open) */
+    
     chunkStoreSetDefaultBranch(cs, zBranch);
     chunkStoreSetHeadCommit(cs, &targetCommit);
   }
@@ -245,9 +210,6 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
   sqlite3_result_int(ctx, 0);
 }
 
-/* --------------------------------------------------------------------------
-** dolt_branches virtual table
-** -------------------------------------------------------------------------- */
 typedef struct BrVtab BrVtab;
 struct BrVtab { sqlite3_vtab base; sqlite3 *db; };
 typedef struct BrCur BrCur;
@@ -317,4 +279,4 @@ int doltliteBranchRegister(sqlite3 *db){
   return rc;
 }
 
-#endif /* DOLTLITE_PROLLY */
+#endif 

--- a/src/doltlite_commit.c
+++ b/src/doltlite_commit.c
@@ -1,4 +1,9 @@
-
+/*
+** Commit V2 wire format (all multi-byte integers little-endian):
+**   [version:1] [nParents:1] [parents:20*N] [catalogHash:20]
+**   [timestamp:8] [nameLen:2][name] [emailLen:2][email] [msgLen:2][msg]
+** V2 has no rootHash field; rootHash is zeroed on deserialize.
+*/
 #ifdef DOLTLITE_PROLLY
 
 #include "doltlite_commit.h"

--- a/src/doltlite_commit.c
+++ b/src/doltlite_commit.c
@@ -1,12 +1,9 @@
-/*
-** Doltlite commit object serialization and utilities.
-*/
+
 #ifdef DOLTLITE_PROLLY
 
 #include "doltlite_commit.h"
 #include <string.h>
 
-/* Little-endian helpers */
 #define DLC_PUT_U16(p,v) do{ (p)[0]=(u8)(v); (p)[1]=(u8)((v)>>8); }while(0)
 #define DLC_GET_U16(p) ((u16)((p)[0] | ((p)[1]<<8)))
 #define DLC_PUT_I64(p,v) do{ \
@@ -26,7 +23,7 @@ int doltliteCommitSerialize(const DoltliteCommit *c, u8 **ppOut, int *pnOut){
     return SQLITE_TOOBIG;
   }
   nPar = c->nParents > 0 ? c->nParents : (prollyHashIsEmpty(&c->parentHash) ? 0 : 1);
-  /* V2: version(1) + nParents(1) + parents(20*N) + catalog(20) + ts(8) + strings */
+  
   int sz = 1 + 1 + PROLLY_HASH_SIZE*nPar + PROLLY_HASH_SIZE + 8
          + 2 + nName + 2 + nEmail + 2 + nMsg;
   u8 *buf = sqlite3_malloc(sz);
@@ -35,10 +32,10 @@ int doltliteCommitSerialize(const DoltliteCommit *c, u8 **ppOut, int *pnOut){
   if( !buf ) return SQLITE_NOMEM;
   p = buf;
 
-  /* version */
+  
   *p++ = DOLTLITE_COMMIT_V2;
 
-  /* nParents + parent hashes */
+  
   *p++ = (u8)nPar;
   if( nPar > 0 && c->nParents > 0 ){
     for(i=0; i<nPar; i++){
@@ -46,26 +43,26 @@ int doltliteCommitSerialize(const DoltliteCommit *c, u8 **ppOut, int *pnOut){
       p += PROLLY_HASH_SIZE;
     }
   }else if( nPar == 1 ){
-    /* Legacy: single parent from parentHash field */
+    
     memcpy(p, c->parentHash.data, PROLLY_HASH_SIZE);
     p += PROLLY_HASH_SIZE;
   }
 
-  /* catalog hash (no rootHash in V2) */
+  
   memcpy(p, c->catalogHash.data, PROLLY_HASH_SIZE); p += PROLLY_HASH_SIZE;
 
-  /* timestamp */
+  
   DLC_PUT_I64(p, c->timestamp); p += 8;
 
-  /* name */
+  
   DLC_PUT_U16(p, (u16)nName); p += 2;
   if( nName>0 ){ memcpy(p, c->zName, nName); p += nName; }
 
-  /* email */
+  
   DLC_PUT_U16(p, (u16)nEmail); p += 2;
   if( nEmail>0 ){ memcpy(p, c->zEmail, nEmail); p += nEmail; }
 
-  /* message */
+  
   DLC_PUT_U16(p, (u16)nMsg); p += 2;
   if( nMsg>0 ){ memcpy(p, c->zMessage, nMsg); p += nMsg; }
 
@@ -87,7 +84,7 @@ int doltliteCommitDeserialize(const u8 *data, int nData, DoltliteCommit *c){
   if( version != DOLTLITE_COMMIT_V2 ) return SQLITE_CORRUPT;
 
   {
-    /* V2: nParents(1) + parents(20*N) + catalog(20) + ts(8) + strings */
+    
     int nPar;
     if( nData < 3 ) return SQLITE_CORRUPT;
     nPar = *p++;
@@ -100,17 +97,17 @@ int doltliteCommitDeserialize(const u8 *data, int nData, DoltliteCommit *c){
       memcpy(c->aParents[i].data, p, PROLLY_HASH_SIZE);
       p += PROLLY_HASH_SIZE;
     }
-    /* Set parentHash to first parent for convenience */
+    
     if( nPar > 0 ) c->parentHash = c->aParents[0];
-    /* catalog hash (no rootHash) */
+    
     memcpy(c->catalogHash.data, p, PROLLY_HASH_SIZE); p += PROLLY_HASH_SIZE;
     memset(c->rootHash.data, 0, PROLLY_HASH_SIZE);
   }
 
-  /* timestamp */
+  
   c->timestamp = DLC_GET_I64(p); p += 8;
 
-  /* name */
+  
   nName = DLC_GET_U16(p); p += 2;
   if( p + nName > data + nData ) return SQLITE_CORRUPT;
   c->zName = sqlite3_malloc(nName + 1);
@@ -119,7 +116,7 @@ int doltliteCommitDeserialize(const u8 *data, int nData, DoltliteCommit *c){
   c->zName[nName] = 0;
   p += nName;
 
-  /* email */
+  
   nEmail = DLC_GET_U16(p); p += 2;
   if( p + nEmail > data + nData ) return SQLITE_CORRUPT;
   c->zEmail = sqlite3_malloc(nEmail + 1);
@@ -128,7 +125,7 @@ int doltliteCommitDeserialize(const u8 *data, int nData, DoltliteCommit *c){
   c->zEmail[nEmail] = 0;
   p += nEmail;
 
-  /* message */
+  
   nMsg = DLC_GET_U16(p); p += 2;
   if( p + nMsg > data + nData ){ doltliteCommitClear(c); return SQLITE_CORRUPT; }
   c->zMessage = sqlite3_malloc(nMsg + 1);
@@ -179,4 +176,4 @@ int doltliteHexToHash(const char *hex, ProllyHash *h){
   return SQLITE_OK;
 }
 
-#endif /* DOLTLITE_PROLLY */
+#endif 

--- a/src/doltlite_commit.h
+++ b/src/doltlite_commit.h
@@ -1,4 +1,4 @@
-
+/* Commit V2: [version:1][nParents:1][parents:20*N][catalog:20][ts:8][name][email][msg] (LE). */
 #ifndef DOLTLITE_COMMIT_H
 #define DOLTLITE_COMMIT_H
 

--- a/src/doltlite_commit.h
+++ b/src/doltlite_commit.h
@@ -1,14 +1,4 @@
-/*
-** Doltlite commit objects: version control for SQLite.
-**
-** A commit is a content-addressed snapshot of the database state.
-** Commits form a DAG via parent hashes (merge commits have 2+ parents).
-**
-** Serialized format:
-**   version(1=0x02) + nParents(1) + parent_hashes(20*nParents) +
-**   catalog_hash(20) + timestamp(8) + name_len(2) + name(...) +
-**   email_len(2) + email(...) + message_len(2) + message(...)
-*/
+
 #ifndef DOLTLITE_COMMIT_H
 #define DOLTLITE_COMMIT_H
 
@@ -18,36 +8,30 @@
 #define DOLTLITE_COMMIT_V2 2
 #define DOLTLITE_COMMIT_VERSION DOLTLITE_COMMIT_V2
 
-/* Maximum parents (merge commits typically have 2) */
 #define DOLTLITE_MAX_PARENTS 8
 
 typedef struct DoltliteCommit DoltliteCommit;
 struct DoltliteCommit {
-  ProllyHash parentHash;     /* First parent (for backward compat / convenience) */
-  ProllyHash rootHash;       /* V1 only: data tree root (unused in V2) */
-  ProllyHash catalogHash;    /* Catalog (table registry) at commit time */
-  i64 timestamp;             /* Unix seconds */
-  char *zName;               /* Author name (owned, sqlite3_free) */
-  char *zEmail;              /* Author email (owned) */
-  char *zMessage;            /* Commit message (owned) */
-  /* Multi-parent support (V2+) */
-  ProllyHash aParents[DOLTLITE_MAX_PARENTS];  /* Parent hashes */
-  int nParents;              /* Number of parents (0 for initial commit) */
+  ProllyHash parentHash;     
+  ProllyHash rootHash;       
+  ProllyHash catalogHash;    
+  i64 timestamp;             
+  char *zName;               
+  char *zEmail;              
+  char *zMessage;            
+  
+  ProllyHash aParents[DOLTLITE_MAX_PARENTS];  
+  int nParents;              
 };
 
-/* Serialize a commit to a byte buffer. Caller must sqlite3_free(*ppOut). */
 int doltliteCommitSerialize(const DoltliteCommit *c, u8 **ppOut, int *pnOut);
 
-/* Deserialize a commit from a byte buffer. Strings are copied (owned). */
 int doltliteCommitDeserialize(const u8 *data, int nData, DoltliteCommit *c);
 
-/* Free owned strings inside a commit (does NOT free the struct itself). */
 void doltliteCommitClear(DoltliteCommit *c);
 
-/* Format a ProllyHash as a 40-character hex string. buf must be >= 41 bytes. */
 void doltliteHashToHex(const ProllyHash *h, char *buf);
 
-/* Parse a 40-character hex string into a ProllyHash. */
 int doltliteHexToHash(const char *hex, ProllyHash *h);
 
-#endif /* DOLTLITE_COMMIT_H */
+#endif 

--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -1,17 +1,4 @@
-/*
-** dolt_conflicts: view and resolve merge conflicts.
-**
-** Summary table:
-**   SELECT * FROM dolt_conflicts;  -- table_name, num_conflicts
-**
-** Per-table conflict rows (registered dynamically as dolt_conflicts_<table>):
-**   SELECT * FROM dolt_conflicts_users;
-**   DELETE FROM dolt_conflicts_users WHERE base_rowid = 5;
-**
-** Bulk resolution:
-**   SELECT dolt_conflicts_resolve('--ours', 'users');
-**   SELECT dolt_conflicts_resolve('--theirs', 'users');
-*/
+
 #ifdef DOLTLITE_PROLLY
 
 #include "sqliteInt.h"
@@ -21,9 +8,6 @@
 #include "doltlite_internal.h"
 #include <string.h>
 
-/* Varint reader: use shared dlReadVarint from doltlite_record.h */
-
-/* Read a big-endian signed integer of nBytes bytes. */
 static i64 cfReadInt(const u8 *pRec, int nBytes){
   i64 v;
   int i;
@@ -36,28 +20,6 @@ static i64 cfReadInt(const u8 *pRec, int nBytes){
   return v;
 }
 
-/* --------------------------------------------------------------------------
-** Build an INSERT OR REPLACE SQL statement for conflict resolution.
-**
-** Constructs a complete INSERT OR REPLACE statement from a raw SQLite
-** record blob, decoding each field according to its serial type (integers,
-** floats, text with %Q quoting, blobs as hex literals). This is used
-** during --theirs conflict resolution to apply the remote side's row
-** values into the local table. The rowid is passed separately because
-** INTKEY tables store it outside the record blob.
-**
-** Parameters:
-**   zTable   - target table name
-**   intKey   - rowid value for the row
-**   azCol    - array of column names (from PRAGMA table_info)
-**   nCol     - number of columns
-**   pRec     - current position in the record header (serial types)
-**   pRecEnd  - end of the record blob
-**   pHdrEnd  - end of the header section
-**   pBody    - start of the data section
-**
-** Returns the SQL string (caller must sqlite3_free), or NULL on OOM.
-** -------------------------------------------------------------------------- */
 static char *buildInsertSql(
   const char *zTable,
   i64 intKey,
@@ -81,17 +43,17 @@ static char *buildInsertSql(
     int stBytes = dlReadVarint(pRec, pHdrEnd, &st);
     pRec += stBytes;
 
-    /* OOM check — if a previous sqlite3_mprintf failed, bail out */
+    
     if( !zIns || !zVals ){
       sqlite3_free(zIns); sqlite3_free(zVals);
       return 0;
     }
 
-    /* Append column name */
+    
     zTmp = sqlite3_mprintf("%s,\"%w\"", zIns, azCol[colIdx]);
     sqlite3_free(zIns); zIns = zTmp;
 
-    /* Decode value and append to VALUES */
+    
     if( st==0 ){
       zTmp = sqlite3_mprintf("%s,NULL", zVals);
       sqlite3_free(zVals); zVals = zTmp;
@@ -111,7 +73,7 @@ static char *buildInsertSql(
       }
       pBodyPos += nBytes;
     }else if( st==7 ){
-      /* IEEE 754 float */
+      
       if( pBodyPos + 8 <= pRecEnd ){
         double v;
         u64 bits = 0;
@@ -123,7 +85,7 @@ static char *buildInsertSql(
       }
       pBodyPos += 8;
     }else if( st>=12 && (st&1)==0 ){
-      /* Blob */
+      
       int len = ((int)st - 12) / 2;
       if( pBodyPos + len <= pRecEnd ){
         zTmp = sqlite3_mprintf("%s,X'", zVals);
@@ -140,10 +102,10 @@ static char *buildInsertSql(
       }
       pBodyPos += len;
     }else if( st>=13 && (st&1)==1 ){
-      /* Text */
+      
       int len = ((int)st - 13) / 2;
       if( pBodyPos + len <= pRecEnd ){
-        /* Use %Q for safe quoting */
+        
         char *zText = sqlite3_malloc(len+1);
         if( zText ){
           memcpy(zText, pBodyPos, len);
@@ -159,18 +121,13 @@ static char *buildInsertSql(
     colIdx++;
   }
 
-  /* Close the statement */
+  
   zTmp = sqlite3_mprintf("%s) %s)", zIns, zVals);
   sqlite3_free(zIns);
   sqlite3_free(zVals);
   return zTmp;
 }
 
-/* --------------------------------------------------------------------------
-** Build and execute an INSERT OR REPLACE for a raw SQLite record blob.
-** The record is the row data (not including the rowid).
-** Uses PRAGMA table_info to get column names.
-** -------------------------------------------------------------------------- */
 static int applyTheirRecord(
   sqlite3 *db,
   const char *zTable,
@@ -185,7 +142,7 @@ static int applyTheirRecord(
   u64 hdrSize;
   int hdrBytes;
 
-  /* Collect column names */
+  
   char **azCol = 0;
   int nColAlloc = 0;
 
@@ -198,11 +155,11 @@ static int applyTheirRecord(
   while( sqlite3_step(pInfo)==SQLITE_ROW ){
     const char *zName = (const char*)sqlite3_column_text(pInfo, 1);
     int pk = sqlite3_column_int(pInfo, 5);
-    /* Skip the INTEGER PRIMARY KEY column — it's the rowid, not in the record */
+    
     if( pk==1 ){
       const char *zType = (const char*)sqlite3_column_text(pInfo, 2);
       if( zType && sqlite3_stricmp(zType, "INTEGER")==0 ){
-        continue; /* This is an alias for rowid; skip */
+        continue; 
       }
     }
     if( nCol >= nColAlloc ){
@@ -220,7 +177,7 @@ static int applyTheirRecord(
     return SQLITE_ERROR;
   }
 
-  /* Parse the record header to get serial types */
+  
   pPos = pRec;
   pRecEnd = pRec + nRec;
   hdrBytes = dlReadVarint(pPos, pRecEnd, &hdrSize);
@@ -228,14 +185,12 @@ static int applyTheirRecord(
   pHdrEnd = pRec + (int)hdrSize;
   pBody = pRec + (int)hdrSize;
 
-  /* Skip the first record field (INTEGER PRIMARY KEY placeholder = NULL).
-  ** The column list already excludes the PK, so the record fields and
-  ** column names must be aligned by skipping this placeholder. */
+  
   if( pPos < pHdrEnd ){
     u64 stSkip;
     int skipBytes = dlReadVarint(pPos, pHdrEnd, &stSkip);
     pPos += skipBytes;
-    /* Advance pBody past the PK field's data (usually 0 bytes for NULL) */
+    
     if( stSkip==0 || stSkip==8 || stSkip==9 ) {}
     else if( stSkip>=1 && stSkip<=6 ){ static const int s[]={0,1,2,3,4,6,8}; pBody+=s[stSkip]; }
     else if( stSkip==7 ) pBody+=8;
@@ -243,7 +198,7 @@ static int applyTheirRecord(
     else if( stSkip>=13 && (stSkip&1)==1 ) pBody+=((int)stSkip-13)/2;
   }
 
-  /* Build and execute the INSERT OR REPLACE statement */
+  
   zSql = buildInsertSql(zTable, intKey, azCol, nCol, pPos, pRecEnd, pHdrEnd, pBody);
   if( zSql ){
     rc = sqlite3_exec(db, zSql, 0, 0, 0);
@@ -252,7 +207,7 @@ static int applyTheirRecord(
     rc = SQLITE_NOMEM;
   }
 
-  /* Free column names */
+  
   {
     int k;
     for(k=0; k<nCol; k++) sqlite3_free(azCol[k]);
@@ -262,21 +217,13 @@ static int applyTheirRecord(
   return rc;
 }
 
-/* --------------------------------------------------------------------------
-** Conflict catalog serialization
-**
-** Format: [num_tables:2]
-** per table: [name_len:2][name:var][num_conflicts:4]
-** per conflict: [intKey:8][baseVal_len:4][baseVal:var][theirVal_len:4][theirVal:var]
-** -------------------------------------------------------------------------- */
-
 typedef struct ConflictTableInfo ConflictTableInfo;
 struct ConflictTableInfo {
   char *zName;
   int nConflicts;
   struct ConflictRow {
     i64 intKey;
-    u8 *pKey; int nKey;       /* blob key (NULL for INTKEY tables) — must match merge's layout */
+    u8 *pKey; int nKey;       
     u8 *pBaseVal; int nBaseVal;
     u8 *pOurVal; int nOurVal;
     u8 *pTheirVal; int nTheirVal;
@@ -288,7 +235,7 @@ int doltliteSerializeConflicts(
   ConflictTableInfo *aTables, int nTables,
   ProllyHash *pHash
 ){
-  int sz = 2;  /* num_tables */
+  int sz = 2;  
   int i, j, rc;
   u8 *buf, *p;
 
@@ -333,10 +280,6 @@ int doltliteSerializeConflicts(
   sqlite3_free(buf);
   return rc;
 }
-
-/* --------------------------------------------------------------------------
-** Load full conflict data (not just summary) for all tables.
-** -------------------------------------------------------------------------- */
 
 static int loadAllConflicts(
   sqlite3 *db,
@@ -428,7 +371,6 @@ static void freeConflictTables(ConflictTableInfo *aTables, int nTables){
   sqlite3_free(aTables);
 }
 
-/* Re-serialize and store updated conflicts, clearing if empty. */
 static int storeUpdatedConflicts(
   sqlite3 *db,
   ChunkStore *cs,
@@ -456,10 +398,6 @@ static int storeUpdatedConflicts(
     return chunkStoreCommit(cs);
   }
 }
-
-/* --------------------------------------------------------------------------
-** dolt_conflicts summary virtual table (unchanged)
-** -------------------------------------------------------------------------- */
 
 typedef struct ConflictsVtab ConflictsVtab;
 struct ConflictsVtab { sqlite3_vtab base; sqlite3 *db; };
@@ -514,20 +452,11 @@ static sqlite3_module conflictsModule = {
   cfColumn,cfRowid,0,0,0,0,0,0,0,0,0,0,0,0
 };
 
-/* --------------------------------------------------------------------------
-** dolt_conflicts_<tablename> per-row virtual table
-**
-** Schema: base_rowid, base_value, our_rowid, our_value,
-**         their_rowid, their_value
-**
-** Supports DELETE to resolve individual conflicts.
-** -------------------------------------------------------------------------- */
-
 typedef struct CfRowVtab CfRowVtab;
 struct CfRowVtab {
   sqlite3_vtab base;
   sqlite3 *db;
-  char *zTableName;    /* Target table name (e.g. "users") */
+  char *zTableName;    
 };
 
 typedef struct CfRowCur CfRowCur;
@@ -535,8 +464,8 @@ struct CfRowCur {
   sqlite3_vtab_cursor base;
   ConflictTableInfo *aTables;
   int nTables;
-  int iTableIdx;       /* Index of our table in aTables */
-  int iRow;            /* Current conflict row */
+  int iTableIdx;       
+  int iRow;            
 };
 
 static int cfrConnect(sqlite3 *db, void *pAux, int argc,
@@ -556,12 +485,12 @@ static int cfrConnect(sqlite3 *db, void *pAux, int argc,
   memset(v,0,sizeof(*v));
   v->db = db;
 
-  /* Extract table name from module name: "dolt_conflicts_<tablename>" */
-  zModuleName = argv[0]; /* module name */
+  
+  zModuleName = argv[0]; 
   if( zModuleName && strncmp(zModuleName, "dolt_conflicts_", 15)==0 ){
     v->zTableName = sqlite3_mprintf("%s", zModuleName + 15);
   }else if( argc > 3 ){
-    /* Fallback: table name passed as argument */
+    
     v->zTableName = sqlite3_mprintf("%s", argv[3]);
   }else{
     v->zTableName = sqlite3_mprintf("");
@@ -605,7 +534,7 @@ static int cfrFilter(sqlite3_vtab_cursor *cur, int n, const char *s, int a, sqli
   c->iTableIdx = -1;
   loadAllConflicts(vt->db, doltliteGetChunkStore(vt->db), &c->aTables, &c->nTables);
 
-  /* Find our table */
+  
   for(i=0; i<c->nTables; i++){
     if( c->aTables[i].zName && strcmp(c->aTables[i].zName, vt->zTableName)==0 ){
       c->iTableIdx = i;
@@ -634,22 +563,22 @@ static int cfrColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
   cr = &c->aTables[c->iTableIdx].aRows[c->iRow];
 
   switch(col){
-    case 0: /* base_rowid */
+    case 0: 
       sqlite3_result_int64(ctx, cr->intKey);
       break;
-    case 1: /* base_value */
+    case 1: 
       doltliteResultRecord(ctx, cr->pBaseVal, cr->nBaseVal);
       break;
-    case 2: /* our_rowid (same key) */
+    case 2: 
       sqlite3_result_int64(ctx, cr->intKey);
       break;
-    case 3: /* our_value */
+    case 3: 
       doltliteResultRecord(ctx, cr->pOurVal, cr->nOurVal);
       break;
-    case 4: /* their_rowid */
+    case 4: 
       sqlite3_result_int64(ctx, cr->intKey);
       break;
-    case 5: /* their_value */
+    case 5: 
       doltliteResultRecord(ctx, cr->pTheirVal, cr->nTheirVal);
       break;
   }
@@ -672,14 +601,6 @@ static int cfrBestIndex(sqlite3_vtab *v, sqlite3_index_info *p){
   return SQLITE_OK;
 }
 
-/* --------------------------------------------------------------------------
-** DELETE from dolt_conflicts_<tablename>
-**
-** Removes the conflict row at the given rowid from the conflict catalog.
-** This resolves that specific conflict (keeping whatever is in the
-** working table for that row).
-** -------------------------------------------------------------------------- */
-
 static int cfrUpdate(
   sqlite3_vtab *pVtab,
   int nArg,
@@ -695,7 +616,7 @@ static int cfrUpdate(
 
   (void)pRowid;
 
-  /* Only DELETE is supported (nArg==1) */
+  
   if( nArg != 1 ){
     pVtab->zErrMsg = sqlite3_mprintf("only DELETE is supported on conflict tables");
     return SQLITE_ERROR;
@@ -703,34 +624,34 @@ static int cfrUpdate(
 
   deleteRowid = sqlite3_value_int64(apArg[0]);
 
-  /* Load all conflicts */
+  
   rc = loadAllConflicts(v->db, cs, &aTables, &nTables);
   if( rc!=SQLITE_OK ) return rc;
 
-  /* Find the table and remove the matching conflict row */
+  
   for(i=0; i<nTables; i++){
     if( !aTables[i].zName || strcmp(aTables[i].zName, v->zTableName)!=0 )
       continue;
 
     for(j=0; j<aTables[i].nConflicts; j++){
       if( aTables[i].aRows[j].intKey == deleteRowid ){
-        /* Free this row's data */
+        
         sqlite3_free(aTables[i].aRows[j].pBaseVal);
         sqlite3_free(aTables[i].aRows[j].pTheirVal);
 
-        /* Shift remaining rows down */
+        
         if( j < aTables[i].nConflicts - 1 ){
           memmove(&aTables[i].aRows[j], &aTables[i].aRows[j+1],
                   (aTables[i].nConflicts - j - 1) * sizeof(struct ConflictRow));
         }
         aTables[i].nConflicts--;
 
-        /* If table has no more conflicts, remove the table entry */
+        
         if( aTables[i].nConflicts == 0 ){
           sqlite3_free(aTables[i].aRows);
           aTables[i].aRows = 0;
           sqlite3_free(aTables[i].zName);
-          /* Shift remaining tables */
+          
           if( i < nTables - 1 ){
             memmove(&aTables[i], &aTables[i+1],
                     (nTables - i - 1) * sizeof(ConflictTableInfo));
@@ -738,7 +659,7 @@ static int cfrUpdate(
           nTables--;
         }
 
-        /* Re-serialize and store */
+        
         rc = storeUpdatedConflicts(v->db, cs, aTables, nTables);
         freeConflictTables(aTables, nTables);
         return rc;
@@ -748,31 +669,26 @@ static int cfrUpdate(
   }
 
   freeConflictTables(aTables, nTables);
-  return SQLITE_OK; /* Row not found — no-op */
+  return SQLITE_OK; 
 }
 
 static sqlite3_module cfRowModule = {
-  0,                   /* iVersion */
-  cfrConnect,          /* xCreate — same as xConnect for eponymous */
-  cfrConnect,          /* xConnect */
-  cfrBestIndex,        /* xBestIndex */
-  cfrDisconnect,       /* xDisconnect */
-  cfrDisconnect,       /* xDestroy — same as xDisconnect */
-  cfrOpen,             /* xOpen */
-  cfrClose,            /* xClose */
-  cfrFilter,           /* xFilter */
-  cfrNext,             /* xNext */
-  cfrEof,              /* xEof */
-  cfrColumn,           /* xColumn */
-  cfrRowid,            /* xRowid */
-  cfrUpdate,           /* xUpdate */
-  0,0,0,0,0,0,0,0,0,0,0  /* remaining */
+  0,                   
+  cfrConnect,          
+  cfrConnect,          
+  cfrBestIndex,        
+  cfrDisconnect,       
+  cfrDisconnect,       
+  cfrOpen,             
+  cfrClose,            
+  cfrFilter,           
+  cfrNext,             
+  cfrEof,              
+  cfrColumn,           
+  cfrRowid,            
+  cfrUpdate,           
+  0,0,0,0,0,0,0,0,0,0,0  
 };
-
-/* --------------------------------------------------------------------------
-** Register dolt_conflicts_<tablename> virtual tables for all conflicted
-** tables.  Called during registration and after merge.
-** -------------------------------------------------------------------------- */
 
 void doltliteRegisterConflictTables(sqlite3 *db){
   ChunkStore *cs = doltliteGetChunkStore(db);
@@ -787,8 +703,7 @@ void doltliteRegisterConflictTables(sqlite3 *db){
     if( aTables[i].zName ){
       char *zModuleName = sqlite3_mprintf("dolt_conflicts_%s", aTables[i].zName);
       if( zModuleName ){
-        /* Register as eponymous virtual table: module name = table name,
-        ** so SELECT * FROM dolt_conflicts_<table> works without CREATE. */
+        
         sqlite3_create_module(db, zModuleName, &cfRowModule, 0);
         sqlite3_free(zModuleName);
       }
@@ -796,10 +711,6 @@ void doltliteRegisterConflictTables(sqlite3 *db){
   }
   freeConflictTables(aTables, nTables);
 }
-
-/* --------------------------------------------------------------------------
-** dolt_conflicts_resolve('--ours'|'--theirs', 'tablename')
-** -------------------------------------------------------------------------- */
 
 static void conflictsResolveFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
@@ -823,10 +734,10 @@ static void conflictsResolveFunc(sqlite3_context *ctx, int argc, sqlite3_value *
   }
 
   if( strcmp(zMode,"--ours")==0 ){
-    /* Keep ours: remove conflicts for this table, leave working data as-is */
+    
     for(i=0; i<nTables; i++){
       if( aTables[i].zName && strcmp(aTables[i].zName, zTable)==0 ){
-        /* Free this table's conflict rows */
+        
         for(j=0; j<aTables[i].nConflicts; j++){
           sqlite3_free(aTables[i].aRows[j].pBaseVal);
           sqlite3_free(aTables[i].aRows[j].pTheirVal);
@@ -835,7 +746,7 @@ static void conflictsResolveFunc(sqlite3_context *ctx, int argc, sqlite3_value *
         aTables[i].aRows = 0;
         aTables[i].nConflicts = 0;
         sqlite3_free(aTables[i].zName);
-        /* Remove table entry */
+        
         if( i < nTables - 1 ){
           memmove(&aTables[i], &aTables[i+1],
                   (nTables - i - 1) * sizeof(ConflictTableInfo));
@@ -849,18 +760,15 @@ static void conflictsResolveFunc(sqlite3_context *ctx, int argc, sqlite3_value *
     sqlite3_result_int(ctx, 0);
 
   }else if( strcmp(zMode,"--theirs")==0 ){
-    /* Take theirs: apply their values to working tree for conflicted rows,
-    ** then clear conflicts for this table */
+    
     for(i=0; i<nTables; i++){
       if( !aTables[i].zName || strcmp(aTables[i].zName, zTable)!=0 ) continue;
 
-      /* Apply each conflict's theirVal */
+      
       for(j=0; j<aTables[i].nConflicts; j++){
         struct ConflictRow *cr = &aTables[i].aRows[j];
         if( cr->pTheirVal && cr->nTheirVal > 0 ){
-          /* Their value exists — decode the raw SQLite record and
-          ** apply it via INSERT OR REPLACE, which handles both the
-          ** deletion of our value and insertion of theirs atomically. */
+          
           rc = applyTheirRecord(db, zTable, cr->intKey,
                                 cr->pTheirVal, cr->nTheirVal);
           if( rc!=SQLITE_OK ){
@@ -869,14 +777,14 @@ static void conflictsResolveFunc(sqlite3_context *ctx, int argc, sqlite3_value *
             return;
           }
         }else{
-          /* Their value is NULL — they deleted the row. Delete ours. */
+          
           char *zSql = sqlite3_mprintf("DELETE FROM \"%w\" WHERE rowid=%lld",
                                         zTable, cr->intKey);
           if(zSql){ sqlite3_exec(db, zSql, 0, 0, 0); sqlite3_free(zSql); }
         }
       }
 
-      /* Clear conflicts for this table */
+      
       for(j=0; j<aTables[i].nConflicts; j++){
         sqlite3_free(aTables[i].aRows[j].pBaseVal);
         sqlite3_free(aTables[i].aRows[j].pTheirVal);
@@ -902,20 +810,16 @@ static void conflictsResolveFunc(sqlite3_context *ctx, int argc, sqlite3_value *
   }
 }
 
-/* --------------------------------------------------------------------------
-** Registration
-** -------------------------------------------------------------------------- */
-
 int doltliteConflictsRegister(sqlite3 *db){
   int rc;
   rc = sqlite3_create_module(db, "dolt_conflicts", &conflictsModule, 0);
   if( rc==SQLITE_OK )
     rc = sqlite3_create_function(db, "dolt_conflicts_resolve", -1, SQLITE_UTF8, 0,
                                   conflictsResolveFunc, 0, 0);
-  /* Register any existing conflict tables from a prior merge */
+  
   if( rc==SQLITE_OK )
     doltliteRegisterConflictTables(db);
   return rc;
 }
 
-#endif /* DOLTLITE_PROLLY */
+#endif 

--- a/src/doltlite_diff.c
+++ b/src/doltlite_diff.c
@@ -1,11 +1,4 @@
-/*
-** dolt_diff table-valued function: row-level diff between two commits
-** or between HEAD and working state.
-**
-** Usage:
-**   SELECT * FROM dolt_diff('tablename');                        -- working vs HEAD
-**   SELECT * FROM dolt_diff('tablename', 'from_hash', 'to_hash'); -- between commits
-*/
+
 #ifdef DOLTLITE_PROLLY
 
 #include "sqliteInt.h"
@@ -19,23 +12,15 @@
 #include "doltlite_internal.h"
 #include <string.h>
 
-/* --------------------------------------------------------------------------
-** Buffered diff row
-** -------------------------------------------------------------------------- */
-
 typedef struct DiffRow DiffRow;
 struct DiffRow {
-  u8 type;        /* PROLLY_DIFF_ADD, DELETE, MODIFY */
-  i64 intKey;     /* rowid for INTKEY tables */
-  u8 *pOldVal;    /* old value (owned, NULL for ADD) */
+  u8 type;        
+  i64 intKey;     
+  u8 *pOldVal;    
   int nOldVal;
-  u8 *pNewVal;    /* new value (owned, NULL for DELETE) */
+  u8 *pNewVal;    
   int nNewVal;
 };
-
-/* --------------------------------------------------------------------------
-** Virtual table structures
-** -------------------------------------------------------------------------- */
 
 typedef struct DoltliteDiffVtab DoltliteDiffVtab;
 struct DoltliteDiffVtab {
@@ -49,7 +34,7 @@ struct DoltliteDiffCursor {
   DiffRow *aRows;
   int nRows;
   int iRow;
-  int iPkField;    /* Record field index of the user's PK, or -1 if rowid alias */
+  int iPkField;    
 };
 
 static const char *diffSchema =
@@ -62,12 +47,6 @@ static const char *diffSchema =
   "  from_commit TEXT HIDDEN,"
   "  to_commit   TEXT HIDDEN"
   ")";
-
-/* --------------------------------------------------------------------------
-** Detect whether a table's PK is a rowid alias (INTEGER PRIMARY KEY).
-** Returns -1 if it IS a rowid alias (intKey == user PK).
-** Returns the column index (0-based) if it's NOT (user PK is in the record).
-** -------------------------------------------------------------------------- */
 
 static int detectPkField(sqlite3 *db, const char *zTable){
   char *zSql;
@@ -85,11 +64,11 @@ static int detectPkField(sqlite3 *db, const char *zTable){
     if( pk==1 ){
       const char *zType = (const char*)sqlite3_column_text(pStmt, 2);
       if( zType && sqlite3_stricmp(zType, "INTEGER")==0 ){
-        /* TRUE rowid alias — intKey IS the user's PK */
+        
         sqlite3_finalize(pStmt);
         return -1;
       }
-      /* NOT a rowid alias — PK is stored in record at this column index */
+      
       pkField = colIdx;
     }
     colIdx++;
@@ -97,11 +76,6 @@ static int detectPkField(sqlite3 *db, const char *zTable){
   sqlite3_finalize(pStmt);
   return pkField;
 }
-
-/* --------------------------------------------------------------------------
-** Extract PK value from a record and set it as the result.
-** Uses the same varint/field parsing as doltlite_record.c.
-** -------------------------------------------------------------------------- */
 
 static void resultPkFromRecord(
   sqlite3_context *ctx,
@@ -115,19 +89,19 @@ static void resultPkFromRecord(
   if( !pData || nData<1 ){ sqlite3_result_null(ctx); return; }
 
   p = pData; pEnd = pData + nData;
-  /* Read header size varint */
+  
   hdrBytes = dlReadVarint(p, pEnd, &hdrSize);
   p += hdrBytes;
   off = (int)hdrSize;
 
-  /* Walk serial types to find the PK field */
+  
   while( p < pData+hdrSize && p < pEnd ){
     u64 st; int stBytes;
     stBytes = dlReadVarint(p, pData+hdrSize, &st);
     p += stBytes;
 
     if( fieldIdx==pkFieldIdx ){
-      /* Found the PK field — decode and return its value */
+      
       if( st==0 ){ sqlite3_result_null(ctx); return; }
       if( st==8 ){ sqlite3_result_int(ctx,0); return; }
       if( st==9 ){ sqlite3_result_int(ctx,1); return; }
@@ -151,16 +125,12 @@ static void resultPkFromRecord(
       return;
     }
 
-    /* Advance offset past this field's data */
+    
     off += dlSerialTypeLen(st);
     fieldIdx++;
   }
   sqlite3_result_null(ctx);
 }
-
-/* --------------------------------------------------------------------------
-** Diff callback: collect changes into buffer
-** -------------------------------------------------------------------------- */
 
 static int diffCollect(void *pCtx, const ProllyDiffChange *pChange){
   DoltliteDiffCursor *pCur = (DoltliteDiffCursor*)pCtx;
@@ -202,10 +172,6 @@ static void freeDiffRows(DoltliteDiffCursor *pCur){
   pCur->nRows = 0;
 }
 
-/* --------------------------------------------------------------------------
-** Helper: find a table's root hash in a catalog
-** -------------------------------------------------------------------------- */
-
 static int findTableRoot(struct TableEntry *a, int n, Pgno iTable,
                          ProllyHash *pRoot, u8 *pFlags){
   struct TableEntry *e = doltliteFindTableByNumber(a, n, iTable);
@@ -219,30 +185,22 @@ static int findTableRoot(struct TableEntry *a, int n, Pgno iTable,
   return SQLITE_NOTFOUND;
 }
 
-/* --------------------------------------------------------------------------
-** Resolve a ref string (branch name, tag name, or hex hash) to a commit hash
-** -------------------------------------------------------------------------- */
-
 static int resolveRef(sqlite3 *db, const char *zRef, ProllyHash *pCommit){
   ChunkStore *cs = doltliteGetChunkStore(db);
   int rc;
-  /* Try as hex hash first */
+  
   if( zRef && strlen(zRef)==PROLLY_HASH_SIZE*2 ){
     rc = doltliteHexToHash(zRef, pCommit);
     if( rc==SQLITE_OK && chunkStoreHas(cs, pCommit) ) return SQLITE_OK;
   }
-  /* Try as branch name */
+  
   rc = chunkStoreFindBranch(cs, zRef, pCommit);
   if( rc==SQLITE_OK && !prollyHashIsEmpty(pCommit) ) return SQLITE_OK;
-  /* Try as tag name */
+  
   rc = chunkStoreFindTag(cs, zRef, pCommit);
   if( rc==SQLITE_OK && !prollyHashIsEmpty(pCommit) ) return SQLITE_OK;
   return SQLITE_NOTFOUND;
 }
-
-/* --------------------------------------------------------------------------
-** Resolve a ref string to a table root hash
-** -------------------------------------------------------------------------- */
 
 static int resolveCommitToTableRoot(
   sqlite3 *db, const char *zRef, Pgno iTable,
@@ -276,10 +234,6 @@ static int resolveCommitToTableRoot(
   return rc;
 }
 
-/* --------------------------------------------------------------------------
-** Virtual table methods
-** -------------------------------------------------------------------------- */
-
 static int diffConnect(sqlite3 *db, void *pAux, int argc,
     const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){
   DoltliteDiffVtab *pVtab;
@@ -312,14 +266,14 @@ static int diffBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
     if( !pInfo->aConstraint[i].usable ) continue;
     if( pInfo->aConstraint[i].op!=SQLITE_INDEX_CONSTRAINT_EQ ) continue;
     switch( pInfo->aConstraint[i].iColumn ){
-      case 4: iTableName = i; break;   /* table_name */
-      case 5: iFromCommit = i; break;  /* from_commit */
-      case 6: iToCommit = i; break;    /* to_commit */
+      case 4: iTableName = i; break;   
+      case 5: iFromCommit = i; break;  
+      case 6: iToCommit = i; break;    
     }
   }
 
   if( iTableName<0 ){
-    /* table_name is required */
+    
     pInfo->estimatedCost = 1e12;
     return SQLITE_OK;
   }
@@ -335,7 +289,7 @@ static int diffBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
     pInfo->aConstraintUsage[iToCommit].omit = 1;
   }
 
-  /* Encode which args are present in idxNum */
+  
   pInfo->idxNum = (iTableName>=0 ? 1 : 0)
                 | (iFromCommit>=0 ? 2 : 0)
                 | (iToCommit>=0 ? 4 : 0);
@@ -383,7 +337,7 @@ static int diffFilter(sqlite3_vtab_cursor *pCursor,
 
   if( !cs || !pBt ) return SQLITE_OK;
 
-  /* Extract arguments */
+  
   if( (idxNum & 1) && argIdx<argc ){
     zTableName = (const char*)sqlite3_value_text(argv[argIdx++]);
   }
@@ -396,18 +350,18 @@ static int diffFilter(sqlite3_vtab_cursor *pCursor,
 
   if( !zTableName ) return SQLITE_OK;
 
-  /* Detect if table PK is a rowid alias or stored in the record */
+  
   pCur->iPkField = detectPkField(db, zTableName);
 
-  /* Resolve table name to Pgno */
+  
   rc = doltliteResolveTableName(db, zTableName, &iTable);
-  if( rc!=SQLITE_OK ) return SQLITE_OK; /* Unknown table = empty diff */
+  if( rc!=SQLITE_OK ) return SQLITE_OK; 
 
-  /* Determine old root hash */
+  
   if( zFromCommit ){
     rc = resolveCommitToTableRoot(db, zFromCommit, iTable, &oldRoot, &flags);
   }else{
-    /* Default: HEAD */
+    
     ProllyHash headCatHash;
     struct TableEntry *aHead = 0;
     int nHead = 0;
@@ -421,13 +375,13 @@ static int diffFilter(sqlite3_vtab_cursor *pCursor,
     }
   }
 
-  /* Determine new root hash */
+  
   if( zToCommit ){
     u8 f2;
     rc = resolveCommitToTableRoot(db, zToCommit, iTable, &newRoot, &f2);
     if( flags==0 ) flags = f2;
   }else{
-    /* Default: working state */
+    
     u8 *catData = 0; int nCatData = 0;
     ProllyHash workingCatHash;
     struct TableEntry *aWork = 0;
@@ -446,10 +400,10 @@ static int diffFilter(sqlite3_vtab_cursor *pCursor,
     }
   }
 
-  /* Same root = no changes */
+  
   if( prollyHashCompare(&oldRoot, &newRoot)==0 ) return SQLITE_OK;
 
-  /* Run the diff */
+  
   {
     ProllyCache *pCache = doltliteGetCache(db);
 
@@ -478,28 +432,28 @@ static int diffColumn(sqlite3_vtab_cursor *pCursor,
   r = &pCur->aRows[pCur->iRow];
 
   switch( iCol ){
-    case 0: /* diff_type */
+    case 0: 
       switch( r->type ){
         case PROLLY_DIFF_ADD:    sqlite3_result_text(ctx,"added",-1,SQLITE_STATIC); break;
         case PROLLY_DIFF_DELETE: sqlite3_result_text(ctx,"removed",-1,SQLITE_STATIC); break;
         case PROLLY_DIFF_MODIFY: sqlite3_result_text(ctx,"modified",-1,SQLITE_STATIC); break;
       }
       break;
-    case 1: /* rowid_val — show user's PK, not hidden rowid */
+    case 1: 
       if( pCur->iPkField >= 0 ){
-        /* PK is NOT a rowid alias — extract from record */
+        
         const u8 *pRec = r->pNewVal ? r->pNewVal : r->pOldVal;
         int nRec = r->pNewVal ? r->nNewVal : r->nOldVal;
         resultPkFromRecord(ctx, pRec, nRec, pCur->iPkField);
       }else{
-        /* PK IS the rowid (INTEGER PRIMARY KEY) */
+        
         sqlite3_result_int64(ctx, r->intKey);
       }
       break;
-    case 2: /* from_value */
+    case 2: 
       doltliteResultRecord(ctx, r->pOldVal, r->nOldVal);
       break;
-    case 3: /* to_value */
+    case 3: 
       doltliteResultRecord(ctx, r->pNewVal, r->nNewVal);
       break;
   }
@@ -510,8 +464,6 @@ static int diffRowid(sqlite3_vtab_cursor *pCursor, sqlite3_int64 *pRowid){
   *pRowid = ((DoltliteDiffCursor*)pCursor)->iRow;
   return SQLITE_OK;
 }
-
-/* -------------------------------------------------------------------------- */
 
 static sqlite3_module doltliteDiffModule = {
   0, 0, diffConnect, diffBestIndex, diffDisconnect, 0,
@@ -524,4 +476,4 @@ int doltliteDiffRegister(sqlite3 *db){
   return sqlite3_create_module(db, "dolt_diff", &doltliteDiffModule, 0);
 }
 
-#endif /* DOLTLITE_PROLLY */
+#endif 

--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -1,12 +1,4 @@
-/*
-** dolt_diff_<tablename> — per-table audit log with Dolt-style column schema.
-**
-** Schema mirrors Dolt:
-**   from_<col1>, from_<col2>, ..., to_<col1>, to_<col2>, ...,
-**   from_commit, to_commit, from_commit_date, to_commit_date, diff_type
-**
-** Values are decoded from SQLite record format into native types.
-*/
+
 #ifdef DOLTLITE_PROLLY
 
 #include "sqliteInt.h"
@@ -21,10 +13,6 @@
 #include <assert.h>
 #include <string.h>
 #include <time.h>
-
-/* --------------------------------------------------------------------------
-** Parse record header to get serial types and body offsets
-** -------------------------------------------------------------------------- */
 
 #define DT_MAX_COLS 64
 
@@ -77,7 +65,6 @@ static void dtParseRecord(const u8 *pData, int nData, RecordInfo *pInfo){
   }
 }
 
-/* Set a sqlite3_context result from a record field */
 static void dtResultField(
   sqlite3_context *ctx,
   const u8 *pData, int nData,
@@ -142,13 +129,8 @@ static void dtResultField(
   sqlite3_result_null(ctx);
 }
 
-/* --------------------------------------------------------------------------
-** Build the virtual table schema dynamically from column names
-** -------------------------------------------------------------------------- */
-
 static char *buildDiffSchema(DoltliteColInfo *ci){
-  /* Schema: from_<col1>, ..., to_<col1>, ...,
-  **         from_commit, to_commit, from_commit_date, to_commit_date, diff_type */
+  
   int i;
   int sz = 256;
   char *z;
@@ -164,13 +146,13 @@ static char *buildDiffSchema(DoltliteColInfo *ci){
 
     p += snprintf(p, end-p, "CREATE TABLE x(");
 
-    /* from_<col> columns */
+    
     for(i=0; i<ci->nCol; i++){
       if( i > 0 ) p += snprintf(p, end-p, ", ");
       p += snprintf(p, end-p, "\"from_%s\"", ci->azName[i]);
     }
 
-    /* to_<col> columns */
+    
     for(i=0; i<ci->nCol; i++){
       p += snprintf(p, end-p, ", \"to_%s\"", ci->azName[i]);
     }
@@ -184,10 +166,6 @@ static char *buildDiffSchema(DoltliteColInfo *ci){
   return z;
 }
 
-/* --------------------------------------------------------------------------
-** Buffered audit row
-** -------------------------------------------------------------------------- */
-
 typedef struct AuditRow AuditRow;
 struct AuditRow {
   u8 diffType;
@@ -200,16 +178,12 @@ struct AuditRow {
   i64 toDate;
 };
 
-/* --------------------------------------------------------------------------
-** Virtual table structures
-** -------------------------------------------------------------------------- */
-
 typedef struct DiffTblVtab DiffTblVtab;
 struct DiffTblVtab {
   sqlite3_vtab base;
   sqlite3 *db;
   char *zTableName;
-  DoltliteColInfo cols;       /* Column names for this table */
+  DoltliteColInfo cols;       
 };
 
 typedef struct DiffTblCursor DiffTblCursor;
@@ -220,10 +194,6 @@ struct DiffTblCursor {
   int nAlloc;
   int iRow;
 };
-
-/* --------------------------------------------------------------------------
-** Diff callback
-** -------------------------------------------------------------------------- */
 
 typedef struct CollectCtx CollectCtx;
 struct CollectCtx {
@@ -284,10 +254,6 @@ static void freeAuditRows(DiffTblCursor *pCur){
   pCur->nAlloc = 0;
 }
 
-/* --------------------------------------------------------------------------
-** Find table root by name
-** -------------------------------------------------------------------------- */
-
 static int findTableRootByName(
   struct TableEntry *a, int n, const char *zName,
   ProllyHash *pRoot, u8 *pFlags
@@ -302,10 +268,6 @@ static int findTableRootByName(
   if( pFlags ) *pFlags = 0;
   return SQLITE_NOTFOUND;
 }
-
-/* --------------------------------------------------------------------------
-** Walk commit history and diff
-** -------------------------------------------------------------------------- */
 
 static int walkHistoryAndDiff(
   DiffTblCursor *pCur, sqlite3 *db, const char *zTableName
@@ -417,10 +379,6 @@ static int walkHistoryAndDiff(
   return SQLITE_OK;
 }
 
-/* --------------------------------------------------------------------------
-** Virtual table methods
-** -------------------------------------------------------------------------- */
-
 static int dtConnect(sqlite3 *db, void *pAux, int argc,
     const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){
   DiffTblVtab *pVtab;
@@ -434,7 +392,7 @@ static int dtConnect(sqlite3 *db, void *pAux, int argc,
   memset(pVtab, 0, sizeof(*pVtab));
   pVtab->db = db;
 
-  /* Extract table name from module name: "dolt_diff_<tablename>" */
+  
   zModName = argv[0];
   if( zModName && strncmp(zModName, "dolt_diff_", 10)==0 ){
     pVtab->zTableName = sqlite3_mprintf("%s", zModName + 10);
@@ -444,14 +402,14 @@ static int dtConnect(sqlite3 *db, void *pAux, int argc,
     pVtab->zTableName = sqlite3_mprintf("");
   }
 
-  /* Get column names from the actual table */
+  
   doltliteGetColumnNames(db, pVtab->zTableName, &pVtab->cols);
 
-  /* Build dynamic schema */
+  
   if( pVtab->cols.nCol > 0 ){
     zSchema = buildDiffSchema(&pVtab->cols);
   }else{
-    /* Fallback: generic schema */
+    
     zSchema = sqlite3_mprintf(
       "CREATE TABLE x(from_value, to_value,"
       " from_commit TEXT, to_commit TEXT,"
@@ -536,32 +494,20 @@ static int dtColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
   AuditRow *r = &c->aRows[c->iRow];
   int nCols = pVtab->cols.nCol;
 
-  /* Column layout:
-  ** 0..nCols-1         : from_<col> values
-  ** nCols..2*nCols-1   : to_<col> values
-  ** 2*nCols            : from_commit
-  ** 2*nCols+1          : to_commit
-  ** 2*nCols+2          : from_commit_date
-  ** 2*nCols+3          : to_commit_date
-  ** 2*nCols+4          : diff_type
-  */
+  
 
   if( nCols > 0 && col < nCols ){
-    /* from_<col> */
+    
     int colIdx = col;
     if( colIdx == pVtab->cols.iPkCol ){
-      /* PK column: value comes from the rowid, not the record body.
-      ** For 'added' rows (no old val), the PK didn't exist → NULL. */
+      
       if( r->pOldVal && r->nOldVal > 0 ){
         sqlite3_result_int64(ctx, r->intKey);
       }else{
         sqlite3_result_null(ctx);
       }
     }else{
-      /* Non-PK column: decode from old record body.
-      ** The record body has fields for all columns in schema order,
-      ** but the PK field stores NULL (placeholder). Map schema col
-      ** index directly to record field index. */
+      
       if( r->pOldVal && r->nOldVal > 0 ){
         RecordInfo ri;
         dtParseRecord(r->pOldVal, r->nOldVal, &ri);
@@ -576,7 +522,7 @@ static int dtColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
       }
     }
   }else if( nCols > 0 && col < 2*nCols ){
-    /* to_<col> */
+    
     int colIdx = col - nCols;
     if( colIdx == pVtab->cols.iPkCol ){
       if( r->pNewVal && r->nNewVal > 0 ){
@@ -599,14 +545,14 @@ static int dtColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
       }
     }
   }else{
-    /* Fixed columns at the end */
+    
     int fixedCol = col - 2*nCols;
-    if( nCols == 0 ) fixedCol = col; /* fallback mode */
+    if( nCols == 0 ) fixedCol = col; 
 
     switch( fixedCol ){
-      case 0: /* from_commit */
+      case 0: 
         if( nCols == 0 ){
-          /* fallback: from_value blob */
+          
           if( r->pOldVal )
             sqlite3_result_blob(ctx, r->pOldVal, r->nOldVal, SQLITE_TRANSIENT);
           else
@@ -615,7 +561,7 @@ static int dtColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
           sqlite3_result_text(ctx, r->zFromCommit, -1, SQLITE_TRANSIENT);
         }
         break;
-      case 1: /* to_commit */
+      case 1: 
         if( nCols == 0 ){
           if( r->pNewVal )
             sqlite3_result_blob(ctx, r->pNewVal, r->nNewVal, SQLITE_TRANSIENT);
@@ -625,19 +571,19 @@ static int dtColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
           sqlite3_result_text(ctx, r->zToCommit, -1, SQLITE_TRANSIENT);
         }
         break;
-      case 2: /* from_commit_date */
+      case 2: 
         { time_t t = (time_t)r->fromDate; struct tm *tm = gmtime(&t);
           if(tm){ char b[32]; strftime(b,sizeof(b),"%Y-%m-%d %H:%M:%S",tm);
             sqlite3_result_text(ctx,b,-1,SQLITE_TRANSIENT);
           }else sqlite3_result_null(ctx); }
         break;
-      case 3: /* to_commit_date */
+      case 3: 
         { time_t t = (time_t)r->toDate; struct tm *tm = gmtime(&t);
           if(tm){ char b[32]; strftime(b,sizeof(b),"%Y-%m-%d %H:%M:%S",tm);
             sqlite3_result_text(ctx,b,-1,SQLITE_TRANSIENT);
           }else sqlite3_result_null(ctx); }
         break;
-      case 4: /* diff_type */
+      case 4: 
         switch( r->diffType ){
           case PROLLY_DIFF_ADD:    sqlite3_result_text(ctx,"added",-1,SQLITE_STATIC); break;
           case PROLLY_DIFF_DELETE: sqlite3_result_text(ctx,"removed",-1,SQLITE_STATIC); break;
@@ -660,10 +606,6 @@ static sqlite3_module diffTableModule = {
   dtOpen, dtClose, dtFilter, dtNext, dtEof, dtColumn, dtRowid,
   0,0,0,0,0,0,0,0,0,0,0,0
 };
-
-/* --------------------------------------------------------------------------
-** Registration
-** -------------------------------------------------------------------------- */
 
 void doltliteRegisterDiffTables(sqlite3 *db){
   ChunkStore *cs = doltliteGetChunkStore(db);
@@ -701,4 +643,4 @@ void doltliteRegisterDiffTables(sqlite3 *db){
   sqlite3_free(aTables);
 }
 
-#endif /* DOLTLITE_PROLLY */
+#endif 

--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -1,18 +1,4 @@
-/*
-** Stop-the-world garbage collection for Doltlite.
-**
-** SQL interface:
-**   SELECT dolt_gc();
-**   -- Returns "N chunks removed, M chunks kept"
-**
-** Algorithm: mark-and-sweep
-**   Mark:  BFS from all roots (branches, tags, HEAD, staged, merge state)
-**          following commit chains, catalogs, and prolly tree nodes.
-**   Sweep: Rewrite the chunk store file with only reachable chunks.
-**
-** This is a stop-the-world operation: no other connections should be
-** active during GC.  The entire file is rewritten atomically.
-*/
+
 #ifdef DOLTLITE_PROLLY
 
 #include "sqliteInt.h"
@@ -24,23 +10,16 @@
 
 #include <string.h>
 #include <stdio.h>
-/* POSIX I/O macros removed — GC file rewrite now routes through SQLite VFS.
-** See gcRewriteFile() below. */
 
 extern void csSerializeManifest(const ChunkStore *cs, u8 *aBuf);
 #include "doltlite_internal.h"
-
-
-/* ----------------------------------------------------------------
-** BFS queue for mark traversal.
-** ---------------------------------------------------------------- */
 
 typedef struct GcQueue GcQueue;
 struct GcQueue {
   ProllyHash *aItems;
   int nItems;
   int nAlloc;
-  int iHead;   /* Next item to dequeue */
+  int iHead;   
 };
 
 static int gcQueueInit(GcQueue *q){
@@ -78,18 +57,13 @@ static int gcQueuePop(GcQueue *q, ProllyHash *h){
   return 1;
 }
 
-/* ----------------------------------------------------------------
-** Chunk type detection helpers.
-** ---------------------------------------------------------------- */
-
 #define PROLLY_NODE_MAGIC_VAL 0x504E4F44
 
 static int isCommitChunk(const u8 *data, int nData){
-  /* Commits start with version byte (V2=2).
-  ** V2: version(1) + nParents(1) + parents(20*N) + catalog(20) + ... min ~30 bytes */
+  
   if( nData < 30 ) return 0;
   if( data[0] != DOLTLITE_COMMIT_V2 ) return 0;
-  /* Verify it's NOT a prolly node (magic would be at offset 0) */
+  
   if( nData >= 4 ){
     u32 m = (u32)data[0] | ((u32)data[1]<<8) |
             ((u32)data[2]<<16) | ((u32)data[3]<<24);
@@ -106,10 +80,6 @@ static int isProllyNodeChunk(const u8 *data, int nData){
   return m == PROLLY_NODE_MAGIC_VAL;
 }
 
-/* ----------------------------------------------------------------
-** Mark phase: BFS from all roots.
-** ---------------------------------------------------------------- */
-
 static int gcMarkReachable(
   ChunkStore *cs,
   ProllyHashSet *marked
@@ -121,19 +91,19 @@ static int gcMarkReachable(
   rc = gcQueueInit(&queue);
   if( rc!=SQLITE_OK ) return rc;
 
-  /* Seed: manifest roots */
+  
   rc = gcQueuePush(&queue, &cs->root);
   if( rc==SQLITE_OK ) rc = gcQueuePush(&queue, &cs->catalog);
   if( rc==SQLITE_OK ) rc = gcQueuePush(&queue, &cs->headCommit);
   if( rc==SQLITE_OK ) rc = gcQueuePush(&queue, &cs->refsHash);
 
-  /* All branch tips + per-branch WorkingSet chunks */
+  
   for(i=0; rc==SQLITE_OK && i<cs->nBranches; i++){
     rc = gcQueuePush(&queue, &cs->aBranches[i].commitHash);
     if( rc==SQLITE_OK ) rc = gcQueuePush(&queue, &cs->aBranches[i].workingSetHash);
   }
 
-  /* All tag targets */
+  
   for(i=0; rc==SQLITE_OK && i<cs->nTags; i++){
     rc = gcQueuePush(&queue, &cs->aTags[i].commitHash);
   }
@@ -142,7 +112,7 @@ static int gcMarkReachable(
     return rc;
   }
 
-  /* BFS */
+  
   while( gcQueuePop(&queue, &current) ){
     u8 *data = 0;
     int nData = 0;
@@ -155,12 +125,12 @@ static int gcMarkReachable(
 
     rc = chunkStoreGet(cs, &current, &data, &nData);
     if( rc!=SQLITE_OK ){
-      /* Chunk missing — skip, don't fail GC */
+      
       continue;
     }
 
     if( isProllyNodeChunk(data, nData) ){
-      /* Prolly tree node — follow child hashes if internal */
+      
       ProllyNode node;
       int parseRc = prollyNodeParse(&node, data, nData);
       if( parseRc==SQLITE_OK && node.level > 0 ){
@@ -172,7 +142,7 @@ static int gcMarkReachable(
         }
       }
     }else if( isCommitChunk(data, nData) ){
-      /* Commit — follow ALL parents + catalog */
+      
       DoltliteCommit commit;
       memset(&commit, 0, sizeof(commit));
       int drc = doltliteCommitDeserialize(data, nData, &commit);
@@ -186,25 +156,21 @@ static int gcMarkReachable(
         doltliteCommitClear(&commit);
       }
     }else{
-      /* Could be a catalog, refs, or conflict chunk.
-      ** Catalogs contain table root hashes we need to follow.
-      ** Format: version(1=0x02)+iNextTable(4)+nTables(4)+entries */
-      /* WorkingSet chunk: version(1=0x01) + staged(20) + merging(1) +
-      ** mergeCommit(20) + conflicts(20) = 62 bytes.
-      ** Follow staged catalog and conflicts catalog hashes. */
+      
+      
       if( nData == WS_TOTAL_SIZE && data[0] == 1 ){
         ProllyHash stagedCat, conflictsCat;
         memcpy(stagedCat.data, data + WS_STAGED_OFF, PROLLY_HASH_SIZE);
         memcpy(conflictsCat.data, data + WS_CONFLICTS_OFF, PROLLY_HASH_SIZE);
         rc = gcQueuePush(&queue, &stagedCat);
         if( rc==SQLITE_OK ) rc = gcQueuePush(&queue, &conflictsCat);
-        if( rc==SQLITE_OK && data[WS_MERGING_OFF] ){  /* isMerging */
+        if( rc==SQLITE_OK && data[WS_MERGING_OFF] ){  
           ProllyHash mergeCommit;
           memcpy(mergeCommit.data, data + WS_MERGE_COMMIT_OFF, PROLLY_HASH_SIZE);
           rc = gcQueuePush(&queue, &mergeCommit);
         }
       }
-      /* Catalog chunk: version(1='C') */
+      
       if( nData >= 9 && data[0] == 0x43 ){
         int nTables = (int)(data[5] | (data[6]<<8) |
                             (data[7]<<16) | (data[8]<<24));
@@ -237,21 +203,6 @@ static int gcMarkReachable(
   return rc;
 }
 
-/* ----------------------------------------------------------------
-** Sweep phase: rewrite chunk store with only marked chunks.
-**
-** Strategy:
-**   1. Build list of surviving ChunkIndexEntry from old index
-**   2. Write new file: manifest + chunk data + new index
-**   3. Atomically replace old file (temp + rename)
-**   4. Reload the chunk store index
-** ---------------------------------------------------------------- */
-
-/*
-** Iterate the existing chunk index, copy surviving (marked) chunks into
-** a new contiguous data buffer, and build a new sorted index.
-** Caller must sqlite3_free *ppNewData and *ppNewIndex when done.
-*/
 static int gcBuildCompactedData(
   ChunkStore *cs,
   ProllyHashSet *marked,
@@ -269,7 +220,7 @@ static int gcBuildCompactedData(
   i64 dataOffset = CHUNK_MANIFEST_SIZE;
   int rc = SQLITE_OK;
 
-  /* Count survivors to pre-allocate */
+  
   for(i=0; i<cs->nIndex; i++){
     if( prollyHashSetContains(marked, &cs->aIndex[i].hash) ) kept++;
   }
@@ -290,7 +241,7 @@ static int gcBuildCompactedData(
       return rc;
     }
 
-    /* Grow buffer: 4 (length prefix) + nChunkData */
+    
     {
       int need = nBuf + 4 + nChunkData;
       if( need > nBufAlloc ){
@@ -306,7 +257,7 @@ static int gcBuildCompactedData(
       }
     }
 
-    /* Write length prefix + data */
+    
     buf[nBuf]   = (u8)(nChunkData);
     buf[nBuf+1] = (u8)(nChunkData>>8);
     buf[nBuf+2] = (u8)(nChunkData>>16);
@@ -323,7 +274,7 @@ static int gcBuildCompactedData(
     sqlite3_free(chunkData);
   }
 
-  /* Sort new index by hash for binary search */
+  
   for(i=1; i<nNewIndex; i++){
     ChunkIndexEntry tmp = aNewIndex[i];
     j = i-1;
@@ -341,10 +292,6 @@ static int gcBuildCompactedData(
   return SQLITE_OK;
 }
 
-/*
-** Write the compacted chunk store file: manifest + chunk data + index.
-** Fsyncs, renames the temp file into place, and reopens the file handle.
-*/
 static int gcRewriteFile(
   ChunkStore *cs,
   const u8 *pNewData,
@@ -359,7 +306,7 @@ static int gcRewriteFile(
   u8 manifest[CHUNK_MANIFEST_SIZE];
   int rc = SQLITE_OK;
 
-  /* Build serialized index */
+  
   indexBuf = sqlite3_malloc(indexSize);
   if( !indexBuf ) return SQLITE_NOMEM;
   for(i=0; i<nNewIndex; i++){
@@ -381,7 +328,7 @@ static int gcRewriteFile(
     }
   }
 
-  /* Update ChunkStore fields so the manifest reflects GC state */
+  
   cs->nChunks = nNewIndex;
   cs->iIndexOffset = indexOffset;
   cs->nIndexSize = indexSize;
@@ -389,10 +336,7 @@ static int gcRewriteFile(
 
   csSerializeManifest(cs, manifest);
 
-  /* Write to temp file via VFS, then rename.  All I/O routes through
-  ** the SQLite VFS layer so encryption extensions, compression plugins,
-  ** and custom I/O backends see every byte written.  Writes are bounded
-  ** to 64 KB per VFS call for broad VFS implementation compatibility. */
+  
   if( cs->zFilename && strcmp(cs->zFilename, ":memory:")!=0 ){
     char *zTmp = sqlite3_mprintf("%s-gc-tmp", cs->zFilename);
     if( !zTmp ){
@@ -406,7 +350,7 @@ static int gcRewriteFile(
                    | SQLITE_OPEN_MAIN_DB;
       i64 writeOff = 0;
 
-      /* Remove stale temp file from a previous failed GC, if any */
+      
       cs->pVfs->xDelete(cs->pVfs, zTmp, 0);
 
       rc = sqlite3OsOpenMalloc(cs->pVfs, zTmp, &pTmpFile, tmpFlags, 0);
@@ -415,11 +359,11 @@ static int gcRewriteFile(
         return SQLITE_CANTOPEN;
       }
 
-      /* Write manifest */
+      
       rc = sqlite3OsWrite(pTmpFile, manifest, CHUNK_MANIFEST_SIZE, writeOff);
       writeOff += CHUNK_MANIFEST_SIZE;
 
-      /* Write chunk data in bounded pieces for VFS compatibility */
+      
       if( rc==SQLITE_OK && nNewData>0 ){
         const u8 *p = pNewData;
         int remaining = nNewData;
@@ -432,7 +376,7 @@ static int gcRewriteFile(
         }
       }
 
-      /* Write index */
+      
       if( rc==SQLITE_OK && indexSize>0 ){
         const u8 *p = indexBuf;
         int remaining = indexSize;
@@ -445,14 +389,14 @@ static int gcRewriteFile(
         }
       }
 
-      /* Sync — durability point */
+      
       if( rc==SQLITE_OK ){
         rc = sqlite3OsSync(pTmpFile, SQLITE_SYNC_NORMAL);
       }
       sqlite3OsCloseFree(pTmpFile);
 
       if( rc==SQLITE_OK ){
-        /* Close the old file handle before rename */
+        
         if( cs->pFile ){
           sqlite3OsCloseFree(cs->pFile);
           cs->pFile = 0;
@@ -468,7 +412,7 @@ static int gcRewriteFile(
           cs->nWalData = 0;
         }
 
-        /* Reopen via VFS for subsequent operations */
+        
         if( rc==SQLITE_OK ){
           int reopenFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB;
           rc = sqlite3OsOpenMalloc(cs->pVfs, cs->zFilename, &cs->pFile,
@@ -498,7 +442,7 @@ static int gcSweep(
   int nBuf = 0;
   int rc = SQLITE_OK;
 
-  /* Count survivors and removals */
+  
   for(i=0; i<cs->nIndex; i++){
     if( prollyHashSetContains(marked, &cs->aIndex[i].hash) ){
       kept++;
@@ -518,14 +462,14 @@ static int gcSweep(
     return SQLITE_OK;
   }
 
-  /* Build compacted data and index */
+  
   rc = gcBuildCompactedData(cs, marked, &buf, &nBuf, &aNewIndex, &nNewIndex);
   if( rc!=SQLITE_OK ) return rc;
 
-  /* Rewrite the file */
+  
   rc = gcRewriteFile(cs, buf, nBuf, aNewIndex, nNewIndex);
 
-  /* Update in-memory state */
+  
   if( rc==SQLITE_OK ){
     int indexSize = nNewIndex * CHUNK_INDEX_ENTRY_SIZE;
     sqlite3_free(cs->aIndex);
@@ -536,7 +480,7 @@ static int gcSweep(
     cs->iIndexOffset = CHUNK_MANIFEST_SIZE + nBuf;
     cs->nIndexSize = indexSize;
     cs->iWalOffset = CHUNK_MANIFEST_SIZE + nBuf + indexSize;
-    aNewIndex = 0;  /* ownership transferred */
+    aNewIndex = 0;  
 
     cs->nPending = 0;
     cs->nWriteBuf = 0;
@@ -549,10 +493,6 @@ static int gcSweep(
   *pRemoved = removed;
   return rc;
 }
-
-/* ----------------------------------------------------------------
-** dolt_gc() SQL function.
-** ---------------------------------------------------------------- */
 
 static void doltliteGcFunc(
   sqlite3_context *context,
@@ -574,7 +514,7 @@ static void doltliteGcFunc(
     return;
   }
 
-  /* In-memory databases don't need GC (no file to compact) */
+  
   if( !cs->zFilename || strcmp(cs->zFilename, ":memory:")==0 ){
     sqlite3_result_text(context, "0 chunks removed, 0 chunks kept (in-memory)", -1, SQLITE_TRANSIENT);
     return;
@@ -586,7 +526,7 @@ static void doltliteGcFunc(
     return;
   }
 
-  /* Mark phase */
+  
   rc = gcMarkReachable(cs, &marked);
   if( rc!=SQLITE_OK ){
     prollyHashSetFree(&marked);
@@ -594,7 +534,7 @@ static void doltliteGcFunc(
     return;
   }
 
-  /* Sweep phase */
+  
   rc = gcSweep(cs, &marked, &nKept, &nRemoved);
   prollyHashSetFree(&marked);
 
@@ -608,10 +548,6 @@ static void doltliteGcFunc(
   sqlite3_result_text(context, result, -1, SQLITE_TRANSIENT);
 }
 
-/* ----------------------------------------------------------------
-** Non-SQL entry point for GC compaction (used by PRAGMA wal_checkpoint).
-** ---------------------------------------------------------------- */
-
 int doltliteGcCompact(sqlite3 *db){
   ChunkStore *cs = doltliteGetChunkStore(db);
   ProllyHashSet marked;
@@ -620,7 +556,7 @@ int doltliteGcCompact(sqlite3 *db){
 
   if( !cs ) return SQLITE_OK;
   if( !cs->zFilename || strcmp(cs->zFilename, ":memory:")==0 ){
-    return SQLITE_OK;  /* In-memory databases don't need compaction */
+    return SQLITE_OK;  
   }
 
   rc = prollyHashSetInit(&marked, cs->nIndex > 64 ? cs->nIndex : 64);
@@ -634,13 +570,9 @@ int doltliteGcCompact(sqlite3 *db){
   return rc;
 }
 
-/* ----------------------------------------------------------------
-** Registration.
-** ---------------------------------------------------------------- */
-
 int doltliteGcRegister(sqlite3 *db){
   return sqlite3_create_function(db, "dolt_gc", 0, SQLITE_UTF8, 0,
                                   doltliteGcFunc, 0, 0);
 }
 
-#endif /* DOLTLITE_PROLLY */
+#endif 

--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -80,6 +80,10 @@ static int isProllyNodeChunk(const u8 *data, int nData){
   return m == PROLLY_NODE_MAGIC_VAL;
 }
 
+/* BFS from all roots (manifest hashes + all branch/tag refs + working sets)
+** to mark every reachable chunk. Understands three chunk types: prolly nodes
+** (recurse into children), commits (follow parents + catalog), and catalog
+** blobs (follow table root hashes). */
 static int gcMarkReachable(
   ChunkStore *cs,
   ProllyHashSet *marked
@@ -397,6 +401,8 @@ static int gcRewriteFile(
 
       if( rc==SQLITE_OK ){
         
+        /* Close the old file before rename. The file handle must be released
+        ** first or rename() will fail on Windows. After rename, reopen. */
         if( cs->pFile ){
           sqlite3OsCloseFree(cs->pFile);
           cs->pFile = 0;

--- a/src/doltlite_history.c
+++ b/src/doltlite_history.c
@@ -1,12 +1,4 @@
-/*
-** dolt_history_<tablename> — time-travel virtual tables.
-**
-** Shows every version of every row across all commits with per-column
-** schema matching the actual table:
-**
-**   SELECT * FROM dolt_history_users;
-**   -- id | name | email | commit_hash | committer | commit_date
-*/
+
 #ifdef DOLTLITE_PROLLY
 
 #include "sqliteInt.h"
@@ -20,12 +12,6 @@
 #include "doltlite_internal.h"
 #include <string.h>
 #include <time.h>
-
-/* Varint reader: use shared dlReadVarint from doltlite_record.h */
-
-/* --------------------------------------------------------------------------
-** Record field parsing and result setting (same as dolt_diff_table.c)
-** -------------------------------------------------------------------------- */
 
 #define HT_MAX_COLS 64
 
@@ -69,8 +55,6 @@ static void htResultField(sqlite3_context *ctx, const u8 *pData, int nData, int 
   sqlite3_result_null(ctx);
 }
 
-
-
 static char *htBuildSchema(DoltliteColInfo *ci){
   int i, sz=256;
   char *z;
@@ -85,10 +69,6 @@ static char *htBuildSchema(DoltliteColInfo *ci){
   return z;
 }
 
-/* --------------------------------------------------------------------------
-** Buffered history row
-** -------------------------------------------------------------------------- */
-
 typedef struct HistoryRow HistoryRow;
 struct HistoryRow {
   i64 intKey;
@@ -97,10 +77,6 @@ struct HistoryRow {
   char *zCommitter;
   i64 commitDate;
 };
-
-/* --------------------------------------------------------------------------
-** Virtual table structures
-** -------------------------------------------------------------------------- */
 
 typedef struct HistVtab HistVtab;
 struct HistVtab {
@@ -129,10 +105,6 @@ static void freeHistoryRows(HistCursor *c){
   c->aRows=0; c->nRows=0; c->nAlloc=0;
 }
 
-/* --------------------------------------------------------------------------
-** Find table root by name
-** -------------------------------------------------------------------------- */
-
 static int htFindRoot(struct TableEntry *a, int n, const char *zName,
                       ProllyHash *pRoot, u8 *pFlags){
   struct TableEntry *e = doltliteFindTableByName(a, n, zName);
@@ -144,10 +116,6 @@ static int htFindRoot(struct TableEntry *a, int n, const char *zName,
   memset(pRoot,0,sizeof(ProllyHash)); if(pFlags)*pFlags=0;
   return SQLITE_NOTFOUND;
 }
-
-/* --------------------------------------------------------------------------
-** Scan all rows from a table at a given commit
-** -------------------------------------------------------------------------- */
 
 static int htScanAtCommit(
   HistCursor *pCur, ChunkStore *cs, ProllyCache *pCache,
@@ -180,10 +148,6 @@ static int htScanAtCommit(
   prollyCursorClose(&cur); return SQLITE_OK;
 }
 
-/* --------------------------------------------------------------------------
-** Walk commit history
-** -------------------------------------------------------------------------- */
-
 static int htWalkHistory(HistCursor *pCur, sqlite3 *db, const char *zTableName){
   ChunkStore *cs=doltliteGetChunkStore(db);
   ProllyCache *pCache; ProllyHash curHash; int rc;
@@ -213,10 +177,6 @@ static int htWalkHistory(HistCursor *pCur, sqlite3 *db, const char *zTableName){
   }
   return SQLITE_OK;
 }
-
-/* --------------------------------------------------------------------------
-** Virtual table methods
-** -------------------------------------------------------------------------- */
 
 static int htConnect(sqlite3 *db, void *pAux, int argc,
     const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){
@@ -292,15 +252,15 @@ static int htColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
   r=&c->aRows[c->iRow];
   int nCols=v->cols.nCol;
 
-  /* Layout: col 0..nCols-1 = table columns, then commit_hash, committer, commit_date */
+  
 
   if(nCols>0 && col<nCols){
-    /* Table column */
+    
     if(col==v->cols.iPkCol){
-      /* INTEGER PRIMARY KEY = rowid */
+      
       sqlite3_result_int64(ctx,r->intKey);
     }else{
-      /* Decode from record */
+      
       if(r->pVal&&r->nVal>0){
         HtRecInfo ri; htParseRecord(r->pVal,r->nVal,&ri);
         if(col<ri.nField) htResultField(ctx,r->pVal,r->nVal,ri.aType[col],ri.aOffset[col]);
@@ -311,9 +271,9 @@ static int htColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
     int fixedCol=col-nCols;
     if(nCols==0) fixedCol=col;
     switch(fixedCol){
-      case 0: /* commit_hash */
+      case 0: 
         if(nCols==0){
-          /* fallback: value as text */
+          
           char *z=doltliteDecodeRecord(r->pVal,r->nVal);
           if(z) sqlite3_result_text(ctx,z,-1,sqlite3_free);
           else sqlite3_result_null(ctx);
@@ -321,10 +281,10 @@ static int htColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
           sqlite3_result_text(ctx,r->zCommit,-1,SQLITE_TRANSIENT);
         }
         break;
-      case 1: /* committer */
+      case 1: 
         sqlite3_result_text(ctx,r->zCommitter,-1,SQLITE_TRANSIENT);
         break;
-      case 2: /* commit_date */
+      case 2: 
         {time_t t=(time_t)r->commitDate;struct tm *tm=gmtime(&t);
           if(tm){char b[32];strftime(b,sizeof(b),"%Y-%m-%d %H:%M:%S",tm);
             sqlite3_result_text(ctx,b,-1,SQLITE_TRANSIENT);
@@ -344,10 +304,6 @@ static sqlite3_module historyModule = {
   htOpen, htClose, htFilter, htNext, htEof, htColumn, htRowid,
   0,0,0,0,0,0,0,0,0,0,0,0
 };
-
-/* --------------------------------------------------------------------------
-** Registration
-** -------------------------------------------------------------------------- */
 
 void doltliteRegisterHistoryTables(sqlite3 *db){
   ChunkStore *cs=doltliteGetChunkStore(db);
@@ -371,4 +327,4 @@ void doltliteRegisterHistoryTables(sqlite3 *db){
   sqlite3_free(aT);
 }
 
-#endif /* DOLTLITE_PROLLY */
+#endif 

--- a/src/doltlite_http_remote.c
+++ b/src/doltlite_http_remote.c
@@ -1,13 +1,4 @@
-/*
-** HTTP remote client for Doltlite.
-**
-** Implements the DoltliteRemote vtable over HTTP, communicating with
-** the doltlite HTTP remote server.  Uses raw BSD sockets — no libcurl
-** or other external dependencies.
-**
-** URL format:  http://host:port/dbname
-** The dbname becomes the base path (e.g., "/dbname").
-*/
+
 #ifdef DOLTLITE_PROLLY
 
 #include "sqliteInt.h"
@@ -20,37 +11,29 @@
 #include <errno.h>
 
 #ifdef _WIN32
-/* HTTP remote not yet ported to Windows (requires Winsock) */
+
 void doltliteRegisterHttpRemote(sqlite3 *db){ (void)db; }
 DoltliteRemote *doltliteHttpRemoteOpen(const char *zUrl){ (void)zUrl; return 0; }
-#else /* POSIX */
+#else 
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <netdb.h>
 #include <unistd.h>
 
-/* ----------------------------------------------------------------
-** HttpRemote structure
-** ---------------------------------------------------------------- */
-
 typedef struct HttpRemote HttpRemote;
 struct HttpRemote {
-  DoltliteRemote base;     /* vtable — must be first */
-  char *zHost;             /* e.g., "localhost" */
-  int port;                /* e.g., 8080 */
-  char *zBasePath;         /* e.g., "/v1" */
-  /* Upload buffer: accumulate chunks during push, flush on commit */
+  DoltliteRemote base;     
+  char *zHost;             
+  int port;                
+  char *zBasePath;         
+  
   u8 *pUploadBuf;
   i64 nUploadBuf;
   i64 nUploadBufAlloc;
-  /* Pending refs update */
+  
   u8 *pPendingRefs;
   int nPendingRefs;
 };
-
-/* ----------------------------------------------------------------
-** Hash-to-hex helper
-** ---------------------------------------------------------------- */
 
 static void hashToHex(const ProllyHash *pHash, char *zOut){
   static const char hex[] = "0123456789abcdef";
@@ -62,14 +45,6 @@ static void hashToHex(const ProllyHash *pHash, char *zOut){
   zOut[PROLLY_HASH_SIZE*2] = 0;
 }
 
-/* ----------------------------------------------------------------
-** Minimal HTTP client (no libcurl)
-** ---------------------------------------------------------------- */
-
-/*
-** Read all available data from fd until EOF.
-** Caller frees *ppOut with sqlite3_free.
-*/
 static int readUntilEof(int fd, u8 **ppOut, int *pnOut){
   int nAlloc = 4096;
   int nUsed = 0;
@@ -101,18 +76,13 @@ static int readUntilEof(int fd, u8 **ppOut, int *pnOut){
   return SQLITE_OK;
 }
 
-/*
-** Perform a single HTTP request. Returns SQLITE_OK on success.
-** Response body is returned in *ppResp (caller frees), *pnResp.
-** *pStatus is the HTTP status code (200, 404, etc.)
-*/
 static int httpRequest(
   const char *zHost, int port,
-  const char *zMethod,        /* "GET", "POST", "PUT" */
-  const char *zPath,          /* "/v1/root" */
-  const u8 *pBody, int nBody, /* Request body (NULL for GET) */
-  int *pStatus,               /* OUT: HTTP status code */
-  u8 **ppResp, int *pnResp   /* OUT: Response body */
+  const char *zMethod,        
+  const char *zPath,          
+  const u8 *pBody, int nBody, 
+  int *pStatus,               
+  u8 **ppResp, int *pnResp   
 ){
   int fd = -1;
   struct sockaddr_in addr;
@@ -127,11 +97,11 @@ static int httpRequest(
   *ppResp = 0;
   *pnResp = 0;
 
-  /* Resolve host */
+  
   he = gethostbyname(zHost);
   if( !he ) return SQLITE_ERROR;
 
-  /* Create socket and connect */
+  
   fd = socket(AF_INET, SOCK_STREAM, 0);
   if( fd < 0 ) return SQLITE_ERROR;
 
@@ -145,7 +115,7 @@ static int httpRequest(
     return SQLITE_ERROR;
   }
 
-  /* Build request headers */
+  
   if( pBody && nBody > 0 ){
     nReqHdr = snprintf(aReqHdr, sizeof(aReqHdr),
       "%s %s HTTP/1.1\r\n"
@@ -164,7 +134,7 @@ static int httpRequest(
       zMethod, zPath, zHost);
   }
 
-  /* Send request */
+  
   {
     ssize_t nSent = write(fd, aReqHdr, nReqHdr);
     if( nSent != nReqHdr ){ close(fd); return SQLITE_ERROR; }
@@ -178,13 +148,13 @@ static int httpRequest(
     }
   }
 
-  /* Read entire response */
+  
   rc = readUntilEof(fd, &pRaw, &nRaw);
   close(fd);
   fd = -1;
   if( rc != SQLITE_OK ) return rc;
 
-  /* Parse status line: "HTTP/1.x NNN ...\r\n" */
+  
   {
     int i;
     int statusStart = -1;
@@ -192,7 +162,7 @@ static int httpRequest(
       if( pRaw[i]==' ' && statusStart<0 ){
         statusStart = i + 1;
       }else if( statusStart>=0 && (pRaw[i]==' ' || pRaw[i]=='\r') ){
-        /* Parse 3-digit status code */
+        
         char aBuf[4];
         int len = i - statusStart;
         if( len>=1 && len<=3 ){
@@ -205,18 +175,18 @@ static int httpRequest(
     }
   }
 
-  /* Find end of headers: \r\n\r\n */
+  
   {
     int i;
     int bodyStart = -1;
     int contentLength = -1;
 
     for(i=0; i<nRaw-3; i++){
-      /* Look for Content-Length header */
+      
       if( (i==0 || pRaw[i-1]=='\n') &&
           nRaw-i > 16 &&
           (pRaw[i]=='C' || pRaw[i]=='c') ){
-        /* Case-insensitive check for "Content-Length:" */
+        
         if( sqlite3_strnicmp((const char*)pRaw+i, "Content-Length:", 15)==0 ){
           contentLength = atoi((const char*)pRaw+i+15);
         }
@@ -228,12 +198,12 @@ static int httpRequest(
     }
 
     if( bodyStart < 0 ){
-      /* No headers found — treat entire raw as empty response */
+      
       sqlite3_free(pRaw);
       return SQLITE_OK;
     }
 
-    /* Extract body */
+    
     {
       int nAvail = nRaw - bodyStart;
       int nCopy;
@@ -258,10 +228,6 @@ static int httpRequest(
   return SQLITE_OK;
 }
 
-/* ----------------------------------------------------------------
-** Append to dynamic upload buffer (realloc pattern).
-** ---------------------------------------------------------------- */
-
 static int uploadBufAppend(HttpRemote *p, const u8 *pData, int nData){
   if( p->nUploadBuf + nData > p->nUploadBufAlloc ){
     i64 nNew = p->nUploadBufAlloc ? p->nUploadBufAlloc * 2 : 4096;
@@ -276,10 +242,6 @@ static int uploadBufAppend(HttpRemote *p, const u8 *pData, int nData){
   return SQLITE_OK;
 }
 
-/* ----------------------------------------------------------------
-** Build a full path: basePath + suffix
-** ---------------------------------------------------------------- */
-
 static char *buildPath(HttpRemote *p, const char *zSuffix){
   int nBase = (int)strlen(p->zBasePath);
   int nSuffix = (int)strlen(zSuffix);
@@ -290,10 +252,6 @@ static char *buildPath(HttpRemote *p, const char *zSuffix){
   }
   return z;
 }
-
-/* ----------------------------------------------------------------
-** VTable implementations
-** ---------------------------------------------------------------- */
 
 static int httpHasChunks(DoltliteRemote *pRemote, const ProllyHash *aHash,
                          int nHash, u8 *aResult){
@@ -308,7 +266,7 @@ static int httpHasChunks(DoltliteRemote *pRemote, const ProllyHash *aHash,
 
   if( nHash <= 0 ) return SQLITE_OK;
 
-  /* Build request body: nHash * PROLLY_HASH_SIZE bytes (concatenated hashes) */
+  
   nReqBody = nHash * PROLLY_HASH_SIZE;
   pReqBody = sqlite3_malloc(nReqBody);
   if( !pReqBody ) return SQLITE_NOMEM;
@@ -331,11 +289,11 @@ static int httpHasChunks(DoltliteRemote *pRemote, const ProllyHash *aHash,
     return SQLITE_ERROR;
   }
 
-  /* Response: nHash bytes, each 0 or 1 */
+  
   if( nResp >= nHash ){
     memcpy(aResult, pResp, nHash);
   }else{
-    /* Short response — treat missing as absent */
+    
     int i;
     if( nResp > 0 ) memcpy(aResult, pResp, nResp);
     for(i=nResp; i<nHash; i++) aResult[i] = 0;
@@ -391,7 +349,7 @@ static int httpPutChunk(DoltliteRemote *pRemote, const ProllyHash *pHash,
   u8 aLen[4];
   int rc;
 
-  /* Append to upload buffer: hash(20) + length(4 LE) + data(length) */
+  
   rc = uploadBufAppend(p, pHash->data, PROLLY_HASH_SIZE);
   if( rc != SQLITE_OK ) return rc;
 
@@ -445,7 +403,7 @@ static int httpGetRefs(DoltliteRemote *pRemote, u8 **ppData, int *pnData){
 static int httpSetRefs(DoltliteRemote *pRemote, const u8 *pData, int nData){
   HttpRemote *p = (HttpRemote*)pRemote;
 
-  /* Free any previous pending refs */
+  
   sqlite3_free(p->pPendingRefs);
   p->pPendingRefs = 0;
   p->nPendingRefs = 0;
@@ -467,7 +425,7 @@ static int httpCommit(DoltliteRemote *pRemote){
   int rc;
   char *zPath;
 
-  /* 1. If upload buffer has data: POST /v1/chunks with entire buffer */
+  
   if( p->pUploadBuf && p->nUploadBuf > 0 ){
     zPath = buildPath(p, "/chunks");
     if( !zPath ) return SQLITE_NOMEM;
@@ -481,7 +439,7 @@ static int httpCommit(DoltliteRemote *pRemote){
     if( status != 200 && status != 204 ) return SQLITE_ERROR;
   }
 
-  /* 2. If pending refs: PUT /v1/refs with refs data */
+  
   if( p->pPendingRefs && p->nPendingRefs > 0 ){
     pResp = 0; nResp = 0; status = 0;
     zPath = buildPath(p, "/refs");
@@ -496,7 +454,7 @@ static int httpCommit(DoltliteRemote *pRemote){
     if( status != 200 && status != 204 ) return SQLITE_ERROR;
   }
 
-  /* 3. POST /v1/commit to finalize */
+  
   {
     pResp = 0; nResp = 0; status = 0;
     zPath = buildPath(p, "/commit");
@@ -510,7 +468,7 @@ static int httpCommit(DoltliteRemote *pRemote){
     if( status != 200 && status != 204 ) return SQLITE_ERROR;
   }
 
-  /* 4. Clear buffers */
+  
   sqlite3_free(p->pUploadBuf);
   p->pUploadBuf = 0;
   p->nUploadBuf = 0;
@@ -532,17 +490,6 @@ static void httpClose(DoltliteRemote *pRemote){
   sqlite3_free(p);
 }
 
-/* ----------------------------------------------------------------
-** Constructor: parse URL and create HttpRemote
-** ---------------------------------------------------------------- */
-
-/*
-** Open an HTTP remote. Parses URL like "http://host:port/path"
-**
-** Examples:
-**   http://localhost:8080/mydb       -> host=localhost, port=8080, path=/mydb
-**   http://example.com:3000/myrepo   -> host=example.com, port=3000, path=/myrepo
-*/
 DoltliteRemote *doltliteHttpRemoteOpen(const char *zUrl){
   HttpRemote *p;
   const char *zAfterScheme;
@@ -556,12 +503,12 @@ DoltliteRemote *doltliteHttpRemoteOpen(const char *zUrl){
 
   if( !zUrl ) return 0;
 
-  /* Skip "http://" */
+  
   if( strncmp(zUrl, "http://", 7) != 0 ) return 0;
   zAfterScheme = zUrl + 7;
   zHostStart = zAfterScheme;
 
-  /* Find end of host (colon for port, slash for path, or end of string) */
+  
   zPortStart = 0;
   zPathStart = 0;
   {
@@ -582,22 +529,22 @@ DoltliteRemote *doltliteHttpRemoteOpen(const char *zUrl){
 
   if( nHost <= 0 ) return 0;
 
-  /* Calculate user path length (0 if no path, excludes trailing slash) */
+  
   nUserPath = 0;
   if( zPathStart ){
     nUserPath = (int)strlen(zPathStart);
-    /* Strip trailing slash */
+    
     while( nUserPath > 0 && zPathStart[nUserPath-1] == '/' ){
       nUserPath--;
     }
   }
 
-  /* Allocate and populate */
+  
   p = sqlite3_malloc(sizeof(HttpRemote));
   if( !p ) return 0;
   memset(p, 0, sizeof(HttpRemote));
 
-  /* Copy host */
+  
   p->zHost = sqlite3_malloc(nHost + 1);
   if( !p->zHost ){
     sqlite3_free(p);
@@ -608,10 +555,10 @@ DoltliteRemote *doltliteHttpRemoteOpen(const char *zUrl){
 
   p->port = port;
 
-  /* Build base path from URL path (e.g., "/dbname") */
+  
   nBasePath = nUserPath;
   if( nBasePath <= 0 ){
-    /* No path in URL -- invalid for multi-db server */
+    
     sqlite3_free(p->zHost);
     sqlite3_free(p);
     return 0;
@@ -625,7 +572,7 @@ DoltliteRemote *doltliteHttpRemoteOpen(const char *zUrl){
   memcpy(p->zBasePath, zPathStart, nBasePath);
   p->zBasePath[nBasePath] = '\0';
 
-  /* Wire up vtable */
+  
   p->base.xGetChunk = httpGetChunk;
   p->base.xPutChunk = httpPutChunk;
   p->base.xHasChunks = httpHasChunks;
@@ -637,5 +584,5 @@ DoltliteRemote *doltliteHttpRemoteOpen(const char *zUrl){
   return &p->base;
 }
 
-#endif /* !_WIN32 */
-#endif /* DOLTLITE_PROLLY */
+#endif 
+#endif 

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -1,35 +1,18 @@
-/*
-** Shared declarations for the doltlite_*.c integration layer.
-**
-** This header consolidates struct definitions and function declarations
-** used across multiple doltlite_*.c files. Include this instead of
-** repeating extern declarations in each file.
-*/
+
 #ifndef DOLTLITE_INTERNAL_H
 #define DOLTLITE_INTERNAL_H
 
-/*
-** This header assumes the consumer has already included sqliteInt.h,
-** prolly_hash.h, and chunk_store.h (all doltlite_*.c files do).
-*/
 typedef struct BtShared BtShared;
 typedef struct ProllyCache ProllyCache;
 
-/*
-** A single table entry from the catalog.  Returned by doltliteLoadCatalog().
-** The pPending field is opaque to the doltlite layer (it is a ProllyMutMap*
-** managed by prolly_btree.c).
-*/
 struct TableEntry {
-  Pgno iTable;           /* Logical table number */
-  ProllyHash root;       /* Current root hash of this table's prolly tree */
-  ProllyHash schemaHash; /* Hash of this table's CREATE TABLE SQL */
-  u8 flags;              /* BTREE_INTKEY or BTREE_BLOBKEY */
-  char *zName;           /* Table name (owned, NULL for internal tables) */
-  void *pPending;        /* Deferred edits (opaque to doltlite layer) */
+  Pgno iTable;           
+  ProllyHash root;       
+  ProllyHash schemaHash; 
+  u8 flags;              
+  char *zName;           
+  void *pPending;        
 };
-
-/* --- Catalog lookup helpers --- */
 
 static SQLITE_INLINE struct TableEntry *doltliteFindTableByNumber(
   struct TableEntry *a, int n, Pgno iTable
@@ -52,8 +35,6 @@ static SQLITE_INLINE struct TableEntry *doltliteFindTableByName(
   return 0;
 }
 
-/* --- Data access (defined in prolly_btree.c) --- */
-
 ChunkStore *doltliteGetChunkStore(sqlite3 *db);
 BtShared *doltliteGetBtShared(sqlite3 *db);
 ProllyCache *doltliteGetCache(sqlite3 *db);
@@ -65,8 +46,6 @@ int doltliteFlushAndSerializeCatalog(sqlite3 *db, u8 **ppOut, int *pnOut);
 int doltliteResolveTableName(sqlite3 *db, const char *zTable, Pgno *piTable);
 char *doltliteResolveTableNumber(sqlite3 *db, Pgno iTable);
 int doltliteHardReset(sqlite3 *db, const ProllyHash *catHash);
-
-/* --- Per-connection session state (defined in prolly_btree.c) --- */
 
 const char *doltliteGetSessionBranch(sqlite3 *db);
 void doltliteSetSessionBranch(sqlite3 *db, const char *zBranch);
@@ -85,11 +64,9 @@ void doltliteGetSessionConflictsCatalog(sqlite3 *db, ProllyHash *pHash);
 void doltliteSetSessionConflictsCatalog(sqlite3 *db, const ProllyHash *pHash);
 int doltliteSaveWorkingSet(sqlite3 *db);
 
-/* --- Author info (defined in prolly_btree.c) --- */
-
 const char *doltliteGetAuthorName(sqlite3 *db);
 void doltliteSetAuthorName(sqlite3 *db, const char *zName);
 const char *doltliteGetAuthorEmail(sqlite3 *db);
 void doltliteSetAuthorEmail(sqlite3 *db, const char *zEmail);
 
-#endif /* DOLTLITE_INTERNAL_H */
+#endif 

--- a/src/doltlite_log.c
+++ b/src/doltlite_log.c
@@ -1,10 +1,4 @@
-/*
-** dolt_log virtual table: walks the commit chain from HEAD.
-**
-** Usage:
-**   SELECT * FROM dolt_log;
-**   SELECT commit_hash, message FROM dolt_log LIMIT 10;
-*/
+
 #ifdef DOLTLITE_PROLLY
 
 #include "sqliteInt.h"
@@ -15,10 +9,6 @@
 #include "doltlite_internal.h"
 #include <time.h>
 
-/* --------------------------------------------------------------------------
-** Virtual table structure
-** -------------------------------------------------------------------------- */
-
 typedef struct DoltliteLogVtab DoltliteLogVtab;
 struct DoltliteLogVtab {
   sqlite3_vtab base;
@@ -28,16 +18,12 @@ struct DoltliteLogVtab {
 typedef struct DoltliteLogCursor DoltliteLogCursor;
 struct DoltliteLogCursor {
   sqlite3_vtab_cursor base;
-  ProllyHash currentHash;      /* Hash of current commit */
-  DoltliteCommit current;      /* Deserialized current commit */
-  int eof;                     /* True if no more commits */
-  i64 iRow;                 /* Row counter */
-  char zHashHex[PROLLY_HASH_SIZE*2+1]; /* Hex string of currentHash */
+  ProllyHash currentHash;      
+  DoltliteCommit current;      
+  int eof;                     
+  i64 iRow;                 
+  char zHashHex[PROLLY_HASH_SIZE*2+1]; 
 };
-
-/* --------------------------------------------------------------------------
-** Schema
-** -------------------------------------------------------------------------- */
 
 static const char *doltliteLogSchema =
   "CREATE TABLE x("
@@ -47,10 +33,6 @@ static const char *doltliteLogSchema =
   "  date TEXT,"
   "  message TEXT"
   ")";
-
-/* --------------------------------------------------------------------------
-** Load a commit by hash from the chunk store
-** -------------------------------------------------------------------------- */
 
 static int loadCommit(sqlite3 *db, const ProllyHash *hash,
                       DoltliteCommit *pCommit){
@@ -69,10 +51,6 @@ static int loadCommit(sqlite3 *db, const ProllyHash *hash,
   sqlite3_free(data);
   return rc;
 }
-
-/* --------------------------------------------------------------------------
-** Virtual table methods
-** -------------------------------------------------------------------------- */
 
 static int doltliteLogConnect(
   sqlite3 *db,
@@ -127,7 +105,7 @@ static int doltliteLogNext(sqlite3_vtab_cursor *pCursor){
   ProllyHash parent;
   int rc;
 
-  /* Follow parent pointer */
+  
   memcpy(&parent, &pCur->current.parentHash, sizeof(ProllyHash));
   doltliteCommitClear(&pCur->current);
 
@@ -141,7 +119,7 @@ static int doltliteLogNext(sqlite3_vtab_cursor *pCursor){
   rc = loadCommit(pVtab->db, &pCur->currentHash, &pCur->current);
   if( rc!=SQLITE_OK ){
     pCur->eof = 1;
-    return SQLITE_OK;  /* Treat missing parent as end of log */
+    return SQLITE_OK;  
   }
   pCur->iRow++;
   return SQLITE_OK;
@@ -158,14 +136,14 @@ static int doltliteLogFilter(
   int rc;
   (void)idxNum; (void)idxStr; (void)argc; (void)argv;
 
-  /* Start from HEAD */
+  
   cs = doltliteGetChunkStore(pVtab->db);
   if( !cs ){
     pCur->eof = 1;
     return SQLITE_OK;
   }
 
-  /* Use this session's HEAD, not the shared store's */
+  
   doltliteGetSessionHead(pVtab->db, &pCur->currentHash);
   if( prollyHashIsEmpty(&pCur->currentHash) ){
     pCur->eof = 1;
@@ -195,18 +173,18 @@ static int doltliteLogColumn(
   DoltliteLogCursor *pCur = (DoltliteLogCursor*)pCursor;
 
   switch( iCol ){
-    case 0: /* commit_hash */
+    case 0: 
       sqlite3_result_text(ctx, pCur->zHashHex, -1, SQLITE_TRANSIENT);
       break;
-    case 1: /* committer */
+    case 1: 
       sqlite3_result_text(ctx, pCur->current.zName ? pCur->current.zName : "",
                           -1, SQLITE_TRANSIENT);
       break;
-    case 2: /* email */
+    case 2: 
       sqlite3_result_text(ctx, pCur->current.zEmail ? pCur->current.zEmail : "",
                           -1, SQLITE_TRANSIENT);
       break;
-    case 3: /* date */
+    case 3: 
       {
         time_t t = (time_t)pCur->current.timestamp;
         struct tm *tm = gmtime(&t);
@@ -219,7 +197,7 @@ static int doltliteLogColumn(
         }
       }
       break;
-    case 4: /* message */
+    case 4: 
       sqlite3_result_text(ctx, pCur->current.zMessage ? pCur->current.zMessage : "",
                           -1, SQLITE_TRANSIENT);
       break;
@@ -239,40 +217,36 @@ static int doltliteLogBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
   return SQLITE_OK;
 }
 
-/* --------------------------------------------------------------------------
-** Module definition
-** -------------------------------------------------------------------------- */
-
 static sqlite3_module doltliteLogModule = {
-  0,                         /* iVersion */
-  0,                         /* xCreate (not used for eponymous) */
-  doltliteLogConnect,        /* xConnect */
-  doltliteLogBestIndex,      /* xBestIndex */
-  doltliteLogDisconnect,     /* xDisconnect */
-  0,                         /* xDestroy */
-  doltliteLogOpen,           /* xOpen */
-  doltliteLogClose,          /* xClose */
-  doltliteLogFilter,         /* xFilter */
-  doltliteLogNext,           /* xNext */
-  doltliteLogEof,            /* xEof */
-  doltliteLogColumn,         /* xColumn */
-  doltliteLogRowid,          /* xRowid */
-  0,                         /* xUpdate */
-  0,                         /* xBegin */
-  0,                         /* xSync */
-  0,                         /* xCommit */
-  0,                         /* xRollback */
-  0,                         /* xFindFunction */
-  0,                         /* xRename */
-  0,                         /* xSavepoint */
-  0,                         /* xRelease */
-  0,                         /* xRollbackTo */
-  0,                         /* xShadowName */
-  0                          /* xIntegrity */
+  0,                         
+  0,                         
+  doltliteLogConnect,        
+  doltliteLogBestIndex,      
+  doltliteLogDisconnect,     
+  0,                         
+  doltliteLogOpen,           
+  doltliteLogClose,          
+  doltliteLogFilter,         
+  doltliteLogNext,           
+  doltliteLogEof,            
+  doltliteLogColumn,         
+  doltliteLogRowid,          
+  0,                         
+  0,                         
+  0,                         
+  0,                         
+  0,                         
+  0,                         
+  0,                         
+  0,                         
+  0,                         
+  0,                         
+  0,                         
+  0                          
 };
 
 int doltliteLogRegister(sqlite3 *db){
   return sqlite3_create_module(db, "dolt_log", &doltliteLogModule, 0);
 }
 
-#endif /* DOLTLITE_PROLLY */
+#endif 

--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -1,4 +1,18 @@
-
+/*
+** Three-way catalog merge. Algorithm:
+**  1. Load ancestor/ours/theirs catalogs (table lists).
+**  2. Pass 1 (mergeCatalogPass1): for each table in "ours", compare against
+**     ancestor and theirs. If both sides changed the same table, perform a
+**     row-level three-way merge via prollyThreeWayDiff, attempting per-field
+**     cell merge for modify/modify conflicts before recording true conflicts.
+**  3. Pass 2 (mergeCatalogPass2): add tables that exist only in "theirs"
+**     (new tables added on the other branch).
+**  4. Serialize the merged catalog and any conflict rows.
+**
+** Row-level merge: LEFT changes (ours) are already in the "ours" tree, so
+** only RIGHT changes (theirs) need to be applied as edits. Convergent
+** changes (both sides made the same edit) are no-ops.
+*/
 #ifdef DOLTLITE_PROLLY
 
 #include "sqliteInt.h"
@@ -269,7 +283,8 @@ static int rowMergeCallback(void *pCtx, const ThreeWayChange *pChange){
     case THREE_WAY_LEFT_ADD:
     case THREE_WAY_LEFT_MODIFY:
     case THREE_WAY_LEFT_DELETE:
-      
+      /* Left (ours) changes are already present in the "ours" tree that
+      ** we are mutating, so no edits needed. */
       break;
 
     case THREE_WAY_RIGHT_ADD:
@@ -297,7 +312,9 @@ static int rowMergeCallback(void *pCtx, const ThreeWayChange *pChange){
       break;
 
     case THREE_WAY_CONFLICT_MM: {
-      
+      /* Both sides modified the same row. Try per-field cell merge: if each
+      ** column was changed by at most one side, merge succeeds. Otherwise
+      ** fall through to record a conflict (intentional fallthrough to DM). */
       u8 *pMerged = 0;
       int nMerged = 0;
 
@@ -312,14 +329,13 @@ static int rowMergeCallback(void *pCtx, const ThreeWayChange *pChange){
       }
 
       if( pMerged ){
-        
         rc = prollyMutMapInsert(ctx->pEdits,
             pChange->pKey, pChange->nKey, pChange->intKey,
             pMerged, nMerged);
         sqlite3_free(pMerged);
         break;
       }
-      
+      /* FALLTHROUGH: cell merge failed, record as conflict */
     }
     case THREE_WAY_CONFLICT_DM: {
       

--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -1,15 +1,4 @@
-/*
-** Three-way catalog merge with conflict detection for Doltlite.
-**
-** Given three catalog hashes (ancestor, ours, theirs), produce a merged
-** catalog. For each table:
-**   - If only one side changed it, take that side's root hash.
-**   - If both sides changed the same table, return SQLITE_ERROR (conflict).
-**   - If a table was added on one side and doesn't exist on the other, include it.
-**   - If deleted on one side and unchanged on the other, delete it.
-**
-** Returns the merged catalog as a serialized chunk stored in the chunk store.
-*/
+
 #ifdef DOLTLITE_PROLLY
 
 #include "sqliteInt.h"
@@ -24,16 +13,10 @@
 #include "doltlite_internal.h"
 #include <string.h>
 
-/* From doltlite_conflicts.c */
 typedef struct ConflictTableInfo ConflictTableInfo;
 extern int doltliteSerializeConflicts(ChunkStore *cs, ConflictTableInfo *aTables,
                                        int nTables, ProllyHash *pHash);
 
-/*
-** Find a table entry by table number in an array of entries.
-** Returns a pointer to the entry, or NULL if not found.
-*/
-/* findTableEntry replaced by doltliteFindTableByNumber in doltlite_internal.h */
 static struct TableEntry *findTableEntry(
   struct TableEntry *aEntries,
   int nEntries,
@@ -42,16 +25,12 @@ static struct TableEntry *findTableEntry(
   return doltliteFindTableByNumber(aEntries, nEntries, iTable);
 }
 
-/*
-** Row-level merge context: collects non-conflicting edits into a MutMap
-** and conflicting rows into a list.
-*/
 typedef struct RowMergeCtx RowMergeCtx;
 struct RowMergeCtx {
-  ProllyMutMap *pEdits;      /* Non-conflicting edits to apply */
+  ProllyMutMap *pEdits;      
   u8 isIntKey;
   int nConflicts;
-  /* Conflict entries: stored as a simple array for later serialization */
+  
   struct ConflictRow {
     i64 intKey;
     u8 *pKey; int nKey;
@@ -62,22 +41,6 @@ struct RowMergeCtx {
   int nConflictsAlloc;
 };
 
-/* --------------------------------------------------------------------------
-** Cell-level (field-by-field) merge of SQLite record blobs.
-**
-** When both sides modify the same row, parse the three records and compare
-** each field. If changes don't overlap, build a merged record.
-**
-** Returns: merged record blob (caller frees) or NULL if there's a real
-**          field-level conflict.
-** -------------------------------------------------------------------------- */
-
-/* Varint reader: use shared dlReadVarint from doltlite_record.h */
-
-/* Serial type size: use shared dlSerialTypeLen from doltlite_record.h */
-
-/* Parse a record's fields into arrays of (serial_type, data_offset, data_len).
-** Returns number of fields, or -1 on error. */
 typedef struct RecField RecField;
 struct RecField { u64 st; int off; int len; };
 
@@ -118,7 +81,6 @@ static int parseRecordFields(const u8 *pRec, int nRec,
   return nFields;
 }
 
-/* Compare a single field between two records. Returns 0 if identical. */
 static int fieldEquals(const u8 *pRecA, RecField *fA,
                        const u8 *pRecB, RecField *fB){
   if(fA->st != fB->st) return 1;
@@ -127,30 +89,23 @@ static int fieldEquals(const u8 *pRecA, RecField *fA,
   return memcmp(pRecA + fA->off, pRecB + fB->off, fA->len);
 }
 
-/*
-** A winning field choice: the source record and which field within it.
-*/
 typedef struct MergeWinner MergeWinner;
 struct MergeWinner { const u8 *pRec; RecField *pField; };
 
-/*
-** Build a merged SQLite record blob from an array of per-field winners.
-** Returns the record (caller must sqlite3_free), or NULL on OOM.
-*/
 static u8 *buildMergedRecord(MergeWinner *aWinners, int nFields, int *pnOut){
   int hdrSize = 0, bodySize = 0, pos, i;
   u8 *result;
 
-  /* First pass: calculate header and body sizes */
+  
   for(i=0; i<nFields; i++){
     u64 st = aWinners[i].pField->st;
     if(st <= 0x7f) hdrSize += 1;
     else if(st <= 0x3fff) hdrSize += 2;
     else if(st <= 0x1fffff) hdrSize += 3;
-    else hdrSize += 4; /* good enough for practical values */
+    else hdrSize += 4; 
     bodySize += aWinners[i].pField->len;
   }
-  /* Header size varint (the header size includes the header size varint itself) */
+  
   { int tentative = hdrSize + 1;
     if(tentative > 0x7f) tentative++;
     hdrSize = tentative;
@@ -159,13 +114,13 @@ static u8 *buildMergedRecord(MergeWinner *aWinners, int nFields, int *pnOut){
   result = sqlite3_malloc(hdrSize + bodySize);
   if(!result){ *pnOut = 0; return 0; }
 
-  /* Write header size varint */
+  
   pos = 0;
   { u64 hs = (u64)hdrSize;
     if(hs <= 0x7f){ result[pos++] = (u8)hs; }
     else{ result[pos++] = (u8)(0x80 | (hs>>7)); result[pos++] = (u8)(hs&0x7f); }
   }
-  /* Write serial types */
+  
   for(i=0; i<nFields; i++){
     u64 st = aWinners[i].pField->st;
     if(st <= 0x7f){
@@ -184,7 +139,7 @@ static u8 *buildMergedRecord(MergeWinner *aWinners, int nFields, int *pnOut){
       result[pos++] = (u8)(st&0x7f);
     }
   }
-  /* Write body */
+  
   for(i=0; i<nFields; i++){
     if(aWinners[i].pField->len > 0){
       memcpy(result + pos, aWinners[i].pRec + aWinners[i].pField->off,
@@ -195,8 +150,7 @@ static u8 *buildMergedRecord(MergeWinner *aWinners, int nFields, int *pnOut){
 
   *pnOut = pos;
 
-  /* Verify round-trip: the manually constructed record should parse back correctly.
-  ** This guards against encoding/decoding divergence. */
+  
 #ifndef NDEBUG
   {
     int nfCheck = 0;
@@ -211,11 +165,6 @@ static u8 *buildMergedRecord(MergeWinner *aWinners, int nFields, int *pnOut){
   return result;
 }
 
-/*
-** Try to merge three records field-by-field.
-** Returns a new merged record blob (caller must sqlite3_free), or NULL
-** if there's a real field-level conflict.
-*/
 static u8 *tryCellMerge(
   const u8 *pBase, int nBase,
   const u8 *pOurs, int nOurs,
@@ -227,17 +176,17 @@ static u8 *tryCellMerge(
   int nfMax, i;
   u8 *result = 0;
 
-  /* Parse all three records */
+  
   if(parseRecordFields(pBase, nBase, &aBase, &nfBase)<0) goto fail;
   if(parseRecordFields(pOurs, nOurs, &aOurs, &nfOurs)<0) goto fail;
   if(parseRecordFields(pTheirs, nTheirs, &aTheirs, &nfTheirs)<0) goto fail;
 
-  /* Determine max fields (handles schema changes adding columns) */
+  
   nfMax = nfBase;
   if(nfOurs > nfMax) nfMax = nfOurs;
   if(nfTheirs > nfMax) nfMax = nfTheirs;
 
-  /* For each field, decide which version to take */
+  
   {
     MergeWinner *winners;
 
@@ -250,47 +199,47 @@ static u8 *tryCellMerge(
       int theirsHas = (i < nfTheirs);
 
       if(!baseHas && oursHas && !theirsHas){
-        /* New field in ours only (schema change on our side) */
+        
         winners[i].pRec = pOurs; winners[i].pField = &aOurs[i];
       }else if(!baseHas && !oursHas && theirsHas){
-        /* New field in theirs only */
+        
         winners[i].pRec = pTheirs; winners[i].pField = &aTheirs[i];
       }else if(!baseHas && oursHas && theirsHas){
-        /* Both added this field (both did schema change) */
+        
         if(fieldEquals(pOurs, &aOurs[i], pTheirs, &aTheirs[i])==0){
           winners[i].pRec = pOurs; winners[i].pField = &aOurs[i];
         }else{
-          sqlite3_free(winners); goto fail; /* conflict */
+          sqlite3_free(winners); goto fail; 
         }
       }else if(baseHas && oursHas && theirsHas){
-        /* Field exists in all three — compare */
+        
         int oursChanged = fieldEquals(pBase, &aBase[i], pOurs, &aOurs[i]);
         int theirsChanged = fieldEquals(pBase, &aBase[i], pTheirs, &aTheirs[i]);
         if(!oursChanged && !theirsChanged){
-          /* Neither changed */
+          
           winners[i].pRec = pOurs; winners[i].pField = &aOurs[i];
         }else if(oursChanged && !theirsChanged){
-          /* Only ours changed */
+          
           winners[i].pRec = pOurs; winners[i].pField = &aOurs[i];
         }else if(!oursChanged && theirsChanged){
-          /* Only theirs changed */
+          
           winners[i].pRec = pTheirs; winners[i].pField = &aTheirs[i];
         }else{
-          /* Both changed — check if convergent */
+          
           if(fieldEquals(pOurs, &aOurs[i], pTheirs, &aTheirs[i])==0){
             winners[i].pRec = pOurs; winners[i].pField = &aOurs[i];
           }else{
-            sqlite3_free(winners); goto fail; /* real conflict */
+            sqlite3_free(winners); goto fail; 
           }
         }
       }else if(baseHas && oursHas && !theirsHas){
-        /* Field dropped in theirs? Take ours (theirs has fewer columns) */
+        
         winners[i].pRec = pOurs; winners[i].pField = &aOurs[i];
       }else if(baseHas && !oursHas && theirsHas){
-        /* Field dropped in ours? Take theirs */
+        
         winners[i].pRec = pTheirs; winners[i].pField = &aTheirs[i];
       }else{
-        /* Edge case: field only in base, dropped by both */
+        
         continue;
       }
     }
@@ -320,35 +269,35 @@ static int rowMergeCallback(void *pCtx, const ThreeWayChange *pChange){
     case THREE_WAY_LEFT_ADD:
     case THREE_WAY_LEFT_MODIFY:
     case THREE_WAY_LEFT_DELETE:
-      /* Our change only — already in our tree, no action needed */
+      
       break;
 
     case THREE_WAY_RIGHT_ADD:
-      /* Theirs added a row — insert it */
+      
       rc = prollyMutMapInsert(ctx->pEdits,
           pChange->pKey, pChange->nKey, pChange->intKey,
           pChange->pTheirVal, pChange->nTheirVal);
       break;
 
     case THREE_WAY_RIGHT_MODIFY:
-      /* Theirs modified a row — update it */
+      
       rc = prollyMutMapInsert(ctx->pEdits,
           pChange->pKey, pChange->nKey, pChange->intKey,
           pChange->pTheirVal, pChange->nTheirVal);
       break;
 
     case THREE_WAY_RIGHT_DELETE:
-      /* Theirs deleted a row — delete it */
+      
       rc = prollyMutMapDelete(ctx->pEdits,
           pChange->pKey, pChange->nKey, pChange->intKey);
       break;
 
     case THREE_WAY_CONVERGENT:
-      /* Both made same change — no action, already in ours */
+      
       break;
 
     case THREE_WAY_CONFLICT_MM: {
-      /* Both sides modified — try cell-level merge first */
+      
       u8 *pMerged = 0;
       int nMerged = 0;
 
@@ -363,17 +312,17 @@ static int rowMergeCallback(void *pCtx, const ThreeWayChange *pChange){
       }
 
       if( pMerged ){
-        /* Cell-level merge succeeded — apply as non-conflicting edit */
+        
         rc = prollyMutMapInsert(ctx->pEdits,
             pChange->pKey, pChange->nKey, pChange->intKey,
             pMerged, nMerged);
         sqlite3_free(pMerged);
         break;
       }
-      /* Fall through to record as conflict */
+      
     }
     case THREE_WAY_CONFLICT_DM: {
-      /* Real conflict — record it with all three values */
+      
       struct ConflictRow *aNew;
       if( ctx->nConflicts >= ctx->nConflictsAlloc ){
         int nNew = ctx->nConflictsAlloc ? ctx->nConflictsAlloc*2 : 16;
@@ -429,10 +378,6 @@ static void freeRowMergeCtx(RowMergeCtx *ctx){
   }
 }
 
-/*
-** Perform row-level three-way merge on a single table.
-** Returns: the new merged root hash + number of conflicts.
-*/
 static int mergeTableRows(
   sqlite3 *db,
   const ProllyHash *pAncRoot,
@@ -457,7 +402,7 @@ static int mergeTableRows(
   rc = prollyMutMapInit(ctx.pEdits, ctx.isIntKey);
   if( rc!=SQLITE_OK ){ sqlite3_free(ctx.pEdits); return rc; }
 
-  /* Run three-way diff */
+  
   rc = prollyThreeWayDiff(cs, cache, pAncRoot, pOursRoot, pTheirsRoot,
                           flags, rowMergeCallback, &ctx);
   if( rc!=SQLITE_OK ){
@@ -465,7 +410,7 @@ static int mergeTableRows(
     return rc;
   }
 
-  /* Apply non-conflicting edits to produce merged tree */
+  
   if( !prollyMutMapIsEmpty(ctx.pEdits) ){
     memset(&mut, 0, sizeof(mut));
     mut.pStore = cs;
@@ -478,13 +423,13 @@ static int mergeTableRows(
       memcpy(pMergedRoot, &mut.newRoot, sizeof(ProllyHash));
     }
   }else{
-    /* No non-conflicting edits — merged root is same as ours */
+    
     memcpy(pMergedRoot, pOursRoot, sizeof(ProllyHash));
   }
 
   *pnConflicts = ctx.nConflicts;
   *ppConflicts = ctx.aConflicts;
-  ctx.aConflicts = 0; /* ownership transferred */
+  ctx.aConflicts = 0; 
   ctx.nConflicts = 0;
 
   freeRowMergeCtx(&ctx);
@@ -499,24 +444,16 @@ static struct TableEntry *findTableByName(
   return doltliteFindTableByName(aEntries, nEntries, zName);
 }
 
-/*
-** Serialize a merged catalog into a chunk and store it.
-**
-** Format: iNextTable(4) + nTables(4) + meta(64) + entries(25 each)
-**
-** Meta is copied from the "ours" catalog (the current branch's metadata
-** takes precedence in a merge).
-*/
 static int serializeMergedCatalog(
   sqlite3 *db,
-  const ProllyHash *oursCatHash,     /* unused (V2 has no meta to copy) */
+  const ProllyHash *oursCatHash,     
   struct TableEntry *aMerged,
   int nMerged,
   Pgno iNextTable,
-  ProllyHash *pOutHash               /* OUT: hash of stored catalog chunk */
+  ProllyHash *pOutHash               
 ){
   ChunkStore *cs = doltliteGetChunkStore(db);
-  int sz = 1 + 4 + 4;  /* V2: version(1) + iNextTable(4) + nTables(4) */
+  int sz = 1 + 4 + 4;  
   { int j; for(j=0;j<nMerged;j++){
     int nl = aMerged[j].zName ? (int)strlen(aMerged[j].zName) : 0;
     sz += 4+1+PROLLY_HASH_SIZE+PROLLY_HASH_SIZE+2+nl;
@@ -525,14 +462,14 @@ static int serializeMergedCatalog(
   u8 *p;
   int rc;
 
-  (void)oursCatHash;  /* V2 catalogs have no meta to copy */
+  (void)oursCatHash;  
 
   buf = sqlite3_malloc(sz);
   if( !buf ) return SQLITE_NOMEM;
   p = buf;
 
-  /* V2 format: version byte + iNextTable + nTables (no aMeta) */
-  *p++ = 0x43;  /* CATALOG_FORMAT_V2 = 'C' */
+  
+  *p++ = 0x43;  
   p[0] = (u8)iNextTable;
   p[1] = (u8)(iNextTable>>8);
   p[2] = (u8)(iNextTable>>16);
@@ -544,7 +481,7 @@ static int serializeMergedCatalog(
   p[3] = (u8)(nMerged>>24);
   p += 4;
 
-  /* Write table entries: iTable(4) + flags(1) + root(20) + schemaHash(20) + name_len(2) + name(var) */
+  
   {
     int i;
     for(i=0; i<nMerged; i++){
@@ -571,7 +508,6 @@ static int serializeMergedCatalog(
   return rc;
 }
 
-/* Collected conflict info for a single table during merge */
 typedef struct MergeConflictTable MergeConflictTable;
 struct MergeConflictTable {
   char *zName;
@@ -579,12 +515,6 @@ struct MergeConflictTable {
   struct ConflictRow *aRows;
 };
 
-/*
-** Pass 1: Process ours' tables.
-**
-** For each table in ours, find it in theirs and ancestor, determine if
-** changed on each side, and resolve or record a conflict.
-*/
 static int mergeCatalogPass1(
   sqlite3 *db,
   struct TableEntry *aAnc, int nAnc,
@@ -601,51 +531,50 @@ static int mergeCatalogPass1(
     struct TableEntry *ancEntry;
     struct TableEntry *theirsEntry;
 
-    /* Table 1 (sqlite_master) has no zName but must be row-merged
-    ** so that CREATE TABLE statements from theirs appear after merge. */
+    
     if( aOurs[i].iTable==1 ){
       ancEntry = findTableEntry(aAnc, nAnc, 1);
       theirsEntry = findTableEntry(aTheirs, nTheirs, 1);
       goto do_merge_entry;
     }
 
-    /* Skip tables without names (internal bookkeeping, not real tables) */
+    
     if( !zName ){
       aMerged[(*pnMerged)++] = aOurs[i];
       continue;
     }
 
-    /* Find by NAME in ancestor and theirs */
+    
     ancEntry = findTableByName(aAnc, nAnc, zName);
     theirsEntry = findTableByName(aTheirs, nTheirs, zName);
 
 do_merge_entry:
 
     if( !ancEntry ){
-      /* Table added in ours (not in ancestor by name) */
+      
       if( theirsEntry ){
-        /* Both sides added a table with the same name */
+        
         if( prollyHashCompare(&aOurs[i].root, &theirsEntry->root)!=0
          || prollyHashCompare(&aOurs[i].schemaHash, &theirsEntry->schemaHash)!=0 ){
           return SQLITE_ERROR;
         }
-        /* Identical content — include once (ours' iTable) */
+        
       }
       aMerged[(*pnMerged)++] = aOurs[i];
     }else{
-      /* Table existed in ancestor */
+      
       int oursChanged = prollyHashCompare(&aOurs[i].root, &ancEntry->root)!=0;
 
       if( !theirsEntry ){
-        /* Deleted in theirs (by name) */
+        
         if( oursChanged ){
-          return SQLITE_ERROR;  /* Modified in ours, deleted in theirs */
+          return SQLITE_ERROR;  
         }
-        /* Unchanged in ours, deleted in theirs — delete (skip) */
+        
       }else{
         int theirsChanged = prollyHashCompare(&theirsEntry->root, &ancEntry->root)!=0;
         if( oursChanged && theirsChanged ){
-          /* Both modified same table — do row-level three-way merge */
+          
           ProllyHash mergedTableRoot;
           int nConflicts = 0;
           struct ConflictRow *aConflictRows = 0;
@@ -672,7 +601,7 @@ do_merge_entry:
                 aNew[*pnConflictTables].nConflicts = nConflicts;
                 aNew[*pnConflictTables].aRows = aConflictRows;
                 (*pnConflictTables)++;
-                aConflictRows = 0; /* ownership transferred */
+                aConflictRows = 0; 
               }else{
                 { int j; for(j=0;j<nConflicts;j++){
                   sqlite3_free(aConflictRows[j].pKey);
@@ -684,7 +613,7 @@ do_merge_entry:
             }
           }
         }else if( theirsChanged ){
-          /* Take theirs' root but with ours' iTable number */
+          
           struct TableEntry merged = aOurs[i];
           memcpy(&merged.root, &theirsEntry->root, sizeof(ProllyHash));
           memcpy(&merged.schemaHash, &theirsEntry->schemaHash, sizeof(ProllyHash));
@@ -699,9 +628,6 @@ do_merge_entry:
   return rc;
 }
 
-/*
-** Pass 2: Process theirs' tables not in ours (new tables added by theirs).
-*/
 static int mergeCatalogPass2(
   struct TableEntry *aAnc, int nAnc,
   struct TableEntry *aOurs, int nOurs,
@@ -718,14 +644,12 @@ static int mergeCatalogPass2(
     if( aTheirs[i].iTable<=1 || !zName ) continue;
 
     oursEntry = findTableByName(aOurs, nOurs, zName);
-    if( oursEntry ) continue;  /* Already handled in pass 1 */
+    if( oursEntry ) continue;  
 
     {
       struct TableEntry *ancEntry = findTableByName(aAnc, nAnc, zName);
       if( !ancEntry ){
-        /* Added in theirs only — keep their iTable if no conflict,
-        ** otherwise assign a new one. Keeping the original iTable is
-        ** important so sqlite_master rootpage values stay consistent. */
+        
         struct TableEntry newEntry = aTheirs[i];
         {
           int j, conflict = 0;
@@ -735,39 +659,29 @@ static int mergeCatalogPass2(
           if( conflict ) newEntry.iTable = (*piNextMerged)++;
         }
         if( newEntry.iTable >= *piNextMerged ) *piNextMerged = newEntry.iTable + 1;
-        /* Copy name string */
+        
         newEntry.zName = sqlite3_mprintf("%s", zName);
         aMerged[(*pnMerged)++] = newEntry;
       }else{
-        /* Was in ancestor, deleted in ours */
+        
         int theirsChanged = prollyHashCompare(&aTheirs[i].root, &ancEntry->root)!=0;
         if( theirsChanged ){
-          return SQLITE_ERROR;  /* Modified in theirs, deleted in ours */
+          return SQLITE_ERROR;  
         }
-        /* Unchanged in theirs, deleted in ours — delete (skip) */
+        
       }
     }
   }
   return SQLITE_OK;
 }
 
-/*
-** Perform a three-way catalog merge.
-**
-** ancestor: the common ancestor catalog hash
-** ours:     the current branch's catalog hash
-** theirs:   the other branch's catalog hash
-**
-** On success, *pMergedHash contains the hash of the merged catalog chunk.
-** Returns SQLITE_OK on success, SQLITE_ERROR on conflict.
-*/
 int doltliteMergeCatalogs(
   sqlite3 *db,
   const ProllyHash *ancestor,
   const ProllyHash *ours,
   const ProllyHash *theirs,
   ProllyHash *pMergedHash,
-  int *pnConflicts          /* OUT: total row conflicts across all tables */
+  int *pnConflicts          
 ){
   struct TableEntry *aAnc = 0, *aOurs = 0, *aTheirs = 0;
   int nAnc = 0, nOurs = 0, nTheirs = 0;
@@ -782,7 +696,7 @@ int doltliteMergeCatalogs(
   MergeConflictTable *aConflictTables = 0;
   int nConflictTables = 0;
 
-  /* Load all three catalogs */
+  
   rc = doltliteLoadCatalog(db, ancestor, &aAnc, &nAnc, &iNextAnc);
   if( rc!=SQLITE_OK ) goto merge_cleanup;
 
@@ -792,7 +706,7 @@ int doltliteMergeCatalogs(
   rc = doltliteLoadCatalog(db, theirs, &aTheirs, &nTheirs, &iNextTheirs);
   if( rc!=SQLITE_OK ) goto merge_cleanup;
 
-  /* Allocate merged array — worst case is all tables from both sides */
+  
   nMergedAlloc = nOurs + nTheirs;
   if( nMergedAlloc==0 ) nMergedAlloc = 1;
   aMerged = sqlite3_malloc(nMergedAlloc * (int)sizeof(struct TableEntry));
@@ -801,19 +715,10 @@ int doltliteMergeCatalogs(
     goto merge_cleanup;
   }
 
-  /* Use ours' iNextTable as the starting point, take max with theirs */
+  
   iNextMerged = iNextOurs > iNextTheirs ? iNextOurs : iNextTheirs;
 
-  /*
-  ** NAME-BASED THREE-WAY MERGE
-  **
-  ** Tables are matched by NAME (zName), not by iTable number.
-  ** This handles the case where two branches independently CREATE TABLE
-  ** and get different iTable numbers for tables with different names.
-  **
-  ** Output uses ours' iTable numbers. Theirs' tables that don't exist
-  ** in ours get new iTable numbers from iNextMerged.
-  */
+  
 
   rc = mergeCatalogPass1(db, aAnc, nAnc, aOurs, nOurs, aTheirs, nTheirs,
                           aMerged, &nMerged,
@@ -825,15 +730,15 @@ int doltliteMergeCatalogs(
                           aMerged, &nMerged, &iNextMerged);
   if( rc!=SQLITE_OK ) goto merge_cleanup;
 
-  /* Serialize the merged catalog */
+  
   rc = serializeMergedCatalog(db, ours, aMerged, nMerged, iNextMerged,
                               pMergedHash);
   if( pnConflicts ) *pnConflicts = totalConflicts;
 
-  /* Store conflicts if any */
+  
   if( totalConflicts>0 && nConflictTables>0 && rc==SQLITE_OK ){
     ProllyHash conflictsHash;
-    /* ConflictTableInfo has the same layout as MergeConflictTable */
+    
     int rc2 = doltliteSerializeConflicts(
         doltliteGetChunkStore(db),
         (ConflictTableInfo*)aConflictTables, nConflictTables,
@@ -846,7 +751,7 @@ int doltliteMergeCatalogs(
     }
   }
 
-  /* Free collected conflicts */
+  
   {
     int ci;
     for(ci=0; ci<nConflictTables; ci++){
@@ -871,4 +776,4 @@ merge_cleanup:
   return rc;
 }
 
-#endif /* DOLTLITE_PROLLY */
+#endif 

--- a/src/doltlite_record.c
+++ b/src/doltlite_record.c
@@ -1,25 +1,4 @@
-/*
-** SQLite record format decoder.
-**
-** Record format:
-**   [header_size: varint]
-**   [serial_type_1: varint] [serial_type_2: varint] ...
-**   [value_1] [value_2] ...
-**
-** Serial types:
-**   0 = NULL
-**   1 = 1-byte int
-**   2 = 2-byte int (big-endian)
-**   3 = 3-byte int
-**   4 = 4-byte int
-**   5 = 6-byte int
-**   6 = 8-byte int
-**   7 = 8-byte IEEE float
-**   8 = integer 0
-**   9 = integer 1
-**   >=12, even = blob of (N-12)/2 bytes
-**   >=13, odd  = text of (N-13)/2 bytes
-*/
+
 #ifdef DOLTLITE_PROLLY
 
 #include "sqliteInt.h"
@@ -27,7 +6,6 @@
 #include <string.h>
 #include <stdio.h>
 
-/* Read a big-endian SQLite varint. Returns bytes consumed. */
 static int recReadVarint(const u8 *p, const u8 *pEnd, u64 *pVal){
   u64 v = 0;
   int i;
@@ -45,11 +23,10 @@ static int recReadVarint(const u8 *p, const u8 *pEnd, u64 *pVal){
   return i ? i : 1;
 }
 
-/* Read a big-endian signed integer of nBytes bytes. */
 static i64 recReadInt(const u8 *p, int nBytes){
   i64 v;
   int i;
-  /* Sign extend from the first byte */
+  
   v = (p[0] & 0x80) ? -1 : 0;
   for(i=0; i<nBytes; i++){
     v = (v << 8) | p[i];
@@ -57,7 +34,6 @@ static i64 recReadInt(const u8 *p, int nBytes){
   return v;
 }
 
-/* Append text to a dynamically growing buffer. */
 typedef struct RecBuf RecBuf;
 struct RecBuf {
   char *z;
@@ -93,13 +69,13 @@ char *doltliteDecodeRecord(const u8 *pData, int nData){
 
   memset(&buf, 0, sizeof(buf));
 
-  /* Read header size */
+  
   hdrBytes = recReadVarint(p, pEnd, &hdrSize);
   p += hdrBytes;
   pHdrEnd = pData + hdrSize;
   pBody = pData + hdrSize;
 
-  /* Walk serial types in header, decode each field from body */
+  
   while( p < pHdrEnd && p < pEnd ){
     u64 st;
     int stBytes = recReadVarint(p, pHdrEnd, &st);
@@ -108,14 +84,14 @@ char *doltliteDecodeRecord(const u8 *pData, int nData){
     if( fieldIdx > 0 ) recBufAppend(&buf, "|", 1);
 
     if( st==0 ){
-      /* NULL */
+      
       recBufAppend(&buf, "NULL", 4);
     }else if( st==8 ){
       recBufAppend(&buf, "0", 1);
     }else if( st==9 ){
       recBufAppend(&buf, "1", 1);
     }else if( st>=1 && st<=6 ){
-      /* Integer: 1,2,3,4,6,8 bytes */
+      
       static const int sizes[] = {0,1,2,3,4,6,8};
       int nBytes = sizes[st];
       if( pBody + nBytes <= pEnd ){
@@ -126,7 +102,7 @@ char *doltliteDecodeRecord(const u8 *pData, int nData){
       }
       pBody += nBytes;
     }else if( st==7 ){
-      /* IEEE 754 float, 8 bytes big-endian */
+      
       if( pBody + 8 <= pEnd ){
         double v;
         u64 bits = 0;
@@ -139,7 +115,7 @@ char *doltliteDecodeRecord(const u8 *pData, int nData){
       }
       pBody += 8;
     }else if( st>=12 && (st&1)==0 ){
-      /* Blob */
+      
       int len = ((int)st - 12) / 2;
       recBufAppend(&buf, "x'", 2);
       if( pBody + len <= pEnd ){
@@ -153,7 +129,7 @@ char *doltliteDecodeRecord(const u8 *pData, int nData){
       recBufAppend(&buf, "'", 1);
       pBody += len;
     }else if( st>=13 && (st&1)==1 ){
-      /* Text */
+      
       int len = ((int)st - 13) / 2;
       if( pBody + len <= pEnd ){
         recBufAppend(&buf, (const char*)pBody, len);
@@ -182,10 +158,6 @@ void doltliteResultRecord(sqlite3_context *ctx, const u8 *pData, int nData){
   }
 }
 
-/* --------------------------------------------------------------------------
-** Shared column-info helpers
-** -------------------------------------------------------------------------- */
-
 void doltliteFreeColInfo(DoltliteColInfo *ci){
   int i;
   for(i=0; i<ci->nCol; i++) sqlite3_free(ci->azName[i]);
@@ -208,7 +180,7 @@ int doltliteGetColumnNames(sqlite3 *db, const char *zTable, DoltliteColInfo *ci)
   sqlite3_free(zSql);
   if( rc!=SQLITE_OK ) return rc;
 
-  /* Count columns first */
+  
   nCol = 0;
   while( sqlite3_step(pStmt)==SQLITE_ROW ) nCol++;
   sqlite3_reset(pStmt);
@@ -223,7 +195,7 @@ int doltliteGetColumnNames(sqlite3 *db, const char *zTable, DoltliteColInfo *ci)
     int pk = sqlite3_column_int(pStmt, 5);
     const char *zType = (const char*)sqlite3_column_text(pStmt, 2);
 
-    /* Track which column is the INTEGER PRIMARY KEY (rowid alias) */
+    
     if( pk==1 && zType && sqlite3_stricmp(zType,"INTEGER")==0 ){
       ci->iPkCol = ci->nCol;
     }
@@ -236,4 +208,4 @@ int doltliteGetColumnNames(sqlite3 *db, const char *zTable, DoltliteColInfo *ci)
   return SQLITE_OK;
 }
 
-#endif /* DOLTLITE_PROLLY */
+#endif 

--- a/src/doltlite_record.h
+++ b/src/doltlite_record.h
@@ -1,52 +1,24 @@
-/*
-** Shared record parsing utilities for doltlite feature files.
-** SQLite record format: varint(header_size) + serial_types + field_data.
-*/
+
 #ifndef DOLTLITE_RECORD_H
 #define DOLTLITE_RECORD_H
 
 #include "sqliteInt.h"
 
-/*
-** Decode a SQLite record-format blob into a pipe-separated text string.
-** Caller must sqlite3_free() the result.
-** Returns NULL on error or empty input.
-**
-** Example: a record with (integer 3, text 'hello') -> "3|hello"
-*/
 char *doltliteDecodeRecord(const u8 *pData, int nData);
 
-/*
-** Set a sqlite3_context result to the decoded text of a record blob,
-** or NULL if the blob is empty/NULL.
-*/
 void doltliteResultRecord(sqlite3_context *ctx, const u8 *pData, int nData);
 
-/*
-** Shared column-info structure used by diff_table, history, and at modules.
-*/
 typedef struct DoltliteColInfo DoltliteColInfo;
 struct DoltliteColInfo {
-  char **azName;    /* Column names (owned) */
-  int nCol;         /* Number of columns (ALL columns including PK) */
-  int iPkCol;       /* Index of the INTEGER PRIMARY KEY column, or -1 */
+  char **azName;    
+  int nCol;         
+  int iPkCol;       
 };
 
-/*
-** Populate ci with column names from the given table via PRAGMA table_info.
-** Caller must call doltliteFreeColInfo() when done.
-*/
 int doltliteGetColumnNames(sqlite3 *db, const char *zTable, DoltliteColInfo *ci);
 
-/*
-** Free the column name array inside ci.
-*/
 void doltliteFreeColInfo(DoltliteColInfo *ci);
 
-/*
-** Read a SQLite varint from pBuf. Returns bytes consumed (1-9).
-** Sets *pVal to the decoded value.
-*/
 static inline int dlReadVarint(const u8 *p, const u8 *pEnd, u64 *pVal){
   u64 v;
   int i;
@@ -62,11 +34,6 @@ static inline int dlReadVarint(const u8 *p, const u8 *pEnd, u64 *pVal){
   return i;
 }
 
-/*
-** Return the payload byte length for a given SQLite serial type.
-** Types: 0=NULL(0), 1-6=int(1,2,3,4,6,8), 7=float(8),
-** 8=false(0), 9=true(0), N>=12=blob((N-12)/2), N>=13=text((N-13)/2)
-*/
 static inline int dlSerialTypeLen(u64 st){
   static const u8 aLen[] = {0, 1, 2, 3, 4, 6, 8};
   if( st <= 6 ) return aLen[st];
@@ -75,4 +42,4 @@ static inline int dlSerialTypeLen(u64 st){
   return 0;
 }
 
-#endif /* DOLTLITE_RECORD_H */
+#endif 

--- a/src/doltlite_record.h
+++ b/src/doltlite_record.h
@@ -1,4 +1,4 @@
-
+/* SQLite record-format decoding helpers and varint/serial-type utilities. */
 #ifndef DOLTLITE_RECORD_H
 #define DOLTLITE_RECORD_H
 

--- a/src/doltlite_remote.c
+++ b/src/doltlite_remote.c
@@ -1,15 +1,4 @@
-/*
-** Transport-agnostic sync engine for Doltlite remotes.
-**
-** Implements BFS-based chunk synchronization between a local ChunkStore
-** and an abstract DoltliteRemote destination.  The filesystem remote
-** implementation wraps a second ChunkStore as the remote.
-**
-** SQL interface (registered elsewhere):
-**   SELECT dolt_push('origin', 'main');
-**   SELECT dolt_fetch('origin', 'main');
-**   SELECT dolt_clone('path/to/remote.doltlite');
-*/
+
 #ifdef DOLTLITE_PROLLY
 
 #include "doltlite_remote.h"
@@ -17,11 +6,6 @@
 #include "prolly_hashset.h"
 #include "prolly_node.h"
 #include <string.h>
-
-
-/* ----------------------------------------------------------------
-** BFS queue for sync traversal.
-** ---------------------------------------------------------------- */
 
 typedef struct SyncQueue SyncQueue;
 struct SyncQueue {
@@ -70,10 +54,6 @@ static int syncQueuePending(SyncQueue *q){
   return q->nItems - q->iHead;
 }
 
-/* ----------------------------------------------------------------
-** Chunk type detection (mirrors doltlite_gc.c helpers).
-** ---------------------------------------------------------------- */
-
 #define SYNC_PROLLY_NODE_MAGIC 0x504E4F44
 
 static int syncIsProllyNodeChunk(const u8 *data, int nData){
@@ -95,10 +75,6 @@ static int syncIsCommitChunk(const u8 *data, int nData){
   return 1;
 }
 
-/* ----------------------------------------------------------------
-** Extract child hashes from a chunk and enqueue them.
-** ---------------------------------------------------------------- */
-
 static int syncEnqueueChildren(
   const u8 *data,
   int nData,
@@ -109,7 +85,7 @@ static int syncEnqueueChildren(
   int i;
 
   if( syncIsProllyNodeChunk(data, nData) ){
-    /* Prolly tree node: follow child hashes if internal (level > 0) */
+    
     ProllyNode node;
     int parseRc = prollyNodeParse(&node, data, nData);
     if( parseRc==SQLITE_OK && node.level > 0 ){
@@ -124,7 +100,7 @@ static int syncEnqueueChildren(
       }
     }
   }else if( syncIsCommitChunk(data, nData) ){
-    /* Commit: follow all parents + catalog hash */
+    
     DoltliteCommit commit;
     memset(&commit, 0, sizeof(commit));
     int drc = doltliteCommitDeserialize(data, nData, &commit);
@@ -150,7 +126,7 @@ static int syncEnqueueChildren(
       doltliteCommitClear(&commit);
     }
   }else{
-    /* WorkingSet: version(1=0x01) + staged(20) + merging(1) + mergeCommit(20) + conflicts(20) = 62 bytes */
+    
     if( nData == WS_TOTAL_SIZE && data[0] == 1 ){
       ProllyHash h;
       memcpy(h.data, data + WS_STAGED_OFF, PROLLY_HASH_SIZE);
@@ -172,7 +148,7 @@ static int syncEnqueueChildren(
       }
     }
 
-    /* Catalog chunk: version(1='C'=0x43) */
+    
     if( nData >= 9 && data[0] == 0x43 ){
       int nTables = (int)(data[5] | (data[6]<<8) |
                           (data[7]<<16) | (data[8]<<24));
@@ -202,10 +178,6 @@ static int syncEnqueueChildren(
   return rc;
 }
 
-/* ----------------------------------------------------------------
-** doltliteSyncChunks: BFS sync engine.
-** ---------------------------------------------------------------- */
-
 #define SYNC_BATCH_SIZE 256
 
 int doltliteSyncChunks(
@@ -229,7 +201,7 @@ int doltliteSyncChunks(
     return rc;
   }
 
-  /* Seed the queue with root hashes */
+  
   for(i=0; i<nRoots && rc==SQLITE_OK; i++){
     if( !prollyHashIsEmpty(&aRoots[i]) && !prollyHashSetContains(&seen, &aRoots[i]) ){
       rc = prollyHashSetAdd(&seen, &aRoots[i]);
@@ -237,48 +209,47 @@ int doltliteSyncChunks(
     }
   }
 
-  /* BFS loop */
+  
   while( rc==SQLITE_OK && syncQueuePending(&queue) > 0 ){
     int nBatch = 0;
 
-    /* Dequeue a batch of hashes */
+    
     while( nBatch < SYNC_BATCH_SIZE && syncQueuePop(&queue, &aBatch[nBatch]) ){
       nBatch++;
     }
     if( nBatch == 0 ) break;
 
-    /* Check which hashes the destination already has */
+    
     rc = pDst->xHasChunks(pDst, aBatch, nBatch, aPresent);
     if( rc!=SQLITE_OK ) break;
 
-    /* For each missing chunk: fetch from src, put to dst, discover children */
+    
     for(i=0; i<nBatch && rc==SQLITE_OK; i++){
       u8 *data = 0;
       int nData = 0;
 
       if( aPresent[i] ){
-        /* Destination already has this chunk and its entire reachable subtree
-        ** (because chunks are content-addressed and immutable). Prune. */
+        
         continue;
       }
 
-      /* Fetch from source */
+      
       rc = pSrc->xGetChunk(pSrc, &aBatch[i], &data, &nData);
       if( rc==SQLITE_NOTFOUND ){
-        /* Chunk missing from source -- skip, don't fail the whole sync */
+        
         rc = SQLITE_OK;
         continue;
       }
       if( rc!=SQLITE_OK ) break;
 
-      /* Put to destination */
+      
       rc = pDst->xPutChunk(pDst, &aBatch[i], data, nData);
       if( rc!=SQLITE_OK ){
         sqlite3_free(data);
         break;
       }
 
-      /* Discover child hashes and enqueue them */
+      
       rc = syncEnqueueChildren(data, nData, &queue, &seen);
       sqlite3_free(data);
     }
@@ -289,16 +260,10 @@ int doltliteSyncChunks(
   return rc;
 }
 
-/* ----------------------------------------------------------------
-** Filesystem remote implementation.
-**
-** Wraps a second ChunkStore opened on another .doltlite file.
-** ---------------------------------------------------------------- */
-
 typedef struct FsRemote FsRemote;
 struct FsRemote {
-  DoltliteRemote base;   /* Must be first: vtable */
-  ChunkStore store;      /* The remote chunk store */
+  DoltliteRemote base;   
+  ChunkStore store;      
 };
 
 static int fsGetChunk(DoltliteRemote *pRemote, const ProllyHash *pHash,
@@ -311,7 +276,7 @@ static int fsPutChunk(DoltliteRemote *pRemote, const ProllyHash *pHash,
                       const u8 *pData, int nData){
   FsRemote *p = (FsRemote*)pRemote;
   ProllyHash computed;
-  (void)pHash; /* Hash is computed by chunkStorePut */
+  (void)pHash; 
   return chunkStorePut(&p->store, pData, nData, &computed);
 }
 
@@ -341,7 +306,7 @@ static int fsSetRefs(DoltliteRemote *pRemote, const u8 *pData, int nData){
   int rc = chunkStorePut(&p->store, pData, nData, &refsHash);
   if( rc==SQLITE_OK ){
     memcpy(&p->store.refsHash, &refsHash, sizeof(ProllyHash));
-    /* Reload in-memory refs from the new blob */
+    
     rc = chunkStoreReloadRefs(&p->store);
   }
   return rc;
@@ -351,14 +316,14 @@ static int fsCommit(DoltliteRemote *pRemote){
   FsRemote *p = (FsRemote*)pRemote;
   int rc;
 
-  /* Serialize refs and commit */
+  
   rc = chunkStoreSerializeRefs(&p->store);
   if( rc!=SQLITE_OK ) return rc;
 
   rc = chunkStoreCommit(&p->store);
   if( rc!=SQLITE_OK ) return rc;
 
-  /* Update headCommit/catalog from default branch */
+  
   {
     const char *zDef = chunkStoreGetDefaultBranch(&p->store);
     ProllyHash branchCommit;
@@ -373,7 +338,7 @@ static int fsCommit(DoltliteRemote *pRemote){
         }
         sqlite3_free(cdata);
       }
-      chunkStoreCommit(&p->store);  /* Write updated manifest */
+      chunkStoreCommit(&p->store);  
     }
   }
 
@@ -412,17 +377,10 @@ DoltliteRemote *doltliteFsRemoteOpen(sqlite3_vfs *pVfs, const char *zPath){
   return &p->base;
 }
 
-/* ----------------------------------------------------------------
-** "Local as remote" adapter.
-**
-** Wraps the local ChunkStore with the DoltliteRemote vtable so that
-** doltliteSyncChunks can write to it (used by fetch).
-** ---------------------------------------------------------------- */
-
 typedef struct LocalAsRemote LocalAsRemote;
 struct LocalAsRemote {
   DoltliteRemote base;
-  ChunkStore *pStore;   /* Borrowed pointer, NOT owned */
+  ChunkStore *pStore;   
 };
 
 static int localGetChunk(DoltliteRemote *pRemote, const ProllyHash *pHash,
@@ -475,7 +433,7 @@ static int localCommit(DoltliteRemote *pRemote){
 }
 
 static void localClose(DoltliteRemote *pRemote){
-  /* Do NOT close the chunk store -- we don't own it */
+  
   sqlite3_free(pRemote);
 }
 
@@ -495,12 +453,6 @@ DoltliteRemote *doltliteLocalAsRemote(ChunkStore *pLocal){
 
   return &p->base;
 }
-
-/* ----------------------------------------------------------------
-** Helper: check if commitA is an ancestor of commitB.
-** Walks commitB's parent chain looking for commitA.
-** Returns 1 if ancestor, 0 if not, negative on error.
-** ---------------------------------------------------------------- */
 
 static int syncIsAncestor(
   ChunkStore *cs,
@@ -562,10 +514,6 @@ static int syncIsAncestor(
   return found;
 }
 
-/* ----------------------------------------------------------------
-** doltlitePush: push a branch from local to remote.
-** ---------------------------------------------------------------- */
-
 int doltlitePush(
   ChunkStore *pLocal,
   DoltliteRemote *pRemote,
@@ -577,24 +525,23 @@ int doltlitePush(
   int rc;
   int i;
 
-  /* 1. Find local branch commit */
+  
   rc = chunkStoreFindBranch(pLocal, zBranch, &localCommit);
   if( rc!=SQLITE_OK ){
-    return SQLITE_ERROR; /* branch not found */
+    return SQLITE_ERROR; 
   }
 
-  /* 2. If !bForce, check fast-forward safety */
+  
   if( !bForce ){
     u8 *refsData = 0;
     int nRefsData = 0;
     rc = pRemote->xGetRefs(pRemote, &refsData, &nRefsData);
     if( rc==SQLITE_OK && refsData ){
-      /* Parse remote refs to find the branch */
+      
       ChunkStore tmpCs;
       memset(&tmpCs, 0, sizeof(tmpCs));
-      /* Use a temporary ChunkStore just for ref parsing.
-      ** We only need the deserialized branch list. */
-      /* Manual parse: version(1) + defLen(2) + def(var) + nBranches(2) ... */
+      
+      
       const u8 *p = refsData;
       if( nRefsData >= 5 ){
         u8 ver = p[0]; p++;
@@ -612,17 +559,17 @@ int doltlitePush(
               memcpy(remoteCommit.data, p+nameLen, PROLLY_HASH_SIZE);
               if( !prollyHashIsEmpty(&remoteCommit)
                   && prollyHashCompare(&remoteCommit, &localCommit)!=0 ){
-                /* Remote branch exists and differs: check ancestry */
+                
                 int isAnc = syncIsAncestor(pLocal, &remoteCommit, &localCommit);
                 if( isAnc <= 0 ){
                   sqlite3_free(refsData);
-                  return SQLITE_ERROR; /* not a fast-forward */
+                  return SQLITE_ERROR; 
                 }
               }
               break;
             }
             p += nameLen + PROLLY_HASH_SIZE;
-            /* Skip workingSetHash if version >= 3 */
+            
             if( ver >= 3 && p+PROLLY_HASH_SIZE <= refsData+nRefsData ){
               p += PROLLY_HASH_SIZE;
             }
@@ -632,12 +579,12 @@ int doltlitePush(
       sqlite3_free(refsData);
       (void)tmpCs;
     }else if( rc==SQLITE_NOTFOUND ){
-      rc = SQLITE_OK; /* No refs yet on remote -- that's fine */
+      rc = SQLITE_OK; 
     }
     if( rc!=SQLITE_OK ) return rc;
   }
 
-  /* 3. Sync all chunks reachable from local branch commit */
+  
   {
     DoltliteRemote *pLocalSrc = doltliteLocalAsRemote(pLocal);
     if( !pLocalSrc ) return SQLITE_NOMEM;
@@ -646,14 +593,14 @@ int doltlitePush(
   }
   if( rc!=SQLITE_OK ) return rc;
 
-  /* 4a. Update remote refs blob with new branch commit */
+  
   {
     u8 *refsData2 = 0; int nRefsData2 = 0;
     rc = pRemote->xGetRefs(pRemote, &refsData2, &nRefsData2);
     if( rc==SQLITE_NOTFOUND ){ refsData2 = 0; nRefsData2 = 0; rc = SQLITE_OK; }
     if( rc!=SQLITE_OK ) return rc;
 
-    /* Patch the branch in the refs blob using a temporary ChunkStore */
+    
     {
       ChunkStore tmpCs;
       u8 *newRefs = 0; int nNewRefs = 0;
@@ -661,7 +608,7 @@ int doltlitePush(
       if( refsData2 && nRefsData2 > 0 ){
         rc = chunkStoreLoadRefsFromBlob(&tmpCs, refsData2, nRefsData2);
       }else{
-        /* No refs yet -- set default branch */
+        
         chunkStoreSetDefaultBranch(&tmpCs, "main");
       }
       sqlite3_free(refsData2);
@@ -670,7 +617,7 @@ int doltlitePush(
         return rc;
       }
 
-      /* Update or add the branch */
+      
       rc = chunkStoreUpdateBranch(&tmpCs, zBranch, &localCommit);
       if( rc==SQLITE_NOTFOUND ){
         rc = chunkStoreAddBranch(&tmpCs, zBranch, &localCommit);
@@ -680,7 +627,7 @@ int doltlitePush(
         return rc;
       }
 
-      /* Serialize to blob */
+      
       rc = chunkStoreSerializeRefsToBlob(&tmpCs, &newRefs, &nNewRefs);
       chunkStoreClose(&tmpCs);
       if( rc!=SQLITE_OK ) return rc;
@@ -691,15 +638,11 @@ int doltlitePush(
     }
   }
 
-  /* 4b. Commit */
+  
   rc = pRemote->xCommit(pRemote);
 
   return rc;
 }
-
-/* ----------------------------------------------------------------
-** doltliteFetch: fetch a branch from remote into local tracking branch.
-** ---------------------------------------------------------------- */
 
 int doltliteFetch(
   ChunkStore *pLocal,
@@ -716,11 +659,11 @@ int doltliteFetch(
 
   memset(&remoteCommit, 0, sizeof(remoteCommit));
 
-  /* 1. Get remote refs to find the branch commit hash */
+  
   rc = pRemote->xGetRefs(pRemote, &refsData, &nRefsData);
   if( rc!=SQLITE_OK ) return rc;
 
-  /* Parse remote refs to find the target branch */
+  
   if( nRefsData >= 5 ){
     const u8 *p = refsData;
     u8 ver = p[0]; p++;
@@ -749,10 +692,10 @@ int doltliteFetch(
   sqlite3_free(refsData);
 
   if( !found || prollyHashIsEmpty(&remoteCommit) ){
-    return SQLITE_NOTFOUND; /* Branch not found on remote */
+    return SQLITE_NOTFOUND; 
   }
 
-  /* 2. Sync chunks from remote to local via vtable. */
+  
   pLocalDst = doltliteLocalAsRemote(pLocal);
   if( !pLocalDst ) return SQLITE_NOMEM;
 
@@ -761,20 +704,16 @@ int doltliteFetch(
   pLocalDst->xClose(pLocalDst);
   if( rc!=SQLITE_OK ) return rc;
 
-  /* 3. Update local tracking branch (e.g., origin/main) */
+  
   rc = chunkStoreUpdateTracking(pLocal, zRemoteName, zBranch, &remoteCommit);
   if( rc!=SQLITE_OK ) return rc;
 
-  /* 4. Serialize refs and commit */
+  
   rc = chunkStoreSerializeRefs(pLocal);
   if( rc==SQLITE_OK ) rc = chunkStoreCommit(pLocal);
 
   return rc;
 }
-
-/* ----------------------------------------------------------------
-** doltliteClone: copy ALL chunks and refs from remote to local.
-** ---------------------------------------------------------------- */
 
 int doltliteClone(ChunkStore *pLocal, DoltliteRemote *pRemote){
   u8 *refsData = 0;
@@ -785,11 +724,11 @@ int doltliteClone(ChunkStore *pLocal, DoltliteRemote *pRemote){
   DoltliteRemote *pLocalDst = 0;
   int rc;
 
-  /* 1. Get remote refs */
+  
   rc = pRemote->xGetRefs(pRemote, &refsData, &nRefsData);
   if( rc!=SQLITE_OK ) return rc;
 
-  /* 2. Parse refs to collect all branch and tag commit hashes */
+  
   if( nRefsData >= 5 ){
     const u8 *p = refsData;
     u8 ver = p[0]; p++;
@@ -812,17 +751,17 @@ int doltliteClone(ChunkStore *pLocal, DoltliteRemote *pRemote){
         nameLen = p[0]|(p[1]<<8); p += 2;
         if( p+nameLen+PROLLY_HASH_SIZE > refsData+nRefsData ) break;
         p += nameLen;
-        /* Collect commit hash */
+        
         memcpy(aRoots[nRoots].data, p, PROLLY_HASH_SIZE);
         if( !prollyHashIsEmpty(&aRoots[nRoots]) ) nRoots++;
         p += PROLLY_HASH_SIZE;
-        /* Skip workingSetHash for v3+ */
+        
         if( ver >= 3 && p+PROLLY_HASH_SIZE <= refsData+nRefsData ){
           p += PROLLY_HASH_SIZE;
         }
       }
 
-      /* Tags */
+      
       if( ver >= 2 && p+2 <= refsData+nRefsData ){
         nTags = p[0]|(p[1]<<8); p += 2;
         if( nRoots + nTags > nRootsAlloc ){
@@ -848,11 +787,11 @@ int doltliteClone(ChunkStore *pLocal, DoltliteRemote *pRemote){
   }
 
   if( nRoots == 0 ){
-    /* Remote is empty -- just copy the refs (which might set default branch) */
+    
     sqlite3_free(aRoots);
-    /* Fall through to copy refs below */
+    
   }else{
-    /* 3. Sync all reachable chunks */
+    
     pLocalDst = doltliteLocalAsRemote(pLocal);
     if( !pLocalDst ){
       sqlite3_free(aRoots);
@@ -872,7 +811,7 @@ int doltliteClone(ChunkStore *pLocal, DoltliteRemote *pRemote){
     }
   }
 
-  /* 4. Copy refs to local: put the raw refs chunk and update the local refsHash */
+  
   if( refsData && nRefsData > 0 ){
     ProllyHash refsHash;
     rc = chunkStorePut(pLocal, refsData, nRefsData, &refsHash);
@@ -883,14 +822,14 @@ int doltliteClone(ChunkStore *pLocal, DoltliteRemote *pRemote){
   sqlite3_free(refsData);
   if( rc!=SQLITE_OK ) return rc;
 
-  /* 5. Commit local */
+  
   rc = chunkStoreCommit(pLocal);
   if( rc!=SQLITE_OK ) return rc;
 
-  /* 6. Reload refs to populate in-memory branch/tag/remote arrays */
+  
   rc = chunkStoreReloadRefs(pLocal);
 
   return rc;
 }
 
-#endif /* DOLTLITE_PROLLY */
+#endif 

--- a/src/doltlite_remote.h
+++ b/src/doltlite_remote.h
@@ -3,84 +3,47 @@
 
 #include "chunk_store.h"
 
-/*
-** Abstract remote store interface.
-** Different transports (filesystem, HTTP) implement this vtable.
-*/
 typedef struct DoltliteRemote DoltliteRemote;
 struct DoltliteRemote {
-  /* Get a chunk by hash. Caller frees *ppData. Returns SQLITE_NOTFOUND if absent. */
+  
   int (*xGetChunk)(DoltliteRemote*, const ProllyHash*, u8**, int*);
 
-  /* Store a chunk. */
+  
   int (*xPutChunk)(DoltliteRemote*, const ProllyHash*, const u8*, int);
 
-  /* Batch existence check. Sets aResult[i]=1 if hash exists, 0 if not. */
+  
   int (*xHasChunks)(DoltliteRemote*, const ProllyHash*, int nHash, u8 *aResult);
 
-  /* Get/set serialized refs blob (branches, tags, remotes). */
+  
   int (*xGetRefs)(DoltliteRemote*, u8**, int*);
   int (*xSetRefs)(DoltliteRemote*, const u8*, int);
 
-  /* Flush any buffered writes. */
+  
   int (*xCommit)(DoltliteRemote*);
 
-  /* Close and free the remote. */
+  
   void (*xClose)(DoltliteRemote*);
 };
 
-/*
-** Sync chunks reachable from root hashes from source to destination.
-** Uses BFS to walk the content-addressed DAG:
-**   commits -> parent commits + catalog chunks
-**   catalog chunks -> table root hashes
-**   prolly tree nodes -> child node hashes (internal nodes only)
-**
-** Uses batch HasChunks to skip chunks the destination already has.
-** When an entire subtree is already present, the BFS prunes it.
-*/
 int doltliteSyncChunks(
-  DoltliteRemote *pSrc,    /* Source (uses xGetChunk to read) */
-  DoltliteRemote *pDst,    /* Destination (uses xHasChunks, xPutChunk) */
-  ProllyHash *aRoots,      /* Root hashes to start sync from */
-  int nRoots               /* Number of root hashes */
+  DoltliteRemote *pSrc,    
+  DoltliteRemote *pDst,    
+  ProllyHash *aRoots,      
+  int nRoots               
 );
 
-/*
-** Push a branch from local to remote.
-** 1. Sync all chunks reachable from local branch commit
-** 2. Update remote's branch ref to point to local commit
-*/
 int doltlitePush(ChunkStore *pLocal, DoltliteRemote *pRemote,
                  const char *zBranch, int bForce);
 
-/*
-** Fetch a branch from remote into local tracking branch.
-** 1. Sync all chunks reachable from remote branch commit
-** 2. Update local tracking branch (remote/branch)
-*/
 int doltliteFetch(ChunkStore *pLocal, DoltliteRemote *pRemote,
                   const char *zRemoteName, const char *zBranch);
 
-/*
-** Clone: copy ALL chunks and refs from remote to local.
-*/
 int doltliteClone(ChunkStore *pLocal, DoltliteRemote *pRemote);
 
-/*
-** Open a filesystem remote (another .doltlite file).
-*/
 DoltliteRemote *doltliteFsRemoteOpen(sqlite3_vfs *pVfs, const char *zPath);
 
-/*
-** Wrap a local ChunkStore with the DoltliteRemote vtable.
-** The ChunkStore is NOT owned (not closed on xClose).
-*/
 DoltliteRemote *doltliteLocalAsRemote(ChunkStore *pLocal);
 
-/*
-** Open an HTTP remote. URL format: http://host:port/dbname
-*/
 DoltliteRemote *doltliteHttpRemoteOpen(const char *zUrl);
 
-#endif /* DOLTLITE_REMOTE_H */
+#endif 

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -1,15 +1,4 @@
-/*
-** SQL function interface for doltlite remotes: push, fetch, pull, clone.
-**
-**   SELECT dolt_remote('add', 'origin', 'file:///path/to/remote.doltlite');
-**   SELECT dolt_remote('remove', 'origin');
-**   SELECT dolt_push('origin', 'main');
-**   SELECT dolt_fetch('origin');
-**   SELECT dolt_fetch('origin', 'main');
-**   SELECT dolt_pull('origin', 'main');
-**   SELECT dolt_clone('file:///path/to/source.doltlite');
-**   SELECT * FROM dolt_remotes;
-*/
+
 #ifdef DOLTLITE_PROLLY
 
 #include "sqliteInt.h"
@@ -20,12 +9,6 @@
 #include "doltlite_internal.h"
 #include <string.h>
 
-/*
-** Open a remote by URL. Dispatches based on scheme:
-**   file:///path  or  file://relative/path  →  filesystem remote
-**   (future: https://... → HTTP remote)
-** Returns NULL on error. Caller must close via pRemote->xClose().
-*/
 static DoltliteRemote *openRemoteByUrl(sqlite3_vfs *pVfs, const char *zUrl){
   if( strncmp(zUrl, "file://", 7)==0 ){
     return doltliteFsRemoteOpen(pVfs, zUrl + 7);
@@ -33,13 +16,10 @@ static DoltliteRemote *openRemoteByUrl(sqlite3_vfs *pVfs, const char *zUrl){
   if( strncmp(zUrl, "http://", 7)==0 ){
     return doltliteHttpRemoteOpen(zUrl);
   }
-  /* No recognized scheme */
+  
   return 0;
 }
 
-/* --------------------------------------------------------------------------
-** dolt_remote('add'|'remove', name [, url]) — manage remotes
-** -------------------------------------------------------------------------- */
 static void doltRemoteFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
   ChunkStore *cs = doltliteGetChunkStore(db);
@@ -87,9 +67,6 @@ static void doltRemoteFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
   sqlite3_result_int(ctx, 0);
 }
 
-/* --------------------------------------------------------------------------
-** dolt_push('remote', 'branch' [, '--force']) — push branch to remote
-** -------------------------------------------------------------------------- */
 static void doltPushFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
   ChunkStore *cs = doltliteGetChunkStore(db);
@@ -138,10 +115,6 @@ static void doltPushFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3_result_int(ctx, 0);
 }
 
-/* --------------------------------------------------------------------------
-** Helper: parse remote refs to get branch names for fetch-all.
-** Returns an array of branch name strings (caller frees each + array).
-** -------------------------------------------------------------------------- */
 static int parseRemoteBranchNames(
   DoltliteRemote *pRemote,
   char ***pazNames,
@@ -160,7 +133,7 @@ static int parseRemoteBranchNames(
   if( rc!=SQLITE_OK ) return rc;
   if( !refsData || nRefsData < 5 ){
     sqlite3_free(refsData);
-    return SQLITE_OK; /* no refs, no branches */
+    return SQLITE_OK; 
   }
 
   {
@@ -191,7 +164,7 @@ static int parseRemoteBranchNames(
           nNames++;
         }
         p += nameLen + PROLLY_HASH_SIZE;
-        /* Skip workingSetHash for v3+ */
+        
         if( ver >= 3 && p+PROLLY_HASH_SIZE <= refsData+nRefsData ){
           p += PROLLY_HASH_SIZE;
         }
@@ -211,9 +184,6 @@ static void freeNameList(char **azNames, int nNames){
   sqlite3_free(azNames);
 }
 
-/* --------------------------------------------------------------------------
-** dolt_fetch('remote' [, 'branch']) — fetch from remote
-** -------------------------------------------------------------------------- */
 static void doltFetchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
   ChunkStore *cs = doltliteGetChunkStore(db);
@@ -246,7 +216,7 @@ static void doltFetchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   }
 
   if( argc>=2 && sqlite3_value_type(argv[1])!=SQLITE_NULL ){
-    /* Fetch a specific branch */
+    
     const char *zBranch = (const char*)sqlite3_value_text(argv[1]);
     if( !zBranch ){
       pRemote->xClose(pRemote);
@@ -260,7 +230,7 @@ static void doltFetchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
       return;
     }
   }else{
-    /* Fetch all branches from remote */
+    
     char **azNames = 0;
     int nNames = 0;
     int i;
@@ -272,10 +242,7 @@ static void doltFetchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
       return;
     }
 
-    /* Need to close and reopen remote for each fetch since doltliteFetch
-    ** may modify the remote's state. Actually, doltliteFetch reads from
-    ** the remote, so we can reuse it, but we need to reopen for each
-    ** branch since the function opens its own remote refs. */
+    
     pRemote->xClose(pRemote);
     pRemote = 0;
 
@@ -301,9 +268,6 @@ static void doltFetchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3_result_int(ctx, 0);
 }
 
-/* --------------------------------------------------------------------------
-** dolt_pull('remote', 'branch') — fetch + fast-forward
-** -------------------------------------------------------------------------- */
 static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
   ChunkStore *cs = doltliteGetChunkStore(db);
@@ -325,7 +289,7 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     return;
   }
 
-  /* 1. Fetch the branch */
+  
   rc = chunkStoreFindRemote(cs, zRemoteName, &zUrl);
   if( rc!=SQLITE_OK || !zUrl ){
     sqlite3_result_error(ctx, "remote not found", -1);
@@ -345,17 +309,17 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     return;
   }
 
-  /* 2. Find tracking branch commit */
+  
   rc = chunkStoreFindTracking(cs, zRemoteName, zBranch, &trackingCommit);
   if( rc!=SQLITE_OK || prollyHashIsEmpty(&trackingCommit) ){
     sqlite3_result_error(ctx, "tracking branch not found after fetch", -1);
     return;
   }
 
-  /* 3. Find local branch commit */
+  
   rc = chunkStoreFindBranch(cs, zBranch, &localCommit);
   if( rc!=SQLITE_OK ){
-    /* Local branch doesn't exist — create it at tracking commit */
+    
     rc = chunkStoreAddBranch(cs, zBranch, &trackingCommit);
     if( rc!=SQLITE_OK ){
       sqlite3_result_error(ctx, "failed to create local branch", -1);
@@ -364,15 +328,13 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     localCommit = trackingCommit;
   }
 
-  /* 4. Check if already up-to-date */
+  
   if( prollyHashCompare(&localCommit, &trackingCommit)==0 ){
-    sqlite3_result_int(ctx, 0); /* already up-to-date */
+    sqlite3_result_int(ctx, 0); 
     return;
   }
 
-  /* 5. Fast-forward check: tracking commit must be a descendant of local.
-  ** For v1, we only support fast-forward. Walk the tracking commit's
-  ** parent chain and see if we hit localCommit. */
+  
   {
     ProllyHash walk;
     int maxDepth = 1000;
@@ -410,14 +372,14 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     }
   }
 
-  /* 6. Fast-forward: update local branch to tracking commit */
+  
   rc = chunkStoreUpdateBranch(cs, zBranch, &trackingCommit);
   if( rc!=SQLITE_OK ){
     sqlite3_result_error(ctx, "failed to update branch", -1);
     return;
   }
 
-  /* 7. If this is the current session branch, hard-reset to the new commit */
+  
   if( strcmp(zBranch, doltliteGetSessionBranch(db))==0 ){
     DoltliteCommit commit;
     u8 *data = 0; int nData = 0;
@@ -447,7 +409,7 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     doltliteCommitClear(&commit);
   }
 
-  /* 8. Persist refs */
+  
   rc = chunkStoreSerializeRefs(cs);
   if( rc==SQLITE_OK ) rc = chunkStoreCommit(cs);
   if( rc!=SQLITE_OK ){
@@ -457,9 +419,6 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3_result_int(ctx, 0);
 }
 
-/* --------------------------------------------------------------------------
-** dolt_clone('url') — clone a remote repository
-** -------------------------------------------------------------------------- */
 static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
   ChunkStore *cs = doltliteGetChunkStore(db);
@@ -478,7 +437,7 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     return;
   }
 
-  /* Check that local store is empty */
+  
   if( !chunkStoreIsEmpty(cs) ){
     sqlite3_result_error(ctx, "database is not empty — clone into a fresh database", -1);
     return;
@@ -497,23 +456,23 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     return;
   }
 
-  /* Set up the remote as 'origin' */
+  
   rc = chunkStoreAddRemote(cs, "origin", zUrl);
-  /* Ignore error if remote already exists (e.g., refs already had remotes) */
+  
 
-  /* Reload refs from the cloned data to populate branches/tags in memory */
+  
   {
     u8 *refsData = 0; int nRefsData = 0;
     ProllyHash refsHash;
     memcpy(&refsHash, &cs->refsHash, sizeof(ProllyHash));
     if( !prollyHashIsEmpty(&refsHash) ){
       rc = chunkStoreGet(cs, &refsHash, &refsData, &nRefsData);
-      (void)refsData; /* refs are already loaded by clone */
+      (void)refsData; 
       sqlite3_free(refsData);
     }
   }
 
-  /* Find default branch and set up session state */
+  
   {
     const char *zDefault = chunkStoreGetDefaultBranch(cs);
     ProllyHash branchCommit;
@@ -525,7 +484,7 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     if( zDefault ){
       rc = chunkStoreFindBranch(cs, zDefault, &branchCommit);
       if( rc==SQLITE_OK && !prollyHashIsEmpty(&branchCommit) ){
-        /* Load commit to get catalog hash */
+        
         u8 *data = 0; int nData = 0;
         DoltliteCommit commit;
 
@@ -549,7 +508,7 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     }
   }
 
-  /* Persist refs (including the new 'origin' remote) */
+  
   rc = chunkStoreSerializeRefs(cs);
   if( rc==SQLITE_OK ) rc = chunkStoreCommit(cs);
   if( rc!=SQLITE_OK ){
@@ -559,9 +518,6 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3_result_int(ctx, 0);
 }
 
-/* --------------------------------------------------------------------------
-** dolt_remotes virtual table (read-only)
-** -------------------------------------------------------------------------- */
 typedef struct RemVtab RemVtab;
 struct RemVtab { sqlite3_vtab base; sqlite3 *db; };
 typedef struct RemCur RemCur;
@@ -620,9 +576,6 @@ static sqlite3_module remotesModule = {
   0,0,0,0,0,0,0,0,0,0,0,0
 };
 
-/* --------------------------------------------------------------------------
-** Registration
-** -------------------------------------------------------------------------- */
 void doltliteRemoteSqlRegister(sqlite3 *db){
   sqlite3_create_function(db, "dolt_remote", -1, SQLITE_UTF8, 0,
                           doltRemoteFunc, 0, 0);
@@ -637,4 +590,4 @@ void doltliteRemoteSqlRegister(sqlite3 *db){
   sqlite3_create_module(db, "dolt_remotes", &remotesModule, 0);
 }
 
-#endif /* DOLTLITE_PROLLY */
+#endif 

--- a/src/doltlite_remotesrv.c
+++ b/src/doltlite_remotesrv.c
@@ -1,13 +1,4 @@
-/*
-** Minimal HTTP/1.1 server for doltlite remote access.
-** Serves a directory of .doltlite files over HTTP, enabling push/fetch/clone
-** from remote clients.
-**
-** URL routing: /{dbname}/endpoint
-**   where dbname maps to {zDir}/{dbname} on disk.
-**
-** Uses POSIX sockets, no external dependencies.
-*/
+
 #ifdef DOLTLITE_PROLLY
 
 #include "sqliteInt.h"
@@ -20,13 +11,13 @@
 #include <stdio.h>
 
 #ifdef _WIN32
-/* remotesrv not yet ported to Windows (requires Winsock + Win32 threads) */
+
 DoltliteServer *doltliteServerCreate(const char *z, int p, char **e){
   (void)z;(void)p; if(e) *e=sqlite3_mprintf("remotesrv not available on Windows"); return 0;
 }
 void doltliteServerDestroy(DoltliteServer *s){ (void)s; }
 int doltliteServerPort(DoltliteServer *s){ (void)s; return 0; }
-#else /* POSIX */
+#else 
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <unistd.h>
@@ -34,16 +25,12 @@ int doltliteServerPort(DoltliteServer *s){ (void)s; return 0; }
 #include <poll.h>
 
 struct DoltliteServer {
-  int listenFd;          /* Listening socket */
-  int port;              /* Actual port (may differ from requested if 0) */
-  volatile int running;  /* Set to 0 to stop */
-  char *zDir;            /* Directory containing .doltlite files */
-  pthread_t thread;      /* Background thread (for async mode) */
+  int listenFd;          
+  int port;              
+  volatile int running;  
+  char *zDir;            
+  pthread_t thread;      
 };
-
-/* ----------------------------------------------------------------
-** Hex utilities
-** ---------------------------------------------------------------- */
 
 static int hexVal(char c){
   if( c>='0' && c<='9' ) return c - '0';
@@ -62,10 +49,6 @@ static int hexToHash(const char *zHex, ProllyHash *pHash){
   }
   return SQLITE_OK;
 }
-
-/* ----------------------------------------------------------------
-** HTTP response helpers
-** ---------------------------------------------------------------- */
 
 static void sendResponse(int fd, int status, const char *zStatus,
                          const u8 *pBody, int nBody){
@@ -101,14 +84,8 @@ static void sendError(int fd){
                (const u8*)"Internal Server Error", 21);
 }
 
-/* ----------------------------------------------------------------
-** Minimal HTTP request parser
-** ---------------------------------------------------------------- */
-
-/* Maximum header size we'll accept */
 #define MAX_HEADER_SIZE 4096
 
-/* Read exactly nBytes from fd into pBuf. Returns 0 on success. */
 static int readExact(int fd, u8 *pBuf, int nBytes){
   int nRead = 0;
   while( nRead < nBytes ){
@@ -119,16 +96,11 @@ static int readExact(int fd, u8 *pBuf, int nBytes){
   return 0;
 }
 
-/*
-** Parse an HTTP request from fd.
-** Extracts method, path, content-length, and reads the body if present.
-** Returns 0 on success, -1 on error.
-*/
 static int parseRequest(
   int fd,
-  char *zMethod, int nMethodMax,    /* OUT: method (GET/POST/PUT) */
-  char *zPath, int nPathMax,        /* OUT: request path */
-  u8 **ppBody, int *pnBody          /* OUT: body (caller frees) */
+  char *zMethod, int nMethodMax,    
+  char *zPath, int nPathMax,        
+  u8 **ppBody, int *pnBody          
 ){
   char aBuf[MAX_HEADER_SIZE];
   int nBuf = 0;
@@ -139,7 +111,7 @@ static int parseRequest(
   *ppBody = 0;
   *pnBody = 0;
 
-  /* Read headers byte by byte until we find \r\n\r\n */
+  
   while( nBuf < MAX_HEADER_SIZE-1 ){
     int n = (int)read(fd, &aBuf[nBuf], 1);
     if( n <= 0 ) return -1;
@@ -154,7 +126,7 @@ static int parseRequest(
   if( !headerEnd ) return -1;
   aBuf[nBuf] = '\0';
 
-  /* Parse request line: METHOD /path HTTP/1.x\r\n */
+  
   p = aBuf;
   {
     char *pSpace = strchr(p, ' ');
@@ -177,13 +149,13 @@ static int parseRequest(
     p = pSpace + 1;
   }
 
-  /* Scan headers for Content-Length */
+  
   {
     const char *zCL = "Content-Length:";
     int nCL = (int)strlen(zCL);
     char *pLine = strstr(aBuf, zCL);
     if( !pLine ){
-      /* Try lowercase */
+      
       zCL = "content-length:";
       pLine = strstr(aBuf, zCL);
     }
@@ -194,7 +166,7 @@ static int parseRequest(
     }
   }
 
-  /* Read body if present */
+  
   if( contentLength > 0 ){
     u8 *pBody = (u8*)sqlite3_malloc(contentLength);
     if( !pBody ) return -1;
@@ -209,15 +181,6 @@ static int parseRequest(
   return 0;
 }
 
-/* ----------------------------------------------------------------
-** Path parsing: extract /{dbname}/{endpoint} from URL path
-** ---------------------------------------------------------------- */
-
-/*
-** Parse path like "/mydb/root" into dbname="mydb", endpoint="root".
-** Also handles "/mydb/chunk/HEXHASH".
-** Returns 0 on success, -1 if path doesn't match expected format.
-*/
 static int parsePath(
   const char *zPath,
   char *zDbName, int nDbNameMax,
@@ -230,9 +193,9 @@ static int parsePath(
   int dbLen, epLen;
 
   if( *p != '/' ) return -1;
-  p++; /* skip leading '/' */
+  p++; 
 
-  /* dbname is everything up to the next '/' */
+  
   dbStart = p;
   while( *p && *p != '/' ) p++;
   dbLen = (int)(p - dbStart);
@@ -241,9 +204,9 @@ static int parsePath(
   zDbName[dbLen] = '\0';
 
   if( *p != '/' ) return -1;
-  p++; /* skip '/' */
+  p++; 
 
-  /* endpoint is the rest */
+  
   epStart = p;
   epLen = (int)strlen(epStart);
   if( epLen <= 0 || epLen >= nEndpointMax ) return -1;
@@ -253,18 +216,12 @@ static int parsePath(
   return 0;
 }
 
-/* ----------------------------------------------------------------
-** Request handlers (now take ChunkStore* instead of DoltliteServer*)
-** ---------------------------------------------------------------- */
-
-/* GET /{db}/root -- Return 20-byte raw root hash */
 static void handleGetRoot(ChunkStore *pStore, int fd){
   ProllyHash root;
   chunkStoreGetRoot(pStore, &root);
   sendOk(fd, root.data, PROLLY_HASH_SIZE);
 }
 
-/* POST /{db}/has-chunks -- Batch existence check */
 static void handleHasChunks(ChunkStore *pStore, int fd,
                             const u8 *pBody, int nBody){
   int nHashes;
@@ -299,7 +256,6 @@ static void handleHasChunks(ChunkStore *pStore, int fd,
   sqlite3_free(aResult);
 }
 
-/* GET /{db}/chunk/{40-char-hex-hash} -- Download one chunk */
 static void handleGetChunk(ChunkStore *pStore, int fd, const char *zHexHash){
   ProllyHash hash;
   u8 *pData = 0;
@@ -330,7 +286,6 @@ static void handleGetChunk(ChunkStore *pStore, int fd, const char *zHexHash){
   sqlite3_free(pData);
 }
 
-/* POST /{db}/chunks -- Upload batch of chunks */
 static void handlePostChunks(ChunkStore *pStore, int fd,
                              const u8 *pBody, int nBody){
   int offset = 0;
@@ -340,10 +295,10 @@ static void handlePostChunks(ChunkStore *pStore, int fd,
     u32 len;
     ProllyHash hash;
 
-    /* Skip the client-provided hash (20 bytes) -- chunkStorePut computes it */
+    
     offset += PROLLY_HASH_SIZE;
 
-    /* Read 4-byte little-endian length */
+    
     len = (u32)pBody[offset]
         | ((u32)pBody[offset+1] << 8)
         | ((u32)pBody[offset+2] << 16)
@@ -363,7 +318,7 @@ static void handlePostChunks(ChunkStore *pStore, int fd,
     offset += (int)len;
   }
 
-  /* Commit so chunks persist across requests (store is opened per-request) */
+  
   rc = chunkStoreCommit(pStore);
   if( rc!=SQLITE_OK ){
     sendError(fd);
@@ -373,7 +328,6 @@ static void handlePostChunks(ChunkStore *pStore, int fd,
   sendOk(fd, 0, 0);
 }
 
-/* GET /{db}/refs -- Get serialized refs blob */
 static void handleGetRefs(ChunkStore *pStore, int fd){
   u8 *pData = 0;
   int nData = 0;
@@ -398,7 +352,6 @@ static void handleGetRefs(ChunkStore *pStore, int fd){
   sqlite3_free(pData);
 }
 
-/* PUT /{db}/refs -- Update refs blob */
 static void handlePutRefs(ChunkStore *pStore, int fd,
                           const u8 *pBody, int nBody){
   ProllyHash hash;
@@ -423,7 +376,7 @@ static void handlePutRefs(ChunkStore *pStore, int fd,
     return;
   }
 
-  /* Commit so refs persist across requests (store is opened per-request) */
+  
   rc = chunkStoreCommit(pStore);
   if( rc!=SQLITE_OK ){
     sendError(fd);
@@ -433,7 +386,6 @@ static void handlePutRefs(ChunkStore *pStore, int fd,
   sendOk(fd, 0, 0);
 }
 
-/* POST /{db}/commit -- Commit pending writes */
 static void handleCommit(ChunkStore *pStore, int fd){
   int rc;
 
@@ -449,7 +401,7 @@ static void handleCommit(ChunkStore *pStore, int fd){
     return;
   }
 
-  /* After refs are committed, update head/catalog from default branch */
+  
   {
     const char *zDef = chunkStoreGetDefaultBranch(pStore);
     ProllyHash branchCommit;
@@ -464,16 +416,12 @@ static void handleCommit(ChunkStore *pStore, int fd){
         }
         sqlite3_free(cdata);
       }
-      chunkStoreCommit(pStore);  /* Write updated manifest */
+      chunkStoreCommit(pStore);  
     }
   }
 
   sendOk(fd, 0, 0);
 }
-
-/* ----------------------------------------------------------------
-** Request routing
-** ---------------------------------------------------------------- */
 
 static void handleRequest(DoltliteServer *pSrv, int fd){
   char zMethod[16];
@@ -493,7 +441,7 @@ static void handleRequest(DoltliteServer *pSrv, int fd){
     return;
   }
 
-  /* Parse /{dbname}/{endpoint} */
+  
   if( parsePath(zPath, zDbName, sizeof(zDbName),
                 zEndpoint, sizeof(zEndpoint))!=0 ){
     sendNotFound(fd);
@@ -501,7 +449,7 @@ static void handleRequest(DoltliteServer *pSrv, int fd){
     return;
   }
 
-  /* Open the chunk store for this database */
+  
   sqlite3_snprintf(sizeof(zDbPath), zDbPath, "%s/%s", pSrv->zDir, zDbName);
   flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB;
   memset(&store, 0, sizeof(store));
@@ -512,7 +460,7 @@ static void handleRequest(DoltliteServer *pSrv, int fd){
     return;
   }
 
-  /* Route to handler based on method + endpoint */
+  
   if( strcmp(zMethod, "GET")==0 ){
     if( strcmp(zEndpoint, "root")==0 ){
       handleGetRoot(&store, fd);
@@ -547,10 +495,6 @@ static void handleRequest(DoltliteServer *pSrv, int fd){
   sqlite3_free(pBody);
 }
 
-/* ----------------------------------------------------------------
-** Server lifecycle
-** ---------------------------------------------------------------- */
-
 static int serverInit(DoltliteServer *pSrv, const char *zDir, int port){
   struct sockaddr_in addr;
   socklen_t addrLen;
@@ -560,13 +504,13 @@ static int serverInit(DoltliteServer *pSrv, const char *zDir, int port){
   memset(pSrv, 0, sizeof(*pSrv));
   pSrv->listenFd = -1;
 
-  /* Copy directory path */
+  
   nDir = (int)strlen(zDir);
   pSrv->zDir = sqlite3_malloc(nDir + 1);
   if( !pSrv->zDir ) return SQLITE_NOMEM;
   memcpy(pSrv->zDir, zDir, nDir + 1);
 
-  /* Create listening socket */
+  
   pSrv->listenFd = socket(AF_INET, SOCK_STREAM, 0);
   if( pSrv->listenFd < 0 ){
     sqlite3_free(pSrv->zDir);
@@ -592,7 +536,7 @@ static int serverInit(DoltliteServer *pSrv, const char *zDir, int port){
     return SQLITE_ERROR;
   }
 
-  /* Retrieve actual port (important when port==0) */
+  
   addrLen = sizeof(addr);
   if( getsockname(pSrv->listenFd, (struct sockaddr*)&addr, &addrLen)==0 ){
     pSrv->port = ntohs(addr.sin_port);
@@ -613,7 +557,7 @@ static void serverLoop(DoltliteServer *pSrv){
     pfd.events = POLLIN;
     pfd.revents = 0;
 
-    /* Poll with 1-second timeout so we can check the running flag */
+    
     if( poll(&pfd, 1, 1000) <= 0 ) continue;
 
     clientFd = accept(pSrv->listenFd, NULL, NULL);
@@ -633,10 +577,6 @@ static void serverCleanup(DoltliteServer *pSrv){
   pSrv->zDir = 0;
 }
 
-/*
-** Start serving doltlite databases in a directory over HTTP.
-** Blocks until stopped. Returns SQLITE_OK on clean shutdown.
-*/
 int doltliteServe(const char *zDir, int port){
   DoltliteServer server;
   int rc;
@@ -649,7 +589,6 @@ int doltliteServe(const char *zDir, int port){
   return SQLITE_OK;
 }
 
-/* Thread entry point for async mode */
 static void *serverThreadEntry(void *pArg){
   DoltliteServer *pSrv = (DoltliteServer*)pArg;
   serverLoop(pSrv);
@@ -657,9 +596,6 @@ static void *serverThreadEntry(void *pArg){
   return 0;
 }
 
-/*
-** Non-blocking: start server in background thread.
-*/
 DoltliteServer *doltliteServeAsync(const char *zDir, int port){
   DoltliteServer *pSrv;
   int rc;
@@ -682,13 +618,10 @@ DoltliteServer *doltliteServeAsync(const char *zDir, int port){
   return pSrv;
 }
 
-/*
-** Stop a running async server and free resources.
-*/
 void doltliteServerStop(DoltliteServer *pServer){
   if( !pServer ) return;
   pServer->running = 0;
-  /* Close the listen socket to unblock accept() */
+  
   if( pServer->listenFd >= 0 ){
     close(pServer->listenFd);
     pServer->listenFd = -1;
@@ -697,12 +630,9 @@ void doltliteServerStop(DoltliteServer *pServer){
   sqlite3_free(pServer);
 }
 
-/*
-** Return the actual port the server is listening on.
-*/
 int doltliteServerPort(DoltliteServer *pServer){
   return pServer ? pServer->port : 0;
 }
 
-#endif /* !_WIN32 */
-#endif /* DOLTLITE_PROLLY */
+#endif 
+#endif 

--- a/src/doltlite_remotesrv.h
+++ b/src/doltlite_remotesrv.h
@@ -3,17 +3,8 @@
 
 typedef struct DoltliteServer DoltliteServer;
 
-/*
-** Start serving doltlite databases in a directory over HTTP.
-** Each .doltlite file in zDir is accessible at /{dbname}/...
-** Blocks until stopped. Returns SQLITE_OK on clean shutdown.
-*/
 int doltliteServe(const char *zDir, int port);
 
-/*
-** Non-blocking: start server in background thread.
-** Use doltliteServerStop() to shut down.
-*/
 DoltliteServer *doltliteServeAsync(const char *zDir, int port);
 void doltliteServerStop(DoltliteServer *pServer);
 int doltliteServerPort(DoltliteServer *pServer);

--- a/src/doltlite_schema_diff.c
+++ b/src/doltlite_schema_diff.c
@@ -1,18 +1,4 @@
-/*
-** dolt_schema_diff('from_ref', 'to_ref') — schema-level diff between commits.
-**
-** Shows tables added, dropped, or modified (schema changed) between
-** two commits:
-**
-**   SELECT * FROM dolt_schema_diff('abc123...', 'def456...');
-**   -- table_name | from_create_stmt | to_create_stmt | diff_type
-**
-** Also accepts branch and tag names.
-** With no arguments, diffs HEAD vs working state.
-**
-** Works by reading sqlite_master (table 1) at each commit and
-** comparing the CREATE TABLE statements.
-*/
+
 #ifdef DOLTLITE_PROLLY
 
 #include "sqliteInt.h"
@@ -25,32 +11,20 @@
 #include "doltlite_internal.h"
 #include <string.h>
 
-/* --------------------------------------------------------------------------
-** Schema entry: name + CREATE statement extracted from sqlite_master rows
-** -------------------------------------------------------------------------- */
-
 typedef struct SchemaEntry SchemaEntry;
 struct SchemaEntry {
   char *zName;
-  char *zSql;       /* CREATE TABLE ... statement */
-  char *zType;      /* "table", "index", "view", etc. */
+  char *zSql;       
+  char *zType;      
 };
-
-/* --------------------------------------------------------------------------
-** Schema diff row
-** -------------------------------------------------------------------------- */
 
 typedef struct SchemaDiffRow SchemaDiffRow;
 struct SchemaDiffRow {
   char *zName;
   char *zFromSql;
   char *zToSql;
-  char *zDiffType;    /* "added", "dropped", "modified" */
+  char *zDiffType;    
 };
-
-/* --------------------------------------------------------------------------
-** Virtual table structures
-** -------------------------------------------------------------------------- */
 
 typedef struct SdVtab SdVtab;
 struct SdVtab {
@@ -80,10 +54,6 @@ static void freeSchemaDiffRows(SdCursor *c){
   c->nAlloc = 0;
 }
 
-/* --------------------------------------------------------------------------
-** Resolve a ref to a commit hash (hash, branch, or tag)
-** -------------------------------------------------------------------------- */
-
 static int sdResolveRef(ChunkStore *cs, const char *zRef, ProllyHash *pCommit){
   int rc;
   if( zRef && strlen(zRef)==40 ){
@@ -96,16 +66,6 @@ static int sdResolveRef(ChunkStore *cs, const char *zRef, ProllyHash *pCommit){
   if( rc==SQLITE_OK && !prollyHashIsEmpty(pCommit) ) return SQLITE_OK;
   return SQLITE_NOTFOUND;
 }
-
-/* --------------------------------------------------------------------------
-** Extract schema entries from sqlite_master (table 1) at a given catalog.
-**
-** sqlite_master rows are SQLite records with fields:
-**   type(TEXT), name(TEXT), tbl_name(TEXT), rootpage(INT), sql(TEXT)
-**
-** We use ProllyCursor to scan table 1's prolly tree, then parse each
-** row's record to extract name and sql.
-** -------------------------------------------------------------------------- */
 
 static int parseRecordHeader(
   const u8 *pData, int nData,
@@ -121,7 +81,7 @@ static int parseRecordHeader(
 
   if( nData < 1 ) return 0;
 
-  /* Header size varint */
+  
   hdrBytes = dlReadVarint(p, pDataEnd, &hdrSize);
   p += hdrBytes;
 
@@ -136,8 +96,8 @@ static int parseRecordHeader(
     aType[iField] = (int)st;
     aOffset[iField] = off;
 
-    /* Compute field size from serial type */
-    if( st==0 ) { /* NULL */ }
+    
+    if( st==0 ) {  }
     else if( st==1 ) off += 1;
     else if( st==2 ) off += 2;
     else if( st==3 ) off += 3;
@@ -145,9 +105,9 @@ static int parseRecordHeader(
     else if( st==5 ) off += 6;
     else if( st==6 ) off += 8;
     else if( st==7 ) off += 8;
-    else if( st==8 || st==9 ) { /* 0 or 1, 0 bytes */ }
-    else if( st>=12 && (st&1)==0 ) off += ((int)st-12)/2;  /* blob */
-    else if( st>=13 && (st&1)==1 ) off += ((int)st-13)/2;  /* text */
+    else if( st==8 || st==9 ) {  }
+    else if( st>=12 && (st&1)==0 ) off += ((int)st-12)/2;  
+    else if( st>=13 && (st&1)==1 ) off += ((int)st-13)/2;  
     iField++;
   }
 
@@ -173,7 +133,7 @@ static int loadSchemaFromCatalog(
   rc = doltliteLoadCatalog(db, pCatHash, &aTables, &nTables, 0);
   if( rc!=SQLITE_OK ){ *ppEntries = 0; *pnEntries = 0; return rc; }
 
-  /* Find table 1 (sqlite_master) */
+  
   memset(&masterRoot, 0, sizeof(masterRoot));
   for(i=0; i<nTables; i++){
     if( aTables[i].iTable==1 ){
@@ -189,7 +149,7 @@ static int loadSchemaFromCatalog(
     return SQLITE_OK;
   }
 
-  /* Scan sqlite_master rows */
+  
   prollyCursorInit(&cur, cs, pCache, &masterRoot, masterFlags);
   rc = prollyCursorFirst(&cur, &res);
   if( rc!=SQLITE_OK || res ){ prollyCursorClose(&cur); *ppEntries = 0; *pnEntries = 0; return rc; }
@@ -204,11 +164,11 @@ static int loadSchemaFromCatalog(
     if( pVal && nVal > 0 ){
       nFields = parseRecordHeader(pVal, nVal, aType, aOffset, 5);
 
-      /* We need: field 0 = type, field 1 = name, field 4 = sql */
+      
       if( nFields >= 5 ){
         char *zType = 0, *zName = 0, *zSql = 0;
 
-        /* Extract text fields */
+        
         if( aType[0] >= 13 && (aType[0]&1)==1 ){
           int len = (aType[0]-13)/2;
           if( aOffset[0]+len <= nVal ){
@@ -270,10 +230,6 @@ static void freeSchemaEntries(SchemaEntry *a, int n){
   sqlite3_free(a);
 }
 
-/* --------------------------------------------------------------------------
-** Find a schema entry by name
-** -------------------------------------------------------------------------- */
-
 static SchemaEntry *findSchemaEntry(SchemaEntry *a, int n, const char *zName){
   int i;
   for(i=0; i<n; i++){
@@ -282,10 +238,6 @@ static SchemaEntry *findSchemaEntry(SchemaEntry *a, int n, const char *zName){
   return 0;
 }
 
-/* --------------------------------------------------------------------------
-** Compute schema diff between two sets of entries
-** -------------------------------------------------------------------------- */
-
 static int computeSchemaDiff(
   SdCursor *pCur,
   SchemaEntry *aFrom, int nFrom,
@@ -293,13 +245,13 @@ static int computeSchemaDiff(
 ){
   int i;
 
-  /* Check each "to" entry: added or modified */
+  
   for(i=0; i<nTo; i++){
     SchemaEntry *fromEntry = findSchemaEntry(aFrom, nFrom, aTo[i].zName);
     SchemaDiffRow *r;
 
     if( !fromEntry ){
-      /* Added */
+      
       if( pCur->nRows >= pCur->nAlloc ){
         int nNew = pCur->nAlloc ? pCur->nAlloc*2 : 16;
         SchemaDiffRow *aNew = sqlite3_realloc(pCur->aRows, nNew*(int)sizeof(SchemaDiffRow));
@@ -314,7 +266,7 @@ static int computeSchemaDiff(
       r->zDiffType = "added";
     }else if( fromEntry->zSql && aTo[i].zSql
            && strcmp(fromEntry->zSql, aTo[i].zSql)!=0 ){
-      /* Modified */
+      
       if( pCur->nRows >= pCur->nAlloc ){
         int nNew = pCur->nAlloc ? pCur->nAlloc*2 : 16;
         SchemaDiffRow *aNew = sqlite3_realloc(pCur->aRows, nNew*(int)sizeof(SchemaDiffRow));
@@ -330,7 +282,7 @@ static int computeSchemaDiff(
     }
   }
 
-  /* Check each "from" entry: dropped if not in "to" */
+  
   for(i=0; i<nFrom; i++){
     SchemaEntry *toEntry = findSchemaEntry(aTo, nTo, aFrom[i].zName);
     if( !toEntry ){
@@ -352,10 +304,6 @@ static int computeSchemaDiff(
 
   return SQLITE_OK;
 }
-
-/* --------------------------------------------------------------------------
-** Virtual table methods
-** -------------------------------------------------------------------------- */
 
 static const char *sdSchema =
   "CREATE TABLE x("
@@ -460,21 +408,20 @@ static int sdFilter(sqlite3_vtab_cursor *cur,
     zToRef = (const char*)sqlite3_value_text(argv[argIdx++]);
   }
 
-  /* Single argument that's not a valid ref = table name filter.
-  ** In this mode, diff HEAD vs working for that specific table. */
+  
   {
     const char *zTableFilter = 0;
     if( zFromRef && !zToRef ){
       ProllyHash testHash;
       int resolved = sdResolveRef(cs, zFromRef, &testHash);
       if( resolved!=SQLITE_OK ){
-        /* Not a valid commit/branch/tag — treat as table name */
+        
         zTableFilter = zFromRef;
         zFromRef = 0;
       }
     }
 
-    /* Resolve "from" ref → catalog hash */
+    
     if( zFromRef ){
     rc = sdResolveRef(cs, zFromRef, &fromCommit);
     if( rc!=SQLITE_OK ) return SQLITE_OK;
@@ -488,12 +435,12 @@ static int sdFilter(sqlite3_vtab_cursor *cur,
     memcpy(&fromCatHash, &commit.catalogHash, sizeof(ProllyHash));
     doltliteCommitClear(&commit);
   }else{
-    /* Default: HEAD */
+    
     rc = doltliteGetHeadCatalogHash(db, &fromCatHash);
     if( rc!=SQLITE_OK ) return SQLITE_OK;
   }
 
-  /* Resolve "to" ref → catalog hash */
+  
   if( zToRef ){
     rc = sdResolveRef(cs, zToRef, &toCommit);
     if( rc!=SQLITE_OK ) return SQLITE_OK;
@@ -507,7 +454,7 @@ static int sdFilter(sqlite3_vtab_cursor *cur,
     memcpy(&toCatHash, &commit.catalogHash, sizeof(ProllyHash));
     doltliteCommitClear(&commit);
   }else{
-    /* Default: working state */
+    
     u8 *catData = 0; int nCatData = 0;
     rc = doltliteFlushAndSerializeCatalog(db, &catData, &nCatData);
     if( rc==SQLITE_OK ){
@@ -517,14 +464,14 @@ static int sdFilter(sqlite3_vtab_cursor *cur,
     if( rc!=SQLITE_OK ) return SQLITE_OK;
   }
 
-  /* Load schema at both points */
+  
   loadSchemaFromCatalog(db, cs, pCache, &fromCatHash, &aFrom, &nFrom);
   loadSchemaFromCatalog(db, cs, pCache, &toCatHash, &aTo, &nTo);
 
-  /* Compute diff */
+  
   computeSchemaDiff(c, aFrom, nFrom, aTo, nTo);
 
-  /* If filtering by table name, remove rows that don't match */
+  
   if( zTableFilter ){
     int j, k=0;
     for(j=0; j<c->nRows; j++){
@@ -540,7 +487,7 @@ static int sdFilter(sqlite3_vtab_cursor *cur,
     c->nRows = k;
   }
 
-  } /* end of zTableFilter scope */
+  } 
 
   freeSchemaEntries(aFrom, nFrom);
   freeSchemaEntries(aTo, nTo);
@@ -583,4 +530,4 @@ int doltliteSchemaDiffRegister(sqlite3 *db){
   return sqlite3_create_module(db, "dolt_schema_diff", &schemaDiffModule, 0);
 }
 
-#endif /* DOLTLITE_PROLLY */
+#endif 

--- a/src/doltlite_status.c
+++ b/src/doltlite_status.c
@@ -1,12 +1,4 @@
-/*
-** dolt_status virtual table: shows working and staged changes.
-**
-** Usage:
-**   SELECT * FROM dolt_status;
-**   -- table_name | staged | status
-**   -- users      | 0      | modified
-**   -- users      | 0      | schema modified
-*/
+
 #ifdef DOLTLITE_PROLLY
 
 #include "sqliteInt.h"
@@ -14,8 +6,6 @@
 #include "chunk_store.h"
 #include "doltlite_commit.h"
 #include "doltlite_internal.h"
-
-/* -------------------------------------------------------------------------- */
 
 typedef struct StatusRow StatusRow;
 struct StatusRow {
@@ -36,7 +26,6 @@ struct DoltliteStatusCursor {
 static const char *statusSchema =
   "CREATE TABLE x(table_name TEXT, staged INTEGER, status TEXT)";
 
-/* findInCatalog replaced by doltliteFindTableByNumber in doltlite_internal.h */
 #define findInCatalog(a,n,t) doltliteFindTableByNumber(a,n,t)
 
 static void addRow(DoltliteStatusCursor *pCur, const char *zName,
@@ -70,11 +59,11 @@ static void compareCatalogs(
     if(!pFrom){
       addRow(pCur, zName, staged, "new table");
     }else{
-      /* Check data changes */
+      
       if(prollyHashCompare(&pFrom->root, &aTo[i].root)!=0){
         addRow(pCur, zName, staged, "modified");
       }
-      /* Check schema changes (schemaHash differs) */
+      
       if(!prollyHashIsEmpty(&pFrom->schemaHash)
        && !prollyHashIsEmpty(&aTo[i].schemaHash)
        && prollyHashCompare(&pFrom->schemaHash, &aTo[i].schemaHash)!=0){
@@ -95,8 +84,6 @@ static void compareCatalogs(
     }
   }
 }
-
-/* -------------------------------------------------------------------------- */
 
 static int statusConnect(sqlite3 *db, void *pAux, int argc,
     const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){
@@ -213,4 +200,4 @@ int doltliteStatusRegister(sqlite3 *db){
   return sqlite3_create_module(db,"dolt_status",&doltliteStatusModule,0);
 }
 
-#endif /* DOLTLITE_PROLLY */
+#endif 

--- a/src/doltlite_tag.c
+++ b/src/doltlite_tag.c
@@ -1,11 +1,4 @@
-/*
-** dolt_tag and dolt_tags: immutable named pointers to commits.
-**
-**   SELECT dolt_tag('v1.0');                           -- tag HEAD
-**   SELECT dolt_tag('v1.0', 'abc123...');              -- tag specific commit
-**   SELECT dolt_tag('-d', 'v1.0');                     -- delete tag
-**   SELECT * FROM dolt_tags;                           -- list tags
-*/
+
 #ifdef DOLTLITE_PROLLY
 
 #include "sqliteInt.h"
@@ -15,9 +8,6 @@
 #include "doltlite_internal.h"
 #include <string.h>
 
-/* --------------------------------------------------------------------------
-** dolt_tag('name' [, 'commit_hash']) or dolt_tag('-d', 'name')
-** -------------------------------------------------------------------------- */
 static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
   ChunkStore *cs = doltliteGetChunkStore(db);
@@ -39,10 +29,10 @@ static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
       return;
     }
   }else{
-    /* Create tag */
+    
     ProllyHash commitHash;
     if( argc>=2 ){
-      /* Tag a specific commit */
+      
       const char *zHash = (const char*)sqlite3_value_text(argv[1]);
       if( !zHash ){ sqlite3_result_error(ctx, "invalid commit hash", -1); return; }
       rc = doltliteHexToHash(zHash, &commitHash);
@@ -51,7 +41,7 @@ static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
         return;
       }
     }else{
-      /* Tag HEAD */
+      
       doltliteGetSessionHead(db, &commitHash);
       if( prollyHashIsEmpty(&commitHash) ){
         sqlite3_result_error(ctx, "no commits to tag", -1);
@@ -71,9 +61,6 @@ static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3_result_int(ctx, 0);
 }
 
-/* --------------------------------------------------------------------------
-** dolt_tags virtual table
-** -------------------------------------------------------------------------- */
 typedef struct TagVtab TagVtab;
 struct TagVtab { sqlite3_vtab base; sqlite3 *db; };
 typedef struct TagCur TagCur;
@@ -122,7 +109,7 @@ static int tagColumn(sqlite3_vtab_cursor *c, sqlite3_context *ctx, int col){
       break;
     }
     case 2: {
-      /* Load commit to get message */
+      
       u8 *data=0; int nData=0;
       int rc = chunkStoreGet(cs, &t->commitHash, &data, &nData);
       if( rc==SQLITE_OK && data ){
@@ -158,4 +145,4 @@ int doltliteTagRegister(sqlite3 *db){
   return rc;
 }
 
-#endif /* DOLTLITE_PROLLY */
+#endif 

--- a/src/pager_shim.c
+++ b/src/pager_shim.c
@@ -1,39 +1,21 @@
-/*
-** Pager shim implementation.
-**
-** When DOLTLITE_PROLLY is defined, the real pager.c is not linked.
-** Instead, sqlite3BtreePager() returns a PagerShim* cast to Pager*.
-** This file implements the subset of sqlite3Pager* functions that are
-** actually called by the 18 files which use sqlite3BtreePager().
-**
-** The PagerShim struct is defined in pager_shim.h. External code
-** receives a Pager* which is really a PagerShim*, so every function
-** here casts its Pager* argument to PagerShim* before accessing fields.
-**
-** Dispatch uses a PagerOps vtable: shim pagers use shimPagerOps,
-** original pagers use origPagerOps. The getPagerOps() helper
-** selects the correct table based on PagerShim magic.
-*/
+
 #ifdef DOLTLITE_PROLLY
 
 #include "pager_shim.h"
 #include "sqliteInt.h"
 #include "chunk_store.h"
 
-/* Globals expected by test code */
 int sqlite3_pager_writej_count = 0;
 int sqlite3_pager_readdb_count = 0;
 int sqlite3_pager_writedb_count = 0;
 int sqlite3_opentemp_count = 0;
 
-/* Shared cache list (empty — no shared cache in prolly) */
 BtShared *SQLITE_WSD sqlite3SharedCacheList = 0;
 
 #include <string.h>
 
 #define SHIM(p) ((PagerShim*)(p))
 
-/* Forward declarations for original pager dispatch */
 extern u32 orig_sqlite3PagerDataVersion(Pager *pPager);
 extern sqlite3_file *orig_sqlite3PagerFile(Pager *pPager);
 extern const char *orig_sqlite3PagerFilename(const Pager *pPager, int);
@@ -90,9 +72,6 @@ extern void orig_sqlite3PagerPagecount(Pager*, int*);
 extern int orig_sqlite3PagerCommitPhaseOne(Pager*, const char*, int);
 extern int orig_sqlite3PagerCommitPhaseTwo(Pager*);
 
-/* -----------------------------------------------------------------------
-** PagerOps vtable — function pointers for all dispatched pager operations
-** ----------------------------------------------------------------------- */
 struct PagerOps {
   sqlite3_file *(*xFile)(Pager*);
   const char *(*xFilename)(const Pager*, int);
@@ -144,9 +123,6 @@ struct PagerOps {
 #endif
 };
 
-/* -----------------------------------------------------------------------
-** Dummy file object for :memory: databases
-** ----------------------------------------------------------------------- */
 static int dummyClose(sqlite3_file *p){ (void)p; return SQLITE_OK; }
 static int dummyRead(sqlite3_file *p, void *b, int n, sqlite3_int64 o){
   (void)p; (void)b; (void)n; (void)o; return SQLITE_IOERR_SHORT_READ;
@@ -170,29 +146,25 @@ static int dummyFileControl(sqlite3_file *p, int op, void *a){
 static int dummySectorSize(sqlite3_file *p){ (void)p; return 4096; }
 static int dummyDevChar(sqlite3_file *p){ (void)p; return 0; }
 static const sqlite3_io_methods dummyIoMethods = {
-  1,                  /* iVersion */
-  dummyClose,         /* xClose */
-  dummyRead,          /* xRead */
-  dummyWrite,         /* xWrite */
-  dummyTruncate,      /* xTruncate */
-  dummySync,          /* xSync */
-  dummyFileSize,      /* xFileSize */
-  dummyLock,          /* xLock */
-  dummyUnlock,        /* xUnlock */
-  dummyCheckLock,     /* xCheckReservedLock */
-  dummyFileControl,   /* xFileControl */
-  dummySectorSize,    /* xSectorSize */
-  dummyDevChar        /* xDeviceCharacteristics */
+  1,                  
+  dummyClose,         
+  dummyRead,          
+  dummyWrite,         
+  dummyTruncate,      
+  dummySync,          
+  dummyFileSize,      
+  dummyLock,          
+  dummyUnlock,        
+  dummyCheckLock,     
+  dummyFileControl,   
+  dummySectorSize,    
+  dummyDevChar        
 };
 static sqlite3_file dummyFileObj;
 static sqlite3_file *pagerShimDummyFile(void){
   dummyFileObj.pMethods = &dummyIoMethods;
   return &dummyFileObj;
 }
-
-/* -----------------------------------------------------------------------
-** Shim vtable implementations — extracted from inline dispatch logic
-** ----------------------------------------------------------------------- */
 
 static sqlite3_file *shimPagerFile(Pager *p){
   return SHIM(p)->pFd;
@@ -362,11 +334,7 @@ static int shimPagerOpenWal(Pager *p, int *pisOpen){
 static int shimPagerCloseWal(Pager *p, sqlite3 *db){
   (void)p; (void)db; return SQLITE_OK;
 }
-#endif /* SQLITE_OMIT_WAL */
-
-/* -----------------------------------------------------------------------
-** Vtable instances
-** ----------------------------------------------------------------------- */
+#endif 
 
 static const PagerOps shimPagerOps = {
   shimPagerFile,
@@ -470,10 +438,6 @@ static const PagerOps origPagerOps = {
 #endif
 };
 
-/*
-** Return the PagerOps vtable for a given Pager pointer.
-** Shim pagers use shimPagerOps; original pagers use origPagerOps.
-*/
 static inline const PagerOps *getPagerOps(const Pager *p){
   if( p && ((const PagerShim*)p)->magic == PAGER_SHIM_MAGIC ){
     return ((const PagerShim*)p)->pOps;
@@ -481,19 +445,6 @@ static inline const PagerOps *getPagerOps(const Pager *p){
   return &origPagerOps;
 }
 
-/* -----------------------------------------------------------------------
-** Lifecycle: create and destroy
-** ----------------------------------------------------------------------- */
-
-/*
-** Allocate a new PagerShim.
-**
-**   pVfs       — VFS to remember (may be NULL)
-**   zFilename  — database file path; NULL and "" are both valid
-**   pFd        — open file descriptor (may be NULL for :memory:)
-**
-** Returns NULL on OOM.
-*/
 PagerShim *pagerShimCreate(
   sqlite3_vfs *pVfs,
   const char *zFilename,
@@ -507,7 +458,7 @@ PagerShim *pagerShimCreate(
   pShim->magic = PAGER_SHIM_MAGIC;
   pShim->pOps = &shimPagerOps;
 
-  /* Copy the filename.  Treat NULL as empty string. */
+  
   if( zFilename && zFilename[0] ){
     int n = (int)strlen(zFilename);
     pShim->zFilename = (char*)sqlite3_malloc(n + 1);
@@ -525,7 +476,7 @@ PagerShim *pagerShimCreate(
     pShim->zFilename[0] = '\0';
   }
 
-  /* Journal name is always an empty string for the shim. */
+  
   pShim->zJournal = (char*)sqlite3_malloc(1);
   if( pShim->zJournal==0 ){
     sqlite3_free(pShim->zFilename);
@@ -534,7 +485,7 @@ PagerShim *pagerShimCreate(
   }
   pShim->zJournal[0] = '\0';
 
-  /* Provide a dummy file object when pFd is NULL (e.g., :memory: dbs). */
+  
   if( pFd==0 ){
     pFd = pagerShimDummyFile();
   }
@@ -542,24 +493,17 @@ PagerShim *pagerShimCreate(
   pShim->pVfs         = pVfs;
   pShim->journalMode  = PAGER_JOURNALMODE_WAL;
   pShim->eLock        = 0;
-  pShim->iDataVersion = 1;   /* Start at 1 so the first check sees data */
+  pShim->iDataVersion = 1;   
 
   return pShim;
 }
 
-/*
-** Free all memory associated with a PagerShim.
-*/
 void pagerShimDestroy(PagerShim *pShim){
   if( pShim==0 ) return;
   sqlite3_free(pShim->zFilename);
   sqlite3_free(pShim->zJournal);
   sqlite3_free(pShim);
 }
-
-/* -----------------------------------------------------------------------
-** Dispatch functions — thin wrappers that delegate through PagerOps
-** ----------------------------------------------------------------------- */
 
 sqlite3_file *sqlite3PagerFile(Pager *pPager){
   return getPagerOps(pPager)->xFile(pPager);
@@ -638,10 +582,6 @@ int sqlite3PagerGet(Pager *pPager, Pgno pgno, DbPage **ppPage, int clrFlag){
   return getPagerOps(pPager)->xGet(pPager, pgno, ppPage, clrFlag);
 }
 
-/* -----------------------------------------------------------------------
-** DbPage-based functions — dispatch on page pointer, not on Pager vtable
-** ----------------------------------------------------------------------- */
-
 void *sqlite3PagerGetData(DbPage *pPg){
   if( pPg ) return orig_sqlite3PagerGetData(pPg);
   return 0;
@@ -678,10 +618,6 @@ int sqlite3PagerPageRefcount(DbPage *pPg){
   if( pPg ) return orig_sqlite3PagerPageRefcount(pPg);
   return 0;
 }
-
-/* -----------------------------------------------------------------------
-** More Pager dispatch functions
-** ----------------------------------------------------------------------- */
 
 void sqlite3PagerPagecount(Pager *pPager, int *pnPage){
   getPagerOps(pPager)->xPagecount(pPager, pnPage);
@@ -829,20 +765,16 @@ int sqlite3PagerCloseWal(Pager *pPager, sqlite3 *db){
 }
 #endif
 
-/* shared cache stub */
 int sqlite3_enable_shared_cache(int enable){
   (void)enable;
   return SQLITE_OK;
 }
 
-/* database_file_object stub */
 sqlite3_file *sqlite3_database_file_object(const char *zName){
   (void)zName;
   return 0;
 }
 
-/* Always provide these — test code links against libsqlite3.a which may
-** not have been compiled with SQLITE_TEST, but testfixture needs them. */
 Pgno sqlite3PagerPagenumber(DbPage *pPg){
   (void)pPg;
   return 0;
@@ -861,7 +793,6 @@ void sqlite3PagerRefdump(Pager *pPager){
   (void)pPager;
 }
 
-/* Undef macros from pager.h so we can define actual functions */
 #undef disable_simulated_io_errors
 #undef enable_simulated_io_errors
 void disable_simulated_io_errors(void){
@@ -869,26 +800,16 @@ void disable_simulated_io_errors(void){
 void enable_simulated_io_errors(void){
 }
 
-/* -----------------------------------------------------------------------
-** Backup API — copies the chunk store file from source to destination.
-** The chunk store is a single self-contained file, so a complete backup
-** is just a file copy.  For ATTACH'd standard SQLite databases, delegates
-** to the original backup implementation.
-** ----------------------------------------------------------------------- */
-
-/* doltliteGetChunkStore is declared in doltlite_internal.h, but pager_shim
-** is a lower layer — use a local forward declaration instead. */
 ChunkStore *doltliteGetChunkStore(sqlite3 *db);
 
-/* Backup state for prolly-tree chunk store file copy. */
 typedef struct DoltliteBackup DoltliteBackup;
 struct DoltliteBackup {
   sqlite3 *pSrcDb;
   sqlite3 *pDestDb;
-  char *zSrcFile;       /* Source chunk store file path (owned copy) */
-  char *zDestFile;      /* Destination chunk store file path (owned copy) */
+  char *zSrcFile;       
+  char *zDestFile;      
   sqlite3_vfs *pVfs;
-  int done;             /* 1 after step completes the copy */
+  int done;             
 };
 
 sqlite3_backup *sqlite3_backup_init(sqlite3 *pDest, const char *zDestDb,
@@ -900,21 +821,21 @@ sqlite3_backup *sqlite3_backup_init(sqlite3 *pDest, const char *zDestDb,
 
   if( !pDest || !pSrc || pDest==pSrc ) return 0;
 
-  /* Find the named databases */
+  
   iSrc = sqlite3FindDbName(pSrc, zSrcDb);
   iDest = sqlite3FindDbName(pDest, zDestDb);
   if( iSrc < 0 || iDest < 0 ) return 0;
 
-  /* For non-main databases (ATTACH'd SQLite btrees), delegate to original */
+  
   if( iSrc != 0 || iDest != 0 ){
     return orig_sqlite3_backup_init(pDest, zDestDb, pSrc, zSrcDb);
   }
 
-  /* Get chunk stores */
+  
   srcCs = doltliteGetChunkStore(pSrc);
   destCs = doltliteGetChunkStore(pDest);
   if( !srcCs || !srcCs->zFilename ) return 0;
-  if( srcCs->isMemory ) return 0;  /* Can't backup in-memory databases */
+  if( srcCs->isMemory ) return 0;  
   if( !destCs || !destCs->zFilename ) return 0;
 
   p = (DoltliteBackup*)sqlite3_malloc(sizeof(DoltliteBackup));
@@ -948,7 +869,7 @@ int sqlite3_backup_step(sqlite3_backup *pBackup, int nPage){
   if( !p ) return SQLITE_DONE;
   if( p->done ) return SQLITE_DONE;
 
-  /* Open source file for reading */
+  
   openFlags = SQLITE_OPEN_READONLY | SQLITE_OPEN_MAIN_DB;
   rc = sqlite3OsOpenMalloc(p->pVfs, p->zSrcFile, &pSrc, openFlags, 0);
   if( rc != SQLITE_OK ) return rc;
@@ -958,7 +879,7 @@ int sqlite3_backup_step(sqlite3_backup *pBackup, int nPage){
     sqlite3OsCloseFree(pSrc);
     return rc;
   }
-  /* Open/create destination file for writing */
+  
   openFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB;
   rc = sqlite3OsOpenMalloc(p->pVfs, p->zDestFile, &pDest, openFlags, 0);
   if( rc != SQLITE_OK ){
@@ -966,7 +887,7 @@ int sqlite3_backup_step(sqlite3_backup *pBackup, int nPage){
     return rc;
   }
 
-  /* Copy in 64KB chunks (VFS write size limit) */
+  
   {
     u8 *buf = (u8*)sqlite3_malloc(65536);
     i64 off = 0;
@@ -1018,7 +939,7 @@ int sqlite3_backup_remaining(sqlite3_backup *pBackup){
 int sqlite3_backup_pagecount(sqlite3_backup *pBackup){
   DoltliteBackup *p = (DoltliteBackup*)pBackup;
   if( !p ) return 0;
-  return 1;  /* Single "page" = entire chunk store file */
+  return 1;  
 }
 
-#endif /* DOLTLITE_PROLLY */
+#endif 

--- a/src/pager_shim.h
+++ b/src/pager_shim.h
@@ -1,4 +1,4 @@
-
+/* Shim that implements the Pager interface on top of ChunkStore instead of btree pages. */
 #ifndef SQLITE_PAGER_SHIM_H
 #define SQLITE_PAGER_SHIM_H
 

--- a/src/pager_shim.h
+++ b/src/pager_shim.h
@@ -1,75 +1,50 @@
-/*
-** Pager shim: minimal Pager facade for code that calls sqlite3BtreePager().
-** Provides filename, file handle, and dummy journal mode responses
-** without the real pager implementation.
-*/
+
 #ifndef SQLITE_PAGER_SHIM_H
 #define SQLITE_PAGER_SHIM_H
 
 #include "sqliteInt.h"
 
-/*
-** Shim Pager structure — enough fields to satisfy the 18 files
-** that call sqlite3BtreePager() and then use the result.
-*/
 typedef struct PagerShim PagerShim;
 typedef struct PagerOps PagerOps;
-#define PAGER_SHIM_MAGIC 0x50534D31  /* "PSM1" */
+#define PAGER_SHIM_MAGIC 0x50534D31  
 struct PagerShim {
-  u32 magic;                   /* PAGER_SHIM_MAGIC — identifies this as PagerShim */
-  const PagerOps *pOps;        /* Vtable for shim or original pager dispatch */
-  sqlite3_file *pFd;        /* File descriptor (may be NULL for :memory:) */
-  char *zFilename;           /* Database filename */
-  char *zJournal;            /* Journal filename (always empty string) */
-  u8 eLock;                  /* Current lock level */
-  u8 journalMode;            /* Journal mode (WAL for doltlite databases) */
-  u32 iDataVersion;          /* Data version counter */
-  sqlite3_vfs *pVfs;         /* VFS reference */
+  u32 magic;                   
+  const PagerOps *pOps;        
+  sqlite3_file *pFd;        
+  char *zFilename;           
+  char *zJournal;            
+  u8 eLock;                  
+  u8 journalMode;            
+  u32 iDataVersion;          
+  sqlite3_vfs *pVfs;         
 };
 
-/* Create a pager shim for a given filename */
 PagerShim *pagerShimCreate(sqlite3_vfs *pVfs, const char *zFilename,
                            sqlite3_file *pFd);
 
-/* Destroy a pager shim */
 void pagerShimDestroy(PagerShim *pShim);
 
-/*
-** The following functions match the subset of Pager API that external
-** code actually uses after calling sqlite3BtreePager().
-** They are implemented so that a PagerShim* can be cast to Pager*
-** and these calls work.
-*/
-
-/* Get the file descriptor */
 sqlite3_file *sqlite3PagerFile(Pager*);
 
-/* Get filename */
 const char *sqlite3PagerFilename(const Pager*, int);
 
-/* Get journal name */
 const char *sqlite3PagerJournalname(Pager*);
 
-/* Get/set journal mode */
 int sqlite3PagerGetJournalMode(Pager*);
 int sqlite3PagerOkToChangeJournalMode(Pager*);
 int sqlite3PagerSetJournalMode(Pager*, int);
 
-/* Lock queries */
 int sqlite3PagerExclusiveLock(Pager*);
 u8 sqlite3PagerIsreadonly(Pager*);
 
-/* Ref count */
 int sqlite3PagerRefcount(Pager*);
 
-/* Data version */
 u32 sqlite3PagerDataVersion(Pager*);
 
-/* No-op stubs */
 void sqlite3PagerShrink(Pager*);
 int sqlite3PagerFlush(Pager*);
 void sqlite3PagerCacheStat(Pager*, int, int, u64*);
 int sqlite3PagerIsMemdb(Pager*);
 int sqlite3PagerLockingMode(Pager*, int);
 
-#endif /* SQLITE_PAGER_SHIM_H */
+#endif 

--- a/src/prolly_arena.c
+++ b/src/prolly_arena.c
@@ -3,26 +3,17 @@
 #include "prolly_arena.h"
 #include <string.h>
 
-/*
-** Initialize an arena with the given default block size.
-** No memory is allocated until the first call to prollyArenaAlloc.
-*/
 void prollyArenaInit(ProllyArena *a, int defaultBlockSize){
   memset(a, 0, sizeof(*a));
   a->defaultBlockSize = defaultBlockSize;
 }
 
-/*
-** Allocate n bytes from the arena. Returns NULL on OOM.
-** If the current block does not have enough room, a new block is allocated
-** whose usable size is the larger of defaultBlockSize and n.
-*/
 void *prollyArenaAlloc(ProllyArena *a, int n){
   ProllyArenaBlock *b;
   void *p;
 
   b = a->pCurrent;
-  /* Align to 8 bytes */
+  
   if( b ){
     int aligned_used = (b->used + 7) & ~7;
     if( (b->sz - aligned_used) >= n ){
@@ -32,13 +23,13 @@ void *prollyArenaAlloc(ProllyArena *a, int n){
     }
   }
 
-  /* Need a new block. Size is at least defaultBlockSize or n. */
+  
   {
     int blockSz = a->defaultBlockSize;
     if( n > blockSz ) blockSz = n;
 
     int totalSz = (int)sizeof(ProllyArenaBlock) + blockSz;
-    if( totalSz < blockSz ){  /* overflow */
+    if( totalSz < blockSz ){  
       return 0;
     }
     b = (ProllyArenaBlock*)sqlite3_malloc(totalSz);
@@ -59,26 +50,19 @@ void *prollyArenaAlloc(ProllyArena *a, int n){
   }
 }
 
-/*
-** Allocate n bytes from the arena and zero-initialize them.
-*/
 void *prollyArenaAllocZero(ProllyArena *a, int n){
   void *p = prollyArenaAlloc(a, n);
   if( p ) memset(p, 0, n);
   return p;
 }
 
-/*
-** Reset the arena: free all blocks except the first, reset the first
-** block's usage counter to zero.
-*/
 void prollyArenaReset(ProllyArena *a){
   ProllyArenaBlock *b;
 
   b = a->pFirst;
   if( b==0 ) return;
 
-  /* Free all blocks after the first */
+  
   {
     ProllyArenaBlock *pNext;
     ProllyArenaBlock *p = b->pNext;
@@ -94,9 +78,6 @@ void prollyArenaReset(ProllyArena *a){
   a->pCurrent = b;
 }
 
-/*
-** Destroy the arena: free all blocks and zero out the struct.
-*/
 void prollyArenaFree(ProllyArena *a){
   ProllyArenaBlock *b = a->pFirst;
   while( b ){
@@ -107,4 +88,4 @@ void prollyArenaFree(ProllyArena *a){
   memset(a, 0, sizeof(*a));
 }
 
-#endif /* DOLTLITE_PROLLY */
+#endif 

--- a/src/prolly_arena.h
+++ b/src/prolly_arena.h
@@ -1,7 +1,4 @@
-/*
-** Bump allocator for prolly tree traversals.
-** Allocations are freed all at once when the arena is reset.
-*/
+
 #ifndef SQLITE_PROLLY_ARENA_H
 #define SQLITE_PROLLY_ARENA_H
 
@@ -11,31 +8,26 @@ typedef struct ProllyArena ProllyArena;
 typedef struct ProllyArenaBlock ProllyArenaBlock;
 
 struct ProllyArenaBlock {
-  ProllyArenaBlock *pNext;  /* Next block in chain */
-  int sz;                   /* Usable size of this block */
-  int used;                 /* Bytes consumed */
-  /* data follows immediately after this struct */
+  ProllyArenaBlock *pNext;  
+  int sz;                   
+  int used;                 
+  
 };
 
 struct ProllyArena {
-  ProllyArenaBlock *pFirst;   /* First block in chain */
-  ProllyArenaBlock *pCurrent; /* Current block for allocations */
-  int defaultBlockSize;       /* Default size for new blocks */
+  ProllyArenaBlock *pFirst;   
+  ProllyArenaBlock *pCurrent; 
+  int defaultBlockSize;       
 };
 
-/* Initialize arena with default block size */
 void prollyArenaInit(ProllyArena *a, int defaultBlockSize);
 
-/* Allocate n bytes from arena. Returns NULL on OOM. */
 void *prollyArenaAlloc(ProllyArena *a, int n);
 
-/* Allocate and zero n bytes */
 void *prollyArenaAllocZero(ProllyArena *a, int n);
 
-/* Reset arena: free all blocks except the first, reset usage */
 void prollyArenaReset(ProllyArena *a);
 
-/* Destroy arena: free all memory */
 void prollyArenaFree(ProllyArena *a);
 
-#endif /* SQLITE_PROLLY_ARENA_H */
+#endif 

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -1,42 +1,4 @@
-/*
-** 2024-01-01
-**
-** The author disclaims copyright to this source code.  In place of
-** a legal notice, here is a blessing:
-**
-**    May you do good and not evil.
-**    May you find forgiveness for yourself and forgive others.
-**    May you share freely, never taking more than you give.
-**
-*************************************************************************
-**
-** Prolly tree implementation of the btree.h API.
-**
-** This file replaces SQLite's traditional B-tree page-based storage with
-** content-addressed prolly trees. Instead of managing database pages via
-** the Pager, we store key-value entries in a prolly tree structure backed
-** by a ChunkStore.
-**
-** Architecture overview:
-**
-**   Btree       -- Per-connection handle (one per attached database)
-**   BtShared    -- Shared state: chunk store, cache, table registry
-**   BtCursor    -- Cursor over a single table's prolly tree
-**
-** Each "table" in the SQLite schema corresponds to a separate prolly tree
-** identified by a ProllyHash root. The BtShared.aTables registry maps
-** table numbers (Pgno) to their current root hashes.
-**
-** Write operations buffer edits in a ProllyMutMap (a skip list), then
-** flush them by merging with the existing tree to produce a new root.
-** This is the copy-on-write / structural sharing model used by Dolt.
-**
-** Transactions are lightweight: beginning a write transaction snapshots
-** the current root hash. Commit writes pending chunks and updates the
-** manifest. Rollback restores the snapshot.
-**
-** Part of the Doltite storage engine.
-*/
+
 #ifdef DOLTLITE_PROLLY
 
 #include "sqliteInt.h"
@@ -57,7 +19,6 @@
 #include <string.h>
 #include <assert.h>
 
-/* SQLite serial type constants */
 #define SERIAL_TYPE_NULL      0
 #define SERIAL_TYPE_INT8      1
 #define SERIAL_TYPE_INT16     2
@@ -66,82 +27,50 @@
 #define SERIAL_TYPE_INT48     5
 #define SERIAL_TYPE_INT64     6
 #define SERIAL_TYPE_FLOAT64   7
-#define SERIAL_TYPE_ZERO      8   /* Integer constant 0 (no payload) */
-#define SERIAL_TYPE_ONE       9   /* Integer constant 1 (no payload) */
-#define SERIAL_TYPE_TEXT_BASE 13  /* Text: serial_type = len*2 + 13 */
-#define SERIAL_TYPE_BLOB_BASE 12  /* Blob: serial_type = len*2 + 12 */
-#define MAX_RECORD_FIELDS     64  /* Max fields in stack-allocated arrays */
-#define MAX_ONEBYTE_HEADER   126  /* Max header size for single-byte varint */
+#define SERIAL_TYPE_ZERO      8   
+#define SERIAL_TYPE_ONE       9   
+#define SERIAL_TYPE_TEXT_BASE 13  
+#define SERIAL_TYPE_BLOB_BASE 12  
+#define MAX_RECORD_FIELDS     64  
+#define MAX_ONEBYTE_HEADER   126  
 
-/* Forward declarations */
 static void registerDoltiteFunctions(sqlite3 *db);
 void doltliteGetSessionHead(sqlite3 *db, ProllyHash *pHead);
 char *doltliteResolveTableNumber(sqlite3 *db, Pgno iTable);
 
-/* --------------------------------------------------------------------------
-** Constants and macros
-** -------------------------------------------------------------------------- */
-
-/*
-** Transaction states.  These must match the TRANS_* values used by
-** the rest of the SQLite codebase (defined in sqliteInt.h for the
-** standard btree, but we define them here for the prolly tree build).
-*/
 #ifndef TRANS_NONE
 #define TRANS_NONE  0
 #define TRANS_READ  1
 #define TRANS_WRITE 2
 #endif
 
-/*
-** Savepoint operation codes.  These are the values passed as the first
-** argument to sqlite3BtreeSavepoint().
-*/
 #ifndef SAVEPOINT_BEGIN
 #define SAVEPOINT_BEGIN    0
 #define SAVEPOINT_RELEASE  1
 #define SAVEPOINT_ROLLBACK 2
 #endif
 
-/*
-** Cursor states.  A cursor is in one of these states at all times.
-**
-** CURSOR_VALID:       Cursor points to a valid entry.
-** CURSOR_INVALID:     Cursor does not point to a valid entry.
-** CURSOR_SKIPNEXT:    Next call to Next or Previous should be skipped.
-** CURSOR_REQUIRESEEK: Cursor position was saved and needs to be restored.
-** CURSOR_FAULT:       An error has occurred; cursor is unusable.
-*/
 #define CURSOR_VALID       0
 #define CURSOR_INVALID     1
 #define CURSOR_SKIPNEXT    2
 #define CURSOR_REQUIRESEEK 3
 #define CURSOR_FAULT       4
 
-/*
-** Cursor flags.  These are stored in BtCursor.curFlags.
-*/
-#define BTCF_WriteFlag  0x01   /* Cursor is open for writing */
-#define BTCF_ValidNKey  0x02   /* Cache of BtCursor.nKey is valid */
-#define BTCF_ValidOvfl  0x04   /* Overflow page cache is valid */
-#define BTCF_AtLast     0x08   /* Cursor is pointing at the last entry */
-#define BTCF_Incrblob   0x10   /* This is an incremental blob cursor */
-#define BTCF_Multiple   0x20   /* Multiple cursors on same btree */
-#define BTCF_Pinned     0x40   /* Cursor is pinned (cannot be moved by save) */
+#define BTCF_WriteFlag  0x01   
+#define BTCF_ValidNKey  0x02   
+#define BTCF_ValidOvfl  0x04   
+#define BTCF_AtLast     0x08   
+#define BTCF_Incrblob   0x10   
+#define BTCF_Multiple   0x20   
+#define BTCF_Pinned     0x40   
 
-/*
-** BtShared flags (stored in BtShared.btsFlags).
-*/
-#define BTS_READ_ONLY       0x0001  /* Database is read-only */
-#define BTS_PAGESIZE_FIXED  0x0002  /* Page size cannot be changed */
-#define BTS_SECURE_DELETE   0x0004  /* Secure delete is enabled */
-#define BTS_OVERWRITE       0x0008  /* Overwrite deleted content with zeros */
-#define BTS_INITIALLY_EMPTY 0x0010  /* Database was empty at open time */
-#define BTS_NO_WAL          0x0020  /* WAL mode is not used */
+#define BTS_READ_ONLY       0x0001  
+#define BTS_PAGESIZE_FIXED  0x0002  
+#define BTS_SECURE_DELETE   0x0004  
+#define BTS_OVERWRITE       0x0008  
+#define BTS_INITIALLY_EMPTY 0x0010  
+#define BTS_NO_WAL          0x0020  
 
-/* WS_* constants now defined in chunk_store.h */
-
-/* Clear the cached payload, freeing owned copies */
 #define CLEAR_CACHED_PAYLOAD(pCur) do{ \
   if( (pCur)->cachedPayloadOwned && (pCur)->pCachedPayload ){ \
     sqlite3_free((pCur)->pCachedPayload); \
@@ -151,86 +80,46 @@ char *doltliteResolveTableNumber(sqlite3 *db, Pgno iTable);
   (pCur)->cachedPayloadOwned = 0; \
 }while(0)
 
-/*
-** BtLock structure.  Not used by prolly trees (no shared cache) but
-** needed for struct compatibility with code that references Btree.lock.
-*/
 typedef struct BtLock BtLock;
 struct BtLock {
-  Btree *pBtree;        /* Btree handle holding this lock */
-  Pgno iTable;           /* Root page of the table being locked */
-  u8 eLock;              /* READ_LOCK or WRITE_LOCK */
-  BtLock *pNext;         /* Next in linked list of locks */
+  Btree *pBtree;        
+  Pgno iTable;           
+  u8 eLock;              
+  BtLock *pNext;         
 };
 
-/* Default cache capacity (number of nodes) */
 #define PROLLY_DEFAULT_CACHE_SIZE 1024
 
-/* Default page size for compatibility with SQLite callers */
 #define PROLLY_DEFAULT_PAGE_SIZE 4096
 
-/* Maximum record size (1 GB) */
 #define PROLLY_MAX_RECORD_SIZE ((sqlite3_int64)(1024*1024*1024))
 
-/* The empty hash (all zeros) represents an empty tree */
 static const ProllyHash emptyHash = {{0}};
 
-/* --------------------------------------------------------------------------
-** Table entry in BtShared table registry.
-**
-** Each entry maps a table number (Pgno, used as a logical identifier)
-** to its current prolly tree root hash and table flags.
-** -------------------------------------------------------------------------- */
 struct TableEntry {
-  Pgno iTable;           /* Logical table number (like SQLite's root page) */
-  ProllyHash root;       /* Current root hash of this table's prolly tree */
-  ProllyHash schemaHash; /* Hash of this table's CREATE TABLE SQL (schema) */
-  u8 flags;              /* BTREE_INTKEY or BTREE_BLOBKEY */
-  char *zName;           /* Table name (owned, NULL for internal tables) */
-  ProllyMutMap *pPending; /* Deferred edits from closed write cursors.
-                          ** Transferred here on cursor close, flushed at
-                          ** BtreeCommitPhaseTwo or BtreeFirst/BtreeLast. */
+  Pgno iTable;           
+  ProllyHash root;       
+  ProllyHash schemaHash; 
+  u8 flags;              
+  char *zName;           
+  ProllyMutMap *pPending; 
 };
 
-/* --------------------------------------------------------------------------
-** Core structure definitions.
-**
-** These are the prolly-tree versions of SQLite's Btree, BtShared, and
-** BtCursor structures. They are forward-declared in btree.h and fully
-** defined here.
-** -------------------------------------------------------------------------- */
-
-/*
-** BtShared: Shared state for a single database file.
-** Contains the chunk store, node cache, table registry, and meta values.
-**
-** In standard SQLite, BtShared can be shared among multiple connections
-** (shared cache mode). In the prolly tree implementation, shared cache
-** is not supported, so there is always a 1:1 relationship between
-** Btree and BtShared.
-*/
 struct BtShared {
-  ChunkStore store;          /* Content-addressed chunk store */
-  ProllyCache cache;         /* LRU cache for deserialized prolly nodes */
+  ChunkStore store;          
+  ProllyCache cache;         
 
-  /* Pager shim: provides the Pager* interface for code that calls
-  ** sqlite3BtreePager() and then uses the result. */
+  
   PagerShim *pPagerShim;
 
-  sqlite3 *db;              /* Database connection (for error reporting) */
-  BtCursor *pCursor;        /* Linked list of all open cursors */
-  u8 openFlags;             /* Flags from sqlite3BtreeOpen() */
-  u16 btsFlags;             /* BTS_* flags */
-  u32 pageSize;             /* Dummy page size for compatibility (4096) */
-  int nRef;                 /* Reference count from Btree handles */
+  sqlite3 *db;              
+  BtCursor *pCursor;        
+  u8 openFlags;             
+  u16 btsFlags;             
+  u32 pageSize;             
+  int nRef;                 
 };
 
-/*
-** BtreeOps: vtable for dispatching Btree operations.
-** Prolly-tree and original-SQLite implementations each provide a static
-** instance of this struct.  Every Btree handle stores a pointer to the
-** appropriate table, eliminating per-call if(pOrigBtree) dispatch checks.
-*/
 struct BtreeOps {
   int (*xClose)(Btree*);
   int (*xNewDb)(Btree*);
@@ -276,9 +165,6 @@ struct BtreeOps {
 #endif
 };
 
-/* --------------------------------------------------------------------------
-** BtCursorOps vtable: function-pointer table for cursor-level dispatch.
-** -------------------------------------------------------------------------- */
 struct BtCursorOps {
   int (*xClearTableOfCursor)(BtCursor*);
   int (*xCloseCursor)(BtCursor*);
@@ -319,133 +205,113 @@ struct BtCursorOps {
   int (*xCursorIsValidNN)(BtCursor*);
 };
 
-/*
-** Btree: Per-connection handle for an open database.
-*/
 struct Btree {
-  sqlite3 *db;              /* The database connection holding this btree */
-  BtShared *pBt;            /* The underlying shared state */
-  u8 inTrans;               /* TRANS_NONE, TRANS_READ, TRANS_WRITE */
-  u8 sharable;              /* Always 0 for prolly tree (no shared cache) */
-  int wantToLock;            /* Number of nested calls to sqlite3BtreeEnter() */
-  int nBackup;               /* Number of backup operations reading this btree */
-  u32 iBDataVersion;         /* Combines with Pager iDataVersion */
-  Btree *pNext;              /* List linkage for db->aDb */
+  sqlite3 *db;              
+  BtShared *pBt;            
+  u8 inTrans;               
+  u8 sharable;              
+  int wantToLock;            
+  int nBackup;               
+  u32 iBDataVersion;         
+  Btree *pNext;              
   Btree *pPrev;
-  BtLock lock;               /* Unused but needed for struct compat */
-  u64 nSeek;                 /* Debug: count of seek operations */
+  BtLock lock;               
+  u64 nSeek;                 
 
-  /* Per-session state (moved from BtShared for per-connection branching) */
-  ProllyHash root;           /* Current root hash (may include uncommitted) */
-  ProllyHash committedRoot;  /* Root hash at last commit (for rollback) */
+  
+  ProllyHash root;           
+  ProllyHash committedRoot;  
 
-  /*
-  ** Table registry: maps table number (Pgno) to prolly tree root hash.
-  ** Table 1 is always the master schema table (sqlite_master).
-  */
+  
   struct TableEntry *aTables;
-  int nTables;               /* Number of tables in registry */
-  int nTablesAlloc;          /* Allocated capacity of aTables */
-  Pgno iNextTable;           /* Next table number to assign on CREATE */
+  int nTables;               
+  int nTablesAlloc;          
+  Pgno iNextTable;           
 
-  /* Meta values (SQLITE_N_BTREE_META = 16). */
+  
   u32 aMeta[16];
 
-  /* Schema management */
-  void *pSchema;             /* Pointer to Schema object */
-  void (*xFreeSchema)(void*); /* Destructor for pSchema */
+  
+  void *pSchema;             
+  void (*xFreeSchema)(void*); 
 
-  u8 inTransaction;         /* TRANS_NONE, TRANS_READ, or TRANS_WRITE */
+  u8 inTransaction;         
 
-  /*
-  ** Savepoint stack.
-  */
-  ProllyHash *aSavepoint;   /* Array of root hash snapshots */
-  int nSavepoint;            /* Number of active savepoints */
-  int nSavepointAlloc;       /* Allocated capacity of aSavepoint */
+  
+  ProllyHash *aSavepoint;   
+  int nSavepoint;            
+  int nSavepointAlloc;       
 
   struct SavepointTableState {
     struct TableEntry *aTables;
-    int *aPendingCount;    /* nEntries for each table's pPending at save time */
+    int *aPendingCount;    
     int nTables;
     Pgno iNextTable;
   } *aSavepointTables;
   int nSavepointTablesAlloc;
 
-  /* Committed table registry for transaction rollback */
+  
   struct TableEntry *aCommittedTables;
   int nCommittedTables;
   Pgno iCommittedNextTable;
 
-  /* Per-session branch state (authoritative in-memory state).
-  ** Persisted to per-branch WorkingSet chunks, NOT in the manifest. */
-  char *zBranch;             /* Current branch name (owned, NULL = "main") */
-  char *zAuthorName;         /* Configured author name (owned, NULL = "doltlite") */
-  char *zAuthorEmail;        /* Configured author email (owned, NULL = "") */
-  ProllyHash headCommit;     /* This session's HEAD commit hash */
-  ProllyHash stagedCatalog;  /* This session's staged catalog hash */
-  u8 isMerging;              /* 1 if a merge is in progress */
-  ProllyHash mergeCommitHash;     /* Commit hash being merged in */
-  ProllyHash conflictsCatalogHash; /* Conflicts catalog hash */
-  const struct BtreeOps *pOps;  /* Vtable: prolly or orig dispatch */
-  void *pOrigBtree;  /* Non-NULL → delegate to original SQLite btree */
+  
+  char *zBranch;             
+  char *zAuthorName;         
+  char *zAuthorEmail;        
+  ProllyHash headCommit;     
+  ProllyHash stagedCatalog;  
+  u8 isMerging;              
+  ProllyHash mergeCommitHash;     
+  ProllyHash conflictsCatalogHash; 
+  const struct BtreeOps *pOps;  
+  void *pOrigBtree;  
 };
 
-/*
-** BtCursor: Cursor for iterating over entries in a single table.
-**
-** Each cursor references a specific table by pgnoRoot (the logical
-** table number) and maintains a ProllyCursor for tree traversal.
-** Write cursors also have a ProllyMutMap for buffering edits.
-*/
 struct BtCursor {
-  u8 eState;                 /* CURSOR_VALID, CURSOR_INVALID, etc. */
-  u8 curFlags;               /* BTCF_* flags */
-  u8 curPagerFlags;          /* Copy of BtShared.btsFlags for cursor */
-  u8 hints;                  /* Hint flags from CursorHintFlags */
-  int skipNext;              /* Skip direction for CURSOR_SKIPNEXT, or error */
-  Btree *pBtree;             /* The Btree handle that opened this cursor */
-  BtShared *pBt;             /* The shared state */
-  BtCursor *pNext;           /* Linked list of all cursors on pBt */
-  Pgno pgnoRoot;             /* Table number (logical root page) */
-  u8 curIntKey;              /* True if this is an INTKEY table */
-  struct KeyInfo *pKeyInfo;  /* Key comparison info for index btrees */
+  u8 eState;                 
+  u8 curFlags;               
+  u8 curPagerFlags;          
+  u8 hints;                  
+  int skipNext;              
+  Btree *pBtree;             
+  BtShared *pBt;             
+  BtCursor *pNext;           
+  Pgno pgnoRoot;             
+  u8 curIntKey;              
+  struct KeyInfo *pKeyInfo;  
 
-  /* Prolly cursor: actual tree traversal state */
+  
   ProllyCursor pCur;
 
-  /* Pending writes for this table */
+  
   ProllyMutMap *pMutMap;
 
-  /* Cached payload — may point to MutMap data (borrowed, not owned) */
+  
   u8 *pCachedPayload;
   int nCachedPayload;
-  u8 cachedPayloadOwned;   /* 1 if pCachedPayload was sqlite3_malloc'd */
+  u8 cachedPayloadOwned;   
   i64 cachedIntKey;
 
-  /* Pinned state */
+  
   u8 isPinned;
 
-  /* Merge iteration state: when mmActive, BtreeNext/Prev merges the
-  ** tree cursor with pending MutMap entries in sorted order. */
-  int mmIdx;                 /* Current MutMap index for merge (-1 = none) */
-  u8 mmActive;               /* 1 if merge iteration is active */
+  
+  int mmIdx;                 
+  u8 mmActive;               
 #define MERGE_SRC_TREE  0
 #define MERGE_SRC_MUT   1
-#define MERGE_SRC_BOTH  2    /* Same key in tree and MutMap — MutMap wins */
-  u8 mergeSrc;               /* Which source provided the current entry */
+#define MERGE_SRC_BOTH  2    
+  u8 mergeSrc;               
 
-  /* Save/restore state */
-  i64 nKey;                  /* Saved integer key or blob key length */
-  void *pKey;                /* Saved blob key (malloc'd) */
-  u64 nSeek;                 /* Debug seek counter (per-cursor) */
-  void *pOrigCursor; /* Non-NULL → delegate to original SQLite cursor */
-  const struct BtCursorOps *pCurOps; /* Vtable: prolly or orig cursor dispatch */
+  
+  i64 nKey;                  
+  void *pKey;                
+  u64 nSeek;                 
+  void *pOrigCursor; 
+  const struct BtCursorOps *pCurOps; 
 };
 
-/* --------------------------------------------------------------------------
-** Internal helper function prototypes
-** -------------------------------------------------------------------------- */
 static struct TableEntry *findTable(Btree *pBtree, Pgno iTable);
 static struct TableEntry *addTable(Btree *pBtree, Pgno iTable, u8 flags);
 static void removeTable(Btree *pBtree, Pgno iTable);
@@ -467,16 +333,6 @@ static int deserializeCatalog(Btree *pBtree, const u8 *data, int nData);
 static int btreeRefreshFromDisk(Btree *p);
 static int btreeDeleteImmediate(BtCursor *pCur, const u8 *pKey, int nKey, i64 iKey);
 
-/* --------------------------------------------------------------------------
-** BtreeOps vtable: forward declarations and static instances.
-**
-** Each Btree-level public function is split into a prolly implementation
-** (prollyBtreeXxx) and an orig-SQLite wrapper (origBtreeXxxVt).  The two
-** static vtable instances below let sqlite3BtreeOpen install the right
-** dispatch table once, eliminating per-call if(pOrigBtree) checks.
-** -------------------------------------------------------------------------- */
-
-/* --- prolly implementation forward declarations --- */
 static int prollyBtreeClose(Btree*);
 static int prollyBtreeNewDb(Btree*);
 static int prollyBtreeSetCacheSize(Btree*, int);
@@ -520,7 +376,6 @@ static struct Pager *prollyBtreePager(Btree*);
 static int prollyBtreeClosesWithCursor(Btree*, BtCursor*);
 #endif
 
-/* --- orig-SQLite wrapper forward declarations --- */
 static int origBtreeCloseVt(Btree*);
 static int origBtreeNewDbVt(Btree*);
 static int origBtreeSetCacheSizeVt(Btree*, int);
@@ -564,7 +419,6 @@ static struct Pager *origBtreePagerVt(Btree*);
 static int origBtreeClosesWithCursorVt(Btree*, BtCursor*);
 #endif
 
-/* --- vtable instances --- */
 static const struct BtreeOps prollyBtreeOps = {
   prollyBtreeClose,
   prollyBtreeNewDb,
@@ -655,16 +509,6 @@ static const struct BtreeOps origBtreeVtOps = {
 #endif
 };
 
-/* --------------------------------------------------------------------------
-** BtCursorOps vtable: forward declarations and static instances.
-**
-** Each cursor-level public function is split into a prolly implementation
-** (prollyCursorXxx) and an orig-SQLite wrapper (origCursorXxxVt).  The two
-** static vtable instances below let cursor creation install the right
-** dispatch table once, eliminating per-call if(pOrigCursor) checks.
-** -------------------------------------------------------------------------- */
-
-/* --- prolly cursor implementation forward declarations --- */
 static int prollyBtCursorClearTableOfCursor(BtCursor*);
 static int prollyBtCursorCloseCursor(BtCursor*);
 static int prollyBtCursorCursorHasMoved(BtCursor*);
@@ -703,7 +547,6 @@ static int prollyBtCursorCursorIsValid(BtCursor*);
 #endif
 static int prollyBtCursorCursorIsValidNN(BtCursor*);
 
-/* --- orig-cursor wrapper forward declarations --- */
 static int origCursorClearTableOfCursorVt(BtCursor*);
 static int origCursorCloseCursorVt(BtCursor*);
 static int origCursorCursorHasMovedVt(BtCursor*);
@@ -742,7 +585,6 @@ static int origCursorCursorIsValidVt(BtCursor*);
 #endif
 static int origCursorCursorIsValidNNVt(BtCursor*);
 
-/* --- cursor vtable instances --- */
 static const struct BtCursorOps prollyCursorOps = {
   prollyBtCursorClearTableOfCursor,
   prollyBtCursorCloseCursor,
@@ -823,14 +665,6 @@ static const struct BtCursorOps origCursorVtOps = {
   origCursorCursorIsValidNNVt,
 };
 
-/* --------------------------------------------------------------------------
-** Internal helper implementations
-** -------------------------------------------------------------------------- */
-
-/*
-** Find a table entry by table number in the BtShared table registry.
-** Returns a pointer to the entry, or NULL if not found.
-*/
 static struct TableEntry *findTable(Btree *pBtree, Pgno iTable){
   int lo = 0, hi = pBtree->nTables - 1;
   while( lo<=hi ){
@@ -847,22 +681,17 @@ static struct TableEntry *findTable(Btree *pBtree, Pgno iTable){
   return 0;
 }
 
-/*
-** Add a new table entry to the registry.  The new table starts with
-** an empty root hash (all zeros), meaning an empty tree.
-** Returns a pointer to the new entry, or NULL on allocation failure.
-*/
 static struct TableEntry *addTable(Btree *pBtree, Pgno iTable, u8 flags){
   struct TableEntry *pEntry;
 
-  /* Check if table already exists */
+  
   pEntry = findTable(pBtree, iTable);
   if( pEntry ){
     pEntry->flags = flags;
     return pEntry;
   }
 
-  /* Grow the array if needed */
+  
   if( pBtree->nTables>=pBtree->nTablesAlloc ){
     int nNew = pBtree->nTablesAlloc ? pBtree->nTablesAlloc*2 : 16;
     struct TableEntry *aNew;
@@ -872,7 +701,7 @@ static struct TableEntry *addTable(Btree *pBtree, Pgno iTable, u8 flags){
     pBtree->nTablesAlloc = nNew;
   }
 
-  /* Find sorted insertion point using binary search */
+  
   {
     int lo = 0, hi = pBtree->nTables;
     while( lo<hi ){
@@ -883,7 +712,7 @@ static struct TableEntry *addTable(Btree *pBtree, Pgno iTable, u8 flags){
         hi = mid;
       }
     }
-    /* Insert at position lo, shifting elements right */
+    
     if( lo < pBtree->nTables ){
       memmove(&pBtree->aTables[lo+1], &pBtree->aTables[lo],
               (pBtree->nTables - lo) * (int)sizeof(struct TableEntry));
@@ -898,9 +727,6 @@ static struct TableEntry *addTable(Btree *pBtree, Pgno iTable, u8 flags){
   return pEntry;
 }
 
-/*
-** Remove a table entry from the registry by table number.
-*/
 static void removeTable(Btree *pBtree, Pgno iTable){
   int i;
   for(i=0; i<pBtree->nTables; i++){
@@ -915,13 +741,6 @@ static void removeTable(Btree *pBtree, Pgno iTable){
   }
 }
 
-/*
-** Invalidate all cursors on a given table (or all if iTable==0).
-*/
-/*
-** Invalidate the schema cache. Called on rollback/savepoint rollback
-** so that SQLite re-reads sqlite_master on the next operation.
-*/
 static void invalidateSchema(Btree *pBtree){
   if( pBtree->pSchema && pBtree->xFreeSchema ){
     pBtree->xFreeSchema(pBtree->pSchema);
@@ -935,15 +754,12 @@ static void invalidateCursors(BtShared *pBt, Pgno iTable, int errCode){
     if( iTable==0 || p->pgnoRoot==iTable ){
       p->eState = CURSOR_FAULT;
       p->skipNext = errCode;
-      /* Discard pending mutations — tree is being rolled back */
+      
       if( p->pMutMap ) prollyMutMapClear(p->pMutMap);
     }
   }
 }
 
-/*
-** Refresh a cursor's prolly cursor root from the table registry.
-*/
 static void refreshCursorRoot(BtCursor *pCur){
   struct TableEntry *pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
   if( pTE ){
@@ -951,41 +767,31 @@ static void refreshCursorRoot(BtCursor *pCur){
   }
 }
 
-/*
-** Serialize the table registry + meta values into a catalog chunk.
-** Format: [iNextTable:4][nTables:4][meta[0..15]: 64 bytes]
-**         per table: [iTable:4][flags:1][root:20]
-*/
-/*
-** Serialize the catalog (table registry) to a content-addressed chunk.
-**
-** Following Dolt's RootValue model, the catalog is purely data-derived:
-** table entries with their root hashes, schema hashes, names, and flags.
-** aMeta[0..15] (SQLite runtime state) is NOT included — it is reconstructed
-** from constants on catalog load. This ensures the catalog hash changes ONLY
-** when actual table data or schema changes, enabling O(1) dirty checks.
-**
-** Format V2 (clean catalog):
-**   version(1) = 0x02
-**   iNextTable(4)
-**   nTables(4)
-**   table_entries[]:
-**     iTable(4) + flags(1) + root(20) + schemaHash(20) + name_len(2) + name(var)
-**
-** Format:
-**   version(1=0x02) + iNextTable(4) + nTables(4) + table_entries[...]
-*/
-/* Catalog version tag — must NOT collide with DOLTLITE_COMMIT_V2 (0x02)
-** or PROLLY_NODE_MAGIC first byte. Using 0x43 = 'C' for Catalog. */
 #define CATALOG_FORMAT_V2 0x43
 
+/*
+** Catalog serialization format (V2):
+**   Byte 0:       CATALOG_FORMAT_V2 magic (0x43)
+**   Bytes 1-4:    iNextTable (little-endian u32)
+**   Bytes 5-8:    nTables (little-endian u32)
+**   Per table:
+**     4 bytes:    iTable (little-endian u32)
+**     1 byte:     flags (BTREE_INTKEY or BTREE_BLOBKEY)
+**     PROLLY_HASH_SIZE bytes: root hash
+**     PROLLY_HASH_SIZE bytes: schema hash
+**     2 bytes:    name length (little-endian u16)
+**     N bytes:    table name (not null-terminated)
+**
+** The catalog is stored as a content-addressed chunk. Its hash is persisted
+** in the manifest so the table registry can be reconstructed on open.
+*/
 static int serializeCatalog(Btree *pBtree, u8 **ppOut, int *pnOut){
   int nTables = pBtree->nTables;
-  int sz = 1 + 4 + 4;  /* version(1) + iNextTable(4) + nTables(4) */
+  int sz = 1 + 4 + 4;  /* header: magic + iNextTable + nTables */
   u8 *buf, *q;
   int i;
 
-  /* Populate table names from sqlite_master if missing */
+  
   if( pBtree->db ){
     for(i=0; i<nTables; i++){
       if( !pBtree->aTables[i].zName && pBtree->aTables[i].iTable>1 ){
@@ -994,12 +800,9 @@ static int serializeCatalog(Btree *pBtree, u8 **ppOut, int *pnOut){
       }
     }
   }
-  /* Note: schemaHash is computed by doltliteUpdateSchemaHashes() which is
-  ** called from dolt_commit/dolt_add at the SQL function level — NOT here,
-  ** because serializeCatalog can be called during BtreeCommitPhaseTwo where
-  ** re-entrant SQL queries would crash. */
+  
 
-  /* Calculate variable size: per table = 4+1+20+20+2+name_len */
+  
   for(i=0; i<nTables; i++){
     int nLen = pBtree->aTables[i].zName ? (int)strlen(pBtree->aTables[i].zName) : 0;
     if( sz > 0x7FFFFFFF - (4 + 1 + PROLLY_HASH_SIZE*2 + 2 + nLen) ){
@@ -1011,7 +814,7 @@ static int serializeCatalog(Btree *pBtree, u8 **ppOut, int *pnOut){
   buf = sqlite3_malloc(sz);
   if( !buf ) return SQLITE_NOMEM;
   q = buf;
-  /* Version tag — distinguishes V2 (no meta) from V1 (has meta) */
+  
   *q++ = CATALOG_FORMAT_V2;
   q[0]=(u8)(pBtree->iNextTable); q[1]=(u8)(pBtree->iNextTable>>8);
   q[2]=(u8)(pBtree->iNextTable>>16); q[3]=(u8)(pBtree->iNextTable>>24);
@@ -1019,7 +822,7 @@ static int serializeCatalog(Btree *pBtree, u8 **ppOut, int *pnOut){
   q[0]=(u8)nTables; q[1]=(u8)(nTables>>8);
   q[2]=(u8)(nTables>>16); q[3]=(u8)(nTables>>24);
   q += 4;
-  /* Table entries only — no aMeta. Hash covers purely data content. */
+  
   for(i=0; i<nTables; i++){
     struct TableEntry *t = &pBtree->aTables[i];
     u32 pg = t->iTable;
@@ -1040,27 +843,13 @@ static int serializeCatalog(Btree *pBtree, u8 **ppOut, int *pnOut){
   return SQLITE_OK;
 }
 
-/*
-** Initialize aMeta with default constant values.
-** Called after deserializing a V2 catalog (which has no meta) or
-** during a fresh database open.
-*/
 static void initDefaultMeta(Btree *pBtree){
   memset(pBtree->aMeta, 0, sizeof(pBtree->aMeta));
   pBtree->aMeta[BTREE_FILE_FORMAT] = 4;
   pBtree->aMeta[BTREE_TEXT_ENCODING] = SQLITE_UTF8;
-  /* BTREE_SCHEMA_VERSION starts at 0, bumped by doltliteHardReset.
-  ** BTREE_LARGEST_ROOT_PAGE is set after table entries are loaded. */
+  
 }
 
-/*
-** Deserialize a V2 catalog chunk into the table registry.
-** V2 format: version(1='C') + iNextTable(4) + nTables(4) + entries.
-** No aMeta — runtime meta is initialized from constants.
-** BTREE_SCHEMA_VERSION is derived from a hash of the catalog data so
-** that different catalogs produce different versions (needed for
-** multi-connection schema change detection).
-*/
 static int deserializeCatalog(Btree *pBtree, const u8 *data, int nData){
   const u8 *q = data;
   int nTables, i;
@@ -1068,33 +857,34 @@ static int deserializeCatalog(Btree *pBtree, const u8 *data, int nData){
   if( nData < 9 ) return SQLITE_CORRUPT;
   if( data[0] != CATALOG_FORMAT_V2 ) return SQLITE_CORRUPT;
 
-  /* Clear table registry */
+  
   sqlite3_free(pBtree->aTables);
   pBtree->aTables = 0;
   pBtree->nTables = 0;
   pBtree->nTablesAlloc = 0;
 
-  /* V2 format: version(1) + iNextTable(4) + nTables(4) + entries */
-  q++;  /* skip version byte */
+  
+  q++;  
   pBtree->iNextTable = (Pgno)(q[0] | (q[1]<<8) | (q[2]<<16) | (q[3]<<24));
   q += 4;
   nTables = (int)(q[0] | (q[1]<<8) | (q[2]<<16) | (q[3]<<24));
   q += 4;
   initDefaultMeta(pBtree);
 
-  /* Derive BTREE_SCHEMA_VERSION from catalog content so multiple
-  ** connections on the same database agree on the version number,
-  ** and schema changes are detected across connections. */
+  /* Derive BTREE_SCHEMA_VERSION from a hash of the entire catalog blob.
+  ** SQLite uses this value to detect schema changes and invalidate prepared
+  ** statements. The |1 ensures it is never zero (zero means "no schema").
+  ** This is a content-derived substitute for SQLite's incrementing counter. */
   {
     u32 schemaHash = 0;
     int j;
     for(j = 0; j < nData; j++){
       schemaHash = schemaHash * 31 + data[j];
     }
-    pBtree->aMeta[BTREE_SCHEMA_VERSION] = schemaHash | 1;  /* ensure non-zero */
+    pBtree->aMeta[BTREE_SCHEMA_VERSION] = schemaHash | 1;
   }
 
-  /* Table entries */
+  
   for(i=0; i<nTables; i++){
     Pgno iTable;
     u8 flags;
@@ -1127,7 +917,7 @@ static int deserializeCatalog(Btree *pBtree, const u8 *data, int nData){
     }
   }
 
-  /* Derive LARGEST_ROOT_PAGE from loaded tables */
+  
   {
     Pgno maxPage = 0;
     for(i=0; i<pBtree->nTables; i++){
@@ -1141,10 +931,6 @@ static int deserializeCatalog(Btree *pBtree, const u8 *data, int nData){
   return SQLITE_OK;
 }
 
-/*
-** Flush pending mutations from a cursor's MutMap into the table's
-** prolly tree.  Produces a new root hash and updates the table registry.
-*/
 static int flushMutMap(BtCursor *pCur){
   int rc;
   struct TableEntry *pTE;
@@ -1178,11 +964,6 @@ static int flushMutMap(BtCursor *pCur){
   return SQLITE_OK;
 }
 
-/*
-** Sync savepoint stack with db->nSavepoint.
-** SQLite creates user savepoints without notifying the btree layer,
-** so we lazily create savepoint snapshots before each write operation.
-*/
 static int syncSavepoints(BtCursor *pCur){
   Btree *pBtree = pCur->pBtree;
   sqlite3 *db = pBtree ? pBtree->db : 0;
@@ -1196,9 +977,6 @@ static int syncSavepoints(BtCursor *pCur){
   return SQLITE_OK;
 }
 
-/*
-** Ensure the cursor has a MutMap allocated for buffering writes.
-*/
 static int ensureMutMap(BtCursor *pCur){
   int rc;
   if( pCur->pMutMap ){
@@ -1217,9 +995,6 @@ static int ensureMutMap(BtCursor *pCur){
   return SQLITE_OK;
 }
 
-/*
-** Save the current cursor position so it can be restored later.
-*/
 static int saveCursorPosition(BtCursor *pCur){
   int rc = SQLITE_OK;
 
@@ -1230,12 +1005,10 @@ static int saveCursorPosition(BtCursor *pCur){
     return SQLITE_OK;
   }
 
-  /* If the prolly cursor isn't actually valid (e.g. empty tree, or
-  ** cursor was set to CURSOR_VALID without a successful seek via MutMap),
-  ** use cached key data if available, otherwise invalidate. */
+  
   if( !prollyCursorIsValid(&pCur->pCur) ){
     if( pCur->curIntKey && (pCur->curFlags & BTCF_ValidNKey) ){
-      /* MutMap-satisfied seek: save the cached integer key */
+      
       pCur->nKey = pCur->cachedIntKey;
       pCur->pKey = 0;
       pCur->eState = CURSOR_REQUIRESEEK;
@@ -1245,7 +1018,7 @@ static int saveCursorPosition(BtCursor *pCur){
     return SQLITE_OK;
   }
 
-  /* Save key BEFORE prollyCursorSave releases node references */
+  
   if( pCur->curIntKey ){
     pCur->nKey = prollyCursorIntKey(&pCur->pCur);
     pCur->pKey = 0;
@@ -1276,9 +1049,6 @@ static int saveCursorPosition(BtCursor *pCur){
   return SQLITE_OK;
 }
 
-/*
-** Restore cursor to its previously saved position.
-*/
 static int restoreCursorPosition(BtCursor *pCur, int *pDifferentRow){
   int rc = SQLITE_OK;
   int res = 0;
@@ -1329,11 +1099,6 @@ static int restoreCursorPosition(BtCursor *pCur, int *pDifferentRow){
   return rc;
 }
 
-/*
-** Push the current state onto the savepoint stack.
-*/
-/* Free a savepoint's table snapshot.  pPending pointers in the snapshot
-** are always NULL (we don't clone MutMaps), so no MutMap freeing needed. */
 static void freeSavepointTables(struct SavepointTableState *pState){
   if( pState->aTables ){
     sqlite3_free(pState->aTables);
@@ -1349,8 +1114,7 @@ static int pushSavepoint(Btree *pBtree){
   struct SavepointTableState *pState;
   int rc;
 
-  /* Flush cursor-level MutMaps so all pending edits land in table-level
-  ** pPending.  This is cheap (MutMap merge, no tree rebuild). */
+  
   {
     BtCursor *p;
     for(p = pBtree->pBt->pCursor; p; p = p->pNext){
@@ -1375,9 +1139,7 @@ static int pushSavepoint(Btree *pBtree){
 
   pBtree->aSavepoint[pBtree->nSavepoint] = pBtree->root;
 
-  /* Snapshot table roots + pPending high-water marks.  No MutMap cloning.
-  ** On rollback, we restore the root hashes and truncate each pPending
-  ** to its saved size, discarding only post-savepoint edits. */
+  
   pState = &pBtree->aSavepointTables[pBtree->nSavepoint];
   pState->aTables = 0;
   pState->aPendingCount = 0;
@@ -1400,7 +1162,7 @@ static int pushSavepoint(Btree *pBtree){
       for(k=0; k<pState->nTables; k++){
         ProllyMutMap *pMap = (ProllyMutMap*)pState->aTables[k].pPending;
         pState->aPendingCount[k] = pMap ? pMap->nEntries : 0;
-        pState->aTables[k].pPending = 0;  /* Don't own live MutMap */
+        pState->aTables[k].pPending = 0;  
       }
     }
   }
@@ -1409,9 +1171,6 @@ static int pushSavepoint(Btree *pBtree){
   return SQLITE_OK;
 }
 
-/*
-** Count all entries in a table's prolly tree by walking the tree.
-*/
 static int countTreeEntries(Btree *pBtree, Pgno iTable, i64 *pCount){
   int rc;
   int res;
@@ -1454,9 +1213,6 @@ static int countTreeEntries(Btree *pBtree, Pgno iTable, i64 *pCount){
   return SQLITE_OK;
 }
 
-/*
-** Save all cursor positions on a particular table before modifying it.
-*/
 static int saveAllCursors(BtShared *pBt, Pgno iRoot, BtCursor *pExcept){
   BtCursor *p;
   for(p=pBt->pCursor; p; p=p->pNext){
@@ -1470,13 +1226,6 @@ static int saveAllCursors(BtShared *pBt, Pgno iRoot, BtCursor *pExcept){
   return SQLITE_OK;
 }
 
-/* --------------------------------------------------------------------------
-** Open / Close / NewDb
-** -------------------------------------------------------------------------- */
-
-/*
-** Open a prolly-tree backed database.
-*/
 int sqlite3BtreeOpen(
   sqlite3_vfs *pVfs,
   const char *zFilename,
@@ -1491,7 +1240,7 @@ int sqlite3BtreeOpen(
 
   *ppBtree = 0;
 
-  /* Detect standard SQLite file → delegate to original btree */
+  
   if( origBtreeIsSqliteFile(zFilename) ){
     p = sqlite3_malloc(sizeof(Btree));
     if( !p ) return SQLITE_NOMEM;
@@ -1561,7 +1310,7 @@ int sqlite3BtreeOpen(
     pBt->btsFlags |= BTS_INITIALLY_EMPTY;
   }
 
-  /* Initialize default meta values */
+  
   p->aMeta[BTREE_FREE_PAGE_COUNT] = 0;
   p->aMeta[BTREE_SCHEMA_VERSION] = 0;
   p->aMeta[BTREE_FILE_FORMAT] = 4;
@@ -1572,8 +1321,7 @@ int sqlite3BtreeOpen(
   p->aMeta[BTREE_INCR_VACUUM] = 0;
   p->aMeta[BTREE_APPLICATION_ID] = 0;
 
-  /* Try to load catalog from existing store. If no catalog exists
-  ** (new database), initialize defaults. */
+  
   {
     ProllyHash catHash;
     chunkStoreGetCatalog(&pBt->store, &catHash);
@@ -1597,7 +1345,7 @@ int sqlite3BtreeOpen(
     }
   }
 
-  /* No catalog found — initialize fresh database */
+  
   p->iNextTable = 2;
   if( !addTable(p, 1, BTREE_INTKEY) ){
     pagerShimDestroy(pBt->pPagerShim);
@@ -1619,25 +1367,24 @@ catalog_loaded:
   p->iBDataVersion = 1;
   p->nSeek = 0;
 
-  /* Initialize per-session branch state from the default branch */
+  
   {
     const char *defBranch = chunkStoreGetDefaultBranch(&pBt->store);
     ProllyHash branchCommit;
     p->zBranch = sqlite3_mprintf("%s", defBranch);
-    /* Try to resolve branch → commit from refs */
+    
     if( chunkStoreFindBranch(&pBt->store, defBranch, &branchCommit)==SQLITE_OK ){
       memcpy(&p->headCommit, &branchCommit, sizeof(ProllyHash));
     }else{
-      /* No refs yet — use manifest headCommit directly */
+      
       chunkStoreGetHeadCommit(&pBt->store, &p->headCommit);
     }
-    /* Load per-branch WorkingSet (staged + merge state).
-    ** Falls back to manifest stagedCatalog for migration from pre-WorkingSet format. */
+    
     {
       ProllyHash wsHash;
       if( chunkStoreGetBranchWorkingSet(&pBt->store, defBranch, &wsHash)==SQLITE_OK
        && !prollyHashIsEmpty(&wsHash) ){
-        /* WorkingSet exists — load it */
+        
         u8 *wsData = 0; int nWsData = 0;
         if( chunkStoreGet(&pBt->store, &wsHash, &wsData, &nWsData)==SQLITE_OK
          && nWsData >= WS_TOTAL_SIZE ){
@@ -1648,7 +1395,7 @@ catalog_loaded:
         }
         sqlite3_free(wsData);
       }else{
-        /* Migration: load from manifest (legacy) */
+        
         chunkStoreGetStagedCatalog(&pBt->store, &p->stagedCatalog);
         chunkStoreGetMergeState(&pBt->store, &p->isMerging,
                                 &p->mergeCommitHash, &p->conflictsCatalogHash);
@@ -1658,17 +1405,12 @@ catalog_loaded:
 
   *ppBtree = p;
 
-  /* Register doltite_engine() SQL function for runtime detection.
-  ** Must happen AFTER *ppBtree is set so that db->aDb[0].pBt is
-  ** accessible for functions that need the chunk store. */
+  
   registerDoltiteFunctions(db);
 
   return SQLITE_OK;
 }
 
-/*
-** Close a database connection and free all associated resources.
-*/
 static int prollyBtreeClose(Btree *p){
   BtShared *pBt;
 
@@ -1679,7 +1421,7 @@ static int prollyBtreeClose(Btree *p){
     sqlite3BtreeCloseCursor(pBt->pCursor);
   }
 
-  /* Free per-session state from Btree */
+  
   if( p->pSchema && p->xFreeSchema ){
     p->xFreeSchema(p->pSchema);
     p->pSchema = 0;
@@ -1717,9 +1459,6 @@ int sqlite3BtreeClose(Btree *p){
   return p->pOps->xClose(p);
 }
 
-/*
-** Initialize a fresh (empty) database with default meta values.
-*/
 static int prollyBtreeNewDb(Btree *p){
   memset(p->aMeta, 0, sizeof(p->aMeta));
   p->aMeta[BTREE_FILE_FORMAT] = 4;
@@ -1743,10 +1482,6 @@ int sqlite3BtreeNewDb(Btree *p){
   if( !p ) return SQLITE_OK;
   return p->pOps->xNewDb(p);
 }
-
-/* --------------------------------------------------------------------------
-** Configuration (mostly no-ops)
-** -------------------------------------------------------------------------- */
 
 static int prollyBtreeSetCacheSize(Btree *p, int mxPage){
   (void)p; (void)mxPage;
@@ -1815,7 +1550,7 @@ Pgno sqlite3BtreeMaxPageCount(Btree *p, Pgno mxPage){
 }
 
 static Pgno prollyBtreeLastPage(Btree *p){
-  /* Must be >= iNextTable so rootpage validation in prepare.c passes */
+  
   return p->iNextTable + 1000;
 }
 Pgno sqlite3BtreeLastPage(Btree *p){
@@ -1901,15 +1636,6 @@ int sqlite3BtreeIsReadonly(Btree *p){
   return p->pOps->xIsReadonly(p);
 }
 
-/* --------------------------------------------------------------------------
-** Transactions
-** -------------------------------------------------------------------------- */
-
-/*
-** Check whether the on-disk manifest has changed since the last refresh
-** and, if so, reload the catalog and root hash from the chunk store.
-** Updates committedRoot, iBDataVersion, and the pager shim version.
-*/
 static int btreeRefreshFromDisk(Btree *p){
   BtShared *pBt = p->pBt;
   int bChanged = 0;
@@ -1917,12 +1643,7 @@ static int btreeRefreshFromDisk(Btree *p){
   if( rc!=SQLITE_OK ) return rc;
   if( !bChanged ) return SQLITE_OK;
 
-  /* After refresh, decide whether the manifest state belongs to THIS
-  ** connection's branch.  The manifest headCommit is updated only by
-  ** dolt_commit / dolt_checkout.  If it matches our branch HEAD, the
-  ** manifest catalog/root may include uncommitted working changes and
-  ** we should use them.  If it doesn't match, a different branch
-  ** committed and we must reload from our branch HEAD commit. */
+  
   {
     ProllyHash catHash;
     ProllyHash manifestHead;
@@ -1936,8 +1657,7 @@ static int btreeRefreshFromDisk(Btree *p){
     if( chunkStoreFindBranch(&pBt->store, zBr, &branchHead)==SQLITE_OK
      && !prollyHashIsEmpty(&branchHead)
      && prollyHashCompare(&manifestHead, &branchHead)!=0 ){
-      /* Manifest was written by a different branch — load our branch's
-      ** committed state instead of the manifest catalog. */
+      
       u8 *commitData = 0;
       int nCommitData = 0;
       rc = chunkStoreGet(&pBt->store, &branchHead, &commitData, &nCommitData);
@@ -1956,8 +1676,7 @@ static int btreeRefreshFromDisk(Btree *p){
     }
 
     if( !useBranchCommit ){
-      /* Manifest belongs to our branch — use manifest catalog/root
-      ** (may include uncommitted working changes). */
+      
       chunkStoreGetCatalog(&pBt->store, &catHash);
       chunkStoreGetRoot(&pBt->store, &p->root);
     }
@@ -1994,7 +1713,7 @@ static int prollyBtreeBeginTrans(Btree *p, int wrFlag, int *pSchemaVersion){
     return SQLITE_OK;
   }
 
-  /* Detect if another connection replaced the database file */
+  
   rc = btreeRefreshFromDisk(p);
   if( rc!=SQLITE_OK ) return rc;
   if( pSchemaVersion ){
@@ -2005,15 +1724,8 @@ static int prollyBtreeBeginTrans(Btree *p, int wrFlag, int *pSchemaVersion){
     if( pBt->btsFlags & BTS_READ_ONLY ){
       return SQLITE_READONLY;
     }
-    /* TODO: exclusive writer enforcement needed here (issue #250).
-    ** Multiple in-process connections sharing a BtShared can corrupt the
-    ** in-memory prolly tree via concurrent DML. The fix requires
-    ** understanding how BtShared is shared across connections. */
-    /* Ensure aTables includes all persistent tables from the catalog.
-    ** Tables are lazily added to aTables when cursors open, so after a
-    ** transaction commits and cursors close, aTables may only contain
-    ** the master table. Reload from the catalog so the snapshot used
-    ** for deferred-write eligibility includes all persistent tables. */
+    
+    
     {
       ProllyHash catHash;
       chunkStoreGetCatalog(&pBt->store, &catHash);
@@ -2028,7 +1740,7 @@ static int prollyBtreeBeginTrans(Btree *p, int wrFlag, int *pSchemaVersion){
         }
       }
     }
-    /* Snapshot table registry for rollback */
+    
     sqlite3_free(p->aCommittedTables);
     p->aCommittedTables = 0;
     p->nCommittedTables = 0;
@@ -2045,8 +1757,7 @@ static int prollyBtreeBeginTrans(Btree *p, int wrFlag, int *pSchemaVersion){
     p->committedRoot = p->root;
     p->inTrans = TRANS_WRITE;
     p->inTransaction = TRANS_WRITE;
-    /* Ensure btree savepoint stack matches db->nSavepoint.
-    ** This mimics what sqlite3PagerOpenSavepoint does in stock SQLite. */
+    
     if( p->db ){
       while( p->nSavepoint < p->db->nSavepoint ){
         int rc2 = pushSavepoint(p);
@@ -2062,8 +1773,7 @@ static int prollyBtreeBeginTrans(Btree *p, int wrFlag, int *pSchemaVersion){
     }
   }
 
-  /* Pin the chunk store snapshot so concurrent commits from other
-  ** connections don't change our view mid-transaction. */
+  
   pBt->store.snapshotPinned = 1;
 
   return SQLITE_OK;
@@ -2088,10 +1798,10 @@ static int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
   (void)bCleanup;
 
   if( p->inTrans==TRANS_WRITE ){
-    /* Flush all pending mutations before committing */
+    
     rc = flushAllPending(pBt, 0);
     if( rc!=SQLITE_OK ) return rc;
-    /* Serialize and store the catalog (table registry + meta) */
+    
     {
       u8 *catData = 0;
       int nCatData = 0;
@@ -2121,7 +1831,7 @@ static int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
   p->inTransaction = TRANS_NONE;
   p->nSavepoint = 0;
 
-  /* Unpin snapshot so next transaction sees latest state */
+  
   pBt->store.snapshotPinned = 0;
 
   return rc;
@@ -2144,10 +1854,6 @@ int sqlite3BtreeCommit(Btree *p){
   return p->pOps->xCommit(p);
 }
 
-/*
-** Restore the table registry from the committed snapshot.
-** Used by both rollback and savepoint rollback to transaction start.
-*/
 static int restoreFromCommitted(Btree *p){
   if( p->aCommittedTables ){
     sqlite3_free(p->aTables);
@@ -2176,7 +1882,7 @@ static int prollyBtreeRollback(Btree *p, int tripCode, int writeOnly){
   (void)writeOnly;
 
   if( p->inTrans==TRANS_WRITE ){
-    /* Restore table registry from committed snapshot */
+    
     if( p->aCommittedTables ){
       sqlite3_free(p->aTables);
       p->aTables = p->aCommittedTables;
@@ -2187,7 +1893,7 @@ static int prollyBtreeRollback(Btree *p, int tripCode, int writeOnly){
       p->nCommittedTables = 0;
     }
     p->root = p->committedRoot;
-    /* Clear all pending mutations (they're being rolled back) */
+    
     {
       BtCursor *pC;
       for(pC = pBt->pCursor; pC; pC = pC->pNext){
@@ -2203,7 +1909,7 @@ static int prollyBtreeRollback(Btree *p, int tripCode, int writeOnly){
   p->inTransaction = TRANS_NONE;
   p->nSavepoint = 0;
 
-  /* Unpin snapshot so next transaction sees latest state */
+  
   pBt->store.snapshotPinned = 0;
 
   return SQLITE_OK;
@@ -2218,7 +1924,7 @@ static int prollyBtreeBeginStmt(Btree *p, int iStatement){
     return SQLITE_ERROR;
   }
 
-  /* Push savepoints until we reach iStatement level */
+  
   while( p->nSavepoint < iStatement ){
     int rc = pushSavepoint(p);
     if( rc!=SQLITE_OK ) return rc;
@@ -2251,17 +1957,14 @@ static int prollyBtreeSavepoint(Btree *p, int op, int iSavepoint){
      && p->aSavepointTables ){
       struct SavepointTableState *pState = &p->aSavepointTables[iSavepoint];
       p->root = p->aSavepoint[iSavepoint];
-      /* Restore table registry: restore root hashes from snapshot and
-      ** truncate each pPending to its pre-savepoint size.  Post-savepoint
-      ** edits in pPending are freed; pre-savepoint edits are preserved. */
+      
       if( pState->aTables ){
-        /* Restore roots and truncate pPending for tables that existed
-        ** at savepoint time.  Tables added after the savepoint are removed. */
+        
         {
           int k;
           for(k=0; k<pState->nTables && k<p->nTables; k++){
             p->aTables[k].root = pState->aTables[k].root;
-            /* Truncate pPending to saved size, freeing post-savepoint entries */
+            
             ProllyMutMap *pMap = (ProllyMutMap*)p->aTables[k].pPending;
             if( pMap ){
               int savedCount = pState->aPendingCount[k];
@@ -2273,7 +1976,7 @@ static int prollyBtreeSavepoint(Btree *p, int op, int iSavepoint){
               }
             }
           }
-          /* Free pPending on tables added after the savepoint */
+          
           for(k=pState->nTables; k<p->nTables; k++){
             if( p->aTables[k].pPending ){
               prollyMutMapFree((ProllyMutMap*)p->aTables[k].pPending);
@@ -2281,17 +1984,17 @@ static int prollyBtreeSavepoint(Btree *p, int op, int iSavepoint){
             }
           }
         }
-        /* Restore table count */
+        
         p->nTables = pState->nTables;
         p->nTablesAlloc = p->nTables;
         p->iNextTable = pState->iNextTable;
-        /* Free the snapshot aTables (we restored roots in-place) */
+        
         sqlite3_free(pState->aTables);
         sqlite3_free(pState->aPendingCount);
         pState->aTables = 0;
         pState->aPendingCount = 0;
       }
-      /* Free savepoints above this one */
+      
       {
         int j;
         for(j=iSavepoint+1; j<p->nSavepoint; j++){
@@ -2318,7 +2021,7 @@ static int prollyBtreeSavepoint(Btree *p, int op, int iSavepoint){
       invalidateSchema(p);
     }
   } else {
-    /* SAVEPOINT_RELEASE: free this savepoint and all above it */
+    
     if( iSavepoint>=0 && iSavepoint<p->nSavepoint ){
       int j;
       for(j=iSavepoint; j<p->nSavepoint; j++){
@@ -2342,10 +2045,6 @@ SQLITE_NOINLINE int sqlite3BtreeTxnState(Btree *p){
   if( p==0 ) return TRANS_NONE;
   return p->pOps->xTxnState(p);
 }
-
-/* --------------------------------------------------------------------------
-** Table operations
-** -------------------------------------------------------------------------- */
 
 static int prollyBtreeCreateTable(Btree *p, Pgno *piTable, int flags){
   struct TableEntry *pTE;
@@ -2439,10 +2138,6 @@ int sqlite3BtreeClearTableOfCursor(BtCursor *pCur){
   return pCur->pCurOps->xClearTableOfCursor(pCur);
 }
 
-/* --------------------------------------------------------------------------
-** Meta values
-** -------------------------------------------------------------------------- */
-
 static void prollyBtreeGetMeta(Btree *p, int idx, u32 *pValue){
   BtShared *pBt = p->pBt;
   assert( idx>=0 && idx<SQLITE_N_BTREE_META );
@@ -2488,10 +2183,6 @@ int sqlite3BtreeUpdateMeta(Btree *p, int idx, u32 value){
   return p->pOps->xUpdateMeta(p, idx, value);
 }
 
-/* --------------------------------------------------------------------------
-** Schema
-** -------------------------------------------------------------------------- */
-
 static void *prollyBtreeSchema(Btree *p, int nBytes, void (*xFree)(void*)){
   if( !p->pSchema && nBytes>0 ){
     p->pSchema = sqlite3_malloc(nBytes);
@@ -2526,10 +2217,6 @@ int sqlite3BtreeLockTable(Btree *p, int iTab, u8 isWriteLock){
   return p->pOps->xLockTable(p, iTab, isWriteLock);
 }
 #endif
-
-/* --------------------------------------------------------------------------
-** Cursor operations
-** -------------------------------------------------------------------------- */
 
 int sqlite3BtreeCursorSize(void){
   return (int)sizeof(BtCursor);
@@ -2573,14 +2260,7 @@ static int prollyBtreeCursor(
     pCur->curFlags = BTCF_WriteFlag;
   }
 
-  /* Piece 2: pick up deferred edits from a previous cursor on this table.
-  **
-  ** Bug #240: When a read cursor opens while a write cursor is still active
-  ** on the same table, the MutMap is in the write cursor (not pPending).
-  ** The read cursor would see a stale tree.  Fix: before any cursor opens
-  ** on a table, flush ALL live MutMaps for that table to the tree. This
-  ** ensures every cursor sees consistent data.
-  */
+  
   {
     BtCursor *pOther;
     for(pOther = pBt->pCursor; pOther; pOther = pOther->pNext){
@@ -2595,7 +2275,7 @@ static int prollyBtreeCursor(
       pCur->pMutMap = (ProllyMutMap*)pTE->pPending;
       pTE->pPending = 0;
     }else{
-      /* Flush pPending too so read cursor sees consistent tree */
+      
       ProllyMutMap *pMap = (ProllyMutMap*)pTE->pPending;
       if( !prollyMutMapIsEmpty(pMap) ){
         ProllyMutator mut;
@@ -2645,18 +2325,14 @@ static int prollyBtCursorCloseCursor(BtCursor *pCur){
   pBt = pCur->pBt;
   if( !pBt ) return SQLITE_OK;
 
-  /* Piece 4: Transfer MutMap to table entry for deferred flush.
-  ** The MutMap will be picked up by the next cursor on this table,
-  ** or flushed at BtreeCommitPhaseTwo / BtreeFirst / BtreeLast. */
+  
   if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
     struct TableEntry *pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
     if( pTE && !pTE->pPending ){
       pTE->pPending = pCur->pMutMap;
       pCur->pMutMap = 0;
     }else if( pTE && pTE->pPending ){
-      /* Merge into existing pending instead of flushing (tree rebuild).
-      ** This happens when multiple cursors on the same table close
-      ** during the same transaction. */
+      
       prollyMutMapMerge((ProllyMutMap*)pTE->pPending, pCur->pMutMap);
       prollyMutMapFree(pCur->pMutMap);
       sqlite3_free(pCur->pMutMap);
@@ -2747,14 +2423,6 @@ int sqlite3BtreeClosesWithCursor(Btree *p, BtCursor *pCur){
 }
 #endif
 
-/* --------------------------------------------------------------------------
-** Merge iteration: two-pointer merge over tree cursor + MutMap.
-** Both sources are sorted by the same key ordering.  On each step,
-** we pick the smaller (Next) or larger (Prev) key, handling DELETEs
-** by skipping entries present in both sources.
-** -------------------------------------------------------------------------- */
-
-/* Compare the tree cursor's current key with a MutMap entry. */
 static int mergeCompare(BtCursor *pCur, ProllyMutMapEntry *e){
   if( pCur->curIntKey ){
     i64 tk = prollyCursorIntKey(&pCur->pCur);
@@ -2771,13 +2439,10 @@ static int mergeCompare(BtCursor *pCur, ProllyMutMapEntry *e){
   }
 }
 
-/* Advance to the next merged entry (forward). Returns SQLITE_OK or
-** SQLITE_DONE.  Skips DELETE entries and tree entries overridden by
-** MutMap. */
 static int mergeStepForward(BtCursor *pCur){
   int treeOk, mutOk;
 
-  /* Advance the source(s) that produced the current entry */
+  
   if( pCur->mergeSrc==MERGE_SRC_TREE || pCur->mergeSrc==MERGE_SRC_BOTH ){
     prollyCursorNext(&pCur->pCur);
   }
@@ -2810,7 +2475,7 @@ static int mergeStepForward(BtCursor *pCur){
       pCur->mergeSrc = MERGE_SRC_MUT;
       return SQLITE_OK;
     }else{
-      /* Same key — MutMap overrides tree */
+      
       if( e->op==PROLLY_EDIT_DELETE ){
         pCur->mmIdx++;
         prollyCursorNext(&pCur->pCur);
@@ -2822,7 +2487,6 @@ static int mergeStepForward(BtCursor *pCur){
   }
 }
 
-/* Advance to the previous merged entry (backward). */
 static int mergeStepBackward(BtCursor *pCur){
   int treeOk, mutOk;
 
@@ -2869,16 +2533,14 @@ static int mergeStepBackward(BtCursor *pCur){
   }
 }
 
-/* Find the first merged entry (for BtreeFirst). */
 static int mergeFirst(BtCursor *pCur, int *pRes){
-  pCur->mergeSrc = MERGE_SRC_TREE;  /* Will be corrected below */
+  pCur->mergeSrc = MERGE_SRC_TREE;  
   pCur->mmIdx = 0;
 
   int treeOk = (pCur->pCur.eState==PROLLY_CURSOR_VALID);
   int mutOk  = (pCur->mmIdx < pCur->pMutMap->nEntries);
 
-  /* Position: we haven't advanced yet, so this IS the first entry.
-  ** Use the same scan logic as mergeStepForward but without advancing first. */
+  
   for(;;){
     treeOk = (pCur->pCur.eState==PROLLY_CURSOR_VALID);
     mutOk  = (pCur->mmIdx >= 0 && pCur->mmIdx < pCur->pMutMap->nEntries);
@@ -2915,7 +2577,6 @@ static int mergeFirst(BtCursor *pCur, int *pRes){
   }
 }
 
-/* Find the last merged entry (for BtreeLast). */
 static int mergeLast(BtCursor *pCur, int *pRes){
   pCur->mmIdx = pCur->pMutMap->nEntries - 1;
   pCur->mergeSrc = MERGE_SRC_TREE;
@@ -2956,10 +2617,6 @@ static int mergeLast(BtCursor *pCur, int *pRes){
   }
 }
 
-/* --------------------------------------------------------------------------
-** Cursor navigation
-** -------------------------------------------------------------------------- */
-
 static int flushTablePending(BtCursor *pCur){
   struct TableEntry *pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
   if( pTE && pTE->pPending ){
@@ -2995,8 +2652,7 @@ static int prollyBtCursorFirst(BtCursor *pCur, int *pRes){
   rc = flushTablePending(pCur);
   if( rc!=SQLITE_OK ) return rc;
 
-  /* Flush OTHER cursors' MutMaps but NOT our own — merge iteration
-  ** handles our pending edits without tree rebuild. */
+  
   {
     BtCursor *p;
     for(p = pCur->pBt->pCursor; p; p = p->pNext){
@@ -3072,15 +2728,12 @@ static int prollyBtCursorNext(BtCursor *pCur, int flags){
   (void)flags;
   CLEAR_CACHED_PAYLOAD(pCur);
 
-  /* Handle cursors invalidated by delete */
+  
   if( pCur->eState==CURSOR_INVALID ){
     return SQLITE_DONE;
   }
 
-  /* Restore cursor position if it was saved (e.g. by saveAllCursors during
-  ** an insert on another cursor sharing the same ephemeral table). Without
-  ** this, window functions crash because the prolly cursor's internal node
-  ** pointers are NULL after a save. */
+  
   if( pCur->eState==CURSOR_REQUIRESEEK ){
     rc = restoreCursorPosition(pCur, 0);
     if( rc!=SQLITE_OK ) return rc;
@@ -3106,8 +2759,7 @@ static int prollyBtCursorNext(BtCursor *pCur, int flags){
       pCur->eState = CURSOR_VALID;
     }
   }else{
-    /* If the MutMap acquired entries mid-scan (e.g. deferred deletes),
-    ** activate merge iteration so we skip deleted entries and see inserts. */
+    
     if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
       ProllyMutMapIter it;
       if( pCur->curIntKey && prollyCursorIsValid(&pCur->pCur) ){
@@ -3247,10 +2899,6 @@ int sqlite3BtreeIsEmpty(BtCursor *pCur, int *pRes){
   return pCur->pCurOps->xIsEmpty(pCur, pRes);
 }
 
-/* --------------------------------------------------------------------------
-** Cursor seek
-** -------------------------------------------------------------------------- */
-
 static int prollyBtCursorTableMoveto(
   BtCursor *pCur,
   i64 intKey,
@@ -3265,23 +2913,17 @@ static int prollyBtCursorTableMoveto(
   pCur->nSeek++;
   if( pCur->pBtree ) pCur->pBtree->nSeek++;
 
-  /*
-  ** Optimization: check the MutMap first before flushing.
-  ** If the key is in the MutMap as an INSERT, it exists — no flush needed.
-  ** If the key is in the MutMap as a DELETE, it doesn't exist.
-  ** If not in MutMap, search the existing tree (also no flush needed).
-  ** Only flush when we have pending edits from OTHER cursors.
-  */
+  
   if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
     ProllyMutMapEntry *pEntry = prollyMutMapFind(pCur->pMutMap, 0, 0, intKey);
     if( pEntry ){
       if( pEntry->op == PROLLY_EDIT_INSERT ){
-        /* Key exists in pending inserts — exact match */
+        
         *pRes = 0;
         pCur->eState = CURSOR_VALID;
         pCur->curFlags |= BTCF_ValidNKey;
         pCur->cachedIntKey = intKey;
-        /* Copy the MutMap value so it's safe after MutMap changes */
+        
         if( pCur->cachedPayloadOwned && pCur->pCachedPayload ){
           sqlite3_free(pCur->pCachedPayload);
         }
@@ -3297,9 +2939,7 @@ static int prollyBtCursorTableMoveto(
           CLEAR_CACHED_PAYLOAD(pCur);
         }
         pCur->cachedPayloadOwned = 1;
-        /* Also position the prolly cursor for Next/Prev support.
-        ** Without this, BtreeNext crashes on an unpositioned cursor
-        ** when pPending edits are carried across savepoints. */
+        
         refreshCursorRoot(pCur);
         {
           int seekRes = 0;
@@ -3308,13 +2948,13 @@ static int prollyBtCursorTableMoveto(
         }
         return SQLITE_OK;
       } else {
-        /* Key is pending DELETE — doesn't exist */
+        
         *pRes = 1;
         pCur->eState = CURSOR_INVALID;
         return SQLITE_OK;
       }
     }
-    /* Not in MutMap — fall through to check the tree without flushing */
+    
   }
 
   refreshCursorRoot(pCur);
@@ -3346,20 +2986,6 @@ int sqlite3BtreeTableMoveto(
   return pCur->pCurOps->xTableMoveto(pCur, intKey, bias, pRes);
 }
 
-/*
-** Serialize an UnpackedRecord to a SQLite record blob, then convert
-** to sort key for prolly tree navigation.
-*/
-/*
-** Compute the SQLite serial type for an in-memory value (Mem).
-**
-** The serial type encodes both the data type and its storage size in the
-** record format. NULL=0, integers 1-6 use 1/2/3/4/6/8 bytes, float=7
-** uses 8 bytes, constants 0 and 1 use types 8/9 with no payload,
-** text = len*2+13, blob = len*2+12.
-**
-** Returns the serial type code and sets *pLen to the payload byte count.
-*/
 static u32 btreeSerialType(Mem *pMem, u32 *pLen){
   int flags = pMem->flags;
   if( flags & MEM_Null ){ *pLen = 0; return SERIAL_TYPE_NULL; }
@@ -3388,17 +3014,6 @@ static u32 btreeSerialType(Mem *pMem, u32 *pLen){
   *pLen = 0; return SERIAL_TYPE_NULL;
 }
 
-/*
-** Serialize an UnpackedRecord into a standard SQLite record blob.
-**
-** The record format is: varint(header_size) followed by serial type varints
-** for each field, then the concatenated field data. This is the same binary
-** format used by SQLite's OP_MakeRecord. The resulting blob can be compared
-** with sqlite3VdbeRecordCompare() or stored as a BLOBKEY table value.
-**
-** On success, *ppOut is set to a sqlite3_malloc'd buffer (caller frees)
-** and *pnOut to its length. Returns SQLITE_OK or SQLITE_NOMEM.
-*/
 static int serializeUnpackedRecord(UnpackedRecord *pRec, u8 **ppOut, int *pnOut){
   int nField = pRec->nField;
   Mem *aMem = pRec->aMem;
@@ -3437,7 +3052,7 @@ static int serializeUnpackedRecord(UnpackedRecord *pRec, u8 **ppOut, int *pnOut)
       Mem *p = &aMem[i];
       u32 st = aType[i];
       if( st==SERIAL_TYPE_NULL || st==SERIAL_TYPE_ZERO || st==SERIAL_TYPE_ONE ){
-        /* no data */
+        
       }else if( st<=SERIAL_TYPE_INT64 ){
         i64 v = p->u.i;
         int nByte = (int)aLen[i];
@@ -3482,19 +3097,14 @@ static int prollyBtCursorIndexMoveto(
 
   CLEAR_CACHED_PAYLOAD(pCur);
 
-  /* Flush pending mutations from other cursors on this table.
-  ** For our own MutMap: flush only if the tree is empty (all data in
-  ** MutMap — e.g. freshly populated auto-index).  When the tree already
-  ** has data, our MutMap is checked inline during the leaf scan and via
-  ** the MutMap seek section below, avoiding O(N^2) flushes during
-  ** scan-based DELETE. */
+  
   {
     BtCursor *p;
     for(p = pCur->pBt->pCursor; p; p = p->pNext){
       if( p->pgnoRoot==pCur->pgnoRoot
        && p->pMutMap && !prollyMutMapIsEmpty(p->pMutMap) ){
         if( p==pCur ){
-          /* Self-flush only when tree is empty (no prior data to seek) */
+          
           struct TableEntry *pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
           if( pTE && prollyHashIsEmpty(&pTE->root) ){
             rc = flushMutMap(p);
@@ -3511,19 +3121,14 @@ static int prollyBtCursorIndexMoveto(
 
   refreshCursorRoot(pCur);
 
-  /*
-  ** Parallel seek: O(log N) tree seek + O(log M) MutMap seek.
-  ** Both the tree and MutMap are sorted by sort key.
-  ** Compute sort key from search key, seek both, pick the best match.
-  ** Verify with VdbeRecordCompare for eqSeen/default_rc correctness.
-  */
+  
   {
     int treeFound = 0, mutFound = 0;
     int treeCmp = 0, mutCmp = 0;
     const u8 *mutKey = 0;
     int mutNKey = 0;
 
-    /* Serialize the UnpackedRecord to a blob, then compute sort key */
+    
     u8 *pSerKey = 0;
     int nSerKey = 0;
     u8 *pSortKey = 0;
@@ -3536,13 +3141,7 @@ static int prollyBtCursorIndexMoveto(
       return rc;
     }
 
-    /* ---- Tree seek: O(log N) sort key descent + bounded leaf scan ----
-    ** Use sort key blob seek for O(log N) tree descent to the correct leaf.
-    ** Then scan the leaf node's VALUES using VdbeRecordCompare.
-    ** Leaf nodes are bounded in size (typically ~100 entries), so the
-    ** leaf scan is O(K) where K is a small constant.
-    ** If not found in the current leaf, check adjacent leaves (prev/next).
-    ** Total: O(log N) + O(K) = O(log N). */
+    
     rc = prollyCursorSeekBlob(&pCur->pCur, pSortKey, nSortKey, &(int){0});
     if( rc==SQLITE_OK && pCur->pCur.eState==PROLLY_CURSOR_VALID ){
       int iLevel = pCur->pCur.iLevel;
@@ -3550,16 +3149,11 @@ static int prollyBtCursorIndexMoveto(
       int seekIdx = pCur->pCur.aLevel[iLevel].idx;
       int nItems = pLeaf->node.nItems;
 
-      /* Binary search on sort key prefix to find matching range, then
-      ** VdbeRecordCompare within that range. O(log L + K) where K is
-      ** the number of entries matching the sort key prefix.
-      ** Entries are sorted by sort key (memcmp). The search sort key
-      ** may be a prefix of stored sort keys (fewer index fields). */
+      
       int bestIdx = -1;
       int bestCmp = 0;
       {
-        /* Phase 1: Binary search for first entry whose sort key prefix
-        ** >= pSortKey. Uses memcmp on the shorter of the two keys. */
+        
         int lo = 0, hi = nItems;
         while( lo < hi ){
           int mid = lo + (hi - lo) / 2;
@@ -3574,16 +3168,13 @@ static int prollyBtCursorIndexMoveto(
           }
         }
 
-        /* Phase 2: Scan from 'lo' using VdbeRecordCompare. Stop when
-        ** we pass the prefix range (sort key prefix no longer matches).
-        ** The SQLite record is either stored as the prolly value (old
-        ** format) or reconstructed from the sort key (new format). */
-        u8 *pRecBuf = 0;  /* Temp buffer for reconstructed records */
+        
+        u8 *pRecBuf = 0;  
         int i;
         for( i = lo; i < nItems; i++ ){
           const u8 *pSK; int nSK;
           prollyNodeKey(&pLeaf->node, i, &pSK, &nSK);
-          /* Check if past prefix range */
+          
           {
             int cmpLen = nSK < nSortKey ? nSK : nSortKey;
             int prefixCmp = memcmp(pSK, pSortKey, cmpLen);
@@ -3651,32 +3242,27 @@ static int prollyBtCursorIndexMoveto(
       }
 
       if( treeFound ){
-        /* Exact match found in leaf */
+        
         pCur->pCur.aLevel[iLevel].idx = bestIdx;
       } else if( bestIdx >= 0 ){
-        /* No exact match but found a larger entry */
+        
         pCur->pCur.aLevel[iLevel].idx = bestIdx;
         treeCmp = bestCmp;
         treeFound = 1;
       }
 
-      /* The sort-key tree descent via prollyCursorSeekBlob lands on the
-      ** correct leaf — adjacent leaf scanning is not needed.  Internal
-      ** node boundary keys are the max key of each child, so the binary
-      ** search at each level guarantees we reach the leaf containing the
-      ** target key (or its immediate neighbor for range queries). */
+      
     }
 
-    /* ---- MutMap seek: O(log M) using prollyMutMapFind ---- */
-    /* Only if tree didn't find exact match */
+    
+    
     if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap)
      && !(treeFound && treeCmp==0) ){
-      /* Use sort key for exact match lookup in MutMap */
+      
       ProllyMutMapEntry *mutE = prollyMutMapFind(
           pCur->pMutMap, pSortKey, nSortKey, 0);
       if( mutE && mutE->op==PROLLY_EDIT_INSERT ){
-        /* MutMap value is the original SQLite record, or empty for
-        ** BLOBKEY entries (reconstructed from sort key via #216). */
+        
         const u8 *pMutVal = mutE->pVal;
         int nMutVal = mutE->nVal;
         u8 *pRecon = 0;
@@ -3699,14 +3285,14 @@ static int prollyBtCursorIndexMoveto(
     sqlite3_free(pSerKey);
     sqlite3_free(pSortKey);
 
-    /* ---- Pick best result ---- */
+    
     if( mutFound && (!treeFound || treeCmp!=0) ){
-      /* MutMap has exact match — cache reconstructed or original record */
+      
       if( pCur->cachedPayloadOwned && pCur->pCachedPayload ){
         sqlite3_free(pCur->pCachedPayload);
       }
       if( mutNKey > 0 ){
-        /* Check if mutKey is already an owned buffer (from recordFromSortKey) */
+        
         u8 *pCopy = sqlite3_malloc(mutNKey);
         if( pCopy ){
           memcpy(pCopy, mutKey, mutNKey);
@@ -3733,8 +3319,7 @@ static int prollyBtCursorIndexMoveto(
   }
 
 no_match:
-  /* Ran off the end — all stored keys < search key.
-  ** Position at the last entry if possible. */
+  
   {
     int lastRes = 0;
     rc = prollyCursorLast(&pCur->pCur, &lastRes);
@@ -3758,14 +3343,10 @@ int sqlite3BtreeIndexMoveto(
   return pCur->pCurOps->xIndexMoveto(pCur, pIdxKey, pRes);
 }
 
-/* --------------------------------------------------------------------------
-** Cursor read
-** -------------------------------------------------------------------------- */
-
 static i64 prollyBtCursorIntegerKey(BtCursor *pCur){
   assert( pCur->eState==CURSOR_VALID );
   assert( pCur->curIntKey );
-  /* Merge iteration: current entry may come from MutMap */
+  
   if( pCur->mmActive
    && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
     return pCur->pMutMap->aEntries[pCur->mmIdx].intKey;
@@ -3780,28 +3361,24 @@ i64 sqlite3BtreeIntegerKey(BtCursor *pCur){
   return pCur->pCurOps->xIntegerKey(pCur);
 }
 
-/*
-** For INTKEY tables: payload = the value (data stored in leaf)
-** For BLOBKEY (index) tables: payload = the key (entire record IS the key)
-*/
 static void getCursorPayload(BtCursor *pCur, const u8 **ppData, int *pnData){
-  /* If we have cached payload, return that. */
+  
   if( pCur->pCachedPayload && pCur->nCachedPayload > 0 ){
     *ppData = pCur->pCachedPayload;
     *pnData = pCur->nCachedPayload;
     return;
   }
 
-  /* Merge iteration: current entry may come from MutMap, not tree. */
+  
   if( pCur->mmActive
    && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
     ProllyMutMapEntry *e = &pCur->pMutMap->aEntries[pCur->mmIdx];
     if( pCur->curIntKey ){
-      /* INTKEY: MutMap value IS the payload */
+      
       *ppData = e->pVal;
       *pnData = e->nVal;
     }else{
-      /* BLOBKEY: reconstruct record from MutMap sort key */
+      
       u8 *pRec = 0; int nRec = 0;
       recordFromSortKey(e->pKey, e->nKey, &pRec, &nRec);
       if( pRec ){
@@ -3821,9 +3398,7 @@ static void getCursorPayload(BtCursor *pCur, const u8 **ppData, int *pnData){
   if( pCur->curIntKey ){
     prollyCursorValue(&pCur->pCur, ppData, pnData);
   }else{
-    /* BLOBKEY: the prolly value may be empty (new format) or contain
-    ** the original SQLite record (old format, backward compat).
-    ** If empty, reconstruct losslessly from the sort key. */
+    
     const u8 *pVal; int nVal;
     prollyCursorValue(&pCur->pCur, &pVal, &nVal);
     if( nVal > 0 ){
@@ -3912,10 +3487,6 @@ i64 sqlite3BtreeOffset(BtCursor *pCur){
   return pCur->pCurOps->xOffset(pCur);
 }
 
-/* --------------------------------------------------------------------------
-** Cursor write
-** -------------------------------------------------------------------------- */
-
 static int prollyBtCursorInsert(
   BtCursor *pCur,
   const BtreePayload *pPayload,
@@ -3925,14 +3496,7 @@ static int prollyBtCursorInsert(
   int rc;
   (void)seekResult;
 
-  /*
-  ** BTREE_PREFORMAT means the data was already inserted by
-  ** sqlite3BtreeTransferRow() during OP_RowCell processing.
-  ** In stock SQLite's page-based btree, PREFORMAT means the cell
-  ** is already formatted in the page buffer and OP_Insert just
-  ** finalizes it. In the prolly tree, TransferRow calls BtreeInsert
-  ** directly, so the row is already stored. Skip the duplicate insert.
-  */
+  
   if( flags & BTREE_PREFORMAT ){
     return SQLITE_OK;
   }
@@ -3971,10 +3535,7 @@ static int prollyBtCursorInsert(
                              pData, nData);
     sqlite3_free(pBuf);
   } else {
-    /* BLOBKEY (index): compute sort key for memcmp-sortable ordering.
-    ** Store sort key as prolly key with empty value — the original
-    ** SQLite record is reconstructed from the sort key on read via
-    ** recordFromSortKey() (the encoding is lossless). */
+    
     u8 *pSortKey = 0;
     int nSortKey = 0;
     rc = sortKeyFromRecord((const u8*)pPayload->pKey,
@@ -3990,17 +3551,12 @@ static int prollyBtCursorInsert(
 
   if( rc!=SQLITE_OK ) return rc;
 
-  /* Defer flush for ALL non-master tables.  BtreeFirst/Last initialize
-  ** merge iteration over the tree cursor + MutMap, and BtreeNext/Prev
-  ** advance through both in sorted order.  This eliminates O(N^2)
-  ** per-row flushes for ephemeral tables (CTEs, DISTINCT, window
-  ** functions) and persistent tables alike. */
+  
   {
     int canDefer = (pCur->pgnoRoot > 1);
     if( canDefer ){
       if( (flags & BTREE_SAVEPOSITION) && pCur->curIntKey ){
-        /* INTKEY SAVEPOSITION: cache the inserted data so cursor reads work.
-        ** The cursor appears positioned on the newly inserted row. */
+        
         ProllyMutMapEntry *pEntry = prollyMutMapFind(
             pCur->pMutMap, NULL, 0, pPayload->nKey);
         pCur->eState = CURSOR_VALID;
@@ -4022,14 +3578,14 @@ static int prollyBtCursorInsert(
         }
         pCur->cachedPayloadOwned = 1;
       } else {
-        /* Non-SAVEPOSITION or BLOBKEY: cursor is not positioned */
+        
         pCur->eState = CURSOR_INVALID;
       }
       return SQLITE_OK;
     }
   }
 
-  /* Master table (pgnoRoot==1) and ephemeral tables: flush immediately */
+  
   rc = flushMutMap(pCur);
   if( rc!=SQLITE_OK ) return rc;
   {
@@ -4061,17 +3617,13 @@ static int prollyBtCursorInsert(
   return rc;
 }
 
-/*
-** Flush pending mutations for a cursor's table if needed.
-** Called before any read operation that needs consistent tree data.
-*/
 static int flushIfNeeded(BtCursor *pCur){
   int rc;
   struct TableEntry *pTE;
   int anyFlushed = 0;
   int needFlush = 0;
 
-  /* Check if any flush is needed before doing the expensive saveAllCursors */
+  
   if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
     needFlush = 1;
   }
@@ -4087,9 +3639,7 @@ static int flushIfNeeded(BtCursor *pCur){
   }
   if( !needFlush ) return SQLITE_OK;
 
-  /* Save or invalidate ALL other cursors on this table before rebuilding
-  ** the tree. Tree rebuild creates new nodes, invalidating any cursor's
-  ** cached prolly node pointers. */
+  
   {
     BtCursor *p;
     for(p = pCur->pBt->pCursor; p; p = p->pNext){
@@ -4102,21 +3652,21 @@ static int flushIfNeeded(BtCursor *pCur){
           if( rc!=SQLITE_OK ) return rc;
         } else if( p->eState!=CURSOR_REQUIRESEEK
                 && p->eState!=CURSOR_INVALID ){
-          /* Release any stale prolly node references */
+          
           prollyCursorReleaseAll(&p->pCur);
         }
       }
     }
   }
 
-  /* Flush THIS cursor's pending mutations */
+  
   if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
     rc = flushMutMap(pCur);
     if( rc!=SQLITE_OK ) return rc;
     anyFlushed = 1;
   }
 
-  /* Also flush any OTHER cursor on the same table with pending mutations */
+  
   {
     BtCursor *p;
     for(p = pCur->pBt->pCursor; p; p = p->pNext){
@@ -4131,7 +3681,7 @@ static int flushIfNeeded(BtCursor *pCur){
   }
 
   if( anyFlushed ){
-    /* Reinitialize this cursor on the updated tree root */
+    
     pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
     if( pTE ){
       prollyCursorClose(&pCur->pCur);
@@ -4143,15 +3693,11 @@ static int flushIfNeeded(BtCursor *pCur){
   return SQLITE_OK;
 }
 
-/*
-** Flush ALL cursors' pending mutations on a given table.
-** Called before reads or when we need consistent data.
-*/
 static int flushAllPending(BtShared *pBt, Pgno iTable){
   BtCursor *p;
   int rc;
 
-  /* Flush cursor-level MutMaps */
+  
   for(p = pBt->pCursor; p; p = p->pNext){
     if( iTable==0 || p->pgnoRoot==iTable ){
       rc = flushIfNeeded(p);
@@ -4159,16 +3705,13 @@ static int flushAllPending(BtShared *pBt, Pgno iTable){
     }
   }
 
-  /* Also flush table-level deferred edits so data persists to disk.
-  ** This is called by both BtreeCommitPhaseTwo (SQLite autocommit)
-  ** and FlushAndSerializeCatalog (dolt functions). */
+  
   rc = flushDeferredEdits(pBt);
   if( rc!=SQLITE_OK ) return rc;
 
   return SQLITE_OK;
 }
 
-/* Flush table-level deferred edits. Called from FlushAndSerializeCatalog. */
 static int flushDeferredEdits(BtShared *pBt){
   int rc = SQLITE_OK;
   if( pBt->db && pBt->db->nDb>0 && pBt->db->aDb[0].pBt ){
@@ -4198,11 +3741,6 @@ static int flushDeferredEdits(BtShared *pBt){
   return rc;
 }
 
-/*
-** Handle the immediate-flush path for BtreeDelete: flush the MutMap to
-** produce a new tree root, reinitialize the cursor, and optionally
-** re-seek for BTREE_SAVEPOSITION.
-*/
 static int btreeDeleteImmediate(BtCursor *pCur, const u8 *pKey, int nKey, i64 iKey){
   int rc;
   (void)pKey;
@@ -4245,11 +3783,7 @@ static int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
   assert( pCur->pBtree->inTrans==TRANS_WRITE );
   assert( pCur->curFlags & BTCF_WriteFlag );
 
-  /* Restore or validate cursor position.  CURSOR_REQUIRESEEK means the
-  ** position was saved and must be re-established.  CURSOR_SKIPNEXT means
-  ** a deferred delete just happened and the cursor is still positioned.
-  ** CURSOR_INVALID is allowed when the delete key is provided by the
-  ** caller (OP_IdxDelete) — no cursor position needed. */
+  
   if( pCur->eState==CURSOR_REQUIRESEEK ){
     rc = restoreCursorPosition(pCur, 0);
     if( rc!=SQLITE_OK || pCur->eState!=CURSOR_VALID ) return rc;
@@ -4257,9 +3791,7 @@ static int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
     pCur->eState = CURSOR_VALID;
     pCur->skipNext = 0;
   }else if( pCur->eState==CURSOR_INVALID ){
-    /* Allow INVALID for index deletes where the key comes from registers,
-    ** not from cursor position (OP_IdxDelete). The MutMap delete below
-    ** uses the extracted key, not the cursor position. */
+    
   }else if( pCur->eState!=CURSOR_VALID ){
     return SQLITE_CORRUPT_BKPT;
   }
@@ -4273,9 +3805,7 @@ static int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
   rc = ensureMutMap(pCur);
   if( rc!=SQLITE_OK ) return rc;
 
-  /* Extract key and record the MutMap deletion.
-  ** In merge mode, the current entry may come from MutMap (not the tree
-  ** cursor), so read the key from the correct source. */
+  
   if( pCur->curIntKey ){
     if( pCur->mmActive
      && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
@@ -4293,7 +3823,7 @@ static int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
 
     if( pCur->mmActive
      && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
-      /* Key is the sort key from the MutMap entry */
+      
       ProllyMutMapEntry *e = &pCur->pMutMap->aEntries[pCur->mmIdx];
       pKey = e->pKey;
       nKey = e->nKey;
@@ -4312,17 +3842,14 @@ static int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
 
   if( rc!=SQLITE_OK ) return rc;
 
-  /* Dispatch to deferred or immediate path — must match BtreeInsert's
-  ** canDefer logic so INSERT and DELETE use the same deferral strategy. */
+  
   {
     int canDefer = (pCur->pgnoRoot > 1);
     if( canDefer ){
       CLEAR_CACHED_PAYLOAD(pCur);
       pCur->curFlags &= ~(BTCF_ValidNKey|BTCF_AtLast);
       if( flags & BTREE_SAVEPOSITION ){
-        /* Cursor is still positioned at the deleted entry in the tree
-        ** (deletion is deferred in MutMap). CURSOR_SKIPNEXT with
-        ** skipNext=0 causes the next BtreeNext to advance normally. */
+        
         pCur->eState = CURSOR_SKIPNEXT;
         pCur->skipNext = 0;
       } else {
@@ -4332,7 +3859,7 @@ static int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
     }
   }
 
-  /* Immediate flush path */
+  
   rc = btreeDeleteImmediate(pCur, pKey, nKey, iKey);
   if( rc!=SQLITE_OK ) return rc;
 
@@ -4341,7 +3868,7 @@ static int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
     if( pCur->curIntKey ){
       rc = prollyCursorSeekInt(&pCur->pCur, iKey, &res);
     } else if( pKey && nKey > 0 ){
-      /* Re-seek with the saved blob key */
+      
       u8 *pReseek = sqlite3_malloc(nKey);
       if( pReseek ){
         memcpy(pReseek, pKey, nKey);
@@ -4371,10 +3898,6 @@ int sqlite3BtreeDelete(BtCursor *pCur, u8 flags){
   return pCur->pCurOps->xDelete(pCur, flags);
 }
 
-/* --------------------------------------------------------------------------
-** TransferRow
-** -------------------------------------------------------------------------- */
-
 static int prollyBtCursorTransferRow(BtCursor *pDest, BtCursor *pSrc, i64 iKey){
   int rc;
   const u8 *pVal;
@@ -4402,10 +3925,6 @@ static int prollyBtCursorTransferRow(BtCursor *pDest, BtCursor *pSrc, i64 iKey){
   rc = sqlite3BtreeInsert(pDest, &payload, 0, 0);
   return rc;
 }
-
-/* --------------------------------------------------------------------------
-** Shared cache (no-ops)
-** -------------------------------------------------------------------------- */
 
 #ifndef SQLITE_OMIT_SHARED_CACHE
 static void prollyBtreeEnter(Btree *p){
@@ -4448,14 +3967,9 @@ int sqlite3SchemaMutexHeld(sqlite3 *db, int iDb, Schema *pSchema){
 }
 #endif
 #elif !defined(SQLITE_OMIT_SHARED_CACHE)
-/* Non-threadsafe build: provide a no-op so the vtable always has a valid
-** function pointer matching prollyBtreeEnter above. */
+
 static void prollyBtreeLeave(Btree *p){ (void)p; }
 #endif
-
-/* --------------------------------------------------------------------------
-** TripAllCursors
-** -------------------------------------------------------------------------- */
 
 int sqlite3BtreeTripAllCursors(Btree *p, int errCode, int writeOnly){
   BtCursor *pCur;
@@ -4483,10 +3997,6 @@ int sqlite3BtreeTransferRow(BtCursor *pDest, BtCursor *pSrc, i64 iKey){
   return pDest->pCurOps->xTransferRow(pDest, pSrc, iKey);
 }
 
-/* --------------------------------------------------------------------------
-** ClearCursor / ClearCache
-** -------------------------------------------------------------------------- */
-
 static void prollyBtCursorClearCursor(BtCursor *pCur){
   if( pCur->pKey ){
     sqlite3_free(pCur->pKey);
@@ -4506,10 +4016,6 @@ void sqlite3BtreeClearCache(Btree *p){
   (void)p;
 }
 
-/* --------------------------------------------------------------------------
-** Pager
-** -------------------------------------------------------------------------- */
-
 static struct Pager *prollyBtreePager(Btree *p){
   return (struct Pager*)(p->pBt->pPagerShim);
 }
@@ -4518,13 +4024,9 @@ struct Pager *sqlite3BtreePager(Btree *p){
   return p->pOps->xPager(p);
 }
 
-/* --------------------------------------------------------------------------
-** Count / RowCountEst
-** -------------------------------------------------------------------------- */
-
 static int prollyBtCursorCount(sqlite3 *db, BtCursor *pCur, i64 *pnEntry){
   (void)db;
-  /* Flush any deferred edits so the count reflects pending inserts/deletes */
+  
   flushTablePending(pCur);
   flushIfNeeded(pCur);
   return countTreeEntries(pCur->pBtree, pCur->pgnoRoot, pnEntry);
@@ -4540,16 +4042,12 @@ static i64 prollyBtCursorRowCountEst(BtCursor *pCur){
   if( !pTE || prollyHashIsEmpty(&pTE->root) ){
     return 0;
   }
-  /* Default estimate for the query planner */
+  
   return 1000000;
 }
 i64 sqlite3BtreeRowCountEst(BtCursor *pCur){
   return pCur->pCurOps->xRowCountEst(pCur);
 }
-
-/* --------------------------------------------------------------------------
-** SetVersion / HeaderSize
-** -------------------------------------------------------------------------- */
 
 int sqlite3BtreeSetVersion(Btree *p, int iVersion){
   if( p->inTrans!=TRANS_WRITE ){
@@ -4564,10 +4062,6 @@ int sqlite3BtreeSetVersion(Btree *p, int iVersion){
 int sqlite3HeaderSizeBtree(void){
   return 100;
 }
-
-/* --------------------------------------------------------------------------
-** IntegrityCheck
-** -------------------------------------------------------------------------- */
 
 int sqlite3BtreeIntegrityCheck(
   sqlite3 *db,
@@ -4595,7 +4089,7 @@ int sqlite3BtreeIntegrityCheck(
   pBt = p->pBt;
 
   for(i=0; i<nRoot; i++){
-    /* Set row count to 0 for each table (we don't count precisely) */
+    
     if( aCnt ){
       sqlite3VdbeMemSetInt64(&aCnt[i], 0);
     }
@@ -4617,10 +4111,6 @@ int sqlite3BtreeIntegrityCheck(
   return SQLITE_OK;
 }
 
-/* --------------------------------------------------------------------------
-** CursorPin / CursorUnpin
-** -------------------------------------------------------------------------- */
-
 static void prollyBtCursorCursorPin(BtCursor *pCur){
   pCur->isPinned = 1;
   pCur->curFlags |= BTCF_Pinned;
@@ -4638,10 +4128,6 @@ void sqlite3BtreeCursorUnpin(BtCursor *pCur){
   if( !pCur ) return;
   pCur->pCurOps->xCursorUnpin(pCur);
 }
-
-/* --------------------------------------------------------------------------
-** CursorHintFlags / CursorHasHint
-** -------------------------------------------------------------------------- */
 
 static void prollyBtCursorCursorHintFlags(BtCursor *pCur, unsigned x){
   pCur->hints = (u8)(x & 0xFF);
@@ -4663,10 +4149,6 @@ int sqlite3BtreeCursorHasHint(BtCursor *pCur, unsigned int mask){
   return pCur->pCurOps->xCursorHasHint(pCur, mask);
 }
 
-/* --------------------------------------------------------------------------
-** FakeValidCursor
-** -------------------------------------------------------------------------- */
-
 BtCursor *sqlite3BtreeFakeValidCursor(void){
   static BtCursor fakeCursor;
   static int initialized = 0;
@@ -4677,10 +4159,6 @@ BtCursor *sqlite3BtreeFakeValidCursor(void){
   }
   return &fakeCursor;
 }
-
-/* --------------------------------------------------------------------------
-** CopyFile
-** -------------------------------------------------------------------------- */
 
 int sqlite3BtreeCopyFile(Btree *pTo, Btree *pFrom){
   BtShared *pBtTo = pTo->pBt;
@@ -4714,17 +4192,9 @@ int sqlite3BtreeCopyFile(Btree *pTo, Btree *pFrom){
   return SQLITE_OK;
 }
 
-/* --------------------------------------------------------------------------
-** IsInBackup
-** -------------------------------------------------------------------------- */
-
 int sqlite3BtreeIsInBackup(Btree *p){
   return p->nBackup > 0;
 }
-
-/* --------------------------------------------------------------------------
-** Checkpoint (WAL compat no-op)
-** -------------------------------------------------------------------------- */
 
 #ifndef SQLITE_OMIT_WAL
 int sqlite3BtreeCheckpoint(Btree *p, int eMode, int *pnLog, int *pnCkpt){
@@ -4734,10 +4204,6 @@ int sqlite3BtreeCheckpoint(Btree *p, int eMode, int *pnLog, int *pnCkpt){
   return SQLITE_OK;
 }
 #endif
-
-/* --------------------------------------------------------------------------
-** Incremental blob
-** -------------------------------------------------------------------------- */
 
 #ifndef SQLITE_OMIT_INCRBLOB
 
@@ -4820,11 +4286,7 @@ void sqlite3BtreeIncrblobCursor(BtCursor *pCur){
   pCur->pCurOps->xIncrblobCursor(pCur);
 }
 
-#endif /* SQLITE_OMIT_INCRBLOB */
-
-/* --------------------------------------------------------------------------
-** Debug / Test
-** -------------------------------------------------------------------------- */
+#endif 
 
 #ifndef NDEBUG
 static int prollyBtCursorCursorIsValid(BtCursor *pCur){
@@ -4902,12 +4364,8 @@ void sqlite3BtreeCursorList(Btree *p){
   (void)p;
 #endif
 }
-#endif /* SQLITE_TEST */
+#endif 
 
-/*
-** Register doltite_engine() SQL function for runtime engine detection.
-**   SELECT doltite_engine();  -->  'prolly'
-*/
 static void doltiteEngineFunc(
   sqlite3_context *context,
   int argc,
@@ -4917,10 +4375,6 @@ static void doltiteEngineFunc(
   sqlite3_result_text(context, "prolly", -1, SQLITE_STATIC);
 }
 
-/*
-** Get the ChunkStore for a database connection.
-** Used by doltlite_commit.c and doltlite_log.c.
-*/
 ChunkStore *doltliteGetChunkStore(sqlite3 *db){
   if( db && db->nDb>0 && db->aDb[0].pBt ){
     Btree *pBt = db->aDb[0].pBt;
@@ -4929,10 +4383,6 @@ ChunkStore *doltliteGetChunkStore(sqlite3 *db){
   return 0;
 }
 
-/*
-** Get the BtShared for a database connection.
-** Used by doltlite_commit.c for flushing and catalog serialization.
-*/
 BtShared *doltliteGetBtShared(sqlite3 *db){
   if( db && db->nDb>0 && db->aDb[0].pBt ){
     return db->aDb[0].pBt->pBt;
@@ -4946,15 +4396,6 @@ ProllyCache *doltliteGetCache(sqlite3 *db){
   return 0;
 }
 
-/*
-** Flush all pending mutations and serialize catalog.
-** Called by dolt_commit before snapshotting state.
-*/
-/*
-** Update a single table's schema hash. Called from doltlite.c which
-** retrieves the CREATE TABLE SQL from sqlite_master (using high-level
-** SQL APIs that are appropriate at the doltlite layer, not here).
-*/
 void doltliteSetTableSchemaHash(sqlite3 *db, Pgno iTable, const ProllyHash *pH){
   Btree *pBtree;
   int i;
@@ -4968,11 +4409,6 @@ void doltliteSetTableSchemaHash(sqlite3 *db, Pgno iTable, const ProllyHash *pH){
   }
 }
 
-/*
-** Iterate table names for schema hash updates. Returns table name
-** and iTable for each user table (iTable > 1). Returns NULL when done.
-** *pIdx should be initialized to 0 before the first call.
-*/
 const char *doltliteNextTableForSchema(sqlite3 *db, int *pIdx, Pgno *piTable){
   Btree *pBtree;
   if( !db || db->nDb<=0 || !db->aDb[0].pBt ) return 0;
@@ -4996,10 +4432,10 @@ int doltliteFlushAndSerializeCatalog(sqlite3 *db, u8 **ppOut, int *pnOut){
   pBtree = db->aDb[0].pBt;
   rc = flushAllPending(pBt, 0);
   if( rc!=SQLITE_OK ) return rc;
-  /* Flush table-level deferred edits (pPending from closed cursors) */
+  
   rc = flushDeferredEdits(pBt);
   if( rc!=SQLITE_OK ) return rc;
-  /* Update schema hashes — delegated to doltlite layer which can use SQL APIs */
+  
   {
     extern void doltliteUpdateSchemaHashes(sqlite3 *db);
     doltliteUpdateSchemaHashes(db);
@@ -5007,10 +4443,6 @@ int doltliteFlushAndSerializeCatalog(sqlite3 *db, u8 **ppOut, int *pnOut){
   return serializeCatalog(pBtree, ppOut, pnOut);
 }
 
-/*
-** Load a catalog snapshot from a catalog hash.
-** Returns an array of TableEntry and count. Caller must sqlite3_free(*ppTables).
-*/
 int doltliteLoadCatalog(sqlite3 *db, const ProllyHash *catHash,
                         struct TableEntry **ppTables, int *pnTables,
                         Pgno *piNextTable){
@@ -5042,9 +4474,6 @@ int doltliteLoadCatalog(sqlite3 *db, const ProllyHash *catHash,
   return SQLITE_OK;
 }
 
-/*
-** Get the HEAD commit's catalog hash.
-*/
 int doltliteGetHeadCatalogHash(sqlite3 *db, ProllyHash *pCatHash){
   ChunkStore *cs = doltliteGetChunkStore(db);
   ProllyHash headHash;
@@ -5054,7 +4483,7 @@ int doltliteGetHeadCatalogHash(sqlite3 *db, ProllyHash *pCatHash){
   DoltliteCommit commit;
 
   if( !cs ) return SQLITE_ERROR;
-  /* Use session HEAD, not shared store */
+  
   doltliteGetSessionHead(db, &headHash);
   if( prollyHashIsEmpty(&headHash) ){
     memset(pCatHash, 0, sizeof(ProllyHash));
@@ -5073,12 +4502,6 @@ int doltliteGetHeadCatalogHash(sqlite3 *db, ProllyHash *pCatHash){
   return SQLITE_OK;
 }
 
-/*
-** Resolve a table name to its rootpage (iTable number).
-** Scans the in-memory schema hash table directly, avoiding
-** sqlite3_prepare_v2 (which is a layering violation from the btree layer
-** and can cause stack overflow when called during BtreeCommitPhaseTwo).
-*/
 int doltliteResolveTableName(sqlite3 *db, const char *zTable, Pgno *piTable){
   Schema *pSchema;
   HashElem *k;
@@ -5095,13 +4518,6 @@ int doltliteResolveTableName(sqlite3 *db, const char *zTable, Pgno *piTable){
   return SQLITE_ERROR;
 }
 
-/*
-** Resolve a rootpage (iTable) to its table name by scanning the in-memory
-** schema hash table directly. This avoids calling sqlite3_prepare_v2 which
-** would trigger the full SQL parser and query planner, causing stack overflow
-** when called from serializeCatalog during BtreeCommitPhaseTwo.
-** Returns sqlite3_malloc'd string. Caller must sqlite3_free.
-*/
 char *doltliteResolveTableNumber(sqlite3 *db, Pgno iTable){
   Schema *pSchema;
   HashElem *k;
@@ -5117,11 +4533,6 @@ char *doltliteResolveTableNumber(sqlite3 *db, Pgno iTable){
   return 0;
 }
 
-/*
-** Hard reset: reload a catalog into the live BtShared table registry.
-** This replaces the working state with the given catalog's state.
-** Also invalidates all cursors and clears the schema cache.
-*/
 int doltliteHardReset(sqlite3 *db, const ProllyHash *catHash){
   BtShared *pBt = doltliteGetBtShared(db);
   Btree *pBtree;
@@ -5140,10 +4551,10 @@ int doltliteHardReset(sqlite3 *db, const ProllyHash *catHash){
   rc = chunkStoreGet(cs, catHash, &data, &nData);
   if( rc!=SQLITE_OK ) return rc;
 
-  /* Invalidate all cursors first */
+  
   invalidateCursors(pBt, 0, SQLITE_ABORT);
 
-  /* Replace table registry */
+  
   sqlite3_free(pBtree->aTables);
   pBtree->aTables = 0;
   pBtree->nTables = 0;
@@ -5153,35 +4564,29 @@ int doltliteHardReset(sqlite3 *db, const ProllyHash *catHash){
   sqlite3_free(data);
   if( rc!=SQLITE_OK ) return rc;
 
-  /* Bump the schema version so SQLite detects the change and re-reads
-  ** sqlite_master on the next statement. Also bump data version. */
+  
   pBtree->aMeta[BTREE_SCHEMA_VERSION]++;
   pBtree->iBDataVersion++;
   if( pBt->pPagerShim ){
     pBt->pPagerShim->iDataVersion++;
   }
 
-  /* Use SQLite's proper schema reset to clear all cached schema objects.
-  ** This ensures db->aDb[0].pSchema is properly cleaned up, not just
-  ** the Btree's copy. */
+  
   if( pBtree->db ){
     sqlite3ResetAllSchemasOfConnection(pBtree->db);
   }else{
     invalidateSchema(pBtree);
   }
 
-  /* Hard reset: staged = target catalog (merge state is caller's responsibility) */
+  
   memcpy(&pBtree->stagedCatalog, catHash, sizeof(ProllyHash));
 
-  /* Persist the new working state */
+  
   chunkStoreSetCatalog(cs, catHash);
   rc = chunkStoreCommit(cs);
   return rc;
 }
 
-/*
-** Per-session branch accessors for dolt functions.
-*/
 const char *doltliteGetSessionBranch(sqlite3 *db){
   if( db && db->nDb>0 && db->aDb[0].pBt ){
     Btree *p = db->aDb[0].pBt;
@@ -5258,7 +4663,6 @@ void doltliteSetSessionStaged(sqlite3 *db, const ProllyHash *pStaged){
   }
 }
 
-/* Per-session merge state accessors */
 void doltliteGetSessionMergeState(sqlite3 *db, u8 *pIsMerging,
                                    ProllyHash *pMergeCommit,
                                    ProllyHash *pConflictsCatalog){
@@ -5301,10 +4705,6 @@ void doltliteSetSessionConflictsCatalog(sqlite3 *db, const ProllyHash *pHash){
   }
 }
 
-/*
-** Save session working state to a per-branch WorkingSet chunk.
-** Format: version(1) + staged(20) + isMerging(1) + mergeCommit(20) + conflicts(20)
-*/
 int doltliteSaveWorkingSet(sqlite3 *db){
   ChunkStore *cs = doltliteGetChunkStore(db);
   Btree *pBtree;
@@ -5319,7 +4719,7 @@ int doltliteSaveWorkingSet(sqlite3 *db){
 
   zBranch = pBtree->zBranch ? pBtree->zBranch : "main";
 
-  buf[0] = 1;  /* WorkingSet version */
+  buf[0] = 1;  
   memcpy(buf + WS_STAGED_OFF, pBtree->stagedCatalog.data, PROLLY_HASH_SIZE);
   buf[WS_MERGING_OFF] = pBtree->isMerging;
   memcpy(buf + WS_MERGE_COMMIT_OFF, pBtree->mergeCommitHash.data, PROLLY_HASH_SIZE);
@@ -5328,13 +4728,10 @@ int doltliteSaveWorkingSet(sqlite3 *db){
   rc = chunkStorePut(cs, buf, WS_TOTAL_SIZE, &wsHash);
   if( rc != SQLITE_OK ) return rc;
 
-  /* Store the WorkingSet hash in the branch ref */
+  
   return chunkStoreSetBranchWorkingSet(cs, zBranch, &wsHash);
 }
 
-/*
-** Load a branch's WorkingSet into the session state.
-*/
 int doltliteLoadWorkingSet(sqlite3 *db, const char *zBranch){
   ChunkStore *cs = doltliteGetChunkStore(db);
   Btree *pBtree;
@@ -5349,7 +4746,7 @@ int doltliteLoadWorkingSet(sqlite3 *db, const char *zBranch){
 
   rc = chunkStoreGetBranchWorkingSet(cs, zBranch, &wsHash);
   if( rc != SQLITE_OK || prollyHashIsEmpty(&wsHash) ){
-    /* No saved WorkingSet — clear to defaults */
+    
     memset(&pBtree->stagedCatalog, 0, sizeof(ProllyHash));
     pBtree->isMerging = 0;
     memset(&pBtree->mergeCommitHash, 0, sizeof(ProllyHash));
@@ -5376,17 +4773,10 @@ int doltliteLoadWorkingSet(sqlite3 *db, const char *zBranch){
   return SQLITE_OK;
 }
 
-/* --------------------------------------------------------------------------
-** origBtreeXxxVt wrapper implementations.
-**
-** Each wrapper extracts p->pOrigBtree and calls the corresponding
-** origBtreeXxx() function from btree_orig_api.h.
-** -------------------------------------------------------------------------- */
-
 static int origBtreeCloseVt(Btree *p){
   int rc = origBtreeClose(p->pOrigBtree);
   p->pOrigBtree = 0;
-  /* Free the Btree shell itself */
+  
   if( p->pSchema && p->xFreeSchema ) p->xFreeSchema(p->pSchema);
   sqlite3_free(p);
   return rc;
@@ -5521,12 +4911,6 @@ static int origBtreeClosesWithCursorVt(Btree *p, BtCursor *pCur){
 }
 #endif
 
-/* --------------------------------------------------------------------------
-** BtCursorOps origCursorVtOps wrappers.
-**
-** Each wrapper extracts pCur->pOrigCursor and calls the corresponding
-** origBtreeXxx() function from btree_orig_api.h.
-** -------------------------------------------------------------------------- */
 static int origCursorClearTableOfCursorVt(BtCursor *pCur){
   return origBtreeClearTableOfCursor(pCur->pOrigCursor);
 }
@@ -5596,7 +4980,7 @@ static int origCursorTransferRowVt(BtCursor *pDest, BtCursor *pSrc, i64 iKey){
 }
 static void origCursorClearCursorVt(BtCursor *pCur){
   (void)pCur;
-  /* orig cursors: no-op, original ClearCursor had early return */
+  
 }
 static int origCursorCountVt(sqlite3 *db, BtCursor *pCur, i64 *pnEntry){
   return origBtreeCount(db, pCur->pOrigCursor, pnEntry);
@@ -5613,7 +4997,7 @@ static void origCursorCursorUnpinVt(BtCursor *pCur){
 }
 static void origCursorCursorHintFlagsVt(BtCursor *pCur, unsigned x){
   (void)pCur; (void)x;
-  /* orig cursors: no-op, original had early return */
+  
 }
 static int origCursorCursorHasHintVt(BtCursor *pCur, unsigned int mask){
   (void)pCur; (void)mask;
@@ -5629,7 +5013,7 @@ static int origCursorPutDataVt(BtCursor *pCur, u32 offset, u32 amt, void *pBuf){
 }
 static void origCursorIncrblobCursorVt(BtCursor *pCur){
   (void)pCur;
-  /* orig cursors: no-op, original had early return */
+  
 }
 #endif
 #ifndef NDEBUG
@@ -5643,7 +5027,6 @@ static int origCursorCursorIsValidNNVt(BtCursor *pCur){
   return 1;
 }
 
-/* External registration for all dolt features */
 extern void doltliteRegister(sqlite3 *db);
 
 static void registerDoltiteFunctions(sqlite3 *db){
@@ -5652,4 +5035,4 @@ static void registerDoltiteFunctions(sqlite3 *db){
   doltliteRegister(db);
 }
 
-#endif /* DOLTLITE_PROLLY */
+#endif 

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -96,30 +96,36 @@ struct BtLock {
 
 static const ProllyHash emptyHash = {{0}};
 
+/* Maps a SQLite table number (Pgno) to its prolly tree root hash.
+** pPending holds deferred MutMap edits not yet flushed to the tree.
+** MUST be flushed before any cursor reads, or the cursor sees stale data. */
 struct TableEntry {
-  Pgno iTable;           
-  ProllyHash root;       
-  ProllyHash schemaHash; 
-  u8 flags;              
-  char *zName;           
-  ProllyMutMap *pPending; 
+  Pgno iTable;
+  ProllyHash root;
+  ProllyHash schemaHash;
+  u8 flags;
+  char *zName;
+  ProllyMutMap *pPending;
 };
 
+/* Shared backend: owns the content-addressed chunk store and node cache.
+** pPagerShim exists solely to satisfy SQLite's pager-level queries (e.g.,
+** iDataVersion for schema change detection) -- no actual paging occurs. */
 struct BtShared {
-  ChunkStore store;          
-  ProllyCache cache;         
-
-  
+  ChunkStore store;
+  ProllyCache cache;
   PagerShim *pPagerShim;
-
-  sqlite3 *db;              
-  BtCursor *pCursor;        
-  u8 openFlags;             
-  u16 btsFlags;             
-  u32 pageSize;             
-  int nRef;                 
+  sqlite3 *db;
+  BtCursor *pCursor;         /* Linked list of all open cursors */
+  u8 openFlags;
+  u16 btsFlags;
+  u32 pageSize;
+  int nRef;
 };
 
+/* Vtable that dispatches every SQLite Btree API call to either the prolly
+** tree implementation or the original SQLite b-tree (for non-DoltLite files
+** like temp databases). This is how a single binary supports both engines. */
 struct BtreeOps {
   int (*xClose)(Btree*);
   int (*xNewDb)(Btree*);
@@ -205,111 +211,116 @@ struct BtCursorOps {
   int (*xCursorIsValidNN)(BtCursor*);
 };
 
+/* Per-connection Btree handle implementing the SQLite Btree interface.
+** 'root' / 'committedRoot': current vs transaction-start prolly root hashes.
+** 'aTables': sorted catalog mapping table numbers to prolly tree roots.
+** 'aSavepoint' + 'aSavepointTables': savepoint stack for ROLLBACK TO.
+** 'aCommittedTables': catalog snapshot at BEGIN for full transaction rollback.
+** 'pOps': dispatches to prolly or original SQLite btree implementation. */
 struct Btree {
-  sqlite3 *db;              
-  BtShared *pBt;            
-  u8 inTrans;               
-  u8 sharable;              
-  int wantToLock;            
-  int nBackup;               
-  u32 iBDataVersion;         
-  Btree *pNext;              
+  sqlite3 *db;
+  BtShared *pBt;
+  u8 inTrans;
+  u8 sharable;
+  int wantToLock;
+  int nBackup;
+  u32 iBDataVersion;
+  Btree *pNext;
   Btree *pPrev;
-  BtLock lock;               
-  u64 nSeek;                 
+  BtLock lock;
+  u64 nSeek;
 
-  
-  ProllyHash root;           
-  ProllyHash committedRoot;  
+  ProllyHash root;           /* Current (in-flight) prolly tree root */
+  ProllyHash committedRoot;  /* Root at last commit -- restored on rollback */
 
-  
-  struct TableEntry *aTables;
-  int nTables;               
-  int nTablesAlloc;          
-  Pgno iNextTable;           
+  struct TableEntry *aTables; /* Sorted by iTable for binary search */
+  int nTables;
+  int nTablesAlloc;
+  Pgno iNextTable;           /* Monotonically increasing table number allocator */
 
-  
   u32 aMeta[16];
 
-  
-  void *pSchema;             
-  void (*xFreeSchema)(void*); 
+  void *pSchema;
+  void (*xFreeSchema)(void*);
 
-  u8 inTransaction;         
+  u8 inTransaction;
 
-  
-  ProllyHash *aSavepoint;   
-  int nSavepoint;            
-  int nSavepointAlloc;       
+  /* Savepoint stack: aSavepoint[i] = prolly root hash at savepoint i,
+  ** aSavepointTables[i] = snapshot of aTables + pending edit counts.
+  ** On rollback, roots are restored and MutMap entries truncated. */
+  ProllyHash *aSavepoint;
+  int nSavepoint;
+  int nSavepointAlloc;
 
   struct SavepointTableState {
     struct TableEntry *aTables;
-    int *aPendingCount;    
+    int *aPendingCount;     /* MutMap nEntries per table at savepoint time */
     int nTables;
     Pgno iNextTable;
   } *aSavepointTables;
   int nSavepointTablesAlloc;
 
-  
+  /* Snapshot of aTables at BEGIN WRITE -- for full transaction rollback */
   struct TableEntry *aCommittedTables;
   int nCommittedTables;
   Pgno iCommittedNextTable;
 
-  
-  char *zBranch;             
-  char *zAuthorName;         
-  char *zAuthorEmail;        
-  ProllyHash headCommit;     
-  ProllyHash stagedCatalog;  
-  u8 isMerging;              
-  ProllyHash mergeCommitHash;     
-  ProllyHash conflictsCatalogHash; 
-  const struct BtreeOps *pOps;  
-  void *pOrigBtree;  
+  /* DoltLite versioning state */
+  char *zBranch;
+  char *zAuthorName;
+  char *zAuthorEmail;
+  ProllyHash headCommit;
+  ProllyHash stagedCatalog;
+  u8 isMerging;
+  ProllyHash mergeCommitHash;
+  ProllyHash conflictsCatalogHash;
+  const struct BtreeOps *pOps;
+  void *pOrigBtree;   /* Non-NULL only for original SQLite btree files */
 };
 
+/* Cursor that merges two sources: the immutable prolly tree (pCur) and an
+** in-memory edit buffer (pMutMap). When mmActive is true, Next/Prev
+** interleave both sources in key order (see mergeStepForward/Backward).
+** pCachedPayload caches the current row -- MUST be cleared via
+** CLEAR_CACHED_PAYLOAD on any cursor movement or caller sees stale data. */
 struct BtCursor {
-  u8 eState;                 
-  u8 curFlags;               
-  u8 curPagerFlags;          
-  u8 hints;                  
-  int skipNext;              
-  Btree *pBtree;             
-  BtShared *pBt;             
-  BtCursor *pNext;           
-  Pgno pgnoRoot;             
-  u8 curIntKey;              
-  struct KeyInfo *pKeyInfo;  
+  u8 eState;
+  u8 curFlags;
+  u8 curPagerFlags;
+  u8 hints;
+  int skipNext;
+  Btree *pBtree;
+  BtShared *pBt;
+  BtCursor *pNext;
+  Pgno pgnoRoot;
+  u8 curIntKey;
+  struct KeyInfo *pKeyInfo;
 
-  
-  ProllyCursor pCur;
+  ProllyCursor pCur;      /* Cursor into the immutable prolly tree */
+  ProllyMutMap *pMutMap;  /* In-memory edit buffer (inserts + deletes) */
 
-  
-  ProllyMutMap *pMutMap;
-
-  
   u8 *pCachedPayload;
   int nCachedPayload;
-  u8 cachedPayloadOwned;   
+  u8 cachedPayloadOwned;  /* 1 if pCachedPayload was malloc'd by us */
   i64 cachedIntKey;
 
-  
-  u8 isPinned;
+  u8 isPinned;            /* When pinned, saveCursorPosition is a no-op */
 
-  
-  int mmIdx;                 
-  u8 mmActive;               
+  /* Merge iteration state: mmIdx indexes into pMutMap->aEntries.
+  ** mergeSrc says where the current row comes from. */
+  int mmIdx;
+  u8 mmActive;
 #define MERGE_SRC_TREE  0
 #define MERGE_SRC_MUT   1
-#define MERGE_SRC_BOTH  2    
-  u8 mergeSrc;               
+#define MERGE_SRC_BOTH  2   /* Same key in tree and MutMap; MutMap wins */
+  u8 mergeSrc;
 
-  
-  i64 nKey;                  
-  void *pKey;                
-  u64 nSeek;                 
-  void *pOrigCursor; 
-  const struct BtCursorOps *pCurOps; 
+  /* Saved position for CURSOR_REQUIRESEEK restore */
+  i64 nKey;
+  void *pKey;
+  u64 nSeek;
+  void *pOrigCursor;
+  const struct BtCursorOps *pCurOps;
 };
 
 static struct TableEntry *findTable(Btree *pBtree, Pgno iTable);
@@ -964,6 +975,10 @@ static int flushMutMap(BtCursor *pCur){
   return SQLITE_OK;
 }
 
+/* SQLite may open implicit statement savepoints (nStatement) in addition to
+** explicit user savepoints (nSavepoint). Our savepoint stack must match
+** their combined count, or ROLLBACK TO will index out of bounds.
+** This is called before any write to ensure we're caught up. */
 static int syncSavepoints(BtCursor *pCur){
   Btree *pBtree = pCur->pBtree;
   sqlite3 *db = pBtree ? pBtree->db : 0;
@@ -1110,11 +1125,18 @@ static void freeSavepointTables(struct SavepointTableState *pState){
   }
 }
 
+/* Snapshot the current state so ROLLBACK TO can restore it.
+** Saves: (1) the current prolly root hash, (2) each table's root hash,
+** (3) the nEntries count of each table's pending MutMap.
+** On rollback, table roots are restored and MutMap entries are truncated
+** back to the saved count -- this works because MutMap is append-only.
+** IMPORTANT: all cursor MutMaps must be flushed first, because the
+** savepoint only records table-level root hashes and MutMap counts. */
 static int pushSavepoint(Btree *pBtree){
   struct SavepointTableState *pState;
   int rc;
 
-  
+  /* Flush all cursor edits before snapshotting */
   {
     BtCursor *p;
     for(p = pBtree->pBt->pCursor; p; p = p->pNext){
@@ -1240,7 +1262,8 @@ int sqlite3BtreeOpen(
 
   *ppBtree = 0;
 
-  
+  /* If the file has a standard SQLite header (e.g., temp databases),
+  ** delegate to the original btree implementation. Otherwise use prolly. */
   if( origBtreeIsSqliteFile(zFilename) ){
     p = sqlite3_malloc(sizeof(Btree));
     if( !p ) return SQLITE_NOMEM;
@@ -1483,6 +1506,13 @@ int sqlite3BtreeNewDb(Btree *p){
   return p->pOps->xNewDb(p);
 }
 
+/* No-op: prolly trees manage their own cache (ProllyCache), not SQLite's
+** page cache. SetCacheSize, SetSpillSize, SetMmapLimit, SetPagerFlags,
+** SecureDelete, AutoVacuum, IncrVacuum, LockTable, and SchemaLocked are
+** all no-ops because the underlying concepts (page cache tuning, WAL spill,
+** mmap, secure overwrite, vacuuming, shared-cache locks) don't apply to
+** content-addressed immutable trees. They must still return SQLITE_OK to
+** satisfy callers that expect success. */
 static int prollyBtreeSetCacheSize(Btree *p, int mxPage){
   (void)p; (void)mxPage;
   return SQLITE_OK;
@@ -1549,8 +1579,11 @@ Pgno sqlite3BtreeMaxPageCount(Btree *p, Pgno mxPage){
   return p->pOps->xMaxPageCount(p, mxPage);
 }
 
+/* Prolly trees have no pages, but SQLite queries this to determine if the
+** database is empty (LastPage==0 means empty). Return a synthetic value
+** larger than any table number to prevent SQLite from treating the db
+** as empty. The +1000 provides headroom for new tables within a txn. */
 static Pgno prollyBtreeLastPage(Btree *p){
-  
   return p->iNextTable + 1000;
 }
 Pgno sqlite3BtreeLastPage(Btree *p){
@@ -1773,7 +1806,9 @@ static int prollyBtreeBeginTrans(Btree *p, int wrFlag, int *pSchemaVersion){
     }
   }
 
-  
+  /* Pin the chunk store snapshot for the duration of this transaction.
+  ** This prevents garbage collection from reclaiming chunks that our
+  ** in-flight cursors reference. Unpinned at commit/rollback. */
   pBt->store.snapshotPinned = 1;
 
   return SQLITE_OK;
@@ -1783,6 +1818,9 @@ int sqlite3BtreeBeginTrans(Btree *p, int wrFlag, int *pSchemaVersion){
   return p->pOps->xBeginTrans(p, wrFlag, pSchemaVersion);
 }
 
+/* Phase one is a no-op for prolly trees. All work happens in phase two.
+** SQLite's two-phase commit exists for journal/WAL coordination, which
+** prolly trees don't use -- the chunk store commit is atomic. */
 static int prollyBtreeCommitPhaseOne(Btree *p, const char *zSuperJrnl){
   (void)p; (void)zSuperJrnl;
   return SQLITE_OK;
@@ -1792,16 +1830,25 @@ int sqlite3BtreeCommitPhaseOne(Btree *p, const char *zSuperJrnl){
   return p->pOps->xCommitPhaseOne(p, zSuperJrnl);
 }
 
+/* Commit protocol for prolly trees:
+**   1. Flush all pending MutMap edits into their respective prolly trees
+**      (this produces new immutable tree roots in the chunk store).
+**   2. Serialize the catalog (table-number-to-root-hash mapping) and store
+**      it as a content-addressed chunk.
+**   3. Update the manifest's catalog hash and root hash.
+**   4. Atomically commit the manifest to disk via chunkStoreCommit.
+** If any step fails, the on-disk state is unchanged (the manifest hasn't
+** been rewritten), so the old data is still valid on next open. */
 static int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
   BtShared *pBt = p->pBt;
   int rc = SQLITE_OK;
   (void)bCleanup;
 
   if( p->inTrans==TRANS_WRITE ){
-    
+    /* Step 1: flush all in-memory edits to prolly trees */
     rc = flushAllPending(pBt, 0);
     if( rc!=SQLITE_OK ) return rc;
-    
+    /* Steps 2-3: serialize catalog, store as chunk, update manifest */
     {
       u8 *catData = 0;
       int nCatData = 0;
@@ -1817,6 +1864,7 @@ static int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
       if( rc!=SQLITE_OK ) return rc;
     }
     chunkStoreSetRoot(&pBt->store, &p->root);
+    /* Step 4: atomic manifest write */
     rc = chunkStoreCommit(&pBt->store);
     if( rc==SQLITE_OK ){
       p->committedRoot = p->root;
@@ -1953,18 +2001,21 @@ static int prollyBtreeSavepoint(Btree *p, int op, int iSavepoint){
   }
 
   if( op==SAVEPOINT_ROLLBACK ){
+    /* Rollback: restore the prolly root and each table's root to the
+    ** values captured at pushSavepoint time. For MutMap entries, we
+    ** truncate back to the saved nEntries count (MutMap is append-only,
+    ** so entries after savedCount are exactly the post-savepoint writes).
+    ** Tables created after the savepoint are removed entirely. */
     if( iSavepoint>=0 && iSavepoint<p->nSavepoint
      && p->aSavepointTables ){
       struct SavepointTableState *pState = &p->aSavepointTables[iSavepoint];
       p->root = p->aSavepoint[iSavepoint];
-      
       if( pState->aTables ){
-        
+        /* Restore table roots and truncate MutMap entries */
         {
           int k;
           for(k=0; k<pState->nTables && k<p->nTables; k++){
             p->aTables[k].root = pState->aTables[k].root;
-            
             ProllyMutMap *pMap = (ProllyMutMap*)p->aTables[k].pPending;
             if( pMap ){
               int savedCount = pState->aPendingCount[k];
@@ -2081,6 +2132,8 @@ static int prollyBtreeDropTable(Btree *p, int iTable, int *piMoved){
     return SQLITE_ERROR;
   }
 
+  /* Table 1 (sqlite_master) cannot be removed from the catalog -- SQLite
+  ** expects it to always exist. Instead, clear its root to make it empty. */
   if( iTable==1 ){
     struct TableEntry *pTE = findTable(p, 1);
     if( pTE ){
@@ -2317,6 +2370,12 @@ int sqlite3BtreeCursor(
   return p->pOps->xCursor(p, iTable, wrFlag, pKeyInfo, pCur);
 }
 
+/* On cursor close, pending edits in the cursor's MutMap must not be lost.
+** They are handed off to the TableEntry's pPending field so a future cursor
+** or commit will flush them. If pPending already has edits (from another
+** closed cursor), the two MutMaps are merged. This is critical: without
+** this handoff, inserts made through a cursor that is closed before commit
+** would silently disappear. */
 static int prollyBtCursorCloseCursor(BtCursor *pCur){
   BtShared *pBt;
   BtCursor **pp;
@@ -2325,7 +2384,6 @@ static int prollyBtCursorCloseCursor(BtCursor *pCur){
   pBt = pCur->pBt;
   if( !pBt ) return SQLITE_OK;
 
-  
   if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
     struct TableEntry *pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
     if( pTE && !pTE->pPending ){
@@ -2423,6 +2481,14 @@ int sqlite3BtreeClosesWithCursor(Btree *p, BtCursor *pCur){
 }
 #endif
 
+/*
+** Merge iteration: the cursor presents a unified view of the immutable prolly
+** tree and the in-memory MutMap (pending inserts/deletes). Both sources are
+** sorted by key. mergeStepForward/Backward advance through both in sorted
+** order, skipping MutMap delete entries and preferring MutMap data when keys
+** match (MERGE_SRC_BOTH). This is conceptually a sorted merge-join where
+** deletes act as tombstones that suppress matching tree entries.
+*/
 static int mergeCompare(BtCursor *pCur, ProllyMutMapEntry *e){
   if( pCur->curIntKey ){
     i64 tk = prollyCursorIntKey(&pCur->pCur);
@@ -2475,12 +2541,14 @@ static int mergeStepForward(BtCursor *pCur){
       pCur->mergeSrc = MERGE_SRC_MUT;
       return SQLITE_OK;
     }else{
-      
+      /* Keys match. If MutMap says delete, advance BOTH sources to suppress
+      ** the tree entry, then loop to find the next visible row. */
       if( e->op==PROLLY_EDIT_DELETE ){
         pCur->mmIdx++;
         prollyCursorNext(&pCur->pCur);
         continue;
       }
+      /* Keys match and MutMap has an insert: MutMap value overrides tree */
       pCur->mergeSrc = MERGE_SRC_BOTH;
       return SQLITE_OK;
     }
@@ -3361,6 +3429,12 @@ i64 sqlite3BtreeIntegerKey(BtCursor *pCur){
   return pCur->pCurOps->xIntegerKey(pCur);
 }
 
+/* Returns the current row's payload. Priority order:
+** 1. Cached payload (set by TableMoveto/IndexMoveto from MutMap lookups)
+** 2. MutMap entry (when merge iteration sourced the row from MutMap)
+** 3. Prolly tree entry (the normal immutable tree path)
+** For index tables, the value may be empty (stored as sort key only),
+** in which case we reconstruct the original record via recordFromSortKey. */
 static void getCursorPayload(BtCursor *pCur, const u8 **ppData, int *pnData){
   
   if( pCur->pCachedPayload && pCur->nCachedPayload > 0 ){
@@ -3496,7 +3570,9 @@ static int prollyBtCursorInsert(
   int rc;
   (void)seekResult;
 
-  
+  /* BTREE_PREFORMAT is used by SQLite's bulk-insert optimization where data
+  ** is pre-formatted into page images. Prolly trees don't use pages, so
+  ** this is a no-op. The actual insert happens in a subsequent non-preformat call. */
   if( flags & BTREE_PREFORMAT ){
     return SQLITE_OK;
   }
@@ -3535,7 +3611,11 @@ static int prollyBtCursorInsert(
                              pData, nData);
     sqlite3_free(pBuf);
   } else {
-    
+    /* Index tables: the record is transformed into a sort key (a binary-
+    ** comparable encoding) and stored as the prolly tree KEY with an empty
+    ** value. The original record can be reconstructed from the sort key
+    ** via recordFromSortKey(). This allows prolly tree key comparison to
+    ** use simple memcmp instead of SQLite's complex record comparator. */
     u8 *pSortKey = 0;
     int nSortKey = 0;
     rc = sortKeyFromRecord((const u8*)pPayload->pKey,
@@ -3551,7 +3631,10 @@ static int prollyBtCursorInsert(
 
   if( rc!=SQLITE_OK ) return rc;
 
-  
+  /* Edits to user tables (pgnoRoot > 1) are deferred in the MutMap and
+  ** flushed lazily. Table 1 (sqlite_master) is flushed immediately because
+  ** SQLite reads it back within the same transaction to verify schema changes,
+  ** and the merge iteration path is not active for schema table reads. */
   {
     int canDefer = (pCur->pgnoRoot > 1);
     if( canDefer ){
@@ -4016,6 +4099,9 @@ void sqlite3BtreeClearCache(Btree *p){
   (void)p;
 }
 
+/* Returns a PagerShim cast to Pager*. SQLite reads iDataVersion from this
+** "pager" to detect schema changes. The shim has no real paging -- it only
+** exists to provide the data version counter that SQLite checks. */
 static struct Pager *prollyBtreePager(Btree *p){
   return (struct Pager*)(p->pBt->pPagerShim);
 }
@@ -4036,13 +4122,16 @@ int sqlite3BtreeCount(sqlite3 *db, BtCursor *pCur, i64 *pnEntry){
   return pCur->pCurOps->xCount(db, pCur, pnEntry);
 }
 
+/* Returns a rough row count estimate for the query planner. Prolly trees
+** don't track exact counts cheaply, so return 1M as a placeholder to
+** avoid the planner choosing bad plans for "empty" tables. TODO: store
+** actual row counts in the catalog for better query planning. */
 static i64 prollyBtCursorRowCountEst(BtCursor *pCur){
   struct TableEntry *pTE;
   pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
   if( !pTE || prollyHashIsEmpty(&pTE->root) ){
     return 0;
   }
-  
   return 1000000;
 }
 i64 sqlite3BtreeRowCountEst(BtCursor *pCur){

--- a/src/prolly_cache.c
+++ b/src/prolly_cache.c
@@ -1,27 +1,16 @@
-/*
-** Implementation of LRU node cache with reference counting for prolly tree
-** nodes. Uses open-chaining hash table keyed by content hash with a
-** doubly-linked LRU eviction list.
-*/
+
 #ifdef DOLTLITE_PROLLY
 
 #include "prolly_cache.h"
 #include <string.h>
 #include <assert.h>
 
-/*
-** Compute the hash bucket index for a ProllyHash. Takes the first 4 bytes
-** of the hash as a little-endian u32 and reduces modulo nBucket.
-*/
 static int cacheHashBucket(const ProllyCache *cache, const ProllyHash *hash){
   u32 h;
   memcpy(&h, hash->data, sizeof(u32));
   return (int)(h % (u32)cache->nBucket);
 }
 
-/*
-** Remove an entry from the LRU doubly-linked list. Does not free the entry.
-*/
 static void lruRemove(ProllyCacheEntry *pEntry){
   pEntry->pLruPrev->pLruNext = pEntry->pLruNext;
   pEntry->pLruNext->pLruPrev = pEntry->pLruPrev;
@@ -29,9 +18,6 @@ static void lruRemove(ProllyCacheEntry *pEntry){
   pEntry->pLruPrev = 0;
 }
 
-/*
-** Insert an entry at the head of the LRU list (most recently used position).
-*/
 static void lruInsertHead(ProllyCache *cache, ProllyCacheEntry *pEntry){
   pEntry->pLruNext = cache->lruHead.pLruNext;
   pEntry->pLruPrev = &cache->lruHead;
@@ -39,9 +25,6 @@ static void lruInsertHead(ProllyCache *cache, ProllyCacheEntry *pEntry){
   cache->lruHead.pLruNext = pEntry;
 }
 
-/*
-** Remove an entry from its hash bucket chain.
-*/
 static void hashRemove(ProllyCache *cache, ProllyCacheEntry *pEntry){
   int iBucket = cacheHashBucket(cache, &pEntry->hash);
   ProllyCacheEntry **pp = &cache->aBucket[iBucket];
@@ -55,9 +38,6 @@ static void hashRemove(ProllyCache *cache, ProllyCacheEntry *pEntry){
   }
 }
 
-/*
-** Free a single cache entry. Frees the owned data copy and the entry itself.
-*/
 static void cacheEntryFree(ProllyCacheEntry *pEntry){
   if( pEntry ){
     sqlite3_free(pEntry->pData);
@@ -65,12 +45,6 @@ static void cacheEntryFree(ProllyCacheEntry *pEntry){
   }
 }
 
-/*
-** Initialize a prolly cache with the given maximum capacity.
-**
-** The hash table uses nCapacity*2 buckets (minimum 16) for a low load factor.
-** Returns SQLITE_OK on success, SQLITE_NOMEM on allocation failure.
-*/
 int prollyCacheInit(ProllyCache *cache, int nCapacity){
   int nBucket;
 
@@ -90,7 +64,7 @@ int prollyCacheInit(ProllyCache *cache, int nCapacity){
   }
   memset(cache->aBucket, 0, sizeof(ProllyCacheEntry *) * nBucket);
 
-  /* Initialize LRU sentinels: head <-> tail */
+  
   cache->lruHead.pLruNext = &cache->lruTail;
   cache->lruHead.pLruPrev = 0;
   cache->lruTail.pLruPrev = &cache->lruHead;
@@ -99,13 +73,6 @@ int prollyCacheInit(ProllyCache *cache, int nCapacity){
   return SQLITE_OK;
 }
 
-/*
-** Look up a node in the cache by its content hash.
-**
-** If found, the entry's reference count is incremented and it is moved
-** to the head of the LRU list (most recently used). Returns the entry
-** pointer, or NULL if not found.
-*/
 ProllyCacheEntry *prollyCacheGet(ProllyCache *cache, const ProllyHash *hash){
   int iBucket;
   ProllyCacheEntry *pEntry;
@@ -117,7 +84,7 @@ ProllyCacheEntry *prollyCacheGet(ProllyCache *cache, const ProllyHash *hash){
 
   while( pEntry ){
     if( memcmp(pEntry->hash.data, hash->data, PROLLY_HASH_SIZE)==0 ){
-      /* Found: increment refcount and promote in LRU */
+      
       pEntry->nRef++;
       lruRemove(pEntry);
       lruInsertHead(cache, pEntry);
@@ -129,22 +96,18 @@ ProllyCacheEntry *prollyCacheGet(ProllyCache *cache, const ProllyHash *hash){
   return 0;
 }
 
-/*
-** Evict a single unreferenced entry from the LRU tail (least recently used).
-** Returns 1 if an entry was evicted, 0 if no evictable entry was found.
-*/
 static int cacheEvictOne(ProllyCache *cache){
   ProllyCacheEntry *pEntry;
 
-  /* Walk from tail toward head looking for an unreferenced entry */
+  
   pEntry = cache->lruTail.pLruPrev;
   while( pEntry!=&cache->lruHead ){
     if( pEntry->nRef==0 ){
-      /* Remove from LRU list */
+      
       lruRemove(pEntry);
-      /* Remove from hash bucket chain */
+      
       hashRemove(cache, pEntry);
-      /* Free and update count */
+      
       cacheEntryFree(pEntry);
       cache->nUsed--;
       return 1;
@@ -154,18 +117,6 @@ static int cacheEvictOne(ProllyCache *cache){
   return 0;
 }
 
-/*
-** Insert node data into the cache, keyed by content hash.
-**
-** If the hash is already present, the existing entry is returned with its
-** reference count incremented. Otherwise, a new entry is created:
-**   - If the cache is at capacity, LRU entries with nRef==0 are evicted.
-**   - A copy of pData is made (owned by the entry).
-**   - prollyNodeParse is called on the copy to populate the ProllyNode.
-**   - The new entry starts with nRef=1.
-**
-** Returns the cache entry, or NULL on allocation failure.
-*/
 ProllyCacheEntry *prollyCachePut(
   ProllyCache *cache,
   const ProllyHash *hash,
@@ -177,26 +128,26 @@ ProllyCacheEntry *prollyCachePut(
   u8 *pCopy;
   int rc;
 
-  /* Check if already present */
+  
   pEntry = prollyCacheGet(cache, hash);
   if( pEntry ){
     return pEntry;
   }
 
-  /* Evict if at capacity */
+  
   while( cache->nUsed>=cache->nCapacity ){
     if( !cacheEvictOne(cache) ){
-      /* All entries are referenced, cannot evict. Allow over-capacity. */
+      
       break;
     }
   }
 
-  /* Allocate new entry */
+  
   pEntry = (ProllyCacheEntry *)sqlite3_malloc(sizeof(ProllyCacheEntry));
   if( pEntry==0 ) return 0;
   memset(pEntry, 0, sizeof(*pEntry));
 
-  /* Copy the serialized data */
+  
   pCopy = (u8 *)sqlite3_malloc(nData);
   if( pCopy==0 ){
     sqlite3_free(pEntry);
@@ -204,13 +155,13 @@ ProllyCacheEntry *prollyCachePut(
   }
   memcpy(pCopy, pData, nData);
 
-  /* Fill in the entry */
+  
   memcpy(pEntry->hash.data, hash->data, PROLLY_HASH_SIZE);
   pEntry->pData = pCopy;
   pEntry->nData = nData;
   pEntry->nRef = 1;
 
-  /* Parse the node from the owned copy */
+  
   rc = prollyNodeParse(&pEntry->node, pCopy, nData);
   if( rc!=SQLITE_OK ){
     sqlite3_free(pCopy);
@@ -218,33 +169,24 @@ ProllyCacheEntry *prollyCachePut(
     return 0;
   }
 
-  /* Insert into hash bucket chain */
+  
   iBucket = cacheHashBucket(cache, hash);
   pEntry->pHashNext = cache->aBucket[iBucket];
   cache->aBucket[iBucket] = pEntry;
 
-  /* Insert at LRU head */
+  
   lruInsertHead(cache, pEntry);
 
   cache->nUsed++;
   return pEntry;
 }
 
-/*
-** Release a reference to a cache entry. Decrements the reference count.
-** The entry remains in the cache and may be evicted later when its
-** reference count is zero.
-*/
 void prollyCacheRelease(ProllyCache *cache, ProllyCacheEntry *entry){
   (void)cache;
   assert( entry->nRef>0 );
   entry->nRef--;
 }
 
-/*
-** Remove all unreferenced entries (nRef==0) from the cache.
-** Walk the LRU list from tail toward head, removing entries with nRef==0.
-*/
 void prollyCachePurge(ProllyCache *cache){
   ProllyCacheEntry *pEntry;
   ProllyCacheEntry *pPrev;
@@ -264,17 +206,13 @@ void prollyCachePurge(ProllyCache *cache){
   }
 }
 
-/*
-** Free all cache resources. Asserts that every entry has nRef==0.
-** After this call the ProllyCache struct is zeroed.
-*/
 void prollyCacheFree(ProllyCache *cache){
   ProllyCacheEntry *pEntry;
   ProllyCacheEntry *pNext;
 
   if( cache->aBucket==0 ) return;
 
-  /* Walk LRU list and free all entries */
+  
   pEntry = cache->lruHead.pLruNext;
   while( pEntry!=&cache->lruTail ){
     pNext = pEntry->pLruNext;
@@ -287,4 +225,4 @@ void prollyCacheFree(ProllyCache *cache){
   memset(cache, 0, sizeof(*cache));
 }
 
-#endif /* DOLTLITE_PROLLY */
+#endif 

--- a/src/prolly_cache.h
+++ b/src/prolly_cache.h
@@ -1,7 +1,4 @@
-/*
-** LRU node cache with reference counting for prolly tree nodes.
-** Caches deserialized ProllyNode structs keyed by content hash.
-*/
+
 #ifndef SQLITE_PROLLY_CACHE_H
 #define SQLITE_PROLLY_CACHE_H
 
@@ -13,46 +10,37 @@ typedef struct ProllyCache ProllyCache;
 typedef struct ProllyCacheEntry ProllyCacheEntry;
 
 struct ProllyCacheEntry {
-  ProllyHash hash;           /* Content hash (lookup key) */
-  u8 *pData;                 /* Owned copy of serialized node data */
-  int nData;                 /* Size of serialized data */
-  ProllyNode node;           /* Parsed node (points into pData) */
-  int nRef;                  /* Reference count */
-  ProllyCacheEntry *pLruNext; /* LRU doubly-linked list */
+  ProllyHash hash;           
+  u8 *pData;                 
+  int nData;                 
+  ProllyNode node;           
+  int nRef;                  
+  ProllyCacheEntry *pLruNext; 
   ProllyCacheEntry *pLruPrev;
-  ProllyCacheEntry *pHashNext; /* Hash bucket chain */
+  ProllyCacheEntry *pHashNext; 
 };
 
 struct ProllyCache {
-  int nCapacity;              /* Max entries */
-  int nUsed;                  /* Current entries */
-  int nBucket;                /* Hash table bucket count */
-  ProllyCacheEntry **aBucket; /* Hash table */
-  ProllyCacheEntry lruHead;   /* LRU sentinel (most recent) */
-  ProllyCacheEntry lruTail;   /* LRU sentinel (least recent) */
+  int nCapacity;              
+  int nUsed;                  
+  int nBucket;                
+  ProllyCacheEntry **aBucket; 
+  ProllyCacheEntry lruHead;   
+  ProllyCacheEntry lruTail;   
 };
 
-/* Create cache with given capacity. Returns SQLITE_OK or SQLITE_NOMEM. */
 int prollyCacheInit(ProllyCache *cache, int nCapacity);
 
-/* Look up a node by hash. Increments refcount if found.
-** Returns NULL if not in cache. */
 ProllyCacheEntry *prollyCacheGet(ProllyCache *cache, const ProllyHash *hash);
 
-/* Insert node data into cache. Returns the cache entry with refcount=1.
-** If already present, returns existing entry with incremented refcount.
-** Evicts LRU entries with refcount==0 if at capacity. */
 ProllyCacheEntry *prollyCachePut(ProllyCache *cache,
                                   const ProllyHash *hash,
                                   const u8 *pData, int nData);
 
-/* Release a reference to a cache entry */
 void prollyCacheRelease(ProllyCache *cache, ProllyCacheEntry *entry);
 
-/* Remove all unreferenced entries */
 void prollyCachePurge(ProllyCache *cache);
 
-/* Free all cache resources. Asserts all refcounts are 0. */
 void prollyCacheFree(ProllyCache *cache);
 
-#endif /* SQLITE_PROLLY_CACHE_H */
+#endif 

--- a/src/prolly_cache.h
+++ b/src/prolly_cache.h
@@ -1,4 +1,4 @@
-
+/* LRU cache for parsed prolly tree nodes, keyed by content hash. Refcounted. */
 #ifndef SQLITE_PROLLY_CACHE_H
 #define SQLITE_PROLLY_CACHE_H
 

--- a/src/prolly_chunker.c
+++ b/src/prolly_chunker.c
@@ -1,24 +1,14 @@
-/*
-** Rolling-hash tree builder for prolly trees.
-**
-** Builds a prolly tree bottom-up by accepting sorted leaf key-value pairs,
-** using rolling hash to determine node boundaries, and recursing upward
-** through levels to produce a content-addressed tree.
-*/
+
 #ifdef DOLTLITE_PROLLY
 
 #include "prolly_chunker.h"
-#include "prolly_cursor.h"  /* For PROLLY_CURSOR_MAX_DEPTH */
+#include "prolly_cursor.h"  
 
 #include <string.h>
 #include <assert.h>
 
-/* Rolling hash window size for boundary detection */
 #define CHUNKER_WINDOW_SIZE 64
 
-/*
-** Forward declarations of internal helpers.
-*/
 static int initLevel(ProllyChunker *ch, int level);
 static int flushLevel(ProllyChunker *ch, int level);
 static int addToLevel(ProllyChunker *ch, int level,
@@ -27,13 +17,6 @@ static int addToLevel(ProllyChunker *ch, int level,
 static int finishFlushLevel(ProllyChunker *ch, int level,
                             ProllyHash *pHash);
 
-/*
-** initLevel — Initialize a ProllyChunkerLevel.
-**
-** Sets up the NodeBuilder with the appropriate tree level and flags,
-** and initializes the RollingHash with window size CHUNKER_WINDOW_SIZE.
-** Returns SQLITE_OK on success or SQLITE_NOMEM on allocation failure.
-*/
 static int initLevel(ProllyChunker *ch, int level){
   ProllyChunkerLevel *pLevel;
   int rc;
@@ -43,9 +26,7 @@ static int initLevel(ProllyChunker *ch, int level){
   pLevel = &ch->aLevel[level];
   memset(pLevel, 0, sizeof(ProllyChunkerLevel));
 
-  /* Internal nodes (level>0) have child hashes as values.
-  ** Leaf nodes (level==0) have arbitrary payload values.
-  ** The builder level corresponds to the tree level. */
+  
   prollyNodeBuilderInit(&pLevel->builder, (u8)level, ch->flags);
 
   rc = prollyRollingHashInit(&pLevel->rh, CHUNKER_WINDOW_SIZE);
@@ -60,11 +41,6 @@ static int initLevel(ProllyChunker *ch, int level){
   return SQLITE_OK;
 }
 
-/*
-** Extract the last key from a node builder.  The builder must have
-** at least one item.  Sets *ppKey and *pnKey to point into the
-** builder's key buffer (valid until the builder is reset or freed).
-*/
 static void builderLastKey(ProllyNodeBuilder *b,
                            const u8 **ppKey, int *pnKey){
   int n = b->nItems;
@@ -76,19 +52,6 @@ static void builderLastKey(ProllyNodeBuilder *b,
   *pnKey = (int)(off1 - off0);
 }
 
-/*
-** flushLevel — Finalize the node builder at a given level during
-** normal (non-finish) operation.
-**
-** 1. Extracts the last key (needed for promotion).
-** 2. Serializes the node via prollyNodeBuilderFinish.
-** 3. Writes the chunk to the ChunkStore via chunkStorePut.
-** 4. Promotes the last key + chunk hash to the parent level (level+1)
-**    via addToLevel, which may recursively flush higher levels.
-** 5. Resets the builder and rolling hash for reuse.
-**
-** Returns SQLITE_OK on success or an error code.
-*/
 static int flushLevel(ProllyChunker *ch, int level){
   ProllyChunkerLevel *pLevel = &ch->aLevel[level];
   u8 *pData = 0;
@@ -100,24 +63,19 @@ static int flushLevel(ProllyChunker *ch, int level){
 
   assert( pLevel->builder.nItems > 0 );
 
-  /* Extract the last key before serialization.  The key data lives in the
-  ** builder's key buffer, which remains valid through Finish and until
-  ** Reset is called. */
+  
   builderLastKey(&pLevel->builder, &pLastKey, &nLastKey);
 
-  /* Serialize the node */
+  
   rc = prollyNodeBuilderFinish(&pLevel->builder, &pData, &nData);
   if( rc!=SQLITE_OK ) return rc;
 
-  /* Write chunk to store, get content hash */
+  
   rc = chunkStorePut(ch->pStore, pData, nData, &hash);
   sqlite3_free(pData);
   if( rc!=SQLITE_OK ) return rc;
 
-  /* Promote last key + hash to the parent level.
-  ** The parent level (level+1) is an internal node whose values are
-  ** child hashes (PROLLY_HASH_SIZE bytes each).
-  ** addToLevel may itself trigger further flushes at higher levels. */
+  
   if( level + 1 < PROLLY_CURSOR_MAX_DEPTH ){
     rc = addToLevel(ch, level + 1,
                     pLastKey, nLastKey,
@@ -125,7 +83,7 @@ static int flushLevel(ProllyChunker *ch, int level){
     if( rc!=SQLITE_OK ) return rc;
   }
 
-  /* Reset the builder and rolling hash for reuse at this level */
+  
   prollyNodeBuilderReset(&pLevel->builder);
   prollyRollingHashReset(&pLevel->rh);
   pLevel->nItems = 0;
@@ -134,15 +92,6 @@ static int flushLevel(ProllyChunker *ch, int level){
   return SQLITE_OK;
 }
 
-/*
-** finishFlushLevel — Flush a level during the Finish phase.
-**
-** Like flushLevel but does NOT promote to parent.  Instead, the
-** resulting chunk hash is returned in *pHash and the last key is
-** left for the caller to handle promotion.
-**
-** Returns SQLITE_OK on success or an error code.
-*/
 static int finishFlushLevel(ProllyChunker *ch, int level,
                             ProllyHash *pHash){
   ProllyChunkerLevel *pLevel = &ch->aLevel[level];
@@ -152,11 +101,11 @@ static int finishFlushLevel(ProllyChunker *ch, int level,
 
   assert( pLevel->builder.nItems > 0 );
 
-  /* Serialize the node */
+  
   rc = prollyNodeBuilderFinish(&pLevel->builder, &pData, &nData);
   if( rc!=SQLITE_OK ) return rc;
 
-  /* Write chunk to store */
+  
   rc = chunkStorePut(ch->pStore, pData, nData, pHash);
   sqlite3_free(pData);
   if( rc!=SQLITE_OK ) return rc;
@@ -164,18 +113,6 @@ static int finishFlushLevel(ProllyChunker *ch, int level,
   return SQLITE_OK;
 }
 
-/*
-** addToLevel — Add a key-value pair to a specific chunker level.
-**
-** 1. Ensures the level is initialized (lazy init).
-** 2. Adds the key-value pair to the level's node builder.
-** 3. Feeds the key bytes into the rolling hash for boundary detection.
-** 4. Increments nBytes by (nKey + nVal).
-** 5. If nBytes >= PROLLY_CHUNK_MIN AND (rolling hash is at boundary OR
-**    nBytes >= PROLLY_CHUNK_MAX), flushes this level.
-**
-** Returns SQLITE_OK on success or an error code.
-*/
 static int addToLevel(ProllyChunker *ch, int level,
                       const u8 *pKey, int nKey,
                       const u8 *pVal, int nVal){
@@ -185,7 +122,7 @@ static int addToLevel(ProllyChunker *ch, int level,
 
   assert( level >= 0 && level < PROLLY_CURSOR_MAX_DEPTH );
 
-  /* Ensure this level is initialized */
+  
   if( level >= ch->nLevels ){
     while( ch->nLevels <= level ){
       rc = initLevel(ch, ch->nLevels);
@@ -196,24 +133,21 @@ static int addToLevel(ProllyChunker *ch, int level,
 
   pLevel = &ch->aLevel[level];
 
-  /* Add the key-value pair to the node builder */
+  
   rc = prollyNodeBuilderAdd(&pLevel->builder, pKey, nKey, pVal, nVal);
   if( rc!=SQLITE_OK ) return rc;
 
   pLevel->nItems++;
 
-  /* Feed each byte of the key into the rolling hash */
+  
   for(i = 0; i < nKey; i++){
     prollyRollingHashUpdate(&pLevel->rh, pKey[i]);
   }
 
-  /* Accumulate byte count */
+  
   pLevel->nBytes += nKey + nVal;
 
-  /* Check if we should flush this level:
-  ** - Must have at least PROLLY_CHUNK_MIN bytes accumulated
-  ** - Either the rolling hash has hit a boundary pattern, or
-  **   we've exceeded the max chunk size */
+  
   if( pLevel->nBytes >= PROLLY_CHUNK_MIN ){
     int atBoundary = prollyRollingHashAtBoundary(&pLevel->rh,
                                                   PROLLY_CHUNK_PATTERN);
@@ -226,12 +160,6 @@ static int addToLevel(ProllyChunker *ch, int level,
   return SQLITE_OK;
 }
 
-/*
-** prollyChunkerInit — Initialize a chunker for building a new tree.
-**
-** Zeros the struct and stores the chunk store pointer and flags.
-** Levels are not initialized until they are first used (lazy init).
-*/
 int prollyChunkerInit(ProllyChunker *ch, ChunkStore *pStore, u8 flags){
   memset(ch, 0, sizeof(ProllyChunker));
   ch->pStore = pStore;
@@ -241,13 +169,6 @@ int prollyChunkerInit(ProllyChunker *ch, ChunkStore *pStore, u8 flags){
   return SQLITE_OK;
 }
 
-/*
-** prollyChunkerAdd — Add a leaf key-value pair.
-**
-** Ensures level 0 is initialized and delegates to addToLevel at level 0.
-** The chunker handles splitting nodes and building internal levels
-** automatically via the rolling hash boundary detection.
-*/
 int prollyChunkerAdd(ProllyChunker *ch,
                      const u8 *pKey, int nKey,
                      const u8 *pVal, int nVal){
@@ -259,72 +180,34 @@ int prollyChunkerAdd(ProllyChunker *ch,
   return SQLITE_OK;
 }
 
-/*
-** prollyChunkerFinish — Finalize the tree.
-**
-** Flushes remaining items at each level from bottom up.  The topmost
-** level that produces a single node becomes the root.
-**
-** Algorithm:
-**   Walk from level 0 upward.  At each level that has pending items
-**   in its builder, serialize and write the node.  If there is a parent
-**   level that already has items (from earlier boundary flushes), or if
-**   the current level had earlier boundary flushes (meaning the parent
-**   already received promotions), promote this final node's last key +
-**   hash to the parent.  Otherwise this node is the root.
-**
-** The key insight: during normal operation, every time a level is
-** flushed, its last key + hash is promoted to level+1.  So if level L
-** was flushed K times during Add, then level L+1 has at least K entries.
-** During Finish, level L may have leftover items.  If L+1 has items
-** (either from earlier promotions or from flushing L-1 during this
-** Finish pass), we must also promote L's final node to L+1.  If L+1
-** has no items and won't get any, then L's node is the root.
-**
-** Special cases:
-**   - Empty tree: root is the zero hash.
-**   - All entries fit in one node at some level: that node is the root.
-*/
 int prollyChunkerFinish(ProllyChunker *ch){
   int rc;
   int level;
   int maxLevel;
 
-  /* Handle empty tree */
+  
   if( ch->nLevels == 0 ){
     memset(&ch->root, 0, sizeof(ProllyHash));
     return SQLITE_OK;
   }
 
-  /*
-  ** We process levels bottom-up.  Flushing level L during Finish adds
-  ** an entry to level L+1, which may increase nLevels.  We must keep
-  ** going until we've handled all levels.  We use a while loop since
-  ** maxLevel can grow.
-  */
+  
   level = 0;
   while( level < ch->nLevels ){
     ProllyChunkerLevel *pLevel = &ch->aLevel[level];
 
     if( pLevel->builder.nItems == 0 ){
-      /* Nothing pending at this level */
+      
       level++;
       continue;
     }
 
-    /* Determine if a parent level exists and has (or will have) items.
-    ** The parent has items if:
-    **   (a) it was already initialized and has items in its builder, OR
-    **   (b) a higher level has items (meaning the tree goes higher).
-    **
-    ** If neither is true, then this level's single remaining node
-    ** is the root candidate.  But we only call it root if no higher
-    ** level has pending items.  */
+    
     {
       int parentActive = 0;
       int k;
 
-      /* Check if any level above has pending items */
+      
       for(k = level + 1; k < ch->nLevels; k++){
         if( ch->aLevel[k].builder.nItems > 0 ){
           parentActive = 1;
@@ -333,8 +216,7 @@ int prollyChunkerFinish(ProllyChunker *ch){
       }
 
       if( parentActive ){
-        /* There are items above.  We must serialize this node and
-        ** promote its last key + hash to level+1. */
+        
         ProllyHash hash;
         const u8 *pLastKey;
         int nLastKey;
@@ -344,7 +226,7 @@ int prollyChunkerFinish(ProllyChunker *ch){
         rc = finishFlushLevel(ch, level, &hash);
         if( rc!=SQLITE_OK ) return rc;
 
-        /* Ensure parent level is initialized */
+        
         if( level + 1 >= ch->nLevels ){
           rc = initLevel(ch, ch->nLevels);
           if( rc!=SQLITE_OK ) return rc;
@@ -359,13 +241,13 @@ int prollyChunkerFinish(ProllyChunker *ch){
         if( rc!=SQLITE_OK ) return rc;
         ch->aLevel[level + 1].nItems++;
 
-        /* Reset this level */
+        
         prollyNodeBuilderReset(&pLevel->builder);
         prollyRollingHashReset(&pLevel->rh);
         pLevel->nItems = 0;
         pLevel->nBytes = 0;
       } else {
-        /* No higher level has items.  This node is the root. */
+        
         ProllyHash hash;
 
         rc = finishFlushLevel(ch, level, &hash);
@@ -373,7 +255,7 @@ int prollyChunkerFinish(ProllyChunker *ch){
 
         memcpy(&ch->root, &hash, sizeof(ProllyHash));
 
-        /* Clean up this level */
+        
         prollyNodeBuilderReset(&pLevel->builder);
         prollyRollingHashReset(&pLevel->rh);
         pLevel->nItems = 0;
@@ -385,48 +267,27 @@ int prollyChunkerFinish(ProllyChunker *ch){
     level++;
   }
 
-  /* Should not reach here with valid input — the loop above should
-  ** always find a topmost root.  But handle gracefully. */
+  
   memset(&ch->root, 0, sizeof(ProllyHash));
   return SQLITE_OK;
 }
 
-/*
-** prollyChunkerGetRoot — Copy the root hash to the output parameter.
-*/
 void prollyChunkerGetRoot(ProllyChunker *ch, ProllyHash *pRoot){
   memcpy(pRoot, &ch->root, sizeof(ProllyHash));
 }
 
-/*
-** prollyChunkerAddAtLevel — Public wrapper for addToLevel.
-** Allows injecting entries at arbitrary levels of the chunker,
-** e.g. inserting (lastKey, childHash) at level 1 to skip
-** re-serializing unchanged leaf nodes.
-*/
 int prollyChunkerAddAtLevel(ProllyChunker *ch, int level,
                             const u8 *pKey, int nKey,
                             const u8 *pVal, int nVal){
   return addToLevel(ch, level, pKey, nKey, pVal, nVal);
 }
 
-/*
-** prollyChunkerFlushLevel — Flush pending entries at a level.
-** If the level has items in its builder, serialize them into a chunk,
-** promote to the parent, and reset. This is needed before injecting
-** entries at a higher level to maintain consistency.
-*/
 int prollyChunkerFlushLevel(ProllyChunker *ch, int level){
   if( level >= ch->nLevels ) return SQLITE_OK;
   if( ch->aLevel[level].builder.nItems == 0 ) return SQLITE_OK;
   return flushLevel(ch, level);
 }
 
-/*
-** prollyChunkerFree — Free all resources held by the chunker.
-**
-** Frees node builders and rolling hashes at every initialized level.
-*/
 void prollyChunkerFree(ProllyChunker *ch){
   int i;
   for(i = 0; i < ch->nLevels; i++){
@@ -436,4 +297,4 @@ void prollyChunkerFree(ProllyChunker *ch){
   ch->nLevels = 0;
 }
 
-#endif /* DOLTLITE_PROLLY */
+#endif 

--- a/src/prolly_chunker.c
+++ b/src/prolly_chunker.c
@@ -76,6 +76,9 @@ static int flushLevel(ProllyChunker *ch, int level){
   if( rc!=SQLITE_OK ) return rc;
 
   
+  /* Propagate upward: add (lastKey -> childHash) entry to parent level.
+  ** The parent's key is the last key from this child, matching prolly tree
+  ** convention where internal keys are the max key of their subtree. */
   if( level + 1 < PROLLY_CURSOR_MAX_DEPTH ){
     rc = addToLevel(ch, level + 1,
                     pLastKey, nLastKey,
@@ -148,6 +151,10 @@ static int addToLevel(ProllyChunker *ch, int level,
   pLevel->nBytes += nKey + nVal;
 
   
+  /* Content-defined chunking: split when the rolling hash of key bytes
+  ** matches PROLLY_CHUNK_PATTERN (after reaching PROLLY_CHUNK_MIN bytes).
+  ** This makes boundaries depend on content, not position, so insertions
+  ** only invalidate nearby chunks rather than shifting all subsequent ones. */
   if( pLevel->nBytes >= PROLLY_CHUNK_MIN ){
     int atBoundary = prollyRollingHashAtBoundary(&pLevel->rh,
                                                   PROLLY_CHUNK_PATTERN);
@@ -180,12 +187,14 @@ int prollyChunkerAdd(ProllyChunker *ch,
   return SQLITE_OK;
 }
 
+/* Flush remaining items bottom-up. At each level, if a parent level has
+** pending items, finalize this level's node and add its hash to the parent.
+** The highest level with items becomes the tree root. */
 int prollyChunkerFinish(ProllyChunker *ch){
   int rc;
   int level;
   int maxLevel;
 
-  
   if( ch->nLevels == 0 ){
     memset(&ch->root, 0, sizeof(ProllyHash));
     return SQLITE_OK;

--- a/src/prolly_chunker.h
+++ b/src/prolly_chunker.h
@@ -1,8 +1,4 @@
-/*
-** Rolling-hash tree builder for prolly trees.
-** Consumes sorted key-value pairs and produces a set of content-addressed
-** nodes organized into a tree structure using rolling hash boundaries.
-*/
+
 #ifndef SQLITE_PROLLY_CHUNKER_H
 #define SQLITE_PROLLY_CHUNKER_H
 
@@ -12,64 +8,46 @@
 #include "prolly_cursor.h"
 #include "chunk_store.h"
 
-/*
-** Target and bounds for chunk sizes.
-** The rolling hash pattern determines boundaries, but we enforce
-** minimum and maximum sizes to prevent degenerate cases.
-*/
 #define PROLLY_CHUNK_TARGET  4096
 #define PROLLY_CHUNK_MIN     512
 #define PROLLY_CHUNK_MAX     16384
 
-/* Rolling hash pattern: boundary when (hash & pattern) == pattern */
-#define PROLLY_CHUNK_PATTERN 0x00000FFF  /* ~1/4096 probability */
+#define PROLLY_CHUNK_PATTERN 0x00000FFF  
 
 typedef struct ProllyChunker ProllyChunker;
 typedef struct ProllyChunkerLevel ProllyChunkerLevel;
 
 struct ProllyChunkerLevel {
-  ProllyNodeBuilder builder;     /* Node builder for this level */
-  ProllyRollingHash rh;         /* Rolling hash for boundary detection */
-  int nItems;                    /* Items added at this level */
-  int nBytes;                    /* Bytes accumulated at this level */
+  ProllyNodeBuilder builder;     
+  ProllyRollingHash rh;         
+  int nItems;                    
+  int nBytes;                    
 };
 
 struct ProllyChunker {
-  ChunkStore *pStore;            /* Where to write chunks */
-  u8 flags;                      /* PROLLY_NODE_INTKEY or PROLLY_NODE_BLOBKEY */
-  int nLevels;                   /* Number of levels currently in use */
+  ChunkStore *pStore;            
+  u8 flags;                      
+  int nLevels;                   
   ProllyChunkerLevel aLevel[PROLLY_CURSOR_MAX_DEPTH];
-  ProllyHash root;               /* Resulting root hash */
+  ProllyHash root;               
 };
 
-/* Initialize chunker for building a new tree */
 int prollyChunkerInit(ProllyChunker *ch, ChunkStore *pStore, u8 flags);
 
-/* Add a leaf key-value pair. The chunker handles splitting and
-** building internal nodes automatically. */
 int prollyChunkerAdd(ProllyChunker *ch,
                      const u8 *pKey, int nKey,
                      const u8 *pVal, int nVal);
 
-/* Finalize the tree. Flushes all pending nodes and builds
-** the root. Sets ch->root to the root hash. */
 int prollyChunkerFinish(ProllyChunker *ch);
 
-/* Get the root hash after finish */
 void prollyChunkerGetRoot(ProllyChunker *ch, ProllyHash *pRoot);
 
-/* Free chunker resources */
 void prollyChunkerFree(ProllyChunker *ch);
 
-/* Add a key-value pair directly at a specific level of the chunker.
-** Used by applyEdits to inject unchanged subtree hashes at the parent
-** level, bypassing leaf-level re-serialization. */
 int prollyChunkerAddAtLevel(ProllyChunker *ch, int level,
                             const u8 *pKey, int nKey,
                             const u8 *pVal, int nVal);
 
-/* Flush any pending entries at the given level without finalizing.
-** Used before injecting at a higher level to ensure level consistency. */
 int prollyChunkerFlushLevel(ProllyChunker *ch, int level);
 
-#endif /* SQLITE_PROLLY_CHUNKER_H */
+#endif 

--- a/src/prolly_chunker.h
+++ b/src/prolly_chunker.h
@@ -1,4 +1,4 @@
-
+/* Content-defined chunking: rolling-hash-based tree builder (min 512, target 4K, max 16K). */
 #ifndef SQLITE_PROLLY_CHUNKER_H
 #define SQLITE_PROLLY_CHUNKER_H
 

--- a/src/prolly_cursor.c
+++ b/src/prolly_cursor.c
@@ -1,17 +1,10 @@
-/*
-** Implementation of hierarchical cursor for prolly tree traversal.
-** See prolly_cursor.h for interface documentation.
-*/
+
 #ifdef DOLTLITE_PROLLY
 
 #include "prolly_cursor.h"
 #include <string.h>
 #include <assert.h>
 
-/*
-** Helper: load a node by hash from cache or chunk store.
-** On success, *ppEntry is set to a cache entry with an incremented refcount.
-*/
 static int loadNode(ProllyCursor *cur, const ProllyHash *hash,
                     ProllyCacheEntry **ppEntry){
   ProllyCacheEntry *pEntry;
@@ -19,14 +12,14 @@ static int loadNode(ProllyCursor *cur, const ProllyHash *hash,
 
   *ppEntry = 0;
 
-  /* Try cache first */
+  
   pEntry = prollyCacheGet(cur->pCache, hash);
   if( pEntry ){
     *ppEntry = pEntry;
     return SQLITE_OK;
   }
 
-  /* Cache miss: fetch from chunk store */
+  
   u8 *pData = 0;
   int nData = 0;
   rc = chunkStoreGet(cur->pStore, hash, &pData, &nData);
@@ -34,7 +27,7 @@ static int loadNode(ProllyCursor *cur, const ProllyHash *hash,
     return rc;
   }
 
-  /* Insert into cache. prollyCachePut makes its own copy of pData. */
+  
   pEntry = prollyCachePut(cur->pCache, hash, pData, nData);
   sqlite3_free(pData);
   if( pEntry==0 ){
@@ -45,10 +38,6 @@ static int loadNode(ProllyCursor *cur, const ProllyHash *hash,
   return SQLITE_OK;
 }
 
-/*
-** Helper: from the current level, descend to the leftmost leaf.
-** Assumes aLevel[iLevel] is already loaded and idx is set.
-*/
 static int descendToLeftmostLeaf(ProllyCursor *cur){
   int rc;
   while( cur->aLevel[cur->iLevel].pEntry->node.level>0 ){
@@ -74,10 +63,6 @@ static int descendToLeftmostLeaf(ProllyCursor *cur){
   return SQLITE_OK;
 }
 
-/*
-** Helper: from the current level, descend to the rightmost leaf.
-** Assumes aLevel[iLevel] is already loaded and idx is set.
-*/
 static int descendToRightmostLeaf(ProllyCursor *cur){
   int rc;
   while( cur->aLevel[cur->iLevel].pEntry->node.level>0 ){
@@ -103,9 +88,6 @@ static int descendToRightmostLeaf(ProllyCursor *cur){
   return SQLITE_OK;
 }
 
-/*
-** Initialize a cursor. Does not load the root node.
-*/
 void prollyCursorInit(ProllyCursor *cur, ChunkStore *pStore,
                       ProllyCache *pCache, const ProllyHash *pRoot, u8 flags){
   memset(cur, 0, sizeof(*cur));
@@ -116,10 +98,6 @@ void prollyCursorInit(ProllyCursor *cur, ChunkStore *pStore,
   cur->eState = PROLLY_CURSOR_INVALID;
 }
 
-/*
-** Move cursor to the first (leftmost) entry in the tree.
-** Sets *pRes=1 if the tree is empty, 0 otherwise.
-*/
 int prollyCursorFirst(ProllyCursor *cur, int *pRes){
   int rc;
 
@@ -147,10 +125,6 @@ int prollyCursorFirst(ProllyCursor *cur, int *pRes){
   return SQLITE_OK;
 }
 
-/*
-** Move cursor to the last (rightmost) entry in the tree.
-** Sets *pRes=1 if the tree is empty, 0 otherwise.
-*/
 int prollyCursorLast(ProllyCursor *cur, int *pRes){
   int rc;
 
@@ -178,26 +152,22 @@ int prollyCursorLast(ProllyCursor *cur, int *pRes){
   return SQLITE_OK;
 }
 
-/*
-** Advance cursor to the next entry.
-** If already at the last entry, sets eState to EOF.
-*/
 int prollyCursorNext(ProllyCursor *cur){
   int rc;
 
   assert( cur->eState==PROLLY_CURSOR_VALID );
 
-  /* Try to advance within the current leaf */
+  
   ProllyCacheEntry *pLeaf = cur->aLevel[cur->iLevel].pEntry;
   if( cur->aLevel[cur->iLevel].idx < pLeaf->node.nItems - 1 ){
     cur->aLevel[cur->iLevel].idx++;
     return SQLITE_OK;
   }
 
-  /* Pop up the stack looking for a level we can advance */
+  
   int level = cur->iLevel;
   while( level>0 ){
-    /* Release the current level's node */
+    
     prollyCacheRelease(cur->pCache, cur->aLevel[level].pEntry);
     cur->aLevel[level].pEntry = 0;
     level--;
@@ -213,27 +183,23 @@ int prollyCursorNext(ProllyCursor *cur){
     }
   }
 
-  /* We've exhausted the tree */
+  
   cur->eState = PROLLY_CURSOR_EOF;
   return SQLITE_OK;
 }
 
-/*
-** Move cursor to the previous entry.
-** If already at the first entry, sets eState to EOF.
-*/
 int prollyCursorPrev(ProllyCursor *cur){
   int rc;
 
   assert( cur->eState==PROLLY_CURSOR_VALID );
 
-  /* Try to go back within the current leaf */
+  
   if( cur->aLevel[cur->iLevel].idx > 0 ){
     cur->aLevel[cur->iLevel].idx--;
     return SQLITE_OK;
   }
 
-  /* Pop up the stack looking for a level we can go back */
+  
   int level = cur->iLevel;
   while( level>0 ){
     prollyCacheRelease(cur->pCache, cur->aLevel[level].pEntry);
@@ -250,16 +216,11 @@ int prollyCursorPrev(ProllyCursor *cur){
     }
   }
 
-  /* We've exhausted the tree */
+  
   cur->eState = PROLLY_CURSOR_EOF;
   return SQLITE_OK;
 }
 
-/*
-** Seek to an integer key (for INTKEY / table btrees).
-** *pRes is set to: 0 if exact match, -1 if cursor is at a smaller key,
-** +1 if cursor is at a larger key.
-*/
 int prollyCursorSeekInt(ProllyCursor *cur, i64 intKey, int *pRes){
   int rc;
 
@@ -278,25 +239,12 @@ int prollyCursorSeekInt(ProllyCursor *cur, i64 intKey, int *pRes){
   cur->iLevel = 0;
   cur->aLevel[0].pEntry = pEntry;
 
-  /* Descend from root to leaf, binary searching at each level */
+  
   while( pEntry->node.level>0 ){
     int searchRes;
     int idx = prollyNodeSearchInt(&pEntry->node, intKey, &searchRes);
 
-    /*
-    ** Internal node keys are the LAST (max) key in each child subtree.
-    ** prollyNodeSearchInt returns the index where intKey would be inserted.
-    **
-    ** If searchRes==0: exact match at idx, descend into child idx.
-    ** If searchRes>0: intKey > key[idx], need child idx+1 (next subtree).
-    ** If searchRes<0: intKey < key[idx], descend into child idx
-    **   (this child's subtree contains keys up to key[idx]).
-    **
-    ** But idx is clamped to [0, nItems-1] by the binary search, so if
-    ** intKey > all keys, idx is at nItems-1 and searchRes>0. In that
-    ** case we can't go to idx+1 (no more children) — but for a valid
-    ** tree, this child should contain the key since it's the rightmost.
-    */
+    
     if( searchRes>0 && idx<pEntry->node.nItems-1 ){
       idx++;
     }
@@ -321,7 +269,7 @@ int prollyCursorSeekInt(ProllyCursor *cur, i64 intKey, int *pRes){
 
   cur->nLevel = cur->iLevel + 1;
 
-  /* At the leaf: binary search for the key */
+  
   int leafRes;
   int leafIdx;
   if( pEntry->node.nItems==0 ){
@@ -333,17 +281,17 @@ int prollyCursorSeekInt(ProllyCursor *cur, i64 intKey, int *pRes){
   cur->aLevel[cur->iLevel].idx = leafIdx;
 
   if( leafRes==0 ){
-    /* Exact match */
+    
     cur->eState = PROLLY_CURSOR_VALID;
     *pRes = 0;
   } else if( leafIdx>=pEntry->node.nItems ){
-    /* Key is past the end of this leaf; try to advance to next entry */
+    
     cur->aLevel[cur->iLevel].idx = pEntry->node.nItems - 1;
     cur->eState = PROLLY_CURSOR_VALID;
     rc = prollyCursorNext(cur);
     if( rc!=SQLITE_OK ) return rc;
     if( cur->eState==PROLLY_CURSOR_EOF ){
-      /* Past last entry in tree, back up to last valid */
+      
       rc = prollyCursorLast(cur, &(int){0});
       if( rc!=SQLITE_OK ) return rc;
       *pRes = -1;
@@ -353,20 +301,15 @@ int prollyCursorSeekInt(ProllyCursor *cur, i64 intKey, int *pRes){
   } else {
     cur->eState = PROLLY_CURSOR_VALID;
     if( leafRes<0 ){
-      *pRes = 1;  /* cursor key > seek key */
+      *pRes = 1;  
     } else {
-      *pRes = -1; /* cursor key < seek key */
+      *pRes = -1; 
     }
   }
 
   return SQLITE_OK;
 }
 
-/*
-** Seek to a blob key (for BLOBKEY / index btrees).
-** *pRes is set to: 0 if exact match, -1 if cursor is at a smaller key,
-** +1 if cursor is at a larger key.
-*/
 int prollyCursorSeekBlob(ProllyCursor *cur,
                          const u8 *pKey, int nKey, int *pRes){
   int rc;
@@ -386,20 +329,16 @@ int prollyCursorSeekBlob(ProllyCursor *cur,
   cur->iLevel = 0;
   cur->aLevel[0].pEntry = pEntry;
 
-  /* Descend from root to leaf */
+  
   while( pEntry->node.level>0 ){
     int searchRes;
     int idx = prollyNodeSearchBlob(&pEntry->node, pKey, nKey, &searchRes);
 
-    /* Internal node boundary keys are the LAST (max) key of each child.
-    ** To find key K, descend into the first child whose max key >= K.
-    ** prollyNodeSearchBlob returns the insertion point idx with searchRes<0
-    ** when K < boundary[idx] — that IS the correct child (its range
-    ** covers K).  searchRes>0 means K > all boundaries — last child. */
+    
     if( searchRes>0 ){
-      /* K past all boundaries — last child is correct (already idx=nItems-1) */
+      
     }
-    /* searchRes<=0: idx is already the correct child */
+    
 
     cur->aLevel[cur->iLevel].idx = idx;
 
@@ -421,7 +360,7 @@ int prollyCursorSeekBlob(ProllyCursor *cur,
 
   cur->nLevel = cur->iLevel + 1;
 
-  /* At the leaf: binary search */
+  
   int leafRes;
   int leafIdx;
   if( pEntry->node.nItems==0 ){
@@ -459,19 +398,10 @@ int prollyCursorSeekBlob(ProllyCursor *cur,
   return SQLITE_OK;
 }
 
-/* nodeSearchRecord and prollyCursorSeekRecord removed — they were dead code
-** (zero callers).  All index seeks use prollyCursorSeekBlob with sort keys. */
-
-/*
-** Return 1 if cursor is valid (pointing to an entry), 0 otherwise.
-*/
 int prollyCursorIsValid(ProllyCursor *cur){
   return cur->eState==PROLLY_CURSOR_VALID;
 }
 
-/*
-** Get the current blob key from the leaf node the cursor points to.
-*/
 void prollyCursorKey(ProllyCursor *cur, const u8 **ppKey, int *pnKey){
   assert( cur->eState==PROLLY_CURSOR_VALID );
   ProllyCacheEntry *pLeaf = cur->aLevel[cur->iLevel].pEntry;
@@ -479,9 +409,6 @@ void prollyCursorKey(ProllyCursor *cur, const u8 **ppKey, int *pnKey){
   prollyNodeKey(&pLeaf->node, idx, ppKey, pnKey);
 }
 
-/*
-** Get the current integer key from the leaf node.
-*/
 i64 prollyCursorIntKey(ProllyCursor *cur){
   assert( cur->eState==PROLLY_CURSOR_VALID );
   ProllyCacheEntry *pLeaf = cur->aLevel[cur->iLevel].pEntry;
@@ -489,9 +416,6 @@ i64 prollyCursorIntKey(ProllyCursor *cur){
   return prollyNodeIntKey(&pLeaf->node, idx);
 }
 
-/*
-** Get the current value from the leaf node.
-*/
 void prollyCursorValue(ProllyCursor *cur, const u8 **ppVal, int *pnVal){
   assert( cur->eState==PROLLY_CURSOR_VALID );
   ProllyCacheEntry *pLeaf = cur->aLevel[cur->iLevel].pEntry;
@@ -499,17 +423,13 @@ void prollyCursorValue(ProllyCursor *cur, const u8 **ppVal, int *pnVal){
   prollyNodeValue(&pLeaf->node, idx, ppVal, pnVal);
 }
 
-/*
-** Save the current cursor position so it can be restored later.
-** If cursor is not valid, clears hasSavedPosition.
-*/
 int prollyCursorSave(ProllyCursor *cur){
   if( cur->eState!=PROLLY_CURSOR_VALID ){
     cur->hasSavedPosition = 0;
     return SQLITE_OK;
   }
 
-  /* Verify we actually have a valid leaf node to read from */
+  
   if( cur->iLevel < 0 || cur->iLevel >= PROLLY_CURSOR_MAX_DEPTH
    || !cur->aLevel[cur->iLevel].pEntry ){
     cur->hasSavedPosition = 0;
@@ -517,7 +437,7 @@ int prollyCursorSave(ProllyCursor *cur){
     return SQLITE_OK;
   }
 
-  /* Save the key */
+  
   if( cur->flags & PROLLY_NODE_INTKEY ){
     cur->iSavedIntKey = prollyCursorIntKey(cur);
   } else {
@@ -536,7 +456,7 @@ int prollyCursorSave(ProllyCursor *cur){
     cur->nSavedKey = nKey;
   }
 
-  /* Release all node references */
+  
   prollyCursorReleaseAll(cur);
 
   cur->hasSavedPosition = 1;
@@ -544,10 +464,6 @@ int prollyCursorSave(ProllyCursor *cur){
   return SQLITE_OK;
 }
 
-/*
-** Restore cursor to its previously saved position.
-** *pDifferentRow is set to 0 if the exact row was found, 1 otherwise.
-*/
 int prollyCursorRestore(ProllyCursor *cur, int *pDifferentRow){
   int rc;
 
@@ -571,7 +487,7 @@ int prollyCursorRestore(ProllyCursor *cur, int *pDifferentRow){
     *pDifferentRow = 1;
   }
 
-  /* Free saved key */
+  
   if( cur->pSavedKey ){
     sqlite3_free(cur->pSavedKey);
     cur->pSavedKey = 0;
@@ -582,9 +498,6 @@ int prollyCursorRestore(ProllyCursor *cur, int *pDifferentRow){
   return SQLITE_OK;
 }
 
-/*
-** Release all node references held by the cursor's level stack.
-*/
 void prollyCursorReleaseAll(ProllyCursor *cur){
   int i;
   for(i=0; i<PROLLY_CURSOR_MAX_DEPTH; i++){
@@ -596,15 +509,10 @@ void prollyCursorReleaseAll(ProllyCursor *cur){
   }
   cur->nLevel = 0;
   cur->iLevel = 0;
-  /* Mark cursor invalid since all node references are released.
-  ** Without this, prollyCursorIsValid returns true but the cursor
-  ** has no valid node data, causing NULL dereferences. */
+  
   cur->eState = PROLLY_CURSOR_INVALID;
 }
 
-/*
-** Close the cursor and free all resources.
-*/
 void prollyCursorClose(ProllyCursor *cur){
   prollyCursorReleaseAll(cur);
   if( cur->pSavedKey ){
@@ -616,4 +524,4 @@ void prollyCursorClose(ProllyCursor *cur){
   cur->eState = PROLLY_CURSOR_INVALID;
 }
 
-#endif /* DOLTLITE_PROLLY */
+#endif 

--- a/src/prolly_cursor.h
+++ b/src/prolly_cursor.h
@@ -1,4 +1,4 @@
-
+/* B-tree-style cursor over a prolly tree with save/restore for concurrent mutation. */
 #ifndef SQLITE_PROLLY_CURSOR_H
 #define SQLITE_PROLLY_CURSOR_H
 

--- a/src/prolly_cursor.h
+++ b/src/prolly_cursor.h
@@ -1,7 +1,4 @@
-/*
-** Hierarchical cursor for prolly tree traversal.
-** Maintains a stack of (node, index) pairs from root to leaf.
-*/
+
 #ifndef SQLITE_PROLLY_CURSOR_H
 #define SQLITE_PROLLY_CURSOR_H
 
@@ -11,88 +8,69 @@
 #include "prolly_cache.h"
 #include "chunk_store.h"
 
-/* Max tree depth (20 levels = enormous trees) */
 #define PROLLY_CURSOR_MAX_DEPTH 20
 
 typedef struct ProllyCursor ProllyCursor;
 typedef struct ProllyCursorLevel ProllyCursorLevel;
 
 struct ProllyCursorLevel {
-  ProllyCacheEntry *pEntry;   /* Cached node (ref counted) */
-  int idx;                    /* Current item index within node */
+  ProllyCacheEntry *pEntry;   
+  int idx;                    
 };
 
 struct ProllyCursor {
-  ChunkStore *pStore;         /* Chunk store for loading nodes */
-  ProllyCache *pCache;        /* Node cache */
-  ProllyHash root;            /* Root hash of the tree */
-  u8 flags;                   /* PROLLY_NODE_INTKEY or PROLLY_NODE_BLOBKEY */
+  ChunkStore *pStore;         
+  ProllyCache *pCache;        
+  ProllyHash root;            
+  u8 flags;                   
 
-  int nLevel;                 /* Number of levels (tree height) */
-  int iLevel;                 /* Current level index (0=root, nLevel-1=leaf) */
+  int nLevel;                 
+  int iLevel;                 
   ProllyCursorLevel aLevel[PROLLY_CURSOR_MAX_DEPTH];
 
-  u8 eState;                  /* Cursor state: VALID, INVALID, etc. */
+  u8 eState;                  
 
-  /* Saved position for save/restore */
-  u8 *pSavedKey;              /* Saved key for restore */
+  
+  u8 *pSavedKey;              
   int nSavedKey;
-  i64 iSavedIntKey;           /* Saved integer key */
-  u8 hasSavedPosition;        /* True if position is saved */
+  i64 iSavedIntKey;           
+  u8 hasSavedPosition;        
 };
 
-/* Cursor states */
 #define PROLLY_CURSOR_VALID    0
 #define PROLLY_CURSOR_INVALID  1
 #define PROLLY_CURSOR_EOF      2
 
-/* Initialize cursor for a tree */
 void prollyCursorInit(ProllyCursor *cur, ChunkStore *pStore,
                       ProllyCache *pCache, const ProllyHash *pRoot, u8 flags);
 
-/* Move to first entry. *pRes=1 if tree is empty. */
 int prollyCursorFirst(ProllyCursor *cur, int *pRes);
 
-/* Move to last entry. *pRes=1 if tree is empty. */
 int prollyCursorLast(ProllyCursor *cur, int *pRes);
 
-/* Move to next entry. Returns SQLITE_OK; sets eState=EOF at end. */
 int prollyCursorNext(ProllyCursor *cur);
 
-/* Move to previous entry. Returns SQLITE_OK; sets eState=EOF at end. */
 int prollyCursorPrev(ProllyCursor *cur);
 
-/* Seek to integer key (table btree).
-** *pRes: 0=exact, -1=cursor at smaller key, +1=cursor at larger key */
 int prollyCursorSeekInt(ProllyCursor *cur, i64 intKey, int *pRes);
 
-/* Seek to blob key (index btree).
-** *pRes: 0=exact, -1=cursor at smaller key, +1=cursor at larger key */
 int prollyCursorSeekBlob(ProllyCursor *cur,
                          const u8 *pKey, int nKey, int *pRes);
 
-/* Check if cursor is valid (pointing to an entry) */
 int prollyCursorIsValid(ProllyCursor *cur);
 
-/* Get current key (blob key) */
 void prollyCursorKey(ProllyCursor *cur, const u8 **ppKey, int *pnKey);
 
-/* Get current integer key */
 i64 prollyCursorIntKey(ProllyCursor *cur);
 
-/* Get current value */
 void prollyCursorValue(ProllyCursor *cur, const u8 **ppVal, int *pnVal);
 
-/* Save cursor position (for cursor save/restore) */
 int prollyCursorSave(ProllyCursor *cur);
 
-/* Restore cursor to saved position */
 int prollyCursorRestore(ProllyCursor *cur, int *pDifferentRow);
 
-/* Release all node references held by cursor */
 void prollyCursorReleaseAll(ProllyCursor *cur);
 
-/* Close cursor and free resources */
 void prollyCursorClose(ProllyCursor *cur);
 
-#endif /* SQLITE_PROLLY_CURSOR_H */
+#endif 

--- a/src/prolly_diff.c
+++ b/src/prolly_diff.c
@@ -1,20 +1,10 @@
-/*
-** prolly_diff.c — Two-tree diff for prolly trees.
-**
-** Computes the set of changes (ADD, DELETE, MODIFY) between two prolly
-** trees by walking two cursors in parallel, comparing keys in sorted
-** order.  When the root hashes are identical the diff is trivially empty.
-*/
+
 #ifdef DOLTLITE_PROLLY
 
 #include "prolly_diff.h"
 
-#include <string.h>  /* memcmp */
+#include <string.h>  
 
-/*
-** Compare two blob keys lexicographically.
-** Returns <0, 0, or >0.
-*/
 static int diffBlobKeyCmp(
   const u8 *pA, int nA,
   const u8 *pB, int nB
@@ -25,13 +15,6 @@ static int diffBlobKeyCmp(
   return nA - nB;
 }
 
-/*
-** Compare the current keys of two cursors.
-** Sets *pCmp to <0, 0, or >0 following the same convention as memcmp.
-**
-** For INTKEY trees the integer keys are compared directly.
-** For BLOBKEY trees the raw key blobs are compared lexicographically.
-*/
 static void diffCompareKeys(
   ProllyCursor *pOld,
   ProllyCursor *pNew,
@@ -53,17 +36,6 @@ static void diffCompareKeys(
   }
 }
 
-/*
-** Fill a ProllyDiffChange from a single cursor entry.
-**   type     – PROLLY_DIFF_ADD, _DELETE, or _MODIFY
-**   pCur     – cursor positioned at the entry
-**   flags    – INTKEY / BLOBKEY
-**   pChange  – [out] change record to populate
-**
-** Key fields are always set from pCur.  Caller is responsible for
-** setting the value pointers that correspond to the "other" side
-** (pOldVal for ADD, pNewVal for DELETE, or both for MODIFY).
-*/
 static void diffFillKey(
   ProllyDiffChange *pChange,
   ProllyCursor *pCur,
@@ -82,9 +54,6 @@ static void diffFillKey(
   }
 }
 
-/*
-** Emit a DELETE change for the current entry of curOld.
-*/
 static int diffEmitDelete(
   ProllyCursor *pOld,
   u8 flags,
@@ -105,9 +74,6 @@ static int diffEmitDelete(
   return xCallback(pCtx, &change);
 }
 
-/*
-** Emit an ADD change for the current entry of curNew.
-*/
 static int diffEmitAdd(
   ProllyCursor *pNew,
   u8 flags,
@@ -128,9 +94,6 @@ static int diffEmitAdd(
   return xCallback(pCtx, &change);
 }
 
-/*
-** Emit a MODIFY change when the key matches but the value differs.
-*/
 static int diffEmitModify(
   ProllyCursor *pOld,
   ProllyCursor *pNew,
@@ -154,10 +117,6 @@ static int diffEmitModify(
   return xCallback(pCtx, &change);
 }
 
-/*
-** Read a SQLite-format varint from p, not reading past pEnd.
-** Returns the number of bytes consumed, or 0 on error.
-*/
 static int diffReadVarint(const u8 *p, const u8 *pEnd, u64 *pVal){
   u64 v = 0;
   int i;
@@ -176,9 +135,6 @@ static int diffReadVarint(const u8 *p, const u8 *pEnd, u64 *pVal){
   return i ? i : 0;
 }
 
-/*
-** Return the data size in bytes for a given SQLite serial type.
-*/
 static int diffSerialTypeSize(u64 st){
   if( st==0 ) return 0;
   if( st==1 ) return 1;
@@ -194,16 +150,6 @@ static int diffSerialTypeSize(u64 st){
   return 0;
 }
 
-/*
-** Compare two SQLite record-format values field-by-field, treating
-** trailing NULL fields (serial type 0) in the longer record as equal
-** to missing fields in the shorter record.  This handles the case
-** where ALTER TABLE ADD COLUMN causes records to be rewritten with
-** extra trailing NULLs.
-**
-** Returns non-zero if the records are logically equal.
-** Returns 0 (not equal) if either record is malformed.
-*/
 int diffRecordsEqualFieldwise(
   const u8 *pA, int nA,
   const u8 *pB, int nB
@@ -266,12 +212,6 @@ int diffRecordsEqualFieldwise(
   return 1;
 }
 
-/*
-** Return non-zero if the two values at the current cursor positions
-** are identical.  Fast path: same length and same bytes.  Slow path:
-** parse SQLite record format to compare field-by-field, tolerating
-** trailing NULL differences from ALTER TABLE ADD COLUMN.
-*/
 static int diffValuesEqual(ProllyCursor *pOld, ProllyCursor *pNew){
   const u8 *pOldVal; int nOldVal;
   const u8 *pNewVal; int nNewVal;
@@ -285,12 +225,6 @@ static int diffValuesEqual(ProllyCursor *pOld, ProllyCursor *pNew){
   return diffRecordsEqualFieldwise(pOldVal, nOldVal, pNewVal, nNewVal);
 }
 
-/* --------------------------------------------------------------------------
-** Cursor-based merge walk: brute-force diff of two subtrees via cursors.
-** O(N+M) where N and M are the entry counts of the two subtrees.
-** Used as fallback when structural comparison can't skip subtrees
-** (e.g., boundary key mismatches at internal node level).
-** -------------------------------------------------------------------------- */
 static int diffCursorWalk(
   ChunkStore *pStore, ProllyCache *pCache,
   const ProllyHash *pOldRoot, const ProllyHash *pNewRoot,
@@ -350,9 +284,6 @@ walk_done:
   return rc;
 }
 
-/* --------------------------------------------------------------------------
-** Emit all entries under a subtree as ADDs or DELETEs.
-** -------------------------------------------------------------------------- */
 static int diffEmitSubtree(
   ChunkStore *pStore, ProllyCache *pCache,
   const ProllyHash *pRoot, u8 flags, u8 changeType,
@@ -378,9 +309,6 @@ static int diffEmitSubtree(
   return rc;
 }
 
-/* --------------------------------------------------------------------------
-** Compare boundary keys from two internal nodes.
-** -------------------------------------------------------------------------- */
 static int diffNodeKeyCmp(
   const ProllyNode *pA, int iA,
   const ProllyNode *pB, int iB,
@@ -399,9 +327,6 @@ static int diffNodeKeyCmp(
   }
 }
 
-/* --------------------------------------------------------------------------
-** Leaf-level diff: compare entries in two leaf nodes directly.
-** -------------------------------------------------------------------------- */
 static int diffLeaves(
   const ProllyNode *pOld, const ProllyNode *pNew, u8 flags,
   ProllyDiffCallback xCb, void *pCtx
@@ -483,22 +408,6 @@ static int diffLeaves(
   return rc;
 }
 
-/* --------------------------------------------------------------------------
-** Recursive structural diff.
-**
-** Compares two prolly tree nodes top-down, skipping shared subtrees
-** by hash comparison.  For k changes on an N-entry tree of depth d,
-** this visits O(k * d) nodes instead of O(N).
-**
-**   diffNodes(oldHash, newHash):
-**     if oldHash == newHash → return (skip entire subtree!)
-**     load both nodes
-**     if both leaves → compare entries directly
-**     if both internal → merge-walk children:
-**       matching childHash → SKIP (the key optimization)
-**       same boundary key, different childHash → recurse
-**       boundary mismatch → fall back to cursor walk for that range
-** -------------------------------------------------------------------------- */
 static int diffNodes(
   ChunkStore *pStore, ProllyCache *pCache,
   const ProllyHash *pOldHash, const ProllyHash *pNewHash,
@@ -510,10 +419,10 @@ static int diffNodes(
   ProllyNode oldNode, newNode;
   int rc = SQLITE_OK;
 
-  /* Same hash → identical subtree, zero diff */
+  
   if( prollyHashCompare(pOldHash, pNewHash)==0 ) return SQLITE_OK;
 
-  /* Handle empty hashes */
+  
   if( prollyHashIsEmpty(pOldHash) && prollyHashIsEmpty(pNewHash) ) return SQLITE_OK;
   if( prollyHashIsEmpty(pOldHash) ){
     return diffEmitSubtree(pStore, pCache, pNewHash, flags, PROLLY_DIFF_ADD, xCb, pCtx);
@@ -522,7 +431,7 @@ static int diffNodes(
     return diffEmitSubtree(pStore, pCache, pOldHash, flags, PROLLY_DIFF_DELETE, xCb, pCtx);
   }
 
-  /* Load both nodes */
+  
   rc = chunkStoreGet(pStore, pOldHash, &oldData, &nOld);
   if( rc!=SQLITE_OK ) return rc;
   rc = prollyNodeParse(&oldNode, oldData, nOld);
@@ -534,11 +443,11 @@ static int diffNodes(
   if( rc!=SQLITE_OK ){ sqlite3_free(oldData); sqlite3_free(newData); return rc; }
 
   if( oldNode.level==0 && newNode.level==0 ){
-    /* ── Both leaves: direct entry comparison ── */
+    
     rc = diffLeaves(&oldNode, &newNode, flags, xCb, pCtx);
 
   }else if( oldNode.level>0 && newNode.level>0 ){
-    /* ── Both internal: compare children, skip shared subtrees ── */
+    
     int i = 0, j = 0;
 
     while( i < (int)oldNode.nItems && j < (int)newNode.nItems && rc==SQLITE_OK ){
@@ -546,7 +455,7 @@ static int diffNodes(
       prollyNodeChildHash(&oldNode, i, &oldChild);
       prollyNodeChildHash(&newNode, j, &newChild);
 
-      /* THE KEY OPTIMIZATION: skip shared subtrees */
+      
       if( prollyHashCompare(&oldChild, &newChild)==0 ){
         i++; j++;
         continue;
@@ -555,19 +464,12 @@ static int diffNodes(
       int cmp = diffNodeKeyCmp(&oldNode, i, &newNode, j, flags);
 
       if( cmp==0 ){
-        /* Same boundary key, different content → recurse */
+        
         rc = diffNodes(pStore, pCache, &oldChild, &newChild,
                        pOldRoot, pNewRoot, flags, xCb, pCtx);
         i++; j++;
       }else{
-        /* Boundary mismatch: the chunker split differently between old
-        ** and new. We can't pair children 1:1 by boundary key.
-        **
-        ** Correct approach: use cursor walk on the FULL tree roots for
-        ** the remaining range. The cursors need to be positioned past
-        ** the already-processed children (those with matching hashes).
-        ** We use the boundary key of the last matched child as the
-        ** seek target. */
+        
         {
           ProllyCursor *pCO = sqlite3_malloc(sizeof(ProllyCursor));
           ProllyCursor *pCN = sqlite3_malloc(sizeof(ProllyCursor));
@@ -578,7 +480,7 @@ static int diffNodes(
             prollyCursorInit(pCO, pStore, pCache, pOldRoot, flags);
             prollyCursorInit(pCN, pStore, pCache, pNewRoot, flags);
 
-            /* Seek past already-processed children */
+            
             if( i > 0 && (flags & PROLLY_NODE_INTKEY) ){
               i64 seekKey = prollyNodeIntKey(&oldNode, i-1);
               int res;
@@ -604,7 +506,7 @@ static int diffNodes(
               if( rc==SQLITE_OK ) rc = prollyCursorFirst(pCN, &emN);
             }
 
-            /* Merge walk the rest */
+            
             while( rc==SQLITE_OK && prollyCursorIsValid(pCO) && prollyCursorIsValid(pCN) ){
               int keyCmp;
               diffCompareKeys(pCO, pCN, flags, &keyCmp);
@@ -642,14 +544,14 @@ static int diffNodes(
       }
     }
 
-    /* Remaining old children → all deleted */
+    
     while( i < (int)oldNode.nItems && rc==SQLITE_OK ){
       ProllyHash ch;
       prollyNodeChildHash(&oldNode, i, &ch);
       rc = diffEmitSubtree(pStore, pCache, &ch, flags, PROLLY_DIFF_DELETE, xCb, pCtx);
       i++;
     }
-    /* Remaining new children → all added */
+    
     while( j < (int)newNode.nItems && rc==SQLITE_OK ){
       ProllyHash ch;
       prollyNodeChildHash(&newNode, j, &ch);
@@ -658,7 +560,7 @@ static int diffNodes(
     }
 
   }else{
-    /* Level mismatch — shouldn't happen in well-formed trees. Fallback. */
+    
     rc = diffCursorWalk(pStore, pCache, pOldRoot, pNewRoot, flags, xCb, pCtx);
   }
 
@@ -667,14 +569,6 @@ static int diffNodes(
   return rc;
 }
 
-/* --------------------------------------------------------------------------
-** Public API: Structural diff between two prolly trees.
-**
-** Exploits content-addressing to skip shared subtrees.  For k changes
-** on an N-entry tree of depth d, this visits O(k * d) nodes instead
-** of O(N).  Falls back to cursor-based merge walk when chunk boundaries
-** shifted between old and new trees.
-** -------------------------------------------------------------------------- */
 int prollyDiff(
   ChunkStore *pStore,
   ProllyCache *pCache,
@@ -688,4 +582,4 @@ int prollyDiff(
                    pOldRoot, pNewRoot, flags, xCallback, pCtx);
 }
 
-#endif /* DOLTLITE_PROLLY */
+#endif 

--- a/src/prolly_diff.c
+++ b/src/prolly_diff.c
@@ -150,6 +150,9 @@ static int diffSerialTypeSize(u64 st){
   return 0;
 }
 
+/* Compare two SQLite record-format values field-by-field. Returns 1 if
+** equal, 0 otherwise. Needed because records with identical logical content
+** can have different total byte lengths due to varint encoding differences. */
 int diffRecordsEqualFieldwise(
   const u8 *pA, int nA,
   const u8 *pB, int nB
@@ -408,6 +411,10 @@ static int diffLeaves(
   return rc;
 }
 
+/* Recursive node-level diff. Identical child hashes are skipped (structural
+** sharing). When internal keys align, recurse into changed subtrees. When
+** keys diverge (tree shape changed), fall back to a full cursor walk from
+** pOldRoot/pNewRoot -- this handles inserts/deletes that shifted boundaries. */
 static int diffNodes(
   ChunkStore *pStore, ProllyCache *pCache,
   const ProllyHash *pOldHash, const ProllyHash *pNewHash,

--- a/src/prolly_diff.h
+++ b/src/prolly_diff.h
@@ -1,4 +1,4 @@
-
+/* Two-tree diff: walks cursors in parallel to emit ADD/DELETE/MODIFY changes. */
 #ifndef SQLITE_PROLLY_DIFF_H
 #define SQLITE_PROLLY_DIFF_H
 

--- a/src/prolly_diff.h
+++ b/src/prolly_diff.h
@@ -1,8 +1,4 @@
-/*
-** Two-tree diff for prolly trees.
-** Efficiently finds differences between two trees by exploiting
-** structural sharing (identical subtrees have identical hashes).
-*/
+
 #ifndef SQLITE_PROLLY_DIFF_H
 #define SQLITE_PROLLY_DIFF_H
 
@@ -13,42 +9,30 @@
 #include "prolly_cache.h"
 #include "chunk_store.h"
 
-/* Diff change types */
-#define PROLLY_DIFF_ADD     1   /* Key exists in new, not in old */
-#define PROLLY_DIFF_DELETE  2   /* Key exists in old, not in new */
-#define PROLLY_DIFF_MODIFY  3   /* Key exists in both, value changed */
+#define PROLLY_DIFF_ADD     1   
+#define PROLLY_DIFF_DELETE  2   
+#define PROLLY_DIFF_MODIFY  3   
 
 typedef struct ProllyDiff ProllyDiff;
 typedef struct ProllyDiffChange ProllyDiffChange;
 
 struct ProllyDiffChange {
-  u8 type;              /* PROLLY_DIFF_ADD, DELETE, or MODIFY */
-  const u8 *pKey;       /* Key data */
-  int nKey;             /* Key size */
-  i64 intKey;           /* Integer key (if INTKEY) */
-  const u8 *pOldVal;   /* Old value (NULL for ADD) */
+  u8 type;              
+  const u8 *pKey;       
+  int nKey;             
+  i64 intKey;           
+  const u8 *pOldVal;   
   int nOldVal;
-  const u8 *pNewVal;   /* New value (NULL for DELETE) */
+  const u8 *pNewVal;   
   int nNewVal;
 };
 
-/* Callback for each difference found */
 typedef int (*ProllyDiffCallback)(void *pCtx, const ProllyDiffChange *pChange);
 
-/*
-** Compute differences between two trees.
-** Calls xCallback for each difference found.
-** Skips subtrees where hashes match (structural sharing optimization).
-*/
 int prollyDiff(ChunkStore *pStore, ProllyCache *pCache,
                const ProllyHash *pOldRoot, const ProllyHash *pNewRoot,
                u8 flags, ProllyDiffCallback xCallback, void *pCtx);
 
-/*
-** Compare two SQLite record-format values field-by-field, treating
-** trailing NULL fields as equal to missing fields.  Returns non-zero
-** if the records are logically equal.
-*/
 int diffRecordsEqualFieldwise(const u8 *pA, int nA, const u8 *pB, int nB);
 
-#endif /* SQLITE_PROLLY_DIFF_H */
+#endif 

--- a/src/prolly_encoding.h
+++ b/src/prolly_encoding.h
@@ -1,10 +1,4 @@
-/*
-** Shared little-endian encoding/decoding macros for DoltLite.
-**
-** All multi-byte integers in the prolly tree and chunk store are
-** little-endian. These macros provide a single set of helpers
-** instead of duplicating the encoding inline.
-*/
+
 #ifndef PROLLY_ENCODING_H
 #define PROLLY_ENCODING_H
 
@@ -21,4 +15,4 @@
   (p)[2]=(u8)((v)>>16); (p)[3]=(u8)((v)>>24); \
 }while(0)
 
-#endif /* PROLLY_ENCODING_H */
+#endif 

--- a/src/prolly_hash.c
+++ b/src/prolly_hash.c
@@ -1,15 +1,7 @@
 #ifdef DOLTLITE_PROLLY
-/*
-** Prolly tree hashing implementation.
-** SHA-512 based (first 20 bytes, matching Dolt) content-addressed hashing
-** and Buzhash rolling hash splitter.
-*/
+
 #include "prolly_hash.h"
 #include <string.h>
-
-/*****************************************************************************
-** SHA-512 implementation (FIPS 180-4)
-*****************************************************************************/
 
 static u64 sha512_rotr(u64 x, int n){ return (x >> n) | (x << (64 - n)); }
 static u64 sha512_Ch(u64 x, u64 y, u64 z){ return (x & y) ^ (~x & z); }
@@ -86,7 +78,7 @@ static void sha512_hash(const void *data, int len, u8 digest[64]){
     remaining -= 128;
   }
 
-  /* Padding */
+  
   memset(block, 0, 128);
   memcpy(block, p, remaining);
   block[remaining] = 0x80;
@@ -96,7 +88,7 @@ static void sha512_hash(const void *data, int len, u8 digest[64]){
     memset(block, 0, 128);
   }
 
-  /* Length in bits as big-endian u128 (we only need lower 64 bits for len < 2^61) */
+  
   sha512_store64be(block + 120, (u64)len * 8);
 
   sha512_transform(state, block);
@@ -104,19 +96,11 @@ static void sha512_hash(const void *data, int len, u8 digest[64]){
   for(i=0; i<8; i++) sha512_store64be(digest + i*8, state[i]);
 }
 
-/*****************************************************************************
-** Content hash: compute a 20-byte hash using SHA-512 truncated
-*****************************************************************************/
-
 void prollyHashCompute(const void *pData, int nData, ProllyHash *pOut){
   u8 digest[64];
   sha512_hash(pData, nData, digest);
-  memcpy(pOut->data, digest, PROLLY_HASH_SIZE);  /* First 20 bytes */
+  memcpy(pOut->data, digest, PROLLY_HASH_SIZE);  
 }
-
-/*****************************************************************************
-** Hash comparison and utility
-*****************************************************************************/
 
 int prollyHashCompare(const ProllyHash *a, const ProllyHash *b){
   return memcmp(a->data, b->data, PROLLY_HASH_SIZE);
@@ -129,14 +113,6 @@ int prollyHashIsEmpty(const ProllyHash *h){
   }
   return 1;
 }
-
-/*****************************************************************************
-** Buzhash rolling hash
-**
-** Uses a 256-entry table of pseudo-random u32 values and a circular buffer
-** of size windowSize. On each update the outgoing byte is rotated out and
-** the incoming byte is XOR'd in.
-*****************************************************************************/
 
 static const u32 buzHashTable[256] = {
   0x6b326ac4U, 0x13f8e1a8U, 0xb240d8d2U, 0x9a7c5e3fU,
@@ -224,11 +200,11 @@ u32 prollyRollingHashUpdate(ProllyRollingHash *rh, u8 byte){
     rh->filled++;
   }
 
-  /* Rotate left by 1 */
+  
   h = rh->hash;
   h = (h << 1) | (h >> 31);
 
-  /* XOR out the contribution of the outgoing byte (rotated by windowSize) */
+  
   {
     u32 outHash = buzHashTable[outgoing];
     int rot = rh->windowSize % 32;
@@ -236,7 +212,7 @@ u32 prollyRollingHashUpdate(ProllyRollingHash *rh, u8 byte){
     h ^= rotatedOut;
   }
 
-  /* XOR in the incoming byte */
+  
   h ^= buzHashTable[byte];
 
   rh->hash = h;
@@ -263,4 +239,4 @@ void prollyRollingHashFree(ProllyRollingHash *rh){
   }
 }
 
-#endif /* DOLTLITE_PROLLY */
+#endif 

--- a/src/prolly_hash.h
+++ b/src/prolly_hash.h
@@ -1,59 +1,39 @@
-/*
-** Prolly tree hashing: SHA-512 based content addressing (first 20 bytes,
-** matching Dolt) + rolling hash splitter.
-** Part of the Doltite prolly tree storage engine.
-*/
+
 #ifndef SQLITE_PROLLY_HASH_H
 #define SQLITE_PROLLY_HASH_H
 
 #include "sqliteInt.h"
 
-/* Hash output size: 20 bytes (matching Dolt's hash) */
 #define PROLLY_HASH_SIZE 20
 
-/* Hash type */
 typedef struct ProllyHash ProllyHash;
 struct ProllyHash {
   u8 data[PROLLY_HASH_SIZE];
 };
 
-/* Content hash: SHA1-like hash over arbitrary data */
 void prollyHashCompute(const void *pData, int nData, ProllyHash *pOut);
 
-/* Compare two hashes. Returns <0, 0, >0 like memcmp */
 int prollyHashCompare(const ProllyHash *a, const ProllyHash *b);
 
-/* Check if hash is all zeros */
 int prollyHashIsEmpty(const ProllyHash *h);
 
-/*
-** Rolling hash splitter for chunk boundaries.
-** Uses a window-based rolling hash to determine where to split
-** nodes during tree construction.
-*/
 typedef struct ProllyRollingHash ProllyRollingHash;
 struct ProllyRollingHash {
-  u32 hash;           /* Current rolling hash value */
-  int windowSize;     /* Size of the rolling window */
-  int pos;            /* Current position in window buffer */
-  int filled;         /* How many bytes have been fed */
-  u8 *window;         /* Circular buffer [windowSize] */
+  u32 hash;           
+  int windowSize;     
+  int pos;            
+  int filled;         
+  u8 *window;         
 };
 
-/* Initialize rolling hash with given window size */
 int prollyRollingHashInit(ProllyRollingHash *rh, int windowSize);
 
-/* Feed one byte, returns updated hash */
 u32 prollyRollingHashUpdate(ProllyRollingHash *rh, u8 byte);
 
-/* Check if current hash crosses the boundary pattern.
-** pattern is a bitmask; boundary when (hash & pattern) == pattern */
 int prollyRollingHashAtBoundary(ProllyRollingHash *rh, u32 pattern);
 
-/* Reset rolling hash state */
 void prollyRollingHashReset(ProllyRollingHash *rh);
 
-/* Free rolling hash resources */
 void prollyRollingHashFree(ProllyRollingHash *rh);
 
-#endif /* SQLITE_PROLLY_HASH_H */
+#endif 

--- a/src/prolly_hash.h
+++ b/src/prolly_hash.h
@@ -1,4 +1,4 @@
-
+/* 20-byte content hash and rolling hash for content-defined chunking. */
 #ifndef SQLITE_PROLLY_HASH_H
 #define SQLITE_PROLLY_HASH_H
 

--- a/src/prolly_hashset.c
+++ b/src/prolly_hashset.c
@@ -1,7 +1,4 @@
-/*
-** Open-addressing hash set keyed by ProllyHash.
-** Shared by GC mark phase and sync engine.
-*/
+
 #ifdef DOLTLITE_PROLLY
 
 #include "prolly_hashset.h"
@@ -65,7 +62,7 @@ int prollyHashSetAdd(ProllyHashSet *hs, const ProllyHash *h){
       return SQLITE_OK;
     }
     if( memcmp(hs->aSlots[slot].data, h->data, PROLLY_HASH_SIZE)==0 ){
-      return SQLITE_OK; /* already present */
+      return SQLITE_OK; 
     }
   }
   return SQLITE_FULL;
@@ -101,4 +98,4 @@ static int prollyHashSetGrow(ProllyHashSet *hs){
   return SQLITE_OK;
 }
 
-#endif /* DOLTLITE_PROLLY */
+#endif 

--- a/src/prolly_hashset.h
+++ b/src/prolly_hashset.h
@@ -1,7 +1,4 @@
-/*
-** Open-addressing hash set keyed by ProllyHash.
-** Shared by GC mark phase and sync engine.
-*/
+
 #ifndef SQLITE_PROLLY_HASHSET_H
 #define SQLITE_PROLLY_HASHSET_H
 
@@ -9,10 +6,10 @@
 
 typedef struct ProllyHashSet ProllyHashSet;
 struct ProllyHashSet {
-  ProllyHash *aSlots;   /* Hash slot array */
-  u8 *aUsed;            /* 1 if slot is occupied */
-  int nSlots;           /* Total slots (power of 2) */
-  int nUsed;            /* Number of entries */
+  ProllyHash *aSlots;   
+  u8 *aUsed;            
+  int nSlots;           
+  int nUsed;            
 };
 
 int prollyHashSetInit(ProllyHashSet *hs, int nCapacity);
@@ -20,4 +17,4 @@ void prollyHashSetFree(ProllyHashSet *hs);
 int prollyHashSetContains(ProllyHashSet *hs, const ProllyHash *h);
 int prollyHashSetAdd(ProllyHashSet *hs, const ProllyHash *h);
 
-#endif /* SQLITE_PROLLY_HASHSET_H */
+#endif 

--- a/src/prolly_mutate.c
+++ b/src/prolly_mutate.c
@@ -213,6 +213,10 @@ static int mergeLeaf(
   return SQLITE_OK;
 }
 
+/* Streaming merge: skip unmodified subtrees by re-linking their hash at the
+** parent level (prollyChunkerAddAtLevel). Only descend into children whose
+** key range overlaps pending edits. O(M*L) when M << N. Falls through to
+** mergeWalk for height-0 (single-leaf) trees. */
 static int streamingMerge(
   ProllyMutator *pMut
 ){
@@ -268,7 +272,10 @@ static int streamingMerge(
                            pBoundKey, nBoundKey, iBoundKey)
        && (chunker.nLevels == 0
            || chunker.aLevel[0].builder.nItems == 0) ){
-        
+        /* No edits AND level-0 builder is empty (at chunk boundary).
+        ** Re-link child hash at parent level to skip this subtree.
+        ** Cannot skip if level-0 has pending items: that would break
+        ** chunk boundary alignment with the new tree. */
         rc = prollyChunkerAddAtLevel(&chunker, rootNode.level,
                                       pBoundKey, nBoundKey,
                                       pChildVal, nChildVal);
@@ -513,8 +520,10 @@ merge_cleanup:
   return rc;
 }
 
+/* Apply pending edits to produce a new tree root. Chooses between
+** streamingMerge (skips unchanged subtrees, good when M << N) and
+** mergeWalk (full scan, better when M ~ N) based on estimated tree size. */
 int prollyMutateFlush(ProllyMutator *pMut){
-  
   if( prollyMutMapIsEmpty(pMut->pEdits) ){
     memcpy(&pMut->newRoot, &pMut->oldRoot, sizeof(ProllyHash));
     return SQLITE_OK;

--- a/src/prolly_mutate.c
+++ b/src/prolly_mutate.c
@@ -1,40 +1,14 @@
-/*
-** Merge-flush: apply buffered edits from MutMap into an existing prolly tree.
-** This is the core mutation algorithm — it merges sorted edits with the
-** existing tree's leaf entries, then rebuilds the tree using the chunker.
-**
-** The algorithm performs a single sorted merge-walk over two streams:
-**   1. The existing tree's leaf entries (via cursor)
-**   2. The pending edits (via MutMap iterator)
-**
-** The merged output is fed to the chunker, which produces a new set of
-** content-addressed nodes forming the updated tree. Unchanged subtrees
-** are structurally shared with the old tree.
-*/
+
 #ifdef DOLTLITE_PROLLY
 
 #include "prolly_mutate.h"
 #include <string.h>
 
-/*
-** Encode a 64-bit integer as 8 bytes in big-endian format.
-** Used to convert INTKEY values into a sortable byte representation
-** for the chunker and node builder.
-*/
-/*
-** Encode a signed 64-bit integer as 8 bytes in BIG-ENDIAN order.
-** Big-endian is required so that memcmp on encoded keys gives the
-** same order as numeric comparison — the prolly tree relies on
-** lexicographic key ordering.
-**
-** For signed integers, we XOR the sign bit so that negative values
-** sort before positive values in unsigned byte comparison:
-**   -1 → 7F FF FF FF FF FF FF FF
-**    0 → 80 00 00 00 00 00 00 00
-**    1 → 80 00 00 00 00 00 00 01
-*/
+/* Encode signed i64 as big-endian sort key. XOR sign bit so memcmp gives
+** correct signed ordering. BIG-ENDIAN despite the rest of the system being
+** little-endian -- sort keys must compare correctly under byte-wise memcmp. */
 static void encodeI64BE(u8 *buf, i64 v){
-  u64 u = (u64)v ^ ((u64)1 << 63);  /* flip sign bit */
+  u64 u = (u64)v ^ ((u64)1 << 63);
   buf[0] = (u8)(u >> 56);
   buf[1] = (u8)(u >> 48);
   buf[2] = (u8)(u >> 40);
@@ -45,20 +19,8 @@ static void encodeI64BE(u8 *buf, i64 v){
   buf[7] = (u8)(u);
 }
 
-/*
-** Estimated entries per leaf node, used for tree size estimation
-** in the merge-vs-apply heuristic.
-*/
 #define PROLLY_EST_ENTRIES_PER_LEAF 50
 
-/*
-** Compare two keys according to the node flags.
-**
-** For INTKEY tables: compare the 64-bit integer keys.
-** For BLOBKEY tables: keys are sort keys — memcmp gives correct order.
-**
-** Returns negative if key1 < key2, zero if equal, positive if key1 > key2.
-*/
 static int compareKeys(
   u8 flags,
   const u8 *pKey1, int nKey1, i64 iKey1,
@@ -78,14 +40,6 @@ static int compareKeys(
   }
 }
 
-/*
-** Feed a single key-value pair into the chunker.
-**
-** For INTKEY tables the key is serialized as an 8-byte big-endian i64
-** so that the chunker (which works on raw bytes) receives a sortable key
-** representation.  For BLOBKEY tables the key bytes are passed through
-** directly.
-*/
 static int feedChunker(
   ProllyChunker *pCh,
   u8 flags,
@@ -93,7 +47,7 @@ static int feedChunker(
   const u8 *pVal, int nVal
 ){
   if( flags & PROLLY_NODE_INTKEY ){
-    /* Encode integer key as 8-byte big-endian for the chunker. */
+    
     u8 aKeyBuf[8];
     encodeI64BE(aKeyBuf, intKey);
     return prollyChunkerAdd(pCh, aKeyBuf, 8, pVal, nVal);
@@ -102,14 +56,6 @@ static int feedChunker(
   }
 }
 
-/*
-** Build a new tree from scratch using only the edits in the MutMap.
-** This is used when the old tree is empty (oldRoot is all-zeros).
-**
-** We simply iterate over all edits in sorted order. INSERT edits are
-** fed to the chunker; DELETE edits are silently ignored (there is
-** nothing to delete in an empty tree).
-*/
 static int buildFromEdits(
   ProllyMutator *pMut
 ){
@@ -146,12 +92,6 @@ static int buildFromEdits(
 
 static int mergeWalk(ProllyMutator *pMut);
 
-/*
-** Check if the next edit key is within a subtree's key range.
-** Returns 1 if the edit key <= the subtree's boundary key (has edits),
-** 0 if the edit key > boundary key (no edits in this subtree).
-** If no edits remain, returns 0.
-*/
 static int subtreeHasEdits(
   u8 flags,
   ProllyMutMapIter *pIter,
@@ -163,14 +103,9 @@ static int subtreeHasEdits(
   pEd = prollyMutMapIterEntry(pIter);
   cmp = compareKeys(flags, pEd->pKey, pEd->nKey, pEd->intKey,
                     pBoundKey, nBoundKey, iBoundKey);
-  return (cmp <= 0);  /* edit key <= boundary key means edits in this subtree */
+  return (cmp <= 0);  
 }
 
-/*
-** Merge a single leaf node's entries with the edit iterator.
-** Feeds merged entries into the chunker at level 0.
-** Advances the edit iterator past all edits consumed.
-*/
 static int mergeLeaf(
   ProllyMutator *pMut,
   ProllyNode *pLeaf,
@@ -198,7 +133,7 @@ static int mergeLeaf(
     }
 
     if( !haveEdit ){
-      /* No more edits — emit remaining leaf entries */
+      
       const u8 *pVal; int nVal;
       prollyNodeValue(pLeaf, j, &pVal, &nVal);
       rc = prollyChunkerAdd(pCh, pCurKey, nCurKey, pVal, nVal);
@@ -207,7 +142,7 @@ static int mergeLeaf(
       continue;
     }
 
-    /* Check if edit is past this leaf */
+    
     {
       const u8 *pLastKey; int nLastKey;
       i64 iLastKey = 0;
@@ -222,7 +157,7 @@ static int mergeLeaf(
       int pastLeaf = compareKeys(flags, pEd->pKey, pEd->nKey, pEd->intKey,
                                  pLastKey, nLastKey, iLastKey);
       if( pastLeaf > 0 ){
-        /* Edit is past this leaf — emit remaining entries and return */
+        
         const u8 *pVal; int nVal;
         prollyNodeValue(pLeaf, j, &pVal, &nVal);
         rc = prollyChunkerAdd(pCh, pCurKey, nCurKey, pVal, nVal);
@@ -232,18 +167,18 @@ static int mergeLeaf(
       }
     }
 
-    /* Compare current entry with edit */
+    
     int cmp = compareKeys(flags, pCurKey, nCurKey, iCurKey,
                           pEd->pKey, pEd->nKey, pEd->intKey);
     if( cmp < 0 ){
-      /* Old entry first */
+      
       const u8 *pVal; int nVal;
       prollyNodeValue(pLeaf, j, &pVal, &nVal);
       rc = prollyChunkerAdd(pCh, pCurKey, nCurKey, pVal, nVal);
       if( rc!=SQLITE_OK ) return rc;
       j++;
     }else if( cmp == 0 ){
-      /* Replace or delete */
+      
       if( pEd->op==PROLLY_EDIT_INSERT ){
         u8 aEditKey[8];
         const u8 *pEK; int nEK;
@@ -259,7 +194,7 @@ static int mergeLeaf(
       j++;
       prollyMutMapIterNext(pIter);
     }else{
-      /* Insert new entry before old */
+      
       if( pEd->op==PROLLY_EDIT_INSERT ){
         u8 aEditKey[8];
         const u8 *pEK; int nEK;
@@ -278,17 +213,6 @@ static int mergeLeaf(
   return SQLITE_OK;
 }
 
-/*
-** Streaming merge: walk the old tree's internal nodes alongside the edit
-** iterator. Skip unchanged subtrees by emitting their hash directly at
-** the parent level. Only descend into subtrees that contain edits.
-**
-** For height-1 trees (root → leaves): O(M * L + S) where M = edits,
-** L = leaf size, S = number of skipped subtrees. Much faster than
-** mergeWalk's O(N + M) when M << N.
-**
-** For height-0 trees (leaf root): falls through to mergeWalk.
-*/
 static int streamingMerge(
   ProllyMutator *pMut
 ){
@@ -300,7 +224,7 @@ static int streamingMerge(
   ProllyNode rootNode;
   ProllyCache *pCache = pMut->pCache;
 
-  /* Load root node */
+  
   rc = chunkStoreGet(pMut->pStore, &pMut->oldRoot, &pRootData, &nRootData);
   if( rc!=SQLITE_OK ) return rc;
   rc = prollyNodeParse(&rootNode, pRootData, nRootData);
@@ -309,7 +233,7 @@ static int streamingMerge(
     return rc;
   }
 
-  /* Height-0 tree: single leaf, use mergeWalk */
+  
   if( rootNode.level == 0 ){
     sqlite3_free(pRootData);
     return mergeWalk(pMut);
@@ -322,7 +246,7 @@ static int streamingMerge(
     return rc;
   }
 
-  /* Walk root node's children (level-1 entries) */
+  
   {
     int i;
     for( i = 0; i < rootNode.nItems; i++ ){
@@ -344,18 +268,15 @@ static int streamingMerge(
                            pBoundKey, nBoundKey, iBoundKey)
        && (chunker.nLevels == 0
            || chunker.aLevel[0].builder.nItems == 0) ){
-        /* No edits in this subtree AND level-0 is empty (naturally
-        ** at a chunk boundary). Skip by emitting hash at parent level.
-        ** If level-0 has pending items, we must descend to preserve
-        ** chunk boundary alignment with the original tree. */
+        
         rc = prollyChunkerAddAtLevel(&chunker, rootNode.level,
                                       pBoundKey, nBoundKey,
                                       pChildVal, nChildVal);
         if( rc!=SQLITE_OK ) goto streaming_cleanup;
       }else{
-        /* Subtree has edits — load child and merge at leaf level */
+        
         if( rootNode.level == 1 ){
-          /* Child is a leaf — merge directly */
+          
           ProllyHash childHash;
           ProllyCacheEntry *pChildEntry;
           u8 *pChildData = 0;
@@ -376,8 +297,7 @@ static int streamingMerge(
           prollyCacheRelease(pCache, pChildEntry);
           if( rc!=SQLITE_OK ) goto streaming_cleanup;
         }else{
-          /* TODO: recurse for height > 2 trees. For now, fall back
-          ** to walking all entries in this subtree. */
+          
           ProllyCursor subCur;
           ProllyHash childHash;
           int subEmpty;
@@ -403,7 +323,7 @@ static int streamingMerge(
             }
             prollyCursorValue(&subCur, &pV, &nV);
 
-            /* Check if current entry should be merged with edit */
+            
             if( prollyMutMapIterValid(&iter) ){
               ProllyMutMapEntry *pEd = prollyMutMapIterEntry(&iter);
               int cmp = compareKeys(pMut->flags, pK, nK, iK,
@@ -445,7 +365,7 @@ static int streamingMerge(
     }
   }
 
-  /* Handle remaining edits past the tree's last key */
+  
   while( prollyMutMapIterValid(&iter) ){
     ProllyMutMapEntry *pEd = prollyMutMapIterEntry(&iter);
     if( pEd->op==PROLLY_EDIT_INSERT ){
@@ -468,11 +388,6 @@ streaming_cleanup:
   return rc;
 }
 
-/*
-** Merge-walk the existing tree with the edit map and produce a new tree.
-** O(N + M) — walks every entry regardless of edit count.
-** Used when M is large relative to N (hybrid flush fallback).
-*/
 static int mergeWalk(
   ProllyMutator *pMut
 ){
@@ -484,7 +399,7 @@ static int mergeWalk(
   int curValid;
   int iterValid;
 
-  /* prollyCursorInit returns void — it just sets fields, cannot fail. */
+  
   prollyCursorInit(&cur, pMut->pStore, pMut->pCache,
                    &pMut->oldRoot, pMut->flags);
   rc = prollyCursorFirst(&cur, &curEmpty);
@@ -598,40 +513,24 @@ merge_cleanup:
   return rc;
 }
 
-/*
-** Apply all edits in pMut->pEdits to the tree rooted at pMut->oldRoot.
-** Produces a new tree whose root hash is stored in pMut->newRoot.
-**
-** Three cases:
-**   1. No edits: newRoot = oldRoot (no work).
-**   2. Old tree is empty: build from edits alone.
-**   3. Otherwise: merge-walk old tree + edits.
-**
-** Returns SQLITE_OK on success with result in pMut->newRoot.
-*/
 int prollyMutateFlush(ProllyMutator *pMut){
-  /* Case 1: no edits — the tree is unchanged */
+  
   if( prollyMutMapIsEmpty(pMut->pEdits) ){
     memcpy(&pMut->newRoot, &pMut->oldRoot, sizeof(ProllyHash));
     return SQLITE_OK;
   }
 
-  /* Case 2: old tree is empty — build entirely from edits */
+  
   if( prollyHashIsEmpty(&pMut->oldRoot) ){
     return buildFromEdits(pMut);
   }
 
-  /* Case 3: pick strategy based on edit count vs tree size.
-  **
-  ** streamingMerge: O(M * L) — skips unchanged subtrees, great when M << N
-  ** mergeWalk:      O(N + M) — walks all entries, better when M ≈ N
-  **
-  ** Estimate N from the root node to choose the threshold. */
+  
   {
     int M = prollyMutMapCount(pMut->pEdits);
     int N = 0;
 
-    /* Load root to estimate N */
+    
     u8 *pRootData = 0;
     int nRootData = 0;
     int rcEst = chunkStoreGet(pMut->pStore, &pMut->oldRoot,
@@ -644,7 +543,7 @@ int prollyMutateFlush(ProllyMutator *pMut){
         }else if( rootNode.level==1 ){
           N = rootNode.nItems * PROLLY_EST_ENTRIES_PER_LEAF;
         }else{
-          /* Height >= 2: large tree */
+          
           int factor = 1;
           int lv;
           for(lv = 0; lv < rootNode.level; lv++) factor *= PROLLY_EST_ENTRIES_PER_LEAF;
@@ -654,19 +553,15 @@ int prollyMutateFlush(ProllyMutator *pMut){
       sqlite3_free(pRootData);
     }
 
-    /* Threshold: use mergeWalk when edits exceed ~50% of estimated tree size.
-    ** With sort key encoding, BLOBKEY comparison is memcmp (same cost as
-    ** INTKEY), so both table types use the same threshold. */
+    
     int threshold;
     if( N <= 0 ){
-      threshold = 1000;  /* Fallback if estimation fails */
+      threshold = 1000;  
     }else{
       threshold = N / 2;
     }
 
-    /* Use streamingMerge for small edit sets — it skips unchanged
-    ** subtrees for O(M * L) instead of mergeWalk's O(N + M).
-    ** Fall back to mergeWalk when edits are a large fraction of the tree. */
+    
     if( M > threshold ){
       return mergeWalk(pMut);
     }else{
@@ -675,12 +570,6 @@ int prollyMutateFlush(ProllyMutator *pMut){
   }
 }
 
-/*
-** Convenience function: apply a single INSERT to a tree.
-**
-** Creates a temporary 1-entry MutMap, wraps it in a ProllyMutator,
-** calls prollyMutateFlush, and returns the new root hash.
-*/
 int prollyMutateInsert(
   ChunkStore *pStore,
   ProllyCache *pCache,
@@ -695,7 +584,7 @@ int prollyMutateInsert(
   int rc;
   u8 isIntKey = (flags & PROLLY_NODE_INTKEY) ? 1 : 0;
 
-  /* Initialize a 1-entry edit map with the INSERT */
+  
   rc = prollyMutMapInit(&mm, isIntKey);
   if( rc!=SQLITE_OK ) return rc;
 
@@ -705,7 +594,7 @@ int prollyMutateInsert(
     return rc;
   }
 
-  /* Set up the mutator */
+  
   memset(&mut, 0, sizeof(mut));
   mut.pStore = pStore;
   mut.pCache = pCache;
@@ -713,7 +602,7 @@ int prollyMutateInsert(
   mut.pEdits = &mm;
   mut.flags = flags;
 
-  /* Flush */
+  
   rc = prollyMutateFlush(&mut);
   if( rc==SQLITE_OK ){
     memcpy(pNewRoot, &mut.newRoot, sizeof(ProllyHash));
@@ -723,12 +612,6 @@ int prollyMutateInsert(
   return rc;
 }
 
-/*
-** Convenience function: apply a single DELETE to a tree.
-**
-** Creates a temporary 1-entry MutMap with a DELETE edit, wraps it in a
-** ProllyMutator, calls prollyMutateFlush, and returns the new root hash.
-*/
 int prollyMutateDelete(
   ChunkStore *pStore,
   ProllyCache *pCache,
@@ -742,7 +625,7 @@ int prollyMutateDelete(
   int rc;
   u8 isIntKey = (flags & PROLLY_NODE_INTKEY) ? 1 : 0;
 
-  /* Initialize a 1-entry edit map with the DELETE */
+  
   rc = prollyMutMapInit(&mm, isIntKey);
   if( rc!=SQLITE_OK ) return rc;
 
@@ -752,7 +635,7 @@ int prollyMutateDelete(
     return rc;
   }
 
-  /* Set up the mutator */
+  
   memset(&mut, 0, sizeof(mut));
   mut.pStore = pStore;
   mut.pCache = pCache;
@@ -760,7 +643,7 @@ int prollyMutateDelete(
   mut.pEdits = &mm;
   mut.flags = flags;
 
-  /* Flush */
+  
   rc = prollyMutateFlush(&mut);
   if( rc==SQLITE_OK ){
     memcpy(pNewRoot, &mut.newRoot, sizeof(ProllyHash));
@@ -770,4 +653,4 @@ int prollyMutateDelete(
   return rc;
 }
 
-#endif /* DOLTLITE_PROLLY */
+#endif 

--- a/src/prolly_mutate.h
+++ b/src/prolly_mutate.h
@@ -1,4 +1,4 @@
-
+/* Tree mutation: apply sorted edit map to produce a new content-addressed root. */
 #ifndef SQLITE_PROLLY_MUTATE_H
 #define SQLITE_PROLLY_MUTATE_H
 

--- a/src/prolly_mutate.h
+++ b/src/prolly_mutate.h
@@ -1,8 +1,4 @@
-/*
-** Merge-flush: apply buffered edits from MutMap into an existing prolly tree.
-** This is the hardest piece — it merges sorted edits with the existing
-** tree's leaf entries, then rebuilds the tree using the chunker.
-*/
+
 #ifndef SQLITE_PROLLY_MUTATE_H
 #define SQLITE_PROLLY_MUTATE_H
 
@@ -20,47 +16,23 @@ typedef struct ProllyMutator ProllyMutator;
 struct ProllyMutator {
   ChunkStore *pStore;
   ProllyCache *pCache;
-  ProllyHash oldRoot;       /* Root of the existing tree */
-  ProllyMutMap *pEdits;     /* Pending edits */
-  u8 flags;                 /* INTKEY or BLOBKEY */
-  ProllyHash newRoot;       /* Result root after flush */
+  ProllyHash oldRoot;       
+  ProllyMutMap *pEdits;     
+  u8 flags;                 
+  ProllyHash newRoot;       
 };
 
-/*
-** Apply all edits in pEdits to the tree rooted at oldRoot.
-** Produces a new tree (newRoot) with edits applied.
-** The old tree's chunks are preserved (structural sharing).
-**
-** Algorithm:
-**   1. Open cursor on existing tree
-**   2. Open iterator on edit map
-**   3. Merge-walk both in sorted order:
-**      - Existing entries not touched by edits pass through
-**      - INSERT edits replace or add entries
-**      - DELETE edits skip existing entries
-**   4. Feed merged stream to chunker to build new tree
-**   5. Return new root hash
-**
-** Returns SQLITE_OK on success with result in pMut->newRoot.
-*/
 int prollyMutateFlush(ProllyMutator *pMut);
 
-/*
-** Convenience: apply a single insert to a tree.
-** Builds a 1-entry MutMap internally.
-*/
 int prollyMutateInsert(ChunkStore *pStore, ProllyCache *pCache,
                        const ProllyHash *pRoot, u8 flags,
                        const u8 *pKey, int nKey, i64 intKey,
                        const u8 *pVal, int nVal,
                        ProllyHash *pNewRoot);
 
-/*
-** Convenience: apply a single delete to a tree.
-*/
 int prollyMutateDelete(ChunkStore *pStore, ProllyCache *pCache,
                        const ProllyHash *pRoot, u8 flags,
                        const u8 *pKey, int nKey, i64 intKey,
                        ProllyHash *pNewRoot);
 
-#endif /* SQLITE_PROLLY_MUTATE_H */
+#endif 

--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -1,11 +1,4 @@
-/*
-** Mutable map implementation: sorted array for buffering pending edits
-** before tree flush. Supports insert, delete, find, and ordered iteration.
-**
-** Sorted array gives O(log M) find, O(M) insert (shift), O(M) clone
-** (memcpy + key/val copy). For typical M <= 256, this is faster than
-** the previous skip list which had O(M log M) clone cost.
-*/
+
 #ifdef DOLTLITE_PROLLY
 
 #include "prolly_mutmap.h"
@@ -14,9 +7,6 @@
 
 #define MUTMAP_INIT_CAP 16
 
-/*
-** Compare two keys using the shared comparator from prolly_node.c.
-*/
 static int compareEntries(
   u8 isIntKey,
   const u8 *pKeyA, int nKeyA, i64 intKeyA,
@@ -27,10 +17,6 @@ static int compareEntries(
                            pKeyB, nKeyB, intKeyB);
 }
 
-/*
-** Free the key and value buffers of an entry (but not the entry itself,
-** since entries are stored inline in the array).
-*/
 static void freeEntryData(ProllyMutMapEntry *e){
   sqlite3_free(e->pKey);
   sqlite3_free(e->pVal);
@@ -40,10 +26,6 @@ static void freeEntryData(ProllyMutMapEntry *e){
   e->nVal = 0;
 }
 
-/*
-** Copy key and value data into an entry. The entry's op, isIntKey,
-** and intKey must already be set.
-*/
 static int copyEntryData(ProllyMutMapEntry *e,
                          const u8 *pKey, int nKey,
                          const u8 *pVal, int nVal){
@@ -70,10 +52,6 @@ static int copyEntryData(ProllyMutMapEntry *e,
   return SQLITE_OK;
 }
 
-/*
-** Binary search for a key. Returns the index where the key is found
-** or should be inserted. Sets *pFound to 1 if an exact match exists.
-*/
 static int bsearch_key(ProllyMutMap *mm,
                        const u8 *pKey, int nKey, i64 intKey,
                        int *pFound){
@@ -97,9 +75,6 @@ static int bsearch_key(ProllyMutMap *mm,
   return lo;
 }
 
-/*
-** Ensure the array has capacity for at least one more entry.
-*/
 static int ensureCapacity(ProllyMutMap *mm){
   if( mm->nEntries >= mm->nAlloc ){
     int nNew = mm->nAlloc ? mm->nAlloc * 2 : MUTMAP_INIT_CAP;
@@ -112,18 +87,12 @@ static int ensureCapacity(ProllyMutMap *mm){
   return SQLITE_OK;
 }
 
-/*
-** Initialize a mutable map.
-*/
 int prollyMutMapInit(ProllyMutMap *mm, u8 isIntKey){
   memset(mm, 0, sizeof(*mm));
   mm->isIntKey = isIntKey;
   return SQLITE_OK;
 }
 
-/*
-** Insert or update a key-value pair.
-*/
 int prollyMutMapInsert(
   ProllyMutMap *mm,
   const u8 *pKey, int nKey, i64 intKey,
@@ -134,7 +103,7 @@ int prollyMutMapInsert(
   idx = bsearch_key(mm, pKey, nKey, intKey, &found);
 
   if( found ){
-    /* Update existing entry */
+    
     ProllyMutMapEntry *e = &mm->aEntries[idx];
     e->op = PROLLY_EDIT_INSERT;
     sqlite3_free(e->pVal);
@@ -149,17 +118,17 @@ int prollyMutMapInsert(
     return SQLITE_OK;
   }
 
-  /* New entry: grow array if needed, shift entries right, insert */
+  
   rc = ensureCapacity(mm);
   if( rc!=SQLITE_OK ) return rc;
 
-  /* Shift entries at idx..nEntries-1 right by 1 */
+  
   if( idx < mm->nEntries ){
     memmove(&mm->aEntries[idx+1], &mm->aEntries[idx],
             (mm->nEntries - idx) * sizeof(ProllyMutMapEntry));
   }
 
-  /* Initialize the new entry */
+  
   {
     ProllyMutMapEntry *e = &mm->aEntries[idx];
     memset(e, 0, sizeof(*e));
@@ -168,7 +137,7 @@ int prollyMutMapInsert(
     e->intKey = intKey;
     rc = copyEntryData(e, pKey, nKey, pVal, nVal);
     if( rc!=SQLITE_OK ){
-      /* Shift back on failure */
+      
       if( idx < mm->nEntries ){
         memmove(&mm->aEntries[idx], &mm->aEntries[idx+1],
                 (mm->nEntries - idx) * sizeof(ProllyMutMapEntry));
@@ -181,9 +150,6 @@ int prollyMutMapInsert(
   return SQLITE_OK;
 }
 
-/*
-** Mark a key for deletion.
-*/
 int prollyMutMapDelete(
   ProllyMutMap *mm,
   const u8 *pKey, int nKey, i64 intKey
@@ -195,18 +161,18 @@ int prollyMutMapDelete(
   if( found ){
     ProllyMutMapEntry *e = &mm->aEntries[idx];
     if( e->op == PROLLY_EDIT_INSERT ){
-      /* Convert INSERT to DELETE */
+      
       e->op = PROLLY_EDIT_DELETE;
       sqlite3_free(e->pVal);
       e->pVal = 0;
       e->nVal = 0;
       return SQLITE_OK;
     }
-    /* Already a DELETE */
+    
     return SQLITE_OK;
   }
 
-  /* New DELETE entry */
+  
   rc = ensureCapacity(mm);
   if( rc!=SQLITE_OK ) return rc;
 
@@ -235,9 +201,6 @@ int prollyMutMapDelete(
   return SQLITE_OK;
 }
 
-/*
-** Look up a key. Returns entry pointer or NULL.
-*/
 ProllyMutMapEntry *prollyMutMapFind(ProllyMutMap *mm,
                                      const u8 *pKey, int nKey, i64 intKey){
   int found, idx;
@@ -283,9 +246,6 @@ void prollyMutMapIterLast(ProllyMutMapIter *it, ProllyMutMap *mm){
   it->idx = mm->nEntries - 1;
 }
 
-/*
-** Clear all entries.
-*/
 void prollyMutMapClear(ProllyMutMap *mm){
   int i;
   for(i=0; i<mm->nEntries; i++){
@@ -294,9 +254,6 @@ void prollyMutMapClear(ProllyMutMap *mm){
   mm->nEntries = 0;
 }
 
-/*
-** Free all resources.
-*/
 void prollyMutMapFree(ProllyMutMap *mm){
   prollyMutMapClear(mm);
   sqlite3_free(mm->aEntries);
@@ -304,9 +261,6 @@ void prollyMutMapFree(ProllyMutMap *mm){
   mm->nAlloc = 0;
 }
 
-/*
-** Merge all entries from pSrc into pDst. pSrc is emptied.
-*/
 int prollyMutMapMerge(ProllyMutMap *pDst, ProllyMutMap *pSrc){
   int i, rc;
   for(i=0; i<pSrc->nEntries; i++){
@@ -323,4 +277,4 @@ int prollyMutMapMerge(ProllyMutMap *pDst, ProllyMutMap *pSrc){
   return SQLITE_OK;
 }
 
-#endif /* DOLTLITE_PROLLY */
+#endif 

--- a/src/prolly_mutmap.h
+++ b/src/prolly_mutmap.h
@@ -1,13 +1,9 @@
-/*
-** Mutable map: sorted array for buffering pending edits before tree flush.
-** Supports insert, delete, find (binary search), and ordered iteration.
-*/
+
 #ifndef SQLITE_PROLLY_MUTMAP_H
 #define SQLITE_PROLLY_MUTMAP_H
 
 #include "sqliteInt.h"
 
-/* Edit operation types */
 #define PROLLY_EDIT_INSERT 1
 #define PROLLY_EDIT_DELETE 2
 
@@ -16,78 +12,60 @@ typedef struct ProllyMutMapEntry ProllyMutMapEntry;
 typedef struct ProllyMutMapIter ProllyMutMapIter;
 
 struct ProllyMutMapEntry {
-  u8 op;                 /* PROLLY_EDIT_INSERT or PROLLY_EDIT_DELETE */
-  u8 isIntKey;           /* True if integer key */
-  i64 intKey;            /* Integer key (for INTKEY tables) */
-  u8 *pKey;              /* Blob key data (for INDEX tables) */
-  int nKey;              /* Blob key size */
-  u8 *pVal;              /* Value data (NULL for delete) */
-  int nVal;              /* Value size */
+  u8 op;                 
+  u8 isIntKey;           
+  i64 intKey;            
+  u8 *pKey;              
+  int nKey;              
+  u8 *pVal;              
+  int nVal;              
 };
 
 struct ProllyMutMap {
-  u8 isIntKey;            /* Table type */
-  int nEntries;           /* Number of entries */
-  int nAlloc;             /* Allocated capacity */
-  ProllyMutMapEntry *aEntries;  /* Sorted array of entries */
+  u8 isIntKey;            
+  int nEntries;           
+  int nAlloc;             
+  ProllyMutMapEntry *aEntries;  
 };
 
-/* Initialize a mutable map */
 int prollyMutMapInit(ProllyMutMap *mm, u8 isIntKey);
 
-/* Insert or update a key-value pair. Copies key and value data. */
 int prollyMutMapInsert(ProllyMutMap *mm,
                        const u8 *pKey, int nKey, i64 intKey,
                        const u8 *pVal, int nVal);
 
-/* Mark a key for deletion */
 int prollyMutMapDelete(ProllyMutMap *mm,
                        const u8 *pKey, int nKey, i64 intKey);
 
-/* Look up a key. Returns the entry if found, NULL if not.
-** For INTKEY: pass intKey. For BLOBKEY: pass pKey/nKey. */
 ProllyMutMapEntry *prollyMutMapFind(ProllyMutMap *mm,
                                      const u8 *pKey, int nKey, i64 intKey);
 
-/* Get number of pending edits */
 int prollyMutMapCount(ProllyMutMap *mm);
 
-/* Check if map is empty */
 int prollyMutMapIsEmpty(ProllyMutMap *mm);
 
-/* Iterator for ordered traversal */
 struct ProllyMutMapIter {
   ProllyMutMap *pMap;
-  int idx;               /* Current index into aEntries */
+  int idx;               
 };
 
-/* Initialize iterator at first entry */
 void prollyMutMapIterFirst(ProllyMutMapIter *it, ProllyMutMap *mm);
 
-/* Advance iterator */
 void prollyMutMapIterNext(ProllyMutMapIter *it);
 
-/* Check if iterator is valid */
 int prollyMutMapIterValid(ProllyMutMapIter *it);
 
-/* Get current entry from iterator */
 ProllyMutMapEntry *prollyMutMapIterEntry(ProllyMutMapIter *it);
 
-/* Seek iterator to first entry >= given key (binary search).
-** If no entry >= key, iterator is positioned past end. */
 void prollyMutMapIterSeek(ProllyMutMapIter *it, ProllyMutMap *mm,
                           const u8 *pKey, int nKey, i64 intKey);
 
-/* Position iterator at last entry */
 void prollyMutMapIterLast(ProllyMutMapIter *it, ProllyMutMap *mm);
 
-/* Merge all entries from pSrc into pDst. pSrc is emptied. */
 int prollyMutMapMerge(ProllyMutMap *pDst, ProllyMutMap *pSrc);
 
-/* Clear all entries */
 void prollyMutMapClear(ProllyMutMap *mm);
 
-/* Free all resources */
 void prollyMutMapFree(ProllyMutMap *mm);
 
-#endif /* SQLITE_PROLLY_MUTMAP_H */
+#endif 

--- a/src/prolly_mutmap.h
+++ b/src/prolly_mutmap.h
@@ -1,4 +1,4 @@
-
+/* Sorted map of pending INSERT/DELETE edits, consumed by prolly_mutate. */
 #ifndef SQLITE_PROLLY_MUTMAP_H
 #define SQLITE_PROLLY_MUTMAP_H
 

--- a/src/prolly_node.c
+++ b/src/prolly_node.c
@@ -1,51 +1,33 @@
-/*
-** Prolly tree node: binary serialization and deserialization for prolly
-** map nodes. Content-addressed immutable nodes for the Doltite storage engine.
-*/
+
 #ifdef DOLTLITE_PROLLY
 
 #include "prolly_node.h"
 #include "prolly_encoding.h"
 #include <string.h>
 
-/*
-** Header layout constants.
-*/
-#define PROLLY_HDR_SIZE       8   /* magic(4) + level(1) + count(2) + flags(1) */
+#define PROLLY_HDR_SIZE       8   
 #define PROLLY_MAGIC_OFF      0
 #define PROLLY_LEVEL_OFF      4
 #define PROLLY_COUNT_OFF      5
 #define PROLLY_FLAGS_OFF      7
 
-/*
-** Parse a serialized prolly node from raw bytes.
-**
-** Layout:
-**   [magic:4][level:1][count:2][flags:1]   = 8 bytes header
-**   [keyOffsets: u32 * (count+1)]
-**   [valOffsets: u32 * (count+1)]
-**   [key data: variable]
-**   [value data: variable]
-**
-** Returns SQLITE_OK on success, SQLITE_CORRUPT if the data is malformed.
-*/
 int prollyNodeParse(ProllyNode *pNode, const u8 *pData, int nData){
   u32 magic;
   u16 count;
-  int nOffsets;        /* total bytes consumed by both offset arrays */
-  int minSize;         /* minimum valid buffer size */
-  u32 totalKeyBytes;   /* last key offset = total key bytes */
-  u32 totalValBytes;   /* last val offset = total val bytes */
+  int nOffsets;        
+  int minSize;         
+  u32 totalKeyBytes;   
+  u32 totalValBytes;   
   const u8 *pCur;
 
   memset(pNode, 0, sizeof(*pNode));
 
-  /* Need at least the header */
+  
   if( nData<PROLLY_HDR_SIZE ){
     return SQLITE_CORRUPT;
   }
 
-  /* Validate magic */
+  
   magic = PROLLY_GET_U32(pData + PROLLY_MAGIC_OFF);
   if( magic!=PROLLY_NODE_MAGIC ){
     return SQLITE_CORRUPT;
@@ -59,7 +41,7 @@ int prollyNodeParse(ProllyNode *pNode, const u8 *pData, int nData){
   pNode->flags = pData[PROLLY_FLAGS_OFF];
 
   if( count==0 ){
-    /* Empty node: no offset arrays or data regions */
+    
     pNode->aKeyOff = 0;
     pNode->aValOff = 0;
     pNode->pKeyData = pData + PROLLY_HDR_SIZE;
@@ -67,28 +49,24 @@ int prollyNodeParse(ProllyNode *pNode, const u8 *pData, int nData){
     return SQLITE_OK;
   }
 
-  /* Each offset array has (count+1) u32 entries */
+  
   nOffsets = (int)(count + 1) * 4 * 2;
   minSize = PROLLY_HDR_SIZE + nOffsets;
   if( nData<minSize ){
     return SQLITE_CORRUPT;
   }
 
-  /* Point offset arrays into the buffer. The buffer is packed u32s in
-  ** little-endian order. We cast directly since we read them through
-  ** the PROLLY_GET_U32 macro when accessing individual entries, but the
-  ** header stores them as a contiguous u32 array so we can also cast
-  ** when aligned.  We store as const u32* for direct indexed access. */
+  
   pCur = pData + PROLLY_HDR_SIZE;
   pNode->aKeyOff = (const u32*)pCur;
   pCur += (count + 1) * 4;
   pNode->aValOff = (const u32*)pCur;
   pCur += (count + 1) * 4;
 
-  /* Key data starts right after the offset arrays */
+  
   pNode->pKeyData = pCur;
 
-  /* Validate that key and value regions fit in the buffer */
+  
   totalKeyBytes = PROLLY_GET_U32((const u8*)&pNode->aKeyOff[count]);
   pNode->pValData = pCur + totalKeyBytes;
 
@@ -101,9 +79,6 @@ int prollyNodeParse(ProllyNode *pNode, const u8 *pData, int nData){
   return SQLITE_OK;
 }
 
-/*
-** Return a pointer to key i and its length.
-*/
 void prollyNodeKey(const ProllyNode *pNode, int i, const u8 **ppKey, int *pnKey){
   assert( i >= 0 && i < (int)pNode->nItems );
   u32 off0 = PROLLY_GET_U32((const u8*)&pNode->aKeyOff[i]);
@@ -112,9 +87,6 @@ void prollyNodeKey(const ProllyNode *pNode, int i, const u8 **ppKey, int *pnKey)
   *pnKey = (int)(off1 - off0);
 }
 
-/*
-** Return a pointer to value i and its length.
-*/
 void prollyNodeValue(const ProllyNode *pNode, int i, const u8 **ppVal, int *pnVal){
   assert( i >= 0 && i < (int)pNode->nItems );
   u32 off0 = PROLLY_GET_U32((const u8*)&pNode->aValOff[i]);
@@ -123,41 +95,22 @@ void prollyNodeValue(const ProllyNode *pNode, int i, const u8 **ppVal, int *pnVa
   *pnVal = (int)(off1 - off0);
 }
 
-/*
-** Read the integer key at index i. The key is stored as 8 bytes
-** in little-endian format.
-*/
 i64 prollyNodeIntKey(const ProllyNode *pNode, int i){
   assert( i >= 0 && i < (int)pNode->nItems );
   u32 off = PROLLY_GET_U32((const u8*)&pNode->aKeyOff[i]);
   const u8 *p = pNode->pKeyData + off;
-  /* Decode big-endian with sign-bit flip (matches encodeI64BE) */
+  
   u64 u = ((u64)p[0]<<56) | ((u64)p[1]<<48) | ((u64)p[2]<<40) | ((u64)p[3]<<32)
          | ((u64)p[4]<<24) | ((u64)p[5]<<16) | ((u64)p[6]<<8) | (u64)p[7];
-  return (i64)(u ^ ((u64)1 << 63));  /* un-flip sign bit */
+  return (i64)(u ^ ((u64)1 << 63));  
 }
 
-/*
-** Copy the child hash at value position i into *pHash.
-** Only valid for internal nodes (level > 0).
-*/
 void prollyNodeChildHash(const ProllyNode *pNode, int i, ProllyHash *pHash){
   assert( i >= 0 && i < (int)pNode->nItems );
   u32 off = PROLLY_GET_U32((const u8*)&pNode->aValOff[i]);
   memcpy(pHash->data, pNode->pValData + off, PROLLY_HASH_SIZE);
 }
 
-/*
-** Binary search for a blob key within the node.
-** NOTE: keep in sync with prollyNodeSearchInt below.
-** Both are hot-path functions; a callback/flag indirection would hurt perf.
-**
-** Returns the index where the key was found or where it would be inserted.
-** *pRes is set to:
-**   0   if an exact match was found
-**   <0  if the search key is less than the key at the returned index
-**   >0  if the search key is greater than the key at the returned index
-*/
 int prollyNodeSearchBlob(
   const ProllyNode *pNode,
   const u8 *pKey,
@@ -181,8 +134,7 @@ int prollyNodeSearchBlob(
     mid = lo + (hi - lo) / 2;
     prollyNodeKey(pNode, mid, &pMidKey, &nMidKey);
 
-    /* BLOBKEY nodes store sort keys — memcmp gives correct order.
-    ** INTKEY fallback also uses memcmp on LE-encoded keys. */
+    
     nCmp = nMidKey < nKey ? nMidKey : nKey;
     c = memcmp(pKey, pMidKey, nCmp);
     if( c==0 ) c = nKey - nMidKey;
@@ -197,7 +149,7 @@ int prollyNodeSearchBlob(
     }
   }
 
-  /* No exact match. lo is the insertion point. */
+  
   if( lo>=pNode->nItems ){
     *pRes = 1;
     return pNode->nItems - 1;
@@ -207,17 +159,6 @@ int prollyNodeSearchBlob(
   }
 }
 
-/*
-** Binary search for an integer key within the node.
-** NOTE: keep in sync with prollyNodeSearchBlob above.
-** Both are hot-path functions; a callback/flag indirection would hurt perf.
-**
-** Returns the index where the key was found or where it would be inserted.
-** *pRes is set to:
-**   0   if an exact match was found
-**   <0  if the search key is less than the key at the returned index
-**   >0  if the search key is greater than the key at the returned index
-*/
 int prollyNodeSearchInt(const ProllyNode *pNode, i64 intKey, int *pRes){
   int lo = 0;
   int hi = pNode->nItems - 1;
@@ -243,7 +184,7 @@ int prollyNodeSearchInt(const ProllyNode *pNode, i64 intKey, int *pRes){
     }
   }
 
-  /* No exact match. lo is the insertion point. */
+  
   if( lo>=pNode->nItems ){
     *pRes = 1;
     return pNode->nItems - 1;
@@ -253,32 +194,17 @@ int prollyNodeSearchInt(const ProllyNode *pNode, i64 intKey, int *pRes){
   }
 }
 
-/* -----------------------------------------------------------------------
-** ProllyNodeBuilder: incremental construction of serialized nodes.
-** -----------------------------------------------------------------------*/
-
-/*
-** Default initial capacity for offset arrays and data buffers.
-*/
 #define PROLLY_BUILDER_INIT_CAP  64
 #define PROLLY_BUILDER_INIT_BUF  1024
 
-/*
-** Initialize a node builder for the given level and flags.
-*/
 void prollyNodeBuilderInit(ProllyNodeBuilder *b, u8 level, u8 flags){
   memset(b, 0, sizeof(*b));
   b->level = level;
   b->flags = flags;
 }
 
-/*
-** Ensure the offset arrays can hold at least (nItems+1) entries.
-** Both aKeyOff and aValOff grow together.
-** Returns SQLITE_OK or SQLITE_NOMEM.
-*/
 static int builderGrowOffsets(ProllyNodeBuilder *b){
-  int nNeeded = b->nItems + 2;  /* need count+1 entries after this add */
+  int nNeeded = b->nItems + 2;  
   if( nNeeded>b->nAlloc ){
     int nNew = b->nAlloc ? b->nAlloc * 2 : PROLLY_BUILDER_INIT_CAP;
     u32 *aNew;
@@ -297,10 +223,6 @@ static int builderGrowOffsets(ProllyNodeBuilder *b){
   return SQLITE_OK;
 }
 
-/*
-** Ensure the key data buffer can hold nKeyBytes + nAdd bytes.
-** Returns SQLITE_OK or SQLITE_NOMEM.
-*/
 static int builderGrowKeyBuf(ProllyNodeBuilder *b, int nAdd){
   int nNeeded = b->nKeyBytes + nAdd;
   if( nNeeded>b->nKeyBufAlloc ){
@@ -315,10 +237,6 @@ static int builderGrowKeyBuf(ProllyNodeBuilder *b, int nAdd){
   return SQLITE_OK;
 }
 
-/*
-** Ensure the value data buffer can hold nValBytes + nAdd bytes.
-** Returns SQLITE_OK or SQLITE_NOMEM.
-*/
 static int builderGrowValBuf(ProllyNodeBuilder *b, int nAdd){
   int nNeeded = b->nValBytes + nAdd;
   if( nNeeded>b->nValBufAlloc ){
@@ -333,10 +251,6 @@ static int builderGrowValBuf(ProllyNodeBuilder *b, int nAdd){
   return SQLITE_OK;
 }
 
-/*
-** Add a key-value pair to the builder.
-** Returns SQLITE_OK, SQLITE_NOMEM, or SQLITE_FULL if too many items.
-*/
 int prollyNodeBuilderAdd(
   ProllyNodeBuilder *b,
   const u8 *pKey, int nKey,
@@ -348,28 +262,28 @@ int prollyNodeBuilderAdd(
     return SQLITE_FULL;
   }
 
-  /* Grow offset arrays if needed */
+  
   rc = builderGrowOffsets(b);
   if( rc ) return rc;
 
-  /* Grow data buffers */
+  
   rc = builderGrowKeyBuf(b, nKey);
   if( rc ) return rc;
   rc = builderGrowValBuf(b, nVal);
   if( rc ) return rc;
 
-  /* Record the starting offset for this key (first entry is 0 for item 0) */
+  
   if( b->nItems==0 ){
     b->aKeyOff[0] = 0;
     b->aValOff[0] = 0;
   }
 
-  /* Copy key data */
+  
   memcpy(b->pKeyBuf + b->nKeyBytes, pKey, nKey);
   b->nKeyBytes += nKey;
   b->aKeyOff[b->nItems + 1] = (u32)b->nKeyBytes;
 
-  /* Copy value data */
+  
   memcpy(b->pValBuf + b->nValBytes, pVal, nVal);
   b->nValBytes += nVal;
   b->aValOff[b->nItems + 1] = (u32)b->nValBytes;
@@ -378,22 +292,9 @@ int prollyNodeBuilderAdd(
   return SQLITE_OK;
 }
 
-/*
-** Serialize the builder contents into a single allocated buffer.
-** The caller must sqlite3_free(*ppOut) when done.
-**
-** Layout:
-**   [magic:4][level:1][count:2][flags:1]
-**   [keyOffsets: u32 * (count+1)]
-**   [valOffsets: u32 * (count+1)]
-**   [key data]
-**   [value data]
-**
-** Returns SQLITE_OK or SQLITE_NOMEM.
-*/
 int prollyNodeBuilderFinish(ProllyNodeBuilder *b, u8 **ppOut, int *pnOut){
-  int nOff;         /* bytes for one offset array */
-  int nTotal;       /* total serialized size */
+  int nOff;         
+  int nTotal;       
   u8 *pBuf;
   u8 *pCur;
   int i;
@@ -407,7 +308,7 @@ int prollyNodeBuilderFinish(ProllyNodeBuilder *b, u8 **ppOut, int *pnOut){
   pBuf = (u8*)sqlite3_malloc(nTotal);
   if( !pBuf ) return SQLITE_NOMEM;
 
-  /* Write header */
+  
   PROLLY_PUT_U32(pBuf + PROLLY_MAGIC_OFF, PROLLY_NODE_MAGIC);
   pBuf[PROLLY_LEVEL_OFF] = b->level;
   PROLLY_PUT_U16(pBuf + PROLLY_COUNT_OFF, (u16)b->nItems);
@@ -415,25 +316,25 @@ int prollyNodeBuilderFinish(ProllyNodeBuilder *b, u8 **ppOut, int *pnOut){
 
   pCur = pBuf + PROLLY_HDR_SIZE;
 
-  /* Write key offsets in little-endian */
+  
   for(i=0; i<=b->nItems; i++){
     PROLLY_PUT_U32(pCur, b->aKeyOff[i]);
     pCur += 4;
   }
 
-  /* Write value offsets in little-endian */
+  
   for(i=0; i<=b->nItems; i++){
     PROLLY_PUT_U32(pCur, b->aValOff[i]);
     pCur += 4;
   }
 
-  /* Write key data */
+  
   if( b->nKeyBytes>0 ){
     memcpy(pCur, b->pKeyBuf, b->nKeyBytes);
     pCur += b->nKeyBytes;
   }
 
-  /* Write value data */
+  
   if( b->nValBytes>0 ){
     memcpy(pCur, b->pValBuf, b->nValBytes);
     pCur += b->nValBytes;
@@ -446,20 +347,13 @@ int prollyNodeBuilderFinish(ProllyNodeBuilder *b, u8 **ppOut, int *pnOut){
   return SQLITE_OK;
 }
 
-/*
-** Reset the builder for reuse. Keeps allocated buffers but zeros
-** counts and sizes so the next build starts fresh.
-*/
 void prollyNodeBuilderReset(ProllyNodeBuilder *b){
   b->nItems = 0;
   b->nKeyBytes = 0;
   b->nValBytes = 0;
-  /* nAlloc, nKeyBufAlloc, nValBufAlloc and pointers are preserved */
+  
 }
 
-/*
-** Free all resources held by the builder.
-*/
 void prollyNodeBuilderFree(ProllyNodeBuilder *b){
   sqlite3_free(b->aKeyOff);
   sqlite3_free(b->aValOff);
@@ -468,20 +362,10 @@ void prollyNodeBuilderFree(ProllyNodeBuilder *b){
   memset(b, 0, sizeof(*b));
 }
 
-/*
-** Compute the content-address hash of a serialized node.
-*/
 void prollyNodeComputeHash(const u8 *pData, int nData, ProllyHash *pOut){
   prollyHashCompute(pData, nData, pOut);
 }
 
-/*
-** Compare two keys. For INTKEY tables, compare the i64 values directly.
-** For BLOBKEY tables, use memcmp with length comparison (sort key encoding
-** ensures memcmp gives correct order).
-**
-** Returns negative if key1 < key2, zero if equal, positive if key1 > key2.
-*/
 int prollyCompareKeys(
   u8 flags,
   const u8 *pKey1, int nKey1, i64 iKey1,
@@ -501,4 +385,4 @@ int prollyCompareKeys(
   }
 }
 
-#endif /* DOLTLITE_PROLLY */
+#endif 

--- a/src/prolly_node.c
+++ b/src/prolly_node.c
@@ -1,11 +1,22 @@
-
+/*
+** Prolly tree node binary format (all multi-byte integers little-endian):
+**   [magic:4 LE "DNOP"] [level:1] [count:2 LE] [flags:1]   = 8-byte header
+**   [keyOffsets: u32 LE * (count+1)]   -- cumulative byte offsets into key data
+**   [valOffsets: u32 LE * (count+1)]   -- cumulative byte offsets into val data
+**   [key data: variable]
+**   [value data: variable]
+**
+** For INTKEY tables, keys are 8-byte big-endian encoded i64 (see encodeI64BE
+** in prolly_mutate.c). For internal nodes (level>0), values are 20-byte
+** child hashes. Leaf values are SQLite record-format blobs.
+*/
 #ifdef DOLTLITE_PROLLY
 
 #include "prolly_node.h"
 #include "prolly_encoding.h"
 #include <string.h>
 
-#define PROLLY_HDR_SIZE       8   
+#define PROLLY_HDR_SIZE       8   /* magic(4) + level(1) + count(2) + flags(1) */
 #define PROLLY_MAGIC_OFF      0
 #define PROLLY_LEVEL_OFF      4
 #define PROLLY_COUNT_OFF      5
@@ -99,7 +110,8 @@ i64 prollyNodeIntKey(const ProllyNode *pNode, int i){
   assert( i >= 0 && i < (int)pNode->nItems );
   u32 off = PROLLY_GET_U32((const u8*)&pNode->aKeyOff[i]);
   const u8 *p = pNode->pKeyData + off;
-  
+  /* Decode big-endian sort key back to signed i64. Keys are stored big-endian
+  ** with sign bit flipped (see encodeI64BE) so memcmp gives signed order. */
   u64 u = ((u64)p[0]<<56) | ((u64)p[1]<<48) | ((u64)p[2]<<40) | ((u64)p[3]<<32)
          | ((u64)p[4]<<24) | ((u64)p[5]<<16) | ((u64)p[6]<<8) | (u64)p[7];
   return (i64)(u ^ ((u64)1 << 63));  

--- a/src/prolly_node.h
+++ b/src/prolly_node.h
@@ -1,82 +1,46 @@
-/*
-** Prolly tree node format: binary serialization for prolly map nodes.
-**
-** Node binary layout:
-**   [magic:4][level:1][count:2][flags:1]
-**   [keyOffsets: u32 * (count+1)]   -- offsets into key region
-**   [valOffsets: u32 * (count+1)]   -- offsets into value region
-**   [key data: variable]
-**   [value data: variable]
-**
-** For internal nodes, values are ProllyHash (child addresses).
-** For leaf nodes, values are arbitrary payloads (SQLite record format).
-*/
+
 #ifndef SQLITE_PROLLY_NODE_H
 #define SQLITE_PROLLY_NODE_H
 
 #include "sqliteInt.h"
 #include "prolly_hash.h"
 
-/* Node magic bytes */
-#define PROLLY_NODE_MAGIC 0x504E4F44  /* "PNOD" */
+#define PROLLY_NODE_MAGIC 0x504E4F44  
 
-/* Node flags */
-#define PROLLY_NODE_INTKEY  0x01  /* Keys are 64-bit integers (table btree) */
-#define PROLLY_NODE_BLOBKEY 0x02  /* Keys are blobs (index btree) */
+#define PROLLY_NODE_INTKEY  0x01  
+#define PROLLY_NODE_BLOBKEY 0x02  
 
-/* Maximum items per node (soft limit, actual limit from chunker) */
 #define PROLLY_NODE_MAX_ITEMS 4096
 
-/*
-** Read-only node handle. Points into chunk data (no copy).
-** Valid only while the underlying chunk data is alive.
-*/
 typedef struct ProllyNode ProllyNode;
 struct ProllyNode {
-  const u8 *pData;    /* Raw serialized node data */
-  int nData;           /* Size of serialized data */
-  u8 level;            /* Tree level: 0=leaf, >0=internal */
-  u16 nItems;          /* Number of key-value pairs */
-  u8 flags;            /* PROLLY_NODE_INTKEY or PROLLY_NODE_BLOBKEY */
-  const u32 *aKeyOff;  /* Key offset array (count+1 entries) */
-  const u32 *aValOff;  /* Value offset array (count+1 entries) */
-  const u8 *pKeyData;  /* Start of key data region */
-  const u8 *pValData;  /* Start of value data region */
-  ProllyHash addr;     /* Content address of this node */
+  const u8 *pData;    
+  int nData;           
+  u8 level;            
+  u16 nItems;          
+  u8 flags;            
+  const u32 *aKeyOff;  
+  const u32 *aValOff;  
+  const u8 *pKeyData;  
+  const u8 *pValData;  
+  ProllyHash addr;     
 };
 
-/* Parse a serialized node. Returns SQLITE_OK or SQLITE_CORRUPT. */
 int prollyNodeParse(ProllyNode *pNode, const u8 *pData, int nData);
 
-/* Get key at index i. Sets *ppKey and *pnKey. */
 void prollyNodeKey(const ProllyNode *pNode, int i, const u8 **ppKey, int *pnKey);
 
-/* Get value at index i. Sets *ppVal and *pnVal. */
 void prollyNodeValue(const ProllyNode *pNode, int i, const u8 **ppVal, int *pnVal);
 
-/* Get integer key at index i (only valid if PROLLY_NODE_INTKEY). */
 i64 prollyNodeIntKey(const ProllyNode *pNode, int i);
 
-/* Get child hash at index i (only valid for internal nodes, level>0). */
 void prollyNodeChildHash(const ProllyNode *pNode, int i, ProllyHash *pHash);
 
-/*
-** Binary search for blob key. Returns index of exact match, or
-** the index where key would be inserted (for seek operations).
-** *pRes: 0 if exact match, <0 if key is less, >0 if key is greater.
-*/
 int prollyNodeSearchBlob(const ProllyNode *pNode,
                          const u8 *pKey, int nKey, int *pRes);
 
-/*
-** Binary search for integer key.
-** *pRes: 0 if exact match, <0 if key is less, >0 if key is greater.
-*/
 int prollyNodeSearchInt(const ProllyNode *pNode, i64 intKey, int *pRes);
 
-/*
-** Node builder: construct a new serialized node.
-*/
 typedef struct ProllyNodeBuilder ProllyNodeBuilder;
 struct ProllyNodeBuilder {
   u8 level;
@@ -84,45 +48,33 @@ struct ProllyNodeBuilder {
   int nItems;
   int nKeyBytes;
   int nValBytes;
-  int nAlloc;          /* Allocated capacity for offset arrays */
-  u32 *aKeyOff;        /* Key offsets */
-  u32 *aValOff;        /* Value offsets */
-  u8 *pKeyBuf;         /* Key data buffer */
+  int nAlloc;          
+  u32 *aKeyOff;        
+  u32 *aValOff;        
+  u8 *pKeyBuf;         
   int nKeyBufAlloc;
-  u8 *pValBuf;         /* Value data buffer */
+  u8 *pValBuf;         
   int nValBufAlloc;
 };
 
-/* Initialize a node builder */
 void prollyNodeBuilderInit(ProllyNodeBuilder *b, u8 level, u8 flags);
 
-/* Add a key-value pair to the builder */
 int prollyNodeBuilderAdd(ProllyNodeBuilder *b,
                          const u8 *pKey, int nKey,
                          const u8 *pVal, int nVal);
 
-/* Serialize the node into a new allocation. Caller must sqlite3_free(*ppOut). */
 int prollyNodeBuilderFinish(ProllyNodeBuilder *b, u8 **ppOut, int *pnOut);
 
-/* Reset builder for reuse (keeps allocated buffers) */
 void prollyNodeBuilderReset(ProllyNodeBuilder *b);
 
-/* Free builder resources */
 void prollyNodeBuilderFree(ProllyNodeBuilder *b);
 
-/* Compute the content hash of serialized node data */
 void prollyNodeComputeHash(const u8 *pData, int nData, ProllyHash *pOut);
 
-/*
-** Compare two keys. For INTKEY tables, compare the i64 values directly.
-** For BLOBKEY tables, use memcmp with length comparison.
-**
-** Returns negative if key1 < key2, zero if equal, positive if key1 > key2.
-*/
 int prollyCompareKeys(
   u8 flags,
   const u8 *pKey1, int nKey1, i64 iKey1,
   const u8 *pKey2, int nKey2, i64 iKey2
 );
 
-#endif /* SQLITE_PROLLY_NODE_H */
+#endif 

--- a/src/prolly_node.h
+++ b/src/prolly_node.h
@@ -1,4 +1,5 @@
-
+/* Prolly tree node: [magic:4][level:1][count:2][flags:1] + offset arrays + data.
+** INTKEY keys are 8-byte big-endian (sign-bit-flipped); values are records or child hashes. */
 #ifndef SQLITE_PROLLY_NODE_H
 #define SQLITE_PROLLY_NODE_H
 

--- a/src/prolly_three_way_diff.c
+++ b/src/prolly_three_way_diff.c
@@ -1,41 +1,29 @@
-/*
-** prolly_three_way_diff.c — Three-way row diff engine for prolly trees.
-**
-** Runs two prollyDiff passes (ancestor→ours, ancestor→theirs), collects
-** both result streams into sorted arrays, then merge-walks them in key
-** order to produce LEFT_*, RIGHT_*, CONVERGENT, or CONFLICT_* changes.
-*/
+
 #ifdef DOLTLITE_PROLLY
 
 #include "prolly_three_way_diff.h"
-#include <string.h>  /* memcmp, memcpy */
+#include <string.h>  
 
-/*
-** Internal structure for collecting diff changes into a dynamic array.
-*/
 typedef struct DiffEntry DiffEntry;
 struct DiffEntry {
-  u8 type;            /* PROLLY_DIFF_ADD, DELETE, or MODIFY */
-  u8 *pKey;           /* Owned copy of key data */
+  u8 type;            
+  u8 *pKey;           
   int nKey;
   i64 intKey;
-  u8 *pOldVal;        /* Owned copy of old value */
+  u8 *pOldVal;        
   int nOldVal;
-  u8 *pNewVal;        /* Owned copy of new value */
+  u8 *pNewVal;        
   int nNewVal;
 };
 
 typedef struct DiffCollector DiffCollector;
 struct DiffCollector {
-  DiffEntry *aEntry;  /* Array of collected entries */
-  int nEntry;         /* Number of entries */
-  int nAlloc;         /* Allocated capacity */
-  u8 flags;           /* INTKEY or BLOBKEY */
+  DiffEntry *aEntry;  
+  int nEntry;         
+  int nAlloc;         
+  u8 flags;           
 };
 
-/*
-** Duplicate a blob. Returns NULL if pSrc is NULL or nSrc is 0.
-*/
 static u8 *dupBlob(const u8 *pSrc, int nSrc){
   u8 *pDst;
   if( !pSrc || nSrc<=0 ) return 0;
@@ -44,14 +32,11 @@ static u8 *dupBlob(const u8 *pSrc, int nSrc){
   return pDst;
 }
 
-/*
-** Callback for prollyDiff — collects changes into the DiffCollector.
-*/
 static int diffCollectCallback(void *pCtx, const ProllyDiffChange *pChange){
   DiffCollector *pColl = (DiffCollector*)pCtx;
   DiffEntry *pEntry;
 
-  /* Grow array if needed */
+  
   if( pColl->nEntry >= pColl->nAlloc ){
     int nNew = pColl->nAlloc ? pColl->nAlloc*2 : 32;
     DiffEntry *aNew = (DiffEntry*)sqlite3_realloc(pColl->aEntry,
@@ -72,7 +57,7 @@ static int diffCollectCallback(void *pCtx, const ProllyDiffChange *pChange){
   pEntry->pNewVal = dupBlob(pChange->pNewVal, pChange->nNewVal);
   pEntry->nNewVal = pChange->nNewVal;
 
-  /* Check for allocation failure on non-null inputs */
+  
   if( (pChange->pKey && pChange->nKey>0 && !pEntry->pKey)
    || (pChange->pOldVal && pChange->nOldVal>0 && !pEntry->pOldVal)
    || (pChange->pNewVal && pChange->nNewVal>0 && !pEntry->pNewVal) ){
@@ -82,9 +67,6 @@ static int diffCollectCallback(void *pCtx, const ProllyDiffChange *pChange){
   return SQLITE_OK;
 }
 
-/*
-** Free all entries in a DiffCollector.
-*/
 static void diffCollectorFree(DiffCollector *pColl){
   int i;
   for(i=0; i<pColl->nEntry; i++){
@@ -98,9 +80,6 @@ static void diffCollectorFree(DiffCollector *pColl){
   pColl->nAlloc = 0;
 }
 
-/*
-** Compare two DiffEntry keys for sorting/merging.
-*/
 static int diffEntryKeyCmp(const DiffEntry *pA, const DiffEntry *pB, u8 flags){
   if( flags & PROLLY_NODE_INTKEY ){
     if( pA->intKey < pB->intKey ) return -1;
@@ -114,12 +93,6 @@ static int diffEntryKeyCmp(const DiffEntry *pA, const DiffEntry *pB, u8 flags){
   }
 }
 
-/*
-** Compare two values for equality, with field-wise fallback.
-** Fast path: same length and same bytes.  Slow path: parse SQLite
-** record format to compare field-by-field, tolerating trailing NULL
-** differences from ALTER TABLE ADD COLUMN.
-*/
 static int valuesEqual(const u8 *pA, int nA, const u8 *pB, int nB){
   if( nA==nB ){
     if( nA==0 ) return 1;
@@ -129,18 +102,12 @@ static int valuesEqual(const u8 *pA, int nA, const u8 *pB, int nB){
   return diffRecordsEqualFieldwise(pA, nA, pB, nB);
 }
 
-/*
-** Fill a ThreeWayChange key from a DiffEntry.
-*/
 static void fillKeyFromEntry(ThreeWayChange *pOut, const DiffEntry *pEntry){
   pOut->pKey = pEntry->pKey;
   pOut->nKey = pEntry->nKey;
   pOut->intKey = pEntry->intKey;
 }
 
-/*
-** Emit a left-only change (change exists in ours diff but not theirs).
-*/
 static int emitLeftOnly(
   const DiffEntry *pLeft,
   ThreeWayDiffCallback xCallback,
@@ -172,9 +139,6 @@ static int emitLeftOnly(
   return xCallback(pCtx, &change);
 }
 
-/*
-** Emit a right-only change (change exists in theirs diff but not ours).
-*/
 static int emitRightOnly(
   const DiffEntry *pRight,
   ThreeWayDiffCallback xCallback,
@@ -206,9 +170,6 @@ static int emitRightOnly(
   return xCallback(pCtx, &change);
 }
 
-/*
-** Emit a merged change where the same key appears in both diffs.
-*/
 static int emitBothSides(
   const DiffEntry *pLeft,
   const DiffEntry *pRight,
@@ -219,7 +180,7 @@ static int emitBothSides(
   memset(&change, 0, sizeof(change));
   fillKeyFromEntry(&change, pLeft);
 
-  /* Both ADD: check if they added the same value */
+  
   if( pLeft->type==PROLLY_DIFF_ADD && pRight->type==PROLLY_DIFF_ADD ){
     if( valuesEqual(pLeft->pNewVal, pLeft->nNewVal,
                     pRight->pNewVal, pRight->nNewVal) ){
@@ -238,7 +199,7 @@ static int emitBothSides(
     return xCallback(pCtx, &change);
   }
 
-  /* Both DELETE: convergent */
+  
   if( pLeft->type==PROLLY_DIFF_DELETE && pRight->type==PROLLY_DIFF_DELETE ){
     change.type = THREE_WAY_CONVERGENT;
     change.pBaseVal = pLeft->pOldVal;
@@ -246,7 +207,7 @@ static int emitBothSides(
     return xCallback(pCtx, &change);
   }
 
-  /* Both MODIFY: check if they modified to the same value */
+  
   if( pLeft->type==PROLLY_DIFF_MODIFY && pRight->type==PROLLY_DIFF_MODIFY ){
     change.pBaseVal = pLeft->pOldVal;
     change.nBaseVal = pLeft->nOldVal;
@@ -263,7 +224,7 @@ static int emitBothSides(
     return xCallback(pCtx, &change);
   }
 
-  /* One deleted, the other modified: CONFLICT_DM */
+  
   if( (pLeft->type==PROLLY_DIFF_DELETE && pRight->type==PROLLY_DIFF_MODIFY)
    || (pLeft->type==PROLLY_DIFF_MODIFY && pRight->type==PROLLY_DIFF_DELETE) ){
     change.type = THREE_WAY_CONFLICT_DM;
@@ -279,8 +240,7 @@ static int emitBothSides(
     return xCallback(pCtx, &change);
   }
 
-  /* One added, the other deleted/modified — shouldn't normally happen
-  ** with a correct ancestor, but handle gracefully as a conflict. */
+  
   change.type = THREE_WAY_CONFLICT_MM;
   change.pBaseVal = pLeft->pOldVal;
   change.nBaseVal = pLeft->nOldVal;
@@ -291,14 +251,6 @@ static int emitBothSides(
   return xCallback(pCtx, &change);
 }
 
-/*
-** Compute three-way diff between ancestor, ours, and theirs trees.
-**
-** Algorithm:
-** 1. prollyDiff(ancestor, ours) → collect left changes
-** 2. prollyDiff(ancestor, theirs) → collect right changes
-** 3. Merge-walk both arrays in sorted key order
-*/
 int prollyThreeWayDiff(
   ChunkStore *pStore,
   ProllyCache *pCache,
@@ -319,35 +271,33 @@ int prollyThreeWayDiff(
   left.flags = flags;
   right.flags = flags;
 
-  /* Step 1: Diff ancestor→ours */
+  
   rc = prollyDiff(pStore, pCache, pAncestorRoot, pOursRoot,
                   flags, diffCollectCallback, &left);
   if( rc!=SQLITE_OK ) goto cleanup;
 
-  /* Step 2: Diff ancestor→theirs */
+  
   rc = prollyDiff(pStore, pCache, pAncestorRoot, pTheirsRoot,
                   flags, diffCollectCallback, &right);
   if( rc!=SQLITE_OK ) goto cleanup;
 
-  /* Step 3: Merge-walk both sorted diff streams.
-  ** prollyDiff already produces entries in key order because it walks
-  ** cursors in sorted order. No additional sorting needed. */
+  
   iL = 0;
   iR = 0;
   while( iL < left.nEntry && iR < right.nEntry ){
     int cmp = diffEntryKeyCmp(&left.aEntry[iL], &right.aEntry[iR], flags);
     if( cmp < 0 ){
-      /* Key only in left diff */
+      
       rc = emitLeftOnly(&left.aEntry[iL], xCallback, pCtx);
       if( rc!=SQLITE_OK ) goto cleanup;
       iL++;
     }else if( cmp > 0 ){
-      /* Key only in right diff */
+      
       rc = emitRightOnly(&right.aEntry[iR], xCallback, pCtx);
       if( rc!=SQLITE_OK ) goto cleanup;
       iR++;
     }else{
-      /* Same key in both diffs */
+      
       rc = emitBothSides(&left.aEntry[iL], &right.aEntry[iR],
                          xCallback, pCtx);
       if( rc!=SQLITE_OK ) goto cleanup;
@@ -356,14 +306,14 @@ int prollyThreeWayDiff(
     }
   }
 
-  /* Drain remaining left entries */
+  
   while( iL < left.nEntry ){
     rc = emitLeftOnly(&left.aEntry[iL], xCallback, pCtx);
     if( rc!=SQLITE_OK ) goto cleanup;
     iL++;
   }
 
-  /* Drain remaining right entries */
+  
   while( iR < right.nEntry ){
     rc = emitRightOnly(&right.aEntry[iR], xCallback, pCtx);
     if( rc!=SQLITE_OK ) goto cleanup;
@@ -376,4 +326,4 @@ cleanup:
   return rc;
 }
 
-#endif /* DOLTLITE_PROLLY */
+#endif 

--- a/src/prolly_three_way_diff.c
+++ b/src/prolly_three_way_diff.c
@@ -251,6 +251,10 @@ static int emitBothSides(
   return xCallback(pCtx, &change);
 }
 
+/* Three-way diff: diff(ancestor,ours) and diff(ancestor,theirs) collected
+** into sorted arrays, then merge-walked in key order. Same-key entries are
+** classified as convergent (identical change), MM conflict (both modified
+** differently), or DM conflict (one deleted, other modified). */
 int prollyThreeWayDiff(
   ChunkStore *pStore,
   ProllyCache *pCache,

--- a/src/prolly_three_way_diff.h
+++ b/src/prolly_three_way_diff.h
@@ -1,4 +1,4 @@
-
+/* Three-way diff for merge: diff(ancestor,ours) + diff(ancestor,theirs) merge-walked by key. */
 #ifndef SQLITE_PROLLY_THREE_WAY_DIFF_H
 #define SQLITE_PROLLY_THREE_WAY_DIFF_H
 

--- a/src/prolly_three_way_diff.h
+++ b/src/prolly_three_way_diff.h
@@ -1,18 +1,4 @@
-/*
-** Three-way row diff engine for prolly trees.
-**
-** Given an ancestor tree, "ours" tree, and "theirs" tree, computes
-** a merged stream of changes by running two prollyDiff passes
-** (ancestor→ours, ancestor→theirs) and merge-walking both result
-** streams in sorted key order.
-**
-** Change types:
-**   LEFT_ADD/DELETE/MODIFY   — change only in "ours"
-**   RIGHT_ADD/DELETE/MODIFY  — change only in "theirs"
-**   CONVERGENT               — both sides made the same change
-**   CONFLICT_MM              — both modified, but to different values
-**   CONFLICT_DM              — one deleted, the other modified
-*/
+
 #ifndef SQLITE_PROLLY_THREE_WAY_DIFF_H
 #define SQLITE_PROLLY_THREE_WAY_DIFF_H
 
@@ -24,7 +10,6 @@
 #include "chunk_store.h"
 #include "prolly_diff.h"
 
-/* Three-way diff change types */
 #define THREE_WAY_LEFT_ADD       1
 #define THREE_WAY_LEFT_DELETE    2
 #define THREE_WAY_LEFT_MODIFY    3
@@ -32,31 +17,26 @@
 #define THREE_WAY_RIGHT_DELETE   5
 #define THREE_WAY_RIGHT_MODIFY   6
 #define THREE_WAY_CONVERGENT     7
-#define THREE_WAY_CONFLICT_MM    8   /* Both modified differently */
-#define THREE_WAY_CONFLICT_DM    9   /* One deleted, other modified */
+#define THREE_WAY_CONFLICT_MM    8   
+#define THREE_WAY_CONFLICT_DM    9   
 
 typedef struct ThreeWayChange ThreeWayChange;
 
 struct ThreeWayChange {
-  u8 type;              /* THREE_WAY_* constant */
-  const u8 *pKey;       /* Key data (NULL for INTKEY) */
-  int nKey;             /* Key size */
-  i64 intKey;           /* Integer key (if INTKEY) */
-  const u8 *pBaseVal;   /* Ancestor value (NULL for ADDs) */
+  u8 type;              
+  const u8 *pKey;       
+  int nKey;             
+  i64 intKey;           
+  const u8 *pBaseVal;   
   int nBaseVal;
-  const u8 *pOurVal;    /* Our value (NULL for DELETEs on our side) */
+  const u8 *pOurVal;    
   int nOurVal;
-  const u8 *pTheirVal;  /* Their value (NULL for DELETEs on their side) */
+  const u8 *pTheirVal;  
   int nTheirVal;
 };
 
-/* Callback for each three-way difference found */
 typedef int (*ThreeWayDiffCallback)(void *pCtx, const ThreeWayChange *pChange);
 
-/*
-** Compute three-way diff between ancestor, ours, and theirs trees.
-** Calls xCallback for each difference found.
-*/
 int prollyThreeWayDiff(
   ChunkStore *pStore,
   ProllyCache *pCache,
@@ -68,4 +48,4 @@ int prollyThreeWayDiff(
   void *pCtx
 );
 
-#endif /* SQLITE_PROLLY_THREE_WAY_DIFF_H */
+#endif 

--- a/src/sortkey.c
+++ b/src/sortkey.c
@@ -1,18 +1,9 @@
-/*
-** Sort key encoding for BLOBKEY (index) entries.
-**
-** Converts SQLite serialized record format into a memcmp-sortable
-** byte string. See sortkey.h for format documentation.
-*/
+
 #ifdef DOLTLITE_PROLLY
 
 #include "sortkey.h"
 #include <string.h>
 
-/*
-** Read a varint from pBuf. Returns the number of bytes consumed.
-** Value is stored in *pVal. Handles 1-9 byte varints.
-*/
 static int skGetVarint32(const u8 *p, u32 *pVal){
   u32 a;
   a = *p;
@@ -20,7 +11,7 @@ static int skGetVarint32(const u8 *p, u32 *pVal){
     *pVal = a;
     return 1;
   }
-  /* Multi-byte varint — defer to full parser */
+  
   {
     u32 v = a & 0x7f;
     int i = 1;
@@ -34,26 +25,14 @@ static int skGetVarint32(const u8 *p, u32 *pVal){
   }
 }
 
-/*
-** Return the payload byte length for a SQLite serial type.
-**
-** Maps serial type codes to their data sizes: NULL(0)=0, int types 1-6
-** use 1/2/3/4/6/8 bytes respectively, float(7)=8 bytes, constants 8-11
-** have no payload, text(N>=13) = (N-13)/2+1 chars, blob(N>=12) = (N-12)/2 bytes.
-*/
 static u32 serialTypeLen(u32 serialType){
   static const u8 aLen[] = {0, 1, 2, 3, 4, 6, 8};
   if( serialType <= 6 ) return aLen[serialType];
   if( serialType == 7 ) return 8;
   if( serialType >= 12 ) return (serialType - 12) / 2;
-  return 0;  /* types 8,9,10,11 are constants */
+  return 0;  
 }
 
-/*
-** Classify a serial type into a sort key tag.
-** INT and FLOAT both map to SORTKEY_NUM for correct cross-type
-** numeric comparison (e.g., integer 0 vs float -1.5).
-*/
 static u8 serialTypeTag(u32 serialType){
   if( serialType == 0 ) return SORTKEY_NULL;
   if( serialType <= 6 || serialType == 8 || serialType == 9 ){
@@ -62,20 +41,9 @@ static u8 serialTypeTag(u32 serialType){
   if( serialType == 7 ) return SORTKEY_NUM;
   if( serialType >= 13 && (serialType & 1) ) return SORTKEY_TEXT;
   if( serialType >= 12 && !(serialType & 1) ) return SORTKEY_BLOB;
-  return SORTKEY_NULL;  /* shouldn't reach here */
+  return SORTKEY_NULL;  
 }
 
-/*
-** Compute the encoded size for a single field in the sort key.
-**
-** NULL:    1 byte (tag only)
-** Integer: 9 bytes (tag + 8 bytes)
-** Float:   9 bytes (tag + 8 bytes)
-** Text:    1 + escaped_length + 2 bytes (tag + escaped data + 0x00 0x00)
-** Blob:    1 + escaped_length + 2 bytes (tag + escaped data + 0x00 0x00)
-**
-** For text/blob, each 0x00 byte in the data expands to 0x00 0x01 (2 bytes).
-*/
 static int encodedFieldSize(u32 serialType, const u8 *pData, u32 nData){
   u8 tag = serialTypeTag(serialType);
   switch( tag ){
@@ -85,29 +53,19 @@ static int encodedFieldSize(u32 serialType, const u8 *pData, u32 nData){
       return 9;
     case SORTKEY_TEXT:
     case SORTKEY_BLOB: {
-      /* Count NUL bytes for escaping */
+      
       int extra = 0;
       u32 i;
       for(i = 0; i < nData; i++){
         if( pData[i] == 0x00 ) extra++;
       }
-      return 1 + (int)nData + extra + 2;  /* tag + data + escapes + terminator */
+      return 1 + (int)nData + extra + 2;  
     }
     default:
       return 1;
   }
 }
 
-/*
-** Encode a numeric field (integer or float) into the sort key buffer.
-** All numbers are converted to IEEE 754 double and encoded with the
-** float encoding scheme. This ensures correct cross-type comparison
-** (e.g., integer 0 vs float -1.5 sorts correctly).
-**
-** Encoding: big-endian IEEE 754 with sign normalization:
-**   Positive (incl. +0): flip sign bit (XOR 0x80 on first byte)
-**   Negative: flip ALL bits (reverses order for negatives)
-*/
 static void encodeNumeric(u8 *pOut, u32 serialType, const u8 *pData, u32 nData){
   u8 buf[8];
   double d;
@@ -115,10 +73,10 @@ static void encodeNumeric(u8 *pOut, u32 serialType, const u8 *pData, u32 nData){
   pOut[0] = SORTKEY_NUM;
 
   if( serialType == 7 ){
-    /* Already a float — data is 8-byte big-endian IEEE 754 */
+    
     memcpy(buf, pData, 8);
   }else{
-    /* Integer — extract value and convert to double */
+    
     i64 v;
     u64 x;
     if( serialType == 8 ){
@@ -132,7 +90,7 @@ static void encodeNumeric(u8 *pOut, u32 serialType, const u8 *pData, u32 nData){
       }
     }
     d = (double)v;
-    /* Convert double to 8-byte big-endian */
+    
     memcpy(&x, &d, 8);
     buf[0] = (u8)(x >> 56); buf[1] = (u8)(x >> 48);
     buf[2] = (u8)(x >> 40); buf[3] = (u8)(x >> 32);
@@ -140,28 +98,18 @@ static void encodeNumeric(u8 *pOut, u32 serialType, const u8 *pData, u32 nData){
     buf[6] = (u8)(x >> 8);  buf[7] = (u8)(x);
   }
 
-  /* Apply sign normalization for correct memcmp ordering */
+  
   if( buf[0] & 0x80 ){
-    /* Negative: flip all bits */
+    
     for(int i = 0; i < 8; i++) buf[i] = ~buf[i];
   }else{
-    /* Positive (or zero): flip sign bit only */
+    
     buf[0] ^= 0x80;
   }
 
   memcpy(pOut + 1, buf, 8);
 }
 
-/*
-** Encode a text or blob field with NUL-byte escaping.
-**
-** Each 0x00 in the input is encoded as 0x00 0x01.
-** The field is terminated by 0x00 0x00.
-** This ensures:
-**   1. No embedded NUL can be confused with the terminator
-**   2. Shorter strings sort before longer strings with the same prefix
-**   3. memcmp gives lexicographic ordering
-*/
 static int encodeVarLen(u8 *pOut, u8 tag, const u8 *pData, u32 nData){
   int pos = 0;
   pOut[pos++] = tag;
@@ -175,18 +123,13 @@ static int encodeVarLen(u8 *pOut, u8 tag, const u8 *pData, u32 nData){
     }
   }
 
-  /* Double-NUL terminator */
+  
   pOut[pos++] = 0x00;
   pOut[pos++] = 0x00;
 
   return pos;
 }
 
-/*
-** Internal implementation: parse record and either compute size or encode.
-** If pOut is NULL, only compute the size.
-** Returns the total sort key size, or -1 on error.
-*/
 static int sortKeyEncode(const u8 *pRec, int nRec, u8 *pOut){
   u32 hdrSize;
   u32 hdrOff;
@@ -195,12 +138,12 @@ static int sortKeyEncode(const u8 *pRec, int nRec, u8 *pOut){
 
   if( nRec <= 0 ) return -1;
 
-  /* Parse header size */
+  
   hdrOff = skGetVarint32(pRec, &hdrSize);
   if( hdrSize > (u32)nRec ) return -1;
   dataOff = hdrSize;
 
-  /* Process each field */
+  
   while( hdrOff < hdrSize ){
     u32 serialType;
     u32 fieldLen;
@@ -209,7 +152,7 @@ static int sortKeyEncode(const u8 *pRec, int nRec, u8 *pOut){
     hdrOff += skGetVarint32(pRec + hdrOff, &serialType);
     fieldLen = serialTypeLen(serialType);
 
-    /* Bounds check */
+    
     if( dataOff + fieldLen > (u32)nRec ) return -1;
     pField = pRec + dataOff;
 
@@ -255,7 +198,7 @@ int sortKeyFromRecord(const u8 *pRec, int nRec, u8 **ppOut, int *pnOut){
   nSize = sortKeyEncode(pRec, nRec, NULL);
   if( nSize < 0 ) return SQLITE_CORRUPT;
   if( nSize == 0 ){
-    /* Empty record — produce empty sort key */
+    
     *ppOut = (u8*)sqlite3_malloc(1);
     if( !*ppOut ) return SQLITE_NOMEM;
     *pnOut = 0;
@@ -267,16 +210,11 @@ int sortKeyFromRecord(const u8 *pRec, int nRec, u8 **ppOut, int *pnOut){
 
   sortKeyEncode(pRec, nRec, pBuf);
 
-
   *ppOut = pBuf;
   *pnOut = nSize;
   return SQLITE_OK;
 }
 
-/*
-** Determine the minimum SQLite serial type for an i64 value.
-** Mirrors btreeSerialType() logic in prolly_btree.c.
-*/
 static void intSerialType(i64 v, u32 *pType, u32 *pLen){
   if( v==0 ){ *pType = 8; *pLen = 0; return; }
   if( v==1 ){ *pType = 9; *pLen = 0; return; }
@@ -288,9 +226,6 @@ static void intSerialType(i64 v, u32 *pType, u32 *pLen){
   *pType = 6; *pLen = 8;
 }
 
-/*
-** Write an integer value as big-endian bytes (SQLite record format).
-*/
 static void writeIntBE(u8 *p, i64 v, int nByte){
   int j;
   for(j = nByte - 1; j >= 0; j--){
@@ -299,20 +234,13 @@ static void writeIntBE(u8 *p, i64 v, int nByte){
   }
 }
 
-/*
-** Decode a sort key back into a SQLite serialized record.
-**
-** First pass: parse sort key fields to determine serial types and data sizes.
-** Second pass: write the SQLite record (varint header + field data).
-*/
 int recordFromSortKey(const u8 *pSortKey, int nSortKey, u8 **ppOut, int *pnOut){
-  /* Max 64 fields (matching serializeUnpackedRecord limit) */
+  
   u32 aType[64];
   u32 aLen[64];
-  /* Temporary storage for decoded field data.
-  ** Text/blob fields point into decode buffer; ints/floats are small. */
+  
   const u8 *aFieldPtr[64];
-  u8 aIntBuf[64][8];  /* Per-field buffer for int/float data */
+  u8 aIntBuf[64][8];  
   int nFields = 0;
   int pos = 0;
   u8 *pOut;
@@ -323,16 +251,16 @@ int recordFromSortKey(const u8 *pSortKey, int nSortKey, u8 **ppOut, int *pnOut){
   *pnOut = 0;
 
   if( nSortKey <= 0 ){
-    /* Empty sort key → empty record */
+    
     pOut = (u8*)sqlite3_malloc(1);
     if( !pOut ) return SQLITE_NOMEM;
-    pOut[0] = 1;  /* header size = 1 (just the header size varint) */
+    pOut[0] = 1;  
     *ppOut = pOut;
     *pnOut = 1;
     return SQLITE_OK;
   }
 
-  /* ---- Pass 1: Parse sort key fields ---- */
+  
   while( pos < nSortKey && nFields < 64 ){
     u8 tag = pSortKey[pos++];
 
@@ -343,39 +271,37 @@ int recordFromSortKey(const u8 *pSortKey, int nSortKey, u8 **ppOut, int *pnOut){
       nFields++;
 
     }else if( tag == SORTKEY_NUM ){
-      /* 8-byte IEEE 754 double with sign normalization → restore.
-      ** If the double is an exact integer, emit integer serial type
-      ** for canonical SQLite record encoding. */
+      
       u8 buf[8];
       double d;
       u64 x;
       if( pos + 8 > nSortKey ) return SQLITE_CORRUPT;
       memcpy(buf, pSortKey + pos, 8);
       pos += 8;
-      /* Undo sign normalization */
+      
       if( buf[0] & 0x80 ){
-        /* Was positive: unflip sign bit only */
+        
         buf[0] ^= 0x80;
       }else{
-        /* Was negative: unflip all bits */
+        
         for(i = 0; i < 8; i++) buf[i] = ~buf[i];
       }
-      /* Convert big-endian bytes to u64 then to double */
+      
       x = ((u64)buf[0] << 56) | ((u64)buf[1] << 48)
         | ((u64)buf[2] << 40) | ((u64)buf[3] << 32)
         | ((u64)buf[4] << 24) | ((u64)buf[5] << 16)
         | ((u64)buf[6] << 8)  | (u64)buf[7];
       memcpy(&d, &x, 8);
-      /* Check if this double is an exact integer */
+      
       {
         i64 iv = (i64)d;
         if( (double)iv == d && d >= -9.22e18 && d <= 9.22e18 ){
-          /* Emit as integer serial type */
+          
           intSerialType(iv, &aType[nFields], &aLen[nFields]);
           writeIntBE(aIntBuf[nFields], iv, (int)aLen[nFields]);
           aFieldPtr[nFields] = aIntBuf[nFields];
         }else{
-          /* Emit as float serial type — store big-endian IEEE 754 */
+          
           aType[nFields] = 7;
           aLen[nFields] = 8;
           memcpy(aIntBuf[nFields], buf, 8);
@@ -385,19 +311,19 @@ int recordFromSortKey(const u8 *pSortKey, int nSortKey, u8 **ppOut, int *pnOut){
       nFields++;
 
     }else if( tag == SORTKEY_TEXT || tag == SORTKEY_BLOB ){
-      /* NUL-escaped data terminated by 0x00 0x00 */
-      /* First, compute unescaped length */
+      
+      
       int start = pos;
       int dataLen = 0;
       while( pos < nSortKey ){
         if( pSortKey[pos] == 0x00 ){
           if( pos + 1 >= nSortKey ) return SQLITE_CORRUPT;
           if( pSortKey[pos+1] == 0x00 ){
-            /* Terminator found */
+            
             pos += 2;
             break;
           }else if( pSortKey[pos+1] == 0x01 ){
-            /* Escaped NUL */
+            
             dataLen++;
             pos += 2;
           }else{
@@ -409,13 +335,13 @@ int recordFromSortKey(const u8 *pSortKey, int nSortKey, u8 **ppOut, int *pnOut){
         }
       }
       if( tag == SORTKEY_TEXT ){
-        aType[nFields] = (u32)dataLen * 2 + 13;  /* SERIAL_TYPE_TEXT_BASE */
+        aType[nFields] = (u32)dataLen * 2 + 13;  
       }else{
-        aType[nFields] = (u32)dataLen * 2 + 12;  /* SERIAL_TYPE_BLOB_BASE */
+        aType[nFields] = (u32)dataLen * 2 + 12;  
       }
       aLen[nFields] = (u32)dataLen;
-      /* We'll decode the data in pass 2. Store the start offset. */
-      /* Use aFieldPtr to store the sort key offset (cast to pointer math) */
+      
+      
       aFieldPtr[nFields] = pSortKey + start;
       nFields++;
 
@@ -424,12 +350,12 @@ int recordFromSortKey(const u8 *pSortKey, int nSortKey, u8 **ppOut, int *pnOut){
     }
   }
 
-  /* ---- Compute SQLite record size ---- */
-  nHdr = 1;  /* At least 1 byte for header size varint */
+  
+  nHdr = 1;  
   for(i = 0; i < nFields; i++){
     nHdr += sqlite3VarintLen(aType[i]);
   }
-  if( nHdr > 126 ) nHdr++;  /* 2-byte varint for header size */
+  if( nHdr > 126 ) nHdr++;  
 
   nData = 0;
   for(i = 0; i < nFields; i++) nData += (int)aLen[i];
@@ -438,32 +364,32 @@ int recordFromSortKey(const u8 *pSortKey, int nSortKey, u8 **ppOut, int *pnOut){
   pOut = (u8*)sqlite3_malloc(nTotal);
   if( !pOut ) return SQLITE_NOMEM;
 
-  /* ---- Pass 2: Write SQLite record ---- */
+  
   {
     int off;
 
-    /* Header: size varint + serial type varints */
+    
     off = putVarint32(pOut, (u32)nHdr);
     for(i = 0; i < nFields; i++){
       off += putVarint32(pOut + off, aType[i]);
     }
 
-    /* Data: field values */
+    
     for(i = 0; i < nFields; i++){
       u32 serialType = aType[i];
       u32 fieldLen = aLen[i];
 
       if( fieldLen == 0 ){
-        /* NULL, or constant int (type 8/9) — no data bytes */
+        
         continue;
       }
 
       if( serialType <= 6 || serialType == 7 ){
-        /* Integer or float — data in aIntBuf */
+        
         memcpy(pOut + off, aIntBuf[i], fieldLen);
         off += (int)fieldLen;
       }else{
-        /* Text or blob — decode from sort key NUL-escaped data */
+        
         const u8 *pSrc = aFieldPtr[i];
         const u8 *pSrcEnd = pSortKey + nSortKey;
         int j = 0;
@@ -477,7 +403,7 @@ int recordFromSortKey(const u8 *pSortKey, int nSortKey, u8 **ppOut, int *pnOut){
             pOut[off++] = pSrc[j];
             j++;
           }else{
-            /* Truncated sort key — pad with zero */
+            
             pOut[off++] = 0x00;
           }
           written++;
@@ -491,4 +417,4 @@ int recordFromSortKey(const u8 *pSortKey, int nSortKey, u8 **ppOut, int *pnOut){
   return SQLITE_OK;
 }
 
-#endif /* DOLTLITE_PROLLY */
+#endif 

--- a/src/sortkey.h
+++ b/src/sortkey.h
@@ -1,71 +1,20 @@
-/*
-** Sort key encoding for BLOBKEY (index) entries.
-**
-** Converts SQLite serialized record format into a byte string where
-** memcmp produces the correct SQLite type-affinity sort order:
-**   NULL < INTEGER < FLOAT < TEXT < BLOB
-**
-** This eliminates the need for field-by-field record parsing during
-** comparison, replacing it with a single memcmp call.
-**
-** Sort key format per field:
-**   NULL:    0x05
-**   Numeric: 0x15 + 8-byte IEEE 754 double with sign normalization
-**            (integers are converted to double for uniform encoding)
-**   Text:    0x35 + raw bytes + 0x00 0x00 terminator
-**   Blob:    0x45 + raw bytes + 0x00 0x00 terminator
-**
-** Tag values are spaced to allow future additions.
-** Text and blob use double-NUL terminator with 0x00→0x00 0x01 escaping
-** so embedded NULs sort correctly.
-*/
+
 #ifndef SQLITE_SORTKEY_H
 #define SQLITE_SORTKEY_H
 
 #include "sqliteInt.h"
 
-/* Type tags — spaced so memcmp gives correct affinity ordering */
 #define SORTKEY_NULL    0x05
-#define SORTKEY_NUM     0x15  /* All numbers (int + float) encoded as double */
+#define SORTKEY_NUM     0x15  
 #define SORTKEY_TEXT    0x35
 #define SORTKEY_BLOB    0x45
 
-/*
-** Compute the sort key for a SQLite serialized record.
-**
-** pRec/nRec:  Input SQLite record (varint header + field data)
-** ppOut:      Output sort key (caller must sqlite3_free)
-** pnOut:      Output sort key size
-**
-** Returns SQLITE_OK on success, SQLITE_NOMEM on allocation failure,
-** SQLITE_CORRUPT if the record is malformed.
-*/
 int sortKeyFromRecord(const u8 *pRec, int nRec, u8 **ppOut, int *pnOut);
 
-/*
-** Compute the sort key size without allocating.
-** Returns the number of bytes needed, or -1 on malformed input.
-*/
 int sortKeySize(const u8 *pRec, int nRec);
 
-/*
-** Decode a sort key back into a SQLite serialized record.
-** The encoding is fully lossless — the reconstructed record is
-** byte-for-byte equivalent to a canonical SQLite record encoding.
-**
-** pSortKey/nSortKey: Input sort key
-** ppOut:             Output SQLite record (caller must sqlite3_free)
-** pnOut:             Output record size
-**
-** Returns SQLITE_OK on success, SQLITE_NOMEM on allocation failure,
-** SQLITE_CORRUPT if the sort key is malformed.
-*/
 int recordFromSortKey(const u8 *pSortKey, int nSortKey, u8 **ppOut, int *pnOut);
 
-/*
-** Compare two sort keys. This is just memcmp with length handling,
-** provided as a convenience for readability.
-*/
 static inline int compareSortKeys(
   const u8 *pKey1, int nKey1,
   const u8 *pKey2, int nKey2
@@ -78,4 +27,4 @@ static inline int compareSortKeys(
   return 0;
 }
 
-#endif /* SQLITE_SORTKEY_H */
+#endif 

--- a/src/sortkey.h
+++ b/src/sortkey.h
@@ -1,4 +1,4 @@
-
+/* BLOBKEY sort key encoding: type-prefixed (NULL/NUM/TEXT/BLOB) for memcmp ordering. */
 #ifndef SQLITE_SORTKEY_H
 #define SQLITE_SORTKEY_H
 


### PR DESCRIPTION
## Summary

Delete all ~3,300 lines of Claude-generated comments from DoltLite source files, then add back only ~170 lines that score 8/10+ on a necessity scale.

**Why:** Aaron's review described the codebase as filled with "detritus, evidence of abandoned attempts." The comments were a major source: stale references to removed code, descriptions of abandoned approaches, wrong claims about endianness, and restated-the-code noise. Trying to audit them individually was unreliable (one audit incorrectly identified used variables as unused, causing a segfault). Deleting everything and deliberately adding back only what matters is more reliable.

**What survives (8/10+ criteria):**
- Binary format documentation (file layout, manifest offsets, WAL records, wire formats)
- Crash safety invariants (fsync durability point, commit protocol steps)
- Non-obvious integration constraints (sort key encoding, table 1 flush requirement, merge iteration model)
- Known hazard warnings (concurrent writer detection, conflict fallthrough)

**What was removed:**
- Comments restating what the code does
- Section divider banners
- Stale references to removed code
- TODO/FIXME without context
- "This function does X" when the function is named X

Net: -3,116 lines across 56 files. Zero logic changes. All 1,344 tests pass.

## Test plan
- [x] Clean build with no errors or warnings
- [x] All 1,344 shell tests pass
- [x] Comments are syntactically inert (no logic changes)

Generated with Claude Code