### PR TITLE
Fix silent data loss for tables with >64 columns

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -33,7 +33,7 @@
 #define SERIAL_TYPE_ONE       9
 #define SERIAL_TYPE_TEXT_BASE 13
 #define SERIAL_TYPE_BLOB_BASE 12
-#define MAX_RECORD_FIELDS     64
+#define MAX_RECORD_FIELDS    256
 #define MAX_ONEBYTE_HEADER   126
 
 static void registerDoltiteFunctions(sqlite3 *db);


### PR DESCRIPTION
## Summary
- `MAX_RECORD_FIELDS` was 64, causing `serializeUnpackedRecordBuffer` to silently truncate records with more than 64 columns. SQLite allows up to 2000 columns; the prolly record format supports 256. Raised the limit to 256 to match.

## Test plan
- [x] 107,802 regression test assertions pass
- [x] Correctness tests pass (41/41)
- [x] Manual verification: 100-column table round-trips correctly through commit, reopen, update, and diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)