### PR TITLE
dolt_schema_diff: detect ALTER TABLE RENAME TO as a rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,45 @@ SELECT * FROM dolt_diff('users', 'abc123...', 'def456...');
 -- diff_type | rowid_val | from_value | to_value
 ```
 
+### Diff Stat
+
+Row- and cell-level change counts between any two commits, branches, or tags.
+One row per changed table, with counts of rows added/deleted/modified and
+cells added/deleted/modified:
+
+```sql
+SELECT * FROM dolt_diff_stat('v1.0', 'HEAD');
+-- table_name | rows_unmodified | rows_added | rows_deleted | rows_modified |
+--   cells_added | cells_deleted | cells_modified |
+--   old_row_count | new_row_count | old_cell_count | new_cell_count
+
+-- Narrow to a single table
+SELECT * FROM dolt_diff_stat('v1.0', 'HEAD', 'users');
+
+-- How many rows changed on feature vs main?
+SELECT sum(rows_added + rows_deleted + rows_modified)
+  FROM dolt_diff_stat('main', 'feature');
+```
+
+### Diff Summary
+
+High-level summary of which tables changed between any two commits, branches,
+or tags. One row per changed table, classifying each change as `added`,
+`dropped`, `renamed`, or `modified`, and indicating whether the change
+touched data, schema, or both:
+
+```sql
+SELECT * FROM dolt_diff_summary('v1.0', 'HEAD');
+-- from_table_name | to_table_name | diff_type | data_change | schema_change
+
+-- Narrow to a single table
+SELECT * FROM dolt_diff_summary('v1.0', 'HEAD', 'users');
+
+-- Which tables had schema changes between two releases?
+SELECT to_table_name FROM dolt_diff_summary('v1.0', 'v2.0')
+  WHERE schema_change = 1;
+```
+
 ### Schema Diff
 
 Compare schemas between any two commits, branches, or tags:
@@ -217,6 +256,30 @@ SELECT * FROM dolt_schema_diff('v1.0', 'v2.0');
 -- empty to_table_name; modified rows have both equal.
 -- Also detects new indexes and views.
 ```
+
+### Schemas (dolt_schemas)
+
+Projection of views and triggers from `sqlite_schema`. This is the Dolt-style
+surface for browsing non-table schema objects. Because `sqlite_schema` lives
+in the branch-scoped catalog, `dolt_schemas` is version-controlled per branch
+just like user tables — switching branches with `dolt_checkout` will show the
+views and triggers defined on that branch:
+
+```sql
+CREATE VIEW active_users AS SELECT * FROM users WHERE active = 1;
+CREATE TRIGGER audit_users AFTER UPDATE ON users
+  BEGIN INSERT INTO audit VALUES(new.id, 'updated'); END;
+SELECT dolt_commit('-Am', 'Add view and trigger');
+
+SELECT * FROM dolt_schemas;
+-- type    | name         | fragment                                  | extra | sql_mode
+-- view    | active_users | CREATE VIEW active_users AS SELECT ...    |       |
+-- trigger | audit_users  | CREATE TRIGGER audit_users AFTER UPDATE...|       |
+```
+
+Rows are filtered to `type IN ('view','trigger')` — ordinary tables and
+indexes are not reported here. Use `sqlite_schema` directly (or
+`dolt_schema_diff`) if you need the full schema surface.
 
 ### Audit Log (dolt_diff_&lt;table&gt;)
 

