### PR TITLE
Fix stale snapshot storage refresh paths

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -142,6 +142,7 @@ static void csFreeRefsState(ChunkStore *cs);
 static int csDeserializeRefsIntoTemp(ChunkStore *pTmp, const u8 *data, int nData);
 static void csAdoptRefsState(ChunkStore *pDst, ChunkStore *pSrc);
 static int csReloadFromDisk(ChunkStore *cs);
+static int csDetectExternalChanges(ChunkStore *cs, int *pChanged);
 
 #define CS_WAL_TAG_CHUNK  0x01
 #define CS_WAL_TAG_ROOT   0x02
@@ -1982,13 +1983,12 @@ void chunkStoreUnlock(ChunkStore *cs){
   }
 }
 
-int chunkStoreRefreshIfChanged(ChunkStore *cs, int *pChanged){
+static int csDetectExternalChanges(ChunkStore *cs, int *pChanged){
   int bMoved = 0;
   int rc;
+
   *pChanged = 0;
   if( cs->isMemory ) return SQLITE_OK;
-
-  if( cs->snapshotPinned ) return SQLITE_OK;
 
   if( cs->pFile==0 ){
     int exists = 0;
@@ -1998,8 +1998,6 @@ int chunkStoreRefreshIfChanged(ChunkStore *cs, int *pChanged){
     if( exists ){
       struct stat mainStat;
       if( stat(cs->zFilename, &mainStat)==0 && mainStat.st_size > 0 ){
-        rc = csReloadFromDisk(cs);
-        if( rc!=SQLITE_OK ) return rc;
         *pChanged = 1;
       }
     }
@@ -2008,13 +2006,38 @@ int chunkStoreRefreshIfChanged(ChunkStore *cs, int *pChanged){
 
   rc = sqlite3OsFileControl(cs->pFile, SQLITE_FCNTL_HAS_MOVED, &bMoved);
   if( rc!=SQLITE_OK ) return rc;
+  if( bMoved ){
+    *pChanged = 1;
+    return SQLITE_OK;
+  }
 
-  if( !bMoved ){
+  {
     i64 fileSize = 0;
     rc = sqlite3OsFileSize(cs->pFile, &fileSize);
     if( rc!=SQLITE_OK ) return rc;
-    if( fileSize <= cs->iFileSize ) return SQLITE_OK;
+    if( fileSize > cs->iFileSize ){
+      *pChanged = 1;
+    }
   }
+  return SQLITE_OK;
+}
+
+int chunkStoreHasExternalChanges(ChunkStore *cs, int *pChanged){
+  return csDetectExternalChanges(cs, pChanged);
+}
+
+int chunkStoreRefreshIfChanged(ChunkStore *cs, int *pChanged){
+  int rc;
+  int bChanged = 0;
+  if( cs->isMemory ){
+    *pChanged = 0;
+    return SQLITE_OK;
+  }
+  *pChanged = 0;
+  if( cs->snapshotPinned ) return SQLITE_OK;
+  rc = csDetectExternalChanges(cs, &bChanged);
+  if( rc!=SQLITE_OK ) return rc;
+  if( !bChanged ) return SQLITE_OK;
 
   rc = csReloadFromDisk(cs);
   if( rc!=SQLITE_OK ) return rc;

--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -181,6 +181,7 @@ int chunkStoreClose(ChunkStore *cs);
 ** another connection holds the lock. Caller must call Unlock after. */
 int chunkStoreLockAndRefresh(ChunkStore *cs);
 void chunkStoreUnlock(ChunkStore *cs);
+int chunkStoreHasExternalChanges(ChunkStore *cs, int *pChanged);
 
 int chunkStoreWriteBranchWorkingCatalog(ChunkStore *cs, const char *zBranch,
                                         const ProllyHash *pCatHash,

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -177,6 +177,17 @@ static int doltliteRefreshAndConfirmHead(
   rc = chunkStoreLockAndRefresh(cs);
   if( rc!=SQLITE_OK ) return rc;
 
+  if( cs->snapshotPinned ){
+    int changed = 0;
+    cs->snapshotPinned = 0;
+    rc = chunkStoreRefreshIfChanged(cs, &changed);
+    cs->snapshotPinned = 1;
+    if( rc!=SQLITE_OK ){
+      chunkStoreUnlock(cs);
+      return rc;
+    }
+  }
+ 
   zBranch = doltliteGetSessionBranch(db);
   if( chunkStoreFindBranch(cs, zBranch, &branchTip)==SQLITE_OK
    && prollyHashCompare(&branchTip, pExpectedHead)!=0 ){
@@ -253,6 +264,16 @@ int doltliteMutateRefs(sqlite3 *db, DoltliteRefsMutation xMutate, void *pArg){
 
   rc = chunkStoreLockAndRefresh(cs);
   if( rc!=SQLITE_OK ) return rc;
+  if( cs->snapshotPinned ){
+    int changed = 0;
+    cs->snapshotPinned = 0;
+    rc = chunkStoreRefreshIfChanged(cs, &changed);
+    cs->snapshotPinned = 1;
+    if( rc!=SQLITE_OK ){
+      chunkStoreUnlock(cs);
+      return rc;
+    }
+  }
 
   rc = xMutate(db, cs, pArg);
   if( rc==SQLITE_OK ){
@@ -658,6 +679,7 @@ static void doltliteCommitFunc(
   int skipEmpty = 0;         /* --skip-empty:  silently no-op when no changes */
   ProllyHash commitHash;
   ProllyHash catalogHash;
+  ProllyHash sessionHeadBeforeLock;
   char hexBuf[PROLLY_HASH_SIZE*2+1];
   int rc;
   int i;
@@ -1017,34 +1039,20 @@ static void doltliteCommitFunc(
     }
   }
 
+  doltliteGetSessionHead(db, &sessionHeadBeforeLock);
+
   /* Lock the commit graph, refresh from disk, then check for conflicts.
   ** This serializes all commit graph mutations across connections. */
-  rc = chunkStoreLockAndRefresh(cs);
+  rc = doltliteRefreshAndConfirmHead(db, cs, &sessionHeadBeforeLock);
   if( rc==SQLITE_BUSY ){
     sqlite3_result_error(context,
-      "database is locked by another connection", -1);
+      "commit conflict: another connection committed to this branch. "
+      "Please retry your transaction.", -1);
     return;
   }
   if( rc!=SQLITE_OK ){
     sqlite3_result_error_code(context, rc);
     return;
-  }
-
-  /* Under lock: check if branch tip still matches our session HEAD */
-  {
-    const char *branch = doltliteGetSessionBranch(db);
-    ProllyHash branchTip;
-    ProllyHash sessionHead;
-    doltliteGetSessionHead(db, &sessionHead);
-    if( chunkStoreFindBranch(cs, branch, &branchTip)==SQLITE_OK ){
-      if( prollyHashCompare(&sessionHead, &branchTip)!=0 ){
-        chunkStoreUnlock(cs);
-        sqlite3_result_error(context,
-          "commit conflict: another connection committed to this branch. "
-          "Please retry your transaction.", -1);
-        return;
-      }
-    }
   }
 
   /* Under lock: update session and shared state */
@@ -1094,6 +1102,7 @@ static void doltliteResetFunc(
   ProllyHash targetCatHash;
   ProllyHash targetCommit;
   ProllyHash preResetHeadCatHash;
+  ProllyHash sessionHeadBeforeLock;
   int havePreResetHead = 0;
   int isHard = 0;
   int isSoft = 0;
@@ -1314,10 +1323,12 @@ static void doltliteResetFunc(
     memcpy(&targetCatHash, &commit.catalogHash, sizeof(ProllyHash));
     doltliteCommitClear(&commit);
 
-    rc = chunkStoreLockAndRefresh(cs);
+    doltliteGetSessionHead(db, &sessionHeadBeforeLock);
+    rc = doltliteRefreshAndConfirmHead(db, cs, &sessionHeadBeforeLock);
     if( rc==SQLITE_BUSY ){
       sqlite3_result_error(context,
-        "database is locked by another connection", -1);
+        "reset conflict: another connection moved this branch. "
+        "Please retry your transaction.", -1);
       return;
     }
     if( rc!=SQLITE_OK ){
@@ -1325,20 +1336,6 @@ static void doltliteResetFunc(
       return;
     }
     graphLocked = 1;
-
-    {
-      const char *branch = doltliteGetSessionBranch(db);
-      ProllyHash branchTip;
-      ProllyHash sessionHead;
-      doltliteGetSessionHead(db, &sessionHead);
-      if( chunkStoreFindBranch(cs, branch, &branchTip)==SQLITE_OK
-       && prollyHashCompare(&sessionHead, &branchTip)!=0 ){
-        sqlite3_result_error(context,
-          "reset conflict: another connection moved this branch. "
-          "Please retry your transaction.", -1);
-        goto reset_cleanup;
-      }
-    }
 
     doltliteSetSessionHead(db, &targetCommit);
     rc = chunkStoreUpdateBranch(cs, doltliteGetSessionBranch(db), &targetCommit);

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -1597,7 +1597,6 @@ int sqlite3BtreeOpen(
           sqlite3_free(p);
           return rc;
         }
-        goto catalog_loaded;
       }else{
         sqlite3_free(catData);
         if( rc!=SQLITE_OK ){
@@ -1635,7 +1634,6 @@ int sqlite3BtreeOpen(
     return SQLITE_NOMEM;
   }
 
-catalog_loaded:
   p->db = db;
   p->pBt = pBt;
   p->pOps = &prollyBtreeOps;

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -1554,10 +1554,34 @@ int sqlite3BtreeOpen(
   ** since p->zBranch hasn't been set yet (checkout happens later). */
   {
     ProllyHash catHash;
+    ProllyHash workingCommit;
+    ProllyHash stagedCatalog;
+    ProllyHash mergeCommitHash;
+    ProllyHash conflictsCatalogHash;
+    ProllyHash branchCommit;
     const char *zDef = chunkStoreGetDefaultBranch(&pBt->store);
+    u8 isMerging = 0;
     if( !zDef ) zDef = "main";
     memset(&catHash, 0, sizeof(catHash));
-    btreeReadWorkingCatalog(&pBt->store, zDef, &catHash, NULL);
+    memset(&workingCommit, 0, sizeof(workingCommit));
+    memset(&stagedCatalog, 0, sizeof(stagedCatalog));
+    memset(&mergeCommitHash, 0, sizeof(mergeCommitHash));
+    memset(&conflictsCatalogHash, 0, sizeof(conflictsCatalogHash));
+    memset(&branchCommit, 0, sizeof(branchCommit));
+    rc = btreeLoadWorkingSetBlob(&pBt->store, zDef, &catHash, &workingCommit,
+                                 &stagedCatalog, &isMerging,
+                                 &mergeCommitHash, &conflictsCatalogHash);
+    if( rc==SQLITE_NOTFOUND ){
+      rc = SQLITE_OK;
+    }
+    if( rc!=SQLITE_OK ){
+      pagerShimDestroy(pBt->pPagerShim);
+      prollyCacheFree(&pBt->cache);
+      chunkStoreClose(&pBt->store);
+      sqlite3_free(pBt);
+      sqlite3_free(p);
+      return rc;
+    }
     if( !prollyHashIsEmpty(&catHash) ){
       u8 *catData = 0;
       int nCatData = 0;
@@ -1574,8 +1598,30 @@ int sqlite3BtreeOpen(
           return rc;
         }
         goto catalog_loaded;
+      }else{
+        sqlite3_free(catData);
+        if( rc!=SQLITE_OK ){
+          pagerShimDestroy(pBt->pPagerShim);
+          prollyCacheFree(&pBt->cache);
+          chunkStoreClose(&pBt->store);
+          sqlite3_free(pBt);
+          sqlite3_free(p);
+          return rc;
+        }
       }
     }
+
+    if( chunkStoreFindBranch(&pBt->store, zDef, &branchCommit)==SQLITE_OK ){
+      memcpy(&p->headCommit, &branchCommit, sizeof(ProllyHash));
+    }else if( !prollyHashIsEmpty(&workingCommit) ){
+      memcpy(&p->headCommit, &workingCommit, sizeof(ProllyHash));
+    }else{
+      memset(&p->headCommit, 0, sizeof(ProllyHash));
+    }
+    p->stagedCatalog = stagedCatalog;
+    p->isMerging = isMerging;
+    p->mergeCommitHash = mergeCommitHash;
+    p->conflictsCatalogHash = conflictsCatalogHash;
   }
 
   
@@ -1605,38 +1651,10 @@ catalog_loaded:
     const char *defBranch = chunkStoreGetDefaultBranch(&pBt->store);
     ProllyHash branchCommit;
     p->zBranch = sqlite3_mprintf("%s", defBranch);
-    
-    if( chunkStoreFindBranch(&pBt->store, defBranch, &branchCommit)==SQLITE_OK ){
+
+    if( prollyHashIsEmpty(&p->headCommit)
+     && chunkStoreFindBranch(&pBt->store, defBranch, &branchCommit)==SQLITE_OK ){
       memcpy(&p->headCommit, &branchCommit, sizeof(ProllyHash));
-    }else{
-      memset(&p->headCommit, 0, sizeof(ProllyHash));
-    }
-    
-    {
-      ProllyHash wsHash;
-      if( chunkStoreGetBranchWorkingSet(&pBt->store, defBranch, &wsHash)==SQLITE_OK
-       && !prollyHashIsEmpty(&wsHash) ){
-        
-        u8 *wsData = 0; int nWsData = 0;
-        if( chunkStoreGet(&pBt->store, &wsHash, &wsData, &nWsData)==SQLITE_OK
-         && wsData && nWsData >= WS_TOTAL_SIZE && wsData[0] == 2 ){
-          memcpy(p->stagedCatalog.data, wsData + WS_STAGED_OFF, PROLLY_HASH_SIZE);
-          p->isMerging = wsData[WS_MERGING_OFF];
-          memcpy(p->mergeCommitHash.data, wsData + WS_MERGE_COMMIT_OFF, PROLLY_HASH_SIZE);
-          memcpy(p->conflictsCatalogHash.data, wsData + WS_CONFLICTS_OFF, PROLLY_HASH_SIZE);
-        }else{
-          memset(&p->stagedCatalog, 0, sizeof(ProllyHash));
-          p->isMerging = 0;
-          memset(&p->mergeCommitHash, 0, sizeof(ProllyHash));
-          memset(&p->conflictsCatalogHash, 0, sizeof(ProllyHash));
-        }
-        sqlite3_free(wsData);
-      }else{
-        memset(&p->stagedCatalog, 0, sizeof(ProllyHash));
-        p->isMerging = 0;
-        memset(&p->mergeCommitHash, 0, sizeof(ProllyHash));
-        memset(&p->conflictsCatalogHash, 0, sizeof(ProllyHash));
-      }
     }
   }
 
@@ -2087,6 +2105,19 @@ static int prollyBtreeBeginTrans(Btree *p, int wrFlag, int *pSchemaVersion){
     ** latest committed state. */
     rc = chunkStoreLockAndRefresh(&pBt->store);
     if( rc!=SQLITE_OK ) return rc;
+
+    if( p->inTrans==TRANS_READ ){
+      int bChanged = 0;
+      rc = chunkStoreHasExternalChanges(&pBt->store, &bChanged);
+      if( rc!=SQLITE_OK ){
+        chunkStoreUnlock(&pBt->store);
+        return rc;
+      }
+      if( bChanged ){
+        chunkStoreUnlock(&pBt->store);
+        return SQLITE_BUSY_SNAPSHOT;
+      }
+    }
 
     rc = btreeReloadBranchWorkingState(p, 1);
     if( rc!=SQLITE_OK ){
@@ -5609,7 +5640,8 @@ int doltliteLoadWorkingSet(sqlite3 *db, const char *zBranch){
   pBtree = db->aDb[0].pBt;
   if( !cs ) return SQLITE_ERROR;
 
-  rc = btreeLoadWorkingSetBlob(cs, zBranch, 0, 0, &pBtree->stagedCatalog,
+  rc = btreeLoadWorkingSetBlob(cs, zBranch, 0, 0,
+                               &pBtree->stagedCatalog,
                                &pBtree->isMerging, &pBtree->mergeCommitHash,
                                &pBtree->conflictsCatalogHash);
   if( rc == SQLITE_NOTFOUND ){

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -40,6 +40,8 @@
 **   ./doltlite_regression_test_c mutmap_empty_reverse_iter
 **   ./doltlite_regression_test_c working_set_refreshes_staged_across_connections
 **   ./doltlite_regression_test_c begin_write_refreshes_working_set_metadata
+**   ./doltlite_regression_test_c begin_write_from_stale_read_snapshot
+**   ./doltlite_regression_test_c open_rejects_corrupt_working_set
 */
 #include <stdio.h>
 #include <stdlib.h>
@@ -1610,6 +1612,88 @@ static void run_begin_write_refreshes_working_set_metadata(void){
   remove_db(dbpath);
 }
 
+static void run_begin_write_from_stale_read_snapshot(void){
+  sqlite3 *db1 = 0;
+  sqlite3 *db2 = 0;
+  sqlite3_stmt *pRead = 0;
+  char dbpath[256];
+  int rc;
+
+  printf("=== Begin Write From Stale Read Snapshot Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_begin_write_from_stale_read_snapshot");
+  remove_db(dbpath);
+
+  check("open_db1_for_stale_snapshot", open_db(dbpath, &db1)==SQLITE_OK);
+  check("create_table_for_stale_snapshot",
+        execsql(db1, "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);")==SQLITE_OK);
+  check("insert_row_for_stale_snapshot",
+        execsql(db1, "INSERT INTO t VALUES(1,'a');")==SQLITE_OK);
+  check("open_db2_for_stale_snapshot", open_db(dbpath, &db2)==SQLITE_OK);
+
+  check("begin_read_txn_for_stale_snapshot", execsql(db2, "BEGIN;")==SQLITE_OK);
+  check("prepare_read_in_stale_snapshot",
+        sqlite3_prepare_v2(db2, "SELECT count(*) FROM t", -1, &pRead, 0)==SQLITE_OK);
+  check("step_read_in_stale_snapshot", sqlite3_step(pRead)==SQLITE_ROW);
+  check("read_in_stale_snapshot", sqlite3_column_int(pRead, 0)==1);
+  check("db1_autocommit_change_after_read_snapshot",
+        execsql(db1, "INSERT INTO t VALUES(2,'b');")==SQLITE_OK);
+
+  rc = execsql_silent(db2, "INSERT INTO t VALUES(3,'c');");
+  check("write_upgrade_fails", rc!=SQLITE_OK);
+  check("write_upgrade_returns_busy_snapshot",
+        sqlite3_extended_errcode(db2)==SQLITE_BUSY_SNAPSHOT);
+  sqlite3_finalize(pRead);
+  check("rollback_stale_snapshot_txn", execsql(db2, "ROLLBACK;")==SQLITE_OK);
+  check("stale_snapshot_did_not_overwrite_rows",
+        strcmp(exec1(db1, "SELECT count(*) FROM t"), "2")==0);
+
+  sqlite3_close(db2);
+  sqlite3_close(db1);
+  remove_db(dbpath);
+}
+
+static void run_open_rejects_corrupt_working_set(void){
+  sqlite3 *db = 0;
+  sqlite3 *db2 = 0;
+  ChunkStore cs;
+  char dbpath[256];
+  int stmtRc;
+  ProllyHash badHash;
+  int rc;
+  static const unsigned char badBlob[] = { 0x01, 0x02, 0x03, 0x04 };
+
+  printf("=== Open Rejects Corrupt Working Set Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_open_rejects_corrupt_working_set");
+  remove_db(dbpath);
+
+  check("open_db_for_corrupt_working_set", open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_repo_for_corrupt_working_set", execsql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'a');"
+    "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
+  sqlite3_close(db);
+  db = 0;
+
+  check("open_store_for_corrupt_working_set",
+        chunkStoreOpen(&cs, sqlite3_vfs_find(0), dbpath,
+          SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB)==SQLITE_OK);
+  check("store_bad_working_set_blob",
+        chunkStorePut(&cs, badBlob, (int)sizeof(badBlob), &badHash)==SQLITE_OK);
+  check("point_main_branch_at_bad_working_set",
+        chunkStoreSetBranchWorkingSet(&cs, "main", &badHash)==SQLITE_OK);
+  check("serialize_refs_for_bad_working_set",
+        chunkStoreSerializeRefs(&cs)==SQLITE_OK);
+  check("commit_bad_working_set_refs", chunkStoreCommit(&cs)==SQLITE_OK);
+  chunkStoreClose(&cs);
+
+  rc = sqlite3_open(dbpath, &db2);
+  stmtRc = db2 ? execsql_silent(db2, "SELECT count(*) FROM sqlite_master;") : rc;
+  check("open_or_first_statement_returns_corrupt_for_bad_working_set",
+        rc==SQLITE_CORRUPT || stmtRc==SQLITE_CORRUPT);
+  if( db2 ) sqlite3_close(db2);
+  remove_db(dbpath);
+}
+
 static void run_truncated_wal_is_rejected(void){
   sqlite3 *db = 0;
   ChunkStore cs;
@@ -2093,6 +2177,8 @@ static const RegressionCase aCases[] = {
   { "prepared_stmt_reuse_after_schema_checkout", "Prepared Statement Reuse After Schema Checkout Test", run_prepared_stmt_reuse_after_schema_checkout },
   { "working_set_refreshes_staged_across_connections", "Working Set Refreshes Staged Across Connections Test", run_working_set_refreshes_staged_across_connections },
   { "begin_write_refreshes_working_set_metadata", "Begin Write Refreshes Working Set Metadata Test", run_begin_write_refreshes_working_set_metadata },
+  { "begin_write_from_stale_read_snapshot", "Begin Write From Stale Read Snapshot Test", run_begin_write_from_stale_read_snapshot },
+  { "open_rejects_corrupt_working_set", "Open Rejects Corrupt Working Set Test", run_open_rejects_corrupt_working_set },
   { "btree_commit_failure_transactional", "Btree Commit Failure Transaction Test", run_btree_commit_failure_transactional },
   { "savepoint_restores_session_metadata", "Savepoint Restores Session Metadata Test", run_savepoint_restores_session_metadata },
   { "hard_reset_failure_restores_memory_state", "Hard Reset Failure Restores Memory State Test", run_hard_reset_failure_restores_memory_state },

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -39,6 +39,7 @@
 **   ./doltlite_regression_test_c btree_commit_failure_transactional
 **   ./doltlite_regression_test_c mutmap_empty_reverse_iter
 **   ./doltlite_regression_test_c working_set_refreshes_staged_across_connections
+**   ./doltlite_regression_test_c reopen_preserves_staged_working_set
 **   ./doltlite_regression_test_c begin_write_refreshes_working_set_metadata
 **   ./doltlite_regression_test_c begin_write_from_stale_read_snapshot
 **   ./doltlite_regression_test_c open_rejects_corrupt_working_set
@@ -1553,6 +1554,46 @@ static void run_working_set_refreshes_staged_across_connections(void){
   remove_db(dbpath);
 }
 
+static void run_reopen_preserves_staged_working_set(void){
+  sqlite3 *db = 0;
+  char dbpath[256];
+  ProllyHash stagedBeforeClose;
+  ProllyHash stagedAfterReopen;
+
+  printf("=== Reopen Preserves Staged Working Set Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_reopen_preserves_staged_working_set");
+  remove_db(dbpath);
+
+  check("open_db_for_reopen_staged", open_db(dbpath, &db)==SQLITE_OK);
+  check("create_table_for_reopen_staged",
+        execsql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);")==SQLITE_OK);
+  check("insert_base_row_for_reopen_staged",
+        execsql(db, "INSERT INTO t VALUES(1,'a');")==SQLITE_OK);
+  check("commit_base_row_for_reopen_staged",
+        execsql(db, "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
+  check("stage_new_row_for_reopen_staged",
+        execsql(db,
+          "INSERT INTO t VALUES(2,'b');"
+          "SELECT dolt_add('-A');")==SQLITE_OK);
+  check("staged_status_before_close",
+        strcmp(exec1(db, "SELECT count(*) FROM dolt_status WHERE staged=1"), "1")==0);
+  doltliteGetSessionStaged(db, &stagedBeforeClose);
+  check("staged_hash_before_close_nonempty",
+        !prollyHashIsEmpty(&stagedBeforeClose));
+  sqlite3_close(db);
+  db = 0;
+
+  check("reopen_db_for_reopen_staged", open_db(dbpath, &db)==SQLITE_OK);
+  check("staged_status_after_reopen",
+        strcmp(exec1(db, "SELECT count(*) FROM dolt_status WHERE staged=1"), "1")==0);
+  doltliteGetSessionStaged(db, &stagedAfterReopen);
+  check("staged_hash_after_reopen_matches",
+        memcmp(&stagedAfterReopen, &stagedBeforeClose, sizeof(ProllyHash))==0);
+
+  sqlite3_close(db);
+  remove_db(dbpath);
+}
+
 static void run_begin_write_refreshes_working_set_metadata(void){
   sqlite3 *db1 = 0;
   sqlite3 *db2 = 0;
@@ -2176,6 +2217,7 @@ static const RegressionCase aCases[] = {
   { "prepared_stmt_reuse_after_commit", "Prepared Statement Reuse After Commit Test", run_prepared_stmt_reuse_after_commit },
   { "prepared_stmt_reuse_after_schema_checkout", "Prepared Statement Reuse After Schema Checkout Test", run_prepared_stmt_reuse_after_schema_checkout },
   { "working_set_refreshes_staged_across_connections", "Working Set Refreshes Staged Across Connections Test", run_working_set_refreshes_staged_across_connections },
+  { "reopen_preserves_staged_working_set", "Reopen Preserves Staged Working Set Test", run_reopen_preserves_staged_working_set },
   { "begin_write_refreshes_working_set_metadata", "Begin Write Refreshes Working Set Metadata Test", run_begin_write_refreshes_working_set_metadata },
   { "begin_write_from_stale_read_snapshot", "Begin Write From Stale Read Snapshot Test", run_begin_write_from_stale_read_snapshot },
   { "open_rejects_corrupt_working_set", "Open Rejects Corrupt Working Set Test", run_open_rejects_corrupt_working_set },


### PR DESCRIPTION
## Summary
- reject read-to-write upgrades from stale pinned snapshots with SQLITE_BUSY_SNAPSHOT
- force command-level ref mutations to refresh under lock even with pinned snapshots
- surface corrupt working-set blobs instead of masking them on open

## Testing
- ./build/doltlite_regression_test_c all