### PR TITLE
Fix failed chunk store commit durability

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -121,6 +121,7 @@ static int csOpenFile(sqlite3_vfs *pVfs, const char *zPath,
                       sqlite3_file **ppFile, int flags);
 static void csCloseFile(sqlite3_file *pFile);
 static int csRollbackFailedAppend(ChunkStore *cs, i64 origFileSize);
+static int csRestoreCommittedRefsState(ChunkStore *cs);
 static int csReadManifest(ChunkStore *cs);
 static int csReadIndex(ChunkStore *cs);
 static int csDeserializeRefs(ChunkStore *cs, const u8 *data, int nData);
@@ -443,6 +444,22 @@ static int csRollbackFailedAppend(ChunkStore *cs, i64 origFileSize){
     return SQLITE_OK;
   }
   return rc==SQLITE_OK ? SQLITE_IOERR_TRUNCATE : rc;
+}
+
+static int csRestoreCommittedRefsState(ChunkStore *cs){
+  csRestoreCommittedRefsHash(cs);
+  if( prollyHashIsEmpty(&cs->committedRefsHash) ){
+    csFreeBranches(cs);
+    csFreeTags(cs);
+    csFreeRemotes(cs);
+    csFreeTracking(cs);
+    if( !cs->zDefaultBranch ){
+      cs->zDefaultBranch = sqlite3_mprintf("main");
+      if( !cs->zDefaultBranch ) return SQLITE_NOMEM;
+    }
+    return SQLITE_OK;
+  }
+  return chunkStoreReloadRefs(cs);
 }
 
 static int csSearchIndex(
@@ -1954,7 +1971,7 @@ commit_done:
     if( cs->pFile && writeOff > origFileSize ){
       (void)csRollbackFailedAppend(cs, origFileSize);
     }
-    csRestoreCommittedRefsHash(cs);
+    (void)csRestoreCommittedRefsState(cs);
     sqlite3_free(aCommittedPending);
     sqlite3_free(aMerged);
     sqlite3_free(pNewWalData);
@@ -2011,7 +2028,7 @@ void chunkStoreRollback(ChunkStore *cs){
   }else{
     cs->nWriteBuf = 0;
   }
-  csRestoreCommittedRefsHash(cs);
+  (void)csRestoreCommittedRefsState(cs);
 }
 
 int chunkStoreIsEmpty(ChunkStore *cs){

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -120,6 +120,7 @@
 static int csOpenFile(sqlite3_vfs *pVfs, const char *zPath,
                       sqlite3_file **ppFile, int flags);
 static void csCloseFile(sqlite3_file *pFile);
+static int csRollbackFailedAppend(ChunkStore *cs, i64 origFileSize);
 static int csReadManifest(ChunkStore *cs);
 static int csReadIndex(ChunkStore *cs);
 static int csDeserializeRefs(ChunkStore *cs, const u8 *data, int nData);
@@ -410,6 +411,38 @@ static void csCloseFile(sqlite3_file *pFile){
   if( pFile ){
     sqlite3OsCloseFree(pFile);
   }
+}
+
+static int csRollbackFailedAppend(ChunkStore *cs, i64 origFileSize){
+  sqlite3_int64 sizeNow = -1;
+  int rc = SQLITE_OK;
+
+  if( !cs->pFile ) return SQLITE_OK;
+
+  rc = sqlite3OsTruncate(cs->pFile, origFileSize);
+  if( rc==SQLITE_OK ){
+    rc = sqlite3OsFileSize(cs->pFile, &sizeNow);
+  }
+  if( rc==SQLITE_OK && sizeNow==origFileSize ){
+    (void)sqlite3OsSync(cs->pFile, SQLITE_SYNC_NORMAL);
+    return SQLITE_OK;
+  }
+
+  csCloseFile(cs->pFile);
+  cs->pFile = 0;
+  rc = csOpenFile(cs->pVfs, cs->zFilename, &cs->pFile,
+                  SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB);
+  if( rc!=SQLITE_OK ) return rc;
+
+  rc = sqlite3OsTruncate(cs->pFile, origFileSize);
+  if( rc==SQLITE_OK ){
+    rc = sqlite3OsFileSize(cs->pFile, &sizeNow);
+  }
+  if( rc==SQLITE_OK && sizeNow==origFileSize ){
+    (void)sqlite3OsSync(cs->pFile, SQLITE_SYNC_NORMAL);
+    return SQLITE_OK;
+  }
+  return rc==SQLITE_OK ? SQLITE_IOERR_TRUNCATE : rc;
 }
 
 static int csSearchIndex(
@@ -1771,7 +1804,8 @@ static int csCommitToFile(ChunkStore *cs){
   int rc;
   int i;
   i64 fileSize = 0;
-  i64 writeOff;
+  i64 origFileSize = 0;
+  i64 writeOff = 0;
   int lockFd = -1;
   int hadFile = (cs->pFile != 0);
   i64 newWalSize = cs->nWalData;
@@ -1805,6 +1839,7 @@ static int csCommitToFile(ChunkStore *cs){
     if( rc != SQLITE_OK ) goto commit_done;
     fileSize = cs->iFileSize;
   }
+  origFileSize = fileSize;
 
   if( cs->nPending > 0 ){
     ChunkStore mergeView;
@@ -1916,6 +1951,9 @@ commit_done:
   csFileUnlock(lockFd);
 
   if( rc != SQLITE_OK ){
+    if( cs->pFile && writeOff > origFileSize ){
+      (void)csRollbackFailedAppend(cs, origFileSize);
+    }
     csRestoreCommittedRefsHash(cs);
     sqlite3_free(aCommittedPending);
     sqlite3_free(aMerged);

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -5452,6 +5452,8 @@ static void run_chunk_store_commit_failure_restores_refs_hash(void){
   check("commit_failure_surfaces_for_refs_commit_failure", rc!=SQLITE_OK);
   check("refs_hash_restored_on_commit_failure",
         memcmp(&cs.refsHash, &refsHashBefore, sizeof(ProllyHash))==0);
+  check("in_memory_tag_absent_after_commit_failure",
+        chunkStoreFindTag(&cs, "v1", &foundHash)!=SQLITE_OK);
 
   chunkStoreRollback(&cs);
   check("reload_refs_after_commit_failure_rollback",

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -17,6 +17,7 @@
 **   ./doltlite_regression_test_c chunk_walk_corruption
 **   ./doltlite_regression_test_c ancestor_missing_start
 **   ./doltlite_regression_test_c pull_persist_failure
+**   ./doltlite_regression_test_c push_persist_failure
 **   ./doltlite_regression_test_c clone_persist_failure
 **   ./doltlite_regression_test_c resolve_ref_non_commit
 **   ./doltlite_regression_test_c commit_parent_limit
@@ -1018,6 +1019,72 @@ static void run_pull_persist_failure(void){
     strcmp(exec1(localDb, "SELECT count(*) FROM dolt_remotes"), "1")==0);
 
   sqlite3_close(localDb);
+  remove_db(localPath);
+  remove_db(remotePath);
+}
+
+static void run_push_persist_failure(void){
+  sqlite3 *localDb = 0;
+  sqlite3 *remoteDb = 0;
+  char localPath[256];
+  char remotePath[256];
+  char sql[1024];
+  const char *res;
+  char zRemoteHeadBefore[128];
+
+  printf("=== Push Persist Failure Test ===\n\n");
+  make_dbpath(localPath, sizeof(localPath), "test_push_persist_failure_local");
+  make_dbpath(remotePath, sizeof(remotePath), "test_push_persist_failure_remote");
+  remove_db(localPath);
+  remove_db(remotePath);
+
+  gFailWriteOnce = 0;
+  gFailSyncOnce = 0;
+  gFailHits = 0;
+  check("register_fail_vfs_for_push", registerFailVfs()==SQLITE_OK);
+  check("open_remote_db_for_push", open_db(remotePath, &remoteDb)==SQLITE_OK);
+  check("setup_remote_repo_for_push", execsql(remoteDb,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'remote');"
+    "SELECT dolt_commit('-A', '-m', 'remote init');")==SQLITE_OK);
+  sqlite3_snprintf(sizeof(zRemoteHeadBefore), zRemoteHeadBefore, "%s",
+                   exec1(remoteDb, "SELECT commit_hash FROM dolt_log LIMIT 1"));
+  sqlite3_close(remoteDb);
+  remoteDb = 0;
+
+  check("open_local_fail_db_for_push", open_fail_db(localPath, &localDb)==SQLITE_OK);
+  snprintf(sql, sizeof(sql),
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'local');"
+    "SELECT dolt_commit('-A', '-m', 'local init');"
+    "SELECT dolt_remote('add','origin','file://%s');"
+    "UPDATE t SET v='local pushed' WHERE id=1;"
+    "SELECT dolt_commit('-A', '-m', 'local update');",
+    remotePath);
+  check("setup_local_repo_for_push", execsql(localDb, sql)==SQLITE_OK);
+
+  gFailHits = 0;
+  gFailSyncOnce = 1;
+  res = exec1(localDb, "SELECT dolt_push('origin','main','--force')");
+  check("push_failure_was_injected", gFailHits>0);
+  check("push_returns_error_on_persist_failure", strstr(res, "ERROR:")!=0);
+  check("push_keeps_local_rows",
+    strcmp(exec1(localDb, "SELECT v FROM t WHERE id=1"), "local pushed")==0);
+  check("push_keeps_local_remote",
+    strcmp(exec1(localDb, "SELECT count(*) FROM dolt_remotes"), "1")==0);
+
+  sqlite3_close(localDb);
+  localDb = 0;
+
+  check("reopen_remote_after_push_failure", open_db(remotePath, &remoteDb)==SQLITE_OK);
+  check("push_failure_preserves_remote_rows_after_reopen",
+    strcmp(exec1(remoteDb, "SELECT v FROM t WHERE id=1"), "remote")==0);
+  check("push_failure_preserves_remote_head_after_reopen",
+    strcmp(exec1(remoteDb, "SELECT commit_hash FROM dolt_log LIMIT 1"), zRemoteHeadBefore)==0);
+  check("push_failure_preserves_remote_log_count_after_reopen",
+    strcmp(exec1(remoteDb, "SELECT count(*) FROM dolt_log"), "2")==0);
+
+  sqlite3_close(remoteDb);
   remove_db(localPath);
   remove_db(remotePath);
 }
@@ -5342,6 +5409,7 @@ static void run_chunk_store_rollback_restores_refs_hash(void){
 
 static void run_chunk_store_commit_failure_restores_refs_hash(void){
   ChunkStore cs;
+  ChunkStore reopened;
   ProllyHash emptyHash;
   ProllyHash refsHashBefore;
   ProllyHash foundHash;
@@ -5392,6 +5460,14 @@ static void run_chunk_store_commit_failure_restores_refs_hash(void){
         chunkStoreFindTag(&cs, "v1", &foundHash)!=SQLITE_OK);
 
   chunkStoreClose(&cs);
+  check("reopen_store_after_refs_commit_failure",
+        chunkStoreOpen(&reopened, sqlite3_vfs_find(0), dbpath,
+          SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB)==SQLITE_OK);
+  check("reopened_store_has_no_failed_tag",
+        chunkStoreFindTag(&reopened, "v1", &foundHash)!=SQLITE_OK);
+  check("reopened_store_keeps_default_branch",
+        reopened.zDefaultBranch!=0 && strcmp(reopened.zDefaultBranch, "main")==0);
+  chunkStoreClose(&reopened);
   remove_db(dbpath);
 }
 
@@ -5781,6 +5857,7 @@ static const RegressionCase aCases[] = {
   { "chunk_walk_corruption", "Chunk Walk Corruption Test", run_chunk_walk_corruption },
   { "ancestor_missing_start", "Ancestor Missing Start Test", run_ancestor_missing_start },
   { "pull_persist_failure", "Pull Persist Failure Test", run_pull_persist_failure },
+  { "push_persist_failure", "Push Persist Failure Test", run_push_persist_failure },
   { "clone_persist_failure", "Clone Persist Failure Test", run_clone_persist_failure },
   { "resolve_ref_non_commit", "Resolve Ref Non-Commit Test", run_resolve_ref_non_commit },
   { "commit_parent_limit", "Commit Parent Limit Test", run_commit_parent_limit },


### PR DESCRIPTION
## Summary
- roll back on-disk chunk-store append state when commit write/sync fails
- add push-side persistence regression coverage
- strengthen low-level refs commit failure reopen coverage

## Testing
- ./build/doltlite_regression_test_c push_persist_failure
- ./build/doltlite_regression_test_c refs_hash_commit_failure_restore
- ./build/doltlite_regression_test_c pull_persist_failure
- ./build/doltlite_regression_test_c clone_persist_failure
- ./build/doltlite_regression_test_c gc_rewrite_failure
- ./build/doltlite_regression_test_c btree_commit_failure_transactional
- cd build && bash ../test/remote_test.sh ./doltlite
- cd build && bash ../test/doltlite_gc.sh ./doltlite
