### PR TITLE
Reject soft reset during merge conflicts

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -1731,6 +1731,7 @@ static void doltliteResetFunc(
   int rc;
   int i;
   int graphLocked = 0;
+  u8 isMerging = 0;
 
   if( !cs ){
     sqlite3_result_error(context, "no database open", -1);
@@ -1784,6 +1785,17 @@ static void doltliteResetFunc(
     return;
   }
 
+  doltliteGetSessionMergeState(db, &isMerging, 0, 0);
+  if( isMerging && !isHard ){
+    sqlite3_free(azPaths);
+    sqlite3_result_error(context,
+      "Merge conflict detected, transaction rolled back. "
+      "Merge conflicts must be resolved using the dolt_conflicts and "
+      "dolt_schema_conflicts tables before committing a transaction. "
+      "To commit transactions with merge conflicts, set "
+      "@@dolt_allow_commit_conflicts = 1", -1);
+    return;
+  }
 
   if( nPaths>0 ){
     if( isHard || isSoft || zRef ){

--- a/test/doltlite_reset.sh
+++ b/test/doltlite_reset.sh
@@ -185,8 +185,34 @@ run_test "hard_reset_restores_head_row_after_conflict" \
   "SELECT v FROM t;" \
   "main" "$DB7"
 
+DB8=/tmp/test_reset8_$$.db; rm -f "$DB8"
+echo "CREATE TABLE t(x INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB8" > /dev/null 2>&1
+echo "SELECT dolt_branch('feat'); SELECT dolt_checkout('feat'); UPDATE t SET v='feat'; SELECT dolt_commit('-A','-m','feat');" | $DOLTLITE "$DB8" > /dev/null 2>&1
+echo "SELECT dolt_checkout('main'); UPDATE t SET v='main'; SELECT dolt_commit('-A','-m','main');" | $DOLTLITE "$DB8" > /dev/null 2>&1
+echo "SELECT dolt_merge('feat');" | $DOLTLITE "$DB8" > /dev/null 2>&1
+
+run_test "merge_conflicts_present_before_reset_guard" \
+  "SELECT count(*) FROM dolt_conflicts_t;" \
+  "1" "$DB8"
+
+run_test_match "no_arg_reset_rejected_during_merge_conflict" \
+  "SELECT dolt_reset();" \
+  "Merge conflict detected" "$DB8"
+
+run_test_match "soft_reset_rejected_during_merge_conflict" \
+  "SELECT dolt_reset('--soft');" \
+  "Merge conflict detected" "$DB8"
+
+run_test "reset_guard_preserves_conflicts" \
+  "SELECT count(*) FROM dolt_conflicts_t;" \
+  "1" "$DB8"
+
+run_test "reset_guard_preserves_working_row" \
+  "SELECT v FROM t;" \
+  "main" "$DB8"
+
 # Cleanup
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7"
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/vc_oracle_reset_test.sh
+++ b/test/vc_oracle_reset_test.sh
@@ -141,6 +141,28 @@ oracle_error() {
   fi
 }
 
+oracle_error_match() {
+  local name="$1" setup="$2" pattern="$3"
+  local dir="$TMPROOT/${name}_err"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  vc_oracle_run_doltlite_script "$dir/dl/db" "$dir/dl.out" "$dir/dl.err" "$setup"
+
+  local dolt_setup
+  dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
+  vc_oracle_run_dolt_script "$dir/dt" "$dir/dt.out" "$dir/dt.err" "$dolt_setup"
+
+  if grep -qE "$pattern" "$dir/dl.err" "$dir/dl.out" \
+    && grep -qE "$pattern" "$dir/dt.err" "$dir/dt.out"; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name (expected both to match error pattern)"
+    echo "    pattern: $pattern"
+  fi
+}
+
 echo "=== Version Control Oracle Tests: dolt_reset ==="
 echo ""
 
@@ -313,6 +335,44 @@ oracle_error "reset_soft_hard_mutually_exclusive_with_ref" "
 $SEED
 SELECT dolt_reset('--soft', '--hard', 'HEAD');
 "
+
+echo "--- merge conflict guards ---"
+
+oracle_error_match "reset_no_args_during_merge_conflict" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_branch('feature');
+UPDATE t SET v = 99 WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main2');
+SELECT dolt_checkout('feature');
+UPDATE t SET v = 11 WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat1');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feature');
+SELECT dolt_reset();
+" "Merge conflict detected"
+
+oracle_error_match "reset_soft_during_merge_conflict" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_branch('feature');
+UPDATE t SET v = 99 WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main2');
+SELECT dolt_checkout('feature');
+UPDATE t SET v = 11 WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat1');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feature');
+SELECT dolt_reset('--soft');
+" "Merge conflict detected"
 
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="


### PR DESCRIPTION
## Summary
- reject `dolt_reset()` and `dolt_reset('--soft')` while merge conflicts are active
- add direct reset regression coverage for conflicted merge state
- add Dolt oracle coverage for the same reset guard behavior

## Testing
- cd build && bash ../test/doltlite_reset.sh
- bash test/vc_oracle_reset_test.sh ./build/doltlite dolt