### PR TITLE
Disambiguate multi-violation row deletes

### DIFF
--- a/src/doltlite_constraint_violations.c
+++ b/src/doltlite_constraint_violations.c
@@ -650,10 +650,47 @@ static int cvrColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
   return SQLITE_OK;
 }
 
+/* Per-row DELETE on dolt_constraint_violations_<table> needs a stable unique
+** rowid even when:
+**   1) the user PK is not SQLite's integer rowid, and/or
+**   2) one user row produces multiple violation rows.
+**
+** So the synthetic rowid must include both the offending row identity and
+** the specific violation identity. */
+static sqlite3_int64 cvrViolationRowid(const ConstraintViolationRow *r){
+  u64 h = 1469598103934665603ULL;
+  int i;
+
+  if( r->nKey>0 && r->pKey ){
+    for(i=0; i<r->nKey; i++){
+      h ^= (u64)r->pKey[i];
+      h *= 1099511628211ULL;
+    }
+  }else{
+    const u8 *p = (const u8*)&r->intKey;
+    for(i=0; i<(int)sizeof(r->intKey); i++){
+      h ^= (u64)p[i];
+      h *= 1099511628211ULL;
+    }
+  }
+
+  h ^= (u64)r->violationType;
+  h *= 1099511628211ULL;
+  if( r->zInfo ){
+    for(i=0; r->zInfo[i]; i++){
+      h ^= (u64)(u8)r->zInfo[i];
+      h *= 1099511628211ULL;
+    }
+  }
+
+  if( h==0 ) h = 1;
+  return (sqlite3_int64)(h & 0x7fffffffffffffffULL);
+}
+
 static int cvrRowid(sqlite3_vtab_cursor *cur, sqlite3_int64 *r){
   CvRowCur *c = (CvRowCur*)cur;
   if( c->iTableIdx >= 0 && c->iRow < c->aTables[c->iTableIdx].nRows ){
-    *r = c->aTables[c->iTableIdx].aRows[c->iRow].intKey;
+    *r = cvrViolationRowid(&c->aTables[c->iTableIdx].aRows[c->iRow]);
   }else{
     *r = 0;
   }
@@ -667,8 +704,9 @@ static int cvrBestIndex(sqlite3_vtab *v, sqlite3_index_info *p){
 }
 
 /* DELETE support: user clears a violation from the per-table
-** vtable to signal "I've resolved this". Matches dolt_conflicts
-** DELETE semantics — rowid comes from the row's intKey. */
+** vtable to signal "I've resolved this". The synthetic rowid
+** includes both the offending row and the specific violation,
+** so compare against the same computed rowid here. */
 static int cvrUpdate(
   sqlite3_vtab *pVtab,
   int nArg,
@@ -697,7 +735,7 @@ static int cvrUpdate(
     if( !aTables[i].zName
      || strcmp(aTables[i].zName, v->zTableName)!=0 ) continue;
     for(j=0; j<aTables[i].nRows; j++){
-      if( aTables[i].aRows[j].intKey == deleteRowid ){
+      if( cvrViolationRowid(&aTables[i].aRows[j]) == deleteRowid ){
         removeViolationRow(&aTables[i], j);
         if( aTables[i].nRows == 0 ){
           removeViolationTable(aTables, &nTables, i);

--- a/test/vc_oracle_fk_merge_test.sh
+++ b/test/vc_oracle_fk_merge_test.sh
@@ -742,6 +742,57 @@ else
 fi
 
 echo ""
+
+# ── Scenario P: one selective delete leaves sibling violation row ─
+echo "--- P. WITHOUT ROWID selective violation delete leaves sibling row ---"
+
+DB="$TMPROOT/without_rowid_multi_fk_delete_one.db"
+rm -f "$DB"
+cat <<'SQL' | dl_setup "$DB" "without_rowid_multi_fk_delete_one"
+CREATE TABLE p1(pk INT PRIMARY KEY, v1 INT UNIQUE);
+CREATE TABLE p2(pk INT PRIMARY KEY, v2 INT UNIQUE);
+CREATE TABLE child(
+  pk TEXT PRIMARY KEY,
+  f1 INT,
+  f2 INT,
+  FOREIGN KEY(f1) REFERENCES p1(v1),
+  FOREIGN KEY(f2) REFERENCES p2(v2)
+) WITHOUT ROWID;
+INSERT INTO p1 VALUES (1,1),(2,2);
+INSERT INTO p2 VALUES (1,10),(2,20);
+INSERT INTO child VALUES ('ok',1,10);
+SELECT dolt_commit('-Am','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO child VALUES ('bad',2,20);
+SELECT dolt_commit('-Am','feat_bad_child');
+SELECT dolt_checkout('main');
+DELETE FROM p1 WHERE pk=2;
+DELETE FROM p2 WHERE pk=2;
+SELECT dolt_commit('-Am','main_drop_parents');
+SELECT dolt_merge('feat');
+SQL
+
+N=$(dl "$DB" "SELECT count(*) FROM dolt_constraint_violations_child WHERE pk='bad';" "without_rowid_multi_fk_delete_one_count")
+expect_eq "without_rowid_multi_fk_delete_one_initial_count" "2" "$N"
+
+dl "$DB" "DELETE FROM dolt_constraint_violations_child WHERE pk='bad' AND violation_info LIKE '%\"f1\"%';" "without_rowid_multi_fk_delete_one_target" >/dev/null
+N_ONE=$(dl "$DB" "SELECT count(*) FROM dolt_constraint_violations_child WHERE pk='bad';" "without_rowid_multi_fk_delete_one_after")
+expect_eq "without_rowid_multi_fk_delete_one_left" "1" "$N_ONE"
+
+LEFT_INFO=$(dl "$DB" "SELECT violation_info FROM dolt_constraint_violations_child WHERE pk='bad';" "without_rowid_multi_fk_delete_one_info")
+case "$LEFT_INFO" in
+  *"\"f2\""*) pass_name "without_rowid_multi_fk_delete_one_keeps_f2" ;;
+  *) fail_name "without_rowid_multi_fk_delete_one_keeps_f2" ;;
+esac
+
+if dl_errors "$DB" "SELECT dolt_commit('-m','still-blocked');" "without_rowid_multi_fk_delete_one_commit"; then
+  pass_name "without_rowid_multi_fk_delete_one_commit_still_blocked"
+else
+  fail_name "without_rowid_multi_fk_delete_one_commit_still_blocked"
+fi
+
+echo ""
 echo "======================================="
 echo "Results: $pass passed, $fail failed"
 echo "======================================="

--- a/test/vc_oracle_fk_merge_test.sh
+++ b/test/vc_oracle_fk_merge_test.sh
@@ -697,6 +697,51 @@ else
 fi
 
 echo ""
+
+# ── Scenario O: one row with two FK violations deletes cleanly ─
+echo "--- O. WITHOUT ROWID row with two FK violations clears all matching rows ---"
+
+DB="$TMPROOT/without_rowid_multi_fk_delete.db"
+rm -f "$DB"
+cat <<'SQL' | dl_setup "$DB" "without_rowid_multi_fk_delete"
+CREATE TABLE p1(pk INT PRIMARY KEY, v1 INT UNIQUE);
+CREATE TABLE p2(pk INT PRIMARY KEY, v2 INT UNIQUE);
+CREATE TABLE child(
+  pk TEXT PRIMARY KEY,
+  f1 INT,
+  f2 INT,
+  FOREIGN KEY(f1) REFERENCES p1(v1),
+  FOREIGN KEY(f2) REFERENCES p2(v2)
+) WITHOUT ROWID;
+INSERT INTO p1 VALUES (1,1),(2,2);
+INSERT INTO p2 VALUES (1,10),(2,20);
+INSERT INTO child VALUES ('ok',1,10);
+SELECT dolt_commit('-Am','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO child VALUES ('bad',2,20);
+SELECT dolt_commit('-Am','feat_bad_child');
+SELECT dolt_checkout('main');
+DELETE FROM p1 WHERE pk=2;
+DELETE FROM p2 WHERE pk=2;
+SELECT dolt_commit('-Am','main_drop_parents');
+SELECT dolt_merge('feat');
+SQL
+
+N=$(dl "$DB" "SELECT count(*) FROM dolt_constraint_violations_child WHERE pk='bad';" "without_rowid_multi_fk_delete_count")
+expect_eq "without_rowid_multi_fk_delete_initial_count" "2" "$N"
+
+dl "$DB" "DELETE FROM dolt_constraint_violations_child WHERE pk='bad';" "without_rowid_multi_fk_delete_target" >/dev/null
+N_ZERO=$(dl "$DB" "SELECT count(*) FROM dolt_constraint_violations_child WHERE pk='bad';" "without_rowid_multi_fk_delete_after")
+expect_eq "without_rowid_multi_fk_delete_cleared" "0" "$N_ZERO"
+
+if dl_errors "$DB" "SELECT dolt_commit('-m','post-merge-cleared');" "without_rowid_multi_fk_delete_commit"; then
+  fail_name "without_rowid_multi_fk_delete_commit_after_clear"
+else
+  pass_name "without_rowid_multi_fk_delete_commit_after_clear"
+fi
+
+echo ""
 echo "======================================="
 echo "Results: $pass passed, $fail failed"
 echo "======================================="


### PR DESCRIPTION
## Summary
- give dolt_constraint_violations_<table> rows stable synthetic rowids that include the specific violation identity, not just the offending row
- fix DELETE ... WHERE pk=... when one row produces multiple violation rows
- add an oracle case for a WITHOUT ROWID child row violating two foreign keys in one merge

## Verification
- bash test/vc_oracle_fk_merge_test.sh ./build/doltlite