### PR TITLE
Serialize ref mutations and refresh stale checkout state

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -115,6 +115,25 @@ static int doltlitePersistState(sqlite3 *db){
   return chunkStoreCommit(cs);
 }
 
+int doltliteMutateRefs(sqlite3 *db, DoltliteRefsMutation xMutate, void *pArg){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  int rc;
+
+  if( !cs ) return SQLITE_ERROR;
+
+  rc = chunkStoreLockAndRefresh(cs);
+  if( rc!=SQLITE_OK ) return rc;
+
+  rc = xMutate(db, cs, pArg);
+  if( rc==SQLITE_OK ){
+    rc = chunkStoreSerializeRefs(cs);
+    if( rc==SQLITE_OK ) rc = chunkStoreCommit(cs);
+  }
+
+  chunkStoreUnlock(cs);
+  return rc;
+}
+
 /*
 ** Helper #2: Flush the in-memory catalog, serialize it into the chunk store,
 ** and return the resulting hash.

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -617,10 +617,12 @@ static void doltliteResetFunc(
   sqlite3 *db = sqlite3_context_db_handle(context);
   ChunkStore *cs = doltliteGetChunkStore(db);
   ProllyHash targetCatHash;
+  ProllyHash targetCommit;
   int isHard = 0;
   const char *zRef = 0;
   int rc;
   int i;
+  int graphLocked = 0;
 
   if( !cs ){
     sqlite3_result_error(context, "no database open", -1);
@@ -637,7 +639,6 @@ static void doltliteResetFunc(
   }
 
   if( zRef ){
-    ProllyHash targetCommit;
     DoltliteCommit commit;
 
     rc = doltliteResolveRef(db,zRef, &targetCommit);
@@ -654,9 +655,38 @@ static void doltliteResetFunc(
     memcpy(&targetCatHash, &commit.catalogHash, sizeof(ProllyHash));
     doltliteCommitClear(&commit);
 
+    rc = chunkStoreLockAndRefresh(cs);
+    if( rc==SQLITE_BUSY ){
+      sqlite3_result_error(context,
+        "database is locked by another connection", -1);
+      return;
+    }
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(context, rc);
+      return;
+    }
+    graphLocked = 1;
+
+    {
+      const char *branch = doltliteGetSessionBranch(db);
+      ProllyHash branchTip;
+      ProllyHash sessionHead;
+      doltliteGetSessionHead(db, &sessionHead);
+      if( chunkStoreFindBranch(cs, branch, &branchTip)==SQLITE_OK
+       && prollyHashCompare(&sessionHead, &branchTip)!=0 ){
+        sqlite3_result_error(context,
+          "reset conflict: another connection moved this branch. "
+          "Please retry your transaction.", -1);
+        goto reset_cleanup;
+      }
+    }
+
     doltliteSetSessionHead(db, &targetCommit);
-    chunkStoreUpdateBranch(cs, doltliteGetSessionBranch(db), &targetCommit);
-    chunkStoreSerializeRefs(cs);
+    rc = chunkStoreUpdateBranch(cs, doltliteGetSessionBranch(db), &targetCommit);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(context, rc);
+      goto reset_cleanup;
+    }
 
     doltliteClearSessionMergeState(db);
   }else{
@@ -672,24 +702,28 @@ static void doltliteResetFunc(
   if( isHard ){
     if( prollyHashIsEmpty(&targetCatHash) ){
       sqlite3_result_error(context, "no commit to reset to", -1);
-      return;
+      goto reset_cleanup;
     }
     doltliteSaveWorkingSet(db);
     chunkStoreSerializeRefs(cs);
     rc = doltliteHardReset(db, &targetCatHash);
     if( rc!=SQLITE_OK ){
       sqlite3_result_error(context, "hard reset failed", -1);
-      return;
+      goto reset_cleanup;
     }
   }else{
     rc = doltlitePersistState(db);
     if( rc!=SQLITE_OK ){
       sqlite3_result_error_code(context, rc);
-      return;
+      goto reset_cleanup;
     }
   }
 
   sqlite3_result_int(context, 0);
+reset_cleanup:
+  if( graphLocked ){
+    chunkStoreUnlock(cs);
+  }
 }
 
 /* extractColNameFromDef, bindRecordField, migrateDiffCb, migrateSchemaRowData

--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -16,15 +16,39 @@ static void activeBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
   sqlite3_result_text(ctx, doltliteGetSessionBranch(db), -1, SQLITE_TRANSIENT);
 }
 
+typedef struct BranchMutationCtx BranchMutationCtx;
+struct BranchMutationCtx {
+  const char *zName;
+  ProllyHash head;
+  int isDelete;
+};
+
+static int mutateBranchRef(sqlite3 *db, ChunkStore *cs, void *pArg){
+  BranchMutationCtx *p = (BranchMutationCtx*)pArg;
+  int rc;
+
+  if( p->isDelete ){
+    ProllyHash empty;
+    rc = chunkStoreDeleteBranch(cs, p->zName);
+    if( rc!=SQLITE_OK ) return rc;
+    memset(&empty, 0, sizeof(empty));
+    return doltliteUpdateBranchWorkingState(db, p->zName, &empty, NULL);
+  }
+
+  return chunkStoreAddBranch(cs, p->zName, &p->head);
+}
+
 static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
   ChunkStore *cs = doltliteGetChunkStore(db);
-  ProllyHash head;
+  BranchMutationCtx m;
   const char *arg0;
   int rc;
 
   if( !cs ){ sqlite3_result_error(ctx, "no database", -1); return; }
   if( argc<1 ){ sqlite3_result_error(ctx, "branch name required", -1); return; }
+
+  memset(&m, 0, sizeof(m));
 
   arg0 = (const char*)sqlite3_value_text(argv[0]);
   if( !arg0 ){ sqlite3_result_error(ctx, "branch name required", -1); return; }
@@ -38,29 +62,21 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
       sqlite3_result_error(ctx, "cannot delete the current branch", -1);
       return;
     }
-    rc = chunkStoreDeleteBranch(cs, zName);
+    m.zName = zName;
+    m.isDelete = 1;
+    rc = doltliteMutateRefs(db, mutateBranchRef, &m);
     if( rc!=SQLITE_OK ){ sqlite3_result_error(ctx, "branch not found", -1); return; }
-    /* Clear this branch's entry from the working state so GC can
-    ** reclaim the deleted branch's catalog and data chunks. */
-    {
-      ProllyHash empty;
-      memset(&empty, 0, sizeof(empty));
-      doltliteUpdateBranchWorkingState(db, zName, &empty, NULL);
-    }
   }else{
-    
-    doltliteGetSessionHead(db, &head);
-    if( prollyHashIsEmpty(&head) ){
+    doltliteGetSessionHead(db, &m.head);
+    if( prollyHashIsEmpty(&m.head) ){
       sqlite3_result_error(ctx, "no commits yet — commit first", -1);
       return;
     }
-    rc = chunkStoreAddBranch(cs, arg0, &head);
+    m.zName = arg0;
+    rc = doltliteMutateRefs(db, mutateBranchRef, &m);
     if( rc!=SQLITE_OK ){ sqlite3_result_error(ctx, "branch already exists", -1); return; }
   }
 
-  rc = chunkStoreSerializeRefs(cs);
-  if( rc==SQLITE_OK ) rc = chunkStoreCommit(cs);
-  if( rc!=SQLITE_OK ){ sqlite3_result_error_code(ctx, rc); return; }
   sqlite3_result_int(ctx, 0);
 }
 
