### PR TITLE
Fix mutmap OOM handling

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -3853,7 +3853,9 @@ static int prollyBtCursorTableMoveto(
   CLEAR_CACHED_PAYLOAD(pCur);
 
   if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
-    ProllyMutMapEntry *pEntry = prollyMutMapFind(pCur->pMutMap, 0, 0, intKey);
+    ProllyMutMapEntry *pEntry = 0;
+    rc = prollyMutMapFindRc(pCur->pMutMap, 0, 0, intKey, &pEntry);
+    if( rc!=SQLITE_OK ) return rc;
     if( pEntry ){
       if( pEntry->op == PROLLY_EDIT_INSERT ){
         *pRes = 0;
@@ -3965,7 +3967,9 @@ static int findMatchingMutMapEntry(
 
   if( pKeyInfo
    && pIdxKey->nField >= pKeyInfo->nAllField ){
-    ProllyMutMapEntry *pEntry = prollyMutMapFind(pMap, pSortKey, nSortKey, 0);
+    ProllyMutMapEntry *pEntry = 0;
+    rc = prollyMutMapFindRc(pMap, pSortKey, nSortKey, 0, &pEntry);
+    if( rc!=SQLITE_OK ) return rc;
     if( pEntry && pEntry->op==PROLLY_EDIT_INSERT ){
       *ppMatch = pEntry;
     }
@@ -4157,8 +4161,9 @@ static int prollyBtCursorIndexMoveto(
               if( bestIdx < 0 ){
                 int isDeleted = 0;
                 if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
-                  ProllyMutMapEntry *mmE = prollyMutMapFind(
-                      pCur->pMutMap, pSK, nSK, 0);
+                  ProllyMutMapEntry *mmE = 0;
+                  rc = prollyMutMapFindRc(pCur->pMutMap, pSK, nSK, 0, &mmE);
+                  if( rc!=SQLITE_OK ) break;
                   if( mmE && mmE->op==PROLLY_EDIT_DELETE ) isDeleted = 1;
                 }
                 if( !isDeleted ){
@@ -4190,8 +4195,9 @@ static int prollyBtCursorIndexMoveto(
 
           if( recCmp==0 || pIdxKey->eqSeen ){
             if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
-              ProllyMutMapEntry *mmE = prollyMutMapFind(
-                  pCur->pMutMap, pSK, nSK, 0);
+              ProllyMutMapEntry *mmE = 0;
+              rc = prollyMutMapFindRc(pCur->pMutMap, pSK, nSK, 0, &mmE);
+              if( rc!=SQLITE_OK ) break;
               if( mmE && mmE->op==PROLLY_EDIT_DELETE ){
                 continue;
               }
@@ -4203,8 +4209,9 @@ static int prollyBtCursorIndexMoveto(
             break;
           } else if( recCmp > 0 ){
             if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
-              ProllyMutMapEntry *mmE = prollyMutMapFind(
-                  pCur->pMutMap, pSK, nSK, 0);
+              ProllyMutMapEntry *mmE = 0;
+              rc = prollyMutMapFindRc(pCur->pMutMap, pSK, nSK, 0, &mmE);
+              if( rc!=SQLITE_OK ) break;
               if( mmE && mmE->op==PROLLY_EDIT_DELETE ){
                 continue;
               }
@@ -4543,11 +4550,12 @@ static int prollyBtCursorInsert(
 
   {
     int canDefer = (pCur->pgnoRoot > 1);
-    if( canDefer ){
-      if( (flags & BTREE_SAVEPOSITION) && pCur->curIntKey ){
+      if( canDefer ){
+        if( (flags & BTREE_SAVEPOSITION) && pCur->curIntKey ){
 
-        ProllyMutMapEntry *pEntry = prollyMutMapFind(
-            pCur->pMutMap, NULL, 0, pPayload->nKey);
+        ProllyMutMapEntry *pEntry = 0;
+        rc = prollyMutMapFindRc(pCur->pMutMap, NULL, 0, pPayload->nKey, &pEntry);
+        if( rc!=SQLITE_OK ) return rc;
         pCur->eState = CURSOR_VALID;
         pCur->curFlags |= BTCF_ValidNKey;
         pCur->cachedIntKey = pPayload->nKey;

--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -247,15 +247,26 @@ static int rankEntryWithoutOrder(ProllyMutMap *mm, int phys){
 static int ensureCapacity(ProllyMutMap *mm){
   if( mm->nEntries >= mm->nAlloc ){
     int nNew = mm->nAlloc ? mm->nAlloc * 2 : MUTMAP_INIT_CAP;
-    ProllyMutMapEntry *aNew = sqlite3_realloc(mm->aEntries,
-                                nNew * sizeof(ProllyMutMapEntry));
+    ProllyMutMapEntry *aNew;
     int *aOrderNew;
     int *aPosNew;
-    if( !aNew ) return SQLITE_NOMEM;
-    aOrderNew = sqlite3_realloc(mm->aOrder, nNew * sizeof(int));
-    if( !aOrderNew ) return SQLITE_NOMEM;
-    aPosNew = sqlite3_realloc(mm->aPos, nNew * sizeof(int));
-    if( !aPosNew ) return SQLITE_NOMEM;
+    aNew = sqlite3_malloc(nNew * sizeof(ProllyMutMapEntry));
+    aOrderNew = sqlite3_malloc(nNew * sizeof(int));
+    aPosNew = sqlite3_malloc(nNew * sizeof(int));
+    if( !aNew || !aOrderNew || !aPosNew ){
+      sqlite3_free(aNew);
+      sqlite3_free(aOrderNew);
+      sqlite3_free(aPosNew);
+      return SQLITE_NOMEM;
+    }
+    if( mm->nEntries > 0 ){
+      memcpy(aNew, mm->aEntries, mm->nEntries * sizeof(ProllyMutMapEntry));
+      memcpy(aOrderNew, mm->aOrder, mm->nEntries * sizeof(int));
+      memcpy(aPosNew, mm->aPos, mm->nEntries * sizeof(int));
+    }
+    sqlite3_free(mm->aEntries);
+    sqlite3_free(mm->aOrder);
+    sqlite3_free(mm->aPos);
     mm->aEntries = aNew;
     mm->aOrder = aOrderNew;
     mm->aPos = aPosNew;
@@ -605,17 +616,32 @@ void prollyMutMapReleaseSavepoint(ProllyMutMap *mm, int level){
   mm->currentSavepointLevel = target;
 }
 
-ProllyMutMapEntry *prollyMutMapFind(ProllyMutMap *mm,
-                                     const u8 *pKey, int nKey, i64 intKey){
+int prollyMutMapFindRc(
+  ProllyMutMap *mm,
+  const u8 *pKey, int nKey, i64 intKey,
+  ProllyMutMapEntry **ppEntry
+){
   int found, idx, phys, rc;
-  if( mm->nEntries==0 ) return 0;
+  *ppEntry = 0;
+  if( mm->nEntries==0 ) return SQLITE_OK;
   if( mm->keepSorted ){
     idx = bsearch_key(mm, pKey, nKey, intKey, &found);
-    return found ? entryAtOrder(mm, idx) : 0;
+    *ppEntry = found ? entryAtOrder(mm, idx) : 0;
+    return SQLITE_OK;
   }
   rc = findPhysLazy(mm, pKey, nKey, intKey, &phys);
-  if( rc!=SQLITE_OK ) return 0;
-  return phys >= 0 ? &mm->aEntries[phys] : 0;
+  if( rc!=SQLITE_OK ) return rc;
+  *ppEntry = phys >= 0 ? &mm->aEntries[phys] : 0;
+  return SQLITE_OK;
+}
+
+ProllyMutMapEntry *prollyMutMapFind(ProllyMutMap *mm,
+                                     const u8 *pKey, int nKey, i64 intKey){
+  ProllyMutMapEntry *pEntry = 0;
+  if( prollyMutMapFindRc(mm, pKey, nKey, intKey, &pEntry)!=SQLITE_OK ){
+    return 0;
+  }
+  return pEntry;
 }
 
 ProllyMutMapEntry *prollyMutMapEntryAt(ProllyMutMap *mm, int idx){

--- a/src/prolly_mutmap.h
+++ b/src/prolly_mutmap.h
@@ -68,6 +68,12 @@ int prollyMutMapDelete(ProllyMutMap *mm,
 ProllyMutMapEntry *prollyMutMapFind(ProllyMutMap *mm,
                                      const u8 *pKey, int nKey, i64 intKey);
 
+int prollyMutMapFindRc(
+  ProllyMutMap *mm,
+  const u8 *pKey, int nKey, i64 intKey,
+  ProllyMutMapEntry **ppEntry
+);
+
 ProllyMutMapEntry *prollyMutMapEntryAt(ProllyMutMap *mm, int idx);
 
 int prollyMutMapOrderIndexFromEntry(ProllyMutMap *mm, ProllyMutMapEntry *pEntry);


### PR DESCRIPTION
## Summary
- make mutmap growth safe under partial allocation failure
- propagate pending-map lookup OOM instead of treating it as a missing entry
- update prolly btree callers to handle lookup errors explicitly

## Verification
- bash test/lint_layers.sh src
- cd build && bash ../test/oracle_savepoints_test.sh ./doltlite ./sqlite3
- cd build && bash ../test/sql_oracle_test.sh ./doltlite ./sqlite3
- cd build && bash ../test/sysbench_compare.sh