### PR TITLE
Fix UPDATE double-apply bug, add missing tests to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,10 @@ jobs:
       run: cd build && bash ../test/correctness_test.sh ./doltlite
       timeout-minutes: 10
 
+    - name: Index operation tests
+      run: cd build && bash ../test/index_test.sh ./doltlite
+      timeout-minutes: 5
+
     - name: Large-scale test (10K rows)
       run: cd build && bash ../test/large_scale_test.sh ./doltlite --quick
       timeout-minutes: 5

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -2906,7 +2906,18 @@ static int prollyBtCursorNext(BtCursor *pCur, int flags){
       }
       pCur->mmIdx = it.idx;
       pCur->mmActive = 1;
-      pCur->mergeSrc = MERGE_SRC_TREE;
+      /* If the MutMap entry matches the current tree key (e.g. an UPDATE
+      ** just wrote to the same key), both sources must advance past it.
+      ** Otherwise only the tree advances. Without this, mergeStepForward
+      ** leaves the MutMap positioned at the current key, causing the
+      ** merged scan to re-visit the row (double-apply UPDATE bug). */
+      if( it.idx >= 0 && it.idx < pCur->pMutMap->nEntries
+       && prollyCursorIsValid(&pCur->pCur)
+       && mergeCompare(pCur, &pCur->pMutMap->aEntries[it.idx])==0 ){
+        pCur->mergeSrc = MERGE_SRC_BOTH;
+      }else{
+        pCur->mergeSrc = MERGE_SRC_TREE;
+      }
       rc = mergeStepForward(pCur);
       if( rc==SQLITE_DONE ){
         pCur->eState = CURSOR_INVALID;
@@ -2981,7 +2992,15 @@ static int prollyBtCursorPrevious(BtCursor *pCur, int flags){
       }
       pCur->mmIdx = it.idx;
       pCur->mmActive = 1;
-      pCur->mergeSrc = MERGE_SRC_TREE;
+      /* Same fix as in Next: if MutMap entry matches the current tree
+      ** key, advance both sources to avoid re-visiting the row. */
+      if( it.idx >= 0 && it.idx < pCur->pMutMap->nEntries
+       && prollyCursorIsValid(&pCur->pCur)
+       && mergeCompare(pCur, &pCur->pMutMap->aEntries[it.idx])==0 ){
+        pCur->mergeSrc = MERGE_SRC_BOTH;
+      }else{
+        pCur->mergeSrc = MERGE_SRC_TREE;
+      }
       rc = mergeStepBackward(pCur);
       if( rc==SQLITE_DONE ){
         pCur->eState = CURSOR_INVALID;
@@ -3726,8 +3745,12 @@ static int prollyBtCursorInsert(
           CLEAR_CACHED_PAYLOAD(pCur);
         }
         pCur->cachedPayloadOwned = 1;
+        /* The MutMap was modified — the merge iteration state (mmIdx,
+        ** mergeSrc) is stale. Reset so the next Next/Previous call
+        ** re-synchronizes the merge cursor with the updated MutMap. */
+        pCur->mmActive = 0;
       } else {
-        
+
         pCur->eState = CURSOR_INVALID;
       }
       return SQLITE_OK;

--- a/test/index_test.sh
+++ b/test/index_test.sh
@@ -29,12 +29,6 @@ check() {
 echo "--- 1. INTKEY + index: scan DELETE ---"
 for N in 100 500 1000 5000; do
   rm -f "$TMPDIR/t.db"
-  "$DB" "$TMPDIR/t.db" "CREATE TABLE t(id INTEGER PRIMARY KEY, val INT); CREATE INDEX idx ON t(val); WITH RECURSIVE c(x) AS (VALUES(1) UNION ALL SELECT x+1 FROM c WHERE x<$N) INSERT INTO t SELECT x,x FROM c; DELETE FROM t WHERE id%10=0; SELECT count(*) FROM t;" 2>/dev/null
-  result=$(tail -1 < /dev/stdin)
-done
-# Can't capture inline. Redo properly:
-for N in 100 500 1000 5000; do
-  rm -f "$TMPDIR/t.db"
   result=$("$DB" "$TMPDIR/t.db" "CREATE TABLE t(id INTEGER PRIMARY KEY, val INT); CREATE INDEX idx ON t(val); WITH RECURSIVE c(x) AS (VALUES(1) UNION ALL SELECT x+1 FROM c WHERE x<$N) INSERT INTO t SELECT x,x FROM c; DELETE FROM t WHERE id%10=0; SELECT count(*) FROM t;" 2>/dev/null | tail -1)
   check "INTKEY+idx delete N=$N" "$((N - N/10))" "$result"
 done

--- a/test/run_doltlite_tests.sh
+++ b/test/run_doltlite_tests.sh
@@ -48,6 +48,15 @@ TESTS=(
   doltlite_perf.sh
   doltlite_demo.sh
   doltlite_e2e.sh
+
+  # Additional tests
+  doltlite_attach_sqlite.sh
+  doltlite_behavior.sh
+  doltlite_branch_edge.sh
+  doltlite_diff_alter.sh
+  doltlite_index_prefix.sh
+  doltlite_issue179_180.sh
+  review_regression_test.sh
 )
 
 total_pass=0

--- a/test/run_doltlite_tests.sh
+++ b/test/run_doltlite_tests.sh
@@ -54,6 +54,7 @@ TESTS=(
   doltlite_behavior.sh
   doltlite_branch_edge.sh
   doltlite_diff_alter.sh
+  doltlite_gc_scale.sh
   doltlite_index_prefix.sh
   doltlite_issue179_180.sh
   review_regression_test.sh


### PR DESCRIPTION
## Summary

- **Fix UPDATE double-apply bug**: Deferred inserts during merge iteration left the merge state (mmIdx, mergeSrc) stale, causing the cursor to re-visit rows. Every `UPDATE t SET val=val+1` was applying twice (val+2). Fixed by:
  1. Using `MERGE_SRC_BOTH` on merge-mode transition when MutMap entry matches the tree key
  2. Resetting `mmActive` after deferred inserts so the next cursor step re-synchronizes

- **CI coverage**: Added `index_test.sh` (catches this bug) as a standalone CI step. Added 7 missing test suites to `run_doltlite_tests.sh`: attach_sqlite, behavior, branch_edge, diff_alter, index_prefix, issue179_180, review_regression.

## Test plan

- [x] index_test.sh: 30/30 (was 26/30 before fix)
- [x] All other test suites pass, 0 regressions
- [x] 100K-row UPDATE benchmark: 0.22s (faster than buggy 0.25s — old code did double work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)