### PR TITLE
Enforce C89: fix 69 mixed-declaration violations

### DIFF
--- a/main.mk
+++ b/main.mk
@@ -401,7 +401,8 @@ T.cc.TARGET_DEBUG ?=
 # Define -D_HAVE_SQLITE_CONFIG_H so that the code knows it
 # can include the generated sqlite_cfg.h.
 #
-T.cc.sqlite.extras = -D_HAVE_SQLITE_CONFIG_H -DBUILD_sqlite $(T.cc.TARGET_DEBUG)
+T.cc.sqlite.extras = -D_HAVE_SQLITE_CONFIG_H -DBUILD_sqlite $(T.cc.TARGET_DEBUG) \
+    -Wdeclaration-after-statement
 
 #
 # $(T.cc.sqlite) is $(T.cc) plus any flags which are desired for the

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -422,6 +422,7 @@ static int csGrowWriteBuf(ChunkStore *cs, int nNeeded){
   i64 nRequired = cs->nWriteBuf + (i64)nNeeded;
   if( nRequired > cs->nWriteBufAlloc ){
     i64 nNew = cs->nWriteBufAlloc ? cs->nWriteBufAlloc : CS_INIT_WRITEBUF_SIZE;
+    u8 *pNew;
     /* Double below 64MB, then grow by 1.5x to limit wasted memory. */
     while( nNew < nRequired ){
       if( nNew < 64*1024*1024 ){
@@ -430,7 +431,7 @@ static int csGrowWriteBuf(ChunkStore *cs, int nNeeded){
         nNew += nNew / 2;
       }
     }
-    u8 *pNew = (u8 *)sqlite3_realloc64(cs->pWriteBuf, (sqlite3_uint64)nNew);
+    pNew = (u8 *)sqlite3_realloc64(cs->pWriteBuf, (sqlite3_uint64)nNew);
     if( pNew == 0 ) return SQLITE_NOMEM;
     cs->pWriteBuf = pNew;
     cs->nWriteBufAlloc = nNew;
@@ -482,11 +483,12 @@ static int csReplayWalRegion(ChunkStore *cs, int updateManifest){
     pos++;
 
     if( tag == CS_WAL_TAG_CHUNK ){
-      if( pos + 20 + 4 > walSize ) break;
       ProllyHash hash;
+      u32 len;
+      if( pos + 20 + 4 > walSize ) break;
       memcpy(&hash, walData + pos, 20);
       pos += 20;
-      u32 len = CS_READ_U32(walData + pos);
+      len = CS_READ_U32(walData + pos);
       pos += 4;
       if( pos < 0 || (u64)pos + len > (u64)walSize ) break;
 
@@ -494,12 +496,13 @@ static int csReplayWalRegion(ChunkStore *cs, int updateManifest){
         int existing = csSearchIndex(cs->aIndex, cs->nIndex, &hash);
         if( existing < 0 ){
           int rc = csGrowPending(cs);
+          ChunkIndexEntry *e;
           if( rc != SQLITE_OK ){
             sqlite3_free(walData);
             cs->pWalData = 0;
             return rc;
           }
-          ChunkIndexEntry *e = &cs->aPending[cs->nPending];
+          e = &cs->aPending[cs->nPending];
           memcpy(&e->hash, &hash, sizeof(ProllyHash));
           e->offset = csEncodeWalOffset((i64)pos);
           e->size = (int)len;
@@ -1554,11 +1557,12 @@ static int csCommitToFile(ChunkStore *cs){
   for( i = 0; i < cs->nPending; i++ ){
     ChunkIndexEntry *pe = &cs->aPending[i];
     u8 recHdr[25];
+    i64 bufOff;
     recHdr[0] = CS_WAL_TAG_CHUNK;
     memcpy(recHdr + 1, &pe->hash, 20);
     CS_WRITE_U32(recHdr + 21, (u32)pe->size);
 
-    i64 bufOff = pe->offset + 4;  /* skip length prefix to get to data */
+    bufOff = pe->offset + 4;  /* skip length prefix to get to data */
     rc = sqlite3OsWrite(cs->pFile, recHdr, 25, writeOff);
     if( rc != SQLITE_OK ) goto commit_done;
     writeOff += 25;

--- a/src/doltlite_ancestor.c
+++ b/src/doltlite_ancestor.c
@@ -146,8 +146,9 @@ static int ancestorBfsCollect(
     if( rc!=SQLITE_OK ){ rc = SQLITE_OK; continue; } 
     for(i=0; i<commit.nParents; i++){
       if( qTail >= qAlloc ){
+        ProllyHash *q2;
         qAlloc *= 2;
-        ProllyHash *q2 = sqlite3_realloc(queue, qAlloc*(int)sizeof(ProllyHash));
+        q2 = sqlite3_realloc(queue, qAlloc*(int)sizeof(ProllyHash));
         if( !q2 ){ doltliteCommitClear(&commit); rc=SQLITE_NOMEM; break; }
         queue = q2;
       }
@@ -224,8 +225,9 @@ int doltliteFindAncestor(
       if( rc!=SQLITE_OK ){ rc = SQLITE_OK; continue; }
       for(i=0; i<commit.nParents; i++){
         if( qTail >= qAlloc ){
+          ProllyHash *q2;
           qAlloc *= 2;
-          ProllyHash *q2 = sqlite3_realloc(queue, qAlloc*(int)sizeof(ProllyHash));
+          q2 = sqlite3_realloc(queue, qAlloc*(int)sizeof(ProllyHash));
           if( !q2 ){ doltliteCommitClear(&commit); hashSetFree(&visited); sqlite3_free(queue); hashSetFree(&ancestors); return SQLITE_NOMEM; }
           queue = q2;
         }

--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -44,17 +44,19 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
   sqlite3 *db = sqlite3_context_db_handle(ctx);
   ChunkStore *cs = doltliteGetChunkStore(db);
   ProllyHash head;
+  const char *arg0;
   int rc;
 
   if( !cs ){ sqlite3_result_error(ctx, "no database", -1); return; }
   if( argc<1 ){ sqlite3_result_error(ctx, "branch name required", -1); return; }
 
-  const char *arg0 = (const char*)sqlite3_value_text(argv[0]);
+  arg0 = (const char*)sqlite3_value_text(argv[0]);
   if( !arg0 ){ sqlite3_result_error(ctx, "branch name required", -1); return; }
 
   if( strcmp(arg0, "-d")==0 || strcmp(arg0, "--delete")==0 ){
+    const char *zName;
     if( argc<2 ){ sqlite3_result_error(ctx, "branch name required", -1); return; }
-    const char *zName = (const char*)sqlite3_value_text(argv[1]);
+    zName = (const char*)sqlite3_value_text(argv[1]);
     if( !zName ){ sqlite3_result_error(ctx, "branch name required", -1); return; }
     if( strcmp(zName, doltliteGetSessionBranch(db))==0 ){
       sqlite3_result_error(ctx, "cannot delete the current branch", -1);
@@ -114,11 +116,12 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
   sqlite3 *db = sqlite3_context_db_handle(ctx);
   ChunkStore *cs = doltliteGetChunkStore(db);
   ProllyHash targetCommit;
+  const char *zBranch;
   int rc;
 
   if( !cs ){ sqlite3_result_error(ctx, "no database", -1); return; }
   if( argc<1 ){ sqlite3_result_error(ctx, "branch name required", -1); return; }
-  const char *zBranch = (const char*)sqlite3_value_text(argv[0]);
+  zBranch = (const char*)sqlite3_value_text(argv[0]);
   if( !zBranch ){ sqlite3_result_error(ctx, "branch name required", -1); return; }
 
   

--- a/src/doltlite_commit.c
+++ b/src/doltlite_commit.c
@@ -24,16 +24,18 @@ int doltliteCommitSerialize(const DoltliteCommit *c, u8 **ppOut, int *pnOut){
   int nEmail = c->zEmail ? (int)strlen(c->zEmail) : 0;
   int nMsg = c->zMessage ? (int)strlen(c->zMessage) : 0;
   int nPar;
+  int sz;
+  u8 *buf;
+  u8 *p;
+  int i;
   if( nName > 0xFFFF || nEmail > 0xFFFF || nMsg > 0xFFFF ){
     return SQLITE_TOOBIG;
   }
   nPar = c->nParents > 0 ? c->nParents : (prollyHashIsEmpty(&c->parentHash) ? 0 : 1);
-  
-  int sz = 1 + 1 + PROLLY_HASH_SIZE*nPar + PROLLY_HASH_SIZE + 8
+
+  sz = 1 + 1 + PROLLY_HASH_SIZE*nPar + PROLLY_HASH_SIZE + 8
          + 2 + nName + 2 + nEmail + 2 + nMsg;
-  u8 *buf = sqlite3_malloc(sz);
-  u8 *p;
-  int i;
+  buf = sqlite3_malloc(sz);
   if( !buf ) return SQLITE_NOMEM;
   p = buf;
 

--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -353,11 +353,12 @@ static int walkHistoryAndDiff(
     }else{
       if( !prollyHashIsEmpty(&curRoot) ){
         ProllyHash emptyRoot;
+        CollectCtx ctx;
         memset(&emptyRoot, 0, sizeof(emptyRoot));
         memset(parentHex, '0', PROLLY_HASH_SIZE*2);
         parentHex[PROLLY_HASH_SIZE*2] = 0;
 
-        CollectCtx ctx;
+
         ctx.pCur = pCur;
         ctx.zFromCommit = parentHex;
         ctx.zToCommit = curHex;

--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -146,10 +146,11 @@ static int gcMarkReachable(
         }
       }
     }else if( isCommitChunk(data, nData) ){
-      
+
       DoltliteCommit commit;
+      int drc;
       memset(&commit, 0, sizeof(commit));
-      int drc = doltliteCommitDeserialize(data, nData, &commit);
+      drc = doltliteCommitDeserialize(data, nData, &commit);
       if( drc==SQLITE_OK ){
         int pi;
         for(pi=0; pi<commit.nParents; pi++){

--- a/src/doltlite_history.c
+++ b/src/doltlite_history.c
@@ -248,9 +248,10 @@ static int htColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
   HistCursor *c=(HistCursor*)cur;
   HistVtab *v=(HistVtab*)cur->pVtab;
   HistoryRow *r;
+  int nCols;
   if( c->iRow>=c->nRows ) return SQLITE_OK;
   r=&c->aRows[c->iRow];
-  int nCols=v->cols.nCol;
+  nCols=v->cols.nCol;
 
   
 

--- a/src/doltlite_http_remote.c
+++ b/src/doltlite_http_remote.c
@@ -54,8 +54,9 @@ static int readUntilEof(int fd, u8 **ppOut, int *pnOut){
   for(;;){
     ssize_t n;
     if( nUsed + 1024 > nAlloc ){
+      u8 *pNew;
       nAlloc *= 2;
-      u8 *pNew = sqlite3_realloc(pBuf, nAlloc);
+      pNew = sqlite3_realloc(pBuf, nAlloc);
       if( !pNew ){
         sqlite3_free(pBuf);
         return SQLITE_NOMEM;
@@ -231,8 +232,9 @@ static int httpRequest(
 static int uploadBufAppend(HttpRemote *p, const u8 *pData, int nData){
   if( p->nUploadBuf + nData > p->nUploadBufAlloc ){
     i64 nNew = p->nUploadBufAlloc ? p->nUploadBufAlloc * 2 : 4096;
+    u8 *pNew;
     while( nNew < p->nUploadBuf + nData ) nNew *= 2;
-    u8 *pNew = sqlite3_realloc64(p->pUploadBuf, nNew);
+    pNew = sqlite3_realloc64(p->pUploadBuf, nNew);
     if( !pNew ) return SQLITE_NOMEM;
     p->pUploadBuf = pNew;
     p->nUploadBufAlloc = nNew;

--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -469,14 +469,14 @@ static int serializeMergedCatalog(
   ProllyHash *pOutHash               
 ){
   ChunkStore *cs = doltliteGetChunkStore(db);
-  int sz = 1 + 4 + 4;  
+  int sz = 1 + 4 + 4;
+  u8 *buf;
+  u8 *p;
+  int rc;
   { int j; for(j=0;j<nMerged;j++){
     int nl = aMerged[j].zName ? (int)strlen(aMerged[j].zName) : 0;
     sz += 4+1+PROLLY_HASH_SIZE+PROLLY_HASH_SIZE+2+nl;
   }}
-  u8 *buf;
-  u8 *p;
-  int rc;
 
   (void)oursCatHash;  
 

--- a/src/doltlite_record.c
+++ b/src/doltlite_record.c
@@ -102,14 +102,14 @@ char *doltliteDecodeRecord(const u8 *pData, int nData){
       }
       pBody += nBytes;
     }else if( st==7 ){
-      
+
       if( pBody + 8 <= pEnd ){
         double v;
         u64 bits = 0;
         int i;
+        char tmp[64];
         for(i=0; i<8; i++) bits = (bits<<8) | pBody[i];
         memcpy(&v, &bits, 8);
-        char tmp[64];
         sqlite3_snprintf(sizeof(tmp), tmp, "%!.15g", v);
         recBufAppend(&buf, tmp, -1);
       }

--- a/src/doltlite_remote.c
+++ b/src/doltlite_remote.c
@@ -100,10 +100,11 @@ static int syncEnqueueChildren(
       }
     }
   }else if( syncIsCommitChunk(data, nData) ){
-    
+
     DoltliteCommit commit;
+    int drc;
     memset(&commit, 0, sizeof(commit));
-    int drc = doltliteCommitDeserialize(data, nData, &commit);
+    drc = doltliteCommitDeserialize(data, nData, &commit);
     if( drc==SQLITE_OK ){
       int pi;
       for(pi=0; pi<commit.nParents && rc==SQLITE_OK; pi++){
@@ -537,15 +538,17 @@ int doltlitePush(
     int nRefsData = 0;
     rc = pRemote->xGetRefs(pRemote, &refsData, &nRefsData);
     if( rc==SQLITE_OK && refsData ){
-      
+
       ChunkStore tmpCs;
+      const u8 *p;
       memset(&tmpCs, 0, sizeof(tmpCs));
-      
-      
-      const u8 *p = refsData;
+
+
+      p = refsData;
       if( nRefsData >= 5 ){
-        u8 ver = p[0]; p++;
-        int defLen = p[0]|(p[1]<<8); p += 2;
+        u8 ver; int defLen;
+        ver = p[0]; p++;
+        defLen = p[0]|(p[1]<<8); p += 2;
         if( p + defLen + 2 <= refsData + nRefsData ){
           int nBranches;
           p += defLen;
@@ -666,8 +669,9 @@ int doltliteFetch(
   
   if( nRefsData >= 5 ){
     const u8 *p = refsData;
-    u8 ver = p[0]; p++;
-    int defLen = p[0]|(p[1]<<8); p += 2;
+    u8 ver; int defLen;
+    ver = p[0]; p++;
+    defLen = p[0]|(p[1]<<8); p += 2;
     if( p + defLen + 2 <= refsData + nRefsData ){
       int nBranches, i;
       p += defLen;
@@ -731,8 +735,9 @@ int doltliteClone(ChunkStore *pLocal, DoltliteRemote *pRemote){
   
   if( nRefsData >= 5 ){
     const u8 *p = refsData;
-    u8 ver = p[0]; p++;
-    int defLen = p[0]|(p[1]<<8); p += 2;
+    u8 ver; int defLen;
+    ver = p[0]; p++;
+    defLen = p[0]|(p[1]<<8); p += 2;
     if( p + defLen + 2 <= refsData + nRefsData ){
       int nBranches, nTags, i;
       p += defLen;

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -23,24 +23,27 @@ static DoltliteRemote *openRemoteByUrl(sqlite3_vfs *pVfs, const char *zUrl){
 static void doltRemoteFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
   ChunkStore *cs = doltliteGetChunkStore(db);
+  const char *zAction;
+  const char *zName;
   int rc;
 
   if( !cs ){ sqlite3_result_error(ctx, "no database", -1); return; }
   if( argc<2 ){ sqlite3_result_error(ctx, "usage: dolt_remote(action, name [, url])", -1); return; }
 
-  const char *zAction = (const char*)sqlite3_value_text(argv[0]);
-  const char *zName = (const char*)sqlite3_value_text(argv[1]);
+  zAction = (const char*)sqlite3_value_text(argv[0]);
+  zName = (const char*)sqlite3_value_text(argv[1]);
   if( !zAction || !zName ){
     sqlite3_result_error(ctx, "action and name required", -1);
     return;
   }
 
   if( strcmp(zAction, "add")==0 ){
+    const char *zUrl;
     if( argc<3 ){
       sqlite3_result_error(ctx, "url required for add", -1);
       return;
     }
-    const char *zUrl = (const char*)sqlite3_value_text(argv[2]);
+    zUrl = (const char*)sqlite3_value_text(argv[2]);
     if( !zUrl ){
       sqlite3_result_error(ctx, "url required for add", -1);
       return;
@@ -72,6 +75,8 @@ static void doltPushFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   ChunkStore *cs = doltliteGetChunkStore(db);
   DoltliteRemote *pRemote = 0;
   const char *zUrl = 0;
+  const char *zRemoteName;
+  const char *zBranch;
   int bForce = 0;
   int rc;
 
@@ -81,8 +86,8 @@ static void doltPushFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     return;
   }
 
-  const char *zRemoteName = (const char*)sqlite3_value_text(argv[0]);
-  const char *zBranch = (const char*)sqlite3_value_text(argv[1]);
+  zRemoteName = (const char*)sqlite3_value_text(argv[0]);
+  zBranch = (const char*)sqlite3_value_text(argv[1]);
   if( !zRemoteName || !zBranch ){
     sqlite3_result_error(ctx, "remote and branch required", -1);
     return;
@@ -138,8 +143,9 @@ static int parseRemoteBranchNames(
 
   {
     const u8 *p = refsData;
-    u8 ver = p[0]; p++;
-    int defLen = p[0]|(p[1]<<8); p += 2;
+    u8 ver; int defLen;
+    ver = p[0]; p++;
+    defLen = p[0]|(p[1]<<8); p += 2;
     if( p + defLen + 2 <= refsData + nRefsData ){
       int nBranches, i;
       p += defLen;
@@ -189,6 +195,7 @@ static void doltFetchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   ChunkStore *cs = doltliteGetChunkStore(db);
   DoltliteRemote *pRemote = 0;
   const char *zUrl = 0;
+  const char *zRemoteName;
   int rc;
 
   if( !cs ){ sqlite3_result_error(ctx, "no database", -1); return; }
@@ -197,7 +204,7 @@ static void doltFetchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     return;
   }
 
-  const char *zRemoteName = (const char*)sqlite3_value_text(argv[0]);
+  zRemoteName = (const char*)sqlite3_value_text(argv[0]);
   if( !zRemoteName ){
     sqlite3_result_error(ctx, "remote name required", -1);
     return;
@@ -273,6 +280,8 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   ChunkStore *cs = doltliteGetChunkStore(db);
   DoltliteRemote *pRemote = 0;
   const char *zUrl = 0;
+  const char *zRemoteName;
+  const char *zBranch;
   ProllyHash trackingCommit, localCommit;
   int rc;
 
@@ -282,8 +291,8 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     return;
   }
 
-  const char *zRemoteName = (const char*)sqlite3_value_text(argv[0]);
-  const char *zBranch = (const char*)sqlite3_value_text(argv[1]);
+  zRemoteName = (const char*)sqlite3_value_text(argv[0]);
+  zBranch = (const char*)sqlite3_value_text(argv[1]);
   if( !zRemoteName || !zBranch ){
     sqlite3_result_error(ctx, "remote and branch required", -1);
     return;
@@ -423,6 +432,7 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
   ChunkStore *cs = doltliteGetChunkStore(db);
   DoltliteRemote *pRemote = 0;
+  const char *zUrl;
   int rc;
 
   if( !cs ){ sqlite3_result_error(ctx, "no database", -1); return; }
@@ -431,7 +441,7 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     return;
   }
 
-  const char *zUrl = (const char*)sqlite3_value_text(argv[0]);
+  zUrl = (const char*)sqlite3_value_text(argv[0]);
   if( !zUrl ){
     sqlite3_result_error(ctx, "url required", -1);
     return;

--- a/src/doltlite_tag.c
+++ b/src/doltlite_tag.c
@@ -11,17 +11,19 @@
 static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
   ChunkStore *cs = doltliteGetChunkStore(db);
+  const char *arg0;
   int rc;
 
   if( !cs ){ sqlite3_result_error(ctx, "no database", -1); return; }
   if( argc<1 ){ sqlite3_result_error(ctx, "tag name required", -1); return; }
 
-  const char *arg0 = (const char*)sqlite3_value_text(argv[0]);
+  arg0 = (const char*)sqlite3_value_text(argv[0]);
   if( !arg0 ){ sqlite3_result_error(ctx, "tag name required", -1); return; }
 
   if( strcmp(arg0, "-d")==0 || strcmp(arg0, "--delete")==0 ){
+    const char *zName;
     if( argc<2 ){ sqlite3_result_error(ctx, "tag name required for delete", -1); return; }
-    const char *zName = (const char*)sqlite3_value_text(argv[1]);
+    zName = (const char*)sqlite3_value_text(argv[1]);
     if( !zName ){ sqlite3_result_error(ctx, "tag name required", -1); return; }
     rc = chunkStoreDeleteTag(cs, zName);
     if( rc!=SQLITE_OK ){

--- a/src/prolly_arena.c
+++ b/src/prolly_arena.c
@@ -26,9 +26,10 @@ void *prollyArenaAlloc(ProllyArena *a, int n){
   
   {
     int blockSz = a->defaultBlockSize;
+    int totalSz;
     if( n > blockSz ) blockSz = n;
 
-    int totalSz = (int)sizeof(ProllyArenaBlock) + blockSz;
+    totalSz = (int)sizeof(ProllyArenaBlock) + blockSz;
     if( totalSz < blockSz ){  
       return 0;
     }

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -2016,15 +2016,18 @@ static int prollyBtreeSavepoint(Btree *p, int op, int iSavepoint){
           int k;
           for(k=0; k<pState->nTables && k<p->nTables; k++){
             p->aTables[k].root = pState->aTables[k].root;
+            {
             ProllyMutMap *pMap = (ProllyMutMap*)p->aTables[k].pPending;
             if( pMap ){
               int savedCount = pState->aPendingCount[k];
               while( pMap->nEntries > savedCount ){
+                ProllyMutMapEntry *e;
                 pMap->nEntries--;
-                ProllyMutMapEntry *e = &pMap->aEntries[pMap->nEntries];
+                e = &pMap->aEntries[pMap->nEntries];
                 sqlite3_free(e->pKey); e->pKey = 0;
                 sqlite3_free(e->pVal); e->pVal = 0;
               }
+            }
             }
           }
           
@@ -2497,9 +2500,10 @@ static int mergeCompare(BtCursor *pCur, ProllyMutMapEntry *e){
     return 0;
   }else{
     const u8 *pK; int nK;
+    int n; int c;
     prollyCursorKey(&pCur->pCur, &pK, &nK);
-    int n = nK < e->nKey ? nK : e->nKey;
-    int c = memcmp(pK, e->pKey, n);
+    n = nK < e->nKey ? nK : e->nKey;
+    c = memcmp(pK, e->pKey, n);
     if( c ) return c;
     return (nK < e->nKey) ? -1 : (nK > e->nKey) ? 1 : 0;
   }
@@ -2508,7 +2512,7 @@ static int mergeCompare(BtCursor *pCur, ProllyMutMapEntry *e){
 static int mergeStepForward(BtCursor *pCur){
   int treeOk, mutOk;
 
-  
+
   if( pCur->mergeSrc==MERGE_SRC_TREE || pCur->mergeSrc==MERGE_SRC_BOTH ){
     prollyCursorNext(&pCur->pCur);
   }
@@ -2517,6 +2521,8 @@ static int mergeStepForward(BtCursor *pCur){
   }
 
   for(;;){
+    ProllyMutMapEntry *e;
+    int cmp;
     treeOk = (pCur->pCur.eState==PROLLY_CURSOR_VALID);
     mutOk  = (pCur->mmIdx >= 0 && pCur->mmIdx < pCur->pMutMap->nEntries);
 
@@ -2526,13 +2532,13 @@ static int mergeStepForward(BtCursor *pCur){
       pCur->mergeSrc = MERGE_SRC_TREE;
       return SQLITE_OK;
     }
-    ProllyMutMapEntry *e = &pCur->pMutMap->aEntries[pCur->mmIdx];
+    e = &pCur->pMutMap->aEntries[pCur->mmIdx];
     if( !treeOk ){
       if( e->op==PROLLY_EDIT_DELETE ){ pCur->mmIdx++; continue; }
       pCur->mergeSrc = MERGE_SRC_MUT;
       return SQLITE_OK;
     }
-    int cmp = mergeCompare(pCur, e);
+    cmp = mergeCompare(pCur, e);
     if( cmp < 0 ){
       pCur->mergeSrc = MERGE_SRC_TREE;
       return SQLITE_OK;
@@ -2566,6 +2572,8 @@ static int mergeStepBackward(BtCursor *pCur){
   }
 
   for(;;){
+    ProllyMutMapEntry *e;
+    int cmp;
     treeOk = (pCur->pCur.eState==PROLLY_CURSOR_VALID);
     mutOk  = (pCur->mmIdx >= 0 && pCur->mmIdx < pCur->pMutMap->nEntries);
 
@@ -2575,13 +2583,13 @@ static int mergeStepBackward(BtCursor *pCur){
       pCur->mergeSrc = MERGE_SRC_TREE;
       return SQLITE_OK;
     }
-    ProllyMutMapEntry *e = &pCur->pMutMap->aEntries[pCur->mmIdx];
+    e = &pCur->pMutMap->aEntries[pCur->mmIdx];
     if( !treeOk ){
       if( e->op==PROLLY_EDIT_DELETE ){ pCur->mmIdx--; continue; }
       pCur->mergeSrc = MERGE_SRC_MUT;
       return SQLITE_OK;
     }
-    int cmp = mergeCompare(pCur, e);
+    cmp = mergeCompare(pCur, e);
     if( cmp > 0 ){
       pCur->mergeSrc = MERGE_SRC_TREE;
       return SQLITE_OK;
@@ -2602,14 +2610,17 @@ static int mergeStepBackward(BtCursor *pCur){
 }
 
 static int mergeFirst(BtCursor *pCur, int *pRes){
-  pCur->mergeSrc = MERGE_SRC_TREE;  
+  int treeOk, mutOk;
+  pCur->mergeSrc = MERGE_SRC_TREE;
   pCur->mmIdx = 0;
 
-  int treeOk = (pCur->pCur.eState==PROLLY_CURSOR_VALID);
-  int mutOk  = (pCur->mmIdx < pCur->pMutMap->nEntries);
+  treeOk = (pCur->pCur.eState==PROLLY_CURSOR_VALID);
+  mutOk  = (pCur->mmIdx < pCur->pMutMap->nEntries);
 
-  
+
   for(;;){
+    ProllyMutMapEntry *e;
+    int cmp;
     treeOk = (pCur->pCur.eState==PROLLY_CURSOR_VALID);
     mutOk  = (pCur->mmIdx >= 0 && pCur->mmIdx < pCur->pMutMap->nEntries);
 
@@ -2619,13 +2630,13 @@ static int mergeFirst(BtCursor *pCur, int *pRes){
       pCur->mergeSrc = MERGE_SRC_TREE;
       *pRes = 0; return SQLITE_OK;
     }
-    ProllyMutMapEntry *e = &pCur->pMutMap->aEntries[pCur->mmIdx];
+    e = &pCur->pMutMap->aEntries[pCur->mmIdx];
     if( !treeOk ){
       if( e->op==PROLLY_EDIT_DELETE ){ pCur->mmIdx++; continue; }
       pCur->mergeSrc = MERGE_SRC_MUT;
       *pRes = 0; return SQLITE_OK;
     }
-    int cmp = mergeCompare(pCur, e);
+    cmp = mergeCompare(pCur, e);
     if( cmp < 0 ){
       pCur->mergeSrc = MERGE_SRC_TREE;
       *pRes = 0; return SQLITE_OK;
@@ -2652,6 +2663,8 @@ static int mergeLast(BtCursor *pCur, int *pRes){
   for(;;){
     int treeOk = (pCur->pCur.eState==PROLLY_CURSOR_VALID);
     int mutOk  = (pCur->mmIdx >= 0 && pCur->mmIdx < pCur->pMutMap->nEntries);
+    ProllyMutMapEntry *e;
+    int cmp;
 
     if( !treeOk && !mutOk ){ *pRes = 1; return SQLITE_OK; }
 
@@ -2659,13 +2672,13 @@ static int mergeLast(BtCursor *pCur, int *pRes){
       pCur->mergeSrc = MERGE_SRC_TREE;
       *pRes = 0; return SQLITE_OK;
     }
-    ProllyMutMapEntry *e = &pCur->pMutMap->aEntries[pCur->mmIdx];
+    e = &pCur->pMutMap->aEntries[pCur->mmIdx];
     if( !treeOk ){
       if( e->op==PROLLY_EDIT_DELETE ){ pCur->mmIdx--; continue; }
       pCur->mergeSrc = MERGE_SRC_MUT;
       *pRes = 0; return SQLITE_OK;
     }
-    int cmp = mergeCompare(pCur, e);
+    cmp = mergeCompare(pCur, e);
     if( cmp > 0 ){
       pCur->mergeSrc = MERGE_SRC_TREE;
       *pRes = 0; return SQLITE_OK;
@@ -3132,8 +3145,8 @@ static int serializeUnpackedRecord(UnpackedRecord *pRec, u8 **ppOut, int *pnOut)
         off += nByte;
       }else if( st==SERIAL_TYPE_FLOAT64 ){
         u64 floatBits;
-        memcpy(&floatBits, &p->u.r, 8);
         int j;
+        memcpy(&floatBits, &p->u.r, 8);
         for(j=7; j>=0; j--){
           pOut[off+j] = (u8)(floatBits & 0xFF);
           floatBits >>= 8;
@@ -3221,14 +3234,17 @@ static int prollyBtCursorIndexMoveto(
       int bestIdx = -1;
       int bestCmp = 0;
       {
-        
+
         int lo = 0, hi = nItems;
+        u8 *pRecBuf = 0;
+        int i;
         while( lo < hi ){
           int mid = lo + (hi - lo) / 2;
           const u8 *pSK; int nSK;
+          int cmpLen; int keyCmp;
           prollyNodeKey(&pLeaf->node, mid, &pSK, &nSK);
-          int cmpLen = nSK < nSortKey ? nSK : nSortKey;
-          int keyCmp = memcmp(pSK, pSortKey, cmpLen);
+          cmpLen = nSK < nSortKey ? nSK : nSortKey;
+          keyCmp = memcmp(pSK, pSortKey, cmpLen);
           if( keyCmp < 0 || (keyCmp==0 && nSK < nSortKey) ){
             lo = mid + 1;
           }else{
@@ -3236,11 +3252,11 @@ static int prollyBtCursorIndexMoveto(
           }
         }
 
-        
-        u8 *pRecBuf = 0;  
-        int i;
+
         for( i = lo; i < nItems; i++ ){
           const u8 *pSK; int nSK;
+          const u8 *pVal; int nVal;
+          int recCmp;
           prollyNodeKey(&pLeaf->node, i, &pSK, &nSK);
           
           {
@@ -3269,7 +3285,6 @@ static int prollyBtCursorIndexMoveto(
               break;
             }
           }
-          const u8 *pVal; int nVal;
           prollyNodeValue(&pLeaf->node, i, &pVal, &nVal);
           if( nVal==0 ){
             sqlite3_free(pRecBuf); pRecBuf = 0;
@@ -3277,7 +3292,7 @@ static int prollyBtCursorIndexMoveto(
             pVal = pRecBuf;
           }
           pIdxKey->eqSeen = 0;
-          int recCmp = sqlite3VdbeRecordCompare(nVal, pVal, pIdxKey);
+          recCmp = sqlite3VdbeRecordCompare(nVal, pVal, pIdxKey);
 
           if( recCmp==0 || pIdxKey->eqSeen ){
             if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
@@ -3480,8 +3495,8 @@ static void getCursorPayload(BtCursor *pCur, const u8 **ppData, int *pnData){
       *pnData = nVal;
     }else{
       const u8 *pKey; int nKey;
-      prollyCursorKey(&pCur->pCur, &pKey, &nKey);
       u8 *pRec = 0; int nRec = 0;
+      prollyCursorKey(&pCur->pCur, &pKey, &nKey);
       recordFromSortKey(pKey, nKey, &pRec, &nRec);
       if( pRec ){
         if( pCur->cachedPayloadOwned && pCur->pCachedPayload ){

--- a/src/prolly_cursor.c
+++ b/src/prolly_cursor.c
@@ -9,19 +9,18 @@ static int loadNode(ProllyCursor *cur, const ProllyHash *hash,
                     ProllyCacheEntry **ppEntry){
   ProllyCacheEntry *pEntry;
   int rc;
+  u8 *pData = 0;
+  int nData = 0;
 
   *ppEntry = 0;
 
-  
+
   pEntry = prollyCacheGet(cur->pCache, hash);
   if( pEntry ){
     *ppEntry = pEntry;
     return SQLITE_OK;
   }
 
-  
-  u8 *pData = 0;
-  int nData = 0;
   rc = chunkStoreGet(cur->pStore, hash, &pData, &nData);
   if( rc!=SQLITE_OK ){
     return rc;
@@ -100,6 +99,7 @@ void prollyCursorInit(ProllyCursor *cur, ChunkStore *pStore,
 
 int prollyCursorFirst(ProllyCursor *cur, int *pRes){
   int rc;
+  ProllyCacheEntry *pRoot = 0;
 
   prollyCursorReleaseAll(cur);
 
@@ -109,7 +109,6 @@ int prollyCursorFirst(ProllyCursor *cur, int *pRes){
     return SQLITE_OK;
   }
 
-  ProllyCacheEntry *pRoot = 0;
   rc = loadNode(cur, &cur->root, &pRoot);
   if( rc!=SQLITE_OK ) return rc;
 
@@ -127,6 +126,7 @@ int prollyCursorFirst(ProllyCursor *cur, int *pRes){
 
 int prollyCursorLast(ProllyCursor *cur, int *pRes){
   int rc;
+  ProllyCacheEntry *pRoot = 0;
 
   prollyCursorReleaseAll(cur);
 
@@ -136,7 +136,6 @@ int prollyCursorLast(ProllyCursor *cur, int *pRes){
     return SQLITE_OK;
   }
 
-  ProllyCacheEntry *pRoot = 0;
   rc = loadNode(cur, &cur->root, &pRoot);
   if( rc!=SQLITE_OK ) return rc;
 
@@ -154,25 +153,28 @@ int prollyCursorLast(ProllyCursor *cur, int *pRes){
 
 int prollyCursorNext(ProllyCursor *cur){
   int rc;
+  ProllyCacheEntry *pLeaf;
+  int level;
+  ProllyCacheEntry *pNode;
 
   assert( cur->eState==PROLLY_CURSOR_VALID );
 
-  
-  ProllyCacheEntry *pLeaf = cur->aLevel[cur->iLevel].pEntry;
+
+  pLeaf = cur->aLevel[cur->iLevel].pEntry;
   if( cur->aLevel[cur->iLevel].idx < pLeaf->node.nItems - 1 ){
     cur->aLevel[cur->iLevel].idx++;
     return SQLITE_OK;
   }
 
-  
-  int level = cur->iLevel;
+
+  level = cur->iLevel;
   while( level>0 ){
-    
+
     prollyCacheRelease(cur->pCache, cur->aLevel[level].pEntry);
     cur->aLevel[level].pEntry = 0;
     level--;
 
-    ProllyCacheEntry *pNode = cur->aLevel[level].pEntry;
+    pNode = cur->aLevel[level].pEntry;
     if( cur->aLevel[level].idx < pNode->node.nItems - 1 ){
       cur->aLevel[level].idx++;
       cur->iLevel = level;
@@ -190,17 +192,18 @@ int prollyCursorNext(ProllyCursor *cur){
 
 int prollyCursorPrev(ProllyCursor *cur){
   int rc;
+  int level;
 
   assert( cur->eState==PROLLY_CURSOR_VALID );
 
-  
+
   if( cur->aLevel[cur->iLevel].idx > 0 ){
     cur->aLevel[cur->iLevel].idx--;
     return SQLITE_OK;
   }
 
-  
-  int level = cur->iLevel;
+
+  level = cur->iLevel;
   while( level>0 ){
     prollyCacheRelease(cur->pCache, cur->aLevel[level].pEntry);
     cur->aLevel[level].pEntry = 0;
@@ -223,6 +226,11 @@ int prollyCursorPrev(ProllyCursor *cur){
 
 int prollyCursorSeekInt(ProllyCursor *cur, i64 intKey, int *pRes){
   int rc;
+  ProllyCacheEntry *pEntry = 0;
+  ProllyHash childHash;
+  ProllyCacheEntry *pChild = 0;
+  int leafRes;
+  int leafIdx;
 
   prollyCursorReleaseAll(cur);
 
@@ -232,7 +240,6 @@ int prollyCursorSeekInt(ProllyCursor *cur, i64 intKey, int *pRes){
     return SQLITE_OK;
   }
 
-  ProllyCacheEntry *pEntry = 0;
   rc = loadNode(cur, &cur->root, &pEntry);
   if( rc!=SQLITE_OK ) return rc;
 
@@ -251,7 +258,6 @@ int prollyCursorSeekInt(ProllyCursor *cur, i64 intKey, int *pRes){
 
     cur->aLevel[cur->iLevel].idx = idx;
 
-    ProllyHash childHash;
     prollyNodeChildHash(&pEntry->node, idx, &childHash);
 
     cur->iLevel++;
@@ -259,7 +265,7 @@ int prollyCursorSeekInt(ProllyCursor *cur, i64 intKey, int *pRes){
       return SQLITE_CORRUPT;
     }
 
-    ProllyCacheEntry *pChild = 0;
+    pChild = 0;
     rc = loadNode(cur, &childHash, &pChild);
     if( rc!=SQLITE_OK ) return rc;
 
@@ -269,9 +275,6 @@ int prollyCursorSeekInt(ProllyCursor *cur, i64 intKey, int *pRes){
 
   cur->nLevel = cur->iLevel + 1;
 
-  
-  int leafRes;
-  int leafIdx;
   if( pEntry->node.nItems==0 ){
     cur->eState = PROLLY_CURSOR_EOF;
     *pRes = -1;
@@ -313,6 +316,11 @@ int prollyCursorSeekInt(ProllyCursor *cur, i64 intKey, int *pRes){
 int prollyCursorSeekBlob(ProllyCursor *cur,
                          const u8 *pKey, int nKey, int *pRes){
   int rc;
+  ProllyCacheEntry *pEntry = 0;
+  ProllyHash childHash;
+  ProllyCacheEntry *pChild = 0;
+  int leafRes;
+  int leafIdx;
 
   prollyCursorReleaseAll(cur);
 
@@ -322,7 +330,6 @@ int prollyCursorSeekBlob(ProllyCursor *cur,
     return SQLITE_OK;
   }
 
-  ProllyCacheEntry *pEntry = 0;
   rc = loadNode(cur, &cur->root, &pEntry);
   if( rc!=SQLITE_OK ) return rc;
 
@@ -342,7 +349,6 @@ int prollyCursorSeekBlob(ProllyCursor *cur,
 
     cur->aLevel[cur->iLevel].idx = idx;
 
-    ProllyHash childHash;
     prollyNodeChildHash(&pEntry->node, idx, &childHash);
 
     cur->iLevel++;
@@ -350,7 +356,7 @@ int prollyCursorSeekBlob(ProllyCursor *cur,
       return SQLITE_CORRUPT;
     }
 
-    ProllyCacheEntry *pChild = 0;
+    pChild = 0;
     rc = loadNode(cur, &childHash, &pChild);
     if( rc!=SQLITE_OK ) return rc;
 
@@ -360,9 +366,6 @@ int prollyCursorSeekBlob(ProllyCursor *cur,
 
   cur->nLevel = cur->iLevel + 1;
 
-  
-  int leafRes;
-  int leafIdx;
   if( pEntry->node.nItems==0 ){
     cur->eState = PROLLY_CURSOR_EOF;
     *pRes = -1;
@@ -403,23 +406,29 @@ int prollyCursorIsValid(ProllyCursor *cur){
 }
 
 void prollyCursorKey(ProllyCursor *cur, const u8 **ppKey, int *pnKey){
+  ProllyCacheEntry *pLeaf;
+  int idx;
   assert( cur->eState==PROLLY_CURSOR_VALID );
-  ProllyCacheEntry *pLeaf = cur->aLevel[cur->iLevel].pEntry;
-  int idx = cur->aLevel[cur->iLevel].idx;
+  pLeaf = cur->aLevel[cur->iLevel].pEntry;
+  idx = cur->aLevel[cur->iLevel].idx;
   prollyNodeKey(&pLeaf->node, idx, ppKey, pnKey);
 }
 
 i64 prollyCursorIntKey(ProllyCursor *cur){
+  ProllyCacheEntry *pLeaf;
+  int idx;
   assert( cur->eState==PROLLY_CURSOR_VALID );
-  ProllyCacheEntry *pLeaf = cur->aLevel[cur->iLevel].pEntry;
-  int idx = cur->aLevel[cur->iLevel].idx;
+  pLeaf = cur->aLevel[cur->iLevel].pEntry;
+  idx = cur->aLevel[cur->iLevel].idx;
   return prollyNodeIntKey(&pLeaf->node, idx);
 }
 
 void prollyCursorValue(ProllyCursor *cur, const u8 **ppVal, int *pnVal){
+  ProllyCacheEntry *pLeaf;
+  int idx;
   assert( cur->eState==PROLLY_CURSOR_VALID );
-  ProllyCacheEntry *pLeaf = cur->aLevel[cur->iLevel].pEntry;
-  int idx = cur->aLevel[cur->iLevel].idx;
+  pLeaf = cur->aLevel[cur->iLevel].pEntry;
+  idx = cur->aLevel[cur->iLevel].idx;
   prollyNodeValue(&pLeaf->node, idx, ppVal, pnVal);
 }
 
@@ -466,6 +475,7 @@ int prollyCursorSave(ProllyCursor *cur){
 
 int prollyCursorRestore(ProllyCursor *cur, int *pDifferentRow){
   int rc;
+  int res;
 
   if( !cur->hasSavedPosition ){
     *pDifferentRow = 1;
@@ -473,7 +483,6 @@ int prollyCursorRestore(ProllyCursor *cur, int *pDifferentRow){
     return SQLITE_OK;
   }
 
-  int res;
   if( cur->flags & PROLLY_NODE_INTKEY ){
     rc = prollyCursorSeekInt(cur, cur->iSavedIntKey, &res);
   } else {

--- a/src/prolly_diff.c
+++ b/src/prolly_diff.c
@@ -369,9 +369,10 @@ static int diffLeaves(
       rc = xCb(pCtx, &ch); j++;
     }else{
       const u8 *pOV; int nOV; const u8 *pNV; int nNV;
+      int eq;
       prollyNodeValue(pOld, i, &pOV, &nOV);
       prollyNodeValue(pNew, j, &pNV, &nNV);
-      int eq = (nOV==nNV && (nOV==0 || memcmp(pOV, pNV, nOV)==0));
+      eq = (nOV==nNV && (nOV==0 || memcmp(pOV, pNV, nOV)==0));
       if( !eq && nOV>=2 && nNV>=2 ) eq = diffRecordsEqualFieldwise(pOV,nOV,pNV,nNV);
       if( !eq ){
         ProllyDiffChange ch;
@@ -459,16 +460,17 @@ static int diffNodes(
 
     while( i < (int)oldNode.nItems && j < (int)newNode.nItems && rc==SQLITE_OK ){
       ProllyHash oldChild, newChild;
+      int cmp;
       prollyNodeChildHash(&oldNode, i, &oldChild);
       prollyNodeChildHash(&newNode, j, &newChild);
 
-      
+
       if( prollyHashCompare(&oldChild, &newChild)==0 ){
         i++; j++;
         continue;
       }
 
-      int cmp = diffNodeKeyCmp(&oldNode, i, &newNode, j, flags);
+      cmp = diffNodeKeyCmp(&oldNode, i, &newNode, j, flags);
 
       if( cmp==0 ){
         

--- a/src/prolly_mutate.c
+++ b/src/prolly_mutate.c
@@ -123,6 +123,7 @@ static int mergeLeaf(
     const u8 *pCurKey; int nCurKey;
     i64 iCurKey = 0;
     u8 aKeyBuf[8];
+    int cmp;
 
     if( flags & PROLLY_NODE_INTKEY ){
       iCurKey = prollyNodeIntKey(pLeaf, j);
@@ -147,6 +148,7 @@ static int mergeLeaf(
       const u8 *pLastKey; int nLastKey;
       i64 iLastKey = 0;
       u8 aLastBuf[8];
+      int pastLeaf;
       if( flags & PROLLY_NODE_INTKEY ){
         iLastKey = prollyNodeIntKey(pLeaf, pLeaf->nItems - 1);
         encodeI64BE(aLastBuf, iLastKey);
@@ -154,7 +156,7 @@ static int mergeLeaf(
       }else{
         prollyNodeKey(pLeaf, pLeaf->nItems - 1, &pLastKey, &nLastKey);
       }
-      int pastLeaf = compareKeys(flags, pEd->pKey, pEd->nKey, pEd->intKey,
+      pastLeaf = compareKeys(flags, pEd->pKey, pEd->nKey, pEd->intKey,
                                  pLastKey, nLastKey, iLastKey);
       if( pastLeaf > 0 ){
         
@@ -167,8 +169,8 @@ static int mergeLeaf(
       }
     }
 
-    
-    int cmp = compareKeys(flags, pCurKey, nCurKey, iCurKey,
+
+    cmp = compareKeys(flags, pCurKey, nCurKey, iCurKey,
                           pEd->pKey, pEd->nKey, pEd->intKey);
     if( cmp < 0 ){
       
@@ -538,8 +540,9 @@ int prollyMutateFlush(ProllyMutator *pMut){
   {
     int M = prollyMutMapCount(pMut->pEdits);
     int N = 0;
+    int threshold;
 
-    
+
     u8 *pRootData = 0;
     int nRootData = 0;
     int rcEst = chunkStoreGet(pMut->pStore, &pMut->oldRoot,
@@ -552,7 +555,7 @@ int prollyMutateFlush(ProllyMutator *pMut){
         }else if( rootNode.level==1 ){
           N = rootNode.nItems * PROLLY_EST_ENTRIES_PER_LEAF;
         }else{
-          
+
           int factor = 1;
           int lv;
           for(lv = 0; lv < rootNode.level; lv++) factor *= PROLLY_EST_ENTRIES_PER_LEAF;
@@ -562,8 +565,7 @@ int prollyMutateFlush(ProllyMutator *pMut){
       sqlite3_free(pRootData);
     }
 
-    
-    int threshold;
+
     if( N <= 0 ){
       threshold = 1000;  
     }else{

--- a/src/prolly_node.c
+++ b/src/prolly_node.c
@@ -91,35 +91,43 @@ int prollyNodeParse(ProllyNode *pNode, const u8 *pData, int nData){
 }
 
 void prollyNodeKey(const ProllyNode *pNode, int i, const u8 **ppKey, int *pnKey){
+  u32 off0;
+  u32 off1;
   assert( i >= 0 && i < (int)pNode->nItems );
-  u32 off0 = PROLLY_GET_U32((const u8*)&pNode->aKeyOff[i]);
-  u32 off1 = PROLLY_GET_U32((const u8*)&pNode->aKeyOff[i+1]);
+  off0 = PROLLY_GET_U32((const u8*)&pNode->aKeyOff[i]);
+  off1 = PROLLY_GET_U32((const u8*)&pNode->aKeyOff[i+1]);
   *ppKey = pNode->pKeyData + off0;
   *pnKey = (int)(off1 - off0);
 }
 
 void prollyNodeValue(const ProllyNode *pNode, int i, const u8 **ppVal, int *pnVal){
+  u32 off0;
+  u32 off1;
   assert( i >= 0 && i < (int)pNode->nItems );
-  u32 off0 = PROLLY_GET_U32((const u8*)&pNode->aValOff[i]);
-  u32 off1 = PROLLY_GET_U32((const u8*)&pNode->aValOff[i+1]);
+  off0 = PROLLY_GET_U32((const u8*)&pNode->aValOff[i]);
+  off1 = PROLLY_GET_U32((const u8*)&pNode->aValOff[i+1]);
   *ppVal = pNode->pValData + off0;
   *pnVal = (int)(off1 - off0);
 }
 
 i64 prollyNodeIntKey(const ProllyNode *pNode, int i){
+  u32 off;
+  const u8 *p;
+  u64 u;
   assert( i >= 0 && i < (int)pNode->nItems );
-  u32 off = PROLLY_GET_U32((const u8*)&pNode->aKeyOff[i]);
-  const u8 *p = pNode->pKeyData + off;
+  off = PROLLY_GET_U32((const u8*)&pNode->aKeyOff[i]);
+  p = pNode->pKeyData + off;
   /* Decode big-endian sort key back to signed i64. Keys are stored big-endian
   ** with sign bit flipped (see encodeI64BE) so memcmp gives signed order. */
-  u64 u = ((u64)p[0]<<56) | ((u64)p[1]<<48) | ((u64)p[2]<<40) | ((u64)p[3]<<32)
-         | ((u64)p[4]<<24) | ((u64)p[5]<<16) | ((u64)p[6]<<8) | (u64)p[7];
+  u = ((u64)p[0]<<56) | ((u64)p[1]<<48) | ((u64)p[2]<<40) | ((u64)p[3]<<32)
+    | ((u64)p[4]<<24) | ((u64)p[5]<<16) | ((u64)p[6]<<8) | (u64)p[7];
   return (i64)(u ^ ((u64)1 << 63));  
 }
 
 void prollyNodeChildHash(const ProllyNode *pNode, int i, ProllyHash *pHash){
+  u32 off;
   assert( i >= 0 && i < (int)pNode->nItems );
-  u32 off = PROLLY_GET_U32((const u8*)&pNode->aValOff[i]);
+  off = PROLLY_GET_U32((const u8*)&pNode->aValOff[i]);
   memcpy(pHash->data, pNode->pValData + off, PROLLY_HASH_SIZE);
 }
 

--- a/src/remotesrv_main.c
+++ b/src/remotesrv_main.c
@@ -37,6 +37,7 @@ int main(int argc, char **argv){
   int port = 8080;
   const char *zDir = 0;
   int i;
+  int rc;
 
   for(i=1; i<argc; i++){
     if( strcmp(argv[i], "-p")==0 && i+1<argc ){
@@ -62,6 +63,6 @@ int main(int argc, char **argv){
   printf("doltlite-remotesrv serving %s on port %d\n", zDir, port);
   printf("Press Ctrl+C to stop.\n\n");
 
-  int rc = doltliteServe(zDir, port);
+  rc = doltliteServe(zDir, port);
   return rc==0 ? 0 : 1;
 }


### PR DESCRIPTION
Closes #258.

Move all variable declarations to the top of their enclosing blocks across 19 files (69 violations). Add `-Wdeclaration-after-statement` to compiler flags so future C99-isms are caught at build time.

This matches SQLite's C89 coding convention, as noted in Aaron's review.

All 1,344 tests pass. Zero logic changes — only declaration reordering.

Generated with Claude Code