### PR TITLE
branch rename: roll back destination on partial failure

### DIFF
--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -102,9 +102,15 @@ static int mutateBranchMove(sqlite3 *db, ChunkStore *cs, void *pArg){
   if( rc!=SQLITE_OK ) return rc;
   if( !prollyHashIsEmpty(&srcWorkingSet) ){
     rc = chunkStoreSetBranchWorkingSet(cs, p->zDest, &srcWorkingSet);
-    if( rc!=SQLITE_OK ) return rc;
+    if( rc!=SQLITE_OK ){
+      chunkStoreDeleteBranch(cs, p->zDest);
+      return rc;
+    }
   }
   rc = chunkStoreDeleteBranch(cs, p->zSrc);
+  if( rc!=SQLITE_OK ){
+    chunkStoreDeleteBranch(cs, p->zDest);
+  }
   return rc;
 }
 


### PR DESCRIPTION
## Summary
- If working-set copy or source delete fails after destination was created, clean up the destination so refs stay consistent
- Makes branch rename all-or-nothing instead of leaving both branches on failure

## Before
```
AddBranch(dest)    ✓
SetWorkingSet(dest) ✗  → dest exists, src exists, working set missing on dest
```

## After
```
AddBranch(dest)    ✓
SetWorkingSet(dest) ✗  → DeleteBranch(dest), return error
                         (source untouched, dest gone)
```

## Test plan
- [x] Branch oracle tests (27/27 pass)
- [x] Lint passes
- [ ] CI full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)