### PR TITLE
feat: add dolt_hashof, dolt_hashof_table, dolt_hashof_db scalars

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -161,6 +161,10 @@ jobs:
       run: cd build && bash ../test/vc_oracle_at_test.sh ./doltlite dolt
       timeout-minutes: 5
 
+    - name: Version control oracle tests (dolt_hashof suite)
+      run: cd build && bash ../test/vc_oracle_hashof_test.sh ./doltlite
+      timeout-minutes: 5
+
     - name: Oracle tests (.import dot-command)
       run: cd build && bash ../test/oracle_import_test.sh ./doltlite dolt
       timeout-minutes: 5

--- a/README.md
+++ b/README.md
@@ -434,6 +434,35 @@ Find the common ancestor of two commits:
 SELECT dolt_merge_base('abc123...', 'def456...');
 ```
 
+### Content-Addressed Hashes
+
+Doltlite exposes the content-address of any ref, table, or the whole
+database as a scalar SQL function. The decentralized use case is
+simple: two peers that compute the same hash are at the exact same
+state — no row-level diff required, no metadata roundtrip.
+
+```sql
+-- Commit hash for a branch, tag, raw hash, HEAD, or HEAD~N / HEAD^N
+SELECT dolt_hashof('main');
+SELECT dolt_hashof('HEAD~2');
+
+-- Table root hash. One-arg form reflects uncommitted working edits.
+SELECT dolt_hashof_table('users');
+SELECT dolt_hashof_table('users', 'main');
+
+-- Whole-catalog hash — changes iff any table root moves or a table
+-- is created/dropped.
+SELECT dolt_hashof_db();
+SELECT dolt_hashof_db('HEAD');
+```
+
+All results are 40-char lowercase hex (20-byte prolly hash).
+
+The `_table` and `_db` variants are history-independent: any two
+rowsets that reduce to the same `(key, value)` set hash identically
+regardless of insert order, transient deletions, commit chain, or
+branch. See `test/vc_oracle_hashof_test.sh` for the property tests.
+
 ### Remotes
 
 Doltlite supports Git-like remotes for pushing, fetching, pulling, and cloning

--- a/main.mk
+++ b/main.mk
@@ -571,7 +571,7 @@ PROLLY_OBJS = prolly_hash.o prolly_hashset.o prolly_arena.o prolly_node.o prolly
               doltlite.o doltlite_commit.o doltlite_ref.o doltlite_log.o doltlite_status.o \
               doltlite_diff.o doltlite_diff_table.o doltlite_branch.o doltlite_tag.o doltlite_ancestor.o doltlite_merge.o doltlite_schema_merge.o doltlite_conflicts.o \
               doltlite_gc.o doltlite_chunk_walk.o doltlite_history.o doltlite_at.o doltlite_blame.o doltlite_schema_diff.o doltlite_schemas.o doltlite_diff_stat.o doltlite_record.o \
-              doltlite_ignore.o \
+              doltlite_ignore.o doltlite_hashof.o \
               doltlite_dbpage.o \
               doltlite_remote.o doltlite_remote_sql.o \
               doltlite_http_remote.o doltlite_remotesrv.o
@@ -1420,6 +1420,9 @@ doltlite_record.o:	$(TOP)/src/doltlite_record.c $(DEPS_OBJ_COMMON)
 
 doltlite_ignore.o:	$(TOP)/src/doltlite_ignore.c $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/doltlite_ignore.c
+
+doltlite_hashof.o:	$(TOP)/src/doltlite_hashof.c $(DEPS_OBJ_COMMON)
+	$(T.cc.sqlite) -c $(TOP)/src/doltlite_hashof.c
 
 doltlite_merge.o:	$(TOP)/src/doltlite_merge.c $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/doltlite_merge.c

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -3375,6 +3375,10 @@ void doltliteRegister(sqlite3 *db){
   if( doltliteSchemasRegister(db)!=SQLITE_OK ) return;
   if( doltliteDiffStatRegister(db)!=SQLITE_OK ) return;
   if( doltliteRemoteSqlRegister(db)!=SQLITE_OK ) return;
+  {
+    extern int doltliteHashofRegister(sqlite3*);
+    if( doltliteHashofRegister(db)!=SQLITE_OK ) return;
+  }
 
   {
     extern int doltliteDbpageInstallAutoExt(void);

--- a/src/doltlite_hashof.c
+++ b/src/doltlite_hashof.c
@@ -1,0 +1,253 @@
+
+#ifdef DOLTLITE_PROLLY
+
+#include "sqliteInt.h"
+#include "prolly_hash.h"
+#include "chunk_store.h"
+#include "doltlite_commit.h"
+#include "doltlite_internal.h"
+
+#include <string.h>
+
+/* dolt_hashof(ref) → commit hash hex for the named ref. Accepts
+** branch names, tag names, raw commit hashes, HEAD, and HEAD~N /
+** HEAD^N shorthand — whatever doltliteResolveRef understands.
+**
+** In the decentralized use case the hash is the primary verifier:
+** two peers at the same hash have the same history up through
+** that commit, and can exchange chunks by hash-reference alone.
+** Keep the output lowercase 40-char hex so a SQL-level string
+** compare is the whole verification. */
+static void doltliteHashofFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
+  sqlite3 *db;
+  const char *zRef;
+  ProllyHash commitHash;
+  char hex[PROLLY_HASH_SIZE*2+1];
+  int rc;
+
+  if( argc!=1 ){
+    sqlite3_result_error(ctx, "dolt_hashof() takes exactly one argument", -1);
+    return;
+  }
+  if( sqlite3_value_type(argv[0])==SQLITE_NULL ){
+    sqlite3_result_null(ctx);
+    return;
+  }
+  zRef = (const char*)sqlite3_value_text(argv[0]);
+  if( !zRef ){
+    sqlite3_result_null(ctx);
+    return;
+  }
+  db = sqlite3_context_db_handle(ctx);
+  rc = doltliteResolveRef(db, zRef, &commitHash);
+  if( rc==SQLITE_NOTFOUND ){
+    sqlite3_result_null(ctx);
+    return;
+  }
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error(ctx, "dolt_hashof: ref resolve failed", -1);
+    return;
+  }
+  doltliteHashToHex(&commitHash, hex);
+  sqlite3_result_text(ctx, hex, PROLLY_HASH_SIZE*2, SQLITE_TRANSIENT);
+}
+
+/* Shared lookup: hashof a table inside a catalog (either the
+** current working catalog or a catalog loaded from a ref).
+** Returns SQLITE_OK with the hex hash written to pHex on success,
+** SQLITE_NOTFOUND if zTable isn't in the catalog. */
+static int hashofTableInCatalog(
+  sqlite3 *db,
+  const ProllyHash *pCatHash,
+  const char *zTable,
+  char *pHex
+){
+  struct TableEntry *aTables = 0;
+  int nTables = 0;
+  ProllyHash rootHash;
+  int rc;
+
+  rc = doltliteLoadCatalog(db, pCatHash, &aTables, &nTables, 0);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = doltliteFindTableRootByName(aTables, nTables, zTable, &rootHash, 0);
+  doltliteFreeCatalog(aTables, nTables);
+  if( rc!=SQLITE_OK ) return rc;
+  doltliteHashToHex(&rootHash, pHex);
+  return SQLITE_OK;
+}
+
+/* dolt_hashof_table(name)
+** dolt_hashof_table(name, ref)
+**
+** 1-arg form returns the current working-catalog hash of the
+** table's prolly root — so it tracks uncommitted edits via
+** doltliteFlushCatalogToHash. 2-arg form resolves the ref, loads
+** its committed catalog, and reads the table root from there.
+**
+** History-independence invariant: for two rowsets that reduce to
+** the same set of (key,value) pairs, this function must return
+** byte-identical hashes regardless of insert order, transient
+** deletions, commit chain, or branch. The oracle in
+** test/vc_oracle_hashof_test.sh exercises every flavour. */
+static void doltliteHashofTableFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
+  sqlite3 *db;
+  const char *zTable;
+  ProllyHash catHash;
+  char hex[PROLLY_HASH_SIZE*2+1];
+  int rc;
+
+  if( argc!=1 && argc!=2 ){
+    sqlite3_result_error(ctx, "dolt_hashof_table() takes 1 or 2 arguments", -1);
+    return;
+  }
+  if( sqlite3_value_type(argv[0])==SQLITE_NULL ){
+    sqlite3_result_null(ctx);
+    return;
+  }
+  zTable = (const char*)sqlite3_value_text(argv[0]);
+  if( !zTable || !*zTable ){
+    sqlite3_result_null(ctx);
+    return;
+  }
+  db = sqlite3_context_db_handle(ctx);
+
+  if( argc==1 ){
+    rc = doltliteFlushCatalogToHash(db, &catHash);
+  }else{
+    const char *zRef;
+    ProllyHash commitHash;
+    DoltliteCommit commit;
+    if( sqlite3_value_type(argv[1])==SQLITE_NULL ){
+      sqlite3_result_null(ctx);
+      return;
+    }
+    zRef = (const char*)sqlite3_value_text(argv[1]);
+    if( !zRef ){
+      sqlite3_result_null(ctx);
+      return;
+    }
+    rc = doltliteResolveRef(db, zRef, &commitHash);
+    if( rc==SQLITE_NOTFOUND ){
+      sqlite3_result_null(ctx);
+      return;
+    }
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error(ctx, "dolt_hashof_table: ref resolve failed", -1);
+      return;
+    }
+    memset(&commit, 0, sizeof(commit));
+    rc = doltliteLoadCommit(db, &commitHash, &commit);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error(ctx, "dolt_hashof_table: commit load failed", -1);
+      return;
+    }
+    catHash = commit.catalogHash;
+    doltliteCommitClear(&commit);
+  }
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error(ctx, "dolt_hashof_table: catalog flush failed", -1);
+    return;
+  }
+
+  rc = hashofTableInCatalog(db, &catHash, zTable, hex);
+  if( rc==SQLITE_NOTFOUND ){
+    sqlite3_result_null(ctx);
+    return;
+  }
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error(ctx, "dolt_hashof_table: table not found in catalog", -1);
+    return;
+  }
+  sqlite3_result_text(ctx, hex, PROLLY_HASH_SIZE*2, SQLITE_TRANSIENT);
+}
+
+/* dolt_hashof_db()
+** dolt_hashof_db(ref)
+**
+** 0-arg returns the hash of the current working catalog — the
+** content-address of the entire database's current logical state,
+** which changes iff any table's root changes or a table is
+** added/dropped. 1-arg resolves the ref and returns that commit's
+** catalog hash.
+**
+** This is the single-string proof-of-equivalence between two
+** doltlite peers in a decentralized setup: same hash, same state,
+** no row-level diffing required. */
+static void doltliteHashofDbFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
+  sqlite3 *db;
+  ProllyHash catHash;
+  char hex[PROLLY_HASH_SIZE*2+1];
+  int rc;
+
+  if( argc!=0 && argc!=1 ){
+    sqlite3_result_error(ctx, "dolt_hashof_db() takes 0 or 1 argument", -1);
+    return;
+  }
+  db = sqlite3_context_db_handle(ctx);
+
+  if( argc==0 ){
+    rc = doltliteFlushCatalogToHash(db, &catHash);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error(ctx, "dolt_hashof_db: catalog flush failed", -1);
+      return;
+    }
+  }else{
+    const char *zRef;
+    ProllyHash commitHash;
+    DoltliteCommit commit;
+    if( sqlite3_value_type(argv[0])==SQLITE_NULL ){
+      sqlite3_result_null(ctx);
+      return;
+    }
+    zRef = (const char*)sqlite3_value_text(argv[0]);
+    if( !zRef ){
+      sqlite3_result_null(ctx);
+      return;
+    }
+    rc = doltliteResolveRef(db, zRef, &commitHash);
+    if( rc==SQLITE_NOTFOUND ){
+      sqlite3_result_null(ctx);
+      return;
+    }
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error(ctx, "dolt_hashof_db: ref resolve failed", -1);
+      return;
+    }
+    memset(&commit, 0, sizeof(commit));
+    rc = doltliteLoadCommit(db, &commitHash, &commit);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error(ctx, "dolt_hashof_db: commit load failed", -1);
+      return;
+    }
+    catHash = commit.catalogHash;
+    doltliteCommitClear(&commit);
+  }
+
+  doltliteHashToHex(&catHash, hex);
+  sqlite3_result_text(ctx, hex, PROLLY_HASH_SIZE*2, SQLITE_TRANSIENT);
+}
+
+int doltliteHashofRegister(sqlite3 *db){
+  int rc;
+  rc = sqlite3_create_function(db, "dolt_hashof", 1, SQLITE_UTF8, 0,
+                               doltliteHashofFunc, 0, 0);
+  if( rc==SQLITE_OK ){
+    rc = sqlite3_create_function(db, "dolt_hashof_table", 1, SQLITE_UTF8, 0,
+                                 doltliteHashofTableFunc, 0, 0);
+  }
+  if( rc==SQLITE_OK ){
+    rc = sqlite3_create_function(db, "dolt_hashof_table", 2, SQLITE_UTF8, 0,
+                                 doltliteHashofTableFunc, 0, 0);
+  }
+  if( rc==SQLITE_OK ){
+    rc = sqlite3_create_function(db, "dolt_hashof_db", 0, SQLITE_UTF8, 0,
+                                 doltliteHashofDbFunc, 0, 0);
+  }
+  if( rc==SQLITE_OK ){
+    rc = sqlite3_create_function(db, "dolt_hashof_db", 1, SQLITE_UTF8, 0,
+                                 doltliteHashofDbFunc, 0, 0);
+  }
+  return rc;
+}
+
+#endif

--- a/test/vc_oracle_hashof_test.sh
+++ b/test/vc_oracle_hashof_test.sh
@@ -1,0 +1,443 @@
+#!/bin/bash
+#
+# Version-control oracle test: dolt_hashof suite
+#
+# dolt_hashof(ref), dolt_hashof_table(tbl[, ref]), and dolt_hashof_db()
+# expose content-addressed hashes to SQL. These are the primary tool
+# for verifying two doltlite databases hold the same state in the
+# decentralized use case — compare a hash, don't diff a million rows.
+#
+# The interesting property isn't that hash values match some external
+# reference — it's that they obey HISTORY INDEPENDENCE: any two code
+# paths that arrive at the same logical state must produce the same
+# hash, regardless of intermediate commits, ordering, or transient
+# rows. Prolly trees give us this by construction (content-addressed
+# nodes keyed on sorted content), and if any of the properties below
+# break, the chunking/serialization layer has a bug.
+#
+# The tests in this oracle are grouped by property:
+#
+#   1. Determinism: the same input sequence run twice in separate
+#      databases produces byte-identical hashes. Exercises the
+#      chunker + serializer end-to-end.
+#
+#   2. Insert order invariance: inserting the same rowset in
+#      different orders converges to the same table hash. This is
+#      the core prolly-tree property; if it breaks, either the
+#      mutmap merge step has stale state or the chunker isn't
+#      hashing sorted content.
+#
+#   3. Intermediate state invariance: inserting rows then deleting
+#      a subset then re-inserting them (net-no-op) produces the
+#      same hash as just inserting the remaining set. Tests that
+#      tombstones flush cleanly and the final root is content-
+#      addressed.
+#
+#   4. Cross-branch state invariance: two branches that diverge and
+#      re-converge on the exact same rowset produce the same
+#      dolt_hashof_table even though their commit graphs differ.
+#      dolt_hashof(ref) DIFFERS because commit metadata differs —
+#      this is correct, and we check both.
+#
+#   5. Separation of concerns: adding a row to table A does NOT
+#      change dolt_hashof_table('B'). dolt_hashof_db() DOES
+#      change because the catalog moved.
+#
+#   6. Reopen stability: close the db, reopen, hashes are
+#      byte-identical. Catches any hashing that depends on live
+#      in-memory state instead of persisted chunks.
+#
+#   7. Negative cases: updating a single cell, adding a row,
+#      altering a schema all MUST change the table hash. If
+#      they don't, the hash is stale and worthless.
+#
+#   8. Ref resolution: dolt_hashof accepts branch names, tag
+#      names, commit hashes, and HEAD~N shorthand. Missing refs
+#      return NULL or an error (we accept either, as long as it
+#      isn't a silent hash).
+#
+#   9. Dolt shape conformance: dolt_hashof(...) result is stable,
+#      lowercase, and exactly 40 hex characters (20-byte
+#      ProllyHash). This is the only Dolt conformance check —
+#      we don't require hash-value equality with the Dolt CLI
+#      because Dolt renders the same bytes as 32-char base32.
+#
+# Usage: bash vc_oracle_hashof_test.sh [path/to/doltlite]
+#
+
+set -u
+
+DOLTLITE="${1:-./doltlite}"
+TMPROOT=$(mktemp -d)
+trap "rm -rf $TMPROOT" EXIT
+pass=0; fail=0
+FAILED_NAMES=""
+
+# Run setup sql against a fresh doltlite db in one process, then run
+# the hash-producing query in a second process so stdout contains
+# ONLY the query result. Without this split, dolt_commit's return
+# value would bleed into the captured hash.
+run_hash() {
+  local name="$1" setup="$2" query="$3"
+  local db="$TMPROOT/$name.db"
+  rm -f "$db"
+  printf "%s\n" "$setup" \
+    | "$DOLTLITE" "$db" >/dev/null 2>"$TMPROOT/$name.setup.err"
+  "$DOLTLITE" "$db" "$query" 2>"$TMPROOT/$name.query.err"
+}
+
+# Like run_hash, but reuses an existing db path — so caller can
+# layer setup sequences and inspect the hash at different points.
+run_hash_on() {
+  local db="$1" query="$2"
+  "$DOLTLITE" "$db" "$query" 2>>"$TMPROOT/shared.err"
+}
+
+# Assert two invocations produce the same hash.
+same() {
+  local name="$1" a="$2" b="$3"
+  if [ -z "$a" ] || [ -z "$b" ]; then
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name (empty hash)"
+    echo "    a=|$a|"
+    echo "    b=|$b|"
+    return
+  fi
+  if [ "$a" = "$b" ]; then
+    pass=$((pass+1))
+    echo "  PASS: $name"
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    a=$a"
+    echo "    b=$b"
+  fi
+}
+
+# Assert two invocations produce DIFFERENT hashes (updates,
+# schema changes, etc. must invalidate).
+different() {
+  local name="$1" a="$2" b="$3"
+  if [ -z "$a" ] || [ -z "$b" ]; then
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name (empty hash)"
+    return
+  fi
+  if [ "$a" != "$b" ]; then
+    pass=$((pass+1))
+    echo "  PASS: $name"
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name (hashes equal but should differ)"
+    echo "    a=$a"
+  fi
+}
+
+# Assert hash matches a specific shape (40 lowercase hex chars).
+shape() {
+  local name="$1" h="$2"
+  if echo "$h" | grep -qE '^[0-9a-f]{40}$'; then
+    pass=$((pass+1))
+    echo "  PASS: $name"
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name (bad shape)"
+    echo "    h=|$h|"
+  fi
+}
+
+echo "=== Version Control Oracle Tests: dolt_hashof suite ==="
+echo ""
+
+# ── 1. Determinism ────────────────────────────────────────
+echo "--- 1. Determinism: same input → same hash ---"
+
+SEED_A="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'a'), (2, 'b'), (3, 'c');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'seed');
+"
+
+H1=$(run_hash "det1" "$SEED_A" "SELECT dolt_hashof_table('t');")
+H2=$(run_hash "det2" "$SEED_A" "SELECT dolt_hashof_table('t');")
+same "determinism_table_same_inputs" "$H1" "$H2"
+
+H1=$(run_hash "det_db1" "$SEED_A" "SELECT dolt_hashof_db();")
+H2=$(run_hash "det_db2" "$SEED_A" "SELECT dolt_hashof_db();")
+same "determinism_db_same_inputs" "$H1" "$H2"
+
+echo ""
+
+# ── 2. Insert order invariance ────────────────────────────
+echo "--- 2. Insert order invariance ---"
+
+ORDER_ABC="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'a');
+INSERT INTO t VALUES (2, 'b');
+INSERT INTO t VALUES (3, 'c');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'abc');
+"
+
+ORDER_CBA="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (3, 'c');
+INSERT INTO t VALUES (2, 'b');
+INSERT INTO t VALUES (1, 'a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'cba');
+"
+
+ORDER_BATCH="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (2, 'b'), (1, 'a'), (3, 'c');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'batch');
+"
+
+H_ABC=$(run_hash "order_abc" "$ORDER_ABC" "SELECT dolt_hashof_table('t');")
+H_CBA=$(run_hash "order_cba" "$ORDER_CBA" "SELECT dolt_hashof_table('t');")
+H_BAT=$(run_hash "order_batch" "$ORDER_BATCH" "SELECT dolt_hashof_table('t');")
+same "order_abc_vs_cba"    "$H_ABC" "$H_CBA"
+same "order_abc_vs_batch"  "$H_ABC" "$H_BAT"
+
+echo ""
+
+# ── 3. Intermediate state invariance ──────────────────────
+echo "--- 3. Intermediate state invariance (delete+reinsert is a no-op) ---"
+
+NET="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'a'), (2, 'b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'net');
+"
+
+THROUGH_DELETE="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'a'), (2, 'b'), (99, 'temp');
+DELETE FROM t WHERE id = 99;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'through_delete');
+"
+
+DELETE_REINSERT="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'a'), (2, 'b');
+DELETE FROM t WHERE id = 1;
+INSERT INTO t VALUES (1, 'a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'delete_reinsert');
+"
+
+H_NET=$(run_hash "net" "$NET" "SELECT dolt_hashof_table('t');")
+H_TD=$(run_hash "through_delete" "$THROUGH_DELETE" "SELECT dolt_hashof_table('t');")
+H_DR=$(run_hash "delete_reinsert" "$DELETE_REINSERT" "SELECT dolt_hashof_table('t');")
+same "net_vs_through_delete"  "$H_NET" "$H_TD"
+same "net_vs_delete_reinsert" "$H_NET" "$H_DR"
+
+echo ""
+
+# ── 4. Cross-branch state invariance ──────────────────────
+echo "--- 4. Cross-branch state invariance ---"
+
+BRANCH_CONVERGE="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES (2, 'b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat_c2');
+
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES (2, 'b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main_c2');
+"
+
+DB="$TMPROOT/cross_branch.db"
+rm -f "$DB"
+printf "%s\n" "$BRANCH_CONVERGE" | "$DOLTLITE" "$DB" >/dev/null 2>"$TMPROOT/cross.err"
+
+H_MAIN_T=$(run_hash_on "$DB" "SELECT dolt_hashof_table('t', 'main');")
+H_FEAT_T=$(run_hash_on "$DB" "SELECT dolt_hashof_table('t', 'feat');")
+same "cross_branch_table_hash_equal" "$H_MAIN_T" "$H_FEAT_T"
+
+H_MAIN_COMMIT=$(run_hash_on "$DB" "SELECT dolt_hashof('main');")
+H_FEAT_COMMIT=$(run_hash_on "$DB" "SELECT dolt_hashof('feat');")
+different "cross_branch_commit_hash_differs" "$H_MAIN_COMMIT" "$H_FEAT_COMMIT"
+
+echo ""
+
+# ── 5. Per-table vs whole-db separation ───────────────────
+echo "--- 5. Per-table isolation in dolt_hashof_table ---"
+
+TWO_TABLES="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+CREATE TABLE u(id INTEGER PRIMARY KEY, w TEXT);
+INSERT INTO t VALUES (1, 'a');
+INSERT INTO u VALUES (1, 'x');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'two_tables');
+"
+
+DB="$TMPROOT/two_tables.db"
+rm -f "$DB"
+printf "%s\n" "$TWO_TABLES" | "$DOLTLITE" "$DB" >/dev/null 2>"$TMPROOT/two.err"
+
+HT_BEFORE=$(run_hash_on "$DB" "SELECT dolt_hashof_table('t');")
+HU_BEFORE=$(run_hash_on "$DB" "SELECT dolt_hashof_table('u');")
+HDB_BEFORE=$(run_hash_on "$DB" "SELECT dolt_hashof_db();")
+
+# Mutate u only; t's hash must not move.
+"$DOLTLITE" "$DB" "INSERT INTO u VALUES (2, 'y'); SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'bump_u');" >/dev/null 2>>"$TMPROOT/two.err"
+
+HT_AFTER=$(run_hash_on "$DB" "SELECT dolt_hashof_table('t');")
+HU_AFTER=$(run_hash_on "$DB" "SELECT dolt_hashof_table('u');")
+HDB_AFTER=$(run_hash_on "$DB" "SELECT dolt_hashof_db();")
+
+same      "t_hash_stable_on_u_mutation"   "$HT_BEFORE" "$HT_AFTER"
+different "u_hash_changes_on_u_mutation"  "$HU_BEFORE" "$HU_AFTER"
+different "db_hash_changes_on_u_mutation" "$HDB_BEFORE" "$HDB_AFTER"
+
+echo ""
+
+# ── 6. Reopen stability ───────────────────────────────────
+echo "--- 6. Reopen stability ---"
+
+REOPEN_SEED="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'a'), (2, 'b'), (3, 'c');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'reopen');
+"
+
+DB="$TMPROOT/reopen.db"
+rm -f "$DB"
+printf "%s\n" "$REOPEN_SEED" | "$DOLTLITE" "$DB" >/dev/null 2>"$TMPROOT/reopen.err"
+
+H_OPEN1=$(run_hash_on "$DB" "SELECT dolt_hashof_table('t');")
+H_OPEN2=$(run_hash_on "$DB" "SELECT dolt_hashof_table('t');")
+H_OPEN3_DB=$(run_hash_on "$DB" "SELECT dolt_hashof_db();")
+H_OPEN4_MAIN=$(run_hash_on "$DB" "SELECT dolt_hashof('main');")
+H_OPEN5_TAB=$(run_hash_on "$DB" "SELECT dolt_hashof_table('t');")
+H_OPEN6_DB=$(run_hash_on "$DB" "SELECT dolt_hashof_db();")
+H_OPEN7_MAIN=$(run_hash_on "$DB" "SELECT dolt_hashof('main');")
+
+same "reopen_table_stable" "$H_OPEN1" "$H_OPEN5_TAB"
+same "reopen_db_stable"    "$H_OPEN3_DB" "$H_OPEN6_DB"
+same "reopen_commit_stable" "$H_OPEN4_MAIN" "$H_OPEN7_MAIN"
+
+echo ""
+
+# ── 7. Negative: mutations must invalidate ────────────────
+echo "--- 7. Mutations must invalidate ---"
+
+BASE="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'a'), (2, 'b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'base');
+"
+
+ADD_ROW="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'a'), (2, 'b'), (3, 'c');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'add_row');
+"
+
+UPDATE_CELL="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'a'), (2, 'b');
+UPDATE t SET v = 'A' WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'update');
+"
+
+ALTER_SCHEMA="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT, w INT);
+INSERT INTO t VALUES (1, 'a', NULL), (2, 'b', NULL);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'alter');
+"
+
+H_BASE=$(run_hash "neg_base" "$BASE" "SELECT dolt_hashof_table('t');")
+H_ADD=$(run_hash "neg_add" "$ADD_ROW" "SELECT dolt_hashof_table('t');")
+H_UPD=$(run_hash "neg_upd" "$UPDATE_CELL" "SELECT dolt_hashof_table('t');")
+H_ALT=$(run_hash "neg_alt" "$ALTER_SCHEMA" "SELECT dolt_hashof_table('t');")
+
+different "add_row_changes_table_hash"   "$H_BASE" "$H_ADD"
+different "update_cell_changes_table_hash" "$H_BASE" "$H_UPD"
+different "alter_schema_changes_table_hash" "$H_BASE" "$H_ALT"
+
+echo ""
+
+# ── 8. Ref resolution ─────────────────────────────────────
+echo "--- 8. Ref resolution ---"
+
+REF_SEED="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+INSERT INTO t VALUES (2, 'b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2');
+"
+
+DB="$TMPROOT/refs.db"
+rm -f "$DB"
+printf "%s\n" "$REF_SEED" | "$DOLTLITE" "$DB" >/dev/null 2>"$TMPROOT/refs.err"
+
+H_MAIN=$(run_hash_on "$DB" "SELECT dolt_hashof('main');")
+H_HEAD=$(run_hash_on "$DB" "SELECT dolt_hashof('HEAD');")
+same "main_equals_HEAD" "$H_MAIN" "$H_HEAD"
+shape "main_hash_shape" "$H_MAIN"
+
+H_HEAD_PARENT=$(run_hash_on "$DB" "SELECT dolt_hashof('HEAD~1');")
+different "HEAD_differs_from_HEAD_parent" "$H_HEAD" "$H_HEAD_PARENT"
+
+# Passing the same commit hash string through dolt_hashof should
+# return the same hash back (identity). Grab HEAD, then feed it.
+H_ID_OUT=$(run_hash_on "$DB" "SELECT dolt_hashof('$H_HEAD');")
+same "commit_hash_is_identity_on_hashof" "$H_HEAD" "$H_ID_OUT"
+
+echo ""
+
+# ── 9. Dolt shape conformance ─────────────────────────────
+echo "--- 9. Dolt shape conformance ---"
+
+SHAPE_SEED="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'shape');
+"
+
+H_T=$(run_hash "shape_t" "$SHAPE_SEED" "SELECT dolt_hashof_table('t');")
+H_D=$(run_hash "shape_d" "$SHAPE_SEED" "SELECT dolt_hashof_db();")
+H_R=$(run_hash "shape_r" "$SHAPE_SEED" "SELECT dolt_hashof('main');")
+shape "hashof_table_shape" "$H_T"
+shape "hashof_db_shape"    "$H_D"
+shape "hashof_ref_shape"   "$H_R"
+
+echo ""
+echo "======================================="
+echo "Results: $pass passed, $fail failed"
+echo "======================================="
+if [ $fail -gt 0 ]; then
+  echo "Failed:$FAILED_NAMES"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Expose content-addressed prolly hashes to SQL as scalar functions. In the decentralized use case doltlite targets, the hash is the primary state-equality verifier: two peers at the same hash are byte-identical through that commit, and can exchange chunks by hash reference alone without a row-level diff.

## API

\`\`\`sql
-- Commit hash for a branch, tag, raw hash, HEAD, or HEAD~N / HEAD^N
SELECT dolt_hashof('main');
SELECT dolt_hashof('HEAD~2');

-- Table root hash. One-arg form reflects uncommitted working edits.
SELECT dolt_hashof_table('users');
SELECT dolt_hashof_table('users', 'main');

-- Whole-catalog hash — changes iff any table root moves or a table
-- is created/dropped.
SELECT dolt_hashof_db();
SELECT dolt_hashof_db('HEAD');
\`\`\`

All results are 40-char lowercase hex (20-byte prolly hash).

## Why the \`_table\` / \`_db\` variants are the interesting ones

Hash of a ref is useful but every VCS has that. The interesting property for decentralized sync is **history independence**: two rowsets that reduce to the same \`(key, value)\` set hash identically regardless of insert order, transient deletions, commit chain, or branch. Prolly trees give us this by construction, and the oracle in \`test/vc_oracle_hashof_test.sh\` tries hard to break it:

- Section 2: insert \`[a,b,c]\` vs \`[c,a,b]\` vs single-batch — same hash
- Section 3: insert + delete + reinsert = same hash as plain net insert
- Section 4: two branches that diverge and re-converge to the same rowset produce the same \`dolt_hashof_table\`, while their \`dolt_hashof\` (commit hash) correctly differs
- Section 5: mutating table u leaves \`dolt_hashof_table('t')\` unchanged; both \`dolt_hashof_table('u')\` and \`dolt_hashof_db()\` move
- Section 6: hashes are stable across close/reopen
- Section 7 (negative): add-row / update-cell / alter-schema all invalidate
- Section 8: \`HEAD\` ≡ \`main\`, \`HEAD\` ≠ \`HEAD~1\`, identity on a commit hash
- Section 9: shape check (40-char hex)

24/24 oracle tests pass.

## Test plan

- [x] New oracle: \`test/vc_oracle_hashof_test.sh\` — 24/24 pass
- [x] 39 doltlite suites pass
- [x] 41/41 correctness tests pass
- [x] 107046/107046 regression tests pass
- [x] README section updated
- [x] Oracle wired into CI (\`.github/workflows/test.yml\`)
- [ ] CI (sqllogictest, ASan, correctness, benchmark)

🤖 Generated with [Claude Code](https://claude.com/claude-code)