### PR TITLE
rebase: interactive mode with pick/drop/reword/squash/fixup

### DIFF
--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -29,11 +29,25 @@
 #define CHUNK_MANIFEST_SIZE 168
 #define CHUNK_INDEX_ENTRY_SIZE 32     /* hash(20) + offset(8) + size(4) */
 
-/* Working set blob format:
-**   [version:1]
-**   [working_catalog:20][working_commit:20][staged_hash:20]
-**   [is_merging:1][merge_commit:20][conflicts:20] */
-#define WS_FORMAT_VERSION   2
+/* Working set blob format. v2 only has merge state; v3 adds rebase
+** state alongside it (parallel to Dolt's working set, which
+** contains optional MergeState and RebaseState substructures).
+**
+**   v2 layout (still readable for backward compat):
+**     [version:1]
+**     [working_catalog:20][working_commit:20][staged_hash:20]
+**     [is_merging:1][merge_commit:20][conflicts:20]
+**
+**   v3 layout (current write format):
+**     v2 fields, then:
+**     [is_rebasing:1]
+**     [pre_rebase_working_cat:20]
+**     [rebase_onto_commit:20]
+**     [rebase_orig_branch: WS_REBASE_BRANCH_LEN bytes, null-padded]
+*/
+#define WS_FORMAT_VERSION_V2 2
+#define WS_FORMAT_VERSION_V3 3
+#define WS_FORMAT_VERSION    WS_FORMAT_VERSION_V3
 #define WS_VERSION_SIZE     1
 #define WS_WORKING_CAT_OFF  WS_VERSION_SIZE
 #define WS_WORKING_COMMIT_OFF (WS_WORKING_CAT_OFF + PROLLY_HASH_SIZE)
@@ -41,7 +55,13 @@
 #define WS_MERGING_OFF      (WS_STAGED_OFF + PROLLY_HASH_SIZE)
 #define WS_MERGE_COMMIT_OFF (WS_MERGING_OFF + 1)
 #define WS_CONFLICTS_OFF    (WS_MERGE_COMMIT_OFF + PROLLY_HASH_SIZE)
