### PR TITLE
Add deterministic GC crash injection tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -360,3 +360,44 @@ jobs:
           tkt-80e031a00f tkt-80ba201079 tkt-31338dca7e \
           tkt-7bbfb7d442 tkt-4dd95f6943 tkt-2d1a5c67d \
           tkt-f3e5abed55
+
+  crash-sqlite-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install crash-test dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y tcl-dev libtommath-dev build-essential zlib1g-dev
+
+    - name: Configure SQLITE_TEST build
+      run: |
+        mkdir -p build-crash && cd build-crash
+        TCL_CONFIG=$(find /usr -name tclConfig.sh 2>/dev/null | head -1)
+        if [ -n "$TCL_CONFIG" ]; then
+          ../configure --with-tcl=$(dirname "$TCL_CONFIG")
+        else
+          ../configure
+        fi
+
+    - name: Build crash-test binaries
+      run: |
+        cd build-crash
+        make OPTIONS='-DSQLITE_TEST=1 -DSQLITE_CRASH_TEST=1' doltlite-lib doltlite-crashtest
+
+    - name: Native crash recovery test (SQLITE_TEST)
+      run: |
+        cd build-crash
+        cc -I. -o crash_recovery_test ../test/crash_recovery_test.c \
+          libdoltlite.a -lz -lpthread
+        ./crash_recovery_test
+      timeout-minutes: 10
+
+    - name: Crash injection durability test (SQLITE_TEST)
+      run: |
+        cd build-crash
+        bash ../test/crash_injection_test.sh ./doltlite-crashtest
+      timeout-minutes: 15

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -395,8 +395,11 @@ jobs:
     - name: Native crash recovery test (SQLITE_TEST)
       run: |
         cd build-crash
-        cc -I. -o crash_recovery_test ../test/crash_recovery_test.c \
-          libdoltlite.a -lz -lpthread -lm
+        TCL_CONFIG=$(find /usr/lib /usr/lib/x86_64-linux-gnu /usr/share -name tclConfig.sh 2>/dev/null | grep -v miniconda | head -1)
+        . "$TCL_CONFIG"
+        cc -I. $TCL_INCLUDE_SPEC -o crash_recovery_test ../test/crash_recovery_test.c \
+          libdoltlite.a ../ext/fts3/fts3_term.c \
+          $TCL_LIB_SPEC $TCL_LIBS -lz -lpthread -lm
         ./crash_recovery_test
       timeout-minutes: 10
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -262,6 +262,14 @@ jobs:
           libdoltlite.a -lz -lpthread -lm
         ./concurrent_write_test
 
+    - name: Native crash recovery test
+      run: |
+        cd build
+        cc -I. -o crash_recovery_test ../test/crash_recovery_test.c \
+          libdoltlite.a -lz -lpthread
+        ./crash_recovery_test
+      timeout-minutes: 10
+
     - name: Prepared statement reuse test
       run: |
         cd build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -386,7 +386,8 @@ jobs:
     - name: Build crash-test binaries
       run: |
         cd build-crash
-        . ./.tclenv.sh
+        TCL_CONFIG=$(find /usr -name tclConfig.sh 2>/dev/null | head -1)
+        . "$TCL_CONFIG"
         make OPTIONS='-DSQLITE_TEST=1 -DSQLITE_CRASH_TEST=1' \
           OPTS="$TCL_INCLUDE_SPEC" \
           doltlite-lib doltlite-crashtest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -398,7 +398,7 @@ jobs:
         TCL_CONFIG=$(find /usr/lib /usr/lib/x86_64-linux-gnu /usr/share -name tclConfig.sh 2>/dev/null | grep -v miniconda | head -1)
         . "$TCL_CONFIG"
         cc -I. $TCL_INCLUDE_SPEC -o crash_recovery_test ../test/crash_recovery_test.c \
-          libdoltlite.a ../ext/fts3/fts3_term.c \
+          ../ext/fts3/fts3_term.c libdoltlite.a \
           $TCL_LIB_SPEC $TCL_LIBS -lz -lpthread -lm
         ./crash_recovery_test
       timeout-minutes: 10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -376,7 +376,7 @@ jobs:
     - name: Configure SQLITE_TEST build
       run: |
         mkdir -p build-crash && cd build-crash
