### PR TITLE
Harden doltlite history row cleanup

### DIFF
--- a/src/doltlite_history.c
+++ b/src/doltlite_history.c
@@ -59,16 +59,39 @@ struct HistCursor {
   int iRow;
 };
 
+static void freeHistoryRow(HistoryRow *r){
+  sqlite3_free(r->pVal);
+  sqlite3_free(r->zCommitter);
+  memset(r, 0, sizeof(*r));
+}
+
 static void freeHistoryRows(HistCursor *c){
   int i;
   for(i=0;i<c->nRows;i++){
-    sqlite3_free(c->aRows[i].pVal);
-    sqlite3_free(c->aRows[i].zCommitter);
+    freeHistoryRow(&c->aRows[i]);
   }
   sqlite3_free(c->aRows);
   c->aRows=0; c->nRows=0; c->nAlloc=0;
 }
 
+static int htCommitParentCount(const DoltliteCommit *pCommit){
+  if( pCommit->nParents>0 ) return pCommit->nParents;
+  return prollyHashIsEmpty(&pCommit->parentHash) ? 0 : 1;
+}
+
+static const ProllyHash *htCommitParentHash(
+  const DoltliteCommit *pCommit,
+  int iParent
+){
+  if( iParent<0 ) return 0;
+  if( pCommit->nParents>0 ){
+    return iParent<pCommit->nParents ? &pCommit->aParents[iParent] : 0;
+  }
+  if( iParent==0 && !prollyHashIsEmpty(&pCommit->parentHash) ){
+    return &pCommit->parentHash;
+  }
+  return 0;
+}
 
 static int htScanAtCommit(
   HistCursor *pCur, ChunkStore *cs, ProllyCache *pCache,
@@ -93,13 +116,21 @@ static int htScanAtCommit(
     prollyCursorValue(&cur,&pVal,&nVal);
     if(pVal&&nVal>0){
       r->pVal=sqlite3_malloc(nVal);
-      if( !r->pVal ){ prollyCursorClose(&cur); return SQLITE_NOMEM; }
+      if( !r->pVal ){
+        freeHistoryRow(r);
+        prollyCursorClose(&cur);
+        return SQLITE_NOMEM;
+      }
       memcpy(r->pVal,pVal,nVal);
       r->nVal=nVal;
     }
     memcpy(r->zCommit,zCommitHex,PROLLY_HASH_SIZE*2+1);
     r->zCommitter=sqlite3_mprintf("%s",zCommitter?zCommitter:"");
-    if( !r->zCommitter ){ prollyCursorClose(&cur); return SQLITE_NOMEM; }
+    if( !r->zCommitter ){
+      freeHistoryRow(r);
+      prollyCursorClose(&cur);
+      return SQLITE_NOMEM;
+    }
     r->commitDate=commitDate;
     pCur->nRows++;
     rc=prollyCursorNext(&cur); if(rc!=SQLITE_OK) break;
@@ -172,18 +203,19 @@ static int htWalkHistory(HistCursor *pCur, sqlite3 *db, const char *zTableName){
       if( rc!=SQLITE_OK ){ doltliteCommitClear(&commit); break; }
     }
 
-    for(i=0;i<commit.nParents;i++){
-      if(prollyHashIsEmpty(&commit.aParents[i])) continue;
-      if( prollyHashSetContains(&visited, &commit.aParents[i]) ) continue;
-      if( prollyHashSetContains(&queued, &commit.aParents[i]) ) continue;
+    for(i=0; i<htCommitParentCount(&commit); i++){
+      const ProllyHash *pParent = htCommitParentHash(&commit, i);
+      if( !pParent || prollyHashIsEmpty(pParent) ) continue;
+      if( prollyHashSetContains(&visited, pParent) ) continue;
+      if( prollyHashSetContains(&queued, pParent) ) continue;
       if(qTail>=qAlloc){
         int na=qAlloc*2;
         ProllyHash *tmp=sqlite3_realloc(queue,na*(int)sizeof(ProllyHash));
         if(!tmp){rc=SQLITE_NOMEM;break;}
         queue=tmp; qAlloc=na;
       }
-      queue[qTail++]=commit.aParents[i];
-      rc = prollyHashSetAdd(&queued, &commit.aParents[i]);
+      queue[qTail++]=*pParent;
+      rc = prollyHashSetAdd(&queued, pParent);
       if( rc!=SQLITE_OK ) break;
     }
     doltliteCommitClear(&commit);


### PR DESCRIPTION
## Summary
- free partially built history rows on allocation failure in dolt_history_<table>
- share parent-selection logic in the history walker so it matches the existing commit compatibility path

## Testing
- === Doltlite dolt_history_<table> Tests ===


Results: 28 passed, 0 failed out of 28 tests
- === DoltLite Regression Tests ===

=== Concurrent Refs Test ===

--- Test 1: stale dolt_reset is rejected ---
--- Test 2: stale dolt_checkout refreshes target branch ---

=== Checkout Persist Failure Test ===

--- Test 1: dolt_checkout surfaces final persist failure ---

=== Savepoint Catalog Restore Test ===

--- Test 1: savepoint rollback restores schema metadata ---

=== Refs Blob Corruption Test ===

--- Test 1: truncated refs blob is rejected ---

=== Refresh Error Propagation Test ===

--- Test 1: xAccess failure is surfaced ---
--- Test 2: xFileControl failure is surfaced ---

=== Conflicts Blob Corruption Test ===


=== Status Error Propagation Test ===


=== Remote Refs Corruption Test ===


=== Chunk Walk Corruption Test ===


=== Ancestor Missing Start Test ===


=== Pull Persist Failure Test ===


=== Clone Persist Failure Test ===


=== Resolve Ref Non-Commit Test ===


=== Commit Parent Limit Test ===


=== Merge Persist Failure Test ===


=== Cherry-pick Stale Branch Test ===


=== Branches Metadata Corruption Test ===


=== GC Rewrite Failure Test ===


=== Record Decode Corruption Test ===


=== Reload Refs Transactional Test ===


=== Refresh Corrupt Refs State Preservation Test ===


=== Prolly Node Corruption Test ===


=== Truncated WAL Rejected Test ===


=== Refresh Open Path Transactional Test ===


=== WAL Offset Corruption Test ===


=== Integrity Check Walks Prolly Nodes Test ===


=== Memory Chunk Lookup Corruption Test ===


=== Prolly Diff Record Corruption Test ===


=== Integrity Check Repository State Test ===


=== Integrity Check Session Merge State Test ===


=== Prepared Statement Reuse After Commit Test ===


=== Prepared Statement Reuse After Schema Checkout Test ===


=== Working Set Refreshes Staged Across Connections Test ===


=== Reopen Preserves Staged Working Set Test ===


=== Begin Write Refreshes Working Set Metadata Test ===


=== Begin Write From Stale Read Snapshot Test ===


=== Open Rejects Corrupt Working Set Test ===


=== Table Moveto MutMap Delete Preserves Neighbors Test ===


=== Index Moveto MutMap Exact Keeps Iteration Aligned Test ===


=== Btree Commit Failure Transaction Test ===


=== Savepoint Restores Session Metadata Test ===


=== Hard Reset Failure Restores Memory State Test ===


=== MutMap Empty Reverse Iterator Test ===


=== Prolly Mutate Skipped Subtree Order Test ===


=== Chunk Store Rollback Restores Refs Hash Test ===


=== Chunk Store Commit Failure Restores Refs Hash Test ===


=== Prolly Blob Cursor Internal Boundary Test ===


=== Prolly Blob Cursor Seek Past Max Test ===


=== Prolly Cursor Empty Leaf Root Test ===


=== Prolly Cursor Corrupt Node Test ===


=== Prolly Diff Iterator Copies Blob Keys Test ===


=== Prolly Diff Leaf Corruption Test ===


Results: 100491 passed, 0 failed out of 100491 tests
