### PR TITLE
Add dolt_branches oracle and align schema with Dolt's nine columns

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,6 +75,10 @@ jobs:
       run: cd build && bash ../test/vc_oracle_add_test.sh ./doltlite dolt
       timeout-minutes: 5
 
+    - name: Version control oracle tests (dolt_branches)
+      run: cd build && bash ../test/vc_oracle_branches_test.sh ./doltlite dolt
+      timeout-minutes: 5
+
     - name: Large-scale test (10K rows)
       run: cd build && bash ../test/large_scale_test.sh ./doltlite --quick
       timeout-minutes: 5

--- a/README.md
+++ b/README.md
@@ -260,7 +260,8 @@ SELECT active_branch();
 
 -- List all branches
 SELECT * FROM dolt_branches;
--- name | hash | is_current
+-- name | hash | latest_committer | latest_committer_email
+-- | latest_commit_date | latest_commit_message | remote | branch | dirty
 
 -- Delete a branch
 SELECT dolt_branch('-d', 'feature');

--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -7,6 +7,7 @@
 #include "doltlite_commit.h"
 #include "doltlite_internal.h"
 #include <string.h>
+#include <time.h>
 
 
 
@@ -340,7 +341,18 @@ static int brConnect(sqlite3 *db, void *pAux, int argc,
     const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){
   BrVtab *p; int rc;
   (void)pAux; (void)argc; (void)argv; (void)pzErr;
-  rc = sqlite3_declare_vtab(db, "CREATE TABLE x(name TEXT, hash TEXT, is_current INTEGER)");
+  rc = sqlite3_declare_vtab(db,
+    "CREATE TABLE x("
+      "name TEXT, "
+      "hash TEXT, "
+      "latest_committer TEXT, "
+      "latest_committer_email TEXT, "
+      "latest_commit_date TEXT, "
+      "latest_commit_message TEXT, "
+      "remote TEXT, "
+      "branch TEXT, "
+      "dirty INTEGER"
+    ")");
   if( rc!=SQLITE_OK ) return rc;
   p = sqlite3_malloc(sizeof(*p));
   if( !p ) return SQLITE_NOMEM;
@@ -364,18 +376,119 @@ static int brEof(sqlite3_vtab_cursor *c){
   ChunkStore *cs = doltliteGetChunkStore(v->db);
   return !cs || ((BrCur*)c)->iRow >= cs->nBranches;
 }
+/*
+** Compute the "dirty" bit for a branch. The current branch is dirty when
+** the in-memory working state differs from HEAD's catalog (already
+** computed by doltliteHasUncommittedChanges). Other branches have a
+** persisted working-set blob on the BranchRef whose hash points at a
+** versioned record containing the staged catalog hash; the branch is
+** dirty when that staged catalog differs from HEAD's catalog.
+*/
+static int brIsDirty(sqlite3 *db, ChunkStore *cs, struct BranchRef *br){
+  ProllyHash stagedCat;
+  ProllyHash commitCat;
+  u8 *wsData = 0;
+  int nWsData = 0;
+  int rc, dirty = 0;
+
+  if( strcmp(br->zName, doltliteGetSessionBranch(db))==0 ){
+    return doltliteHasUncommittedChanges(db) ? 1 : 0;
+  }
+  if( prollyHashIsEmpty(&br->workingSetHash) ){
+    return 0;
+  }
+
+  rc = chunkStoreGet(cs, &br->workingSetHash, &wsData, &nWsData);
+  if( rc!=SQLITE_OK || !wsData || nWsData < WS_TOTAL_SIZE ){
+    sqlite3_free(wsData);
+    return 0;
+  }
+  memcpy(stagedCat.data, wsData + WS_STAGED_OFF, PROLLY_HASH_SIZE);
+  sqlite3_free(wsData);
+
+  if( prollyHashIsEmpty(&stagedCat) ){
+    return 0;
+  }
+
+  {
+    DoltliteCommit c;
+    memset(&c, 0, sizeof(c));
+    rc = doltliteLoadCommit(db, &br->commitHash, &c);
+    if( rc==SQLITE_OK ){
+      memcpy(commitCat.data, c.catalogHash.data, PROLLY_HASH_SIZE);
+      dirty = prollyHashCompare(&stagedCat, &commitCat)!=0;
+    }
+    doltliteCommitClear(&c);
+  }
+  return dirty;
+}
+
 static int brColumn(sqlite3_vtab_cursor *c, sqlite3_context *ctx, int col){
   BrVtab *v = (BrVtab*)c->pVtab;
   ChunkStore *cs = doltliteGetChunkStore(v->db);
   struct BranchRef *br;
   if(!cs) return SQLITE_OK;
   br = &cs->aBranches[((BrCur*)c)->iRow];
+
   switch(col){
-    case 0: sqlite3_result_text(ctx, br->zName, -1, SQLITE_TRANSIENT); break;
-    case 1: { char h[41]; doltliteHashToHex(&br->commitHash, h);
-              sqlite3_result_text(ctx, h, -1, SQLITE_TRANSIENT); break; }
-    case 2: sqlite3_result_int(ctx,
-              strcmp(br->zName, doltliteGetSessionBranch(v->db))==0 ? 1 : 0); break;
+    case 0:
+      sqlite3_result_text(ctx, br->zName, -1, SQLITE_TRANSIENT);
+      return SQLITE_OK;
+    case 1: {
+      char h[41];
+      doltliteHashToHex(&br->commitHash, h);
+      sqlite3_result_text(ctx, h, -1, SQLITE_TRANSIENT);
+      return SQLITE_OK;
+    }
+    case 6: case 7:
+      /* Upstream tracking: doltlite has no local-branch upstream concept,
+      ** so these are always empty (matches Dolt's output for branches
+      ** without an upstream configured). */
+      sqlite3_result_text(ctx, "", -1, SQLITE_STATIC);
+      return SQLITE_OK;
+    case 8:
+      sqlite3_result_int(ctx, brIsDirty(v->db, cs, br));
+      return SQLITE_OK;
+  }
+
+  /* Columns 2-5 require the head commit. Load once. */
+  {
+    DoltliteCommit cm;
+    int rc;
+    memset(&cm, 0, sizeof(cm));
+    rc = doltliteLoadCommit(v->db, &br->commitHash, &cm);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_null(ctx);
+      doltliteCommitClear(&cm);
+      return SQLITE_OK;
+    }
+    switch(col){
+      case 2:
+        sqlite3_result_text(ctx, cm.zName ? cm.zName : "",
+                            -1, SQLITE_TRANSIENT);
+        break;
+      case 3:
+        sqlite3_result_text(ctx, cm.zEmail ? cm.zEmail : "",
+                            -1, SQLITE_TRANSIENT);
+        break;
+      case 4: {
+        time_t t = (time_t)cm.timestamp;
+        struct tm *tm = gmtime(&t);
+        if( tm ){
+          char buf[32];
+          strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", tm);
+          sqlite3_result_text(ctx, buf, -1, SQLITE_TRANSIENT);
+        }else{
+          sqlite3_result_null(ctx);
+        }
+        break;
+      }
+      case 5:
+        sqlite3_result_text(ctx, cm.zMessage ? cm.zMessage : "",
+                            -1, SQLITE_TRANSIENT);
+        break;
+    }
+    doltliteCommitClear(&cm);
   }
   return SQLITE_OK;
 }

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -94,6 +94,7 @@ int doltliteSerializeCatalogEntries(sqlite3 *db, struct TableEntry *aTables,
                                     int nTables, u8 **ppOut, int *pnOut);
 int doltliteGetHeadCatalogHash(sqlite3 *db, ProllyHash *pCatHash);
 int doltliteFlushAndSerializeCatalog(sqlite3 *db, u8 **ppOut, int *pnOut);
