### PR TITLE
dolt_ignore: propagate OOM from tie-pattern bookkeeping

### DIFF
--- a/src/doltlite_ignore.c
+++ b/src/doltlite_ignore.c
@@ -165,6 +165,7 @@ int doltliteCheckIgnore(
       bestIgnored = ign;
       sqlite3_free(zBestPat);
       zBestPat = sqlite3_mprintf("%s", zPat);
+      if( !zBestPat ){ rc = SQLITE_NOMEM; break; }
       tieDisagrees = 0;
       sqlite3_free(zTiePat);
       zTiePat = 0;
@@ -172,6 +173,7 @@ int doltliteCheckIgnore(
       tieDisagrees = 1;
       sqlite3_free(zTiePat);
       zTiePat = sqlite3_mprintf("%s", zPat);
+      if( !zTiePat ){ rc = SQLITE_NOMEM; break; }
     }
   }
   sqlite3_finalize(pStmt);


### PR DESCRIPTION
``sqlite3_mprintf`` can return NULL on OOM. Two call sites in ``doltliteCheckIgnore``'s pattern scan loop assigned the result to ``zBestPat`` / ``zTiePat`` without checking, then later fed those pointers to a tie-conflict error formatter as ``%s`` args. Passing NULL to a printf ``%s`` specifier is undefined behavior — glibc prints ``"(null)"``, musl and some platforms crash.

Two-line fix: null-check each assignment inside the loop and bail out cleanly with ``SQLITE_NOMEM`` so the caller (``doltlite_status`` / ``doltlite_add``) can surface the real failure.

## Test plan
- [x] ``make doltlite`` — clean
- [x] ``bash test/vc_oracle_ignore_test.sh`` — 43/43

🤖 Generated with [Claude Code](https://claude.com/claude-code)