### PR TITLE
Tighten checkout and branch command semantics

### DIFF
--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -4,6 +4,7 @@
 #include "sqliteInt.h"
 #include "prolly_hash.h"
 #include "chunk_store.h"
+#include "doltlite_ancestor.h"
 #include "doltlite_commit.h"
 #include "doltlite_internal.h"
 #include <string.h>
@@ -22,6 +23,10 @@ struct BranchMutationCtx {
   int isDelete;
   int force;
 };
+
+static int branchNameEmpty(const char *zName){
+  return zName==0 || zName[0]==0;
+}
 
 static void branchResultError(
   sqlite3_context *ctx,
@@ -163,12 +168,29 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
   switch( mode ){
     case MODE_DELETE: {
       BranchMutationCtx m;
+      ProllyHash branchHead, currentHead, ancestor;
       if( nPositional<1 ){
+        sqlite3_result_error(ctx, "branch name required", -1); return;
+      }
+      if( branchNameEmpty(aPositional[0]) ){
         sqlite3_result_error(ctx, "branch name required", -1); return;
       }
       if( strcmp(aPositional[0], doltliteGetSessionBranch(db))==0 ){
         sqlite3_result_error(ctx, "cannot delete the current branch", -1);
         return;
+      }
+      if( !force ){
+        rc = chunkStoreFindBranch(cs, aPositional[0], &branchHead);
+        if( rc!=SQLITE_OK ){
+          branchResultError(ctx, rc, "branch not found", 0);
+          return;
+        }
+        doltliteGetSessionHead(db, &currentHead);
+        rc = doltliteFindAncestor(db, &currentHead, &branchHead, &ancestor);
+        if( rc!=SQLITE_OK || prollyHashCompare(&ancestor, &branchHead)!=0 ){
+          sqlite3_result_error(ctx, "branch is not fully merged", -1);
+          return;
+        }
       }
       memset(&m, 0, sizeof(m));
       m.zName = aPositional[0];
@@ -185,6 +207,10 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
       BranchCopyCtx m;
       if( nPositional<2 ){
         sqlite3_result_error(ctx, "copy requires source and destination", -1);
+        return;
+      }
+      if( branchNameEmpty(aPositional[0]) || branchNameEmpty(aPositional[1]) ){
+        sqlite3_result_error(ctx, "branch name required", -1);
         return;
       }
       memset(&m, 0, sizeof(m));
@@ -204,6 +230,10 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
       int renamingCurrent;
       if( nPositional<2 ){
         sqlite3_result_error(ctx, "move requires source and destination", -1);
+        return;
+      }
+      if( branchNameEmpty(aPositional[0]) || branchNameEmpty(aPositional[1]) ){
+        sqlite3_result_error(ctx, "branch name required", -1);
         return;
       }
       memset(&m, 0, sizeof(m));
@@ -229,6 +259,9 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
         sqlite3_result_error(ctx, "branch name required", -1); return;
       }
       zName = aPositional[0];
+      if( branchNameEmpty(zName) ){
+        sqlite3_result_error(ctx, "branch name required", -1); return;
+      }
       zStart = nPositional>=2 ? aPositional[1] : 0;
       memset(&m, 0, sizeof(m));
       if( zStart ){
@@ -564,7 +597,7 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
   if( strcmp(zBranch, "-b")==0 ){
     if( argc<2 ){ sqlite3_result_error(ctx, "branch name required after -b", -1); return; }
     zBranch = (const char*)sqlite3_value_text(argv[1]);
-    if( !zBranch ){ sqlite3_result_error(ctx, "branch name required after -b", -1); return; }
+    if( branchNameEmpty(zBranch) ){ sqlite3_result_error(ctx, "branch name required after -b", -1); return; }
 
     doltliteGetSessionHead(db, &branchCreate.head);
     if( prollyHashIsEmpty(&branchCreate.head) ){

--- a/test/doltlite_branch.sh
+++ b/test/doltlite_branch.sh
@@ -29,7 +29,8 @@ run_test "feature_two_rows" "SELECT count(*) FROM t;" "2" "$DB"
 run_test_match "dup_branch" "SELECT dolt_branch('feature');" "already exists" "$DB"
 run_test_match "del_current" "SELECT dolt_branch('-d','feature');" "cannot delete" "$DB"
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
-run_test "delete_branch" "SELECT dolt_branch('-d','feature');" "0" "$DB"
+run_test_match "delete_unmerged_branch" "SELECT dolt_branch('-d','feature');" "not fully merged" "$DB"
+run_test "force_delete_branch" "SELECT dolt_branch('-D','feature');" "0" "$DB"
 run_test "one_branch" "SELECT count(*) FROM dolt_branches;" "1" "$DB"
 run_test_match "checkout_gone" "SELECT dolt_checkout('feature');" "no such branch or table" "$DB"
 
@@ -99,6 +100,12 @@ run_test "checkout_b_main_data" "SELECT count(*) FROM t;" "1" "$DB9"
 
 # checkout -b with existing name errors
 run_test_match "checkout_b_dup" "SELECT dolt_checkout('-b','main');" "already exists" "$DB9"
+run_test_match "create_empty_branch_name" "SELECT dolt_branch('');" "branch name required" "$DB9"
+run_test_match "copy_empty_source" "SELECT dolt_branch('-c','','copy');" "branch name required" "$DB9"
+run_test_match "copy_empty_dest" "SELECT dolt_branch('-c','main','');" "branch name required" "$DB9"
+run_test_match "move_empty_source" "SELECT dolt_branch('-m','','renamed');" "branch name required" "$DB9"
+run_test_match "move_empty_dest" "SELECT dolt_branch('-m','main','');" "branch name required" "$DB9"
+run_test_match "checkout_b_empty_name" "SELECT dolt_checkout('-b','');" "branch name required" "$DB9"
 
 rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9"
 echo ""

--- a/test/doltlite_branch_edge.sh
+++ b/test/doltlite_branch_edge.sh
@@ -34,7 +34,7 @@ SELECT dolt_commit('-A','-m','old branch commit');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 # Delete the branch
-echo "SELECT dolt_branch('-d','temp');" | $DOLTLITE "$DB" > /dev/null 2>&1
+echo "SELECT dolt_branch('-D','temp');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 # Recreate with same name -- should start from main's HEAD (1 row)
 echo "SELECT dolt_branch('temp');

--- a/test/doltlite_branch_gc_stress.sh
+++ b/test/doltlite_branch_gc_stress.sh
@@ -81,7 +81,7 @@ run_test "merge_5_has_b5" "SELECT val FROM t WHERE id=5;" "5" "$DB"
 
 echo "  Deleting 90 branches..."
 for i in $(seq 6 95); do
-  echo "SELECT dolt_branch('-d','b$i');" | $DOLTLITE "$DB" > /dev/null 2>&1
+  echo "SELECT dolt_branch('-D','b$i');" | $DOLTLITE "$DB" > /dev/null 2>&1
 done
 echo "  Done deleting branches."
 
@@ -167,7 +167,7 @@ echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 SIZE_WITH_BULK=$(file_size "$DB")
 
-echo "SELECT dolt_branch('-d','bulk');" | $DOLTLITE "$DB" > /dev/null 2>&1
+echo "SELECT dolt_branch('-D','bulk');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_gc();" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 SIZE_AFTER_BULK_GC=$(file_size "$DB")
@@ -310,7 +310,7 @@ for cycle in $(seq 1 10); do
   echo "INSERT INTO t VALUES($((cycle + 100)),'cycle_$cycle');
 SELECT dolt_commit('-A','-m','cycle $cycle');" | $DOLTLITE "$DB" > /dev/null 2>&1
   echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
-  echo "SELECT dolt_branch('-d','recycled');" | $DOLTLITE "$DB" > /dev/null 2>&1
+  echo "SELECT dolt_branch('-D','recycled');" | $DOLTLITE "$DB" > /dev/null 2>&1
 done
 
 # After 10 create/delete cycles, only main should remain

--- a/test/doltlite_e2e.sh
+++ b/test/doltlite_e2e.sh
@@ -158,7 +158,7 @@ run_test_match "e2e_commit_all" "SELECT dolt_commit('-A','-m','Add Dave');" "^[0
 
 run_test "e2e_branch_count" "SELECT count(*) FROM dolt_branches;" "3" "$DB"
 
-echo "SELECT dolt_branch('-d','hotfix');" | $DOLTLITE "$DB" > /dev/null 2>&1
+echo "SELECT dolt_branch('-D','hotfix');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "e2e_deleted_branch" "SELECT count(*) FROM dolt_branches;" "2" "$DB"
 run_test_match "e2e_delete_gone" "SELECT dolt_checkout('hotfix');" "no such branch or table" "$DB"
 

--- a/test/doltlite_feature_deep.sh
+++ b/test/doltlite_feature_deep.sh
@@ -129,7 +129,7 @@ echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 SIZE_BEFORE=$(db_size "$DB")
 
-echo "SELECT dolt_branch('-d','big');" | $DOLTLITE "$DB" > /dev/null 2>&1
+echo "SELECT dolt_branch('-D','big');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_gc();" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 SIZE_AFTER=$(db_size "$DB")

--- a/test/doltlite_persistence.sh
+++ b/test/doltlite_persistence.sh
@@ -290,7 +290,7 @@ SELECT dolt_checkout('temp');
 INSERT INTO t VALUES(2,'temp');
 SELECT dolt_commit('-A','-m','temp');
 SELECT dolt_checkout('main');
-SELECT dolt_branch('-d','temp');
+SELECT dolt_branch('-D','temp');
 SELECT dolt_gc();" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "gc_data" "SELECT v FROM t WHERE id=1;" "keep" "$DB"

--- a/test/doltlite_structural.sh
+++ b/test/doltlite_structural.sh
@@ -176,7 +176,7 @@ SIZE_WITH_BRANCH=$(file_size "$DB")
 echo "  With branch (2K rows): ${SIZE_WITH_BRANCH} bytes"
 
 # Delete branch and GC
-echo "SELECT dolt_branch('-d','big');
+echo "SELECT dolt_branch('-D','big');
 SELECT dolt_gc();" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 SIZE_AFTER_GC=$(file_size "$DB")
@@ -368,7 +368,7 @@ SELECT dolt_checkout('feat');
 INSERT INTO t VALUES(9999,'feat');
 SELECT dolt_commit('-A','-m','feat');
 SELECT dolt_checkout('main');
-SELECT dolt_branch('-d','feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_branch('-D','feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 echo "SELECT dolt_gc();" | $DOLTLITE "$DB" > /dev/null 2>&1
 SIZE_FIRST_GC=$(file_size "$DB")

--- a/test/vc_oracle_branch_test.sh
+++ b/test/vc_oracle_branch_test.sh
@@ -143,6 +143,28 @@ SELECT dolt_branch('feature');
 SELECT dolt_branch('-D', 'feature');
 "
 
+oracle_error "delete_unmerged_requires_force" "
+$SEED
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat');
+SELECT dolt_checkout('main');
+SELECT dolt_branch('-d', 'feature');
+"
+
+oracle "delete_unmerged_force" "
+$SEED
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat');
+SELECT dolt_checkout('main');
+SELECT dolt_branch('-D', 'feature');
+"
+
 echo "--- copy ---"
 
 oracle "copy_from_main" "
@@ -211,6 +233,31 @@ oracle_error "create_duplicate" "
 $SEED
 SELECT dolt_branch('feature');
 SELECT dolt_branch('feature');
+"
+
+oracle_error "create_empty_name" "
+$SEED
+SELECT dolt_branch('');
+"
+
+oracle_error "copy_empty_source" "
+$SEED
+SELECT dolt_branch('-c', '', 'dest');
+"
+
+oracle_error "copy_empty_dest" "
+$SEED
+SELECT dolt_branch('-c', 'main', '');
+"
+
+oracle_error "move_empty_source" "
+$SEED
+SELECT dolt_branch('-m', '', 'dest');
+"
+
+oracle_error "move_empty_dest" "
+$SEED
+SELECT dolt_branch('-m', 'main', '');
 "
 
 oracle_error "no_args" "

--- a/test/vc_oracle_checkout_test.sh
+++ b/test/vc_oracle_checkout_test.sh
@@ -264,6 +264,11 @@ $SEED
 SELECT dolt_checkout('-b');
 "
 
+oracle_error "dash_b_empty_name" "
+$SEED
+SELECT dolt_checkout('-b', '');
+"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then


### PR DESCRIPTION
## Summary
- reject empty branch names across create, copy, move, and checkout -b
- reject deleting unmerged branches unless forced
- add Dolt oracle coverage for the new checkout and branch error paths
- update the direct branch shell suite to match the stricter delete semantics

## Testing
- bash test/vc_oracle_branch_test.sh ./build/doltlite dolt
- bash test/vc_oracle_checkout_test.sh ./build/doltlite dolt
- (cd build && bash ../test/doltlite_branch.sh)