### PR TITLE
Add dolt_schemas vtable + surface view changes in dolt_diff

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,6 +139,10 @@ jobs:
       run: cd build && bash ../test/vc_oracle_schema_diff_test.sh ./doltlite dolt
       timeout-minutes: 5
 
+    - name: Version control oracle tests (dolt_schemas)
+      run: cd build && bash ../test/vc_oracle_schemas_test.sh ./doltlite dolt
+      timeout-minutes: 5
+
     - name: Version control oracle tests (dolt_history_<table>)
       run: cd build && bash ../test/vc_oracle_history_test.sh ./doltlite dolt
       timeout-minutes: 5

--- a/main.mk
+++ b/main.mk
@@ -570,7 +570,7 @@ PROLLY_OBJS = prolly_hash.o prolly_hashset.o prolly_arena.o prolly_node.o prolly
               prolly_mutate.o prolly_diff.o prolly_three_way_diff.o prolly_btree.o pager_shim.o sortkey.o \
               doltlite.o doltlite_commit.o doltlite_ref.o doltlite_log.o doltlite_status.o \
               doltlite_diff.o doltlite_diff_table.o doltlite_branch.o doltlite_tag.o doltlite_ancestor.o doltlite_merge.o doltlite_schema_merge.o doltlite_conflicts.o \
-              doltlite_gc.o doltlite_chunk_walk.o doltlite_history.o doltlite_at.o doltlite_schema_diff.o doltlite_record.o \
+              doltlite_gc.o doltlite_chunk_walk.o doltlite_history.o doltlite_at.o doltlite_schema_diff.o doltlite_schemas.o doltlite_record.o \
               doltlite_remote.o doltlite_remote_sql.o \
               doltlite_http_remote.o doltlite_remotesrv.o
 
@@ -1381,6 +1381,9 @@ doltlite_at.o:	$(TOP)/src/doltlite_at.c $(DEPS_OBJ_COMMON)
 
 doltlite_schema_diff.o:	$(TOP)/src/doltlite_schema_diff.c $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/doltlite_schema_diff.c
