### PR TITLE
Add dolt_add oracle and fix three divergences from Dolt

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,10 @@ jobs:
       run: cd build && bash ../test/vc_oracle_status_test.sh ./doltlite dolt
       timeout-minutes: 5
 
+    - name: Version control oracle tests (dolt_add)
+      run: cd build && bash ../test/vc_oracle_add_test.sh ./doltlite dolt
+      timeout-minutes: 5
+
     - name: Large-scale test (10K rows)
       run: cd build && bash ../test/large_scale_test.sh ./doltlite --quick
       timeout-minutes: 5

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -282,11 +282,26 @@ static void doltliteAddFunc(
   }
 
   
+  /* Recognized "stage everything" flags. Match Dolt: -A, --all, and the
+  ** pathspec "." count; lowercase -a is rejected (Dolt errors with
+  ** "unknown option `a`"). Any other dash-prefixed arg is an unknown flag
+  ** and is rejected for the same reason. */
   for(i=0; i<argc; i++){
     const char *arg = (const char*)sqlite3_value_text(argv[i]);
-    if( arg && (strcmp(arg, "-A")==0 || strcmp(arg, "-a")==0 || strcmp(arg, ".")==0) ){
+    if( !arg ) continue;
+    if( strcmp(arg, "-A")==0
+     || strcmp(arg, "--all")==0
+     || strcmp(arg, ".")==0 ){
       stageAll = 1;
-      break;
+    }else if( arg[0]=='-' ){
+      char *zErr = sqlite3_mprintf("unknown option `%s`", arg);
+      if( zErr ){
+        sqlite3_result_error(context, zErr, -1);
+        sqlite3_free(zErr);
+      }else{
+        sqlite3_result_error_nomem(context);
+      }
+      return;
     }
   }
 
@@ -336,15 +351,20 @@ static void doltliteAddFunc(
         return;
       }
 
-      
+
       for(i=0; i<argc; i++){
         const char *zTable = (const char*)sqlite3_value_text(argv[i]);
         Pgno iTable = 0;
         int j;
 
-        if( !zTable || zTable[0]=='-' ) continue;
+        if( !zTable || zTable[0]=='-' || strcmp(zTable, ".")==0 ) continue;
         rc = doltliteResolveTableName(db, zTable, &iTable);
         if( rc!=SQLITE_OK ){
+          /* Table no longer exists in working. If it's still in the staged
+          ** catalog, the user is staging the deletion — drop the entry and
+          ** carry on. If it's nowhere, this is a bogus table name and we
+          ** error like Dolt does. */
+          int found = 0;
           for(j=0; j<nStaged; j++){
             if( aStaged[j].zName && strcmp(aStaged[j].zName, zTable)==0 ){
               if( j+1 < nStaged ){
@@ -352,8 +372,22 @@ static void doltliteAddFunc(
                         (nStaged-j-1) * (int)sizeof(struct TableEntry));
               }
               nStaged--;
+              found = 1;
               break;
             }
+          }
+          if( !found ){
+            char *zErr = sqlite3_mprintf(
+                "table not found: %s", zTable);
+            sqlite3_free(aWorking);
+            sqlite3_free(aStaged);
+            if( zErr ){
+              sqlite3_result_error(context, zErr, -1);
+              sqlite3_free(zErr);
+            }else{
+              sqlite3_result_error_nomem(context);
+            }
+            return;
           }
           continue;
         }

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -826,11 +826,18 @@ int doltliteSerializeCatalogEntries(
   }
 
   /* Create a shallow copy sorted by name. The in-memory aTables array
-  ** stays sorted by iTable (binary search by page number depends on it). */
-  aSorted = sqlite3_malloc(nTables * (int)sizeof(struct TableEntry));
-  if( !aSorted ) return SQLITE_NOMEM;
-  memcpy(aSorted, aTables, nTables * (int)sizeof(struct TableEntry));
-  qsort(aSorted, nTables, sizeof(struct TableEntry), tableEntryNameCmp);
+  ** stays sorted by iTable (binary search by page number depends on it).
+  ** Empty catalogs are legal (e.g. dolt_add('-A') with no working tables);
+  ** sqlite3_malloc(0) returns NULL, which would otherwise be misread as
+  ** SQLITE_NOMEM. */
+  if( nTables > 0 ){
+    aSorted = sqlite3_malloc(nTables * (int)sizeof(struct TableEntry));
+    if( !aSorted ) return SQLITE_NOMEM;
+    memcpy(aSorted, aTables, nTables * (int)sizeof(struct TableEntry));
+    qsort(aSorted, nTables, sizeof(struct TableEntry), tableEntryNameCmp);
+  }else{
+    aSorted = 0;
+  }
 
   for(i=0; i<nTables; i++){
     int nLen = aSorted[i].zName ? (int)strlen(aSorted[i].zName) : 0;

--- a/test/doltlite_staging.sh
+++ b/test/doltlite_staging.sh
@@ -224,17 +224,6 @@ run_test "add_dot_stages_all" \
   "SELECT count(*) FROM dolt_status WHERE staged=1;" \
   "1" "$DB7"
 
-# --- dolt_add('-a') lowercase flag ---
-DB8=/tmp/test_staging_8_$$.db
-rm -f "$DB8"
-echo "CREATE TABLE t(x); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB8" > /dev/null 2>&1
-echo "INSERT INTO t VALUES(2);" | $DOLTLITE "$DB8" > /dev/null 2>&1
-
-echo "SELECT dolt_add('-a');" | $DOLTLITE "$DB8" > /dev/null 2>&1
-run_test "add_lowercase_a_stages_all" \
-  "SELECT count(*) FROM dolt_status WHERE staged=1;" \
-  "1" "$DB8"
-
 # --- dolt_status ignores internal index roots in clean state ---
 DB9=/tmp/test_staging_9_$$.db
 rm -f "$DB9"

--- a/test/vc_oracle_add_test.sh
+++ b/test/vc_oracle_add_test.sh
@@ -1,0 +1,242 @@
+#!/bin/bash
+#
+# Version-control oracle test: dolt_add
+#
+# Runs identical dolt_add scenarios against doltlite and Dolt and compares
+# the resulting dolt_status (since dolt_add's whole purpose is to mutate
+# the staged catalog, and dolt_status is what makes that mutation visible).
+#
+# Error scenarios are checked separately: both engines must fail, but the
+# specific error text is allowed to differ.
+#
+# Usage: bash vc_oracle_add_test.sh [path/to/doltlite] [path/to/dolt]
+#
+
+set -u
+
+DOLTLITE="${1:-./doltlite}"
+DOLT="${2:-dolt}"
+TMPROOT=$(mktemp -d)
+trap "rm -rf $TMPROOT" EXIT
+pass=0; fail=0
+FAILED_NAMES=""
+
+normalize() { tr -d '\r'; }
+
+# Compare post-state status. $1=name, $2=setup SQL using doltlite syntax.
+oracle() {
+  local name="$1" setup="$2"
+  local dir="$TMPROOT/$name"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_out
+  dl_out=$(printf "%s\n.headers off\n.mode list\n.separator '\t'\nSELECT table_name || char(9) || staged || char(9) || status FROM dolt_status ORDER BY table_name, staged, status;\n" "$setup" \
+           | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
+           | grep -v '^[0-9]*$' \
+           | grep -v '^[0-9a-f]\{40\}$' \
+           | normalize)
+
+  local dolt_setup
+  dolt_setup=$(echo "$setup" | sed -E 's/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g')
+
+  (
+    cd "$dir/dt" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    echo "$dolt_setup" | "$DOLT" sql >/dev/null 2>"$dir/dt.err"
+    "$DOLT" sql -r csv -q "SELECT concat(table_name, char(9), staged, char(9), status) FROM dolt_status ORDER BY table_name, staged, status;" 2>>"$dir/dt.err"
+  ) > "$dir/dt.raw"
+
+  local dt_out
+  dt_out=$(tail -n +2 "$dir/dt.raw" | tr -d '"' | normalize)
+
+  if [ "$dl_out" = "$dt_out" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite:"; echo "$dl_out" | sed 's/^/      /'
+    echo "    dolt:"    ; echo "$dt_out" | sed 's/^/      /'
+  fi
+}
+
+# Both engines must fail on this setup. Error text is allowed to differ.
+oracle_error() {
+  local name="$1" setup="$2"
+  local dir="$TMPROOT/${name}_err"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_rc=0
+  echo "$setup" | "$DOLTLITE" "$dir/dl/db" >"$dir/dl.out" 2>"$dir/dl.err"
+  if grep -qiE 'error|fail' "$dir/dl.out" "$dir/dl.err" 2>/dev/null; then
+    dl_rc=0  # error reported
+  else
+    dl_rc=1  # no error
+  fi
+
+  local dolt_setup
+  dolt_setup=$(echo "$setup" | sed -E 's/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g')
+  local dt_rc=0
+  (
+    cd "$dir/dt" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    echo "$dolt_setup" | "$DOLT" sql >"$dir/dt.out" 2>"$dir/dt.err"
+  )
+  if grep -qiE 'error|fail' "$dir/dt.out" "$dir/dt.err" 2>/dev/null; then
+    dt_rc=0
+  else
+    dt_rc=1
+  fi
+
+  if [ "$dl_rc" = 0 ] && [ "$dt_rc" = 0 ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name (expected both to error)"
+    echo "    doltlite errored: $([ $dl_rc = 0 ] && echo yes || echo NO)"
+    echo "    dolt errored:     $([ $dt_rc = 0 ] && echo yes || echo NO)"
+  fi
+}
+
+echo "=== Version Control Oracle Tests: dolt_add ==="
+echo ""
+
+echo "--- argument shapes ---"
+
+oracle "single_table_by_name" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('t');
+"
+
+oracle "two_tables_by_name" "
+CREATE TABLE a(id INTEGER PRIMARY KEY);
+CREATE TABLE b(id INTEGER PRIMARY KEY);
+INSERT INTO a VALUES (1);
+INSERT INTO b VALUES (1);
+SELECT dolt_add('a', 'b');
+"
+
+oracle "all_dash_capital_A" "
+CREATE TABLE a(id INTEGER PRIMARY KEY);
+CREATE TABLE b(id INTEGER PRIMARY KEY);
+INSERT INTO a VALUES (1);
+INSERT INTO b VALUES (1);
+SELECT dolt_add('-A');
+"
+
+oracle "all_dash_lowercase_a" "
+CREATE TABLE a(id INTEGER PRIMARY KEY);
+CREATE TABLE b(id INTEGER PRIMARY KEY);
+INSERT INTO a VALUES (1);
+INSERT INTO b VALUES (1);
+SELECT dolt_add('-a');
+"
+
+oracle "all_long_flag" "
+CREATE TABLE a(id INTEGER PRIMARY KEY);
+CREATE TABLE b(id INTEGER PRIMARY KEY);
+INSERT INTO a VALUES (1);
+INSERT INTO b VALUES (1);
+SELECT dolt_add('--all');
+"
+
+oracle "dot_pathspec" "
+CREATE TABLE a(id INTEGER PRIMARY KEY);
+CREATE TABLE b(id INTEGER PRIMARY KEY);
+INSERT INTO a VALUES (1);
+INSERT INTO b VALUES (1);
+SELECT dolt_add('.');
+"
+
+echo "--- idempotency and additivity ---"
+
+oracle "idempotent_repeat" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1);
+SELECT dolt_add('t');
+SELECT dolt_add('t');
+"
+
+oracle "additive_separate_calls" "
+CREATE TABLE a(id INTEGER PRIMARY KEY);
+CREATE TABLE b(id INTEGER PRIMARY KEY);
+INSERT INTO a VALUES (1);
+INSERT INTO b VALUES (1);
+SELECT dolt_add('a');
+SELECT dolt_add('b');
+"
+
+oracle "stage_subset_leaves_others_unstaged" "
+CREATE TABLE a(id INTEGER PRIMARY KEY);
+CREATE TABLE b(id INTEGER PRIMARY KEY);
+INSERT INTO a VALUES (1);
+INSERT INTO b VALUES (1);
+SELECT dolt_add('a');
+"
+
+echo "--- working tree advances past staged ---"
+
+oracle "stage_then_modify_more" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('t');
+SELECT dolt_commit('-m', 'seed');
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_add('t');
+INSERT INTO t VALUES (3, 30);
+"
+
+echo "--- staging deletions ---"
+
+oracle "stage_dropped_table" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'seed');
+DROP TABLE t;
+SELECT dolt_add('t');
+"
+
+oracle "stage_dropped_table_via_all" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'seed');
+DROP TABLE t;
+SELECT dolt_add('-A');
+"
+
+echo "--- noop and clean states ---"
+
+oracle "all_on_empty_repo" "
+SELECT dolt_add('-A');
+"
+
+oracle "all_after_commit_no_changes" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'seed');
+SELECT dolt_add('-A');
+"
+
+echo "--- error paths ---"
+
+oracle_error "no_args" "
+SELECT dolt_add();
+"
+
+oracle_error "nonexistent_table" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1);
+SELECT dolt_add('nonexistent');
+"
+
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+if [ $fail -gt 0 ]; then
+  echo "Failed:$FAILED_NAMES"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- New `test/vc_oracle_add_test.sh`: sixteen scenarios comparing doltlite's `dolt_add` to Dolt's. Wired into CI as a hard gate alongside the log and status oracles.
- Three real bugs in doltlite's `dolt_add` fixed along the way. All caught by the oracle on the first run.
- Stacked on top of #338 (status oracle).

