### PR TITLE
Finish multi-parent helper sweep

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -1173,7 +1173,7 @@ static void doltliteCommitFunc(
           "cannot --amend: failed to load HEAD commit", -1);
         return;
       }
-      if( headCommit.nParents == 0 ){
+      if( doltliteCommitParentCount(&headCommit)==0 ){
         doltliteCommitClear(&headCommit);
         sqlite3_result_error(context,
           "cannot --amend: HEAD has no parent (initial commit)", -1);
@@ -2143,7 +2143,7 @@ static int doltliteLoadHeadAndParentedCommit(
   int rc = doltliteLoadCommit(db, pTargetHash, pTargetCommit);
   if( rc!=SQLITE_OK ) return SQLITE_NOTFOUND;
 
-  if( prollyHashIsEmpty(&pTargetCommit->parentHash) ){
+  if( doltliteCommitParentCount(pTargetCommit)==0 ){
     return SQLITE_EMPTY;
   }
 

--- a/src/doltlite_diff.c
+++ b/src/doltlite_diff.c
@@ -400,10 +400,11 @@ static int collectSummary(DoltliteDiffCursor *pCur, sqlite3 *db){
       break;
     }
 
-    for(i=0; i<commit.nParents; i++){
-      if( prollyHashIsEmpty(&commit.aParents[i]) ) continue;
-      if( prollyHashSetContains(&visited, &commit.aParents[i]) ) continue;
-      if( prollyHashSetContains(&queued,  &commit.aParents[i]) ) continue;
+    for(i=0; i<doltliteCommitParentCount(&commit); i++){
+      const ProllyHash *pParent = doltliteCommitParentHash(&commit, i);
+      if( !pParent || prollyHashIsEmpty(pParent) ) continue;
+      if( prollyHashSetContains(&visited, pParent) ) continue;
+      if( prollyHashSetContains(&queued,  pParent) ) continue;
       if( qTail>=qAlloc ){
         int newAlloc = qAlloc*2;
         ProllyHash *tmp = sqlite3_realloc(queue,
@@ -411,8 +412,8 @@ static int collectSummary(DoltliteDiffCursor *pCur, sqlite3 *db){
         if( !tmp ){ rc = SQLITE_NOMEM; break; }
         queue = tmp; qAlloc = newAlloc;
       }
-      queue[qTail++] = commit.aParents[i];
-      rc = prollyHashSetAdd(&queued, &commit.aParents[i]);
+      queue[qTail++] = *pParent;
+      rc = prollyHashSetAdd(&queued, pParent);
       if( rc!=SQLITE_OK ) break;
     }
     doltliteCommitClear(&commit);

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -649,7 +649,7 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
       DoltliteCommit c;
       memset(&c, 0, sizeof(c));
       if( doltliteLoadCommit(db, &cs->aBranches[0].commitHash, &c)==SQLITE_OK
-       && prollyHashIsEmpty(&c.parentHash) ){
+       && doltliteCommitParentCount(&c)==0 ){
         virgin = 1;
       }
       doltliteCommitClear(&c);


### PR DESCRIPTION
## Summary
- finish the remaining multi-parent helper migration in commit-walk code
- fix diff traversal to honor legacy single-parent commits represented via parentHash
- keep intentional first-parent policy explicit in command flows

## Testing
- bash test/lint_layers.sh src
- cd build && bash ../test/vc_oracle_blame_test.sh ./doltlite dolt
- cd build && bash ../test/vc_oracle_rebase_test.sh ./doltlite dolt
- cd build && bash ../test/vc_oracle_diff_stat_test.sh ./doltlite dolt
- cd build && bash ../test/sql_oracle_test.sh ./doltlite ./sqlite3