### PR TITLE
diff: project WITHOUT-ROWID records via PK-first permutation + multi-PK oracle

### DIFF
--- a/src/doltlite_at.c
+++ b/src/doltlite_at.c
@@ -269,8 +269,10 @@ static int atColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
       sqlite3_result_int64(ctx,r->intKey);
     }else{
       if(r->pVal&&r->nVal>0){
-        DoltliteRecordInfo ri; doltliteParseRecord(r->pVal,r->nVal,&ri);
-        if(col<ri.nField) doltliteResultField(ctx,r->pVal,r->nVal,ri.aType[col],ri.aOffset[col]);
+        DoltliteRecordInfo ri;
+        int recField = v->cols.aColToRec ? v->cols.aColToRec[col] : col;
+        doltliteParseRecord(r->pVal,r->nVal,&ri);
+        if(recField<ri.nField) doltliteResultField(ctx,r->pVal,r->nVal,ri.aType[recField],ri.aOffset[recField]);
         else sqlite3_result_null(ctx);
       }else sqlite3_result_null(ctx);
     }

--- a/src/doltlite_blame.c
+++ b/src/doltlite_blame.c
@@ -711,10 +711,16 @@ static int bmColumn(sqlite3_vtab_cursor *pCursor,
       sqlite3_result_int64(ctx, r->intKey);
     }else if( r->pCurVal && r->nCurVal>0 ){
       DoltliteRecordInfo ri;
+      /* Non-rowid PK tables are auto-converted to WITHOUT ROWID in
+      ** build.c, so records store the PK columns first in PRIMARY KEY
+      ** declaration order. aPkColIdx is sorted by pkPos, so iCol is
+      ** exactly the PK col's record-field index regardless of its
+      ** declared cid. (Blame projects only PK cols so non-PK record
+      ** fields never come into play here.) */
       doltliteParseRecord(r->pCurVal, r->nCurVal, &ri);
-      if( cid < ri.nField ){
+      if( iCol < ri.nField ){
         doltliteResultField(ctx, r->pCurVal, r->nCurVal,
-                            ri.aType[cid], ri.aOffset[cid]);
+                            ri.aType[iCol], ri.aOffset[iCol]);
       }else{
         sqlite3_result_null(ctx);
       }

--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -507,25 +507,27 @@ static void cfrEmitRecordCol(
   sqlite3_context *ctx,
   const u8 *pRec, int nRec,
   int iUserCol,
-  int iPkCol,
+  const DoltliteColInfo *pCols,
   i64 intKey
 ){
+  int recField;
   if( !pRec || nRec<=0 ){
     sqlite3_result_null(ctx);
     return;
   }
-  if( iUserCol==iPkCol ){
+  if( iUserCol==pCols->iPkCol ){
     sqlite3_result_int64(ctx, intKey);
     return;
   }
+  recField = pCols->aColToRec ? pCols->aColToRec[iUserCol] : iUserCol;
   {
     DoltliteRecordInfo ri;
     doltliteParseRecord(pRec, nRec, &ri);
-    if( iUserCol >= ri.nField ){
+    if( recField >= ri.nField ){
       sqlite3_result_null(ctx);
       return;
     }
-    doltliteResultField(ctx, pRec, nRec, ri.aType[iUserCol], ri.aOffset[iUserCol]);
+    doltliteResultField(ctx, pRec, nRec, ri.aType[recField], ri.aOffset[recField]);
   }
 }
 
@@ -564,17 +566,17 @@ static int cfrColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
     sqlite3_result_null(ctx);
   }else if( col>=colBaseStart && col<colOurStart ){
     cfrEmitRecordCol(ctx, cr->pBaseVal, cr->nBaseVal,
-                     col - colBaseStart, v->cols.iPkCol, cr->intKey);
+                     col - colBaseStart, &v->cols, cr->intKey);
   }else if( col>=colOurStart && col<colOurDiff ){
     cfrEmitRecordCol(ctx, cr->pOurVal, cr->nOurVal,
-                     col - colOurStart, v->cols.iPkCol, cr->intKey);
+                     col - colOurStart, &v->cols, cr->intKey);
   }else if( col==colOurDiff ){
     sqlite3_result_text(ctx,
       cfrDiffType(cr->pBaseVal, cr->nBaseVal, cr->pOurVal, cr->nOurVal),
       -1, SQLITE_STATIC);
   }else if( col>=colTheirStart && col<colTheirDiff ){
     cfrEmitRecordCol(ctx, cr->pTheirVal, cr->nTheirVal,
-                     col - colTheirStart, v->cols.iPkCol, cr->intKey);
+                     col - colTheirStart, &v->cols, cr->intKey);
   }else if( col==colTheirDiff ){
     sqlite3_result_text(ctx,
       cfrDiffType(cr->pBaseVal, cr->nBaseVal, cr->pTheirVal, cr->nTheirVal),

--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -1143,7 +1143,9 @@ static int dtColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
     }else{
       if( r->pNewVal && r->nNewVal > 0 ){
         int st, off;
-        int rc = diffRecordField(r->pNewVal, r->nNewVal, colIdx, &st, &off);
+        int recField = pVtab->cols.aColToRec
+                          ? pVtab->cols.aColToRec[colIdx] : colIdx;
+        int rc = diffRecordField(r->pNewVal, r->nNewVal, recField, &st, &off);
         if( rc==SQLITE_OK ){
           doltliteResultField(ctx, r->pNewVal, r->nNewVal, st, off);
         }else if( rc==SQLITE_NOTFOUND ){
@@ -1182,7 +1184,9 @@ static int dtColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
     }else{
       if( r->pOldVal && r->nOldVal > 0 ){
         int st, off;
-        int rc = diffRecordField(r->pOldVal, r->nOldVal, colIdx, &st, &off);
+        int recField = pVtab->cols.aColToRec
+                          ? pVtab->cols.aColToRec[colIdx] : colIdx;
+        int rc = diffRecordField(r->pOldVal, r->nOldVal, recField, &st, &off);
         if( rc==SQLITE_OK ){
           doltliteResultField(ctx, r->pOldVal, r->nOldVal, st, off);
         }else if( rc==SQLITE_NOTFOUND ){

--- a/src/doltlite_history.c
+++ b/src/doltlite_history.c
@@ -298,8 +298,10 @@ static int htColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
     }else{
 
       if(r->pVal&&r->nVal>0){
-        DoltliteRecordInfo ri; doltliteParseRecord(r->pVal,r->nVal,&ri);
-        if(col<ri.nField) doltliteResultField(ctx,r->pVal,r->nVal,ri.aType[col],ri.aOffset[col]);
+        DoltliteRecordInfo ri;
+        int recField = v->cols.aColToRec ? v->cols.aColToRec[col] : col;
+        doltliteParseRecord(r->pVal,r->nVal,&ri);
+        if(recField<ri.nField) doltliteResultField(ctx,r->pVal,r->nVal,ri.aType[recField],ri.aOffset[recField]);
         else sqlite3_result_null(ctx);
       }else sqlite3_result_null(ctx);
     }

--- a/src/doltlite_record.c
+++ b/src/doltlite_record.c
@@ -150,7 +150,9 @@ void doltliteFreeColInfo(DoltliteColInfo *ci){
   int i;
   for(i=0; i<ci->nCol; i++) sqlite3_free(ci->azName[i]);
   sqlite3_free(ci->azName);
+  sqlite3_free(ci->aColToRec);
   ci->azName = 0;
+  ci->aColToRec = 0;
   ci->nCol = 0;
 }
 
@@ -158,13 +160,23 @@ void doltliteFreeColInfo(DoltliteColInfo *ci){
 ** Other PK columns live in the record payload like any user column,
 ** so callers that serialize INT PK values separately (at, history,
 ** diff vtables) use iPkCol to pull the rowid from the cursor
-** instead of the record. */
+** instead of the record.
+**
+** aColToRec maps declared column index → record field index. For
+** rowid-aliased and keyless tables that's the identity; for
+** WITHOUT ROWID tables (compound or single non-INT PK — all
+** auto-converted by build.c) the layout is PK columns first in
+** PRIMARY KEY declaration order, then non-PK columns in declared
+** order, matching the aiColumn[] that convertToWithoutRowidTable
+** builds for the covering PK index. */
 int doltliteGetColumnNames(sqlite3 *db, const char *zTable, DoltliteColInfo *ci){
   char *zSql;
   sqlite3_stmt *pStmt = 0;
   int rc, nCol;
   int nPkCols = 0;
   int iCandidateAlias = -1;
+  int *aPk = 0;
+  int i, iNonPk;
 
   memset(ci, 0, sizeof(*ci));
   ci->iPkCol = -1;
@@ -188,6 +200,15 @@ int doltliteGetColumnNames(sqlite3 *db, const char *zTable, DoltliteColInfo *ci)
   memset(ci->azName, 0, nCol * (int)sizeof(char*));
   ci->nCol = 0;
 
+  if( nCol>0 ){
+    aPk = sqlite3_malloc(nCol * (int)sizeof(int));
+    if( !aPk ){
+      doltliteFreeColInfo(ci);
+      sqlite3_finalize(pStmt);
+      return SQLITE_NOMEM;
+    }
+  }
+
   while( (rc = sqlite3_step(pStmt))==SQLITE_ROW ){
     const char *zName = (const char*)sqlite3_column_text(pStmt, 1);
     int pk = sqlite3_column_int(pStmt, 5);
@@ -198,8 +219,10 @@ int doltliteGetColumnNames(sqlite3 *db, const char *zTable, DoltliteColInfo *ci)
       iCandidateAlias = ci->nCol;
     }
 
+    aPk[ci->nCol] = pk;
     ci->azName[ci->nCol] = sqlite3_mprintf("%s", zName ? zName : "");
     if( !ci->azName[ci->nCol] ){
+      sqlite3_free(aPk);
       doltliteFreeColInfo(ci);
       sqlite3_finalize(pStmt);
       return SQLITE_NOMEM;
@@ -207,6 +230,7 @@ int doltliteGetColumnNames(sqlite3 *db, const char *zTable, DoltliteColInfo *ci)
     ci->nCol++;
   }
   if( rc!=SQLITE_DONE ){
+    sqlite3_free(aPk);
     doltliteFreeColInfo(ci);
     sqlite3_finalize(pStmt);
     return rc;
@@ -220,6 +244,31 @@ int doltliteGetColumnNames(sqlite3 *db, const char *zTable, DoltliteColInfo *ci)
     ci->iPkCol = iCandidateAlias;
   }
 
+  if( ci->nCol>0 ){
+    ci->aColToRec = sqlite3_malloc(ci->nCol * (int)sizeof(int));
+    if( !ci->aColToRec ){
+      sqlite3_free(aPk);
+      doltliteFreeColInfo(ci);
+      sqlite3_finalize(pStmt);
+      return SQLITE_NOMEM;
+    }
+    if( ci->iPkCol>=0 || nPkCols==0 ){
+      /* Rowid-aliased or keyless: record stays in declared order. */
+      for(i=0; i<ci->nCol; i++) ci->aColToRec[i] = i;
+    }else{
+      /* WITHOUT ROWID: PK cols first in PK-declaration order, then
+      ** non-PK cols in declared order. */
+      for(i=0; i<ci->nCol; i++){
+        if( aPk[i]>0 ) ci->aColToRec[i] = aPk[i] - 1;
+      }
+      iNonPk = nPkCols;
+      for(i=0; i<ci->nCol; i++){
+        if( aPk[i]==0 ) ci->aColToRec[i] = iNonPk++;
+      }
+    }
+  }
+
+  sqlite3_free(aPk);
   sqlite3_finalize(pStmt);
   return SQLITE_OK;
 }

--- a/src/doltlite_record.h
+++ b/src/doltlite_record.h
@@ -13,6 +13,15 @@ struct DoltliteColInfo {
   char **azName;
   int nCol;
   int iPkCol;
+  /* aColToRec[i] is the record field index for the i-th declared
+  ** column. Identity for rowid-aliased and keyless tables. For
+  ** WITHOUT ROWID tables (including all doltlite tables with a
+  ** non-INT-PK, which build.c auto-converts) the layout is
+  ** PK-first: PK columns in PRIMARY KEY declaration order, then
+  ** non-PK columns in declared order — matching aiColumn[] that
+  ** SQLite's convertToWithoutRowidTable builds for the covering
+  ** PK index. */
+  int *aColToRec;
 };
 
 int doltliteGetColumnNames(sqlite3 *db, const char *zTable, DoltliteColInfo *ci);

--- a/test/vc_oracle_diff_multi_pk_test.sh
+++ b/test/vc_oracle_diff_multi_pk_test.sh
@@ -1,0 +1,261 @@
+#!/bin/bash
+#
+# Version-control oracle tests: diff surfaces on multi-column PKs
+#
+# Depth suite covering every dolt_diff* surface against tables with
+# compound primary keys, mixed-type keys, keys that are not the
+# leading declared columns, and keys that are reordered relative to
+# declaration. These are the shapes that previously surfaced a
+# rowid-alias detection bug; this harness makes sure no surface
+# regresses silently.
+#
+# Oracle target: real Dolt 1.83.5. For each scenario the harness
+# runs identical setup SQL on both engines and compares tagged
+# output lines. Commit metadata is excluded from comparisons (hashes
+# and timestamps differ by engine); PK values, non-PK values,
+# diff_type, and row/cell counts are the comparison keys.
+#
+# Usage: bash vc_oracle_diff_multi_pk_test.sh [path/to/doltlite] [path/to/dolt]
+#
+
+set -u
+
+DOLTLITE="${1:-./doltlite}"
+DOLT="${2:-dolt}"
+TMPROOT=$(mktemp -d)
+trap "rm -rf $TMPROOT" EXIT
+pass=0; fail=0
+FAILED_NAMES=""
+
+# doltlite uses `SELECT dolt_*()` for procedure-style calls and
+# `dolt_diff_<t>(...)` for the per-table slice TVF. Dolt uses `CALL
+# dolt_*()` and `dolt_diff(..., '<t>')`. Translate only the per-table
+# slice form, not dolt_diff_stat / dolt_diff_summary which share the
+# dolt_diff_ prefix but are commit-range TVFs with identical signatures
+# on both engines.
+translate_for_dolt() {
+  sed -E '
+    s/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g
+    s/dolt_diff_(stat|summary)([^a-zA-Z0-9_])/@@DOLT_DIFF_\1@@\2/g
+    s/dolt_diff_([a-zA-Z0-9_]+)\(([^)]*)\)/dolt_diff(\2, "\1")/g
+    s/@@DOLT_DIFF_(stat|summary)@@/dolt_diff_\1/g
+  '
+}
+
+oracle() {
+  local name="$1" setup="$2" query="$3"
+  local dir="$TMPROOT/$name"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_out
+  dl_out=$(printf "%s\n.headers off\n.mode list\n%s\n" "$setup" "$query" \
+           | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
+           | tr -d '\r' \
+           | grep '^R|' | sort)
+
+  local dolt_setup dolt_query
+  dolt_setup=$(echo "$setup" | translate_for_dolt)
+  dolt_query=$(echo "$query" | translate_for_dolt)
+
+  local dt_out
+  (
+    cd "$dir/dt" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    {
+      echo "$dolt_setup"
+      echo "$dolt_query"
+    } | "$DOLT" sql -r csv 2>"$dir/dt.err"
+  ) > "$dir/dt.raw"
+  dt_out=$(tr -d '"\r' < "$dir/dt.raw" | grep '^R|' | sort)
+
+  if [ "$dl_out" = "$dt_out" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite:"; echo "$dl_out" | sed 's/^/      /'
+    echo "    dolt:";     echo "$dt_out" | sed 's/^/      /'
+  fi
+}
+
+echo "=== Version Control Oracle Tests: multi-col PK diff ==="
+echo ""
+
+# ---------------------------------------------------------------
+# Group A: Two-column INT PK — insert / update-nonpk / delete.
+# Hits dolt_diff_<t> (full history), dolt_diff_<t>(from,to) slice
+# TVF, and dolt_diff summary.
+# ---------------------------------------------------------------
+
+SETUP_A="
+CREATE TABLE t(a INTEGER, b INTEGER, v TEXT, PRIMARY KEY(a, b));
+INSERT INTO t VALUES (1, 1, 'one'), (1, 2, 'two'), (2, 1, 'three');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'seed');
+UPDATE t SET v = 'TWO' WHERE a = 1 AND b = 2;
+INSERT INTO t VALUES (3, 3, 'four');
+DELETE FROM t WHERE a = 1 AND b = 1;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'c2');
+"
+
+echo "--- Group A: two-col INT PK ---"
+
+oracle "a_history" "$SETUP_A" \
+  "SELECT CONCAT('R|', IFNULL(to_a,''), '|', IFNULL(to_b,''), '|', IFNULL(to_v,''), '|', IFNULL(from_a,''), '|', IFNULL(from_b,''), '|', IFNULL(from_v,''), '|', diff_type) FROM dolt_diff_t;"
+
+oracle "a_slice_one" "$SETUP_A" \
+  "SELECT CONCAT('R|', IFNULL(to_a,''), '|', IFNULL(to_b,''), '|', IFNULL(to_v,''), '|', IFNULL(from_a,''), '|', IFNULL(from_b,''), '|', IFNULL(from_v,''), '|', diff_type) FROM dolt_diff_t('HEAD~1', 'HEAD');"
+
+oracle "a_slice_full" "$SETUP_A" \
+  "SELECT CONCAT('R|', IFNULL(to_a,''), '|', IFNULL(to_b,''), '|', IFNULL(to_v,''), '|', IFNULL(from_a,''), '|', IFNULL(from_b,''), '|', IFNULL(from_v,''), '|', diff_type) FROM dolt_diff_t('HEAD~2', 'HEAD');"
+
+# Summary: one row per (commit, table). Compare table_name + change flags joined on message.
+oracle "a_summary" "$SETUP_A" \
+  "SELECT CONCAT('R|', dd.table_name, '|', coalesce(dl.message, dd.commit_hash), '|', dd.data_change, '|', dd.schema_change) FROM dolt_diff dd LEFT JOIN dolt_log dl ON dl.commit_hash = dd.commit_hash WHERE dd.table_name = 't';"
+
+# ---------------------------------------------------------------
+# Group B: Two-column PK with PK-column UPDATE (= delete + add).
+# ---------------------------------------------------------------
+
+echo "--- Group B: PK-column UPDATE ---"
+
+oracle "b_pk_update" "
+CREATE TABLE t(a INTEGER, b INTEGER, v TEXT, PRIMARY KEY(a, b));
+INSERT INTO t VALUES (1, 1, 'one');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'seed');
+UPDATE t SET b = 99 WHERE a = 1 AND b = 1;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'move_pk');
+" "SELECT CONCAT('R|', IFNULL(to_a,''), '|', IFNULL(to_b,''), '|', IFNULL(to_v,''), '|', IFNULL(from_a,''), '|', IFNULL(from_b,''), '|', IFNULL(from_v,''), '|', diff_type) FROM dolt_diff_t('HEAD~1', 'HEAD');"
+
+oracle "b_pk_update_history" "
+CREATE TABLE t(a INTEGER, b INTEGER, v TEXT, PRIMARY KEY(a, b));
+INSERT INTO t VALUES (1, 1, 'one');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'seed');
+UPDATE t SET a = 99 WHERE a = 1 AND b = 1;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'move_pk');
+" "SELECT CONCAT('R|', IFNULL(to_a,''), '|', IFNULL(to_b,''), '|', IFNULL(to_v,''), '|', IFNULL(from_a,''), '|', IFNULL(from_b,''), '|', IFNULL(from_v,''), '|', diff_type) FROM dolt_diff_t;"
+
+# ---------------------------------------------------------------
+# Group C: PK columns not in the first declared positions.
+# PRAGMA table_info order differs from the PK positions, which
+# has historically broken both projection and sortkey encoding.
+# ---------------------------------------------------------------
+
+echo "--- Group C: PK cols not at the front of the declaration ---"
+
+oracle "c_pk_after_nonpk" "
+CREATE TABLE t(v TEXT, a INTEGER, b INTEGER, PRIMARY KEY(a, b));
+INSERT INTO t VALUES ('one', 1, 1), ('two', 1, 2);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'seed');
+INSERT INTO t VALUES ('three', 2, 1);
+UPDATE t SET v = 'TWO' WHERE a = 1 AND b = 2;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'c2');
+" "SELECT CONCAT('R|', IFNULL(to_a,''), '|', IFNULL(to_b,''), '|', IFNULL(to_v,''), '|', IFNULL(from_a,''), '|', IFNULL(from_b,''), '|', IFNULL(from_v,''), '|', diff_type) FROM dolt_diff_t('HEAD~1', 'HEAD');"
+
+# PK declared in REVERSE order vs physical column position.
+oracle "c_pk_reversed" "
+CREATE TABLE t(a INTEGER, b INTEGER, v TEXT, PRIMARY KEY(b, a));
+INSERT INTO t VALUES (1, 10, 'one'), (2, 20, 'two');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'seed');
+UPDATE t SET v = 'TWO' WHERE a = 2 AND b = 20;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'c2');
+" "SELECT CONCAT('R|', IFNULL(to_a,''), '|', IFNULL(to_b,''), '|', IFNULL(to_v,''), '|', IFNULL(from_a,''), '|', IFNULL(from_b,''), '|', IFNULL(from_v,''), '|', diff_type) FROM dolt_diff_t('HEAD~1', 'HEAD');"
+
+# ---------------------------------------------------------------
+# Group D: Three-column compound PK.
+# ---------------------------------------------------------------
+
+echo "--- Group D: three-col PK ---"
+
+oracle "d_three_col_pk" "
+CREATE TABLE t(a INTEGER, b INTEGER, c INTEGER, v TEXT, PRIMARY KEY(a, b, c));
+INSERT INTO t VALUES (1, 1, 10, 'alpha'), (1, 1, 20, 'beta'), (1, 2, 10, 'gamma');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'seed');
+UPDATE t SET v = 'BETA' WHERE a = 1 AND b = 1 AND c = 20;
+INSERT INTO t VALUES (2, 2, 20, 'delta');
+DELETE FROM t WHERE a = 1 AND b = 2 AND c = 10;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'c2');
+" "SELECT CONCAT('R|', IFNULL(to_a,''), '|', IFNULL(to_b,''), '|', IFNULL(to_c,''), '|', IFNULL(to_v,''), '|', IFNULL(from_a,''), '|', IFNULL(from_b,''), '|', IFNULL(from_c,''), '|', IFNULL(from_v,''), '|', diff_type) FROM dolt_diff_t('HEAD~1', 'HEAD');"
+
+oracle "d_three_col_history" "
+CREATE TABLE t(a INTEGER, b INTEGER, c INTEGER, v TEXT, PRIMARY KEY(a, b, c));
+INSERT INTO t VALUES (1, 1, 10, 'alpha'), (1, 1, 20, 'beta');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'seed');
+UPDATE t SET v = 'ALPHA' WHERE a = 1 AND b = 1 AND c = 10;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'c2');
+" "SELECT CONCAT('R|', IFNULL(to_a,''), '|', IFNULL(to_b,''), '|', IFNULL(to_c,''), '|', IFNULL(to_v,''), '|', IFNULL(from_a,''), '|', IFNULL(from_b,''), '|', IFNULL(from_c,''), '|', IFNULL(from_v,''), '|', diff_type) FROM dolt_diff_t;"
+
+# ---------------------------------------------------------------
+# Group E: Mixed-type PKs. VARCHAR in PK is accepted by both
+# engines (Dolt needs an explicit length; SQLite is flexible).
+# ---------------------------------------------------------------
+
+echo "--- Group E: mixed-type PKs ---"
+
+oracle "e_text_int_pk" "
+CREATE TABLE t(name VARCHAR(20), id INTEGER, v TEXT, PRIMARY KEY(name, id));
+INSERT INTO t VALUES ('alice', 1, 'a'), ('alice', 2, 'b'), ('bob', 1, 'c');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'seed');
+UPDATE t SET v = 'B' WHERE name = 'alice' AND id = 2;
+INSERT INTO t VALUES ('carol', 1, 'd');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'c2');
+" "SELECT CONCAT('R|', IFNULL(to_name,''), '|', IFNULL(to_id,''), '|', IFNULL(to_v,''), '|', IFNULL(from_name,''), '|', IFNULL(from_id,''), '|', IFNULL(from_v,''), '|', diff_type) FROM dolt_diff_t('HEAD~1', 'HEAD');"
+
+oracle "e_int_text_pk" "
+CREATE TABLE t(id INTEGER, tag VARCHAR(20), v TEXT, PRIMARY KEY(id, tag));
+INSERT INTO t VALUES (1, 'x', 'foo'), (1, 'y', 'bar');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'seed');
+UPDATE t SET v = 'BAR' WHERE id = 1 AND tag = 'y';
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'c2');
+" "SELECT CONCAT('R|', IFNULL(to_id,''), '|', IFNULL(to_tag,''), '|', IFNULL(to_v,''), '|', IFNULL(from_id,''), '|', IFNULL(from_tag,''), '|', IFNULL(from_v,''), '|', diff_type) FROM dolt_diff_t('HEAD~1', 'HEAD');"
+
+# ---------------------------------------------------------------
+# Group F: dolt_diff_stat row/cell counts on multi-col PK tables.
+# If PK column projection is broken, stat counts can still be
+# right (stat counts rows, not columns), but cell math depends on
+# the correct column total for the table.
+# ---------------------------------------------------------------
+
+echo "--- Group F: dolt_diff_stat on multi-col PK ---"
+
+oracle "f_stat_counts" "
+CREATE TABLE t(a INTEGER, b INTEGER, v1 TEXT, v2 TEXT, PRIMARY KEY(a, b));
+INSERT INTO t VALUES (1, 1, 'one', 'I'), (1, 2, 'two', 'II');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'seed');
+UPDATE t SET v1 = 'TWO', v2 = 'II-prime' WHERE a = 1 AND b = 2;
+INSERT INTO t VALUES (2, 1, 'three', 'III');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'c2');
+" "SELECT CONCAT('R|', table_name, '|', rows_added, '|', rows_deleted, '|', rows_modified, '|', cells_added, '|', cells_deleted, '|', cells_modified) FROM dolt_diff_stat('HEAD~1', 'HEAD', 't');"
+
+oracle "f_stat_pk_update" "
+CREATE TABLE t(a INTEGER, b INTEGER, v TEXT, PRIMARY KEY(a, b));
+INSERT INTO t VALUES (1, 1, 'one'), (1, 2, 'two');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'seed');
+UPDATE t SET b = 99 WHERE a = 1 AND b = 2;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'pk_update');
+" "SELECT CONCAT('R|', table_name, '|', rows_added, '|', rows_deleted, '|', rows_modified) FROM dolt_diff_stat('HEAD~1', 'HEAD', 't');"
+
+# ---------------------------------------------------------------
+# Group G: dolt_blame_<t> on a compound-PK table. Blame projects
+# the PK columns separately from the record payload, so it
+# exercises the same rowid-alias detection path.
+# ---------------------------------------------------------------
+
+echo "--- Group G: dolt_blame on multi-col PK ---"
+
+oracle "g_blame_multi_pk" "
+CREATE TABLE t(a INTEGER, b INTEGER, v TEXT, PRIMARY KEY(a, b));
+INSERT INTO t VALUES (1, 1, 'one'), (1, 2, 'two');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'c1');
+UPDATE t SET v = 'TWO' WHERE a = 1 AND b = 2;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'c2');
+INSERT INTO t VALUES (2, 1, 'three');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'c3');
+" "SELECT CONCAT('R|', a, '|', b, '|', message) FROM dolt_blame_t ORDER BY a, b;"
+
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+if [ $fail -gt 0 ]; then
+  echo "Failed:$FAILED_NAMES"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Records for doltlite's auto-converted WITHOUT-ROWID tables (compound or non-INT PK) are stored PK-first in PRIMARY KEY declaration order, then non-PK columns in declared order — matching the covering PK index SQLite's `convertToWithoutRowidTable` builds. The diff / blame / history / at / conflicts vtables were reading by declared column index, silently projecting the wrong field when PK cols weren't the leading declared columns.
- Adds `DoltliteColInfo.aColToRec[]`, a declared → record-field permutation built from `PRAGMA table_info` pk positions, and routes every record-field read through it (identity for rowid-alias / keyless tables, PK-first remap otherwise). Blame keeps its existing `iCol`-indexed projection — the loop already iterates in PK-declaration order, which matches the record layout for the PK prefix.
- New oracle suite `vc_oracle_diff_multi_pk_test.sh` covers every diff surface against real Dolt 1.83.5 for compound INT PKs, PK-column UPDATE, PK cols not at the front of the declaration, reversed PK order, three-col compound PK, mixed-type PKs, and `dolt_diff_stat` row/cell counts. 15/15 pass. The translator skips `dolt_diff_stat` / `dolt_diff_summary` so they aren't miscompiled into the per-table `dolt_diff` slice form.

## Test plan
- [x] `bash test/vc_oracle_diff_multi_pk_test.sh` — 15/15 pass
- [x] `bash test/doltlite_diff_table.sh` — 39/39
- [x] `bash test/doltlite_history.sh` — 28/28
- [x] `bash test/doltlite_at.sh` — 39/39
- [x] `bash test/doltlite_conflict_rows.sh` — 29/29
- [x] `bash test/doltlite_schema_diff.sh` — 31/31
- [x] `bash test/doltlite_diff.sh` — 20/20
- [x] `bash test/vc_oracle_diff_test.sh`, `vc_oracle_diff_tvf_test.sh`, `vc_oracle_at_test.sh`, `vc_oracle_history_test.sh`, `vc_oracle_blame_test.sh`, `vc_oracle_conflicts_table_test.sh`, `vc_oracle_diff_stat_test.sh`, `vc_oracle_schema_diff_test.sh`
- [x] `bash test/run_doltlite_tests.sh` — 39/39 suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)