### PR TITLE
Harden gc, record decoding, and tag author parsing

### DIFF
--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -270,6 +270,7 @@ static int gcRewriteFile(
   i64 indexOffset = CHUNK_MANIFEST_SIZE + nNewData;
   u8 *indexBuf = 0;
   u8 manifest[CHUNK_MANIFEST_SIZE];
+  ChunkStore manifestCs;
   int rc = SQLITE_OK;
 
   
@@ -294,13 +295,13 @@ static int gcRewriteFile(
     }
   }
 
-  
-  cs->nChunks = nNewIndex;
-  cs->iIndexOffset = indexOffset;
-  cs->nIndexSize = indexSize;
-  cs->iWalOffset = indexOffset + indexSize;
+  manifestCs = *cs;
+  manifestCs.nChunks = nNewIndex;
+  manifestCs.iIndexOffset = indexOffset;
+  manifestCs.nIndexSize = indexSize;
+  manifestCs.iWalOffset = indexOffset + indexSize;
 
-  csSerializeManifest(cs, manifest);
+  csSerializeManifest(&manifestCs, manifest);
 
   
   if( cs->zFilename && strcmp(cs->zFilename, ":memory:")!=0 ){

--- a/src/doltlite_log.c
+++ b/src/doltlite_log.c
@@ -1,4 +1,4 @@
-/* dolt_log: BFS traversal of all reachable commits, sorted by timestamp desc.
+/* dolt_log: BFS traversal of all reachable commits.
 ** Follows ALL parents (not just the first), deduplicating by commit hash. */
 #ifdef DOLTLITE_PROLLY
 

--- a/src/doltlite_record.c
+++ b/src/doltlite_record.c
@@ -6,23 +6,6 @@
 #include <string.h>
 #include <stdio.h>
 
-static int recReadVarint(const u8 *p, const u8 *pEnd, u64 *pVal){
-  u64 v = 0;
-  int i;
-  for(i=0; i<9 && p+i<pEnd; i++){
-    if( i<8 ){
-      v = (v << 7) | (p[i] & 0x7f);
-      if( (p[i] & 0x80)==0 ){ *pVal = v; return i+1; }
-    }else{
-      v = (v << 8) | p[i];
-      *pVal = v;
-      return 9;
-    }
-  }
-  *pVal = v;
-  return i ? i : 1;
-}
-
 static i64 recReadInt(const u8 *p, int nBytes){
   i64 v;
   int i;
@@ -41,18 +24,21 @@ struct RecBuf {
   int nAlloc;
 };
 
-static void recBufAppend(RecBuf *b, const char *z, int n){
+static int recBufAppend(RecBuf *b, const char *z, int n){
+  char *zNew;
   if( n<0 ) n = (int)strlen(z);
   if( b->n + n + 1 > b->nAlloc ){
     int nNew = b->nAlloc ? b->nAlloc*2 : 128;
     while( nNew < b->n + n + 1 ) nNew *= 2;
-    b->z = sqlite3_realloc(b->z, nNew);
-    if( !b->z ){ b->nAlloc = 0; return; }
+    zNew = sqlite3_realloc(b->z, nNew);
+    if( !zNew ) return SQLITE_NOMEM;
+    b->z = zNew;
     b->nAlloc = nNew;
   }
   memcpy(b->z + b->n, z, n);
   b->n += n;
   b->z[b->n] = 0;
+  return SQLITE_OK;
 }
 
 char *doltliteDecodeRecord(const u8 *pData, int nData){
@@ -64,82 +50,84 @@ char *doltliteDecodeRecord(const u8 *pData, int nData){
   const u8 *pBody;
   RecBuf buf;
   int fieldIdx = 0;
+  int rc = SQLITE_OK;
 
   if( !pData || nData < 1 ) return 0;
 
   memset(&buf, 0, sizeof(buf));
 
-  
-  hdrBytes = recReadVarint(p, pEnd, &hdrSize);
+  hdrBytes = dlReadVarint(p, pEnd, &hdrSize);
+  if( hdrBytes<=0 ) return 0;
   p += hdrBytes;
+  if( hdrSize<(u64)hdrBytes || hdrSize>(u64)nData ) return 0;
   pHdrEnd = pData + hdrSize;
   pBody = pData + hdrSize;
 
-  
-  while( p < pHdrEnd && p < pEnd ){
+  while( rc==SQLITE_OK && p < pHdrEnd && p < pEnd ){
     u64 st;
-    int stBytes = recReadVarint(p, pHdrEnd, &st);
+    int stBytes = dlReadVarint(p, pHdrEnd, &st);
+    if( stBytes<=0 ) rc = SQLITE_CORRUPT;
+    if( rc!=SQLITE_OK ) break;
     p += stBytes;
 
-    if( fieldIdx > 0 ) recBufAppend(&buf, "|", 1);
+    if( fieldIdx > 0 ){
+      rc = recBufAppend(&buf, "|", 1);
+      if( rc!=SQLITE_OK ) break;
+    }
 
     if( st==0 ){
-      
-      recBufAppend(&buf, "NULL", 4);
+      rc = recBufAppend(&buf, "NULL", 4);
     }else if( st==8 ){
-      recBufAppend(&buf, "0", 1);
+      rc = recBufAppend(&buf, "0", 1);
     }else if( st==9 ){
-      recBufAppend(&buf, "1", 1);
+      rc = recBufAppend(&buf, "1", 1);
     }else if( st>=1 && st<=6 ){
-      
       static const int sizes[] = {0,1,2,3,4,6,8};
       int nBytes = sizes[st];
-      if( pBody + nBytes <= pEnd ){
-        i64 v = recReadInt(pBody, nBytes);
-        char tmp[32];
-        sqlite3_snprintf(sizeof(tmp), tmp, "%lld", v);
-        recBufAppend(&buf, tmp, -1);
-      }
+      char tmp[32];
+      if( pBody + nBytes > pEnd ){ rc = SQLITE_CORRUPT; break; }
+      sqlite3_snprintf(sizeof(tmp), tmp, "%lld", recReadInt(pBody, nBytes));
+      rc = recBufAppend(&buf, tmp, -1);
       pBody += nBytes;
     }else if( st==7 ){
-
-      if( pBody + 8 <= pEnd ){
-        double v;
-        u64 bits = 0;
-        int i;
-        char tmp[64];
-        for(i=0; i<8; i++) bits = (bits<<8) | pBody[i];
-        memcpy(&v, &bits, 8);
-        sqlite3_snprintf(sizeof(tmp), tmp, "%!.15g", v);
-        recBufAppend(&buf, tmp, -1);
-      }
+      double v;
+      u64 bits = 0;
+      int i;
+      char tmp[64];
+      if( pBody + 8 > pEnd ){ rc = SQLITE_CORRUPT; break; }
+      for(i=0; i<8; i++) bits = (bits<<8) | pBody[i];
+      memcpy(&v, &bits, 8);
+      sqlite3_snprintf(sizeof(tmp), tmp, "%!.15g", v);
+      rc = recBufAppend(&buf, tmp, -1);
       pBody += 8;
     }else if( st>=12 && (st&1)==0 ){
-      
       int len = ((int)st - 12) / 2;
-      recBufAppend(&buf, "x'", 2);
-      if( pBody + len <= pEnd ){
-        int i;
-        for(i=0; i<len; i++){
-          char hex[3];
-          sqlite3_snprintf(3, hex, "%02x", pBody[i]);
-          recBufAppend(&buf, hex, 2);
-        }
+      int i;
+      if( len<0 || pBody + len > pEnd ){ rc = SQLITE_CORRUPT; break; }
+      rc = recBufAppend(&buf, "x'", 2);
+      for(i=0; rc==SQLITE_OK && i<len; i++){
+        char hex[3];
+        sqlite3_snprintf(3, hex, "%02x", pBody[i]);
+        rc = recBufAppend(&buf, hex, 2);
       }
-      recBufAppend(&buf, "'", 1);
+      if( rc==SQLITE_OK ) rc = recBufAppend(&buf, "'", 1);
       pBody += len;
     }else if( st>=13 && (st&1)==1 ){
-      
       int len = ((int)st - 13) / 2;
-      if( pBody + len <= pEnd ){
-        recBufAppend(&buf, (const char*)pBody, len);
-      }
+      if( len<0 || pBody + len > pEnd ){ rc = SQLITE_CORRUPT; break; }
+      rc = recBufAppend(&buf, (const char*)pBody, len);
       pBody += len;
+    }else{
+      rc = SQLITE_CORRUPT;
     }
 
     fieldIdx++;
   }
 
+  if( rc!=SQLITE_OK || p!=pHdrEnd ){
+    sqlite3_free(buf.z);
+    return 0;
+  }
   return buf.z;
 }
 
@@ -180,9 +168,12 @@ int doltliteGetColumnNames(sqlite3 *db, const char *zTable, DoltliteColInfo *ci)
   sqlite3_free(zSql);
   if( rc!=SQLITE_OK ) return rc;
 
-  
   nCol = 0;
-  while( sqlite3_step(pStmt)==SQLITE_ROW ) nCol++;
+  while( (rc = sqlite3_step(pStmt))==SQLITE_ROW ) nCol++;
+  if( rc!=SQLITE_DONE ){
+    sqlite3_finalize(pStmt);
+    return rc;
+  }
   sqlite3_reset(pStmt);
 
   ci->azName = sqlite3_malloc(nCol * (int)sizeof(char*));
@@ -190,7 +181,7 @@ int doltliteGetColumnNames(sqlite3 *db, const char *zTable, DoltliteColInfo *ci)
   memset(ci->azName, 0, nCol * (int)sizeof(char*));
   ci->nCol = 0;
 
-  while( sqlite3_step(pStmt)==SQLITE_ROW ){
+  while( (rc = sqlite3_step(pStmt))==SQLITE_ROW ){
     const char *zName = (const char*)sqlite3_column_text(pStmt, 1);
     int pk = sqlite3_column_int(pStmt, 5);
     const char *zType = (const char*)sqlite3_column_text(pStmt, 2);
@@ -201,7 +192,17 @@ int doltliteGetColumnNames(sqlite3 *db, const char *zTable, DoltliteColInfo *ci)
     }
 
     ci->azName[ci->nCol] = sqlite3_mprintf("%s", zName ? zName : "");
+    if( !ci->azName[ci->nCol] ){
+      doltliteFreeColInfo(ci);
+      sqlite3_finalize(pStmt);
+      return SQLITE_NOMEM;
+    }
     ci->nCol++;
+  }
+  if( rc!=SQLITE_DONE ){
+    doltliteFreeColInfo(ci);
+    sqlite3_finalize(pStmt);
+    return rc;
   }
 
   sqlite3_finalize(pStmt);

--- a/src/doltlite_tag.c
+++ b/src/doltlite_tag.c
@@ -136,6 +136,12 @@ static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
       zParsedTagger = sqlite3_mprintf("%s", zAuthor);
       zParsedEmail  = sqlite3_mprintf("");
     }
+    if( !zParsedTagger || !zParsedEmail ){
+      sqlite3_free(zParsedTagger);
+      sqlite3_free(zParsedEmail);
+      sqlite3_result_error_nomem(ctx);
+      return;
+    }
     m.zTagger = zParsedTagger;
     m.zEmail  = zParsedEmail;
   }else{

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -23,6 +23,8 @@
 **   ./doltlite_regression_test_c merge_persist_failure
 **   ./doltlite_regression_test_c cherry_pick_stale_branch
 **   ./doltlite_regression_test_c branches_metadata_corruption
+**   ./doltlite_regression_test_c gc_rewrite_failure
+**   ./doltlite_regression_test_c record_decode_corruption
 */
 #include <stdio.h>
 #include <stdlib.h>
@@ -35,6 +37,7 @@
 #include "doltlite_chunk_walk.h"
 #include "doltlite_ancestor.h"
 #include "doltlite_internal.h"
+#include "doltlite_record.h"
 
 typedef unsigned char u8;
 typedef unsigned int Pgno;
@@ -1073,6 +1076,60 @@ static void run_branches_metadata_corruption(void){
   remove_db(dbpath);
 }
 
+static void run_gc_rewrite_failure(void){
+  sqlite3 *db = 0;
+  sqlite3 *db2 = 0;
+  char dbpath[256];
+  const char *res;
+
+  printf("=== GC Rewrite Failure Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_gc_rewrite_failure");
+  remove_db(dbpath);
+
+  gFailSyncOnce = 0;
+  gFailHits = 0;
+  check("register_fail_vfs_for_gc", registerFailVfs()==SQLITE_OK);
+  check("open_fail_db", open_fail_db(dbpath, &db)==SQLITE_OK);
+  check("setup_gc_repo", execsql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'a');"
+    "SELECT dolt_commit('-A', '-m', 'init');"
+    "INSERT INTO t VALUES(2,'b');"
+    "SELECT dolt_commit('-A', '-m', 'second');")==SQLITE_OK);
+
+  gFailHits = 0;
+  gFailSyncOnce = 1;
+  res = exec1(db, "SELECT dolt_gc()");
+  check("gc_failure_was_injected", gFailHits>0);
+  check("gc_returns_error_on_rewrite_failure", strstr(res, "ERROR:")!=0);
+  check("gc_connection_still_reads_data",
+    strcmp(exec1(db, "SELECT count(*) FROM t"), "2")==0);
+  check("gc_connection_still_reads_log",
+    strcmp(exec1(db, "SELECT count(*) FROM dolt_log"), "3")==0);
+
+  sqlite3_close(db);
+  check("reopen_db_after_gc_failure", open_db(dbpath, &db2)==SQLITE_OK);
+  check("gc_reopen_reads_data",
+    strcmp(exec1(db2, "SELECT count(*) FROM t"), "2")==0);
+  check("gc_reopen_reads_log",
+    strcmp(exec1(db2, "SELECT count(*) FROM dolt_log"), "3")==0);
+
+  sqlite3_close(db2);
+  remove_db(dbpath);
+}
+
+static void run_record_decode_corruption(void){
+  static const u8 badRecord[] = {
+    0x05, 0x01
+  };
+  char *z;
+
+  printf("=== Record Decode Corruption Test ===\n\n");
+  z = doltliteDecodeRecord(badRecord, (int)sizeof(badRecord));
+  check("corrupt_record_decodes_to_null", z==0);
+  sqlite3_free(z);
+}
+
 static const RegressionCase aCases[] = {
   { "concurrent_refs", "Concurrent Refs Test", run_concurrent_refs },
   { "checkout_persist_failure", "Checkout Persist Failure Test", run_checkout_persist_failure },
@@ -1090,7 +1147,9 @@ static const RegressionCase aCases[] = {
   { "commit_parent_limit", "Commit Parent Limit Test", run_commit_parent_limit },
   { "merge_persist_failure", "Merge Persist Failure Test", run_merge_persist_failure },
   { "cherry_pick_stale_branch", "Cherry-pick Stale Branch Test", run_cherry_pick_stale_branch },
-  { "branches_metadata_corruption", "Branches Metadata Corruption Test", run_branches_metadata_corruption }
+  { "branches_metadata_corruption", "Branches Metadata Corruption Test", run_branches_metadata_corruption },
+  { "gc_rewrite_failure", "GC Rewrite Failure Test", run_gc_rewrite_failure },
+  { "record_decode_corruption", "Record Decode Corruption Test", run_record_decode_corruption }
 };
 
 static int run_case_by_name(const char *zName){


### PR DESCRIPTION
This review-driven patch tightens a few correctness and error-handling paths in files that were not already covered by the open PRs.

Main changes:
- keep GC manifest updates local until rewrite success, so failed gc does not poison in-memory store metadata
- make record decoding fail closed on malformed/truncated input and OOM instead of returning partial strings
- make `doltliteGetColumnNames()` propagate step and allocation failures instead of returning partial schema state
- reject `dolt_tag(..., --author ...)` when parsing the author string runs out of memory
- remove the stale `dolt_log` timestamp-order comment

Regression coverage:
- `gc_rewrite_failure` in `test/doltlite_regression_test_c.c`
- `record_decode_corruption` in `test/doltlite_regression_test_c.c`

Verified:
- `cd build && bash ../test/doltlite_regression_test_c.sh`
- `cd build && bash ../test/doltlite_tag.sh`
- `cd build && bash ../test/doltlite_gc.sh`