### PR TITLE
test: dolt_ignore cross-branch / merge / reset oracle

### DIFF
--- a/test/vc_oracle_ignore_test.sh
+++ b/test/vc_oracle_ignore_test.sh
@@ -88,11 +88,15 @@ $setup"
   local dolt_setup
   dolt_setup=$(echo "$setup" | sed -E 's/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g')
 
+  # Run setup AND the status query in a single dolt sql invocation so
+  # that branch checkouts and working-set state persist from setup
+  # into the query (a second dolt sql call would reset to main and
+  # lose the per-branch working set).
   (
     cd "$dir/dt" || exit 1
     "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
-    echo "$dolt_setup" | "$DOLT" sql >/dev/null 2>"$dir/dt.err"
-    "$DOLT" sql -r csv -q "SELECT concat('S|', table_name, '|', staged, '|', status) FROM dolt_status" 2>>"$dir/dt.err"
+    printf "%s\nSELECT concat('S|', table_name, '|', staged, '|', status) FROM dolt_status;\n" "$dolt_setup" \
+      | "$DOLT" sql -r csv 2>"$dir/dt.err"
   ) > "$dir/dt.raw"
 
   local dt_out
@@ -544,6 +548,84 @@ doltlite_runtime_reject "runtime_wrong_shape_view" "
 CREATE VIEW dolt_ignore AS SELECT 'tmp_*' AS pattern;
 CREATE TABLE tmp_bad(x INT PRIMARY KEY);
 SELECT * FROM dolt_status;
+"
+
+# ---------------------------------------------------------------
+# cross-branch + merge + reset
+# ---------------------------------------------------------------
+#
+# These scenarios pin dolt_ignore's behavior across branch, merge,
+# and reset operations. All interactions are checked against Dolt
+# 1.83.5; the oracle helpers already handle doltlite's manual
+# CREATE TABLE dolt_ignore prefix.
+#
+# Note scenario 3 (committed_then_reset): after dolt_reset --hard
+# HEAD~1, both engines leave the previously-untracked matching
+# table in the working tree (reset --hard does not clean untracked
+# files). Once the ignore pattern is gone, both that leftover table
+# and any freshly-created matching table show up in dolt_status.
+# Note scenario 5 (merge_conflicting_patterns): an UPDATE-UPDATE
+# conflict on the same dolt_ignore row surfaces as a merge conflict
+# in Dolt and as "Merge has N conflict(s)" in doltlite; oracle_error
+# only requires both to report an error.
+
+echo "--- cross-branch + merge + reset ---"
+
+oracle "pattern_survives_branch_create" "
+INSERT INTO dolt_ignore VALUES ('tmp_*', 1);
+SELECT dolt_commit('-A', '-m', 'add pattern');
+SELECT dolt_checkout('-b', 'feat');
+CREATE TABLE tmp_foo(x INT PRIMARY KEY);
+CREATE TABLE keep(x INT PRIMARY KEY);
+"
+
+oracle "pattern_different_on_branches" "
+SELECT dolt_checkout('-b', 'bA');
+INSERT INTO dolt_ignore VALUES ('tmp_*', 1);
+SELECT dolt_commit('-A', '-m', 'bA ignores tmp_');
+SELECT dolt_checkout('main');
+SELECT dolt_checkout('-b', 'bB');
+INSERT INTO dolt_ignore VALUES ('cache_*', 1);
+SELECT dolt_commit('-A', '-m', 'bB ignores cache_');
+CREATE TABLE tmp_foo(x INT PRIMARY KEY);
+CREATE TABLE cache_bar(x INT PRIMARY KEY);
+"
+
+oracle "pattern_committed_then_reset" "
+CREATE TABLE sentinel(x INT PRIMARY KEY);
+SELECT dolt_commit('-A', '-m', 'base');
+INSERT INTO dolt_ignore VALUES ('tmp_*', 1);
+SELECT dolt_commit('-A', '-m', 'add pattern');
+CREATE TABLE tmp_foo(x INT PRIMARY KEY);
+SELECT dolt_reset('--hard', 'HEAD~1');
+CREATE TABLE tmp_bar(x INT PRIMARY KEY);
+"
+
+oracle "merge_adds_pattern_ff" "
+CREATE TABLE sentinel(x INT PRIMARY KEY);
+SELECT dolt_commit('-A', '-m', 'base');
+SELECT dolt_checkout('-b', 'feature');
+INSERT INTO dolt_ignore VALUES ('tmp_*', 1);
+SELECT dolt_commit('-A', '-m', 'feature adds pattern');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feature');
+CREATE TABLE tmp_new(x INT PRIMARY KEY);
+CREATE TABLE keep(x INT PRIMARY KEY);
+"
+
+oracle_error "merge_conflicting_patterns" "
+CREATE TABLE sentinel(x INT PRIMARY KEY);
+SELECT dolt_commit('-A', '-m', 'base');
+SELECT dolt_checkout('-b', 'b1');
+INSERT INTO dolt_ignore VALUES ('shared_pat', 1);
+SELECT dolt_commit('-A', '-m', 'b1 ignores shared_pat');
+SELECT dolt_checkout('main');
+SELECT dolt_checkout('-b', 'b2');
+INSERT INTO dolt_ignore VALUES ('shared_pat', 0);
+SELECT dolt_commit('-A', '-m', 'b2 unignores shared_pat');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('b1');
+SELECT dolt_merge('b2');
 "
 
 echo ""


