### PR TITLE
bench: tighten sysbench ceiling from 6x to 4x

### DIFF
--- a/test/sysbench_compare.sh
+++ b/test/sysbench_compare.sh
@@ -336,7 +336,7 @@ echo "_${ROWS} rows, single CLI invocation per test, workload-only timing via SQ
 # ============================================================
 # Enforce performance ceiling (exit 1 if any test exceeds limit)
 # ============================================================
-MAX_MULTIPLIER=${BENCH_MAX_MULTIPLIER:-6}
+MAX_MULTIPLIER=${BENCH_MAX_MULTIPLIER:-4}
 
 check_ceiling() {
   local tests="$1" db_sq="$2" db_dl="$3"


### PR DESCRIPTION
Post the oltp_read_write pending-ownership speedup in #427, there's room to tighten the ceiling. Latest master benchmark run:

| Test | Master ratio | Headroom under 4x |
|---|---|---|
| oltp_update_index | 2.98–3.22x | ~0.78x |
| oltp_delete_insert | 2.52–2.58x | ~1.42x |
| oltp_write_only | 1.90–2.24x | ~1.76x |
| oltp_read_write | 1.40–1.66x | ~2.34x |
| oltp_insert | 1.80–2.00x | ~2.00x |
| oltp_bulk_insert | 1.35–1.50x | ~2.50x |

Worst case is `oltp_update_index` at ~3.22x. A 4x ceiling gives it roughly 0.78x of headroom — enough to absorb GitHub runner noise while catching any real regression above ~25%.

6x was appropriate when we were stacking savepoint / collation / FK fixes and needed slack. Now that the dust has settled and #427 locked in the big `oltp_read_write` win (was 2.45–3.65x, now 1.40–1.66x), 4x correctly reflects where we actually are.

`BENCH_MAX_MULTIPLIER` env var still overrides the default for anyone wanting a looser local run.

## Test plan

- [x] Master's most recent benchmark run (#24368226343) passes at 4x by the margins in the table above
- [ ] CI benchmark on this PR should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)