### PR TITLE
prolly: plug remaining TableEntry zName leaks across call sites

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -441,13 +441,13 @@ static int doltliteReportConflicts(
 }
 
 static void addFreeEntries(
-  struct TableEntry *aWorking,
-  struct TableEntry *aStaged,
-  struct TableEntry *aNew
+  struct TableEntry *aWorking, int nWorking,
+  struct TableEntry *aStaged,  int nStaged,
+  struct TableEntry *aNew,     int nNew
 ){
-  sqlite3_free(aWorking);
-  sqlite3_free(aStaged);
-  sqlite3_free(aNew);
+  doltliteFreeCatalog(aWorking, nWorking);
+  doltliteFreeCatalog(aStaged, nStaged);
+  doltliteFreeCatalog(aNew, nNew);
 }
 
 static void addResultIgnoreConflict(sqlite3_context *context, char *zIgnErr){
@@ -478,20 +478,37 @@ static int addCheckIgnore(
   return rc;
 }
 
+/* Append a TableEntry to a growing array, duping its zName so the
+** destination array has independent ownership. Required because the
+** source entry's zName is usually borrowed from another catalog
+** array (aWorking / aStaged) that will be freed separately — a
+** plain struct copy would alias the pointer and set up a
+** double-free. */
 static int addAppendTableEntry(
   sqlite3_context *context,
   struct TableEntry **paEntries,
   int *pnEntries,
   const struct TableEntry *pEntry
 ){
-  struct TableEntry *aNew = sqlite3_realloc(
+  struct TableEntry *aNew;
+  char *zDup = 0;
+  if( pEntry->zName ){
+    zDup = sqlite3_mprintf("%s", pEntry->zName);
+    if( !zDup ){
+      sqlite3_result_error_nomem(context);
+      return SQLITE_NOMEM;
+    }
+  }
+  aNew = sqlite3_realloc(
       *paEntries, (*pnEntries + 1) * (int)sizeof(struct TableEntry));
   if( !aNew ){
+    sqlite3_free(zDup);
     sqlite3_result_error_nomem(context);
     return SQLITE_NOMEM;
   }
   *paEntries = aNew;
   (*paEntries)[*pnEntries] = *pEntry;
+  (*paEntries)[*pnEntries].zName = zDup;
   (*pnEntries)++;
   return SQLITE_OK;
 }
@@ -541,7 +558,7 @@ static int addLoadWorkingAndStagedCatalogs(
     rc = doltliteLoadCatalog(db, &stagedHash, paStaged, pnStaged, 0);
   }
   if( rc!=SQLITE_OK ){
-    sqlite3_free(*paWorking);
+    doltliteFreeCatalog(*paWorking, *pnWorking);
     *paWorking = 0;
     *pnWorking = 0;
   }
@@ -598,7 +615,7 @@ static int addStageAllTables(
       int ignored = 0;
       rc = addCheckIgnore(db, context, zName, &ignored);
       if( rc!=SQLITE_OK ){
-        addFreeEntries(aWorking, aStaged, aNew);
+        addFreeEntries(aWorking, nWorking, aStaged, nStaged, aNew, nNew);
         return rc;
       }
       if( ignored ){
@@ -608,7 +625,7 @@ static int addStageAllTables(
     }
     rc = addAppendTableEntry(context, &aNew, &nNew, pUse);
     if( rc!=SQLITE_OK ){
-      addFreeEntries(aWorking, aStaged, aNew);
+      addFreeEntries(aWorking, nWorking, aStaged, nStaged, aNew, nNew);
       return rc;
     }
   }
@@ -621,20 +638,20 @@ static int addStageAllTables(
       int ignored = 0;
       rc = addCheckIgnore(db, context, zName, &ignored);
       if( rc!=SQLITE_OK ){
-        addFreeEntries(aWorking, aStaged, aNew);
+        addFreeEntries(aWorking, nWorking, aStaged, nStaged, aNew, nNew);
         return rc;
       }
       if( !ignored ) continue;
     }
     rc = addAppendTableEntry(context, &aNew, &nNew, &aStaged[k]);
     if( rc!=SQLITE_OK ){
-      addFreeEntries(aWorking, aStaged, aNew);
+      addFreeEntries(aWorking, nWorking, aStaged, nStaged, aNew, nNew);
       return rc;
     }
   }
 
   rc = addWriteStagedCatalog(db, cs, aNew, nNew);
-  addFreeEntries(aWorking, aStaged, aNew);
+  addFreeEntries(aWorking, nWorking, aStaged, nStaged, aNew, nNew);
   if( rc!=SQLITE_OK ){
     sqlite3_result_error_code(context, rc);
   }
@@ -660,7 +677,6 @@ static int addStageNamedTables(
                                        &aWorking, &nWorking,
                                        &aStaged, &nStaged);
   if( rc!=SQLITE_OK ){
-    sqlite3_free(aWorking);
     sqlite3_result_error(context, "failed to load staged catalog", -1);
     return rc;
   }
@@ -675,8 +691,8 @@ static int addStageNamedTables(
       int ignored = 0;
       rc = addCheckIgnore(db, context, zTable, &ignored);
       if( rc!=SQLITE_OK ){
-        sqlite3_free(aWorking);
-        sqlite3_free(aStaged);
+        doltliteFreeCatalog(aWorking, nWorking);
+        doltliteFreeCatalog(aStaged, nStaged);
         return rc;
       }
       if( ignored ) continue;
@@ -687,6 +703,7 @@ static int addStageNamedTables(
       int found = 0;
       for(j=0; j<nStaged; j++){
         if( aStaged[j].zName && strcmp(aStaged[j].zName, zTable)==0 ){
+          sqlite3_free(aStaged[j].zName);
           if( j+1 < nStaged ){
             memmove(&aStaged[j], &aStaged[j+1],
                     (nStaged-j-1) * (int)sizeof(struct TableEntry));
@@ -698,8 +715,8 @@ static int addStageNamedTables(
       }
       if( !found ){
         char *zErr = sqlite3_mprintf("table not found: %s", zTable);
-        sqlite3_free(aWorking);
-        sqlite3_free(aStaged);
+        doltliteFreeCatalog(aWorking, nWorking);
+        doltliteFreeCatalog(aStaged, nStaged);
         if( zErr ){
           sqlite3_result_error(context, zErr, -1);
           sqlite3_free(zErr);
@@ -717,7 +734,17 @@ static int addStageNamedTables(
         int updated = 0;
         for(k=0; k<nStaged; k++){
           if( aStaged[k].iTable==iTable ){
+            char *zDup = aWorking[j].zName
+                           ? sqlite3_mprintf("%s", aWorking[j].zName) : 0;
+            if( aWorking[j].zName && !zDup ){
+              doltliteFreeCatalog(aWorking, nWorking);
+              doltliteFreeCatalog(aStaged, nStaged);
+              sqlite3_result_error_nomem(context);
+              return SQLITE_NOMEM;
+            }
+            sqlite3_free(aStaged[k].zName);
             aStaged[k] = aWorking[j];
+            aStaged[k].zName = zDup;
             updated = 1;
             break;
           }
@@ -725,8 +752,8 @@ static int addStageNamedTables(
         if( !updated ){
           rc = addAppendTableEntry(context, &aStaged, &nStaged, &aWorking[j]);
           if( rc!=SQLITE_OK ){
-            sqlite3_free(aWorking);
-            sqlite3_free(aStaged);
+            doltliteFreeCatalog(aWorking, nWorking);
+            doltliteFreeCatalog(aStaged, nStaged);
             return rc;
           }
         }
@@ -736,8 +763,8 @@ static int addStageNamedTables(
   }
 
   rc = addWriteStagedCatalog(db, cs, aStaged, nStaged);
-  sqlite3_free(aWorking);
-  sqlite3_free(aStaged);
+  doltliteFreeCatalog(aWorking, nWorking);
+  doltliteFreeCatalog(aStaged, nStaged);
   if( rc!=SQLITE_OK ){
     sqlite3_result_error_code(context, rc);
   }
@@ -803,7 +830,7 @@ static void doltliteAddFunc(
       }else{
         rc = addStageNamedTables(db, context, cs, &workingHash, argc, argv);
         if( rc!=SQLITE_OK ) return;
-    }
+      }
 
     rc = doltlitePersistWorkingSet(db);
     if( rc!=SQLITE_OK ){
@@ -940,7 +967,7 @@ static void doltliteCommitFunc(
     if( rc==SQLITE_OK && !prollyHashIsEmpty(&headCatHash) ){
       rc = doltliteLoadCatalog(db, &headCatHash, &aHead, &nHead, 0);
       if( rc!=SQLITE_OK ){
-        sqlite3_free(aWorking);
+        doltliteFreeCatalog(aWorking, nWorking);
         sqlite3_result_error(context, "failed to load HEAD catalog", -1);
         return;
       }
@@ -953,8 +980,8 @@ static void doltliteCommitFunc(
       rc = doltliteLoadCatalog(db, &headCatHash, &aStaged, &nStaged, 0);
     }
     if( rc!=SQLITE_OK ){
-      sqlite3_free(aWorking);
-      sqlite3_free(aHead);
+      doltliteFreeCatalog(aWorking, nWorking);
+      doltliteFreeCatalog(aHead, nHead);
       sqlite3_result_error(context, "failed to load staged catalog", -1);
       return;
     }
@@ -964,6 +991,7 @@ static void doltliteCommitFunc(
       const char *zName = aWorking[j].zName;
       int inHead = 0;
       int updated = 0;
+      char *zDup;
       for(k=0; k<nHead; k++){
         if( aHead[k].zName && zName && strcmp(aHead[k].zName, zName)==0 ){
           inHead = 1; break;
@@ -973,7 +1001,17 @@ static void doltliteCommitFunc(
 
       for(k=0; k<nStaged; k++){
         if( aStaged[k].zName && zName && strcmp(aStaged[k].zName, zName)==0 ){
+          zDup = zName ? sqlite3_mprintf("%s", zName) : 0;
+          if( zName && !zDup ){
+            doltliteFreeCatalog(aWorking, nWorking);
+            doltliteFreeCatalog(aHead, nHead);
+            doltliteFreeCatalog(aStaged, nStaged);
+            sqlite3_result_error_nomem(context);
+            return;
+          }
+          sqlite3_free(aStaged[k].zName);
           aStaged[k] = aWorking[j];
+          aStaged[k].zName = zDup;
           updated = 1;
           break;
         }
@@ -982,12 +1020,24 @@ static void doltliteCommitFunc(
         struct TableEntry *aNew = sqlite3_realloc(aStaged,
             (nStaged+1)*(int)sizeof(struct TableEntry));
         if( !aNew ){
-          sqlite3_free(aWorking); sqlite3_free(aHead); sqlite3_free(aStaged);
+          doltliteFreeCatalog(aWorking, nWorking);
+          doltliteFreeCatalog(aHead, nHead);
+          doltliteFreeCatalog(aStaged, nStaged);
           sqlite3_result_error_nomem(context);
           return;
         }
         aStaged = aNew;
-        aStaged[nStaged++] = aWorking[j];
+        zDup = zName ? sqlite3_mprintf("%s", zName) : 0;
+        if( zName && !zDup ){
+          doltliteFreeCatalog(aWorking, nWorking);
+          doltliteFreeCatalog(aHead, nHead);
+          doltliteFreeCatalog(aStaged, nStaged);
+          sqlite3_result_error_nomem(context);
+          return;
+        }
+        aStaged[nStaged] = aWorking[j];
+        aStaged[nStaged].zName = zDup;
+        nStaged++;
       }
     }
 
@@ -1005,6 +1055,7 @@ static void doltliteCommitFunc(
 
       for(j2=0; j2<nStaged; j2++){
         if( aStaged[j2].zName && zName && strcmp(aStaged[j2].zName, zName)==0 ){
+          sqlite3_free(aStaged[j2].zName);
           if( j2+1<nStaged ){
             memmove(&aStaged[j2], &aStaged[j2+1],
                     (nStaged-j2-1)*(int)sizeof(struct TableEntry));
@@ -1017,9 +1068,9 @@ static void doltliteCommitFunc(
 
 
     if( nStaged==0 ){
-      sqlite3_free(aWorking);
-      sqlite3_free(aHead);
-      sqlite3_free(aStaged);
+      doltliteFreeCatalog(aWorking, nWorking);
+      doltliteFreeCatalog(aHead, nHead);
+      doltliteFreeCatalog(aStaged, nStaged);
       sqlite3_result_error(context,
         "nothing to commit, working tree clean (use dolt_add to stage changes)", -1);
       return;
@@ -1039,9 +1090,9 @@ static void doltliteCommitFunc(
       }
     }
 
-    sqlite3_free(aWorking);
-    sqlite3_free(aHead);
-    sqlite3_free(aStaged);
+    doltliteFreeCatalog(aWorking, nWorking);
+    doltliteFreeCatalog(aHead, nHead);
+    doltliteFreeCatalog(aStaged, nStaged);
     if( rc!=SQLITE_OK ){
       sqlite3_result_error_code(context, rc);
       return;
@@ -1289,7 +1340,7 @@ static int resetStageNamedPaths(
   if( !prollyHashIsEmpty(&stagedHash) ){
     rc = doltliteLoadCatalog(db, &stagedHash, &aStaged, &nStaged, 0);
     if( rc!=SQLITE_OK ){
-      sqlite3_free(aHead);
+      doltliteFreeCatalog(aHead, nHead);
       return rc;
     }
   }
@@ -1298,11 +1349,13 @@ static int resetStageNamedPaths(
     const char *zTable = azPaths[p];
     int iH = resetFindTableIndex(aHead, nHead, zTable);
     int iS = resetFindTableIndex(aStaged, nStaged, zTable);
+    char *zDup;
     if( iH<0 && iS<0 ){
       rc = SQLITE_NOTFOUND;
       goto done;
     }
     if( iH<0 ){
+      sqlite3_free(aStaged[iS].zName);
       if( iS+1<nStaged ){
         memmove(&aStaged[iS], &aStaged[iS+1],
                 (nStaged-iS-1)*(int)sizeof(struct TableEntry));
@@ -1316,9 +1369,23 @@ static int resetStageNamedPaths(
         goto done;
       }
       aStaged = aNew;
-      aStaged[nStaged++] = aHead[iH];
+      zDup = aHead[iH].zName ? sqlite3_mprintf("%s", aHead[iH].zName) : 0;
+      if( aHead[iH].zName && !zDup ){
+        rc = SQLITE_NOMEM;
+        goto done;
+      }
+      aStaged[nStaged] = aHead[iH];
+      aStaged[nStaged].zName = zDup;
+      nStaged++;
     }else{
+      zDup = aHead[iH].zName ? sqlite3_mprintf("%s", aHead[iH].zName) : 0;
+      if( aHead[iH].zName && !zDup ){
+        rc = SQLITE_NOMEM;
+        goto done;
+      }
+      sqlite3_free(aStaged[iS].zName);
       aStaged[iS] = aHead[iH];
+      aStaged[iS].zName = zDup;
     }
   }
 
@@ -1337,8 +1404,8 @@ static int resetStageNamedPaths(
   }
 
 done:
-  sqlite3_free(aHead);
-  sqlite3_free(aStaged);
+  doltliteFreeCatalog(aHead, nHead);
+  doltliteFreeCatalog(aStaged, nStaged);
   return rc;
 }
 
@@ -1650,7 +1717,15 @@ static void doltliteResetFunc(
               }
             }
             if( tgtIdx>=0 ){
+              char *zDup = aTarget[tgtIdx].zName
+                             ? sqlite3_mprintf("%s", aTarget[tgtIdx].zName) : 0;
+              if( aTarget[tgtIdx].zName && !zDup ){
+                rc = SQLITE_NOMEM;
+                break;
+              }
+              sqlite3_free(aWorking[j].zName);
               aWorking[j] = aTarget[tgtIdx];
+              aWorking[j].zName = zDup;
             }
           }
         }
@@ -1668,13 +1743,13 @@ static void doltliteResetFunc(
             memcpy(&targetCatHash, &mergedHash, sizeof(ProllyHash));
           }
         }
-        sqlite3_free(aWorking);
-        sqlite3_free(aTarget);
+        doltliteFreeCatalog(aWorking, nWorking);
+        doltliteFreeCatalog(aTarget, nTarget);
       }
 
       for(j=0; j<nUntracked; j++) sqlite3_free(azUntracked[j]);
       sqlite3_free(azUntracked);
-      sqlite3_free(aHead);
+      doltliteFreeCatalog(aHead, nHead);
       if( rc!=SQLITE_OK ){
         sqlite3_result_error_code(context, rc);
         goto reset_cleanup;

--- a/src/doltlite_at.c
+++ b/src/doltlite_at.c
@@ -240,7 +240,7 @@ static int atFilter(sqlite3_vtab_cursor *cur,
 at_find_root:
 
   rc=doltliteFindTableRootByName(aTables,nTables,v->zTableName,&tableRoot,&flags);
-  sqlite3_free(aTables);
+  doltliteFreeCatalog(aTables,nTables);
   if(rc==SQLITE_NOTFOUND) return SQLITE_OK;
   if(rc!=SQLITE_OK) return rc;
 

--- a/src/doltlite_blame.c
+++ b/src/doltlite_blame.c
@@ -346,12 +346,12 @@ static int blameLoadTableRoot(
 
   pEntry = doltliteFindTableByName(aTables, nTables, zTableName);
   if( !pEntry ){
-    sqlite3_free(aTables);
+    doltliteFreeCatalog(aTables, nTables);
     return SQLITE_NOTFOUND;
   }
   memcpy(pOutRoot, &pEntry->root, sizeof(ProllyHash));
   *pOutFlags = pEntry->flags;
-  sqlite3_free(aTables);
+  doltliteFreeCatalog(aTables, nTables);
   return SQLITE_OK;
 }
 

--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -425,7 +425,7 @@ static int doltliteCheckoutTables(
 
   rc = doltliteLoadCatalog(db, &sourceCatHash, &aSource, &nSource, 0);
   if( rc!=SQLITE_OK ){
-    sqlite3_free(aWorking);
+    doltliteFreeCatalog(aWorking, nWorking);
     return rc;
   }
 
@@ -433,6 +433,7 @@ static int doltliteCheckoutTables(
   for(i=0; i<nNames; i++){
     const char *zName = (const char*)sqlite3_value_text(argv[i]);
     int srcIdx = -1, workIdx = -1;
+    char *zDup;
     if( !zName ) continue;
 
     for(j=0; j<nSource; j++){
@@ -447,12 +448,13 @@ static int doltliteCheckoutTables(
     }
 
     if( srcIdx<0 && workIdx<0 ){
-      sqlite3_free(aWorking); sqlite3_free(aSource);
+      doltliteFreeCatalog(aWorking, nWorking);
+      doltliteFreeCatalog(aSource, nSource);
       return SQLITE_NOTFOUND;
     }
 
     if( srcIdx<0 ){
-
+      sqlite3_free(aWorking[workIdx].zName);
       if( workIdx+1<nWorking ){
         memmove(&aWorking[workIdx], &aWorking[workIdx+1],
                 (nWorking-workIdx-1)*(int)sizeof(struct TableEntry));
@@ -463,13 +465,32 @@ static int doltliteCheckoutTables(
       struct TableEntry *aNew = sqlite3_realloc(aWorking,
           (nWorking+1)*(int)sizeof(struct TableEntry));
       if( !aNew ){
-        sqlite3_free(aWorking); sqlite3_free(aSource);
+        doltliteFreeCatalog(aWorking, nWorking);
+        doltliteFreeCatalog(aSource, nSource);
         return SQLITE_NOMEM;
       }
       aWorking = aNew;
-      aWorking[nWorking++] = aSource[srcIdx];
+      zDup = aSource[srcIdx].zName
+               ? sqlite3_mprintf("%s", aSource[srcIdx].zName) : 0;
+      if( aSource[srcIdx].zName && !zDup ){
+        doltliteFreeCatalog(aWorking, nWorking);
+        doltliteFreeCatalog(aSource, nSource);
+        return SQLITE_NOMEM;
+      }
+      aWorking[nWorking] = aSource[srcIdx];
+      aWorking[nWorking].zName = zDup;
+      nWorking++;
     }else{
+      zDup = aSource[srcIdx].zName
+               ? sqlite3_mprintf("%s", aSource[srcIdx].zName) : 0;
+      if( aSource[srcIdx].zName && !zDup ){
+        doltliteFreeCatalog(aWorking, nWorking);
+        doltliteFreeCatalog(aSource, nSource);
+        return SQLITE_NOMEM;
+      }
+      sqlite3_free(aWorking[workIdx].zName);
       aWorking[workIdx] = aSource[srcIdx];
+      aWorking[workIdx].zName = zDup;
     }
   }
 
@@ -491,8 +512,8 @@ static int doltliteCheckoutTables(
     }
   }
 
-  sqlite3_free(aWorking);
-  sqlite3_free(aSource);
+  doltliteFreeCatalog(aWorking, nWorking);
+  doltliteFreeCatalog(aSource, nSource);
   return rc;
 }
 

--- a/src/doltlite_dbpage.c
+++ b/src/doltlite_dbpage.c
@@ -96,7 +96,7 @@ static void synthesizeHeader(sqlite3 *db, unsigned char *aPage){
     for(i=0; i<4; i++){
       schemaCookie = (schemaCookie << 8) | catHash.data[i];
     }
-    sqlite3_free(aTables);
+    doltliteFreeCatalog(aTables, nTables);
   }
 
   put4byteBE(aHdr + 28, pageCount);

--- a/src/doltlite_diff.c
+++ b/src/doltlite_diff.c
@@ -213,7 +213,7 @@ static int collectWorkingSetSummary(DoltliteDiffCursor *pCur, sqlite3 *db){
   if( rc!=SQLITE_OK ) return rc;
   rc = doltliteLoadCatalog(db, &workCat, &aWork, &nWork, 0);
   if( rc!=SQLITE_OK ){
-    sqlite3_free(aHead);
+    doltliteFreeCatalog(aHead, nHead);
     return rc;
   }
 
@@ -262,8 +262,8 @@ static int collectWorkingSetSummary(DoltliteDiffCursor *pCur, sqlite3 *db){
   }
 
 done:
-  sqlite3_free(aHead);
-  sqlite3_free(aWork);
+  doltliteFreeCatalog(aHead, nHead);
+  doltliteFreeCatalog(aWork, nWork);
   return rc;
 }
 
@@ -290,7 +290,7 @@ static int collectSummaryForCommit(DoltliteDiffCursor *pCur, sqlite3 *db,
       doltliteCommitClear(&parent);
     }
     if( rc!=SQLITE_OK ){
-      sqlite3_free(aChild);
+      doltliteFreeCatalog(aChild, nChild);
       return rc;
     }
   }
@@ -342,8 +342,8 @@ static int collectSummaryForCommit(DoltliteDiffCursor *pCur, sqlite3 *db,
   }
 
 done:
-  sqlite3_free(aChild);
-  sqlite3_free(aParent);
+  doltliteFreeCatalog(aChild, nChild);
+  doltliteFreeCatalog(aParent, nParent);
   return rc;
 }
 

--- a/src/doltlite_diff_stat.c
+++ b/src/doltlite_diff_stat.c
@@ -283,7 +283,7 @@ static int dsComputeTableStats(
   if( rc!=SQLITE_OK ) return rc;
   rc = doltliteLoadCatalog(db, pToCatHash, &aTo, &nToCat, 0);
   if( rc!=SQLITE_OK ){
-    sqlite3_free(aFrom);
+    doltliteFreeCatalog(aFrom, nFromCat);
     return rc;
   }
 
@@ -302,8 +302,8 @@ static int dsComputeTableStats(
     memcpy(&toRoot, &pToEntry->root, sizeof(ProllyHash));
     toFlags = pToEntry->flags;
   }
-  sqlite3_free(aFrom);
-  sqlite3_free(aTo);
+  doltliteFreeCatalog(aFrom, nFromCat);
+  doltliteFreeCatalog(aTo, nToCat);
 
   if( !hasFrom && !hasTo ) return SQLITE_OK;
 
@@ -553,7 +553,7 @@ static int dsCollectTableNames(
   if( rc!=SQLITE_OK ) return rc;
   rc = doltliteLoadCatalog(db, pToCat, &aTo, &nTo, 0);
   if( rc!=SQLITE_OK ){
-    sqlite3_free(aFrom);
+    doltliteFreeCatalog(aFrom, nFrom);
     return rc;
   }
 
@@ -592,8 +592,8 @@ static int dsCollectTableNames(
     n++;
   }
 
-  sqlite3_free(aFrom);
-  sqlite3_free(aTo);
+  doltliteFreeCatalog(aFrom, nFrom);
+  doltliteFreeCatalog(aTo, nTo);
   *pazOut = az;
   *pnOut = n;
   return SQLITE_OK;
@@ -601,8 +601,8 @@ static int dsCollectTableNames(
 fail:
   for(j=0; j<n; j++) sqlite3_free(az[j]);
   sqlite3_free(az);
-  sqlite3_free(aFrom);
-  sqlite3_free(aTo);
+  doltliteFreeCatalog(aFrom, nFrom);
+  doltliteFreeCatalog(aTo, nTo);
   return rc;
 }
 
@@ -947,8 +947,8 @@ static int dssFilter(sqlite3_vtab_cursor *cur,
   }
 
 done:
-  sqlite3_free(aFromCat);
-  sqlite3_free(aToCat);
+  doltliteFreeCatalog(aFromCat, nFromCat);
+  doltliteFreeCatalog(aToCat, nToCat);
   dsFilterCtxClear(&fctx);
   return rc;
 }

--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -322,7 +322,7 @@ static int loadTblRootAtCommit(sqlite3 *db, const ProllyHash *pCatHash,
       memcpy(pSchemaHash, &pEntry->schemaHash, sizeof(ProllyHash));
     }
   }
-  sqlite3_free(aTables);
+  doltliteFreeCatalog(aTables, nTables);
   return SQLITE_OK;
 }
 

--- a/src/doltlite_history.c
+++ b/src/doltlite_history.c
@@ -184,7 +184,7 @@ static int htWalkHistory(HistCursor *pCur, sqlite3 *db, const char *zTableName){
       if(rc==SQLITE_OK){
         if(doltliteFindTableRootByName(aT,nT,zTableName,&tableRoot,&flags)==SQLITE_OK)
           rc = htScanAtCommit(pCur,cs,pCache,&tableRoot,flags,hexBuf,commit.zName,commit.timestamp);
-        sqlite3_free(aT);
+        doltliteFreeCatalog(aT,nT);
       }
       if( rc!=SQLITE_OK ){ doltliteCommitClear(&commit); break; }
     }

--- a/src/doltlite_ref.c
+++ b/src/doltlite_ref.c
@@ -229,18 +229,18 @@ int doltliteForEachUserTable(
     if( aTables[i].zName && aTables[i].iTable > 1 ){
       char *zMod = sqlite3_mprintf("%s%s", zPrefix, aTables[i].zName);
       if( !zMod ){
-        sqlite3_free(aTables);
+        doltliteFreeCatalog(aTables, nTables);
         return SQLITE_NOMEM;
       }
       rc = sqlite3_create_module(db, zMod, pModule, 0);
       sqlite3_free(zMod);
       if( rc!=SQLITE_OK ){
-        sqlite3_free(aTables);
+        doltliteFreeCatalog(aTables, nTables);
         return rc;
       }
     }
   }
-  sqlite3_free(aTables);
+  doltliteFreeCatalog(aTables, nTables);
   return SQLITE_OK;
 }
 

--- a/src/doltlite_schema_diff.c
+++ b/src/doltlite_schema_diff.c
@@ -166,7 +166,7 @@ int loadSchemaFromCatalog(
       break;
     }
   }
-  sqlite3_free(aTables);
+  doltliteFreeCatalog(aTables, nTables);
 
   if( prollyHashIsEmpty(&masterRoot) ){
     *ppEntries = 0; *pnEntries = 0;
@@ -622,8 +622,8 @@ static int sdFilter(sqlite3_vtab_cursor *cur,
 sd_filter_done:
   freeSchemaEntries(aFrom, nFrom);
   freeSchemaEntries(aTo, nTo);
-  sqlite3_free(aFromTables);
-  sqlite3_free(aToTables);
+  doltliteFreeCatalog(aFromTables, nFromTables);
+  doltliteFreeCatalog(aToTables, nToTables);
   if( freeRangeRefs ){
     sqlite3_free((char*)zFromRef);
     sqlite3_free((char*)zToRef);

--- a/src/doltlite_schema_merge.c
+++ b/src/doltlite_schema_merge.c
@@ -170,13 +170,17 @@ int migrateSchemaRowData(
   rc = doltliteLoadCatalog(db, pAncCatHash, &aAncTables, &nAncTables, 0);
   if( rc!=SQLITE_OK ) return rc;
   rc = doltliteLoadCatalog(db, pTheirCatHash, &aTheirTables, &nTheirTables, 0);
-  if( rc!=SQLITE_OK ){ sqlite3_free(aAncTables); return rc; }
+  if( rc!=SQLITE_OK ){
+    doltliteFreeCatalog(aAncTables, nAncTables);
+    return rc;
+  }
 
 
   rc = loadSchemaFromCatalog(db, cs, pCache, pTheirCatHash,
                               &aTheirSchema, &nTheirSchema);
   if( rc!=SQLITE_OK ){
-    sqlite3_free(aTheirTables);
+    doltliteFreeCatalog(aAncTables, nAncTables);
+    doltliteFreeCatalog(aTheirTables, nTheirTables);
     return rc;
   }
 
@@ -405,8 +409,8 @@ next_action:
   }
 
   freeSchemaEntries(aTheirSchema, nTheirSchema);
-  sqlite3_free(aTheirTables);
-  sqlite3_free(aAncTables);
+  doltliteFreeCatalog(aTheirTables, nTheirTables);
+  doltliteFreeCatalog(aAncTables, nAncTables);
   return rc;
 }
 

--- a/src/doltlite_status.c
+++ b/src/doltlite_status.c
@@ -260,7 +260,9 @@ static int statusFilter(sqlite3_vtab_cursor *pCursor,
   }
 
 status_done:
-  sqlite3_free(aHead);sqlite3_free(aStaged);sqlite3_free(aWorking);
+  doltliteFreeCatalog(aHead, nHead);
+  doltliteFreeCatalog(aStaged, nStaged);
+  doltliteFreeCatalog(aWorking, nWorking);
   return rc;
 }
 


### PR DESCRIPTION
Follow-up to #461. Applies ``doltliteFreeCatalog`` to the remaining call sites of ``doltliteLoadCatalog`` that had the same "free the array backbone but not the per-entry zName" leak.

## Two shapes of caller

**(A) Read-only consumers** — just walk the returned array and free at the end. Mechanical replacement of ``sqlite3_free(aX)`` with ``doltliteFreeCatalog(aX, nX)``:

- ``doltlite_at.c``, ``doltlite_history.c``, ``doltlite_ref.c``
- ``doltlite_status.c`` (``statusFilter``)
- ``doltlite_diff.c`` (``collectSummaryForWorking`` + ``collectSummaryForCommit``)
- ``doltlite_diff_table.c`` (``loadTblRootAtCommit``)
- ``doltlite_diff_stat.c`` (``dsComputeTableStats``, ``dsCollectTableNames``, ``dssFilter``)
- ``doltlite_schema_diff.c``, ``doltlite_schema_merge.c``
- ``doltlite_blame.c``, ``doltlite_dbpage.c``

**(B) Shallow-copy consumers** — move ``TableEntry`` values between arrays (the source transfers zName ownership non-explicitly). Rewritten as **dup-on-copy** so each array has independent ownership and can be freed with ``doltliteFreeCatalog``:

- ``doltlite_branch.c`` checkout-paths branch (``aWorking`` ← ``aSource`` append / overwrite / memmove-delete)
- ``doltlite.c`` ``doltliteAddFunc`` explicit-name path (``aStaged`` ← ``aWorking``)
- ``doltlite.c`` ``doltliteCommitFunc`` ``addModifiedOnly`` path (``aStaged`` ← ``aWorking``)
- ``doltlite.c`` ``doltliteResetFunc`` path-branch (``aStaged`` ← ``aHead``)
- ``doltlite.c`` ``doltliteResetFunc`` ``--hard`` untracked-preserve (``aWorking`` ← ``aTarget`` in-place overwrite)

## Deliberately left alone

``doltlite_merge.c``'s ``mergeCatalogPass1`` / ``Pass2`` build ``aMerged`` with a **mix** of shallow-copies from ``aOurs`` / ``aTheirs`` / ``aAnc`` (borrowing zName) and fresh ``sqlite3_mprintf`` allocations at line 1259 in the ``i<nTheirs`` loop. Mixed ownership makes any naive free strategy wrong:

- ``doltliteFreeCatalog`` on the sources double-frees the aliased entries
- plain ``sqlite3_free`` on ``aMerged`` leaks the fresh ones

Proper fix requires restructuring pass1/pass2 to always dup into aMerged — that's a bigger surgery and is left for a follow-up. First attempt at treating ``merge.c`` the same way as the others produced ``SIGABRT`` under ``doltlite_reset.sh``'s merge-conflict scenario, confirming the hazard. Reverted the merge change for this PR.

## Test plan
- [x] ``make doltlite`` — clean
- [x] ``bash test/run_doltlite_tests.sh`` — 39/39 suites
- [x] ``bash test/vc_oracle_add_test.sh`` — 16/16
- [x] ``bash test/vc_oracle_status_test.sh`` — 11/11
- [x] ``bash test/vc_oracle_branch_test.sh`` — 16/16
- [x] ``bash test/vc_oracle_reset_test.sh`` — 15/15

🤖 Generated with [Claude Code](https://claude.com/claude-code)