### PR TITLE
dolt_diff_stat: widen row counters from int to i64

### DIFF
--- a/src/doltlite_diff_stat.c
+++ b/src/doltlite_diff_stat.c
@@ -273,7 +273,7 @@ static int dsComputeTableStats(
   char **azFromCols = 0, **azToCols = 0;
   int nFromCols = 0, nToCols = 0;
   i64 oldCount = 0, newCount = 0;
-  int rowsMod = 0, rowsAdd = 0, rowsDel = 0;
+  i64 rowsMod = 0, rowsAdd = 0, rowsDel = 0;
   i64 cellsMod = 0, cellsAdd = 0, cellsDel = 0;
   int rc;
 


### PR DESCRIPTION
## Summary
- Widen `rowsMod`, `rowsAdd`, `rowsDel` from `int` to `i64` to prevent overflow on tables with >2B rows

One-line fix. The output struct fields were already `i64`; only the local accumulators were `int`.

## Test plan
- [x] dolt_diff_stat oracle tests (34/34 pass)
- [x] Lint passes
- [ ] CI full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)