### PR TITLE
Add dolt_remotes oracle; expand schema to match Dolt's four columns

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,6 +83,10 @@ jobs:
       run: cd build && bash ../test/vc_oracle_tags_test.sh ./doltlite dolt
       timeout-minutes: 5
 
+    - name: Version control oracle tests (dolt_remotes)
+      run: cd build && bash ../test/vc_oracle_remotes_test.sh ./doltlite dolt
+      timeout-minutes: 5
+
     - name: Large-scale test (10K rows)
       run: cd build && bash ../test/large_scale_test.sh ./doltlite --quick
       timeout-minutes: 5

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -795,7 +795,13 @@ static int remConnect(sqlite3 *db, void *pAux, int argc,
     const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){
   RemVtab *p; int rc;
   (void)pAux; (void)argc; (void)argv; (void)pzErr;
-  rc = sqlite3_declare_vtab(db, "CREATE TABLE x(name TEXT, url TEXT)");
+  rc = sqlite3_declare_vtab(db,
+    "CREATE TABLE x("
+      "name TEXT, "
+      "url TEXT, "
+      "fetch_specs TEXT, "
+      "params TEXT"
+    ")");
   if( rc!=SQLITE_OK ) return rc;
   p = sqlite3_malloc(sizeof(*p));
   if( !p ) return SQLITE_NOMEM;
@@ -826,8 +832,31 @@ static int remColumn(sqlite3_vtab_cursor *c, sqlite3_context *ctx, int col){
   if(!cs) return SQLITE_OK;
   rem = &cs->aRemotes[((RemCur*)c)->iRow];
   switch(col){
-    case 0: sqlite3_result_text(ctx, rem->zName, -1, SQLITE_TRANSIENT); break;
-    case 1: sqlite3_result_text(ctx, rem->zUrl, -1, SQLITE_TRANSIENT); break;
+    case 0:
+      sqlite3_result_text(ctx, rem->zName, -1, SQLITE_TRANSIENT);
+      break;
+    case 1:
+      sqlite3_result_text(ctx, rem->zUrl, -1, SQLITE_TRANSIENT);
+      break;
+    case 2: {
+      /* Default fetch refspec derived from the remote name, matching the
+      ** shape Dolt emits for a vanilla dolt_remote add call. doltlite has
+      ** no concept of customizable refspecs, so this is always derived. */
+      char *zSpec = sqlite3_mprintf(
+          "[\"refs/heads/*:refs/remotes/%s/*\"]", rem->zName);
+      if( zSpec ){
+        sqlite3_result_text(ctx, zSpec, -1, SQLITE_TRANSIENT);
+        sqlite3_free(zSpec);
+      }else{
+        sqlite3_result_null(ctx);
+      }
+      break;
+    }
+    case 3:
+      /* Dolt uses params for auth/config overrides; doltlite has none,
+      ** so this is always an empty JSON object. */
+      sqlite3_result_text(ctx, "{}", -1, SQLITE_STATIC);
+      break;
   }
   return SQLITE_OK;
 }

--- a/test/vc_oracle_remotes_test.sh
+++ b/test/vc_oracle_remotes_test.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+#
+# Version-control oracle test: dolt_remotes
+#
+# Runs identical remote-management scenarios against doltlite and Dolt and
+# compares the normalized dolt_remotes output. Every column's value is
+# fully determined by the user's input — name and url come directly from
+# the dolt_remote('add', ...) call, fetch_specs is derived from the name
+# using the standard refspec template, and params is always {} — so all
+# four columns are included in the comparison.
+#
+# Error scenarios are checked with oracle_error: both engines must fail
+# but the specific error text is allowed to differ.
+#
+# Usage: bash vc_oracle_remotes_test.sh [path/to/doltlite] [path/to/dolt]
+#
+
+set -u
+
+DOLTLITE="${1:-./doltlite}"
+DOLT="${2:-dolt}"
+TMPROOT=$(mktemp -d)
+trap "rm -rf $TMPROOT" EXIT
+pass=0; fail=0
+FAILED_NAMES=""
+
+normalize() { tr -d '\r'; }
+
+oracle() {
+  local name="$1" setup="$2"
+  local dir="$TMPROOT/$name"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local q='SELECT name || char(9) || url || char(9) || fetch_specs || char(9) || params FROM dolt_remotes ORDER BY name'
+
+  local dl_out
+  dl_out=$(printf "%s\n.headers off\n.mode list\n.separator '\t'\n%s;\n" "$setup" "$q" \
+           | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
+           | grep -v '^[0-9]*$' \
+           | grep -v '^[0-9a-f]\{40\}$' \
+           | normalize)
+
+  local dolt_setup
+  dolt_setup=$(echo "$setup" | sed -E 's/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g')
+
+  (
+    cd "$dir/dt" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    echo "$dolt_setup" | "$DOLT" sql >/dev/null 2>"$dir/dt.err"
+    "$DOLT" sql -r csv -q "SELECT concat(name, char(9), url, char(9), fetch_specs, char(9), params) FROM dolt_remotes ORDER BY name;" 2>>"$dir/dt.err"
+  ) > "$dir/dt.raw"
+
+  # Dolt wraps the whole concatenated value in quotes because it contains
+  # commas in the JSON. Strip the outer quotes and un-escape internal
+  # double quotes ("" → ") before comparing.
+  local dt_out
+  dt_out=$(tail -n +2 "$dir/dt.raw" \
+           | sed -E 's/^"(.*)"$/\1/' \
+           | sed 's/""/"/g' \
+           | normalize)
+
+  if [ "$dl_out" = "$dt_out" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite:"; echo "$dl_out" | sed 's/^/      /'
+    echo "    dolt:"    ; echo "$dt_out" | sed 's/^/      /'
+  fi
+}
+
+oracle_error() {
+  local name="$1" setup="$2"
+  local dir="$TMPROOT/${name}_err"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_err=0
+  echo "$setup" | "$DOLTLITE" "$dir/dl/db" >"$dir/dl.out" 2>"$dir/dl.err"
+  if grep -qiE 'error|fail' "$dir/dl.out" "$dir/dl.err" 2>/dev/null; then dl_err=1; fi
+
+  local dolt_setup
+  dolt_setup=$(echo "$setup" | sed -E 's/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g')
+  local dt_err=0
+  (
+    cd "$dir/dt" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    echo "$dolt_setup" | "$DOLT" sql >"$dir/dt.out" 2>"$dir/dt.err"
+  )
+  if grep -qiE 'error|fail' "$dir/dt.out" "$dir/dt.err" 2>/dev/null; then dt_err=1; fi
+
+  if [ "$dl_err" = 1 ] && [ "$dt_err" = 1 ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name (expected both to error)"
+    echo "    doltlite errored: $([ $dl_err = 1 ] && echo yes || echo NO)"
+    echo "    dolt errored:     $([ $dt_err = 1 ] && echo yes || echo NO)"
+  fi
+}
+
+echo "=== Version Control Oracle Tests: dolt_remotes ==="
+echo ""
+
+echo "--- baseline ---"
+
+oracle "no_remotes_on_fresh_repo" "
+SELECT 1;
+"
+
+echo "--- add ---"
+
+oracle "add_single_remote" "
+SELECT dolt_remote('add', 'origin', 'file:///tmp/oracle_origin');
+"
+
+oracle "add_two_remotes" "
+SELECT dolt_remote('add', 'origin', 'file:///tmp/oracle_origin');
+SELECT dolt_remote('add', 'upstream', 'file:///tmp/oracle_upstream');
+"
+
+oracle "add_remote_with_non_standard_name" "
+SELECT dolt_remote('add', 'backup-1', 'file:///tmp/oracle_backup');
+"
+
+# Dolt rewrites http:// URLs to git+http:// on add as a scheme qualifier
+# signaling "git over HTTP". doltlite uses http:// for its own HTTP remote
+# protocol, which is not git-over-HTTP, so matching that rewrite would
+# break doltlite's actual HTTP remote behavior. file:// URLs have the
+# same meaning on both engines, so that's what the add/remove scenarios
+# exercise.
+
+echo "--- remove ---"
+
+oracle "remove_only_remote" "
+SELECT dolt_remote('add', 'origin', 'file:///tmp/oracle_origin');
+SELECT dolt_remote('remove', 'origin');
+"
+
+oracle "remove_one_keep_others" "
+SELECT dolt_remote('add', 'origin', 'file:///tmp/oracle_origin');
+SELECT dolt_remote('add', 'upstream', 'file:///tmp/oracle_upstream');
+SELECT dolt_remote('remove', 'origin');
+"
+
+oracle "add_remove_add_same_name" "
+SELECT dolt_remote('add', 'origin', 'file:///tmp/oracle_origin');
+SELECT dolt_remote('remove', 'origin');
+SELECT dolt_remote('add', 'origin', 'file:///tmp/oracle_new');
+"
+
+echo "--- error paths ---"
+
+oracle_error "add_duplicate_remote" "
+SELECT dolt_remote('add', 'origin', 'file:///tmp/oracle_origin');
+SELECT dolt_remote('add', 'origin', 'file:///tmp/oracle_other');
+"
+
+oracle_error "remove_nonexistent_remote" "
+SELECT dolt_remote('remove', 'nonexistent');
+"
+
+oracle_error "unknown_action" "
+SELECT dolt_remote('whatever', 'origin', 'file:///tmp/oracle_origin');
+"
+
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+if [ $fail -gt 0 ]; then
+  echo "Failed:$FAILED_NAMES"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- New `test/vc_oracle_remotes_test.sh`: ten scenarios comparing doltlite's `dolt_remotes` to Dolt's. Wired into CI as a hard gate alongside the other vc oracles.
- Doltlite's `dolt_remotes` now has the same four columns as Dolt's instead of the old two. The two new columns (`fetch_specs`, `params`) have fully-derived values — no storage changes, just vtable schema and emission.
- One legitimate divergence on URL scheme handling is deliberately left out of the oracle and documented inline.

## The schema change

The vtable now declares four columns:

```
name TEXT,
url TEXT,
fetch_specs TEXT,
params TEXT
```

`fetch_specs` emits `["refs/heads/*:refs/remotes/<name>/*"]`, the standard refspec template with the remote's name substituted in. Dolt emits the same string by default for any `dolt_remote add` call that doesn't specify custom refspecs, and doltlite has no concept of user-customizable refspecs at all, so the value is always this derived default.

`params` always emits `{}`. Dolt uses it for auth and configuration overrides that don't exist in doltlite.

No storage format changes — the `RemoteRef` struct stays at `(zName, zUrl)`, and the new columns are computed on the fly in `remColumn`. Compare this with the `dolt_tags` PR, which had to bump the refs blob format to v6 because tags needed to *store* new metadata. Here the information is either in the name or a constant.

## Why the oracle skips `http://` URL scenarios

Dolt rewrites `http://example.com/repo.git` to `git+http://example.com/repo.git` on add — the `git+` prefix is a scheme qualifier signaling "git protocol over HTTP". Doltlite uses `http://` for its own HTTP remote protocol, which is *not* git-over-HTTP (there's a custom wire format in `doltlite_http_remote.c`). Matching Dolt's rewrite would mean storing URLs that would subsequently break doltlite's actual HTTP remote behavior.

This is a real semantic divergence where the same string means different things on the two engines, and it's not worth papering over to make the oracle green. The oracle exercises add/remove via `file://` URLs only, which have the same meaning on both engines, and a comment in the test file documents the reason the HTTP scenario is missing.

## Test plan

- [ ] `vc_oracle_remotes_test.sh`: 10/10 pass locally
- [ ] `vc_oracle_tags_test.sh`: 9/9 still pass
- [ ] `vc_oracle_branches_test.sh`: 9/9 still pass
- [ ] `vc_oracle_status_test.sh`: 11/11 still pass
- [ ] `vc_oracle_log_test.sh`: 7/7 still pass
- [ ] `vc_oracle_add_test.sh`: 16/16 still pass
- [ ] `index_oracle_test.sh`: 526/526 still pass
- [ ] `run_doltlite_tests.sh`: 39/39 suites pass — the vtable schema change is the load-bearing regression check
- [ ] `remote_test.sh`: 63/63 (the existing remote integration tests, unaffected because they query `name` and `url` which didn't move)
- [ ] `large_scale_test.sh --quick`, `multi_table_test.sh --quick`, `diff_test.sh`, `config_test.sh`: all pass
- [ ] `concurrent_write_test`: 52/52

🤖 Generated with [Claude Code](https://claude.com/claude-code)