## The three bugs

### 1. `sqlite3_malloc(0)` mistaken for OOM

`doltliteSerializeCatalogEntries` did `sqlite3_malloc(nTables * sizeof)` and interpreted a NULL return as `SQLITE_NOMEM`. With `nTables == 0`, malloc returns NULL not because the system is out of memory but because the request was zero bytes. Two visible symptoms shared this cause: `dolt_add('--all')` (which fell through to a path producing an empty staged catalog) and `dolt_add('nonexistent')` (same path), both surfaced as a misleading "out of memory" error from the shell.

Fixed by skipping the malloc when `nTables == 0`. Empty catalogs are a legal state — `dolt_add('-A')` on a clean repo produces one — and shouldn't have been routed through the error path at all.

### 2. `--all` long form unrecognized; `-a` accepted permissively

The flag list only had `-A`, `-a`, and `.`. Dolt accepts `-A`, `--all`, and `.`, and rejects lowercase `-a` with "unknown option `a`". So doltlite was failing on the long form Dolt accepts, *and* was silently accepting the lowercase form Dolt rejects — divergent in both directions.

Fixed by adding `--all`, removing `-a`, and adding a catch-all for any unrecognized dash-prefixed argument that errors with the same "unknown option" shape Dolt uses. `doltlite_staging.sh` had a test asserting `dolt_add('-a')` worked; it was documenting the unintentional extension and is deleted as obsolete.

