### PR TITLE
Fix remote refs rollback and schema loader errors

### DIFF
--- a/src/doltlite_remote.c
+++ b/src/doltlite_remote.c
@@ -265,12 +265,21 @@ static int fsGetRefs(DoltliteRemote *pRemote, u8 **ppData, int *pnData){
 
 static int fsSetRefs(DoltliteRemote *pRemote, const u8 *pData, int nData){
   FsRemote *p = (FsRemote*)pRemote;
+  ProllyHash oldRefsHash;
   ProllyHash refsHash;
   int rc = chunkStorePut(&p->store, pData, nData, &refsHash);
   if( rc==SQLITE_OK ){
+    memcpy(&oldRefsHash, &p->store.refsHash, sizeof(ProllyHash));
     memcpy(&p->store.refsHash, &refsHash, sizeof(ProllyHash));
     
     rc = chunkStoreReloadRefs(&p->store);
+    if( rc!=SQLITE_OK ){
+      memcpy(&p->store.refsHash, &oldRefsHash, sizeof(ProllyHash));
+      if( !prollyHashIsEmpty(&oldRefsHash) ){
+        int restoreRc = chunkStoreReloadRefs(&p->store);
+        if( restoreRc!=SQLITE_OK ) return restoreRc;
+      }
+    }
   }
   return rc;
 }
@@ -662,7 +671,10 @@ int doltliteClone(ChunkStore *pLocal, DoltliteRemote *pRemote){
   ProllyHash *aRoots = 0;
   int nRoots = 0;
   DoltliteRemote *pLocalDst = 0;
+  ProllyHash oldRefsHash;
   int rc;
+
+  memcpy(&oldRefsHash, &pLocal->refsHash, sizeof(ProllyHash));
 
   
   rc = pRemote->xGetRefs(pRemote, &refsData, &nRefsData);
@@ -713,10 +725,20 @@ int doltliteClone(ChunkStore *pLocal, DoltliteRemote *pRemote){
 
   
   rc = chunkStoreCommit(pLocal);
-  if( rc!=SQLITE_OK ) return rc;
+  if( rc!=SQLITE_OK ){
+    memcpy(&pLocal->refsHash, &oldRefsHash, sizeof(ProllyHash));
+    return rc;
+  }
 
   
   rc = chunkStoreReloadRefs(pLocal);
+  if( rc!=SQLITE_OK ){
+    memcpy(&pLocal->refsHash, &oldRefsHash, sizeof(ProllyHash));
+    if( !prollyHashIsEmpty(&oldRefsHash) ){
+      int restoreRc = chunkStoreReloadRefs(pLocal);
+      if( restoreRc!=SQLITE_OK ) return restoreRc;
+    }
+  }
 
   return rc;
 }

--- a/src/doltlite_schema_diff.c
+++ b/src/doltlite_schema_diff.c
@@ -36,6 +36,32 @@ struct SdCursor {
   int iRow;
 };
 
+static int schemaTextField(
+  const u8 *pVal,
+  int nVal,
+  DoltliteRecordInfo *pRi,
+  int iField,
+  char **pzOut
+){
+  int st, off, len;
+  char *zOut;
+
+  *pzOut = 0;
+  if( iField>=pRi->nField ) return SQLITE_CORRUPT;
+  st = pRi->aType[iField];
+  off = pRi->aOffset[iField];
+  if( st==0 ) return SQLITE_OK;
+  if( st<13 || (st&1)==0 ) return SQLITE_CORRUPT;
+  len = (st-13)/2;
+  if( off<0 || off+len>nVal ) return SQLITE_CORRUPT;
+  zOut = sqlite3_malloc(len+1);
+  if( !zOut ) return SQLITE_NOMEM;
+  memcpy(zOut, pVal+off, len);
+  zOut[len] = 0;
+  *pzOut = zOut;
+  return SQLITE_OK;
+}
+
 static void freeSchemaDiffRows(SdCursor *c){
   int i;
   for(i=0; i<c->nRows; i++){
@@ -168,42 +194,29 @@ int loadSchemaFromCatalog(
     if( pVal && nVal > 0 ){
       doltliteParseRecord(pVal, nVal, &ri);
 
-      if( ri.nField >= 5 ){
-        int *aType = ri.aType;
-        int *aOffset = ri.aOffset;
+      if( ri.nField < 5 ){
+        rc = SQLITE_CORRUPT;
+        goto load_schema_done;
+      }else{
         char *zType = 0, *zName = 0, *zSql = 0;
 
-        
-        if( aType[0] >= 13 && (aType[0]&1)==1 ){
-          int len = (aType[0]-13)/2;
-          if( aOffset[0]+len <= nVal ){
-            zType = sqlite3_malloc(len+1);
-            if( !zType ){ rc = SQLITE_NOMEM; goto load_schema_done; }
-            memcpy(zType, pVal+aOffset[0], len); zType[len]=0;
-          }
+        rc = schemaTextField(pVal, nVal, &ri, 0, &zType);
+        if( rc!=SQLITE_OK ) goto load_schema_done;
+        rc = schemaTextField(pVal, nVal, &ri, 1, &zName);
+        if( rc!=SQLITE_OK ){
+          sqlite3_free(zType);
+          goto load_schema_done;
         }
-        if( aType[1] >= 13 && (aType[1]&1)==1 ){
-          int len = (aType[1]-13)/2;
-          if( aOffset[1]+len <= nVal ){
-            zName = sqlite3_malloc(len+1);
-            if( !zName ){ rc = SQLITE_NOMEM; goto load_schema_done; }
-            memcpy(zName, pVal+aOffset[1], len); zName[len]=0;
-          }
-        }
-        if( aType[4] >= 13 && (aType[4]&1)==1 ){
-          int len = (aType[4]-13)/2;
-          if( aOffset[4]+len <= nVal ){
-            zSql = sqlite3_malloc(len+1);
-            if( !zSql ){ rc = SQLITE_NOMEM; goto load_schema_done; }
-            memcpy(zSql, pVal+aOffset[4], len); zSql[len]=0;
-          }
+        rc = schemaTextField(pVal, nVal, &ri, 4, &zSql);
+        if( rc!=SQLITE_OK ){
+          sqlite3_free(zType);
+          sqlite3_free(zName);
+          goto load_schema_done;
         }
 
         if( zName ){
           rc = appendSchemaEntry(&aEntries, &nEntries, &nAlloc, zName, zSql, zType);
-          if( rc!=SQLITE_OK ){
-            goto load_schema_done;
-          }
+          if( rc!=SQLITE_OK ) goto load_schema_done;
           zName = 0;
           zSql = 0;
           zType = 0;

--- a/src/doltlite_schema_merge.c
+++ b/src/doltlite_schema_merge.c
@@ -247,8 +247,13 @@ int migrateSchemaRowData(
 
       for(sj=0; sj<pAct->nAddColumns; sj++){
         azColNames[sj] = extractColNameFromDef(pAct->azAddColumns[sj]);
+        if( !azColNames[sj] ){
+          rc = SQLITE_NOMEM;
+          break;
+        }
         aiColIdx[sj] = -1;
       }
+      if( rc!=SQLITE_OK ) break;
 
       /* Now parse theirs' CREATE TABLE SQL to find each column's ordinal.
       ** Column ordinal in the record = position in CREATE TABLE column list.
@@ -263,7 +268,7 @@ int migrateSchemaRowData(
 
         /* Find '(' */
         while( *p && *p!='(' ) p++;
-        if( !*p ) goto next_action;
+        if( !*p ){ rc = SQLITE_CORRUPT; goto next_action; }
         p++;
 
         segStart = p;
@@ -276,7 +281,7 @@ int migrateSchemaRowData(
             else if(*pSqlEnd==')') d2--;
             pSqlEnd++;
           }
-          if( d2!=0 ) goto next_action;
+          if( d2!=0 ){ rc = SQLITE_CORRUPT; goto next_action; }
           pSqlEnd--; /* back to ')' */
 
           while( p <= pSqlEnd ){
@@ -316,15 +321,20 @@ int migrateSchemaRowData(
                   int nl = dlIdentTokenLen(ns, (int)(e - ns));
 
                   zColName = dlExtractIdentLower(ns, nl);
-                  if( zColName ){
-                    /* Check if this column matches any of our added columns */
-                    for(sj=0; sj<pAct->nAddColumns; sj++){
-                      if( azColNames[sj]
-                       && strcmp(azColNames[sj], zColName)==0 ){
-                        aiColIdx[sj] = colOrdinal;
-                      }
+                  if( !zColName ){
+                    rc = SQLITE_NOMEM;
+                    goto next_action;
+                  }
+                  /* Check if this column matches any of our added columns */
+                  for(sj=0; sj<pAct->nAddColumns; sj++){
+                    if( azColNames[sj]
+                     && strcmp(azColNames[sj], zColName)==0 ){
+                      aiColIdx[sj] = colOrdinal;
                     }
-                    sqlite3_free(zColName);
+                  }
+                  sqlite3_free(zColName);
+                  if( rc!=SQLITE_OK ){
+                    goto next_action;
                   }
                   colOrdinal++;
                 }


### PR DESCRIPTION
This fixes current-master review findings in remote refs installation and schema loading:

- roll back in-memory refs state if filesystem remote refs reload fails
- roll back local clone refs state if commit or refs reload fails
- fail schema row migration on allocation/malformed schema parse errors instead of silently succeeding
- fail schema diff loading on malformed sqlite_master records instead of degrading to partial rows

Tests:
- cd build && bash ../test/remote_test.sh ./doltlite
- cd build && bash ../test/doltlite_schema_merge.sh
- cd build && bash ../test/doltlite_schema_diff.sh
- cd build && bash ../test/doltlite_regression_test_c.sh clone_persist_failure