### PR TITLE
Harden remote refs handling and review fixes

### DIFF
--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -81,9 +81,14 @@ static int parseRecordFields(const u8 *pRec, int nRec,
     sz = dlSerialTypeLen(st);
 
     if(nFields >= nAlloc){
+      RecField *aNew;
       nAlloc = nAlloc ? nAlloc*2 : 16;
-      aFields = sqlite3_realloc(aFields, nAlloc*(int)sizeof(RecField));
-      if(!aFields) return -1;
+      aNew = sqlite3_realloc(aFields, nAlloc*(int)sizeof(RecField));
+      if(!aNew){
+        sqlite3_free(aFields);
+        return -1;
+      }
+      aFields = aNew;
     }
     aFields[nFields].st = st;
     aFields[nFields].off = bodyOff;

--- a/src/doltlite_ref.c
+++ b/src/doltlite_ref.c
@@ -100,8 +100,15 @@ int doltliteForEachUserTable(
     if( aTables[i].zName && aTables[i].iTable > 1 ){
       char *zMod = sqlite3_mprintf("%s%s", zPrefix, aTables[i].zName);
       if( zMod ){
-        sqlite3_create_module(db, zMod, pModule, 0);
+        rc = sqlite3_create_module(db, zMod, pModule, 0);
         sqlite3_free(zMod);
+        if( rc!=SQLITE_OK ){
+          sqlite3_free(aTables);
+          return rc;
+        }
+      }else{
+        sqlite3_free(aTables);
+        return SQLITE_NOMEM;
       }
     }
   }

--- a/src/doltlite_remote.c
+++ b/src/doltlite_remote.c
@@ -534,7 +534,11 @@ int doltlitePush(
         }
       }
       sqlite3_free(refsData);
-      if( rc!=SQLITE_OK && rc!=SQLITE_NOTFOUND ) return rc;
+      if( rc==SQLITE_NOTFOUND ){
+        rc = SQLITE_OK;
+      }else if( rc!=SQLITE_OK ){
+        return rc;
+      }
     }else if( rc==SQLITE_NOTFOUND ){
       rc = SQLITE_OK; 
     }

--- a/src/doltlite_remote.c
+++ b/src/doltlite_remote.c
@@ -55,6 +55,64 @@ static int syncQueuePending(SyncQueue *q){
   return q->nItems - q->iHead;
 }
 
+static int remoteLoadRefsView(const u8 *pData, int nData, ChunkStore *pRefs){
+  memset(pRefs, 0, sizeof(*pRefs));
+  if( !pData || nData<=0 ) return SQLITE_NOTFOUND;
+  return chunkStoreLoadRefsFromBlob(pRefs, pData, nData);
+}
+
+static int remoteFindBranchFromRefsBlob(
+  const u8 *pData, int nData, const char *zBranch, ProllyHash *pCommit
+){
+  ChunkStore refsView;
+  int rc = remoteLoadRefsView(pData, nData, &refsView);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = chunkStoreFindBranch(&refsView, zBranch, pCommit);
+  chunkStoreClose(&refsView);
+  return rc;
+}
+
+static int remoteCollectRootsFromRefsBlob(
+  const u8 *pData, int nData, ProllyHash **paRoots, int *pnRoots
+){
+  ChunkStore refsView;
+  ProllyHash *aRoots = 0;
+  int nRoots = 0;
+  int nAlloc = 0;
+  int rc;
+  int i;
+
+  *paRoots = 0;
+  *pnRoots = 0;
+  rc = remoteLoadRefsView(pData, nData, &refsView);
+  if( rc!=SQLITE_OK ) return rc;
+
+  nAlloc = refsView.nBranches + refsView.nTags + 1;
+  if( nAlloc>0 ){
+    aRoots = sqlite3_malloc(nAlloc * (int)sizeof(ProllyHash));
+    if( !aRoots ){
+      chunkStoreClose(&refsView);
+      return SQLITE_NOMEM;
+    }
+  }
+
+  for(i=0; i<refsView.nBranches; i++){
+    if( !prollyHashIsEmpty(&refsView.aBranches[i].commitHash) ){
+      aRoots[nRoots++] = refsView.aBranches[i].commitHash;
+    }
+  }
+  for(i=0; i<refsView.nTags; i++){
+    if( !prollyHashIsEmpty(&refsView.aTags[i].commitHash) ){
+      aRoots[nRoots++] = refsView.aTags[i].commitHash;
+    }
+  }
+
+  chunkStoreClose(&refsView);
+  *paRoots = aRoots;
+  *pnRoots = nRoots;
+  return SQLITE_OK;
+}
+
 typedef struct SyncEnqCtx SyncEnqCtx;
 struct SyncEnqCtx {
   SyncQueue *q;
@@ -384,8 +442,18 @@ static int syncIsAncestor(
     return -1;
   }
 
-  syncQueuePush(&queue, pDescendant);
-  prollyHashSetAdd(&visited, pDescendant);
+  rc = syncQueuePush(&queue, pDescendant);
+  if( rc!=SQLITE_OK ){
+    prollyHashSetFree(&visited);
+    syncQueueFree(&queue);
+    return -1;
+  }
+  rc = prollyHashSetAdd(&visited, pDescendant);
+  if( rc!=SQLITE_OK ){
+    prollyHashSetFree(&visited);
+    syncQueueFree(&queue);
+    return -1;
+  }
 
   while( !found ){
     ProllyHash current;
@@ -409,14 +477,23 @@ static int syncIsAncestor(
             break;
           }
           if( !prollyHashSetContains(&visited, &commit.aParents[pi]) ){
-            prollyHashSetAdd(&visited, &commit.aParents[pi]);
-            syncQueuePush(&queue, &commit.aParents[pi]);
+            rc = prollyHashSetAdd(&visited, &commit.aParents[pi]);
+            if( rc!=SQLITE_OK ){
+              found = -1;
+              break;
+            }
+            rc = syncQueuePush(&queue, &commit.aParents[pi]);
+            if( rc!=SQLITE_OK ){
+              found = -1;
+              break;
+            }
           }
         }
         doltliteCommitClear(&commit);
       }
     }
     sqlite3_free(data);
