### PR TITLE
Refactor remote restore and persistence helpers

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -134,6 +134,7 @@ static int csMergeIndex(ChunkStore *cs, ChunkIndexEntry **ppMerged,
                         int *pnMerged);
 static int csGrowPending(ChunkStore *cs);
 static int csGrowWriteBuf(ChunkStore *cs, int nNeeded);
+static void csPendHTClear(ChunkStore *cs);
 
 static int csReplayWalRegion(ChunkStore *cs, int updateManifest);
 static int csReplayWal(ChunkStore *cs){ return csReplayWalRegion(cs, 1); }
@@ -307,6 +308,70 @@ static void csCaptureReloadState(ChunkStore *cs, ChunkStoreReloadState *pSaved){
   pSaved->aIndex = cs->aIndex;
   pSaved->pWalData = cs->pWalData;
   csCaptureSavedRefsState(cs, &pSaved->refs);
+}
+
+static void csReleaseReplayState(
+  ChunkStore *cs,
+  ChunkStoreReplayState *pSaved
+){
+  if( cs->aIndex!=pSaved->aIndex ) sqlite3_free(pSaved->aIndex);
+  sqlite3_free(pSaved->pWalData);
+  csFreeSavedRefsState(&pSaved->refs);
+  memset(pSaved, 0, sizeof(*pSaved));
+}
+
+static void csRollbackReplayState(
+  ChunkStore *cs,
+  ChunkStoreReplayState *pSaved,
+  int nPendingBefore
+){
+  if( cs->aIndex!=pSaved->aIndex ) sqlite3_free(cs->aIndex);
+  sqlite3_free(cs->pWalData);
+  csRestoreReplayState(cs, pSaved);
+  cs->nPending = nPendingBefore;
+  csPendHTClear(cs);
+}
+
+static void csAdoptOpenedStoreState(ChunkStore *pDst, ChunkStore *pSrc){
+  pDst->pFile = pSrc->pFile;
+  pDst->readOnly = pSrc->readOnly;
+  pDst->refsHash = pSrc->refsHash;
+  pDst->committedRefsHash = pSrc->committedRefsHash;
+  pDst->nChunks = pSrc->nChunks;
+  pDst->iIndexOffset = pSrc->iIndexOffset;
+  pDst->nIndexSize = pSrc->nIndexSize;
+  pDst->iWalOffset = pSrc->iWalOffset;
+  pDst->iFileSize = pSrc->iFileSize;
+  pDst->aIndex = pSrc->aIndex;
+  pDst->nIndex = pSrc->nIndex;
+  pDst->nIndexAlloc = pSrc->nIndexAlloc;
+  pDst->pWalData = pSrc->pWalData;
+  pDst->nWalData = pSrc->nWalData;
+  pDst->aBranches = pSrc->aBranches;
+  pDst->nBranches = pSrc->nBranches;
+  pDst->zDefaultBranch = pSrc->zDefaultBranch;
+  pDst->aTags = pSrc->aTags;
+  pDst->nTags = pSrc->nTags;
+  pDst->aRemotes = pSrc->aRemotes;
+  pDst->nRemotes = pSrc->nRemotes;
+  pDst->aTracking = pSrc->aTracking;
+  pDst->nTracking = pSrc->nTracking;
+
+  pSrc->pFile = 0;
+  pSrc->aIndex = 0;
+  pSrc->nIndex = 0;
+  pSrc->nIndexAlloc = 0;
+  pSrc->pWalData = 0;
+  pSrc->nWalData = 0;
+  pSrc->aBranches = 0;
+  pSrc->nBranches = 0;
+  pSrc->zDefaultBranch = 0;
+  pSrc->aTags = 0;
+  pSrc->nTags = 0;
+  pSrc->aRemotes = 0;
+  pSrc->nRemotes = 0;
+  pSrc->aTracking = 0;
+  pSrc->nTracking = 0;
 }
 
 static void csFreeReloadState(ChunkStoreReloadState *pSaved){
@@ -757,19 +822,13 @@ static int csReplayWalRegion(ChunkStore *cs, int updateManifest){
     }
   }
 
-  if( cs->aIndex!=saved.aIndex ) sqlite3_free(saved.aIndex);
-  sqlite3_free(saved.pWalData);
-  csFreeSavedRefsState(&saved.refs);
+  csReleaseReplayState(cs, &saved);
 
   return SQLITE_OK;
 
 replay_error:
   if( haveTmpRefs ) csFreeRefsState(&tmpRefs);
