### PR TITLE
Replace hardcoded catalog offsets in GC with named constants

### DIFF
--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -37,6 +37,17 @@
 #define WS_CONFLICTS_OFF    (WS_MERGE_COMMIT_OFF + PROLLY_HASH_SIZE)
 #define WS_TOTAL_SIZE       (WS_CONFLICTS_OFF + PROLLY_HASH_SIZE)
 
+/* Catalog (table registry) binary format V2:
+**   magic(1) + iNextTable(4 LE) + nTables(4 LE) + entries...
+** Per entry: iTable(4 LE) + flags(1) + root(20) + schema(20) + nameLen(2 LE) + name */
+#define CATALOG_FORMAT_V2       0x43
+#define CAT_NEXT_TABLE_OFF      1
+#define CAT_NUM_TABLES_OFF      5
+#define CAT_HEADER_SIZE         9
+#define CAT_ENTRY_ITABLE_SIZE   4
+#define CAT_ENTRY_FLAGS_SIZE    1
+#define CAT_ENTRY_FIXED_SIZE    (CAT_ENTRY_ITABLE_SIZE + CAT_ENTRY_FLAGS_SIZE + PROLLY_HASH_SIZE + PROLLY_HASH_SIZE + 2)
+
 typedef struct ChunkStore ChunkStore;
 typedef struct ChunkIndexEntry ChunkIndexEntry;
 typedef struct ConflictEntry ConflictEntry;

--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -175,22 +175,26 @@ static int gcMarkReachable(
         }
       }
       
-      if( nData >= 9 && data[0] == 0x43 ){
-        int nTables = (int)(data[5] | (data[6]<<8) |
-                            (data[7]<<16) | (data[8]<<24));
+      if( nData >= CAT_HEADER_SIZE && data[0] == CATALOG_FORMAT_V2 ){
+        int nTables = (int)(data[CAT_NUM_TABLES_OFF]
+                          | (data[CAT_NUM_TABLES_OFF+1]<<8)
+                          | (data[CAT_NUM_TABLES_OFF+2]<<16)
+                          | (data[CAT_NUM_TABLES_OFF+3]<<24));
         if( nTables >= 0 && nTables < 10000 ){
-          const u8 *p = data + 9;
+          const u8 *p = data + CAT_HEADER_SIZE;
           for(i=0; i<nTables; i++){
-            if( p + 4 + 1 + PROLLY_HASH_SIZE + PROLLY_HASH_SIZE + 2 > data + nData ) break;
+            if( p + CAT_ENTRY_FIXED_SIZE > data + nData ) break;
             {
               ProllyHash tableRoot;
-              memcpy(tableRoot.data, p + 5, PROLLY_HASH_SIZE);
+              memcpy(tableRoot.data, p + CAT_ENTRY_ITABLE_SIZE + CAT_ENTRY_FLAGS_SIZE,
+                     PROLLY_HASH_SIZE);
               rc = gcQueuePush(&queue, &tableRoot);
               if( rc!=SQLITE_OK ) break;
             }
             {
               int nameLen;
-              p += 4 + 1 + PROLLY_HASH_SIZE + PROLLY_HASH_SIZE;
+              p += CAT_ENTRY_ITABLE_SIZE + CAT_ENTRY_FLAGS_SIZE
+                 + PROLLY_HASH_SIZE + PROLLY_HASH_SIZE;
               nameLen = p[0] | (p[1]<<8);
               p += 2 + nameLen;
             }

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -5,6 +5,7 @@
 typedef struct BtShared BtShared;
 typedef struct ProllyCache ProllyCache;
 
+
 struct TableEntry {
   Pgno iTable;           
   ProllyHash root;       

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -778,8 +778,6 @@ static void refreshCursorRoot(BtCursor *pCur){
   }
 }
 
-#define CATALOG_FORMAT_V2 0x43
-
 /*
 ** Catalog serialization format (V2):
 **   Byte 0:       CATALOG_FORMAT_V2 magic (0x43)


### PR DESCRIPTION
Closes #260.

Move catalog V2 format constants to chunk_store.h so the serializer (prolly_btree.c) and GC mark traversal (doltlite_gc.c) share the same definitions. Replaces raw magic numbers with CAT_HEADER_SIZE, CAT_NUM_TABLES_OFF, CAT_ENTRY_FIXED_SIZE, etc.

All GC tests pass.

Generated with Claude Code