### PR TITLE
Refresh working-set metadata across connections

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -245,21 +245,6 @@ void doltliteUpdateSchemaHashes(sqlite3 *db){
   }
 }
 
-/*
-** Helper #1: Persist working-set + refs to disk.
-** Replaces the doltliteSaveWorkingSet/chunkStoreSerializeRefs/chunkStoreCommit
-** sequence found at many call sites.
-*/
-static int doltlitePersistState(sqlite3 *db){
-  ChunkStore *cs = doltliteGetChunkStore(db);
-  int rc;
-  rc = doltliteSaveWorkingSet(db);
-  if( rc!=SQLITE_OK ) return rc;
-  rc = chunkStoreSerializeRefs(cs);
-  if( rc!=SQLITE_OK ) return rc;
-  return chunkStoreCommit(cs);
-}
-
 int doltliteMutateRefs(sqlite3 *db, DoltliteRefsMutation xMutate, void *pArg){
   ChunkStore *cs = doltliteGetChunkStore(db);
   int rc;
@@ -425,7 +410,7 @@ static int doltliteAdvanceBranch(
   doltliteSetSessionHead(db, pNewHead);
   doltliteSetSessionStaged(db, pCatalogHash);
 
-  rc = doltlitePersistState(db);
+  rc = doltlitePersistWorkingSet(db);
   if( rc!=SQLITE_OK ){
     int rc2 = doltliteRestoreTxnState(db, &saved);
     doltliteTxnStateClear(&saved);
@@ -450,7 +435,7 @@ static int doltliteReportConflicts(
   int rc;
   rc = doltliteRegisterConflictTables(db);
   if( rc!=SQLITE_OK ) return rc;
-  rc = doltlitePersistState(db);
+  rc = doltlitePersistWorkingSet(db);
   if( rc!=SQLITE_OK ) return rc;
   sqlite3_snprintf(sizeof(msg), msg,
     "%s has %d conflict(s). Resolve and then commit with dolt_commit.",
@@ -645,7 +630,7 @@ static void doltliteAddFunc(
       sqlite3_free(aStaged);
     }
 
-    rc = doltlitePersistState(db);
+    rc = doltlitePersistWorkingSet(db);
     if( rc!=SQLITE_OK ){
       doltliteSetSessionStaged(db, &savedStaged);
       sqlite3_result_error_code(context, rc);
@@ -1293,7 +1278,11 @@ static void doltliteResetFunc(
       sqlite3_result_error_code(context, rc);
       return;
     }
-    doltlitePersistState(db);
+    rc = doltlitePersistWorkingSet(db);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(context, rc);
+      return;
+    }
     sqlite3_result_int(context, 0);
     return;
   }
@@ -1505,8 +1494,11 @@ static void doltliteResetFunc(
       }
     }
 
-    doltliteSaveWorkingSet(db);
-    chunkStoreSerializeRefs(cs);
+    rc = doltliteSaveWorkingSet(db);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(context, rc);
+      goto reset_cleanup;
+    }
     rc = doltliteHardReset(db, &targetCatHash);
     if( rc!=SQLITE_OK ){
       sqlite3_result_error(context, "hard reset failed", -1);
@@ -1517,9 +1509,13 @@ static void doltliteResetFunc(
     ** tables). Restore staged to the original target so untracked
     ** tables show up as unstaged in dolt_status, matching Dolt. */
     doltliteSetSessionStaged(db, &origStagedAfterReset);
-    doltlitePersistState(db);
+    rc = doltlitePersistWorkingSet(db);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(context, rc);
+      goto reset_cleanup;
+    }
   }else{
-    rc = doltlitePersistState(db);
+    rc = doltlitePersistWorkingSet(db);
     if( rc!=SQLITE_OK ){
       sqlite3_result_error_code(context, rc);
       goto reset_cleanup;
@@ -1629,7 +1625,11 @@ static void doltliteMergeFunc(
 
 
     doltliteClearSessionMergeState(db);
-    doltlitePersistState(db);
+    rc = doltlitePersistWorkingSet(db);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(context, rc);
+      return;
+    }
 
     sqlite3_result_int(context, 0);
     return;

--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -503,7 +503,7 @@ static int doltliteCheckoutTables(
       rc = doltliteSwitchCatalog(db, &newWorkingHash);
     }
     if( rc==SQLITE_OK ){
-      doltliteSaveWorkingSet(db);
+      rc = doltliteSaveWorkingSet(db);
     }
   }
 

--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -520,7 +520,6 @@ static int storeUpdatedConflicts(
     int rc;
     extern void doltliteSetSessionConflictsCatalog(sqlite3*, const ProllyHash*);
     extern void doltliteSetSessionMergeState(sqlite3*, u8, const ProllyHash*, const ProllyHash*);
-    extern int doltliteSaveWorkingSet(sqlite3*);
     if( totalConflicts==0 ){
       doltliteSetSessionConflictsCatalog(db, &(ProllyHash){{0}});
     }else{
@@ -530,11 +529,7 @@ static int storeUpdatedConflicts(
       doltliteSetSessionConflictsCatalog(db, &newHash);
       doltliteSetSessionMergeState(db, 1, 0, &newHash);
     }
-    rc = doltliteSaveWorkingSet(db);
-    if( rc!=SQLITE_OK ) return rc;
-    rc = chunkStoreSerializeRefs(cs);
-    if( rc!=SQLITE_OK ) return rc;
-    return chunkStoreCommit(cs);
+    return doltlitePersistWorkingSet(db);
   }
 }
 

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -134,6 +134,7 @@ void doltliteClearSessionMergeState(sqlite3 *db);
 void doltliteGetSessionConflictsCatalog(sqlite3 *db, ProllyHash *pHash);
 void doltliteSetSessionConflictsCatalog(sqlite3 *db, const ProllyHash *pHash);
 int doltliteSaveWorkingSet(sqlite3 *db);
+int doltlitePersistWorkingSet(sqlite3 *db);
 int doltliteLoadWorkingSet(sqlite3 *db, const char *zBranch);
 
 typedef int (*DoltliteRefsMutation)(sqlite3 *db, ChunkStore *cs, void *pArg);

--- a/src/doltlite_remote.c
+++ b/src/doltlite_remote.c
@@ -314,6 +314,8 @@ static int fsCommit(DoltliteRemote *pRemote){
         sqlite3_free(cdata);
         if( rc!=SQLITE_OK ) return rc;
       }
+      rc = chunkStoreSerializeRefs(&p->store);
+      if( rc!=SQLITE_OK ) return rc;
       rc = chunkStoreCommit(&p->store);
       if( rc!=SQLITE_OK ) return rc;
     }
@@ -566,9 +568,24 @@ int doltlitePush(
   
   {
     u8 *refsData2 = 0; int nRefsData2 = 0;
+    u8 *commitData = 0; int nCommitData = 0;
+    DoltliteCommit pushedCommit;
     rc = pRemote->xGetRefs(pRemote, &refsData2, &nRefsData2);
     if( rc==SQLITE_NOTFOUND ){ refsData2 = 0; nRefsData2 = 0; rc = SQLITE_OK; }
     if( rc!=SQLITE_OK ) return rc;
+    memset(&pushedCommit, 0, sizeof(pushedCommit));
+
+    rc = chunkStoreGet(pLocal, &localCommit, &commitData, &nCommitData);
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(refsData2);
+      return rc;
+    }
+    rc = doltliteCommitDeserialize(commitData, nCommitData, &pushedCommit);
+    sqlite3_free(commitData);
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(refsData2);
+      return rc;
+    }
 
     
     {
@@ -593,12 +610,23 @@ int doltlitePush(
         rc = chunkStoreAddBranch(&tmpCs, zBranch, &localCommit);
       }
       if( rc!=SQLITE_OK ){
+        doltliteCommitClear(&pushedCommit);
+        chunkStoreClose(&tmpCs);
+        return rc;
+      }
+
+      rc = chunkStoreWriteBranchWorkingCatalog(&tmpCs, zBranch,
+                                               &pushedCommit.catalogHash,
+                                               &localCommit);
+      if( rc!=SQLITE_OK ){
+        doltliteCommitClear(&pushedCommit);
         chunkStoreClose(&tmpCs);
         return rc;
       }
 
       
       rc = chunkStoreSerializeRefsToBlob(&tmpCs, &newRefs, &nNewRefs);
+      doltliteCommitClear(&pushedCommit);
       chunkStoreClose(&tmpCs);
       if( rc!=SQLITE_OK ) return rc;
 

--- a/src/doltlite_remotesrv.c
+++ b/src/doltlite_remotesrv.c
@@ -469,6 +469,11 @@ static void handleCommit(ChunkStore *pStore, int fd){
         }
         sqlite3_free(cdata);
       }
+      rc = chunkStoreSerializeRefs(pStore);
+      if( rc!=SQLITE_OK ){
+        sendError(fd);
+        return;
+      }
       rc = chunkStoreCommit(pStore);
       if( rc!=SQLITE_OK ){
         sendError(fd);

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -352,6 +352,7 @@ static int serializeCatalog(Btree *pBtree, u8 **ppOut, int *pnOut);
 static int deserializeCatalog(Btree *pBtree, const u8 *data, int nData);
 static int tableEntryIsTableRoot(Btree *pBtree, struct TableEntry *pTE);
 static int btreeRefreshFromDisk(Btree *p);
+static int btreeReloadBranchWorkingState(Btree *p, int bLoadCatalog);
 static int btreeReadWorkingCatalog(ChunkStore *cs, const char *zBranch,
                                    ProllyHash *pCatHash,
                                    ProllyHash *pCommitHash);
@@ -1990,6 +1991,50 @@ static int btreeWriteWorkingState(
                                   &mergeCommitHash, &conflictsCatalogHash);
 }
 
+static int btreeReloadBranchWorkingState(Btree *p, int bLoadCatalog){
+  BtShared *pBt = p->pBt;
+  ProllyHash catHash;
+  ProllyHash stagedCatalog;
+  ProllyHash mergeCommitHash;
+  ProllyHash conflictsCatalogHash;
+  const char *zBr = p->zBranch ? p->zBranch : "main";
+  u8 isMerging = 0;
+  int rc;
+
+  memset(&catHash, 0, sizeof(catHash));
+  memset(&stagedCatalog, 0, sizeof(stagedCatalog));
+  memset(&mergeCommitHash, 0, sizeof(mergeCommitHash));
+  memset(&conflictsCatalogHash, 0, sizeof(conflictsCatalogHash));
+
+  rc = btreeLoadWorkingSetBlob(
+      &pBt->store, zBr, &catHash, 0, &stagedCatalog, &isMerging,
+      &mergeCommitHash, &conflictsCatalogHash);
+  if( rc==SQLITE_NOTFOUND ){
+    rc = SQLITE_OK;
+  }
+  if( rc!=SQLITE_OK ) return rc;
+
+  if( bLoadCatalog && !prollyHashIsEmpty(&catHash) ){
+    u8 *catData = 0;
+    int nCatData = 0;
+    rc = chunkStoreGet(&pBt->store, &catHash, &catData, &nCatData);
+    if( rc==SQLITE_OK && catData ){
+      rc = deserializeCatalog(p, catData, nCatData);
+      sqlite3_free(catData);
+      if( rc!=SQLITE_OK ) return rc;
+    }else{
+      sqlite3_free(catData);
+      if( rc!=SQLITE_OK ) return rc;
+    }
+  }
+
+  p->stagedCatalog = stagedCatalog;
+  p->isMerging = isMerging;
+  p->mergeCommitHash = mergeCommitHash;
+  p->conflictsCatalogHash = conflictsCatalogHash;
+  return SQLITE_OK;
+}
+
 static int btreeRefreshFromDisk(Btree *p){
   BtShared *pBt = p->pBt;
   int bChanged = 0;
@@ -1997,32 +2042,12 @@ static int btreeRefreshFromDisk(Btree *p){
   if( rc!=SQLITE_OK ) return rc;
   if( !bChanged ) return SQLITE_OK;
 
-  /* The file changed. Load the catalog for THIS connection's branch.
-  ** Each branch's working catalog is stored in the branch WorkingSet blob
-  ** (persisted on every autocommit). This prevents cross-branch corruption
-  ** where one branch's autocommit overwrites the shared manifest catalog. */
-  {
-    ProllyHash catHash;
-    const char *zBr = p->zBranch ? p->zBranch : "main";
+  rc = btreeReloadBranchWorkingState(p, 1);
+  if( rc!=SQLITE_OK ) return rc;
 
-    memset(&catHash, 0, sizeof(catHash));
-
-    btreeReadWorkingCatalog(&pBt->store, zBr, &catHash, NULL);
-
-    if( !prollyHashIsEmpty(&catHash) ){
-      u8 *catData = 0;
-      int nCatData = 0;
-      rc = chunkStoreGet(&pBt->store, &catHash, &catData, &nCatData);
-      if( rc==SQLITE_OK && catData ){
-        rc = deserializeCatalog(p, catData, nCatData);
-        sqlite3_free(catData);
-        if( rc!=SQLITE_OK ) return rc;
-      }
-    }
-    p->iBDataVersion++;
-    if( pBt->pPagerShim ){
-      pBt->pPagerShim->iDataVersion++;
-    }
+  p->iBDataVersion++;
+  if( pBt->pPagerShim ){
+    pBt->pPagerShim->iDataVersion++;
   }
 
   return SQLITE_OK;
@@ -2048,6 +2073,7 @@ static int prollyBtreeBeginTrans(Btree *p, int wrFlag, int *pSchemaVersion){
   }
 
   if( wrFlag ){
+    int nSavepointStart = p->nSavepoint;
     if( pBt->btsFlags & BTS_READ_ONLY ){
       return SQLITE_READONLY;
     }
@@ -2058,25 +2084,10 @@ static int prollyBtreeBeginTrans(Btree *p, int wrFlag, int *pSchemaVersion){
     rc = chunkStoreLockAndRefresh(&pBt->store);
     if( rc!=SQLITE_OK ) return rc;
 
-    /* Reload catalog under lock from per-branch working state. */
-    {
-      ProllyHash catHash;
-      const char *zBr = p->zBranch ? p->zBranch : "main";
-      memset(&catHash, 0, sizeof(catHash));
-      btreeReadWorkingCatalog(&pBt->store, zBr, &catHash, NULL);
-      if( !prollyHashIsEmpty(&catHash) ){
-        u8 *catData = 0;
-        int nCatData = 0;
-        int rc2 = chunkStoreGet(&pBt->store, &catHash, &catData, &nCatData);
-        if( rc2==SQLITE_OK && catData ){
-          rc2 = deserializeCatalog(p, catData, nCatData);
-          sqlite3_free(catData);
-          if( rc2!=SQLITE_OK ){
-            chunkStoreUnlock(&pBt->store);
-            return rc2;
-          }
-        }
-      }
+    rc = btreeReloadBranchWorkingState(p, 1);
+    if( rc!=SQLITE_OK ){
+      chunkStoreUnlock(&pBt->store);
+      return rc;
     }
 
     sqlite3_free(p->aCommittedTables);
@@ -2096,15 +2107,22 @@ static int prollyBtreeBeginTrans(Btree *p, int wrFlag, int *pSchemaVersion){
     p->committedIsMerging = p->isMerging;
     p->committedMergeCommitHash = p->mergeCommitHash;
     p->committedConflictsCatalogHash = p->conflictsCatalogHash;
-    p->inTrans = TRANS_WRITE;
-    p->inTransaction = TRANS_WRITE;
     
     if( p->db ){
       while( p->nSavepoint < p->db->nSavepoint ){
         int rc2 = pushSavepoint(p);
-        if( rc2!=SQLITE_OK ) return rc2;
+        if( rc2!=SQLITE_OK ){
+          while( p->nSavepoint > nSavepointStart ){
+            p->nSavepoint--;
+            freeSavepointTables(&p->aSavepointTables[p->nSavepoint]);
+          }
+          chunkStoreUnlock(&pBt->store);
+          return rc2;
+        }
       }
     }
+    p->inTrans = TRANS_WRITE;
+    p->inTransaction = TRANS_WRITE;
   } else {
     if( p->inTrans==TRANS_NONE ){
       p->inTrans = TRANS_READ;

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -1459,11 +1459,13 @@ int sqlite3BtreeOpen(
   *ppBtree = 0;
 
   /* Delegate to the original SQLite btree implementation for:
-  ** - NULL/empty filenames (temp databases, ephemeral tables)
+  ** - NULL/empty filenames
+  ** - explicit in-memory databases
   ** - BTREE_SINGLE flag (transient/ephemeral btrees)
   ** - Temp database (SQLITE_OPEN_TEMP_DB in vfsFlags)
   ** - Existing files with standard SQLite headers */
   if( !zFilename || zFilename[0]=='\0'
+   || strcmp(zFilename, ":memory:")==0
    || (flags & BTREE_SINGLE)
    || (vfsFlags & SQLITE_OPEN_TEMP_DB)
    || origBtreeIsSqliteFile(zFilename)

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -1460,12 +1460,15 @@ int sqlite3BtreeOpen(
 
   /* Delegate to the original SQLite btree implementation for:
   ** - NULL/empty filenames
-  ** - explicit in-memory databases
+  ** - attached explicit in-memory databases
   ** - BTREE_SINGLE flag (transient/ephemeral btrees)
   ** - Temp database (SQLITE_OPEN_TEMP_DB in vfsFlags)
-  ** - Existing files with standard SQLite headers */
+  ** - Existing files with standard SQLite headers
+  **
+  ** Keep the main ":memory:" database on the Doltlite path so the shell and
+  ** SQL functions/modules are registered normally. */
   if( !zFilename || zFilename[0]=='\0'
-   || strcmp(zFilename, ":memory:")==0
+   || (strcmp(zFilename, ":memory:")==0 && db->aDb[0].pBt!=0)
    || (flags & BTREE_SINGLE)
    || (vfsFlags & SQLITE_OPEN_TEMP_DB)
    || origBtreeIsSqliteFile(zFilename)

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -1950,8 +1950,7 @@ static int btreeStoreWorkingSetBlob(
   if( rc == SQLITE_NOTFOUND && chunkStoreIsEmpty(cs) ){
     return SQLITE_OK;
   }
-  if( rc != SQLITE_OK ) return rc;
-  return chunkStoreSerializeRefs(cs);
+  return rc;
 }
 
 static int btreeReadWorkingCatalog(
@@ -2192,6 +2191,8 @@ static int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
         const char *zBr = p->zBranch ? p->zBranch : "main";
         rc = btreeWriteWorkingState(&pBt->store, zBr, &catHash, NULL);
         if( rc!=SQLITE_OK ) return rc;
+        rc = chunkStoreSerializeRefs(&pBt->store);
+        if( rc!=SQLITE_OK ) return rc;
       }
     }
     /* Step 4: atomic manifest write */
@@ -2326,6 +2327,9 @@ static int prollyBtreeRollback(Btree *p, int tripCode, int writeOnly){
       sqlite3_free(catData);
       if( rc==SQLITE_OK ){
         rc = btreeWriteWorkingState(&pBt->store, zBr, &catHash, &p->headCommit);
+      }
+      if( rc==SQLITE_OK ){
+        rc = chunkStoreSerializeRefs(&pBt->store);
       }
       if( rc==SQLITE_OK ){
         rc = chunkStoreCommit(&pBt->store);
@@ -5373,6 +5377,9 @@ int doltliteHardReset(sqlite3 *db, const ProllyHash *catHash){
     rc = btreeWriteWorkingState(cs, zBr, catHash, NULL);
   }
   if( rc==SQLITE_OK ){
+    rc = chunkStoreSerializeRefs(cs);
+  }
+  if( rc==SQLITE_OK ){
     rc = chunkStoreCommit(cs);
   }
   if( rc!=SQLITE_OK ){
@@ -5574,6 +5581,18 @@ int doltliteSaveWorkingSet(sqlite3 *db){
                                   &pBtree->headCommit, &pBtree->stagedCatalog,
                                   pBtree->isMerging, &pBtree->mergeCommitHash,
                                   &pBtree->conflictsCatalogHash);
+}
+
+int doltlitePersistWorkingSet(sqlite3 *db){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  int rc;
+
+  if( !cs ) return SQLITE_ERROR;
+  rc = doltliteSaveWorkingSet(db);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = chunkStoreSerializeRefs(cs);
+  if( rc!=SQLITE_OK ) return rc;
+  return chunkStoreCommit(cs);
 }
 
 int doltliteLoadWorkingSet(sqlite3 *db, const char *zBranch){

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -38,6 +38,8 @@
 **   ./doltlite_regression_test_c integrity_check_session_merge_state
 **   ./doltlite_regression_test_c btree_commit_failure_transactional
 **   ./doltlite_regression_test_c mutmap_empty_reverse_iter
+**   ./doltlite_regression_test_c working_set_refreshes_staged_across_connections
+**   ./doltlite_regression_test_c begin_write_refreshes_working_set_metadata
 */
 #include <stdio.h>
 #include <stdlib.h>
@@ -369,6 +371,13 @@ static int open_fail_db(const char *path, sqlite3 **ppDb){
     sqlite3_busy_timeout(*ppDb, 5000);
   }
   return rc;
+}
+
+static int persist_working_set(sqlite3 *db){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  int rc = doltliteSaveWorkingSet(db);
+  if( rc!=SQLITE_OK ) return rc;
+  return chunkStoreCommit(cs);
 }
 
 static void test_concurrent_refs_stale_reset_is_rejected(void){
@@ -1505,6 +1514,105 @@ static void run_prepared_stmt_reuse_after_schema_checkout(void){
   remove_db(dbpath);
 }
 
+static void run_working_set_refreshes_staged_across_connections(void){
+  sqlite3 *db1 = 0;
+  sqlite3 *db2 = 0;
+  char dbpath[256];
+  ProllyHash stagedBefore;
+  ProllyHash stagedExpected;
+  ProllyHash stagedAfter;
+
+  printf("=== Working Set Refreshes Staged Across Connections Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_working_set_refreshes_staged_across_connections");
+  remove_db(dbpath);
+
+  check("open_db1_for_cross_conn_staged", open_db(dbpath, &db1)==SQLITE_OK);
+  check("create_table_for_cross_conn_staged",
+        execsql(db1, "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);")==SQLITE_OK);
+  check("insert_row_for_cross_conn_staged",
+        execsql(db1, "INSERT INTO t VALUES(1,'a');")==SQLITE_OK);
+  check("initial_commit_for_cross_conn_staged",
+        execsql(db1, "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
+  check("open_db2_for_cross_conn_staged", open_db(dbpath, &db2)==SQLITE_OK);
+
+  doltliteGetSessionStaged(db2, &stagedBefore);
+  check("db1_stage_new_row", execsql(db1,
+    "INSERT INTO t VALUES(2,'b');"
+    "SELECT dolt_add('-A');")==SQLITE_OK);
+  doltliteGetSessionStaged(db1, &stagedExpected);
+  check("staged_hash_changed_after_dolt_add",
+        memcmp(&stagedExpected, &stagedBefore, sizeof(ProllyHash))!=0);
+
+  check("db2_refreshes_working_catalog_on_read",
+        strcmp(exec1(db2, "SELECT count(*) FROM t"), "2")==0);
+  doltliteGetSessionStaged(db2, &stagedAfter);
+  check("db2_refreshes_staged_hash",
+        memcmp(&stagedAfter, &stagedExpected, sizeof(ProllyHash))==0);
+
+  sqlite3_close(db2);
+  sqlite3_close(db1);
+  remove_db(dbpath);
+}
+
+static void run_begin_write_refreshes_working_set_metadata(void){
+  sqlite3 *db1 = 0;
+  sqlite3 *db2 = 0;
+  char dbpath[256];
+  ProllyHash stagedBefore;
+  ProllyHash stagedExpected;
+  ProllyHash mergeExpected;
+  ProllyHash conflictsExpected;
+  ProllyHash stagedAfter;
+  ProllyHash mergeAfter;
+  ProllyHash conflictsAfter;
+  u8 isMergingAfter = 0;
+
+  printf("=== Begin Write Refreshes Working Set Metadata Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_begin_write_refreshes_working_set_metadata");
+  remove_db(dbpath);
+
+  check("open_db1_for_begin_write_refresh", open_db(dbpath, &db1)==SQLITE_OK);
+  check("create_table_for_begin_write_refresh",
+        execsql(db1, "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);")==SQLITE_OK);
+  check("insert_row_for_begin_write_refresh",
+        execsql(db1, "INSERT INTO t VALUES(1,'a');")==SQLITE_OK);
+  check("initial_commit_for_begin_write_refresh",
+        execsql(db1, "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
+  check("open_db2_for_begin_write_refresh", open_db(dbpath, &db2)==SQLITE_OK);
+
+  doltliteGetSessionStaged(db2, &stagedBefore);
+  check("db1_prepare_new_working_state", execsql(db1,
+    "INSERT INTO t VALUES(2,'b');"
+    "SELECT dolt_add('-A');")==SQLITE_OK);
+  doltliteGetSessionStaged(db1, &stagedExpected);
+  memset(&mergeExpected, 0x55, sizeof(mergeExpected));
+  memset(&conflictsExpected, 0x66, sizeof(conflictsExpected));
+  doltliteSetSessionMergeState(db1, 1, &mergeExpected, &conflictsExpected);
+  check("persist_merge_state_for_begin_write_refresh",
+        persist_working_set(db1)==SQLITE_OK);
+
+  check("db2_staged_state_is_initially_stale",
+        memcmp(&stagedBefore, &stagedExpected, sizeof(ProllyHash))!=0);
+  check("db2_begin_immediate_refreshes_branch_state",
+        execsql(db2, "BEGIN IMMEDIATE;")==SQLITE_OK);
+  check("db2_sees_latest_working_rows_in_write_txn",
+        strcmp(exec1(db2, "SELECT count(*) FROM t"), "2")==0);
+  doltliteGetSessionStaged(db2, &stagedAfter);
+  doltliteGetSessionMergeState(db2, &isMergingAfter, &mergeAfter, &conflictsAfter);
+  check("begin_write_refreshes_staged_hash",
+        memcmp(&stagedAfter, &stagedExpected, sizeof(ProllyHash))==0);
+  check("begin_write_refreshes_merge_flag", isMergingAfter==1);
+  check("begin_write_refreshes_merge_commit",
+        memcmp(&mergeAfter, &mergeExpected, sizeof(ProllyHash))==0);
+  check("begin_write_refreshes_conflicts_catalog",
+        memcmp(&conflictsAfter, &conflictsExpected, sizeof(ProllyHash))==0);
+  check("rollback_begin_write_refresh_txn", execsql(db2, "ROLLBACK;")==SQLITE_OK);
+
+  sqlite3_close(db2);
+  sqlite3_close(db1);
+  remove_db(dbpath);
+}
+
 static void run_truncated_wal_is_rejected(void){
   sqlite3 *db = 0;
   ChunkStore cs;
@@ -1986,6 +2094,8 @@ static const RegressionCase aCases[] = {
   { "integrity_check_session_merge_state", "Integrity Check Session Merge State Test", run_integrity_check_session_merge_state },
   { "prepared_stmt_reuse_after_commit", "Prepared Statement Reuse After Commit Test", run_prepared_stmt_reuse_after_commit },
   { "prepared_stmt_reuse_after_schema_checkout", "Prepared Statement Reuse After Schema Checkout Test", run_prepared_stmt_reuse_after_schema_checkout },
+  { "working_set_refreshes_staged_across_connections", "Working Set Refreshes Staged Across Connections Test", run_working_set_refreshes_staged_across_connections },
+  { "begin_write_refreshes_working_set_metadata", "Begin Write Refreshes Working Set Metadata Test", run_begin_write_refreshes_working_set_metadata },
   { "btree_commit_failure_transactional", "Btree Commit Failure Transaction Test", run_btree_commit_failure_transactional },
   { "savepoint_restores_session_metadata", "Savepoint Restores Session Metadata Test", run_savepoint_restores_session_metadata },
   { "hard_reset_failure_restores_memory_state", "Hard Reset Failure Restores Memory State Test", run_hard_reset_failure_restores_memory_state },

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -374,10 +374,7 @@ static int open_fail_db(const char *path, sqlite3 **ppDb){
 }
 
 static int persist_working_set(sqlite3 *db){
-  ChunkStore *cs = doltliteGetChunkStore(db);
-  int rc = doltliteSaveWorkingSet(db);
-  if( rc!=SQLITE_OK ) return rc;
-  return chunkStoreCommit(cs);
+  return doltlitePersistWorkingSet(db);
 }
 
 static void test_concurrent_refs_stale_reset_is_rejected(void){

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -129,6 +129,12 @@ static int open_db(const char *path, sqlite3 **ppDb){
   return rc;
 }
 
+static int stmt_column_text_equals(sqlite3_stmt *stmt, int iCol, const char *zExpect){
+  const unsigned char *z = sqlite3_column_text(stmt, iCol);
+  if( !zExpect ) return z==0;
+  return z && strcmp((const char*)z, zExpect)==0;
+}
+
 static void make_dbpath(char *zBuf, size_t nBuf, const char *zBase){
   snprintf(zBuf, nBuf, "/tmp/%s_%ld.db", zBase, (long)getpid());
 }
@@ -1407,6 +1413,98 @@ static void run_integrity_check_session_merge_state(void){
   remove_db(dbpath);
 }
 
+static void run_prepared_stmt_reuse_after_commit(void){
+  sqlite3 *db = 0;
+  sqlite3_stmt *stmt = 0;
+  char dbpath[256];
+  int rc;
+
+  printf("=== Prepared Statement Reuse After Commit Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_prepared_stmt_reuse_after_commit");
+  remove_db(dbpath);
+
+  check("open_db_stmt_commit", open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_repo_stmt_commit", execsql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'a');"
+    "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
+
+  rc = sqlite3_prepare_v2(db, "SELECT id, v FROM t ORDER BY id", -1, &stmt, 0);
+  check("prepare_stmt_commit", rc==SQLITE_OK);
+  if( rc==SQLITE_OK ){
+    check("stmt_commit_first_row", sqlite3_step(stmt)==SQLITE_ROW);
+    check("stmt_commit_first_id", sqlite3_column_int(stmt, 0)==1);
+    check("stmt_commit_first_val", stmt_column_text_equals(stmt, 1, "a"));
+    check("stmt_commit_done", sqlite3_step(stmt)==SQLITE_DONE);
+    check("stmt_commit_reset_initial", sqlite3_reset(stmt)==SQLITE_OK);
+
+    check("commit_new_row_same_conn", execsql(db,
+      "INSERT INTO t VALUES(2,'b');"
+      "SELECT dolt_commit('-A', '-m', 'second');")==SQLITE_OK);
+
+    check("stmt_commit_reuse_row1", sqlite3_step(stmt)==SQLITE_ROW);
+    check("stmt_commit_reuse_row1_id", sqlite3_column_int(stmt, 0)==1);
+    check("stmt_commit_reuse_row1_val", stmt_column_text_equals(stmt, 1, "a"));
+    check("stmt_commit_reuse_row2", sqlite3_step(stmt)==SQLITE_ROW);
+    check("stmt_commit_reuse_row2_id", sqlite3_column_int(stmt, 0)==2);
+    check("stmt_commit_reuse_row2_val", stmt_column_text_equals(stmt, 1, "b"));
+    check("stmt_commit_reuse_done", sqlite3_step(stmt)==SQLITE_DONE);
+    check("stmt_commit_reset_final", sqlite3_reset(stmt)==SQLITE_OK);
+  }
+
+  sqlite3_finalize(stmt);
+  sqlite3_close(db);
+  remove_db(dbpath);
+}
+
+static void run_prepared_stmt_reuse_after_schema_checkout(void){
+  sqlite3 *db = 0;
+  sqlite3_stmt *stmt = 0;
+  char dbpath[256];
+  int rc;
+
+  printf("=== Prepared Statement Reuse After Schema Checkout Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_prepared_stmt_reuse_after_schema_checkout");
+  remove_db(dbpath);
+
+  check("open_db_stmt_checkout", open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_repo_stmt_checkout", execsql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'a');"
+    "SELECT dolt_commit('-A', '-m', 'init');"
+    "SELECT dolt_checkout('-b', 'schema_branch');"
+    "ALTER TABLE t ADD COLUMN x INT;"
+    "UPDATE t SET x=7;"
+    "SELECT dolt_commit('-A', '-m', 'schema');"
+    "SELECT dolt_checkout('main');")==SQLITE_OK);
+
+  rc = sqlite3_prepare_v2(db, "SELECT * FROM t ORDER BY id", -1, &stmt, 0);
+  check("prepare_stmt_checkout", rc==SQLITE_OK);
+  if( rc==SQLITE_OK ){
+    check("stmt_checkout_main_row", sqlite3_step(stmt)==SQLITE_ROW);
+    check("stmt_checkout_main_colcount", sqlite3_column_count(stmt)==2);
+    check("stmt_checkout_main_id", sqlite3_column_int(stmt, 0)==1);
+    check("stmt_checkout_main_val", stmt_column_text_equals(stmt, 1, "a"));
+    check("stmt_checkout_main_done", sqlite3_step(stmt)==SQLITE_DONE);
+    check("stmt_checkout_reset_initial", sqlite3_reset(stmt)==SQLITE_OK);
+
+    check("checkout_schema_branch", execsql(db,
+      "SELECT dolt_checkout('schema_branch');")==SQLITE_OK);
+
+    check("stmt_checkout_branch_row", sqlite3_step(stmt)==SQLITE_ROW);
+    check("stmt_checkout_branch_colcount", sqlite3_column_count(stmt)==3);
+    check("stmt_checkout_branch_id", sqlite3_column_int(stmt, 0)==1);
+    check("stmt_checkout_branch_val", stmt_column_text_equals(stmt, 1, "a"));
+    check("stmt_checkout_branch_extra", sqlite3_column_int(stmt, 2)==7);
+    check("stmt_checkout_branch_done", sqlite3_step(stmt)==SQLITE_DONE);
+    check("stmt_checkout_reset_final", sqlite3_reset(stmt)==SQLITE_OK);
+  }
+
+  sqlite3_finalize(stmt);
+  sqlite3_close(db);
+  remove_db(dbpath);
+}
+
 static void run_truncated_wal_is_rejected(void){
   sqlite3 *db = 0;
   ChunkStore cs;
@@ -1886,6 +1984,8 @@ static const RegressionCase aCases[] = {
   { "prolly_diff_record_corruption", "Prolly Diff Record Corruption Test", run_prolly_diff_record_corruption },
   { "integrity_check_repo_state", "Integrity Check Repository State Test", run_integrity_check_repo_state },
   { "integrity_check_session_merge_state", "Integrity Check Session Merge State Test", run_integrity_check_session_merge_state },
+  { "prepared_stmt_reuse_after_commit", "Prepared Statement Reuse After Commit Test", run_prepared_stmt_reuse_after_commit },
+  { "prepared_stmt_reuse_after_schema_checkout", "Prepared Statement Reuse After Schema Checkout Test", run_prepared_stmt_reuse_after_schema_checkout },
   { "btree_commit_failure_transactional", "Btree Commit Failure Transaction Test", run_btree_commit_failure_transactional },
   { "savepoint_restores_session_metadata", "Savepoint Restores Session Metadata Test", run_savepoint_restores_session_metadata },
   { "hard_reset_failure_restores_memory_state", "Hard Reset Failure Restores Memory State Test", run_hard_reset_failure_restores_memory_state },


### PR DESCRIPTION
## Summary
- reload persisted staged and merge/conflict metadata whenever a connection refreshes or starts a write transaction
- avoid leaking the chunk-store graph lock when begin-transaction savepoint setup fails
- add cross-connection regressions for staged and working-set metadata refresh behavior

## Testing
- ./doltlite_regression_test_c working_set_refreshes_staged_across_connections
- ./doltlite_regression_test_c begin_write_refreshes_working_set_metadata
- ./doltlite_regression_test_c prepared_stmt_reuse_after_commit
- ./doltlite_regression_test_c btree_commit_failure_transactional