### PR TITLE
prolly: plug TableEntry zName leak in dolt_add -A path

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -500,13 +500,26 @@ static void doltliteAddFunc(
       ** any) is kept instead — ignore blocks new staging but doesn't
       ** un-stage tables that were already staged. Deletions (in
       ** staged but not in working) are synced only for non-ignored
-      ** tables; ignored deletions stay in new staged to match Dolt. */
+      ** tables; ignored deletions stay in new staged to match Dolt.
+      **
+      ** zName ownership: doltliteLoadCatalog allocates each entry's
+      ** zName; we dup when copying into aNew so all three arrays
+      ** (aWorking/aStaged/aNew) have independent ownership and can
+      ** each be freed with doltliteFreeCatalog at the end. */
       struct TableEntry *aWorking = 0;
       struct TableEntry *aStaged = 0;
       struct TableEntry *aNew = 0;
       int nWorking = 0, nStaged = 0, nNew = 0;
       int k;
       ProllyHash stagedHash;
+
+      #define DA_FAIL(rc_expr) do { \
+        doltliteFreeCatalog(aWorking, nWorking); \
+        doltliteFreeCatalog(aStaged, nStaged); \
+        doltliteFreeCatalog(aNew, nNew); \
+        rc_expr; \
+        return; \
+      } while(0)
 
       rc = doltliteLoadCatalog(db, &workingHash, &aWorking, &nWorking, 0);
       if( rc!=SQLITE_OK ){
@@ -525,9 +538,7 @@ static void doltliteAddFunc(
         rc = doltliteLoadCatalog(db, &stagedHash, &aStaged, &nStaged, 0);
       }
       if( rc!=SQLITE_OK ){
-        sqlite3_free(aWorking);
-        sqlite3_result_error(context, "failed to load staged catalog", -1);
-        return;
+        DA_FAIL(sqlite3_result_error(context, "failed to load staged catalog", -1));
       }
 
       for(k=0; k<nWorking; k++){
@@ -537,28 +548,21 @@ static void doltliteAddFunc(
         int irc;
         struct TableEntry *pUse = &aWorking[k];
         struct TableEntry *aTmp;
+        char *zDup;
 
         if( aWorking[k].iTable>1 && zName ){
           irc = doltliteCheckIgnore(db, zName, &ignored, &zIgnErr);
           if( irc==SQLITE_CONSTRAINT ){
-            sqlite3_free(aWorking);
-            sqlite3_free(aStaged);
-            sqlite3_free(aNew);
             if( zIgnErr ){
               sqlite3_result_error(context, zIgnErr, -1);
               sqlite3_free(zIgnErr);
-            }else{
-              sqlite3_result_error(context, "dolt_ignore conflict", -1);
+              DA_FAIL((void)0);
             }
-            return;
+            DA_FAIL(sqlite3_result_error(context, "dolt_ignore conflict", -1));
           }
           if( irc!=SQLITE_OK ){
             sqlite3_free(zIgnErr);
-            sqlite3_free(aWorking);
-            sqlite3_free(aStaged);
-            sqlite3_free(aNew);
-            sqlite3_result_error_code(context, irc);
-            return;
+            DA_FAIL(sqlite3_result_error_code(context, irc));
           }
           if( ignored ){
             /* Keep the existing staged entry if any; otherwise skip. */
@@ -575,15 +579,12 @@ static void doltliteAddFunc(
         }
 
         aTmp = sqlite3_realloc(aNew, (nNew+1)*(int)sizeof(struct TableEntry));
-        if( !aTmp ){
-          sqlite3_free(aWorking);
-          sqlite3_free(aStaged);
-          sqlite3_free(aNew);
-          sqlite3_result_error_nomem(context);
-          return;
-        }
+        if( !aTmp ) DA_FAIL(sqlite3_result_error_nomem(context));
         aNew = aTmp;
+        zDup = pUse->zName ? sqlite3_mprintf("%s", pUse->zName) : 0;
+        if( pUse->zName && !zDup ) DA_FAIL(sqlite3_result_error_nomem(context));
         aNew[nNew] = *pUse;
+        aNew[nNew].zName = zDup;
         nNew++;
       }
 
@@ -595,6 +596,7 @@ static void doltliteAddFunc(
         int found = 0;
         int j;
         struct TableEntry *aTmp;
+        char *zDup;
         if( aStaged[k].iTable<=1 || !zName ) continue;
         for(j=0; j<nWorking; j++){
           if( aWorking[j].zName && strcmp(aWorking[j].zName, zName)==0 ){
@@ -608,37 +610,26 @@ static void doltliteAddFunc(
           char *zIgnErr = 0;
           int irc = doltliteCheckIgnore(db, zName, &ignored, &zIgnErr);
           if( irc==SQLITE_CONSTRAINT ){
-            sqlite3_free(aWorking);
-            sqlite3_free(aStaged);
-            sqlite3_free(aNew);
             if( zIgnErr ){
               sqlite3_result_error(context, zIgnErr, -1);
               sqlite3_free(zIgnErr);
-            }else{
-              sqlite3_result_error(context, "dolt_ignore conflict", -1);
+              DA_FAIL((void)0);
             }
-            return;
+            DA_FAIL(sqlite3_result_error(context, "dolt_ignore conflict", -1));
           }
           if( irc!=SQLITE_OK ){
             sqlite3_free(zIgnErr);
-            sqlite3_free(aWorking);
-            sqlite3_free(aStaged);
-            sqlite3_free(aNew);
-            sqlite3_result_error_code(context, irc);
-            return;
+            DA_FAIL(sqlite3_result_error_code(context, irc));
           }
           if( !ignored ) continue;
         }
         aTmp = sqlite3_realloc(aNew, (nNew+1)*(int)sizeof(struct TableEntry));
-        if( !aTmp ){
-          sqlite3_free(aWorking);
-          sqlite3_free(aStaged);
-          sqlite3_free(aNew);
-          sqlite3_result_error_nomem(context);
-          return;
-        }
+        if( !aTmp ) DA_FAIL(sqlite3_result_error_nomem(context));
         aNew = aTmp;
+        zDup = aStaged[k].zName ? sqlite3_mprintf("%s", aStaged[k].zName) : 0;
+        if( aStaged[k].zName && !zDup ) DA_FAIL(sqlite3_result_error_nomem(context));
         aNew[nNew] = aStaged[k];
+        aNew[nNew].zName = zDup;
         nNew++;
       }
 
@@ -648,11 +639,7 @@ static void doltliteAddFunc(
         ProllyHash newStagedHash;
         rc = doltliteSerializeCatalogEntries(db, aNew, nNew, &buf, &nBuf);
         if( rc!=SQLITE_OK ){
-          sqlite3_free(aWorking);
-          sqlite3_free(aStaged);
-          sqlite3_free(aNew);
-          sqlite3_result_error_code(context, rc);
-          return;
+          DA_FAIL(sqlite3_result_error_code(context, rc));
         }
         rc = chunkStorePut(cs, buf, nBuf, &newStagedHash);
         sqlite3_free(buf);
@@ -661,9 +648,10 @@ static void doltliteAddFunc(
         }
       }
 
-      sqlite3_free(aWorking);
-      sqlite3_free(aStaged);
-      sqlite3_free(aNew);
+      doltliteFreeCatalog(aWorking, nWorking);
+      doltliteFreeCatalog(aStaged, nStaged);
+      doltliteFreeCatalog(aNew, nNew);
+      #undef DA_FAIL
     }else{
 
       struct TableEntry *aWorking = 0, *aStaged = 0;

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -86,6 +86,7 @@ ProllyCache *doltliteGetCache(sqlite3 *db);
 int doltliteLoadCatalog(sqlite3 *db, const ProllyHash *catHash,
                         struct TableEntry **ppTables, int *pnTables,
                         Pgno *piNextTable);
+void doltliteFreeCatalog(struct TableEntry *a, int n);
 int doltliteSerializeCatalogEntries(sqlite3 *db, struct TableEntry *aTables,
                                     int nTables, u8 **ppOut, int *pnOut);
 int doltliteGetHeadCatalogHash(sqlite3 *db, ProllyHash *pCatHash);

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -5722,6 +5722,17 @@ int doltliteLoadCatalog(sqlite3 *db, const ProllyHash *catHash,
   return SQLITE_OK;
 }
 
+/* Free a TableEntry array returned by doltliteLoadCatalog. Each
+** TableEntry owns its zName allocation via deserializeCatalog(); the
+** callers that just did sqlite3_free(a) were leaking N strings per
+** call. Null-tolerant so cleanup paths don't need to guard. */
+void doltliteFreeCatalog(struct TableEntry *a, int n){
+  int i;
+  if( !a ) return;
+  for(i=0; i<n; i++) sqlite3_free(a[i].zName);
+  sqlite3_free(a);
+}
+
 int doltliteGetHeadCatalogHash(sqlite3 *db, ProllyHash *pCatHash){
   ChunkStore *cs = doltliteGetChunkStore(db);
   ProllyHash headHash;


### PR DESCRIPTION
Minimum-scope fix for a leak class I spotted during the dolt_ignore work.

## The leak

``doltliteLoadCatalog`` returns a ``TableEntry`` array where each entry's ``zName`` is its own ``sqlite3_malloc``'d allocation (``deserializeCatalog`` around ``prolly_btree.c:1010``). Callers that do ``sqlite3_free(aTables)`` free the array backbone but leak every ``zName``.

## Fix

- New ``void doltliteFreeCatalog(TableEntry *a, int n)`` in ``prolly_btree.c``, declared in ``doltlite_internal.h``. Null-tolerant, walks the array and frees every ``zName`` before releasing the backbone.
- Fixed the leaking call site in the ``dolt_add -A`` path that I rewrote during the dolt_ignore work (``src/doltlite.c`` ``stageAll`` branch). It allocates three catalog arrays (``aWorking`` / ``aStaged`` / ``aNew``) and freed them with plain ``sqlite3_free``, leaking ``O(tables × 3)`` strings per call. The shallow-copy shape ``aNew[nNew] = *pUse`` transferred ``zName`` ownership non-explicitly — a naive "free each entry's zName" fix would have double-freed, so the fix is **dup-on-copy**: ``sqlite3_mprintf("%s", src.zName)`` at each copy site so all three arrays own independent strings and can each be released with ``doltliteFreeCatalog``.

## Scope

Deliberately limited to the path I introduced. Other callers of ``doltliteLoadCatalog`` have the same class of leak:

- ``src/doltlite.c`` ``doltliteAddFunc`` explicit-name branch (shallow-copy)
- ``src/doltlite.c`` ``doltliteCommitFunc`` ``addModifiedOnly`` branch (shallow-copy)
- ``src/doltlite_status.c``
- ``src/doltlite_branch.c``
- ``src/doltlite_diff.c`` / ``doltlite_diff_stat.c`` / ``doltlite_diff_table.c``
- ``src/doltlite_gc.c``
- ``src/doltlite_conflicts.c``
- ``src/doltlite_schema_diff.c``

Each needs its own ownership analysis. Doing them all in one PR was attempted and got sprawling; this one delivers the helper + the hottest path only. Follow-up ticket worth.

## Test plan
- [x] ``make doltlite`` — no warnings
- [x] ``bash test/run_doltlite_tests.sh`` — 39/39 suites
- [x] ``bash test/vc_oracle_add_test.sh`` — 16/16
- [x] ``bash test/vc_oracle_ignore_test.sh`` — 38/38
- [x] ``bash test/vc_oracle_status_test.sh`` — 11/11

Note: ``vc_oracle_commit_test.sh`` has 14/21 pre-existing failures on master (date normalization mismatch) unrelated to this PR — verified by re-running on master without my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)