### PR TITLE
diff: dolt_diff_<table>(from_ref, to_ref) TVF form

### DIFF
--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -52,7 +52,15 @@ static char *buildDiffSchema(DoltliteColInfo *ci){
     sqlite3_free(zColName);
   }
   sqlite3_str_appendall(pStr, ", from_commit TEXT, from_commit_date TEXT"
-                              ", diff_type TEXT)");
+                              ", diff_type TEXT"
+                              /* Hidden TVF arguments: used to expose the
+                              ** dolt_diff(from_ref, to_ref, table) shape as
+                              ** dolt_diff_<table>(from_ref, to_ref). Both
+                              ** must be supplied together; if either is
+                              ** absent the vtab falls back to its full-
+                              ** history no-arg behavior. */
+                              ", from_ref TEXT HIDDEN"
+                              ", to_ref TEXT HIDDEN)");
   z = sqlite3_str_finish(pStr);
   return z;
 }
@@ -123,6 +131,7 @@ struct DiffTblCursor {
 };
 
 #define DT_IDX_TO_COMMIT_EQ  0x01
+#define DT_IDX_SLICE         0x02
 
 static int diffRecordField(
   const u8 *pData,
@@ -520,6 +529,109 @@ static int buildWorkingDiffPair(
   return rc;
 }
 
+/* TVF slice builder: produce exactly one DiffPair between the two
+** supplied refs. Matches Dolt's dolt_diff(from_ref, to_ref, table)
+** shape — one pair, net diff between endpoints, no history walk.
+** to_ref == 'WORKING' diffs against the current working catalog
+** (staged + pending); from_ref == 'WORKING' is not supported by
+** Dolt either and returns an empty slice. */
+static int buildSliceDiffPair(
+  DiffTblCursor *pCur,
+  sqlite3 *db,
+  const char *zTableName,
+  const char *zFromRef,
+  const char *zToRef
+){
+  ProllyHash fromHash, toHash;
+  ProllyHash fromTblRoot, toTblRoot;
+  ProllyHash fromCatHash, toCatHash;
+  ProllyHash fromSchemaHash, toSchemaHash;
+  DoltliteCommit fromCommit;
+  u8 fromFlags = 0;
+  u8 toFlags = 0;
+  i64 fromDate = 0;
+  i64 toDate = 0;
+  int toIsWorking = 0;
+  char zToLabel[PROLLY_HASH_SIZE*2+1];
+  int rc;
+
+  memset(&fromHash, 0, sizeof(fromHash));
+  memset(&toHash, 0, sizeof(toHash));
+  memset(&fromTblRoot, 0, sizeof(fromTblRoot));
+  memset(&toTblRoot, 0, sizeof(toTblRoot));
+  memset(&fromCatHash, 0, sizeof(fromCatHash));
+  memset(&toCatHash, 0, sizeof(toCatHash));
+  memset(&fromSchemaHash, 0, sizeof(fromSchemaHash));
+  memset(&toSchemaHash, 0, sizeof(toSchemaHash));
+  memset(&fromCommit, 0, sizeof(fromCommit));
+  memset(zToLabel, 0, sizeof(zToLabel));
+
+  if( !zFromRef || !zToRef ) return SQLITE_OK;
+
+  rc = doltliteResolveRef(db, zFromRef, &fromHash);
+  if( rc!=SQLITE_OK ) return SQLITE_OK;
+  rc = doltliteLoadCommit(db, &fromHash, &fromCommit);
+  if( rc!=SQLITE_OK ) return rc;
+  memcpy(&fromCatHash, &fromCommit.catalogHash, sizeof(ProllyHash));
+  fromDate = fromCommit.timestamp;
+  doltliteCommitClear(&fromCommit);
+
+  rc = loadTblRootAtCommit(db, &fromCatHash, zTableName,
+                           &fromTblRoot, &fromFlags, &fromSchemaHash);
+  if( rc!=SQLITE_OK && rc!=SQLITE_NOTFOUND ) return rc;
+
+  if( sqlite3_stricmp(zToRef, "WORKING")==0 ){
+    toIsWorking = 1;
+    rc = doltliteGetWorkingTableState(db, zTableName,
+                                      &toTblRoot, &toFlags,
+                                      &toSchemaHash);
+    if( rc==SQLITE_NOTFOUND ) rc = SQLITE_OK;
+    if( rc!=SQLITE_OK ) return rc;
+    /* Flush working catalog only if we need its hash; otherwise
+    ** leave toCatHash empty so column resolution falls back to
+    ** the table root itself. */
+    rc = doltliteFlushCatalogToHash(db, &toCatHash);
+    if( rc!=SQLITE_OK ) return rc;
+    memcpy(zToLabel, "WORKING", 7);
+    toDate = 0;
+  }else{
+    DoltliteCommit toCommit;
+    memset(&toCommit, 0, sizeof(toCommit));
+    rc = doltliteResolveRef(db, zToRef, &toHash);
+    if( rc!=SQLITE_OK ) return SQLITE_OK;
+    rc = doltliteLoadCommit(db, &toHash, &toCommit);
+    if( rc!=SQLITE_OK ) return rc;
+    memcpy(&toCatHash, &toCommit.catalogHash, sizeof(ProllyHash));
+    toDate = toCommit.timestamp;
+    doltliteCommitClear(&toCommit);
+    rc = loadTblRootAtCommit(db, &toCatHash, zTableName,
+                             &toTblRoot, &toFlags, &toSchemaHash);
+    if( rc!=SQLITE_OK && rc!=SQLITE_NOTFOUND ) return rc;
+    doltliteHashToHex(&toHash, zToLabel);
+  }
+
+  /* No-op slice: same endpoint or identical table roots. */
+  if( !toIsWorking
+   && prollyHashCompare(&fromHash, &toHash)==0 ){
+    return SQLITE_OK;
+  }
+  if( prollyHashCompare(&fromTblRoot, &toTblRoot)==0
+   && prollyHashCompare(&fromSchemaHash, &toSchemaHash)==0 ){
+    return SQLITE_OK;
+  }
+
+  /* Use whichever side has a non-zero flags bitfield as the
+  ** diff-iteration flags (both sides should agree for a single
+  ** table, but be tolerant when one side is missing). */
+  if( !fromFlags ) fromFlags = toFlags;
+  if( !toFlags ) toFlags = fromFlags;
+
+  return pairsAppend(pCur, &fromHash, &fromTblRoot, &fromCatHash,
+                     &fromSchemaHash, fromFlags, fromDate,
+                     zToLabel, &toTblRoot, &toCatHash, &toSchemaHash,
+                     toFlags, toDate);
+}
+
 static void freePairCols(DiffTblCursor *pCur){
   int i;
   if( pCur->azFromCols ){
@@ -879,18 +991,46 @@ static int dtBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
   DiffTblVtab *p = (DiffTblVtab*)pVtab;
   int i;
   int iToCommitEq = -1;
-  int toCommitCol = p->cols.nCol;
+  int iFromRefEq = -1;
+  int iToRefEq = -1;
+  int nUser = p->cols.nCol;
+  /* Schema layout after buildDiffSchema():
+  **   0..nUser-1       : user cols (to_<col>)
+  **   nUser            : to_commit
+  **   nUser+1          : to_commit_date
+  **   nUser+2..2n+1    : from_<col>
+  **   2n+2             : from_commit
+  **   2n+3             : from_commit_date
+  **   2n+4             : diff_type
+  **   2n+5             : from_ref  (HIDDEN — TVF arg 1)
+  **   2n+6             : to_ref    (HIDDEN — TVF arg 2)
+  */
+  int toCommitCol = nUser;
+  int fromRefCol  = 2*nUser + 5;
+  int toRefCol    = 2*nUser + 6;
 
   for(i=0; i<pInfo->nConstraint; i++){
     if( !pInfo->aConstraint[i].usable ) continue;
     if( pInfo->aConstraint[i].op!=SQLITE_INDEX_CONSTRAINT_EQ ) continue;
     if( pInfo->aConstraint[i].iColumn==toCommitCol ){
       iToCommitEq = i;
-      break;
+    }else if( pInfo->aConstraint[i].iColumn==fromRefCol ){
+      iFromRefEq = i;
+    }else if( pInfo->aConstraint[i].iColumn==toRefCol ){
+      iToRefEq = i;
     }
   }
 
-  if( iToCommitEq>=0 ){
+  if( iFromRefEq>=0 && iToRefEq>=0 ){
+    /* TVF slice form: dolt_diff_<table>(from_ref, to_ref). Both
+    ** hidden args are bound; build exactly one diff pair. */
+    pInfo->idxNum = DT_IDX_SLICE;
+    pInfo->aConstraintUsage[iFromRefEq].argvIndex = 1;
+    pInfo->aConstraintUsage[iFromRefEq].omit = 1;
+    pInfo->aConstraintUsage[iToRefEq].argvIndex = 2;
+    pInfo->aConstraintUsage[iToRefEq].omit = 1;
+    pInfo->estimatedCost = 10.0;
+  }else if( iToCommitEq>=0 ){
     pInfo->idxNum = DT_IDX_TO_COMMIT_EQ;
     pInfo->aConstraintUsage[iToCommitEq].argvIndex = 1;
     pInfo->estimatedCost = 100.0;
@@ -949,7 +1089,11 @@ static int dtFilter(sqlite3_vtab_cursor *cur,
     }
   }
 
-  if( (idxNum & DT_IDX_TO_COMMIT_EQ)!=0 && argc>=1 ){
+  if( (idxNum & DT_IDX_SLICE)!=0 && argc>=2 ){
+    const char *zFromRef = (const char*)sqlite3_value_text(argv[0]);
+    const char *zToRef = (const char*)sqlite3_value_text(argv[1]);
+    rc = buildSliceDiffPair(c, db, pVtab->zTableName, zFromRef, zToRef);
+  }else if( (idxNum & DT_IDX_TO_COMMIT_EQ)!=0 && argc>=1 ){
     const char *zToCommit = (const char*)sqlite3_value_text(argv[0]);
     if( zToCommit && sqlite3_stricmp(zToCommit, "WORKING")==0 ){
       rc = buildWorkingDiffPair(c, db, pVtab->zTableName);
@@ -1065,13 +1209,17 @@ static int dtColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
     }else{
       sqlite3_result_null(ctx);
     }
-  }else{
-
+  }else if( nCols > 0 && col == 2*nCols+4 ){
     switch( r->diffType ){
       case PROLLY_DIFF_ADD:    sqlite3_result_text(ctx,"added",-1,SQLITE_STATIC); break;
       case PROLLY_DIFF_DELETE: sqlite3_result_text(ctx,"removed",-1,SQLITE_STATIC); break;
       case PROLLY_DIFF_MODIFY: sqlite3_result_text(ctx,"modified",-1,SQLITE_STATIC); break;
     }
+  }else{
+    /* Hidden TVF arg columns (from_ref, to_ref) — never materialized
+    ** in the result set, but SQLite may still ask for them during
+    ** query planning. Always return NULL. */
+    sqlite3_result_null(ctx);
   }
 
   return SQLITE_OK;

--- a/src/doltlite_record.c
+++ b/src/doltlite_record.c
@@ -163,6 +163,8 @@ int doltliteGetColumnNames(sqlite3 *db, const char *zTable, DoltliteColInfo *ci)
   char *zSql;
   sqlite3_stmt *pStmt = 0;
   int rc, nCol;
+  int nPkCols = 0;
+  int iCandidateAlias = -1;
 
   memset(ci, 0, sizeof(*ci));
   ci->iPkCol = -1;
@@ -191,9 +193,9 @@ int doltliteGetColumnNames(sqlite3 *db, const char *zTable, DoltliteColInfo *ci)
     int pk = sqlite3_column_int(pStmt, 5);
     const char *zType = (const char*)sqlite3_column_text(pStmt, 2);
 
-
+    if( pk>0 ) nPkCols++;
     if( pk==1 && zType && sqlite3_stricmp(zType,"INTEGER")==0 ){
-      ci->iPkCol = ci->nCol;
+      iCandidateAlias = ci->nCol;
     }
 
     ci->azName[ci->nCol] = sqlite3_mprintf("%s", zName ? zName : "");
@@ -208,6 +210,14 @@ int doltliteGetColumnNames(sqlite3 *db, const char *zTable, DoltliteColInfo *ci)
     doltliteFreeColInfo(ci);
     sqlite3_finalize(pStmt);
     return rc;
+  }
+
+  /* A column is a rowid alias only when it's the SOLE PK column and
+  ** has declared type INTEGER. Compound PKs (even if their first
+  ** column is INTEGER) store all fields in the record payload and
+  ** must NOT be treated as rowid-alias projections. */
+  if( nPkCols==1 && iCandidateAlias>=0 ){
+    ci->iPkCol = iCandidateAlias;
   }
 
   sqlite3_finalize(pStmt);

--- a/test/vc_oracle_diff_tvf_test.sh
+++ b/test/vc_oracle_diff_tvf_test.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+#
+# Version-control oracle test: dolt_diff_<table>(from_ref, to_ref) TVF form
+#
+# Dolt exposes row-level range diffs via a generic TVF
+# `dolt_diff(from_ref, to_ref, table_name)` whose output schema is
+# per-table. SQLite eponymous TVFs declare a static schema at
+# connect time, so we expose the same functionality by adding
+# (from_ref, to_ref) as positional args to the existing
+# `dolt_diff_<table>` virtual table — the table name rides in the
+# module name, where it's already per-instance, and the schema is
+# the same as the no-arg form.
+#
+# The oracle query uses the doltlite form:
+#
+#   SELECT * FROM dolt_diff_users('HEAD~1', 'HEAD')
+#
+# and a sed transformation rewrites it for Dolt to:
+#
+#   SELECT * FROM dolt_diff('HEAD~1', 'HEAD', 'users')
+#
+# Each row is serialized as "R|<pk>|<to_vals>|<from_vals>|<diff_type>"
+# so the commit hash columns (which differ between engines —
+# doltlite emits resolved hashes, Dolt emits the ref literal) are
+# intentionally excluded from the comparison.
+#
+# Usage: bash vc_oracle_diff_tvf_test.sh [path/to/doltlite] [path/to/dolt]
+#
+
+set -u
+
+DOLTLITE="${1:-./doltlite}"
+DOLT="${2:-dolt}"
+TMPROOT=$(mktemp -d)
+trap "rm -rf $TMPROOT" EXIT
+pass=0; fail=0
+FAILED_NAMES=""
+
+# Translate setup SQL (SELECT dolt_* → CALL dolt_*) and the query
+# (dolt_diff_<t>(...) → dolt_diff(..., '<t>')) for Dolt.
+translate_for_dolt() {
+  sed -E '
+    s/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g
+    s/dolt_diff_([a-zA-Z0-9_]+)\(([^)]*)\)/dolt_diff(\2, "\1")/g
+  '
+}
+
+oracle() {
+  local name="$1" setup="$2" query="$3"
+  local dir="$TMPROOT/$name"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_out
+  dl_out=$(printf "%s\n.headers off\n.mode list\n%s\n" "$setup" "$query" \
+           | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
+           | tr -d '\r' \
+           | grep '^R|' | sort)
+
+  local dolt_setup dolt_query
+  dolt_setup=$(echo "$setup" | translate_for_dolt)
+  dolt_query=$(echo "$query" | translate_for_dolt)
+
+  local dt_out
+  (
+    cd "$dir/dt" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    {
+      echo "$dolt_setup"
+      echo "$dolt_query"
+    } | "$DOLT" sql -r csv 2>"$dir/dt.err"
+  ) > "$dir/dt.raw"
+  dt_out=$(tr -d '"\r' < "$dir/dt.raw" | grep '^R|' | sort)
+
+  if [ "$dl_out" = "$dt_out" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite:"; echo "$dl_out" | sed 's/^/      /'
+    echo "    dolt:";     echo "$dt_out" | sed 's/^/      /'
+  fi
+}
+
+echo "=== Version Control Oracle Tests: dolt_diff TVF form ==="
+echo ""
+
+SETUP_LINEAR="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 1), (2, 2);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'c1');
+INSERT INTO t VALUES (3, 3);
+UPDATE t SET v = 20 WHERE id = 2;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'c2');
+DELETE FROM t WHERE id = 1;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'c3');
+"
+
+echo "--- linear history slice ---"
+
+oracle "slice_one_commit" "$SETUP_LINEAR" \
+  "SELECT CONCAT('R|', IFNULL(to_id,''), '|', IFNULL(to_v,''), '|', IFNULL(from_id,''), '|', IFNULL(from_v,''), '|', diff_type) FROM dolt_diff_t('HEAD~1', 'HEAD');"
+
+oracle "slice_two_commits" "$SETUP_LINEAR" \
+  "SELECT CONCAT('R|', IFNULL(to_id,''), '|', IFNULL(to_v,''), '|', IFNULL(from_id,''), '|', IFNULL(from_v,''), '|', diff_type) FROM dolt_diff_t('HEAD~2', 'HEAD');"
+
+oracle "slice_full_range" "$SETUP_LINEAR" \
+  "SELECT CONCAT('R|', IFNULL(to_id,''), '|', IFNULL(to_v,''), '|', IFNULL(from_id,''), '|', IFNULL(from_v,''), '|', diff_type) FROM dolt_diff_t('HEAD~3', 'HEAD');"
+
+echo "--- ref types ---"
+
+# Named refs: branch names.
+oracle "slice_branch_refs" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 1);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');
+SELECT dolt_checkout('-b', 'feat');
+INSERT INTO t VALUES (2, 2);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'feat_c1');
+" "SELECT CONCAT('R|', IFNULL(to_id,''), '|', IFNULL(to_v,''), '|', IFNULL(from_id,''), '|', IFNULL(from_v,''), '|', diff_type) FROM dolt_diff_t('main', 'feat');"
+
+# Tags.
+oracle "slice_tag_refs" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 1);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'v1');
+SELECT dolt_tag('v1', (SELECT commit_hash FROM dolt_log WHERE message='v1'));
+INSERT INTO t VALUES (2, 2);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'v2');
+" "SELECT CONCAT('R|', IFNULL(to_id,''), '|', IFNULL(to_v,''), '|', IFNULL(from_id,''), '|', IFNULL(from_v,''), '|', diff_type) FROM dolt_diff_t('v1', 'HEAD');"
+
+echo "--- WORKING ref ---"
+
+oracle "slice_to_working" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 1);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');
+INSERT INTO t VALUES (99, 99);
+" "SELECT CONCAT('R|', IFNULL(to_id,''), '|', IFNULL(to_v,''), '|', IFNULL(from_id,''), '|', IFNULL(from_v,''), '|', diff_type) FROM dolt_diff_t('HEAD', 'WORKING');"
+
+echo "--- no diff (same ref both sides) ---"
+
+oracle "slice_no_change" "$SETUP_LINEAR" \
+  "SELECT CONCAT('R|', IFNULL(to_id,''), '|', IFNULL(to_v,''), '|', IFNULL(from_id,''), '|', IFNULL(from_v,''), '|', diff_type) FROM dolt_diff_t('HEAD', 'HEAD');"
+
+echo "--- multi-column table ---"
+
+SETUP_MULTI="
+CREATE TABLE m(a INTEGER, b INTEGER, v TEXT, PRIMARY KEY(a, b));
+INSERT INTO m VALUES (1, 1, 'one'), (1, 2, 'two');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'c1');
+UPDATE m SET v = 'TWO' WHERE a = 1 AND b = 2;
+INSERT INTO m VALUES (2, 1, 'three');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'c2');
+"
+
+oracle "slice_multi_col" "$SETUP_MULTI" \
+  "SELECT CONCAT('R|', IFNULL(to_a,''), '|', IFNULL(to_b,''), '|', IFNULL(to_v,''), '|', IFNULL(from_a,''), '|', IFNULL(from_b,''), '|', IFNULL(from_v,''), '|', diff_type) FROM dolt_diff_m('HEAD~1', 'HEAD');"
+
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+if [ $fail -gt 0 ]; then
+  echo "Failed:$FAILED_NAMES"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Adds the TVF form of ``dolt_diff_<table>`` so you can slice a single table between two refs: ``SELECT * FROM dolt_diff_users('HEAD~1', 'HEAD')``. This is doltlite's expression of Dolt's ``dolt_diff(from_ref, to_ref, table_name)`` TVF, constrained by SQLite's requirement that eponymous TVFs declare their schema statically — the table name rides in the module name (where each per-table instance already has a fixed, typed, per-table schema) and the two refs come through as hidden columns.
- ``to_ref='WORKING'`` works the same way as the existing ``WHERE to_commit='WORKING'`` filter. ``from_ref='WORKING'`` isn't supported (Dolt doesn't either). Same-endpoint slices yield zero rows.
- Drive-by fix to ``doltliteGetColumnNames``: rowid-alias detection was firing on the first PK column of compound-PK tables (it checked only ``pk==1 && type=='INTEGER'`` without verifying there was only one PK column), which caused ``dolt_diff_<table>`` to project ``intKey`` in place of the real value for multi-column PKs. Surfaced by the new ``slice_multi_col`` oracle case.

## Spec
Built from a new oracle test (``test/vc_oracle_diff_tvf_test.sh``) that translates the doltlite call form to Dolt's via sed (``dolt_diff_<t>(from, to)`` → ``dolt_diff(from, to, '<t>')``) and compares row output excluding the ``to_commit`` / ``from_commit`` columns (which Dolt emits as ref literals and doltlite emits as resolved hashes — the data columns match).

Coverage: linear history slices (one commit, two commits, full range), branch refs, tag refs, ``WORKING`` ref, no-op same-endpoint, multi-column primary key. 8/8 match Dolt 1.83.5.

## Test plan
- [x] ``bash test/vc_oracle_diff_tvf_test.sh`` → 8/8 pass
- [x] ``bash test/run_doltlite_tests.sh`` → 39/39 suites green

🤖 Generated with [Claude Code](https://claude.com/claude-code)