### PR TITLE
Add dolt_reset oracle, fix three divergences from Dolt

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,6 +99,10 @@ jobs:
       run: cd build && bash ../test/vc_oracle_conflicts_test.sh ./doltlite dolt
       timeout-minutes: 5
 
+    - name: Version control oracle tests (dolt_reset)
+      run: cd build && bash ../test/vc_oracle_reset_test.sh ./doltlite dolt
+      timeout-minutes: 5
+
     - name: Large-scale test (10K rows)
       run: cd build && bash ../test/large_scale_test.sh ./doltlite --quick
       timeout-minutes: 5

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -792,7 +792,11 @@ static void doltliteResetFunc(
   ProllyHash targetCatHash;
   ProllyHash targetCommit;
   int isHard = 0;
+  int isSoft = 0;
+  int isMixed = 0;
   const char *zRef = 0;
+  const char **azPaths = 0;
+  int nPaths = 0;
   int rc;
   int i;
   int graphLocked = 0;
@@ -802,14 +806,179 @@ static void doltliteResetFunc(
     return;
   }
 
-  
+  /* Parse arguments. The first non-flag positional that resolves as
+  ** a ref is the target commit; any other non-flag positional is
+  ** treated as a table-path argument to unstage. Recognized flags:
+  ** --hard, --soft, --mixed (default). Other dash-prefixed args are
+  ** rejected. */
+  azPaths = (const char**)sqlite3_malloc(sizeof(char*) * (argc>0?argc:1));
+  if( !azPaths ){ sqlite3_result_error_nomem(context); return; }
   for(i=0; i<argc; i++){
     const char *arg = (const char*)sqlite3_value_text(argv[i]);
     if( !arg ) continue;
     if( strcmp(arg, "--hard")==0 ){ isHard = 1; }
-    else if( strcmp(arg, "--soft")==0 ){  }
-    else{ zRef = arg; }
+    else if( strcmp(arg, "--soft")==0 ){ isSoft = 1; }
+    else if( strcmp(arg, "--mixed")==0 ){ isMixed = 1; }
+    else if( arg[0]=='-' ){
+      char *zErr = sqlite3_mprintf("unknown option `%s`", arg);
+      sqlite3_result_error(context, zErr ? zErr : "unknown option", -1);
+      sqlite3_free(zErr);
+      sqlite3_free(azPaths);
+      return;
+    }
+    else if( !zRef ){
+      /* First non-flag positional. If a mode flag (--hard / --soft /
+      ** --mixed) was given, this MUST be a ref — path mode is
+      ** mutually exclusive with mode flags. Otherwise, try as a ref
+      ** first; if it doesn't resolve, treat as a table path so that
+      ** dolt_reset('table_name') works. */
+      if( isHard || isSoft || isMixed ){
+        zRef = arg;
+      }else{
+        ProllyHash probe;
+        if( doltliteResolveRef(db, arg, &probe)==SQLITE_OK ){
+          zRef = arg;
+        }else{
+          azPaths[nPaths++] = arg;
+        }
+      }
+    }
+    else{
+      /* Subsequent non-flag positionals are always table paths */
+      azPaths[nPaths++] = arg;
+    }
   }
+
+  /* Path-based unstage: rewrite the staged catalog so that the
+  ** listed tables match HEAD again, leave every other staged entry
+  ** alone, and don't touch HEAD or the working set. Mutually
+  ** exclusive with --hard / --soft and with a target ref. */
+  if( nPaths>0 ){
+    struct TableEntry *aHead = 0, *aStaged = 0;
+    int nHead = 0, nStaged = 0;
+    ProllyHash headCatHash, stagedHash;
+    int p;
+
+    if( isHard || isSoft || zRef ){
+      sqlite3_result_error(context,
+        "table paths cannot be combined with --hard / --soft or a target ref", -1);
+      sqlite3_free(azPaths);
+      return;
+    }
+
+    rc = doltliteGetHeadCatalogHash(db, &headCatHash);
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(azPaths);
+      sqlite3_result_error(context, "failed to read HEAD", -1);
+      return;
+    }
+    if( !prollyHashIsEmpty(&headCatHash) ){
+      rc = doltliteLoadCatalog(db, &headCatHash, &aHead, &nHead, 0);
+      if( rc!=SQLITE_OK ){
+        sqlite3_free(azPaths);
+        sqlite3_result_error(context, "failed to load HEAD catalog", -1);
+        return;
+      }
+    }
+
+    doltliteGetSessionStaged(db, &stagedHash);
+    if( !prollyHashIsEmpty(&stagedHash) ){
+      rc = doltliteLoadCatalog(db, &stagedHash, &aStaged, &nStaged, 0);
+      if( rc!=SQLITE_OK ){
+        sqlite3_free(aHead);
+        sqlite3_free(azPaths);
+        sqlite3_result_error(context, "failed to load staged catalog", -1);
+        return;
+      }
+    }
+
+    for(p=0; p<nPaths; p++){
+      const char *zTable = azPaths[p];
+      int iH;
+      int iS = -1;
+      int j;
+
+      /* Find this table in HEAD and in staged */
+      for(j=0; j<nStaged; j++){
+        if( aStaged[j].zName && strcmp(aStaged[j].zName, zTable)==0 ){
+          iS = j; break;
+        }
+      }
+      iH = -1;
+      for(j=0; j<nHead; j++){
+        if( aHead[j].zName && strcmp(aHead[j].zName, zTable)==0 ){
+          iH = j; break;
+        }
+      }
+
+      if( iH<0 && iS<0 ){
+        char *zErr = sqlite3_mprintf("table not found: %s", zTable);
+        sqlite3_free(aHead); sqlite3_free(aStaged); sqlite3_free(azPaths);
+        sqlite3_result_error(context, zErr ? zErr : "table not found", -1);
+        sqlite3_free(zErr);
+        return;
+      }
+
+      if( iH<0 ){
+        /* Not in HEAD: drop the staged entry */
+        if( iS+1<nStaged ){
+          memmove(&aStaged[iS], &aStaged[iS+1],
+                  (nStaged-iS-1)*(int)sizeof(struct TableEntry));
+        }
+        nStaged--;
+      }else if( iS<0 ){
+        /* In HEAD but not staged yet: add it */
+        struct TableEntry *aNew = sqlite3_realloc(aStaged,
+            (nStaged+1)*(int)sizeof(struct TableEntry));
+        if( !aNew ){
+          sqlite3_free(aHead); sqlite3_free(aStaged); sqlite3_free(azPaths);
+          sqlite3_result_error_nomem(context);
+          return;
+        }
+        aStaged = aNew;
+        aStaged[nStaged] = aHead[iH];
+        nStaged++;
+      }else{
+        /* In both: replace staged with HEAD's version */
+        aStaged[iS] = aHead[iH];
+      }
+    }
+
+    {
+      u8 *buf = 0;
+      int nBuf = 0;
+      ProllyHash newStagedHash;
+      rc = doltliteSerializeCatalogEntries(db, aStaged, nStaged, &buf, &nBuf);
+      if( rc==SQLITE_OK ){
+        rc = chunkStorePut(cs, buf, nBuf, &newStagedHash);
+      }
+      sqlite3_free(buf);
+      if( rc==SQLITE_OK ){
+        doltliteSetSessionStaged(db, &newStagedHash);
+      }
+    }
+
+    sqlite3_free(aHead);
+    sqlite3_free(aStaged);
+    sqlite3_free(azPaths);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(context, rc);
+      return;
+    }
+    doltlitePersistState(db);
+    sqlite3_result_int(context, 0);
+    return;
+  }
+  sqlite3_free(azPaths);
+
+  /* `dolt_reset('--soft')` with no target ref is a no-op (matches
+  ** Dolt's git-like semantics: --soft HEAD changes nothing). The
+  ** unstage-all behavior is reserved for no-args and --mixed. */
+  if( isSoft && !zRef ){
+    sqlite3_result_int(context, 0);
+    return;
+  }
+  (void)isMixed;
 
   if( zRef ){
     DoltliteCommit commit;

--- a/src/doltlite_ref.c
+++ b/src/doltlite_ref.c
@@ -27,10 +27,23 @@ static int doltliteValidateCommitHash(
   return rc;
 }
 
-int doltliteResolveRef(sqlite3 *db, const char *zRef, ProllyHash *pCommit){
+/* Resolve a base ref (no ~N / ^N suffix) to a commit hash. Tries
+** the literal "HEAD" keyword, then 40-char hex, then branch name,
+** then tag name. Returns SQLITE_NOTFOUND if none match. */
+static int doltliteResolveBaseRef(
+  sqlite3 *db,
+  const char *zRef,
+  ProllyHash *pCommit
+){
   ChunkStore *cs = doltliteGetChunkStore(db);
   int rc;
-  if( !zRef || !cs ) return SQLITE_ERROR;
+
+  /* "HEAD" keyword resolves to the current session head */
+  if( strcmp(zRef, "HEAD")==0 ){
+    doltliteGetSessionHead(db, pCommit);
+    if( prollyHashIsEmpty(pCommit) ) return SQLITE_NOTFOUND;
+    return SQLITE_OK;
+  }
 
   /* Try 40-char hex hash */
   if( strlen(zRef)==PROLLY_HASH_SIZE*2 ){
@@ -59,6 +72,86 @@ int doltliteResolveRef(sqlite3 *db, const char *zRef, ProllyHash *pCommit){
   }
 
   return SQLITE_NOTFOUND;
+}
+
+/* Walk back N commits along the first-parent chain. */
+static int doltliteWalkFirstParent(
+  sqlite3 *db,
+  ProllyHash *pCommit,
+  int n
+){
+  int i;
+  for(i=0; i<n; i++){
+    DoltliteCommit commit;
+    int rc;
+    memset(&commit, 0, sizeof(commit));
+    rc = doltliteLoadCommit(db, pCommit, &commit);
+    if( rc!=SQLITE_OK ) return rc;
+    if( commit.nParents==0 ){
+      doltliteCommitClear(&commit);
+      return SQLITE_NOTFOUND;
+    }
+    memcpy(pCommit, &commit.aParents[0], sizeof(ProllyHash));
+    doltliteCommitClear(&commit);
+  }
+  return SQLITE_OK;
+}
+
+int doltliteResolveRef(sqlite3 *db, const char *zRef, ProllyHash *pCommit){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  int len, j, n_back, rc;
+  int suffix_pos = -1;
+  char *base_buf = 0;
+  const char *base;
+
+  if( !zRef || !cs ) return SQLITE_ERROR;
+
+  /* Look for a trailing ~N or ^N (rightmost) revision suffix. The
+  ** base ref before the suffix is resolved by doltliteResolveBaseRef
+  ** and then walked back N commits along the first-parent chain. An
+  ** empty digit run (HEAD~ / HEAD^) is treated as N=1, matching git.
+  ** Only the rightmost suffix is honored — chained suffixes such as
+  ** HEAD~2~3 are not supported. */
+  len = (int)strlen(zRef);
+  for(j=len-1; j>=0; j--){
+    if( zRef[j]=='~' || zRef[j]=='^' ){
+      int k, allDigits = 1;
+      for(k=j+1; k<len; k++){
+        if( zRef[k]<'0' || zRef[k]>'9' ){ allDigits = 0; break; }
+      }
+      if( allDigits ) suffix_pos = j;
+      break;
+    }
+  }
+
+  n_back = 0;
+  base = zRef;
+  if( suffix_pos>=0 ){
+    if( suffix_pos==len-1 ){
+      n_back = 1;
+    }else{
+      n_back = atoi(zRef + suffix_pos + 1);
+      if( n_back<=0 ) n_back = 0;
+    }
+    if( n_back>0 ){
+      if( suffix_pos==0 ){
+        base = "HEAD";
+      }else{
+        base_buf = sqlite3_malloc(suffix_pos + 1);
+        if( !base_buf ) return SQLITE_NOMEM;
+        memcpy(base_buf, zRef, suffix_pos);
+        base_buf[suffix_pos] = '\0';
+        base = base_buf;
+      }
+    }
+  }
+
+  rc = doltliteResolveBaseRef(db, base, pCommit);
+  if( rc==SQLITE_OK && n_back>0 ){
+    rc = doltliteWalkFirstParent(db, pCommit, n_back);
+  }
+  if( base_buf ) sqlite3_free(base_buf);
+  return rc;
 }
 
 int doltliteLoadCommit(sqlite3 *db, const ProllyHash *pHash,

--- a/test/doltlite_advanced.sh
+++ b/test/doltlite_advanced.sh
@@ -592,8 +592,8 @@ INSERT INTO b VALUES(2,'b2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 # Stage only a
 echo "SELECT dolt_add('a');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Soft reset — should unstage a but keep all data
-echo "SELECT dolt_reset('--soft');" | $DOLTLITE "$DB" > /dev/null 2>&1
+# No-args reset (== --mixed) — unstage a but keep all data
+echo "SELECT dolt_reset();" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "resetstage_unstaged" "SELECT count(*) FROM dolt_status WHERE staged=1;" "0" "$DB"
 run_test "resetstage_data_a" "SELECT count(*) FROM a;" "2" "$DB"
 run_test "resetstage_data_b" "SELECT count(*) FROM b;" "2" "$DB"

--- a/test/doltlite_branch_edge.sh
+++ b/test/doltlite_branch_edge.sh
@@ -289,11 +289,11 @@ echo "INSERT INTO t VALUES(2,'new'); SELECT dolt_add('-A');" | $DOLTLITE "$DB" >
 run_test "soft_reset_staged" \
   "SELECT count(*) FROM dolt_status WHERE staged=1;" "1" "$DB"
 
-echo "SELECT dolt_reset('--soft');" | $DOLTLITE "$DB" > /dev/null 2>&1
+echo "SELECT dolt_reset();" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-run_test "soft_reset_unstaged" \
+run_test "reset_unstaged" \
   "SELECT count(*) FROM dolt_status WHERE staged=1;" "0" "$DB"
-run_test "soft_reset_data_kept" "SELECT count(*) FROM t;" "2" "$DB"
+run_test "reset_data_kept" "SELECT count(*) FROM t;" "2" "$DB"
 db_rm "$DB"
 
 # Test: Hard reset then checkout another branch

--- a/test/doltlite_e2e.sh
+++ b/test/doltlite_e2e.sh
@@ -144,9 +144,9 @@ echo "SELECT dolt_add('users');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "e2e_one_staged" "SELECT count(*) FROM dolt_status WHERE staged=1;" "1" "$DB"
 run_test "e2e_one_unstaged" "SELECT count(*) FROM dolt_status WHERE staged=0;" "1" "$DB"
 
-# Soft reset unstages
-echo "SELECT dolt_reset('--soft');" | $DOLTLITE "$DB" > /dev/null 2>&1
-run_test "e2e_after_soft_reset" "SELECT count(*) FROM dolt_status WHERE staged=1;" "0" "$DB"
+# No-args reset (== --mixed) unstages
+echo "SELECT dolt_reset();" | $DOLTLITE "$DB" > /dev/null 2>&1
+run_test "e2e_after_reset" "SELECT count(*) FROM dolt_status WHERE staged=1;" "0" "$DB"
 run_test "e2e_data_preserved" "SELECT count(*) FROM users;" "4" "$DB"
 
 # Stage all and commit

--- a/test/doltlite_edge_cases.sh
+++ b/test/doltlite_edge_cases.sh
@@ -293,9 +293,10 @@ echo "SELECT dolt_add('a');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "stg_a_staged" "SELECT count(*) FROM dolt_status WHERE staged=1;" "1" "$DB"
 run_test "stg_b_unstaged" "SELECT count(*) FROM dolt_status WHERE staged=0;" "1" "$DB"
 
-# Soft reset unstages a
-echo "SELECT dolt_reset('--soft');" | $DOLTLITE "$DB" > /dev/null 2>&1
-run_test "stg_soft_reset" "SELECT count(*) FROM dolt_status WHERE staged=1;" "0" "$DB"
+# No-args reset (== --mixed) unstages a. (--soft with no target ref
+# is a no-op under git/Dolt semantics.)
+echo "SELECT dolt_reset();" | $DOLTLITE "$DB" > /dev/null 2>&1
+run_test "stg_reset_unstages" "SELECT count(*) FROM dolt_status WHERE staged=1;" "0" "$DB"
 run_test "stg_data_kept" "SELECT count(*) FROM a;" "2" "$DB"
 
 # Stage a again, commit just a

--- a/test/doltlite_reset.sh
+++ b/test/doltlite_reset.sh
@@ -29,20 +29,33 @@ run_test "staged_before_soft_reset" \
   "SELECT count(*) FROM dolt_status WHERE staged=1;" \
   "1" "$DB"
 
-# Soft reset
+# --soft with no target ref is a no-op (matches Dolt and git: --soft
+# HEAD changes nothing). The unstage-all behavior is reserved for the
+# no-args / --mixed forms.
 echo "SELECT dolt_reset('--soft');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-run_test "unstaged_after_soft_reset" \
+run_test "still_staged_after_soft_noop" \
+  "SELECT count(*) FROM dolt_status WHERE staged=1;" \
+  "1" "$DB"
+
+run_test "no_unstaged_after_soft_noop" \
+  "SELECT count(*) FROM dolt_status WHERE staged=0;" \
+  "0" "$DB"
+
+run_test "data_preserved_soft_noop" \
+  "SELECT count(*) FROM t;" \
+  "2" "$DB"
+
+# No-args reset (== --mixed) does unstage everything.
+echo "SELECT dolt_reset();" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test "unstaged_after_no_args_reset" \
   "SELECT count(*) FROM dolt_status WHERE staged=0;" \
   "1" "$DB"
 
-run_test "no_staged_after_soft_reset" \
+run_test "no_staged_after_no_args_reset" \
   "SELECT count(*) FROM dolt_status WHERE staged=1;" \
   "0" "$DB"
-
-run_test "data_preserved_soft_reset" \
-  "SELECT count(*) FROM t;" \
-  "2" "$DB"
 
 # --- Hard reset ---
 echo "SELECT dolt_reset('--hard');" | $DOLTLITE "$DB" > /dev/null 2>&1

--- a/test/vc_oracle_reset_test.sh
+++ b/test/vc_oracle_reset_test.sh
@@ -1,0 +1,304 @@
+#!/bin/bash
+#
+# Version-control oracle test: dolt_reset
+#
+# Runs identical reset scenarios against doltlite and Dolt and compares
+# the resulting (dolt_log, dolt_status) post-state. dolt_reset has three
+# overlapping concerns the oracle has to verify together:
+#
+#   1. Where HEAD points after the reset (visible in dolt_log)
+#   2. The staged-tables set (visible in dolt_status with staged=1)
+#   3. The working-set tables (visible in dolt_status with staged=0)
+#
+# Comparing only one of those would miss class of bugs that change the
+# wrong surface — e.g. a soft reset that incorrectly clobbers the
+# working set, or a hard reset that fails to advance HEAD. So the
+# oracle compares the log AND the status output, concatenated, for
+# each scenario.
+#
+# Covers: --soft (default) with no ref (un-stage), --hard with no ref
+# (un-stage + drop working changes), --soft and --hard with a target
+# ref (branch / tag / commit hash), reset to current HEAD as a no-op,
+# table-name positionals (Dolt's path-based unstage), and error paths.
+#
+# Usage: bash vc_oracle_reset_test.sh [path/to/doltlite] [path/to/dolt]
+#
+
+set -u
+
+DOLTLITE="${1:-./doltlite}"
+DOLT="${2:-dolt}"
+TMPROOT=$(mktemp -d)
+trap "rm -rf $TMPROOT" EXIT
+pass=0; fail=0
+FAILED_NAMES=""
+
+# Strip CRs and drop blank lines, sort the log section by message and
+# the status section by table_name. The H1/H2/... renaming makes the
+# commit hashes deterministic across the two engines (which disagree
+# on hash content because doltlite uses prolly hashes and Dolt uses
+# noms hashes — only the SHAPE of the chain has to match).
+normalize_log() {
+  tr -d '\r' \
+    | awk -F'\t' 'NF >= 3 && $1 == "L" { print }' \
+    | sort -t$'\t' -k3 \
+    | awk -F'\t' '
+        {
+          h = $2
+          if (!(h in seen)) { n++; seen[h] = "H" n }
+          print "L\t" seen[h] "\t" $3
+        }
+      '
+}
+
+normalize_status() {
+  tr -d '\r' \
+    | awk -F'\t' 'NF >= 4 && $1 == "S" { print }' \
+    | sort -t$'\t' -k2,2 -k3,3 -k4,4
+}
+
+# Run a scenario. $1=name, $2=setup SQL in doltlite syntax. The harness
+# rewrites SELECT dolt_*(...) -> CALL dolt_*(...) for Dolt.
+oracle() {
+  local name="$1" setup="$2"
+  local dir="$TMPROOT/$name"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_log dl_status
+  dl_log=$(printf "%s\n.headers off\n.mode list\n.separator '\t'\nSELECT 'L' || char(9) || commit_hash || char(9) || message FROM dolt_log;\n" "$setup" \
+           | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
+           | grep -v '^[0-9]*$' \
+           | grep -v '^[0-9a-f]\{40\}$' \
+           | normalize_log)
+  dl_status=$(printf "%s\n.headers off\n.mode list\n.separator '\t'\nSELECT 'S' || char(9) || table_name || char(9) || staged || char(9) || status FROM dolt_status;\n" "$setup" \
+              | "$DOLTLITE" "$dir/dl/db.s" 2>>"$dir/dl.err" \
+              | grep -v '^[0-9]*$' \
+              | grep -v '^[0-9a-f]\{40\}$' \
+              | normalize_status)
+
+  local dolt_setup
+  dolt_setup=$(echo "$setup" | sed -E 's/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g')
+
+  local dt_log dt_status
+  (
+    cd "$dir/dt" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    echo "$dolt_setup" | "$DOLT" sql >/dev/null 2>"$dir/dt.err"
+    "$DOLT" sql -r csv -q "SELECT concat('L', char(9), commit_hash, char(9), message) FROM dolt_log ORDER BY commit_order DESC;" 2>>"$dir/dt.err"
+  ) > "$dir/dt.log.raw"
+  dt_log=$(tail -n +2 "$dir/dt.log.raw" | tr -d '"' | normalize_log)
+
+  (
+    cd "$dir/dt.s" 2>/dev/null || mkdir -p "$dir/dt.s" && cd "$dir/dt.s" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    echo "$dolt_setup" | "$DOLT" sql >/dev/null 2>"$dir/dt.s.err"
+    "$DOLT" sql -r csv -q "SELECT concat('S', char(9), table_name, char(9), staged, char(9), status) FROM dolt_status;" 2>>"$dir/dt.s.err"
+  ) > "$dir/dt.status.raw"
+  dt_status=$(tail -n +2 "$dir/dt.status.raw" | tr -d '"' | normalize_status)
+
+  local dl_combined dt_combined
+  dl_combined="$dl_log"$'\n'"$dl_status"
+  dt_combined="$dt_log"$'\n'"$dt_status"
+
+  if [ "$dl_combined" = "$dt_combined" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite log:";    echo "$dl_log"    | sed 's/^/      /'
+    echo "    dolt log:";        echo "$dt_log"    | sed 's/^/      /'
+    echo "    doltlite status:"; echo "$dl_status" | sed 's/^/      /'
+    echo "    dolt status:";     echo "$dt_status" | sed 's/^/      /'
+  fi
+}
+
+oracle_error() {
+  local name="$1" setup="$2"
+  local dir="$TMPROOT/${name}_err"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_err=0
+  echo "$setup" | "$DOLTLITE" "$dir/dl/db" >"$dir/dl.out" 2>"$dir/dl.err"
+  if grep -qiE 'error|fail' "$dir/dl.out" "$dir/dl.err" 2>/dev/null; then dl_err=1; fi
+
+  local dolt_setup
+  dolt_setup=$(echo "$setup" | sed -E 's/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g')
+  local dt_err=0
+  (
+    cd "$dir/dt" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    echo "$dolt_setup" | "$DOLT" sql >"$dir/dt.out" 2>"$dir/dt.err"
+  )
+  if grep -qiE 'error|fail' "$dir/dt.out" "$dir/dt.err" 2>/dev/null; then dt_err=1; fi
+
+  if [ "$dl_err" = 1 ] && [ "$dt_err" = 1 ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name (expected both to error)"
+    echo "    doltlite errored: $([ $dl_err = 1 ] && echo yes || echo NO)"
+    echo "    dolt errored:     $([ $dt_err = 1 ] && echo yes || echo NO)"
+  fi
+}
+
+echo "=== Version Control Oracle Tests: dolt_reset ==="
+echo ""
+
+SEED="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+"
+
+echo "--- reset with no ref (unstage) ---"
+
+# Stage some changes, then dolt_reset() with no args. Both engines
+# should leave HEAD where it is and move the staged changes back to
+# unstaged.
+oracle "reset_no_args_unstages_all" "
+$SEED
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_reset();
+"
+
+# Same as above with explicit --soft. Should be identical to no-args.
+oracle "reset_soft_no_ref_unstages_all" "
+$SEED
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_reset('--soft');
+"
+
+# --hard with no ref both unstages AND drops working-set changes.
+# Final state: clean working set, no staged changes, table contents
+# match HEAD.
+oracle "reset_hard_no_ref_clears_everything" "
+$SEED
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_add('-A');
+INSERT INTO t VALUES (3, 30);
+SELECT dolt_reset('--hard');
+"
+
+# Reset on a clean tree should be a no-op.
+oracle "reset_no_changes_to_unstage" "
+$SEED
+SELECT dolt_reset();
+"
+
+# Reset --hard on a clean tree should also be a no-op.
+oracle "reset_hard_no_changes" "
+$SEED
+SELECT dolt_reset('--hard');
+"
+
+echo "--- reset with ref (move HEAD) ---"
+
+# --soft to the previous commit: HEAD moves back, working set is
+# unchanged, the diff between c2 and c1 shows up as STAGED changes.
+oracle "reset_soft_to_previous_commit" "
+$SEED
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2');
+SELECT dolt_reset('--soft', 'HEAD~1');
+"
+
+# --hard to the previous commit: HEAD moves back, working set is
+# rewound, no staged or unstaged changes.
+oracle "reset_hard_to_previous_commit" "
+$SEED
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2');
+SELECT dolt_reset('--hard', 'HEAD~1');
+"
+
+# Reset to another branch's tip. Pulls main back to feature's tip
+# (which is identical to main's c1 because feature was branched
+# right after c1 with no further commits).
+oracle "reset_hard_to_branch_name" "
+$SEED
+SELECT dolt_branch('feature');
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2');
+SELECT dolt_reset('--hard', 'feature');
+"
+
+# Reset to a tag. Tags were promoted to first-class objects in
+# 0557f09b8 — verifies dolt_reset accepts a tag name as the target.
+# (This is the same surface gap that bit dolt_merge in PR #364, so
+# explicit oracle coverage matters.)
+oracle "reset_hard_to_tag" "
+$SEED
+SELECT dolt_tag('release-1');
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2');
+SELECT dolt_reset('--hard', 'release-1');
+"
+
+# Reset to a bare commit hash. Captures c1's hash via subquery so
+# the scenario is fully self-contained.
+oracle "reset_hard_to_commit_hash" "
+$SEED
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2');
+SELECT dolt_reset('--hard', (SELECT commit_hash FROM dolt_log WHERE message = 'c1'));
+"
+
+# Reset to current HEAD: HEAD doesn't move, staged/working unchanged.
+oracle "reset_hard_to_current_head_noop" "
+$SEED
+SELECT dolt_reset('--hard', 'HEAD');
+"
+
+# Working-set-only changes (no add) plus --hard should drop them.
+oracle "reset_hard_with_uncommitted_modifications" "
+$SEED
+INSERT INTO t VALUES (2, 20);
+INSERT INTO t VALUES (3, 30);
+SELECT dolt_reset('--hard');
+"
+
+echo "--- table-name positional unstage ---"
+
+# Stage two new tables, then reset only one of them. The other
+# should remain staged.
+oracle "reset_specific_table_unstages_only_that" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, v INT);
+CREATE TABLE b(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO a VALUES (1, 10);
+INSERT INTO b VALUES (1, 100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+INSERT INTO a VALUES (2, 20);
+INSERT INTO b VALUES (2, 200);
+SELECT dolt_add('-A');
+SELECT dolt_reset('a');
+"
+
+echo "--- error paths ---"
+
+oracle_error "reset_to_nonexistent_ref" "
+$SEED
+SELECT dolt_reset('--hard', 'nope');
+"
+
+oracle_error "reset_unknown_flag" "
+$SEED
+SELECT dolt_reset('--bogus');
+"
+
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+if [ $fail -gt 0 ]; then
+  echo "Failed:$FAILED_NAMES"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Adds a new \`vc_oracle_reset_test.sh\` with 15 scenarios covering reset surface area: \`--soft\` / \`--hard\` / \`--mixed\` (default), with and without target refs, target refs via branch / tag / commit hash / \`HEAD~N\`, no-op edge cases, table-name positional unstage, and error paths.

11 of 15 passed on first run. The 4 failures surfaced **three real divergences** from Dolt, all fixed in the same commit.

## The bugs

### 1. \`dolt_reset('--soft')\` was unstaging everything

doltlite treated \`--soft\` with no target ref as identical to no-args (unstage everything). Dolt (matching git) treats \`--soft\` with no target as a no-op — \`git reset --soft HEAD\` changes nothing — and reserves the unstage-all behavior for the no-args / \`--mixed\` forms. Fixed by returning early as a no-op when \`--soft\` is set without a target.

### 2. \`HEAD~N\` revision syntax wasn't supported

\`doltliteResolveRef\` only knew hex hashes, branch names, and tag names. The literal \`HEAD\` keyword and any \`~N\` / \`^N\` suffix failed to resolve, which silently broke \`dolt_reset('--hard', 'HEAD~1')\` and the same form for any other caller. This affects every consumer of \`doltliteResolveRef\`: merge, reset, log, cherry-pick, revert, and at.

Fixed by extending \`doltliteResolveRef\` with a small parser for the rightmost \`~N\` / \`^N\` suffix and a \`doltliteWalkFirstParent\` helper that walks N commits along the first-parent chain. Empty digit run (\`HEAD~\`) defaults to N=1, matching git. The \`HEAD\` base is handled. Chained suffixes (\`HEAD~2~3\`) are intentionally not supported.

### 3. \`dolt_reset('table_name')\` was failing

doltlite always treated the first non-flag positional as a target ref, errored on resolution failure, and never reached the path-based unstage case. Dolt supports \`dolt_reset table\` to unstage a specific table without touching HEAD or the working set.

Fixed by adding path-based unstage to \`doltliteResetFunc\`: when no mode flag is set and the first positional doesn't resolve as a ref, treat subsequent positionals as table names and rewrite the staged catalog so those tables match HEAD again. Mutually exclusive with \`--hard\` / \`--soft\` / a target ref.

## Self-tests that needed updating

Four pre-existing doltlite_*.sh test cases tested the **old (Dolt-divergent) \`--soft\`** semantics. They were inadvertently locking in doltlite-against-doltlite behavior rather than doltlite-against-Dolt — the exact failure mode oracle tests catch. Each one was updated to use the no-args form (\`dolt_reset()\`), which is the correct way to unstage under Dolt-compatible semantics.

## Test plan

- [x] \`vc_oracle_reset_test.sh\`: **15/15** (new)
- [x] \`vc_oracle_merge_test.sh\`: 15/15 (no regressions from the resolver change)
- [x] doltlite oracle suite: 39/39
- [x] \`vc_oracle_log_test.sh\`, status, add, branches, branch, tags, conflicts: all passing
- [x] \`index_oracle_test.sh\`: 526/526
- [ ] CI green