### PR TITLE
Fix WAL read truncation for >2GB WAL regions

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -769,10 +769,20 @@ static int csReplayWalRegion(ChunkStore *cs, int updateManifest){
   walData = (u8*)sqlite3_malloc64(walSize);
   if( !walData ) return SQLITE_NOMEM;
   {
-    int rc = sqlite3OsRead(cs->pFile, walData, (int)walSize, cs->iWalOffset);
-    if( rc != SQLITE_OK ){
-      sqlite3_free(walData);
-      return rc;
+    /* Read in chunks of at most 1GB to avoid truncating walSize to int. */
+    i64 remaining = walSize;
+    i64 off = cs->iWalOffset;
+    u8 *p = walData;
+    while( remaining > 0 ){
+      int n = (remaining > 0x40000000) ? 0x40000000 : (int)remaining;
+      int rc = sqlite3OsRead(cs->pFile, p, n, off);
+      if( rc != SQLITE_OK ){
+        sqlite3_free(walData);
+        return rc;
+      }
+      p += n;
+      off += n;
+      remaining -= n;
     }
   }
 


### PR DESCRIPTION
## Summary
- Fix integer truncation in `csReplayWalRegion` where `walSize` (i64) was cast to `int` for `sqlite3OsRead`, corrupting WAL replay for databases with WAL regions exceeding 2GB
- Reads in 1GB loop iterations to handle arbitrarily large WAL regions safely

## Test plan
- [x] Crash recovery test suite (115/115 pass)
- [x] Correctness regression tests (41/41 pass)
- [x] Lint passes
- [ ] CI full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)