### PR TITLE
Fix #318 WITHOUT ROWID REPLACE conflict detection

### DIFF
--- a/src/insert.c
+++ b/src/insert.c
@@ -2495,6 +2495,7 @@ void sqlite3GenerateConstraintChecks(
     ** is invoked.  */
     assert( IsOrdinaryTable(pTab) );
 #ifndef SQLITE_ENABLE_PREUPDATE_HOOK
+#ifndef DOLTLITE_PROLLY
     if( (ix==0 && pIdx->pNext==0)                   /* Condition 3 */
      && pPk==pIdx                                   /* Condition 2 */
      && onError==OE_Replace                         /* Condition 1 */
@@ -2506,6 +2507,7 @@ void sqlite3GenerateConstraintChecks(
       sqlite3VdbeResolveLabel(v, addrUniqueOk);
       continue;
     }
+#endif
 #endif /* ifndef SQLITE_ENABLE_PREUPDATE_HOOK */
 
     /* Check to see if the new index entry will be unique */

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -3297,17 +3297,18 @@ static int serializeUnpackedRecord(UnpackedRecord *pRec, u8 **ppOut, int *pnOut)
 
 static int findMatchingMutMapEntry(
   ProllyMutMap *pMap,
+  KeyInfo *pKeyInfo,
   UnpackedRecord *pIdxKey,
   const u8 *pSortKey,
   int nSortKey,
   ProllyMutMapEntry **ppMatch,
   int *pCmp
 ){
-  ProllyMutMapIter it;
   int rc = SQLITE_OK;
   int cmp = 0;
   ProllyMutMapEntry *pMatch = 0;
   u8 *pRecBuf = 0;
+  int lo, hi;
 
   *ppMatch = 0;
   *pCmp = 0;
@@ -3315,20 +3316,26 @@ static int findMatchingMutMapEntry(
     return SQLITE_OK;
   }
 
-  (void)pSortKey;
-  (void)nSortKey;
-  prollyMutMapIterFirst(&it, pMap);
-  while( prollyMutMapIterValid(&it) ){
-    ProllyMutMapEntry *pEntry = prollyMutMapIterEntry(&it);
+  if( pKeyInfo
+   && pIdxKey->nField >= pKeyInfo->nAllField ){
+    ProllyMutMapEntry *pEntry = prollyMutMapFind(pMap, pSortKey, nSortKey, 0);
+    if( pEntry && pEntry->op==PROLLY_EDIT_INSERT ){
+      *ppMatch = pEntry;
+    }
+    return SQLITE_OK;
+  }
+
+  lo = 0;
+  hi = pMap->nEntries;
+  while( lo < hi ){
+    int mid = lo + (hi - lo) / 2;
+    ProllyMutMapEntry *pEntry = &pMap->aEntries[mid];
     const u8 *pRec = pEntry->pVal;
     int nRec = pEntry->nVal;
+    int isLess;
 
     if( pEntry->isIntKey ){
-      prollyMutMapIterNext(&it);
-      continue;
-    }
-    if( pEntry->op!=PROLLY_EDIT_INSERT ){
-      prollyMutMapIterNext(&it);
+      lo = mid + 1;
       continue;
     }
     if( nRec==0 ){
@@ -3340,11 +3347,40 @@ static int findMatchingMutMapEntry(
     }
     pIdxKey->eqSeen = 0;
     cmp = sqlite3VdbeRecordCompare(nRec, pRec, pIdxKey);
-    if( cmp==0 || pIdxKey->eqSeen ){
+    isLess = (cmp<0 && !pIdxKey->eqSeen);
+    if( isLess ){
+      lo = mid + 1;
+    }else{
+      hi = mid;
+    }
+  }
+
+  while( rc==SQLITE_OK && lo < pMap->nEntries ){
+    ProllyMutMapEntry *pEntry = &pMap->aEntries[lo];
+    const u8 *pRec = pEntry->pVal;
+    int nRec = pEntry->nVal;
+
+    if( pEntry->isIntKey ){
+      lo++;
+      continue;
+    }
+    if( nRec==0 ){
+      sqlite3_free(pRecBuf);
+      pRecBuf = 0;
+      rc = recordFromSortKey(pEntry->pKey, pEntry->nKey, &pRecBuf, &nRec);
+      if( rc!=SQLITE_OK ) break;
+      pRec = pRecBuf;
+    }
+    pIdxKey->eqSeen = 0;
+    cmp = sqlite3VdbeRecordCompare(nRec, pRec, pIdxKey);
+    if( cmp!=0 && !pIdxKey->eqSeen ){
+      break;
+    }
+    if( pEntry->op==PROLLY_EDIT_INSERT ){
       pMatch = pEntry;
       break;
     }
-    prollyMutMapIterNext(&it);
+    lo++;
   }
 
   sqlite3_free(pRecBuf);
@@ -3538,6 +3574,7 @@ static int prollyBtCursorIndexMoveto(
        && !(treeFound && treeCmp==0) ){
       ProllyMutMapEntry *mutE = 0;
       rc = findMatchingMutMapEntry((ProllyMutMap*)pCur->pMutMap,
+                                   pCur->pKeyInfo,
                                    pIdxKey, pSortKey, nSortKey,
                                    &mutE, &mutCmp);
       if( rc!=SQLITE_OK ){
@@ -3547,6 +3584,7 @@ static int prollyBtCursorIndexMoveto(
       }
       if( !mutE && pPending && pPending!=pCur->pMutMap ){
         rc = findMatchingMutMapEntry(pPending,
+                                     pCur->pKeyInfo,
                                      pIdxKey, pSortKey, nSortKey,
                                      &mutE, &mutCmp);
         if( rc!=SQLITE_OK ){

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -3295,6 +3295,66 @@ static int serializeUnpackedRecord(UnpackedRecord *pRec, u8 **ppOut, int *pnOut)
   return SQLITE_OK;
 }
 
+static int findMatchingMutMapEntry(
+  ProllyMutMap *pMap,
+  UnpackedRecord *pIdxKey,
+  const u8 *pSortKey,
+  int nSortKey,
+  ProllyMutMapEntry **ppMatch,
+  int *pCmp
+){
+  ProllyMutMapIter it;
+  int rc = SQLITE_OK;
+  int cmp = 0;
+  ProllyMutMapEntry *pMatch = 0;
+  u8 *pRecBuf = 0;
+
+  *ppMatch = 0;
+  *pCmp = 0;
+  if( !pMap || prollyMutMapIsEmpty(pMap) ){
+    return SQLITE_OK;
+  }
+
+  (void)pSortKey;
+  (void)nSortKey;
+  prollyMutMapIterFirst(&it, pMap);
+  while( prollyMutMapIterValid(&it) ){
+    ProllyMutMapEntry *pEntry = prollyMutMapIterEntry(&it);
+    const u8 *pRec = pEntry->pVal;
+    int nRec = pEntry->nVal;
+
+    if( pEntry->isIntKey ){
+      prollyMutMapIterNext(&it);
+      continue;
+    }
+    if( pEntry->op!=PROLLY_EDIT_INSERT ){
+      prollyMutMapIterNext(&it);
+      continue;
+    }
+    if( nRec==0 ){
+      sqlite3_free(pRecBuf);
+      pRecBuf = 0;
+      rc = recordFromSortKey(pEntry->pKey, pEntry->nKey, &pRecBuf, &nRec);
+      if( rc!=SQLITE_OK ) break;
+      pRec = pRecBuf;
+    }
+    pIdxKey->eqSeen = 0;
+    cmp = sqlite3VdbeRecordCompare(nRec, pRec, pIdxKey);
+    if( cmp==0 || pIdxKey->eqSeen ){
+      pMatch = pEntry;
+      break;
+    }
+    prollyMutMapIterNext(&it);
+  }
+
+  sqlite3_free(pRecBuf);
+  if( rc==SQLITE_OK && pMatch ){
+    *ppMatch = pMatch;
+    *pCmp = cmp;
+  }
+  return rc;
+}
+
 static int prollyBtCursorIndexMoveto(
   BtCursor *pCur,
   UnpackedRecord *pIdxKey,
@@ -3469,12 +3529,33 @@ static int prollyBtCursorIndexMoveto(
 
     
     
-    if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap)
-     && !(treeFound && treeCmp==0) ){
-      
-      ProllyMutMapEntry *mutE = prollyMutMapFind(
-          pCur->pMutMap, pSortKey, nSortKey, 0);
-      if( mutE && mutE->op==PROLLY_EDIT_INSERT ){
+    {
+      struct TableEntry *pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
+      ProllyMutMap *pPending = pTE ? (ProllyMutMap*)pTE->pPending : 0;
+      if( ((pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap))
+         || (pPending && pPending!=pCur->pMutMap
+             && !prollyMutMapIsEmpty(pPending)))
+       && !(treeFound && treeCmp==0) ){
+      ProllyMutMapEntry *mutE = 0;
+      rc = findMatchingMutMapEntry((ProllyMutMap*)pCur->pMutMap,
+                                   pIdxKey, pSortKey, nSortKey,
+                                   &mutE, &mutCmp);
+      if( rc!=SQLITE_OK ){
+        sqlite3_free(pSerKey);
+        sqlite3_free(pSortKey);
+        return rc;
+      }
+      if( !mutE && pPending && pPending!=pCur->pMutMap ){
+        rc = findMatchingMutMapEntry(pPending,
+                                     pIdxKey, pSortKey, nSortKey,
+                                     &mutE, &mutCmp);
+        if( rc!=SQLITE_OK ){
+          sqlite3_free(pSerKey);
+          sqlite3_free(pSortKey);
+          return rc;
+        }
+      }
+      if( mutE ){
         
         const u8 *pMutVal = mutE->pVal;
         int nMutVal = mutE->nVal;
@@ -3484,16 +3565,13 @@ static int prollyBtCursorIndexMoveto(
           pMutVal = pRecon;
         }
         if( pMutVal ){
-          pIdxKey->eqSeen = 0;
-          mutCmp = sqlite3VdbeRecordCompare(nMutVal, pMutVal, pIdxKey);
-          if( mutCmp==0 || pIdxKey->eqSeen ){
-            mutKey = pMutVal;
-            mutNKey = nMutVal;
-            mutFound = 1;
-          }
+          mutKey = pMutVal;
+          mutNKey = nMutVal;
+          mutFound = 1;
         }
         if( !mutFound ) sqlite3_free(pRecon);
       }
+    }
     }
     sqlite3_free(pSerKey);
     sqlite3_free(pSortKey);

--- a/test/index_oracle_test.sh
+++ b/test/index_oracle_test.sh
@@ -751,6 +751,18 @@ SELECT a, b, c FROM t ORDER BY a, b;
 SELECT count(*) FROM t WHERE c > 1000;
 "
 
+# 6g2. WITHOUT ROWID PK conflict sees prior deferred replace in same tx
+oracle "cat6_without_rowid_replace_same_tx" "
+CREATE TABLE t(a INT, b INT, c INT, PRIMARY KEY(a, b)) WITHOUT ROWID;
+BEGIN;
+INSERT INTO t VALUES(1, 1, 100);
+REPLACE INTO t VALUES(1, 1, 200);
+REPLACE INTO t VALUES(1, 1, 300);
+SELECT a, b, c FROM t ORDER BY a, b, c;
+SELECT count(*) FROM t;
+COMMIT;
+"
+
 # 6h. Partial index: CREATE INDEX idx ON t(a) WHERE a IS NOT NULL
 oracle "cat6_partial_index" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, a INT);


### PR DESCRIPTION
## Summary
- fix same-transaction REPLACE on WITHOUT ROWID tables so prior deferred rows are seen during conflict detection
- disable the unsafe WITHOUT ROWID REPLACE fast path for the prolly storage engine
- add an oracle regression for sequential REPLACE on a composite PK in one transaction

Fixes #318

## Testing
- bash ../test/index_oracle_test.sh ./doltlite sqlite3