### PR TITLE
Add state-transitions oracle, fix three checkout/reset divergences

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,6 +111,10 @@ jobs:
       run: cd build && bash ../test/vc_oracle_commit_test.sh ./doltlite dolt
       timeout-minutes: 5
 
+    - name: Version control oracle tests (state transitions)
+      run: cd build && bash ../test/vc_oracle_state_transitions_test.sh ./doltlite dolt
+      timeout-minutes: 5
+
     - name: Large-scale test (10K rows)
       run: cd build && bash ../test/large_scale_test.sh ./doltlite --quick
       timeout-minutes: 5

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -1067,6 +1067,8 @@ static void doltliteResetFunc(
   ChunkStore *cs = doltliteGetChunkStore(db);
   ProllyHash targetCatHash;
   ProllyHash targetCommit;
+  ProllyHash preResetHeadCatHash;
+  int havePreResetHead = 0;
   int isHard = 0;
   int isSoft = 0;
   int isMixed = 0;
@@ -1080,6 +1082,15 @@ static void doltliteResetFunc(
   if( !cs ){
     sqlite3_result_error(context, "no database open", -1);
     return;
+  }
+
+  /* Capture the pre-reset HEAD catalog hash now, before any
+  ** session state mutations. The --hard preserve-untracked logic
+  ** below uses this to identify which tables in the working set
+  ** are untracked (in working but NOT in pre-reset HEAD). */
+  if( doltliteGetHeadCatalogHash(db, &preResetHeadCatHash)==SQLITE_OK
+   && !prollyHashIsEmpty(&preResetHeadCatHash) ){
+    havePreResetHead = 1;
   }
 
   /* Parse arguments. The first non-flag positional that resolves as
@@ -1318,10 +1329,135 @@ static void doltliteResetFunc(
   doltliteSetSessionStaged(db, &targetCatHash);
 
   if( isHard ){
+    /* Save the original (target) staged catalog so we can restore
+    ** it after doltliteHardReset clobbers it with the merged
+    ** working-set catalog. The merged catalog includes untracked
+    ** tables for the working set, but those should NOT appear in
+    ** the staged set. */
+    ProllyHash origStagedAfterReset;
+    memcpy(&origStagedAfterReset, &targetCatHash, sizeof(ProllyHash));
+
     if( prollyHashIsEmpty(&targetCatHash) ){
       sqlite3_result_error(context, "no commit to reset to", -1);
       goto reset_cleanup;
     }
+
+    /* Preserve untracked tables across --hard, matching git's
+    ** semantics: tables in the working set that aren't in the
+    ** PRE-RESET HEAD catalog are left alone. The check is a
+    ** two-step:
+    **
+    **   1. Cheap pre-scan via sqlite_master (no flush, no chunk
+    **      writes) to find table NAMES that exist in the live
+    **      schema but aren't in the pre-reset HEAD catalog.
+    **
+    **   2. Only if any untracked names are found, do the
+    **      expensive flush + per-entry merge to actually rebuild
+    **      the target catalog with those entries preserved.
+    **
+    ** Step 1 is required because doltliteFlushCatalogToHash has
+    ** subtle side effects on pending DROP TABLE operations that
+    ** can leave a tracked table dropped instead of restored when
+    ** there's nothing untracked to preserve. */
+    if( havePreResetHead ){
+      struct TableEntry *aHead = 0;
+      int nHead = 0;
+      int nUntracked = 0;
+      char **azUntracked = 0;
+      sqlite3_stmt *pStmt = 0;
+      int j, k;
+
+      rc = doltliteLoadCatalog(db, &preResetHeadCatHash, &aHead, &nHead, 0);
+      if( rc==SQLITE_OK ){
+        rc = sqlite3_prepare_v2(db,
+            "SELECT name FROM sqlite_master WHERE type='table' "
+            "AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'dolt_%'",
+            -1, &pStmt, 0);
+      }
+      if( rc==SQLITE_OK ){
+        while( sqlite3_step(pStmt)==SQLITE_ROW ){
+          const char *zName = (const char*)sqlite3_column_text(pStmt, 0);
+          int inHead = 0;
+          if( !zName ) continue;
+          for(k=0; k<nHead; k++){
+            if( aHead[k].zName && strcmp(aHead[k].zName, zName)==0 ){
+              inHead = 1; break;
+            }
+          }
+          if( !inHead ){
+            char **aNew = sqlite3_realloc(azUntracked,
+                (nUntracked+1)*(int)sizeof(char*));
+            if( !aNew ){ rc = SQLITE_NOMEM; break; }
+            azUntracked = aNew;
+            azUntracked[nUntracked++] = sqlite3_mprintf("%s", zName);
+          }
+        }
+        sqlite3_finalize(pStmt);
+      }
+
+      /* Only flush + rebuild if there's something to preserve.
+      ** The simplest correct approach: take the LIVE working
+      ** catalog (which contains both tracked and untracked
+      ** tables), then for every TRACKED table, replace its entry
+      ** with HEAD's version of that table. The result is
+      ** "HEAD's content for tracked tables + working's untracked
+      ** entries", which is exactly the git --hard semantic. */
+      if( rc==SQLITE_OK && nUntracked>0 ){
+        ProllyHash workingHash;
+        struct TableEntry *aWorking = 0, *aTarget = 0;
+        int nWorking = 0, nTarget = 0;
+
+        rc = doltliteFlushCatalogToHash(db, &workingHash);
+        if( rc==SQLITE_OK ){
+          rc = doltliteLoadCatalog(db, &workingHash, &aWorking, &nWorking, 0);
+        }
+        if( rc==SQLITE_OK ){
+          rc = doltliteLoadCatalog(db, &targetCatHash, &aTarget, &nTarget, 0);
+        }
+        if( rc==SQLITE_OK ){
+          /* For each working entry that IS in the target catalog
+          ** (i.e. tracked), replace its content with the target's
+          ** version. Untracked entries (not in target) stay
+          ** unchanged. */
+          for(j=0; j<nWorking; j++){
+            int tgtIdx = -1;
+            for(k=0; k<nTarget; k++){
+              if( aTarget[k].zName && aWorking[j].zName
+               && strcmp(aTarget[k].zName, aWorking[j].zName)==0 ){
+                tgtIdx = k; break;
+              }
+            }
+            if( tgtIdx>=0 ){
+              aWorking[j] = aTarget[tgtIdx];
+            }
+          }
+        }
+        if( rc==SQLITE_OK ){
+          u8 *buf = 0;
+          int nBuf = 0;
+          ProllyHash mergedHash;
+          rc = doltliteSerializeCatalogEntries(db, aWorking, nWorking, &buf, &nBuf);
+          if( rc==SQLITE_OK ){
+            rc = chunkStorePut(cs, buf, nBuf, &mergedHash);
+          }
+          sqlite3_free(buf);
+          if( rc==SQLITE_OK ){
+            memcpy(&targetCatHash, &mergedHash, sizeof(ProllyHash));
+          }
+        }
+        sqlite3_free(aWorking);
+        sqlite3_free(aTarget);
+      }
+
+      for(j=0; j<nUntracked; j++) sqlite3_free(azUntracked[j]);
+      sqlite3_free(azUntracked);
+      sqlite3_free(aHead);
+      if( rc!=SQLITE_OK ){
+        sqlite3_result_error_code(context, rc);
+        goto reset_cleanup;
+      }
+    }
+
     doltliteSaveWorkingSet(db);
     chunkStoreSerializeRefs(cs);
     rc = doltliteHardReset(db, &targetCatHash);
@@ -1329,6 +1465,12 @@ static void doltliteResetFunc(
       sqlite3_result_error(context, "hard reset failed", -1);
       goto reset_cleanup;
     }
+    /* doltliteHardReset clobbers the staged catalog with whatever
+    ** we passed it (the merged working catalog including untracked
+    ** tables). Restore staged to the original target so untracked
+    ** tables show up as unstaged in dolt_status, matching Dolt. */
+    doltliteSetSessionStaged(db, &origStagedAfterReset);
+    doltlitePersistState(db);
   }else{
     rc = doltlitePersistState(db);
     if( rc!=SQLITE_OK ){

--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -387,6 +387,130 @@ static int checkoutMutateRefs(sqlite3 *db, ChunkStore *cs, void *pArg){
   return rc;
 }
 
+/* Per-table checkout: revert each named table's working state back
+** to whatever the staged catalog has for that table (or HEAD's entry
+** if nothing is staged). Matches git's `git checkout file` semantics
+** — reverts to the index, NOT all the way to HEAD. To go to HEAD,
+** the user uses dolt_reset.
+**
+** Returns SQLITE_NOTFOUND if any of the named tables doesn't exist
+** in the working catalog or in the source (staged/HEAD) catalog —
+** in that case nothing is mutated.
+*/
+static int doltliteCheckoutTables(
+  sqlite3 *db,
+  sqlite3_value **argv,
+  int nNames
+){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  ProllyHash workingHash, headCatHash, stagedHash;
+  ProllyHash sourceCatHash;       /* staged-or-HEAD */
+  struct TableEntry *aWorking = 0, *aSource = 0;
+  int nWorking = 0, nSource = 0;
+  int i, j;
+  int rc;
+
+  if( !cs ) return SQLITE_ERROR;
+  if( nNames<=0 ) return SQLITE_NOTFOUND;
+
+  /* Build the source catalog: staged if non-empty, else HEAD. */
+  doltliteGetSessionStaged(db, &stagedHash);
+  if( !prollyHashIsEmpty(&stagedHash) ){
+    memcpy(&sourceCatHash, &stagedHash, sizeof(ProllyHash));
+  }else{
+    rc = doltliteGetHeadCatalogHash(db, &headCatHash);
+    if( rc!=SQLITE_OK ) return rc;
+    memcpy(&sourceCatHash, &headCatHash, sizeof(ProllyHash));
+  }
+  if( prollyHashIsEmpty(&sourceCatHash) ){
+    /* Nothing tracked yet — nothing to revert. */
+    return SQLITE_NOTFOUND;
+  }
+
+  /* Snapshot the current working catalog so we can build a modified
+  ** copy and pass it to switchCatalog. */
+  rc = doltliteFlushCatalogToHash(db, &workingHash);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = doltliteLoadCatalog(db, &workingHash, &aWorking, &nWorking, 0);
+  if( rc!=SQLITE_OK ) return rc;
+
+  rc = doltliteLoadCatalog(db, &sourceCatHash, &aSource, &nSource, 0);
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(aWorking);
+    return rc;
+  }
+
+  /* For each named table, replace the working entry with the
+  ** source-catalog entry. If the table is in working but not in
+  ** the source, drop it from working (it was untracked, revert
+  ** removes it). If it's in neither, that's an error. */
+  for(i=0; i<nNames; i++){
+    const char *zName = (const char*)sqlite3_value_text(argv[i]);
+    int srcIdx = -1, workIdx = -1;
+    if( !zName ) continue;
+
+    for(j=0; j<nSource; j++){
+      if( aSource[j].zName && strcmp(aSource[j].zName, zName)==0 ){
+        srcIdx = j; break;
+      }
+    }
+    for(j=0; j<nWorking; j++){
+      if( aWorking[j].zName && strcmp(aWorking[j].zName, zName)==0 ){
+        workIdx = j; break;
+      }
+    }
+
+    if( srcIdx<0 && workIdx<0 ){
+      sqlite3_free(aWorking); sqlite3_free(aSource);
+      return SQLITE_NOTFOUND;
+    }
+
+    if( srcIdx<0 ){
+      /* Table is in working but not in source — drop from working. */
+      if( workIdx+1<nWorking ){
+        memmove(&aWorking[workIdx], &aWorking[workIdx+1],
+                (nWorking-workIdx-1)*(int)sizeof(struct TableEntry));
+      }
+      nWorking--;
+    }else if( workIdx<0 ){
+      /* Source has it, working does not (the user dropped the
+      ** table; checkout brings it back). */
+      struct TableEntry *aNew = sqlite3_realloc(aWorking,
+          (nWorking+1)*(int)sizeof(struct TableEntry));
+      if( !aNew ){
+        sqlite3_free(aWorking); sqlite3_free(aSource);
+        return SQLITE_NOMEM;
+      }
+      aWorking = aNew;
+      aWorking[nWorking++] = aSource[srcIdx];
+    }else{
+      aWorking[workIdx] = aSource[srcIdx];
+    }
+  }
+
+  /* Serialize the new working catalog and switch to it. */
+  {
+    u8 *buf = 0;
+    int nBuf = 0;
+    ProllyHash newWorkingHash;
+    rc = doltliteSerializeCatalogEntries(db, aWorking, nWorking, &buf, &nBuf);
+    if( rc==SQLITE_OK ){
+      rc = chunkStorePut(cs, buf, nBuf, &newWorkingHash);
+    }
+    sqlite3_free(buf);
+    if( rc==SQLITE_OK ){
+      rc = doltliteSwitchCatalog(db, &newWorkingHash);
+    }
+    if( rc==SQLITE_OK ){
+      doltliteSaveWorkingSet(db);
+    }
+  }
+
+  sqlite3_free(aWorking);
+  sqlite3_free(aSource);
+  return rc;
+}
+
 static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
   ChunkStore *cs = doltliteGetChunkStore(db);
@@ -476,8 +600,25 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
     checkoutRestoreSession(db, &m);
   }
   sqlite3_free(zCurrentBranch);
+  zCurrentBranch = 0;
   if( rc==SQLITE_NOTFOUND ){
-    sqlite3_result_error(ctx, "branch not found", -1);
+    /* Not a branch — fall through to per-table checkout (revert
+    ** the named tables in the working set to whatever the staged
+    ** catalog has, or HEAD if nothing is staged). Matches git
+    ** semantics: `git checkout file` reverts working to staged. */
+    rc = doltliteCheckoutTables(db, argv, argc);
+    if( rc==SQLITE_NOTFOUND ){
+      char *zErr = sqlite3_mprintf(
+          "no such branch or table: %s", zBranch);
+      sqlite3_result_error(ctx, zErr ? zErr : "no such branch or table", -1);
+      sqlite3_free(zErr);
+      return;
+    }
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(ctx, rc);
+      return;
+    }
+    sqlite3_result_int(ctx, 0);
     return;
   }
   if( rc==SQLITE_EMPTY ){

--- a/test/doltlite_branch.sh
+++ b/test/doltlite_branch.sh
@@ -31,7 +31,7 @@ run_test_match "del_current" "SELECT dolt_branch('-d','feature');" "cannot delet
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "delete_branch" "SELECT dolt_branch('-d','feature');" "0" "$DB"
 run_test "one_branch" "SELECT count(*) FROM dolt_branches;" "1" "$DB"
-run_test_match "checkout_gone" "SELECT dolt_checkout('feature');" "not found" "$DB"
+run_test_match "checkout_gone" "SELECT dolt_checkout('feature');" "no such branch or table" "$DB"
 
 DB3=/tmp/test_branch3_$$.db; rm -f "$DB3"
 echo "CREATE TABLE t(x); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','i');" | $DOLTLITE "$DB3" > /dev/null 2>&1

--- a/test/doltlite_e2e.sh
+++ b/test/doltlite_e2e.sh
@@ -160,7 +160,7 @@ run_test "e2e_branch_count" "SELECT count(*) FROM dolt_branches;" "3" "$DB"
 
 echo "SELECT dolt_branch('-d','hotfix');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "e2e_deleted_branch" "SELECT count(*) FROM dolt_branches;" "2" "$DB"
-run_test_match "e2e_delete_gone" "SELECT dolt_checkout('hotfix');" "not found" "$DB"
+run_test_match "e2e_delete_gone" "SELECT dolt_checkout('hotfix');" "no such branch or table" "$DB"
 
 # ============================================================
 # Phase 10: Full history

--- a/test/doltlite_edge_cases.sh
+++ b/test/doltlite_edge_cases.sh
@@ -232,8 +232,8 @@ SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 # Merge non-existent branch
 run_test_match "err_merge_noexist" "SELECT dolt_merge('nope');" "not found" "$DB"
 
-# Checkout non-existent branch
-run_test_match "err_checkout_noexist" "SELECT dolt_checkout('nope');" "not found" "$DB"
+# Checkout non-existent branch / table
+run_test_match "err_checkout_noexist" "SELECT dolt_checkout('nope');" "no such branch or table" "$DB"
 
 # Branch already exists
 echo "SELECT dolt_branch('dup');" | $DOLTLITE "$DB" > /dev/null 2>&1

--- a/test/doltlite_reset.sh
+++ b/test/doltlite_reset.sh
@@ -72,7 +72,8 @@ run_test "correct_data_after_hard" \
   "SELECT v FROM t;" \
   "a" "$DB"
 
-# --- Hard reset discards multiple changes ---
+# --- Hard reset reverts tracked-table modifications but preserves
+# --- untracked tables (matching git --hard semantics).
 DB2=/tmp/test_reset2_$$.db; rm -f "$DB2"
 echo "CREATE TABLE a(x); CREATE TABLE b(y); INSERT INTO a VALUES(1); INSERT INTO b VALUES(2); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB2" > /dev/null 2>&1
 echo "INSERT INTO a VALUES(10); INSERT INTO b VALUES(20); CREATE TABLE c(z);" | $DOLTLITE "$DB2" > /dev/null 2>&1
@@ -83,9 +84,15 @@ run_test "changes_before_hard" \
 
 echo "SELECT dolt_reset('--hard');" | $DOLTLITE "$DB2" > /dev/null 2>&1
 
-run_test "clean_after_multi_hard" \
+# After hard reset: a and b are reverted (no longer in status),
+# but c (untracked new table) is preserved as an unstaged new table.
+run_test "untracked_preserved_after_multi_hard" \
   "SELECT count(*) FROM dolt_status;" \
-  "0" "$DB2"
+  "1" "$DB2"
+
+run_test "untracked_table_still_present_after_hard" \
+  "SELECT table_name FROM dolt_status;" \
+  "c" "$DB2"
 
 run_test "a_reverted" \
   "SELECT * FROM a;" \

--- a/test/vc_oracle_state_transitions_test.sh
+++ b/test/vc_oracle_state_transitions_test.sh
@@ -1,0 +1,433 @@
+#!/bin/bash
+#
+# Version-control oracle test: HEAD / staged / working state transitions
+#
+# Doltlite has three stages for table state — HEAD (committed),
+# staged (what dolt_commit will commit), and working (live database
+# state) — and the forward path (modify → add → commit) is well
+# covered by other oracles. This file targets the REVERSE and
+# SIDE-STEP paths where things tend to subtly diverge: dolt_reset
+# moving rows between stages, dolt_checkout swapping branches with
+# uncommitted changes, table-level reset undoing only some changes,
+# and the interactions between concurrent staged and working
+# modifications to the same table.
+#
+# Each scenario builds up a specific (HEAD, staged, working) state
+# and then runs a state-changing operation. The oracle compares
+# the resulting state across THREE surfaces:
+#
+#   1. dolt_log    — what HEAD points to
+#   2. dolt_status — what's staged vs unstaged
+#   3. SELECT * FROM t — actual working-set table contents
+#
+# Comparing all three is essential here. The status alone could
+# show "no changes" while the working table actually contains
+# divergent data; the log alone could show the right HEAD while
+# the working set is silently wrong; and the table contents alone
+# could match while the staged catalog is in a wrong state that
+# would corrupt the next commit.
+#
+# Usage: bash vc_oracle_state_transitions_test.sh [path/to/doltlite] [path/to/dolt]
+#
+
+set -u
+
+DOLTLITE="${1:-./doltlite}"
+DOLT="${2:-dolt}"
+TMPROOT=$(mktemp -d)
+trap "rm -rf $TMPROOT" EXIT
+pass=0; fail=0
+FAILED_NAMES=""
+
+normalize_log() {
+  tr -d '\r' \
+    | awk -F'\t' 'NF >= 3 && $1 == "L" { print }' \
+    | sort -t$'\t' -k3 \
+    | awk -F'\t' '
+        {
+          h = $2
+          if (!(h in seen)) { n++; seen[h] = "H" n }
+          print "L\t" seen[h] "\t" $3
+        }
+      '
+}
+
+normalize_status() {
+  tr -d '\r' \
+    | awk -F'\t' 'NF >= 4 && $1 == "S" { print }' \
+    | sort -t$'\t' -k2,2 -k3,3 -k4,4
+}
+
+normalize_table() {
+  tr -d '\r' \
+    | awk -F'\t' 'NF >= 2 && $1 == "T" { print }' \
+    | sort
+}
+
+# Each scenario provides setup SQL and the name of the table whose
+# contents should be compared (some scenarios use multiple tables;
+# they pass a comma-separated list which becomes a UNION ALL).
+oracle() {
+  local name="$1" setup="$2" tables="${3:-t}"
+  local dir="$TMPROOT/$name"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  # Build the table-content query as a UNION ALL across the named
+  # tables, prefixing each row with the table name so the harness
+  # can sort across tables consistently. Schema is assumed
+  # (id, v) — every scenario in this file uses that shape.
+  local table_query=""
+  IFS=',' read -ra tarr <<< "$tables"
+  for tn in "${tarr[@]}"; do
+    if [ -z "$table_query" ]; then
+      table_query="SELECT 'T' || char(9) || '$tn' || char(9) || coalesce(id,'') || char(9) || coalesce(v,'') FROM $tn"
+    else
+      table_query="$table_query UNION ALL SELECT 'T' || char(9) || '$tn' || char(9) || coalesce(id,'') || char(9) || coalesce(v,'') FROM $tn"
+    fi
+  done
+
+  local dl_log dl_status dl_table
+  dl_log=$(printf "%s\n.headers off\n.mode list\n.separator '\t'\nSELECT 'L' || char(9) || commit_hash || char(9) || message FROM dolt_log;\n" "$setup" \
+           | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
+           | grep -v '^[0-9]*$' \
+           | grep -v '^[0-9a-f]\{40\}$' \
+           | normalize_log)
+  dl_status=$(printf "%s\n.headers off\n.mode list\n.separator '\t'\nSELECT 'S' || char(9) || table_name || char(9) || staged || char(9) || status FROM dolt_status;\n" "$setup" \
+              | "$DOLTLITE" "$dir/dl/db.s" 2>>"$dir/dl.err" \
+              | grep -v '^[0-9]*$' \
+              | grep -v '^[0-9a-f]\{40\}$' \
+              | normalize_status)
+  dl_table=$(printf "%s\n.headers off\n.mode list\n.separator '\t'\n%s;\n" "$setup" "$table_query" \
+             | "$DOLTLITE" "$dir/dl/db.t" 2>>"$dir/dl.err" \
+             | grep -v '^[0-9]*$' \
+             | grep -v '^[0-9a-f]\{40\}$' \
+             | normalize_table)
+
+  local dolt_setup
+  dolt_setup=$(echo "$setup" | sed -E 's/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g')
+
+  local dt_log dt_status dt_table
+  (
+    cd "$dir/dt" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    echo "$dolt_setup" | "$DOLT" sql >/dev/null 2>"$dir/dt.err"
+    "$DOLT" sql -r csv -q "SELECT concat('L', char(9), commit_hash, char(9), message) FROM dolt_log ORDER BY commit_order DESC;" 2>>"$dir/dt.err"
+  ) > "$dir/dt.log.raw"
+  dt_log=$(tail -n +2 "$dir/dt.log.raw" | tr -d '"' | normalize_log)
+
+  (
+    mkdir -p "$dir/dt.s" && cd "$dir/dt.s" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    echo "$dolt_setup" | "$DOLT" sql >/dev/null 2>"$dir/dt.s.err"
+    "$DOLT" sql -r csv -q "SELECT concat('S', char(9), table_name, char(9), staged, char(9), status) FROM dolt_status;" 2>>"$dir/dt.s.err"
+  ) > "$dir/dt.status.raw"
+  dt_status=$(tail -n +2 "$dir/dt.status.raw" | tr -d '"' | normalize_status)
+
+  # Build a Dolt-syntax table query (concat instead of ||).
+  local dolt_table_query=""
+  for tn in "${tarr[@]}"; do
+    local part="SELECT concat('T', char(9), '$tn', char(9), coalesce(id,''), char(9), coalesce(v,'')) FROM $tn"
+    if [ -z "$dolt_table_query" ]; then
+      dolt_table_query="$part"
+    else
+      dolt_table_query="$dolt_table_query UNION ALL $part"
+    fi
+  done
+  (
+    mkdir -p "$dir/dt.t" && cd "$dir/dt.t" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    echo "$dolt_setup" | "$DOLT" sql >/dev/null 2>"$dir/dt.t.err"
+    "$DOLT" sql -r csv -q "$dolt_table_query;" 2>>"$dir/dt.t.err"
+  ) > "$dir/dt.table.raw"
+  dt_table=$(tail -n +2 "$dir/dt.table.raw" | tr -d '"' | normalize_table)
+
+  # Empty-on-both-sides safeguard. Every scenario in this file
+  # commits at least once and queries at least one table, so an
+  # empty log AND empty table on both sides means the harness
+  # query errored and the test is meaningless.
+  if [ -z "$dl_log" ] && [ -z "$dt_log" ] && [ -z "$dl_table" ] && [ -z "$dt_table" ]; then
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name (everything empty on both sides — harness bug)"
+    return
+  fi
+
+  local dl_combined dt_combined
+  dl_combined="$dl_log"$'\n'"$dl_status"$'\n'"$dl_table"
+  dt_combined="$dt_log"$'\n'"$dt_status"$'\n'"$dt_table"
+
+  if [ "$dl_combined" = "$dt_combined" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite log:";    echo "$dl_log"    | sed 's/^/      /'
+    echo "    dolt log:";        echo "$dt_log"    | sed 's/^/      /'
+    echo "    doltlite status:"; echo "$dl_status" | sed 's/^/      /'
+    echo "    dolt status:";     echo "$dt_status" | sed 's/^/      /'
+    echo "    doltlite table:";  echo "$dl_table"  | sed 's/^/      /'
+    echo "    dolt table:";      echo "$dt_table"  | sed 's/^/      /'
+  fi
+}
+
+echo "=== Version Control Oracle Tests: HEAD / staged / working state transitions ==="
+echo ""
+
+SEED="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+"
+
+echo "--- reset moving things between stages ---"
+
+# Stage one change, modify ANOTHER thing in working only, then
+# reset (no args). The staged change should move back to working,
+# joining the existing unstaged change. Both should appear as
+# unstaged after the reset.
+oracle "reset_unstages_while_working_has_separate_diff" "
+$SEED
+INSERT INTO t VALUES (3, 30);
+SELECT dolt_add('-A');
+INSERT INTO t VALUES (4, 40);
+SELECT dolt_reset();
+"
+
+# Stage a row, then DELETE it from working. After --hard reset,
+# both the staged add and the working delete should be gone, and
+# the table should be back to HEAD's contents.
+oracle "hard_reset_undoes_stage_then_working_delete" "
+$SEED
+INSERT INTO t VALUES (3, 30);
+SELECT dolt_add('-A');
+DELETE FROM t WHERE id = 3;
+SELECT dolt_reset('--hard');
+"
+
+# Stage a modification, then make a SECOND modification to the
+# same row in working. After plain reset (mixed), staged is
+# cleared but working keeps both modifications visible (since
+# the second one was never committed and -mixed leaves working
+# alone). The visible row v should reflect the second change.
+oracle "mixed_reset_preserves_subsequent_working_change" "
+$SEED
+UPDATE t SET v = 100 WHERE id = 1;
+SELECT dolt_add('-A');
+UPDATE t SET v = 200 WHERE id = 1;
+SELECT dolt_reset();
+"
+
+# Same setup as above but --hard. Now BOTH the staged
+# modification AND the second working modification should be
+# wiped, and id=1 should be back to HEAD's value of 10.
+oracle "hard_reset_wipes_both_staged_and_working" "
+$SEED
+UPDATE t SET v = 100 WHERE id = 1;
+SELECT dolt_add('-A');
+UPDATE t SET v = 200 WHERE id = 1;
+SELECT dolt_reset('--hard');
+"
+
+# Stage a row addition, then reset that ONE table by name. The
+# staged add for that specific table should move back to working;
+# any other staged work should remain staged.
+oracle "table_reset_unstages_only_named_table" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, v INT);
+CREATE TABLE b(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO a VALUES (1, 10);
+INSERT INTO b VALUES (1, 100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+INSERT INTO a VALUES (2, 20);
+INSERT INTO b VALUES (2, 200);
+SELECT dolt_add('-A');
+SELECT dolt_reset('a');
+" "a,b"
+
+# Reset to a previous commit with --mixed. HEAD moves back, the
+# diff between c2 and c1 becomes UNSTAGED working changes, and
+# nothing is staged.
+oracle "mixed_reset_to_prev_commit_moves_diff_to_working" "
+$SEED
+INSERT INTO t VALUES (3, 30);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2');
+SELECT dolt_reset('HEAD~1');
+"
+
+# Reset to a previous commit with --hard. HEAD moves back, the
+# diff is GONE entirely from working — table back to c1's content.
+oracle "hard_reset_to_prev_commit_drops_diff_entirely" "
+$SEED
+INSERT INTO t VALUES (3, 30);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2');
+SELECT dolt_reset('--hard', 'HEAD~1');
+"
+
+echo "--- checkout moving things between stages ---"
+
+# Checkout to another branch with a CLEAN working set. Working
+# should swap to that branch's HEAD; staged should also reflect
+# that branch's HEAD.
+oracle "checkout_branch_clean_swaps_working" "
+$SEED
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (3, 30);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat1');
+SELECT dolt_checkout('main');
+"
+
+# Working set is per-BRANCH in the Dolt server model (different
+# from git's session-tied behavior). When the user makes a
+# working-only change on main and checks out feature, the
+# change STAYS on main and is not visible on feature. Round-tripping
+# back to main restores the change. The harness uses two
+# separate `dolt sql` invocations to defeat single-session
+# carry-over so the comparison reflects the persistent
+# per-branch model.
+oracle "checkout_branch_per_branch_working_set" "
+$SEED
+SELECT dolt_branch('feature');
+INSERT INTO t VALUES (3, 30);
+SELECT dolt_checkout('feature');
+SELECT dolt_checkout('main');
+"
+
+# checkout -b creates the new branch from current HEAD and
+# switches to it. Under the per-branch model, the new branch
+# starts with HEAD's working set — uncommitted main changes
+# are NOT inherited by the new branch.
+oracle "checkout_b_starts_from_head_not_working" "
+$SEED
+SELECT dolt_branch('feature');
+INSERT INTO t VALUES (3, 30);
+SELECT dolt_checkout('feature');
+SELECT dolt_checkout('-b', 'feature2');
+SELECT dolt_checkout('main');
+"
+
+# Checkout a single TABLE from HEAD. Working changes to that
+# table are reverted, working changes to other tables are
+# preserved.
+oracle "checkout_table_reverts_only_named_table" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, v INT);
+CREATE TABLE b(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO a VALUES (1, 10);
+INSERT INTO b VALUES (1, 100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+UPDATE a SET v = 999 WHERE id = 1;
+UPDATE b SET v = 999 WHERE id = 1;
+SELECT dolt_checkout('a');
+" "a,b"
+
+# Checkout a table that was both modified in working AND staged.
+# Both the staged modification and the working modification for
+# that table should be reverted.
+oracle "checkout_table_clears_both_staged_and_working" "
+$SEED
+UPDATE t SET v = 100 WHERE id = 1;
+SELECT dolt_add('-A');
+UPDATE t SET v = 200 WHERE id = 1;
+SELECT dolt_checkout('t');
+"
+
+echo "--- full cycle ---"
+
+# Full forward-then-reverse cycle: commit something, reset --soft
+# back, the diff is now staged, commit again. Should produce a
+# new commit with the same content but a different message.
+oracle "soft_reset_uncommit_then_recommit" "
+$SEED
+INSERT INTO t VALUES (3, 30);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2');
+SELECT dolt_reset('--soft', 'HEAD~1');
+SELECT dolt_commit('-m', 'c2-recommitted');
+"
+
+# Commit, then mixed reset, then re-stage and re-commit with a
+# new message. The diff was unstaged in the middle.
+oracle "mixed_reset_uncommit_then_readd_recommit" "
+$SEED
+INSERT INTO t VALUES (3, 30);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2');
+SELECT dolt_reset('HEAD~1');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2-take-two');
+"
+
+# Cycle through branches: create feature, modify, switch back to
+# main, modify differently, switch to feature, switch to main.
+# Each switch should restore the right working set.
+oracle "branch_round_trip_preserves_each_side" "
+$SEED
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (3, 30);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat1');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES (4, 40);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main2');
+SELECT dolt_checkout('feature');
+SELECT dolt_checkout('main');
+"
+
+echo "--- edge cases ---"
+
+# Stage a deletion of a tracked table (the whole table). After
+# reset, the deletion is undone and the table is back.
+oracle "reset_undoes_staged_table_deletion" "
+$SEED
+DROP TABLE t;
+SELECT dolt_add('-A');
+SELECT dolt_reset('--hard');
+"
+
+# Working has a brand-new table; mixed reset shouldn't touch it
+# (the new table is untracked, like an unstaged file in git).
+oracle "mixed_reset_does_not_touch_untracked_new_table" "
+$SEED
+CREATE TABLE u(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO u VALUES (1, 99);
+SELECT dolt_reset();
+" "t,u"
+
+# Hard reset DOES wipe new untracked tables (matches git --hard
+# semantics: anything in working goes away).
+# UPDATE: actually git --hard does NOT remove untracked files;
+# you need --hard plus -x or git clean. Let's see what Dolt does.
+oracle "hard_reset_with_untracked_new_table" "
+$SEED
+CREATE TABLE u(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO u VALUES (1, 99);
+SELECT dolt_reset('--hard');
+" "t,u"
+
+# Add a table, commit, then reset --hard to BEFORE the add. The
+# table should be gone from working entirely (it was tracked,
+# now it's not even in HEAD).
+oracle "hard_reset_drops_table_added_after_target" "
+$SEED
+CREATE TABLE u(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO u VALUES (1, 99);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'add_u');
+SELECT dolt_reset('--hard', 'HEAD~1');
+" "t"
+
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+if [ $fail -gt 0 ]; then
+  echo "Failed:$FAILED_NAMES"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Adds 19 scenarios to a new \`vc_oracle_state_transitions_test.sh\` focused on the **HEAD ↔ staged ↔ working state machine** — the area of doltlite with the least forward-path coverage but the highest blast radius. The forward path (modify → add → commit) is well covered by existing oracles; this file targets the **reverse and side-step paths** where \`dolt_reset\` and \`dolt_checkout\` move tables between stages.

The harness compares **all three** state surfaces per scenario:
- \`dolt_log\` — HEAD position
- \`dolt_status\` — staged vs unstaged
- \`SELECT * FROM\` user tables — live working contents

Comparing only one would miss whole classes of bug. **Three real divergences fixed.**

## The bugs

### 1. \`dolt_checkout('table_name')\` was a no-op

doltlite always treated the first positional as a branch name and silently errored on table-name arguments. Dolt supports per-table checkout matching git's \`git checkout file\` semantics: revert that one table's working state back to the staged catalog (or HEAD if nothing is staged).

Fix: implemented \`doltliteCheckoutTables()\` in \`doltlite_branch.c\`, called as a fall-through when \`chunkStoreFindBranch\` returns NOTFOUND. Builds a new working catalog by replacing each named table's entry with the staged-or-HEAD entry, then switches via \`doltliteSwitchCatalog\`. Correctly handles dropped-then-restored and modified-then-reverted cases.

### 2. \`dolt_reset --hard\` was wiping untracked tables

Matching git \`--hard\` semantics: tables in the working set that were never tracked by HEAD should NOT be touched. doltlite was wiping them entirely because \`doltliteHardReset\` replaces the whole in-memory catalog with the target catalog.

Fix in two parts:
- **Cheap pre-scan** in \`doltliteResetFunc\` queries \`sqlite_master\` for table names and checks each against the pre-reset HEAD catalog. Avoids the expensive flush-and-chunk-write path when there's nothing untracked.
- **Per-entry merge** when at least one untracked table is found: take the live working catalog, replace each tracked entry with the target's version, pass the merged result to \`doltliteHardReset\`. After hardReset completes, the staged catalog is explicitly restored to the un-merged target so untracked tables show as unstaged \`new table\` in dolt_status, matching Dolt.

The pre-scan is essential — calling \`doltliteFlushCatalogToHash\` before the hardReset has subtle side effects on pending DROP TABLE operations that can leave a tracked table dropped instead of restored when there is nothing untracked to preserve.

### 3. \`dolt_reset --hard <ref>\` captured the wrong HEAD

When resetting back to an older commit, the \"what was tracked at the time of reset\" check needs the **pre-reset** HEAD, not the already-moved-to-target HEAD. Captured \`preResetHeadCatHash\` at the top of \`doltliteResetFunc\` before any session mutations. This makes \"reset to before a table was added\" correctly drop that table even when it has working changes.

## Per-branch working set model

Two scenarios verify doltlite's intentional divergence from git's checkout semantics: **the working set is tied to the BRANCH, not the session**. When you modify the working set on main and check out feature, the change STAYS on main and is NOT visible on feature. This is required for the multi-connection server deployment Dolt supports. The scenarios round-trip via two checkouts to defeat single-session carry-over.

## Self-test cleanup

Four pre-existing \`doltlite_*.sh\` self-tests locked in the old behavior:
- \`doltlite_branch.sh\`, \`doltlite_edge_cases.sh\`, \`doltlite_e2e.sh\`: error message for \"no such branch\" changed from \"branch not found\" to \"no such branch or table\" (the new fall-through from per-table checkout)
- \`doltlite_reset.sh\`: \`clean_after_multi_hard\` now expects untracked tables to be preserved after \`--hard\`, matching the new git-compatible behavior

## Test plan

Verified against Dolt 1.86.0:

- [x] \`vc_oracle_state_transitions_test.sh\`: **19/19** (new)
- [x] doltlite oracle suite: 39/39 (including \`doltlite_regression_test_c\` 171/171)
- [x] \`vc_oracle_reset_test.sh\`: 15/15 (no regressions)
- [x] all other vc oracles: passing
- [x] \`index_oracle_test.sh\`: 526/526
- [ ] CI green

**Depends on #368** for the \`dolt_commit\` flag fixes; rebase onto master once #368 merges.