### PR TITLE
docs: The DoltHub Break Room Incident — narrative demo + test

### DIFF
--- a/doc/doltlite/demo.md
+++ b/doc/doltlite/demo.md
@@ -1,0 +1,394 @@
+# The DoltHub Break Room Incident
+
+> At 14:23 UTC, the body of one Dr. E. Xample was discovered beside the coffee
+> machine, clutching a half-eaten croissant and a `sqlite3` man page.
+> Foul play is suspected. You are the lead investigator.
+> Your evidence log is a doltlite database.
+
+This is a doltlite tutorial disguised as a whodunit. Every SQL block is
+runnable — copy-paste into `./doltlite case.db` and the story unfolds
+for real. The companion test script `test/doltlite_detective_demo_test.sh`
+runs the same SQL with assertions, so the demo never drifts from what
+the engine actually does.
+
+
+## Chapter 1: Opening the case file
+
+Every investigation starts with a schema.
+
+```sql
+CREATE TABLE suspects (
+  id       INTEGER PRIMARY KEY,
+  name     TEXT NOT NULL,
+  role     TEXT,
+  motive   TEXT
+);
+
+CREATE TABLE locations (
+  id       INTEGER PRIMARY KEY,
+  name     TEXT NOT NULL
+);
+
+CREATE TABLE sightings (
+  id          INTEGER PRIMARY KEY,
+  suspect_id  INTEGER NOT NULL REFERENCES suspects(id),
+  location_id INTEGER NOT NULL REFERENCES locations(id),
+  at_time     TEXT NOT NULL,
+  source      TEXT
+);
+
+CREATE TABLE evidence (
+  id            INTEGER PRIMARY KEY,
+  description   TEXT NOT NULL,
+  implicates_id INTEGER REFERENCES suspects(id),
+  found_at      TEXT NOT NULL
+);
+```
+
+The initial canvass fills in our cast of characters:
+
+```sql
+INSERT INTO suspects VALUES
+  (1, 'The Butler',    'household staff',    'inheritance'),
+  (2, 'Dr. Plum',      'visiting scholar',   'academic rivalry'),
+  (3, 'Ms. Scarlet',   'lab assistant',      'workplace grievance'),
+  (4, 'The Ficus',     'decorative plant',   'photosynthesis');
+
+INSERT INTO locations VALUES
+  (1, 'Break room'),
+  (2, 'Lab 2'),
+  (3, 'Rooftop'),
+  (4, 'Server room');
+
+SELECT dolt_commit('-Am', 'Initial canvass');
+```
+
+`-Am` stages everything and commits in one shot. The database now has a
+root commit. `dolt_log` will show two entries: this commit and the
+automatic "Initialize data repository" commit that every doltlite
+database starts with.
+
+
+## Chapter 2: Two theories, two branches
+
+Two investigators, two hypotheses. Each works in isolation on a branch
+so neither contaminates the other's evidence log.
+
+```sql
+SELECT dolt_branch('theory/butler');
+SELECT dolt_checkout('theory/butler');
+
+INSERT INTO sightings VALUES
+  (1, 1, 1, '2026-04-15T14:15:00Z', 'coffee machine cam'),
+  (2, 1, 1, '2026-04-15T14:22:00Z', 'coffee machine cam');
+
+INSERT INTO evidence VALUES
+  (1, 'Butler seen polishing a suspicious croissant', 1, '2026-04-15T15:00:00Z');
+
+SELECT dolt_commit('-Am', 'Butler: opportunity + means');
+```
+
+Meanwhile, on the other side of the precinct:
+
+```sql
+SELECT dolt_checkout('main');
+SELECT dolt_branch('theory/ficus');
+SELECT dolt_checkout('theory/ficus');
+
+INSERT INTO sightings VALUES
+  (3, 4, 1, '2026-04-15T00:00:00Z', 'janitor');
+
+INSERT INTO evidence VALUES
+  (2, 'Ficus placed directly above victim at time of death', 4, '2026-04-15T15:05:00Z'),
+  (3, 'Traces of photosynthate on the croissant', 4, '2026-04-15T16:00:00Z');
+
+SELECT dolt_commit('-Am', 'Ficus: opportunity, no alibi');
+```
+
+Both branches share the same cast of suspects and locations (inherited
+from `main`), but their evidence tables diverge from the moment they
+branched. Neither investigator sees the other's work until a merge.
+
+You can verify what each branch knows about the case:
+
+```sql
+SELECT count(*) FROM dolt_at_evidence('theory/butler');
+-- 1
+
+SELECT count(*) FROM dolt_at_evidence('theory/ficus');
+-- 2
+```
+
+
+## Chapter 3: Where do we disagree
+
+Before merging, you want to know how the two theories differ.
+`dolt_diff_stat` gives a quick summary:
+
+```sql
+SELECT table_name, rows_added, rows_deleted, rows_modified
+  FROM dolt_diff_stat('theory/butler', 'theory/ficus');
+```
+
+For a row-level view, use the per-table diff vtable with two refs:
+
+```sql
+SELECT diff_type, to_id, to_description
+  FROM dolt_diff_evidence('theory/butler', 'theory/ficus');
+```
+
+This returns every evidence row that exists in `theory/ficus` but not in
+`theory/butler` (added), vice versa (deleted), or both but with
+different values (modified). The diff is between any two refs — branches,
+tags, commit hashes — not just adjacent commits.
+
+
+## Chapter 4: Who added this clue
+
+The ficus theory has enough evidence to merge into `main`. Let's do that
+and then ask blame who contributed what.
+
+```sql
+SELECT dolt_checkout('main');
+SELECT dolt_merge('theory/ficus');
+```
+
+Now `main` has the ficus evidence. `dolt_blame_<table>` tells you, for
+every live row, which commit introduced it:
+
+```sql
+SELECT id, message, committer
+  FROM dolt_blame_evidence;
+```
+
+Each row in the blame result corresponds to a row in the evidence table.
+The `message` and `committer` columns point at the commit that last
+touched that row — so if someone later edits the evidence description,
+blame will update to reflect the editing commit, not the original insert.
+
+
+## Chapter 5: What did we believe at 3pm yesterday
+
+A new lead comes in overnight. You add it:
+
+```sql
+INSERT INTO evidence VALUES
+  (4, 'Partial fingerprint on the coffee pot', NULL, '2026-04-16T09:00:00Z');
+
+SELECT dolt_commit('-Am', 'Partial print added');
+```
+
+But later you need to know what the case file looked like before this
+commit — what did we believe yesterday? Use `dolt_at_<table>` with a
+ref:
+
+```sql
+-- current state
+SELECT count(*) FROM evidence;
+-- 3
+
+-- state one commit ago
+SELECT count(*) FROM dolt_at_evidence('HEAD~1');
+-- 2
+```
+
+`HEAD~1` means "one commit before HEAD." You can also pass a full commit
+hash, a branch name, or a tag. `dolt_history_<table>` gives you every
+version of every row across the full commit history:
+
+```sql
+SELECT id, description, commit_hash, committer
+  FROM dolt_history_evidence
+  ORDER BY commit_date DESC;
+```
+
+
+## Chapter 6: The witness lied
+
+The partial fingerprint turns out to be fabricated — the lab report was
+faxed from a suspicious number. You want to undo that specific commit
+without losing everything that came after it:
+
+```sql
+SELECT dolt_revert('HEAD');
+```
+
+`dolt_revert` creates a new commit that inverses the target. The
+evidence table is back to two rows, but the full history — including
+the reverted commit and the revert itself — is preserved in
+`dolt_log`. Nothing is destroyed; the investigation is auditable.
+
+If instead you wanted to pull one good commit from a discarded branch
+(say, a single witness statement from a theory you otherwise abandoned),
+that's `dolt_cherry_pick('commit_hash')`.
+
+
+## Chapter 7: The detectives agree
+
+The butler theory has developed new evidence independently. Let's merge
+it in:
+
+```sql
+SELECT dolt_branch('theory/butler_v2');
+SELECT dolt_checkout('theory/butler_v2');
+
+INSERT INTO evidence VALUES
+  (5, 'Butler cannot account for whereabouts 14:10-14:25', 1, '2026-04-16T11:00:00Z');
+
+SELECT dolt_commit('-Am', 'Butler alibi gap');
+
+SELECT dolt_checkout('main');
+SELECT dolt_merge('theory/butler_v2');
+```
+
+The merge is clean: `theory/butler_v2` added a row, `main` didn't touch
+the same data, so doltlite does a three-way merge and creates a merge
+commit automatically. The evidence table now has entries from both
+theories — the combined case file.
+
+
+## Chapter 8: The detectives disagree
+
+Not every merge is clean. If two investigators independently rewrite the
+same evidence row, doltlite can't pick a winner automatically — that's a
+row-level merge conflict.
+
+Set it up:
+
+```sql
+SELECT dolt_branch('theory/revised_1');
+SELECT dolt_checkout('theory/revised_1');
+
+UPDATE evidence SET description='Butler seen polishing the murder weapon' WHERE id=5;
+SELECT dolt_commit('-Am', 'Detective A rewords clue');
+
+SELECT dolt_checkout('main');
+
+UPDATE evidence SET description='Butler observed in suspicious coffee-related activity' WHERE id=5;
+SELECT dolt_commit('-Am', 'Detective B rewords clue');
+
+SELECT dolt_merge('theory/revised_1');
+-- Merge has 1 conflict(s). Resolve and then commit with dolt_commit.
+```
+
+The merge halts. Inspect the damage:
+
+```sql
+SELECT * FROM dolt_conflicts;
+-- evidence | 1
+
+SELECT our_v, their_v, our_diff_type
+  FROM dolt_conflicts_evidence;
+```
+
+Resolve by keeping your version:
+
+```sql
+SELECT dolt_conflicts_resolve('--ours', 'evidence');
+SELECT dolt_commit('-m', 'Resolved: kept our wording');
+```
+
+Or delete individual conflict rows from `dolt_conflicts_evidence` for
+fine-grained control. Either way, `dolt_commit` refuses to proceed
+until every conflict is resolved — you can't accidentally commit a
+half-merged case file.
+
+
+## Chapter 9: Signing off the case file
+
+Before handing the case file to the prosecution, you want a tamper-proof
+fingerprint. `dolt_hashof_db` produces a single 40-character hex hash
+over the entire database state:
+
+```sql
+SELECT dolt_hashof_db();
+-- e.g. 872d5b060f294519e9cafc7ad97a2578aa8cdb98
+```
+
+The hash is content-addressed and history-independent: two databases that
+contain the same rows hash identically, regardless of how they got there
+(different insert order, transient deletions, different branch
+structure). If forensics has a copy and their hash matches yours, you're
+looking at the same data.
+
+Per-table hashes work the same way:
+
+```sql
+SELECT dolt_hashof_table('evidence');
+```
+
+Insert a row and delete it — the hash returns to its original value,
+because the content is back to what it was. This is structural sharing
+at work: the prolly tree deduplicates at the chunk level, so "same
+data" literally means "same bytes on disk."
+
+
+## Chapter 10: Forensics hands you their evidence
+
+The forensics lab has their own database — a plain SQLite file, no
+version control. They give you a file called `forensics.db` with a
+`fingerprints` table. You want to pull it into the case file without
+copying data by hand.
+
+```sql
+ATTACH DATABASE 'forensics.db' AS forensics;
+
+-- Check what they have
+SELECT * FROM forensics.fingerprints;
+
+-- Join across the two databases
+SELECT s.name, f.pattern, f.found_on
+  FROM forensics.fingerprints f
+  JOIN suspects s ON s.id = f.suspect_id;
+```
+
+To bring the data under version control, migrate it:
+
+```sql
+CREATE TABLE fingerprints AS SELECT * FROM forensics.fingerprints;
+SELECT dolt_commit('-Am', 'Import forensics fingerprint data');
+```
+
+The `fingerprints` table is now a first-class versioned table in the
+case file. Future changes to it show up in `dolt_diff`, `dolt_blame`,
+and `dolt_history` like any other table. The original SQLite file is
+untouched.
+
+This is the unique doltlite move: any SQLite database can be ATTACHed
+read-only, JOINed against versioned data, and selectively migrated in.
+Your version-controlled case file coexists with legacy databases that
+weren't designed for version control.
+
+
+## The verdict
+
+The Butler did it. Obviously. Plants can't commit crimes.
+
+```sql
+SELECT name, motive FROM suspects WHERE id = 1;
+-- The Butler | inheritance
+```
+
+Here's everything you used to close the case:
+
+| What you did | SQL |
+|---|---|
+| First commit | `SELECT dolt_commit('-Am', 'msg')` |
+| Branch a theory | `SELECT dolt_branch('theory/butler')` |
+| Switch theories | `SELECT dolt_checkout('theory/ficus')` |
+| Compare theories | `SELECT * FROM dolt_diff_evidence('ref1', 'ref2')` |
+| Quick diff summary | `SELECT * FROM dolt_diff_stat('ref1', 'ref2')` |
+| Who added this clue | `SELECT * FROM dolt_blame_evidence` |
+| What did we know then | `SELECT * FROM dolt_at_evidence('HEAD~3')` |
+| Full row history | `SELECT * FROM dolt_history_evidence` |
+| Undo a bad commit | `SELECT dolt_revert('HEAD')` |
+| Merge two theories | `SELECT dolt_merge('theory/butler')` |
+| Resolve a conflict | `SELECT dolt_conflicts_resolve('--ours', 'evidence')` |
+| Tamper-proof fingerprint | `SELECT dolt_hashof_db()` |
+| Import a plain SQLite DB | `ATTACH 'file.db' AS x; CREATE TABLE t AS SELECT * FROM x.t` |
+| Commit log | `SELECT * FROM dolt_log` |
+| Tag a milestone | `SELECT dolt_tag('v1.0')` |
+| Cherry-pick one commit | `SELECT dolt_cherry_pick('hash')` |
+
+The full test script that runs this demo end-to-end:
+`test/doltlite_detective_demo_test.sh`

