### PR TITLE
dolt_conflicts_<table>: project user columns to match Dolt schema

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,6 +111,10 @@ jobs:
       run: cd build && bash ../test/vc_oracle_conflicts_resolve_test.sh ./doltlite dolt
       timeout-minutes: 5
 
+    - name: Version control oracle tests (dolt_conflicts_<table>)
+      run: cd build && bash ../test/vc_oracle_conflicts_table_test.sh ./doltlite dolt
+      timeout-minutes: 5
+
     - name: Version control oracle tests (active_branch)
       run: cd build && bash ../test/vc_oracle_active_branch_test.sh ./doltlite dolt
       timeout-minutes: 5

--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -777,7 +777,8 @@ typedef struct CfRowVtab CfRowVtab;
 struct CfRowVtab {
   sqlite3_vtab base;
   sqlite3 *db;
-  char *zTableName;    
+  char *zTableName;
+  DoltliteColInfo cols;
 };
 
 typedef struct CfRowCur CfRowCur;
@@ -789,32 +790,84 @@ struct CfRowCur {
   int iRow;            
 };
 
+/* Build a dolt-conformant dolt_conflicts_<table> schema by projecting
+** every user column of `t` under three prefixes (base_, our_, their_),
+** plus the standard metadata columns Dolt emits: from_root_ish,
+** our_diff_type, their_diff_type, dolt_conflict_id. */
+static char *cfrBuildSchema(const DoltliteColInfo *ci){
+  sqlite3_str *pStr = sqlite3_str_new(0);
+  int i;
+  char *z;
+  if( !pStr ) return 0;
+  sqlite3_str_appendall(pStr, "CREATE TABLE x(from_root_ish TEXT");
+  /* base_* */
+  for(i=0; i<ci->nCol; i++){
+    sqlite3_str_appendf(pStr, ", \"base_%w\"", ci->azName[i]);
+  }
+  /* our_* + our_diff_type */
+  for(i=0; i<ci->nCol; i++){
+    sqlite3_str_appendf(pStr, ", \"our_%w\"", ci->azName[i]);
+  }
+  sqlite3_str_appendall(pStr, ", our_diff_type TEXT");
+  /* their_* + their_diff_type */
+  for(i=0; i<ci->nCol; i++){
+    sqlite3_str_appendf(pStr, ", \"their_%w\"", ci->azName[i]);
+  }
+  sqlite3_str_appendall(pStr, ", their_diff_type TEXT");
+  sqlite3_str_appendall(pStr, ", dolt_conflict_id TEXT");
+  sqlite3_str_appendall(pStr, ")");
+  z = sqlite3_str_finish(pStr);
+  return z;
+}
+
 static int cfrConnect(sqlite3 *db, void *pAux, int argc,
     const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){
-  CfRowVtab *v; int rc;
+  CfRowVtab *v;
+  int rc;
   const char *zModuleName;
-  (void)pAux;(void)pzErr;
-
-  rc = sqlite3_declare_vtab(db,
-    "CREATE TABLE x(base_rowid INTEGER, base_value BLOB,"
-    " our_rowid INTEGER, our_value BLOB,"
-    " their_rowid INTEGER, their_value BLOB)");
-  if(rc!=SQLITE_OK) return rc;
+  char *zSchema;
+  (void)pAux;
 
   v = sqlite3_malloc(sizeof(*v));
   if(!v) return SQLITE_NOMEM;
   memset(v,0,sizeof(*v));
   v->db = db;
 
-  
-  zModuleName = argv[0]; 
+  zModuleName = argv[0];
   if( zModuleName && strncmp(zModuleName, "dolt_conflicts_", 15)==0 ){
     v->zTableName = sqlite3_mprintf("%s", zModuleName + 15);
   }else if( argc > 3 ){
-    
     v->zTableName = sqlite3_mprintf("%s", argv[3]);
   }else{
     v->zTableName = sqlite3_mprintf("");
+  }
+  if( !v->zTableName ){
+    sqlite3_free(v);
+    return SQLITE_NOMEM;
+  }
+
+  rc = doltliteLoadUserTableColumns(db, v->zTableName, &v->cols, pzErr);
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(v->zTableName);
+    doltliteFreeColInfo(&v->cols);
+    sqlite3_free(v);
+    return rc;
+  }
+
+  zSchema = cfrBuildSchema(&v->cols);
+  if( !zSchema ){
+    sqlite3_free(v->zTableName);
+    doltliteFreeColInfo(&v->cols);
+    sqlite3_free(v);
+    return SQLITE_NOMEM;
+  }
+  rc = sqlite3_declare_vtab(db, zSchema);
+  sqlite3_free(zSchema);
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(v->zTableName);
+    doltliteFreeColInfo(&v->cols);
+    sqlite3_free(v);
+    return rc;
   }
 
   *ppVtab = &v->base;
