### PR TITLE
oracle + fix: WITHOUT ROWID coverage, honor NOCASE/RTRIM on TEXT PK

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -193,6 +193,10 @@ jobs:
       run: cd build && bash ../test/oracle_generated_columns_test.sh ./doltlite ./sqlite3
       timeout-minutes: 5
 
+    - name: Oracle tests (WITHOUT ROWID)
+      run: cd build && bash ../test/oracle_without_rowid_test.sh ./doltlite ./sqlite3
+      timeout-minutes: 5
+
     - name: Large-scale test (10K rows)
       run: cd build && bash ../test/large_scale_test.sh ./doltlite --quick
       timeout-minutes: 5

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -3391,8 +3391,9 @@ static int seedMutMapIterFromCursor(
        && pCur->pKeyInfo->nKeyField < pCur->pKeyInfo->nAllField ){
         nMutKeyField = (int)pCur->pKeyInfo->nKeyField;
       }
-      rc = sortKeyFromRecordPrefix(pCur->pCachedPayload, pCur->nCachedPayload,
-                                   nMutKeyField, &pSortKey, &nSortKey);
+      rc = sortKeyFromRecordPrefixColl(pCur->pCachedPayload, pCur->nCachedPayload,
+                                        nMutKeyField, pCur->pKeyInfo,
+                                        &pSortKey, &nSortKey);
       if( rc!=SQLITE_OK ) return rc;
       prollyMutMapIterSeek(pIt, pCur->pMutMap, pSortKey, nSortKey, 0);
       sqlite3_free(pSortKey);
@@ -4058,8 +4059,8 @@ static int prollyBtCursorIndexMoveto(
     }
     rc = serializeUnpackedRecord(pIdxKey, &pSerKey, &nSerKey);
     if( rc!=SQLITE_OK ) return rc;