-        TCL_CONFIG=$(find /usr -name tclConfig.sh 2>/dev/null | head -1)
+        TCL_CONFIG=$(find /usr/lib /usr/lib/x86_64-linux-gnu /usr/share -name tclConfig.sh 2>/dev/null | grep -v miniconda | head -1)
         if [ -n "$TCL_CONFIG" ]; then
           ../configure --with-tcl=$(dirname "$TCL_CONFIG")
         else
@@ -386,7 +386,7 @@ jobs:
     - name: Build crash-test binaries
       run: |
         cd build-crash
-        TCL_CONFIG=$(find /usr -name tclConfig.sh 2>/dev/null | head -1)
+        TCL_CONFIG=$(find /usr/lib /usr/lib/x86_64-linux-gnu /usr/share -name tclConfig.sh 2>/dev/null | grep -v miniconda | head -1)
         . "$TCL_CONFIG"
         make OPTIONS='-DSQLITE_TEST=1 -DSQLITE_CRASH_TEST=1' \
           OPTS="$TCL_INCLUDE_SPEC" \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -386,7 +386,10 @@ jobs:
     - name: Build crash-test binaries
       run: |
         cd build-crash
-        make OPTIONS='-DSQLITE_TEST=1 -DSQLITE_CRASH_TEST=1' doltlite-lib doltlite-crashtest
+        . ./.tclenv.sh
+        make OPTIONS='-DSQLITE_TEST=1 -DSQLITE_CRASH_TEST=1' \
+          OPTS="$TCL_INCLUDE_SPEC" \
+          doltlite-lib doltlite-crashtest
 
     - name: Native crash recovery test (SQLITE_TEST)
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -390,17 +390,12 @@ jobs:
         . "$TCL_CONFIG"
         make OPTIONS='-DSQLITE_TEST=1 -DSQLITE_CRASH_TEST=1' \
           OPTS="$TCL_INCLUDE_SPEC" \
-          libdoltlite.a doltlite-crashtest
+          libdoltlite.a doltlite-crashtest crash_recovery_test_sqlite_test
 
     - name: Native crash recovery test (SQLITE_TEST)
       run: |
         cd build-crash
-        TCL_CONFIG=$(find /usr/lib /usr/lib/x86_64-linux-gnu /usr/share -name tclConfig.sh 2>/dev/null | grep -v miniconda | head -1)
-        . "$TCL_CONFIG"
-        cc -I. $TCL_INCLUDE_SPEC -o crash_recovery_test ../test/crash_recovery_test.c \
-          ../ext/fts3/fts3_term.c libdoltlite.a \
-          $TCL_LIB_SPEC $TCL_LIBS -lz -lpthread -lm
-        ./crash_recovery_test
+        ./crash_recovery_test_sqlite_test
       timeout-minutes: 10
 
     - name: Crash injection durability test (SQLITE_TEST)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -266,7 +266,7 @@ jobs:
       run: |
         cd build
         cc -I. -o crash_recovery_test ../test/crash_recovery_test.c \
-          libdoltlite.a -lz -lpthread
+          libdoltlite.a -lz -lpthread -lm
         ./crash_recovery_test
       timeout-minutes: 10
 
@@ -390,13 +390,13 @@ jobs:
         . "$TCL_CONFIG"
         make OPTIONS='-DSQLITE_TEST=1 -DSQLITE_CRASH_TEST=1' \
           OPTS="$TCL_INCLUDE_SPEC" \
-          doltlite-lib doltlite-crashtest
+          libdoltlite.a doltlite-crashtest
 
     - name: Native crash recovery test (SQLITE_TEST)
       run: |
         cd build-crash
         cc -I. -o crash_recovery_test ../test/crash_recovery_test.c \
-          libdoltlite.a -lz -lpthread
+          libdoltlite.a -lz -lpthread -lm
         ./crash_recovery_test
       timeout-minutes: 10
 

--- a/main.mk
+++ b/main.mk
@@ -2469,6 +2469,15 @@ doltlite-crashtest$(T.exe): $(T.tcl.env.sh) has_tclsh85 shell_renamed.c $(TOP)/s
 		-L/usr/local/lib -L/opt/homebrew/lib \
 		$(LDFLAGS.libsqlite3) $(LDFLAGS.readline)
 