-  if( cs->aIndex!=saved.aIndex ) sqlite3_free(cs->aIndex);
-  sqlite3_free(cs->pWalData);
-  csRestoreReplayState(cs, &saved);
-  cs->nPending = nPendingBefore;
-  csPendHTClear(cs);
+  csRollbackReplayState(cs, &saved, nPendingBefore);
   return rc;
 }
 
@@ -2050,46 +2109,7 @@ static int csReloadFromDisk(ChunkStore *cs){
   if( rc!=SQLITE_OK ) return rc;
 
   csCaptureReloadState(cs, &saved);
-
-  cs->pFile = tmp.pFile;
-  cs->readOnly = tmp.readOnly;
-  cs->refsHash = tmp.refsHash;
-  cs->committedRefsHash = tmp.committedRefsHash;
-  cs->nChunks = tmp.nChunks;
-  cs->iIndexOffset = tmp.iIndexOffset;
-  cs->nIndexSize = tmp.nIndexSize;
-  cs->iWalOffset = tmp.iWalOffset;
-  cs->iFileSize = tmp.iFileSize;
-  cs->aIndex = tmp.aIndex;
-  cs->nIndex = tmp.nIndex;
-  cs->nIndexAlloc = tmp.nIndexAlloc;
-  cs->pWalData = tmp.pWalData;
-  cs->nWalData = tmp.nWalData;
-  cs->aBranches = tmp.aBranches;
-  cs->nBranches = tmp.nBranches;
-  cs->zDefaultBranch = tmp.zDefaultBranch;
-  cs->aTags = tmp.aTags;
-  cs->nTags = tmp.nTags;
-  cs->aRemotes = tmp.aRemotes;
-  cs->nRemotes = tmp.nRemotes;
-  cs->aTracking = tmp.aTracking;
-  cs->nTracking = tmp.nTracking;
-
-  tmp.pFile = 0;
-  tmp.aIndex = 0;
-  tmp.nIndex = 0;
-  tmp.nIndexAlloc = 0;
-  tmp.pWalData = 0;
-  tmp.nWalData = 0;
-  tmp.aBranches = 0;
-  tmp.nBranches = 0;
-  tmp.zDefaultBranch = 0;
-  tmp.aTags = 0;
-  tmp.nTags = 0;
-  tmp.aRemotes = 0;
-  tmp.nRemotes = 0;
-  tmp.aTracking = 0;
-  tmp.nTracking = 0;
+  csAdoptOpenedStoreState(cs, &tmp);
   chunkStoreClose(&tmp);
 
   csFreeReloadState(&saved);

--- a/src/doltlite_remote.c
+++ b/src/doltlite_remote.c
@@ -290,44 +290,50 @@ static int fsSetRefs(DoltliteRemote *pRemote, const u8 *pData, int nData){
   return rc;
 }
 
-static int fsCommit(DoltliteRemote *pRemote){
-  FsRemote *p = (FsRemote*)pRemote;
+static int remoteStorePersistRefs(ChunkStore *pStore){
+  int rc = chunkStoreSerializeRefs(pStore);
+  if( rc==SQLITE_OK ) rc = chunkStoreCommit(pStore);
+  return rc;
+}
+
+static int remoteStorePersistDefaultBranchCatalog(ChunkStore *pStore){
+  const char *zDef = chunkStoreGetDefaultBranch(pStore);
+  ProllyHash branchCommit;
   int rc;
 
-
-  rc = chunkStoreSerializeRefs(&p->store);
-  if( rc!=SQLITE_OK ) return rc;
-
-  rc = chunkStoreCommit(&p->store);
-  if( rc!=SQLITE_OK ) return rc;
-
+  if( !zDef || chunkStoreFindBranch(pStore, zDef, &branchCommit)!=SQLITE_OK ){
+    return SQLITE_OK;
+  }
 
   {
-    const char *zDef = chunkStoreGetDefaultBranch(&p->store);
-    ProllyHash branchCommit;
-    if( zDef && chunkStoreFindBranch(&p->store, zDef, &branchCommit)==SQLITE_OK ){
-      u8 *cdata = 0; int ncdata = 0;
-      rc = chunkStoreGet(&p->store, &branchCommit, &cdata, &ncdata);
-      if( rc!=SQLITE_OK ) return rc;
-      if( cdata ){
-        DoltliteCommit commit;
-        rc = doltliteCommitDeserialize(cdata, ncdata, &commit);
-        if( rc==SQLITE_OK ){
-          rc = chunkStoreWriteBranchWorkingCatalog(&p->store, zDef,
-                                                   &commit.catalogHash, NULL);
-          doltliteCommitClear(&commit);
-        }
-        sqlite3_free(cdata);
-        if( rc!=SQLITE_OK ) return rc;
+    u8 *cdata = 0;
+    int ncdata = 0;
+    rc = chunkStoreGet(pStore, &branchCommit, &cdata, &ncdata);
+    if( rc!=SQLITE_OK ) return rc;
+    if( cdata ){
+      DoltliteCommit commit;
+      rc = doltliteCommitDeserialize(cdata, ncdata, &commit);
+      if( rc==SQLITE_OK ){
+        rc = chunkStoreWriteBranchWorkingCatalog(
+          pStore, zDef, &commit.catalogHash, NULL
+        );
+        doltliteCommitClear(&commit);
       }
-      rc = chunkStoreSerializeRefs(&p->store);
-      if( rc!=SQLITE_OK ) return rc;
-      rc = chunkStoreCommit(&p->store);
+      sqlite3_free(cdata);
       if( rc!=SQLITE_OK ) return rc;
     }
   }
 
-  return SQLITE_OK;
+  return remoteStorePersistRefs(pStore);
+}
+
+static int fsCommit(DoltliteRemote *pRemote){
+  FsRemote *p = (FsRemote*)pRemote;
+  int rc;
+
+  rc = remoteStorePersistRefs(&p->store);
+  if( rc!=SQLITE_OK ) return rc;
+  return remoteStorePersistDefaultBranchCatalog(&p->store);
 }
 
 static void fsClose(DoltliteRemote *pRemote){
@@ -700,10 +706,7 @@ int doltliteFetch(
   if( rc!=SQLITE_OK ) return rc;
 
 
-  rc = chunkStoreSerializeRefs(pLocal);
-  if( rc==SQLITE_OK ) rc = chunkStoreCommit(pLocal);
-
-  return rc;
+  return remoteStorePersistRefs(pLocal);
 }
 
 int doltliteClone(ChunkStore *pLocal, DoltliteRemote *pRemote){

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -133,6 +133,38 @@ static void remoteSqlRestoreAndReport(
   remoteSqlResultError(ctx, opRc, zMsg);
 }
 
+static void remoteSqlClearAndSucceed(
+  sqlite3_context *ctx,
+  RemoteSqlState *pSavedState
+){
+  remoteSqlStateClear(pSavedState);
+  sqlite3_result_int(ctx, 0);
+}
+
+static int remoteSqlOpenNamedRemote(
+  ChunkStore *cs,
+  const char *zRemoteName,
+  const char **pzUrl,
+  DoltliteRemote **ppRemote
+){
+  int rc = chunkStoreFindRemote(cs, zRemoteName, pzUrl);
+  if( rc!=SQLITE_OK || !*pzUrl ){
+    return SQLITE_NOTFOUND;
+  }
+
+  *ppRemote = openRemoteByUrl(cs->pVfs, *pzUrl);
+  if( !*ppRemote ){
+    return SQLITE_CANTOPEN;
+  }
+  return SQLITE_OK;
+}
+
+static int remoteSqlPersistRefs(ChunkStore *cs){
+  int rc = chunkStoreSerializeRefs(cs);
+  if( rc==SQLITE_OK ) rc = chunkStoreCommit(cs);
+  return rc;
+}
+
 static int remoteSqlLoadCommit(
   ChunkStore *cs,
   const ProllyHash *pCommitHash,
@@ -463,16 +495,13 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     return;
   }
 
-
-  rc = chunkStoreFindRemote(cs, zRemoteName, &zUrl);
-  if( rc!=SQLITE_OK || !zUrl ){
+  rc = remoteSqlOpenNamedRemote(cs, zRemoteName, &zUrl, &pRemote);
+  if( rc==SQLITE_NOTFOUND ){
     remoteSqlStateClear(&savedState);
     sqlite3_result_error(ctx, "remote not found", -1);
     return;
   }
-
-  pRemote = openRemoteByUrl(cs->pVfs, zUrl);
-  if( !pRemote ){
+  if( rc==SQLITE_CANTOPEN ){
     remoteSqlStateClear(&savedState);
     sqlite3_result_error(ctx, "failed to open remote (URL must start with file://)", -1);
     return;
@@ -509,8 +538,7 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
 
 
   if( prollyHashCompare(&localCommit, &trackingCommit)==0 ){
-    remoteSqlStateClear(&savedState);
-    sqlite3_result_int(ctx, 0);
+    remoteSqlClearAndSucceed(ctx, &savedState);
     return;
   }
 
@@ -581,14 +609,12 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   }
 
 
-  rc = chunkStoreSerializeRefs(cs);
-  if( rc==SQLITE_OK ) rc = chunkStoreCommit(cs);
+  rc = remoteSqlPersistRefs(cs);
   if( rc!=SQLITE_OK ){
     remoteSqlRestoreAndReport(ctx, db, cs, &savedState, rc, 0);
     return;
   }
-  remoteSqlStateClear(&savedState);
-  sqlite3_result_int(ctx, 0);
+  remoteSqlClearAndSucceed(ctx, &savedState);
 }
 
 static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
@@ -709,15 +735,12 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     }
   }
 
-
-  rc = chunkStoreSerializeRefs(cs);
-  if( rc==SQLITE_OK ) rc = chunkStoreCommit(cs);
+  rc = remoteSqlPersistRefs(cs);
   if( rc!=SQLITE_OK ){
     remoteSqlRestoreAndReport(ctx, db, cs, &savedState, rc, 0);
     return;
   }
-  remoteSqlStateClear(&savedState);
-  sqlite3_result_int(ctx, 0);
+  remoteSqlClearAndSucceed(ctx, &savedState);
 }
 
 typedef struct RemVtab RemVtab;

--- a/src/doltlite_remotesrv.c
+++ b/src/doltlite_remotesrv.c
@@ -394,6 +394,43 @@ static void handleGetRefs(ChunkStore *pStore, int fd){
   sqlite3_free(pData);
 }
 
+static int remoteSrvPersistRefs(ChunkStore *pStore){
+  int rc = chunkStoreSerializeRefs(pStore);
+  if( rc==SQLITE_OK ) rc = chunkStoreCommit(pStore);
+  return rc;
+}
+
+static int remoteSrvPersistDefaultBranchCatalog(ChunkStore *pStore){
+  const char *zDef = chunkStoreGetDefaultBranch(pStore);
+  ProllyHash branchCommit;
+  int rc;
+
+  if( !zDef || chunkStoreFindBranch(pStore, zDef, &branchCommit)!=SQLITE_OK ){
+    return SQLITE_OK;
+  }
+
+  {
+    u8 *cdata = 0;
+    int ncdata = 0;
+    rc = chunkStoreGet(pStore, &branchCommit, &cdata, &ncdata);
+    if( rc!=SQLITE_OK ) return rc;
+    if( cdata ){
+      DoltliteCommit commit;
+      rc = doltliteCommitDeserialize(cdata, ncdata, &commit);
+      if( rc==SQLITE_OK ){
+        rc = chunkStoreWriteBranchWorkingCatalog(
+          pStore, zDef, &commit.catalogHash, NULL
+        );
+        doltliteCommitClear(&commit);
+      }
+      sqlite3_free(cdata);
+      if( rc!=SQLITE_OK ) return rc;
+    }
+  }
+
+  return remoteSrvPersistRefs(pStore);
+}
+
 static void handlePutRefs(ChunkStore *pStore, int fd,
                           const u8 *pBody, int nBody){
   ProllyHash hash;
@@ -431,59 +468,15 @@ static void handlePutRefs(ChunkStore *pStore, int fd,
 static void handleCommit(ChunkStore *pStore, int fd){
   int rc;
 
-  rc = chunkStoreSerializeRefs(pStore);
+  rc = remoteSrvPersistRefs(pStore);
   if( rc!=SQLITE_OK ){
     sendError(fd);
     return;
   }
-
-  rc = chunkStoreCommit(pStore);
+  rc = remoteSrvPersistDefaultBranchCatalog(pStore);
   if( rc!=SQLITE_OK ){
     sendError(fd);
     return;
-  }
-
-
-  {
-    const char *zDef = chunkStoreGetDefaultBranch(pStore);
-    ProllyHash branchCommit;
-    if( zDef && chunkStoreFindBranch(pStore, zDef, &branchCommit)==SQLITE_OK ){
-      u8 *cdata = 0; int ncdata = 0;
-      rc = chunkStoreGet(pStore, &branchCommit, &cdata, &ncdata);
-      if( rc!=SQLITE_OK ){
-        if( cdata ) sqlite3_free(cdata);
-        sendError(fd);
-        return;
-      }
-      if( cdata ){
-        DoltliteCommit commit;
-        rc = doltliteCommitDeserialize(cdata, ncdata, &commit);
-        if( rc!=SQLITE_OK ){
-          sqlite3_free(cdata);
-          sendError(fd);
-          return;
-        }
-        rc = chunkStoreWriteBranchWorkingCatalog(pStore, zDef,
-                                                 &commit.catalogHash, NULL);
-        doltliteCommitClear(&commit);
-        if( rc!=SQLITE_OK ){
-          sqlite3_free(cdata);
-          sendError(fd);
-          return;
-        }
-        sqlite3_free(cdata);
-      }
-      rc = chunkStoreSerializeRefs(pStore);
-      if( rc!=SQLITE_OK ){
-        sendError(fd);
-        return;
-      }
-      rc = chunkStoreCommit(pStore);
-      if( rc!=SQLITE_OK ){
-        sendError(fd);
-        return;
-      }
-    }
   }
 
   sendOk(fd, 0, 0);

--- a/test/http_remote_test.sh
+++ b/test/http_remote_test.sh
@@ -34,7 +34,7 @@ echo "=== HTTP remote URL recognition tests ==="
 result=$("$DB" "$TMPDIR/test.db" "SELECT dolt_remote('add','origin','http://localhost:19999/mydb');" 2>/dev/null)
 check "http remote add succeeds" "0" "$result"
 
-result=$("$DB" "$TMPDIR/test.db" "SELECT * FROM dolt_remotes;")
+result=$("$DB" "$TMPDIR/test.db" "SELECT name, url FROM dolt_remotes;")
 check "http remote in list" "origin|http://localhost:19999/mydb" "$result"
 
 result=$("$DB" "$TMPDIR/test.db" "SELECT dolt_push('origin','main');" 2>&1)
@@ -423,8 +423,8 @@ int main(int argc, char **argv) {
     run_sql(deepDb, sql);
   }
   CHECK("deep source has 15 rows", 15, query_int(deepDb, "SELECT count(*) FROM log"));
-  /* 16 commits = 1 create + 15 inserts */
-  CHECK("deep source has 16 commits", 16, query_int(deepDb, "SELECT count(*) FROM dolt_log"));
+  /* 17 commits = 1 initial + 1 create + 15 inserts */
+  CHECK("deep source has 17 commits", 17, query_int(deepDb, "SELECT count(*) FROM dolt_log"));
   sqlite3_close(deepDb);
 
   /* ============================================================
@@ -437,7 +437,7 @@ int main(int argc, char **argv) {
   snprintf(sql, sizeof(sql), "SELECT dolt_clone('http://127.0.0.1:%d/deep.db')", port);
   run_sql(deepClone, sql);
   CHECK("deep clone has 15 rows", 15, query_int(deepClone, "SELECT count(*) FROM log"));
-  CHECK("deep clone has 16 commits", 16, query_int(deepClone, "SELECT count(*) FROM dolt_log"));
+  CHECK("deep clone has 17 commits", 17, query_int(deepClone, "SELECT count(*) FROM dolt_log"));
   CHECK_STR("deep clone latest msg", "step 15",
     query_str(deepClone, "SELECT message FROM dolt_log LIMIT 1"));
   sqlite3_close(deepClone);


### PR DESCRIPTION
## Summary
- refactor remote SQL save/restore helpers for pull and clone
- extract chunk store replay and reload state adoption helpers
- deduplicate remote and remotesrv refs persistence helpers

## Testing
- make -C build doltlite
- bash test/lint_layers.sh src
- bash test/remote_test.sh ./build/doltlite
- cd build && bash ../test/oracle_savepoints_test.sh ./doltlite ./sqlite3
- cd build && bash ../test/vc_oracle_rebase_test.sh ./doltlite dolt
- cd build && bash ../test/sql_oracle_test.sh ./doltlite ./sqlite3