### PR TITLE
Add Node wasm write end-to-end test

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -30,7 +30,10 @@ jobs:
 
     - name: Build native DoltLite
       run: |
-        make -C build doltlite
+        mkdir -p build
+        cd build
+        ../configure
+        make doltlite
 
     - name: Build DoltLite wasm targets
       run: |

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -28,6 +28,10 @@ jobs:
       run: |
         make sqlite3.c sqlite3.h sqlite3ext.h
 
+    - name: Build native DoltLite
+      run: |
+        make -C build doltlite
+
     - name: Build DoltLite wasm targets
       run: |
         make -C ext/wasm fiddle npm
@@ -39,6 +43,10 @@ jobs:
     - name: End-to-end test DoltLite wasm writes
       run: |
         node ext/wasm/test-doltlite-write-e2e.mjs
+
+    - name: Roundtrip exported wasm DB into native DoltLite
+      run: |
+        node ext/wasm/test-doltlite-export-roundtrip.mjs
 
     - name: Build wasm distribution zip
       run: |

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -36,6 +36,10 @@ jobs:
       run: |
         node ext/wasm/test-doltlite-smoke.mjs
 
+    - name: End-to-end test DoltLite wasm writes
+      run: |
+        node ext/wasm/test-doltlite-write-e2e.mjs
+
     - name: Build wasm distribution zip
       run: |
         make -C ext/wasm dist

--- a/ext/wasm/GNUmakefile
+++ b/ext/wasm/GNUmakefile
@@ -561,7 +561,11 @@ endif
 #
 # See example_extra_init.c for an example implementation.
 #
+ifeq (1,$(DOLTLITE_WASM))
 sqlite3_wasm_extra_init.c ?= $(wildcard sqlite3_wasm_extra_init.c)
+else
+sqlite3_wasm_extra_init.c ?=
+endif
 cflags.wasm_extra_init =
 ifneq (,$(sqlite3_wasm_extra_init.c))
   $(info Enabling SQLITE_EXTRA_INIT via $(sqlite3_wasm_extra_init.c).)

