### PR TITLE
Preserve duplicate rows during merge violations

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -2207,18 +2207,16 @@ static void doltliteMergeFunc(
   }
 
   /* Post-merge constraint detection. Release the graph lock
-  ** first — detection runs DELETEs against the merged working
-  ** set (eviction of unique-index losers) and those need a
-  ** fully committed btree state to avoid
-  ** SQLITE_CORRUPT ("database disk image is malformed") from
-  ** modifying a btree whose savepoint is still mid-flight.
+  ** first so the merged catalog and working set are fully
+  ** visible to the walkers.
   **
   ** The merged catalog is installed (schema reflects the merged
   ** DDL, Table.pFKey is loaded), so PRAGMA foreign_key_check
   ** sees any row where one side's child references a parent
   ** the other side deleted. Unique-index detection walks each
-  ** table's UNIQUE indexes and evicts duplicates to the
-  ** violations vtable. Each detected violation lands in
+  ** table's UNIQUE indexes and records merge-introduced
+  ** duplicates in the violations vtable without rewriting the
+  ** base table. Each detected violation lands in
   ** dolt_constraint_violations_<table>; dolt_commit refuses to
   ** proceed while any violation remains. */
   if( graphLocked ){
@@ -2268,27 +2266,6 @@ static void doltliteMergeFunc(
       return;
     }
     sqlite3_free(zDetectErrMsg);
-    if( nUnique > 0 ){
-      /* The unique-index walker evicts loser rows from the base
-      ** via DELETE — flush those mutations out of the mutmap and
-      ** re-pin the session's working catalog at the new hash so
-      ** the next reopen sees the post-eviction state. */
-      ProllyHash newCatHash;
-      memset(&newCatHash, 0, sizeof(newCatHash));
-      vrc = doltliteFlushCatalogToHash(db, &newCatHash);
-      if( vrc == SQLITE_OK ){
-        doltliteSetSessionStaged(db, &newCatHash);
-        vrc = doltliteUpdateBranchWorkingState(db,
-            doltliteGetSessionBranch(db), &newCatHash, NULL);
-      }
-      if( vrc == SQLITE_OK ){
-        mergedCatHash = newCatHash;
-      }else{
-        sqlite3_result_error_code(context,
-            doltliteRestoreTxnStateOnFailure(db, &savedState, vrc));
-        return;
-      }
-    }
     if( nViolations + nUnique + nCheck > 0 ){
       u8 alreadyMerging = 0;
       nMergeConflicts += nViolations + nUnique + nCheck;

--- a/src/doltlite_merge_constraints.c
+++ b/src/doltlite_merge_constraints.c
@@ -790,12 +790,113 @@ static int fetchRowByPkFromTable(
                             ppKey, pnKey, ppVal, pnVal);
 }
 
+static int appendUniqueViolationByRowid(
+  sqlite3 *db,
+  struct TableEntry *aAnc, int nAnc,
+  const char *zTable,
+  const char *zIndexName,
+  const char *zCols,
+  sqlite3_int64 rowid,
+  int *pAppended
+){
+  u8 *pKey = 0;
+  int nKey = 0;
+  u8 *pVal = 0;
+  int nVal = 0;
+  char *zInfo = 0;
+  int rc;
+
+  if( pAppended ) *pAppended = 0;
+  rc = fetchOrphanRow(db, zTable, rowid, &pKey, &nKey, &pVal, &nVal);
+  if( rc==SQLITE_NOTFOUND ) return SQLITE_OK;
+  if( rc!=SQLITE_OK ) return rc;
+
+  if( aAnc ){
+    u8 *pAncVal = 0;
+    int nAncVal = 0;
+    int ancRc = fetchAncestorRowByName(db, aAnc, nAnc, zTable,
+                                       rowid, &pAncVal, &nAncVal);
+    int preExisting = (ancRc==SQLITE_OK)
+        && isRowPreExisting(pVal, nVal, pAncVal, nAncVal);
+    sqlite3_free(pAncVal);
+    if( preExisting ){
+      sqlite3_free(pKey);
+      sqlite3_free(pVal);
+      return SQLITE_OK;
+    }
+  }
+
+  zInfo = sqlite3_mprintf(
+      "{\"Columns\": [%s], \"Name\": \"%w\"}",
+      zCols, zIndexName);
+  rc = doltliteAppendConstraintViolation(
+      db, zTable, DOLTLITE_CV_UNIQUE_INDEX,
+      rowid, pKey, nKey, pVal, nVal, zInfo);
+  sqlite3_free(zInfo);
+  sqlite3_free(pKey);
+  sqlite3_free(pVal);
+  if( rc==SQLITE_OK && pAppended ) *pAppended = 1;
+  return rc;
+}
+
+static int appendUniqueViolationByPk(
+  sqlite3 *db,
+  struct TableEntry *aAnc, int nAnc,
+  const char *zTable,
+  const char *zIndexName,
+  const char *zCols,
+  const MergePkInfo *pPk,
+  const u8 *pPkRec, int nPkRec,
+  int *pAppended
+){
+  u8 *pKey = 0;
+  int nKey = 0;
+  u8 *pVal = 0;
+  int nVal = 0;
+  char *zInfo = 0;
+  int rc;
+
+  if( pAppended ) *pAppended = 0;
+  rc = fetchRowByPkFromTable(db, zTable, pPkRec, nPkRec, pPk->nPk,
+                             &pKey, &nKey, &pVal, &nVal);
+  if( rc==SQLITE_NOTFOUND ) return SQLITE_OK;
+  if( rc!=SQLITE_OK ) return rc;
+
+  if( aAnc ){
+    u8 *pAncVal = 0;
+    int nAncVal = 0;
+    int ancRc = fetchAncestorRowByKey(db, aAnc, nAnc, zTable,
+                                      pKey, nKey, &pAncVal, &nAncVal);
+    int preExisting = (ancRc==SQLITE_OK)
+        && isRowPreExisting(pVal, nVal, pAncVal, nAncVal);
+    sqlite3_free(pAncVal);
+    if( preExisting ){
+      sqlite3_free(pKey);
+      sqlite3_free(pVal);
+      return SQLITE_OK;
+    }
+  }
+
+  zInfo = sqlite3_mprintf(
+      "{\"Columns\": [%s], \"Name\": \"%w\"}",
+      zCols, zIndexName);
+  rc = doltliteAppendConstraintViolation(
+      db, zTable, DOLTLITE_CV_UNIQUE_INDEX,
+      0, pKey, nKey, pVal, nVal, zInfo);
+  sqlite3_free(zInfo);
+  sqlite3_free(pKey);
+  sqlite3_free(pVal);
+  if( rc==SQLITE_OK && pAppended ) *pAppended = 1;
+  return rc;
+}
+
 /* Walk every row in zTable and look for duplicate values on the
 ** given UNIQUE index columns. When a duplicate group is found,
-** the row with the lowest rowid is kept (treated as the "main
-** side" row) and every other row in the group is evicted from
-** the base table into dolt_constraint_violations_<table> with
-** violation_type = 'unique index'.
+** every merge-introduced row in that group is recorded in
+** dolt_constraint_violations_<table> with
+** violation_type = 'unique index'. The base table keeps all
+** merged rows intact; users resolve the violation by deleting
+** rows from the violation vtable and then committing.
 **
 ** We can't just `GROUP BY` the index columns here — SQLite's
 ** query planner sees the UNIQUE constraint and optimizes on the
@@ -815,6 +916,8 @@ static int detectUniqueViolationsForIndex(
   sqlite3_stmt *pScan = 0;
   char *zQuery;
   char *zWinnerKey = 0;
+  sqlite3_int64 winnerRowid = 0;
+  int winnerHandled = 0;
   int rc;
   (void)pzErrMsg;
 
@@ -851,56 +954,27 @@ static int detectUniqueViolationsForIndex(
       /* New group — this row wins, remember its value set. */
       sqlite3_free(zWinnerKey);
       zWinnerKey = zRowKey;
+      winnerRowid = rowid;
+      winnerHandled = 0;
       continue;
     }
     sqlite3_free(zRowKey);
 