+
+doltlite_schemas.o:	$(TOP)/src/doltlite_schemas.c $(DEPS_OBJ_COMMON)
+	$(T.cc.sqlite) -c $(TOP)/src/doltlite_schemas.c
 
 doltlite_record.o:	$(TOP)/src/doltlite_record.c $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/doltlite_record.c

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -59,6 +59,7 @@ static time_t dlWinTimegm(struct tm *pTm){
 extern int doltliteLogRegister(sqlite3 *db);
 extern int doltliteStatusRegister(sqlite3 *db);
 extern int doltliteDiffRegister(sqlite3 *db);
+extern int doltliteSchemasRegister(sqlite3 *db);
 extern int doltliteBranchRegister(sqlite3 *db);
 extern int doltliteConflictsRegister(sqlite3 *db);
 extern int doltliteRegisterConflictTables(sqlite3 *db);
@@ -2324,6 +2325,7 @@ void doltliteRegister(sqlite3 *db){
   if( doltliteAtRegister(db)!=SQLITE_OK ) return;
   if( doltliteRegisterHistoryTables(db)!=SQLITE_OK ) return;
   if( doltliteSchemaDiffRegister(db)!=SQLITE_OK ) return;
+  if( doltliteSchemasRegister(db)!=SQLITE_OK ) return;
   if( doltliteRemoteSqlRegister(db)!=SQLITE_OK ) return;
   doltliteMaybeSeedRepo(db);
 }

--- a/src/doltlite_diff.c
+++ b/src/doltlite_diff.c
@@ -14,6 +14,62 @@
 #include <string.h>
 #include <time.h>
 
+/* Does a sqlite_schema record represent a view or a trigger? Returns
+** 1 if the record's type field (field 0) is "view" or "trigger", 0
+** otherwise. The caller should pass whichever side of a diff change
+** has a non-NULL record (both base and new sides need checking —
+** either a newly-added view has a new record, or a dropped view has
+** an old record). */
+static int schemaRecordIsViewOrTrigger(const u8 *pRec, int nRec){
+  DoltliteRecordInfo ri;
+  int st, off, len;
+  const u8 *pBody;
+  if( !pRec || nRec<=0 ) return 0;
+  doltliteParseRecord(pRec, nRec, &ri);
+  if( ri.nField < 1 ) return 0;
+  st = ri.aType[0];
+  off = ri.aOffset[0];
+  if( st < 13 || (st & 1)==0 ) return 0;  /* not a TEXT serial type */
+  len = (st - 13) / 2;
+  if( off < 0 || off + len > nRec ) return 0;
+  pBody = pRec + off;
+  if( len==4 && memcmp(pBody, "view", 4)==0 ) return 1;
+  if( len==7 && memcmp(pBody, "trigger", 7)==0 ) return 1;
+  return 0;
+}
+
+/* Walk a prolly diff between two sqlite_schema roots and return 1 if
+** any change touches a view or trigger row. Used by the dolt_diff
+** summary walker to decide whether to emit a synthetic "dolt_schemas"
+** entry for a commit. Returns 0 for no view/trigger change (so the
+** caller can skip emitting) or on any error; dolt_diff is an
+** informational surface and shouldn't fail just because sqlite_schema
+** couldn't be walked. */
+static int schemaHasViewOrTriggerDiff(sqlite3 *db,
+                                      const ProllyHash *pOldRoot,
+                                      const ProllyHash *pNewRoot,
+                                      u8 flags){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  ProllyCache *pCache = doltliteGetCache(db);
+  ProllyDiffIter iter;
+  ProllyDiffChange *pChange = 0;
+  int rc;
+  int found = 0;
+  if( !cs || !pCache ) return 0;
+  if( prollyHashCompare(pOldRoot, pNewRoot)==0 ) return 0;
+  rc = prollyDiffIterOpen(&iter, cs, pCache, pOldRoot, pNewRoot, flags);
+  if( rc!=SQLITE_OK ) return 0;
+  while( (rc = prollyDiffIterStep(&iter, &pChange))==SQLITE_ROW && pChange ){
+    if( schemaRecordIsViewOrTrigger(pChange->pNewVal, pChange->nNewVal)
+     || schemaRecordIsViewOrTrigger(pChange->pOldVal, pChange->nOldVal) ){
+      found = 1;
+      break;
+    }
+  }
+  prollyDiffIterClose(&iter);
+  return found;
+}
+
 /* Per-row diff (legacy form: dolt_diff('table', from, to)). */
 typedef struct DiffRow DiffRow;
 struct DiffRow {
@@ -287,7 +343,20 @@ static int collectWorkingSetSummary(DoltliteDiffCursor *pCur, sqlite3 *db){
     struct TableEntry *e = &aWork[i];
     struct TableEntry *p;
     u8 dataChange, schemaChange;
-    if( !e->zName ) continue;
+    if( !e->zName ){
+      /* sqlite_master: surface uncommitted view/trigger changes. */
+      ProllyHash emptyRoot;
+      const ProllyHash *pOldRoot;
+      struct TableEntry *pOldMaster;
+      memset(&emptyRoot, 0, sizeof(emptyRoot));
+      pOldMaster = doltliteFindTableByNumber(aHead, nHead, 1);
+      pOldRoot = pOldMaster ? &pOldMaster->root : &emptyRoot;
+      if( schemaHasViewOrTriggerDiff(db, pOldRoot, &e->root, e->flags) ){
+        rc = appendSummaryRow(pCur, zHexBuf, "dolt_schemas", 0, 1, 0);
+        if( rc!=SQLITE_OK ) goto done;
+      }
+      continue;
+    }
     p = doltliteFindTableByName(aHead, nHead, e->zName);
     if( !p ){
       dataChange = 1;
@@ -350,7 +419,25 @@ static int collectSummaryForCommit(DoltliteDiffCursor *pCur, sqlite3 *db,
     struct TableEntry *e = &aChild[i];
     struct TableEntry *p;
     u8 dataChange, schemaChange;
-    if( !e->zName ) continue;  /* skip sqlite_master */
+    if( !e->zName ){
+      /* sqlite_master: surface view/trigger changes as "dolt_schemas".
+      ** Regular CREATE TABLE also touches sqlite_master but is
+      ** already attributed to the created table above, so we only
+      ** emit dolt_schemas when the change specifically touches a
+      ** view or trigger row. */
+      ProllyHash emptyRoot;
+      const ProllyHash *pOldRoot;
+      struct TableEntry *pOldMaster;
+      memset(&emptyRoot, 0, sizeof(emptyRoot));
+      pOldMaster = doltliteFindTableByNumber(aParent, nParent, 1);
+      pOldRoot = pOldMaster ? &pOldMaster->root : &emptyRoot;
+      if( schemaHasViewOrTriggerDiff(db, pOldRoot, &e->root, e->flags) ){
+        rc = appendSummaryRow(pCur, zCommitHex, "dolt_schemas", pCommit,
+                              1, 0);
+        if( rc!=SQLITE_OK ) goto done;
+      }
+      continue;
+    }
     p = doltliteFindTableByName(aParent, nParent, e->zName);
     if( !p ){
       /* Newly added in this commit. */

--- a/src/doltlite_schemas.c
+++ b/src/doltlite_schemas.c
@@ -1,0 +1,208 @@
+/* dolt_schemas: projection over sqlite_schema, filtered to views and
+** triggers. Mirrors Dolt's dolt_schemas system table so user-level
+** view/trigger management is visible, diffable, and version-controlled
+** alongside regular table data.
+**
+** Storage layer: sqlite_schema is already branch-scoped in the
+** doltlite catalog (table #1 in each commit), so every branch sees
+** its own view set automatically. This vtable is a read-only
+** projection that runs an internal SELECT against sqlite_schema on
+** every xFilter and caches the result rows for the cursor.
+**
+** Columns (matching Dolt's dolt_schemas for oracle comparability):
+**   type     TEXT  -- 'view' or 'trigger'
+**   name     TEXT  -- object name
+**   fragment TEXT  -- full CREATE statement (Dolt stores the same)
+**   extra    TEXT  -- always NULL in doltlite (Dolt uses this for JSON
+**                    metadata; we don't track it)
+**   sql_mode TEXT  -- always NULL in doltlite (MySQL-specific)
+*/
+
+#ifdef DOLTLITE_PROLLY
+
+#include "sqliteInt.h"
+#include "prolly_hash.h"
+#include "chunk_store.h"
+#include "doltlite_internal.h"
+#include <string.h>
+
+typedef struct SchemasRow SchemasRow;
+struct SchemasRow {
+  char *zType;
+  char *zName;
+  char *zFragment;
+};
+
+typedef struct SchemasVtab SchemasVtab;
+struct SchemasVtab {
+  sqlite3_vtab base;
+  sqlite3 *db;
+};
+
+typedef struct SchemasCursor SchemasCursor;
+struct SchemasCursor {
+  sqlite3_vtab_cursor base;
+  SchemasRow *aRows;
+  int nRows;
+  int iRow;
+};
+
+static const char *zSchemasSchema =
+  "CREATE TABLE x("
+  "  type     TEXT,"
+  "  name     TEXT,"
+  "  fragment TEXT,"
+  "  extra    TEXT,"
+  "  sql_mode TEXT"
+  ")";
+
+static int schemasConnect(sqlite3 *db, void *pAux, int argc,
+    const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){
+  SchemasVtab *pVtab;
+  int rc;
+  (void)pAux; (void)argc; (void)argv; (void)pzErr;
+  rc = sqlite3_declare_vtab(db, zSchemasSchema);
+  if( rc!=SQLITE_OK ) return rc;
+  pVtab = sqlite3_malloc(sizeof(*pVtab));
+  if( !pVtab ) return SQLITE_NOMEM;
+  memset(pVtab, 0, sizeof(*pVtab));
+  pVtab->db = db;
+  *ppVtab = &pVtab->base;
+  return SQLITE_OK;
+}
+
+static int schemasDisconnect(sqlite3_vtab *pVtab){
+  sqlite3_free(pVtab);
+  return SQLITE_OK;
+}
+
+static int schemasBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
+  (void)pVtab;
+  pInfo->estimatedCost = 100.0;
+  pInfo->estimatedRows = 10;
+  return SQLITE_OK;
+}
+
+static int schemasOpen(sqlite3_vtab *pVtab, sqlite3_vtab_cursor **ppCursor){
+  SchemasCursor *pCur;
+  (void)pVtab;
+  pCur = sqlite3_malloc(sizeof(*pCur));
+  if( !pCur ) return SQLITE_NOMEM;
+  memset(pCur, 0, sizeof(*pCur));
+  *ppCursor = &pCur->base;
+  return SQLITE_OK;
+}
+
+static void freeRows(SchemasCursor *pCur){
+  int i;
+  for(i=0; i<pCur->nRows; i++){
+    sqlite3_free(pCur->aRows[i].zType);
+    sqlite3_free(pCur->aRows[i].zName);
+    sqlite3_free(pCur->aRows[i].zFragment);
+  }
+  sqlite3_free(pCur->aRows);
+  pCur->aRows = 0;
+  pCur->nRows = 0;
+}
+
+static int schemasClose(sqlite3_vtab_cursor *pCursor){
+  SchemasCursor *pCur = (SchemasCursor*)pCursor;
+  freeRows(pCur);
+  sqlite3_free(pCur);
+  return SQLITE_OK;
+}
+
+static int schemasFilter(sqlite3_vtab_cursor *pCursor,
+    int idxNum, const char *idxStr, int argc, sqlite3_value **argv){
+  SchemasCursor *pCur = (SchemasCursor*)pCursor;
+  SchemasVtab *pVtab = (SchemasVtab*)pCursor->pVtab;
+  sqlite3_stmt *pStmt = 0;
+  int rc;
+  (void)idxNum; (void)idxStr; (void)argc; (void)argv;
+
+  freeRows(pCur);
+  pCur->iRow = 0;
+
+  /* Pull view/trigger rows from the live sqlite_schema, which is
+  ** already branch-scoped. Order by (type, name) so the output is
+  ** deterministic across runs — same ordering the oracle test uses. */
+  rc = sqlite3_prepare_v2(pVtab->db,
+    "SELECT type, name, sql FROM sqlite_schema "
+    "WHERE type IN ('view','trigger') ORDER BY type, name",
+    -1, &pStmt, 0);
+  if( rc!=SQLITE_OK ) return rc;
+
+  while( sqlite3_step(pStmt)==SQLITE_ROW ){
+    const char *zType = (const char*)sqlite3_column_text(pStmt, 0);
+    const char *zName = (const char*)sqlite3_column_text(pStmt, 1);
+    const char *zSql  = (const char*)sqlite3_column_text(pStmt, 2);
+    SchemasRow *aNew = sqlite3_realloc(pCur->aRows,
+                                       (pCur->nRows+1)*(int)sizeof(SchemasRow));
+    if( !aNew ){ rc = SQLITE_NOMEM; break; }
+    pCur->aRows = aNew;
+    memset(&pCur->aRows[pCur->nRows], 0, sizeof(SchemasRow));
+    pCur->aRows[pCur->nRows].zType     = sqlite3_mprintf("%s", zType ? zType : "");
+    pCur->aRows[pCur->nRows].zName     = sqlite3_mprintf("%s", zName ? zName : "");
+    pCur->aRows[pCur->nRows].zFragment = sqlite3_mprintf("%s", zSql  ? zSql  : "");
+    if( !pCur->aRows[pCur->nRows].zType
+     || !pCur->aRows[pCur->nRows].zName
+     || !pCur->aRows[pCur->nRows].zFragment ){
+      rc = SQLITE_NOMEM;
+      break;
+    }
+    pCur->nRows++;
+  }
+  sqlite3_finalize(pStmt);
+  if( rc!=SQLITE_OK && rc!=SQLITE_DONE ){
+    freeRows(pCur);
+    return rc;
+  }
+  return SQLITE_OK;
+}
+
+static int schemasNext(sqlite3_vtab_cursor *pCursor){
+  ((SchemasCursor*)pCursor)->iRow++;
+  return SQLITE_OK;
+}
+
+static int schemasEof(sqlite3_vtab_cursor *pCursor){
+  SchemasCursor *pCur = (SchemasCursor*)pCursor;
+  return pCur->iRow >= pCur->nRows;
+}
+
+static int schemasColumn(sqlite3_vtab_cursor *pCursor,
+    sqlite3_context *ctx, int iCol){
+  SchemasCursor *pCur = (SchemasCursor*)pCursor;
+  SchemasRow *r;
+  if( pCur->iRow >= pCur->nRows ) return SQLITE_OK;
+  r = &pCur->aRows[pCur->iRow];
+  switch( iCol ){
+    case 0: sqlite3_result_text(ctx, r->zType,     -1, SQLITE_TRANSIENT); break;
+    case 1: sqlite3_result_text(ctx, r->zName,     -1, SQLITE_TRANSIENT); break;
+    case 2: sqlite3_result_text(ctx, r->zFragment, -1, SQLITE_TRANSIENT); break;
+    case 3: /* extra: JSON metadata Dolt tracks, doltlite does not. */
+    case 4: /* sql_mode: MySQL-specific. */
+    default:
+      sqlite3_result_null(ctx);
+      break;
+  }
+  return SQLITE_OK;
+}
+
+static int schemasRowid(sqlite3_vtab_cursor *pCursor, sqlite3_int64 *pRowid){
+  *pRowid = ((SchemasCursor*)pCursor)->iRow;
+  return SQLITE_OK;
+}
+
+static sqlite3_module doltliteSchemasModule = {
+  0, 0, schemasConnect, schemasBestIndex, schemasDisconnect, 0,
+  schemasOpen, schemasClose, schemasFilter, schemasNext, schemasEof,
+  schemasColumn, schemasRowid,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+};
+
+int doltliteSchemasRegister(sqlite3 *db){
+  return sqlite3_create_module(db, "dolt_schemas", &doltliteSchemasModule, 0);
+}
+
+#endif

--- a/test/vc_oracle_schemas_test.sh
+++ b/test/vc_oracle_schemas_test.sh
@@ -1,0 +1,233 @@
+#!/bin/bash
+#
+# Version-control oracle test: dolt_schemas vtable + dolt_diff view
+# visibility.
+#
+# doltlite's dolt_schemas is a projection over sqlite_schema filtered
+# to type IN ('view','trigger'). Since sqlite_schema is already in the
+# branch-scoped catalog, views are version-controlled per branch for
+# free: committed views appear in the commit they were created,
+# uncommitted views show up as a WORKING dolt_schemas entry in
+# dolt_diff, and branch switches surface the right view set.
+#
+# This oracle compares against Dolt 1.86.0+ on:
+#
+#   1. SELECT type, name, fragment FROM dolt_schemas ORDER BY type, name
+#      — the live view set on the current branch. `extra` and
+#      `sql_mode` are NOT compared (doltlite emits NULL for both;
+#      Dolt uses them for MySQL-specific metadata).
+#
+#   2. SELECT table_name FROM dolt_diff — which commits touch
+#      dolt_schemas. Compared on (message, table_name, data_change)
+#      via a LEFT JOIN with dolt_log so engine-specific commit hashes
+#      don't matter. schema_change is NOT compared because doltlite
+#      emits 0 for dolt_schemas content changes while Dolt emits 1 on
+#      the initial view creation.
+#
+# Scope: views only. Triggers diverge in syntax between Dolt's MySQL
+# dialect (FOR EACH ROW BEGIN ... END;) and doltlite's SQLite
+# dialect (BEGIN SELECT ...; END;), so trigger scenarios would need
+# per-engine SQL. Left as a follow-up.
+#
+# Usage: bash vc_oracle_schemas_test.sh [path/to/doltlite] [path/to/dolt]
+#
+
+set -u
+
+DOLTLITE="${1:-./doltlite}"
+DOLT="${2:-dolt}"
+TMPROOT=$(mktemp -d)
+trap "rm -rf $TMPROOT" EXIT
+pass=0; fail=0
+FAILED_NAMES=""
+
+normalize() {
+  tr -d '\r' | sort
+}
+
+# Oracle for dolt_schemas table contents after a setup script.
+# Runs identical SQL on both engines, projects type|name|fragment
+# rows, sorts, compares.
+oracle_schemas() {
+  local name="$1" setup="$2"
+  local dir="$TMPROOT/${name}_schemas"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local q="SELECT 'S' || char(9) || type || char(9) || name || char(9) || fragment FROM dolt_schemas ORDER BY type, name"
+  local q_dolt="SELECT concat('S', char(9), type, char(9), name, char(9), fragment) FROM dolt_schemas ORDER BY type, name"
+
+  local dl_out
+  dl_out=$(printf "%s\n.headers off\n.mode list\n.separator '\t'\n%s;\n" "$setup" "$q" \
+           | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
+           | grep '^S' \
+           | normalize)
+
+  local dolt_setup
+  dolt_setup=$(echo "$setup" | sed -E 's/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g')
+
+  local dt_out
+  dt_out=$(
+    cd "$dir/dt" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    {
+      printf '%s\n' "$dolt_setup"
+      printf '%s;\n' "$q_dolt"
+    } | "$DOLT" sql -r csv 2>"$dir/dt.err"
+  )
+  dt_out=$(echo "$dt_out" | tr -d '"' | grep '^S' | normalize)
+
+  if [ "$dl_out" = "$dt_out" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite:"; echo "$dl_out" | sed 's/^/      /'
+    echo "    dolt:";     echo "$dt_out" | sed 's/^/      /'
+  fi
+}
+
+# Oracle for which commits touch dolt_schemas in dolt_diff, joined
+# against dolt_log on commit_hash so we compare by commit MESSAGE
+# (stable across engines). IMPORTANT: doltlite's dolt_diff treats
+# `table_name` as a HIDDEN constraint column — a WHERE clause like
+# `table_name='dolt_schemas'` triggers the polymorphic vtable's
+# per-row mode (dolt_diff('dolt_schemas',...)) instead of filtering
+# the summary rows. We query without that filter and grep
+# dolt_schemas rows out in shell.
+oracle_diff_touches_schemas() {
+  local name="$1" setup="$2"
+  local dir="$TMPROOT/${name}_diff"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local q="SELECT 'D' || char(9) || dd.table_name || char(9) || coalesce(dl.message, dd.commit_hash) || char(9) || dd.data_change FROM dolt_diff dd LEFT JOIN dolt_log dl ON dl.commit_hash = dd.commit_hash"
+  local q_dolt="SELECT concat('D', char(9), dd.table_name, char(9), coalesce(dl.message, dd.commit_hash), char(9), dd.data_change) FROM dolt_diff dd LEFT JOIN dolt_log dl ON dl.commit_hash = dd.commit_hash"
+
+  local dl_out
+  dl_out=$(printf "%s\n.headers off\n.mode list\n.separator '\t'\n%s;\n" "$setup" "$q" \
+           | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
+           | grep '^D.*dolt_schemas' \
+           | sed -e 's/	true$/	1/' -e 's/	false$/	0/' \
+           | normalize)
+
+  local dolt_setup
+  dolt_setup=$(echo "$setup" | sed -E 's/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g')
+
+  local dt_out
+  dt_out=$(
+    cd "$dir/dt" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    {
+      printf '%s\n' "$dolt_setup"
+      printf '%s;\n' "$q_dolt"
+    } | "$DOLT" sql -r csv 2>"$dir/dt.err"
+  )
+  dt_out=$(echo "$dt_out" | tr -d '"' | grep '^D.*dolt_schemas' \
+           | sed -e 's/	true$/	1/' -e 's/	false$/	0/' \
+           | normalize)
+
+  if [ "$dl_out" = "$dt_out" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite:"; echo "$dl_out" | sed 's/^/      /'
+    echo "    dolt:";     echo "$dt_out" | sed 's/^/      /'
+  fi
+}
+
+SEED="
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1, 10);
+INSERT INTO t VALUES(2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'seed');
+"
+
+echo "=== Version Control Oracle Tests: dolt_schemas ==="
+echo ""
+
+echo "--- dolt_schemas table contents ---"
+
+oracle_schemas "no_views" "$SEED"
+
+oracle_schemas "one_view" "
+$SEED
+CREATE VIEW high AS SELECT * FROM t WHERE v > 15;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'add_view');
+"
+
+oracle_schemas "two_views" "
+$SEED
+CREATE VIEW high AS SELECT * FROM t WHERE v > 15;
+CREATE VIEW low AS SELECT * FROM t WHERE v < 100;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'add_views');
+"
+
+oracle_schemas "view_then_drop" "
+$SEED
+CREATE VIEW high AS SELECT * FROM t WHERE v > 15;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'add_view');
+DROP VIEW high;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'drop_view');
+"
+
+oracle_schemas "uncommitted_view_visible" "
+$SEED
+CREATE VIEW pending AS SELECT * FROM t;
+"
+
+echo "--- dolt_diff visibility of view-touching commits ---"
+
+# Adding a view in its own commit: dolt_diff should show dolt_schemas
+# touched and NOT show the underlying table 't' touched.
+oracle_diff_touches_schemas "view_only_commit" "
+$SEED
+CREATE VIEW high AS SELECT * FROM t WHERE v > 15;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'just_view');
+"
+
+# CREATE TABLE does NOT touch dolt_schemas in either engine.
+oracle_diff_touches_schemas "table_only_no_schemas_touch" "
+CREATE TABLE t(id INT PRIMARY KEY);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'just_table');
+"
+
+# Multiple commits, some touching views, some not.
+oracle_diff_touches_schemas "mixed_commits" "
+$SEED
+CREATE VIEW v1 AS SELECT * FROM t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'view_commit_1');
+INSERT INTO t VALUES(3, 30);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'data_commit');
+DROP VIEW v1;
+CREATE VIEW v2 AS SELECT * FROM t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'view_commit_2');
+"
+
+# Combined commit: both a table change and a view change in one
+# commit. dolt_diff should surface both as separate rows.
+oracle_diff_touches_schemas "combined_table_and_view" "
+$SEED
+INSERT INTO t VALUES(3, 30);
+CREATE VIEW high AS SELECT * FROM t WHERE v > 15;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'combined');
+"
+
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+if [ $fail -gt 0 ]; then
+  echo "Failed:$FAILED_NAMES"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
Mirrors Dolt's `dolt_schemas` system table by projecting `sqlite_schema` rows with `type IN ('view','trigger')`. Since `sqlite_schema` is already table #1 in doltlite's branch-scoped catalog, views are already version-controlled per branch — this PR just makes them visible and diffable through the Dolt-compatible surface.

