### PR TITLE
Fix conflict row deletes for non-integer keys

### DIFF
--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -526,6 +526,24 @@ static const char *cfrDiffType(const u8 *pBase, int nBase,
   return "modified";
 }
 
+/* For row-wise DELETE on dolt_conflicts_<table>, the vtab rowid must uniquely
+** identify a conflict row even when the user PK is not SQLite's integer
+** rowid. Use the raw serialized prolly key when present; integer PK conflicts
+** continue to use intKey directly. */
+static sqlite3_int64 cfrConflictRowid(const struct ConflictRow *cr){
+  if( cr->nKey>0 && cr->pKey ){
+    u64 h = 1469598103934665603ULL;
+    int i;
+    for(i=0; i<cr->nKey; i++){
+      h ^= (u64)cr->pKey[i];
+      h *= 1099511628211ULL;
+    }
+    if( h==0 ) h = 1;
+    return (sqlite3_int64)(h & 0x7fffffffffffffffULL);
+  }
+  return (sqlite3_int64)cr->intKey;
+}
+
 static int cfrColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
   CfRowCur *c = (CfRowCur*)cur;
   CfRowVtab *v = (CfRowVtab*)cur->pVtab;
@@ -581,7 +599,7 @@ static int cfrColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
 static int cfrRowid(sqlite3_vtab_cursor *cur, sqlite3_int64 *r){
   CfRowCur *c = (CfRowCur*)cur;
   if( c->iTableIdx >= 0 && c->iRow < c->aTables[c->iTableIdx].nConflicts ){
-    *r = c->aTables[c->iTableIdx].aRows[c->iRow].intKey;
+    *r = cfrConflictRowid(&c->aTables[c->iTableIdx].aRows[c->iRow]);
   }else{
     *r = 0;
   }
@@ -627,7 +645,7 @@ static int cfrUpdate(
       continue;
 
     for(j=0; j<aTables[i].nConflicts; j++){
-      if( aTables[i].aRows[j].intKey == deleteRowid ){
+      if( cfrConflictRowid(&aTables[i].aRows[j]) == deleteRowid ){
         removeConflictRow(&aTables[i], j);
 
 

--- a/test/doltlite_conflict_rows.sh
+++ b/test/doltlite_conflict_rows.sh
@@ -179,6 +179,118 @@ run_test "bigid_val" "SELECT v FROM t WHERE id=1000;" "main_val" "$DB"
 rm -f "$DB"
 
 # ============================================================
+# DELETE resolves targeted TEXT PK conflict row
+# ============================================================
+
+DB=/tmp/test_cfrow_textpk_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id VARCHAR(32) PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES('alice','orig');
+INSERT INTO t VALUES('bob','keep');
+SELECT dolt_commit('-A','-m','init');
+SELECT dolt_branch('hf');
+SELECT dolt_checkout('hf');
+UPDATE t SET v='hf_alice' WHERE id='alice';
+UPDATE t SET v='hf_bob' WHERE id='bob';
+SELECT dolt_commit('-A','-m','hf');
+SELECT dolt_checkout('main');
+UPDATE t SET v='main_alice' WHERE id='alice';
+UPDATE t SET v='main_bob' WHERE id='bob';
+SELECT dolt_commit('-A','-m','main');
+SELECT dolt_merge('hf');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test "textpk_conflict_rows" "SELECT count(*) FROM dolt_conflicts_t;" "2" "$DB"
+echo "DELETE FROM dolt_conflicts_t WHERE our_id='alice';" | $DOLTLITE "$DB" > /dev/null 2>&1
+run_test "textpk_one_conflict_left" "SELECT count(*) FROM dolt_conflicts_t;" "1" "$DB"
+run_test "textpk_remaining_conflict" "SELECT our_id FROM dolt_conflicts_t;" "bob" "$DB"
+run_test "textpk_deleted_row_kept_ours" "SELECT v FROM t WHERE id='alice';" "main_alice" "$DB"
+run_test "textpk_remaining_row_still_conflicted" "SELECT v FROM t WHERE id='bob';" "main_bob" "$DB"
+
+rm -f "$DB"
+
+# ============================================================
+# DELETE ALL resolves all TEXT PK conflict rows
+# ============================================================
+
+DB=/tmp/test_cfrow_textpk_all_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id VARCHAR(32) PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES('alice','orig');
+INSERT INTO t VALUES('bob','keep');
+SELECT dolt_commit('-A','-m','init');
+SELECT dolt_branch('hf');
+SELECT dolt_checkout('hf');
+UPDATE t SET v='hf_alice' WHERE id='alice';
+UPDATE t SET v='hf_bob' WHERE id='bob';
+SELECT dolt_commit('-A','-m','hf');
+SELECT dolt_checkout('main');
+UPDATE t SET v='main_alice' WHERE id='alice';
+UPDATE t SET v='main_bob' WHERE id='bob';
+SELECT dolt_commit('-A','-m','main');
+SELECT dolt_merge('hf');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+echo "DELETE FROM dolt_conflicts_t;" | $DOLTLITE "$DB" > /dev/null 2>&1
+run_test "textpk_all_conflicts_cleared" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
+run_test "textpk_all_kept_ours_alice" "SELECT v FROM t WHERE id='alice';" "main_alice" "$DB"
+run_test "textpk_all_kept_ours_bob" "SELECT v FROM t WHERE id='bob';" "main_bob" "$DB"
+
+rm -f "$DB"
+
+# ============================================================
+# DELETE resolves targeted composite PK conflict row
+# ============================================================
+
+DB=/tmp/test_cfrow_compoundpk_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(a INT, b INT, v TEXT, PRIMARY KEY(a,b));
+INSERT INTO t VALUES(1,1,'orig11');
+INSERT INTO t VALUES(1,2,'orig12');
+SELECT dolt_commit('-A','-m','init');
+SELECT dolt_branch('hf');
+SELECT dolt_checkout('hf');
+UPDATE t SET v='hf11' WHERE a=1 AND b=1;
+UPDATE t SET v='hf12' WHERE a=1 AND b=2;
+SELECT dolt_commit('-A','-m','hf');
+SELECT dolt_checkout('main');
+UPDATE t SET v='main11' WHERE a=1 AND b=1;
+UPDATE t SET v='main12' WHERE a=1 AND b=2;
+SELECT dolt_commit('-A','-m','main');
+SELECT dolt_merge('hf');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test "compoundpk_conflict_rows" "SELECT count(*) FROM dolt_conflicts_t;" "2" "$DB"
+echo "DELETE FROM dolt_conflicts_t WHERE our_a=1 AND our_b=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
+run_test "compoundpk_one_conflict_left" "SELECT count(*) FROM dolt_conflicts_t;" "1" "$DB"
+run_test "compoundpk_remaining_conflict" "SELECT our_a || ':' || our_b FROM dolt_conflicts_t;" "1:2" "$DB"
+run_test "compoundpk_deleted_row_kept_ours" "SELECT v FROM t WHERE a=1 AND b=1;" "main11" "$DB"
+run_test "compoundpk_remaining_row_still_conflicted" "SELECT v FROM t WHERE a=1 AND b=2;" "main12" "$DB"
+
+rm -f "$DB"
+
+# ============================================================
+# DELETE ALL resolves all composite PK conflict rows
+# ============================================================
+
+DB=/tmp/test_cfrow_compoundpk_all_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(a INT, b INT, v TEXT, PRIMARY KEY(a,b));
+INSERT INTO t VALUES(1,1,'orig11');
+INSERT INTO t VALUES(1,2,'orig12');
+SELECT dolt_commit('-A','-m','init');
+SELECT dolt_branch('hf');
+SELECT dolt_checkout('hf');
+UPDATE t SET v='hf11' WHERE a=1 AND b=1;
+UPDATE t SET v='hf12' WHERE a=1 AND b=2;
+SELECT dolt_commit('-A','-m','hf');
+SELECT dolt_checkout('main');
+UPDATE t SET v='main11' WHERE a=1 AND b=1;
+UPDATE t SET v='main12' WHERE a=1 AND b=2;
+SELECT dolt_commit('-A','-m','main');
+SELECT dolt_merge('hf');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+echo "DELETE FROM dolt_conflicts_t;" | $DOLTLITE "$DB" > /dev/null 2>&1
+run_test "compoundpk_all_conflicts_cleared" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
+run_test "compoundpk_all_kept_ours_11" "SELECT v FROM t WHERE a=1 AND b=1;" "main11" "$DB"
+run_test "compoundpk_all_kept_ours_12" "SELECT v FROM t WHERE a=1 AND b=2;" "main12" "$DB"
+
+rm -f "$DB"
+
+# ============================================================
 # Resolve, then make new commit, then verify log
 # ============================================================
 

--- a/test/vc_oracle_conflicts_resolve_test.sh
+++ b/test/vc_oracle_conflicts_resolve_test.sh
@@ -260,6 +260,55 @@ SELECT dolt_merge('feature');
   "SELECT dolt_conflicts_resolve('--ours', 't');
 SELECT CONCAT('R|', id, '|', v) FROM t ORDER BY id;"
 
+echo "--- per-row DELETE on conflict tables (TEXT primary key) ---"
+
+oracle "delete_conflict_row_text_pk" \
+"CREATE TABLE t(id VARCHAR(32) PRIMARY KEY, v INT);
+INSERT INTO t VALUES('alice', 10);
+INSERT INTO t VALUES('bob', 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+UPDATE t SET v=200 WHERE id='alice';
+UPDATE t SET v=201 WHERE id='bob';
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat_update');
+SELECT dolt_checkout('main');
+UPDATE t SET v=300 WHERE id='alice';
+UPDATE t SET v=301 WHERE id='bob';
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main_update');
+SELECT dolt_merge('feature');
+" \
+  "DELETE FROM dolt_conflicts_t WHERE our_id='alice';
+SELECT CONCAT('R|row|', our_id, '|', our_v, '|', their_v) FROM dolt_conflicts_t ORDER BY our_id;
+SELECT CONCAT('R|table|', id, '|', v) FROM t ORDER BY id;
+SELECT CONCAT('R|count|', count(*)) FROM dolt_conflicts;"
+
+oracle "delete_all_conflict_rows_text_pk" \
+"CREATE TABLE t(id VARCHAR(32) PRIMARY KEY, v INT);
+INSERT INTO t VALUES('alice', 10);
+INSERT INTO t VALUES('bob', 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+UPDATE t SET v=200 WHERE id='alice';
+UPDATE t SET v=201 WHERE id='bob';
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat_update');
+SELECT dolt_checkout('main');
+UPDATE t SET v=300 WHERE id='alice';
+UPDATE t SET v=301 WHERE id='bob';
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main_update');
+SELECT dolt_merge('feature');
+" \
+  "DELETE FROM dolt_conflicts_t;
+SELECT CONCAT('R|table|', id, '|', v) FROM t ORDER BY id;
+SELECT CONCAT('R|count|', count(*)) FROM dolt_conflicts;"
+
 echo "--- composite primary key (two INT columns) ---"
 
 # Composite PK exercises the path where the tree key alone can't
@@ -310,6 +359,57 @@ SELECT dolt_merge('feature');
 " \
   "SELECT dolt_conflicts_resolve('--ours', 't');
 SELECT CONCAT('R|', a, '|', b, '|', v) FROM t ORDER BY a, b;"
+
+echo "--- per-row DELETE on conflict tables (composite primary key) ---"
+
+oracle "delete_conflict_row_composite_pk" \
+"CREATE TABLE t(a INT, b INT, v INT, PRIMARY KEY(a, b));
+INSERT INTO t VALUES(1, 1, 11);
+INSERT INTO t VALUES(1, 2, 12);
+INSERT INTO t VALUES(2, 1, 21);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+UPDATE t SET v=110 WHERE a=1 AND b=1;
+UPDATE t SET v=120 WHERE a=1 AND b=2;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat');
+SELECT dolt_checkout('main');
+UPDATE t SET v=1100 WHERE a=1 AND b=1;
+UPDATE t SET v=1200 WHERE a=1 AND b=2;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'mainu');
+SELECT dolt_merge('feature');
+" \
+  "DELETE FROM dolt_conflicts_t WHERE our_a=1 AND our_b=1;
+SELECT CONCAT('R|row|', our_a, '|', our_b, '|', our_v, '|', their_v) FROM dolt_conflicts_t ORDER BY our_a, our_b;
+SELECT CONCAT('R|table|', a, '|', b, '|', v) FROM t ORDER BY a, b;
+SELECT CONCAT('R|count|', count(*)) FROM dolt_conflicts;"
+
+oracle "delete_all_conflict_rows_composite_pk" \
+"CREATE TABLE t(a INT, b INT, v INT, PRIMARY KEY(a, b));
+INSERT INTO t VALUES(1, 1, 11);
+INSERT INTO t VALUES(1, 2, 12);
+INSERT INTO t VALUES(2, 1, 21);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+UPDATE t SET v=110 WHERE a=1 AND b=1;
+UPDATE t SET v=120 WHERE a=1 AND b=2;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat');
+SELECT dolt_checkout('main');
+UPDATE t SET v=1100 WHERE a=1 AND b=1;
+UPDATE t SET v=1200 WHERE a=1 AND b=2;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'mainu');
+SELECT dolt_merge('feature');
+" \
+  "DELETE FROM dolt_conflicts_t;
+SELECT CONCAT('R|table|', a, '|', b, '|', v) FROM t ORDER BY a, b;
+SELECT CONCAT('R|count|', count(*)) FROM dolt_conflicts;"
 
 echo "--- composite PK mixing INT and TEXT ---"
 


### PR DESCRIPTION
## Summary
- make dolt_conflicts_<table> rowids unique for non-integer conflict rows
- fix targeted and full-row DELETE behavior for text/composite PK conflict tables
- add Dolt oracle coverage and local conflict-row regressions for text/composite PK deletes

## Testing
- cd build && bash ../test/doltlite_conflict_rows.sh
- bash test/vc_oracle_conflicts_resolve_test.sh ./build/doltlite dolt