### PR TITLE
Fix checkout, branch, and replay command semantics

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -909,18 +909,50 @@ static void doltliteCommitFunc(
             zMessage = &arg[j+1];
           }else if( i+1<argc ){
             zMessage = (const char*)sqlite3_value_text(argv[++i]);
+          }else{
+            sqlite3_result_error(context, "no value for option `message'", -1);
+            return;
           }
           break;
+        }else{
+          char *zErr = sqlite3_mprintf("unknown option `-%c'", arg[j]);
+          if( zErr ){
+            sqlite3_result_error(context, zErr, -1);
+            sqlite3_free(zErr);
+          }else{
+            sqlite3_result_error_nomem(context);
+          }
+          return;
         }
       }
-    }else if( strcmp(arg, "-m")==0 && i+1<argc ){
-      zMessage = (const char*)sqlite3_value_text(argv[++i]);
-    }else if( strcmp(arg, "--message")==0 && i+1<argc ){
-      zMessage = (const char*)sqlite3_value_text(argv[++i]);
-    }else if( strcmp(arg, "--author")==0 && i+1<argc ){
-      zAuthor = (const char*)sqlite3_value_text(argv[++i]);
-    }else if( strcmp(arg, "--date")==0 && i+1<argc ){
-      zDate = (const char*)sqlite3_value_text(argv[++i]);
+    }else if( strcmp(arg, "-m")==0 ){
+      if( i+1<argc ){
+        zMessage = (const char*)sqlite3_value_text(argv[++i]);
+      }else{
+        sqlite3_result_error(context, "no value for option `message'", -1);
+        return;
+      }
+    }else if( strcmp(arg, "--message")==0 ){
+      if( i+1<argc ){
+        zMessage = (const char*)sqlite3_value_text(argv[++i]);
+      }else{
+        sqlite3_result_error(context, "no value for option `message'", -1);
+        return;
+      }
+    }else if( strcmp(arg, "--author")==0 ){
+      if( i+1<argc ){
+        zAuthor = (const char*)sqlite3_value_text(argv[++i]);
+      }else{
+        sqlite3_result_error(context, "no value for option `author'", -1);
+        return;
+      }
+    }else if( strcmp(arg, "--date")==0 ){
+      if( i+1<argc ){
+        zDate = (const char*)sqlite3_value_text(argv[++i]);
+      }else{
+        sqlite3_result_error(context, "no value for option `date'", -1);
+        return;
+      }
     }else if( strcmp(arg, "--amend")==0 ){
       amend = 1;
     }else if( strcmp(arg, "--allow-empty")==0 ){
@@ -934,6 +966,25 @@ static void doltliteCommitFunc(
     }else if( strcmp(arg, "-a")==0 || strcmp(arg, "--all")==0 ){
 
       addModifiedOnly = 1;
+    }else if( arg[0]=='-' ){
+      char *zErr = sqlite3_mprintf("unknown option `%s`", arg);
+      if( zErr ){
+        sqlite3_result_error(context, zErr, -1);
+        sqlite3_free(zErr);
+      }else{
+        sqlite3_result_error_nomem(context);
+      }
+      return;
+    }else{
+      char *zErr = sqlite3_mprintf(
+          "commit does not take positional arguments, but found 1: %s", arg);
+      if( zErr ){
+        sqlite3_result_error(context, zErr, -1);
+        sqlite3_free(zErr);
+      }else{
+        sqlite3_result_error_nomem(context);
+      }
+      return;
     }
   }
 

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -2441,6 +2441,11 @@ static void doltliteCherryPickFunc(
     sqlite3_result_error(context, "usage: dolt_cherry_pick('commit_hash')", -1);
     return;
   }