+int doltliteHasUncommittedChanges(sqlite3 *db);
 /* Ref resolution: try hex hash, then branch, then tag (doltlite_ref.c) */
 int doltliteResolveRef(sqlite3 *db, const char *zRef, ProllyHash *pCommit);
 

--- a/test/doltlite_branch.sh
+++ b/test/doltlite_branch.sh
@@ -12,7 +12,7 @@ echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'
 run_test "default_branch" "SELECT active_branch();" "main" "$DB"
 run_test "create_branch" "SELECT dolt_branch('feature');" "0" "$DB"
 run_test "list_branches" "SELECT count(*) FROM dolt_branches;" "2" "$DB"
-run_test "main_current" "SELECT is_current FROM dolt_branches WHERE name='main';" "1" "$DB"
+run_test "main_current" "SELECT active_branch();" "main" "$DB"
 
 run_test "checkout_feature" "SELECT dolt_checkout('feature');" "0" "$DB"
 run_test "active_feature" "SELECT active_branch();" "feature" "$DB"

--- a/test/vc_oracle_branches_test.sh
+++ b/test/vc_oracle_branches_test.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+#
+# Version-control oracle test: dolt_branches
+#
+# Runs identical branch-management scenarios against doltlite and Dolt and
+# compares the normalized dolt_branches output. Catches divergence in how
+# each engine reports branch listings, the latest-commit metadata for each
+# branch, upstream tracking, and the per-branch dirty bit.
+#
+# Columns compared: name, hash (normalized), latest_commit_message,
+# remote, branch, dirty. The committer/email/date columns are excluded
+# because their values come from process/config and legitimately differ
+# across the two engines.
+#
+# Usage: bash vc_oracle_branches_test.sh [path/to/doltlite] [path/to/dolt]
+#
+
+set -u
+
+DOLTLITE="${1:-./doltlite}"
+DOLT="${2:-dolt}"
+TMPROOT=$(mktemp -d)
+trap "rm -rf $TMPROOT" EXIT
+pass=0; fail=0
+FAILED_NAMES=""
+
+# Replace each distinct hash with H1, H2, ... in first-appearance order;
+# strip CRLF.
+normalize() {
+  tr -d '\r' | awk -F'\t' '
+    {
+      h = $2
+      if (!(h in seen)) { n++; seen[h] = "H" n }
+      $2 = seen[h]
+      out = $1
+      for (i = 2; i <= NF; i++) out = out "\t" $i
+      print out
+    }
+  '
+}
+
+oracle() {
+  local name="$1" setup="$2"
+  local dir="$TMPROOT/$name"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local q='SELECT name || char(9) || hash || char(9) || latest_commit_message || char(9) || remote || char(9) || branch || char(9) || dirty FROM dolt_branches ORDER BY name'
+
+  local dl_out
+  dl_out=$(printf "%s\n.headers off\n.mode list\n.separator '\t'\n%s;\n" "$setup" "$q" \
+           | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
+           | grep -v '^[0-9]*$' \
+           | grep -v '^[0-9a-f]\{40\}$' \
+           | normalize)
+
+  local dolt_setup
+  dolt_setup=$(echo "$setup" | sed -E 's/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g')
+
+  (
+    cd "$dir/dt" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    echo "$dolt_setup" | "$DOLT" sql >/dev/null 2>"$dir/dt.err"
+    "$DOLT" sql -r csv -q "SELECT concat(name, char(9), hash, char(9), latest_commit_message, char(9), remote, char(9), branch, char(9), dirty) FROM dolt_branches ORDER BY name;" 2>>"$dir/dt.err"
+  ) > "$dir/dt.raw"
+
+  # Dolt prints "true"/"false" for the dirty tinyint(1); doltlite prints
+  # "0"/"1". Map both to 0/1 before comparison.
+  local dt_out
+  dt_out=$(tail -n +2 "$dir/dt.raw" \
+           | tr -d '"' \
+           | sed -E 's/\ttrue$/\t1/; s/\tfalse$/\t0/' \
+           | normalize)
+
+  if [ "$dl_out" = "$dt_out" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite:"; echo "$dl_out" | sed 's/^/      /'
+    echo "    dolt:"    ; echo "$dt_out" | sed 's/^/      /'
+  fi
+}
+
+echo "=== Version Control Oracle Tests: dolt_branches ==="
+echo ""
+
+echo "--- baseline ---"
+
+oracle "default_branch_only" "
+SELECT 1;
+"
+
+echo "--- single commit ---"
+
+oracle "main_after_one_commit" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'first');
+"
+
+echo "--- branch creation ---"
+
+oracle "create_branch_from_main" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'first');
+SELECT dolt_branch('feature');
+"
+
+oracle "create_two_branches_share_head" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'first');
+SELECT dolt_branch('feature');
+SELECT dolt_branch('experiment');
+"
+
+echo "--- divergence ---"
+
+oracle "branches_at_different_heads" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main_c1');
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feature_c2');
+"
+
+echo "--- deletion ---"
+
+oracle "delete_branch" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'first');
+SELECT dolt_branch('temp');
+SELECT dolt_branch('-d', 'temp');
+"
+
+echo "--- dirty bit ---"
+
+oracle "dirty_after_uncommitted_insert" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'first');
+SELECT dolt_branch('feature');
+INSERT INTO t VALUES (2);
+"
+
+oracle "dirty_after_staged_insert" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'first');
+SELECT dolt_branch('feature');
+INSERT INTO t VALUES (2);
+SELECT dolt_add('-A');
+"
+
+oracle "clean_after_commit_no_changes" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'first');
+"
+
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+if [ $fail -gt 0 ]; then
+  echo "Failed:$FAILED_NAMES"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- New `test/vc_oracle_branches_test.sh`: nine scenarios comparing doltlite's `dolt_branches` to Dolt's. Wired into CI as a hard gate.
- Doltlite's `dolt_branches` now has the same nine columns as Dolt's instead of the old three. The dropped `is_current` column was doltlite-specific; the six new columns (`latest_committer`, `latest_committer_email`, `latest_commit_date`, `latest_commit_message`, `remote`, `branch`, `dirty`) are populated from the head commit and the per-branch working-set blob.
- One subtle bug fixed during construction: my first attempt at the `dirty` bit compared `workingSetHash` to `commit.catalogHash`, which always returned dirty because they're different kinds of hashes (one is the hash of a versioned working-set *blob*, not of any catalog).