### 3. Bogus table names silently no-oped

`dolt_add('nonexistent')` would fall through `doltliteResolveTableName`, which fails for nonexistent tables, into a fallback that walks `aStaged` looking for the name. If found there, the entry gets removed — that's the deliberate "stage a deletion" path (you `DROP TABLE t` and then `dolt_add('t')` to record the deletion in the staged catalog). If *not* found there, the old code silently `continue`'d to the next argument. Dolt errors with "the table(s) X do not exist".

Fixed by tracking whether the name was found in staged. If yes, preserve the existing deletion-staging behavior. If no, error with "table not found: <name>". The deletion-staging path still works; the bogus-name path now errors.

## Why the oracle works for a function

`dolt_add` is a function rather than a vtable, so its observable effect is the new value of `dolt_status` after the call. The harness reuses the same tab-separated single-column trick from the status oracle to compare post-state. Error scenarios are checked by a separate `oracle_error` helper that asserts both engines emit *some* error without comparing the message text — the messages legitimately differ ("dolt_add requires table name or '-A'" vs "Nothing specified, nothing added. Maybe you wanted to say 'dolt add .'?") but the failure semantics match.

## Test plan

- [ ] `vc_oracle_add_test.sh`: 16/16 pass locally
- [ ] `vc_oracle_status_test.sh`: 11/11 still pass (sanity check after `doltliteSerializeCatalogEntries` change)
- [ ] `vc_oracle_log_test.sh`: 7/7 still pass
- [ ] `index_oracle_test.sh`: 526/526 still pass
- [ ] `run_doltlite_tests.sh`: 39/39 suites pass (the staging test that asserted `-a` is removed)
- [ ] `remote_test.sh`: 63/63
- [ ] `large_scale_test.sh --quick`, `multi_table_test.sh --quick`, `diff_test.sh`, `config_test.sh`: all pass
- [ ] `concurrent_write_test`: 52/52

🤖 Generated with [Claude Code](https://claude.com/claude-code)