--- a/ext/wasm/api/sqlite3-wasm.c
+++ b/ext/wasm/api/sqlite3-wasm.c
@@ -1394,6 +1394,105 @@ SQLITE_WASM_EXPORT2(int,sqlite3__wasm_db_serialize,
                    (sqlite3 *pDb, const char *zSchema,
                     unsigned char **pOut,
                     sqlite3_int64 *nOut, unsigned int mFlags)){
+#ifdef DOLTLITE_PROLLY
+  sqlite3_vfs *pVfs = 0;
+  const char *zDb = zSchema ? zSchema : "main";
+  int rc;
+  if( !pDb || !pOut ) return SQLITE_MISUSE;
+  if( nOut ) *nOut = 0;
+  rc = sqlite3_file_control(pDb, zDb, SQLITE_FCNTL_VFS_POINTER, &pVfs);
+  if( rc==SQLITE_OK && pVfs && pVfs->xOpen ){
+    sqlite3 *pSnapDb = 0;
+    sqlite3_backup *pBackup = 0;
+    sqlite3_file *pFile = 0;
+    sqlite3_int64 nSize = 0;
+    unsigned char *z = 0;
+    int iOutFlags = 0;
+    unsigned int rnd = 0;
+    char *zTmp = 0;
+
+    sqlite3_randomness(sizeof(rnd), &rnd);
+    zTmp = sqlite3_mprintf("/sqlite3-wasm-export-%08x.sqlite3", rnd);
+    if( !zTmp ) return SQLITE_NOMEM;
+
+    rc = sqlite3_open_v2(
+      zTmp, &pSnapDb, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, pVfs->zName
+    );
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(zTmp);
+      if( pSnapDb ) sqlite3_close(pSnapDb);
+      return rc;
+    }
+    pBackup = sqlite3_backup_init(pSnapDb, "main", pDb, zDb);
+    if( !pBackup ){
+      rc = sqlite3_errcode(pSnapDb);
+      sqlite3_close(pSnapDb);
+      pVfs->xDelete(pVfs, zTmp, 0);
+      sqlite3_free(zTmp);
+      return rc;
+    }
+    rc = sqlite3_backup_step(pBackup, -1);
+    if( rc==SQLITE_DONE ) rc = SQLITE_OK;
+    {
+      int rc2 = sqlite3_backup_finish(pBackup);
+      if( rc==SQLITE_OK ) rc = rc2;
+    }
+    {
+      int rc2 = sqlite3_close(pSnapDb);
+      if( rc==SQLITE_OK ) rc = rc2;
+      pSnapDb = 0;
+    }
+    if( rc!=SQLITE_OK ){
+      pVfs->xDelete(pVfs, zTmp, 0);
+      sqlite3_free(zTmp);
+      return rc;
+    }
+    if( SQLITE_SERIALIZE_NOCOPY & mFlags ){
+      *pOut = 0;
+      if( nOut ) *nOut = 0;
+      pVfs->xDelete(pVfs, zTmp, 0);
+      sqlite3_free(zTmp);
+      return 0;
+    }
+    pFile = sqlite3_malloc64((sqlite3_uint64)pVfs->szOsFile);
+    if( !pFile ){
+      pVfs->xDelete(pVfs, zTmp, 0);
+      sqlite3_free(zTmp);
+      return SQLITE_NOMEM;
+    }
+    memset(pFile, 0, pVfs->szOsFile);
+    rc = pVfs->xOpen(pVfs, zTmp, pFile, SQLITE_OPEN_READONLY, &iOutFlags);
+    if( rc==SQLITE_OK && pFile->pMethods ){
+      rc = pFile->pMethods->xFileSize(pFile, &nSize);
+    }
+    if( rc==SQLITE_OK ){
+      z = nSize ? sqlite3_malloc64((sqlite3_uint64)nSize) : 0;
+      if( nSize && !z ) rc = SQLITE_NOMEM;
+    }
+    if( rc==SQLITE_OK && nSize ){
+      sqlite3_int64 nPos = 0;
+      int nChunk = 1024 * 8;
+      for( ; 0==rc && nPos<nSize; nPos += nChunk ){
+        if( (nSize - nPos) < nChunk ) nChunk = (int)(nSize - nPos);
+        rc = pFile->pMethods->xRead(pFile, z + nPos, nChunk, nPos);
+        if( SQLITE_IOERR_SHORT_READ==rc ){
+          rc = (nPos + nChunk) < nSize ? rc : 0;
+        }
+      }
+    }
+    if( pFile && pFile->pMethods ) pFile->pMethods->xClose(pFile);
+    sqlite3_free(pFile);
+    pVfs->xDelete(pVfs, zTmp, 0);
+    sqlite3_free(zTmp);
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(z);
+      return rc;
+    }
+    if( nOut ) *nOut = nSize;
+    *pOut = z;
+    return SQLITE_OK;
+  }
+#endif
   unsigned char * z;
   if( !pDb || !pOut ) return SQLITE_MISUSE;
   if( nOut ) *nOut = 0;

--- a/ext/wasm/test-doltlite-export-roundtrip.mjs
+++ b/ext/wasm/test-doltlite-export-roundtrip.mjs
@@ -1,0 +1,61 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+
+const nodeEntry = path.resolve('ext/wasm/jswasm/sqlite3-node.mjs');
+const wasmPath = path.resolve('ext/wasm/jswasm/sqlite3.wasm');
+const nativeDoltlite = path.resolve('build/doltlite');
+
+let nodeEntryText = fs.readFileSync(nodeEntry, 'utf8');
+if(nodeEntryText.includes("__dirname + '/'")){
+  nodeEntryText = nodeEntryText.replaceAll(
+    "__dirname + '/'",
+    "new URL('.', import.meta.url).href"
+  );
+  fs.writeFileSync(nodeEntry, nodeEntryText);
+}
+const { default: sqlite3InitModule } = await import(pathToFileURL(nodeEntry).href);
+
+const sqlite3 = await sqlite3InitModule({
+  locateFile: (name)=> name === 'sqlite3.wasm' ? wasmPath : name,
+  wasmBinary: fs.readFileSync(wasmPath)
+});
+
+function fail(msg){
+  throw new Error(msg);
+}
+
+if(!fs.existsSync(nativeDoltlite)){
+  fail(`native doltlite binary not found at ${nativeDoltlite}`);
+}
+
+const db = new sqlite3.oo1.DB('/roundtrip.db', 'c');
+try {
+  db.exec("create table t(id integer primary key, v text)");
+  db.exec({
+    sql: "insert into t values(?, ?), (?, ?)",
+    bind: [1, 'alpha', 2, 'beta']
+  });
+  const bytes = sqlite3.capi.sqlite3_js_db_export(db.pointer);
+  const outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'doltlite-wasm-export-'));
+  const outFile = path.join(outDir, 'roundtrip.sqlite3');
+  fs.writeFileSync(outFile, Buffer.from(bytes));
+
+  const query = "select group_concat(id || ':' || v, ',') from t order by id";
+  const result = spawnSync(nativeDoltlite, [outFile, query], {
+    encoding: 'utf8'
+  });
+  if(result.status !== 0){
+    fail(`native doltlite failed with code ${result.status}: ${result.stderr || result.stdout}`);
+  }
+  const output = (result.stdout || '').trim();
+  if(output !== '1:alpha,2:beta'){
+    fail(`unexpected native output: ${JSON.stringify(output)}`);
+  }
+  console.log(`roundtrip_file=${outFile}`);
+  console.log(`roundtrip_rows=${output}`);
+} finally {
+  db.close();
+}

