### PR TITLE
Restore prolly btree transaction metadata

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -254,6 +254,10 @@ struct Btree {
     int *aPendingCount;     /* MutMap nEntries per table at savepoint time */
     int nTables;
     Pgno iNextTable;
+    ProllyHash stagedCatalog;
+    u8 isMerging;
+    ProllyHash mergeCommitHash;
+    ProllyHash conflictsCatalogHash;
   } *aSavepointTables;
   int nSavepointTablesAlloc;
 
@@ -261,6 +265,10 @@ struct Btree {
   struct TableEntry *aCommittedTables;
   int nCommittedTables;
   Pgno iCommittedNextTable;
+  ProllyHash committedStagedCatalog;
+  u8 committedIsMerging;
+  ProllyHash committedMergeCommitHash;
+  ProllyHash committedConflictsCatalogHash;
 
   /* DoltLite versioning state */
   char *zBranch;
@@ -337,6 +345,7 @@ static int ensureMutMap(BtCursor *pCur);
 static int saveCursorPosition(BtCursor *pCur);
 static int restoreCursorPosition(BtCursor *pCur, int *pDifferentRow);
 static int pushSavepoint(Btree *pBtree);
+static int restoreFromCommitted(Btree *p);
 static void refreshCursorRoot(BtCursor *pCur);
 static int countTreeEntries(Btree *pBtree, Pgno iTable, i64 *pCount);
 static int saveAllCursors(BtShared *pBt, Pgno iRoot, BtCursor *pExcept);
@@ -1218,6 +1227,10 @@ static void freeSavepointTables(struct SavepointTableState *pState){
     sqlite3_free(pState->aPendingCount);
     pState->aPendingCount = 0;
   }
+  memset(&pState->stagedCatalog, 0, sizeof(pState->stagedCatalog));
+  pState->isMerging = 0;
+  memset(&pState->mergeCommitHash, 0, sizeof(pState->mergeCommitHash));
+  memset(&pState->conflictsCatalogHash, 0, sizeof(pState->conflictsCatalogHash));
 }
 
 static void truncatePendingToCount(ProllyMutMap *pMap, int savedCount){
@@ -1347,6 +1360,10 @@ static int pushSavepoint(Btree *pBtree){
   pState->aPendingCount = 0;
   pState->nTables = 0;
   pState->iNextTable = pBtree->iNextTable;
+  pState->stagedCatalog = pBtree->stagedCatalog;
+  pState->isMerging = pBtree->isMerging;
+  pState->mergeCommitHash = pBtree->mergeCommitHash;
+  pState->conflictsCatalogHash = pBtree->conflictsCatalogHash;
   if( pBtree->nTables > 0 ){
     pState->aTables = sqlite3_malloc(pBtree->nTables * (int)sizeof(struct TableEntry));
     if( !pState->aTables ) return SQLITE_NOMEM;
@@ -2077,6 +2094,10 @@ static int prollyBtreeBeginTrans(Btree *p, int wrFlag, int *pSchemaVersion){
       }
     }
     p->iCommittedNextTable = p->iNextTable;
+    p->committedStagedCatalog = p->stagedCatalog;
+    p->committedIsMerging = p->isMerging;
+    p->committedMergeCommitHash = p->mergeCommitHash;
+    p->committedConflictsCatalogHash = p->conflictsCatalogHash;
     p->inTrans = TRANS_WRITE;
     p->inTransaction = TRANS_WRITE;
     
@@ -2176,14 +2197,12 @@ static int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
       ** durably persist the rollback result here. The durable commit did
       ** not happen, so the correct outcome is simply "old durable state
       ** remains on disk". */
-      if( p->aCommittedTables ){
-        sqlite3_free(p->aTables);
-        p->aTables = p->aCommittedTables;
-        p->nTables = p->nCommittedTables;
-        p->nTablesAlloc = p->nCommittedTables;
-        p->iNextTable = p->iCommittedNextTable;
-        p->aCommittedTables = 0;
-        p->nCommittedTables = 0;
+      int rc2 = restoreFromCommitted(p);
+      if( rc2!=SQLITE_OK ){
+        chunkStoreRollback(&pBt->store);
+        chunkStoreUnlock(&pBt->store);
+        pBt->store.snapshotPinned = 0;
+        return rc2;
       }
       {
         BtCursor *pC;
@@ -2250,6 +2269,10 @@ static int restoreFromCommitted(Btree *p){
     p->nTablesAlloc = p->nCommittedTables;
     p->iNextTable = p->iCommittedNextTable;
   }
+  p->stagedCatalog = p->committedStagedCatalog;
+  p->isMerging = p->committedIsMerging;
+  p->mergeCommitHash = p->committedMergeCommitHash;
+  p->conflictsCatalogHash = p->committedConflictsCatalogHash;
   return SQLITE_OK;
 }
 
@@ -2259,15 +2282,11 @@ static int prollyBtreeRollback(Btree *p, int tripCode, int writeOnly){
   (void)writeOnly;
 
   if( p->inTrans==TRANS_WRITE ){
-    
-    if( p->aCommittedTables ){
-      sqlite3_free(p->aTables);
-      p->aTables = p->aCommittedTables;
-      p->nTables = p->nCommittedTables;
-      p->nTablesAlloc = p->nCommittedTables;
-      p->iNextTable = p->iCommittedNextTable;
-      p->aCommittedTables = 0;
-      p->nCommittedTables = 0;
+    rc = restoreFromCommitted(p);
+    if( rc!=SQLITE_OK ){
+      chunkStoreUnlock(&pBt->store);
+      pBt->store.snapshotPinned = 0;
+      return rc;
     }
     {
       BtCursor *pC;
@@ -2362,12 +2381,12 @@ static int prollyBtreeSavepoint(Btree *p, int op, int iSavepoint){
       if( pState->aTables ){
         int rc = restoreTablesFromSavepoint(p, pState);
         if( rc!=SQLITE_OK ) return rc;
-
-        sqlite3_free(pState->aTables);
-        sqlite3_free(pState->aPendingCount);
-        pState->aTables = 0;
-        pState->aPendingCount = 0;
       }
+      p->stagedCatalog = pState->stagedCatalog;
+      p->isMerging = pState->isMerging;
+      p->mergeCommitHash = pState->mergeCommitHash;
+      p->conflictsCatalogHash = pState->conflictsCatalogHash;
+      freeSavepointTables(pState);
       
       {
         int j;
@@ -5256,6 +5275,12 @@ int doltliteHardReset(sqlite3 *db, const ProllyHash *catHash){
   BtShared *pBt = doltliteGetBtShared(db);
   Btree *pBtree;
   ChunkStore *cs;
+  u8 *oldCatData = 0;
+  int nOldCatData = 0;
+  ProllyHash oldStagedCatalog;
+  u8 oldIsMerging;
+  ProllyHash oldMergeCommitHash;
+  ProllyHash oldConflictsCatalogHash;
   u8 *data = 0;
   int nData = 0;
   int rc;
@@ -5267,21 +5292,44 @@ int doltliteHardReset(sqlite3 *db, const ProllyHash *catHash){
 
   if( prollyHashIsEmpty(catHash) ) return SQLITE_OK;
 
-  rc = chunkStoreGet(cs, catHash, &data, &nData);
+  rc = serializeCatalog(pBtree, &oldCatData, &nOldCatData);
   if( rc!=SQLITE_OK ) return rc;
+  rc = chunkStoreGet(cs, catHash, &data, &nData);
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(oldCatData);
+    return rc;
+  }
+
+  oldStagedCatalog = pBtree->stagedCatalog;
+  oldIsMerging = pBtree->isMerging;
+  oldMergeCommitHash = pBtree->mergeCommitHash;
+  oldConflictsCatalogHash = pBtree->conflictsCatalogHash;
 
   
   invalidateCursors(pBt, 0, SQLITE_ABORT);
 
   
-  sqlite3_free(pBtree->aTables);
   pBtree->aTables = 0;
   pBtree->nTables = 0;
   pBtree->nTablesAlloc = 0;
 
   rc = deserializeCatalog(pBtree, data, nData);
   sqlite3_free(data);
-  if( rc!=SQLITE_OK ) return rc;
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(pBtree->aTables);
+    pBtree->aTables = 0;
+    pBtree->nTables = 0;
+    pBtree->nTablesAlloc = 0;
+    if( oldCatData ){
+      rc = deserializeCatalog(pBtree, oldCatData, nOldCatData);
+    }
+    sqlite3_free(oldCatData);
+    pBtree->stagedCatalog = oldStagedCatalog;
+    pBtree->isMerging = oldIsMerging;
+    pBtree->mergeCommitHash = oldMergeCommitHash;
+    pBtree->conflictsCatalogHash = oldConflictsCatalogHash;
+    return rc;
+  }
 
   
   pBtree->aMeta[BTREE_SCHEMA_VERSION]++;
@@ -5306,10 +5354,45 @@ int doltliteHardReset(sqlite3 *db, const ProllyHash *catHash){
   ** working catalog BEFORE calling hardReset. */
   {
     const char *zBr = pBtree->zBranch ? pBtree->zBranch : "main";
-    btreeWriteWorkingState(cs, zBr, catHash, NULL);
+    rc = btreeWriteWorkingState(cs, zBr, catHash, NULL);
   }
-  rc = chunkStoreCommit(cs);
-  return rc;
+  if( rc==SQLITE_OK ){
+    rc = chunkStoreCommit(cs);
+  }
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(pBtree->aTables);
+    pBtree->aTables = 0;
+    pBtree->nTables = 0;
+    pBtree->nTablesAlloc = 0;
+    if( oldCatData ){
+      int rc2 = deserializeCatalog(pBtree, oldCatData, nOldCatData);
+      if( rc2!=SQLITE_OK ){
+        sqlite3_free(oldCatData);
+        chunkStoreRollback(cs);
+        return rc;
+      }
+    }
+    pBtree->stagedCatalog = oldStagedCatalog;
+    pBtree->isMerging = oldIsMerging;
+    pBtree->mergeCommitHash = oldMergeCommitHash;
+    pBtree->conflictsCatalogHash = oldConflictsCatalogHash;
+    if( pBtree->db ){
+      sqlite3ResetAllSchemasOfConnection(pBtree->db);
+    }else{
+      invalidateSchema(pBtree);
+    }
+    pBtree->aMeta[BTREE_SCHEMA_VERSION]++;
+    pBtree->iBDataVersion++;
+    if( pBt->pPagerShim ){
+      pBt->pPagerShim->iDataVersion++;
+    }
+    chunkStoreRollback(cs);
+    sqlite3_free(oldCatData);
+    return rc;
+  }
+
+  sqlite3_free(oldCatData);
+  return SQLITE_OK;
 }
 
 int doltliteUpdateBranchWorkingState(sqlite3 *db, const char *zBranch,

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -1556,6 +1556,14 @@ static void run_btree_commit_failure_transactional(void){
   sqlite3 *db = 0;
   char dbpath[256];
   int rc;
+  ProllyHash headCatHash;
+  ProllyHash dummyStaged;
+  ProllyHash dummyMerge;
+  ProllyHash dummyConflicts;
+  ProllyHash stagedAfter;
+  ProllyHash mergeAfter;
+  ProllyHash conflictsAfter;
+  u8 isMergingAfter = 0;
 
   printf("=== Btree Commit Failure Transaction Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_btree_commit_failure_transactional");
@@ -1569,7 +1577,16 @@ static void run_btree_commit_failure_transactional(void){
   check("setup_table", execsql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');")==SQLITE_OK);
+  check("get_head_catalog_for_commit_failure",
+        doltliteGetHeadCatalogHash(db, &headCatHash)==SQLITE_OK);
+  doltliteSetSessionStaged(db, &headCatHash);
+  doltliteClearSessionMergeState(db);
   check("begin_write_txn", execsql(db, "BEGIN; INSERT INTO t VALUES(2,'b');")==SQLITE_OK);
+  memset(&dummyStaged, 0x71, sizeof(dummyStaged));
+  memset(&dummyMerge, 0x72, sizeof(dummyMerge));
+  memset(&dummyConflicts, 0x73, sizeof(dummyConflicts));
+  doltliteSetSessionStaged(db, &dummyStaged);
+  doltliteSetSessionMergeState(db, 1, &dummyMerge, &dummyConflicts);
 
   gFailWriteOnce = 1;
   rc = execsql_silent(db, "COMMIT;");
@@ -1578,11 +1595,120 @@ static void run_btree_commit_failure_transactional(void){
   check("autocommit_restored_after_failed_commit", sqlite3_get_autocommit(db)==1);
   check("failed_commit_rolled_back_visible_state",
         strcmp(exec1(db, "SELECT count(*) FROM t"), "1")==0);
+  doltliteGetSessionStaged(db, &stagedAfter);
+  doltliteGetSessionMergeState(db, &isMergingAfter, &mergeAfter, &conflictsAfter);
+  check("failed_commit_restores_session_staged",
+        memcmp(&stagedAfter, &headCatHash, sizeof(headCatHash))==0);
+  check("failed_commit_clears_merge_flag", isMergingAfter==0);
+  check("failed_commit_restores_merge_commit",
+        memcmp(&mergeAfter, &(ProllyHash){{0}}, sizeof(ProllyHash))==0);
+  check("failed_commit_restores_conflicts_catalog",
+        memcmp(&conflictsAfter, &(ProllyHash){{0}}, sizeof(ProllyHash))==0);
 
   sqlite3_close(db);
   check("reopen_after_failed_commit", open_db(dbpath, &db)==SQLITE_OK);
   check("failed_commit_did_not_persist_row",
         strcmp(exec1(db, "SELECT count(*) FROM t"), "1")==0);
+  sqlite3_close(db);
+  remove_db(dbpath);
+}
+
+static void run_savepoint_restores_session_metadata(void){
+  sqlite3 *db = 0;
+  char dbpath[256];
+  ProllyHash baseStaged;
+  ProllyHash dummyStaged;
+  ProllyHash dummyMerge;
+  ProllyHash dummyConflicts;
+  ProllyHash stagedAfter;
+  ProllyHash mergeAfter;
+  ProllyHash conflictsAfter;
+  u8 isMergingAfter = 0;
+
+  printf("=== Savepoint Restores Session Metadata Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_savepoint_restores_session_metadata");
+  remove_db(dbpath);
+
+  check("open_db_for_savepoint_metadata", open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_repo_for_savepoint_metadata", execsql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'a');"
+    "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
+
+  check("get_head_catalog_for_savepoint_metadata",
+        doltliteGetHeadCatalogHash(db, &baseStaged)==SQLITE_OK);
+  doltliteSetSessionStaged(db, &baseStaged);
+  doltliteClearSessionMergeState(db);
+
+  check("begin_immediate_for_savepoint_metadata",
+        execsql(db, "BEGIN IMMEDIATE;")==SQLITE_OK);
+  check("create_savepoint_for_metadata",
+        execsql(db, "SAVEPOINT s1;")==SQLITE_OK);
+
+  memset(&dummyStaged, 0x41, sizeof(dummyStaged));
+  memset(&dummyMerge, 0x42, sizeof(dummyMerge));
+  memset(&dummyConflicts, 0x43, sizeof(dummyConflicts));
+  doltliteSetSessionStaged(db, &dummyStaged);
+  doltliteSetSessionMergeState(db, 1, &dummyMerge, &dummyConflicts);
+  doltliteGetSessionStaged(db, &stagedAfter);
+  check("savepoint_metadata_mutation_applied",
+        memcmp(&stagedAfter, &dummyStaged, sizeof(dummyStaged))==0);
+
+  check("rollback_to_savepoint_metadata",
+        execsql(db, "ROLLBACK TO s1;")==SQLITE_OK);
+  doltliteGetSessionStaged(db, &stagedAfter);
+  doltliteGetSessionMergeState(db, &isMergingAfter, &mergeAfter, &conflictsAfter);
+  check("rollback_to_savepoint_restores_staged",
+        memcmp(&stagedAfter, &baseStaged, sizeof(baseStaged))==0);
+  check("rollback_to_savepoint_clears_merge_flag", isMergingAfter==0);
+  check("rollback_to_savepoint_clears_merge_commit",
+        memcmp(&mergeAfter, &(ProllyHash){{0}}, sizeof(ProllyHash))==0);
+  check("rollback_to_savepoint_clears_conflicts_catalog",
+        memcmp(&conflictsAfter, &(ProllyHash){{0}}, sizeof(ProllyHash))==0);
+
+  check("release_savepoint_metadata", execsql(db, "RELEASE s1;")==SQLITE_OK);
+  check("rollback_outer_txn_metadata", execsql(db, "ROLLBACK;")==SQLITE_OK);
+  sqlite3_close(db);
+  remove_db(dbpath);
+}
+
+static void run_hard_reset_failure_restores_memory_state(void){
+  sqlite3 *db = 0;
+  char dbpath[256];
+  ProllyHash headCatHash;
+  int rc;
+
+  printf("=== Hard Reset Failure Restores Memory State Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_hard_reset_failure_restores_memory_state");
+  remove_db(dbpath);
+  gFailWriteOnce = 0;
+  gFailSyncOnce = 0;
+  gFailHits = 0;
+
+  check("register_fail_vfs_for_hard_reset", registerFailVfs()==SQLITE_OK);
+  check("open_fail_db_for_hard_reset", open_fail_db(dbpath, &db)==SQLITE_OK);
+  check("setup_repo_for_hard_reset_failure", execsql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'a');"
+    "SELECT dolt_commit('-A', '-m', 'init');"
+    "INSERT INTO t VALUES(2,'b');")==SQLITE_OK);
+  check("working_row_visible_before_hard_reset",
+        strcmp(exec1(db, "SELECT count(*) FROM t"), "2")==0);
+  check("get_head_catalog_for_hard_reset",
+        doltliteGetHeadCatalogHash(db, &headCatHash)==SQLITE_OK);
+
+  gFailHits = 0;
+  gFailWriteOnce = 1;
+  rc = doltliteHardReset(db, &headCatHash);
+  check("hard_reset_failure_injected", gFailHits>0);
+  check("hard_reset_returns_error_on_commit_failure", rc!=SQLITE_OK);
+  check("failed_hard_reset_preserves_memory_state",
+        strcmp(exec1(db, "SELECT count(*) FROM t"), "2")==0);
+
+  sqlite3_close(db);
+  check("reopen_after_failed_hard_reset", open_db(dbpath, &db)==SQLITE_OK);
+  check("failed_hard_reset_preserves_durable_state",
+        strcmp(exec1(db, "SELECT count(*) FROM t"), "2")==0);
   sqlite3_close(db);
   remove_db(dbpath);
 }
@@ -1731,6 +1857,8 @@ static const RegressionCase aCases[] = {
   { "prolly_diff_record_corruption", "Prolly Diff Record Corruption Test", run_prolly_diff_record_corruption },
   { "integrity_check_repo_state", "Integrity Check Repository State Test", run_integrity_check_repo_state },
   { "btree_commit_failure_transactional", "Btree Commit Failure Transaction Test", run_btree_commit_failure_transactional },
+  { "savepoint_restores_session_metadata", "Savepoint Restores Session Metadata Test", run_savepoint_restores_session_metadata },
+  { "hard_reset_failure_restores_memory_state", "Hard Reset Failure Restores Memory State Test", run_hard_reset_failure_restores_memory_state },
   { "mutmap_empty_reverse_iter", "MutMap Empty Reverse Iterator Test", run_mutmap_empty_reverse_iter },
   { "prolly_blob_cursor_boundary", "Prolly Blob Cursor Internal Boundary Test", run_prolly_blob_cursor_seek_across_internal_boundary },
   { "prolly_cursor_corrupt_node", "Prolly Cursor Corrupt Node Test", run_prolly_cursor_surfaces_corrupt_node }


### PR DESCRIPTION
## Summary
- snapshot and restore staged/merge working-set metadata across savepoints, rollbacks, and failed commits
- make hard reset restore the pre-reset in-memory catalog when persisting the new working state fails
- add focused regressions for savepoint metadata rollback, failed commit metadata rollback, and hard reset failure recovery

## Testing
- ./doltlite_regression_test_c savepoint_restores_session_metadata
- ./doltlite_regression_test_c hard_reset_failure_restores_memory_state
- ./doltlite_regression_test_c btree_commit_failure_transactional