### PR TITLE
Fix merge: fast-forward and message quoting

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -705,6 +705,9 @@ static void doltliteMergeFunc(
 
   
   if( prollyHashCompare(&ancestorHash, &ourHead)==0 ){
+    /* Fast-forward: move branch pointer to their commit, no merge commit. */
+    char hx[PROLLY_HASH_SIZE*2+1];
+
     rc = chunkStoreGet(cs, &theirHead, &data, &nData);
     if( rc!=SQLITE_OK ){ sqlite3_result_error(context, "failed to load commit", -1); return; }
     rc = doltliteCommitDeserialize(data, nData, &theirCommit);
@@ -712,55 +715,24 @@ static void doltliteMergeFunc(
     if( rc!=SQLITE_OK ){ sqlite3_result_error(context, "corrupt commit", -1); return; }
 
     rc = doltliteHardReset(db, &theirCommit.catalogHash);
-    if( rc==SQLITE_OK ){
-    }
     if( rc!=SQLITE_OK ){
       doltliteCommitClear(&theirCommit);
       sqlite3_result_error(context, "fast-forward failed", -1);
       return;
     }
 
-    {
-      DoltliteCommit mc;
-      u8 *cd2 = 0;
-      int ncd2 = 0;
-      ProllyHash ch2, sc2;
-      char hx2[PROLLY_HASH_SIZE*2+1];
-      char mg2[256];
+    doltliteSetSessionHead(db, &theirHead);
+    doltliteSetSessionStaged(db, &theirCommit.catalogHash);
+    doltliteCommitClear(&theirCommit);
 
-      memcpy(&sc2, &theirCommit.catalogHash, sizeof(ProllyHash));
-      doltliteCommitClear(&theirCommit);
+    chunkStoreUpdateBranch(cs, doltliteGetSessionBranch(db), &theirHead);
+    doltliteSaveWorkingSet(db);
+    chunkStoreSerializeRefs(cs);
+    chunkStoreCommit(cs);
 
-      memset(&mc, 0, sizeof(mc));
-      memcpy(&mc.parentHash, &theirHead, sizeof(ProllyHash));
-      memcpy(&mc.catalogHash, &sc2, sizeof(ProllyHash));
-      mc.timestamp = (i64)time(0);
-      snprintf(mg2, sizeof(mg2), "Merge branch '%s'", zBranch);
-      mc.zName = sqlite3_mprintf("%s", doltliteGetAuthorName(db));
-      mc.zEmail = sqlite3_mprintf("%s", doltliteGetAuthorEmail(db));
-      mc.zMessage = sqlite3_mprintf("%s", mg2);
-
-      rc = doltliteCommitSerialize(&mc, &cd2, &ncd2);
-      if( rc==SQLITE_OK ) rc = chunkStorePut(cs, cd2, ncd2, &ch2);
-      sqlite3_free(cd2);
-      doltliteCommitClear(&mc);
-      if( rc!=SQLITE_OK ){
-        sqlite3_result_error(context, "failed to create merge commit", -1);
-        return;
-      }
-
-      doltliteSetSessionHead(db, &ch2);
-      doltliteSetSessionStaged(db, &sc2);
-
-      chunkStoreUpdateBranch(cs, doltliteGetSessionBranch(db), &ch2);
-      doltliteSaveWorkingSet(db);
-      chunkStoreSerializeRefs(cs);
-      chunkStoreCommit(cs);
-
-      doltliteHashToHex(&ch2, hx2);
-      sqlite3_result_text(context, hx2, -1, SQLITE_TRANSIENT);
-      return;
-    }
+    doltliteHashToHex(&theirHead, hx);
+    sqlite3_result_text(context, hx, -1, SQLITE_TRANSIENT);
+    return;
   }
 
   

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -735,7 +735,7 @@ static void doltliteMergeFunc(
       memcpy(&mc.parentHash, &theirHead, sizeof(ProllyHash));
       memcpy(&mc.catalogHash, &sc2, sizeof(ProllyHash));
       mc.timestamp = (i64)time(0);
-      sqlite3_snprintf(sizeof(mg2), mg2, "Merge branch '%s'", zBranch);
+      snprintf(mg2, sizeof(mg2), "Merge branch '%s'", zBranch);
       mc.zName = sqlite3_mprintf("%s", doltliteGetAuthorName(db));
       mc.zEmail = sqlite3_mprintf("%s", doltliteGetAuthorEmail(db));
       mc.zMessage = sqlite3_mprintf("%s", mg2);
@@ -838,7 +838,7 @@ static void doltliteMergeFunc(
       mergeCommit.parentHash = ourHead;  
       memcpy(&mergeCommit.catalogHash, &mergedCatHash, sizeof(ProllyHash));
       mergeCommit.timestamp = (i64)time(0);
-      sqlite3_snprintf(sizeof(msg), msg, "Merge branch '%s'", zBranch);
+      snprintf(msg, sizeof(msg), "Merge branch '%s'", zBranch);
       mergeCommit.zName = sqlite3_mprintf("%s", doltliteGetAuthorName(db));
       mergeCommit.zEmail = sqlite3_mprintf("%s", doltliteGetAuthorEmail(db));
       mergeCommit.zMessage = sqlite3_mprintf("%s", msg);

--- a/test/doltlite_demo.sh
+++ b/test/doltlite_demo.sh
@@ -186,7 +186,7 @@ run_test "tags_v1_data" "SELECT count(*) FROM dolt_at_employees('v1');" "4" "$DB
 # ============================================================
 
 run_test "persist_emp" "SELECT count(*) FROM employees;" "5" "$DB"
-run_test "persist_log" "SELECT count(*) FROM dolt_log;" "4" "$DB"
+run_test "persist_log" "SELECT count(*) FROM dolt_log;" "3" "$DB"
 run_test "persist_branch" "SELECT active_branch();" "main" "$DB"
 run_test "persist_tags" "SELECT count(*) FROM dolt_tags;" "1" "$DB"
 

--- a/test/doltlite_merge.sh
+++ b/test/doltlite_merge.sh
@@ -32,8 +32,8 @@ echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB2" > /dev/null 2>&1
 run_test "ff_before" "SELECT count(*) FROM t;" "1" "$DB2"
 run_test_match "ff_merge" "SELECT dolt_merge('feature');" "^[0-9a-f]{40}$" "$DB2"
 run_test "ff_after" "SELECT count(*) FROM t;" "2" "$DB2"
-run_test "ff_merge_msg" "SELECT message FROM dolt_log LIMIT 1;" "Merge branch 'feature'" "$DB2"
-run_test "ff_log_count" "SELECT count(*) FROM dolt_log;" "3" "$DB2"
+run_test "ff_no_merge_commit" "SELECT message FROM dolt_log LIMIT 1;" "feature" "$DB2"
+run_test "ff_log_count" "SELECT count(*) FROM dolt_log;" "2" "$DB2"
 
 # Test 3: Already up to date
 run_test "up_to_date" "SELECT dolt_merge('feature');" "Already up to date" "$DB2"
@@ -85,9 +85,9 @@ run_test_match "diff_3way_orders" \
   "added" "$DB"
 
 # Test 9: dolt_diff after fast-forward merge (DB2 from Test 2)
-# Log has 3 entries: merge commit (0), feature (1), init (2)
+# Log has 2 entries: feature (0), init (1) — no merge commit for ff
 run_test_match "diff_ff_added" \
-  "SELECT diff_type, to_value FROM dolt_diff('t', (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 2), (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 0));" \
+  "SELECT diff_type, to_value FROM dolt_diff('t', (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1), (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 0));" \
   "added" "$DB2"
 
 # Test 10: After merge with conflicts, dolt_diff between init and HEAD shows the main change
@@ -157,9 +157,9 @@ echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'
 echo "SELECT dolt_branch('feat'); SELECT dolt_checkout('feat'); INSERT INTO t VALUES(2,'b'); SELECT dolt_commit('-A','-m','feat');" | $DOLTLITE "$DB10" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB10" > /dev/null 2>&1
 
-run_test_match "clean_merge_commits" "SELECT dolt_merge('feat');" "^[0-9a-f]" "$DB10"
-run_test_match "clean_merge_log" "SELECT message FROM dolt_log LIMIT 1;" "Merge" "$DB10"
-run_test "clean_merge_data" "SELECT count(*) FROM t;" "2" "$DB10"
+run_test_match "clean_ff_merge" "SELECT dolt_merge('feat');" "^[0-9a-f]" "$DB10"
+run_test "clean_ff_log" "SELECT message FROM dolt_log LIMIT 1;" "feat" "$DB10"
+run_test "clean_ff_data" "SELECT count(*) FROM t;" "2" "$DB10"
 
 rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10"
 echo ""

--- a/test/doltlite_savepoint.sh
+++ b/test/doltlite_savepoint.sh
@@ -235,9 +235,9 @@ run_test "merge_in_txn_feature_row" \
   "SELECT v FROM t WHERE id=2;" \
   "feature-row" "$DB7"
 
-run_test_match "merge_in_txn_log" \
+run_test "merge_in_txn_log" \
   "SELECT message FROM dolt_log LIMIT 1;" \
-  "Merge branch" "$DB7"
+  "feature work" "$DB7"
 
 # ============================================================
 # Test 8: ROLLBACK after dolt_branch — does the branch creation persist?


### PR DESCRIPTION
## Summary

- **Fast-forward merges fixed**: when the ancestor equals our HEAD, just move the branch pointer to the target commit instead of creating a synthetic merge commit. Matches Git/Dolt behavior.
- **Merge message quoting fixed**: `sqlite3_snprintf` doubles single quotes (SQL escaping), producing `Merge branch ''feature''`. Switched to `snprintf`.

## Test plan

- [x] All 31 shell test suites (updated merge, savepoint, demo tests for ff behavior)
- [x] 63 remote tests
- [x] 45 cross-branch tests
- [x] 52 concurrent write tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)