### PR TITLE
Harden schema migration and diff helpers

### DIFF
--- a/src/doltlite_diff.c
+++ b/src/doltlite_diff.c
@@ -88,61 +88,6 @@ static int detectPkField(sqlite3 *db, const char *zTable){
   return pkField;
 }
 
-static void resultPkFromRecord(
-  sqlite3_context *ctx,
-  const u8 *pData, int nData,
-  int pkFieldIdx
-){
-  const u8 *p, *pEnd;
-  u64 hdrSize;
-  int hdrBytes, fieldIdx = 0, off;
-
-  if( !pData || nData<1 ){ sqlite3_result_null(ctx); return; }
-
-  p = pData; pEnd = pData + nData;
-  
-  hdrBytes = dlReadVarint(p, pEnd, &hdrSize);
-  p += hdrBytes;
-  off = (int)hdrSize;
-
-  
-  while( p < pData+hdrSize && p < pEnd ){
-    u64 st; int stBytes;
-    stBytes = dlReadVarint(p, pData+hdrSize, &st);
-    p += stBytes;
-
-    if( fieldIdx==pkFieldIdx ){
-      
-      if( st==0 ){ sqlite3_result_null(ctx); return; }
-      if( st==8 ){ sqlite3_result_int(ctx,0); return; }
-      if( st==9 ){ sqlite3_result_int(ctx,1); return; }
-      if( st>=1 && st<=6 ){
-        static const int sizes[]={0,1,2,3,4,6,8};
-        int nB=sizes[st];
-        if( off+nB<=nData ){
-          const u8 *q=pData+off; i64 v=(q[0]&0x80)?-1:0; int i;
-          for(i=0;i<nB;i++) v=(v<<8)|q[i];
-          sqlite3_result_int64(ctx,v);
-        }else sqlite3_result_null(ctx);
-        return;
-      }
-      if( st>=13 && (st&1)==1 ){
-        int len=((int)st-13)/2;
-        if(off+len<=nData) sqlite3_result_text(ctx,(const char*)(pData+off),len,SQLITE_TRANSIENT);
-        else sqlite3_result_null(ctx);
-        return;
-      }
-      sqlite3_result_null(ctx);
-      return;
-    }
-
-    
-    off += dlSerialTypeLen(st);
-    fieldIdx++;
-  }
-  sqlite3_result_null(ctx);
-}
-
 static int diffCollect(void *pCtx, const ProllyDiffChange *pChange){
   DoltliteDiffCursor *pCur = (DoltliteDiffCursor*)pCtx;
   DiffRow *aNew;
@@ -310,8 +255,6 @@ static int diffFilter(sqlite3_vtab_cursor *pCursor,
   struct TableEntry *aWork = 0;
   int nHead = 0;
   int nWork = 0;
-  u8 *catData = 0;
-  int nCatData = 0;
   (void)idxStr;
 
   freeDiffRows(pCur);
@@ -374,15 +317,12 @@ static int diffFilter(sqlite3_vtab_cursor *pCursor,
     }
     if( flags==0 ) flags = f2;
   }else{
-    rc = doltliteFlushAndSerializeCatalog(db, &catData, &nCatData);
+    rc = doltliteFlushCatalogToHash(db, &workingCatHash);
     if( rc==SQLITE_OK ){
-      rc = chunkStorePut(cs, catData, nCatData, &workingCatHash);
+      rc = doltliteLoadCatalog(db, &workingCatHash, &aWork, &nWork, 0);
       if( rc==SQLITE_OK ){
-        rc = doltliteLoadCatalog(db, &workingCatHash, &aWork, &nWork, 0);
-        if( rc==SQLITE_OK ){
-          rc = doltliteFindTableRoot(aWork, nWork, iTable, &newRoot, &flags);
-          if( rc==SQLITE_NOTFOUND ) rc = SQLITE_OK;
-        }
+        rc = doltliteFindTableRoot(aWork, nWork, iTable, &newRoot, &flags);
+        if( rc==SQLITE_NOTFOUND ) rc = SQLITE_OK;
       }
     }
   }
@@ -402,7 +342,6 @@ static int diffFilter(sqlite3_vtab_cursor *pCursor,
 diff_filter_done:
   sqlite3_free(aHead);
   sqlite3_free(aWork);
-  sqlite3_free(catData);
   return rc;
 }
 
@@ -436,7 +375,7 @@ static int diffColumn(sqlite3_vtab_cursor *pCursor,
         
         const u8 *pRec = r->pNewVal ? r->pNewVal : r->pOldVal;
         int nRec = r->pNewVal ? r->nNewVal : r->nOldVal;
-        resultPkFromRecord(ctx, pRec, nRec, pCur->iPkField);
+        doltliteResultRecordPkField(ctx, pRec, nRec, pCur->iPkField);
       }else{
         
         sqlite3_result_int64(ctx, r->intKey);

--- a/src/doltlite_record.c
+++ b/src/doltlite_record.c
@@ -284,6 +284,23 @@ void doltliteResultField(
   sqlite3_result_null(ctx);
 }
 
+void doltliteResultRecordPkField(
+  sqlite3_context *ctx, const u8 *pData, int nData, int iPkField
+){
+  DoltliteRecordInfo ri;
+  if( !pData || nData<1 || iPkField<0 ){
+    sqlite3_result_null(ctx);
+    return;
+  }
+  doltliteParseRecord(pData, nData, &ri);
+  if( iPkField>=ri.nField ){
+    sqlite3_result_null(ctx);
+    return;
+  }
+  doltliteResultField(ctx, pData, nData,
+                      ri.aType[iPkField], ri.aOffset[iPkField]);
+}
+
 int doltliteBindField(
   sqlite3_stmt *pStmt, int iParam,
   const u8 *pData, int nData,

--- a/src/doltlite_record.h
+++ b/src/doltlite_record.h
@@ -59,6 +59,9 @@ void doltliteParseRecord(const u8 *pData, int nData, DoltliteRecordInfo *pInfo);
 
 void doltliteResultField(sqlite3_context *ctx, const u8 *pData, int nData,
                          int serialType, int offset);
+void doltliteResultRecordPkField(sqlite3_context *ctx,
+                                 const u8 *pData, int nData,
+                                 int iPkField);
 
 int doltliteBindField(sqlite3_stmt *pStmt, int iParam,
                       const u8 *pData, int nData,

--- a/src/doltlite_schema_merge.c
+++ b/src/doltlite_schema_merge.c
@@ -22,39 +22,69 @@
 #include <string.h>
 #include <ctype.h>
 
+static int dlIdentTokenLen(const char *z, int n){
+  int i = 0;
+  if( !z || n<=0 ) return 0;
+  if( z[0]=='"' || z[0]=='`' ){
+    char q = z[0];
+    for(i=1; i<n; i++){
+      if( z[i]==q ){
+        if( i+1<n && z[i+1]==q ){
+          i++;
+          continue;
+        }
+        return i+1;
+      }
+    }
+    return n;
+  }
+  if( z[0]=='[' ){
+    for(i=1; i<n; i++){
+      if( z[i]==']' ){
+        if( i+1<n && z[i+1]==']' ){
+          i++;
+          continue;
+        }
+        return i+1;
+      }
+    }
+    return n;
+  }
+  while( i<n && !isspace((unsigned char)z[i]) && z[i]!='(' && z[i]!=',' ){
+    i++;
+  }
+  return i;
+}
+
+static char *dlExtractIdentLower(const char *z, int n){
+  char *zName;
+  int i;
+  if( !z || n<=0 ) return 0;
+  zName = sqlite3_malloc(n + 1);
+  if( !zName ) return 0;
+  memcpy(zName, z, n);
+  zName[n] = 0;
+  sqlite3Dequote(zName);
+  for(i=0; zName[i]; i++){
+    zName[i] = (char)tolower((unsigned char)zName[i]);
+  }
+  return zName;
+}
+
 /*
 ** Extract the column name from an ADD COLUMN definition string like "y INTEGER".
 ** Returns a malloc'd, lowercased copy of the name. Caller must sqlite3_free.
 */
 char *extractColNameFromDef(const char *zDef){
   const char *s = zDef;
-  const char *e;
-  char *zName;
-  int len, i;
+  int len;
 
   /* Skip leading whitespace */
   while( *s && isspace((unsigned char)*s) ) s++;
   if( !*s ) return 0;
 
-  /* Handle quoted names */
-  if( *s=='"' || *s=='`' || *s=='[' ){
-    char close = (*s=='"') ? '"' : (*s=='`') ? '`' : ']';
-    s++;
-    e = s;
-    while( *e && *e!=close ) e++;
-    len = (int)(e - s);
-  }else{
-    e = s;
-    while( *e && !isspace((unsigned char)*e) && *e!='(' && *e!=',' ) e++;
-    len = (int)(e - s);
-  }
-  if( len<=0 ) return 0;
-  zName = sqlite3_malloc(len + 1);
-  if( !zName ) return 0;
-  memcpy(zName, s, len);
-  zName[len] = 0;
-  for(i=0; zName[i]; i++) zName[i] = (char)tolower((unsigned char)zName[i]);
-  return zName;
+  len = dlIdentTokenLen(s, (int)strlen(s));
+  return dlExtractIdentLower(s, len);
 }
 
 /*
@@ -110,16 +140,23 @@ int migrateDiffCb(void *pArg, const ProllyDiffChange *pChange){
   for(sj=0; sj<ctx->nCols; sj++){
     if( ctx->aiColIdx[sj]<0 || !ctx->azColNames[sj] ) continue;
     if( ctx->aiColIdx[sj] < nFields ){
-      doltliteBindField(ctx->pUpd, bindIdx, pVal, nVal,
-                      aType[ctx->aiColIdx[sj]],
-                      aOffset[ctx->aiColIdx[sj]]);
+      int brc = doltliteBindField(ctx->pUpd, bindIdx, pVal, nVal,
+                                  aType[ctx->aiColIdx[sj]],
+                                  aOffset[ctx->aiColIdx[sj]]);
+      if( brc!=SQLITE_OK ) return brc;
     }else{
-      sqlite3_bind_null(ctx->pUpd, bindIdx);
+      int brc = sqlite3_bind_null(ctx->pUpd, bindIdx);
+      if( brc!=SQLITE_OK ) return brc;
     }
     bindIdx++;
   }
-  sqlite3_bind_int64(ctx->pUpd, bindIdx, pChange->intKey);
-  sqlite3_step(ctx->pUpd);
+  {
+    int brc = sqlite3_bind_int64(ctx->pUpd, bindIdx, pChange->intKey);
+    int src;
+    if( brc!=SQLITE_OK ) return brc;
+    src = sqlite3_step(ctx->pUpd);
+    if( src!=SQLITE_DONE ) return src;
+  }
 
   return SQLITE_OK;
 }
@@ -276,30 +313,10 @@ int migrateSchemaRowData(
                   /* Extract the column name */
                   char *zColName;
                   const char *ns = s;
-                  const char *ne;
-                  int nl;
+                  int nl = dlIdentTokenLen(ns, (int)(e - ns));
 
-                  if( *ns=='"' || *ns=='`' || *ns=='[' ){
-                    char close = (*ns=='"') ? '"' : (*ns=='`') ? '`' : ']';
-                    ns++;
-                    ne = ns;
-                    while( ne<e && *ne!=close ) ne++;
-                    nl = (int)(ne - ns);
-                  }else{
-                    ne = ns;
-                    while( ne<e && !isspace((unsigned char)*ne)
-                        && *ne!='(' && *ne!=',' ) ne++;
-                    nl = (int)(ne - ns);
-                  }
-
-                  zColName = sqlite3_malloc(nl + 1);
+                  zColName = dlExtractIdentLower(ns, nl);
                   if( zColName ){
-                    int ci;
-                    memcpy(zColName, ns, nl);
-                    zColName[nl] = 0;
-                    for(ci=0; zColName[ci]; ci++)
-                      zColName[ci] = (char)tolower((unsigned char)zColName[ci]);
-
                     /* Check if this column matches any of our added columns */
                     for(sj=0; sj<pAct->nAddColumns; sj++){
                       if( azColNames[sj]
@@ -390,7 +407,6 @@ int migrateSchemaRowData(
 
           rc = prollyDiff(cs, pCache, &ancRoot, &theirTE->root,
                           theirTE->flags, migrateDiffCb, &diffCtx);
-          if( rc!=SQLITE_OK ) rc = SQLITE_OK; /* best-effort */
         }
 
         sqlite3_finalize(pUpd);
@@ -405,8 +421,7 @@ next_action:
     }
     sqlite3_free(aiColIdx);
 
-    /* Continue even on non-fatal errors */
-    if( rc!=SQLITE_OK && rc!=SQLITE_NOMEM ) rc = SQLITE_OK;
+    if( rc!=SQLITE_OK ) break;
   }
 
   freeSchemaEntries(aTheirSchema, nTheirSchema);

--- a/test/doltlite_schema_merge.sh
+++ b/test/doltlite_schema_merge.sh
@@ -45,6 +45,28 @@ run_test "alter_merge_count" "SELECT count(*) FROM t;" "2" "$DB"
 rm -f "$DB"
 
 # ============================================================
+# Test 1b: quoted added columns migrate correctly across merge
+# ============================================================
+
+DB=/tmp/test_alter_merge1b_$$.db; rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_commit('-A','-m','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+ALTER TABLE t ADD COLUMN "odd""name" TEXT;
+UPDATE t SET "odd""name"='quoted' WHERE id=1;
+SELECT dolt_commit('-A','-m','add quoted column');
+SELECT dolt_checkout('main');
+EOF
+
+run_test_match "alter_merge_quoted_hash" "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB"
+run_test "alter_merge_quoted_val" 'SELECT "odd""name" FROM t WHERE id=1;' "quoted" "$DB"
+
+rm -f "$DB"
+
+# ============================================================
 # Test 2: ALTER TABLE ADD COLUMN same name on both branches — conflict?
 # ============================================================
 


### PR DESCRIPTION
This PR fixes the latest schema-merge/diff review findings.

Changes:
- make schema merge row migration fail on real bind/step/diff errors instead of silently succeeding with partial data
- use SQLite dequoting rules for extracted schema identifiers so quoted added-column names migrate correctly
- route `dolt_diff()` working-state catalog flushing through the shared helper instead of open-coding it again
- remove the duplicate PK-field record decoder from `dolt_diff` and reuse shared record helpers
- add regression coverage for merging a quoted added column

Verified:
- `cd build && make -j4 doltlite`
- `cd build && bash ../test/doltlite_schema_merge.sh`
- `cd build && bash ../test/doltlite_diff.sh`
- `cd build && bash ../test/doltlite_diff_alter.sh`