### PR TITLE
Polish config and tag SQL argument handling

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -3662,6 +3662,11 @@ static void doltliteConfigFunc(sqlite3_context *context, int argc, sqlite3_value
     sqlite3_result_error(context, "usage: dolt_config(key [, value])", -1);
     return;
   }
+  if( argc>2 ){
+    sqlite3_result_error(context,
+      "too many positional arguments to dolt_config", -1);
+    return;
+  }
   zKey = (const char*)sqlite3_value_text(argv[0]);
   if( !zKey ){
     sqlite3_result_error(context, "key required", -1);

--- a/src/doltlite_tag.c
+++ b/src/doltlite_tag.c
@@ -68,6 +68,10 @@ static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   if( strcmp(arg0, "-d")==0 || strcmp(arg0, "--delete")==0 ){
     const char *zName;
     if( argc<2 ){ sqlite3_result_error(ctx, "tag name required for delete", -1); return; }
+    if( argc!=2 ){
+      sqlite3_result_error(ctx, "too many positional arguments to dolt_tag", -1);
+      return;
+    }
     zName = (const char*)sqlite3_value_text(argv[1]);
     if( !zName ){ sqlite3_result_error(ctx, "tag name required", -1); return; }
     m.zName = zName;

--- a/test/config_test.sh
+++ b/test/config_test.sh
@@ -265,6 +265,15 @@ result=$("$DB" "$TMPDIR/t14.db" "SELECT committer FROM dolt_log LIMIT 1;")
 check "-A commit uses config" "Quick Author" "$result"
 
 # ============================================================
+echo "=== 15. Error: extra config args ==="
+# ============================================================
+result=$("$DB" "$TMPDIR/t1.db" "SELECT dolt_config('user.name', 'Alice', 'Extra');" 2>&1)
+check "extra config args error" "1" "$(echo "$result" | grep -c 'too many positional arguments to dolt_config')"
+
+result=$("$DB" "$TMPDIR/t1.db" "SELECT dolt_config('user.name');")
+check "extra config args preserve session value" "doltlite" "$result"
+
+# ============================================================
 echo ""
 echo "======================================="
 echo "Results: $pass passed, $fail failed"

--- a/test/doltlite_tag.sh
+++ b/test/doltlite_tag.sh
@@ -32,6 +32,11 @@ run_test_match "tag_missing_commit" \
 # Delete tag
 run_test "delete_tag" "SELECT dolt_tag('-d','v0.9');" "0" "$DB"
 run_test "one_tag_left" "SELECT count(*) FROM dolt_tags;" "1" "$DB"
+run_test_match "delete_tag_extra_arg" \
+  "SELECT dolt_tag('-d','v1.0','extra');" \
+  "too many positional arguments to dolt_tag" "$DB"
+run_test "delete_extra_arg_keeps_tag" \
+  "SELECT count(*) FROM dolt_tags WHERE tag_name='v1.0';" "1" "$DB"
 
 # Delete nonexistent
 run_test_match "delete_missing" "SELECT dolt_tag('-d','nope');" "not found" "$DB"


### PR DESCRIPTION
## Summary
- reject extra positional args in `dolt_config()` instead of silently ignoring them
- reject extra positional args in `dolt_tag('-d', ...)` delete mode
- add focused regression coverage for both error paths and state preservation

## Testing
- bash test/config_test.sh ./build/doltlite
- cd build && bash ../test/doltlite_tag.sh
- bash test/vc_oracle_tags_test.sh ./build/doltlite dolt
- bash test/vc_oracle_merge_test.sh ./build/doltlite dolt
- bash test/vc_oracle_revert_cherrypick_test.sh ./build/doltlite dolt
- bash test/vc_oracle_checkout_test.sh ./build/doltlite dolt
- bash test/vc_oracle_branch_test.sh ./build/doltlite dolt
- bash test/vc_oracle_rebase_test.sh ./build/doltlite dolt