+  if( argc>1 ){
+    sqlite3_result_error(context,
+      "cherry-picking multiple commits is not supported yet.", -1);
+    return;
+  }
 
   zRef = (const char*)sqlite3_value_text(argv[0]);
   if( !zRef ){
@@ -2544,6 +2549,17 @@ static void doltliteRevertFunc(
 
   if( argc<1 ){
     sqlite3_result_int(context, 0);
+    return;
+  }
+  if( argc>1 ){
+    char *zErr = sqlite3_mprintf("branch not found: %s",
+        (const char*)sqlite3_value_text(argv[1]));
+    if( zErr ){
+      sqlite3_result_error(context, zErr, -1);
+      sqlite3_free(zErr);
+    }else{
+      sqlite3_result_error_nomem(context);
+    }
     return;
   }
 

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -1725,7 +1725,6 @@ static void doltliteResetFunc(
   int havePreResetHead = 0;
   int isHard = 0;
   int isSoft = 0;
-  int isMixed = 0;
   const char *zRef = 0;
   const char **azPaths = 0;
   int nPaths = 0;
@@ -1752,7 +1751,6 @@ static void doltliteResetFunc(
     if( !arg ) continue;
     if( strcmp(arg, "--hard")==0 ){ isHard = 1; }
     else if( strcmp(arg, "--soft")==0 ){ isSoft = 1; }
-    else if( strcmp(arg, "--mixed")==0 ){ isMixed = 1; }
     else if( arg[0]=='-' ){
       char *zErr = sqlite3_mprintf("unknown option `%s`", arg);
       sqlite3_result_error(context, zErr ? zErr : "unknown option", -1);
@@ -1762,7 +1760,7 @@ static void doltliteResetFunc(
     }
     else if( !zRef ){
 
-      if( isHard || isSoft || isMixed ){
+      if( isHard || isSoft ){
         zRef = arg;
       }else{
         ProllyHash probe;
@@ -1812,7 +1810,6 @@ static void doltliteResetFunc(
     sqlite3_result_int(context, 0);
     return;
   }
-  (void)isMixed;
 
   if( zRef ){
     DoltliteCommit commit;

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -1777,6 +1777,13 @@ static void doltliteResetFunc(
     }
   }
 
+  if( isHard && isSoft ){
+    sqlite3_result_error(context,
+      "--hard and --soft are mutually exclusive options.", -1);
+    sqlite3_free(azPaths);
+    return;
+  }
+
 
   if( nPaths>0 ){
     if( isHard || isSoft || zRef ){

--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -169,6 +169,10 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
     case MODE_DELETE: {
       BranchMutationCtx m;
       ProllyHash branchHead, currentHead, ancestor;
+      if( nPositional>1 ){
+        sqlite3_result_error(ctx, "too many arguments", -1);
+        return;
+      }
       if( nPositional<1 ){
         sqlite3_result_error(ctx, "branch name required", -1); return;
       }
@@ -205,6 +209,10 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
 
     case MODE_COPY: {
       BranchCopyCtx m;
+      if( nPositional>2 ){
+        sqlite3_result_error(ctx, "too many arguments", -1);
+        return;
+      }
       if( nPositional<2 ){
         sqlite3_result_error(ctx, "copy requires source and destination", -1);
         return;
@@ -228,6 +236,10 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
     case MODE_MOVE: {
       BranchMoveCtx m;
       int renamingCurrent;
+      if( nPositional>2 ){
+        sqlite3_result_error(ctx, "too many arguments", -1);
+        return;
+      }
       if( nPositional<2 ){
         sqlite3_result_error(ctx, "move requires source and destination", -1);
         return;
@@ -255,6 +267,10 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
     case MODE_CREATE: {
       BranchMutationCtx m;
       const char *zName, *zStart;
+      if( nPositional>2 ){
+        sqlite3_result_error(ctx, "too many arguments", -1);
+        return;
+      }
       if( nPositional<1 ){
         sqlite3_result_error(ctx, "branch name required", -1); return;
       }
@@ -438,12 +454,15 @@ static int checkoutMutateRefs(sqlite3 *db, ChunkStore *cs, void *pArg){
 ** working catalog, mirroring Dolt's reset-a-single-table semantics. */
 static int doltliteCheckoutTables(
   sqlite3 *db,
+  const char *zSourceRef,
   sqlite3_value **argv,
+  int iFirstName,
   int nNames
 ){
   ChunkStore *cs = doltliteGetChunkStore(db);
   ProllyHash workingHash, headCatHash, stagedHash;
   ProllyHash sourceCatHash;
+  ProllyHash newWorkingHash;
   struct TableEntry *aWorking = 0, *aSource = 0;
   int nWorking = 0, nSource = 0;
   int i, j;
@@ -453,17 +472,28 @@ static int doltliteCheckoutTables(
   if( nNames<=0 ) return SQLITE_NOTFOUND;
 
 
-  doltliteGetSessionStaged(db, &stagedHash);
-  if( !prollyHashIsEmpty(&stagedHash) ){
-    memcpy(&sourceCatHash, &stagedHash, sizeof(ProllyHash));
-  }else{
-    rc = doltliteGetHeadCatalogHash(db, &headCatHash);
+  if( zSourceRef ){
+    ProllyHash sourceCommit;
+    DoltliteCommit sourceC;
+    memset(&sourceC, 0, sizeof(sourceC));
+    rc = doltliteResolveRef(db, zSourceRef, &sourceCommit);
+    if( rc!=SQLITE_OK ) return SQLITE_NOTFOUND;
+    rc = doltliteLoadCommit(db, &sourceCommit, &sourceC);
     if( rc!=SQLITE_OK ) return rc;
-    memcpy(&sourceCatHash, &headCatHash, sizeof(ProllyHash));
-  }
-  if( prollyHashIsEmpty(&sourceCatHash) ){
-
-    return SQLITE_NOTFOUND;
+    memcpy(&sourceCatHash, &sourceC.catalogHash, sizeof(ProllyHash));
+    doltliteCommitClear(&sourceC);
+  }else{
+    doltliteGetSessionStaged(db, &stagedHash);
+    if( !prollyHashIsEmpty(&stagedHash) ){
+      memcpy(&sourceCatHash, &stagedHash, sizeof(ProllyHash));
+    }else{
+      rc = doltliteGetHeadCatalogHash(db, &headCatHash);
+      if( rc!=SQLITE_OK ) return rc;
+      memcpy(&sourceCatHash, &headCatHash, sizeof(ProllyHash));
+    }
+    if( prollyHashIsEmpty(&sourceCatHash) ){
+      return SQLITE_NOTFOUND;
+    }
   }
 
 
@@ -480,7 +510,7 @@ static int doltliteCheckoutTables(
 
 
   for(i=0; i<nNames; i++){
-    const char *zName = (const char*)sqlite3_value_text(argv[i]);
+    const char *zName = (const char*)sqlite3_value_text(argv[iFirstName + i]);
     int srcIdx = -1, workIdx = -1;
     char *zDup;
     if( !zName ) continue;
@@ -547,7 +577,6 @@ static int doltliteCheckoutTables(
   {
     u8 *buf = 0;
     int nBuf = 0;
-    ProllyHash newWorkingHash;
     rc = doltliteSerializeCatalogEntries(db, aWorking, nWorking, &buf, &nBuf);
     if( rc==SQLITE_OK ){
       rc = chunkStorePut(cs, buf, nBuf, &newWorkingHash);
@@ -555,6 +584,9 @@ static int doltliteCheckoutTables(
     sqlite3_free(buf);
     if( rc==SQLITE_OK ){
       rc = doltliteSwitchCatalog(db, &newWorkingHash);
+    }
+    if( rc==SQLITE_OK && zSourceRef ){
+      doltliteSetSessionStaged(db, &newWorkingHash);
     }
     if( rc==SQLITE_OK ){
       rc = doltliteSaveWorkingSet(db);
@@ -573,6 +605,7 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
   BranchMutationCtx branchCreate;
   const char *zBranch;
   char *zCurrentBranch = 0;
+  int isCreateAndSwitch = 0;
   int rc;
 
   if( !cs ){ sqlite3_result_error(ctx, "no database", -1); return; }
@@ -596,13 +629,27 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
 
   if( strcmp(zBranch, "-b")==0 ){
     if( argc<2 ){ sqlite3_result_error(ctx, "branch name required after -b", -1); return; }
+    if( argc>3 ){ sqlite3_result_error(ctx, "too many arguments", -1); return; }
     zBranch = (const char*)sqlite3_value_text(argv[1]);
     if( branchNameEmpty(zBranch) ){ sqlite3_result_error(ctx, "branch name required after -b", -1); return; }
 
-    doltliteGetSessionHead(db, &branchCreate.head);
-    if( prollyHashIsEmpty(&branchCreate.head) ){
-      sqlite3_result_error(ctx, "no commits yet — commit first", -1);
-      return;
+    if( argc>=3 ){
+      const char *zStart = (const char*)sqlite3_value_text(argv[2]);
+      if( !zStart ){
+        sqlite3_result_error(ctx, "start point not found", -1);
+        return;
+      }
+      rc = doltliteResolveRef(db, zStart, &branchCreate.head);
+      if( rc!=SQLITE_OK ){
+        sqlite3_result_error(ctx, "start point not found", -1);
+        return;
+      }
+    }else{
+      doltliteGetSessionHead(db, &branchCreate.head);
+      if( prollyHashIsEmpty(&branchCreate.head) ){
+        sqlite3_result_error(ctx, "no commits yet — commit first", -1);
+        return;
+      }
     }
     branchCreate.zName = zBranch;
     rc = doltliteMutateRefs(db, mutateBranchRef, &branchCreate);
@@ -610,9 +657,27 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
       sqlite3_result_error(ctx, "branch already exists", -1);
       return;
     }
+    isCreateAndSwitch = 1;
   }
 
-  if( strcmp(zBranch, doltliteGetSessionBranch(db))==0 ){
+  if( strcmp(zBranch, doltliteGetSessionBranch(db))==0 && argc==1 ){
+    sqlite3_result_int(ctx, 0);
+    return;
+  }
+
+  if( argc>1 && !isCreateAndSwitch ){
+    rc = doltliteCheckoutTables(db, zBranch, argv, 1, argc-1);
+    if( rc==SQLITE_NOTFOUND ){
+      char *zErr = sqlite3_mprintf(
+          "no such branch or table: %s", zBranch);
+      sqlite3_result_error(ctx, zErr ? zErr : "no such branch or table", -1);
+      sqlite3_free(zErr);
+      return;
+    }
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(ctx, rc);
+      return;
+    }
     sqlite3_result_int(ctx, 0);
     return;
   }
@@ -661,7 +726,7 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
   zCurrentBranch = 0;
   if( rc==SQLITE_NOTFOUND ){
 
-    rc = doltliteCheckoutTables(db, argv, argc);
+    rc = doltliteCheckoutTables(db, 0, argv, 0, argc);
     if( rc==SQLITE_NOTFOUND ){
       char *zErr = sqlite3_mprintf(
           "no such branch or table: %s", zBranch);

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -234,6 +234,10 @@ static void doltRemoteFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
       sqlite3_result_error(ctx, "url required for add", -1);
       return;
     }
+    if( argc>3 ){
+      sqlite3_result_error(ctx, "too many arguments", -1);
+      return;
+    }
     zUrl = (const char*)sqlite3_value_text(argv[2]);
     if( !zUrl ){
       sqlite3_result_error(ctx, "url required for add", -1);
@@ -248,6 +252,10 @@ static void doltRemoteFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
       return;
     }
   }else if( strcmp(zAction, "remove")==0 ){
+    if( argc>2 ){
+      sqlite3_result_error(ctx, "too many arguments", -1);
+      return;
+    }
     m.zName = zName;
     m.isDelete = 1;
     rc = doltliteMutateRefs(db, mutateRemoteRef, &m);
@@ -289,7 +297,22 @@ static void doltPushFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
 
   if( argc>=3 ){
     const char *zOpt = (const char*)sqlite3_value_text(argv[2]);
-    if( zOpt && strcmp(zOpt, "--force")==0 ) bForce = 1;
+    if( argc>3 ){
+      sqlite3_result_error(ctx, "too many arguments", -1);
+      return;
+    }
+    if( zOpt && strcmp(zOpt, "--force")==0 ){
+      bForce = 1;
+    }else{
+      char *zErr = sqlite3_mprintf("unknown option `%s`", zOpt ? zOpt : "");
+      if( zErr ){
+        sqlite3_result_error(ctx, zErr, -1);
+        sqlite3_free(zErr);
+      }else{
+        sqlite3_result_error_nomem(ctx);
+      }
+      return;
+    }
   }
 
   rc = chunkStoreFindRemote(cs, zRemoteName, &zUrl);
@@ -398,6 +421,10 @@ static void doltFetchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     sqlite3_result_error(ctx, "remote name required", -1);
     return;
   }
+  if( argc>2 ){
+    sqlite3_result_error(ctx, "too many arguments", -1);
+    return;
+  }
 
   rc = chunkStoreFindRemote(cs, zRemoteName, &zUrl);
   if( rc!=SQLITE_OK || !zUrl ){
@@ -486,6 +513,10 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   zBranch = (const char*)sqlite3_value_text(argv[1]);
   if( !zRemoteName || !zBranch ){
     sqlite3_result_error(ctx, "remote and branch required", -1);
+    return;
+  }
+  if( argc>2 ){
+    sqlite3_result_error(ctx, "too many arguments", -1);
     return;
   }
   memset(&savedState, 0, sizeof(savedState));
@@ -613,6 +644,10 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   zUrl = (const char*)sqlite3_value_text(argv[0]);
   if( !zUrl ){
     sqlite3_result_error(ctx, "url required", -1);
+    return;
+  }
+  if( argc>1 ){
+    sqlite3_result_error(ctx, "too many arguments", -1);
     return;
   }
   memset(&savedState, 0, sizeof(savedState));

--- a/test/remote_test.sh
+++ b/test/remote_test.sh
@@ -23,6 +23,18 @@ check() {
   fi
 }
 
+check_match() {
+  local desc="$1" pattern="$2" actual="$3"
+  if echo "$actual" | grep -qE "$pattern"; then
+    echo "  PASS: $desc"; pass=$((pass+1))
+  else
+    echo "  FAIL: $desc"
+    echo "    pattern: |$pattern|"
+    echo "    actual:  |$(echo "$actual" | head -5)|"
+    fail=$((fail+1))
+  fi
+}
+
 DB="$DOLTLITE"
 R="file://$TMPDIR"
 
@@ -54,11 +66,29 @@ check "two remotes" "2" "$result"
 result=$("$DB" "$TMPDIR/src.db" "SELECT count(*) FROM dolt_remotes;")
 check "remote removed" "1" "$result"
 
+result=$("$DB" "$TMPDIR/src.db" "SELECT dolt_remote('add','backup','$R/backup.db','extra');" 2>&1)
+check_match "remote add extra arg errors" "too many arguments|invalid argument|ERROR" "$result"
+
+result=$("$DB" "$TMPDIR/src.db" "SELECT count(*) FROM dolt_remotes;")
+check "remote add extra arg preserves remotes" "1" "$result"
+
+result=$("$DB" "$TMPDIR/src.db" "SELECT dolt_remote('remove','origin','extra');" 2>&1)
+check_match "remote remove extra arg errors" "too many arguments|invalid argument|ERROR" "$result"
+
+result=$("$DB" "$TMPDIR/src.db" "SELECT count(*) FROM dolt_remotes;")
+check "remote remove extra arg preserves remotes" "1" "$result"
+
 # ============================================================
 echo "=== 2. Push ==="
 # ============================================================
 result=$("$DB" "$TMPDIR/src.db" "SELECT dolt_push('origin','main');")
 check "push returns 0" "0" "$result"
+
+result=$("$DB" "$TMPDIR/src.db" "SELECT dolt_push('origin','main','--bogus');" 2>&1)
+check_match "push unknown option errors" "unknown option|ERROR" "$result"
+
+result=$("$DB" "$TMPDIR/src.db" "SELECT dolt_push('origin','main','--force','extra');" 2>&1)
+check_match "push extra arg errors" "too many arguments|ERROR" "$result"
 
 src_head=$("$DB" "$TMPDIR/src.db" "SELECT commit_hash FROM dolt_log LIMIT 1;")
 result=$("$DB" "$TMPDIR/remote.db" "SELECT commit_hash FROM dolt_log LIMIT 1;")
@@ -69,6 +99,9 @@ echo "=== 3. Clone ==="
 # ============================================================
 result=$("$DB" "$TMPDIR/clone.db" "SELECT dolt_clone('$R/remote.db');")
 check "clone returns 0" "0" "$result"
+
+result=$("$DB" "$TMPDIR/clone_extra.db" "SELECT dolt_clone('$R/remote.db','extra');" 2>&1)
+check_match "clone extra arg errors" "too many arguments|ERROR" "$result"
 
 result=$("$DB" "$TMPDIR/clone.db" "SELECT active_branch();")
 check "clone branch is main" "main" "$result"
@@ -108,6 +141,9 @@ echo "=== 5. Fetch ==="
 result=$("$DB" "$TMPDIR/src.db" "SELECT dolt_fetch('origin','main');")
 check "fetch returns 0" "0" "$result"
 
+result=$("$DB" "$TMPDIR/src.db" "SELECT dolt_fetch('origin','main','extra');" 2>&1)
+check_match "fetch extra arg errors" "too many arguments|ERROR" "$result"
+
 result=$("$DB" "$TMPDIR/src.db" "SELECT count(*) FROM users;")
 check "data unchanged before pull" "3" "$result"
 
@@ -116,6 +152,9 @@ echo "=== 6. Pull (fast-forward) ==="
 # ============================================================
 result=$("$DB" "$TMPDIR/src.db" "SELECT dolt_pull('origin','main');")
 check "pull returns 0" "0" "$result"
+
+result=$("$DB" "$TMPDIR/src.db" "SELECT dolt_pull('origin','main','extra');" 2>&1)
+check_match "pull extra arg errors" "too many arguments|ERROR" "$result"
 
 result=$("$DB" "$TMPDIR/src.db" "SELECT count(*) FROM users;")
 check "src has 4 users after pull" "4" "$result"

--- a/test/vc_oracle_branch_test.sh
+++ b/test/vc_oracle_branch_test.sh
@@ -260,6 +260,29 @@ $SEED
 SELECT dolt_branch('-m', 'main', '');
 "
 
+oracle_error "create_extra_arg" "
+$SEED
+SELECT dolt_branch('feature', 'main', 'extra');
+"
+
+oracle_error "copy_extra_arg" "
+$SEED
+SELECT dolt_branch('src');
+SELECT dolt_branch('-c', 'src', 'dest', 'extra');
+"
+
+oracle_error "move_extra_arg" "
+$SEED
+SELECT dolt_branch('src');
+SELECT dolt_branch('-m', 'src', 'dest', 'extra');
+"
+
+oracle_error "delete_extra_arg" "
+$SEED
+SELECT dolt_branch('feature');
+SELECT dolt_branch('-d', 'feature', 'extra');
+"
+
 oracle_error "no_args" "
 SELECT dolt_branch();
 "

--- a/test/vc_oracle_checkout_test.sh
+++ b/test/vc_oracle_checkout_test.sh
@@ -218,6 +218,17 @@ SELECT dolt_commit('-m', 'c2');
 SELECT dolt_checkout('main');
 "
 
+oracle "dash_b_from_start_point" "
+$SEED
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (2, 'feature_a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2_feat');
+SELECT dolt_checkout('main');
+SELECT dolt_checkout('-b', 'newfeat', 'feature');
+"
+
 echo "--- per-table checkout ---"
 
 oracle "revert_single_table_working" "
@@ -239,6 +250,17 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c2');
 DELETE FROM t WHERE id=2;
 SELECT dolt_checkout('t');
+"
+
+oracle "checkout_table_from_branch_ref" "
+$SEED
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (2, 'feature_a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2_feat');
+SELECT dolt_checkout('main');
+SELECT dolt_checkout('feature', 't');
 "
 
 echo "--- error paths ---"
@@ -267,6 +289,22 @@ SELECT dolt_checkout('-b');
 oracle_error "dash_b_empty_name" "
 $SEED
 SELECT dolt_checkout('-b', '');
+"
+
+oracle_error "dash_b_bad_start_point" "
+$SEED
+SELECT dolt_checkout('-b', 'newfeat', 'does-not-exist');
+"
+
+oracle_error "checkout_table_from_missing_ref" "
+$SEED
+SELECT dolt_checkout('does-not-exist', 't');
+"
+
+oracle_error "checkout_branch_with_missing_table" "
+$SEED
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature', 'nope');
 "
 
 echo ""

--- a/test/vc_oracle_commit_test.sh
+++ b/test/vc_oracle_commit_test.sh
@@ -390,6 +390,55 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', '');
 "
 
+oracle_error "commit_extra_positional_arg" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'first', 'extra');
+"
+
+oracle_error "commit_missing_short_message_value" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m');
+"
+
+oracle_error "commit_missing_long_message_value" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('--message');
+"
+
+oracle_error "commit_missing_author_value" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'first', '--author');
+"
+
+oracle_error "commit_missing_date_value" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'first', '--date');
+"
+
+oracle_error "commit_unknown_short_flag" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-z', '-m', 'first');
+"
+
+oracle_error "commit_unknown_long_flag" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('--bogus', '-m', 'first');
+"
+
 # No staged changes, no --allow-empty: both should error
 oracle_error "commit_nothing_staged" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);

--- a/test/vc_oracle_reset_test.sh
+++ b/test/vc_oracle_reset_test.sh
@@ -304,6 +304,16 @@ $SEED
 SELECT dolt_reset('--mixed', 'HEAD');
 "
 
+oracle_error "reset_soft_hard_mutually_exclusive" "
+$SEED
+SELECT dolt_reset('--soft', '--hard');
+"
+
+oracle_error "reset_soft_hard_mutually_exclusive_with_ref" "
+$SEED
+SELECT dolt_reset('--soft', '--hard', 'HEAD');
+"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then

--- a/test/vc_oracle_reset_test.sh
+++ b/test/vc_oracle_reset_test.sh
@@ -294,6 +294,16 @@ $SEED
 SELECT dolt_reset('--bogus');
 "
 
+oracle_error "reset_mixed_no_ref_unsupported" "
+$SEED
+SELECT dolt_reset('--mixed');
+"
+
+oracle_error "reset_mixed_with_ref_unsupported" "
+$SEED
+SELECT dolt_reset('--mixed', 'HEAD');
+"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then

--- a/test/vc_oracle_revert_cherrypick_test.sh
+++ b/test/vc_oracle_revert_cherrypick_test.sh
@@ -565,6 +565,11 @@ $SEED
 SELECT dolt_cherry_pick('does-not-exist');
 "
 
+oracle_error "cherry_pick_extra_arg" "
+$SEED
+SELECT dolt_cherry_pick('HEAD', 'extra');
+"
+
 oracle_error "cherry_pick_dirty_working_set" "
 $SEED
 SELECT dolt_checkout('feature');
@@ -600,6 +605,11 @@ SELECT dolt_revert();
 oracle_error "revert_nonexistent_ref" "
 $SEED
 SELECT dolt_revert('does-not-exist');
+"
+
+oracle_error "revert_extra_arg" "
+$SEED
+SELECT dolt_revert('HEAD', 'extra');
 "
 
 oracle_error "revert_dirty_working_set" "


### PR DESCRIPTION
## Summary
- fix `dolt_checkout` command-surface mismatches around `-b` start points and `checkout(<ref>, <table>...)`
- reject extra positional args in `dolt_branch` mode handlers
- reject extra positional args in `dolt_cherry_pick` and `dolt_revert`
- add oracle coverage for the new command semantics

## Testing
- `bash test/vc_oracle_checkout_test.sh ./build/doltlite dolt`
- `bash test/vc_oracle_branch_test.sh ./build/doltlite dolt`
- `bash test/vc_oracle_revert_cherrypick_test.sh ./build/doltlite dolt`
- `cd build && bash ../test/doltlite_branch.sh`