### PR TITLE
dolt_diff_<table>: match Dolt's merge edge attribution (#374)

### DIFF
--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -85,24 +85,40 @@ struct DiffTblVtab {
   DoltliteColInfo cols;
 };
 
+/* A (from, to) commit pair eligible for diffing. Built up-front in
+** dtFilter from a Dolt-matching walk of the commit graph (see
+** buildDiffPairs); the cursor iterates through this list, opening one
+** ProllyDiffIter per pair. */
+typedef struct DiffPair DiffPair;
+struct DiffPair {
+  /* From side = the older commit being processed. */
+  ProllyHash fromHash;
+  ProllyHash fromTblRoot;
+  u8         fromFlags;
+  i64        fromDate;
+  /* To side = the descendant assigned to this commit by the walk.
+  ** zToCommit is either the descendant's hex hash or the literal
+  ** "WORKING" for the working-set entry. */
+  char       zToCommit[PROLLY_HASH_SIZE*2+1];
+  ProllyHash toTblRoot;
+  u8         toFlags;
+  i64        toDate;
+};
+
 /*
-** Streaming cursor: walks commit history lazily and yields one diff row
-** at a time via a ProllyDiffIter for each commit pair.
+** Streaming cursor: pre-builds the list of (from,to) diff pairs from a
+** Dolt-matching graph walk in dtFilter, then opens one ProllyDiffIter
+** per pair lazily and yields rows from each in sequence.
 */
 typedef struct DiffTblCursor DiffTblCursor;
 struct DiffTblCursor {
   sqlite3_vtab_cursor base;
 
-  /* Commit walk state. Instead of a linear first-parent advance,
-  ** the cursor pre-builds the full set of commits reachable from
-  ** HEAD via BFS through all parent edges (so merge commits
-  ** contribute both branches' history). dtFilter populates aWalk;
-  ** the cursor walks through it sequentially. */
-  ProllyHash *aWalk;            /* Commits to visit, in walk order */
-  int nWalk;                    /* Number of commits in aWalk */
-  int iWalk;                    /* Index of the commit currently being diffed */
-  int commitWalkDone;           /* 1 when iWalk has passed the end */
-  int workingPhaseDone;         /* 1 once the working-vs-HEAD diff has been emitted */
+  /* Pairs to diff, in iteration order. */
+  DiffPair *aPairs;
+  int nPairs;
+  int iPair;                    /* Index of the pair currently being diffed */
+  int pairsDone;                /* 1 when iPair has passed the end */
 
   /* Diff iterator for the current commit pair */
   ProllyDiffIter diffIter;
@@ -168,286 +184,312 @@ static void closeDiffIter(DiffTblCursor *pCur){
   }
 }
 
