### PR TITLE
Use main schema for blame PK introspection

### DIFF
--- a/src/doltlite_blame.c
+++ b/src/doltlite_blame.c
@@ -97,7 +97,7 @@ static int blameLoadPkColumns(
   *pnCols = 0;
   *pIntPkCid = -1;
 
-  zSql = sqlite3_mprintf("PRAGMA table_info(\"%w\")", zTable);
+  zSql = sqlite3_mprintf("PRAGMA main.table_info(\"%w\")", zTable);
   if( !zSql ) return SQLITE_NOMEM;
   rc = sqlite3_prepare_v2(db, zSql, -1, &pStmt, 0);
   sqlite3_free(zSql);

--- a/test/vc_oracle_blame_test.sh
+++ b/test/vc_oracle_blame_test.sh
@@ -224,6 +224,31 @@ CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'CREATE');
 " "SELECT CONCAT('BL|', id, '|', message) FROM dolt_blame_t;"
 
+echo "--- temp shadow table does not spoof blame PK schema ---"
+
+{
+  dir="$TMPROOT/temp_shadow_pk"
+  mkdir -p "$dir"
+  out=$(printf "%s\n" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'a');
+SELECT dolt_commit('-Am', 'INIT');
+UPDATE t SET v = 'b' WHERE id = 1;
+SELECT dolt_commit('-Am', 'UPDATE');
+CREATE TEMP TABLE t(x TEXT PRIMARY KEY, y INT);
+SELECT CONCAT('BL|', id, '|', message) FROM dolt_blame_t;
+" | "$DOLTLITE" "$dir/db" 2>"$dir/err" | tr -d '\r' | grep '^BL|')
+  if [ "$out" = "BL|1|UPDATE" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES temp_shadow_pk"
+    echo "  FAIL: temp_shadow_pk"
+    echo "    doltlite:"
+    echo "$out" | sed 's/^/      /'
+  fi
+}
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then


### PR DESCRIPTION
## Summary
- qualify dolt_blame PK introspection to `main`
- prevent temp table shadowing from spoofing blame PK layout
- add direct regression coverage in the blame oracle suite

## Notes
- the remote command/state layer looked clean in this authority pass
- the concrete remaining same-family bug was in `dolt_blame_<table>`

## Testing
- bash test/vc_oracle_blame_test.sh ./build/doltlite dolt
- direct temp-shadow repro against ./build/doltlite