### PR TITLE
fix: plug zName leaks in doltliteMergeCatalogs

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -80,5 +80,27 @@ jobs:
     - name: SQL oracle tests
       run: cd build && bash ../test/sql_oracle_test.sh ./doltlite ./sqlite3
 
+    # Focused leak reproducer for the write sequence that aborts
+    # inside correctness_test.sh but whose stderr is silenced by
+    # the harness. Mirrors the "Merge correctness" sub-test at
+    # correctness_test.sh:210. Lets stderr flow so the LSan stack
+    # shows up in CI logs directly.
+    - name: Leak reproducer (branch + update + merge)
+      run: |
+        cd build
+        rm -f /tmp/leak.db
+        ./doltlite /tmp/leak.db "CREATE TABLE t(id INTEGER PRIMARY KEY, val INT); \
+          WITH RECURSIVE c(x) AS (VALUES(1) UNION ALL SELECT x+1 FROM c WHERE x<100) \
+          INSERT INTO t SELECT x,x FROM c; \
+          SELECT dolt_add('-A'); SELECT dolt_commit('-m','init'); \
+          SELECT dolt_branch('feat'); \
+          SELECT dolt_checkout('feat'); \
+          INSERT INTO t VALUES(101,999); \
+          SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat'); \
+          SELECT dolt_checkout('main'); \
+          UPDATE t SET val=0 WHERE id=1; \
+          SELECT dolt_add('-A'); SELECT dolt_commit('-m','main'); \
+          SELECT dolt_merge('feat');"
+
     - name: Correctness regression tests
       run: cd build && bash ../test/correctness_test.sh ./doltlite

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -80,27 +80,5 @@ jobs:
     - name: SQL oracle tests
       run: cd build && bash ../test/sql_oracle_test.sh ./doltlite ./sqlite3
 
-    # Focused leak reproducer for the write sequence that aborts
-    # inside correctness_test.sh but whose stderr is silenced by
-    # the harness. Mirrors the "Merge correctness" sub-test at
-    # correctness_test.sh:210. Lets stderr flow so the LSan stack
-    # shows up in CI logs directly.
-    - name: Leak reproducer (branch + update + merge)
-      run: |
-        cd build
-        rm -f /tmp/leak.db
-        ./doltlite /tmp/leak.db "CREATE TABLE t(id INTEGER PRIMARY KEY, val INT); \
-          WITH RECURSIVE c(x) AS (VALUES(1) UNION ALL SELECT x+1 FROM c WHERE x<100) \
-          INSERT INTO t SELECT x,x FROM c; \
-          SELECT dolt_add('-A'); SELECT dolt_commit('-m','init'); \
-          SELECT dolt_branch('feat'); \
-          SELECT dolt_checkout('feat'); \
-          INSERT INTO t VALUES(101,999); \
-          SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat'); \
-          SELECT dolt_checkout('main'); \
-          UPDATE t SET val=0 WHERE id=1; \
-          SELECT dolt_add('-A'); SELECT dolt_commit('-m','main'); \
-          SELECT dolt_merge('feat');"
-
     - name: Correctness regression tests
       run: cd build && bash ../test/correctness_test.sh ./doltlite

--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -1424,6 +1424,26 @@ int doltliteMergeCatalogs(
                           ppActions, pnActions);
   if( rc!=SQLITE_OK ) goto merge_cleanup;
 
+  /* pass1 shallow-copies TableEntry structs from aOurs into aMerged,
+  ** which means zName pointers are aliased — aMerged[k].zName ==
+  ** aOurs[i].zName for some i. serializeMergedCatalog below frees
+  ** those strings via doltliteResolveTableNumber's refresh step,
+  ** leaving aOurs with dangling pointers. Break the aliasing here
+  ** by strdup'ing every aMerged zName so aMerged owns its own
+  ** storage and all four catalogs can be cleaned up independently
+  ** via doltliteFreeCatalog. pass2 already strdup's on append, so
+  ** this loop only needs to fix pass1's output. */
+  {
+    int k;
+    for(k=0; k<nMerged; k++){
+      if( aMerged[k].zName ){
+        char *z = sqlite3_mprintf("%s", aMerged[k].zName);
+        if( !z ){ rc = SQLITE_NOMEM; goto merge_cleanup; }
+        aMerged[k].zName = z;
+      }
+    }
+  }
+
   rc = mergeCatalogPass2(aAnc, nAnc, aOurs, nOurs, aTheirs, nTheirs,
                           aMerged, &nMerged, &iNextMerged);
   if( rc!=SQLITE_OK ) goto merge_cleanup;
@@ -1440,10 +1460,10 @@ int doltliteMergeCatalogs(
 
 merge_cleanup:
   freeConflictTables(aConflictTables, nConflictTables);
-  sqlite3_free(aAnc);
-  sqlite3_free(aOurs);
-  sqlite3_free(aTheirs);
-  sqlite3_free(aMerged);
+  doltliteFreeCatalog(aAnc, nAnc);
+  doltliteFreeCatalog(aOurs, nOurs);
+  doltliteFreeCatalog(aTheirs, nTheirs);
+  doltliteFreeCatalog(aMerged, nMerged);
   return rc;
 }
 


### PR DESCRIPTION
## Summary

Three merge-path zName leaks surfaced by running the correctness test's "Merge correctness" sub-test under ASan with stderr flowing. Root cause in \`doltliteMergeCatalogs\`:

1. Cleanup did a **bare \`sqlite3_free\`** on \`aAnc\` / \`aOurs\` / \`aTheirs\` / \`aMerged\`, losing every \`zName\` allocation inside.
2. \`pass1\` shallow-copies \`TableEntry\` structs from \`aOurs\` into \`aMerged\`, so \`zName\` pointers were aliased. \`serializeMergedCatalog\` then walks via \`doltliteResolveTableNumber\` and does \`sqlite3_free(aTables[i].zName)\` on the shared pointer, leaving \`aOurs\` with dangling ptrs and \`aMerged\` owning a fresh set that never got freed.

## Fix

- After \`pass1\`, walk \`aMerged\` and \`sqlite3_mprintf\` each \`zName\` into an independent allocation. That breaks the aliasing with \`aOurs\` so all four catalogs own their own strings.
- Swap the four bare \`sqlite3_free\` calls for \`doltliteFreeCatalog\`, which walks \`zName\` before releasing the array.
- \`pass2\` already strdup's on append, so no change needed there.

## Test plan

- [x] 39 doltlite suites pass
- [x] 41/41 correctness tests pass
- [x] asan-ubsan passes on CI — verified with a focused reproducer (removed in the follow-up commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)