### PR TITLE
Fix cross-branch corruption with per-branch working catalog state

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -343,6 +343,7 @@ void csSerializeManifest(const ChunkStore *cs, u8 *aBuf){
   memcpy(aBuf + 64, cs->headCommit.data, PROLLY_HASH_SIZE);
   CS_WRITE_I64(aBuf + 84, cs->iWalOffset);
   memcpy(aBuf + 104, cs->refsHash.data, PROLLY_HASH_SIZE);
+  memcpy(aBuf + 124, cs->workingState.data, PROLLY_HASH_SIZE);
 }
 
 static void csSerializeIndexEntry(const ChunkIndexEntry *e, u8 *aBuf){
@@ -378,6 +379,7 @@ static int csReadManifest(ChunkStore *cs){
   memcpy(cs->headCommit.data, aBuf + 64, PROLLY_HASH_SIZE);
   cs->iWalOffset = CS_READ_I64(aBuf + 84);
   memcpy(cs->refsHash.data, aBuf + 104, PROLLY_HASH_SIZE);
+  memcpy(cs->workingState.data, aBuf + 124, PROLLY_HASH_SIZE);
 
   return SQLITE_OK;
 }
@@ -547,6 +549,7 @@ static int csReplayWalRegion(ChunkStore *cs, int updateManifest){
           memcpy(cs->catalog.data, m + 44, PROLLY_HASH_SIZE);
           memcpy(cs->headCommit.data, m + 64, PROLLY_HASH_SIZE);
           memcpy(cs->refsHash.data, m + 104, PROLLY_HASH_SIZE);
+          memcpy(cs->workingState.data, m + 124, PROLLY_HASH_SIZE);
           /* Don't update iWalOffset/iIndexOffset from WAL root records --
           ** those fields describe the compacted region and only change on GC. */
         }
@@ -825,6 +828,14 @@ void chunkStoreGetHeadCommit(ChunkStore *cs, ProllyHash *pHead){
 
 void chunkStoreSetHeadCommit(ChunkStore *cs, const ProllyHash *pHead){
   memcpy(&cs->headCommit, pHead, sizeof(ProllyHash));
+}
+
+void chunkStoreGetWorkingState(ChunkStore *cs, ProllyHash *pState){
+  memcpy(pState, &cs->workingState, sizeof(ProllyHash));
+}
+
+void chunkStoreSetWorkingState(ChunkStore *cs, const ProllyHash *pState){
+  memcpy(&cs->workingState, pState, sizeof(ProllyHash));
 }
 
 void chunkStoreGetStagedCatalog(ChunkStore *cs, ProllyHash *pStaged){
@@ -1806,12 +1817,27 @@ int chunkStoreRefreshIfChanged(ChunkStore *cs, int *pChanged){
     rc = sqlite3OsFileSize(cs->pFile, &fileSize);
     if( rc!=SQLITE_OK ) return SQLITE_OK;
     if( fileSize > cs->iFileSize ){
-      /* File grew from another writer; re-read WAL to pick up new chunks. */
+      /* File grew from another writer; re-read WAL to pick up new chunks.
+      ** Must also clear WAL-offset entries from the index because committed
+      ** chunks were appended as raw data to pWalData (at positions that won't
+      ** match the on-disk WAL format after re-read). Keeping the on-disk
+      ** sorted index entries is safe since their file offsets don't change. */
       sqlite3_free(cs->pWalData);
       cs->pWalData = 0;
       cs->nWalData = 0;
       cs->nPending = 0;
-    csPendHTClear(cs);
+      csPendHTClear(cs);
+      /* Remove WAL-offset entries from aIndex (keep file-offset entries). */
+      {
+        int rd, wr;
+        for(rd=0, wr=0; rd<cs->nIndex; rd++){
+          if( !csIsWalOffset(cs->aIndex[rd].offset) ){
+            if( wr!=rd ) cs->aIndex[wr] = cs->aIndex[rd];
+            wr++;
+          }
+        }
+        cs->nIndex = wr;
+      }
       rc = csReplayWal(cs);
       if( rc!=SQLITE_OK ) return rc;
       cs->iFileSize = fileSize;

--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -6,7 +6,7 @@
 **     magic(4) + version(4) + root_hash(20) + nChunks(4) +
 **     index_offset(8) + index_size(4) + catalog_hash(20) +
 **     head_commit_hash(20) + wal_offset(8) + reserved(12) +
-**     refs_hash(20) + reserved(44)
+**     refs_hash(20) + working_state_hash(20) + reserved(24)
 **   [Chunk data region: after manifest, before index]
 **     Each chunk stored as: length_le32(4) + data(length)
 **   [Sorted index: nChunks * 32-byte entries]
@@ -76,6 +76,7 @@ struct ChunkStore {
   ProllyHash catalog;
   ProllyHash headCommit;
   ProllyHash refsHash;
+  ProllyHash workingState;  /* Per-branch working catalog state chunk hash */
 
   /* These fields come from the per-branch WorkingSet, not from the manifest. */
   ProllyHash stagedCatalog;
@@ -164,6 +165,9 @@ void chunkStoreSetCatalog(ChunkStore *cs, const ProllyHash *pCat);
 
 void chunkStoreGetHeadCommit(ChunkStore *cs, ProllyHash *pHead);
 void chunkStoreSetHeadCommit(ChunkStore *cs, const ProllyHash *pHead);
+
+void chunkStoreGetWorkingState(ChunkStore *cs, ProllyHash *pState);
+void chunkStoreSetWorkingState(ChunkStore *cs, const ProllyHash *pState);
 
 void chunkStoreGetStagedCatalog(ChunkStore *cs, ProllyHash *pStaged);
 void chunkStoreSetStagedCatalog(ChunkStore *cs, const ProllyHash *pStaged);

--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -202,10 +202,15 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
     
     chunkStoreSetDefaultBranch(cs, zBranch);
     chunkStoreSetHeadCommit(cs, &targetCommit);
-  }
-  {
-    extern int doltliteSaveWorkingSet(sqlite3*);
-    doltliteSaveWorkingSet(db);
+
+    {
+      extern int doltliteSaveWorkingSet(sqlite3*);
+      extern int doltliteUpdateBranchWorkingState(sqlite3*, const char*, const ProllyHash*);
+      doltliteSaveWorkingSet(db);
+      /* Record the target branch's working catalog in the per-branch working
+      ** state so cross-branch connections find the correct catalog on refresh. */
+      doltliteUpdateBranchWorkingState(db, zBranch, &catHash);
+    }
   }
   rc = chunkStoreSerializeRefs(cs);
   if( rc==SQLITE_OK ) rc = chunkStoreCommit(cs);

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -1667,6 +1667,152 @@ int sqlite3BtreeIsReadonly(Btree *p){
   return p->pOps->xIsReadonly(p);
 }
 
+/*
+** Working state chunk: per-branch working catalog hashes.
+** Format: [nBranches:2 LE] per branch: [nameLen:2 LE][name][catHash:20]
+**
+** This allows each branch to persist its working catalog independently,
+** so cross-branch autocommits don't overwrite each other's catalogs.
+*/
+
+/*
+** Read the working catalog hash for zBranch from the working state chunk.
+** Returns SQLITE_OK and fills *pCatHash if found.
+** Returns SQLITE_NOTFOUND if the branch is not in the working state.
+*/
+static int btreeReadWorkingCatalog(
+  ChunkStore *cs,
+  const char *zBranch,
+  ProllyHash *pCatHash
+){
+  ProllyHash wsHash;
+  u8 *data = 0;
+  int nData = 0;
+  int rc;
+  int nBr, i;
+  int brLen = (int)strlen(zBranch);
+  const u8 *p;
+
+  chunkStoreGetWorkingState(cs, &wsHash);
+  if( prollyHashIsEmpty(&wsHash) ) return SQLITE_NOTFOUND;
+
+  rc = chunkStoreGet(cs, &wsHash, &data, &nData);
+  if( rc!=SQLITE_OK || !data ) return SQLITE_NOTFOUND;
+  if( nData < 2 ){ sqlite3_free(data); return SQLITE_NOTFOUND; }
+
+  nBr = (int)data[0] | ((int)data[1] << 8);
+  p = data + 2;
+  for(i=0; i<nBr; i++){
+    int nl;
+    if( p + 2 > data + nData ) break;
+    nl = (int)p[0] | ((int)p[1] << 8);
+    p += 2;
+    if( p + nl + PROLLY_HASH_SIZE > data + nData ) break;
+    if( nl==brLen && memcmp(p, zBranch, nl)==0 ){
+      memcpy(pCatHash->data, p + nl, PROLLY_HASH_SIZE);
+      sqlite3_free(data);
+      return SQLITE_OK;
+    }
+    p += nl + PROLLY_HASH_SIZE;
+  }
+
+  sqlite3_free(data);
+  return SQLITE_NOTFOUND;
+}
+
+/*
+** Update the working state chunk: set zBranch's catalog hash to *pCatHash.
+** Merges with existing entries for other branches.
+** Writes the new chunk to the store and updates cs->workingState.
+*/
+static int btreeWriteWorkingState(
+  ChunkStore *cs,
+  const char *zBranch,
+  const ProllyHash *pCatHash
+){
+  ProllyHash wsHash;
+  u8 *oldData = 0;
+  int nOldData = 0;
+  u8 *newBuf = 0;
+  int nNew = 0;
+  int nAlloc;
+  int nBr = 0, i;
+  int brLen = (int)strlen(zBranch);
+  int found = 0;
+  int rc;
+
+  chunkStoreGetWorkingState(cs, &wsHash);
+  if( !prollyHashIsEmpty(&wsHash) ){
+    chunkStoreGet(cs, &wsHash, &oldData, &nOldData);
+  }
+
+  /* Calculate max size: old data + our new entry */
+  nAlloc = (oldData && nOldData >= 2) ? nOldData : 2;
+  nAlloc += 2 + brLen + PROLLY_HASH_SIZE + 16; /* extra space */
+  newBuf = (u8*)sqlite3_malloc(nAlloc);
+  if( !newBuf ){
+    sqlite3_free(oldData);
+    return SQLITE_NOMEM;
+  }
+
+  /* Start writing at offset 2 (skip nBranches header) */
+  nNew = 2;
+
+  /* Copy existing entries, replacing our branch if found */
+  if( oldData && nOldData >= 2 ){
+    int oldNBr = (int)oldData[0] | ((int)oldData[1] << 8);
+    const u8 *p = oldData + 2;
+    for(i=0; i<oldNBr; i++){
+      int nl;
+      if( p + 2 > oldData + nOldData ) break;
+      nl = (int)p[0] | ((int)p[1] << 8);
+      p += 2;
+      if( p + nl + PROLLY_HASH_SIZE > oldData + nOldData ) break;
+      if( nl==brLen && memcmp(p, zBranch, nl)==0 ){
+        /* Replace our entry */
+        newBuf[nNew++] = (u8)(nl & 0xff);
+        newBuf[nNew++] = (u8)((nl >> 8) & 0xff);
+        memcpy(newBuf + nNew, zBranch, nl); nNew += nl;
+        memcpy(newBuf + nNew, pCatHash->data, PROLLY_HASH_SIZE); nNew += PROLLY_HASH_SIZE;
+        found = 1;
+      }else{
+        /* Copy other branch's entry as-is */
+        int entrySize = 2 + nl + PROLLY_HASH_SIZE;
+        memcpy(newBuf + nNew, p - 2, entrySize);
+        nNew += entrySize;
+      }
+      p += nl + PROLLY_HASH_SIZE;
+      nBr++;
+    }
+  }
+
+  if( !found ){
+    /* Append new entry for our branch */
+    newBuf[nNew++] = (u8)(brLen & 0xff);
+    newBuf[nNew++] = (u8)((brLen >> 8) & 0xff);
+    memcpy(newBuf + nNew, zBranch, brLen); nNew += brLen;
+    memcpy(newBuf + nNew, pCatHash->data, PROLLY_HASH_SIZE); nNew += PROLLY_HASH_SIZE;
+    nBr++;
+  }
+
+  /* Write branch count header */
+  newBuf[0] = (u8)(nBr & 0xff);
+  newBuf[1] = (u8)((nBr >> 8) & 0xff);
+
+  sqlite3_free(oldData);
+
+  /* Store the chunk and update the manifest field */
+  {
+    ProllyHash newHash;
+    rc = chunkStorePut(cs, newBuf, nNew, &newHash);
+    sqlite3_free(newBuf);
+    if( rc!=SQLITE_OK ) return rc;
+    chunkStoreSetWorkingState(cs, &newHash);
+  }
+
+  return SQLITE_OK;
+}
+
 static int btreeRefreshFromDisk(Btree *p){
   BtShared *pBt = p->pBt;
   int bChanged = 0;
@@ -1674,43 +1820,24 @@ static int btreeRefreshFromDisk(Btree *p){
   if( rc!=SQLITE_OK ) return rc;
   if( !bChanged ) return SQLITE_OK;
 
-  
+  /* The file changed. Load the catalog for THIS connection's branch.
+  ** Each branch's working catalog is stored in the working state chunk
+  ** (persisted on every autocommit). This prevents cross-branch corruption
+  ** where one branch's autocommit overwrites the shared manifest catalog. */
   {
     ProllyHash catHash;
-    ProllyHash manifestHead;
     const char *zBr = p->zBranch ? p->zBranch : "main";
-    ProllyHash branchHead;
-    int useBranchCommit = 0;
 
     memset(&catHash, 0, sizeof(catHash));
-    chunkStoreGetHeadCommit(&pBt->store, &manifestHead);
 
-    if( chunkStoreFindBranch(&pBt->store, zBr, &branchHead)==SQLITE_OK
-     && !prollyHashIsEmpty(&branchHead)
-     && prollyHashCompare(&manifestHead, &branchHead)!=0 ){
-      
-      u8 *commitData = 0;
-      int nCommitData = 0;
-      rc = chunkStoreGet(&pBt->store, &branchHead, &commitData, &nCommitData);
-      if( rc==SQLITE_OK && commitData ){
-        DoltliteCommit commit;
-        rc = doltliteCommitDeserialize(commitData, nCommitData, &commit);
-        sqlite3_free(commitData);
-        if( rc==SQLITE_OK ){
-          memcpy(&catHash, &commit.catalogHash, sizeof(ProllyHash));
-          chunkStoreGetRoot(&pBt->store, &p->root);
-          memcpy(&p->headCommit, &branchHead, sizeof(ProllyHash));
-          doltliteCommitClear(&commit);
-          useBranchCommit = 1;
-        }
-      }
-    }
-
-    if( !useBranchCommit ){
-      
+    /* Try per-branch working catalog first */
+    /* Try per-branch working catalog first */
+    if( btreeReadWorkingCatalog(&pBt->store, zBr, &catHash)!=SQLITE_OK ){
+      /* Fallback: no working state yet (first open, or pre-existing db).
+      ** Use the manifest catalog. */
       chunkStoreGetCatalog(&pBt->store, &catHash);
-      chunkStoreGetRoot(&pBt->store, &p->root);
     }
+    chunkStoreGetRoot(&pBt->store, &p->root);
 
     if( !prollyHashIsEmpty(&catHash) ){
       u8 *catData = 0;
@@ -1763,9 +1890,15 @@ static int prollyBtreeBeginTrans(Btree *p, int wrFlag, int *pSchemaVersion){
     if( rc!=SQLITE_OK ) return rc;
     
     
+    /* Reload catalog under lock — use per-branch working catalog to avoid
+    ** cross-branch corruption, same as btreeRefreshFromDisk. */
     {
       ProllyHash catHash;
-      chunkStoreGetCatalog(&pBt->store, &catHash);
+      const char *zBr = p->zBranch ? p->zBranch : "main";
+      memset(&catHash, 0, sizeof(catHash));
+      if( btreeReadWorkingCatalog(&pBt->store, zBr, &catHash)!=SQLITE_OK ){
+        chunkStoreGetCatalog(&pBt->store, &catHash);
+      }
       if( !prollyHashIsEmpty(&catHash) ){
         u8 *catData = 0;
         int nCatData = 0;
@@ -1773,11 +1906,14 @@ static int prollyBtreeBeginTrans(Btree *p, int wrFlag, int *pSchemaVersion){
         if( rc2==SQLITE_OK && catData ){
           rc2 = deserializeCatalog(p, catData, nCatData);
           sqlite3_free(catData);
-          if( rc2!=SQLITE_OK ) return rc2;
+          if( rc2!=SQLITE_OK ){
+            chunkStoreUnlock(&pBt->store);
+            return rc2;
+          }
         }
       }
     }
-    
+
     sqlite3_free(p->aCommittedTables);
     p->aCommittedTables = 0;
     p->nCommittedTables = 0;
@@ -1868,6 +2004,15 @@ static int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
       if( rc!=SQLITE_OK ) return rc;
     }
     chunkStoreSetRoot(&pBt->store, &p->root);
+    /* Step 3b: save per-branch working catalog so cross-branch connections
+    ** can find this branch's catalog without relying on the shared manifest. */
+    {
+      const char *zBr = p->zBranch ? p->zBranch : "main";
+      ProllyHash catHash2;
+      chunkStoreGetCatalog(&pBt->store, &catHash2);
+      rc = btreeWriteWorkingState(&pBt->store, zBr, &catHash2);
+      if( rc!=SQLITE_OK ) return rc;
+    }
     /* Step 4: atomic manifest write */
     rc = chunkStoreCommit(&pBt->store);
     if( rc==SQLITE_OK ){
@@ -4581,8 +4726,22 @@ int doltliteHardReset(sqlite3 *db, const ProllyHash *catHash){
 
   
   chunkStoreSetCatalog(cs, catHash);
+  /* Update per-branch working state with the new catalog so cross-branch
+  ** connections refresh correctly. Uses current branch name (correct for
+  ** reset/merge; checkout overwrites with the target branch afterward). */
+  {
+    const char *zBr = pBtree->zBranch ? pBtree->zBranch : "main";
+    btreeWriteWorkingState(cs, zBr, catHash);
+  }
   rc = chunkStoreCommit(cs);
   return rc;
+}
+
+int doltliteUpdateBranchWorkingState(sqlite3 *db, const char *zBranch,
+                                     const ProllyHash *pCatHash){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  if( !cs ) return SQLITE_ERROR;
+  return btreeWriteWorkingState(cs, zBranch, pCatHash);
 }
 
 const char *doltliteGetSessionBranch(sqlite3 *db){

--- a/test/cross_branch_test.c
+++ b/test/cross_branch_test.c
@@ -1,0 +1,193 @@
+/*
+** Cross-branch concurrent access test for DoltLite.
+**
+** Reproduces the corruption described in issue #277:
+** Two connections on different branches both autocommit.
+** Without per-branch working catalogs, the second writer's
+** catalog overwrites the first's in the manifest, causing
+** SQLITE_CORRUPT reads from the first connection.
+*/
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "sqlite3.h"
+
+static int nPass = 0;
+static int nFail = 0;
+
+static void check(const char *name, int condition){
+  if( condition ){
+    nPass++;
+  }else{
+    nFail++;
+    fprintf(stderr, "FAIL: %s\n", name);
+  }
+}
+
+static char result_buf[4096];
+static const char *exec1(sqlite3 *db, const char *sql){
+  sqlite3_stmt *stmt = 0;
+  int rc;
+  result_buf[0] = 0;
+  rc = sqlite3_prepare_v2(db, sql, -1, &stmt, 0);
+  if( rc!=SQLITE_OK ){
+    snprintf(result_buf, sizeof(result_buf), "ERROR: %s", sqlite3_errmsg(db));
+    return result_buf;
+  }
+  rc = sqlite3_step(stmt);
+  if( rc==SQLITE_ROW ){
+    const char *val = (const char*)sqlite3_column_text(stmt, 0);
+    if( val ){
+      snprintf(result_buf, sizeof(result_buf), "%s", val);
+    }
+  }
+  sqlite3_finalize(stmt);
+  return result_buf;
+}
+
+static int execsql(sqlite3 *db, const char *sql){
+  char *err = 0;
+  int rc = sqlite3_exec(db, sql, 0, 0, &err);
+  if( rc!=SQLITE_OK ){
+    fprintf(stderr, "  SQL error: %s (rc=%d)\n  SQL: %s\n", err ? err : "?", rc, sql);
+    sqlite3_free(err);
+  }
+  return rc;
+}
+
+int main(){
+  sqlite3 *db1 = 0, *db2 = 0;
+  const char *dbpath = "/tmp/test_cross_branch.db";
+  const char *r;
+  int rc;
+
+  remove(dbpath);
+  { char w[256]; snprintf(w,256,"%s-wal",dbpath); remove(w); }
+
+  printf("=== Cross-Branch Concurrent Access Test ===\n\n");
+
+  /* Open db1 for initial setup */
+  rc = sqlite3_open(dbpath, &db1);
+  check("open_db1", rc==SQLITE_OK);
+  sqlite3_busy_timeout(db1, 5000);
+
+  printf("--- Setup: create table and initial commit on main ---\n");
+
+  /* db1: create schema, insert data, commit on main */
+  rc = execsql(db1, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+  check("create_table", rc==SQLITE_OK);
+  rc = execsql(db1, "INSERT INTO t VALUES(1, 'main-1')");
+  check("insert_main", rc==SQLITE_OK);
+  exec1(db1, "SELECT dolt_commit('-A', '-m', 'initial on main')");
+
+  /* Open db2 AFTER the commit so it sees the head commit */
+  rc = sqlite3_open(dbpath, &db2);
+  check("open_db2", rc==SQLITE_OK);
+  sqlite3_busy_timeout(db2, 5000);
+
+  /* Verify both see it */
+  check("db1_sees_main", strcmp(exec1(db1, "SELECT val FROM t WHERE id=1"), "main-1")==0);
+  check("db2_sees_main", strcmp(exec1(db2, "SELECT val FROM t WHERE id=1"), "main-1")==0);
+
+  printf("--- Create dev branch and checkout db2 to dev ---\n");
+
+  /* db2: create branch and checkout */
+  exec1(db2, "SELECT dolt_checkout('-b', 'dev')");
+  check("db2_on_dev", strcmp(exec1(db2, "SELECT active_branch()"), "dev")==0);
+  check("db1_on_main", strcmp(exec1(db1, "SELECT active_branch()"), "main")==0);
+
+  printf("--- Test 1: autocommit writes on different branches ---\n");
+
+  /* db1 writes on main (autocommit) */
+  rc = execsql(db1, "INSERT INTO t VALUES(2, 'main-2')");
+  check("db1_insert_main2", rc==SQLITE_OK);
+
+  /* db2 writes on dev (autocommit) — this overwrites manifest catalog */
+  rc = execsql(db2, "INSERT INTO t VALUES(3, 'dev-3')");
+  check("db2_insert_dev3", rc==SQLITE_OK);
+
+  printf("--- Test 2: reads after cross-branch writes (the bug) ---\n");
+
+  /* THIS IS THE CRITICAL TEST: db1 on main should still see its data
+  ** without SQLITE_CORRUPT. Before the fix, the manifest catalog was
+  ** overwritten by db2's autocommit, causing db1 to load the wrong
+  ** catalog and get corrupt reads. */
+  r = exec1(db1, "SELECT count(*) FROM t");
+  check("db1_main_count", strcmp(r, "2")==0);
+
+  r = exec1(db1, "SELECT val FROM t WHERE id=1");
+  check("db1_main_val1", strcmp(r, "main-1")==0);
+
+  r = exec1(db1, "SELECT val FROM t WHERE id=2");
+  check("db1_main_val2", strcmp(r, "main-2")==0);
+
+  /* db2 on dev should see its data */
+  r = exec1(db2, "SELECT count(*) FROM t");
+  check("db2_dev_count", strcmp(r, "2")==0);
+
+  r = exec1(db2, "SELECT val FROM t WHERE id=1");
+  check("db2_dev_val1", strcmp(r, "main-1")==0);
+
+  r = exec1(db2, "SELECT val FROM t WHERE id=3");
+  check("db2_dev_val3", strcmp(r, "dev-3")==0);
+
+  printf("--- Test 3: more writes interleaved ---\n");
+
+  /* Interleave more writes */
+  rc = execsql(db1, "INSERT INTO t VALUES(4, 'main-4')");
+  check("db1_insert_main4", rc==SQLITE_OK);
+
+  rc = execsql(db2, "INSERT INTO t VALUES(5, 'dev-5')");
+  check("db2_insert_dev5", rc==SQLITE_OK);
+
+  rc = execsql(db1, "INSERT INTO t VALUES(6, 'main-6')");
+  check("db1_insert_main6", rc==SQLITE_OK);
+
+  /* Verify isolation */
+  r = exec1(db1, "SELECT count(*) FROM t");
+  check("db1_main_count_after", strcmp(r, "4")==0);
+
+  r = exec1(db2, "SELECT count(*) FROM t");
+  check("db2_dev_count_after", strcmp(r, "3")==0);
+
+  printf("--- Test 4: dolt_commit on each branch ---\n");
+
+  exec1(db1, "SELECT dolt_commit('-A', '-m', 'main writes')");
+  exec1(db2, "SELECT dolt_commit('-A', '-m', 'dev writes')");
+
+  /* Verify commits */
+  r = exec1(db1, "SELECT message FROM dolt_log LIMIT 1");
+  check("db1_commit_msg", strcmp(r, "main writes")==0);
+
+  r = exec1(db2, "SELECT message FROM dolt_log LIMIT 1");
+  check("db2_commit_msg", strcmp(r, "dev writes")==0);
+
+  printf("--- Test 5: reads after commits still correct ---\n");
+
+  r = exec1(db1, "SELECT count(*) FROM t");
+  check("db1_final_count", strcmp(r, "4")==0);
+
+  r = exec1(db2, "SELECT count(*) FROM t");
+  check("db2_final_count", strcmp(r, "3")==0);
+
+  printf("--- Test 6: fresh connection sees committed state ---\n");
+
+  {
+    sqlite3 *fresh = 0;
+    sqlite3_open(dbpath, &fresh);
+    /* Fresh connection opens on default branch (main after last commit) */
+    r = exec1(fresh, "SELECT count(*) FROM t");
+    /* Should see main's 4 rows (main was last to update default branch) */
+    check("fresh_sees_data", strcmp(r, "0")!=0);
+    sqlite3_close(fresh);
+  }
+
+  /* Cleanup */
+  sqlite3_close(db1);
+  sqlite3_close(db2);
+  remove(dbpath);
+  { char w[256]; snprintf(w,256,"%s-wal",dbpath); remove(w); }
+
+  printf("\nResults: %d passed, %d failed out of %d tests\n", nPass, nFail, nPass+nFail);
+  return nFail > 0 ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

- Fixes cross-branch corruption (#277) where two connections on different branches corrupt each other's catalog via the shared manifest
- Adds per-branch working catalog storage in a new "working state" chunk, tracked by a `workingState` hash in the manifest (uses previously reserved bytes at offset 124)
- Fixes a latent WAL index staleness bug where `chunkStoreRefreshIfChanged` kept stale WAL-offset entries in the chunk index after re-reading the WAL

## Test plan

- [x] New `cross_branch_test.c` (26 assertions) - reproduces the #277 corruption scenario and verifies branch isolation
- [x] `concurrent_write_test` (52 tests) - same-branch multi-connection reads
- [x] `sql_transaction_test` (24 tests) - transaction concurrency
- [x] All 31 shell test suites pass (1,344+ individual tests)

Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)