### PR TITLE
Add dolt_status oracle and fix four divergences from Dolt

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,6 +67,10 @@ jobs:
       run: cd build && bash ../test/vc_oracle_log_test.sh ./doltlite dolt
       timeout-minutes: 5
 
+    - name: Version control oracle tests (dolt_status)
+      run: cd build && bash ../test/vc_oracle_status_test.sh ./doltlite dolt
+      timeout-minutes: 5
+
     - name: Large-scale test (10K rows)
       run: cd build && bash ../test/large_scale_test.sh ./doltlite --quick
       timeout-minutes: 5

--- a/src/doltlite_status.c
+++ b/src/doltlite_status.c
@@ -26,13 +26,28 @@ struct DoltliteStatusCursor {
 static const char *statusSchema =
   "CREATE TABLE x(table_name TEXT, staged INTEGER, status TEXT)";
 
-#define findInCatalog(a,n,t) doltliteFindTableByNumber(a,n,t)
-
 static char *statusTableName(sqlite3 *db, const struct TableEntry *pEntry){
   if( pEntry->zName ){
     return sqlite3_mprintf("%s", pEntry->zName);
   }
   return doltliteResolveTableNumber(db, pEntry->iTable);
+}
+
+/*
+** Find a catalog entry by name, falling back to iTable when the entry has
+** no resolved name (rare for user tables but possible during bootstrap).
+** Matching by name is required for correct status reporting when sqlite
+** reuses a dropped table's iTable for a freshly created one — in that case
+** an iTable-only match would falsely classify the new table as a
+** modification of the old one and silently swallow the deletion.
+*/
+static struct TableEntry *findCatalogEntry(
+  struct TableEntry *a, int n, const struct TableEntry *pNeedle
+){
+  if( pNeedle->zName ){
+    return doltliteFindTableByName(a, n, pNeedle->zName);
+  }
+  return doltliteFindTableByNumber(a, n, pNeedle->iTable);
 }
 
 static int addRow(DoltliteStatusCursor *pCur, const char *zName,
@@ -49,18 +64,60 @@ static int addRow(DoltliteStatusCursor *pCur, const char *zName,
   return SQLITE_OK;
 }
 
+/*
+** A rename in doltlite preserves the underlying btree iTable: ALTER TABLE
+** RENAME TO is purely a sqlite_master update. So an entry that shares iTable
+** and root hash with a counterpart in the other catalog but carries a
+** different name is unambiguously a rename, not a drop+create that happens
+** to reuse the iTable (which always changes the root hash to empty).
+*/
+static int isRenamePair(const struct TableEntry *pA, const struct TableEntry *pB){
+  if( pA->iTable != pB->iTable ) return 0;
+  if( !pA->zName || !pB->zName ) return 0;
+  if( strcmp(pA->zName, pB->zName)==0 ) return 0;
+  return prollyHashCompare(&pA->root, &pB->root)==0;
+}
+
 static int compareCatalogs(
   DoltliteStatusCursor *pCur, sqlite3 *db,
   struct TableEntry *aFrom, int nFrom,
   struct TableEntry *aTo, int nTo,
   int staged
 ){
-  int i, rc;
+  int i, j, rc;
+  /* Two-bit bitmaps marking entries already accounted for as the source or
+  ** destination of a rename. Cap at a sane size; if a catalog ever exceeds
+  ** this, fall through to the regular delete+new representation. */
+  #define DOLT_STATUS_RENAME_CAP 4096
+  unsigned char fromHandled[DOLT_STATUS_RENAME_CAP] = {0};
+  unsigned char toHandled[DOLT_STATUS_RENAME_CAP] = {0};
+  int useRename = (nFrom <= DOLT_STATUS_RENAME_CAP && nTo <= DOLT_STATUS_RENAME_CAP);
+
+  if( useRename ){
+    for(i=0; i<nFrom; i++){
+      if( aFrom[i].iTable<=1 || fromHandled[i] ) continue;
+      for(j=0; j<nTo; j++){
+        if( aTo[j].iTable<=1 || toHandled[j] ) continue;
+        if( isRenamePair(&aFrom[i], &aTo[j]) ){
+          char *zCompound = sqlite3_mprintf("%s -> %s", aFrom[i].zName, aTo[j].zName);
+          if( !zCompound ) return SQLITE_NOMEM;
+          rc = addRow(pCur, zCompound, staged, "renamed");
+          sqlite3_free(zCompound);
+          if( rc!=SQLITE_OK ) return rc;
+          fromHandled[i] = 1;
+          toHandled[j] = 1;
+          break;
+        }
+      }
+    }
+  }
+
   for(i=0; i<nTo; i++){
     struct TableEntry *pFrom;
     char *zName;
     if(aTo[i].iTable<=1) continue;
-    pFrom = findInCatalog(aFrom, nFrom, aTo[i].iTable);
+    if( useRename && toHandled[i] ) continue;
+    pFrom = findCatalogEntry(aFrom, nFrom, &aTo[i]);
     zName = statusTableName(db, &aTo[i]);
     if(!zName) continue;
     if(!pFrom){
@@ -83,7 +140,8 @@ static int compareCatalogs(
   for(i=0; i<nFrom; i++){
     char *zName;
     if(aFrom[i].iTable<=1) continue;
-    if(!findInCatalog(aTo, nTo, aFrom[i].iTable)){
+    if( useRename && fromHandled[i] ) continue;
+    if(!findCatalogEntry(aTo, nTo, &aFrom[i])){
       zName = statusTableName(db, &aFrom[i]);
       if(!zName) continue;
       rc = addRow(pCur, zName, staged, "deleted");
@@ -92,6 +150,7 @@ static int compareCatalogs(
     }
   }
   return SQLITE_OK;
+  #undef DOLT_STATUS_RENAME_CAP
 }
 
 static int statusConnect(sqlite3 *db, void *pAux, int argc,
@@ -167,7 +226,11 @@ static int statusFilter(sqlite3_vtab_cursor *pCursor,
     if( rc!=SQLITE_OK ) goto status_done;
   }
 
-  if(aStaged&&aHead){
+  /* Compare HEAD vs staged. aHead may legitimately be NULL when the head
+  ** commit's catalog is empty (e.g. fresh repo with only the seed commit
+  ** and a staged "new table"); compareCatalogs handles a NULL "from" by
+  ** treating every "to" entry as new. */
+  if(aStaged){
     rc = compareCatalogs(pCur,db,aHead,nHead,aStaged,nStaged,1);
     if( rc!=SQLITE_OK ) goto status_done;
   }

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -809,11 +809,18 @@ int doltliteSerializeCatalogEntries(
   struct TableEntry *aSorted;  /* name-sorted copy for deterministic output */
   int i;
 
-  /* Resolve table names eagerly so serialization is deterministic. */
+  /* Refresh table names from sqlite_master so serialization is deterministic
+  ** and reflects the current schema. A simple "resolve only when null" check
+  ** would leave zName stale after ALTER TABLE ... RENAME, which would in turn
+  ** make dolt_status invisible to the rename. */
   if( db ){
     for(i=0; i<nTables; i++){
-      if( !aTables[i].zName && aTables[i].iTable>1 ){
-        aTables[i].zName = doltliteResolveTableNumber(db, aTables[i].iTable);
+      if( aTables[i].iTable>1 ){
+        char *zCur = doltliteResolveTableNumber(db, aTables[i].iTable);
+        if( zCur ){
+          sqlite3_free(aTables[i].zName);
+          aTables[i].zName = zCur;
+        }
       }
     }
   }

--- a/test/vc_oracle_status_test.sh
+++ b/test/vc_oracle_status_test.sh
@@ -1,0 +1,175 @@
+#!/bin/bash
+#
+# Version-control oracle test: dolt_status
+#
+# Runs identical working-set scenarios against doltlite and Dolt, then
+# compares the normalized `dolt_status` output. Catches divergence in how
+# each engine classifies new/modified/deleted/renamed tables, staged vs
+# unstaged, and mixed states.
+#
+# Usage: bash vc_oracle_status_test.sh [path/to/doltlite] [path/to/dolt]
+#
+
+set -u
+
+DOLTLITE="${1:-./doltlite}"
+DOLT="${2:-dolt}"
+TMPROOT=$(mktemp -d)
+trap "rm -rf $TMPROOT" EXIT
+pass=0; fail=0
+FAILED_NAMES=""
+
+# Strip CRLF only; status rows are already in sort order.
+normalize() {
+  tr -d '\r'
+}
+
+# Run a scenario. $1=name, $2=setup SQL in doltlite syntax.
+# The harness rewrites `SELECT dolt_*(...)` -> `CALL dolt_*(...)` for Dolt.
+oracle() {
+  local name="$1" setup="$2"
+  local dir="$TMPROOT/$name"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  # doltlite side: single tab-separated column, no csv quoting.
+  local dl_out
+  dl_out=$(printf "%s\n.headers off\n.mode list\n.separator '\t'\nSELECT table_name || char(9) || staged || char(9) || status FROM dolt_status ORDER BY table_name, staged, status;\n" "$setup" \
+           | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
+           | grep -v '^[0-9]*$' \
+           | grep -v '^[0-9a-f]\{40\}$' \
+           | normalize)
+
+  local dolt_setup
+  dolt_setup=$(echo "$setup" | sed -E 's/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g')
+
+  (
+    cd "$dir/dt" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    echo "$dolt_setup" | "$DOLT" sql >/dev/null 2>"$dir/dt.err"
+    "$DOLT" sql -r csv -q "SELECT concat(table_name, char(9), staged, char(9), status) FROM dolt_status ORDER BY table_name, staged, status;" 2>>"$dir/dt.err"
+  ) > "$dir/dt.raw"
+
+  local dt_out
+  dt_out=$(tail -n +2 "$dir/dt.raw" | tr -d '"' | normalize)
+
+  if [ "$dl_out" = "$dt_out" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite:"; echo "$dl_out" | sed 's/^/      /'
+    echo "    dolt:"    ; echo "$dt_out" | sed 's/^/      /'
+  fi
+}
+
+echo "=== Version Control Oracle Tests: dolt_status ==="
+echo ""
+
+echo "--- empty / baseline ---"
+
+oracle "empty_fresh_db" "
+-- no DDL, no commits; both sides should report empty status
+SELECT 1;
+"
+
+echo "--- new tables ---"
+
+oracle "new_table_unstaged" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+"
+
+oracle "new_table_staged" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('t');
+"
+
+oracle "two_new_tables_one_staged" "
+CREATE TABLE a(id INTEGER PRIMARY KEY);
+CREATE TABLE b(id INTEGER PRIMARY KEY);
+INSERT INTO a VALUES (1);
+INSERT INTO b VALUES (1);
+SELECT dolt_add('a');
+"
+
+echo "--- modifications ---"
+
+oracle "modified_unstaged" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('t');
+SELECT dolt_commit('-m', 'seed');
+INSERT INTO t VALUES (2, 20);
+"
+
+oracle "modified_staged" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('t');
+SELECT dolt_commit('-m', 'seed');
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_add('t');
+"
+
+oracle "modified_mixed_staged_and_unstaged" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('t');
+SELECT dolt_commit('-m', 'seed');
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_add('t');
+INSERT INTO t VALUES (3, 30);
+"
+
+echo "--- deletions ---"
+
+oracle "deleted_unstaged" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1);
+SELECT dolt_add('t');
+SELECT dolt_commit('-m', 'seed');
+DROP TABLE t;
+"
+
+oracle "deleted_staged" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1);
+SELECT dolt_add('t');
+SELECT dolt_commit('-m', 'seed');
+DROP TABLE t;
+SELECT dolt_add('-A');
+"
+
+echo "--- renames ---"
+
+oracle "renamed_unstaged" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1);
+SELECT dolt_add('t');
+SELECT dolt_commit('-m', 'seed');
+ALTER TABLE t RENAME TO t2;
+"
+
+echo "--- multi-table ---"
+
+oracle "multi_table_mixed_states" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, v INT);
+CREATE TABLE b(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO a VALUES (1, 10);
+INSERT INTO b VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'seed');
+INSERT INTO a VALUES (2, 20);
+DROP TABLE b;
+CREATE TABLE c(id INTEGER PRIMARY KEY);
+INSERT INTO c VALUES (1);
+"
+
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+if [ $fail -gt 0 ]; then
+  echo "Failed:$FAILED_NAMES"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- New `test/vc_oracle_status_test.sh`: eleven scenarios comparing doltlite's `dolt_status` to Dolt's. Wired into CI as a hard gate alongside the existing `dolt_log` oracle.
- Four real bugs in doltlite's status reporting fixed along the way. Each was caught by the oracle, not by hand-written expectations.
- Stacked on top of #336 (seed commit).

## The four bugs

### 1. Staged new tables disappeared

`compareCatalogs` was guarded by `if (aStaged && aHead)`, which skipped the staged comparison entirely whenever the head catalog was empty. That's the common case after the seed commit lands, or for any repo whose first table was never committed. Relaxed to `if (aStaged)`; the inner loop already handles a NULL "from" by treating every "to" entry as new.

### 2 + 3. Drops and creates collided on iTable reuse

`compareCatalogs` used `doltliteFindTableByNumber` to match entries across catalogs, but sqlite reuses a dropped table's iTable for a freshly created one. So in a scenario like "modify a, drop b, create c":

- The new `c` looked up its iTable (b's old number) in the committed catalog, found `b`, and reported `c` as "modified" instead of "new table" — and emitted a spurious "schema modified" row on top.
- The deleted `b` looked up its iTable in the new catalog, found `c`, decided `b` was "still present", and never emitted a "deleted" row at all.

Fixed by switching to name-based matching via a new `findCatalogEntry` helper that prefers `doltliteFindTableByName` and falls back to iTable only when an entry has no resolved name.

### 4. Renames were invisible

Two interacting causes:

- **Stale names in the catalog.** `doltliteSerializeCatalogEntries` had a "resolve names only when null" shortcut. After `ALTER TABLE t RENAME TO t2`, the in-memory `TableEntry` still carried `zName="t"`, so the serialized working catalog never reflected the rename. Fixed by always re-resolving from `sqlite_master` during serialization.
- **No compound representation.** Even with names corrected, the natural diff produces "deleted t" + "new table t2", while Dolt emits a single "t -> t2, renamed" row. Added a rename-pair detector in `compareCatalogs`: any pair sharing the same iTable, the same root hash, and different names is unambiguously a rename (drop+create reuse changes the root). The detector marks both entries as handled before the regular diff loops, then emits the compound row using a `from -> to` format identical to Dolt's.

## Test plan

- [ ] `vc_oracle_status_test.sh`: 11/11 pass locally against Dolt v1.86.0 / 1.83.5
- [ ] `vc_oracle_log_test.sh`: 7/7 still pass (unrelated, sanity check)
- [ ] `index_oracle_test.sh`: 526/526 still pass
- [ ] `run_doltlite_tests.sh`: 39/39 suites pass — the catalog name refresh runs on every serialize, so this is the load-bearing regression check
- [ ] `remote_test.sh`: 63/63
- [ ] `large_scale_test.sh --quick`, `multi_table_test.sh --quick`, `diff_test.sh`, `config_test.sh`: all pass
- [ ] `concurrent_write_test`: 52/52
- [ ] CI runs the new step on a Dolt-installed Ubuntu runner

## Notes

The catalog name refresh in `doltliteSerializeCatalogEntries` is the biggest blast-radius change here — it runs on every catalog serialize, which is hot. The work it adds is one `doltliteResolveTableNumber` call per table, which queries `sqlite_master`. If that becomes a perf concern, the right fix is to invalidate `zName` from the ALTER TABLE RENAME path rather than always re-resolving, but the current shape is correct and the regression suite is happy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)