### PR TITLE
Use main schema in merge constraint detection

### DIFF
--- a/src/doltlite_merge_constraints.c
+++ b/src/doltlite_merge_constraints.c
@@ -125,7 +125,7 @@ static char *buildFkViolationInfo(
   pCols = sqlite3_str_new(0);
   pRefCols = sqlite3_str_new(0);
 
-  zQuery = sqlite3_mprintf("PRAGMA foreign_key_list(%Q)", zChildTable);
+  zQuery = sqlite3_mprintf("PRAGMA main.foreign_key_list(%Q)", zChildTable);
   if( !zQuery ){
     fatal = 1;
   }else{
@@ -281,7 +281,7 @@ static int tableHasRowid(sqlite3 *db, const char *zTable){
   sqlite3_stmt *pStmt = 0;
   char *zQuery;
   int rc;
-  zQuery = sqlite3_mprintf("SELECT rowid FROM \"%w\" LIMIT 0", zTable);
+  zQuery = sqlite3_mprintf("SELECT rowid FROM main.\"%w\" LIMIT 0", zTable);
   if( !zQuery ) return 1; /* treat OOM as rowid — caller will fail elsewhere */
   rc = sqlite3_prepare_v2(db, zQuery, -1, &pStmt, 0);
   sqlite3_free(zQuery);
@@ -382,7 +382,7 @@ static int detectUniqueViolationsForIndex(
   (void)pzErrMsg;
 
   zQuery = sqlite3_mprintf(
-    "SELECT rowid, %s FROM \"%w\" NOT INDEXED ORDER BY %s, rowid",
+    "SELECT rowid, %s FROM main.\"%w\" NOT INDEXED ORDER BY %s, rowid",
     zCols, zTable, zCols);
   if( !zQuery ) return SQLITE_NOMEM;
   rc = sqlite3_prepare_v2(db, zQuery, -1, &pScan, 0);
@@ -499,7 +499,7 @@ int doltliteDetectMergeUniqueViolations(
   }
 
   rc = sqlite3_prepare_v2(db,
-      "SELECT name FROM sqlite_master WHERE type='table' "
+      "SELECT name FROM main.sqlite_master WHERE type='table' "
       "AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'dolt_%'",
       -1, &pTbls, 0);
   if( rc != SQLITE_OK ){
@@ -517,7 +517,7 @@ int doltliteDetectMergeUniqueViolations(
     zTable = sqlite3_mprintf("%s", zTableRaw);
     if( !zTable ){ rc = SQLITE_NOMEM; break; }
 
-    zIdxQ = sqlite3_mprintf("PRAGMA index_list(%Q)", zTable);
+    zIdxQ = sqlite3_mprintf("PRAGMA main.index_list(%Q)", zTable);
     if( !zIdxQ ){ sqlite3_free(zTable); rc = SQLITE_NOMEM; break; }
     rc = sqlite3_prepare_v2(db, zIdxQ, -1, &pIdxList, 0);
     sqlite3_free(zIdxQ);
@@ -559,7 +559,7 @@ int doltliteDetectMergeUniqueViolations(
 
       zIdx = sqlite3_mprintf("%s", zIdxRaw);
       if( !zIdx ) break;
-      zColsQ = sqlite3_mprintf("PRAGMA index_xinfo(%Q)", zIdx);
+      zColsQ = sqlite3_mprintf("PRAGMA main.index_xinfo(%Q)", zIdx);
       if( !zColsQ ){ sqlite3_free(zIdx); break; }
       idxRc = sqlite3_prepare_v2(db, zColsQ, -1, &pCols, 0);
       sqlite3_free(zColsQ);
@@ -735,7 +735,7 @@ int doltliteDetectMergeCheckViolations(
   }
 
   rc = sqlite3_prepare_v2(db,
-      "SELECT name, sql FROM sqlite_master WHERE type='table' "
+      "SELECT name, sql FROM main.sqlite_master WHERE type='table' "
       "AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'dolt_%'",
       -1, &pTbls, 0);
   if( rc != SQLITE_OK ){
@@ -794,7 +794,7 @@ int doltliteDetectMergeCheckViolations(
       }
 
       zQuery = sqlite3_mprintf(
-          "SELECT rowid FROM \"%w\" NOT INDEXED WHERE NOT (%s)",
+          "SELECT rowid FROM main.\"%w\" NOT INDEXED WHERE NOT (%s)",
           zTable, zExpr);
       if( !zQuery ){
         sqlite3_free(zExpr);
@@ -906,7 +906,7 @@ int doltliteDetectMergeFkViolations(
     }
   }
 
-  rc = sqlite3_prepare_v2(db, "PRAGMA foreign_key_check", -1, &pStmt, 0);
+  rc = sqlite3_prepare_v2(db, "PRAGMA main.foreign_key_check", -1, &pStmt, 0);
   if( rc != SQLITE_OK ){
     if( haveAnc ) doltliteFreeCatalog(aAnc, nAnc);
     return rc;

--- a/test/vc_oracle_fk_merge_test.sh
+++ b/test/vc_oracle_fk_merge_test.sh
@@ -242,6 +242,37 @@ expect_eq "unique_violation_main_side_kept" "1" "$BASE_KEEPS_MAIN"
 
 echo ""
 
+# ── Scenario C2: Unique violation survives temp shadowing ─
+echo "--- C2. UNIQUE: temp shadow table cannot hide merge violation ---"
+
+DB="$TMPROOT/uniq_shadow.db"
+rm -f "$DB"
+cat <<'SQL' | dl_setup "$DB" "uniq_shadow"
+CREATE TABLE t(pk INTEGER PRIMARY KEY, v1 INT, UNIQUE(v1));
+INSERT INTO t VALUES (1,10);
+SELECT dolt_commit('-Am','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES (3,20);
+SELECT dolt_commit('-Am','feat_add_3_20');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES (2,20);
+SELECT dolt_commit('-Am','main_add_2_20');
+CREATE TEMP TABLE t(x INT);
+SELECT dolt_merge('feat');
+SQL
+
+N=$(dl "$DB" "SELECT num_violations FROM dolt_constraint_violations WHERE \"table\"='t';" "uniq_shadow_count")
+expect_eq "unique_shadow_violation_summary_count" "1" "$N"
+
+TYPE=$(dl "$DB" "SELECT violation_type FROM dolt_constraint_violations_t;" "uniq_shadow_type")
+expect_eq "unique_shadow_violation_type" "unique index" "$TYPE"
+
+BASE_COUNT=$(dl "$DB" "SELECT count(*) FROM t;" "uniq_shadow_base")
+expect_eq "unique_shadow_loser_not_in_base" "2" "$BASE_COUNT"
+
+echo ""
+
 # ── Scenario D: CHECK constraint violation ───────────────
 echo "--- D. CHECK: one side adds constraint, other side commits a violating row ---"
 
@@ -278,6 +309,37 @@ if dl_errors "$DB" "SELECT dolt_commit('-m','post-merge');" "check_commit_block"
 else
   fail_name "check_violation_commit_blocked"
 fi
+
+echo ""
+
+# ── Scenario D2: CHECK violation survives temp shadowing ──
+echo "--- D2. CHECK: temp shadow table cannot hide merge violation ---"
+
+DB="$TMPROOT/check_shadow.db"
+rm -f "$DB"
+cat <<'SQL' | dl_setup "$DB" "check_shadow"
+CREATE TABLE t(pk INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1,10);
+SELECT dolt_commit('-Am','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES (2,-5);
+SELECT dolt_commit('-Am','feat_add_neg');
+SELECT dolt_checkout('main');
+ALTER TABLE t ADD CONSTRAINT positive_v CHECK (v > 0);
+SELECT dolt_commit('-Am','main_add_check');
+CREATE TEMP TABLE t(x INT);
+SELECT dolt_merge('feat');
+SQL
+
+N=$(dl "$DB" "SELECT num_violations FROM dolt_constraint_violations WHERE \"table\"='t';" "check_shadow_count")
+expect_eq "check_shadow_violation_summary_count" "1" "$N"
+
+TYPE=$(dl "$DB" "SELECT violation_type FROM dolt_constraint_violations_t WHERE pk=2;" "check_shadow_type")
+expect_eq "check_shadow_violation_type" "check constraint" "$TYPE"
+
+BASE_COUNT=$(dl "$DB" "SELECT count(*) FROM t WHERE pk=2;" "check_shadow_base")
+expect_eq "check_shadow_row_present_in_table" "1" "$BASE_COUNT"
 
 echo ""
 


### PR DESCRIPTION
## Summary
- qualify merge-constraint metadata and table scans to `main`
- prevent temp table shadowing from hiding unique/check/fk merge violations
- add regression coverage for temp-shadowed unique and check merges

## Testing
- bash test/vc_oracle_fk_merge_test.sh ./build/doltlite dolt
- cd build && bash ../test/doltlite_conflicts.sh
- direct temp-shadow merge repro against ./build/doltlite