### PR TITLE
Fix two durability gaps in commit and GC paths

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -1886,6 +1886,20 @@ static int csCommitToFile(ChunkStore *cs){
   rc = cs->pFile->pMethods->xFileSize(cs->pFile, &fileSize);
   if( rc != SQLITE_OK ) goto commit_done;
 
+  /* Detect file replacement by another process (e.g. GC compaction
+  ** renamed a new file over the original). Our fd still points at
+  ** the orphaned inode — writes would be lost. Reload from the
+  ** current file at this path. */
+  if( hadFile ){
+    int bMoved = 0;
+    int rc2 = sqlite3OsFileControl(cs->pFile, SQLITE_FCNTL_HAS_MOVED,
+                                   &bMoved);
+    if( rc2==SQLITE_OK && bMoved ){
+      rc = csReloadFromDisk(cs);
+      if( rc != SQLITE_OK ) goto commit_done;
+      fileSize = cs->iFileSize;
+    }
+  }
 
   if( fileSize > cs->iFileSize && hadFile ){
     rc = csReloadFromDisk(cs);

--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -333,6 +333,12 @@ static int gcRewriteFile(
         }
 
         if( rename(zTmp, cs->zFilename)!=0 ){
+          /* Rename failed — original file still exists on disk
+          ** but cs->pFile was already closed. Reopen it so the
+          ** session doesn't crash on subsequent operations. */
+          int reopenFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB;
+          (void)sqlite3OsOpenMalloc(cs->pVfs, cs->zFilename,
+                                    &cs->pFile, reopenFlags, 0);
           rc = SQLITE_IOERR;
         }
 


### PR DESCRIPTION
## Summary
- Commit path now checks `SQLITE_FCNTL_HAS_MOVED` after acquiring the file lock. If another process ran `dolt_gc()` (rename over the original file), the stale fd is detected and `csReloadFromDisk` is called before writing. Previously writes went to the orphaned inode and were lost on exit.
- GC rename failure now reopens the original file. Previously `cs->pFile` was left NULL after close+failed-rename, crashing the session on the next operation.

## Test plan
- [x] 107,769 regression test assertions pass
- [x] Correctness tests pass (41/41)
- [x] Concurrent write tests pass (52/52)
- [x] GC rewrite failure test passes (10/10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)