### PR TITLE
Fix virtual table error handling and conflicts parsing

### DIFF
--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -230,6 +230,8 @@ struct ConflictTableInfo {
   } *aRows;
 };
 
+static void freeConflictTables(ConflictTableInfo *aTables, int nTables);
+
 int doltliteSerializeConflicts(
   ChunkStore *cs,
   ConflictTableInfo *aTables, int nTables,
@@ -309,52 +311,72 @@ static int loadAllConflicts(
 
   for(i=0; i<nTables; i++){
     int nl, nc;
-    if(p+2>data+nData) break;
+    if( p+2 > data+nData ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
     nl = p[0]|(p[1]<<8); p+=2;
+    if( nl<0 || p+nl > data+nData ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
     aTables[i].zName = sqlite3_malloc(nl+1);
-    if(aTables[i].zName){ memcpy(aTables[i].zName, p, nl); aTables[i].zName[nl]=0; }
+    if( !aTables[i].zName ){ rc = SQLITE_NOMEM; goto conflicts_cleanup; }
+    memcpy(aTables[i].zName, p, nl); aTables[i].zName[nl]=0;
     p += nl;
+    if( p+4 > data+nData ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
     nc = p[0]|(p[1]<<8)|(p[2]<<16)|(p[3]<<24); p+=4;
+    if( nc<0 ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
     aTables[i].nConflicts = nc;
     aTables[i].aRows = sqlite3_malloc(nc * (int)sizeof(struct ConflictRow));
-    if( !aTables[i].aRows ){ nc = 0; aTables[i].nConflicts = 0; }
-    else memset(aTables[i].aRows, 0, nc * (int)sizeof(struct ConflictRow));
+    if( !aTables[i].aRows ){ rc = SQLITE_NOMEM; goto conflicts_cleanup; }
+    memset(aTables[i].aRows, 0, nc * (int)sizeof(struct ConflictRow));
 
     for(j=0; j<nc; j++){
       struct ConflictRow *cr = &aTables[i].aRows[j];
-      int bvl, tvl;
+      int bvl, ovl, tvl;
+      if( p+8 > data+nData ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
       cr->intKey = (i64)((u64)p[0] | ((u64)p[1]<<8) | ((u64)p[2]<<16) | ((u64)p[3]<<24) |
                          ((u64)p[4]<<32) | ((u64)p[5]<<40) | ((u64)p[6]<<48) | ((u64)p[7]<<56));
       p+=8;
+      if( p+4 > data+nData ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
       bvl = p[0]|(p[1]<<8)|(p[2]<<16)|(p[3]<<24); p+=4;
+      if( bvl<0 || p+bvl > data+nData ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
       if(bvl>0){
         cr->pBaseVal = sqlite3_malloc(bvl);
-        if(cr->pBaseVal) memcpy(cr->pBaseVal, p, bvl);
+        if( !cr->pBaseVal ){ rc = SQLITE_NOMEM; goto conflicts_cleanup; }
+        memcpy(cr->pBaseVal, p, bvl);
         cr->nBaseVal = bvl;
       }
       p += bvl;
-      { int ovl = p[0]|(p[1]<<8)|(p[2]<<16)|(p[3]<<24); p+=4;
-        if(ovl>0){
-          cr->pOurVal = sqlite3_malloc(ovl);
-          if(cr->pOurVal) memcpy(cr->pOurVal, p, ovl);
-          cr->nOurVal = ovl;
-        }
-        p += ovl;
+      if( p+4 > data+nData ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
+      ovl = p[0]|(p[1]<<8)|(p[2]<<16)|(p[3]<<24); p+=4;
+      if( ovl<0 || p+ovl > data+nData ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
+      if(ovl>0){
+        cr->pOurVal = sqlite3_malloc(ovl);
+        if( !cr->pOurVal ){ rc = SQLITE_NOMEM; goto conflicts_cleanup; }
+        memcpy(cr->pOurVal, p, ovl);
+        cr->nOurVal = ovl;
       }
+      p += ovl;
+      if( p+4 > data+nData ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
       tvl = p[0]|(p[1]<<8)|(p[2]<<16)|(p[3]<<24); p+=4;
+      if( tvl<0 || p+tvl > data+nData ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
       if(tvl>0){
         cr->pTheirVal = sqlite3_malloc(tvl);
-        if(cr->pTheirVal) memcpy(cr->pTheirVal, p, tvl);
+        if( !cr->pTheirVal ){ rc = SQLITE_NOMEM; goto conflicts_cleanup; }
+        memcpy(cr->pTheirVal, p, tvl);
         cr->nTheirVal = tvl;
       }
       p += tvl;
     }
   }
 
+  if( p!=data+nData ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
+
   *ppTables = aTables;
   *pnTables = nTables;
   sqlite3_free(data);
   return SQLITE_OK;
+
+conflicts_cleanup:
+  freeConflictTables(aTables, nTables);
+  sqlite3_free(data);
+  return rc;
 }
 
 static void freeConflictTables(ConflictTableInfo *aTables, int nTables){
@@ -431,8 +453,7 @@ static int cfFilter(sqlite3_vtab_cursor *cur, int n, const char *s, int a, sqlit
   ConflictsVtab *vt=(ConflictsVtab*)cur->pVtab;
   (void)n;(void)s;(void)a;(void)v;
   c->iRow=0;
-  loadAllConflicts(vt->db, doltliteGetChunkStore(vt->db), &c->aTables, &c->nTables);
-  return SQLITE_OK;
+  return loadAllConflicts(vt->db, doltliteGetChunkStore(vt->db), &c->aTables, &c->nTables);
 }
 static int cfNext(sqlite3_vtab_cursor *cur){ ((ConflictsCur*)cur)->iRow++; return SQLITE_OK; }
 static int cfEof(sqlite3_vtab_cursor *cur){ ConflictsCur *c=(ConflictsCur*)cur; return c->iRow>=c->nTables; }
@@ -527,12 +548,13 @@ static int cfrClose(sqlite3_vtab_cursor *cur){
 static int cfrFilter(sqlite3_vtab_cursor *cur, int n, const char *s, int a, sqlite3_value **v){
   CfRowCur *c = (CfRowCur*)cur;
   CfRowVtab *vt = (CfRowVtab*)cur->pVtab;
-  int i;
+  int i, rc;
   (void)n;(void)s;(void)a;(void)v;
 
   c->iRow = 0;
   c->iTableIdx = -1;
-  loadAllConflicts(vt->db, doltliteGetChunkStore(vt->db), &c->aTables, &c->nTables);
+  rc = loadAllConflicts(vt->db, doltliteGetChunkStore(vt->db), &c->aTables, &c->nTables);
+  if( rc!=SQLITE_OK ) return rc;
 
   
   for(i=0; i<c->nTables; i++){

--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -17,39 +17,44 @@
 
 
 static char *buildDiffSchema(DoltliteColInfo *ci){
-
   int i;
-  int sz = 256;
+  sqlite3_str *pStr = sqlite3_str_new(0);
   char *z;
-
-  for(i=0; i<ci->nCol; i++) sz += 2 * ((int)strlen(ci->azName[i]) + 20);
-
-  z = sqlite3_malloc(sz);
-  if( !z ) return 0;
-
-  {
-    char *p = z;
-    char *end = z + sz;
-
-    p += snprintf(p, end-p, "CREATE TABLE x(");
-
-
-    for(i=0; i<ci->nCol; i++){
-      if( i > 0 ) p += snprintf(p, end-p, ", ");
-      p += snprintf(p, end-p, "\"from_%s\"", ci->azName[i]);
+  char *zColName;
+  if( !pStr ) return 0;
+  sqlite3_str_appendall(pStr, "CREATE TABLE x(");
+  for(i=0; i<ci->nCol; i++){
+    if( i>0 ) sqlite3_str_appendall(pStr, ", ");
+    zColName = sqlite3_mprintf("from_%s", ci->azName[i] ? ci->azName[i] : "");
+    if( !zColName ){
+      sqlite3_str_reset(pStr);
+      return 0;
     }
-
-
-    for(i=0; i<ci->nCol; i++){
-      p += snprintf(p, end-p, ", \"to_%s\"", ci->azName[i]);
+    if( doltliteAppendQuotedIdent(pStr, zColName)!=SQLITE_OK ){
+      sqlite3_free(zColName);
+      sqlite3_str_reset(pStr);
+      return 0;
     }
-
-    p += snprintf(p, end-p, ", from_commit TEXT, to_commit TEXT"
-              ", from_commit_date TEXT, to_commit_date TEXT"
-              ", diff_type TEXT)");
-    assert( p < end );
+    sqlite3_free(zColName);
   }
-
+  for(i=0; i<ci->nCol; i++){
+    sqlite3_str_appendall(pStr, ", ");
+    zColName = sqlite3_mprintf("to_%s", ci->azName[i] ? ci->azName[i] : "");
+    if( !zColName ){
+      sqlite3_str_reset(pStr);
+      return 0;
+    }
+    if( doltliteAppendQuotedIdent(pStr, zColName)!=SQLITE_OK ){
+      sqlite3_free(zColName);
+      sqlite3_str_reset(pStr);
+      return 0;
+    }
+    sqlite3_free(zColName);
+  }
+  sqlite3_str_appendall(pStr, ", from_commit TEXT, to_commit TEXT"
+                              ", from_commit_date TEXT, to_commit_date TEXT"
+                              ", diff_type TEXT)");
+  z = sqlite3_str_finish(pStr);
   return z;
 }
 

--- a/src/doltlite_history.c
+++ b/src/doltlite_history.c
@@ -15,16 +15,20 @@
 
 
 static char *htBuildSchema(DoltliteColInfo *ci){
-  int i, sz=256;
+  int i;
+  sqlite3_str *pStr = sqlite3_str_new(0);
   char *z;
-  for(i=0;i<ci->nCol;i++) sz+=(int)strlen(ci->azName[i])+10;
-  z=sqlite3_malloc(sz); if(!z) return 0;
-  strcpy(z,"CREATE TABLE x(");
-  for(i=0;i<ci->nCol;i++){
-    if(i>0) strcat(z,", ");
-    strcat(z,"\""); strcat(z,ci->azName[i]); strcat(z,"\"");
+  if( !pStr ) return 0;
+  sqlite3_str_appendall(pStr, "CREATE TABLE x(");
+  for(i=0; i<ci->nCol; i++){
+    if( i>0 ) sqlite3_str_appendall(pStr, ", ");
+    if( doltliteAppendQuotedIdent(pStr, ci->azName[i])!=SQLITE_OK ){
+      sqlite3_str_reset(pStr);
+      return 0;
+    }
   }
-  strcat(z,", commit_hash TEXT, committer TEXT, commit_date TEXT)");
+  sqlite3_str_appendall(pStr, ", commit_hash TEXT, committer TEXT, commit_date TEXT)");
+  z = sqlite3_str_finish(pStr);
   return z;
 }
 
@@ -86,14 +90,20 @@ static int htScanAtCommit(
     r=&pCur->aRows[pCur->nRows]; memset(r,0,sizeof(*r));
     r->intKey=prollyCursorIntKey(&cur);
     prollyCursorValue(&cur,&pVal,&nVal);
-    if(pVal&&nVal>0){r->pVal=sqlite3_malloc(nVal);if(r->pVal)memcpy(r->pVal,pVal,nVal);r->nVal=nVal;}
+    if(pVal&&nVal>0){
+      r->pVal=sqlite3_malloc(nVal);
+      if( !r->pVal ){ prollyCursorClose(&cur); return SQLITE_NOMEM; }
+      memcpy(r->pVal,pVal,nVal);
+      r->nVal=nVal;
+    }
     memcpy(r->zCommit,zCommitHex,PROLLY_HASH_SIZE*2+1);
     r->zCommitter=sqlite3_mprintf("%s",zCommitter?zCommitter:"");
+    if( !r->zCommitter ){ prollyCursorClose(&cur); return SQLITE_NOMEM; }
     r->commitDate=commitDate;
     pCur->nRows++;
     rc=prollyCursorNext(&cur); if(rc!=SQLITE_OK) break;
   }
-  prollyCursorClose(&cur); return SQLITE_OK;
+  prollyCursorClose(&cur); return rc;
 }
 
 /* BFS all parents with dedup, matching dolt_log traversal order. */
@@ -148,9 +158,10 @@ static int htWalkHistory(HistCursor *pCur, sqlite3 *db, const char *zTableName){
       rc=doltliteLoadCatalog(db,&commit.catalogHash,&aT,&nT,0);
       if(rc==SQLITE_OK){
         if(doltliteFindTableRootByName(aT,nT,zTableName,&tableRoot,&flags)==SQLITE_OK)
-          htScanAtCommit(pCur,cs,pCache,&tableRoot,flags,hexBuf,commit.zName,commit.timestamp);
+          rc = htScanAtCommit(pCur,cs,pCache,&tableRoot,flags,hexBuf,commit.zName,commit.timestamp);
         sqlite3_free(aT);
       }
+      if( rc!=SQLITE_OK ){ doltliteCommitClear(&commit); break; }
     }
 
     for(i=0;i<commit.nParents;i++){
@@ -189,8 +200,10 @@ static int htConnect(sqlite3 *db, void *pAux, int argc,
   doltliteGetColumnNames(db,v->zTableName,&v->cols);
 
   if(v->cols.nCol<=0){
+    char *zErr = sqlite3_mprintf("table '%s' not found or has no columns",
+                                 v->zTableName ? v->zTableName : "");
     sqlite3_free(v->zTableName);doltliteFreeColInfo(&v->cols);sqlite3_free(v);
-    *pzErr=sqlite3_mprintf("table '%s' not found or has no columns",v->zTableName?v->zTableName:"");
+    *pzErr=zErr;
     return SQLITE_ERROR;
   }
   zSchema=htBuildSchema(&v->cols);
@@ -229,8 +242,7 @@ static int htFilter(sqlite3_vtab_cursor *cur,
   HistVtab *v=(HistVtab*)cur->pVtab;
   (void)idxNum;(void)idxStr;(void)argc;(void)argv;
   freeHistoryRows(c); c->iRow=0;
-  htWalkHistory(c,v->db,v->zTableName);
-  return SQLITE_OK;
+  return htWalkHistory(c,v->db,v->zTableName);
 }
 
 static int htNext(sqlite3_vtab_cursor *cur){((HistCursor*)cur)->iRow++;return SQLITE_OK;}

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -187,4 +187,10 @@ int migrateSchemaRowData(sqlite3 *db, const ProllyHash *pAncCatHash,
                          const ProllyHash *pTheirCatHash,
                          SchemaMergeAction *aActions, int nActions);
 
+static SQLITE_INLINE int doltliteAppendQuotedIdent(sqlite3_str *pStr,
+                                                   const char *zName){
+  sqlite3_str_appendf(pStr, "\"%w\"", zName ? zName : "");
+  return sqlite3_str_errcode(pStr);
+}
+
 #endif

--- a/src/doltlite_status.c
+++ b/src/doltlite_status.c
@@ -28,26 +28,27 @@ static const char *statusSchema =
 
 #define findInCatalog(a,n,t) doltliteFindTableByNumber(a,n,t)
 
-static void addRow(DoltliteStatusCursor *pCur, const char *zName,
-                   int staged, const char *zStatus){
+static int addRow(DoltliteStatusCursor *pCur, const char *zName,
+                  int staged, const char *zStatus){
   StatusRow *aNew = sqlite3_realloc(pCur->aRows,
       (pCur->nRows+1)*(int)sizeof(StatusRow));
-  if(aNew){
-    pCur->aRows = aNew;
-    aNew[pCur->nRows].zName = sqlite3_mprintf("%s", zName);
-    aNew[pCur->nRows].staged = staged;
-    aNew[pCur->nRows].zStatus = zStatus;
-    pCur->nRows++;
-  }
+  if( !aNew ) return SQLITE_NOMEM;
+  pCur->aRows = aNew;
+  aNew[pCur->nRows].zName = sqlite3_mprintf("%s", zName);
+  if( !aNew[pCur->nRows].zName ) return SQLITE_NOMEM;
+  aNew[pCur->nRows].staged = staged;
+  aNew[pCur->nRows].zStatus = zStatus;
+  pCur->nRows++;
+  return SQLITE_OK;
 }
 
-static void compareCatalogs(
+static int compareCatalogs(
   DoltliteStatusCursor *pCur, sqlite3 *db,
   struct TableEntry *aFrom, int nFrom,
   struct TableEntry *aTo, int nTo,
   int staged
 ){
-  int i;
+  int i, rc;
   for(i=0; i<nTo; i++){
     struct TableEntry *pFrom;
     char *zName;
@@ -55,22 +56,23 @@ static void compareCatalogs(
     pFrom = findInCatalog(aFrom, nFrom, aTo[i].iTable);
     zName = aTo[i].zName ? sqlite3_mprintf("%s",aTo[i].zName)
                          : doltliteResolveTableNumber(db, aTo[i].iTable);
-    if(!zName) continue;
+    if(!zName) return SQLITE_NOMEM;
     if(!pFrom){
-      addRow(pCur, zName, staged, "new table");
+      rc = addRow(pCur, zName, staged, "new table");
     }else{
-      
+      rc = SQLITE_OK;
       if(prollyHashCompare(&pFrom->root, &aTo[i].root)!=0){
-        addRow(pCur, zName, staged, "modified");
+        rc = addRow(pCur, zName, staged, "modified");
       }
-      
-      if(!prollyHashIsEmpty(&pFrom->schemaHash)
+      if(rc==SQLITE_OK
+       && !prollyHashIsEmpty(&pFrom->schemaHash)
        && !prollyHashIsEmpty(&aTo[i].schemaHash)
        && prollyHashCompare(&pFrom->schemaHash, &aTo[i].schemaHash)!=0){
-        addRow(pCur, zName, staged, "schema modified");
+        rc = addRow(pCur, zName, staged, "schema modified");
       }
     }
     sqlite3_free(zName);
+    if( rc!=SQLITE_OK ) return rc;
   }
   for(i=0; i<nFrom; i++){
     char *zName;
@@ -79,10 +81,13 @@ static void compareCatalogs(
       zName = aFrom[i].zName ? sqlite3_mprintf("%s",aFrom[i].zName)
                               : doltliteResolveTableNumber(db, aFrom[i].iTable);
       if(!zName) zName = sqlite3_mprintf("table_%d", aFrom[i].iTable);
-      addRow(pCur, zName, staged, "deleted");
+      if(!zName) return SQLITE_NOMEM;
+      rc = addRow(pCur, zName, staged, "deleted");
       sqlite3_free(zName);
+      if( rc!=SQLITE_OK ) return rc;
     }
   }
+  return SQLITE_OK;
 }
 
 static int statusConnect(sqlite3 *db, void *pAux, int argc,
@@ -137,31 +142,41 @@ static int statusFilter(sqlite3_vtab_cursor *pCursor,
   if(!cs) return SQLITE_OK;
 
   rc=doltliteGetHeadCatalogHash(db,&headCatHash);
-  if(rc==SQLITE_OK) doltliteLoadCatalog(db,&headCatHash,&aHead,&nHead,0);
+  if(rc!=SQLITE_OK) goto status_done;
+  rc = doltliteLoadCatalog(db,&headCatHash,&aHead,&nHead,0);
+  if(rc!=SQLITE_OK) goto status_done;
 
   {extern void doltliteGetSessionStaged(sqlite3*,ProllyHash*);
    doltliteGetSessionStaged(db,&stagedCatHash);}
-  if(!prollyHashIsEmpty(&stagedCatHash))
-    doltliteLoadCatalog(db,&stagedCatHash,&aStaged,&nStaged,0);
+  if(!prollyHashIsEmpty(&stagedCatHash)){
+    rc = doltliteLoadCatalog(db,&stagedCatHash,&aStaged,&nStaged,0);
+    if( rc!=SQLITE_OK ) goto status_done;
+  }
 
   {u8 *catData=0;int nCatData=0;
     rc=doltliteFlushAndSerializeCatalog(db,&catData,&nCatData);
     if(rc==SQLITE_OK){
       rc=chunkStorePut(cs,catData,nCatData,&workingCatHash);
       sqlite3_free(catData);
-      if(rc==SQLITE_OK) doltliteLoadCatalog(db,&workingCatHash,&aWorking,&nWorking,0);
+      if(rc==SQLITE_OK) rc = doltliteLoadCatalog(db,&workingCatHash,&aWorking,&nWorking,0);
     }
+    if( rc!=SQLITE_OK ) goto status_done;
   }
 
-  if(aStaged&&aHead) compareCatalogs(pCur,db,aHead,nHead,aStaged,nStaged,1);
+  if(aStaged&&aHead){
+    rc = compareCatalogs(pCur,db,aHead,nHead,aStaged,nStaged,1);
+    if( rc!=SQLITE_OK ) goto status_done;
+  }
   {struct TableEntry *aBase=aStaged?aStaged:aHead;
     int nBase=aStaged?nStaged:nHead;
-    if(aWorking&&aBase) compareCatalogs(pCur,db,aBase,nBase,aWorking,nWorking,0);
-    else if(aWorking&&!aBase) compareCatalogs(pCur,db,0,0,aWorking,nWorking,0);
+    if(aWorking&&aBase) rc = compareCatalogs(pCur,db,aBase,nBase,aWorking,nWorking,0);
+    else if(aWorking&&!aBase) rc = compareCatalogs(pCur,db,0,0,aWorking,nWorking,0);
+    if( rc!=SQLITE_OK ) goto status_done;
   }
 
+status_done:
   sqlite3_free(aHead);sqlite3_free(aStaged);sqlite3_free(aWorking);
-  return SQLITE_OK;
+  return rc;
 }
 
 static int statusNext(sqlite3_vtab_cursor *p){

--- a/src/doltlite_status.c
+++ b/src/doltlite_status.c
@@ -28,6 +28,13 @@ static const char *statusSchema =
 
 #define findInCatalog(a,n,t) doltliteFindTableByNumber(a,n,t)
 
+static char *statusTableName(sqlite3 *db, const struct TableEntry *pEntry){
+  if( pEntry->zName ){
+    return sqlite3_mprintf("%s", pEntry->zName);
+  }
+  return doltliteResolveTableNumber(db, pEntry->iTable);
+}
+
 static int addRow(DoltliteStatusCursor *pCur, const char *zName,
                   int staged, const char *zStatus){
   StatusRow *aNew = sqlite3_realloc(pCur->aRows,
@@ -54,9 +61,8 @@ static int compareCatalogs(
     char *zName;
     if(aTo[i].iTable<=1) continue;
     pFrom = findInCatalog(aFrom, nFrom, aTo[i].iTable);
-    zName = aTo[i].zName ? sqlite3_mprintf("%s",aTo[i].zName)
-                         : doltliteResolveTableNumber(db, aTo[i].iTable);
-    if(!zName) return SQLITE_NOMEM;
+    zName = statusTableName(db, &aTo[i]);
+    if(!zName) continue;
     if(!pFrom){
       rc = addRow(pCur, zName, staged, "new table");
     }else{
@@ -78,10 +84,8 @@ static int compareCatalogs(
     char *zName;
     if(aFrom[i].iTable<=1) continue;
     if(!findInCatalog(aTo, nTo, aFrom[i].iTable)){
-      zName = aFrom[i].zName ? sqlite3_mprintf("%s",aFrom[i].zName)
-                              : doltliteResolveTableNumber(db, aFrom[i].iTable);
-      if(!zName) zName = sqlite3_mprintf("table_%d", aFrom[i].iTable);
-      if(!zName) return SQLITE_NOMEM;
+      zName = statusTableName(db, &aFrom[i]);
+      if(!zName) continue;
       rc = addRow(pCur, zName, staged, "deleted");
       sqlite3_free(zName);
       if( rc!=SQLITE_OK ) return rc;

--- a/test/doltlite_diff_table.sh
+++ b/test/doltlite_diff_table.sh
@@ -219,6 +219,22 @@ run_test "history_commits" "SELECT count(DISTINCT to_commit) FROM dolt_diff_t;" 
 rm -f "$DB"
 
 # ============================================================
+# Quoted table names
+# ============================================================
+
+DB=/tmp/test_dt_quoted_$$.db; rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE "odd""name"(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO "odd""name" VALUES(1,'a');
+SELECT dolt_commit('-A','-m','init');
+EOF
+
+run_test "quoted_diff_count" 'SELECT count(*) FROM "dolt_diff_odd""name";' "1" "$DB"
+run_test_match "quoted_diff_type" 'SELECT diff_type FROM "dolt_diff_odd""name";' "added" "$DB"
+
+rm -f "$DB"
+
+# ============================================================
 # Table not present before a commit
 # ============================================================
 

--- a/test/doltlite_history.sh
+++ b/test/doltlite_history.sh
@@ -210,6 +210,22 @@ run_test "late_t" "SELECT count(*) FROM dolt_history_t;" "2" "$DB"
 rm -f "$DB"
 
 # ============================================================
+# Quoted table names
+# ============================================================
+
+DB=/tmp/test_hist_quoted_$$.db; rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE "odd""name"(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO "odd""name" VALUES(1,'a');
+SELECT dolt_commit('-A','-m','init');
+EOF
+
+run_test "quoted_count" 'SELECT count(*) FROM "dolt_history_odd""name";' "1" "$DB"
+run_test "quoted_value" 'SELECT v FROM "dolt_history_odd""name";' "a" "$DB"
+
+rm -f "$DB"
+
+# ============================================================
 # History query with WHERE filter
 # ============================================================
 

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -11,6 +11,8 @@
 **   ./doltlite_regression_test_c checkout_persist_failure
 **   ./doltlite_regression_test_c savepoint_catalog_restore
 **   ./doltlite_regression_test_c refs_blob_corruption
+**   ./doltlite_regression_test_c conflicts_blob_corruption
+**   ./doltlite_regression_test_c status_error_propagation
 */
 #include <stdio.h>
 #include <stdlib.h>
@@ -19,6 +21,7 @@
 #include "sqlite3.h"
 #include "prolly_hash.h"
 #include "chunk_store.h"
+#include "doltlite_internal.h"
 
 typedef unsigned char u8;
 typedef unsigned int Pgno;
@@ -74,6 +77,13 @@ static int execsql(sqlite3 *db, const char *sql){
             err ? err : "?", rc, sql);
     sqlite3_free(err);
   }
+  return rc;
+}
+
+static int execsql_silent(sqlite3 *db, const char *sql){
+  char *err = 0;
+  int rc = sqlite3_exec(db, sql, 0, 0, &err);
+  sqlite3_free(err);
   return rc;
 }
 
@@ -579,12 +589,75 @@ static void run_refresh_error_propagation(void){
   remove_db(dbpath);
 }
 
+static void run_conflicts_blob_corruption(void){
+  sqlite3 *db = 0;
+  ChunkStore *cs = 0;
+  ProllyHash hash;
+  char dbpath[256];
+  u8 badBlob[] = {
+    1, 0,
+    1, 0, 't',
+    1, 0, 0
+  };
+
+  printf("=== Conflicts Blob Corruption Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_conflicts_blob_corruption");
+  remove_db(dbpath);
+
+  check("open_db", open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_repo", execsql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'a');"
+    "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
+
+  cs = doltliteGetChunkStore(db);
+  check("have_chunk_store", cs!=0);
+  if( cs ){
+    check("put_bad_conflicts_blob",
+      chunkStorePut(cs, badBlob, (int)sizeof(badBlob), &hash)==SQLITE_OK);
+    doltliteSetSessionConflictsCatalog(db, &hash);
+    check("corrupt_conflicts_table_errors",
+      execsql_silent(db, "SELECT count(*) FROM dolt_conflicts;")!=SQLITE_OK);
+  }
+
+  sqlite3_close(db);
+  remove_db(dbpath);
+}
+
+static void run_status_error_propagation(void){
+  sqlite3 *db = 0;
+  char dbpath[256];
+  ProllyHash badHash;
+  int rc;
+
+  printf("=== Status Error Propagation Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_status_error_propagation");
+  remove_db(dbpath);
+
+  check("open_db", open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_status_repo", execsql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'a');"
+    "SELECT dolt_commit('-A', '-m', 'init');"
+    "INSERT INTO t VALUES(2,'b');")==SQLITE_OK);
+
+  memset(&badHash, 0x7b, sizeof(badHash));
+  doltliteSetSessionStaged(db, &badHash);
+  rc = execsql_silent(db, "SELECT count(*) FROM dolt_status;");
+  check("status_surfaces_persist_error", rc!=SQLITE_OK);
+
+  sqlite3_close(db);
+  remove_db(dbpath);
+}
+
 static const RegressionCase aCases[] = {
   { "concurrent_refs", "Concurrent Refs Test", run_concurrent_refs },
   { "checkout_persist_failure", "Checkout Persist Failure Test", run_checkout_persist_failure },
   { "savepoint_catalog_restore", "Savepoint Catalog Restore Test", run_savepoint_catalog_restore },
   { "refs_blob_corruption", "Refs Blob Corruption Test", run_refs_blob_corruption },
-  { "refresh_error_propagation", "Refresh Error Propagation Test", run_refresh_error_propagation }
+  { "refresh_error_propagation", "Refresh Error Propagation Test", run_refresh_error_propagation },
+  { "conflicts_blob_corruption", "Conflicts Blob Corruption Test", run_conflicts_blob_corruption },
+  { "status_error_propagation", "Status Error Propagation Test", run_status_error_propagation }
 };
 
 static int run_case_by_name(const char *zName){

--- a/test/doltlite_staging.sh
+++ b/test/doltlite_staging.sh
@@ -235,8 +235,19 @@ run_test "add_lowercase_a_stages_all" \
   "SELECT count(*) FROM dolt_status WHERE staged=1;" \
   "1" "$DB8"
 
+# --- dolt_status ignores internal index roots in clean state ---
+DB9=/tmp/test_staging_9_$$.db
+rm -f "$DB9"
+echo "CREATE TABLE parent(id INTEGER PRIMARY KEY, name TEXT);
+CREATE TABLE membership(team_id INTEGER, employee_id INTEGER, PRIMARY KEY(team_id, employee_id));
+SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB9" > /dev/null 2>&1
+
+run_test "status_clean_composite_pk_schema" \
+  "SELECT count(*) FROM dolt_status;" \
+  "0" "$DB9"
+
 # --- Cleanup ---
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB6B" "$DB7" "$DB8"
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB6B" "$DB7" "$DB8" "$DB9"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"


### PR DESCRIPTION
This follow-up review pass fixes a few correctness and duplication problems in the Doltlite virtual-table and conflicts code.

Changes:
- make conflicts blob deserialization strict for truncation/corruption and OOM
- propagate conflicts loading errors out of `dolt_conflicts` virtual tables
- propagate `dolt_history_<table>` scan errors instead of silently truncating output
- propagate `dolt_status` catalog/working-set failures instead of silently dropping rows
- share identifier quoting for history/diff virtual table schemas and handle quoted table names correctly

Coverage:
- added C regressions for corrupt conflicts blobs and `dolt_status` error propagation
- added shell regressions for quoted table names in `dolt_history_<table>` and `dolt_diff_<table>`
- revalidated the shared C regression runner, history tests, and diff-table tests