### PR TITLE
savepoints: oracle coverage + fix rollback over in-place mutmap edits

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -177,6 +177,10 @@ jobs:
       run: cd build && bash ../test/oracle_triggers_test.sh ./doltlite ./sqlite3
       timeout-minutes: 5
 
+    - name: Oracle tests (savepoints + rollbacks)
+      run: cd build && bash ../test/oracle_savepoints_test.sh ./doltlite ./sqlite3
+      timeout-minutes: 5
+
     - name: Large-scale test (10K rows)
       run: cd build && bash ../test/large_scale_test.sh ./doltlite --quick
       timeout-minutes: 5

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -252,7 +252,14 @@ struct Btree {
 
   struct SavepointTableState {
     struct TableEntry *aTables;
-    int *aPendingCount;     /* MutMap nEntries per table at savepoint time */
+    /* Lazy deep-copy snapshot of each table's pPending mutmap. Populated
+    ** on the first flush of that table under this savepoint (see
+    ** snapshotPendingForSavepoint). NULL slots mean "no flush happened
+    ** under this savepoint" — rollback falls through to per-entry
+    ** undo-log rollback on the live pPending. Required because the
+    ** root-hash snapshot alone would lose entries that were buffered
+    ** in pPending at savepoint time and then flushed away. */
+    ProllyMutMap **aPendingSnapshot;
     int nTables;
     Pgno iNextTable;
     ProllyHash stagedCatalog;
@@ -345,6 +352,8 @@ static int ensureMutMap(BtCursor *pCur);
 static int saveCursorPosition(BtCursor *pCur);
 static int restoreCursorPosition(BtCursor *pCur, int *pDifferentRow);
 static int pushSavepoint(Btree *pBtree);
+static int findTableIndexInArray(struct TableEntry *aTables, int nTables, Pgno iTable);
+static int snapshotPendingForFlush(Btree *pBtree, Pgno iTable, ProllyMutMap *pPending);
 static int restoreFromCommitted(Btree *p);
 static void refreshCursorRoot(BtCursor *pCur);
 static int countTreeEntries(Btree *pBtree, Pgno iTable, i64 *pCount);
@@ -1082,6 +1091,7 @@ static int advanceTreeCursor(BtCursor *pCur, int dir){
 
 static int flushMutMap(BtCursor *pCur){
   struct TableEntry *pTE;
+  int rc;
 
   if( !pCur->pMutMap || prollyMutMapIsEmpty(pCur->pMutMap) ){
     return SQLITE_OK;
@@ -1092,10 +1102,15 @@ static int flushMutMap(BtCursor *pCur){
     return SQLITE_INTERNAL;
   }
 
-  {
-    int rc = applyMutMapToTableRoot(pCur->pBt, pTE, pCur->pMutMap);
-    if( rc!=SQLITE_OK ) return rc;
-  }
+  /* Same savepoint-snapshot invariant as pTE->pPending flushes: a
+  ** cursor mutmap can also hold pre-savepoint edits (see the write
+  ** cursor open path that transfers pTE->pPending into the cursor).
+  ** Capturing the pre-flush state here lets rollback reconstruct
+  ** pTE->pPending from the snapshot. */
+  rc = snapshotPendingForFlush(pCur->pBtree, pCur->pgnoRoot, pCur->pMutMap);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = applyMutMapToTableRoot(pCur->pBt, pTE, pCur->pMutMap);
+  if( rc!=SQLITE_OK ) return rc;
   pCur->pCur.root = pTE->root;
   prollyMutMapClear(pCur->pMutMap);
 
@@ -1133,6 +1148,8 @@ static int flushOtherCursorPending(BtCursor *pCur){
   if( pTE && pTE->pPending ){
     ProllyMutMap *pMap = (ProllyMutMap*)pTE->pPending;
     if( !prollyMutMapIsEmpty(pMap) ){
+      rc = snapshotPendingForFlush(pCur->pBtree, pCur->pgnoRoot, pMap);
+      if( rc!=SQLITE_OK ) return rc;
       rc = applyMutMapToTableRoot(pCur->pBt, pTE, pMap);
       if( rc!=SQLITE_OK ) return rc;
     }
@@ -1184,6 +1201,11 @@ static int ensureMutMap(BtCursor *pCur){
     sqlite3_free(pCur->pMutMap);
     pCur->pMutMap = 0;
     return rc;
+  }
+  /* A cursor opened mid-savepoint inherits the current level so any
+  ** subsequent in-place mutations correctly trigger undo logging. */
+  if( pCur->pBtree ){
+    pCur->pMutMap->currentSavepointLevel = pCur->pBtree->nSavepoint;
   }
   return SQLITE_OK;
 }
@@ -1312,13 +1334,20 @@ static int restoreCursorPosition(BtCursor *pCur, int *pDifferentRow){
 }
 
 static void freeSavepointTables(struct SavepointTableState *pState){
+  if( pState->aPendingSnapshot ){
+    int i;
+    for(i=0; i<pState->nTables; i++){
+      if( pState->aPendingSnapshot[i] ){
+        prollyMutMapFree(pState->aPendingSnapshot[i]);
+        sqlite3_free(pState->aPendingSnapshot[i]);
+      }
+    }
+    sqlite3_free(pState->aPendingSnapshot);
+    pState->aPendingSnapshot = 0;
+  }
   if( pState->aTables ){
     sqlite3_free(pState->aTables);
     pState->aTables = 0;
-  }
-  if( pState->aPendingCount ){
-    sqlite3_free(pState->aPendingCount);
-    pState->aPendingCount = 0;
   }
   memset(&pState->stagedCatalog, 0, sizeof(pState->stagedCatalog));
   pState->isMerging = 0;
@@ -1326,16 +1355,127 @@ static void freeSavepointTables(struct SavepointTableState *pState){
   memset(&pState->conflictsCatalogHash, 0, sizeof(pState->conflictsCatalogHash));
 }
 
-static void truncatePendingToCount(ProllyMutMap *pMap, int savedCount){
-  while( pMap && pMap->nEntries > savedCount ){
-    ProllyMutMapEntry *e;
-    pMap->nEntries--;
-    e = &pMap->aEntries[pMap->nEntries];
-    sqlite3_free(e->pKey);
-    e->pKey = 0;
-    sqlite3_free(e->pVal);
-    e->pVal = 0;
+/* Walk every live mutmap belonging to this Btree — both the per-table
+** pPending slots and every cursor's own pMutMap — and broadcast a
+** savepoint state change. The mutmap state machine (bornAt stamps +
+** lazy undo log) relies on seeing every transition. Cursors from a
+** shared BtShared that belong to a different Btree are skipped. */
+static void pushSavepointOnMutMaps(Btree *pBtree, int level){
+  int k;
+  BtCursor *p;
+  for(k=0; k<pBtree->nTables; k++){
+    ProllyMutMap *pMap = (ProllyMutMap*)pBtree->aTables[k].pPending;
+    if( pMap ) prollyMutMapPushSavepoint(pMap, level);
   }
+  for(p = pBtree->pBt->pCursor; p; p = p->pNext){
+    if( p->pBtree==pBtree && p->pMutMap ){
+      prollyMutMapPushSavepoint(p->pMutMap, level);
+    }
+  }
+}
+
+/* Find the smallest-index savepoint in [iFromSavepoint..nSavepoint) that
+** has a pPending snapshot for iTable. Returns the snapshot pointer (not
+** ownership — caller clones) or NULL if none found. */
+static ProllyMutMap *findPendingSnapshot(Btree *pBtree, int iFromSavepoint,
+                                          Pgno iTable){
+  int i;
+  for(i=iFromSavepoint; i<pBtree->nSavepoint; i++){
+    struct SavepointTableState *pState = &pBtree->aSavepointTables[i];
+    int j;
+    if( !pState->aPendingSnapshot ) continue;
+    j = findTableIndexInArray(pState->aTables, pState->nTables, iTable);
+    if( j < 0 ) continue;
+    if( pState->aPendingSnapshot[j] ){
+      return pState->aPendingSnapshot[j];
+    }
+  }
+  return 0;
+}
+
+/* Rollback all live mutmaps to the given savepoint level. For each
+** table mutmap: if any savepoint in the range being rolled back has a
+** snapshot (captured at first flush under that savepoint), replace
+** pTE->pPending with a clone of the smallest-level snapshot, then
+** apply per-entry rollback to the clone. Otherwise just apply
+** per-entry rollback to the live pPending — the live state is
+** authoritative because no flush happened to destroy it. */
+static int rollbackMutMapsToSavepoint(Btree *pBtree, int level,
+                                       int iFromSavepoint){
+  int k, rc;
+  BtCursor *p;
+  for(k=0; k<pBtree->nTables; k++){
+    struct TableEntry *pTE = &pBtree->aTables[k];
+    ProllyMutMap *pMap = (ProllyMutMap*)pTE->pPending;
+    ProllyMutMap *pSnap = findPendingSnapshot(pBtree, iFromSavepoint,
+                                               pTE->iTable);
+    if( pSnap ){
+      ProllyMutMap *pClone = 0;
+      rc = prollyMutMapClone(&pClone, pSnap);
+      if( rc!=SQLITE_OK ) return rc;
+      if( pMap ){
+        prollyMutMapFree(pMap);
+        sqlite3_free(pMap);
+      }
+      pTE->pPending = pClone;
+      rc = prollyMutMapRollbackToSavepoint(pClone, level);
+      if( rc!=SQLITE_OK ) return rc;
+    }else if( pMap ){
+      rc = prollyMutMapRollbackToSavepoint(pMap, level);
+      if( rc!=SQLITE_OK ) return rc;
+    }
+  }
+  for(p = pBtree->pBt->pCursor; p; p = p->pNext){
+    if( p->pBtree==pBtree && p->pMutMap ){
+      rc = prollyMutMapRollbackToSavepoint(p->pMutMap, level);
+      if( rc!=SQLITE_OK ) return rc;
+    }
+  }
+  return SQLITE_OK;
+}
+
+static void releaseMutMapsToSavepoint(Btree *pBtree, int level){
+  int k;
+  BtCursor *p;
+  for(k=0; k<pBtree->nTables; k++){
+    ProllyMutMap *pMap = (ProllyMutMap*)pBtree->aTables[k].pPending;
+    if( pMap ) prollyMutMapReleaseSavepoint(pMap, level);
+  }
+  for(p = pBtree->pBt->pCursor; p; p = p->pNext){
+    if( p->pBtree==pBtree && p->pMutMap ){
+      prollyMutMapReleaseSavepoint(p->pMutMap, level);
+    }
+  }
+}
+
+/* Before a flush applies pTE->pPending to the tree, make sure each
+** active savepoint has captured whatever state that flush is about
+** to destroy. Only the innermost savepoint without a snapshot for
+** this table actually takes the (deep-copy) snapshot — deeper walks
+** are skipped because the innermost snapshot is sufficient to roll
+** back the outer savepoints too (applyRollback on the clone walks
+** the snapshot's internal bornAt stamps and undo log). */
+static int snapshotPendingForFlush(Btree *pBtree, Pgno iTable,
+                                   ProllyMutMap *pPending){
+  int i;
+  if( !pBtree || !pPending ) return SQLITE_OK;
+  if( pBtree->nSavepoint <= 0 ) return SQLITE_OK;
+  if( prollyMutMapIsEmpty(pPending) ) return SQLITE_OK;
+
+  for(i = pBtree->nSavepoint - 1; i >= 0; i--){
+    struct SavepointTableState *pState = &pBtree->aSavepointTables[i];
+    int j;
+    if( !pState->aPendingSnapshot ) continue;
+    j = findTableIndexInArray(pState->aTables, pState->nTables, iTable);
+    if( j < 0 ) continue;
+    if( pState->aPendingSnapshot[j] ) return SQLITE_OK;
+    {
+      int rc = prollyMutMapClone(&pState->aPendingSnapshot[j], pPending);
+      if( rc!=SQLITE_OK ) return rc;
+    }
+    return SQLITE_OK;
+  }
+  return SQLITE_OK;
 }
 
 static int findTableIndexInArray(
@@ -1392,7 +1532,9 @@ static int restoreTablesFromSavepoint(
     iSaved = findTableIndexInArray(
         pState->aTables, pState->nTables, pBtree->aTables[k].iTable);
     if( iSaved>=0 ){
-      truncatePendingToCount(pMap, pState->aPendingCount[iSaved]);
+      /* Mutmap content was already rolled back via the per-entry
+      ** bornAt stamps + undo log in rollbackMutMapsToSavepoint; just
+      ** preserve the pointer so it survives the aTables memcpy. */
       apPending[iSaved] = pMap;
     }else{
       prollyMutMapFree(pMap);
@@ -1418,25 +1560,16 @@ static int restoreTablesFromSavepoint(
   return SQLITE_OK;
 }
 
-/* Snapshot the current state so ROLLBACK TO can restore it.
-** Saves: (1) the current prolly root hash, (2) each table's root hash,
-** (3) the nEntries count of each table's pending MutMap.
-** On rollback, table roots are restored and MutMap entries are truncated
-** back to the saved count -- this works because MutMap is append-only.
-** IMPORTANT: all cursor MutMaps must be flushed first, because the
-** savepoint only records table-level root hashes and MutMap counts. */
+/* Snapshot just enough to let ROLLBACK TO reconstruct table-level
+** state. Per-entry mutmap edits are tracked separately by the bornAt
+** stamp + lazy undo log in each ProllyMutMap (see prolly_mutmap.c),
+** so we no longer flush cursor edits here or record per-table mutmap
+** sizes — the root-hash snapshot covers the case where a flush happens
+** mid-savepoint, and the per-entry tracking covers everything still
+** buffered. Cost of push is O(nTables) memcpy plus O(live mutmaps)
+** int-writes from pushSavepointOnMutMaps. */
 static int pushSavepoint(Btree *pBtree){
   struct SavepointTableState *pState;
-  int rc;
-
-  /* Flush all cursor edits before snapshotting */
-  {
-    BtCursor *p;
-    for(p = pBtree->pBt->pCursor; p; p = p->pNext){
-      rc = flushIfNeeded(p);
-      if( rc!=SQLITE_OK ) return rc;
-    }
-  }
 
   if( pBtree->nSavepoint>=pBtree->nSavepointAlloc ){
     int nNew = pBtree->nSavepointAlloc ? pBtree->nSavepointAlloc*2 : 8;
@@ -1449,7 +1582,7 @@ static int pushSavepoint(Btree *pBtree){
 
   pState = &pBtree->aSavepointTables[pBtree->nSavepoint];
   pState->aTables = 0;
-  pState->aPendingCount = 0;
+  pState->aPendingSnapshot = 0;
   pState->nTables = 0;
   pState->iNextTable = pBtree->iNextTable;
   pState->stagedCatalog = pBtree->stagedCatalog;
@@ -1459,26 +1592,28 @@ static int pushSavepoint(Btree *pBtree){
   if( pBtree->nTables > 0 ){
     pState->aTables = sqlite3_malloc(pBtree->nTables * (int)sizeof(struct TableEntry));
     if( !pState->aTables ) return SQLITE_NOMEM;
-    pState->aPendingCount = sqlite3_malloc(pBtree->nTables * (int)sizeof(int));
-    if( !pState->aPendingCount ){
+    pState->aPendingSnapshot = sqlite3_malloc(
+        pBtree->nTables * (int)sizeof(ProllyMutMap*));
+    if( !pState->aPendingSnapshot ){
       sqlite3_free(pState->aTables);
       pState->aTables = 0;
       return SQLITE_NOMEM;
     }
+    memset(pState->aPendingSnapshot, 0,
+           pBtree->nTables * sizeof(ProllyMutMap*));
     memcpy(pState->aTables, pBtree->aTables,
            pBtree->nTables * sizeof(struct TableEntry));
     pState->nTables = pBtree->nTables;
     {
       int k;
       for(k=0; k<pState->nTables; k++){
-        ProllyMutMap *pMap = (ProllyMutMap*)pState->aTables[k].pPending;
-        pState->aPendingCount[k] = pMap ? pMap->nEntries : 0;
-        pState->aTables[k].pPending = 0;  
+        pState->aTables[k].pPending = 0;
       }
     }
   }
 
   pBtree->nSavepoint++;
+  pushSavepointOnMutMaps(pBtree, pBtree->nSavepoint);
   return SQLITE_OK;
 }
 
@@ -2517,16 +2652,18 @@ static int prollyBtreeSavepoint(Btree *p, int op, int iSavepoint){
   }
 
   if( op==SAVEPOINT_ROLLBACK ){
-    /* Rollback: restore the prolly root and each table's root to the
-    ** values captured at pushSavepoint time. For MutMap entries, we
-    ** truncate back to the saved nEntries count (MutMap is append-only,
-    ** so entries after savedCount are exactly the post-savepoint writes).
-    ** Tables created after the savepoint are removed entirely. */
+    /* Rollback: per-entry bornAt + undo log reverts buffered edits in
+    ** every live mutmap first, then the table-level snapshot (root
+    ** hashes, catalog state) is restored for the case where a flush
+    ** happened mid-savepoint. Tables created under the savepoint are
+    ** freed by restoreTablesFromSavepoint. */
     if( iSavepoint>=0 && iSavepoint<p->nSavepoint
      && p->aSavepointTables ){
       struct SavepointTableState *pState = &p->aSavepointTables[iSavepoint];
+      int rc = rollbackMutMapsToSavepoint(p, iSavepoint + 1, iSavepoint);
+      if( rc!=SQLITE_OK ) return rc;
       if( pState->aTables ){
-        int rc = restoreTablesFromSavepoint(p, pState);
+        rc = restoreTablesFromSavepoint(p, pState);
         if( rc!=SQLITE_OK ) return rc;
       }
       p->stagedCatalog = pState->stagedCatalog;
@@ -2534,7 +2671,7 @@ static int prollyBtreeSavepoint(Btree *p, int op, int iSavepoint){
       p->mergeCommitHash = pState->mergeCommitHash;
       p->conflictsCatalogHash = pState->conflictsCatalogHash;
       freeSavepointTables(pState);
-      
+
       {
         int j;
         for(j=iSavepoint+1; j<p->nSavepoint; j++){
@@ -2559,9 +2696,13 @@ static int prollyBtreeSavepoint(Btree *p, int op, int iSavepoint){
       invalidateSchema(p);
     }
   } else {
-    
+    /* RELEASE: commit savepoint levels [iSavepoint+1..nSavepoint] into
+    ** level iSavepoint. The per-mutmap release relabels undo records
+    ** and clamps entry bornAt so a later ROLLBACK TO the parent still
+    ** finds the correct state. */
     if( iSavepoint>=0 && iSavepoint<p->nSavepoint ){
       int j;
+      releaseMutMapsToSavepoint(p, iSavepoint + 1);
       for(j=iSavepoint; j<p->nSavepoint; j++){
         freeSavepointTables(&p->aSavepointTables[j]);
       }
@@ -2823,10 +2964,12 @@ static int prollyBtreeCursor(
       }
       pTE->pendingFlushSeekEdits = 0;
     }else{
-      
+
       ProllyMutMap *pMap = (ProllyMutMap*)pTE->pPending;
       if( !prollyMutMapIsEmpty(pMap) ){
-        int rc2 = applyMutMapToTableRoot(pBt, pTE, pMap);
+        int rc2 = snapshotPendingForFlush(p, iTable, pMap);
+        if( rc2!=SQLITE_OK ) return rc2;
+        rc2 = applyMutMapToTableRoot(pBt, pTE, pMap);
         prollyMutMapFree(pMap);
         sqlite3_free(pMap);
         pTE->pPending = 0;
@@ -3113,7 +3256,9 @@ static int flushTablePending(BtCursor *pCur){
   if( pTE && pTE->pPending ){
     ProllyMutMap *pMap = (ProllyMutMap*)pTE->pPending;
     if( !prollyMutMapIsEmpty(pMap) ){
-      int rc = applyMutMapToTableRoot(pCur->pBt, pTE, pMap);
+      int rc = snapshotPendingForFlush(pCur->pBtree, pCur->pgnoRoot, pMap);
+      if( rc!=SQLITE_OK ) return rc;
+      rc = applyMutMapToTableRoot(pCur->pBt, pTE, pMap);
       prollyMutMapFree(pMap);
       sqlite3_free(pMap);
       pTE->pPending = 0;
@@ -4403,6 +4548,9 @@ static int flushDeferredEdits(BtShared *pBt){
     for(i=0; i<pBtree->nTables; i++){
       struct TableEntry *pTE = &pBtree->aTables[i];
       if( pTE->pPending && !prollyMutMapIsEmpty((ProllyMutMap*)pTE->pPending) ){
+        rc = snapshotPendingForFlush(pBtree, pTE->iTable,
+                                     (ProllyMutMap*)pTE->pPending);
+        if( rc!=SQLITE_OK ) return rc;
         rc = applyMutMapToTableRoot(pBt, pTE, (ProllyMutMap*)pTE->pPending);
         prollyMutMapFree((ProllyMutMap*)pTE->pPending);
         sqlite3_free(pTE->pPending);
@@ -5306,6 +5454,8 @@ int doltliteApplyRawRowMutation(
   if( pTE->pPending ){
     ProllyMutMap *pPend = (ProllyMutMap*)pTE->pPending;
     if( !prollyMutMapIsEmpty(pPend) ){
+      rc = snapshotPendingForFlush(pBtree, pTE->iTable, pPend);
+      if( rc!=SQLITE_OK ) return rc;
       rc = applyMutMapToTableRoot(pBt, pTE, pPend);
       if( rc!=SQLITE_OK ) return rc;
     }

--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -93,6 +93,51 @@ int prollyMutMapInit(ProllyMutMap *mm, u8 isIntKey){
   return SQLITE_OK;
 }
 
+/* Append an undo record snapshotting the current state of
+** aEntries[idx]. Only called when an in-place mutation under an
+** active savepoint would lose information that ROLLBACK TO needs.
+*/
+static int appendUndoRec(ProllyMutMap *mm, int idx){
+  ProllyMutMapEntry *e;
+  ProllyMutMapUndoRec *rec;
+  if( mm->nUndo >= mm->nUndoAlloc ){
+    int nNew = mm->nUndoAlloc ? mm->nUndoAlloc*2 : 8;
+    ProllyMutMapUndoRec *aNew = sqlite3_realloc(mm->aUndo,
+        nNew * sizeof(ProllyMutMapUndoRec));
+    if( !aNew ) return SQLITE_NOMEM;
+    mm->aUndo = aNew;
+    mm->nUndoAlloc = nNew;
+  }
+  e = &mm->aEntries[idx];
+  rec = &mm->aUndo[mm->nUndo];
+  rec->level = mm->currentSavepointLevel;
+  rec->entryIdx = idx;
+  rec->prevBornAt = e->bornAt;
+  rec->prevOp = e->op;
+  rec->nPrevVal = e->nVal;
+  if( e->nVal > 0 && e->pVal ){
+    rec->prevVal = (u8*)sqlite3_malloc(e->nVal);
+    if( !rec->prevVal ) return SQLITE_NOMEM;
+    memcpy(rec->prevVal, e->pVal, e->nVal);
+  }else{
+    rec->prevVal = 0;
+  }
+  mm->nUndo++;
+  return SQLITE_OK;
+}
+
+/* When an insert at idx shifts later entries to the right, any
+** undo records pointing at the shifted entries need their indices
+** bumped to track. Symmetric for an undo of the insert. */
+static void shiftUndoIndices(ProllyMutMap *mm, int idx, int delta){
+  int i;
+  for(i=0; i<mm->nUndo; i++){
+    if( mm->aUndo[i].entryIdx >= idx ){
+      mm->aUndo[i].entryIdx += delta;
+    }
+  }
+}
+
 int prollyMutMapInsert(
   ProllyMutMap *mm,
   const u8 *pKey, int nKey, i64 intKey,
@@ -103,8 +148,14 @@ int prollyMutMapInsert(
   idx = bsearch_key(mm, pKey, nKey, intKey, &found);
 
   if( found ){
-    
     ProllyMutMapEntry *e = &mm->aEntries[idx];
+    /* In-place mutation. If a savepoint is active AND the entry
+    ** predates it, snapshot before overwriting. */
+    if( mm->currentSavepointLevel > 0
+     && e->bornAt < mm->currentSavepointLevel ){
+      rc = appendUndoRec(mm, idx);
+      if( rc!=SQLITE_OK ) return rc;
+    }
     e->op = PROLLY_EDIT_INSERT;
     sqlite3_free(e->pVal);
     e->pVal = 0;
@@ -115,32 +166,36 @@ int prollyMutMapInsert(
       memcpy(e->pVal, pVal, nVal);
       e->nVal = nVal;
     }
+    e->bornAt = mm->currentSavepointLevel;
     return SQLITE_OK;
   }
 
-  
   rc = ensureCapacity(mm);
   if( rc!=SQLITE_OK ) return rc;
 
-  
   if( idx < mm->nEntries ){
     memmove(&mm->aEntries[idx+1], &mm->aEntries[idx],
             (mm->nEntries - idx) * sizeof(ProllyMutMapEntry));
+    if( mm->currentSavepointLevel > 0 ){
+      shiftUndoIndices(mm, idx, 1);
+    }
   }
 
-  
   {
     ProllyMutMapEntry *e = &mm->aEntries[idx];
     memset(e, 0, sizeof(*e));
     e->op = PROLLY_EDIT_INSERT;
     e->isIntKey = mm->isIntKey;
     e->intKey = intKey;
+    e->bornAt = mm->currentSavepointLevel;
     rc = copyEntryData(e, pKey, nKey, pVal, nVal);
     if( rc!=SQLITE_OK ){
-      
       if( idx < mm->nEntries ){
         memmove(&mm->aEntries[idx], &mm->aEntries[idx+1],
                 (mm->nEntries - idx) * sizeof(ProllyMutMapEntry));
+        if( mm->currentSavepointLevel > 0 ){
+          shiftUndoIndices(mm, idx+1, -1);
+        }
       }
       return rc;
     }
@@ -161,24 +216,31 @@ int prollyMutMapDelete(
   if( found ){
     ProllyMutMapEntry *e = &mm->aEntries[idx];
     if( e->op == PROLLY_EDIT_INSERT ){
-      
+      if( mm->currentSavepointLevel > 0
+       && e->bornAt < mm->currentSavepointLevel ){
+        rc = appendUndoRec(mm, idx);
+        if( rc!=SQLITE_OK ) return rc;
+      }
       e->op = PROLLY_EDIT_DELETE;
       sqlite3_free(e->pVal);
       e->pVal = 0;
       e->nVal = 0;
+      e->bornAt = mm->currentSavepointLevel;
       return SQLITE_OK;
     }
-    
+    /* Already a DELETE — no state change. */
     return SQLITE_OK;
   }
 
-  
   rc = ensureCapacity(mm);
   if( rc!=SQLITE_OK ) return rc;
 
   if( idx < mm->nEntries ){
     memmove(&mm->aEntries[idx+1], &mm->aEntries[idx],
             (mm->nEntries - idx) * sizeof(ProllyMutMapEntry));
+    if( mm->currentSavepointLevel > 0 ){
+      shiftUndoIndices(mm, idx, 1);
+    }
   }
 
   {
@@ -187,11 +249,15 @@ int prollyMutMapDelete(
     e->op = PROLLY_EDIT_DELETE;
     e->isIntKey = mm->isIntKey;
     e->intKey = intKey;
+    e->bornAt = mm->currentSavepointLevel;
     rc = copyEntryData(e, pKey, nKey, 0, 0);
     if( rc!=SQLITE_OK ){
       if( idx < mm->nEntries ){
         memmove(&mm->aEntries[idx], &mm->aEntries[idx+1],
                 (mm->nEntries - idx) * sizeof(ProllyMutMapEntry));
+        if( mm->currentSavepointLevel > 0 ){
+          shiftUndoIndices(mm, idx+1, -1);
+        }
       }
       return rc;
     }
@@ -199,6 +265,114 @@ int prollyMutMapDelete(
 
   mm->nEntries++;
   return SQLITE_OK;
+}
+
+void prollyMutMapPushSavepoint(ProllyMutMap *mm, int level){
+  if( !mm ) return;
+  mm->currentSavepointLevel = level;
+}
+
+/* Rollback order matters: first walk the undo log backward restoring
+** in-place mutations to their pre-savepoint state (including resetting
+** bornAt). THEN drop any remaining entries with bornAt >= level —
+** those are fresh-key inserts under the rolled-back savepoints, which
+** never had undo records in the first place. Doing it the other way
+** would drop in-place-mutated entries before their undo record was
+** applied, losing the restored state. */
+int prollyMutMapRollbackToSavepoint(ProllyMutMap *mm, int level){
+  int i;
+  if( !mm ) return SQLITE_OK;
+
+  /* Restore in-place mutations. Walk undo backward. */
+  while( mm->nUndo > 0
+      && mm->aUndo[mm->nUndo - 1].level >= level ){
+    ProllyMutMapUndoRec *rec = &mm->aUndo[mm->nUndo - 1];
+    int idx = rec->entryIdx;
+    if( idx >= 0 && idx < mm->nEntries ){
+      ProllyMutMapEntry *e = &mm->aEntries[idx];
+      e->op = rec->prevOp;
+      e->bornAt = rec->prevBornAt;
+      sqlite3_free(e->pVal);
+      e->pVal = 0;
+      e->nVal = 0;
+      if( rec->prevVal && rec->nPrevVal > 0 ){
+        e->pVal = (u8*)sqlite3_malloc(rec->nPrevVal);
+        if( !e->pVal ) return SQLITE_NOMEM;
+        memcpy(e->pVal, rec->prevVal, rec->nPrevVal);
+        e->nVal = rec->nPrevVal;
+      }
+    }
+    sqlite3_free(rec->prevVal);
+    rec->prevVal = 0;
+    mm->nUndo--;
+  }
+
+  /* Drop new entries (bornAt >= level) — these are fresh-key inserts
+  ** under the rolled-back savepoints. Walk descending so removals
+  ** don't disturb later indices. Patch surviving lower-level undo
+  ** records whose entryIdx > i as each removal shifts later entries
+  ** left by one. */
+  for(i = mm->nEntries - 1; i >= 0; i--){
+    if( mm->aEntries[i].bornAt >= level ){
+      ProllyMutMapEntry *e = &mm->aEntries[i];
+      sqlite3_free(e->pKey);
+      sqlite3_free(e->pVal);
+      if( i < mm->nEntries - 1 ){
+        memmove(&mm->aEntries[i], &mm->aEntries[i+1],
+                (mm->nEntries - 1 - i) * sizeof(ProllyMutMapEntry));
+      }
+      mm->nEntries--;
+      {
+        int j;
+        for(j=0; j<mm->nUndo; j++){
+          if( mm->aUndo[j].entryIdx > i ){
+            mm->aUndo[j].entryIdx--;
+          }
+        }
+      }
+    }
+  }
+
+  mm->currentSavepointLevel = level - 1;
+  return SQLITE_OK;
+}
+
+/* RELEASE commits everything at level >= `level` into level `level-1`.
+** Two things need to happen: (1) in-place undo records at the released
+** levels get "inherited" by the parent level so a future ROLLBACK TO
+** the parent can still find the pre-release state; (2) entries with
+** bornAt in the released range get clamped down to level-1 so a later
+** ROLLBACK TO the parent doesn't mistakenly drop them as fresh post-
+** savepoint inserts. Special case: releasing to level 0 (fast path)
+** drops the undo log entirely — there's no outer savepoint to preserve
+** those records for, and COMMIT/full-ROLLBACK don't use them. */
+void prollyMutMapReleaseSavepoint(ProllyMutMap *mm, int level){
+  int i;
+  int target;
+  if( !mm ) return;
+  target = level - 1;
+
+  if( target == 0 ){
+    for(i=0; i<mm->nUndo; i++){
+      sqlite3_free(mm->aUndo[i].prevVal);
+      mm->aUndo[i].prevVal = 0;
+    }
+    mm->nUndo = 0;
+  }else{
+    for(i=0; i<mm->nUndo; i++){
+      if( mm->aUndo[i].level >= level ){
+        mm->aUndo[i].level = target;
+      }
+    }
+  }
+
+  for(i=0; i<mm->nEntries; i++){
+    if( mm->aEntries[i].bornAt >= level ){
+      mm->aEntries[i].bornAt = target;
+    }
+  }
+
+  mm->currentSavepointLevel = target;
 }
 
 ProllyMutMapEntry *prollyMutMapFind(ProllyMutMap *mm,
@@ -246,12 +420,20 @@ void prollyMutMapIterLast(ProllyMutMapIter *it, ProllyMutMap *mm){
   it->idx = mm->nEntries>0 ? mm->nEntries - 1 : mm->nEntries;
 }
 
+/* Clear wipes data only (entries + undo records). currentSavepointLevel
+** is savepoint *context* not data; a flushMutMap mid-savepoint calls
+** clear but the mutmap continues to live under the same savepoint,
+** so any subsequent writes must still be attributed to that level. */
 void prollyMutMapClear(ProllyMutMap *mm){
   int i;
   for(i=0; i<mm->nEntries; i++){
     freeEntryData(&mm->aEntries[i]);
   }
   mm->nEntries = 0;
+  for(i=0; i<mm->nUndo; i++){
+    sqlite3_free(mm->aUndo[i].prevVal);
+  }
+  mm->nUndo = 0;
 }
 
 void prollyMutMapFree(ProllyMutMap *mm){
@@ -259,6 +441,109 @@ void prollyMutMapFree(ProllyMutMap *mm){
   sqlite3_free(mm->aEntries);
   mm->aEntries = 0;
   mm->nAlloc = 0;
+  sqlite3_free(mm->aUndo);
+  mm->aUndo = 0;
+  mm->nUndoAlloc = 0;
+  mm->currentSavepointLevel = 0;
+}
+
+int prollyMutMapClone(ProllyMutMap **out, const ProllyMutMap *src){
+  ProllyMutMap *dst;
+  int i;
+  *out = 0;
+  dst = (ProllyMutMap*)sqlite3_malloc(sizeof(ProllyMutMap));
+  if( !dst ) return SQLITE_NOMEM;
+  memset(dst, 0, sizeof(*dst));
+  dst->isIntKey = src->isIntKey;
+  dst->currentSavepointLevel = src->currentSavepointLevel;
+
+  if( src->nEntries > 0 ){
+    dst->aEntries = (ProllyMutMapEntry*)sqlite3_malloc(
+        src->nEntries * (int)sizeof(ProllyMutMapEntry));
+    if( !dst->aEntries ){
+      prollyMutMapFree(dst);
+      sqlite3_free(dst);
+      return SQLITE_NOMEM;
+    }
+    memset(dst->aEntries, 0,
+           src->nEntries * sizeof(ProllyMutMapEntry));
+    dst->nAlloc = src->nEntries;
+    for(i=0; i<src->nEntries; i++){
+      ProllyMutMapEntry *se = &src->aEntries[i];
+      ProllyMutMapEntry *de = &dst->aEntries[i];
+      de->op = se->op;
+      de->isIntKey = se->isIntKey;
+      de->intKey = se->intKey;
+      de->bornAt = se->bornAt;
+      de->nKey = 0;
+      de->nVal = 0;
+      de->pKey = 0;
+      de->pVal = 0;
+      if( se->pKey && se->nKey > 0 ){
+        de->pKey = (u8*)sqlite3_malloc(se->nKey);
+        if( !de->pKey ){
+          dst->nEntries = i;
+          prollyMutMapFree(dst);
+          sqlite3_free(dst);
+          return SQLITE_NOMEM;
+        }
+        memcpy(de->pKey, se->pKey, se->nKey);
+        de->nKey = se->nKey;
+      }
+      if( se->pVal && se->nVal > 0 ){
+        de->pVal = (u8*)sqlite3_malloc(se->nVal);
+        if( !de->pVal ){
+          sqlite3_free(de->pKey);
+          de->pKey = 0;
+          dst->nEntries = i;
+          prollyMutMapFree(dst);
+          sqlite3_free(dst);
+          return SQLITE_NOMEM;
+        }
+        memcpy(de->pVal, se->pVal, se->nVal);
+        de->nVal = se->nVal;
+      }
+      dst->nEntries++;
+    }
+  }
+
+  if( src->nUndo > 0 ){
+    dst->aUndo = (ProllyMutMapUndoRec*)sqlite3_malloc(
+        src->nUndo * (int)sizeof(ProllyMutMapUndoRec));
+    if( !dst->aUndo ){
+      prollyMutMapFree(dst);
+      sqlite3_free(dst);
+      return SQLITE_NOMEM;
+    }
+    memset(dst->aUndo, 0,
+           src->nUndo * sizeof(ProllyMutMapUndoRec));
+    dst->nUndoAlloc = src->nUndo;
+    for(i=0; i<src->nUndo; i++){
+      ProllyMutMapUndoRec *sr = &src->aUndo[i];
+      ProllyMutMapUndoRec *dr = &dst->aUndo[i];
+      dr->level = sr->level;
+      dr->entryIdx = sr->entryIdx;
+      dr->prevBornAt = sr->prevBornAt;
+      dr->prevOp = sr->prevOp;
+      dr->nPrevVal = 0;
+      dr->prevVal = 0;
+      if( sr->prevVal && sr->nPrevVal > 0 ){
+        dr->prevVal = (u8*)sqlite3_malloc(sr->nPrevVal);
+        if( !dr->prevVal ){
+          dst->nUndo = i;
+          prollyMutMapFree(dst);
+          sqlite3_free(dst);
+          return SQLITE_NOMEM;
+        }
+        memcpy(dr->prevVal, sr->prevVal, sr->nPrevVal);
+        dr->nPrevVal = sr->nPrevVal;
+      }
+      dst->nUndo++;
+    }
+  }
+
+  *out = dst;
+  return SQLITE_OK;
 }
 
 int prollyMutMapMerge(ProllyMutMap *pDst, ProllyMutMap *pSrc){

--- a/src/prolly_mutmap.h
+++ b/src/prolly_mutmap.h
@@ -12,20 +12,49 @@ typedef struct ProllyMutMapEntry ProllyMutMapEntry;
 typedef struct ProllyMutMapIter ProllyMutMapIter;
 
 struct ProllyMutMapEntry {
-  u8 op;                 
-  u8 isIntKey;           
-  i64 intKey;            
-  u8 *pKey;              
-  int nKey;              
-  u8 *pVal;              
-  int nVal;              
+  u8 op;
+  u8 isIntKey;
+  i64 intKey;
+  u8 *pKey;
+  int nKey;
+  u8 *pVal;
+  int nVal;
+  /* Savepoint level at which this entry was created or last
+  ** modified in place. 0 means "no savepoint active when written".
+  ** Used by the savepoint rollback path to drop post-savepoint
+  ** entries — see prollyMutMapPushSavepoint. */
+  int bornAt;
+};
+
+/* Undo record: pre-mutation snapshot of an entry whose op or value
+** was overwritten in place under an active savepoint. The record
+** captures enough to put the entry back the way it was. Created
+** lazily — only when an in-place mutation actually crosses a
+** savepoint boundary, never on fresh-key inserts. */
+typedef struct ProllyMutMapUndoRec ProllyMutMapUndoRec;
+struct ProllyMutMapUndoRec {
+  int level;        /* savepoint level this record belongs to */
+  int entryIdx;     /* aEntries[] index at the time of capture */
+  int prevBornAt;   /* original bornAt to restore */
+  u8 prevOp;
+  u8 *prevVal;
+  int nPrevVal;
 };
 
 struct ProllyMutMap {
-  u8 isIntKey;            
-  int nEntries;           
-  int nAlloc;             
-  ProllyMutMapEntry *aEntries;  
+  u8 isIntKey;
+  int nEntries;
+  int nAlloc;
+  ProllyMutMapEntry *aEntries;
+  /* Active savepoint level. 0 = no savepoint, mutations skip
+  ** the undo-log path entirely (fast path for autocommit). */
+  int currentSavepointLevel;
+  /* Undo log, append-only between savepoint state transitions.
+  ** Rollback walks backward; release drops the suffix at or
+  ** above the released level. */
+  ProllyMutMapUndoRec *aUndo;
+  int nUndo;
+  int nUndoAlloc;
 };
 
 int prollyMutMapInit(ProllyMutMap *mm, u8 isIntKey);
@@ -63,6 +92,47 @@ void prollyMutMapIterSeek(ProllyMutMapIter *it, ProllyMutMap *mm,
 void prollyMutMapIterLast(ProllyMutMapIter *it, ProllyMutMap *mm);
 
 int prollyMutMapMerge(ProllyMutMap *pDst, ProllyMutMap *pSrc);
+
+/* Deep-copy src into a fresh mutmap returned via *out. Preserves entries
+** (key/val bytes), the undo log, isIntKey, and currentSavepointLevel.
+** Used by the btree savepoint layer to snapshot a pPending mutmap before
+** the btree flushes it into the underlying tree — without this the
+** savepoint's root snapshot alone loses pre-savepoint buffered writes. */
+int prollyMutMapClone(ProllyMutMap **out, const ProllyMutMap *src);
+
+/* Savepoint controls. The btree calls these to bracket a savepoint:
+**
+**   prollyMutMapPushSavepoint(mm, level)
+**     O(1). Sets mm->currentSavepointLevel to level. New entries
+**     written henceforth get bornAt = level; in-place mutations on
+**     existing entries with bornAt < level log an undo record (lazy
+**     — only the first mutation per entry per level allocates).
+**
+**   prollyMutMapRollbackToSavepoint(mm, level)
+**     Reverts everything done at savepoint levels >= level.
+**     Order matters: walk the undo log backward FIRST, restoring
+**     in-place mutations to their pre-savepoint state (including
+**     resetting bornAt), THEN drop remaining entries with
+**     bornAt >= level (fresh inserts under the rolled-back savepoints
+**     that have no undo records). Sets currentSavepointLevel to
+**     level - 1.
+**
+**   prollyMutMapReleaseSavepoint(mm, level)
+**     Commits everything done at levels >= level into level-1.
+**     Relabels undo records at level >= the released level down to
+**     level-1 (so a future ROLLBACK TO the parent still finds the
+**     pre-release state) and clamps entry bornAt >= level to level-1
+**     (so fresh post-savepoint inserts aren't mistakenly dropped by
+**     a later parent rollback). Special case: when releasing to 0
+**     (fast path), the entire undo log is freed. Sets
+**     currentSavepointLevel to level - 1.
+**
+** Hot path: when currentSavepointLevel == 0 (autocommit, no user
+** savepoints) the in-place mutation paths fast-path past the undo
+** log code entirely. */
+void prollyMutMapPushSavepoint(ProllyMutMap *mm, int level);
+int  prollyMutMapRollbackToSavepoint(ProllyMutMap *mm, int level);
+void prollyMutMapReleaseSavepoint(ProllyMutMap *mm, int level);
 
 void prollyMutMapClear(ProllyMutMap *mm);
 

--- a/test/oracle_savepoints_test.sh
+++ b/test/oracle_savepoints_test.sh
@@ -1,0 +1,789 @@
+#!/bin/bash
+#
+# Oracle test: savepoints, rollbacks, and transaction boundaries
+# against stock SQLite.
+#
+# Savepoints are a dense corner of the prolly btree layer: each
+# SAVEPOINT snapshots the in-memory catalog and the per-table
+# pending mutmap state; ROLLBACK TO walks the stack to revert
+# both. Any mismatch between snapshot and restore surfaces as a
+# row that shouldn't exist or is missing after the rollback.
+#
+# Oracle target is stock sqlite3 built from the same tree so both
+# engines parse identical SQLite SAVEPOINT syntax and the only
+# variable is the storage layer's unwind logic.
+#
+# Coverage:
+#   - BEGIN / COMMIT / ROLLBACK (full-transaction semantics)
+#   - SAVEPOINT / RELEASE / ROLLBACK TO (partial revert)
+#   - Nested savepoints (release-inner, rollback-inner, rollback-middle)
+#   - Same-name shadowing (innermost wins)
+#   - Savepoint over multi-table writes
+#   - Savepoint over UPDATE and DELETE (not just INSERT)
+#   - Savepoint over CREATE / DROP / ALTER TABLE
+#   - Savepoint over triggered side effects (trigger body writes
+#     to a second table; rollback has to revert both)
+#   - In-place mutmap mutation transitions (INSERT→DELETE,
+#     DELETE→INSERT, chained UPDATEs, UPSERT, REPLACE INTO, etc.)
+#   - Bulk savepoint rollbacks (100/1000 rows)
+#   - Savepoint-inside-BEGIN interaction
+#   - Trigger RAISE(ROLLBACK) unwinding nested savepoints
+#
+# Known disabled scenarios (marked DISABLED inline with the
+# repro and a pointer to the underlying bug):
+#
+#   - rollback_undoes_alter_rename,
+#     rollback_undoes_alter_rename_column — pre-existing SIGSEGV
+#     in the ALTER TABLE RENAME + ROLLBACK TO interaction
+#     (reproduces on master). Crash lands in
+#     sqlite3BtreeTripAllCursors before the savepoint restore
+#     code. Filed as a separate follow-up.
+#
+# Usage: bash oracle_savepoints_test.sh [path/to/doltlite] [path/to/sqlite3]
+#
+
+set -u
+
+DOLTLITE="${1:-./doltlite}"
+SQLITE3="${2:-./sqlite3}"
+TMPROOT=$(mktemp -d)
+trap "rm -rf $TMPROOT" EXIT
+pass=0; fail=0
+FAILED_NAMES=""
+
+normalize() {
+  # Normalize shell error prefixes: stock sqlite3 prints
+  # "Runtime error near line N: msg (code)" while doltlite prints
+  # "Error near line N: msg". Drop the leading "Runtime " token and
+  # the trailing " (NN)" code so the two forms compare equal —
+  # savepoint correctness is about row outcomes, not shell prose.
+  tr -d '\r' \
+    | sed -e 's/[[:space:]]\{1,\}/ /g' -e 's/^ //' -e 's/ $//' \
+          -e 's/^Runtime error /Error /' \
+          -e 's/^Error: in prepare, / /' \
+          -e 's/ ([0-9]*)$//'
+}
+
+oracle() {
+  local name="$1" sql="$2"
+  local dir="$TMPROOT/$name"
+  mkdir -p "$dir/dl" "$dir/sq"
+
+  local dl_out
+  dl_out=$(printf '%s\n' "$sql" | "$DOLTLITE" "$dir/dl/db" 2>&1 | normalize)
+
+  local sq_out
+  sq_out=$(printf '%s\n' "$sql" | "$SQLITE3" "$dir/sq/db" 2>&1 | normalize)
+
+  if [ "$dl_out" = "$sq_out" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite:"; echo "$dl_out" | sed 's/^/      /'
+    echo "    sqlite3:";  echo "$sq_out" | sed 's/^/      /'
+  fi
+}
+
+echo "=== Oracle Tests: savepoints + rollbacks ==="
+echo ""
+
+# ─── Basic transactions ──────────────────────────────────────────────
+echo "--- basic transactions ---"
+
+oracle "txn_commit_visible" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+BEGIN;
+INSERT INTO t VALUES(1, 10);
+INSERT INTO t VALUES(2, 20);
+COMMIT;
+SELECT id, v FROM t ORDER BY id;
+"
+
+oracle "txn_rollback_reverts_all" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1, 10);
+BEGIN;
+INSERT INTO t VALUES(2, 20);
+INSERT INTO t VALUES(3, 30);
+ROLLBACK;
+SELECT id, v FROM t ORDER BY id;
+"
+
+oracle "txn_rollback_reverts_update" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1, 10),(2, 20),(3, 30);
+BEGIN;
+UPDATE t SET v = v * 10;
+ROLLBACK;
+SELECT id, v FROM t ORDER BY id;
+"
+
+oracle "txn_rollback_reverts_delete" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1, 10),(2, 20),(3, 30);
+BEGIN;
+DELETE FROM t WHERE id >= 2;
+ROLLBACK;
+SELECT id, v FROM t ORDER BY id;
+"
+
+oracle "txn_rollback_reverts_multi_table" "
+CREATE TABLE a(id INT PRIMARY KEY, v INT);
+CREATE TABLE b(id INT PRIMARY KEY, v INT);
+INSERT INTO a VALUES(1, 10);
+INSERT INTO b VALUES(1, 100);
+BEGIN;
+INSERT INTO a VALUES(2, 20);
+INSERT INTO b VALUES(2, 200);
+UPDATE a SET v = 999 WHERE id = 1;
+DELETE FROM b WHERE id = 1;
+ROLLBACK;
+SELECT 'a', id, v FROM a ORDER BY id;
+SELECT 'b', id, v FROM b ORDER BY id;
+"
+
+# ─── Single savepoint operations ─────────────────────────────────────
+echo "--- single savepoint ---"
+
+oracle "savepoint_release_keeps_changes" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+SAVEPOINT s1;
+INSERT INTO t VALUES(1, 10);
+INSERT INTO t VALUES(2, 20);
+RELEASE SAVEPOINT s1;
+SELECT id, v FROM t ORDER BY id;
+"
+
+oracle "savepoint_rollback_to_reverts" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1, 10);
+SAVEPOINT s1;
+INSERT INTO t VALUES(2, 20);
+INSERT INTO t VALUES(3, 30);
+ROLLBACK TO SAVEPOINT s1;
+RELEASE SAVEPOINT s1;
+SELECT id, v FROM t ORDER BY id;
+"
+
+# After ROLLBACK TO the savepoint is still active; a second batch
+# of writes then RELEASE should leave only the second batch.
+oracle "savepoint_rollback_then_reuse" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+SAVEPOINT s1;
+INSERT INTO t VALUES(1, 10);
+INSERT INTO t VALUES(2, 20);
+ROLLBACK TO SAVEPOINT s1;
+INSERT INTO t VALUES(3, 30);
+INSERT INTO t VALUES(4, 40);
+RELEASE SAVEPOINT s1;
+SELECT id, v FROM t ORDER BY id;
+"
+
+# Savepoint over an UPDATE that overwrites existing rows — the
+# rollback has to restore the original values, not just discard
+# the staged edit.
+oracle "savepoint_rollback_update_restores" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1, 10),(2, 20),(3, 30);
+SAVEPOINT s1;
+UPDATE t SET v = v + 1000;
+ROLLBACK TO SAVEPOINT s1;
+RELEASE SAVEPOINT s1;
+SELECT id, v FROM t ORDER BY id;
+"
+
+# Savepoint over a DELETE — rollback has to restore deleted rows.
+oracle "savepoint_rollback_delete_restores" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1, 10),(2, 20),(3, 30);
+SAVEPOINT s1;
+DELETE FROM t WHERE id >= 2;
+ROLLBACK TO SAVEPOINT s1;
+RELEASE SAVEPOINT s1;
+SELECT id, v FROM t ORDER BY id;
+"
+
+# Mixed DML inside a savepoint.
+oracle "savepoint_rollback_mixed_dml" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1, 10),(2, 20),(3, 30);
+SAVEPOINT s1;
+INSERT INTO t VALUES(4, 40);
+UPDATE t SET v = v + 100 WHERE id = 2;
+DELETE FROM t WHERE id = 1;
+ROLLBACK TO SAVEPOINT s1;
+RELEASE SAVEPOINT s1;
+SELECT id, v FROM t ORDER BY id;
+"
+
+# ─── Nested savepoints ───────────────────────────────────────────────
+echo "--- nested savepoints ---"
+
+# Two nested savepoints, release inner-only: outer state is the
+# union of both batches.
+oracle "nested_release_inner_only" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+SAVEPOINT s1;
+INSERT INTO t VALUES(1, 10);
+SAVEPOINT s2;
+INSERT INTO t VALUES(2, 20);
+RELEASE SAVEPOINT s2;
+INSERT INTO t VALUES(3, 30);
+RELEASE SAVEPOINT s1;
+SELECT id, v FROM t ORDER BY id;
+"
+
+# Rollback inner only: rows inside s2 gone, rows before s2 kept.
+oracle "nested_rollback_inner_only" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+SAVEPOINT s1;
+INSERT INTO t VALUES(1, 10);
+SAVEPOINT s2;
+INSERT INTO t VALUES(2, 20);
+INSERT INTO t VALUES(3, 30);
+ROLLBACK TO SAVEPOINT s2;
+RELEASE SAVEPOINT s2;
+RELEASE SAVEPOINT s1;
+SELECT id, v FROM t ORDER BY id;
+"
+
+# Rollback outer: rows from BOTH savepoints gone, even though the
+# inner was released before the outer rollback fired.
+oracle "nested_rollback_outer_discards_inner" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+SAVEPOINT s1;
+INSERT INTO t VALUES(1, 10);
+SAVEPOINT s2;
+INSERT INTO t VALUES(2, 20);
+RELEASE SAVEPOINT s2;
+INSERT INTO t VALUES(3, 30);
+ROLLBACK TO SAVEPOINT s1;
+RELEASE SAVEPOINT s1;
+SELECT id, v FROM t ORDER BY id;
+"
+
+# Three-deep nesting, rollback to middle. Everything inside s3 is
+# reverted, but the s1→s2 writes are kept.
+oracle "three_deep_rollback_to_middle" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+SAVEPOINT s1;
+INSERT INTO t VALUES(1, 10);
+SAVEPOINT s2;
+INSERT INTO t VALUES(2, 20);
+SAVEPOINT s3;
+INSERT INTO t VALUES(3, 30);
+INSERT INTO t VALUES(4, 40);
+ROLLBACK TO SAVEPOINT s2;
+RELEASE SAVEPOINT s1;
+SELECT id, v FROM t ORDER BY id;
+"
+
+# Same-name savepoint shadowing: ROLLBACK TO goes to the innermost
+# savepoint with that name (LIFO).
+oracle "savepoint_same_name_shadowing" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+SAVEPOINT s;
+INSERT INTO t VALUES(1, 10);
+SAVEPOINT s;
+INSERT INTO t VALUES(2, 20);
+INSERT INTO t VALUES(3, 30);
+ROLLBACK TO SAVEPOINT s;
+RELEASE SAVEPOINT s;
+RELEASE SAVEPOINT s;
+SELECT id, v FROM t ORDER BY id;
+"
+
+# ─── Multi-table savepoints ──────────────────────────────────────────
+echo "--- multi-table savepoints ---"
+
+oracle "savepoint_rollback_multi_table" "
+CREATE TABLE a(id INT PRIMARY KEY, v INT);
+CREATE TABLE b(id INT PRIMARY KEY, v INT);
+INSERT INTO a VALUES(1, 10);
+INSERT INTO b VALUES(1, 100);
+SAVEPOINT s1;
+INSERT INTO a VALUES(2, 20);
+INSERT INTO b VALUES(2, 200);
+UPDATE a SET v = 999 WHERE id = 1;
+DELETE FROM b WHERE id = 1;
+ROLLBACK TO SAVEPOINT s1;
+RELEASE SAVEPOINT s1;
+SELECT 'a', id, v FROM a ORDER BY id;
+SELECT 'b', id, v FROM b ORDER BY id;
+"
+
+# Three tables, inner rollback over an UPDATE that targets a
+# pending INSERT from the OUTER savepoint. Without the lazy
+# undo-log fix in this PR, prollyMutMapInsert overwrites the
+# existing mutmap entry in place and the savepoint count-based
+# truncate can't undo it.
+oracle "savepoint_three_tables_inner_rollback" "
+CREATE TABLE a(id INT PRIMARY KEY, v INT);
+CREATE TABLE b(id INT PRIMARY KEY, v INT);
+CREATE TABLE c(id INT PRIMARY KEY, v INT);
+SAVEPOINT s1;
+INSERT INTO a VALUES(1, 1);
+INSERT INTO b VALUES(1, 11);
+SAVEPOINT s2;
+INSERT INTO c VALUES(1, 111);
+UPDATE a SET v = 999 WHERE id = 1;
+ROLLBACK TO SAVEPOINT s2;
+RELEASE SAVEPOINT s2;
+RELEASE SAVEPOINT s1;
+SELECT 'a', id, v FROM a ORDER BY id;
+SELECT 'b', id, v FROM b ORDER BY id;
+SELECT 'c', id, v FROM c ORDER BY id;
+"
+
+# ─── In-place mutmap mutation transitions ──────────────────────────
+#
+# Each of these scenarios drives a specific transition through
+# the in-place-mutating paths of prolly_mutmap.c and verifies the
+# savepoint snapshot reverts it correctly. The fixed savepoint
+# code stores a full mutmap clone, so any transition between
+# (op, value) states should round-trip through ROLLBACK TO. If a
+# new in-place mutation path is added later that doesn't go
+# through prollyMutMapInsert / prollyMutMapDelete, one of these
+# is the canary that will catch it.
+
+echo "--- in-place mutation transitions ---"
+
+# Transition: (INSERT, v0) → DELETE.
+# Outer savepoint buffers an INSERT. Inner savepoint takes a
+# snapshot. DELETE flips the mutmap entry's op from INSERT to
+# DELETE and frees the value. ROLLBACK TO must restore the
+# original (INSERT, v0).
+oracle "rollback_undoes_insert_then_delete" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+SAVEPOINT s1;
+INSERT INTO t VALUES(1, 10);
+SAVEPOINT s2;
+DELETE FROM t WHERE id = 1;
+ROLLBACK TO SAVEPOINT s2;
+RELEASE SAVEPOINT s2;
+RELEASE SAVEPOINT s1;
+SELECT id, v FROM t;
+"
+
+# Transition: (INSERT, v0) → DELETE → INSERT, v1.
+# Two in-place mutations on top of the same savepointed entry,
+# rolled back. Final state must be (INSERT, v0).
+oracle "rollback_undoes_insert_delete_insert" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+SAVEPOINT s1;
+INSERT INTO t VALUES(1, 10);
+SAVEPOINT s2;
+DELETE FROM t WHERE id = 1;
+INSERT INTO t VALUES(1, 999);
+ROLLBACK TO SAVEPOINT s2;
+RELEASE SAVEPOINT s2;
+RELEASE SAVEPOINT s1;
+SELECT id, v FROM t;
+"
+
+# Transition: (DELETE) → INSERT, resurrecting a row that was
+# committed to the tree before the savepoint. Inner savepoint
+# snapshots a (DELETE) mutmap entry; the resurrect-INSERT mutates
+# it back to (INSERT, v_new). Rollback must restore the (DELETE)
+# state — i.e., the row from the tree must NOT reappear.
+oracle "rollback_undoes_delete_then_resurrect" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1, 10);
+SAVEPOINT s1;
+DELETE FROM t WHERE id = 1;
+SAVEPOINT s2;
+INSERT INTO t VALUES(1, 999);
+ROLLBACK TO SAVEPOINT s2;
+RELEASE SAVEPOINT s2;
+SELECT 'after_rollback', count(*) FROM t;
+RELEASE SAVEPOINT s1;
+SELECT 'after_outer_release', id, v FROM t;
+"
+
+# Transition: (INSERT, v0) → UPDATE → UPDATE → UPDATE.
+# Three in-place value mutations on the same entry. The savepoint
+# snapshot captured (INSERT, v0). Rollback must skip past all
+# three intermediate values.
+oracle "rollback_undoes_chained_updates" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+SAVEPOINT s1;
+INSERT INTO t VALUES(1, 10);
+SAVEPOINT s2;
+UPDATE t SET v = 100 WHERE id = 1;
+UPDATE t SET v = 200 WHERE id = 1;
+UPDATE t SET v = 300 WHERE id = 1;
+ROLLBACK TO SAVEPOINT s2;
+RELEASE SAVEPOINT s2;
+RELEASE SAVEPOINT s1;
+SELECT id, v FROM t;
+"
+
+# UPSERT: INSERT INTO ... ON CONFLICT DO UPDATE goes through one
+# statement that does insert-or-overwrite via the mutmap. Run it
+# inside a savepoint after a row already exists, then roll back.
+oracle "rollback_undoes_upsert_overwrite" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1, 10);
+SAVEPOINT s1;
+INSERT INTO t VALUES(1, 999) ON CONFLICT(id) DO UPDATE SET v = 999;
+INSERT INTO t VALUES(2, 20) ON CONFLICT(id) DO UPDATE SET v = excluded.v;
+ROLLBACK TO SAVEPOINT s1;
+RELEASE SAVEPOINT s1;
+SELECT id, v FROM t ORDER BY id;
+"
+
+# UPSERT inside an inner savepoint, on a row that the OUTER
+# savepoint just inserted (so the mutmap entry exists from outer
+# scope). Rolls back past the upsert.
+oracle "rollback_undoes_upsert_on_pending_insert" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+SAVEPOINT s1;
+INSERT INTO t VALUES(1, 10);
+SAVEPOINT s2;
+INSERT INTO t VALUES(1, 999) ON CONFLICT(id) DO UPDATE SET v = 999;
+ROLLBACK TO SAVEPOINT s2;
+RELEASE SAVEPOINT s2;
+RELEASE SAVEPOINT s1;
+SELECT id, v FROM t;
+"
+
+# REPLACE INTO is INSERT OR REPLACE — does delete-then-insert
+# under the hood for PK conflicts. Inside a savepoint, on a row
+# from the tree, then rollback.
+oracle "rollback_undoes_replace_into" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1, 10);
+SAVEPOINT s1;
+REPLACE INTO t VALUES(1, 999);
+REPLACE INTO t VALUES(2, 22);
+ROLLBACK TO SAVEPOINT s1;
+RELEASE SAVEPOINT s1;
+SELECT id, v FROM t ORDER BY id;
+"
+
+# UPDATE inside savepoint where the target row was inserted in
+# the SAME savepoint — the mutmap entry was created by this
+# savepoint and is still subject to its own rollback. The
+# snapshot at the savepoint had no entry for this key; on
+# rollback, the entry must vanish entirely (not just have its
+# pre-update value restored).
+oracle "rollback_drops_insert_then_update_in_same_savepoint" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1, 10);
+SAVEPOINT s1;
+INSERT INTO t VALUES(2, 20);
+UPDATE t SET v = 999 WHERE id = 2;
+ROLLBACK TO SAVEPOINT s1;
+RELEASE SAVEPOINT s1;
+SELECT id, v FROM t ORDER BY id;
+"
+
+# Trigger that does UPDATE on a row in another table, where that
+# other table has a pending INSERT from the same outer savepoint.
+# The trigger-driven UPDATE mutates the mutmap in place. Rollback
+# must revert both the trigger-side row and the rest.
+oracle "rollback_undoes_trigger_update_on_pending" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+CREATE TABLE other(id INT PRIMARY KEY, v INT);
+CREATE TRIGGER t_au AFTER UPDATE ON t BEGIN
+  UPDATE other SET v = v + 1000 WHERE id = new.id;
+END;
+SAVEPOINT s1;
+INSERT INTO t     VALUES(1, 10);
+INSERT INTO other VALUES(1, 100);
+SAVEPOINT s2;
+UPDATE t SET v = 99 WHERE id = 1;
+ROLLBACK TO SAVEPOINT s2;
+RELEASE SAVEPOINT s2;
+RELEASE SAVEPOINT s1;
+SELECT 't', id, v FROM t ORDER BY id;
+SELECT 'o', id, v FROM other ORDER BY id;
+"
+
+# Nested savepoints with mutations at each level. Rollback to the
+# OUTERMOST savepoint must walk all three levels of in-place
+# mutations and end up at the pre-savepoint state.
+oracle "deep_nesting_rollback_to_outer" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1, 1);
+SAVEPOINT s1;
+UPDATE t SET v = 10 WHERE id = 1;
+SAVEPOINT s2;
+UPDATE t SET v = 100 WHERE id = 1;
+SAVEPOINT s3;
+UPDATE t SET v = 1000 WHERE id = 1;
+SAVEPOINT s4;
+UPDATE t SET v = 10000 WHERE id = 1;
+ROLLBACK TO SAVEPOINT s1;
+RELEASE SAVEPOINT s1;
+SELECT id, v FROM t;
+"
+
+# Nested savepoints where each level inserts a different new row
+# AND mutates a row from above. Rollback to s2 should keep s1's
+# work and discard everything s3 and below.
+oracle "nested_inserts_and_updates_rollback" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+SAVEPOINT s1;
+INSERT INTO t VALUES(1, 1);
+SAVEPOINT s2;
+INSERT INTO t VALUES(2, 2);
+UPDATE t SET v = 11 WHERE id = 1;
+SAVEPOINT s3;
+INSERT INTO t VALUES(3, 3);
+UPDATE t SET v = 22 WHERE id = 2;
+UPDATE t SET v = 111 WHERE id = 1;
+ROLLBACK TO SAVEPOINT s2;
+RELEASE SAVEPOINT s2;
+RELEASE SAVEPOINT s1;
+SELECT id, v FROM t ORDER BY id;
+"
+
+# ─── Schema state shallow-copy edge cases ──────────────────────────
+#
+# DISABLED: ALTER TABLE RENAME [COLUMN] inside a savepoint followed
+# by ROLLBACK TO SAVEPOINT crashes doltlite with SIGSEGV. This
+# reproduces on master (without the savepoint snapshot deep-copy
+# fix in this PR), so it is a pre-existing crash in the rename +
+# rollback interaction, NOT a regression and NOT addressed by the
+# mutmap-snapshot fix here. The crash backtrace lands inside
+# sqlite3BtreeTripAllCursors which runs BEFORE the savepoint
+# restore code, suggesting the rename leaves a cursor-list /
+# catalog state inconsistent that the rollback path then walks.
+#
+# Repro:
+#
+#   CREATE TABLE t(id INT PRIMARY KEY, v INT);
+#   INSERT INTO t VALUES(1, 10);
+#   SAVEPOINT s1;
+#   ALTER TABLE t RENAME TO renamed_t;
+#   ROLLBACK TO SAVEPOINT s1;            -- SIGSEGV here
+#
+# Filed as a follow-up issue. Re-enable when the rename interaction
+# is fixed.
+#
+# oracle "rollback_undoes_alter_rename" "
+# CREATE TABLE t(id INT PRIMARY KEY, v INT);
+# INSERT INTO t VALUES(1, 10);
+# SAVEPOINT s1;
+# ALTER TABLE t RENAME TO renamed_t;
+# ROLLBACK TO SAVEPOINT s1;
+# RELEASE SAVEPOINT s1;
+# SELECT name FROM sqlite_master WHERE type='table' ORDER BY name;
+# SELECT id, v FROM t;
+# "
+#
+# oracle "rollback_undoes_alter_rename_column" "
+# CREATE TABLE t(id INT PRIMARY KEY, v INT);
+# INSERT INTO t VALUES(1, 10);
+# SAVEPOINT s1;
+# ALTER TABLE t RENAME COLUMN v TO val;
+# ROLLBACK TO SAVEPOINT s1;
+# RELEASE SAVEPOINT s1;
+# SELECT sql FROM sqlite_master WHERE type='table' AND name='t';
+# SELECT id, v FROM t;
+# "
+
+# CREATE INDEX inside a savepoint. Indexes are sqlite_master rows
+# with their own iTable / root. Rollback must remove both the
+# schema row and the catalog table entry. Scoped to the user-created
+# index name — doltlite and stock SQLite differ on how
+# sqlite_autoindex_* entries are exposed in sqlite_master for PK
+# columns, which is orthogonal to savepoint rollback correctness.
+oracle "rollback_undoes_create_index" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT, tag TEXT);
+INSERT INTO t VALUES(1, 10, 'a'),(2, 20, 'b');
+SAVEPOINT s1;
+CREATE INDEX idx_t_tag ON t(tag);
+ROLLBACK TO SAVEPOINT s1;
+RELEASE SAVEPOINT s1;
+SELECT name FROM sqlite_master WHERE type='index' AND name='idx_t_tag';
+SELECT id, v, tag FROM t ORDER BY id;
+"
+
+# ─── Savepoint + schema changes ──────────────────────────────────────
+echo "--- savepoint + schema ---"
+
+oracle "savepoint_rollback_create_table" "
+CREATE TABLE t(id INT PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SAVEPOINT s1;
+CREATE TABLE u(id INT PRIMARY KEY, v TEXT);
+INSERT INTO u VALUES(1, 'x');
+ROLLBACK TO SAVEPOINT s1;
+RELEASE SAVEPOINT s1;
+SELECT name FROM sqlite_master WHERE type='table' ORDER BY name;
+SELECT id FROM t ORDER BY id;
+"
+
+oracle "savepoint_rollback_drop_table" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+CREATE TABLE u(id INT PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1, 10),(2, 20);
+INSERT INTO u VALUES(1, 'a'),(2, 'b');
+SAVEPOINT s1;
+DROP TABLE u;
+ROLLBACK TO SAVEPOINT s1;
+RELEASE SAVEPOINT s1;
+SELECT name FROM sqlite_master WHERE type='table' ORDER BY name;
+SELECT id, v FROM u ORDER BY id;
+"
+
+oracle "savepoint_rollback_add_column" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1, 10),(2, 20);
+SAVEPOINT s1;
+ALTER TABLE t ADD COLUMN extra TEXT;
+UPDATE t SET extra = 'filled' WHERE id = 1;
+ROLLBACK TO SAVEPOINT s1;
+RELEASE SAVEPOINT s1;
+SELECT sql FROM sqlite_master WHERE type='table' AND name='t';
+SELECT id, v FROM t ORDER BY id;
+"
+
+# ─── Savepoint + triggers ────────────────────────────────────────────
+echo "--- savepoint + triggers ---"
+
+# Trigger fires during an INSERT inside a savepoint; the trigger
+# writes to a second table. Rolling back to the savepoint must
+# revert BOTH tables.
+oracle "savepoint_rollback_reverts_trigger_writes" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+CREATE TABLE log(id INT, v INT);
+CREATE TRIGGER t_ai AFTER INSERT ON t BEGIN
+  INSERT INTO log VALUES(new.id, new.v);
+END;
+INSERT INTO t VALUES(1, 10);
+SAVEPOINT s1;
+INSERT INTO t VALUES(2, 20);
+INSERT INTO t VALUES(3, 30);
+ROLLBACK TO SAVEPOINT s1;
+RELEASE SAVEPOINT s1;
+SELECT 't', id, v FROM t ORDER BY id;
+SELECT 'log', id, v FROM log ORDER BY id;
+"
+
+# Trigger RAISE(ROLLBACK) inside a nested savepoint — SQLite's
+# semantics say RAISE(ROLLBACK) aborts the full transaction, NOT
+# just the nearest savepoint. Both engines should revert the
+# pre-savepoint writes too.
+oracle "trigger_raise_rollback_through_savepoint" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+CREATE TRIGGER no_neg BEFORE INSERT ON t WHEN new.v < 0 BEGIN
+  SELECT RAISE(ROLLBACK, 'no neg');
+END;
+BEGIN;
+INSERT INTO t VALUES(1, 10);
+SAVEPOINT s1;
+INSERT INTO t VALUES(2, 20);
+INSERT INTO t VALUES(3, -1);
+COMMIT;
+SELECT id, v FROM t ORDER BY id;
+"
+
+# ─── Bulk savepoint rollbacks ────────────────────────────────────────
+echo "--- bulk ---"
+
+# 100 rows inside a savepoint, rolled back. Stresses the mutmap
+# snapshot/restore rather than individual row paths.
+make_bulk_insert() {
+  local n="$1" tbl="$2"
+  local i
+  for i in $(seq 1 "$n"); do
+    echo "INSERT INTO $tbl VALUES($i, 'row_$i');"
+  done
+}
+
+BULK_100="$(make_bulk_insert 100 t)"
+BULK_1K="$(make_bulk_insert 1000 t)"
+
+oracle "savepoint_rollback_100_rows" "
+CREATE TABLE t(id INT PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(0, 'seed');
+SAVEPOINT s1;
+$BULK_100
+ROLLBACK TO SAVEPOINT s1;
+RELEASE SAVEPOINT s1;
+SELECT count(*) FROM t;
+SELECT id, v FROM t ORDER BY id;
+"
+
+oracle "savepoint_rollback_1000_rows" "
+CREATE TABLE t(id INT PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(0, 'seed');
+SAVEPOINT s1;
+$BULK_1K
+ROLLBACK TO SAVEPOINT s1;
+RELEASE SAVEPOINT s1;
+SELECT count(*) FROM t;
+SELECT id FROM t;
+"
+
+# 1k rows inside a savepoint, RELEASED (not rolled back). All rows
+# should land in the tree.
+oracle "savepoint_release_1000_rows" "
+CREATE TABLE t(id INT PRIMARY KEY, v TEXT);
+SAVEPOINT s1;
+$BULK_1K
+RELEASE SAVEPOINT s1;
+SELECT count(*) FROM t;
+SELECT id FROM t WHERE id IN (1, 250, 500, 750, 1000) ORDER BY id;
+"
+
+# ─── Savepoint inside an explicit transaction ────────────────────────
+echo "--- savepoint inside BEGIN ---"
+
+# BEGIN → INSERT → SAVEPOINT → more inserts → RELEASE → COMMIT.
+# Straightforward.
+oracle "begin_savepoint_release_commit" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+BEGIN;
+INSERT INTO t VALUES(1, 10);
+SAVEPOINT s1;
+INSERT INTO t VALUES(2, 20);
+INSERT INTO t VALUES(3, 30);
+RELEASE SAVEPOINT s1;
+COMMIT;
+SELECT id, v FROM t ORDER BY id;
+"
+
+# BEGIN → INSERT → SAVEPOINT → insert → ROLLBACK TO → COMMIT.
+# Outer transaction keeps only the pre-savepoint write.
+oracle "begin_savepoint_rollback_to_commit" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+BEGIN;
+INSERT INTO t VALUES(1, 10);
+SAVEPOINT s1;
+INSERT INTO t VALUES(2, 20);
+INSERT INTO t VALUES(3, 30);
+ROLLBACK TO SAVEPOINT s1;
+RELEASE SAVEPOINT s1;
+COMMIT;
+SELECT id, v FROM t ORDER BY id;
+"
+
+# BEGIN → everything → ROLLBACK. Outer rollback discards all
+# savepoints and their effects, including released ones.
+oracle "begin_rollback_discards_everything" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1, 10);
+BEGIN;
+INSERT INTO t VALUES(2, 20);
+SAVEPOINT s1;
+INSERT INTO t VALUES(3, 30);
+RELEASE SAVEPOINT s1;
+SAVEPOINT s2;
+INSERT INTO t VALUES(4, 40);
+RELEASE SAVEPOINT s2;
+ROLLBACK;
+SELECT id, v FROM t ORDER BY id;
+"
+
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+if [ $fail -gt 0 ]; then
+  echo "Failed:$FAILED_NAMES"
+  exit 1
+fi


### PR DESCRIPTION
Two commits: fix first (self-contained) and then 41 oracle scenarios that exercise it.

## Commit 1 — `prolly mutmap: lazy undo-log + flush-time snapshot for savepoints`

The old savepoint rollback path relied on mutmap being append-only (truncate to pre-savepoint `nEntries`). In-place INSERT→INSERT, INSERT→DELETE, and UPDATE-on-pending-INSERT mutations silently corrupted state when they crossed a savepoint boundary:

```sql
SAVEPOINT s1;
INSERT INTO a VALUES(1, 1);    -- a.pPending has 1 entry (INSERT)
SAVEPOINT s2;
INSERT INTO c VALUES(1, 111);
UPDATE a SET v = 999 WHERE id = 1;   -- mutmap entry overwritten in place
ROLLBACK TO SAVEPOINT s2;       -- a.pPending was silently dropped
```

Fix has three cooperating pieces — important for perf, because the OLTP hot path cannot afford any per-statement-savepoint deep copies.

### 1. Per-entry bornAt + lazy undo log

`ProllyMutMap` gains a `currentSavepointLevel` counter and a per-entry `bornAt` stamp. On in-place mutation under an active savepoint, the previous `(op, value, bornAt)` is captured in a lazy undo log. The fast path (`currentSavepointLevel == 0`, autocommit) still runs allocation-free — fresh-key inserts take zero extra cost.

`prollyMutMapRollbackToSavepoint` walks the undo log backward restoring in-place mutations, then drops entries with `bornAt >= target`. `prollyMutMapReleaseSavepoint` relabels undo records at the released level down to the parent so a later rollback to the parent still finds the pre-release state.

### 2. Savepoint threading through the btree

`prollyBtreeSavepoint` now walks every live mutmap (table `pPending` and every cursor `pMutMap`) on push / rollback / release via `pushSavepointOnMutMaps` / `rollbackMutMapsToSavepoint` / `releaseMutMapsToSavepoint`. Each mutmap observes every savepoint transition and keeps its bornAt stamps coherent. Removed `aPendingCount` and `truncatePendingToCount` — the truncation path was load-bearing for the old bug.

### 3. Flush-time snapshots (only when needed)

A flush mid-savepoint destroys the in-memory state the per-entry machinery relies on, so `snapshotPendingForFlush` takes a **lazy deep clone** into the innermost savepoint's new `aPendingSnapshot[]` slot — but only on the first flush per table per savepoint. On rollback, if any savepoint in the rollback range has a snapshot for that table, `rollbackMutMapsToSavepoint` restores `pTE->pPending` from the smallest-index snapshot and applies per-entry rollback to the clone. If no snapshot exists, per-entry rollback runs against the live `pPending` directly.

Autocommit pays nothing. Transactions with savepoints pay one clone per (table × first-flush). OLTP bulk insert / write-only workloads that never flush mid-transaction pay nothing extra.

Snapshot call sites covered: `flushOtherCursorPending`, `flushTablePending`, `flushMutMap` (cursor's own mutmap), the read-cursor open path in `prollyBtreeCursor`, `flushDeferredEdits` (used by `dolt_commit` inside a txn), and the conflict-resolution `doltliteApplyRawRowMutation` helper.

## Commit 2 — `test: savepoint + rollback oracle vs stock sqlite3`

41 scenarios vs stock sqlite3:

| Section | Scenarios |
|---|---|
| **basic transactions** | BEGIN/COMMIT, ROLLBACK reverts inserts/updates/deletes/multi-table |
| **single savepoint** | RELEASE keeps changes, ROLLBACK TO reverts, ROLLBACK TO + reuse, UPDATE-restore, DELETE-restore, mixed DML |
| **nested savepoints** | RELEASE inner, ROLLBACK inner, ROLLBACK outer discards released inner, three-deep rollback to middle, same-name shadowing |
| **multi-table** | rollback reverts writes on every table, three-table inner rollback (the bug-finder) |
| **in-place mutation transitions** | INSERT→DELETE, DELETE→INSERT, UPSERT, REPLACE INTO, chained UPDATEs, UPDATE-on-pending-INSERT across a savepoint |
| **schema changes** | rollback reverts CREATE TABLE / DROP TABLE / ALTER TABLE ADD COLUMN |
| **triggers** | rollback reverts trigger side effects, RAISE(ROLLBACK) inside savepoint aborts full txn |
| **bulk** | 100/1000 row rollback / release |
| **savepoint inside BEGIN** | RELEASE+COMMIT, ROLLBACK TO+COMMIT, outer ROLLBACK discards released savepoints |

Two pre-existing ALTER-RENAME + ROLLBACK-TO SIGSEGVs are documented inline and left disabled (repro on master) with pointers back to the offending `sqlite3BtreeTripAllCursors` path. Filed as follow-up.

## Test plan

- [x] `bash test/oracle_savepoints_test.sh ./doltlite sqlite3` — 41/41
- [x] `bash test/doltlite_savepoint.sh` — 21/21 (existing in-repo savepoint test, regression fixed by commit 1)
- [x] `bash test/run_doltlite_tests.sh` — 39/39 suites
- [x] `bash test/correctness_test.sh ./doltlite` — 41/41
- [x] `bash test/diff_test.sh ./doltlite` — 41/41
- [x] `bash test/index_test.sh ./doltlite` — 30/30
- [x] `bash test/vc_oracle_merge_test.sh ./doltlite dolt` — 31/31
- [x] `bash test/run_testfixture.sh "Core" 120 insert select1 update delete where in in2 alter auth` — 3417 passing (7 known divergences unchanged)
- [x] `bash test/run_testfixture.sh "Savepoint" 120 savepoint trans fkey1 trigger1` — 584 passing (1 known divergence unchanged)
- [x] `bash test/sysbench_compare.sh` — all tests within 6× ceiling; oltp_write_only 1.79× vs master 1.78× (write-path hot loop unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)