### PR TITLE
commit: trim message whitespace; dolt_diff: schema_change on first view

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -1008,8 +1008,45 @@ static void doltliteCommitFunc(
       }
     }
 
+    /* Trim leading/trailing ASCII whitespace from the commit message
+    ** to match git / Dolt semantics. The caller keeps whatever
+    ** internal whitespace they wrote. A message that's entirely
+    ** whitespace is rejected as empty. Scoped tightly so we can free
+    ** the allocation immediately after the commit is created. */
+    char *zTrimmedMessage = 0;
+    {
+      const char *pStart = zMessage;
+      const char *pEnd;
+      int len;
+      while( *pStart==' ' || *pStart=='\t'
+          || *pStart=='\n' || *pStart=='\r' ) pStart++;
+      pEnd = pStart + strlen(pStart);
+      while( pEnd>pStart
+          && (pEnd[-1]==' ' || pEnd[-1]=='\t'
+           || pEnd[-1]=='\n' || pEnd[-1]=='\r') ) pEnd--;
+      if( pEnd==pStart ){
+        sqlite3_free(zParsedName);
+        sqlite3_free(zParsedEmail);
+        sqlite3_result_error(context,
+          "dolt_commit requires a non-empty message", -1);
+        return;
+      }
+      len = (int)(pEnd - pStart);
+      zTrimmedMessage = sqlite3_malloc(len+1);
+      if( !zTrimmedMessage ){
+        sqlite3_free(zParsedName);
+        sqlite3_free(zParsedEmail);
+        sqlite3_result_error_code(context, SQLITE_NOMEM);
+        return;
+      }
+      memcpy(zTrimmedMessage, pStart, len);
+      zTrimmedMessage[len] = 0;
+      zMessage = zTrimmedMessage;
+    }
+
     rc = doltliteCreateAndStoreCommitWithTime(db, &parentHash, &catalogHash,
         zMessage, zParsedName, zParsedEmail, 0, 0, explicitTimestamp, &commitHash);
