### PR TITLE
README: fix dolt_diff_<table> column documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,16 +220,20 @@ SELECT * FROM dolt_schema_diff('v1.0', 'v2.0');
 
 ### Audit Log (dolt_diff_&lt;table&gt;)
 
-Full history of every change to every row, across all commits:
+Full history of every change to every row, across all commits. For a
+table `users(id, name, email)`, the columns are the real per-column
+to_/from_ pairs plus commit metadata and a `diff_type`:
 
 ```sql
 SELECT * FROM dolt_diff_users;
--- diff_type | rowid_val | from_value | to_value |
---   from_commit | to_commit | from_commit_date | to_commit_date
+-- to_id | to_name | to_email | to_commit | to_commit_date |
+--   from_id | from_name | from_email | from_commit | from_commit_date |
+--   diff_type
 
 -- Every INSERT, UPDATE, DELETE that was ever committed is here
-SELECT diff_type, rowid_val, to_commit FROM dolt_diff_users
-  WHERE rowid_val = 42;
+SELECT diff_type, to_name, to_email, to_commit
+  FROM dolt_diff_users
+  WHERE to_id = 42;
 ```
 
 One `dolt_diff_<table>` virtual table is automatically created for each


### PR DESCRIPTION
## Summary
The Audit Log section listed the columns of the polymorphic \`dolt_diff\` vtable (\`diff_type, rowid_val, from_value, to_value, ...\`) instead of the per-table audit-log columns. The example query also referenced a nonexistent \`rowid_val\` column, so following the docs would produce a SQL error.

The real \`dolt_diff_<table>\` schema (from \`src/doltlite_diff_table.c\`) emits per-column to_/from_ pairs that mirror the user table, plus commit metadata at each end and \`diff_type\` at the end:

\`\`\`
to_<col1>, ..., to_commit, to_commit_date,
from_<col1>, ..., from_commit, from_commit_date,
diff_type
\`\`\`

Updated the section to show concrete columns for a \`users(id, name, email)\` table and a working filter on \`to_id\`.

## Test plan
- [x] Verified the new example query runs against a freshly built doltlite binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)