### PR TITLE
Fix conflict row deletes for non-integer keys

### DIFF
--- a/test/doltlite_conflict_rows.sh
+++ b/test/doltlite_conflict_rows.sh
@@ -310,6 +310,62 @@ run_test_match "flow_log" "SELECT message FROM dolt_log LIMIT 1;" "Merge" "$DB"
 rm -f "$DB"
 
 # ============================================================
+# Text PK conflicts delete by synthetic rowid
+# ============================================================
+
+DB=/tmp/test_cfrow_textpk_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id TEXT PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES('a','orig_a'),('b','orig_b');
+SELECT dolt_commit('-A','-m','init');
+SELECT dolt_branch('hf');
+SELECT dolt_checkout('hf');
+UPDATE t SET v='hf_a' WHERE id='a';
+UPDATE t SET v='hf_b' WHERE id='b';
+SELECT dolt_commit('-A','-m','hf');
+SELECT dolt_checkout('main');
+UPDATE t SET v='main_a' WHERE id='a';
+UPDATE t SET v='main_b' WHERE id='b';
+SELECT dolt_commit('-A','-m','main');
+SELECT dolt_merge('hf');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test "textpk_conflict_count" "SELECT count(*) FROM dolt_conflicts_t;" "2" "$DB"
+echo "DELETE FROM dolt_conflicts_t WHERE base_id='a';" | $DOLTLITE "$DB" > /dev/null 2>&1
+run_test "textpk_target_delete_leaves_one" "SELECT count(*) FROM dolt_conflicts_t;" "1" "$DB"
+run_test "textpk_target_delete_keeps_b" "SELECT base_id FROM dolt_conflicts_t;" "b" "$DB"
+echo "DELETE FROM dolt_conflicts_t;" | $DOLTLITE "$DB" > /dev/null 2>&1
+run_test "textpk_full_delete_clears" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
+
+rm -f "$DB"
+
+# ============================================================
+# Composite PK conflicts delete by synthetic rowid
+# ============================================================
+
+DB=/tmp/test_cfrow_compositepk_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(a INT, b INT, v TEXT, PRIMARY KEY(a,b));
+INSERT INTO t VALUES(1,1,'orig_a'),(2,2,'orig_b');
+SELECT dolt_commit('-A','-m','init');
+SELECT dolt_branch('hf');
+SELECT dolt_checkout('hf');
+UPDATE t SET v='hf_a' WHERE a=1 AND b=1;
+UPDATE t SET v='hf_b' WHERE a=2 AND b=2;
+SELECT dolt_commit('-A','-m','hf');
+SELECT dolt_checkout('main');
+UPDATE t SET v='main_a' WHERE a=1 AND b=1;
+UPDATE t SET v='main_b' WHERE a=2 AND b=2;
+SELECT dolt_commit('-A','-m','main');
+SELECT dolt_merge('hf');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test "compositepk_conflict_count" "SELECT count(*) FROM dolt_conflicts_t;" "2" "$DB"
+echo "DELETE FROM dolt_conflicts_t WHERE base_a=1 AND base_b=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
+run_test "compositepk_target_delete_leaves_one" "SELECT count(*) FROM dolt_conflicts_t;" "1" "$DB"
+run_test "compositepk_target_delete_keeps_other" "SELECT base_a || ',' || base_b FROM dolt_conflicts_t;" "2,2" "$DB"
+echo "DELETE FROM dolt_conflicts_t;" | $DOLTLITE "$DB" > /dev/null 2>&1
+run_test "compositepk_full_delete_clears" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
+
+rm -f "$DB"
+
+# ============================================================
 # Done
 # ============================================================
 

--- a/test/vc_oracle_conflicts_table_test.sh
+++ b/test/vc_oracle_conflicts_table_test.sh
@@ -88,6 +88,43 @@ oracle() {
   fi
 }
 