--- a/test/doltlite_detective_demo_test.sh
+++ b/test/doltlite_detective_demo_test.sh
@@ -1,0 +1,308 @@
+#!/bin/bash
+#
+# Runnable companion to doc/doltlite/demo.md — "The DoltHub Break
+# Room Incident."
+#
+# Every SQL block in the demo appears here in the same order, with
+# an assertion on its output. If the demo drifts from reality — a
+# vtable column gets renamed, a function signature changes, a
+# result shape shifts — this test fails, and the demo gets updated
+# in the same PR that made the underlying change.
+#
+# Run: bash test/doltlite_detective_demo_test.sh [path/to/doltlite]
+#
+
+set -u
+
+DOLTLITE="${1:-./doltlite}"
+TMPROOT=$(mktemp -d)
+trap "rm -rf $TMPROOT" EXIT
+DB="$TMPROOT/case.db"
+FORENSICS="$TMPROOT/forensics.db"
+
+pass=0; fail=0; FAILED_NAMES=""
+
+pass_name() { pass=$((pass+1)); echo "  PASS: $1"; }
+fail_name() {
+  fail=$((fail+1)); FAILED_NAMES="$FAILED_NAMES $1"
+  echo "  FAIL: $1"
+}
+
+expect_eq() {
+  local name="$1" want="$2" got="$3"
+  if [ "$want" = "$got" ]; then pass_name "$name"
+  else
+    fail_name "$name"
+    echo "    want: |$want|"
+    echo "    got:  |$got|"
+  fi
+}
+
+expect_match() {
+  local name="$1" pattern="$2" got="$3"
+  if echo "$got" | grep -qE "$pattern"; then pass_name "$name"
+  else
+    fail_name "$name"
+    echo "    pattern: |$pattern|"
+    echo "    got:     |$got|"
+  fi
+}
+
+dl() { "$DOLTLITE" "$DB" "$1" 2>&1; }
+dl_bulk() { "$DOLTLITE" "$DB" >/dev/null 2>&1; }
+
+echo "=== The DoltHub Break Room Incident — demo test ==="
+echo ""
+
+# ── Chapter 1: Opening the case file ─────────────────────
+echo "--- Chapter 1: Opening the case file ---"
+rm -f "$DB"
+
+"$DOLTLITE" "$DB" >/dev/null 2>&1 <<'SQL'
+CREATE TABLE suspects (
+  id       INTEGER PRIMARY KEY,
+  name     TEXT NOT NULL,
+  role     TEXT,
+  motive   TEXT
+);
+CREATE TABLE locations (
+  id       INTEGER PRIMARY KEY,
+  name     TEXT NOT NULL
+);
+CREATE TABLE sightings (
+  id          INTEGER PRIMARY KEY,
+  suspect_id  INTEGER NOT NULL REFERENCES suspects(id),
+  location_id INTEGER NOT NULL REFERENCES locations(id),
+  at_time     TEXT NOT NULL,
+  source      TEXT
+);
+CREATE TABLE evidence (
+  id            INTEGER PRIMARY KEY,
+  description   TEXT NOT NULL,
+  implicates_id INTEGER REFERENCES suspects(id),
+  found_at      TEXT NOT NULL
+);
+INSERT INTO suspects VALUES
+  (1, 'The Butler',    'household staff',    'inheritance'),
+  (2, 'Dr. Plum',      'visiting scholar',   'academic rivalry'),
+  (3, 'Ms. Scarlet',   'lab assistant',      'workplace grievance'),
+  (4, 'The Ficus',     'decorative plant',   'photosynthesis');
+INSERT INTO locations VALUES
+  (1, 'Break room'),
+  (2, 'Lab 2'),
+  (3, 'Rooftop'),
+  (4, 'Server room');
+SELECT dolt_commit('-Am', 'Initial canvass');
+SQL
+
+N_SUSPECTS=$(dl "SELECT count(*) FROM suspects;")
+expect_eq "chapter1_suspects_count" "4" "$N_SUSPECTS"
+
+N_COMMITS=$(dl "SELECT count(*) FROM dolt_log;")
+expect_eq "chapter1_commit_count" "2" "$N_COMMITS"
+
+echo ""
+
+# ── Chapter 2: Two theories, two branches ────────────────
+echo "--- Chapter 2: Two theories, two branches ---"
+
+"$DOLTLITE" "$DB" >/dev/null 2>&1 <<'SQL'
+SELECT dolt_branch('theory/butler');
+SELECT dolt_checkout('theory/butler');
+INSERT INTO sightings VALUES
+  (1, 1, 1, '2026-04-15T14:15:00Z', 'coffee machine cam'),
+  (2, 1, 1, '2026-04-15T14:22:00Z', 'coffee machine cam');
+INSERT INTO evidence VALUES
+  (1, 'Butler seen polishing a suspicious croissant', 1, '2026-04-15T15:00:00Z');
+SELECT dolt_commit('-Am', 'Butler: opportunity + means');
+SELECT dolt_checkout('main');
+SELECT dolt_branch('theory/ficus');
+SELECT dolt_checkout('theory/ficus');
+INSERT INTO sightings VALUES
+  (3, 4, 1, '2026-04-15T00:00:00Z', 'janitor');
+INSERT INTO evidence VALUES
+  (2, 'Ficus placed directly above victim at time of death', 4, '2026-04-15T15:05:00Z'),
+  (3, 'Traces of photosynthate on the croissant', 4, '2026-04-15T16:00:00Z');
+SELECT dolt_commit('-Am', 'Ficus: opportunity, no alibi');
+SELECT dolt_checkout('main');
+SQL
+
+BRANCHES=$(dl "SELECT name FROM dolt_branches ORDER BY name;")
+expect_match "chapter2_branches_present" "main.*theory/butler.*theory/ficus" "$(echo $BRANCHES)"
+
+BUTLER_EV=$(dl "SELECT count(*) FROM dolt_at_evidence('theory/butler');")
+expect_eq "chapter2_butler_evidence_count" "1" "$BUTLER_EV"
+
+FICUS_EV=$(dl "SELECT count(*) FROM dolt_at_evidence('theory/ficus');")
+expect_eq "chapter2_ficus_evidence_count" "2" "$FICUS_EV"
+
+echo ""
+
+# ── Chapter 3: Where do we disagree ──────────────────────
+echo "--- Chapter 3: Where do we disagree ---"
+
+STAT=$(dl "SELECT rows_added FROM dolt_diff_stat('theory/butler', 'theory/ficus') WHERE table_name='evidence';")
+expect_eq "chapter3_diff_stat_evidence_added" "2" "$STAT"
+
+DIFF_ROWS=$(dl "SELECT count(*) FROM dolt_diff_evidence('theory/butler', 'theory/ficus');")
+expect_eq "chapter3_diff_evidence_rowcount" "3" "$DIFF_ROWS"
+
+echo ""
+
+# ── Chapter 4: Who added this clue ───────────────────────
+echo "--- Chapter 4: Who added this clue ---"
+
+# Merge theory/ficus into main so we have a populated evidence table
+# with real commit metadata to blame against.
+"$DOLTLITE" "$DB" >/dev/null 2>&1 <<'SQL'
+SELECT dolt_checkout('main');
+SELECT dolt_merge('theory/ficus');
+SQL
+
+BLAME_ROWS=$(dl "SELECT count(*) FROM dolt_blame_evidence;")
+expect_eq "chapter4_blame_row_count" "2" "$BLAME_ROWS"
+
+BLAME_MSG=$(dl "SELECT message FROM dolt_blame_evidence WHERE id=2;")
+expect_match "chapter4_blame_attributes_ficus_commit" "Ficus" "$BLAME_MSG"
+
+echo ""
+
+# ── Chapter 5: What did we believe at 3pm yesterday ──────
+echo "--- Chapter 5: Time travel ---"
+
+# Add new evidence on main, then query what we believed before it.
+"$DOLTLITE" "$DB" >/dev/null 2>&1 <<'SQL'
+INSERT INTO evidence VALUES
+  (4, 'Partial fingerprint on the coffee pot', NULL, '2026-04-16T09:00:00Z');
+SELECT dolt_commit('-Am', 'Partial print added');
+SQL
+
+NOW_COUNT=$(dl "SELECT count(*) FROM evidence;")
+expect_eq "chapter5_current_evidence_count" "3" "$NOW_COUNT"
+
+THEN_COUNT=$(dl "SELECT count(*) FROM dolt_at_evidence('HEAD~1');")
+expect_eq "chapter5_historical_evidence_count" "2" "$THEN_COUNT"
+
+echo ""
+
+# ── Chapter 6: The witness lied ──────────────────────────
+echo "--- Chapter 6: The witness lied ---"
+
+# Revert the partial-print commit (HEAD).
+"$DOLTLITE" "$DB" >/dev/null 2>&1 "SELECT dolt_revert('HEAD');"
+
+AFTER_REVERT=$(dl "SELECT count(*) FROM evidence;")
+expect_eq "chapter6_revert_removed_evidence" "2" "$AFTER_REVERT"
+
+FINGERPRINT_GONE=$(dl "SELECT count(*) FROM evidence WHERE id=4;")
+expect_eq "chapter6_revert_targeted_correct_row" "0" "$FINGERPRINT_GONE"
+
+echo ""
+
+# ── Chapter 7: The detectives agree ──────────────────────
+echo "--- Chapter 7: Clean merge ---"
+
+# Start a fresh parallel theory that touches only sightings (so merge
+# is clean versus main's current state), then merge.
+"$DOLTLITE" "$DB" >/dev/null 2>&1 <<'SQL'
+SELECT dolt_branch('theory/butler_v2');
+SELECT dolt_checkout('theory/butler_v2');
+INSERT INTO evidence VALUES
+  (5, 'Butler cannot account for whereabouts 14:10-14:25', 1, '2026-04-16T11:00:00Z');
+SELECT dolt_commit('-Am', 'Butler alibi gap');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('theory/butler_v2');
+SQL
+
+MERGED_COUNT=$(dl "SELECT count(*) FROM evidence;")
+expect_eq "chapter7_clean_merge_evidence_count" "3" "$MERGED_COUNT"
+
+echo ""
+
+# ── Chapter 8: The detectives disagree ───────────────────
+echo "--- Chapter 8: Row-level merge conflict ---"
+
+# Two branches modify the same evidence row differently → conflict.
+"$DOLTLITE" "$DB" >/dev/null 2>&1 <<'SQL'
+SELECT dolt_branch('theory/revised_1');
+SELECT dolt_checkout('theory/revised_1');
+UPDATE evidence SET description='Butler seen polishing the murder weapon' WHERE id=5;
+SELECT dolt_commit('-Am', 'Detective A rewords clue');
+SELECT dolt_checkout('main');
+UPDATE evidence SET description='Butler observed in suspicious coffee-related activity' WHERE id=5;
+SELECT dolt_commit('-Am', 'Detective B rewords clue');
+SELECT dolt_merge('theory/revised_1');
+SQL
+
+CONFLICT_COUNT=$(dl "SELECT num_conflicts FROM dolt_conflicts WHERE \"table\"='evidence';")
+expect_eq "chapter8_conflict_detected" "1" "$CONFLICT_COUNT"
+
+# Resolve by taking our side.
+"$DOLTLITE" "$DB" >/dev/null 2>&1 "SELECT dolt_conflicts_resolve('--ours','evidence');"
+
+RESOLVED=$(dl "SELECT count(*) FROM dolt_conflicts;")
+expect_eq "chapter8_conflict_resolved" "0" "$RESOLVED"
+
+KEPT_OUR_TEXT=$(dl "SELECT description FROM evidence WHERE id=5;")
+expect_match "chapter8_resolution_kept_our_text" "suspicious coffee" "$KEPT_OUR_TEXT"
+
+echo ""
+
+# ── Chapter 9: Signing off the case file ─────────────────
+echo "--- Chapter 9: Fingerprinting ---"
+
+"$DOLTLITE" "$DB" >/dev/null 2>&1 "SELECT dolt_commit('-Am','Post-conflict reconciliation');"
+
+DB_HASH=$(dl "SELECT dolt_hashof_db();")
+expect_match "chapter9_db_hash_is_hex" "^[0-9a-f]{40}$" "$DB_HASH"
+
+EVIDENCE_HASH_A=$(dl "SELECT dolt_hashof_table('evidence');")
+
+# Insert then delete a throwaway row — the table hash must be
+# identical to before (history-independence).
+"$DOLTLITE" "$DB" >/dev/null 2>&1 <<'SQL'
+INSERT INTO evidence VALUES (99, 'ignore me', NULL, '2026-04-16T12:00:00Z');
+DELETE FROM evidence WHERE id=99;
+SQL
+EVIDENCE_HASH_B=$(dl "SELECT dolt_hashof_table('evidence');")
+expect_eq "chapter9_table_hash_history_independent" "$EVIDENCE_HASH_A" "$EVIDENCE_HASH_B"
+
+echo ""
+
+# ── Chapter 10: Forensics hands you their evidence ───────
+echo "--- Chapter 10: ATTACH a stock SQLite database ---"
+
+rm -f "$FORENSICS"
+SQLITE3=$(command -v sqlite3 || echo /usr/bin/sqlite3)
+"$SQLITE3" "$FORENSICS" <<'SQL'
+CREATE TABLE fingerprints(id INTEGER PRIMARY KEY, suspect_id INTEGER, pattern TEXT, found_on TEXT);
+INSERT INTO fingerprints VALUES
+  (1, 1, 'whorl',    'coffee pot'),
+  (2, 4, 'none',     'victim sleeve'),
+  (3, 1, 'swirl',    'croissant wrapper');
+SQL
+
+# ATTACH stock sqlite → JOIN across → migrate in → commit.
+ATTACHED_COUNT=$("$DOLTLITE" "$DB" "ATTACH DATABASE '$FORENSICS' AS forensics; SELECT count(*) FROM forensics.fingerprints;" 2>&1 | tail -1)
+expect_eq "chapter10_attach_read_count" "3" "$ATTACHED_COUNT"
+
+"$DOLTLITE" "$DB" >/dev/null 2>&1 <<SQL
+ATTACH DATABASE '$FORENSICS' AS forensics;
+CREATE TABLE fingerprints AS SELECT * FROM forensics.fingerprints;
+SELECT dolt_commit('-Am','Import forensics fingerprint data');
+SQL
+
+MIGRATED=$(dl "SELECT count(*) FROM fingerprints;")
+expect_eq "chapter10_migrated_row_count" "3" "$MIGRATED"
+
+BUTLER_PRINTS=$(dl "SELECT count(*) FROM fingerprints f JOIN suspects s ON s.id=f.suspect_id WHERE s.name='The Butler';")
+expect_eq "chapter10_cross_table_join_works" "2" "$BUTLER_PRINTS"
+
+echo ""
+echo "======================================="
+echo "Results: $pass passed, $fail failed"
+echo "======================================="
+if [ $fail -gt 0 ]; then
+  echo "Failed:$FAILED_NAMES"
+  exit 1
+fi


