### PR TITLE
fix: auto-register violation vtables after commit + refuse WITHOUT ROWID loudly

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -74,6 +74,7 @@ extern int doltliteAtRegister(sqlite3 *db);
 extern int doltliteRegisterAtTables(sqlite3 *db);
 extern int doltliteRegisterHistoryTables(sqlite3 *db);
 extern int doltliteRegisterBlameTables(sqlite3 *db);
+extern int doltliteRefreshConstraintViolationTables(sqlite3 *db);
 extern int doltliteSchemaDiffRegister(sqlite3 *db);
 extern int doltliteRemoteSqlRegister(sqlite3 *db);
 
@@ -1338,6 +1339,11 @@ static void doltliteCommitFunc(
     sqlite3_result_error_code(context, rc);
     return;
   }
+  rc = doltliteRefreshConstraintViolationTables(db);
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error_code(context, rc);
+    return;
+  }
 
   sqlite3_result_text(context, hexBuf, -1, SQLITE_TRANSIENT);
 }
@@ -2140,32 +2146,47 @@ static void doltliteMergeFunc(
   }
   {
     extern int doltliteDetectMergeFkViolations(
-        sqlite3*, const ProllyHash*, int*);
+        sqlite3*, const ProllyHash*, char**, int*);
     extern int doltliteDetectMergeUniqueViolations(
-        sqlite3*, const ProllyHash*, int*);
+        sqlite3*, const ProllyHash*, char**, int*);
     extern int doltliteDetectMergeCheckViolations(
-        sqlite3*, const ProllyHash*, int*);
+        sqlite3*, const ProllyHash*, char**, int*);
     int nViolations = 0;
     int nUnique = 0;
     int nCheck = 0;
+    char *zDetectErrMsg = 0;
     /* Pass the three-way-merge ancestor catalog hash so each
     ** walker can filter out pre-existing violations — rows that
     ** were already broken before either side of the merge
     ** started. Dolt's semantics only flag merge-introduced
     ** violations, not any violating row that happens to be in
-    ** the post-merge tree. */
-    int vrc = doltliteDetectMergeFkViolations(db, &ancCatHash, &nViolations);
+    ** the post-merge tree. zDetectErrMsg captures any user-facing
+    ** error text a walker wants to surface (e.g. the WITHOUT
+    ** ROWID refusal) — we pass it through to the merge result
+    ** so users get an actionable message instead of "SQL logic
+    ** error". */
+    int vrc = doltliteDetectMergeFkViolations(db, &ancCatHash,
+                                              &zDetectErrMsg, &nViolations);
     if( vrc == SQLITE_OK ){
-      vrc = doltliteDetectMergeUniqueViolations(db, &ancCatHash, &nUnique);
+      vrc = doltliteDetectMergeUniqueViolations(db, &ancCatHash,
+                                                &zDetectErrMsg, &nUnique);
     }
     if( vrc == SQLITE_OK ){
-      vrc = doltliteDetectMergeCheckViolations(db, &ancCatHash, &nCheck);
+      vrc = doltliteDetectMergeCheckViolations(db, &ancCatHash,
+                                               &zDetectErrMsg, &nCheck);
     }
     if( vrc != SQLITE_OK ){
-      sqlite3_result_error_code(context,
-          doltliteRestoreTxnStateOnFailure(db, &savedState, vrc));
+      if( zDetectErrMsg ){
+        sqlite3_result_error(context, zDetectErrMsg, -1);
+        sqlite3_free(zDetectErrMsg);
+        doltliteRestoreTxnStateOnFailure(db, &savedState, vrc);
+      }else{
+        sqlite3_result_error_code(context,
+            doltliteRestoreTxnStateOnFailure(db, &savedState, vrc));
+      }
       return;
     }