+crash_recovery_test_sqlite_test$(T.exe): $(T.tcl.env.sh) has_tclsh85 $(TOP)/test/crash_recovery_test.c $(LIBOBJS0) $(TOP)/ext/fts3/fts3_term.c
+	$(T.link.tcl) -DSQLITE_TEST=1 -DSQLITE_CRASH_TEST=1 \
+		-DSQLITE_CORE -DBUILD_sqlite -DSQLITE_PRIVATE="" -o $@ \
+		$(TOP)/test/crash_recovery_test.c $(TOP)/ext/fts3/fts3_term.c $(LIBOBJS0) \
+		$(SHELL_OPT) \
+		$$TCL_LIB_SPEC $$TCL_INCLUDE_SPEC $$TCL_LIBS \
+		-L/usr/local/lib -L/opt/homebrew/lib \
+		-lz -lpthread -lm
+
 #
 # libdoltlite: static and shared libraries with prolly tree engine.
 # These use the non-amalgamation objects (LIBOBJS0) which include the

--- a/main.mk
+++ b/main.mk
@@ -2457,6 +2457,18 @@ doltlite$(T.exe):	shell_renamed.c $(TOP)/src/shell_wrapper.c $(LIBOBJS0)
 		$(CFLAGS.readline) $(SHELL_OPT) \
 		$(LDFLAGS.libsqlite3) $(LDFLAGS.readline)
 
+# Doltlite crash-test shell: same CLI surface as doltlite, but linked
+# with the TCL/test-only pieces needed by SQLITE_TEST builds.
+doltlite-crashtest$(T.exe): $(T.tcl.env.sh) has_tclsh85 shell_renamed.c $(TOP)/src/shell_wrapper.c $(LIBOBJS0) $(TOP)/ext/fts3/fts3_term.c
+	$(T.link.tcl) -DSQLITE_TEST=1 -DSQLITE_CRASH_TEST=1 \
+		-DSQLITE_CORE -DBUILD_sqlite -DSQLITE_PRIVATE="" -o $@ \
+		shell_renamed.c $(TOP)/src/shell_wrapper.c $(LIBOBJS0) \
+		$(TOP)/ext/fts3/fts3_term.c \
+		$(CFLAGS.readline) $(SHELL_OPT) \
+		$$TCL_LIB_SPEC $$TCL_INCLUDE_SPEC $$TCL_LIBS \
+		-L/usr/local/lib -L/opt/homebrew/lib \
+		$(LDFLAGS.libsqlite3) $(LDFLAGS.readline)
+
 #
 # libdoltlite: static and shared libraries with prolly tree engine.
 # These use the non-amalgamation objects (LIBOBJS0) which include the

--- a/src/btree_orig_prefix.h
+++ b/src/btree_orig_prefix.h
@@ -238,6 +238,16 @@
 
 #define sqlite3_database_file_object orig_sqlite3_database_file_object
 #define sqlite3_enable_shared_cache orig_sqlite3_enable_shared_cache
+
+#ifdef SQLITE_TEST
+#define sqlite3SharedCacheList orig_sqlite3SharedCacheList
+#define sqlite3_pager_readdb_count orig_sqlite3_pager_readdb_count
+#define sqlite3_pager_writedb_count orig_sqlite3_pager_writedb_count
+#define sqlite3_pager_writej_count orig_sqlite3_pager_writej_count
+#define sqlite3_opentemp_count orig_sqlite3_opentemp_count
+#define disable_simulated_io_errors orig_disable_simulated_io_errors
+#define enable_simulated_io_errors orig_enable_simulated_io_errors
+#endif
 #define sqlite3HeaderSizeBtree orig_sqlite3HeaderSizeBtree
 #define sqlite3SectorSize orig_sqlite3SectorSize
 

