### PR TITLE
Extract 5 shared modules, eliminate duplicated code across 17 files

### DIFF
--- a/main.mk
+++ b/main.mk
@@ -570,7 +570,7 @@ PROLLY_OBJS = prolly_hash.o prolly_hashset.o prolly_arena.o prolly_node.o prolly
               prolly_mutate.o prolly_diff.o prolly_three_way_diff.o prolly_btree.o pager_shim.o sortkey.o \
               doltlite.o doltlite_commit.o doltlite_ref.o doltlite_log.o doltlite_status.o \
               doltlite_diff.o doltlite_diff_table.o doltlite_branch.o doltlite_tag.o doltlite_ancestor.o doltlite_merge.o doltlite_schema_merge.o doltlite_conflicts.o \
-              doltlite_gc.o doltlite_history.o doltlite_at.o doltlite_schema_diff.o doltlite_record.o \
+              doltlite_gc.o doltlite_chunk_walk.o doltlite_history.o doltlite_at.o doltlite_schema_diff.o doltlite_record.o \
               doltlite_remote.o doltlite_remote_sql.o \
               doltlite_http_remote.o doltlite_remotesrv.o
 
@@ -1366,6 +1366,9 @@ doltlite_conflicts.o:	$(TOP)/src/doltlite_conflicts.c $(DEPS_OBJ_COMMON)
 
 doltlite_gc.o:	$(TOP)/src/doltlite_gc.c $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/doltlite_gc.c
+
+doltlite_chunk_walk.o:	$(TOP)/src/doltlite_chunk_walk.c $(DEPS_OBJ_COMMON)
+	$(T.cc.sqlite) -c $(TOP)/src/doltlite_chunk_walk.c
 
 doltlite_diff_table.o:	$(TOP)/src/doltlite_diff_table.c $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/doltlite_diff_table.c

--- a/main.mk
+++ b/main.mk
@@ -568,7 +568,7 @@ LIBOBJS0 = alter.o analyze.o attach.o auth.o \
 PROLLY_OBJS = prolly_hash.o prolly_hashset.o prolly_arena.o prolly_node.o prolly_cache.o \
               chunk_store.o prolly_cursor.o prolly_mutmap.o prolly_chunker.o \
               prolly_mutate.o prolly_diff.o prolly_three_way_diff.o prolly_btree.o pager_shim.o sortkey.o \
-              doltlite.o doltlite_commit.o doltlite_log.o doltlite_status.o \
+              doltlite.o doltlite_commit.o doltlite_ref.o doltlite_log.o doltlite_status.o \
               doltlite_diff.o doltlite_diff_table.o doltlite_branch.o doltlite_tag.o doltlite_ancestor.o doltlite_merge.o doltlite_schema_merge.o doltlite_conflicts.o \
               doltlite_gc.o doltlite_history.o doltlite_at.o doltlite_schema_diff.o doltlite_record.o \
               doltlite_remote.o doltlite_remote_sql.o \
@@ -1345,6 +1345,9 @@ doltlite_log.o:	$(TOP)/src/doltlite_log.c $(DEPS_OBJ_COMMON)
 
 doltlite_status.o:	$(TOP)/src/doltlite_status.c $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/doltlite_status.c
+
+doltlite_ref.o:	$(TOP)/src/doltlite_ref.c $(DEPS_OBJ_COMMON)
+	$(T.cc.sqlite) -c $(TOP)/src/doltlite_ref.c
 
 doltlite_diff.o:	$(TOP)/src/doltlite_diff.c $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/doltlite_diff.c

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -146,34 +146,7 @@ void freeSchemaMergeActions(SchemaMergeAction *a, int n){
   sqlite3_free(a);
 }
 
-/*
-** Helper #4: Resolve a commit reference — tries hex hash, branch name, then
-** tag name.  Replaces the old resolveCommitRef (hex-only) and inline resolution
-** in doltliteResetFunc.
-*/
-static int resolveCommitRef(
-  ChunkStore *cs,
-  const char *zRef,
-  ProllyHash *pHash
-){
-  int rc = SQLITE_NOTFOUND;
-  if( !zRef ) return SQLITE_ERROR;
-  /* Try 40-char hex hash */
-  if( strlen(zRef)==PROLLY_HASH_SIZE*2 ){
-    rc = doltliteHexToHash(zRef, pHash);
-    if( rc==SQLITE_OK && !chunkStoreHas(cs, pHash) ) rc = SQLITE_NOTFOUND;
-  }
-  /* Try branch name */
-  if( rc!=SQLITE_OK ){
-    rc = chunkStoreFindBranch(cs, zRef, pHash);
-    if( rc!=SQLITE_OK || prollyHashIsEmpty(pHash) ){
-      /* Try tag name */
-      rc = chunkStoreFindTag(cs, zRef, pHash);
-    }
-  }
-  if( rc==SQLITE_OK && prollyHashIsEmpty(pHash) ) rc = SQLITE_NOTFOUND;
-  return rc;
-}
+/* resolveCommitRef removed — use doltliteResolveRef() from doltlite_ref.c */
 
 /*
 ** Helper #5 uses the existing loadCommitByHash — declared later.  Forward-declare
@@ -685,7 +658,7 @@ static void doltliteResetFunc(
     ProllyHash targetCommit;
     DoltliteCommit commit;
 
-    rc = resolveCommitRef(cs, zRef, &targetCommit);
+    rc = doltliteResolveRef(db,zRef, &targetCommit);
     if( rc!=SQLITE_OK ){
       sqlite3_result_error(context, "commit not found", -1);
       return;
@@ -1058,7 +1031,7 @@ static void doltliteCherryPickFunc(
   }
 
   
-  rc = resolveCommitRef(cs, zRef, &pickHash);
+  rc = doltliteResolveRef(db,zRef, &pickHash);
   if( rc!=SQLITE_OK ){
     sqlite3_result_error(context, "invalid commit hash", -1);
     return;
@@ -1160,7 +1133,7 @@ static void doltliteRevertFunc(
   }
 
   
-  rc = resolveCommitRef(cs, zRef, &revertHash);
+  rc = doltliteResolveRef(db,zRef, &revertHash);
   if( rc!=SQLITE_OK ){
     sqlite3_result_error(context, "invalid commit hash", -1);
     return;

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -148,12 +148,7 @@ void freeSchemaMergeActions(SchemaMergeAction *a, int n){
 
 /* resolveCommitRef removed — use doltliteResolveRef() from doltlite_ref.c */
 
-/*
-** Helper #5 uses the existing loadCommitByHash — declared later.  Forward-declare
-** it here so the helpers below can use it.
-*/
-static int loadCommitByHash(ChunkStore *cs, const ProllyHash *pHash,
-                            DoltliteCommit *pCommit);
+/* Helper #5: loadCommitByHash replaced by doltliteLoadCommit from doltlite_ref.c */
 
 /*
 ** Helper #6: Build a commit object, serialize it, store it, and clear.
@@ -664,7 +659,7 @@ static void doltliteResetFunc(
       return;
     }
 
-    rc = loadCommitByHash(cs, &targetCommit, &commit);
+    rc = doltliteLoadCommit(db, &targetCommit, &commit);
     if( rc!=SQLITE_OK ){
       sqlite3_result_error(context, "failed to load commit", -1);
       return;
@@ -824,7 +819,7 @@ static void doltliteMergeFunc(
     /* Fast-forward: move branch pointer to their commit, no merge commit. */
     char hx[PROLLY_HASH_SIZE*2+1];
 
-    rc = loadCommitByHash(cs, &theirHead, &theirCommit);
+    rc = doltliteLoadCommit(db, &theirHead, &theirCommit);
     if( rc!=SQLITE_OK ){ sqlite3_result_error(context, "failed to load commit", -1); return; }
 
     rc = doltliteSwitchCatalog(db, &theirCommit.catalogHash);
@@ -845,15 +840,15 @@ static void doltliteMergeFunc(
   }
 
 
-  rc = loadCommitByHash(cs, &ourHead, &ourCommit);
+  rc = doltliteLoadCommit(db, &ourHead, &ourCommit);
   if( rc!=SQLITE_OK ){ sqlite3_result_error(context, "failed to load our commit", -1); return; }
   memcpy(&ourCatHash, &ourCommit.catalogHash, sizeof(ProllyHash));
 
-  rc = loadCommitByHash(cs, &theirHead, &theirCommit);
+  rc = doltliteLoadCommit(db, &theirHead, &theirCommit);
   if( rc!=SQLITE_OK ){ doltliteCommitClear(&ourCommit); sqlite3_result_error(context, "failed to load their commit", -1); return; }
   memcpy(&theirCatHash, &theirCommit.catalogHash, sizeof(ProllyHash));
 
-  rc = loadCommitByHash(cs, &ancestorHash, &ancCommit);
+  rc = doltliteLoadCommit(db, &ancestorHash, &ancCommit);
   if( rc!=SQLITE_OK ){ doltliteCommitClear(&ourCommit); doltliteCommitClear(&theirCommit); sqlite3_result_error(context, "failed to load ancestor", -1); return; }
   memcpy(&ancCatHash, &ancCommit.catalogHash, sizeof(ProllyHash));
   doltliteCommitClear(&ancCommit);
@@ -947,21 +942,7 @@ static void doltliteMergeFunc(
   }
 }
 
