### PR TITLE
Support WITHOUT ROWID merge constraint detection

### DIFF
--- a/src/doltlite_merge_constraints.c
+++ b/src/doltlite_merge_constraints.c
@@ -7,6 +7,7 @@
 #include "prolly_cache.h"
 #include "chunk_store.h"
 #include "doltlite_internal.h"
+#include "doltlite_record.h"
 #include "doltlite_constraint_violations.h"
 
 #include <string.h>
@@ -92,6 +93,376 @@ static int fetchRowByRowid(
 
   prollyCursorClose(&cur);
   return SQLITE_OK;
+}
+
+static int copyCursorRow(
+  ProllyCursor *pCur,
+  u8 **ppKey, int *pnKey,
+  u8 **ppVal, int *pnVal
+){
+  const u8 *pKey = 0, *pVal = 0;
+  int nKey = 0, nVal = 0;
+
+  *ppKey = 0; *pnKey = 0;
+  *ppVal = 0; *pnVal = 0;
+
+  prollyCursorKey(pCur, &pKey, &nKey);
+  prollyCursorValue(pCur, &pVal, &nVal);
+  if( pKey && nKey>0 ){
+    *ppKey = sqlite3_malloc(nKey);
+    if( !*ppKey ) return SQLITE_NOMEM;
+    memcpy(*ppKey, pKey, nKey);
+    *pnKey = nKey;
+  }
+  if( pVal && nVal>0 ){
+    *ppVal = sqlite3_malloc(nVal);
+    if( !*ppVal ){
+      sqlite3_free(*ppKey);
+      *ppKey = 0; *pnKey = 0;
+      return SQLITE_NOMEM;
+    }
+    memcpy(*ppVal, pVal, nVal);
+    *pnVal = nVal;
+  }
+  return SQLITE_OK;
+}
+
+static int fetchRowByBlobKey(
+  ChunkStore *cs,
+  ProllyCache *pCache,
+  const ProllyHash *pRoot,
+  u8 flags,
+  const u8 *pKey, int nKey,
+  u8 **ppKey, int *pnKey,
+  u8 **ppVal, int *pnVal
+){
+  ProllyCursor cur;
+  int res, rc;
+
+  *ppKey = 0; *pnKey = 0;
+  *ppVal = 0; *pnVal = 0;
+
+  if( prollyHashIsEmpty(pRoot) ) return SQLITE_NOTFOUND;
+
+  prollyCursorInit(&cur, cs, pCache, pRoot, flags);
+  rc = prollyCursorSeekBlob(&cur, pKey, nKey, &res);
+  if( rc!=SQLITE_OK ){
+    prollyCursorClose(&cur);
+    return rc;
+  }
+  if( res!=0 ){
+    prollyCursorClose(&cur);
+    return SQLITE_NOTFOUND;
+  }
+  rc = copyCursorRow(&cur, ppKey, pnKey, ppVal, pnVal);
+  prollyCursorClose(&cur);
+  return rc;
+}
+
+typedef struct MergePkInfo MergePkInfo;
+struct MergePkInfo {
+  int nPk;
+  char **azPk;
+  char *zPkCols;
+};
+
+static void freeMergePkInfo(MergePkInfo *pPk){
+  int i;
+  if( !pPk ) return;
+  for(i=0; i<pPk->nPk; i++) sqlite3_free(pPk->azPk[i]);
+  sqlite3_free(pPk->azPk);
+  sqlite3_free(pPk->zPkCols);
+  memset(pPk, 0, sizeof(*pPk));
+}
+
+static int loadMergePkInfo(sqlite3 *db, const char *zTable, MergePkInfo *pPk){
+  sqlite3_stmt *pStmt = 0;
+  sqlite3_str *pCols = 0;
+  char *zQuery = 0;
+  int rc;
+  int nPk = 0;
+  char **azPk = 0;
+  int i;
+
+  memset(pPk, 0, sizeof(*pPk));
+  zQuery = sqlite3_mprintf("PRAGMA main.table_info(%Q)", zTable);
+  if( !zQuery ) return SQLITE_NOMEM;
+  rc = sqlite3_prepare_v2(db, zQuery, -1, &pStmt, 0);
+  sqlite3_free(zQuery);
+  if( rc!=SQLITE_OK ) return rc;
+
+  while( sqlite3_step(pStmt)==SQLITE_ROW ){
+    int pk = sqlite3_column_int(pStmt, 5);
+    if( pk>nPk ) nPk = pk;
+  }
+  rc = sqlite3_reset(pStmt);
+  if( rc!=SQLITE_OK ){
+    sqlite3_finalize(pStmt);
+    return rc;
+  }
+  if( nPk<=0 ){
+    sqlite3_finalize(pStmt);
+    return SQLITE_NOTFOUND;
+  }
+
+  azPk = sqlite3_malloc64((sqlite3_int64)nPk * sizeof(char*));
+  if( !azPk ){
+    sqlite3_finalize(pStmt);
+    return SQLITE_NOMEM;
+  }
+  memset(azPk, 0, (size_t)nPk * sizeof(char*));
+
+  while( sqlite3_step(pStmt)==SQLITE_ROW ){
+    const char *zCol = (const char*)sqlite3_column_text(pStmt, 1);
+    int pk = sqlite3_column_int(pStmt, 5);
+    if( pk<=0 || pk>nPk ) continue;
+    azPk[pk-1] = sqlite3_mprintf("%s", zCol ? zCol : "");
+    if( !azPk[pk-1] ){
+      rc = SQLITE_NOMEM;
+      break;
+    }
+  }
+  sqlite3_finalize(pStmt);
+  if( rc!=SQLITE_DONE && rc!=SQLITE_OK ){
+    for(i=0; i<nPk; i++) sqlite3_free(azPk[i]);
+    sqlite3_free(azPk);
+    return rc;
+  }
+
+  pCols = sqlite3_str_new(0);
+  for(i=0; i<nPk; i++){
+    if( !azPk[i] ){
+      sqlite3_free(sqlite3_str_finish(pCols));
+      for(i=0; i<nPk; i++) sqlite3_free(azPk[i]);
+      sqlite3_free(azPk);
+      return SQLITE_CORRUPT;
+    }
+    if( i>0 ) sqlite3_str_appendall(pCols, ", ");
+    sqlite3_str_appendf(pCols, "\"%w\"", azPk[i]);
+  }
+
+  pPk->nPk = nPk;
+  pPk->azPk = azPk;
+  pPk->zPkCols = sqlite3_str_finish(pCols);
+  if( !pPk->zPkCols ){
+    freeMergePkInfo(pPk);
+    return SQLITE_NOMEM;
+  }
+  return SQLITE_OK;
+}
+
+typedef struct MergeFieldValue MergeFieldValue;
+struct MergeFieldValue {
+  int eType;
+  i64 i;
+  double r;
+  const void *p;
+  int n;
+};
+
+static u32 mergeSerialType(const MergeFieldValue *pMem, u32 *pLen){
+  if( pMem->eType == SQLITE_NULL ){ *pLen = 0; return 0; }
+  if( pMem->eType == SQLITE_INTEGER ){
+    i64 v = pMem->i;
+    if( v==0 ){ *pLen = 0; return 8; }
+    if( v==1 ){ *pLen = 0; return 9; }
+    if( v>=-128 && v<=127 ){ *pLen = 1; return 1; }
+    if( v>=-32768 && v<=32767 ){ *pLen = 2; return 2; }
+    if( v>=-8388608 && v<=8388607 ){ *pLen = 3; return 3; }
+    if( v>=-2147483648LL && v<=2147483647LL ){ *pLen = 4; return 4; }
+    if( v>=-140737488355328LL && v<=140737488355327LL ){ *pLen = 6; return 5; }
+    *pLen = 8; return 6;
+  }
+  if( pMem->eType == SQLITE_FLOAT ){ *pLen = 8; return 7; }
+  if( pMem->eType == SQLITE_TEXT ){
+    *pLen = (u32)pMem->n;
+    return (u32)(pMem->n * 2 + 13);
+  }
+  if( pMem->eType == SQLITE_BLOB ){
+    *pLen = (u32)pMem->n;
+    return (u32)(pMem->n * 2 + 12);
+  }
+  *pLen = 0;
+  return 0;
+}
+
+static void mergeWriteIntBe(u8 *pOut, i64 v, int nByte){
+  int i;
+  for(i=nByte-1; i>=0; i--){
+    pOut[i] = (u8)(v & 0xFF);
+    v >>= 8;
+  }
+}
+
+static void mergeSerialPut(u8 *pOut, const MergeFieldValue *pMem, u32 serialType){
+  switch( serialType ){
+    case 0:
+    case 8:
+    case 9:
+      return;
+    case 1: mergeWriteIntBe(pOut, pMem->i, 1); return;
+    case 2: mergeWriteIntBe(pOut, pMem->i, 2); return;
+    case 3: mergeWriteIntBe(pOut, pMem->i, 3); return;
+    case 4: mergeWriteIntBe(pOut, pMem->i, 4); return;
+    case 5: mergeWriteIntBe(pOut, pMem->i, 6); return;
+    case 6: mergeWriteIntBe(pOut, pMem->i, 8); return;
+    case 7: {
+      sqlite3_uint64 u;
+      memcpy(&u, &pMem->r, 8);
+      mergeWriteIntBe(pOut, (i64)u, 8);
+      return;
+    }
+    default:
+      if( serialType>=12 ){
+        memcpy(pOut, pMem->p, (size_t)pMem->n);
+      }
+      return;
+  }
+}
+
+static u8 *buildRecordFromStmtCols(
+  sqlite3_stmt *pStmt,
+  int iStart,
+  int nField,
+  int *pnOut
+){
+  MergeFieldValue *aMem = 0;
+  u32 *aType = 0;
+  u32 *aLen = 0;
+  u8 *pOut = 0;
+  int hdrSize = 0, bodySize = 0, i, pos;
+  u8 *pHdr, *pBody;
+
+  *pnOut = 0;
+  if( nField<=0 ) return 0;
+
+  aMem = sqlite3_malloc64((sqlite3_int64)nField * sizeof(MergeFieldValue));
+  aType = sqlite3_malloc64((sqlite3_int64)nField * sizeof(u32));
+  aLen = sqlite3_malloc64((sqlite3_int64)nField * sizeof(u32));
+  if( !aMem || !aType || !aLen ){
+    sqlite3_free(aMem); sqlite3_free(aType); sqlite3_free(aLen);
+    return 0;
+  }
+  memset(aMem, 0, (size_t)nField * sizeof(MergeFieldValue));
+
+  for(i=0; i<nField; i++){
+    int iCol = iStart + i;
+    int eType = sqlite3_column_type(pStmt, iCol);
+    aMem[i].eType = eType;
+    switch( eType ){
+      case SQLITE_INTEGER:
+        aMem[i].i = sqlite3_column_int64(pStmt, iCol);
+        break;
+      case SQLITE_FLOAT:
+        aMem[i].r = sqlite3_column_double(pStmt, iCol);
+        break;
+      case SQLITE_BLOB:
+        aMem[i].n = sqlite3_column_bytes(pStmt, iCol);
+        aMem[i].p = sqlite3_column_blob(pStmt, iCol);
+        break;
+      case SQLITE_TEXT:
+        aMem[i].p = sqlite3_column_text(pStmt, iCol);
+        aMem[i].n = sqlite3_column_bytes(pStmt, iCol);
+        break;
+      case SQLITE_NULL:
+      default:
+        break;
+    }
+    aType[i] = mergeSerialType(&aMem[i], &aLen[i]);
+    hdrSize += sqlite3VarintLen(aType[i]);
+    bodySize += (int)aLen[i];
+  }
+  hdrSize += sqlite3VarintLen(hdrSize);
+
+  pOut = sqlite3_malloc(hdrSize + bodySize);
+  if( !pOut ){
+    sqlite3_free(aMem); sqlite3_free(aType); sqlite3_free(aLen);
+    return 0;
+  }
+
+  pos = sqlite3PutVarint(pOut, hdrSize);
+  pHdr = pOut + pos;
+  pBody = pOut + hdrSize;
+  for(i=0; i<nField; i++){
+    pHdr += sqlite3PutVarint(pHdr, aType[i]);
+    if( aLen[i]>0 ){
+      mergeSerialPut(pBody, &aMem[i], aType[i]);
+      pBody += aLen[i];
+    }
+  }
+
+  *pnOut = hdrSize + bodySize;
+  sqlite3_free(aMem);
+  sqlite3_free(aType);
+  sqlite3_free(aLen);
+  return pOut;
+}
+
+static int recordPrefixEquals(
+  const u8 *pLeft, int nLeft,
+  const u8 *pRight, int nRight,
+  int nField
+){
+  DoltliteRecordInfo a, b;
+  int i;
+
+  if( nField<=0 ) return 1;
+  if( doltliteParseRecordStrict(pLeft, nLeft, &a)!=SQLITE_OK ) return 0;
+  if( doltliteParseRecordStrict(pRight, nRight, &b)!=SQLITE_OK ) return 0;
+  if( a.nField < nField || b.nField < nField ) return 0;
+
+  for(i=0; i<nField; i++){
+    int nA = dlSerialTypeLen((u64)a.aType[i]);
+    int nB = dlSerialTypeLen((u64)b.aType[i]);
+    if( a.aType[i]!=b.aType[i] ) return 0;
+    if( nA!=nB ) return 0;
+    if( nA>0 && memcmp(pLeft + a.aOffset[i], pRight + b.aOffset[i], (size_t)nA)!=0 ){
+      return 0;
+    }
+  }
+  return 1;
+}
+
+static int fetchRowByPkRecord(
+  ChunkStore *cs,
+  ProllyCache *pCache,
+  const ProllyHash *pRoot,
+  u8 flags,
+  const u8 *pPkRec, int nPkRec,
+  int nPkField,
+  u8 **ppKey, int *pnKey,
+  u8 **ppVal, int *pnVal
+){
+  ProllyCursor cur;
+  int rc, res;
+
+  *ppKey = 0; *pnKey = 0;
+  *ppVal = 0; *pnVal = 0;
+  if( prollyHashIsEmpty(pRoot) ) return SQLITE_NOTFOUND;
+
+  prollyCursorInit(&cur, cs, pCache, pRoot, flags);
+  rc = prollyCursorFirst(&cur, &res);
+  if( rc!=SQLITE_OK ){
+    prollyCursorClose(&cur);
+    return rc;
+  }
+  while( res==0 && prollyCursorIsValid(&cur) ){
+    const u8 *pVal = 0;
+    int nVal = 0;
+    prollyCursorValue(&cur, &pVal, &nVal);
+    if( pVal && recordPrefixEquals(pVal, nVal, pPkRec, nPkRec, nPkField) ){
+      rc = copyCursorRow(&cur, ppKey, pnKey, ppVal, pnVal);
+      prollyCursorClose(&cur);
+      return rc;
+    }
+    rc = prollyCursorNext(&cur);
+    if( rc!=SQLITE_OK ){
+      prollyCursorClose(&cur);
+      return rc;
+    }
+  }
+  prollyCursorClose(&cur);
+  return SQLITE_NOTFOUND;
 }
 
 /* Build the violation_info JSON string for one FK orphan. The
@@ -242,6 +613,39 @@ static int fetchAncestorRowByName(
   return rc;
 }
 
+static int fetchAncestorRowByKey(
+  sqlite3 *db,
+  struct TableEntry *aAnc, int nAnc,
+  const char *zTable,
+  const u8 *pKey, int nKey,
+  u8 **ppAncVal, int *pnAncVal
+){
+  ChunkStore *cs;
+  ProllyCache *pCache;
+  struct TableEntry *pTE;
+  u8 *pAncKey = 0;
+  int nAncKey = 0;
+  int rc;
+
+  *ppAncVal = 0;
+  *pnAncVal = 0;
+
+  if( !aAnc || nAnc==0 ) return SQLITE_NOTFOUND;
+
+  cs = doltliteGetChunkStore(db);
+  pCache = doltliteGetCache(db);
+  if( !cs || !pCache ) return SQLITE_ERROR;
+
+  pTE = doltliteFindTableByName(aAnc, nAnc, zTable);
+  if( !pTE ) return SQLITE_NOTFOUND;
+  if( pTE->flags & PROLLY_NODE_INTKEY ) return SQLITE_NOTFOUND;
+
+  rc = fetchRowByBlobKey(cs, pCache, &pTE->root, pTE->flags, pKey, nKey,
+                         &pAncKey, &nAncKey, ppAncVal, pnAncVal);
+  sqlite3_free(pAncKey);
+  return rc;
+}
+
 /* Decide whether a candidate violation is pre-existing: the row
 ** exists in the ancestor catalog at the same rowid with byte-for-
 ** byte identical value payload. Returns 1 if pre-existing (the
@@ -353,6 +757,39 @@ static int fetchOrphanRow(
                          ppKey, pnKey, ppVal, pnVal);
 }
 
+static int fetchRowByPkFromTable(
+  sqlite3 *db,
+  const char *zTable,
+  const u8 *pPkRec, int nPkRec,
+  int nPkField,
+  u8 **ppKey, int *pnKey,
+  u8 **ppVal, int *pnVal
+){
+  ChunkStore *cs;
+  ProllyCache *pCache;
+  ProllyHash root;
+  u8 flags = 0;
+  Pgno iTable;
+  int rc;
+
+  *ppKey = 0; *pnKey = 0;
+  *ppVal = 0; *pnVal = 0;
+
+  cs = doltliteGetChunkStore(db);
+  pCache = doltliteGetCache(db);
+  if( !cs || !pCache ) return SQLITE_ERROR;
+
+  rc = doltliteResolveTableName(db, zTable, &iTable);
+  if( rc != SQLITE_OK ) return rc;
+
+  rc = doltliteGetSessionTableRoot(db, iTable, &root, &flags);
+  if( rc != SQLITE_OK ) return rc;
+  if( flags & PROLLY_NODE_INTKEY ) return SQLITE_NOTFOUND;
+
+  return fetchRowByPkRecord(cs, pCache, &root, flags, pPkRec, nPkRec, nPkField,
+                            ppKey, pnKey, ppVal, pnVal);
+}
+
 /* Walk every row in zTable and look for duplicate values on the
 ** given UNIQUE index columns. When a duplicate group is found,
 ** the row with the lowest rowid is kept (treated as the "main
@@ -453,19 +890,128 @@ static int detectUniqueViolationsForIndex(
           db, zTable, DOLTLITE_CV_UNIQUE_INDEX,
           rowid, pKey, nKey, pVal, nVal, zInfo);
       sqlite3_free(zInfo);
-      sqlite3_free(pKey);
-      sqlite3_free(pVal);
       if( appendRc != SQLITE_OK ){ rc = appendRc; break; }
 
       /* Evict via doltliteApplyRawRowMutation — goes straight
       ** through the prolly layer, unlike SQL DELETE which hits
       ** the mid-merge btree state and returns SQLITE_CORRUPT. */
       rc = doltliteApplyRawRowMutation(db, zTable, pKey, nKey, rowid, 0, 0);
