### PR TITLE
Rollback replay constraint violations

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -2434,6 +2434,68 @@ static int applyMergedCatalogAndCommit(
       doltliteGetSessionBranch(db), &mergedCatHash, NULL);
   if( rc!=SQLITE_OK ) goto apply_rollback;
 
+  if( graphLocked ){
+    chunkStoreUnlock(cs);
+    graphLocked = 0;
+  }
+
+  {
+    extern int doltliteDetectMergeFkViolations(
+        sqlite3*, const ProllyHash*, char**, int*);
+    extern int doltliteDetectMergeUniqueViolations(
+        sqlite3*, const ProllyHash*, char**, int*);
+    extern int doltliteDetectMergeCheckViolations(
+        sqlite3*, const ProllyHash*, char**, int*);
+    int nViolations = 0;
+    int nUnique = 0;
+    int nCheck = 0;
+    char *zDetectErrMsg = 0;
+
+    rc = doltliteDetectMergeFkViolations(db, ancCatHash,
+                                         &zDetectErrMsg, &nViolations);
+    if( rc==SQLITE_OK ){
+      rc = doltliteDetectMergeUniqueViolations(db, ancCatHash,
+                                               &zDetectErrMsg, &nUnique);
+    }
+    if( rc==SQLITE_OK ){
+      rc = doltliteDetectMergeCheckViolations(db, ancCatHash,
+                                              &zDetectErrMsg, &nCheck);
+    }
+    if( rc!=SQLITE_OK ){
+      if( zDetectErrMsg ){
+        sqlite3_result_error(context, zDetectErrMsg, -1);
+        sqlite3_free(zDetectErrMsg);
+      }
+      goto apply_rollback;
+    }
+    sqlite3_free(zDetectErrMsg);
+
+    if( nViolations + nUnique + nCheck > 0 ){
+      rc = doltliteHardReset(db, &savedState.sessionCatalogHash);
+      if( rc==SQLITE_OK ){
+        doltliteSetSessionBranch(db, savedState.zSessionBranch);
+        doltliteSetSessionHead(db, &savedState.sessionHead);
+        doltliteSetSessionStaged(db, &savedState.sessionStaged);
+        doltliteSetSessionMergeState(db, savedState.sessionIsMerging,
+                                     &savedState.sessionMergeCommit,
+                                     &savedState.sessionConflictsCatalog);
+        {
+          extern int doltliteClearAllConstraintViolations(sqlite3*);
+          doltliteClearAllConstraintViolations(db);
+        }
+        rc = doltlitePersistWorkingSet(db);
+      }
+      doltliteTxnStateClear(&savedState);
+      if( rc!=SQLITE_OK ){
+        return rc;
+      }
+      sqlite3_result_error(context,
+        "Committing this transaction resulted in a working set with "
+        "constraint violations, transaction rolled back.", -1);
+      return SQLITE_OK;
+    }
+  }
+
   if( *pnConflicts > 0 ){
     rc = doltliteReportConflicts(db, context, *pnConflicts,
                                  sqlite3_strnicmp(zMessage, "Revert", 6)==0

--- a/test/doltlite_cherry_pick.sh
+++ b/test/doltlite_cherry_pick.sh
@@ -480,6 +480,51 @@ run_test "cp_newtbl_val" "SELECT w FROM t2 WHERE id=1;" "new_table" "$DB"
 rm -f "$DB"
 
 # ============================================================
+# Cherry-pick / revert: constraint violations roll back
+# ============================================================
+
+DB=/tmp/test_cp_violation_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, u INT UNIQUE, v TEXT);
+INSERT INTO t VALUES(1,1,'base1'),(2,2,'base2');
+SELECT dolt_commit('-A','-m','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+UPDATE t SET u=9, v='feat2' WHERE id=2;
+SELECT dolt_commit('-A','-m','feat_unique');
+SELECT dolt_checkout('main');
+UPDATE t SET u=9, v='main1' WHERE id=1;
+SELECT dolt_commit('-A','-m','main_unique');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test_match "cp_violation_err" \
+  "SELECT dolt_cherry_pick('feat');" \
+  "Error near line 1" "$DB"
+run_test "cp_violation_none" "SELECT count(*) FROM dolt_constraint_violations;" "0" "$DB"
+run_test "cp_violation_state" \
+  "SELECT group_concat(id || ':' || u || ':' || v, ',') FROM (SELECT id,u,v FROM t ORDER BY id);" \
+  "1:9:main1,2:2:base2" "$DB"
+
+rm -f "$DB"
+
+DB=/tmp/test_rv_violation_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, u INT UNIQUE, v TEXT);
+INSERT INTO t VALUES(1,1,'base1'),(2,2,'base2');
+SELECT dolt_commit('-A','-m','init');
+UPDATE t SET u=9, v='c1' WHERE id=1;
+SELECT dolt_commit('-A','-m','c1_set_9');
+UPDATE t SET u=1, v='c2_take_1' WHERE id=2;
+SELECT dolt_commit('-A','-m','c2_take_1');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test_match "rv_violation_err" \
+  "SELECT dolt_revert('HEAD~1');" \
+  "Error near line 1" "$DB"
+run_test "rv_violation_none" "SELECT count(*) FROM dolt_constraint_violations;" "0" "$DB"
+run_test "rv_violation_state" \
+  "SELECT group_concat(id || ':' || u || ':' || v, ',') FROM (SELECT id,u,v FROM t ORDER BY id);" \
+  "1:9:c1,2:1:c2_take_1" "$DB"
+
+rm -f "$DB"
+
+# ============================================================
 # Done
 # ============================================================
 

--- a/test/vc_oracle_revert_cherrypick_test.sh
+++ b/test/vc_oracle_revert_cherrypick_test.sh
@@ -168,6 +168,41 @@ oracle_error() {
   fi
 }
 
+oracle_error_poststate() {
+  local name="$1" setup="$2" dl_query="$3" dolt_query="${4:-$3}"
+  local dir="$TMPROOT/${name}_post"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  vc_oracle_run_doltlite_script "$dir/dl/db" "$dir/dl.out" "$dir/dl.err" "$setup" || true
+  local dl_out
+  dl_out=$(
+    printf ".headers off\n.mode list\n%s;\n" "$dl_query" \
+      | "$DOLTLITE" "$dir/dl/db" 2>>"$dir/dl.err" \
+      | tr -d '\r'
+  )
+
+  local dolt_setup
+  dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
+  vc_oracle_run_dolt_script "$dir/dt" "$dir/dt.out" "$dir/dt.err" "$dolt_setup" || true
+  local dt_out
+  dt_out=$(
+    cd "$dir/dt" || exit 1
+    "$DOLT" sql -r csv -q "$dolt_query" 2>>"$dir/dt.err" \
+      | tail -n +2 \
+      | tr -d '"\r'
+  )
+
+  if [ "$dl_out" = "$dt_out" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite: |$dl_out|"
+    echo "    dolt:     |$dt_out|"
+  fi
+}
+
 echo "=== Version Control Oracle Tests: dolt_revert / dolt_cherry_pick ==="
 echo ""
 
@@ -637,6 +672,39 @@ oracle_error "cherry_pick_initial_commit" "
 $SEED
 SELECT dolt_cherry_pick((SELECT commit_hash FROM dolt_log WHERE message = 'Initialize data repository'));
 "
+
+oracle_error_poststate "cherry_pick_constraint_violation_rolls_back" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, u INT UNIQUE, v TEXT);
+INSERT INTO t VALUES (1,1,'base1'),(2,2,'base2');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','init');
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+UPDATE t SET u=9, v='feat2' WHERE id=2;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat_unique');
+SELECT dolt_checkout('main');
+UPDATE t SET u=9, v='main1' WHERE id=1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main_unique');
+SELECT dolt_cherry_pick('feature');
+" "SELECT (SELECT count(*) FROM dolt_constraint_violations) || '|' || (SELECT group_concat(id || ':' || u || ':' || v, ',') FROM (SELECT id,u,v FROM t ORDER BY id) AS ordered_rows)" \
+"SELECT CONCAT((SELECT COUNT(*) FROM dolt_constraint_violations), '|', (SELECT GROUP_CONCAT(CONCAT(id, ':', u, ':', v) ORDER BY id SEPARATOR ',') FROM t))"
+
+oracle_error_poststate "revert_constraint_violation_rolls_back" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, u INT UNIQUE, v TEXT);
+INSERT INTO t VALUES (1,1,'base1'),(2,2,'base2');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','init');
+UPDATE t SET u=9, v='c1' WHERE id=1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c1_set_9');
+UPDATE t SET u=1, v='c2_take_1' WHERE id=2;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2_take_1');
+SELECT dolt_revert('HEAD~1');
+" "SELECT (SELECT count(*) FROM dolt_constraint_violations) || '|' || (SELECT group_concat(id || ':' || u || ':' || v, ',') FROM (SELECT id,u,v FROM t ORDER BY id) AS ordered_rows)" \
+"SELECT CONCAT((SELECT COUNT(*) FROM dolt_constraint_violations), '|', (SELECT GROUP_CONCAT(CONCAT(id, ':', u, ':', v) ORDER BY id SEPARATOR ',') FROM t))"
 
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="


### PR DESCRIPTION
## Summary
- detect FK / UNIQUE / CHECK violations in the shared cherry-pick / revert replay path
- roll the working set back instead of committing invalid replay results
- add local and Dolt oracle coverage for constraint-violating cherry-pick and revert cases

## Testing
- cd build && bash ../test/doltlite_cherry_pick.sh
- bash test/vc_oracle_revert_cherrypick_test.sh ./build/doltlite dolt