-/* Open a working-set vs HEAD diff iterator for the named table.
-** The "to" side is the live working catalog; the "from" side is
-** HEAD's catalog. Sets row.zToCommit to "WORKING" and row.zFromCommit
-** to HEAD's commit hash so the user can filter on either. Returns
-** SQLITE_OK with diffIterOpen=1 on success, or SQLITE_OK with
-** diffIterOpen=0 if there's nothing to diff (empty working or
-** identical to HEAD). */
-static int openWorkingDiffIter(DiffTblCursor *pCur, sqlite3 *db,
-                               const char *zTableName){
-  ChunkStore *cs = doltliteGetChunkStore(db);
-  ProllyCache *pCache = doltliteGetCache(db);
-  ProllyHash workingCatHash, headCatHash;
-  ProllyHash workingRoot, headRoot;
-  ProllyHash headHash;
-  u8 flags = 0, headFlags = 0;
-  int rc;
+/* Working-set vs HEAD diff is no longer a separate phase: it's the
+** first entry produced by buildDiffPairs (cmHashToTblInfo[HEAD] is
+** seeded with the working catalog as the "to" side, and HEAD's own
+** processCommit step emits the (HEAD, WORKING) pair if they differ). */
 
-  if( !cs ) return SQLITE_OK;
+/* Per-commit "to-side" info recorded in the cmHashToTblInfo map
+** during the graph walk. Each commit, when reached, looks up its
+** entry to know which descendant commit it should be diffed against
+** (and against which version of the table). Mirrors Dolt's
+** TblInfoAtCommit struct. */
+typedef struct CmTblInfo CmTblInfo;
+struct CmTblInfo {
+  ProllyHash key;
+  ProllyHash tblRoot;
+  u8         flags;
+  i64        date;
+  char       zHexName[PROLLY_HASH_SIZE*2+1];
+};
 
-  memset(&workingCatHash, 0, sizeof(workingCatHash));
-  memset(&headCatHash, 0, sizeof(headCatHash));
-  memset(&workingRoot, 0, sizeof(workingRoot));
-  memset(&headRoot, 0, sizeof(headRoot));
-
-  rc = doltliteFlushCatalogToHash(db, &workingCatHash);
-  if( rc!=SQLITE_OK ) return rc;
-  rc = doltliteGetHeadCatalogHash(db, &headCatHash);
-  if( rc!=SQLITE_OK ) return rc;
-
-  /* Find the table's root in working and in HEAD. */
-  {
-    struct TableEntry *aTables = 0;
-    int nTables = 0;
-    rc = doltliteLoadCatalog(db, &workingCatHash, &aTables, &nTables, 0);
-    if( rc==SQLITE_OK ){
-      doltliteFindTableRootByName(aTables, nTables, zTableName,
-                                  &workingRoot, &flags);
-    }
-    sqlite3_free(aTables);
-    if( rc!=SQLITE_OK ) return rc;
+/* Linear-search map operations. The walk visits each commit once,
+** so n is bounded by the size of the commit graph; for that range
+** linear search beats hash-table overhead. Returns the index of the
+** existing entry if found, or -1 otherwise. */
+static int mapFind(const CmTblInfo *aMap, int nMap, const ProllyHash *pKey){
+  int i;
+  for(i=0; i<nMap; i++){
+    if( prollyHashCompare(&aMap[i].key, pKey)==0 ) return i;
   }
-  if( !prollyHashIsEmpty(&headCatHash) ){
-    struct TableEntry *aTables = 0;
-    int nTables = 0;
-    rc = doltliteLoadCatalog(db, &headCatHash, &aTables, &nTables, 0);
-    if( rc==SQLITE_OK ){
-      doltliteFindTableRootByName(aTables, nTables, zTableName,
-                                  &headRoot, &headFlags);
-    }
-    sqlite3_free(aTables);
-    if( rc!=SQLITE_OK ) return rc;
-  }
-  if( flags==0 ) flags = headFlags;
-
-  /* Same root → no working diff to emit. */
-  if( prollyHashCompare(&workingRoot, &headRoot)==0 ) return SQLITE_OK;
-
-  /* Set up commit metadata: to_commit="WORKING", from_commit=HEAD hash. */
-  memcpy(pCur->row.zToCommit, "WORKING", 7);
-  pCur->row.zToCommit[7] = 0;
-  pCur->row.toDate = 0;
-  doltliteGetSessionHead(db, &headHash);
-  if( prollyHashIsEmpty(&headHash) ){
-    memset(pCur->row.zFromCommit, '0', PROLLY_HASH_SIZE*2);
-    pCur->row.zFromCommit[PROLLY_HASH_SIZE*2] = 0;
-    pCur->row.fromDate = 0;
-  }else{
-    DoltliteCommit headCommit;
-    memset(&headCommit, 0, sizeof(headCommit));
-    doltliteHashToHex(&headHash, pCur->row.zFromCommit);
-    if( doltliteLoadCommit(db, &headHash, &headCommit)==SQLITE_OK ){
-      pCur->row.fromDate = headCommit.timestamp;
-    }
-    doltliteCommitClear(&headCommit);
-  }
-
-  rc = prollyDiffIterOpen(&pCur->diffIter, cs, pCache,
-                          &headRoot, &workingRoot, flags);
-  if( rc==SQLITE_OK ) pCur->diffIterOpen = 1;
-  return rc;
+  return -1;
 }
 
-/* BFS-walk all commits reachable from HEAD via every parent edge,
-** populating aWalk with the visit order. Used by dtFilter to build
-** the full per-commit walk before iteration starts. The walk
-** matches what dolt_log shows so dolt_diff_<table> visits every
-** commit in the branch's history, not just the first-parent
-** chain. */
-static int buildWalkList(DiffTblCursor *pCur, sqlite3 *db){
+/* Insert or overwrite an entry in the cmHashToTblInfo map. Mirrors
+** Dolt's `dps.cmHashToTblInfo[h] = newInfo` behavior, where the most
+** recent processCommit call wins. */
+static int mapPut(CmTblInfo **paMap, int *pnMap, const ProllyHash *pKey,
+                  const ProllyHash *pTblRoot, u8 flags,
+                  const char *zHexName, i64 date){
+  int idx = mapFind(*paMap, *pnMap, pKey);
+  CmTblInfo *e;
+  if( idx<0 ){
+    CmTblInfo *aNew = sqlite3_realloc(*paMap,
+                          (*pnMap+1)*(int)sizeof(CmTblInfo));
+    if( !aNew ) return SQLITE_NOMEM;
+    *paMap = aNew;
+    e = &aNew[*pnMap];
+    memset(e, 0, sizeof(*e));
+    e->key = *pKey;
+    (*pnMap)++;
+  }else{
+    e = &(*paMap)[idx];
+  }
+  e->tblRoot = *pTblRoot;
+  e->flags = flags;
+  e->date = date;
+  memcpy(e->zHexName, zHexName, PROLLY_HASH_SIZE*2+1);
+  return SQLITE_OK;
+}
+
+/* Append a (from,to) pair to the cursor's diff-pair list. */
+static int pairsAppend(DiffTblCursor *pCur,
+                       const ProllyHash *pFromHash,
+                       const ProllyHash *pFromTblRoot,
+                       u8 fromFlags, i64 fromDate,
+                       const char *zToHex,
+                       const ProllyHash *pToTblRoot,
+                       u8 toFlags, i64 toDate){
+  DiffPair *aNew, *r;
+  aNew = sqlite3_realloc(pCur->aPairs,
+                         (pCur->nPairs+1)*(int)sizeof(DiffPair));
+  if( !aNew ) return SQLITE_NOMEM;
+  pCur->aPairs = aNew;
+  r = &aNew[pCur->nPairs++];
+  memset(r, 0, sizeof(*r));
+  r->fromHash    = *pFromHash;
+  r->fromTblRoot = *pFromTblRoot;
+  r->fromFlags   = fromFlags;
+  r->fromDate    = fromDate;
+  memcpy(r->zToCommit, zToHex, PROLLY_HASH_SIZE*2+1);
+  r->toTblRoot   = *pToTblRoot;
+  r->toFlags     = toFlags;
+  r->toDate      = toDate;
+  return SQLITE_OK;
+}
+
+/* Helper: load a commit's catalog and look up the named table's root
+** and flags. Sets pTblRoot to the empty hash and *pFlags to 0 if the
+** table doesn't exist at this commit. */
+static int loadTblRootAtCommit(sqlite3 *db, const ProllyHash *pCatHash,
+                               const char *zTableName,
+                               ProllyHash *pTblRoot, u8 *pFlags){
+  struct TableEntry *aTables = 0;
+  int nTables = 0;
+  int rc;
+  memset(pTblRoot, 0, sizeof(*pTblRoot));
+  *pFlags = 0;
+  rc = doltliteLoadCatalog(db, pCatHash, &aTables, &nTables, 0);
+  if( rc!=SQLITE_OK ) return rc;
+  doltliteFindTableRootByName(aTables, nTables, zTableName, pTblRoot, pFlags);
+  sqlite3_free(aTables);
+  return SQLITE_OK;
+}
+
+/* Walk the commit graph from HEAD using the same algorithm as Dolt's
+** dolt_diff_<table>:
+**
+**   1. Initialize cmHashToTblInfo[HEAD] = {name: "WORKING", tblRoot:
+**      working catalog's root for this table}.
+**   2. DFS-LIFO walk via a stack: push parents in forward order, pop
+**      from the END (so the LAST parent is visited first).
+**   3. For each visited commit C: read cmHashToTblInfo[C] (its assigned
+**      descendant info, set by some prior step). If the descendant's
+**      tblRoot differs from C's tblRoot, record a (from=C, to=desc)
+**      diff pair. Then overwrite cmHashToTblInfo[parent] = C's info
+**      for every parent of C (last writer wins).
+**
+** This produces the exact (commit, parent) attribution Dolt produces
+** for merge commits — the merge edge "absorbs" first-parent diffs that
+** would otherwise be redundant. See diff_table.go:processCommit /
+** commit_itr.go:Next in the dolt repo for the canonical algorithm. */
+static int buildDiffPairs(DiffTblCursor *pCur, sqlite3 *db,
+                          const char *zTableName){
   ChunkStore *cs = doltliteGetChunkStore(db);
   ProllyHash headHash;
-  ProllyHash *aQueue = 0;
-  int nQueue = 0, qHead = 0;
-  ProllyHash *aSeen = 0;
-  int nSeen = 0;
+  ProllyHash workingCat, workingTblRoot;
+  u8 workingFlags = 0;
+  CmTblInfo *aMap = 0;
+  int nMap = 0;
+  ProllyHash *aStack = 0;
+  int nStack = 0;
+  ProllyHash *aAdded = 0;  /* commits already pushed to stack */
+  int nAdded = 0;
+  int currInited = 0;
+  ProllyHash curr;
   int rc = SQLITE_OK;
+  int i;
 
   if( !cs ) return SQLITE_OK;
+
   doltliteGetSessionHead(db, &headHash);
   if( prollyHashIsEmpty(&headHash) ) return SQLITE_OK;
 
-  aQueue = sqlite3_malloc((int)sizeof(ProllyHash));
-  if( !aQueue ) return SQLITE_NOMEM;
-  aQueue[0] = headHash;
-  nQueue = 1;
+  /* Initialize cmHashToTblInfo[HEAD] = {name:"WORKING", working root}. */
+  memset(&workingCat, 0, sizeof(workingCat));
+  memset(&workingTblRoot, 0, sizeof(workingTblRoot));
+  rc = doltliteFlushCatalogToHash(db, &workingCat);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = loadTblRootAtCommit(db, &workingCat, zTableName,
+                           &workingTblRoot, &workingFlags);
+  if( rc!=SQLITE_OK ) return rc;
 
-  while( qHead<nQueue ){
-    ProllyHash hash = aQueue[qHead++];
+  {
+    char zWorking[PROLLY_HASH_SIZE*2+1];
+    memset(zWorking, 0, sizeof(zWorking));
+    memcpy(zWorking, "WORKING", 7);
+    rc = mapPut(&aMap, &nMap, &headHash, &workingTblRoot, workingFlags,
+                zWorking, 0);
+    if( rc!=SQLITE_OK ) goto walk_done;
+  }
+
+  /* Mark HEAD as added so we don't push it twice if a parent edge
+  ** ever cycles back. Initial curr = HEAD; the iter equivalent
+  ** returns it before pushing any parents. */
+  {
+    ProllyHash *aN = sqlite3_realloc(aAdded, (nAdded+1)*(int)sizeof(ProllyHash));
+    if( !aN ){ rc = SQLITE_NOMEM; goto walk_done; }
+    aAdded = aN;
+    aAdded[nAdded++] = headHash;
+  }
+  curr = headHash;
+  currInited = 1;
+
+  while( currInited ){
     DoltliteCommit commit;
-    int seen = 0;
-    int i;
-
-    for(i=0; i<nSeen; i++){
-      if( prollyHashCompare(&aSeen[i], &hash)==0 ){ seen = 1; break; }
-    }
-    if( seen ) continue;
-    {
-      ProllyHash *aNewSeen = sqlite3_realloc(aSeen,
-          (nSeen+1)*(int)sizeof(ProllyHash));
-      if( !aNewSeen ){ rc = SQLITE_NOMEM; break; }
-      aSeen = aNewSeen;
-      aSeen[nSeen++] = hash;
-    }
-    {
-      ProllyHash *aNewWalk = sqlite3_realloc(pCur->aWalk,
-          (pCur->nWalk+1)*(int)sizeof(ProllyHash));
-      if( !aNewWalk ){ rc = SQLITE_NOMEM; break; }
-      pCur->aWalk = aNewWalk;
-      pCur->aWalk[pCur->nWalk++] = hash;
-    }
+    ProllyHash curTblRoot;
+    u8 curFlags = 0;
+    char curHex[PROLLY_HASH_SIZE*2+1];
+    int idx;
 
     memset(&commit, 0, sizeof(commit));
-    rc = doltliteLoadCommit(db, &hash, &commit);
+    memset(&curTblRoot, 0, sizeof(curTblRoot));
+
+    rc = doltliteLoadCommit(db, &curr, &commit);
     if( rc!=SQLITE_OK ) break;
 
+    rc = loadTblRootAtCommit(db, &commit.catalogHash, zTableName,
+                             &curTblRoot, &curFlags);
+    if( rc!=SQLITE_OK ){
+      doltliteCommitClear(&commit);
+      break;
+    }
+
+    doltliteHashToHex(&curr, curHex);
+
+    /* processCommit: compare against to-info, emit pair if different. */
+    idx = mapFind(aMap, nMap, &curr);
+    if( idx>=0 ){
+      CmTblInfo *info = &aMap[idx];
+      if( prollyHashCompare(&info->tblRoot, &curTblRoot)!=0 ){
+        u8 fromFlags = curFlags;
+        if( fromFlags==0 ) fromFlags = info->flags;
+        rc = pairsAppend(pCur, &curr, &curTblRoot, fromFlags,
+                         commit.timestamp,
+                         info->zHexName, &info->tblRoot, info->flags,
+                         info->date);
+        if( rc!=SQLITE_OK ){
+          doltliteCommitClear(&commit);
+          break;
+        }
+      }
+    }
+    /* If idx<0 the commit was reached without an assigned to-info;
+    ** that shouldn't happen for a connected graph rooted at HEAD,
+    ** so silently skip without emitting. */
+
+    /* For each parent: overwrite cmHashToTblInfo[parent] with curr's
+    ** info (last writer wins). */
     {
-      int nParents;
-      int p;
-      nParents = commit.nParents>0
-                   ? commit.nParents
-                   : (prollyHashIsEmpty(&commit.parentHash) ? 0 : 1);
-      for(p=0; p<nParents; p++){
-        ProllyHash *aNewQ = sqlite3_realloc(aQueue,
-            (nQueue+1)*(int)sizeof(ProllyHash));
-        if( !aNewQ ){ rc = SQLITE_NOMEM; break; }
-        aQueue = aNewQ;
-        if( commit.nParents>0 ){
-          aQueue[nQueue++] = commit.aParents[p];
-        }else{
-          aQueue[nQueue++] = commit.parentHash;
+      int nParents = commit.nParents>0
+                       ? commit.nParents
+                       : (prollyHashIsEmpty(&commit.parentHash) ? 0 : 1);
+      for(i=0; i<nParents; i++){
+        const ProllyHash *pParent = commit.nParents>0
+                                       ? &commit.aParents[i]
+                                       : &commit.parentHash;
+        rc = mapPut(&aMap, &nMap, pParent, &curTblRoot, curFlags,
+                    curHex, commit.timestamp);
+        if( rc!=SQLITE_OK ) break;
+      }
+      if( rc!=SQLITE_OK ){
+        doltliteCommitClear(&commit);
+        break;
+      }
+
+      /* Push parents (those not yet added) onto the stack in forward
+      ** order so popping from the END visits the LAST parent first.
+      ** This matches Dolt's CommitItrForRoots LIFO ordering. */
+      for(i=0; i<nParents; i++){
+        const ProllyHash *pParent = commit.nParents>0
+                                       ? &commit.aParents[i]
+                                       : &commit.parentHash;
+        int already = 0;
+        int j;
+        for(j=0; j<nAdded; j++){
+          if( prollyHashCompare(&aAdded[j], pParent)==0 ){ already = 1; break; }
+        }
+        if( already ) continue;
+        {
+          ProllyHash *aN = sqlite3_realloc(aAdded,
+                              (nAdded+1)*(int)sizeof(ProllyHash));
+          if( !aN ){ rc = SQLITE_NOMEM; break; }
+          aAdded = aN;
+          aAdded[nAdded++] = *pParent;
+        }
+        {
+          ProllyHash *aN = sqlite3_realloc(aStack,
+                              (nStack+1)*(int)sizeof(ProllyHash));
+          if( !aN ){ rc = SQLITE_NOMEM; break; }
+          aStack = aN;
+          aStack[nStack++] = *pParent;
         }
       }
     }
     doltliteCommitClear(&commit);
     if( rc!=SQLITE_OK ) break;
+
+    /* Pop the next commit from the END of the stack. */
+    if( nStack==0 ){
+      currInited = 0;
+    }else{
+      curr = aStack[nStack-1];
+      nStack--;
+    }
   }
 
-  sqlite3_free(aQueue);
-  sqlite3_free(aSeen);
+walk_done:
+  sqlite3_free(aMap);
+  sqlite3_free(aStack);
+  sqlite3_free(aAdded);
   return rc;
 }
 
-/*
-** Open a ProllyDiffIter for the next commit in aWalk[iWalk]
-** compared against its first parent. Advances iWalk; sets
-** commitWalkDone=1 when the walk is exhausted. Returns SQLITE_OK
-** on success.
-*/
-static int openNextCommitPairIter(DiffTblCursor *pCur, sqlite3 *db,
-                                  const char *zTableName){
+/* Open a ProllyDiffIter for the next pair in aPairs[iPair] and
+** advance iPair. Sets pairsDone=1 when the list is exhausted. */
+static int openNextPairIter(DiffTblCursor *pCur, sqlite3 *db){
   ChunkStore *cs = doltliteGetChunkStore(db);
   ProllyCache *pCache = doltliteGetCache(db);
   int rc;
 
   if( !cs ) return SQLITE_OK;
 
-  for(;;){
-    DoltliteCommit commit, parentCommit;
-    ProllyHash curRoot, parentRoot;
-    ProllyHash firstParent;
-    u8 flags = 0;
-    int hasParent = 0;
+  if( pCur->iPair >= pCur->nPairs ){
+    pCur->pairsDone = 1;
+    return SQLITE_OK;
+  }
 
-    if( pCur->iWalk >= pCur->nWalk ){
-      pCur->commitWalkDone = 1;
-      return SQLITE_OK;
-    }
-
-    memset(&commit, 0, sizeof(commit));
-    memset(&parentCommit, 0, sizeof(parentCommit));
-    memset(&curRoot, 0, sizeof(curRoot));
-    memset(&parentRoot, 0, sizeof(parentRoot));
-    memset(&firstParent, 0, sizeof(firstParent));
-
-    rc = doltliteLoadCommit(db, &pCur->aWalk[pCur->iWalk], &commit);
-    if( rc!=SQLITE_OK ) return rc;
-
-    /* Load current commit's catalog and find this table's root. */
-    {
-      struct TableEntry *aTables = 0; int nTables = 0;
-      rc = doltliteLoadCatalog(db, &commit.catalogHash, &aTables, &nTables, 0);
-      if( rc!=SQLITE_OK ){
-        doltliteCommitClear(&commit);
-        return rc;
-      }
-      doltliteFindTableRootByName(aTables, nTables, zTableName, &curRoot, &flags);
-      sqlite3_free(aTables);
-    }
-
-    doltliteHashToHex(&pCur->aWalk[pCur->iWalk], pCur->row.zToCommit);
-    pCur->row.toDate = commit.timestamp;
-
-    /* First parent: aParents[0] for merge commits, parentHash for
-    ** legacy single-parent commits, none for root commits. */
-    if( commit.nParents>0 ){
-      memcpy(&firstParent, &commit.aParents[0], sizeof(ProllyHash));
-      hasParent = 1;
-    }else if( !prollyHashIsEmpty(&commit.parentHash) ){
-      memcpy(&firstParent, &commit.parentHash, sizeof(ProllyHash));
-      hasParent = 1;
-    }
-
-    pCur->iWalk++;
-
-    if( hasParent ){
-      rc = doltliteLoadCommit(db, &firstParent, &parentCommit);
-      if( rc!=SQLITE_OK ){
-        doltliteCommitClear(&commit);
-        return rc;
-      }
-
-      doltliteHashToHex(&firstParent, pCur->row.zFromCommit);
-      pCur->row.fromDate = parentCommit.timestamp;
-
-      {
-        struct TableEntry *aPT = 0; int nPT = 0;
-        rc = doltliteLoadCatalog(db, &parentCommit.catalogHash, &aPT, &nPT, 0);
-        if( rc!=SQLITE_OK ){
-          doltliteCommitClear(&parentCommit);
-          doltliteCommitClear(&commit);
-          return rc;
-        }
-        doltliteFindTableRootByName(aPT, nPT, zTableName, &parentRoot, 0);
-        sqlite3_free(aPT);
-      }
-      doltliteCommitClear(&parentCommit);
-
-      if( prollyHashCompare(&parentRoot, &curRoot)==0 ){
-        /* No diff for this table at this commit — skip and try
-        ** the next entry in the walk list. */
-        doltliteCommitClear(&commit);
-        continue;
-      }
-
-      rc = prollyDiffIterOpen(&pCur->diffIter, cs, pCache,
-                              &parentRoot, &curRoot, flags);
-      if( rc==SQLITE_OK ) pCur->diffIterOpen = 1;
-      doltliteCommitClear(&commit);
-      return rc;
-    }
-
-    /* Root commit (no parent) — diff against an empty root so
-    ** every row appears as added. */
-    if( !prollyHashIsEmpty(&curRoot) ){
-      ProllyHash emptyRoot;
-      memset(&emptyRoot, 0, sizeof(emptyRoot));
-      memset(pCur->row.zFromCommit, '0', PROLLY_HASH_SIZE*2);
-      pCur->row.zFromCommit[PROLLY_HASH_SIZE*2] = 0;
-      pCur->row.fromDate = 0;
-
-      rc = prollyDiffIterOpen(&pCur->diffIter, cs, pCache,
-                              &emptyRoot, &curRoot, flags);
-      if( rc==SQLITE_OK ) pCur->diffIterOpen = 1;
-      doltliteCommitClear(&commit);
-      return rc;
-    }
-
-    /* Root commit with no table — nothing to diff, skip. */
-    doltliteCommitClear(&commit);
-    continue;
+  {
+    DiffPair *p = &pCur->aPairs[pCur->iPair++];
+    u8 flags = p->fromFlags ? p->fromFlags : p->toFlags;
+    doltliteHashToHex(&p->fromHash, pCur->row.zFromCommit);
+    pCur->row.fromDate = p->fromDate;
+    memcpy(pCur->row.zToCommit, p->zToCommit, PROLLY_HASH_SIZE*2+1);
+    pCur->row.toDate = p->toDate;
+    rc = prollyDiffIterOpen(&pCur->diffIter, cs, pCache,
+                            &p->fromTblRoot, &p->toTblRoot, flags);
+    if( rc==SQLITE_OK ) pCur->diffIterOpen = 1;
+    return rc;
   }
 }
 
@@ -511,24 +553,16 @@ static int advanceToNextRow(DiffTblCursor *pCur, sqlite3 *db,
       }
       /* This iter is exhausted */
       closeDiffIter(pCur);
-
-      /* If the working-phase iter just finished, transition to the
-      ** commit walk by starting at HEAD. */
-      if( !pCur->workingPhaseDone ){
-        pCur->workingPhaseDone = 1;
-        rc = openNextCommitPairIter(pCur, db, zTableName);
-        if( rc!=SQLITE_OK ) return rc;
-        continue;
-      }
     }
 
-    /* Try the next commit pair from the BFS walk list. */
-    if( pCur->commitWalkDone ){
+    /* Open the next pair, if any. */
+    if( pCur->pairsDone ){
       return SQLITE_OK;
     }
 
-    rc = openNextCommitPairIter(pCur, db, zTableName);
+    rc = openNextPairIter(pCur, db);
     if( rc!=SQLITE_OK ) return rc;
+    (void)zTableName;
   }
 }
 
@@ -612,7 +646,7 @@ static int dtClose(sqlite3_vtab_cursor *cur){
   DiffTblCursor *c = (DiffTblCursor*)cur;
   closeDiffIter(c);
   clearAuditRow(&c->row);
-  sqlite3_free(c->aWalk);
+  sqlite3_free(c->aPairs);
   sqlite3_free(c);
   return SQLITE_OK;
 }
@@ -628,12 +662,11 @@ static int dtFilter(sqlite3_vtab_cursor *cur,
   /* Reset state */
   closeDiffIter(c);
   clearAuditRow(&c->row);
-  sqlite3_free(c->aWalk);
-  c->aWalk = 0;
-  c->nWalk = 0;
-  c->iWalk = 0;
-  c->commitWalkDone = 0;
-  c->workingPhaseDone = 0;
+  sqlite3_free(c->aPairs);
+  c->aPairs = 0;
+  c->nPairs = 0;
+  c->iPair = 0;
+  c->pairsDone = 0;
   c->hasRow = 0;
   c->iRowid = 0;
 
@@ -641,32 +674,20 @@ static int dtFilter(sqlite3_vtab_cursor *cur,
     ChunkStore *cs = doltliteGetChunkStore(db);
     void *pBt = doltliteGetBtShared(db);
     if( !cs || !pBt ){
-      c->commitWalkDone = 1;
-      c->workingPhaseDone = 1;
+      c->pairsDone = 1;
       return SQLITE_OK;
     }
   }
 
-  /* Pre-build the BFS walk list of all reachable commits. */
-  rc = buildWalkList(c, db);
+  /* Pre-build the (from,to) diff pairs from a Dolt-matching graph
+  ** walk. The first pair (when present) is the working-set diff
+  ** against HEAD; subsequent pairs are commits walked DFS-LIFO with
+  ** descendant attribution overwritten on each step. */
+  rc = buildDiffPairs(c, db, pVtab->zTableName);
   if( rc!=SQLITE_OK ) return rc;
-  if( c->nWalk==0 ){
-    c->commitWalkDone = 1;
-    c->workingPhaseDone = 1;
+  if( c->nPairs==0 ){
+    c->pairsDone = 1;
     return SQLITE_OK;
-  }
-
-  /* Phase 1: working-set diff vs HEAD. Emits rows with
-  ** to_commit="WORKING" first, matching Dolt's dolt_diff_<table>
-  ** behavior of including uncommitted changes at the head. If
-  ** there are no working changes, openWorkingDiffIter is a no-op
-  ** and we fall through to the commit walk. */
-  rc = openWorkingDiffIter(c, db, pVtab->zTableName);
-  if( rc!=SQLITE_OK ) return rc;
-  if( !c->diffIterOpen ){
-    c->workingPhaseDone = 1;
-    rc = openNextCommitPairIter(c, db, pVtab->zTableName);
-    if( rc!=SQLITE_OK ) return rc;
   }
 
   return advanceToNextRow(c, db, pVtab->zTableName);

--- a/test/vc_oracle_diff_test.sh
+++ b/test/vc_oracle_diff_test.sh
@@ -303,27 +303,71 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'feat1');
 "
 
-# Diff-after-merge: not oracle-tested. Both engines correctly walk
-# the merge commit graph and emit per-(commit, parent) diff rows,
-# but they DIFFER on which (commit, parent) edge they attribute
-# each row to. Concretely, for a merge of feature(adds row 2)
-# into main(adds row 3):
-#
-#   doltlite emits:
-#     row 3 added at main2 vs c1
-#     row 2 added at feat1 vs c1
-#     row 2 added at merge vs main2
-#
-#   Dolt emits:
-#     row 2 added at feat1 vs c1
-#     row 2 added at merge vs main2
-#     row 3 added at merge vs feat1   (NOT main2 vs c1)
-#
-# Both views are correct — row 3 IS added across both edges. The
-# walk attribution algorithm differs and matching it would require
-# either reverse-engineering Dolt's exact graph traversal or
-# changing doltlite's. Tracked as a separate follow-up; the
-# summary-level dolt_diff for the merge case (above) does match.
+echo "--- merges ---"
+
+# Simple merge: feature adds row 2, main adds row 3, then merge.
+# Dolt's algorithm (now mirrored by doltlite) attributes row 3 to
+# the merge-vs-feat1 edge — NOT to main2-vs-c1 — because the merge
+# absorbs main2's first-parent diff. See doltlite_diff_table.c
+# buildDiffPairs() and the dolt diff_table.go processCommit /
+# CommitItrForRoots LIFO walk for the canonical algorithm.
+oracle "diff_after_simple_merge" "
+$SEED
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat1');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES (3, 30);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main2');
+SELECT dolt_merge('feature');
+"
+
+# Merge with multiple commits between branch base and merge on the
+# main side. This exercises the more interesting case where main3
+# is the merge's first parent but main2 is reachable only via
+# main3's first-parent edge — main3 vs main2 IS emitted, but
+# main2 vs c1 is suppressed because the merge edge (merge,feat1)
+# already covers row 3.
+oracle "diff_after_merge_with_intermediate_commits" "
+$SEED
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat1');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES (3, 30);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main2');
+INSERT INTO t VALUES (4, 40);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main3');
+SELECT dolt_merge('feature');
+"
+
+# Merge that introduces no new content on the main side (feature is
+# a fast-forwardable change but we force a merge commit by having
+# main also commit). Verifies the per-edge row attribution still
+# matches when the merge's first-parent diff is empty.
+oracle "diff_after_merge_no_main_changes_after_branch" "
+$SEED
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat1');
+INSERT INTO t VALUES (3, 30);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat2');
+SELECT dolt_checkout('main');
+UPDATE t SET v = 11 WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main_update');
+SELECT dolt_merge('feature');
+"
 
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="


### PR DESCRIPTION
## Summary
- Replace the BFS commit walk + first-parent diff in `dolt_diff_<table>` with the same DFS-LIFO walk + descendant-attribution algorithm Dolt uses in `diff_table.go` (`processCommit` + `CommitItrForRoots`). For each visited commit, the diff is emitted from-current to whichever descendant last claimed it via `cmHashToTblInfo` (last writer wins, mirroring Dolt's overwrite-on-each-step behavior).
- Concretely: `aWalk[]` is replaced by `aPairs[]` (a pre-built list of (from, to) commit pairs). New `buildDiffPairs()` walks the graph DFS-LIFO, seeds `cmHashToTblInfo[HEAD] = {name:"WORKING", working catalog's table root}`, then for each popped commit looks up its descendant info, records a pair if the table roots differ, and overwrites `cmHashToTblInfo[parent]` for every parent. The working-set diff is no longer a separate phase — it falls out naturally as the first emitted pair when HEAD's table differs from the working catalog.
- Adds 3 merge oracle scenarios in `vc_oracle_diff_test.sh`: the reduced reproducer from #374, a variant with intermediate commits between branch base and merge on the main side (so `main3 vs main2` IS emitted while `main2 vs c1` is correctly suppressed), and a merge where the feature branch contributes multiple commits. The previous comment that documented the divergence as a known follow-up is removed.

After this change, doltlite produces byte-for-byte the same `dolt_diff_<table>` output as Dolt for merge histories. Both engines visit every commit reachable from HEAD and the per-edge row attribution is identical.

Closes #374.

## Test plan
- [x] Reproducer from #374 against `./doltlite`: matches Dolt's expected output exactly (`(merge,feat1) row 3`, `(feat1,c1) row 2`, `(c1,Init) row 1`, `(merge,main2) row 2`).
- [x] Variant with intermediate `main3` commit: matches Dolt's `(merge,main3) row 2`, `(merge,feat1) rows 3+4`, `(c1,Init) row 1`, `(feat1,c1) row 2`, `(main3,main2) row 4` — notably `(main2,c1)` is correctly suppressed.
- [x] `bash test/vc_oracle_diff_test.sh ./doltlite dolt` → 18 passed (15 existing + 3 new merge), 0 failed.
- [x] All 272 existing diff-using self-tests still pass: `doltlite_diff` (22), `doltlite_diff_alter` (15), `doltlite_unicode_blob` (46), `doltlite_advanced` (140), `doltlite_gc` (49).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)