### PR TITLE
rebase: add dolt_rebase replaying on shared cherry-pick core

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -3,6 +3,7 @@
 
 #include "sqliteInt.h"
 #include "prolly_hash.h"
+#include "prolly_hashset.h"
 #include "chunk_store.h"
 #include "prolly_cursor.h"
 #include "prolly_cache.h"
@@ -2132,6 +2133,308 @@ static void doltliteRevertFunc(
   }
 }
 
+/* Collect the set of commits reachable from pHeadHash but NOT from
+** pUpstreamHash. Walks upstream's full ancestor graph into a hash
+** set (BFS), then walks head first-parent backward and records every
+** commit that isn't already in that set. Emits the replay list in
+** oldest-first order (so iteration N's parent is N-1). */
+static int doltliteRebaseCollectReplaySet(
+  sqlite3 *db,
+  const ProllyHash *pHeadHash,
+  const ProllyHash *pUpstreamHash,
+  ProllyHash **paReplay,
+  int *pnReplay
+){
+  ProllyHashSet upstreamAncestors;
+  ProllyHash *queue = 0;
+  int qHead = 0, qTail = 0, qAlloc = 0;
+  ProllyHash *aReplay = 0;
+  int nReplay = 0, nAllocReplay = 0;
+  int rc;
+  int upstreamInit = 0;
+  ProllyHash walk;
+  int i;
+
+  *paReplay = 0;
+  *pnReplay = 0;
+
+  rc = prollyHashSetInit(&upstreamAncestors, 256);
+  if( rc!=SQLITE_OK ) return rc;
+  upstreamInit = 1;
+
+  qAlloc = 64;
+  queue = sqlite3_malloc(qAlloc * (int)sizeof(ProllyHash));
+  if( !queue ){ rc = SQLITE_NOMEM; goto cleanup; }
+  queue[qTail++] = *pUpstreamHash;
+
+  while( qHead < qTail ){
+    ProllyHash cur = queue[qHead++];
+    DoltliteCommit c;
+
+    if( prollyHashIsEmpty(&cur) ) continue;
+    if( prollyHashSetContains(&upstreamAncestors, &cur) ) continue;
+    rc = prollyHashSetAdd(&upstreamAncestors, &cur);
+    if( rc!=SQLITE_OK ) goto cleanup;
+
+    memset(&c, 0, sizeof(c));
+    if( doltliteLoadCommit(db, &cur, &c)!=SQLITE_OK ) continue;
+    for(i=0; i<doltliteCommitParentCount(&c); i++){
+      const ProllyHash *pp = doltliteCommitParentHash(&c, i);
+      if( !pp || prollyHashIsEmpty(pp) ) continue;
+      if( prollyHashSetContains(&upstreamAncestors, pp) ) continue;
+      if( qTail >= qAlloc ){
+        int nNew = qAlloc * 2;
+        ProllyHash *tmp = sqlite3_realloc(queue, nNew*(int)sizeof(ProllyHash));
+        if( !tmp ){ doltliteCommitClear(&c); rc = SQLITE_NOMEM; goto cleanup; }
+        queue = tmp;
+        qAlloc = nNew;
+      }
+      queue[qTail++] = *pp;
+    }
+    doltliteCommitClear(&c);
+  }
+
+  sqlite3_free(queue);
+  queue = 0;
+
+  /* Walk HEAD backward via first-parent, stopping at the first
+  ** commit that's already in upstream's ancestry. */
+  walk = *pHeadHash;
+  while( !prollyHashIsEmpty(&walk) && !prollyHashSetContains(&upstreamAncestors, &walk) ){
+    DoltliteCommit c;
+    const ProllyHash *pParent;
+
+    if( nReplay >= nAllocReplay ){
+      int nNew = nAllocReplay ? nAllocReplay*2 : 16;
+      ProllyHash *tmp = sqlite3_realloc(aReplay, nNew*(int)sizeof(ProllyHash));
+      if( !tmp ){ rc = SQLITE_NOMEM; goto cleanup; }
+      aReplay = tmp;
+      nAllocReplay = nNew;
+    }
+    aReplay[nReplay++] = walk;
+
+    memset(&c, 0, sizeof(c));
+    rc = doltliteLoadCommit(db, &walk, &c);
+    if( rc!=SQLITE_OK ) goto cleanup;
+    pParent = doltliteCommitParentHash(&c, 0);
+    if( pParent && !prollyHashIsEmpty(pParent) ){
+      walk = *pParent;
+    }else{
+      memset(&walk, 0, sizeof(walk));
+    }
+    doltliteCommitClear(&c);
+  }
+
+  /* Reverse so the output is oldest-first (ancestor-first). */
+  for(i=0; i<nReplay/2; i++){
+    ProllyHash tmp = aReplay[i];
+    aReplay[i] = aReplay[nReplay-1-i];
+    aReplay[nReplay-1-i] = tmp;
+  }
+
+  *paReplay = aReplay;
+  *pnReplay = nReplay;
+  aReplay = 0;
+  rc = SQLITE_OK;
+
+cleanup:
+  sqlite3_free(queue);
+  sqlite3_free(aReplay);
+  if( upstreamInit ) prollyHashSetFree(&upstreamAncestors);
+  return rc;
+}
+
+/* dolt_rebase: replay commits reachable from HEAD but not from the
+** upstream ref on top of the upstream. Shares the per-commit apply
+** logic with cherry-pick/revert via applyMergedCatalogAndCommit.
+** Atomic: if any replay step fails or produces conflicts, restore
+** the pre-rebase state and error out. Interactive mode and
+** --continue / --abort (beyond "no rebase in progress") are not
+** supported in this initial implementation. */
+static void doltliteRebaseFunc(
+  sqlite3_context *context,
+  int argc,
+  sqlite3_value **argv
+){
+  sqlite3 *db = sqlite3_context_db_handle(context);
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  const char *zUpstream;
+  ProllyHash upstreamHash, headHash;
+  ProllyHash *aReplay = 0;
+  int nReplay = 0;
+  DoltliteTxnState saved;
+  DoltliteCommit upstreamCommit;
+  int savedInit = 0;
+  int rc;
+  int i;
+
+  memset(&saved, 0, sizeof(saved));
+  memset(&upstreamCommit, 0, sizeof(upstreamCommit));
+
+  if( !cs ){ sqlite3_result_error(context, "no database", -1); return; }
+  if( argc<1 ){
+    sqlite3_result_error(context, "usage: dolt_rebase('upstream_branch')", -1);
+    return;
+  }
+
+  zUpstream = (const char*)sqlite3_value_text(argv[0]);
+  if( !zUpstream ){
+    sqlite3_result_error(context, "upstream ref required", -1);
+    return;
+  }
+
+  if( strcmp(zUpstream, "--abort")==0 || strcmp(zUpstream, "--continue")==0 ){
+    sqlite3_result_error(context, "no rebase in progress", -1);
+    return;
+  }
+
+  if( doltliteHasUncommittedChanges(db) ){
+    sqlite3_result_error(context,
+      "cannot start a rebase with uncommitted changes", -1);
+    return;
+  }
+
+  rc = doltliteResolveRef(db, zUpstream, &upstreamHash);
+  if( rc!=SQLITE_OK ){
+    char *zErr = sqlite3_mprintf("branch not found: %s", zUpstream);
+    sqlite3_result_error(context, zErr ? zErr : "branch not found", -1);
+    sqlite3_free(zErr);
+    return;
+  }
+
+  doltliteGetSessionHead(db, &headHash);
+  if( prollyHashIsEmpty(&headHash) ){
+    sqlite3_result_error(context, "no commits on current branch", -1);
+    return;
+  }
+
+  rc = doltliteRebaseCollectReplaySet(db, &headHash, &upstreamHash,
+                                      &aReplay, &nReplay);
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error_code(context, rc);
+    return;
+  }
+  if( nReplay==0 ){
+    sqlite3_free(aReplay);
+    sqlite3_result_error(context, "didn't identify any commits!", -1);
+    return;
+  }
+
+  rc = doltliteSaveTxnState(db, &saved);
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(aReplay);
+    sqlite3_result_error_code(context, rc);
+    return;
+  }
+  savedInit = 1;
+
+  /* Reset the branch to the upstream tip so applyMergedCatalog sees
+  ** a consistent session HEAD for the first replay iteration. The
+  ** saved txn state will undo this on rollback. */
+  rc = doltliteLoadCommit(db, &upstreamHash, &upstreamCommit);
+  if( rc!=SQLITE_OK ) goto rollback;
+
+  rc = doltliteSwitchCatalog(db, &upstreamCommit.catalogHash);
+  if( rc!=SQLITE_OK ){
+    doltliteCommitClear(&upstreamCommit);
+    goto rollback;
+  }
+  doltliteSetSessionHead(db, &upstreamHash);
+  doltliteSetSessionStaged(db, &upstreamCommit.catalogHash);
+  rc = doltliteAdvanceBranch(db, &upstreamHash, &upstreamCommit.catalogHash);
+  doltliteCommitClear(&upstreamCommit);
+  memset(&upstreamCommit, 0, sizeof(upstreamCommit));
+  if( rc!=SQLITE_OK ) goto rollback;
+
+  for(i=0; i<nReplay; i++){
+    DoltliteCommit replayCommit, parentCommit, curHeadCommit;
+    ProllyHash curHead;
+    int nConflicts = 0;
+    char hexBuf[PROLLY_HASH_SIZE*2+1];
+
+    memset(&replayCommit, 0, sizeof(replayCommit));
+    memset(&parentCommit, 0, sizeof(parentCommit));
+    memset(&curHeadCommit, 0, sizeof(curHeadCommit));
+
+    rc = doltliteLoadCommit(db, &aReplay[i], &replayCommit);
+    if( rc!=SQLITE_OK ) goto rollback;
+
+    if( replayCommit.nParents==0 || prollyHashIsEmpty(&replayCommit.aParents[0]) ){
+      /* Root commit can't be replayed — no parent to diff against. */
+      doltliteCommitClear(&replayCommit);
+      rc = SQLITE_ERROR;
+      goto rollback;
+    }
+    rc = doltliteLoadCommit(db, &replayCommit.aParents[0], &parentCommit);
+    if( rc!=SQLITE_OK ){
+      doltliteCommitClear(&replayCommit);
+      goto rollback;
+    }
+
+    doltliteGetSessionHead(db, &curHead);
+    rc = doltliteLoadCommit(db, &curHead, &curHeadCommit);
+    if( rc!=SQLITE_OK ){
+      doltliteCommitClear(&replayCommit);
+      doltliteCommitClear(&parentCommit);
+      goto rollback;
+    }
+
+    rc = applyMergedCatalogAndCommit(db, context,
+        &parentCommit.catalogHash,
+        &curHeadCommit.catalogHash,
+        &replayCommit.catalogHash,
+        &curHead,
+        replayCommit.zMessage ? replayCommit.zMessage : "",
+        &nConflicts, hexBuf);
+
+    doltliteCommitClear(&replayCommit);
+    doltliteCommitClear(&parentCommit);
+    doltliteCommitClear(&curHeadCommit);
+
+    if( rc!=SQLITE_OK ){
+      goto rollback;
+    }
+    if( nConflicts>0 ){
+      /* Conflict during a replay. applyMerged has staged the
+      ** conflict and set the session to "merging" state; undo all
+      ** of that by restoring the saved pre-rebase state. */
+      rc = SQLITE_ERROR;
+      goto rollback;
+    }
+  }
+
+  doltliteTxnStateClear(&saved);
+  sqlite3_free(aReplay);
+  {
+    char *zMsg = sqlite3_mprintf("Successfully rebased and updated refs/heads/%s",
+                                 doltliteGetSessionBranch(db));
+    if( zMsg ){
+      sqlite3_result_text(context, zMsg, -1, sqlite3_free);
+    }else{
+      sqlite3_result_text(context, "Successfully rebased", -1, SQLITE_STATIC);
+    }
+  }
+  return;
+
+rollback:
+  if( savedInit ){
+    int rc2 = doltliteRestoreTxnState(db, &saved);
+    doltliteTxnStateClear(&saved);
+    (void)rc2;
+  }
+  sqlite3_free(aReplay);
+  {
+    char *zErr = sqlite3_mprintf(
+      "rebase failed (conflict or error during replay) — branch restored to pre-rebase state");
+    if( zErr ){
+      sqlite3_result_error(context, zErr, -1);
+      sqlite3_free(zErr);
+    }else{
+      sqlite3_result_error_code(context, rc);
+    }
+  }
+}
+
 static void doltliteConfigFunc(sqlite3_context *context, int argc, sqlite3_value **argv){
   sqlite3 *db = sqlite3_context_db_handle(context);
   const char *zKey;
@@ -2210,6 +2513,8 @@ void doltliteRegister(sqlite3 *db){
                                                    doltliteCherryPickFunc, 0, 0);
   if( rc==SQLITE_OK ) rc = sqlite3_create_function(db, "dolt_revert", -1, SQLITE_UTF8, 0,
                                                    doltliteRevertFunc, 0, 0);
+  if( rc==SQLITE_OK ) rc = sqlite3_create_function(db, "dolt_rebase", -1, SQLITE_UTF8, 0,
+                                                   doltliteRebaseFunc, 0, 0);
   if( rc==SQLITE_OK ) rc = sqlite3_create_function(db, "dolt_config", -1, SQLITE_UTF8, 0,
                                                    doltliteConfigFunc, 0, 0);
   if( rc!=SQLITE_OK ) return;

--- a/test/vc_oracle_rebase_test.sh
+++ b/test/vc_oracle_rebase_test.sh
@@ -1,0 +1,248 @@
+#!/bin/bash
+#
+# Version-control oracle test: dolt_rebase
+#
+# Runs identical rebase scenarios against doltlite and Dolt. Commit
+# hashes don't match across engines (prolly vs noms) so the oracle
+# compares the sequence of commit messages via dolt_log, which on
+# linear history gives HEAD-first first-parent ordering on both
+# engines.
+#
+# dolt_rebase spec (from real Dolt 1.83.5):
+#
+#   CALL dolt_rebase(<upstream>)
+#
+#     Replays each commit that's reachable from HEAD but NOT from
+#     <upstream> on top of <upstream>, preserving original commit
+#     messages. Fails if:
+#       - the upstream ref can't be resolved
+#       - the set of commits to replay is empty
+#       - the working tree has uncommitted changes
+#       - a replayed commit would create conflicts (auto-abort in
+#         default session; staged + --continue path when
+#         @@dolt_allow_commit_conflicts is on — not supported in
+#         the initial doltlite implementation)
+#
+#   CALL dolt_rebase('--abort')
+#     Valid only while an interactive rebase is in progress. In the
+#     non-interactive default path, errors with "no rebase in
+#     progress" because non-interactive rebases are atomic.
+#
+# Usage: bash vc_oracle_rebase_test.sh [path/to/doltlite] [path/to/dolt]
+#
+
+set -u
+
+DOLTLITE="${1:-./doltlite}"
+DOLT="${2:-dolt}"
+TMPROOT=$(mktemp -d)
+trap "rm -rf $TMPROOT" EXIT
+pass=0; fail=0
+FAILED_NAMES=""
+
+# Compare commit-message ordered sequences after running setup SQL
+# on both engines. The tag "LOG|<message>" is used to cleanly
+# extract log rows from the surrounding noise CALL statements emit.
+oracle() {
+  local name="$1" setup="$2" query="$3"
+  local dir="$TMPROOT/$name"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_out
+  dl_out=$(printf "%s\n.headers off\n.mode list\n%s\n" "$setup" "$query" \
+           | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
+           | tr -d '\r' \
+           | grep '^LOG|')
+
+  local dolt_setup
+  dolt_setup=$(echo "$setup" | sed -E 's/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g')
+
+  local dt_out
+  (
+    cd "$dir/dt" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    {
+      echo "$dolt_setup"
+      echo "$query"
+    } | "$DOLT" sql -r csv 2>"$dir/dt.err"
+  ) > "$dir/dt.raw"
+  dt_out=$(tr -d '"\r' < "$dir/dt.raw" | grep '^LOG|')
+
+  if [ "$dl_out" = "$dt_out" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite:"
+    echo "$dl_out" | sed 's/^/      /'
+    echo "    dolt:"
+    echo "$dt_out" | sed 's/^/      /'
+  fi
+}
+
+# Error oracle: expect both engines to error on the same SQL.
+oracle_error() {
+  local name="$1" setup="$2"
+  local dir="$TMPROOT/${name}_err"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_err=0
+  echo "$setup" | "$DOLTLITE" "$dir/dl/db" >"$dir/dl.out" 2>"$dir/dl.err"
+  if grep -qiE 'error|fail' "$dir/dl.out" "$dir/dl.err" 2>/dev/null; then dl_err=1; fi
+
+  local dolt_setup
+  dolt_setup=$(echo "$setup" | sed -E 's/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g')
+  local dt_err=0
+  (
+    cd "$dir/dt" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    echo "$dolt_setup" | "$DOLT" sql >"$dir/dt.out" 2>"$dir/dt.err"
+  )
+  if grep -qiE 'error|fail' "$dir/dt.out" "$dir/dt.err" 2>/dev/null; then dt_err=1; fi
+
+  if [ "$dl_err" = 1 ] && [ "$dt_err" = 1 ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name (expected both to error)"
+    echo "    doltlite errored: $([ $dl_err = 1 ] && echo yes || echo NO)"
+    echo "    dolt errored:     $([ $dt_err = 1 ] && echo yes || echo NO)"
+  fi
+}
+
+echo "=== Version Control Oracle Tests: dolt_rebase ==="
+echo ""
+
+echo "--- linear rebase onto diverged upstream ---"
+
+LINEAR_SETUP="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 1);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');
+SELECT dolt_checkout('-b', 'feat');
+INSERT INTO t VALUES (2, 2);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'feat_c1');
+INSERT INTO t VALUES (3, 3);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'feat_c2');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES (10, 10);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'main_c2');
+SELECT dolt_checkout('feat');
+SELECT dolt_rebase('main');
+"
+
+oracle "linear_log_order" "$LINEAR_SETUP" \
+  "SELECT CONCAT('LOG|', message) FROM dolt_log;"
+
+oracle "linear_table_state" "$LINEAR_SETUP" \
+  "SELECT CONCAT('LOG|', id, '=', v) FROM t ORDER BY id;"
+
+echo "--- rebase when feat is strict descendant of main (noop-ish: feat's commits replay onto unchanged main) ---"
+
+DESCEND_SETUP="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 1);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');
+SELECT dolt_checkout('-b', 'feat');
+INSERT INTO t VALUES (2, 2);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'feat_only');
+SELECT dolt_rebase('main');
+"
+
+oracle "descendant_log_order" "$DESCEND_SETUP" \
+  "SELECT CONCAT('LOG|', message) FROM dolt_log;"
+
+echo "--- rebase with multi-commit chain preserving order ---"
+
+MULTI_SETUP="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 1);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');
+SELECT dolt_checkout('-b', 'feat');
+INSERT INTO t VALUES (2, 2);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'f1');
+INSERT INTO t VALUES (3, 3);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'f2');
+INSERT INTO t VALUES (4, 4);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'f3');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES (100, 100);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'm');
+SELECT dolt_checkout('feat');
+SELECT dolt_rebase('main');
+"
+
+oracle "multi_commit_log" "$MULTI_SETUP" \
+  "SELECT CONCAT('LOG|', message) FROM dolt_log;"
+
+oracle "multi_commit_table" "$MULTI_SETUP" \
+  "SELECT CONCAT('LOG|', id) FROM t ORDER BY id;"
+
+echo "--- error paths ---"
+
+oracle_error "no_divergent_commits" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');
+SELECT dolt_rebase('main');
+"
+
+oracle_error "behind_upstream" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');
+SELECT dolt_checkout('-b', 'feat');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES (1);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'm');
+SELECT dolt_checkout('feat');
+SELECT dolt_rebase('main');
+"
+
+oracle_error "uncommitted_changes" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');
+SELECT dolt_checkout('-b', 'feat');
+INSERT INTO t VALUES (1);
+SELECT dolt_rebase('main');
+"
+
+oracle_error "unknown_upstream" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');
+SELECT dolt_checkout('-b', 'feat');
+SELECT dolt_rebase('nope');
+"
+
+oracle_error "abort_without_active_rebase" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');
+SELECT dolt_rebase('--abort');
+"
+
+oracle_error "conflict_rebase" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 1);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');
+SELECT dolt_checkout('-b', 'feat');
+UPDATE t SET v = 100 WHERE id = 1;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'f');
+SELECT dolt_checkout('main');
+UPDATE t SET v = 999 WHERE id = 1;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'm');
+SELECT dolt_checkout('feat');
+SELECT dolt_rebase('main');
+"
+
+oracle_error "no_args" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');
+SELECT dolt_rebase();
+"
+
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+if [ $fail -gt 0 ]; then
+  echo "Failed:$FAILED_NAMES"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- ``dolt_rebase('upstream')`` collects commits reachable from HEAD but NOT from upstream, hard-resets the session to the upstream tip, and replays each in oldest-first order using the existing ``applyMergedCatalogAndCommit`` helper that also powers cherry-pick and revert. Shared logic as requested — rebase is a loop of cherry-picks with atomic outer save/restore.
- Atomic: a save-txn-state snapshot is captured before the replay loop and restored on any error or conflict, so a failed rebase leaves the branch exactly where it started.
- ``--abort`` / ``--continue`` error with "no rebase in progress" since the default path is atomic. Interactive mode and ``--empty``/``@@dolt_allow_commit_conflicts`` staging are deferred.

## Spec
Built from an oracle test (``test/vc_oracle_rebase_test.sh``) that diffs doltlite's output against real Dolt across 12 scenarios. All pass. Coverage:
- Linear rebase onto diverged upstream (checks both log order AND final table state)
- Descendant case: feat strictly ahead of main
- Multi-commit chain preserving order
- Error: no divergent commits (``didn't identify any commits!``)
- Error: feat behind upstream (same condition)
- Error: uncommitted changes (``cannot start a rebase with uncommitted changes``)
- Error: unknown upstream ref (``branch not found``)
- Error: ``--abort`` without an active rebase (``no rebase in progress``)
- Error: rebase producing conflicts (atomic abort)
- Error: no-arg call

## Test plan
- [x] ``bash test/vc_oracle_rebase_test.sh`` → 12/12 pass vs real Dolt 1.83.5
- [x] Full regression sweep: ``bash test/run_doltlite_tests.sh`` → 39/39 suites green
- [x] Manual smoke test: conflict path leaves branch in pre-rebase state (id=1 unchanged, log still shows pre-rebase commits only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)