### PR TITLE
dolt_ignore: case-insensitive matching + iterative backtracking

### DIFF
--- a/src/doltlite_ignore.c
+++ b/src/doltlite_ignore.c
@@ -5,34 +5,41 @@
 #include "doltlite_ignore.h"
 #include <string.h>
 
-/* Match zStr against zPat. '*' and '%' match zero or more characters,
-** '?' matches exactly one, everything else is literal. Returns 1 on
-** match, 0 otherwise. Recursive on wildcard to keep the code short;
-** table names are bounded by sqlite_master so pathological nesting
-** isn't a concern. */
+static unsigned char ignoreLower(unsigned char c){
+  return (c>='A' && c<='Z') ? c + 32 : c;
+}
+
+/* Match zStr against zPat (case-insensitive). '*' and '%' match zero
+** or more characters, '?' matches exactly one, everything else is a
+** case-folded literal. Uses iterative backtracking instead of
+** recursion to avoid stack overflow on pathological patterns. */
 static int ignorePatternMatch(const char *zPat, const char *zStr){
-  while( *zPat ){
-    char c = *zPat;
+  const char *pStar = 0;   /* Last '*' position in pattern */
+  const char *sStar = 0;   /* String position at last '*' */
+
+  while( *zStr ){
+    unsigned char c = (unsigned char)*zPat;
     if( c=='*' || c=='%' ){
       while( *(zPat+1)=='*' || *(zPat+1)=='%' ) zPat++;
+      pStar = zPat;
+      sStar = zStr;
       zPat++;
-      if( !*zPat ) return 1;
-      while( *zStr ){
-        if( ignorePatternMatch(zPat, zStr) ) return 1;
-        zStr++;
-      }
-      return 0;
     }else if( c=='?' ){
-      if( !*zStr ) return 0;
       zPat++;
       zStr++;
+    }else if( ignoreLower(c)==ignoreLower((unsigned char)*zStr) ){
+      zPat++;
+      zStr++;
+    }else if( pStar ){
+      zPat = pStar + 1;
+      sStar++;
+      zStr = sStar;
     }else{
-      if( *zStr != c ) return 0;
-      zPat++;
-      zStr++;
+      return 0;
     }
   }
-  return *zStr == 0;
+  while( *zPat=='*' || *zPat=='%' ) zPat++;
+  return *zPat == 0;
 }
 
 /* Specificity score = count of literal (non-wildcard) chars. Higher


### PR DESCRIPTION
## Summary
- Pattern matching is now case-insensitive, matching SQLite's table name semantics
- Replace unbounded recursion with iterative backtracking (constant stack, O(n*m) time)

## Before
- Pattern `'Test_*'` would NOT ignore table `test_users` (case mismatch)
- Pattern `'*a*a*a*...*a*b'` could cause stack overflow via exponential recursion

## After
- `'Test_*'` ignores `test_users`, `TEST_ORDERS`, `Test_Anything` — all case variants
- Pathological patterns complete in bounded time with zero recursion

## Algorithm
Uses the standard iterative glob matching with a single saved backtrack position (`pStar`/`sStar`). On mismatch, rewinds to the last `*` position and advances the string by one character. No recursion, no auxiliary memory.

## Test plan
- [x] Correctness tests (41/41 pass)
- [x] Status oracle tests (11/11 pass)
- [x] Lint passes
- [x] Manual: `test_*` ignores both `test_users` and `TEST_ORDERS`
- [x] Manual: pathological pattern `*a*a*...*b` completes instantly
- [ ] CI full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)