### PR TITLE
Fix remote rollback and commit ref validation

### DIFF
--- a/src/doltlite_commit.c
+++ b/src/doltlite_commit.c
@@ -32,6 +32,9 @@ int doltliteCommitSerialize(const DoltliteCommit *c, u8 **ppOut, int *pnOut){
     return SQLITE_TOOBIG;
   }
   nPar = c->nParents > 0 ? c->nParents : (prollyHashIsEmpty(&c->parentHash) ? 0 : 1);
+  if( nPar > DOLTLITE_MAX_PARENTS || nPar > 0xFF ){
+    return SQLITE_TOOBIG;
+  }
 
   sz = 1 + 1 + PROLLY_HASH_SIZE*nPar + PROLLY_HASH_SIZE + 8
          + 2 + nName + 2 + nEmail + 2 + nMsg;

--- a/src/doltlite_ref.c
+++ b/src/doltlite_ref.c
@@ -12,6 +12,21 @@
 #include "doltlite_commit.h"
 #include "doltlite_internal.h"
 
+static int doltliteValidateCommitHash(
+  sqlite3 *db,
+  const ProllyHash *pHash
+){
+  DoltliteCommit commit;
+  int rc;
+
+  memset(&commit, 0, sizeof(commit));
+  rc = doltliteLoadCommit(db, pHash, &commit);
+  if( rc==SQLITE_OK ){
+    doltliteCommitClear(&commit);
+  }
+  return rc;
+}
+
 int doltliteResolveRef(sqlite3 *db, const char *zRef, ProllyHash *pCommit){
   ChunkStore *cs = doltliteGetChunkStore(db);
   int rc;
@@ -20,16 +35,28 @@ int doltliteResolveRef(sqlite3 *db, const char *zRef, ProllyHash *pCommit){
   /* Try 40-char hex hash */
   if( strlen(zRef)==PROLLY_HASH_SIZE*2 ){
     rc = doltliteHexToHash(zRef, pCommit);
-    if( rc==SQLITE_OK && chunkStoreHas(cs, pCommit) ) return SQLITE_OK;
+    if( rc==SQLITE_OK ){
+      rc = doltliteValidateCommitHash(db, pCommit);
+      if( rc==SQLITE_OK ) return SQLITE_OK;
+      if( rc!=SQLITE_NOTFOUND ) return rc;
+    }
   }
 
   /* Try branch name */
   rc = chunkStoreFindBranch(cs, zRef, pCommit);
-  if( rc==SQLITE_OK && !prollyHashIsEmpty(pCommit) ) return SQLITE_OK;
+  if( rc==SQLITE_OK && !prollyHashIsEmpty(pCommit) ){
+    rc = doltliteValidateCommitHash(db, pCommit);
+    if( rc==SQLITE_OK ) return SQLITE_OK;
+    return rc;
+  }
 
   /* Try tag name */
   rc = chunkStoreFindTag(cs, zRef, pCommit);
-  if( rc==SQLITE_OK && !prollyHashIsEmpty(pCommit) ) return SQLITE_OK;
+  if( rc==SQLITE_OK && !prollyHashIsEmpty(pCommit) ){
+    rc = doltliteValidateCommitHash(db, pCommit);
+    if( rc==SQLITE_OK ) return SQLITE_OK;
+    return rc;
+  }
 
   return SQLITE_NOTFOUND;
 }

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -16,6 +16,80 @@ struct RemoteMutationCtx {
   int isDelete;
 };
 
+typedef struct RemoteSqlState RemoteSqlState;
+struct RemoteSqlState {
+  u8 *pRefsBlob;
+  int nRefsBlob;
+  ProllyHash refsHash;
+  char *zSessionBranch;
+  ProllyHash sessionHead;
+  ProllyHash sessionStaged;
+  ProllyHash sessionMergeCommit;
+  ProllyHash sessionConflictsCatalog;
+  ProllyHash sessionCatalogHash;
+  u8 sessionIsMerging;
+};
+
+static void remoteSqlStateClear(RemoteSqlState *p){
+  sqlite3_free(p->pRefsBlob);
+  sqlite3_free(p->zSessionBranch);
+  memset(p, 0, sizeof(*p));
+}
+
+static int remoteSqlStateSave(sqlite3 *db, ChunkStore *cs, RemoteSqlState *p){
+  u8 *pCatalog = 0;
+  int nCatalog = 0;
+  int rc;
+
+  memset(p, 0, sizeof(*p));
+
+  rc = chunkStoreSerializeRefsToBlob(cs, &p->pRefsBlob, &p->nRefsBlob);
+  if( rc!=SQLITE_OK ) return rc;
+  memcpy(&p->refsHash, &cs->refsHash, sizeof(ProllyHash));
+
+  p->zSessionBranch = sqlite3_mprintf("%s", doltliteGetSessionBranch(db));
+  if( !p->zSessionBranch ){
+    remoteSqlStateClear(p);
+    return SQLITE_NOMEM;
+  }
+  doltliteGetSessionHead(db, &p->sessionHead);
+  doltliteGetSessionStaged(db, &p->sessionStaged);
+  doltliteGetSessionMergeState(db, &p->sessionIsMerging,
+                               &p->sessionMergeCommit,
+                               &p->sessionConflictsCatalog);
+
+  rc = doltliteFlushAndSerializeCatalog(db, &pCatalog, &nCatalog);
+  if( rc!=SQLITE_OK ){
+    remoteSqlStateClear(p);
+    return rc;
+  }
+  rc = chunkStorePut(cs, pCatalog, nCatalog, &p->sessionCatalogHash);
+  sqlite3_free(pCatalog);
+  if( rc!=SQLITE_OK ){
+    remoteSqlStateClear(p);
+  }
+  return rc;
+}
+
+static int remoteSqlStateRestore(sqlite3 *db, ChunkStore *cs, RemoteSqlState *p){
+  int rc;
+
+  rc = chunkStoreLoadRefsFromBlob(cs, p->pRefsBlob, p->nRefsBlob);
+  if( rc!=SQLITE_OK ) return rc;
+  memcpy(&cs->refsHash, &p->refsHash, sizeof(ProllyHash));
+
+  rc = doltliteSwitchCatalog(db, &p->sessionCatalogHash);
+  if( rc!=SQLITE_OK ) return rc;
+
+  doltliteSetSessionBranch(db, p->zSessionBranch);
+  doltliteSetSessionHead(db, &p->sessionHead);
+  doltliteSetSessionStaged(db, &p->sessionStaged);
+  doltliteSetSessionMergeState(db, p->sessionIsMerging,
+                               &p->sessionMergeCommit,
+                               &p->sessionConflictsCatalog);
+  return SQLITE_OK;
+}
+
 static int mutateRemoteRef(sqlite3 *db, ChunkStore *cs, void *pArg){
   RemoteMutationCtx *p = (RemoteMutationCtx*)pArg;
   (void)db;
@@ -318,6 +392,7 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   const char *zRemoteName;
   const char *zBranch;
   ProllyHash trackingCommit, localCommit;
+  RemoteSqlState savedState;
   int rc;
 
   if( !cs ){ sqlite3_result_error(ctx, "no database", -1); return; }
@@ -330,6 +405,13 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   zBranch = (const char*)sqlite3_value_text(argv[1]);
   if( !zRemoteName || !zBranch ){
     sqlite3_result_error(ctx, "remote and branch required", -1);
+    return;
+  }
+  memset(&savedState, 0, sizeof(savedState));
+
+  rc = remoteSqlStateSave(db, cs, &savedState);
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error_code(ctx, rc);
     return;
   }
 
@@ -349,6 +431,7 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   rc = doltliteFetch(cs, pRemote, zRemoteName, zBranch);
   pRemote->xClose(pRemote);
   if( rc!=SQLITE_OK ){
+    remoteSqlStateClear(&savedState);
     sqlite3_result_error(ctx, "fetch failed: branch not found on remote", -1);
     return;
   }
@@ -356,6 +439,12 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   
   rc = chunkStoreFindTracking(cs, zRemoteName, zBranch, &trackingCommit);
   if( rc!=SQLITE_OK || prollyHashIsEmpty(&trackingCommit) ){
+    rc = remoteSqlStateRestore(db, cs, &savedState);
+    remoteSqlStateClear(&savedState);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(ctx, rc);
+      return;
+    }
     sqlite3_result_error(ctx, "tracking branch not found after fetch", -1);
     return;
   }