+    sqlite3_free(zDetectErrMsg);
     if( nUnique > 0 ){
       /* The unique-index walker evicts loser rows from the base
       ** via DELETE — flush those mutations out of the mutmap and

--- a/src/doltlite_constraint_violations.c
+++ b/src/doltlite_constraint_violations.c
@@ -732,7 +732,15 @@ static sqlite3_module cvRowModule = {
   0,0,0,0,0,0,0,0,0,0,0
 };
 
-static int doltliteRegisterConstraintViolationTables(sqlite3 *db){
+/* Walk the session's user tables and register a
+** dolt_constraint_violations_<table> vtable for each one that
+** doesn't already have one. Safe to call repeatedly —
+** doltliteForEachUserTable skips tables whose module is
+** already registered. Exposed so the commit / checkout / merge
+** / reset flows can refresh the surface for tables created
+** mid-session, matching how the diff / history / at / blame
+** / conflicts vtables get refreshed. */
+int doltliteRefreshConstraintViolationTables(sqlite3 *db){
   return doltliteForEachUserTable(db, "dolt_constraint_violations_", &cvRowModule);
 }
 
@@ -741,7 +749,7 @@ int doltliteConstraintViolationsRegister(sqlite3 *db){
   rc = sqlite3_create_module(db, "dolt_constraint_violations",
                              &cvSummaryModule, 0);
   if( rc==SQLITE_OK ){
-    rc = doltliteRegisterConstraintViolationTables(db);
+    rc = doltliteRefreshConstraintViolationTables(db);
   }
   return rc;
 }

--- a/src/doltlite_merge_constraints.c
+++ b/src/doltlite_merge_constraints.c
@@ -271,6 +271,56 @@ static int isRowPreExisting(
   return memcmp(pMergedVal, pAncVal, nMergedVal)==0 ? 1 : 0;
 }
 
+/* Probe whether zTable exposes a `rowid` column. Returns 1 if
+** the table has a rowid (standard SQLite tables), 0 if it is
+** declared WITHOUT ROWID. The post-merge walkers lean heavily
+** on rowid to identify specific violating rows and to fetch
+** their prolly-layer payload; WITHOUT ROWID tables break every
+** piece of that pipeline, so detection refuses to proceed
+** rather than silently miss violations. Tracked in GitHub
+** issue #495 — proper WITHOUT ROWID support requires a prolly-
+** layer-level walker that keys on the composite PK instead. */
+static int tableHasRowid(sqlite3 *db, const char *zTable){
+  sqlite3_stmt *pStmt = 0;
+  char *zQuery;
+  int rc;
+  zQuery = sqlite3_mprintf("SELECT rowid FROM \"%w\" LIMIT 0", zTable);
+  if( !zQuery ) return 1; /* treat OOM as rowid — caller will fail elsewhere */
+  rc = sqlite3_prepare_v2(db, zQuery, -1, &pStmt, 0);
+  sqlite3_free(zQuery);
+  if( pStmt ) sqlite3_finalize(pStmt);
+  return rc == SQLITE_OK ? 1 : 0;
+}
+
+/* Emit a descriptive error and return SQLITE_ERROR. Used when a
+** walker refuses to process a WITHOUT ROWID table. Writes a
+** user-facing message into *ppzErrMsg (owned by sqlite3_free)
+** so the merge function can surface it via sqlite3_result_error
+** instead of falling back to the generic "SQL logic error"
+** text. Safe to pass a NULL ppzErrMsg. */
+static int refuseWithoutRowid(
+  sqlite3 *db,
+  char **ppzErrMsg,
+  const char *zTable,
+  const char *zWhich
+){
+  char *zMsg = sqlite3_mprintf(
+      "constraint-violation detection on WITHOUT ROWID tables is not "
+      "yet supported (%s check on \"%s\"); see GitHub issue #495. "
+      "Drop WITHOUT ROWID or use INTEGER PRIMARY KEY to keep merges flowing.",
+      zWhich, zTable);
+  if( zMsg ){
+    sqlite3_log(SQLITE_ERROR, "%s", zMsg);
+    if( ppzErrMsg && !*ppzErrMsg ){
+      *ppzErrMsg = zMsg;
+    }else{
+      sqlite3_free(zMsg);
+    }
+  }
+  (void)db;
+  return SQLITE_ERROR;
+}
+
 /* Resolve a (zTable, rowid) pair to the raw prolly row by looking
 ** the table up in the current btree's catalog via the public
 ** doltliteGetSessionTableRoot accessor and walking its prolly
@@ -325,12 +375,14 @@ static int detectUniqueViolationsForIndex(
   const char *zTable,
   const char *zIndexName,
   const char *zCols,
+  char **pzErrMsg,
   int *pnFound
 ){
   sqlite3_stmt *pScan = 0;
   char *zQuery;
   char *zWinnerKey = 0;
   int rc;
+  (void)pzErrMsg;
 
   zQuery = sqlite3_mprintf(
     "SELECT rowid, %s FROM \"%w\" NOT INDEXED ORDER BY %s, rowid",
@@ -431,6 +483,7 @@ static int detectUniqueViolationsForIndex(
 int doltliteDetectMergeUniqueViolations(
   sqlite3 *db,
   const ProllyHash *pAncCatHash,
+  char **pzErrMsg,
   int *pnFound
 ){
   sqlite3_stmt *pTbls = 0;
@@ -496,6 +549,17 @@ int doltliteDetectMergeUniqueViolations(
       zOrigin = (const char*)sqlite3_column_text(pIdxList, 3);
       if( zOrigin && strcmp(zOrigin, "pk")==0 ) continue;
 
+      /* We've found a non-PK unique index to walk. That means we
+      ** actually need a way to identify violating rows by rowid —
+      ** which fails on WITHOUT ROWID / non-INTEGER-PK tables.
+      ** Refuse loudly rather than silently walking garbage.
+      ** (Tables with only the PK autoindex don't trip this
+      ** branch and still merge cleanly on WITHOUT ROWID.) */
+      if( !tableHasRowid(db, zTable) ){
+        rc = refuseWithoutRowid(db, pzErrMsg, zTable, "unique index");
+        break;
+      }
+
       zIdx = sqlite3_mprintf("%s", zIdxRaw);
       if( !zIdx ) break;
       zColsQ = sqlite3_mprintf("PRAGMA index_xinfo(%Q)", zIdx);
@@ -518,7 +582,8 @@ int doltliteDetectMergeUniqueViolations(
       zColList = sqlite3_str_finish(pColList);
       if( zColList && *zColList ){
         rc = detectUniqueViolationsForIndex(db, aAnc, nAnc, zTable,
-                                             zIdx, zColList, pnFound);
+                                             zIdx, zColList, pzErrMsg,
+                                             pnFound);
       }
       sqlite3_free(zColList);
       sqlite3_free(zIdx);
@@ -653,6 +718,7 @@ static int nextCheckClause(
 int doltliteDetectMergeCheckViolations(
   sqlite3 *db,
   const ProllyHash *pAncCatHash,
+  char **pzErrMsg,
   int *pnFound
 ){
   sqlite3_stmt *pTbls = 0;
@@ -695,6 +761,25 @@ int doltliteDetectMergeCheckViolations(
       sqlite3_free(zSql);
       rc = SQLITE_NOMEM;
       break;
+    }
+
+    /* Refuse WITHOUT ROWID tables that carry a CHECK clause.
+    ** Tables with no CHECK expressions pass through unharmed
+    ** because nextCheckClause returns 0 on the first call and
+    ** the main loop exits immediately. */
+    {
+      char *zPeekExpr = 0;
+      char *zPeekName = 0;
+      int peekOffset = 0;
+      int peekRc = nextCheckClause(zSql, &peekOffset, &zPeekExpr, &zPeekName);
+      sqlite3_free(zPeekExpr);
+      sqlite3_free(zPeekName);
+      if( peekRc > 0 && !tableHasRowid(db, zTable) ){
+        rc = refuseWithoutRowid(db, pzErrMsg, zTable, "check constraint");
+        sqlite3_free(zTable);
+        sqlite3_free(zSql);
+        break;
+      }
     }
 
     for(;;){
@@ -805,6 +890,7 @@ int doltliteDetectMergeCheckViolations(
 int doltliteDetectMergeFkViolations(
   sqlite3 *db,
   const ProllyHash *pAncCatHash,
+  char **pzErrMsg,
   int *pnFound
 ){
   sqlite3_stmt *pStmt = 0;
@@ -839,7 +925,17 @@ int doltliteDetectMergeFkViolations(
     int appendRc;
 
     if( !zTable ) continue;
-    if( sqlite3_column_type(pStmt, 1) == SQLITE_NULL ) continue;
+    /* PRAGMA foreign_key_check reports rowid=NULL for WITHOUT
+    ** ROWID child tables, which means we lose the ability to
+    ** identify and fetch the specific orphan row via the
+    ** existing rowid-keyed machinery. Fail the detection pass
+    ** rather than silently skipping — a passing merge that
+    ** leaves an FK orphan in place is worse than a merge that
+    ** refuses to run. */
+    if( sqlite3_column_type(pStmt, 1) == SQLITE_NULL ){
+      rc = refuseWithoutRowid(db, pzErrMsg, zTable, "foreign key");
+      break;
+    }
     rowid = sqlite3_column_int64(pStmt, 1);
     fkid  = sqlite3_column_int(pStmt, 3);
 

--- a/test/vc_oracle_fk_merge_test.sh
+++ b/test/vc_oracle_fk_merge_test.sh
@@ -71,6 +71,15 @@ dl_setup() {
   "$DOLTLITE" "$db" 2>"$TMPROOT/$tag.err" >/dev/null
 }
 
+# Bulk setup capturing stdout too. Used by the single-session
+# scenarios (e.g. the vtable-auto-register tests) where the
+# setup statements and the assertion queries must run in the
+# same process to exercise in-session registration.
+dl_setup_capture() {
+  local db="$1" tag="$2"
+  "$DOLTLITE" "$db" >"$TMPROOT/$tag.out" 2>"$TMPROOT/$tag.err"
+}
+
 # Does the given SQL error out? Returns 0 (true) if any error
 # token shows up in stdout/stderr, 1 otherwise.
 dl_errors() {
@@ -409,6 +418,80 @@ SQL
 
 N=$(dl "$DB" "SELECT count(*) FROM dolt_constraint_violations;" "check_preexisting_count")
 expect_eq "check_preexisting_not_reflagged" "0" "$N"
+
+echo ""
+
+# ── Scenario I: vtable auto-register after mid-session CREATE + commit ─
+#
+# Per #494: dolt_constraint_violations_<table> used to register
+# only at db open time via doltliteForEachUserTable, so a table
+# created in a live session never got its per-table vtable
+# until the next reopen. Post-commit refresh now re-runs the
+# registration walker, matching how dolt_diff_<table> and
+# friends behave. Everything in this scenario runs in a single
+# doltlite process so we actually exercise in-session state.
+echo "--- I. dolt_constraint_violations_<table> auto-registers after in-session CREATE + commit ---"
+
+DB="$TMPROOT/vtable_autoreg.db"
+rm -f "$DB"
+cat <<'SQL' | dl_setup_capture "$DB" "vtable_autoreg"
+CREATE TABLE parent(pk INTEGER PRIMARY KEY, v1 INT, UNIQUE(v1));
+CREATE TABLE child(pk INTEGER PRIMARY KEY, v1 INT, FOREIGN KEY(v1) REFERENCES parent(v1));
+INSERT INTO parent VALUES (1,1),(2,2);
+INSERT INTO child VALUES (1,1);
+SELECT dolt_commit('-Am','init');
+SELECT '=== query after commit ===' AS marker;
+SELECT count(*) FROM dolt_constraint_violations_child;
+SELECT count(*) FROM dolt_constraint_violations_parent;
+SQL
+
+if grep -q "no such table: dolt_constraint_violations_" "$TMPROOT/vtable_autoreg.out" \
+                                                         "$TMPROOT/vtable_autoreg.err" 2>/dev/null; then
+  fail_name "vtable_autoreg_after_commit"
+  echo "    (in-session query after commit still reports no such table)"
+else
+  pass_name "vtable_autoreg_after_commit"
+fi
+
+echo ""
+
+# ── Scenario J: WITHOUT ROWID FK merge refused loudly ────
+#
+# Per #495: constraint-violation detection assumes every table
+# has a rowid and breaks silently on WITHOUT ROWID tables.
+# Until prolly-layer-level support lands, the walker refuses
+# the merge loudly with an actionable error instead of
+# silently committing over missed violations. This scenario
+# verifies that behavior: a merge that would produce an FK
+# orphan on a WITHOUT ROWID child table must fail with the
+# issue-495 error message, not silently commit.
+echo "--- J. WITHOUT ROWID FK merge is refused loudly ---"
+
+DB="$TMPROOT/without_rowid_fk.db"
+rm -f "$DB"
+cat <<'SQL' | dl_setup_capture "$DB" "without_rowid_fk"
+CREATE TABLE parent(pk INTEGER PRIMARY KEY, v1 INT, UNIQUE(v1));
+CREATE TABLE child(pk TEXT PRIMARY KEY, v1 INT, FOREIGN KEY(v1) REFERENCES parent(v1)) WITHOUT ROWID;
+INSERT INTO parent VALUES (1,1),(2,2);
+INSERT INTO child VALUES ('a',1);
+SELECT dolt_commit('-Am','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO child VALUES ('b',2);
+SELECT dolt_commit('-Am','feat_add_child');
+SELECT dolt_checkout('main');
+DELETE FROM parent WHERE pk=2;
+SELECT dolt_commit('-Am','main_drop_parent');
+SELECT dolt_merge('feat');
+SQL
+
+if grep -q "WITHOUT ROWID" "$TMPROOT/without_rowid_fk.out" \
+                            "$TMPROOT/without_rowid_fk.err" 2>/dev/null; then
+  pass_name "without_rowid_fk_refused"
+else
+  fail_name "without_rowid_fk_refused"
+  echo "    (merge did not surface the WITHOUT ROWID refusal)"
+fi
 
 echo ""
 echo "======================================="


### PR DESCRIPTION
Stacks fixes for two known limitations filed during the #483 self-review. Both are tracked as separate GitHub issues and both are now closable.

Closes #494, closes #495.

Fix for #494: auto-register dolt_constraint_violations_<table>

`doltliteConstraintViolationsRegister` only ran at db-open time via `doltliteForEachUserTable`, so tables created in a live session never got their per-table violations vtable until the next reopen. `CREATE TABLE` + `dolt_commit` + `SELECT FROM dolt_constraint_violations_<table>` within one process hit "no such table".

Fix: renamed the static helper to `doltliteRefreshConstraintViolationTables`, made it non-static, and added a call to `doltliteCommitFunc`'s post-commit refresh chain next to the existing `RegisterDiffTables` / `RegisterHistoryTables` / `RegisterAtTables` / `RegisterBlameTables` calls. Matches how the sibling vtable families already handle mid-session CREATEs.

Oracle scenario I exercises this via a new `dl_setup_capture` helper that captures stdout+stderr so we can grep for the no-such-table error.

Fix for #495: WITHOUT ROWID / non-INTEGER-PK refusal

All three detection walkers (FK / UNIQUE / CHECK) assume every table has a rowid and fall back to rowid-keyed lookup to identify violations. On WITHOUT ROWID tables — including doltlite's TEXT PK and composite PK tables, which internally key on PK bytes without exposing a SQL rowid — the walkers silently misbehaved:

- FK: `PRAGMA foreign_key_check` returned NULL-rowid rows, walker skipped them via `continue`, silent orphan miss.
- UNIQUE / CHECK: `SELECT rowid ...` would fail to prepare on rowid-less tables (unreached in existing tests).

A proper prolly-layer-level fix is a significant refactor (the issue stays open). In the meantime the walkers now refuse WITHOUT ROWID tables loudly with an actionable error pointing at #495. A passing merge that leaves an FK orphan in place is strictly worse than a merge that refuses to run.

Design call: defer the probe

My first attempt broke 4 pre-existing `vc_oracle_merge_test.sh` scenarios (`three_way_text_pk`, `three_way_composite_pk`, etc.) because they use TEXT / composite PK tables and my UNIQUE walker refused them unconditionally at the top of each table iteration. Fixed by deferring the probe:

- FK walker refuses only when `PRAGMA foreign_key_check` actually returns a NULL-rowid row (= an FK violation exists on a WITHOUT ROWID table).
- UNIQUE walker refuses only when we find a non-PK unique index to walk. Tables with only the PK autoindex never trigger the refusal.
- CHECK walker peeks for a `CHECK` clause in the DDL first and only probes when one is present.

Plumbing

New `pzErrMsg` out-param threaded through all three walker signatures so the user-facing refusal message ("constraint-violation detection on WITHOUT ROWID tables is not yet supported ...") gets surfaced via `sqlite3_result_error` instead of the generic "SQL logic error". `doltliteMergeFunc` cleans up the buffer on both success and error paths.

Oracle scenario J constructs a minimal FK orphan against a WITHOUT ROWID child table and asserts the captured merge output contains "WITHOUT ROWID".

Test plan

| Suite | Result |
|---|---|
| `vc_oracle_fk_merge_test.sh` | 25 / 25 (was 23; + I + J) |
| `doltlite_regression_test_c all` | 107046 / 107046 |
| `vc_oracle_merge_test.sh` | 31 / 31 |
| `vc_oracle_conflicts_test.sh` | 9 / 9 |
| `sql_oracle_test.sh` vs stock sqlite3 | 526 / 526 |
| Total | 107,637 / 107,637 |

- [x] Full FK oracle with new I + J scenarios
- [x] C regression
- [x] SQL oracle vs stock sqlite3
- [x] VC merge / conflicts oracles (including the previously-passing TEXT / composite PK cases that caught my over-eager refusal)
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

