### PR TITLE
Tighten remote server and SQL wrapper errors

### DIFF
--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -158,7 +158,8 @@ static void doltRemoteFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
     m.zUrl = zUrl;
     rc = doltliteMutateRefs(db, mutateRemoteRef, &m);
     if( rc!=SQLITE_OK ){
-      sqlite3_result_error(ctx, "remote already exists or error", -1);
+      remoteSqlResultError(ctx, rc,
+        rc==SQLITE_ERROR ? "remote already exists" : 0);
       return;
     }
   }else if( strcmp(zAction, "remove")==0 ){
@@ -166,7 +167,8 @@ static void doltRemoteFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
     m.isDelete = 1;
     rc = doltliteMutateRefs(db, mutateRemoteRef, &m);
     if( rc!=SQLITE_OK ){
-      sqlite3_result_error(ctx, "remote not found", -1);
+      remoteSqlResultError(ctx, rc,
+        rc==SQLITE_NOTFOUND ? "remote not found" : 0);
       return;
     }
   }else{
@@ -257,6 +259,10 @@ static int parseRemoteBranchNames(
   if( rc!=SQLITE_OK ){
     chunkStoreClose(&refsView);
     return rc;
+  }
+  if( refsView.nBranches > nRefsData / 44 ){
+    chunkStoreClose(&refsView);
+    return SQLITE_CORRUPT;
   }
 
   if( refsView.nBranches>0 ){

--- a/src/doltlite_remotesrv.c
+++ b/src/doltlite_remotesrv.c
@@ -445,15 +445,35 @@ static void handleCommit(ChunkStore *pStore, int fd){
     ProllyHash branchCommit;
     if( zDef && chunkStoreFindBranch(pStore, zDef, &branchCommit)==SQLITE_OK ){
       u8 *cdata = 0; int ncdata = 0;
-      if( chunkStoreGet(pStore, &branchCommit, &cdata, &ncdata)==SQLITE_OK && cdata ){
+      rc = chunkStoreGet(pStore, &branchCommit, &cdata, &ncdata);
+      if( rc!=SQLITE_OK ){
+        if( cdata ) sqlite3_free(cdata);
+        sendError(fd);
+        return;
+      }
+      if( cdata ){
         DoltliteCommit commit;
-        if( doltliteCommitDeserialize(cdata, ncdata, &commit)==SQLITE_OK ){
-          chunkStoreWriteBranchWorkingCatalog(pStore, zDef, &commit.catalogHash, NULL);
-          doltliteCommitClear(&commit);
+        rc = doltliteCommitDeserialize(cdata, ncdata, &commit);
+        if( rc!=SQLITE_OK ){
+          sqlite3_free(cdata);
+          sendError(fd);
+          return;
+        }
+        rc = chunkStoreWriteBranchWorkingCatalog(pStore, zDef,
+                                                 &commit.catalogHash, NULL);
+        doltliteCommitClear(&commit);
+        if( rc!=SQLITE_OK ){
+          sqlite3_free(cdata);
+          sendError(fd);
+          return;
         }
         sqlite3_free(cdata);
       }
-      chunkStoreCommit(pStore);  
+      rc = chunkStoreCommit(pStore);
+      if( rc!=SQLITE_OK ){
+        sendError(fd);
+        return;
+      }
     }
   }
 

--- a/test/remote_test.sh
+++ b/test/remote_test.sh
@@ -239,6 +239,12 @@ check "push to unknown remote errors" "1" "$(echo "$result" | grep -c 'remote no
 result=$("$DB" "$TMPDIR/src.db" "SELECT dolt_push('origin','nonexistent');" 2>&1)
 check "push unknown branch errors" "1" "$(echo "$result" | grep -c 'push failed')"
 
+result=$("$DB" "$TMPDIR/src.db" "SELECT dolt_remote('add','origin','$R/duplicate.db');" 2>&1)
+check "duplicate remote add errors" "1" "$(echo "$result" | grep -c 'remote already exists')"
+
+result=$("$DB" "$TMPDIR/src.db" "SELECT dolt_remote('remove','missing_remote');" 2>&1)
+check "missing remote remove errors" "1" "$(echo "$result" | grep -c 'remote not found')"
+
 # clone into a db that already has data errors
 result=$("$DB" "$TMPDIR/src.db" "SELECT dolt_clone('$R/remote.db');" 2>&1)
 check "clone into non-empty errors" "1" "$(echo "$result" | grep -c 'not empty')"


### PR DESCRIPTION
## Summary
- make the HTTP remote server fail requests when the post-refs working-set update fails
- preserve real add/remove remote error codes and tighten SQL remote branch-list handling
- add remote wrapper regression coverage for duplicate add and missing remove

## Testing
- make -C build -j4 doltlite
- cd build && bash ../test/remote_test.sh ./doltlite
- cd build && bash ../test/doltlite_regression_test_c.sh remote_refs_corruption

## Notes
- the HTTP suites covering the changed paths passed, but `test/http_remote_test.sh` still has two existing deep-history count expectation failures (`16 commits` vs actual `17`) unrelated to this patch
