### PR TITLE
Harden chunk store and prolly storage parsing

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -138,6 +138,10 @@ static int csGrowWriteBuf(ChunkStore *cs, int nNeeded);
 
 static int csReplayWalRegion(ChunkStore *cs, int updateManifest);
 static int csReplayWal(ChunkStore *cs){ return csReplayWalRegion(cs, 1); }
+static void csFreeRefsState(ChunkStore *cs);
+static int csDeserializeRefsIntoTemp(ChunkStore *pTmp, const u8 *data, int nData);
+static void csAdoptRefsState(ChunkStore *pDst, ChunkStore *pSrc);
+static int csReloadFromDisk(ChunkStore *cs);
 
 #define CS_WAL_TAG_CHUNK  0x01
 #define CS_WAL_TAG_ROOT   0x02
@@ -191,6 +195,14 @@ static void csFreeTracking(ChunkStore *cs){
   sqlite3_free(cs->aTracking);
   cs->aTracking = 0;
   cs->nTracking = 0;
+}
+static void csFreeRefsState(ChunkStore *cs){
+  csFreeBranches(cs);
+  csFreeTags(cs);
+  csFreeRemotes(cs);
+  csFreeTracking(cs);
+  sqlite3_free(cs->zDefaultBranch);
+  cs->zDefaultBranch = 0;
 }
 
 #define CS_INIT_INDEX_ALLOC   64
@@ -483,6 +495,7 @@ static int csReplayWalRegion(ChunkStore *cs, int updateManifest){
   i64 walSize;
   u8 *walData;
   i64 pos;
+  int nRootedPending = cs->nPending;
 
   if( cs->iWalOffset <= 0 || !cs->pFile ) return SQLITE_OK;
 
@@ -559,11 +572,14 @@ static int csReplayWalRegion(ChunkStore *cs, int updateManifest){
         }
       }
       pos += CHUNK_MANIFEST_SIZE;
+      nRootedPending = cs->nPending;
 
     } else {
       break;
     }
   }