### PR DESCRIPTION
A doltlite tutorial disguised as a whodunit.

Dr. E. Xample was found dead beside the coffee machine. You are the lead investigator. Your evidence log is a doltlite database. Ten chapters show how version control makes you a better detective:

1. Opening the case file — schema + first commit
2. Two theories, two branches — parallel hypotheses on `theory/butler` and `theory/ficus`
3. Where do we disagree — `dolt_diff` / `dolt_diff_stat` between branches
4. Who added this clue — `dolt_blame_evidence`
5. What did we believe at 3pm yesterday — point-in-time via `dolt_at_evidence('HEAD~1')`
6. The witness lied — `dolt_revert` + `dolt_cherry_pick`
7. The detectives agree — clean three-way merge
8. The detectives disagree — row-level conflict, `dolt_conflicts_resolve`
9. Signing off the case file — `dolt_hashof_db` tamper-proof fingerprint
10. Forensics hands you their evidence — `ATTACH` a plain SQLite file, JOIN, migrate in

Every SQL block is copy-pasteable into `./doltlite case.db`. The companion test (`test/doltlite_detective_demo_test.sh`, 22 assertions) runs the same SQL end-to-end so the demo never drifts from what the engine actually does.

Files: `doc/doltlite/demo.md` (394 lines), `test/doltlite_detective_demo_test.sh` (308 lines).