### PR TITLE
Harden diff, status, and history walkers

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -42,7 +42,7 @@ extern void doltliteSetTableSchemaHash(sqlite3 *db, Pgno iTable, const ProllyHas
 ** Returns 1 if there are uncommitted changes (working differs from HEAD
 ** or staged differs from HEAD), 0 otherwise.
 */
-static int doltliteFlushCatalogToHash(sqlite3 *db, ProllyHash *pHash);
+int doltliteFlushCatalogToHash(sqlite3 *db, ProllyHash *pHash);
 
 typedef struct DoltliteTxnState DoltliteTxnState;
 struct DoltliteTxnState {
@@ -241,7 +241,7 @@ int doltliteMutateRefs(sqlite3 *db, DoltliteRefsMutation xMutate, void *pArg){
 ** Helper #2: Flush the in-memory catalog, serialize it into the chunk store,
 ** and return the resulting hash.
 */
-static int doltliteFlushCatalogToHash(sqlite3 *db, ProllyHash *pHash){
+int doltliteFlushCatalogToHash(sqlite3 *db, ProllyHash *pHash){
   ChunkStore *cs = doltliteGetChunkStore(db);
   u8 *catData = 0;
   int nCatData = 0;

--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -126,7 +126,7 @@ static int openNextCommitPairIter(DiffTblCursor *pCur, sqlite3 *db,
                                   const char *zTableName){
   ChunkStore *cs = doltliteGetChunkStore(db);
   ProllyCache *pCache = doltliteGetCache(db);
-  DoltliteCommit commit;
+  DoltliteCommit commit, parentCommit;
   ProllyHash curRoot, parentRoot;
   ProllyHash emptyRoot;
   u8 flags = 0;
@@ -134,76 +134,71 @@ static int openNextCommitPairIter(DiffTblCursor *pCur, sqlite3 *db,
 
   if( !cs ) return SQLITE_OK;
 
-  memset(&commit, 0, sizeof(commit));
-  rc = doltliteLoadCommit(db, &pCur->curCommitHash, &commit);
-  if( rc!=SQLITE_OK ) return rc;
+  for(;;){
+    memset(&commit, 0, sizeof(commit));
+    memset(&parentCommit, 0, sizeof(parentCommit));
+    memset(&curRoot, 0, sizeof(curRoot));
+    memset(&parentRoot, 0, sizeof(parentRoot));
+    flags = 0;
 
-  /* Get the table root for the current commit */
-  {
-    struct TableEntry *aTables = 0; int nTables = 0;
-    rc = doltliteLoadCatalog(db, &commit.catalogHash, &aTables, &nTables, 0);
-    if( rc==SQLITE_OK ){
+    rc = doltliteLoadCommit(db, &pCur->curCommitHash, &commit);
+    if( rc!=SQLITE_OK ) return rc;
+
+    {
+      struct TableEntry *aTables = 0; int nTables = 0;
+      rc = doltliteLoadCatalog(db, &commit.catalogHash, &aTables, &nTables, 0);
+      if( rc!=SQLITE_OK ){
+        doltliteCommitClear(&commit);
+        return rc;
+      }
       doltliteFindTableRootByName(aTables, nTables, zTableName, &curRoot, &flags);
       sqlite3_free(aTables);
-    }else{
-      memset(&curRoot, 0, sizeof(curRoot));
     }
-  }
 
-  /* Fill in the "to" commit info on the row */
-  doltliteHashToHex(&pCur->curCommitHash, pCur->row.zToCommit);
-  pCur->row.toDate = commit.timestamp;
+    doltliteHashToHex(&pCur->curCommitHash, pCur->row.zToCommit);
+    pCur->row.toDate = commit.timestamp;
 
-  if( !prollyHashIsEmpty(&commit.parentHash) ){
-    /* Non-initial commit: diff parent -> current */
-    DoltliteCommit parentCommit;
-    memset(&parentCommit, 0, sizeof(parentCommit));
-    rc = doltliteLoadCommit(db, &commit.parentHash, &parentCommit);
-    if( rc!=SQLITE_OK ){
+    if( !prollyHashIsEmpty(&commit.parentHash) ){
+      ProllyHash nextHash;
+      memset(&nextHash, 0, sizeof(nextHash));
+      rc = doltliteLoadCommit(db, &commit.parentHash, &parentCommit);
+      if( rc!=SQLITE_OK ){
+        doltliteCommitClear(&commit);
+        return rc;
+      }
+
+      doltliteHashToHex(&commit.parentHash, pCur->row.zFromCommit);
+      pCur->row.fromDate = parentCommit.timestamp;
+
+      {
+        struct TableEntry *aPT = 0; int nPT = 0;
+        rc = doltliteLoadCatalog(db, &parentCommit.catalogHash, &aPT, &nPT, 0);
+        if( rc!=SQLITE_OK ){
+          doltliteCommitClear(&parentCommit);
+          doltliteCommitClear(&commit);
+          return rc;
+        }
+        doltliteFindTableRootByName(aPT, nPT, zTableName, &parentRoot, 0);
+        sqlite3_free(aPT);
+      }
+
+      memcpy(&nextHash, &commit.parentHash, sizeof(ProllyHash));
+      doltliteCommitClear(&parentCommit);
+
+      if( prollyHashCompare(&parentRoot, &curRoot)==0 ){
+        doltliteCommitClear(&commit);
+        memcpy(&pCur->curCommitHash, &nextHash, sizeof(ProllyHash));
+        continue;
+      }
+
+      rc = prollyDiffIterOpen(&pCur->diffIter, cs, pCache,
+                              &parentRoot, &curRoot, flags);
+      if( rc==SQLITE_OK ) pCur->diffIterOpen = 1;
       doltliteCommitClear(&commit);
+      memcpy(&pCur->curCommitHash, &nextHash, sizeof(ProllyHash));
       return rc;
     }
 
-    doltliteHashToHex(&commit.parentHash, pCur->row.zFromCommit);
-    pCur->row.fromDate = parentCommit.timestamp;
-
-    /* Get the table root for the parent commit */
-    {
-      struct TableEntry *aPT = 0; int nPT = 0;
-      rc = doltliteLoadCatalog(db, &parentCommit.catalogHash, &aPT, &nPT, 0);
-      if( rc==SQLITE_OK ){
-        doltliteFindTableRootByName(aPT, nPT, zTableName, &parentRoot, 0);
-        sqlite3_free(aPT);
-      }else{
-        memset(&parentRoot, 0, sizeof(parentRoot));
-      }
-    }
-
-    doltliteCommitClear(&parentCommit);
-
-    /* If roots are the same, no diff for this pair — skip. */
-    if( prollyHashCompare(&parentRoot, &curRoot)==0 ){
-      /* Advance to parent and try next pair */
-      ProllyHash nextHash;
-      memcpy(&nextHash, &commit.parentHash, sizeof(ProllyHash));
-      doltliteCommitClear(&commit);
-      memcpy(&pCur->curCommitHash, &nextHash, sizeof(ProllyHash));
-      return openNextCommitPairIter(pCur, db, zTableName);
-    }
-
-    rc = prollyDiffIterOpen(&pCur->diffIter, cs, pCache,
-                            &parentRoot, &curRoot, flags);
-    if( rc==SQLITE_OK ) pCur->diffIterOpen = 1;
-
-    /* Advance commit walk to the parent for the next pair */
-    {
-      ProllyHash nextHash;
-      memcpy(&nextHash, &commit.parentHash, sizeof(ProllyHash));
-      doltliteCommitClear(&commit);
-      memcpy(&pCur->curCommitHash, &nextHash, sizeof(ProllyHash));
-    }
-  }else{
-    /* Initial commit: diff empty -> current */
     if( !prollyHashIsEmpty(&curRoot) ){
       memset(&emptyRoot, 0, sizeof(emptyRoot));
       memset(pCur->row.zFromCommit, '0', PROLLY_HASH_SIZE*2);
@@ -213,14 +208,17 @@ static int openNextCommitPairIter(DiffTblCursor *pCur, sqlite3 *db,
       rc = prollyDiffIterOpen(&pCur->diffIter, cs, pCache,
                               &emptyRoot, &curRoot, flags);
       if( rc==SQLITE_OK ) pCur->diffIterOpen = 1;
+      doltliteCommitClear(&commit);
+      memset(&pCur->curCommitHash, 0, sizeof(ProllyHash));
+      pCur->commitWalkDone = 1;
+      return rc;
     }
-    /* No more commits after the initial one */
+
     doltliteCommitClear(&commit);
     memset(&pCur->curCommitHash, 0, sizeof(ProllyHash));
     pCur->commitWalkDone = 1;
+    return SQLITE_OK;
   }
-
-  return rc;
 }
 
 /*
@@ -239,35 +237,39 @@ static int advanceToNextRow(DiffTblCursor *pCur, sqlite3 *db,
       ProllyDiffChange *pChange = 0;
       rc = prollyDiffIterStep(&pCur->diffIter, &pChange);
       if( rc==SQLITE_ROW && pChange ){
+        u8 *pOldVal = 0;
+        u8 *pNewVal = 0;
         /* Free previous value copies (preserves commit-pair metadata) */
         sqlite3_free(pCur->row.pOldVal);
         sqlite3_free(pCur->row.pNewVal);
+        pCur->row.pOldVal = 0;
+        pCur->row.nOldVal = 0;
+        pCur->row.pNewVal = 0;
+        pCur->row.nNewVal = 0;
 
         pCur->row.diffType = pChange->type;
         pCur->row.intKey = pChange->intKey;
 
         /* Copy value data — the iterator's copies are valid until next Step */
         if( pChange->pOldVal && pChange->nOldVal > 0 ){
-          pCur->row.pOldVal = sqlite3_malloc(pChange->nOldVal);
-          if( pCur->row.pOldVal ){
-            memcpy(pCur->row.pOldVal, pChange->pOldVal, pChange->nOldVal);
-          }
-          pCur->row.nOldVal = pChange->nOldVal;
-        }else{
-          pCur->row.pOldVal = 0;
-          pCur->row.nOldVal = 0;
+          pOldVal = sqlite3_malloc(pChange->nOldVal);
+          if( !pOldVal ) return SQLITE_NOMEM;
+          memcpy(pOldVal, pChange->pOldVal, pChange->nOldVal);
         }
 
         if( pChange->pNewVal && pChange->nNewVal > 0 ){
-          pCur->row.pNewVal = sqlite3_malloc(pChange->nNewVal);
-          if( pCur->row.pNewVal ){
-            memcpy(pCur->row.pNewVal, pChange->pNewVal, pChange->nNewVal);
+          pNewVal = sqlite3_malloc(pChange->nNewVal);
+          if( !pNewVal ){
+            sqlite3_free(pOldVal);
+            return SQLITE_NOMEM;
           }
-          pCur->row.nNewVal = pChange->nNewVal;
-        }else{
-          pCur->row.pNewVal = 0;
-          pCur->row.nNewVal = 0;
+          memcpy(pNewVal, pChange->pNewVal, pChange->nNewVal);
         }
+
+        pCur->row.pOldVal = pOldVal;
+        pCur->row.nOldVal = pChange->pOldVal ? pChange->nOldVal : 0;
+        pCur->row.pNewVal = pNewVal;
+        pCur->row.nNewVal = pChange->pNewVal ? pChange->nNewVal : 0;
 
         pCur->hasRow = 1;
         pCur->iRowid++;

--- a/src/doltlite_history.c
+++ b/src/doltlite_history.c
@@ -5,6 +5,7 @@
 #include "prolly_hash.h"
 #include "prolly_cursor.h"
 #include "prolly_cache.h"
+#include "prolly_hashset.h"
 #include "chunk_store.h"
 #include "doltlite_commit.h"
 
@@ -110,43 +111,50 @@ static int htScanAtCommit(
 static int htWalkHistory(HistCursor *pCur, sqlite3 *db, const char *zTableName){
   ChunkStore *cs=doltliteGetChunkStore(db);
   ProllyCache *pCache;
-  ProllyHash *queue=0, *visited=0;
+  ProllyHash *queue=0;
+  ProllyHashSet visited, queued;
   int qHead=0, qTail=0, qAlloc=0;
-  int nVisited=0, nVisitedAlloc=0;
   int rc=SQLITE_OK;
   ProllyHash head;
 
   if(!cs) return SQLITE_OK;
   pCache=doltliteGetCache(db);
   if(!pCache) return SQLITE_OK;
+  memset(&visited, 0, sizeof(visited));
+  memset(&queued, 0, sizeof(queued));
 
   doltliteGetSessionHead(db, &head);
   if(prollyHashIsEmpty(&head)) return SQLITE_OK;
 
+  rc = prollyHashSetInit(&visited, 64);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = prollyHashSetInit(&queued, 64);
+  if( rc!=SQLITE_OK ){
+    prollyHashSetFree(&visited);
+    return rc;
+  }
+
   qAlloc=16;
   queue=sqlite3_malloc(qAlloc*(int)sizeof(ProllyHash));
-  if(!queue) return SQLITE_NOMEM;
+  if(!queue){
+    prollyHashSetFree(&visited);
+    prollyHashSetFree(&queued);
+    return SQLITE_NOMEM;
+  }
   queue[qTail++]=head;
+  rc = prollyHashSetAdd(&queued, &head);
+  if( rc!=SQLITE_OK ) goto history_done;
 
   while(qHead<qTail){
     ProllyHash cur=queue[qHead++];
     DoltliteCommit commit;
     ProllyHash tableRoot; u8 flags=0;
     char hexBuf[PROLLY_HASH_SIZE*2+1];
-    int dup=0, i;
+    int i;
 
-    for(i=0;i<nVisited;i++){
-      if(prollyHashCompare(&visited[i],&cur)==0){dup=1;break;}
-    }
-    if(dup) continue;
-
-    if(nVisited>=nVisitedAlloc){
-      int na=nVisitedAlloc?nVisitedAlloc*2:16;
-      ProllyHash *tmp=sqlite3_realloc(visited,na*(int)sizeof(ProllyHash));
-      if(!tmp){rc=SQLITE_NOMEM;break;}
-      visited=tmp; nVisitedAlloc=na;
-    }
-    visited[nVisited++]=cur;
+    if( prollyHashSetContains(&visited, &cur) ) continue;
+    rc = prollyHashSetAdd(&visited, &cur);
+    if( rc!=SQLITE_OK ) break;
 
     memset(&commit,0,sizeof(commit));
     rc=doltliteLoadCommit(db,&cur,&commit);
@@ -166,6 +174,8 @@ static int htWalkHistory(HistCursor *pCur, sqlite3 *db, const char *zTableName){
 
     for(i=0;i<commit.nParents;i++){
       if(prollyHashIsEmpty(&commit.aParents[i])) continue;
+      if( prollyHashSetContains(&visited, &commit.aParents[i]) ) continue;
+      if( prollyHashSetContains(&queued, &commit.aParents[i]) ) continue;
       if(qTail>=qAlloc){
         int na=qAlloc*2;
         ProllyHash *tmp=sqlite3_realloc(queue,na*(int)sizeof(ProllyHash));
@@ -173,13 +183,17 @@ static int htWalkHistory(HistCursor *pCur, sqlite3 *db, const char *zTableName){
         queue=tmp; qAlloc=na;
       }
       queue[qTail++]=commit.aParents[i];
+      rc = prollyHashSetAdd(&queued, &commit.aParents[i]);
+      if( rc!=SQLITE_OK ) break;
     }
     doltliteCommitClear(&commit);
     if(rc!=SQLITE_OK) break;
   }
 
+history_done:
   sqlite3_free(queue);
-  sqlite3_free(visited);
+  prollyHashSetFree(&visited);
+  prollyHashSetFree(&queued);
   return rc;
 }
 

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -94,6 +94,7 @@ int doltliteSerializeCatalogEntries(sqlite3 *db, struct TableEntry *aTables,
                                     int nTables, u8 **ppOut, int *pnOut);
 int doltliteGetHeadCatalogHash(sqlite3 *db, ProllyHash *pCatHash);
 int doltliteFlushAndSerializeCatalog(sqlite3 *db, u8 **ppOut, int *pnOut);
+int doltliteFlushCatalogToHash(sqlite3 *db, ProllyHash *pHash);
 int doltliteHasUncommittedChanges(sqlite3 *db);
 /* Ref resolution: try hex hash, then branch, then tag (doltlite_ref.c) */
 int doltliteResolveRef(sqlite3 *db, const char *zRef, ProllyHash *pCommit);

--- a/src/doltlite_status.c
+++ b/src/doltlite_status.c
@@ -26,11 +26,20 @@ struct DoltliteStatusCursor {
 static const char *statusSchema =
   "CREATE TABLE x(table_name TEXT, staged INTEGER, status TEXT)";
 
-static char *statusTableName(sqlite3 *db, const struct TableEntry *pEntry){
+static int statusTableName(sqlite3 *db, const struct TableEntry *pEntry, char **pzName){
+  *pzName = 0;
   if( pEntry->zName ){
-    return sqlite3_mprintf("%s", pEntry->zName);
+    *pzName = sqlite3_mprintf("%s", pEntry->zName);
+    return *pzName ? SQLITE_OK : SQLITE_NOMEM;
   }
-  return doltliteResolveTableNumber(db, pEntry->iTable);
+  /* Internal index roots can legitimately lack a table name in sqlite's
+  ** schema hash; dolt_status should ignore them rather than surfacing an
+  ** error for an otherwise clean working tree. */
+  if( pEntry->flags & BTREE_BLOBKEY ){
+    return SQLITE_NOTFOUND;
+  }
+  *pzName = doltliteResolveTableNumber(db, pEntry->iTable);
+  return *pzName ? SQLITE_OK : SQLITE_NOMEM;
 }
 
 /*
@@ -118,8 +127,9 @@ static int compareCatalogs(
     if(aTo[i].iTable<=1) continue;
     if( useRename && toHandled[i] ) continue;
     pFrom = findCatalogEntry(aFrom, nFrom, &aTo[i]);
-    zName = statusTableName(db, &aTo[i]);
-    if(!zName) continue;
+    rc = statusTableName(db, &aTo[i], &zName);
+    if( rc==SQLITE_NOTFOUND ) continue;
+    if( rc!=SQLITE_OK ) return rc;
     if(!pFrom){
       rc = addRow(pCur, zName, staged, "new table");
     }else{
@@ -142,8 +152,9 @@ static int compareCatalogs(
     if(aFrom[i].iTable<=1) continue;
     if( useRename && fromHandled[i] ) continue;
     if(!findCatalogEntry(aTo, nTo, &aFrom[i])){
-      zName = statusTableName(db, &aFrom[i]);
-      if(!zName) continue;
+      rc = statusTableName(db, &aFrom[i], &zName);
+      if( rc==SQLITE_NOTFOUND ) continue;
+      if( rc!=SQLITE_OK ) return rc;
       rc = addRow(pCur, zName, staged, "deleted");
       sqlite3_free(zName);
       if( rc!=SQLITE_OK ) return rc;
@@ -216,12 +227,10 @@ static int statusFilter(sqlite3_vtab_cursor *pCursor,
     if( rc!=SQLITE_OK ) goto status_done;
   }
 
-  {u8 *catData=0;int nCatData=0;
-    rc=doltliteFlushAndSerializeCatalog(db,&catData,&nCatData);
+  {
+    rc = doltliteFlushCatalogToHash(db, &workingCatHash);
     if(rc==SQLITE_OK){
-      rc=chunkStorePut(cs,catData,nCatData,&workingCatHash);
-      sqlite3_free(catData);
-      if(rc==SQLITE_OK) rc = doltliteLoadCatalog(db,&workingCatHash,&aWorking,&nWorking,0);
+      rc = doltliteLoadCatalog(db,&workingCatHash,&aWorking,&nWorking,0);
     }
     if( rc!=SQLITE_OK ) goto status_done;
   }

--- a/test/doltlite_diff_table.sh
+++ b/test/doltlite_diff_table.sh
@@ -214,6 +214,27 @@ run_test "history_commits" "SELECT count(DISTINCT to_commit) FROM dolt_diff_t;" 
 rm -f "$DB"
 
 # ============================================================
+# Unchanged commit spans do not break diff traversal
+# ============================================================
+
+DB=/tmp/test_dt_unchanged_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+CREATE TABLE u(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'keep');
+INSERT INTO u VALUES(1,'u0');
+SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+for i in $(seq 1 25); do
+  echo "UPDATE u SET v='u$i' WHERE id=1;
+SELECT dolt_commit('-A','-m','u$i');" | $DOLTLITE "$DB" > /dev/null 2>&1
+done
+
+run_test "unchanged_table_diff_count" "SELECT count(*) FROM dolt_diff_t;" "1" "$DB"
+run_test "unchanged_table_diff_type" "SELECT diff_type FROM dolt_diff_t;" "added" "$DB"
+
+rm -f "$DB"
+
+# ============================================================
 # Quoted table names
 # ============================================================
 


### PR DESCRIPTION
This PR cleans up the latest review findings in the history/status/diff-table vtab paths.

Changes:
- make dolt_diff_<table> fail on real catalog-load errors instead of treating them as empty roots
- avoid partial diff rows on OOM and remove recursive unchanged-commit skipping
- route dolt_status working catalog flush through the shared helper and fail harder on unresolved user-table names while still skipping internal index roots
- switch dolt_history_<table> to hash-set backed traversal to avoid quadratic visited checks and duplicate queue growth
- add regression coverage for long unchanged commit spans in dolt_diff_<table>

Verified:
- `cd build && bash ../test/doltlite_diff_table.sh`
- `cd build && bash ../test/doltlite_history.sh`
- `cd build && bash ../test/doltlite_staging.sh`