### PR TITLE
Refactor large SQL and prolly orchestration paths

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -440,6 +440,310 @@ static int doltliteReportConflicts(
   return SQLITE_OK;
 }
 
+static void addFreeEntries(
+  struct TableEntry *aWorking,
+  struct TableEntry *aStaged,
+  struct TableEntry *aNew
+){
+  sqlite3_free(aWorking);
+  sqlite3_free(aStaged);
+  sqlite3_free(aNew);
+}
+
+static void addResultIgnoreConflict(sqlite3_context *context, char *zIgnErr){
+  if( zIgnErr ){
+    sqlite3_result_error(context, zIgnErr, -1);
+    sqlite3_free(zIgnErr);
+  }else{
+    sqlite3_result_error(context, "dolt_ignore conflict", -1);
+  }
+}
+
+static int addCheckIgnore(
+  sqlite3 *db,
+  sqlite3_context *context,
+  const char *zName,
+  int *pIgnored
+){
+  char *zIgnErr = 0;
+  int rc;
+  *pIgnored = 0;
+  rc = doltliteCheckIgnore(db, zName, pIgnored, &zIgnErr);
+  if( rc==SQLITE_CONSTRAINT ){
+    addResultIgnoreConflict(context, zIgnErr);
+  }else if( rc!=SQLITE_OK ){
+    sqlite3_free(zIgnErr);
+    sqlite3_result_error_code(context, rc);
+  }
+  return rc;
+}
+
+static int addAppendTableEntry(
+  sqlite3_context *context,
+  struct TableEntry **paEntries,
+  int *pnEntries,
+  const struct TableEntry *pEntry
+){
+  struct TableEntry *aNew = sqlite3_realloc(
+      *paEntries, (*pnEntries + 1) * (int)sizeof(struct TableEntry));
+  if( !aNew ){
+    sqlite3_result_error_nomem(context);
+    return SQLITE_NOMEM;
+  }
+  *paEntries = aNew;
+  (*paEntries)[*pnEntries] = *pEntry;
+  (*pnEntries)++;
+  return SQLITE_OK;
+}
+
+static struct TableEntry *addFindEntryByName(
+  struct TableEntry *aEntries,
+  int nEntries,
+  const char *zName
+){
+  int i;
+  if( !zName ) return 0;
+  for(i=0; i<nEntries; i++){
+    if( aEntries[i].zName && strcmp(aEntries[i].zName, zName)==0 ){
+      return &aEntries[i];
+    }
+  }
+  return 0;
+}
+
+static int addLoadWorkingAndStagedCatalogs(
+  sqlite3 *db,
+  const ProllyHash *pWorkingHash,
+  struct TableEntry **paWorking,
+  int *pnWorking,
+  struct TableEntry **paStaged,
+  int *pnStaged
+){
+  ProllyHash stagedHash;
+  int rc;
+
+  *paWorking = 0;
+  *pnWorking = 0;
+  *paStaged = 0;
+  *pnStaged = 0;
+
+  rc = doltliteLoadCatalog(db, pWorkingHash, paWorking, pnWorking, 0);
+  if( rc!=SQLITE_OK ) return rc;
+
+  doltliteGetSessionStaged(db, &stagedHash);
+  if( prollyHashIsEmpty(&stagedHash) ){
+    ProllyHash headCat;
+    rc = doltliteGetHeadCatalogHash(db, &headCat);
+    if( rc==SQLITE_OK && !prollyHashIsEmpty(&headCat) ){
+      rc = doltliteLoadCatalog(db, &headCat, paStaged, pnStaged, 0);
+    }
+  }else{
+    rc = doltliteLoadCatalog(db, &stagedHash, paStaged, pnStaged, 0);
+  }
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(*paWorking);
+    *paWorking = 0;
+    *pnWorking = 0;
+  }
+  return rc;
+}
+
+static int addWriteStagedCatalog(
+  sqlite3 *db,
+  ChunkStore *cs,
+  struct TableEntry *aEntries,
+  int nEntries
+){
+  u8 *buf = 0;
+  int nBuf = 0;
+  ProllyHash newStagedHash;
+  int rc = doltliteSerializeCatalogEntries(db, aEntries, nEntries, &buf, &nBuf);
+  if( rc==SQLITE_OK ){
+    rc = chunkStorePut(cs, buf, nBuf, &newStagedHash);
+  }
+  sqlite3_free(buf);
+  if( rc==SQLITE_OK ){
+    doltliteSetSessionStaged(db, &newStagedHash);
+  }
+  return rc;
+}
+
+static int addStageAllTables(
+  sqlite3 *db,
+  sqlite3_context *context,
+  ChunkStore *cs,
+  const ProllyHash *pWorkingHash
+){
+  struct TableEntry *aWorking = 0;
+  struct TableEntry *aStaged = 0;
+  struct TableEntry *aNew = 0;
+  int nWorking = 0;
+  int nStaged = 0;
+  int nNew = 0;
+  int k;
+  int rc;
+
+  rc = addLoadWorkingAndStagedCatalogs(db, pWorkingHash,
+                                       &aWorking, &nWorking,
+                                       &aStaged, &nStaged);
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error(context, "failed to load staged catalog", -1);
+    return rc;
+  }
+
+  for(k=0; k<nWorking; k++){
+    const char *zName = aWorking[k].zName;
+    struct TableEntry *pUse = &aWorking[k];
+    if( aWorking[k].iTable>1 && zName ){
+      int ignored = 0;
+      rc = addCheckIgnore(db, context, zName, &ignored);
+      if( rc!=SQLITE_OK ){
+        addFreeEntries(aWorking, aStaged, aNew);
+        return rc;
+      }
+      if( ignored ){
+        pUse = addFindEntryByName(aStaged, nStaged, zName);
+        if( !pUse ) continue;
+      }
+    }
+    rc = addAppendTableEntry(context, &aNew, &nNew, pUse);
+    if( rc!=SQLITE_OK ){
+      addFreeEntries(aWorking, aStaged, aNew);
+      return rc;
+    }
+  }
+
+  for(k=0; k<nStaged; k++){
+    const char *zName = aStaged[k].zName;
+    if( aStaged[k].iTable<=1 || !zName ) continue;
+    if( addFindEntryByName(aWorking, nWorking, zName) ) continue;
+    {
+      int ignored = 0;
+      rc = addCheckIgnore(db, context, zName, &ignored);
+      if( rc!=SQLITE_OK ){
+        addFreeEntries(aWorking, aStaged, aNew);
+        return rc;
+      }
+      if( !ignored ) continue;
+    }
+    rc = addAppendTableEntry(context, &aNew, &nNew, &aStaged[k]);
+    if( rc!=SQLITE_OK ){
+      addFreeEntries(aWorking, aStaged, aNew);
+      return rc;
+    }
+  }
+
+  rc = addWriteStagedCatalog(db, cs, aNew, nNew);
+  addFreeEntries(aWorking, aStaged, aNew);
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error_code(context, rc);
+  }
+  return rc;
+}
+
+static int addStageNamedTables(
+  sqlite3 *db,
+  sqlite3_context *context,
+  ChunkStore *cs,
+  const ProllyHash *pWorkingHash,
+  int argc,
+  sqlite3_value **argv
+){
+  struct TableEntry *aWorking = 0;
+  struct TableEntry *aStaged = 0;
+  int nWorking = 0;
+  int nStaged = 0;
+  int i;
+  int rc;
+
+  rc = addLoadWorkingAndStagedCatalogs(db, pWorkingHash,
+                                       &aWorking, &nWorking,
+                                       &aStaged, &nStaged);
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(aWorking);
+    sqlite3_result_error(context, "failed to load staged catalog", -1);
+    return rc;
+  }
+
+  for(i=0; i<argc; i++){
+    const char *zTable = (const char*)sqlite3_value_text(argv[i]);
+    Pgno iTable = 0;
+    int j;
+    if( !zTable || zTable[0]=='-' || strcmp(zTable, ".")==0 ) continue;
+
+    {
+      int ignored = 0;
+      rc = addCheckIgnore(db, context, zTable, &ignored);
+      if( rc!=SQLITE_OK ){
+        sqlite3_free(aWorking);
+        sqlite3_free(aStaged);
+        return rc;
+      }
+      if( ignored ) continue;
+    }
+
+    rc = doltliteResolveTableName(db, zTable, &iTable);
+    if( rc!=SQLITE_OK ){
+      int found = 0;
+      for(j=0; j<nStaged; j++){
+        if( aStaged[j].zName && strcmp(aStaged[j].zName, zTable)==0 ){
+          if( j+1 < nStaged ){
+            memmove(&aStaged[j], &aStaged[j+1],
+                    (nStaged-j-1) * (int)sizeof(struct TableEntry));
+          }
+          nStaged--;
+          found = 1;
+          break;
+        }
+      }
+      if( !found ){
+        char *zErr = sqlite3_mprintf("table not found: %s", zTable);
+        sqlite3_free(aWorking);
+        sqlite3_free(aStaged);
+        if( zErr ){
+          sqlite3_result_error(context, zErr, -1);
+          sqlite3_free(zErr);
+        }else{
+          sqlite3_result_error_nomem(context);
+        }
+        return SQLITE_ERROR;
+      }
+      continue;
+    }
+
+    for(j=0; j<nWorking; j++){
+      if( aWorking[j].iTable==iTable ){
+        int k;
+        int updated = 0;
+        for(k=0; k<nStaged; k++){
+          if( aStaged[k].iTable==iTable ){
+            aStaged[k] = aWorking[j];
+            updated = 1;
+            break;
+          }
+        }
+        if( !updated ){
+          rc = addAppendTableEntry(context, &aStaged, &nStaged, &aWorking[j]);
+          if( rc!=SQLITE_OK ){
+            sqlite3_free(aWorking);
+            sqlite3_free(aStaged);
+            return rc;
+          }
+        }
+        break;
+      }
+    }
+  }
+
+  rc = addWriteStagedCatalog(db, cs, aStaged, nStaged);
+  sqlite3_free(aWorking);
+  sqlite3_free(aStaged);
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error_code(context, rc);
+  }
+  return rc;
+}
+
 static void doltliteAddFunc(
   sqlite3_context *context,
   int argc,
@@ -494,323 +798,11 @@ static void doltliteAddFunc(
     }
 
     if( stageAll ){
-      /* Filter working through dolt_ignore. An entry is preserved in
-      ** new staged as working's version unless its name matches an
-      ** ignore pattern, in which case the current staged entry (if
-      ** any) is kept instead — ignore blocks new staging but doesn't
-      ** un-stage tables that were already staged. Deletions (in
-      ** staged but not in working) are synced only for non-ignored
-      ** tables; ignored deletions stay in new staged to match Dolt. */
-      struct TableEntry *aWorking = 0;
-      struct TableEntry *aStaged = 0;
-      struct TableEntry *aNew = 0;
-      int nWorking = 0, nStaged = 0, nNew = 0;
-      int k;
-      ProllyHash stagedHash;
-
-      rc = doltliteLoadCatalog(db, &workingHash, &aWorking, &nWorking, 0);
-      if( rc!=SQLITE_OK ){
-        sqlite3_result_error(context, "failed to load working catalog", -1);
-        return;
-      }
-
-      doltliteGetSessionStaged(db, &stagedHash);
-      if( prollyHashIsEmpty(&stagedHash) ){
-        ProllyHash headCat;
-        rc = doltliteGetHeadCatalogHash(db, &headCat);
-        if( rc==SQLITE_OK && !prollyHashIsEmpty(&headCat) ){
-          rc = doltliteLoadCatalog(db, &headCat, &aStaged, &nStaged, 0);
-        }
-      }else{
-        rc = doltliteLoadCatalog(db, &stagedHash, &aStaged, &nStaged, 0);
-      }
-      if( rc!=SQLITE_OK ){
-        sqlite3_free(aWorking);
-        sqlite3_result_error(context, "failed to load staged catalog", -1);
-        return;
-      }
-
-      for(k=0; k<nWorking; k++){
-        const char *zName = aWorking[k].zName;
-        int ignored = 0;
-        char *zIgnErr = 0;
-        int irc;
-        struct TableEntry *pUse = &aWorking[k];
-        struct TableEntry *aTmp;
-
-        if( aWorking[k].iTable>1 && zName ){
-          irc = doltliteCheckIgnore(db, zName, &ignored, &zIgnErr);
-          if( irc==SQLITE_CONSTRAINT ){
-            sqlite3_free(aWorking);
-            sqlite3_free(aStaged);
-            sqlite3_free(aNew);
-            if( zIgnErr ){
-              sqlite3_result_error(context, zIgnErr, -1);
-              sqlite3_free(zIgnErr);
-            }else{
-              sqlite3_result_error(context, "dolt_ignore conflict", -1);
-            }
-            return;
-          }
-          if( irc!=SQLITE_OK ){
-            sqlite3_free(zIgnErr);
-            sqlite3_free(aWorking);
-            sqlite3_free(aStaged);
-            sqlite3_free(aNew);
-            sqlite3_result_error_code(context, irc);
-            return;
-          }
-          if( ignored ){
-            /* Keep the existing staged entry if any; otherwise skip. */
-            int j;
-            pUse = 0;
-            for(j=0; j<nStaged; j++){
-              if( aStaged[j].zName && strcmp(aStaged[j].zName, zName)==0 ){
-                pUse = &aStaged[j];
-                break;
-              }
-            }
-            if( !pUse ) continue;
-          }
-        }
-
-        aTmp = sqlite3_realloc(aNew, (nNew+1)*(int)sizeof(struct TableEntry));
-        if( !aTmp ){
-          sqlite3_free(aWorking);
-          sqlite3_free(aStaged);
-          sqlite3_free(aNew);
-          sqlite3_result_error_nomem(context);
-          return;
-        }
-        aNew = aTmp;
-        aNew[nNew] = *pUse;
-        nNew++;
-      }
-
-      /* Deletions: staged entries absent from working are dropped,
-      ** unless they match an ignore pattern (in which case the
-      ** deletion stays un-synced and staged keeps them). */
-      for(k=0; k<nStaged; k++){
-        const char *zName = aStaged[k].zName;
-        int found = 0;
-        int j;
-        struct TableEntry *aTmp;
-        if( aStaged[k].iTable<=1 || !zName ) continue;
-        for(j=0; j<nWorking; j++){
-          if( aWorking[j].zName && strcmp(aWorking[j].zName, zName)==0 ){
-            found = 1;
-            break;
-          }
-        }
-        if( found ) continue;
-        {
-          int ignored = 0;
-          char *zIgnErr = 0;
-          int irc = doltliteCheckIgnore(db, zName, &ignored, &zIgnErr);
-          if( irc==SQLITE_CONSTRAINT ){
-            sqlite3_free(aWorking);
-            sqlite3_free(aStaged);
-            sqlite3_free(aNew);
-            if( zIgnErr ){
-              sqlite3_result_error(context, zIgnErr, -1);
-              sqlite3_free(zIgnErr);
-            }else{
-              sqlite3_result_error(context, "dolt_ignore conflict", -1);
-            }
-            return;
-          }
-          if( irc!=SQLITE_OK ){
-            sqlite3_free(zIgnErr);
-            sqlite3_free(aWorking);
-            sqlite3_free(aStaged);
-            sqlite3_free(aNew);
-            sqlite3_result_error_code(context, irc);
-            return;
-          }
-          if( !ignored ) continue;
-        }
-        aTmp = sqlite3_realloc(aNew, (nNew+1)*(int)sizeof(struct TableEntry));
-        if( !aTmp ){
-          sqlite3_free(aWorking);
-          sqlite3_free(aStaged);
-          sqlite3_free(aNew);
-          sqlite3_result_error_nomem(context);
-          return;
-        }
-        aNew = aTmp;
-        aNew[nNew] = aStaged[k];
-        nNew++;
-      }
-
-      {
-        u8 *buf = 0;
-        int nBuf = 0;
-        ProllyHash newStagedHash;
-        rc = doltliteSerializeCatalogEntries(db, aNew, nNew, &buf, &nBuf);
-        if( rc!=SQLITE_OK ){
-          sqlite3_free(aWorking);
-          sqlite3_free(aStaged);
-          sqlite3_free(aNew);
-          sqlite3_result_error_code(context, rc);
-          return;
-        }
-        rc = chunkStorePut(cs, buf, nBuf, &newStagedHash);
-        sqlite3_free(buf);
-        if( rc==SQLITE_OK ){
-          doltliteSetSessionStaged(db, &newStagedHash);
-        }
-      }
-
-      sqlite3_free(aWorking);
-      sqlite3_free(aStaged);
-      sqlite3_free(aNew);
+      rc = addStageAllTables(db, context, cs, &workingHash);
+      if( rc!=SQLITE_OK ) return;
     }else{
-
-      struct TableEntry *aWorking = 0, *aStaged = 0;
-      int nWorking = 0, nStaged = 0;
-      ProllyHash stagedHash;
-
-
-      rc = doltliteLoadCatalog(db, &workingHash, &aWorking, &nWorking, 0);
-      if( rc!=SQLITE_OK ){
-        sqlite3_result_error(context, "failed to load working catalog", -1);
-        return;
-      }
-
-      doltliteGetSessionStaged(db, &stagedHash);
-      if( prollyHashIsEmpty(&stagedHash) ){
-
-        ProllyHash headCat;
-        rc = doltliteGetHeadCatalogHash(db, &headCat);
-        if( rc==SQLITE_OK && !prollyHashIsEmpty(&headCat) ){
-          rc = doltliteLoadCatalog(db, &headCat, &aStaged, &nStaged, 0);
-        }
-      }else{
-        rc = doltliteLoadCatalog(db, &stagedHash, &aStaged, &nStaged, 0);
-      }
-      if( rc!=SQLITE_OK ){
-        sqlite3_free(aWorking);
-        sqlite3_result_error(context, "failed to load staged catalog", -1);
-        return;
-      }
-
-      for(i=0; i<argc; i++){
-        const char *zTable = (const char*)sqlite3_value_text(argv[i]);
-        Pgno iTable = 0;
-        int j;
-        int ignored = 0;
-        char *zIgnErr = 0;
-        int irc;
-
-        if( !zTable || zTable[0]=='-' || strcmp(zTable, ".")==0 ) continue;
-
-        /* Explicit-name add respects dolt_ignore: silent no-op for
-        ** ignored tables; error on conflicting patterns. */
-        irc = doltliteCheckIgnore(db, zTable, &ignored, &zIgnErr);
-        if( irc==SQLITE_CONSTRAINT ){
-          sqlite3_free(aWorking);
-          sqlite3_free(aStaged);
-          if( zIgnErr ){
-            sqlite3_result_error(context, zIgnErr, -1);
-            sqlite3_free(zIgnErr);
-          }else{
-            sqlite3_result_error(context, "dolt_ignore conflict", -1);
-          }
-          return;
-        }
-        if( irc!=SQLITE_OK ){
-          sqlite3_free(zIgnErr);
-          sqlite3_free(aWorking);
-          sqlite3_free(aStaged);
-          sqlite3_result_error_code(context, irc);
-          return;
-        }
-        if( ignored ) continue;
-
-        rc = doltliteResolveTableName(db, zTable, &iTable);
-        if( rc!=SQLITE_OK ){
-
-          int found = 0;
-          for(j=0; j<nStaged; j++){
-            if( aStaged[j].zName && strcmp(aStaged[j].zName, zTable)==0 ){
-              if( j+1 < nStaged ){
-                memmove(&aStaged[j], &aStaged[j+1],
-                        (nStaged-j-1) * (int)sizeof(struct TableEntry));
-              }
-              nStaged--;
-              found = 1;
-              break;
-            }
-          }
-          if( !found ){
-            char *zErr = sqlite3_mprintf(
-                "table not found: %s", zTable);
-            sqlite3_free(aWorking);
-            sqlite3_free(aStaged);
-            if( zErr ){
-              sqlite3_result_error(context, zErr, -1);
-              sqlite3_free(zErr);
-            }else{
-              sqlite3_result_error_nomem(context);
-            }
-            return;
-          }
-          continue;
-        }
-
-
-        for(j=0; j<nWorking; j++){
-          if( aWorking[j].iTable==iTable ){
-
-            int k;
-            int updated = 0;
-            for(k=0; k<nStaged; k++){
-              if( aStaged[k].iTable==iTable ){
-                aStaged[k] = aWorking[j];
-                updated = 1;
-                break;
-              }
-            }
-            if( !updated ){
-
-              struct TableEntry *aNew = sqlite3_realloc(aStaged,
-                  (nStaged+1)*(int)sizeof(struct TableEntry));
-              if( !aNew ){
-                sqlite3_free(aWorking);
-                sqlite3_free(aStaged);
-                sqlite3_result_error_nomem(context);
-                return;
-              }
-              aStaged = aNew;
-              aStaged[nStaged] = aWorking[j];
-              nStaged++;
-            }
-            break;
-          }
-        }
-      }
-
-
-      {
-        u8 *buf = 0;
-        int nBuf = 0;
-        ProllyHash newStagedHash;
-        rc = doltliteSerializeCatalogEntries(db, aStaged, nStaged, &buf, &nBuf);
-        if( rc!=SQLITE_OK ){
-          sqlite3_free(aWorking);
-          sqlite3_free(aStaged);
-          sqlite3_result_error_code(context, rc);
-          return;
-        }
-        rc = chunkStorePut(cs, buf, nBuf, &newStagedHash);
-        sqlite3_free(buf);
-        if( rc==SQLITE_OK ){
-          doltliteSetSessionStaged(db, &newStagedHash);
-        }
-      }
-
-      sqlite3_free(aWorking);
-      sqlite3_free(aStaged);
+      rc = addStageNamedTables(db, context, cs, &workingHash, argc, argv);
+      if( rc!=SQLITE_OK ) return;
     }
 
     rc = doltlitePersistWorkingSet(db);

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -1253,6 +1253,255 @@ static void doltliteCommitFunc(
   sqlite3_result_text(context, hexBuf, -1, SQLITE_TRANSIENT);
 }
 
+static int resetPathMatchesName(const struct TableEntry *pEntry, const char *zName){
+  return pEntry->zName && strcmp(pEntry->zName, zName)==0;
+}
+
+static int resetFindTableIndex(struct TableEntry *aTables, int nTables,
+                               const char *zTable){
+  int i;
+  for(i=0; i<nTables; i++){
+    if( resetPathMatchesName(&aTables[i], zTable) ) return i;
+  }
+  return -1;
+}
+
+static int resetStageNamedPaths(
+  sqlite3 *db,
+  ChunkStore *cs,
+  const char **azPaths,
+  int nPaths
+){
+  struct TableEntry *aHead = 0, *aStaged = 0;
+  int nHead = 0, nStaged = 0;
+  ProllyHash headCatHash, stagedHash;
+  int p;
+  int rc;
+
+  rc = doltliteGetHeadCatalogHash(db, &headCatHash);
+  if( rc!=SQLITE_OK ) return rc;
+  if( !prollyHashIsEmpty(&headCatHash) ){
+    rc = doltliteLoadCatalog(db, &headCatHash, &aHead, &nHead, 0);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+
+  doltliteGetSessionStaged(db, &stagedHash);
+  if( !prollyHashIsEmpty(&stagedHash) ){
+    rc = doltliteLoadCatalog(db, &stagedHash, &aStaged, &nStaged, 0);
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(aHead);
+      return rc;
+    }
+  }
+
+  for(p=0; p<nPaths; p++){
+    const char *zTable = azPaths[p];
+    int iH = resetFindTableIndex(aHead, nHead, zTable);
+    int iS = resetFindTableIndex(aStaged, nStaged, zTable);
+    if( iH<0 && iS<0 ){
+      rc = SQLITE_NOTFOUND;
+      goto done;
+    }
+    if( iH<0 ){
+      if( iS+1<nStaged ){
+        memmove(&aStaged[iS], &aStaged[iS+1],
+                (nStaged-iS-1)*(int)sizeof(struct TableEntry));
+      }
+      nStaged--;
+    }else if( iS<0 ){
+      struct TableEntry *aNew = sqlite3_realloc(aStaged,
+          (nStaged+1)*(int)sizeof(struct TableEntry));
+      if( !aNew ){
+        rc = SQLITE_NOMEM;
+        goto done;
+      }
+      aStaged = aNew;
+      aStaged[nStaged++] = aHead[iH];
+    }else{
+      aStaged[iS] = aHead[iH];
+    }
+  }
+
+  {
+    u8 *buf = 0;
+    int nBuf = 0;
+    ProllyHash newStagedHash;
+    rc = doltliteSerializeCatalogEntries(db, aStaged, nStaged, &buf, &nBuf);
+    if( rc==SQLITE_OK ){
+      rc = chunkStorePut(cs, buf, nBuf, &newStagedHash);
+    }
+    sqlite3_free(buf);
+    if( rc==SQLITE_OK ){
+      doltliteSetSessionStaged(db, &newStagedHash);
+    }
+  }
+
+done:
+  sqlite3_free(aHead);
+  sqlite3_free(aStaged);
+  return rc;
+}
+
+static int resetMergeUntrackedWorkingTables(
+  sqlite3 *db,
+  ChunkStore *cs,
+  const ProllyHash *pHeadCatHash,
+  ProllyHash *pTargetCatHash
+){
+  struct TableEntry *aHead = 0;
+  int nHead = 0;
+  int nUntracked = 0;
+  char **azUntracked = 0;
+  sqlite3_stmt *pStmt = 0;
+  int j, k;
+  int rc = doltliteLoadCatalog(db, pHeadCatHash, &aHead, &nHead, 0);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = sqlite3_prepare_v2(db,
+      "SELECT name FROM sqlite_master WHERE type='table' "
+      "AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'dolt_%'",
+      -1, &pStmt, 0);
+  if( rc!=SQLITE_OK ) goto done;
+  while( sqlite3_step(pStmt)==SQLITE_ROW ){
+    const char *zName = (const char*)sqlite3_column_text(pStmt, 0);
+    int inHead = 0;
+    if( !zName ) continue;
+    for(k=0; k<nHead; k++){
+      if( resetPathMatchesName(&aHead[k], zName) ){
+        inHead = 1;
+        break;
+      }
+    }
+    if( !inHead ){
+      char **aNew = sqlite3_realloc(azUntracked,
+          (nUntracked+1)*(int)sizeof(char*));
+      if( !aNew ){ rc = SQLITE_NOMEM; goto done; }
+      azUntracked = aNew;
+      azUntracked[nUntracked++] = sqlite3_mprintf("%s", zName);
+      if( !azUntracked[nUntracked-1] ){ rc = SQLITE_NOMEM; goto done; }
+    }
+  }
+  if( rc!=SQLITE_DONE && rc!=SQLITE_ROW ) goto done;
+  rc = SQLITE_OK;
+
+  if( nUntracked>0 ){
+    ProllyHash workingHash;
+    struct TableEntry *aWorking = 0, *aTarget = 0;
+    int nWorking = 0, nTarget = 0;
+    rc = doltliteFlushCatalogToHash(db, &workingHash);
+    if( rc==SQLITE_OK ) rc = doltliteLoadCatalog(db, &workingHash, &aWorking, &nWorking, 0);
+    if( rc==SQLITE_OK ) rc = doltliteLoadCatalog(db, pTargetCatHash, &aTarget, &nTarget, 0);
+    if( rc==SQLITE_OK ){
+      for(j=0; j<nWorking; j++){
+        int tgtIdx = -1;
+        if( aWorking[j].iTable==1 ) continue;
+        for(k=0; k<nTarget; k++){
+          if( aTarget[k].zName && aWorking[j].zName
+           && strcmp(aTarget[k].zName, aWorking[j].zName)==0 ){
+            tgtIdx = k;
+            break;
+          }
+        }
+        if( tgtIdx>=0 ) aWorking[j] = aTarget[tgtIdx];
+      }
+    }
+    if( rc==SQLITE_OK ){
+      u8 *buf = 0;
+      int nBuf = 0;
+      ProllyHash mergedHash;
+      rc = doltliteSerializeCatalogEntries(db, aWorking, nWorking, &buf, &nBuf);
+      if( rc==SQLITE_OK ) rc = chunkStorePut(cs, buf, nBuf, &mergedHash);
+      sqlite3_free(buf);
+      if( rc==SQLITE_OK ) *pTargetCatHash = mergedHash;
+    }
+    sqlite3_free(aWorking);
+    sqlite3_free(aTarget);
+  }
+
+done:
+  if( pStmt ) sqlite3_finalize(pStmt);
+  for(j=0; j<nUntracked; j++) sqlite3_free(azUntracked[j]);
+  sqlite3_free(azUntracked);
+  sqlite3_free(aHead);
+  return rc;
+}
+
+static int mergeAbortInPlace(sqlite3 *db){
+  ProllyHash headCatHash;
+  int rc = doltliteGetHeadCatalogHash(db, &headCatHash);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = doltliteHardReset(db, &headCatHash);
+  if( rc!=SQLITE_OK ) return rc;
+  doltliteSetSessionStaged(db, &headCatHash);
+  doltliteClearSessionMergeState(db);
+  return doltlitePersistWorkingSet(db);
+}
+
+static int mergeFastForward(
+  sqlite3 *db,
+  sqlite3_context *context,
+  ChunkStore *cs,
+  const ProllyHash *pOurHead,
+  const ProllyHash *pTheirHead
+){
+  DoltliteCommit theirCommit;
+  DoltliteTxnState savedState;
+  int graphLocked = 0;
+  int rc;
+  char hx[PROLLY_HASH_SIZE*2+1];
+
+  memset(&theirCommit, 0, sizeof(theirCommit));
+  memset(&savedState, 0, sizeof(savedState));
+
+  rc = doltliteLoadCommit(db, pTheirHead, &theirCommit);
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error(context, "failed to load commit", -1);
+    return rc;
+  }
+  rc = doltliteSaveTxnState(db, &savedState);
+  if( rc!=SQLITE_OK ){
+    doltliteCommitClear(&theirCommit);
+    sqlite3_result_error_code(context, rc);
+    return rc;
+  }
+  rc = doltliteRefreshAndConfirmHead(db, cs, pOurHead);
+  if( rc==SQLITE_BUSY ){
+    doltliteTxnStateClear(&savedState);
+    doltliteCommitClear(&theirCommit);
+    sqlite3_result_error(context,
+      "merge conflict: another connection committed to this branch. Please retry your transaction.",
+      -1);
+    return rc;
+  }
+  if( rc!=SQLITE_OK ){
+    doltliteTxnStateClear(&savedState);
+    doltliteCommitClear(&theirCommit);
+    sqlite3_result_error_code(context, rc);
+    return rc;
+  }
+  graphLocked = 1;
+  rc = doltliteSwitchCatalog(db, &theirCommit.catalogHash);
+  if( rc==SQLITE_OK ){
+    rc = doltliteUpdateBranchWorkingState(db, doltliteGetSessionBranch(db),
+                                          &theirCommit.catalogHash, NULL);
+  }
+  if( rc==SQLITE_OK ){
+    rc = doltliteAdvanceBranch(db, pTheirHead, &theirCommit.catalogHash);
+  }
+  if( graphLocked ) chunkStoreUnlock(cs);
+  if( rc!=SQLITE_OK ){
+    int rc2 = doltliteRestoreTxnState(db, &savedState);
+    doltliteTxnStateClear(&savedState);
+    doltliteCommitClear(&theirCommit);
+    sqlite3_result_error_code(context, rc2==SQLITE_OK ? rc : rc2);
+    return rc;
+  }
+  doltliteTxnStateClear(&savedState);
+  doltliteCommitClear(&theirCommit);
+  doltliteHashToHex(pTheirHead, hx);
+  sqlite3_result_text(context, hx, -1, SQLITE_TRANSIENT);
+  return SQLITE_OK;
+}
+
 static void doltliteResetFunc(
   sqlite3_context *context,
   int argc,
@@ -1323,113 +1572,18 @@ static void doltliteResetFunc(
 
 
   if( nPaths>0 ){
-    struct TableEntry *aHead = 0, *aStaged = 0;
-    int nHead = 0, nStaged = 0;
-    ProllyHash headCatHash, stagedHash;
-    int p;
-
     if( isHard || isSoft || zRef ){
       sqlite3_result_error(context,
         "table paths cannot be combined with --hard / --soft or a target ref", -1);
       sqlite3_free(azPaths);
       return;
     }
-
-    rc = doltliteGetHeadCatalogHash(db, &headCatHash);
-    if( rc!=SQLITE_OK ){
-      sqlite3_free(azPaths);
-      sqlite3_result_error(context, "failed to read HEAD", -1);
+    rc = resetStageNamedPaths(db, cs, azPaths, nPaths);
+    sqlite3_free(azPaths);
+    if( rc==SQLITE_NOTFOUND ){
+      sqlite3_result_error(context, "table not found", -1);
       return;
     }
-    if( !prollyHashIsEmpty(&headCatHash) ){
-      rc = doltliteLoadCatalog(db, &headCatHash, &aHead, &nHead, 0);
-      if( rc!=SQLITE_OK ){
-        sqlite3_free(azPaths);
-        sqlite3_result_error(context, "failed to load HEAD catalog", -1);
-        return;
-      }
-    }
-
-    doltliteGetSessionStaged(db, &stagedHash);
-    if( !prollyHashIsEmpty(&stagedHash) ){
-      rc = doltliteLoadCatalog(db, &stagedHash, &aStaged, &nStaged, 0);
-      if( rc!=SQLITE_OK ){
-        sqlite3_free(aHead);
-        sqlite3_free(azPaths);
-        sqlite3_result_error(context, "failed to load staged catalog", -1);
-        return;
-      }
-    }
-
-    for(p=0; p<nPaths; p++){
-      const char *zTable = azPaths[p];
-      int iH;
-      int iS = -1;
-      int j;
-
-
-      for(j=0; j<nStaged; j++){
-        if( aStaged[j].zName && strcmp(aStaged[j].zName, zTable)==0 ){
-          iS = j; break;
-        }
-      }
-      iH = -1;
-      for(j=0; j<nHead; j++){
-        if( aHead[j].zName && strcmp(aHead[j].zName, zTable)==0 ){
-          iH = j; break;
-        }
-      }
-
-      if( iH<0 && iS<0 ){
-        char *zErr = sqlite3_mprintf("table not found: %s", zTable);
-        sqlite3_free(aHead); sqlite3_free(aStaged); sqlite3_free(azPaths);
-        sqlite3_result_error(context, zErr ? zErr : "table not found", -1);
-        sqlite3_free(zErr);
-        return;
-      }
-
-      if( iH<0 ){
-
-        if( iS+1<nStaged ){
-          memmove(&aStaged[iS], &aStaged[iS+1],
-                  (nStaged-iS-1)*(int)sizeof(struct TableEntry));
-        }
-        nStaged--;
-      }else if( iS<0 ){
-
-        struct TableEntry *aNew = sqlite3_realloc(aStaged,
-            (nStaged+1)*(int)sizeof(struct TableEntry));
-        if( !aNew ){
-          sqlite3_free(aHead); sqlite3_free(aStaged); sqlite3_free(azPaths);
-          sqlite3_result_error_nomem(context);
-          return;
-        }
-        aStaged = aNew;
-        aStaged[nStaged] = aHead[iH];
-        nStaged++;
-      }else{
-
-        aStaged[iS] = aHead[iH];
-      }
-    }
-
-    {
-      u8 *buf = 0;
-      int nBuf = 0;
-      ProllyHash newStagedHash;
-      rc = doltliteSerializeCatalogEntries(db, aStaged, nStaged, &buf, &nBuf);
-      if( rc==SQLITE_OK ){
-        rc = chunkStorePut(cs, buf, nBuf, &newStagedHash);
-      }
-      sqlite3_free(buf);
-      if( rc==SQLITE_OK ){
-        doltliteSetSessionStaged(db, &newStagedHash);
-      }
-    }
-
-    sqlite3_free(aHead);
-    sqlite3_free(aStaged);
-    sqlite3_free(azPaths);
     if( rc!=SQLITE_OK ){
       sqlite3_result_error_code(context, rc);
       return;
@@ -1517,93 +1671,8 @@ static void doltliteResetFunc(
     ** CREATE TABLE silently deleted. Merge those tables into the
     ** target catalog before applying the reset. */
     if( havePreResetHead ){
-      struct TableEntry *aHead = 0;
-      int nHead = 0;
-      int nUntracked = 0;
-      char **azUntracked = 0;
-      sqlite3_stmt *pStmt = 0;
-      int j, k;
-
-      rc = doltliteLoadCatalog(db, &preResetHeadCatHash, &aHead, &nHead, 0);
-      if( rc==SQLITE_OK ){
-        rc = sqlite3_prepare_v2(db,
-            "SELECT name FROM sqlite_master WHERE type='table' "
-            "AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'dolt_%'",
-            -1, &pStmt, 0);
-      }
-      if( rc==SQLITE_OK ){
-        while( sqlite3_step(pStmt)==SQLITE_ROW ){
-          const char *zName = (const char*)sqlite3_column_text(pStmt, 0);
-          int inHead = 0;
-          if( !zName ) continue;
-          for(k=0; k<nHead; k++){
-            if( aHead[k].zName && strcmp(aHead[k].zName, zName)==0 ){
-              inHead = 1; break;
-            }
-          }
-          if( !inHead ){
-            char **aNew = sqlite3_realloc(azUntracked,
-                (nUntracked+1)*(int)sizeof(char*));
-            if( !aNew ){ rc = SQLITE_NOMEM; break; }
-            azUntracked = aNew;
-            azUntracked[nUntracked++] = sqlite3_mprintf("%s", zName);
-          }
-        }
-        sqlite3_finalize(pStmt);
-      }
-
-
-      if( rc==SQLITE_OK && nUntracked>0 ){
-        ProllyHash workingHash;
-        struct TableEntry *aWorking = 0, *aTarget = 0;
-        int nWorking = 0, nTarget = 0;
-
-        rc = doltliteFlushCatalogToHash(db, &workingHash);
-        if( rc==SQLITE_OK ){
-          rc = doltliteLoadCatalog(db, &workingHash, &aWorking, &nWorking, 0);
-        }
-        if( rc==SQLITE_OK ){
-          rc = doltliteLoadCatalog(db, &targetCatHash, &aTarget, &nTarget, 0);
-        }
-        if( rc==SQLITE_OK ){
-
-          for(j=0; j<nWorking; j++){
-            int tgtIdx = -1;
-            if( aWorking[j].iTable==1 ){
-
-              continue;
-            }
-            for(k=0; k<nTarget; k++){
-              if( aTarget[k].zName && aWorking[j].zName
-               && strcmp(aTarget[k].zName, aWorking[j].zName)==0 ){
-                tgtIdx = k; break;
-              }
-            }
-            if( tgtIdx>=0 ){
-              aWorking[j] = aTarget[tgtIdx];
-            }
-          }
-        }
-        if( rc==SQLITE_OK ){
-          u8 *buf = 0;
-          int nBuf = 0;
-          ProllyHash mergedHash;
-          rc = doltliteSerializeCatalogEntries(db, aWorking, nWorking, &buf, &nBuf);
-          if( rc==SQLITE_OK ){
-            rc = chunkStorePut(cs, buf, nBuf, &mergedHash);
-          }
-          sqlite3_free(buf);
-          if( rc==SQLITE_OK ){
-            memcpy(&targetCatHash, &mergedHash, sizeof(ProllyHash));
-          }
-        }
-        sqlite3_free(aWorking);
-        sqlite3_free(aTarget);
-      }
-
-      for(j=0; j<nUntracked; j++) sqlite3_free(azUntracked[j]);
-      sqlite3_free(azUntracked);
-      sqlite3_free(aHead);
+      rc = resetMergeUntrackedWorkingTables(db, cs, &preResetHeadCatHash,
+                                            &targetCatHash);
       if( rc!=SQLITE_OK ){
         sqlite3_result_error_code(context, rc);
         goto reset_cleanup;
@@ -1703,32 +1772,12 @@ static void doltliteMergeFunc(
 
   if( isAbort ){
     u8 isMerging = 0;
-    ProllyHash headCatHash;
-
     doltliteGetSessionMergeState(db, &isMerging, 0, 0);
     if( !isMerging ){
       sqlite3_result_error(context, "no merge in progress", -1);
       return;
     }
-
-
-    rc = doltliteGetHeadCatalogHash(db, &headCatHash);
-    if( rc!=SQLITE_OK ){
-      sqlite3_result_error(context, "failed to read HEAD", -1);
-      return;
-    }
-    rc = doltliteHardReset(db, &headCatHash);
-    if( rc!=SQLITE_OK ){
-      sqlite3_result_error(context, "abort reset failed", -1);
-      return;
-    }
-
-
-    doltliteSetSessionStaged(db, &headCatHash);
-
-
-    doltliteClearSessionMergeState(db);
-    rc = doltlitePersistWorkingSet(db);
+    rc = mergeAbortInPlace(db);
     if( rc!=SQLITE_OK ){
       sqlite3_result_error_code(context, rc);
       return;
@@ -1788,61 +1837,7 @@ static void doltliteMergeFunc(
   ** creating a merge commit. --no-ff forces a merge commit even
   ** when ff would be possible (matches git behavior). */
   if( prollyHashCompare(&ancestorHash, &ourHead)==0 && !noFastForward ){
-
-    char hx[PROLLY_HASH_SIZE*2+1];
-
-    rc = doltliteLoadCommit(db, &theirHead, &theirCommit);
-    if( rc!=SQLITE_OK ){ sqlite3_result_error(context, "failed to load commit", -1); return; }
-
-    rc = doltliteSaveTxnState(db, &savedState);
-    if( rc!=SQLITE_OK ){
-      doltliteCommitClear(&theirCommit);
-      sqlite3_result_error_code(context, rc);
-      return;
-    }
-
-    rc = doltliteRefreshAndConfirmHead(db, cs, &ourHead);
-    if( rc==SQLITE_BUSY ){
-      doltliteTxnStateClear(&savedState);
-      doltliteCommitClear(&theirCommit);
-      sqlite3_result_error(context,
-        "merge conflict: another connection committed to this branch. Please retry your transaction.",
-        -1);
-      return;
-    }
-    if( rc!=SQLITE_OK ){
-      doltliteTxnStateClear(&savedState);
-      doltliteCommitClear(&theirCommit);
-      sqlite3_result_error_code(context, rc);
-      return;
-    }
-    graphLocked = 1;
-
-    rc = doltliteSwitchCatalog(db, &theirCommit.catalogHash);
-    if( rc==SQLITE_OK ){
-      rc = doltliteUpdateBranchWorkingState(db,
-          doltliteGetSessionBranch(db), &theirCommit.catalogHash, NULL);
-    }
-    if( rc==SQLITE_OK ){
-      rc = doltliteAdvanceBranch(db, &theirHead, &theirCommit.catalogHash);
-    }
-    if( graphLocked ){
-      chunkStoreUnlock(cs);
-      graphLocked = 0;
-    }
-    if( rc!=SQLITE_OK ){
-      int rc2 = doltliteRestoreTxnState(db, &savedState);
-      doltliteTxnStateClear(&savedState);
-      doltliteCommitClear(&theirCommit);
-      sqlite3_result_error_code(context, rc2==SQLITE_OK ? rc : rc2);
-      return;
-    }
-    doltliteTxnStateClear(&savedState);
-
-    doltliteCommitClear(&theirCommit);
-
-    doltliteHashToHex(&theirHead, hx);
-    sqlite3_result_text(context, hx, -1, SQLITE_TRANSIENT);
+    rc = mergeFastForward(db, context, cs, &ourHead, &theirHead);
     return;
   }
 

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -1342,89 +1342,6 @@ done:
   return rc;
 }
 
-static int resetMergeUntrackedWorkingTables(
-  sqlite3 *db,
-  ChunkStore *cs,
-  const ProllyHash *pHeadCatHash,
-  ProllyHash *pTargetCatHash
-){
-  struct TableEntry *aHead = 0;
-  int nHead = 0;
-  int nUntracked = 0;
-  char **azUntracked = 0;
-  sqlite3_stmt *pStmt = 0;
-  int j, k;
-  int rc = doltliteLoadCatalog(db, pHeadCatHash, &aHead, &nHead, 0);
-  if( rc!=SQLITE_OK ) return rc;
-  rc = sqlite3_prepare_v2(db,
-      "SELECT name FROM sqlite_master WHERE type='table' "
-      "AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'dolt_%'",
-      -1, &pStmt, 0);
-  if( rc!=SQLITE_OK ) goto done;
-  while( sqlite3_step(pStmt)==SQLITE_ROW ){
-    const char *zName = (const char*)sqlite3_column_text(pStmt, 0);
-    int inHead = 0;
-    if( !zName ) continue;
-    for(k=0; k<nHead; k++){
-      if( resetPathMatchesName(&aHead[k], zName) ){
-        inHead = 1;
-        break;
-      }
-    }
-    if( !inHead ){
-      char **aNew = sqlite3_realloc(azUntracked,
-          (nUntracked+1)*(int)sizeof(char*));
-      if( !aNew ){ rc = SQLITE_NOMEM; goto done; }
-      azUntracked = aNew;
-      azUntracked[nUntracked++] = sqlite3_mprintf("%s", zName);
-      if( !azUntracked[nUntracked-1] ){ rc = SQLITE_NOMEM; goto done; }
-    }
-  }
-  if( rc!=SQLITE_DONE && rc!=SQLITE_ROW ) goto done;
-  rc = SQLITE_OK;
-
-  if( nUntracked>0 ){
-    ProllyHash workingHash;
-    struct TableEntry *aWorking = 0, *aTarget = 0;
-    int nWorking = 0, nTarget = 0;
-    rc = doltliteFlushCatalogToHash(db, &workingHash);
-    if( rc==SQLITE_OK ) rc = doltliteLoadCatalog(db, &workingHash, &aWorking, &nWorking, 0);
-    if( rc==SQLITE_OK ) rc = doltliteLoadCatalog(db, pTargetCatHash, &aTarget, &nTarget, 0);
-    if( rc==SQLITE_OK ){
-      for(j=0; j<nWorking; j++){
-        int tgtIdx = -1;
-        if( aWorking[j].iTable==1 ) continue;
-        for(k=0; k<nTarget; k++){
-          if( aTarget[k].zName && aWorking[j].zName
-           && strcmp(aTarget[k].zName, aWorking[j].zName)==0 ){
-            tgtIdx = k;
-            break;
-          }
-        }
-        if( tgtIdx>=0 ) aWorking[j] = aTarget[tgtIdx];
-      }
-    }
-    if( rc==SQLITE_OK ){
-      u8 *buf = 0;
-      int nBuf = 0;
-      ProllyHash mergedHash;
-      rc = doltliteSerializeCatalogEntries(db, aWorking, nWorking, &buf, &nBuf);
-      if( rc==SQLITE_OK ) rc = chunkStorePut(cs, buf, nBuf, &mergedHash);
-      sqlite3_free(buf);
-      if( rc==SQLITE_OK ) *pTargetCatHash = mergedHash;
-    }
-    sqlite3_free(aWorking);
-    sqlite3_free(aTarget);
-  }
-
-done:
-  if( pStmt ) sqlite3_finalize(pStmt);
-  for(j=0; j<nUntracked; j++) sqlite3_free(azUntracked[j]);
-  sqlite3_free(azUntracked);
-  sqlite3_free(aHead);
-  return rc;
-}
-
 static int mergeAbortInPlace(sqlite3 *db){
   ProllyHash headCatHash;
   int rc = doltliteGetHeadCatalogHash(db, &headCatHash);
@@ -1671,8 +1588,93 @@ static void doltliteResetFunc(
     ** CREATE TABLE silently deleted. Merge those tables into the
     ** target catalog before applying the reset. */
     if( havePreResetHead ){
-      rc = resetMergeUntrackedWorkingTables(db, cs, &preResetHeadCatHash,
-                                            &targetCatHash);
+      struct TableEntry *aHead = 0;
+      int nHead = 0;
+      int nUntracked = 0;
+      char **azUntracked = 0;
+      sqlite3_stmt *pStmt = 0;
+      int j, k;
+
+      rc = doltliteLoadCatalog(db, &preResetHeadCatHash, &aHead, &nHead, 0);
+      if( rc==SQLITE_OK ){
+        rc = sqlite3_prepare_v2(db,
+            "SELECT name FROM sqlite_master WHERE type='table' "
+            "AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'dolt_%'",
+            -1, &pStmt, 0);
+      }
+      if( rc==SQLITE_OK ){
+        while( sqlite3_step(pStmt)==SQLITE_ROW ){
+          const char *zName = (const char*)sqlite3_column_text(pStmt, 0);
+          int inHead = 0;
+          if( !zName ) continue;
+          for(k=0; k<nHead; k++){
+            if( aHead[k].zName && strcmp(aHead[k].zName, zName)==0 ){
+              inHead = 1;
+              break;
+            }
+          }
+          if( !inHead ){
+            char **aNew = sqlite3_realloc(azUntracked,
+                (nUntracked+1)*(int)sizeof(char*));
+            if( !aNew ){ rc = SQLITE_NOMEM; break; }
+            azUntracked = aNew;
+            azUntracked[nUntracked++] = sqlite3_mprintf("%s", zName);
+          }
+        }
+        sqlite3_finalize(pStmt);
+      }
+
+      if( rc==SQLITE_OK && nUntracked>0 ){
+        ProllyHash workingHash;
+        struct TableEntry *aWorking = 0, *aTarget = 0;
+        int nWorking = 0, nTarget = 0;
+
+        rc = doltliteFlushCatalogToHash(db, &workingHash);
+        if( rc==SQLITE_OK ){
+          rc = doltliteLoadCatalog(db, &workingHash, &aWorking, &nWorking, 0);
+        }
+        if( rc==SQLITE_OK ){
+          rc = doltliteLoadCatalog(db, &targetCatHash, &aTarget, &nTarget, 0);
+        }
+        if( rc==SQLITE_OK ){
+          for(j=0; j<nWorking; j++){
+            int tgtIdx = -1;
+            if( aWorking[j].iTable==1 ){
+              continue;
+            }
+            for(k=0; k<nTarget; k++){
+              if( aTarget[k].zName && aWorking[j].zName
+               && strcmp(aTarget[k].zName, aWorking[j].zName)==0 ){
+                tgtIdx = k;
+                break;
+              }
+            }
+            if( tgtIdx>=0 ){
+              aWorking[j] = aTarget[tgtIdx];
+            }
+          }
+        }
+        if( rc==SQLITE_OK ){
+          u8 *buf = 0;
+          int nBuf = 0;
+          ProllyHash mergedHash;
+          rc = doltliteSerializeCatalogEntries(db, aWorking, nWorking,
+                                               &buf, &nBuf);
+          if( rc==SQLITE_OK ){
+            rc = chunkStorePut(cs, buf, nBuf, &mergedHash);
+          }
+          sqlite3_free(buf);
+          if( rc==SQLITE_OK ){
+            memcpy(&targetCatHash, &mergedHash, sizeof(ProllyHash));
+          }
+        }
+        sqlite3_free(aWorking);
+        sqlite3_free(aTarget);
+      }
+
+      for(j=0; j<nUntracked; j++) sqlite3_free(azUntracked[j]);
+      sqlite3_free(azUntracked);
+      sqlite3_free(aHead);
       if( rc!=SQLITE_OK ){
         sqlite3_result_error_code(context, rc);
         goto reset_cleanup;

--- a/src/doltlite_diff_stat.c
+++ b/src/doltlite_diff_stat.c
@@ -606,43 +606,81 @@ fail:
   return rc;
 }
 
+typedef struct DsFilterCtx DsFilterCtx;
+struct DsFilterCtx {
+  const char *zFromRef;
+  const char *zToRef;
+  const char *zTblFilter;
+  ProllyHash fromCat;
+  ProllyHash toCat;
+  char **azNames;
+  int nNames;
+};
+
+static void dsFilterCtxClear(DsFilterCtx *pCtx){
+  int i;
+  for(i=0; i<pCtx->nNames; i++) sqlite3_free(pCtx->azNames[i]);
+  sqlite3_free(pCtx->azNames);
+  memset(pCtx, 0, sizeof(*pCtx));
+}
+
+static int dsFilterInit(
+  sqlite3 *db,
+  sqlite3_vtab *pVtab,
+  int idxNum,
+  int argc,
+  sqlite3_value **argv,
+  const char *zName,
+  DsFilterCtx *pCtx
+){
+  int rc;
+  int argIdx = 0;
+
+  memset(pCtx, 0, sizeof(*pCtx));
+  rc = dsRequireRefs(pVtab, idxNum, zName);
+  if( rc!=SQLITE_OK ) return rc;
+
+  if( (idxNum & 1) && argIdx<argc ){
+    pCtx->zFromRef = (const char*)sqlite3_value_text(argv[argIdx++]);
+  }
+  if( (idxNum & 2) && argIdx<argc ){
+    pCtx->zToRef = (const char*)sqlite3_value_text(argv[argIdx++]);
+  }
+  if( (idxNum & 4) && argIdx<argc ){
+    pCtx->zTblFilter = (const char*)sqlite3_value_text(argv[argIdx++]);
+  }
+
+  rc = dsResolveCatHash(db, pCtx->zFromRef, &pCtx->fromCat);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = dsResolveCatHash(db, pCtx->zToRef, &pCtx->toCat);
+  if( rc!=SQLITE_OK ) return rc;
+  return dsCollectTableNames(db, &pCtx->fromCat, &pCtx->toCat,
+                             &pCtx->azNames, &pCtx->nNames);
+}
+
+static int dsTableNameMatchesFilter(const DsFilterCtx *pCtx, const char *zName){
+  return !pCtx->zTblFilter || strcmp(zName, pCtx->zTblFilter)==0;
+}
+
 static int dstFilter(sqlite3_vtab_cursor *cur,
     int idxNum, const char *idxStr, int argc, sqlite3_value **argv){
   DstCursor *c = (DstCursor*)cur;
   DstVtab *v = (DstVtab*)cur->pVtab;
   sqlite3 *db = v->db;
-  const char *zFromRef = 0, *zToRef = 0, *zTblFilter = 0;
-  ProllyHash fromCat, toCat;
-  char **azNames = 0;
-  int nNames = 0;
-  int rc, argIdx = 0, i;
+  DsFilterCtx fctx;
+  int rc, i;
   (void)idxStr;
 
   dstFreeRows(c);
   c->iRow = 0;
 
-  rc = dsRequireRefs(&v->base, idxNum, "dolt_diff_stat");
+  rc = dsFilterInit(db, &v->base, idxNum, argc, argv, "dolt_diff_stat", &fctx);
   if( rc!=SQLITE_OK ) return rc;
 
-  if( (idxNum & 1) && argIdx<argc )
-    zFromRef = (const char*)sqlite3_value_text(argv[argIdx++]);
-  if( (idxNum & 2) && argIdx<argc )
-    zToRef = (const char*)sqlite3_value_text(argv[argIdx++]);
-  if( (idxNum & 4) && argIdx<argc )
-    zTblFilter = (const char*)sqlite3_value_text(argv[argIdx++]);
-
-  rc = dsResolveCatHash(db, zFromRef, &fromCat);
-  if( rc!=SQLITE_OK ) return rc;
-  rc = dsResolveCatHash(db, zToRef, &toCat);
-  if( rc!=SQLITE_OK ) return rc;
-
-  rc = dsCollectTableNames(db, &fromCat, &toCat, &azNames, &nNames);
-  if( rc!=SQLITE_OK ) return rc;
-
-  for(i=0; i<nNames; i++){
+  for(i=0; i<fctx.nNames; i++){
     DsStatRow row;
-    if( zTblFilter && strcmp(azNames[i], zTblFilter)!=0 ) continue;
-    rc = dsComputeTableStats(db, azNames[i], &fromCat, &toCat, &row);
+    if( !dsTableNameMatchesFilter(&fctx, fctx.azNames[i]) ) continue;
+    rc = dsComputeTableStats(db, fctx.azNames[i], &fctx.fromCat, &fctx.toCat, &row);
     if( rc!=SQLITE_OK ){
       sqlite3_free(row.zTableName);
       goto done;
@@ -662,8 +700,7 @@ static int dstFilter(sqlite3_vtab_cursor *cur,
   }
 
 done:
-  for(i=0; i<nNames; i++) sqlite3_free(azNames[i]);
-  sqlite3_free(azNames);
+  dsFilterCtxClear(&fctx);
   return rc;
 }
 
@@ -836,84 +873,75 @@ static int dssAppend(DssCursor *c, const char *zFrom, const char *zTo,
   return SQLITE_OK;
 }
 
+static int dssAppendTableChange(
+  DssCursor *c,
+  sqlite3 *db,
+  const char *zTableName,
+  struct TableEntry *pFromEntry,
+  struct TableEntry *pToEntry
+){
+  int rc;
+  i64 rowCount = 0;
+  int dataChange;
+  int schemaChange;
+  const char *zDiffType;
+
+  if( pFromEntry && pToEntry ){
+    int rootsDiffer = prollyHashCompare(&pFromEntry->root, &pToEntry->root)!=0;
+    int schemasDiffer = prollyHashCompare(&pFromEntry->schemaHash,
+                                          &pToEntry->schemaHash)!=0;
+    if( !rootsDiffer && !schemasDiffer ) return SQLITE_OK;
+    return dssAppend(c, zTableName, zTableName, "modified",
+                     rootsDiffer, schemasDiffer);
+  }
+
+  if( pToEntry ){
+    rc = dsCountRows(db, &pToEntry->root, pToEntry->flags, &rowCount);
+    if( rc!=SQLITE_OK ) return rc;
+    dataChange = rowCount > 0;
+    schemaChange = 1;
+    zDiffType = "added";
+    return dssAppend(c, "", zTableName, zDiffType, dataChange, schemaChange);
+  }
+
+  rc = dsCountRows(db, &pFromEntry->root, pFromEntry->flags, &rowCount);
+  if( rc!=SQLITE_OK ) return rc;
+  dataChange = rowCount > 0;
+  schemaChange = 1;
+  zDiffType = "dropped";
+  return dssAppend(c, zTableName, "", zDiffType, dataChange, schemaChange);
+}
+
 static int dssFilter(sqlite3_vtab_cursor *cur,
     int idxNum, const char *idxStr, int argc, sqlite3_value **argv){
   DssCursor *c = (DssCursor*)cur;
   DssVtab *v = (DssVtab*)cur->pVtab;
   sqlite3 *db = v->db;
-  const char *zFromRef = 0, *zToRef = 0, *zTblFilter = 0;
-  ProllyHash fromCat, toCat;
+  DsFilterCtx fctx;
   struct TableEntry *aFromCat = 0, *aToCat = 0;
   int nFromCat = 0, nToCat = 0;
-  char **azNames = 0;
-  int nNames = 0;
-  int rc, argIdx = 0, i;
+  int rc, i;
   (void)idxStr;
 
   dssFreeRows(c);
   c->iRow = 0;
 
-  rc = dsRequireRefs(&v->base, idxNum, "dolt_diff_summary");
+  rc = dsFilterInit(db, &v->base, idxNum, argc, argv,
+                    "dolt_diff_summary", &fctx);
   if( rc!=SQLITE_OK ) return rc;
-
-  if( (idxNum & 1) && argIdx<argc )
-    zFromRef = (const char*)sqlite3_value_text(argv[argIdx++]);
-  if( (idxNum & 2) && argIdx<argc )
-    zToRef = (const char*)sqlite3_value_text(argv[argIdx++]);
-  if( (idxNum & 4) && argIdx<argc )
-    zTblFilter = (const char*)sqlite3_value_text(argv[argIdx++]);
-
-  rc = dsResolveCatHash(db, zFromRef, &fromCat);
-  if( rc!=SQLITE_OK ) return rc;
-  rc = dsResolveCatHash(db, zToRef, &toCat);
-  if( rc!=SQLITE_OK ) return rc;
-
-  rc = dsCollectTableNames(db, &fromCat, &toCat, &azNames, &nNames);
-  if( rc!=SQLITE_OK ) return rc;
-  rc = doltliteLoadCatalog(db, &fromCat, &aFromCat, &nFromCat, 0);
+  rc = doltliteLoadCatalog(db, &fctx.fromCat, &aFromCat, &nFromCat, 0);
   if( rc!=SQLITE_OK ) goto done;
-  rc = doltliteLoadCatalog(db, &toCat, &aToCat, &nToCat, 0);
+  rc = doltliteLoadCatalog(db, &fctx.toCat, &aToCat, &nToCat, 0);
   if( rc!=SQLITE_OK ) goto done;
 
-  for(i=0; i<nNames; i++){
+  for(i=0; i<fctx.nNames; i++){
     struct TableEntry *pFromEntry, *pToEntry;
-    i64 oldCount = 0, newCount = 0;
-    int dataChange, schemaChange;
-    const char *zDiffType;
 
-    if( zTblFilter && strcmp(azNames[i], zTblFilter)!=0 ) continue;
+    if( !dsTableNameMatchesFilter(&fctx, fctx.azNames[i]) ) continue;
 
-    pFromEntry = doltliteFindTableByName(aFromCat, nFromCat, azNames[i]);
-    pToEntry   = doltliteFindTableByName(aToCat,   nToCat,   azNames[i]);
-
-    if( pFromEntry && pToEntry ){
-      int rootsDiffer = (prollyHashCompare(&pFromEntry->root,
-                                           &pToEntry->root)!=0);
-      int schemasDiffer = (prollyHashCompare(&pFromEntry->schemaHash,
-                                             &pToEntry->schemaHash)!=0);
-      if( !rootsDiffer && !schemasDiffer ){
-        continue;
-      }
-      dataChange = rootsDiffer;
-      schemaChange = schemasDiffer;
-      zDiffType = "modified";
-      rc = dssAppend(c, azNames[i], azNames[i], zDiffType,
-                     dataChange, schemaChange);
-    }else if( !pFromEntry && pToEntry ){
-      rc = dsCountRows(db, &pToEntry->root, pToEntry->flags, &newCount);
-      if( rc!=SQLITE_OK ) goto done;
-      dataChange = newCount > 0;
-      schemaChange = 1;
-      rc = dssAppend(c, "", azNames[i], "added",
-                     dataChange, schemaChange);
-    }else if( pFromEntry && !pToEntry ){
-      rc = dsCountRows(db, &pFromEntry->root, pFromEntry->flags, &oldCount);
-      if( rc!=SQLITE_OK ) goto done;
-      dataChange = oldCount > 0;
-      schemaChange = 1;
-      rc = dssAppend(c, azNames[i], "", "dropped",
-                     dataChange, schemaChange);
-    }
+    pFromEntry = doltliteFindTableByName(aFromCat, nFromCat, fctx.azNames[i]);
+    pToEntry   = doltliteFindTableByName(aToCat,   nToCat,   fctx.azNames[i]);
+    rc = dssAppendTableChange(c, db, fctx.azNames[i], pFromEntry, pToEntry);
 
     if( rc!=SQLITE_OK ) goto done;
   }
@@ -921,8 +949,7 @@ static int dssFilter(sqlite3_vtab_cursor *cur,
 done:
   sqlite3_free(aFromCat);
   sqlite3_free(aToCat);
-  for(i=0; i<nNames; i++) sqlite3_free(azNames[i]);
-  sqlite3_free(azNames);
+  dsFilterCtxClear(&fctx);
   return rc;
 }
 

--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -266,6 +266,35 @@ static int pairsAppend(DiffTblCursor *pCur,
   return SQLITE_OK;
 }
 
+static int stackPushUnique(ProllyHash **paAdded, int *pnAdded,
+                           ProllyHash **paStack, int *pnStack,
+                           const ProllyHash *pHash){
+  ProllyHash *aAddedNew;
+  ProllyHash *aStackNew;
+  int i;
+  for(i=0; i<*pnAdded; i++){
+    if( prollyHashCompare(&(*paAdded)[i], pHash)==0 ) return SQLITE_OK;
+  }
+  aAddedNew = sqlite3_malloc((*pnAdded+1)*(int)sizeof(ProllyHash));
+  if( !aAddedNew ) return SQLITE_NOMEM;
+  aStackNew = sqlite3_malloc((*pnStack+1)*(int)sizeof(ProllyHash));
+  if( !aStackNew ){
+    sqlite3_free(aAddedNew);
+    return SQLITE_NOMEM;
+  }
+  if( *pnAdded>0 ) memcpy(aAddedNew, *paAdded, (*pnAdded)*(int)sizeof(ProllyHash));
+  if( *pnStack>0 ) memcpy(aStackNew, *paStack, (*pnStack)*(int)sizeof(ProllyHash));
+  sqlite3_free(*paAdded);
+  sqlite3_free(*paStack);
+  *paAdded = aAddedNew;
+  *paStack = aStackNew;
+  (*paAdded)[*pnAdded] = *pHash;
+  (*pnAdded)++;
+  (*paStack)[*pnStack] = *pHash;
+  (*pnStack)++;
+  return SQLITE_OK;
+}
+
 static int loadTblRootAtCommit(sqlite3 *db, const ProllyHash *pCatHash,
                                const char *zTableName,
                                ProllyHash *pTblRoot, u8 *pFlags,
@@ -291,6 +320,101 @@ static int loadTblRootAtCommit(sqlite3 *db, const ProllyHash *pCatHash,
   return SQLITE_OK;
 }
 
+static int seedWorkingChildInfo(
+  sqlite3 *db,
+  const ProllyHash *pHeadHash,
+  const char *zTableName,
+  CmTblInfo **paMap,
+  int *pnMap
+){
+  ProllyHash workingCat;
+  ProllyHash workingTblRoot;
+  ProllyHash workingSchemaHash;
+  u8 workingFlags;
+  char zWorking[PROLLY_HASH_SIZE*2+1];
+  int rc;
+
+  memset(&workingCat, 0, sizeof(workingCat));
+  memset(&workingTblRoot, 0, sizeof(workingTblRoot));
+  memset(&workingSchemaHash, 0, sizeof(workingSchemaHash));
+  memset(zWorking, 0, sizeof(zWorking));
+  memcpy(zWorking, "WORKING", 7);
+
+  rc = doltliteFlushCatalogToHash(db, &workingCat);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = loadTblRootAtCommit(db, &workingCat, zTableName, &workingTblRoot,
+                           &workingFlags, &workingSchemaHash);
+  if( rc!=SQLITE_OK ) return rc;
+  return mapPut(paMap, pnMap, pHeadHash, &workingTblRoot, &workingCat,
+                &workingSchemaHash, workingFlags, zWorking, 0);
+}
+
+static int appendCurrentDiffPair(
+  DiffTblCursor *pCur,
+  const ProllyHash *pCurr,
+  const DoltliteCommit *pCommit,
+  const ProllyHash *pCurTblRoot,
+  const ProllyHash *pCurSchemaHash,
+  u8 curFlags,
+  CmTblInfo *aMap,
+  int nMap
+){
+  CmTblInfo *pInfo;
+  int idx;
+  int rootsDiffer;
+  int schemasDiffer;
+  u8 fromFlags;
+
+  idx = mapFind(aMap, nMap, pCurr);
+  if( idx<0 ) return SQLITE_OK;
+  pInfo = &aMap[idx];
+  rootsDiffer = prollyHashCompare(&pInfo->tblRoot, pCurTblRoot)!=0;
+  schemasDiffer = prollyHashCompare(&pInfo->schemaHash, pCurSchemaHash)!=0;
+  if( !rootsDiffer && !schemasDiffer ) return SQLITE_OK;
+
+  fromFlags = curFlags;
+  if( fromFlags==0 ) fromFlags = pInfo->flags;
+  return pairsAppend(pCur, pCurr, pCurTblRoot, &pCommit->catalogHash,
+                     pCurSchemaHash, fromFlags, pCommit->timestamp,
+                     pInfo->zHexName, &pInfo->tblRoot, &pInfo->catHash,
+                     &pInfo->schemaHash, pInfo->flags, pInfo->date);
+}
+
+static int registerCommitParents(
+  CmTblInfo **paMap,
+  int *pnMap,
+  ProllyHash **paStack,
+  int *pnStack,
+  ProllyHash **paAdded,
+  int *pnAdded,
+  const DoltliteCommit *pCommit,
+  const ProllyHash *pCurTblRoot,
+  const ProllyHash *pCurSchemaHash,
+  u8 curFlags,
+  const char *zCurHex
+){
+  int i;
+  int nParents;
+  const ProllyHash *pParent;
+  int rc;
+
+  nParents = pCommit->nParents>0
+               ? pCommit->nParents
+               : (prollyHashIsEmpty(&pCommit->parentHash) ? 0 : 1);
+  for(i=0; i<nParents; i++){
+    pParent = pCommit->nParents>0 ? &pCommit->aParents[i] : &pCommit->parentHash;
+    rc = mapPut(paMap, pnMap, pParent, pCurTblRoot, &pCommit->catalogHash,
+                pCurSchemaHash, curFlags, zCurHex, pCommit->timestamp);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+  for(i=0; i<nParents; i++){
+    pParent = pCommit->nParents>0 ? &pCommit->aParents[i] : &pCommit->parentHash;
+    rc = stackPushUnique(paAdded, pnAdded, paStack, pnStack, pParent);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+  return SQLITE_OK;
+}
+
 /* Walk history toward the root, emitting one DiffPair per commit
 ** whose table root (or schema) differs from the commit that follows
 ** it. aMap is keyed by commit hash and stores "what child info do we
@@ -303,8 +427,6 @@ static int buildDiffPairs(DiffTblCursor *pCur, sqlite3 *db,
                           const char *zTableName){
   ChunkStore *cs = doltliteGetChunkStore(db);
   ProllyHash headHash;
-  ProllyHash workingCat, workingTblRoot;
-  u8 workingFlags = 0;
   CmTblInfo *aMap = 0;
   int nMap = 0;
   ProllyHash *aStack = 0;
@@ -320,39 +442,14 @@ static int buildDiffPairs(DiffTblCursor *pCur, sqlite3 *db,
 
   doltliteGetSessionHead(db, &headHash);
   if( prollyHashIsEmpty(&headHash) ) return SQLITE_OK;
+  rc = seedWorkingChildInfo(db, &headHash, zTableName, &aMap, &nMap);
+  if( rc!=SQLITE_OK ) goto walk_done;
 
-
-  memset(&workingCat, 0, sizeof(workingCat));
-  memset(&workingTblRoot, 0, sizeof(workingTblRoot));
-  rc = doltliteFlushCatalogToHash(db, &workingCat);
-  if( rc!=SQLITE_OK ) return rc;
-  {
-    ProllyHash workingSchemaHash;
-    rc = loadTblRootAtCommit(db, &workingCat, zTableName,
-                             &workingTblRoot, &workingFlags,
-                             &workingSchemaHash);
-    if( rc!=SQLITE_OK ) return rc;
-
-    {
-      char zWorking[PROLLY_HASH_SIZE*2+1];
-      memset(zWorking, 0, sizeof(zWorking));
-      memcpy(zWorking, "WORKING", 7);
-      rc = mapPut(&aMap, &nMap, &headHash, &workingTblRoot,
-                  &workingCat, &workingSchemaHash,
-                  workingFlags, zWorking, 0);
-      if( rc!=SQLITE_OK ) goto walk_done;
-    }
-  }
-
-
-  {
-    ProllyHash *aN = sqlite3_realloc(aAdded, (nAdded+1)*(int)sizeof(ProllyHash));
-    if( !aN ){ rc = SQLITE_NOMEM; goto walk_done; }
-    aAdded = aN;
-    aAdded[nAdded++] = headHash;
-  }
+  rc = stackPushUnique(&aAdded, &nAdded, &aStack, &nStack, &headHash);
+  if( rc!=SQLITE_OK ) goto walk_done;
   curr = headHash;
   currInited = 1;
+  nStack--;
 
   while( currInited ){
     DoltliteCommit commit;
@@ -360,7 +457,6 @@ static int buildDiffPairs(DiffTblCursor *pCur, sqlite3 *db,
     ProllyHash curSchemaHash;
     u8 curFlags = 0;
     char curHex[PROLLY_HASH_SIZE*2+1];
-    int idx;
 
     memset(&commit, 0, sizeof(commit));
     memset(&curTblRoot, 0, sizeof(curTblRoot));
@@ -377,72 +473,12 @@ static int buildDiffPairs(DiffTblCursor *pCur, sqlite3 *db,
     }
 
     doltliteHashToHex(&curr, curHex);
-
-
-    idx = mapFind(aMap, nMap, &curr);
-    if( idx>=0 ){
-      CmTblInfo *info = &aMap[idx];
-      int rootsDiffer = (prollyHashCompare(&info->tblRoot, &curTblRoot)!=0);
-      int schemasDiffer = (prollyHashCompare(&info->schemaHash, &curSchemaHash)!=0);
-      if( rootsDiffer || schemasDiffer ){
-        u8 fromFlags = curFlags;
-        if( fromFlags==0 ) fromFlags = info->flags;
-        rc = pairsAppend(pCur, &curr, &curTblRoot, &commit.catalogHash,
-                         &curSchemaHash, fromFlags, commit.timestamp,
-                         info->zHexName, &info->tblRoot, &info->catHash,
-                         &info->schemaHash, info->flags, info->date);
-        if( rc!=SQLITE_OK ){
-          doltliteCommitClear(&commit);
-          break;
-        }
-      }
-    }
-
-
-
-    {
-      int nParents = commit.nParents>0
-                       ? commit.nParents
-                       : (prollyHashIsEmpty(&commit.parentHash) ? 0 : 1);
-      for(i=0; i<nParents; i++){
-        const ProllyHash *pParent = commit.nParents>0
-                                       ? &commit.aParents[i]
-                                       : &commit.parentHash;
-        rc = mapPut(&aMap, &nMap, pParent, &curTblRoot, &commit.catalogHash,
-                    &curSchemaHash, curFlags, curHex, commit.timestamp);
-        if( rc!=SQLITE_OK ) break;
-      }
-      if( rc!=SQLITE_OK ){
-        doltliteCommitClear(&commit);
-        break;
-      }
-
-
-      for(i=0; i<nParents; i++){
-        const ProllyHash *pParent = commit.nParents>0
-                                       ? &commit.aParents[i]
-                                       : &commit.parentHash;
-        int already = 0;
-        int j;
-        for(j=0; j<nAdded; j++){
-          if( prollyHashCompare(&aAdded[j], pParent)==0 ){ already = 1; break; }
-        }
-        if( already ) continue;
-        {
-          ProllyHash *aN = sqlite3_realloc(aAdded,
-                              (nAdded+1)*(int)sizeof(ProllyHash));
-          if( !aN ){ rc = SQLITE_NOMEM; break; }
-          aAdded = aN;
-          aAdded[nAdded++] = *pParent;
-        }
-        {
-          ProllyHash *aN = sqlite3_realloc(aStack,
-                              (nStack+1)*(int)sizeof(ProllyHash));
-          if( !aN ){ rc = SQLITE_NOMEM; break; }
-          aStack = aN;
-          aStack[nStack++] = *pParent;
-        }
-      }
+    rc = appendCurrentDiffPair(pCur, &curr, &commit, &curTblRoot,
+                               &curSchemaHash, curFlags, aMap, nMap);
+    if( rc==SQLITE_OK ){
+      rc = registerCommitParents(&aMap, &nMap, &aStack, &nStack,
+                                 &aAdded, &nAdded, &commit, &curTblRoot,
+                                 &curSchemaHash, curFlags, curHex);
     }
     doltliteCommitClear(&commit);
     if( rc!=SQLITE_OK ) break;
@@ -840,8 +876,11 @@ static int openNextPairIter(DiffTblCursor *pCur, sqlite3 *db){
   }
 
   {
-    DiffPair *p = &pCur->aPairs[pCur->iPair++];
-    u8 flags = p->fromFlags ? p->fromFlags : p->toFlags;
+    DiffPair *p;
+    u8 flags;
+    int rc2;
+    p = &pCur->aPairs[pCur->iPair++];
+    flags = p->fromFlags ? p->fromFlags : p->toFlags;
     doltliteHashToHex(&p->fromHash, pCur->row.zFromCommit);
     pCur->row.fromDate = p->fromDate;
     memcpy(pCur->row.zToCommit, p->zToCommit, PROLLY_HASH_SIZE*2+1);
@@ -851,20 +890,19 @@ static int openNextPairIter(DiffTblCursor *pCur, sqlite3 *db){
     if( rc!=SQLITE_OK ) return rc;
     pCur->diffIterOpen = 1;
 
-
-    if( prollyHashCompare(&p->fromSchemaHash, &p->toSchemaHash)!=0 ){
-      int rc2;
-      rc2 = loadColNamesAtCatalog(db, &p->fromCatHash, pVtab->zTableName,
-                                  &pCur->azFromCols, &pCur->nFromCols);
-      if( rc2==SQLITE_OK ){
-        rc2 = loadColNamesAtCatalog(db, &p->toCatHash, pVtab->zTableName,
-                                    &pCur->azToCols, &pCur->nToCols);
-      }
-      if( rc2==SQLITE_OK ){
-        pCur->needFilter = 1;
-      }else{
-        freePairCols(pCur);
-      }
+    if( prollyHashCompare(&p->fromSchemaHash, &p->toSchemaHash)==0 ){
+      return SQLITE_OK;
+    }
+    rc2 = loadColNamesAtCatalog(db, &p->fromCatHash, pVtab->zTableName,
+                                &pCur->azFromCols, &pCur->nFromCols);
+    if( rc2==SQLITE_OK ){
+      rc2 = loadColNamesAtCatalog(db, &p->toCatHash, pVtab->zTableName,
+                                  &pCur->azToCols, &pCur->nToCols);
+    }
+    if( rc2==SQLITE_OK ){
+      pCur->needFilter = 1;
+    }else{
+      freePairCols(pCur);
     }
     return SQLITE_OK;
   }

--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -1317,6 +1317,66 @@ static int mergeCatalogPass2(
   return SQLITE_OK;
 }
 
+static void freeConflictTables(
+  MergeConflictTable *aConflictTables,
+  int nConflictTables
+){
+  int ci;
+  for(ci=0; ci<nConflictTables; ci++){
+    freeConflictRows(aConflictTables[ci].aRows, aConflictTables[ci].nConflicts);
+    sqlite3_free(aConflictTables[ci].zName);
+  }
+  sqlite3_free(aConflictTables);
+}
+
+static int loadMergeCatalogs(
+  sqlite3 *db,
+  const ProllyHash *ancestor,
+  const ProllyHash *ours,
+  const ProllyHash *theirs,
+  struct TableEntry **paAnc, int *pnAnc, Pgno *piNextAnc,
+  struct TableEntry **paOurs, int *pnOurs, Pgno *piNextOurs,
+  struct TableEntry **paTheirs, int *pnTheirs, Pgno *piNextTheirs
+){
+  int rc;
+  rc = doltliteLoadCatalog(db, ancestor, paAnc, pnAnc, piNextAnc);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = doltliteLoadCatalog(db, ours, paOurs, pnOurs, piNextOurs);
+  if( rc!=SQLITE_OK ) return rc;
+  return doltliteLoadCatalog(db, theirs, paTheirs, pnTheirs, piNextTheirs);
+}
+
+static int allocMergedCatalogEntries(
+  int nOurs,
+  int nTheirs,
+  struct TableEntry **paMerged
+){
+  int nMergedAlloc = nOurs + nTheirs;
+  if( nMergedAlloc==0 ) nMergedAlloc = 1;
+  *paMerged = sqlite3_malloc(nMergedAlloc * (int)sizeof(struct TableEntry));
+  return *paMerged ? SQLITE_OK : SQLITE_NOMEM;
+}
+
+static void recordMergeConflicts(
+  sqlite3 *db,
+  MergeConflictTable *aConflictTables,
+  int nConflictTables
+){
+  ProllyHash conflictsHash;
+  int rc2;
+
+  rc2 = doltliteSerializeConflicts(
+      doltliteGetChunkStore(db),
+      (ConflictTableInfo*)aConflictTables, nConflictTables,
+      &conflictsHash);
+  if( rc2==SQLITE_OK ){
+    extern void doltliteSetSessionConflictsCatalog(sqlite3*, const ProllyHash*);
+    extern void doltliteSetSessionMergeState(sqlite3*, u8, const ProllyHash*, const ProllyHash*);
+    doltliteSetSessionConflictsCatalog(db, &conflictsHash);
+    doltliteSetSessionMergeState(db, 1, 0, &conflictsHash);
+  }
+}
+
 int doltliteMergeCatalogs(
   sqlite3 *db,
   const ProllyHash *ancestor,
@@ -1340,25 +1400,16 @@ int doltliteMergeCatalogs(
 
   MergeConflictTable *aConflictTables = 0;
   int nConflictTables = 0;
+  (void)nMergedAlloc;
 
-
-  rc = doltliteLoadCatalog(db, ancestor, &aAnc, &nAnc, &iNextAnc);
+  rc = loadMergeCatalogs(db, ancestor, ours, theirs,
+                         &aAnc, &nAnc, &iNextAnc,
+                         &aOurs, &nOurs, &iNextOurs,
+                         &aTheirs, &nTheirs, &iNextTheirs);
   if( rc!=SQLITE_OK ) goto merge_cleanup;
 
-  rc = doltliteLoadCatalog(db, ours, &aOurs, &nOurs, &iNextOurs);
+  rc = allocMergedCatalogEntries(nOurs, nTheirs, &aMerged);
   if( rc!=SQLITE_OK ) goto merge_cleanup;
-
-  rc = doltliteLoadCatalog(db, theirs, &aTheirs, &nTheirs, &iNextTheirs);
-  if( rc!=SQLITE_OK ) goto merge_cleanup;
-
-
-  nMergedAlloc = nOurs + nTheirs;
-  if( nMergedAlloc==0 ) nMergedAlloc = 1;
-  aMerged = sqlite3_malloc(nMergedAlloc * (int)sizeof(struct TableEntry));
-  if( !aMerged ){
-    rc = SQLITE_NOMEM;
-    goto merge_cleanup;
-  }
 
 
   iNextMerged = iNextOurs > iNextTheirs ? iNextOurs : iNextTheirs;
@@ -1384,38 +1435,11 @@ int doltliteMergeCatalogs(
 
 
   if( totalConflicts>0 && nConflictTables>0 && rc==SQLITE_OK ){
-    ProllyHash conflictsHash;
-
-    int rc2 = doltliteSerializeConflicts(
-        doltliteGetChunkStore(db),
-        (ConflictTableInfo*)aConflictTables, nConflictTables,
-        &conflictsHash);
-    if( rc2==SQLITE_OK ){
-      extern void doltliteSetSessionConflictsCatalog(sqlite3*, const ProllyHash*);
-      extern void doltliteSetSessionMergeState(sqlite3*, u8, const ProllyHash*, const ProllyHash*);
-      doltliteSetSessionConflictsCatalog(db, &conflictsHash);
-      doltliteSetSessionMergeState(db, 1, 0, &conflictsHash);
-    }
-  }
-
-
-  {
-    int ci;
-    for(ci=0; ci<nConflictTables; ci++){
-      int cj;
-      for(cj=0; cj<aConflictTables[ci].nConflicts; cj++){
-        sqlite3_free(aConflictTables[ci].aRows[cj].pKey);
-        sqlite3_free(aConflictTables[ci].aRows[cj].pBaseVal);
-        sqlite3_free(aConflictTables[ci].aRows[cj].pOurVal);
-        sqlite3_free(aConflictTables[ci].aRows[cj].pTheirVal);
-      }
-      sqlite3_free(aConflictTables[ci].aRows);
-      sqlite3_free(aConflictTables[ci].zName);
-    }
-    sqlite3_free(aConflictTables);
+    recordMergeConflicts(db, aConflictTables, nConflictTables);
   }
 
 merge_cleanup:
+  freeConflictTables(aConflictTables, nConflictTables);
   sqlite3_free(aAnc);
   sqlite3_free(aOurs);
   sqlite3_free(aTheirs);

--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -912,6 +912,156 @@ struct MergeConflictTable {
   struct ConflictRow *aRows;
 };
 
+static void freeConflictRows(struct ConflictRow *aRows, int nRows){
+  int i;
+  for(i=0; i<nRows; i++){
+    sqlite3_free(aRows[i].pKey);
+    sqlite3_free(aRows[i].pBaseVal);
+    sqlite3_free(aRows[i].pTheirVal);
+  }
+  sqlite3_free(aRows);
+}
+
+static void freeAddedColumns(char **azCols, int nCols){
+  int i;
+  for(i=0; i<nCols; i++) sqlite3_free(azCols[i]);
+  sqlite3_free(azCols);
+}
+
+static int appendConflictTable(
+  MergeConflictTable **ppConflictTables,
+  int *pnConflictTables,
+  const char *zName,
+  int nConflicts,
+  struct ConflictRow *aConflictRows
+){
+  MergeConflictTable *aNew;
+  aNew = sqlite3_realloc(*ppConflictTables,
+    (*pnConflictTables+1)*(int)sizeof(MergeConflictTable));
+  if( !aNew ){
+    freeConflictRows(aConflictRows, nConflicts);
+    return SQLITE_NOMEM;
+  }
+  *ppConflictTables = aNew;
+  aNew[*pnConflictTables].zName = sqlite3_mprintf("%s", zName);
+  aNew[*pnConflictTables].nConflicts = nConflicts;
+  aNew[*pnConflictTables].aRows = aConflictRows;
+  (*pnConflictTables)++;
+  return SQLITE_OK;
+}
+
+static int recordSchemaAddColumns(
+  SchemaMergeAction **ppSchemaActions,
+  int *pnSchemaActions,
+  const char *zName,
+  char **azAddCols,
+  int nAddCols
+){
+  SchemaMergeAction *aNew;
+  aNew = sqlite3_realloc(*ppSchemaActions,
+    (*pnSchemaActions+1)*(int)sizeof(SchemaMergeAction));
+  if( !aNew ) return SQLITE_NOMEM;
+  *ppSchemaActions = aNew;
+  aNew[*pnSchemaActions].zTableName = sqlite3_mprintf("%s", zName);
+  if( !aNew[*pnSchemaActions].zTableName ) return SQLITE_NOMEM;
+  aNew[*pnSchemaActions].azAddColumns = azAddCols;
+  aNew[*pnSchemaActions].nAddColumns = nAddCols;
+  (*pnSchemaActions)++;
+  return SQLITE_OK;
+}
+
+static int tryResolveSchemaDivergence(
+  sqlite3 *db,
+  const char *zName,
+  const ProllyHash *pCatAnc,
+  const ProllyHash *pCatOurs,
+  const ProllyHash *pCatTheirs,
+  SchemaMergeAction **ppSchemaActions,
+  int *pnSchemaActions,
+  int *pSkipRowMerge,
+  char **pzErrMsg
+){
+  ChunkStore *csLocal;
+  ProllyCache *cacheLocal;
+  SchemaEntry *aAncSchema = 0;
+  SchemaEntry *aOursSchema = 0;
+  SchemaEntry *aTheirsSchema = 0;
+  int nAncSchema = 0;
+  int nOursSchema = 0;
+  int nTheirsSchema = 0;
+  SchemaEntry *ancSchEntry;
+  SchemaEntry *ourSchEntry;
+  SchemaEntry *theirSchEntry;
+  char **azAddCols = 0;
+  int nAddCols = 0;
+  int useTheirSchema = 0;
+  char *zSchemaErr = 0;
+  int rc;
+
+  *pSkipRowMerge = 0;
+  csLocal = doltliteGetChunkStore(db);
+  cacheLocal = doltliteGetCache(db);
+  loadSchemaFromCatalog(db, csLocal, cacheLocal, pCatAnc, &aAncSchema, &nAncSchema);
+  loadSchemaFromCatalog(db, csLocal, cacheLocal, pCatOurs, &aOursSchema, &nOursSchema);
+  loadSchemaFromCatalog(db, csLocal, cacheLocal, pCatTheirs, &aTheirsSchema, &nTheirsSchema);
+
+  ancSchEntry = findSchemaEntry(aAncSchema, nAncSchema, zName);
+  ourSchEntry = findSchemaEntry(aOursSchema, nOursSchema, zName);
+  theirSchEntry = findSchemaEntry(aTheirsSchema, nTheirsSchema, zName);
+
+  if( ancSchEntry && ancSchEntry->zSql
+   && ourSchEntry && ourSchEntry->zSql
+   && theirSchEntry && theirSchEntry->zSql ){
+    rc = trySchemaColumnMerge(
+      ancSchEntry->zSql, ourSchEntry->zSql, theirSchEntry->zSql,
+      &azAddCols, &nAddCols, &useTheirSchema, &zSchemaErr);
+  }else{
+    rc = SQLITE_ERROR;
+    zSchemaErr = sqlite3_mprintf("cannot load schemas for merge");
+  }
+
+  freeSchemaEntries(aAncSchema, nAncSchema);
+  freeSchemaEntries(aOursSchema, nOursSchema);
+  freeSchemaEntries(aTheirsSchema, nTheirsSchema);
+
+  if( rc!=SQLITE_OK ){
+    if( pzErrMsg ){
+      if( zSchemaErr ){
+        *pzErrMsg = sqlite3_mprintf(
+          "schema conflict on table '%s' \xe2\x80\x94 %s",
+          zName ? zName : "(unknown)", zSchemaErr);
+      }else{
+        *pzErrMsg = sqlite3_mprintf(
+          "schema conflict on table '%s'",
+          zName ? zName : "(unknown)");
+      }
+    }
+    sqlite3_free(zSchemaErr);
+    freeAddedColumns(azAddCols, nAddCols);
+    return SQLITE_ERROR;
+  }
+  sqlite3_free(zSchemaErr);
+
+  if( nAddCols>0 ){
+    if( ppSchemaActions && pnSchemaActions ){
+      rc = recordSchemaAddColumns(ppSchemaActions, pnSchemaActions, zName,
+                                  azAddCols, nAddCols);
+      if( rc!=SQLITE_OK ){
+        freeAddedColumns(azAddCols, nAddCols);
+        return rc;
+      }
+      azAddCols = 0;
+      nAddCols = 0;
+    }
+    freeAddedColumns(azAddCols, nAddCols);
+    *pSkipRowMerge = 1;
+    return SQLITE_OK;
+  }
+
+  freeAddedColumns(azAddCols, nAddCols);
+  return SQLITE_OK;
+}
+
 /* Pass 1: walk OUR side, resolving each table against anc/theirs.
 ** For every "ours" table, determine whether row-merge is needed and
 ** invoke mergeTableRows; any rows that can't auto-merge become
@@ -992,85 +1142,12 @@ do_merge_entry:
         if( ourSchemaChanged && theirSchemaChanged
          && prollyHashCompare(&aOurs[i].schemaHash,
                               &theirsEntry->schemaHash)!=0 ){
-
-          ChunkStore *csLocal = doltliteGetChunkStore(db);
-          ProllyCache *cacheLocal = doltliteGetCache(db);
-          SchemaEntry *aAncSchema=0, *aOursSchema=0, *aTheirsSchema=0;
-          int nAncSchema=0, nOursSchema=0, nTheirsSchema=0;
-          SchemaEntry *ancSchEntry=0, *ourSchEntry=0, *theirSchEntry=0;
-          char **azAddCols = 0;
-          int nAddCols = 0;
-          int useTheirSchema = 0;
-          char *zSchemaErr = 0;
-
-          loadSchemaFromCatalog(db, csLocal, cacheLocal, pCatAnc, &aAncSchema, &nAncSchema);
-          loadSchemaFromCatalog(db, csLocal, cacheLocal, pCatOurs, &aOursSchema, &nOursSchema);
-          loadSchemaFromCatalog(db, csLocal, cacheLocal, pCatTheirs, &aTheirsSchema, &nTheirsSchema);
-
-          ancSchEntry = findSchemaEntry(aAncSchema, nAncSchema, zName);
-          ourSchEntry = findSchemaEntry(aOursSchema, nOursSchema, zName);
-          theirSchEntry = findSchemaEntry(aTheirsSchema, nTheirsSchema, zName);
-
-          if( ancSchEntry && ancSchEntry->zSql
-           && ourSchEntry && ourSchEntry->zSql
-           && theirSchEntry && theirSchEntry->zSql ){
-            rc = trySchemaColumnMerge(
-              ancSchEntry->zSql, ourSchEntry->zSql, theirSchEntry->zSql,
-              &azAddCols, &nAddCols, &useTheirSchema, &zSchemaErr);
-          }else{
-            rc = SQLITE_ERROR;
-            zSchemaErr = sqlite3_mprintf(
-              "cannot load schemas for merge");
-          }
-
-          freeSchemaEntries(aAncSchema, nAncSchema);
-          freeSchemaEntries(aOursSchema, nOursSchema);
-          freeSchemaEntries(aTheirsSchema, nTheirsSchema);
-
-          if( rc!=SQLITE_OK ){
-            if( pzErrMsg ){
-              if( zSchemaErr ){
-                *pzErrMsg = sqlite3_mprintf(
-                  "schema conflict on table '%s' \xe2\x80\x94 %s",
-                  zName ? zName : "(unknown)", zSchemaErr);
-              }else{
-                *pzErrMsg = sqlite3_mprintf(
-                  "schema conflict on table '%s'",
-                  zName ? zName : "(unknown)");
-              }
-            }
-            sqlite3_free(zSchemaErr);
-            { int j; for(j=0;j<nAddCols;j++) sqlite3_free(azAddCols[j]); }
-            sqlite3_free(azAddCols);
-            return SQLITE_ERROR;
-          }
-          sqlite3_free(zSchemaErr);
-
-
-          if( nAddCols > 0 ){
-
-            if( ppSchemaActions && pnSchemaActions ){
-              SchemaMergeAction *aNew = sqlite3_realloc(*ppSchemaActions,
-                (*pnSchemaActions+1)*(int)sizeof(SchemaMergeAction));
-              if( aNew ){
-                *ppSchemaActions = aNew;
-                aNew[*pnSchemaActions].zTableName = sqlite3_mprintf("%s", zName);
-                aNew[*pnSchemaActions].azAddColumns = azAddCols;
-                aNew[*pnSchemaActions].nAddColumns = nAddCols;
-                (*pnSchemaActions)++;
-                azAddCols = 0; nAddCols = 0;
-              }
-            }
-            { int j; for(j=0;j<nAddCols;j++) sqlite3_free(azAddCols[j]); }
-            sqlite3_free(azAddCols);
-
-
+          rc = tryResolveSchemaDivergence(
+            db, zName, pCatAnc, pCatOurs, pCatTheirs,
+            ppSchemaActions, pnSchemaActions, &skipRowMerge, pzErrMsg);
+          if( rc!=SQLITE_OK ) return rc;
+          if( skipRowMerge ){
             aMerged[(*pnMerged)++] = aOurs[i];
-            skipRowMerge = 1;
-          }else{
-
-            { int j; for(j=0;j<nAddCols;j++) sqlite3_free(azAddCols[j]); }
-            sqlite3_free(azAddCols);
           }
         }
 
@@ -1101,25 +1178,9 @@ do_merge_entry:
 
             if( nConflicts>0 ){
               *pTotalConflicts += nConflicts;
-              {
-                MergeConflictTable *aNew = sqlite3_realloc(*ppConflictTables,
-                  (*pnConflictTables+1)*(int)sizeof(MergeConflictTable));
-                if( aNew ){
-                  *ppConflictTables = aNew;
-                  aNew[*pnConflictTables].zName = sqlite3_mprintf("%s", zName);
-                  aNew[*pnConflictTables].nConflicts = nConflicts;
-                  aNew[*pnConflictTables].aRows = aConflictRows;
-                  (*pnConflictTables)++;
-                  aConflictRows = 0;
-                }else{
-                  { int j; for(j=0;j<nConflicts;j++){
-                    sqlite3_free(aConflictRows[j].pKey);
-                    sqlite3_free(aConflictRows[j].pBaseVal);
-                    sqlite3_free(aConflictRows[j].pTheirVal);
-                  }}
-                  sqlite3_free(aConflictRows);
-                }
-              }
+              rc = appendConflictTable(ppConflictTables, pnConflictTables,
+                                       zName, nConflicts, aConflictRows);
+              if( rc!=SQLITE_OK ) return rc;
             }
           }else if( theirsChanged ){
             struct TableEntry merged = aOurs[i];
@@ -1189,25 +1250,10 @@ do_merge_entry:
 
         if( nConflicts>0 ){
           *pTotalConflicts += nConflicts;
-          {
-            MergeConflictTable *aNew = sqlite3_realloc(*ppConflictTables,
-              (*pnConflictTables+1)*(int)sizeof(MergeConflictTable));
-            if( aNew ){
-              *ppConflictTables = aNew;
-              aNew[*pnConflictTables].zName = sqlite3_mprintf("%s", "(sqlite_master)");
-              aNew[*pnConflictTables].nConflicts = nConflicts;
-              aNew[*pnConflictTables].aRows = aConflictRows;
-              (*pnConflictTables)++;
-              aConflictRows = 0;
-            }else{
-              { int j; for(j=0;j<nConflicts;j++){
-                sqlite3_free(aConflictRows[j].pKey);
-                sqlite3_free(aConflictRows[j].pBaseVal);
-                sqlite3_free(aConflictRows[j].pTheirVal);
-              }}
-              sqlite3_free(aConflictRows);
-            }
-          }
+          rc = appendConflictTable(ppConflictTables, pnConflictTables,
+                                   "(sqlite_master)", nConflicts,
+                                   aConflictRows);
+          if( rc!=SQLITE_OK ) return rc;
         }
       }else if( theirsChanged ){
         struct TableEntry merged = aOurs[iTable1Idx];

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -142,6 +142,46 @@ static void remoteSqlRestoreAndReport(
   remoteSqlResultError(ctx, opRc, zMsg);
 }
 
+static int remoteSqlLoadCommit(
+  ChunkStore *cs,
+  const ProllyHash *pCommitHash,
+  DoltliteCommit *pCommit
+){
+  u8 *data = 0;
+  int nData = 0;
+  int rc = chunkStoreGet(cs, pCommitHash, &data, &nData);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = doltliteCommitDeserialize(data, nData, pCommit);
+  sqlite3_free(data);
+  return rc;
+}
+
+static int remoteSqlResetSessionToCommit(
+  sqlite3 *db,
+  const char *zBranch,
+  const ProllyHash *pCommitHash
+){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  DoltliteCommit commit;
+  int rc;
+
+  if( !cs ) return SQLITE_ERROR;
+  memset(&commit, 0, sizeof(commit));
+  rc = remoteSqlLoadCommit(cs, pCommitHash, &commit);
+  if( rc!=SQLITE_OK ) return rc;
+
+  rc = doltliteHardReset(db, &commit.catalogHash);
+  if( rc==SQLITE_OK && zBranch ){
+    doltliteSetSessionBranch(db, zBranch);
+  }
+  if( rc==SQLITE_OK ){
+    doltliteSetSessionHead(db, pCommitHash);
+    doltliteSetSessionStaged(db, &commit.catalogHash);
+  }
+  doltliteCommitClear(&commit);
+  return rc;
+}
+
 static void freeNameList(char **azNames, int nNames);
 
 static void doltRemoteFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
@@ -541,34 +581,12 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
 
 
   if( strcmp(zBranch, doltliteGetSessionBranch(db))==0 ){
-    DoltliteCommit commit;
-    u8 *data = 0; int nData = 0;
-
-    rc = chunkStoreGet(cs, &trackingCommit, &data, &nData);
+    rc = remoteSqlResetSessionToCommit(db, 0, &trackingCommit);
     if( rc!=SQLITE_OK ){
       remoteSqlRestoreAndReport(ctx, db, cs, &savedState, SQLITE_ERROR,
-                                "failed to load commit");
+                                "failed to update working tree from branch");
       return;
     }
-    rc = doltliteCommitDeserialize(data, nData, &commit);
-    sqlite3_free(data);
-    if( rc!=SQLITE_OK ){
-      remoteSqlRestoreAndReport(ctx, db, cs, &savedState, SQLITE_ERROR,
-                                "failed to deserialize commit");
-      return;
-    }
-
-    rc = doltliteHardReset(db, &commit.catalogHash);
-    if( rc!=SQLITE_OK ){
-      doltliteCommitClear(&commit);
-      remoteSqlRestoreAndReport(ctx, db, cs, &savedState, SQLITE_ERROR,
-                                "hard reset failed");
-      return;
-    }
-
-    doltliteSetSessionHead(db, &trackingCommit);
-    doltliteSetSessionStaged(db, &commit.catalogHash);
-    doltliteCommitClear(&commit);
   }
 
 
@@ -684,43 +702,18 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
                                   "default branch missing from cloned refs");
         return;
       }
-      {
-
-        u8 *data = 0; int nData = 0;
-        DoltliteCommit commit;
-
-        rc = chunkStoreGet(cs, &branchCommit, &data, &nData);
-        if( rc!=SQLITE_OK || !data ){
-          if( data ) sqlite3_free(data);
-          remoteSqlRestoreAndReport(ctx, db, cs, &savedState, SQLITE_ERROR,
-                                    "failed to load default branch commit");
-          return;
-        }
-        rc = doltliteCommitDeserialize(data, nData, &commit);
-        sqlite3_free(data);
-        if( rc!=SQLITE_OK ){
-          remoteSqlRestoreAndReport(ctx, db, cs, &savedState, SQLITE_ERROR,
-                                    "failed to deserialize default branch commit");
-          return;
-        }
-        rc = doltliteHardReset(db, &commit.catalogHash);
-        if( rc!=SQLITE_OK ){
-          doltliteCommitClear(&commit);
-          remoteSqlRestoreAndReport(
-              ctx, db, cs, &savedState, SQLITE_ERROR,
-              "failed to initialize working tree from default branch");
-          return;
-        }
-        doltliteSetSessionBranch(db, zDefault);
-        doltliteSetSessionHead(db, &branchCommit);
-        doltliteSetSessionStaged(db, &commit.catalogHash);
-        rc = chunkStoreSetDefaultBranch(cs, zDefault);
-        doltliteCommitClear(&commit);
-        if( rc!=SQLITE_OK ){
-          remoteSqlRestoreAndReport(ctx, db, cs, &savedState, SQLITE_ERROR,
-                                    "failed to record default branch");
-          return;
-        }
+      rc = remoteSqlResetSessionToCommit(db, zDefault, &branchCommit);
+      if( rc!=SQLITE_OK ){
+        remoteSqlRestoreAndReport(
+            ctx, db, cs, &savedState, SQLITE_ERROR,
+            "failed to initialize working tree from default branch");
+        return;
+      }
+      rc = chunkStoreSetDefaultBranch(cs, zDefault);
+      if( rc!=SQLITE_OK ){
+        remoteSqlRestoreAndReport(ctx, db, cs, &savedState, SQLITE_ERROR,
+                                  "failed to record default branch");
+        return;
       }
     }
   }

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -125,6 +125,23 @@ static void remoteSqlResultError(
   }
 }
 
+static void remoteSqlRestoreAndReport(
+  sqlite3_context *ctx,
+  sqlite3 *db,
+  ChunkStore *cs,
+  RemoteSqlState *pSavedState,
+  int opRc,
+  const char *zMsg
+){
+  int restoreRc = remoteSqlStateRestore(db, cs, pSavedState);
+  remoteSqlStateClear(pSavedState);
+  if( restoreRc!=SQLITE_OK ){
+    sqlite3_result_error_code(ctx, restoreRc);
+    return;
+  }
+  remoteSqlResultError(ctx, opRc, zMsg);
+}
+
 static void freeNameList(char **azNames, int nNames);
 
 static void doltRemoteFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
@@ -433,28 +450,16 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   rc = doltliteFetch(cs, pRemote, zRemoteName, zBranch);
   pRemote->xClose(pRemote);
   if( rc!=SQLITE_OK ){
-    int restoreRc = remoteSqlStateRestore(db, cs, &savedState);
-    int opRc = rc;
-    remoteSqlStateClear(&savedState);
-    if( restoreRc!=SQLITE_OK ){
-      sqlite3_result_error_code(ctx, restoreRc);
-      return;
-    }
-    remoteSqlResultError(ctx, opRc,
-      opRc==SQLITE_NOTFOUND ? "fetch failed: branch not found on remote" : 0);
+    remoteSqlRestoreAndReport(ctx, db, cs, &savedState, rc,
+      rc==SQLITE_NOTFOUND ? "fetch failed: branch not found on remote" : 0);
     return;
   }
 
 
   rc = chunkStoreFindTracking(cs, zRemoteName, zBranch, &trackingCommit);
   if( rc!=SQLITE_OK || prollyHashIsEmpty(&trackingCommit) ){
-    int restoreRc = remoteSqlStateRestore(db, cs, &savedState);
-    remoteSqlStateClear(&savedState);
-    if( restoreRc!=SQLITE_OK ){
-      sqlite3_result_error_code(ctx, restoreRc);
-      return;
-    }
-    sqlite3_result_error(ctx, "tracking branch not found after fetch", -1);
+    remoteSqlRestoreAndReport(ctx, db, cs, &savedState, SQLITE_ERROR,
+                              "tracking branch not found after fetch");
     return;
   }
 
@@ -464,13 +469,8 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
 
     rc = chunkStoreAddBranch(cs, zBranch, &trackingCommit);
     if( rc!=SQLITE_OK ){
-      int restoreRc = remoteSqlStateRestore(db, cs, &savedState);
-      remoteSqlStateClear(&savedState);
-      if( restoreRc!=SQLITE_OK ){
-        sqlite3_result_error_code(ctx, restoreRc);
-        return;
-      }
-      sqlite3_result_error(ctx, "failed to create local branch", -1);
+      remoteSqlRestoreAndReport(ctx, db, cs, &savedState, SQLITE_ERROR,
+                                "failed to create local branch");
       return;
     }
     localCommit = trackingCommit;
@@ -519,25 +519,14 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     }
 
     if( walkRc!=SQLITE_OK ){
-      int restoreRc = remoteSqlStateRestore(db, cs, &savedState);
-      remoteSqlStateClear(&savedState);
-      if( restoreRc!=SQLITE_OK ){
-        sqlite3_result_error_code(ctx, restoreRc);
-        return;
-      }
-      sqlite3_result_error_code(ctx, walkRc);
+      remoteSqlRestoreAndReport(ctx, db, cs, &savedState, walkRc, 0);
       return;
     }
 
     if( !canFF ){
-      int restoreRc = remoteSqlStateRestore(db, cs, &savedState);
-      remoteSqlStateClear(&savedState);
-      if( restoreRc!=SQLITE_OK ){
-        sqlite3_result_error_code(ctx, restoreRc);
-        return;
-      }
-      sqlite3_result_error(ctx,
-        "cannot fast-forward — use dolt_merge with the tracking branch instead", -1);
+      remoteSqlRestoreAndReport(
+        ctx, db, cs, &savedState, SQLITE_ERROR,
+        "cannot fast-forward — use dolt_merge with the tracking branch instead");
       return;
     }
   }
@@ -545,13 +534,8 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
 
   rc = chunkStoreUpdateBranch(cs, zBranch, &trackingCommit);
   if( rc!=SQLITE_OK ){
-    int restoreRc = remoteSqlStateRestore(db, cs, &savedState);
-    remoteSqlStateClear(&savedState);
-    if( restoreRc!=SQLITE_OK ){
-      sqlite3_result_error_code(ctx, restoreRc);
-      return;
-    }
-    sqlite3_result_error(ctx, "failed to update branch", -1);
+    remoteSqlRestoreAndReport(ctx, db, cs, &savedState, SQLITE_ERROR,
+                              "failed to update branch");
     return;
   }
 
@@ -562,40 +546,23 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
 
     rc = chunkStoreGet(cs, &trackingCommit, &data, &nData);
     if( rc!=SQLITE_OK ){
-      int restoreRc = remoteSqlStateRestore(db, cs, &savedState);
-      remoteSqlStateClear(&savedState);
-      if( restoreRc!=SQLITE_OK ){
-        sqlite3_result_error_code(ctx, restoreRc);
-        return;
-      }
-      sqlite3_result_error(ctx, "failed to load commit", -1);
+      remoteSqlRestoreAndReport(ctx, db, cs, &savedState, SQLITE_ERROR,
+                                "failed to load commit");
       return;
     }
     rc = doltliteCommitDeserialize(data, nData, &commit);
     sqlite3_free(data);
     if( rc!=SQLITE_OK ){
-      int restoreRc = remoteSqlStateRestore(db, cs, &savedState);
-      remoteSqlStateClear(&savedState);
-      if( restoreRc!=SQLITE_OK ){
-        sqlite3_result_error_code(ctx, restoreRc);
-        return;
-      }
-      sqlite3_result_error(ctx, "failed to deserialize commit", -1);
+      remoteSqlRestoreAndReport(ctx, db, cs, &savedState, SQLITE_ERROR,
+                                "failed to deserialize commit");
       return;
     }
 
     rc = doltliteHardReset(db, &commit.catalogHash);
     if( rc!=SQLITE_OK ){
       doltliteCommitClear(&commit);
-      {
-        int restoreRc = remoteSqlStateRestore(db, cs, &savedState);
-        remoteSqlStateClear(&savedState);
-        if( restoreRc!=SQLITE_OK ){
-          sqlite3_result_error_code(ctx, restoreRc);
-          return;
-        }
-      }
-      sqlite3_result_error(ctx, "hard reset failed", -1);
+      remoteSqlRestoreAndReport(ctx, db, cs, &savedState, SQLITE_ERROR,
+                                "hard reset failed");
       return;
     }
 
@@ -608,14 +575,7 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   rc = chunkStoreSerializeRefs(cs);
   if( rc==SQLITE_OK ) rc = chunkStoreCommit(cs);
   if( rc!=SQLITE_OK ){
-    int restoreRc = remoteSqlStateRestore(db, cs, &savedState);
-    int opRc = rc;
-    remoteSqlStateClear(&savedState);
-    if( restoreRc!=SQLITE_OK ){
-      sqlite3_result_error_code(ctx, restoreRc);
-      return;
-    }
-    sqlite3_result_error_code(ctx, opRc);
+    remoteSqlRestoreAndReport(ctx, db, cs, &savedState, rc, 0);
     return;
   }
   remoteSqlStateClear(&savedState);
@@ -674,39 +634,24 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
 
   pRemote = openRemoteByUrl(cs->pVfs, zUrl);
   if( !pRemote ){
-    int restoreRc = remoteSqlStateRestore(db, cs, &savedState);
-    remoteSqlStateClear(&savedState);
-    if( restoreRc!=SQLITE_OK ){
-      sqlite3_result_error_code(ctx, restoreRc);
-      return;
-    }
-    sqlite3_result_error(ctx, "failed to open remote (URL must start with file://)", -1);
+    remoteSqlRestoreAndReport(ctx, db, cs, &savedState, SQLITE_ERROR,
+                              "failed to open remote (URL must start with file://)");
     return;
   }
 
   rc = doltliteClone(cs, pRemote);
   pRemote->xClose(pRemote);
   if( rc!=SQLITE_OK ){
-    int restoreRc = remoteSqlStateRestore(db, cs, &savedState);
-    remoteSqlStateClear(&savedState);
-    if( restoreRc!=SQLITE_OK ){
-      sqlite3_result_error_code(ctx, restoreRc);
-      return;
-    }
-    sqlite3_result_error(ctx, "clone failed", -1);
+    remoteSqlRestoreAndReport(ctx, db, cs, &savedState, SQLITE_ERROR,
+                              "clone failed");
     return;
   }
 
 
   rc = chunkStoreAddRemote(cs, "origin", zUrl);
   if( rc!=SQLITE_OK ){
-    int restoreRc = remoteSqlStateRestore(db, cs, &savedState);
-    remoteSqlStateClear(&savedState);
-    if( restoreRc!=SQLITE_OK ){
-      sqlite3_result_error_code(ctx, restoreRc);
-      return;
-    }
-    sqlite3_result_error(ctx, "failed to add origin remote", -1);
+    remoteSqlRestoreAndReport(ctx, db, cs, &savedState, SQLITE_ERROR,
+                              "failed to add origin remote");
     return;
   }
 
@@ -735,13 +680,8 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     if( zDefault ){
       rc = chunkStoreFindBranch(cs, zDefault, &branchCommit);
       if( rc!=SQLITE_OK || prollyHashIsEmpty(&branchCommit) ){
-        int restoreRc = remoteSqlStateRestore(db, cs, &savedState);
-        remoteSqlStateClear(&savedState);
-        if( restoreRc!=SQLITE_OK ){
-          sqlite3_result_error_code(ctx, restoreRc);
-          return;
-        }
-        sqlite3_result_error(ctx, "default branch missing from cloned refs", -1);
+        remoteSqlRestoreAndReport(ctx, db, cs, &savedState, SQLITE_ERROR,
+                                  "default branch missing from cloned refs");
         return;
       }
       {
@@ -752,41 +692,23 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
         rc = chunkStoreGet(cs, &branchCommit, &data, &nData);
         if( rc!=SQLITE_OK || !data ){
           if( data ) sqlite3_free(data);
-          {
-            int restoreRc = remoteSqlStateRestore(db, cs, &savedState);
-            remoteSqlStateClear(&savedState);
-            if( restoreRc!=SQLITE_OK ){
-              sqlite3_result_error_code(ctx, restoreRc);
-              return;
-            }
-          }
-          sqlite3_result_error(ctx, "failed to load default branch commit", -1);
+          remoteSqlRestoreAndReport(ctx, db, cs, &savedState, SQLITE_ERROR,
+                                    "failed to load default branch commit");
           return;
         }
         rc = doltliteCommitDeserialize(data, nData, &commit);
         sqlite3_free(data);
         if( rc!=SQLITE_OK ){
-          int restoreRc = remoteSqlStateRestore(db, cs, &savedState);
-          remoteSqlStateClear(&savedState);
-          if( restoreRc!=SQLITE_OK ){
-            sqlite3_result_error_code(ctx, restoreRc);
-            return;
-          }
-          sqlite3_result_error(ctx, "failed to deserialize default branch commit", -1);
+          remoteSqlRestoreAndReport(ctx, db, cs, &savedState, SQLITE_ERROR,
+                                    "failed to deserialize default branch commit");
           return;
         }
         rc = doltliteHardReset(db, &commit.catalogHash);
         if( rc!=SQLITE_OK ){
           doltliteCommitClear(&commit);
-          {
-            int restoreRc = remoteSqlStateRestore(db, cs, &savedState);
-            remoteSqlStateClear(&savedState);
-            if( restoreRc!=SQLITE_OK ){
-              sqlite3_result_error_code(ctx, restoreRc);
-              return;
-            }
-          }
-          sqlite3_result_error(ctx, "failed to initialize working tree from default branch", -1);
+          remoteSqlRestoreAndReport(
+              ctx, db, cs, &savedState, SQLITE_ERROR,
+              "failed to initialize working tree from default branch");
           return;
         }
         doltliteSetSessionBranch(db, zDefault);
@@ -795,13 +717,8 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
         rc = chunkStoreSetDefaultBranch(cs, zDefault);
         doltliteCommitClear(&commit);
         if( rc!=SQLITE_OK ){
-          int restoreRc = remoteSqlStateRestore(db, cs, &savedState);
-          remoteSqlStateClear(&savedState);
-          if( restoreRc!=SQLITE_OK ){
-            sqlite3_result_error_code(ctx, restoreRc);
-            return;
-          }
-          sqlite3_result_error(ctx, "failed to record default branch", -1);
+          remoteSqlRestoreAndReport(ctx, db, cs, &savedState, SQLITE_ERROR,
+                                    "failed to record default branch");
           return;
         }
       }
@@ -812,14 +729,7 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   rc = chunkStoreSerializeRefs(cs);
   if( rc==SQLITE_OK ) rc = chunkStoreCommit(cs);
   if( rc!=SQLITE_OK ){
-    int restoreRc = remoteSqlStateRestore(db, cs, &savedState);
-    int opRc = rc;
-    remoteSqlStateClear(&savedState);
-    if( restoreRc!=SQLITE_OK ){
-      sqlite3_result_error_code(ctx, restoreRc);
-      return;
-    }
-    sqlite3_result_error_code(ctx, opRc);
+    remoteSqlRestoreAndReport(ctx, db, cs, &savedState, rc, 0);
     return;
   }
   remoteSqlStateClear(&savedState);

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -1475,6 +1475,48 @@ static void freeSavepointTables(struct SavepointTableState *pState){
   memset(&pState->conflictsCatalogHash, 0, sizeof(pState->conflictsCatalogHash));
 }
 
+static void captureSavepointSessionState(
+  Btree *pBtree,
+  struct SavepointTableState *pState
+){
+  pState->iNextTable = pBtree->iNextTable;
+  pState->stagedCatalog = pBtree->stagedCatalog;
+  pState->isMerging = pBtree->isMerging;
+  pState->mergeCommitHash = pBtree->mergeCommitHash;
+  pState->conflictsCatalogHash = pBtree->conflictsCatalogHash;
+}
+
+static void restoreSavepointSessionState(
+  Btree *pBtree,
+  struct SavepointTableState *pState
+){
+  pBtree->stagedCatalog = pState->stagedCatalog;
+  pBtree->isMerging = pState->isMerging;
+  pBtree->mergeCommitHash = pState->mergeCommitHash;
+  pBtree->conflictsCatalogHash = pState->conflictsCatalogHash;
+}
+
+static int captureSavepointTables(
+  Btree *pBtree,
+  struct SavepointTableState *pState
+){
+  int k;
+  if( pBtree->nTables<=0 ) return SQLITE_OK;
+  pState->aTables = sqlite3_malloc(
+      pBtree->nTables * (int)sizeof(SavepointTableEntry));
+  if( !pState->aTables ) return SQLITE_NOMEM;
+  for(k=0; k<pBtree->nTables; k++){
+    pState->aTables[k].iTable = pBtree->aTables[k].iTable;
+    pState->aTables[k].root = pBtree->aTables[k].root;
+    pState->aTables[k].schemaHash = pBtree->aTables[k].schemaHash;
+    pState->aTables[k].flags = pBtree->aTables[k].flags;
+    pState->aTables[k].pendingFlushSeekEdits =
+        pBtree->aTables[k].pendingFlushSeekEdits;
+  }
+  pState->nTables = pBtree->nTables;
+  return SQLITE_OK;
+}
+
 static void pushSavepointOnMutMaps(Btree *pBtree, int level){
   int k;
   BtCursor *p;
@@ -1791,7 +1833,6 @@ static int restoreTablesFromSavepoint(
 
 static int pushSavepoint(Btree *pBtree){
   struct SavepointTableState *pState;
-  int k;
 
   if( pBtree->nSavepoint>=pBtree->nSavepointAlloc ){
     int nNew = pBtree->nSavepointAlloc ? pBtree->nSavepointAlloc*2 : 8;
@@ -1808,24 +1849,8 @@ static int pushSavepoint(Btree *pBtree){
   pState->nPendingSnapshot = 0;
   pState->nPendingSnapshotAlloc = 0;
   pState->nTables = 0;
-  pState->iNextTable = pBtree->iNextTable;
-  pState->stagedCatalog = pBtree->stagedCatalog;
-  pState->isMerging = pBtree->isMerging;
-  pState->mergeCommitHash = pBtree->mergeCommitHash;
-  pState->conflictsCatalogHash = pBtree->conflictsCatalogHash;
-  if( pBtree->nTables > 0 ){
-    pState->aTables = sqlite3_malloc(pBtree->nTables * (int)sizeof(SavepointTableEntry));
-    if( !pState->aTables ) return SQLITE_NOMEM;
-    for(k=0; k<pBtree->nTables; k++){
-      pState->aTables[k].iTable = pBtree->aTables[k].iTable;
-      pState->aTables[k].root = pBtree->aTables[k].root;
-      pState->aTables[k].schemaHash = pBtree->aTables[k].schemaHash;
-      pState->aTables[k].flags = pBtree->aTables[k].flags;
-      pState->aTables[k].pendingFlushSeekEdits =
-          pBtree->aTables[k].pendingFlushSeekEdits;
-    }
-    pState->nTables = pBtree->nTables;
-  }
+  captureSavepointSessionState(pBtree, pState);
+  if( captureSavepointTables(pBtree, pState)!=SQLITE_OK ) return SQLITE_NOMEM;
 
   pBtree->nSavepoint++;
   pushSavepointOnMutMaps(pBtree, pBtree->nSavepoint);
@@ -2907,6 +2932,60 @@ int sqlite3BtreeBeginStmt(Btree *p, int iStatement){
   return p->pOps->xBeginStmt(p, iStatement);
 }
 
+static int rollbackCommittedState(Btree *p, BtShared *pBt){
+  int rc = restoreFromCommitted(p);
+  if( rc!=SQLITE_OK ) return rc;
+  invalidateCursors(pBt, 0, SQLITE_ABORT);
+  invalidateSchema(p);
+  return SQLITE_OK;
+}
+
+static int rollbackAllSavepoints(Btree *p, BtShared *pBt){
+  int j;
+  for(j=0; j<p->nSavepoint; j++){
+    freeSavepointTables(&p->aSavepointTables[j]);
+  }
+  p->nSavepoint = 0;
+  return rollbackCommittedState(p, pBt);
+}
+
+static int rollbackNamedSavepoint(Btree *p, BtShared *pBt, int iSavepoint){
+  struct SavepointTableState *pState = &p->aSavepointTables[iSavepoint];
+  int j;
+  int rc = rollbackMutMapsToSavepoint(p, iSavepoint + 1, iSavepoint);
+  if( rc!=SQLITE_OK ) return rc;
+  if( pState->aTables ){
+    rc = restoreTablesFromSavepoint(p, pState);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+  restoreSavepointSessionState(p, pState);
+  freeSavepointTables(pState);
+  for(j=iSavepoint+1; j<p->nSavepoint; j++){
+    freeSavepointTables(&p->aSavepointTables[j]);
+  }
+  p->nSavepoint = iSavepoint;
+  invalidateCursors(pBt, 0, SQLITE_ABORT);
+  invalidateSchema(p);
+  return SQLITE_OK;
+}
+
+static int releaseSavepointsFrom(Btree *p, int iSavepoint){
+  int j;
+  releaseMutMapsToSavepoint(p, iSavepoint + 1);
+  if( iSavepoint > 0 ){
+    for(j=iSavepoint; j<p->nSavepoint; j++){
+      int rc = inheritPendingSnapshots(&p->aSavepointTables[iSavepoint-1],
+                                       &p->aSavepointTables[j]);
+      if( rc!=SQLITE_OK ) return rc;
+    }
+  }
+  for(j=iSavepoint; j<p->nSavepoint; j++){
+    freeSavepointTables(&p->aSavepointTables[j]);
+  }
+  p->nSavepoint = iSavepoint;
+  return SQLITE_OK;
+}
+
 static int prollyBtreeSavepoint(Btree *p, int op, int iSavepoint){
   BtShared *pBt;
 
@@ -2927,58 +3006,16 @@ static int prollyBtreeSavepoint(Btree *p, int op, int iSavepoint){
 
     if( iSavepoint>=0 && iSavepoint<p->nSavepoint
      && p->aSavepointTables ){
-      struct SavepointTableState *pState = &p->aSavepointTables[iSavepoint];
-      int rc = rollbackMutMapsToSavepoint(p, iSavepoint + 1, iSavepoint);
-      if( rc!=SQLITE_OK ) return rc;
-      if( pState->aTables ){
-        rc = restoreTablesFromSavepoint(p, pState);
-        if( rc!=SQLITE_OK ) return rc;
-      }
-      p->stagedCatalog = pState->stagedCatalog;
-      p->isMerging = pState->isMerging;
-      p->mergeCommitHash = pState->mergeCommitHash;
-      p->conflictsCatalogHash = pState->conflictsCatalogHash;
-      freeSavepointTables(pState);
-
-      {
-        int j;
-        for(j=iSavepoint+1; j<p->nSavepoint; j++){
-          freeSavepointTables(&p->aSavepointTables[j]);
-        }
-      }
-      p->nSavepoint = iSavepoint;
-      invalidateCursors(pBt, 0, SQLITE_ABORT);
-      invalidateSchema(p);
+      return rollbackNamedSavepoint(p, pBt, iSavepoint);
     } else if( iSavepoint>=0 && iSavepoint>=p->nSavepoint ){
-      { int rc2 = restoreFromCommitted(p); if( rc2 ) return rc2; }
-      invalidateCursors(pBt, 0, SQLITE_ABORT);
-      invalidateSchema(p);
+      return rollbackCommittedState(p, pBt);
     } else if( iSavepoint<0 ){
-      int j;
-      for(j=0; j<p->nSavepoint; j++){
-        freeSavepointTables(&p->aSavepointTables[j]);
-      }
-      { int rc2 = restoreFromCommitted(p); if( rc2 ) return rc2; }
-      p->nSavepoint = 0;
-      invalidateCursors(pBt, 0, SQLITE_ABORT);
-      invalidateSchema(p);
+      return rollbackAllSavepoints(p, pBt);
     }
   } else {
 
     if( iSavepoint>=0 && iSavepoint<p->nSavepoint ){
-      int j;
-      releaseMutMapsToSavepoint(p, iSavepoint + 1);
-      if( iSavepoint > 0 ){
-        for(j=iSavepoint; j<p->nSavepoint; j++){
-          int rc = inheritPendingSnapshots(&p->aSavepointTables[iSavepoint-1],
-                                           &p->aSavepointTables[j]);
-          if( rc!=SQLITE_OK ) return rc;
-        }
-      }
-      for(j=iSavepoint; j<p->nSavepoint; j++){
-        freeSavepointTables(&p->aSavepointTables[j]);
-      }
-      p->nSavepoint = iSavepoint;
+      return releaseSavepointsFrom(p, iSavepoint);
     }
   }
 


### PR DESCRIPTION
## Summary
This PR is a cleanup pass over several of DoltLite's largest and most stateful code paths. It focuses on reducing code bloat, splitting orchestration from policy, and making rollback/error/savepoint flows easier to audit without changing behavior.

## Included Refactors
- refactored `dolt_add` staging flows in `src/doltlite.c`
- refactored `dolt_reset` and `dolt_merge` command helpers in `src/doltlite.c`
- refactored remote SQL orchestration in `src/doltlite_remote_sql.c`
- refactored diff-table history planning in `src/doltlite_diff_table.c`
- refactored merge catalog helpers and orchestration in `src/doltlite_merge.c`
- refactored savepoint state helpers in `src/prolly_btree.c`
- refactored diff-stat / diff-summary filter orchestration in `src/doltlite_diff_stat.c`

## Follow-up Fix
- restored the known-good untracked-table preservation block in `dolt_reset('--hard')` after the helper extraction regressed `doltlite_reset.sh`

## Verification
- `make -C build doltlite`
- `bash test/lint_layers.sh src`
- `bash test/remote_test.sh ./build/doltlite`
- `cd build && bash ../test/doltlite_diff_table.sh`
- `cd build && bash ../test/doltlite_diff_alter.sh`
- `cd build && bash ../test/vc_oracle_diff_test.sh ./doltlite dolt`
- `cd build && bash ../test/doltlite_merge.sh`
- `cd build && bash ../test/vc_oracle_merge_test.sh ./doltlite dolt`
- `cd build && bash ../test/doltlite_reset.sh`
- `cd build && bash ../test/oracle_savepoints_test.sh ./doltlite ./sqlite3`
- `cd build && bash ../test/sql_oracle_test.sh ./doltlite ./sqlite3`
- `cd build && bash ../test/vc_oracle_diff_stat_test.sh ./doltlite dolt`
- `cd build && ./doltlite_regression_test_c diff_stat_requires_refs`
- `cd build && ./doltlite_regression_test_c diff_stat_surfaces_corrupt_root`
