### PR TITLE
Propagate table registration failures

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -26,8 +26,8 @@ extern int doltliteGcRegister(sqlite3 *db);
 extern void doltliteRegisterDiffTables(sqlite3 *db);
 extern int doltliteAncestorRegister(sqlite3 *db);
 extern int doltliteAtRegister(sqlite3 *db);
-extern void doltliteRegisterAtTables(sqlite3 *db);
-extern void doltliteRegisterHistoryTables(sqlite3 *db);
+extern int doltliteRegisterAtTables(sqlite3 *db);
+extern int doltliteRegisterHistoryTables(sqlite3 *db);
 extern int doltliteSchemaDiffRegister(sqlite3 *db);
 
 extern int doltliteFindAncestor(sqlite3 *db, const ProllyHash *h1,
@@ -763,8 +763,16 @@ static void doltliteCommitFunc(
 
   
   doltliteRegisterDiffTables(db);
-  doltliteRegisterHistoryTables(db);
-  doltliteRegisterAtTables(db);
+  rc = doltliteRegisterHistoryTables(db);
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error_code(context, rc);
+    return;
+  }
+  rc = doltliteRegisterAtTables(db);
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error_code(context, rc);
+    return;
+  }
 
   sqlite3_result_text(context, hexBuf, -1, SQLITE_TRANSIENT);
 }
@@ -1656,18 +1664,18 @@ void doltliteRegister(sqlite3 *db){
                           doltliteRevertFunc, 0, 0);
   sqlite3_create_function(db, "dolt_config", -1, SQLITE_UTF8, 0,
                           doltliteConfigFunc, 0, 0);
-  doltliteLogRegister(db);
-  doltliteStatusRegister(db);
-  doltliteDiffRegister(db);
-  doltliteBranchRegister(db);
-  doltliteTagRegister(db);
-  doltliteConflictsRegister(db);
-  doltliteGcRegister(db);
+  if( doltliteLogRegister(db)!=SQLITE_OK ) return;
+  if( doltliteStatusRegister(db)!=SQLITE_OK ) return;
+  if( doltliteDiffRegister(db)!=SQLITE_OK ) return;
+  if( doltliteBranchRegister(db)!=SQLITE_OK ) return;
+  if( doltliteTagRegister(db)!=SQLITE_OK ) return;
+  if( doltliteConflictsRegister(db)!=SQLITE_OK ) return;
+  if( doltliteGcRegister(db)!=SQLITE_OK ) return;
   doltliteRegisterDiffTables(db);
