### PR TITLE
Fix prolly btree cursor mutmap state

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -1049,6 +1049,36 @@ static int cacheCursorPayloadCopy(BtCursor *pCur, const u8 *pData, int nData){
   return SQLITE_OK;
 }
 
+static void clearMergeCursorState(BtCursor *pCur){
+  pCur->mmIdx = -1;
+  pCur->mmActive = 0;
+  pCur->mergeSrc = MERGE_SRC_TREE;
+}
+
+static void setCursorToMutMapEntry(BtCursor *pCur, int idx){
+  ProllyMutMapEntry *pEntry = &pCur->pMutMap->aEntries[idx];
+  CLEAR_CACHED_PAYLOAD(pCur);
+  pCur->mmIdx = idx;
+  pCur->mmActive = 1;
+  pCur->mergeSrc = MERGE_SRC_MUT;
+  pCur->eState = CURSOR_VALID;
+  pCur->curFlags &= ~BTCF_AtLast;
+  if( pCur->curIntKey ){
+    pCur->cachedIntKey = pEntry->intKey;
+    pCur->curFlags |= BTCF_ValidNKey;
+  }else{
+    pCur->curFlags &= ~BTCF_ValidNKey;
+  }
+}
+
+static int advanceTreeCursor(BtCursor *pCur, int dir){
+  if( dir>0 ){
+    return prollyCursorNext(&pCur->pCur);
+  }else{
+    return prollyCursorPrev(&pCur->pCur);
+  }
+}
+
 static int flushMutMap(BtCursor *pCur){
   struct TableEntry *pTE;
 
@@ -1131,14 +1161,26 @@ static int saveCursorPosition(BtCursor *pCur){
 
   
   if( pCur->curIntKey ){
-    pCur->nKey = prollyCursorIntKey(&pCur->pCur);
+    if( pCur->mmActive
+     && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
+      pCur->nKey = pCur->pMutMap->aEntries[pCur->mmIdx].intKey;
+    }else{
+      pCur->nKey = prollyCursorIntKey(&pCur->pCur);
+    }
     pCur->pKey = 0;
   } else {
-    const u8 *pKey;
-    int nKey;
-    prollyCursorKey(&pCur->pCur, &pKey, &nKey);
+    const u8 *pKey = 0;
+    int nKey = 0;
+    if( pCur->mmActive
+     && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
+      pKey = pCur->pMutMap->aEntries[pCur->mmIdx].pKey;
+      nKey = pCur->pMutMap->aEntries[pCur->mmIdx].nKey;
+    }else{
+      prollyCursorKey(&pCur->pCur, &pKey, &nKey);
+    }
+    sqlite3_free(pCur->pKey);
+    pCur->pKey = 0;
     if( nKey>0 ){
-      sqlite3_free(pCur->pKey);
       pCur->pKey = sqlite3_malloc(nKey);
       if( !pCur->pKey ){
         return SQLITE_NOMEM;
@@ -1146,7 +1188,6 @@ static int saveCursorPosition(BtCursor *pCur){
       memcpy(pCur->pKey, pKey, nKey);
       pCur->nKey = nKey;
     } else {
-      pCur->pKey = 0;
       pCur->nKey = 0;
     }
   }
@@ -2940,8 +2981,8 @@ static int mergeScan(BtCursor *pCur, int dir, int *pRes){
     }else{
       if( e->op==PROLLY_EDIT_DELETE ){
         pCur->mmIdx += dir;
-        if( dir > 0 ) prollyCursorNext(&pCur->pCur);
-        else           prollyCursorPrev(&pCur->pCur);
+        cmp = advanceTreeCursor(pCur, dir);
+        if( cmp!=SQLITE_OK ) return cmp;
         continue;
       }
       pCur->mergeSrc = MERGE_SRC_BOTH;
@@ -2952,16 +2993,22 @@ static int mergeScan(BtCursor *pCur, int dir, int *pRes){
 }
 
 static int mergeStepForward(BtCursor *pCur){
-  if( pCur->mergeSrc==MERGE_SRC_TREE || pCur->mergeSrc==MERGE_SRC_BOTH )
-    prollyCursorNext(&pCur->pCur);
+  int rc = SQLITE_OK;
+  if( pCur->mergeSrc==MERGE_SRC_TREE || pCur->mergeSrc==MERGE_SRC_BOTH ){
+    rc = advanceTreeCursor(pCur, 1);
+    if( rc!=SQLITE_OK ) return rc;
+  }
   if( pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH )
     pCur->mmIdx++;
   return mergeScan(pCur, 1, 0);
 }
 
 static int mergeStepBackward(BtCursor *pCur){
-  if( pCur->mergeSrc==MERGE_SRC_TREE || pCur->mergeSrc==MERGE_SRC_BOTH )
-    prollyCursorPrev(&pCur->pCur);
+  int rc = SQLITE_OK;
+  if( pCur->mergeSrc==MERGE_SRC_TREE || pCur->mergeSrc==MERGE_SRC_BOTH ){
+    rc = advanceTreeCursor(pCur, -1);
+    if( rc!=SQLITE_OK ) return rc;
+  }
   if( pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH )
     pCur->mmIdx--;
   return mergeScan(pCur, -1, 0);
@@ -3048,6 +3095,7 @@ static int prollyBtCursorFirst(BtCursor *pCur, int *pRes){
   refreshCursorRoot(pCur);
   rc = prollyCursorFirst(&pCur->pCur, pRes);
   if( rc!=SQLITE_OK ) return rc;
+  clearMergeCursorState(pCur);
 
   if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
     pCur->mmActive = 1;
@@ -3084,6 +3132,7 @@ static int prollyBtCursorLast(BtCursor *pCur, int *pRes){
   refreshCursorRoot(pCur);
   rc = prollyCursorLast(&pCur->pCur, pRes);
   if( rc!=SQLITE_OK ) return rc;
+  clearMergeCursorState(pCur);
 
   if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
     pCur->mmActive = 1;
@@ -3332,27 +3381,24 @@ static int prollyBtCursorTableMoveto(
 
   pCur->nSeek++;
   if( pCur->pBtree ) pCur->pBtree->nSeek++;
+  clearMergeCursorState(pCur);
+  CLEAR_CACHED_PAYLOAD(pCur);
 
   
   if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
     ProllyMutMapEntry *pEntry = prollyMutMapFind(pCur->pMutMap, 0, 0, intKey);
     if( pEntry ){
       if( pEntry->op == PROLLY_EDIT_INSERT ){
+        int idx = (int)(pEntry - pCur->pMutMap->aEntries);
         
         *pRes = 0;
-        pCur->eState = CURSOR_VALID;
-        pCur->curFlags |= BTCF_ValidNKey;
-        pCur->cachedIntKey = intKey;
-        
-  rc = cacheCursorPayloadCopy(pCur, pEntry->pVal, pEntry->nVal);
-  if( rc!=SQLITE_OK ) return rc;
-        
         refreshCursorRoot(pCur);
         {
           int seekRes = 0;
           rc = prollyCursorSeekInt(&pCur->pCur, intKey, &seekRes);
           if( rc!=SQLITE_OK ) return rc;
         }
+        setCursorToMutMapEntry(pCur, idx);
         return SQLITE_OK;
       } else {
         
@@ -3598,6 +3644,7 @@ static int prollyBtCursorIndexMoveto(
 
   if( pCur->pBtree ) pCur->pBtree->nSeek++;
 
+  clearMergeCursorState(pCur);
   CLEAR_CACHED_PAYLOAD(pCur);
 
   if( pCur->flushSeekEdits
@@ -3638,6 +3685,8 @@ static int prollyBtCursorIndexMoveto(
     int treeCmp = 0, mutCmp = 0;
     const u8 *mutKey = 0;
     int mutNKey = 0;
+    ProllyMutMapEntry *mutE = 0;
+    int mutFromCursorMap = 0;
 
     /* Build the sort-key prefix used to seek the prolly tree. For unique
     ** indexes (and the PK index of WITHOUT ROWID tables), nKeyField <
@@ -3787,7 +3836,6 @@ static int prollyBtCursorIndexMoveto(
          || (pPending && pPending!=pCur->pMutMap
              && !prollyMutMapIsEmpty(pPending)))
        && !(treeFound && treeCmp==0) ){
-      ProllyMutMapEntry *mutE = 0;
       rc = findMatchingMutMapEntry((ProllyMutMap*)pCur->pMutMap,
                                    pCur->pKeyInfo,
                                    pIdxKey, pSortKey, nSortKey,
@@ -3797,6 +3845,7 @@ static int prollyBtCursorIndexMoveto(
         sqlite3_free(pSortKey);
         return rc;
       }
+      if( mutE ) mutFromCursorMap = 1;
       if( !mutE && pPending && pPending!=pCur->pMutMap ){
         rc = findMatchingMutMapEntry(pPending,
                                      pCur->pKeyInfo,
@@ -3831,16 +3880,16 @@ static int prollyBtCursorIndexMoveto(
 
     
     if( mutFound && (!treeFound || treeCmp!=0) ){
-      
-      if( pCur->cachedPayloadOwned && pCur->pCachedPayload ){
-        sqlite3_free(pCur->pCachedPayload);
-      }
-      rc = cacheCursorPayloadCopy(pCur, mutKey, mutNKey);
-      if( rc!=SQLITE_OK ){
-        return rc;
+      if( mutFromCursorMap ){
+        setCursorToMutMapEntry(pCur, (int)(mutE - pCur->pMutMap->aEntries));
+      }else{
+        rc = cacheCursorPayloadCopy(pCur, mutKey, mutNKey);
+        if( rc!=SQLITE_OK ){
+          return rc;
+        }
+        pCur->eState = CURSOR_VALID;
       }
       *pRes = mutCmp;
-      pCur->eState = CURSOR_VALID;
       return SQLITE_OK;
     }
     if( treeFound ){
@@ -4624,6 +4673,7 @@ static void prollyBtCursorClearCursor(BtCursor *pCur){
     pCur->nKey = 0;
   }
   CLEAR_CACHED_PAYLOAD(pCur);
+  clearMergeCursorState(pCur);
   pCur->eState = CURSOR_INVALID;
   pCur->curFlags &= ~(BTCF_ValidNKey|BTCF_ValidOvfl|BTCF_AtLast);
   pCur->skipNext = 0;

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -1923,6 +1923,72 @@ static void run_integrity_check_walks_prolly_nodes(void){
   remove_db(dbpath);
 }
 
+static void run_table_moveto_mutmap_delete_preserves_neighbors(void){
+  sqlite3 *db = 0;
+  char dbpath[256];
+
+  printf("=== Table Moveto MutMap Delete Preserves Neighbors Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_table_moveto_mutmap_delete_preserves_neighbors");
+  remove_db(dbpath);
+
+  check("open_db_for_table_moveto_delete", open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_table_for_table_moveto_delete", execsql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'a');"
+    "INSERT INTO t VALUES(3,'c');")==SQLITE_OK);
+  check("begin_txn_for_table_moveto_delete", execsql(db, "BEGIN IMMEDIATE;")==SQLITE_OK);
+  check("insert_mutmap_only_row_for_table_moveto_delete",
+        execsql(db, "INSERT INTO t VALUES(2,'b');")==SQLITE_OK);
+  check("delete_mutmap_only_row_by_rowid",
+        execsql(db, "DELETE FROM t WHERE rowid=2;")==SQLITE_OK);
+  check("neighbors_preserved_after_delete",
+        strcmp(exec1(db,
+          "SELECT group_concat(id, ',') FROM (SELECT id FROM t ORDER BY id)"),
+          "1,3")==0);
+  check("rollback_table_moveto_delete_txn", execsql(db, "ROLLBACK;")==SQLITE_OK);
+
+  sqlite3_close(db);
+  remove_db(dbpath);
+}
+
+static void run_index_moveto_mutmap_exact_keeps_iteration_aligned(void){
+  sqlite3 *db = 0;
+  sqlite3_stmt *stmt = 0;
+  char dbpath[256];
+  int rc;
+
+  printf("=== Index Moveto MutMap Exact Keeps Iteration Aligned Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_index_moveto_mutmap_exact_keeps_iteration_aligned");
+  remove_db(dbpath);
+
+  check("open_db_for_index_moveto_exact", open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_table_for_index_moveto_exact", execsql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, b TEXT, c TEXT);"
+    "CREATE INDEX idx_b ON t(b);"
+    "INSERT INTO t VALUES(1,'a','aa');"
+    "INSERT INTO t VALUES(3,'c','cc');")==SQLITE_OK);
+  check("begin_txn_for_index_moveto_exact", execsql(db, "BEGIN IMMEDIATE;")==SQLITE_OK);
+  check("insert_mutmap_only_index_row",
+        execsql(db, "INSERT INTO t VALUES(2,'b','bb');")==SQLITE_OK);
+
+  rc = sqlite3_prepare_v2(db,
+    "SELECT b FROM t INDEXED BY idx_b WHERE b >= 'b' ORDER BY b",
+    -1, &stmt, 0);
+  check("prepare_index_moveto_exact_stmt", rc==SQLITE_OK);
+  if( rc==SQLITE_OK ){
+    check("index_moveto_exact_first_row", sqlite3_step(stmt)==SQLITE_ROW);
+    check("index_moveto_exact_first_val", stmt_column_text_equals(stmt, 0, "b"));
+    check("index_moveto_exact_second_row", sqlite3_step(stmt)==SQLITE_ROW);
+    check("index_moveto_exact_second_val", stmt_column_text_equals(stmt, 0, "c"));
+    check("index_moveto_exact_done", sqlite3_step(stmt)==SQLITE_DONE);
+  }
+  sqlite3_finalize(stmt);
+  check("rollback_index_moveto_exact_txn", execsql(db, "ROLLBACK;")==SQLITE_OK);
+
+  sqlite3_close(db);
+  remove_db(dbpath);
+}
+
 static void run_btree_commit_failure_transactional(void){
   sqlite3 *db = 0;
   char dbpath[256];
@@ -2507,6 +2573,8 @@ static const RegressionCase aCases[] = {
   { "begin_write_refreshes_working_set_metadata", "Begin Write Refreshes Working Set Metadata Test", run_begin_write_refreshes_working_set_metadata },
   { "begin_write_from_stale_read_snapshot", "Begin Write From Stale Read Snapshot Test", run_begin_write_from_stale_read_snapshot },
   { "open_rejects_corrupt_working_set", "Open Rejects Corrupt Working Set Test", run_open_rejects_corrupt_working_set },
+  { "table_moveto_mutmap_delete_preserves_neighbors", "Table Moveto MutMap Delete Preserves Neighbors Test", run_table_moveto_mutmap_delete_preserves_neighbors },
+  { "index_moveto_mutmap_exact_keeps_iteration_aligned", "Index Moveto MutMap Exact Keeps Iteration Aligned Test", run_index_moveto_mutmap_exact_keeps_iteration_aligned },
   { "btree_commit_failure_transactional", "Btree Commit Failure Transaction Test", run_btree_commit_failure_transactional },
   { "savepoint_restores_session_metadata", "Savepoint Restores Session Metadata Test", run_savepoint_restores_session_metadata },
   { "hard_reset_failure_restores_memory_state", "Hard Reset Failure Restores Memory State Test", run_hard_reset_failure_restores_memory_state },


### PR DESCRIPTION
## Summary
- make exact MutMap `Moveto` hits explicit cursor state instead of borrowing neighbor tree position
- save and restore the logical current row for MutMap-backed cursor positions
- propagate tree-advance errors during merged cursor iteration and add regressions for delete and index iteration correctness

## Testing
- ./build/doltlite_regression_test_c table_moveto_mutmap_delete_preserves_neighbors
- ./build/doltlite_regression_test_c index_moveto_mutmap_exact_keeps_iteration_aligned
- ./build/doltlite_regression_test_c all