### PR TITLE
Promote tags to first-class objects with metadata; add dolt_tags oracle

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,6 +79,10 @@ jobs:
       run: cd build && bash ../test/vc_oracle_branches_test.sh ./doltlite dolt
       timeout-minutes: 5
 
+    - name: Version control oracle tests (dolt_tags)
+      run: cd build && bash ../test/vc_oracle_tags_test.sh ./doltlite dolt
+      timeout-minutes: 5
+
     - name: Large-scale test (10K rows)
       run: cd build && bash ../test/large_scale_test.sh ./doltlite --quick
       timeout-minutes: 5

--- a/DEMO.md
+++ b/DEMO.md
@@ -169,8 +169,8 @@ SELECT * FROM dolt_branches;
 -- modifications | 15542b3e3de19d575287bd5fde8398a52cf65534 | 0
 
 SELECT * FROM dolt_tags;
--- name | hash
--- v1   | 4e130d15c8858d3ab474bfdb48f3f23e358fa822
+-- tag_name | tag_hash                                 | tagger   | email | date | message
+-- v1       | 4e130d15c8858d3ab474bfdb48f3f23e358fa822 | doltlite |       | ...  |
 
 SELECT active_branch();
 -- main

--- a/examples/go/main.go
+++ b/examples/go/main.go
@@ -152,7 +152,7 @@ func main() {
 	// ---- 7. Tag ----
 	fmt.Println("== Tag current state ==\n")
 	exec(db, "SELECT dolt_tag('v1.0')")
-	rows, _ = db.Query("SELECT name, hash FROM dolt_tags")
+	rows, _ = db.Query("SELECT tag_name, tag_hash FROM dolt_tags")
 	for rows.Next() {
 		var name, h string
 		rows.Scan(&name, &h)

--- a/examples/quickstart.c
+++ b/examples/quickstart.c
@@ -116,7 +116,7 @@ int main(int argc, char **argv){
   /* ---- 7. Tag the release ---- */
   printf("== Tag current state ==\n\n");
   exec(db, "SELECT dolt_tag('v1.0')");
-  exec(db, "SELECT name, hash FROM dolt_tags");
+  exec(db, "SELECT tag_name, tag_hash FROM dolt_tags");
 
   /* ---- Cleanup ---- */
   sqlite3_close(db);

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -97,7 +97,7 @@ def main():
     # ---- 7. Tag ----
     print("== Tag current state ==\n")
     cur.execute("SELECT dolt_tag('v1.0')")
-    for row in cur.execute("SELECT name, hash FROM dolt_tags"):
+    for row in cur.execute("SELECT tag_name, tag_hash FROM dolt_tags"):
         print(f"  {row[0]}: {row[1][:12]}...")
     print()
 

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -162,7 +162,12 @@ static void csFreeBranches(ChunkStore *cs){
 }
 static void csFreeTags(ChunkStore *cs){
   int k;
-  for(k=0; k<cs->nTags; k++) sqlite3_free(cs->aTags[k].zName);
+  for(k=0; k<cs->nTags; k++){
+    sqlite3_free(cs->aTags[k].zName);
+    sqlite3_free(cs->aTags[k].zTagger);
+    sqlite3_free(cs->aTags[k].zEmail);
+    sqlite3_free(cs->aTags[k].zMessage);
+  }
   sqlite3_free(cs->aTags);
   cs->aTags = 0;
   cs->nTags = 0;
@@ -905,14 +910,34 @@ int chunkStoreFindTag(ChunkStore *cs, const char *zName, ProllyHash *pCommit){
 }
 
 int chunkStoreAddTag(ChunkStore *cs, const char *zName, const ProllyHash *pCommit){
+  return chunkStoreAddTagFull(cs, zName, pCommit, 0, 0, 0, 0);
+}
+
+int chunkStoreAddTagFull(
+  ChunkStore *cs,
+  const char *zName,
+  const ProllyHash *pCommit,
+  const char *zTagger,
+  const char *zEmail,
+  i64 timestamp,
+  const char *zMessage
+){
   struct TagRef *aNew;
   if( chunkStoreFindTag(cs, zName, 0)==SQLITE_OK ) return SQLITE_ERROR;
   aNew = sqlite3_realloc(cs->aTags, (cs->nTags+1)*(int)sizeof(struct TagRef));
   if( !aNew ) return SQLITE_NOMEM;
   cs->aTags = aNew;
+  memset(&aNew[cs->nTags], 0, sizeof(struct TagRef));
   aNew[cs->nTags].zName = sqlite3_mprintf("%s", zName);
   if( !aNew[cs->nTags].zName ) return SQLITE_NOMEM;
   memcpy(&aNew[cs->nTags].commitHash, pCommit, sizeof(ProllyHash));
+  aNew[cs->nTags].zTagger  = sqlite3_mprintf("%s", zTagger  ? zTagger  : "");
+  aNew[cs->nTags].zEmail   = sqlite3_mprintf("%s", zEmail   ? zEmail   : "");
+  aNew[cs->nTags].zMessage = sqlite3_mprintf("%s", zMessage ? zMessage : "");
+  if( !aNew[cs->nTags].zTagger || !aNew[cs->nTags].zEmail || !aNew[cs->nTags].zMessage ){
+    return SQLITE_NOMEM;
+  }
+  aNew[cs->nTags].timestamp = timestamp;
   cs->nTags++;
   return SQLITE_OK;
 }
@@ -1048,13 +1073,19 @@ int chunkStoreHasMany(ChunkStore *cs, const ProllyHash *aHash, int nHash, u8 *aR
 }
 
 /*
-** Refs blob format (version 5):
+** Refs blob format (version 6):
 **   [version:1][default_branch_len:4][default_branch:N]
 **   [nBranches:4] { [name_len:4][name:N][commit_hash:20][ws_hash:20] }...
-**   [nTags:4]     { [name_len:4][name:N][commit_hash:20] }...
+**   [nTags:4]     { [name_len:4][name:N][commit_hash:20]
+**                   [tagger_len:4][tagger:N]
+**                   [email_len:4][email:N]
+**                   [timestamp:8]
+**                   [message_len:4][message:N] }...
 **   [nRemotes:4]  { [name_len:4][name:N][url_len:4][url:N] }...
 **   [nTracking:4] { [remote_len:4][remote:N][branch_len:4][branch:N][commit_hash:20] }...
-** All length fields are little-endian u32.
+** Version 5 omits the per-tag metadata fields; the deserializer accepts
+** both versions and defaults missing tag metadata to empty/0.
+** All length fields are little-endian u32; timestamp is little-endian i64.
 */
 static int csSerializeRefsBlob(ChunkStore *cs, u8 **ppOut, int *pnOut){
   const char *def = cs->zDefaultBranch ? cs->zDefaultBranch : "main";
@@ -1074,7 +1105,14 @@ static int csSerializeRefsBlob(ChunkStore *cs, u8 **ppOut, int *pnOut){
     sz += inc;
   }
   for(i=0; i<cs->nTags; i++){
-    int inc = 4 + (int)strlen(cs->aTags[i].zName) + PROLLY_HASH_SIZE;
+    int taggerLen  = cs->aTags[i].zTagger  ? (int)strlen(cs->aTags[i].zTagger)  : 0;
+    int emailLen   = cs->aTags[i].zEmail   ? (int)strlen(cs->aTags[i].zEmail)   : 0;
+    int messageLen = cs->aTags[i].zMessage ? (int)strlen(cs->aTags[i].zMessage) : 0;
+    int inc = 4 + (int)strlen(cs->aTags[i].zName) + PROLLY_HASH_SIZE
+            + 4 + taggerLen
+            + 4 + emailLen
+            + 8
+            + 4 + messageLen;
     if( sz > INT_MAX - inc ){
       return SQLITE_TOOBIG;
     }
@@ -1097,7 +1135,7 @@ static int csSerializeRefsBlob(ChunkStore *cs, u8 **ppOut, int *pnOut){
   buf = sqlite3_malloc(sz);
   if( !buf ) return SQLITE_NOMEM;
   bufCur = buf;
-  *bufCur++ = 5;  /* refs format version */
+  *bufCur++ = 6;  /* refs format version */
   CS_WRITE_U32(bufCur,defLen); bufCur+=4;
   memcpy(bufCur, def, defLen); bufCur+=defLen;
   CS_WRITE_U32(bufCur,cs->nBranches); bufCur+=4;
@@ -1110,10 +1148,23 @@ static int csSerializeRefsBlob(ChunkStore *cs, u8 **ppOut, int *pnOut){
   }
   CS_WRITE_U32(bufCur,cs->nTags); bufCur+=4;
   for(i=0; i<cs->nTags; i++){
-    int nameLen = (int)strlen(cs->aTags[i].zName);
+    int nameLen    = (int)strlen(cs->aTags[i].zName);
+    int taggerLen  = cs->aTags[i].zTagger  ? (int)strlen(cs->aTags[i].zTagger)  : 0;
+    int emailLen   = cs->aTags[i].zEmail   ? (int)strlen(cs->aTags[i].zEmail)   : 0;
+    int messageLen = cs->aTags[i].zMessage ? (int)strlen(cs->aTags[i].zMessage) : 0;
     CS_WRITE_U32(bufCur,nameLen); bufCur+=4;
     memcpy(bufCur, cs->aTags[i].zName, nameLen); bufCur+=nameLen;
     memcpy(bufCur, cs->aTags[i].commitHash.data, PROLLY_HASH_SIZE); bufCur+=PROLLY_HASH_SIZE;
+    CS_WRITE_U32(bufCur,taggerLen); bufCur+=4;
+    if( taggerLen ) memcpy(bufCur, cs->aTags[i].zTagger, taggerLen);
+    bufCur+=taggerLen;
+    CS_WRITE_U32(bufCur,emailLen); bufCur+=4;
+    if( emailLen ) memcpy(bufCur, cs->aTags[i].zEmail, emailLen);
+    bufCur+=emailLen;
+    CS_WRITE_I64(bufCur,cs->aTags[i].timestamp); bufCur+=8;
+    CS_WRITE_U32(bufCur,messageLen); bufCur+=4;
+    if( messageLen ) memcpy(bufCur, cs->aTags[i].zMessage, messageLen);
+    bufCur+=messageLen;
   }
   CS_WRITE_U32(bufCur,cs->nRemotes); bufCur+=4;
   for(i=0; i<cs->nRemotes; i++){
@@ -1159,7 +1210,7 @@ static int csDeserializeRefs(ChunkStore *cs, const u8 *data, int nData){
   u8 version;
   if( nData<5 ) return SQLITE_CORRUPT;
   version = *bufCur++;
-  if( version!=5 ) return SQLITE_CORRUPT;
+  if( version!=5 && version!=6 ) return SQLITE_CORRUPT;
   if( bufCur+4>data+nData ) return SQLITE_CORRUPT;
   defLen = (int)CS_READ_U32(bufCur); bufCur+=4;
   if( bufCur+defLen>data+nData ) return SQLITE_CORRUPT;
@@ -1204,6 +1255,36 @@ static int csDeserializeRefs(ChunkStore *cs, const u8 *data, int nData){
         if(!cs->aTags[i].zName) return SQLITE_NOMEM;
         memcpy(cs->aTags[i].zName,bufCur,nameLen); cs->aTags[i].zName[nameLen]=0; bufCur+=nameLen;
         memcpy(cs->aTags[i].commitHash.data,bufCur,PROLLY_HASH_SIZE); bufCur+=PROLLY_HASH_SIZE;
+        if( version>=6 ){
+          int taggerLen, emailLen, messageLen;
+          if(bufCur+4>data+nData) return SQLITE_CORRUPT;
+          taggerLen=(int)CS_READ_U32(bufCur); bufCur+=4;
+          if(bufCur+taggerLen>data+nData) return SQLITE_CORRUPT;
+          cs->aTags[i].zTagger=sqlite3_malloc(taggerLen+1);
+          if(!cs->aTags[i].zTagger) return SQLITE_NOMEM;
+          memcpy(cs->aTags[i].zTagger,bufCur,taggerLen); cs->aTags[i].zTagger[taggerLen]=0; bufCur+=taggerLen;
+          if(bufCur+4>data+nData) return SQLITE_CORRUPT;
+          emailLen=(int)CS_READ_U32(bufCur); bufCur+=4;
+          if(bufCur+emailLen>data+nData) return SQLITE_CORRUPT;
+          cs->aTags[i].zEmail=sqlite3_malloc(emailLen+1);
+          if(!cs->aTags[i].zEmail) return SQLITE_NOMEM;
+          memcpy(cs->aTags[i].zEmail,bufCur,emailLen); cs->aTags[i].zEmail[emailLen]=0; bufCur+=emailLen;
+          if(bufCur+8>data+nData) return SQLITE_CORRUPT;
+          cs->aTags[i].timestamp=CS_READ_I64(bufCur); bufCur+=8;
+          if(bufCur+4>data+nData) return SQLITE_CORRUPT;
+          messageLen=(int)CS_READ_U32(bufCur); bufCur+=4;
+          if(bufCur+messageLen>data+nData) return SQLITE_CORRUPT;
+          cs->aTags[i].zMessage=sqlite3_malloc(messageLen+1);
+          if(!cs->aTags[i].zMessage) return SQLITE_NOMEM;
+          memcpy(cs->aTags[i].zMessage,bufCur,messageLen); cs->aTags[i].zMessage[messageLen]=0; bufCur+=messageLen;
+        }else{
+          cs->aTags[i].zTagger  = sqlite3_mprintf("");
+          cs->aTags[i].zEmail   = sqlite3_mprintf("");
+          cs->aTags[i].zMessage = sqlite3_mprintf("");
+          if( !cs->aTags[i].zTagger || !cs->aTags[i].zEmail || !cs->aTags[i].zMessage ){
+            return SQLITE_NOMEM;
+          }
+        }
         cs->nTags++;
       }
     }

--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -121,6 +121,10 @@ struct ChunkStore {
   struct TagRef {
     char *zName;
     ProllyHash commitHash;
+    char *zTagger;
+    char *zEmail;
+    i64 timestamp;
+    char *zMessage;
   } *aTags;
   int nTags;
 
@@ -208,6 +212,9 @@ int chunkStoreGetBranchWorkingSet(ChunkStore *cs, const char *zBranch, ProllyHas
 int chunkStoreSetBranchWorkingSet(ChunkStore *cs, const char *zBranch, const ProllyHash *pHash);
 
 int chunkStoreAddTag(ChunkStore *cs, const char *zName, const ProllyHash *pCommit);
+int chunkStoreAddTagFull(ChunkStore *cs, const char *zName, const ProllyHash *pCommit,
+                         const char *zTagger, const char *zEmail,
+                         i64 timestamp, const char *zMessage);
 int chunkStoreDeleteTag(ChunkStore *cs, const char *zName);
 int chunkStoreFindTag(ChunkStore *cs, const char *zName, ProllyHash *pCommit);
 

--- a/src/doltlite_tag.c
+++ b/src/doltlite_tag.c
@@ -7,12 +7,17 @@
 #include "doltlite_commit.h"
 #include "doltlite_internal.h"
 #include <string.h>
+#include <time.h>
 
 typedef struct TagMutationCtx TagMutationCtx;
 struct TagMutationCtx {
   const char *zName;
   ProllyHash commitHash;
   int isDelete;
+  const char *zTagger;
+  const char *zEmail;
+  i64 timestamp;
+  const char *zMessage;
 };
 
 static void tagResultError(
@@ -34,7 +39,9 @@ static int mutateTagRef(sqlite3 *db, ChunkStore *cs, void *pArg){
   TagMutationCtx *p = (TagMutationCtx*)pArg;
   (void)db;
   if( p->isDelete ) return chunkStoreDeleteTag(cs, p->zName);
-  return chunkStoreAddTag(cs, p->zName, &p->commitHash);
+  return chunkStoreAddTagFull(cs, p->zName, &p->commitHash,
+                              p->zTagger, p->zEmail,
+                              p->timestamp, p->zMessage);
 }
 
 static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
@@ -42,7 +49,12 @@ static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   ChunkStore *cs = doltliteGetChunkStore(db);
   TagMutationCtx m;
   const char *arg0;
-  int rc;
+  const char *zMessage = 0;
+  const char *zAuthor = 0;
+  const char *zCommitRef = 0;
+  char *zParsedTagger = 0;
+  char *zParsedEmail = 0;
+  int rc, i;
 
   if( !cs ){ sqlite3_result_error(ctx, "no database", -1); return; }
   if( argc<1 ){ sqlite3_result_error(ctx, "tag name required", -1); return; }
@@ -52,6 +64,7 @@ static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   arg0 = (const char*)sqlite3_value_text(argv[0]);
   if( !arg0 ){ sqlite3_result_error(ctx, "tag name required", -1); return; }
 
+  /* Delete: dolt_tag('-d', name) — same shape as before. */
   if( strcmp(arg0, "-d")==0 || strcmp(arg0, "--delete")==0 ){
     const char *zName;
     if( argc<2 ){ sqlite3_result_error(ctx, "tag name required for delete", -1); return; }
@@ -64,40 +77,82 @@ static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
       tagResultError(ctx, rc, "tag not found", 0);
       return;
     }
-  }else{
-    
-    if( argc>=2 ){
-      DoltliteCommit commit;
-      const char *zHash = (const char*)sqlite3_value_text(argv[1]);
-      if( !zHash ){ sqlite3_result_error(ctx, "invalid commit hash", -1); return; }
-      rc = doltliteHexToHash(zHash, &m.commitHash);
-      if( rc!=SQLITE_OK ){
-        sqlite3_result_error(ctx, "invalid commit hash format", -1);
-        return;
+    sqlite3_result_int(ctx, 0);
+    return;
+  }
+
+  /* Create: dolt_tag(name [, commit_ref] [, '-m', msg] [, '--author', 'name <email>'])
+  ** The first non-flag positional argument after the name is treated as
+  ** the commit ref to tag; if absent, the session HEAD is used. */
+  for(i=1; i<argc; i++){
+    const char *arg = (const char*)sqlite3_value_text(argv[i]);
+    if( !arg ) continue;
+    if( strcmp(arg, "-m")==0 || strcmp(arg, "--message")==0 ){
+      if( i+1<argc ) zMessage = (const char*)sqlite3_value_text(argv[++i]);
+      else{ sqlite3_result_error(ctx, "-m requires a message", -1); return; }
+    }else if( strcmp(arg, "--author")==0 ){
+      if( i+1<argc ) zAuthor = (const char*)sqlite3_value_text(argv[++i]);
+      else{ sqlite3_result_error(ctx, "--author requires 'name <email>'", -1); return; }
+    }else if( arg[0]=='-' ){
+      char *zErr = sqlite3_mprintf("unknown option `%s`", arg);
+      if( zErr ){
+        sqlite3_result_error(ctx, zErr, -1);
+        sqlite3_free(zErr);
+      }else{
+        sqlite3_result_error_nomem(ctx);
       }
-      memset(&commit, 0, sizeof(commit));
-      rc = doltliteLoadCommit(db, &m.commitHash, &commit);
-      if( rc!=SQLITE_OK ){
-        sqlite3_result_error(ctx, "commit not found", -1);
-        return;
-      }
-      doltliteCommitClear(&commit);
+      return;
+    }else if( !zCommitRef ){
+      zCommitRef = arg;
     }else{
-      
-      doltliteGetSessionHead(db, &m.commitHash);
-      if( prollyHashIsEmpty(&m.commitHash) ){
-        sqlite3_result_error(ctx, "no commits to tag", -1);
-        return;
-      }
-    }
-    m.zName = arg0;
-    rc = doltliteMutateRefs(db, mutateTagRef, &m);
-    if( rc!=SQLITE_OK ){
-      tagResultError(ctx, rc, "tag not found", "tag already exists");
+      sqlite3_result_error(ctx, "too many positional arguments to dolt_tag", -1);
       return;
     }
   }
 
+  if( zCommitRef ){
+    rc = doltliteResolveRef(db, zCommitRef, &m.commitHash);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error(ctx, "commit not found", -1);
+      return;
+    }
+  }else{
+    doltliteGetSessionHead(db, &m.commitHash);
+    if( prollyHashIsEmpty(&m.commitHash) ){
+      sqlite3_result_error(ctx, "no commits to tag", -1);
+      return;
+    }
+  }
+
+  if( zAuthor ){
+    const char *lt = strchr(zAuthor, '<');
+    const char *gt = lt ? strchr(lt, '>') : 0;
+    if( lt && gt ){
+      int nameLen = (int)(lt - zAuthor);
+      while( nameLen>0 && zAuthor[nameLen-1]==' ' ) nameLen--;
+      zParsedTagger = sqlite3_mprintf("%.*s", nameLen, zAuthor);
+      zParsedEmail  = sqlite3_mprintf("%.*s", (int)(gt-lt-1), lt+1);
+    }else{
+      zParsedTagger = sqlite3_mprintf("%s", zAuthor);
+      zParsedEmail  = sqlite3_mprintf("");
+    }
+    m.zTagger = zParsedTagger;
+    m.zEmail  = zParsedEmail;
+  }else{
+    m.zTagger = doltliteGetAuthorName(db);
+    m.zEmail  = doltliteGetAuthorEmail(db);
+  }
+  m.timestamp = (i64)time(0);
+  m.zMessage = zMessage ? zMessage : "";
+  m.zName = arg0;
+
+  rc = doltliteMutateRefs(db, mutateTagRef, &m);
+  sqlite3_free(zParsedTagger);
+  sqlite3_free(zParsedEmail);
+  if( rc!=SQLITE_OK ){
+    tagResultError(ctx, rc, "tag not found", "tag already exists");
+    return;
+  }
   sqlite3_result_int(ctx, 0);
 }
 
@@ -110,7 +165,15 @@ static int tagConnect(sqlite3 *db, void *pAux, int argc,
     const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){
   TagVtab *v; int rc;
   (void)pAux; (void)argc; (void)argv; (void)pzErr;
-  rc = sqlite3_declare_vtab(db, "CREATE TABLE x(name TEXT, hash TEXT, commit_message TEXT)");
+  rc = sqlite3_declare_vtab(db,
+    "CREATE TABLE x("
+      "tag_name TEXT, "
+      "tag_hash TEXT, "
+      "tagger TEXT, "
+      "email TEXT, "
+      "date TEXT, "
+      "message TEXT"
+    ")");
   if( rc!=SQLITE_OK ) return rc;
   v = sqlite3_malloc(sizeof(*v));
   if( !v ) return SQLITE_NOMEM;
@@ -141,21 +204,39 @@ static int tagColumn(sqlite3_vtab_cursor *c, sqlite3_context *ctx, int col){
   if(!cs) return SQLITE_OK;
   t = &cs->aTags[((TagCur*)c)->iRow];
   switch(col){
-    case 0: sqlite3_result_text(ctx, t->zName, -1, SQLITE_TRANSIENT); break;
+    case 0:
+      sqlite3_result_text(ctx, t->zName, -1, SQLITE_TRANSIENT);
+      break;
     case 1: {
       char h[PROLLY_HASH_SIZE*2+1];
       doltliteHashToHex(&t->commitHash, h);
       sqlite3_result_text(ctx, h, -1, SQLITE_TRANSIENT);
       break;
     }
-    case 2: {
-      DoltliteCommit commit;
-      if( doltliteLoadCommit(v->db, &t->commitHash, &commit)==SQLITE_OK ){
-        sqlite3_result_text(ctx, commit.zMessage?commit.zMessage:"", -1, SQLITE_TRANSIENT);
-        doltliteCommitClear(&commit);
+    case 2:
+      sqlite3_result_text(ctx, t->zTagger ? t->zTagger : "",
+                          -1, SQLITE_TRANSIENT);
+      break;
+    case 3:
+      sqlite3_result_text(ctx, t->zEmail ? t->zEmail : "",
+                          -1, SQLITE_TRANSIENT);
+      break;
+    case 4: {
+      time_t secs = (time_t)t->timestamp;
+      struct tm *tm = gmtime(&secs);
+      if( tm ){
+        char buf[32];
+        strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", tm);
+        sqlite3_result_text(ctx, buf, -1, SQLITE_TRANSIENT);
+      }else{
+        sqlite3_result_null(ctx);
       }
       break;
     }
+    case 5:
+      sqlite3_result_text(ctx, t->zMessage ? t->zMessage : "",
+                          -1, SQLITE_TRANSIENT);
+      break;
   }
   return SQLITE_OK;
 }

--- a/test/doltlite_advanced.sh
+++ b/test/doltlite_advanced.sh
@@ -416,10 +416,10 @@ SELECT dolt_commit('-A','-m','release v2');
 SELECT dolt_tag('v2.0');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "tagmeta_count" "SELECT count(*) FROM dolt_tags;" "2" "$DB"
-run_test_match "tagmeta_hash" "SELECT hash FROM dolt_tags WHERE name='v1.0';" "^[0-9a-f]{40}$" "$DB"
-run_test "tagmeta_diff_hash" "SELECT count(DISTINCT hash) FROM dolt_tags;" "2" "$DB"
+run_test_match "tagmeta_hash" "SELECT tag_hash FROM dolt_tags WHERE tag_name='v1.0';" "^[0-9a-f]{40}$" "$DB"
+run_test "tagmeta_diff_hash" "SELECT count(DISTINCT tag_hash) FROM dolt_tags;" "2" "$DB"
 run_test_match "tagmeta_names" \
-  "SELECT group_concat(name) FROM (SELECT name FROM dolt_tags ORDER BY name);" "v1.*v2" "$DB"
+  "SELECT group_concat(tag_name) FROM (SELECT tag_name FROM dolt_tags ORDER BY tag_name);" "v1.*v2" "$DB"
 
 rm -f "$DB"
 
@@ -519,7 +519,7 @@ run_test "subq_tag" "SELECT count(*) FROM dolt_tags;" "1" "$DB"
 
 # Diff using subquery for hashes
 run_test_match "subq_diff" \
-  "SELECT count(*) FROM dolt_diff('t', (SELECT hash FROM dolt_tags WHERE name='first'), (SELECT commit_hash FROM dolt_log LIMIT 1));" \
+  "SELECT count(*) FROM dolt_diff('t', (SELECT tag_hash FROM dolt_tags WHERE tag_name='first'), (SELECT commit_hash FROM dolt_log LIMIT 1));" \
   "^[1-9]" "$DB"
 
 rm -f "$DB"

--- a/test/doltlite_demo.sh
+++ b/test/doltlite_demo.sh
@@ -176,7 +176,7 @@ run_test "schema_diff_same" \
 # ============================================================
 
 run_test "tags_count" "SELECT count(*) FROM dolt_tags;" "1" "$DB"
-run_test "tags_v1" "SELECT name FROM dolt_tags;" "v1" "$DB"
+run_test "tags_v1" "SELECT tag_name FROM dolt_tags;" "v1" "$DB"
 
 # Data at v1: 4 employees
 run_test "tags_v1_data" "SELECT count(*) FROM dolt_at_employees('v1');" "4" "$DB"

--- a/test/doltlite_e2e.sh
+++ b/test/doltlite_e2e.sh
@@ -34,7 +34,7 @@ run_test "e2e_clean_status" "SELECT count(*) FROM dolt_status;" "0" "$DB"
 
 # Tag the initial release
 echo "SELECT dolt_tag('v0.1');" | $DOLTLITE "$DB" > /dev/null 2>&1
-run_test "e2e_tag_exists" "SELECT name FROM dolt_tags;" "v0.1" "$DB"
+run_test "e2e_tag_exists" "SELECT tag_name FROM dolt_tags;" "v0.1" "$DB"
 
 # ============================================================
 # Phase 2: Feature branch — add comments table
@@ -90,7 +90,7 @@ run_test "e2e_two_tags" "SELECT count(*) FROM dolt_tags;" "2" "$DB"
 # ============================================================
 
 run_test_match "e2e_diff_users_v01_v02" \
-  "SELECT count(*) FROM dolt_diff('users', (SELECT hash FROM dolt_tags WHERE name='v0.1'), (SELECT hash FROM dolt_tags WHERE name='v0.2'));" \
+  "SELECT count(*) FROM dolt_diff('users', (SELECT tag_hash FROM dolt_tags WHERE tag_name='v0.1'), (SELECT tag_hash FROM dolt_tags WHERE tag_name='v0.2'));" \
   "^[0-9]" "$DB"
 
 # ============================================================

--- a/test/doltlite_edge_cases.sh
+++ b/test/doltlite_edge_cases.sh
@@ -400,7 +400,7 @@ echo "SELECT dolt_tag('v1', (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 2))
 echo "SELECT dolt_tag('v3', (SELECT commit_hash FROM dolt_log LIMIT 1));" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test_match "diff_tags" \
-  "SELECT count(*) FROM dolt_diff('t', (SELECT hash FROM dolt_tags WHERE name='v1'), (SELECT hash FROM dolt_tags WHERE name='v3'));" \
+  "SELECT count(*) FROM dolt_diff('t', (SELECT tag_hash FROM dolt_tags WHERE tag_name='v1'), (SELECT tag_hash FROM dolt_tags WHERE tag_name='v3'));" \
   "^[2-9]" "$DB"
 
 # Verify log has 3 commits
@@ -423,7 +423,7 @@ INSERT INTO t VALUES(3); SELECT dolt_commit('-A','-m','c3');" | $DOLTLITE "$DB" 
 
 # Tag specific commit (the first one)
 echo "SELECT dolt_tag('old', (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 2));" | $DOLTLITE "$DB" > /dev/null 2>&1
-run_test "tag_specific" "SELECT count(*) FROM dolt_tags WHERE name='old';" "1" "$DB"
+run_test "tag_specific" "SELECT count(*) FROM dolt_tags WHERE tag_name='old';" "1" "$DB"
 
 # Multiple tags on same commit
 echo "SELECT dolt_tag('latest');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -433,11 +433,11 @@ run_test "tag_multi_same" "SELECT count(*) FROM dolt_tags;" "3" "$DB"
 # Delete a tag
 echo "SELECT dolt_tag('-d','also-latest');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "tag_deleted" "SELECT count(*) FROM dolt_tags;" "2" "$DB"
-run_test "tag_correct_remain" "SELECT count(*) FROM dolt_tags WHERE name='latest';" "1" "$DB"
+run_test "tag_correct_remain" "SELECT count(*) FROM dolt_tags WHERE tag_name='latest';" "1" "$DB"
 
 # Tag persists across reopen
-run_test "tag_persist" "SELECT count(*) FROM dolt_tags WHERE name='old';" "1" "$DB"
-run_test "tag_persist2" "SELECT name FROM dolt_tags WHERE name='latest';" "latest" "$DB"
+run_test "tag_persist" "SELECT count(*) FROM dolt_tags WHERE tag_name='old';" "1" "$DB"
+run_test "tag_persist2" "SELECT tag_name FROM dolt_tags WHERE tag_name='latest';" "latest" "$DB"
 
 rm -f "$DB"
 
@@ -905,11 +905,11 @@ run_test "tagstate_current" "SELECT count(*) FROM t;" "2" "$DB"
 
 # Tags have different hashes
 run_test_match "tagstate_diff_hashes" \
-  "SELECT count(DISTINCT hash) FROM dolt_tags;" "2" "$DB"
+  "SELECT count(DISTINCT tag_hash) FROM dolt_tags;" "2" "$DB"
 
 # Diff between tags should show changes
 run_test_match "tagstate_diff" \
-  "SELECT count(*) FROM dolt_diff('t', (SELECT hash FROM dolt_tags WHERE name='v1.0'), (SELECT hash FROM dolt_tags WHERE name='v2.0'));" \
+  "SELECT count(*) FROM dolt_diff('t', (SELECT tag_hash FROM dolt_tags WHERE tag_name='v1.0'), (SELECT tag_hash FROM dolt_tags WHERE tag_name='v2.0'));" \
   "^[1-9]" "$DB"
 
 rm -f "$DB"

--- a/test/doltlite_gc.sh
+++ b/test/doltlite_gc.sh
@@ -344,7 +344,7 @@ run_test "gc_taghist_data" "SELECT count(*) FROM t;" "3" "$DB"
 
 # Diff between tags should still work (old tree nodes preserved)
 run_test_match "gc_taghist_diff" \
-  "SELECT count(*) FROM dolt_diff('t', (SELECT hash FROM dolt_tags WHERE name='v1.0'), (SELECT hash FROM dolt_tags WHERE name='v2.0'));" \
+  "SELECT count(*) FROM dolt_diff('t', (SELECT tag_hash FROM dolt_tags WHERE tag_name='v1.0'), (SELECT tag_hash FROM dolt_tags WHERE tag_name='v2.0'));" \
   "^[1-9]" "$DB"
 
 db_rm "$DB"

--- a/test/doltlite_persistence.sh
+++ b/test/doltlite_persistence.sh
@@ -196,8 +196,8 @@ SELECT dolt_commit('-A','-m','c2');
 SELECT dolt_tag('v2.0');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "tag_count" "SELECT count(*) FROM dolt_tags;" "2" "$DB"
-run_test_match "tag_v1" "SELECT name FROM dolt_tags WHERE name='v1.0';" "v1.0" "$DB"
-run_test_match "tag_v2" "SELECT name FROM dolt_tags WHERE name='v2.0';" "v2.0" "$DB"
+run_test_match "tag_v1" "SELECT tag_name FROM dolt_tags WHERE tag_name='v1.0';" "v1.0" "$DB"
+run_test_match "tag_v2" "SELECT tag_name FROM dolt_tags WHERE tag_name='v2.0';" "v2.0" "$DB"
 
 rm -f "$DB"
 

--- a/test/doltlite_tag.sh
+++ b/test/doltlite_tag.sh
@@ -9,11 +9,11 @@ echo ""
 DB=/tmp/test_tag_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(x); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','first');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-run_test "tag_head" "SELECT dolt_tag('v1.0');" "0" "$DB"
+run_test "tag_head" "SELECT dolt_tag('v1.0','-m','release one');" "0" "$DB"
 run_test "list_tags" "SELECT count(*) FROM dolt_tags;" "1" "$DB"
-run_test "tag_name" "SELECT name FROM dolt_tags;" "v1.0" "$DB"
-run_test_match "tag_hash" "SELECT hash FROM dolt_tags;" "^[0-9a-f]{40}$" "$DB"
-run_test "tag_message" "SELECT commit_message FROM dolt_tags;" "first" "$DB"
+run_test "tag_name" "SELECT tag_name FROM dolt_tags;" "v1.0" "$DB"
+run_test_match "tag_hash" "SELECT tag_hash FROM dolt_tags;" "^[0-9a-f]{40}$" "$DB"
+run_test "tag_message" "SELECT message FROM dolt_tags;" "release one" "$DB"
 
 # Second commit, tag specific commit
 echo "INSERT INTO t VALUES(2); SELECT dolt_commit('-A','-m','second');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -37,7 +37,7 @@ run_test "one_tag_left" "SELECT count(*) FROM dolt_tags;" "1" "$DB"
 run_test_match "delete_missing" "SELECT dolt_tag('-d','nope');" "not found" "$DB"
 
 # Tag persists across reopen
-run_test "tag_persists" "SELECT name FROM dolt_tags;" "v1.0" "$DB"
+run_test "tag_persists" "SELECT tag_name FROM dolt_tags;" "v1.0" "$DB"
 
 rm -f "$DB"
 echo ""

--- a/test/vc_oracle_tags_test.sh
+++ b/test/vc_oracle_tags_test.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+#
+# Version-control oracle test: dolt_tags
+#
+# Runs identical tag-management scenarios against doltlite and Dolt and
+# compares the normalized dolt_tags output. Catches divergence in how each
+# engine reports tag listings, the per-tag tagger metadata and message,
+# and which commit a tag points at.
+#
+# Columns compared: tag_name, tag_hash (normalized), message. The
+# tagger/email/date columns are excluded because their values come from
+# process state and legitimately differ across the two engines unless
+# every scenario passes --author overrides; the message and pointed-at
+# commit are the load-bearing semantic axes.
+#
+# Usage: bash vc_oracle_tags_test.sh [path/to/doltlite] [path/to/dolt]
+#
+
+set -u
+
+DOLTLITE="${1:-./doltlite}"
+DOLT="${2:-dolt}"
+TMPROOT=$(mktemp -d)
+trap "rm -rf $TMPROOT" EXIT
+pass=0; fail=0
+FAILED_NAMES=""
+
+normalize() {
+  tr -d '\r' | awk -F'\t' '
+    {
+      h = $2
+      if (!(h in seen)) { n++; seen[h] = "H" n }
+      $2 = seen[h]
+      out = $1
+      for (i = 2; i <= NF; i++) out = out "\t" $i
+      print out
+    }
+  '
+}
+
+oracle() {
+  local name="$1" setup="$2"
+  local dir="$TMPROOT/$name"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local q='SELECT tag_name || char(9) || tag_hash || char(9) || message FROM dolt_tags ORDER BY tag_name'
+
+  local dl_out
+  dl_out=$(printf "%s\n.headers off\n.mode list\n.separator '\t'\n%s;\n" "$setup" "$q" \
+           | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
+           | grep -v '^[0-9]*$' \
+           | grep -v '^[0-9a-f]\{40\}$' \
+           | normalize)
+
+  local dolt_setup
+  dolt_setup=$(echo "$setup" | sed -E 's/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g')
+
+  (
+    cd "$dir/dt" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    echo "$dolt_setup" | "$DOLT" sql >/dev/null 2>"$dir/dt.err"
+    "$DOLT" sql -r csv -q "SELECT concat(tag_name, char(9), tag_hash, char(9), message) FROM dolt_tags ORDER BY tag_name;" 2>>"$dir/dt.err"
+  ) > "$dir/dt.raw"
+
+  local dt_out
+  dt_out=$(tail -n +2 "$dir/dt.raw" | tr -d '"' | normalize)
+
+  if [ "$dl_out" = "$dt_out" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite:"; echo "$dl_out" | sed 's/^/      /'
+    echo "    dolt:"    ; echo "$dt_out" | sed 's/^/      /'
+  fi
+}
+
+echo "=== Version Control Oracle Tests: dolt_tags ==="
+echo ""
+
+echo "--- baseline ---"
+
+oracle "no_tags_on_fresh_repo" "
+SELECT 1;
+"
+
+echo "--- single tag ---"
+
+oracle "tag_head_no_message" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'first');
+SELECT dolt_tag('v1.0');
+"
+
+oracle "tag_head_with_message" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'first');
+SELECT dolt_tag('v1.0', '-m', 'first release');
+"
+
+oracle "tag_message_with_special_chars" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'first');
+SELECT dolt_tag('v1.0', '-m', 'fix: x<y & z>w, ok?');
+"
+
+echo "--- multiple tags ---"
+
+oracle "two_tags_on_same_commit" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'first');
+SELECT dolt_tag('v1.0');
+SELECT dolt_tag('latest');
+"
+
+oracle "tags_on_different_commits" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_tag('v1.0');
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2');
+SELECT dolt_tag('v2.0');
+"
+
+echo "--- tagging older commits ---"
+
+oracle "tag_older_commit_by_hash" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+INSERT INTO t VALUES (2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2');
+SELECT dolt_tag('historical', (SELECT commit_hash FROM dolt_log WHERE message='c1'));
+"
+
+echo "--- deletion ---"
+
+oracle "delete_tag" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'first');
+SELECT dolt_tag('temp');
+SELECT dolt_tag('-d', 'temp');
+"
+
+oracle "delete_one_keep_others" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'first');
+SELECT dolt_tag('keep');
+SELECT dolt_tag('drop');
+SELECT dolt_tag('-d', 'drop');
+"
+
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+if [ $fail -gt 0 ]; then
+  echo "Failed:$FAILED_NAMES"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- New `test/vc_oracle_tags_test.sh`: nine scenarios comparing doltlite's `dolt_tags` to Dolt's. Wired into CI as a hard gate alongside the other vc oracles.
- `dolt_tags` schema is realigned to Dolt's six columns (`tag_name, tag_hash, tagger, email, date, message`) from the previous three (`name, hash, commit_message`).
- Tags are now first-class objects with their own tagger/email/date/message rather than pure refs that borrowed the commit's metadata.
- `dolt_tag` learns to parse `-m` / `--message`, `--author`, and unknown dash-prefixed flags (rejected with the same "unknown option" shape Dolt uses).
- The refs-blob storage format is bumped to v6 to carry the new per-tag metadata. The deserializer accepts both v5 and v6, defaulting missing metadata to empty.
- Stacked on top of #342 (branches oracle).

## The structural problem with the old `dolt_tags`

Doltlite's `dolt_tags` had a column literally named `commit_message` that returned the *commit's* message, not the *tag's* message. That was the only annotation surface tags had — there was no place to store a tag's own message because tags weren't objects, they were just (name, commit_hash) pairs in a `TagRef` array.

Dolt's tags carry their own annotation. `dolt_tag('v1.0')` creates an unmessaged tag (`message = ''`); `dolt_tag('v1.0', '-m', 'release')` attaches "release" as the tag's message, distinct from whatever message the tagged commit has. That's the behavior we're matching.

## Storage changes

`struct TagRef` gains `zTagger`, `zEmail`, `timestamp`, and `zMessage`. `csFreeTags` releases them. `chunkStoreAddTag` becomes a thin wrapper around the new `chunkStoreAddTagFull` so existing call sites that don't carry metadata still work.

The refs blob format ([documented inline at `chunk_store.c`'s `csSerializeRefsBlob`](src/chunk_store.c)) is bumped from v5 to v6. The serializer always emits v6. The deserializer accepts both, defaulting v5 tags to empty metadata strings and zero timestamps. That makes existing on-disk repos roll forward cleanly: open with the new doltlite, the v5 blob is parsed normally, the next refs write produces a v6 blob.

This is a one-way migration — older doltlite reading the new v6 format will error with `SQLITE_CORRUPT`. Acceptable for "this project is just a baby."

## `doltTagFunc` argument parsing

The old function accepted exactly `dolt_tag(name)` or `dolt_tag(name, hash)`. Any flag-shaped second argument like `-m` was treated as a commit hash and errored with "invalid commit hash format". So tags could not carry messages at all.

The new parser walks the remaining arguments after the tag name:

- `-m` / `--message`: consumes the next arg as the tag message.
- `--author`: consumes the next arg as `'name <email>'` and parses it the same way `dolt_commit` does.
- Any other dash-prefixed arg: rejected with `unknown option \`X\``, matching Dolt's error shape.
- The first non-flag positional becomes the commit ref to tag, resolved via `doltliteResolveRef` (so tags can target hashes, branches, or other tags). If absent, the session HEAD is used.

A second non-flag positional is rejected with "too many positional arguments to dolt_tag".

## Schema realignment and column emission

The vtable now declares the six Dolt columns. `tagColumn` emits each field directly from the `TagRef` plus a `strftime`'d date matching `dolt_log`'s `%Y-%m-%d %H:%M:%S` format (the same format the branches PR uses for `latest_commit_date`).

The `commit_message` column is gone. The semantic shift is intentional: "the tag's message" is now a different thing from "the message of the commit the tag points at," and only the former is reachable from `dolt_tags`. Anyone who needs the commit's message can join through `dolt_log` on `tag_hash = commit_hash`.

## Test churn

About 25 call sites across seven test files queried the old column names. All are mechanically renamed: `name → tag_name`, `hash → tag_hash`. The `tag_message` test in `doltlite_tag.sh` was the only semantic update — it asserted `commit_message = "first"`, which only worked because the old column secretly returned the commit's message. The new test passes `-m 'release one'` to the tag and asserts `message = "release one"`, exercising the new tag-message semantics.

## Why tagger/email/date are excluded from the oracle comparison

Same reason as the branches oracle: those fields get their values from process state, not the user's SQL. Dolt's `dolt sql` uses the OS user; doltlite uses its session config default; making them line up would mean a `--author` flag on every tag in every scenario, which is noise. The comparable axes are `tag_name`, `tag_hash` (normalized to `H1, H2, ...`), and `message` — the things fully determined by what the user typed.

## Test plan

- [ ] `vc_oracle_tags_test.sh`: 9/9 pass locally
- [ ] `vc_oracle_branches_test.sh`: 9/9 still pass (sanity)
- [ ] `vc_oracle_status_test.sh`: 11/11 still pass
- [ ] `vc_oracle_log_test.sh`: 7/7 still pass
- [ ] `vc_oracle_add_test.sh`: 16/16 still pass
- [ ] `index_oracle_test.sh`: 526/526 still pass
- [ ] `run_doltlite_tests.sh`: 39/39 suites pass — the format bump and column rename is the load-bearing regression check
- [ ] `remote_test.sh`: 63/63
- [ ] `large_scale_test.sh --quick`, `multi_table_test.sh --quick`, `diff_test.sh`, `config_test.sh`: all pass
- [ ] `concurrent_write_test`: 52/52

🤖 Generated with [Claude Code](https://claude.com/claude-code)