### PR TITLE
fix: dispatch sqlite3BtreeTripAllCursors to stock btree

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -5006,7 +5006,16 @@ int sqlite3BtreeTripAllCursors(Btree *p, int errCode, int writeOnly){
   BtShared *pBt;
 
   if( !p ) return SQLITE_OK;
+  /* Attached stock-SQLite files keep their state under p->pOrigBtree
+  ** and have p->pBt==NULL. VDBE walks db->aDb[] on savepoint rollback
+  ** and calls us for every attached db indiscriminately, so we must
+  ** dispatch here instead of unconditionally dereferencing pBt. */
+  if( p->pOrigBtree ){
+    origBtreeTripAllCursors(p->pOrigBtree, errCode, writeOnly);
+    return SQLITE_OK;
+  }
   pBt = p->pBt;
+  if( !pBt ) return SQLITE_OK;
 
   for(pCur=pBt->pCursor; pCur; pCur=pCur->pNext){
     if( writeOnly && !(pCur->curFlags & BTCF_WriteFlag) ){

--- a/test/oracle_savepoints_test.sh
+++ b/test/oracle_savepoints_test.sh
@@ -29,16 +29,6 @@
 #   - Savepoint-inside-BEGIN interaction
 #   - Trigger RAISE(ROLLBACK) unwinding nested savepoints
 #
-# Known disabled scenarios (marked DISABLED inline with the
-# repro and a pointer to the underlying bug):
-#
-#   - rollback_undoes_alter_rename,
-#     rollback_undoes_alter_rename_column — pre-existing SIGSEGV
-#     in the ALTER TABLE RENAME + ROLLBACK TO interaction
-#     (reproduces on master). Crash lands in
-#     sqlite3BtreeTripAllCursors before the savepoint restore
-#     code. Filed as a separate follow-up.
-#
 # Usage: bash oracle_savepoints_test.sh [path/to/doltlite] [path/to/sqlite3]
 #
 
@@ -541,50 +531,36 @@ RELEASE SAVEPOINT s1;
 SELECT id, v FROM t ORDER BY id;
 "
 
-# ─── Schema state shallow-copy edge cases ──────────────────────────
+# ─── ALTER TABLE RENAME inside a savepoint ─────────────────────────
 #
-# DISABLED: ALTER TABLE RENAME [COLUMN] inside a savepoint followed
-# by ROLLBACK TO SAVEPOINT crashes doltlite with SIGSEGV. This
-# reproduces on master (without the savepoint snapshot deep-copy
-# fix in this PR), so it is a pre-existing crash in the rename +
-# rollback interaction, NOT a regression and NOT addressed by the
-# mutmap-snapshot fix here. The crash backtrace lands inside
-# sqlite3BtreeTripAllCursors which runs BEFORE the savepoint
-# restore code, suggesting the rename leaves a cursor-list /
-# catalog state inconsistent that the rollback path then walks.
-#
-# Repro:
-#
-#   CREATE TABLE t(id INT PRIMARY KEY, v INT);
-#   INSERT INTO t VALUES(1, 10);
-#   SAVEPOINT s1;
-#   ALTER TABLE t RENAME TO renamed_t;
-#   ROLLBACK TO SAVEPOINT s1;            -- SIGSEGV here
-#
-# Filed as a follow-up issue. Re-enable when the rename interaction
-# is fixed.
-#
-# oracle "rollback_undoes_alter_rename" "
-# CREATE TABLE t(id INT PRIMARY KEY, v INT);
-# INSERT INTO t VALUES(1, 10);
-# SAVEPOINT s1;
-# ALTER TABLE t RENAME TO renamed_t;
-# ROLLBACK TO SAVEPOINT s1;
-# RELEASE SAVEPOINT s1;
-# SELECT name FROM sqlite_master WHERE type='table' ORDER BY name;
-# SELECT id, v FROM t;
-# "
-#
-# oracle "rollback_undoes_alter_rename_column" "
-# CREATE TABLE t(id INT PRIMARY KEY, v INT);
-# INSERT INTO t VALUES(1, 10);
-# SAVEPOINT s1;
-# ALTER TABLE t RENAME COLUMN v TO val;
-# ROLLBACK TO SAVEPOINT s1;
-# RELEASE SAVEPOINT s1;
-# SELECT sql FROM sqlite_master WHERE type='table' AND name='t';
-# SELECT id, v FROM t;
-# "
+# ROLLBACK TO SAVEPOINT over an ALTER TABLE RENAME / RENAME COLUMN.
+# VDBE's savepoint-rollback opcode walks db->aDb[] and calls
+# sqlite3BtreeTripAllCursors on every attached btree. Attached stock-
+# SQLite files (temp, memory, etc.) have pBt==NULL and store state
+# under pOrigBtree, so the trip-all-cursors path must dispatch to
+# origBtreeTripAllCursors instead of dereferencing pBt directly.
+
+oracle "rollback_undoes_alter_rename" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1, 10);
+SAVEPOINT s1;
+ALTER TABLE t RENAME TO renamed_t;
+ROLLBACK TO SAVEPOINT s1;
+RELEASE SAVEPOINT s1;
+SELECT name FROM sqlite_master WHERE type='table' ORDER BY name;
+SELECT id, v FROM t;
+"
+
+oracle "rollback_undoes_alter_rename_column" "
+CREATE TABLE t(id INT PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1, 10);
+SAVEPOINT s1;
+ALTER TABLE t RENAME COLUMN v TO val;
+ROLLBACK TO SAVEPOINT s1;
+RELEASE SAVEPOINT s1;
+SELECT sql FROM sqlite_master WHERE type='table' AND name='t';
+SELECT id, v FROM t;
+"
 
 # CREATE INDEX inside a savepoint. Indexes are sqlite_master rows
 # with their own iTable / root. Rollback must remove both the


### PR DESCRIPTION
Fixes the pre-existing SIGSEGV that was left as two DISABLED scenarios (\`rollback_undoes_alter_rename\` and \`rollback_undoes_alter_rename_column\`) in #420's oracle_savepoints_test.sh. Both are re-enabled in this PR — full suite is now 43/43.

## The crash

\`ALTER TABLE t RENAME TO renamed_t\` inside a savepoint followed by \`ROLLBACK TO SAVEPOINT s1\` lands in \`sqlite3BtreeTripAllCursors\` at \`prolly_btree.c:5011\` dereferencing a NULL \`pBt\`:

\`\`\`
thread #2, stop reason = EXC_BAD_ACCESS (code=1, address=0x278)
  frame #0: sqlite3BtreeTripAllCursors at prolly_btree.c:5011
     5009	  pBt = p->pBt;
  -> 5011	  for(pCur=pBt->pCursor; pCur; pCur=pCur->pNext){
  frame #1: sqlite3VdbeExec at vdbe.c:3941  (OP_Savepoint ROLLBACK)
  frame #2: sqlite3Step              (from "ROLLBACK TO SAVEPOINT s1;")
\`\`\`

0x278 = \`offsetof(BtShared, pCursor)\` — the base pointer is NULL.

## Root cause

VDBE's \`OP_Savepoint\` ROLLBACK path walks every attached database:

\`\`\`c
for(ii=0; ii<db->nDb; ii++){
    rc = sqlite3BtreeTripAllCursors(db->aDb[ii].pBt,
                                    SQLITE_ABORT_ROLLBACK,
                                    isSchemaChange==0);
\`\`\`

doltlite's multi-engine dispatch keeps stock-SQLite btree state under \`p->pOrigBtree\` and leaves \`p->pBt == NULL\` for attached temp / \`:memory:\` / plain-sqlite files. Our \`sqlite3BtreeTripAllCursors\` wrapper unconditionally loaded \`p->pBt\` and then \`pBt->pCursor\`, so the first attached stock btree crashed the loop.

The ALTER RENAME + savepoint rollback combo specifically hits this because ALTER RENAME sets \`DBFLAG_SchemaChange\`, which makes VDBE call \`sqlite3BtreeTripAllCursors\` on *every* attached database (not just the writer) as part of the rollback. Without the schema change flag the trip walk is narrower and the temp btree is skipped, which is why most scenarios don't reproduce.

## Fix

Dispatch like every other multi-impl function in \`prolly_btree.c\`: when \`p->pOrigBtree\` is set, forward to \`origBtreeTripAllCursors\` (which already exists in \`btree_orig_api.c\` and calls the original SQLite btree implementation). Also guard against a NULL \`pBt\` on the prolly path for defensive symmetry — previously the deref was the only thing that would hit it, so it was never caught.

\`\`\`c
if( p->pOrigBtree ){
  origBtreeTripAllCursors(p->pOrigBtree, errCode, writeOnly);
  return SQLITE_OK;
}
pBt = p->pBt;
if( !pBt ) return SQLITE_OK;
\`\`\`

## Tests re-enabled

\`oracle_savepoints_test.sh\` had two DISABLED blocks pointing at this exact crash. Both are re-enabled with fresh comments explaining the dispatch fix. Full suite: 43/43 (was 41/41 with the two skipped).

## Test plan

- [x] \`bash test/oracle_savepoints_test.sh ./doltlite ./sqlite3\` — 43/43
- [x] \`bash test/oracle_triggers_test.sh ./doltlite ./sqlite3\` — 27/27
- [x] \`bash test/sql_oracle_test.sh ./doltlite ./sqlite3\` — 526/526
- [x] \`bash test/oracle_dot_commands_test.sh ./doltlite ./sqlite3\` — 61/61
- [x] \`bash test/oracle_fts5_test.sh ./doltlite ./sqlite3\` — 7/7
- [x] \`bash test/correctness_test.sh ./doltlite\` — 41/41
- [x] \`bash test/diff_test.sh ./doltlite\` — 41/41
- [x] \`bash test/vc_oracle_merge_test.sh ./doltlite dolt\` — 31/31
- [x] \`bash test/doltlite_savepoint.sh\` — 21/21

🤖 Generated with [Claude Code](https://claude.com/claude-code)