### PR TITLE
Allow dolt_checkout with uncommitted changes

### DIFF
--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -8,31 +8,7 @@
 #include "doltlite_internal.h"
 #include <string.h>
 
-static int checkWorkingDirty(sqlite3 *db){
-  ChunkStore *cs = doltliteGetChunkStore(db);
-  ProllyHash headCatHash, workingCatHash;
-  int rc;
 
-  if( !cs ) return -1;
-
-  
-  rc = doltliteGetHeadCatalogHash(db, &headCatHash);
-  if( rc!=SQLITE_OK ) return -1;
-  if( prollyHashIsEmpty(&headCatHash) ) return 0;
-
-  
-  {
-    u8 *catData = 0; int nCatData = 0;
-    rc = doltliteFlushAndSerializeCatalog(db, &catData, &nCatData);
-    if( rc!=SQLITE_OK ) return -1;
-    rc = chunkStorePut(cs, catData, nCatData, &workingCatHash);
-    sqlite3_free(catData);
-    if( rc!=SQLITE_OK ) return -1;
-  }
-
-  
-  return prollyHashCompare(&headCatHash, &workingCatHash) != 0;
-}
 
 static void activeBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
@@ -157,15 +133,6 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
 
   rc = chunkStoreFindBranch(cs, zBranch, &targetCommit);
   if( rc!=SQLITE_OK ){ sqlite3_result_error(ctx, "branch not found", -1); return; }
-
-  
-  {
-    int dirty = checkWorkingDirty(db);
-    if( dirty>0 ){
-      sqlite3_result_error(ctx, "uncommitted changes — commit or reset first", -1);
-      return;
-    }
-  }
 
   if( prollyHashIsEmpty(&targetCommit) ){
     sqlite3_result_error(ctx, "target branch has no commits", -1);

--- a/test/doltlite_branch.sh
+++ b/test/doltlite_branch.sh
@@ -41,7 +41,7 @@ DB3=/tmp/test_branch3_$$.db; rm -f "$DB3"
 echo "CREATE TABLE t(x); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','i');" | $DOLTLITE "$DB3" > /dev/null 2>&1
 echo "SELECT dolt_branch('b2');" | $DOLTLITE "$DB3" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(2);" | $DOLTLITE "$DB3" > /dev/null 2>&1
-run_test_match "dirty_checkout" "SELECT dolt_checkout('b2');" "uncommitted" "$DB3"
+run_test "dirty_checkout" "SELECT dolt_checkout('b2');" "0" "$DB3"
 
 # --- Checkout after hard reset (issue #107) ---
 DB4=/tmp/test_branch4_$$.db; rm -f "$DB4"
@@ -78,7 +78,7 @@ echo "CREATE TABLE t(x INTEGER PRIMARY KEY); INSERT INTO t VALUES(1); SELECT dol
 echo "INSERT INTO t VALUES(2); SELECT dolt_reset('--hard');" | $DOLTLITE "$DB7" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(99);" | $DOLTLITE "$DB7" > /dev/null 2>&1
 echo "SELECT dolt_branch('b4');" | $DOLTLITE "$DB7" > /dev/null 2>&1
-run_test_match "dirty_after_hard_reset_new_changes" "SELECT dolt_checkout('b4');" "uncommitted" "$DB7"
+run_test "dirty_after_hard_reset_new_changes" "SELECT dolt_checkout('b4');" "0" "$DB7"
 
 # Schema change (CREATE TABLE) then hard reset then checkout
 DB8=/tmp/test_branch8_$$.db; rm -f "$DB8"

--- a/test/doltlite_edge_cases.sh
+++ b/test/doltlite_edge_cases.sh
@@ -255,9 +255,9 @@ run_test_match "err_tag_dup" "SELECT dolt_tag('v1');" "already exists" "$DB"
 # Delete non-existent tag
 run_test_match "err_tag_del_noexist" "SELECT dolt_tag('-d','nope');" "not found" "$DB"
 
-# Checkout with uncommitted changes
+# Checkout with uncommitted changes (allowed, like Dolt SQL context)
 echo "INSERT INTO t VALUES(2,'dirty');" | $DOLTLITE "$DB" > /dev/null 2>&1
-run_test_match "err_checkout_dirty" "SELECT dolt_checkout('dup');" "uncommitted" "$DB"
+run_test "checkout_dirty_allowed" "SELECT dolt_checkout('dup');" "0" "$DB"
 
 # Hard reset cleans it
 echo "SELECT dolt_reset('--hard');" | $DOLTLITE "$DB" > /dev/null 2>&1

--- a/test/doltlite_savepoint.sh
+++ b/test/doltlite_savepoint.sh
@@ -206,10 +206,10 @@ DB6b=/tmp/test_savepoint6b_$$.db; rm -f "$DB6b"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6b" > /dev/null 2>&1
 echo "SELECT dolt_branch('other');" | $DOLTLITE "$DB6b" > /dev/null 2>&1
 
-# INSERT then checkout in same transaction — should fail due to uncommitted changes
-run_test_match "checkout_dirty_in_txn" \
+# INSERT then checkout in same transaction — allowed (like Dolt SQL context)
+run_test "checkout_dirty_in_txn" \
   "BEGIN; INSERT INTO t VALUES(2,'dirty'); SELECT dolt_checkout('other'); COMMIT;" \
-  "uncommitted" "$DB6b"
+  "0" "$DB6b"
 
 # ============================================================
 # Test 7: dolt_merge inside a BEGIN/COMMIT block


### PR DESCRIPTION
## Summary

Remove the dirty-working-set check from `dolt_checkout`. Dolt allows switching branches with uncommitted changes in the SQL context. Also removes the now-unused `checkWorkingDirty` function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)