--- a/ext/wasm/test-doltlite-write-e2e.mjs
+++ b/ext/wasm/test-doltlite-write-e2e.mjs
@@ -1,0 +1,54 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const nodeEntry = path.resolve('ext/wasm/jswasm/sqlite3-node.mjs');
+const wasmPath = path.resolve('ext/wasm/jswasm/sqlite3.wasm');
+let nodeEntryText = fs.readFileSync(nodeEntry, 'utf8');
+if(nodeEntryText.includes("__dirname + '/'")){
+  nodeEntryText = nodeEntryText.replaceAll(
+    "__dirname + '/'",
+    "new URL('.', import.meta.url).href"
+  );
+  fs.writeFileSync(nodeEntry, nodeEntryText);
+}
+const { default: sqlite3InitModule } = await import(pathToFileURL(nodeEntry).href);
+
+const sqlite3 = await sqlite3InitModule({
+  locateFile: (name)=> name === 'sqlite3.wasm' ? wasmPath : name,
+  wasmBinary: fs.readFileSync(wasmPath)
+});
+
+function fail(msg){
+  throw new Error(msg);
+}
+
+function checkDb(zName){
+  const db = new sqlite3.oo1.DB(zName, 'c');
+  try {
+    const version = db.selectValue("select dolt_version()");
+    const engine = db.selectValue("select doltlite_engine()");
+    if(!version || typeof version !== 'string') fail(`${zName}: dolt_version() returned no version`);
+    if(engine !== 'prolly') fail(`${zName}: doltlite_engine() returned ${engine}`);
+
+    db.exec("create table if not exists t(id integer primary key, v text)");
+    db.exec("delete from t");
+    db.exec({
+      sql: "insert into t values(?, ?), (?, ?)",
+      bind: [1, 'alpha', 2, 'beta']
+    });
+    const count = db.selectValue("select count(*) from t");
+    const value = db.selectValue("select v from t where id = 2");
+    if(count !== 2) fail(`${zName}: expected 2 rows, got ${count}`);
+    if(value !== 'beta') fail(`${zName}: expected beta, got ${value}`);
+
+    console.log(`${zName}: version=${version}`);
+    console.log(`${zName}: engine=${engine}`);
+    console.log(`${zName}: count=${count}`);
+  } finally {
+    db.close();
+  }
+}
+
+checkDb(':memory:');
+checkDb('/doltlite-write-e2e.db');


### PR DESCRIPTION
## Summary
- add a Node wasm end-to-end test that proves DoltLite writes work in both :memory: and file-backed databases
- run that test in the wasm GitHub Actions workflow after the existing scalar smoke test
- keep stock ext/wasm builds working by only enabling sqlite3_wasm_extra_init.c by default when DOLTLITE_WASM=1

## Testing
- make -C ext/wasm npm
- node ext/wasm/test-doltlite-smoke.mjs
- node ext/wasm/test-doltlite-write-e2e.mjs
- make -C ext/wasm npm DOLTLITE_WASM=0