### PR TITLE
Refactor txn restore failure handling

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -155,6 +155,16 @@ static int doltliteRestoreTxnState(sqlite3 *db, DoltliteTxnState *p){
   return SQLITE_OK;
 }
 
+static int doltliteRestoreTxnStateOnFailure(
+  sqlite3 *db,
+  DoltliteTxnState *pSaved,
+  int opRc
+){
+  int rc = doltliteRestoreTxnState(db, pSaved);
+  doltliteTxnStateClear(pSaved);
+  return rc==SQLITE_OK ? opRc : rc;
+}
+
 /* Commit-race guard. Takes the graph lock, refreshes ref state from
 ** disk, then verifies the session's head still matches the branch
 ** tip. If another connection advanced the branch between the start
@@ -393,9 +403,7 @@ static int doltliteAdvanceBranch(
     rc = chunkStoreUpdateBranch(cs, branch, pNewHead);
   }
   if( rc!=SQLITE_OK ){
-    int rc2 = doltliteRestoreTxnState(db, &saved);
-    doltliteTxnStateClear(&saved);
-    return rc2==SQLITE_OK ? rc : rc2;
+    return doltliteRestoreTxnStateOnFailure(db, &saved, rc);
   }
 
   doltliteSetSessionHead(db, pNewHead);
@@ -403,9 +411,7 @@ static int doltliteAdvanceBranch(
 
   rc = doltlitePersistWorkingSet(db);
   if( rc!=SQLITE_OK ){
-    int rc2 = doltliteRestoreTxnState(db, &saved);
-    doltliteTxnStateClear(&saved);
-    return rc2==SQLITE_OK ? rc : rc2;
+    return doltliteRestoreTxnStateOnFailure(db, &saved, rc);
   }
 
   doltliteTxnStateClear(&saved);
@@ -1464,10 +1470,9 @@ static int mergeFastForward(
   }
   if( graphLocked ) chunkStoreUnlock(cs);
   if( rc!=SQLITE_OK ){
-    int rc2 = doltliteRestoreTxnState(db, &savedState);
-    doltliteTxnStateClear(&savedState);
     doltliteCommitClear(&theirCommit);
-    sqlite3_result_error_code(context, rc2==SQLITE_OK ? rc : rc2);
+    sqlite3_result_error_code(context,
+        doltliteRestoreTxnStateOnFailure(db, &savedState, rc));
     return rc;
   }
   doltliteTxnStateClear(&savedState);
@@ -1983,15 +1988,13 @@ static void doltliteMergeFunc(
     doltliteCommitClear(&ourCommit);
     doltliteCommitClear(&theirCommit);
     if( rc!=SQLITE_OK ){
-      int rc2;
       if( graphLocked ){
         chunkStoreUnlock(cs);
         graphLocked = 0;
       }
-      rc2 = doltliteRestoreTxnState(db, &savedState);
-      doltliteTxnStateClear(&savedState);
       freeSchemaMergeActions(aSchemaActions, nSchemaActions);
-      sqlite3_result_error_code(context, rc2==SQLITE_OK ? rc : rc2);
+      sqlite3_result_error_code(context,
+          doltliteRestoreTxnStateOnFailure(db, &savedState, rc));
       return;
     }
 
@@ -2025,14 +2028,12 @@ static void doltliteMergeFunc(
       }
       freeSchemaMergeActions(aSchemaActions, nSchemaActions);
       if( rc!=SQLITE_OK ){
-        int rc2;
         if( graphLocked ){
           chunkStoreUnlock(cs);
           graphLocked = 0;
         }
-        rc2 = doltliteRestoreTxnState(db, &savedState);
-        doltliteTxnStateClear(&savedState);
-        sqlite3_result_error_code(context, rc2==SQLITE_OK ? rc : rc2);
+        sqlite3_result_error_code(context,
+            doltliteRestoreTxnStateOnFailure(db, &savedState, rc));
         return;
       }
     }
@@ -2045,9 +2046,8 @@ static void doltliteMergeFunc(
       graphLocked = 0;
     }
     if( rc!=SQLITE_OK ){
-      int rc2 = doltliteRestoreTxnState(db, &savedState);
-      doltliteTxnStateClear(&savedState);
-      sqlite3_result_error_code(context, rc2==SQLITE_OK ? rc : rc2);
+      sqlite3_result_error_code(context,
+          doltliteRestoreTxnStateOnFailure(db, &savedState, rc));
       return;
     }
     doltliteTxnStateClear(&savedState);
@@ -2077,9 +2077,8 @@ static void doltliteMergeFunc(
       graphLocked = 0;
     }
     if( rc!=SQLITE_OK ){
-      int rc2 = doltliteRestoreTxnState(db, &savedState);
-      doltliteTxnStateClear(&savedState);
-      sqlite3_result_error_code(context, rc2==SQLITE_OK ? rc : rc2);
+      sqlite3_result_error_code(context,
+          doltliteRestoreTxnStateOnFailure(db, &savedState, rc));
       return;
     }
     doltliteTxnStateClear(&savedState);
@@ -2165,9 +2164,7 @@ apply_rollback:
     chunkStoreUnlock(cs);
   }
   {
-    int rc2 = doltliteRestoreTxnState(db, &savedState);
-    doltliteTxnStateClear(&savedState);
-    return rc2==SQLITE_OK ? rc : rc2;
+    return doltliteRestoreTxnStateOnFailure(db, &savedState, rc);
   }
 }
 
@@ -2637,9 +2634,7 @@ static int doltliteRebaseLinearReplay(
 
 rollback:
   if( savedInit ){
-    int rc2 = doltliteRestoreTxnState(db, &saved);
-    doltliteTxnStateClear(&saved);
-    (void)rc2;
+    (void)doltliteRestoreTxnStateOnFailure(db, &saved, rc);
   }
   (void)cs;
   sqlite3_free(aReplay);

--- a/src/doltlite_blame.c
+++ b/src/doltlite_blame.c
@@ -432,6 +432,47 @@ static int blameUnresolvedCount(BlameCursor *pCur){
   return n;
 }
 
+/* For merge blame we need the merge base across every parent, not just
+** the first two. Fold pairwise merge-base resolution left-to-right:
+** base(p0,p1,p2) := base(base(p0,p1), p2). If any step has no common
+** ancestor, the merge has no shared base across all parents. */
+static int blameFindAllParentMergeBase(
+  sqlite3 *db,
+  const DoltliteCommit *pCommit,
+  ProllyHash *pBaseHash
+){
+  ProllyHash base;
+  int i;
+  int rc;
+
+  memset(&base, 0, sizeof(base));
+  if( doltliteCommitParentCount(pCommit) < 2 ){
+    memset(pBaseHash, 0, sizeof(*pBaseHash));
+    return SQLITE_OK;
+  }
+
+  base = *doltliteCommitParentHash(pCommit, 0);
+  for(i=1; i<doltliteCommitParentCount(pCommit); i++){
+    ProllyHash nextBase;
+    const ProllyHash *pParent = doltliteCommitParentHash(pCommit, i);
+    if( !pParent || prollyHashIsEmpty(pParent) || prollyHashIsEmpty(&base) ){
+      memset(&base, 0, sizeof(base));
+      break;
+    }
+    memset(&nextBase, 0, sizeof(nextBase));
+    rc = doltliteFindAncestor(db, &base, pParent, &nextBase);
+    if( rc==SQLITE_NOTFOUND || prollyHashIsEmpty(&nextBase) ){
+      memset(&base, 0, sizeof(base));
+      break;
+    }
+    if( rc!=SQLITE_OK ) return rc;
+    base = nextBase;
+  }
+
+  *pBaseHash = base;
+  return SQLITE_OK;
+}
+
 /* Main blame walk. Starts from HEAD, walks first-parent, and at
 ** each commit applies the linear or merge comparison rule. */
 static int blameWalk(
@@ -464,12 +505,12 @@ static int blameWalk(
     }
 
     if( commit.nParents >= 2 ){
-      /* Merge commit: compare against the merge base of parents. */
+      /* Merge commit: compare against the merge base of all parents. */
       ProllyHash baseHash;
       DoltliteCommit baseCommit;
       memset(&baseHash, 0, sizeof(baseHash));
-      rc = doltliteFindAncestor(db, &commit.aParents[0], &commit.aParents[1], &baseHash);
-      if( rc!=SQLITE_OK && rc!=SQLITE_NOTFOUND ){
+      rc = blameFindAllParentMergeBase(db, &commit, &baseHash);
+      if( rc!=SQLITE_OK ){
         doltliteCommitClear(&commit);
         return rc;
       }

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -1026,6 +1026,114 @@ static void run_commit_parent_limit(void){
   sqlite3_free(pBlob);
 }
 
+static void run_blame_all_parents_merge_base(void){
+  sqlite3 *db = 0;
+  ChunkStore *cs = 0;
+  char dbpath[256];
+  ProllyHash b1Hash, b2Hash, b3Hash, curHeadHash, mergeHash;
+  ProllyHash base12Hash, base123Hash;
+  DoltliteCommit b2Commit, mergeCommit;
+  u8 *pCommitData = 0;
+  int nCommitData = 0;
+  int rc;
+  const char *res;
+
+  printf("=== Blame All-Parents Merge Base Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_blame_all_parents_merge_base");
+  remove_db(dbpath);
+
+  memset(&b1Hash, 0, sizeof(b1Hash));
+  memset(&b2Hash, 0, sizeof(b2Hash));
+  memset(&b3Hash, 0, sizeof(b3Hash));
+  memset(&curHeadHash, 0, sizeof(curHeadHash));
+  memset(&mergeHash, 0, sizeof(mergeHash));
+  memset(&base12Hash, 0, sizeof(base12Hash));
+  memset(&base123Hash, 0, sizeof(base123Hash));
+  memset(&b2Commit, 0, sizeof(b2Commit));
+  memset(&mergeCommit, 0, sizeof(mergeCommit));
+
+  check("open_db_for_blame_all_parents", open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_base_for_blame_all_parents", execsql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'base');"
+    "SELECT dolt_commit('-A', '-m', 'BASE');"
+    "SELECT dolt_branch('b1');"
+    "SELECT dolt_checkout('b1');"
+    "UPDATE t SET v='one' WHERE id=1;"
+    "SELECT dolt_commit('-A', '-m', 'B1');")==SQLITE_OK);
+  doltliteGetSessionHead(db, &b1Hash);
+  check("have_b1_head_for_blame_all_parents", !prollyHashIsEmpty(&b1Hash));
+
+  check("setup_b2_for_blame_all_parents", execsql(db,
+    "SELECT dolt_branch('b2');"
+    "SELECT dolt_checkout('b2');"
+    "INSERT INTO t VALUES(2,'side');"
+    "SELECT dolt_commit('-A', '-m', 'B2');")==SQLITE_OK);
+  doltliteGetSessionHead(db, &b2Hash);
+  check("have_b2_head_for_blame_all_parents", !prollyHashIsEmpty(&b2Hash));
+
+  check("setup_b3_for_blame_all_parents", execsql(db,
+    "SELECT dolt_checkout('main');"
+    "SELECT dolt_branch('b3');"
+    "SELECT dolt_checkout('b3');"
+    "INSERT INTO t VALUES(3,'other');"
+    "SELECT dolt_commit('-A', '-m', 'B3');")==SQLITE_OK);
+  doltliteGetSessionHead(db, &b3Hash);
+  check("have_b3_head_for_blame_all_parents", !prollyHashIsEmpty(&b3Hash));
+
+  check("ancestor_b1_b2_for_blame_all_parents",
+        doltliteFindAncestor(db, &b1Hash, &b2Hash, &base12Hash)==SQLITE_OK
+        && !prollyHashIsEmpty(&base12Hash)
+        && prollyHashCompare(&base12Hash, &b1Hash)==0);
+  check("ancestor_b12_b3_for_blame_all_parents",
+        doltliteFindAncestor(db, &base12Hash, &b3Hash, &base123Hash)==SQLITE_OK
+        && !prollyHashIsEmpty(&base123Hash)
+        && prollyHashCompare(&base123Hash, &b1Hash)!=0);
+
+  check("checkout_b2_before_synthetic_merge", execsql(db,
+    "SELECT dolt_checkout('b2');")==SQLITE_OK);
+  doltliteGetSessionHead(db, &curHeadHash);
+  check("head_is_b2_before_synthetic_merge",
+        prollyHashCompare(&curHeadHash, &b2Hash)==0);
+  check("load_b2_commit_for_blame_all_parents",
+        doltliteLoadCommit(db, &b2Hash, &b2Commit)==SQLITE_OK);
+
+  cs = doltliteGetChunkStore(db);
+  check("have_chunk_store_for_blame_all_parents", cs!=0);
+  if( cs ){
+    mergeCommit.parentHash = b1Hash;
+    mergeCommit.catalogHash = b2Commit.catalogHash;
+    mergeCommit.timestamp = b2Commit.timestamp + 1;
+    mergeCommit.zName = sqlite3_mprintf("oracle");
+    mergeCommit.zEmail = sqlite3_mprintf("oracle@test");
+    mergeCommit.zMessage = sqlite3_mprintf("OCTO");
+    mergeCommit.nParents = 3;
+    mergeCommit.aParents[0] = b1Hash;
+    mergeCommit.aParents[1] = b2Hash;
+    mergeCommit.aParents[2] = b3Hash;
+    check("serialize_octopus_commit_for_blame_all_parents",
+          doltliteCommitSerialize(&mergeCommit, &pCommitData, &nCommitData)==SQLITE_OK);
+    check("store_octopus_commit_for_blame_all_parents",
+          chunkStorePut(cs, pCommitData, nCommitData, &mergeHash)==SQLITE_OK);
+    check("commit_octopus_commit_for_blame_all_parents",
+          chunkStoreCommit(cs)==SQLITE_OK);
+    doltliteSetSessionHead(db, &mergeHash);
+    doltliteSetSessionStaged(db, &mergeCommit.catalogHash);
+    check("switch_catalog_to_octopus_commit_for_blame_all_parents",
+          doltliteSwitchCatalog(db, &mergeCommit.catalogHash)==SQLITE_OK);
+  }
+
+  res = exec1(db, "SELECT message FROM dolt_blame_t WHERE id = 1;");
+  check("blame_query_returns_row_for_all_parents", res[0]!=0);
+  check("blame_uses_all_parents_merge_base", strcmp(res, "OCTO")==0);
+
+  sqlite3_free(pCommitData);
+  doltliteCommitClear(&b2Commit);
+  doltliteCommitClear(&mergeCommit);
+  sqlite3_close(db);
+  remove_db(dbpath);
+}
+
 static void run_merge_persist_failure(void){
   sqlite3 *db = 0;
   char dbpath[256];
@@ -2905,6 +3013,7 @@ static const RegressionCase aCases[] = {
   { "clone_persist_failure", "Clone Persist Failure Test", run_clone_persist_failure },
   { "resolve_ref_non_commit", "Resolve Ref Non-Commit Test", run_resolve_ref_non_commit },
   { "commit_parent_limit", "Commit Parent Limit Test", run_commit_parent_limit },
+  { "blame_all_parents_merge_base", "Blame All-Parents Merge Base Test", run_blame_all_parents_merge_base },
   { "merge_persist_failure", "Merge Persist Failure Test", run_merge_persist_failure },
   { "cherry_pick_stale_branch", "Cherry-pick Stale Branch Test", run_cherry_pick_stale_branch },
   { "branches_metadata_corruption", "Branches Metadata Corruption Test", run_branches_metadata_corruption },


### PR DESCRIPTION
## Summary
- add a shared helper for restoring saved transaction state on command failure
- use it in branch advance, merge fast-forward, merge rollback paths, applyMergedCatalogAndCommit, and linear rebase rollback
- reduce duplicated restore-and-clear logic in the highest-risk command/session flows

## Verification
- make -C build doltlite
- bash test/lint_layers.sh src
- cd build && bash ../test/doltlite_reset.sh
- cd build && bash ../test/vc_oracle_merge_test.sh ./doltlite dolt
- bash test/remote_test.sh ./build/doltlite
- cd build && bash ../test/vc_oracle_rebase_test.sh ./doltlite dolt
- cd build && bash ../test/sql_oracle_test.sh ./doltlite ./sqlite3