### PR TITLE
Remove dead storage working-state code

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -959,14 +959,6 @@ int chunkStoreClose(ChunkStore *cs){
   return SQLITE_OK;
 }
 
-void chunkStoreGetStagedCatalog(ChunkStore *cs, ProllyHash *pStaged){
-  memcpy(pStaged, &cs->stagedCatalog, sizeof(ProllyHash));
-}
-
-void chunkStoreSetStagedCatalog(ChunkStore *cs, const ProllyHash *pStaged){
-  memcpy(&cs->stagedCatalog, pStaged, sizeof(ProllyHash));
-}
-
 const char *chunkStoreGetDefaultBranch(ChunkStore *cs){
   return cs->zDefaultBranch ? cs->zDefaultBranch : "main";
 }
@@ -1937,7 +1929,6 @@ void chunkStoreClearRefs(ChunkStore *cs){
   csFreeRemotes(cs);
   csFreeTracking(cs);
   memset(&cs->refsHash, 0, sizeof(cs->refsHash));
-  memset(&cs->stagedCatalog, 0, sizeof(cs->stagedCatalog));
 }
 
 int chunkStoreReloadRefs(ChunkStore *cs){
@@ -2043,10 +2034,6 @@ static int csReloadFromDisk(ChunkStore *cs){
   cs->pFile = tmp.pFile;
   cs->readOnly = tmp.readOnly;
   cs->refsHash = tmp.refsHash;
-  cs->stagedCatalog = tmp.stagedCatalog;
-  cs->isMerging = tmp.isMerging;
-  cs->mergeCommitHash = tmp.mergeCommitHash;
-  cs->conflictsCatalogHash = tmp.conflictsCatalogHash;
   cs->nChunks = tmp.nChunks;
   cs->iIndexOffset = tmp.iIndexOffset;
   cs->nIndexSize = tmp.nIndexSize;
@@ -2086,51 +2073,6 @@ static int csReloadFromDisk(ChunkStore *cs){
 
   csFreeReloadState(&saved);
   return SQLITE_OK;
-}
-
-int chunkStoreGetMergeState(
-  ChunkStore *cs,
-  u8 *pIsMerging,
-  ProllyHash *pMergeCommit,
-  ProllyHash *pConflictsCatalog
-){
-  if( pIsMerging ) *pIsMerging = cs->isMerging;
-  if( pMergeCommit ) memcpy(pMergeCommit, &cs->mergeCommitHash, sizeof(ProllyHash));
-  if( pConflictsCatalog ) memcpy(pConflictsCatalog, &cs->conflictsCatalogHash, sizeof(ProllyHash));
-  return SQLITE_OK;
-}
-
-void chunkStoreSetMergeState(
-  ChunkStore *cs,
-  u8 isMerging,
-  const ProllyHash *pMergeCommit,
-  const ProllyHash *pConflictsCatalog
-){
-  cs->isMerging = isMerging;
-  if( pMergeCommit ){
-    memcpy(&cs->mergeCommitHash, pMergeCommit, sizeof(ProllyHash));
-  }else{
-    memset(&cs->mergeCommitHash, 0, sizeof(ProllyHash));
-  }
-  if( pConflictsCatalog ){
-    memcpy(&cs->conflictsCatalogHash, pConflictsCatalog, sizeof(ProllyHash));
-  }else{
-    memset(&cs->conflictsCatalogHash, 0, sizeof(ProllyHash));
-  }
-}
-
-void chunkStoreClearMergeState(ChunkStore *cs){
-  cs->isMerging = 0;
-  memset(&cs->mergeCommitHash, 0, sizeof(ProllyHash));
-  memset(&cs->conflictsCatalogHash, 0, sizeof(ProllyHash));
-}
-
-void chunkStoreGetConflictsCatalog(ChunkStore *cs, ProllyHash *pHash){
-  memcpy(pHash, &cs->conflictsCatalogHash, sizeof(ProllyHash));
-}
-
-void chunkStoreSetConflictsCatalog(ChunkStore *cs, const ProllyHash *pHash){
-  memcpy(&cs->conflictsCatalogHash, pHash, sizeof(ProllyHash));
 }
 
 #endif /* DOLTLITE_PROLLY */

--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -106,12 +106,6 @@ struct ChunkStore {
   sqlite3_vfs *pVfs;
   ProllyHash refsHash;
 
-  /* These fields come from the per-branch WorkingSet, not from the manifest. */
-  ProllyHash stagedCatalog;
-  u8 isMerging;
-  ProllyHash mergeCommitHash;
-  ProllyHash conflictsCatalogHash;
-
   struct BranchRef {
     char *zName;
     ProllyHash commitHash;
@@ -195,9 +189,6 @@ int chunkStoreReadBranchWorkingCatalog(ChunkStore *cs, const char *zBranch,
                                        ProllyHash *pCatHash,
                                        ProllyHash *pCommitHash);
 
-void chunkStoreGetStagedCatalog(ChunkStore *cs, ProllyHash *pStaged);
-void chunkStoreSetStagedCatalog(ChunkStore *cs, const ProllyHash *pStaged);
-
 int chunkStoreReloadRefs(ChunkStore *cs);
 
 const char *chunkStoreGetDefaultBranch(ChunkStore *cs);
@@ -256,16 +247,5 @@ void chunkStoreClearRefs(ChunkStore *cs);
 const char *chunkStoreFilename(ChunkStore *cs);
 
 int chunkStoreRefreshIfChanged(ChunkStore *cs, int *pChanged);
-
-int chunkStoreGetMergeState(ChunkStore *cs, u8 *pIsMerging,
-                            ProllyHash *pMergeCommit,
-                            ProllyHash *pConflictsCatalog);
-void chunkStoreSetMergeState(ChunkStore *cs, u8 isMerging,
-                             const ProllyHash *pMergeCommit,
-                             const ProllyHash *pConflictsCatalog);
-void chunkStoreClearMergeState(ChunkStore *cs);
-
-void chunkStoreGetConflictsCatalog(ChunkStore *cs, ProllyHash *pHash);
-void chunkStoreSetConflictsCatalog(ChunkStore *cs, const ProllyHash *pHash);
 
 #endif /* SQLITE_CHUNK_STORE_H */

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -259,7 +259,6 @@ struct Btree {
     ProllyHash mergeCommitHash;
     ProllyHash conflictsCatalogHash;
   } *aSavepointTables;
-  int nSavepointTablesAlloc;
 
   /* Snapshot of aTables at BEGIN WRITE -- for full transaction rollback */
   struct TableEntry *aCommittedTables;
@@ -1352,7 +1351,6 @@ static int pushSavepoint(Btree *pBtree){
     if( !aNewT ) return SQLITE_NOMEM;
     pBtree->aSavepointTables = aNewT;
     pBtree->nSavepointAlloc = nNew;
-    pBtree->nSavepointTablesAlloc = nNew;
   }
 
   pState = &pBtree->aSavepointTables[pBtree->nSavepoint];
@@ -4698,11 +4696,11 @@ int doltliteCheckRepoGraphIntegrity(Btree *p, int mxErr, int *pnErr){
   for(i=0; rc==SQLITE_OK && i<pBt->store.nTracking; i++){
     rc = integrityCheckChunkGraph(&ctx, &pBt->store.aTracking[i].commitHash);
   }
-  if( rc==SQLITE_OK && pBt->store.isMerging ){
-    rc = integrityCheckChunkGraph(&ctx, &pBt->store.mergeCommitHash);
+  if( rc==SQLITE_OK && p->isMerging ){
+    rc = integrityCheckChunkGraph(&ctx, &p->mergeCommitHash);
   }
   if( rc==SQLITE_OK ){
-    rc = integrityCheckChunkGraph(&ctx, &pBt->store.conflictsCatalogHash);
+    rc = integrityCheckChunkGraph(&ctx, &p->conflictsCatalogHash);
   }
 
   prollyHashSetFree(&ctx.seen);

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -35,6 +35,7 @@
 **   ./doltlite_regression_test_c memory_chunk_lookup_corruption
 **   ./doltlite_regression_test_c prolly_diff_record_corruption
 **   ./doltlite_regression_test_c integrity_check_repo_state
+**   ./doltlite_regression_test_c integrity_check_session_merge_state
 **   ./doltlite_regression_test_c btree_commit_failure_transactional
 **   ./doltlite_regression_test_c mutmap_empty_reverse_iter
 */
@@ -1378,6 +1379,34 @@ static void run_integrity_check_repo_state(void){
   remove_db(dbpath);
 }
 
+static void run_integrity_check_session_merge_state(void){
+  sqlite3 *db = 0;
+  char dbpath[256];
+  ProllyHash badHash;
+  int nErr = 0;
+  int rc;
+
+  printf("=== Integrity Check Session Merge State Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_integrity_check_session_merge_state");
+  remove_db(dbpath);
+
+  check("open_db_session_merge_state", open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_repo_session_merge_state", execsql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'a');"
+    "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
+
+  memset(&badHash, 0x4c, sizeof(badHash));
+  doltliteSetSessionMergeState(db, 1, &badHash, &badHash);
+
+  rc = doltliteCheckRepoGraphIntegrity(db->aDb[0].pBt, 100, &nErr);
+  check("session_merge_state_integrity_call_succeeds", rc==SQLITE_OK);
+  check("integrity_check_reports_session_merge_state_corruption", nErr>0);
+
+  sqlite3_close(db);
+  remove_db(dbpath);
+}
+
 static void run_truncated_wal_is_rejected(void){
   sqlite3 *db = 0;
   ChunkStore cs;
@@ -1856,6 +1885,7 @@ static const RegressionCase aCases[] = {
   { "memory_chunk_lookup_corruption", "Memory Chunk Lookup Corruption Test", run_memory_chunk_lookup_corruption },
   { "prolly_diff_record_corruption", "Prolly Diff Record Corruption Test", run_prolly_diff_record_corruption },
   { "integrity_check_repo_state", "Integrity Check Repository State Test", run_integrity_check_repo_state },
+  { "integrity_check_session_merge_state", "Integrity Check Session Merge State Test", run_integrity_check_session_merge_state },
   { "btree_commit_failure_transactional", "Btree Commit Failure Transaction Test", run_btree_commit_failure_transactional },
   { "savepoint_restores_session_metadata", "Savepoint Restores Session Metadata Test", run_savepoint_restores_session_metadata },
   { "hard_reset_failure_restores_memory_state", "Hard Reset Failure Restores Memory State Test", run_hard_reset_failure_restores_memory_state },


### PR DESCRIPTION
## Summary
- remove dead chunk-store working-state fields and unused storage APIs
- make repo integrity checking walk live session merge/conflict metadata
- remove unused savepoint allocation bookkeeping and add a regression for session merge-state integrity

## Testing
- ./build/doltlite_regression_test_c integrity_check_session_merge_state
- ./build/doltlite_regression_test_c integrity_check_repo_state
- ./build/doltlite_regression_test_c savepoint_restores_session_metadata
- ./build/doltlite_regression_test_c btree_commit_failure_transactional