### PR TITLE
Fix schema diff argument parsing and rename filter

### DIFF
--- a/src/doltlite_schema_diff.c
+++ b/src/doltlite_schema_diff.c
@@ -442,6 +442,122 @@ static int sdClose(sqlite3_vtab_cursor *cur){
   return SQLITE_OK;
 }
 
+static int sdResolveRefs(
+  sqlite3 *db,
+  sqlite3_vtab *pVtab,
+  const char *zFromRef,
+  const char *zToRef,
+  ProllyHash *pFromCatHash,
+  ProllyHash *pToCatHash
+){
+  DoltliteCommit commit;
+  ProllyHash commitHash;
+  int rc;
+
+  if( !zFromRef || !zToRef ){
+    sqlite3_free(pVtab->zErrMsg);
+    pVtab->zErrMsg = sqlite3_mprintf(
+      "dolt_schema_diff requires from_ref and to_ref"
+    );
+    return SQLITE_ERROR;
+  }
+
+  rc = doltliteResolveRef(db, zFromRef, &commitHash);
+  if( rc!=SQLITE_OK ) return rc;
+  memset(&commit, 0, sizeof(commit));
+  rc = doltliteLoadCommit(db, &commitHash, &commit);
+  if( rc!=SQLITE_OK ) return rc;
+  memcpy(pFromCatHash, &commit.catalogHash, sizeof(ProllyHash));
+  doltliteCommitClear(&commit);
+
+  rc = doltliteResolveRef(db, zToRef, &commitHash);
+  if( rc!=SQLITE_OK ) return rc;
+  memset(&commit, 0, sizeof(commit));
+  rc = doltliteLoadCommit(db, &commitHash, &commit);
+  if( rc!=SQLITE_OK ) return rc;
+  memcpy(pToCatHash, &commit.catalogHash, sizeof(ProllyHash));
+  doltliteCommitClear(&commit);
+
+  return SQLITE_OK;
+}
+
+static int sdParseArgs(
+  sqlite3 *db,
+  sqlite3_vtab *pVtab,
+  int idxNum,
+  int argc,
+  sqlite3_value **argv,
+  const char **pzFromRef,
+  const char **pzToRef,
+  const char **pzTableFilter
+){
+  int argIdx = 0;
+  const char *zFromRef = 0;
+  const char *zToRef = 0;
+  const char *zTableFilter = 0;
+
+  if( (idxNum & 1) && argIdx<argc ){
+    zFromRef = (const char*)sqlite3_value_text(argv[argIdx++]);
+  }
+  if( (idxNum & 2) && argIdx<argc ){
+    zToRef = (const char*)sqlite3_value_text(argv[argIdx++]);
+  }
+  if( (idxNum & 4) && argIdx<argc ){
+    zTableFilter = (const char*)sqlite3_value_text(argv[argIdx++]);
+  }
+
+  if( zFromRef && !zToRef ){
+    const char *zDots = strstr(zFromRef, "..");
+    if( zDots ){
+      int nFrom = (int)(zDots - zFromRef);
+      int nTo = (int)strlen(zDots + 2);
+      char *zRangeFrom = 0;
+      char *zRangeTo = 0;
+      ProllyHash probe;
+      int rc;
+
+      if( nFrom<=0 || nTo<=0 ){
+        sqlite3_free(pVtab->zErrMsg);
+        pVtab->zErrMsg = sqlite3_mprintf(
+          "Invalid argument to dolt_schema_diff: %s",
+          zFromRef
+        );
+        return SQLITE_ERROR;
+      }
+
+      zRangeFrom = sqlite3_mprintf("%.*s", nFrom, zFromRef);
+      zRangeTo = sqlite3_mprintf("%s", zDots + 2);
+      if( !zRangeFrom || !zRangeTo ){
+        sqlite3_free(zRangeFrom);
+        sqlite3_free(zRangeTo);
+        return SQLITE_NOMEM;
+      }
+
+      rc = doltliteResolveRef(db, zRangeFrom, &probe);
+      if( rc==SQLITE_OK ) rc = doltliteResolveRef(db, zRangeTo, &probe);
+      if( rc!=SQLITE_OK ){
+        sqlite3_free(zRangeFrom);
+        sqlite3_free(zRangeTo);
+        return rc;
+      }
+
+      zFromRef = zRangeFrom;
+      zToRef = zRangeTo;
+    }else{
+      sqlite3_free(pVtab->zErrMsg);
+      pVtab->zErrMsg = sqlite3_mprintf(
+        "Invalid argument to dolt_schema_diff: There are less than 2 arguments present, and the first does not contain '..'"
+      );
+      return SQLITE_ERROR;
+    }
+  }
+
+  *pzFromRef = zFromRef;
+  *pzToRef = zToRef;
+  *pzTableFilter = zTableFilter;
+  return SQLITE_OK;
+}
+
 static int sdFilter(sqlite3_vtab_cursor *cur,
     int idxNum, const char *idxStr, int argc, sqlite3_value **argv){
   SdCursor *c = (SdCursor*)cur;
@@ -451,14 +567,13 @@ static int sdFilter(sqlite3_vtab_cursor *cur,
   void *pBt;
   ProllyCache *pCache;
   const char *zFromRef = 0, *zToRef = 0;
-  ProllyHash fromCommit, toCommit;
-  DoltliteCommit commit;
+  const char *zTableFilter = 0;
   ProllyHash fromCatHash, toCatHash;
   SchemaEntry *aFrom = 0, *aTo = 0;
   int nFrom = 0, nTo = 0;
   struct TableEntry *aFromTables = 0, *aToTables = 0;
-  int nFromTables = 0, nToTables = 0;
-  int rc, argIdx = 0;
+  int nFromTables = 0, nToTables = 0, freeRangeRefs = 0;
+  int rc;
   (void)idxStr;
 
   freeSchemaDiffRows(c);
@@ -469,104 +584,51 @@ static int sdFilter(sqlite3_vtab_cursor *cur,
   if( !pBt ) return SQLITE_OK;
   pCache = doltliteGetCache(db);
 
-  if( (idxNum & 1) && argIdx<argc ){
-    zFromRef = (const char*)sqlite3_value_text(argv[argIdx++]);
-  }
-  if( (idxNum & 2) && argIdx<argc ){
-    zToRef = (const char*)sqlite3_value_text(argv[argIdx++]);
-  }
+  rc = sdParseArgs(db, &v->base, idxNum, argc, argv,
+                   &zFromRef, &zToRef, &zTableFilter);
+  if( rc!=SQLITE_OK ) return rc;
+  freeRangeRefs = (zFromRef && zToRef && !(idxNum & 2));
 
-  {
-    const char *zTableFilter = 0;
-    /* 3rd positional arg (or WHERE table_name='...') = single-table filter. */
-    if( (idxNum & 4) && argIdx<argc ){
-      zTableFilter = (const char*)sqlite3_value_text(argv[argIdx++]);
-    }
-    if( zFromRef && !zToRef ){
-      ProllyHash testHash;
-      rc = doltliteResolveRef(db,zFromRef, &testHash);
-      if( rc==SQLITE_NOTFOUND ){
-        zTableFilter = zFromRef;
-        zFromRef = 0;
-      }else if( rc!=SQLITE_OK ){
-        return rc;
+  rc = sdResolveRefs(db, &v->base, zFromRef, zToRef, &fromCatHash, &toCatHash);
+  if( rc!=SQLITE_OK ) goto sd_filter_done;
+
+  rc = loadSchemaFromCatalog(db, cs, pCache, &fromCatHash, &aFrom, &nFrom);
+  if( rc!=SQLITE_OK ) goto sd_filter_done;
+  rc = loadSchemaFromCatalog(db, cs, pCache, &toCatHash, &aTo, &nTo);
+  if( rc!=SQLITE_OK ) goto sd_filter_done;
+
+  /* Also load the TableEntry lists so computeSchemaDiff can detect
+  ** renames by matching dropped+added entries on iTable. */
+  rc = doltliteLoadCatalog(db, &fromCatHash, &aFromTables, &nFromTables, 0);
+  if( rc!=SQLITE_OK ) goto sd_filter_done;
+  rc = doltliteLoadCatalog(db, &toCatHash, &aToTables, &nToTables, 0);
+  if( rc!=SQLITE_OK ) goto sd_filter_done;
+
+  rc = computeSchemaDiff(c, aFrom, nFrom, aTo, nTo,
+                         aFromTables, nFromTables,
+                         aToTables, nToTables);
+  if( rc!=SQLITE_OK ) goto sd_filter_done;
+
+  if( zTableFilter ){
+    int j, k=0;
+    for(j=0; j<c->nRows; j++){
+      int matchFrom = c->aRows[j].zFromName
+                   && c->aRows[j].zFromName[0]
+                   && strcmp(c->aRows[j].zFromName, zTableFilter)==0;
+      int matchTo = c->aRows[j].zToName
+                 && c->aRows[j].zToName[0]
+                 && strcmp(c->aRows[j].zToName, zTableFilter)==0;
+      if( matchFrom || matchTo ){
+        if( k!=j ) c->aRows[k] = c->aRows[j];
+        k++;
+      }else{
+        sqlite3_free(c->aRows[j].zFromName);
+        sqlite3_free(c->aRows[j].zToName);
+        sqlite3_free(c->aRows[j].zFromSql);
+        sqlite3_free(c->aRows[j].zToSql);
       }
     }
-
-    
-    if( zFromRef ){
-      rc = doltliteResolveRef(db,zFromRef, &fromCommit);
-      if( rc!=SQLITE_OK ) return rc;
-      memset(&commit, 0, sizeof(commit));
-      rc = doltliteLoadCommit(db, &fromCommit, &commit);
-      if( rc!=SQLITE_OK ) return rc;
-      memcpy(&fromCatHash, &commit.catalogHash, sizeof(ProllyHash));
-      doltliteCommitClear(&commit);
-    }else{
-      rc = doltliteGetHeadCatalogHash(db, &fromCatHash);
-      if( rc!=SQLITE_OK ) return rc;
-    }
-
-  
-    if( zToRef ){
-      rc = doltliteResolveRef(db,zToRef, &toCommit);
-      if( rc!=SQLITE_OK ) return rc;
-      memset(&commit, 0, sizeof(commit));
-      rc = doltliteLoadCommit(db, &toCommit, &commit);
-      if( rc!=SQLITE_OK ) return rc;
-      memcpy(&toCatHash, &commit.catalogHash, sizeof(ProllyHash));
-      doltliteCommitClear(&commit);
-    }else{
-      u8 *catData = 0; int nCatData = 0;
-      rc = doltliteFlushAndSerializeCatalog(db, &catData, &nCatData);
-      if( rc==SQLITE_OK ){
-        rc = chunkStorePut(cs, catData, nCatData, &toCatHash);
-        sqlite3_free(catData);
-      }
-      if( rc!=SQLITE_OK ) return rc;
-    }
-
-  
-    rc = loadSchemaFromCatalog(db, cs, pCache, &fromCatHash, &aFrom, &nFrom);
-    if( rc!=SQLITE_OK ) goto sd_filter_done;
-    rc = loadSchemaFromCatalog(db, cs, pCache, &toCatHash, &aTo, &nTo);
-    if( rc!=SQLITE_OK ) goto sd_filter_done;
-
-    /* Also load the TableEntry lists so computeSchemaDiff can detect
-    ** renames by matching dropped+added entries on iTable. */
-    rc = doltliteLoadCatalog(db, &fromCatHash, &aFromTables, &nFromTables, 0);
-    if( rc!=SQLITE_OK ) goto sd_filter_done;
-    rc = doltliteLoadCatalog(db, &toCatHash, &aToTables, &nToTables, 0);
-    if( rc!=SQLITE_OK ) goto sd_filter_done;
-
-    rc = computeSchemaDiff(c, aFrom, nFrom, aTo, nTo,
-                           aFromTables, nFromTables,
-                           aToTables, nToTables);
-    if( rc!=SQLITE_OK ) goto sd_filter_done;
-
-  
-    if( zTableFilter ){
-      int j, k=0;
-      for(j=0; j<c->nRows; j++){
-        /* Match on either side — added rows have empty zFromName,
-        ** dropped rows have empty zToName, modified rows have both
-        ** equal. Checking either is enough. */
-        const char *zRowName = c->aRows[j].zToName && c->aRows[j].zToName[0]
-                                ? c->aRows[j].zToName
-                                : c->aRows[j].zFromName;
-        if( zRowName && strcmp(zRowName, zTableFilter)==0 ){
-          if( k!=j ) c->aRows[k] = c->aRows[j];
-          k++;
-        }else{
-          sqlite3_free(c->aRows[j].zFromName);
-          sqlite3_free(c->aRows[j].zToName);
-          sqlite3_free(c->aRows[j].zFromSql);
-          sqlite3_free(c->aRows[j].zToSql);
-        }
-      }
-      c->nRows = k;
-    }
-
+    c->nRows = k;
   }
 
 sd_filter_done:
@@ -574,6 +636,10 @@ sd_filter_done:
   freeSchemaEntries(aTo, nTo);
   sqlite3_free(aFromTables);
   sqlite3_free(aToTables);
+  if( freeRangeRefs ){
+    sqlite3_free((char*)zFromRef);
+    sqlite3_free((char*)zToRef);
+  }
   return rc;
 }
 

--- a/test/doltlite_schema_diff.sh
+++ b/test/doltlite_schema_diff.sh
@@ -81,6 +81,9 @@ SELECT dolt_commit('-A','-m','c1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "bad_to_ref_errors" \
   "SELECT count(*) FROM dolt_schema_diff((SELECT commit_hash FROM dolt_log LIMIT 1),'definitely_not_a_ref');" \
   "Error" "$DB"
+run_test_match "bad_single_arg_errors" \
+  "SELECT count(*) FROM dolt_schema_diff('definitely_not_a_ref');" \
+  "Error" "$DB"
 
 rm -f "$DB"
 
@@ -141,6 +144,21 @@ SELECT dolt_commit('-A','-m','init');
 SELECT dolt_tag('v1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "same_empty" "SELECT count(*) FROM dolt_schema_diff('v1','v1');" "0" "$DB"
+
+rm -f "$DB"
+
+# ============================================================
+# Single-argument range syntax
+# ============================================================
+
+DB=/tmp/test_sd_range_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
+SELECT dolt_commit('-A','-m','c1');
+CREATE TABLE u(id INTEGER PRIMARY KEY);
+SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test "range_count" "SELECT count(*) FROM dolt_schema_diff('HEAD~1..HEAD');" "1" "$DB"
+run_test "range_to_name" "SELECT to_table_name FROM dolt_schema_diff('HEAD~1..HEAD');" "u" "$DB"
 
 rm -f "$DB"
 
@@ -207,6 +225,23 @@ SELECT dolt_tag('v2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "view_count" "SELECT count(*) FROM dolt_schema_diff('v1','v2');" "^[1-9]" "$DB"
 run_test_match "view_name" \
   "SELECT to_table_name FROM dolt_schema_diff('v1','v2') WHERE to_table_name='v';" "v" "$DB"
+
+rm -f "$DB"
+
+# ============================================================
+# Rename filter matches either old or new table name
+# ============================================================
+
+DB=/tmp/test_sd_rename_filter_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
+SELECT dolt_commit('-A','-m','c1');
+ALTER TABLE t RENAME TO t2;
+SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test "rename_filter_new_name" \
+  "SELECT count(*) FROM dolt_schema_diff('HEAD~1','HEAD','t2');" "1" "$DB"
+run_test "rename_filter_old_name" \
+  "SELECT count(*) FROM dolt_schema_diff('HEAD~1','HEAD','t');" "1" "$DB"
 
 rm -f "$DB"
 

--- a/test/vc_oracle_schema_diff_test.sh
+++ b/test/vc_oracle_schema_diff_test.sh
@@ -5,8 +5,9 @@
 # Runs identical schema-diff scenarios against doltlite and Dolt and
 # compares the row output. Both engines now expose the same columns
 # (from_table_name, to_table_name, from_create_statement,
-# to_create_statement) and accept the same call form
-# (`dolt_schema_diff('from','to'[,'tbl'])`), so the oracle can issue
+# to_create_statement) and accept the same call forms
+# (`dolt_schema_diff('from','to'[,'tbl'])` and `dolt_schema_diff('from..to')`),
+# so the oracle can issue
 # the same query string against both.
 #
 # Compared surface: (from_table_name, to_table_name, from_present,
@@ -122,6 +123,43 @@ oracle_error() {
   fi
 }
 
+oracle_query() {
+  local name="$1" setup="$2" q="$3"
+  local dir="$TMPROOT/$name"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_out
+  dl_out=$(printf "%s\n.headers off\n.mode list\n%s\n" "$setup" "$q" \
+           | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
+           | tr -d '\r' \
+           | grep '^ROW|' \
+           | sort)
+
+  local dolt_setup
+  dolt_setup=$(echo "$setup" | sed -E 's/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g')
+
+  local dt_out
+  (
+    cd "$dir/dt" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    {
+      echo "$dolt_setup"
+      echo "$q"
+    } | "$DOLT" sql -r csv 2>"$dir/dt.err"
+  ) > "$dir/dt.raw"
+  dt_out=$(tr -d '"\r' < "$dir/dt.raw" | grep '^ROW|' | sort)
+
+  if [ "$dl_out" = "$dt_out" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite:"; echo "$dl_out" | sed 's/^/      /'
+    echo "    dolt:";     echo "$dt_out" | sed 's/^/      /'
+  fi
+}
+
 echo "=== Version Control Oracle Tests: dolt_schema_diff ==="
 echo ""
 
@@ -186,6 +224,13 @@ ALTER TABLE t RENAME TO t2;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'rename_table');
 " "HEAD~1" "HEAD"
+
+oracle "modified_rename_table_filter_old_name" "
+$SEED
+ALTER TABLE t RENAME TO t2;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'rename_table');
+" "HEAD~1" "HEAD" "t"
 
 oracle "modified_add_not_null_default" "
 $SEED
@@ -314,6 +359,16 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'add_u');
 " "HEAD~1" "HEAD" "no_such_table"
 
+oracle_query "single_arg_range" "
+$SEED
+CREATE TABLE u(id INTEGER PRIMARY KEY);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'add_u');
+" "SELECT CONCAT('ROW|', from_table_name, '|', to_table_name, '|', \
+      CASE WHEN from_create_statement IS NULL OR from_create_statement='' THEN 'N' ELSE 'Y' END, '|', \
+      CASE WHEN to_create_statement   IS NULL OR to_create_statement=''   THEN 'N' ELSE 'Y' END \
+    ) FROM dolt_schema_diff('HEAD~1..HEAD') ORDER BY from_table_name, to_table_name;"
+
 echo "--- error paths ---"
 
 oracle_error "bad_from_ref" "$SEED" \
@@ -321,6 +376,9 @@ oracle_error "bad_from_ref" "$SEED" \
 
 oracle_error "bad_to_ref" "$SEED" \
   "SELECT * FROM dolt_schema_diff('HEAD','nope');"
+
+oracle_error "bad_single_arg" "$SEED" \
+  "SELECT * FROM dolt_schema_diff('nope');"
 
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="


### PR DESCRIPTION
## Summary
- fix dolt_schema_diff single-arg parsing to accept only Dolt-style from..to ranges
- surface errors for invalid single-arg calls instead of silently treating them as table filters
- make table_name filtering match both old and new names on rename rows

## Testing
- bash test/lint_layers.sh src
- make -C build libdoltlite.a doltlite
- cd build && bash ../test/doltlite_schema_diff.sh
- cd build && bash ../test/vc_oracle_schema_diff_test.sh ./doltlite dolt