### PR TITLE
Fix secondary index merge: three-way merge by iTable

### DIFF
--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -1099,8 +1099,13 @@ static int mergeCatalogPass1(
 
 
     if( !zName ){
-      aMerged[(*pnMerged)++] = aOurs[i];
-      continue;
+      /* Nameless catalog entry — secondary index. Match by iTable
+      ** number across ancestor/theirs and three-way merge the index
+      ** tree just like a named table. Without this, the feat-side
+      ** index entries are lost on merge. */
+      ancEntry = findTableEntry(aAnc, nAnc, aOurs[i].iTable);
+      theirsEntry = findTableEntry(aTheirs, nTheirs, aOurs[i].iTable);
+      goto do_merge_entry;
     }
 
 


### PR DESCRIPTION
## Summary
- Secondary indexes (nameless catalog entries) were skipped during three-way merge. The code copied the ours-side index root as-is, so rows added or modified on the other branch never appeared in the merged index. This caused `count(*)` and index-scan queries to return wrong results while `SELECT *` (full table scan) was correct.
- The fix matches nameless entries by `iTable` number (stable across branches) and runs the same three-way merge used for named tables.
- 5-line change in `doltlite_merge.c`.

## Test plan
- [x] 107,802 regression test assertions pass
- [x] All merge/conflict/schema-merge oracle tests pass (76/76)
- [x] Correctness tests pass (41/41)
- [x] Index tests pass (30/30)
- [x] Manual: 3-row indexed merge now returns correct count via both table scan and index scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)