### PR TITLE
Speed up secondary index mutmap writes

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -335,7 +335,9 @@ struct BtCursor {
   /* Merge iteration state: mmIdx indexes into the mutmap's sorted order.
   ** mergeSrc says where the current row comes from. */
   int mmIdx;
+  int mmPhysIdx;           /* Physical mutmap entry index for exact hits */
   u8 mmActive;
+  u8 mmPhysActive;
 #define MERGE_SRC_TREE  0
 #define MERGE_SRC_MUT   1
 #define MERGE_SRC_BOTH  2   /* Same key in tree and MutMap; MutMap wins */
@@ -1081,15 +1083,44 @@ static int cacheCursorPayloadCopy(BtCursor *pCur, const u8 *pData, int nData){
 
 static void clearMergeCursorState(BtCursor *pCur){
   pCur->mmIdx = -1;
+  pCur->mmPhysIdx = -1;
   pCur->mmActive = 0;
+  pCur->mmPhysActive = 0;
   pCur->mergeSrc = MERGE_SRC_TREE;
+}
+
+static ProllyMutMapEntry *currentMutMapEntry(BtCursor *pCur){
+  if( pCur->mmPhysActive ){
+    return &pCur->pMutMap->aEntries[pCur->mmPhysIdx];
+  }
+  return prollyMutMapEntryAt(pCur->pMutMap, pCur->mmIdx);
+}
+
+static void setCursorToMutMapEntryPhys(BtCursor *pCur, int physIdx){
+  ProllyMutMapEntry *pEntry = &pCur->pMutMap->aEntries[physIdx];
+  CLEAR_CACHED_PAYLOAD(pCur);
+  pCur->mmIdx = -1;
+  pCur->mmPhysIdx = physIdx;
+  pCur->mmActive = 1;
+  pCur->mmPhysActive = 1;
+  pCur->mergeSrc = MERGE_SRC_MUT;
+  pCur->eState = CURSOR_VALID;
+  pCur->curFlags &= ~BTCF_AtLast;
+  if( pCur->curIntKey ){
+    pCur->cachedIntKey = pEntry->intKey;
+    pCur->curFlags |= BTCF_ValidNKey;
+  }else{
+    pCur->curFlags &= ~BTCF_ValidNKey;
+  }
 }
 
 static void setCursorToMutMapEntry(BtCursor *pCur, int idx){
   ProllyMutMapEntry *pEntry = prollyMutMapEntryAt(pCur->pMutMap, idx);
   CLEAR_CACHED_PAYLOAD(pCur);
   pCur->mmIdx = idx;
+  pCur->mmPhysIdx = -1;
   pCur->mmActive = 1;
+  pCur->mmPhysActive = 0;
   pCur->mergeSrc = MERGE_SRC_MUT;
   pCur->eState = CURSOR_VALID;
   pCur->curFlags &= ~BTCF_AtLast;
@@ -1223,6 +1254,8 @@ static int syncSavepoints(BtCursor *pCur){
 
 static int ensureMutMap(BtCursor *pCur){
   int rc;
+  struct TableEntry *pTE;
+  int keepSorted;
   if( pCur->pMutMap ){
     return SQLITE_OK;
   }
@@ -1230,7 +1263,9 @@ static int ensureMutMap(BtCursor *pCur){
   if( !pCur->pMutMap ){
     return SQLITE_NOMEM;
   }
-  rc = prollyMutMapInit(pCur->pMutMap, pCur->curIntKey);
+  pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
+  keepSorted = tableEntryIsTableRoot(pCur->pBtree, pTE);
+  rc = prollyMutMapInitMode(pCur->pMutMap, pCur->curIntKey, (u8)keepSorted);
   if( rc!=SQLITE_OK ){
     sqlite3_free(pCur->pMutMap);
     pCur->pMutMap = 0;
@@ -1271,7 +1306,7 @@ static int saveCursorPosition(BtCursor *pCur){
   if( pCur->curIntKey ){
     if( pCur->mmActive
      && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
-      pCur->nKey = prollyMutMapEntryAt(pCur->pMutMap, pCur->mmIdx)->intKey;
+      pCur->nKey = currentMutMapEntry(pCur)->intKey;
     }else{
       pCur->nKey = prollyCursorIntKey(&pCur->pCur);
     }
@@ -1281,7 +1316,7 @@ static int saveCursorPosition(BtCursor *pCur){
     int nKey = 0;
     if( pCur->mmActive
      && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
-      ProllyMutMapEntry *pEntry = prollyMutMapEntryAt(pCur->pMutMap, pCur->mmIdx);
+      ProllyMutMapEntry *pEntry = currentMutMapEntry(pCur);
       pKey = pEntry->pKey;
       nKey = pEntry->nKey;
     }else{
@@ -1453,7 +1488,7 @@ static int allocEmptyPendingLike(ProllyMutMap *pSrc, ProllyMutMap **ppOut){
   *ppOut = 0;
   pNew = sqlite3_malloc(sizeof(ProllyMutMap));
   if( !pNew ) return SQLITE_NOMEM;
-  rc = prollyMutMapInit(pNew, pSrc->isIntKey);
+  rc = prollyMutMapInitMode(pNew, pSrc->isIntKey, pSrc->keepSorted);
   if( rc!=SQLITE_OK ){
     sqlite3_free(pNew);
     return rc;
@@ -3318,6 +3353,12 @@ static int mergeCompare(BtCursor *pCur, ProllyMutMapEntry *e){
 ** If pRes is non-NULL (mergeFirst/mergeLast), sets *pRes=1 if empty.
 ** If pRes is NULL (mergeStep), returns SQLITE_DONE if exhausted. */
 static int mergeScan(BtCursor *pCur, int dir, int *pRes){
+  if( pCur->mmPhysActive ){
+    pCur->mmIdx = prollyMutMapOrderIndexFromEntry(
+        pCur->pMutMap, &pCur->pMutMap->aEntries[pCur->mmPhysIdx]);
+    pCur->mmPhysIdx = -1;
+    pCur->mmPhysActive = 0;
+  }
   for(;;){
     int treeOk = (pCur->pCur.eState==PROLLY_CURSOR_VALID);
     int mutOk  = (pCur->mmIdx >= 0 && pCur->mmIdx < pCur->pMutMap->nEntries);
@@ -3750,8 +3791,6 @@ static int prollyBtCursorTableMoveto(
     ProllyMutMapEntry *pEntry = prollyMutMapFind(pCur->pMutMap, 0, 0, intKey);
     if( pEntry ){
       if( pEntry->op == PROLLY_EDIT_INSERT ){
-        int idx = prollyMutMapOrderIndexFromEntry(pCur->pMutMap, pEntry);
-
         *pRes = 0;
         refreshCursorRoot(pCur);
         {
@@ -3759,7 +3798,7 @@ static int prollyBtCursorTableMoveto(
           rc = prollyCursorSeekInt(&pCur->pCur, intKey, &seekRes);
           if( rc!=SQLITE_OK ) return rc;
         }
-        setCursorToMutMapEntry(pCur, idx);
+        setCursorToMutMapEntryPhys(pCur, (int)(pEntry - pCur->pMutMap->aEntries));
         return SQLITE_OK;
       } else {
 
@@ -4247,10 +4286,10 @@ static int prollyBtCursorIndexMoveto(
     sqlite3_free(pSortKey);
 
     
-    if( mutFound && (!treeFound || treeCmp!=0) ){
+      if( mutFound && (!treeFound || treeCmp!=0) ){
       if( mutFromCursorMap ){
-        setCursorToMutMapEntry(pCur,
-            prollyMutMapOrderIndexFromEntry(pCur->pMutMap, mutE));
+        setCursorToMutMapEntryPhys(
+            pCur, (int)(mutE - pCur->pMutMap->aEntries));
       }else{
         rc = cacheCursorPayloadCopy(pCur, mutKey, mutNKey);
         if( rc!=SQLITE_OK ){
@@ -4299,7 +4338,7 @@ static i64 prollyBtCursorIntegerKey(BtCursor *pCur){
   
   if( pCur->mmActive
    && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
-    return prollyMutMapEntryAt(pCur->pMutMap, pCur->mmIdx)->intKey;
+    return currentMutMapEntry(pCur)->intKey;
   }
   if( !prollyCursorIsValid(&pCur->pCur)
    && (pCur->curFlags & BTCF_ValidNKey) ){
@@ -4328,7 +4367,7 @@ static void getCursorPayload(BtCursor *pCur, const u8 **ppData, int *pnData){
   
   if( pCur->mmActive
    && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
-    ProllyMutMapEntry *e = prollyMutMapEntryAt(pCur->pMutMap, pCur->mmIdx);
+    ProllyMutMapEntry *e = currentMutMapEntry(pCur);
     if( pCur->curIntKey ){
       
       *ppData = e->pVal;
@@ -4824,7 +4863,7 @@ static int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
     if( pCur->curIntKey ){
       if( pCur->mmActive
        && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
-        savedIntKey = prollyMutMapEntryAt(pCur->pMutMap, pCur->mmIdx)->intKey;
+        savedIntKey = currentMutMapEntry(pCur)->intKey;
         hasSavedKey = 1;
       }else if( !prollyCursorIsValid(&pCur->pCur)
        && (pCur->curFlags & BTCF_ValidNKey) ){
@@ -4837,7 +4876,7 @@ static int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
     } else {
       if( pCur->mmActive
        && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
-        ProllyMutMapEntry *e = prollyMutMapEntryAt(pCur->pMutMap, pCur->mmIdx);
+        ProllyMutMapEntry *e = currentMutMapEntry(pCur);
         pSavedDelKey = sqlite3_malloc(e->nKey);
         if( !pSavedDelKey ) return SQLITE_NOMEM;
         memcpy(pSavedDelKey, e->pKey, e->nKey);

--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -4,8 +4,10 @@
 #include "prolly_mutmap.h"
 #include "prolly_node.h"
 #include <string.h>
+#include <stdlib.h>
 
 #define MUTMAP_INIT_CAP 16
+#define MUTMAP_MIN_HASH 32
 
 static int compareEntries(
   u8 isIntKey,
@@ -21,6 +23,32 @@ static ProllyMutMapEntry *entryAtOrder(ProllyMutMap *mm, int idx){
   return &mm->aEntries[mm->aOrder[idx]];
 }
 
+static u32 hashKey(
+  u8 isIntKey,
+  const u8 *pKey, int nKey, i64 intKey
+){
+  u32 h = 2166136261u;
+  if( isIntKey ){
+    u64 x = (u64)intKey;
+    int i;
+    for(i=0; i<8; i++){
+      h ^= (u8)(x & 0xff);
+      h *= 16777619u;
+      x >>= 8;
+    }
+  }else{
+    int i;
+    for(i=0; i<nKey; i++){
+      h ^= pKey[i];
+      h *= 16777619u;
+    }
+    h ^= (u32)nKey;
+    h *= 16777619u;
+  }
+  return h;
+}
+
+static ProllyMutMap *gSortCtx = 0;
 static void freeEntryData(ProllyMutMapEntry *e){
   sqlite3_free(e->pKey);
   sqlite3_free(e->pVal);
@@ -79,6 +107,116 @@ static int bsearch_key(ProllyMutMap *mm,
   return lo;
 }
 
+static int hashEntryMatches(
+  ProllyMutMap *mm, int phys,
+  const u8 *pKey, int nKey, i64 intKey
+){
+  ProllyMutMapEntry *e = &mm->aEntries[phys];
+  return compareEntries(mm->isIntKey,
+                        e->pKey, e->nKey, e->intKey,
+                        pKey, nKey, intKey)==0;
+}
+
+static int rebuildHash(ProllyMutMap *mm){
+  int i;
+  int nHash = MUTMAP_MIN_HASH;
+  while( nHash < (mm->nEntries > 0 ? mm->nEntries * 2 : 1) ) nHash *= 2;
+  if( nHash != mm->nHashAlloc ){
+    int *aNew = sqlite3_realloc(mm->aHash, nHash * sizeof(int));
+    if( !aNew ) return SQLITE_NOMEM;
+    mm->aHash = aNew;
+    mm->nHashAlloc = nHash;
+  }
+  memset(mm->aHash, 0, mm->nHashAlloc * sizeof(int));
+  for(i=0; i<mm->nEntries; i++){
+    u32 h = hashKey(mm->isIntKey,
+                    mm->aEntries[i].pKey, mm->aEntries[i].nKey, mm->aEntries[i].intKey);
+    int mask = mm->nHashAlloc - 1;
+    int slot = (int)(h & (u32)mask);
+    while( mm->aHash[slot] != 0 ){
+      slot = (slot + 1) & mask;
+    }
+    mm->aHash[slot] = i + 1;
+  }
+  return SQLITE_OK;
+}
+
+static int ensureHashForInsert(ProllyMutMap *mm){
+  if( mm->keepSorted ) return SQLITE_OK;
+  if( mm->nHashAlloc==0 || (mm->nEntries + 1) * 2 > mm->nHashAlloc ){
+    return rebuildHash(mm);
+  }
+  return SQLITE_OK;
+}
+
+static void hashInsertPhys(ProllyMutMap *mm, int phys){
+  u32 h;
+  int mask;
+  int slot;
+  if( mm->keepSorted || mm->nHashAlloc==0 ) return;
+  h = hashKey(mm->isIntKey,
+              mm->aEntries[phys].pKey, mm->aEntries[phys].nKey,
+              mm->aEntries[phys].intKey);
+  mask = mm->nHashAlloc - 1;
+  slot = (int)(h & (u32)mask);
+  while( mm->aHash[slot] != 0 ){
+    slot = (slot + 1) & mask;
+  }
+  mm->aHash[slot] = phys + 1;
+}
+
+static int findPhysLazy(ProllyMutMap *mm,
+                        const u8 *pKey, int nKey, i64 intKey,
+                        int *pPhys){
+  *pPhys = -1;
+  if( mm->nEntries==0 ) return SQLITE_OK;
+  if( mm->nHashAlloc==0 ){
+    int rc = rebuildHash(mm);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+  {
+    u32 h = hashKey(mm->isIntKey, pKey, nKey, intKey);
+    int mask = mm->nHashAlloc - 1;
+    int slot = (int)(h & (u32)mask);
+    while( mm->aHash[slot] != 0 ){
+      int phys = mm->aHash[slot] - 1;
+      if( hashEntryMatches(mm, phys, pKey, nKey, intKey) ){
+        *pPhys = phys;
+        return SQLITE_OK;
+      }
+      slot = (slot + 1) & mask;
+    }
+  }
+  return SQLITE_OK;
+}
+
+static int compareOrderIndexes(const void *a, const void *b){
+  ProllyMutMap *mm = gSortCtx;
+  int ia = *(const int*)a;
+  int ib = *(const int*)b;
+  ProllyMutMapEntry *ea = &mm->aEntries[ia];
+  ProllyMutMapEntry *eb = &mm->aEntries[ib];
+  return compareEntries(mm->isIntKey,
+                        ea->pKey, ea->nKey, ea->intKey,
+                        eb->pKey, eb->nKey, eb->intKey);
+}
+
+static int ensureOrder(ProllyMutMap *mm){
+  int i;
+  if( mm->keepSorted || !mm->orderDirty ) return SQLITE_OK;
+  for(i=0; i<mm->nEntries; i++){
+    mm->aOrder[i] = i;
+  }
+  gSortCtx = mm;
+  qsort(mm->aOrder, mm->nEntries, sizeof(int), compareOrderIndexes);
+  gSortCtx = 0;
+  for(i=0; i<mm->nEntries; i++){
+    mm->aPos[mm->aOrder[i]] = i;
+  }
+  mm->orderDirty = 0;
+  return SQLITE_OK;
+}
+
 static int ensureCapacity(ProllyMutMap *mm){
   if( mm->nEntries >= mm->nAlloc ){
     int nNew = mm->nAlloc ? mm->nAlloc * 2 : MUTMAP_INIT_CAP;
@@ -100,8 +238,13 @@ static int ensureCapacity(ProllyMutMap *mm){
 }
 
 int prollyMutMapInit(ProllyMutMap *mm, u8 isIntKey){
+  return prollyMutMapInitMode(mm, isIntKey, 1);
+}
+
+int prollyMutMapInitMode(ProllyMutMap *mm, u8 isIntKey, u8 keepSorted){
   memset(mm, 0, sizeof(*mm));
   mm->isIntKey = isIntKey;
+  mm->keepSorted = keepSorted;
   return SQLITE_OK;
 }
 
@@ -155,17 +298,26 @@ int prollyMutMapInsert(
   const u8 *pKey, int nKey, i64 intKey,
   const u8 *pVal, int nVal
 ){
-  int found, idx, rc;
+  int found = 0, idx = 0, rc, phys = -1;
 
-  idx = bsearch_key(mm, pKey, nKey, intKey, &found);
+  if( mm->keepSorted ){
+    idx = bsearch_key(mm, pKey, nKey, intKey, &found);
+    if( found ){
+      phys = mm->aOrder[idx];
+    }
+  }else{
+    rc = findPhysLazy(mm, pKey, nKey, intKey, &phys);
+    if( rc!=SQLITE_OK ) return rc;
+    found = (phys >= 0);
+  }
 
   if( found ){
-    ProllyMutMapEntry *e = entryAtOrder(mm, idx);
+    ProllyMutMapEntry *e = &mm->aEntries[phys];
     /* In-place mutation. If a savepoint is active AND the entry
     ** predates it, snapshot before overwriting. */
     if( mm->currentSavepointLevel > 0
      && e->bornAt < mm->currentSavepointLevel ){
-      rc = appendUndoRec(mm, idx);
+      rc = appendUndoRec(mm, phys);
       if( rc!=SQLITE_OK ) return rc;
     }
     e->op = PROLLY_EDIT_INSERT;
@@ -184,9 +336,11 @@ int prollyMutMapInsert(
 
   rc = ensureCapacity(mm);
   if( rc!=SQLITE_OK ) return rc;
+  rc = ensureHashForInsert(mm);
+  if( rc!=SQLITE_OK ) return rc;
 
   {
-    int phys = mm->nEntries;
+    phys = mm->nEntries;
     int i;
     ProllyMutMapEntry *e = &mm->aEntries[phys];
     memset(e, 0, sizeof(*e));
@@ -198,18 +352,27 @@ int prollyMutMapInsert(
     if( rc!=SQLITE_OK ){
       return rc;
     }
-    if( idx < mm->nEntries ){
-      memmove(&mm->aOrder[idx+1], &mm->aOrder[idx],
-              (mm->nEntries - idx) * sizeof(int));
-    }
-    mm->aOrder[idx] = phys;
-    mm->aPos[phys] = idx;
-    for(i = idx + 1; i <= mm->nEntries; i++){
-      mm->aPos[mm->aOrder[i]] = i;
+    if( mm->keepSorted ){
+      if( idx < mm->nEntries ){
+        memmove(&mm->aOrder[idx+1], &mm->aOrder[idx],
+                (mm->nEntries - idx) * sizeof(int));
+      }
+      mm->aOrder[idx] = phys;
+      mm->aPos[phys] = idx;
+      for(i = idx + 1; i <= mm->nEntries; i++){
+        mm->aPos[mm->aOrder[i]] = i;
+      }
+    }else{
+      mm->aOrder[phys] = phys;
+      mm->aPos[phys] = phys;
+      mm->orderDirty = 1;
     }
   }
 
   mm->nEntries++;
+  if( !mm->keepSorted ){
+    hashInsertPhys(mm, phys);
+  }
   return SQLITE_OK;
 }
 
@@ -217,16 +380,25 @@ int prollyMutMapDelete(
   ProllyMutMap *mm,
   const u8 *pKey, int nKey, i64 intKey
 ){
-  int found, idx, rc;
+  int found = 0, idx = 0, rc, phys = -1;
 
-  idx = bsearch_key(mm, pKey, nKey, intKey, &found);
+  if( mm->keepSorted ){
+    idx = bsearch_key(mm, pKey, nKey, intKey, &found);
+    if( found ){
+      phys = mm->aOrder[idx];
+    }
+  }else{
+    rc = findPhysLazy(mm, pKey, nKey, intKey, &phys);
+    if( rc!=SQLITE_OK ) return rc;
+    found = (phys >= 0);
+  }
 
   if( found ){
-    ProllyMutMapEntry *e = entryAtOrder(mm, idx);
+    ProllyMutMapEntry *e = &mm->aEntries[phys];
     if( e->op == PROLLY_EDIT_INSERT ){
       if( mm->currentSavepointLevel > 0
        && e->bornAt < mm->currentSavepointLevel ){
-        rc = appendUndoRec(mm, idx);
+        rc = appendUndoRec(mm, phys);
         if( rc!=SQLITE_OK ) return rc;
       }
       e->op = PROLLY_EDIT_DELETE;
@@ -242,9 +414,11 @@ int prollyMutMapDelete(
 
   rc = ensureCapacity(mm);
   if( rc!=SQLITE_OK ) return rc;
+  rc = ensureHashForInsert(mm);
+  if( rc!=SQLITE_OK ) return rc;
 
   {
-    int phys = mm->nEntries;
+    phys = mm->nEntries;
     int i;
     ProllyMutMapEntry *e = &mm->aEntries[phys];
     memset(e, 0, sizeof(*e));
@@ -256,18 +430,27 @@ int prollyMutMapDelete(
     if( rc!=SQLITE_OK ){
       return rc;
     }
-    if( idx < mm->nEntries ){
-      memmove(&mm->aOrder[idx+1], &mm->aOrder[idx],
-              (mm->nEntries - idx) * sizeof(int));
-    }
-    mm->aOrder[idx] = phys;
-    mm->aPos[phys] = idx;
-    for(i = idx + 1; i <= mm->nEntries; i++){
-      mm->aPos[mm->aOrder[i]] = i;
+    if( mm->keepSorted ){
+      if( idx < mm->nEntries ){
+        memmove(&mm->aOrder[idx+1], &mm->aOrder[idx],
+                (mm->nEntries - idx) * sizeof(int));
+      }
+      mm->aOrder[idx] = phys;
+      mm->aPos[phys] = idx;
+      for(i = idx + 1; i <= mm->nEntries; i++){
+        mm->aPos[mm->aOrder[i]] = i;
+      }
+    }else{
+      mm->aOrder[phys] = phys;
+      mm->aPos[phys] = phys;
+      mm->orderDirty = 1;
     }
   }
 
   mm->nEntries++;
+  if( !mm->keepSorted ){
+    hashInsertPhys(mm, phys);
+  }
   return SQLITE_OK;
 }
 
@@ -337,21 +520,31 @@ int prollyMutMapRollbackToSavepoint(ProllyMutMap *mm, int level){
     {
       int j;
       int out = 0;
-      for(j=0; j<oldN; j++){
-        int mapped = aMap[mm->aOrder[j]];
-        if( mapped >= 0 ){
-          mm->aOrder[out++] = mapped;
+      if( mm->keepSorted ){
+        for(j=0; j<oldN; j++){
+          int mapped = aMap[mm->aOrder[j]];
+          if( mapped >= 0 ){
+            mm->aOrder[out++] = mapped;
+          }
         }
-      }
-      mm->nEntries = out;
-      for(j=0; j<mm->nEntries; j++){
-        mm->aPos[mm->aOrder[j]] = j;
+        mm->nEntries = out;
+        for(j=0; j<mm->nEntries; j++){
+          mm->aPos[mm->aOrder[j]] = j;
+        }
+      }else{
+        mm->nEntries = newN;
+        mm->orderDirty = 1;
       }
       for(j=0; j<mm->nUndo; j++){
         mm->aUndo[j].entryIdx = aMap[mm->aUndo[j].entryIdx];
       }
     }
     sqlite3_free(aMap);
+  }
+
+  if( !mm->keepSorted ){
+    int rc = rebuildHash(mm);
+    if( rc!=SQLITE_OK ) return rc;
   }
 
   mm->currentSavepointLevel = level - 1;
@@ -398,18 +591,25 @@ void prollyMutMapReleaseSavepoint(ProllyMutMap *mm, int level){
 
 ProllyMutMapEntry *prollyMutMapFind(ProllyMutMap *mm,
                                      const u8 *pKey, int nKey, i64 intKey){
-  int found, idx;
+  int found, idx, phys, rc;
   if( mm->nEntries==0 ) return 0;
-  idx = bsearch_key(mm, pKey, nKey, intKey, &found);
-  return found ? entryAtOrder(mm, idx) : 0;
+  if( mm->keepSorted ){
+    idx = bsearch_key(mm, pKey, nKey, intKey, &found);
+    return found ? entryAtOrder(mm, idx) : 0;
+  }
+  rc = findPhysLazy(mm, pKey, nKey, intKey, &phys);
+  if( rc!=SQLITE_OK ) return 0;
+  return phys >= 0 ? &mm->aEntries[phys] : 0;
 }
 
 ProllyMutMapEntry *prollyMutMapEntryAt(ProllyMutMap *mm, int idx){
+  ensureOrder(mm);
   return entryAtOrder(mm, idx);
 }
 
 int prollyMutMapOrderIndexFromEntry(ProllyMutMap *mm, ProllyMutMapEntry *pEntry){
   int phys = (int)(pEntry - mm->aEntries);
+  ensureOrder(mm);
   return mm->aPos[phys];
 }
 
@@ -422,6 +622,7 @@ int prollyMutMapIsEmpty(ProllyMutMap *mm){
 }
 
 void prollyMutMapIterFirst(ProllyMutMapIter *it, ProllyMutMap *mm){
+  ensureOrder(mm);
   it->pMap = mm;
   it->idx = 0;
 }
@@ -435,17 +636,20 @@ int prollyMutMapIterValid(ProllyMutMapIter *it){
 }
 
 ProllyMutMapEntry *prollyMutMapIterEntry(ProllyMutMapIter *it){
+  ensureOrder(it->pMap);
   return entryAtOrder(it->pMap, it->idx);
 }
 
 void prollyMutMapIterSeek(ProllyMutMapIter *it, ProllyMutMap *mm,
                           const u8 *pKey, int nKey, i64 intKey){
   int found = 0;
+  ensureOrder(mm);
   it->pMap = mm;
   it->idx = bsearch_key(mm, pKey, nKey, intKey, &found);
 }
 
 void prollyMutMapIterLast(ProllyMutMapIter *it, ProllyMutMap *mm){
+  ensureOrder(mm);
   it->pMap = mm;
   it->idx = mm->nEntries>0 ? mm->nEntries - 1 : mm->nEntries;
 }
@@ -460,6 +664,10 @@ void prollyMutMapClear(ProllyMutMap *mm){
     freeEntryData(&mm->aEntries[i]);
   }
   mm->nEntries = 0;
+  mm->orderDirty = 0;
+  if( mm->aHash && mm->nHashAlloc>0 ){
+    memset(mm->aHash, 0, mm->nHashAlloc * sizeof(int));
+  }
   for(i=0; i<mm->nUndo; i++){
     sqlite3_free(mm->aUndo[i].prevVal);
   }
@@ -474,6 +682,9 @@ void prollyMutMapFree(ProllyMutMap *mm){
   mm->aOrder = 0;
   sqlite3_free(mm->aPos);
   mm->aPos = 0;
+  sqlite3_free(mm->aHash);
+  mm->aHash = 0;
+  mm->nHashAlloc = 0;
   mm->nAlloc = 0;
   sqlite3_free(mm->aUndo);
   mm->aUndo = 0;
@@ -489,6 +700,8 @@ int prollyMutMapClone(ProllyMutMap **out, const ProllyMutMap *src){
   if( !dst ) return SQLITE_NOMEM;
   memset(dst, 0, sizeof(*dst));
   dst->isIntKey = src->isIntKey;
+  dst->keepSorted = src->keepSorted;
+  dst->orderDirty = src->orderDirty;
   dst->currentSavepointLevel = src->currentSavepointLevel;
 
   if( src->nEntries > 0 ){
@@ -541,8 +754,13 @@ int prollyMutMapClone(ProllyMutMap **out, const ProllyMutMap *src){
       }
       dst->nEntries++;
     }
-    memcpy(dst->aOrder, src->aOrder, src->nEntries * sizeof(int));
-    memcpy(dst->aPos, src->aPos, src->nEntries * sizeof(int));
+    if( src->keepSorted || !src->orderDirty ){
+      memcpy(dst->aOrder, src->aOrder, src->nEntries * sizeof(int));
+      memcpy(dst->aPos, src->aPos, src->nEntries * sizeof(int));
+    }else{
+      memset(dst->aOrder, 0, src->nEntries * sizeof(int));
+      memset(dst->aPos, 0, src->nEntries * sizeof(int));
+    }
   }
 
   if( src->nUndo > 0 ){
@@ -577,6 +795,15 @@ int prollyMutMapClone(ProllyMutMap **out, const ProllyMutMap *src){
         dr->nPrevVal = sr->nPrevVal;
       }
       dst->nUndo++;
+    }
+  }
+
+  if( !dst->keepSorted && dst->nEntries > 0 ){
+    int rc = rebuildHash(dst);
+    if( rc!=SQLITE_OK ){
+      prollyMutMapFree(dst);
+      sqlite3_free(dst);
+      return rc;
     }
   }
 

--- a/src/prolly_mutmap.h
+++ b/src/prolly_mutmap.h
@@ -43,11 +43,15 @@ struct ProllyMutMapUndoRec {
 
 struct ProllyMutMap {
   u8 isIntKey;
+  u8 keepSorted;
+  u8 orderDirty;
   int nEntries;
   int nAlloc;
   ProllyMutMapEntry *aEntries;
   int *aOrder;              /* sorted-position -> physical entry index */
   int *aPos;                /* physical entry index -> sorted-position */
+  int *aHash;               /* open-addressing hash table storing phys+1 */
+  int nHashAlloc;
   /* Active savepoint level. 0 = no savepoint, mutations skip
   ** the undo-log path entirely (fast path for autocommit). */
   int currentSavepointLevel;
@@ -60,6 +64,7 @@ struct ProllyMutMap {
 };
 
 int prollyMutMapInit(ProllyMutMap *mm, u8 isIntKey);
+int prollyMutMapInitMode(ProllyMutMap *mm, u8 isIntKey, u8 keepSorted);
 
 int prollyMutMapInsert(ProllyMutMap *mm,
                        const u8 *pKey, int nKey, i64 intKey,

--- a/test/sysbench_compare.sh
+++ b/test/sysbench_compare.sh
@@ -336,7 +336,7 @@ echo "_${ROWS} rows, single CLI invocation per test, workload-only timing via SQ
 # ============================================================
 # Enforce performance ceiling (exit 1 if any test exceeds limit)
 # ============================================================
-MAX_MULTIPLIER=${BENCH_MAX_MULTIPLIER:-4}
+MAX_MULTIPLIER=${BENCH_MAX_MULTIPLIER:-3}
 
 check_ceiling() {
   local tests="$1" db_sq="$2" db_dl="$3"


### PR DESCRIPTION
## Performance
- file-backed `oltp_update_index`: `2.97x -> 1.72x`
- in-memory `oltp_update_index`: `3.12x -> 1.85x`
- file-backed `oltp_delete_insert`: `2.31x -> 2.03x`
- in-memory `oltp_delete_insert`: `2.24x -> 1.90x`

## Validation
- `cd build && bash ../test/oracle_savepoints_test.sh ./doltlite ./sqlite3`
- `cd build && bash ../test/sql_oracle_test.sh ./doltlite ./sqlite3`
- `cd build && bash ../test/sysbench_compare.sh`

## Notes
- keeps the existing always-sorted mutmap behavior for table roots
- adds lazy-order exact-lookup mode only for non-table roots (secondary indexes)
- avoids forcing sorted-order materialization on exact mutmap cursor hits