@@ -366,6 +455,12 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     
     rc = chunkStoreAddBranch(cs, zBranch, &trackingCommit);
     if( rc!=SQLITE_OK ){
+      rc = remoteSqlStateRestore(db, cs, &savedState);
+      remoteSqlStateClear(&savedState);
+      if( rc!=SQLITE_OK ){
+        sqlite3_result_error_code(ctx, rc);
+        return;
+      }
       sqlite3_result_error(ctx, "failed to create local branch", -1);
       return;
     }
@@ -374,6 +469,7 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
 
   
   if( prollyHashCompare(&localCommit, &trackingCommit)==0 ){
+    remoteSqlStateClear(&savedState);
     sqlite3_result_int(ctx, 0); 
     return;
   }
@@ -410,6 +506,12 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     }
 
     if( !canFF ){
+      rc = remoteSqlStateRestore(db, cs, &savedState);
+      remoteSqlStateClear(&savedState);
+      if( rc!=SQLITE_OK ){
+        sqlite3_result_error_code(ctx, rc);
+        return;
+      }
       sqlite3_result_error(ctx,
         "cannot fast-forward — use dolt_merge with the tracking branch instead", -1);
       return;
@@ -419,6 +521,12 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   
   rc = chunkStoreUpdateBranch(cs, zBranch, &trackingCommit);
   if( rc!=SQLITE_OK ){
+    rc = remoteSqlStateRestore(db, cs, &savedState);
+    remoteSqlStateClear(&savedState);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(ctx, rc);
+      return;
+    }
     sqlite3_result_error(ctx, "failed to update branch", -1);
     return;
   }