-static int loadCommitByHash(
-  ChunkStore *cs,
-  const ProllyHash *pHash,
-  DoltliteCommit *pCommit
-){
-  u8 *data = 0;
-  int nData = 0;
-  int rc;
-  memset(pCommit, 0, sizeof(*pCommit));
-  rc = chunkStoreGet(cs, pHash, &data, &nData);
-  if( rc!=SQLITE_OK ) return rc;
-  rc = doltliteCommitDeserialize(data, nData, pCommit);
-  sqlite3_free(data);
-  return rc;
-}
+/* loadCommitByHash removed — callers migrated to doltliteLoadCommit */
 
 static int applyMergedCatalogAndCommit(
   sqlite3 *db,
@@ -1038,7 +1019,7 @@ static void doltliteCherryPickFunc(
   }
 
   
-  rc = loadCommitByHash(cs, &pickHash, &pickCommit);
+  rc = doltliteLoadCommit(db, &pickHash, &pickCommit);
   if( rc!=SQLITE_OK ){
     sqlite3_result_error(context, "commit not found", -1);
     return;
@@ -1051,7 +1032,7 @@ static void doltliteCherryPickFunc(
     return;
   }
 
-  rc = loadCommitByHash(cs, &pickCommit.parentHash, &parentCommit);
+  rc = doltliteLoadCommit(db, &pickCommit.parentHash, &parentCommit);
   if( rc!=SQLITE_OK ){
     doltliteCommitClear(&pickCommit);
     sqlite3_result_error(context, "parent commit not found", -1);
@@ -1067,7 +1048,7 @@ static void doltliteCherryPickFunc(
     return;
   }
 
-  rc = loadCommitByHash(cs, &ourHead, &ourCommit);
+  rc = doltliteLoadCommit(db, &ourHead, &ourCommit);
   if( rc!=SQLITE_OK ){
     doltliteCommitClear(&pickCommit);
     doltliteCommitClear(&parentCommit);
@@ -1140,7 +1121,7 @@ static void doltliteRevertFunc(
   }
 
   
-  rc = loadCommitByHash(cs, &revertHash, &revertCommit);
+  rc = doltliteLoadCommit(db, &revertHash, &revertCommit);
   if( rc!=SQLITE_OK ){
     sqlite3_result_error(context, "commit not found", -1);
     return;
@@ -1153,7 +1134,7 @@ static void doltliteRevertFunc(
     return;
   }
 
-  rc = loadCommitByHash(cs, &revertCommit.parentHash, &parentCommit);
+  rc = doltliteLoadCommit(db, &revertCommit.parentHash, &parentCommit);
   if( rc!=SQLITE_OK ){
     doltliteCommitClear(&revertCommit);
     sqlite3_result_error(context, "parent commit not found", -1);
@@ -1169,7 +1150,7 @@ static void doltliteRevertFunc(
     return;
   }
 
-  rc = loadCommitByHash(cs, &ourHead, &ourCommit);
+  rc = doltliteLoadCommit(db, &ourHead, &ourCommit);
   if( rc!=SQLITE_OK ){
     doltliteCommitClear(&revertCommit);
     doltliteCommitClear(&parentCommit);

--- a/src/doltlite_ancestor.c
+++ b/src/doltlite_ancestor.c
@@ -247,24 +247,6 @@ int doltliteFindAncestor(
 extern int chunkStoreFindBranch(ChunkStore *cs, const char *zName, ProllyHash *pCommit);
 extern int chunkStoreFindTag(ChunkStore *cs, const char *zName, ProllyHash *pCommit);
 
-static int resolveCommitRef(sqlite3 *db, const char *zRef, ProllyHash *pHash){
-  ChunkStore *cs;
-  
-  if( zRef && strlen(zRef)==PROLLY_HASH_SIZE*2 ){
-    if( doltliteHexToHash(zRef, pHash)==SQLITE_OK ) return SQLITE_OK;
-  }
-  cs = doltliteGetChunkStore(db);
-  if( !cs ) return SQLITE_ERROR;
-  
-  if( chunkStoreFindBranch(cs, zRef, pHash)==SQLITE_OK ){
-    return SQLITE_OK;
-  }
-  
-  if( chunkStoreFindTag(cs, zRef, pHash)==SQLITE_OK ){
-    return SQLITE_OK;
-  }
-  return SQLITE_ERROR;
-}
 
 static void doltMergeBaseFunc(
   sqlite3_context *ctx,
@@ -288,12 +270,12 @@ static void doltMergeBaseFunc(
     return;
   }
 
-  rc = resolveCommitRef(db, zRef1, &hash1);
+  rc = doltliteResolveRef(db,zRef1, &hash1);
   if( rc!=SQLITE_OK ){
     sqlite3_result_error(ctx, "could not resolve first argument to a commit", -1);
     return;
   }
-  rc = resolveCommitRef(db, zRef2, &hash2);
+  rc = doltliteResolveRef(db,zRef2, &hash2);
   if( rc!=SQLITE_OK ){
     sqlite3_result_error(ctx, "could not resolve second argument to a commit", -1);
     return;

--- a/src/doltlite_ancestor.c
+++ b/src/doltlite_ancestor.c
@@ -103,20 +103,8 @@ static int hashSetContains(const HashSet *hs, const ProllyHash *h){
 
 static int loadCommitByHash(sqlite3 *db, const ProllyHash *hash,
                             DoltliteCommit *pCommit){
-  ChunkStore *cs = doltliteGetChunkStore(db);
-  u8 *data = 0;
-  int nData = 0;
-  int rc;
-
-  if( !cs ) return SQLITE_ERROR;
   if( prollyHashIsEmpty(hash) ) return SQLITE_NOTFOUND;
-
-  rc = chunkStoreGet(cs, hash, &data, &nData);
-  if( rc!=SQLITE_OK ) return rc;
-
-  rc = doltliteCommitDeserialize(data, nData, pCommit);
-  sqlite3_free(data);
-  return rc;
+  return doltliteLoadCommit(db, hash, pCommit);
 }
 
 static int ancestorBfsCollect(

--- a/src/doltlite_at.c
+++ b/src/doltlite_at.c
@@ -13,50 +13,6 @@
 #include <string.h>
 #include <time.h>
 
-#define AT_MAX_COLS 64
-
-typedef struct AtRecInfo AtRecInfo;
-struct AtRecInfo { int nField; int aType[AT_MAX_COLS]; int aOffset[AT_MAX_COLS]; };
-
-static void atParseRecord(const u8 *pData, int nData, AtRecInfo *ri){
-  const u8 *p=pData, *pEnd=pData+nData;
-  u64 hdrSize; int hdrBytes, off;
-  memset(ri,0,sizeof(*ri));
-  if(!pData||nData<1) return;
-  hdrBytes=dlReadVarint(p,pEnd,&hdrSize); p+=hdrBytes;
-  off=(int)hdrSize;
-  while(p<pData+hdrSize && p<pEnd && ri->nField<AT_MAX_COLS){
-    u64 st; int stBytes=dlReadVarint(p,pData+hdrSize,&st); p+=stBytes;
-    ri->aType[ri->nField]=(int)st; ri->aOffset[ri->nField]=off;
-    if(st==0){}else if(st==1)off+=1;else if(st==2)off+=2;else if(st==3)off+=3;
-    else if(st==4)off+=4;else if(st==5)off+=6;else if(st==6)off+=8;else if(st==7)off+=8;
-    else if(st==8||st==9){}else if(st>=12&&(st&1)==0)off+=((int)st-12)/2;
-    else if(st>=13&&(st&1)==1)off+=((int)st-13)/2;
-    ri->nField++;
-  }
-}
-
-static void atResultField(sqlite3_context *ctx, const u8 *pData, int nData, int st, int off){
-  if(st==0){sqlite3_result_null(ctx);return;}
-  if(st==8){sqlite3_result_int(ctx,0);return;}
-  if(st==9){sqlite3_result_int(ctx,1);return;}
-  if(st>=1&&st<=6){
-    static const int sz[]={0,1,2,3,4,6,8}; int nB=sz[st];
-    if(off+nB<=nData){const u8*q=pData+off;i64 v=(q[0]&0x80)?-1:0;int i;
-      for(i=0;i<nB;i++)v=(v<<8)|q[i];sqlite3_result_int64(ctx,v);}
-    else sqlite3_result_null(ctx); return;
-  }
-  if(st==7){if(off+8<=nData){const u8*q=pData+off;double v;u64 bits=0;int i;
-    for(i=0;i<8;i++)bits=(bits<<8)|q[i];memcpy(&v,&bits,8);
-    sqlite3_result_double(ctx,v);}else sqlite3_result_null(ctx);return;}
-  if(st>=13&&(st&1)==1){int len=(st-13)/2;
-    if(off+len<=nData)sqlite3_result_text(ctx,(const char*)(pData+off),len,SQLITE_TRANSIENT);
-    else sqlite3_result_null(ctx);return;}
-  if(st>=12&&(st&1)==0){int len=(st-12)/2;
-    if(off+len<=nData)sqlite3_result_blob(ctx,pData+off,len,SQLITE_TRANSIENT);
-    else sqlite3_result_null(ctx);return;}
-  sqlite3_result_null(ctx);
-}
 
 static char *atBuildSchema(DoltliteColInfo *ci){
   int i, sz=256;
@@ -285,8 +241,8 @@ static int atColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
       sqlite3_result_int64(ctx,r->intKey);
     }else{
       if(r->pVal&&r->nVal>0){
-        AtRecInfo ri; atParseRecord(r->pVal,r->nVal,&ri);
-        if(col<ri.nField) atResultField(ctx,r->pVal,r->nVal,ri.aType[col],ri.aOffset[col]);
+        DoltliteRecordInfo ri; doltliteParseRecord(r->pVal,r->nVal,&ri);
+        if(col<ri.nField) doltliteResultField(ctx,r->pVal,r->nVal,ri.aType[col],ri.aOffset[col]);
         else sqlite3_result_null(ctx);
       }else sqlite3_result_null(ctx);
     }

--- a/src/doltlite_at.c
+++ b/src/doltlite_at.c
@@ -100,30 +100,6 @@ static void freeAtRows(AtCursor *c){
   sqlite3_free(c->aRows); c->aRows=0; c->nRows=0; c->nAlloc=0;
 }
 
-static int atResolveRef(ChunkStore *cs, const char *zRef, ProllyHash *pCommit){
-  int rc;
-  if(zRef&&strlen(zRef)==40){
-    rc=doltliteHexToHash(zRef,pCommit);
-    if(rc==SQLITE_OK&&chunkStoreHas(cs,pCommit)) return SQLITE_OK;
-  }
-  rc=chunkStoreFindBranch(cs,zRef,pCommit);
-  if(rc==SQLITE_OK&&!prollyHashIsEmpty(pCommit)) return SQLITE_OK;
-  rc=chunkStoreFindTag(cs,zRef,pCommit);
-  if(rc==SQLITE_OK&&!prollyHashIsEmpty(pCommit)) return SQLITE_OK;
-  return SQLITE_NOTFOUND;
-}
-
-static int atFindRoot(struct TableEntry *a, int n, const char *zName,
-                      ProllyHash *pRoot, u8 *pFlags){
-  struct TableEntry *e = doltliteFindTableByName(a, n, zName);
-  if( e ){
-    memcpy(pRoot, &e->root, sizeof(ProllyHash));
-    if( pFlags ) *pFlags = e->flags;
-    return SQLITE_OK;
-  }
-  memset(pRoot,0,sizeof(ProllyHash)); if(pFlags)*pFlags=0;
-  return SQLITE_NOTFOUND;
-}
 
 static int atScanTree(AtCursor *pCur, ChunkStore *cs, ProllyCache *pCache,
                       const ProllyHash *pRoot, u8 flags){
@@ -247,14 +223,11 @@ static int atFilter(sqlite3_vtab_cursor *cur,
   zRef=(const char*)sqlite3_value_text(argv[0]);
   if(!zRef) return SQLITE_OK;
 
-  rc=atResolveRef(cs,zRef,&commitHash);
+  rc=doltliteResolveRef(db,zRef,&commitHash);
   if(rc!=SQLITE_OK) return SQLITE_OK;
 
   memset(&commit,0,sizeof(commit));
-  rc=chunkStoreGet(cs,&commitHash,&data,&nData);
-  if(rc!=SQLITE_OK) return SQLITE_OK;
-  rc=doltliteCommitDeserialize(data,nData,&commit);
-  sqlite3_free(data);
+  rc=doltliteLoadCommit(db,&commitHash,&commit);
   if(rc!=SQLITE_OK) return SQLITE_OK;
 
   /* For branch refs, prefer the working state catalog if it has
@@ -286,7 +259,7 @@ static int atFilter(sqlite3_vtab_cursor *cur,
 
 at_find_root:
 
-  rc=atFindRoot(aTables,nTables,v->zTableName,&tableRoot,&flags);
+  rc=doltliteFindTableRootByName(aTables,nTables,v->zTableName,&tableRoot,&flags);
   sqlite3_free(aTables);
   if(rc!=SQLITE_OK) return SQLITE_OK;
 

--- a/src/doltlite_at.c
+++ b/src/doltlite_at.c
@@ -262,22 +262,7 @@ static sqlite3_module atModule = {
 };
 
 void doltliteRegisterAtTables(sqlite3 *db){
-  ProllyHash headCommit;
-  DoltliteCommit commit; struct TableEntry *aT=0;int nT=0,i,rc;
-  doltliteGetSessionHead(db,&headCommit);
-  if(prollyHashIsEmpty(&headCommit)) return;
-  memset(&commit,0,sizeof(commit));
-  rc=doltliteLoadCommit(db,&headCommit,&commit);
-  if(rc!=SQLITE_OK) return;
-  rc=doltliteLoadCatalog(db,&commit.catalogHash,&aT,&nT,0);
-  doltliteCommitClear(&commit); if(rc!=SQLITE_OK) return;
-  for(i=0;i<nT;i++){
-    if(aT[i].zName&&aT[i].iTable>1){
-      char *zMod=sqlite3_mprintf("dolt_at_%s",aT[i].zName);
-      if(zMod){sqlite3_create_module(db,zMod,&atModule,0);sqlite3_free(zMod);}
-    }
-  }
-  sqlite3_free(aT);
+  doltliteForEachUserTable(db, "dolt_at_", &atModule);
 }
 
 int doltliteAtRegister(sqlite3 *db){

--- a/src/doltlite_at.c
+++ b/src/doltlite_at.c
@@ -262,15 +262,12 @@ static sqlite3_module atModule = {
 };
 
 void doltliteRegisterAtTables(sqlite3 *db){
-  ProllyHash headCommit; u8 *data=0;int nData=0;
+  ProllyHash headCommit;
   DoltliteCommit commit; struct TableEntry *aT=0;int nT=0,i,rc;
-  ChunkStore *cs=doltliteGetChunkStore(db);
-  if(!cs) return;
   doltliteGetSessionHead(db,&headCommit);
   if(prollyHashIsEmpty(&headCommit)) return;
-  rc=chunkStoreGet(cs,&headCommit,&data,&nData); if(rc!=SQLITE_OK) return;
   memset(&commit,0,sizeof(commit));
-  rc=doltliteCommitDeserialize(data,nData,&commit); sqlite3_free(data);
+  rc=doltliteLoadCommit(db,&headCommit,&commit);
   if(rc!=SQLITE_OK) return;
   rc=doltliteLoadCatalog(db,&commit.catalogHash,&aT,&nT,0);
   doltliteCommitClear(&commit); if(rc!=SQLITE_OK) return;

--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -77,13 +77,8 @@ static int checkoutLoadAndApply(
   /* Load the committed catalog for this branch. */
   {
     DoltliteCommit commit;
-    u8 *data = 0;
-    int nData = 0;
 
-    rc = chunkStoreGet(cs, pCommitHash, &data, &nData);
-    if( rc!=SQLITE_OK ) return rc;
-    rc = doltliteCommitDeserialize(data, nData, &commit);
-    sqlite3_free(data);
+    rc = doltliteLoadCommit(db, pCommitHash, &commit);
     if( rc!=SQLITE_OK ) return rc;
 
     memcpy(&committedCatHash, &commit.catalogHash, sizeof(ProllyHash));

--- a/src/doltlite_chunk_walk.c
+++ b/src/doltlite_chunk_walk.c
@@ -1,0 +1,181 @@
+
+#ifdef DOLTLITE_PROLLY
+
+#include "sqliteInt.h"
+#include "prolly_hash.h"
+#include "prolly_node.h"
+#include "chunk_store.h"
+#include "doltlite_commit.h"
+#include "doltlite_chunk_walk.h"
+
+#include <string.h>
+
+DoltliteChunkType doltliteClassifyChunk(const u8 *data, int nData){
+  u32 m;
+
+  if( !data || nData < 4 ) return CHUNK_UNKNOWN;
+
+  /* Check prolly node magic first (4-byte LE) */
+  m = (u32)data[0] | ((u32)data[1]<<8) |
+      ((u32)data[2]<<16) | ((u32)data[3]<<24);
+  if( m == PROLLY_NODE_MAGIC && nData >= 8 ){
+    return CHUNK_PROLLY_NODE;
+  }
+
+  /* Working set: exactly WS_TOTAL_SIZE bytes, version byte == 1 */
+  if( nData == WS_TOTAL_SIZE && data[0] == 1 ){
+    return CHUNK_WORKING_SET;
+  }
+
+  /* Catalog V2: starts with magic 0x43, has at least header size */
+  if( nData >= CAT_HEADER_SIZE && data[0] == CATALOG_FORMAT_V2 ){
+    return CHUNK_CATALOG;
+  }
+
+  /* Commit V2: version byte matches, minimum size 30 */
+  if( nData >= 30 && data[0] == DOLTLITE_COMMIT_V2 ){
+    return CHUNK_COMMIT;
+  }
+
+  return CHUNK_UNKNOWN;
+}
+
+static int enumerateProllyNodeChildren(
+  const u8 *data,
+  int nData,
+  DoltliteChildCb xChild,
+  void *ctx
+){
+  ProllyNode node;
+  int rc;
+  int i;
+
+  rc = prollyNodeParse(&node, data, nData);
+  if( rc!=SQLITE_OK ) return SQLITE_OK; /* parse failure: no children */
+  if( node.level == 0 ) return SQLITE_OK; /* leaf: no child hashes */
+
+  for(i=0; i<(int)node.nItems; i++){
+    ProllyHash childHash;
+    prollyNodeChildHash(&node, i, &childHash);
+    rc = xChild(ctx, &childHash);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+  return SQLITE_OK;
+}
+
+static int enumerateCommitChildren(
+  const u8 *data,
+  int nData,
+  DoltliteChildCb xChild,
+  void *ctx
+){
+  DoltliteCommit commit;
+  int drc, rc = SQLITE_OK;
+  int pi;
+
+  memset(&commit, 0, sizeof(commit));
+  drc = doltliteCommitDeserialize(data, nData, &commit);
+  if( drc!=SQLITE_OK ) return SQLITE_OK; /* can't parse: no children */
+
+  for(pi=0; pi<commit.nParents && rc==SQLITE_OK; pi++){
+    rc = xChild(ctx, &commit.aParents[pi]);
+  }
+  if( rc==SQLITE_OK ){
+    rc = xChild(ctx, &commit.catalogHash);
+  }
+  doltliteCommitClear(&commit);
+  return rc;
+}
+
+static int enumerateCatalogChildren(
+  const u8 *data,
+  int nData,
+  DoltliteChildCb xChild,
+  void *ctx
+){
+  int nTables;
+  const u8 *p;
+  int i;
+  int rc = SQLITE_OK;
+
+  nTables = (int)(data[CAT_NUM_TABLES_OFF]
+                | (data[CAT_NUM_TABLES_OFF+1]<<8)
+                | (data[CAT_NUM_TABLES_OFF+2]<<16)
+                | (data[CAT_NUM_TABLES_OFF+3]<<24));
+  if( nTables < 0 || nTables >= 10000 ) return SQLITE_OK;
+
+  p = data + CAT_HEADER_SIZE;
+  for(i=0; i<nTables && rc==SQLITE_OK; i++){
+    int nameLen;
+    ProllyHash tableRoot;
+
+    if( p + CAT_ENTRY_FIXED_SIZE > data + nData ) break;
+
+    memcpy(tableRoot.data,
+           p + CAT_ENTRY_ITABLE_SIZE + CAT_ENTRY_FLAGS_SIZE,
+           PROLLY_HASH_SIZE);
+    rc = xChild(ctx, &tableRoot);
+    if( rc!=SQLITE_OK ) break;
+
+    p += CAT_ENTRY_ITABLE_SIZE + CAT_ENTRY_FLAGS_SIZE
+       + PROLLY_HASH_SIZE + PROLLY_HASH_SIZE;
+    nameLen = p[0] | (p[1]<<8);
+    p += 2 + nameLen;
+  }
+  return rc;
+}
+
+static int enumerateWorkingSetChildren(
+  const u8 *data,
+  int nData,
+  DoltliteChildCb xChild,
+  void *ctx
+){
+  ProllyHash h;
+  int rc;
+
+  (void)nData;
+
+  /* staged catalog hash */
+  memcpy(h.data, data + WS_STAGED_OFF, PROLLY_HASH_SIZE);
+  rc = xChild(ctx, &h);
+  if( rc!=SQLITE_OK ) return rc;
+
+  /* conflicts catalog hash */
+  memcpy(h.data, data + WS_CONFLICTS_OFF, PROLLY_HASH_SIZE);
+  rc = xChild(ctx, &h);
+  if( rc!=SQLITE_OK ) return rc;
+
+  /* merge commit hash (only if merging) */
+  if( data[WS_MERGING_OFF] ){
+    memcpy(h.data, data + WS_MERGE_COMMIT_OFF, PROLLY_HASH_SIZE);
+    rc = xChild(ctx, &h);
+  }
+
+  return rc;
+}
+
+int doltliteEnumerateChunkChildren(
+  const u8 *data,
+  int nData,
+  DoltliteChildCb xChild,
+  void *ctx
+){
+  DoltliteChunkType type = doltliteClassifyChunk(data, nData);
+
+  switch( type ){
+    case CHUNK_PROLLY_NODE:
+      return enumerateProllyNodeChildren(data, nData, xChild, ctx);
+    case CHUNK_COMMIT:
+      return enumerateCommitChildren(data, nData, xChild, ctx);
+    case CHUNK_CATALOG:
+      return enumerateCatalogChildren(data, nData, xChild, ctx);
+    case CHUNK_WORKING_SET:
+      return enumerateWorkingSetChildren(data, nData, xChild, ctx);
+    case CHUNK_UNKNOWN:
+    default:
+      return SQLITE_OK;
+  }
+}
+
+#endif /* DOLTLITE_PROLLY */

--- a/src/doltlite_chunk_walk.h
+++ b/src/doltlite_chunk_walk.h
@@ -1,0 +1,27 @@
+
+#ifndef DOLTLITE_CHUNK_WALK_H
+#define DOLTLITE_CHUNK_WALK_H
+
+#include "sqliteInt.h"
+#include "prolly_hash.h"
+
+typedef enum {
+  CHUNK_UNKNOWN = 0,
+  CHUNK_COMMIT,
+  CHUNK_PROLLY_NODE,
+  CHUNK_CATALOG,
+  CHUNK_WORKING_SET
+} DoltliteChunkType;
+
+typedef int (*DoltliteChildCb)(void *ctx, const ProllyHash *pHash);
+
+DoltliteChunkType doltliteClassifyChunk(const u8 *data, int nData);
+
+int doltliteEnumerateChunkChildren(
+  const u8 *data,
+  int nData,
+  DoltliteChildCb xChild,
+  void *ctx
+);
+
+#endif /* DOLTLITE_CHUNK_WALK_H */

--- a/src/doltlite_diff.c
+++ b/src/doltlite_diff.c
@@ -172,64 +172,27 @@ static void freeDiffRows(DoltliteDiffCursor *pCur){
   pCur->nRows = 0;
 }
 
-static int findTableRoot(struct TableEntry *a, int n, Pgno iTable,
-                         ProllyHash *pRoot, u8 *pFlags){
-  struct TableEntry *e = doltliteFindTableByNumber(a, n, iTable);
-  if( e ){
-    memcpy(pRoot, &e->root, sizeof(ProllyHash));
-    if( pFlags ) *pFlags = e->flags;
-    return SQLITE_OK;
-  }
-  memset(pRoot, 0, sizeof(ProllyHash));
-  if( pFlags ) *pFlags = 0;
-  return SQLITE_NOTFOUND;
-}
-
-static int resolveRef(sqlite3 *db, const char *zRef, ProllyHash *pCommit){
-  ChunkStore *cs = doltliteGetChunkStore(db);
-  int rc;
-  
-  if( zRef && strlen(zRef)==PROLLY_HASH_SIZE*2 ){
-    rc = doltliteHexToHash(zRef, pCommit);
-    if( rc==SQLITE_OK && chunkStoreHas(cs, pCommit) ) return SQLITE_OK;
-  }
-  
-  rc = chunkStoreFindBranch(cs, zRef, pCommit);
-  if( rc==SQLITE_OK && !prollyHashIsEmpty(pCommit) ) return SQLITE_OK;
-  
-  rc = chunkStoreFindTag(cs, zRef, pCommit);
-  if( rc==SQLITE_OK && !prollyHashIsEmpty(pCommit) ) return SQLITE_OK;
-  return SQLITE_NOTFOUND;
-}
-
 static int resolveCommitToTableRoot(
   sqlite3 *db, const char *zRef, Pgno iTable,
   ProllyHash *pRoot, u8 *pFlags
 ){
-  ChunkStore *cs = doltliteGetChunkStore(db);
   ProllyHash commitHash;
-  u8 *data = 0;
-  int nData = 0;
   DoltliteCommit commit;
   struct TableEntry *aTables = 0;
   int nTables = 0;
   int rc;
 
-  rc = resolveRef(db, zRef, &commitHash);
+  rc = doltliteResolveRef(db, zRef, &commitHash);
   if( rc!=SQLITE_OK ) return rc;
 
-  rc = chunkStoreGet(cs, &commitHash, &data, &nData);
-  if( rc!=SQLITE_OK ) return rc;
-
-  rc = doltliteCommitDeserialize(data, nData, &commit);
-  sqlite3_free(data);
+  rc = doltliteLoadCommit(db, &commitHash, &commit);
   if( rc!=SQLITE_OK ) return rc;
 
   rc = doltliteLoadCatalog(db, &commit.catalogHash, &aTables, &nTables, 0);
   doltliteCommitClear(&commit);
   if( rc!=SQLITE_OK ) return rc;
 
-  rc = findTableRoot(aTables, nTables, iTable, pRoot, pFlags);
+  rc = doltliteFindTableRoot(aTables, nTables, iTable, pRoot, pFlags);
   sqlite3_free(aTables);
   return rc;
 }
@@ -369,7 +332,7 @@ static int diffFilter(sqlite3_vtab_cursor *pCursor,
     if( rc==SQLITE_OK ){
       rc = doltliteLoadCatalog(db, &headCatHash, &aHead, &nHead, 0);
       if( rc==SQLITE_OK ){
-        findTableRoot(aHead, nHead, iTable, &oldRoot, &flags);
+        doltliteFindTableRoot(aHead, nHead, iTable, &oldRoot, &flags);
         sqlite3_free(aHead);
       }
     }
@@ -393,7 +356,7 @@ static int diffFilter(sqlite3_vtab_cursor *pCursor,
       if( rc==SQLITE_OK ){
         rc = doltliteLoadCatalog(db, &workingCatHash, &aWork, &nWork, 0);
         if( rc==SQLITE_OK ){
-          findTableRoot(aWork, nWork, iTable, &newRoot, &flags);
+          doltliteFindTableRoot(aWork, nWork, iTable, &newRoot, &flags);
           sqlite3_free(aWork);
         }
       }

--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -158,7 +158,6 @@ static int walkHistoryAndDiff(
   if( prollyHashIsEmpty(&curHash) ) return SQLITE_OK;
 
   while( !prollyHashIsEmpty(&curHash) ){
-    u8 *data = 0; int nData = 0;
     DoltliteCommit commit;
     ProllyHash curRoot, parentRoot;
     u8 flags = 0;
@@ -166,10 +165,7 @@ static int walkHistoryAndDiff(
     char parentHex[PROLLY_HASH_SIZE*2+1];
 
     memset(&commit, 0, sizeof(commit));
-    rc = chunkStoreGet(cs, &curHash, &data, &nData);
-    if( rc!=SQLITE_OK ) break;
-    rc = doltliteCommitDeserialize(data, nData, &commit);
-    sqlite3_free(data);
+    rc = doltliteLoadCommit(db, &curHash, &commit);
     if( rc!=SQLITE_OK ) break;
 
     doltliteHashToHex(&curHash, curHex);
@@ -187,14 +183,9 @@ static int walkHistoryAndDiff(
 
     if( !prollyHashIsEmpty(&commit.parentHash) ){
       DoltliteCommit parentCommit;
-      u8 *pdata = 0; int npdata = 0;
 
       memset(&parentCommit, 0, sizeof(parentCommit));
-      rc = chunkStoreGet(cs, &commit.parentHash, &pdata, &npdata);
-      if( rc==SQLITE_OK ){
-        rc = doltliteCommitDeserialize(pdata, npdata, &parentCommit);
-        sqlite3_free(pdata);
-      }
+      rc = doltliteLoadCommit(db, &commit.parentHash, &parentCommit);
 
       if( rc==SQLITE_OK ){
         doltliteHashToHex(&commit.parentHash, parentHex);
@@ -464,23 +455,16 @@ static sqlite3_module diffTableModule = {
 };
 
 void doltliteRegisterDiffTables(sqlite3 *db){
-  ChunkStore *cs = doltliteGetChunkStore(db);
   ProllyHash headCommit;
-  u8 *data = 0; int nData = 0;
   DoltliteCommit commit;
   struct TableEntry *aTables = 0;
   int nTables = 0, i, rc;
 
-  if( !cs ) return;
   doltliteGetSessionHead(db, &headCommit);
   if( prollyHashIsEmpty(&headCommit) ) return;
 
-  rc = chunkStoreGet(cs, &headCommit, &data, &nData);
-  if( rc!=SQLITE_OK ) return;
-
   memset(&commit, 0, sizeof(commit));
-  rc = doltliteCommitDeserialize(data, nData, &commit);
-  sqlite3_free(data);
+  rc = doltliteLoadCommit(db, &headCommit, &commit);
   if( rc!=SQLITE_OK ) return;
 
   rc = doltliteLoadCatalog(db, &commit.catalogHash, &aTables, &nTables, 0);

--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -455,32 +455,7 @@ static sqlite3_module diffTableModule = {
 };
 
 void doltliteRegisterDiffTables(sqlite3 *db){
-  ProllyHash headCommit;
-  DoltliteCommit commit;
-  struct TableEntry *aTables = 0;
-  int nTables = 0, i, rc;
-
-  doltliteGetSessionHead(db, &headCommit);
-  if( prollyHashIsEmpty(&headCommit) ) return;
-
-  memset(&commit, 0, sizeof(commit));
-  rc = doltliteLoadCommit(db, &headCommit, &commit);
-  if( rc!=SQLITE_OK ) return;
-
-  rc = doltliteLoadCatalog(db, &commit.catalogHash, &aTables, &nTables, 0);
-  doltliteCommitClear(&commit);
-  if( rc!=SQLITE_OK ) return;
-
-  for(i=0; i<nTables; i++){
-    if( aTables[i].zName && aTables[i].iTable > 1 ){
-      char *zModName = sqlite3_mprintf("dolt_diff_%s", aTables[i].zName);
-      if( zModName ){
-        sqlite3_create_module(db, zModName, &diffTableModule, 0);
-        sqlite3_free(zModName);
-      }
-    }
-  }
-  sqlite3_free(aTables);
+  doltliteForEachUserTable(db, "dolt_diff_", &diffTableModule);
 }
 
-#endif 
+#endif

--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -14,120 +14,7 @@
 #include <string.h>
 #include <time.h>
 
-#define DT_MAX_COLS 64
 
-typedef struct RecordInfo RecordInfo;
-struct RecordInfo {
-  int nField;
-  int aType[DT_MAX_COLS];
-  int aOffset[DT_MAX_COLS];
-  int bodyStart;
-};
-
-static void dtParseRecord(const u8 *pData, int nData, RecordInfo *pInfo){
-  const u8 *p = pData;
-  const u8 *pEnd = pData + nData;
-  u64 hdrSize;
-  int hdrBytes;
-  const u8 *pHdrEnd;
-  int off;
-
-  memset(pInfo, 0, sizeof(*pInfo));
-  if( !pData || nData < 1 ) return;
-
-  hdrBytes = dlReadVarint(p, pEnd, &hdrSize);
-  p += hdrBytes;
-  pHdrEnd = pData + (int)hdrSize;
-  off = (int)hdrSize;
-  pInfo->bodyStart = off;
-
-  while( p < pHdrEnd && p < pEnd && pInfo->nField < DT_MAX_COLS ){
-    u64 st;
-    int stBytes = dlReadVarint(p, pHdrEnd, &st);
-    p += stBytes;
-
-    pInfo->aType[pInfo->nField] = (int)st;
-    pInfo->aOffset[pInfo->nField] = off;
-
-    if( st==0 ) {}
-    else if( st==1 ) off += 1;
-    else if( st==2 ) off += 2;
-    else if( st==3 ) off += 3;
-    else if( st==4 ) off += 4;
-    else if( st==5 ) off += 6;
-    else if( st==6 ) off += 8;
-    else if( st==7 ) off += 8;
-    else if( st==8 || st==9 ) {}
-    else if( st>=12 && (st&1)==0 ) off += ((int)st-12)/2;
-    else if( st>=13 && (st&1)==1 ) off += ((int)st-13)/2;
-
-    pInfo->nField++;
-  }
-}
-
-static void dtResultField(
-  sqlite3_context *ctx,
-  const u8 *pData, int nData,
-  int fieldType, int fieldOffset
-){
-  int st = fieldType;
-
-  if( st==0 ){ sqlite3_result_null(ctx); return; }
-  if( st==8 ){ sqlite3_result_int(ctx, 0); return; }
-  if( st==9 ){ sqlite3_result_int(ctx, 1); return; }
-
-  if( st>=1 && st<=6 ){
-    static const int sizes[] = {0,1,2,3,4,6,8};
-    int nBytes = sizes[st];
-    if( fieldOffset + nBytes <= nData ){
-      const u8 *p = pData + fieldOffset;
-      i64 v = (p[0] & 0x80) ? -1 : 0;
-      int i;
-      for(i=0; i<nBytes; i++) v = (v<<8) | p[i];
-      sqlite3_result_int64(ctx, v);
-    }else{
-      sqlite3_result_null(ctx);
-    }
-    return;
-  }
-
-  if( st==7 ){
-    if( fieldOffset + 8 <= nData ){
-      const u8 *p = pData + fieldOffset;
-      double v;
-      u64 bits = 0;
-      int i;
-      for(i=0; i<8; i++) bits = (bits<<8) | p[i];
-      memcpy(&v, &bits, 8);
-      sqlite3_result_double(ctx, v);
-    }else{
-      sqlite3_result_null(ctx);
-    }
-    return;
-  }
-
-  if( st>=13 && (st&1)==1 ){
-    int len = (st-13)/2;
-    if( fieldOffset + len <= nData ){
-      sqlite3_result_text(ctx, (const char*)(pData+fieldOffset), len, SQLITE_TRANSIENT);
-    }else{
-      sqlite3_result_null(ctx);
-    }
-    return;
-  }
-
-  if( st>=12 && (st&1)==0 ){
-    int len = (st-12)/2;
-    if( fieldOffset + len <= nData ){
-      sqlite3_result_blob(ctx, pData+fieldOffset, len, SQLITE_TRANSIENT);
-    }else{
-      sqlite3_result_null(ctx);
-    }
-    return;
-  }
-
-  sqlite3_result_null(ctx);
-}
 
 static char *buildDiffSchema(DoltliteColInfo *ci){
   
@@ -494,10 +381,10 @@ static int dtColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
     }else{
       
       if( r->pOldVal && r->nOldVal > 0 ){
-        RecordInfo ri;
-        dtParseRecord(r->pOldVal, r->nOldVal, &ri);
+        DoltliteRecordInfo ri;
+        doltliteParseRecord(r->pOldVal, r->nOldVal, &ri);
         if( colIdx < ri.nField ){
-          dtResultField(ctx, r->pOldVal, r->nOldVal,
+          doltliteResultField(ctx, r->pOldVal, r->nOldVal,
                         ri.aType[colIdx], ri.aOffset[colIdx]);
         }else{
           sqlite3_result_null(ctx);
@@ -517,10 +404,10 @@ static int dtColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
       }
     }else{
       if( r->pNewVal && r->nNewVal > 0 ){
-        RecordInfo ri;
-        dtParseRecord(r->pNewVal, r->nNewVal, &ri);
+        DoltliteRecordInfo ri;
+        doltliteParseRecord(r->pNewVal, r->nNewVal, &ri);
         if( colIdx < ri.nField ){
-          dtResultField(ctx, r->pNewVal, r->nNewVal,
+          doltliteResultField(ctx, r->pNewVal, r->nNewVal,
                         ri.aType[colIdx], ri.aOffset[colIdx]);
         }else{
           sqlite3_result_null(ctx);

--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -254,20 +254,6 @@ static void freeAuditRows(DiffTblCursor *pCur){
   pCur->nAlloc = 0;
 }
 
-static int findTableRootByName(
-  struct TableEntry *a, int n, const char *zName,
-  ProllyHash *pRoot, u8 *pFlags
-){
-  struct TableEntry *e = doltliteFindTableByName(a, n, zName);
-  if( e ){
-    memcpy(pRoot, &e->root, sizeof(ProllyHash));
-    if( pFlags ) *pFlags = e->flags;
-    return SQLITE_OK;
-  }
-  memset(pRoot, 0, sizeof(ProllyHash));
-  if( pFlags ) *pFlags = 0;
-  return SQLITE_NOTFOUND;
-}
 
 static int walkHistoryAndDiff(
   DiffTblCursor *pCur, sqlite3 *db, const char *zTableName
@@ -305,7 +291,7 @@ static int walkHistoryAndDiff(
       struct TableEntry *aTables = 0; int nTables = 0;
       rc = doltliteLoadCatalog(db, &commit.catalogHash, &aTables, &nTables, 0);
       if( rc==SQLITE_OK ){
-        findTableRootByName(aTables, nTables, zTableName, &curRoot, &flags);
+        doltliteFindTableRootByName(aTables, nTables, zTableName, &curRoot, &flags);
         sqlite3_free(aTables);
       }else{
         memset(&curRoot, 0, sizeof(curRoot));
@@ -330,7 +316,7 @@ static int walkHistoryAndDiff(
           struct TableEntry *aPT = 0; int nPT = 0;
           rc = doltliteLoadCatalog(db, &parentCommit.catalogHash, &aPT, &nPT, 0);
           if( rc==SQLITE_OK ){
-            findTableRootByName(aPT, nPT, zTableName, &parentRoot, 0);
+            doltliteFindTableRootByName(aPT, nPT, zTableName, &parentRoot, 0);
             sqlite3_free(aPT);
           }else{
             memset(&parentRoot, 0, sizeof(parentRoot));

--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -7,6 +7,7 @@
 #include "prolly_node.h"
 #include "chunk_store.h"
 #include "doltlite_commit.h"
+#include "doltlite_chunk_walk.h"
 
 #include <string.h>
 #include <stdio.h>
@@ -57,33 +58,15 @@ static int gcQueuePop(GcQueue *q, ProllyHash *h){
   return 1;
 }
 
-#define PROLLY_NODE_MAGIC_VAL 0x504E4F44
-
-static int isCommitChunk(const u8 *data, int nData){
-  
-  if( nData < 30 ) return 0;
-  if( data[0] != DOLTLITE_COMMIT_V2 ) return 0;
-  
-  if( nData >= 4 ){
-    u32 m = (u32)data[0] | ((u32)data[1]<<8) |
-            ((u32)data[2]<<16) | ((u32)data[3]<<24);
-    if( m == PROLLY_NODE_MAGIC_VAL ) return 0;
-  }
-  return 1;
-}
-
-static int isProllyNodeChunk(const u8 *data, int nData){
-  u32 m;
-  if( nData < 8 ) return 0;
-  m = (u32)data[0] | ((u32)data[1]<<8) |
-      ((u32)data[2]<<16) | ((u32)data[3]<<24);
-  return m == PROLLY_NODE_MAGIC_VAL;
-}
-
 /* BFS from all roots (manifest hashes + all branch/tag refs + working sets)
-** to mark every reachable chunk. Understands three chunk types: prolly nodes
-** (recurse into children), commits (follow parents + catalog), and catalog
-** blobs (follow table root hashes). */
+** to mark every reachable chunk. Uses doltliteEnumerateChunkChildren to
+** discover child hashes from all known chunk types. */
+
+static int gcChildCb(void *ctx, const ProllyHash *pHash){
+  GcQueue *q = (GcQueue*)ctx;
+  return gcQueuePush(q, pHash);
+}
+
 static int gcMarkReachable(
   ChunkStore *cs,
   ProllyHashSet *marked
@@ -162,76 +145,7 @@ static int gcMarkReachable(
       continue;
     }
 
-    if( isProllyNodeChunk(data, nData) ){
-      
-      ProllyNode node;
-      int parseRc = prollyNodeParse(&node, data, nData);
-      if( parseRc==SQLITE_OK && node.level > 0 ){
-        for(i=0; i<(int)node.nItems; i++){
-          ProllyHash childHash;
-          prollyNodeChildHash(&node, i, &childHash);
-          rc = gcQueuePush(&queue, &childHash);
-          if( rc!=SQLITE_OK ) break;
-        }
-      }
-    }else if( isCommitChunk(data, nData) ){
-
-      DoltliteCommit commit;
-      int drc;
-      memset(&commit, 0, sizeof(commit));
-      drc = doltliteCommitDeserialize(data, nData, &commit);
-      if( drc==SQLITE_OK ){
-        int pi;
-        for(pi=0; pi<commit.nParents; pi++){
-          rc = gcQueuePush(&queue, &commit.aParents[pi]);
-          if( rc!=SQLITE_OK ) break;
-        }
-        if( rc==SQLITE_OK ) rc = gcQueuePush(&queue, &commit.catalogHash);
-        doltliteCommitClear(&commit);
-      }
-    }else{
-      
-      
-      if( nData == WS_TOTAL_SIZE && data[0] == 1 ){
-        ProllyHash stagedCat, conflictsCat;
-        memcpy(stagedCat.data, data + WS_STAGED_OFF, PROLLY_HASH_SIZE);
-        memcpy(conflictsCat.data, data + WS_CONFLICTS_OFF, PROLLY_HASH_SIZE);
-        rc = gcQueuePush(&queue, &stagedCat);
-        if( rc==SQLITE_OK ) rc = gcQueuePush(&queue, &conflictsCat);
-        if( rc==SQLITE_OK && data[WS_MERGING_OFF] ){  
-          ProllyHash mergeCommit;
-          memcpy(mergeCommit.data, data + WS_MERGE_COMMIT_OFF, PROLLY_HASH_SIZE);
-          rc = gcQueuePush(&queue, &mergeCommit);
-        }
-      }
-      
-      if( nData >= CAT_HEADER_SIZE && data[0] == CATALOG_FORMAT_V2 ){
-        int nTables = (int)(data[CAT_NUM_TABLES_OFF]
-                          | (data[CAT_NUM_TABLES_OFF+1]<<8)
-                          | (data[CAT_NUM_TABLES_OFF+2]<<16)
-                          | (data[CAT_NUM_TABLES_OFF+3]<<24));
-        if( nTables >= 0 && nTables < 10000 ){
-          const u8 *p = data + CAT_HEADER_SIZE;
-          for(i=0; i<nTables; i++){
-            if( p + CAT_ENTRY_FIXED_SIZE > data + nData ) break;
-            {
-              ProllyHash tableRoot;
-              memcpy(tableRoot.data, p + CAT_ENTRY_ITABLE_SIZE + CAT_ENTRY_FLAGS_SIZE,
-                     PROLLY_HASH_SIZE);
-              rc = gcQueuePush(&queue, &tableRoot);
-              if( rc!=SQLITE_OK ) break;
-            }
-            {
-              int nameLen;
-              p += CAT_ENTRY_ITABLE_SIZE + CAT_ENTRY_FLAGS_SIZE
-                 + PROLLY_HASH_SIZE + PROLLY_HASH_SIZE;
-              nameLen = p[0] | (p[1]<<8);
-              p += 2 + nameLen;
-            }
-          }
-        }
-      }
-    }
+    rc = doltliteEnumerateChunkChildren(data, nData, gcChildCb, &queue);
 
     sqlite3_free(data);
     if( rc!=SQLITE_OK ) break;

--- a/src/doltlite_history.c
+++ b/src/doltlite_history.c
@@ -13,47 +13,6 @@
 #include <string.h>
 #include <time.h>
 
-#define HT_MAX_COLS 64
-
-typedef struct HtRecInfo HtRecInfo;
-struct HtRecInfo { int nField; int aType[HT_MAX_COLS]; int aOffset[HT_MAX_COLS]; };
-
-static void htParseRecord(const u8 *pData, int nData, HtRecInfo *ri){
-  const u8 *p=pData, *pEnd=pData+nData;
-  u64 hdrSize; int hdrBytes, off;
-  memset(ri,0,sizeof(*ri));
-  if(!pData||nData<1) return;
-  hdrBytes=dlReadVarint(p,pEnd,&hdrSize); p+=hdrBytes;
-  off=(int)hdrSize;
-  while(p<pData+hdrSize && p<pEnd && ri->nField<HT_MAX_COLS){
-    u64 st; int stBytes=dlReadVarint(p,pData+hdrSize,&st); p+=stBytes;
-    ri->aType[ri->nField]=(int)st; ri->aOffset[ri->nField]=off;
-    off += dlSerialTypeLen(st);
-    ri->nField++;
-  }
-}
-
-static void htResultField(sqlite3_context *ctx, const u8 *pData, int nData, int st, int off){
-  if(st==0){sqlite3_result_null(ctx);return;}
-  if(st==8){sqlite3_result_int(ctx,0);return;}
-  if(st==9){sqlite3_result_int(ctx,1);return;}
-  if(st>=1&&st<=6){
-    static const int sz[]={0,1,2,3,4,6,8}; int nB=sz[st];
-    if(off+nB<=nData){const u8*q=pData+off;i64 v=(q[0]&0x80)?-1:0;int i;
-      for(i=0;i<nB;i++)v=(v<<8)|q[i];sqlite3_result_int64(ctx,v);}
-    else sqlite3_result_null(ctx); return;
-  }
-  if(st==7){if(off+8<=nData){const u8*q=pData+off;double v;u64 bits=0;int i;
-    for(i=0;i<8;i++)bits=(bits<<8)|q[i];memcpy(&v,&bits,8);
-    sqlite3_result_double(ctx,v);}else sqlite3_result_null(ctx);return;}
-  if(st>=13&&(st&1)==1){int len=(st-13)/2;
-    if(off+len<=nData)sqlite3_result_text(ctx,(const char*)(pData+off),len,SQLITE_TRANSIENT);
-    else sqlite3_result_null(ctx);return;}
-  if(st>=12&&(st&1)==0){int len=(st-12)/2;
-    if(off+len<=nData)sqlite3_result_blob(ctx,pData+off,len,SQLITE_TRANSIENT);
-    else sqlite3_result_null(ctx);return;}
-  sqlite3_result_null(ctx);
-}
 
 static char *htBuildSchema(DoltliteColInfo *ci){
   int i, sz=256;
@@ -303,8 +262,8 @@ static int htColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
     }else{
       
       if(r->pVal&&r->nVal>0){
-        HtRecInfo ri; htParseRecord(r->pVal,r->nVal,&ri);
-        if(col<ri.nField) htResultField(ctx,r->pVal,r->nVal,ri.aType[col],ri.aOffset[col]);
+        DoltliteRecordInfo ri; doltliteParseRecord(r->pVal,r->nVal,&ri);
+        if(col<ri.nField) doltliteResultField(ctx,r->pVal,r->nVal,ri.aType[col],ri.aOffset[col]);
         else sqlite3_result_null(ctx);
       }else sqlite3_result_null(ctx);
     }

--- a/src/doltlite_history.c
+++ b/src/doltlite_history.c
@@ -294,22 +294,7 @@ static sqlite3_module historyModule = {
 };
 
 void doltliteRegisterHistoryTables(sqlite3 *db){
-  ProllyHash headCommit;
-  DoltliteCommit commit; struct TableEntry *aT=0;int nT=0,i,rc;
-  doltliteGetSessionHead(db,&headCommit);
-  if(prollyHashIsEmpty(&headCommit)) return;
-  memset(&commit,0,sizeof(commit));
-  rc=doltliteLoadCommit(db,&headCommit,&commit);
-  if(rc!=SQLITE_OK) return;
-  rc=doltliteLoadCatalog(db,&commit.catalogHash,&aT,&nT,0);
-  doltliteCommitClear(&commit); if(rc!=SQLITE_OK) return;
-  for(i=0;i<nT;i++){
-    if(aT[i].zName&&aT[i].iTable>1){
-      char *zMod=sqlite3_mprintf("dolt_history_%s",aT[i].zName);
-      if(zMod){sqlite3_create_module(db,zMod,&historyModule,0);sqlite3_free(zMod);}
-    }
-  }
-  sqlite3_free(aT);
+  doltliteForEachUserTable(db, "dolt_history_", &historyModule);
 }
 
 #endif 

--- a/src/doltlite_history.c
+++ b/src/doltlite_history.c
@@ -120,7 +120,6 @@ static int htWalkHistory(HistCursor *pCur, sqlite3 *db, const char *zTableName){
 
   while(qHead<qTail){
     ProllyHash cur=queue[qHead++];
-    u8 *data=0; int nData=0;
     DoltliteCommit commit;
     ProllyHash tableRoot; u8 flags=0;
     char hexBuf[PROLLY_HASH_SIZE*2+1];
@@ -140,10 +139,7 @@ static int htWalkHistory(HistCursor *pCur, sqlite3 *db, const char *zTableName){
     visited[nVisited++]=cur;
 
     memset(&commit,0,sizeof(commit));
-    rc=chunkStoreGet(cs,&cur,&data,&nData);
-    if(rc!=SQLITE_OK) break;
-    rc=doltliteCommitDeserialize(data,nData,&commit);
-    sqlite3_free(data);
+    rc=doltliteLoadCommit(db,&cur,&commit);
     if(rc!=SQLITE_OK) break;
 
     doltliteHashToHex(&cur,hexBuf);
@@ -298,15 +294,12 @@ static sqlite3_module historyModule = {
 };
 
 void doltliteRegisterHistoryTables(sqlite3 *db){
-  ProllyHash headCommit; u8 *data=0;int nData=0;
+  ProllyHash headCommit;
   DoltliteCommit commit; struct TableEntry *aT=0;int nT=0,i,rc;
-  ChunkStore *cs=doltliteGetChunkStore(db);
-  if(!cs) return;
   doltliteGetSessionHead(db,&headCommit);
   if(prollyHashIsEmpty(&headCommit)) return;
-  rc=chunkStoreGet(cs,&headCommit,&data,&nData); if(rc!=SQLITE_OK) return;
   memset(&commit,0,sizeof(commit));
-  rc=doltliteCommitDeserialize(data,nData,&commit); sqlite3_free(data);
+  rc=doltliteLoadCommit(db,&headCommit,&commit);
   if(rc!=SQLITE_OK) return;
   rc=doltliteLoadCatalog(db,&commit.catalogHash,&aT,&nT,0);
   doltliteCommitClear(&commit); if(rc!=SQLITE_OK) return;

--- a/src/doltlite_history.c
+++ b/src/doltlite_history.c
@@ -105,17 +105,6 @@ static void freeHistoryRows(HistCursor *c){
   c->aRows=0; c->nRows=0; c->nAlloc=0;
 }
 
-static int htFindRoot(struct TableEntry *a, int n, const char *zName,
-                      ProllyHash *pRoot, u8 *pFlags){
-  struct TableEntry *e = doltliteFindTableByName(a, n, zName);
-  if( e ){
-    memcpy(pRoot, &e->root, sizeof(ProllyHash));
-    if( pFlags ) *pFlags = e->flags;
-    return SQLITE_OK;
-  }
-  memset(pRoot,0,sizeof(ProllyHash)); if(pFlags)*pFlags=0;
-  return SQLITE_NOTFOUND;
-}
 
 static int htScanAtCommit(
   HistCursor *pCur, ChunkStore *cs, ProllyCache *pCache,
@@ -203,7 +192,7 @@ static int htWalkHistory(HistCursor *pCur, sqlite3 *db, const char *zTableName){
       struct TableEntry *aT=0; int nT=0;
       rc=doltliteLoadCatalog(db,&commit.catalogHash,&aT,&nT,0);
       if(rc==SQLITE_OK){
-        if(htFindRoot(aT,nT,zTableName,&tableRoot,&flags)==SQLITE_OK)
+        if(doltliteFindTableRootByName(aT,nT,zTableName,&tableRoot,&flags)==SQLITE_OK)
           htScanAtCommit(pCur,cs,pCache,&tableRoot,flags,hexBuf,commit.zName,commit.timestamp);
         sqlite3_free(aT);
       }

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -99,6 +99,11 @@ typedef struct DoltliteCommit DoltliteCommit;
 int doltliteLoadCommit(sqlite3 *db, const ProllyHash *pHash,
                        DoltliteCommit *pCommit);
 
+/* Register a per-table virtual table module for each user table in HEAD.
+** Creates modules named "<zPrefix><tablename>" (doltlite_ref.c) */
+int doltliteForEachUserTable(sqlite3 *db, const char *zPrefix,
+                             const sqlite3_module *pModule);
+
 int doltliteResolveTableName(sqlite3 *db, const char *zTable, Pgno *piTable);
 char *doltliteResolveTableNumber(sqlite3 *db, Pgno iTable);
 int doltliteSwitchCatalog(sqlite3 *db, const ProllyHash *catHash);

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -49,6 +49,40 @@ static SQLITE_INLINE int tableEntryNameCmp(const void *a, const void *b){
   return strcmp(ea->zName, eb->zName);
 }
 
+/*
+** Find a table's root hash and flags from a catalog entry array.
+** Returns SQLITE_OK if found, SQLITE_NOTFOUND otherwise (with pRoot zeroed).
+*/
+static SQLITE_INLINE int doltliteFindTableRoot(
+  struct TableEntry *a, int n, Pgno iTable,
+  ProllyHash *pRoot, u8 *pFlags
+){
+  struct TableEntry *e = doltliteFindTableByNumber(a, n, iTable);
+  if( e ){
+    memcpy(pRoot, &e->root, sizeof(ProllyHash));
+    if( pFlags ) *pFlags = e->flags;
+    return SQLITE_OK;
+  }
+  memset(pRoot, 0, sizeof(ProllyHash));
+  if( pFlags ) *pFlags = 0;
+  return SQLITE_NOTFOUND;
+}
+
+static SQLITE_INLINE int doltliteFindTableRootByName(
+  struct TableEntry *a, int n, const char *zName,
+  ProllyHash *pRoot, u8 *pFlags
+){
+  struct TableEntry *e = doltliteFindTableByName(a, n, zName);
+  if( e ){
+    memcpy(pRoot, &e->root, sizeof(ProllyHash));
+    if( pFlags ) *pFlags = e->flags;
+    return SQLITE_OK;
+  }
+  memset(pRoot, 0, sizeof(ProllyHash));
+  if( pFlags ) *pFlags = 0;
+  return SQLITE_NOTFOUND;
+}
+
 ChunkStore *doltliteGetChunkStore(sqlite3 *db);
 BtShared *doltliteGetBtShared(sqlite3 *db);
 ProllyCache *doltliteGetCache(sqlite3 *db);
@@ -57,6 +91,14 @@ int doltliteLoadCatalog(sqlite3 *db, const ProllyHash *catHash,
                         Pgno *piNextTable);
 int doltliteGetHeadCatalogHash(sqlite3 *db, ProllyHash *pCatHash);
 int doltliteFlushAndSerializeCatalog(sqlite3 *db, u8 **ppOut, int *pnOut);
+/* Ref resolution: try hex hash, then branch, then tag (doltlite_ref.c) */
+int doltliteResolveRef(sqlite3 *db, const char *zRef, ProllyHash *pCommit);
+
+/* Load a commit by hash. Caller must doltliteCommitClear() (doltlite_ref.c) */
+typedef struct DoltliteCommit DoltliteCommit;
+int doltliteLoadCommit(sqlite3 *db, const ProllyHash *pHash,
+                       DoltliteCommit *pCommit);
+
 int doltliteResolveTableName(sqlite3 *db, const char *zTable, Pgno *piTable);
 char *doltliteResolveTableNumber(sqlite3 *db, Pgno iTable);
 int doltliteSwitchCatalog(sqlite3 *db, const ProllyHash *catHash);

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -170,8 +170,6 @@ struct MigrateDiffCtx {
 };
 
 char *extractColNameFromDef(const char *zDef);
-int bindRecordField(sqlite3_stmt *pStmt, int iParam, const u8 *pData,
-                    int nData, int serialType, int offset);
 int migrateDiffCb(void *pArg, const struct ProllyDiffChange *pChange);
 int migrateSchemaRowData(sqlite3 *db, const ProllyHash *pAncCatHash,
                          const ProllyHash *pTheirCatHash,

--- a/src/doltlite_log.c
+++ b/src/doltlite_log.c
@@ -66,8 +66,6 @@ static int logCollectAll(sqlite3 *db, const ProllyHash *pHead,
 
   while( qHead < qTail ){
     ProllyHash cur = queue[qHead++];
-    u8 *data = 0;
-    int nData = 0;
     DoltliteCommit commit;
     LogEntry *pEntry;
     int dup = 0;
@@ -88,11 +86,8 @@ static int logCollectAll(sqlite3 *db, const ProllyHash *pHead,
     visited[nVisited++] = cur;
 
     /* Load commit */
-    rc = chunkStoreGet(cs, &cur, &data, &nData);
-    if( rc!=SQLITE_OK ) break;
     memset(&commit, 0, sizeof(commit));
-    rc = doltliteCommitDeserialize(data, nData, &commit);
-    sqlite3_free(data);
+    rc = doltliteLoadCommit(db, &cur, &commit);
     if( rc!=SQLITE_OK ) break;
 
     /* Add to results */

--- a/src/doltlite_record.c
+++ b/src/doltlite_record.c
@@ -208,4 +208,125 @@ int doltliteGetColumnNames(sqlite3 *db, const char *zTable, DoltliteColInfo *ci)
   return SQLITE_OK;
 }
 
-#endif 
+void doltliteParseRecord(const u8 *pData, int nData, DoltliteRecordInfo *pInfo){
+  const u8 *p = pData;
+  const u8 *pEnd = pData + nData;
+  u64 hdrSize;
+  int hdrBytes, off;
+  const u8 *pHdrEnd;
+
+  memset(pInfo, 0, sizeof(*pInfo));
+  if( !pData || nData < 1 ) return;
+
+  hdrBytes = dlReadVarint(p, pEnd, &hdrSize);
+  p += hdrBytes;
+  pHdrEnd = pData + (int)hdrSize;
+  off = (int)hdrSize;
+
+  while( p < pHdrEnd && p < pEnd && pInfo->nField < DOLTLITE_MAX_RECORD_FIELDS ){
+    u64 st;
+    int stBytes = dlReadVarint(p, pHdrEnd, &st);
+    p += stBytes;
+    pInfo->aType[pInfo->nField] = (int)st;
+    pInfo->aOffset[pInfo->nField] = off;
+    off += dlSerialTypeLen(st);
+    pInfo->nField++;
+  }
+}
+
+void doltliteResultField(
+  sqlite3_context *ctx, const u8 *pData, int nData,
+  int st, int off
+){
+  if( st==0 ){ sqlite3_result_null(ctx); return; }
+  if( st==8 ){ sqlite3_result_int(ctx, 0); return; }
+  if( st==9 ){ sqlite3_result_int(ctx, 1); return; }
+  if( st>=1 && st<=6 ){
+    static const int sizes[] = {0,1,2,3,4,6,8};
+    int nB = sizes[st];
+    if( off+nB <= nData ){
+      const u8 *q = pData + off;
+      i64 v = (q[0] & 0x80) ? -1 : 0;
+      int i;
+      for(i=0; i<nB; i++) v = (v<<8) | q[i];
+      sqlite3_result_int64(ctx, v);
+    }else{
+      sqlite3_result_null(ctx);
+    }
+    return;
+  }
+  if( st==7 ){
+    if( off+8 <= nData ){
+      const u8 *q = pData + off;
+      double v; u64 bits = 0; int i;
+      for(i=0; i<8; i++) bits = (bits<<8) | q[i];
+      memcpy(&v, &bits, 8);
+      sqlite3_result_double(ctx, v);
+    }else{
+      sqlite3_result_null(ctx);
+    }
+    return;
+  }
+  if( st>=13 && (st&1)==1 ){
+    int len = (st-13)/2;
+    if( off+len <= nData )
+      sqlite3_result_text(ctx, (const char*)(pData+off), len, SQLITE_TRANSIENT);
+    else sqlite3_result_null(ctx);
+    return;
+  }
+  if( st>=12 && (st&1)==0 ){
+    int len = (st-12)/2;
+    if( off+len <= nData )
+      sqlite3_result_blob(ctx, pData+off, len, SQLITE_TRANSIENT);
+    else sqlite3_result_null(ctx);
+    return;
+  }
+  sqlite3_result_null(ctx);
+}
+
+int doltliteBindField(
+  sqlite3_stmt *pStmt, int iParam,
+  const u8 *pData, int nData,
+  int st, int off
+){
+  if( st==0 ) return sqlite3_bind_null(pStmt, iParam);
+  if( st==8 ) return sqlite3_bind_int(pStmt, iParam, 0);
+  if( st==9 ) return sqlite3_bind_int(pStmt, iParam, 1);
+  if( st>=1 && st<=6 ){
+    static const int sizes[] = {0,1,2,3,4,6,8};
+    int nB = sizes[st];
+    if( off+nB <= nData ){
+      const u8 *q = pData + off;
+      i64 v = (q[0] & 0x80) ? -1 : 0;
+      int i;
+      for(i=0; i<nB; i++) v = (v<<8) | q[i];
+      return sqlite3_bind_int64(pStmt, iParam, v);
+    }
+    return sqlite3_bind_null(pStmt, iParam);
+  }
+  if( st==7 ){
+    if( off+8 <= nData ){
+      const u8 *q = pData + off;
+      double v; u64 bits = 0; int i;
+      for(i=0; i<8; i++) bits = (bits<<8) | q[i];
+      memcpy(&v, &bits, 8);
+      return sqlite3_bind_double(pStmt, iParam, v);
+    }
+    return sqlite3_bind_null(pStmt, iParam);
+  }
+  if( st>=13 && (st&1)==1 ){
+    int len = (st-13)/2;
+    if( off+len <= nData )
+      return sqlite3_bind_text(pStmt, iParam, (const char*)(pData+off), len, SQLITE_TRANSIENT);
+    return sqlite3_bind_null(pStmt, iParam);
+  }
+  if( st>=12 && (st&1)==0 ){
+    int len = (st-12)/2;
+    if( off+len <= nData )
+      return sqlite3_bind_blob(pStmt, iParam, pData+off, len, SQLITE_TRANSIENT);
+    return sqlite3_bind_null(pStmt, iParam);
+  }
+  return sqlite3_bind_null(pStmt, iParam);
+}
+
+#endif

--- a/src/doltlite_record.h
+++ b/src/doltlite_record.h
@@ -42,4 +42,26 @@ static inline int dlSerialTypeLen(u64 st){
   return 0;
 }
 
-#endif 
+/*
+** Parsed record header: field count, serial types, and data offsets.
+** Shared across diff_table, history, at, schema_diff, and merge.
+*/
+#define DOLTLITE_MAX_RECORD_FIELDS 64
+
+typedef struct DoltliteRecordInfo DoltliteRecordInfo;
+struct DoltliteRecordInfo {
+  int nField;
+  int aType[DOLTLITE_MAX_RECORD_FIELDS];
+  int aOffset[DOLTLITE_MAX_RECORD_FIELDS];
+};
+
+void doltliteParseRecord(const u8 *pData, int nData, DoltliteRecordInfo *pInfo);
+
+void doltliteResultField(sqlite3_context *ctx, const u8 *pData, int nData,
+                         int serialType, int offset);
+
+int doltliteBindField(sqlite3_stmt *pStmt, int iParam,
+                      const u8 *pData, int nData,
+                      int serialType, int offset);
+
+#endif

--- a/src/doltlite_ref.c
+++ b/src/doltlite_ref.c
@@ -1,0 +1,51 @@
+/*
+** Shared ref resolution and commit loading.
+**
+** doltliteResolveRef: resolve a string (hex hash, branch, tag) to a commit.
+** doltliteLoadCommit: load a commit object by hash from the chunk store.
+*/
+#ifdef DOLTLITE_PROLLY
+
+#include "sqliteInt.h"
+#include "prolly_hash.h"
+#include "chunk_store.h"
+#include "doltlite_commit.h"
+#include "doltlite_internal.h"
+
+int doltliteResolveRef(sqlite3 *db, const char *zRef, ProllyHash *pCommit){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  int rc;
+  if( !zRef || !cs ) return SQLITE_ERROR;
+
+  /* Try 40-char hex hash */
+  if( strlen(zRef)==PROLLY_HASH_SIZE*2 ){
+    rc = doltliteHexToHash(zRef, pCommit);
+    if( rc==SQLITE_OK && chunkStoreHas(cs, pCommit) ) return SQLITE_OK;
+  }
+
+  /* Try branch name */
+  rc = chunkStoreFindBranch(cs, zRef, pCommit);
+  if( rc==SQLITE_OK && !prollyHashIsEmpty(pCommit) ) return SQLITE_OK;
+
+  /* Try tag name */
+  rc = chunkStoreFindTag(cs, zRef, pCommit);
+  if( rc==SQLITE_OK && !prollyHashIsEmpty(pCommit) ) return SQLITE_OK;
+
+  return SQLITE_NOTFOUND;
+}
+
+int doltliteLoadCommit(sqlite3 *db, const ProllyHash *pHash,
+                       DoltliteCommit *pCommit){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  u8 *data = 0;
+  int nData = 0;
+  int rc;
+  if( !cs ) return SQLITE_ERROR;
+  rc = chunkStoreGet(cs, pHash, &data, &nData);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = doltliteCommitDeserialize(data, nData, pCommit);
+  sqlite3_free(data);
+  return rc;
+}
+
+#endif

--- a/src/doltlite_ref.c
+++ b/src/doltlite_ref.c
@@ -48,4 +48,38 @@ int doltliteLoadCommit(sqlite3 *db, const ProllyHash *pHash,
   return rc;
 }
 
+int doltliteForEachUserTable(
+  sqlite3 *db,
+  const char *zPrefix,
+  const sqlite3_module *pModule
+){
+  ProllyHash headCommit;
+  DoltliteCommit commit;
+  struct TableEntry *aTables = 0;
+  int nTables = 0, i, rc;
+
+  doltliteGetSessionHead(db, &headCommit);
+  if( prollyHashIsEmpty(&headCommit) ) return SQLITE_OK;
+
+  memset(&commit, 0, sizeof(commit));
+  rc = doltliteLoadCommit(db, &headCommit, &commit);
+  if( rc!=SQLITE_OK ) return rc;
+
+  rc = doltliteLoadCatalog(db, &commit.catalogHash, &aTables, &nTables, 0);
+  doltliteCommitClear(&commit);
+  if( rc!=SQLITE_OK ) return rc;
+
+  for(i=0; i<nTables; i++){
+    if( aTables[i].zName && aTables[i].iTable > 1 ){
+      char *zMod = sqlite3_mprintf("%s%s", zPrefix, aTables[i].zName);
+      if( zMod ){
+        sqlite3_create_module(db, zMod, pModule, 0);
+        sqlite3_free(zMod);
+      }
+    }
+  }
+  sqlite3_free(aTables);
+  return SQLITE_OK;
+}
+
 #endif

--- a/src/doltlite_remote.c
+++ b/src/doltlite_remote.c
@@ -5,6 +5,7 @@
 #include "doltlite_commit.h"
 #include "prolly_hashset.h"
 #include "prolly_node.h"
+#include "doltlite_chunk_walk.h"
 #include <string.h>
 
 typedef struct SyncQueue SyncQueue;
@@ -54,25 +55,20 @@ static int syncQueuePending(SyncQueue *q){
   return q->nItems - q->iHead;
 }
 
-#define SYNC_PROLLY_NODE_MAGIC 0x504E4F44
+typedef struct SyncEnqCtx SyncEnqCtx;
+struct SyncEnqCtx {
+  SyncQueue *q;
+  ProllyHashSet *seen;
+};
 
-static int syncIsProllyNodeChunk(const u8 *data, int nData){
-  u32 m;
-  if( nData < 8 ) return 0;
-  m = (u32)data[0] | ((u32)data[1]<<8) |
-      ((u32)data[2]<<16) | ((u32)data[3]<<24);
-  return m == SYNC_PROLLY_NODE_MAGIC;
-}
-
-static int syncIsCommitChunk(const u8 *data, int nData){
-  if( nData < 30 ) return 0;
-  if( data[0] != DOLTLITE_COMMIT_V2 ) return 0;
-  if( nData >= 4 ){
-    u32 m = (u32)data[0] | ((u32)data[1]<<8) |
-            ((u32)data[2]<<16) | ((u32)data[3]<<24);
-    if( m == SYNC_PROLLY_NODE_MAGIC ) return 0;
-  }
-  return 1;
+static int syncChildCb(void *pCtx, const ProllyHash *pHash){
+  SyncEnqCtx *ctx = (SyncEnqCtx*)pCtx;
+  int rc;
+  if( prollyHashIsEmpty(pHash) ) return SQLITE_OK;
+  if( prollyHashSetContains(ctx->seen, pHash) ) return SQLITE_OK;
+  rc = prollyHashSetAdd(ctx->seen, pHash);
+  if( rc==SQLITE_OK ) rc = syncQueuePush(ctx->q, pHash);
+  return rc;
 }
 
 static int syncEnqueueChildren(
@@ -81,97 +77,10 @@ static int syncEnqueueChildren(
   SyncQueue *q,
   ProllyHashSet *seen
 ){
-  int rc = SQLITE_OK;
-  int i;
-
-  if( syncIsProllyNodeChunk(data, nData) ){
-    
-    ProllyNode node;
-    int parseRc = prollyNodeParse(&node, data, nData);
-    if( parseRc==SQLITE_OK && node.level > 0 ){
-      for(i=0; i<(int)node.nItems; i++){
-        ProllyHash childHash;
-        prollyNodeChildHash(&node, i, &childHash);
-        if( !prollyHashIsEmpty(&childHash) && !prollyHashSetContains(seen, &childHash) ){
-          rc = prollyHashSetAdd(seen, &childHash);
-          if( rc==SQLITE_OK ) rc = syncQueuePush(q, &childHash);
-        }
-        if( rc!=SQLITE_OK ) break;
-      }
-    }
-  }else if( syncIsCommitChunk(data, nData) ){
-
-    DoltliteCommit commit;
-    int drc;
-    memset(&commit, 0, sizeof(commit));
-    drc = doltliteCommitDeserialize(data, nData, &commit);
-    if( drc==SQLITE_OK ){
-      int pi;
-      for(pi=0; pi<commit.nParents && rc==SQLITE_OK; pi++){
-        if( !prollyHashIsEmpty(&commit.aParents[pi])
-            && !prollyHashSetContains(seen, &commit.aParents[pi]) ){
-          rc = prollyHashSetAdd(seen, &commit.aParents[pi]);
-          if( rc==SQLITE_OK ) rc = syncQueuePush(q, &commit.aParents[pi]);
-        }
-      }
-      if( rc==SQLITE_OK && !prollyHashIsEmpty(&commit.catalogHash)
-          && !prollyHashSetContains(seen, &commit.catalogHash) ){
-        rc = prollyHashSetAdd(seen, &commit.catalogHash);
-        if( rc==SQLITE_OK ) rc = syncQueuePush(q, &commit.catalogHash);
-      }
-      doltliteCommitClear(&commit);
-    }
-  }else{
-    
-    if( nData == WS_TOTAL_SIZE && data[0] == 1 ){
-      ProllyHash h;
-      memcpy(h.data, data + WS_STAGED_OFF, PROLLY_HASH_SIZE);
-      if( !prollyHashIsEmpty(&h) && !prollyHashSetContains(seen, &h) ){
-        rc = prollyHashSetAdd(seen, &h);
-        if( rc==SQLITE_OK ) rc = syncQueuePush(q, &h);
-      }
-      memcpy(h.data, data + WS_CONFLICTS_OFF, PROLLY_HASH_SIZE);
-      if( rc==SQLITE_OK && !prollyHashIsEmpty(&h) && !prollyHashSetContains(seen, &h) ){
-        rc = prollyHashSetAdd(seen, &h);
-        if( rc==SQLITE_OK ) rc = syncQueuePush(q, &h);
-      }
-      if( rc==SQLITE_OK && data[WS_MERGING_OFF] ){
-        memcpy(h.data, data + WS_MERGE_COMMIT_OFF, PROLLY_HASH_SIZE);
-        if( !prollyHashIsEmpty(&h) && !prollyHashSetContains(seen, &h) ){
-          rc = prollyHashSetAdd(seen, &h);
-          if( rc==SQLITE_OK ) rc = syncQueuePush(q, &h);
-        }
-      }
-    }
-
-    
-    if( nData >= 9 && data[0] == 0x43 ){
-      int nTables = (int)(data[5] | (data[6]<<8) |
-                          (data[7]<<16) | (data[8]<<24));
-      if( nTables >= 0 && nTables < 10000 ){
-        const u8 *p = data + 9;
-        for(i=0; i<nTables && rc==SQLITE_OK; i++){
-          if( p + 4 + 1 + PROLLY_HASH_SIZE + PROLLY_HASH_SIZE + 2 > data + nData ) break;
-          {
-            ProllyHash tableRoot;
-            memcpy(tableRoot.data, p + 5, PROLLY_HASH_SIZE);
-            if( !prollyHashIsEmpty(&tableRoot) && !prollyHashSetContains(seen, &tableRoot) ){
-              rc = prollyHashSetAdd(seen, &tableRoot);
-              if( rc==SQLITE_OK ) rc = syncQueuePush(q, &tableRoot);
-            }
-          }
-          {
-            int nameLen;
-            p += 4 + 1 + PROLLY_HASH_SIZE + PROLLY_HASH_SIZE;
-            nameLen = p[0] | (p[1]<<8);
-            p += 2 + nameLen;
-          }
-        }
-      }
-    }
-  }
-
-  return rc;
+  SyncEnqCtx ctx;
+  ctx.q = q;
+  ctx.seen = seen;
+  return doltliteEnumerateChunkChildren(data, nData, syncChildCb, &ctx);
 }
 
 #define SYNC_BATCH_SIZE 256
@@ -482,7 +391,7 @@ static int syncIsAncestor(
     rc = chunkStoreGet(cs, &current, &data, &nData);
     if( rc!=SQLITE_OK ) break;
 
-    if( syncIsCommitChunk(data, nData) ){
+    if( doltliteClassifyChunk(data, nData) == CHUNK_COMMIT ){
       DoltliteCommit commit;
       memset(&commit, 0, sizeof(commit));
       if( doltliteCommitDeserialize(data, nData, &commit)==SQLITE_OK ){

--- a/src/doltlite_schema_diff.c
+++ b/src/doltlite_schema_diff.c
@@ -50,52 +50,6 @@ static void freeSchemaDiffRows(SdCursor *c){
 }
 
 
-static int parseRecordHeader(
-  const u8 *pData, int nData,
-  int *aType, int *aOffset, int maxFields
-){
-  int iField = 0;
-  const u8 *p = pData;
-  const u8 *pDataEnd = pData + nData;
-  const u8 *pEnd;
-  int off;
-  u64 hdrSize;
-  int hdrBytes;
-
-  if( nData < 1 ) return 0;
-
-  
-  hdrBytes = dlReadVarint(p, pDataEnd, &hdrSize);
-  p += hdrBytes;
-
-  pEnd = pData + (int)hdrSize;
-  off = (int)hdrSize;
-
-  while( p < pEnd && p < pDataEnd && iField < maxFields ){
-    u64 st;
-    int stBytes = dlReadVarint(p, pEnd, &st);
-    p += stBytes;
-
-    aType[iField] = (int)st;
-    aOffset[iField] = off;
-
-    
-    if( st==0 ) {  }
-    else if( st==1 ) off += 1;
-    else if( st==2 ) off += 2;
-    else if( st==3 ) off += 3;
-    else if( st==4 ) off += 4;
-    else if( st==5 ) off += 6;
-    else if( st==6 ) off += 8;
-    else if( st==7 ) off += 8;
-    else if( st==8 || st==9 ) {  }
-    else if( st>=12 && (st&1)==0 ) off += ((int)st-12)/2;  
-    else if( st>=13 && (st&1)==1 ) off += ((int)st-13)/2;  
-    iField++;
-  }
-
-  return iField;
-}
 
 int loadSchemaFromCatalog(
   sqlite3 *db,
@@ -139,16 +93,16 @@ int loadSchemaFromCatalog(
 
   while( prollyCursorIsValid(&cur) ){
     const u8 *pVal; int nVal;
-    int aType[5], aOffset[5];
-    int nFields = 0;
+    DoltliteRecordInfo ri;
 
     prollyCursorValue(&cur, &pVal, &nVal);
 
     if( pVal && nVal > 0 ){
-      nFields = parseRecordHeader(pVal, nVal, aType, aOffset, 5);
+      doltliteParseRecord(pVal, nVal, &ri);
 
-      
-      if( nFields >= 5 ){
+      if( ri.nField >= 5 ){
+        int *aType = ri.aType;
+        int *aOffset = ri.aOffset;
         char *zType = 0, *zName = 0, *zSql = 0;
 
         

--- a/src/doltlite_schema_diff.c
+++ b/src/doltlite_schema_diff.c
@@ -49,18 +49,6 @@ static void freeSchemaDiffRows(SdCursor *c){
   c->nAlloc = 0;
 }
 
-static int sdResolveRef(ChunkStore *cs, const char *zRef, ProllyHash *pCommit){
-  int rc;
-  if( zRef && strlen(zRef)==40 ){
-    rc = doltliteHexToHash(zRef, pCommit);
-    if( rc==SQLITE_OK && chunkStoreHas(cs, pCommit) ) return SQLITE_OK;
-  }
-  rc = chunkStoreFindBranch(cs, zRef, pCommit);
-  if( rc==SQLITE_OK && !prollyHashIsEmpty(pCommit) ) return SQLITE_OK;
-  rc = chunkStoreFindTag(cs, zRef, pCommit);
-  if( rc==SQLITE_OK && !prollyHashIsEmpty(pCommit) ) return SQLITE_OK;
-  return SQLITE_NOTFOUND;
-}
 
 static int parseRecordHeader(
   const u8 *pData, int nData,
@@ -408,7 +396,7 @@ static int sdFilter(sqlite3_vtab_cursor *cur,
     const char *zTableFilter = 0;
     if( zFromRef && !zToRef ){
       ProllyHash testHash;
-      int resolved = sdResolveRef(cs, zFromRef, &testHash);
+      int resolved = doltliteResolveRef(db,zFromRef, &testHash);
       if( resolved!=SQLITE_OK ){
         
         zTableFilter = zFromRef;
@@ -418,14 +406,10 @@ static int sdFilter(sqlite3_vtab_cursor *cur,
 
     
     if( zFromRef ){
-    rc = sdResolveRef(cs, zFromRef, &fromCommit);
+    rc = doltliteResolveRef(db,zFromRef, &fromCommit);
     if( rc!=SQLITE_OK ) return SQLITE_OK;
-    if( prollyHashIsEmpty(&fromCommit) ) return SQLITE_OK;
     memset(&commit, 0, sizeof(commit));
-    rc = chunkStoreGet(cs, &fromCommit, &data, &nData);
-    if( rc!=SQLITE_OK ) return SQLITE_OK;
-    rc = doltliteCommitDeserialize(data, nData, &commit);
-    sqlite3_free(data); data = 0;
+    rc = doltliteLoadCommit(db, &fromCommit, &commit);
     if( rc!=SQLITE_OK ) return SQLITE_OK;
     memcpy(&fromCatHash, &commit.catalogHash, sizeof(ProllyHash));
     doltliteCommitClear(&commit);
@@ -437,14 +421,10 @@ static int sdFilter(sqlite3_vtab_cursor *cur,
 
   
   if( zToRef ){
-    rc = sdResolveRef(cs, zToRef, &toCommit);
+    rc = doltliteResolveRef(db,zToRef, &toCommit);
     if( rc!=SQLITE_OK ) return SQLITE_OK;
-    if( prollyHashIsEmpty(&toCommit) ) return SQLITE_OK;
     memset(&commit, 0, sizeof(commit));
-    rc = chunkStoreGet(cs, &toCommit, &data, &nData);
-    if( rc!=SQLITE_OK ) return SQLITE_OK;
-    rc = doltliteCommitDeserialize(data, nData, &commit);
-    sqlite3_free(data); data = 0;
+    rc = doltliteLoadCommit(db, &toCommit, &commit);
     if( rc!=SQLITE_OK ) return SQLITE_OK;
     memcpy(&toCatHash, &commit.catalogHash, sizeof(ProllyHash));
     doltliteCommitClear(&commit);

--- a/src/doltlite_schema_merge.c
+++ b/src/doltlite_schema_merge.c
@@ -3,7 +3,7 @@
 **
 ** Functions that handle data migration after a schema merge:
 **   extractColNameFromDef()  - parse column name from ADD COLUMN def
-**   bindRecordField()        - bind a field from a SQLite record blob
+**   doltliteBindField()        - bind a field from a SQLite record blob
 **   migrateDiffCb()          - diff callback for schema data migration
 **   migrateSchemaRowData()   - top-level migration driver
 */
@@ -62,64 +62,7 @@ char *extractColNameFromDef(const char *zDef){
 ** parameter. The field is identified by its serial type and offset within
 ** the record data.
 */
-int bindRecordField(
-  sqlite3_stmt *pStmt,
-  int iParam,             /* 1-based bind parameter index */
-  const u8 *pData,
-  int nData,
-  int serialType,
-  int offset
-){
-  if( serialType==0 ){
-    return sqlite3_bind_null(pStmt, iParam);
-  }
-  if( serialType==8 ){
-    return sqlite3_bind_int(pStmt, iParam, 0);
-  }
-  if( serialType==9 ){
-    return sqlite3_bind_int(pStmt, iParam, 1);
-  }
-  if( serialType>=1 && serialType<=6 ){
-    static const int sz[] = {0,1,2,3,4,6,8};
-    int nB = sz[serialType];
-    if( offset+nB <= nData ){
-      const u8 *q = pData + offset;
-      i64 v = (q[0] & 0x80) ? -1 : 0;
-      int i;
-      for(i=0; i<nB; i++) v = (v<<8) | q[i];
-      return sqlite3_bind_int64(pStmt, iParam, v);
-    }
-    return sqlite3_bind_null(pStmt, iParam);
-  }
-  if( serialType==7 ){
-    if( offset+8 <= nData ){
-      const u8 *q = pData + offset;
-      double v;
-      u64 bits = 0;
-      int i;
-      for(i=0; i<8; i++) bits = (bits<<8) | q[i];
-      memcpy(&v, &bits, 8);
-      return sqlite3_bind_double(pStmt, iParam, v);
-    }
-    return sqlite3_bind_null(pStmt, iParam);
-  }
-  if( serialType>=13 && (serialType&1)==1 ){
-    int len = (serialType-13)/2;
-    if( offset+len <= nData ){
-      return sqlite3_bind_text(pStmt, iParam,
-                               (const char*)(pData+offset), len, SQLITE_TRANSIENT);
-    }
-    return sqlite3_bind_null(pStmt, iParam);
-  }
-  if( serialType>=12 && (serialType&1)==0 ){
-    int len = (serialType-12)/2;
-    if( offset+len <= nData ){
-      return sqlite3_bind_blob(pStmt, iParam, pData+offset, len, SQLITE_TRANSIENT);
-    }
-    return sqlite3_bind_null(pStmt, iParam);
-  }
-  return sqlite3_bind_null(pStmt, iParam);
-}
+/* bindRecordField removed — use doltliteBindField() from doltlite_record.c */
 
 /*
 ** Diff callback for schema data migration. Called for each row that
@@ -167,7 +110,7 @@ int migrateDiffCb(void *pArg, const ProllyDiffChange *pChange){
   for(sj=0; sj<ctx->nCols; sj++){
     if( ctx->aiColIdx[sj]<0 || !ctx->azColNames[sj] ) continue;
     if( ctx->aiColIdx[sj] < nFields ){
-      bindRecordField(ctx->pUpd, bindIdx, pVal, nVal,
+      doltliteBindField(ctx->pUpd, bindIdx, pVal, nVal,
                       aType[ctx->aiColIdx[sj]],
                       aOffset[ctx->aiColIdx[sj]]);
     }else{

--- a/src/doltlite_tag.c
+++ b/src/doltlite_tag.c
@@ -111,16 +111,10 @@ static int tagColumn(sqlite3_vtab_cursor *c, sqlite3_context *ctx, int col){
       break;
     }
     case 2: {
-      
-      u8 *data=0; int nData=0;
-      int rc = chunkStoreGet(cs, &t->commitHash, &data, &nData);
-      if( rc==SQLITE_OK && data ){
-        DoltliteCommit commit;
-        if( doltliteCommitDeserialize(data, nData, &commit)==SQLITE_OK ){
-          sqlite3_result_text(ctx, commit.zMessage?commit.zMessage:"", -1, SQLITE_TRANSIENT);
-          doltliteCommitClear(&commit);
-        }
-        sqlite3_free(data);
+      DoltliteCommit commit;
+      if( doltliteLoadCommit(v->db, &t->commitHash, &commit)==SQLITE_OK ){
+        sqlite3_result_text(ctx, commit.zMessage?commit.zMessage:"", -1, SQLITE_TRANSIENT);
+        doltliteCommitClear(&commit);
       }
       break;
     }


### PR DESCRIPTION
## Summary

Extracts duplicated patterns from 17 feature files into shared modules. Net -273 lines.

### New shared infrastructure

- **`doltlite_ref.c`**: `doltliteResolveRef()` (replaces 5 static copies), `doltliteLoadCommit()` (replaces 22 inline get+deserialize+free sequences), `doltliteForEachUserTable()` (replaces 3 identical 15-line registration functions)

- **`doltlite_record.c`**: `doltliteParseRecord()` (replaces 5 static record parsers), `doltliteResultField()` (replaces 3 static result emitters), `doltliteBindField()` (replaces `bindRecordField`)

- **`doltlite_chunk_walk.h/c`**: `doltliteClassifyChunk()` + `doltliteEnumerateChunkChildren()` (replaces duplicated chunk-type detection and graph walking in GC and remote sync)

- **`doltlite_internal.h`**: `doltliteFindTableRoot()` / `doltliteFindTableRootByName()` inlines (replaces 4 static copies)

### Why

Every new feature (diff, merge, gc, remote, history, at) was written as a standalone file that re-implemented the same format parsing, ref resolution, commit traversal, and record decoding. A format change (like V2→V3 catalog) required touching 6+ files. Now it requires touching 1-2.

### Files changed

| Shrunk | Lines removed |
|--------|-------------|
| doltlite_diff_table.c | -192 |
| doltlite_remote.c | -129 |
| doltlite_gc.c | -102 |
| doltlite_at.c | -101 |
| doltlite_schema_diff.c | -86 |
| doltlite_history.c | -84 |
| doltlite.c | -80 |
| doltlite_schema_merge.c | -63 |
| doltlite_diff.c | -47 |
| doltlite_ancestor.c | -36 |
| + 7 more | |

## Test plan

- [x] All test suites pass after each commit (tested incrementally)
- [x] gc, gc_scale, remote, correctness, e2e, merge, diff, diff_table, history, at, schema_diff, schema_merge, branch, tag, cherry_pick, advanced, edge_cases all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)