### PR TITLE
Fix diff and conflict error handling

### DIFF
--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -232,6 +232,61 @@ struct ConflictTableInfo {
 
 static void freeConflictTables(ConflictTableInfo *aTables, int nTables);
 
+static void freeConflictRow(struct ConflictRow *pRow){
+  if( !pRow ) return;
+  sqlite3_free(pRow->pKey);
+  sqlite3_free(pRow->pBaseVal);
+  sqlite3_free(pRow->pOurVal);
+  sqlite3_free(pRow->pTheirVal);
+  memset(pRow, 0, sizeof(*pRow));
+}
+
+static int dupConflictBytes(const u8 *pIn, int nIn, u8 **ppOut){
+  u8 *pCopy;
+  *ppOut = 0;
+  if( !pIn || nIn<=0 ) return SQLITE_OK;
+  pCopy = sqlite3_malloc(nIn);
+  if( !pCopy ) return SQLITE_NOMEM;
+  memcpy(pCopy, pIn, nIn);
+  *ppOut = pCopy;
+  return SQLITE_OK;
+}
+
+static void removeConflictRow(ConflictTableInfo *pTable, int iRow){
+  if( !pTable || iRow<0 || iRow>=pTable->nConflicts ) return;
+  freeConflictRow(&pTable->aRows[iRow]);
+  if( iRow < pTable->nConflicts - 1 ){
+    memmove(&pTable->aRows[iRow], &pTable->aRows[iRow+1],
+            (pTable->nConflicts - iRow - 1) * sizeof(struct ConflictRow));
+  }
+  pTable->nConflicts--;
+  if( pTable->aRows ){
+    memset(&pTable->aRows[pTable->nConflicts], 0, sizeof(struct ConflictRow));
+  }
+}
+
+static void removeConflictTable(ConflictTableInfo *aTables, int *pnTables, int iTable){
+  int nTables;
+  if( !aTables || !pnTables ) return;
+  nTables = *pnTables;
+  if( iTable<0 || iTable>=nTables ) return;
+  sqlite3_free(aTables[iTable].zName);
+  {
+    int j;
+    for(j=0; j<aTables[iTable].nConflicts; j++){
+      freeConflictRow(&aTables[iTable].aRows[j]);
+    }
+  }
+  sqlite3_free(aTables[iTable].aRows);
+  memset(&aTables[iTable], 0, sizeof(aTables[iTable]));
+  if( iTable < nTables - 1 ){
+    memmove(&aTables[iTable], &aTables[iTable+1],
+            (nTables - iTable - 1) * sizeof(ConflictTableInfo));
+  }
+  (*pnTables)--;
+  memset(&aTables[*pnTables], 0, sizeof(aTables[*pnTables]));
+}
+
 int doltliteSerializeConflicts(
   ChunkStore *cs,
   ConflictTableInfo *aTables, int nTables,
@@ -383,9 +438,7 @@ static void freeConflictTables(ConflictTableInfo *aTables, int nTables){
   int i, j;
   for(i=0; i<nTables; i++){
     for(j=0; j<aTables[i].nConflicts; j++){
-      sqlite3_free(aTables[i].aRows[j].pBaseVal);
-      sqlite3_free(aTables[i].aRows[j].pOurVal);
-      sqlite3_free(aTables[i].aRows[j].pTheirVal);
+      freeConflictRow(&aTables[i].aRows[j]);
     }
     sqlite3_free(aTables[i].aRows);
     sqlite3_free(aTables[i].zName);
@@ -403,11 +456,13 @@ static int storeUpdatedConflicts(
   for(i=0; i<nTables; i++) totalConflicts += aTables[i].nConflicts;
 
   {
+    int rc;
     extern void doltliteSetSessionConflictsCatalog(sqlite3*, const ProllyHash*);
     extern void doltliteSetSessionMergeState(sqlite3*, u8, const ProllyHash*, const ProllyHash*);
     extern int doltliteSaveWorkingSet(sqlite3*);
     if( totalConflicts==0 ){
       doltliteSetSessionConflictsCatalog(db, &(ProllyHash){{0}});
+      doltliteSetSessionMergeState(db, 0, 0, 0);
     }else{
       ProllyHash newHash;
       int rc = doltliteSerializeConflicts(cs, aTables, nTables, &newHash);
@@ -415,8 +470,10 @@ static int storeUpdatedConflicts(
       doltliteSetSessionConflictsCatalog(db, &newHash);
       doltliteSetSessionMergeState(db, 1, 0, &newHash);
     }
-    doltliteSaveWorkingSet(db);
-    chunkStoreSerializeRefs(cs);
+    rc = doltliteSaveWorkingSet(db);
+    if( rc!=SQLITE_OK ) return rc;
+    rc = chunkStoreSerializeRefs(cs);
+    if( rc!=SQLITE_OK ) return rc;
     return chunkStoreCommit(cs);
   }
 }
@@ -657,28 +714,11 @@ static int cfrUpdate(
 
     for(j=0; j<aTables[i].nConflicts; j++){
       if( aTables[i].aRows[j].intKey == deleteRowid ){
-        
-        sqlite3_free(aTables[i].aRows[j].pBaseVal);
-        sqlite3_free(aTables[i].aRows[j].pTheirVal);
-
-        
-        if( j < aTables[i].nConflicts - 1 ){
-          memmove(&aTables[i].aRows[j], &aTables[i].aRows[j+1],
-                  (aTables[i].nConflicts - j - 1) * sizeof(struct ConflictRow));
-        }
-        aTables[i].nConflicts--;
+        removeConflictRow(&aTables[i], j);
 
         
         if( aTables[i].nConflicts == 0 ){
-          sqlite3_free(aTables[i].aRows);
-          aTables[i].aRows = 0;
-          sqlite3_free(aTables[i].zName);
-          
-          if( i < nTables - 1 ){
-            memmove(&aTables[i], &aTables[i+1],
-                    (nTables - i - 1) * sizeof(ConflictTableInfo));
-          }
-          nTables--;
+          removeConflictTable(aTables, &nTables, i);
         }
 
         
@@ -759,26 +799,16 @@ static void conflictsResolveFunc(sqlite3_context *ctx, int argc, sqlite3_value *
     
     for(i=0; i<nTables; i++){
       if( aTables[i].zName && strcmp(aTables[i].zName, zTable)==0 ){
-        
-        for(j=0; j<aTables[i].nConflicts; j++){
-          sqlite3_free(aTables[i].aRows[j].pBaseVal);
-          sqlite3_free(aTables[i].aRows[j].pTheirVal);
-        }
-        sqlite3_free(aTables[i].aRows);
-        aTables[i].aRows = 0;
-        aTables[i].nConflicts = 0;
-        sqlite3_free(aTables[i].zName);
-        
-        if( i < nTables - 1 ){
-          memmove(&aTables[i], &aTables[i+1],
-                  (nTables - i - 1) * sizeof(ConflictTableInfo));
-        }
-        nTables--;
+        removeConflictTable(aTables, &nTables, i);
         break;
       }
     }
-    storeUpdatedConflicts(db, cs, aTables, nTables);
+    rc = storeUpdatedConflicts(db, cs, aTables, nTables);
     freeConflictTables(aTables, nTables);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(ctx, rc);
+      return;
+    }
     sqlite3_result_int(ctx, 0);
 
   }else if( strcmp(zMode,"--theirs")==0 ){
@@ -802,28 +832,30 @@ static void conflictsResolveFunc(sqlite3_context *ctx, int argc, sqlite3_value *
           
           char *zSql = sqlite3_mprintf("DELETE FROM \"%w\" WHERE rowid=%lld",
                                         zTable, cr->intKey);
-          if(zSql){ sqlite3_exec(db, zSql, 0, 0, 0); sqlite3_free(zSql); }
+          if( !zSql ){
+            freeConflictTables(aTables, nTables);
+            sqlite3_result_error_code(ctx, SQLITE_NOMEM);
+            return;
+          }
+          rc = sqlite3_exec(db, zSql, 0, 0, 0);
+          sqlite3_free(zSql);
+          if( rc!=SQLITE_OK ){
+            freeConflictTables(aTables, nTables);
+            sqlite3_result_error(ctx, "failed to apply theirs value", -1);
+            return;
+          }
         }
       }
 
-      
-      for(j=0; j<aTables[i].nConflicts; j++){
-        sqlite3_free(aTables[i].aRows[j].pBaseVal);
-        sqlite3_free(aTables[i].aRows[j].pTheirVal);
-      }
-      sqlite3_free(aTables[i].aRows);
-      aTables[i].aRows = 0;
-      aTables[i].nConflicts = 0;
-      sqlite3_free(aTables[i].zName);
-      if( i < nTables - 1 ){
-        memmove(&aTables[i], &aTables[i+1],
-                (nTables - i - 1) * sizeof(ConflictTableInfo));
-      }
-      nTables--;
+      removeConflictTable(aTables, &nTables, i);
       break;
     }
-    storeUpdatedConflicts(db, cs, aTables, nTables);
+    rc = storeUpdatedConflicts(db, cs, aTables, nTables);
     freeConflictTables(aTables, nTables);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(ctx, rc);
+      return;
+    }
     sqlite3_result_int(ctx, 0);
 
   }else{

--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -462,7 +462,6 @@ static int storeUpdatedConflicts(
     extern int doltliteSaveWorkingSet(sqlite3*);
     if( totalConflicts==0 ){
       doltliteSetSessionConflictsCatalog(db, &(ProllyHash){{0}});
-      doltliteSetSessionMergeState(db, 0, 0, 0);
     }else{
       ProllyHash newHash;
       int rc = doltliteSerializeConflicts(cs, aTables, nTables, &newHash);

--- a/src/doltlite_diff.c
+++ b/src/doltlite_diff.c
@@ -48,6 +48,17 @@ static const char *diffSchema =
   "  to_commit   TEXT HIDDEN"
   ")";
 
+static int diffDupValue(const u8 *pIn, int nIn, u8 **ppOut){
+  u8 *pCopy;
+  *ppOut = 0;
+  if( !pIn || nIn<=0 ) return SQLITE_OK;
+  pCopy = sqlite3_malloc(nIn);
+  if( !pCopy ) return SQLITE_NOMEM;
+  memcpy(pCopy, pIn, nIn);
+  *ppOut = pCopy;
+  return SQLITE_OK;
+}
+
 static int detectPkField(sqlite3 *db, const char *zTable){
   char *zSql;
   sqlite3_stmt *pStmt = 0;
@@ -136,6 +147,7 @@ static int diffCollect(void *pCtx, const ProllyDiffChange *pChange){
   DoltliteDiffCursor *pCur = (DoltliteDiffCursor*)pCtx;
   DiffRow *aNew;
   DiffRow *r;
+  int rc;
 
   aNew = sqlite3_realloc(pCur->aRows, (pCur->nRows+1)*(int)sizeof(DiffRow));
   if( !aNew ) return SQLITE_NOMEM;
@@ -147,13 +159,18 @@ static int diffCollect(void *pCtx, const ProllyDiffChange *pChange){
   r->intKey = pChange->intKey;
 
   if( pChange->pOldVal && pChange->nOldVal>0 ){
-    r->pOldVal = sqlite3_malloc(pChange->nOldVal);
-    if( r->pOldVal ) memcpy(r->pOldVal, pChange->pOldVal, pChange->nOldVal);
+    rc = diffDupValue(pChange->pOldVal, pChange->nOldVal, &r->pOldVal);
+    if( rc!=SQLITE_OK ) return rc;
     r->nOldVal = pChange->nOldVal;
   }
   if( pChange->pNewVal && pChange->nNewVal>0 ){
-    r->pNewVal = sqlite3_malloc(pChange->nNewVal);
-    if( r->pNewVal ) memcpy(r->pNewVal, pChange->pNewVal, pChange->nNewVal);
+    rc = diffDupValue(pChange->pNewVal, pChange->nNewVal, &r->pNewVal);
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(r->pOldVal);
+      r->pOldVal = 0;
+      r->nOldVal = 0;
+      return rc;
+    }
     r->nNewVal = pChange->nNewVal;
   }
 
@@ -173,19 +190,15 @@ static void freeDiffRows(DoltliteDiffCursor *pCur){
 }
 
 static int resolveCommitToTableRoot(
-  sqlite3 *db, const char *zRef, Pgno iTable,
+  sqlite3 *db, const ProllyHash *pCommitHash, Pgno iTable,
   ProllyHash *pRoot, u8 *pFlags
 ){
-  ProllyHash commitHash;
   DoltliteCommit commit;
   struct TableEntry *aTables = 0;
   int nTables = 0;
   int rc;
 
-  rc = doltliteResolveRef(db, zRef, &commitHash);
-  if( rc!=SQLITE_OK ) return rc;
-
-  rc = doltliteLoadCommit(db, &commitHash, &commit);
+  rc = doltliteLoadCommit(db, pCommitHash, &commit);
   if( rc!=SQLITE_OK ) return rc;
 
   rc = doltliteLoadCatalog(db, &commit.catalogHash, &aTables, &nTables, 0);
@@ -288,15 +301,25 @@ static int diffFilter(sqlite3_vtab_cursor *pCursor,
   const char *zTableName = 0;
   const char *zFromCommit = 0;
   const char *zToCommit = 0;
-  ProllyHash oldRoot, newRoot;
+  ProllyHash oldRoot, newRoot, headCatHash, workingCatHash;
   u8 flags = 0;
   Pgno iTable;
-  int rc;
+  int rc = SQLITE_OK;
   int argIdx = 0;
+  struct TableEntry *aHead = 0;
+  struct TableEntry *aWork = 0;
+  int nHead = 0;
+  int nWork = 0;
+  u8 *catData = 0;
+  int nCatData = 0;
   (void)idxStr;
 
   freeDiffRows(pCur);
   pCur->iRow = 0;
+  memset(&oldRoot, 0, sizeof(oldRoot));
+  memset(&newRoot, 0, sizeof(newRoot));
+  memset(&headCatHash, 0, sizeof(headCatHash));
+  memset(&workingCatHash, 0, sizeof(workingCatHash));
 
   if( !cs || !pBt ) return SQLITE_OK;
 
@@ -322,49 +345,51 @@ static int diffFilter(sqlite3_vtab_cursor *pCursor,
 
   
   if( zFromCommit ){
-    rc = resolveCommitToTableRoot(db, zFromCommit, iTable, &oldRoot, &flags);
+    ProllyHash fromCommitHash;
+    rc = doltliteResolveRef(db, zFromCommit, &fromCommitHash);
+    if( rc==SQLITE_OK ){
+      rc = resolveCommitToTableRoot(db, &fromCommitHash, iTable, &oldRoot, &flags);
+      if( rc==SQLITE_NOTFOUND ) rc = SQLITE_OK;
+    }
   }else{
-    
-    ProllyHash headCatHash;
-    struct TableEntry *aHead = 0;
-    int nHead = 0;
     rc = doltliteGetHeadCatalogHash(db, &headCatHash);
     if( rc==SQLITE_OK ){
       rc = doltliteLoadCatalog(db, &headCatHash, &aHead, &nHead, 0);
       if( rc==SQLITE_OK ){
-        doltliteFindTableRoot(aHead, nHead, iTable, &oldRoot, &flags);
-        sqlite3_free(aHead);
+        rc = doltliteFindTableRoot(aHead, nHead, iTable, &oldRoot, &flags);
+        if( rc==SQLITE_NOTFOUND ) rc = SQLITE_OK;
       }
     }
   }
+  if( rc!=SQLITE_OK ) goto diff_filter_done;
 
   
   if( zToCommit ){
+    ProllyHash toCommitHash;
     u8 f2;
-    rc = resolveCommitToTableRoot(db, zToCommit, iTable, &newRoot, &f2);
+    rc = doltliteResolveRef(db, zToCommit, &toCommitHash);
+    if( rc==SQLITE_OK ){
+      rc = resolveCommitToTableRoot(db, &toCommitHash, iTable, &newRoot, &f2);
+      if( rc==SQLITE_NOTFOUND ) rc = SQLITE_OK;
+    }
     if( flags==0 ) flags = f2;
   }else{
-    
-    u8 *catData = 0; int nCatData = 0;
-    ProllyHash workingCatHash;
-    struct TableEntry *aWork = 0;
-    int nWork = 0;
     rc = doltliteFlushAndSerializeCatalog(db, &catData, &nCatData);
     if( rc==SQLITE_OK ){
       rc = chunkStorePut(cs, catData, nCatData, &workingCatHash);
-      sqlite3_free(catData);
       if( rc==SQLITE_OK ){
         rc = doltliteLoadCatalog(db, &workingCatHash, &aWork, &nWork, 0);
         if( rc==SQLITE_OK ){
-          doltliteFindTableRoot(aWork, nWork, iTable, &newRoot, &flags);
-          sqlite3_free(aWork);
+          rc = doltliteFindTableRoot(aWork, nWork, iTable, &newRoot, &flags);
+          if( rc==SQLITE_NOTFOUND ) rc = SQLITE_OK;
         }
       }
     }
   }
+  if( rc!=SQLITE_OK ) goto diff_filter_done;
 
   
-  if( prollyHashCompare(&oldRoot, &newRoot)==0 ) return SQLITE_OK;
+  if( prollyHashCompare(&oldRoot, &newRoot)==0 ) goto diff_filter_done;
 
   
   {
@@ -374,7 +399,11 @@ static int diffFilter(sqlite3_vtab_cursor *pCursor,
                     diffCollect, (void*)pCur);
   }
 
-  return SQLITE_OK;
+diff_filter_done:
+  sqlite3_free(aHead);
+  sqlite3_free(aWork);
+  sqlite3_free(catData);
+  return rc;
 }
 
 static int diffNext(sqlite3_vtab_cursor *pCursor){

--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -108,6 +108,17 @@ static int fieldEquals(const u8 *pRecA, RecField *fA,
 typedef struct MergeWinner MergeWinner;
 struct MergeWinner { const u8 *pRec; RecField *pField; };
 
+static int mergeDupBytes(const u8 *pIn, int nIn, u8 **ppOut){
+  u8 *pCopy;
+  *ppOut = 0;
+  if( !pIn || nIn<=0 ) return SQLITE_OK;
+  pCopy = sqlite3_malloc(nIn);
+  if( !pCopy ) return SQLITE_NOMEM;
+  memcpy(pCopy, pIn, nIn);
+  *ppOut = pCopy;
+  return SQLITE_OK;
+}
+
 static u8 *buildMergedRecord(MergeWinner *aWinners, int nFields, int *pnOut){
   int hdrSize = 0, bodySize = 0, pos, i;
   u8 *result;
@@ -354,23 +365,38 @@ static int rowMergeCallback(void *pCtx, const ThreeWayChange *pChange){
         memset(cr, 0, sizeof(*cr));
         cr->intKey = pChange->intKey;
         if( pChange->pKey && pChange->nKey>0 ){
-          cr->pKey = sqlite3_malloc(pChange->nKey);
-          if(cr->pKey) memcpy(cr->pKey, pChange->pKey, pChange->nKey);
+          rc = mergeDupBytes(pChange->pKey, pChange->nKey, &cr->pKey);
+          if( rc!=SQLITE_OK ) return rc;
           cr->nKey = pChange->nKey;
         }
         if( pChange->pBaseVal && pChange->nBaseVal>0 ){
-          cr->pBaseVal = sqlite3_malloc(pChange->nBaseVal);
-          if(cr->pBaseVal) memcpy(cr->pBaseVal, pChange->pBaseVal, pChange->nBaseVal);
+          rc = mergeDupBytes(pChange->pBaseVal, pChange->nBaseVal, &cr->pBaseVal);
+          if( rc!=SQLITE_OK ){
+            sqlite3_free(cr->pKey);
+            memset(cr, 0, sizeof(*cr));
+            return rc;
+          }
           cr->nBaseVal = pChange->nBaseVal;
         }
         if( pChange->pOurVal && pChange->nOurVal>0 ){
-          cr->pOurVal = sqlite3_malloc(pChange->nOurVal);
-          if(cr->pOurVal) memcpy(cr->pOurVal, pChange->pOurVal, pChange->nOurVal);
+          rc = mergeDupBytes(pChange->pOurVal, pChange->nOurVal, &cr->pOurVal);
+          if( rc!=SQLITE_OK ){
+            sqlite3_free(cr->pKey);
+            sqlite3_free(cr->pBaseVal);
+            memset(cr, 0, sizeof(*cr));
+            return rc;
+          }
           cr->nOurVal = pChange->nOurVal;
         }
         if( pChange->pTheirVal && pChange->nTheirVal>0 ){
-          cr->pTheirVal = sqlite3_malloc(pChange->nTheirVal);
-          if(cr->pTheirVal) memcpy(cr->pTheirVal, pChange->pTheirVal, pChange->nTheirVal);
+          rc = mergeDupBytes(pChange->pTheirVal, pChange->nTheirVal, &cr->pTheirVal);
+          if( rc!=SQLITE_OK ){
+            sqlite3_free(cr->pKey);
+            sqlite3_free(cr->pBaseVal);
+            sqlite3_free(cr->pOurVal);
+            memset(cr, 0, sizeof(*cr));
+            return rc;
+          }
           cr->nTheirVal = pChange->nTheirVal;
         }
         ctx->nConflicts++;

--- a/test/doltlite_conflicts.sh
+++ b/test/doltlite_conflicts.sh
@@ -117,7 +117,28 @@ run_test_match "multi_row_has_row1" "SELECT their_value FROM dolt_conflicts_t WH
 run_test_match "multi_row_has_row2" "SELECT their_value FROM dolt_conflicts_t WHERE base_rowid=2;" "B" "$DB8"
 run_test_match "multi_row_has_row3" "SELECT their_value FROM dolt_conflicts_t WHERE base_rowid=3;" "C" "$DB8"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8"
+# Test 9: --theirs delete failure should keep conflict state
+DB9=/tmp/test_conflicts9_$$.db; rm -f "$DB9"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'orig');
+SELECT dolt_commit('-A','-m','init');
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+DELETE FROM t WHERE id=1;
+SELECT dolt_commit('-A','-m','feat delete');
+SELECT dolt_checkout('main');
+UPDATE t SET v='main' WHERE id=1;
+SELECT dolt_commit('-A','-m','main update');
+SELECT dolt_merge('feature');" | $DOLTLITE "$DB9" > /dev/null 2>&1
+run_test "theirs_delete_conflict_present" "SELECT count(*) FROM dolt_conflicts;" "1" "$DB9"
+echo "CREATE TRIGGER block_delete BEFORE DELETE ON t BEGIN SELECT RAISE(FAIL,'blocked delete'); END;" | $DOLTLITE "$DB9" > /dev/null 2>&1
+run_test_match "theirs_delete_failure_errors" \
+  "SELECT dolt_conflicts_resolve('--theirs','t');" \
+  "failed to apply theirs value" "$DB9"
+run_test "theirs_delete_failure_conflict_kept" "SELECT count(*) FROM dolt_conflicts;" "1" "$DB9"
+run_test "theirs_delete_failure_row_kept" "SELECT v FROM t WHERE id=1;" "main" "$DB9"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9"
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
 if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi

--- a/test/doltlite_diff.sh
+++ b/test/doltlite_diff.sh
@@ -75,6 +75,11 @@ run_test "diff_no_such_table" \
   "SELECT count(*) FROM dolt_diff('nonexistent');" \
   "0" "$DB"
 
+# Bad ref should surface an error, not an empty diff
+run_test_match "diff_bad_ref_errors" \
+  "SELECT count(*) FROM dolt_diff('t', 'definitely_not_a_ref', (SELECT commit_hash FROM dolt_log LIMIT 1));" \
+  "Error" "$DB"
+
 # Diff with only adds (new table after commit)
 DB2=/tmp/test_diff2_$$.db; rm -f "$DB2"
 echo "CREATE TABLE t(x); SELECT dolt_commit('-A','-m','empty');" | $DOLTLITE "$DB2" > /dev/null 2>&1


### PR DESCRIPTION
## Summary
- make `dolt_diff()` surface bad refs and internal diff failures instead of silently normalizing them to empty output
- make conflict resolution persist failures and failed `--theirs` deletes return errors instead of clearing conflict state anyway
- harden merge conflict capture so OOM does not serialize partial conflict payloads

## Testing
- cd build && bash ../test/doltlite_diff.sh
- cd build && bash ../test/doltlite_conflicts.sh
- cd build && bash ../test/doltlite_merge.sh