@@ -430,12 +538,24 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
 
     rc = chunkStoreGet(cs, &trackingCommit, &data, &nData);
     if( rc!=SQLITE_OK ){
+      rc = remoteSqlStateRestore(db, cs, &savedState);
+      remoteSqlStateClear(&savedState);
+      if( rc!=SQLITE_OK ){
+        sqlite3_result_error_code(ctx, rc);
+        return;
+      }
       sqlite3_result_error(ctx, "failed to load commit", -1);
       return;
     }
     rc = doltliteCommitDeserialize(data, nData, &commit);
     sqlite3_free(data);
     if( rc!=SQLITE_OK ){
+      rc = remoteSqlStateRestore(db, cs, &savedState);
+      remoteSqlStateClear(&savedState);
+      if( rc!=SQLITE_OK ){
+        sqlite3_result_error_code(ctx, rc);
+        return;
+      }
       sqlite3_result_error(ctx, "failed to deserialize commit", -1);
       return;
     }
@@ -443,6 +563,12 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     rc = doltliteHardReset(db, &commit.catalogHash);
     if( rc!=SQLITE_OK ){
       doltliteCommitClear(&commit);
+      rc = remoteSqlStateRestore(db, cs, &savedState);
+      remoteSqlStateClear(&savedState);
+      if( rc!=SQLITE_OK ){
+        sqlite3_result_error_code(ctx, rc);
+        return;
+      }
       sqlite3_result_error(ctx, "hard reset failed", -1);
       return;
     }
@@ -456,9 +582,16 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   rc = chunkStoreSerializeRefs(cs);
   if( rc==SQLITE_OK ) rc = chunkStoreCommit(cs);
   if( rc!=SQLITE_OK ){
+    rc = remoteSqlStateRestore(db, cs, &savedState);
+    remoteSqlStateClear(&savedState);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(ctx, rc);
+      return;
+    }
     sqlite3_result_error_code(ctx, rc);
     return;
   }
+  remoteSqlStateClear(&savedState);
   sqlite3_result_int(ctx, 0);
 }
 
@@ -467,6 +600,7 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   ChunkStore *cs = doltliteGetChunkStore(db);
   DoltliteRemote *pRemote = 0;
   const char *zUrl;
+  RemoteSqlState savedState;
   int rc;
 
   if( !cs ){ sqlite3_result_error(ctx, "no database", -1); return; }
@@ -480,6 +614,7 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     sqlite3_result_error(ctx, "url required", -1);
     return;
   }
