### PR TITLE
Fix dolt diff stat contract and errors

### DIFF
--- a/src/doltlite_diff_stat.c
+++ b/src/doltlite_diff_stat.c
@@ -111,25 +111,28 @@ static void dsFreeColNames(char **az, int n){
   sqlite3_free(az);
 }
 
-/* Count rows in a prolly tree by iterating. Returns -1 on error. */
-static int dsCountRows(sqlite3 *db, const ProllyHash *pRoot, u8 flags){
+/* Count rows in a prolly tree by iterating. */
+static int dsCountRows(sqlite3 *db, const ProllyHash *pRoot, u8 flags,
+                       i64 *pnRow){
   ChunkStore *cs = doltliteGetChunkStore(db);
   ProllyCache *pCache = doltliteGetCache(db);
   ProllyCursor cur;
   int rc, res;
-  int n = 0;
-  if( !cs || !pCache ) return -1;
-  if( prollyHashIsEmpty(pRoot) ) return 0;
+  i64 n = 0;
+  if( pnRow ) *pnRow = 0;
+  if( !cs || !pCache ) return SQLITE_ERROR;
+  if( prollyHashIsEmpty(pRoot) ) return SQLITE_OK;
   prollyCursorInit(&cur, cs, pCache, pRoot, flags);
   rc = prollyCursorFirst(&cur, &res);
-  if( rc!=SQLITE_OK ){ prollyCursorClose(&cur); return -1; }
+  if( rc!=SQLITE_OK ){ prollyCursorClose(&cur); return rc; }
   while( !res && prollyCursorIsValid(&cur) ){
     n++;
     rc = prollyCursorNext(&cur);
-    if( rc!=SQLITE_OK ){ prollyCursorClose(&cur); return -1; }
+    if( rc!=SQLITE_OK ){ prollyCursorClose(&cur); return rc; }
   }
   prollyCursorClose(&cur);
-  return n;
+  if( pnRow ) *pnRow = n;
+  return SQLITE_OK;
 }
 
 /* Compare two record fields by semantic value (same logic as
@@ -294,6 +297,15 @@ static int dsResolveCatHash(sqlite3 *db, const char *zRef,
   return doltliteGetHeadCatalogHash(db, pOut);
 }
 
+static int dsRequireRefs(sqlite3_vtab *pVtab, int idxNum, const char *zName){
+  if( (idxNum & 3)!=3 ){
+    sqlite3_free(pVtab->zErrMsg);
+    pVtab->zErrMsg = sqlite3_mprintf("%s requires from_ref and to_ref", zName);
+    return SQLITE_ERROR;
+  }
+  return SQLITE_OK;
+}
+
 /* ──────────────────────────────────────────────────────────────── */
 /*  Per-table work: compute stat counters for a single table across */
 /*  from and to. Returns 1 if the table should be included in the   */
@@ -310,13 +322,14 @@ static int dsComputeTableStats(
   struct TableEntry *aFrom = 0, *aTo = 0;
   int nFromCat = 0, nToCat = 0;
   struct TableEntry *pFromEntry, *pToEntry;
+  int hasFrom = 0, hasTo = 0;
   ProllyHash fromRoot, toRoot;
   u8 fromFlags = 0, toFlags = 0;
   char **azFromCols = 0, **azToCols = 0;
   int nFromCols = 0, nToCols = 0;
-  int oldCount = 0, newCount = 0;
+  i64 oldCount = 0, newCount = 0;
   int rowsMod = 0, rowsAdd = 0, rowsDel = 0;
-  int cellsMod = 0, cellsAdd = 0, cellsDel = 0;
+  i64 cellsMod = 0, cellsAdd = 0, cellsDel = 0;
   int rc;
 
   memset(pOut, 0, sizeof(*pOut));
@@ -331,6 +344,8 @@ static int dsComputeTableStats(
 
   pFromEntry = doltliteFindTableByName(aFrom, nFromCat, zTableName);
   pToEntry   = doltliteFindTableByName(aTo,   nToCat,   zTableName);
+  hasFrom = pFromEntry!=0;
+  hasTo = pToEntry!=0;
 
   memset(&fromRoot, 0, sizeof(fromRoot));
   memset(&toRoot,   0, sizeof(toRoot));
@@ -345,14 +360,14 @@ static int dsComputeTableStats(
   sqlite3_free(aFrom);
   sqlite3_free(aTo);
 
-  if( !pFromEntry && !pToEntry ) return SQLITE_OK;
+  if( !hasFrom && !hasTo ) return SQLITE_OK;
 
   /* Column name lists for each side (for semantic cell compare). */
-  if( pFromEntry ){
+  if( hasFrom ){
     rc = dsLoadColNames(db, pFromCatHash, zTableName, &azFromCols, &nFromCols);
     if( rc!=SQLITE_OK ) return rc;
   }
-  if( pToEntry ){
+  if( hasTo ){
     rc = dsLoadColNames(db, pToCatHash, zTableName, &azToCols, &nToCols);
     if( rc!=SQLITE_OK ){
       dsFreeColNames(azFromCols, nFromCols);
@@ -361,17 +376,17 @@ static int dsComputeTableStats(
   }
 
   /* Row counts on each side. */
-  if( pFromEntry ){
-    oldCount = dsCountRows(db, &fromRoot, fromFlags);
-    if( oldCount<0 ) oldCount = 0;
+  if( hasFrom ){
+    rc = dsCountRows(db, &fromRoot, fromFlags, &oldCount);
+    if( rc!=SQLITE_OK ) goto done;
   }
-  if( pToEntry ){
-    newCount = dsCountRows(db, &toRoot, toFlags);
-    if( newCount<0 ) newCount = 0;
+  if( hasTo ){
+    rc = dsCountRows(db, &toRoot, toFlags, &newCount);
+    if( rc!=SQLITE_OK ) goto done;
   }
 
   /* Walk the prolly diff iter to count per-row changes. */
-  if( pFromEntry && pToEntry
+  if( hasFrom && hasTo
    && prollyHashCompare(&fromRoot, &toRoot)!=0 ){
     ChunkStore *cs = doltliteGetChunkStore(db);
     ProllyCache *pCache = doltliteGetCache(db);
@@ -420,8 +435,8 @@ static int dsComputeTableStats(
   ** reported as modified and the non-NULL-value contribution is
   ** counted in cells_modified. The two counters can legitimately
   ** overlap on the same physical cell. */
-  if( pFromEntry && pToEntry ){
-    int rowsInBoth = oldCount - rowsDel;
+  if( hasFrom && hasTo ){
+    i64 rowsInBoth = oldCount - rowsDel;
     if( rowsInBoth < 0 ) rowsInBoth = 0;
     if( nToCols > nFromCols ){
       cellsAdd += (i64)rowsInBoth * (nToCols - nFromCols);
@@ -431,11 +446,11 @@ static int dsComputeTableStats(
   }
 
   /* For added tables, every row+cell is new; for dropped, all gone. */
-  if( !pFromEntry && pToEntry ){
+  if( !hasFrom && hasTo ){
     rowsAdd = newCount;
     cellsAdd = (i64)newCount * nToCols;
   }
-  if( pFromEntry && !pToEntry ){
+  if( hasFrom && !hasTo ){
     rowsDel = oldCount;
     cellsDel = (i64)oldCount * nFromCols;
   }
@@ -444,7 +459,7 @@ static int dsComputeTableStats(
   pOut->rowsAdded      = rowsAdd;
   pOut->rowsDeleted    = rowsDel;
   pOut->rowsModified   = rowsMod;
-  pOut->rowsUnmodified = (pFromEntry ? oldCount - rowsDel - rowsMod : 0);
+  pOut->rowsUnmodified = hasFrom ? oldCount - rowsDel - rowsMod : 0;
   if( pOut->rowsUnmodified<0 ) pOut->rowsUnmodified = 0;
   pOut->cellsAdded     = cellsAdd;
   pOut->cellsDeleted   = cellsDel;
@@ -669,6 +684,9 @@ static int dstFilter(sqlite3_vtab_cursor *cur,
 
   dstFreeRows(c);
   c->iRow = 0;
+
+  rc = dsRequireRefs(&v->base, idxNum, "dolt_diff_stat");
+  if( rc!=SQLITE_OK ) return rc;
 
   if( (idxNum & 1) && argIdx<argc )
     zFromRef = (const char*)sqlite3_value_text(argv[argIdx++]);
@@ -896,6 +914,8 @@ static int dssFilter(sqlite3_vtab_cursor *cur,
   sqlite3 *db = v->db;
   const char *zFromRef = 0, *zToRef = 0, *zTblFilter = 0;
   ProllyHash fromCat, toCat;
+  struct TableEntry *aFromCat = 0, *aToCat = 0;
+  int nFromCat = 0, nToCat = 0;
   char **azNames = 0;
   int nNames = 0;
   int rc, argIdx = 0, i;
@@ -903,6 +923,9 @@ static int dssFilter(sqlite3_vtab_cursor *cur,
 
   dssFreeRows(c);
   c->iRow = 0;
+
+  rc = dsRequireRefs(&v->base, idxNum, "dolt_diff_summary");
+  if( rc!=SQLITE_OK ) return rc;
 
   if( (idxNum & 1) && argIdx<argc )
     zFromRef = (const char*)sqlite3_value_text(argv[argIdx++]);
@@ -918,21 +941,18 @@ static int dssFilter(sqlite3_vtab_cursor *cur,
 
   rc = dsCollectTableNames(db, &fromCat, &toCat, &azNames, &nNames);
   if( rc!=SQLITE_OK ) return rc;
+  rc = doltliteLoadCatalog(db, &fromCat, &aFromCat, &nFromCat, 0);
+  if( rc!=SQLITE_OK ) goto done;
+  rc = doltliteLoadCatalog(db, &toCat, &aToCat, &nToCat, 0);
+  if( rc!=SQLITE_OK ) goto done;
 
   for(i=0; i<nNames; i++){
-    struct TableEntry *aFromCat = 0, *aToCat = 0;
-    int nFromCat = 0, nToCat = 0;
     struct TableEntry *pFromEntry, *pToEntry;
-    int oldCount = 0, newCount = 0;
+    i64 oldCount = 0, newCount = 0;
     int dataChange, schemaChange;
     const char *zDiffType;
 
     if( zTblFilter && strcmp(azNames[i], zTblFilter)!=0 ) continue;
-
-    rc = doltliteLoadCatalog(db, &fromCat, &aFromCat, &nFromCat, 0);
-    if( rc!=SQLITE_OK ) goto done;
-    rc = doltliteLoadCatalog(db, &toCat, &aToCat, &nToCat, 0);
-    if( rc!=SQLITE_OK ){ sqlite3_free(aFromCat); goto done; }
 
     pFromEntry = doltliteFindTableByName(aFromCat, nFromCat, azNames[i]);
     pToEntry   = doltliteFindTableByName(aToCat,   nToCat,   azNames[i]);
@@ -943,8 +963,6 @@ static int dssFilter(sqlite3_vtab_cursor *cur,
       int schemasDiffer = (prollyHashCompare(&pFromEntry->schemaHash,
                                              &pToEntry->schemaHash)!=0);
       if( !rootsDiffer && !schemasDiffer ){
-        sqlite3_free(aFromCat);
-        sqlite3_free(aToCat);
         continue;
       }
       dataChange = rootsDiffer;
@@ -953,27 +971,27 @@ static int dssFilter(sqlite3_vtab_cursor *cur,
       rc = dssAppend(c, azNames[i], azNames[i], zDiffType,
                      dataChange, schemaChange);
     }else if( !pFromEntry && pToEntry ){
-      newCount = dsCountRows(db, &pToEntry->root, pToEntry->flags);
-      if( newCount<0 ) newCount = 0;
+      rc = dsCountRows(db, &pToEntry->root, pToEntry->flags, &newCount);
+      if( rc!=SQLITE_OK ) goto done;
       dataChange = newCount > 0;
       schemaChange = 1;
       rc = dssAppend(c, "", azNames[i], "added",
                      dataChange, schemaChange);
     }else if( pFromEntry && !pToEntry ){
-      oldCount = dsCountRows(db, &pFromEntry->root, pFromEntry->flags);
-      if( oldCount<0 ) oldCount = 0;
+      rc = dsCountRows(db, &pFromEntry->root, pFromEntry->flags, &oldCount);
+      if( rc!=SQLITE_OK ) goto done;
       dataChange = oldCount > 0;
       schemaChange = 1;
       rc = dssAppend(c, azNames[i], "", "dropped",
                      dataChange, schemaChange);
     }
 
-    sqlite3_free(aFromCat);
-    sqlite3_free(aToCat);
     if( rc!=SQLITE_OK ) goto done;
   }
 
 done:
+  sqlite3_free(aFromCat);
+  sqlite3_free(aToCat);
   for(i=0; i<nNames; i++) sqlite3_free(azNames[i]);
   sqlite3_free(azNames);
   return rc;

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -1791,6 +1791,140 @@ static void run_open_rejects_corrupt_working_set(void){
   remove_db(dbpath);
 }
 
+static void run_diff_stat_requires_refs(void){
+  sqlite3 *db = 0;
+  char dbpath[256];
+  const char *res;
+
+  printf("=== Diff Stat Requires Refs Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_diff_stat_requires_refs");
+  remove_db(dbpath);
+
+  check("open_db_for_diff_stat_requires_refs", open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_repo_for_diff_stat_requires_refs", execsql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'a');"
+    "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
+
+  res = exec1(db, "SELECT count(*) FROM dolt_diff_stat('HEAD');");
+  check("diff_stat_missing_to_ref_returns_error", strstr(res, "ERROR:")!=0);
+  res = exec1(db, "SELECT count(*) FROM dolt_diff_summary('HEAD');");
+  check("diff_summary_missing_to_ref_returns_error", strstr(res, "ERROR:")!=0);
+
+  sqlite3_close(db);
+  remove_db(dbpath);
+}
+
+static void run_diff_stat_surfaces_corrupt_root(void){
+  sqlite3 *db = 0;
+  ChunkStore *cs = 0;
+  char dbpath[256];
+  ProllyHash headHash, fromHash, badRootHash, badCatHash, badCommitHash;
+  DoltliteCommit headCommit, fromCommit, badCommit;
+  struct TableEntry *aTables = 0;
+  int nTables = 0;
+  u8 *pCatData = 0;
+  int nCatData = 0;
+  u8 *pCommitData = 0;
+  int nCommitData = 0;
+  int rc;
+  int i;
+  char zFrom[PROLLY_HASH_SIZE*2 + 1];
+  char zTo[PROLLY_HASH_SIZE*2 + 1];
+  char sql[512];
+  const char *res;
+  static const u8 badNode[] = { 'b', 'a', 'd', '!' };
+
+  printf("=== Diff Stat Surfaces Corrupt Root Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_diff_stat_surfaces_corrupt_root");
+  remove_db(dbpath);
+
+  memset(&headCommit, 0, sizeof(headCommit));
+  memset(&fromCommit, 0, sizeof(fromCommit));
+  memset(&badCommit, 0, sizeof(badCommit));
+
+  check("open_db_for_diff_stat_corrupt_root", open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_repo_for_diff_stat_corrupt_root", execsql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'a');"
+    "SELECT dolt_commit('-A', '-m', 'c1');"
+    "DROP TABLE t;"
+    "SELECT dolt_commit('-A', '-m', 'c2');")==SQLITE_OK);
+
+  doltliteGetSessionHead(db, &headHash);
+  check("load_head_commit_for_diff_stat_corrupt_root",
+        doltliteLoadCommit(db, &headHash, &headCommit)==SQLITE_OK);
+  if( headCommit.nParents>0 ){
+    fromHash = headCommit.aParents[0];
+  }else{
+    fromHash = headCommit.parentHash;
+  }
+  check("have_from_commit_hash_for_diff_stat_corrupt_root",
+        !prollyHashIsEmpty(&fromHash));
+  check("load_from_commit_for_diff_stat_corrupt_root",
+        doltliteLoadCommit(db, &fromHash, &fromCommit)==SQLITE_OK);
+  check("load_from_catalog_for_diff_stat_corrupt_root",
+        doltliteLoadCatalog(db, &fromCommit.catalogHash, &aTables, &nTables, 0)==SQLITE_OK);
+
+  for(i=0; i<nTables; i++){
+    if( aTables[i].zName && strcmp(aTables[i].zName, "t")==0 ){
+      break;
+    }
+  }
+  check("find_table_in_from_catalog_for_diff_stat_corrupt_root", i<nTables);
+
+  cs = doltliteGetChunkStore(db);
+  check("have_chunk_store_for_diff_stat_corrupt_root", cs!=0);
+  if( cs && i<nTables ){
+    check("store_bad_root_for_diff_stat_corrupt_root",
+          chunkStorePut(cs, badNode, (int)sizeof(badNode), &badRootHash)==SQLITE_OK);
+    aTables[i].root = badRootHash;
+    check("serialize_corrupt_catalog_for_diff_stat_corrupt_root",
+          doltliteSerializeCatalogEntries(db, aTables, nTables, &pCatData, &nCatData)==SQLITE_OK);
+    check("store_corrupt_catalog_for_diff_stat_corrupt_root",
+          chunkStorePut(cs, pCatData, nCatData, &badCatHash)==SQLITE_OK);
+
+    badCommit.parentHash = fromCommit.parentHash;
+    badCommit.catalogHash = badCatHash;
+    badCommit.timestamp = fromCommit.timestamp;
+    badCommit.zName = sqlite3_mprintf("%s", fromCommit.zName ? fromCommit.zName : "");
+    badCommit.zEmail = sqlite3_mprintf("%s", fromCommit.zEmail ? fromCommit.zEmail : "");
+    badCommit.zMessage = sqlite3_mprintf("%s", fromCommit.zMessage ? fromCommit.zMessage : "");
+    badCommit.nParents = fromCommit.nParents;
+    memcpy(badCommit.aParents, fromCommit.aParents, sizeof(fromCommit.aParents));
+    check("serialize_bad_commit_for_diff_stat_corrupt_root",
+          doltliteCommitSerialize(&badCommit, &pCommitData, &nCommitData)==SQLITE_OK);
+    check("store_bad_commit_for_diff_stat_corrupt_root",
+          chunkStorePut(cs, pCommitData, nCommitData, &badCommitHash)==SQLITE_OK);
+    rc = chunkStoreCommit(cs);
+    check("commit_bad_commit_for_diff_stat_corrupt_root", rc==SQLITE_OK);
+  }
+
+  doltliteHashToHex(&badCommitHash, zFrom);
+  doltliteHashToHex(&headHash, zTo);
+
+  snprintf(sql, sizeof(sql),
+           "SELECT count(*) FROM dolt_diff_stat('%s','%s','t');",
+           zFrom, zTo);
+  res = exec1(db, sql);
+  check("diff_stat_corrupt_root_returns_error", strstr(res, "ERROR:")!=0);
+
+  snprintf(sql, sizeof(sql),
+           "SELECT count(*) FROM dolt_diff_summary('%s','%s','t');",
+           zFrom, zTo);
+  res = exec1(db, sql);
+  check("diff_summary_corrupt_root_returns_error", strstr(res, "ERROR:")!=0);
+
+  sqlite3_free(pCommitData);
+  sqlite3_free(pCatData);
+  sqlite3_free(aTables);
+  doltliteCommitClear(&badCommit);
+  doltliteCommitClear(&fromCommit);
+  doltliteCommitClear(&headCommit);
+  sqlite3_close(db);
+  remove_db(dbpath);
+}
+
 static void run_truncated_wal_is_rejected(void){
   sqlite3 *db = 0;
   ChunkStore cs;
@@ -2794,6 +2928,8 @@ static const RegressionCase aCases[] = {
   { "begin_write_refreshes_working_set_metadata", "Begin Write Refreshes Working Set Metadata Test", run_begin_write_refreshes_working_set_metadata },
   { "begin_write_from_stale_read_snapshot", "Begin Write From Stale Read Snapshot Test", run_begin_write_from_stale_read_snapshot },
   { "open_rejects_corrupt_working_set", "Open Rejects Corrupt Working Set Test", run_open_rejects_corrupt_working_set },
+  { "diff_stat_requires_refs", "Diff Stat Requires Refs Test", run_diff_stat_requires_refs },
+  { "diff_stat_surfaces_corrupt_root", "Diff Stat Surfaces Corrupt Root Test", run_diff_stat_surfaces_corrupt_root },
   { "table_moveto_mutmap_delete_preserves_neighbors", "Table Moveto MutMap Delete Preserves Neighbors Test", run_table_moveto_mutmap_delete_preserves_neighbors },
   { "index_moveto_mutmap_exact_keeps_iteration_aligned", "Index Moveto MutMap Exact Keeps Iteration Aligned Test", run_index_moveto_mutmap_exact_keeps_iteration_aligned },
   { "btree_commit_failure_transactional", "Btree Commit Failure Transaction Test", run_btree_commit_failure_transactional },


### PR DESCRIPTION
## Summary
- require both from_ref and to_ref for dolt_diff_stat / dolt_diff_summary
- surface corrupt diff roots instead of flattening them into zero-count rows
- load summary catalogs once per query and remove dangling catalog-entry pointer use

## Testing
- === Diff Stat Requires Refs Test ===


Results: 4 passed, 0 failed out of 4 tests
- === Diff Stat Surfaces Corrupt Root Test ===


Results: 16 passed, 0 failed out of 16 tests
- === DoltLite Regression Tests ===

=== Concurrent Refs Test ===

--- Test 1: stale dolt_reset is rejected ---
--- Test 2: stale dolt_checkout refreshes target branch ---

=== Checkout Persist Failure Test ===

--- Test 1: dolt_checkout surfaces final persist failure ---

=== Savepoint Catalog Restore Test ===

--- Test 1: savepoint rollback restores schema metadata ---

=== Refs Blob Corruption Test ===

--- Test 1: truncated refs blob is rejected ---

=== Refresh Error Propagation Test ===

--- Test 1: xAccess failure is surfaced ---
--- Test 2: xFileControl failure is surfaced ---

=== Conflicts Blob Corruption Test ===


=== Status Error Propagation Test ===


=== Remote Refs Corruption Test ===


=== Chunk Walk Corruption Test ===


=== Ancestor Missing Start Test ===


=== Pull Persist Failure Test ===


=== Clone Persist Failure Test ===


=== Resolve Ref Non-Commit Test ===


=== Commit Parent Limit Test ===


=== Merge Persist Failure Test ===


=== Cherry-pick Stale Branch Test ===


=== Branches Metadata Corruption Test ===


=== GC Rewrite Failure Test ===


=== Record Decode Corruption Test ===


=== Reload Refs Transactional Test ===


=== Refresh Corrupt Refs State Preservation Test ===


=== Prolly Node Corruption Test ===


=== Truncated WAL Rejected Test ===


=== Refresh Open Path Transactional Test ===


=== WAL Offset Corruption Test ===


=== Integrity Check Walks Prolly Nodes Test ===


=== Memory Chunk Lookup Corruption Test ===


=== Prolly Diff Record Corruption Test ===


=== Integrity Check Repository State Test ===


=== Integrity Check Session Merge State Test ===


=== Prepared Statement Reuse After Commit Test ===


=== Prepared Statement Reuse After Schema Checkout Test ===


=== Working Set Refreshes Staged Across Connections Test ===


=== Reopen Preserves Staged Working Set Test ===


=== Begin Write Refreshes Working Set Metadata Test ===


=== Begin Write From Stale Read Snapshot Test ===


=== Open Rejects Corrupt Working Set Test ===


=== Diff Stat Requires Refs Test ===


=== Diff Stat Surfaces Corrupt Root Test ===


=== Table Moveto MutMap Delete Preserves Neighbors Test ===


=== Index Moveto MutMap Exact Keeps Iteration Aligned Test ===


=== Btree Commit Failure Transaction Test ===


=== Savepoint Restores Session Metadata Test ===


=== Hard Reset Failure Restores Memory State Test ===


=== MutMap Empty Reverse Iterator Test ===


=== Prolly Mutate Skipped Subtree Order Test ===


=== Chunk Store Rollback Restores Refs Hash Test ===


=== Chunk Store Commit Failure Restores Refs Hash Test ===


=== Prolly Blob Cursor Internal Boundary Test ===


=== Prolly Blob Cursor Seek Past Max Test ===


=== Prolly Cursor Empty Leaf Root Test ===


=== Prolly Cursor Corrupt Node Test ===


=== Prolly Diff Iterator Copies Blob Keys Test ===


=== Prolly Diff Leaf Corruption Test ===


Results: 100511 passed, 0 failed out of 100511 tests
- === Doltlite Diff Tests ===


Results: 20 passed, 0 failed out of 20 tests
- === Version Control Oracle Tests: dolt_diff_stat / dolt_diff_summary ===

--- no changes ---
--- single row modify ---
--- insert / delete ---
--- table creation / drop ---
--- schema change: ADD COLUMN ---
--- multi-table ---
--- table filter ---
--- ranges spanning multiple commits ---
--- branch refs ---

=== Results: 34 passed, 0 failed ===