## The schema realignment

The vtable now declares:

```
name TEXT,
hash TEXT,
latest_committer TEXT,
latest_committer_email TEXT,
latest_commit_date TEXT,
latest_commit_message TEXT,
remote TEXT,
branch TEXT,
dirty INTEGER
```

`brColumn` loads each branch's head commit on demand and emits the committer name/email, date (gmtime + strftime, matching `dolt_log`'s format), and message. `remote` and `branch` are empty strings — doltlite has no local-branch upstream tracking concept, and Dolt also returns empty strings for branches with no upstream configured, so the comparison is well-defined.

`is_current` is dropped because Dolt doesn't have it. The single test that asserted it (`test/doltlite_branch.sh::main_current`) was an obvious replacement — `active_branch()` returns the same information.

## The dirty-bit subtlety worth flagging

I assumed `BranchRef.workingSetHash` was a hash of the working catalog, the way you'd model it in Git. It isn't. Doltlite's working set per branch is a versioned blob containing four things — version byte, staged catalog hash, merge flag, merge commit hash, conflicts catalog hash — and `workingSetHash` is the hash of *that whole blob*. So my first dirty implementation `workingSetHash != commit.catalogHash` was always true (different things being hashed) and reported every non-current branch as dirty. The oracle caught it on the first run.

