### PR TITLE
Add merge and rebase stress coverage

### DIFF
--- a/test/large_merge_test.sh
+++ b/test/large_merge_test.sh
@@ -375,6 +375,72 @@ fi
 
 echo ""
 
+# ── Scenario 6b: Repeated merge abort/retry across multiple tables ──
+echo "--- Scenario 6b: Repeated merge abort/retry across multiple tables ---"
+
+DB="$TMPROOT/s6b.db"
+rm -f "$DB"
+
+"$DOLTLITE" "$DB" "$(
+  echo "CREATE TABLE t1(id INTEGER PRIMARY KEY, v TEXT);"
+  echo "CREATE TABLE t2(id INTEGER PRIMARY KEY, v TEXT);"
+  echo "CREATE TABLE t3(id INTEGER PRIMARY KEY, v TEXT);"
+  gen_inserts 1 1000 base | sed 's/INTO t/INTO t1/'
+  gen_inserts 1 1000 base | sed 's/INTO t/INTO t2/'
+  gen_inserts 1 1000 base | sed 's/INTO t/INTO t3/'
+  echo "SELECT dolt_commit('-Am','base');"
+)" >/dev/null 2>&1
+
+"$DOLTLITE" "$DB" "$(
+  echo "SELECT dolt_branch('feat');"
+  echo "SELECT dolt_checkout('feat');"
+  echo "BEGIN;"
+  gen_updates 201 500 feat | sed 's/UPDATE t/UPDATE t1/'
+  gen_updates 201 500 feat | sed 's/UPDATE t/UPDATE t2/'
+  gen_updates 201 500 feat | sed 's/UPDATE t/UPDATE t3/'
+  echo "COMMIT;"
+  echo "SELECT dolt_commit('-Am','feat conflicts');"
+  echo "SELECT dolt_checkout('main');"
+)" >/dev/null 2>&1
+
+"$DOLTLITE" "$DB" "$(
+  echo "BEGIN;"
+  gen_updates 201 500 main | sed 's/UPDATE t/UPDATE t1/'
+  gen_updates 201 500 main | sed 's/UPDATE t/UPDATE t2/'
+  gen_updates 201 500 main | sed 's/UPDATE t/UPDATE t3/'
+  echo "COMMIT;"
+  echo "SELECT dolt_commit('-Am','main conflicts');"
+)" >/dev/null 2>&1
+
+for attempt in 1 2 3; do
+  "$DOLTLITE" "$DB" "SELECT dolt_merge('feat');" >/dev/null 2>&1
+  CONFLICTS=$("$DOLTLITE" "$DB" "SELECT count(*) FROM dolt_conflicts;" 2>/dev/null)
+  V1=$("$DOLTLITE" "$DB" "SELECT v FROM t1 WHERE id=250;" 2>/dev/null)
+  V2=$("$DOLTLITE" "$DB" "SELECT v FROM t2 WHERE id=250;" 2>/dev/null)
+  V3=$("$DOLTLITE" "$DB" "SELECT v FROM t3 WHERE id=250;" 2>/dev/null)
+  if [ "$CONFLICTS" = "3" ] && [ "$V1" = "main_250" ] && [ "$V2" = "main_250" ] && [ "$V3" = "main_250" ]; then
+    pass_name "s6b_attempt_${attempt}_merge_conflicts"
+  else
+    fail_name "s6b_attempt_${attempt}_merge_conflicts"
+    echo "    conflicts=$CONFLICTS t1=$V1 t2=$V2 t3=$V3"
+  fi
+
+  ABORT=$("$DOLTLITE" "$DB" "SELECT dolt_merge('--abort');" 2>/dev/null)
+  CONFLICTS_AFTER=$("$DOLTLITE" "$DB" "SELECT count(*) FROM dolt_conflicts;" 2>/dev/null)
+  V1_AFTER=$("$DOLTLITE" "$DB" "SELECT v FROM t1 WHERE id=250;" 2>/dev/null)
+  V2_AFTER=$("$DOLTLITE" "$DB" "SELECT v FROM t2 WHERE id=250;" 2>/dev/null)
+  V3_AFTER=$("$DOLTLITE" "$DB" "SELECT v FROM t3 WHERE id=250;" 2>/dev/null)
+  if [ "$ABORT" = "0" ] && [ "$CONFLICTS_AFTER" = "0" ] \
+     && [ "$V1_AFTER" = "main_250" ] && [ "$V2_AFTER" = "main_250" ] && [ "$V3_AFTER" = "main_250" ]; then
+    pass_name "s6b_attempt_${attempt}_abort_restores"
+  else
+    fail_name "s6b_attempt_${attempt}_abort_restores"
+    echo "    abort=$ABORT conflicts_after=$CONFLICTS_AFTER t1=$V1_AFTER t2=$V2_AFTER t3=$V3_AFTER"
+  fi
+done
+
+echo ""
+
 if [ "$QUICK" = "1" ]; then
   echo "(skipping 50K+ row scenarios in --quick mode)"
   echo ""

