### PR TITLE
dolt_blame: O(1) unresolved-count check instead of O(n) scan

### DIFF
--- a/src/doltlite_blame.c
+++ b/src/doltlite_blame.c
@@ -57,6 +57,7 @@ struct BlameCursor {
   BlameRow *aRows;
   int nRows;
   int nAlloc;
+  int nUnresolved;
   int iRow;
 };
 
@@ -418,18 +419,14 @@ static int blameCompareAgainstRef(
     if( !blameRowValueEqual(r->pCurVal, r->nCurVal, pRefVal, nRefVal) ){
       rc = blameAssign(r, pCommitHash, pCommit);
       if( rc!=SQLITE_OK ) return rc;
+      pCur->nUnresolved--;
     }
   }
   return SQLITE_OK;
 }
 
-/* Count rows still awaiting a blame. Used as the walk terminator. */
 static int blameUnresolvedCount(BlameCursor *pCur){
-  int i, n = 0;
-  for(i=0; i<pCur->nRows; i++){
-    if( !pCur->aRows[i].blamed ) n++;
-  }
-  return n;
+  return pCur->nUnresolved;
 }
 
 /* For merge blame we need the merge base across every parent, not just
@@ -717,6 +714,7 @@ static int bmFilter(sqlite3_vtab_cursor *pCursor,
 
   rc = blameCollectLiveRows(c, cs, pCache, &tableRoot, tableFlags);
   if( rc!=SQLITE_OK ){ blameFreeRows(c); return rc; }
+  c->nUnresolved = c->nRows;
 
   rc = blameWalk(c, db, v->zTableName);
   if( rc!=SQLITE_OK ){ blameFreeRows(c); return rc; }


### PR DESCRIPTION
## Summary
- Replace O(n) `blameUnresolvedCount` scan with an O(1) decrement counter
- Eliminates O(n × commits) overhead from the blame walk termination check

## Before
`blameUnresolvedCount` scanned all N rows checking the `blamed` flag on every commit iteration. For a 10K-row table with 500 commits, this was 5M flag checks just to decide whether to keep walking.

## After
`nUnresolved` counter on the cursor starts at `nRows`, decremented on each `blameAssign`. The while-loop check is now a single integer comparison.

## Test plan
- [x] dolt_blame oracle tests (12/12 pass)
- [x] Lint passes
- [ ] CI full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)