-    /* Evict the loser row. */
+    if( !winnerHandled ){
+      int appended = 0;
+      rc = appendUniqueViolationByRowid(db, aAnc, nAnc, zTable, zIndexName,
+                                        zCols, winnerRowid, &appended);
+      if( rc != SQLITE_OK ) break;
+      if( appended && pnFound ) (*pnFound)++;
+      winnerHandled = 1;
+    }
+
     {
-      u8 *pKey = 0; int nKey = 0;
-      u8 *pVal = 0; int nVal = 0;
-      char *zInfo;
-      int appendRc;
-
-      rc = fetchOrphanRow(db, zTable, rowid, &pKey, &nKey, &pVal, &nVal);
-      if( rc == SQLITE_NOTFOUND ){ rc = SQLITE_OK; continue; }
+      int appended = 0;
+      rc = appendUniqueViolationByRowid(db, aAnc, nAnc, zTable, zIndexName,
+                                        zCols, rowid, &appended);
       if( rc != SQLITE_OK ) break;
-
-      /* Skip the eviction if the loser row already existed in
-      ** ancestor with identical bytes — the duplicate predates
-      ** this merge and isn't ours to flag (or destroy). */
-      if( aAnc ){
-        u8 *pAncVal = 0; int nAncVal = 0;
-        int ancRc = fetchAncestorRowByName(db, aAnc, nAnc, zTable,
-                                            rowid, &pAncVal, &nAncVal);
-        int preExisting = (ancRc==SQLITE_OK)
-            && isRowPreExisting(pVal, nVal, pAncVal, nAncVal);
-        sqlite3_free(pAncVal);
-        if( preExisting ){
-          sqlite3_free(pKey);
-          sqlite3_free(pVal);
-          continue;
-        }
-      }
-
-      zInfo = sqlite3_mprintf(
-          "{\"Columns\": [%s], \"Name\": \"%w\"}",
-          zCols, zIndexName);
-      appendRc = doltliteAppendConstraintViolation(
-          db, zTable, DOLTLITE_CV_UNIQUE_INDEX,
-          rowid, pKey, nKey, pVal, nVal, zInfo);
-      sqlite3_free(zInfo);
-      if( appendRc != SQLITE_OK ){ rc = appendRc; break; }
-
-      /* Evict via doltliteApplyRawRowMutation — goes straight
-      ** through the prolly layer, unlike SQL DELETE which hits
-      ** the mid-merge btree state and returns SQLITE_CORRUPT. */
-      rc = doltliteApplyRawRowMutation(db, zTable, pKey, nKey, rowid, 0, 0);
-      sqlite3_free(pKey);
-      sqlite3_free(pVal);
-      if( rc != SQLITE_OK ) break;
-
-      if( pnFound ) (*pnFound)++;
+      if( appended && pnFound ) (*pnFound)++;
     }
   }
   sqlite3_free(zWinnerKey);