+    sqlite3_free(zTrimmedMessage);
     sqlite3_free(zParsedName);
     sqlite3_free(zParsedEmail);
     if( rc!=SQLITE_OK ){

--- a/src/doltlite_diff.c
+++ b/src/doltlite_diff.c
@@ -70,6 +70,41 @@ static int schemaHasViewOrTriggerDiff(sqlite3 *db,
   return found;
 }
 
+/* Returns 1 if the sqlite_schema btree at pRoot contains at least
+** one row whose type is 'view' or 'trigger'. Used by the summary
+** walker to detect whether dolt_schemas is being CREATED at a given
+** commit (parent has zero view/trigger rows) vs merely modified
+** (parent already has at least one). Dolt emits schema_change=1 on
+** the initial creation; we match that. */
+static int schemaHasAnyViewOrTrigger(sqlite3 *db,
+                                     const ProllyHash *pRoot,
+                                     u8 flags){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  ProllyCache *pCache = doltliteGetCache(db);
+  ProllyCursor cur;
+  int rc, res;
+  int found = 0;
+  if( !cs || !pCache ) return 0;
+  if( prollyHashIsEmpty(pRoot) ) return 0;
+  prollyCursorInit(&cur, cs, pCache, pRoot, flags);
+  rc = prollyCursorFirst(&cur, &res);
+  if( rc!=SQLITE_OK || res ){
+    prollyCursorClose(&cur);
+    return 0;
+  }
+  while( prollyCursorIsValid(&cur) ){
+    const u8 *pVal; int nVal;
+    prollyCursorValue(&cur, &pVal, &nVal);
+    if( schemaRecordIsViewOrTrigger(pVal, nVal) ){
+      found = 1;
+      break;
+    }
+    if( prollyCursorNext(&cur)!=SQLITE_OK ) break;
+  }
+  prollyCursorClose(&cur);
+  return found;
+}
+
 /* Per-row diff (legacy form: dolt_diff('table', from, to)). */
 typedef struct DiffRow DiffRow;
 struct DiffRow {
@@ -344,7 +379,10 @@ static int collectWorkingSetSummary(DoltliteDiffCursor *pCur, sqlite3 *db){
     struct TableEntry *p;
     u8 dataChange, schemaChange;
     if( !e->zName ){
-      /* sqlite_master: surface uncommitted view/trigger changes. */
+      /* sqlite_master: surface uncommitted view/trigger changes.
+      ** schema_change is 1 iff the HEAD side has NO view/trigger
+      ** rows yet — matching Dolt's behavior of reporting
+      ** schema_change on the implicit creation of dolt_schemas. */
       ProllyHash emptyRoot;
       const ProllyHash *pOldRoot;
       struct TableEntry *pOldMaster;
@@ -352,7 +390,10 @@ static int collectWorkingSetSummary(DoltliteDiffCursor *pCur, sqlite3 *db){
       pOldMaster = doltliteFindTableByNumber(aHead, nHead, 1);
       pOldRoot = pOldMaster ? &pOldMaster->root : &emptyRoot;
       if( schemaHasViewOrTriggerDiff(db, pOldRoot, &e->root, e->flags) ){
-        rc = appendSummaryRow(pCur, zHexBuf, "dolt_schemas", 0, 1, 0);
+        u8 schemaChangeFlag =
+          schemaHasAnyViewOrTrigger(db, pOldRoot, e->flags) ? 0 : 1;
+        rc = appendSummaryRow(pCur, zHexBuf, "dolt_schemas", 0,
+                              1, schemaChangeFlag);
         if( rc!=SQLITE_OK ) goto done;
       }
       continue;
@@ -424,7 +465,9 @@ static int collectSummaryForCommit(DoltliteDiffCursor *pCur, sqlite3 *db,
       ** Regular CREATE TABLE also touches sqlite_master but is
       ** already attributed to the created table above, so we only
       ** emit dolt_schemas when the change specifically touches a
-      ** view or trigger row. */
+      ** view or trigger row. schema_change is 1 iff the parent side
+      ** had NO view/trigger rows yet — matching Dolt's reporting of
+      ** schema_change on the implicit creation of dolt_schemas. */
       ProllyHash emptyRoot;
       const ProllyHash *pOldRoot;
       struct TableEntry *pOldMaster;
@@ -432,8 +475,10 @@ static int collectSummaryForCommit(DoltliteDiffCursor *pCur, sqlite3 *db,
       pOldMaster = doltliteFindTableByNumber(aParent, nParent, 1);
       pOldRoot = pOldMaster ? &pOldMaster->root : &emptyRoot;
       if( schemaHasViewOrTriggerDiff(db, pOldRoot, &e->root, e->flags) ){
+        u8 schemaChangeFlag =
+          schemaHasAnyViewOrTrigger(db, pOldRoot, e->flags) ? 0 : 1;
         rc = appendSummaryRow(pCur, zCommitHex, "dolt_schemas", pCommit,
-                              1, 0);
+                              1, schemaChangeFlag);
         if( rc!=SQLITE_OK ) goto done;
       }
       continue;

--- a/test/vc_oracle_log_test.sh
+++ b/test/vc_oracle_log_test.sh
@@ -170,14 +170,23 @@ SELECT dolt_add('t');
 SELECT dolt_commit('-m', 'this is a deliberately very long commit message that goes on and on and on to exercise any buffer-size assumptions in the log walker or in either engine|s output format and should still come back intact');
 "
 
-# Dolt trims leading/trailing whitespace from commit messages
-# (matching git's behavior); doltlite preserves them. Test only
-# internal whitespace to avoid that divergence.
+# Internal whitespace is preserved exactly as written on both
+# engines.
 oracle "internal_whitespace_preserved" "
 CREATE TABLE t(id INTEGER PRIMARY KEY);
 INSERT INTO t VALUES (1);
 SELECT dolt_add('t');
 SELECT dolt_commit('-m', 'one    two     three');
+"
+
+# Leading/trailing whitespace gets trimmed on both engines, matching
+# git's behavior. A message of '  hello  ' becomes 'hello' in both
+# engines' dolt_log.
+oracle "leading_trailing_whitespace_trimmed" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1);
+SELECT dolt_add('t');
+SELECT dolt_commit('-m', '   hello world   ');
 "
 
 # ─── Category 3: merge-commit shapes ─────────────────────────────────

--- a/test/vc_oracle_schema_diff_test.sh
+++ b/test/vc_oracle_schema_diff_test.sh
@@ -16,6 +16,22 @@
 # canonicalize CREATE TABLE differently (whitespace, type aliases,
 # quoting, ENGINE=... suffix in Dolt).
 #
+# Known intentional divergences from Dolt (NOT oracle-tested here):
+#
+#   - CREATE INDEX: doltlite treats indexes as first-class schema
+#     entries (sqlite_schema has a row of type='index' for each
+#     one), so ALTER TABLE ... / CREATE INDEX adds a new row to
+#     dolt_schema_diff with the index as a separate "added" entry.
+#     Dolt rolls indexes into the table's CREATE statement and
+#     reports the table as modified instead. doltlite's behavior is
+#     the natural consequence of the sqlite_schema model and is
+#     intentional — indexes ARE schemas in SQLite.
+#
+#   - ALTER TABLE RENAME TO: doltlite emits (drop old, add new)
+#     as two separate rows; Dolt emits a single row with
+#     from_table_name != to_table_name. Worth conforming, tracked
+#     separately.
+#
 # Usage: bash vc_oracle_schema_diff_test.sh [path/to/doltlite] [path/to/dolt]
 #
 

--- a/test/vc_oracle_schemas_test.sh
+++ b/test/vc_oracle_schemas_test.sh
@@ -18,11 +18,12 @@
 #      Dolt uses them for MySQL-specific metadata).
 #
 #   2. SELECT table_name FROM dolt_diff — which commits touch
-#      dolt_schemas. Compared on (message, table_name, data_change)
-#      via a LEFT JOIN with dolt_log so engine-specific commit hashes
-#      don't matter. schema_change is NOT compared because doltlite
-#      emits 0 for dolt_schemas content changes while Dolt emits 1 on
-#      the initial view creation.
+#      dolt_schemas. Compared on (message, table_name, data_change,
+#      schema_change) via a LEFT JOIN with dolt_log so engine-
+#      specific commit hashes don't matter. Both engines now emit
+#      schema_change=1 on the FIRST view/trigger creation (the
+#      implicit creation of dolt_schemas) and schema_change=0 on
+#      subsequent view/trigger commits.
 #
 # Scope: views only. Triggers diverge in syntax between Dolt's MySQL
 # dialect (FOR EACH ROW BEGIN ... END;) and doltlite's SQLite
@@ -100,8 +101,8 @@ oracle_diff_touches_schemas() {
   local dir="$TMPROOT/${name}_diff"
   mkdir -p "$dir/dl" "$dir/dt"
 
-  local q="SELECT 'D' || char(9) || dd.table_name || char(9) || coalesce(dl.message, dd.commit_hash) || char(9) || dd.data_change FROM dolt_diff dd LEFT JOIN dolt_log dl ON dl.commit_hash = dd.commit_hash"
-  local q_dolt="SELECT concat('D', char(9), dd.table_name, char(9), coalesce(dl.message, dd.commit_hash), char(9), dd.data_change) FROM dolt_diff dd LEFT JOIN dolt_log dl ON dl.commit_hash = dd.commit_hash"
+  local q="SELECT 'D' || char(9) || dd.table_name || char(9) || coalesce(dl.message, dd.commit_hash) || char(9) || dd.data_change || char(9) || dd.schema_change FROM dolt_diff dd LEFT JOIN dolt_log dl ON dl.commit_hash = dd.commit_hash"
+  local q_dolt="SELECT concat('D', char(9), dd.table_name, char(9), coalesce(dl.message, dd.commit_hash), char(9), dd.data_change, char(9), dd.schema_change) FROM dolt_diff dd LEFT JOIN dolt_log dl ON dl.commit_hash = dd.commit_hash"
 
   local dl_out
   dl_out=$(printf "%s\n.headers off\n.mode list\n.separator '\t'\n%s;\n" "$setup" "$q" \


### PR DESCRIPTION
## Summary
Fixes two documented-but-unfixed divergences from the oracle tests.

### 1. dolt_commit: trim message whitespace
Dolt (matching git) trims leading/trailing whitespace from commit messages; doltlite preserved them, so `'   hello   '` became a literal `'   hello   '` in `dolt_log`. The oracle scenario `internal_whitespace_preserved` had to deliberately avoid leading/trailing whitespace to skip this divergence.

Fix: trim leading/trailing ASCII whitespace (` `, `\t`, `\n`, `\r`) just before the commit is created. Internal whitespace is preserved unchanged. A message that's entirely whitespace is now rejected as empty (same code path as a literal `''`). The trim happens just before the commit create call so the allocation's scope is tight and we free it immediately after.

### 2. dolt_diff summary: `schema_change` on first view creation
Dolt emits `schema_change=1` on the first commit that introduces any view/trigger (the implicit creation of `dolt_schemas` as a logical table), and `schema_change=0` on subsequent view/trigger commits. doltlite was always emitting 0, so the `vc_oracle_schemas_test.sh` diff query had to skip the `schema_change` column entirely.

Fix: new `schemaHasAnyViewOrTrigger()` helper scans the parent side's `sqlite_schema` for any `type='view'` or `type='trigger'` row. If absent → this commit is creating `dolt_schemas` → `schema_change=1`. Otherwise → 0. Applied in both the committed-history walker and the working-set walker.

### Oracle updates
- **`vc_oracle_log_test.sh`**: adds `leading_trailing_whitespace_trimmed` scenario. Total: 13 → 14.
- **`vc_oracle_schemas_test.sh`**: `oracle_diff_touches_schemas` now compares `schema_change` alongside `data_change`. Header comment no longer lists `schema_change` as an excluded column. All 9 scenarios still pass under the stricter comparison.
- **`vc_oracle_schema_diff_test.sh`**: header documents the intentional divergence on `CREATE INDEX` — doltlite treats indexes as first-class schema entries (consistent with the `sqlite_schema` model, which has a row with `type='index'` for each). Dolt rolls them into the table's CREATE statement. That's by design on doltlite's side: indexes ARE schemas in SQLite. `ALTER TABLE RENAME TO` is flagged as worth conforming separately.

## Test plan
- [x] `bash test/vc_oracle_log_test.sh ./doltlite dolt` → 14 passed (was 13)
- [x] `bash test/vc_oracle_schemas_test.sh ./doltlite dolt` → 9 passed (with stricter schema_change compare)
- [x] `bash test/vc_oracle_schema_diff_test.sh ./doltlite dolt` → 21 passed
- [x] `bash test/vc_oracle_commit_test.sh ./doltlite dolt` → 21 passed
- [x] `bash test/doltlite_commit.sh` → 35 passed
- [x] `bash test/doltlite_diff.sh` → 22 passed
- [x] `bash test/doltlite_advanced.sh` → 140 passed
- [x] Spot-check: `dolt_commit('-m','   hello   world   ')` stores `'hello   world'` (outer trimmed, inner preserved)
- [x] Spot-check: `dolt_commit('-m','   ')` rejected with "requires a non-empty message"
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)