@@ -109,11 +125,66 @@ static int checkoutLoadAndApply(
   return rc;
 }
 
+typedef struct CheckoutMutationCtx CheckoutMutationCtx;
+struct CheckoutMutationCtx {
+  const char *zTargetBranch;
+  const char *zCurrentBranch;
+  ProllyHash oldCatHash;
+  ProllyHash oldCommitHash;
+  ProllyHash targetCommit;
+  ProllyHash targetCatHash;
+  int haveOldState;
+};
+
+static int checkoutMutateRefs(sqlite3 *db, ChunkStore *cs, void *pArg){
+  CheckoutMutationCtx *p = (CheckoutMutationCtx*)pArg;
+  int rc;
+
+  rc = chunkStoreFindBranch(cs, p->zTargetBranch, &p->targetCommit);
+  if( rc!=SQLITE_OK ) return rc;
+  if( prollyHashIsEmpty(&p->targetCommit) ) return SQLITE_EMPTY;
+
+  rc = checkoutLoadAndApply(db, cs, p->zTargetBranch,
+                            &p->targetCommit, &p->targetCatHash);
+  if( rc!=SQLITE_OK ) return rc;
+
+  doltliteSetSessionBranch(db, p->zTargetBranch);
+  doltliteSetSessionHead(db, &p->targetCommit);
+
+  rc = doltliteLoadWorkingSet(db, p->zTargetBranch);
+  if( rc!=SQLITE_OK ) return rc;
+
+  {
+    ProllyHash staged;
+    doltliteGetSessionStaged(db, &staged);
+    if( prollyHashIsEmpty(&staged) ){
+      doltliteSetSessionStaged(db, &p->targetCatHash);
+    }
+  }
+
+  rc = chunkStoreSetDefaultBranch(cs, p->zTargetBranch);
+  if( rc!=SQLITE_OK ) return rc;
+
+  rc = doltliteSaveWorkingSet(db);
+  if( rc!=SQLITE_OK ) return rc;
+
+  if( p->haveOldState ){
+    rc = doltliteUpdateBranchWorkingState(db, p->zCurrentBranch,
+                                          &p->oldCatHash, &p->oldCommitHash);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+
+  return doltliteUpdateBranchWorkingState(db, p->zTargetBranch,
+                                          &p->targetCatHash, &p->targetCommit);
+}
+
 static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
   ChunkStore *cs = doltliteGetChunkStore(db);
-  ProllyHash targetCommit;
+  CheckoutMutationCtx m;
+  BranchMutationCtx branchCreate;
   const char *zBranch;
+  char *zCurrentBranch = 0;
   int rc;
 
   if( !cs ){ sqlite3_result_error(ctx, "no database", -1); return; }
@@ -121,42 +192,30 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
   zBranch = (const char*)sqlite3_value_text(argv[0]);
   if( !zBranch ){ sqlite3_result_error(ctx, "branch name required", -1); return; }
 
+  memset(&m, 0, sizeof(m));
+  memset(&branchCreate, 0, sizeof(branchCreate));
+
   
   if( strcmp(zBranch, "-b")==0 ){
-    ProllyHash head;
     if( argc<2 ){ sqlite3_result_error(ctx, "branch name required after -b", -1); return; }
     zBranch = (const char*)sqlite3_value_text(argv[1]);
     if( !zBranch ){ sqlite3_result_error(ctx, "branch name required after -b", -1); return; }
 
-    doltliteGetSessionHead(db, &head);
-    if( prollyHashIsEmpty(&head) ){
+    doltliteGetSessionHead(db, &branchCreate.head);
+    if( prollyHashIsEmpty(&branchCreate.head) ){
       sqlite3_result_error(ctx, "no commits yet — commit first", -1);
       return;
     }
-    rc = chunkStoreAddBranch(cs, zBranch, &head);
+    branchCreate.zName = zBranch;
+    rc = doltliteMutateRefs(db, mutateBranchRef, &branchCreate);
     if( rc!=SQLITE_OK ){
       sqlite3_result_error(ctx, "branch already exists", -1);
       return;
     }
-    rc = chunkStoreSerializeRefs(cs);
-    if( rc==SQLITE_OK ) rc = chunkStoreCommit(cs);
-    if( rc!=SQLITE_OK ){
-      sqlite3_result_error_code(ctx, rc);
-      return;
-    }
-    
   }
 
   if( strcmp(zBranch, doltliteGetSessionBranch(db))==0 ){
     sqlite3_result_int(ctx, 0);
-    return;
-  }
-
-  rc = chunkStoreFindBranch(cs, zBranch, &targetCommit);
-  if( rc!=SQLITE_OK ){ sqlite3_result_error(ctx, "branch not found", -1); return; }
-
-  if( prollyHashIsEmpty(&targetCommit) ){
-    sqlite3_result_error(ctx, "target branch has no commits", -1);
     return;
   }
 
@@ -173,63 +232,40 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
   /* Save the current branch's working catalog before hardReset overwrites
   ** it with the target branch's catalog. */
   {
-    extern int doltliteFlushAndSerializeCatalog(sqlite3*, u8**, int*);
-    extern int doltliteUpdateBranchWorkingState(sqlite3*, const char*,
-                                                const ProllyHash*, const ProllyHash*);
     u8 *oldCatData = 0; int nOldCat = 0;
-    ProllyHash oldCatHash;
-    ProllyHash oldCommitHash;
-    doltliteGetSessionHead(db, &oldCommitHash);
-    if( doltliteFlushAndSerializeCatalog(db, &oldCatData, &nOldCat)==SQLITE_OK ){
-      chunkStorePut(cs, oldCatData, nOldCat, &oldCatHash);
-      sqlite3_free(oldCatData);
-      doltliteUpdateBranchWorkingState(db,
-          doltliteGetSessionBranch(db), &oldCatHash, &oldCommitHash);
-    }
-  }
-
-  {
-    ProllyHash catHash;
-    rc = checkoutLoadAndApply(db, cs, zBranch, &targetCommit, &catHash);
-    if( rc!=SQLITE_OK ){
-      sqlite3_result_error(ctx, "checkout failed", -1);
+    doltliteGetSessionHead(db, &m.oldCommitHash);
+    zCurrentBranch = sqlite3_mprintf("%s", doltliteGetSessionBranch(db));
+    if( !zCurrentBranch ){
+      sqlite3_result_error_nomem(ctx);
       return;
     }
-
-
-    doltliteSetSessionBranch(db, zBranch);
-    doltliteSetSessionHead(db, &targetCommit);
-
-
-    {
-      extern int doltliteLoadWorkingSet(sqlite3*, const char*);
-      doltliteLoadWorkingSet(db, zBranch);
-
-      {
-        ProllyHash staged;
-        doltliteGetSessionStaged(db, &staged);
-        if( prollyHashIsEmpty(&staged) ){
-          doltliteSetSessionStaged(db, &catHash);
-        }
-      }
-    }
-
-
-    chunkStoreSetDefaultBranch(cs, zBranch);
-
-    {
-      extern int doltliteSaveWorkingSet(sqlite3*);
-      extern int doltliteUpdateBranchWorkingState(sqlite3*, const char*,
-                                                  const ProllyHash*, const ProllyHash*);
-      doltliteSaveWorkingSet(db);
-      /* Record the target branch's working catalog in the per-branch working
-      ** state so cross-branch connections find the correct catalog on refresh. */
-      doltliteUpdateBranchWorkingState(db, zBranch, &catHash, &targetCommit);
+    if( doltliteFlushAndSerializeCatalog(db, &oldCatData, &nOldCat)==SQLITE_OK ){
+      rc = chunkStorePut(cs, oldCatData, nOldCat, &m.oldCatHash);
+      sqlite3_free(oldCatData);
+      if( rc==SQLITE_OK ) m.haveOldState = 1;
     }
   }
-  rc = chunkStoreSerializeRefs(cs);
-  if( rc==SQLITE_OK ) rc = chunkStoreCommit(cs);
 
+  m.zTargetBranch = zBranch;
+  m.zCurrentBranch = zCurrentBranch;
+  rc = doltliteMutateRefs(db, checkoutMutateRefs, &m);
+  sqlite3_free(zCurrentBranch);
+  if( rc==SQLITE_NOTFOUND ){
+    sqlite3_result_error(ctx, "branch not found", -1);
+    return;
+  }
+  if( rc==SQLITE_EMPTY ){
+    sqlite3_result_error(ctx, "target branch has no commits", -1);
+    return;
+  }
+  if( rc==SQLITE_BUSY ){
+    sqlite3_result_error(ctx, "database is locked by another connection", -1);
+    return;
+  }
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error(ctx, "checkout failed", -1);
+    return;
+  }
   sqlite3_result_int(ctx, 0);
 }
 

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -128,6 +128,10 @@ void doltliteClearSessionMergeState(sqlite3 *db);
 void doltliteGetSessionConflictsCatalog(sqlite3 *db, ProllyHash *pHash);
 void doltliteSetSessionConflictsCatalog(sqlite3 *db, const ProllyHash *pHash);
 int doltliteSaveWorkingSet(sqlite3 *db);
+int doltliteLoadWorkingSet(sqlite3 *db, const char *zBranch);
+
+typedef int (*DoltliteRefsMutation)(sqlite3 *db, ChunkStore *cs, void *pArg);
+int doltliteMutateRefs(sqlite3 *db, DoltliteRefsMutation xMutate, void *pArg);
 
 const char *doltliteGetAuthorName(sqlite3 *db);
 void doltliteSetAuthorName(sqlite3 *db, const char *zName);

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -9,6 +9,20 @@
 #include "doltlite_internal.h"
 #include <string.h>
 
+typedef struct RemoteMutationCtx RemoteMutationCtx;
+struct RemoteMutationCtx {
+  const char *zName;
+  const char *zUrl;
+  int isDelete;
+};
+
+static int mutateRemoteRef(sqlite3 *db, ChunkStore *cs, void *pArg){
+  RemoteMutationCtx *p = (RemoteMutationCtx*)pArg;
+  (void)db;
+  if( p->isDelete ) return chunkStoreDeleteRemote(cs, p->zName);
+  return chunkStoreAddRemote(cs, p->zName, p->zUrl);
+}
+
 static DoltliteRemote *openRemoteByUrl(sqlite3_vfs *pVfs, const char *zUrl){
   if( strncmp(zUrl, "file://", 7)==0 ){
     return doltliteFsRemoteOpen(pVfs, zUrl + 7);
@@ -23,12 +37,15 @@ static DoltliteRemote *openRemoteByUrl(sqlite3_vfs *pVfs, const char *zUrl){
 static void doltRemoteFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
   ChunkStore *cs = doltliteGetChunkStore(db);
+  RemoteMutationCtx m;
   const char *zAction;
   const char *zName;
   int rc;
 
   if( !cs ){ sqlite3_result_error(ctx, "no database", -1); return; }
   if( argc<2 ){ sqlite3_result_error(ctx, "usage: dolt_remote(action, name [, url])", -1); return; }
+
+  memset(&m, 0, sizeof(m));
 
   zAction = (const char*)sqlite3_value_text(argv[0]);
   zName = (const char*)sqlite3_value_text(argv[1]);
@@ -48,13 +65,17 @@ static void doltRemoteFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
       sqlite3_result_error(ctx, "url required for add", -1);
       return;
     }
-    rc = chunkStoreAddRemote(cs, zName, zUrl);
+    m.zName = zName;
+    m.zUrl = zUrl;
+    rc = doltliteMutateRefs(db, mutateRemoteRef, &m);
     if( rc!=SQLITE_OK ){
       sqlite3_result_error(ctx, "remote already exists or error", -1);
       return;
     }
   }else if( strcmp(zAction, "remove")==0 ){
-    rc = chunkStoreDeleteRemote(cs, zName);
+    m.zName = zName;
+    m.isDelete = 1;
+    rc = doltliteMutateRefs(db, mutateRemoteRef, &m);
     if( rc!=SQLITE_OK ){
       sqlite3_result_error(ctx, "remote not found", -1);
       return;
@@ -64,9 +85,6 @@ static void doltRemoteFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
     return;
   }
 
-  rc = chunkStoreSerializeRefs(cs);
-  if( rc==SQLITE_OK ) rc = chunkStoreCommit(cs);
-  if( rc!=SQLITE_OK ){ sqlite3_result_error_code(ctx, rc); return; }
   sqlite3_result_int(ctx, 0);
 }
 

--- a/src/doltlite_tag.c
+++ b/src/doltlite_tag.c
@@ -8,14 +8,31 @@
 #include "doltlite_internal.h"
 #include <string.h>
 
+typedef struct TagMutationCtx TagMutationCtx;
+struct TagMutationCtx {
+  const char *zName;
+  ProllyHash commitHash;
+  int isDelete;
+};
+
+static int mutateTagRef(sqlite3 *db, ChunkStore *cs, void *pArg){
+  TagMutationCtx *p = (TagMutationCtx*)pArg;
+  (void)db;
+  if( p->isDelete ) return chunkStoreDeleteTag(cs, p->zName);
+  return chunkStoreAddTag(cs, p->zName, &p->commitHash);
+}
+
 static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
   ChunkStore *cs = doltliteGetChunkStore(db);
+  TagMutationCtx m;
   const char *arg0;
   int rc;
 
   if( !cs ){ sqlite3_result_error(ctx, "no database", -1); return; }
   if( argc<1 ){ sqlite3_result_error(ctx, "tag name required", -1); return; }
+
+  memset(&m, 0, sizeof(m));
 
   arg0 = (const char*)sqlite3_value_text(argv[0]);
   if( !arg0 ){ sqlite3_result_error(ctx, "tag name required", -1); return; }
@@ -25,41 +42,40 @@ static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     if( argc<2 ){ sqlite3_result_error(ctx, "tag name required for delete", -1); return; }
     zName = (const char*)sqlite3_value_text(argv[1]);
     if( !zName ){ sqlite3_result_error(ctx, "tag name required", -1); return; }
-    rc = chunkStoreDeleteTag(cs, zName);
+    m.zName = zName;
+    m.isDelete = 1;
+    rc = doltliteMutateRefs(db, mutateTagRef, &m);
     if( rc!=SQLITE_OK ){
       sqlite3_result_error(ctx, "tag not found", -1);
       return;
     }
   }else{
     
-    ProllyHash commitHash;
     if( argc>=2 ){
       
       const char *zHash = (const char*)sqlite3_value_text(argv[1]);
       if( !zHash ){ sqlite3_result_error(ctx, "invalid commit hash", -1); return; }
-      rc = doltliteHexToHash(zHash, &commitHash);
+      rc = doltliteHexToHash(zHash, &m.commitHash);
       if( rc!=SQLITE_OK ){
         sqlite3_result_error(ctx, "invalid commit hash format", -1);
         return;
       }
     }else{
       
-      doltliteGetSessionHead(db, &commitHash);
-      if( prollyHashIsEmpty(&commitHash) ){
+      doltliteGetSessionHead(db, &m.commitHash);
+      if( prollyHashIsEmpty(&m.commitHash) ){
         sqlite3_result_error(ctx, "no commits to tag", -1);
         return;
       }
     }
-    rc = chunkStoreAddTag(cs, arg0, &commitHash);
+    m.zName = arg0;
+    rc = doltliteMutateRefs(db, mutateTagRef, &m);
     if( rc!=SQLITE_OK ){
       sqlite3_result_error(ctx, "tag already exists", -1);
       return;
     }
   }
 
-  rc = chunkStoreSerializeRefs(cs);
-  if( rc==SQLITE_OK ) rc = chunkStoreCommit(cs);
-  if( rc!=SQLITE_OK ){ sqlite3_result_error_code(ctx, rc); return; }
   sqlite3_result_int(ctx, 0);
 }
 

--- a/test/concurrent_refs_test.c
+++ b/test/concurrent_refs_test.c
@@ -140,10 +140,47 @@ static void test_stale_reset_loses_branch_history(void){
   remove_db(dbpath);
 }
 
+static void test_stale_checkout_refreshes_target_branch(void){
+  sqlite3 *db1 = 0, *db2 = 0;
+  const char *dbpath = "/tmp/test_concurrent_refs_checkout.db";
+
+  printf("--- Test 2: stale dolt_checkout refreshes target branch ---\n");
+  remove_db(dbpath);
+
+  check("checkout_open_db1", open_db(dbpath, &db1)==SQLITE_OK);
+  check("checkout_open_db2", open_db(dbpath, &db2)==SQLITE_OK);
+
+  check("checkout_setup_schema", execsql(db1,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'a');")==SQLITE_OK);
+  check("checkout_init_commit",
+    strlen(exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')"))==40);
+  check("checkout_create_branch",
+    strcmp(exec1(db1, "SELECT dolt_branch('feature')"), "0")==0);
+  check("checkout_switch_db1_feature",
+    strcmp(exec1(db1, "SELECT dolt_checkout('feature')"), "0")==0);
+  check("checkout_feature_insert",
+    execsql(db1, "INSERT INTO t VALUES(2,'feature')")==SQLITE_OK);
+  check("checkout_feature_commit",
+    strlen(exec1(db1, "SELECT dolt_commit('-A', '-m', 'feature update')"))==40);
+
+  check("checkout_stale_connection_switches",
+    strcmp(exec1(db2, "SELECT dolt_checkout('feature')"), "0")==0);
+  check("checkout_latest_branch_tip_visible",
+    strcmp(exec1(db2, "SELECT message FROM dolt_log LIMIT 1"), "feature update")==0);
+  check("checkout_latest_branch_data_visible",
+    strcmp(exec1(db2, "SELECT count(*) FROM t"), "2")==0);
+
+  sqlite3_close(db1);
+  sqlite3_close(db2);
+  remove_db(dbpath);
+}
+
 int main(void){
   printf("=== Concurrent Refs Test ===\n\n");
 
   test_stale_reset_loses_branch_history();
+  test_stale_checkout_refreshes_target_branch();
 
   printf("\nResults: %d passed, %d failed out of %d tests\n",
          nPass, nFail, nPass+nFail);

--- a/test/concurrent_refs_test.c
+++ b/test/concurrent_refs_test.c
@@ -1,0 +1,151 @@
+/*
+** Concurrent refs mutation repro for DoltLite.
+**
+** This reproduces a stale-writer bug in concurrent refs mutation:
+**
+**   1. db1 and db2 open on the same branch tip
+**   2. db1 creates a new commit on main
+**   3. db2, still stale, runs dolt_reset(<old hash>)
+**
+** Correct behavior:
+**   - the stale reset is rejected
+**   - the branch tip remains on the newer commit
+**   - branch history still contains both commits
+**
+** Current buggy behavior before the fix:
+**   - dolt_reset() returns success
+**   - the branch tip moves back to the old commit
+**   - the newer commit disappears from dolt_log on that branch
+**
+** Build from build/:
+**   cc -g -I. -o concurrent_refs_test \
+**     ../test/concurrent_refs_test.c libdoltlite.a -lz -lpthread
+**
+** Run from build/:
+**   ./concurrent_refs_test
+*/
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "sqlite3.h"
+
+static int nPass = 0;
+static int nFail = 0;
+
+static void check(const char *name, int condition){
+  if( condition ){
+    nPass++;
+  }else{
+    nFail++;
+    fprintf(stderr, "FAIL: %s\n", name);
+  }
+}
+
+static int execsql(sqlite3 *db, const char *sql){
+  char *err = 0;
+  int rc = sqlite3_exec(db, sql, 0, 0, &err);
+  if( rc!=SQLITE_OK ){
+    fprintf(stderr, "  SQL error: %s (rc=%d)\n  SQL: %s\n",
+            err ? err : "?", rc, sql);
+    sqlite3_free(err);
+  }
+  return rc;
+}
+
+static char result_buf[8192];
+static const char *exec1(sqlite3 *db, const char *sql){
+  sqlite3_stmt *stmt = 0;
+  int rc;
+  result_buf[0] = 0;
+  rc = sqlite3_prepare_v2(db, sql, -1, &stmt, 0);
+  if( rc!=SQLITE_OK ){
+    snprintf(result_buf, sizeof(result_buf), "ERROR: %s", sqlite3_errmsg(db));
+    return result_buf;
+  }
+  rc = sqlite3_step(stmt);
+  if( rc==SQLITE_ROW ){
+    const char *val = (const char*)sqlite3_column_text(stmt, 0);
+    if( val ) snprintf(result_buf, sizeof(result_buf), "%s", val);
+  }else if( rc!=SQLITE_DONE ){
+    snprintf(result_buf, sizeof(result_buf), "ERROR: %s", sqlite3_errmsg(db));
+  }
+  sqlite3_finalize(stmt);
+  return result_buf;
+}
+
+static int open_db(const char *path, sqlite3 **ppDb){
+  int rc = sqlite3_open(path, ppDb);
+  if( rc==SQLITE_OK ){
+    sqlite3_busy_timeout(*ppDb, 5000);
+  }
+  return rc;
+}
+
+static void remove_db(const char *path){
+  char tmp[512];
+  remove(path);
+  snprintf(tmp, sizeof(tmp), "%s-wal", path);
+  remove(tmp);
+  snprintf(tmp, sizeof(tmp), "%s-shm", path);
+  remove(tmp);
+}
+
+static void test_stale_reset_loses_branch_history(void){
+  sqlite3 *db1 = 0, *db2 = 0, *db3 = 0;
+  const char *dbpath = "/tmp/test_concurrent_refs_reset.db";
+  char firstCommit[128];
+  char secondCommit[128];
+  char sql[512];
+
+  printf("--- Test 1: stale dolt_reset is rejected ---\n");
+  remove_db(dbpath);
+
+  check("open_db1", open_db(dbpath, &db1)==SQLITE_OK);
+  check("open_db2", open_db(dbpath, &db2)==SQLITE_OK);
+
+  check("setup_schema", execsql(db1,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'a');")==SQLITE_OK);
+
+  snprintf(firstCommit, sizeof(firstCommit), "%s",
+           exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')"));
+  check("first_commit_hash", strlen(firstCommit)==40);
+
+  check("insert_second_row",
+    execsql(db1, "INSERT INTO t VALUES(2,'b')")==SQLITE_OK);
+  snprintf(secondCommit, sizeof(secondCommit), "%s",
+           exec1(db1, "SELECT dolt_commit('-A', '-m', 'second')"));
+  check("second_commit_hash", strlen(secondCommit)==40);
+
+  snprintf(sql, sizeof(sql), "SELECT dolt_reset('%s')", firstCommit);
+  exec1(db2, sql);
+  check("stale_reset_is_rejected",
+    strstr(result_buf, "ERROR")!=0 || strstr(result_buf, "conflict")!=0);
+
+  sqlite3_close(db1);
+  sqlite3_close(db2);
+
+  check("open_db3", open_db(dbpath, &db3)==SQLITE_OK);
+
+  check("newer_commit_still_head",
+    strcmp(exec1(db3, "SELECT message FROM dolt_log LIMIT 1"), "second")==0);
+  snprintf(sql, sizeof(sql),
+           "SELECT count(*) FROM dolt_log WHERE commit_hash='%s'", secondCommit);
+  check("newer_commit_still_visible_in_log",
+    strcmp(exec1(db3, sql), "1")==0);
+  check("branch_history_has_both_commits",
+    strcmp(exec1(db3, "SELECT count(*) FROM dolt_log"), "2")==0);
+
+  sqlite3_close(db3);
+  remove_db(dbpath);
+}
+
+int main(void){
+  printf("=== Concurrent Refs Test ===\n\n");
+
+  test_stale_reset_loses_branch_history();
+
+  printf("\nResults: %d passed, %d failed out of %d tests\n",
+         nPass, nFail, nPass+nFail);
+  return nFail > 0 ? 1 : 0;
+}

--- a/test/concurrent_refs_test.sh
+++ b/test/concurrent_refs_test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Build and run the concurrent refs repro.
+# This is intentionally a focused repro for the stale-refs overwrite bug.
+# It is not part of the default suite until the underlying bug is fixed.
+
+set -euo pipefail
+
+echo "=== Concurrent Refs Repro ==="
+cc -g -I. -o concurrent_refs_test ../test/concurrent_refs_test.c libdoltlite.a -lz -lpthread
+./concurrent_refs_test

--- a/test/concurrent_refs_test.sh
+++ b/test/concurrent_refs_test.sh
@@ -7,5 +7,5 @@
 set -euo pipefail
 
 echo "=== Concurrent Refs Repro ==="
-cc -g -I. -o concurrent_refs_test ../test/concurrent_refs_test.c libdoltlite.a -lz -lpthread
+cc -g -I. -o concurrent_refs_test ../test/concurrent_refs_test.c libdoltlite.a -lz -lpthread -lm
 ./concurrent_refs_test

--- a/test/run_doltlite_tests.sh
+++ b/test/run_doltlite_tests.sh
@@ -57,6 +57,7 @@ TESTS=(
   doltlite_gc_scale.sh
   doltlite_index_prefix.sh
   doltlite_issue179_180.sh
+  concurrent_refs_test.sh
   review_regression_test.sh
 )
 


### PR DESCRIPTION
## Summary
- reject stale `dolt_reset(<ref>)` calls that would rewind a branch after another connection already moved it
- centralize plain refs writes behind a shared locked `doltliteMutateRefs()` helper and move branch, tag, remote, and checkout persistence onto it
- refresh the target branch inside `dolt_checkout()` before switching so stale connections do not check out an out-of-date branch tip
- add concurrent refs regression coverage for stale reset and stale checkout, and run it from the standard feature-test runner used by GitHub CI

## Testing
- `make libdoltlite.a -j4`
- `make doltlite -j4`
- `bash ../test/concurrent_refs_test.sh`
- `bash ../test/run_doltlite_tests.sh`
