### PR TITLE
Stop propagating remote working sets on push

### DIFF
--- a/src/doltlite_remote.c
+++ b/src/doltlite_remote.c
@@ -296,44 +296,9 @@ static int remoteStorePersistRefs(ChunkStore *pStore){
   return rc;
 }
 
-static int remoteStorePersistDefaultBranchCatalog(ChunkStore *pStore){
-  const char *zDef = chunkStoreGetDefaultBranch(pStore);
-  ProllyHash branchCommit;
-  int rc;
-
-  if( !zDef || chunkStoreFindBranch(pStore, zDef, &branchCommit)!=SQLITE_OK ){
-    return SQLITE_OK;
-  }
-
-  {
-    u8 *cdata = 0;
-    int ncdata = 0;
-    rc = chunkStoreGet(pStore, &branchCommit, &cdata, &ncdata);
-    if( rc!=SQLITE_OK ) return rc;
-    if( cdata ){
-      DoltliteCommit commit;
-      rc = doltliteCommitDeserialize(cdata, ncdata, &commit);
-      if( rc==SQLITE_OK ){
-        rc = chunkStoreWriteBranchWorkingCatalog(
-          pStore, zDef, &commit.catalogHash, NULL
-        );
-        doltliteCommitClear(&commit);
-      }
-      sqlite3_free(cdata);
-      if( rc!=SQLITE_OK ) return rc;
-    }
-  }
-
-  return remoteStorePersistRefs(pStore);
-}
-
 static int fsCommit(DoltliteRemote *pRemote){
   FsRemote *p = (FsRemote*)pRemote;
-  int rc;
-
-  rc = remoteStorePersistRefs(&p->store);
-  if( rc!=SQLITE_OK ) return rc;
-  return remoteStorePersistDefaultBranchCatalog(&p->store);
+  return remoteStorePersistRefs(&p->store);
 }
 
 static void fsClose(DoltliteRemote *pRemote){
@@ -588,24 +553,9 @@ int doltlitePush(
 
   {
     u8 *refsData2 = 0; int nRefsData2 = 0;
-    u8 *commitData = 0; int nCommitData = 0;
-    DoltliteCommit pushedCommit;
     rc = pRemote->xGetRefs(pRemote, &refsData2, &nRefsData2);
     if( rc==SQLITE_NOTFOUND ){ refsData2 = 0; nRefsData2 = 0; rc = SQLITE_OK; }
     if( rc!=SQLITE_OK ) return rc;
-    memset(&pushedCommit, 0, sizeof(pushedCommit));
-
-    rc = chunkStoreGet(pLocal, &localCommit, &commitData, &nCommitData);
-    if( rc!=SQLITE_OK ){
-      sqlite3_free(refsData2);
-      return rc;
-    }
-    rc = doltliteCommitDeserialize(commitData, nCommitData, &pushedCommit);
-    sqlite3_free(commitData);
-    if( rc!=SQLITE_OK ){
-      sqlite3_free(refsData2);
-      return rc;
-    }
 
 
     {
@@ -630,23 +580,12 @@ int doltlitePush(
         rc = chunkStoreAddBranch(&tmpCs, zBranch, &localCommit);
       }
       if( rc!=SQLITE_OK ){
-        doltliteCommitClear(&pushedCommit);
-        chunkStoreClose(&tmpCs);
-        return rc;
-      }
-
-      rc = chunkStoreWriteBranchWorkingCatalog(&tmpCs, zBranch,
-                                               &pushedCommit.catalogHash,
-                                               &localCommit);
-      if( rc!=SQLITE_OK ){
-        doltliteCommitClear(&pushedCommit);
         chunkStoreClose(&tmpCs);
         return rc;
       }
 
 
       rc = chunkStoreSerializeRefsToBlob(&tmpCs, &newRefs, &nNewRefs);
-      doltliteCommitClear(&pushedCommit);
       chunkStoreClose(&tmpCs);
       if( rc!=SQLITE_OK ) return rc;
 

--- a/src/doltlite_remotesrv.c
+++ b/src/doltlite_remotesrv.c
@@ -400,37 +400,6 @@ static int remoteSrvPersistRefs(ChunkStore *pStore){
   return rc;
 }
 
-static int remoteSrvPersistDefaultBranchCatalog(ChunkStore *pStore){
-  const char *zDef = chunkStoreGetDefaultBranch(pStore);
-  ProllyHash branchCommit;
-  int rc;
-
-  if( !zDef || chunkStoreFindBranch(pStore, zDef, &branchCommit)!=SQLITE_OK ){
-    return SQLITE_OK;
-  }
-
-  {
-    u8 *cdata = 0;
-    int ncdata = 0;
-    rc = chunkStoreGet(pStore, &branchCommit, &cdata, &ncdata);
-    if( rc!=SQLITE_OK ) return rc;
-    if( cdata ){
-      DoltliteCommit commit;
-      rc = doltliteCommitDeserialize(cdata, ncdata, &commit);
-      if( rc==SQLITE_OK ){
-        rc = chunkStoreWriteBranchWorkingCatalog(
-          pStore, zDef, &commit.catalogHash, NULL
-        );
-        doltliteCommitClear(&commit);
-      }
-      sqlite3_free(cdata);
-      if( rc!=SQLITE_OK ) return rc;
-    }
-  }
-
-  return remoteSrvPersistRefs(pStore);
-}
-
 static void handlePutRefs(ChunkStore *pStore, int fd,
                           const u8 *pBody, int nBody){
   ProllyHash hash;
@@ -469,11 +438,6 @@ static void handleCommit(ChunkStore *pStore, int fd){
   int rc;
 
   rc = remoteSrvPersistRefs(pStore);
-  if( rc!=SQLITE_OK ){
-    sendError(fd);
-    return;
-  }
-  rc = remoteSrvPersistDefaultBranchCatalog(pStore);
   if( rc!=SQLITE_OK ){
     sendError(fd);
     return;

--- a/test/http_remote_test.sh
+++ b/test/http_remote_test.sh
@@ -201,7 +201,7 @@ static int raw_http_status(int port, const char *path) {
   else { printf("  FAIL: %s\n    expected: |%s|\n    actual:   |%s|\n", desc, _e, _a); fail++; } \
 } while(0)
 
-#define HTTP_TEST_EXPECTED_ASSERTIONS 54
+#define HTTP_TEST_EXPECTED_ASSERTIONS 51
 
 int main(int argc, char **argv) {
   int pass = 0, fail = 0;
@@ -299,9 +299,9 @@ int main(int argc, char **argv) {
   sqlite3 *verifyDb;
   snprintf(path, sizeof(path), "%s/src.db", srvdir);
   sqlite3_open(path, &verifyDb);
-  CHECK("server has 4 users after push", 4, query_int(verifyDb, "SELECT count(*) FROM users"));
-  CHECK("server has 4 scores after push", 4, query_int(verifyDb, "SELECT count(*) FROM scores"));
-  CHECK_STR("server has diana", "diana", query_str(verifyDb, "SELECT name FROM users WHERE id=4"));
+  CHECK_STR("server head matches clone push",
+    query_str(cloneDb, "SELECT commit_hash FROM dolt_log LIMIT 1"),
+    query_str(verifyDb, "SELECT commit_hash FROM dolt_log LIMIT 1"));
   sqlite3_close(verifyDb);
 
   /* ============================================================
@@ -477,9 +477,9 @@ int main(int argc, char **argv) {
   /* Verify server got everything */
   snprintf(path, sizeof(path), "%s/batch.db", srvdir);
   sqlite3_open(path, &verifyDb);
-  CHECK("batch server has 4 items", 4, query_int(verifyDb, "SELECT count(*) FROM items"));
-  CHECK_STR("batch server last item", "fourth",
-    query_str(verifyDb, "SELECT val FROM items WHERE id=4"));
+  CHECK_STR("batch server head matches batch push",
+    query_str(batchClone, "SELECT commit_hash FROM dolt_log LIMIT 1"),
+    query_str(verifyDb, "SELECT commit_hash FROM dolt_log LIMIT 1"));
   sqlite3_close(verifyDb);
   sqlite3_close(batchClone);
 

--- a/test/remote_test.sh
+++ b/test/remote_test.sh
@@ -60,14 +60,9 @@ echo "=== 2. Push ==="
 result=$("$DB" "$TMPDIR/src.db" "SELECT dolt_push('origin','main');")
 check "push returns 0" "0" "$result"
 
-result=$("$DB" "$TMPDIR/remote.db" "SELECT count(*) FROM users;")
-check "remote has 3 users" "3" "$result"
-
-result=$("$DB" "$TMPDIR/remote.db" "SELECT count(*) FROM scores;")
-check "remote has 3 scores" "3" "$result"
-
-result=$("$DB" "$TMPDIR/remote.db" "SELECT name FROM users WHERE id=2;")
-check "remote data correct" "bob" "$result"
+src_head=$("$DB" "$TMPDIR/src.db" "SELECT commit_hash FROM dolt_log LIMIT 1;")
+result=$("$DB" "$TMPDIR/remote.db" "SELECT commit_hash FROM dolt_log LIMIT 1;")
+check "remote head matches pushed main" "$src_head" "$result"
 
 # ============================================================
 echo "=== 3. Clone ==="
@@ -103,11 +98,9 @@ ENDSQL
 result=$("$DB" "$TMPDIR/clone.db" "SELECT dolt_push('origin','main');")
 check "push from clone returns 0" "0" "$result"
 
-result=$("$DB" "$TMPDIR/remote.db" "SELECT count(*) FROM users;")
-check "remote has 4 users after clone push" "4" "$result"
-
-result=$("$DB" "$TMPDIR/remote.db" "SELECT name FROM users WHERE id=4;")
-check "remote has diana" "diana" "$result"
+clone_head=$("$DB" "$TMPDIR/clone.db" "SELECT commit_hash FROM dolt_log LIMIT 1;")
+result=$("$DB" "$TMPDIR/remote.db" "SELECT commit_hash FROM dolt_log LIMIT 1;")
+check "remote head matches clone push" "$clone_head" "$result"
 
 # ============================================================
 echo "=== 5. Fetch ==="
@@ -204,9 +197,9 @@ ENDSQL
 result=$("$DB" "$TMPDIR/src.db" "SELECT dolt_push('origin','main');")
 check "push descendant commit succeeds" "0" "$result"
 
-# DELETE WHERE id>5 removes frank(6) and grace(7), leaving 4 users: alice,bob,charlie,diana
-result=$("$DB" "$TMPDIR/remote.db" "SELECT count(*) FROM users;")
-check "remote has 4 users after revert push" "4" "$result"
+src_head=$("$DB" "$TMPDIR/src.db" "SELECT commit_hash FROM dolt_log LIMIT 1;")
+result=$("$DB" "$TMPDIR/remote.db" "SELECT commit_hash FROM dolt_log LIMIT 1;")
+check "remote head matches revert push" "$src_head" "$result"
 
 # ============================================================
 echo "=== 13. Schema changes push/pull ==="
@@ -222,9 +215,9 @@ SELECT dolt_push('origin','main');
 ENDSQL
 
 # remote.db session needs checkout to main to see the pushed schema change
-result=$("$DB" "$TMPDIR/remote.db" "SELECT dolt_checkout('main'); SELECT email FROM users WHERE id=1;")
-check "remote has schema change" "0
-alice@test.com" "$result"
+src_head=$("$DB" "$TMPDIR/src.db" "SELECT commit_hash FROM dolt_log LIMIT 1;")
+result=$("$DB" "$TMPDIR/remote.db" "SELECT commit_hash FROM dolt_log LIMIT 1;")
+check "remote head matches schema push" "$src_head" "$result"
 
 result=$("$DB" "$TMPDIR/clone.db" "SELECT dolt_reset('--hard');")
 check "clone reset before schema pull" "0" "$result"
@@ -300,9 +293,9 @@ check "clone has 500 rows" "500" "$result"
 echo "=== 17. Push to second remote ==="
 # ============================================================
 "$DB" "$TMPDIR/src.db" "SELECT dolt_remote('add','mirror','$R/mirror.db'); SELECT dolt_push('mirror','main');" > /dev/null
-# src main has 4 users (after test 12 deleted id>5, leaving alice,bob,charlie,diana)
-result=$("$DB" "$TMPDIR/mirror.db" "SELECT count(*) FROM users;")
-check "mirror has data" "4" "$result"
+src_head=$("$DB" "$TMPDIR/src.db" "SELECT commit_hash FROM dolt_log LIMIT 1;")
+result=$("$DB" "$TMPDIR/mirror.db" "SELECT commit_hash FROM dolt_log LIMIT 1;")
+check "mirror head matches pushed main" "$src_head" "$result"
 
 # ============================================================
 echo "=== 18. Clone preserves multiple branches ==="
@@ -326,9 +319,6 @@ for i in $(seq 1 20); do
   "$DB" "$TMPDIR/deep_src.db" "INSERT INTO log VALUES($i,$i,'step $i'); SELECT dolt_add('-A'); SELECT dolt_commit('-m','step $i');" > /dev/null
 done
 "$DB" "$TMPDIR/deep_src.db" "SELECT dolt_remote('add','origin','$R/deep_remote.db'); SELECT dolt_push('origin','main');" > /dev/null
-
-result=$("$DB" "$TMPDIR/deep_remote.db" "SELECT count(*) FROM log;")
-check "deep remote has 20 rows" "20" "$result"
 
 result=$("$DB" "$TMPDIR/deep_clone.db" "SELECT dolt_clone('$R/deep_remote.db');")
 check "deep clone returns 0" "0" "$result"
@@ -436,12 +426,6 @@ SELECT dolt_remote('add','origin','$R/merge_remote.db');
 SELECT dolt_push('origin','main');
 .quit
 ENDSQL
-
-result=$("$DB" "$TMPDIR/merge_remote.db" "SELECT count(*) FROM doc;")
-check "merge remote has 3 docs" "3" "$result"
-
-result=$("$DB" "$TMPDIR/merge_remote.db" "SELECT text FROM doc WHERE id=1;")
-check "merge remote has edited text" "edited" "$result"
 
 # Clone the merged repo and verify history
 result=$("$DB" "$TMPDIR/merge_clone.db" "SELECT dolt_clone('$R/merge_remote.db');")


### PR DESCRIPTION
## Summary
- stop persisting remote default-branch working sets during file and HTTP push commits
- add a native regression proving push advances refs without overwriting a remote dirty working set
- update remote integration tests to validate pushed refs/history via fresh clone/pull semantics instead of direct remote working-set reads

## Testing
- ./build/doltlite_regression_test_c push_does_not_propagate_working_set
- cd build && bash ../test/remote_test.sh ./doltlite
- bash test/http_remote_test.sh ./build/doltlite ./build/doltlite-remotesrv