### PR TITLE
Harden prolly btree commit and cursor flush paths

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -328,6 +328,8 @@ static int flushMutMap(BtCursor *pCur);
 static void getCursorPayload(BtCursor *pCur, const u8 **ppData, int *pnData);
 static int flushIfNeeded(BtCursor *pCur);
 static int flushAllPending(BtShared *pBt, Pgno iTable);
+static int applyMutMapToTableRoot(BtShared *pBt, struct TableEntry *pTE, ProllyMutMap *pMap);
+static int cacheCursorPayloadCopy(BtCursor *pCur, const u8 *pData, int nData);
 static int flushDeferredEdits(BtShared *pBt);
 static int ensureMutMap(BtCursor *pCur);
 static int saveCursorPosition(BtCursor *pCur);
@@ -974,10 +976,44 @@ static int deserializeCatalog(Btree *pBtree, const u8 *data, int nData){
   return SQLITE_OK;
 }
 
-static int flushMutMap(BtCursor *pCur){
-  int rc;
-  struct TableEntry *pTE;
+static int applyMutMapToTableRoot(
+  BtShared *pBt,
+  struct TableEntry *pTE,
+  ProllyMutMap *pMap
+){
   ProllyMutator mut;
+  int rc;
+
+  memset(&mut, 0, sizeof(mut));
+  mut.pStore = &pBt->store;
+  mut.pCache = &pBt->cache;
+  mut.oldRoot = pTE->root;
+  mut.pEdits = pMap;
+  mut.flags = pTE->flags;
+
+  rc = prollyMutateFlush(&mut);
+  if( rc!=SQLITE_OK ) return rc;
+
+  pTE->root = mut.newRoot;
+  return SQLITE_OK;
+}
+
+static int cacheCursorPayloadCopy(BtCursor *pCur, const u8 *pData, int nData){
+  u8 *pCopy = 0;
+  if( nData > 0 ){
+    pCopy = sqlite3_malloc(nData);
+    if( !pCopy ) return SQLITE_NOMEM;
+    memcpy(pCopy, pData, nData);
+  }
+  CLEAR_CACHED_PAYLOAD(pCur);
+  pCur->pCachedPayload = pCopy;
+  pCur->nCachedPayload = nData;
+  pCur->cachedPayloadOwned = 1;
+  return SQLITE_OK;
+}
+
+static int flushMutMap(BtCursor *pCur){
+  struct TableEntry *pTE;
 
   if( !pCur->pMutMap || prollyMutMapIsEmpty(pCur->pMutMap) ){
     return SQLITE_OK;
@@ -988,20 +1024,11 @@ static int flushMutMap(BtCursor *pCur){
     return SQLITE_INTERNAL;
   }
 
-  memset(&mut, 0, sizeof(mut));
-  mut.pStore = &pCur->pBt->store;
-  mut.pCache = &pCur->pBt->cache;
-  mut.oldRoot = pTE->root;
-  mut.pEdits = pCur->pMutMap;
-  mut.flags = pTE->flags;
-
-  rc = prollyMutateFlush(&mut);
-  if( rc!=SQLITE_OK ){
-    return rc;
+  {
+    int rc = applyMutMapToTableRoot(pCur->pBt, pTE, pCur->pMutMap);
+    if( rc!=SQLITE_OK ) return rc;
   }
-
-  pTE->root = mut.newRoot;
-  pCur->pCur.root = mut.newRoot;
+  pCur->pCur.root = pTE->root;
   prollyMutMapClear(pCur->pMutMap);
 
   return SQLITE_OK;
@@ -2123,7 +2150,11 @@ int sqlite3BtreeCommitPhaseOne(Btree *p, const char *zSuperJrnl){
 static int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
   BtShared *pBt = p->pBt;
   int rc = SQLITE_OK;
+  int rcRollback = SQLITE_OK;
+  ProllyHash oldWorkingState;
   (void)bCleanup;
+
+  oldWorkingState = pBt->store.workingState;
 
   if( p->inTrans==TRANS_WRITE ){
     /* Step 1: flush all in-memory edits to prolly trees */
@@ -2155,7 +2186,23 @@ static int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
       if( pBt->pPagerShim ){
         pBt->pPagerShim->iDataVersion++;
       }
+      p->inTrans = TRANS_NONE;
+      p->inTransaction = TRANS_NONE;
+      p->nSavepoint = 0;
+
+      chunkStoreUnlock(&pBt->store);
+      pBt->store.snapshotPinned = 0;
+    }else{
+      /* SQLite tears down the outer transaction on COMMIT failure here.
+      ** Roll back our in-memory roots and chunk-store state so the
+      ** connection does not keep seeing uncommitted edits. */
+      pBt->store.workingState = oldWorkingState;
+      rcRollback = prollyBtreeRollback(p, rc, 0);
+      if( rcRollback!=SQLITE_OK ){
+        return rcRollback;
+      }
     }
+    return rc;
   }
 
   p->inTrans = TRANS_NONE;
@@ -2571,7 +2618,8 @@ static int prollyBtreeCursor(
     for(pOther = pBt->pCursor; pOther; pOther = pOther->pNext){
       if( pOther->pgnoRoot==iTable && pOther->pMutMap
           && !prollyMutMapIsEmpty(pOther->pMutMap) ){
-        flushMutMap(pOther);
+        int rc = flushMutMap(pOther);
+        if( rc!=SQLITE_OK ) return rc;
       }
     }
   }
@@ -2590,18 +2638,7 @@ static int prollyBtreeCursor(
       
       ProllyMutMap *pMap = (ProllyMutMap*)pTE->pPending;
       if( !prollyMutMapIsEmpty(pMap) ){
-        ProllyMutator mut;
-        int rc2;
-        memset(&mut, 0, sizeof(mut));
-        mut.pStore = &pBt->store;
-        mut.pCache = &pBt->cache;
-        memcpy(&mut.oldRoot, &pTE->root, sizeof(ProllyHash));
-        mut.pEdits = pMap;
-        mut.flags = pTE->flags;
-        rc2 = prollyMutateFlush(&mut);
-        if( rc2==SQLITE_OK ){
-          memcpy(&pTE->root, &mut.newRoot, sizeof(ProllyHash));
-        }
+        int rc2 = applyMutMapToTableRoot(pBt, pTE, pMap);
         prollyMutMapFree(pMap);
         sqlite3_free(pMap);
         pTE->pPending = 0;
@@ -2650,14 +2687,15 @@ static int prollyBtCursorCloseCursor(BtCursor *pCur){
       pTE->pendingFlushSeekEdits = pCur->flushSeekEdits;
       pCur->pMutMap = 0;
     }else if( pTE && pTE->pPending ){
-      
-      prollyMutMapMerge((ProllyMutMap*)pTE->pPending, pCur->pMutMap);
-      pTE->pendingFlushSeekEdits = pCur->flushSeekEdits;
+      int rc = prollyMutMapMerge((ProllyMutMap*)pTE->pPending, pCur->pMutMap);
+      if( rc!=SQLITE_OK ) return rc;
+      pTE->pendingFlushSeekEdits |= pCur->flushSeekEdits;
       prollyMutMapFree(pCur->pMutMap);
       sqlite3_free(pCur->pMutMap);
       pCur->pMutMap = 0;
     }else{
-      flushMutMap(pCur);
+      int rc = flushMutMap(pCur);
+      if( rc!=SQLITE_OK ) return rc;
     }
   }
 
@@ -2881,18 +2919,7 @@ static int flushTablePending(BtCursor *pCur){
   if( pTE && pTE->pPending ){
     ProllyMutMap *pMap = (ProllyMutMap*)pTE->pPending;
     if( !prollyMutMapIsEmpty(pMap) ){
-      ProllyMutator mut;
-      int rc;
-      memset(&mut, 0, sizeof(mut));
-      mut.pStore = &pCur->pBt->store;
-      mut.pCache = &pCur->pBt->cache;
-      memcpy(&mut.oldRoot, &pTE->root, sizeof(ProllyHash));
-      mut.pEdits = pMap;
-      mut.flags = pTE->flags;
-      rc = prollyMutateFlush(&mut);
-      if( rc==SQLITE_OK ){
-        memcpy(&pTE->root, &mut.newRoot, sizeof(ProllyHash));
-      }
+      int rc = applyMutMapToTableRoot(pCur->pBt, pTE, pMap);
       prollyMutMapFree(pMap);
       sqlite3_free(pMap);
       pTE->pPending = 0;
@@ -3222,21 +3249,8 @@ static int prollyBtCursorTableMoveto(
         pCur->curFlags |= BTCF_ValidNKey;
         pCur->cachedIntKey = intKey;
         
-        if( pCur->cachedPayloadOwned && pCur->pCachedPayload ){
-          sqlite3_free(pCur->pCachedPayload);
-        }
-        if( pEntry->nVal > 0 && pEntry->pVal ){
-          pCur->pCachedPayload = sqlite3_malloc(pEntry->nVal);
-          if( pCur->pCachedPayload ){
-            memcpy(pCur->pCachedPayload, pEntry->pVal, pEntry->nVal);
-            pCur->nCachedPayload = pEntry->nVal;
-          } else {
-            pCur->nCachedPayload = 0;
-          }
-        } else {
-          CLEAR_CACHED_PAYLOAD(pCur);
-        }
-        pCur->cachedPayloadOwned = 1;
+  rc = cacheCursorPayloadCopy(pCur, pEntry->pVal, pEntry->nVal);
+  if( rc!=SQLITE_OK ) return rc;
         
         refreshCursorRoot(pCur);
         {
@@ -3726,22 +3740,10 @@ static int prollyBtCursorIndexMoveto(
       if( pCur->cachedPayloadOwned && pCur->pCachedPayload ){
         sqlite3_free(pCur->pCachedPayload);
       }
-      if( mutNKey > 0 ){
-        
-        u8 *pCopy = sqlite3_malloc(mutNKey);
-        if( pCopy ){
-          memcpy(pCopy, mutKey, mutNKey);
-          pCur->pCachedPayload = pCopy;
-          pCur->nCachedPayload = mutNKey;
-        } else {
-          pCur->nCachedPayload = 0;
-          pCur->pCachedPayload = 0;
-        }
-      } else {
-        pCur->pCachedPayload = 0;
-        pCur->nCachedPayload = 0;
+      rc = cacheCursorPayloadCopy(pCur, mutKey, mutNKey);
+      if( rc!=SQLITE_OK ){
+        return rc;
       }
-      pCur->cachedPayloadOwned = 1;
       *pRes = mutCmp;
       pCur->eState = CURSOR_VALID;
       return SQLITE_OK;
@@ -4042,21 +4044,11 @@ static int prollyBtCursorInsert(
         pCur->eState = CURSOR_VALID;
         pCur->curFlags |= BTCF_ValidNKey;
         pCur->cachedIntKey = pPayload->nKey;
-        if( pCur->cachedPayloadOwned && pCur->pCachedPayload ){
-          sqlite3_free(pCur->pCachedPayload);
-        }
-        if( pEntry && pEntry->nVal > 0 && pEntry->pVal ){
-          pCur->pCachedPayload = sqlite3_malloc(pEntry->nVal);
-          if( pCur->pCachedPayload ){
-            memcpy(pCur->pCachedPayload, pEntry->pVal, pEntry->nVal);
-            pCur->nCachedPayload = pEntry->nVal;
-          } else {
-            pCur->nCachedPayload = 0;
-          }
-        } else {
-          CLEAR_CACHED_PAYLOAD(pCur);
-        }
-        pCur->cachedPayloadOwned = 1;
+        rc = cacheCursorPayloadCopy(
+            pCur,
+            (pEntry && pEntry->nVal > 0 && pEntry->pVal) ? pEntry->pVal : 0,
+            (pEntry && pEntry->nVal > 0 && pEntry->pVal) ? pEntry->nVal : 0);
+        if( rc!=SQLITE_OK ) return rc;
         /* The MutMap was modified — the merge iteration state (mmIdx,
         ** mergeSrc) is stale. Reset so the next Next/Previous call
         ** re-synchronizes the merge cursor with the updated MutMap. */
@@ -4227,17 +4219,7 @@ static int flushDeferredEdits(BtShared *pBt){
     for(i=0; i<pBtree->nTables; i++){
       struct TableEntry *pTE = &pBtree->aTables[i];
       if( pTE->pPending && !prollyMutMapIsEmpty((ProllyMutMap*)pTE->pPending) ){
-        ProllyMutator mut;
-        memset(&mut, 0, sizeof(mut));
-        mut.pStore = &pBt->store;
-        mut.pCache = &pBt->cache;
-        memcpy(&mut.oldRoot, &pTE->root, sizeof(ProllyHash));
-        mut.pEdits = (ProllyMutMap*)pTE->pPending;
-        mut.flags = pTE->flags;
-        rc = prollyMutateFlush(&mut);
-        if( rc==SQLITE_OK ){
-          memcpy(&pTE->root, &mut.newRoot, sizeof(ProllyHash));
-        }
+        rc = applyMutMapToTableRoot(pBt, pTE, (ProllyMutMap*)pTE->pPending);
         prollyMutMapFree((ProllyMutMap*)pTE->pPending);
         sqlite3_free(pTE->pPending);
         pTE->pPending = 0;

--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -227,7 +227,7 @@ void prollyMutMapIterNext(ProllyMutMapIter *it){
 }
 
 int prollyMutMapIterValid(ProllyMutMapIter *it){
-  return it->idx < it->pMap->nEntries;
+  return it->idx >= 0 && it->idx < it->pMap->nEntries;
 }
 
 ProllyMutMapEntry *prollyMutMapIterEntry(ProllyMutMapIter *it){
@@ -243,7 +243,7 @@ void prollyMutMapIterSeek(ProllyMutMapIter *it, ProllyMutMap *mm,
 
 void prollyMutMapIterLast(ProllyMutMapIter *it, ProllyMutMap *mm){
   it->pMap = mm;
-  it->idx = mm->nEntries - 1;
+  it->idx = mm->nEntries>0 ? mm->nEntries - 1 : mm->nEntries;
 }
 
 void prollyMutMapClear(ProllyMutMap *mm){

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -28,6 +28,8 @@
 **   ./doltlite_regression_test_c reload_refs_transactional
 **   ./doltlite_regression_test_c refresh_refs_corruption_preserves_state
 **   ./doltlite_regression_test_c prolly_node_corruption
+**   ./doltlite_regression_test_c btree_commit_failure_transactional
+**   ./doltlite_regression_test_c mutmap_empty_reverse_iter
 */
 #include <stdio.h>
 #include <stdlib.h>
@@ -42,6 +44,7 @@
 #include "doltlite_internal.h"
 #include "doltlite_record.h"
 #include "prolly_node.h"
+#include "prolly_mutmap.h"
 
 typedef unsigned char u8;
 typedef unsigned int Pgno;
@@ -155,6 +158,7 @@ struct FailFile {
 
 static sqlite3_vfs gFailVfs;
 static sqlite3_vfs *gBaseVfs = 0;
+static int gFailWriteOnce = 0;
 static int gFailSyncOnce = 0;
 static int gFailAccessOnce = 0;
 static int gFailHasMovedOnce = 0;
@@ -175,6 +179,11 @@ static int failRead(sqlite3_file *pFile, void *zBuf, int iAmt, sqlite3_int64 iOf
 
 static int failWrite(sqlite3_file *pFile, const void *zBuf, int iAmt, sqlite3_int64 iOfst){
   FailFile *p = (FailFile*)pFile;
+  if( gFailWriteOnce>0 ){
+    gFailWriteOnce--;
+    gFailHits++;
+    return SQLITE_IOERR_WRITE;
+  }
   return p->pReal->pMethods->xWrite(p->pReal, zBuf, iAmt, iOfst);
 }
 
@@ -1269,6 +1278,52 @@ static void run_prolly_node_corruption(void){
         prollyNodeParse(&node, badIntKeyNode, (int)sizeof(badIntKeyNode))==SQLITE_CORRUPT);
 }
 
+static void run_btree_commit_failure_transactional(void){
+  sqlite3 *db = 0;
+  char dbpath[256];
+  int rc;
+
+  printf("=== Btree Commit Failure Transaction Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_btree_commit_failure_transactional");
+  remove_db(dbpath);
+  gFailWriteOnce = 0;
+  gFailSyncOnce = 0;
+  gFailHits = 0;
+
+  check("register_fail_vfs_for_btree_commit", registerFailVfs()==SQLITE_OK);
+  check("open_fail_db_for_btree_commit", open_fail_db(dbpath, &db)==SQLITE_OK);
+  check("setup_table", execsql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'a');")==SQLITE_OK);
+  check("begin_write_txn", execsql(db, "BEGIN; INSERT INTO t VALUES(2,'b');")==SQLITE_OK);
+
+  gFailWriteOnce = 1;
+  rc = execsql_silent(db, "COMMIT;");
+  check("commit_failure_injected", gFailHits>0);
+  check("commit_returns_error", rc!=SQLITE_OK);
+  check("autocommit_restored_after_failed_commit", sqlite3_get_autocommit(db)==1);
+  check("failed_commit_rolled_back_visible_state",
+        strcmp(exec1(db, "SELECT count(*) FROM t"), "1")==0);
+
+  sqlite3_close(db);
+  check("reopen_after_failed_commit", open_db(dbpath, &db)==SQLITE_OK);
+  check("failed_commit_did_not_persist_row",
+        strcmp(exec1(db, "SELECT count(*) FROM t"), "1")==0);
+  sqlite3_close(db);
+  remove_db(dbpath);
+}
+
+static void run_mutmap_empty_reverse_iter(void){
+  ProllyMutMap mm;
+  ProllyMutMapIter it;
+
+  printf("=== MutMap Empty Reverse Iterator Test ===\n\n");
+  check("mutmap_init_for_reverse_iter", prollyMutMapInit(&mm, 1)==SQLITE_OK);
+  prollyMutMapIterLast(&it, &mm);
+  check("empty_reverse_iter_is_invalid", !prollyMutMapIterValid(&it));
+  prollyMutMapFree(&mm);
+}
+
 static const RegressionCase aCases[] = {
   { "concurrent_refs", "Concurrent Refs Test", run_concurrent_refs },
   { "checkout_persist_failure", "Checkout Persist Failure Test", run_checkout_persist_failure },
@@ -1291,7 +1346,9 @@ static const RegressionCase aCases[] = {
   { "record_decode_corruption", "Record Decode Corruption Test", run_record_decode_corruption },
   { "reload_refs_transactional", "Reload Refs Transactional Test", run_reload_refs_transactional },
   { "refresh_refs_corruption_preserves_state", "Refresh Corrupt Refs State Preservation Test", run_refresh_refs_corruption_preserves_state },
-  { "prolly_node_corruption", "Prolly Node Corruption Test", run_prolly_node_corruption }
+  { "prolly_node_corruption", "Prolly Node Corruption Test", run_prolly_node_corruption },
+  { "btree_commit_failure_transactional", "Btree Commit Failure Transaction Test", run_btree_commit_failure_transactional },
+  { "mutmap_empty_reverse_iter", "MutMap Empty Reverse Iterator Test", run_mutmap_empty_reverse_iter }
 };
 
 static int run_case_by_name(const char *zName){


### PR DESCRIPTION
Fixes the prolly-core review findings around commit failure handling, dropped flush/merge errors, empty reverse iteration, and deferred payload caching.

This change:
- rolls back prolly-side live state when the final chunk-store commit fails
- propagates sibling cursor flush failures on cursor open
- propagates mutmap merge/flush failures on cursor close instead of silently dropping edits
- fixes empty reverse iteration validity in prolly mutmap
- returns OOM from mutmap-backed payload caching instead of leaving cursors valid with stale payload state
- centralizes mutmap-to-root application behind a shared helper

Verified with:
- `cd build && ./doltlite_regression_test_c all`
- `cd build && bash ../test/index_oracle_test.sh ./doltlite sqlite3`
- `cd build && bash ../test/doltlite_merge.sh`
