### PR TITLE
Fix command guards and remote ancestry checks

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -210,7 +210,23 @@ int doltliteHasUncommittedChanges(sqlite3 *db){
   int rc;
 
   rc = doltliteGetHeadCatalogHash(db, &headCatHash);
-  if( rc!=SQLITE_OK || prollyHashIsEmpty(&headCatHash) ) return 0;
+  if( rc!=SQLITE_OK ) return 0;
+  if( prollyHashIsEmpty(&headCatHash) ){
+    sqlite3_stmt *pStmt = 0;
+    int hasUserTables = 0;
+    rc = sqlite3_prepare_v2(db,
+      "SELECT 1 FROM sqlite_master "
+      "WHERE type='table' "
+      "AND name NOT LIKE 'sqlite_%' "
+      "AND name NOT LIKE 'dolt_%' "
+      "LIMIT 1",
+      -1, &pStmt, 0);
+    if( rc==SQLITE_OK && sqlite3_step(pStmt)==SQLITE_ROW ){
+      hasUserTables = 1;
+    }
+    sqlite3_finalize(pStmt);
+    return hasUserTables;
+  }
 
 
   doltliteGetSessionStaged(db, &stagedHash);
@@ -2422,6 +2438,12 @@ static void doltliteCherryPickFunc(
     return;
   }
 
+  if( doltliteHasUncommittedChanges(db) ){
+    sqlite3_result_error(context,
+      "cannot cherry-pick with uncommitted changes", -1);
+    return;
+  }
+
   rc = doltliteResolveRef(db,zRef, &pickHash);
   if( rc!=SQLITE_OK ){
     sqlite3_result_error(context, "invalid commit hash", -1);
@@ -2518,6 +2540,12 @@ static void doltliteRevertFunc(
   zRef = (const char*)sqlite3_value_text(argv[0]);
   if( !zRef ){
     sqlite3_result_int(context, 0);
+    return;
+  }
+
+  if( doltliteHasUncommittedChanges(db) ){
+    sqlite3_result_error(context,
+      "cannot revert with uncommitted changes", -1);
     return;
   }
 

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -4,6 +4,7 @@
 #include "sqliteInt.h"
 #include "prolly_hash.h"
 #include "chunk_store.h"
+#include "doltlite_ancestor.h"
 #include "doltlite_remote.h"
 #include "doltlite_commit.h"
 #include "doltlite_internal.h"
@@ -543,49 +544,17 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   }
 
 
-  /* dolt_pull is fast-forward-only; we walk the tracking branch's
-  ** first-parent chain back to the local tip. If we hit the local
-  ** commit, the local side has no unique commits and FF is safe.
-  ** Otherwise the user must dolt_merge to reconcile. maxDepth is
-  ** a safety cap against malformed cycles — legitimate histories
-  ** don't exceed it in practice. */
+  /* dolt_pull is fast-forward-only. A fast-forward is valid if the
+  ** local tip is any ancestor of the fetched tracking tip, not just
+  ** part of its first-parent chain. */
   {
-    ProllyHash walk;
-    int maxDepth = 1000;
-    int canFF = 0;
-    int walkRc = SQLITE_OK;
-    memcpy(&walk, &trackingCommit, sizeof(ProllyHash));
-
-    while( maxDepth-- > 0 ){
-      DoltliteCommit commit;
-
-      if( prollyHashCompare(&walk, &localCommit)==0 ){
-        canFF = 1;
-        break;
-      }
-      if( prollyHashIsEmpty(&walk) ) break;
-
-      memset(&commit, 0, sizeof(commit));
-      walkRc = doltliteLoadCommit(db, &walk, &commit);
-      if( walkRc!=SQLITE_OK ) break;
-
-      {
-        const ProllyHash *pParent = doltliteCommitParentHash(&commit, 0);
-        if( pParent && !prollyHashIsEmpty(pParent) ){
-          memcpy(&walk, pParent, sizeof(ProllyHash));
-        }else{
-          memset(&walk, 0, sizeof(ProllyHash));
-        }
-      }
-      doltliteCommitClear(&commit);
-    }
-
-    if( walkRc!=SQLITE_OK ){
-      remoteSqlRestoreAndReport(ctx, db, cs, &savedState, walkRc, 0);
+    ProllyHash ancestor;
+    rc = doltliteFindAncestor(db, &trackingCommit, &localCommit, &ancestor);
+    if( rc!=SQLITE_OK ){
+      remoteSqlRestoreAndReport(ctx, db, cs, &savedState, rc, 0);
       return;
     }
-
-    if( !canFF ){
+    if( prollyHashCompare(&ancestor, &localCommit)!=0 ){
       remoteSqlRestoreAndReport(
         ctx, db, cs, &savedState, SQLITE_ERROR,
         "cannot fast-forward — use dolt_merge with the tracking branch instead");
@@ -648,7 +617,11 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   }
   memset(&savedState, 0, sizeof(savedState));
 
-
+  if( doltliteHasUncommittedChanges(db) ){
+    sqlite3_result_error(ctx,
+      "database has uncommitted changes — clone into a fresh database", -1);
+    return;
+  }
 
   if( !chunkStoreIsEmpty(cs) ){
     int virgin = 0;

--- a/test/remote_test.sh
+++ b/test/remote_test.sh
@@ -229,7 +229,67 @@ result=$("$DB" "$TMPDIR/clone.db" "SELECT email FROM users WHERE id=1;")
 check "clone pulled schema change" "alice@test.com" "$result"
 
 # ============================================================
-echo "=== 14. Error cases ==="
+echo "=== 14. Pull full-ancestry fast-forward ==="
+# ============================================================
+"$DB" "$TMPDIR/anc_src.db" <<ENDSQL
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'base');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_branch('side');
+SELECT dolt_checkout('side');
+INSERT INTO t VALUES(2,'side');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','side commit');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(3,'main');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main commit');
+SELECT dolt_remote('add','origin','$R/anc_remote.db');
+SELECT dolt_push('origin','main');
+SELECT dolt_push('origin','side');
+.quit
+ENDSQL
+
+"$DB" "$TMPDIR/anc_remote_client.db" <<ENDSQL
+SELECT dolt_clone('$R/anc_remote.db');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('side');
+SELECT dolt_branch('--force','side','main');
+SELECT dolt_push('origin','side');
+.quit
+ENDSQL
+
+result=$("$DB" "$TMPDIR/anc_src.db" "SELECT dolt_checkout('side'); SELECT dolt_pull('origin','side'); SELECT count(*) FROM t;")
+check "pull with non-first-parent ancestry succeeds" "0
+0
+3" "$result"
+
+result=$("$DB" "$TMPDIR/anc_src.db" "SELECT v FROM t ORDER BY id;")
+check "pull with non-first-parent ancestry brings merged rows" "base
+side
+main" "$result"
+
+# ============================================================
+echo "=== 15. Clone into seeded dirty db fails safely ==="
+# ============================================================
+"$DB" "$TMPDIR/seeded_dirty.db" <<'ENDSQL'
+CREATE TABLE local_only(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO local_only VALUES(1,'local');
+.quit
+ENDSQL
+
+result=$("$DB" "$TMPDIR/seeded_dirty.db" "SELECT dolt_clone('$R/remote.db');" 2>&1)
+check "clone into seeded dirty db errors" "1" "$(echo "$result" | grep -c 'uncommitted changes')"
+
+result=$("$DB" "$TMPDIR/seeded_dirty.db" "SELECT count(*) FROM local_only;")
+check "clone into seeded dirty db keeps local rows" "1" "$result"
+
+result=$("$DB" "$TMPDIR/seeded_dirty.db" "SELECT count(*) FROM dolt_remotes;")
+check "clone into seeded dirty db keeps remotes empty" "0" "$result"
+
+# ============================================================
+echo "=== 16. Error cases ==="
 # ============================================================
 result=$("$DB" "$TMPDIR/src.db" "SELECT dolt_push('nonexistent','main');" 2>&1)
 check "push to unknown remote errors" "1" "$(echo "$result" | grep -c 'remote not found')"
@@ -254,7 +314,7 @@ result=$("$DB" "$TMPDIR/err2.db" "SELECT dolt_clone('file:///nonexistent/path.db
 check "clone nonexistent file errors" "1" "$(echo "$result" | grep -c 'clone failed')"
 
 # ============================================================
-echo "=== 15. Empty table push/clone ==="
+echo "=== 17. Empty table push/clone ==="
 # ============================================================
 "$DB" "$TMPDIR/empty_src.db" <<ENDSQL
 CREATE TABLE empty_t(id INTEGER PRIMARY KEY);
@@ -271,7 +331,7 @@ result=$("$DB" "$TMPDIR/empty_clone.db" "SELECT count(*) FROM empty_t;")
 check "empty table exists in clone" "0" "$result"
 
 # ============================================================
-echo "=== 16. Large data push/clone ==="
+echo "=== 18. Large data push/clone ==="
 # ============================================================
 "$DB" "$TMPDIR/large_src.db" <<ENDSQL
 CREATE TABLE big(id INTEGER PRIMARY KEY, data TEXT);
@@ -290,7 +350,7 @@ result=$("$DB" "$TMPDIR/large_clone.db" "SELECT count(*) FROM big;")
 check "clone has 500 rows" "500" "$result"
 
 # ============================================================
-echo "=== 17. Push to second remote ==="
+echo "=== 19. Push to second remote ==="
 # ============================================================
 "$DB" "$TMPDIR/src.db" "SELECT dolt_remote('add','mirror','$R/mirror.db'); SELECT dolt_push('mirror','main');" > /dev/null
 src_head=$("$DB" "$TMPDIR/src.db" "SELECT commit_hash FROM dolt_log LIMIT 1;")
@@ -298,7 +358,7 @@ result=$("$DB" "$TMPDIR/mirror.db" "SELECT commit_hash FROM dolt_log LIMIT 1;")
 check "mirror head matches pushed main" "$src_head" "$result"
 
 # ============================================================
-echo "=== 18. Clone preserves multiple branches ==="
+echo "=== 20. Clone preserves multiple branches ==="
 # ============================================================
 result=$("$DB" "$TMPDIR/multi_clone.db" "SELECT dolt_clone('$R/remote.db');")
 check "multi-branch clone returns 0" "0" "$result"
@@ -307,7 +367,7 @@ result=$("$DB" "$TMPDIR/multi_clone.db" "SELECT count(*) FROM dolt_branches;")
 check "clone has 2 branches" "2" "$result"
 
 # ============================================================
-echo "=== 19. Deep history push/clone (20 commits) ==="
+echo "=== 21. Deep history push/clone (20 commits) ==="
 # ============================================================
 "$DB" "$TMPDIR/deep_src.db" <<ENDSQL
 CREATE TABLE log(id INTEGER PRIMARY KEY, step INTEGER, msg TEXT);
@@ -331,7 +391,7 @@ result=$("$DB" "$TMPDIR/deep_clone.db" "SELECT count(*) FROM dolt_log;")
 check "deep clone has 22 commits" "22" "$result"
 
 # ============================================================
-echo "=== 20. Diverged branches: push both, clone gets all ==="
+echo "=== 22. Diverged branches: push both, clone gets all ==="
 # ============================================================
 "$DB" "$TMPDIR/div_src.db" <<ENDSQL
 CREATE TABLE items(id INTEGER PRIMARY KEY, val TEXT);
@@ -384,7 +444,7 @@ check "div clone main has 1 item" "0
 1" "$result"
 
 # ============================================================
-echo "=== 21. Incremental fetch: push more, fetch only new ==="
+echo "=== 23. Incremental fetch: push more, fetch only new ==="
 # ============================================================
 # Add 5 more commits on branchA in source
 "$DB" "$TMPDIR/div_src.db" "SELECT dolt_checkout('branchA');" > /dev/null
@@ -404,7 +464,7 @@ check "incremental pull has 16 items" "0
 16" "$result"
 
 # ============================================================
-echo "=== 22. Push after merge ==="
+echo "=== 24. Push after merge ==="
 # ============================================================
 "$DB" "$TMPDIR/merge_src.db" <<ENDSQL
 CREATE TABLE doc(id INTEGER PRIMARY KEY, text TEXT);
@@ -438,7 +498,7 @@ result=$("$DB" "$TMPDIR/merge_clone.db" "SELECT count(*) FROM dolt_log;")
 check "merge clone has commit history" "5" "$result"
 
 # ============================================================
-echo "=== 23. Round-trip: A→remote→B→remote→A (3 hops) ==="
+echo "=== 25. Round-trip: A→remote→B→remote→A (3 hops) ==="
 # ============================================================
 "$DB" "$TMPDIR/hop_a.db" <<ENDSQL
 CREATE TABLE chain(id INTEGER PRIMARY KEY, who TEXT);

--- a/test/vc_oracle_revert_cherrypick_test.sh
+++ b/test/vc_oracle_revert_cherrypick_test.sh
@@ -565,6 +565,29 @@ $SEED
 SELECT dolt_cherry_pick('does-not-exist');
 "
 
+oracle_error "cherry_pick_dirty_working_set" "
+$SEED
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat_add_2');
+SELECT dolt_checkout('main');
+UPDATE t SET v = 11 WHERE id = 1;
+SELECT dolt_cherry_pick('feature');
+"
+
+oracle_error "cherry_pick_staged_changes" "
+$SEED
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat_add_2');
+SELECT dolt_checkout('main');
+UPDATE t SET v = 11 WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_cherry_pick('feature');
+"
+
 # Dolt's dolt_revert() with no args is a silent no-op rather than
 # an error (likely an undocumented quirk — there's no defined
 # semantics for "revert nothing"). doltlite matches Dolt for
@@ -577,6 +600,25 @@ SELECT dolt_revert();
 oracle_error "revert_nonexistent_ref" "
 $SEED
 SELECT dolt_revert('does-not-exist');
+"
+
+oracle_error "revert_dirty_working_set" "
+$SEED
+UPDATE t SET v = 50 WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2_set_50');
+UPDATE t SET v = 99 WHERE id = 1;
+SELECT dolt_revert('HEAD');
+"
+
+oracle_error "revert_staged_changes" "
+$SEED
+UPDATE t SET v = 50 WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2_set_50');
+UPDATE t SET v = 99 WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_revert('HEAD');
 "
 
 # Reverting the initial commit has no parent to diff against — should


### PR DESCRIPTION
## Summary
- reject cherry-pick and revert with uncommitted changes
- use full ancestry for pull fast-forward checks instead of first-parent only
- reject clone into dirty seeded databases
- add oracle and remote integration coverage for these correctness cases

## Testing
- bash test/vc_oracle_revert_cherrypick_test.sh ./build/doltlite dolt
- bash test/remote_test.sh ./build/doltlite
- ./build/doltlite_regression_test_c pull_persist_failure
- ./build/doltlite_regression_test_c pull_dirty_working_set_fails
- ./build/doltlite_regression_test_c pull_staged_changes_fails
- ./build/doltlite_regression_test_c clone_persist_failure