### PR TITLE
Tighten dolt_at and remote error handling

### DIFF
--- a/src/doltlite_at.c
+++ b/src/doltlite_at.c
@@ -15,16 +15,20 @@
 
 
 static char *atBuildSchema(DoltliteColInfo *ci){
-  int i, sz=256;
+  int i;
+  sqlite3_str *pStr = sqlite3_str_new(0);
   char *z;
-  for(i=0;i<ci->nCol;i++) sz+=(int)strlen(ci->azName[i])+10;
-  z=sqlite3_malloc(sz); if(!z) return 0;
-  strcpy(z,"CREATE TABLE x(");
-  for(i=0;i<ci->nCol;i++){
-    if(i>0) strcat(z,", ");
-    strcat(z,"\""); strcat(z,ci->azName[i]); strcat(z,"\"");
+  if( !pStr ) return 0;
+  sqlite3_str_appendall(pStr, "CREATE TABLE x(");
+  for(i=0; i<ci->nCol; i++){
+    if( i>0 ) sqlite3_str_appendall(pStr, ", ");
+    if( doltliteAppendQuotedIdent(pStr, ci->azName[i])!=SQLITE_OK ){
+      sqlite3_str_reset(pStr);
+      return 0;
+    }
   }
-  strcat(z,", commit_ref TEXT HIDDEN)");
+  sqlite3_str_appendall(pStr, ", commit_ref TEXT HIDDEN)");
+  z = sqlite3_str_finish(pStr);
   return z;
 }
 
@@ -75,11 +79,20 @@ static int atScanTree(AtCursor *pCur, ChunkStore *cs, ProllyCache *pCache,
     r=&pCur->aRows[pCur->nRows]; memset(r,0,sizeof(*r));
     r->intKey=prollyCursorIntKey(&cur);
     prollyCursorValue(&cur,&pVal,&nVal);
-    if(pVal&&nVal>0){r->pVal=sqlite3_malloc(nVal);if(r->pVal)memcpy(r->pVal,pVal,nVal);r->nVal=nVal;}
+    if( pVal && nVal>0 ){
+      r->pVal = sqlite3_malloc(nVal);
+      if( !r->pVal ){
+        prollyCursorClose(&cur);
+        return SQLITE_NOMEM;
+      }
+      memcpy(r->pVal,pVal,nVal);
+      r->nVal=nVal;
+    }
     pCur->nRows++;
     rc=prollyCursorNext(&cur); if(rc!=SQLITE_OK) break;
   }
-  prollyCursorClose(&cur); return SQLITE_OK;
+  prollyCursorClose(&cur);
+  return rc;
 }
 
 static int atConnect(sqlite3 *db, void *pAux, int argc,
@@ -99,8 +112,10 @@ static int atConnect(sqlite3 *db, void *pAux, int argc,
   doltliteGetColumnNames(db,v->zTableName,&v->cols);
 
   if(v->cols.nCol<=0){
+    char *zErr = sqlite3_mprintf("table '%s' not found or has no columns",
+                                 v->zTableName ? v->zTableName : "");
     sqlite3_free(v->zTableName);doltliteFreeColInfo(&v->cols);sqlite3_free(v);
-    *pzErr=sqlite3_mprintf("table '%s' not found or has no columns",v->zTableName?v->zTableName:"");
+    *pzErr = zErr;
     return SQLITE_ERROR;
   }
   zSchema=atBuildSchema(&v->cols);
@@ -180,11 +195,12 @@ static int atFilter(sqlite3_vtab_cursor *cur,
   if(!zRef) return SQLITE_OK;
 
   rc=doltliteResolveRef(db,zRef,&commitHash);
-  if(rc!=SQLITE_OK) return SQLITE_OK;
+  if(rc==SQLITE_NOTFOUND) return SQLITE_OK;
+  if(rc!=SQLITE_OK) return rc;
 
   memset(&commit,0,sizeof(commit));
   rc=doltliteLoadCommit(db,&commitHash,&commit);
-  if(rc!=SQLITE_OK) return SQLITE_OK;
+  if(rc!=SQLITE_OK) return rc;
 
   /* For branch refs, prefer the working state catalog if it has
   ** uncommitted changes (same logic as checkout). */
@@ -203,7 +219,7 @@ static int atFilter(sqlite3_vtab_cursor *cur,
         /* Working state has uncommitted changes — use it. */
         rc=doltliteLoadCatalog(db,&wsCatHash,&aTables,&nTables,0);
         doltliteCommitClear(&commit);
-        if(rc!=SQLITE_OK) return SQLITE_OK;
+        if(rc!=SQLITE_OK) return rc;
         goto at_find_root;
       }
     }
@@ -211,16 +227,17 @@ static int atFilter(sqlite3_vtab_cursor *cur,
 
   rc=doltliteLoadCatalog(db,&commit.catalogHash,&aTables,&nTables,0);
   doltliteCommitClear(&commit);
-  if(rc!=SQLITE_OK) return SQLITE_OK;
+  if(rc!=SQLITE_OK) return rc;
 
 at_find_root:
 
   rc=doltliteFindTableRootByName(aTables,nTables,v->zTableName,&tableRoot,&flags);
   sqlite3_free(aTables);
-  if(rc!=SQLITE_OK) return SQLITE_OK;
+  if(rc==SQLITE_NOTFOUND) return SQLITE_OK;
+  if(rc!=SQLITE_OK) return rc;
 
-  atScanTree(c,cs,pCache,&tableRoot,flags);
-  return SQLITE_OK;
+  rc = atScanTree(c,cs,pCache,&tableRoot,flags);
+  return rc;
 }
 
 static int atNext(sqlite3_vtab_cursor *cur){((AtCursor*)cur)->iRow++;return SQLITE_OK;}

--- a/src/doltlite_log.c
+++ b/src/doltlite_log.c
@@ -5,6 +5,7 @@
 #include "sqliteInt.h"
 #include "doltlite_commit.h"
 #include "prolly_hash.h"
+#include "prolly_hashset.h"
 #include "chunk_store.h"
 
 #include "doltlite_internal.h"
@@ -46,12 +47,11 @@ static int logCollectAll(sqlite3 *db, const ProllyHash *pHead,
   ChunkStore *cs = doltliteGetChunkStore(db);
   ProllyHash *queue = 0;
   int qHead = 0, qTail = 0, qAlloc = 0;
-  ProllyHash *visited = 0;
-  int nVisited = 0, nVisitedAlloc = 0;
+  ProllyHashSet visited;
   LogEntry *aEntries = 0;
   int nEntries = 0, nAlloc = 0;
   int rc = SQLITE_OK;
-  int i;
+  int i, visitedInit = 0;
 
   if( !cs || prollyHashIsEmpty(pHead) ){
     *ppOut = 0; *pnOut = 0;
@@ -63,27 +63,24 @@ static int logCollectAll(sqlite3 *db, const ProllyHash *pHead,
   queue = sqlite3_malloc(qAlloc * (int)sizeof(ProllyHash));
   if( !queue ) return SQLITE_NOMEM;
   queue[qTail++] = *pHead;
+  rc = prollyHashSetInit(&visited, 64);
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(queue);
+    return rc;
+  }
+  visitedInit = 1;
 
   while( qHead < qTail ){
     ProllyHash cur = queue[qHead++];
     DoltliteCommit commit;
     LogEntry *pEntry;
-    int dup = 0;
 
     /* Dedup by hash */
-    for(i = 0; i < nVisited; i++){
-      if( prollyHashCompare(&visited[i], &cur)==0 ){ dup = 1; break; }
+    if( prollyHashSetContains(&visited, &cur) ) continue;
+    rc = prollyHashSetAdd(&visited, &cur);
+    if( rc!=SQLITE_OK ){
+      break;
     }
-    if( dup ) continue;
-
-    /* Add to visited */
-    if( nVisited >= nVisitedAlloc ){
-      int newAlloc = nVisitedAlloc ? nVisitedAlloc*2 : 16;
-      ProllyHash *tmp = sqlite3_realloc(visited, newAlloc*(int)sizeof(ProllyHash));
-      if( !tmp ){ rc = SQLITE_NOMEM; break; }
-      visited = tmp; nVisitedAlloc = newAlloc;
-    }
-    visited[nVisited++] = cur;
 
     /* Load commit */
     memset(&commit, 0, sizeof(commit));
@@ -120,7 +117,7 @@ static int logCollectAll(sqlite3 *db, const ProllyHash *pHead,
   }
 
   sqlite3_free(queue);
-  sqlite3_free(visited);
+  if( visitedInit ) prollyHashSetFree(&visited);
 
   if( rc!=SQLITE_OK ){
     for(i = 0; i < nEntries; i++) doltliteCommitClear(&aEntries[i].commit);

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -34,6 +34,8 @@ static DoltliteRemote *openRemoteByUrl(sqlite3_vfs *pVfs, const char *zUrl){
   return 0;
 }
 
+static void freeNameList(char **azNames, int nNames);
+
 static void doltRemoteFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
   ChunkStore *cs = doltliteGetChunkStore(db);
@@ -156,15 +158,23 @@ static int parseRemoteBranchNames(
   if( rc!=SQLITE_OK ) return rc;
   if( !refsData || nRefsData < 9 ){
     sqlite3_free(refsData);
-    return SQLITE_OK; 
+    return SQLITE_CORRUPT;
   }
 
   {
     const u8 *p = refsData;
     u8 ver; int defLen;
     ver = p[0]; p++;
+    if( ver!=5 ){
+      sqlite3_free(refsData);
+      return SQLITE_CORRUPT;
+    }
     defLen = (int)p[0]|((int)p[1]<<8)|((int)p[2]<<16)|((int)p[3]<<24); p += 4;
-    if( p + defLen + 4 <= refsData + nRefsData ){
+    if( p + defLen + 4 > refsData + nRefsData ){
+      sqlite3_free(refsData);
+      return SQLITE_CORRUPT;
+    }
+    {
       int nBranches, i;
       p += defLen;
       nBranches = (int)p[0]|((int)p[1]<<8)|((int)p[2]<<16)|((int)p[3]<<24); p += 4;
@@ -178,20 +188,27 @@ static int parseRemoteBranchNames(
 
       for(i=0; i<nBranches; i++){
         int nameLen;
-        if( p+4 > refsData+nRefsData ) break;
+        if( p+4 > refsData+nRefsData ){
+          freeNameList(azNames, nNames);
+          sqlite3_free(refsData);
+          return SQLITE_CORRUPT;
+        }
         nameLen = (int)p[0]|((int)p[1]<<8)|((int)p[2]<<16)|((int)p[3]<<24); p += 4;
-        if( p+nameLen+PROLLY_HASH_SIZE > refsData+nRefsData ) break;
+        if( p+nameLen+(PROLLY_HASH_SIZE*2) > refsData+nRefsData ){
+          freeNameList(azNames, nNames);
+          sqlite3_free(refsData);
+          return SQLITE_CORRUPT;
+        }
         azNames[nNames] = sqlite3_malloc(nameLen+1);
-        if( azNames[nNames] ){
-          memcpy(azNames[nNames], p, nameLen);
-          azNames[nNames][nameLen] = 0;
-          nNames++;
+        if( !azNames[nNames] ){
+          freeNameList(azNames, nNames);
+          sqlite3_free(refsData);
+          return SQLITE_NOMEM;
         }
-        p += nameLen + PROLLY_HASH_SIZE;
-
-        if( p+PROLLY_HASH_SIZE <= refsData+nRefsData ){
-          p += PROLLY_HASH_SIZE;
-        }
+        memcpy(azNames[nNames], p, nameLen);
+        azNames[nNames][nameLen] = 0;
+        nNames++;
+        p += nameLen + (PROLLY_HASH_SIZE*2);
       }
     }
   }
@@ -485,6 +502,10 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
 
   
   rc = chunkStoreAddRemote(cs, "origin", zUrl);
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error(ctx, "failed to add origin remote", -1);
+    return;
+  }
   
 
   
@@ -516,19 +537,30 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
         DoltliteCommit commit;
 
         rc = chunkStoreGet(cs, &branchCommit, &data, &nData);
-        if( rc==SQLITE_OK && data ){
-          rc = doltliteCommitDeserialize(data, nData, &commit);
-          sqlite3_free(data);
-          if( rc==SQLITE_OK ){
-            rc = doltliteHardReset(db, &commit.catalogHash);
-            if( rc==SQLITE_OK ){
-              doltliteSetSessionBranch(db, zDefault);
-              doltliteSetSessionHead(db, &branchCommit);
-              doltliteSetSessionStaged(db, &commit.catalogHash);
-              chunkStoreSetDefaultBranch(cs, zDefault);
-            }
-            doltliteCommitClear(&commit);
-          }
+        if( rc!=SQLITE_OK || !data ){
+          sqlite3_result_error(ctx, "failed to load default branch commit", -1);
+          return;
+        }
+        rc = doltliteCommitDeserialize(data, nData, &commit);
+        sqlite3_free(data);
+        if( rc!=SQLITE_OK ){
+          sqlite3_result_error(ctx, "failed to deserialize default branch commit", -1);
+          return;
+        }
+        rc = doltliteHardReset(db, &commit.catalogHash);
+        if( rc!=SQLITE_OK ){
+          doltliteCommitClear(&commit);
+          sqlite3_result_error(ctx, "failed to initialize working tree from default branch", -1);
+          return;
+        }
+        doltliteSetSessionBranch(db, zDefault);
+        doltliteSetSessionHead(db, &branchCommit);
+        doltliteSetSessionStaged(db, &commit.catalogHash);
+        rc = chunkStoreSetDefaultBranch(cs, zDefault);
+        doltliteCommitClear(&commit);
+        if( rc!=SQLITE_OK ){
+          sqlite3_result_error(ctx, "failed to record default branch", -1);
+          return;
         }
       }
     }

--- a/test/doltlite_at.sh
+++ b/test/doltlite_at.sh
@@ -41,6 +41,25 @@ run_test "basic_c3" \
 rm -f "$DB"
 
 # ============================================================
+# Quoted table names work in dolt_at_<table>
+# ============================================================
+
+DB=/tmp/test_at_quoted_$$.db; rm -f "$DB"
+echo "CREATE TABLE \"odd\"\"name\"(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO \"odd\"\"name\" VALUES(1,'a');
+SELECT dolt_commit('-A','-m','c1');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test "quoted_name_count" \
+  "SELECT count(*) FROM \"dolt_at_odd\"\"name\"( (SELECT commit_hash FROM dolt_log LIMIT 1));" \
+  "1" "$DB"
+
+run_test "quoted_name_value" \
+  "SELECT v FROM \"dolt_at_odd\"\"name\"( (SELECT commit_hash FROM dolt_log LIMIT 1));" \
+  "a" "$DB"
+
+rm -f "$DB"
+
+# ============================================================
 # Rowid values correct at each commit
 # ============================================================
 

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -13,6 +13,7 @@
 **   ./doltlite_regression_test_c refs_blob_corruption
 **   ./doltlite_regression_test_c conflicts_blob_corruption
 **   ./doltlite_regression_test_c status_error_propagation
+**   ./doltlite_regression_test_c remote_refs_corruption
 */
 #include <stdio.h>
 #include <stdlib.h>
@@ -650,6 +651,59 @@ static void run_status_error_propagation(void){
   remove_db(dbpath);
 }
 
+static void run_remote_refs_corruption(void){
+  sqlite3 *srcDb = 0;
+  sqlite3 *localDb = 0;
+  ChunkStore cs;
+  ProllyHash badRefsHash;
+  u8 badBlob[] = { 5, 0, 0, 0, 0, 1, 0, 0 };
+  char remotePath[256];
+  char localPath[256];
+  int rc;
+
+  printf("=== Remote Refs Corruption Test ===\n\n");
+  make_dbpath(remotePath, sizeof(remotePath), "test_remote_refs_corruption_remote");
+  make_dbpath(localPath, sizeof(localPath), "test_remote_refs_corruption_local");
+  remove_db(remotePath);
+  remove_db(localPath);
+
+  check("open_remote_db", open_db(remotePath, &srcDb)==SQLITE_OK);
+  check("setup_remote_repo", execsql(srcDb,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'a');"
+    "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
+  sqlite3_close(srcDb);
+  srcDb = 0;
+
+  check("open_local_db", open_db(localPath, &localDb)==SQLITE_OK);
+  {
+    char sql[1024];
+    snprintf(sql, sizeof(sql),
+      "CREATE TABLE seed(x INTEGER);"
+      "SELECT dolt_commit('-A', '-m', 'seed');"
+      "SELECT dolt_remote('add','origin','file://%s');",
+      remotePath);
+    check("setup_local_remote", execsql(localDb, sql)==SQLITE_OK);
+  }
+
+  check("open_chunk_store", chunkStoreOpen(&cs, sqlite3_vfs_find(0), remotePath,
+        SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB)==SQLITE_OK);
+  check("lock_remote_store", chunkStoreLockAndRefresh(&cs)==SQLITE_OK);
+  check("put_bad_remote_refs",
+        chunkStorePut(&cs, badBlob, (int)sizeof(badBlob), &badRefsHash)==SQLITE_OK);
+  memcpy(&cs.refsHash, &badRefsHash, sizeof(ProllyHash));
+  check("commit_bad_remote_refs", chunkStoreCommit(&cs)==SQLITE_OK);
+  chunkStoreUnlock(&cs);
+  chunkStoreClose(&cs);
+
+  rc = execsql_silent(localDb, "SELECT dolt_fetch('origin');");
+  check("fetch_surfaces_corrupt_refs", rc!=SQLITE_OK);
+
+  sqlite3_close(localDb);
+  remove_db(remotePath);
+  remove_db(localPath);
+}
+
 static const RegressionCase aCases[] = {
   { "concurrent_refs", "Concurrent Refs Test", run_concurrent_refs },
   { "checkout_persist_failure", "Checkout Persist Failure Test", run_checkout_persist_failure },
@@ -657,7 +711,8 @@ static const RegressionCase aCases[] = {
   { "refs_blob_corruption", "Refs Blob Corruption Test", run_refs_blob_corruption },
   { "refresh_error_propagation", "Refresh Error Propagation Test", run_refresh_error_propagation },
   { "conflicts_blob_corruption", "Conflicts Blob Corruption Test", run_conflicts_blob_corruption },
-  { "status_error_propagation", "Status Error Propagation Test", run_status_error_propagation }
+  { "status_error_propagation", "Status Error Propagation Test", run_status_error_propagation },
+  { "remote_refs_corruption", "Remote Refs Corruption Test", run_remote_refs_corruption }
 };
 
 static int run_case_by_name(const char *zName){


### PR DESCRIPTION
This follow-up review pass fixes several correctness issues in `dolt_at`, remote refs handling, and `dolt_log` traversal performance.

Changes:
- make `dolt_at_<table>` use shared quoted-identifier schema building
- propagate real `dolt_at_<table>` load/scan failures instead of silently returning empty results
- fix the freed-pointer error path in `dolt_at_<table>` connect
- make remote branch enumeration reject corrupt refs blobs and OOM instead of returning partial success
- make `dolt_clone()` fail if origin/default-branch initialization steps fail
- replace `dolt_log`'s quadratic visited scan with `ProllyHashSet`

Coverage:
- added quoted-identifier coverage for `dolt_at_<table>`
- added a C regression for corrupt remote refs on `dolt_fetch('origin')`
- revalidated `dolt_at`, remote integration, and the shared C regression runner