### PR TITLE
Add dolt_merge oracle; parse -m, --message, --no-ff

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,6 +91,10 @@ jobs:
       run: cd build && bash ../test/vc_oracle_branch_test.sh ./doltlite dolt
       timeout-minutes: 5
 
+    - name: Version control oracle tests (dolt_merge)
+      run: cd build && bash ../test/vc_oracle_merge_test.sh ./doltlite dolt
+      timeout-minutes: 5
+
     - name: Large-scale test (10K rows)
       run: cd build && bash ../test/large_scale_test.sh ./doltlite --quick
       timeout-minutes: 5

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -898,29 +898,63 @@ static void doltliteMergeFunc(
 ){
   sqlite3 *db = sqlite3_context_db_handle(context);
   ChunkStore *cs = doltliteGetChunkStore(db);
-  const char *zBranch;
+  const char *zBranch = 0;
+  const char *zMessage = 0;
+  int isAbort = 0;
+  int noFastForward = 0;
   ProllyHash ourHead, theirHead, ancestorHash;
   ProllyHash ourCatHash, theirCatHash, ancCatHash, mergedCatHash;
   DoltliteTxnState savedState;
   int nMergeConflicts = 0;
   DoltliteCommit ourCommit, theirCommit, ancCommit;
   int graphLocked = 0;
-  int rc;
+  int rc, i;
 
   memset(&ourCommit, 0, sizeof(ourCommit));
   memset(&theirCommit, 0, sizeof(theirCommit));
   memset(&ancCommit, 0, sizeof(ancCommit));
   memset(&savedState, 0, sizeof(savedState));
 
-  
+
   if( !cs ){ sqlite3_result_error(context, "no database", -1); return; }
   if( argc<1 ){ sqlite3_result_error(context, "usage: dolt_merge('branch')", -1); return; }
 
-  zBranch = (const char*)sqlite3_value_text(argv[0]);
-  if( !zBranch ){ sqlite3_result_error(context, "branch name required", -1); return; }
+  /* Parse arguments. The first non-flag positional is the target branch
+  ** (or --abort, which is handled as a special branch-position keyword).
+  ** Recognized flags: -m / --message, --no-ff, --abort. Unknown
+  ** dash-prefixed flags are rejected. */
+  for(i=0; i<argc; i++){
+    const char *arg = (const char*)sqlite3_value_text(argv[i]);
+    if( !arg ) continue;
+    if( strcmp(arg, "--abort")==0 ){
+      isAbort = 1;
+    }else if( strcmp(arg, "--no-ff")==0 ){
+      noFastForward = 1;
+    }else if( strcmp(arg, "-m")==0 || strcmp(arg, "--message")==0 ){
+      if( i+1<argc ){
+        zMessage = (const char*)sqlite3_value_text(argv[++i]);
+      }else{
+        sqlite3_result_error(context, "-m requires a message", -1);
+        return;
+      }
+    }else if( arg[0]=='-' ){
+      char *zErr = sqlite3_mprintf("unknown option `%s`", arg);
+      if( zErr ){
+        sqlite3_result_error(context, zErr, -1);
+        sqlite3_free(zErr);
+      }else{
+        sqlite3_result_error_nomem(context);
+      }
+      return;
+    }else if( !zBranch ){
+      zBranch = arg;
+    }else{
+      sqlite3_result_error(context, "too many positional arguments to dolt_merge", -1);
+      return;
+    }
+  }
 
-  
-  if( strcmp(zBranch, "--abort")==0 ){
+  if( isAbort ){
     u8 isMerging = 0;
     ProllyHash headCatHash;
 
@@ -954,7 +988,11 @@ static void doltliteMergeFunc(
     return;
   }
 
-  
+  if( !zBranch ){
+    sqlite3_result_error(context, "branch name required", -1);
+    return;
+  }
+
   doltliteGetSessionHead(db, &ourHead);
   if( prollyHashIsEmpty(&ourHead) ){
     sqlite3_result_error(context, "no commits on current branch", -1);
@@ -999,8 +1037,11 @@ static void doltliteMergeFunc(
   }
 
   
-  if( prollyHashCompare(&ancestorHash, &ourHead)==0 ){
-    /* Fast-forward: move branch pointer to their commit, no merge commit. */
+  if( prollyHashCompare(&ancestorHash, &ourHead)==0 && !noFastForward ){
+    /* Fast-forward: move branch pointer to their commit, no merge commit.
+    ** Skipped when --no-ff was passed; in that case fall through to the
+    ** three-way merge path which will produce a real merge commit even
+    ** though the row content is identical to theirs. */
     char hx[PROLLY_HASH_SIZE*2+1];
 
     rc = doltliteLoadCommit(db, &theirHead, &theirCommit);
@@ -1208,7 +1249,12 @@ static void doltliteMergeFunc(
 
     doltliteSetSessionStaged(db, &mergedCatHash);
 
-    snprintf(msg, sizeof(msg), "Merge branch '%s'", zBranch);
+    if( zMessage && zMessage[0] ){
+      sqlite3_snprintf(sizeof(msg), msg, "%s", zMessage);
+    }else{
+      snprintf(msg, sizeof(msg), "Merge branch '%s' into %s",
+               zBranch, doltliteGetSessionBranch(db));
+    }
     rc = doltliteCreateAndStoreCommit(db, &ourHead, &mergedCatHash,
         msg, NULL, NULL, &theirHead, 1, &commitHash);
     if( rc!=SQLITE_OK ){

--- a/test/doltlite_merge.sh
+++ b/test/doltlite_merge.sh
@@ -19,7 +19,7 @@ echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "merge_hash" "SELECT dolt_merge('feature');" "^[0-9a-f]{40}$" "$DB"
 run_test "merge_users" "SELECT name FROM users;" "ALICE" "$DB"
 run_test "merge_orders" "SELECT count(*) FROM orders;" "2" "$DB"
-run_test "merge_log" "SELECT message FROM dolt_log LIMIT 1;" "Merge branch 'feature'" "$DB"
+run_test "merge_log" "SELECT message FROM dolt_log LIMIT 1;" "Merge branch 'feature' into main" "$DB"
 run_test "merge_log_count" "SELECT count(*) FROM dolt_log;" "5" "$DB"
 
 # Test 2: Fast-forward merge

--- a/test/vc_oracle_merge_test.sh
+++ b/test/vc_oracle_merge_test.sh
@@ -1,0 +1,310 @@
+#!/bin/bash
+#
+# Version-control oracle test: dolt_merge
+#
+# Runs identical merge scenarios against doltlite and Dolt and compares
+# the resulting dolt_log post-state. Covers fast-forward, three-way no
+# conflict, --no-ff (force a merge commit even when fast-forward would
+# work), -m / --message overrides, --abort, and a few error paths.
+#
+# IMPORTANT: every scenario uses INTEGER PRIMARY KEY (the sqlite rowid
+# alias) for its merged tables. doltlite stores rows keyed by sqlite's
+# auto-rowid, which is allocated independently per branch. With a non-
+# alias PK like `id INT PRIMARY KEY`, two branches that each insert one
+# new row both land on rowid=2 and the row-level merge sees a spurious
+# MM conflict on rowid 2 even though the user's PK values are distinct.
+# Dolt keys by user PK directly, so the same scenario merges cleanly
+# there. Until doltlite's storage layer supports user-PK-keyed rows,
+# the oracle scenarios stick to INTEGER PRIMARY KEY where the user's
+# value IS the rowid and the keys never collide. The conflict scenario
+# below also uses INTEGER PRIMARY KEY and exercises a true MM conflict
+# (UPDATE on the same row from both sides) which doltlite handles
+# correctly.
+#
+# Conflict scenarios are checked via oracle_error_or_state because
+# doltlite enters a merge state on conflict while Dolt rolls back the
+# transaction under autocommit. The two engines diverge in HOW the
+# conflict is surfaced, but both refuse to produce a clean merge
+# commit, which is the property the oracle gates on.
+#
+# Usage: bash vc_oracle_merge_test.sh [path/to/doltlite] [path/to/dolt]
+#
+
+set -u
+
+DOLTLITE="${1:-./doltlite}"
+DOLT="${2:-dolt}"
+TMPROOT=$(mktemp -d)
+trap "rm -rf $TMPROOT" EXIT
+pass=0; fail=0
+FAILED_NAMES=""
+
+normalize() {
+  # 1. Strip CRs.
+  # 2. Drop non-tab lines (function-result text like "Already up to date"
+  #    leaks through stdout in list mode).
+  # 3. Sort by message (column 2) so the H1/H2/... assignment in step 4 is
+  #    deterministic across both engines regardless of native log walk
+  #    order. After a merge, the two engines disagree on which parent
+  #    appears first in dolt_log; sorting by message canonicalizes.
+  # 4. Replace each distinct hash with H1, H2, ... in first-appearance
+  #    order on the sorted output.
+  tr -d '\r' \
+    | awk -F'\t' 'NF >= 2 { print }' \
+    | sort -t$'\t' -k2 \
+    | awk -F'\t' '
+        {
+          h = $1
+          if (!(h in seen)) { n++; seen[h] = "H" n }
+          print seen[h] "\t" $2
+        }
+      '
+}
+
+# Compare post-state via dolt_log: (commit_hash normalized, message),
+# in order from newest to oldest. Same shape as the log oracle.
+oracle() {
+  local name="$1" setup="$2"
+  local dir="$TMPROOT/$name"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local q='SELECT commit_hash || char(9) || message FROM dolt_log'
+
+  local dl_out
+  dl_out=$(printf "%s\n.headers off\n.mode list\n.separator '\t'\n%s;\n" "$setup" "$q" \
+           | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
+           | grep -v '^[0-9]*$' \
+           | grep -v '^[0-9a-f]\{40\}$' \
+           | normalize)
+
+  local dolt_setup
+  dolt_setup=$(echo "$setup" | sed -E 's/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g')
+
+  (
+    cd "$dir/dt" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    echo "$dolt_setup" | "$DOLT" sql >/dev/null 2>"$dir/dt.err"
+    "$DOLT" sql -r csv -q "SELECT concat(commit_hash, char(9), message) FROM dolt_log ORDER BY commit_order DESC;" 2>>"$dir/dt.err"
+  ) > "$dir/dt.raw"
+
+  local dt_out
+  dt_out=$(tail -n +2 "$dir/dt.raw" | tr -d '"' | normalize)
+
+  if [ "$dl_out" = "$dt_out" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite:"; echo "$dl_out" | sed 's/^/      /'
+    echo "    dolt:"    ; echo "$dt_out" | sed 's/^/      /'
+  fi
+}
+
+# A merge that should not produce a new merge commit (because both
+# engines diverge on how they surface conflict). Compares only the
+# property that BOTH engines refuse to advance the branch tip to a
+# clean merge commit — checked by counting commits on the current
+# branch and asserting both report the same pre-merge count.
+oracle_no_merge_commit() {
+  local name="$1" setup="$2"
+  local dir="$TMPROOT/${name}_nm"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_count
+  dl_count=$(printf "%s\n.headers off\n.mode list\nSELECT count(*) FROM dolt_log;\n" "$setup" \
+             | "$DOLTLITE" "$dir/dl/db" 2>/dev/null \
+             | grep -E '^[0-9]+$' | tail -1)
+
+  local dolt_setup
+  dolt_setup=$(echo "$setup" | sed -E 's/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g')
+
+  local dt_count
+  dt_count=$(
+    cd "$dir/dt" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    echo "$dolt_setup" | "$DOLT" sql >/dev/null 2>&1
+    "$DOLT" sql -r csv -q "SELECT count(*) FROM dolt_log;" 2>/dev/null \
+      | tail -n +2
+  )
+
+  if [ "$dl_count" = "$dt_count" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite log count: $dl_count"
+    echo "    dolt log count:     $dt_count"
+  fi
+}
+
+oracle_error() {
+  local name="$1" setup="$2"
+  local dir="$TMPROOT/${name}_err"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_err=0
+  echo "$setup" | "$DOLTLITE" "$dir/dl/db" >"$dir/dl.out" 2>"$dir/dl.err"
+  if grep -qiE 'error|fail' "$dir/dl.out" "$dir/dl.err" 2>/dev/null; then dl_err=1; fi
+
+  local dolt_setup
+  dolt_setup=$(echo "$setup" | sed -E 's/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g')
+  local dt_err=0
+  (
+    cd "$dir/dt" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    echo "$dolt_setup" | "$DOLT" sql >"$dir/dt.out" 2>"$dir/dt.err"
+  )
+  if grep -qiE 'error|fail' "$dir/dt.out" "$dir/dt.err" 2>/dev/null; then dt_err=1; fi
+
+  if [ "$dl_err" = 1 ] && [ "$dt_err" = 1 ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name (expected both to error)"
+    echo "    doltlite errored: $([ $dl_err = 1 ] && echo yes || echo NO)"
+    echo "    dolt errored:     $([ $dt_err = 1 ] && echo yes || echo NO)"
+  fi
+}
+
+echo "=== Version Control Oracle Tests: dolt_merge ==="
+echo ""
+
+SEED="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_branch('feature');
+"
+
+echo "--- fast forward ---"
+
+oracle "fast_forward_clean" "
+$SEED
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat1');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feature');
+"
+
+echo "--- three-way no conflict ---"
+
+oracle "three_way_independent_inserts" "
+$SEED
+INSERT INTO t VALUES (10, 100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main2');
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (20, 200);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat1');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feature');
+"
+
+oracle "three_way_disjoint_columns_modified" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, a INT, b INT);
+INSERT INTO t VALUES (1, 0, 0);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_branch('feature');
+UPDATE t SET a = 10 WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main_a');
+SELECT dolt_checkout('feature');
+UPDATE t SET b = 20 WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat_b');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feature');
+"
+
+echo "--- --no-ff ---"
+
+oracle "no_ff_creates_merge_commit" "
+$SEED
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat1');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feature', '--no-ff');
+"
+
+echo "--- custom message ---"
+
+oracle "merge_with_custom_message" "
+$SEED
+INSERT INTO t VALUES (10, 100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main2');
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (20, 200);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat1');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feature', '-m', 'release sync');
+"
+
+oracle "merge_with_message_long_flag" "
+$SEED
+INSERT INTO t VALUES (10, 100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main2');
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (20, 200);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat1');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feature', '--message', 'release sync');
+"
+
+echo "--- conflict (no merge commit) ---"
+
+oracle_no_merge_commit "modify_modify_conflict_blocks_merge" "
+$SEED
+UPDATE t SET v = 99 WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main2');
+SELECT dolt_checkout('feature');
+UPDATE t SET v = 11 WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat1');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feature');
+"
+
+echo "--- already up to date ---"
+
+oracle "merge_same_branch_no_op" "
+$SEED
+SELECT dolt_merge('main');
+"
+
+echo "--- error paths ---"
+
+oracle_error "merge_nonexistent_branch" "
+$SEED
+SELECT dolt_merge('nope');
+"
+
+oracle_error "merge_unknown_flag" "
+$SEED
+SELECT dolt_merge('feature', '--bogus');
+"
+
+oracle_error "merge_no_args" "
+SELECT dolt_merge();
+"
+
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+if [ $fail -gt 0 ]; then
+  echo "Failed:$FAILED_NAMES"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- New `test/vc_oracle_merge_test.sh`: eleven scenarios exercising fast-forward, three-way no-conflict, `--no-ff`, custom messages via `-m` / `--message`, conflict refusal, and a few error paths. Wired into CI.
- Three real `dolt_merge` parser bugs fixed: `-m`, `--no-ff`, and unknown flags were all being silently ignored.
- Default merge commit message changed from `"Merge branch 'X'"` to `"Merge branch 'X' into <current>"` to match Dolt's wording.
- One large impedance documented but not fixed: doltlite's storage keys rows by sqlite's auto-rowid, which collides on independent inserts across branches when the user's PK isn't `INTEGER PRIMARY KEY`.
- Stacked on #347 (`dolt_branch` PR).

## The flag parser bugs

`doltliteMergeFunc` only ever called `sqlite3_value_text(argv[0])` and only treated the literal string `"--abort"` as a special first-position keyword. Every other argument shape was either silently ignored (`-m`, `--no-ff`) or interpreted as a literal branch name. Concretely:

- `dolt_merge('feature', '-m', 'msg')` ignored both `-m` and `'msg'`, used the default merge message.
- `dolt_merge('feature', '--no-ff')` ignored `--no-ff` and fast-forwarded anyway whenever the merge could be a fast-forward.
- `dolt_merge('feature', '--bogus')` silently succeeded instead of rejecting the unknown flag, same shape as the bugs in `dolt_branch` and `dolt_add` from the previous oracle PRs.

The rewrite walks all arguments once, classifies each as a recognized flag, an unknown flag (rejected with `unknown option \`X\`` matching Dolt's wording and the rest of the doltlite oracle work), or a positional. The first non-flag positional becomes the target branch (or `--abort`, which is its own keyword).

The fast-forward path now tests `!noFastForward` before taking it; with `--no-ff` set, control falls through to the three-way merge code which produces a real merge commit even when the row content is identical to theirs.

## Default merge commit message

Doltlite emitted `"Merge branch 'feature'"`. Dolt emits `"Merge branch 'feature' into main"`. The `into <current>` suffix is the long-standing Git convention. Updated the format string and the single existing test (`test/doltlite_merge.sh::merge_log`) that asserted the old wording.

## Why the conflict scenario is checked separately

doltlite enters a merge state on conflict; Dolt rolls back the autocommit transaction with an explicit error about `dolt_allow_commit_conflicts`. The two engines diverge on *how* they surface the conflict but both refuse to advance the branch tip to a clean merge commit, which is the property the oracle gates on. The `oracle_no_merge_commit` helper just compares post-merge `dolt_log` counts on both sides.

## Why oracle output is sorted by message before hash normalization

After a merge, the two engines walk the commit graph in different orders for `dolt_log` — they emit the same set of commits but doltlite shows main's parent first while Dolt shows the feature parent first (or vice versa, depending on the scenario). Sorting by message before assigning H1, H2, ... canonicalizes both outputs to the same shape regardless of native walk order.

## The big impedance, documented but not fixed

Every merge scenario in this PR uses `INTEGER PRIMARY KEY` for its merged tables. That's not a stylistic choice, it's a workaround for a real divergence I found while building the oracle:

doltlite stores user table rows in a prolly tree keyed by sqlite's auto-allocated rowid. When a user table is created with `id INT PRIMARY KEY` (note: `INT`, not `INTEGER`), the `id` column is *not* a rowid alias — sqlite allocates rowids independently, starting at 1 and incrementing. So if branches `main` and `feature` each insert one new row after diverging from `c1`, both rows land on rowid=2 even though their user-visible PK values are distinct (e.g., main inserts `(100, ...)`, feature inserts `(200, ...)`). The three-way row-level merge then sees an `ADD(rowid=2)` from each side with different values and reports a modify-modify conflict on rowid 2.

Dolt keys rows by the user's PK directly, so the same scenario merges cleanly there. Verified by hand against a real Dolt repo.

`INTEGER PRIMARY KEY` (the rowid alias) avoids the issue because the user's value *is* the rowid, so independent inserts land on different rowids and the prolly key matches the user's intuition. The merge tests in this PR use that form throughout, and there's a long inline comment in the test file explaining why.

This is a real bug in doltlite, but it's a storage-layer change, not a merge-logic change. Worth a follow-up PR (probably with `WITHOUT ROWID` support or a doltlite-specific rowid override). I didn't bundle it here because the scope would balloon way beyond an oracle PR.

## Test plan

- [ ] `vc_oracle_merge_test.sh`: 11/11 pass locally
- [ ] `vc_oracle_branch_test.sh`: 16/16 still pass
- [ ] All other vc oracles still pass (status, log, add, branches, tags, remotes)
- [ ] `run_doltlite_tests.sh`: 39/39 — `doltlite_merge.sh::merge_log` updated for the new default message
- [ ] `remote_test.sh`: 63/63 — exercises merge indirectly via push/pull
- [ ] `large_scale_test.sh --quick`, `multi_table_test.sh --quick`, `diff_test.sh`, `config_test.sh`: all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)