+  memset(&savedState, 0, sizeof(savedState));
 
   
   /* Allow cloning over a pristine, auto-seeded repository: a single branch
@@ -500,11 +635,26 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
       sqlite3_result_error(ctx, "database is not empty — clone into a fresh database", -1);
       return;
     }
+  }
+
+  rc = remoteSqlStateSave(db, cs, &savedState);
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error_code(ctx, rc);
+    return;
+  }
+
+  if( !chunkStoreIsEmpty(cs) ){
     chunkStoreClearRefs(cs);
   }
 
   pRemote = openRemoteByUrl(cs->pVfs, zUrl);
   if( !pRemote ){
+    rc = remoteSqlStateRestore(db, cs, &savedState);
+    remoteSqlStateClear(&savedState);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(ctx, rc);
+      return;
+    }
     sqlite3_result_error(ctx, "failed to open remote (URL must start with file://)", -1);
     return;
   }
@@ -512,6 +662,12 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   rc = doltliteClone(cs, pRemote);
   pRemote->xClose(pRemote);
   if( rc!=SQLITE_OK ){
+    rc = remoteSqlStateRestore(db, cs, &savedState);
+    remoteSqlStateClear(&savedState);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(ctx, rc);
+      return;
+    }
     sqlite3_result_error(ctx, "clone failed", -1);
     return;
   }
@@ -519,6 +675,12 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   
   rc = chunkStoreAddRemote(cs, "origin", zUrl);
   if( rc!=SQLITE_OK ){
+    rc = remoteSqlStateRestore(db, cs, &savedState);
+    remoteSqlStateClear(&savedState);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(ctx, rc);
+      return;
+    }
     sqlite3_result_error(ctx, "failed to add origin remote", -1);
     return;
   }
@@ -554,18 +716,37 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
 
         rc = chunkStoreGet(cs, &branchCommit, &data, &nData);
         if( rc!=SQLITE_OK || !data ){
+          if( data ) sqlite3_free(data);
+          rc = remoteSqlStateRestore(db, cs, &savedState);
+          remoteSqlStateClear(&savedState);
+          if( rc!=SQLITE_OK ){
+            sqlite3_result_error_code(ctx, rc);
+            return;
+          }
           sqlite3_result_error(ctx, "failed to load default branch commit", -1);
           return;
         }
         rc = doltliteCommitDeserialize(data, nData, &commit);
         sqlite3_free(data);
         if( rc!=SQLITE_OK ){
+          rc = remoteSqlStateRestore(db, cs, &savedState);
+          remoteSqlStateClear(&savedState);
+          if( rc!=SQLITE_OK ){
+            sqlite3_result_error_code(ctx, rc);
+            return;
+          }
           sqlite3_result_error(ctx, "failed to deserialize default branch commit", -1);
           return;
         }
         rc = doltliteHardReset(db, &commit.catalogHash);
         if( rc!=SQLITE_OK ){
           doltliteCommitClear(&commit);
+          rc = remoteSqlStateRestore(db, cs, &savedState);
+          remoteSqlStateClear(&savedState);
+          if( rc!=SQLITE_OK ){
+            sqlite3_result_error_code(ctx, rc);
+            return;
+          }
           sqlite3_result_error(ctx, "failed to initialize working tree from default branch", -1);
           return;
         }
@@ -575,6 +756,12 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
         rc = chunkStoreSetDefaultBranch(cs, zDefault);
         doltliteCommitClear(&commit);
         if( rc!=SQLITE_OK ){
+          rc = remoteSqlStateRestore(db, cs, &savedState);
+          remoteSqlStateClear(&savedState);
+          if( rc!=SQLITE_OK ){
+            sqlite3_result_error_code(ctx, rc);
+            return;
+          }
           sqlite3_result_error(ctx, "failed to record default branch", -1);
           return;
         }
@@ -586,9 +773,16 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   rc = chunkStoreSerializeRefs(cs);
   if( rc==SQLITE_OK ) rc = chunkStoreCommit(cs);
   if( rc!=SQLITE_OK ){
+    rc = remoteSqlStateRestore(db, cs, &savedState);
+    remoteSqlStateClear(&savedState);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(ctx, rc);
+      return;
+    }
     sqlite3_result_error_code(ctx, rc);
     return;
   }
+  remoteSqlStateClear(&savedState);
   sqlite3_result_int(ctx, 0);
 }
 

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -16,6 +16,10 @@
 **   ./doltlite_regression_test_c remote_refs_corruption
 **   ./doltlite_regression_test_c chunk_walk_corruption
 **   ./doltlite_regression_test_c ancestor_missing_start
+**   ./doltlite_regression_test_c pull_persist_failure
+**   ./doltlite_regression_test_c clone_persist_failure
+**   ./doltlite_regression_test_c resolve_ref_non_commit
+**   ./doltlite_regression_test_c commit_parent_limit
 */
 #include <stdio.h>
 #include <stdlib.h>
