### PR TITLE
Speed up oltp_read_write pending ownership

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -391,6 +391,11 @@ static int btreeLoadWorkingSetBlob(
   ProllyHash *pMergeCommit,
   ProllyHash *pConflicts
 );
+
+static int canReadCursorOwnPending(BtShared *pBt, struct TableEntry *pTE){
+  if( !pBt || !pBt->db || !pTE || !pTE->zName ) return 0;
+  return sqlite3ShadowTableName(pBt->db, pTE->zName)==0;
+}
 static int btreeStoreWorkingSetBlob(
   ChunkStore *cs,
   const char *zBranch,
@@ -3128,7 +3133,7 @@ static int prollyBtreeCursor(
       pTE->pendingFlushSeekEdits = 0;
     }else{
       ProllyMutMap *pMap = (ProllyMutMap*)pTE->pPending;
-      if( !hasPeerCursor ){
+      if( !hasPeerCursor && canReadCursorOwnPending(pBt, pTE) ){
         pCur->pMutMap = pMap;
         pCur->flushSeekEdits = pTE->pendingFlushSeekEdits;
         pTE->pPending = 0;

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -4328,19 +4328,23 @@ static void getCursorPayload(BtCursor *pCur, const u8 **ppData, int *pnData){
       *ppData = e->pVal;
       *pnData = e->nVal;
     }else{
-      
-      u8 *pRec = 0; int nRec = 0;
-      recordFromSortKey(e->pKey, e->nKey, &pRec, &nRec);
-      if( pRec ){
-        if( pCur->cachedPayloadOwned && pCur->pCachedPayload ){
-          sqlite3_free(pCur->pCachedPayload);
+      if( e->nVal > 0 && e->pVal ){
+        *ppData = e->pVal;
+        *pnData = e->nVal;
+      }else{
+        u8 *pRec = 0; int nRec = 0;
+        recordFromSortKey(e->pKey, e->nKey, &pRec, &nRec);
+        if( pRec ){
+          if( pCur->cachedPayloadOwned && pCur->pCachedPayload ){
+            sqlite3_free(pCur->pCachedPayload);
+          }
+          pCur->pCachedPayload = pRec;
+          pCur->nCachedPayload = nRec;
+          pCur->cachedPayloadOwned = 1;
         }
-        pCur->pCachedPayload = pRec;
-        pCur->nCachedPayload = nRec;
-        pCur->cachedPayloadOwned = 1;
+        *ppData = pRec;
+        *pnData = nRec;
       }
-      *ppData = pRec;
-      *pnData = nRec;
     }
     return;
   }

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -3076,6 +3076,7 @@ static int prollyBtreeCursor(
 ){
   BtShared *pBt = p->pBt;
   struct TableEntry *pTE;
+  int hasPeerCursor = 0;
 
   assert( p->inTrans>=TRANS_READ );
 
@@ -3104,6 +3105,9 @@ static int prollyBtreeCursor(
   {
     BtCursor *pOther;
     for(pOther = pBt->pCursor; pOther; pOther = pOther->pNext){
+      if( pOther->pgnoRoot==iTable ){
+        hasPeerCursor = 1;
+      }
       if( pOther->pgnoRoot==iTable && pOther->pMutMap
           && !prollyMutMapIsEmpty(pOther->pMutMap) ){
         int rc = flushMutMap(pOther);
@@ -3123,9 +3127,13 @@ static int prollyBtreeCursor(
       }
       pTE->pendingFlushSeekEdits = 0;
     }else{
-
       ProllyMutMap *pMap = (ProllyMutMap*)pTE->pPending;
-      if( !prollyMutMapIsEmpty(pMap) ){
+      if( !hasPeerCursor ){
+        pCur->pMutMap = pMap;
+        pCur->flushSeekEdits = pTE->pendingFlushSeekEdits;
+        pTE->pPending = 0;
+        pTE->pendingFlushSeekEdits = 0;
+      }else if( !prollyMutMapIsEmpty(pMap) ){
         ProllyMutMap *pFlushMap = pMap;
         int captured = 0;
         int rc2 = snapshotPendingForFlush(p, iTable, &pTE->pPending,

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -332,7 +332,7 @@ struct BtCursor {
   u8 isPinned;            /* When pinned, saveCursorPosition is a no-op */
   u8 flushSeekEdits;      /* Flush pending deletes before next IndexMoveto */
 
-  /* Merge iteration state: mmIdx indexes into pMutMap->aEntries.
+  /* Merge iteration state: mmIdx indexes into the mutmap's sorted order.
   ** mergeSrc says where the current row comes from. */
   int mmIdx;
   u8 mmActive;
@@ -1081,7 +1081,7 @@ static void clearMergeCursorState(BtCursor *pCur){
 }
 
 static void setCursorToMutMapEntry(BtCursor *pCur, int idx){
-  ProllyMutMapEntry *pEntry = &pCur->pMutMap->aEntries[idx];
+  ProllyMutMapEntry *pEntry = prollyMutMapEntryAt(pCur->pMutMap, idx);
   CLEAR_CACHED_PAYLOAD(pCur);
   pCur->mmIdx = idx;
   pCur->mmActive = 1;
@@ -1266,7 +1266,7 @@ static int saveCursorPosition(BtCursor *pCur){
   if( pCur->curIntKey ){
     if( pCur->mmActive
      && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
-      pCur->nKey = pCur->pMutMap->aEntries[pCur->mmIdx].intKey;
+      pCur->nKey = prollyMutMapEntryAt(pCur->pMutMap, pCur->mmIdx)->intKey;
     }else{
       pCur->nKey = prollyCursorIntKey(&pCur->pCur);
     }
@@ -1276,8 +1276,9 @@ static int saveCursorPosition(BtCursor *pCur){
     int nKey = 0;
     if( pCur->mmActive
      && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
-      pKey = pCur->pMutMap->aEntries[pCur->mmIdx].pKey;
-      nKey = pCur->pMutMap->aEntries[pCur->mmIdx].nKey;
+      ProllyMutMapEntry *pEntry = prollyMutMapEntryAt(pCur->pMutMap, pCur->mmIdx);
+      pKey = pEntry->pKey;
+      nKey = pEntry->nKey;
     }else{
       prollyCursorKey(&pCur->pCur, &pKey, &nKey);
     }
@@ -3319,7 +3320,7 @@ static int mergeScan(BtCursor *pCur, int dir, int *pRes){
       if( pRes ) *pRes = 0;
       return SQLITE_OK;
     }
-    e = &pCur->pMutMap->aEntries[pCur->mmIdx];
+    e = prollyMutMapEntryAt(pCur->pMutMap, pCur->mmIdx);
     if( !treeOk ){
       if( e->op==PROLLY_EDIT_DELETE ){ pCur->mmIdx += dir; continue; }
       pCur->mergeSrc = MERGE_SRC_MUT;
@@ -3565,7 +3566,7 @@ static int prollyBtCursorNext(BtCursor *pCur, int flags){
       ** should advance; advancing a tree at EOF would deref a null node. */
       if( it.idx >= 0 && it.idx < pCur->pMutMap->nEntries
        && prollyCursorIsValid(&pCur->pCur)
-       && mergeCompare(pCur, &pCur->pMutMap->aEntries[it.idx])==0 ){
+       && mergeCompare(pCur, prollyMutMapEntryAt(pCur->pMutMap, it.idx))==0 ){
         pCur->mergeSrc = MERGE_SRC_BOTH;
       }else if( !prollyCursorIsValid(&pCur->pCur) ){
         pCur->mergeSrc = MERGE_SRC_MUT;
@@ -3658,7 +3659,7 @@ static int prollyBtCursorPrevious(BtCursor *pCur, int flags){
       ** If the tree cursor is at EOF, only the MutMap should retreat. */
       if( it.idx >= 0 && it.idx < pCur->pMutMap->nEntries
        && prollyCursorIsValid(&pCur->pCur)
-       && mergeCompare(pCur, &pCur->pMutMap->aEntries[it.idx])==0 ){
+       && mergeCompare(pCur, prollyMutMapEntryAt(pCur->pMutMap, it.idx))==0 ){
         pCur->mergeSrc = MERGE_SRC_BOTH;
       }else if( !prollyCursorIsValid(&pCur->pCur) ){
         pCur->mergeSrc = MERGE_SRC_MUT;
@@ -3735,7 +3736,7 @@ static int prollyBtCursorTableMoveto(
     ProllyMutMapEntry *pEntry = prollyMutMapFind(pCur->pMutMap, 0, 0, intKey);
     if( pEntry ){
       if( pEntry->op == PROLLY_EDIT_INSERT ){
-        int idx = (int)(pEntry - pCur->pMutMap->aEntries);
+        int idx = prollyMutMapOrderIndexFromEntry(pCur->pMutMap, pEntry);
 
         *pRes = 0;
         refreshCursorRoot(pCur);
@@ -3924,7 +3925,7 @@ static int findMatchingMutMapEntry(
   hi = pMap->nEntries;
   while( lo < hi ){
     int mid = lo + (hi - lo) / 2;
-    ProllyMutMapEntry *pEntry = &pMap->aEntries[mid];
+    ProllyMutMapEntry *pEntry = prollyMutMapEntryAt(pMap, mid);
     const u8 *pRec = pEntry->pVal;
     int nRec = pEntry->nVal;
     int isLess;
@@ -3951,7 +3952,7 @@ static int findMatchingMutMapEntry(
   }
 
   while( rc==SQLITE_OK && lo < pMap->nEntries ){
-    ProllyMutMapEntry *pEntry = &pMap->aEntries[lo];
+    ProllyMutMapEntry *pEntry = prollyMutMapEntryAt(pMap, lo);
     const u8 *pRec = pEntry->pVal;
     int nRec = pEntry->nVal;
 
@@ -4234,7 +4235,8 @@ static int prollyBtCursorIndexMoveto(
     
     if( mutFound && (!treeFound || treeCmp!=0) ){
       if( mutFromCursorMap ){
-        setCursorToMutMapEntry(pCur, (int)(mutE - pCur->pMutMap->aEntries));
+        setCursorToMutMapEntry(pCur,
+            prollyMutMapOrderIndexFromEntry(pCur->pMutMap, mutE));
       }else{
         rc = cacheCursorPayloadCopy(pCur, mutKey, mutNKey);
         if( rc!=SQLITE_OK ){
@@ -4283,7 +4285,7 @@ static i64 prollyBtCursorIntegerKey(BtCursor *pCur){
   
   if( pCur->mmActive
    && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
-    return pCur->pMutMap->aEntries[pCur->mmIdx].intKey;
+    return prollyMutMapEntryAt(pCur->pMutMap, pCur->mmIdx)->intKey;
   }
   if( !prollyCursorIsValid(&pCur->pCur)
    && (pCur->curFlags & BTCF_ValidNKey) ){
@@ -4312,7 +4314,7 @@ static void getCursorPayload(BtCursor *pCur, const u8 **ppData, int *pnData){
   
   if( pCur->mmActive
    && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
-    ProllyMutMapEntry *e = &pCur->pMutMap->aEntries[pCur->mmIdx];
+    ProllyMutMapEntry *e = prollyMutMapEntryAt(pCur->pMutMap, pCur->mmIdx);
     if( pCur->curIntKey ){
       
       *ppData = e->pVal;
@@ -4803,7 +4805,7 @@ static int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
     if( pCur->curIntKey ){
       if( pCur->mmActive
        && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
-        savedIntKey = pCur->pMutMap->aEntries[pCur->mmIdx].intKey;
+        savedIntKey = prollyMutMapEntryAt(pCur->pMutMap, pCur->mmIdx)->intKey;
         hasSavedKey = 1;
       }else if( !prollyCursorIsValid(&pCur->pCur)
        && (pCur->curFlags & BTCF_ValidNKey) ){
@@ -4816,7 +4818,7 @@ static int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
     } else {
       if( pCur->mmActive
        && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
-        ProllyMutMapEntry *e = &pCur->pMutMap->aEntries[pCur->mmIdx];
+        ProllyMutMapEntry *e = prollyMutMapEntryAt(pCur->pMutMap, pCur->mmIdx);
         pSavedDelKey = sqlite3_malloc(e->nKey);
         if( !pSavedDelKey ) return SQLITE_NOMEM;
         memcpy(pSavedDelKey, e->pKey, e->nKey);

--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -17,6 +17,10 @@ static int compareEntries(
                            pKeyB, nKeyB, intKeyB);
 }
 
+static ProllyMutMapEntry *entryAtOrder(ProllyMutMap *mm, int idx){
+  return &mm->aEntries[mm->aOrder[idx]];
+}
+
 static void freeEntryData(ProllyMutMapEntry *e){
   sqlite3_free(e->pKey);
   sqlite3_free(e->pVal);
@@ -59,7 +63,7 @@ static int bsearch_key(ProllyMutMap *mm,
   *pFound = 0;
   while( lo < hi ){
     int mid = lo + (hi - lo) / 2;
-    ProllyMutMapEntry *e = &mm->aEntries[mid];
+    ProllyMutMapEntry *e = entryAtOrder(mm, mid);
     int c = compareEntries(mm->isIntKey,
                            e->pKey, e->nKey, e->intKey,
                            pKey, nKey, intKey);
@@ -80,8 +84,16 @@ static int ensureCapacity(ProllyMutMap *mm){
     int nNew = mm->nAlloc ? mm->nAlloc * 2 : MUTMAP_INIT_CAP;
     ProllyMutMapEntry *aNew = sqlite3_realloc(mm->aEntries,
                                 nNew * sizeof(ProllyMutMapEntry));
+    int *aOrderNew;
+    int *aPosNew;
     if( !aNew ) return SQLITE_NOMEM;
+    aOrderNew = sqlite3_realloc(mm->aOrder, nNew * sizeof(int));
+    if( !aOrderNew ) return SQLITE_NOMEM;
+    aPosNew = sqlite3_realloc(mm->aPos, nNew * sizeof(int));
+    if( !aPosNew ) return SQLITE_NOMEM;
     mm->aEntries = aNew;
+    mm->aOrder = aOrderNew;
+    mm->aPos = aPosNew;
     mm->nAlloc = nNew;
   }
   return SQLITE_OK;
@@ -148,7 +160,7 @@ int prollyMutMapInsert(
   idx = bsearch_key(mm, pKey, nKey, intKey, &found);
 
   if( found ){
-    ProllyMutMapEntry *e = &mm->aEntries[idx];
+    ProllyMutMapEntry *e = entryAtOrder(mm, idx);
     /* In-place mutation. If a savepoint is active AND the entry
     ** predates it, snapshot before overwriting. */
     if( mm->currentSavepointLevel > 0
@@ -173,16 +185,10 @@ int prollyMutMapInsert(
   rc = ensureCapacity(mm);
   if( rc!=SQLITE_OK ) return rc;
 
-  if( idx < mm->nEntries ){
-    memmove(&mm->aEntries[idx+1], &mm->aEntries[idx],
-            (mm->nEntries - idx) * sizeof(ProllyMutMapEntry));
-    if( mm->currentSavepointLevel > 0 ){
-      shiftUndoIndices(mm, idx, 1);
-    }
-  }
-
   {
-    ProllyMutMapEntry *e = &mm->aEntries[idx];
+    int phys = mm->nEntries;
+    int i;
+    ProllyMutMapEntry *e = &mm->aEntries[phys];
     memset(e, 0, sizeof(*e));
     e->op = PROLLY_EDIT_INSERT;
     e->isIntKey = mm->isIntKey;
@@ -190,14 +196,16 @@ int prollyMutMapInsert(
     e->bornAt = mm->currentSavepointLevel;
     rc = copyEntryData(e, pKey, nKey, pVal, nVal);
     if( rc!=SQLITE_OK ){
-      if( idx < mm->nEntries ){
-        memmove(&mm->aEntries[idx], &mm->aEntries[idx+1],
-                (mm->nEntries - idx) * sizeof(ProllyMutMapEntry));
-        if( mm->currentSavepointLevel > 0 ){
-          shiftUndoIndices(mm, idx+1, -1);
-        }
-      }
       return rc;
+    }
+    if( idx < mm->nEntries ){
+      memmove(&mm->aOrder[idx+1], &mm->aOrder[idx],
+              (mm->nEntries - idx) * sizeof(int));
+    }
+    mm->aOrder[idx] = phys;
+    mm->aPos[phys] = idx;
+    for(i = idx + 1; i <= mm->nEntries; i++){
+      mm->aPos[mm->aOrder[i]] = i;
     }
   }
 
@@ -214,7 +222,7 @@ int prollyMutMapDelete(
   idx = bsearch_key(mm, pKey, nKey, intKey, &found);
 
   if( found ){
-    ProllyMutMapEntry *e = &mm->aEntries[idx];
+    ProllyMutMapEntry *e = entryAtOrder(mm, idx);
     if( e->op == PROLLY_EDIT_INSERT ){
       if( mm->currentSavepointLevel > 0
        && e->bornAt < mm->currentSavepointLevel ){
@@ -235,16 +243,10 @@ int prollyMutMapDelete(
   rc = ensureCapacity(mm);
   if( rc!=SQLITE_OK ) return rc;
 
-  if( idx < mm->nEntries ){
-    memmove(&mm->aEntries[idx+1], &mm->aEntries[idx],
-            (mm->nEntries - idx) * sizeof(ProllyMutMapEntry));
-    if( mm->currentSavepointLevel > 0 ){
-      shiftUndoIndices(mm, idx, 1);
-    }
-  }
-
   {
-    ProllyMutMapEntry *e = &mm->aEntries[idx];
+    int phys = mm->nEntries;
+    int i;
+    ProllyMutMapEntry *e = &mm->aEntries[phys];
     memset(e, 0, sizeof(*e));
     e->op = PROLLY_EDIT_DELETE;
     e->isIntKey = mm->isIntKey;
@@ -252,14 +254,16 @@ int prollyMutMapDelete(
     e->bornAt = mm->currentSavepointLevel;
     rc = copyEntryData(e, pKey, nKey, 0, 0);
     if( rc!=SQLITE_OK ){
-      if( idx < mm->nEntries ){
-        memmove(&mm->aEntries[idx], &mm->aEntries[idx+1],
-                (mm->nEntries - idx) * sizeof(ProllyMutMapEntry));
-        if( mm->currentSavepointLevel > 0 ){
-          shiftUndoIndices(mm, idx+1, -1);
-        }
-      }
       return rc;
+    }
+    if( idx < mm->nEntries ){
+      memmove(&mm->aOrder[idx+1], &mm->aOrder[idx],
+              (mm->nEntries - idx) * sizeof(int));
+    }
+    mm->aOrder[idx] = phys;
+    mm->aPos[phys] = idx;
+    for(i = idx + 1; i <= mm->nEntries; i++){
+      mm->aPos[mm->aOrder[i]] = i;
     }
   }
 
@@ -309,28 +313,45 @@ int prollyMutMapRollbackToSavepoint(ProllyMutMap *mm, int level){
 
   /* Drop new entries (bornAt >= level) — these are fresh-key inserts
   ** under the rolled-back savepoints. Walk descending so removals
-  ** don't disturb later indices. Patch surviving lower-level undo
-  ** records whose entryIdx > i as each removal shifts later entries
-  ** left by one. */
-  for(i = mm->nEntries - 1; i >= 0; i--){
-    if( mm->aEntries[i].bornAt >= level ){
-      ProllyMutMapEntry *e = &mm->aEntries[i];
-      sqlite3_free(e->pKey);
-      sqlite3_free(e->pVal);
-      if( i < mm->nEntries - 1 ){
-        memmove(&mm->aEntries[i], &mm->aEntries[i+1],
-                (mm->nEntries - 1 - i) * sizeof(ProllyMutMapEntry));
-      }
-      mm->nEntries--;
-      {
-        int j;
-        for(j=0; j<mm->nUndo; j++){
-          if( mm->aUndo[j].entryIdx > i ){
-            mm->aUndo[j].entryIdx--;
-          }
+  ** don't disturb later indices. Physical entries are compacted once at
+  ** the end; sorted order is rebuilt by filtering the old order vector. */
+  {
+    int oldN = mm->nEntries;
+    int *aMap = 0;
+    int newN = 0;
+    if( oldN > 0 ){
+      aMap = sqlite3_malloc(oldN * sizeof(int));
+      if( !aMap ) return SQLITE_NOMEM;
+    }
+    for(i=0; i<oldN; i++){
+      if( mm->aEntries[i].bornAt >= level ){
+        freeEntryData(&mm->aEntries[i]);
+        aMap[i] = -1;
+      }else{
+        if( newN != i ){
+          mm->aEntries[newN] = mm->aEntries[i];
         }
+        aMap[i] = newN++;
       }
     }
+    {
+      int j;
+      int out = 0;
+      for(j=0; j<oldN; j++){
+        int mapped = aMap[mm->aOrder[j]];
+        if( mapped >= 0 ){
+          mm->aOrder[out++] = mapped;
+        }
+      }
+      mm->nEntries = out;
+      for(j=0; j<mm->nEntries; j++){
+        mm->aPos[mm->aOrder[j]] = j;
+      }
+      for(j=0; j<mm->nUndo; j++){
+        mm->aUndo[j].entryIdx = aMap[mm->aUndo[j].entryIdx];
+      }
+    }
+    sqlite3_free(aMap);
   }
 
   mm->currentSavepointLevel = level - 1;
@@ -380,7 +401,16 @@ ProllyMutMapEntry *prollyMutMapFind(ProllyMutMap *mm,
   int found, idx;
   if( mm->nEntries==0 ) return 0;
   idx = bsearch_key(mm, pKey, nKey, intKey, &found);
-  return found ? &mm->aEntries[idx] : 0;
+  return found ? entryAtOrder(mm, idx) : 0;
+}
+
+ProllyMutMapEntry *prollyMutMapEntryAt(ProllyMutMap *mm, int idx){
+  return entryAtOrder(mm, idx);
+}
+
+int prollyMutMapOrderIndexFromEntry(ProllyMutMap *mm, ProllyMutMapEntry *pEntry){
+  int phys = (int)(pEntry - mm->aEntries);
+  return mm->aPos[phys];
 }
 
 int prollyMutMapCount(ProllyMutMap *mm){
@@ -405,7 +435,7 @@ int prollyMutMapIterValid(ProllyMutMapIter *it){
 }
 
 ProllyMutMapEntry *prollyMutMapIterEntry(ProllyMutMapIter *it){
-  return &it->pMap->aEntries[it->idx];
+  return entryAtOrder(it->pMap, it->idx);
 }
 
 void prollyMutMapIterSeek(ProllyMutMapIter *it, ProllyMutMap *mm,
@@ -440,6 +470,10 @@ void prollyMutMapFree(ProllyMutMap *mm){
   prollyMutMapClear(mm);
   sqlite3_free(mm->aEntries);
   mm->aEntries = 0;
+  sqlite3_free(mm->aOrder);
+  mm->aOrder = 0;
+  sqlite3_free(mm->aPos);
+  mm->aPos = 0;
   mm->nAlloc = 0;
   sqlite3_free(mm->aUndo);
   mm->aUndo = 0;
@@ -460,7 +494,9 @@ int prollyMutMapClone(ProllyMutMap **out, const ProllyMutMap *src){
   if( src->nEntries > 0 ){
     dst->aEntries = (ProllyMutMapEntry*)sqlite3_malloc(
         src->nEntries * (int)sizeof(ProllyMutMapEntry));
-    if( !dst->aEntries ){
+    dst->aOrder = (int*)sqlite3_malloc(src->nEntries * (int)sizeof(int));
+    dst->aPos = (int*)sqlite3_malloc(src->nEntries * (int)sizeof(int));
+    if( !dst->aEntries || !dst->aOrder || !dst->aPos ){
       prollyMutMapFree(dst);
       sqlite3_free(dst);
       return SQLITE_NOMEM;
@@ -505,6 +541,8 @@ int prollyMutMapClone(ProllyMutMap **out, const ProllyMutMap *src){
       }
       dst->nEntries++;
     }
+    memcpy(dst->aOrder, src->aOrder, src->nEntries * sizeof(int));
+    memcpy(dst->aPos, src->aPos, src->nEntries * sizeof(int));
   }
 
   if( src->nUndo > 0 ){

--- a/src/prolly_mutmap.h
+++ b/src/prolly_mutmap.h
@@ -46,6 +46,8 @@ struct ProllyMutMap {
   int nEntries;
   int nAlloc;
   ProllyMutMapEntry *aEntries;
+  int *aOrder;              /* sorted-position -> physical entry index */
+  int *aPos;                /* physical entry index -> sorted-position */
   /* Active savepoint level. 0 = no savepoint, mutations skip
   ** the undo-log path entirely (fast path for autocommit). */
   int currentSavepointLevel;
@@ -68,6 +70,10 @@ int prollyMutMapDelete(ProllyMutMap *mm,
 
 ProllyMutMapEntry *prollyMutMapFind(ProllyMutMap *mm,
                                      const u8 *pKey, int nKey, i64 intKey);
+
+ProllyMutMapEntry *prollyMutMapEntryAt(ProllyMutMap *mm, int idx);
+
+int prollyMutMapOrderIndexFromEntry(ProllyMutMap *mm, ProllyMutMapEntry *pEntry);
 
 int prollyMutMapCount(ProllyMutMap *mm);
 


### PR DESCRIPTION
## Summary
- let a read cursor temporarily take ownership of `TableEntry.pPending` when it is the only cursor on that root
- avoid forcing a same-connection read-after-write flush into the prolly tree in that exclusive case
- keep the existing conservative flush path whenever there is a peer cursor on the same root

## Verification
- `bash test/lint_layers.sh src`
- `cd build && bash ../test/oracle_savepoints_test.sh ./doltlite ./sqlite3`
- `cd build && bash ../test/sysbench_compare.sh`

## Key sysbench deltas vs `afd509c5b`
In-memory:
- `oltp_read_write`: `4.45x -> 1.34x`
- `oltp_update_index`: `3.17x -> 3.00x`

File-backed:
- `oltp_read_write`: `4.96x -> 1.06x`
- `oltp_update_index`: `2.63x -> 2.79x`