+      sqlite3_free(pKey);
+      sqlite3_free(pVal);
       if( rc != SQLITE_OK ) break;
 
       if( pnFound ) (*pnFound)++;
     }
   }
+  sqlite3_free(zWinnerKey);
+  if( rc == SQLITE_DONE ) rc = SQLITE_OK;
+  sqlite3_finalize(pScan);
+  return rc;
+}
+
+static int detectUniqueViolationsForIndexWithoutRowid(
+  sqlite3 *db,
+  struct TableEntry *aAnc, int nAnc,
+  const char *zTable,
+  const char *zIndexName,
+  const char *zCols,
+  const MergePkInfo *pPk,
+  int *pnFound
+){
+  sqlite3_stmt *pScan = 0;
+  sqlite3_str *pSql = 0;
+  char *zQuery = 0;
+  char *zWinnerKey = 0;
+  int rc;
+
+  pSql = sqlite3_str_new(0);
+  sqlite3_str_appendf(pSql,
+      "SELECT %s, %s FROM main.\"%w\" NOT INDEXED ORDER BY %s, %s",
+      zCols, pPk->zPkCols, zTable, zCols, pPk->zPkCols);
+  zQuery = sqlite3_str_finish(pSql);
+  if( !zQuery ) return SQLITE_NOMEM;
+  rc = sqlite3_prepare_v2(db, zQuery, -1, &pScan, 0);
+  sqlite3_free(zQuery);
+  if( rc!=SQLITE_OK ) return rc;
+
+  while( (rc = sqlite3_step(pScan)) == SQLITE_ROW ){
+    int nc = sqlite3_column_count(pScan);
+    int nDupKeyCol = nc - pPk->nPk;
+    sqlite3_str *pS = sqlite3_str_new(0);
+    char *zRowKey = 0;
+    int i, isDup;
+
+    for(i=0; i<nDupKeyCol; i++){
+      const char *zV = (const char*)sqlite3_column_text(pScan, i);
+      int type = sqlite3_column_type(pScan, i);
+      if( type == SQLITE_NULL ){
+        sqlite3_str_appendf(pS, "%sNULL", i>0?"|":"");
+      }else{
+        sqlite3_str_appendf(pS, "%s%Q", i>0?"|":"", zV ? zV : "");
+      }
+    }
+    zRowKey = sqlite3_str_finish(pS);
+    if( !zRowKey ){ rc = SQLITE_NOMEM; break; }
+
+    isDup = zWinnerKey && strcmp(zWinnerKey, zRowKey)==0;
+    if( !isDup ){
+      sqlite3_free(zWinnerKey);
+      zWinnerKey = zRowKey;
+      continue;
+    }
+    sqlite3_free(zRowKey);
+
+    {
+      u8 *pPkRec = 0; int nPkRec = 0;
+      u8 *pKey = 0; int nKey = 0;
+      u8 *pVal = 0; int nVal = 0;
+      char *zInfo;
+      int appendRc;
+
+      pPkRec = buildRecordFromStmtCols(pScan, nDupKeyCol, pPk->nPk, &nPkRec);
+      if( !pPkRec ){ rc = SQLITE_NOMEM; break; }
+      rc = fetchRowByPkFromTable(db, zTable, pPkRec, nPkRec, pPk->nPk,
+                                 &pKey, &nKey, &pVal, &nVal);
+      sqlite3_free(pPkRec);
+      if( rc == SQLITE_NOTFOUND ){ rc = SQLITE_OK; continue; }
+      if( rc != SQLITE_OK ) break;
+
+      if( aAnc ){
+        u8 *pAncVal = 0; int nAncVal = 0;
+        int ancRc = fetchAncestorRowByKey(db, aAnc, nAnc, zTable,
+                                          pKey, nKey, &pAncVal, &nAncVal);
+        int preExisting = (ancRc==SQLITE_OK)
+            && isRowPreExisting(pVal, nVal, pAncVal, nAncVal);
+        sqlite3_free(pAncVal);
+        if( preExisting ){
+          sqlite3_free(pKey);
+          sqlite3_free(pVal);
+          continue;
+        }
+      }
+
+      zInfo = sqlite3_mprintf(
+          "{\"Columns\": [%s], \"Name\": \"%w\"}",
+          zCols, zIndexName);
+      appendRc = doltliteAppendConstraintViolation(
+          db, zTable, DOLTLITE_CV_UNIQUE_INDEX,
+          0, pKey, nKey, pVal, nVal, zInfo);
+      sqlite3_free(zInfo);
+      if( appendRc != SQLITE_OK ){
+        sqlite3_free(pKey);
+        sqlite3_free(pVal);
+        rc = appendRc;
+        break;
+      }
+
+      rc = doltliteApplyRawRowMutation(db, zTable, pKey, nKey, 0, 0, 0);
+      sqlite3_free(pKey);
+      sqlite3_free(pVal);
+      if( rc != SQLITE_OK ) break;
+      if( pnFound ) (*pnFound)++;
+    }
+  }
+
   sqlite3_free(zWinnerKey);
   if( rc == SQLITE_DONE ) rc = SQLITE_OK;
   sqlite3_finalize(pScan);
@@ -512,16 +1058,31 @@ int doltliteDetectMergeUniqueViolations(
     char *zTable;
     sqlite3_stmt *pIdxList = 0;
     char *zIdxQ;
+    int hasRowid = 1;
+    MergePkInfo pkInfo;
 
     if( !zTableRaw ) continue;
     zTable = sqlite3_mprintf("%s", zTableRaw);
     if( !zTable ){ rc = SQLITE_NOMEM; break; }
+    memset(&pkInfo, 0, sizeof(pkInfo));
+    hasRowid = tableHasRowid(db, zTable);
+    if( !hasRowid ){
+      rc = loadMergePkInfo(db, zTable, &pkInfo);
+      if( rc != SQLITE_OK ){
+        sqlite3_free(zTable);
+        break;
+      }
+    }
 
     zIdxQ = sqlite3_mprintf("PRAGMA main.index_list(%Q)", zTable);
     if( !zIdxQ ){ sqlite3_free(zTable); rc = SQLITE_NOMEM; break; }
     rc = sqlite3_prepare_v2(db, zIdxQ, -1, &pIdxList, 0);
     sqlite3_free(zIdxQ);
-    if( rc != SQLITE_OK ){ sqlite3_free(zTable); break; }
+    if( rc != SQLITE_OK ){
+      freeMergePkInfo(&pkInfo);
+      sqlite3_free(zTable);
+      break;
+    }
 
     while( sqlite3_step(pIdxList) == SQLITE_ROW ){
       int unique = sqlite3_column_int(pIdxList, 2);
@@ -546,17 +1107,6 @@ int doltliteDetectMergeUniqueViolations(
       zOrigin = (const char*)sqlite3_column_text(pIdxList, 3);
       if( zOrigin && strcmp(zOrigin, "pk")==0 ) continue;
 
-      /* We've found a non-PK unique index to walk. That means we
-      ** actually need a way to identify violating rows by rowid —
-      ** which fails on WITHOUT ROWID / non-INTEGER-PK tables.
-      ** Refuse loudly rather than silently walking garbage.
-      ** (Tables with only the PK autoindex don't trip this
-      ** branch and still merge cleanly on WITHOUT ROWID.) */
-      if( !tableHasRowid(db, zTable) ){
-        rc = refuseWithoutRowid(db, pzErrMsg, zTable, "unique index");
-        break;
-      }
-
       zIdx = sqlite3_mprintf("%s", zIdxRaw);
       if( !zIdx ) break;
       zColsQ = sqlite3_mprintf("PRAGMA main.index_xinfo(%Q)", zIdx);
@@ -568,8 +1118,9 @@ int doltliteDetectMergeUniqueViolations(
       pColList = sqlite3_str_new(0);
       while( sqlite3_step(pCols) == SQLITE_ROW ){
         int cno = sqlite3_column_int(pCols, 1);
+        int isKey = sqlite3_column_int(pCols, 5);
         const char *zCol = (const char*)sqlite3_column_text(pCols, 2);
-        if( cno < 0 || !zCol ) continue;
+        if( cno < 0 || !zCol || !isKey ) continue;
         if( sqlite3_str_length(pColList) > 0 ){
           sqlite3_str_appendall(pColList, ", ");
         }
@@ -578,9 +1129,14 @@ int doltliteDetectMergeUniqueViolations(
       sqlite3_finalize(pCols);
       zColList = sqlite3_str_finish(pColList);
       if( zColList && *zColList ){
-        rc = detectUniqueViolationsForIndex(db, aAnc, nAnc, zTable,
-                                             zIdx, zColList, pzErrMsg,
-                                             pnFound);
+        if( hasRowid ){
+          rc = detectUniqueViolationsForIndex(db, aAnc, nAnc, zTable,
+                                               zIdx, zColList, pzErrMsg,
+                                               pnFound);
+        }else{
+          rc = detectUniqueViolationsForIndexWithoutRowid(
+              db, aAnc, nAnc, zTable, zIdx, zColList, &pkInfo, pnFound);
+        }
       }
       sqlite3_free(zColList);
       sqlite3_free(zIdx);
@@ -588,6 +1144,7 @@ int doltliteDetectMergeUniqueViolations(
     }
 
     sqlite3_finalize(pIdxList);
+    freeMergePkInfo(&pkInfo);
     sqlite3_free(zTable);
     if( rc != SQLITE_OK ) break;
   }
@@ -749,6 +1306,8 @@ int doltliteDetectMergeCheckViolations(
     char *zTable;
     char *zSql;
     int offset = 0;
+    int hasRowid = 1;
+    MergePkInfo pkInfo;
 
     if( !zTableRaw || !zSqlRaw ) continue;
     zTable = sqlite3_mprintf("%s", zTableRaw);
@@ -759,20 +1318,11 @@ int doltliteDetectMergeCheckViolations(
       rc = SQLITE_NOMEM;
       break;
     }
-
-    /* Refuse WITHOUT ROWID tables that carry a CHECK clause.
-    ** Tables with no CHECK expressions pass through unharmed
-    ** because nextCheckClause returns 0 on the first call and
-    ** the main loop exits immediately. */
-    {
-      char *zPeekExpr = 0;
-      char *zPeekName = 0;
-      int peekOffset = 0;
-      int peekRc = nextCheckClause(zSql, &peekOffset, &zPeekExpr, &zPeekName);
-      sqlite3_free(zPeekExpr);
-      sqlite3_free(zPeekName);
-      if( peekRc > 0 && !tableHasRowid(db, zTable) ){
-        rc = refuseWithoutRowid(db, pzErrMsg, zTable, "check constraint");
+    memset(&pkInfo, 0, sizeof(pkInfo));
+    hasRowid = tableHasRowid(db, zTable);
+    if( !hasRowid ){
+      rc = loadMergePkInfo(db, zTable, &pkInfo);
+      if( rc != SQLITE_OK ){
         sqlite3_free(zTable);
         sqlite3_free(zSql);
         break;
@@ -793,9 +1343,15 @@ int doltliteDetectMergeCheckViolations(
         break;
       }
 
-      zQuery = sqlite3_mprintf(
-          "SELECT rowid FROM main.\"%w\" NOT INDEXED WHERE NOT (%s)",
-          zTable, zExpr);
+      if( hasRowid ){
+        zQuery = sqlite3_mprintf(
+            "SELECT rowid FROM main.\"%w\" NOT INDEXED WHERE NOT (%s)",
+            zTable, zExpr);
+      }else{
+        zQuery = sqlite3_mprintf(
+            "SELECT %s FROM main.\"%w\" NOT INDEXED WHERE NOT (%s)",
+            pkInfo.zPkCols, zTable, zExpr);
+      }
       if( !zQuery ){
         sqlite3_free(zExpr);
         sqlite3_free(zCkName);
@@ -811,13 +1367,23 @@ int doltliteDetectMergeCheckViolations(
       }
 
       while( sqlite3_step(pQ) == SQLITE_ROW ){
-        sqlite3_int64 rowid = sqlite3_column_int64(pQ, 0);
         u8 *pKey = 0; int nKey = 0;
         u8 *pVal = 0; int nVal = 0;
         char *zInfo;
         int appendRc;
+        i64 intKey = 0;
 
-        rc = fetchOrphanRow(db, zTable, rowid, &pKey, &nKey, &pVal, &nVal);
+        if( hasRowid ){
+          intKey = sqlite3_column_int64(pQ, 0);
+          rc = fetchOrphanRow(db, zTable, intKey, &pKey, &nKey, &pVal, &nVal);
+        }else{
+          u8 *pPkRec = 0; int nPkRec = 0;
+          pPkRec = buildRecordFromStmtCols(pQ, 0, pkInfo.nPk, &nPkRec);
+          if( !pPkRec ){ rc = SQLITE_NOMEM; break; }
+          rc = fetchRowByPkFromTable(db, zTable, pPkRec, nPkRec, pkInfo.nPk,
+                                     &pKey, &nKey, &pVal, &nVal);
+          sqlite3_free(pPkRec);
+        }
         if( rc == SQLITE_NOTFOUND ){ rc = SQLITE_OK; continue; }
         if( rc != SQLITE_OK ){
           sqlite3_free(pKey);
@@ -827,8 +1393,11 @@ int doltliteDetectMergeCheckViolations(
 
         if( haveAnc ){
           u8 *pAncVal = 0; int nAncVal = 0;
-          int ancRc = fetchAncestorRowByName(db, aAnc, nAnc, zTable,
-                                              rowid, &pAncVal, &nAncVal);
+          int ancRc = hasRowid
+              ? fetchAncestorRowByName(db, aAnc, nAnc, zTable,
+                                       intKey, &pAncVal, &nAncVal)
+              : fetchAncestorRowByKey(db, aAnc, nAnc, zTable,
+                                      pKey, nKey, &pAncVal, &nAncVal);
           int preExisting = (ancRc==SQLITE_OK)
               && isRowPreExisting(pVal, nVal, pAncVal, nAncVal);
           sqlite3_free(pAncVal);
@@ -844,7 +1413,7 @@ int doltliteDetectMergeCheckViolations(
             zCkName ? zCkName : "", zExpr);
         appendRc = doltliteAppendConstraintViolation(
             db, zTable, DOLTLITE_CV_CHECK_CONSTRAINT,
-            rowid, pKey, nKey, pVal, nVal, zInfo);
+            intKey, pKey, nKey, pVal, nVal, zInfo);
         sqlite3_free(zInfo);
         sqlite3_free(pKey);
         sqlite3_free(pVal);
@@ -859,6 +1428,7 @@ int doltliteDetectMergeCheckViolations(
 
     sqlite3_free(zTable);
     sqlite3_free(zSql);
+    freeMergePkInfo(&pkInfo);
     if( rc != SQLITE_OK ) break;
   }
   if( rc == SQLITE_OK && stepRc != SQLITE_DONE && stepRc != SQLITE_ROW ){
@@ -866,6 +1436,113 @@ int doltliteDetectMergeCheckViolations(
   }
   sqlite3_finalize(pTbls);
   if( haveAnc ) doltliteFreeCatalog(aAnc, nAnc);
+  return rc;
+}
+
+static void freeStringArray(char **az, int n){
+  int i;
+  if( !az ) return;
+  for(i=0; i<n; i++) sqlite3_free(az[i]);
+  sqlite3_free(az);
+}
+
+static int detectFkViolationsForSpec(
+  sqlite3 *db,
+  struct TableEntry *aAnc, int nAnc,
+  const char *zChildTable,
+  int hasRowid,
+  const MergePkInfo *pChildPk,
+  const char *zParentTable,
+  int fkid,
+  char **azFrom,
+  char **azTo,
+  int nCol,
+  int *pnFound
+){
+  sqlite3_str *pSql = 0;
+  char *zQuery = 0;
+  sqlite3_stmt *pStmt = 0;
+  int rc;
+
+  pSql = sqlite3_str_new(0);
+  sqlite3_str_appendf(pSql, "SELECT %s FROM main.\"%w\" AS c WHERE ",
+      hasRowid ? "rowid" : pChildPk->zPkCols, zChildTable);
+  for(int i=0; i<nCol; i++){
+    if( i>0 ) sqlite3_str_appendall(pSql, " AND ");
+    sqlite3_str_appendf(pSql, "c.\"%w\" IS NOT NULL", azFrom[i]);
+  }
+  sqlite3_str_appendf(pSql, " AND NOT EXISTS (SELECT 1 FROM main.\"%w\" AS p WHERE ",
+      zParentTable);
+  for(int i=0; i<nCol; i++){
+    if( i>0 ) sqlite3_str_appendall(pSql, " AND ");
+    sqlite3_str_appendf(pSql, "p.\"%w\" = c.\"%w\"", azTo[i], azFrom[i]);
+  }
+  sqlite3_str_appendall(pSql, ")");
+  zQuery = sqlite3_str_finish(pSql);
+  if( !zQuery ) return SQLITE_NOMEM;
+
+  rc = sqlite3_prepare_v2(db, zQuery, -1, &pStmt, 0);
+  sqlite3_free(zQuery);
+  if( rc!=SQLITE_OK ) return rc;
+
+  while( sqlite3_step(pStmt)==SQLITE_ROW ){
+    u8 *pKey = 0; int nKey = 0;
+    u8 *pVal = 0; int nVal = 0;
+    i64 intKey = 0;
+    char *zInfo;
+    int appendRc;
+
+    if( hasRowid ){
+      intKey = sqlite3_column_int64(pStmt, 0);
+      rc = fetchOrphanRow(db, zChildTable, intKey, &pKey, &nKey, &pVal, &nVal);
+    }else{
+      u8 *pPkRec = 0; int nPkRec = 0;
+      pPkRec = buildRecordFromStmtCols(pStmt, 0, pChildPk->nPk, &nPkRec);
+      if( !pPkRec ){ rc = SQLITE_NOMEM; break; }
+      rc = fetchRowByPkFromTable(db, zChildTable, pPkRec, nPkRec, pChildPk->nPk,
+                                 &pKey, &nKey, &pVal, &nVal);
+      sqlite3_free(pPkRec);
+    }
+    if( rc == SQLITE_NOTFOUND ){ rc = SQLITE_OK; continue; }
+    if( rc != SQLITE_OK ){
+      sqlite3_free(pKey);
+      sqlite3_free(pVal);
+      break;
+    }
+
+    if( aAnc ){
+      u8 *pAncVal = 0; int nAncVal = 0;
+      int ancRc = hasRowid
+          ? fetchAncestorRowByName(db, aAnc, nAnc, zChildTable,
+                                   intKey, &pAncVal, &nAncVal)
+          : fetchAncestorRowByKey(db, aAnc, nAnc, zChildTable,
+                                  pKey, nKey, &pAncVal, &nAncVal);
+      int preExisting = (ancRc==SQLITE_OK)
+          && isRowPreExisting(pVal, nVal, pAncVal, nAncVal);
+      sqlite3_free(pAncVal);
+      if( preExisting ){
+        sqlite3_free(pKey);
+        sqlite3_free(pVal);
+        continue;
+      }
+    }
+
+    zInfo = buildFkViolationInfo(db, zChildTable, fkid);
+    appendRc = doltliteAppendConstraintViolation(
+        db, zChildTable, DOLTLITE_CV_FOREIGN_KEY,
+        intKey, pKey, nKey, pVal, nVal, zInfo);
+    sqlite3_free(zInfo);
+    sqlite3_free(pKey);
+    sqlite3_free(pVal);
+    if( appendRc != SQLITE_OK ){
+      rc = appendRc;
+      break;
+    }
+    if( pnFound ) (*pnFound)++;
+  }
+
+  if( rc==SQLITE_DONE ) rc = SQLITE_OK;
+  sqlite3_finalize(pStmt);
   return rc;
 }
 
@@ -890,13 +1567,16 @@ int doltliteDetectMergeFkViolations(
   char **pzErrMsg,
   int *pnFound
 ){
-  sqlite3_stmt *pStmt = 0;
+  sqlite3_stmt *pTbls = 0;
   struct TableEntry *aAnc = 0;
   int nAnc = 0;
   Pgno iNextAnc = 0;
   int haveAnc = 0;
   int rc;
   int nFound = 0;
+  int stepRc;
+
+  (void)pzErrMsg;
 
   if( pnFound ) *pnFound = 0;
 
@@ -906,86 +1586,160 @@ int doltliteDetectMergeFkViolations(
     }
   }
 
-  rc = sqlite3_prepare_v2(db, "PRAGMA main.foreign_key_check", -1, &pStmt, 0);
+  rc = sqlite3_prepare_v2(db,
+      "SELECT name FROM main.sqlite_master WHERE type='table' "
+      "AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'dolt_%'",
+      -1, &pTbls, 0);
   if( rc != SQLITE_OK ){
     if( haveAnc ) doltliteFreeCatalog(aAnc, nAnc);
     return rc;
   }
 
-  while( (rc = sqlite3_step(pStmt)) == SQLITE_ROW ){
-    const char *zTable = (const char*)sqlite3_column_text(pStmt, 0);
-    i64 rowid;
-    int fkid;
-    u8 *pKey = 0; int nKey = 0;
-    u8 *pVal = 0; int nVal = 0;
-    char *zInfo;
-    int appendRc;
+  while( (stepRc = sqlite3_step(pTbls)) == SQLITE_ROW ){
+    const char *zTableRaw = (const char*)sqlite3_column_text(pTbls, 0);
+    char *zTable = 0;
+    char *zFkQ = 0;
+    sqlite3_stmt *pFk = 0;
+    int hasRowid = 1;
+    MergePkInfo childPk;
+    int curId = -1;
+    char *zParent = 0;
+    char **azFrom = 0;
+    char **azTo = 0;
+    int nCol = 0;
+    int nAlloc = 0;
 
-    if( !zTable ) continue;
-    /* PRAGMA foreign_key_check reports rowid=NULL for WITHOUT
-    ** ROWID child tables, which means we lose the ability to
-    ** identify and fetch the specific orphan row via the
-    ** existing rowid-keyed machinery. Fail the detection pass
-    ** rather than silently skipping — a passing merge that
-    ** leaves an FK orphan in place is worse than a merge that
-    ** refuses to run. */
-    if( sqlite3_column_type(pStmt, 1) == SQLITE_NULL ){
-      rc = refuseWithoutRowid(db, pzErrMsg, zTable, "foreign key");
-      break;
-    }
-    rowid = sqlite3_column_int64(pStmt, 1);
-    fkid  = sqlite3_column_int(pStmt, 3);
-
-    /* zTable pointer is owned by the statement cursor and goes
-    ** stale on the next step — dup it so we can close the
-    ** pragma statement before running our own prepared queries. */
-    {
-      char *zTableCopy = sqlite3_mprintf("%s", zTable);
-      if( !zTableCopy ){ rc = SQLITE_NOMEM; break; }
-
-      rc = fetchOrphanRow(db, zTableCopy, rowid, &pKey, &nKey, &pVal, &nVal);
-      if( rc == SQLITE_NOTFOUND ){
-        /* Row may have been deleted between PRAGMA and fetch —
-        ** treat as no longer a violation and skip. */
-        sqlite3_free(zTableCopy);
-        rc = SQLITE_OK;
-        continue;
-      }
+    if( !zTableRaw ) continue;
+    zTable = sqlite3_mprintf("%s", zTableRaw);
+    if( !zTable ){ rc = SQLITE_NOMEM; break; }
+    memset(&childPk, 0, sizeof(childPk));
+    hasRowid = tableHasRowid(db, zTable);
+    if( !hasRowid ){
+      rc = loadMergePkInfo(db, zTable, &childPk);
       if( rc != SQLITE_OK ){
-        sqlite3_free(zTableCopy);
+        sqlite3_free(zTable);
         break;
       }
+    }
 
-      if( haveAnc ){
-        u8 *pAncVal = 0; int nAncVal = 0;
-        int ancRc = fetchAncestorRowByName(db, aAnc, nAnc, zTableCopy,
-                                            rowid, &pAncVal, &nAncVal);
-        int preExisting = (ancRc==SQLITE_OK)
-            && isRowPreExisting(pVal, nVal, pAncVal, nAncVal);
-        sqlite3_free(pAncVal);
-        if( preExisting ){
-          sqlite3_free(pKey);
-          sqlite3_free(pVal);
-          sqlite3_free(zTableCopy);
-          continue;
+    zFkQ = sqlite3_mprintf("PRAGMA main.foreign_key_list(%Q)", zTable);
+    if( !zFkQ ){
+      freeMergePkInfo(&childPk);
+      sqlite3_free(zTable);
+      rc = SQLITE_NOMEM;
+      break;
+    }
+    rc = sqlite3_prepare_v2(db, zFkQ, -1, &pFk, 0);
+    sqlite3_free(zFkQ);
+    if( rc != SQLITE_OK ){
+      freeMergePkInfo(&childPk);
+      sqlite3_free(zTable);
+      break;
+    }
+
+    while( sqlite3_step(pFk) == SQLITE_ROW ){
+      int id = sqlite3_column_int(pFk, 0);
+      const char *zParentRaw = (const char*)sqlite3_column_text(pFk, 2);
+      const char *zFromRaw = (const char*)sqlite3_column_text(pFk, 3);
+      const char *zToRaw = (const char*)sqlite3_column_text(pFk, 4);
+
+      if( curId>=0 && id!=curId ){
+        int needParentPk = 0;
+        for(int i=0; i<nCol; i++) if( !azTo[i] ) needParentPk = 1;
+        if( needParentPk ){
+          MergePkInfo parentPk;
+          memset(&parentPk, 0, sizeof(parentPk));
+          rc = loadMergePkInfo(db, zParent, &parentPk);
+          if( rc == SQLITE_OK ){
+            for(int i=0; i<nCol; i++){
+              if( !azTo[i] && i < parentPk.nPk ){
+                azTo[i] = sqlite3_mprintf("%s", parentPk.azPk[i]);
+              }
+            }
+          }
+          freeMergePkInfo(&parentPk);
+          if( rc != SQLITE_OK ) break;
         }
+        rc = detectFkViolationsForSpec(db,
+            haveAnc ? aAnc : 0, haveAnc ? nAnc : 0,
+            zTable, hasRowid, &childPk, zParent, curId,
+            azFrom, azTo, nCol, &nFound);
+        freeStringArray(azFrom, nCol);
+        freeStringArray(azTo, nCol);
+        azFrom = 0; azTo = 0; nCol = 0; nAlloc = 0;
+        sqlite3_free(zParent); zParent = 0;
+        if( rc != SQLITE_OK ) break;
       }
 
-      zInfo = buildFkViolationInfo(db, zTableCopy, fkid);
-      appendRc = doltliteAppendConstraintViolation(
-          db, zTableCopy, DOLTLITE_CV_FOREIGN_KEY,
-          rowid, pKey, nKey, pVal, nVal, zInfo);
-      sqlite3_free(zInfo);
-      sqlite3_free(pKey);
-      sqlite3_free(pVal);
-      sqlite3_free(zTableCopy);
-      if( appendRc != SQLITE_OK ){ rc = appendRc; break; }
-      nFound++;
-    }
-  }
-  if( rc == SQLITE_DONE ) rc = SQLITE_OK;
+      if( curId != id ){
+        curId = id;
+        zParent = sqlite3_mprintf("%s", zParentRaw ? zParentRaw : "");
+        if( !zParent ){ rc = SQLITE_NOMEM; break; }
+      }
 
-  sqlite3_finalize(pStmt);
+      if( nCol >= nAlloc ){
+        int nNew = nAlloc ? nAlloc*2 : 4;
+        char **azFromNew = sqlite3_realloc64(azFrom, (sqlite3_int64)nNew * sizeof(char*));
+        char **azToNew = sqlite3_realloc64(azTo, (sqlite3_int64)nNew * sizeof(char*));
+        if( !azFromNew || !azToNew ){
+          sqlite3_free(azFromNew);
+          sqlite3_free(azToNew);
+          rc = SQLITE_NOMEM;
+          break;
+        }
+        azFrom = azFromNew;
+        azTo = azToNew;
+        nAlloc = nNew;
+      }
+      azFrom[nCol] = sqlite3_mprintf("%s", zFromRaw ? zFromRaw : "");
+      azTo[nCol] = zToRaw ? sqlite3_mprintf("%s", zToRaw) : 0;
+      if( !azFrom[nCol] || (zToRaw && !azTo[nCol]) ){
+        rc = SQLITE_NOMEM;
+        break;
+      }
+      nCol++;
+    }
+
+    if( rc==SQLITE_ROW || rc==SQLITE_DONE ){
+      rc = SQLITE_OK;
+    }
+    if( rc==SQLITE_OK && curId>=0 ){
+      int needParentPk = 0;
+      for(int i=0; i<nCol; i++) if( !azTo[i] ) needParentPk = 1;
+      if( needParentPk ){
+        MergePkInfo parentPk;
+        memset(&parentPk, 0, sizeof(parentPk));
+        rc = loadMergePkInfo(db, zParent, &parentPk);
+        if( rc == SQLITE_OK ){
+          for(int i=0; i<nCol; i++){
+            if( !azTo[i] && i < parentPk.nPk ){
+              azTo[i] = sqlite3_mprintf("%s", parentPk.azPk[i]);
+            }
+          }
+        }
+        freeMergePkInfo(&parentPk);
+      }
+      if( rc==SQLITE_OK ){
+        rc = detectFkViolationsForSpec(db,
+            haveAnc ? aAnc : 0, haveAnc ? nAnc : 0,
+            zTable, hasRowid, &childPk, zParent, curId,
+            azFrom, azTo, nCol, &nFound);
+      }
+    }
+
+    freeStringArray(azFrom, nCol);
+    freeStringArray(azTo, nCol);
+    sqlite3_free(zParent);
+    sqlite3_finalize(pFk);
+    freeMergePkInfo(&childPk);
+    sqlite3_free(zTable);
+    if( rc != SQLITE_OK ) break;
+  }
+
+  if( rc == SQLITE_OK && stepRc != SQLITE_DONE && stepRc != SQLITE_ROW ){
+    rc = stepRc;
+  }
+  sqlite3_finalize(pTbls);
   if( haveAnc ) doltliteFreeCatalog(aAnc, nAnc);
   if( pnFound ) *pnFound = nFound;
   return rc;

--- a/test/vc_oracle_fk_merge_test.sh
+++ b/test/vc_oracle_fk_merge_test.sh
@@ -517,21 +517,12 @@ fi
 
 echo ""
 
-# ── Scenario J: WITHOUT ROWID FK merge refused loudly ────
-#
-# Per #495: constraint-violation detection assumes every table
-# has a rowid and breaks silently on WITHOUT ROWID tables.
-# Until prolly-layer-level support lands, the walker refuses
-# the merge loudly with an actionable error instead of
-# silently committing over missed violations. This scenario
-# verifies that behavior: a merge that would produce an FK
-# orphan on a WITHOUT ROWID child table must fail with the
-# issue-495 error message, not silently commit.
-echo "--- J. WITHOUT ROWID FK merge is refused loudly ---"
+# ── Scenario J: WITHOUT ROWID FK violation works ─────────
+echo "--- J. WITHOUT ROWID FK merge records orphan violation ---"
 
 DB="$TMPROOT/without_rowid_fk.db"
 rm -f "$DB"
-cat <<'SQL' | dl_setup_capture "$DB" "without_rowid_fk"
+cat <<'SQL' | dl_setup "$DB" "without_rowid_fk"
 CREATE TABLE parent(pk INTEGER PRIMARY KEY, v1 INT, UNIQUE(v1));
 CREATE TABLE child(pk TEXT PRIMARY KEY, v1 INT, FOREIGN KEY(v1) REFERENCES parent(v1)) WITHOUT ROWID;
 INSERT INTO parent VALUES (1,1),(2,2);
@@ -547,13 +538,76 @@ SELECT dolt_commit('-Am','main_drop_parent');
 SELECT dolt_merge('feat');
 SQL
 
-if grep -q "WITHOUT ROWID" "$TMPROOT/without_rowid_fk.out" \
-                            "$TMPROOT/without_rowid_fk.err" 2>/dev/null; then
-  pass_name "without_rowid_fk_refused"
-else
-  fail_name "without_rowid_fk_refused"
-  echo "    (merge did not surface the WITHOUT ROWID refusal)"
-fi
+N=$(dl "$DB" "SELECT num_violations FROM dolt_constraint_violations WHERE \"table\"='child';" "without_rowid_fk_count")
+expect_eq "without_rowid_fk_summary_count" "1" "$N"
+
+TYPE=$(dl "$DB" "SELECT violation_type FROM dolt_constraint_violations_child WHERE pk='b';" "without_rowid_fk_type")
+expect_eq "without_rowid_fk_type" "foreign key" "$TYPE"
+
+ROW_PRESENT=$(dl "$DB" "SELECT count(*) FROM child WHERE pk='b';" "without_rowid_fk_row_present")
+expect_eq "without_rowid_fk_row_present" "1" "$ROW_PRESENT"
+
+echo ""
+
+# ── Scenario K: WITHOUT ROWID UNIQUE violation works ─────
+echo "--- K. WITHOUT ROWID UNIQUE merge records loser row ---"
+
+DB="$TMPROOT/without_rowid_unique.db"
+rm -f "$DB"
+cat <<'SQL' | dl_setup "$DB" "without_rowid_unique"
+CREATE TABLE t(pk TEXT PRIMARY KEY, v1 INT UNIQUE) WITHOUT ROWID;
+SELECT dolt_commit('-Am','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES ('feat',1);
+SELECT dolt_commit('-Am','feat_add');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES ('main',1);
+SELECT dolt_commit('-Am','main_add');
+SELECT dolt_merge('feat');
+SQL
+
+N=$(dl "$DB" "SELECT num_violations FROM dolt_constraint_violations WHERE \"table\"='t';" "without_rowid_unique_count")
+expect_eq "without_rowid_unique_summary_count" "1" "$N"
+
+TYPE=$(dl "$DB" "SELECT violation_type FROM dolt_constraint_violations_t;" "without_rowid_unique_type")
+expect_eq "without_rowid_unique_type" "unique index" "$TYPE"
+
+BASE_COUNT=$(dl "$DB" "SELECT count(*) FROM t;" "without_rowid_unique_base")
+expect_eq "without_rowid_unique_base_count" "1" "$BASE_COUNT"
+
+echo ""
+
+# ── Scenario L: WITHOUT ROWID CHECK violation works ──────
+echo "--- L. WITHOUT ROWID CHECK merge records violating row ---"
+
+DB="$TMPROOT/without_rowid_check.db"
+rm -f "$DB"
+cat <<'SQL' | dl_setup "$DB" "without_rowid_check"
+CREATE TABLE t(pk TEXT PRIMARY KEY, v1 INT) WITHOUT ROWID;
+INSERT INTO t VALUES ('a', 1);
+SELECT dolt_commit('-Am','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES ('b', -5);
+SELECT dolt_commit('-Am','feat_bad_row');
+SELECT dolt_checkout('main');
+CREATE TABLE t_new(pk TEXT PRIMARY KEY, v1 INT CHECK(v1 > 0)) WITHOUT ROWID;
+INSERT INTO t_new SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t_new RENAME TO t;
+SELECT dolt_commit('-Am','main_add_check');
+SELECT dolt_merge('feat');
+SQL
+
+N=$(dl "$DB" "SELECT num_violations FROM dolt_constraint_violations WHERE \"table\"='t';" "without_rowid_check_count")
+expect_eq "without_rowid_check_summary_count" "1" "$N"
+
+TYPE=$(dl "$DB" "SELECT violation_type FROM dolt_constraint_violations_t WHERE pk='b';" "without_rowid_check_type")
+expect_eq "without_rowid_check_type" "check constraint" "$TYPE"
+
+BASE_COUNT=$(dl "$DB" "SELECT count(*) FROM t WHERE pk='b' AND v1=-5;" "without_rowid_check_base")
+expect_eq "without_rowid_check_row_present" "1" "$BASE_COUNT"
 
 echo ""
 echo "======================================="


### PR DESCRIPTION
## Summary
- support merge-time FK, unique, and check constraint detection for WITHOUT ROWID tables
- switch merge walkers to identify offending rows by primary-key values/raw keys when rowid is unavailable
- add oracle coverage for WITHOUT ROWID FK, unique, and check merge violations

## Testing
- bash test/vc_oracle_fk_merge_test.sh ./build/doltlite
- cd build && bash ../test/doltlite_merge.sh
- bash test/vc_oracle_merge_test.sh ./build/doltlite dolt
