### PR TITLE
Seed new repositories with an init commit, matching Dolt

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -1630,6 +1630,16 @@ int chunkStoreIsEmpty(ChunkStore *cs){
   return cs->nBranches == 0 && prollyHashIsEmpty(&cs->refsHash);
 }
 
+void chunkStoreClearRefs(ChunkStore *cs){
+  csFreeBranches(cs);
+  csFreeTags(cs);
+  csFreeRemotes(cs);
+  csFreeTracking(cs);
+  memset(&cs->refsHash, 0, sizeof(cs->refsHash));
+  memset(&cs->workingState, 0, sizeof(cs->workingState));
+  memset(&cs->stagedCatalog, 0, sizeof(cs->stagedCatalog));
+}
+
 int chunkStoreReloadRefs(ChunkStore *cs){
   u8 *refsData = 0;
   int nRefsData = 0;

--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -244,6 +244,8 @@ void chunkStoreRollback(ChunkStore *cs);
 
 int chunkStoreIsEmpty(ChunkStore *cs);
 
+void chunkStoreClearRefs(ChunkStore *cs);
+
 const char *chunkStoreFilename(ChunkStore *cs);
 
 int chunkStoreRefreshIfChanged(ChunkStore *cs, int *pChanged);

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -1246,6 +1246,34 @@ static void doltliteConfigFunc(sqlite3_context *context, int argc, sqlite3_value
   }
 }
 
+/*
+** Seed a brand-new repository with an "Initialize data repository" commit
+** on the default branch. Matches Dolt: a freshly initialized repo has one
+** commit whose catalog is empty. No-op if the chunk store already has any
+** branches, if no chunk store is attached, or if the database was opened
+** read-only.
+*/
+static void doltliteMaybeSeedRepo(sqlite3 *db){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  ProllyHash emptyParent;
+  ProllyHash emptyCatalog;
+  ProllyHash seedHash;
+  int rc;
+
+  if( !cs ) return;
+  if( cs->nBranches > 0 ) return;
+  if( sqlite3_db_readonly(db, "main")==1 ) return;
+
+  memset(&emptyParent, 0, sizeof(emptyParent));
+  memset(&emptyCatalog, 0, sizeof(emptyCatalog));
+
+  rc = doltliteCreateAndStoreCommit(db, &emptyParent, &emptyCatalog,
+      "Initialize data repository", NULL, NULL, 0, 0, &seedHash);
+  if( rc!=SQLITE_OK ) return;
+
+  (void)doltliteAdvanceBranch(db, &seedHash, &emptyCatalog);
+}
+
 void doltliteRegister(sqlite3 *db){
   sqlite3_create_function(db, "dolt_commit", -1, SQLITE_UTF8, 0,
                           doltliteCommitFunc, 0, 0);
@@ -1277,6 +1305,7 @@ void doltliteRegister(sqlite3 *db){
     extern void doltliteRemoteSqlRegister(sqlite3 *db);
     doltliteRemoteSqlRegister(db);
   }
+  doltliteMaybeSeedRepo(db);
 }
 
 #endif 

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -482,9 +482,25 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   }
 
   
+  /* Allow cloning over a pristine, auto-seeded repository: a single branch
+  ** whose head commit is a root (empty parent). Any real commit descends
+  ** from the seed and thus has a non-empty parent. */
   if( !chunkStoreIsEmpty(cs) ){
-    sqlite3_result_error(ctx, "database is not empty — clone into a fresh database", -1);
-    return;
+    int virgin = 0;
+    if( cs->nBranches==1 ){
+      DoltliteCommit c;
+      memset(&c, 0, sizeof(c));
+      if( doltliteLoadCommit(db, &cs->aBranches[0].commitHash, &c)==SQLITE_OK
+       && prollyHashIsEmpty(&c.parentHash) ){
+        virgin = 1;
+      }
+      doltliteCommitClear(&c);
+    }
+    if( !virgin ){
+      sqlite3_result_error(ctx, "database is not empty — clone into a fresh database", -1);
+      return;
+    }
+    chunkStoreClearRefs(cs);
   }
 
   pRemote = openRemoteByUrl(cs->pVfs, zUrl);

--- a/test/config_test.sh
+++ b/test/config_test.sh
@@ -223,7 +223,7 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','third');
 .quit
 SQL
-result=$("$DB" "$TMPDIR/t12.db" "SELECT count(DISTINCT committer) FROM dolt_log;")
+result=$("$DB" "$TMPDIR/t12.db" "SELECT count(DISTINCT committer) FROM dolt_log WHERE message != 'Initialize data repository';")
 check "all 3 commits same author" "1" "$result"
 
 result=$("$DB" "$TMPDIR/t12.db" "SELECT committer FROM dolt_log LIMIT 1;")

--- a/test/doltlite_advanced.sh
+++ b/test/doltlite_advanced.sh
@@ -65,7 +65,7 @@ run_test_match "txn_status" "SELECT count(*) FROM dolt_status;" "^[1-9]" "$DB"
 # Dolt commit captures it
 run_test_match "txn_dolt_commit" "SELECT dolt_commit('-A','-m','txn work');" "^[0-9a-f]{40}$" "$DB"
 run_test "txn_clean" "SELECT count(*) FROM dolt_status;" "0" "$DB"
-run_test "txn_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
+run_test "txn_log" "SELECT count(*) FROM dolt_log;" "3" "$DB"
 
 rm -f "$DB"
 
@@ -103,7 +103,7 @@ echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 SELECT dolt_commit('-A','-m','empty table');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "empty_count" "SELECT count(*) FROM t;" "0" "$DB"
-run_test "empty_log" "SELECT count(*) FROM dolt_log;" "1" "$DB"
+run_test "empty_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 run_test "empty_diff" "SELECT count(*) FROM dolt_diff('t');" "0" "$DB"
 
 # Branch empty table
@@ -141,7 +141,7 @@ INSERT INTO ids VALUES(50);
 SELECT dolt_commit('-A','-m','more ids');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "pkonly_count2" "SELECT count(*) FROM ids;" "5" "$DB"
-run_test "pkonly_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
+run_test "pkonly_log" "SELECT count(*) FROM dolt_log;" "3" "$DB"
 
 rm -f "$DB"
 
@@ -168,7 +168,7 @@ echo "INSERT OR REPLACE INTO t VALUES(2,'or_replaced');
 SELECT dolt_commit('-A','-m','or replace');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "or_replace_val" "SELECT v FROM t WHERE id=2;" "or_replaced" "$DB"
-run_test "or_replace_log" "SELECT count(*) FROM dolt_log;" "3" "$DB"
+run_test "or_replace_log" "SELECT count(*) FROM dolt_log;" "4" "$DB"
 
 rm -f "$DB"
 
@@ -189,7 +189,7 @@ SELECT dolt_commit('-A','-m','ignore test');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "ignore_orig" "SELECT v FROM t WHERE id=1;" "first" "$DB"
 run_test "ignore_new" "SELECT v FROM t WHERE id=2;" "new" "$DB"
 run_test "ignore_count" "SELECT count(*) FROM t;" "2" "$DB"
-run_test "ignore_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
+run_test "ignore_log" "SELECT count(*) FROM dolt_log;" "3" "$DB"
 
 rm -f "$DB"
 
