### PR TITLE
dolt_schema_diff: conform column names to Dolt + add oracle (supersedes #380)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,6 +123,10 @@ jobs:
       run: cd build && bash ../test/vc_oracle_diff_test.sh ./doltlite dolt
       timeout-minutes: 5
 
+    - name: Version control oracle tests (dolt_schema_diff)
+      run: cd build && bash ../test/vc_oracle_schema_diff_test.sh ./doltlite dolt
+      timeout-minutes: 5
+
     - name: Version control oracle tests (dolt_history_<table>)
       run: cd build && bash ../test/vc_oracle_history_test.sh ./doltlite dolt
       timeout-minutes: 5

--- a/DEMO.md
+++ b/DEMO.md
@@ -207,12 +207,13 @@ WHERE rowid_val = 0;
 Compare schemas between two points:
 
 ```sql
-SELECT table_name, diff_type, to_create_stmt
+SELECT from_table_name, to_table_name, to_create_statement
 FROM dolt_schema_diff(
     (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 2),
     (SELECT commit_hash FROM dolt_log LIMIT 1)
 );
--- Shows tables/indexes added, dropped, or modified between commits
+-- Added rows have empty from_table_name; dropped rows have empty
+-- to_table_name; modified rows have both equal.
 ```
 
 ## Garbage Collection

--- a/README.md
+++ b/README.md
@@ -211,10 +211,11 @@ Compare schemas between any two commits, branches, or tags:
 
 ```sql
 SELECT * FROM dolt_schema_diff('v1.0', 'v2.0');
--- table_name | from_create_stmt | to_create_stmt | diff_type
-
--- Shows tables added, dropped, or modified (schema changed)
--- Also detects new indexes and views
+-- from_table_name | to_table_name | from_create_statement | to_create_statement
+--
+-- Added rows have an empty from_table_name; dropped rows have an
+-- empty to_table_name; modified rows have both equal.
+-- Also detects new indexes and views.
 ```
 
 ### Audit Log (dolt_diff_&lt;table&gt;)

--- a/src/doltlite_schema_diff.c
+++ b/src/doltlite_schema_diff.c
@@ -15,10 +15,10 @@
 
 typedef struct SchemaDiffRow SchemaDiffRow;
 struct SchemaDiffRow {
-  char *zName;
+  char *zFromName;
+  char *zToName;
   char *zFromSql;
   char *zToSql;
-  char *zDiffType;    
 };
 
 typedef struct SdVtab SdVtab;
@@ -65,7 +65,8 @@ static int schemaTextField(
 static void freeSchemaDiffRows(SdCursor *c){
   int i;
   for(i=0; i<c->nRows; i++){
-    sqlite3_free(c->aRows[i].zName);
+    sqlite3_free(c->aRows[i].zFromName);
+    sqlite3_free(c->aRows[i].zToName);
     sqlite3_free(c->aRows[i].zFromSql);
     sqlite3_free(c->aRows[i].zToSql);
   }
@@ -104,10 +105,10 @@ static int appendSchemaEntry(
 
 static int appendSchemaDiffRow(
   SdCursor *pCur,
-  const char *zName,
+  const char *zFromName,
+  const char *zToName,
   const char *zFromSql,
-  const char *zToSql,
-  char *zDiffType
+  const char *zToSql
 ){
   SchemaDiffRow *r;
   if( pCur->nRows >= pCur->nAlloc ){
@@ -119,26 +120,18 @@ static int appendSchemaDiffRow(
   }
   r = &pCur->aRows[pCur->nRows];
   memset(r, 0, sizeof(*r));
-  r->zName = sqlite3_mprintf("%s", zName ? zName : "");
-  if( !r->zName ) return SQLITE_NOMEM;
-  if( zFromSql ){
-    r->zFromSql = sqlite3_mprintf("%s", zFromSql);
-    if( !r->zFromSql ){
-      sqlite3_free(r->zName);
-      memset(r, 0, sizeof(*r));
-      return SQLITE_NOMEM;
-    }
+  r->zFromName = sqlite3_mprintf("%s", zFromName ? zFromName : "");
+  r->zToName   = sqlite3_mprintf("%s", zToName   ? zToName   : "");
+  r->zFromSql  = sqlite3_mprintf("%s", zFromSql  ? zFromSql  : "");
+  r->zToSql    = sqlite3_mprintf("%s", zToSql    ? zToSql    : "");
+  if( !r->zFromName || !r->zToName || !r->zFromSql || !r->zToSql ){
+    sqlite3_free(r->zFromName);
+    sqlite3_free(r->zToName);
+    sqlite3_free(r->zFromSql);
+    sqlite3_free(r->zToSql);
+    memset(r, 0, sizeof(*r));
+    return SQLITE_NOMEM;
   }
-  if( zToSql ){
-    r->zToSql = sqlite3_mprintf("%s", zToSql);
-    if( !r->zToSql ){
-      sqlite3_free(r->zName);
-      sqlite3_free(r->zFromSql);
-      memset(r, 0, sizeof(*r));
-      return SQLITE_NOMEM;
-    }
-  }
-  r->zDiffType = zDiffType;
   pCur->nRows++;
   return SQLITE_OK;
 }
@@ -269,29 +262,31 @@ static int computeSchemaDiff(
 ){
   int i;
 
-  
+  /* Added or modified: walk the to-side and look for matches in from. */
   for(i=0; i<nTo; i++){
     SchemaEntry *fromEntry = findSchemaEntry(aFrom, nFrom, aTo[i].zName);
 
     if( !fromEntry ){
-      int rc = appendSchemaDiffRow(pCur, aTo[i].zName, 0,
-                                   aTo[i].zSql ? aTo[i].zSql : "", "added");
+      /* Added: from_table_name and from_create_statement are empty. */
+      int rc = appendSchemaDiffRow(pCur, "", aTo[i].zName,
+                                   "", aTo[i].zSql);
       if( rc!=SQLITE_OK ) return rc;
     }else if( fromEntry->zSql && aTo[i].zSql
            && strcmp(fromEntry->zSql, aTo[i].zSql)!=0 ){
-      int rc = appendSchemaDiffRow(pCur, aTo[i].zName, fromEntry->zSql,
-                                   aTo[i].zSql, "modified");
+      /* Modified: both names equal, both SQL strings present. */
+      int rc = appendSchemaDiffRow(pCur, aTo[i].zName, aTo[i].zName,
+                                   fromEntry->zSql, aTo[i].zSql);
       if( rc!=SQLITE_OK ) return rc;
     }
   }
 
-  
+  /* Dropped: walk the from-side and emit anything missing on the to-side. */
   for(i=0; i<nFrom; i++){
     SchemaEntry *toEntry = findSchemaEntry(aTo, nTo, aFrom[i].zName);
     if( !toEntry ){
-      int rc = appendSchemaDiffRow(pCur, aFrom[i].zName,
-                                   aFrom[i].zSql ? aFrom[i].zSql : "",
-                                   0, "dropped");
+      /* Dropped: to_table_name and to_create_statement are empty. */
+      int rc = appendSchemaDiffRow(pCur, aFrom[i].zName, "",
+                                   aFrom[i].zSql, "");
       if( rc!=SQLITE_OK ) return rc;
     }
   }
@@ -301,12 +296,13 @@ static int computeSchemaDiff(
 
 static const char *sdSchema =
   "CREATE TABLE x("
-  "  table_name TEXT,"
-  "  from_create_stmt TEXT,"
-  "  to_create_stmt TEXT,"
-  "  diff_type TEXT,"
+  "  from_table_name TEXT,"
+  "  to_table_name TEXT,"
+  "  from_create_statement TEXT,"
+  "  to_create_statement TEXT,"
   "  from_ref TEXT HIDDEN,"
-  "  to_ref TEXT HIDDEN"
+  "  to_ref TEXT HIDDEN,"
+  "  table_name TEXT HIDDEN"      /* 3rd positional arg: filter to a single table */
   ")";
 
 static int sdConnect(sqlite3 *db, void *pAux, int argc,
@@ -326,7 +322,7 @@ static int sdConnect(sqlite3 *db, void *pAux, int argc,
 static int sdDisconnect(sqlite3_vtab *v){ sqlite3_free(v); return SQLITE_OK; }
 
 static int sdBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
-  int iFrom = -1, iTo = -1;
+  int iFrom = -1, iTo = -1, iTbl = -1;
   int i, argvIdx = 1;
   (void)pVtab;
 
@@ -335,7 +331,8 @@ static int sdBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
     if( pInfo->aConstraint[i].op!=SQLITE_INDEX_CONSTRAINT_EQ ) continue;
     switch( pInfo->aConstraint[i].iColumn ){
       case 4: iFrom = i; break;
-      case 5: iTo = i; break;
+      case 5: iTo   = i; break;
+      case 6: iTbl  = i; break;
     }
   }
 
@@ -347,8 +344,12 @@ static int sdBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
     pInfo->aConstraintUsage[iTo].argvIndex = argvIdx++;
     pInfo->aConstraintUsage[iTo].omit = 1;
   }
+  if( iTbl>=0 ){
+    pInfo->aConstraintUsage[iTbl].argvIndex = argvIdx++;
+    pInfo->aConstraintUsage[iTbl].omit = 1;
+  }
 
-  pInfo->idxNum = (iFrom>=0 ? 1 : 0) | (iTo>=0 ? 2 : 0);
+  pInfo->idxNum = (iFrom>=0 ? 1 : 0) | (iTo>=0 ? 2 : 0) | (iTbl>=0 ? 4 : 0);
   pInfo->estimatedCost = 1000.0;
   return SQLITE_OK;
 }
@@ -401,9 +402,12 @@ static int sdFilter(sqlite3_vtab_cursor *cur,
     zToRef = (const char*)sqlite3_value_text(argv[argIdx++]);
   }
 
-  
   {
     const char *zTableFilter = 0;
+    /* 3rd positional arg (or WHERE table_name='...') = single-table filter. */
+    if( (idxNum & 4) && argIdx<argc ){
+      zTableFilter = (const char*)sqlite3_value_text(argv[argIdx++]);
+    }
     if( zFromRef && !zToRef ){
       ProllyHash testHash;
       rc = doltliteResolveRef(db,zFromRef, &testHash);
@@ -462,11 +466,18 @@ static int sdFilter(sqlite3_vtab_cursor *cur,
     if( zTableFilter ){
       int j, k=0;
       for(j=0; j<c->nRows; j++){
-        if( c->aRows[j].zName && strcmp(c->aRows[j].zName, zTableFilter)==0 ){
+        /* Match on either side — added rows have empty zFromName,
+        ** dropped rows have empty zToName, modified rows have both
+        ** equal. Checking either is enough. */
+        const char *zRowName = c->aRows[j].zToName && c->aRows[j].zToName[0]
+                                ? c->aRows[j].zToName
+                                : c->aRows[j].zFromName;
+        if( zRowName && strcmp(zRowName, zTableFilter)==0 ){
           if( k!=j ) c->aRows[k] = c->aRows[j];
           k++;
         }else{
-          sqlite3_free(c->aRows[j].zName);
+          sqlite3_free(c->aRows[j].zFromName);
+          sqlite3_free(c->aRows[j].zToName);
           sqlite3_free(c->aRows[j].zFromSql);
           sqlite3_free(c->aRows[j].zToSql);
         }
@@ -488,17 +499,14 @@ static int sdEof(sqlite3_vtab_cursor *cur){ return ((SdCursor*)cur)->iRow >= ((S
 static int sdColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
   SdCursor *c = (SdCursor*)cur;
   SchemaDiffRow *r = &c->aRows[c->iRow];
+  /* All four visible columns are emitted as text, never NULL — empty
+  ** string when the row's side of the from/to pair is missing. This
+  ** matches Dolt's dolt_schema_diff column shape. */
   switch( col ){
-    case 0: sqlite3_result_text(ctx, r->zName, -1, SQLITE_TRANSIENT); break;
-    case 1:
-      if(r->zFromSql) sqlite3_result_text(ctx, r->zFromSql, -1, SQLITE_TRANSIENT);
-      else sqlite3_result_null(ctx);
-      break;
-    case 2:
-      if(r->zToSql) sqlite3_result_text(ctx, r->zToSql, -1, SQLITE_TRANSIENT);
-      else sqlite3_result_null(ctx);
-      break;
-    case 3: sqlite3_result_text(ctx, r->zDiffType, -1, SQLITE_STATIC); break;
+    case 0: sqlite3_result_text(ctx, r->zFromName, -1, SQLITE_TRANSIENT); break;
+    case 1: sqlite3_result_text(ctx, r->zToName,   -1, SQLITE_TRANSIENT); break;
+    case 2: sqlite3_result_text(ctx, r->zFromSql,  -1, SQLITE_TRANSIENT); break;
+    case 3: sqlite3_result_text(ctx, r->zToSql,    -1, SQLITE_TRANSIENT); break;
   }
   return SQLITE_OK;
 }

--- a/test/doltlite_schema_diff.sh
+++ b/test/doltlite_schema_diff.sh
@@ -25,12 +25,12 @@ SELECT dolt_commit('-A','-m','c2');
 SELECT dolt_tag('v2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "add_count" "SELECT count(*) FROM dolt_schema_diff('v1','v2');" "1" "$DB"
-run_test "add_name" "SELECT table_name FROM dolt_schema_diff('v1','v2');" "t2" "$DB"
-run_test "add_type" "SELECT diff_type FROM dolt_schema_diff('v1','v2');" "added" "$DB"
+run_test "add_to_name" "SELECT to_table_name FROM dolt_schema_diff('v1','v2');" "t2" "$DB"
+run_test "add_from_name_empty" "SELECT length(from_table_name) FROM dolt_schema_diff('v1','v2');" "0" "$DB"
 run_test_match "add_to_sql" \
-  "SELECT to_create_stmt FROM dolt_schema_diff('v1','v2');" "CREATE TABLE t2" "$DB"
-run_test "add_from_null" \
-  "SELECT from_create_stmt IS NULL FROM dolt_schema_diff('v1','v2');" "1" "$DB"
+  "SELECT to_create_statement FROM dolt_schema_diff('v1','v2');" "CREATE TABLE t2" "$DB"
+run_test "add_from_sql_empty" \
+  "SELECT length(from_create_statement) FROM dolt_schema_diff('v1','v2');" "0" "$DB"
 
 rm -f "$DB"
 
@@ -98,8 +98,8 @@ SELECT dolt_commit('-A','-m','feat add table');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "branch_count" "SELECT count(*) FROM dolt_schema_diff('main','feat');" "1" "$DB"
-run_test "branch_name" "SELECT table_name FROM dolt_schema_diff('main','feat');" "feat_tbl" "$DB"
-run_test "branch_type" "SELECT diff_type FROM dolt_schema_diff('main','feat');" "added" "$DB"
+run_test "branch_to_name" "SELECT to_table_name FROM dolt_schema_diff('main','feat');" "feat_tbl" "$DB"
+run_test "branch_from_name_empty" "SELECT length(from_table_name) FROM dolt_schema_diff('main','feat');" "0" "$DB"
 
 rm -f "$DB"
 
@@ -115,18 +115,19 @@ CREATE TABLE extra(id INTEGER PRIMARY KEY);
 SELECT dolt_commit('-A','-m','c2');
 SELECT dolt_tag('v2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# v1→v2: extra is added
-run_test "reverse_fwd" "SELECT diff_type FROM dolt_schema_diff('v1','v2');" "added" "$DB"
+# v1→v2: extra is added (from side empty, to side has the table)
+run_test "reverse_fwd_to_name" "SELECT to_table_name FROM dolt_schema_diff('v1','v2');" "extra" "$DB"
+run_test "reverse_fwd_from_empty" "SELECT length(from_table_name) FROM dolt_schema_diff('v1','v2');" "0" "$DB"
 
-# v2→v1: extra is dropped
-run_test "reverse_rev" "SELECT diff_type FROM dolt_schema_diff('v2','v1');" "dropped" "$DB"
-run_test "reverse_rev_name" "SELECT table_name FROM dolt_schema_diff('v2','v1');" "extra" "$DB"
+# v2→v1: extra is dropped (from side has the table, to side empty)
+run_test "reverse_rev_from_name" "SELECT from_table_name FROM dolt_schema_diff('v2','v1');" "extra" "$DB"
+run_test "reverse_rev_to_empty" "SELECT length(to_table_name) FROM dolt_schema_diff('v2','v1');" "0" "$DB"
 
-# When dropped, from_create_stmt is set, to_create_stmt is null
+# When dropped, from_create_statement is set, to_create_statement is empty
 run_test_match "reverse_from" \
-  "SELECT from_create_stmt FROM dolt_schema_diff('v2','v1');" "CREATE TABLE" "$DB"
-run_test "reverse_to_null" \
-  "SELECT to_create_stmt IS NULL FROM dolt_schema_diff('v2','v1');" "1" "$DB"
+  "SELECT from_create_statement FROM dolt_schema_diff('v2','v1');" "CREATE TABLE" "$DB"
+run_test "reverse_to_empty_sql" \
+  "SELECT length(to_create_statement) FROM dolt_schema_diff('v2','v1');" "0" "$DB"
 
 rm -f "$DB"
 
@@ -163,9 +164,9 @@ SELECT dolt_commit('-A','-m','main work');
 SELECT dolt_merge('feat');
 SELECT dolt_tag('after');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# before→after should show feat_tbl as added
+# before→after should show feat_tbl as added (to_table_name set, from empty)
 run_test_match "merge_added" \
-  "SELECT table_name FROM dolt_schema_diff('before','after') WHERE diff_type='added';" \
+  "SELECT to_table_name FROM dolt_schema_diff('before','after') WHERE from_table_name='';" \
   "feat_tbl" "$DB"
 
 rm -f "$DB"
@@ -186,7 +187,7 @@ SELECT dolt_tag('v2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 # Index creation adds an entry to sqlite_master
 run_test_match "index_count" "SELECT count(*) FROM dolt_schema_diff('v1','v2');" "^[1-9]" "$DB"
 run_test_match "index_name" \
-  "SELECT table_name FROM dolt_schema_diff('v1','v2') LIMIT 1;" "idx_name" "$DB"
+  "SELECT to_table_name FROM dolt_schema_diff('v1','v2') LIMIT 1;" "idx_name" "$DB"
 
 rm -f "$DB"
 
@@ -205,7 +206,7 @@ SELECT dolt_tag('v2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test_match "view_count" "SELECT count(*) FROM dolt_schema_diff('v1','v2');" "^[1-9]" "$DB"
 run_test_match "view_name" \
-  "SELECT table_name FROM dolt_schema_diff('v1','v2') WHERE table_name='v';" "v" "$DB"
+  "SELECT to_table_name FROM dolt_schema_diff('v1','v2') WHERE to_table_name='v';" "v" "$DB"
 
 rm -f "$DB"
 
@@ -237,10 +238,10 @@ SELECT dolt_commit('-A','-m','add users');
 SELECT dolt_tag('v2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test_match "stmt_content" \
-  "SELECT to_create_stmt FROM dolt_schema_diff('v1','v2');" \
+  "SELECT to_create_statement FROM dolt_schema_diff('v1','v2');" \
   "CREATE TABLE users" "$DB"
 run_test_match "stmt_cols" \
-  "SELECT to_create_stmt FROM dolt_schema_diff('v1','v2');" \
+  "SELECT to_create_statement FROM dolt_schema_diff('v1','v2');" \
   "name TEXT" "$DB"
 
 rm -f "$DB"

--- a/test/doltlite_schema_merge.sh
+++ b/test/doltlite_schema_merge.sh
@@ -334,17 +334,17 @@ run_test_match "schema_diff_alter_count" \
   "^[1-9]" "$DB"
 
 run_test_match "schema_diff_alter_table" \
-  "SELECT table_name FROM dolt_schema_diff('v1','v2') WHERE table_name='t';" \
+  "SELECT to_table_name FROM dolt_schema_diff('v1','v2') WHERE to_table_name='t';" \
   "^t$" "$DB"
 
-# The to_create_stmt should include the extra column
+# The to_create_statement should include the extra column
 run_test_match "schema_diff_alter_to_stmt" \
-  "SELECT to_create_stmt FROM dolt_schema_diff('v1','v2') WHERE table_name='t';" \
+  "SELECT to_create_statement FROM dolt_schema_diff('v1','v2') WHERE to_table_name='t';" \
   "extra" "$DB"
 
-# The from_create_stmt should NOT include the extra column
+# The from_create_statement should NOT include the extra column
 run_test_match "schema_diff_alter_from_stmt" \
-  "SELECT from_create_stmt FROM dolt_schema_diff('v1','v2') WHERE table_name='t';" \
+  "SELECT from_create_statement FROM dolt_schema_diff('v1','v2') WHERE to_table_name='t';" \
   "v TEXT" "$DB"
 
 rm -f "$DB"

--- a/test/vc_oracle_schema_diff_test.sh
+++ b/test/vc_oracle_schema_diff_test.sh
@@ -1,0 +1,232 @@
+#!/bin/bash
+#
+# Version-control oracle test: dolt_schema_diff
+#
+# Runs identical schema-diff scenarios against doltlite and Dolt and
+# compares the row output. Both engines now expose the same columns
+# (from_table_name, to_table_name, from_create_statement,
+# to_create_statement) and accept the same call form
+# (`dolt_schema_diff('from','to'[,'tbl'])`), so the oracle can issue
+# the same query string against both.
+#
+# Compared surface: (from_table_name, to_table_name, from_present,
+# to_present) sorted, where {from,to}_present is Y/N for whether the
+# create-statement column is non-empty. The create-statement TEXT is
+# intentionally NOT compared row-for-row because Dolt and doltlite
+# canonicalize CREATE TABLE differently (whitespace, type aliases,
+# quoting, ENGINE=... suffix in Dolt).
+#
+# Usage: bash vc_oracle_schema_diff_test.sh [path/to/doltlite] [path/to/dolt]
+#
+
+set -u
+
+DOLTLITE="${1:-./doltlite}"
+DOLT="${2:-dolt}"
+TMPROOT=$(mktemp -d)
+trap "rm -rf $TMPROOT" EXIT
+pass=0; fail=0
+FAILED_NAMES=""
+
+# $1=name, $2=setup SQL, $3=from_ref, $4=to_ref, $5=optional table filter.
+oracle() {
+  local name="$1" setup="$2" from_ref="$3" to_ref="$4" tbl="${5:-}"
+  local dir="$TMPROOT/$name"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local args
+  if [ -n "$tbl" ]; then
+    args="'$from_ref','$to_ref','$tbl'"
+  else
+    args="'$from_ref','$to_ref'"
+  fi
+
+  # The "ROW|" sentinel lets us grep the answer rows out of the noise
+  # that CALL dolt_*(...) emits in dolt's csv output. Use CONCAT not
+  # || (MySQL parses || as logical OR). Both engines accept CONCAT.
+  local q="SELECT CONCAT('ROW|', from_table_name, '|', to_table_name, '|', \
+            CASE WHEN from_create_statement IS NULL OR from_create_statement='' THEN 'N' ELSE 'Y' END, '|', \
+            CASE WHEN to_create_statement   IS NULL OR to_create_statement=''   THEN 'N' ELSE 'Y' END \
+          ) FROM dolt_schema_diff($args) ORDER BY from_table_name, to_table_name;"
+
+  local dl_out
+  dl_out=$(printf "%s\n.headers off\n.mode list\n%s\n" "$setup" "$q" \
+           | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
+           | tr -d '\r' \
+           | grep '^ROW|' \
+           | sort)
+
+  local dolt_setup
+  dolt_setup=$(echo "$setup" | sed -E 's/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g')
+
+  local dt_out
+  (
+    cd "$dir/dt" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    {
+      echo "$dolt_setup"
+      echo "$q"
+    } | "$DOLT" sql -r csv 2>"$dir/dt.err"
+  ) > "$dir/dt.raw"
+  dt_out=$(tr -d '"\r' < "$dir/dt.raw" | grep '^ROW|' | sort)
+
+  if [ "$dl_out" = "$dt_out" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite:"; echo "$dl_out" | sed 's/^/      /'
+    echo "    dolt:";     echo "$dt_out" | sed 's/^/      /'
+  fi
+}
+
+oracle_error() {
+  local name="$1" setup="$2" q="$3"
+  local dir="$TMPROOT/${name}_err"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_err=0
+  printf "%s\n%s\n" "$setup" "$q" | "$DOLTLITE" "$dir/dl/db" >"$dir/dl.out" 2>"$dir/dl.err"
+  if grep -qiE 'error|fail' "$dir/dl.out" "$dir/dl.err" 2>/dev/null; then dl_err=1; fi
+
+  local dolt_setup
+  dolt_setup=$(echo "$setup" | sed -E 's/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g')
+  local dt_err=0
+  (
+    cd "$dir/dt" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    { echo "$dolt_setup"; echo "$q"; } | "$DOLT" sql >"$dir/dt.out" 2>"$dir/dt.err"
+  )
+  if grep -qiE 'error|fail' "$dir/dt.out" "$dir/dt.err" 2>/dev/null; then dt_err=1; fi
+
+  if [ "$dl_err" = 1 ] && [ "$dt_err" = 1 ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name (expected both to error)"
+    echo "    doltlite errored: $([ $dl_err = 1 ] && echo yes || echo NO)"
+    echo "    dolt errored:     $([ $dt_err = 1 ] && echo yes || echo NO)"
+  fi
+}
+
+echo "=== Version Control Oracle Tests: dolt_schema_diff ==="
+echo ""
+
+SEED="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+"
+
+echo "--- added table ---"
+
+oracle "added_table" "
+$SEED
+CREATE TABLE u(id INTEGER PRIMARY KEY, x TEXT);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'add_u');
+" "HEAD~1" "HEAD"
+
+echo "--- dropped table ---"
+
+oracle "dropped_table" "
+$SEED
+DROP TABLE t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'drop_t');
+" "HEAD~1" "HEAD"
+
+echo "--- modified table (add column) ---"
+
+oracle "modified_add_col" "
+$SEED
+ALTER TABLE t ADD COLUMN extra TEXT;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'add_col');
+" "HEAD~1" "HEAD"
+
+echo "--- multiple changes in one diff ---"
+
+oracle "multi_change" "
+$SEED
+CREATE TABLE u(id INTEGER PRIMARY KEY, x TEXT);
+ALTER TABLE t ADD COLUMN extra TEXT;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'multi');
+" "HEAD~1" "HEAD"
+
+echo "--- no changes ---"
+
+oracle "no_changes" "
+$SEED
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'data_only');
+" "HEAD~1" "HEAD"
+
+oracle "self_diff" "
+$SEED
+" "HEAD" "HEAD"
+
+echo "--- branch refs ---"
+
+oracle "branch_diff" "
+$SEED
+SELECT dolt_checkout('-b', 'feat');
+CREATE TABLE u(id INTEGER PRIMARY KEY);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat_add');
+" "main" "feat"
+
+echo "--- tag refs ---"
+
+oracle "tag_diff" "
+$SEED
+SELECT dolt_tag('v1');
+CREATE TABLE u(id INTEGER PRIMARY KEY);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'after_tag');
+" "v1" "HEAD"
+
+echo "--- table_name filter ---"
+
+oracle "filter_added_table_only" "
+$SEED
+CREATE TABLE u(id INTEGER PRIMARY KEY, x TEXT);
+ALTER TABLE t ADD COLUMN extra TEXT;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'multi');
+" "HEAD~1" "HEAD" "u"
+
+oracle "filter_modified_table_only" "
+$SEED
+CREATE TABLE u(id INTEGER PRIMARY KEY, x TEXT);
+ALTER TABLE t ADD COLUMN extra TEXT;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'multi');
+" "HEAD~1" "HEAD" "t"
+
+oracle "filter_nonexistent_table" "
+$SEED
+CREATE TABLE u(id INTEGER PRIMARY KEY);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'add_u');
+" "HEAD~1" "HEAD" "no_such_table"
+
+echo "--- error paths ---"
+
+oracle_error "bad_from_ref" "$SEED" \
+  "SELECT * FROM dolt_schema_diff('nope','HEAD');"
+
+oracle_error "bad_to_ref" "$SEED" \
+  "SELECT * FROM dolt_schema_diff('HEAD','nope');"
+
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+if [ $fail -gt 0 ]; then
+  echo "Failed:$FAILED_NAMES"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
Renames `dolt_schema_diff` columns to match Dolt's documented shape and folds in the oracle from #380 (now simplified). Supersedes #380.

### Column changes
| Before | After |
| --- | --- |
| `table_name` | `from_table_name` + `to_table_name` |
| `diff_type` | (derived from which side is empty) |
| `from_create_stmt` | `from_create_statement` |
| `to_create_stmt` | `to_create_statement` |

- Added rows: `from_table_name` and `from_create_statement` are empty.
- Dropped rows: `to_table_name` and `to_create_statement` are empty.
- Modified rows: both names equal, both statements populated.

All four visible columns are emitted as text (empty string when missing) rather than NULL — matches what Dolt's table function returns.

### Hidden filter column
Added a third hidden filter column `table_name` so the 3-arg function form `dolt_schema_diff('from','to','tbl')` works as a single-table filter, matching Dolt's API. SQLite binds the third positional arg to the third hidden column automatically.

### Oracle
Folded in the schema_diff oracle from #380 and simplified — now both engines accept the same query string. 13 scenarios pass: added/dropped/modified tables, multiple changes, no-change and self-diff, branch and tag refs, `table_name` filter (added-only/modified-only/nonexistent), and error paths.

### Other updates
- Feature tests (`doltlite_schema_diff.sh`, `doltlite_schema_merge.sh`) updated to use the new column names.
- README.md and DEMO.md updated.
- Wired the new oracle into CI.

## Test plan
- [x] \`vc_oracle_schema_diff_test.sh\` — 13/13 passing
- [x] \`doltlite_schema_diff.sh\` — 26/26 passing
- [x] \`doltlite_schema_merge.sh\` — 63/63 passing
- [x] Full doltlite suite — 39/39 suites passing
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)