### PR TITLE
Fix remote and storage correctness issues

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -1056,13 +1056,15 @@ int chunkStoreHasMany(ChunkStore *cs, const ProllyHash *aHash, int nHash, u8 *aR
 **   [nTracking:4] { [remote_len:4][remote:N][branch_len:4][branch:N][commit_hash:20] }...
 ** All length fields are little-endian u32.
 */
-int chunkStoreSerializeRefs(ChunkStore *cs){
+static int csSerializeRefsBlob(ChunkStore *cs, u8 **ppOut, int *pnOut){
   const char *def = cs->zDefaultBranch ? cs->zDefaultBranch : "main";
   int defLen = (int)strlen(def);
   int sz = 1 + 4 + defLen + 4 + 4 + 4 + 4;
-  int i, rc;
+  int i;
   u8 *buf, *bufCur;
-  ProllyHash refsHash;
+
+  *ppOut = 0;
+  *pnOut = 0;
 
   for(i=0; i<cs->nBranches; i++){
     int inc = 4 + (int)strlen(cs->aBranches[i].zName) + PROLLY_HASH_SIZE*2;
@@ -1132,6 +1134,19 @@ int chunkStoreSerializeRefs(ChunkStore *cs){
     memcpy(bufCur, cs->aTracking[i].zBranch, branchLen); bufCur+=branchLen;
     memcpy(bufCur, cs->aTracking[i].commitHash.data, PROLLY_HASH_SIZE); bufCur+=PROLLY_HASH_SIZE;
   }
+  *ppOut = buf;
+  *pnOut = sz;
+  return SQLITE_OK;
+}
+
+int chunkStoreSerializeRefs(ChunkStore *cs){
+  int rc;
+  u8 *buf = 0;
+  int sz = 0;
+  ProllyHash refsHash;
+
+  rc = csSerializeRefsBlob(cs, &buf, &sz);
+  if( rc!=SQLITE_OK ) return rc;
   rc = chunkStorePut(cs, buf, sz, &refsHash);
   sqlite3_free(buf);
   if( rc==SQLITE_OK ) memcpy(&cs->refsHash, &refsHash, sizeof(ProllyHash));
@@ -1180,10 +1195,11 @@ static int csDeserializeRefs(ChunkStore *cs, const u8 *data, int nData){
     if( nTags>0 ){
       cs->aTags = sqlite3_malloc(nTags*(int)sizeof(struct TagRef));
       if(!cs->aTags) return SQLITE_NOMEM;
+      memset(cs->aTags, 0, nTags*(int)sizeof(struct TagRef));
       for(i=0;i<nTags;i++){
-        int nameLen; if(bufCur+4>data+nData) break;
+        int nameLen; if(bufCur+4>data+nData) return SQLITE_CORRUPT;
         nameLen=(int)CS_READ_U32(bufCur); bufCur+=4;
-        if(bufCur+nameLen+PROLLY_HASH_SIZE>data+nData) break;
+        if(bufCur+nameLen+PROLLY_HASH_SIZE>data+nData) return SQLITE_CORRUPT;
         cs->aTags[i].zName=sqlite3_malloc(nameLen+1);
         if(!cs->aTags[i].zName) return SQLITE_NOMEM;
         memcpy(cs->aTags[i].zName,bufCur,nameLen); cs->aTags[i].zName[nameLen]=0; bufCur+=nameLen;
@@ -1200,18 +1216,19 @@ static int csDeserializeRefs(ChunkStore *cs, const u8 *data, int nData){
     if( nRemotes>0 ){
       cs->aRemotes = sqlite3_malloc(nRemotes*(int)sizeof(struct RemoteRef));
       if(!cs->aRemotes) return SQLITE_NOMEM;
+      memset(cs->aRemotes, 0, nRemotes*(int)sizeof(struct RemoteRef));
       for(i=0;i<nRemotes;i++){
         int nameLen, urlLen;
-        if(bufCur+4>data+nData) break;
+        if(bufCur+4>data+nData) return SQLITE_CORRUPT;
         nameLen=(int)CS_READ_U32(bufCur); bufCur+=4;
-        if(bufCur+nameLen+4>data+nData) break;
+        if(bufCur+nameLen+4>data+nData) return SQLITE_CORRUPT;
         cs->aRemotes[i].zName=sqlite3_malloc(nameLen+1);
         if(!cs->aRemotes[i].zName) return SQLITE_NOMEM;
         memcpy(cs->aRemotes[i].zName,bufCur,nameLen); cs->aRemotes[i].zName[nameLen]=0; bufCur+=nameLen;
         urlLen=(int)CS_READ_U32(bufCur); bufCur+=4;
-        if(bufCur+urlLen>data+nData){ sqlite3_free(cs->aRemotes[i].zName); break; }
+        if(bufCur+urlLen>data+nData) return SQLITE_CORRUPT;
         cs->aRemotes[i].zUrl=sqlite3_malloc(urlLen+1);
-        if(!cs->aRemotes[i].zUrl){ sqlite3_free(cs->aRemotes[i].zName); return SQLITE_NOMEM; }
+        if(!cs->aRemotes[i].zUrl) return SQLITE_NOMEM;
         memcpy(cs->aRemotes[i].zUrl,bufCur,urlLen); cs->aRemotes[i].zUrl[urlLen]=0; bufCur+=urlLen;
         cs->nRemotes++;
       }
@@ -1221,18 +1238,19 @@ static int csDeserializeRefs(ChunkStore *cs, const u8 *data, int nData){
       if( nTracking>0 ){
         cs->aTracking = sqlite3_malloc(nTracking*(int)sizeof(struct TrackingBranch));
         if(!cs->aTracking) return SQLITE_NOMEM;
+        memset(cs->aTracking, 0, nTracking*(int)sizeof(struct TrackingBranch));
         for(i=0;i<nTracking;i++){
           int remoteLen, branchLen;
-          if(bufCur+4>data+nData) break;
+          if(bufCur+4>data+nData) return SQLITE_CORRUPT;
           remoteLen=(int)CS_READ_U32(bufCur); bufCur+=4;
-          if(bufCur+remoteLen+4>data+nData) break;
+          if(bufCur+remoteLen+4>data+nData) return SQLITE_CORRUPT;
           cs->aTracking[i].zRemote=sqlite3_malloc(remoteLen+1);
           if(!cs->aTracking[i].zRemote) return SQLITE_NOMEM;
           memcpy(cs->aTracking[i].zRemote,bufCur,remoteLen); cs->aTracking[i].zRemote[remoteLen]=0; bufCur+=remoteLen;
           branchLen=(int)CS_READ_U32(bufCur); bufCur+=4;
-          if(bufCur+branchLen+PROLLY_HASH_SIZE>data+nData){ sqlite3_free(cs->aTracking[i].zRemote); break; }
+          if(bufCur+branchLen+PROLLY_HASH_SIZE>data+nData) return SQLITE_CORRUPT;
           cs->aTracking[i].zBranch=sqlite3_malloc(branchLen+1);
-          if(!cs->aTracking[i].zBranch){ sqlite3_free(cs->aTracking[i].zRemote); return SQLITE_NOMEM; }
+          if(!cs->aTracking[i].zBranch) return SQLITE_NOMEM;
           memcpy(cs->aTracking[i].zBranch,bufCur,branchLen); cs->aTracking[i].zBranch[branchLen]=0; bufCur+=branchLen;
           memcpy(cs->aTracking[i].commitHash.data,bufCur,PROLLY_HASH_SIZE); bufCur+=PROLLY_HASH_SIZE;
           cs->nTracking++;
@@ -1253,85 +1271,7 @@ int chunkStoreLoadRefsFromBlob(ChunkStore *cs, const u8 *data, int nData){
 }
 
 int chunkStoreSerializeRefsToBlob(ChunkStore *cs, u8 **ppOut, int *pnOut){
-  const char *def = cs->zDefaultBranch ? cs->zDefaultBranch : "main";
-  int defLen = (int)strlen(def);
-  int sz = 1 + 4 + defLen + 4 + 4 + 4 + 4;
-  int i;
-  u8 *buf, *bufCur;
-
-  *ppOut = 0;
-  *pnOut = 0;
-
-  for(i=0; i<cs->nBranches; i++){
-    int inc = 4 + (int)strlen(cs->aBranches[i].zName) + PROLLY_HASH_SIZE*2;
-    if( sz > INT_MAX - inc ) return SQLITE_TOOBIG;
-    sz += inc;
-  }
-  for(i=0; i<cs->nTags; i++){
-    int inc = 4 + (int)strlen(cs->aTags[i].zName) + PROLLY_HASH_SIZE;
-    if( sz > INT_MAX - inc ) return SQLITE_TOOBIG;
-    sz += inc;
-  }
-  for(i=0; i<cs->nRemotes; i++){
-    int inc = 4 + (int)strlen(cs->aRemotes[i].zName) + 4 + (int)strlen(cs->aRemotes[i].zUrl);
-    if( sz > INT_MAX - inc ) return SQLITE_TOOBIG;
-    sz += inc;
-  }
-  for(i=0; i<cs->nTracking; i++){
-    int inc = 4 + (int)strlen(cs->aTracking[i].zRemote) + 4 + (int)strlen(cs->aTracking[i].zBranch) + PROLLY_HASH_SIZE;
-    if( sz > INT_MAX - inc ) return SQLITE_TOOBIG;
-    sz += inc;
-  }
-
-  buf = sqlite3_malloc(sz);
-  if( !buf ) return SQLITE_NOMEM;
-  bufCur = buf;
-
-  *bufCur++ = 5;  /* refs format version */
-  CS_WRITE_U32(bufCur,defLen); bufCur+=4;
-  memcpy(bufCur, def, defLen); bufCur+=defLen;
-
-  CS_WRITE_U32(bufCur,cs->nBranches); bufCur+=4;
-  for(i=0; i<cs->nBranches; i++){
-    int nameLen = (int)strlen(cs->aBranches[i].zName);
-    CS_WRITE_U32(bufCur,nameLen); bufCur+=4;
-    memcpy(bufCur, cs->aBranches[i].zName, nameLen); bufCur+=nameLen;
-    memcpy(bufCur, cs->aBranches[i].commitHash.data, PROLLY_HASH_SIZE); bufCur+=PROLLY_HASH_SIZE;
-    memcpy(bufCur, cs->aBranches[i].workingSetHash.data, PROLLY_HASH_SIZE); bufCur+=PROLLY_HASH_SIZE;
-  }
-
-  CS_WRITE_U32(bufCur,cs->nTags); bufCur+=4;
-  for(i=0; i<cs->nTags; i++){
-    int nameLen = (int)strlen(cs->aTags[i].zName);
-    CS_WRITE_U32(bufCur,nameLen); bufCur+=4;
-    memcpy(bufCur, cs->aTags[i].zName, nameLen); bufCur+=nameLen;
-    memcpy(bufCur, cs->aTags[i].commitHash.data, PROLLY_HASH_SIZE); bufCur+=PROLLY_HASH_SIZE;
-  }
-
-  CS_WRITE_U32(bufCur,cs->nRemotes); bufCur+=4;
-  for(i=0; i<cs->nRemotes; i++){
-    int nameLen = (int)strlen(cs->aRemotes[i].zName);
-    int urlLen = (int)strlen(cs->aRemotes[i].zUrl);
-    CS_WRITE_U32(bufCur,nameLen); bufCur+=4;
-    memcpy(bufCur, cs->aRemotes[i].zName, nameLen); bufCur+=nameLen;
-    CS_WRITE_U32(bufCur,urlLen); bufCur+=4;
-    memcpy(bufCur, cs->aRemotes[i].zUrl, urlLen); bufCur+=urlLen;
-  }
-
-  CS_WRITE_U32(bufCur,cs->nTracking); bufCur+=4;
-  for(i=0; i<cs->nTracking; i++){
-    int remoteLen = (int)strlen(cs->aTracking[i].zRemote);
-    int branchLen = (int)strlen(cs->aTracking[i].zBranch);
-    CS_WRITE_U32(bufCur,remoteLen); bufCur+=4;
-    memcpy(bufCur, cs->aTracking[i].zRemote, remoteLen); bufCur+=remoteLen;
-    CS_WRITE_U32(bufCur,branchLen); bufCur+=4;
-    memcpy(bufCur, cs->aTracking[i].zBranch, branchLen); bufCur+=branchLen;
-    memcpy(bufCur, cs->aTracking[i].commitHash.data, PROLLY_HASH_SIZE); bufCur+=PROLLY_HASH_SIZE;
-  }
-
-  *ppOut = buf;
-  *pnOut = sz;
-  return SQLITE_OK;
+  return csSerializeRefsBlob(cs, ppOut, pnOut);
 }
 
 int chunkStoreHas(ChunkStore *cs, const ProllyHash *hash){
@@ -1750,7 +1690,7 @@ int chunkStoreRefreshIfChanged(ChunkStore *cs, int *pChanged){
     int exists = 0;
     rc = sqlite3OsAccess(cs->pVfs, cs->zFilename,
                          SQLITE_ACCESS_EXISTS, &exists);
-    if( rc!=SQLITE_OK ) return SQLITE_OK;
+    if( rc!=SQLITE_OK ) return rc;
     if( exists ){
       struct stat mainStat;
       if( stat(cs->zFilename, &mainStat)==0 && mainStat.st_size > 0 ){
@@ -1770,12 +1710,12 @@ int chunkStoreRefreshIfChanged(ChunkStore *cs, int *pChanged){
   }
 
   rc = sqlite3OsFileControl(cs->pFile, SQLITE_FCNTL_HAS_MOVED, &bMoved);
-  if( rc!=SQLITE_OK ) return SQLITE_OK;
+  if( rc!=SQLITE_OK ) return rc;
 
   if( !bMoved ){
     i64 fileSize = 0;
     rc = sqlite3OsFileSize(cs->pFile, &fileSize);
-    if( rc!=SQLITE_OK ) return SQLITE_OK;
+    if( rc!=SQLITE_OK ) return rc;
     if( fileSize > cs->iFileSize ){
       /* File grew from another writer; re-read WAL to pick up new chunks.
       ** Must also clear WAL-offset entries from the index because committed

--- a/src/doltlite_http_remote.c
+++ b/src/doltlite_http_remote.c
@@ -35,6 +35,21 @@ struct HttpRemote {
   int nPendingRefs;
 };
 
+static int writeAll(int fd, const void *pBuf, int nBuf){
+  int nWritten = 0;
+  const u8 *p = (const u8*)pBuf;
+  while( nWritten < nBuf ){
+    ssize_t n = write(fd, p + nWritten, nBuf - nWritten);
+    if( n < 0 ){
+      if( errno==EINTR ) continue;
+      return SQLITE_IOERR_WRITE;
+    }
+    if( n == 0 ) return SQLITE_IOERR_WRITE;
+    nWritten += (int)n;
+  }
+  return SQLITE_OK;
+}
+
 static void hashToHex(const ProllyHash *pHash, char *zOut){
   static const char hex[] = "0123456789abcdef";
   int i;
@@ -136,17 +151,11 @@ static int httpRequest(
   }
 
   
-  {
-    ssize_t nSent = write(fd, aReqHdr, nReqHdr);
-    if( nSent != nReqHdr ){ close(fd); return SQLITE_ERROR; }
-  }
+  rc = writeAll(fd, aReqHdr, nReqHdr);
+  if( rc != SQLITE_OK ){ close(fd); return rc; }
   if( pBody && nBody > 0 ){
-    int nOff = 0;
-    while( nOff < nBody ){
-      ssize_t n = write(fd, pBody + nOff, nBody - nOff);
-      if( n <= 0 ){ close(fd); return SQLITE_ERROR; }
-      nOff += (int)n;
-    }
+    rc = writeAll(fd, pBody, nBody);
+    if( rc != SQLITE_OK ){ close(fd); return rc; }
   }
 
   

--- a/src/doltlite_remotesrv.c
+++ b/src/doltlite_remotesrv.c
@@ -23,6 +23,7 @@ int doltliteServerPort(DoltliteServer *s){ (void)s; return 0; }
 #include <unistd.h>
 #include <pthread.h>
 #include <poll.h>
+#include <errno.h>
 
 struct DoltliteServer {
   int listenFd;          
@@ -50,6 +51,21 @@ static int hexToHash(const char *zHex, ProllyHash *pHash){
   return SQLITE_OK;
 }
 
+static int writeAll(int fd, const void *pBuf, int nBuf){
+  int nWritten = 0;
+  const u8 *p = (const u8*)pBuf;
+  while( nWritten < nBuf ){
+    ssize_t n = write(fd, p + nWritten, nBuf - nWritten);
+    if( n<0 ){
+      if( errno==EINTR ) continue;
+      return SQLITE_IOERR_WRITE;
+    }
+    if( n==0 ) return SQLITE_IOERR_WRITE;
+    nWritten += (int)n;
+  }
+  return SQLITE_OK;
+}
+
 static void sendResponse(int fd, int status, const char *zStatus,
                          const u8 *pBody, int nBody){
   char zHeader[256];
@@ -61,9 +77,9 @@ static void sendResponse(int fd, int status, const char *zStatus,
     "\r\n",
     status, zStatus, nBody);
   nHeader = (int)strlen(zHeader);
-  write(fd, zHeader, nHeader);
+  if( writeAll(fd, zHeader, nHeader)!=SQLITE_OK ) return;
   if( pBody && nBody>0 ){
-    write(fd, pBody, nBody);
+    writeAll(fd, pBody, nBody);
   }
 }
 
@@ -214,6 +230,23 @@ static int parsePath(
   zEndpoint[epLen] = '\0';
 
   return 0;
+}
+
+static int isSafeDbName(const char *zDbName){
+  int i;
+  if( zDbName[0]=='.' && zDbName[1]=='\0' ) return 0;
+  if( zDbName[0]=='.' && zDbName[1]=='.' && zDbName[2]=='\0' ) return 0;
+  for(i=0; zDbName[i]; i++){
+    char c = zDbName[i];
+    if( (c>='a' && c<='z')
+     || (c>='A' && c<='Z')
+     || (c>='0' && c<='9')
+     || c=='_' || c=='-' || c=='.' ){
+      continue;
+    }
+    return 0;
+  }
+  return 1;
 }
 
 static void handleGetRoot(ChunkStore *pStore, int fd){
@@ -448,6 +481,11 @@ static void handleRequest(DoltliteServer *pSrv, int fd){
   
   if( parsePath(zPath, zDbName, sizeof(zDbName),
                 zEndpoint, sizeof(zEndpoint))!=0 ){
+    sendNotFound(fd);
+    sqlite3_free(pBody);
+    return;
+  }
+  if( !isSafeDbName(zDbName) ){
     sendNotFound(fd);
     sqlite3_free(pBody);
     return;

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -10,6 +10,7 @@
 **   ./doltlite_regression_test_c concurrent_refs
 **   ./doltlite_regression_test_c checkout_persist_failure
 **   ./doltlite_regression_test_c savepoint_catalog_restore
+**   ./doltlite_regression_test_c refs_blob_corruption
 */
 #include <stdio.h>
 #include <stdlib.h>
@@ -17,6 +18,7 @@
 #include <unistd.h>
 #include "sqlite3.h"
 #include "prolly_hash.h"
+#include "chunk_store.h"
 
 typedef unsigned char u8;
 typedef unsigned int Pgno;
@@ -124,7 +126,12 @@ struct FailFile {
 static sqlite3_vfs gFailVfs;
 static sqlite3_vfs *gBaseVfs = 0;
 static int gFailSyncOnce = 0;
+static int gFailAccessOnce = 0;
+static int gFailHasMovedOnce = 0;
+static int gFailFileSizeOnce = 0;
 static int gFailHits = 0;
+
+static int failAccess(sqlite3_vfs *pVfs, const char *zName, int flags, int *pResOut);
 
 static int failClose(sqlite3_file *pFile){
   FailFile *p = (FailFile*)pFile;
@@ -158,6 +165,11 @@ static int failSync(sqlite3_file *pFile, int flags){
 
 static int failFileSize(sqlite3_file *pFile, sqlite3_int64 *pSize){
   FailFile *p = (FailFile*)pFile;
+  if( gFailFileSizeOnce>0 ){
+    gFailFileSizeOnce--;
+    gFailHits++;
+    return SQLITE_IOERR;
+  }
   return p->pReal->pMethods->xFileSize(p->pReal, pSize);
 }
 
@@ -178,6 +190,11 @@ static int failCheckReservedLock(sqlite3_file *pFile, int *pResOut){
 
 static int failFileControl(sqlite3_file *pFile, int op, void *pArg){
   FailFile *p = (FailFile*)pFile;
+  if( op==SQLITE_FCNTL_HAS_MOVED && gFailHasMovedOnce>0 ){
+    gFailHasMovedOnce--;
+    gFailHits++;
+    return SQLITE_IOERR;
+  }
   return p->pReal->pMethods->xFileControl(p->pReal, op, pArg);
 }
 
@@ -275,7 +292,18 @@ static int registerFailVfs(void){
   gFailVfs.zName = "doltlite-failvfs";
   gFailVfs.szOsFile = sizeof(FailFile) + gBaseVfs->szOsFile;
   gFailVfs.xOpen = failOpen;
+  gFailVfs.xAccess = failAccess;
   return sqlite3_vfs_register(&gFailVfs, 0);
+}
+
+static int failAccess(sqlite3_vfs *pVfs, const char *zName, int flags, int *pResOut){
+  (void)pVfs;
+  if( gFailAccessOnce>0 ){
+    gFailAccessOnce--;
+    gFailHits++;
+    return SQLITE_IOERR;
+  }
+  return gBaseVfs->xAccess(gBaseVfs, zName, flags, pResOut);
 }
 
 static int open_fail_db(const char *path, sqlite3 **ppDb){
@@ -454,10 +482,109 @@ static void run_savepoint_catalog_restore(void){
   sqlite3_close(db);
 }
 
+static void run_refs_blob_corruption(void){
+  ChunkStore cs;
+  ChunkStore cs2;
+  u8 *pBlob = 0;
+  int nBlob = 0;
+  int rc;
+
+  printf("=== Refs Blob Corruption Test ===\n\n");
+  printf("--- Test 1: truncated refs blob is rejected ---\n");
+
+  check("open_mem_store_1",
+        chunkStoreOpen(&cs, sqlite3_vfs_find(0), ":memory:", 0)==SQLITE_OK);
+  check("open_mem_store_2",
+        chunkStoreOpen(&cs2, sqlite3_vfs_find(0), ":memory:", 0)==SQLITE_OK);
+
+  check("set_default_branch",
+        chunkStoreSetDefaultBranch(&cs, "main")==SQLITE_OK);
+  cs.aBranches = sqlite3_malloc(sizeof(*cs.aBranches));
+  check("alloc_branch_ref", cs.aBranches!=0);
+  if( cs.aBranches ){
+    memset(cs.aBranches, 0, sizeof(*cs.aBranches));
+    cs.nBranches = 1;
+    cs.aBranches[0].zName = sqlite3_mprintf("main");
+    check("alloc_branch_name", cs.aBranches[0].zName!=0);
+  }
+
+  cs.aTags = sqlite3_malloc(sizeof(*cs.aTags));
+  check("alloc_tag_ref", cs.aTags!=0);
+  if( cs.aTags ){
+    memset(cs.aTags, 0, sizeof(*cs.aTags));
+    cs.nTags = 1;
+    cs.aTags[0].zName = sqlite3_mprintf("v1");
+    check("alloc_tag_name", cs.aTags[0].zName!=0);
+  }
+
+  check("serialize_refs_blob",
+        chunkStoreSerializeRefsToBlob(&cs, &pBlob, &nBlob)==SQLITE_OK);
+  check("refs_blob_has_tag_payload", nBlob>0);
+
+  rc = chunkStoreLoadRefsFromBlob(&cs2, pBlob, nBlob-20);
+  check("truncated_blob_returns_corrupt", rc==SQLITE_CORRUPT);
+
+  sqlite3_free(pBlob);
+  chunkStoreClose(&cs2);
+  chunkStoreClose(&cs);
+}
+
+static void run_refresh_error_propagation(void){
+  sqlite3 *db = 0;
+  ChunkStore cs;
+  int changed = -1;
+  int rc;
+  char dbpath[256];
+
+  printf("=== Refresh Error Propagation Test ===\n\n");
+  check("register_fail_vfs_for_refresh", registerFailVfs()==SQLITE_OK);
+
+  printf("--- Test 1: xAccess failure is surfaced ---\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_refresh_access_failure");
+  remove_db(dbpath);
+  check("open_empty_chunk_store",
+        chunkStoreOpen(&cs, &gFailVfs, dbpath,
+          SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB)==SQLITE_OK);
+  gFailHits = 0;
+  gFailAccessOnce = 1;
+  changed = -1;
+  rc = chunkStoreRefreshIfChanged(&cs, &changed);
+  check("refresh_returns_access_error", rc!=SQLITE_OK);
+  check("access_failure_injected", gFailHits>0);
+  check("changed_left_false_on_access_error", changed==0);
+  chunkStoreClose(&cs);
+  remove_db(dbpath);
+
+  printf("--- Test 2: xFileControl failure is surfaced ---\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_refresh_filecontrol_failure");
+  remove_db(dbpath);
+  check("open_sql_db", open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_doltlite_repo", execsql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'a');"
+    "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
+  sqlite3_close(db);
+  db = 0;
+  check("open_chunk_store_with_file",
+        chunkStoreOpen(&cs, &gFailVfs, dbpath,
+          SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB)==SQLITE_OK);
+  gFailHits = 0;
+  gFailHasMovedOnce = 1;
+  changed = -1;
+  rc = chunkStoreRefreshIfChanged(&cs, &changed);
+  check("refresh_returns_filecontrol_error", rc!=SQLITE_OK);
+  check("filecontrol_failure_injected", gFailHits>0);
+  check("changed_left_false_on_filecontrol_error", changed==0);
+  chunkStoreClose(&cs);
+  remove_db(dbpath);
+}
+
 static const RegressionCase aCases[] = {
   { "concurrent_refs", "Concurrent Refs Test", run_concurrent_refs },
   { "checkout_persist_failure", "Checkout Persist Failure Test", run_checkout_persist_failure },
-  { "savepoint_catalog_restore", "Savepoint Catalog Restore Test", run_savepoint_catalog_restore }
+  { "savepoint_catalog_restore", "Savepoint Catalog Restore Test", run_savepoint_catalog_restore },
+  { "refs_blob_corruption", "Refs Blob Corruption Test", run_refs_blob_corruption },
+  { "refresh_error_propagation", "Refresh Error Propagation Test", run_refresh_error_propagation }
 };
 
 static int run_case_by_name(const char *zName){

--- a/test/http_remote_test.sh
+++ b/test/http_remote_test.sh
@@ -48,11 +48,60 @@ echo "=== Building embedded HTTP test binary ==="
 # Write a C test that starts server async, runs operations, verifies
 cat > "$TMPDIR/http_test.c" << 'CEOF'
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #include <sys/stat.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <errno.h>
+#include <dlfcn.h>
 #include "sqlite3.h"
 #include "doltlite_remotesrv.h"
+
+static int gShortWriteOnce = 0;
+
+static void enable_short_write_once(void) {
+  gShortWriteOnce = 1;
+}
+
+static ssize_t call_real_write(int fd, const void *buf, size_t count) {
+#ifdef __APPLE__
+  static ssize_t (*xRealWrite)(int, const void*, size_t) = 0;
+  if (!xRealWrite) {
+    xRealWrite = (ssize_t (*)(int, const void*, size_t))dlsym(RTLD_NEXT, "write");
+  }
+  return xRealWrite(fd, buf, count);
+#else
+  return write(fd, buf, count);
+#endif
+}
+
+static ssize_t short_write_interceptor(int fd, const void *buf, size_t count) {
+  if (gShortWriteOnce > 0 && count > 1) {
+    int soType = 0;
+    socklen_t nOpt = sizeof(soType);
+    if (getsockopt(fd, SOL_SOCKET, SO_TYPE, &soType, &nOpt) == 0) {
+      size_t nShort = count / 2;
+      if (nShort < 1) nShort = 1;
+      gShortWriteOnce--;
+      return call_real_write(fd, buf, nShort);
+    }
+  }
+  return call_real_write(fd, buf, count);
+}
+
+#ifdef __APPLE__
+__attribute__((used))
+static struct {
+  const void *replacement;
+  const void *replacee;
+} write_interposers[]
+__attribute__((section("__DATA,__interpose"))) = {
+  { (const void*)short_write_interceptor, (const void*)write }
+};
+#endif
 
 static int run_sql(sqlite3 *db, const char *sql) {
   char *err = 0;
@@ -93,6 +142,51 @@ static int query_int(sqlite3 *db, const char *sql) {
     sqlite3_finalize(stmt);
   }
   return val;
+}
+
+static int raw_http_status(int port, const char *path) {
+  int fd, n;
+  struct sockaddr_in addr;
+  char req[512];
+  char resp[1024];
+  char *p;
+  int nOff = 0;
+
+  fd = socket(AF_INET, SOCK_STREAM, 0);
+  if (fd < 0) return -1;
+
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons((unsigned short)port);
+  addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  if (connect(fd, (struct sockaddr*)&addr, sizeof(addr)) != 0) {
+    close(fd);
+    return -1;
+  }
+
+  n = snprintf(req, sizeof(req),
+    "GET %s HTTP/1.1\r\n"
+    "Host: 127.0.0.1\r\n"
+    "Connection: close\r\n"
+    "\r\n",
+    path);
+  while (nOff < n) {
+    int nSent = (int)send(fd, req + nOff, n - nOff, 0);
+    if (nSent <= 0) {
+      close(fd);
+      return -1;
+    }
+    nOff += nSent;
+  }
+
+  n = (int)read(fd, resp, sizeof(resp)-1);
+  close(fd);
+  if (n <= 0) return -1;
+  resp[n] = 0;
+
+  p = strchr(resp, ' ');
+  if (!p) return -1;
+  return atoi(p + 1);
 }
 
 #define CHECK(desc, expected, actual) do { \
@@ -148,6 +242,28 @@ int main(int argc, char **argv) {
   printf("  Server started on port %d\n", port);
   CHECK("server started", 1, port > 0);
   usleep(100000);
+
+  /* ============================================================
+   * 2b. Invalid traversal-like paths are rejected
+   * ============================================================ */
+  printf("=== 2b. Reject traversal-like paths ===\n");
+  CHECK("parent path returns 404", 404, raw_http_status(port, "/../root"));
+  CHECK("dot path returns 404", 404, raw_http_status(port, "/./root"));
+
+  /* ============================================================
+   * 2c. Short-write transport handling
+   * ============================================================ */
+  printf("=== 2c. Short-write transport handling ===\n");
+  enable_short_write_once();
+  CHECK("server response survives short write", 200, raw_http_status(port, "/src.db/root"));
+  sqlite3 *shortCloneDb;
+  snprintf(path, sizeof(path), "%s/short_clone.db", tmpdir);
+  sqlite3_open(path, &shortCloneDb);
+  snprintf(sql, sizeof(sql), "SELECT dolt_clone('http://127.0.0.1:%d/src.db')", port);
+  enable_short_write_once();
+  CHECK("client request survives short write", SQLITE_OK, run_sql(shortCloneDb, sql));
+  CHECK("short-write clone has 3 users", 3, query_int(shortCloneDb, "SELECT count(*) FROM users"));
+  sqlite3_close(shortCloneDb);
 
   /* ============================================================
    * 3. Clone via HTTP - verify all data, branch, remote, history


### PR DESCRIPTION
## Summary
- harden the HTTP remote server and client against path traversal and short-write transport bugs
- make chunk store refresh propagate filesystem errors and reject truncated refs blobs
- add direct regression coverage for refresh syscall failures and short-write socket behavior

## Testing
- bash ../test/doltlite_regression_test_c.sh
- bash ../test/http_remote_test.sh
- bash ../test/remote_test.sh