### PR TITLE
Harden GC and schema diff traversal

### DIFF
--- a/src/doltlite_chunk_walk.c
+++ b/src/doltlite_chunk_walk.c
@@ -54,7 +54,7 @@ static int enumerateProllyNodeChildren(
   int i;
 
   rc = prollyNodeParse(&node, data, nData);
-  if( rc!=SQLITE_OK ) return SQLITE_OK; /* parse failure: no children */
+  if( rc!=SQLITE_OK ) return rc;
   if( node.level == 0 ) return SQLITE_OK; /* leaf: no child hashes */
 
   for(i=0; i<(int)node.nItems; i++){
@@ -78,7 +78,7 @@ static int enumerateCommitChildren(
 
   memset(&commit, 0, sizeof(commit));
   drc = doltliteCommitDeserialize(data, nData, &commit);
-  if( drc!=SQLITE_OK ) return SQLITE_OK; /* can't parse: no children */
+  if( drc!=SQLITE_OK ) return drc;
 
   for(pi=0; pi<commit.nParents && rc==SQLITE_OK; pi++){
     rc = xChild(ctx, &commit.aParents[pi]);
@@ -101,13 +101,14 @@ static int enumerateCatalogChildren(
   int i;
   int rc = SQLITE_OK;
 
-  if( !catalogParseHeader(data, nData, &nTables, &p) ) return SQLITE_OK;
-  if( nTables < 0 || nTables >= 10000 ) return SQLITE_OK;
+  if( !catalogParseHeader(data, nData, &nTables, &p) ) return SQLITE_CORRUPT;
+  if( nTables < 0 || nTables >= 10000 ) return SQLITE_CORRUPT;
   for(i=0; i<nTables && rc==SQLITE_OK; i++){
     int nameLen;
     ProllyHash tableRoot;
+    const u8 *pEnd = data + nData;
 
-    if( p + CAT_ENTRY_FIXED_SIZE > data + nData ) break;
+    if( p + CAT_ENTRY_FIXED_SIZE > pEnd ) return SQLITE_CORRUPT;
 
     memcpy(tableRoot.data,
            p + CAT_ENTRY_ITABLE_SIZE + CAT_ENTRY_FLAGS_SIZE,
@@ -117,7 +118,9 @@ static int enumerateCatalogChildren(
 
     p += CAT_ENTRY_ITABLE_SIZE + CAT_ENTRY_FLAGS_SIZE
        + PROLLY_HASH_SIZE + PROLLY_HASH_SIZE;
+    if( p + 2 > pEnd ) return SQLITE_CORRUPT;
     nameLen = p[0] | (p[1]<<8);
+    if( p + 2 + nameLen > pEnd ) return SQLITE_CORRUPT;
     p += 2 + nameLen;
   }
   return rc;

--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -86,21 +86,36 @@ static int gcMarkReachable(
   ** We push catHash to the GC queue. commitHash is skipped because
   ** commits are already reachable via branch refs. */
   if( rc==SQLITE_OK && !prollyHashIsEmpty(&cs->workingState) ){
-    rc = gcQueuePush(&queue, &cs->workingState);
+    rc = prollyHashSetAdd(marked, &cs->workingState);
     if( rc==SQLITE_OK ){
       u8 *wsData = 0; int nWsData = 0;
       int entryHashSize = PROLLY_HASH_SIZE * 2; /* catHash + commitHash */
-      if( chunkStoreGet(cs, &cs->workingState, &wsData, &nWsData)==SQLITE_OK
-       && wsData && nWsData >= 4 ){
+      rc = chunkStoreGet(cs, &cs->workingState, &wsData, &nWsData);
+      if( rc!=SQLITE_OK ){
+        gcQueueFree(&queue);
+        return rc;
+      }
+      if( !wsData || nWsData < 4 ){
+        sqlite3_free(wsData);
+        gcQueueFree(&queue);
+        return SQLITE_CORRUPT;
+      }
+      {
         int nBr = (int)((u32)wsData[0] | ((u32)wsData[1]<<8) | ((u32)wsData[2]<<16) | ((u32)wsData[3]<<24));
         const u8 *pp = wsData + 4;
         int j;
         for(j=0; j<nBr && rc==SQLITE_OK; j++){
           int nl;
-          if( pp + 4 > wsData + nWsData ) break;
+          if( pp + 4 > wsData + nWsData ){
+            rc = SQLITE_CORRUPT;
+            break;
+          }
           nl = (int)((u32)pp[0] | ((u32)pp[1]<<8) | ((u32)pp[2]<<16) | ((u32)pp[3]<<24));
           pp += 4;
-          if( pp + nl + entryHashSize > wsData + nWsData ) break;
+          if( pp + nl + entryHashSize > wsData + nWsData ){
+            rc = SQLITE_CORRUPT;
+            break;
+          }
           {
             ProllyHash brCat;
             memcpy(brCat.data, pp + nl, PROLLY_HASH_SIZE);
@@ -108,8 +123,8 @@ static int gcMarkReachable(
           }
           pp += nl + entryHashSize;
         }
-        sqlite3_free(wsData);
       }
+      sqlite3_free(wsData);
     }
   }
 
@@ -141,8 +156,7 @@ static int gcMarkReachable(
 
     rc = chunkStoreGet(cs, &current, &data, &nData);
     if( rc!=SQLITE_OK ){
-      
-      continue;
+      break;
     }
 
     rc = doltliteEnumerateChunkChildren(data, nData, gcChildCb, &queue);
@@ -528,14 +542,21 @@ int doltliteGcCompact(sqlite3 *db){
     return SQLITE_OK;  
   }
 
-  rc = prollyHashSetInit(&marked, cs->nIndex > 64 ? cs->nIndex : 64);
+  rc = chunkStoreLockAndRefresh(cs);
   if( rc!=SQLITE_OK ) return rc;
+
+  rc = prollyHashSetInit(&marked, cs->nIndex > 64 ? cs->nIndex : 64);
+  if( rc!=SQLITE_OK ){
+    chunkStoreUnlock(cs);
+    return rc;
+  }
 
   rc = gcMarkReachable(cs, &marked);
   if( rc==SQLITE_OK ){
     rc = gcSweep(cs, &marked, &nKept, &nRemoved);
   }
   prollyHashSetFree(&marked);
+  chunkStoreUnlock(cs);
   return rc;
 }
 

--- a/src/doltlite_schema_diff.c
+++ b/src/doltlite_schema_diff.c
@@ -49,6 +49,74 @@ static void freeSchemaDiffRows(SdCursor *c){
   c->nAlloc = 0;
 }
 
+static int appendSchemaEntry(
+  SchemaEntry **paEntries,
+  int *pnEntries,
+  int *pnAlloc,
+  char *zName,
+  char *zSql,
+  char *zType
+){
+  SchemaEntry *aEntries = *paEntries;
+  int nEntries = *pnEntries;
+  int nAlloc = *pnAlloc;
+  if( nEntries >= nAlloc ){
+    int nNew = nAlloc ? nAlloc*2 : 16;
+    SchemaEntry *aNew = sqlite3_realloc(aEntries, nNew*(int)sizeof(SchemaEntry));
+    if( !aNew ) return SQLITE_NOMEM;
+    aEntries = aNew;
+    nAlloc = nNew;
+  }
+  aEntries[nEntries].zName = zName;
+  aEntries[nEntries].zSql = zSql;
+  aEntries[nEntries].zType = zType;
+  *paEntries = aEntries;
+  *pnEntries = nEntries + 1;
+  *pnAlloc = nAlloc;
+  return SQLITE_OK;
+}
+
+static int appendSchemaDiffRow(
+  SdCursor *pCur,
+  const char *zName,
+  const char *zFromSql,
+  const char *zToSql,
+  char *zDiffType
+){
+  SchemaDiffRow *r;
+  if( pCur->nRows >= pCur->nAlloc ){
+    int nNew = pCur->nAlloc ? pCur->nAlloc*2 : 16;
+    SchemaDiffRow *aNew = sqlite3_realloc(pCur->aRows, nNew*(int)sizeof(SchemaDiffRow));
+    if( !aNew ) return SQLITE_NOMEM;
+    pCur->aRows = aNew;
+    pCur->nAlloc = nNew;
+  }
+  r = &pCur->aRows[pCur->nRows];
+  memset(r, 0, sizeof(*r));
+  r->zName = sqlite3_mprintf("%s", zName ? zName : "");
+  if( !r->zName ) return SQLITE_NOMEM;
+  if( zFromSql ){
+    r->zFromSql = sqlite3_mprintf("%s", zFromSql);
+    if( !r->zFromSql ){
+      sqlite3_free(r->zName);
+      memset(r, 0, sizeof(*r));
+      return SQLITE_NOMEM;
+    }
+  }
+  if( zToSql ){
+    r->zToSql = sqlite3_mprintf("%s", zToSql);
+    if( !r->zToSql ){
+      sqlite3_free(r->zName);
+      sqlite3_free(r->zFromSql);
+      memset(r, 0, sizeof(*r));
+      return SQLITE_NOMEM;
+    }
+  }
+  r->zDiffType = zDiffType;
+  pCur->nRows++;
+  return SQLITE_OK;
+}
+
 
 
 int loadSchemaFromCatalog(
@@ -110,36 +178,35 @@ int loadSchemaFromCatalog(
           int len = (aType[0]-13)/2;
           if( aOffset[0]+len <= nVal ){
             zType = sqlite3_malloc(len+1);
-            if(zType){ memcpy(zType, pVal+aOffset[0], len); zType[len]=0; }
+            if( !zType ){ rc = SQLITE_NOMEM; goto load_schema_done; }
+            memcpy(zType, pVal+aOffset[0], len); zType[len]=0;
           }
         }
         if( aType[1] >= 13 && (aType[1]&1)==1 ){
           int len = (aType[1]-13)/2;
           if( aOffset[1]+len <= nVal ){
             zName = sqlite3_malloc(len+1);
-            if(zName){ memcpy(zName, pVal+aOffset[1], len); zName[len]=0; }
+            if( !zName ){ rc = SQLITE_NOMEM; goto load_schema_done; }
+            memcpy(zName, pVal+aOffset[1], len); zName[len]=0;
           }
         }
         if( aType[4] >= 13 && (aType[4]&1)==1 ){
           int len = (aType[4]-13)/2;
           if( aOffset[4]+len <= nVal ){
             zSql = sqlite3_malloc(len+1);
-            if(zSql){ memcpy(zSql, pVal+aOffset[4], len); zSql[len]=0; }
+            if( !zSql ){ rc = SQLITE_NOMEM; goto load_schema_done; }
+            memcpy(zSql, pVal+aOffset[4], len); zSql[len]=0;
           }
         }
 
         if( zName ){
-          if( nEntries >= nAlloc ){
-            int nNew = nAlloc ? nAlloc*2 : 16;
-            SchemaEntry *aNew = sqlite3_realloc(aEntries, nNew*(int)sizeof(SchemaEntry));
-            if( aNew ){ aEntries = aNew; nAlloc = nNew; }
+          rc = appendSchemaEntry(&aEntries, &nEntries, &nAlloc, zName, zSql, zType);
+          if( rc!=SQLITE_OK ){
+            goto load_schema_done;
           }
-          if( nEntries < nAlloc ){
-            aEntries[nEntries].zName = zName; zName = 0;
-            aEntries[nEntries].zSql = zSql; zSql = 0;
-            aEntries[nEntries].zType = zType; zType = 0;
-            nEntries++;
-          }
+          zName = 0;
+          zSql = 0;
+          zType = 0;
         }
         sqlite3_free(zType);
         sqlite3_free(zName);
@@ -151,10 +218,17 @@ int loadSchemaFromCatalog(
     if( rc!=SQLITE_OK ) break;
   }
 
+load_schema_done:
   prollyCursorClose(&cur);
+  if( rc!=SQLITE_OK ){
+    freeSchemaEntries(aEntries, nEntries);
+    *ppEntries = 0;
+    *pnEntries = 0;
+    return rc;
+  }
   *ppEntries = aEntries;
   *pnEntries = nEntries;
-  return SQLITE_OK;
+  return rc;
 }
 
 void freeSchemaEntries(SchemaEntry *a, int n){
@@ -185,37 +259,16 @@ static int computeSchemaDiff(
   
   for(i=0; i<nTo; i++){
     SchemaEntry *fromEntry = findSchemaEntry(aFrom, nFrom, aTo[i].zName);
-    SchemaDiffRow *r;
 
     if( !fromEntry ){
-      
-      if( pCur->nRows >= pCur->nAlloc ){
-        int nNew = pCur->nAlloc ? pCur->nAlloc*2 : 16;
-        SchemaDiffRow *aNew = sqlite3_realloc(pCur->aRows, nNew*(int)sizeof(SchemaDiffRow));
-        if( !aNew ) return SQLITE_NOMEM;
-        pCur->aRows = aNew; pCur->nAlloc = nNew;
-      }
-      r = &pCur->aRows[pCur->nRows++];
-      memset(r, 0, sizeof(*r));
-      r->zName = sqlite3_mprintf("%s", aTo[i].zName);
-      r->zFromSql = 0;
-      r->zToSql = sqlite3_mprintf("%s", aTo[i].zSql ? aTo[i].zSql : "");
-      r->zDiffType = "added";
+      int rc = appendSchemaDiffRow(pCur, aTo[i].zName, 0,
+                                   aTo[i].zSql ? aTo[i].zSql : "", "added");
+      if( rc!=SQLITE_OK ) return rc;
     }else if( fromEntry->zSql && aTo[i].zSql
            && strcmp(fromEntry->zSql, aTo[i].zSql)!=0 ){
-      
-      if( pCur->nRows >= pCur->nAlloc ){
-        int nNew = pCur->nAlloc ? pCur->nAlloc*2 : 16;
-        SchemaDiffRow *aNew = sqlite3_realloc(pCur->aRows, nNew*(int)sizeof(SchemaDiffRow));
-        if( !aNew ) return SQLITE_NOMEM;
-        pCur->aRows = aNew; pCur->nAlloc = nNew;
-      }
-      r = &pCur->aRows[pCur->nRows++];
-      memset(r, 0, sizeof(*r));
-      r->zName = sqlite3_mprintf("%s", aTo[i].zName);
-      r->zFromSql = sqlite3_mprintf("%s", fromEntry->zSql);
-      r->zToSql = sqlite3_mprintf("%s", aTo[i].zSql);
-      r->zDiffType = "modified";
+      int rc = appendSchemaDiffRow(pCur, aTo[i].zName, fromEntry->zSql,
+                                   aTo[i].zSql, "modified");
+      if( rc!=SQLITE_OK ) return rc;
     }
   }
 
@@ -223,19 +276,10 @@ static int computeSchemaDiff(
   for(i=0; i<nFrom; i++){
     SchemaEntry *toEntry = findSchemaEntry(aTo, nTo, aFrom[i].zName);
     if( !toEntry ){
-      SchemaDiffRow *r;
-      if( pCur->nRows >= pCur->nAlloc ){
-        int nNew = pCur->nAlloc ? pCur->nAlloc*2 : 16;
-        SchemaDiffRow *aNew = sqlite3_realloc(pCur->aRows, nNew*(int)sizeof(SchemaDiffRow));
-        if( !aNew ) return SQLITE_NOMEM;
-        pCur->aRows = aNew; pCur->nAlloc = nNew;
-      }
-      r = &pCur->aRows[pCur->nRows++];
-      memset(r, 0, sizeof(*r));
-      r->zName = sqlite3_mprintf("%s", aFrom[i].zName);
-      r->zFromSql = sqlite3_mprintf("%s", aFrom[i].zSql ? aFrom[i].zSql : "");
-      r->zToSql = 0;
-      r->zDiffType = "dropped";
+      int rc = appendSchemaDiffRow(pCur, aFrom[i].zName,
+                                   aFrom[i].zSql ? aFrom[i].zSql : "",
+                                   0, "dropped");
+      if( rc!=SQLITE_OK ) return rc;
     }
   }
 
@@ -326,7 +370,6 @@ static int sdFilter(sqlite3_vtab_cursor *cur,
   ProllyHash fromCatHash, toCatHash;
   SchemaEntry *aFrom = 0, *aTo = 0;
   int nFrom = 0, nTo = 0;
-  u8 *data = 0; int nData = 0;
   int rc, argIdx = 0;
   (void)idxStr;
 
@@ -350,77 +393,80 @@ static int sdFilter(sqlite3_vtab_cursor *cur,
     const char *zTableFilter = 0;
     if( zFromRef && !zToRef ){
       ProllyHash testHash;
-      int resolved = doltliteResolveRef(db,zFromRef, &testHash);
-      if( resolved!=SQLITE_OK ){
-        
+      rc = doltliteResolveRef(db,zFromRef, &testHash);
+      if( rc==SQLITE_NOTFOUND ){
         zTableFilter = zFromRef;
         zFromRef = 0;
+      }else if( rc!=SQLITE_OK ){
+        return rc;
       }
     }
 
     
     if( zFromRef ){
-    rc = doltliteResolveRef(db,zFromRef, &fromCommit);
-    if( rc!=SQLITE_OK ) return SQLITE_OK;
-    memset(&commit, 0, sizeof(commit));
-    rc = doltliteLoadCommit(db, &fromCommit, &commit);
-    if( rc!=SQLITE_OK ) return SQLITE_OK;
-    memcpy(&fromCatHash, &commit.catalogHash, sizeof(ProllyHash));
-    doltliteCommitClear(&commit);
-  }else{
-    
-    rc = doltliteGetHeadCatalogHash(db, &fromCatHash);
-    if( rc!=SQLITE_OK ) return SQLITE_OK;
-  }
-
-  
-  if( zToRef ){
-    rc = doltliteResolveRef(db,zToRef, &toCommit);
-    if( rc!=SQLITE_OK ) return SQLITE_OK;
-    memset(&commit, 0, sizeof(commit));
-    rc = doltliteLoadCommit(db, &toCommit, &commit);
-    if( rc!=SQLITE_OK ) return SQLITE_OK;
-    memcpy(&toCatHash, &commit.catalogHash, sizeof(ProllyHash));
-    doltliteCommitClear(&commit);
-  }else{
-    
-    u8 *catData = 0; int nCatData = 0;
-    rc = doltliteFlushAndSerializeCatalog(db, &catData, &nCatData);
-    if( rc==SQLITE_OK ){
-      rc = chunkStorePut(cs, catData, nCatData, &toCatHash);
-      sqlite3_free(catData);
+      rc = doltliteResolveRef(db,zFromRef, &fromCommit);
+      if( rc!=SQLITE_OK ) return rc;
+      memset(&commit, 0, sizeof(commit));
+      rc = doltliteLoadCommit(db, &fromCommit, &commit);
+      if( rc!=SQLITE_OK ) return rc;
+      memcpy(&fromCatHash, &commit.catalogHash, sizeof(ProllyHash));
+      doltliteCommitClear(&commit);
+    }else{
+      rc = doltliteGetHeadCatalogHash(db, &fromCatHash);
+      if( rc!=SQLITE_OK ) return rc;
     }
-    if( rc!=SQLITE_OK ) return SQLITE_OK;
-  }
 
   
-  loadSchemaFromCatalog(db, cs, pCache, &fromCatHash, &aFrom, &nFrom);
-  loadSchemaFromCatalog(db, cs, pCache, &toCatHash, &aTo, &nTo);
-
-  
-  computeSchemaDiff(c, aFrom, nFrom, aTo, nTo);
-
-  
-  if( zTableFilter ){
-    int j, k=0;
-    for(j=0; j<c->nRows; j++){
-      if( c->aRows[j].zName && strcmp(c->aRows[j].zName, zTableFilter)==0 ){
-        if( k!=j ) c->aRows[k] = c->aRows[j];
-        k++;
-      }else{
-        sqlite3_free(c->aRows[j].zName);
-        sqlite3_free(c->aRows[j].zFromSql);
-        sqlite3_free(c->aRows[j].zToSql);
+    if( zToRef ){
+      rc = doltliteResolveRef(db,zToRef, &toCommit);
+      if( rc!=SQLITE_OK ) return rc;
+      memset(&commit, 0, sizeof(commit));
+      rc = doltliteLoadCommit(db, &toCommit, &commit);
+      if( rc!=SQLITE_OK ) return rc;
+      memcpy(&toCatHash, &commit.catalogHash, sizeof(ProllyHash));
+      doltliteCommitClear(&commit);
+    }else{
+      u8 *catData = 0; int nCatData = 0;
+      rc = doltliteFlushAndSerializeCatalog(db, &catData, &nCatData);
+      if( rc==SQLITE_OK ){
+        rc = chunkStorePut(cs, catData, nCatData, &toCatHash);
+        sqlite3_free(catData);
       }
+      if( rc!=SQLITE_OK ) return rc;
     }
-    c->nRows = k;
+
+  
+    rc = loadSchemaFromCatalog(db, cs, pCache, &fromCatHash, &aFrom, &nFrom);
+    if( rc!=SQLITE_OK ) goto sd_filter_done;
+    rc = loadSchemaFromCatalog(db, cs, pCache, &toCatHash, &aTo, &nTo);
+    if( rc!=SQLITE_OK ) goto sd_filter_done;
+
+  
+    rc = computeSchemaDiff(c, aFrom, nFrom, aTo, nTo);
+    if( rc!=SQLITE_OK ) goto sd_filter_done;
+
+  
+    if( zTableFilter ){
+      int j, k=0;
+      for(j=0; j<c->nRows; j++){
+        if( c->aRows[j].zName && strcmp(c->aRows[j].zName, zTableFilter)==0 ){
+          if( k!=j ) c->aRows[k] = c->aRows[j];
+          k++;
+        }else{
+          sqlite3_free(c->aRows[j].zName);
+          sqlite3_free(c->aRows[j].zFromSql);
+          sqlite3_free(c->aRows[j].zToSql);
+        }
+      }
+      c->nRows = k;
+    }
+
   }
 
-  } 
-
+sd_filter_done:
   freeSchemaEntries(aFrom, nFrom);
   freeSchemaEntries(aTo, nTo);
-  return SQLITE_OK;
+  return rc;
 }
 
 static int sdNext(sqlite3_vtab_cursor *cur){ ((SdCursor*)cur)->iRow++; return SQLITE_OK; }

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -14,6 +14,7 @@
 **   ./doltlite_regression_test_c conflicts_blob_corruption
 **   ./doltlite_regression_test_c status_error_propagation
 **   ./doltlite_regression_test_c remote_refs_corruption
+**   ./doltlite_regression_test_c chunk_walk_corruption
 */
 #include <stdio.h>
 #include <stdlib.h>
@@ -22,6 +23,7 @@
 #include "sqlite3.h"
 #include "prolly_hash.h"
 #include "chunk_store.h"
+#include "doltlite_chunk_walk.h"
 #include "doltlite_internal.h"
 
 typedef unsigned char u8;
@@ -704,6 +706,22 @@ static void run_remote_refs_corruption(void){
   remove_db(localPath);
 }
 
+static void run_chunk_walk_corruption(void){
+  static const u8 badCatalog[] = {
+    'D','L','C','T',
+    3, 0,
+    1, 0, 0, 0,
+    2, 0, 0, 0,
+    0,
+    1, 0
+  };
+  int rc;
+
+  printf("=== Chunk Walk Corruption Test ===\n\n");
+  rc = doltliteEnumerateChunkChildren(badCatalog, (int)sizeof(badCatalog), 0, 0);
+  check("truncated_catalog_is_corrupt", rc==SQLITE_CORRUPT);
+}
+
 static const RegressionCase aCases[] = {
   { "concurrent_refs", "Concurrent Refs Test", run_concurrent_refs },
   { "checkout_persist_failure", "Checkout Persist Failure Test", run_checkout_persist_failure },
@@ -712,7 +730,8 @@ static const RegressionCase aCases[] = {
   { "refresh_error_propagation", "Refresh Error Propagation Test", run_refresh_error_propagation },
   { "conflicts_blob_corruption", "Conflicts Blob Corruption Test", run_conflicts_blob_corruption },
   { "status_error_propagation", "Status Error Propagation Test", run_status_error_propagation },
-  { "remote_refs_corruption", "Remote Refs Corruption Test", run_remote_refs_corruption }
+  { "remote_refs_corruption", "Remote Refs Corruption Test", run_remote_refs_corruption },
+  { "chunk_walk_corruption", "Chunk Walk Corruption Test", run_chunk_walk_corruption }
 };
 
 static int run_case_by_name(const char *zName){

--- a/test/doltlite_schema_diff.sh
+++ b/test/doltlite_schema_diff.sh
@@ -70,6 +70,21 @@ run_test "none_count" "SELECT count(*) FROM dolt_schema_diff('v1','v2');" "0" "$
 rm -f "$DB"
 
 # ============================================================
+# Bad refs surface an error
+# ============================================================
+
+DB=/tmp/test_sd_badref_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_commit('-A','-m','c1');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test_match "bad_to_ref_errors" \
+  "SELECT count(*) FROM dolt_schema_diff((SELECT commit_hash FROM dolt_log LIMIT 1),'definitely_not_a_ref');" \
+  "Error" "$DB"
+
+rm -f "$DB"
+
+# ============================================================
 # Resolve by branch name
 # ============================================================
 


### PR DESCRIPTION
## Summary
- make chunk-walk and GC traversal fail hard on corrupt or unreadable reachable chunks instead of treating them as empty leaves
- lock the internal GC compaction path the same way `dolt_gc()` does
- make `dolt_schema_diff` propagate ref, catalog, cursor, and allocation errors instead of returning partial or empty success

## Testing
- cd build && bash ../test/doltlite_gc.sh
- cd build && bash ../test/doltlite_schema_diff.sh
- cd build && bash ../test/doltlite_regression_test_c.sh