### PR TITLE
Harden chunk store recovery and integrity checks

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -497,9 +497,26 @@ static int csReplayWalRegion(ChunkStore *cs, int updateManifest){
   u8 *pOldWalData = cs->pWalData;
   i64 nOldWalData = cs->nWalData;
   i64 pos;
-  int rc = SQLITE_OK;
   int nPendingBefore = cs->nPending;
   int nRootedPending = cs->nPending;
+  int nOldChunks = cs->nChunks;
+  ProllyHash oldRefsHash = cs->refsHash;
+  ProllyHash oldWorkingState = cs->workingState;
+  ChunkIndexEntry *aOldIndex = cs->aIndex;
+  int nOldIndex = cs->nIndex;
+  int nOldIndexAlloc = cs->nIndexAlloc;
+  char *zOldDefaultBranch = cs->zDefaultBranch;
+  struct BranchRef *aOldBranches = cs->aBranches;
+  int nOldBranches = cs->nBranches;
+  struct TagRef *aOldTags = cs->aTags;
+  int nOldTags = cs->nTags;
+  struct RemoteRef *aOldRemotes = cs->aRemotes;
+  int nOldRemotes = cs->nRemotes;
+  struct TrackingBranch *aOldTracking = cs->aTracking;
+  int nOldTracking = cs->nTracking;
+  ChunkStore tmpRefs;
+  int haveTmpRefs = 0;
+  int rc = SQLITE_OK;
 
   if( cs->iWalOffset <= 0 || !cs->pFile ) return SQLITE_OK;
 
@@ -522,7 +539,6 @@ static int csReplayWalRegion(ChunkStore *cs, int updateManifest){
     }
   }
 
-  sqlite3_free(cs->pWalData);
   cs->pWalData = walData;
   cs->nWalData = walSize;
 
@@ -598,7 +614,6 @@ static int csReplayWalRegion(ChunkStore *cs, int updateManifest){
     int nMerged = 0;
     rc = csMergeIndex(cs, &aMerged, &nMerged);
     if( rc != SQLITE_OK ) goto replay_error;
-    sqlite3_free(cs->aIndex);
     cs->aIndex = aMerged;
     cs->nIndex = nMerged;
     cs->nIndexAlloc = nMerged;
@@ -619,21 +634,65 @@ static int csReplayWalRegion(ChunkStore *cs, int updateManifest){
         rc = rc2;
         goto replay_error;
       }
-      csFreeRefsState(cs);
-      csAdoptRefsState(cs, &tmpRefs);
+      haveTmpRefs = 1;
     }else if( rc2!=SQLITE_OK ){
       rc = rc2;
       goto replay_error;
     }
   }
-  if( !cs->zDefaultBranch ) cs->zDefaultBranch = sqlite3_mprintf("main");
+  if( haveTmpRefs ){
+    csFreeRefsState(cs);
+    csAdoptRefsState(cs, &tmpRefs);
+    haveTmpRefs = 0;
+  }
+  if( !cs->zDefaultBranch ){
+    cs->zDefaultBranch = sqlite3_mprintf("main");
+    if( !cs->zDefaultBranch ){
+      rc = SQLITE_NOMEM;
+      goto replay_error;
+    }
+  }
+
+  if( cs->aIndex!=aOldIndex ) sqlite3_free(aOldIndex);
+  sqlite3_free(pOldWalData);
+  {
+    ChunkStore oldRefs;
+    memset(&oldRefs, 0, sizeof(oldRefs));
+    oldRefs.zDefaultBranch = zOldDefaultBranch;
+    oldRefs.aBranches = aOldBranches;
+    oldRefs.nBranches = nOldBranches;
+    oldRefs.aTags = aOldTags;
+    oldRefs.nTags = nOldTags;
+    oldRefs.aRemotes = aOldRemotes;
+    oldRefs.nRemotes = nOldRemotes;
+    oldRefs.aTracking = aOldTracking;
+    oldRefs.nTracking = nOldTracking;
+    csFreeRefsState(&oldRefs);
+  }
 
   return SQLITE_OK;
 
 replay_error:
+  if( haveTmpRefs ) csFreeRefsState(&tmpRefs);
+  if( cs->aIndex!=aOldIndex ) sqlite3_free(cs->aIndex);
   sqlite3_free(cs->pWalData);
   cs->pWalData = pOldWalData;
   cs->nWalData = nOldWalData;
+  cs->nChunks = nOldChunks;
+  cs->refsHash = oldRefsHash;
+  cs->workingState = oldWorkingState;
+  cs->aIndex = aOldIndex;
+  cs->nIndex = nOldIndex;
+  cs->nIndexAlloc = nOldIndexAlloc;
+  cs->zDefaultBranch = zOldDefaultBranch;
+  cs->aBranches = aOldBranches;
+  cs->nBranches = nOldBranches;
+  cs->aTags = aOldTags;
+  cs->nTags = nOldTags;
+  cs->aRemotes = aOldRemotes;
+  cs->nRemotes = nOldRemotes;
+  cs->aTracking = aOldTracking;
+  cs->nTracking = nOldTracking;
   cs->nPending = nPendingBefore;
   csPendHTClear(cs);
   return rc;
@@ -1499,7 +1558,7 @@ int chunkStoreGet(
       *pnData = e->size;
       return SQLITE_OK;
     }