--- a/src/doltlite_schema_diff.c
+++ b/src/doltlite_schema_diff.c
@@ -258,40 +258,112 @@ SchemaEntry *findSchemaEntry(SchemaEntry *a, int n, const char *zName){
 static int computeSchemaDiff(
   SdCursor *pCur,
   SchemaEntry *aFrom, int nFrom,
-  SchemaEntry *aTo, int nTo
+  SchemaEntry *aTo, int nTo,
+  struct TableEntry *aFromTables, int nFromTables,
+  struct TableEntry *aToTables, int nToTables
 ){
   int i;
+  u8 *fromConsumed = 0, *toConsumed = 0;
+  int rc = SQLITE_OK;
+
+  if( nFrom > 0 ){
+    fromConsumed = sqlite3_malloc(nFrom);
+    if( !fromConsumed ) return SQLITE_NOMEM;
+    memset(fromConsumed, 0, nFrom);
+  }
+  if( nTo > 0 ){
+    toConsumed = sqlite3_malloc(nTo);
+    if( !toConsumed ){
+      sqlite3_free(fromConsumed);
+      return SQLITE_NOMEM;
+    }
+    memset(toConsumed, 0, nTo);
+  }
+
+  /* Rename detection: ALTER TABLE RENAME TO preserves the table's rootpage
+  ** (iTable) AND its tree root (data content), while changing zName and
+  ** the CREATE-TABLE DDL. Matching a (dropped, added) pair on both
+  ** iTable and root rejects drop+create sequences that happen to reuse
+  ** an iTable via SQLite's rootpage freelist. The collapsed row emits
+  ** from_table_name != to_table_name, matching Dolt's dolt_schema_diff.
+  **
+  ** Views and triggers have iTable==0 and are excluded. Rename + data
+  ** modification in a single commit is not detected here — the root
+  ** hashes differ, so the pair still emits as (dropped, added). */
+  for(i=0; i<nTo; i++){
+    SchemaEntry *fromEntry;
+    struct TableEntry *toTE;
+    int j;
+
+    fromEntry = findSchemaEntry(aFrom, nFrom, aTo[i].zName);
+    if( fromEntry ) continue;
+
+    toTE = doltliteFindTableByName(aToTables, nToTables, aTo[i].zName);
+    if( !toTE || toTE->iTable==0 ) continue;
+
+    for(j=0; j<nFromTables; j++){
+      SchemaEntry *dropped;
+      int k;
+      if( aFromTables[j].iTable != toTE->iTable ) continue;
+      if( !aFromTables[j].zName ) continue;
+      if( prollyHashCompare(&aFromTables[j].root, &toTE->root)!=0 ) break;
+      /* The from-side table with this iTable must not still exist under
+      ** its old name in the to-side catalog — otherwise it's a modify or
+      ** a no-op, not a rename. */
+      if( doltliteFindTableByName(aToTables, nToTables, aFromTables[j].zName) ) break;
+
+      dropped = findSchemaEntry(aFrom, nFrom, aFromTables[j].zName);
+      if( !dropped ) break;
+
+      rc = appendSchemaDiffRow(pCur, dropped->zName, aTo[i].zName,
+                               dropped->zSql, aTo[i].zSql);
+      if( rc!=SQLITE_OK ) goto done;
+
+      toConsumed[i] = 1;
+      for(k=0; k<nFrom; k++){
+        if( &aFrom[k] == dropped ){ fromConsumed[k] = 1; break; }
+      }
+      break;
+    }
+  }
 
   /* Added or modified: walk the to-side and look for matches in from. */
   for(i=0; i<nTo; i++){
-    SchemaEntry *fromEntry = findSchemaEntry(aFrom, nFrom, aTo[i].zName);
+    SchemaEntry *fromEntry;
+    if( toConsumed && toConsumed[i] ) continue;
+    fromEntry = findSchemaEntry(aFrom, nFrom, aTo[i].zName);
 
     if( !fromEntry ){
       /* Added: from_table_name and from_create_statement are empty. */
-      int rc = appendSchemaDiffRow(pCur, "", aTo[i].zName,
-                                   "", aTo[i].zSql);
-      if( rc!=SQLITE_OK ) return rc;
+      rc = appendSchemaDiffRow(pCur, "", aTo[i].zName,
+                               "", aTo[i].zSql);
+      if( rc!=SQLITE_OK ) goto done;
     }else if( fromEntry->zSql && aTo[i].zSql
            && strcmp(fromEntry->zSql, aTo[i].zSql)!=0 ){
       /* Modified: both names equal, both SQL strings present. */
-      int rc = appendSchemaDiffRow(pCur, aTo[i].zName, aTo[i].zName,
-                                   fromEntry->zSql, aTo[i].zSql);
-      if( rc!=SQLITE_OK ) return rc;
+      rc = appendSchemaDiffRow(pCur, aTo[i].zName, aTo[i].zName,
+                               fromEntry->zSql, aTo[i].zSql);
+      if( rc!=SQLITE_OK ) goto done;
     }
   }
 
   /* Dropped: walk the from-side and emit anything missing on the to-side. */
   for(i=0; i<nFrom; i++){
-    SchemaEntry *toEntry = findSchemaEntry(aTo, nTo, aFrom[i].zName);
+    SchemaEntry *toEntry;
+    if( fromConsumed && fromConsumed[i] ) continue;
+    toEntry = findSchemaEntry(aTo, nTo, aFrom[i].zName);
     if( !toEntry ){
       /* Dropped: to_table_name and to_create_statement are empty. */
-      int rc = appendSchemaDiffRow(pCur, aFrom[i].zName, "",
-                                   aFrom[i].zSql, "");
-      if( rc!=SQLITE_OK ) return rc;
+      rc = appendSchemaDiffRow(pCur, aFrom[i].zName, "",
+                               aFrom[i].zSql, "");
+      if( rc!=SQLITE_OK ) goto done;
     }
   }
 
-  return SQLITE_OK;
+done:
+  sqlite3_free(fromConsumed);
+  sqlite3_free(toConsumed);
+  return rc;
 }
 
 static const char *sdSchema =
@@ -384,6 +456,8 @@ static int sdFilter(sqlite3_vtab_cursor *cur,
   ProllyHash fromCatHash, toCatHash;
   SchemaEntry *aFrom = 0, *aTo = 0;
   int nFrom = 0, nTo = 0;
+  struct TableEntry *aFromTables = 0, *aToTables = 0;
+  int nFromTables = 0, nToTables = 0;
   int rc, argIdx = 0;
   (void)idxStr;
 
@@ -458,8 +532,16 @@ static int sdFilter(sqlite3_vtab_cursor *cur,
     rc = loadSchemaFromCatalog(db, cs, pCache, &toCatHash, &aTo, &nTo);
     if( rc!=SQLITE_OK ) goto sd_filter_done;
 
-  
-    rc = computeSchemaDiff(c, aFrom, nFrom, aTo, nTo);
+    /* Also load the TableEntry lists so computeSchemaDiff can detect
+    ** renames by matching dropped+added entries on iTable. */
+    rc = doltliteLoadCatalog(db, &fromCatHash, &aFromTables, &nFromTables, 0);
+    if( rc!=SQLITE_OK ) goto sd_filter_done;
+    rc = doltliteLoadCatalog(db, &toCatHash, &aToTables, &nToTables, 0);
+    if( rc!=SQLITE_OK ) goto sd_filter_done;
+
+    rc = computeSchemaDiff(c, aFrom, nFrom, aTo, nTo,
+                           aFromTables, nFromTables,
+                           aToTables, nToTables);
     if( rc!=SQLITE_OK ) goto sd_filter_done;
 
   
@@ -490,6 +572,8 @@ static int sdFilter(sqlite3_vtab_cursor *cur,
 sd_filter_done:
   freeSchemaEntries(aFrom, nFrom);
   freeSchemaEntries(aTo, nTo);
+  sqlite3_free(aFromTables);
+  sqlite3_free(aToTables);
   return rc;
 }
 

--- a/test/vc_oracle_schema_diff_test.sh
+++ b/test/vc_oracle_schema_diff_test.sh
@@ -27,11 +27,6 @@
 #     the natural consequence of the sqlite_schema model and is
 #     intentional — indexes ARE schemas in SQLite.
 #
-#   - ALTER TABLE RENAME TO: doltlite emits (drop old, add new)
-#     as two separate rows; Dolt emits a single row with
-#     from_table_name != to_table_name. Worth conforming, tracked
-#     separately.
-#
 # Usage: bash vc_oracle_schema_diff_test.sh [path/to/doltlite] [path/to/dolt]
 #
 
@@ -179,6 +174,17 @@ $SEED
 ALTER TABLE t RENAME COLUMN v TO vv;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'rename_col');
+" "HEAD~1" "HEAD"
+
+# ALTER TABLE RENAME TO: both engines emit a single row with
+# from_table_name != to_table_name. doltlite's heuristic detects this
+# by matching dropped+added pairs on iTable + tree root, which works
+# for the pure-rename case (no data change in the same commit).
+oracle "modified_rename_table" "
+$SEED
+ALTER TABLE t RENAME TO t2;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'rename_table');
 " "HEAD~1" "HEAD"
 
 oracle "modified_add_not_null_default" "


### PR DESCRIPTION
## Summary
- Collapse (dropped, added) pairs that share both `iTable` and tree root into a single rename row with `from_table_name != to_table_name`, matching Dolt's `dolt_schema_diff` output.
- Root-equality check rejects DROP+CREATE sequences that reuse an `iTable` via SQLite's rootpage freelist. Views/triggers (iTable==0) are excluded.
- Rename + data modification in the same commit is a known limitation — roots diverge, so the pair still emits as (dropped, added).
- Adds `modified_rename_table` oracle scenario and removes the "known divergence" note for rename.
- Also adds README sections documenting `dolt_diff_stat`, `dolt_diff_summary`, and `dolt_schemas`.

## Test plan
- [x] `bash test/vc_oracle_schema_diff_test.sh ./doltlite dolt` — 22/22 pass (including new `modified_rename_table`)
- [x] `bash test/vc_oracle_schemas_test.sh ./doltlite dolt` — 9/9 pass
- [x] `bash test/vc_oracle_status_test.sh ./doltlite dolt` — 11/11 pass
- [x] Manual: pure rename collapses to 1 row; DROP+CREATE with different columns still emits 2 rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)