### PR TITLE
Use main schema for conflict table column lookup

### DIFF
--- a/src/doltlite_record.c
+++ b/src/doltlite_record.c
@@ -180,7 +180,7 @@ int doltliteGetColumnNames(sqlite3 *db, const char *zTable, DoltliteColInfo *ci)
 
   memset(ci, 0, sizeof(*ci));
   ci->iPkCol = -1;
-  zSql = sqlite3_mprintf("PRAGMA table_info(\"%w\")", zTable);
+  zSql = sqlite3_mprintf("PRAGMA main.table_info(\"%w\")", zTable);
   if( !zSql ) return SQLITE_NOMEM;
 
   rc = sqlite3_prepare_v2(db, zSql, -1, &pStmt, 0);

--- a/test/doltlite_conflicts.sh
+++ b/test/doltlite_conflicts.sh
@@ -104,6 +104,13 @@ run_test_match "conflict_base_decoded" "SELECT base_name FROM dolt_conflicts_t;"
 run_test_match "conflict_our_decoded" "SELECT our_name FROM dolt_conflicts_t;" "CHARLIE" "$DB7"
 run_test_match "conflict_their_decoded" "SELECT their_name FROM dolt_conflicts_t;" "BOB" "$DB7"
 
+# Temp table shadowing the user table must not affect dolt_conflicts_<table>
+# projection. The conflict view should derive its schema from main.t.
+echo "CREATE TEMP TABLE t(fake TEXT PRIMARY KEY);" | $DOLTLITE "$DB7" > /dev/null 2>&1
+run_test_match "conflict_temp_shadow_base_ignored" "SELECT base_name FROM dolt_conflicts_t;" "alice" "$DB7"
+run_test_match "conflict_temp_shadow_our_ignored" "SELECT our_name FROM dolt_conflicts_t;" "CHARLIE" "$DB7"
+run_test_match "conflict_temp_shadow_their_ignored" "SELECT their_name FROM dolt_conflicts_t;" "BOB" "$DB7"
+
 # --- Multiple conflicting rows in one table ---
 DB8=/tmp/test_conflicts8_$$.db; rm -f "$DB8"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, name TEXT); INSERT INTO t VALUES(1,'a'),(2,'b'),(3,'c'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB8" > /dev/null 2>&1


### PR DESCRIPTION
## Summary
- make conflict-table column projection authoritative to main user tables
- prevent temp-shadowed user tables from spoofing dolt_conflicts_<table> schema
- add a regression covering temp shadowing during conflict inspection

## Testing
- cd build && bash ../test/doltlite_conflicts.sh
- bash test/vc_oracle_conflicts_table_test.sh ./build/doltlite dolt
- bash test/vc_oracle_conflicts_test.sh ./build/doltlite dolt
