### PR TITLE
Fix uninitialized read in field-level merge

### DIFF
--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -263,8 +263,11 @@ static u8 *tryCellMerge(
 
         winners[i].pRec = pTheirs; winners[i].pField = &aTheirs[i];
       }else{
-
-        continue;
+        /* Both sides dropped this field (baseHas && !oursHas &&
+        ** !theirsHas), or the impossible (0,0,0) case. Field-level
+        ** merge can't represent a dropped field in the output —
+        ** fall back to row-level conflict handling. */
+        sqlite3_free(winners); goto fail;
       }
     }
 


### PR DESCRIPTION
## Summary
- `tryCellMerge` had an uninitialized memory read when both branches dropped the same column from a row. The `continue` at line 267 skipped setting `winners[i]`, then `buildMergedRecord` read the garbage slot. Now falls back to row-level conflict handling instead.
- Requires ALTER TABLE DROP COLUMN on both branches + modifying the same row to trigger. Edge case, but reads uninitialized heap memory.

## Test plan
- [x] 107,802 regression tests pass
- [x] All merge/schema-merge oracle tests pass (67/67)
- [x] Large merge tests pass (12/12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)