### PR TITLE
dolt_diff: fall through to summary filter when table_name isn't live

### DIFF
--- a/src/doltlite_diff.c
+++ b/src/doltlite_diff.c
@@ -613,12 +613,43 @@ static int diffFilter(sqlite3_vtab_cursor *pCursor,
 
   if( !zTableName ) return SQLITE_OK;
 
-  
   pCur->iPkField = detectPkField(db, zTableName);
 
-  
   rc = doltliteResolveTableName(db, zTableName, &iTable);
-  if( rc!=SQLITE_OK ) return SQLITE_OK; 
+  if( rc!=SQLITE_OK ){
+    /* The named object isn't a user table — but the user may be
+    ** filtering dolt_diff's summary output by table_name (e.g.
+    ** `SELECT * FROM dolt_diff WHERE table_name='dolt_schemas'`).
+    ** The HIDDEN column + bestIndex routing can't distinguish a
+    ** filter from a TVF call, so fall through to summary mode and
+    ** filter the result by name. Only do this when no commit bounds
+    ** are specified — a 3-arg call names a missing table for a
+    ** real reason and should stay empty. */
+    if( zFromCommit==0 && zToCommit==0 ){
+      int i;
+      pCur->isSummary = 1;
+      rc = collectSummary(pCur, db);
+      if( rc!=SQLITE_OK ) return rc;
+      /* In-place filter. Shift-compact kept rows to the front. */
+      {
+        int out = 0;
+        for(i=0; i<pCur->nSummary; i++){
+          if( pCur->aSummary[i].zTableName
+           && strcmp(pCur->aSummary[i].zTableName, zTableName)==0 ){
+            if( out!=i ) pCur->aSummary[out] = pCur->aSummary[i];
+            out++;
+          }else{
+            sqlite3_free(pCur->aSummary[i].zTableName);
+            sqlite3_free(pCur->aSummary[i].zCommitter);
+            sqlite3_free(pCur->aSummary[i].zEmail);
+            sqlite3_free(pCur->aSummary[i].zMessage);
+          }
+        }
+        pCur->nSummary = out;
+      }
+    }
+    return SQLITE_OK;
+  }
 
   
   if( zFromCommit ){

--- a/test/vc_oracle_diff_test.sh
+++ b/test/vc_oracle_diff_test.sh
@@ -210,6 +210,51 @@ oracle_summary() {
   fi
 }
 
+# Oracle for `dolt_diff WHERE dd.table_name='X'` filtering a commit
+# that names a table that no longer exists (dropped at some point).
+# This exercises the fallback path where doltlite's polymorphic
+# vtable can't resolve the name to a live user table and therefore
+# falls through to summary mode with an in-memory name filter.
+#
+# Intentionally different from the TVF form `dolt_diff('X')`, which
+# still goes per-row against a live table.
+oracle_summary_filter_name() {
+  local name="$1" setup="$2" target="$3"
+  local dir="$TMPROOT/${name}_filter"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local q="SELECT 'S' || char(9) || dd.table_name || char(9) || coalesce(dl.message, dd.commit_hash) || char(9) || dd.data_change || char(9) || dd.schema_change FROM dolt_diff dd LEFT JOIN dolt_log dl ON dl.commit_hash = dd.commit_hash WHERE dd.table_name = '$target'"
+  local q_dolt="SELECT concat('S', char(9), dd.table_name, char(9), coalesce(dl.message, dd.commit_hash), char(9), dd.data_change, char(9), dd.schema_change) FROM dolt_diff dd LEFT JOIN dolt_log dl ON dl.commit_hash = dd.commit_hash WHERE dd.table_name = '$target'"
+
+  local dl_out
+  dl_out=$(printf "%s\n.headers off\n.mode list\n.separator '\t'\n%s;\n" "$setup" "$q" \
+           | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
+           | normalize_summary)
+
+  local dolt_setup
+  dolt_setup=$(echo "$setup" | sed -E 's/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g')
+
+  local dt_out
+  dt_out=$(
+    cd "$dir/dt" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    {
+      printf '%s\n' "$dolt_setup"
+      printf '%s;\n' "$q_dolt"
+    } | "$DOLT" sql -r csv 2>"$dir/dt.err" | tr -d '"' | normalize_summary
+  )
+
+  if [ "$dl_out" = "$dt_out" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite:"; echo "$dl_out" | sed 's/^/      /'
+    echo "    dolt:";     echo "$dt_out" | sed 's/^/      /'
+  fi
+}
+
 echo "=== Version Control Oracle Tests: dolt_diff / dolt_diff_<table> ==="
 echo ""
 
@@ -515,6 +560,57 @@ oracle_summary "summary_working_set_excluded" "
 $SEED
 UPDATE t SET v = 99 WHERE id = 1;
 "
+
+echo "--- summary form: WHERE table_name=... filter ---"
+
+# Filter summary rows to a table that has been DROPPED by the time
+# of the query. doltlite's polymorphic vtable can't resolve the
+# name to a live user table, so it must fall through to summary
+# mode with an in-memory name filter.
+oracle_summary_filter_name "filter_dropped_table" "
+CREATE TABLE dropped(id INT PRIMARY KEY, v INT);
+INSERT INTO dropped VALUES(1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1_create_dropped');
+INSERT INTO dropped VALUES(2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2_modify_dropped');
+DROP TABLE dropped;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c3_drop_dropped');
+" "dropped"
+
+# Filter to a name that never existed — both engines return empty.
+oracle_summary_filter_name "filter_nonexistent_name" "
+$SEED
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2');
+" "never_existed"
+
+# Filter to a table that appears in multiple commits with a mix of
+# data and schema changes, along with unrelated tables in those
+# commits. The filter should return only the rows that match the
+# named table.
+oracle_summary_filter_name "filter_mixed_history" "
+CREATE TABLE x(id INT PRIMARY KEY, v INT);
+INSERT INTO x VALUES(1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'create_x');
+CREATE TABLE y(id INT PRIMARY KEY);
+INSERT INTO y VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'create_y');
+INSERT INTO x VALUES(2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'update_x');
+INSERT INTO y VALUES(2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'update_y');
+DROP TABLE x;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'drop_x');
+" "x"
 
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="


### PR DESCRIPTION
## Summary
doltlite's `dolt_diff` vtable is polymorphic — when the HIDDEN `table_name` column is constrained (either via the TVF form `dolt_diff('t')` or a bare `WHERE table_name='t'` clause), `xFilter` routes to the legacy per-row form. SQLite's `bestIndex` can't distinguish the two syntactic origins, so both look the same to the vtable.

For names that resolve to live user tables this is fine: per-row mode is the intended behavior for `dolt_diff('t')`. But for names that **don't** resolve to a live table — dropped tables, synthetic names like `dolt_schemas`, or typos — the previous behavior was to silently return empty. Users who wrote `WHERE table_name=...` to filter summary rows got an empty result set, not the filtered summary they expected. The `dolt_schemas` oracle test (#397) worked around this by grep-filtering in shell.

**Fix:** in `diffFilter`, when the per-row path's `doltliteResolveTableName` fails **and** no `from_commit`/`to_commit` is specified, fall through to summary mode and filter `pCur->aSummary` in-place to rows whose `table_name` matches the requested value.

### Scope rules
| Query shape | Behavior |
|---|---|
| Table exists | per-row mode (unchanged, preserves TVF semantics) |
| Table doesn't exist + no commit bounds | summary mode + name filter (NEW) |
| Table doesn't exist + commit bounds specified | empty (unchanged; a 3-arg call for a missing table is an explicit per-row request that should stay empty) |

### New oracle scenarios
Adds 3 new oracle scenarios via a new helper `oracle_summary_filter_name`:
- **`filter_dropped_table`**: name was dropped by the time of the query; should return all historical summary rows mentioning it
- **`filter_nonexistent_name`**: returns empty on both engines
- **`filter_mixed_history`**: multiple tables in history, filter returns only rows matching the target name

## Test plan
- [x] `bash test/vc_oracle_diff_test.sh ./doltlite dolt` → 28 passed (25 existing + 3 new), 0 failed
- [x] `bash test/doltlite_diff.sh` → 22 passed (existing TVF `dolt_diff('t')` tests)
- [x] `bash test/doltlite_diff_alter.sh` → 15 passed
- [x] `bash test/doltlite_advanced.sh` → 140 passed
- [x] `bash test/doltlite_unicode_blob.sh` → 46 passed
- [x] `bash test/doltlite_gc.sh` → 49 passed
- [x] `bash test/doltlite_conflicts.sh` → 37 passed
- [ ] CI green

## Follow-up
After this lands, `test/vc_oracle_schemas_test.sh` (PR #397) can drop its shell-level grep workaround and use `WHERE table_name='dolt_schemas'` directly. Small cleanup, deferred until both PRs are merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)