The fix loads the WS blob from `chunkStoreGet`, extracts the staged catalog hash from `WS_STAGED_OFF`, and compares *that* to `commit.catalogHash`. Branches with no persisted working set (`workingSetHash` empty) are considered clean, which is the right answer for branches you've never been on.

## Why committer/email/date are excluded from the oracle comparison

These three columns get their values from process state, not user actions. Dolt's `dolt sql` uses the OS username; doltlite uses its session config default ("doltlite"); local config and `--author` overrides are possible but would need to be applied to every commit in every scenario. The remaining six columns — `name`, `hash` (normalized), `message`, `remote`, `branch`, `dirty` — are fully determined by what the user typed, so they're the load-bearing comparison axis.

Same approach as the log oracle, which also normalizes hashes and skips committer/email.

## Test plan

- [ ] `vc_oracle_branches_test.sh`: 9/9 pass locally
- [ ] `vc_oracle_status_test.sh`: 11/11 still pass (sanity)
- [ ] `vc_oracle_log_test.sh`: 7/7 still pass
- [ ] `vc_oracle_add_test.sh`: 16/16 still pass
- [ ] `index_oracle_test.sh`: 526/526 still pass
- [ ] `run_doltlite_tests.sh`: 39/39 suites pass
- [ ] `remote_test.sh`: 63/63
- [ ] `large_scale_test.sh --quick`, `multi_table_test.sh --quick`, `diff_test.sh`, `config_test.sh`: all pass
- [ ] `concurrent_write_test`: 52/52

🤖 Generated with [Claude Code](https://claude.com/claude-code)