+
+  cs->nPending = nRootedPending;
 
   if( cs->nPending > 0 ){
     ChunkIndexEntry *aMerged = 0;
@@ -1343,12 +1359,43 @@ static int csDeserializeRefs(ChunkStore *cs, const u8 *data, int nData){
   return SQLITE_OK;
 }
 
+static int csDeserializeRefsIntoTemp(ChunkStore *pTmp, const u8 *data, int nData){
+  memset(pTmp, 0, sizeof(*pTmp));
+  return csDeserializeRefs(pTmp, data, nData);
+}
+
+static void csAdoptRefsState(ChunkStore *pDst, ChunkStore *pSrc){
+  pDst->aBranches = pSrc->aBranches;
+  pDst->nBranches = pSrc->nBranches;
+  pDst->zDefaultBranch = pSrc->zDefaultBranch;
+  pDst->aTags = pSrc->aTags;
+  pDst->nTags = pSrc->nTags;
+  pDst->aRemotes = pSrc->aRemotes;
+  pDst->nRemotes = pSrc->nRemotes;
+  pDst->aTracking = pSrc->aTracking;
+  pDst->nTracking = pSrc->nTracking;
+
+  pSrc->aBranches = 0;
+  pSrc->nBranches = 0;
+  pSrc->zDefaultBranch = 0;
+  pSrc->aTags = 0;
+  pSrc->nTags = 0;
+  pSrc->aRemotes = 0;
+  pSrc->nRemotes = 0;
+  pSrc->aTracking = 0;
+  pSrc->nTracking = 0;
+}
+
 int chunkStoreLoadRefsFromBlob(ChunkStore *cs, const u8 *data, int nData){
-  csFreeBranches(cs);
-  csFreeTags(cs);
-  csFreeRemotes(cs);
-  csFreeTracking(cs);
-  return csDeserializeRefs(cs, data, nData);
+  ChunkStore tmp;
+  int rc = csDeserializeRefsIntoTemp(&tmp, data, nData);
+  if( rc!=SQLITE_OK ){
+    csFreeRefsState(&tmp);
+    return rc;
+  }
+  csFreeRefsState(cs);
+  csAdoptRefsState(cs, &tmp);
+  return SQLITE_OK;
 }
 
 int chunkStoreSerializeRefsToBlob(ChunkStore *cs, u8 **ppOut, int *pnOut){
@@ -1542,6 +1589,11 @@ static int csCommitToFile(ChunkStore *cs){
   i64 writeOff;
   int lockFd = -1;
   int hadFile = (cs->pFile != 0);
+  i64 newWalSize = cs->nWalData;
+  u8 *pNewWalData = 0;
+  ChunkIndexEntry *aCommittedPending = 0;
+  ChunkIndexEntry *aMerged = 0;
+  int nMerged = 0;
 
   if( cs->pFile == 0 ){
     int openFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE
@@ -1565,16 +1617,60 @@ static int csCommitToFile(ChunkStore *cs){
 
   /* Detect concurrent writer: if file grew, re-read WAL to pick up new chunks. */
   if( fileSize > cs->iFileSize && hadFile ){
-    sqlite3_free(cs->pWalData);
-    cs->pWalData = 0;
-    cs->nWalData = 0;
-    {
-      int savePending = cs->nPending;
-      cs->nPending = 0;
-      csPendHTClear(cs);
-      csReplayWalRegion(cs, 1);
-      cs->nPending = savePending;
+    rc = csReloadFromDisk(cs);
+    if( rc != SQLITE_OK ) goto commit_done;
+    fileSize = cs->iFileSize;
+  }
+
+  if( cs->nPending > 0 ){
+    ChunkStore mergeView;
+    i64 walPos = cs->nWalData;
+    i64 appendBytes = 0;
+
+    for( i = 0; i < cs->nPending; i++ ){
+      if( appendBytes > LARGEST_INT64 - cs->aPending[i].size ){
+        rc = SQLITE_TOOBIG;
+        goto commit_done;
+      }
+      appendBytes += cs->aPending[i].size;
     }
+    if( cs->nWalData > LARGEST_INT64 - appendBytes ){
+      rc = SQLITE_TOOBIG;
+      goto commit_done;
+    }
+    newWalSize = cs->nWalData + appendBytes;
+    if( newWalSize > 0 ){
+      pNewWalData = (u8*)sqlite3_malloc64(newWalSize);
+      if( !pNewWalData ){
+        rc = SQLITE_NOMEM;
+        goto commit_done;
+      }
+      if( cs->nWalData > 0 ){
+        memcpy(pNewWalData, cs->pWalData, cs->nWalData);
+      }
+    }
+
+    aCommittedPending = (ChunkIndexEntry*)sqlite3_malloc(
+      cs->nPending * (int)sizeof(ChunkIndexEntry)
+    );
+    if( !aCommittedPending ){
+      rc = SQLITE_NOMEM;
+      goto commit_done;
+    }
+
+    for( i = 0; i < cs->nPending; i++ ){
+      ChunkIndexEntry *pSrc = &cs->aPending[i];
+      aCommittedPending[i] = *pSrc;
+      aCommittedPending[i].offset = csEncodeWalOffset(walPos);
+      memcpy(pNewWalData + walPos, cs->pWriteBuf + pSrc->offset + 4, pSrc->size);
+      walPos += pSrc->size;
+    }
+
+    mergeView = *cs;
+    mergeView.aPending = aCommittedPending;
+    mergeView.nPending = cs->nPending;
+    rc = csMergeIndex(&mergeView, &aMerged, &nMerged);
+    if( rc!=SQLITE_OK ) goto commit_done;
   }
 
   if( fileSize == 0 ){
@@ -1635,38 +1731,25 @@ static int csCommitToFile(ChunkStore *cs){
 commit_done:
   csFileUnlock(lockFd);
 
-  if( rc != SQLITE_OK ) return rc;
-
-  /* Move pending chunks into the WAL data cache with encoded offsets. */
-  for( i = 0; i < cs->nPending; i++ ){
-    ChunkIndexEntry *pe = &cs->aPending[i];
-    i64 bufOff = pe->offset + 4;
-    int sz = pe->size;
-
-    i64 newSize = cs->nWalData + sz;
-    u8 *newBuf = (u8*)sqlite3_realloc64(cs->pWalData, newSize);
-    if( newBuf ){
-      memcpy(newBuf + cs->nWalData, cs->pWriteBuf + bufOff, sz);
-      pe->offset = csEncodeWalOffset(cs->nWalData);
-      cs->pWalData = newBuf;
-      cs->nWalData = newSize;
-    } else {
-      return SQLITE_NOMEM;
-    }
+  if( rc != SQLITE_OK ){
+    sqlite3_free(aCommittedPending);
+    sqlite3_free(aMerged);
+    sqlite3_free(pNewWalData);
+    return rc;
   }
 
-  {
-    ChunkIndexEntry *aMerged = 0;
-    int nMerged = 0;
-    rc = csMergeIndex(cs, &aMerged, &nMerged);
-    if( rc!=SQLITE_OK ){
-      sqlite3_free(aMerged);
-      return rc;
-    }
+  sqlite3_free(aCommittedPending);
+  if( cs->nPending > 0 ){
     sqlite3_free(cs->aIndex);
     cs->aIndex = aMerged;
     cs->nIndex = nMerged;
     cs->nIndexAlloc = nMerged;
+    sqlite3_free(cs->pWalData);
+    cs->pWalData = pNewWalData;
+    cs->nWalData = newWalSize;
+  }else{
+    sqlite3_free(aMerged);
+    sqlite3_free(pNewWalData);
   }
 
   sqlite3_free(cs->pWriteBuf);
@@ -1724,6 +1807,7 @@ void chunkStoreClearRefs(ChunkStore *cs){
 int chunkStoreReloadRefs(ChunkStore *cs){
   u8 *refsData = 0;
   int nRefsData = 0;
+  ChunkStore tmp;
   int rc;
 
   if( prollyHashIsEmpty(&cs->refsHash) ) return SQLITE_OK;
@@ -1731,14 +1815,16 @@ int chunkStoreReloadRefs(ChunkStore *cs){
   rc = chunkStoreGet(cs, &cs->refsHash, &refsData, &nRefsData);
   if( rc!=SQLITE_OK ) return rc;
 
-  csFreeBranches(cs);
-  csFreeTags(cs);
-  csFreeRemotes(cs);
-  csFreeTracking(cs);
-
-  rc = csDeserializeRefs(cs, refsData, nRefsData);
+  rc = csDeserializeRefsIntoTemp(&tmp, refsData, nRefsData);
   sqlite3_free(refsData);
-  return rc;
+  if( rc!=SQLITE_OK ){
+    csFreeRefsState(&tmp);
+    return rc;
+  }
+
+  csFreeRefsState(cs);
+  csAdoptRefsState(cs, &tmp);
+  return SQLITE_OK;
 }
 
 const char *chunkStoreFilename(ChunkStore *cs){
@@ -1807,71 +1893,90 @@ int chunkStoreRefreshIfChanged(ChunkStore *cs, int *pChanged){
     i64 fileSize = 0;
     rc = sqlite3OsFileSize(cs->pFile, &fileSize);
     if( rc!=SQLITE_OK ) return rc;
-    if( fileSize > cs->iFileSize ){
-      /* File grew from another writer; re-read WAL to pick up new chunks.
-      ** Must also clear WAL-offset entries from the index because committed
-      ** chunks were appended as raw data to pWalData (at positions that won't
-      ** match the on-disk WAL format after re-read). Keeping the on-disk
-      ** sorted index entries is safe since their file offsets don't change. */
-      sqlite3_free(cs->pWalData);
-      cs->pWalData = 0;
-      cs->nWalData = 0;
-      cs->nPending = 0;
-      csPendHTClear(cs);
-      /* Remove WAL-offset entries from aIndex (keep file-offset entries). */
-      {
-        int rd, wr;
-        for(rd=0, wr=0; rd<cs->nIndex; rd++){
-          if( !csIsWalOffset(cs->aIndex[rd].offset) ){
-            if( wr!=rd ) cs->aIndex[wr] = cs->aIndex[rd];
-            wr++;
-          }
-        }
-        cs->nIndex = wr;
-      }
-      rc = csReplayWal(cs);
-      if( rc!=SQLITE_OK ) return rc;
-      cs->iFileSize = fileSize;
-      *pChanged = 1;
-    }
-    return SQLITE_OK;
+    if( fileSize <= cs->iFileSize ) return SQLITE_OK;
   }
 
-  /* File was moved/replaced (e.g., by GC). Reopen and reload everything. */
-  csCloseFile(cs->pFile);
-  cs->pFile = 0;
-  sqlite3_free(cs->aIndex);
-  cs->aIndex = 0; cs->nIndex = 0; cs->nIndexAlloc = 0;
-  sqlite3_free(cs->pWalData);
-  cs->pWalData = 0; cs->nWalData = 0;
-  csFreeBranches(cs);
-  csFreeTags(cs);
-  csFreeRemotes(cs);
-  csFreeTracking(cs);
-  sqlite3_free(cs->zDefaultBranch);
-  cs->zDefaultBranch = 0;
-  {
-    int openFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB;
-    rc = csOpenFile(cs->pVfs, cs->zFilename, &cs->pFile, openFlags);
-    if( rc!=SQLITE_OK ) return rc;
-  }
-  rc = csReadManifest(cs);
+  rc = csReloadFromDisk(cs);
   if( rc!=SQLITE_OK ) return rc;
-  rc = csReadIndex(cs);
-  if( rc!=SQLITE_OK ) return rc;
-  rc = csReplayWal(cs);
-  if( rc!=SQLITE_OK ) return rc;
-  if( !prollyHashIsEmpty(&cs->refsHash) ){
-    u8 *refsData = 0; int nRefsData = 0;
-    rc = chunkStoreGet(cs, &cs->refsHash, &refsData, &nRefsData);
-    if( rc==SQLITE_OK ){
-      rc = csDeserializeRefs(cs, refsData, nRefsData);
-      sqlite3_free(refsData);
-    }
-    if( rc!=SQLITE_OK ) return rc;
-  }
-  if( !cs->zDefaultBranch ) cs->zDefaultBranch = sqlite3_mprintf("main");
   *pChanged = 1;
+  return SQLITE_OK;
+}
+
+static int csReloadFromDisk(ChunkStore *cs){
+  ChunkStore tmp;
+  sqlite3_file *pOldFile = cs->pFile;
+  ChunkIndexEntry *aOldIndex = cs->aIndex;
+  u8 *pOldWalData = cs->pWalData;
+  char *zOldDefaultBranch = cs->zDefaultBranch;
+  struct BranchRef *aOldBranches = cs->aBranches;
+  struct TagRef *aOldTags = cs->aTags;
+  struct RemoteRef *aOldRemotes = cs->aRemotes;
+  struct TrackingBranch *aOldTracking = cs->aTracking;
+  int rc = chunkStoreOpen(&tmp, cs->pVfs, cs->zFilename,
+                          SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB);
+  if( rc!=SQLITE_OK ) return rc;
+
+  cs->pFile = tmp.pFile;
+  cs->readOnly = tmp.readOnly;
+  cs->refsHash = tmp.refsHash;
+  cs->workingState = tmp.workingState;
+  cs->stagedCatalog = tmp.stagedCatalog;
+  cs->isMerging = tmp.isMerging;
+  cs->mergeCommitHash = tmp.mergeCommitHash;
+  cs->conflictsCatalogHash = tmp.conflictsCatalogHash;
+  cs->nChunks = tmp.nChunks;
+  cs->iIndexOffset = tmp.iIndexOffset;
+  cs->nIndexSize = tmp.nIndexSize;
+  cs->iWalOffset = tmp.iWalOffset;
+  cs->iFileSize = tmp.iFileSize;
+  cs->aIndex = tmp.aIndex;
+  cs->nIndex = tmp.nIndex;
+  cs->nIndexAlloc = tmp.nIndexAlloc;
+  cs->pWalData = tmp.pWalData;
+  cs->nWalData = tmp.nWalData;
+  cs->aBranches = tmp.aBranches;
+  cs->nBranches = tmp.nBranches;
+  cs->zDefaultBranch = tmp.zDefaultBranch;
+  cs->aTags = tmp.aTags;
+  cs->nTags = tmp.nTags;
+  cs->aRemotes = tmp.aRemotes;
+  cs->nRemotes = tmp.nRemotes;
+  cs->aTracking = tmp.aTracking;
+  cs->nTracking = tmp.nTracking;
+
+  tmp.pFile = 0;
+  tmp.aIndex = 0;
+  tmp.nIndex = 0;
+  tmp.nIndexAlloc = 0;
+  tmp.pWalData = 0;
+  tmp.nWalData = 0;
+  tmp.aBranches = 0;
+  tmp.nBranches = 0;
+  tmp.zDefaultBranch = 0;
+  tmp.aTags = 0;
+  tmp.nTags = 0;
+  tmp.aRemotes = 0;
+  tmp.nRemotes = 0;
+  tmp.aTracking = 0;
+  tmp.nTracking = 0;
+  chunkStoreClose(&tmp);
+
+  csCloseFile(pOldFile);
+  sqlite3_free(aOldIndex);
+  sqlite3_free(pOldWalData);
+  sqlite3_free(zOldDefaultBranch);
+  {
+    ChunkStore oldRefs;
+    memset(&oldRefs, 0, sizeof(oldRefs));
+    oldRefs.aBranches = aOldBranches;
+    oldRefs.aTags = aOldTags;
+    oldRefs.aRemotes = aOldRemotes;
+    oldRefs.aTracking = aOldTracking;
+    csFreeBranches(&oldRefs);
+    csFreeTags(&oldRefs);
+    csFreeRemotes(&oldRefs);
+    csFreeTracking(&oldRefs);
+  }
   return SQLITE_OK;
 }
 

--- a/src/prolly_diff.c
+++ b/src/prolly_diff.c
@@ -2,6 +2,7 @@
 #ifdef DOLTLITE_PROLLY
 
 #include "prolly_diff.h"
+#include "doltlite_record.h"
 
 #include <string.h>  
 
@@ -117,24 +118,6 @@ static int diffEmitModify(
   return xCallback(pCtx, &change);
 }
 
-static int diffReadVarint(const u8 *p, const u8 *pEnd, u64 *pVal){
-  u64 v = 0;
-  int i;
-  if( p >= pEnd ){ *pVal = 0; return 0; }
-  for(i=0; i<9 && p+i<pEnd; i++){
-    if( i<8 ){
-      v = (v << 7) | (p[i] & 0x7f);
-      if( (p[i] & 0x80)==0 ){ *pVal = v; return i+1; }
-    }else{
-      v = (v << 8) | p[i];
-      *pVal = v;
-      return 9;
-    }
-  }
-  *pVal = v;
-  return i ? i : 0;
-}
-
 static int diffSerialTypeSize(u64 st){
   if( st==0 ) return 0;
   if( st==1 ) return 1;
@@ -169,9 +152,9 @@ int diffRecordsEqualFieldwise(
   pEndA = pA + nA;
   pEndB = pB + nB;
 
-  hdrBytesA = diffReadVarint(pA, pEndA, &hdrSizeA);
+  hdrBytesA = dlReadVarint(pA, pEndA, &hdrSizeA);
   if( hdrBytesA == 0 ) return 0;
-  hdrBytesB = diffReadVarint(pB, pEndB, &hdrSizeB);
+  hdrBytesB = dlReadVarint(pB, pEndB, &hdrSizeB);
   if( hdrBytesB == 0 ) return 0;
 
   if( (int)hdrSizeA < hdrBytesA || (int)hdrSizeA > nA ) return 0;
@@ -189,12 +172,12 @@ int diffRecordsEqualFieldwise(
     int szA, szB;
 
     if( hpA < hdrEndA ){
-      int n = diffReadVarint(hpA, hdrEndA, &stA);
+      int n = dlReadVarint(hpA, hdrEndA, &stA);
       if( n == 0 ) return 0;
       hpA += n;
     }
     if( hpB < hdrEndB ){
-      int n = diffReadVarint(hpB, hdrEndB, &stB);
+      int n = dlReadVarint(hpB, hdrEndB, &stB);
       if( n == 0 ) return 0;
       hpB += n;
     }

--- a/src/prolly_node.c
+++ b/src/prolly_node.c
@@ -30,6 +30,7 @@ int prollyNodeParse(ProllyNode *pNode, const u8 *pData, int nData){
   u32 totalKeyBytes;   
   u32 totalValBytes;   
   const u8 *pCur;
+  int i;
 
   memset(pNode, 0, sizeof(*pNode));
 
@@ -48,8 +49,14 @@ int prollyNodeParse(ProllyNode *pNode, const u8 *pData, int nData){
   pNode->nData = nData;
   pNode->level = pData[PROLLY_LEVEL_OFF];
   count = PROLLY_GET_U16(pData + PROLLY_COUNT_OFF);
+  if( count > PROLLY_NODE_MAX_ITEMS ){
+    return SQLITE_CORRUPT;
+  }
   pNode->nItems = count;
   pNode->flags = pData[PROLLY_FLAGS_OFF];
+  if( pNode->flags!=PROLLY_NODE_INTKEY && pNode->flags!=PROLLY_NODE_BLOBKEY ){
+    return SQLITE_CORRUPT;
+  }
 
   if( count==0 ){
     
@@ -85,6 +92,27 @@ int prollyNodeParse(ProllyNode *pNode, const u8 *pData, int nData){
   if( totalKeyBytes > (u32)nData || totalValBytes > (u32)nData
    || minSize + (int)totalKeyBytes + (int)totalValBytes != nData ){
     return SQLITE_CORRUPT;
+  }
+
+  for(i=0; i<=count; i++){
+    u32 keyOff = PROLLY_GET_U32((const u8*)&pNode->aKeyOff[i]);
+    u32 valOff = PROLLY_GET_U32((const u8*)&pNode->aValOff[i]);
+    if( keyOff > totalKeyBytes || valOff > totalValBytes ){
+      return SQLITE_CORRUPT;
+    }
+    if( i>0 ){
+      u32 prevKeyOff = PROLLY_GET_U32((const u8*)&pNode->aKeyOff[i-1]);
+      u32 prevValOff = PROLLY_GET_U32((const u8*)&pNode->aValOff[i-1]);
+      if( keyOff < prevKeyOff || valOff < prevValOff ){
+        return SQLITE_CORRUPT;
+      }
+      if( (pNode->flags & PROLLY_NODE_INTKEY) && keyOff - prevKeyOff != 8 ){
+        return SQLITE_CORRUPT;
+      }
+      if( pNode->level>0 && valOff - prevValOff != PROLLY_HASH_SIZE ){
+        return SQLITE_CORRUPT;
+      }
+    }
   }
 
   return SQLITE_OK;

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -25,6 +25,9 @@
 **   ./doltlite_regression_test_c branches_metadata_corruption
 **   ./doltlite_regression_test_c gc_rewrite_failure
 **   ./doltlite_regression_test_c record_decode_corruption
+**   ./doltlite_regression_test_c reload_refs_transactional
+**   ./doltlite_regression_test_c refresh_refs_corruption_preserves_state
+**   ./doltlite_regression_test_c prolly_node_corruption
 */
 #include <stdio.h>
 #include <stdlib.h>
@@ -38,6 +41,7 @@
 #include "doltlite_ancestor.h"
 #include "doltlite_internal.h"
 #include "doltlite_record.h"
+#include "prolly_node.h"
 
 typedef unsigned char u8;
 typedef unsigned int Pgno;
@@ -1130,6 +1134,141 @@ static void run_record_decode_corruption(void){
   sqlite3_free(z);
 }
 
+static void run_reload_refs_transactional(void){
+  ChunkStore cs;
+  ProllyHash emptyHash;
+  ProllyHash badHash;
+  static const u8 badBlob[] = { 6, 0, 0, 0 };
+  int nBranchesBefore;
+  char *zDefaultBefore = 0;
+  char *zBranchBefore = 0;
+  int rc;
+
+  printf("=== Reload Refs Transactional Test ===\n\n");
+  memset(&emptyHash, 0, sizeof(emptyHash));
+  check("open_mem_store",
+        chunkStoreOpen(&cs, sqlite3_vfs_find(0), ":memory:", 0)==SQLITE_OK);
+  check("set_default_branch",
+        chunkStoreSetDefaultBranch(&cs, "main")==SQLITE_OK);
+  check("add_branch",
+        chunkStoreAddBranch(&cs, "main", &emptyHash)==SQLITE_OK);
+  check("serialize_good_refs",
+        chunkStoreSerializeRefs(&cs)==SQLITE_OK);
+  nBranchesBefore = cs.nBranches;
+  zDefaultBefore = sqlite3_mprintf("%s", cs.zDefaultBranch ? cs.zDefaultBranch : "");
+  zBranchBefore = (cs.aBranches && cs.nBranches>0 && cs.aBranches[0].zName)
+                ? sqlite3_mprintf("%s", cs.aBranches[0].zName)
+                : sqlite3_mprintf("");
+
+  check("load_bad_refs_blob_as_chunk",
+        chunkStorePut(&cs, badBlob, (int)sizeof(badBlob), &badHash)==SQLITE_OK);
+
+  rc = chunkStoreLoadRefsFromBlob(&cs, badBlob, (int)sizeof(badBlob));
+  check("load_refs_blob_returns_corrupt", rc==SQLITE_CORRUPT);
+  check("load_refs_blob_preserves_default_branch",
+        cs.zDefaultBranch && strcmp(cs.zDefaultBranch, zDefaultBefore)==0);
+  check("load_refs_blob_preserves_branch_count", cs.nBranches==nBranchesBefore);
+  check("load_refs_blob_preserves_branch_name",
+        nBranchesBefore==0 ||
+        (cs.aBranches && cs.aBranches[0].zName
+         && strcmp(cs.aBranches[0].zName, zBranchBefore)==0));
+
+  memcpy(&cs.refsHash, &badHash, sizeof(badHash));
+  rc = chunkStoreReloadRefs(&cs);
+  check("reload_refs_returns_corrupt", rc==SQLITE_CORRUPT);
+  check("reload_refs_preserves_default_branch",
+        cs.zDefaultBranch && strcmp(cs.zDefaultBranch, zDefaultBefore)==0);
+  check("reload_refs_preserves_branch_count", cs.nBranches==nBranchesBefore);
+  check("reload_refs_preserves_branch_name",
+        nBranchesBefore==0 ||
+        (cs.aBranches && cs.aBranches[0].zName
+         && strcmp(cs.aBranches[0].zName, zBranchBefore)==0));
+
+  sqlite3_free(zDefaultBefore);
+  sqlite3_free(zBranchBefore);
+  chunkStoreClose(&cs);
+}
+
+static void run_refresh_refs_corruption_preserves_state(void){
+  sqlite3 *db = 0;
+  ChunkStore cs1;
+  ChunkStore cs2;
+  ProllyHash badHash;
+  static const u8 badBlob[] = { 6, 0, 0, 0 };
+  char dbpath[256];
+  int nBranchesBefore;
+  char *zDefaultBefore = 0;
+  char *zBranchBefore = 0;
+  int changed = -1;
+  int rc;
+
+  printf("=== Refresh Corrupt Refs State Preservation Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_refresh_refs_preserves_state");
+  remove_db(dbpath);
+
+  check("open_db", open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_repo", execsql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'a');"
+    "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
+  sqlite3_close(db);
+  db = 0;
+
+  check("open_store_1", chunkStoreOpen(&cs1, sqlite3_vfs_find(0), dbpath,
+        SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB)==SQLITE_OK);
+  nBranchesBefore = cs1.nBranches;
+  zDefaultBefore = sqlite3_mprintf("%s", cs1.zDefaultBranch ? cs1.zDefaultBranch : "");
+  zBranchBefore = (cs1.aBranches && cs1.nBranches>0 && cs1.aBranches[0].zName)
+                ? sqlite3_mprintf("%s", cs1.aBranches[0].zName)
+                : sqlite3_mprintf("");
+
+  check("open_store_2", chunkStoreOpen(&cs2, sqlite3_vfs_find(0), dbpath,
+        SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB)==SQLITE_OK);
+  check("lock_store_2", chunkStoreLockAndRefresh(&cs2)==SQLITE_OK);
+  check("put_bad_refs_chunk",
+        chunkStorePut(&cs2, badBlob, (int)sizeof(badBlob), &badHash)==SQLITE_OK);
+  memcpy(&cs2.refsHash, &badHash, sizeof(badHash));
+  check("commit_bad_refs_hash", chunkStoreCommit(&cs2)==SQLITE_OK);
+  chunkStoreUnlock(&cs2);
+  chunkStoreClose(&cs2);
+
+  rc = chunkStoreRefreshIfChanged(&cs1, &changed);
+  check("refresh_returns_error_for_corrupt_refs", rc==SQLITE_CORRUPT);
+  check("refresh_does_not_mark_changed", changed==0);
+  check("refresh_preserves_default_branch",
+        cs1.zDefaultBranch && strcmp(cs1.zDefaultBranch, zDefaultBefore)==0);
+  check("refresh_preserves_branch_count", cs1.nBranches==nBranchesBefore);
+  check("refresh_preserves_branch_name",
+        nBranchesBefore==0 ||
+        (cs1.aBranches && cs1.aBranches[0].zName
+         && strcmp(cs1.aBranches[0].zName, zBranchBefore)==0));
+
+  sqlite3_free(zDefaultBefore);
+  sqlite3_free(zBranchBefore);
+  chunkStoreClose(&cs1);
+  remove_db(dbpath);
+}
+
+static void run_prolly_node_corruption(void){
+  static const u8 badIntKeyNode[] = {
+    'D','O','N','P',
+    0,
+    1, 0,
+    PROLLY_NODE_INTKEY,
+    0,0,0,0,
+    7,0,0,0,
+    0,0,0,0,
+    1,0,0,0,
+    1,2,3,4,5,6,7,
+    0x2a
+  };
+  ProllyNode node;
+
+  printf("=== Prolly Node Corruption Test ===\n\n");
+  check("intkey_width_corruption_is_rejected",
+        prollyNodeParse(&node, badIntKeyNode, (int)sizeof(badIntKeyNode))==SQLITE_CORRUPT);
+}
+
 static const RegressionCase aCases[] = {
   { "concurrent_refs", "Concurrent Refs Test", run_concurrent_refs },
   { "checkout_persist_failure", "Checkout Persist Failure Test", run_checkout_persist_failure },
@@ -1149,7 +1288,10 @@ static const RegressionCase aCases[] = {
   { "cherry_pick_stale_branch", "Cherry-pick Stale Branch Test", run_cherry_pick_stale_branch },
   { "branches_metadata_corruption", "Branches Metadata Corruption Test", run_branches_metadata_corruption },
   { "gc_rewrite_failure", "GC Rewrite Failure Test", run_gc_rewrite_failure },
-  { "record_decode_corruption", "Record Decode Corruption Test", run_record_decode_corruption }
+  { "record_decode_corruption", "Record Decode Corruption Test", run_record_decode_corruption },
+  { "reload_refs_transactional", "Reload Refs Transactional Test", run_reload_refs_transactional },
+  { "refresh_refs_corruption_preserves_state", "Refresh Corrupt Refs State Preservation Test", run_refresh_refs_corruption_preserves_state },
+  { "prolly_node_corruption", "Prolly Node Corruption Test", run_prolly_node_corruption }
 };
 
 static int run_case_by_name(const char *zName){


### PR DESCRIPTION
This hardens the storage core in the chunk store and prolly layers.

Main changes:
- make refs reload/load transactional in memory
- make refresh/reload use a full disk reload helper instead of tearing down live state first
- prebuild post-commit in-memory WAL/index state before fsync so post-fsync OOM does not leave a half-updated store
- reject corrupt prolly node offset/width layouts
- route prolly diff fieldwise comparison through the shared varint reader
- add focused regressions for refs reload preservation, refresh corruption handling, and corrupt prolly nodes
