### PR TITLE
Fix checkout -b conflict guard and schema parser

### DIFF
--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -404,6 +404,16 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
   memset(&m, 0, sizeof(m));
   memset(&branchCreate, 0, sizeof(branchCreate));
 
+  /* Block checkout during unresolved merge conflicts. */
+  {
+    u8 isMerging = 0;
+    doltliteGetSessionMergeState(db, &isMerging, 0, 0);
+    if( isMerging ){
+      sqlite3_result_error(ctx, "unresolved merge conflicts \xe2\x80\x94 commit or abort first", -1);
+      return;
+    }
+  }
+
   
   if( strcmp(zBranch, "-b")==0 ){
     if( argc<2 ){ sqlite3_result_error(ctx, "branch name required after -b", -1); return; }
@@ -426,16 +436,6 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
   if( strcmp(zBranch, doltliteGetSessionBranch(db))==0 ){
     sqlite3_result_int(ctx, 0);
     return;
-  }
-
-  /* Block checkout during unresolved merge conflicts. */
-  {
-    u8 isMerging = 0;
-    doltliteGetSessionMergeState(db, &isMerging, 0, 0);
-    if( isMerging ){
-      sqlite3_result_error(ctx, "unresolved merge conflicts \xe2\x80\x94 commit or abort first", -1);
-      return;
-    }
   }
 
   /* Save the current branch's working catalog before hardReset overwrites

--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -502,6 +502,57 @@ struct ParsedColumn {
   char *zDef;     /* Full column definition text */
 };
 
+static int parseQuotedIdentifier(
+  const char *z,
+  const char *zEnd,
+  const char **ppEnd,
+  char **pzName
+){
+  char cOpen, cClose;
+  const char *p;
+  int nOut = 0;
+  char *zName;
+
+  *ppEnd = z;
+  *pzName = 0;
+  if( z>=zEnd ) return SQLITE_CORRUPT;
+
+  cOpen = *z;
+  cClose = cOpen=='[' ? ']' : cOpen;
+  p = z + 1;
+  while( p<zEnd ){
+    if( *p==cClose ){
+      if( p+1<zEnd && p[1]==cClose ){
+        nOut++;
+        p += 2;
+        continue;
+      }
+      break;
+    }
+    nOut++;
+    p++;
+  }
+  if( p>=zEnd || *p!=cClose ) return SQLITE_CORRUPT;
+
+  zName = sqlite3_malloc(nOut + 1);
+  if( !zName ) return SQLITE_NOMEM;
+
+  p = z + 1;
+  nOut = 0;
+  while( p<zEnd && *p!=cClose ){
+    if( p+1<zEnd && p[0]==cClose && p[1]==cClose ){
+      zName[nOut++] = cClose;
+      p += 2;
+    }else{
+      zName[nOut++] = *p++;
+    }
+  }
+  zName[nOut] = 0;
+  *ppEnd = p + 1;
+  *pzName = zName;
+  return SQLITE_OK;
+}
+
 /*
 ** Parse columns from a CREATE TABLE SQL string.
 ** Returns an array of ParsedColumn entries.
@@ -525,7 +576,7 @@ static int parseColumns(
   /* Find the opening '(' after CREATE TABLE ... */
   p = zSql;
   while( *p && *p!='(' ) p++;
-  if( *p!='(' ) return SQLITE_OK;
+  if( *p!='(' ) return SQLITE_CORRUPT;
   p++; /* skip '(' */
 
   /* Find the matching closing ')' */
@@ -536,7 +587,7 @@ static int parseColumns(
     else if( *pEnd==')' ) depth--;
     pEnd++;
   }
-  if( depth!=0 ) return SQLITE_OK;
+  if( depth!=0 ) return SQLITE_CORRUPT;
   pEnd--; /* back to the ')' */
 
   /* Now parse comma-separated segments between p and pEnd */
