### PR TITLE
Harden remote SQL wrappers and branch metadata

### DIFF
--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -547,30 +547,38 @@ static int brEof(sqlite3_vtab_cursor *c){
 ** versioned record containing the staged catalog hash; the branch is
 ** dirty when that staged catalog differs from HEAD's catalog.
 */
-static int brIsDirty(sqlite3 *db, ChunkStore *cs, struct BranchRef *br){
+static int brIsDirty(
+  sqlite3 *db,
+  ChunkStore *cs,
+  struct BranchRef *br,
+  int *pDirty
+){
   ProllyHash stagedCat;
   ProllyHash commitCat;
   u8 *wsData = 0;
   int nWsData = 0;
-  int rc, dirty = 0;
+  int rc;
+
+  *pDirty = 0;
 
   if( strcmp(br->zName, doltliteGetSessionBranch(db))==0 ){
-    return doltliteHasUncommittedChanges(db) ? 1 : 0;
+    *pDirty = doltliteHasUncommittedChanges(db) ? 1 : 0;
+    return SQLITE_OK;
   }
   if( prollyHashIsEmpty(&br->workingSetHash) ){
-    return 0;
+    return SQLITE_OK;
   }
 
   rc = chunkStoreGet(cs, &br->workingSetHash, &wsData, &nWsData);
   if( rc!=SQLITE_OK || !wsData || nWsData < WS_TOTAL_SIZE ){
     sqlite3_free(wsData);
-    return 0;
+    return rc==SQLITE_OK ? SQLITE_CORRUPT : rc;
   }
   memcpy(stagedCat.data, wsData + WS_STAGED_OFF, PROLLY_HASH_SIZE);
   sqlite3_free(wsData);
 
   if( prollyHashIsEmpty(&stagedCat) ){
-    return 0;
+    return SQLITE_OK;
   }
 
   {
@@ -579,11 +587,11 @@ static int brIsDirty(sqlite3 *db, ChunkStore *cs, struct BranchRef *br){
     rc = doltliteLoadCommit(db, &br->commitHash, &c);
     if( rc==SQLITE_OK ){
       memcpy(commitCat.data, c.catalogHash.data, PROLLY_HASH_SIZE);
-      dirty = prollyHashCompare(&stagedCat, &commitCat)!=0;
+      *pDirty = prollyHashCompare(&stagedCat, &commitCat)!=0;
     }
     doltliteCommitClear(&c);
   }
-  return dirty;
+  return rc;
 }
 
 static int brColumn(sqlite3_vtab_cursor *c, sqlite3_context *ctx, int col){
@@ -609,9 +617,16 @@ static int brColumn(sqlite3_vtab_cursor *c, sqlite3_context *ctx, int col){
       ** without an upstream configured). */
       sqlite3_result_text(ctx, "", -1, SQLITE_STATIC);
       return SQLITE_OK;
-    case 8:
-      sqlite3_result_int(ctx, brIsDirty(v->db, cs, br));
+    case 8: {
+      int dirty = 0;
+      int rc = brIsDirty(v->db, cs, br, &dirty);
+      if( rc!=SQLITE_OK ){
+        sqlite3_result_error_code(ctx, rc);
+        return rc;
+      }
+      sqlite3_result_int(ctx, dirty);
       return SQLITE_OK;
+    }
   }
 
   /* Columns 2-5 require the head commit. Load once. */
@@ -621,9 +636,9 @@ static int brColumn(sqlite3_vtab_cursor *c, sqlite3_context *ctx, int col){
     memset(&cm, 0, sizeof(cm));
     rc = doltliteLoadCommit(v->db, &br->commitHash, &cm);
     if( rc!=SQLITE_OK ){
-      sqlite3_result_null(ctx);
+      sqlite3_result_error_code(ctx, rc);
       doltliteCommitClear(&cm);
-      return SQLITE_OK;
+      return rc;
     }
     switch(col){
       case 2:

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -108,6 +108,19 @@ static DoltliteRemote *openRemoteByUrl(sqlite3_vfs *pVfs, const char *zUrl){
   return 0;
 }
 
+static void remoteSqlResultError(
+  sqlite3_context *ctx,
+  int rc,
+  const char *zMsg
+){
+  if( zMsg ){
+    sqlite3_result_error(ctx, zMsg, -1);
+    sqlite3_result_error_code(ctx, rc);
+  }else{
+    sqlite3_result_error_code(ctx, rc);
+  }
+}
+
 static void freeNameList(char **azNames, int nNames);
 
 static void doltRemoteFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
@@ -208,7 +221,8 @@ static void doltPushFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   pRemote->xClose(pRemote);
 
   if( rc!=SQLITE_OK ){
-    sqlite3_result_error(ctx, "push failed (not a fast-forward?)", -1);
+    remoteSqlResultError(ctx, rc,
+      rc==SQLITE_ERROR ? "push failed (not a fast-forward?)" : 0);
     return;
   }
   sqlite3_result_int(ctx, 0);
@@ -222,72 +236,47 @@ static int parseRemoteBranchNames(
   u8 *refsData = 0;
   int nRefsData = 0;
   int rc;
+  ChunkStore refsView;
   char **azNames = 0;
   int nNames = 0;
+  int i;
 
   *pazNames = 0;
   *pnNames = 0;
 
   rc = pRemote->xGetRefs(pRemote, &refsData, &nRefsData);
   if( rc!=SQLITE_OK ) return rc;
-  if( !refsData || nRefsData < 9 ){
+  if( !refsData || nRefsData <= 0 ){
     sqlite3_free(refsData);
     return SQLITE_CORRUPT;
   }
 
-  {
-    const u8 *p = refsData;
-    u8 ver; int defLen;
-    ver = p[0]; p++;
-    if( ver!=5 ){
-      sqlite3_free(refsData);
-      return SQLITE_CORRUPT;
-    }
-    defLen = (int)p[0]|((int)p[1]<<8)|((int)p[2]<<16)|((int)p[3]<<24); p += 4;
-    if( p + defLen + 4 > refsData + nRefsData ){
-      sqlite3_free(refsData);
-      return SQLITE_CORRUPT;
-    }
-    {
-      int nBranches, i;
-      p += defLen;
-      nBranches = (int)p[0]|((int)p[1]<<8)|((int)p[2]<<16)|((int)p[3]<<24); p += 4;
-
-      azNames = sqlite3_malloc(nBranches * sizeof(char*));
-      if( !azNames ){
-        sqlite3_free(refsData);
-        return SQLITE_NOMEM;
-      }
-      memset(azNames, 0, nBranches * sizeof(char*));
-
-      for(i=0; i<nBranches; i++){
-        int nameLen;
-        if( p+4 > refsData+nRefsData ){
-          freeNameList(azNames, nNames);
-          sqlite3_free(refsData);
-          return SQLITE_CORRUPT;
-        }
-        nameLen = (int)p[0]|((int)p[1]<<8)|((int)p[2]<<16)|((int)p[3]<<24); p += 4;
-        if( p+nameLen+(PROLLY_HASH_SIZE*2) > refsData+nRefsData ){
-          freeNameList(azNames, nNames);
-          sqlite3_free(refsData);
-          return SQLITE_CORRUPT;
-        }
-        azNames[nNames] = sqlite3_malloc(nameLen+1);
-        if( !azNames[nNames] ){
-          freeNameList(azNames, nNames);
-          sqlite3_free(refsData);
-          return SQLITE_NOMEM;
-        }
-        memcpy(azNames[nNames], p, nameLen);
-        azNames[nNames][nameLen] = 0;
-        nNames++;
-        p += nameLen + (PROLLY_HASH_SIZE*2);
-      }
-    }
+  memset(&refsView, 0, sizeof(refsView));
+  rc = chunkStoreLoadRefsFromBlob(&refsView, refsData, nRefsData);
+  sqlite3_free(refsData);
+  if( rc!=SQLITE_OK ){
+    chunkStoreClose(&refsView);
+    return rc;
   }
 
-  sqlite3_free(refsData);
+  if( refsView.nBranches>0 ){
+    azNames = sqlite3_malloc(refsView.nBranches * sizeof(char*));
+    if( !azNames ){
+      chunkStoreClose(&refsView);
+      return SQLITE_NOMEM;
+    }
+    memset(azNames, 0, refsView.nBranches * sizeof(char*));
+    for(i=0; i<refsView.nBranches; i++){
+      azNames[nNames] = sqlite3_mprintf("%s", refsView.aBranches[i].zName);
+      if( !azNames[nNames] ){
+        freeNameList(azNames, nNames);
+        chunkStoreClose(&refsView);
+        return SQLITE_NOMEM;
+      }
+      nNames++;
+    }
+  }
+  chunkStoreClose(&refsView);
   *pazNames = azNames;
   *pnNames = nNames;
   return SQLITE_OK;
@@ -342,7 +331,8 @@ static void doltFetchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     rc = doltliteFetch(cs, pRemote, zRemoteName, zBranch);
     if( rc!=SQLITE_OK ){
       pRemote->xClose(pRemote);
-      sqlite3_result_error(ctx, "fetch failed: branch not found on remote", -1);
+      remoteSqlResultError(ctx, rc,
+        rc==SQLITE_NOTFOUND ? "fetch failed: branch not found on remote" : 0);
       return;
     }
   }else{
@@ -371,9 +361,9 @@ static void doltFetchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
       }
       rc = doltliteFetch(cs, pBrRemote, zRemoteName, azNames[i]);
       pBrRemote->xClose(pBrRemote);
-      if( rc!=SQLITE_OK && rc!=SQLITE_NOTFOUND ){
+      if( rc!=SQLITE_OK ){
         freeNameList(azNames, nNames);
-        sqlite3_result_error(ctx, "fetch failed", -1);
+        remoteSqlResultError(ctx, rc, "fetch failed");
         return;
       }
     }
@@ -418,12 +408,14 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   
   rc = chunkStoreFindRemote(cs, zRemoteName, &zUrl);
   if( rc!=SQLITE_OK || !zUrl ){
+    remoteSqlStateClear(&savedState);
     sqlite3_result_error(ctx, "remote not found", -1);
     return;
   }
 
   pRemote = openRemoteByUrl(cs->pVfs, zUrl);
   if( !pRemote ){
+    remoteSqlStateClear(&savedState);
     sqlite3_result_error(ctx, "failed to open remote (URL must start with file://)", -1);
     return;
   }
@@ -431,8 +423,14 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   rc = doltliteFetch(cs, pRemote, zRemoteName, zBranch);
   pRemote->xClose(pRemote);
   if( rc!=SQLITE_OK ){
+    rc = remoteSqlStateRestore(db, cs, &savedState);
     remoteSqlStateClear(&savedState);
-    sqlite3_result_error(ctx, "fetch failed: branch not found on remote", -1);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(ctx, rc);
+      return;
+    }
+    remoteSqlResultError(ctx, rc,
+      rc==SQLITE_NOTFOUND ? "fetch failed: branch not found on remote" : 0);
     return;
   }
 
@@ -479,10 +477,10 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     ProllyHash walk;
     int maxDepth = 1000;
     int canFF = 0;
+    int walkRc = SQLITE_OK;
     memcpy(&walk, &trackingCommit, sizeof(ProllyHash));
 
     while( maxDepth-- > 0 ){
-      u8 *data = 0; int nData = 0;
       DoltliteCommit commit;
 
       if( prollyHashCompare(&walk, &localCommit)==0 ){
@@ -491,11 +489,9 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
       }
       if( prollyHashIsEmpty(&walk) ) break;
 
-      rc = chunkStoreGet(cs, &walk, &data, &nData);
-      if( rc!=SQLITE_OK || !data ) break;
-      rc = doltliteCommitDeserialize(data, nData, &commit);
-      sqlite3_free(data);
-      if( rc!=SQLITE_OK ) break;
+      memset(&commit, 0, sizeof(commit));
+      walkRc = doltliteLoadCommit(db, &walk, &commit);
+      if( walkRc!=SQLITE_OK ) break;
 
       if( commit.nParents > 0 ){
         memcpy(&walk, &commit.aParents[0], sizeof(ProllyHash));
@@ -503,6 +499,17 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
         memset(&walk, 0, sizeof(ProllyHash));
       }
       doltliteCommitClear(&commit);
+    }
+
+    if( walkRc!=SQLITE_OK ){
+      int restoreRc = remoteSqlStateRestore(db, cs, &savedState);
+      remoteSqlStateClear(&savedState);
+      if( restoreRc!=SQLITE_OK ){
+        sqlite3_result_error_code(ctx, restoreRc);
+        return;
+      }
+      sqlite3_result_error_code(ctx, walkRc);
+      return;
     }
 
     if( !canFF ){
@@ -709,7 +716,17 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
 
     if( zDefault ){
       rc = chunkStoreFindBranch(cs, zDefault, &branchCommit);
-      if( rc==SQLITE_OK && !prollyHashIsEmpty(&branchCommit) ){
+      if( rc!=SQLITE_OK || prollyHashIsEmpty(&branchCommit) ){
+        rc = remoteSqlStateRestore(db, cs, &savedState);
+        remoteSqlStateClear(&savedState);
+        if( rc!=SQLITE_OK ){
+          sqlite3_result_error_code(ctx, rc);
+          return;
+        }
+        sqlite3_result_error(ctx, "default branch missing from cloned refs", -1);
+        return;
+      }
+      {
         
         u8 *data = 0; int nData = 0;
         DoltliteCommit commit;

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -423,24 +423,25 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   rc = doltliteFetch(cs, pRemote, zRemoteName, zBranch);
   pRemote->xClose(pRemote);
   if( rc!=SQLITE_OK ){
-    rc = remoteSqlStateRestore(db, cs, &savedState);
+    int restoreRc = remoteSqlStateRestore(db, cs, &savedState);
+    int opRc = rc;
     remoteSqlStateClear(&savedState);
-    if( rc!=SQLITE_OK ){
-      sqlite3_result_error_code(ctx, rc);
+    if( restoreRc!=SQLITE_OK ){
+      sqlite3_result_error_code(ctx, restoreRc);
       return;
     }
-    remoteSqlResultError(ctx, rc,
-      rc==SQLITE_NOTFOUND ? "fetch failed: branch not found on remote" : 0);
+    remoteSqlResultError(ctx, opRc,
+      opRc==SQLITE_NOTFOUND ? "fetch failed: branch not found on remote" : 0);
     return;
   }
 
   
   rc = chunkStoreFindTracking(cs, zRemoteName, zBranch, &trackingCommit);
   if( rc!=SQLITE_OK || prollyHashIsEmpty(&trackingCommit) ){
-    rc = remoteSqlStateRestore(db, cs, &savedState);
+    int restoreRc = remoteSqlStateRestore(db, cs, &savedState);
     remoteSqlStateClear(&savedState);
-    if( rc!=SQLITE_OK ){
-      sqlite3_result_error_code(ctx, rc);
+    if( restoreRc!=SQLITE_OK ){
+      sqlite3_result_error_code(ctx, restoreRc);
       return;
     }
     sqlite3_result_error(ctx, "tracking branch not found after fetch", -1);
@@ -453,10 +454,10 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     
     rc = chunkStoreAddBranch(cs, zBranch, &trackingCommit);
     if( rc!=SQLITE_OK ){
-      rc = remoteSqlStateRestore(db, cs, &savedState);
+      int restoreRc = remoteSqlStateRestore(db, cs, &savedState);
       remoteSqlStateClear(&savedState);
-      if( rc!=SQLITE_OK ){
-        sqlite3_result_error_code(ctx, rc);
+      if( restoreRc!=SQLITE_OK ){
+        sqlite3_result_error_code(ctx, restoreRc);
         return;
       }
       sqlite3_result_error(ctx, "failed to create local branch", -1);
@@ -513,10 +514,10 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     }
 
     if( !canFF ){
-      rc = remoteSqlStateRestore(db, cs, &savedState);
+      int restoreRc = remoteSqlStateRestore(db, cs, &savedState);
       remoteSqlStateClear(&savedState);
-      if( rc!=SQLITE_OK ){
-        sqlite3_result_error_code(ctx, rc);
+      if( restoreRc!=SQLITE_OK ){
+        sqlite3_result_error_code(ctx, restoreRc);
         return;
       }
       sqlite3_result_error(ctx,
@@ -528,10 +529,10 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   
   rc = chunkStoreUpdateBranch(cs, zBranch, &trackingCommit);
   if( rc!=SQLITE_OK ){
-    rc = remoteSqlStateRestore(db, cs, &savedState);
+    int restoreRc = remoteSqlStateRestore(db, cs, &savedState);
     remoteSqlStateClear(&savedState);
-    if( rc!=SQLITE_OK ){
-      sqlite3_result_error_code(ctx, rc);
+    if( restoreRc!=SQLITE_OK ){
+      sqlite3_result_error_code(ctx, restoreRc);
       return;
     }
     sqlite3_result_error(ctx, "failed to update branch", -1);
@@ -545,10 +546,10 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
 
     rc = chunkStoreGet(cs, &trackingCommit, &data, &nData);
     if( rc!=SQLITE_OK ){
-      rc = remoteSqlStateRestore(db, cs, &savedState);
+      int restoreRc = remoteSqlStateRestore(db, cs, &savedState);
       remoteSqlStateClear(&savedState);
-      if( rc!=SQLITE_OK ){
-        sqlite3_result_error_code(ctx, rc);
+      if( restoreRc!=SQLITE_OK ){
+        sqlite3_result_error_code(ctx, restoreRc);
         return;
       }
       sqlite3_result_error(ctx, "failed to load commit", -1);
@@ -557,10 +558,10 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     rc = doltliteCommitDeserialize(data, nData, &commit);
     sqlite3_free(data);
     if( rc!=SQLITE_OK ){
-      rc = remoteSqlStateRestore(db, cs, &savedState);
+      int restoreRc = remoteSqlStateRestore(db, cs, &savedState);
       remoteSqlStateClear(&savedState);
-      if( rc!=SQLITE_OK ){
-        sqlite3_result_error_code(ctx, rc);
+      if( restoreRc!=SQLITE_OK ){
+        sqlite3_result_error_code(ctx, restoreRc);
         return;
       }
       sqlite3_result_error(ctx, "failed to deserialize commit", -1);
@@ -570,11 +571,13 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     rc = doltliteHardReset(db, &commit.catalogHash);
     if( rc!=SQLITE_OK ){
       doltliteCommitClear(&commit);
-      rc = remoteSqlStateRestore(db, cs, &savedState);
-      remoteSqlStateClear(&savedState);
-      if( rc!=SQLITE_OK ){
-        sqlite3_result_error_code(ctx, rc);
-        return;
+      {
+        int restoreRc = remoteSqlStateRestore(db, cs, &savedState);
+        remoteSqlStateClear(&savedState);
+        if( restoreRc!=SQLITE_OK ){
+          sqlite3_result_error_code(ctx, restoreRc);
+          return;
+        }
       }
       sqlite3_result_error(ctx, "hard reset failed", -1);
       return;
@@ -589,13 +592,14 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   rc = chunkStoreSerializeRefs(cs);
   if( rc==SQLITE_OK ) rc = chunkStoreCommit(cs);
   if( rc!=SQLITE_OK ){
-    rc = remoteSqlStateRestore(db, cs, &savedState);
+    int restoreRc = remoteSqlStateRestore(db, cs, &savedState);
+    int opRc = rc;
     remoteSqlStateClear(&savedState);
-    if( rc!=SQLITE_OK ){
-      sqlite3_result_error_code(ctx, rc);
+    if( restoreRc!=SQLITE_OK ){
+      sqlite3_result_error_code(ctx, restoreRc);
       return;
     }
-    sqlite3_result_error_code(ctx, rc);
+    sqlite3_result_error_code(ctx, opRc);
     return;
   }
   remoteSqlStateClear(&savedState);
@@ -656,10 +660,10 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
 
   pRemote = openRemoteByUrl(cs->pVfs, zUrl);
   if( !pRemote ){
-    rc = remoteSqlStateRestore(db, cs, &savedState);
+    int restoreRc = remoteSqlStateRestore(db, cs, &savedState);
     remoteSqlStateClear(&savedState);
-    if( rc!=SQLITE_OK ){
-      sqlite3_result_error_code(ctx, rc);
+    if( restoreRc!=SQLITE_OK ){
+      sqlite3_result_error_code(ctx, restoreRc);
       return;
     }
     sqlite3_result_error(ctx, "failed to open remote (URL must start with file://)", -1);
@@ -669,10 +673,10 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   rc = doltliteClone(cs, pRemote);
   pRemote->xClose(pRemote);
   if( rc!=SQLITE_OK ){
-    rc = remoteSqlStateRestore(db, cs, &savedState);
+    int restoreRc = remoteSqlStateRestore(db, cs, &savedState);
     remoteSqlStateClear(&savedState);
-    if( rc!=SQLITE_OK ){
-      sqlite3_result_error_code(ctx, rc);
+    if( restoreRc!=SQLITE_OK ){
+      sqlite3_result_error_code(ctx, restoreRc);
       return;
     }
     sqlite3_result_error(ctx, "clone failed", -1);
@@ -682,10 +686,10 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   
   rc = chunkStoreAddRemote(cs, "origin", zUrl);
   if( rc!=SQLITE_OK ){
-    rc = remoteSqlStateRestore(db, cs, &savedState);
+    int restoreRc = remoteSqlStateRestore(db, cs, &savedState);
     remoteSqlStateClear(&savedState);
-    if( rc!=SQLITE_OK ){
-      sqlite3_result_error_code(ctx, rc);
+    if( restoreRc!=SQLITE_OK ){
+      sqlite3_result_error_code(ctx, restoreRc);
       return;
     }
     sqlite3_result_error(ctx, "failed to add origin remote", -1);
@@ -717,10 +721,10 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     if( zDefault ){
       rc = chunkStoreFindBranch(cs, zDefault, &branchCommit);
       if( rc!=SQLITE_OK || prollyHashIsEmpty(&branchCommit) ){
-        rc = remoteSqlStateRestore(db, cs, &savedState);
+        int restoreRc = remoteSqlStateRestore(db, cs, &savedState);
         remoteSqlStateClear(&savedState);
-        if( rc!=SQLITE_OK ){
-          sqlite3_result_error_code(ctx, rc);
+        if( restoreRc!=SQLITE_OK ){
+          sqlite3_result_error_code(ctx, restoreRc);
           return;
         }
         sqlite3_result_error(ctx, "default branch missing from cloned refs", -1);
@@ -734,11 +738,13 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
         rc = chunkStoreGet(cs, &branchCommit, &data, &nData);
         if( rc!=SQLITE_OK || !data ){
           if( data ) sqlite3_free(data);
-          rc = remoteSqlStateRestore(db, cs, &savedState);
-          remoteSqlStateClear(&savedState);
-          if( rc!=SQLITE_OK ){
-            sqlite3_result_error_code(ctx, rc);
-            return;
+          {
+            int restoreRc = remoteSqlStateRestore(db, cs, &savedState);
+            remoteSqlStateClear(&savedState);
+            if( restoreRc!=SQLITE_OK ){
+              sqlite3_result_error_code(ctx, restoreRc);
+              return;
+            }
           }
           sqlite3_result_error(ctx, "failed to load default branch commit", -1);
           return;
@@ -746,10 +752,10 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
         rc = doltliteCommitDeserialize(data, nData, &commit);
         sqlite3_free(data);
         if( rc!=SQLITE_OK ){
-          rc = remoteSqlStateRestore(db, cs, &savedState);
+          int restoreRc = remoteSqlStateRestore(db, cs, &savedState);
           remoteSqlStateClear(&savedState);
-          if( rc!=SQLITE_OK ){
-            sqlite3_result_error_code(ctx, rc);
+          if( restoreRc!=SQLITE_OK ){
+            sqlite3_result_error_code(ctx, restoreRc);
             return;
           }
           sqlite3_result_error(ctx, "failed to deserialize default branch commit", -1);
@@ -758,11 +764,13 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
         rc = doltliteHardReset(db, &commit.catalogHash);
         if( rc!=SQLITE_OK ){
           doltliteCommitClear(&commit);
-          rc = remoteSqlStateRestore(db, cs, &savedState);
-          remoteSqlStateClear(&savedState);
-          if( rc!=SQLITE_OK ){
-            sqlite3_result_error_code(ctx, rc);
-            return;
+          {
+            int restoreRc = remoteSqlStateRestore(db, cs, &savedState);
+            remoteSqlStateClear(&savedState);
+            if( restoreRc!=SQLITE_OK ){
+              sqlite3_result_error_code(ctx, restoreRc);
+              return;
+            }
           }
           sqlite3_result_error(ctx, "failed to initialize working tree from default branch", -1);
           return;
@@ -773,10 +781,10 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
         rc = chunkStoreSetDefaultBranch(cs, zDefault);
         doltliteCommitClear(&commit);
         if( rc!=SQLITE_OK ){
-          rc = remoteSqlStateRestore(db, cs, &savedState);
+          int restoreRc = remoteSqlStateRestore(db, cs, &savedState);
           remoteSqlStateClear(&savedState);
-          if( rc!=SQLITE_OK ){
-            sqlite3_result_error_code(ctx, rc);
+          if( restoreRc!=SQLITE_OK ){
+            sqlite3_result_error_code(ctx, restoreRc);
             return;
           }
           sqlite3_result_error(ctx, "failed to record default branch", -1);
@@ -790,13 +798,14 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   rc = chunkStoreSerializeRefs(cs);
   if( rc==SQLITE_OK ) rc = chunkStoreCommit(cs);
   if( rc!=SQLITE_OK ){
-    rc = remoteSqlStateRestore(db, cs, &savedState);
+    int restoreRc = remoteSqlStateRestore(db, cs, &savedState);
+    int opRc = rc;
     remoteSqlStateClear(&savedState);
-    if( rc!=SQLITE_OK ){
-      sqlite3_result_error_code(ctx, rc);
+    if( restoreRc!=SQLITE_OK ){
+      sqlite3_result_error_code(ctx, restoreRc);
       return;
     }
-    sqlite3_result_error_code(ctx, rc);
+    sqlite3_result_error_code(ctx, opRc);
     return;
   }
   remoteSqlStateClear(&savedState);

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -22,6 +22,7 @@
 **   ./doltlite_regression_test_c commit_parent_limit
 **   ./doltlite_regression_test_c merge_persist_failure
 **   ./doltlite_regression_test_c cherry_pick_stale_branch
+**   ./doltlite_regression_test_c branches_metadata_corruption
 */
 #include <stdio.h>
 #include <stdlib.h>
@@ -994,6 +995,67 @@ static void run_cherry_pick_stale_branch(void){
   remove_db(dbpath);
 }
 
+static void run_branches_metadata_corruption(void){
+  sqlite3 *db = 0;
+  ChunkStore cs;
+  char dbpath[256];
+  ProllyHash badHash;
+  int iFeature = -1;
+  int rc;
+
+  printf("=== Branches Metadata Corruption Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_branches_metadata_corruption");
+  remove_db(dbpath);
+
+  check("open_db", open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_repo", execsql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'a');"
+    "SELECT dolt_commit('-A', '-m', 'init');"
+    "SELECT dolt_branch('feature');"
+    "SELECT dolt_checkout('feature');"
+    "INSERT INTO t VALUES(2,'feat');"
+    "SELECT dolt_add('-A');"
+    "SELECT dolt_checkout('main');")==SQLITE_OK);
+  sqlite3_close(db);
+  db = 0;
+
+  memset(&badHash, 0x7c, sizeof(badHash));
+  memset(&cs, 0, sizeof(cs));
+  check("open_store", chunkStoreOpen(&cs, sqlite3_vfs_find(0), dbpath,
+        SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB)==SQLITE_OK);
+  check("lock_store", chunkStoreLockAndRefresh(&cs)==SQLITE_OK);
+  {
+    int i;
+    for(i=0; i<cs.nBranches; i++){
+      if( cs.aBranches[i].zName && strcmp(cs.aBranches[i].zName, "feature")==0 ){
+        iFeature = i;
+        break;
+      }
+    }
+  }
+  check("have_feature_branch", iFeature >= 0);
+  if( iFeature >= 0 ){
+    memcpy(&cs.aBranches[iFeature].commitHash, &badHash, sizeof(ProllyHash));
+    memcpy(&cs.aBranches[iFeature].workingSetHash, &badHash, sizeof(ProllyHash));
+  }
+  check("serialize_corrupt_branch_refs", chunkStoreSerializeRefs(&cs)==SQLITE_OK);
+  check("commit_corrupt_branch_refs", chunkStoreCommit(&cs)==SQLITE_OK);
+  chunkStoreUnlock(&cs);
+  chunkStoreClose(&cs);
+
+  check("reopen_db", open_db(dbpath, &db)==SQLITE_OK);
+  rc = execsql_silent(db,
+    "SELECT latest_commit_message FROM dolt_branches WHERE name='feature';");
+  check("branches_latest_commit_surfaces_corruption", rc!=SQLITE_OK);
+  rc = execsql_silent(db,
+    "SELECT dirty FROM dolt_branches WHERE name='feature';");
+  check("branches_dirty_surfaces_corruption", rc!=SQLITE_OK);
+
+  sqlite3_close(db);
+  remove_db(dbpath);
+}
+
 static const RegressionCase aCases[] = {
   { "concurrent_refs", "Concurrent Refs Test", run_concurrent_refs },
   { "checkout_persist_failure", "Checkout Persist Failure Test", run_checkout_persist_failure },
@@ -1010,7 +1072,8 @@ static const RegressionCase aCases[] = {
   { "resolve_ref_non_commit", "Resolve Ref Non-Commit Test", run_resolve_ref_non_commit },
   { "commit_parent_limit", "Commit Parent Limit Test", run_commit_parent_limit },
   { "merge_persist_failure", "Merge Persist Failure Test", run_merge_persist_failure },
-  { "cherry_pick_stale_branch", "Cherry-pick Stale Branch Test", run_cherry_pick_stale_branch }
+  { "cherry_pick_stale_branch", "Cherry-pick Stale Branch Test", run_cherry_pick_stale_branch },
+  { "branches_metadata_corruption", "Branches Metadata Corruption Test", run_branches_metadata_corruption }
 };
 
 static int run_case_by_name(const char *zName){


### PR DESCRIPTION
This fixes the latest review findings in the SQL remote wrappers and `dolt_branches`.

- replace SQL-side remote branch enumeration parsing with the shared refs loader
- stop flattening remote wrapper failures into misleading branch-not-found / fast-forward messages
- make `dolt_fetch(remote)` fail instead of silently partially succeeding when a fetched branch disappears
- make `dolt_pull()` surface reachable commit-load errors during fast-forward checks instead of reporting a fake non-fast-forward
- make `dolt_branches` surface working-set and commit metadata corruption instead of returning clean/null rows
- add regression coverage for `dolt_branches` metadata corruption in the shared C runner

Verified:
- `cd build && bash ../test/doltlite_regression_test_c.sh branches_metadata_corruption`
- `cd build && bash ../test/remote_test.sh ./doltlite`
- `cd build && bash ../test/doltlite_branch.sh`