@@ -298,7 +298,7 @@ run_test "multiupd_count" "SELECT count(*) FROM t;" "1" "$DB"
 run_test_match "multiupd_diff" \
   "SELECT count(*) FROM dolt_diff('t', (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1), (SELECT commit_hash FROM dolt_log LIMIT 1));" \
   "^1$" "$DB"
-run_test "multiupd_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
+run_test "multiupd_log" "SELECT count(*) FROM dolt_log;" "3" "$DB"
 
 rm -f "$DB"
 
@@ -431,14 +431,14 @@ DB=/tmp/test_adv_schemaonly_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 SELECT dolt_commit('-A','-m','empty schema');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-run_test "schemaonly_log" "SELECT count(*) FROM dolt_log;" "1" "$DB"
+run_test "schemaonly_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 run_test "schemaonly_count" "SELECT count(*) FROM t;" "0" "$DB"
 
 # Add another table (schema change, no data)
 echo "CREATE TABLE t2(id INTEGER PRIMARY KEY);
 SELECT dolt_commit('-A','-m','add t2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-run_test "schemaonly_log2" "SELECT count(*) FROM dolt_log;" "2" "$DB"
+run_test "schemaonly_log2" "SELECT count(*) FROM dolt_log;" "3" "$DB"
 run_test "schemaonly_tables" "SELECT count(*) FROM sqlite_master WHERE type='table';" "2" "$DB"
 
 rm -f "$DB"
@@ -540,7 +540,7 @@ run_test "logorder_last" "SELECT message FROM dolt_log LIMIT 1 OFFSET 2;" "first
 
 # Count and offset
 run_test "logorder_offset1" "SELECT message FROM dolt_log LIMIT 1 OFFSET 1;" "second" "$DB"
-run_test "logorder_total" "SELECT count(*) FROM dolt_log;" "3" "$DB"
+run_test "logorder_total" "SELECT count(*) FROM dolt_log;" "4" "$DB"
 
 rm -f "$DB"
 

--- a/test/doltlite_branch.sh
+++ b/test/doltlite_branch.sh
@@ -33,10 +33,6 @@ run_test "delete_branch" "SELECT dolt_branch('-d','feature');" "0" "$DB"
 run_test "one_branch" "SELECT count(*) FROM dolt_branches;" "1" "$DB"
 run_test_match "checkout_gone" "SELECT dolt_checkout('feature');" "not found" "$DB"
 
-DB2=/tmp/test_branch2_$$.db; rm -f "$DB2"
-echo "CREATE TABLE t(x);" | $DOLTLITE "$DB2" > /dev/null 2>&1
-run_test_match "branch_no_commit" "SELECT dolt_branch('foo');" "no commits" "$DB2"
-
 DB3=/tmp/test_branch3_$$.db; rm -f "$DB3"
 echo "CREATE TABLE t(x); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','i');" | $DOLTLITE "$DB3" > /dev/null 2>&1
 echo "SELECT dolt_branch('b2');" | $DOLTLITE "$DB3" > /dev/null 2>&1

--- a/test/doltlite_branch_edge.sh
+++ b/test/doltlite_branch_edge.sh
@@ -150,7 +150,7 @@ echo "SELECT dolt_reset('--hard','$C1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 # Session 2: verify reset took effect
 run_test "xsess_reset_count" "SELECT count(*) FROM t;" "1" "$DB"
 run_test "xsess_reset_val" "SELECT v FROM t WHERE id=1;" "keep" "$DB"
-run_test "xsess_reset_log" "SELECT count(*) FROM dolt_log;" "1" "$DB"
+run_test "xsess_reset_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 db_rm "$DB"
 
 echo ""
@@ -208,7 +208,7 @@ run_test_match "ff_history_count" \
 
 # Test: dolt_log after fast-forward merge -- no merge commit
 run_test "ff_log_no_merge" "SELECT message FROM dolt_log LIMIT 1;" "feat commit 2" "$DB"
-run_test "ff_log_count" "SELECT count(*) FROM dolt_log;" "3" "$DB"
+run_test "ff_log_count" "SELECT count(*) FROM dolt_log;" "4" "$DB"
 
 # Test: dolt_at with branch name shows branch's committed state
 DB2=/tmp/test_bedge_at_branch_$$.db; db_rm "$DB2"
@@ -275,7 +275,7 @@ echo "SELECT dolt_reset('--hard','$C1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "reset_hash_count" "SELECT count(*) FROM t;" "1" "$DB"
 run_test "reset_hash_val" "SELECT v FROM t WHERE id=1;" "v1" "$DB"
-run_test "reset_hash_log" "SELECT count(*) FROM dolt_log;" "1" "$DB"
+run_test "reset_hash_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 db_rm "$DB"
 
 # Test: Soft reset unstages but keeps working changes
@@ -453,7 +453,7 @@ run_test "ff_merge_data" "SELECT count(*) FROM t;" "2" "$DB"
 run_test "ff_merge_val" "SELECT v FROM t WHERE id=2;" "ff_data" "$DB"
 # No merge commit: last message should be feat's commit
 run_test "ff_merge_no_merge_commit" "SELECT message FROM dolt_log LIMIT 1;" "feat commit" "$DB"
-run_test "ff_merge_log_count" "SELECT count(*) FROM dolt_log;" "2" "$DB"
+run_test "ff_merge_log_count" "SELECT count(*) FROM dolt_log;" "3" "$DB"
 db_rm "$DB"
 
 # Test: Non-fast-forward merge -- merge commit exists, data from both branches
@@ -476,7 +476,7 @@ run_test "noff_merge_feat_row" "SELECT v FROM t WHERE id=3;" "feat_row" "$DB"
 # Non-ff merge should have a merge commit
 run_test_match "noff_merge_commit_msg" "SELECT message FROM dolt_log LIMIT 1;" "Merge" "$DB"
 # Log should have: merge, main adds, feat adds, init = 4 commits
-run_test "noff_merge_log_count" "SELECT count(*) FROM dolt_log;" "4" "$DB"
+run_test "noff_merge_log_count" "SELECT count(*) FROM dolt_log;" "5" "$DB"
 db_rm "$DB"
 
 echo ""
@@ -514,7 +514,7 @@ done
 
 run_test_match "gc_many_commits" "SELECT dolt_gc();" "chunks" "$DB"
 run_test "gc_many_val" "SELECT v FROM t WHERE id=1;" "v15" "$DB"
-run_test "gc_many_log" "SELECT count(*) FROM dolt_log;" "16" "$DB"
+run_test "gc_many_log" "SELECT count(*) FROM dolt_log;" "17" "$DB"
 
 # Verify old commits still reachable via dolt_at
 run_test_match "gc_many_history" \
@@ -529,7 +529,7 @@ SELECT dolt_commit('-A','-m','empty');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test_match "gc_empty_db" "SELECT dolt_gc();" "chunks" "$DB"
 run_test "gc_empty_db_data" "SELECT count(*) FROM t;" "0" "$DB"
-run_test "gc_empty_db_log" "SELECT count(*) FROM dolt_log;" "1" "$DB"
+run_test "gc_empty_db_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 db_rm "$DB"
 
 echo ""

--- a/test/doltlite_branch_gc_stress.sh
+++ b/test/doltlite_branch_gc_stress.sh
@@ -291,7 +291,7 @@ SELECT dolt_commit('-A','-m','first');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "gc_first_commit" "SELECT dolt_gc();" "chunks" "$DB"
 run_test "gc_first_data" "SELECT count(*) FROM t;" "1" "$DB"
 run_test "gc_first_val" "SELECT v FROM t WHERE id=1;" "hello" "$DB"
-run_test "gc_first_log" "SELECT count(*) FROM dolt_log;" "1" "$DB"
+run_test "gc_first_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 
 db_rm "$DB"
 
@@ -325,7 +325,7 @@ run_test_match "recycle_gc" "SELECT dolt_gc();" "chunks removed" "$DB"
 
 # Data still intact after GC
 run_test "recycle_post_gc_data" "SELECT count(*) FROM t;" "1" "$DB"
-run_test "recycle_post_gc_log" "SELECT count(*) FROM dolt_log;" "1" "$DB"
+run_test "recycle_post_gc_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 
 # Create the branch one more time to prove the name is reusable after GC
 echo "SELECT dolt_branch('recycled');" | $DOLTLITE "$DB" > /dev/null 2>&1

--- a/test/doltlite_cherry_pick.sh
+++ b/test/doltlite_cherry_pick.sh
@@ -32,7 +32,7 @@ run_test "cp_basic_count" "SELECT count(*) FROM t;" "2" "$DB"
 run_test "cp_basic_val" "SELECT v FROM t WHERE id=2;" "feat_row" "$DB"
 run_test_match "cp_basic_msg" "SELECT message FROM dolt_log LIMIT 1;" "Cherry-pick: add feat_row" "$DB"
 run_test "cp_basic_branch" "SELECT active_branch();" "main" "$DB"
-run_test "cp_basic_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
+run_test "cp_basic_log" "SELECT count(*) FROM dolt_log;" "3" "$DB"
 
 rm -f "$DB"
 
@@ -142,9 +142,9 @@ run_test_match "cp_err_noarg" "SELECT dolt_cherry_pick();" "usage" "$DB"
 # Invalid hash
 run_test_match "cp_err_badhash" "SELECT dolt_cherry_pick('not_a_hash');" "invalid" "$DB"
 
-# Cannot cherry-pick initial commit (no parent)
+# Cannot cherry-pick the root (seed) commit: it has no parent to replay
 run_test_match "cp_err_initial" \
-  "SELECT dolt_cherry_pick((SELECT commit_hash FROM dolt_log LIMIT 1));" \
+  "SELECT dolt_cherry_pick((SELECT commit_hash FROM dolt_log WHERE message='Initialize data repository'));" \
   "initial commit" "$DB"
 
 rm -f "$DB"
@@ -194,7 +194,7 @@ run_test "rv_basic_count" "SELECT count(*) FROM t;" "1" "$DB"
 run_test "rv_basic_val" "SELECT v FROM t WHERE id=1;" "init" "$DB"
 run_test "rv_basic_no2" "SELECT count(*) FROM t WHERE id=2;" "0" "$DB"
 run_test_match "rv_basic_msg" "SELECT message FROM dolt_log LIMIT 1;" "Revert 'add row 2'" "$DB"
-run_test "rv_basic_log" "SELECT count(*) FROM dolt_log;" "3" "$DB"
+run_test "rv_basic_log" "SELECT count(*) FROM dolt_log;" "4" "$DB"
 
 rm -f "$DB"
 
@@ -288,7 +288,7 @@ SELECT dolt_commit('-A','-m','c1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "rv_err_noarg" "SELECT dolt_revert();" "usage" "$DB"
 run_test_match "rv_err_badhash" "SELECT dolt_revert('bad');" "invalid" "$DB"
 run_test_match "rv_err_initial" \
-  "SELECT dolt_revert((SELECT commit_hash FROM dolt_log LIMIT 1));" \
+  "SELECT dolt_revert((SELECT commit_hash FROM dolt_log WHERE message='Initialize data repository'));" \
   "initial commit" "$DB"
 
 rm -f "$DB"
@@ -309,7 +309,7 @@ echo "SELECT dolt_revert((SELECT commit_hash FROM dolt_log LIMIT 1));" | $DOLTLI
 # Verify after reopen
 run_test "rv_persist_count" "SELECT count(*) FROM t;" "1" "$DB"
 run_test_match "rv_persist_log" "SELECT message FROM dolt_log LIMIT 1;" "Revert" "$DB"
-run_test "rv_persist_log_count" "SELECT count(*) FROM dolt_log;" "3" "$DB"
+run_test "rv_persist_log_count" "SELECT count(*) FROM dolt_log;" "4" "$DB"
 
 rm -f "$DB"
 
@@ -336,7 +336,7 @@ run_test_match "combo_revert" \
   "SELECT dolt_revert((SELECT commit_hash FROM dolt_log LIMIT 1));" \
   "^[0-9a-f]{40}$" "$DB"
 run_test "combo_after_rv" "SELECT count(*) FROM t;" "1" "$DB"
-run_test "combo_log" "SELECT count(*) FROM dolt_log;" "3" "$DB"
+run_test "combo_log" "SELECT count(*) FROM dolt_log;" "4" "$DB"
 
 rm -f "$DB"
 
@@ -373,7 +373,7 @@ echo "SELECT dolt_cherry_pick('$HASH2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "cp_multi_both" "SELECT count(*) FROM t;" "3" "$DB"
 run_test "cp_multi_has11" "SELECT v FROM t WHERE id=11;" "cp2" "$DB"
-run_test "cp_multi_log" "SELECT count(*) FROM dolt_log;" "3" "$DB"
+run_test "cp_multi_log" "SELECT count(*) FROM dolt_log;" "4" "$DB"
 
 rm -f "$DB"
 
@@ -398,7 +398,7 @@ run_test_match "rv_double_revert2" \
   "^[0-9a-f]{40}$" "$DB"
 run_test "rv_double_after2" "SELECT count(*) FROM t;" "2" "$DB"
 run_test "rv_double_val" "SELECT v FROM t WHERE id=2;" "added" "$DB"
-run_test "rv_double_log" "SELECT count(*) FROM dolt_log;" "4" "$DB"
+run_test "rv_double_log" "SELECT count(*) FROM dolt_log;" "5" "$DB"
 
 rm -f "$DB"
 

--- a/test/doltlite_commit.sh
+++ b/test/doltlite_commit.sh
@@ -77,7 +77,7 @@ run_test_match "second_commit" \
 
 run_test "log_count_two" \
   "SELECT count(*) FROM dolt_log;" \
-  "2" "$DB"
+  "3" "$DB"
 
 run_test_match "log_order" \
   "SELECT message FROM dolt_log;" \
@@ -99,7 +99,7 @@ run_test "author_email" \
 
 run_test "log_count_three" \
   "SELECT count(*) FROM dolt_log;" \
-  "3" "$DB"
+  "4" "$DB"
 
 # --- Data persists across reopen ---
 
@@ -114,7 +114,7 @@ run_test "persist_data" \
 coat" "$DB2"
 
 run_test "persist_log" \
-  "SELECT message FROM dolt_log;" \
+  "SELECT message FROM dolt_log LIMIT 1;" \
   "create items" "$DB2"
 
 # --- Commit after schema change ---
@@ -125,13 +125,13 @@ run_test_match "commit_after_alter" \
 
 run_test "log_after_alter" \
   "SELECT count(*) FROM dolt_log;" \
-  "2" "$DB2"
+  "3" "$DB2"
 
 # --- Empty log before first commit ---
 
 run_test "empty_log" \
   "SELECT count(*) FROM dolt_log;" \
-  "0" ":memory:"
+  "1" ":memory:"
 
 # --- Commit with no changes (should fail) ---
 
@@ -146,7 +146,7 @@ run_test "commit_no_changes" \
 
 run_test "one_commit_after_no_change" \
   "SELECT count(*) FROM dolt_log;" \
-  "1" "$DB3"
+  "2" "$DB3"
 
 # --- Multiple tables ---
 
@@ -238,7 +238,7 @@ SELECT dolt_commit('-am','second');" \
 
 run_test "compound_am_multi_count" \
   "SELECT count(*) FROM dolt_log;" \
-  "2" "$DB8"
+  "3" "$DB8"
 
 run_test "compound_am_multi_data" \
   "SELECT count(*) FROM t;" \

--- a/test/doltlite_deep_history.sh
+++ b/test/doltlite_deep_history.sh
@@ -54,7 +54,7 @@ echo "Done building commits."
 echo "Test 1: dolt_log count..."
 run_test "log_count_500" \
   "SELECT count(*) FROM dolt_log;" \
-  "500" "$DB"
+  "501" "$DB"
 
 # ============================================================
 # Test 2: dolt_diff between first and last commit works

--- a/test/doltlite_demo.sh
+++ b/test/doltlite_demo.sh
@@ -24,7 +24,7 @@ CREATE TABLE employees_teams(team_id INTEGER, employee_id INTEGER, PRIMARY KEY(t
 SELECT dolt_commit('-A','-m','Created initial schema');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "schema_tables" "SELECT count(*) FROM sqlite_master WHERE type='table';" "3" "$DB"
-run_test "schema_log" "SELECT count(*) FROM dolt_log;" "1" "$DB"
+run_test "schema_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 run_test_match "schema_msg" "SELECT message FROM dolt_log;" "Created initial schema" "$DB"
 run_test "schema_clean" "SELECT count(*) FROM dolt_status;" "0" "$DB"
 
@@ -60,7 +60,7 @@ run_test "data_eng_team" \
 echo "SELECT dolt_commit('-A','-m','Populated tables with data');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_tag('v1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-run_test "data_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
+run_test "data_log" "SELECT count(*) FROM dolt_log;" "3" "$DB"
 run_test "data_clean" "SELECT count(*) FROM dolt_status;" "0" "$DB"
 
 # ============================================================
@@ -186,7 +186,7 @@ run_test "tags_v1_data" "SELECT count(*) FROM dolt_at_employees('v1');" "4" "$DB
 # ============================================================
 
 run_test "persist_emp" "SELECT count(*) FROM employees;" "5" "$DB"
-run_test "persist_log" "SELECT count(*) FROM dolt_log;" "3" "$DB"
+run_test "persist_log" "SELECT count(*) FROM dolt_log;" "4" "$DB"
 run_test "persist_branch" "SELECT active_branch();" "main" "$DB"
 run_test "persist_tags" "SELECT count(*) FROM dolt_tags;" "1" "$DB"
 

--- a/test/doltlite_diff_table.sh
+++ b/test/doltlite_diff_table.sh
@@ -74,11 +74,6 @@ run_test_match "ctx_from_hash" "SELECT from_commit FROM dolt_diff_t WHERE diff_t
 # to_commit_date should be a datetime string
 run_test_match "ctx_to_date" "SELECT to_commit_date FROM dolt_diff_t LIMIT 1;" "^[0-9]{4}-" "$DB"
 
-# For the initial commit, from_commit is all zeros
-run_test_match "ctx_initial_from" \
-  "SELECT from_commit FROM dolt_diff_t WHERE to_v IS NOT NULL AND diff_type='added';" \
-  "^0{40}$" "$DB"
-
 rm -f "$DB"
 
 # ============================================================

--- a/test/doltlite_e2e.sh
+++ b/test/doltlite_e2e.sh
@@ -29,7 +29,7 @@ SELECT dolt_commit('-A','-m','Initial schema: users and posts');" | $DOLTLITE "$
 run_test "e2e_initial_users" "SELECT count(*) FROM users;" "2" "$DB"
 run_test "e2e_initial_posts" "SELECT count(*) FROM posts;" "2" "$DB"
 run_test "e2e_initial_branch" "SELECT active_branch();" "main" "$DB"
-run_test "e2e_initial_log" "SELECT count(*) FROM dolt_log;" "1" "$DB"
+run_test "e2e_initial_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 run_test "e2e_clean_status" "SELECT count(*) FROM dolt_status;" "0" "$DB"
 
 # Tag the initial release

--- a/test/doltlite_edge_cases.sh
+++ b/test/doltlite_edge_cases.sh
@@ -71,7 +71,7 @@ run_test "empty_string_val" "SELECT val FROM t WHERE id=1;" "" "$DB"
 run_test "max_int" "SELECT val FROM t WHERE id=9223372036854775807;" "maxint" "$DB"
 run_test "min_int" "SELECT val FROM t WHERE id=-9223372036854775808;" "minint" "$DB"
 run_test "boundary_count" "SELECT count(*) FROM t;" "4" "$DB"
-run_test "boundary_log" "SELECT count(*) FROM dolt_log;" "1" "$DB"
+run_test "boundary_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 
 # Persist and reopen
 run_test "boundary_persist_max" "SELECT val FROM t WHERE id=9223372036854775807;" "maxint" "$DB"
@@ -153,7 +153,7 @@ run_test "multi_c2" "SELECT z FROM c WHERE id=2;" "c2_main" "$DB"
 
 # Verify merge log
 run_test_match "multi_merge_log" "SELECT message FROM dolt_log LIMIT 1;" "Merge" "$DB"
-run_test "multi_merge_log_count" "SELECT count(*) FROM dolt_log;" "4" "$DB"
+run_test "multi_merge_log_count" "SELECT count(*) FROM dolt_log;" "5" "$DB"
 
 rm -f "$DB"
 
@@ -331,7 +331,7 @@ run_test_match "schema_diff_working" "SELECT count(*) FROM dolt_diff('t');" "^[1
 echo "SELECT dolt_commit('-A','-m','add email column');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "schema_new_col" "SELECT email FROM t WHERE id=1;" "alice@test.com" "$DB"
-run_test "schema_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
+run_test "schema_log" "SELECT count(*) FROM dolt_log;" "3" "$DB"
 
 # Insert with new column
 echo "INSERT INTO t VALUES(2,'Bob','bob@test.com');
@@ -404,7 +404,7 @@ run_test_match "diff_tags" \
   "^[2-9]" "$DB"
 
 # Verify log has 3 commits
-run_test "diff_log_count" "SELECT count(*) FROM dolt_log;" "3" "$DB"
+run_test "diff_log_count" "SELECT count(*) FROM dolt_log;" "4" "$DB"
 
 # Tag listing
 run_test "diff_tag_count" "SELECT count(*) FROM dolt_tags;" "2" "$DB"
@@ -580,7 +580,7 @@ echo "$SQL" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "bulk_count" "SELECT count(*) FROM big;" "500" "$DB"
 run_test "bulk_first" "SELECT v FROM big WHERE id=1;" "row_1" "$DB"
 run_test "bulk_last" "SELECT v FROM big WHERE id=500;" "row_500" "$DB"
-run_test "bulk_log" "SELECT count(*) FROM dolt_log;" "1" "$DB"
+run_test "bulk_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 
 # Persist and verify
 run_test "bulk_persist_count" "SELECT count(*) FROM big;" "500" "$DB"
@@ -690,7 +690,7 @@ run_test_match "difftype_new_working_type" "SELECT diff_type FROM dolt_diff('t')
 echo "SELECT dolt_reset('--hard');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 # Verify data integrity
-run_test "difftype_data_ok" "SELECT count(*) FROM dolt_log;" "2" "$DB"
+run_test "difftype_data_ok" "SELECT count(*) FROM dolt_log;" "3" "$DB"
 
 rm -f "$DB"
 
@@ -734,7 +734,7 @@ SELECT dolt_commit('-A','-m','round3');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 # Verify after multiple commits (each is a separate session/reopen)
 run_test "persist_count" "SELECT count(*) FROM t;" "3" "$DB"
-run_test "persist_log" "SELECT count(*) FROM dolt_log;" "3" "$DB"
+run_test "persist_log" "SELECT count(*) FROM dolt_log;" "4" "$DB"
 run_test "persist_branch" "SELECT active_branch();" "main" "$DB"
 
 # Create branch and commit on it
@@ -846,12 +846,12 @@ for i in $(seq 2 21); do
   echo "INSERT INTO t VALUES($i,'v$i'); SELECT dolt_commit('-A','-m','commit $i');" | $DOLTLITE "$DB" > /dev/null 2>&1
 done
 
-run_test "history_count" "SELECT count(*) FROM dolt_log;" "21" "$DB"
+run_test "history_count" "SELECT count(*) FROM dolt_log;" "22" "$DB"
 run_test "history_data" "SELECT count(*) FROM t;" "21" "$DB"
 run_test_match "history_first_msg" "SELECT message FROM dolt_log LIMIT 1;" "commit 21" "$DB"
 
 # Persist and verify
-run_test "history_persist" "SELECT count(*) FROM dolt_log;" "21" "$DB"
+run_test "history_persist" "SELECT count(*) FROM dolt_log;" "22" "$DB"
 
 rm -f "$DB"
 
@@ -927,7 +927,7 @@ INSERT INTO t VALUES(4,'d'); SELECT dolt_commit('-A','-m','c4');
 INSERT INTO t VALUES(5,'e'); SELECT dolt_commit('-A','-m','c5');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "rapid_data" "SELECT count(*) FROM t;" "5" "$DB"
-run_test "rapid_log" "SELECT count(*) FROM dolt_log;" "5" "$DB"
+run_test "rapid_log" "SELECT count(*) FROM dolt_log;" "6" "$DB"
 run_test "rapid_last_msg" "SELECT message FROM dolt_log LIMIT 1;" "c5" "$DB"
 run_test "rapid_persist" "SELECT count(*) FROM t;" "5" "$DB"
 

--- a/test/doltlite_feature_deep.sh
+++ b/test/doltlite_feature_deep.sh
@@ -156,7 +156,7 @@ SELECT dolt_commit('-A','-m','c3');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 echo "SELECT dolt_gc();" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-run_test "gc_log_count" "SELECT count(*) FROM dolt_log;" "3" "$DB"
+run_test "gc_log_count" "SELECT count(*) FROM dolt_log;" "4" "$DB"
 run_test "gc_log_first" "SELECT message FROM dolt_log LIMIT 1;" "c3" "$DB"
 run_test "gc_log_last" "SELECT message FROM dolt_log LIMIT 1 OFFSET 2;" "c1" "$DB"
 
@@ -564,7 +564,7 @@ echo "SELECT dolt_gc();" | $DOLTLITE "$DB" > /dev/null 2>&1
 SIZE_AFTER=$(db_size "$DB")
 
 run_test "gc_revert_data" "SELECT count(*) FROM t;" "1" "$DB"
-run_test "gc_revert_log" "SELECT count(*) FROM dolt_log;" "3" "$DB"
+run_test "gc_revert_log" "SELECT count(*) FROM dolt_log;" "4" "$DB"
 
 db_rm "$DB"
 

--- a/test/doltlite_gc.sh
+++ b/test/doltlite_gc.sh
@@ -29,7 +29,7 @@ echo "SELECT dolt_gc();" | $DOLTLITE "$DB" > /dev/null 2>&1
 # Second GC should find nothing to remove
 run_test_match "gc_clean" "SELECT dolt_gc();" "0 chunks removed" "$DB"
 run_test "gc_clean_data" "SELECT count(*) FROM t;" "1" "$DB"
-run_test "gc_clean_log" "SELECT count(*) FROM dolt_log;" "1" "$DB"
+run_test "gc_clean_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 
 # Single-file: no -wal after GC
 nFiles=$(ls "$DB"* 2>/dev/null | wc -l | tr -d ' ')
@@ -62,12 +62,12 @@ if [ "$SIZE_AFTER" -le "$SIZE_BEFORE" ]; then PASS=$((PASS+1)); else FAIL=$((FAI
 
 # Data intact after GC
 run_test "gc_multi_count" "SELECT count(*) FROM t;" "3" "$DB"
-run_test "gc_multi_log" "SELECT count(*) FROM dolt_log;" "3" "$DB"
+run_test "gc_multi_log" "SELECT count(*) FROM dolt_log;" "4" "$DB"
 run_test "gc_multi_val" "SELECT v FROM t WHERE id=3;" "c" "$DB"
 
 # Data intact after reopen
 run_test "gc_multi_reopen_count" "SELECT count(*) FROM t;" "3" "$DB"
-run_test "gc_multi_reopen_log" "SELECT count(*) FROM dolt_log;" "3" "$DB"
+run_test "gc_multi_reopen_log" "SELECT count(*) FROM dolt_log;" "4" "$DB"
 
 db_rm "$DB"
 
@@ -103,7 +103,7 @@ if [ "$SIZE_AFTER_GC" -lt "$SIZE_WITH_BRANCH" ]; then PASS=$((PASS+1)); else FAI
 # Main data intact
 run_test "gc_branch_data" "SELECT count(*) FROM t;" "1" "$DB"
 run_test "gc_branch_val" "SELECT v FROM t WHERE id=1;" "a" "$DB"
-run_test "gc_branch_log" "SELECT count(*) FROM dolt_log;" "1" "$DB"
+run_test "gc_branch_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 
 # feat data should be gone
 run_test "gc_branch_no_feat" "SELECT count(*) FROM t WHERE id=100;" "0" "$DB"
@@ -172,7 +172,7 @@ if [ "$SIZE_AFTER" -le "$SIZE_BEFORE" ]; then PASS=$((PASS+1)); else FAIL=$((FAI
 
 # Latest data intact
 run_test "gc_updates_val" "SELECT v FROM t WHERE id=1;" "v20" "$DB"
-run_test "gc_updates_log" "SELECT count(*) FROM dolt_log;" "21" "$DB"
+run_test "gc_updates_log" "SELECT count(*) FROM dolt_log;" "22" "$DB"
 
 # All 21 commits still navigable
 run_test_match "gc_updates_first_msg" \
@@ -268,7 +268,7 @@ run_test_match "gc_cprv_result" "SELECT dolt_gc();" "chunks" "$DB"
 
 # After revert, row 2 should be gone
 run_test "gc_cprv_count" "SELECT count(*) FROM t;" "1" "$DB"
-run_test "gc_cprv_log" "SELECT count(*) FROM dolt_log;" "3" "$DB"
+run_test "gc_cprv_log" "SELECT count(*) FROM dolt_log;" "4" "$DB"
 
 # Reopen
 run_test "gc_cprv_reopen" "SELECT count(*) FROM t;" "1" "$DB"

--- a/test/doltlite_merge.sh
+++ b/test/doltlite_merge.sh
@@ -20,7 +20,7 @@ run_test_match "merge_hash" "SELECT dolt_merge('feature');" "^[0-9a-f]{40}$" "$D
 run_test "merge_users" "SELECT name FROM users;" "ALICE" "$DB"
 run_test "merge_orders" "SELECT count(*) FROM orders;" "2" "$DB"
 run_test "merge_log" "SELECT message FROM dolt_log LIMIT 1;" "Merge branch 'feature'" "$DB"
-run_test "merge_log_count" "SELECT count(*) FROM dolt_log;" "4" "$DB"
+run_test "merge_log_count" "SELECT count(*) FROM dolt_log;" "5" "$DB"
 
 # Test 2: Fast-forward merge
 DB2=/tmp/test_merge2_$$.db; rm -f "$DB2"
@@ -33,7 +33,7 @@ run_test "ff_before" "SELECT count(*) FROM t;" "1" "$DB2"
 run_test_match "ff_merge" "SELECT dolt_merge('feature');" "^[0-9a-f]{40}$" "$DB2"
 run_test "ff_after" "SELECT count(*) FROM t;" "2" "$DB2"
 run_test "ff_no_merge_commit" "SELECT message FROM dolt_log LIMIT 1;" "feature" "$DB2"
-run_test "ff_log_count" "SELECT count(*) FROM dolt_log;" "2" "$DB2"
+run_test "ff_log_count" "SELECT count(*) FROM dolt_log;" "3" "$DB2"
 
 # Test 3: Already up to date
 run_test "up_to_date" "SELECT dolt_merge('feature');" "Already up to date" "$DB2"

--- a/test/doltlite_persistence.sh
+++ b/test/doltlite_persistence.sh
@@ -29,7 +29,7 @@ SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "basic_count" "SELECT count(*) FROM t;" "2" "$DB"
 run_test "basic_val1" "SELECT v FROM t WHERE id=1;" "hello" "$DB"
 run_test "basic_val2" "SELECT v FROM t WHERE id=2;" "world" "$DB"
-run_test "basic_log" "SELECT count(*) FROM dolt_log;" "1" "$DB"
+run_test "basic_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 run_test_match "basic_msg" "SELECT message FROM dolt_log;" "init" "$DB"
 
 # Single-file: doltlite creates exactly one file, no -wal or -journal
@@ -56,7 +56,7 @@ INSERT INTO t VALUES(3,'c');
 SELECT dolt_commit('-A','-m','c3');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "multi_count" "SELECT count(*) FROM t;" "3" "$DB"
-run_test "multi_log" "SELECT count(*) FROM dolt_log;" "3" "$DB"
+run_test "multi_log" "SELECT count(*) FROM dolt_log;" "4" "$DB"
 run_test_match "multi_latest" "SELECT message FROM dolt_log LIMIT 1;" "c3" "$DB"
 
 rm -f "$DB"
@@ -82,7 +82,7 @@ run_test "bulk100_count" "SELECT count(*) FROM t;" "100" "$DB"
 run_test "bulk100_first" "SELECT v FROM t WHERE id=0;" "row_0" "$DB"
 run_test "bulk100_last" "SELECT v FROM t WHERE id=99;" "row_99" "$DB"
 run_test "bulk100_mid" "SELECT v FROM t WHERE id=50;" "row_50" "$DB"
-run_test "bulk100_log" "SELECT count(*) FROM dolt_log;" "1" "$DB"
+run_test "bulk100_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 
 rm -f "$DB"
 
@@ -125,7 +125,7 @@ UPDATE t SET v='changed' WHERE id=1;
 SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "update_val" "SELECT v FROM t WHERE id=1;" "changed" "$DB"
-run_test "update_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
+run_test "update_log" "SELECT count(*) FROM dolt_log;" "3" "$DB"
 
 rm -f "$DB"
 
@@ -343,7 +343,7 @@ run_test "bulkmod_count" "SELECT count(*) FROM t;" "999" "$DB"
 run_test "bulkmod_modified" "SELECT v FROM t WHERE id=500;" "MODIFIED" "$DB"
 run_test "bulkmod_deleted" "SELECT count(*) FROM t WHERE id=999;" "0" "$DB"
 run_test "bulkmod_unchanged" "SELECT v FROM t WHERE id=1;" "row_1" "$DB"
-run_test "bulkmod_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
+run_test "bulkmod_log" "SELECT count(*) FROM dolt_log;" "3" "$DB"
 
 rm -f "$DB"
 
@@ -364,7 +364,7 @@ SELECT dolt_commit('-A','-m','commit $i');" | $DOLTLITE "$DB" > /dev/null 2>&1
 done
 
 run_test "rapid_count" "SELECT count(*) FROM t;" "10" "$DB"
-run_test "rapid_log" "SELECT count(*) FROM dolt_log;" "11" "$DB"
+run_test "rapid_log" "SELECT count(*) FROM dolt_log;" "12" "$DB"
 run_test "rapid_val5" "SELECT v FROM t WHERE id=5;" "val_5" "$DB"
 
 rm -f "$DB"

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -369,7 +369,7 @@ static void test_concurrent_refs_stale_reset_is_rejected(void){
   check("newer_commit_still_visible_in_log",
     strcmp(exec1(db3, sql), "1")==0);
   check("branch_history_has_both_commits",
-    strcmp(exec1(db3, "SELECT count(*) FROM dolt_log"), "2")==0);
+    strcmp(exec1(db3, "SELECT count(*) FROM dolt_log"), "3")==0);
 
   sqlite3_close(db3);
   remove_db(dbpath);

--- a/test/doltlite_reset.sh
+++ b/test/doltlite_reset.sh
@@ -115,13 +115,13 @@ echo "UPDATE t SET v='v2' WHERE x=1; SELECT dolt_commit('-A','-m','c2');" | $DOL
 echo "INSERT INTO t VALUES(2,'new'); SELECT dolt_commit('-A','-m','c3');" | $DOLTLITE "$DB5" > /dev/null 2>&1
 
 run_test "pre_reset_count" "SELECT count(*) FROM t;" "2" "$DB5"
-run_test "pre_reset_commits" "SELECT count(*) FROM dolt_log;" "3" "$DB5"
+run_test "pre_reset_commits" "SELECT count(*) FROM dolt_log;" "4" "$DB5"
 
 echo "SELECT dolt_reset('--hard','$C1');" | $DOLTLITE "$DB5" > /dev/null 2>&1
 
 run_test "reset_to_hash_data" "SELECT v FROM t;" "v1" "$DB5"
 run_test "reset_to_hash_count" "SELECT count(*) FROM t;" "1" "$DB5"
-run_test "reset_to_hash_log" "SELECT count(*) FROM dolt_log;" "1" "$DB5"
+run_test "reset_to_hash_log" "SELECT count(*) FROM dolt_log;" "2" "$DB5"
 run_test "reset_to_hash_head" "SELECT commit_hash FROM dolt_log LIMIT 1;" "$C1" "$DB5"
 run_test "reset_to_hash_clean" "SELECT count(*) FROM dolt_status;" "0" "$DB5"
 

--- a/test/doltlite_savepoint.sh
+++ b/test/doltlite_savepoint.sh
@@ -62,7 +62,7 @@ run_test "txn_rollback_data_count" \
 # Expected: 2 commits (init + in-txn commit) — dolt operations persist
 run_test "txn_rollback_dolt_commit_survives" \
   "SELECT count(*) FROM dolt_log;" \
-  "2" "$DB1"
+  "3" "$DB1"
 
 # ============================================================
 # Test 2: BEGIN; INSERT; SAVEPOINT x; INSERT more; dolt_commit; ROLLBACK TO x
@@ -93,7 +93,7 @@ run_test "savepoint_rollback_row3_gone" \
 # Dolt commit log should still show the commit made inside the savepoint
 run_test "savepoint_dolt_commit_in_log" \
   "SELECT count(*) FROM dolt_log;" \
-  "2" "$DB2"
+  "3" "$DB2"
 
 # ============================================================
 # Test 3: INSERT outside transaction; dolt_commit — basic sanity
@@ -110,7 +110,7 @@ run_test "basic_no_txn_data" \
   "hello" "$DB3"
 
 run_test "basic_no_txn_log" \
-  "SELECT message FROM dolt_log;" \
+  "SELECT message FROM dolt_log LIMIT 1;" \
   "basic" "$DB3"
 
 # ============================================================

--- a/test/doltlite_staging.sh
+++ b/test/doltlite_staging.sh
@@ -72,7 +72,7 @@ run_test "status_clean_after_staged_commit" \
 # --- Log has 2 commits ---
 run_test "log_two_commits" \
   "SELECT count(*) FROM dolt_log;" \
-  "2" "$DB"
+  "3" "$DB"
 
 # --- New table shows as 'new table' ---
 echo "CREATE TABLE orders(id INTEGER PRIMARY KEY, item TEXT); INSERT INTO orders VALUES(1,'hat');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -93,7 +93,7 @@ run_test_match "commit_orders" \
 
 run_test "log_three_commits" \
   "SELECT count(*) FROM dolt_log;" \
-  "3" "$DB"
+  "4" "$DB"
 
 # --- dolt_add -A stages everything ---
 DB2=/tmp/test_staging2_$$.db
@@ -134,7 +134,7 @@ run_test "clean_after_dash_a" \
 
 run_test "log_after_dash_a" \
   "SELECT count(*) FROM dolt_log;" \
-  "2" "$DB3"
+  "3" "$DB3"
 
 # --- Commit without staging fails ---
 DB4=/tmp/test_staging4_$$.db

--- a/test/doltlite_tag.sh
+++ b/test/doltlite_tag.sh
@@ -34,12 +34,7 @@ run_test_match "delete_missing" "SELECT dolt_tag('-d','nope');" "not found" "$DB
 # Tag persists across reopen
 run_test "tag_persists" "SELECT name FROM dolt_tags;" "v1.0" "$DB"
 
-# No commits = can't tag
-DB2=/tmp/test_tag2_$$.db; rm -f "$DB2"
-echo "CREATE TABLE t(x);" | $DOLTLITE "$DB2" > /dev/null 2>&1
-run_test_match "tag_no_commits" "SELECT dolt_tag('foo');" "no commits" "$DB2"
-
-rm -f "$DB" "$DB2"
+rm -f "$DB"
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
 if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi

--- a/test/remote_test.sh
+++ b/test/remote_test.sh
@@ -325,9 +325,9 @@ check "deep clone returns 0" "0" "$result"
 result=$("$DB" "$TMPDIR/deep_clone.db" "SELECT count(*) FROM log;")
 check "deep clone has 20 rows" "20" "$result"
 
-# Count commits in clone (21 = create + 20 inserts)
+# Count commits in clone (22 = seed + create + 20 inserts)
 result=$("$DB" "$TMPDIR/deep_clone.db" "SELECT count(*) FROM dolt_log;")
-check "deep clone has 21 commits" "21" "$result"
+check "deep clone has 22 commits" "22" "$result"
 
 # ============================================================
 echo "=== 20. Diverged branches: push both, clone gets all ==="
@@ -440,7 +440,7 @@ result=$("$DB" "$TMPDIR/merge_clone.db" "SELECT count(*) FROM doc;")
 check "merge clone has 3 docs" "3" "$result"
 
 result=$("$DB" "$TMPDIR/merge_clone.db" "SELECT count(*) FROM dolt_log;")
-check "merge clone has commit history" "4" "$result"
+check "merge clone has commit history" "5" "$result"
 
 # ============================================================
 echo "=== 23. Round-trip: A→remote→B→remote→A (3 hops) ==="

--- a/test/review_regression_test.sh
+++ b/test/review_regression_test.sh
@@ -36,14 +36,14 @@ INSERT INTO t VALUES(1,'durable');
 SELECT dolt_commit('-A','-m','persist test');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "durable_data" "SELECT v FROM t WHERE id=1;" "durable" "$DB"
-run_test "durable_log" "SELECT count(*) FROM dolt_log;" "1" "$DB"
+run_test "durable_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 
 # Second commit
 echo "INSERT INTO t VALUES(2,'also durable');
 SELECT dolt_commit('-A','-m','second persist');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "durable_second" "SELECT v FROM t WHERE id=2;" "also durable" "$DB"
-run_test "durable_log2" "SELECT count(*) FROM dolt_log;" "2" "$DB"
+run_test "durable_log2" "SELECT count(*) FROM dolt_log;" "3" "$DB"
 rm -f "$DB"
 
 # ============================================================
@@ -126,9 +126,9 @@ INSERT INTO t VALUES(3,'main2');
 SELECT dolt_commit('-A','-m','main work');
 SELECT dolt_merge('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Log must have 4 entries: merge + main work + feature work + init
+# Log must have 5 entries: merge + main work + feature work + init + seed
 run_test "merge_log_all_parents" \
-  "SELECT count(*) FROM dolt_log;" "4" "$DB"
+  "SELECT count(*) FROM dolt_log;" "5" "$DB"
 
 # Feature commit must be visible in the log
 run_test_match "merge_log_has_feature" \
@@ -290,7 +290,7 @@ SELECT dolt_commit('-A','-m','pre-gc 2');
 SELECT dolt_gc();" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "gc_data_intact" "SELECT count(*) FROM t;" "2" "$DB"
-run_test "gc_log_intact" "SELECT count(*) FROM dolt_log;" "2" "$DB"
+run_test "gc_log_intact" "SELECT count(*) FROM dolt_log;" "3" "$DB"
 run_test "gc_val_intact" "SELECT v FROM t WHERE id=1;" "before gc" "$DB"
 
 # Reopen after GC

--- a/test/vc_oracle_log_test.sh
+++ b/test/vc_oracle_log_test.sh
@@ -18,20 +18,18 @@ trap "rm -rf $TMPROOT" EXIT
 pass=0; fail=0
 FAILED_NAMES=""
 
-# Normalize a `commit_hash,message` CSV stream:
-#   - drop Dolt's seed "Initialize data repository" row
+# Normalize a `hash\tmessage` stream (tab-separated, one row per line):
 #   - replace each distinct hash with H1, H2, ... in first-appearance order
-#   - trim trailing whitespace
+#   - strip CRLF
 normalize() {
-  tr -d '\r' | awk -F, '
-    $2 == "Initialize data repository" { next }
+  tr -d '\r' | awk -F'\t' '
     {
       h = $1
       if (!(h in seen)) { n++; seen[h] = "H" n }
       $1 = seen[h]
-      print $1 "," $2
+      print $1 "\t" $2
     }
-  ' OFS=,
+  '
 }
 
 # Run an oracle scenario. $1=name, $2=setup SQL using doltlite syntax
@@ -42,11 +40,10 @@ oracle() {
   local dir="$TMPROOT/$name"
   mkdir -p "$dir/dl" "$dir/dt"
 
-  # doltlite side
+  # doltlite side: tab mode, single concatenated column avoids csv quoting.
   local dl_out
-  dl_out=$(printf "%s\n.headers off\n.mode csv\nSELECT commit_hash, message FROM dolt_log;\n" "$setup" \
+  dl_out=$(printf "%s\n.headers off\n.mode list\n.separator '\t'\nSELECT commit_hash || char(9) || message FROM dolt_log;\n" "$setup" \
            | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
-           | tail -n +1 \
            | grep -v '^[0-9]*$' \
            | grep -v '^[0-9a-f]\{40\}$' \
            | normalize)
@@ -59,11 +56,11 @@ oracle() {
     cd "$dir/dt" || exit 1
     "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
     echo "$dolt_setup" | "$DOLT" sql >/dev/null 2>"$dir/dt.err"
-    "$DOLT" sql -r csv -q "SELECT commit_hash, message FROM dolt_log ORDER BY commit_order DESC;" 2>>"$dir/dt.err"
+    "$DOLT" sql -r csv -q "SELECT concat(commit_hash, char(9), message) FROM dolt_log ORDER BY commit_order DESC;" 2>>"$dir/dt.err"
   ) > "$dir/dt.raw"
 
   local dt_out
-  dt_out=$(tail -n +2 "$dir/dt.raw" | normalize)
+  dt_out=$(tail -n +2 "$dir/dt.raw" | tr -d '"' | normalize)
 
   if [ "$dl_out" = "$dt_out" ]; then
     pass=$((pass+1))
@@ -78,6 +75,14 @@ oracle() {
 
 echo "=== Version Control Oracle Tests: dolt_log ==="
 echo ""
+
+# ─── Category 0: fresh repository state ──────────────────────────────
+echo "--- fresh repo ---"
+
+oracle "fresh_db_has_seed_commit" "
+-- no user commits; both sides should report a single seed commit
+SELECT 1;
+"
 
 # ─── Category 1: linear commit chains ────────────────────────────────
 echo "--- linear chains ---"


### PR DESCRIPTION
## Summary

- A freshly initialized doltlite database now has one commit on the default branch — an "Initialize data repository" commit with an empty catalog and no parent — matching Dolt's behavior. Previously, `SELECT count(*) FROM dolt_log` on a new database returned 0; it now returns 1.
- The seed is written lazily at the end of `doltliteRegister()` when the chunk store has no branches. Read-only opens skip it; `:memory:` databases get one per open, which is what we want.
- `dolt_clone` is taught to reset refs when the destination holds only a seed commit, so cloning into a fresh database keeps working without a manual wipe.
- `test/vc_oracle_log_test.sh` gains a new fresh-DB scenario and drops its "skip the init commit" normalization — both engines now emit the same seed row on initialization. The harness also switches from CSV parsing to tab-separated single-column output, which dodges differences in how doltlite's and Dolt's CSV modes quote fields.

## Why

The follow-up to #333 flagged this as the cleanest way to reconcile the philosophical split: Git leaves an uninitialized branch as a real first-class state, but Dolt can't, because `dolt_log` / `dolt_branches` / diff tables all need something concrete to return. Doltlite's SQL surface borrows from Dolt, so Dolt's choice is the one that lets the semantics line up.

## Test churn

Most test updates are mechanical: the suite was full of assertions like `count(*) FROM dolt_log == "N"` where N was hardcoded, and each one becomes N+1 with the seed in place (~70 assertions across 23 files). A handful of tests that asserted "no commits yet" as an error path — cherry-picking the initial commit, tagging before committing, branching before committing — were deleted or retargeted at the seed commit itself, which is still parentless and thus still a valid "can't replay this" case for cherry-pick and revert.

One test in `config_test.sh` was filtering `COUNT(DISTINCT committer)` for a single-author assertion; it now excludes the seed commit explicitly, since the seed is a system-generated row that predates any user config.

## Clone semantics

`doltCloneFunc` previously refused to clone into any non-empty database. That would now reject every fresh database, since every fresh database has a seed. The fix detects the "seed-only" state — exactly one branch whose head is a root commit (empty parent) — and calls the new `chunkStoreClearRefs` helper to wipe local state before importing the remote. Any database with real commits still gets the "not empty" error.

The seed commit chunk becomes unreferenced after a clone-over-seed and will be reclaimed by GC.

## Test plan

- [ ] `run_doltlite_tests.sh`: 42/42 suites pass locally, all counts updated
- [ ] `remote_test.sh`: 63/63 including the clone-over-seed path
- [ ] `vc_oracle_log_test.sh`: 7/7 including the new fresh-DB scenario
- [ ] `index_oracle_test.sh`: 526/526 (unaffected, sanity check)
- [ ] `large_scale_test.sh --quick`, `multi_table_test.sh --quick`, `diff_test.sh`, `config_test.sh`: all pass
- [ ] `concurrent_write_test`: 52/52
- [ ] Locally: `echo "SELECT count(*) FROM dolt_log" | ./doltlite :memory:` returns `1`
- [ ] Locally: `echo "SELECT message FROM dolt_log" | ./doltlite :memory:` returns `Initialize data repository`

## Known follow-ups

Divergent roots across machines are still a thing: two freshly initialized doltlite databases have different seed commit hashes (the seed uses `time(0)` and the session author), so pushing one into the other would still fail with unrelated-histories, same as before. Dolt has this problem too. Worth addressing separately if it becomes a friction point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)