### PR DESCRIPTION
Extends ``test/vc_oracle_ignore_test.sh`` with five new scenarios covering ``dolt_ignore`` under branch create / switch, fast-forward merge, reset, and a merge conflict on the ``dolt_ignore`` table itself. All scenarios are pinned against real Dolt 1.83.5. Doltlite matches on every row-level semantic tested — no bugs found, just new coverage for interactions we hadn't exercised.

## Scenarios
- ``pattern_survives_branch_create`` — pattern created on main, new branch created, matching table on the branch is hidden.
- ``pattern_different_on_branches`` — disjoint patterns per branch; on branch B the non-matching ``tmp_foo`` shows and the matching ``cache_bar`` hides.
- ``pattern_committed_then_reset`` — ``dolt_reset('--hard','HEAD~1')`` undoes the pattern commit. Both engines leave the pre-reset untracked ``tmp_foo`` in the working tree (``reset --hard`` doesn't clean untracked files), so both ``tmp_foo`` and ``tmp_bar`` show once the pattern is gone. Documented in a comment so the expected output doesn't look surprising.
- ``merge_adds_pattern_ff`` — feature branch adds pattern, fast-forward merges into main, new matching tables on main are hidden.
- ``merge_conflicting_patterns`` (``oracle_error``) — diverging ``INSERT``s of the same ``shared_pat`` PK trigger a merge conflict on ``dolt_ignore``. Dolt errors "Merge conflict detected", doltlite "Merge has 1 conflict(s)"; ``oracle_error`` is happy as long as both engines error.

## Test-harness fix

The existing ``oracle()`` helper was running Dolt setup in one ``dolt sql`` invocation and the status query in a second invocation. Dolt's second invocation resets the working-set state to ``main``, so any test that ran ``CALL dolt_checkout('branch')`` during setup would silently lose the branch context — its status query would always run against main regardless. This masks real row-level failures on any branch-touching scenario.

Fixed in the same PR: pipe the setup and the final ``SELECT ... FROM dolt_status`` into one ``dolt sql -r csv`` call. Every previously-passing test still passes, and the new cross-branch scenarios now exercise real branch state on the Dolt side.

## Test plan
- [x] ``bash test/vc_oracle_ignore_test.sh`` — 29/29 (was 24/24, added 5)
- [x] Other oracles unchanged by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)