@@ -824,6 +877,7 @@ static int cfrConnect(sqlite3 *db, void *pAux, int argc,
 static int cfrDisconnect(sqlite3_vtab *pVtab){
   CfRowVtab *v = (CfRowVtab*)pVtab;
   sqlite3_free(v->zTableName);
+  doltliteFreeColInfo(&v->cols);
   sqlite3_free(v);
   return SQLITE_OK;
 }
@@ -877,32 +931,105 @@ static int cfrEof(sqlite3_vtab_cursor *cur){
   return c->iRow >= c->aTables[c->iTableIdx].nConflicts;
 }
 
+/* Emit one projected column from a record body. If iPkCol>=0 and
+** iUserCol==iPkCol, the PK value comes from intKey (rowid-aliased
+** INTEGER PRIMARY KEY case) rather than the record body. */
+static void cfrEmitRecordCol(
+  sqlite3_context *ctx,
+  const u8 *pRec, int nRec,
+  int iUserCol,
+  int iPkCol,
+  i64 intKey
+){
+  if( !pRec || nRec<=0 ){
+    sqlite3_result_null(ctx);
+    return;
+  }
+  if( iUserCol==iPkCol ){
+    sqlite3_result_int64(ctx, intKey);
+    return;
+  }
+  {
+    DoltliteRecordInfo ri;
+    doltliteParseRecord(pRec, nRec, &ri);
+    if( iUserCol >= ri.nField ){
+      sqlite3_result_null(ctx);
+      return;
+    }
+    doltliteResultField(ctx, pRec, nRec, ri.aType[iUserCol], ri.aOffset[iUserCol]);
+  }
+}
+
+/* Classify a conflict row on one side as added/modified/removed
+** relative to its base. Dolt uses "added" if the base is missing,
+** "removed" if the side is missing, otherwise "modified". */
+static const char *cfrDiffType(const u8 *pBase, int nBase,
+                               const u8 *pSide, int nSide){
+  int baseHas = (pBase && nBase>0);
+  int sideHas = (pSide && nSide>0);
+  if( !sideHas ) return "removed";
+  if( !baseHas ) return "added";
+  return "modified";
+}
+
 static int cfrColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
   CfRowCur *c = (CfRowCur*)cur;
+  CfRowVtab *v = (CfRowVtab*)cur->pVtab;
   struct ConflictRow *cr;
+  int nUserCols;
+  int colBaseStart, colOurStart, colOurDiff;
+  int colTheirStart, colTheirDiff, colConflictId;
+
   if( c->iTableIdx < 0 ) return SQLITE_OK;
   if( c->iRow >= c->aTables[c->iTableIdx].nConflicts ) return SQLITE_OK;
   cr = &c->aTables[c->iTableIdx].aRows[c->iRow];
 
-  switch(col){
-    case 0: 
-      sqlite3_result_int64(ctx, cr->intKey);
-      break;
-    case 1: 
-      doltliteResultRecord(ctx, cr->pBaseVal, cr->nBaseVal);
-      break;
-    case 2: 
-      sqlite3_result_int64(ctx, cr->intKey);
-      break;
-    case 3: 
-      doltliteResultRecord(ctx, cr->pOurVal, cr->nOurVal);
-      break;
-    case 4: 
-      sqlite3_result_int64(ctx, cr->intKey);
-      break;
-    case 5: 
-      doltliteResultRecord(ctx, cr->pTheirVal, cr->nTheirVal);
-      break;
+  /* Schema layout:
+  **   col 0                     : from_root_ish
+  **   col 1..nUserCols          : base_<col>
+  **   col nUserCols+1..2*nUserCols : our_<col>
+  **   col 2*nUserCols+1         : our_diff_type
+  **   col 2*nUserCols+2..3*nUserCols+1 : their_<col>
+  **   col 3*nUserCols+2         : their_diff_type
+  **   col 3*nUserCols+3         : dolt_conflict_id
+  */
+  nUserCols = v->cols.nCol;
+  colBaseStart  = 1;
+  colOurStart   = 1 + nUserCols;
+  colOurDiff    = 1 + 2*nUserCols;
+  colTheirStart = 2 + 2*nUserCols;
+  colTheirDiff  = 2 + 3*nUserCols;
+  colConflictId = 3 + 3*nUserCols;
+
+  if( col==0 ){
+    /* from_root_ish: doltlite doesn't track this per-conflict. Emit
+    ** NULL — oracle tests should not compare this column. */
+    sqlite3_result_null(ctx);
+  }else if( col>=colBaseStart && col<colOurStart ){
+    cfrEmitRecordCol(ctx, cr->pBaseVal, cr->nBaseVal,
+                     col - colBaseStart, v->cols.iPkCol, cr->intKey);
+  }else if( col>=colOurStart && col<colOurDiff ){
+    cfrEmitRecordCol(ctx, cr->pOurVal, cr->nOurVal,
+                     col - colOurStart, v->cols.iPkCol, cr->intKey);
+  }else if( col==colOurDiff ){
+    sqlite3_result_text(ctx,
+      cfrDiffType(cr->pBaseVal, cr->nBaseVal, cr->pOurVal, cr->nOurVal),
+      -1, SQLITE_STATIC);
+  }else if( col>=colTheirStart && col<colTheirDiff ){
+    cfrEmitRecordCol(ctx, cr->pTheirVal, cr->nTheirVal,
+                     col - colTheirStart, v->cols.iPkCol, cr->intKey);
+  }else if( col==colTheirDiff ){
+    sqlite3_result_text(ctx,
+      cfrDiffType(cr->pBaseVal, cr->nBaseVal, cr->pTheirVal, cr->nTheirVal),
+      -1, SQLITE_STATIC);
+  }else if( col==colConflictId ){
+    /* Stable synthetic id: intKey + iRow. Oracle tests should not
+    ** compare this column since Dolt uses a different scheme. */
+    char buf[64];
+    sqlite3_snprintf(sizeof(buf), buf, "%lld:%d", cr->intKey, c->iRow);
+    sqlite3_result_text(ctx, buf, -1, SQLITE_TRANSIENT);
+  }else{
+    sqlite3_result_null(ctx);
   }
   return SQLITE_OK;
 }

--- a/test/doltlite_conflict_rows.sh
+++ b/test/doltlite_conflict_rows.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Tests for per-row conflict resolution via dolt_conflicts_<tablename>.
-# Uses DELETE FROM dolt_conflicts_<table> WHERE base_rowid=N to resolve
+# Uses DELETE FROM dolt_conflicts_<table> WHERE base_id=N to resolve
 # individual conflict rows.
 #
 DOLTLITE=./doltlite
@@ -38,12 +38,13 @@ DB=/tmp/test_cfrow_view_$$.db
 setup_conflict "$DB"
 
 run_test "view_count" "SELECT count(*) FROM dolt_conflicts_t;" "1" "$DB"
-run_test "view_base_rowid" "SELECT base_rowid FROM dolt_conflicts_t;" "1" "$DB"
-run_test "view_our_rowid" "SELECT our_rowid FROM dolt_conflicts_t;" "1" "$DB"
-run_test "view_their_rowid" "SELECT their_rowid FROM dolt_conflicts_t;" "1" "$DB"
-# Values are now decoded as text (pipe-separated fields)
-run_test_match "view_base_val" "SELECT typeof(base_value) FROM dolt_conflicts_t;" "text|null" "$DB"
-run_test_match "view_their_val" "SELECT typeof(their_value) FROM dolt_conflicts_t;" "text" "$DB"
+run_test "view_base_id" "SELECT base_id FROM dolt_conflicts_t;" "1" "$DB"
+run_test "view_our_id" "SELECT our_id FROM dolt_conflicts_t;" "1" "$DB"
+run_test "view_their_id" "SELECT their_id FROM dolt_conflicts_t;" "1" "$DB"
+# User columns are projected individually now (Dolt-compatible schema).
+# The v column is declared TEXT so typeof(base_v) is "text".
+run_test_match "view_base_val" "SELECT typeof(base_v) FROM dolt_conflicts_t;" "text|null" "$DB"
+run_test_match "view_their_val" "SELECT typeof(their_v) FROM dolt_conflicts_t;" "text" "$DB"
 
 rm -f "$DB"
 
@@ -54,7 +55,7 @@ rm -f "$DB"
 DB=/tmp/test_cfrow_del_$$.db
 setup_conflict "$DB"
 
-echo "DELETE FROM dolt_conflicts_t WHERE base_rowid=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
+echo "DELETE FROM dolt_conflicts_t WHERE base_id=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 # After deleting all conflicts, the conflict table module is removed
 run_test "del_summary_cleared" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
@@ -103,10 +104,10 @@ setup_conflict "$DB"
 # Reopen — conflicts visible
 run_test "persist_summary" "SELECT count(*) FROM dolt_conflicts;" "1" "$DB"
 run_test "persist_rows" "SELECT count(*) FROM dolt_conflicts_t;" "1" "$DB"
-run_test "persist_rowid" "SELECT base_rowid FROM dolt_conflicts_t;" "1" "$DB"
+run_test "persist_rowid" "SELECT base_id FROM dolt_conflicts_t;" "1" "$DB"
 
 # Delete via new session
-echo "DELETE FROM dolt_conflicts_t WHERE base_rowid=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
+echo "DELETE FROM dolt_conflicts_t WHERE base_id=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 # Verify cleared after another reopen
 run_test "persist_after_del" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
@@ -120,10 +121,10 @@ rm -f "$DB"
 DB=/tmp/test_cfrow_noop_$$.db
 setup_conflict "$DB"
 
-echo "DELETE FROM dolt_conflicts_t WHERE base_rowid=999;" | $DOLTLITE "$DB" > /dev/null 2>&1
+echo "DELETE FROM dolt_conflicts_t WHERE base_id=999;" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "noop_still_there" "SELECT count(*) FROM dolt_conflicts_t;" "1" "$DB"
-run_test "noop_rowid" "SELECT base_rowid FROM dolt_conflicts_t;" "1" "$DB"
+run_test "noop_rowid" "SELECT base_id FROM dolt_conflicts_t;" "1" "$DB"
 
 rm -f "$DB"
 
@@ -146,7 +147,7 @@ SELECT dolt_cherry_pick((SELECT hash FROM dolt_branches WHERE name='feat'));" | 
 
 run_test "cp_has_conflict" "SELECT count(*) FROM dolt_conflicts_t;" "1" "$DB"
 
-echo "DELETE FROM dolt_conflicts_t WHERE base_rowid=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
+echo "DELETE FROM dolt_conflicts_t WHERE base_id=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "cp_resolved" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
 run_test "cp_val" "SELECT v FROM t WHERE id=1;" "main_val" "$DB"
 
@@ -169,9 +170,9 @@ UPDATE t SET v='main_val' WHERE id=1000;
 SELECT dolt_commit('-A','-m','main');
 SELECT dolt_merge('hf');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-run_test "bigid_rowid" "SELECT base_rowid FROM dolt_conflicts_t;" "1000" "$DB"
+run_test "bigid_rowid" "SELECT base_id FROM dolt_conflicts_t;" "1000" "$DB"
 
-echo "DELETE FROM dolt_conflicts_t WHERE base_rowid=1000;" | $DOLTLITE "$DB" > /dev/null 2>&1
+echo "DELETE FROM dolt_conflicts_t WHERE base_id=1000;" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "bigid_cleared" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
 run_test "bigid_val" "SELECT v FROM t WHERE id=1000;" "main_val" "$DB"
 
@@ -184,7 +185,7 @@ rm -f "$DB"
 DB=/tmp/test_cfrow_fullflow_$$.db
 setup_conflict "$DB"
 
-echo "DELETE FROM dolt_conflicts_t WHERE base_rowid=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
+echo "DELETE FROM dolt_conflicts_t WHERE base_id=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 # Conflicts resolved but merge not committed yet — user must commit
 run_test "flow_val" "SELECT v FROM t WHERE id=1;" "main_val" "$DB"

--- a/test/doltlite_conflicts.sh
+++ b/test/doltlite_conflicts.sh
@@ -99,10 +99,10 @@ echo "SELECT dolt_checkout('main'); UPDATE t SET name='CHARLIE' WHERE id=1; SELE
 run_test_match "real_conflict" "SELECT dolt_merge('c');" "conflict" "$DB7"
 run_test "real_conflict_count" "SELECT num_conflicts FROM dolt_conflicts;" "1" "$DB7"
 
-# Conflict values are now decoded text, not raw binary
-run_test_match "conflict_base_decoded" "SELECT base_value FROM dolt_conflicts_t;" "alice" "$DB7"
-run_test_match "conflict_our_decoded" "SELECT our_value FROM dolt_conflicts_t;" "CHARLIE" "$DB7"
-run_test_match "conflict_their_decoded" "SELECT their_value FROM dolt_conflicts_t;" "BOB" "$DB7"
+# User columns are now projected individually (Dolt-compatible schema).
+run_test_match "conflict_base_decoded" "SELECT base_name FROM dolt_conflicts_t;" "alice" "$DB7"
+run_test_match "conflict_our_decoded" "SELECT our_name FROM dolt_conflicts_t;" "CHARLIE" "$DB7"
+run_test_match "conflict_their_decoded" "SELECT their_name FROM dolt_conflicts_t;" "BOB" "$DB7"
 
 # --- Multiple conflicting rows in one table ---
 DB8=/tmp/test_conflicts8_$$.db; rm -f "$DB8"
@@ -113,9 +113,9 @@ echo "SELECT dolt_checkout('main'); UPDATE t SET name='a2' WHERE id=1; UPDATE t 
 run_test_match "multi_row_conflict" "SELECT dolt_merge('other');" "3 conflict" "$DB8"
 run_test "multi_row_conflict_count" "SELECT num_conflicts FROM dolt_conflicts;" "3" "$DB8"
 run_test "multi_row_all_rows" "SELECT count(*) FROM dolt_conflicts_t;" "3" "$DB8"
-run_test_match "multi_row_has_row1" "SELECT their_value FROM dolt_conflicts_t WHERE base_rowid=1;" "A" "$DB8"
-run_test_match "multi_row_has_row2" "SELECT their_value FROM dolt_conflicts_t WHERE base_rowid=2;" "B" "$DB8"
-run_test_match "multi_row_has_row3" "SELECT their_value FROM dolt_conflicts_t WHERE base_rowid=3;" "C" "$DB8"
+run_test_match "multi_row_has_row1" "SELECT their_name FROM dolt_conflicts_t WHERE base_id=1;" "A" "$DB8"
+run_test_match "multi_row_has_row2" "SELECT their_name FROM dolt_conflicts_t WHERE base_id=2;" "B" "$DB8"
+run_test_match "multi_row_has_row3" "SELECT their_name FROM dolt_conflicts_t WHERE base_id=3;" "C" "$DB8"
 
 # Test 9: --theirs delete failure should keep conflict state
 DB9=/tmp/test_conflicts9_$$.db; rm -f "$DB9"

--- a/test/doltlite_feature_deep.sh
+++ b/test/doltlite_feature_deep.sh
@@ -199,7 +199,7 @@ UPDATE t SET v='main' WHERE id=1;
 SELECT dolt_commit('-A','-m','main');
 SELECT dolt_merge('hf');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-echo "DELETE FROM dolt_conflicts_t WHERE base_rowid=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
+echo "DELETE FROM dolt_conflicts_t WHERE base_id=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 # Now make more changes and commit
 echo "INSERT INTO t VALUES(3,'new_after_resolve');
@@ -231,10 +231,10 @@ SELECT dolt_merge('hf');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 # Reopen — conflicts should be there
 run_test "cfr_reopen_exists" "SELECT count(*) FROM dolt_conflicts;" "1" "$DB"
-run_test "cfr_reopen_row" "SELECT base_rowid FROM dolt_conflicts_t;" "1" "$DB"
+run_test "cfr_reopen_row" "SELECT base_id FROM dolt_conflicts_t;" "1" "$DB"
 
 # Resolve in this session
-echo "DELETE FROM dolt_conflicts_t WHERE base_rowid=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
+echo "DELETE FROM dolt_conflicts_t WHERE base_id=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 # Reopen again — should be clean
 run_test "cfr_reopen_clean" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"

--- a/test/vc_oracle_conflicts_table_test.sh
+++ b/test/vc_oracle_conflicts_table_test.sh
@@ -1,0 +1,303 @@
+#!/bin/bash
+#
+# Version-control oracle test: dolt_conflicts_<table> (per-row schema)
+#
+# doltlite's dolt_conflicts_<table> vtable projects every user column
+# under three prefixes (base_, our_, their_) and emits our_diff_type /
+# their_diff_type classifications, matching Dolt's schema. This oracle
+# compares the resulting rows byte-for-byte against Dolt for a variety
+# of conflict scenarios and PK shapes.
+#
+# Columns NOT compared (because they diverge non-semantically):
+#   - from_root_ish  (doltlite emits NULL, Dolt emits a commit hash)
+#   - dolt_conflict_id (engines use different schemes)
+#
+# Compared: base_<col>, our_<col>, our_diff_type,
+#           their_<col>, their_diff_type
+#
+# Scenarios cover single-row modify, multi-row modify, different PK
+# shapes (INT, TEXT, composite), insert/insert conflicts, delete/modify
+# conflicts (both directions), and wide schemas.
+#
+# Usage: bash vc_oracle_conflicts_table_test.sh [path/to/doltlite] [path/to/dolt]
+#
+
+set -u
+
+DOLTLITE="${1:-./doltlite}"
+DOLT="${2:-dolt}"
+TMPROOT=$(mktemp -d)
+trap "rm -rf $TMPROOT" EXIT
+pass=0; fail=0
+FAILED_NAMES=""
+
+normalize() {
+  tr -d '\r' | sort
+}
+
+# $1=name, $2=setup SQL (runs on both engines), $3=comparison query
+# The comparison query must project rows prefixed with "R|" and use
+# CONCAT (works in both SQLite and MySQL for string concatenation).
+oracle() {
+  local name="$1" setup="$2" query="$3"
+  local dir="$TMPROOT/$name"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  # -- doltlite --
+  local dl_out
+  dl_out=$(printf "%s\n.headers off\n.mode list\n%s\n" "$setup" "$query" \
+           | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
+           | grep '^R|' \
+           | normalize)
+
+  # -- Dolt --
+  # Same scenario piped as a single `dolt sql` invocation so
+  # @@autocommit=0 and @@dolt_allow_commit_conflicts=1 persist.
+  local dolt_all
+  dolt_all=$(printf '%s\n%s' "$setup" "$query" \
+             | sed -E 's/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g')
+
+  local dt_out
+  dt_out=$(
+    cd "$dir/dt" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    {
+      printf 'SET @@autocommit = 0;\n'
+      printf 'SET @@dolt_allow_commit_conflicts = 1;\n'
+      printf '%s\n' "$dolt_all"
+    } | "$DOLT" sql -r csv 2>"$dir/dt.err"
+  )
+  dt_out=$(echo "$dt_out" | tr -d '"' | grep '^R|' | normalize)
+
+  if [ -z "$dl_out" ] && [ -z "$dt_out" ]; then
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name (both queries empty — harness bug)"
+    return
+  fi
+
+  if [ "$dl_out" = "$dt_out" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite:"; echo "$dl_out" | sed 's/^/      /'
+    echo "    dolt:";     echo "$dt_out" | sed 's/^/      /'
+  fi
+}
+
+echo "=== Version Control Oracle Tests: dolt_conflicts_<table> ==="
+echo ""
+
+echo "--- single-row modify/modify, INT PK ---"
+
+oracle "int_pk_single_row" \
+"CREATE TABLE t(id INT PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1,10);
+SELECT dolt_commit('-A','-m','c1');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+UPDATE t SET v=100 WHERE id=1;
+SELECT dolt_commit('-A','-m','feat');
+SELECT dolt_checkout('main');
+UPDATE t SET v=1000 WHERE id=1;
+SELECT dolt_commit('-A','-m','mainu');
+SELECT dolt_merge('feat');
+" \
+"SELECT CONCAT('R|', base_id, '|', base_v, '|', our_id, '|', our_v, '|', our_diff_type, '|', their_id, '|', their_v, '|', their_diff_type) FROM dolt_conflicts_t ORDER BY base_id;"
+
+echo "--- multi-row modify/modify, INT PK ---"
+
+oracle "int_pk_multi_row" \
+"CREATE TABLE t(id INT PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1,10),(2,20),(3,30);
+SELECT dolt_commit('-A','-m','c1');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+UPDATE t SET v=100 WHERE id=1;
+UPDATE t SET v=200 WHERE id=2;
+UPDATE t SET v=300 WHERE id=3;
+SELECT dolt_commit('-A','-m','feat');
+SELECT dolt_checkout('main');
+UPDATE t SET v=1000 WHERE id=1;
+UPDATE t SET v=2000 WHERE id=2;
+UPDATE t SET v=3000 WHERE id=3;
+SELECT dolt_commit('-A','-m','mainu');
+SELECT dolt_merge('feat');
+" \
+"SELECT CONCAT('R|', base_id, '|', base_v, '|', our_id, '|', our_v, '|', our_diff_type, '|', their_id, '|', their_v, '|', their_diff_type) FROM dolt_conflicts_t ORDER BY base_id;"
+
+echo "--- INTEGER PRIMARY KEY (rowid-aliased) ---"
+
+# INTEGER PK is the rowid-aliased shape where the PK is NOT stored in
+# the record body (it's the intKey). The projected column must come
+# from intKey, not from the record.
+oracle "integer_pk_single_row" \
+"CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1,10);
+SELECT dolt_commit('-A','-m','c1');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+UPDATE t SET v=100 WHERE id=1;
+SELECT dolt_commit('-A','-m','feat');
+SELECT dolt_checkout('main');
+UPDATE t SET v=1000 WHERE id=1;
+SELECT dolt_commit('-A','-m','mainu');
+SELECT dolt_merge('feat');
+" \
+"SELECT CONCAT('R|', base_id, '|', base_v, '|', our_id, '|', our_v, '|', our_diff_type, '|', their_id, '|', their_v, '|', their_diff_type) FROM dolt_conflicts_t ORDER BY base_id;"
+
+echo "--- VARCHAR PK ---"
+
+oracle "varchar_pk" \
+"CREATE TABLE t(id VARCHAR(32) PRIMARY KEY, v INT);
+INSERT INTO t VALUES('alice',10),('bob',20);
+SELECT dolt_commit('-A','-m','c1');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+UPDATE t SET v=100 WHERE id='alice';
+UPDATE t SET v=200 WHERE id='bob';
+SELECT dolt_commit('-A','-m','feat');
+SELECT dolt_checkout('main');
+UPDATE t SET v=1000 WHERE id='alice';
+UPDATE t SET v=2000 WHERE id='bob';
+SELECT dolt_commit('-A','-m','mainu');
+SELECT dolt_merge('feat');
+" \
+"SELECT CONCAT('R|', base_id, '|', base_v, '|', our_id, '|', our_v, '|', our_diff_type, '|', their_id, '|', their_v, '|', their_diff_type) FROM dolt_conflicts_t ORDER BY base_id;"
+
+echo "--- composite INT PK ---"
+
+oracle "composite_int_pk" \
+"CREATE TABLE t(a INT, b INT, v INT, PRIMARY KEY(a, b));
+INSERT INTO t VALUES(1,1,11),(1,2,12),(2,1,21);
+SELECT dolt_commit('-A','-m','c1');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+UPDATE t SET v=110 WHERE a=1 AND b=1;
+UPDATE t SET v=120 WHERE a=1 AND b=2;
+SELECT dolt_commit('-A','-m','feat');
+SELECT dolt_checkout('main');
+UPDATE t SET v=1100 WHERE a=1 AND b=1;
+UPDATE t SET v=1200 WHERE a=1 AND b=2;
+SELECT dolt_commit('-A','-m','mainu');
+SELECT dolt_merge('feat');
+" \
+"SELECT CONCAT('R|', base_a, '|', base_b, '|', base_v, '|', our_a, '|', our_b, '|', our_v, '|', our_diff_type, '|', their_a, '|', their_b, '|', their_v, '|', their_diff_type) FROM dolt_conflicts_t ORDER BY base_a, base_b;"
+
+echo "--- composite mixed VARCHAR + INT PK ---"
+
+oracle "composite_mixed_pk" \
+"CREATE TABLE t(region VARCHAR(8), id INT, v INT, PRIMARY KEY(region, id));
+INSERT INTO t VALUES('us',1,11),('us',2,12),('eu',1,21);
+SELECT dolt_commit('-A','-m','c1');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+UPDATE t SET v=110 WHERE region='us' AND id=1;
+SELECT dolt_commit('-A','-m','feat');
+SELECT dolt_checkout('main');
+UPDATE t SET v=1100 WHERE region='us' AND id=1;
+SELECT dolt_commit('-A','-m','mainu');
+SELECT dolt_merge('feat');
+" \
+"SELECT CONCAT('R|', base_region, '|', base_id, '|', base_v, '|', our_region, '|', our_id, '|', our_v, '|', our_diff_type, '|', their_region, '|', their_id, '|', their_v, '|', their_diff_type) FROM dolt_conflicts_t ORDER BY base_region, base_id;"
+
+echo "--- insert/insert same PK ---"
+
+# Both sides add a row with the same PK. base should be NULL (no
+# common ancestor for this row), diff types should be 'added' on
+# both sides.
+oracle "insert_insert_same_pk" \
+"CREATE TABLE t(id INT PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1,10);
+SELECT dolt_commit('-A','-m','c1');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES(2,200);
+SELECT dolt_commit('-A','-m','feat');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(2,2000);
+SELECT dolt_commit('-A','-m','mainu');
+SELECT dolt_merge('feat');
+" \
+"SELECT CONCAT('R|', IFNULL(base_id,'NULL'), '|', IFNULL(base_v,'NULL'), '|', our_id, '|', our_v, '|', our_diff_type, '|', their_id, '|', their_v, '|', their_diff_type) FROM dolt_conflicts_t ORDER BY our_id;"
+
+echo "--- delete/modify: main deletes, feature modifies ---"
+
+# main deletes row 1, feature modifies it. our side is "removed",
+# their side is "modified".
+oracle "main_delete_feat_modify" \
+"CREATE TABLE t(id INT PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1,10),(2,20);
+SELECT dolt_commit('-A','-m','c1');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+UPDATE t SET v=100 WHERE id=1;
+SELECT dolt_commit('-A','-m','feat');
+SELECT dolt_checkout('main');
+DELETE FROM t WHERE id=1;
+SELECT dolt_commit('-A','-m','mainu');
+SELECT dolt_merge('feat');
+" \
+"SELECT CONCAT('R|', base_id, '|', base_v, '|', IFNULL(our_id,'NULL'), '|', IFNULL(our_v,'NULL'), '|', our_diff_type, '|', their_id, '|', their_v, '|', their_diff_type) FROM dolt_conflicts_t ORDER BY base_id;"
+
+echo "--- modify/delete: main modifies, feature deletes ---"
+
+oracle "main_modify_feat_delete" \
+"CREATE TABLE t(id INT PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1,10),(2,20);
+SELECT dolt_commit('-A','-m','c1');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+DELETE FROM t WHERE id=1;
+SELECT dolt_commit('-A','-m','feat');
+SELECT dolt_checkout('main');
+UPDATE t SET v=100 WHERE id=1;
+SELECT dolt_commit('-A','-m','mainu');
+SELECT dolt_merge('feat');
+" \
+"SELECT CONCAT('R|', base_id, '|', base_v, '|', our_id, '|', our_v, '|', our_diff_type, '|', IFNULL(their_id,'NULL'), '|', IFNULL(their_v,'NULL'), '|', their_diff_type) FROM dolt_conflicts_t ORDER BY base_id;"
+
+echo "--- wide schema (many mixed-type columns) ---"
+
+oracle "wide_schema" \
+"CREATE TABLE t(id INT PRIMARY KEY, a VARCHAR(32), b INT, c DOUBLE, d VARCHAR(32), e INT);
+INSERT INTO t VALUES(1,'a1',11,1.5,'d1',111);
+SELECT dolt_commit('-A','-m','c1');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+UPDATE t SET a='FEAT_A', b=999, d='feat_d' WHERE id=1;
+SELECT dolt_commit('-A','-m','feat');
+SELECT dolt_checkout('main');
+UPDATE t SET a='MAIN_A', b=888, c=9.99 WHERE id=1;
+SELECT dolt_commit('-A','-m','mainu');
+SELECT dolt_merge('feat');
+" \
+"SELECT CONCAT('R|', base_id, '|', base_a, '|', base_b, '|', base_c, '|', base_d, '|', base_e, '|', our_a, '|', our_b, '|', our_c, '|', our_d, '|', our_e, '|', our_diff_type, '|', their_a, '|', their_b, '|', their_c, '|', their_d, '|', their_e, '|', their_diff_type) FROM dolt_conflicts_t ORDER BY base_id;"
+
+echo "--- NULL non-PK values on each side ---"
+
+oracle "nulls_in_conflict" \
+"CREATE TABLE t(id INT PRIMARY KEY, v INT, note VARCHAR(32));
+INSERT INTO t VALUES(1,10,NULL),(2,NULL,'hello');
+SELECT dolt_commit('-A','-m','c1');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+UPDATE t SET note='feat' WHERE id=1;
+UPDATE t SET v=222 WHERE id=2;
+SELECT dolt_commit('-A','-m','feat');
+SELECT dolt_checkout('main');
+UPDATE t SET note='main' WHERE id=1;
+UPDATE t SET v=333 WHERE id=2;
+SELECT dolt_commit('-A','-m','mainu');
+SELECT dolt_merge('feat');
+" \
+"SELECT CONCAT('R|', base_id, '|', IFNULL(base_v,'NULL'), '|', IFNULL(base_note,'NULL'), '|', IFNULL(our_v,'NULL'), '|', IFNULL(our_note,'NULL'), '|', our_diff_type, '|', IFNULL(their_v,'NULL'), '|', IFNULL(their_note,'NULL'), '|', their_diff_type) FROM dolt_conflicts_t ORDER BY base_id;"
+
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+if [ $fail -gt 0 ]; then
+  echo "Failed:$FAILED_NAMES"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
doltlite's `dolt_conflicts_<table>` vtable previously exposed a legacy 6-column generic schema (`base_rowid, base_value, our_rowid, our_value, their_rowid, their_value`) where the value columns held opaque concatenated representations of all user columns. Dolt projects every user column individually under three prefixes (`base_`, `our_`, `their_`) plus per-side `diff_type` and a stable conflict id.

Rewrites the vtable to build its schema dynamically from the user table's columns, matching Dolt's layout exactly:
```
from_root_ish TEXT,
base_<col1>, ..., base_<colN>,
our_<col1>, ..., our_<colN>, our_diff_type TEXT,
their_<col1>, ..., their_<colN>, their_diff_type TEXT,
dolt_conflict_id TEXT
```

Column decoding:
- Rowid-aliased `INTEGER PRIMARY KEY` tables pull the PK value from the conflict row's `intKey` (same pattern as `dtColumn` in `doltlite_diff_table.c`).
- `INT`/`TEXT`/composite user PKs parse the PK from the record body along with the other columns via `doltliteParseRecord` + `doltliteResultField`.
- `our_diff_type` / `their_diff_type` classify `added`/`modified`/`removed` by comparing base-vs-side presence.
- `from_root_ish` is emitted as NULL (doltlite doesn't track per-conflict merge root) and `dolt_conflict_id` as a synthetic `intKey:iRow` string. The oracle comparisons explicitly skip these two columns since both engines legitimately diverge.

Adds `test/vc_oracle_conflicts_table_test.sh` with **11 scenarios vs Dolt** covering:
- `INT PK` single-row and multi-row modify
- `INTEGER PRIMARY KEY` (rowid-aliased)
- `VARCHAR(32) PK`
- Composite `(INT, INT)` PK
- Composite mixed `(VARCHAR, INT)` PK
- Insert/insert with same PK (base NULL, both sides `added`)
- Delete/modify in both directions (one side NULL + `removed`)
- Wide schema with mixed types (`VARCHAR`, `INT`, `DOUBLE`)
- NULL non-PK values on each side

**All 11 scenarios match Dolt byte-for-byte on the compared columns.**

Also updates the existing self-tests that referenced the old generic schema:
- `doltlite_conflict_rows.sh`: `base_rowid` -> `base_id` (et al), `typeof(base_value)` -> `typeof(base_v)`
- `doltlite_conflicts.sh`: `base_value`/`our_value`/`their_value` -> `base_name`/`our_name`/`their_name` for its multi-row section

Closes a gap flagged in `vc_oracle_conflicts_test.sh` as a known follow-up.

## Test plan
- [x] `bash test/vc_oracle_conflicts_table_test.sh ./doltlite dolt` → 11 passed, 0 failed
- [x] `bash test/doltlite_conflicts.sh` → 37 passed, 0 failed
- [x] `bash test/doltlite_conflict_rows.sh` → 29 passed, 0 failed
- [x] `bash test/vc_oracle_conflicts_test.sh ./doltlite dolt` → 9 passed (existing summary oracle)
- [x] `bash test/vc_oracle_conflicts_resolve_test.sh ./doltlite dolt` → 17 passed (existing)
- [x] Broader regression (`doltlite_diff`, `doltlite_unicode_blob`, `doltlite_advanced`) → 208 passed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)