@@ -24,6 +28,7 @@
 #include "sqlite3.h"
 #include "prolly_hash.h"
 #include "chunk_store.h"
+#include "doltlite_commit.h"
 #include "doltlite_chunk_walk.h"
 #include "doltlite_ancestor.h"
 #include "doltlite_internal.h"
@@ -751,6 +756,158 @@ static void run_ancestor_missing_start(void){
   remove_db(dbpath);
 }
 
+static void run_pull_persist_failure(void){
+  sqlite3 *localDb = 0;
+  sqlite3 *remoteDb = 0;
+  char localPath[256];
+  char remotePath[256];
+  char sql[1024];
+  const char *res;
+
+  printf("=== Pull Persist Failure Test ===\n\n");
+  make_dbpath(localPath, sizeof(localPath), "test_pull_persist_failure_local");
+  make_dbpath(remotePath, sizeof(remotePath), "test_pull_persist_failure_remote");
+  remove_db(localPath);
+  remove_db(remotePath);
+
+  gFailSyncOnce = 0;
+  gFailHits = 0;
+  check("register_fail_vfs_for_pull", registerFailVfs()==SQLITE_OK);
+  check("open_local_fail_db", open_fail_db(localPath, &localDb)==SQLITE_OK);
+  check("open_remote_db", open_db(remotePath, &remoteDb)==SQLITE_OK);
+
+  snprintf(sql, sizeof(sql),
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'a');"
+    "SELECT dolt_commit('-A', '-m', 'init');"
+    "SELECT dolt_remote('add','origin','file://%s');"
+    "SELECT dolt_push('origin','main');",
+    remotePath);
+  check("setup_local_and_push", execsql(localDb, sql)==SQLITE_OK);
+
+  sqlite3_close(remoteDb);
+  remoteDb = 0;
+  check("reopen_remote_db", open_db(remotePath, &remoteDb)==SQLITE_OK);
+  check("advance_remote", execsql(remoteDb,
+    "INSERT INTO t VALUES(2,'b');"
+    "SELECT dolt_commit('-A', '-m', 'remote update');")==SQLITE_OK);
+
+  gFailHits = 0;
+  gFailSyncOnce = 2;
+  res = exec1(localDb, "SELECT dolt_pull('origin','main')");
+  check("pull_failure_was_injected", gFailHits>0);
+  check("pull_returns_error_on_persist_failure", strstr(res, "ERROR:")!=0);
+  check("pull_branch_stays_main",
+    strcmp(exec1(localDb, "SELECT active_branch()"), "main")==0);
+  check("pull_head_data_restored",
+    strcmp(exec1(localDb, "SELECT count(*) FROM t"), "1")==0);
+
+  sqlite3_close(remoteDb);
+  sqlite3_close(localDb);
+  remove_db(localPath);
+  remove_db(remotePath);
+}
+
+static void run_clone_persist_failure(void){
+  sqlite3 *localDb = 0;
+  sqlite3 *remoteDb = 0;
+  char localPath[256];
+  char remotePath[256];
+  char sql[1024];
+  const char *res;
+
+  printf("=== Clone Persist Failure Test ===\n\n");
+  make_dbpath(localPath, sizeof(localPath), "test_clone_persist_failure_local");
+  make_dbpath(remotePath, sizeof(remotePath), "test_clone_persist_failure_remote");
+  remove_db(localPath);
+  remove_db(remotePath);
+
+  gFailSyncOnce = 0;
+  gFailHits = 0;
+  check("register_fail_vfs_for_clone", registerFailVfs()==SQLITE_OK);
+  check("open_remote_db", open_db(remotePath, &remoteDb)==SQLITE_OK);
+  check("setup_remote_repo", execsql(remoteDb,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'a');"
+    "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
+  sqlite3_close(remoteDb);
+  remoteDb = 0;
+
+  check("open_local_fail_db", open_fail_db(localPath, &localDb)==SQLITE_OK);
+  snprintf(sql, sizeof(sql), "SELECT dolt_clone('file://%s')", remotePath);
+  gFailHits = 0;
+  gFailSyncOnce = 2;
+  res = exec1(localDb, sql);
+  check("clone_failure_was_injected", gFailHits>0);
+  check("clone_returns_error_on_persist_failure", strstr(res, "ERROR:")!=0);
+  check("clone_does_not_leave_origin_remote",
+    strcmp(exec1(localDb, "SELECT count(*) FROM dolt_remotes"), "0")==0);
+  check("clone_restores_empty_catalog",
+    strcmp(exec1(localDb,
+      "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='t'"), "0")==0);
+
+  sqlite3_close(localDb);
+  remove_db(localPath);
+  remove_db(remotePath);
+}
+
+static void run_resolve_ref_non_commit(void){
+  sqlite3 *db = 0;
+  ChunkStore *cs = 0;
+  char dbpath[256];
+  ProllyHash headHash;
+  ProllyHash resolved;
+  DoltliteCommit commit;
+  char hex[PROLLY_HASH_SIZE*2 + 1];
+  int rc;
+
+  printf("=== Resolve Ref Non-Commit Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_resolve_ref_non_commit");
+  remove_db(dbpath);
+
+  check("open_db", open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_repo", execsql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'a');"
+    "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
+
+  doltliteGetSessionHead(db, &headHash);
+  memset(&commit, 0, sizeof(commit));
+  check("load_head_commit", doltliteLoadCommit(db, &headHash, &commit)==SQLITE_OK);
+  doltliteHashToHex(&commit.catalogHash, hex);
+
+  rc = doltliteResolveRef(db, hex, &resolved);
+  check("hex_catalog_hash_is_not_resolved_as_commit", rc!=SQLITE_OK);
+
+  cs = doltliteGetChunkStore(db);
+  check("have_chunk_store", cs!=0);
+  if( cs ){
+    check("corrupt_branch_ref_to_catalog_hash",
+      chunkStoreUpdateBranch(cs, "main", &commit.catalogHash)==SQLITE_OK);
+    rc = doltliteResolveRef(db, "main", &resolved);
+    check("branch_catalog_hash_is_not_resolved_as_commit", rc!=SQLITE_OK);
+  }
+
+  doltliteCommitClear(&commit);
+  sqlite3_close(db);
+  remove_db(dbpath);
+}
+
+static void run_commit_parent_limit(void){
+  DoltliteCommit commit;
+  u8 *pBlob = 0;
+  int nBlob = 0;
+  int rc;
+
+  printf("=== Commit Parent Limit Test ===\n\n");
+  memset(&commit, 0, sizeof(commit));
+  commit.nParents = DOLTLITE_MAX_PARENTS + 1;
+
+  rc = doltliteCommitSerialize(&commit, &pBlob, &nBlob);
+  check("serialize_rejects_too_many_parents", rc==SQLITE_TOOBIG);
+  sqlite3_free(pBlob);
+}
+
 static const RegressionCase aCases[] = {
   { "concurrent_refs", "Concurrent Refs Test", run_concurrent_refs },
   { "checkout_persist_failure", "Checkout Persist Failure Test", run_checkout_persist_failure },
@@ -761,7 +918,11 @@ static const RegressionCase aCases[] = {
   { "status_error_propagation", "Status Error Propagation Test", run_status_error_propagation },
   { "remote_refs_corruption", "Remote Refs Corruption Test", run_remote_refs_corruption },
   { "chunk_walk_corruption", "Chunk Walk Corruption Test", run_chunk_walk_corruption },
-  { "ancestor_missing_start", "Ancestor Missing Start Test", run_ancestor_missing_start }
+  { "ancestor_missing_start", "Ancestor Missing Start Test", run_ancestor_missing_start },
+  { "pull_persist_failure", "Pull Persist Failure Test", run_pull_persist_failure },
+  { "clone_persist_failure", "Clone Persist Failure Test", run_clone_persist_failure },
+  { "resolve_ref_non_commit", "Resolve Ref Non-Commit Test", run_resolve_ref_non_commit },
+  { "commit_parent_limit", "Commit Parent Limit Test", run_commit_parent_limit }
 };
 
 static int run_case_by_name(const char *zName){


### PR DESCRIPTION
## Summary
- make dolt_pull and dolt_clone restore prior refs/session/catalog state if later persistence fails
- validate resolved commit refs as real commits instead of accepting any existing chunk
- reject commit serialization inputs that exceed the parent limit

## Testing
- cd build && bash ../test/doltlite_regression_test_c.sh
- cd build && bash ../test/remote_test.sh ./doltlite
- cd build && bash ../test/doltlite_tag.sh