### PR TITLE
Tighten dolt_conflicts_resolve argument checks

### DIFF
--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -670,6 +670,29 @@ int doltliteRegisterConflictTables(sqlite3 *db){
   return doltliteForEachUserTable(db, "dolt_conflicts_", &cfRowModule);
 }
 
+static int conflictsResolveTableExists(sqlite3 *db, const char *zTable, int *pExists){
+  sqlite3_stmt *pStmt = 0;
+  int rc;
+
+  *pExists = 0;
+  rc = sqlite3_prepare_v2(db,
+      "SELECT 1 FROM main.sqlite_master WHERE type='table' AND name=?1",
+      -1, &pStmt, 0);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = sqlite3_bind_text(pStmt, 1, zTable, -1, SQLITE_TRANSIENT);
+  if( rc==SQLITE_OK ){
+    rc = sqlite3_step(pStmt);
+    if( rc==SQLITE_ROW ){
+      *pExists = 1;
+      rc = SQLITE_OK;
+    }else if( rc==SQLITE_DONE ){
+      rc = SQLITE_OK;
+    }
+  }
+  sqlite3_finalize(pStmt);
+  return rc;
+}
+
 static void conflictsResolveFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
   ChunkStore *cs = doltliteGetChunkStore(db);
@@ -677,6 +700,7 @@ static void conflictsResolveFunc(sqlite3_context *ctx, int argc, sqlite3_value *
   ConflictTableInfo *aTables = 0;
   int nTables = 0;
   int found = 0;
+  int tableExists = 0;
   int i, j, rc;
 
   if(!cs){ sqlite3_result_error(ctx,"no database",-1); return; }
@@ -707,7 +731,16 @@ static void conflictsResolveFunc(sqlite3_context *ctx, int argc, sqlite3_value *
       }
     }
     if( !found ){
+      rc = conflictsResolveTableExists(db, zTable, &tableExists);
       freeConflictTables(aTables, nTables);
+      if( rc!=SQLITE_OK ){
+        sqlite3_result_error_code(ctx, rc);
+        return;
+      }
+      if( tableExists ){
+        sqlite3_result_int(ctx, 0);
+        return;
+      }
       sqlite3_result_error(ctx, "table not found", -1);
       return;
     }
@@ -742,7 +775,16 @@ static void conflictsResolveFunc(sqlite3_context *ctx, int argc, sqlite3_value *
       break;
     }
     if( !found ){
+      rc = conflictsResolveTableExists(db, zTable, &tableExists);
       freeConflictTables(aTables, nTables);
+      if( rc!=SQLITE_OK ){
+        sqlite3_result_error_code(ctx, rc);
+        return;
+      }
+      if( tableExists ){
+        sqlite3_result_int(ctx, 0);
+        return;
+      }
       sqlite3_result_error(ctx, "table not found", -1);
       return;
     }