+oracle_mutate() {
+  local name="$1" setup="$2" mutate="$3" query="$4"
+  local dir="$TMPROOT/$name"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_out
+  dl_out=$(printf "%s\n%s\n%s\n" "$setup" "$mutate" "$query" \
+           | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
+           | grep '^R|' \
+           | normalize)
+
+  local dolt_all
+  dolt_all=$(vc_oracle_translate_for_dolt "$(printf '%s\n%s\n%s' "$setup" "$mutate" "$query")")
+
+  local dt_out
+  dt_out=$(
+    cd "$dir/dt" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    {
+      printf 'SET @@autocommit = 0;\n'
+      printf 'SET @@dolt_allow_commit_conflicts = 1;\n'
+      printf '%s\n' "$dolt_all"
+    } | "$DOLT" sql -r csv 2>"$dir/dt.err"
+  )
+  dt_out=$(echo "$dt_out" | tr -d '"' | grep '^R|' | normalize)
+
+  if [ "$dl_out" = "$dt_out" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite:"; echo "$dl_out" | sed 's/^/      /'
+    echo "    dolt:";     echo "$dt_out" | sed 's/^/      /'
+  fi
+}
+
 echo "=== Version Control Oracle Tests: dolt_conflicts_<table> ==="
 echo ""
 
@@ -295,6 +332,44 @@ SELECT dolt_commit('-A','-m','mainu');
 SELECT dolt_merge('feat');
 " \
 "SELECT CONCAT('R|', base_id, '|', IFNULL(base_v,'NULL'), '|', IFNULL(base_note,'NULL'), '|', IFNULL(our_v,'NULL'), '|', IFNULL(our_note,'NULL'), '|', our_diff_type, '|', IFNULL(their_v,'NULL'), '|', IFNULL(their_note,'NULL'), '|', their_diff_type) FROM dolt_conflicts_t ORDER BY base_id;"
+
+echo "--- delete targeted conflict row, text PK ---"
+
+oracle_mutate "delete_text_pk_row" \
+"CREATE TABLE t(id VARCHAR(32) PRIMARY KEY, v INT);
+INSERT INTO t VALUES('alice',10),('bob',20);
+SELECT dolt_commit('-A','-m','c1');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+UPDATE t SET v=100 WHERE id='alice';
+UPDATE t SET v=200 WHERE id='bob';
+SELECT dolt_commit('-A','-m','feat');
+SELECT dolt_checkout('main');
+UPDATE t SET v=1000 WHERE id='alice';
+UPDATE t SET v=2000 WHERE id='bob';
+SELECT dolt_commit('-A','-m','mainu');
+SELECT dolt_merge('feat');" \
+"DELETE FROM dolt_conflicts_t WHERE base_id='alice';" \
+"SELECT CONCAT('R|', base_id, '|', base_v, '|', our_id, '|', our_v, '|', our_diff_type, '|', their_id, '|', their_v, '|', their_diff_type) FROM dolt_conflicts_t ORDER BY base_id;"
+
+echo "--- delete targeted conflict row, composite PK ---"
+
+oracle_mutate "delete_composite_pk_row" \
+"CREATE TABLE t(a INT, b INT, v INT, PRIMARY KEY(a, b));
+INSERT INTO t VALUES(1,1,11),(1,2,12),(2,1,21);
+SELECT dolt_commit('-A','-m','c1');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+UPDATE t SET v=110 WHERE a=1 AND b=1;
+UPDATE t SET v=120 WHERE a=1 AND b=2;
+SELECT dolt_commit('-A','-m','feat');
+SELECT dolt_checkout('main');
+UPDATE t SET v=1100 WHERE a=1 AND b=1;
+UPDATE t SET v=1200 WHERE a=1 AND b=2;
+SELECT dolt_commit('-A','-m','mainu');
+SELECT dolt_merge('feat');" \
+"DELETE FROM dolt_conflicts_t WHERE base_a=1 AND base_b=1;" \
+"SELECT CONCAT('R|', base_a, '|', base_b, '|', base_v, '|', our_a, '|', our_b, '|', our_v, '|', our_diff_type, '|', their_a, '|', their_b, '|', their_v, '|', their_diff_type) FROM dolt_conflicts_t ORDER BY base_a, base_b;"
 
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="


### PR DESCRIPTION
## Summary
- give dolt_conflicts_<table> rows a stable synthetic rowid when the user PK is not SQLite's integer rowid
- fix targeted and full DELETE behavior for text and composite primary key conflict rows
- add local and Dolt-oracle coverage for those conflict-table delete paths

## Testing
- cd build && bash ../test/doltlite_conflict_rows.sh
- bash test/vc_oracle_conflicts_table_test.sh ./build/doltlite dolt
- cd build && bash ../test/doltlite_conflicts.sh