### PR TITLE
dolt_ignore: drop unused tieIgnored local

### DIFF
--- a/src/doltlite_ignore.c
+++ b/src/doltlite_ignore.c
@@ -127,7 +127,6 @@ int doltliteCheckIgnore(
   char *zBestPat = 0;
   int tieDisagrees = 0;
   char *zTiePat = 0;
-  int tieIgnored = 0;
 
   *pIgnored = 0;
   if( pzErr ) *pzErr = 0;
@@ -173,7 +172,6 @@ int doltliteCheckIgnore(
       tieDisagrees = 1;
       sqlite3_free(zTiePat);
       zTiePat = sqlite3_mprintf("%s", zPat);
-      tieIgnored = ign;
     }
   }
   sqlite3_finalize(pStmt);
@@ -195,7 +193,6 @@ int doltliteCheckIgnore(
     }
     sqlite3_free(zBestPat);
     sqlite3_free(zTiePat);
-    (void)tieIgnored;
     return SQLITE_CONSTRAINT;
   }
 


### PR DESCRIPTION
Leftover from earlier drafts of the conflict-detection loop. ``tieIgnored`` was assigned but never read, and a trailing ``(void)tieIgnored`` cast was suppressing the warning. The actual tie-conflict error message picks the "ignored" vs "not ignored" pattern via ``bestIgnored``, so ``tieIgnored`` wasn't contributing anything.

Three lines removed: the declaration, the assignment inside the loop, and the void cast. No behavior change.

## Test plan
- [x] ``make doltlite`` — clean
- [x] ``bash test/vc_oracle_ignore_test.sh`` — 38/38

🤖 Generated with [Claude Code](https://claude.com/claude-code)