@@ -922,6 +996,9 @@ static int detectUniqueViolationsForIndexWithoutRowid(
   sqlite3_str *pSql = 0;
   char *zQuery = 0;
   char *zWinnerKey = 0;
+  u8 *pWinnerPkRec = 0;
+  int nWinnerPkRec = 0;
+  int winnerHandled = 0;
   int rc;
 
   pSql = sqlite3_str_new(0);
@@ -955,64 +1032,53 @@ static int detectUniqueViolationsForIndexWithoutRowid(
 
     isDup = zWinnerKey && strcmp(zWinnerKey, zRowKey)==0;
     if( !isDup ){
+      u8 *pPkRec = 0;
+      int nPkRec = 0;
+      pPkRec = buildRecordFromStmtCols(pScan, nDupKeyCol, pPk->nPk, &nPkRec);
+      if( !pPkRec ){
+        sqlite3_free(zRowKey);
+        rc = SQLITE_NOMEM;
+        break;
+      }
       sqlite3_free(zWinnerKey);
+      sqlite3_free(pWinnerPkRec);
       zWinnerKey = zRowKey;
+      pWinnerPkRec = pPkRec;
+      nWinnerPkRec = nPkRec;
+      winnerHandled = 0;
       continue;
     }
     sqlite3_free(zRowKey);
 
     {
       u8 *pPkRec = 0; int nPkRec = 0;
-      u8 *pKey = 0; int nKey = 0;
-      u8 *pVal = 0; int nVal = 0;
-      char *zInfo;
-      int appendRc;
-
       pPkRec = buildRecordFromStmtCols(pScan, nDupKeyCol, pPk->nPk, &nPkRec);
       if( !pPkRec ){ rc = SQLITE_NOMEM; break; }
-      rc = fetchRowByPkFromTable(db, zTable, pPkRec, nPkRec, pPk->nPk,
-                                 &pKey, &nKey, &pVal, &nVal);
-      sqlite3_free(pPkRec);
-      if( rc == SQLITE_NOTFOUND ){ rc = SQLITE_OK; continue; }
-      if( rc != SQLITE_OK ) break;
-
-      if( aAnc ){
-        u8 *pAncVal = 0; int nAncVal = 0;
-        int ancRc = fetchAncestorRowByKey(db, aAnc, nAnc, zTable,
-                                          pKey, nKey, &pAncVal, &nAncVal);
-        int preExisting = (ancRc==SQLITE_OK)
-            && isRowPreExisting(pVal, nVal, pAncVal, nAncVal);
-        sqlite3_free(pAncVal);
-        if( preExisting ){
-          sqlite3_free(pKey);
-          sqlite3_free(pVal);
-          continue;
+      if( !winnerHandled ){
+        int appended = 0;
+        rc = appendUniqueViolationByPk(db, aAnc, nAnc, zTable, zIndexName,
+                                       zCols, pPk, pWinnerPkRec, nWinnerPkRec,
+                                       &appended);
+        if( rc != SQLITE_OK ){
+          sqlite3_free(pPkRec);
+          break;
         }
+        if( appended && pnFound ) (*pnFound)++;
+        winnerHandled = 1;
       }
-
-      zInfo = sqlite3_mprintf(
-          "{\"Columns\": [%s], \"Name\": \"%w\"}",
-          zCols, zIndexName);
-      appendRc = doltliteAppendConstraintViolation(
-          db, zTable, DOLTLITE_CV_UNIQUE_INDEX,
-          0, pKey, nKey, pVal, nVal, zInfo);
-      sqlite3_free(zInfo);
-      if( appendRc != SQLITE_OK ){
-        sqlite3_free(pKey);
-        sqlite3_free(pVal);
-        rc = appendRc;
-        break;
+      {
+        int appended = 0;
+        rc = appendUniqueViolationByPk(db, aAnc, nAnc, zTable, zIndexName,
+                                       zCols, pPk, pPkRec, nPkRec, &appended);
+        sqlite3_free(pPkRec);
+        if( rc != SQLITE_OK ) break;
+        if( appended && pnFound ) (*pnFound)++;
       }
-
-      rc = doltliteApplyRawRowMutation(db, zTable, pKey, nKey, 0, 0, 0);
-      sqlite3_free(pKey);
-      sqlite3_free(pVal);
-      if( rc != SQLITE_OK ) break;
-      if( pnFound ) (*pnFound)++;
     }
   }
 
   sqlite3_free(zWinnerKey);
+  sqlite3_free(pWinnerPkRec);
   if( rc == SQLITE_DONE ) rc = SQLITE_OK;
   sqlite3_finalize(pScan);
   return rc;

--- a/test/vc_oracle_fk_merge_test.sh
+++ b/test/vc_oracle_fk_merge_test.sh
@@ -20,7 +20,7 @@
 #
 #   - violation_type values (matching Dolt, lowercase):
 #       'foreign key'       FK orphan — row IS in the base table
-#       'unique index'      duplicate — row is NOT in the base table
+#       'unique index'      duplicate — row IS in the base table
 #       'check constraint'  CHECK failure — row IS in the base table
 #
 #   - `dolt_commit` MUST fail while any dolt_constraint_violations
@@ -37,7 +37,8 @@
 #     1. Existence of violation row(s) in the per-table vtable
 #     2. The summary vtable reports the right count
 #     3. The base table's post-merge content matches the rule
-#        (FK/CHECK: row present; UNIQUE: row absent)
+#        (FK/CHECK/UNIQUE: row present; UNIQUE duplicates stay
+#         in the base table until the user resolves them)
 #     4. `dolt_commit` refuses to proceed while violations exist
 #     5. Deleting violations from the per-table vtable allows
 #        commit to succeed
@@ -229,16 +230,19 @@ SELECT dolt_merge('feat');
 SQL
 
 N=$(dl "$DB" "SELECT num_violations FROM dolt_constraint_violations WHERE \"table\"='t';" "uniq_count")
-expect_eq "unique_violation_summary_count" "1" "$N"
+expect_eq "unique_violation_summary_count" "2" "$N"
 
-TYPE=$(dl "$DB" "SELECT violation_type FROM dolt_constraint_violations_t;" "uniq_type")
+TYPE=$(dl "$DB" "SELECT group_concat(violation_type, ',') FROM (SELECT DISTINCT violation_type FROM dolt_constraint_violations_t ORDER BY violation_type);" "uniq_type")
 expect_eq "unique_violation_type" "unique index" "$TYPE"
 
 BASE_COUNT=$(dl "$DB" "SELECT count(*) FROM t;" "uniq_base")
-expect_eq "unique_violation_loser_not_in_base" "1" "$BASE_COUNT"
+expect_eq "unique_violation_rows_kept_in_base" "2" "$BASE_COUNT"
 
-BASE_KEEPS_MAIN=$(dl "$DB" "SELECT pk FROM t;" "uniq_base_pk")
-expect_eq "unique_violation_main_side_kept" "1" "$BASE_KEEPS_MAIN"
+BASE_ROWS=$(dl "$DB" "SELECT group_concat(pk, ',') FROM (SELECT pk FROM t ORDER BY pk);" "uniq_base_pk")
+expect_eq "unique_violation_base_rows" "1,2" "$BASE_ROWS"
+
+VIOL_ROWS=$(dl "$DB" "SELECT group_concat(pk, ',') FROM (SELECT pk FROM dolt_constraint_violations_t ORDER BY pk);" "uniq_viol_rows")
+expect_eq "unique_violation_rows" "1,2" "$VIOL_ROWS"
 
 echo ""
 
@@ -263,13 +267,16 @@ SELECT dolt_merge('feat');
 SQL
 
 N=$(dl "$DB" "SELECT num_violations FROM dolt_constraint_violations WHERE \"table\"='t';" "uniq_shadow_count")
-expect_eq "unique_shadow_violation_summary_count" "1" "$N"
+expect_eq "unique_shadow_violation_summary_count" "2" "$N"
 
-TYPE=$(dl "$DB" "SELECT violation_type FROM dolt_constraint_violations_t;" "uniq_shadow_type")
+TYPE=$(dl "$DB" "SELECT group_concat(violation_type, ',') FROM (SELECT DISTINCT violation_type FROM dolt_constraint_violations_t ORDER BY violation_type);" "uniq_shadow_type")
 expect_eq "unique_shadow_violation_type" "unique index" "$TYPE"
 
-BASE_COUNT=$(dl "$DB" "SELECT count(*) FROM t;" "uniq_shadow_base")
-expect_eq "unique_shadow_loser_not_in_base" "2" "$BASE_COUNT"
+BASE_ROWS=$(dl "$DB" "SELECT group_concat(pk, ',') FROM (SELECT pk FROM t ORDER BY pk);" "uniq_shadow_base")
+expect_eq "unique_shadow_rows_kept_in_base" "1,2,3" "$BASE_ROWS"
+
+VIOL_ROWS=$(dl "$DB" "SELECT group_concat(pk, ',') FROM (SELECT pk FROM dolt_constraint_violations_t ORDER BY pk);" "uniq_shadow_viol")
+expect_eq "unique_shadow_rows" "2,3" "$VIOL_ROWS"
 
 echo ""
 
@@ -568,13 +575,81 @@ SELECT dolt_merge('feat');
 SQL
 
 N=$(dl "$DB" "SELECT num_violations FROM dolt_constraint_violations WHERE \"table\"='t';" "without_rowid_unique_count")
-expect_eq "without_rowid_unique_summary_count" "1" "$N"
+expect_eq "without_rowid_unique_summary_count" "2" "$N"
 
-TYPE=$(dl "$DB" "SELECT violation_type FROM dolt_constraint_violations_t;" "without_rowid_unique_type")
+TYPE=$(dl "$DB" "SELECT group_concat(violation_type, ',') FROM (SELECT DISTINCT violation_type FROM dolt_constraint_violations_t ORDER BY violation_type);" "without_rowid_unique_type")
 expect_eq "without_rowid_unique_type" "unique index" "$TYPE"
 
 BASE_COUNT=$(dl "$DB" "SELECT count(*) FROM t;" "without_rowid_unique_base")
-expect_eq "without_rowid_unique_base_count" "1" "$BASE_COUNT"
+expect_eq "without_rowid_unique_base_count" "2" "$BASE_COUNT"
+
+VIOL_ROWS=$(dl "$DB" "SELECT group_concat(pk, ',') FROM (SELECT pk FROM dolt_constraint_violations_t ORDER BY pk);" "without_rowid_unique_rows")
+expect_eq "without_rowid_unique_rows" "feat,main" "$VIOL_ROWS"
+
+echo ""
+
+# ── Scenario O: WITHOUT ROWID UNIQUE multi-row groups work ──
+echo "--- O. WITHOUT ROWID UNIQUE merge records every duplicate row ---"
+
+DB="$TMPROOT/without_rowid_unique_multi.db"
+rm -f "$DB"
+cat <<'SQL' | dl_setup "$DB" "without_rowid_unique_multi"
+CREATE TABLE t(pk TEXT PRIMARY KEY, v1 INT UNIQUE) WITHOUT ROWID;
+SELECT dolt_commit('-Am','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES ('feat1',1),('feat2',2);
+SELECT dolt_commit('-Am','feat_add');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES ('main1',1),('main2',2);
+SELECT dolt_commit('-Am','main_add');
+SELECT dolt_merge('feat');
+SQL
+
+N=$(dl "$DB" "SELECT num_violations FROM dolt_constraint_violations WHERE \"table\"='t';" "without_rowid_unique_multi_count")
+expect_eq "without_rowid_unique_multi_summary_count" "4" "$N"
+
+VIOL_ROWS=$(dl "$DB" "SELECT group_concat(pk, ',') FROM (SELECT pk FROM dolt_constraint_violations_t ORDER BY pk);" "without_rowid_unique_multi_rows")
+expect_eq "without_rowid_unique_multi_rows" "feat1,feat2,main1,main2" "$VIOL_ROWS"
+
+BASE_ROWS=$(dl "$DB" "SELECT group_concat(pk, ',') FROM (SELECT pk FROM t ORDER BY pk);" "without_rowid_unique_multi_base")
+expect_eq "without_rowid_unique_multi_base_rows" "feat1,feat2,main1,main2" "$BASE_ROWS"
+
+echo ""
+
+# ── Scenario P: mixed WITHOUT ROWID FK + UNIQUE violations ──
+echo "--- P. Mixed WITHOUT ROWID FK + UNIQUE violations both block commit ---"
+
+DB="$TMPROOT/without_rowid_mixed_violations.db"
+rm -f "$DB"
+cat <<'SQL' | dl_setup "$DB" "without_rowid_mixed_violations"
+CREATE TABLE parent(pk TEXT PRIMARY KEY, v1 INT UNIQUE) WITHOUT ROWID;
+CREATE TABLE child(pk TEXT PRIMARY KEY, pv INT,
+  FOREIGN KEY(pv) REFERENCES parent(v1)) WITHOUT ROWID;
+CREATE TABLE u(pk TEXT PRIMARY KEY, v1 INT UNIQUE) WITHOUT ROWID;
+INSERT INTO parent VALUES ('p1',1),('p2',2);
+INSERT INTO child VALUES ('c1',1);
+SELECT dolt_commit('-Am','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO child VALUES ('c2',2);
+INSERT INTO u VALUES ('uf',7);
+SELECT dolt_commit('-Am','feat_add');
+SELECT dolt_checkout('main');
+DELETE FROM parent WHERE pk='p2';
+INSERT INTO u VALUES ('um',7);
+SELECT dolt_commit('-Am','main_add');
+SELECT dolt_merge('feat');
+SQL
+
+SUMMARY=$(dl "$DB" "SELECT group_concat(\"table\" || ':' || num_violations, ',') FROM (SELECT \"table\", num_violations FROM dolt_constraint_violations ORDER BY \"table\");" "without_rowid_mixed_summary")
+expect_eq "without_rowid_mixed_summary" "child:1,u:2" "$SUMMARY"
+
+if dl_errors "$DB" "SELECT dolt_commit('-m','post-merge');" "without_rowid_mixed_commit"; then
+  pass_name "without_rowid_mixed_commit_blocked"
+else
+  fail_name "without_rowid_mixed_commit_blocked"
+fi
 
 echo ""
 


### PR DESCRIPTION
## Summary
- preserve duplicate rows in the base table during merge-time UNIQUE violation detection
- record every merge-introduced row in a duplicate group, including WITHOUT ROWID tables
- expand the merge-constraint oracle to lock in single-pair, multi-pair, temp-shadowed, and mixed FK+UNIQUE behavior

## Verification
- bash test/vc_oracle_fk_merge_test.sh ./build/doltlite
- cd build && bash ../test/doltlite_merge.sh
- bash test/vc_oracle_merge_test.sh ./build/doltlite dolt