-    return SQLITE_NOTFOUND;
+    return SQLITE_CORRUPT;
   }
 
   /* 4. Read from file. Verify stored length matches index for corruption check. */

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -346,7 +346,7 @@ static int csSearchPending(ChunkStore *cs, const ProllyHash *pHash){
 **   0: magic(4) | 4: version(4) | 8: reserved(20) | 28: nChunks(4)
 **   32: indexOffset(8) | 40: indexSize(4) | 44: reserved(20)
 **   64: reserved(20) | 84: walOffset(8) | 92: reserved(12)
-**   104: refs_hash(20) | 124: working_state_hash(20) | 144: reserved(24)
+**   104: refs_hash(20) | 124: reserved(44)
 */
 void csSerializeManifest(const ChunkStore *cs, u8 *aBuf){
   memset(aBuf, 0, CHUNK_MANIFEST_SIZE);
@@ -360,7 +360,6 @@ void csSerializeManifest(const ChunkStore *cs, u8 *aBuf){
   /* offset 64: reserved (was headCommit_hash) */
   CS_WRITE_I64(aBuf + 84, cs->iWalOffset);
   memcpy(aBuf + 104, cs->refsHash.data, PROLLY_HASH_SIZE);
-  memcpy(aBuf + 124, cs->workingState.data, PROLLY_HASH_SIZE);
 }
 
 static void csSerializeIndexEntry(const ChunkIndexEntry *e, u8 *aBuf){
@@ -396,7 +395,6 @@ static int csReadManifest(ChunkStore *cs){
   /* offset 64: reserved (was headCommit_hash) */
   cs->iWalOffset = CS_READ_I64(aBuf + 84);
   memcpy(cs->refsHash.data, aBuf + 104, PROLLY_HASH_SIZE);
-  memcpy(cs->workingState.data, aBuf + 124, PROLLY_HASH_SIZE);
 
   return SQLITE_OK;
 }
@@ -501,7 +499,6 @@ static int csReplayWalRegion(ChunkStore *cs, int updateManifest){
   int nRootedPending = cs->nPending;
   int nOldChunks = cs->nChunks;
   ProllyHash oldRefsHash = cs->refsHash;
-  ProllyHash oldWorkingState = cs->workingState;
   ChunkIndexEntry *aOldIndex = cs->aIndex;
   int nOldIndex = cs->nIndex;
   int nOldIndexAlloc = cs->nIndexAlloc;
@@ -594,7 +591,6 @@ static int csReplayWalRegion(ChunkStore *cs, int updateManifest){
         cs->nChunks = (int)CS_READ_U32(m + 28);
         /* offset 64: reserved (was headCommit_hash) */
         memcpy(cs->refsHash.data, m + 104, PROLLY_HASH_SIZE);
-        memcpy(cs->workingState.data, m + 124, PROLLY_HASH_SIZE);
         /* Don't update iWalOffset/iIndexOffset from WAL root records --
         ** those fields describe the compacted region and only change on GC. */
       }
@@ -680,7 +676,6 @@ replay_error:
   cs->nWalData = nOldWalData;
   cs->nChunks = nOldChunks;
   cs->refsHash = oldRefsHash;
-  cs->workingState = oldWorkingState;
   cs->aIndex = aOldIndex;
   cs->nIndex = nOldIndex;
   cs->nIndexAlloc = nOldIndexAlloc;
@@ -892,14 +887,6 @@ int chunkStoreClose(ChunkStore *cs){
   csFreeTracking(cs);
   memset(cs, 0, sizeof(*cs));
   return SQLITE_OK;
-}
-
-void chunkStoreGetWorkingState(ChunkStore *cs, ProllyHash *pState){
-  memcpy(pState, &cs->workingState, sizeof(ProllyHash));
-}
-
-void chunkStoreSetWorkingState(ChunkStore *cs, const ProllyHash *pState){
-  memcpy(&cs->workingState, pState, sizeof(ProllyHash));
 }
 
 void chunkStoreGetStagedCatalog(ChunkStore *cs, ProllyHash *pStaged){
@@ -1880,7 +1867,6 @@ void chunkStoreClearRefs(ChunkStore *cs){
   csFreeRemotes(cs);
   csFreeTracking(cs);
   memset(&cs->refsHash, 0, sizeof(cs->refsHash));
-  memset(&cs->workingState, 0, sizeof(cs->workingState));
   memset(&cs->stagedCatalog, 0, sizeof(cs->stagedCatalog));
 }
 
@@ -1992,7 +1978,6 @@ static int csReloadFromDisk(ChunkStore *cs){
   cs->pFile = tmp.pFile;
   cs->readOnly = tmp.readOnly;
   cs->refsHash = tmp.refsHash;
-  cs->workingState = tmp.workingState;
   cs->stagedCatalog = tmp.stagedCatalog;
   cs->isMerging = tmp.isMerging;
   cs->mergeCommitHash = tmp.mergeCommitHash;

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -146,6 +146,40 @@ static int csReloadFromDisk(ChunkStore *cs);
 #define CS_WAL_TAG_CHUNK  0x01
 #define CS_WAL_TAG_ROOT   0x02
 
+typedef struct SavedRefsState SavedRefsState;
+typedef struct ChunkStoreReplayState ChunkStoreReplayState;
+typedef struct ChunkStoreReloadState ChunkStoreReloadState;
+
+struct SavedRefsState {
+  char *zDefaultBranch;
+  struct BranchRef *aBranches;
+  int nBranches;
+  struct TagRef *aTags;
+  int nTags;
+  struct RemoteRef *aRemotes;
+  int nRemotes;
+  struct TrackingBranch *aTracking;
+  int nTracking;
+};
+
+struct ChunkStoreReplayState {
+  u8 *pWalData;
+  i64 nWalData;
+  int nChunks;
+  ProllyHash refsHash;
+  ChunkIndexEntry *aIndex;
+  int nIndex;
+  int nIndexAlloc;
+  SavedRefsState refs;
+};
+
+struct ChunkStoreReloadState {
+  sqlite3_file *pFile;
+  ChunkIndexEntry *aIndex;
+  u8 *pWalData;
+  SavedRefsState refs;
+};
+
 /*
 ** WAL offsets are stored as negative values in ChunkIndexEntry.offset to
 ** distinguish them from regular file offsets. The encoding maps walPos 0
@@ -195,6 +229,86 @@ static void csFreeTracking(ChunkStore *cs){
   sqlite3_free(cs->aTracking);
   cs->aTracking = 0;
   cs->nTracking = 0;
+}
+
+static void csCaptureSavedRefsState(ChunkStore *cs, SavedRefsState *pSaved){
+  memset(pSaved, 0, sizeof(*pSaved));
+  pSaved->zDefaultBranch = cs->zDefaultBranch;
+  pSaved->aBranches = cs->aBranches;
+  pSaved->nBranches = cs->nBranches;
+  pSaved->aTags = cs->aTags;
+  pSaved->nTags = cs->nTags;
+  pSaved->aRemotes = cs->aRemotes;
+  pSaved->nRemotes = cs->nRemotes;
+  pSaved->aTracking = cs->aTracking;
+  pSaved->nTracking = cs->nTracking;
+}
+
+static void csRestoreSavedRefsState(ChunkStore *cs, const SavedRefsState *pSaved){
+  cs->zDefaultBranch = pSaved->zDefaultBranch;
+  cs->aBranches = pSaved->aBranches;
+  cs->nBranches = pSaved->nBranches;
+  cs->aTags = pSaved->aTags;
+  cs->nTags = pSaved->nTags;
+  cs->aRemotes = pSaved->aRemotes;
+  cs->nRemotes = pSaved->nRemotes;
+  cs->aTracking = pSaved->aTracking;
+  cs->nTracking = pSaved->nTracking;
+}
+
+static void csFreeSavedRefsState(SavedRefsState *pSaved){
+  ChunkStore refsStore;
+  memset(&refsStore, 0, sizeof(refsStore));
+  refsStore.zDefaultBranch = pSaved->zDefaultBranch;
+  refsStore.aBranches = pSaved->aBranches;
+  refsStore.nBranches = pSaved->nBranches;
+  refsStore.aTags = pSaved->aTags;
+  refsStore.nTags = pSaved->nTags;
+  refsStore.aRemotes = pSaved->aRemotes;
+  refsStore.nRemotes = pSaved->nRemotes;
+  refsStore.aTracking = pSaved->aTracking;
+  refsStore.nTracking = pSaved->nTracking;
+  csFreeRefsState(&refsStore);
+  memset(pSaved, 0, sizeof(*pSaved));
+}
+
+static void csCaptureReplayState(ChunkStore *cs, ChunkStoreReplayState *pSaved){
+  memset(pSaved, 0, sizeof(*pSaved));
+  pSaved->pWalData = cs->pWalData;
+  pSaved->nWalData = cs->nWalData;
+  pSaved->nChunks = cs->nChunks;
+  pSaved->refsHash = cs->refsHash;
+  pSaved->aIndex = cs->aIndex;
+  pSaved->nIndex = cs->nIndex;
+  pSaved->nIndexAlloc = cs->nIndexAlloc;
+  csCaptureSavedRefsState(cs, &pSaved->refs);
+}
+
+static void csRestoreReplayState(ChunkStore *cs, const ChunkStoreReplayState *pSaved){
+  cs->pWalData = pSaved->pWalData;
+  cs->nWalData = pSaved->nWalData;
+  cs->nChunks = pSaved->nChunks;
+  cs->refsHash = pSaved->refsHash;
+  cs->aIndex = pSaved->aIndex;
+  cs->nIndex = pSaved->nIndex;
+  cs->nIndexAlloc = pSaved->nIndexAlloc;
+  csRestoreSavedRefsState(cs, &pSaved->refs);
+}
+
+static void csCaptureReloadState(ChunkStore *cs, ChunkStoreReloadState *pSaved){
+  memset(pSaved, 0, sizeof(*pSaved));
+  pSaved->pFile = cs->pFile;
+  pSaved->aIndex = cs->aIndex;
+  pSaved->pWalData = cs->pWalData;
+  csCaptureSavedRefsState(cs, &pSaved->refs);
+}
+
+static void csFreeReloadState(ChunkStoreReloadState *pSaved){
+  csCloseFile(pSaved->pFile);
+  sqlite3_free(pSaved->aIndex);
+  sqlite3_free(pSaved->pWalData);
+  csFreeSavedRefsState(&pSaved->refs);
+  memset(pSaved, 0, sizeof(*pSaved));
 }
 static void csFreeRefsState(ChunkStore *cs){
   csFreeBranches(cs);
@@ -492,28 +606,15 @@ static int csGrowWriteBuf(ChunkStore *cs, int nNeeded){
 static int csReplayWalRegion(ChunkStore *cs, int updateManifest){
   i64 walSize;
   u8 *walData;
-  u8 *pOldWalData = cs->pWalData;
-  i64 nOldWalData = cs->nWalData;
+  ChunkStoreReplayState saved;
   i64 pos;
   int nPendingBefore = cs->nPending;
   int nRootedPending = cs->nPending;
-  int nOldChunks = cs->nChunks;
-  ProllyHash oldRefsHash = cs->refsHash;
-  ChunkIndexEntry *aOldIndex = cs->aIndex;
-  int nOldIndex = cs->nIndex;
-  int nOldIndexAlloc = cs->nIndexAlloc;
-  char *zOldDefaultBranch = cs->zDefaultBranch;
-  struct BranchRef *aOldBranches = cs->aBranches;
-  int nOldBranches = cs->nBranches;
-  struct TagRef *aOldTags = cs->aTags;
-  int nOldTags = cs->nTags;
-  struct RemoteRef *aOldRemotes = cs->aRemotes;
-  int nOldRemotes = cs->nRemotes;
-  struct TrackingBranch *aOldTracking = cs->aTracking;
-  int nOldTracking = cs->nTracking;
   ChunkStore tmpRefs;
   int haveTmpRefs = 0;
   int rc = SQLITE_OK;
+
+  csCaptureReplayState(cs, &saved);
 
   if( cs->iWalOffset <= 0 || !cs->pFile ) return SQLITE_OK;
 
@@ -562,9 +663,9 @@ static int csReplayWalRegion(ChunkStore *cs, int updateManifest){
 
       {
         int existing = csSearchIndex(cs->aIndex, cs->nIndex, &hash);
+        ChunkIndexEntry *e = 0;
         if( existing < 0 ){
           rc = csGrowPending(cs);
-          ChunkIndexEntry *e;
           if( rc != SQLITE_OK ) goto replay_error;
           e = &cs->aPending[cs->nPending];
           memcpy(&e->hash, &hash, sizeof(ProllyHash));
@@ -649,45 +750,17 @@ static int csReplayWalRegion(ChunkStore *cs, int updateManifest){
     }
   }
 
-  if( cs->aIndex!=aOldIndex ) sqlite3_free(aOldIndex);
-  sqlite3_free(pOldWalData);
-  {
-    ChunkStore oldRefs;
-    memset(&oldRefs, 0, sizeof(oldRefs));
-    oldRefs.zDefaultBranch = zOldDefaultBranch;
-    oldRefs.aBranches = aOldBranches;
-    oldRefs.nBranches = nOldBranches;
-    oldRefs.aTags = aOldTags;
-    oldRefs.nTags = nOldTags;
-    oldRefs.aRemotes = aOldRemotes;
-    oldRefs.nRemotes = nOldRemotes;
-    oldRefs.aTracking = aOldTracking;
-    oldRefs.nTracking = nOldTracking;
-    csFreeRefsState(&oldRefs);
-  }
+  if( cs->aIndex!=saved.aIndex ) sqlite3_free(saved.aIndex);
+  sqlite3_free(saved.pWalData);
+  csFreeSavedRefsState(&saved.refs);
 
   return SQLITE_OK;
 
 replay_error:
   if( haveTmpRefs ) csFreeRefsState(&tmpRefs);
-  if( cs->aIndex!=aOldIndex ) sqlite3_free(cs->aIndex);
+  if( cs->aIndex!=saved.aIndex ) sqlite3_free(cs->aIndex);
   sqlite3_free(cs->pWalData);
-  cs->pWalData = pOldWalData;
-  cs->nWalData = nOldWalData;
-  cs->nChunks = nOldChunks;
-  cs->refsHash = oldRefsHash;
-  cs->aIndex = aOldIndex;
-  cs->nIndex = nOldIndex;
-  cs->nIndexAlloc = nOldIndexAlloc;
-  cs->zDefaultBranch = zOldDefaultBranch;
-  cs->aBranches = aOldBranches;
-  cs->nBranches = nOldBranches;
-  cs->aTags = aOldTags;
-  cs->nTags = nOldTags;
-  cs->aRemotes = aOldRemotes;
-  cs->nRemotes = nOldRemotes;
-  cs->aTracking = aOldTracking;
-  cs->nTracking = nOldTracking;
+  csRestoreReplayState(cs, &saved);
   cs->nPending = nPendingBefore;
   csPendHTClear(cs);
   return rc;
@@ -1963,17 +2036,12 @@ int chunkStoreRefreshIfChanged(ChunkStore *cs, int *pChanged){
 
 static int csReloadFromDisk(ChunkStore *cs){
   ChunkStore tmp;
-  sqlite3_file *pOldFile = cs->pFile;
-  ChunkIndexEntry *aOldIndex = cs->aIndex;
-  u8 *pOldWalData = cs->pWalData;
-  char *zOldDefaultBranch = cs->zDefaultBranch;
-  struct BranchRef *aOldBranches = cs->aBranches;
-  struct TagRef *aOldTags = cs->aTags;
-  struct RemoteRef *aOldRemotes = cs->aRemotes;
-  struct TrackingBranch *aOldTracking = cs->aTracking;
+  ChunkStoreReloadState saved;
   int rc = chunkStoreOpen(&tmp, cs->pVfs, cs->zFilename,
                           SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB);
   if( rc!=SQLITE_OK ) return rc;
+
+  csCaptureReloadState(cs, &saved);
 
   cs->pFile = tmp.pFile;
   cs->readOnly = tmp.readOnly;
@@ -2019,22 +2087,7 @@ static int csReloadFromDisk(ChunkStore *cs){
   tmp.nTracking = 0;
   chunkStoreClose(&tmp);
 
-  csCloseFile(pOldFile);
-  sqlite3_free(aOldIndex);
-  sqlite3_free(pOldWalData);
-  sqlite3_free(zOldDefaultBranch);
-  {
-    ChunkStore oldRefs;
-    memset(&oldRefs, 0, sizeof(oldRefs));
-    oldRefs.aBranches = aOldBranches;
-    oldRefs.aTags = aOldTags;
-    oldRefs.aRemotes = aOldRemotes;
-    oldRefs.aTracking = aOldTracking;
-    csFreeBranches(&oldRefs);
-    csFreeTags(&oldRefs);
-    csFreeRemotes(&oldRefs);
-    csFreeTracking(&oldRefs);
-  }
+  csFreeReloadState(&saved);
   return SQLITE_OK;
 }
 

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -494,7 +494,11 @@ static int csGrowWriteBuf(ChunkStore *cs, int nNeeded){
 static int csReplayWalRegion(ChunkStore *cs, int updateManifest){
   i64 walSize;
   u8 *walData;
+  u8 *pOldWalData = cs->pWalData;
+  i64 nOldWalData = cs->nWalData;
   i64 pos;
+  int rc = SQLITE_OK;
+  int nPendingBefore = cs->nPending;
   int nRootedPending = cs->nPending;
 
   if( cs->iWalOffset <= 0 || !cs->pFile ) return SQLITE_OK;
@@ -530,23 +534,25 @@ static int csReplayWalRegion(ChunkStore *cs, int updateManifest){
     if( tag == CS_WAL_TAG_CHUNK ){
       ProllyHash hash;
       u32 len;
-      if( pos + 20 + 4 > walSize ) break;
+      if( pos + 20 + 4 > walSize ){
+        rc = SQLITE_CORRUPT;
+        goto replay_error;
+      }
       memcpy(&hash, walData + pos, 20);
       pos += 20;
       len = CS_READ_U32(walData + pos);
       pos += 4;
-      if( pos < 0 || (u64)pos + len > (u64)walSize ) break;
+      if( pos < 0 || (u64)pos + len > (u64)walSize ){
+        rc = SQLITE_CORRUPT;
+        goto replay_error;
+      }
 
       {
         int existing = csSearchIndex(cs->aIndex, cs->nIndex, &hash);
         if( existing < 0 ){
-          int rc = csGrowPending(cs);
+          rc = csGrowPending(cs);
           ChunkIndexEntry *e;
-          if( rc != SQLITE_OK ){
-            sqlite3_free(walData);
-            cs->pWalData = 0;
-            return rc;
-          }
+          if( rc != SQLITE_OK ) goto replay_error;
           e = &cs->aPending[cs->nPending];
           memcpy(&e->hash, &hash, sizeof(ProllyHash));
           e->offset = csEncodeWalOffset((i64)pos);
@@ -557,25 +563,31 @@ static int csReplayWalRegion(ChunkStore *cs, int updateManifest){
       pos += len;
 
     } else if( tag == CS_WAL_TAG_ROOT ){
-      if( pos + CHUNK_MANIFEST_SIZE > walSize ) break;
+      if( pos + CHUNK_MANIFEST_SIZE > walSize ){
+        rc = SQLITE_CORRUPT;
+        goto replay_error;
+      }
       if( updateManifest ){
         u8 *m = walData + pos;
         u32 magic = CS_READ_U32(m);
-        if( magic == CHUNK_STORE_MAGIC ){
-          /* offset 8: reserved (was root_hash) */
-          cs->nChunks = (int)CS_READ_U32(m + 28);
-          /* offset 64: reserved (was headCommit_hash) */
-          memcpy(cs->refsHash.data, m + 104, PROLLY_HASH_SIZE);
-          memcpy(cs->workingState.data, m + 124, PROLLY_HASH_SIZE);
-          /* Don't update iWalOffset/iIndexOffset from WAL root records --
-          ** those fields describe the compacted region and only change on GC. */
+        if( magic != CHUNK_STORE_MAGIC ){
+          rc = SQLITE_CORRUPT;
+          goto replay_error;
         }
+        /* offset 8: reserved (was root_hash) */
+        cs->nChunks = (int)CS_READ_U32(m + 28);
+        /* offset 64: reserved (was headCommit_hash) */
+        memcpy(cs->refsHash.data, m + 104, PROLLY_HASH_SIZE);
+        memcpy(cs->workingState.data, m + 124, PROLLY_HASH_SIZE);
+        /* Don't update iWalOffset/iIndexOffset from WAL root records --
+        ** those fields describe the compacted region and only change on GC. */
       }
       pos += CHUNK_MANIFEST_SIZE;
       nRootedPending = cs->nPending;
 
     } else {
-      break;
+      rc = SQLITE_CORRUPT;
+      goto replay_error;
     }
   }
 
@@ -584,12 +596,8 @@ static int csReplayWalRegion(ChunkStore *cs, int updateManifest){
   if( cs->nPending > 0 ){
     ChunkIndexEntry *aMerged = 0;
     int nMerged = 0;
-    int rc = csMergeIndex(cs, &aMerged, &nMerged);
-    if( rc != SQLITE_OK ){
-      sqlite3_free(walData);
-      cs->pWalData = 0;
-      return rc;
-    }
+    rc = csMergeIndex(cs, &aMerged, &nMerged);
+    if( rc != SQLITE_OK ) goto replay_error;
     sqlite3_free(cs->aIndex);
     cs->aIndex = aMerged;
     cs->nIndex = nMerged;
@@ -599,23 +607,36 @@ static int csReplayWalRegion(ChunkStore *cs, int updateManifest){
   }
 
   if( !prollyHashIsEmpty(&cs->refsHash) ){
-    u8 *refsData = 0; int nRefsData = 0;
+    u8 *refsData = 0;
+    int nRefsData = 0;
+    ChunkStore tmpRefs;
     int rc2 = chunkStoreGet(cs, &cs->refsHash, &refsData, &nRefsData);
     if( rc2==SQLITE_OK && refsData ){
-      csFreeBranches(cs);
-      csFreeTags(cs);
-      csFreeRemotes(cs);
-      csFreeTracking(cs);
-      rc2 = csDeserializeRefs(cs, refsData, nRefsData);
+      rc2 = csDeserializeRefsIntoTemp(&tmpRefs, refsData, nRefsData);
       sqlite3_free(refsData);
-      if( rc2!=SQLITE_OK ) return rc2;
+      if( rc2!=SQLITE_OK ){
+        csFreeRefsState(&tmpRefs);
+        rc = rc2;
+        goto replay_error;
+      }
+      csFreeRefsState(cs);
+      csAdoptRefsState(cs, &tmpRefs);
     }else if( rc2!=SQLITE_OK ){
-      return rc2;
+      rc = rc2;
+      goto replay_error;
     }
   }
   if( !cs->zDefaultBranch ) cs->zDefaultBranch = sqlite3_mprintf("main");
 
   return SQLITE_OK;
+
+replay_error:
+  sqlite3_free(cs->pWalData);
+  cs->pWalData = pOldWalData;
+  cs->nWalData = nOldWalData;
+  cs->nPending = nPendingBefore;
+  csPendHTClear(cs);
+  return rc;
 }
 
 static int csIndexEntryCmp(const void *a, const void *b){
@@ -1462,7 +1483,7 @@ int chunkStoreGet(
         *pnData = sz;
         return SQLITE_OK;
       }
-      return SQLITE_NOTFOUND;
+      return SQLITE_CORRUPT;
     }
   }
 
@@ -1871,14 +1892,7 @@ int chunkStoreRefreshIfChanged(ChunkStore *cs, int *pChanged){
     if( exists ){
       struct stat mainStat;
       if( stat(cs->zFilename, &mainStat)==0 && mainStat.st_size > 0 ){
-        int openFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB;
-        rc = csOpenFile(cs->pVfs, cs->zFilename, &cs->pFile, openFlags);
-        if( rc!=SQLITE_OK ) return rc;
-        rc = csReadManifest(cs);
-        if( rc!=SQLITE_OK ) return rc;
-        rc = csReadIndex(cs);
-        if( rc!=SQLITE_OK ) return rc;
-        rc = csReplayWal(cs);
+        rc = csReloadFromDisk(cs);
         if( rc!=SQLITE_OK ) return rc;
         *pChanged = 1;
       }

--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -6,7 +6,7 @@
 **     magic(4) + version(4) + reserved(20) + nChunks(4) +
 **     index_offset(8) + index_size(4) + reserved(20) +
 **     reserved(20) + wal_offset(8) + reserved(12) +
-**     refs_hash(20) + working_state_hash(20) + reserved(24)
+**     refs_hash(20) + reserved(44)
 **   [Chunk data region: after manifest, before index]
 **     Each chunk stored as: length_le32(4) + data(length)
 **   [Sorted index: nChunks * 32-byte entries]
@@ -24,14 +24,17 @@
 #include "prolly_hash.h"
 
 #define CHUNK_STORE_MAGIC 0x444C5443  /* "DLTC" in little-endian */
-#define CHUNK_STORE_VERSION 7
+#define CHUNK_STORE_VERSION 8
 #define CHUNK_MANIFEST_SIZE 168
 #define CHUNK_INDEX_ENTRY_SIZE 32     /* 20-byte hash + 8-byte offset + 4-byte size */
 
 /* Working set blob layout:
-**   [version:1][staged_hash:20][is_merging:1][merge_commit:20][conflicts:20] */
+**   [version:1][working_catalog:20][working_commit:20][staged_hash:20]
+**   [is_merging:1][merge_commit:20][conflicts:20] */
 #define WS_VERSION_SIZE     1
-#define WS_STAGED_OFF       WS_VERSION_SIZE
+#define WS_WORKING_CAT_OFF  WS_VERSION_SIZE
+#define WS_WORKING_COMMIT_OFF (WS_WORKING_CAT_OFF + PROLLY_HASH_SIZE)
+#define WS_STAGED_OFF       (WS_WORKING_COMMIT_OFF + PROLLY_HASH_SIZE)
 #define WS_MERGING_OFF      (WS_STAGED_OFF + PROLLY_HASH_SIZE)
 #define WS_MERGE_COMMIT_OFF (WS_MERGING_OFF + 1)
 #define WS_CONFLICTS_OFF    (WS_MERGE_COMMIT_OFF + PROLLY_HASH_SIZE)
@@ -102,7 +105,6 @@ struct ChunkStore {
   sqlite3_file *pFile;
   sqlite3_vfs *pVfs;
   ProllyHash refsHash;
-  ProllyHash workingState;  /* Per-branch working catalog state chunk hash */
 
   /* These fields come from the per-branch WorkingSet, not from the manifest. */
   ProllyHash stagedCatalog;
@@ -186,8 +188,6 @@ int chunkStoreClose(ChunkStore *cs);
 int chunkStoreLockAndRefresh(ChunkStore *cs);
 void chunkStoreUnlock(ChunkStore *cs);
 
-void chunkStoreGetWorkingState(ChunkStore *cs, ProllyHash *pState);
-void chunkStoreSetWorkingState(ChunkStore *cs, const ProllyHash *pState);
 int chunkStoreWriteBranchWorkingCatalog(ChunkStore *cs, const char *zBranch,
                                         const ProllyHash *pCatHash,
                                         const ProllyHash *pCommitHash);

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -1421,6 +1421,12 @@ static void doltliteResetFunc(
           ** unchanged. */
           for(j=0; j<nWorking; j++){
             int tgtIdx = -1;
+            if( aWorking[j].iTable==1 ){
+              /* Keep the working sqlite_master root when preserving
+              ** untracked tables. Replacing table 1 from HEAD would drop
+              ** the schema rows for those untracked objects immediately. */
+              continue;
+            }
             for(k=0; k<nTarget; k++){
               if( aTarget[k].zName && aWorking[j].zName
                && strcmp(aTarget[k].zName, aWorking[j].zName)==0 ){

--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -570,7 +570,7 @@ static int brIsDirty(
   }
 
   rc = chunkStoreGet(cs, &br->workingSetHash, &wsData, &nWsData);
-  if( rc!=SQLITE_OK || !wsData || nWsData < WS_TOTAL_SIZE ){
+  if( rc!=SQLITE_OK || !wsData || nWsData < WS_TOTAL_SIZE || wsData[0] != 2 ){
     sqlite3_free(wsData);
     return rc==SQLITE_OK ? SQLITE_CORRUPT : rc;
   }

--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -45,11 +45,8 @@ static int mutateBranchRef(sqlite3 *db, ChunkStore *cs, void *pArg){
   int rc;
 
   if( p->isDelete ){
-    ProllyHash empty;
-    rc = chunkStoreDeleteBranch(cs, p->zName);
-    if( rc!=SQLITE_OK ) return rc;
-    memset(&empty, 0, sizeof(empty));
-    return doltliteUpdateBranchWorkingState(db, p->zName, &empty, NULL);
+    (void)db;
+    return chunkStoreDeleteBranch(cs, p->zName);
   }
 
   if( p->force && chunkStoreFindBranch(cs, p->zName, 0)==SQLITE_OK ){
@@ -94,18 +91,22 @@ struct BranchMoveCtx {
 
 static int mutateBranchMove(sqlite3 *db, ChunkStore *cs, void *pArg){
   BranchMoveCtx *p = (BranchMoveCtx*)pArg;
-  ProllyHash srcCommit, empty;
+  ProllyHash srcCommit, srcWorkingSet;
   int rc;
   (void)db;
 
   rc = chunkStoreFindBranch(cs, p->zSrc, &srcCommit);
   if( rc!=SQLITE_OK ) return rc;
+  rc = chunkStoreGetBranchWorkingSet(cs, p->zSrc, &srcWorkingSet);
+  if( rc!=SQLITE_OK ) memset(&srcWorkingSet, 0, sizeof(srcWorkingSet));
   rc = chunkStoreAddBranch(cs, p->zDest, &srcCommit);
   if( rc!=SQLITE_OK ) return rc;
+  if( !prollyHashIsEmpty(&srcWorkingSet) ){
+    rc = chunkStoreSetBranchWorkingSet(cs, p->zDest, &srcWorkingSet);
+    if( rc!=SQLITE_OK ) return rc;
+  }
   rc = chunkStoreDeleteBranch(cs, p->zSrc);
-  if( rc!=SQLITE_OK ) return rc;
-  memset(&empty, 0, sizeof(empty));
-  return doltliteUpdateBranchWorkingState(db, p->zSrc, &empty, NULL);
+  return rc;
 }
 
 static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){

--- a/src/doltlite_chunk_walk.c
+++ b/src/doltlite_chunk_walk.c
@@ -22,8 +22,8 @@ DoltliteChunkType doltliteClassifyChunk(const u8 *data, int nData){
     return CHUNK_PROLLY_NODE;
   }
 
-  /* Working set: exactly WS_TOTAL_SIZE bytes, version byte == 1 */
-  if( nData == WS_TOTAL_SIZE && data[0] == 1 ){
+  /* Working set: exactly WS_TOTAL_SIZE bytes, version byte == 2 */
+  if( nData == WS_TOTAL_SIZE && data[0] == 2 ){
     return CHUNK_WORKING_SET;
   }
 
@@ -141,6 +141,16 @@ static int enumerateWorkingSetChildren(
   int rc;
 
   (void)nData;
+
+  /* working catalog hash */
+  memcpy(h.data, data + WS_WORKING_CAT_OFF, PROLLY_HASH_SIZE);
+  rc = xChild(ctx, &h);
+  if( rc!=SQLITE_OK ) return rc;
+
+  /* working commit hash */
+  memcpy(h.data, data + WS_WORKING_COMMIT_OFF, PROLLY_HASH_SIZE);
+  rc = xChild(ctx, &h);
+  if( rc!=SQLITE_OK ) return rc;
 
   /* staged catalog hash */
   memcpy(h.data, data + WS_STAGED_OFF, PROLLY_HASH_SIZE);

--- a/src/doltlite_chunk_walk.c
+++ b/src/doltlite_chunk_walk.c
@@ -40,6 +40,11 @@ DoltliteChunkType doltliteClassifyChunk(const u8 *data, int nData){
     return CHUNK_COMMIT;
   }
 
+  /* Refs blob: version byte 5/6 with length-prefixed sections. */
+  if( nData >= 5 && (data[0] == 5 || data[0] == 6) ){
+    return CHUNK_REFS;
+  }
+
   return CHUNK_UNKNOWN;
 }
 
@@ -156,6 +161,136 @@ static int enumerateWorkingSetChildren(
   return rc;
 }
 
+static int enumerateRefsChildren(
+  const u8 *data,
+  int nData,
+  DoltliteChildCb xChild,
+  void *ctx
+){
+  const u8 *p = data;
+  const u8 *pEnd = data + nData;
+  int version;
+  int defLen;
+  int nBranches;
+  int nTags;
+  int nRemotes;
+  int nTracking;
+  int i;
+  ProllyHash h;
+  int rc = SQLITE_OK;
+
+  if( nData < 5 ) return SQLITE_CORRUPT;
+  version = *p++;
+  if( version!=5 && version!=6 ) return SQLITE_CORRUPT;
+  if( p + 4 > pEnd ) return SQLITE_CORRUPT;
+  defLen = (int)(p[0] | (p[1]<<8) | (p[2]<<16) | (p[3]<<24));
+  p += 4;
+  if( defLen < 0 || p + defLen > pEnd ) return SQLITE_CORRUPT;
+  p += defLen;
+
+  if( p + 4 > pEnd ) return SQLITE_CORRUPT;
+  nBranches = (int)(p[0] | (p[1]<<8) | (p[2]<<16) | (p[3]<<24));
+  p += 4;
+  if( nBranches < 0 || nBranches > 100000 ) return SQLITE_CORRUPT;
+  for(i=0; i<nBranches && rc==SQLITE_OK; i++){
+    int nameLen;
+    if( p + 4 > pEnd ) return SQLITE_CORRUPT;
+    nameLen = (int)(p[0] | (p[1]<<8) | (p[2]<<16) | (p[3]<<24));
+    p += 4;
+    if( nameLen < 0 || p + nameLen + PROLLY_HASH_SIZE > pEnd ) return SQLITE_CORRUPT;
+    p += nameLen;
+    memcpy(h.data, p, PROLLY_HASH_SIZE);
+    p += PROLLY_HASH_SIZE;
+    rc = xChild(ctx, &h);
+    if( rc!=SQLITE_OK ) break;
+    if( p + PROLLY_HASH_SIZE > pEnd ) return SQLITE_CORRUPT;
+    memcpy(h.data, p, PROLLY_HASH_SIZE);
+    p += PROLLY_HASH_SIZE;
+    rc = xChild(ctx, &h);
+  }
+  if( rc!=SQLITE_OK ) return rc;
+
+  if( p + 4 > pEnd ) return SQLITE_CORRUPT;
+  nTags = (int)(p[0] | (p[1]<<8) | (p[2]<<16) | (p[3]<<24));
+  p += 4;
+  if( nTags < 0 || nTags > 100000 ) return SQLITE_CORRUPT;
+  for(i=0; i<nTags && rc==SQLITE_OK; i++){
+    int nameLen;
+    if( p + 4 > pEnd ) return SQLITE_CORRUPT;
+    nameLen = (int)(p[0] | (p[1]<<8) | (p[2]<<16) | (p[3]<<24));
+    p += 4;
+    if( nameLen < 0 || p + nameLen + PROLLY_HASH_SIZE > pEnd ) return SQLITE_CORRUPT;
+    p += nameLen;
+    memcpy(h.data, p, PROLLY_HASH_SIZE);
+    p += PROLLY_HASH_SIZE;
+    rc = xChild(ctx, &h);
+    if( rc!=SQLITE_OK ) break;
+    if( version>=6 ){
+      int n;
+      if( p + 4 > pEnd ) return SQLITE_CORRUPT;
+      n = (int)(p[0] | (p[1]<<8) | (p[2]<<16) | (p[3]<<24));
+      p += 4;
+      if( n < 0 || p + n > pEnd ) return SQLITE_CORRUPT;
+      p += n;
+      if( p + 4 > pEnd ) return SQLITE_CORRUPT;
+      n = (int)(p[0] | (p[1]<<8) | (p[2]<<16) | (p[3]<<24));
+      p += 4;
+      if( n < 0 || p + n > pEnd ) return SQLITE_CORRUPT;
+      p += n;
+      if( p + 8 > pEnd ) return SQLITE_CORRUPT;
+      p += 8;
+      if( p + 4 > pEnd ) return SQLITE_CORRUPT;
+      n = (int)(p[0] | (p[1]<<8) | (p[2]<<16) | (p[3]<<24));
+      p += 4;
+      if( n < 0 || p + n > pEnd ) return SQLITE_CORRUPT;
+      p += n;
+    }
+  }
+  if( rc!=SQLITE_OK ) return rc;
+
+  if( p + 4 > pEnd ) return SQLITE_CORRUPT;
+  nRemotes = (int)(p[0] | (p[1]<<8) | (p[2]<<16) | (p[3]<<24));
+  p += 4;
+  if( nRemotes < 0 || nRemotes > 100000 ) return SQLITE_CORRUPT;
+  for(i=0; i<nRemotes; i++){
+    int n;
+    if( p + 4 > pEnd ) return SQLITE_CORRUPT;
+    n = (int)(p[0] | (p[1]<<8) | (p[2]<<16) | (p[3]<<24));
+    p += 4;
+    if( n < 0 || p + n > pEnd ) return SQLITE_CORRUPT;
+    p += n;
+    if( p + 4 > pEnd ) return SQLITE_CORRUPT;
+    n = (int)(p[0] | (p[1]<<8) | (p[2]<<16) | (p[3]<<24));
+    p += 4;
+    if( n < 0 || p + n > pEnd ) return SQLITE_CORRUPT;
+    p += n;
+  }
+
+  if( p + 4 > pEnd ) return SQLITE_CORRUPT;
+  nTracking = (int)(p[0] | (p[1]<<8) | (p[2]<<16) | (p[3]<<24));
+  p += 4;
+  if( nTracking < 0 || nTracking > 100000 ) return SQLITE_CORRUPT;
+  for(i=0; i<nTracking && rc==SQLITE_OK; i++){
+    int n;
+    if( p + 4 > pEnd ) return SQLITE_CORRUPT;
+    n = (int)(p[0] | (p[1]<<8) | (p[2]<<16) | (p[3]<<24));
+    p += 4;
+    if( n < 0 || p + n > pEnd ) return SQLITE_CORRUPT;
+    p += n;
+    if( p + 4 > pEnd ) return SQLITE_CORRUPT;
+    n = (int)(p[0] | (p[1]<<8) | (p[2]<<16) | (p[3]<<24));
+    p += 4;
+    if( n < 0 || p + n + PROLLY_HASH_SIZE > pEnd ) return SQLITE_CORRUPT;
+    p += n;
+    memcpy(h.data, p, PROLLY_HASH_SIZE);
+    p += PROLLY_HASH_SIZE;
+    rc = xChild(ctx, &h);
+  }
+  if( rc!=SQLITE_OK ) return rc;
+  if( p != pEnd ) return SQLITE_CORRUPT;
+  return SQLITE_OK;
+}
+
 int doltliteEnumerateChunkChildren(
   const u8 *data,
   int nData,
@@ -173,6 +308,8 @@ int doltliteEnumerateChunkChildren(
       return enumerateCatalogChildren(data, nData, xChild, ctx);
     case CHUNK_WORKING_SET:
       return enumerateWorkingSetChildren(data, nData, xChild, ctx);
+    case CHUNK_REFS:
+      return enumerateRefsChildren(data, nData, xChild, ctx);
     case CHUNK_UNKNOWN:
     default:
       return SQLITE_OK;

--- a/src/doltlite_chunk_walk.h
+++ b/src/doltlite_chunk_walk.h
@@ -10,7 +10,8 @@ typedef enum {
   CHUNK_COMMIT,
   CHUNK_PROLLY_NODE,
   CHUNK_CATALOG,
-  CHUNK_WORKING_SET
+  CHUNK_WORKING_SET,
+  CHUNK_REFS
 } DoltliteChunkType;
 
 typedef int (*DoltliteChildCb)(void *ctx, const ProllyHash *pHash);

--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -81,54 +81,6 @@ static int gcMarkReachable(
   
   rc = gcQueuePush(&queue, &cs->refsHash);
 
-  /* Mark the per-branch working state chunk and all catalog hashes within it.
-  ** Entry format: [nameLen:4 LE][name][catHash:20][commitHash:20]
-  ** We push catHash to the GC queue. commitHash is skipped because
-  ** commits are already reachable via branch refs. */
-  if( rc==SQLITE_OK && !prollyHashIsEmpty(&cs->workingState) ){
-    rc = prollyHashSetAdd(marked, &cs->workingState);
-    if( rc==SQLITE_OK ){
-      u8 *wsData = 0; int nWsData = 0;
-      int entryHashSize = PROLLY_HASH_SIZE * 2; /* catHash + commitHash */
-      rc = chunkStoreGet(cs, &cs->workingState, &wsData, &nWsData);
-      if( rc!=SQLITE_OK ){
-        gcQueueFree(&queue);
-        return rc;
-      }
-      if( !wsData || nWsData < 4 ){
-        sqlite3_free(wsData);
-        gcQueueFree(&queue);
-        return SQLITE_CORRUPT;
-      }
-      {
-        int nBr = (int)((u32)wsData[0] | ((u32)wsData[1]<<8) | ((u32)wsData[2]<<16) | ((u32)wsData[3]<<24));
-        const u8 *pp = wsData + 4;
-        int j;
-        for(j=0; j<nBr && rc==SQLITE_OK; j++){
-          int nl;
-          if( pp + 4 > wsData + nWsData ){
-            rc = SQLITE_CORRUPT;
-            break;
-          }
-          nl = (int)((u32)pp[0] | ((u32)pp[1]<<8) | ((u32)pp[2]<<16) | ((u32)pp[3]<<24));
-          pp += 4;
-          if( pp + nl + entryHashSize > wsData + nWsData ){
-            rc = SQLITE_CORRUPT;
-            break;
-          }
-          {
-            ProllyHash brCat;
-            memcpy(brCat.data, pp + nl, PROLLY_HASH_SIZE);
-            rc = gcQueuePush(&queue, &brCat);
-          }
-          pp += nl + entryHashSize;
-        }
-      }
-      sqlite3_free(wsData);
-    }
-  }
-
-  
   for(i=0; rc==SQLITE_OK && i<cs->nBranches; i++){
     rc = gcQueuePush(&queue, &cs->aBranches[i].commitHash);
     if( rc==SQLITE_OK ) rc = gcQueuePush(&queue, &cs->aBranches[i].workingSetHash);

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -116,6 +116,7 @@ int doltliteHardReset(sqlite3 *db, const ProllyHash *catHash);
 int doltliteUpdateBranchWorkingState(sqlite3 *db, const char *zBranch,
                                      const ProllyHash *pCatHash,
                                      const ProllyHash *pCommitHash);
+int doltliteCheckRepoGraphIntegrity(Btree *p, int mxErr, int *pnErr);
 
 const char *doltliteGetSessionBranch(sqlite3 *db);
 void doltliteSetSessionBranch(sqlite3 *db, const char *zBranch);

--- a/src/doltlite_record.c
+++ b/src/doltlite_record.c
@@ -209,7 +209,11 @@ int doltliteGetColumnNames(sqlite3 *db, const char *zTable, DoltliteColInfo *ci)
   return SQLITE_OK;
 }
 
-void doltliteParseRecord(const u8 *pData, int nData, DoltliteRecordInfo *pInfo){
+int doltliteParseRecordStrict(
+  const u8 *pData,
+  int nData,
+  DoltliteRecordInfo *pInfo
+){
   const u8 *p = pData;
   const u8 *pEnd = pData + nData;
   u64 hdrSize;
@@ -217,22 +221,38 @@ void doltliteParseRecord(const u8 *pData, int nData, DoltliteRecordInfo *pInfo){
   const u8 *pHdrEnd;
 
   memset(pInfo, 0, sizeof(*pInfo));
-  if( !pData || nData < 1 ) return;
+  if( !pData || nData < 1 ) return SQLITE_CORRUPT;
 
   hdrBytes = dlReadVarint(p, pEnd, &hdrSize);
+  if( hdrBytes<=0 ) return SQLITE_CORRUPT;
+  if( (int)hdrSize < hdrBytes || (int)hdrSize > nData ) return SQLITE_CORRUPT;
   p += hdrBytes;
   pHdrEnd = pData + (int)hdrSize;
   off = (int)hdrSize;
 
-  while( p < pHdrEnd && p < pEnd && pInfo->nField < DOLTLITE_MAX_RECORD_FIELDS ){
+  while( p < pHdrEnd ){
     u64 st;
     int stBytes = dlReadVarint(p, pHdrEnd, &st);
+    int nField;
+    int nSerial;
+    if( stBytes<=0 ) return SQLITE_CORRUPT;
+    nField = pInfo->nField;
+    if( nField >= DOLTLITE_MAX_RECORD_FIELDS ) return SQLITE_CORRUPT;
     p += stBytes;
-    pInfo->aType[pInfo->nField] = (int)st;
-    pInfo->aOffset[pInfo->nField] = off;
-    off += dlSerialTypeLen(st);
-    pInfo->nField++;
+    nSerial = dlSerialTypeLen(st);
+    if( off > nData - nSerial ) return SQLITE_CORRUPT;
+    pInfo->aType[nField] = (int)st;
+    pInfo->aOffset[nField] = off;
+    off += nSerial;
+    pInfo->nField = nField + 1;
   }
+  if( p != pHdrEnd ) return SQLITE_CORRUPT;
+  if( off != nData ) return SQLITE_CORRUPT;
+  return SQLITE_OK;
+}
+
+void doltliteParseRecord(const u8 *pData, int nData, DoltliteRecordInfo *pInfo){
+  (void)doltliteParseRecordStrict(pData, nData, pInfo);
 }
 
 void doltliteResultField(

--- a/src/doltlite_record.h
+++ b/src/doltlite_record.h
@@ -74,6 +74,9 @@ struct DoltliteRecordInfo {
   int aOffset[DOLTLITE_MAX_RECORD_FIELDS];
 };
 
+int doltliteParseRecordStrict(const u8 *pData, int nData,
+                              DoltliteRecordInfo *pInfo);
+
 void doltliteParseRecord(const u8 *pData, int nData, DoltliteRecordInfo *pInfo);
 
 void doltliteResultField(sqlite3_context *ctx, const u8 *pData, int nData,

--- a/src/doltlite_record.h
+++ b/src/doltlite_record.h
@@ -65,7 +65,7 @@ static inline int dlSerialTypeLen(u64 st){
 ** Parsed record header: field count, serial types, and data offsets.
 ** Shared across diff_table, history, at, schema_diff, and merge.
 */
-#define DOLTLITE_MAX_RECORD_FIELDS 64
+#define DOLTLITE_MAX_RECORD_FIELDS 256
 
 typedef struct DoltliteRecordInfo DoltliteRecordInfo;
 struct DoltliteRecordInfo {

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -8,9 +8,11 @@
 #include "prolly_cache.h"
 #include "chunk_store.h"
 #include "prolly_cursor.h"
+#include "prolly_hashset.h"
 #include "prolly_mutmap.h"
 #include "prolly_mutate.h"
 #include "pager_shim.h"
+#include "doltlite_chunk_walk.h"
 #include "doltlite_commit.h"
 #include "sortkey.h"
 #include "btree_orig_api.h"
@@ -4580,46 +4582,94 @@ i64 sqlite3BtreeRowCountEst(BtCursor *pCur){
   return pCur->pCurOps->xRowCountEst(pCur);
 }
 
-static int integrityCheckProllySubtree(
-  BtShared *pBt,
-  const ProllyHash *pHash,
-  int mxErr,
-  int *pnErr
+typedef struct IntegrityCheckCtx IntegrityCheckCtx;
+struct IntegrityCheckCtx {
+  BtShared *pBt;
+  ProllyHashSet seen;
+  int mxErr;
+  int *pnErr;
+};
+
+static int integrityCheckChunkGraph(IntegrityCheckCtx *pCtx, const ProllyHash *pHash);
+
+static int integrityCheckChildCb(void *pArg, const ProllyHash *pHash){
+  return integrityCheckChunkGraph((IntegrityCheckCtx*)pArg, pHash);
+}
+
+static int integrityCheckChunkGraph(
+  IntegrityCheckCtx *pCtx,
+  const ProllyHash *pHash
 ){
   u8 *pData = 0;
   int nData = 0;
-  ProllyNode node;
   int rc;
-  int i;
 
   if( prollyHashIsEmpty(pHash) ) return SQLITE_OK;
-  if( mxErr>0 && *pnErr>=mxErr ) return SQLITE_OK;
+  if( pCtx->mxErr>0 && *pCtx->pnErr>=pCtx->mxErr ) return SQLITE_OK;
+  if( prollyHashSetContains(&pCtx->seen, pHash) ) return SQLITE_OK;
 
-  rc = chunkStoreGet(&pBt->store, pHash, &pData, &nData);
+  rc = prollyHashSetAdd(&pCtx->seen, pHash);
+  if( rc!=SQLITE_OK ) return rc;
+
+  rc = chunkStoreGet(&pCtx->pBt->store, pHash, &pData, &nData);
   if( rc==SQLITE_NOTFOUND || rc==SQLITE_CORRUPT ){
-    (*pnErr)++;
+    (*pCtx->pnErr)++;
     return SQLITE_OK;
   }
   if( rc!=SQLITE_OK ) return rc;
 
-  rc = prollyNodeParse(&node, pData, nData);
+  rc = doltliteEnumerateChunkChildren(pData, nData, integrityCheckChildCb, pCtx);
   sqlite3_free(pData);
-  if( rc!=SQLITE_OK ){
-    (*pnErr)++;
+  if( rc==SQLITE_NOTFOUND || rc==SQLITE_CORRUPT ){
+    (*pCtx->pnErr)++;
     return SQLITE_OK;
   }
+  return rc;
+}
 
-  if( node.level==0 ) return SQLITE_OK;
+int doltliteCheckRepoGraphIntegrity(Btree *p, int mxErr, int *pnErr){
+  BtShared *pBt;
+  IntegrityCheckCtx ctx;
+  int i;
+  int nErr = 0;
+  int rc;
 
-  for(i=0; i<(int)node.nItems; i++){
-    ProllyHash childHash;
-    prollyNodeChildHash(&node, i, &childHash);
-    rc = integrityCheckProllySubtree(pBt, &childHash, mxErr, pnErr);
-    if( rc!=SQLITE_OK ) return rc;
-    if( mxErr>0 && *pnErr>=mxErr ) break;
+  if( pnErr ) *pnErr = 0;
+  if( !p || !p->pBt ) return SQLITE_OK;
+  if( p->pOrigBtree ) return SQLITE_OK;
+
+  pBt = p->pBt;
+  memset(&ctx, 0, sizeof(ctx));
+  ctx.pBt = pBt;
+  ctx.mxErr = mxErr;
+  ctx.pnErr = &nErr;
+  rc = prollyHashSetInit(&ctx.seen, 256);
+  if( rc!=SQLITE_OK ) return rc;
+
+  rc = integrityCheckChunkGraph(&ctx, &pBt->store.refsHash);
+  if( rc==SQLITE_OK ) rc = integrityCheckChunkGraph(&ctx, &pBt->store.workingState);
+  for(i=0; rc==SQLITE_OK && i<pBt->store.nBranches; i++){
+    rc = integrityCheckChunkGraph(&ctx, &pBt->store.aBranches[i].commitHash);
+    if( rc==SQLITE_OK ){
+      rc = integrityCheckChunkGraph(&ctx, &pBt->store.aBranches[i].workingSetHash);
+    }
+  }
+  for(i=0; rc==SQLITE_OK && i<pBt->store.nTags; i++){
+    rc = integrityCheckChunkGraph(&ctx, &pBt->store.aTags[i].commitHash);
+  }
+  for(i=0; rc==SQLITE_OK && i<pBt->store.nTracking; i++){
+    rc = integrityCheckChunkGraph(&ctx, &pBt->store.aTracking[i].commitHash);
+  }
+  if( rc==SQLITE_OK && pBt->store.isMerging ){
+    rc = integrityCheckChunkGraph(&ctx, &pBt->store.mergeCommitHash);
+  }
+  if( rc==SQLITE_OK ){
+    rc = integrityCheckChunkGraph(&ctx, &pBt->store.conflictsCatalogHash);
   }
 
-  return SQLITE_OK;
+  prollyHashSetFree(&ctx.seen);
+  if( pnErr ) *pnErr = nErr;
+  return rc;
 }
 
 int sqlite3BtreeSetVersion(Btree *p, int iVersion){
@@ -4647,8 +4697,10 @@ int sqlite3BtreeIntegrityCheck(
   char **pzOut
 ){
   BtShared *pBt;
+  IntegrityCheckCtx ctx;
   int i;
   int nErr = 0;
+  int rc;
 
   if( !p ){
     if( pnErr ) *pnErr = 0;
@@ -4671,6 +4723,12 @@ int sqlite3BtreeIntegrityCheck(
     return SQLITE_OK;
   }
   pBt = p->pBt;
+  memset(&ctx, 0, sizeof(ctx));
+  ctx.pBt = pBt;
+  ctx.mxErr = mxErr;
+  ctx.pnErr = &nErr;
+  rc = prollyHashSetInit(&ctx.seen, 256);
+  if( rc!=SQLITE_OK ) return rc;
 
   for(i=0; i<nRoot; i++){
     
@@ -4682,14 +4740,29 @@ int sqlite3BtreeIntegrityCheck(
       struct TableEntry *pTE = findTable(p, aRoot[i]);
       if( !pTE ) continue;
       if( !prollyHashIsEmpty(&pTE->root) ){
-        int rc = integrityCheckProllySubtree(pBt, &pTE->root, mxErr, &nErr);
-        if( rc!=SQLITE_OK ) return rc;
+        rc = integrityCheckChunkGraph(&ctx, &pTE->root);
+        if( rc!=SQLITE_OK ) goto integrity_done;
       }
     }
   }
 
+  rc = doltliteCheckRepoGraphIntegrity(p, mxErr, &i);
+  if( rc!=SQLITE_OK ) goto integrity_done;
+  nErr += i;
+
+integrity_done:
+  prollyHashSetFree(&ctx.seen);
+  if( rc!=SQLITE_OK ) return rc;
+
   if( pnErr ) *pnErr = nErr;
-  if( pzOut ) *pzOut = 0;
+  if( pzOut ){
+    if( nErr>0 ){
+      *pzOut = sqlite3_mprintf("integrity check failed");
+      if( !*pzOut ) return SQLITE_NOMEM;
+    }else{
+      *pzOut = 0;
+    }
+  }
 
   return SQLITE_OK;
 }

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -347,6 +347,26 @@ static int btreeRefreshFromDisk(Btree *p);
 static int btreeReadWorkingCatalog(ChunkStore *cs, const char *zBranch,
                                    ProllyHash *pCatHash,
                                    ProllyHash *pCommitHash);
+static int btreeLoadWorkingSetBlob(
+  ChunkStore *cs,
+  const char *zBranch,
+  ProllyHash *pWorkingCat,
+  ProllyHash *pWorkingCommit,
+  ProllyHash *pStaged,
+  u8 *pIsMerging,
+  ProllyHash *pMergeCommit,
+  ProllyHash *pConflicts
+);
+static int btreeStoreWorkingSetBlob(
+  ChunkStore *cs,
+  const char *zBranch,
+  const ProllyHash *pWorkingCat,
+  const ProllyHash *pWorkingCommit,
+  const ProllyHash *pStaged,
+  u8 isMerging,
+  const ProllyHash *pMergeCommit,
+  const ProllyHash *pConflicts
+);
 static int btreeDeleteImmediate(BtCursor *pCur, const u8 *pKey, int nKey, i64 iKey);
 
 static int prollyBtreeClose(Btree*);
@@ -1503,7 +1523,7 @@ int sqlite3BtreeOpen(
   p->aMeta[BTREE_APPLICATION_ID] = 0;
 
   
-  /* Load catalog from per-branch working state. Use the default branch
+  /* Load catalog from the default branch working-set blob. Use the default branch
   ** since p->zBranch hasn't been set yet (checkout happens later). */
   {
     ProllyHash catHash;
@@ -1572,18 +1592,23 @@ catalog_loaded:
         
         u8 *wsData = 0; int nWsData = 0;
         if( chunkStoreGet(&pBt->store, &wsHash, &wsData, &nWsData)==SQLITE_OK
-         && nWsData >= WS_TOTAL_SIZE ){
+         && wsData && nWsData >= WS_TOTAL_SIZE && wsData[0] == 2 ){
           memcpy(p->stagedCatalog.data, wsData + WS_STAGED_OFF, PROLLY_HASH_SIZE);
           p->isMerging = wsData[WS_MERGING_OFF];
           memcpy(p->mergeCommitHash.data, wsData + WS_MERGE_COMMIT_OFF, PROLLY_HASH_SIZE);
           memcpy(p->conflictsCatalogHash.data, wsData + WS_CONFLICTS_OFF, PROLLY_HASH_SIZE);
+        }else{
+          memset(&p->stagedCatalog, 0, sizeof(ProllyHash));
+          p->isMerging = 0;
+          memset(&p->mergeCommitHash, 0, sizeof(ProllyHash));
+          memset(&p->conflictsCatalogHash, 0, sizeof(ProllyHash));
         }
         sqlite3_free(wsData);
       }else{
-        
-        chunkStoreGetStagedCatalog(&pBt->store, &p->stagedCatalog);
-        chunkStoreGetMergeState(&pBt->store, &p->isMerging,
-                                &p->mergeCommitHash, &p->conflictsCatalogHash);
+        memset(&p->stagedCatalog, 0, sizeof(ProllyHash));
+        p->isMerging = 0;
+        memset(&p->mergeCommitHash, 0, sizeof(ProllyHash));
+        memset(&p->conflictsCatalogHash, 0, sizeof(ProllyHash));
       }
     }
   }
@@ -1827,173 +1852,121 @@ int sqlite3BtreeIsReadonly(Btree *p){
   return p->pOps->xIsReadonly(p);
 }
 
-/*
-** Working state chunk: per-branch working catalog hashes.
-** Format: [nBranches:2 LE] per branch: [nameLen:2 LE][name][catHash:20]
-**
-** This allows each branch to persist its working catalog independently,
-** so cross-branch autocommits don't overwrite each other's catalogs.
-*/
+static int btreeLoadWorkingSetBlob(
+  ChunkStore *cs,
+  const char *zBranch,
+  ProllyHash *pWorkingCat,
+  ProllyHash *pWorkingCommit,
+  ProllyHash *pStaged,
+  u8 *pIsMerging,
+  ProllyHash *pMergeCommit,
+  ProllyHash *pConflicts
+){
+  ProllyHash wsHash;
+  u8 *data = 0;
+  int nData = 0;
+  int rc;
 
-/*
-** Read the working catalog hash for zBranch from the working state chunk.
-** Returns SQLITE_OK and fills *pCatHash if found.
-** Returns SQLITE_NOTFOUND if the branch is not in the working state.
-*/
+  if( pWorkingCat ) memset(pWorkingCat, 0, sizeof(ProllyHash));
+  if( pWorkingCommit ) memset(pWorkingCommit, 0, sizeof(ProllyHash));
+  if( pStaged ) memset(pStaged, 0, sizeof(ProllyHash));
+  if( pIsMerging ) *pIsMerging = 0;
+  if( pMergeCommit ) memset(pMergeCommit, 0, sizeof(ProllyHash));
+  if( pConflicts ) memset(pConflicts, 0, sizeof(ProllyHash));
+
+  rc = chunkStoreGetBranchWorkingSet(cs, zBranch, &wsHash);
+  if( rc!=SQLITE_OK || prollyHashIsEmpty(&wsHash) ) return SQLITE_NOTFOUND;
+
+  rc = chunkStoreGet(cs, &wsHash, &data, &nData);
+  if( rc!=SQLITE_OK ) return rc;
+  if( !data || nData < WS_TOTAL_SIZE || data[0] != 2 ){
+    sqlite3_free(data);
+    return SQLITE_CORRUPT;
+  }
+
+  if( pWorkingCat ) memcpy(pWorkingCat->data, data + WS_WORKING_CAT_OFF, PROLLY_HASH_SIZE);
+  if( pWorkingCommit ) memcpy(pWorkingCommit->data, data + WS_WORKING_COMMIT_OFF, PROLLY_HASH_SIZE);
+  if( pStaged ) memcpy(pStaged->data, data + WS_STAGED_OFF, PROLLY_HASH_SIZE);
+  if( pIsMerging ) *pIsMerging = data[WS_MERGING_OFF];
+  if( pMergeCommit ) memcpy(pMergeCommit->data, data + WS_MERGE_COMMIT_OFF, PROLLY_HASH_SIZE);
+  if( pConflicts ) memcpy(pConflicts->data, data + WS_CONFLICTS_OFF, PROLLY_HASH_SIZE);
+  sqlite3_free(data);
+  return SQLITE_OK;
+}
+
+static int btreeStoreWorkingSetBlob(
+  ChunkStore *cs,
+  const char *zBranch,
+  const ProllyHash *pWorkingCat,
+  const ProllyHash *pWorkingCommit,
+  const ProllyHash *pStaged,
+  u8 isMerging,
+  const ProllyHash *pMergeCommit,
+  const ProllyHash *pConflicts
+){
+  u8 buf[WS_TOTAL_SIZE];
+  ProllyHash wsHash;
+  static const ProllyHash emptyHash = {{0}};
+  int rc;
+
+  buf[0] = 2;
+  memcpy(buf + WS_WORKING_CAT_OFF,
+         (pWorkingCat ? pWorkingCat : &emptyHash)->data, PROLLY_HASH_SIZE);
+  memcpy(buf + WS_WORKING_COMMIT_OFF,
+         (pWorkingCommit ? pWorkingCommit : &emptyHash)->data, PROLLY_HASH_SIZE);
+  memcpy(buf + WS_STAGED_OFF,
+         (pStaged ? pStaged : &emptyHash)->data, PROLLY_HASH_SIZE);
+  buf[WS_MERGING_OFF] = isMerging;
+  memcpy(buf + WS_MERGE_COMMIT_OFF,
+         (pMergeCommit ? pMergeCommit : &emptyHash)->data, PROLLY_HASH_SIZE);
+  memcpy(buf + WS_CONFLICTS_OFF,
+         (pConflicts ? pConflicts : &emptyHash)->data, PROLLY_HASH_SIZE);
+
+  rc = chunkStorePut(cs, buf, WS_TOTAL_SIZE, &wsHash);
+  if( rc != SQLITE_OK ) return rc;
+  rc = chunkStoreSetBranchWorkingSet(cs, zBranch, &wsHash);
+  if( rc == SQLITE_NOTFOUND && chunkStoreIsEmpty(cs) ){
+    return SQLITE_OK;
+  }
+  if( rc != SQLITE_OK ) return rc;
+  return chunkStoreSerializeRefs(cs);
+}
+
 static int btreeReadWorkingCatalog(
   ChunkStore *cs,
   const char *zBranch,
   ProllyHash *pCatHash,
   ProllyHash *pCommitHash
 ){
-  ProllyHash wsHash;
-  u8 *data = 0;
-  int nData = 0;
-  int rc;
-  int nBr, i;
-  int brLen = (int)strlen(zBranch);
-  const u8 *p;
-  int entryHashSize = PROLLY_HASH_SIZE * 2; /* catHash + commitHash */
-
-  if( pCommitHash ) memset(pCommitHash, 0, sizeof(ProllyHash));
-
-  chunkStoreGetWorkingState(cs, &wsHash);
-  if( prollyHashIsEmpty(&wsHash) ) return SQLITE_NOTFOUND;
-
-  rc = chunkStoreGet(cs, &wsHash, &data, &nData);
-  if( rc!=SQLITE_OK || !data ) return SQLITE_NOTFOUND;
-  if( nData < 4 ){ sqlite3_free(data); return SQLITE_NOTFOUND; }
-
-  nBr = (int)((u32)data[0] | ((u32)data[1]<<8) | ((u32)data[2]<<16) | ((u32)data[3]<<24));
-  p = data + 4;
-  for(i=0; i<nBr; i++){
-    int nl;
-    if( p + 4 > data + nData ) break;
-    nl = (int)((u32)p[0] | ((u32)p[1]<<8) | ((u32)p[2]<<16) | ((u32)p[3]<<24));
-    p += 4;
-    if( p + nl + entryHashSize > data + nData ) break;
-    if( nl==brLen && memcmp(p, zBranch, nl)==0 ){
-      memcpy(pCatHash->data, p + nl, PROLLY_HASH_SIZE);
-      if( pCommitHash ){
-        memcpy(pCommitHash->data, p + nl + PROLLY_HASH_SIZE, PROLLY_HASH_SIZE);
-      }
-      sqlite3_free(data);
-      return SQLITE_OK;
-    }
-    p += nl + entryHashSize;
-  }
-
-  sqlite3_free(data);
-  return SQLITE_NOTFOUND;
+  return btreeLoadWorkingSetBlob(cs, zBranch, pCatHash, pCommitHash,
+                                 0, 0, 0, 0);
 }
 
-/*
-** Update the working state chunk: set zBranch's catalog hash to *pCatHash
-** and commit hash to *pCommitHash (or zeros if NULL).
-** Merges with existing entries for other branches.
-** Writes the new chunk to the store and updates cs->workingState.
-**
-** Each entry is: [nameLen:4 LE][name][catHash:20][commitHash:20]
-*/
 static int btreeWriteWorkingState(
   ChunkStore *cs,
   const char *zBranch,
   const ProllyHash *pCatHash,
   const ProllyHash *pCommitHash
 ){
-  ProllyHash wsHash;
-  u8 *oldData = 0;
-  int nOldData = 0;
-  u8 *newBuf = 0;
-  int nNew = 0;
-  int nAlloc;
-  int nBr = 0, i;
-  int brLen = (int)strlen(zBranch);
-  int found = 0;
+  ProllyHash stagedCatalog;
+  ProllyHash mergeCommitHash;
+  ProllyHash conflictsCatalogHash;
+  u8 isMerging = 0;
   int rc;
-  int entryHashSize = PROLLY_HASH_SIZE * 2; /* catHash + commitHash */
-  static const u8 zeroHash[PROLLY_HASH_SIZE] = {0};
 
-  chunkStoreGetWorkingState(cs, &wsHash);
-  if( !prollyHashIsEmpty(&wsHash) ){
-    chunkStoreGet(cs, &wsHash, &oldData, &nOldData);
+  rc = btreeLoadWorkingSetBlob(cs, zBranch, 0, 0, &stagedCatalog, &isMerging,
+                               &mergeCommitHash, &conflictsCatalogHash);
+  if( rc!=SQLITE_OK && rc!=SQLITE_NOTFOUND ) return rc;
+  if( rc==SQLITE_NOTFOUND ){
+    memset(&stagedCatalog, 0, sizeof(ProllyHash));
+    memset(&mergeCommitHash, 0, sizeof(ProllyHash));
+    memset(&conflictsCatalogHash, 0, sizeof(ProllyHash));
+    isMerging = 0;
   }
 
-  /* Calculate max size: old data + our new entry */
-  nAlloc = (oldData && nOldData >= 4) ? nOldData : 4;
-  nAlloc += 4 + brLen + entryHashSize + 64; /* extra space */
-  newBuf = (u8*)sqlite3_malloc(nAlloc);
-  if( !newBuf ){
-    sqlite3_free(oldData);
-    return SQLITE_NOMEM;
-  }
-
-  /* Start writing at offset 4 (skip nBranches header) */
-  nNew = 4;
-
-  /* Copy existing entries, replacing our branch if found */
-  if( oldData && nOldData >= 4 ){
-    int oldNBr = (int)((u32)oldData[0] | ((u32)oldData[1]<<8) | ((u32)oldData[2]<<16) | ((u32)oldData[3]<<24));
-    const u8 *p = oldData + 4;
-    for(i=0; i<oldNBr; i++){
-      int nl;
-      if( p + 4 > oldData + nOldData ) break;
-      nl = (int)((u32)p[0] | ((u32)p[1]<<8) | ((u32)p[2]<<16) | ((u32)p[3]<<24));
-      p += 4;
-      if( p + nl + entryHashSize > oldData + nOldData ) break;
-      if( nl==brLen && memcmp(p, zBranch, nl)==0 ){
-        /* Replace our entry */
-        newBuf[nNew++] = (u8)(nl & 0xff);
-        newBuf[nNew++] = (u8)((nl >> 8) & 0xff);
-        newBuf[nNew++] = (u8)((nl >> 16) & 0xff);
-        newBuf[nNew++] = (u8)((nl >> 24) & 0xff);
-        memcpy(newBuf + nNew, zBranch, nl); nNew += nl;
-        memcpy(newBuf + nNew, pCatHash->data, PROLLY_HASH_SIZE); nNew += PROLLY_HASH_SIZE;
-        memcpy(newBuf + nNew, pCommitHash ? pCommitHash->data : zeroHash, PROLLY_HASH_SIZE);
-        nNew += PROLLY_HASH_SIZE;
-        found = 1;
-      }else{
-        /* Copy other branch's entry as-is */
-        int entrySize = 4 + nl + entryHashSize;
-        memcpy(newBuf + nNew, p - 4, entrySize);
-        nNew += entrySize;
-      }
-      p += nl + entryHashSize;
-      nBr++;
-    }
-  }
-
-  if( !found ){
-    /* Append new entry for our branch */
-    newBuf[nNew++] = (u8)(brLen & 0xff);
-    newBuf[nNew++] = (u8)((brLen >> 8) & 0xff);
-    newBuf[nNew++] = (u8)((brLen >> 16) & 0xff);
-    newBuf[nNew++] = (u8)((brLen >> 24) & 0xff);
-    memcpy(newBuf + nNew, zBranch, brLen); nNew += brLen;
-    memcpy(newBuf + nNew, pCatHash->data, PROLLY_HASH_SIZE); nNew += PROLLY_HASH_SIZE;
-    memcpy(newBuf + nNew, pCommitHash ? pCommitHash->data : zeroHash, PROLLY_HASH_SIZE);
-    nNew += PROLLY_HASH_SIZE;
-    nBr++;
-  }
-
-  /* Write branch count header */
-  newBuf[0] = (u8)(nBr & 0xff);
-  newBuf[1] = (u8)((nBr >> 8) & 0xff);
-  newBuf[2] = (u8)((nBr >> 16) & 0xff);
-  newBuf[3] = (u8)((nBr >> 24) & 0xff);
-
-  sqlite3_free(oldData);
-
-  /* Store the chunk and update the manifest field */
-  {
-    ProllyHash newHash;
-    rc = chunkStorePut(cs, newBuf, nNew, &newHash);
-    sqlite3_free(newBuf);
-    if( rc!=SQLITE_OK ) return rc;
-    chunkStoreSetWorkingState(cs, &newHash);
-  }
-
-  return SQLITE_OK;
+  return btreeStoreWorkingSetBlob(cs, zBranch, pCatHash, pCommitHash,
+                                  &stagedCatalog, isMerging,
+                                  &mergeCommitHash, &conflictsCatalogHash);
 }
 
 static int btreeRefreshFromDisk(Btree *p){
@@ -2004,7 +1977,7 @@ static int btreeRefreshFromDisk(Btree *p){
   if( !bChanged ) return SQLITE_OK;
 
   /* The file changed. Load the catalog for THIS connection's branch.
-  ** Each branch's working catalog is stored in the working state chunk
+  ** Each branch's working catalog is stored in the branch WorkingSet blob
   ** (persisted on every autocommit). This prevents cross-branch corruption
   ** where one branch's autocommit overwrites the shared manifest catalog. */
   {
@@ -2153,10 +2126,7 @@ static int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
   BtShared *pBt = p->pBt;
   int rc = SQLITE_OK;
   int rcRollback = SQLITE_OK;
-  ProllyHash oldWorkingState;
   (void)bCleanup;
-
-  oldWorkingState = pBt->store.workingState;
 
   if( p->inTrans==TRANS_WRITE ){
     /* Step 1: flush all in-memory edits to prolly trees */
@@ -2198,7 +2168,6 @@ static int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
       /* SQLite tears down the outer transaction on COMMIT failure here.
       ** Roll back our in-memory roots and chunk-store state so the
       ** connection does not keep seeing uncommitted edits. */
-      pBt->store.workingState = oldWorkingState;
       rcRollback = prollyBtreeRollback(p, rc, 0);
       if( rcRollback!=SQLITE_OK ){
         return rcRollback;
@@ -4647,7 +4616,6 @@ int doltliteCheckRepoGraphIntegrity(Btree *p, int mxErr, int *pnErr){
   if( rc!=SQLITE_OK ) return rc;
 
   rc = integrityCheckChunkGraph(&ctx, &pBt->store.refsHash);
-  if( rc==SQLITE_OK ) rc = integrityCheckChunkGraph(&ctx, &pBt->store.workingState);
   for(i=0; rc==SQLITE_OK && i<pBt->store.nBranches; i++){
     rc = integrityCheckChunkGraph(&ctx, &pBt->store.aBranches[i].commitHash);
     if( rc==SQLITE_OK ){
@@ -5434,8 +5402,9 @@ void doltliteSetSessionConflictsCatalog(sqlite3 *db, const ProllyHash *pHash){
 int doltliteSaveWorkingSet(sqlite3 *db){
   ChunkStore *cs = doltliteGetChunkStore(db);
   Btree *pBtree;
-  u8 buf[WS_TOTAL_SIZE];
-  ProllyHash wsHash;
+  u8 *catData = 0;
+  int nCatData = 0;
+  ProllyHash workingCatHash;
   const char *zBranch;
   int rc;
 
@@ -5445,58 +5414,38 @@ int doltliteSaveWorkingSet(sqlite3 *db){
 
   zBranch = pBtree->zBranch ? pBtree->zBranch : "main";
 
-  buf[0] = 1;  
-  memcpy(buf + WS_STAGED_OFF, pBtree->stagedCatalog.data, PROLLY_HASH_SIZE);
-  buf[WS_MERGING_OFF] = pBtree->isMerging;
-  memcpy(buf + WS_MERGE_COMMIT_OFF, pBtree->mergeCommitHash.data, PROLLY_HASH_SIZE);
-  memcpy(buf + WS_CONFLICTS_OFF, pBtree->conflictsCatalogHash.data, PROLLY_HASH_SIZE);
-
-  rc = chunkStorePut(cs, buf, WS_TOTAL_SIZE, &wsHash);
+  rc = serializeCatalog(pBtree, &catData, &nCatData);
+  if( rc != SQLITE_OK ) return rc;
+  rc = chunkStorePut(cs, catData, nCatData, &workingCatHash);
+  sqlite3_free(catData);
   if( rc != SQLITE_OK ) return rc;
 
-  
-  return chunkStoreSetBranchWorkingSet(cs, zBranch, &wsHash);
+  return btreeStoreWorkingSetBlob(cs, zBranch, &workingCatHash,
+                                  &pBtree->headCommit, &pBtree->stagedCatalog,
+                                  pBtree->isMerging, &pBtree->mergeCommitHash,
+                                  &pBtree->conflictsCatalogHash);
 }
 
 int doltliteLoadWorkingSet(sqlite3 *db, const char *zBranch){
   ChunkStore *cs = doltliteGetChunkStore(db);
   Btree *pBtree;
-  ProllyHash wsHash;
-  u8 *data = 0;
-  int nData = 0;
   int rc;
 
   if( !db || db->nDb<=0 || !db->aDb[0].pBt ) return SQLITE_ERROR;
   pBtree = db->aDb[0].pBt;
   if( !cs ) return SQLITE_ERROR;
 
-  rc = chunkStoreGetBranchWorkingSet(cs, zBranch, &wsHash);
-  if( rc != SQLITE_OK || prollyHashIsEmpty(&wsHash) ){
-    
+  rc = btreeLoadWorkingSetBlob(cs, zBranch, 0, 0, &pBtree->stagedCatalog,
+                               &pBtree->isMerging, &pBtree->mergeCommitHash,
+                               &pBtree->conflictsCatalogHash);
+  if( rc == SQLITE_NOTFOUND ){
     memset(&pBtree->stagedCatalog, 0, sizeof(ProllyHash));
     pBtree->isMerging = 0;
     memset(&pBtree->mergeCommitHash, 0, sizeof(ProllyHash));
     memset(&pBtree->conflictsCatalogHash, 0, sizeof(ProllyHash));
     return SQLITE_OK;
   }
-
-  rc = chunkStoreGet(cs, &wsHash, &data, &nData);
-  if( rc != SQLITE_OK || nData < WS_TOTAL_SIZE ){
-    sqlite3_free(data);
-    memset(&pBtree->stagedCatalog, 0, sizeof(ProllyHash));
-    pBtree->isMerging = 0;
-    memset(&pBtree->mergeCommitHash, 0, sizeof(ProllyHash));
-    memset(&pBtree->conflictsCatalogHash, 0, sizeof(ProllyHash));
-    return SQLITE_OK;
-  }
-
-  memcpy(pBtree->stagedCatalog.data, data + WS_STAGED_OFF, PROLLY_HASH_SIZE);
-  pBtree->isMerging = data[WS_MERGING_OFF];
-  memcpy(pBtree->mergeCommitHash.data, data + WS_MERGE_COMMIT_OFF, PROLLY_HASH_SIZE);
-  memcpy(pBtree->conflictsCatalogHash.data, data + WS_CONFLICTS_OFF, PROLLY_HASH_SIZE);
-
-  sqlite3_free(data);
-  return SQLITE_OK;
+  return rc;
 }
 
 static int origBtreeCloseVt(Btree *p){

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -4580,6 +4580,48 @@ i64 sqlite3BtreeRowCountEst(BtCursor *pCur){
   return pCur->pCurOps->xRowCountEst(pCur);
 }
 
+static int integrityCheckProllySubtree(
+  BtShared *pBt,
+  const ProllyHash *pHash,
+  int mxErr,
+  int *pnErr
+){
+  u8 *pData = 0;
+  int nData = 0;
+  ProllyNode node;
+  int rc;
+  int i;
+
+  if( prollyHashIsEmpty(pHash) ) return SQLITE_OK;
+  if( mxErr>0 && *pnErr>=mxErr ) return SQLITE_OK;
+
+  rc = chunkStoreGet(&pBt->store, pHash, &pData, &nData);
+  if( rc==SQLITE_NOTFOUND || rc==SQLITE_CORRUPT ){
+    (*pnErr)++;
+    return SQLITE_OK;
+  }
+  if( rc!=SQLITE_OK ) return rc;
+
+  rc = prollyNodeParse(&node, pData, nData);
+  sqlite3_free(pData);
+  if( rc!=SQLITE_OK ){
+    (*pnErr)++;
+    return SQLITE_OK;
+  }
+
+  if( node.level==0 ) return SQLITE_OK;
+
+  for(i=0; i<(int)node.nItems; i++){
+    ProllyHash childHash;
+    prollyNodeChildHash(&node, i, &childHash);
+    rc = integrityCheckProllySubtree(pBt, &childHash, mxErr, pnErr);
+    if( rc!=SQLITE_OK ) return rc;
+    if( mxErr>0 && *pnErr>=mxErr ) break;
+  }
+
+  return SQLITE_OK;
+}
+
 int sqlite3BtreeSetVersion(Btree *p, int iVersion){
   if( p->inTrans!=TRANS_WRITE ){
     int rc = sqlite3BtreeBeginTrans(p, 2, 0);
@@ -4640,9 +4682,8 @@ int sqlite3BtreeIntegrityCheck(
       struct TableEntry *pTE = findTable(p, aRoot[i]);
       if( !pTE ) continue;
       if( !prollyHashIsEmpty(&pTE->root) ){
-        if( !chunkStoreHas(&pBt->store, &pTE->root) ){
-          nErr++;
-        }
+        int rc = integrityCheckProllySubtree(pBt, &pTE->root, mxErr, &nErr);
+        if( rc!=SQLITE_OK ) return rc;
       }
     }
   }

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -367,6 +367,12 @@ static int btreeStoreWorkingSetBlob(
   const ProllyHash *pMergeCommit,
   const ProllyHash *pConflicts
 );
+static int btreeWriteWorkingState(
+  ChunkStore *cs,
+  const char *zBranch,
+  const ProllyHash *pCatHash,
+  const ProllyHash *pCommitHash
+);
 static int btreeDeleteImmediate(BtCursor *pCur, const u8 *pKey, int nKey, i64 iKey);
 
 static int prollyBtreeClose(Btree*);
@@ -2165,13 +2171,34 @@ static int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
       chunkStoreUnlock(&pBt->store);
       pBt->store.snapshotPinned = 0;
     }else{
-      /* SQLite tears down the outer transaction on COMMIT failure here.
-      ** Roll back our in-memory roots and chunk-store state so the
-      ** connection does not keep seeing uncommitted edits. */
-      rcRollback = prollyBtreeRollback(p, rc, 0);
-      if( rcRollback!=SQLITE_OK ){
-        return rcRollback;
+      /* Commit failed after we had already materialized in-memory roots.
+      ** Restore the pre-transaction in-memory state, but do not try to
+      ** durably persist the rollback result here. The durable commit did
+      ** not happen, so the correct outcome is simply "old durable state
+      ** remains on disk". */
+      if( p->aCommittedTables ){
+        sqlite3_free(p->aTables);
+        p->aTables = p->aCommittedTables;
+        p->nTables = p->nCommittedTables;
+        p->nTablesAlloc = p->nCommittedTables;
+        p->iNextTable = p->iCommittedNextTable;
+        p->aCommittedTables = 0;
+        p->nCommittedTables = 0;
       }
+      {
+        BtCursor *pC;
+        for(pC = pBt->pCursor; pC; pC = pC->pNext){
+          if( pC->pMutMap ) prollyMutMapClear(pC->pMutMap);
+        }
+      }
+      invalidateCursors(pBt, 0, rc);
+      invalidateSchema(p);
+      chunkStoreRollback(&pBt->store);
+      p->inTrans = TRANS_NONE;
+      p->inTransaction = TRANS_NONE;
+      p->nSavepoint = 0;
+      chunkStoreUnlock(&pBt->store);
+      pBt->store.snapshotPinned = 0;
     }
     return rc;
   }
@@ -2228,6 +2255,7 @@ static int restoreFromCommitted(Btree *p){
 
 static int prollyBtreeRollback(Btree *p, int tripCode, int writeOnly){
   BtShared *pBt = p->pBt;
+  int rc = SQLITE_OK;
   (void)writeOnly;
 
   if( p->inTrans==TRANS_WRITE ){
@@ -2250,6 +2278,29 @@ static int prollyBtreeRollback(Btree *p, int tripCode, int writeOnly){
     invalidateCursors(pBt, 0, tripCode ? tripCode : SQLITE_ABORT);
     invalidateSchema(p);
     chunkStoreRollback(&pBt->store);
+    {
+      u8 *catData = 0;
+      int nCatData = 0;
+      ProllyHash catHash;
+      const char *zBr = p->zBranch ? p->zBranch : "main";
+
+      rc = serializeCatalog(p, &catData, &nCatData);
+      if( rc==SQLITE_OK ){
+        rc = chunkStorePut(&pBt->store, catData, nCatData, &catHash);
+      }
+      sqlite3_free(catData);
+      if( rc==SQLITE_OK ){
+        rc = btreeWriteWorkingState(&pBt->store, zBr, &catHash, &p->headCommit);
+      }
+      if( rc==SQLITE_OK ){
+        rc = chunkStoreCommit(&pBt->store);
+      }
+      if( rc!=SQLITE_OK ){
+        chunkStoreUnlock(&pBt->store);
+        pBt->store.snapshotPinned = 0;
+        return rc;
+      }
+    }
   }
 
   p->inTrans = TRANS_NONE;
@@ -2259,7 +2310,7 @@ static int prollyBtreeRollback(Btree *p, int tripCode, int writeOnly){
   chunkStoreUnlock(&pBt->store);
   pBt->store.snapshotPinned = 0;
 
-  return SQLITE_OK;
+  return rc;
 }
 int sqlite3BtreeRollback(Btree *p, int tripCode, int writeOnly){
   if( !p ) return SQLITE_OK;

--- a/src/prolly_diff.c
+++ b/src/prolly_diff.c
@@ -133,88 +133,87 @@ static int diffSerialTypeSize(u64 st){
   return 0;
 }
 
-/* Compare two SQLite record-format values field-by-field. Returns 1 if
-** equal, 0 otherwise. Needed because records with identical logical content
-** can have different total byte lengths due to varint encoding differences. */
-int diffRecordsEqualFieldwise(
+/* Compare two SQLite record-format values field-by-field. Returns
+** SQLITE_OK and sets *pEqual, or SQLITE_CORRUPT for malformed records. */
+static int diffRecordsEqualFieldwise(
   const u8 *pA, int nA,
-  const u8 *pB, int nB
+  const u8 *pB, int nB,
+  int *pEqual
 ){
-  const u8 *pEndA, *pEndB;
-  u64 hdrSizeA, hdrSizeB;
-  int hdrBytesA, hdrBytesB;
-  const u8 *hpA, *hpB;
-  const u8 *hdrEndA, *hdrEndB;
-  int offA, offB;
+  DoltliteRecordInfo aInfo;
+  DoltliteRecordInfo bInfo;
+  int i;
+  int rc;
 
-  if( nA < 1 || nB < 1 ) return 0;
+  *pEqual = 0;
+  if( nA < 1 || nB < 1 ) return SQLITE_CORRUPT;
 
-  pEndA = pA + nA;
-  pEndB = pB + nB;
+  rc = doltliteParseRecordStrict(pA, nA, &aInfo);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = doltliteParseRecordStrict(pB, nB, &bInfo);
+  if( rc!=SQLITE_OK ) return rc;
 
-  hdrBytesA = dlReadVarint(pA, pEndA, &hdrSizeA);
-  if( hdrBytesA == 0 ) return 0;
-  hdrBytesB = dlReadVarint(pB, pEndB, &hdrSizeB);
-  if( hdrBytesB == 0 ) return 0;
+  if( aInfo.nField != bInfo.nField ) return SQLITE_OK;
 
-  if( (int)hdrSizeA < hdrBytesA || (int)hdrSizeA > nA ) return 0;
-  if( (int)hdrSizeB < hdrBytesB || (int)hdrSizeB > nB ) return 0;
+  for(i=0; i<aInfo.nField; i++){
+    int stA = aInfo.aType[i];
+    int stB = bInfo.aType[i];
+    int szA;
+    int szB;
 
-  hpA = pA + hdrBytesA;
-  hpB = pB + hdrBytesB;
-  hdrEndA = pA + (int)hdrSizeA;
-  hdrEndB = pB + (int)hdrSizeB;
-  offA = (int)hdrSizeA;
-  offB = (int)hdrSizeB;
-
-  while( hpA < hdrEndA || hpB < hdrEndB ){
-    u64 stA = 0, stB = 0;
-    int szA, szB;
-
-    if( hpA < hdrEndA ){
-      int n = dlReadVarint(hpA, hdrEndA, &stA);
-      if( n == 0 ) return 0;
-      hpA += n;
+    if( stA != stB ) return SQLITE_OK;
+    szA = diffSerialTypeSize((u64)stA);
+    szB = diffSerialTypeSize((u64)stB);
+    if( szA != szB ) return SQLITE_OK;
+    if( szA>0 && memcmp(pA + aInfo.aOffset[i], pB + bInfo.aOffset[i], szA)!=0 ){
+      return SQLITE_OK;
     }
-    if( hpB < hdrEndB ){
-      int n = dlReadVarint(hpB, hdrEndB, &stB);
-      if( n == 0 ) return 0;
-      hpB += n;
-    }
-
-    szA = diffSerialTypeSize(stA);
-    szB = diffSerialTypeSize(stB);
-
-    if( stA == 0 && stB == 0 ) continue;
-    if( stA != stB ) return 0;
-
-    if( offA + szA > nA || offB + szB > nB ) return 0;
-    if( szA > 0 && memcmp(pA + offA, pB + offB, szA) != 0 ) return 0;
-
-    offA += szA;
-    offB += szB;
   }
-
-  return 1;
+  *pEqual = 1;
+  return SQLITE_OK;
 }
 
 /* Compare two record values: fast memcmp path, then field-wise fallback
 ** for records with different varint encodings of the same logical data. */
-int prollyValuesEqual(const u8 *pA, int nA, const u8 *pB, int nB){
+int prollyValuesEqual(
+  const u8 *pA, int nA,
+  const u8 *pB, int nB,
+  int *pEqual
+){
+  int rc;
   if( nA==nB ){
-    if( nA==0 ) return 1;
-    if( memcmp(pA, pB, nA)==0 ) return 1;
+    if( nA==0 ){
+      *pEqual = 1;
+      return SQLITE_OK;
+    }
+    if( memcmp(pA, pB, nA)==0 ){
+      if( nA < 2 ){
+        *pEqual = 0;
+        return SQLITE_CORRUPT;
+      }
+      rc = diffRecordsEqualFieldwise(pA, nA, pB, nB, pEqual);
+      if( rc!=SQLITE_OK ) return rc;
+      if( *pEqual ) return SQLITE_OK;
+      return SQLITE_CORRUPT;
+    }
   }
-  if( nA < 2 || nB < 2 ) return 0;
-  return diffRecordsEqualFieldwise(pA, nA, pB, nB);
+  if( nA < 2 || nB < 2 ){
+    *pEqual = 0;
+    return SQLITE_CORRUPT;
+  }
+  return diffRecordsEqualFieldwise(pA, nA, pB, nB, pEqual);
 }
 
 static int diffValuesEqual(ProllyCursor *pOld, ProllyCursor *pNew){
   const u8 *pOldVal; int nOldVal;
   const u8 *pNewVal; int nNewVal;
+  int equal = 0;
+  int rc;
   prollyCursorValue(pOld, &pOldVal, &nOldVal);
   prollyCursorValue(pNew, &pNewVal, &nNewVal);
-  return prollyValuesEqual(pOldVal, nOldVal, pNewVal, nNewVal);
+  rc = prollyValuesEqual(pOldVal, nOldVal, pNewVal, nNewVal, &equal);
+  if( rc!=SQLITE_OK ) return rc;
+  return equal ? SQLITE_OK : SQLITE_DONE;
 }
 
 /* Merge-walk two positioned cursors, emitting diffs until both are exhausted. */
@@ -233,8 +232,11 @@ static int diffMergeWalk(
       rc = diffEmitAdd(pCurNew, flags, xCb, pCtx);
       if( rc==SQLITE_OK ) rc = prollyCursorNext(pCurNew);
     }else{
-      if( !diffValuesEqual(pCurOld, pCurNew) ){
+      rc = diffValuesEqual(pCurOld, pCurNew);
+      if( rc==SQLITE_DONE ){
         rc = diffEmitModify(pCurOld, pCurNew, flags, xCb, pCtx);
+      }else if( rc!=SQLITE_OK ){
+        break;
       }
       if( rc==SQLITE_OK ) rc = prollyCursorNext(pCurOld);
       if( rc==SQLITE_OK ) rc = prollyCursorNext(pCurNew);
@@ -370,10 +372,14 @@ static int diffLeaves(
     }else{
       const u8 *pOV; int nOV; const u8 *pNV; int nNV;
       int eq;
+      int eqRc = SQLITE_OK;
       prollyNodeValue(pOld, i, &pOV, &nOV);
       prollyNodeValue(pNew, j, &pNV, &nNV);
       eq = (nOV==nNV && (nOV==0 || memcmp(pOV, pNV, nOV)==0));
-      if( !eq && nOV>=2 && nNV>=2 ) eq = diffRecordsEqualFieldwise(pOV,nOV,pNV,nNV);
+      if( !eq && nOV>=2 && nNV>=2 ){
+        eqRc = diffRecordsEqualFieldwise(pOV, nOV, pNV, nNV, &eq);
+      }
+      if( eqRc!=SQLITE_OK ) return eqRc;
       if( !eq ){
         ProllyDiffChange ch;
         memset(&ch, 0, sizeof(ch));
@@ -732,13 +738,15 @@ int prollyDiffIterStep(ProllyDiffIter *pIter, ProllyDiffChange **ppChange){
         break; /* Found a change */
       }else{
         /* Same key in both trees: check if values differ */
-        if( diffValuesEqual(pOld, pNew) ){
+        pIter->rc = diffValuesEqual(pOld, pNew);
+        if( pIter->rc==SQLITE_OK ){
           /* Values equal — advance both cursors and loop */
           pIter->rc = prollyCursorNext(pOld);
           if( pIter->rc==SQLITE_OK ) pIter->rc = prollyCursorNext(pNew);
           if( pIter->rc!=SQLITE_OK ) return pIter->rc;
           continue; /* Skip to next pair */
-        }else{
+        }else if( pIter->rc==SQLITE_DONE ){
+          pIter->rc = SQLITE_OK;
           const u8 *pOV; int nOV;
           const u8 *pNV; int nNV;
           pCh->type = PROLLY_DIFF_MODIFY;
@@ -764,6 +772,8 @@ int prollyDiffIterStep(ProllyDiffIter *pIter, ProllyDiffChange **ppChange){
           pIter->rc = prollyCursorNext(pOld);
           if( pIter->rc==SQLITE_OK ) pIter->rc = prollyCursorNext(pNew);
           break; /* Found a change */
+        }else{
+          return pIter->rc;
         }
       }
     }else if( validOld ){

--- a/src/prolly_diff.h
+++ b/src/prolly_diff.h
@@ -33,8 +33,11 @@ int prollyDiff(ChunkStore *pStore, ProllyCache *pCache,
                const ProllyHash *pOldRoot, const ProllyHash *pNewRoot,
                u8 flags, ProllyDiffCallback xCallback, void *pCtx);
 
-int diffRecordsEqualFieldwise(const u8 *pA, int nA, const u8 *pB, int nB);
-int prollyValuesEqual(const u8 *pA, int nA, const u8 *pB, int nB);
+int prollyValuesEqual(
+  const u8 *pA, int nA,
+  const u8 *pB, int nB,
+  int *pEqual
+);
 
 /*
 ** Streaming diff iterator: yields one ProllyDiffChange at a time from the

--- a/src/prolly_node.c
+++ b/src/prolly_node.c
@@ -59,6 +59,9 @@ int prollyNodeParse(ProllyNode *pNode, const u8 *pData, int nData){
   }
 
   if( count==0 ){
+    if( pNode->level>0 ){
+      return SQLITE_CORRUPT;
+    }
     
     pNode->aKeyOff = 0;
     pNode->aValOff = 0;

--- a/src/prolly_three_way_diff.c
+++ b/src/prolly_three_way_diff.c
@@ -93,7 +93,10 @@ static int diffEntryKeyCmp(const DiffEntry *pA, const DiffEntry *pB, u8 flags){
   }
 }
 
-#define valuesEqual prollyValuesEqual
+static int valuesEqual(const u8 *pA, int nA, const u8 *pB, int nB){
+  int equal = 0;
+  return prollyValuesEqual(pA, nA, pB, nB, &equal)==SQLITE_OK && equal;
+}
 
 static void fillKeyFromEntry(ThreeWayChange *pOut, const DiffEntry *pEntry){
   pOut->pKey = pEntry->pKey;

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -32,6 +32,9 @@
 **   ./doltlite_regression_test_c refresh_open_path_transactional
 **   ./doltlite_regression_test_c wal_offset_corruption
 **   ./doltlite_regression_test_c integrity_check_walks_nodes
+**   ./doltlite_regression_test_c memory_chunk_lookup_corruption
+**   ./doltlite_regression_test_c prolly_diff_record_corruption
+**   ./doltlite_regression_test_c integrity_check_repo_state
 **   ./doltlite_regression_test_c btree_commit_failure_transactional
 **   ./doltlite_regression_test_c mutmap_empty_reverse_iter
 */
@@ -47,6 +50,7 @@
 #include "doltlite_ancestor.h"
 #include "doltlite_internal.h"
 #include "doltlite_record.h"
+#include "prolly_diff.h"
 #include "prolly_node.h"
 #include "prolly_mutmap.h"
 
@@ -1207,6 +1211,8 @@ static void run_refresh_refs_corruption_preserves_state(void){
   ChunkStore cs1;
   ChunkStore cs2;
   ProllyHash badHash;
+  ProllyHash refsHashBefore;
+  ProllyHash workingStateBefore;
   static const u8 badBlob[] = { 6, 0, 0, 0 };
   char dbpath[256];
   int nBranchesBefore;
@@ -1229,6 +1235,8 @@ static void run_refresh_refs_corruption_preserves_state(void){
 
   check("open_store_1", chunkStoreOpen(&cs1, sqlite3_vfs_find(0), dbpath,
         SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB)==SQLITE_OK);
+  refsHashBefore = cs1.refsHash;
+  workingStateBefore = cs1.workingState;
   nBranchesBefore = cs1.nBranches;
   zDefaultBefore = sqlite3_mprintf("%s", cs1.zDefaultBranch ? cs1.zDefaultBranch : "");
   zBranchBefore = (cs1.aBranches && cs1.nBranches>0 && cs1.aBranches[0].zName)
@@ -1255,6 +1263,10 @@ static void run_refresh_refs_corruption_preserves_state(void){
         nBranchesBefore==0 ||
         (cs1.aBranches && cs1.aBranches[0].zName
          && strcmp(cs1.aBranches[0].zName, zBranchBefore)==0));
+  check("refresh_preserves_refs_hash",
+        memcmp(&cs1.refsHash, &refsHashBefore, sizeof(ProllyHash))==0);
+  check("refresh_preserves_working_state",
+        memcmp(&cs1.workingState, &workingStateBefore, sizeof(ProllyHash))==0);
 
   sqlite3_free(zDefaultBefore);
   sqlite3_free(zBranchBefore);
@@ -1280,6 +1292,93 @@ static void run_prolly_node_corruption(void){
   printf("=== Prolly Node Corruption Test ===\n\n");
   check("intkey_width_corruption_is_rejected",
         prollyNodeParse(&node, badIntKeyNode, (int)sizeof(badIntKeyNode))==SQLITE_CORRUPT);
+  {
+    static const u8 badEmptyInternalNode[] = {
+      'D','O','N','P',
+      1,
+      0, 0,
+      PROLLY_NODE_BLOBKEY
+    };
+    check("empty_internal_node_is_rejected",
+          prollyNodeParse(&node, badEmptyInternalNode,
+                          (int)sizeof(badEmptyInternalNode))==SQLITE_CORRUPT);
+  }
+}
+
+static void run_memory_chunk_lookup_corruption(void){
+  ChunkStore cs;
+  ProllyHash h;
+  static const u8 payload[] = { 1, 2, 3, 4 };
+  u8 *pOut = 0;
+  int nOut = 0;
+  int rc;
+
+  printf("=== Memory Chunk Lookup Corruption Test ===\n\n");
+  check("open_mem_store_for_lookup",
+        chunkStoreOpen(&cs, sqlite3_vfs_find(0), ":memory:", 0)==SQLITE_OK);
+  check("put_chunk_for_lookup",
+        chunkStorePut(&cs, payload, (int)sizeof(payload), &h)==SQLITE_OK);
+  check("commit_mem_store_lookup",
+        chunkStoreCommit(&cs)==SQLITE_OK);
+  check("have_committed_index_entry", cs.nIndex > 0);
+  if( cs.nIndex > 0 ){
+    cs.aIndex[0].offset = cs.nWriteBuf + 100;
+  }
+  rc = chunkStoreGet(&cs, &h, &pOut, &nOut);
+  check("memory_lookup_corruption_returns_corrupt", rc==SQLITE_CORRUPT);
+  sqlite3_free(pOut);
+  chunkStoreClose(&cs);
+}
+
+static void run_prolly_diff_record_corruption(void){
+  static const u8 badRecord[] = { 0x05, 0x01 };
+  int equal = 0;
+  int rc;
+
+  printf("=== Prolly Diff Record Corruption Test ===\n\n");
+  rc = prollyValuesEqual(badRecord, (int)sizeof(badRecord),
+                         badRecord, (int)sizeof(badRecord), &equal);
+  check("prolly_diff_surfaces_record_corruption", rc==SQLITE_CORRUPT);
+  check("corrupt_records_not_reported_equal", equal==0);
+}
+
+static void run_integrity_check_repo_state(void){
+  sqlite3 *db = 0;
+  ChunkStore cs;
+  char dbpath[256];
+  ProllyHash badHash;
+  int nErr = 0;
+  int rc;
+
+  printf("=== Integrity Check Repository State Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_integrity_check_repo_state");
+  remove_db(dbpath);
+
+  check("open_db_repo_state", open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_repo_state", execsql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'a');"
+    "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
+  sqlite3_close(db);
+  db = 0;
+
+  memset(&badHash, 0x5d, sizeof(badHash));
+  check("open_store_repo_state", chunkStoreOpen(&cs, sqlite3_vfs_find(0), dbpath,
+        SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB)==SQLITE_OK);
+  check("lock_store_repo_state", chunkStoreLockAndRefresh(&cs)==SQLITE_OK);
+  check("set_bad_branch_working_set",
+        chunkStoreSetBranchWorkingSet(&cs, "main", &badHash)==SQLITE_OK);
+  check("serialize_corrupt_branch_refs", chunkStoreSerializeRefs(&cs)==SQLITE_OK);
+  check("commit_bad_branch_working_set", chunkStoreCommit(&cs)==SQLITE_OK);
+  chunkStoreUnlock(&cs);
+  chunkStoreClose(&cs);
+
+  check("reopen_repo_state_db", open_db(dbpath, &db)==SQLITE_OK);
+  rc = doltliteCheckRepoGraphIntegrity(db->aDb[0].pBt, 100, &nErr);
+  check("repo_graph_integrity_call_succeeds", rc==SQLITE_OK);
+  check("integrity_check_reports_repo_state_corruption", nErr>0);
+  sqlite3_close(db);
+  remove_db(dbpath);
 }
 
 static void run_truncated_wal_is_rejected(void){
@@ -1531,6 +1630,9 @@ static const RegressionCase aCases[] = {
   { "refresh_open_path_transactional", "Refresh Open Path Transactional Test", run_refresh_open_path_transactional },
   { "wal_offset_corruption", "WAL Offset Corruption Test", run_wal_offset_corruption_is_rejected },
   { "integrity_check_walks_nodes", "Integrity Check Walks Prolly Nodes Test", run_integrity_check_walks_prolly_nodes },
+  { "memory_chunk_lookup_corruption", "Memory Chunk Lookup Corruption Test", run_memory_chunk_lookup_corruption },
+  { "prolly_diff_record_corruption", "Prolly Diff Record Corruption Test", run_prolly_diff_record_corruption },
+  { "integrity_check_repo_state", "Integrity Check Repository State Test", run_integrity_check_repo_state },
   { "btree_commit_failure_transactional", "Btree Commit Failure Transaction Test", run_btree_commit_failure_transactional },
   { "mutmap_empty_reverse_iter", "MutMap Empty Reverse Iterator Test", run_mutmap_empty_reverse_iter }
 };

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -1212,7 +1212,6 @@ static void run_refresh_refs_corruption_preserves_state(void){
   ChunkStore cs2;
   ProllyHash badHash;
   ProllyHash refsHashBefore;
-  ProllyHash workingStateBefore;
   static const u8 badBlob[] = { 6, 0, 0, 0 };
   char dbpath[256];
   int nBranchesBefore;
@@ -1236,7 +1235,6 @@ static void run_refresh_refs_corruption_preserves_state(void){
   check("open_store_1", chunkStoreOpen(&cs1, sqlite3_vfs_find(0), dbpath,
         SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB)==SQLITE_OK);
   refsHashBefore = cs1.refsHash;
-  workingStateBefore = cs1.workingState;
   nBranchesBefore = cs1.nBranches;
   zDefaultBefore = sqlite3_mprintf("%s", cs1.zDefaultBranch ? cs1.zDefaultBranch : "");
   zBranchBefore = (cs1.aBranches && cs1.nBranches>0 && cs1.aBranches[0].zName)
@@ -1265,9 +1263,6 @@ static void run_refresh_refs_corruption_preserves_state(void){
          && strcmp(cs1.aBranches[0].zName, zBranchBefore)==0));
   check("refresh_preserves_refs_hash",
         memcmp(&cs1.refsHash, &refsHashBefore, sizeof(ProllyHash))==0);
-  check("refresh_preserves_working_state",
-        memcmp(&cs1.workingState, &workingStateBefore, sizeof(ProllyHash))==0);
-
   sqlite3_free(zDefaultBefore);
   sqlite3_free(zBranchBefore);
   chunkStoreClose(&cs1);
@@ -1446,8 +1441,6 @@ static void run_refresh_open_path_transactional(void){
   check("refresh_open_path_returns_error", rc!=SQLITE_OK);
   check("refresh_open_path_does_not_mark_changed", changed==0);
   check("refresh_open_path_preserves_empty_refs", prollyHashIsEmpty(&cs.refsHash));
-  check("refresh_open_path_preserves_empty_working_state",
-        prollyHashIsEmpty(&cs.workingState));
   check("refresh_open_path_preserves_branch_count", cs.nBranches==0);
 
   chunkStoreClose(&cs);

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -28,6 +28,10 @@
 **   ./doltlite_regression_test_c reload_refs_transactional
 **   ./doltlite_regression_test_c refresh_refs_corruption_preserves_state
 **   ./doltlite_regression_test_c prolly_node_corruption
+**   ./doltlite_regression_test_c truncated_wal_rejected
+**   ./doltlite_regression_test_c refresh_open_path_transactional
+**   ./doltlite_regression_test_c wal_offset_corruption
+**   ./doltlite_regression_test_c integrity_check_walks_nodes
 **   ./doltlite_regression_test_c btree_commit_failure_transactional
 **   ./doltlite_regression_test_c mutmap_empty_reverse_iter
 */
@@ -1278,6 +1282,182 @@ static void run_prolly_node_corruption(void){
         prollyNodeParse(&node, badIntKeyNode, (int)sizeof(badIntKeyNode))==SQLITE_CORRUPT);
 }
 
+static void run_truncated_wal_is_rejected(void){
+  sqlite3 *db = 0;
+  ChunkStore cs;
+  char dbpath[256];
+  int rc;
+
+  printf("=== Truncated WAL Rejected Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_truncated_wal_rejected");
+  remove_db(dbpath);
+
+  check("open_db_for_truncated_wal", open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_repo_for_truncated_wal", execsql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'a');"
+    "SELECT dolt_commit('-A', '-m', 'init');"
+    "INSERT INTO t VALUES(2,'b');"
+    "SELECT dolt_commit('-A', '-m', 'second');")==SQLITE_OK);
+  sqlite3_close(db);
+
+  check("open_store_for_wal_tag_corruption", chunkStoreOpen(&cs, sqlite3_vfs_find(0), dbpath,
+        SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB)==SQLITE_OK);
+  check("have_wal_region", cs.nWalData > 0);
+  if( cs.nWalData > 0 ){
+    unsigned char badTag = 0xff;
+    check("corrupt_first_wal_tag",
+          sqlite3OsWrite(cs.pFile, &badTag, 1, cs.iWalOffset)==SQLITE_OK);
+  }
+  chunkStoreClose(&cs);
+
+  rc = chunkStoreOpen(&cs, sqlite3_vfs_find(0), dbpath,
+          SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB);
+  check("chunk_store_open_rejects_corrupt_wal", rc==SQLITE_CORRUPT);
+
+  remove_db(dbpath);
+}
+
+static void run_refresh_open_path_transactional(void){
+  ChunkStore cs;
+  char dbpath[256];
+  FILE *f = 0;
+  int changed = -1;
+  int rc;
+
+  printf("=== Refresh Open Path Transactional Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_refresh_open_path_transactional");
+  remove_db(dbpath);
+
+  check("open_empty_store_with_no_file",
+        chunkStoreOpen(&cs, sqlite3_vfs_find(0), dbpath,
+          SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB)==SQLITE_OK);
+  check("store_starts_without_file", cs.pFile==0);
+
+  f = fopen(dbpath, "wb");
+  check("create_corrupt_file", f!=0);
+  if( f ){
+    static const unsigned char badFile[] = { 'b', 'a', 'd' };
+    check("write_corrupt_file",
+          fwrite(badFile, 1, sizeof(badFile), f)==sizeof(badFile));
+    fclose(f);
+  }
+
+  rc = chunkStoreRefreshIfChanged(&cs, &changed);
+  check("refresh_open_path_returns_error", rc!=SQLITE_OK);
+  check("refresh_open_path_does_not_mark_changed", changed==0);
+  check("refresh_open_path_preserves_empty_refs", prollyHashIsEmpty(&cs.refsHash));
+  check("refresh_open_path_preserves_empty_working_state",
+        prollyHashIsEmpty(&cs.workingState));
+  check("refresh_open_path_preserves_branch_count", cs.nBranches==0);
+
+  chunkStoreClose(&cs);
+  remove_db(dbpath);
+}
+
+static void run_wal_offset_corruption_is_rejected(void){
+  sqlite3 *db = 0;
+  ChunkStore cs;
+  char dbpath[256];
+  int iWal = -1;
+  u8 *pData = 0;
+  int nData = 0;
+  int rc;
+
+  printf("=== WAL Offset Corruption Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_wal_offset_corruption");
+  remove_db(dbpath);
+
+  check("open_db_for_wal_offset", open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_repo_for_wal_offset", execsql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'a');"
+    "SELECT dolt_commit('-A', '-m', 'init');"
+    "INSERT INTO t VALUES(2,'b');"
+    "SELECT dolt_commit('-A', '-m', 'second');")==SQLITE_OK);
+  sqlite3_close(db);
+
+  check("open_store_for_wal_offset", chunkStoreOpen(&cs, sqlite3_vfs_find(0), dbpath,
+        SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB)==SQLITE_OK);
+  {
+    int i;
+    for(i=0; i<cs.nIndex; i++){
+      if( cs.aIndex[i].offset < 0 ){
+        iWal = i;
+        break;
+      }
+    }
+  }
+  check("have_wal_backed_index_entry", iWal >= 0);
+  if( iWal >= 0 ){
+    cs.aIndex[iWal].offset = -(cs.nWalData + cs.aIndex[iWal].size + 2);
+    rc = chunkStoreGet(&cs, &cs.aIndex[iWal].hash, &pData, &nData);
+    check("corrupt_wal_offset_returns_error", rc!=SQLITE_OK);
+  }
+  sqlite3_free(pData);
+  chunkStoreClose(&cs);
+  remove_db(dbpath);
+}
+
+static void run_integrity_check_walks_prolly_nodes(void){
+  sqlite3 *db = 0;
+  sqlite3 *db2 = 0;
+  ChunkStore cs;
+  char dbpath[256];
+  ProllyHash catHash;
+  struct TableEntry *aTables = 0;
+  int nTables = 0;
+  Pgno iNextTable = 0;
+  struct TableEntry *pTable = 0;
+  i64 dataOff = -1;
+
+  printf("=== Integrity Check Walks Prolly Nodes Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_integrity_check_walks_nodes");
+  remove_db(dbpath);
+
+  check("open_db_for_integrity_walk", open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_repo_for_integrity_walk", execsql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'a');"
+    "INSERT INTO t VALUES(2,'b');"
+    "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
+  check("get_head_catalog_hash", doltliteGetHeadCatalogHash(db, &catHash)==SQLITE_OK);
+  check("load_head_catalog", doltliteLoadCatalog(db, &catHash, &aTables, &nTables, &iNextTable)==SQLITE_OK);
+  pTable = doltliteFindTableByName(aTables, nTables, "t");
+  check("find_table_root_in_catalog", pTable!=0);
+  sqlite3_close(db);
+
+  check("open_store_for_integrity_walk", chunkStoreOpen(&cs, sqlite3_vfs_find(0), dbpath,
+        SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB)==SQLITE_OK);
+  if( pTable ){
+    int i;
+    for(i=0; i<cs.nIndex; i++){
+      if( prollyHashCompare(&cs.aIndex[i].hash, &pTable->root)==0 ){
+        if( cs.aIndex[i].offset < 0 ){
+          dataOff = cs.iWalOffset + (-(cs.aIndex[i].offset + 1));
+        }else{
+          dataOff = cs.aIndex[i].offset + 4;
+        }
+        break;
+      }
+    }
+  }
+  check("find_root_chunk_offset", dataOff >= 0);
+  if( dataOff >= 0 ){
+    unsigned char badByte = 0;
+    check("corrupt_root_chunk_magic",
+          sqlite3OsWrite(cs.pFile, &badByte, 1, dataOff)==SQLITE_OK);
+  }
+  chunkStoreClose(&cs);
+
+  check("reopen_db_for_integrity_walk", open_db(dbpath, &db2)==SQLITE_OK);
+  check("integrity_check_surfaces_root_corruption",
+        strcmp(exec1(db2, "PRAGMA integrity_check"), "ok")!=0);
+
+  sqlite3_close(db2);
+  remove_db(dbpath);
+}
+
 static void run_btree_commit_failure_transactional(void){
   sqlite3 *db = 0;
   char dbpath[256];
@@ -1347,6 +1527,10 @@ static const RegressionCase aCases[] = {
   { "reload_refs_transactional", "Reload Refs Transactional Test", run_reload_refs_transactional },
   { "refresh_refs_corruption_preserves_state", "Refresh Corrupt Refs State Preservation Test", run_refresh_refs_corruption_preserves_state },
   { "prolly_node_corruption", "Prolly Node Corruption Test", run_prolly_node_corruption },
+  { "truncated_wal_rejected", "Truncated WAL Rejected Test", run_truncated_wal_is_rejected },
+  { "refresh_open_path_transactional", "Refresh Open Path Transactional Test", run_refresh_open_path_transactional },
+  { "wal_offset_corruption", "WAL Offset Corruption Test", run_wal_offset_corruption_is_rejected },
+  { "integrity_check_walks_nodes", "Integrity Check Walks Prolly Nodes Test", run_integrity_check_walks_prolly_nodes },
   { "btree_commit_failure_transactional", "Btree Commit Failure Transaction Test", run_btree_commit_failure_transactional },
   { "mutmap_empty_reverse_iter", "MutMap Empty Reverse Iterator Test", run_mutmap_empty_reverse_iter }
 };


### PR DESCRIPTION
This follow-up storage-core hardening pass focuses on fail-fast recovery and stronger structural validation in the chunk store / prolly stack.

## What changed

- make WAL replay fail hard on malformed or truncated records instead of treating corruption as a shorter valid WAL
- make the `pFile == 0` refresh/open path use the transactional reload path instead of mutating live store state directly
- return corruption, not `SQLITE_NOTFOUND`, for invalid WAL-backed chunk offsets
- make refs reload during WAL replay transactional in memory
- strengthen `PRAGMA integrity_check` so it actually parses and walks prolly subtrees from each table root

## Verified

- `cd build && ./doltlite_regression_test_c all`
- `cd build && bash ../test/remote_test.sh ./doltlite`
- `cd build && bash ../test/doltlite_gc.sh`
- `cd build && bash ../test/index_oracle_test.sh ./doltlite sqlite3`