### PR TITLE
Fix branch, tag, and ancestor correctness issues

### DIFF
--- a/src/doltlite_ancestor.c
+++ b/src/doltlite_ancestor.c
@@ -131,7 +131,7 @@ static int ancestorBfsCollect(
     if( rc!=SQLITE_OK ) break;
     memset(&commit, 0, sizeof(commit));
     rc = loadCommitByHash(db, &current, &commit);
-    if( rc!=SQLITE_OK ){ rc = SQLITE_OK; continue; } 
+    if( rc!=SQLITE_OK ) break;
     for(i=0; i<commit.nParents; i++){
       if( qTail >= qAlloc ){
         ProllyHash *q2;
@@ -200,7 +200,13 @@ int doltliteFindAncestor(
       current = queue[qHead++];
       if( prollyHashIsEmpty(&current) ) continue;
       if( hashSetContains(&visited, &current) ) continue;
-      hashSetInsert(&visited, &current);
+      rc = hashSetInsert(&visited, &current);
+      if( rc!=SQLITE_OK ){
+        hashSetFree(&visited);
+        sqlite3_free(queue);
+        hashSetFree(&ancestors);
+        return rc;
+      }
       if( hashSetContains(&ancestors, &current) ){
         *pAncestor = current;
         hashSetFree(&visited);
@@ -210,7 +216,12 @@ int doltliteFindAncestor(
       }
       memset(&commit, 0, sizeof(commit));
       rc = loadCommitByHash(db, &current, &commit);
-      if( rc!=SQLITE_OK ){ rc = SQLITE_OK; continue; }
+      if( rc!=SQLITE_OK ){
+        hashSetFree(&visited);
+        sqlite3_free(queue);
+        hashSetFree(&ancestors);
+        return rc;
+      }
       for(i=0; i<commit.nParents; i++){
         if( qTail >= qAlloc ){
           ProllyHash *q2;

--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -23,6 +23,21 @@ struct BranchMutationCtx {
   int isDelete;
 };
 
+static void branchResultError(
+  sqlite3_context *ctx,
+  int rc,
+  const char *zNotFound,
+  const char *zExists
+){
+  if( rc==SQLITE_NOTFOUND ){
+    sqlite3_result_error(ctx, zNotFound, -1);
+  }else if( rc==SQLITE_ERROR && zExists ){
+    sqlite3_result_error(ctx, zExists, -1);
+  }else{
+    sqlite3_result_error(ctx, sqlite3_errstr(rc), -1);
+  }
+}
+
 static int mutateBranchRef(sqlite3 *db, ChunkStore *cs, void *pArg){
   BranchMutationCtx *p = (BranchMutationCtx*)pArg;
   int rc;
@@ -65,7 +80,10 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
     m.zName = zName;
     m.isDelete = 1;
     rc = doltliteMutateRefs(db, mutateBranchRef, &m);
-    if( rc!=SQLITE_OK ){ sqlite3_result_error(ctx, "branch not found", -1); return; }
+    if( rc!=SQLITE_OK ){
+      branchResultError(ctx, rc, "branch not found", 0);
+      return;
+    }
   }else{
     doltliteGetSessionHead(db, &m.head);
     if( prollyHashIsEmpty(&m.head) ){
@@ -74,7 +92,10 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
     }
     m.zName = arg0;
     rc = doltliteMutateRefs(db, mutateBranchRef, &m);
-    if( rc!=SQLITE_OK ){ sqlite3_result_error(ctx, "branch already exists", -1); return; }
+    if( rc!=SQLITE_OK ){
+      branchResultError(ctx, rc, "branch not found", "branch already exists");
+      return;
+    }
   }
 
   sqlite3_result_int(ctx, 0);
@@ -129,12 +150,29 @@ typedef struct CheckoutMutationCtx CheckoutMutationCtx;
 struct CheckoutMutationCtx {
   const char *zTargetBranch;
   const char *zCurrentBranch;
+  ProllyHash savedSessionHead;
+  ProllyHash savedSessionStaged;
+  ProllyHash savedMergeCommit;
+  ProllyHash savedConflictsCatalog;
   ProllyHash oldCatHash;
   ProllyHash oldCommitHash;
   ProllyHash targetCommit;
   ProllyHash targetCatHash;
+  u8 savedIsMerging;
   int haveOldState;
 };
+
+static void checkoutRestoreSession(sqlite3 *db, CheckoutMutationCtx *p){
+  doltliteSetSessionBranch(db, p->zCurrentBranch);
+  doltliteSetSessionHead(db, &p->savedSessionHead);
+  doltliteSetSessionStaged(db, &p->savedSessionStaged);
+  doltliteSetSessionMergeState(db, p->savedIsMerging,
+                               &p->savedMergeCommit,
+                               &p->savedConflictsCatalog);
+  if( p->haveOldState ){
+    doltliteSwitchCatalog(db, &p->oldCatHash);
+  }
+}
 
 static int checkoutMutateRefs(sqlite3 *db, ChunkStore *cs, void *pArg){
   CheckoutMutationCtx *p = (CheckoutMutationCtx*)pArg;
@@ -171,11 +209,18 @@ static int checkoutMutateRefs(sqlite3 *db, ChunkStore *cs, void *pArg){
   if( p->haveOldState ){
     rc = doltliteUpdateBranchWorkingState(db, p->zCurrentBranch,
                                           &p->oldCatHash, &p->oldCommitHash);
-    if( rc!=SQLITE_OK ) return rc;
+    if( rc!=SQLITE_OK ){
+      checkoutRestoreSession(db, p);
+      return rc;
+    }
   }
 
-  return doltliteUpdateBranchWorkingState(db, p->zTargetBranch,
-                                          &p->targetCatHash, &p->targetCommit);
+  rc = doltliteUpdateBranchWorkingState(db, p->zTargetBranch,
+                                        &p->targetCatHash, &p->targetCommit);
+  if( rc!=SQLITE_OK ){
+    checkoutRestoreSession(db, p);
+  }
+  return rc;
 }
 
 static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
@@ -254,10 +299,18 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
     }
     m.haveOldState = 1;
   }
+  doltliteGetSessionHead(db, &m.savedSessionHead);
+  doltliteGetSessionStaged(db, &m.savedSessionStaged);
+  doltliteGetSessionMergeState(db, &m.savedIsMerging,
+                               &m.savedMergeCommit,
+                               &m.savedConflictsCatalog);
 
   m.zTargetBranch = zBranch;
   m.zCurrentBranch = zCurrentBranch;
   rc = doltliteMutateRefs(db, checkoutMutateRefs, &m);
+  if( rc!=SQLITE_OK ){
+    checkoutRestoreSession(db, &m);
+  }
   sqlite3_free(zCurrentBranch);
   if( rc==SQLITE_NOTFOUND ){
     sqlite3_result_error(ctx, "branch not found", -1);

--- a/src/doltlite_remote.c
+++ b/src/doltlite_remote.c
@@ -234,15 +234,21 @@ static int fsCommit(DoltliteRemote *pRemote){
     ProllyHash branchCommit;
     if( zDef && chunkStoreFindBranch(&p->store, zDef, &branchCommit)==SQLITE_OK ){
       u8 *cdata = 0; int ncdata = 0;
-      if( chunkStoreGet(&p->store, &branchCommit, &cdata, &ncdata)==SQLITE_OK && cdata ){
+      rc = chunkStoreGet(&p->store, &branchCommit, &cdata, &ncdata);
+      if( rc!=SQLITE_OK ) return rc;
+      if( cdata ){
         DoltliteCommit commit;
-        if( doltliteCommitDeserialize(cdata, ncdata, &commit)==SQLITE_OK ){
-          chunkStoreWriteBranchWorkingCatalog(&p->store, zDef, &commit.catalogHash, NULL);
+        rc = doltliteCommitDeserialize(cdata, ncdata, &commit);
+        if( rc==SQLITE_OK ){
+          rc = chunkStoreWriteBranchWorkingCatalog(&p->store, zDef,
+                                                   &commit.catalogHash, NULL);
           doltliteCommitClear(&commit);
         }
         sqlite3_free(cdata);
+        if( rc!=SQLITE_OK ) return rc;
       }
-      chunkStoreCommit(&p->store);  
+      rc = chunkStoreCommit(&p->store);
+      if( rc!=SQLITE_OK ) return rc;
     }
   }
 

--- a/src/doltlite_tag.c
+++ b/src/doltlite_tag.c
@@ -15,6 +15,21 @@ struct TagMutationCtx {
   int isDelete;
 };
 
+static void tagResultError(
+  sqlite3_context *ctx,
+  int rc,
+  const char *zNotFound,
+  const char *zExists
+){
+  if( rc==SQLITE_NOTFOUND ){
+    sqlite3_result_error(ctx, zNotFound, -1);
+  }else if( rc==SQLITE_ERROR && zExists ){
+    sqlite3_result_error(ctx, zExists, -1);
+  }else{
+    sqlite3_result_error(ctx, sqlite3_errstr(rc), -1);
+  }
+}
+
 static int mutateTagRef(sqlite3 *db, ChunkStore *cs, void *pArg){
   TagMutationCtx *p = (TagMutationCtx*)pArg;
   (void)db;
@@ -46,13 +61,13 @@ static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     m.isDelete = 1;
     rc = doltliteMutateRefs(db, mutateTagRef, &m);
     if( rc!=SQLITE_OK ){
-      sqlite3_result_error(ctx, "tag not found", -1);
+      tagResultError(ctx, rc, "tag not found", 0);
       return;
     }
   }else{
     
     if( argc>=2 ){
-      
+      DoltliteCommit commit;
       const char *zHash = (const char*)sqlite3_value_text(argv[1]);
       if( !zHash ){ sqlite3_result_error(ctx, "invalid commit hash", -1); return; }
       rc = doltliteHexToHash(zHash, &m.commitHash);
@@ -60,6 +75,13 @@ static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
         sqlite3_result_error(ctx, "invalid commit hash format", -1);
         return;
       }
+      memset(&commit, 0, sizeof(commit));
+      rc = doltliteLoadCommit(db, &m.commitHash, &commit);
+      if( rc!=SQLITE_OK ){
+        sqlite3_result_error(ctx, "commit not found", -1);
+        return;
+      }
+      doltliteCommitClear(&commit);
     }else{
       
       doltliteGetSessionHead(db, &m.commitHash);
@@ -71,7 +93,7 @@ static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     m.zName = arg0;
     rc = doltliteMutateRefs(db, mutateTagRef, &m);
     if( rc!=SQLITE_OK ){
-      sqlite3_result_error(ctx, "tag already exists", -1);
+      tagResultError(ctx, rc, "tag not found", "tag already exists");
       return;
     }
   }

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -15,6 +15,7 @@
 **   ./doltlite_regression_test_c status_error_propagation
 **   ./doltlite_regression_test_c remote_refs_corruption
 **   ./doltlite_regression_test_c chunk_walk_corruption
+**   ./doltlite_regression_test_c ancestor_missing_start
 */
 #include <stdio.h>
 #include <stdlib.h>
@@ -24,6 +25,7 @@
 #include "prolly_hash.h"
 #include "chunk_store.h"
 #include "doltlite_chunk_walk.h"
+#include "doltlite_ancestor.h"
 #include "doltlite_internal.h"
 
 typedef unsigned char u8;
@@ -446,8 +448,8 @@ static void run_checkout_persist_failure(void){
   res = exec1(db1, "SELECT dolt_checkout('feature')");
   check("persist_failure_was_injected", gFailHits>0);
   check("checkout_returns_error_on_persist_failure", strstr(res, "ERROR:")!=0);
-  check("session_branch_already_switched_before_error",
-    strcmp(exec1(db1, "SELECT active_branch()"), "feature")==0);
+  check("session_branch_restored_after_error",
+    strcmp(exec1(db1, "SELECT active_branch()"), "main")==0);
 
   sqlite3_close(db1);
   remove_db(dbpath);
@@ -722,6 +724,33 @@ static void run_chunk_walk_corruption(void){
   check("truncated_catalog_is_corrupt", rc==SQLITE_CORRUPT);
 }
 
+static void run_ancestor_missing_start(void){
+  sqlite3 *db = 0;
+  char dbpath[256];
+  ProllyHash badHash;
+  ProllyHash headHash;
+  ProllyHash ancestor;
+  int rc;
+
+  printf("=== Ancestor Missing Start Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_ancestor_missing_start");
+  remove_db(dbpath);
+
+  check("open_db", open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_repo", execsql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'a');"
+    "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
+
+  doltliteGetSessionHead(db, &headHash);
+  memset(&badHash, 0x5a, sizeof(badHash));
+  rc = doltliteFindAncestor(db, &badHash, &headHash, &ancestor);
+  check("missing_start_commit_returns_notfound", rc==SQLITE_NOTFOUND);
+
+  sqlite3_close(db);
+  remove_db(dbpath);
+}
+
 static const RegressionCase aCases[] = {
   { "concurrent_refs", "Concurrent Refs Test", run_concurrent_refs },
   { "checkout_persist_failure", "Checkout Persist Failure Test", run_checkout_persist_failure },
@@ -731,7 +760,8 @@ static const RegressionCase aCases[] = {
   { "conflicts_blob_corruption", "Conflicts Blob Corruption Test", run_conflicts_blob_corruption },
   { "status_error_propagation", "Status Error Propagation Test", run_status_error_propagation },
   { "remote_refs_corruption", "Remote Refs Corruption Test", run_remote_refs_corruption },
-  { "chunk_walk_corruption", "Chunk Walk Corruption Test", run_chunk_walk_corruption }
+  { "chunk_walk_corruption", "Chunk Walk Corruption Test", run_chunk_walk_corruption },
+  { "ancestor_missing_start", "Ancestor Missing Start Test", run_ancestor_missing_start }
 };
 
 static int run_case_by_name(const char *zName){

--- a/test/doltlite_tag.sh
+++ b/test/doltlite_tag.sh
@@ -24,6 +24,11 @@ run_test "two_tags" "SELECT count(*) FROM dolt_tags;" "2" "$DB"
 # Duplicate tag error
 run_test_match "dup_tag" "SELECT dolt_tag('v1.0');" "already exists" "$DB"
 
+# Explicit tag target must resolve to a real commit
+run_test_match "tag_missing_commit" \
+  "SELECT dolt_tag('badtag','0123456789abcdef0123456789abcdef01234567');" \
+  "commit not found" "$DB"
+
 # Delete tag
 run_test "delete_tag" "SELECT dolt_tag('-d','v0.9');" "0" "$DB"
 run_test "one_tag_left" "SELECT count(*) FROM dolt_tags;" "1" "$DB"


### PR DESCRIPTION
## Summary
- make checkout restore prior session state if later persistence fails
- validate explicit tag hashes as real commits and propagate ancestor traversal failures
- stop swallowing fs remote post-commit errors and avoid misleading branch/tag mutation errors

## Testing
- cd build && bash ../test/doltlite_branch.sh
- cd build && bash ../test/doltlite_tag.sh
- cd build && bash ../test/doltlite_regression_test_c.sh
- cd build && bash ../test/doltlite_feature_deep.sh
- cd build && bash ../test/remote_test.sh ./doltlite