@@ -601,33 +652,48 @@ static int parseColumns(
             const char *nameStart = s;
             const char *nameEnd = nameStart;
             int nameLen;
+            int rc;
             /* Handle quoted names */
             if( *nameStart=='"' || *nameStart=='`' || *nameStart=='[' ){
-              char closeChar = (*nameStart=='"') ? '"' :
-                               (*nameStart=='`') ? '`' : ']';
-              nameEnd = nameStart + 1;
-              while( nameEnd<e && *nameEnd!=closeChar ) nameEnd++;
-              if( nameEnd<e ) nameEnd++; /* include close quote */
-              nameLen = (int)(nameEnd - nameStart);
-              /* Store unquoted name for comparison */
-              zName = sqlite3_malloc(nameLen - 1);  /* minus 2 quotes + 1 NUL */
-              if( zName ){
-                memcpy(zName, nameStart+1, nameLen-2);
-                zName[nameLen-2] = 0;
-                /* Lowercase for comparison */
-                { int ci; for(ci=0;zName[ci];ci++) zName[ci]=(char)tolower((unsigned char)zName[ci]); }
+              rc = parseQuotedIdentifier(nameStart, e, &nameEnd, &zName);
+              if( rc!=SQLITE_OK ){
+                sqlite3_free(zTrimmed);
+                { int ci; for(ci=0;ci<nCols;ci++){
+                  sqlite3_free(aCols[ci].zName);
+                  sqlite3_free(aCols[ci].zDef);
+                }}
+                sqlite3_free(aCols);
+                return rc;
               }
             }else{
               while( nameEnd<e && !isspace((unsigned char)*nameEnd)
                   && *nameEnd!='(' && *nameEnd!=',' ) nameEnd++;
               nameLen = (int)(nameEnd - nameStart);
               zName = sqlite3_malloc(nameLen + 1);
-              if( zName ){
-                memcpy(zName, nameStart, nameLen);
-                zName[nameLen] = 0;
-                /* Lowercase for comparison */
-                { int ci; for(ci=0;zName[ci];ci++) zName[ci]=(char)tolower((unsigned char)zName[ci]); }
+              if( !zName ){
+                sqlite3_free(zTrimmed);
+                { int ci; for(ci=0;ci<nCols;ci++){
+                  sqlite3_free(aCols[ci].zName);
+                  sqlite3_free(aCols[ci].zDef);
+                }}
+                sqlite3_free(aCols);
+                return SQLITE_NOMEM;
               }
+              memcpy(zName, nameStart, nameLen);
+              zName[nameLen] = 0;
+            }
+            /* Lowercase for comparison */
+            { int ci; for(ci=0;zName[ci];ci++) zName[ci]=(char)tolower((unsigned char)zName[ci]); }
+
+            if( nameEnd<=nameStart ){
+              sqlite3_free(zName);
+              sqlite3_free(zTrimmed);
+              { int ci; for(ci=0;ci<nCols;ci++){
+                sqlite3_free(aCols[ci].zName);
+                sqlite3_free(aCols[ci].zDef);
+              }}
+              sqlite3_free(aCols);
+              return SQLITE_CORRUPT;
             }
 
             if( nCols >= nAlloc ){

--- a/test/doltlite_behavior.sh
+++ b/test/doltlite_behavior.sh
@@ -35,6 +35,14 @@ run_test_match "checkout_blocked_conflict" \
   "SELECT dolt_checkout('feature');" \
   "conflict|merge" "$DB"
 
+run_test_match "checkout_create_blocked_conflict" \
+  "SELECT dolt_checkout('-b','blocked_branch');" \
+  "conflict|merge" "$DB"
+
+run_test "checkout_create_no_branch_on_conflict" \
+  "SELECT count(*) FROM dolt_branches WHERE name='blocked_branch';" \
+  "0" "$DB"
+
 # Test 2: Resolve conflicts, then checkout should succeed
 echo "SELECT dolt_conflicts_resolve('--ours','t');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_commit('-A','-m','resolved');" | $DOLTLITE "$DB" > /dev/null 2>&1

--- a/test/doltlite_schema_merge.sh
+++ b/test/doltlite_schema_merge.sh
@@ -67,6 +67,32 @@ run_test "alter_merge_quoted_val" 'SELECT "odd""name" FROM t WHERE id=1;' "quote
 rm -f "$DB"
 
 # ============================================================
+# Test 1c: schema merge handles escaped quoted identifiers
+# ============================================================
+
+DB=/tmp/test_alter_merge1c_$$.db; rm -f "$DB"
+cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_commit('-A','-m','init');
+SELECT dolt_branch('feat');
+ALTER TABLE t ADD COLUMN "main""col" TEXT;
+UPDATE t SET "main""col"='left' WHERE id=1;
+SELECT dolt_commit('-A','-m','main quoted add');
+SELECT dolt_checkout('feat');
+ALTER TABLE t ADD COLUMN "feat""col" TEXT;
+UPDATE t SET "feat""col"='right' WHERE id=1;
+SELECT dolt_commit('-A','-m','feat quoted add');
+SELECT dolt_checkout('main');
+EOF
+
+run_test_match "alter_merge_escaped_quoted_hash" "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB"
+run_test "alter_merge_escaped_main_val" 'SELECT "main""col" FROM t WHERE id=1;' "left" "$DB"
+run_test "alter_merge_escaped_feat_val" 'SELECT "feat""col" FROM t WHERE id=1;' "right" "$DB"
+
+rm -f "$DB"
+
+# ============================================================
 # Test 2: ALTER TABLE ADD COLUMN same name on both branches — conflict?
 # ============================================================
 


### PR DESCRIPTION
This fixes two review findings on current master:

- block `dolt_checkout('-b', ...)` before creating the branch when a merge is unresolved\n- make schema merge column parsing fail hard on malformed/OOM input and handle escaped quoted identifiers correctly\n\nTests:\n- cd build && bash ../test/doltlite_behavior.sh\n- cd build && bash ../test/doltlite_schema_merge.sh\n- cd build && bash ../test/doltlite_branch.sh