### PR TITLE
Fix checkout persist rollback durability

### DIFF
--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -333,6 +333,22 @@ static void checkoutRestoreSession(sqlite3 *db, CheckoutMutationCtx *p){
   }
 }
 
+static int checkoutRestoreDurableState(
+  sqlite3 *db,
+  ChunkStore *cs,
+  void *pArg
+){
+  CheckoutMutationCtx *p = (CheckoutMutationCtx*)pArg;
+  int rc = chunkStoreSetDefaultBranch(cs, p->zCurrentBranch);
+  if( rc!=SQLITE_OK ) return rc;
+  if( p->haveOldState ){
+    rc = doltliteUpdateBranchWorkingState(db, p->zCurrentBranch,
+                                          &p->oldCatHash, &p->oldCommitHash);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+  return SQLITE_OK;
+}
+
 static int checkoutMutateRefs(sqlite3 *db, ChunkStore *cs, void *pArg){
   CheckoutMutationCtx *p = (CheckoutMutationCtx*)pArg;
   int rc;
@@ -571,9 +587,9 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
 
   {
     u8 *oldCatData = 0; int nOldCat = 0;
-    doltliteGetSessionHead(db, &m.oldCommitHash);
-    zCurrentBranch = sqlite3_mprintf("%s", doltliteGetSessionBranch(db));
-    if( !zCurrentBranch ){
+  doltliteGetSessionHead(db, &m.oldCommitHash);
+  zCurrentBranch = sqlite3_mprintf("%s", doltliteGetSessionBranch(db));
+  if( !zCurrentBranch ){
       sqlite3_result_error_nomem(ctx);
       return;
     }
@@ -603,6 +619,10 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
   rc = doltliteMutateRefs(db, checkoutMutateRefs, &m);
   if( rc!=SQLITE_OK ){
     checkoutRestoreSession(db, &m);
+    {
+      int restoreRc = doltliteMutateRefs(db, checkoutRestoreDurableState, &m);
+      if( restoreRc!=SQLITE_OK ) rc = restoreRc;
+    }
   }
   sqlite3_free(zCurrentBranch);
   zCurrentBranch = 0;

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -494,6 +494,7 @@ static void run_concurrent_refs(void){
 
 static void run_checkout_persist_failure(void){
   sqlite3 *db1 = 0;
+  sqlite3 *db2 = 0;
   char dbpath[256];
   const char *res;
 
@@ -521,8 +522,27 @@ static void run_checkout_persist_failure(void){
   check("checkout_returns_error_on_persist_failure", strstr(res, "ERROR:")!=0);
   check("session_branch_restored_after_error",
     strcmp(exec1(db1, "SELECT active_branch()"), "main")==0);
+  check("working_rows_preserved_after_checkout_error",
+    strcmp(exec1(db1, "SELECT count(*) FROM t"), "1")==0);
 
   sqlite3_close(db1);
+  db1 = 0;
+
+  check("reopen_db_after_checkout_persist_failure", open_db(dbpath, &db2)==SQLITE_OK);
+  check("active_branch_persists_after_checkout_error",
+    strcmp(exec1(db2, "SELECT active_branch()"), "main")==0);
+  check("main_rows_persist_after_checkout_error",
+    strcmp(exec1(db2, "SELECT count(*) FROM t"), "1")==0);
+  check("feature_tip_still_visible_after_checkout_error",
+    strcmp(exec1(db2,
+      "SELECT latest_commit_message FROM dolt_branches WHERE name='feature'"),
+      "init")==0);
+  check("feature_checkout_still_works_after_checkout_error",
+    strcmp(exec1(db2, "SELECT dolt_checkout('feature')"), "0")==0);
+  check("feature_rows_visible_after_reopen_checkout",
+    strcmp(exec1(db2, "SELECT count(*) FROM t"), "1")==0);
+
+  sqlite3_close(db2);
   remove_db(dbpath);
 }
 


### PR DESCRIPTION
## Summary
- extend the native checkout persist-failure regression to assert durable state after reopen
- fix dolt_checkout rollback so a persist failure restores the current branch working state durably
- keep branch switch behavior and sql oracle coverage green

## Testing
- ./build/doltlite_regression_test_c checkout_persist_failure
- cd build && bash ../test/vc_oracle_checkout_test.sh ./doltlite dolt
- cd build && bash ../test/sql_oracle_test.sh ./doltlite ./sqlite3