### PR TITLE
Add dolt_conflicts oracle; rename table_name to table

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,6 +91,10 @@ jobs:
       run: cd build && bash ../test/vc_oracle_branch_test.sh ./doltlite dolt
       timeout-minutes: 5
 
+    - name: Version control oracle tests (dolt_merge)
+      run: cd build && bash ../test/vc_oracle_merge_test.sh ./doltlite dolt
+      timeout-minutes: 5
+
     - name: Large-scale test (10K rows)
       run: cd build && bash ../test/large_scale_test.sh ./doltlite --quick
       timeout-minutes: 5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,6 +95,10 @@ jobs:
       run: cd build && bash ../test/vc_oracle_merge_test.sh ./doltlite dolt
       timeout-minutes: 5
 
+    - name: Version control oracle tests (dolt_conflicts)
+      run: cd build && bash ../test/vc_oracle_conflicts_test.sh ./doltlite dolt
+      timeout-minutes: 5
+
     - name: Large-scale test (10K rows)
       run: cd build && bash ../test/large_scale_test.sh ./doltlite --quick
       timeout-minutes: 5

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -898,29 +898,63 @@ static void doltliteMergeFunc(
 ){
   sqlite3 *db = sqlite3_context_db_handle(context);
   ChunkStore *cs = doltliteGetChunkStore(db);
-  const char *zBranch;
+  const char *zBranch = 0;
+  const char *zMessage = 0;
+  int isAbort = 0;
+  int noFastForward = 0;
   ProllyHash ourHead, theirHead, ancestorHash;
   ProllyHash ourCatHash, theirCatHash, ancCatHash, mergedCatHash;
   DoltliteTxnState savedState;
   int nMergeConflicts = 0;
   DoltliteCommit ourCommit, theirCommit, ancCommit;
   int graphLocked = 0;
-  int rc;
+  int rc, i;
 
   memset(&ourCommit, 0, sizeof(ourCommit));
   memset(&theirCommit, 0, sizeof(theirCommit));
   memset(&ancCommit, 0, sizeof(ancCommit));
   memset(&savedState, 0, sizeof(savedState));
 
-  
+
   if( !cs ){ sqlite3_result_error(context, "no database", -1); return; }
   if( argc<1 ){ sqlite3_result_error(context, "usage: dolt_merge('branch')", -1); return; }
 
-  zBranch = (const char*)sqlite3_value_text(argv[0]);
-  if( !zBranch ){ sqlite3_result_error(context, "branch name required", -1); return; }
+  /* Parse arguments. The first non-flag positional is the target branch
+  ** (or --abort, which is handled as a special branch-position keyword).
+  ** Recognized flags: -m / --message, --no-ff, --abort. Unknown
+  ** dash-prefixed flags are rejected. */
+  for(i=0; i<argc; i++){
+    const char *arg = (const char*)sqlite3_value_text(argv[i]);
+    if( !arg ) continue;
+    if( strcmp(arg, "--abort")==0 ){
+      isAbort = 1;
+    }else if( strcmp(arg, "--no-ff")==0 ){
+      noFastForward = 1;
+    }else if( strcmp(arg, "-m")==0 || strcmp(arg, "--message")==0 ){
+      if( i+1<argc ){
+        zMessage = (const char*)sqlite3_value_text(argv[++i]);
+      }else{
+        sqlite3_result_error(context, "-m requires a message", -1);
+        return;
+      }
+    }else if( arg[0]=='-' ){
+      char *zErr = sqlite3_mprintf("unknown option `%s`", arg);
+      if( zErr ){
+        sqlite3_result_error(context, zErr, -1);
+        sqlite3_free(zErr);
+      }else{
+        sqlite3_result_error_nomem(context);
+      }
+      return;
+    }else if( !zBranch ){
+      zBranch = arg;
+    }else{
+      sqlite3_result_error(context, "too many positional arguments to dolt_merge", -1);
+      return;
+    }
+  }
 
-  
-  if( strcmp(zBranch, "--abort")==0 ){
+  if( isAbort ){
     u8 isMerging = 0;
     ProllyHash headCatHash;
 
@@ -954,7 +988,11 @@ static void doltliteMergeFunc(
     return;
   }
 
-  
+  if( !zBranch ){
+    sqlite3_result_error(context, "branch name required", -1);
+    return;
+  }
+
   doltliteGetSessionHead(db, &ourHead);
   if( prollyHashIsEmpty(&ourHead) ){
     sqlite3_result_error(context, "no commits on current branch", -1);
@@ -999,8 +1037,11 @@ static void doltliteMergeFunc(
   }
 
   
-  if( prollyHashCompare(&ancestorHash, &ourHead)==0 ){
-    /* Fast-forward: move branch pointer to their commit, no merge commit. */
+  if( prollyHashCompare(&ancestorHash, &ourHead)==0 && !noFastForward ){
+    /* Fast-forward: move branch pointer to their commit, no merge commit.
+    ** Skipped when --no-ff was passed; in that case fall through to the
+    ** three-way merge path which will produce a real merge commit even
+    ** though the row content is identical to theirs. */
     char hx[PROLLY_HASH_SIZE*2+1];
 
     rc = doltliteLoadCommit(db, &theirHead, &theirCommit);
@@ -1208,7 +1249,12 @@ static void doltliteMergeFunc(
 
     doltliteSetSessionStaged(db, &mergedCatHash);
 
-    snprintf(msg, sizeof(msg), "Merge branch '%s'", zBranch);
+    if( zMessage && zMessage[0] ){
+      sqlite3_snprintf(sizeof(msg), msg, "%s", zMessage);
+    }else{
+      snprintf(msg, sizeof(msg), "Merge branch '%s' into %s",
+               zBranch, doltliteGetSessionBranch(db));
+    }
     rc = doltliteCreateAndStoreCommit(db, &ourHead, &mergedCatHash,
         msg, NULL, NULL, &theirHead, 1, &commitHash);
     if( rc!=SQLITE_OK ){

--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -489,7 +489,10 @@ static int cfConnect(sqlite3 *db, void *pAux, int argc,
     const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){
   ConflictsVtab *v; int rc;
   (void)pAux;(void)argc;(void)argv;(void)pzErr;
-  rc = sqlite3_declare_vtab(db, "CREATE TABLE x(table_name TEXT, num_conflicts INTEGER)");
+  /* Column is named "table" to match Dolt; the quoting is required because
+  ** "table" is a reserved keyword in SQL. Callers must quote it on access:
+  ** SELECT "table" FROM dolt_conflicts. */
+  rc = sqlite3_declare_vtab(db, "CREATE TABLE x(\"table\" TEXT, num_conflicts INTEGER)");
   if(rc!=SQLITE_OK) return rc;
   v = sqlite3_malloc(sizeof(*v)); if(!v) return SQLITE_NOMEM;
   memset(v,0,sizeof(*v)); v->db=db; *ppVtab=&v->base; return SQLITE_OK;

--- a/test/doltlite_conflicts.sh
+++ b/test/doltlite_conflicts.sh
@@ -17,7 +17,7 @@ echo "UPDATE t SET v='feat'; SELECT dolt_commit('-A','-m','feat');" | $DOLTLITE 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_merge('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-run_test "conflicts_table" "SELECT table_name FROM dolt_conflicts;" "t" "$DB"
+run_test "conflicts_table" "SELECT \"table\" FROM dolt_conflicts;" "t" "$DB"
 run_test "conflicts_count" "SELECT num_conflicts FROM dolt_conflicts;" "1" "$DB"
 
 # Test 2: Commit blocked with conflicts

--- a/test/doltlite_e2e.sh
+++ b/test/doltlite_e2e.sh
@@ -110,7 +110,7 @@ SELECT dolt_commit('-A','-m','Main: update Alice name');" | $DOLTLITE "$DB" > /d
 run_test_match "e2e_conflict_merge" "SELECT dolt_merge('hotfix');" "conflict" "$DB"
 
 # Verify conflict state
-run_test "e2e_has_conflicts" "SELECT num_conflicts FROM dolt_conflicts WHERE table_name='users';" "1" "$DB"
+run_test "e2e_has_conflicts" "SELECT num_conflicts FROM dolt_conflicts WHERE \"table\"='users';" "1" "$DB"
 
 # Commit should be blocked
 run_test_match "e2e_commit_blocked" "SELECT dolt_commit('-A','-m','fail');" "unresolved" "$DB"

--- a/test/doltlite_merge.sh
+++ b/test/doltlite_merge.sh
@@ -19,7 +19,7 @@ echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "merge_hash" "SELECT dolt_merge('feature');" "^[0-9a-f]{40}$" "$DB"
 run_test "merge_users" "SELECT name FROM users;" "ALICE" "$DB"
 run_test "merge_orders" "SELECT count(*) FROM orders;" "2" "$DB"
-run_test "merge_log" "SELECT message FROM dolt_log LIMIT 1;" "Merge branch 'feature'" "$DB"
+run_test "merge_log" "SELECT message FROM dolt_log LIMIT 1;" "Merge branch 'feature' into main" "$DB"
 run_test "merge_log_count" "SELECT count(*) FROM dolt_log;" "5" "$DB"
 
 # Test 2: Fast-forward merge

--- a/test/vc_oracle_conflicts_test.sh
+++ b/test/vc_oracle_conflicts_test.sh
@@ -1,0 +1,260 @@
+#!/bin/bash
+#
+# Version-control oracle test: dolt_conflicts (summary form)
+#
+# Runs identical merge-conflict scenarios against doltlite and Dolt and
+# compares the resulting dolt_conflicts post-state. Covers no conflicts,
+# single-table conflicts, multi-row conflicts, multi-table conflicts,
+# resolution with --ours / --theirs, partial resolution, and abort.
+#
+# IMPORTANT: every scenario uses INTEGER PRIMARY KEY for the same reason
+# documented in vc_oracle_merge_test.sh — doltlite stores rows by sqlite
+# auto-rowid which collides on independent inserts across branches when
+# the user's PK isn't the rowid alias. Pure conflict scenarios (modify
+# same row on both sides) work either way, but using INTEGER PRIMARY KEY
+# keeps the test setup symmetric with the merge oracle.
+#
+# IMPORTANT: Dolt's autocommit mode rolls back the transaction when a
+# merge produces a conflict, so dolt_conflicts is empty by default. The
+# harness sets @@dolt_allow_commit_conflicts = 1 on the Dolt side before
+# running the scenario so the conflict survives long enough to query.
+# doltlite has no equivalent setting because it doesn't roll back.
+#
+# Compares only the summary `dolt_conflicts` vtable (rename of
+# table_name → table just landed in this PR). The per-table
+# `dolt_conflicts_<table>` vtable has a much larger schema gap with Dolt
+# (doltlite uses 6 generic blob columns while Dolt projects each user
+# column as base_/our_/their_), and is left as a separate follow-up.
+#
+# Usage: bash vc_oracle_conflicts_test.sh [path/to/doltlite] [path/to/dolt]
+#
+
+set -u
+
+DOLTLITE="${1:-./doltlite}"
+DOLT="${2:-dolt}"
+TMPROOT=$(mktemp -d)
+trap "rm -rf $TMPROOT" EXIT
+pass=0; fail=0
+FAILED_NAMES=""
+
+normalize() {
+  tr -d '\r' | awk -F'\t' 'NF >= 2 { print }' | sort
+}
+
+oracle() {
+  local name="$1" setup="$2"
+  local dir="$TMPROOT/$name"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  # doltlite side: scenario as written. The vtable column "table" needs
+  # double-quote escaping in the SELECT.
+  local dl_out
+  dl_out=$(printf "%s\n.headers off\n.mode list\n.separator '\t'\nSELECT \"table\" || char(9) || num_conflicts FROM dolt_conflicts ORDER BY \"table\";\n" "$setup" \
+           | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
+           | grep -v '^[0-9]*$' \
+           | grep -v '^[0-9a-f]\{40\}$' \
+           | normalize)
+
+  # Dolt side: rewrite SELECT dolt_*(...) -> CALL dolt_*(...) and prepend
+  # the autocommit override so the conflict state survives the merge.
+  local dolt_setup
+  dolt_setup=$(echo "$setup" | sed -E 's/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g')
+
+  (
+    cd "$dir/dt" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    {
+      printf '%s\n' "SET @@dolt_allow_commit_conflicts = 1;"
+      printf '%s\n' "$dolt_setup"
+    } | "$DOLT" sql >/dev/null 2>"$dir/dt.err"
+    "$DOLT" sql -r csv -q "SELECT concat(\`table\`, char(9), num_conflicts) FROM dolt_conflicts ORDER BY \`table\`;" 2>>"$dir/dt.err"
+  ) > "$dir/dt.raw"
+
+  local dt_out
+  dt_out=$(tail -n +2 "$dir/dt.raw" | tr -d '"' | normalize)
+
+  if [ "$dl_out" = "$dt_out" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite:"; echo "$dl_out" | sed 's/^/      /'
+    echo "    dolt:"    ; echo "$dt_out" | sed 's/^/      /'
+  fi
+}
+
+echo "=== Version Control Oracle Tests: dolt_conflicts ==="
+echo ""
+
+echo "--- baseline ---"
+
+oracle "empty_when_no_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+"
+
+oracle "empty_after_clean_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat1');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feature');
+"
+
+echo "--- single-table conflict ---"
+
+oracle "modify_modify_one_row" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_branch('feature');
+UPDATE t SET v = 99 WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main2');
+SELECT dolt_checkout('feature');
+UPDATE t SET v = 11 WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat1');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feature');
+"
+
+oracle "modify_modify_three_rows" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+INSERT INTO t VALUES (2, 20);
+INSERT INTO t VALUES (3, 30);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_branch('feature');
+UPDATE t SET v = v + 100;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main2');
+SELECT dolt_checkout('feature');
+UPDATE t SET v = v + 200;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat1');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feature');
+"
+
+echo "--- multi-table conflict ---"
+
+oracle "two_tables_each_with_conflict" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, v INT);
+CREATE TABLE b(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO a VALUES (1, 10);
+INSERT INTO b VALUES (1, 100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_branch('feature');
+UPDATE a SET v = 99 WHERE id = 1;
+UPDATE b SET v = 999 WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main2');
+SELECT dolt_checkout('feature');
+UPDATE a SET v = 11 WHERE id = 1;
+UPDATE b SET v = 111 WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat1');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feature');
+"
+
+echo "--- resolution clears conflicts ---"
+
+oracle "resolve_ours_clears" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_branch('feature');
+UPDATE t SET v = 99 WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main2');
+SELECT dolt_checkout('feature');
+UPDATE t SET v = 11 WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat1');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feature');
+SELECT dolt_conflicts_resolve('--ours', 't');
+"
+
+oracle "resolve_theirs_clears" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_branch('feature');
+UPDATE t SET v = 99 WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main2');
+SELECT dolt_checkout('feature');
+UPDATE t SET v = 11 WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat1');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feature');
+SELECT dolt_conflicts_resolve('--theirs', 't');
+"
+
+oracle "resolve_one_of_two_tables" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, v INT);
+CREATE TABLE b(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO a VALUES (1, 10);
+INSERT INTO b VALUES (1, 100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_branch('feature');
+UPDATE a SET v = 99 WHERE id = 1;
+UPDATE b SET v = 999 WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main2');
+SELECT dolt_checkout('feature');
+UPDATE a SET v = 11 WHERE id = 1;
+UPDATE b SET v = 111 WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat1');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feature');
+SELECT dolt_conflicts_resolve('--ours', 'a');
+"
+
+echo "--- abort ---"
+
+oracle "abort_clears_conflicts" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_branch('feature');
+UPDATE t SET v = 99 WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main2');
+SELECT dolt_checkout('feature');
+UPDATE t SET v = 11 WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat1');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feature');
+SELECT dolt_merge('--abort');
+"
+
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+if [ $fail -gt 0 ]; then
+  echo "Failed:$FAILED_NAMES"
+  exit 1
+fi

--- a/test/vc_oracle_merge_test.sh
+++ b/test/vc_oracle_merge_test.sh
@@ -1,0 +1,310 @@
+#!/bin/bash
+#
+# Version-control oracle test: dolt_merge
+#
+# Runs identical merge scenarios against doltlite and Dolt and compares
+# the resulting dolt_log post-state. Covers fast-forward, three-way no
+# conflict, --no-ff (force a merge commit even when fast-forward would
+# work), -m / --message overrides, --abort, and a few error paths.
+#
+# IMPORTANT: every scenario uses INTEGER PRIMARY KEY (the sqlite rowid
+# alias) for its merged tables. doltlite stores rows keyed by sqlite's
+# auto-rowid, which is allocated independently per branch. With a non-
+# alias PK like `id INT PRIMARY KEY`, two branches that each insert one
+# new row both land on rowid=2 and the row-level merge sees a spurious
+# MM conflict on rowid 2 even though the user's PK values are distinct.
+# Dolt keys by user PK directly, so the same scenario merges cleanly
+# there. Until doltlite's storage layer supports user-PK-keyed rows,
+# the oracle scenarios stick to INTEGER PRIMARY KEY where the user's
+# value IS the rowid and the keys never collide. The conflict scenario
+# below also uses INTEGER PRIMARY KEY and exercises a true MM conflict
+# (UPDATE on the same row from both sides) which doltlite handles
+# correctly.
+#
+# Conflict scenarios are checked via oracle_error_or_state because
+# doltlite enters a merge state on conflict while Dolt rolls back the
+# transaction under autocommit. The two engines diverge in HOW the
+# conflict is surfaced, but both refuse to produce a clean merge
+# commit, which is the property the oracle gates on.
+#
+# Usage: bash vc_oracle_merge_test.sh [path/to/doltlite] [path/to/dolt]
+#
+
+set -u
+
+DOLTLITE="${1:-./doltlite}"
+DOLT="${2:-dolt}"
+TMPROOT=$(mktemp -d)
+trap "rm -rf $TMPROOT" EXIT
+pass=0; fail=0
+FAILED_NAMES=""
+
+normalize() {
+  # 1. Strip CRs.
+  # 2. Drop non-tab lines (function-result text like "Already up to date"
+  #    leaks through stdout in list mode).
+  # 3. Sort by message (column 2) so the H1/H2/... assignment in step 4 is
+  #    deterministic across both engines regardless of native log walk
+  #    order. After a merge, the two engines disagree on which parent
+  #    appears first in dolt_log; sorting by message canonicalizes.
+  # 4. Replace each distinct hash with H1, H2, ... in first-appearance
+  #    order on the sorted output.
+  tr -d '\r' \
+    | awk -F'\t' 'NF >= 2 { print }' \
+    | sort -t$'\t' -k2 \
+    | awk -F'\t' '
+        {
+          h = $1
+          if (!(h in seen)) { n++; seen[h] = "H" n }
+          print seen[h] "\t" $2
+        }
+      '
+}
+
+# Compare post-state via dolt_log: (commit_hash normalized, message),
+# in order from newest to oldest. Same shape as the log oracle.
+oracle() {
+  local name="$1" setup="$2"
+  local dir="$TMPROOT/$name"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local q='SELECT commit_hash || char(9) || message FROM dolt_log'
+
+  local dl_out
+  dl_out=$(printf "%s\n.headers off\n.mode list\n.separator '\t'\n%s;\n" "$setup" "$q" \
+           | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
+           | grep -v '^[0-9]*$' \
+           | grep -v '^[0-9a-f]\{40\}$' \
+           | normalize)
+
+  local dolt_setup
+  dolt_setup=$(echo "$setup" | sed -E 's/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g')
+
+  (
+    cd "$dir/dt" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    echo "$dolt_setup" | "$DOLT" sql >/dev/null 2>"$dir/dt.err"
+    "$DOLT" sql -r csv -q "SELECT concat(commit_hash, char(9), message) FROM dolt_log ORDER BY commit_order DESC;" 2>>"$dir/dt.err"
+  ) > "$dir/dt.raw"
+
+  local dt_out
+  dt_out=$(tail -n +2 "$dir/dt.raw" | tr -d '"' | normalize)
+
+  if [ "$dl_out" = "$dt_out" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite:"; echo "$dl_out" | sed 's/^/      /'
+    echo "    dolt:"    ; echo "$dt_out" | sed 's/^/      /'
+  fi
+}
+
+# A merge that should not produce a new merge commit (because both
+# engines diverge on how they surface conflict). Compares only the
+# property that BOTH engines refuse to advance the branch tip to a
+# clean merge commit — checked by counting commits on the current
+# branch and asserting both report the same pre-merge count.
+oracle_no_merge_commit() {
+  local name="$1" setup="$2"
+  local dir="$TMPROOT/${name}_nm"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_count
+  dl_count=$(printf "%s\n.headers off\n.mode list\nSELECT count(*) FROM dolt_log;\n" "$setup" \
+             | "$DOLTLITE" "$dir/dl/db" 2>/dev/null \
+             | grep -E '^[0-9]+$' | tail -1)
+
+  local dolt_setup
+  dolt_setup=$(echo "$setup" | sed -E 's/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g')
+
+  local dt_count
+  dt_count=$(
+    cd "$dir/dt" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    echo "$dolt_setup" | "$DOLT" sql >/dev/null 2>&1
+    "$DOLT" sql -r csv -q "SELECT count(*) FROM dolt_log;" 2>/dev/null \
+      | tail -n +2
+  )
+
+  if [ "$dl_count" = "$dt_count" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite log count: $dl_count"
+    echo "    dolt log count:     $dt_count"
+  fi
+}
+
+oracle_error() {
+  local name="$1" setup="$2"
+  local dir="$TMPROOT/${name}_err"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_err=0
+  echo "$setup" | "$DOLTLITE" "$dir/dl/db" >"$dir/dl.out" 2>"$dir/dl.err"
+  if grep -qiE 'error|fail' "$dir/dl.out" "$dir/dl.err" 2>/dev/null; then dl_err=1; fi
+
+  local dolt_setup
+  dolt_setup=$(echo "$setup" | sed -E 's/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g')
+  local dt_err=0
+  (
+    cd "$dir/dt" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    echo "$dolt_setup" | "$DOLT" sql >"$dir/dt.out" 2>"$dir/dt.err"
+  )
+  if grep -qiE 'error|fail' "$dir/dt.out" "$dir/dt.err" 2>/dev/null; then dt_err=1; fi
+
+  if [ "$dl_err" = 1 ] && [ "$dt_err" = 1 ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name (expected both to error)"
+    echo "    doltlite errored: $([ $dl_err = 1 ] && echo yes || echo NO)"
+    echo "    dolt errored:     $([ $dt_err = 1 ] && echo yes || echo NO)"
+  fi
+}
+
+echo "=== Version Control Oracle Tests: dolt_merge ==="
+echo ""
+
+SEED="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_branch('feature');
+"
+
+echo "--- fast forward ---"
+
+oracle "fast_forward_clean" "
+$SEED
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat1');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feature');
+"
+
+echo "--- three-way no conflict ---"
+
+oracle "three_way_independent_inserts" "
+$SEED
+INSERT INTO t VALUES (10, 100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main2');
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (20, 200);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat1');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feature');
+"
+
+oracle "three_way_disjoint_columns_modified" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, a INT, b INT);
+INSERT INTO t VALUES (1, 0, 0);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_branch('feature');
+UPDATE t SET a = 10 WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main_a');
+SELECT dolt_checkout('feature');
+UPDATE t SET b = 20 WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat_b');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feature');
+"
+
+echo "--- --no-ff ---"
+
+oracle "no_ff_creates_merge_commit" "
+$SEED
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat1');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feature', '--no-ff');
+"
+
+echo "--- custom message ---"
+
+oracle "merge_with_custom_message" "
+$SEED
+INSERT INTO t VALUES (10, 100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main2');
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (20, 200);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat1');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feature', '-m', 'release sync');
+"
+
+oracle "merge_with_message_long_flag" "
+$SEED
+INSERT INTO t VALUES (10, 100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main2');
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (20, 200);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat1');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feature', '--message', 'release sync');
+"
+
+echo "--- conflict (no merge commit) ---"
+
+oracle_no_merge_commit "modify_modify_conflict_blocks_merge" "
+$SEED
+UPDATE t SET v = 99 WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main2');
+SELECT dolt_checkout('feature');
+UPDATE t SET v = 11 WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat1');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feature');
+"
+
+echo "--- already up to date ---"
+
+oracle "merge_same_branch_no_op" "
+$SEED
+SELECT dolt_merge('main');
+"
+
+echo "--- error paths ---"
+
+oracle_error "merge_nonexistent_branch" "
+$SEED
+SELECT dolt_merge('nope');
+"
+
+oracle_error "merge_unknown_flag" "
+$SEED
+SELECT dolt_merge('feature', '--bogus');
+"
+
+oracle_error "merge_no_args" "
+SELECT dolt_merge();
+"
+
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+if [ $fail -gt 0 ]; then
+  echo "Failed:$FAILED_NAMES"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- New `test/vc_oracle_conflicts_test.sh`: nine scenarios exercising the summary `dolt_conflicts` vtable across no-merge, clean merge, single/multi-row conflicts, multi-table conflicts, `--ours` / `--theirs` resolution, partial resolution, and `--abort`. Wired into CI.
- Renamed the column `table_name` to `table` in `dolt_conflicts` to match Dolt's schema.
- Documented but did not fix the much larger `dolt_conflicts_<table>` schema gap.
- Stacked on #349 (`dolt_merge` PR).

## The schema fix

doltlite's vtable declared `(table_name TEXT, num_conflicts INTEGER)`. Dolt's schema is `(table TEXT, num_conflicts BIGINT UNSIGNED)`. Renamed the first column. The new name is a SQL reserved keyword so it has to be quoted at the call site:

```sql
SELECT "table" FROM dolt_conflicts;        -- sqlite/doltlite
SELECT `table` FROM dolt_conflicts;        -- mysql/dolt
```

The two existing tests that referenced the old name (`test/doltlite_conflicts.sh::conflicts_table` and `test/doltlite_e2e.sh::e2e_has_conflicts`) are updated to use the quoted form.

## The autocommit wrinkle

Dolt's default behavior under autocommit is to roll back the transaction when a merge produces a conflict. The merge function returns a result row indicating "conflicts found" but the working state is reset, so `dolt_conflicts` is empty by default. To make the conflict state observable, you have to set `@@dolt_allow_commit_conflicts = 1` before the merge.

doltlite doesn't have this setting because it doesn't roll back — when `dolt_merge` produces a conflict, doltlite enters a merge state and the conflict survives in `dolt_conflicts` until you resolve it or `--abort`.

The harness papers over this by automatically prepending `SET @@dolt_allow_commit_conflicts = 1;` to every Dolt-side scenario so both engines end up in the same observable state for the comparison.

## Why every scenario uses INTEGER PRIMARY KEY

Same reason as the `dolt_merge` oracle PR: doltlite stores rows keyed by sqlite's auto-allocated rowid, which collides on independent inserts across branches when the user PK isn't the rowid alias. The conflict scenarios in this PR all modify the SAME row on both sides, so the rowid collision doesn't actually matter for the conflict itself — but staying in `INTEGER PRIMARY KEY` land keeps the test setup symmetric with the merge oracle and avoids any cross-test confusion.

## What this PR does NOT cover, and why

The per-table `dolt_conflicts_<table>` vtable has a much bigger schema gap:

```
doltlite  : base_rowid, base_value, our_rowid, our_value, their_rowid, their_value
dolt      : from_root_ish, base_<col>, our_<col>, their_<col>, *_diff_type, dolt_conflict_id
```

Dolt's per-table form projects each user column individually with `base_/our_/their_` prefixes. Doltlite stores the row values as opaque blobs and exposes them generically. To match Dolt, doltlite would need a vtable that dynamically declares its schema based on the target table's columns at connect time, which is a meaningful rewrite.

That's worth its own PR. The summary `dolt_conflicts` is the most commonly queried form (`SELECT count(*) FROM dolt_conflicts` is the standard "are there conflicts?" check) and is fully gated by this PR.

## Test plan

- [ ] `vc_oracle_conflicts_test.sh`: 9/9 pass locally
- [ ] `vc_oracle_merge_test.sh`: 11/11 still pass
- [ ] All other vc oracles still pass (status, log, add, branches, tags, remotes, branch)
- [ ] `run_doltlite_tests.sh`: 39/39 — `doltlite_conflicts.sh::conflicts_table` and `doltlite_e2e.sh::e2e_has_conflicts` are updated for the new column name
- [ ] `remote_test.sh`: 63/63

🤖 Generated with [Claude Code](https://claude.com/claude-code)