--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -676,10 +676,11 @@ static void conflictsResolveFunc(sqlite3_context *ctx, int argc, sqlite3_value *
   const char *zMode, *zTable;
   ConflictTableInfo *aTables = 0;
   int nTables = 0;
+  int found = 0;
   int i, j, rc;
 
   if(!cs){ sqlite3_result_error(ctx,"no database",-1); return; }
-  if(argc<2){ sqlite3_result_error(ctx,"usage: dolt_conflicts_resolve('--ours'|'--theirs','table')",-1); return; }
+  if(argc!=2){ sqlite3_result_error(ctx,"usage: dolt_conflicts_resolve('--ours'|'--theirs','table')",-1); return; }
 
   zMode = (const char*)sqlite3_value_text(argv[0]);
   zTable = (const char*)sqlite3_value_text(argv[1]);
@@ -700,9 +701,15 @@ static void conflictsResolveFunc(sqlite3_context *ctx, int argc, sqlite3_value *
 
     for(i=0; i<nTables; i++){
       if( aTables[i].zName && strcmp(aTables[i].zName, zTable)==0 ){
+        found = 1;
         removeConflictTable(aTables, &nTables, i);
         break;
       }
+    }
+    if( !found ){
+      freeConflictTables(aTables, nTables);
+      sqlite3_result_error(ctx, "table not found", -1);
+      return;
     }
     rc = storeUpdatedConflicts(db, cs, aTables, nTables);
     freeConflictTables(aTables, nTables);
@@ -716,6 +723,7 @@ static void conflictsResolveFunc(sqlite3_context *ctx, int argc, sqlite3_value *
 
     for(i=0; i<nTables; i++){
       if( !aTables[i].zName || strcmp(aTables[i].zName, zTable)!=0 ) continue;
+      found = 1;
 
 
       for(j=0; j<aTables[i].nConflicts; j++){
@@ -732,6 +740,11 @@ static void conflictsResolveFunc(sqlite3_context *ctx, int argc, sqlite3_value *
 
       removeConflictTable(aTables, &nTables, i);
       break;
+    }
+    if( !found ){
+      freeConflictTables(aTables, nTables);
+      sqlite3_result_error(ctx, "table not found", -1);
+      return;
     }
     rc = storeUpdatedConflicts(db, cs, aTables, nTables);
     freeConflictTables(aTables, nTables);

--- a/test/vc_oracle_conflicts_resolve_test.sh
+++ b/test/vc_oracle_conflicts_resolve_test.sh
@@ -74,6 +74,35 @@ oracle() {
   fi
 }
 
+oracle_error() {
+  local name="$1" setup="$2"
+  local dir="$TMPROOT/${name}_err"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_rc
+  vc_oracle_run_doltlite_script "$dir/dl/db" "$dir/dl.out" "$dir/dl.err" "$setup"
+  dl_rc=$?
+
+  local dolt_setup
+  dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
+  local dt_rc
+  vc_oracle_run_dolt_script "$dir/dt" "$dir/dt.out" "$dir/dt.err" \
+    "SET @@autocommit = 0;
+SET @@dolt_allow_commit_conflicts = 1;
+$dolt_setup"
+  dt_rc=$?
+
+  if [ "$dl_rc" -ne 0 ] && [ "$dt_rc" -ne 0 ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name (expected both to error)"
+    echo "    doltlite rc: $dl_rc"
+    echo "    dolt rc:     $dt_rc"
+  fi
+}
+
 # Standard conflict setup: both sides modify the same row differently.
 CONFLICT_SETUP="
 CREATE TABLE t(id INT PRIMARY KEY, v INT);
@@ -146,6 +175,18 @@ oracle "resolve_and_commit" \
 SELECT dolt_commit('-A', '-m', 'resolved');
 SELECT CONCAT('R|', id, '|', v) FROM t ORDER BY id;
 SELECT CONCAT('R|conflicts|', count(*)) FROM dolt_conflicts;"
+
+echo "--- error paths ---"
+
+oracle_error "resolve_missing_table" \
+  "$CONFLICT_SETUP
+SELECT dolt_conflicts_resolve('--ours', 'nope');
+"
+
+oracle_error "resolve_extra_positional_arg" \
+  "$CONFLICT_SETUP
+SELECT dolt_conflicts_resolve('--ours', 't', 'extra');
+"
 
 echo "--- TEXT primary key ---"
 

--- a/test/vc_oracle_conflicts_resolve_test.sh
+++ b/test/vc_oracle_conflicts_resolve_test.sh
@@ -176,6 +176,28 @@ SELECT dolt_commit('-A', '-m', 'resolved');
 SELECT CONCAT('R|', id, '|', v) FROM t ORDER BY id;
 SELECT CONCAT('R|conflicts|', count(*)) FROM dolt_conflicts;"
 
+echo "--- no-op on existing table with no conflicts ---"
+
+oracle "resolve_ours_no_conflicts_noop" \
+"CREATE TABLE t(id INT PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1, 10), (2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+" \
+  "SELECT dolt_conflicts_resolve('--ours', 't');
+SELECT CONCAT('R|', id, '|', v) FROM t ORDER BY id;
+SELECT CONCAT('R|conflicts|', count(*)) FROM dolt_conflicts;"
+
+oracle "resolve_theirs_no_conflicts_noop" \
+"CREATE TABLE t(id INT PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1, 10), (2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+" \
+  "SELECT dolt_conflicts_resolve('--theirs', 't');
+SELECT CONCAT('R|', id, '|', v) FROM t ORDER BY id;
+SELECT CONCAT('R|conflicts|', count(*)) FROM dolt_conflicts;"
+
 echo "--- error paths ---"
 
 oracle_error "resolve_missing_table" \


### PR DESCRIPTION
## Summary
- require exactly two args for dolt_conflicts_resolve
- error when the named table is not in the conflict set
- add oracle coverage for both error paths

## Testing
- bash test/vc_oracle_conflicts_resolve_test.sh ./build/doltlite dolt
- cd build && bash ../test/doltlite_conflicts.sh
