### PR TITLE
Lock merge and rebase argument semantics

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -1904,6 +1904,7 @@ static void doltliteMergeFunc(
   const char *zMessage = 0;
   int isAbort = 0;
   int noFastForward = 0;
+  u8 isMerging = 0;
   ProllyHash ourHead, theirHead, ancestorHash;
   ProllyHash ourCatHash, theirCatHash, ancCatHash, mergedCatHash;
   DoltliteTxnState savedState;
@@ -1953,7 +1954,11 @@ static void doltliteMergeFunc(
   }
 
   if( isAbort ){
-    u8 isMerging = 0;
+    if( zBranch || zMessage || noFastForward ){
+      sqlite3_result_error(context,
+        "--abort does not take other arguments", -1);
+      return;
+    }
     doltliteGetSessionMergeState(db, &isMerging, 0, 0);
     if( !isMerging ){
       sqlite3_result_error(context, "no merge in progress", -1);
@@ -3577,12 +3582,33 @@ static void doltliteRebaseFunc(
         "dolt_rebase('-i', 'upstream')", -1);
       return;
     }
+    if( argc!=2 ){
+      sqlite3_result_error(context,
+        "interactive rebase takes exactly one upstream branch", -1);
+      return;
+    }
     zUpstream = (const char*)sqlite3_value_text(argv[1]);
     if( !zUpstream ){
       sqlite3_result_error(context, "upstream ref required", -1);
       return;
     }
     doltliteRebaseInteractiveStart(context, db, zUpstream);
+    return;
+  }
+
+  if( zArg0[0]=='-' ){
+    char *zErr = sqlite3_mprintf("unknown option `%s`", zArg0);
+    if( zErr ){
+      sqlite3_result_error(context, zErr, -1);
+      sqlite3_free(zErr);
+    }else{
+      sqlite3_result_error_nomem(context);
+    }
+    return;
+  }
+  if( argc!=1 ){
+    sqlite3_result_error(context,
+      "too many positional arguments to dolt_rebase", -1);
     return;
   }
 

--- a/test/vc_oracle_merge_test.sh
+++ b/test/vc_oracle_merge_test.sh
@@ -688,6 +688,21 @@ oracle_error "merge_no_args" "
 SELECT dolt_merge();
 "
 
+oracle_error "merge_abort_with_extra_args" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 1);
+SELECT dolt_commit('-A', '-m', 'init');
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+UPDATE t SET v = 100 WHERE id = 1;
+SELECT dolt_commit('-A', '-m', 'feat1');
+SELECT dolt_checkout('main');
+UPDATE t SET v = 999 WHERE id = 1;
+SELECT dolt_commit('-A', '-m', 'main2');
+SELECT dolt_merge('feature');
+SELECT dolt_merge('--abort', 'extra');
+"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then

--- a/test/vc_oracle_rebase_test.sh
+++ b/test/vc_oracle_rebase_test.sh
@@ -238,6 +238,25 @@ SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');
 SELECT dolt_rebase();
 "
 
+oracle_error "too_many_args" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');
+SELECT dolt_checkout('-b', 'feat');
+INSERT INTO t VALUES (1);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'f');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES (2);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'm');
+SELECT dolt_checkout('feat');
+SELECT dolt_rebase('main', 'extra');
+"
+
+oracle_error "unknown_flag" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');
+SELECT dolt_rebase('--bogus');
+"
+
 echo "--- interactive rebase ---"
 
 # All interactive scenarios share this setup: three commits f1,f2,f3 on
@@ -340,6 +359,11 @@ oracle_error "continue_without_active" "
 CREATE TABLE t(id INTEGER PRIMARY KEY);
 SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');
 SELECT dolt_rebase('--continue');
+"
+
+oracle_error "interactive_too_many_args" "
+$INTERACTIVE_SETUP
+SELECT dolt_rebase('-i', 'main', 'extra');
 "
 
 echo ""


### PR DESCRIPTION
## Summary
- tighten merge/rebase argument handling to match Dolt's SQL surface
- reject extra args for non-interactive and interactive-start rebase paths
- reject extra args for merge --abort and add oracle coverage for merge/rebase arg semantics

## Testing
- bash test/vc_oracle_merge_test.sh ./build/doltlite dolt
- bash test/vc_oracle_rebase_test.sh ./build/doltlite dolt
- cd build && bash ../test/doltlite_merge.sh
- cd build && bash ../test/doltlite_rebase.sh ./doltlite