### PR TITLE
Rename index_oracle_test to sql_oracle_test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,8 +59,8 @@ jobs:
       run: cd build && bash ../test/index_test.sh ./doltlite
       timeout-minutes: 5
 
-    - name: Index oracle tests
-      run: cd build && bash ../test/index_oracle_test.sh ./doltlite sqlite3
+    - name: SQL oracle tests (vs stock SQLite)
+      run: cd build && bash ../test/sql_oracle_test.sh ./doltlite sqlite3
       timeout-minutes: 5
 
     - name: Version control oracle tests (dolt_log)

--- a/test/sql_oracle_test.sh
+++ b/test/sql_oracle_test.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 #
-# Oracle test: run identical SQL against doltlite and stock SQLite,
-# compare output. Catches any divergence in index-related mutations.
+# SQL oracle test: run identical SQL against doltlite and stock SQLite,
+# compare output. Exercises general SQL semantics (DDL, DML, indexes,
+# joins, aggregates, etc.) — anywhere doltlite should behave like
+# upstream SQLite at the row level.
 #
-# Usage: bash index_oracle_test.sh [path/to/doltlite] [path/to/sqlite3]
+# Usage: bash sql_oracle_test.sh [path/to/doltlite] [path/to/sqlite3]
 #
 
 DOLTLITE="${1:-./doltlite}"


### PR DESCRIPTION
## Summary
The test exercises general SQL semantics against stock SQLite — DDL, DML, indexes, joins, aggregates — not just index-related mutations. The \`index_oracle\` name was too narrow. Rename the file and CI step; update the usage comment at the top of the file.

## Test plan
- [x] \`grep -rn index_oracle .github/ test/ src/ Makefile* README.md\` returns no remaining references
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)