-#define WS_TOTAL_SIZE       (WS_CONFLICTS_OFF + PROLLY_HASH_SIZE)
+#define WS_TOTAL_SIZE_V2    (WS_CONFLICTS_OFF + PROLLY_HASH_SIZE)
+#define WS_REBASING_OFF     WS_TOTAL_SIZE_V2
+#define WS_PRE_REBASE_CAT_OFF (WS_REBASING_OFF + 1)
+#define WS_REBASE_ONTO_OFF  (WS_PRE_REBASE_CAT_OFF + PROLLY_HASH_SIZE)
+#define WS_REBASE_BRANCH_OFF (WS_REBASE_ONTO_OFF + PROLLY_HASH_SIZE)
+#define WS_REBASE_BRANCH_LEN 64
+#define WS_TOTAL_SIZE       (WS_REBASE_BRANCH_OFF + WS_REBASE_BRANCH_LEN)
 
 /* Catalog (table registry) format:
 **   magic(1) + nTables(4 LE) + entries (sorted by name)

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -2250,21 +2250,17 @@ cleanup:
   return rc;
 }
 
-/* dolt_rebase: replay commits reachable from HEAD but not from the
-** upstream ref on top of the upstream. Shares the per-commit apply
-** logic with cherry-pick/revert via applyMergedCatalogAndCommit.
-** Atomic: if any replay step fails or produces conflicts, restore
-** the pre-rebase state and error out. Interactive mode and
-** --continue / --abort (beyond "no rebase in progress") are not
-** supported in this initial implementation. */
-static void doltliteRebaseFunc(
+/* Linear-replay rebase: the non-interactive path. Called by the
+** rebase dispatcher when no -i / --continue / --abort flag is
+** present. Atomic: any replay error or conflict restores the
+** pre-rebase state via the save/restore txn envelope. */
+static int doltliteRebaseLinearReplay(
+  sqlite3 *db,
   sqlite3_context *context,
-  int argc,
-  sqlite3_value **argv
+  const char *zUpstream,
+  char **pzFinalMessage
 ){
-  sqlite3 *db = sqlite3_context_db_handle(context);
   ChunkStore *cs = doltliteGetChunkStore(db);
-  const char *zUpstream;
   ProllyHash upstreamHash, headHash;
   ProllyHash *aReplay = 0;
   int nReplay = 0;
@@ -2274,23 +2270,261 @@ static void doltliteRebaseFunc(
   int rc;
   int i;
 
+  *pzFinalMessage = 0;
   memset(&saved, 0, sizeof(saved));
   memset(&upstreamCommit, 0, sizeof(upstreamCommit));
 
-  if( !cs ){ sqlite3_result_error(context, "no database", -1); return; }
-  if( argc<1 ){
-    sqlite3_result_error(context, "usage: dolt_rebase('upstream_branch')", -1);
-    return;
+  if( doltliteHasUncommittedChanges(db) ){
+    sqlite3_result_error(context,
+      "cannot start a rebase with uncommitted changes", -1);
+    return SQLITE_ERROR;
   }
 
-  zUpstream = (const char*)sqlite3_value_text(argv[0]);
-  if( !zUpstream ){
-    sqlite3_result_error(context, "upstream ref required", -1);
-    return;
+  rc = doltliteResolveRef(db, zUpstream, &upstreamHash);
+  if( rc!=SQLITE_OK ){
+    char *zErr = sqlite3_mprintf("branch not found: %s", zUpstream);
+    sqlite3_result_error(context, zErr ? zErr : "branch not found", -1);
+    sqlite3_free(zErr);
+    return SQLITE_ERROR;
   }
 
-  if( strcmp(zUpstream, "--abort")==0 || strcmp(zUpstream, "--continue")==0 ){
-    sqlite3_result_error(context, "no rebase in progress", -1);
+  doltliteGetSessionHead(db, &headHash);
+  if( prollyHashIsEmpty(&headHash) ){
+    sqlite3_result_error(context, "no commits on current branch", -1);
+    return SQLITE_ERROR;
+  }
+
+  rc = doltliteRebaseCollectReplaySet(db, &headHash, &upstreamHash,
+                                      &aReplay, &nReplay);
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error_code(context, rc);
+    return rc;
+  }
+  if( nReplay==0 ){
+    sqlite3_free(aReplay);
+    sqlite3_result_error(context, "didn't identify any commits!", -1);
+    return SQLITE_ERROR;
+  }
+
+  rc = doltliteSaveTxnState(db, &saved);
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(aReplay);
+    sqlite3_result_error_code(context, rc);
+    return rc;
+  }
+  savedInit = 1;
+
+  rc = doltliteLoadCommit(db, &upstreamHash, &upstreamCommit);
+  if( rc!=SQLITE_OK ) goto rollback;
+
+  rc = doltliteSwitchCatalog(db, &upstreamCommit.catalogHash);
+  if( rc!=SQLITE_OK ){
+    doltliteCommitClear(&upstreamCommit);
+    goto rollback;
+  }
+  doltliteSetSessionHead(db, &upstreamHash);
+  doltliteSetSessionStaged(db, &upstreamCommit.catalogHash);
+  rc = doltliteAdvanceBranch(db, &upstreamHash, &upstreamCommit.catalogHash);
+  doltliteCommitClear(&upstreamCommit);
+  memset(&upstreamCommit, 0, sizeof(upstreamCommit));
+  if( rc!=SQLITE_OK ) goto rollback;
+
+  for(i=0; i<nReplay; i++){
+    DoltliteCommit replayCommit, parentCommit, curHeadCommit;
+    ProllyHash curHead;
+    int nConflicts = 0;
+    char hexBuf[PROLLY_HASH_SIZE*2+1];
+
+    memset(&replayCommit, 0, sizeof(replayCommit));
+    memset(&parentCommit, 0, sizeof(parentCommit));
+    memset(&curHeadCommit, 0, sizeof(curHeadCommit));
+
+    rc = doltliteLoadCommit(db, &aReplay[i], &replayCommit);
+    if( rc!=SQLITE_OK ) goto rollback;
+
+    if( replayCommit.nParents==0 || prollyHashIsEmpty(&replayCommit.aParents[0]) ){
+      doltliteCommitClear(&replayCommit);
+      rc = SQLITE_ERROR;
+      goto rollback;
+    }
+    rc = doltliteLoadCommit(db, &replayCommit.aParents[0], &parentCommit);
+    if( rc!=SQLITE_OK ){
+      doltliteCommitClear(&replayCommit);
+      goto rollback;
+    }
+
+    doltliteGetSessionHead(db, &curHead);
+    rc = doltliteLoadCommit(db, &curHead, &curHeadCommit);
+    if( rc!=SQLITE_OK ){
+      doltliteCommitClear(&replayCommit);
+      doltliteCommitClear(&parentCommit);
+      goto rollback;
+    }
+
+    rc = applyMergedCatalogAndCommit(db, context,
+        &parentCommit.catalogHash,
+        &curHeadCommit.catalogHash,
+        &replayCommit.catalogHash,
+        &curHead,
+        replayCommit.zMessage ? replayCommit.zMessage : "",
+        &nConflicts, hexBuf);
+
+    doltliteCommitClear(&replayCommit);
+    doltliteCommitClear(&parentCommit);
+    doltliteCommitClear(&curHeadCommit);
+
+    if( rc!=SQLITE_OK ) goto rollback;
+    if( nConflicts>0 ){ rc = SQLITE_ERROR; goto rollback; }
+  }
+
+  doltliteTxnStateClear(&saved);
+  sqlite3_free(aReplay);
+  *pzFinalMessage = sqlite3_mprintf(
+    "Successfully rebased and updated refs/heads/%s",
+    doltliteGetSessionBranch(db));
+  return SQLITE_OK;
+
+rollback:
+  if( savedInit ){
+    int rc2 = doltliteRestoreTxnState(db, &saved);
+    doltliteTxnStateClear(&saved);
+    (void)rc2;
+  }
+  (void)cs;
+  sqlite3_free(aReplay);
+  {
+    char *zErr = sqlite3_mprintf(
+      "rebase failed (conflict or error during replay) — branch restored to pre-rebase state");
+    if( zErr ){
+      sqlite3_result_error(context, zErr, -1);
+      sqlite3_free(zErr);
+    }else{
+      sqlite3_result_error_code(context, rc);
+    }
+  }
+  return SQLITE_ERROR;
+}
+
+/* A single plan entry materialized from the dolt_rebase table. */
+typedef struct RebasePlanRow RebasePlanRow;
+struct RebasePlanRow {
+  double order;
+  char *zAction;
+  ProllyHash commitHash;
+  char *zCommitMessage;
+};
+
+static void rebaseFreePlan(RebasePlanRow *aPlan, int nPlan){
+  int i;
+  for(i=0; i<nPlan; i++){
+    sqlite3_free(aPlan[i].zAction);
+    sqlite3_free(aPlan[i].zCommitMessage);
+  }
+  sqlite3_free(aPlan);
+}
+
+/* Read the user's (possibly edited) rebase plan back out of the
+** dolt_rebase table, sorted by rebase_order. */
+static int rebaseReadPlan(sqlite3 *db, RebasePlanRow **paPlan, int *pnPlan){
+  sqlite3_stmt *pStmt = 0;
+  RebasePlanRow *aPlan = 0;
+  int nPlan = 0, nAlloc = 0;
+  int rc;
+
+  *paPlan = 0;
+  *pnPlan = 0;
+
+  rc = sqlite3_prepare_v2(db,
+    "SELECT rebase_order, action, commit_hash, commit_message "
+    "FROM dolt_rebase ORDER BY rebase_order", -1, &pStmt, 0);
+  if( rc!=SQLITE_OK ) return rc;
+
+  while( (rc = sqlite3_step(pStmt))==SQLITE_ROW ){
+    RebasePlanRow *r;
+    const char *zHex;
+
+    if( nPlan >= nAlloc ){
+      int nNew = nAlloc ? nAlloc*2 : 16;
+      RebasePlanRow *tmp = sqlite3_realloc(aPlan, nNew*(int)sizeof(RebasePlanRow));
+      if( !tmp ){ rc = SQLITE_NOMEM; goto fail; }
+      aPlan = tmp;
+      nAlloc = nNew;
+    }
+    r = &aPlan[nPlan];
+    memset(r, 0, sizeof(*r));
+    r->order = sqlite3_column_double(pStmt, 0);
+    r->zAction = sqlite3_mprintf("%s",
+        (const char*)sqlite3_column_text(pStmt, 1));
+    zHex = (const char*)sqlite3_column_text(pStmt, 2);
+    if( !zHex || doltliteHexToHash(zHex, &r->commitHash)!=SQLITE_OK ){
+      rc = SQLITE_CORRUPT;
+      sqlite3_free(r->zAction);
+      goto fail;
+    }
+    r->zCommitMessage = sqlite3_mprintf("%s",
+        (const char*)sqlite3_column_text(pStmt, 3));
+    if( !r->zAction || !r->zCommitMessage ){
+      rc = SQLITE_NOMEM;
+      goto fail;
+    }
+    nPlan++;
+  }
+  sqlite3_finalize(pStmt);
+  if( rc!=SQLITE_DONE ){ rc = SQLITE_OK; /* ignore */ }
+
+  *paPlan = aPlan;
+  *pnPlan = nPlan;
+  return SQLITE_OK;
+
+fail:
+  sqlite3_finalize(pStmt);
+  rebaseFreePlan(aPlan, nPlan);
+  return rc;
+}
+
+/* Checkout helper used by rebase to switch the session back to the
+** original branch after --continue or --abort. Delegates to the
+** existing dolt_checkout function so we don't reimplement the full
+** state transition (working set load, catalog switch, branch ref
+** lookup, etc.). */
+static int rebaseCheckoutBranch(sqlite3 *db, const char *zBranch){
+  char *zSql;
+  int rc;
+  zSql = sqlite3_mprintf("SELECT dolt_checkout('%q')", zBranch);
+  if( !zSql ) return SQLITE_NOMEM;
+  rc = sqlite3_exec(db, zSql, 0, 0, 0);
+  sqlite3_free(zSql);
+  return rc;
+}
+
+/* Interactive start (`dolt_rebase('-i', 'upstream')`). Creates a
+** working branch dolt_rebase_<orig>, checks it out pointing at
+** upstream, writes the rebase state into the working set, and
+** materializes the default plan into a SQL table named dolt_rebase
+** that the user can edit via DML before calling --continue. */
+static void doltliteRebaseInteractiveStart(
+  sqlite3_context *context,
+  sqlite3 *db,
+  const char *zUpstream
+){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  char *zOrig = 0;
+  char *zWorking = 0;
+  ProllyHash upstreamHash, headHash;
+  ProllyHash preRebaseCat;
+  ProllyHash *aReplay = 0;
+  int nReplay = 0;
+  sqlite3_stmt *pIns = 0;
+  int rc;
+  int i;
+  u8 curIsRebasing = 0;
+
+  memset(&preRebaseCat, 0, sizeof(preRebaseCat));
+
+  doltliteGetSessionRebaseState(db, &curIsRebasing, 0, 0, 0);
+  if( curIsRebasing ){
+    sqlite3_result_error(context,
+      "rebase already in progress; use --continue or --abort", -1);
     return;
   }
 
@@ -2326,117 +2560,471 @@ static void doltliteRebaseFunc(
     return;
   }
 
-  rc = doltliteSaveTxnState(db, &saved);
-  if( rc!=SQLITE_OK ){
+  /* Copy the original branch name off the session struct — the
+  ** upcoming dolt_checkout('dolt_rebase_feat') will free the
+  ** current p->zBranch pointer, and any uncopied reference we hold
+  ** would dangle into freed memory. */
+  zOrig = sqlite3_mprintf("%s", doltliteGetSessionBranch(db));
+  zWorking = sqlite3_mprintf("dolt_rebase_%s", zOrig ? zOrig : "");
+  if( !zOrig || !zWorking ){
+    sqlite3_free(zOrig);
+    sqlite3_free(zWorking);
     sqlite3_free(aReplay);
-    sqlite3_result_error_code(context, rc);
+    sqlite3_result_error_code(context, SQLITE_NOMEM);
     return;
   }
-  savedInit = 1;
+  {
+    ProllyHash probe;
+    if( chunkStoreFindBranch(cs, zWorking, &probe)==SQLITE_OK ){
+      sqlite3_free(zOrig);
+      sqlite3_free(zWorking);
+      sqlite3_free(aReplay);
+      sqlite3_result_error(context,
+        "rebase working branch already exists", -1);
+      return;
+    }
+  }
 
-  /* Reset the branch to the upstream tip so applyMergedCatalog sees
-  ** a consistent session HEAD for the first replay iteration. The
-  ** saved txn state will undo this on rollback. */
-  rc = doltliteLoadCommit(db, &upstreamHash, &upstreamCommit);
-  if( rc!=SQLITE_OK ) goto rollback;
+  /* Flush the original branch's current working catalog so --abort
+  ** can restore exactly what the user had before the rebase. */
+  rc = doltliteFlushCatalogToHash(db, &preRebaseCat);
+  if( rc!=SQLITE_OK ) goto fail;
 
-  rc = doltliteSwitchCatalog(db, &upstreamCommit.catalogHash);
+  /* Create the working branch at upstream and switch to it. We do
+  ** this via SQL so the session state flips cleanly via the existing
+  ** checkout machinery. */
+  {
+    char *zSql = sqlite3_mprintf(
+      "SELECT dolt_branch('%q', '%q'); SELECT dolt_checkout('%q');",
+      zWorking, zUpstream, zWorking);
+    if( !zSql ){ rc = SQLITE_NOMEM; goto fail; }
+    rc = sqlite3_exec(db, zSql, 0, 0, 0);
+    sqlite3_free(zSql);
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(zOrig);
+      sqlite3_free(zWorking);
+      sqlite3_free(aReplay);
+      sqlite3_result_error(context,
+        "failed to create rebase working branch", -1);
+      return;
+    }
+  }
+
+  /* Materialize the default plan as a real SQL table on the
+  ** working branch. Create and populate BEFORE setting the rebase
+  ** state — each DDL/DML statement opens a write trans that
+  ** reloads the working set from disk, which would clobber any
+  ** in-memory rebase state we set beforehand. By deferring the
+  ** state flip until after the plan table is populated, the
+  ** reloads pick up a clean "no rebase yet" state, and the final
+  ** persist atomically flips disk to rebase=1 along with the plan. */
+  rc = sqlite3_exec(db,
+    "CREATE TABLE dolt_rebase("
+    "  rebase_order REAL PRIMARY KEY,"
+    "  action TEXT,"
+    "  commit_hash TEXT,"
+    "  commit_message TEXT"
+    ")", 0, 0, 0);
   if( rc!=SQLITE_OK ){
-    doltliteCommitClear(&upstreamCommit);
-    goto rollback;
+    sqlite3_free(zOrig);
+    sqlite3_free(zWorking);
+    sqlite3_free(aReplay);
+    sqlite3_result_error(context, "failed to create dolt_rebase table", -1);
+    return;
   }
-  doltliteSetSessionHead(db, &upstreamHash);
-  doltliteSetSessionStaged(db, &upstreamCommit.catalogHash);
-  rc = doltliteAdvanceBranch(db, &upstreamHash, &upstreamCommit.catalogHash);
-  doltliteCommitClear(&upstreamCommit);
-  memset(&upstreamCommit, 0, sizeof(upstreamCommit));
-  if( rc!=SQLITE_OK ) goto rollback;
 
+  rc = sqlite3_prepare_v2(db,
+    "INSERT INTO dolt_rebase VALUES (?, 'pick', ?, ?)", -1, &pIns, 0);
+  if( rc!=SQLITE_OK ) goto fail;
   for(i=0; i<nReplay; i++){
-    DoltliteCommit replayCommit, parentCommit, curHeadCommit;
-    ProllyHash curHead;
-    int nConflicts = 0;
-    char hexBuf[PROLLY_HASH_SIZE*2+1];
+    DoltliteCommit c;
+    char zHex[PROLLY_HASH_SIZE*2+1];
+    memset(&c, 0, sizeof(c));
+    rc = doltliteLoadCommit(db, &aReplay[i], &c);
+    if( rc!=SQLITE_OK ){ sqlite3_finalize(pIns); goto fail; }
+    doltliteHashToHex(&aReplay[i], zHex);
 
-    memset(&replayCommit, 0, sizeof(replayCommit));
-    memset(&parentCommit, 0, sizeof(parentCommit));
-    memset(&curHeadCommit, 0, sizeof(curHeadCommit));
-
-    rc = doltliteLoadCommit(db, &aReplay[i], &replayCommit);
-    if( rc!=SQLITE_OK ) goto rollback;
-
-    if( replayCommit.nParents==0 || prollyHashIsEmpty(&replayCommit.aParents[0]) ){
-      /* Root commit can't be replayed — no parent to diff against. */
-      doltliteCommitClear(&replayCommit);
-      rc = SQLITE_ERROR;
-      goto rollback;
-    }
-    rc = doltliteLoadCommit(db, &replayCommit.aParents[0], &parentCommit);
-    if( rc!=SQLITE_OK ){
-      doltliteCommitClear(&replayCommit);
-      goto rollback;
-    }
-
-    doltliteGetSessionHead(db, &curHead);
-    rc = doltliteLoadCommit(db, &curHead, &curHeadCommit);
-    if( rc!=SQLITE_OK ){
-      doltliteCommitClear(&replayCommit);
-      doltliteCommitClear(&parentCommit);
-      goto rollback;
-    }
-
-    rc = applyMergedCatalogAndCommit(db, context,
-        &parentCommit.catalogHash,
-        &curHeadCommit.catalogHash,
-        &replayCommit.catalogHash,
-        &curHead,
-        replayCommit.zMessage ? replayCommit.zMessage : "",
-        &nConflicts, hexBuf);
-
-    doltliteCommitClear(&replayCommit);
-    doltliteCommitClear(&parentCommit);
-    doltliteCommitClear(&curHeadCommit);
-
-    if( rc!=SQLITE_OK ){
-      goto rollback;
-    }
-    if( nConflicts>0 ){
-      /* Conflict during a replay. applyMerged has staged the
-      ** conflict and set the session to "merging" state; undo all
-      ** of that by restoring the saved pre-rebase state. */
-      rc = SQLITE_ERROR;
-      goto rollback;
-    }
+    sqlite3_reset(pIns);
+    sqlite3_bind_double(pIns, 1, (double)(i + 1));
+    sqlite3_bind_text(pIns, 2, zHex, -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(pIns, 3,
+        c.zMessage ? c.zMessage : "", -1, SQLITE_TRANSIENT);
+    rc = sqlite3_step(pIns);
+    doltliteCommitClear(&c);
+    if( rc!=SQLITE_DONE ){ sqlite3_finalize(pIns); goto fail; }
   }
+  sqlite3_finalize(pIns);
 
-  doltliteTxnStateClear(&saved);
+  /* Now set the rebase state on the session and persist it.
+  ** Nothing after this triggers a reload before -i returns. */
+  doltliteSetSessionRebaseState(db, 1, &preRebaseCat, &upstreamHash, zOrig);
+  rc = doltlitePersistWorkingSet(db);
+  if( rc!=SQLITE_OK ) goto fail;
+
+  sqlite3_free(zOrig);
   sqlite3_free(aReplay);
   {
-    char *zMsg = sqlite3_mprintf("Successfully rebased and updated refs/heads/%s",
-                                 doltliteGetSessionBranch(db));
-    if( zMsg ){
-      sqlite3_result_text(context, zMsg, -1, sqlite3_free);
-    }else{
-      sqlite3_result_text(context, "Successfully rebased", -1, SQLITE_STATIC);
-    }
+    char *zMsg = sqlite3_mprintf(
+      "interactive rebase started on branch %s; adjust the rebase plan "
+      "in the dolt_rebase table, then continue rebasing by calling "
+      "dolt_rebase('--continue')", zWorking);
+    sqlite3_free(zWorking);
+    if( zMsg ) sqlite3_result_text(context, zMsg, -1, sqlite3_free);
+    else sqlite3_result_text(context, "interactive rebase started", -1, SQLITE_STATIC);
   }
   return;
 
-rollback:
-  if( savedInit ){
-    int rc2 = doltliteRestoreTxnState(db, &saved);
-    doltliteTxnStateClear(&saved);
-    (void)rc2;
-  }
+fail:
+  sqlite3_free(zOrig);
+  sqlite3_free(zWorking);
   sqlite3_free(aReplay);
+  sqlite3_result_error_code(context, rc);
+}
+
+/* Interactive abort: the working branch is thrown away and the
+** session returns to the original branch unchanged. */
+static void doltliteRebaseInteractiveAbort(
+  sqlite3_context *context,
+  sqlite3 *db
+){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  u8 isRebasing = 0;
+  const char *zOrigBranchConst = 0;
+  char *zOrigBranch = 0;
+  char *zWorking = 0;
+  int rc;
+
+  doltliteGetSessionRebaseState(db, &isRebasing, 0, 0, &zOrigBranchConst);
+  if( !isRebasing || !zOrigBranchConst ){
+    sqlite3_result_error(context, "no rebase in progress", -1);
+    return;
+  }
+  zOrigBranch = sqlite3_mprintf("%s", zOrigBranchConst);
+  zWorking = sqlite3_mprintf("%s", doltliteGetSessionBranch(db));
+  if( !zOrigBranch || !zWorking ){
+    sqlite3_free(zOrigBranch);
+    sqlite3_free(zWorking);
+    sqlite3_result_error_code(context, SQLITE_NOMEM);
+    return;
+  }
+
+  /* The working branch has the dolt_rebase plan table as an
+  ** uncommitted change. Drop it so checkout doesn't refuse, and
+  ** clear the session rebase state so the post-checkout persist
+  ** doesn't leak stale values. */
+  (void)sqlite3_exec(db, "DROP TABLE IF EXISTS dolt_rebase", 0, 0, 0);
+  doltliteClearSessionRebaseState(db);
+  rc = doltlitePersistWorkingSet(db);
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(zOrigBranch);
+    sqlite3_free(zWorking);
+    sqlite3_result_error_code(context, rc);
+    return;
+  }
+
+  rc = rebaseCheckoutBranch(db, zOrigBranch);
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(zOrigBranch);
+    sqlite3_free(zWorking);
+    sqlite3_result_error(context, "abort: failed to checkout original branch", -1);
+    return;
+  }
+
+  (void)chunkStoreDeleteBranch(cs, zWorking);
+  (void)chunkStoreSerializeRefs(cs);
+  (void)chunkStoreCommit(cs);
+
+  sqlite3_free(zOrigBranch);
+  sqlite3_free(zWorking);
+  sqlite3_result_text(context, "Interactive rebase aborted", -1, SQLITE_STATIC);
+}
+
+/* Interactive continue: read the user-edited plan, drop the
+** dolt_rebase table, group the plan rows into pick/squash/fixup
+** groups, replay each group as one combined commit on top of the
+** working branch, then move the original branch ref to the new
+** tip and checkout the original branch. */
+static void doltliteRebaseInteractiveContinue(
+  sqlite3_context *context,
+  sqlite3 *db
+){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  u8 isRebasing = 0;
+  const char *zOrigBranchConst = 0;
+  char *zOrigBranch = 0;
+  char *zWorking = 0;
+  RebasePlanRow *aPlan = 0;
+  int nPlan = 0;
+  int rc;
+  int i;
+  ProllyHash curCat;
+  ProllyHash curHead;
+
+  memset(&curCat, 0, sizeof(curCat));
+  memset(&curHead, 0, sizeof(curHead));
+
+  doltliteGetSessionRebaseState(db, &isRebasing, 0, 0, &zOrigBranchConst);
+  if( !isRebasing || !zOrigBranchConst ){
+    sqlite3_result_error(context, "no rebase in progress", -1);
+    return;
+  }
+  zOrigBranch = sqlite3_mprintf("%s", zOrigBranchConst);
+  zWorking = sqlite3_mprintf("%s", doltliteGetSessionBranch(db));
+  if( !zOrigBranch || !zWorking ){ rc = SQLITE_NOMEM; goto abort_err; }
+
+  rc = rebaseReadPlan(db, &aPlan, &nPlan);
+  if( rc!=SQLITE_OK ) goto abort_err;
+
+  rc = sqlite3_exec(db, "DROP TABLE dolt_rebase", 0, 0, 0);
+  if( rc!=SQLITE_OK ) goto abort_err;
+
+  /* Flush catalog (now without dolt_rebase) to get the clean base
+  ** catalog hash that iterating merges will build on. */
+  rc = doltliteFlushCatalogToHash(db, &curCat);
+  if( rc!=SQLITE_OK ) goto abort_err;
+  doltliteGetSessionHead(db, &curHead);
+
+  /* Walk the plan in order, grouping each pick/reword with any
+  ** immediately-following squash/fixup rows. A group finishes at
+  ** the next pick/reword (or end of plan) and produces ONE
+  ** combined commit with the accumulated content and message. */
+  i = 0;
+  while( i < nPlan ){
+    RebasePlanRow *leader;
+    char *combinedMsg = 0;
+    ProllyHash mergedCat;
+    int nConflicts = 0;
+    int j;
+    DoltliteCommit parentC, replayC, curHeadC;
+
+    /* Skip drops. */
+    while( i < nPlan && strcmp(aPlan[i].zAction, "drop")==0 ) i++;
+    if( i >= nPlan ) break;
+
+    leader = &aPlan[i];
+    if( strcmp(leader->zAction, "pick")!=0
+     && strcmp(leader->zAction, "reword")!=0 ){
+      rc = SQLITE_ERROR;
+      sqlite3_result_error(context,
+        "first non-drop action must be pick or reword", -1);
+      goto abort_err_silent;
+    }
+
+    /* Apply leader. */
+    memset(&parentC, 0, sizeof(parentC));
+    memset(&replayC, 0, sizeof(replayC));
+    rc = doltliteLoadCommit(db, &leader->commitHash, &replayC);
+    if( rc!=SQLITE_OK ){ goto abort_err; }
+    if( replayC.nParents==0 || prollyHashIsEmpty(&replayC.aParents[0]) ){
+      doltliteCommitClear(&replayC);
+      rc = SQLITE_ERROR;
+      goto abort_err;
+    }
+    rc = doltliteLoadCommit(db, &replayC.aParents[0], &parentC);
+    if( rc!=SQLITE_OK ){
+      doltliteCommitClear(&replayC);
+      goto abort_err;
+    }
+
+    rc = doltliteMergeCatalogs(db, &parentC.catalogHash, &curCat,
+                               &replayC.catalogHash, &mergedCat,
+                               &nConflicts, 0, 0, 0);
+    doltliteCommitClear(&parentC);
+    doltliteCommitClear(&replayC);
+    if( rc!=SQLITE_OK ) goto abort_err;
+    if( nConflicts>0 ){ rc = SQLITE_ERROR; goto abort_err_conflict; }
+
+    curCat = mergedCat;
+    combinedMsg = sqlite3_mprintf("%s",
+        leader->zCommitMessage ? leader->zCommitMessage : "");
+    if( !combinedMsg ){ rc = SQLITE_NOMEM; goto abort_err; }
+
+    /* Apply any squash/fixup followers. */
+    j = i + 1;
+    while( j < nPlan
+        && (strcmp(aPlan[j].zAction, "squash")==0
+         || strcmp(aPlan[j].zAction, "fixup")==0
+         || strcmp(aPlan[j].zAction, "drop")==0) ){
+      if( strcmp(aPlan[j].zAction, "drop")==0 ){ j++; continue; }
+
+      memset(&parentC, 0, sizeof(parentC));
+      memset(&replayC, 0, sizeof(replayC));
+      rc = doltliteLoadCommit(db, &aPlan[j].commitHash, &replayC);
+      if( rc!=SQLITE_OK ){ sqlite3_free(combinedMsg); goto abort_err; }
+      if( replayC.nParents==0 || prollyHashIsEmpty(&replayC.aParents[0]) ){
+        doltliteCommitClear(&replayC);
+        sqlite3_free(combinedMsg);
+        rc = SQLITE_ERROR;
+        goto abort_err;
+      }
+      rc = doltliteLoadCommit(db, &replayC.aParents[0], &parentC);
+      if( rc!=SQLITE_OK ){
+        doltliteCommitClear(&replayC);
+        sqlite3_free(combinedMsg);
+        goto abort_err;
+      }
+
+      rc = doltliteMergeCatalogs(db, &parentC.catalogHash, &curCat,
+                                 &replayC.catalogHash, &mergedCat,
+                                 &nConflicts, 0, 0, 0);
+      doltliteCommitClear(&parentC);
+      doltliteCommitClear(&replayC);
+      if( rc!=SQLITE_OK ){ sqlite3_free(combinedMsg); goto abort_err; }
+      if( nConflicts>0 ){
+        sqlite3_free(combinedMsg);
+        rc = SQLITE_ERROR;
+        goto abort_err_conflict;
+      }
+      curCat = mergedCat;
+
+      if( strcmp(aPlan[j].zAction, "squash")==0 ){
+        char *zNew = sqlite3_mprintf("%s\n\n%s", combinedMsg,
+                                     aPlan[j].zCommitMessage ? aPlan[j].zCommitMessage : "");
+        sqlite3_free(combinedMsg);
+        combinedMsg = zNew;
+        if( !combinedMsg ){ rc = SQLITE_NOMEM; goto abort_err; }
+      }
+      /* fixup: message discarded. */
+      j++;
+    }
+
+    /* Create the combined commit and advance the working branch. */
+    memset(&curHeadC, 0, sizeof(curHeadC));
+    {
+      ProllyHash newCommit;
+      rc = doltliteCreateAndStoreCommit(db, &curHead, &curCat, combinedMsg,
+                                        NULL, NULL, NULL, 0, &newCommit);
+      if( rc!=SQLITE_OK ){ sqlite3_free(combinedMsg); goto abort_err; }
+
+      rc = doltliteSwitchCatalog(db, &curCat);
+      if( rc!=SQLITE_OK ){ sqlite3_free(combinedMsg); goto abort_err; }
+      doltliteSetSessionStaged(db, &curCat);
+      rc = doltliteAdvanceBranch(db, &newCommit, &curCat);
+      if( rc!=SQLITE_OK ){ sqlite3_free(combinedMsg); goto abort_err; }
+      curHead = newCommit;
+    }
+    sqlite3_free(combinedMsg);
+
+    i = j;
+  }
+
+  /* Move the original branch ref to the new tip and copy the
+  ** working-branch working-catalog over. */
+  rc = chunkStoreUpdateBranch(cs, zOrigBranch, &curHead);
+  if( rc!=SQLITE_OK ) goto abort_err;
+  rc = chunkStoreWriteBranchWorkingCatalog(cs, zOrigBranch, &curCat, &curHead);
+  if( rc!=SQLITE_OK ) goto abort_err;
+
+  /* Clear rebase state on the working branch's session state so it
+  ** doesn't leak into the checkout that follows. */
+  doltliteClearSessionRebaseState(db);
+  rc = doltlitePersistWorkingSet(db);
+  if( rc!=SQLITE_OK ) goto abort_err;
+
+  rc = rebaseCheckoutBranch(db, zOrigBranch);
+  if( rc!=SQLITE_OK ) goto abort_err;
+
+  (void)chunkStoreDeleteBranch(cs, zWorking);
+  (void)chunkStoreSerializeRefs(cs);
+  (void)chunkStoreCommit(cs);
+
+  rebaseFreePlan(aPlan, nPlan);
   {
-    char *zErr = sqlite3_mprintf(
-      "rebase failed (conflict or error during replay) — branch restored to pre-rebase state");
-    if( zErr ){
-      sqlite3_result_error(context, zErr, -1);
-      sqlite3_free(zErr);
-    }else{
-      sqlite3_result_error_code(context, rc);
+    char *zMsg = sqlite3_mprintf(
+      "Successfully rebased and updated refs/heads/%s", zOrigBranch);
+    sqlite3_free(zOrigBranch);
+    sqlite3_free(zWorking);
+    if( zMsg ) sqlite3_result_text(context, zMsg, -1, sqlite3_free);
+    else sqlite3_result_text(context, "Successfully rebased", -1, SQLITE_STATIC);
+  }
+  return;
+
+abort_err_conflict:
+  rebaseFreePlan(aPlan, nPlan);
+  /* Throw away the working branch and restore the original. */
+  doltliteClearSessionRebaseState(db);
+  (void)doltlitePersistWorkingSet(db);
+  (void)rebaseCheckoutBranch(db, zOrigBranch);
+  (void)chunkStoreDeleteBranch(cs, zWorking);
+  (void)chunkStoreSerializeRefs(cs);
+  (void)chunkStoreCommit(cs);
+  sqlite3_free(zOrigBranch);
+  sqlite3_free(zWorking);
+  sqlite3_result_error(context,
+    "data conflicts from rebase — rebase has been aborted", -1);
+  return;
+
+abort_err:
+  rebaseFreePlan(aPlan, nPlan);
+  doltliteClearSessionRebaseState(db);
+  (void)doltlitePersistWorkingSet(db);
+  (void)rebaseCheckoutBranch(db, zOrigBranch ? zOrigBranch : "main");
+  if( zWorking ) (void)chunkStoreDeleteBranch(cs, zWorking);
+  (void)chunkStoreSerializeRefs(cs);
+  (void)chunkStoreCommit(cs);
+  sqlite3_free(zOrigBranch);
+  sqlite3_free(zWorking);
+  sqlite3_result_error(context, "rebase failed — branch restored to pre-rebase state", -1);
+  return;
+
+abort_err_silent:
+  rebaseFreePlan(aPlan, nPlan);
+  sqlite3_free(zOrigBranch);
+  sqlite3_free(zWorking);
+}
+
+/* Dispatcher for dolt_rebase. */
+static void doltliteRebaseFunc(
+  sqlite3_context *context,
+  int argc,
+  sqlite3_value **argv
+){
+  sqlite3 *db = sqlite3_context_db_handle(context);
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  const char *zArg0;
+
+  if( !cs ){ sqlite3_result_error(context, "no database", -1); return; }
+  if( argc<1 ){
+    sqlite3_result_error(context, "usage: dolt_rebase('upstream_branch')", -1);
+    return;
+  }
+
+  zArg0 = (const char*)sqlite3_value_text(argv[0]);
+  if( !zArg0 ){
+    sqlite3_result_error(context, "upstream ref required", -1);
+    return;
+  }
+
+  if( strcmp(zArg0, "--abort")==0 ){
+    doltliteRebaseInteractiveAbort(context, db);
+    return;
+  }
+  if( strcmp(zArg0, "--continue")==0 ){
+    doltliteRebaseInteractiveContinue(context, db);
+    return;
+  }
+  if( strcmp(zArg0, "-i")==0 || strcmp(zArg0, "--interactive")==0 ){
+    const char *zUpstream;
+    if( argc<2 ){
+      sqlite3_result_error(context,
+        "interactive rebase requires upstream branch: "
+        "dolt_rebase('-i', 'upstream')", -1);
+      return;
+    }
+    zUpstream = (const char*)sqlite3_value_text(argv[1]);
+    if( !zUpstream ){
+      sqlite3_result_error(context, "upstream ref required", -1);
+      return;
+    }
+    doltliteRebaseInteractiveStart(context, db, zUpstream);
+    return;
+  }
+
+  {
+    char *zFinalMessage = 0;
+    int rc = doltliteRebaseLinearReplay(db, context, zArg0, &zFinalMessage);
+    if( rc==SQLITE_OK && zFinalMessage ){
+      sqlite3_result_text(context, zFinalMessage, -1, sqlite3_free);
     }
   }
 }

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -130,6 +130,15 @@ void doltliteSetSessionMergeState(sqlite3 *db, u8 isMerging,
                                   const ProllyHash *pMergeCommit,
                                   const ProllyHash *pConflictsCatalog);
 void doltliteClearSessionMergeState(sqlite3 *db);
+void doltliteGetSessionRebaseState(sqlite3 *db, u8 *pIsRebasing,
+                                   ProllyHash *pPreRebaseCat,
+                                   ProllyHash *pRebaseOnto,
+                                   const char **pzOrigBranch);
+void doltliteSetSessionRebaseState(sqlite3 *db, u8 isRebasing,
+                                   const ProllyHash *pPreRebaseCat,
+                                   const ProllyHash *pRebaseOnto,
+                                   const char *zOrigBranch);
+void doltliteClearSessionRebaseState(sqlite3 *db);
 void doltliteGetSessionConflictsCatalog(sqlite3 *db, ProllyHash *pHash);
 void doltliteSetSessionConflictsCatalog(sqlite3 *db, const ProllyHash *pHash);
 int doltliteSaveWorkingSet(sqlite3 *db);

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -282,6 +282,18 @@ struct Btree {
   u8 isMerging;
   ProllyHash mergeCommitHash;
   ProllyHash conflictsCatalogHash;
+
+  /* Active interactive-rebase state, parallel to merge state.
+  ** Persisted into the working set blob (v3). isRebasing is 1 when
+  ** a `dolt_rebase('-i', ...)` call has set things up and not yet
+  ** been --continue'd or --abort'd. preRebaseWorkingCat is the
+  ** working catalog of the original branch before the rebase
+  ** started, used by --abort to restore cleanly. */
+  u8 isRebasing;
+  ProllyHash preRebaseWorkingCat;
+  ProllyHash rebaseOntoCommit;
+  char *zRebaseOrigBranch;
+
   const struct BtreeOps *pOps;
   void *pOrigBtree;
 };
@@ -380,7 +392,11 @@ static int btreeLoadWorkingSetBlob(
   ProllyHash *pStaged,
   u8 *pIsMerging,
   ProllyHash *pMergeCommit,
-  ProllyHash *pConflicts
+  ProllyHash *pConflicts,
+  u8 *pIsRebasing,
+  ProllyHash *pPreRebaseCat,
+  ProllyHash *pRebaseOnto,
+  char **pzRebaseOrigBranch
 );
 
 static int canReadCursorOwnPending(BtShared *pBt, struct TableEntry *pTE){
@@ -395,7 +411,11 @@ static int btreeStoreWorkingSetBlob(
   const ProllyHash *pStaged,
   u8 isMerging,
   const ProllyHash *pMergeCommit,
-  const ProllyHash *pConflicts
+  const ProllyHash *pConflicts,
+  u8 isRebasing,
+  const ProllyHash *pPreRebaseCat,
+  const ProllyHash *pRebaseOnto,
+  const char *zRebaseOrigBranch
 );
 static int btreeWriteWorkingState(
   ChunkStore *cs,
@@ -1973,6 +1993,10 @@ int sqlite3BtreeOpen(
     ProllyHash mergeCommitHash;
     ProllyHash conflictsCatalogHash;
     ProllyHash branchCommit;
+    ProllyHash preRebaseCat;
+    ProllyHash rebaseOnto;
+    char *zRebaseOrigBranch = 0;
+    u8 isRebasing = 0;
     const char *zDef = chunkStoreGetDefaultBranch(&pBt->store);
     u8 isMerging = 0;
     if( !zDef ) zDef = "main";
@@ -1982,9 +2006,13 @@ int sqlite3BtreeOpen(
     memset(&mergeCommitHash, 0, sizeof(mergeCommitHash));
     memset(&conflictsCatalogHash, 0, sizeof(conflictsCatalogHash));
     memset(&branchCommit, 0, sizeof(branchCommit));
+    memset(&preRebaseCat, 0, sizeof(preRebaseCat));
+    memset(&rebaseOnto, 0, sizeof(rebaseOnto));
     rc = btreeLoadWorkingSetBlob(&pBt->store, zDef, &catHash, &workingCommit,
                                  &stagedCatalog, &isMerging,
-                                 &mergeCommitHash, &conflictsCatalogHash);
+                                 &mergeCommitHash, &conflictsCatalogHash,
+                                 &isRebasing, &preRebaseCat, &rebaseOnto,
+                                 &zRebaseOrigBranch);
     if( rc==SQLITE_NOTFOUND ){
       rc = SQLITE_OK;
     }
@@ -2035,6 +2063,10 @@ int sqlite3BtreeOpen(
     p->isMerging = isMerging;
     p->mergeCommitHash = mergeCommitHash;
     p->conflictsCatalogHash = conflictsCatalogHash;
+    p->isRebasing = isRebasing;
+    p->preRebaseWorkingCat = preRebaseCat;
+    p->rebaseOntoCommit = rebaseOnto;
+    p->zRebaseOrigBranch = zRebaseOrigBranch;
   }
 
 
@@ -2117,6 +2149,7 @@ static int prollyBtreeClose(Btree *p){
   sqlite3_free(p->zBranch);
   sqlite3_free(p->zAuthorName);
   sqlite3_free(p->zAuthorEmail);
+  sqlite3_free(p->zRebaseOrigBranch);
   sqlite3_free(p);
   return SQLITE_OK;
 }
@@ -2306,12 +2339,17 @@ static int btreeLoadWorkingSetBlob(
   ProllyHash *pStaged,
   u8 *pIsMerging,
   ProllyHash *pMergeCommit,
-  ProllyHash *pConflicts
+  ProllyHash *pConflicts,
+  u8 *pIsRebasing,
+  ProllyHash *pPreRebaseCat,
+  ProllyHash *pRebaseOnto,
+  char **pzRebaseOrigBranch
 ){
   ProllyHash wsHash;
   u8 *data = 0;
   int nData = 0;
   int rc;
+  u8 version;
 
   if( pWorkingCat ) memset(pWorkingCat, 0, sizeof(ProllyHash));
   if( pWorkingCommit ) memset(pWorkingCommit, 0, sizeof(ProllyHash));
@@ -2319,13 +2357,22 @@ static int btreeLoadWorkingSetBlob(
   if( pIsMerging ) *pIsMerging = 0;
   if( pMergeCommit ) memset(pMergeCommit, 0, sizeof(ProllyHash));
   if( pConflicts ) memset(pConflicts, 0, sizeof(ProllyHash));
+  if( pIsRebasing ) *pIsRebasing = 0;
+  if( pPreRebaseCat ) memset(pPreRebaseCat, 0, sizeof(ProllyHash));
+  if( pRebaseOnto ) memset(pRebaseOnto, 0, sizeof(ProllyHash));
+  if( pzRebaseOrigBranch ) *pzRebaseOrigBranch = 0;
 
   rc = chunkStoreGetBranchWorkingSet(cs, zBranch, &wsHash);
   if( rc!=SQLITE_OK || prollyHashIsEmpty(&wsHash) ) return SQLITE_NOTFOUND;
 
   rc = chunkStoreGet(cs, &wsHash, &data, &nData);
   if( rc!=SQLITE_OK ) return rc;
-  if( !data || nData < WS_TOTAL_SIZE || data[0] != WS_FORMAT_VERSION ){
+  if( !data || nData < WS_TOTAL_SIZE_V2 ){
+    sqlite3_free(data);
+    return SQLITE_CORRUPT;
+  }
+  version = data[0];
+  if( version != WS_FORMAT_VERSION_V2 && version != WS_FORMAT_VERSION_V3 ){
     sqlite3_free(data);
     return SQLITE_CORRUPT;
   }
@@ -2336,6 +2383,26 @@ static int btreeLoadWorkingSetBlob(
   if( pIsMerging ) *pIsMerging = data[WS_MERGING_OFF];
   if( pMergeCommit ) memcpy(pMergeCommit->data, data + WS_MERGE_COMMIT_OFF, PROLLY_HASH_SIZE);
   if( pConflicts ) memcpy(pConflicts->data, data + WS_CONFLICTS_OFF, PROLLY_HASH_SIZE);
+
+  if( version == WS_FORMAT_VERSION_V3 && nData >= WS_TOTAL_SIZE ){
+    if( pIsRebasing ) *pIsRebasing = data[WS_REBASING_OFF];
+    if( pPreRebaseCat ) memcpy(pPreRebaseCat->data,
+                                data + WS_PRE_REBASE_CAT_OFF, PROLLY_HASH_SIZE);
+    if( pRebaseOnto ) memcpy(pRebaseOnto->data,
+                              data + WS_REBASE_ONTO_OFF, PROLLY_HASH_SIZE);
+    if( pzRebaseOrigBranch ){
+      const char *src = (const char*)(data + WS_REBASE_BRANCH_OFF);
+      int n = 0;
+      while( n < WS_REBASE_BRANCH_LEN && src[n] ) n++;
+      if( n > 0 ){
+        char *z = sqlite3_malloc(n + 1);
+        if( !z ){ sqlite3_free(data); return SQLITE_NOMEM; }
+        memcpy(z, src, n);
+        z[n] = 0;
+        *pzRebaseOrigBranch = z;
+      }
+    }
+  }
   sqlite3_free(data);
   return SQLITE_OK;
 }
@@ -2348,13 +2415,18 @@ static int btreeStoreWorkingSetBlob(
   const ProllyHash *pStaged,
   u8 isMerging,
   const ProllyHash *pMergeCommit,
-  const ProllyHash *pConflicts
+  const ProllyHash *pConflicts,
+  u8 isRebasing,
+  const ProllyHash *pPreRebaseCat,
+  const ProllyHash *pRebaseOnto,
+  const char *zRebaseOrigBranch
 ){
   u8 buf[WS_TOTAL_SIZE];
   ProllyHash wsHash;
   static const ProllyHash emptyHash = {{0}};
   int rc;
 
+  memset(buf, 0, sizeof(buf));
   buf[0] = WS_FORMAT_VERSION;
   memcpy(buf + WS_WORKING_CAT_OFF,
          (pWorkingCat ? pWorkingCat : &emptyHash)->data, PROLLY_HASH_SIZE);
@@ -2367,6 +2439,16 @@ static int btreeStoreWorkingSetBlob(
          (pMergeCommit ? pMergeCommit : &emptyHash)->data, PROLLY_HASH_SIZE);
   memcpy(buf + WS_CONFLICTS_OFF,
          (pConflicts ? pConflicts : &emptyHash)->data, PROLLY_HASH_SIZE);
+  buf[WS_REBASING_OFF] = isRebasing;
+  memcpy(buf + WS_PRE_REBASE_CAT_OFF,
+         (pPreRebaseCat ? pPreRebaseCat : &emptyHash)->data, PROLLY_HASH_SIZE);
+  memcpy(buf + WS_REBASE_ONTO_OFF,
+         (pRebaseOnto ? pRebaseOnto : &emptyHash)->data, PROLLY_HASH_SIZE);
+  if( zRebaseOrigBranch ){
+    int n = (int)strlen(zRebaseOrigBranch);
+    if( n > WS_REBASE_BRANCH_LEN - 1 ) n = WS_REBASE_BRANCH_LEN - 1;
+    memcpy(buf + WS_REBASE_BRANCH_OFF, zRebaseOrigBranch, n);
+  }
 
   rc = chunkStorePut(cs, buf, WS_TOTAL_SIZE, &wsHash);
   if( rc != SQLITE_OK ) return rc;
@@ -2384,7 +2466,7 @@ static int btreeReadWorkingCatalog(
   ProllyHash *pCommitHash
 ){
   return btreeLoadWorkingSetBlob(cs, zBranch, pCatHash, pCommitHash,
-                                 0, 0, 0, 0);
+                                 0, 0, 0, 0, 0, 0, 0, 0);
 }
 
 static int btreeWriteWorkingState(
@@ -2396,22 +2478,38 @@ static int btreeWriteWorkingState(
   ProllyHash stagedCatalog;
   ProllyHash mergeCommitHash;
   ProllyHash conflictsCatalogHash;
+  ProllyHash preRebaseCat;
+  ProllyHash rebaseOnto;
+  char *zRebaseOrigBranch = 0;
   u8 isMerging = 0;
+  u8 isRebasing = 0;
   int rc;
 
   rc = btreeLoadWorkingSetBlob(cs, zBranch, 0, 0, &stagedCatalog, &isMerging,
-                               &mergeCommitHash, &conflictsCatalogHash);
-  if( rc!=SQLITE_OK && rc!=SQLITE_NOTFOUND ) return rc;
+                               &mergeCommitHash, &conflictsCatalogHash,
+                               &isRebasing, &preRebaseCat, &rebaseOnto,
+                               &zRebaseOrigBranch);
+  if( rc!=SQLITE_OK && rc!=SQLITE_NOTFOUND ){
+    sqlite3_free(zRebaseOrigBranch);
+    return rc;
+  }
   if( rc==SQLITE_NOTFOUND ){
     memset(&stagedCatalog, 0, sizeof(ProllyHash));
     memset(&mergeCommitHash, 0, sizeof(ProllyHash));
     memset(&conflictsCatalogHash, 0, sizeof(ProllyHash));
+    memset(&preRebaseCat, 0, sizeof(ProllyHash));
+    memset(&rebaseOnto, 0, sizeof(ProllyHash));
     isMerging = 0;
+    isRebasing = 0;
   }
 
-  return btreeStoreWorkingSetBlob(cs, zBranch, pCatHash, pCommitHash,
-                                  &stagedCatalog, isMerging,
-                                  &mergeCommitHash, &conflictsCatalogHash);
+  rc = btreeStoreWorkingSetBlob(cs, zBranch, pCatHash, pCommitHash,
+                                &stagedCatalog, isMerging,
+                                &mergeCommitHash, &conflictsCatalogHash,
+                                isRebasing, &preRebaseCat, &rebaseOnto,
+                                zRebaseOrigBranch);
+  sqlite3_free(zRebaseOrigBranch);
+  return rc;
 }
 
 static int btreeReloadBranchWorkingState(Btree *p, int bLoadCatalog){
@@ -2420,22 +2518,32 @@ static int btreeReloadBranchWorkingState(Btree *p, int bLoadCatalog){
   ProllyHash stagedCatalog;
   ProllyHash mergeCommitHash;
   ProllyHash conflictsCatalogHash;
+  ProllyHash preRebaseCat;
+  ProllyHash rebaseOnto;
+  char *zRebaseOrigBranch = 0;
   const char *zBr = p->zBranch ? p->zBranch : "main";
   u8 isMerging = 0;
+  u8 isRebasing = 0;
   int rc;
 
   memset(&catHash, 0, sizeof(catHash));
   memset(&stagedCatalog, 0, sizeof(stagedCatalog));
   memset(&mergeCommitHash, 0, sizeof(mergeCommitHash));
   memset(&conflictsCatalogHash, 0, sizeof(conflictsCatalogHash));
+  memset(&preRebaseCat, 0, sizeof(preRebaseCat));
+  memset(&rebaseOnto, 0, sizeof(rebaseOnto));
 
   rc = btreeLoadWorkingSetBlob(
       &pBt->store, zBr, &catHash, 0, &stagedCatalog, &isMerging,
-      &mergeCommitHash, &conflictsCatalogHash);
+      &mergeCommitHash, &conflictsCatalogHash,
+      &isRebasing, &preRebaseCat, &rebaseOnto, &zRebaseOrigBranch);
   if( rc==SQLITE_NOTFOUND ){
     rc = SQLITE_OK;
   }
-  if( rc!=SQLITE_OK ) return rc;
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(zRebaseOrigBranch);
+    return rc;
+  }
 
   if( bLoadCatalog && !prollyHashIsEmpty(&catHash) ){
     u8 *catData = 0;
@@ -2444,10 +2552,16 @@ static int btreeReloadBranchWorkingState(Btree *p, int bLoadCatalog){
     if( rc==SQLITE_OK && catData ){
       rc = deserializeCatalog(p, catData, nCatData);
       sqlite3_free(catData);
-      if( rc!=SQLITE_OK ) return rc;
+      if( rc!=SQLITE_OK ){
+        sqlite3_free(zRebaseOrigBranch);
+        return rc;
+      }
     }else{
       sqlite3_free(catData);
-      if( rc!=SQLITE_OK ) return rc;
+      if( rc!=SQLITE_OK ){
+        sqlite3_free(zRebaseOrigBranch);
+        return rc;
+      }
     }
   }
 
@@ -2455,6 +2569,11 @@ static int btreeReloadBranchWorkingState(Btree *p, int bLoadCatalog){
   p->isMerging = isMerging;
   p->mergeCommitHash = mergeCommitHash;
   p->conflictsCatalogHash = conflictsCatalogHash;
+  p->isRebasing = isRebasing;
+  p->preRebaseWorkingCat = preRebaseCat;
+  p->rebaseOntoCommit = rebaseOnto;
+  sqlite3_free(p->zRebaseOrigBranch);
+  p->zRebaseOrigBranch = zRebaseOrigBranch;
   return SQLITE_OK;
 }
 
@@ -5976,6 +6095,44 @@ void doltliteClearSessionMergeState(sqlite3 *db){
   doltliteSetSessionMergeState(db, 0, 0, 0);
 }
 
+void doltliteGetSessionRebaseState(sqlite3 *db, u8 *pIsRebasing,
+                                    ProllyHash *pPreRebaseCat,
+                                    ProllyHash *pRebaseOnto,
+                                    const char **pzOrigBranch){
+  if( db && db->nDb>0 && db->aDb[0].pBt ){
+    Btree *p = db->aDb[0].pBt;
+    if( pIsRebasing ) *pIsRebasing = p->isRebasing;
+    if( pPreRebaseCat ) memcpy(pPreRebaseCat, &p->preRebaseWorkingCat, sizeof(ProllyHash));
+    if( pRebaseOnto ) memcpy(pRebaseOnto, &p->rebaseOntoCommit, sizeof(ProllyHash));
+    if( pzOrigBranch ) *pzOrigBranch = p->zRebaseOrigBranch;
+  }else{
+    if( pIsRebasing ) *pIsRebasing = 0;
+    if( pPreRebaseCat ) memset(pPreRebaseCat, 0, sizeof(ProllyHash));
+    if( pRebaseOnto ) memset(pRebaseOnto, 0, sizeof(ProllyHash));
+    if( pzOrigBranch ) *pzOrigBranch = 0;
+  }
+}
+
+void doltliteSetSessionRebaseState(sqlite3 *db, u8 isRebasing,
+                                    const ProllyHash *pPreRebaseCat,
+                                    const ProllyHash *pRebaseOnto,
+                                    const char *zOrigBranch){
+  if( db && db->nDb>0 && db->aDb[0].pBt ){
+    Btree *p = db->aDb[0].pBt;
+    p->isRebasing = isRebasing;
+    if( pPreRebaseCat ) memcpy(&p->preRebaseWorkingCat, pPreRebaseCat, sizeof(ProllyHash));
+    else memset(&p->preRebaseWorkingCat, 0, sizeof(ProllyHash));
+    if( pRebaseOnto ) memcpy(&p->rebaseOntoCommit, pRebaseOnto, sizeof(ProllyHash));
+    else memset(&p->rebaseOntoCommit, 0, sizeof(ProllyHash));
+    sqlite3_free(p->zRebaseOrigBranch);
+    p->zRebaseOrigBranch = zOrigBranch ? sqlite3_mprintf("%s", zOrigBranch) : 0;
+  }
+}
+
+void doltliteClearSessionRebaseState(sqlite3 *db){
+  doltliteSetSessionRebaseState(db, 0, 0, 0, 0);
+}
+
 void doltliteGetSessionConflictsCatalog(sqlite3 *db, ProllyHash *pHash){
   doltliteGetSessionMergeState(db, 0, 0, pHash);
 }
@@ -6010,7 +6167,11 @@ int doltliteSaveWorkingSet(sqlite3 *db){
   return btreeStoreWorkingSetBlob(cs, zBranch, &workingCatHash,
                                   &pBtree->headCommit, &pBtree->stagedCatalog,
                                   pBtree->isMerging, &pBtree->mergeCommitHash,
-                                  &pBtree->conflictsCatalogHash);
+                                  &pBtree->conflictsCatalogHash,
+                                  pBtree->isRebasing,
+                                  &pBtree->preRebaseWorkingCat,
+                                  &pBtree->rebaseOntoCommit,
+                                  pBtree->zRebaseOrigBranch);
 }
 
 int doltlitePersistWorkingSet(sqlite3 *db){
@@ -6028,6 +6189,7 @@ int doltlitePersistWorkingSet(sqlite3 *db){
 int doltliteLoadWorkingSet(sqlite3 *db, const char *zBranch){
   ChunkStore *cs = doltliteGetChunkStore(db);
   Btree *pBtree;
+  char *zNewRebaseOrigBranch = 0;
   int rc;
 
   if( !db || db->nDb<=0 || !db->aDb[0].pBt ) return SQLITE_ERROR;
@@ -6037,13 +6199,28 @@ int doltliteLoadWorkingSet(sqlite3 *db, const char *zBranch){
   rc = btreeLoadWorkingSetBlob(cs, zBranch, 0, 0,
                                &pBtree->stagedCatalog,
                                &pBtree->isMerging, &pBtree->mergeCommitHash,
-                               &pBtree->conflictsCatalogHash);
+                               &pBtree->conflictsCatalogHash,
+                               &pBtree->isRebasing,
+                               &pBtree->preRebaseWorkingCat,
+                               &pBtree->rebaseOntoCommit,
+                               &zNewRebaseOrigBranch);
   if( rc == SQLITE_NOTFOUND ){
     memset(&pBtree->stagedCatalog, 0, sizeof(ProllyHash));
     pBtree->isMerging = 0;
     memset(&pBtree->mergeCommitHash, 0, sizeof(ProllyHash));
     memset(&pBtree->conflictsCatalogHash, 0, sizeof(ProllyHash));
+    pBtree->isRebasing = 0;
+    memset(&pBtree->preRebaseWorkingCat, 0, sizeof(ProllyHash));
+    memset(&pBtree->rebaseOntoCommit, 0, sizeof(ProllyHash));
+    sqlite3_free(pBtree->zRebaseOrigBranch);
+    pBtree->zRebaseOrigBranch = 0;
     return SQLITE_OK;
+  }
+  if( rc==SQLITE_OK ){
+    sqlite3_free(pBtree->zRebaseOrigBranch);
+    pBtree->zRebaseOrigBranch = zNewRebaseOrigBranch;
+  }else{
+    sqlite3_free(zNewRebaseOrigBranch);
   }
   return rc;
 }

--- a/test/vc_oracle_rebase_test.sh
+++ b/test/vc_oracle_rebase_test.sh
@@ -240,6 +240,110 @@ SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');
 SELECT dolt_rebase();
 "
 
+echo "--- interactive rebase ---"
+
+# All interactive scenarios share this setup: three commits f1,f2,f3 on
+# feat atop one commit m on main that diverged after init.
+INTERACTIVE_SETUP="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 1);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');
+SELECT dolt_checkout('-b', 'feat');
+INSERT INTO t VALUES (2, 2);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'f1');
+INSERT INTO t VALUES (3, 3);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'f2');
+INSERT INTO t VALUES (4, 4);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'f3');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES (10, 10);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'm');
+SELECT dolt_checkout('feat');
+"
+
+# After -i, the working branch is dolt_rebase_feat and dolt_rebase has
+# the default pick plan. Default pick/continue should match non-interactive.
+oracle "interactive_default_plan" "
+$INTERACTIVE_SETUP
+SELECT dolt_rebase('-i', 'main');
+SELECT dolt_rebase('--continue');
+" "SELECT CONCAT('LOG|', message) FROM dolt_log;"
+
+oracle "interactive_default_table" "
+$INTERACTIVE_SETUP
+SELECT dolt_rebase('-i', 'main');
+SELECT dolt_rebase('--continue');
+" "SELECT CONCAT('LOG|', id) FROM t ORDER BY id;"
+
+# Drop the middle commit f2 from the plan.
+oracle "interactive_drop_one" "
+$INTERACTIVE_SETUP
+SELECT dolt_rebase('-i', 'main');
+UPDATE dolt_rebase SET action = 'drop' WHERE commit_message = 'f2';
+SELECT dolt_rebase('--continue');
+" "SELECT CONCAT('LOG|', message) FROM dolt_log;"
+
+oracle "interactive_drop_table" "
+$INTERACTIVE_SETUP
+SELECT dolt_rebase('-i', 'main');
+UPDATE dolt_rebase SET action = 'drop' WHERE commit_message = 'f2';
+SELECT dolt_rebase('--continue');
+" "SELECT CONCAT('LOG|', id) FROM t ORDER BY id;"
+
+# Reorder: move f3 before f1 using a fractional rebase_order.
+oracle "interactive_reorder" "
+$INTERACTIVE_SETUP
+SELECT dolt_rebase('-i', 'main');
+UPDATE dolt_rebase SET rebase_order = 0.5 WHERE commit_message = 'f3';
+SELECT dolt_rebase('--continue');
+" "SELECT CONCAT('LOG|', message) FROM dolt_log;"
+
+# Reword f1; message in the plan overrides the original commit message.
+oracle "interactive_reword" "
+$INTERACTIVE_SETUP
+SELECT dolt_rebase('-i', 'main');
+UPDATE dolt_rebase SET action = 'reword', commit_message = 'f1 renamed' WHERE commit_message = 'f1';
+SELECT dolt_rebase('--continue');
+" "SELECT CONCAT('LOG|', message) FROM dolt_log;"
+
+# Squash f2 into f1: expect a single combined commit with message 'f1 | f2'
+# (we replace newlines with ' | ' in the oracle so shell/csv escaping
+# doesn't diverge between engines on the literal newline characters).
+oracle "interactive_squash" "
+$INTERACTIVE_SETUP
+SELECT dolt_rebase('-i', 'main');
+UPDATE dolt_rebase SET action = 'squash' WHERE commit_message = 'f2';
+SELECT dolt_rebase('--continue');
+" "SELECT CONCAT('LOG|', REPLACE(message, CHAR(10), ' | ')) FROM dolt_log;"
+
+# Fixup f3 into f2: combined commit keeps only f2's message.
+oracle "interactive_fixup" "
+$INTERACTIVE_SETUP
+SELECT dolt_rebase('-i', 'main');
+UPDATE dolt_rebase SET action = 'fixup' WHERE commit_message = 'f3';
+SELECT dolt_rebase('--continue');
+" "SELECT CONCAT('LOG|', message) FROM dolt_log;"
+
+# --abort leaves the original branch untouched and restores us to it.
+oracle "interactive_abort_log" "
+$INTERACTIVE_SETUP
+SELECT dolt_rebase('-i', 'main');
+SELECT dolt_rebase('--abort');
+" "SELECT CONCAT('LOG|', message) FROM dolt_log;"
+
+oracle "interactive_abort_branch" "
+$INTERACTIVE_SETUP
+SELECT dolt_rebase('-i', 'main');
+SELECT dolt_rebase('--abort');
+" "SELECT CONCAT('LOG|', active_branch());"
+
+# --continue is an error when not in an interactive rebase.
+oracle_error "continue_without_active" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');
+SELECT dolt_rebase('--continue');
+"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then


### PR DESCRIPTION
## Summary
Adds interactive rebase to ``dolt_rebase``, matching Dolt's semantics and storage model. The session-level rebase state (is_rebasing / pre-rebase working cat / onto commit / original branch name) now rides in the working-set blob alongside merge state, and the plan itself lives as a real SQL table named ``dolt_rebase`` on the working branch — exactly how Dolt's ``Database.SaveRebasePlan`` does it via ``createSqlTable``.

## Stacked commits
- **ws: bump to v3 with rebase state** — extends the WS blob format with rebase state fields, adds session accessors parallel to the existing merge-state ones, handles v2 reads for backward compat. No behavior change on its own.
- **rebase: interactive rebase with pick/drop/reword/squash/fixup** — dispatcher + ``-i`` / ``--continue`` / ``--abort`` handlers + the replay loop with group-based commit emission for squash/fixup.

## Workflow (from the end-to-end smoke test)
```sql
-- Start interactive rebase of feat onto main
SELECT dolt_rebase('-i', 'main');
--> interactive rebase started on branch dolt_rebase_feat; adjust the
    rebase plan in the dolt_rebase table, then continue rebasing by
    calling dolt_rebase('--continue')

-- Edit the plan with normal SQL
UPDATE dolt_rebase SET action='drop'   WHERE commit_message='f2';
UPDATE dolt_rebase SET action='reword', commit_message='f1 (reworded)'
  WHERE commit_message='f1';
UPDATE dolt_rebase SET action='squash' WHERE commit_message='f3';

-- Apply it
SELECT dolt_rebase('--continue');
--> Successfully rebased and updated refs/heads/feat
```

After this, the log on feat is ``f1 (reworded)\n\nf3`` → ``main`` → ``init`` — f2 dropped, f3 squashed into the reworded f1.

## Bugs shaken out during bring-up
1. Setting session rebase state before any subsequent DDL/DML got clobbered because every write trans reloads the WS from disk at begin-trans time. Fix: populate the plan table first, flip the rebase state after, persist once so disk and memory flip atomically.
2. The original branch name was being held as a bare pointer into ``p->zBranch``, which ``dolt_checkout`` frees and reallocates on every switch. Fix: ``sqlite3_mprintf`` a copy before issuing the internal checkout.

## Spec coverage
Eleven new interactive scenarios in ``vc_oracle_rebase_test.sh``:
- default ``-i + --continue`` (matches non-interactive result)
- drop a commit
- reorder via fractional ``rebase_order``
- reword a commit's message
- squash one commit into another (joined message)
- fixup one commit into another (first message only)
- ``--abort`` (log and active branch)
- ``--continue`` without an active rebase (error)

## Test plan
- [x] ``bash test/vc_oracle_rebase_test.sh`` → 23/23 pass vs real Dolt 1.83.5
- [x] ``bash test/run_doltlite_tests.sh`` → 39/39 suites green
- [x] End-to-end smoke: drop + reword + squash cycle produces correct log, table state, and active branch

## Not yet supported
- ``edit`` action (pauses for user to stage changes; requires a more sophisticated continuation model)
- ``--empty=keep`` (default is drop)
- Conflict-staging path gated by ``@@dolt_allow_commit_conflicts`` (current impl auto-aborts on conflict)

🤖 Generated with [Claude Code](https://claude.com/claude-code)