-  doltliteAncestorRegister(db);
-  doltliteAtRegister(db);
-  doltliteRegisterHistoryTables(db);
-  doltliteSchemaDiffRegister(db);
+  if( doltliteAncestorRegister(db)!=SQLITE_OK ) return;
+  if( doltliteAtRegister(db)!=SQLITE_OK ) return;
+  if( doltliteRegisterHistoryTables(db)!=SQLITE_OK ) return;
+  if( doltliteSchemaDiffRegister(db)!=SQLITE_OK ) return;
   {
     extern void doltliteRemoteSqlRegister(sqlite3 *db);
     doltliteRemoteSqlRegister(db);

--- a/src/doltlite_at.c
+++ b/src/doltlite_at.c
@@ -53,11 +53,13 @@ struct AtCursor {
   int nRows;
   int nAlloc;
   int iRow;
+  char *zCommitRef;
 };
 
 static void freeAtRows(AtCursor *c){
   int i; for(i=0;i<c->nRows;i++) sqlite3_free(c->aRows[i].pVal);
   sqlite3_free(c->aRows); c->aRows=0; c->nRows=0; c->nAlloc=0;
+  sqlite3_free(c->zCommitRef); c->zCommitRef=0;
 }
 
 
@@ -193,6 +195,8 @@ static int atFilter(sqlite3_vtab_cursor *cur,
 
   zRef=(const char*)sqlite3_value_text(argv[0]);
   if(!zRef) return SQLITE_OK;
+  c->zCommitRef = sqlite3_mprintf("%s", zRef);
+  if( !c->zCommitRef ) return SQLITE_NOMEM;
 
   rc=doltliteResolveRef(db,zRef,&commitHash);
   if(rc==SQLITE_NOTFOUND) return SQLITE_OK;
@@ -252,7 +256,10 @@ static int atColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
   AtRow *r=&c->aRows[c->iRow];
   int nCols=v->cols.nCol;
 
-  if(nCols>0 && col<nCols){
+  if( col==nCols ){
+    sqlite3_result_text(ctx, c->zCommitRef ? c->zCommitRef : "",
+                        -1, SQLITE_TRANSIENT);
+  }else if(nCols>0 && col<nCols){
     
     if(col==v->cols.iPkCol){
       sqlite3_result_int64(ctx,r->intKey);
@@ -278,15 +285,12 @@ static sqlite3_module atModule = {
   0,0,0,0,0,0,0,0,0,0,0,0
 };
 
-void doltliteRegisterAtTables(sqlite3 *db){
-  doltliteForEachUserTable(db, "dolt_at_", &atModule);
+int doltliteRegisterAtTables(sqlite3 *db){
+  return doltliteForEachUserTable(db, "dolt_at_", &atModule);
 }
 
 int doltliteAtRegister(sqlite3 *db){
-  
-  
-  doltliteRegisterAtTables(db);
-  return SQLITE_OK;
+  return doltliteRegisterAtTables(db);
 }
 
 #endif 

--- a/src/doltlite_history.c
+++ b/src/doltlite_history.c
@@ -319,8 +319,8 @@ static sqlite3_module historyModule = {
   0,0,0,0,0,0,0,0,0,0,0,0
 };
 
-void doltliteRegisterHistoryTables(sqlite3 *db){
-  doltliteForEachUserTable(db, "dolt_history_", &historyModule);
+int doltliteRegisterHistoryTables(sqlite3 *db){
+  return doltliteForEachUserTable(db, "dolt_history_", &historyModule);
 }
 
 #endif 

--- a/src/doltlite_ref.c
+++ b/src/doltlite_ref.c
@@ -99,9 +99,15 @@ int doltliteForEachUserTable(
   for(i=0; i<nTables; i++){
     if( aTables[i].zName && aTables[i].iTable > 1 ){
       char *zMod = sqlite3_mprintf("%s%s", zPrefix, aTables[i].zName);
-      if( zMod ){
-        sqlite3_create_module(db, zMod, pModule, 0);
-        sqlite3_free(zMod);
+      if( !zMod ){
+        sqlite3_free(aTables);
+        return SQLITE_NOMEM;
+      }
+      rc = sqlite3_create_module(db, zMod, pModule, 0);
+      sqlite3_free(zMod);
+      if( rc!=SQLITE_OK ){
+        sqlite3_free(aTables);
+        return rc;
       }
     }
   }

--- a/test/doltlite_at.sh
+++ b/test/doltlite_at.sh
@@ -38,6 +38,10 @@ run_test "basic_c3" \
   "SELECT count(*) FROM dolt_at_t( (SELECT commit_hash FROM dolt_log LIMIT 1));" \
   "3" "$DB"
 
+run_test "basic_commit_ref_hash" \
+  "SELECT commit_ref FROM dolt_at_t( (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1)) LIMIT 1;" \
+  "$(echo "SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1;" | $DOLTLITE "$DB" 2>/dev/null)" "$DB"
+
 rm -f "$DB"
 
 # ============================================================
@@ -103,6 +107,9 @@ run_test "branch_feat" "SELECT count(*) FROM dolt_at_t( 'feat');" "2" "$DB"
 
 # At branch 'main': rows 1,3
 run_test "branch_main" "SELECT count(*) FROM dolt_at_t( 'main');" "2" "$DB"
+
+run_test "branch_commit_ref_name" \
+  "SELECT commit_ref FROM dolt_at_t( 'feat') LIMIT 1;" "feat" "$DB"
 
 # Specific rowids per branch
 run_test "branch_feat_has2" \


### PR DESCRIPTION
## Summary
- propagate per-table module registration failures instead of silently succeeding
- make dolt_at_<table> expose its hidden commit_ref column value
- surface registration failures during commit-time and startup re-registration

## Testing
- cd build && bash ../test/doltlite_at.sh
- cd build && bash ../test/doltlite_history.sh