Three pieces:

1. **`src/doltlite_schemas.c`** (new): read-only `dolt_schemas` vtable. On `xFilter`, runs an internal `SELECT` over the live `sqlite_schema` filtered to views/triggers and caches rows with the columns Dolt exposes: `type`, `name`, `fragment`, `extra`, `sql_mode`. The `fragment` column holds the full `CREATE` statement (matching Dolt). `extra` and `sql_mode` are always NULL — Dolt uses them for JSON metadata and MySQL `sql_mode` respectively, neither of which doltlite tracks.

2. **`src/doltlite_diff.c`**: extend the summary walker so `sqlite_master` changes surface under the synthetic name `dolt_schemas` when they touch view/trigger rows specifically (not for plain `CREATE TABLE`, which is already attributed to the created table). Detection opens a prolly diff iter between parent and child `sqlite_schema` roots and inspects field 0 (the `type` column) of each diff change. Works for both committed history and the working-set `WORKING` pseudo-row.

3. **`test/vc_oracle_schemas_test.sh`** (new): **9 oracle scenarios vs Dolt 1.86.0+**
   - **`dolt_schemas` contents**: no views, one view, two views, after a `DROP VIEW`, uncommitted view visible live
   - **`dolt_diff` visibility**: view-only commit, table-only commit does NOT touch `dolt_schemas`, mixed view/data commit sequence, combined table+view in one commit

