### PR TITLE
Fix README claims, BFS dolt_history, remove stress test tolerance

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,11 +244,9 @@ SELECT dolt_reset('--hard');   -- discard all uncommitted changes
 
 ### Branching (Per-Session)
 
-Each connection tracks its own active branch. Two connections can be on
-different branches, seeing different data, at the same time. Branch state
-(active branch name, HEAD commit, staged catalog hash) lives in the `Btree`
-struct (per-connection). The chunk store in `BtShared` is shared across
-connections.
+Each connection tracks its own active branch. Branch state (active branch
+name, HEAD commit, staged catalog hash) lives in the `Btree` struct
+(per-connection). Each connection gets its own `BtShared` and chunk store.
 
 ```sql
 -- Create a branch at current HEAD
@@ -509,18 +507,20 @@ SELECT * FROM dolt_diff('config');
 
 ## Per-Session Branching Architecture
 
-SQLite's `Btree` struct is per-connection. Doltlite stores each session's
-branch name, HEAD commit hash, and staged catalog hash there. The underlying
-chunk store (`BtShared`) is shared. This means:
+Each connection gets its own `Btree` and `BtShared` (not shared across
+connections). Doltlite stores the session's branch name, HEAD commit hash,
+and staged catalog hash in the `Btree` struct.
 
-- Two connections to the same database file can be on different branches.
-- Each sees its own tables, schema, and data based on its branch's HEAD.
+- Each connection can be on a different branch.
 - `dolt_checkout` reloads the table registry from the target branch's catalog.
-- Writers are serialized by SQLite's existing locking, so branch switches are
-  safe.
-
-The `concurrent_branch_test.c` test demonstrates two connections on different
-branches querying different data simultaneously.
+- All commit graph mutations (`dolt_commit`, `dolt_merge`, `dolt_reset`,
+  `dolt_branch`, `dolt_tag`, push, pull) are serialized via an exclusive
+  file-level lock. Under that lock, the connection refreshes from disk
+  before writing, preventing silent data loss from concurrent commits.
+- DML (INSERT/UPDATE/DELETE) operates on the connection's local state
+  with no cross-connection locking. DoltLite is currently validated for
+  single-writer use; concurrent DML from multiple connections to the same
+  tables is not supported.
 
 ## Performance
 

--- a/src/doltlite_history.c
+++ b/src/doltlite_history.c
@@ -148,23 +148,59 @@ static int htScanAtCommit(
   prollyCursorClose(&cur); return SQLITE_OK;
 }
 
+/* BFS all parents with dedup, matching dolt_log traversal order. */
 static int htWalkHistory(HistCursor *pCur, sqlite3 *db, const char *zTableName){
   ChunkStore *cs=doltliteGetChunkStore(db);
-  ProllyCache *pCache; ProllyHash curHash; int rc;
+  ProllyCache *pCache;
+  ProllyHash *queue=0, *visited=0;
+  int qHead=0, qTail=0, qAlloc=0;
+  int nVisited=0, nVisitedAlloc=0;
+  int rc=SQLITE_OK;
+  ProllyHash head;
+
   if(!cs) return SQLITE_OK;
   pCache=doltliteGetCache(db);
   if(!pCache) return SQLITE_OK;
-  chunkStoreGetHeadCommit(cs,&curHash);
-  while(!prollyHashIsEmpty(&curHash)){
-    u8 *data=0;int nData=0; DoltliteCommit commit;
+
+  doltliteGetSessionHead(db, &head);
+  if(prollyHashIsEmpty(&head)) return SQLITE_OK;
+
+  qAlloc=16;
+  queue=sqlite3_malloc(qAlloc*(int)sizeof(ProllyHash));
+  if(!queue) return SQLITE_NOMEM;
+  queue[qTail++]=head;
+
+  while(qHead<qTail){
+    ProllyHash cur=queue[qHead++];
+    u8 *data=0; int nData=0;
+    DoltliteCommit commit;
     ProllyHash tableRoot; u8 flags=0;
     char hexBuf[PROLLY_HASH_SIZE*2+1];
+    int dup=0, i;
+
+    for(i=0;i<nVisited;i++){
+      if(prollyHashCompare(&visited[i],&cur)==0){dup=1;break;}
+    }
+    if(dup) continue;
+
+    if(nVisited>=nVisitedAlloc){
+      int na=nVisitedAlloc?nVisitedAlloc*2:16;
+      ProllyHash *tmp=sqlite3_realloc(visited,na*(int)sizeof(ProllyHash));
+      if(!tmp){rc=SQLITE_NOMEM;break;}
+      visited=tmp; nVisitedAlloc=na;
+    }
+    visited[nVisited++]=cur;
+
     memset(&commit,0,sizeof(commit));
-    rc=chunkStoreGet(cs,&curHash,&data,&nData); if(rc!=SQLITE_OK) break;
-    rc=doltliteCommitDeserialize(data,nData,&commit); sqlite3_free(data);
+    rc=chunkStoreGet(cs,&cur,&data,&nData);
     if(rc!=SQLITE_OK) break;
-    doltliteHashToHex(&curHash,hexBuf);
-    {struct TableEntry *aT=0;int nT=0;
+    rc=doltliteCommitDeserialize(data,nData,&commit);
+    sqlite3_free(data);
+    if(rc!=SQLITE_OK) break;
+
+    doltliteHashToHex(&cur,hexBuf);
+    {
+      struct TableEntry *aT=0; int nT=0;
       rc=doltliteLoadCatalog(db,&commit.catalogHash,&aT,&nT,0);
       if(rc==SQLITE_OK){
         if(htFindRoot(aT,nT,zTableName,&tableRoot,&flags)==SQLITE_OK)
@@ -172,10 +208,24 @@ static int htWalkHistory(HistCursor *pCur, sqlite3 *db, const char *zTableName){
         sqlite3_free(aT);
       }
     }
-    {ProllyHash next;memcpy(&next,&commit.parentHash,sizeof(ProllyHash));
-      doltliteCommitClear(&commit);memcpy(&curHash,&next,sizeof(ProllyHash));}
+
+    for(i=0;i<commit.nParents;i++){
+      if(prollyHashIsEmpty(&commit.aParents[i])) continue;
+      if(qTail>=qAlloc){
+        int na=qAlloc*2;
+        ProllyHash *tmp=sqlite3_realloc(queue,na*(int)sizeof(ProllyHash));
+        if(!tmp){rc=SQLITE_NOMEM;break;}
+        queue=tmp; qAlloc=na;
+      }
+      queue[qTail++]=commit.aParents[i];
+    }
+    doltliteCommitClear(&commit);
+    if(rc!=SQLITE_OK) break;
   }
-  return SQLITE_OK;
+
+  sqlite3_free(queue);
+  sqlite3_free(visited);
+  return rc;
 }
 
 static int htConnect(sqlite3 *db, void *pAux, int argc,

--- a/test/concurrent_stress_test.c
+++ b/test/concurrent_stress_test.c
@@ -2459,13 +2459,5 @@ int main(void){
 
   printf("=== Results: %d passed, %d failed out of %d total ===\n",
          nPass, nFail, nTotal);
-  /* Known failures from shared BtShared corruption (issue #250):
-  ** 2.2, 2.3, 2.10, 4.6 — these involve concurrent DML from multiple
-  ** connections. Exit 0 if ONLY known failures remain, exit 1 if new
-  ** regressions appear. */
-  if( nFail > 0 && nFail <= 4 ){
-    printf("(all failures are known issues — see #250)\n");
-    return 0;
-  }
   return nFail > 0 ? 1 : 0;
 }

--- a/test/review_regression_test.sh
+++ b/test/review_regression_test.sh
@@ -1,0 +1,307 @@
+#!/bin/bash
+#
+# Regression guards for every issue from Aaron's code review.
+# Each test section references the specific bug it prevents from regressing.
+# If any of these fail, a fix from the review remediation has regressed.
+#
+DOLTLITE=./doltlite
+PASS=0; FAIL=0; ERRORS=""
+run_test() {
+  local n="$1" s="$2" e="$3" d="$4"
+  local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1)
+  if [ "$r" = "$e" ]; then PASS=$((PASS+1))
+  else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi
+}
+run_test_match() {
+  local n="$1" s="$2" p="$3" d="$4"
+  local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1)
+  if echo "$r"|grep -qE "$p"; then PASS=$((PASS+1))
+  else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  pattern: $p\n  got:     $r"; fi
+}
+
+echo "=== Review Regression Guards ==="
+echo ""
+
+# ============================================================
+# GUARD 1: Durability — committed data survives reopen
+# Bug: pre-fsync manifest overwrite could lose data on crash
+# Fix: removed write to offset 0 before fsync
+# ============================================================
+
+echo "--- Guard 1: Durability (data survives reopen) ---"
+
+DB=/tmp/test_rg_durable_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'durable');
+SELECT dolt_commit('-A','-m','persist test');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test "durable_data" "SELECT v FROM t WHERE id=1;" "durable" "$DB"
+run_test "durable_log" "SELECT count(*) FROM dolt_log;" "1" "$DB"
+
+# Second commit
+echo "INSERT INTO t VALUES(2,'also durable');
+SELECT dolt_commit('-A','-m','second persist');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test "durable_second" "SELECT v FROM t WHERE id=2;" "also durable" "$DB"
+run_test "durable_log2" "SELECT count(*) FROM dolt_log;" "2" "$DB"
+rm -f "$DB"
+
+# ============================================================
+# GUARD 2: Error propagation — corrupt refs returns error
+# Bug: csDeserializeRefs errors were silently swallowed,
+#      losing all branches/tags without any error
+# Fix: propagate error at all 3 call sites + consistency check
+# ============================================================
+
+echo "--- Guard 2: Error propagation (refs integrity) ---"
+
+DB=/tmp/test_rg_refs_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id INT);
+INSERT INTO t VALUES(1);
+SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+# Refs must exist after commit
+run_test_match "refs_exist" \
+  "SELECT count(*) FROM dolt_branches;" "^[1-9]" "$DB"
+
+# Branches must have valid commit hashes
+run_test_match "refs_valid_hash" \
+  "SELECT length(hash) FROM dolt_branches LIMIT 1;" "^40$" "$DB"
+
+rm -f "$DB"
+
+# ============================================================
+# GUARD 3: Concurrent commit conflict detection
+# Bug: two connections commit to same branch, first is silently
+#      lost. No error, no indication of data loss.
+# Fix: session HEAD vs branch tip check under graph lock
+# ============================================================
+
+echo "--- Guard 3: Concurrent commit detection ---"
+
+# This requires the C test (concurrent_commit_test.c) which
+# exercises the actual two-connection scenario. Here we verify
+# the simpler invariant: after commit, session HEAD matches
+# branch tip (prerequisite for conflict detection to work).
+
+DB=/tmp/test_rg_conflict_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id INT, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_commit('-A','-m','first');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+# HEAD commit hash should match the branch's commit hash
+run_test "head_matches_branch" \
+  "SELECT (SELECT commit_hash FROM dolt_log LIMIT 1) = (SELECT hash FROM dolt_branches WHERE name='main');" \
+  "1" "$DB"
+
+# After a second commit, still matches
+echo "INSERT INTO t VALUES(2,'b');
+SELECT dolt_commit('-A','-m','second');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test "head_matches_branch_2" \
+  "SELECT (SELECT commit_hash FROM dolt_log LIMIT 1) = (SELECT hash FROM dolt_branches WHERE name='main');" \
+  "1" "$DB"
+
+rm -f "$DB"
+
+# ============================================================
+# GUARD 4: Merge log shows both parents' history
+# Bug: dolt_log and dolt_history only followed parentHash
+#      (first parent), missing the merged branch's commits
+# Fix: BFS all parents with dedup
+# ============================================================
+
+echo "--- Guard 4: Merge log shows both parents ---"
+
+DB=/tmp/test_rg_merge_log_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'main1');
+SELECT dolt_commit('-A','-m','main init');
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES(2,'feat1');
+SELECT dolt_commit('-A','-m','feature work');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(3,'main2');
+SELECT dolt_commit('-A','-m','main work');
+SELECT dolt_merge('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+# Log must have 4 entries: merge + main work + feature work + init
+run_test "merge_log_all_parents" \
+  "SELECT count(*) FROM dolt_log;" "4" "$DB"
+
+# Feature commit must be visible in the log
+run_test_match "merge_log_has_feature" \
+  "SELECT group_concat(message, '|') FROM dolt_log;" "feature work" "$DB"
+
+# Main commit must also be visible
+run_test_match "merge_log_has_main" \
+  "SELECT group_concat(message, '|') FROM dolt_log;" "main work" "$DB"
+
+rm -f "$DB"
+
+# ============================================================
+# GUARD 5: Branch commit reopen with diverged manifest head
+# Bug: p->root was set from always-empty commit.rootHash,
+#      zeroing the working tree on reopen
+# Fix: use chunkStoreGetRoot instead of commit.rootHash
+# ============================================================
+
+echo "--- Guard 5: Branch reopen with diverged manifest ---"
+
+DB=/tmp/test_rg_diverge_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'from_main');
+SELECT dolt_commit('-A','-m','main commit');
+SELECT dolt_branch('dev');
+SELECT dolt_checkout('dev');
+INSERT INTO t VALUES(2,'from_dev');
+SELECT dolt_commit('-A','-m','dev commit');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(3,'main_again');
+SELECT dolt_commit('-A','-m','main second');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+# Reopen on dev — manifest head is main's latest, not dev's
+echo "SELECT dolt_checkout('dev');" | $DOLTLITE "$DB" > /dev/null 2>&1
+run_test "diverged_dev_count" "SELECT count(*) FROM t;" "2" "$DB"
+run_test "diverged_dev_val" "SELECT v FROM t WHERE id=2;" "from_dev" "$DB"
+
+rm -f "$DB"
+
+# ============================================================
+# GUARD 6: Virtual tables use real column names, not fallback
+# Bug: when column names couldn't be determined, virtual tables
+#      fell back to generic schemas (from_value, to_value)
+# Fix: return SQLITE_ERROR instead of generic schema
+# ============================================================
+
+echo "--- Guard 6: Virtual table schema correctness ---"
+
+DB=/tmp/test_rg_vtab_$$.db; rm -f "$DB"
+echo "CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT, age INT);
+INSERT INTO users VALUES(1,'alice',30);
+SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+# dolt_diff_users must have from_name/to_name columns, not from_value/to_value
+run_test_match "diff_has_real_cols" \
+  "SELECT group_concat(name) FROM pragma_table_info('dolt_diff_users');" \
+  "from_name" "$DB"
+
+# dolt_history_users must have actual column names
+run_test_match "history_has_real_cols" \
+  "SELECT group_concat(name) FROM pragma_table_info('dolt_history_users');" \
+  "\bname\b" "$DB"
+
+rm -f "$DB"
+
+# ============================================================
+# GUARD 7: Commit chain integrity after multiple operations
+# Bug: various issues could leave orphan commits, broken chains
+# Fix: multiple fixes; this verifies the invariant holistically
+# ============================================================
+
+echo "--- Guard 7: Commit chain integrity ---"
+
+DB=/tmp/test_rg_chain_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_commit('-A','-m','c1');
+INSERT INTO t VALUES(2,'b');
+SELECT dolt_commit('-A','-m','c2');
+SELECT dolt_branch('br');
+SELECT dolt_checkout('br');
+INSERT INTO t VALUES(3,'c');
+SELECT dolt_commit('-A','-m','c3');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(4,'d');
+SELECT dolt_commit('-A','-m','c4');
+SELECT dolt_merge('br');
+SELECT dolt_commit('-A','-m','c5 merge');
+SELECT dolt_gc();" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+# After all operations + GC, commit chain must be intact
+run_test_match "chain_log_count" \
+  "SELECT count(*) FROM dolt_log;" "^[5-6]$" "$DB"
+
+# All branches must point to valid commits
+run_test_match "chain_branches_valid" \
+  "SELECT length(hash) FROM dolt_branches WHERE name='main';" "^40$" "$DB"
+
+# Data must be complete
+run_test "chain_data_count" "SELECT count(*) FROM t;" "4" "$DB"
+
+# Reopen and verify persistence
+run_test "chain_reopen_count" "SELECT count(*) FROM t;" "4" "$DB"
+run_test_match "chain_reopen_log" \
+  "SELECT count(*) FROM dolt_log;" "^[5-6]$" "$DB"
+
+rm -f "$DB"
+
+# ============================================================
+# GUARD 8: Encoding consistency (LE macros match inline code)
+# Bug: encoding was done inline with inconsistent patterns
+# Fix: shared PROLLY_GET/PUT_U16/U32 macros
+# Invariant: round-trip encode/decode produces same values
+# (tested implicitly by all persistence tests; this verifies
+# the serialization format hasn't drifted)
+# ============================================================
+
+echo "--- Guard 8: Serialization round-trip ---"
+
+DB=/tmp/test_rg_serial_$$.db; rm -f "$DB"
+
+# Create data that exercises various field types and sizes
+echo "CREATE TABLE mixed(
+  id INTEGER PRIMARY KEY,
+  name TEXT,
+  score REAL,
+  data BLOB,
+  flag INTEGER
+);
+INSERT INTO mixed VALUES(1,'hello',3.14,X'DEADBEEF',1);
+INSERT INTO mixed VALUES(2,'world',2.71828,X'00FF00FF00',0);
+INSERT INTO mixed VALUES(999999,'big id',0.0,NULL,-1);
+SELECT dolt_commit('-A','-m','mixed types');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+# Reopen and verify all types survived serialization
+run_test "serial_text" "SELECT name FROM mixed WHERE id=1;" "hello" "$DB"
+run_test "serial_real" "SELECT printf('%.2f',score) FROM mixed WHERE id=1;" "3.14" "$DB"
+run_test "serial_blob" "SELECT hex(data) FROM mixed WHERE id=1;" "DEADBEEF" "$DB"
+run_test "serial_null" "SELECT data IS NULL FROM mixed WHERE id=999999;" "1" "$DB"
+run_test "serial_negative" "SELECT flag FROM mixed WHERE id=999999;" "-1" "$DB"
+run_test "serial_large_id" "SELECT name FROM mixed WHERE id=999999;" "big id" "$DB"
+
+rm -f "$DB"
+
+# ============================================================
+# GUARD 9: GC preserves all reachable data
+# Bug: hardcoded offsets in GC catalog parsing could miss chunks
+# Fix: named constants (CAT_HEADER_SIZE, etc.)
+# ============================================================
+
+echo "--- Guard 9: GC preserves data ---"
+
+DB=/tmp/test_rg_gc_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'before gc');
+SELECT dolt_commit('-A','-m','pre-gc');
+INSERT INTO t VALUES(2,'more data');
+SELECT dolt_commit('-A','-m','pre-gc 2');
+SELECT dolt_gc();" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test "gc_data_intact" "SELECT count(*) FROM t;" "2" "$DB"
+run_test "gc_log_intact" "SELECT count(*) FROM dolt_log;" "2" "$DB"
+run_test "gc_val_intact" "SELECT v FROM t WHERE id=1;" "before gc" "$DB"
+
+# Reopen after GC
+run_test "gc_reopen_data" "SELECT count(*) FROM t;" "2" "$DB"
+
+rm -f "$DB"
+
+# ============================================================
+# Done
+# ============================================================
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
+if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi


### PR DESCRIPTION
Addresses remaining gaps from Aaron's code review:

**README**: Fix the inaccurate claims Aaron quoted. BtShared is NOT shared across connections. Document the actual concurrency model (graph lock serializes commits, DML is single-writer).

**dolt_history**: BFS all parents with dedup, matching the dolt_log fix from #270. Previously only followed parentHash, missing merged branch rows.

**concurrent_stress_test**: Remove tolerance code for 4 "known failures" — they all pass now with the graph lock from #272. 116/116 stress tests pass.

All 1,344 shell tests pass.

Generated with Claude Code