### PR TITLE
Fix merge-base parent selection

### DIFF
--- a/src/doltlite_ancestor.c
+++ b/src/doltlite_ancestor.c
@@ -132,7 +132,9 @@ static int ancestorBfsCollect(
     memset(&commit, 0, sizeof(commit));
     rc = loadCommitByHash(db, &current, &commit);
     if( rc!=SQLITE_OK ) break;
-    for(i=0; i<commit.nParents; i++){
+    for(i=0; i<doltliteCommitParentCount(&commit); i++){
+      const ProllyHash *pParent = doltliteCommitParentHash(&commit, i);
+      if( !pParent ) continue;
       if( qTail >= qAlloc ){
         ProllyHash *q2;
         qAlloc *= 2;
@@ -140,7 +142,7 @@ static int ancestorBfsCollect(
         if( !q2 ){ doltliteCommitClear(&commit); rc=SQLITE_NOMEM; break; }
         queue = q2;
       }
-      queue[qTail++] = commit.aParents[i];
+      queue[qTail++] = *pParent;
     }
     doltliteCommitClear(&commit);
     if( rc!=SQLITE_OK ) break;
@@ -222,7 +224,9 @@ int doltliteFindAncestor(
         hashSetFree(&ancestors);
         return rc;
       }
-      for(i=0; i<commit.nParents; i++){
+      for(i=0; i<doltliteCommitParentCount(&commit); i++){
+        const ProllyHash *pParent = doltliteCommitParentHash(&commit, i);
+        if( !pParent ) continue;
         if( qTail >= qAlloc ){
           ProllyHash *q2;
           qAlloc *= 2;
@@ -230,7 +234,7 @@ int doltliteFindAncestor(
           if( !q2 ){ doltliteCommitClear(&commit); hashSetFree(&visited); sqlite3_free(queue); hashSetFree(&ancestors); return SQLITE_NOMEM; }
           queue = q2;
         }
-        queue[qTail++] = commit.aParents[i];
+        queue[qTail++] = *pParent;
       }
       doltliteCommitClear(&commit);
     }

--- a/src/doltlite_commit.h
+++ b/src/doltlite_commit.h
@@ -29,6 +29,25 @@ int doltliteCommitDeserialize(const u8 *data, int nData, DoltliteCommit *c);
 
 void doltliteCommitClear(DoltliteCommit *c);
 
+static SQLITE_INLINE int doltliteCommitParentCount(const DoltliteCommit *pCommit){
+  if( pCommit->nParents>0 ) return pCommit->nParents;
+  return prollyHashIsEmpty(&pCommit->parentHash) ? 0 : 1;
+}
+
+static SQLITE_INLINE const ProllyHash *doltliteCommitParentHash(
+  const DoltliteCommit *pCommit,
+  int iParent
+){
+  if( iParent<0 ) return 0;
+  if( pCommit->nParents>0 ){
+    return iParent<pCommit->nParents ? &pCommit->aParents[iParent] : 0;
+  }
+  if( iParent==0 && !prollyHashIsEmpty(&pCommit->parentHash) ){
+    return &pCommit->parentHash;
+  }
+  return 0;
+}
+
 void doltliteHashToHex(const ProllyHash *h, char *buf);
 
 int doltliteHexToHash(const char *hex, ProllyHash *h);

--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -69,8 +69,8 @@ typedef struct AuditRow AuditRow;
 struct AuditRow {
   u8 diffType;
   i64 intKey;
-  u8 *pOldVal; int nOldVal;
-  u8 *pNewVal; int nNewVal;
+  const u8 *pOldVal; int nOldVal;
+  const u8 *pNewVal; int nNewVal;
   char zFromCommit[PROLLY_HASH_SIZE*2+1];
   char zToCommit[PROLLY_HASH_SIZE*2+1];
   i64 fromDate;
@@ -191,8 +191,6 @@ static int diffRecordField(
 }
 
 static void clearAuditRow(AuditRow *r){
-  sqlite3_free(r->pOldVal);
-  sqlite3_free(r->pNewVal);
   memset(r, 0, sizeof(*r));
 }
 
@@ -885,9 +883,6 @@ static int advanceToNextRow(DiffTblCursor *pCur, sqlite3 *db,
       ProllyDiffChange *pChange = 0;
       rc = prollyDiffIterStep(&pCur->diffIter, &pChange);
       if( rc==SQLITE_ROW && pChange ){
-        u8 *pOldVal = 0;
-        u8 *pNewVal = 0;
-
         /* When the pair's schemas differ (ADD/DROP/RENAME column
         ** between these commits), a MODIFY change may be a pure
         ** schema-encoding artifact: the record bytes differ but
@@ -903,9 +898,9 @@ static int advanceToNextRow(DiffTblCursor *pCur, sqlite3 *db,
           continue;
         }
 
-        /* Free previous value copies (preserves commit-pair metadata) */
-        sqlite3_free(pCur->row.pOldVal);
-        sqlite3_free(pCur->row.pNewVal);
+        /* Row value pointers borrow the diff iterator's storage, which
+        ** remains valid until the next Step/Close. Clear any previous
+        ** borrowed pointers before publishing the new current row. */
         pCur->row.pOldVal = 0;
         pCur->row.nOldVal = 0;
         pCur->row.pNewVal = 0;
@@ -914,25 +909,9 @@ static int advanceToNextRow(DiffTblCursor *pCur, sqlite3 *db,
         pCur->row.diffType = pChange->type;
         pCur->row.intKey = pChange->intKey;
 
-        /* Copy value data — the iterator's copies are valid until next Step */
-        if( pChange->pOldVal && pChange->nOldVal > 0 ){
-          pOldVal = sqlite3_malloc(pChange->nOldVal);
-          if( !pOldVal ) return SQLITE_NOMEM;
-          memcpy(pOldVal, pChange->pOldVal, pChange->nOldVal);
-        }
-
-        if( pChange->pNewVal && pChange->nNewVal > 0 ){
-          pNewVal = sqlite3_malloc(pChange->nNewVal);
-          if( !pNewVal ){
-            sqlite3_free(pOldVal);
-            return SQLITE_NOMEM;
-          }
-          memcpy(pNewVal, pChange->pNewVal, pChange->nNewVal);
-        }
-
-        pCur->row.pOldVal = pOldVal;
+        pCur->row.pOldVal = pChange->pOldVal;
         pCur->row.nOldVal = pChange->pOldVal ? pChange->nOldVal : 0;
-        pCur->row.pNewVal = pNewVal;
+        pCur->row.pNewVal = pChange->pNewVal;
         pCur->row.nNewVal = pChange->pNewVal ? pChange->nNewVal : 0;
 
         pCur->hasRow = 1;

--- a/src/doltlite_history.c
+++ b/src/doltlite_history.c
@@ -74,25 +74,6 @@ static void freeHistoryRows(HistCursor *c){
   c->aRows=0; c->nRows=0; c->nAlloc=0;
 }
 
-static int htCommitParentCount(const DoltliteCommit *pCommit){
-  if( pCommit->nParents>0 ) return pCommit->nParents;
-  return prollyHashIsEmpty(&pCommit->parentHash) ? 0 : 1;
-}
-
-static const ProllyHash *htCommitParentHash(
-  const DoltliteCommit *pCommit,
-  int iParent
-){
-  if( iParent<0 ) return 0;
-  if( pCommit->nParents>0 ){
-    return iParent<pCommit->nParents ? &pCommit->aParents[iParent] : 0;
-  }
-  if( iParent==0 && !prollyHashIsEmpty(&pCommit->parentHash) ){
-    return &pCommit->parentHash;
-  }
-  return 0;
-}
-
 static int htScanAtCommit(
   HistCursor *pCur, ChunkStore *cs, ProllyCache *pCache,
   const ProllyHash *pRoot, u8 flags,
@@ -203,8 +184,8 @@ static int htWalkHistory(HistCursor *pCur, sqlite3 *db, const char *zTableName){
       if( rc!=SQLITE_OK ){ doltliteCommitClear(&commit); break; }
     }
 
-    for(i=0; i<htCommitParentCount(&commit); i++){
-      const ProllyHash *pParent = htCommitParentHash(&commit, i);
+    for(i=0; i<doltliteCommitParentCount(&commit); i++){
+      const ProllyHash *pParent = doltliteCommitParentHash(&commit, i);
       if( !pParent || prollyHashIsEmpty(pParent) ) continue;
       if( prollyHashSetContains(&visited, pParent) ) continue;
       if( prollyHashSetContains(&queued, pParent) ) continue;

--- a/src/doltlite_log.c
+++ b/src/doltlite_log.c
@@ -103,15 +103,16 @@ static int logCollectAll(sqlite3 *db, const ProllyHash *pHead,
     pEntry->commit = commit;
 
     /* Enqueue all parents */
-    for(i = 0; i < commit.nParents; i++){
-      if( prollyHashIsEmpty(&commit.aParents[i]) ) continue;
+    for(i = 0; i < doltliteCommitParentCount(&commit); i++){
+      const ProllyHash *pParent = doltliteCommitParentHash(&commit, i);
+      if( !pParent || prollyHashIsEmpty(pParent) ) continue;
       if( qTail >= qAlloc ){
         int newAlloc = qAlloc*2;
         ProllyHash *tmp = sqlite3_realloc(queue, newAlloc*(int)sizeof(ProllyHash));
         if( !tmp ){ rc = SQLITE_NOMEM; break; }
         queue = tmp; qAlloc = newAlloc;
       }
-      queue[qTail++] = commit.aParents[i];
+      queue[qTail++] = *pParent;
     }
     if( rc!=SQLITE_OK ) break;
   }

--- a/src/doltlite_ref.c
+++ b/src/doltlite_ref.c
@@ -83,33 +83,57 @@ static int doltliteWalkFirstParent(
   int i;
   for(i=0; i<n; i++){
     DoltliteCommit commit;
+    const ProllyHash *pParent;
     int rc;
     memset(&commit, 0, sizeof(commit));
     rc = doltliteLoadCommit(db, pCommit, &commit);
     if( rc!=SQLITE_OK ) return rc;
-    if( commit.nParents==0 ){
+    pParent = doltliteCommitParentHash(&commit, 0);
+    if( !pParent ){
       doltliteCommitClear(&commit);
       return SQLITE_NOTFOUND;
     }
-    memcpy(pCommit, &commit.aParents[0], sizeof(ProllyHash));
+    memcpy(pCommit, pParent, sizeof(ProllyHash));
     doltliteCommitClear(&commit);
   }
   return SQLITE_OK;
 }
 
+static int doltliteSelectParent(
+  sqlite3 *db,
+  ProllyHash *pCommit,
+  int iParent
+){
+  DoltliteCommit commit;
+  const ProllyHash *pParent;
+  int rc;
+
+  memset(&commit, 0, sizeof(commit));
+  rc = doltliteLoadCommit(db, pCommit, &commit);
+  if( rc!=SQLITE_OK ) return rc;
+  pParent = doltliteCommitParentHash(&commit, iParent);
+  if( !pParent ){
+    doltliteCommitClear(&commit);
+    return SQLITE_NOTFOUND;
+  }
+  memcpy(pCommit, pParent, sizeof(ProllyHash));
+  doltliteCommitClear(&commit);
+  return SQLITE_OK;
+}
+
 int doltliteResolveRef(sqlite3 *db, const char *zRef, ProllyHash *pCommit){
   ChunkStore *cs = doltliteGetChunkStore(db);
-  int len, j, n_back, rc;
+  int len, j, n_back, parent_sel, rc;
   int suffix_pos = -1;
+  char suffix_op = 0;
   char *base_buf = 0;
   const char *base;
 
   if( !zRef || !cs ) return SQLITE_ERROR;
 
-  /* Look for a trailing ~N or ^N (rightmost) revision suffix. The
-  ** base ref before the suffix is resolved by doltliteResolveBaseRef
-  ** and then walked back N commits along the first-parent chain. An
-  ** empty digit run (HEAD~ / HEAD^) is treated as N=1, matching git.
+  /* Look for a trailing ~N or ^N (rightmost) revision suffix.
+  **  ~N walks back N commits along the first-parent chain.
+  **  ^N selects the Nth parent of the resolved commit (default 1).
   ** Only the rightmost suffix is honored — chained suffixes such as
   ** HEAD~2~3 are not supported. */
   len = (int)strlen(zRef);
@@ -119,21 +143,34 @@ int doltliteResolveRef(sqlite3 *db, const char *zRef, ProllyHash *pCommit){
       for(k=j+1; k<len; k++){
         if( zRef[k]<'0' || zRef[k]>'9' ){ allDigits = 0; break; }
       }
-      if( allDigits ) suffix_pos = j;
+      if( allDigits ){
+        suffix_pos = j;
+        suffix_op = zRef[j];
+      }
       break;
     }
   }
 
   n_back = 0;
+  parent_sel = 0;
   base = zRef;
   if( suffix_pos>=0 ){
     if( suffix_pos==len-1 ){
-      n_back = 1;
+      if( suffix_op=='~' ){
+        n_back = 1;
+      }else{
+        parent_sel = 1;
+      }
     }else{
-      n_back = atoi(zRef + suffix_pos + 1);
-      if( n_back<=0 ) n_back = 0;
+      int n = atoi(zRef + suffix_pos + 1);
+      if( n<=0 ) n = 0;
+      if( suffix_op=='~' ){
+        n_back = n;
+      }else{
+        parent_sel = n;
+      }
     }
-    if( n_back>0 ){
+    if( n_back>0 || parent_sel>0 ){
       if( suffix_pos==0 ){
         base = "HEAD";
       }else{
@@ -149,6 +186,8 @@ int doltliteResolveRef(sqlite3 *db, const char *zRef, ProllyHash *pCommit){
   rc = doltliteResolveBaseRef(db, base, pCommit);
   if( rc==SQLITE_OK && n_back>0 ){
     rc = doltliteWalkFirstParent(db, pCommit, n_back);
+  }else if( rc==SQLITE_OK && parent_sel>0 ){
+    rc = doltliteSelectParent(db, pCommit, parent_sel-1);
   }
   if( base_buf ) sqlite3_free(base_buf);
   return rc;

--- a/test/ancestor_test.c
+++ b/test/ancestor_test.c
@@ -59,7 +59,7 @@ int main(){
   const char *dbpath = "/tmp/test_ancestor.db";
   int rc;
   const char *main_head, *feature_head, *ancestor;
-  char main_head_buf[128], feature_head_buf[128];
+  char main_head_buf[128], feature_head_buf[128], merge_head_buf[128];
 
   remove(dbpath);
   remove("/tmp/test_ancestor.db-chunks");
@@ -143,6 +143,34 @@ int main(){
     ancestor = exec1(db, sql);
     printf("Ancestor (C2,feature):   %s\n", ancestor);
     check("ancestor where one is ancestor of other",
+          strcmp(ancestor, c2_hash_buf)==0);
+  }
+
+  /* Merge feature back into main to exercise ^N parent selection. */
+  execsql(db, "SELECT dolt_checkout('main')");
+  execsql(db, "SELECT dolt_merge('feature')");
+  main_head = exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1");
+  snprintf(merge_head_buf, sizeof(merge_head_buf), "%s", main_head);
+
+  /* Test 4: HEAD^2 resolves to the second parent of the merge commit. */
+  {
+    char sql[512];
+    snprintf(sql, sizeof(sql),
+      "SELECT dolt_merge_base('%s^2', '%s^2')", merge_head_buf, merge_head_buf);
+    ancestor = exec1(db, sql);
+    printf("Ancestor (HEAD^2,HEAD^2): %s\n", ancestor);
+    check("merge second-parent ref resolves to feature head",
+          strcmp(ancestor, feature_head_buf)==0);
+  }
+
+  /* Test 5: second parent vs first parent merges at the branch point. */
+  {
+    char sql[512];
+    snprintf(sql, sizeof(sql),
+      "SELECT dolt_merge_base('%s^2', '%s~1')", merge_head_buf, merge_head_buf);
+    ancestor = exec1(db, sql);
+    printf("Ancestor (HEAD^2,HEAD~1): %s\n", ancestor);
+    check("merge first/second parent base is C2",
           strcmp(ancestor, c2_hash_buf)==0);
   }
 

--- a/test/vc_oracle_merge_base_test.sh
+++ b/test/vc_oracle_merge_base_test.sh
@@ -160,6 +160,8 @@ SELECT dolt_merge('feat');
 
 oracle "merged_main_feat" "$POST_MERGE" "'main'" "'feat'"
 oracle "merged_feat_head" "$POST_MERGE" "'feat'" "'HEAD'"
+oracle "merged_second_parent_self" "$POST_MERGE" "'HEAD^2'" "'HEAD^2'"
+oracle "merged_second_parent_vs_first_parent" "$POST_MERGE" "'HEAD^2'" "'HEAD~1'"
 
 echo "--- tag refs ---"
 


### PR DESCRIPTION
## Summary
- fix dolt_merge_base ref resolution so ^N selects the Nth parent instead of walking first-parent history
- centralize commit parent iteration in shared helpers and reuse them in log, ancestor, and history walkers
- add merge-parent oracle coverage for HEAD^2 cases

## Testing
- bash test/lint_layers.sh src
- make -C build libdoltlite.a doltlite
- cd build && bash ../test/vc_oracle_merge_base_test.sh ./doltlite dolt