### PR TITLE
Fix prolly cursor error handling and blob seeks

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -915,10 +915,7 @@ int chunkStoreOpen(
         sqlite3_free(refsData);
       }
       if( rc!=SQLITE_OK ){
-        csCloseFile(cs->pFile);
-        cs->pFile = 0;
-        sqlite3_free(cs->zFilename);
-        cs->zFilename = 0;
+        chunkStoreClose(cs);
         return rc;
       }
     }

--- a/src/prolly_cache.c
+++ b/src/prolly_cache.c
@@ -121,12 +121,15 @@ ProllyCacheEntry *prollyCachePut(
   ProllyCache *cache,
   const ProllyHash *hash,
   const u8 *pData,
-  int nData
+  int nData,
+  int *pRc
 ){
   int iBucket;
   ProllyCacheEntry *pEntry;
   u8 *pCopy;
   int rc;
+
+  if( pRc ) *pRc = SQLITE_OK;
 
   
   pEntry = prollyCacheGet(cache, hash);
@@ -144,12 +147,16 @@ ProllyCacheEntry *prollyCachePut(
 
   
   pEntry = (ProllyCacheEntry *)sqlite3_malloc(sizeof(ProllyCacheEntry));
-  if( pEntry==0 ) return 0;
+  if( pEntry==0 ){
+    if( pRc ) *pRc = SQLITE_NOMEM;
+    return 0;
+  }
   memset(pEntry, 0, sizeof(*pEntry));
 
   
   pCopy = (u8 *)sqlite3_malloc(nData);
   if( pCopy==0 ){
+    if( pRc ) *pRc = SQLITE_NOMEM;
     sqlite3_free(pEntry);
     return 0;
   }
@@ -164,6 +171,7 @@ ProllyCacheEntry *prollyCachePut(
   
   rc = prollyNodeParse(&pEntry->node, pCopy, nData);
   if( rc!=SQLITE_OK ){
+    if( pRc ) *pRc = rc;
     sqlite3_free(pCopy);
     sqlite3_free(pEntry);
     return 0;

--- a/src/prolly_cache.h
+++ b/src/prolly_cache.h
@@ -35,7 +35,8 @@ ProllyCacheEntry *prollyCacheGet(ProllyCache *cache, const ProllyHash *hash);
 
 ProllyCacheEntry *prollyCachePut(ProllyCache *cache,
                                   const ProllyHash *hash,
-                                  const u8 *pData, int nData);
+                                  const u8 *pData, int nData,
+                                  int *pRc);
 
 void prollyCacheRelease(ProllyCache *cache, ProllyCacheEntry *entry);
 

--- a/src/prolly_cursor.c
+++ b/src/prolly_cursor.c
@@ -27,10 +27,10 @@ static int loadNode(ProllyCursor *cur, const ProllyHash *hash,
   }
 
   
-  pEntry = prollyCachePut(cur->pCache, hash, pData, nData);
+  pEntry = prollyCachePut(cur->pCache, hash, pData, nData, &rc);
   sqlite3_free(pData);
   if( pEntry==0 ){
-    return SQLITE_NOMEM;
+    return rc;
   }
 
   *ppEntry = pEntry;
@@ -341,11 +341,9 @@ int prollyCursorSeekBlob(ProllyCursor *cur,
     int searchRes;
     int idx = prollyNodeSearchBlob(&pEntry->node, pKey, nKey, &searchRes);
 
-    
     if( searchRes>0 ){
-      
+      idx++;
     }
-    
 
     cur->aLevel[cur->iLevel].idx = idx;
 

--- a/src/prolly_mutate.c
+++ b/src/prolly_mutate.c
@@ -262,9 +262,9 @@ static int streamingMergeNode(
       if( !pChildEntry ){
         rc = chunkStoreGet(pMut->pStore, &childHash, &pChildData, &nChildData);
         if( rc!=SQLITE_OK ) return rc;
-        pChildEntry = prollyCachePut(pCache, &childHash, pChildData, nChildData);
+        pChildEntry = prollyCachePut(pCache, &childHash, pChildData, nChildData, &rc);
         sqlite3_free(pChildData);
-        if( !pChildEntry ) return SQLITE_NOMEM;
+        if( !pChildEntry ) return rc;
       }
 
       if( pChildEntry->node.level == 0 ){

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -50,6 +50,8 @@
 #include "doltlite_ancestor.h"
 #include "doltlite_internal.h"
 #include "doltlite_record.h"
+#include "prolly_cache.h"
+#include "prolly_cursor.h"
 #include "prolly_diff.h"
 #include "prolly_node.h"
 #include "prolly_mutmap.h"
@@ -1596,6 +1598,108 @@ static void run_mutmap_empty_reverse_iter(void){
   prollyMutMapFree(&mm);
 }
 
+static void run_prolly_blob_cursor_seek_across_internal_boundary(void){
+  ChunkStore cs;
+  ProllyCache cache;
+  ProllyCursor cur;
+  ProllyNodeBuilder b;
+  ProllyHash leftHash, rightHash, rootHash;
+  u8 *pNode = 0;
+  int nNode = 0;
+  const u8 *pKey = 0;
+  int nKey = 0;
+  int rc;
+  int res = 99;
+
+  static const u8 v1[] = { '1' };
+  static const u8 v2[] = { '2' };
+  static const u8 kA[] = { 'a' };
+  static const u8 kM[] = { 'm' };
+  static const u8 kT[] = { 't' };
+  static const u8 kZ[] = { 'z' };
+
+  printf("=== Prolly Blob Cursor Internal Boundary Test ===\n\n");
+
+  check("open_memory_store_for_blob_cursor",
+        chunkStoreOpen(&cs, sqlite3_vfs_find(0), ":memory:", 0)==SQLITE_OK);
+  check("init_cache_for_blob_cursor", prollyCacheInit(&cache, 8)==SQLITE_OK);
+
+  prollyNodeBuilderInit(&b, 0, PROLLY_NODE_BLOBKEY);
+  check("build_left_leaf_a",
+        prollyNodeBuilderAdd(&b, kA, sizeof(kA), v1, sizeof(v1))==SQLITE_OK);
+  check("build_left_leaf_m",
+        prollyNodeBuilderAdd(&b, kM, sizeof(kM), v1, sizeof(v1))==SQLITE_OK);
+  check("finish_left_leaf", prollyNodeBuilderFinish(&b, &pNode, &nNode)==SQLITE_OK);
+  check("store_left_leaf", chunkStorePut(&cs, pNode, nNode, &leftHash)==SQLITE_OK);
+  sqlite3_free(pNode);
+  pNode = 0;
+  prollyNodeBuilderFree(&b);
+
+  prollyNodeBuilderInit(&b, 0, PROLLY_NODE_BLOBKEY);
+  check("build_right_leaf_t",
+        prollyNodeBuilderAdd(&b, kT, sizeof(kT), v2, sizeof(v2))==SQLITE_OK);
+  check("build_right_leaf_z",
+        prollyNodeBuilderAdd(&b, kZ, sizeof(kZ), v2, sizeof(v2))==SQLITE_OK);
+  check("finish_right_leaf", prollyNodeBuilderFinish(&b, &pNode, &nNode)==SQLITE_OK);
+  check("store_right_leaf", chunkStorePut(&cs, pNode, nNode, &rightHash)==SQLITE_OK);
+  sqlite3_free(pNode);
+  pNode = 0;
+  prollyNodeBuilderFree(&b);
+
+  prollyNodeBuilderInit(&b, 1, PROLLY_NODE_BLOBKEY);
+  check("build_root_left_sep",
+        prollyNodeBuilderAdd(&b, kM, sizeof(kM),
+                             leftHash.data, PROLLY_HASH_SIZE)==SQLITE_OK);
+  check("build_root_right_sep",
+        prollyNodeBuilderAdd(&b, kZ, sizeof(kZ),
+                             rightHash.data, PROLLY_HASH_SIZE)==SQLITE_OK);
+  check("finish_root", prollyNodeBuilderFinish(&b, &pNode, &nNode)==SQLITE_OK);
+  check("store_root", chunkStorePut(&cs, pNode, nNode, &rootHash)==SQLITE_OK);
+  sqlite3_free(pNode);
+  prollyNodeBuilderFree(&b);
+
+  prollyCursorInit(&cur, &cs, &cache, &rootHash, PROLLY_NODE_BLOBKEY);
+  rc = prollyCursorSeekBlob(&cur, kT, sizeof(kT), &res);
+  check("seek_blob_key_across_internal_boundary", rc==SQLITE_OK);
+  check("seek_blob_key_finds_exact_match", res==0);
+  check("blob_cursor_valid_after_seek", prollyCursorIsValid(&cur));
+  if( prollyCursorIsValid(&cur) ){
+    prollyCursorKey(&cur, &pKey, &nKey);
+    check("blob_cursor_lands_on_right_child_key",
+          nKey==(int)sizeof(kT) && memcmp(pKey, kT, sizeof(kT))==0);
+  }
+
+  prollyCursorClose(&cur);
+  prollyCacheFree(&cache);
+  chunkStoreClose(&cs);
+}
+
+static void run_prolly_cursor_surfaces_corrupt_node(void){
+  ChunkStore cs;
+  ProllyCache cache;
+  ProllyCursor cur;
+  ProllyHash rootHash;
+  int rc;
+  int res = 99;
+  static const u8 badNode[] = { 'b', 'a', 'd', '!' };
+
+  printf("=== Prolly Cursor Corrupt Node Test ===\n\n");
+
+  check("open_memory_store_for_corrupt_cursor",
+        chunkStoreOpen(&cs, sqlite3_vfs_find(0), ":memory:", 0)==SQLITE_OK);
+  check("init_cache_for_corrupt_cursor", prollyCacheInit(&cache, 4)==SQLITE_OK);
+  check("store_bad_root_node",
+        chunkStorePut(&cs, badNode, (int)sizeof(badNode), &rootHash)==SQLITE_OK);
+
+  prollyCursorInit(&cur, &cs, &cache, &rootHash, PROLLY_NODE_BLOBKEY);
+  rc = prollyCursorFirst(&cur, &res);
+  check("cursor_first_reports_corrupt_node", rc==SQLITE_CORRUPT);
+
+  prollyCursorClose(&cur);
+  prollyCacheFree(&cache);
+  chunkStoreClose(&cs);
+}
+
 static const RegressionCase aCases[] = {
   { "concurrent_refs", "Concurrent Refs Test", run_concurrent_refs },
   { "checkout_persist_failure", "Checkout Persist Failure Test", run_checkout_persist_failure },
@@ -1627,7 +1731,9 @@ static const RegressionCase aCases[] = {
   { "prolly_diff_record_corruption", "Prolly Diff Record Corruption Test", run_prolly_diff_record_corruption },
   { "integrity_check_repo_state", "Integrity Check Repository State Test", run_integrity_check_repo_state },
   { "btree_commit_failure_transactional", "Btree Commit Failure Transaction Test", run_btree_commit_failure_transactional },
-  { "mutmap_empty_reverse_iter", "MutMap Empty Reverse Iterator Test", run_mutmap_empty_reverse_iter }
+  { "mutmap_empty_reverse_iter", "MutMap Empty Reverse Iterator Test", run_mutmap_empty_reverse_iter },
+  { "prolly_blob_cursor_boundary", "Prolly Blob Cursor Internal Boundary Test", run_prolly_blob_cursor_seek_across_internal_boundary },
+  { "prolly_cursor_corrupt_node", "Prolly Cursor Corrupt Node Test", run_prolly_cursor_surfaces_corrupt_node }
 };
 
 static int run_case_by_name(const char *zName){


### PR DESCRIPTION
## Summary
- fix blob-key cursor descent so seeks move to the right child past internal separators
- propagate prolly node parse failures as corruption instead of collapsing them to SQLITE_NOMEM
- clean up chunk store state on refs deserialization failure during open and add focused regressions

## Testing
- ./doltlite_regression_test_c prolly_blob_cursor_boundary
- ./doltlite_regression_test_c prolly_cursor_corrupt_node
- ./doltlite_regression_test_c truncated_wal_rejected
- ./doltlite_regression_test_c memory_chunk_lookup_corruption
- ./doltlite_regression_test_c refresh_open_path_transactional
- ./doltlite_regression_test_c refs_blob_corruption