-    rc = sortKeyFromRecordPrefix(pSerKey, nSerKey, nSeekKeyField,
-                                 &pSortKey, &nSortKey);
+    rc = sortKeyFromRecordPrefixColl(pSerKey, nSerKey, nSeekKeyField,
+                                      pCur->pKeyInfo, &pSortKey, &nSortKey);
     if( rc!=SQLITE_OK ){
       sqlite3_free(pSerKey);
       return rc;
@@ -4507,10 +4508,11 @@ static int prollyBtCursorInsert(
       nKeyField = (int)pCur->pKeyInfo->nKeyField;
       splitKey = 1;
     }
-    rc = sortKeyFromRecordPrefix((const u8*)pPayload->pKey,
-                                 (int)pPayload->nKey,
-                                 splitKey ? nKeyField : 0,
-                                 &pSortKey, &nSortKey);
+    rc = sortKeyFromRecordPrefixColl((const u8*)pPayload->pKey,
+                                      (int)pPayload->nKey,
+                                      splitKey ? nKeyField : 0,
+                                      pCur->pKeyInfo,
+                                      &pSortKey, &nSortKey);
     if( rc==SQLITE_OK ){
       if( splitKey ){
         rc = prollyMutMapInsert(pCur->pMutMap,
@@ -4828,8 +4830,9 @@ static int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
          && pCur->pKeyInfo->nKeyField < pCur->pKeyInfo->nAllField ){
           nDelKeyField = (int)pCur->pKeyInfo->nKeyField;
         }
-        rc = sortKeyFromRecordPrefix(pCur->pCachedPayload, pCur->nCachedPayload,
-                                     nDelKeyField, &pSavedDelKey, &nSavedDelKey);
+        rc = sortKeyFromRecordPrefixColl(pCur->pCachedPayload, pCur->nCachedPayload,
+                                          nDelKeyField, pCur->pKeyInfo,
+                                          &pSavedDelKey, &nSavedDelKey);
         if( rc!=SQLITE_OK ) return rc;
         hasSavedKey = 1;
       }else if( prollyCursorIsValid(&pCur->pCur) ){

--- a/src/sortkey.c
+++ b/src/sortkey.c
@@ -44,22 +44,60 @@ static u8 serialTypeTag(u32 serialType){
   return SORTKEY_NULL;  
 }
 
-static int encodedFieldSize(u32 serialType, const u8 *pData, u32 nData){
+/* Collation identifiers. 0 = BINARY / unknown (no transform), 1 = NOCASE
+** (fold ASCII A-Z to a-z), 2 = RTRIM (strip trailing 0x20). Keyed from
+** the collation's zName at encode time — we avoid calling xCmp because
+** the encoder produces byte-comparable keys, not pair-wise comparisons,
+** and there's no general way to invert a custom xCmp into a transform. */
+#define SORTKEY_COLL_BINARY 0
+#define SORTKEY_COLL_NOCASE 1
+#define SORTKEY_COLL_RTRIM  2
+
+static int collFromKeyInfo(const KeyInfo *pKeyInfo, int iCol){
+  const CollSeq *pColl;
+  if( !pKeyInfo ) return SORTKEY_COLL_BINARY;
+  if( iCol < 0 || iCol >= pKeyInfo->nAllField ) return SORTKEY_COLL_BINARY;
+  pColl = pKeyInfo->aColl[iCol];
+  if( !pColl || !pColl->zName ) return SORTKEY_COLL_BINARY;
+  if( sqlite3StrICmp(pColl->zName, "NOCASE")==0 ) return SORTKEY_COLL_NOCASE;
+  if( sqlite3StrICmp(pColl->zName, "RTRIM")==0 ) return SORTKEY_COLL_RTRIM;
+  return SORTKEY_COLL_BINARY;
+}
+
+/* Return the effective byte length of pData/nData after applying the
+** given collation's transform. Pure byte counting — no allocation. */
+static u32 collTextLen(int coll, const u8 *pData, u32 nData){
+  if( coll==SORTKEY_COLL_RTRIM ){
+    while( nData > 0 && pData[nData - 1] == 0x20 ) nData--;
+  }
+  return nData;
+}
+
+static int encodedFieldSize(u32 serialType, const u8 *pData, u32 nData, int coll){
   u8 tag = serialTypeTag(serialType);
   switch( tag ){
     case SORTKEY_NULL:
       return 1;
     case SORTKEY_NUM:
       return 9;
-    case SORTKEY_TEXT:
+    case SORTKEY_TEXT: {
+      u32 n = collTextLen(coll, pData, nData);
+      int extra = 0;
+      u32 i;
+      for(i = 0; i < n; i++){
+        u8 b = pData[i];
+        if( coll==SORTKEY_COLL_NOCASE && b >= 'A' && b <= 'Z' ) b += 32;
+        if( b == 0x00 ) extra++;
+      }
+      return 1 + (int)n + extra + 2;
+    }
     case SORTKEY_BLOB: {
-      
       int extra = 0;
       u32 i;
       for(i = 0; i < nData; i++){
         if( pData[i] == 0x00 ) extra++;
       }
-      return 1 + (int)nData + extra + 2;  
+      return 1 + (int)nData + extra + 2;
     }
     default:
       return 1;
@@ -123,20 +161,46 @@ static int encodeVarLen(u8 *pOut, u8 tag, const u8 *pData, u32 nData){
     }
   }
 
-  
+
   pOut[pos++] = 0x00;
   pOut[pos++] = 0x00;
 
   return pos;
 }
 
+/* Write a TEXT sort-key field with the collation transform applied.
+** Matches encodedFieldSize's size arithmetic byte-for-byte so the
+** pre-computed output buffer is exactly the right size. */
+static int encodeText(u8 *pOut, const u8 *pData, u32 nData, int coll){
+  int pos = 0;
+  u32 n = collTextLen(coll, pData, nData);
+  pOut[pos++] = SORTKEY_TEXT;
+  for(u32 i = 0; i < n; i++){
+    u8 b = pData[i];
+    if( coll==SORTKEY_COLL_NOCASE && b >= 'A' && b <= 'Z' ) b += 32;
+    if( b == 0x00 ){
+      pOut[pos++] = 0x00;
+      pOut[pos++] = 0x01;
+    }else{
+      pOut[pos++] = b;
+    }
+  }
+  pOut[pos++] = 0x00;
+  pOut[pos++] = 0x00;
+  return pos;
+}
+
 /*
 ** Encode the first nMaxFields columns of pRec as a binary-comparable
 ** sort key. Pass nMaxFields = 0 (or any value larger than the field
-** count) to encode the whole record. Returns the encoded byte count, or
-** -1 on error.
+** count) to encode the whole record. When pKeyInfo is non-NULL, each
+** TEXT field is transformed by its declared collation before encoding
+** so a CASE-INSENSITIVE or RTRIM PK produces identical sort keys for
+** values that should be considered equal. Returns the encoded byte
+** count, or -1 on error.
 */
-static int sortKeyEncode(const u8 *pRec, int nRec, u8 *pOut, int nMaxFields){
+static int sortKeyEncode(const u8 *pRec, int nRec, u8 *pOut, int nMaxFields,
+                         const KeyInfo *pKeyInfo){
   u32 hdrSize;
   u32 hdrOff;
   u32 dataOff;
@@ -155,6 +219,7 @@ static int sortKeyEncode(const u8 *pRec, int nRec, u8 *pOut, int nMaxFields){
     u32 serialType;
     u32 fieldLen;
     const u8 *pField;
+    int coll;
 
     if( nMaxFields > 0 && nField >= nMaxFields ) break;
 
@@ -164,6 +229,7 @@ static int sortKeyEncode(const u8 *pRec, int nRec, u8 *pOut, int nMaxFields){
 
     if( dataOff + fieldLen > (u32)nRec ) return -1;
     pField = pRec + dataOff;
+    coll = collFromKeyInfo(pKeyInfo, nField);
 
     if( pOut ){
       u8 tag = serialTypeTag(serialType);
@@ -176,6 +242,8 @@ static int sortKeyEncode(const u8 *pRec, int nRec, u8 *pOut, int nMaxFields){
           outPos += 9;
           break;
         case SORTKEY_TEXT:
+          outPos += encodeText(pOut + outPos, pField, fieldLen, coll);
+          break;
         case SORTKEY_BLOB:
           outPos += encodeVarLen(pOut + outPos, tag, pField, fieldLen);
           break;
@@ -184,7 +252,7 @@ static int sortKeyEncode(const u8 *pRec, int nRec, u8 *pOut, int nMaxFields){
           break;
       }
     }else{
-      outPos += encodedFieldSize(serialType, pField, fieldLen);
+      outPos += encodedFieldSize(serialType, pField, fieldLen, coll);
     }
 
     dataOff += fieldLen;
@@ -195,7 +263,7 @@ static int sortKeyEncode(const u8 *pRec, int nRec, u8 *pOut, int nMaxFields){
 }
 
 int sortKeySize(const u8 *pRec, int nRec){
-  return sortKeyEncode(pRec, nRec, NULL, 0);
+  return sortKeyEncode(pRec, nRec, NULL, 0, NULL);
 }
 
 int sortKeyFromRecord(const u8 *pRec, int nRec, u8 **ppOut, int *pnOut){
@@ -205,13 +273,20 @@ int sortKeyFromRecord(const u8 *pRec, int nRec, u8 **ppOut, int *pnOut){
 int sortKeyFromRecordPrefix(
   const u8 *pRec, int nRec, int nKeyField, u8 **ppOut, int *pnOut
 ){
+  return sortKeyFromRecordPrefixColl(pRec, nRec, nKeyField, NULL, ppOut, pnOut);
+}
+
+int sortKeyFromRecordPrefixColl(
+  const u8 *pRec, int nRec, int nKeyField, const KeyInfo *pKeyInfo,
+  u8 **ppOut, int *pnOut
+){
   int nSize;
   u8 *pBuf;
 
   *ppOut = 0;
   *pnOut = 0;
 
-  nSize = sortKeyEncode(pRec, nRec, NULL, nKeyField);
+  nSize = sortKeyEncode(pRec, nRec, NULL, nKeyField, pKeyInfo);
   if( nSize < 0 ) return SQLITE_CORRUPT;
   if( nSize == 0 ){
 
@@ -224,7 +299,7 @@ int sortKeyFromRecordPrefix(
   pBuf = (u8*)sqlite3_malloc(nSize);
   if( !pBuf ) return SQLITE_NOMEM;
 
-  sortKeyEncode(pRec, nRec, pBuf, nKeyField);
+  sortKeyEncode(pRec, nRec, pBuf, nKeyField, pKeyInfo);
 
   *ppOut = pBuf;
   *pnOut = nSize;

--- a/src/sortkey.h
+++ b/src/sortkey.h
@@ -24,6 +24,25 @@ int sortKeyFromRecord(const u8 *pRec, int nRec, u8 **ppOut, int *pnOut);
 int sortKeyFromRecordPrefix(const u8 *pRec, int nRec, int nKeyField,
                             u8 **ppOut, int *pnOut);
 
+/*
+** Collation-aware variant. When pKeyInfo is non-NULL, each encoded TEXT
+** column is transformed according to its declared collation before
+** being written into the sort key:
+**
+**   BINARY  — no transform (default)
+**   NOCASE  — ASCII A-Z folded to a-z so 'Alice' and 'alice' produce
+**             the same sort key
+**   RTRIM   — trailing 0x20 bytes stripped so 'abc' and 'abc ' produce
+**             the same sort key
+**
+** Any other collation (user-defined, etc.) falls back to BINARY because
+** the prolly tree can't pair-wise invoke xCmp at key-encode time. Pass
+** pKeyInfo=NULL to get the legacy byte-level encoding.
+*/
+int sortKeyFromRecordPrefixColl(const u8 *pRec, int nRec, int nKeyField,
+                                 const KeyInfo *pKeyInfo,
+                                 u8 **ppOut, int *pnOut);
+
 int sortKeySize(const u8 *pRec, int nRec);
 
 int recordFromSortKey(const u8 *pSortKey, int nSortKey, u8 **ppOut, int *pnOut);

--- a/test/oracle_without_rowid_test.sh
+++ b/test/oracle_without_rowid_test.sh
@@ -1,0 +1,471 @@
+#!/bin/bash
+#
+# Oracle test: WITHOUT ROWID tables against stock SQLite.
+#
+# doltlite keys the prolly btree on the user PK for every table —
+# not on sqlite's auto-allocated rowid — so a WITHOUT ROWID
+# declaration is closer to a no-op here than in stock sqlite. That
+# makes this oracle especially pointed at:
+#
+#   - the few SQL-level behaviors that WITHOUT ROWID genuinely
+#     changes (no rowid column; INTEGER PRIMARY KEY is NOT a rowid
+#     alias; AUTOINCREMENT is illegal; PK columns become NOT NULL
+#     effectively via "PRIMARY KEY implies NOT NULL" in WITHOUT
+#     ROWID — in plain tables it still allows NULL),
+#   - composite PK shapes (WITHOUT ROWID was invented to support
+#     these efficiently; the prolly btree key encoder has to match),
+#   - TEXT / BLOB PKs with non-default collations,
+#   - PK updates, where stock sqlite has to delete + re-insert the
+#     row record while doltlite's prolly mutate does the same work
+#     via a different code path,
+#   - interactions with generated columns, triggers, FKs, and
+#     savepoints that we've previously oracled on rowid tables.
+#
+# Oracle target is stock sqlite3 built from the same source tree so
+# both engines parse identical SQL and the only variable is the
+# storage layer.
+#
+# Usage: bash oracle_without_rowid_test.sh [doltlite] [sqlite3]
+#
+
+set -u
+
+DOLTLITE="${1:-./doltlite}"
+SQLITE3="${2:-./sqlite3}"
+TMPROOT=$(mktemp -d)
+trap "rm -rf $TMPROOT" EXIT
+pass=0; fail=0
+FAILED_NAMES=""
+
+normalize() {
+  tr -d '\r' \
+    | sed -e 's/[[:space:]]\{1,\}/ /g' -e 's/^ //' -e 's/ $//' \
+          -e 's/^Runtime error /Error /' \
+          -e 's/^Error: in prepare, / /' \
+          -e 's/ ([0-9]*)$//'
+}
+
+oracle() {
+  local name="$1" sql="$2"
+  local dir="$TMPROOT/$name"
+  mkdir -p "$dir/dl" "$dir/sq"
+
+  local dl_out
+  dl_out=$(printf '%s\n' "$sql" | "$DOLTLITE" "$dir/dl/db" 2>&1 | normalize)
+
+  local sq_out
+  sq_out=$(printf '%s\n' "$sql" | "$SQLITE3" "$dir/sq/db" 2>&1 | normalize)
+
+  if [ "$dl_out" = "$sq_out" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite:"; echo "$dl_out" | sed 's/^/      /'
+    echo "    sqlite3:";  echo "$sq_out" | sed 's/^/      /'
+  fi
+}
+
+echo "=== Oracle Tests: WITHOUT ROWID ==="
+echo ""
+
+# ─── Basic round-trip ──────────────────────────────────────────────
+echo "--- basic round-trip ---"
+
+# Simple single-column PK.
+oracle "int_pk_basic" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT) WITHOUT ROWID;
+INSERT INTO t VALUES(1, 'a'), (2, 'b'), (3, 'c');
+SELECT id, v FROM t ORDER BY id;
+"
+
+# TEXT PK.
+oracle "text_pk_basic" "
+CREATE TABLE t(k TEXT PRIMARY KEY, v INT) WITHOUT ROWID;
+INSERT INTO t VALUES('apple', 1), ('banana', 2), ('cherry', 3);
+SELECT k, v FROM t ORDER BY k;
+"
+
+# BLOB PK.
+oracle "blob_pk_basic" "
+CREATE TABLE t(k BLOB PRIMARY KEY, v INT) WITHOUT ROWID;
+INSERT INTO t VALUES(x'01', 1), (x'02', 2), (x'0f', 3);
+SELECT hex(k), v FROM t ORDER BY k;
+"
+
+# Ordering relies on the PK comparator — reverse-ordered INSERT,
+# natural SELECT order.
+oracle "int_pk_sorted_on_scan" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT) WITHOUT ROWID;
+INSERT INTO t VALUES(3,30),(1,10),(2,20);
+SELECT id, v FROM t;
+"
+
+# ─── rowid column absence ──────────────────────────────────────────
+echo "--- rowid column absence ---"
+
+# Referring to rowid in a WITHOUT ROWID table is an error in stock
+# sqlite (rowid is not a column). Both engines should reject it.
+oracle "select_rowid_rejected" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT) WITHOUT ROWID;
+INSERT INTO t VALUES(1, 10);
+SELECT rowid FROM t;
+"
+
+oracle "select_oid_rejected" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT) WITHOUT ROWID;
+INSERT INTO t VALUES(1, 10);
+SELECT oid FROM t;
+"
+
+# SELECT * must NOT include a rowid column for a WITHOUT ROWID table
+# (it doesn't include one for plain tables either, but pin it here).
+oracle "select_star_no_rowid_column" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT) WITHOUT ROWID;
+INSERT INTO t VALUES(1, 10), (2, 20);
+SELECT * FROM t ORDER BY id;
+"
+
+# ─── INTEGER PRIMARY KEY is NOT a rowid alias ──────────────────────
+echo "--- integer PK semantics ---"
+
+# In a WITHOUT ROWID table, INTEGER PRIMARY KEY is a regular
+# integer-typed column. It is still UNIQUE (PK), but it does NOT
+# alias rowid, which means INSERT does not auto-allocate a value,
+# and AUTOINCREMENT is not allowed.
+oracle "int_pk_without_rowid_no_autoalloc" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT) WITHOUT ROWID;
+INSERT INTO t(v) VALUES('a');
+SELECT id, v FROM t;
+"
+
+# AUTOINCREMENT is illegal on WITHOUT ROWID.
+oracle "autoincrement_rejected" "
+CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT, v TEXT) WITHOUT ROWID;
+SELECT 1;
+"
+
+# ─── PRIMARY KEY implies NOT NULL ──────────────────────────────────
+echo "--- PK implies NOT NULL ---"
+
+# A quirk of stock sqlite: in a plain (rowid) table, a non-INTEGER
+# PRIMARY KEY column allows NULL values. In a WITHOUT ROWID table
+# the PK is strictly NOT NULL. Both engines should match.
+oracle "text_pk_null_rejected" "
+CREATE TABLE t(k TEXT PRIMARY KEY, v INT) WITHOUT ROWID;
+INSERT INTO t VALUES(NULL, 1);
+SELECT count(*) FROM t;
+"
+
+oracle "composite_pk_null_half_rejected" "
+CREATE TABLE t(a INT, b INT, v INT, PRIMARY KEY(a, b)) WITHOUT ROWID;
+INSERT INTO t VALUES(1, NULL, 10);
+SELECT count(*) FROM t;
+"
+
+# ─── Composite PK ──────────────────────────────────────────────────
+echo "--- composite PK ---"
+
+oracle "composite_int_pk_round_trip" "
+CREATE TABLE t(a INT, b INT, v TEXT, PRIMARY KEY(a, b)) WITHOUT ROWID;
+INSERT INTO t VALUES(1, 1, 'a'),(1, 2, 'b'),(2, 1, 'c'),(2, 2, 'd');
+SELECT a, b, v FROM t ORDER BY a, b;
+"
+
+oracle "composite_text_int_pk" "
+CREATE TABLE t(region TEXT, code INT, v TEXT, PRIMARY KEY(region, code)) WITHOUT ROWID;
+INSERT INTO t VALUES
+  ('us', 1, 'a'), ('us', 2, 'b'),
+  ('eu', 1, 'c'), ('eu', 2, 'd');
+SELECT region, code, v FROM t ORDER BY region, code;
+"
+
+oracle "composite_pk_range_scan" "
+CREATE TABLE t(a INT, b INT, v INT, PRIMARY KEY(a, b)) WITHOUT ROWID;
+INSERT INTO t VALUES(1,1,11),(1,2,12),(2,1,21),(2,2,22),(3,1,31);
+SELECT a, b, v FROM t WHERE a = 2 ORDER BY b;
+"
+
+# Duplicate composite PK must be rejected.
+oracle "composite_pk_dup_rejected" "
+CREATE TABLE t(a INT, b INT, v TEXT, PRIMARY KEY(a, b)) WITHOUT ROWID;
+INSERT INTO t VALUES(1, 1, 'a');
+INSERT INTO t VALUES(1, 1, 'b');
+SELECT a, b, v FROM t;
+"
+
+# ─── PK with collation ─────────────────────────────────────────────
+echo "--- PK collation ---"
+
+# NOCASE collation on a TEXT PK: 'Alice' and 'alice' collide.
+oracle "text_pk_nocase" "
+CREATE TABLE t(k TEXT PRIMARY KEY COLLATE NOCASE, v INT) WITHOUT ROWID;
+INSERT INTO t VALUES('Alice', 1);
+INSERT INTO t VALUES('alice', 2);
+SELECT k, v FROM t ORDER BY k;
+"
+
+# RTRIM collation.
+oracle "text_pk_rtrim" "
+CREATE TABLE t(k TEXT PRIMARY KEY COLLATE RTRIM, v INT) WITHOUT ROWID;
+INSERT INTO t VALUES('abc', 1);
+INSERT INTO t VALUES('abc ', 2);
+SELECT k, v FROM t;
+"
+
+# ─── UPDATE the PK ─────────────────────────────────────────────────
+echo "--- UPDATE PK ---"
+
+# UPDATE that changes the PK: row is effectively deleted + inserted
+# under the new key. In the prolly btree this flows through the
+# mutmap as an INSERT of the new key and a DELETE of the old.
+oracle "update_pk_same_row" "
+CREATE TABLE t(k INT PRIMARY KEY, v TEXT) WITHOUT ROWID;
+INSERT INTO t VALUES(1, 'a'),(2, 'b');
+UPDATE t SET k = 99 WHERE k = 1;
+SELECT k, v FROM t ORDER BY k;
+"
+
+# UPDATE composite PK half.
+oracle "update_composite_pk_half" "
+CREATE TABLE t(a INT, b INT, v TEXT, PRIMARY KEY(a, b)) WITHOUT ROWID;
+INSERT INTO t VALUES(1, 1, 'a'),(1, 2, 'b'),(2, 1, 'c');
+UPDATE t SET a = 10 WHERE a = 1 AND b = 1;
+SELECT a, b, v FROM t ORDER BY a, b;
+"
+
+# UPDATE that would collide with an existing PK is rejected.
+oracle "update_pk_to_existing_collides" "
+CREATE TABLE t(k INT PRIMARY KEY, v TEXT) WITHOUT ROWID;
+INSERT INTO t VALUES(1, 'a'),(2, 'b');
+UPDATE t SET k = 2 WHERE k = 1;
+SELECT k, v FROM t ORDER BY k;
+"
+
+# ─── REPLACE / UPSERT ──────────────────────────────────────────────
+echo "--- REPLACE / UPSERT ---"
+
+oracle "replace_into_without_rowid" "
+CREATE TABLE t(k INT PRIMARY KEY, v TEXT) WITHOUT ROWID;
+INSERT INTO t VALUES(1, 'a');
+REPLACE INTO t VALUES(1, 'b');
+SELECT k, v FROM t;
+"
+
+oracle "upsert_do_update_without_rowid" "
+CREATE TABLE t(k INT PRIMARY KEY, v TEXT) WITHOUT ROWID;
+INSERT INTO t VALUES(1, 'a');
+INSERT INTO t VALUES(1, 'b') ON CONFLICT(k) DO UPDATE SET v = excluded.v;
+SELECT k, v FROM t;
+"
+
+oracle "upsert_do_nothing_without_rowid" "
+CREATE TABLE t(k INT PRIMARY KEY, v TEXT) WITHOUT ROWID;
+INSERT INTO t VALUES(1, 'a');
+INSERT INTO t VALUES(1, 'b') ON CONFLICT(k) DO NOTHING;
+SELECT k, v FROM t;
+"
+
+# Composite UPSERT target.
+oracle "composite_upsert_do_update" "
+CREATE TABLE t(a INT, b INT, v INT, PRIMARY KEY(a, b)) WITHOUT ROWID;
+INSERT INTO t VALUES(1, 1, 10);
+INSERT INTO t VALUES(1, 1, 999)
+  ON CONFLICT(a, b) DO UPDATE SET v = excluded.v;
+SELECT a, b, v FROM t;
+"
+
+# ─── Secondary indexes ─────────────────────────────────────────────
+echo "--- secondary indexes ---"
+
+oracle "secondary_index_on_without_rowid" "
+CREATE TABLE t(k INT PRIMARY KEY, tag TEXT, v INT) WITHOUT ROWID;
+CREATE INDEX idx_tag ON t(tag);
+INSERT INTO t VALUES(1, 'a', 10),(2, 'b', 20),(3, 'a', 30);
+SELECT k, v FROM t WHERE tag = 'a' ORDER BY k;
+"
+
+oracle "unique_secondary_index_on_without_rowid" "
+CREATE TABLE t(k INT PRIMARY KEY, u INT, v INT) WITHOUT ROWID;
+CREATE UNIQUE INDEX idx_u ON t(u);
+INSERT INTO t VALUES(1, 100, 'a');
+INSERT INTO t VALUES(2, 100, 'b');
+SELECT k, u FROM t ORDER BY k;
+"
+
+# ─── Aggregates, joins, ORDER BY ───────────────────────────────────
+echo "--- aggregates / joins ---"
+
+oracle "aggregate_over_without_rowid" "
+CREATE TABLE t(k INT PRIMARY KEY, v INT) WITHOUT ROWID;
+INSERT INTO t VALUES(1,10),(2,20),(3,30),(4,40);
+SELECT count(*), sum(v), min(v), max(v) FROM t;
+"
+
+oracle "join_two_without_rowid_tables" "
+CREATE TABLE a(k INT PRIMARY KEY, x INT) WITHOUT ROWID;
+CREATE TABLE b(k INT PRIMARY KEY, y INT) WITHOUT ROWID;
+INSERT INTO a VALUES(1, 10), (2, 20);
+INSERT INTO b VALUES(1, 100), (2, 200);
+SELECT a.k, a.x, b.y FROM a JOIN b USING (k) ORDER BY a.k;
+"
+
+# Join between a rowid table and a WITHOUT ROWID table.
+oracle "join_mixed_rowid_and_without" "
+CREATE TABLE a(k INT PRIMARY KEY, x INT);
+CREATE TABLE b(k INT PRIMARY KEY, y INT) WITHOUT ROWID;
+INSERT INTO a VALUES(1, 10),(2, 20);
+INSERT INTO b VALUES(1, 100),(2, 200);
+SELECT a.k, a.x, b.y FROM a JOIN b USING (k) ORDER BY a.k;
+"
+
+# ─── FK interactions ──────────────────────────────────────────────
+echo "--- FK interactions ---"
+
+# FK from a WITHOUT ROWID child to a WITHOUT ROWID parent.
+oracle "fk_without_rowid_parent_and_child" "
+PRAGMA foreign_keys = ON;
+CREATE TABLE p(k INT PRIMARY KEY, name TEXT) WITHOUT ROWID;
+CREATE TABLE c(id INT PRIMARY KEY,
+  pk INT REFERENCES p(k) ON DELETE CASCADE) WITHOUT ROWID;
+INSERT INTO p VALUES(1, 'a'), (2, 'b');
+INSERT INTO c VALUES(10, 1), (11, 1), (12, 2);
+DELETE FROM p WHERE k = 1;
+SELECT k FROM p ORDER BY k;
+SELECT id, pk FROM c ORDER BY id;
+"
+
+# Composite-PK parent with FK from a plain child.
+oracle "fk_to_composite_pk_parent" "
+PRAGMA foreign_keys = ON;
+CREATE TABLE p(region TEXT, code INT, PRIMARY KEY(region, code)) WITHOUT ROWID;
+CREATE TABLE c(id INT PRIMARY KEY, region TEXT, code INT,
+  FOREIGN KEY(region, code) REFERENCES p(region, code) ON DELETE CASCADE);
+INSERT INTO p VALUES('us', 1), ('us', 2);
+INSERT INTO c VALUES(10, 'us', 1), (11, 'us', 1), (12, 'us', 2);
+DELETE FROM p WHERE code = 1;
+SELECT region, code FROM p;
+SELECT id FROM c ORDER BY id;
+"
+
+# ─── Triggers ─────────────────────────────────────────────────────
+echo "--- triggers ---"
+
+oracle "trigger_before_insert_on_without_rowid" "
+CREATE TABLE t(k INT PRIMARY KEY, v INT) WITHOUT ROWID;
+CREATE TABLE log(id INTEGER PRIMARY KEY AUTOINCREMENT, k INT, v INT);
+CREATE TRIGGER bi BEFORE INSERT ON t BEGIN
+  INSERT INTO log(k, v) VALUES(new.k, new.v);
+END;
+INSERT INTO t VALUES(1, 10), (2, 20);
+SELECT k, v FROM t ORDER BY k;
+SELECT k, v FROM log ORDER BY id;
+"
+
+oracle "trigger_after_update_on_without_rowid" "
+CREATE TABLE t(k INT PRIMARY KEY, v INT) WITHOUT ROWID;
+CREATE TABLE log(id INTEGER PRIMARY KEY AUTOINCREMENT, old_v INT, new_v INT);
+CREATE TRIGGER au AFTER UPDATE ON t BEGIN
+  INSERT INTO log(old_v, new_v) VALUES(old.v, new.v);
+END;
+INSERT INTO t VALUES(1, 10);
+UPDATE t SET v = 99 WHERE k = 1;
+SELECT old_v, new_v FROM log;
+"
+
+# ─── Generated columns ────────────────────────────────────────────
+echo "--- generated columns ---"
+
+oracle "stored_generated_on_without_rowid" "
+CREATE TABLE t(
+  k INT PRIMARY KEY,
+  a INT,
+  doubled INT GENERATED ALWAYS AS (a * 2) STORED
+) WITHOUT ROWID;
+INSERT INTO t(k, a) VALUES(1, 5), (2, 10);
+SELECT k, a, doubled FROM t ORDER BY k;
+"
+
+oracle "virtual_generated_on_without_rowid" "
+CREATE TABLE t(
+  k INT PRIMARY KEY,
+  a INT,
+  doubled INT GENERATED ALWAYS AS (a * 2) VIRTUAL
+) WITHOUT ROWID;
+INSERT INTO t(k, a) VALUES(1, 5);
+SELECT k, a, doubled FROM t;
+"
+
+# ─── Savepoint interaction ────────────────────────────────────────
+echo "--- savepoint ---"
+
+oracle "rollback_to_savepoint_without_rowid" "
+CREATE TABLE t(k INT PRIMARY KEY, v TEXT) WITHOUT ROWID;
+INSERT INTO t VALUES(1, 'a');
+SAVEPOINT s;
+INSERT INTO t VALUES(2, 'b');
+UPDATE t SET v = 'z' WHERE k = 1;
+ROLLBACK TO SAVEPOINT s;
+RELEASE SAVEPOINT s;
+SELECT k, v FROM t ORDER BY k;
+"
+
+# Nested savepoint: inner rollback should keep outer inserts.
+oracle "nested_savepoint_without_rowid" "
+CREATE TABLE t(k INT PRIMARY KEY, v INT) WITHOUT ROWID;
+SAVEPOINT s1;
+INSERT INTO t VALUES(1, 10);
+SAVEPOINT s2;
+INSERT INTO t VALUES(2, 20);
+ROLLBACK TO SAVEPOINT s2;
+RELEASE SAVEPOINT s2;
+RELEASE SAVEPOINT s1;
+SELECT k, v FROM t ORDER BY k;
+"
+
+# ─── Bulk ─────────────────────────────────────────────────────────
+echo "--- bulk ---"
+
+make_inserts() {
+  local n="$1"
+  local i
+  for i in $(seq 1 "$n"); do
+    echo "INSERT INTO t VALUES($i, 'row-$i');"
+  done
+}
+
+oracle "bulk_100_rows_int_pk" "
+CREATE TABLE t(k INT PRIMARY KEY, v TEXT) WITHOUT ROWID;
+$(make_inserts 100)
+SELECT count(*) FROM t;
+SELECT k, v FROM t WHERE k = 50;
+SELECT k, v FROM t WHERE k BETWEEN 95 AND 100 ORDER BY k;
+"
+
+make_composite_inserts() {
+  local n="$1"
+  local i
+  for i in $(seq 1 "$n"); do
+    echo "INSERT INTO t VALUES(1, $i, 'even-$i');"
+    echo "INSERT INTO t VALUES(2, $i, 'odd-$i');"
+  done
+}
+
+oracle "bulk_composite_pk" "
+CREATE TABLE t(a INT, b INT, v TEXT, PRIMARY KEY(a, b)) WITHOUT ROWID;
+$(make_composite_inserts 50)
+SELECT count(*) FROM t;
+SELECT v FROM t WHERE a = 2 AND b = 25;
+SELECT count(*) FROM t WHERE a = 1;
+"
+
+# ─── Final report ───────────────────────────────────────────────────
+
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+if [ "$fail" -gt 0 ]; then
+  echo "Failed:$FAILED_NAMES"
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
Two commits: a storage-layer **fix** in the sortkey encoder for `COLLATE NOCASE` / `RTRIM` on TEXT primary keys (a silent-data-corruption bug the oracle surfaced), and then the 39-scenario WITHOUT ROWID oracle that re-enables the passing state.

## Commit 1 — `sortkey: honor NOCASE/RTRIM collations on TEXT PK columns`

### The bug

doltlite keys the prolly btree on the user PK via a byte-comparable sort key built by `sortKeyFromRecordPrefix`. The encoder was `memcmp`-only, so a table with a collated TEXT PK would let two values SQL considers equal live in the tree as distinct rows:

\`\`\`sql
CREATE TABLE t(k TEXT PRIMARY KEY COLLATE NOCASE);
INSERT INTO t VALUES('Alice');  -- ok
INSERT INTO t VALUES('alice');  -- should be UNIQUE violation
-- doltlite silently accepted both
\`\`\`

`SELECT WHERE k = 'ALICE'` and `UPDATE WHERE k = 'ALICE'` were already correct because the VDBE's WHERE-clause evaluator dispatches to the collation's `xCmp`. Only the PK-uniqueness check went through the byte-level prolly comparator.

This affects **both** rowid and WITHOUT ROWID tables — doltlite uses the same user-PK storage for everything, so every `COLLATE NOCASE` / `COLLATE RTRIM` TEXT PK was affected.

### The fix

The encoder produces a one-shot byte sequence, not pair-wise comparisons, so it can't invoke `xCmp`. Instead, preprocess the text bytes for the built-in collations before encoding:

| Collation | Transform |
|---|---|
| `BINARY` (default) | no transform |
| `NOCASE` | fold ASCII A-Z → a-z |
| `RTRIM` | strip trailing 0x20 bytes |

Any other (user-defined) collation falls back to BINARY — matching the existing behavior for those paths. Users who need a custom collation on a PK will keep seeing the old byte-level ordering and are no worse off than before.

New `sortKeyFromRecordPrefixColl(..., const KeyInfo *pKeyInfo, ...)` is the threaded variant. The legacy `sortKeyFromRecordPrefix` forwards with `pKeyInfo=NULL`. `prolly_btree.c` passes `pCur->pKeyInfo` through the four call sites: `xIndexMoveto`, `xInsert`, the MutMap seek path, and the delete-save path.

### Breaking change

**This is an on-disk format change.** Existing databases with `COLLATE NOCASE` or `COLLATE RTRIM` TEXT PKs stored their keys with the old byte-level encoding, so the new encoder will not find them. Per the user direction on this PR, the fix will ship with a **major version bump** rather than an automatic migration — older files will need to be dumped and re-imported.

## Commit 2 — `test: WITHOUT ROWID oracle vs stock sqlite3`

39 scenarios. This oracle was what surfaced the collation bug — the two `text_pk_nocase` and `text_pk_rtrim` scenarios fail on master and pass after the sortkey fix.

| Section | Scenarios |
|---|---|
| **basic round-trip** | INT / TEXT / BLOB PKs, natural ordering regardless of insert order |
| **rowid absence** | `SELECT rowid` / `oid` rejected, `SELECT *` does not include a rowid column |
| **INTEGER PK semantics** | no auto-allocation, `AUTOINCREMENT` rejected |
| **PK implies NOT NULL** | TEXT PK NULL rejected, composite PK NULL-half rejected |
| **composite PK** | (INT, INT), (TEXT, INT), range scan, duplicate rejection |
| **PK collation** | NOCASE and RTRIM uniqueness (**this is the fix**) |
| **UPDATE PK** | single, composite half, collision rejected |
| **REPLACE / UPSERT** | REPLACE INTO, DO UPDATE, DO NOTHING, composite target |
| **secondary indexes** | seek + unique on WITHOUT ROWID |
| **aggregates / joins** | aggregates, WITHOUT ROWID × WITHOUT ROWID join, rowid × WITHOUT ROWID mixed join |
| **FK interactions** | WITHOUT ROWID parent + child, composite-PK parent with CASCADE |
| **triggers** | BEFORE INSERT, AFTER UPDATE |
| **generated columns** | STORED + VIRTUAL inside WITHOUT ROWID |
| **savepoint** | ROLLBACK TO, nested savepoint |
| **bulk** | 100-row INT PK, 100-row composite PK |

## Test plan

- [x] `bash test/oracle_without_rowid_test.sh ./doltlite ./sqlite3` — 39/39 (was 37/39 with the bug)
- [x] `bash test/oracle_savepoints_test.sh ./doltlite ./sqlite3` — 43/43
- [x] `bash test/oracle_foreign_keys_test.sh ./doltlite ./sqlite3` — 45/45
- [x] `bash test/oracle_upsert_test.sh ./doltlite ./sqlite3` — 35/35
- [x] `bash test/oracle_triggers_test.sh ./doltlite ./sqlite3` — 27/27
- [x] `bash test/sql_oracle_test.sh ./doltlite ./sqlite3` — 526/526
- [x] `bash test/correctness_test.sh ./doltlite` — 41/41
- [x] `bash test/diff_test.sh ./doltlite` — 41/41
- [x] `bash test/index_test.sh ./doltlite` — 30/30

🤖 Generated with [Claude Code](https://claude.com/claude-code)