--- a/test/vc_oracle_rebase_test.sh
+++ b/test/vc_oracle_rebase_test.sh
@@ -341,6 +341,54 @@ UPDATE dolt_rebase SET action = 'fixup' WHERE commit_message = 'f3';
 SELECT dolt_rebase('--continue');
 " "SELECT CONCAT('LOG|', message) FROM dolt_log;"
 
+# Longer plan with mixed actions to stress replay ordering and state
+# transitions. We intentionally combine reorder, drop, squash, reword,
+# and fixup in one plan.
+LONG_INTERACTIVE_SETUP="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 1);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');
+SELECT dolt_checkout('-b', 'feat');
+INSERT INTO t VALUES (2, 2);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'f1');
+INSERT INTO t VALUES (3, 3);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'f2');
+INSERT INTO t VALUES (4, 4);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'f3');
+INSERT INTO t VALUES (5, 5);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'f4');
+INSERT INTO t VALUES (6, 6);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'f5');
+INSERT INTO t VALUES (7, 7);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'f6');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES (100, 100);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'm');
+SELECT dolt_checkout('feat');
+"
+
+oracle "interactive_long_mixed_plan_log" "
+$LONG_INTERACTIVE_SETUP
+SELECT dolt_rebase('-i', 'main');
+UPDATE dolt_rebase SET rebase_order = 0.5 WHERE commit_message = 'f6';
+UPDATE dolt_rebase SET action = 'drop' WHERE commit_message = 'f2';
+UPDATE dolt_rebase SET action = 'squash' WHERE commit_message = 'f4';
+UPDATE dolt_rebase SET action = 'reword', commit_message = 'f5 renamed' WHERE commit_message = 'f5';
+UPDATE dolt_rebase SET action = 'fixup' WHERE commit_message = 'f3';
+SELECT dolt_rebase('--continue');
+" "SELECT CONCAT('LOG|', REPLACE(message, CHAR(10), ' | ')) FROM dolt_log;"
+
+oracle "interactive_long_mixed_plan_table" "
+$LONG_INTERACTIVE_SETUP
+SELECT dolt_rebase('-i', 'main');
+UPDATE dolt_rebase SET rebase_order = 0.5 WHERE commit_message = 'f6';
+UPDATE dolt_rebase SET action = 'drop' WHERE commit_message = 'f2';
+UPDATE dolt_rebase SET action = 'squash' WHERE commit_message = 'f4';
+UPDATE dolt_rebase SET action = 'reword', commit_message = 'f5 renamed' WHERE commit_message = 'f5';
+UPDATE dolt_rebase SET action = 'fixup' WHERE commit_message = 'f3';
+SELECT dolt_rebase('--continue');
+" "SELECT CONCAT('LOG|', id) FROM t ORDER BY id;"
+
 # --abort leaves the original branch untouched and restores us to it.
 oracle "interactive_abort_log" "
 $INTERACTIVE_SETUP


### PR DESCRIPTION
## Summary
- add repeated multi-table merge abort/retry stress coverage
- add a longer mixed-action interactive rebase oracle case
- lock in merge/rebase state-machine behavior under heavier plans

## Testing
- bash test/vc_oracle_rebase_test.sh ./build/doltlite dolt
- bash test/large_merge_test.sh ./build/doltlite --quick