The `dolt_diff` oracle intentionally filters `dolt_schemas` rows in shell rather than via `WHERE table_name='dolt_schemas'`, because `table_name` is a HIDDEN polymorphic constraint column on `dolt_diff` — a `WHERE table_name=...` clause routes the query into the legacy per-row form and returns empty. (Worth filing separately as a minor rough edge on the polymorphic vtable design.)

**All 9 scenarios match Dolt byte-for-byte on the compared columns.**

## Test plan
- [x] `bash test/vc_oracle_schemas_test.sh ./doltlite dolt` → 9 passed, 0 failed
- [x] `bash test/vc_oracle_diff_test.sh ./doltlite dolt` → 25 passed (existing summary + dolt_diff_<table>)
- [x] `bash test/doltlite_diff.sh` → 22 passed
- [x] `bash test/doltlite_advanced.sh` → 140 passed
- [x] `bash test/doltlite_unicode_blob.sh` → 46 passed
- [x] `bash test/doltlite_commit.sh` → 35 passed
- [x] `bash test/doltlite_conflicts.sh` → 37 passed
- [x] `bash test/doltlite_gc.sh` → 49 passed
- [ ] CI green

## Scope for follow-up
- **Triggers** are in scope semantically (`type='trigger'`) but not oracle-tested because Dolt uses MySQL-style `CREATE TRIGGER ... FOR EACH ROW BEGIN ... END` while doltlite uses SQLite-style `CREATE TRIGGER ... BEGIN SELECT ...; END`. Oracle would need per-engine SQL.
- **Writable `dolt_schemas`** (`INSERT`/`UPDATE`/`DELETE` translated to `CREATE`/`DROP` DDL) is deferred; `CREATE VIEW` / `DROP VIEW` is the supported path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)