### PR TITLE
Fix deferred-row update loop in transactions

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -2791,6 +2791,30 @@ static int mergeStepBackward(BtCursor *pCur){
   return mergeScan(pCur, -1, 0);
 }
 
+static int seedMutMapIterFromCursor(
+  BtCursor *pCur,
+  ProllyMutMapIter *pIt
+){
+  if( pCur->curIntKey ){
+    if( pCur->curFlags & BTCF_ValidNKey ){
+      prollyMutMapIterSeek(pIt, pCur->pMutMap, 0, 0, pCur->cachedIntKey);
+      return SQLITE_OK;
+    }
+  }else{
+    if( pCur->pCachedPayload && pCur->nCachedPayload > 0 ){
+      u8 *pSortKey = 0;
+      int nSortKey = 0;
+      int rc = sortKeyFromRecord(pCur->pCachedPayload, pCur->nCachedPayload,
+                                 &pSortKey, &nSortKey);
+      if( rc!=SQLITE_OK ) return rc;
+      prollyMutMapIterSeek(pIt, pCur->pMutMap, pSortKey, nSortKey, 0);
+      sqlite3_free(pSortKey);
+      return SQLITE_OK;
+    }
+  }
+  return SQLITE_NOTFOUND;
+}
+
 static int mergeFirst(BtCursor *pCur, int *pRes){
   pCur->mergeSrc = MERGE_SRC_TREE;
   pCur->mmIdx = 0;
@@ -2947,6 +2971,7 @@ static int prollyBtCursorNext(BtCursor *pCur, int flags){
     
     if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
       ProllyMutMapIter it;
+      rc = SQLITE_OK;
       if( pCur->curIntKey && prollyCursorIsValid(&pCur->pCur) ){
         prollyMutMapIterSeek(&it, pCur->pMutMap, 0, 0,
                              prollyCursorIntKey(&pCur->pCur));
@@ -2954,6 +2979,12 @@ static int prollyBtCursorNext(BtCursor *pCur, int flags){
         const u8 *pK; int nK;
         prollyCursorKey(&pCur->pCur, &pK, &nK);
         prollyMutMapIterSeek(&it, pCur->pMutMap, pK, nK, 0);
+      }else if( pCur->eState==CURSOR_VALID ){
+        rc = seedMutMapIterFromCursor(pCur, &it);
+        if( rc!=SQLITE_OK && rc!=SQLITE_NOTFOUND ) return rc;
+        if( rc==SQLITE_NOTFOUND ){
+          prollyMutMapIterFirst(&it, pCur->pMutMap);
+        }
       }else{
         prollyMutMapIterFirst(&it, pCur->pMutMap);
       }
@@ -3037,6 +3068,7 @@ static int prollyBtCursorPrevious(BtCursor *pCur, int flags){
   }else{
     if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
       ProllyMutMapIter it;
+      rc = SQLITE_OK;
       if( pCur->curIntKey && prollyCursorIsValid(&pCur->pCur) ){
         prollyMutMapIterSeek(&it, pCur->pMutMap, 0, 0,
                              prollyCursorIntKey(&pCur->pCur));
@@ -3044,6 +3076,12 @@ static int prollyBtCursorPrevious(BtCursor *pCur, int flags){
         const u8 *pK; int nK;
         prollyCursorKey(&pCur->pCur, &pK, &nK);
         prollyMutMapIterSeek(&it, pCur->pMutMap, pK, nK, 0);
+      }else if( pCur->eState==CURSOR_VALID ){
+        rc = seedMutMapIterFromCursor(pCur, &it);
+        if( rc!=SQLITE_OK && rc!=SQLITE_NOTFOUND ) return rc;
+        if( rc==SQLITE_NOTFOUND ){
+          prollyMutMapIterLast(&it, pCur->pMutMap);
+        }
       }else{
         prollyMutMapIterLast(&it, pCur->pMutMap);
       }

--- a/test/doltlite_issue319.sh
+++ b/test/doltlite_issue319.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+#
+# Regression test for GitHub issue #319
+#
+# Updating rows that exist only in the current transaction's deferred
+# MutMap must advance through those rows exactly once instead of looping.
+#
+set -euo pipefail
+
+DOLTLITE=./doltlite
+PASS=0
+FAIL=0
+ERRORS=""
+
+run_test() {
+  local name="$1"
+  local sql="$2"
+  local expected="$3"
+  local db="$4"
+  local result
+  result=$(printf "%s\n" "$sql" | perl -e 'alarm(10); exec @ARGV' "$DOLTLITE" "$db" 2>&1)
+  if [ "$result" = "$expected" ]; then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1))
+    ERRORS="$ERRORS\nFAIL: $name\n  expected: $expected\n  got:      $result"
+  fi
+}
+
+echo "=== Issue #319 Regression Tests ==="
+echo ""
+
+DB1=/tmp/test_issue319_$$.db
+rm -f "$DB1"
+run_test "issue319_update_rows_inserted_in_txn" \
+"CREATE TABLE t1(id INTEGER PRIMARY KEY, val INT);
+CREATE INDEX idx1 ON t1(val);
+BEGIN;
+INSERT INTO t1 VALUES(1,100),(2,200);
+UPDATE t1 SET val = val + 50;
+SELECT id, val FROM t1 ORDER BY id;
+COMMIT;" \
+"1|150
+2|250" "$DB1"
+
+DB2=/tmp/test_issue319_cross_table_repro_$$.db
+rm -f "$DB2"
+run_test "issue319_cross_table_repro" \
+"CREATE TABLE t1(id INTEGER PRIMARY KEY, val INT);
+CREATE TABLE t2(id INTEGER PRIMARY KEY, ref INT, data TEXT);
+CREATE INDEX idx1 ON t1(val);
+CREATE INDEX idx2 ON t2(ref);
+BEGIN;
+INSERT INTO t1 VALUES(1,100),(2,200);
+INSERT INTO t2 VALUES(1,1,'a'),(2,2,'b');
+UPDATE t1 SET val = val + 50;
+SELECT id, val FROM t1 ORDER BY id;
+SELECT id, ref, data FROM t2 ORDER BY id;
+COMMIT;" \
+"1|150
+2|250
+1|1|a
+2|2|b" "$DB2"
+
+rm -f "$DB1" "$DB2"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ $FAIL -gt 0 ]; then
+  echo -e "$ERRORS"
+  exit 1
+fi
+echo "All tests passed!"

--- a/test/run_doltlite_tests.sh
+++ b/test/run_doltlite_tests.sh
@@ -57,6 +57,7 @@ TESTS=(
   doltlite_gc_scale.sh
   doltlite_index_prefix.sh
   doltlite_issue179_180.sh
+  doltlite_issue319.sh
   doltlite_regression_test_c.sh
   review_regression_test.sh
 )


### PR DESCRIPTION
Fixes #319

## Summary
- preserve the current logical row when reseeding MutMap iteration during deferred-row scans
- add a focused regression for updates over rows inserted in the same transaction
- cover the original cross-table repro from #319

## Testing
- bash ../test/doltlite_issue319.sh
- bash ../test/index_oracle_test.sh ./doltlite sqlite3
- bash ../test/doltlite_issue179_180.sh