### PR TITLE
Remove fallback generic schemas from virtual tables

### DIFF
--- a/src/doltlite_at.c
+++ b/src/doltlite_at.c
@@ -153,7 +153,7 @@ static int atScanTree(AtCursor *pCur, ChunkStore *cs, ProllyCache *pCache,
 static int atConnect(sqlite3 *db, void *pAux, int argc,
     const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){
   AtVtab *v; int rc; const char *zMod; char *zSchema;
-  (void)pAux;(void)pzErr;
+  (void)pAux;
 
   v=sqlite3_malloc(sizeof(*v)); if(!v) return SQLITE_NOMEM;
   memset(v,0,sizeof(*v)); v->db=db;
@@ -166,11 +166,12 @@ static int atConnect(sqlite3 *db, void *pAux, int argc,
 
   doltliteGetColumnNames(db,v->zTableName,&v->cols);
 
-  if(v->cols.nCol>0){
-    zSchema=atBuildSchema(&v->cols);
-  }else{
-    zSchema=sqlite3_mprintf("CREATE TABLE x(rowid_val INTEGER, value TEXT, commit_ref TEXT HIDDEN)");
+  if(v->cols.nCol<=0){
+    sqlite3_free(v->zTableName);doltliteFreeColInfo(&v->cols);sqlite3_free(v);
+    *pzErr=sqlite3_mprintf("table '%s' not found or has no columns",v->zTableName?v->zTableName:"");
+    return SQLITE_ERROR;
   }
+  zSchema=atBuildSchema(&v->cols);
   if(!zSchema){sqlite3_free(v->zTableName);doltliteFreeColInfo(&v->cols);sqlite3_free(v);return SQLITE_NOMEM;}
 
   rc=sqlite3_declare_vtab(db,zSchema); sqlite3_free(zSchema);

--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -407,16 +407,14 @@ static int dtConnect(sqlite3 *db, void *pAux, int argc,
   doltliteGetColumnNames(db, pVtab->zTableName, &pVtab->cols);
 
   
-  if( pVtab->cols.nCol > 0 ){
-    zSchema = buildDiffSchema(&pVtab->cols);
-  }else{
-    
-    zSchema = sqlite3_mprintf(
-      "CREATE TABLE x(from_value, to_value,"
-      " from_commit TEXT, to_commit TEXT,"
-      " from_commit_date TEXT, to_commit_date TEXT,"
-      " diff_type TEXT)");
+  if( pVtab->cols.nCol <= 0 ){
+    sqlite3_free(pVtab->zTableName);
+    doltliteFreeColInfo(&pVtab->cols);
+    sqlite3_free(pVtab);
+    *pzErr = sqlite3_mprintf("table '%s' not found or has no columns", argv[3] ? argv[3] : "");
+    return SQLITE_ERROR;
   }
+  zSchema = buildDiffSchema(&pVtab->cols);
 
   if( !zSchema ){
     sqlite3_free(pVtab->zTableName);
@@ -548,29 +546,13 @@ static int dtColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
   }else{
     
     int fixedCol = col - 2*nCols;
-    if( nCols == 0 ) fixedCol = col; 
 
     switch( fixedCol ){
-      case 0: 
-        if( nCols == 0 ){
-          
-          if( r->pOldVal )
-            sqlite3_result_blob(ctx, r->pOldVal, r->nOldVal, SQLITE_TRANSIENT);
-          else
-            sqlite3_result_null(ctx);
-        }else{
-          sqlite3_result_text(ctx, r->zFromCommit, -1, SQLITE_TRANSIENT);
-        }
+      case 0:
+        sqlite3_result_text(ctx, r->zFromCommit, -1, SQLITE_TRANSIENT);
         break;
-      case 1: 
-        if( nCols == 0 ){
-          if( r->pNewVal )
-            sqlite3_result_blob(ctx, r->pNewVal, r->nNewVal, SQLITE_TRANSIENT);
-          else
-            sqlite3_result_null(ctx);
-        }else{
-          sqlite3_result_text(ctx, r->zToCommit, -1, SQLITE_TRANSIENT);
-        }
+      case 1:
+        sqlite3_result_text(ctx, r->zToCommit, -1, SQLITE_TRANSIENT);
         break;
       case 2: 
         { time_t t = (time_t)r->fromDate; struct tm *tm = gmtime(&t);

--- a/src/doltlite_history.c
+++ b/src/doltlite_history.c
@@ -181,7 +181,7 @@ static int htWalkHistory(HistCursor *pCur, sqlite3 *db, const char *zTableName){
 static int htConnect(sqlite3 *db, void *pAux, int argc,
     const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){
   HistVtab *v; int rc; const char *zMod; char *zSchema;
-  (void)pAux;(void)pzErr;
+  (void)pAux;
 
   v=sqlite3_malloc(sizeof(*v)); if(!v) return SQLITE_NOMEM;
   memset(v,0,sizeof(*v)); v->db=db;
@@ -194,11 +194,12 @@ static int htConnect(sqlite3 *db, void *pAux, int argc,
 
   doltliteGetColumnNames(db,v->zTableName,&v->cols);
 
-  if(v->cols.nCol>0){
-    zSchema=htBuildSchema(&v->cols);
-  }else{
-    zSchema=sqlite3_mprintf("CREATE TABLE x(value TEXT, commit_hash TEXT, committer TEXT, commit_date TEXT)");
+  if(v->cols.nCol<=0){
+    sqlite3_free(v->zTableName);doltliteFreeColInfo(&v->cols);sqlite3_free(v);
+    *pzErr=sqlite3_mprintf("table '%s' not found or has no columns",v->zTableName?v->zTableName:"");
+    return SQLITE_ERROR;
   }
+  zSchema=htBuildSchema(&v->cols);
   if(!zSchema){sqlite3_free(v->zTableName);doltliteFreeColInfo(&v->cols);sqlite3_free(v);return SQLITE_NOMEM;}
 
   rc=sqlite3_declare_vtab(db,zSchema); sqlite3_free(zSchema);
@@ -270,17 +271,9 @@ static int htColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
     }
   }else{
     int fixedCol=col-nCols;
-    if(nCols==0) fixedCol=col;
     switch(fixedCol){
-      case 0: 
-        if(nCols==0){
-          
-          char *z=doltliteDecodeRecord(r->pVal,r->nVal);
-          if(z) sqlite3_result_text(ctx,z,-1,sqlite3_free);
-          else sqlite3_result_null(ctx);
-        }else{
-          sqlite3_result_text(ctx,r->zCommit,-1,SQLITE_TRANSIENT);
-        }
+      case 0:
+        sqlite3_result_text(ctx,r->zCommit,-1,SQLITE_TRANSIENT);
         break;
       case 1: 
         sqlite3_result_text(ctx,r->zCommitter,-1,SQLITE_TRANSIENT);

--- a/test/doltlite_edge_cases.sh
+++ b/test/doltlite_edge_cases.sh
@@ -968,6 +968,47 @@ run_test_match "branchfrom_to_main" "SELECT dolt_merge('dev');" "^[0-9a-f]{40}$"
 rm -f "$DB"
 
 # ============================================================
+# Virtual table error on nonexistent table (regression: previously
+# these fell back to generic schemas instead of erroring)
+# ============================================================
+
+echo ""
+echo "--- Virtual table errors for missing tables ---"
+
+DB=/tmp/test_edge_vtab_err_$$.db; rm -f "$DB"
+echo "CREATE TABLE real_table(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO real_table VALUES(1,'x');
+SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+# Schema must use real column names (from_v, to_v), not generic fallback
+# names (from_value, to_value). The fallback was removed — if column
+# detection fails, the vtable now returns an error instead.
+run_test_match "diff_schema_has_from_v" \
+  "SELECT group_concat(name) FROM pragma_table_info('dolt_diff_real_table');" \
+  "from_v" "$DB"
+
+run_test_match "diff_schema_no_generic" \
+  "SELECT group_concat(name) FROM pragma_table_info('dolt_diff_real_table');" \
+  "from_v.*to_v" "$DB"
+
+run_test_match "history_schema_has_v" \
+  "SELECT group_concat(name) FROM pragma_table_info('dolt_history_real_table');" \
+  "\bv\b" "$DB"
+
+# Virtual tables work with real data
+run_test_match "diff_table_real_works" \
+  "SELECT count(*) FROM dolt_diff_real_table;" \
+  "^[0-9]" "$DB"
+run_test_match "history_real_works" \
+  "SELECT count(*) FROM dolt_history_real_table;" \
+  "^[0-9]" "$DB"
+run_test_match "at_real_works" \
+  "SELECT count(*) FROM dolt_at_real_table('HEAD');" \
+  "^[0-9]" "$DB"
+
+rm -f "$DB"
+
+# ============================================================
 # Done
 # ============================================================
 


### PR DESCRIPTION
Closes #252.

dolt_diff_<table>, dolt_at_<table>, and dolt_history_<table> had fallback code that produced generic schemas when column names couldn't be determined. This silently gave wrong results. Now returns SQLITE_ERROR with a descriptive message instead.

Also removes the now-unreachable nCols==0 branches in column() methods.

-24 net lines. All tests pass.

Generated with Claude Code