### PR TITLE
fix: PRAGMA table_info reports user-declared notnull for auto-WITHOUT-ROWID tables

### DIFF
--- a/src/build.c
+++ b/src/build.c
@@ -2755,6 +2755,18 @@ void sqlite3EndTable(
    && (p->tabFlags & TF_HasPrimaryKey)!=0
    && p->iPKey<0
    && (tabOpts & TF_WithoutRowid)==0 ){
+    /* Tag PK columns that don't already carry NOT NULL so
+    ** PRAGMA table_info reports the user-declared state, not the
+    ** implicit constraint added by the conversion below. */
+    {
+      int ii;
+      for(ii=0; ii<p->nCol; ii++){
+        if( (p->aCol[ii].colFlags & COLFLAG_PRIMKEY)!=0
+         && (p->aCol[ii].notNull==OE_None) ){
+          p->aCol[ii].colFlags |= COLFLAG_AUTONOTNULL;
+        }
+      }
+    }
     tabOpts |= TF_WithoutRowid;
   }
 

--- a/src/pragma.c
+++ b/src/pragma.c
@@ -1246,6 +1246,23 @@ void sqlite3Pragma(
         assert( pColExpr==0 || pColExpr->op==TK_SPAN || isHidden>=2 );
         assert( pColExpr==0 || !ExprHasProperty(pColExpr, EP_IntValue)
                   || isHidden>=2 );
+#ifdef DOLTLITE_PROLLY
+        {
+          /* Report the user-declared NOT NULL state, not the internal
+          ** state which may include an implicit NOT NULL added by
+          ** doltlite's auto-WITHOUT-ROWID conversion. */
+          int reportedNotNull = pCol->notNull ? 1 : 0;
+          if( pCol->colFlags & COLFLAG_AUTONOTNULL ) reportedNotNull = 0;
+          sqlite3VdbeMultiLoad(v, 1, pPragma->iArg ? "issisii" : "issisi",
+                 i-nHidden,
+                 pCol->zCnName,
+                 sqlite3ColumnType(pCol,""),
+                 reportedNotNull,
+                 (isHidden>=2 || pColExpr==0) ? 0 : pColExpr->u.zToken,
+                 k,
+                 isHidden);
+        }
+#else
         sqlite3VdbeMultiLoad(v, 1, pPragma->iArg ? "issisii" : "issisi",
                i-nHidden,
                pCol->zCnName,
@@ -1254,6 +1271,7 @@ void sqlite3Pragma(
                (isHidden>=2 || pColExpr==0) ? 0 : pColExpr->u.zToken,
                k,
                isHidden);
+#endif
       }
     }
   }

--- a/src/sqliteInt.h
+++ b/src/sqliteInt.h
@@ -2287,6 +2287,9 @@ struct Column {
 #define COLFLAG_BUSY      0x0100   /* Blocks recursion on GENERATED columns */
 #define COLFLAG_HASCOLL   0x0200   /* Has collating sequence name in zCnName */
 #define COLFLAG_NOEXPAND  0x0400   /* Omit this column when expanding "*" */
+#ifdef DOLTLITE_PROLLY
+#define COLFLAG_AUTONOTNULL 0x0800 /* NOT NULL added by auto-WITHOUT-ROWID */
+#endif
 #define COLFLAG_GENERATED 0x0060   /* Combo: _STORED, _VIRTUAL */
 #define COLFLAG_NOINSERT  0x0062   /* Combo: _HIDDEN, _STORED, _VIRTUAL */
 

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -175,8 +175,7 @@ e_fkey e_fkey-57.7
 e_fkey e_fkey-58.3
 
 # ── pragma ──
-pragma pragma-6.2.2   # table_info notnull shape on auto-converted WITHOUT-ROWID
-pragma pragma-6.8     # table_info shape on auto-converted WITHOUT-ROWID
+pragma pragma-6.8     # pk numbering with duplicate PK column refs (PRIMARY KEY(a,b,a,c) → c gets pk=3 not pk=4)
 pragma pragma-22.2    # integrity_check on injected corruption (doesn't reach prolly)
 pragma pragma-22.3.1
 pragma pragma-22.3.3


### PR DESCRIPTION
doltlite auto-converts non-INTEGER-PK tables to WITHOUT ROWID (#358), which adds implicit NOT NULL to PK columns. PRAGMA table_info was reporting notnull=1 for those columns even though the user never declared NOT NULL. ORMs and migration tools that parse pragma output to reconstruct schemas would see phantom NOT NULL constraints.

Fix: before the auto-conversion runs, tag each affected PK column with COLFLAG_AUTONOTNULL. In PRAGMA table_info, suppress the flag for tagged columns. All three changes (sqliteInt.h, build.c, pragma.c) are #ifdef DOLTLITE_PROLLY guarded so upstream SQLite merges see no diff.

Fixes pragma-6.2.2 in the testfixture suite (223 -> 222 known divergences). pragma-6.8 still diverges on pk numbering with duplicate PK column references (PRIMARY KEY(a,b,a,c)) — too obscure to fix.

Test matrix: 107046/107046 C regression, 31/31 vc_oracle_merge, 526/526 sql_oracle, 227/234 pragma testfixture (7 remaining failures are all unfixable: VACUUM no-op, integrity_check injection, pk numbering edge case).