### PR TITLE
Use hash-based rollback authority

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -87,8 +87,6 @@ int doltliteFlushCatalogToHash(sqlite3 *db, ProllyHash *pHash);
 
 typedef struct DoltliteTxnState DoltliteTxnState;
 struct DoltliteTxnState {
-  u8 *pRefsBlob;
-  int nRefsBlob;
   ProllyHash refsHash;
   char *zSessionBranch;
   ProllyHash sessionHead;
@@ -100,22 +98,17 @@ struct DoltliteTxnState {
 };
 
 static void doltliteTxnStateClear(DoltliteTxnState *p){
-  sqlite3_free(p->pRefsBlob);
   sqlite3_free(p->zSessionBranch);
   memset(p, 0, sizeof(*p));
 }
 
 static int doltliteSaveTxnState(sqlite3 *db, DoltliteTxnState *p){
   ChunkStore *cs = doltliteGetChunkStore(db);
-  u8 *pCatalog = 0;
-  int nCatalog = 0;
   int rc;
 
   memset(p, 0, sizeof(*p));
   if( !cs ) return SQLITE_ERROR;
 
-  rc = chunkStoreSerializeRefsToBlob(cs, &p->pRefsBlob, &p->nRefsBlob);
-  if( rc!=SQLITE_OK ) return rc;
   memcpy(&p->refsHash, &cs->refsHash, sizeof(ProllyHash));
 
   p->zSessionBranch = sqlite3_mprintf("%s", doltliteGetSessionBranch(db));
@@ -129,13 +122,7 @@ static int doltliteSaveTxnState(sqlite3 *db, DoltliteTxnState *p){
                                &p->sessionMergeCommit,
                                &p->sessionConflictsCatalog);
 
-  rc = doltliteFlushAndSerializeCatalog(db, &pCatalog, &nCatalog);
-  if( rc!=SQLITE_OK ){
-    doltliteTxnStateClear(p);
-    return rc;
-  }
-  rc = chunkStorePut(cs, pCatalog, nCatalog, &p->sessionCatalogHash);
-  sqlite3_free(pCatalog);
+  rc = doltliteFlushCatalogToHash(db, &p->sessionCatalogHash);
   if( rc!=SQLITE_OK ){
     doltliteTxnStateClear(p);
   }
@@ -148,9 +135,13 @@ static int doltliteRestoreTxnState(sqlite3 *db, DoltliteTxnState *p){
 
   if( !cs ) return SQLITE_ERROR;
 
-  rc = chunkStoreLoadRefsFromBlob(cs, p->pRefsBlob, p->nRefsBlob);
-  if( rc!=SQLITE_OK ) return rc;
   memcpy(&cs->refsHash, &p->refsHash, sizeof(ProllyHash));
+  if( prollyHashIsEmpty(&p->refsHash) ){
+    chunkStoreClearRefs(cs);
+  }else{
+    rc = chunkStoreReloadRefs(cs);
+    if( rc!=SQLITE_OK ) return rc;
+  }
 
   rc = doltliteSwitchCatalog(db, &p->sessionCatalogHash);
   if( rc!=SQLITE_OK ) return rc;

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -18,8 +18,6 @@ struct RemoteMutationCtx {
 
 typedef struct RemoteSqlState RemoteSqlState;
 struct RemoteSqlState {
-  u8 *pRefsBlob;
-  int nRefsBlob;
   ProllyHash refsHash;
   char *zSessionBranch;
   ProllyHash sessionHead;
@@ -31,7 +29,6 @@ struct RemoteSqlState {
 };
 
 static void remoteSqlStateClear(RemoteSqlState *p){
-  sqlite3_free(p->pRefsBlob);
   sqlite3_free(p->zSessionBranch);
   memset(p, 0, sizeof(*p));
 }
@@ -41,14 +38,10 @@ static void remoteSqlStateClear(RemoteSqlState *p){
 ** the working set pointing at chunks we're about to roll back —
 ** this state is the snapshot we restore to if something errors. */
 static int remoteSqlStateSave(sqlite3 *db, ChunkStore *cs, RemoteSqlState *p){
-  u8 *pCatalog = 0;
-  int nCatalog = 0;
   int rc;
 
   memset(p, 0, sizeof(*p));
 
-  rc = chunkStoreSerializeRefsToBlob(cs, &p->pRefsBlob, &p->nRefsBlob);
-  if( rc!=SQLITE_OK ) return rc;
   memcpy(&p->refsHash, &cs->refsHash, sizeof(ProllyHash));
 
   p->zSessionBranch = sqlite3_mprintf("%s", doltliteGetSessionBranch(db));
@@ -62,13 +55,7 @@ static int remoteSqlStateSave(sqlite3 *db, ChunkStore *cs, RemoteSqlState *p){
                                &p->sessionMergeCommit,
                                &p->sessionConflictsCatalog);
 
-  rc = doltliteFlushAndSerializeCatalog(db, &pCatalog, &nCatalog);
-  if( rc!=SQLITE_OK ){
-    remoteSqlStateClear(p);
-    return rc;
-  }
-  rc = chunkStorePut(cs, pCatalog, nCatalog, &p->sessionCatalogHash);
-  sqlite3_free(pCatalog);
+  rc = doltliteFlushCatalogToHash(db, &p->sessionCatalogHash);
   if( rc!=SQLITE_OK ){
     remoteSqlStateClear(p);
   }
@@ -78,9 +65,13 @@ static int remoteSqlStateSave(sqlite3 *db, ChunkStore *cs, RemoteSqlState *p){
 static int remoteSqlStateRestore(sqlite3 *db, ChunkStore *cs, RemoteSqlState *p){
   int rc;
 
-  rc = chunkStoreLoadRefsFromBlob(cs, p->pRefsBlob, p->nRefsBlob);
-  if( rc!=SQLITE_OK ) return rc;
   memcpy(&cs->refsHash, &p->refsHash, sizeof(ProllyHash));
+  if( prollyHashIsEmpty(&p->refsHash) ){
+    chunkStoreClearRefs(cs);
+  }else{
+    rc = chunkStoreReloadRefs(cs);
+    if( rc!=SQLITE_OK ) return rc;
+  }
 
   rc = doltliteSwitchCatalog(db, &p->sessionCatalogHash);
   if( rc!=SQLITE_OK ) return rc;

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -112,9 +112,6 @@ struct TableEntry {
 typedef struct SavepointTableEntry SavepointTableEntry;
 struct SavepointTableEntry {
   Pgno iTable;
-  ProllyHash root;
-  ProllyHash schemaHash;
-  u8 flags;
   u8 pendingFlushSeekEdits;
 };
 
@@ -251,6 +248,7 @@ struct Btree {
   int nSavepointAlloc;
 
   struct SavepointTableState {
+    ProllyHash catalogHash;
     SavepointTableEntry *aTables;
 
     SavepointPendingSnapshot *aPendingSnapshot;
@@ -1466,6 +1464,7 @@ static void freeSavepointTables(struct SavepointTableState *pState){
     sqlite3_free(pState->aTables);
     pState->aTables = 0;
   }
+  memset(&pState->catalogHash, 0, sizeof(pState->catalogHash));
   memset(&pState->stagedCatalog, 0, sizeof(pState->stagedCatalog));
   pState->isMerging = 0;
   memset(&pState->mergeCommitHash, 0, sizeof(pState->mergeCommitHash));
@@ -1498,15 +1497,21 @@ static int captureSavepointTables(
   struct SavepointTableState *pState
 ){
   int k;
+  int rc;
+  u8 *catData = 0;
+  int nCatData = 0;
+  memset(&pState->catalogHash, 0, sizeof(pState->catalogHash));
+  rc = serializeCatalog(pBtree, &catData, &nCatData);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = chunkStorePut(&pBtree->pBt->store, catData, nCatData, &pState->catalogHash);
+  sqlite3_free(catData);
+  if( rc!=SQLITE_OK ) return rc;
   if( pBtree->nTables<=0 ) return SQLITE_OK;
   pState->aTables = sqlite3_malloc(
       pBtree->nTables * (int)sizeof(SavepointTableEntry));
   if( !pState->aTables ) return SQLITE_NOMEM;
   for(k=0; k<pBtree->nTables; k++){
     pState->aTables[k].iTable = pBtree->aTables[k].iTable;
-    pState->aTables[k].root = pBtree->aTables[k].root;
-    pState->aTables[k].schemaHash = pBtree->aTables[k].schemaHash;
-    pState->aTables[k].flags = pBtree->aTables[k].flags;
     pState->aTables[k].pendingFlushSeekEdits =
         pBtree->aTables[k].pendingFlushSeekEdits;
   }
@@ -1771,6 +1776,9 @@ static int restoreTablesFromSavepoint(
 ){
   ProllyMutMap **apPending = 0;
   int k;
+  int rc;
+  struct TableEntry *aCurrent = pBtree->aTables;
+  int nCurrent = pBtree->nTables;
 
   if( pState->nTables>0 ){
     apPending = sqlite3_malloc64(
@@ -1790,12 +1798,12 @@ static int restoreTablesFromSavepoint(
     }
   }
 
-  for(k=0; k<pBtree->nTables; k++){
-    ProllyMutMap *pMap = pBtree->aTables[k].pPending;
+  for(k=0; k<nCurrent; k++){
+    ProllyMutMap *pMap = aCurrent[k].pPending;
     int iSaved;
     if( !pMap ) continue;
     iSaved = findSavepointTableIndexInArray(
-        pState->aTables, pState->nTables, pBtree->aTables[k].iTable);
+        pState->aTables, pState->nTables, aCurrent[k].iTable);
     if( iSaved>=0 ){
 
       apPending[iSaved] = pMap;
@@ -1805,24 +1813,43 @@ static int restoreTablesFromSavepoint(
     }
   }
 
-  if( pState->nTables>0 ){
-    for(k=0; k<pState->nTables; k++){
-      pBtree->aTables[k].iTable = pState->aTables[k].iTable;
-      pBtree->aTables[k].root = pState->aTables[k].root;
-      pBtree->aTables[k].schemaHash = pState->aTables[k].schemaHash;
-      pBtree->aTables[k].flags = pState->aTables[k].flags;
-      pBtree->aTables[k].pendingFlushSeekEdits =
-          pState->aTables[k].pendingFlushSeekEdits;
-      pBtree->aTables[k].zName = 0;
-      pBtree->aTables[k].pPending = apPending[k];
-    }
-  }else{
+  if( prollyHashIsEmpty(&pState->catalogHash) ){
     sqlite3_free(pBtree->aTables);
     pBtree->aTables = 0;
+    pBtree->nTables = 0;
     pBtree->nTablesAlloc = 0;
+    initDefaultMeta(pBtree);
+    pBtree->iNextTable = 2;
+  }else{
+    u8 *catData = 0;
+    int nCatData = 0;
+    rc = chunkStoreGet(&pBtree->pBt->store, &pState->catalogHash, &catData, &nCatData);
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(apPending);
+      return rc;
+    }
+    rc = deserializeCatalog(pBtree, catData, nCatData);
+    sqlite3_free(catData);
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(apPending);
+      return rc;
+    }
   }
 
-  pBtree->nTables = pState->nTables;
+  if( pState->nTables>0 ){
+    for(k=0; k<pState->nTables; k++){
+      int idx = findTableIndexInArray(
+          pBtree->aTables, pBtree->nTables, pState->aTables[k].iTable);
+      if( idx < 0 ){
+        sqlite3_free(apPending);
+        return SQLITE_CORRUPT;
+      }
+      pBtree->aTables[idx].pendingFlushSeekEdits =
+          pState->aTables[k].pendingFlushSeekEdits;
+      pBtree->aTables[idx].pPending = apPending[k];
+    }
+  }
+
   pBtree->iNextTable = pState->iNextTable;
   sqlite3_free(apPending);
   return SQLITE_OK;
@@ -1841,6 +1868,7 @@ static int pushSavepoint(Btree *pBtree){
   }
 
   pState = &pBtree->aSavepointTables[pBtree->nSavepoint];
+  memset(&pState->catalogHash, 0, sizeof(pState->catalogHash));
   pState->aTables = 0;
   pState->aPendingSnapshot = 0;
   pState->nPendingSnapshot = 0;

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -264,10 +264,7 @@ struct Btree {
     ProllyHash conflictsCatalogHash;
   } *aSavepointTables;
 
-
-  struct TableEntry *aCommittedTables;
-  int nCommittedTables;
-  Pgno iCommittedNextTable;
+  ProllyHash committedCatalogHash;
   ProllyHash committedStagedCatalog;
   u8 committedIsMerging;
   ProllyHash committedMergeCommitHash;
@@ -2158,7 +2155,6 @@ static int prollyBtreeClose(Btree *p){
     }
     sqlite3_free(p->aSavepointTables);
   }
-  sqlite3_free(p->aCommittedTables);
 
   pBt->nRef--;
   if( pBt->nRef<=0 ){
@@ -2667,19 +2663,19 @@ static int prollyBtreeBeginTrans(Btree *p, int wrFlag, int *pSchemaVersion){
       return rc;
     }
 
-    sqlite3_free(p->aCommittedTables);
-    p->aCommittedTables = 0;
-    p->nCommittedTables = 0;
-    if( p->nTables > 0 ){
-      p->aCommittedTables = sqlite3_malloc(
-          p->nTables * (int)sizeof(struct TableEntry));
-      if( p->aCommittedTables ){
-        memcpy(p->aCommittedTables, p->aTables,
-               p->nTables * sizeof(struct TableEntry));
-        p->nCommittedTables = p->nTables;
+    memset(&p->committedCatalogHash, 0, sizeof(ProllyHash));
+    {
+      const char *zBr = p->zBranch ? p->zBranch : "main";
+      int rc2 = btreeReadWorkingCatalog(&pBt->store, zBr,
+                                        &p->committedCatalogHash, 0);
+      if( rc2!=SQLITE_OK && rc2!=SQLITE_NOTFOUND ){
+        chunkStoreUnlock(&pBt->store);
+        return rc2;
+      }
+      if( rc2==SQLITE_NOTFOUND ){
+        memset(&p->committedCatalogHash, 0, sizeof(ProllyHash));
       }
     }
-    p->iCommittedNextTable = p->iNextTable;
     p->committedStagedCatalog = p->stagedCatalog;
     p->committedIsMerging = p->isMerging;
     p->committedMergeCommitHash = p->mergeCommitHash;
@@ -2826,24 +2822,22 @@ int sqlite3BtreeCommit(Btree *p){
 }
 
 static int restoreFromCommitted(Btree *p){
-  if( p->aCommittedTables ){
+  if( prollyHashIsEmpty(&p->committedCatalogHash) ){
     sqlite3_free(p->aTables);
-    if( p->nCommittedTables > 0 ){
-      p->aTables = sqlite3_malloc(
-          p->nCommittedTables * (int)sizeof(struct TableEntry));
-      if( !p->aTables ){
-        p->nTables = 0;
-        p->nTablesAlloc = 0;
-        return SQLITE_NOMEM;
-      }
-      memcpy(p->aTables, p->aCommittedTables,
-             p->nCommittedTables * sizeof(struct TableEntry));
-    } else {
-      p->aTables = 0;
-    }
-    p->nTables = p->nCommittedTables;
-    p->nTablesAlloc = p->nCommittedTables;
-    p->iNextTable = p->iCommittedNextTable;
+    p->aTables = 0;
+    p->nTables = 0;
+    p->nTablesAlloc = 0;
+    initDefaultMeta(p);
+    p->iNextTable = 2;
+  }else{
+    u8 *catData = 0;
+    int nCatData = 0;
+    int rc = chunkStoreGet(&p->pBt->store, &p->committedCatalogHash,
+                           &catData, &nCatData);
+    if( rc!=SQLITE_OK ) return rc;
+    rc = deserializeCatalog(p, catData, nCatData);
+    sqlite3_free(catData);
+    if( rc!=SQLITE_OK ) return rc;
   }
   p->stagedCatalog = p->committedStagedCatalog;
   p->isMerging = p->committedIsMerging;


### PR DESCRIPTION
## Summary
- replace command-level rollback snapshots with refs and catalog hashes instead of serialized mutable state
- replace committed write-transaction rollback snapshots with a saved committed catalog hash
- replace savepoint table rollback authority with a saved catalog hash plus per-table pending metadata reattachment

## Verification
- bash test/lint_layers.sh src
- cd build && bash ../test/oracle_savepoints_test.sh ./doltlite ./sqlite3
- cd build && bash ../test/sql_oracle_test.sh ./doltlite ./sqlite3
- cd build && bash ../test/vc_oracle_rebase_test.sh ./doltlite dolt
- bash test/remote_test.sh ./build/doltlite