+    if( found<0 ) break;
   }
 
   prollyHashSetFree(&visited);
@@ -447,49 +524,17 @@ int doltlitePush(
     int nRefsData = 0;
     rc = pRemote->xGetRefs(pRemote, &refsData, &nRefsData);
     if( rc==SQLITE_OK && refsData ){
-
-      ChunkStore tmpCs;
-      const u8 *p;
-      memset(&tmpCs, 0, sizeof(tmpCs));
-
-
-      p = refsData;
-      if( nRefsData >= 9 ){
-        u8 ver; int defLen;
-        ver = p[0]; p++;
-        defLen = (int)p[0]|((int)p[1]<<8)|((int)p[2]<<16)|((int)p[3]<<24); p += 4;
-        if( p + defLen + 4 <= refsData + nRefsData ){
-          int nBranches;
-          p += defLen;
-          nBranches = (int)p[0]|((int)p[1]<<8)|((int)p[2]<<16)|((int)p[3]<<24); p += 4;
-          for(i=0; i<nBranches; i++){
-            int nameLen;
-            if( p+4 > refsData+nRefsData ) break;
-            nameLen = (int)p[0]|((int)p[1]<<8)|((int)p[2]<<16)|((int)p[3]<<24); p += 4;
-            if( p+nameLen+PROLLY_HASH_SIZE > refsData+nRefsData ) break;
-            if( nameLen==(int)strlen(zBranch) && memcmp(p, zBranch, nameLen)==0 ){
-              memcpy(remoteCommit.data, p+nameLen, PROLLY_HASH_SIZE);
-              if( !prollyHashIsEmpty(&remoteCommit)
-                  && prollyHashCompare(&remoteCommit, &localCommit)!=0 ){
-
-                int isAnc = syncIsAncestor(pLocal, &remoteCommit, &localCommit);
-                if( isAnc <= 0 ){
-                  sqlite3_free(refsData);
-                  return SQLITE_ERROR;
-                }
-              }
-              break;
-            }
-            p += nameLen + PROLLY_HASH_SIZE;
-
-            if( p+PROLLY_HASH_SIZE <= refsData+nRefsData ){
-              p += PROLLY_HASH_SIZE;
-            }
-          }
+      rc = remoteFindBranchFromRefsBlob(refsData, nRefsData, zBranch, &remoteCommit);
+      if( rc==SQLITE_OK && !prollyHashIsEmpty(&remoteCommit)
+          && prollyHashCompare(&remoteCommit, &localCommit)!=0 ){
+        int isAnc = syncIsAncestor(pLocal, &remoteCommit, &localCommit);
+        if( isAnc <= 0 ){
+          sqlite3_free(refsData);
+          return isAnc<0 ? SQLITE_NOMEM : SQLITE_ERROR;
         }
       }
       sqlite3_free(refsData);
-      (void)tmpCs;
+      if( rc!=SQLITE_OK && rc!=SQLITE_NOTFOUND ) return rc;
     }else if( rc==SQLITE_NOTFOUND ){
       rc = SQLITE_OK; 
     }
@@ -576,33 +621,12 @@ int doltliteFetch(
   if( rc!=SQLITE_OK ) return rc;
 
   
-  if( nRefsData >= 9 ){
-    const u8 *p = refsData;
-    u8 ver; int defLen;
-    ver = p[0]; p++;
-    defLen = (int)p[0]|((int)p[1]<<8)|((int)p[2]<<16)|((int)p[3]<<24); p += 4;
-    if( p + defLen + 4 <= refsData + nRefsData ){
-      int nBranches, i;
-      p += defLen;
-      nBranches = (int)p[0]|((int)p[1]<<8)|((int)p[2]<<16)|((int)p[3]<<24); p += 4;
-      for(i=0; i<nBranches; i++){
-        int nameLen;
-        if( p+4 > refsData+nRefsData ) break;
-        nameLen = (int)p[0]|((int)p[1]<<8)|((int)p[2]<<16)|((int)p[3]<<24); p += 4;
-        if( p+nameLen+PROLLY_HASH_SIZE > refsData+nRefsData ) break;
-        if( nameLen==(int)strlen(zBranch) && memcmp(p, zBranch, nameLen)==0 ){
-          memcpy(remoteCommit.data, p+nameLen, PROLLY_HASH_SIZE);
-          found = 1;
-        }
-        p += nameLen + PROLLY_HASH_SIZE;
-        if( p+PROLLY_HASH_SIZE <= refsData+nRefsData ){
-          p += PROLLY_HASH_SIZE;
-        }
-        if( found ) break;
-      }
-    }
-  }
+  rc = remoteFindBranchFromRefsBlob(refsData, nRefsData, zBranch, &remoteCommit);
   sqlite3_free(refsData);
+  if( rc!=SQLITE_OK ){
+    return rc==SQLITE_NOTFOUND ? SQLITE_NOTFOUND : rc;
+  }
+  found = !prollyHashIsEmpty(&remoteCommit);
 
   if( !found || prollyHashIsEmpty(&remoteCommit) ){
     return SQLITE_NOTFOUND; 
@@ -633,7 +657,6 @@ int doltliteClone(ChunkStore *pLocal, DoltliteRemote *pRemote){
   int nRefsData = 0;
   ProllyHash *aRoots = 0;
   int nRoots = 0;
-  int nRootsAlloc = 0;
   DoltliteRemote *pLocalDst = 0;
   int rc;
 
@@ -642,60 +665,10 @@ int doltliteClone(ChunkStore *pLocal, DoltliteRemote *pRemote){
   if( rc!=SQLITE_OK ) return rc;
 
   
-  if( nRefsData >= 9 ){
-    const u8 *p = refsData;
-    u8 ver; int defLen;
-    ver = p[0]; p++;
-    defLen = (int)p[0]|((int)p[1]<<8)|((int)p[2]<<16)|((int)p[3]<<24); p += 4;
-    if( p + defLen + 4 <= refsData + nRefsData ){
-      int nBranches, nTags, i;
-      p += defLen;
-      nBranches = (int)p[0]|((int)p[1]<<8)|((int)p[2]<<16)|((int)p[3]<<24); p += 4;
-
-      nRootsAlloc = nBranches + 16;
-      aRoots = sqlite3_malloc(nRootsAlloc * sizeof(ProllyHash));
-      if( !aRoots ){
-        sqlite3_free(refsData);
-        return SQLITE_NOMEM;
-      }
-
-      for(i=0; i<nBranches; i++){
-        int nameLen;
-        if( p+4 > refsData+nRefsData ) break;
-        nameLen = (int)p[0]|((int)p[1]<<8)|((int)p[2]<<16)|((int)p[3]<<24); p += 4;
-        if( p+nameLen+PROLLY_HASH_SIZE > refsData+nRefsData ) break;
-        p += nameLen;
-
-        memcpy(aRoots[nRoots].data, p, PROLLY_HASH_SIZE);
-        if( !prollyHashIsEmpty(&aRoots[nRoots]) ) nRoots++;
-        p += PROLLY_HASH_SIZE;
-
-        p += PROLLY_HASH_SIZE; /* skip workingSetHash */
-      }
-
-
-      if( p+4 <= refsData+nRefsData ){
-        nTags = (int)p[0]|((int)p[1]<<8)|((int)p[2]<<16)|((int)p[3]<<24); p += 4;
-        if( nRoots + nTags > nRootsAlloc ){
-          nRootsAlloc = nRoots + nTags + 8;
-          aRoots = sqlite3_realloc(aRoots, nRootsAlloc * sizeof(ProllyHash));
-          if( !aRoots ){
-            sqlite3_free(refsData);
-            return SQLITE_NOMEM;
-          }
-        }
-        for(i=0; i<nTags; i++){
-          int nameLen;
-          if( p+4 > refsData+nRefsData ) break;
-          nameLen = (int)p[0]|((int)p[1]<<8)|((int)p[2]<<16)|((int)p[3]<<24); p += 4;
-          if( p+nameLen+PROLLY_HASH_SIZE > refsData+nRefsData ) break;
-          p += nameLen;
-          memcpy(aRoots[nRoots].data, p, PROLLY_HASH_SIZE);
-          if( !prollyHashIsEmpty(&aRoots[nRoots]) ) nRoots++;
-          p += PROLLY_HASH_SIZE;
-        }
-      }
-    }
+  rc = remoteCollectRootsFromRefsBlob(refsData, nRefsData, &aRoots, &nRoots);
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(refsData);
+    return rc;
   }
 
   if( nRoots == 0 ){

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -665,18 +665,22 @@ static void run_status_error_propagation(void){
 static void run_remote_refs_corruption(void){
   sqlite3 *srcDb = 0;
   sqlite3 *localDb = 0;
+  sqlite3 *cloneDb = 0;
   ChunkStore cs;
   ProllyHash badRefsHash;
   u8 badBlob[] = { 5, 0, 0, 0, 0, 1, 0, 0 };
   char remotePath[256];
   char localPath[256];
+  char clonePath[256];
   int rc;
 
   printf("=== Remote Refs Corruption Test ===\n\n");
   make_dbpath(remotePath, sizeof(remotePath), "test_remote_refs_corruption_remote");
   make_dbpath(localPath, sizeof(localPath), "test_remote_refs_corruption_local");
+  make_dbpath(clonePath, sizeof(clonePath), "test_remote_refs_corruption_clone");
   remove_db(remotePath);
   remove_db(localPath);
+  remove_db(clonePath);
 
   check("open_remote_db", open_db(remotePath, &srcDb)==SQLITE_OK);
   check("setup_remote_repo", execsql(srcDb,
@@ -710,9 +714,22 @@ static void run_remote_refs_corruption(void){
   rc = execsql_silent(localDb, "SELECT dolt_fetch('origin');");
   check("fetch_surfaces_corrupt_refs", rc!=SQLITE_OK);
 
+  rc = execsql_silent(localDb, "SELECT dolt_push('origin','main');");
+  check("push_surfaces_corrupt_refs", rc!=SQLITE_OK);
+
+  check("open_clone_db", open_db(clonePath, &cloneDb)==SQLITE_OK);
+  if( cloneDb ){
+    char sql[1024];
+    snprintf(sql, sizeof(sql), "SELECT dolt_clone('file://%s')", remotePath);
+    rc = execsql_silent(cloneDb, sql);
+    check("clone_surfaces_corrupt_refs", rc!=SQLITE_OK);
+  }
+
+  sqlite3_close(cloneDb);
   sqlite3_close(localDb);
   remove_db(remotePath);
   remove_db(localPath);
+  remove_db(clonePath);
 }
 
 static void run_chunk_walk_corruption(void){


### PR DESCRIPTION
This fixes the latest remote/storage review findings.

- replace duplicated manual remote refs parsing in push/fetch/clone with the shared refs loader
- treat corrupt or truncated remote refs as hard errors instead of missing branches
- propagate queue / visited-set failures in syncIsAncestor()
- return module registration failures from doltliteForEachUserTable()
- fix parseRecordFields() realloc OOM handling
- add corrupt-remote-refs regressions covering fetch, push, and clone

Verified:
- `cd build && make -j4 doltlite`
- `cd build && bash ../test/doltlite_regression_test_c.sh remote_refs_corruption`
- `cd build && bash ../test/remote_test.sh ./doltlite`