### PR TITLE
Centralize catalog staging logic

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -293,6 +293,9 @@ static void doltliteAddFunc(
 
   {
     ProllyHash workingHash;
+    ProllyHash savedStaged;
+
+    doltliteGetSessionStaged(db, &savedStaged);
 
     rc = doltliteFlushCatalogToHash(db, &workingHash);
     if( rc!=SQLITE_OK ){
@@ -336,12 +339,24 @@ static void doltliteAddFunc(
       
       for(i=0; i<argc; i++){
         const char *zTable = (const char*)sqlite3_value_text(argv[i]);
-        Pgno iTable;
+        Pgno iTable = 0;
         int j;
 
         if( !zTable || zTable[0]=='-' ) continue;
         rc = doltliteResolveTableName(db, zTable, &iTable);
-        if( rc!=SQLITE_OK ) continue;
+        if( rc!=SQLITE_OK ){
+          for(j=0; j<nStaged; j++){
+            if( aStaged[j].zName && strcmp(aStaged[j].zName, zTable)==0 ){
+              if( j+1 < nStaged ){
+                memmove(&aStaged[j], &aStaged[j+1],
+                        (nStaged-j-1) * (int)sizeof(struct TableEntry));
+              }
+              nStaged--;
+              break;
+            }
+          }
+          continue;
+        }
 
         
         for(j=0; j<nWorking; j++){
@@ -351,9 +366,7 @@ static void doltliteAddFunc(
             int updated = 0;
             for(k=0; k<nStaged; k++){
               if( aStaged[k].iTable==iTable ){
-                aStaged[k].root = aWorking[j].root;
-                aStaged[k].schemaHash = aWorking[j].schemaHash;
-                aStaged[k].flags = aWorking[j].flags;
+                aStaged[k] = aWorking[j];
                 updated = 1;
                 break;
               }
@@ -362,11 +375,15 @@ static void doltliteAddFunc(
               
               struct TableEntry *aNew = sqlite3_realloc(aStaged,
                   (nStaged+1)*(int)sizeof(struct TableEntry));
-              if( aNew ){
-                aStaged = aNew;
-                aStaged[nStaged] = aWorking[j];
-                nStaged++;
+              if( !aNew ){
+                sqlite3_free(aWorking);
+                sqlite3_free(aStaged);
+                sqlite3_result_error_nomem(context);
+                return;
               }
+              aStaged = aNew;
+              aStaged[nStaged] = aWorking[j];
+              nStaged++;
             }
             break;
           }
@@ -375,49 +392,20 @@ static void doltliteAddFunc(
 
       
       {
-        {
-          int sz = CAT_HEADER_SIZE_V3;
-          u8 *buf, *p;
-          ProllyHash newStagedHash;
-          int j;
-
-          for(j=0;j<nStaged;j++){
-            int nl = aStaged[j].zName ? (int)strlen(aStaged[j].zName) : 0;
-            sz += 4+1+PROLLY_HASH_SIZE+PROLLY_HASH_SIZE+2+nl;
-          }
-          buf = sqlite3_malloc(sz);
-          if( !buf ){
-            sqlite3_free(aWorking);
-            sqlite3_free(aStaged);
-            sqlite3_result_error(context, "out of memory", -1);
-            return;
-          }
-          p = buf;
-          *p++ = CATALOG_FORMAT_V3;
-          p[0]=(u8)nStaged; p[1]=(u8)(nStaged>>8);
-          p[2]=(u8)(nStaged>>16); p[3]=(u8)(nStaged>>24);
-          p += 4;
-
-          for(i=0; i<nStaged; i++){
-            Pgno pg = aStaged[i].iTable;
-            int nl = aStaged[i].zName ? (int)strlen(aStaged[i].zName) : 0;
-            p[0]=(u8)pg; p[1]=(u8)(pg>>8); p[2]=(u8)(pg>>16); p[3]=(u8)(pg>>24);
-            p += 4;
-            *p++ = aStaged[i].flags;
-            memcpy(p, aStaged[i].root.data, PROLLY_HASH_SIZE);
-            p += PROLLY_HASH_SIZE;
-            memcpy(p, aStaged[i].schemaHash.data, PROLLY_HASH_SIZE);
-            p += PROLLY_HASH_SIZE;
-            p[0]=(u8)nl; p[1]=(u8)(nl>>8); p+=2;
-            if(nl>0) memcpy(p, aStaged[i].zName, nl);
-            p += nl;
-          }
-
-          rc = chunkStorePut(cs, buf, (int)(p-buf), &newStagedHash);
-          sqlite3_free(buf);
-          if( rc==SQLITE_OK ){
-            doltliteSetSessionStaged(db, &newStagedHash);
-          }
+        u8 *buf = 0;
+        int nBuf = 0;
+        ProllyHash newStagedHash;
+        rc = doltliteSerializeCatalogEntries(db, aStaged, nStaged, &buf, &nBuf);
+        if( rc!=SQLITE_OK ){
+          sqlite3_free(aWorking);
+          sqlite3_free(aStaged);
+          sqlite3_result_error_code(context, rc);
+          return;
+        }
+        rc = chunkStorePut(cs, buf, nBuf, &newStagedHash);
+        sqlite3_free(buf);
+        if( rc==SQLITE_OK ){
+          doltliteSetSessionStaged(db, &newStagedHash);
         }
       }
 
@@ -425,16 +413,11 @@ static void doltliteAddFunc(
       sqlite3_free(aStaged);
     }
 
-
-    {
-      ProllyHash savedStaged;
-      doltliteGetSessionStaged(db, &savedStaged);
-      rc = doltlitePersistState(db);
-      if( rc!=SQLITE_OK ){
-        doltliteSetSessionStaged(db, &savedStaged);
-        sqlite3_result_error_code(context, rc);
-        return;
-      }
+    rc = doltlitePersistState(db);
+    if( rc!=SQLITE_OK ){
+      doltliteSetSessionStaged(db, &savedStaged);
+      sqlite3_result_error_code(context, rc);
+      return;
     }
   }
 

--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -239,11 +239,20 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
       sqlite3_result_error_nomem(ctx);
       return;
     }
-    if( doltliteFlushAndSerializeCatalog(db, &oldCatData, &nOldCat)==SQLITE_OK ){
-      rc = chunkStorePut(cs, oldCatData, nOldCat, &m.oldCatHash);
-      sqlite3_free(oldCatData);
-      if( rc==SQLITE_OK ) m.haveOldState = 1;
+    rc = doltliteFlushAndSerializeCatalog(db, &oldCatData, &nOldCat);
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(zCurrentBranch);
+      sqlite3_result_error(ctx, "failed to snapshot current branch state", -1);
+      return;
     }
+    rc = chunkStorePut(cs, oldCatData, nOldCat, &m.oldCatHash);
+    sqlite3_free(oldCatData);
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(zCurrentBranch);
+      sqlite3_result_error(ctx, "failed to snapshot current branch state", -1);
+      return;
+    }
+    m.haveOldState = 1;
   }
 
   m.zTargetBranch = zBranch;

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -89,6 +89,8 @@ ProllyCache *doltliteGetCache(sqlite3 *db);
 int doltliteLoadCatalog(sqlite3 *db, const ProllyHash *catHash,
                         struct TableEntry **ppTables, int *pnTables,
                         Pgno *piNextTable);
+int doltliteSerializeCatalogEntries(sqlite3 *db, struct TableEntry *aTables,
+                                    int nTables, u8 **ppOut, int *pnOut);
 int doltliteGetHeadCatalogHash(sqlite3 *db, ProllyHash *pCatHash);
 int doltliteFlushAndSerializeCatalog(sqlite3 *db, u8 **ppOut, int *pnOut);
 /* Ref resolution: try hex hash, then branch, then tag (doltlite_ref.c) */

--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -812,66 +812,17 @@ static int serializeMergedCatalog(
   ProllyHash *pOutHash
 ){
   ChunkStore *cs = doltliteGetChunkStore(db);
-  int sz = CAT_HEADER_SIZE_V3;
-  u8 *buf;
-  u8 *p;
+  u8 *buf = 0;
+  int nBuf = 0;
   int rc;
 
   (void)oursCatHash;
   (void)iNextTable;
 
-  /* Sort a copy by name for deterministic serialization (same as
-  ** serializeCatalog in prolly_btree.c). */
-  {
-    struct TableEntry *aSorted = sqlite3_malloc(
-        nMerged * (int)sizeof(struct TableEntry));
-    if( !aSorted ) return SQLITE_NOMEM;
-    memcpy(aSorted, aMerged, nMerged * (int)sizeof(struct TableEntry));
-    qsort(aSorted, nMerged, sizeof(struct TableEntry), tableEntryNameCmp);
+  rc = doltliteSerializeCatalogEntries(db, aMerged, nMerged, &buf, &nBuf);
+  if( rc!=SQLITE_OK ) return rc;
 
-    { int j; for(j=0;j<nMerged;j++){
-      int nl = aSorted[j].zName ? (int)strlen(aSorted[j].zName) : 0;
-      sz += 4+1+PROLLY_HASH_SIZE+PROLLY_HASH_SIZE+2+nl;
-    }}
-
-    buf = sqlite3_malloc(sz);
-    if( !buf ){
-      sqlite3_free(aSorted);
-      return SQLITE_NOMEM;
-    }
-    p = buf;
-
-    *p++ = CATALOG_FORMAT_V3;
-    p[0] = (u8)nMerged;
-    p[1] = (u8)(nMerged>>8);
-    p[2] = (u8)(nMerged>>16);
-    p[3] = (u8)(nMerged>>24);
-    p += 4;
-
-    {
-      int i;
-      for(i=0; i<nMerged; i++){
-        Pgno pg = aSorted[i].iTable;
-        int nl = aSorted[i].zName ? (int)strlen(aSorted[i].zName) : 0;
-        p[0] = (u8)pg;
-        p[1] = (u8)(pg>>8);
-        p[2] = (u8)(pg>>16);
-        p[3] = (u8)(pg>>24);
-        p += 4;
-        *p++ = aSorted[i].flags;
-        memcpy(p, aSorted[i].root.data, PROLLY_HASH_SIZE);
-        p += PROLLY_HASH_SIZE;
-        memcpy(p, aSorted[i].schemaHash.data, PROLLY_HASH_SIZE);
-        p += PROLLY_HASH_SIZE;
-        p[0]=(u8)nl; p[1]=(u8)(nl>>8); p+=2;
-        if(nl>0) memcpy(p, aSorted[i].zName, nl);
-        p += nl;
-      }
-    }
-    sqlite3_free(aSorted);
-  }
-
-  rc = chunkStorePut(cs, buf, (int)(p - buf), pOutHash);
+  rc = chunkStorePut(cs, buf, nBuf, pOutHash);
   sqlite3_free(buf);
   return rc;
 }

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -793,19 +793,23 @@ static int tableEntryNameCmp(const void *a, const void *b){
   return strcmp(ea->zName, eb->zName);
 }
 
-static int serializeCatalog(Btree *pBtree, u8 **ppOut, int *pnOut){
-  int nTables = pBtree->nTables;
+int doltliteSerializeCatalogEntries(
+  sqlite3 *db,
+  struct TableEntry *aTables,
+  int nTables,
+  u8 **ppOut,
+  int *pnOut
+){
   int sz = CAT_HEADER_SIZE_V3;
   u8 *buf, *q;
   struct TableEntry *aSorted;  /* name-sorted copy for deterministic output */
   int i;
 
   /* Resolve table names eagerly so serialization is deterministic. */
-  if( pBtree->db ){
+  if( db ){
     for(i=0; i<nTables; i++){
-      if( !pBtree->aTables[i].zName && pBtree->aTables[i].iTable>1 ){
-        pBtree->aTables[i].zName = doltliteResolveTableNumber(
-            pBtree->db, pBtree->aTables[i].iTable);
+      if( !aTables[i].zName && aTables[i].iTable>1 ){
+        aTables[i].zName = doltliteResolveTableNumber(db, aTables[i].iTable);
       }
     }
   }
@@ -814,7 +818,7 @@ static int serializeCatalog(Btree *pBtree, u8 **ppOut, int *pnOut){
   ** stays sorted by iTable (binary search by page number depends on it). */
   aSorted = sqlite3_malloc(nTables * (int)sizeof(struct TableEntry));
   if( !aSorted ) return SQLITE_NOMEM;
-  memcpy(aSorted, pBtree->aTables, nTables * (int)sizeof(struct TableEntry));
+  memcpy(aSorted, aTables, nTables * (int)sizeof(struct TableEntry));
   qsort(aSorted, nTables, sizeof(struct TableEntry), tableEntryNameCmp);
 
   for(i=0; i<nTables; i++){
@@ -857,6 +861,11 @@ static int serializeCatalog(Btree *pBtree, u8 **ppOut, int *pnOut){
   *ppOut = buf;
   *pnOut = (int)(q - buf);
   return SQLITE_OK;
+}
+
+static int serializeCatalog(Btree *pBtree, u8 **ppOut, int *pnOut){
+  return doltliteSerializeCatalogEntries(
+      pBtree->db, pBtree->aTables, pBtree->nTables, ppOut, pnOut);
 }
 
 static void initDefaultMeta(Btree *pBtree){

--- a/test/doltlite_staging.sh
+++ b/test/doltlite_staging.sh
@@ -190,6 +190,29 @@ run_test "staged_persists" \
   "SELECT count(*) FROM dolt_status WHERE staged=1;" \
   "1" "$DB6"
 
+# --- Named dolt_add can stage a dropped table ---
+DB6B=/tmp/test_staging6b_$$.db
+rm -f "$DB6B"
+echo "CREATE TABLE keep_t(x); CREATE TABLE drop_t(y); INSERT INTO keep_t VALUES(1); INSERT INTO drop_t VALUES(2); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6B" > /dev/null 2>&1
+echo "DROP TABLE drop_t;" | $DOLTLITE "$DB6B" > /dev/null 2>&1
+
+run_test "dropped_table_unstaged" \
+  "SELECT table_name, staged, status FROM dolt_status WHERE table_name='drop_t';" \
+  "drop_t|0|deleted" "$DB6B"
+
+echo "SELECT dolt_add('drop_t');" | $DOLTLITE "$DB6B" > /dev/null 2>&1
+run_test "dropped_table_staged" \
+  "SELECT table_name, staged, status FROM dolt_status WHERE table_name='drop_t';" \
+  "drop_t|1|deleted" "$DB6B"
+
+run_test_match "commit_dropped_table" \
+  "SELECT dolt_commit('-m','drop drop_t');" \
+  "^[0-9a-f]{40}$" "$DB6B"
+
+run_test "dropped_table_gone_after_commit" \
+  "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='drop_t';" \
+  "0" "$DB6B"
+
 # --- dolt_add dot (.) stages everything ---
 DB7=/tmp/test_staging7_$$.db
 rm -f "$DB7"
@@ -213,7 +236,7 @@ run_test "add_lowercase_a_stages_all" \
   "1" "$DB8"
 
 # --- Cleanup ---
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8"
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB6B" "$DB7" "$DB8"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"


### PR DESCRIPTION
## Summary
- centralize catalog serialization behind one shared helper
- fix named `dolt_add()` staging for rename/drop metadata and allocation rollback cases
- fail `dolt_checkout()` if the source branch working state cannot be snapshotted before switching
- consolidate focused C regressions into the shared `_c` runner
- include the savepoint catalog restore fix and regression

## Review Issues Addressed
- closes #310
- closes #311
- closes #312
- closes #313
- closes #314

## Testing
- `bash ../test/doltlite_staging.sh`
- `bash ../test/doltlite_branch.sh`
- `bash ../test/doltlite_branch_edge.sh`
- `bash ../test/doltlite_regression_test_c.sh`
- `bash ../test/doltlite_schema_merge.sh`
- `bash ../test/index_oracle_test.sh ./doltlite sqlite3`
