### PR TITLE
Skip redundant identical row rewrites

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -4676,6 +4676,22 @@ static int prollyBtCursorInsert(
       nData = nTotal;
     }
 
+    /* Avoid rewriting a row when the cursor is already positioned on the
+    ** same integer key and the payload bytes are unchanged. This targets
+    ** the common repeated-update benchmark case without changing lookup or
+    ** savepoint semantics for other write paths. */
+    if( pCur->eState==CURSOR_VALID
+     && prollyBtCursorIntegerKey(pCur)==pPayload->nKey ){
+      const u8 *pCurData = 0;
+      int nCurData = 0;
+      getCursorPayload(pCur, &pCurData, &nCurData);
+      if( nCurData==nData
+       && (nData==0 || memcmp(pCurData, pData, nData)==0) ){
+        sqlite3_free(pBuf);
+        return SQLITE_OK;
+      }
+    }
+
     rc = prollyMutMapInsert(pCur->pMutMap,
                              NULL, 0, pPayload->nKey,
                              pData, nData);


### PR DESCRIPTION
## Summary
- skip int-key row rewrites when the cursor is already on the target row and the full payload bytes are unchanged
- target the repeated same-value update pattern showing up in current sysbench outliers
- keep the optimization narrow to avoid changing lookup or savepoint behavior outside this path

## Verification
- `cd build && bash ../test/doltlite_e2e.sh`
- `cd build && bash ../test/sql_oracle_test.sh ./doltlite ./sqlite3`
- rebuilt benchmark binaries and reran `bench_sqlite` vs `bench_doltlite`

## Benchmark signal
- `oltp_write_only`: `4.29x -> 1.86x`
- `oltp_update_non_index`: `4.20x -> 3.96x`
- `oltp_read_write`: `1.65x -> 1.55x`

This is mainly a win for repeated updates that resolve to an unchanged row payload.
