### PR TITLE
Strengthen correctness regressions and rebase authority

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -2860,6 +2860,96 @@ struct RebasePlanRow {
   char *zCommitMessage;
 };
 
+enum DoltliteRebaseSchemaState {
+  DOLTLITE_REBASE_SCHEMA_ABSENT = 0,
+  DOLTLITE_REBASE_SCHEMA_OK = 1,
+  DOLTLITE_REBASE_SCHEMA_BAD = 2
+};
+
+static int doltliteRebaseSchemaState(sqlite3 *db, int *pState){
+  sqlite3_stmt *pStmt = 0;
+  int rc;
+  int nCol = 0;
+
+  *pState = DOLTLITE_REBASE_SCHEMA_ABSENT;
+  rc = sqlite3_prepare_v2(db, "PRAGMA main.table_info(\"dolt_rebase\")",
+                          -1, &pStmt, 0);
+  if( rc!=SQLITE_OK ) return rc;
+
+  while( (rc = sqlite3_step(pStmt))==SQLITE_ROW ){
+    const char *zName = (const char*)sqlite3_column_text(pStmt, 1);
+    const char *zType = (const char*)sqlite3_column_text(pStmt, 2);
+    int notNull = sqlite3_column_int(pStmt, 3);
+    int pkPos = sqlite3_column_int(pStmt, 5);
+    char aff;
+    if( !zName ) goto bad;
+    aff = sqlite3AffinityType(zType ? zType : "", 0);
+    if( nCol==0 ){
+      if( sqlite3_stricmp(zName, "rebase_order")!=0 ) goto bad;
+      if( aff!=SQLITE_AFF_REAL && aff!=SQLITE_AFF_NUMERIC ) goto bad;
+      if( !notNull ) goto bad;
+      if( pkPos!=1 ) goto bad;
+    }else if( nCol==1 ){
+      if( sqlite3_stricmp(zName, "action")!=0 ) goto bad;
+      if( aff!=SQLITE_AFF_TEXT ) goto bad;
+      if( pkPos!=0 ) goto bad;
+    }else if( nCol==2 ){
+      if( sqlite3_stricmp(zName, "commit_hash")!=0 ) goto bad;
+      if( aff!=SQLITE_AFF_TEXT ) goto bad;
+      if( pkPos!=0 ) goto bad;
+    }else if( nCol==3 ){
+      if( sqlite3_stricmp(zName, "commit_message")!=0 ) goto bad;
+      if( aff!=SQLITE_AFF_TEXT ) goto bad;
+      if( pkPos!=0 ) goto bad;
+    }else{
+      goto bad;
+    }
+    nCol++;
+  }
+  if( rc!=SQLITE_DONE ){
+    sqlite3_finalize(pStmt);
+    return rc;
+  }
+  sqlite3_finalize(pStmt);
+
+  if( nCol==0 ){
+    *pState = DOLTLITE_REBASE_SCHEMA_ABSENT;
+  }else if( nCol==4 ){
+    *pState = DOLTLITE_REBASE_SCHEMA_OK;
+  }else{
+    *pState = DOLTLITE_REBASE_SCHEMA_BAD;
+  }
+  return SQLITE_OK;
+
+bad:
+  *pState = DOLTLITE_REBASE_SCHEMA_BAD;
+  sqlite3_finalize(pStmt);
+  return SQLITE_OK;
+}
+
+static int doltliteValidateRebasePlanTable(sqlite3 *db, char **pzErr){
+  int rc;
+  int state;
+  if( pzErr ) *pzErr = 0;
+  rc = doltliteRebaseSchemaState(db, &state);
+  if( rc!=SQLITE_OK ) return rc;
+  if( state==DOLTLITE_REBASE_SCHEMA_OK ) return SQLITE_OK;
+  if( state==DOLTLITE_REBASE_SCHEMA_ABSENT ){
+    if( pzErr ) *pzErr = sqlite3_mprintf("no rebase plan found");
+    return SQLITE_NOTFOUND;
+  }
+  if( pzErr ){
+    *pzErr = sqlite3_mprintf(
+      "dolt_rebase has an unexpected schema; expected: "
+      "CREATE TABLE dolt_rebase("
+      "rebase_order REAL PRIMARY KEY, "
+      "action TEXT, "
+      "commit_hash TEXT, "
+      "commit_message TEXT)");
+  }
+  return SQLITE_CONSTRAINT;
+}
+
 static void rebaseFreePlan(RebasePlanRow *aPlan, int nPlan){
   int i;
   for(i=0; i<nPlan; i++){
@@ -2876,13 +2966,20 @@ static int rebaseReadPlan(sqlite3 *db, RebasePlanRow **paPlan, int *pnPlan){
   RebasePlanRow *aPlan = 0;
   int nPlan = 0, nAlloc = 0;
   int rc;
+  char *zErr = 0;
 
   *paPlan = 0;
   *pnPlan = 0;
 
+  rc = doltliteValidateRebasePlanTable(db, &zErr);
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(zErr);
+    return rc;
+  }
+
   rc = sqlite3_prepare_v2(db,
     "SELECT rebase_order, action, commit_hash, commit_message "
-    "FROM dolt_rebase ORDER BY rebase_order", -1, &pStmt, 0);
+    "FROM main.dolt_rebase ORDER BY rebase_order", -1, &pStmt, 0);
   if( rc!=SQLITE_OK ) return rc;
 
   while( (rc = sqlite3_step(pStmt))==SQLITE_ROW ){
@@ -2953,7 +3050,7 @@ static int rebaseCreateAndPopulatePlanTable(
   int i;
 
   rc = sqlite3_exec(db,
-    "CREATE TABLE dolt_rebase("
+    "CREATE TABLE main.dolt_rebase("
     "  rebase_order REAL PRIMARY KEY,"
     "  action TEXT,"
     "  commit_hash TEXT,"
@@ -2962,7 +3059,7 @@ static int rebaseCreateAndPopulatePlanTable(
   if( rc!=SQLITE_OK ) return rc;
 
   rc = sqlite3_prepare_v2(db,
-    "INSERT INTO dolt_rebase VALUES (?, 'pick', ?, ?)", -1, &pIns, 0);
+    "INSERT INTO main.dolt_rebase VALUES (?, 'pick', ?, ?)", -1, &pIns, 0);
   if( rc!=SQLITE_OK ) return rc;
 
   for(i=0; i<nReplay; i++){
@@ -3093,8 +3190,9 @@ static void rebaseDiscardWorkingBranch(
   const char *zWorkingBranch
 ){
   ChunkStore *cs = doltliteGetChunkStore(db);
+  char *zErr = 0;
 
-  (void)sqlite3_exec(db, "DROP TABLE IF EXISTS dolt_rebase", 0, 0, 0);
+  (void)sqlite3_exec(db, "DROP TABLE IF EXISTS main.dolt_rebase", 0, 0, 0);
   doltliteClearSessionRebaseState(db);
   (void)doltlitePersistWorkingSet(db);
 
@@ -3323,6 +3421,7 @@ static void doltliteRebaseInteractiveContinue(
   int bPlanDropped = 0;
   ProllyHash curCat;
   ProllyHash curHead;
+  char *zPlanErr = 0;
 
   memset(&curCat, 0, sizeof(curCat));
   memset(&curHead, 0, sizeof(curHead));
@@ -3335,6 +3434,13 @@ static void doltliteRebaseInteractiveContinue(
   zOrigBranch = sqlite3_mprintf("%s", zOrigBranchConst);
   zWorking = sqlite3_mprintf("%s", doltliteGetSessionBranch(db));
   if( !zOrigBranch || !zWorking ){ rc = SQLITE_NOMEM; goto abort_err; }
+
+  rc = doltliteValidateRebasePlanTable(db, &zPlanErr);
+  if( rc!=SQLITE_OK ){
+    if( zPlanErr ) sqlite3_result_error(context, zPlanErr, -1);
+    sqlite3_free(zPlanErr);
+    goto abort_err_silent;
+  }
 
   rc = rebaseReadPlan(db, &aPlan, &nPlan);
   if( rc!=SQLITE_OK ) goto abort_err;
@@ -3352,7 +3458,7 @@ static void doltliteRebaseInteractiveContinue(
     goto abort_err_silent;
   }
 
-  rc = sqlite3_exec(db, "DROP TABLE dolt_rebase", 0, 0, 0);
+  rc = sqlite3_exec(db, "DROP TABLE main.dolt_rebase", 0, 0, 0);
   if( rc!=SQLITE_OK ) goto abort_err;
   bPlanDropped = 1;
 

--- a/src/doltlite_blame.c
+++ b/src/doltlite_blame.c
@@ -504,7 +504,7 @@ static int blameWalk(
       return rc;
     }
 
-    if( commit.nParents >= 2 ){
+    if( doltliteCommitParentCount(&commit) >= 2 ){
       /* Merge commit: compare against the merge base of all parents. */
       ProllyHash baseHash;
       DoltliteCommit baseCommit;

--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -400,21 +400,19 @@ static int registerCommitParents(
   const char *zCurHex
 ){
   int i;
-  int nParents;
   const ProllyHash *pParent;
   int rc;
 
-  nParents = pCommit->nParents>0
-               ? pCommit->nParents
-               : (prollyHashIsEmpty(&pCommit->parentHash) ? 0 : 1);
-  for(i=0; i<nParents; i++){
-    pParent = pCommit->nParents>0 ? &pCommit->aParents[i] : &pCommit->parentHash;
+  for(i=0; i<doltliteCommitParentCount(pCommit); i++){
+    pParent = doltliteCommitParentHash(pCommit, i);
+    if( !pParent ) continue;
     rc = mapPut(paMap, pnMap, pParent, pCurTblRoot, &pCommit->catalogHash,
                 pCurSchemaHash, curFlags, zCurHex, pCommit->timestamp);
     if( rc!=SQLITE_OK ) return rc;
   }
-  for(i=0; i<nParents; i++){
-    pParent = pCommit->nParents>0 ? &pCommit->aParents[i] : &pCommit->parentHash;
+  for(i=0; i<doltliteCommitParentCount(pCommit); i++){
+    pParent = doltliteCommitParentHash(pCommit, i);
+    if( !pParent ) continue;
     rc = stackPushUnique(paAdded, pnAdded, paStack, pnStack, pParent);
     if( rc!=SQLITE_OK ) return rc;
   }

--- a/src/doltlite_remote.c
+++ b/src/doltlite_remote.c
@@ -493,19 +493,20 @@ static int syncIsAncestor(
       memset(&commit, 0, sizeof(commit));
       if( doltliteCommitDeserialize(data, nData, &commit)==SQLITE_OK ){
         int pi;
-        for(pi=0; pi<commit.nParents; pi++){
-          if( prollyHashIsEmpty(&commit.aParents[pi]) ) continue;
-          if( prollyHashCompare(&commit.aParents[pi], pAncestor)==0 ){
+        for(pi=0; pi<doltliteCommitParentCount(&commit); pi++){
+          const ProllyHash *pParent = doltliteCommitParentHash(&commit, pi);
+          if( !pParent || prollyHashIsEmpty(pParent) ) continue;
+          if( prollyHashCompare(pParent, pAncestor)==0 ){
             found = 1;
             break;
           }
-          if( !prollyHashSetContains(&visited, &commit.aParents[pi]) ){
-            rc = prollyHashSetAdd(&visited, &commit.aParents[pi]);
+          if( !prollyHashSetContains(&visited, pParent) ){
+            rc = prollyHashSetAdd(&visited, pParent);
             if( rc!=SQLITE_OK ){
               found = -1;
               break;
             }
-            rc = syncQueuePush(&queue, &commit.aParents[pi]);
+            rc = syncQueuePush(&queue, pParent);
             if( rc!=SQLITE_OK ){
               found = -1;
               break;

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -150,11 +150,65 @@ struct DiffCountCtx {
   int nChange;
 };
 
+typedef struct RepoStateSnapshot RepoStateSnapshot;
+struct RepoStateSnapshot {
+  char zBranch[128];
+  char zHead[128];
+  char zStatusCount[32];
+  char zConflictsCount[32];
+  char zRemotesCount[32];
+  char zRebasePlanCount[32];
+  u8 isMerging;
+  u8 isRebasing;
+  ProllyHash mergeHash;
+  ProllyHash conflictsHash;
+  ProllyHash rebaseOntoHash;
+  char zOrigBranch[128];
+};
+
 static int count_diff_change(void *pCtx, const ProllyDiffChange *pChange){
   DiffCountCtx *p = (DiffCountCtx*)pCtx;
   (void)pChange;
   p->nChange++;
   return SQLITE_OK;
+}
+
+static void capture_repo_state_snapshot(sqlite3 *db, RepoStateSnapshot *p){
+  const char *zOrigBranch = 0;
+  memset(p, 0, sizeof(*p));
+  sqlite3_snprintf(sizeof(p->zBranch), p->zBranch, "%s",
+                   exec1(db, "SELECT active_branch()"));
+  sqlite3_snprintf(sizeof(p->zHead), p->zHead, "%s",
+                   exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1"));
+  sqlite3_snprintf(sizeof(p->zStatusCount), p->zStatusCount, "%s",
+                   exec1(db, "SELECT count(*) FROM dolt_status"));
+  sqlite3_snprintf(sizeof(p->zConflictsCount), p->zConflictsCount, "%s",
+                   exec1(db, "SELECT count(*) FROM dolt_conflicts"));
+  sqlite3_snprintf(sizeof(p->zRemotesCount), p->zRemotesCount, "%s",
+                   exec1(db, "SELECT count(*) FROM dolt_remotes"));
+  sqlite3_snprintf(sizeof(p->zRebasePlanCount), p->zRebasePlanCount, "%s",
+                   exec1(db, "SELECT count(*) FROM sqlite_master "
+                             "WHERE type='table' AND name='dolt_rebase'"));
+  doltliteGetSessionMergeState(db, &p->isMerging, &p->mergeHash, &p->conflictsHash);
+  doltliteGetSessionRebaseState(db, &p->isRebasing, 0, &p->rebaseOntoHash, &zOrigBranch);
+  if( zOrigBranch ){
+    sqlite3_snprintf(sizeof(p->zOrigBranch), p->zOrigBranch, "%s", zOrigBranch);
+  }
+}
+
+static int repo_state_snapshot_eq(const RepoStateSnapshot *a, const RepoStateSnapshot *b){
+  return strcmp(a->zBranch, b->zBranch)==0
+      && strcmp(a->zHead, b->zHead)==0
+      && strcmp(a->zStatusCount, b->zStatusCount)==0
+      && strcmp(a->zConflictsCount, b->zConflictsCount)==0
+      && strcmp(a->zRemotesCount, b->zRemotesCount)==0
+      && strcmp(a->zRebasePlanCount, b->zRebasePlanCount)==0
+      && a->isMerging==b->isMerging
+      && a->isRebasing==b->isRebasing
+      && prollyHashCompare(&a->mergeHash, &b->mergeHash)==0
+      && prollyHashCompare(&a->conflictsHash, &b->conflictsHash)==0
+      && prollyHashCompare(&a->rebaseOntoHash, &b->rebaseOntoHash)==0
+      && strcmp(a->zOrigBranch, b->zOrigBranch)==0;
 }
 
 static void make_dbpath(char *zBuf, size_t nBuf, const char *zBase){
@@ -1352,6 +1406,8 @@ static void run_merge_abort_after_reopen_restores_durable_state(void){
   ProllyHash mergeHash;
   ProllyHash conflictsHash;
   char zHeadBefore[128];
+  RepoStateSnapshot beforeReopenAbort;
+  RepoStateSnapshot afterReopenAbort;
 
   printf("=== Merge Abort After Reopen Restores Durable State Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_merge_abort_after_reopen_restores_durable_state");
@@ -1405,6 +1461,7 @@ static void run_merge_abort_after_reopen_restores_durable_state(void){
   check("merge_abort_after_reopen_clears_merge_flag", isMerging==0);
   check("merge_abort_after_reopen_clears_conflicts_hash",
         prollyHashIsEmpty(&conflictsHash));
+  capture_repo_state_snapshot(db, &beforeReopenAbort);
 
   sqlite3_close(db);
   db = 0;
@@ -1422,6 +1479,9 @@ static void run_merge_abort_after_reopen_restores_durable_state(void){
   check("merge_abort_persists_merge_flag_cleared", isMerging==0);
   check("merge_abort_persists_conflicts_hash_cleared",
         prollyHashIsEmpty(&conflictsHash));
+  capture_repo_state_snapshot(db, &afterReopenAbort);
+  check("merge_abort_reopen_snapshot_matches",
+        repo_state_snapshot_eq(&beforeReopenAbort, &afterReopenAbort));
 
   sqlite3_close(db);
   remove_db(dbpath);
@@ -3442,6 +3502,8 @@ static void run_rebase_abort_after_reopen_restores_durable_state(void){
   u8 isRebasing = 0;
   const char *zOrigBranch = 0;
   char zHeadBefore[128];
+  RepoStateSnapshot beforeReopenAbort;
+  RepoStateSnapshot afterReopenAbort;
 
   printf("=== Rebase Abort After Reopen Restores Durable State Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_rebase_abort_after_reopen_restores_durable_state");
@@ -3498,6 +3560,7 @@ static void run_rebase_abort_after_reopen_restores_durable_state(void){
           "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='dolt_rebase'"), "0")==0);
   doltliteGetSessionRebaseState(db, &isRebasing, 0, 0, &zOrigBranch);
   check("rebase_abort_after_reopen_clears_flag", isRebasing==0);
+  capture_repo_state_snapshot(db, &beforeReopenAbort);
 
   sqlite3_close(db);
   db = 0;
@@ -3512,6 +3575,112 @@ static void run_rebase_abort_after_reopen_restores_durable_state(void){
           "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='dolt_rebase'"), "0")==0);
   doltliteGetSessionRebaseState(db, &isRebasing, 0, 0, &zOrigBranch);
   check("rebase_abort_persists_flag_cleared", isRebasing==0);
+  capture_repo_state_snapshot(db, &afterReopenAbort);
+  check("rebase_abort_reopen_snapshot_matches",
+        repo_state_snapshot_eq(&beforeReopenAbort, &afterReopenAbort));
+
+  sqlite3_close(db);
+  remove_db(dbpath);
+}
+
+static void run_rebase_main_table_schema_guard(void){
+  sqlite3 *db = 0;
+  char dbpath[256];
+  const char *res;
+  u8 isRebasing = 0;
+  const char *zOrigBranch = 0;
+
+  printf("=== Rebase Main Table Schema Guard Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_rebase_main_table_schema_guard");
+  remove_db(dbpath);
+
+  check("open_db_for_rebase_schema_guard", open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_repo_for_rebase_schema_guard", execsql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);"
+    "INSERT INTO t VALUES (1, 1);"
+    "SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');"
+    "SELECT dolt_checkout('-b', 'feat');"
+    "INSERT INTO t VALUES (2, 2);"
+    "SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'f1');"
+    "SELECT dolt_checkout('main');"
+    "INSERT INTO t VALUES (10, 10);"
+    "SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'm');"
+    "SELECT dolt_checkout('feat');"
+    "SELECT dolt_rebase('-i', 'main');"
+    "DROP TABLE main.dolt_rebase;"
+    "CREATE TABLE main.dolt_rebase(id INTEGER PRIMARY KEY);")==SQLITE_OK);
+
+  res = exec1(db, "SELECT dolt_rebase('--continue')");
+  check("rebase_schema_guard_returns_error",
+        strstr(res, "ERROR: dolt_rebase has an unexpected schema")!=0);
+  check("rebase_schema_guard_keeps_working_branch",
+        strcmp(exec1(db, "SELECT active_branch()"), "dolt_rebase_feat")==0);
+  doltliteGetSessionRebaseState(db, &isRebasing, 0, 0, &zOrigBranch);
+  check("rebase_schema_guard_keeps_rebase_flag", isRebasing==1);
+  check("rebase_schema_guard_keeps_orig_branch",
+        zOrigBranch && strcmp(zOrigBranch, "feat")==0);
+
+  sqlite3_close(db);
+  db = 0;
+
+  check("reopen_db_for_rebase_schema_guard", open_db(dbpath, &db)==SQLITE_OK);
+  check("rebase_schema_guard_persists_working_branch",
+        strcmp(exec1(db, "SELECT active_branch()"), "dolt_rebase_feat")==0);
+  check("rebase_schema_guard_abort_works",
+        strcmp(exec1(db, "SELECT dolt_rebase('--abort')"), "Interactive rebase aborted")==0);
+  check("rebase_schema_guard_abort_restores_branch",
+        strcmp(exec1(db, "SELECT active_branch()"), "feat")==0);
+
+  sqlite3_close(db);
+  remove_db(dbpath);
+}
+
+static void run_rebase_temp_shadow_ignored(void){
+  sqlite3 *db = 0;
+  char dbpath[256];
+  const char *res;
+
+  printf("=== Rebase Temp Shadow Ignored Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_rebase_temp_shadow_ignored");
+  remove_db(dbpath);
+
+  check("open_db_for_rebase_temp_shadow", open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_repo_for_rebase_temp_shadow", execsql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);"
+    "INSERT INTO t VALUES (1, 1);"
+    "SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');"
+    "SELECT dolt_checkout('-b', 'feat');"
+    "INSERT INTO t VALUES (2, 2);"
+    "SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'f1');"
+    "INSERT INTO t VALUES (3, 3);"
+    "SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'f2');"
+    "SELECT dolt_checkout('main');"
+    "INSERT INTO t VALUES (10, 10);"
+    "SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'm');"
+    "SELECT dolt_checkout('feat');"
+    "SELECT dolt_rebase('-i', 'main');"
+    "CREATE TEMP TABLE dolt_rebase(rebase_order REAL PRIMARY KEY, action TEXT, commit_hash TEXT, commit_message TEXT);"
+    "INSERT INTO temp.dolt_rebase VALUES(1, 'oops', 'badbadbadbadbadbadbadbadbadbadbadbadbadb', 'shadow');")==SQLITE_OK);
+
+  res = exec1(db, "SELECT dolt_rebase('--continue')");
+  check("rebase_temp_shadow_ignored_continue_succeeds",
+        strstr(res, "Successfully rebased and updated refs/heads/feat")!=0);
+  check("rebase_temp_shadow_ignored_restores_branch",
+        strcmp(exec1(db, "SELECT active_branch()"), "feat")==0);
+  check("rebase_temp_shadow_ignored_rows_rebased",
+        strcmp(exec1(db, "SELECT count(*) FROM t"), "4")==0);
+  check("rebase_temp_shadow_ignored_main_plan_gone",
+        strcmp(exec1(db,
+          "SELECT count(*) FROM main.sqlite_master WHERE type='table' AND name='dolt_rebase'"), "0")==0);
+
+  sqlite3_close(db);
+  db = 0;
+
+  check("reopen_db_for_rebase_temp_shadow", open_db(dbpath, &db)==SQLITE_OK);
+  check("rebase_temp_shadow_ignored_branch_after_reopen",
+        strcmp(exec1(db, "SELECT active_branch()"), "feat")==0);
+  check("rebase_temp_shadow_ignored_rows_after_reopen",
+        strcmp(exec1(db, "SELECT count(*) FROM t"), "4")==0);
 
   sqlite3_close(db);
   remove_db(dbpath);
@@ -5038,6 +5207,8 @@ static const RegressionCase aCases[] = {
   { "merge_abort_after_reopen_restores_durable_state", "Merge Abort After Reopen Restores Durable State Test", run_merge_abort_after_reopen_restores_durable_state },
   { "rebase_continue_without_active_preserves_durable_state", "Rebase Continue Without Active Preserves Durable State Test", run_rebase_continue_without_active_preserves_durable_state },
   { "rebase_abort_after_reopen_restores_durable_state", "Rebase Abort After Reopen Restores Durable State Test", run_rebase_abort_after_reopen_restores_durable_state },
+  { "rebase_main_table_schema_guard", "Rebase Main Table Schema Guard Test", run_rebase_main_table_schema_guard },
+  { "rebase_temp_shadow_ignored", "Rebase Temp Shadow Ignored Test", run_rebase_temp_shadow_ignored },
   { "remote_add_duplicate_preserves_durable_state", "Remote Add Duplicate Preserves Durable State Test", run_remote_add_duplicate_preserves_durable_state },
   { "remote_remove_missing_preserves_durable_state", "Remote Remove Missing Preserves Durable State Test", run_remote_remove_missing_preserves_durable_state },
   { "checkout_nonexistent_preserves_durable_state", "Checkout Nonexistent Preserves Durable State Test", run_checkout_nonexistent_preserves_durable_state },


### PR DESCRIPTION
## Summary
- combine the current correctness arc into one branch to avoid regression-file conflicts
- add command and savepoint durability regressions, including reopen-state coverage
- harden interactive rebase system-table authority and temp-shadow handling
- finish the remaining helper-based commit parent sweep in diff/blame/remote paths

## Testing
- ./build/doltlite_regression_test_c merge_abort_after_reopen_restores_durable_state
- ./build/doltlite_regression_test_c rebase_abort_after_reopen_restores_durable_state
- ./build/doltlite_regression_test_c rebase_main_table_schema_guard
- ./build/doltlite_regression_test_c rebase_temp_shadow_ignored
- cd build && bash ../test/oracle_savepoints_test.sh ./doltlite ./sqlite3
- cd build && bash ../test/doltlite_rebase.sh ./doltlite
- cd build && bash ../test/vc_oracle_merge_test.sh ./doltlite dolt
- cd build && bash ../test/vc_oracle_rebase_test.sh ./doltlite dolt
- cd build && bash ../test/remote_test.sh ./doltlite
- cd build && bash ../test/doltlite_diff_table.sh