--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -231,6 +231,27 @@ static int gcRewriteFile(
   ChunkStore manifestCs;
   int rc = SQLITE_OK;
 
+  /* Deterministic crash injection for GC rewrite durability tests.
+  ** DOLTLITE_CRASH_GC_WRITE=N crashes at the Nth write/sync/rename
+  ** step in the compaction rewrite path. */
+#ifdef SQLITE_TEST
+  {
+    static int crashGcTarget = -2;
+    static int crashGcCount = 0;
+    if( crashGcTarget == -2 ){
+      const char *zEnv = getenv("DOLTLITE_CRASH_GC_WRITE");
+      crashGcTarget = zEnv ? atoi(zEnv) : -1;
+    }
+    if( crashGcTarget > 0 ) crashGcCount = 0;
+#define GC_CRASH_CHECK() do{ \
+  if( crashGcTarget>0 && ++crashGcCount>=crashGcTarget ){ \
+    _exit(99); \
+  } \
+}while(0)
+#else
+#define GC_CRASH_CHECK() ((void)0)
+#endif
+
 
   indexBuf = sqlite3_malloc(indexSize);
   if( !indexBuf ) return SQLITE_NOMEM;
@@ -289,6 +310,7 @@ static int gcRewriteFile(
       }
 
 
+      GC_CRASH_CHECK();
       rc = sqlite3OsWrite(pTmpFile, manifest, CHUNK_MANIFEST_SIZE, writeOff);
       writeOff += CHUNK_MANIFEST_SIZE;
 
@@ -298,6 +320,7 @@ static int gcRewriteFile(
         int remaining = nNewData;
         while( remaining > 0 && rc==SQLITE_OK ){
           int toWrite = remaining > 65536 ? 65536 : remaining;
+          GC_CRASH_CHECK();
           rc = sqlite3OsWrite(pTmpFile, p, toWrite, writeOff);
           p += toWrite;
           writeOff += toWrite;
@@ -311,6 +334,7 @@ static int gcRewriteFile(
         int remaining = indexSize;
         while( remaining > 0 && rc==SQLITE_OK ){
           int toWrite = remaining > 65536 ? 65536 : remaining;
+          GC_CRASH_CHECK();
           rc = sqlite3OsWrite(pTmpFile, p, toWrite, writeOff);
           p += toWrite;
           writeOff += toWrite;
@@ -320,6 +344,7 @@ static int gcRewriteFile(
 
 
       if( rc==SQLITE_OK ){
+        GC_CRASH_CHECK();
         rc = sqlite3OsSync(pTmpFile, SQLITE_SYNC_NORMAL);
       }
       sqlite3OsCloseFree(pTmpFile);
@@ -332,6 +357,7 @@ static int gcRewriteFile(
           cs->pFile = 0;
         }
 
+        GC_CRASH_CHECK();
         if( rename(zTmp, cs->zFilename)!=0 ){
           /* Rename failed — original file still exists on disk
           ** but cs->pFile was already closed. Reopen it so the
@@ -356,7 +382,11 @@ static int gcRewriteFile(
             if( k>0 ) zDir[k-1] = 0; else{ zDir[0]='.'; zDir[1]=0; }
             {
               int dfd = open(zDir, O_RDONLY);
-              if( dfd>=0 ){ fsync(dfd); close(dfd); }
+              if( dfd>=0 ){
+                GC_CRASH_CHECK();
+                fsync(dfd);
+                close(dfd);
+              }
             }
             sqlite3_free(zDir);
           }
@@ -383,6 +413,10 @@ static int gcRewriteFile(
   }
 
   sqlite3_free(indexBuf);
+#ifdef SQLITE_TEST
+  }
+#undef GC_CRASH_CHECK
+#endif
   return rc;
 }
 

--- a/test/crash_injection_test.sh
+++ b/test/crash_injection_test.sh
@@ -465,14 +465,56 @@ done
 
 echo ""
 
-# Note: GC crash testing is not covered here. GC writes to a temp
-# file via sqlite3OsWrite directly (not through chunkStoreCommit),
-# so the DOLTLITE_CRASH_WRITE injection doesn't reach it. GC
-# durability is ensured by the atomic-rename pattern: write temp +
-# fsync temp + rename. A separate injection mechanism (hooking
-# sqlite3OsWrite globally or using a fault-injection VFS) would
-# be needed to test GC crashes. The directory-fsync fix (PR #509)
-# addresses the one known gap in that path.
+# ── Scenario 8: Crash during GC rewrite/rename ───────────
+#
+# GC is a pure storage rewrite. Crashing at any write/sync/rename
+# point must preserve identical logical state after reopen.
+echo "--- Scenario 8: Crash during GC rewrite ---"
+
+BASELINE8="$TMPROOT/s8_baseline.db"
+rm -f "$BASELINE8"
+"$DOLTLITE" "$BASELINE8" >/dev/null 2>&1 <<'SQL'
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'main-1');
+SELECT dolt_commit('-Am','c1');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES(2,'feat-2');
+SELECT dolt_commit('-Am','c2');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(3,'main-3');
+SELECT dolt_commit('-Am','c3');
+SELECT dolt_gc();
+SQL
+
+BASE_COUNT=$("$DOLTLITE" "$BASELINE8" "SELECT count(*) FROM t;" 2>/dev/null)
+BASE_LOG=$("$DOLTLITE" "$BASELINE8" "SELECT count(*) FROM dolt_log;" 2>/dev/null)
+BASE_BRANCHES=$("$DOLTLITE" "$BASELINE8" "SELECT count(*) FROM dolt_branches;" 2>/dev/null)
+
+for N in 1 2 3 4 5 6 7 8 9 10 11 12; do
+  DB="$TMPROOT/s8_n${N}.db"
+  cp "$BASELINE8" "$DB"
+
+  DOLTLITE_CRASH_GC_WRITE=$N "$DOLTLITE" "$DB" \
+    "SELECT dolt_gc();" >/dev/null 2>&1
+  RC=$?
+
+  COUNT=$("$DOLTLITE" "$DB" "SELECT count(*) FROM t;" 2>/dev/null)
+  LOGCOUNT=$("$DOLTLITE" "$DB" "SELECT count(*) FROM dolt_log;" 2>/dev/null)
+  BRANCHES=$("$DOLTLITE" "$DB" "SELECT count(*) FROM dolt_branches;" 2>/dev/null)
+
+  if [ "$COUNT" = "$BASE_COUNT" ] && [ "$LOGCOUNT" = "$BASE_LOG" ] && [ "$BRANCHES" = "$BASE_BRANCHES" ]; then
+    if [ "$RC" = "99" ]; then
+      pass_name "s8_write${N}_gc_crash_preserves_state"
+    else
+      pass_name "s8_write${N}_gc_completed_preserves_state"
+      break
+    fi
+  else
+    fail_name "s8_write${N}_gc_state_changed"
+    echo "    rc=$RC count=$COUNT/$BASE_COUNT log=$LOGCOUNT/$BASE_LOG branches=$BRANCHES/$BASE_BRANCHES"
+  fi
+done
 
 echo ""
 echo "======================================="

--- a/test/crash_recovery_test.c
+++ b/test/crash_recovery_test.c
@@ -24,6 +24,10 @@
 ** Uses POSIX fork()/kill(SIGKILL) to simulate crashes. The parent
 ** process reopens the database and verifies invariants hold.
 **
+** The GC cases in this file are best-effort async-kill tests around
+** dolt_gc(). Deterministic crash-at-write coverage for the rewrite path
+** lives in test/crash_injection_test.sh under SQLITE_TEST builds.
+**
 ** Build from build/ directory:
 **   cc -I. -o crash_recovery_test \
 **     ../test/crash_recovery_test.c libdoltlite.a -lz -lpthread
@@ -792,7 +796,7 @@ static void test_11_increasing_data_kill(void){
 ** ==================================================================== */
 
 /*
-** Test 12: Commit, GC, commit. Kill during GC.
+** Test 12: Commit, GC, commit. Asynchronously kill around GC.
 ** Database should be usable afterward.
 */
 static void test_12_gc_crash(void){
@@ -894,7 +898,7 @@ static void test_13_gc_then_crash(void){
 }
 
 /*
-** Test 14: GC with branches. Kill during GC.
+** Test 14: GC with branches. Asynchronously kill around GC.
 ** Both branches' data must remain reachable.
 */
 static void test_14_gc_with_branches_crash(void){
@@ -1676,7 +1680,7 @@ static void test_28_rapid_small_commits(void){
 }
 
 /*
-** Test 29: GC after many small commits. Kill during GC.
+** Test 29: GC after many small commits. Asynchronously kill around GC.
 ** All committed data must remain accessible.
 */
 static void test_29_gc_after_many_commits(void){

--- a/test/crash_recovery_test.c
+++ b/test/crash_recovery_test.c
@@ -231,6 +231,32 @@ static int verify_commit_count(const char *dbpath, const char *label,
   return cnt;
 }
 
+/* dolt_log includes the automatic repository initialization commit.
+** Crash tests generally care about user commits after that seed. */
+static int exec_user_commit_count(sqlite3 *db){
+  int nLog = exec_int(db, "SELECT count(*) FROM dolt_log", -1);
+  if( nLog<0 ) return nLog;
+  return nLog>0 ? nLog-1 : 0;
+}
+
+static int verify_user_commit_count(const char *dbpath, const char *label,
+                                    int expected){
+  sqlite3 *db = 0;
+  char desc[256];
+  int rc, cnt;
+
+  rc = sqlite3_open(dbpath, &db);
+  if( rc!=SQLITE_OK ){
+    sqlite3_close(db);
+    return -1;
+  }
+  cnt = exec_user_commit_count(db);
+  snprintf(desc, sizeof(desc), "%s: user commit count is %d", label, expected);
+  check(desc, cnt==expected);
+  sqlite3_close(db);
+  return cnt;
+}
+
 /* ====================================================================
 ** GROUP 1: Single commit crash recovery
 ** ==================================================================== */
@@ -266,7 +292,7 @@ static void test_01_clean_commit(void){
   }
   verify_consistency(dbpath, "test_01");
   verify_row_count(dbpath, "test_01", "t", 3);
-  verify_commit_count(dbpath, "test_01", 1);
+  verify_user_commit_count(dbpath, "test_01", 1);
   remove_db(dbpath);
 }
 
@@ -304,7 +330,7 @@ static void test_02_kill_after_commit(void){
   }
   verify_consistency(dbpath, "test_02");
   verify_row_count(dbpath, "test_02", "t", 2);
-  verify_commit_count(dbpath, "test_02", 1);
+  verify_user_commit_count(dbpath, "test_02", 1);
   remove_db(dbpath);
 }
 
@@ -351,7 +377,7 @@ static void test_03_kill_during_commit(void){
     int rc = sqlite3_open(dbpath, &db);
     check("test_03: db opens after crash", rc==SQLITE_OK);
     if( rc==SQLITE_OK ){
-      int nLog = exec_int(db, "SELECT count(*) FROM dolt_log", -1);
+      int nLog = exec_user_commit_count(db);
       /* Commit is either fully present (1 commit) or fully absent (0 commits).
       ** 0 means the initial state (no user commit), 1 means the commit landed. */
       check("test_03: commit atomic (0 or 1)",
@@ -400,7 +426,7 @@ static void test_04_two_commits_kill_after_second(void){
   {
     sqlite3 *db = 0;
     sqlite3_open(dbpath, &db);
-    int nLog = exec_int(db, "SELECT count(*) FROM dolt_log", -1);
+    int nLog = exec_user_commit_count(db);
     check("test_04: at least commit-1 present", nLog>=1);
     /* If both commits landed, verify both rows. */
     if( nLog>=2 ){
@@ -460,7 +486,7 @@ static void test_05_kill_during_second_commit(void){
     int rc = sqlite3_open(dbpath, &db);
     check("test_05: db opens", rc==SQLITE_OK);
     if( rc==SQLITE_OK ){
-      int nLog = exec_int(db, "SELECT count(*) FROM dolt_log", -1);
+      int nLog = exec_user_commit_count(db);
       check("test_05: at least stable-commit present", nLog>=1);
       /* The stable row must always be present. */
       int hasStable = exec_int(db,
@@ -568,7 +594,7 @@ static void test_07_five_commits_random_kill(void){
     int rc = sqlite3_open(dbpath, &db);
     check("test_07: db opens", rc==SQLITE_OK);
     if( rc==SQLITE_OK ){
-      int nLog = exec_int(db, "SELECT count(*) FROM dolt_log", -1);
+      int nLog = exec_user_commit_count(db);
       check("test_07: commit count in [0..5]", nLog>=0 && nLog<=5);
 
       /* If there are N commits, there should be N rows. */
@@ -638,7 +664,7 @@ static void test_08_branch_crash(void){
       sqlite3_finalize(stmt);
 
       /* dolt_log must be consistent. */
-      int nLog = exec_int(db, "SELECT count(*) FROM dolt_log", -1);
+      int nLog = exec_user_commit_count(db);
       check("test_08: dolt_log consistent", nLog>=0);
     }
     sqlite3_close(db);
@@ -717,7 +743,7 @@ static void test_10_very_early_kill(void){
     sqlite3 *db = 0;
     int rc = sqlite3_open(dbpath, &db);
     if( rc==SQLITE_OK ){
-      int nLog = exec_int(db, "SELECT count(*) FROM dolt_log", -1);
+      int nLog = exec_user_commit_count(db);
       /* Whatever number of commits landed, data must be consistent. */
       check("test_10: commit count non-negative", nLog>=0);
       if( nLog>0 ){
@@ -774,7 +800,7 @@ static void test_11_increasing_data_kill(void){
     int rc = sqlite3_open(dbpath, &db);
     check("test_11: db opens", rc==SQLITE_OK);
     if( rc==SQLITE_OK ){
-      int nLog = exec_int(db, "SELECT count(*) FROM dolt_log", -1);
+      int nLog = exec_user_commit_count(db);
       check("test_11: commit count in [0..5]", nLog>=0 && nLog<=5);
       /* Verify data is self-consistent: all queryable rows belong to
       ** committed batches. */
@@ -845,7 +871,7 @@ static void test_12_gc_crash(void){
       int cnt = exec_int(db, "SELECT count(*) FROM t", -1);
       check("test_12: table queryable after GC crash", cnt>=0);
       /* dolt_log must still work. */
-      int nLog = exec_int(db, "SELECT count(*) FROM dolt_log", -1);
+      int nLog = exec_user_commit_count(db);
       check("test_12: dolt_log works after GC crash", nLog>=1);
     }
     sqlite3_close(db);
@@ -889,7 +915,7 @@ static void test_13_gc_then_crash(void){
     int rc = sqlite3_open(dbpath, &db);
     check("test_13: db opens", rc==SQLITE_OK);
     if( rc==SQLITE_OK ){
-      int nLog = exec_int(db, "SELECT count(*) FROM dolt_log", -1);
+      int nLog = exec_user_commit_count(db);
       check("test_13: at least 2 commits (pre-GC)", nLog>=2);
     }
     sqlite3_close(db);
@@ -993,7 +1019,7 @@ static void test_15_large_insert_crash(void){
     int rc = sqlite3_open(dbpath, &db);
     check("test_15: db opens", rc==SQLITE_OK);
     if( rc==SQLITE_OK ){
-      int nLog = exec_int(db, "SELECT count(*) FROM dolt_log", -1);
+      int nLog = exec_user_commit_count(db);
       check("test_15: commit atomic (0 or 1)", nLog==0 || nLog==1);
       if( nLog==1 ){
         int cnt = exec_int(db, "SELECT count(*) FROM t", -1);
@@ -1037,7 +1063,7 @@ static void test_16_large_insert_complete_then_kill(void){
 
   verify_consistency(dbpath, "test_16");
   verify_row_count(dbpath, "test_16", "t", 1000);
-  verify_commit_count(dbpath, "test_16", 1);
+  verify_user_commit_count(dbpath, "test_16", 1);
   remove_db(dbpath);
 }
 
@@ -1081,7 +1107,7 @@ static void test_17_multiple_large_commits(void){
     int rc = sqlite3_open(dbpath, &db);
     check("test_17: db opens", rc==SQLITE_OK);
     if( rc==SQLITE_OK ){
-      int nLog = exec_int(db, "SELECT count(*) FROM dolt_log", -1);
+      int nLog = exec_user_commit_count(db);
       check("test_17: commit count in [0..3]", nLog>=0 && nLog<=3);
       if( nLog>0 ){
         int nRows = exec_int(db, "SELECT count(*) FROM t", -1);
@@ -1130,7 +1156,7 @@ static void test_18_schema_change_crash(void){
     int rc = sqlite3_open(dbpath, &db);
     check("test_18: db opens", rc==SQLITE_OK);
     if( rc==SQLITE_OK ){
-      int nLog = exec_int(db, "SELECT count(*) FROM dolt_log", -1);
+      int nLog = exec_user_commit_count(db);
       check("test_18: at least 1 commit", nLog>=1);
       /* If both commits landed, the extra column must exist. */
       if( nLog==2 ){
@@ -1192,7 +1218,7 @@ static void test_19_delete_all_crash(void){
     int rc = sqlite3_open(dbpath, &db);
     check("test_19: db opens", rc==SQLITE_OK);
     if( rc==SQLITE_OK ){
-      int nLog = exec_int(db, "SELECT count(*) FROM dolt_log", -1);
+      int nLog = exec_user_commit_count(db);
       int cnt = exec_int(db, "SELECT count(*) FROM t", -1);
       /* Either the delete committed (0 rows, 2 log entries) or
       ** only the initial state remains (3 rows, 1 log entry). */
@@ -1333,7 +1359,7 @@ static void test_22_multi_table_commit_crash(void){
     int rc = sqlite3_open(dbpath, &db);
     check("test_22: db opens", rc==SQLITE_OK);
     if( rc==SQLITE_OK ){
-      int nLog = exec_int(db, "SELECT count(*) FROM dolt_log", -1);
+      int nLog = exec_user_commit_count(db);
       if( nLog==1 ){
         /* If committed, all 10 tables must exist with data. */
         int i;
@@ -1462,7 +1488,7 @@ static void test_24_repeated_crash_cycles(void){
       snprintf(desc, sizeof(desc), "test_24_cycle%d: db opens", cycle);
       check(desc, rc==SQLITE_OK);
       if( rc==SQLITE_OK ){
-        int nLog = exec_int(db, "SELECT count(*) FROM dolt_log", -1);
+        int nLog = exec_user_commit_count(db);
         snprintf(desc, sizeof(desc),
                  "test_24_cycle%d: log non-negative", cycle);
         check(desc, nLog>=1);
@@ -1513,7 +1539,7 @@ static void test_25_tag_crash(void){
     sqlite3 *db = 0;
     sqlite3_open(dbpath, &db);
     /* Commit must be present. Tag may or may not have persisted. */
-    int nLog = exec_int(db, "SELECT count(*) FROM dolt_log", -1);
+    int nLog = exec_user_commit_count(db);
     check("test_25: commit present", nLog>=1);
     int cnt = exec_int(db, "SELECT count(*) FROM t", -1);
     check("test_25: data intact", cnt==1);
@@ -1559,7 +1585,7 @@ static void test_26_blob_data_crash(void){
     int rc = sqlite3_open(dbpath, &db);
     check("test_26: db opens", rc==SQLITE_OK);
     if( rc==SQLITE_OK ){
-      int nLog = exec_int(db, "SELECT count(*) FROM dolt_log", -1);
+      int nLog = exec_user_commit_count(db);
       check("test_26: commit atomic (0 or 1)", nLog==0 || nLog==1);
       if( nLog==1 ){
         int cnt = exec_int(db, "SELECT count(*) FROM t", -1);
@@ -1617,7 +1643,7 @@ static void test_27_uncommitted_changes_crash(void){
   {
     sqlite3 *db = 0;
     sqlite3_open(dbpath, &db);
-    int nLog = exec_int(db, "SELECT count(*) FROM dolt_log", -1);
+    int nLog = exec_user_commit_count(db);
     check("test_27: only baseline commit", nLog==1);
     /* The committed row must be present. The uncommitted rows may or
     ** may not be in the SQL layer (WAL recovery), but dolt state should
@@ -1667,7 +1693,7 @@ static void test_28_rapid_small_commits(void){
     int rc = sqlite3_open(dbpath, &db);
     check("test_28: db opens", rc==SQLITE_OK);
     if( rc==SQLITE_OK ){
-      int nLog = exec_int(db, "SELECT count(*) FROM dolt_log", -1);
+      int nLog = exec_user_commit_count(db);
       check("test_28: commit count in [0..10]", nLog>=0 && nLog<=10);
       if( nLog>0 ){
         int nRows = exec_int(db, "SELECT count(*) FROM t", -1);
@@ -1728,7 +1754,7 @@ static void test_29_gc_after_many_commits(void){
     int rc = sqlite3_open(dbpath, &db);
     check("test_29: db opens after GC crash", rc==SQLITE_OK);
     if( rc==SQLITE_OK ){
-      int nLog = exec_int(db, "SELECT count(*) FROM dolt_log", -1);
+      int nLog = exec_user_commit_count(db);
       check("test_29: all 10 commits present", nLog==10);
       int cnt = exec_int(db, "SELECT count(*) FROM t", -1);
       check("test_29: all 10 rows present", cnt==10);


### PR DESCRIPTION
## Summary

- add SQLITE_TEST-only crash injection in the GC rewrite path

- add deterministic crash-injection coverage for GC rewrite/rename durability

- clarify that the native GC fork/kill suite is best-effort async coverage
