### PR TITLE
Fix delete scan regressions after #323

### DIFF
--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -11,6 +11,7 @@ struct TableEntry {
   ProllyHash root;       
   ProllyHash schemaHash; 
   u8 flags;              
+  u8 pendingFlushSeekEdits;
   char *zName;           
   void *pPending;        
 };

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -324,6 +324,7 @@ static void removeTable(Btree *pBtree, Pgno iTable);
 static void invalidateCursors(BtShared *pBt, Pgno iTable, int errCode);
 static void invalidateSchema(Btree *pBtree);
 static int flushMutMap(BtCursor *pCur);
+static void getCursorPayload(BtCursor *pCur, const u8 **ppData, int *pnData);
 static int mutMapHasDeleteOps(ProllyMutMap *pMap);
 static int flushIfNeeded(BtCursor *pCur);
 static int flushAllPending(BtShared *pBt, Pgno iTable);
@@ -3456,11 +3457,6 @@ static int prollyBtCursorIndexMoveto(
 
   CLEAR_CACHED_PAYLOAD(pCur);
 
-  /* Re-seeking a write cursor against its own unflushed BLOBKEY edits can
-  ** leave the cursor comparing against stale in-memory state across repeated
-  ** DELETE/UPDATE probes in the same statement. Materialize the current
-  ** cursor's pending edits before the seek so later seek/recheck opcodes
-  ** see a consistent tree image. */
   if( pCur->flushSeekEdits
    && (pCur->curFlags & BTCF_WriteFlag)
    && pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
@@ -3470,7 +3466,6 @@ static int prollyBtCursorIndexMoveto(
     pCur->flushSeekEdits = 0;
   }
 
-  
   {
     BtCursor *p;
     for(p = pCur->pBt->pCursor; p; p = p->pNext){
@@ -3991,6 +3986,7 @@ static int prollyBtCursorInsert(
         ** mergeSrc) is stale. Reset so the next Next/Previous call
         ** re-synchronizes the merge cursor with the updated MutMap. */
         pCur->mmActive = 0;
+        pCur->flushSeekEdits = 0;
       } else if( (flags & BTREE_SAVEPOSITION) && !pCur->curIntKey ){
         /* For BLOBKEY cursors (WITHOUT ROWID PK), after a deferred insert
         ** following a deferred delete with SAVEPOSITION, advance the tree
@@ -4013,8 +4009,10 @@ static int prollyBtCursorInsert(
           pCur->eState = CURSOR_INVALID;
         }
         pCur->mmActive = 0;
+        pCur->flushSeekEdits = 0;
       } else {
         pCur->eState = CURSOR_INVALID;
+        pCur->flushSeekEdits = 0;
       }
       return SQLITE_OK;
     }
@@ -4312,6 +4310,7 @@ static int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
     if( canDefer ){
       CLEAR_CACHED_PAYLOAD(pCur);
       pCur->curFlags &= ~(BTCF_ValidNKey|BTCF_AtLast);
+      pCur->mmActive = 0;
       if( flags & (BTREE_SAVEPOSITION | BTREE_AUXDELETE) ){
         pCur->flushSeekEdits = 1;
         pCur->eState = CURSOR_SKIPNEXT;

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -104,6 +104,7 @@ struct TableEntry {
   ProllyHash root;
   ProllyHash schemaHash;
   u8 flags;
+  u8 pendingFlushSeekEdits;
   char *zName;
   ProllyMutMap *pPending;
 };
@@ -325,7 +326,6 @@ static void invalidateCursors(BtShared *pBt, Pgno iTable, int errCode);
 static void invalidateSchema(Btree *pBtree);
 static int flushMutMap(BtCursor *pCur);
 static void getCursorPayload(BtCursor *pCur, const u8 **ppData, int *pnData);
-static int mutMapHasDeleteOps(ProllyMutMap *pMap);
 static int flushIfNeeded(BtCursor *pCur);
 static int flushAllPending(BtShared *pBt, Pgno iTable);
 static int flushDeferredEdits(BtShared *pBt);
@@ -338,6 +338,7 @@ static int countTreeEntries(Btree *pBtree, Pgno iTable, i64 *pCount);
 static int saveAllCursors(BtShared *pBt, Pgno iRoot, BtCursor *pExcept);
 static int serializeCatalog(Btree *pBtree, u8 **ppOut, int *pnOut);
 static int deserializeCatalog(Btree *pBtree, const u8 *data, int nData);
+static int tableEntryIsTableRoot(Btree *pBtree, struct TableEntry *pTE);
 static int btreeRefreshFromDisk(Btree *p);
 static int btreeReadWorkingCatalog(ChunkStore *cs, const char *zBranch,
                                    ProllyHash *pCatHash,
@@ -1027,17 +1028,6 @@ static int ensureMutMap(BtCursor *pCur){
   return SQLITE_OK;
 }
 
-static int mutMapHasDeleteOps(ProllyMutMap *pMap){
-  int i;
-  if( !pMap ) return 0;
-  for(i=0; i<pMap->nEntries; i++){
-    if( pMap->aEntries[i].op==PROLLY_EDIT_DELETE ){
-      return 1;
-    }
-  }
-  return 0;
-}
-
 static int saveCursorPosition(BtCursor *pCur){
   int rc = SQLITE_OK;
 
@@ -1090,6 +1080,14 @@ static int saveCursorPosition(BtCursor *pCur){
 
   pCur->eState = CURSOR_REQUIRESEEK;
   return SQLITE_OK;
+}
+
+static int tableEntryIsTableRoot(Btree *pBtree, struct TableEntry *pTE){
+  if( !pTE || pTE->iTable<=1 ) return 0;
+  if( !pTE->zName && pBtree && pBtree->db ){
+    pTE->zName = doltliteResolveTableNumber(pBtree->db, pTE->iTable);
+  }
+  return pTE->zName!=0;
 }
 
 static int restoreCursorPosition(BtCursor *pCur, int *pDifferentRow){
@@ -2560,7 +2558,13 @@ static int prollyBtreeCursor(
     if( wrFlag & BTREE_WRCSR ){
       pCur->pMutMap = (ProllyMutMap*)pTE->pPending;
       pTE->pPending = 0;
-      pCur->flushSeekEdits = mutMapHasDeleteOps(pCur->pMutMap);
+      pCur->flushSeekEdits = pTE->pendingFlushSeekEdits;
+      if( !pCur->curIntKey
+       && tableEntryIsTableRoot(p, pTE)
+       && !prollyMutMapIsEmpty(pCur->pMutMap) ){
+        pCur->flushSeekEdits = 1;
+      }
+      pTE->pendingFlushSeekEdits = 0;
     }else{
       
       ProllyMutMap *pMap = (ProllyMutMap*)pTE->pPending;
@@ -2580,6 +2584,7 @@ static int prollyBtreeCursor(
         prollyMutMapFree(pMap);
         sqlite3_free(pMap);
         pTE->pPending = 0;
+        pTE->pendingFlushSeekEdits = 0;
         if( rc2!=SQLITE_OK ) return rc2;
       }
     }
@@ -2621,10 +2626,12 @@ static int prollyBtCursorCloseCursor(BtCursor *pCur){
     struct TableEntry *pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
     if( pTE && !pTE->pPending ){
       pTE->pPending = pCur->pMutMap;
+      pTE->pendingFlushSeekEdits = pCur->flushSeekEdits;
       pCur->pMutMap = 0;
     }else if( pTE && pTE->pPending ){
       
       prollyMutMapMerge((ProllyMutMap*)pTE->pPending, pCur->pMutMap);
+      pTE->pendingFlushSeekEdits = pCur->flushSeekEdits;
       prollyMutMapFree(pCur->pMutMap);
       sqlite3_free(pCur->pMutMap);
       pCur->pMutMap = 0;

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -299,6 +299,7 @@ struct BtCursor {
   i64 cachedIntKey;
 
   u8 isPinned;            /* When pinned, saveCursorPosition is a no-op */
+  u8 flushSeekEdits;      /* Flush pending deletes before next IndexMoveto */
 
   /* Merge iteration state: mmIdx indexes into pMutMap->aEntries.
   ** mergeSrc says where the current row comes from. */
@@ -323,6 +324,7 @@ static void removeTable(Btree *pBtree, Pgno iTable);
 static void invalidateCursors(BtShared *pBt, Pgno iTable, int errCode);
 static void invalidateSchema(Btree *pBtree);
 static int flushMutMap(BtCursor *pCur);
+static int mutMapHasDeleteOps(ProllyMutMap *pMap);
 static int flushIfNeeded(BtCursor *pCur);
 static int flushAllPending(BtShared *pBt, Pgno iTable);
 static int flushDeferredEdits(BtShared *pBt);
@@ -1022,6 +1024,17 @@ static int ensureMutMap(BtCursor *pCur){
     return rc;
   }
   return SQLITE_OK;
+}
+
+static int mutMapHasDeleteOps(ProllyMutMap *pMap){
+  int i;
+  if( !pMap ) return 0;
+  for(i=0; i<pMap->nEntries; i++){
+    if( pMap->aEntries[i].op==PROLLY_EDIT_DELETE ){
+      return 1;
+    }
+  }
+  return 0;
 }
 
 static int saveCursorPosition(BtCursor *pCur){
@@ -2546,6 +2559,7 @@ static int prollyBtreeCursor(
     if( wrFlag & BTREE_WRCSR ){
       pCur->pMutMap = (ProllyMutMap*)pTE->pPending;
       pTE->pPending = 0;
+      pCur->flushSeekEdits = mutMapHasDeleteOps(pCur->pMutMap);
     }else{
       
       ProllyMutMap *pMap = (ProllyMutMap*)pTE->pPending;
@@ -3442,6 +3456,20 @@ static int prollyBtCursorIndexMoveto(
 
   CLEAR_CACHED_PAYLOAD(pCur);
 
+  /* Re-seeking a write cursor against its own unflushed BLOBKEY edits can
+  ** leave the cursor comparing against stale in-memory state across repeated
+  ** DELETE/UPDATE probes in the same statement. Materialize the current
+  ** cursor's pending edits before the seek so later seek/recheck opcodes
+  ** see a consistent tree image. */
+  if( pCur->flushSeekEdits
+   && (pCur->curFlags & BTCF_WriteFlag)
+   && pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
+    rc = flushMutMap(pCur);
+    if( rc!=SQLITE_OK ) return rc;
+    pCur->mmActive = 0;
+    pCur->flushSeekEdits = 0;
+  }
+
   
   {
     BtCursor *p;
@@ -4284,8 +4312,8 @@ static int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
     if( canDefer ){
       CLEAR_CACHED_PAYLOAD(pCur);
       pCur->curFlags &= ~(BTCF_ValidNKey|BTCF_AtLast);
-      if( flags & BTREE_SAVEPOSITION ){
-        
+      if( flags & (BTREE_SAVEPOSITION | BTREE_AUXDELETE) ){
+        pCur->flushSeekEdits = 1;
         pCur->eState = CURSOR_SKIPNEXT;
         pCur->skipNext = 0;
       } else {

--- a/test/doltlite_issue325_327.sh
+++ b/test/doltlite_issue325_327.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+#
+# Regression tests for GitHub issues #325, #326, and #327
+#
+set -euo pipefail
+
+DOLTLITE=./doltlite
+PASS=0
+FAIL=0
+ERRORS=""
+
+run_test() {
+  local name="$1"
+  local sql="$2"
+  local expected="$3"
+  local db="$4"
+  local result
+  result=$(printf "%s\n" "$sql" | perl -e 'alarm(10); exec @ARGV' "$DOLTLITE" "$db" 2>&1)
+  if [ "$result" = "$expected" ]; then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1))
+    ERRORS="$ERRORS\nFAIL: $name\n  expected: $expected\n  got:      $result"
+  fi
+}
+
+echo "=== Issue #325 / #326 / #327 Regression Tests ==="
+echo ""
+
+DB325=/tmp/test_issue325_$$.db
+rm -f "$DB325"
+run_test "issue325_delete_in_index_scan" \
+"CREATE TABLE t(id INTEGER PRIMARY KEY, val INT);
+CREATE INDEX idx ON t(val);
+INSERT INTO t VALUES(1,10),(2,20),(3,30),(4,40),(5,50);
+DELETE FROM t WHERE val IN (10, 50);
+SELECT val FROM t ORDER BY val;" \
+"20
+30
+40" "$DB325"
+
+DB326=/tmp/test_issue326_$$.db
+rm -f "$DB326"
+run_test "issue326_without_rowid_savepoint_sequence" \
+"CREATE TABLE t(k INT PRIMARY KEY, v TEXT) WITHOUT ROWID;
+INSERT INTO t VALUES(1,'a'),(2,'b'),(3,'c');
+SAVEPOINT sp;
+UPDATE t SET v = 'x' WHERE k = 2;
+DELETE FROM t WHERE k = 3;
+INSERT INTO t VALUES(4,'d');
+RELEASE sp;
+SELECT * FROM t ORDER BY k;" \
+"1|a
+2|x
+4|d" "$DB326"
+
+DB327=/tmp/test_issue327_$$.db
+rm -f "$DB327"
+run_test "issue327_without_rowid_multi_delete" \
+"CREATE TABLE t(k INT PRIMARY KEY, a INT, b TEXT, c REAL) WITHOUT ROWID;
+CREATE INDEX idx_a ON t(a);
+CREATE INDEX idx_b ON t(b);
+CREATE INDEX idx_c ON t(c);
+INSERT INTO t VALUES(1,10,'x',1.1),(2,20,'y',2.2),(3,30,'z',3.3),(4,40,'w',4.4);
+DELETE FROM t WHERE k IN (2, 4);
+SELECT * FROM t ORDER BY k;" \
+"1|10|x|1.1
+3|30|z|3.3" "$DB327"
+
+rm -f "$DB325" "$DB326" "$DB327"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ $FAIL -gt 0 ]; then
+  echo -e "$ERRORS"
+  exit 1
+fi
+echo "All tests passed!"

--- a/test/run_doltlite_tests.sh
+++ b/test/run_doltlite_tests.sh
@@ -57,6 +57,7 @@ TESTS=(
   doltlite_gc_scale.sh
   doltlite_index_prefix.sh
   doltlite_issue179_180.sh
+  doltlite_issue325_327.sh
   doltlite_issue319.sh
   doltlite_regression_test_c.sh
   review_regression_test.sh


### PR DESCRIPTION
## Summary
- fix repeated delete/seek handling for deferred prolly mutations after #323
- keep write cursors from re-seeking against stale pending delete state
- add regression coverage for the #325, #326, and #327 delete cases

Fixes #325
Fixes #326
Fixes #327