### PR TITLE
Add failed merge reopen regression

### DIFF
--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -1215,6 +1215,84 @@ static void run_merge_conflict_surfaces_error_and_persists_state(void){
   remove_db(dbpath);
 }
 
+static void run_failed_merge_reopen_preserves_working_set_state(void){
+  sqlite3 *db = 0;
+  char dbpath[256];
+  const char *res;
+  ProllyHash stagedBeforeClose;
+  ProllyHash mergeBeforeClose;
+  ProllyHash conflictsBeforeClose;
+  ProllyHash stagedAfterReopen;
+  ProllyHash mergeAfterReopen;
+  ProllyHash conflictsAfterReopen;
+  u8 isMergingBeforeClose = 0;
+  u8 isMergingAfterReopen = 0;
+
+  printf("=== Failed Merge Reopen Preserves Working Set State Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_failed_merge_reopen_preserves_working_set_state");
+  remove_db(dbpath);
+
+  check("open_db_for_failed_merge_reopen", open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_failed_merge_reopen_repo", execsql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'base');"
+    "SELECT dolt_commit('-A', '-m', 'init');"
+    "SELECT dolt_branch('feature');"
+    "UPDATE t SET v='main' WHERE id=1;"
+    "SELECT dolt_commit('-A', '-m', 'main edit');"
+    "SELECT dolt_checkout('feature');"
+    "UPDATE t SET v='feature' WHERE id=1;"
+    "SELECT dolt_commit('-A', '-m', 'feature edit');"
+    "SELECT dolt_checkout('main');")==SQLITE_OK);
+
+  res = exec1(db, "SELECT dolt_merge('feature')");
+  check("failed_merge_reopen_returns_error",
+        strstr(res, "ERROR: Merge has 1 conflict(s).")!=0);
+  check("failed_merge_reopen_conflicts_summary_before_close",
+        strcmp(exec1(db, "SELECT count(*) FROM dolt_conflicts"), "1")==0);
+  check("failed_merge_reopen_conflicts_table_before_close",
+        strcmp(exec1(db, "SELECT count(*) FROM dolt_conflicts_t"), "1")==0);
+  check("failed_merge_reopen_working_value_before_close",
+        strcmp(exec1(db, "SELECT v FROM t WHERE id=1"), "main")==0);
+  doltliteGetSessionStaged(db, &stagedBeforeClose);
+  doltliteGetSessionMergeState(db, &isMergingBeforeClose,
+                               &mergeBeforeClose, &conflictsBeforeClose);
+  check("failed_merge_reopen_staged_hash_before_close_nonempty",
+        !prollyHashIsEmpty(&stagedBeforeClose));
+  check("failed_merge_reopen_sets_merging_flag_before_close",
+        isMergingBeforeClose==1);
+  check("failed_merge_reopen_conflicts_hash_before_close_nonempty",
+        !prollyHashIsEmpty(&conflictsBeforeClose));
+
+  sqlite3_close(db);
+  db = 0;
+
+  check("reopen_db_for_failed_merge_reopen", open_db(dbpath, &db)==SQLITE_OK);
+  check("failed_merge_reopen_conflicts_summary_after_reopen",
+        strcmp(exec1(db, "SELECT count(*) FROM dolt_conflicts"), "1")==0);
+  check("failed_merge_reopen_conflicts_table_after_reopen",
+        strcmp(exec1(db, "SELECT count(*) FROM dolt_conflicts_t"), "1")==0);
+  check("failed_merge_reopen_working_value_after_reopen",
+        strcmp(exec1(db, "SELECT v FROM t WHERE id=1"), "main")==0);
+  check("failed_merge_reopen_branch_after_reopen",
+        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
+
+  doltliteGetSessionStaged(db, &stagedAfterReopen);
+  doltliteGetSessionMergeState(db, &isMergingAfterReopen,
+                               &mergeAfterReopen, &conflictsAfterReopen);
+  check("failed_merge_reopen_staged_hash_matches_after_reopen",
+        memcmp(&stagedAfterReopen, &stagedBeforeClose, sizeof(ProllyHash))==0);
+  check("failed_merge_reopen_merging_flag_persists_after_reopen",
+        isMergingAfterReopen==1);
+  check("failed_merge_reopen_merge_hash_matches_after_reopen",
+        memcmp(&mergeAfterReopen, &mergeBeforeClose, sizeof(ProllyHash))==0);
+  check("failed_merge_reopen_conflicts_hash_matches_after_reopen",
+        memcmp(&conflictsAfterReopen, &conflictsBeforeClose, sizeof(ProllyHash))==0);
+
+  sqlite3_close(db);
+  remove_db(dbpath);
+}
+
 static void run_cherry_pick_stale_branch(void){
   sqlite3 *db1 = 0;
   sqlite3 *db2 = 0;
@@ -3491,6 +3569,7 @@ static const RegressionCase aCases[] = {
   { "blame_all_parents_merge_base", "Blame All-Parents Merge Base Test", run_blame_all_parents_merge_base },
   { "merge_persist_failure", "Merge Persist Failure Test", run_merge_persist_failure },
   { "merge_conflict_surfaces_error", "Merge Conflict Surfaces Error Test", run_merge_conflict_surfaces_error_and_persists_state },
+  { "failed_merge_reopen_preserves_working_set_state", "Failed Merge Reopen Preserves Working Set State Test", run_failed_merge_reopen_preserves_working_set_state },
   { "cherry_pick_stale_branch", "Cherry-pick Stale Branch Test", run_cherry_pick_stale_branch },
   { "branches_metadata_corruption", "Branches Metadata Corruption Test", run_branches_metadata_corruption },
   { "gc_rewrite_failure", "GC Rewrite Failure Test", run_gc_rewrite_failure },


### PR DESCRIPTION
## Summary
- add a native regression for conflicted merge state surviving reopen
- assert conflict tables, working row, branch, and working-set metadata persist
- cover this durability path independently of shell oracles

## Testing
- ./build/doltlite_regression_test_c failed_merge_reopen_preserves_working_set_state
- cd build && bash ../test/vc_oracle_merge_test.sh ./doltlite dolt
- cd build && bash ../test/oracle_savepoints_test.sh ./doltlite ./sqlite3