### PR TITLE
dolt_ignore: enforce schema at CREATE TABLE time

### DIFF
--- a/src/build.c
+++ b/src/build.c
@@ -2757,6 +2757,50 @@ void sqlite3EndTable(
     tabOpts |= TF_WithoutRowid;
   }
 
+  /* Doltlite: dolt_ignore is a user-created system table whose
+  ** schema is load-bearing — dolt_add / dolt_status run
+  ** `SELECT pattern, ignored FROM dolt_ignore` and would silently
+  ** ignore all patterns if the columns don't match. Enforce the
+  ** exact shape at CREATE TIME so the failure mode is a clear parse
+  ** error instead of silent mis-configuration. Skipped during
+  ** schema replay (db->init.busy): a previously-validated on-disk
+  ** schema is assumed correct. */
+  if( !db->init.busy
+   && !db->init.imposterTable
+   && iDb!=1
+   && pParse->eParseMode!=PARSE_MODE_DECLARE_VTAB
+   && IsOrdinaryTable(p)
+   && sqlite3StrICmp(p->zName, "dolt_ignore")==0 ){
+    const char *zFail = 0;
+    if( p->nCol!=2 ){
+      zFail = "dolt_ignore must have exactly two columns";
+    }else if( sqlite3StrICmp(p->aCol[0].zCnName, "pattern")!=0 ){
+      zFail = "dolt_ignore.pattern must be the first column";
+    }else if( sqlite3StrICmp(p->aCol[1].zCnName, "ignored")!=0 ){
+      zFail = "dolt_ignore.ignored must be the second column";
+    }else if( p->aCol[0].affinity!=SQLITE_AFF_TEXT
+           && p->aCol[0].affinity!=SQLITE_AFF_BLOB ){
+      zFail = "dolt_ignore.pattern must be TEXT";
+    }else if( p->aCol[1].affinity!=SQLITE_AFF_INTEGER
+           && p->aCol[1].affinity!=SQLITE_AFF_NUMERIC ){
+      zFail = "dolt_ignore.ignored must be INTEGER";
+    }else if( p->aCol[0].notNull==OE_None ){
+      zFail = "dolt_ignore.pattern must be NOT NULL";
+    }else if( p->aCol[1].notNull==OE_None ){
+      zFail = "dolt_ignore.ignored must be NOT NULL";
+    }else if( (p->aCol[0].colFlags & COLFLAG_PRIMKEY)==0
+           || (p->aCol[1].colFlags & COLFLAG_PRIMKEY)!=0 ){
+      zFail = "dolt_ignore must have PRIMARY KEY(pattern) and no other key columns";
+    }
+    if( zFail ){
+      sqlite3ErrorMsg(pParse,
+          "%s; expected: CREATE TABLE dolt_ignore("
+          "pattern TEXT NOT NULL, ignored TINYINT NOT NULL, "
+          "PRIMARY KEY(pattern))", zFail);
+      return;
+    }
+  }
+
   /* Special processing for WITHOUT ROWID Tables */
   if( tabOpts & TF_WithoutRowid ){
     if( (p->tabFlags & TF_Autoincrement) ){

--- a/src/doltlite_ignore.c
+++ b/src/doltlite_ignore.c
@@ -48,6 +48,53 @@ static int ignoreSpecificity(const char *zPat){
   return n;
 }
 
+/* Read-time schema guard. The parse-time check in build.c catches
+** new bad CREATE TABLE statements, but on-disk repos created before
+** the guard landed (or via an older binary) can still have a
+** wrong-shape dolt_ignore. Detect it here and raise an error so the
+** user gets a clear signal instead of a silent "no filtering".
+** Called once per check, cached by the prepare failure path below. */
+static int doltliteIgnoreSchemaOk(sqlite3 *db){
+  sqlite3_stmt *pStmt = 0;
+  int nCol;
+  int ok = 0;
+  if( sqlite3_prepare_v2(db, "PRAGMA table_info(\"dolt_ignore\")",
+                         -1, &pStmt, 0)!=SQLITE_OK ){
+    return 0;
+  }
+  nCol = 0;
+  while( sqlite3_step(pStmt)==SQLITE_ROW ){
+    const char *zName = (const char*)sqlite3_column_text(pStmt, 1);
+    const char *zType = (const char*)sqlite3_column_text(pStmt, 2);
+    int notNull = sqlite3_column_int(pStmt, 3);
+    int pkPos = sqlite3_column_int(pStmt, 5);
+    if( !zName || !zType ) goto done;
+    if( nCol==0 ){
+      if( sqlite3_stricmp(zName, "pattern")!=0 ) goto done;
+      if( sqlite3_stricmp(zType, "TEXT")!=0
+       && sqlite3_strnicmp(zType, "VARCHAR", 7)!=0 ) goto done;
+      if( !notNull ) goto done;
+      if( pkPos!=1 ) goto done;
+    }else if( nCol==1 ){
+      if( sqlite3_stricmp(zName, "ignored")!=0 ) goto done;
+      if( sqlite3_stricmp(zType, "TINYINT")!=0
+       && sqlite3_stricmp(zType, "TINYINT(1)")!=0
+       && sqlite3_stricmp(zType, "INT")!=0
+       && sqlite3_stricmp(zType, "INTEGER")!=0
+       && sqlite3_stricmp(zType, "BOOLEAN")!=0 ) goto done;
+      if( !notNull ) goto done;
+      if( pkPos!=0 ) goto done;
+    }else{
+      goto done;
+    }
+    nCol++;
+  }
+  if( nCol==2 ) ok = 1;
+done:
+  sqlite3_finalize(pStmt);
+  return ok;
+}
+
 int doltliteCheckIgnore(
   sqlite3 *db,
   const char *zTable,
@@ -72,6 +119,16 @@ int doltliteCheckIgnore(
     /* Table missing — e.g. legacy repo or pre-seed call. No patterns
     ** means no filtering. */
     return SQLITE_OK;
+  }
+  if( !doltliteIgnoreSchemaOk(db) ){
+    sqlite3_finalize(pStmt);
+    if( pzErr ){
+      *pzErr = sqlite3_mprintf(
+          "dolt_ignore has an unexpected schema; expected: "
+          "CREATE TABLE dolt_ignore(pattern TEXT NOT NULL, "
+          "ignored TINYINT NOT NULL, PRIMARY KEY(pattern))");
+    }
+    return SQLITE_CONSTRAINT;
   }
 
   while( (rc = sqlite3_step(pStmt))==SQLITE_ROW ){

--- a/test/vc_oracle_ignore_test.sh
+++ b/test/vc_oracle_ignore_test.sh
@@ -109,6 +109,28 @@ $setup"
   fi
 }
 
+# doltlite_schema_reject: doltlite-only check that a CREATE TABLE
+# dolt_ignore with a wrong schema is rejected at parse time. Not an
+# oracle comparison — Dolt rejects any `dolt_` name wholesale with
+# "reserved for internal use", so there's no row-level semantics to
+# compare against. We just assert doltlite produces an error that
+# mentions dolt_ignore.
+doltlite_schema_reject() {
+  local name="$1" sql="$2"
+  local dir="$TMPROOT/${name}_rej"
+  mkdir -p "$dir/dl"
+  echo "$sql" | "$DOLTLITE" "$dir/dl/db" > "$dir/out" 2>&1
+  if grep -qi 'dolt_ignore' "$dir/out" \
+     && grep -qiE 'error|fail' "$dir/out"; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name (expected doltlite to reject)"
+    echo "    output:"; sed 's/^/      /' "$dir/out"
+  fi
+}
+
 # oracle_error: both engines must error on the same setup. Exact
 # message text is allowed to differ.
 oracle_error() {
@@ -389,6 +411,85 @@ echo "--- no special-case for dolt_ignore ---"
 oracle "star_hides_dolt_ignore" "
 INSERT INTO dolt_ignore VALUES ('*', 1);
 CREATE TABLE foo(x INT PRIMARY KEY);
+"
+
+# ---------------------------------------------------------------
+# Schema guard: doltlite rejects CREATE TABLE dolt_ignore with the
+# wrong shape so the failure mode is a clear parse error instead of
+# silent "no patterns apply". Doltlite-only — Dolt rejects any
+# dolt_ prefix wholesale so there's nothing to compare against.
+# ---------------------------------------------------------------
+
+echo "--- schema guard ---"
+
+doltlite_schema_reject "schema_one_column" "
+CREATE TABLE dolt_ignore(pattern TEXT NOT NULL PRIMARY KEY);
+"
+
+doltlite_schema_reject "schema_three_columns" "
+CREATE TABLE dolt_ignore(pattern TEXT NOT NULL, ignored TINYINT NOT NULL, extra INT, PRIMARY KEY(pattern));
+"
+
+doltlite_schema_reject "schema_wrong_first_name" "
+CREATE TABLE dolt_ignore(foo TEXT NOT NULL, ignored TINYINT NOT NULL, PRIMARY KEY(foo));
+"
+
+doltlite_schema_reject "schema_wrong_second_name" "
+CREATE TABLE dolt_ignore(pattern TEXT NOT NULL, flagged TINYINT NOT NULL, PRIMARY KEY(pattern));
+"
+
+doltlite_schema_reject "schema_wrong_pattern_type" "
+CREATE TABLE dolt_ignore(pattern INTEGER NOT NULL, ignored TINYINT NOT NULL, PRIMARY KEY(pattern));
+"
+
+doltlite_schema_reject "schema_wrong_ignored_type" "
+CREATE TABLE dolt_ignore(pattern TEXT NOT NULL, ignored TEXT NOT NULL, PRIMARY KEY(pattern));
+"
+
+doltlite_schema_reject "schema_pattern_nullable" "
+CREATE TABLE dolt_ignore(pattern TEXT, ignored TINYINT NOT NULL, PRIMARY KEY(pattern));
+"
+
+doltlite_schema_reject "schema_ignored_nullable" "
+CREATE TABLE dolt_ignore(pattern TEXT NOT NULL, ignored TINYINT, PRIMARY KEY(pattern));
+"
+
+doltlite_schema_reject "schema_compound_pk" "
+CREATE TABLE dolt_ignore(pattern TEXT NOT NULL, ignored TINYINT NOT NULL, PRIMARY KEY(pattern, ignored));
+"
+
+doltlite_schema_reject "schema_no_pk" "
+CREATE TABLE dolt_ignore(pattern TEXT NOT NULL, ignored TINYINT NOT NULL);
+"
+
+# Accepted variants: BOOLEAN, VARCHAR, INTEGER for ignored all map
+# to the right affinities. Not an oracle comparison — just assert
+# doltlite accepts them and INSERT works.
+doltlite_schema_accept() {
+  local name="$1" sql="$2"
+  local dir="$TMPROOT/${name}_acc"
+  mkdir -p "$dir/dl"
+  echo "$sql" | "$DOLTLITE" "$dir/dl/db" > "$dir/out" 2>&1
+  if ! grep -qiE 'error|fail' "$dir/out"; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name (expected doltlite to accept)"
+    echo "    output:"; sed 's/^/      /' "$dir/out"
+  fi
+}
+
+doltlite_schema_accept "schema_varchar_boolean" "
+CREATE TABLE dolt_ignore(pattern VARCHAR(255) NOT NULL, ignored BOOLEAN NOT NULL, PRIMARY KEY(pattern));
+INSERT INTO dolt_ignore VALUES ('tmp_*', 1);
+SELECT * FROM dolt_ignore;
+"
+
+doltlite_schema_accept "schema_integer_ignored" "
+CREATE TABLE dolt_ignore(pattern TEXT NOT NULL, ignored INTEGER NOT NULL, PRIMARY KEY(pattern));
+INSERT INTO dolt_ignore VALUES ('tmp_*', 1);
+SELECT * FROM dolt_ignore;
 "
 
 echo ""


### PR DESCRIPTION
Addresses the concern raised on #455: a user creating ``dolt_ignore`` with the wrong schema would silently turn off all pattern filtering, since ``dolt_add`` and ``dolt_status`` run ``SELECT pattern, ignored FROM dolt_ignore`` and just swallow the prepare failure.

## Summary
- **Parse-time guard** in ``src/build.c`` (next to the existing WITHOUT-ROWID auto-convert hook): after a ``CREATE TABLE`` whose name is ``dolt_ignore``, validate exactly two columns (``pattern`` then ``ignored``), TEXT/BLOB affinity on ``pattern``, INTEGER/NUMERIC on ``ignored``, both NOT NULL, and ``PRIMARY KEY(pattern)`` only. Any mismatch raises a parse error quoting the expected ``CREATE TABLE``. Skipped during schema replay (``db->init.busy``) so reopening a valid repo isn't affected — the stored schema is assumed correct.
- **Read-time guard** in ``src/doltlite_ignore.c``: before iterating patterns, run ``PRAGMA table_info(dolt_ignore)`` and reject if the shape doesn't match. Safety net for legacy on-disk repos written by a pre-guard binary — those slip past the parse-time check on reopen because of the ``init.busy`` skip, but the read-time check catches them the first time a user runs ``dolt_add`` / ``dolt_status`` on the bad repo.

Both guards are permissive about the type-name form: ``VARCHAR(255)`` is accepted as TEXT, ``BOOLEAN``/``INT``/``INTEGER`` are accepted as INTEGER, so users who type the schema slightly differently than the canonical form still get through.

## Test plan
- [x] New ``doltlite_schema_reject`` / ``doltlite_schema_accept`` helpers in ``test/vc_oracle_ignore_test.sh`` + 12 new scenarios (10 rejected shapes, 2 accepted variants). Not oracle comparisons: Dolt rejects any ``dolt_`` prefix table wholesale with "reserved for internal use", so there's no row-level semantics to compare against here — the guards are doltlite-specific behavior.
- [x] ``bash test/vc_oracle_ignore_test.sh`` — 36/36
- [x] ``bash test/run_doltlite_tests.sh`` — 39/39 suites
- [x] ``bash test/oracle_dot_commands_test.sh`` — 61/61
- [x] ``bash test/oracle_savepoints_test.sh`` — 43/43
- [x] Manual smoke: correct schema accepted, every rejected shape produces a clear error naming the expected CREATE TABLE

🤖 Generated with [Claude Code](https://claude.com/claude-code)