### PR TITLE
Rollback autocommit replay and merge conflicts

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -475,6 +475,30 @@ static int doltliteReportConstraintViolations(
   return SQLITE_OK;
 }
 
+static void doltliteReportAutocommitConflictRollback(sqlite3_context *ctx){
+  sqlite3_result_error(ctx,
+    "Merge conflict detected, @autocommit transaction rolled back. "
+    "@autocommit must be disabled so that merge conflicts can be "
+    "resolved using the dolt_conflicts and dolt_schema_conflicts "
+    "tables before manually committing the transaction. "
+    "Alternatively, to commit transactions with merge conflicts, set "
+    "@@dolt_allow_commit_conflicts = 1",
+    -1);
+}
+
+static int doltliteRollbackAutocommitConflict(
+  sqlite3 *db,
+  sqlite3_context *ctx,
+  DoltliteTxnState *pSaved
+){
+  int rc = doltliteRestoreTxnState(db, pSaved);
+  doltliteTxnStateClear(pSaved);
+  if( rc==SQLITE_OK ){
+    doltliteReportAutocommitConflictRollback(ctx);
+  }
+  return rc;
+}
+
 static void addFreeEntries(
   struct TableEntry *aWorking, int nWorking,
   struct TableEntry *aStaged,  int nStaged,
@@ -2340,11 +2364,14 @@ static void doltliteMergeFunc(
   }
 
   if( nMergeConflicts > 0 ){
-    rc = doltliteReportConflicts(db, context, nMergeConflicts, "Merge");
-    if( graphLocked ){
-      chunkStoreUnlock(cs);
-      graphLocked = 0;
+    if( db->autoCommit ){
+      rc = doltliteRollbackAutocommitConflict(db, context, &savedState);
+      if( rc!=SQLITE_OK ){
+        sqlite3_result_error_code(context, rc);
+      }
+      return;
     }
+    rc = doltliteReportConflicts(db, context, nMergeConflicts, "Merge");
     if( rc!=SQLITE_OK ){
       sqlite3_result_error_code(context,
           doltliteRestoreTxnStateOnFailure(db, &savedState, rc));
@@ -2538,11 +2565,19 @@ static int applyMergedCatalogAndCommit(
   }
 
   if( *pnConflicts > 0 ){
+    if( graphLocked ){
+      chunkStoreUnlock(cs);
+      graphLocked = 0;
+    }
+    if( db->autoCommit ){
+      rc = doltliteRollbackAutocommitConflict(db, context, &savedState);
+      if( rc!=SQLITE_OK ) return rc;
+      return SQLITE_OK;
+    }
     rc = doltliteReportConflicts(db, context, *pnConflicts,
                                  sqlite3_strnicmp(zMessage, "Revert", 6)==0
                                    ? "Revert" : "Cherry-pick");
     if( rc!=SQLITE_OK ) goto apply_rollback;
-    chunkStoreUnlock(cs);
     doltliteTxnStateClear(&savedState);
     return SQLITE_OK;
   }

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -2364,6 +2364,10 @@ static void doltliteMergeFunc(
   }
 
   if( nMergeConflicts > 0 ){
+    if( graphLocked ){
+      chunkStoreUnlock(cs);
+      graphLocked = 0;
+    }
     if( db->autoCommit ){
       rc = doltliteRollbackAutocommitConflict(db, context, &savedState);
       if( rc!=SQLITE_OK ){
@@ -2539,27 +2543,35 @@ static int applyMergedCatalogAndCommit(
     sqlite3_free(zDetectErrMsg);
 
     if( nViolations + nUnique + nCheck > 0 ){
-      rc = doltliteHardReset(db, &savedState.sessionCatalogHash);
-      if( rc==SQLITE_OK ){
-        doltliteSetSessionBranch(db, savedState.zSessionBranch);
-        doltliteSetSessionHead(db, &savedState.sessionHead);
-        doltliteSetSessionStaged(db, &savedState.sessionStaged);
-        doltliteSetSessionMergeState(db, savedState.sessionIsMerging,
-                                     &savedState.sessionMergeCommit,
-                                     &savedState.sessionConflictsCatalog);
-        {
-          extern int doltliteClearAllConstraintViolations(sqlite3*);
-          doltliteClearAllConstraintViolations(db);
+      if( db->autoCommit ){
+        rc = doltliteHardReset(db, &savedState.sessionCatalogHash);
+        if( rc==SQLITE_OK ){
+          doltliteSetSessionBranch(db, savedState.zSessionBranch);
+          doltliteSetSessionHead(db, &savedState.sessionHead);
+          doltliteSetSessionStaged(db, &savedState.sessionStaged);
+          doltliteSetSessionMergeState(db, savedState.sessionIsMerging,
+                                       &savedState.sessionMergeCommit,
+                                       &savedState.sessionConflictsCatalog);
+          {
+            extern int doltliteClearAllConstraintViolations(sqlite3*);
+            doltliteClearAllConstraintViolations(db);
+          }
+          rc = doltlitePersistWorkingSet(db);
         }
-        rc = doltlitePersistWorkingSet(db);
+        doltliteTxnStateClear(&savedState);
+        if( rc!=SQLITE_OK ){
+          return rc;
+        }
+        sqlite3_result_error(context,
+          "Committing this transaction resulted in a working set with "
+          "constraint violations, transaction rolled back.", -1);
+      }else{
+        rc = doltliteReportConstraintViolations(db, context,
+                                 sqlite3_strnicmp(zMessage, "Revert", 6)==0
+                                   ? "Revert" : "Cherry-pick");
+        if( rc!=SQLITE_OK ) goto apply_rollback;
+        doltliteTxnStateClear(&savedState);
       }
-      doltliteTxnStateClear(&savedState);
-      if( rc!=SQLITE_OK ){
-        return rc;
-      }
-      sqlite3_result_error(context,
-        "Committing this transaction resulted in a working set with "
-        "constraint violations, transaction rolled back.", -1);
       return SQLITE_OK;
     }
   }

--- a/test/doltlite_behavior.sh
+++ b/test/doltlite_behavior.sh
@@ -30,24 +30,21 @@ SELECT dolt_commit('-A','-m','feat edit');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_merge('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Now we have unresolved conflicts; checkout should fail
+# In the same SQL session, unresolved conflicts block checkout
 run_test_match "checkout_blocked_conflict" \
-  "SELECT dolt_checkout('feature');" \
-  "conflict|merge" "$DB"
+  "SELECT dolt_merge('feature'); SELECT dolt_checkout('feature');" \
+  "unresolved merge conflicts" "$DB"
 
 run_test_match "checkout_create_blocked_conflict" \
-  "SELECT dolt_checkout('-b','blocked_branch');" \
-  "conflict|merge" "$DB"
+  "SELECT dolt_merge('feature'); SELECT dolt_checkout('-b','blocked_branch');" \
+  "unresolved merge conflicts" "$DB"
 
-run_test "checkout_create_no_branch_on_conflict" \
-  "SELECT count(*) FROM dolt_branches WHERE name='blocked_branch';" \
-  "0" "$DB"
+run_test_match "checkout_create_no_branch_on_conflict" \
+  "SELECT dolt_merge('feature'); SELECT dolt_checkout('-b','blocked_branch'); SELECT 'CNT|' || count(*) FROM dolt_branches WHERE name='blocked_branch';" \
+  "^CNT\\|0$" "$DB"
 
-# Test 2: Resolve conflicts, then checkout should succeed
-echo "SELECT dolt_conflicts_resolve('--ours','t');" | $DOLTLITE "$DB" > /dev/null 2>&1
-echo "SELECT dolt_commit('-A','-m','resolved');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
-run_test "checkout_after_resolve" \
+# Test 2: In a new session after autocommit rollback, checkout should succeed
+run_test "checkout_after_rollback" \
   "SELECT dolt_checkout('feature'); SELECT active_branch();" \
   "0
 feature" "$DB"
@@ -71,11 +68,8 @@ SELECT dolt_commit('-A','-m','feat2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_merge('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Abort the merge
-echo "SELECT dolt_merge('--abort');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
-# Checkout should now succeed
-run_test "checkout_after_abort" \
+# Merge rolled back across sessions; checkout should still succeed
+run_test "checkout_after_rolled_back_merge" \
   "SELECT dolt_checkout('feature'); SELECT active_branch();" \
   "0
 feature" "$DB"

--- a/test/doltlite_cherry_pick.sh
+++ b/test/doltlite_cherry_pick.sh
@@ -87,13 +87,7 @@ SELECT dolt_commit('-A','-m','main modifies row 1');" | $DOLTLITE "$DB" > /dev/n
 
 run_test_match "cp_conflict_msg" \
   "SELECT dolt_cherry_pick((SELECT hash FROM dolt_branches WHERE name='feat'));" \
-  "conflict" "$DB"
-
-run_test_match "cp_conflict_count" "SELECT count(*) FROM dolt_conflicts;" "^[1-9]" "$DB"
-run_test_match "cp_conflict_blocked" "SELECT dolt_commit('-A','-m','fail');" "unresolved" "$DB"
-
-# Resolve with ours
-echo "SELECT dolt_conflicts_resolve('--ours','t');" | $DOLTLITE "$DB" > /dev/null 2>&1
+  "conflict|rolled back" "$DB"
 run_test "cp_conflict_resolved" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
 run_test "cp_conflict_ours" "SELECT v FROM t WHERE id=1;" "main_val" "$DB"
 
@@ -266,12 +260,8 @@ SELECT dolt_commit('-A','-m','update to v3');" | $DOLTLITE "$DB" > /dev/null 2>&
 # this should conflict.
 run_test_match "rv_conf_msg" \
   "SELECT dolt_revert((SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1));" \
-  "conflict" "$DB"
-
-run_test_match "rv_conf_count" "SELECT count(*) FROM dolt_conflicts;" "^[1-9]" "$DB"
-
-# Resolve with ours (keep v3)
-echo "SELECT dolt_conflicts_resolve('--ours','t');" | $DOLTLITE "$DB" > /dev/null 2>&1
+  "conflict|rolled back" "$DB"
+run_test "rv_conf_count" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
 run_test "rv_conf_ours" "SELECT v FROM t WHERE id=1;" "v3" "$DB"
 
 rm -f "$DB"

--- a/test/doltlite_conflict_rows.sh
+++ b/test/doltlite_conflict_rows.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 #
 # Tests for per-row conflict resolution via dolt_conflicts_<tablename>.
-# Uses DELETE FROM dolt_conflicts_<table> WHERE base_id=N to resolve
-# individual conflict rows.
+# Autocommit conflict state is session-local, so all conflict-row checks
+# happen in a single SQL invocation.
 #
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
@@ -12,8 +12,7 @@ run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -
 echo "=== Doltlite Per-Row Conflict Resolution Tests ==="
 echo ""
 
-# Helper: create a merge conflict on row 1 of table t
-setup_conflict() {
+setup_row_conflict_repo() {
   local DB="$1"
   rm -f "$DB"
   echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -26,295 +25,29 @@ UPDATE t SET v='hf_val' WHERE id=1;
 SELECT dolt_commit('-A','-m','hf');
 SELECT dolt_checkout('main');
 UPDATE t SET v='main_val' WHERE id=1;
-SELECT dolt_commit('-A','-m','main');
-SELECT dolt_merge('hf');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-A','-m','main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 }
 
-# ============================================================
-# View individual conflict rows
-# ============================================================
-
-DB=/tmp/test_cfrow_view_$$.db
-setup_conflict "$DB"
-
-run_test "view_count" "SELECT count(*) FROM dolt_conflicts_t;" "1" "$DB"
-run_test "view_base_id" "SELECT base_id FROM dolt_conflicts_t;" "1" "$DB"
-run_test "view_our_id" "SELECT our_id FROM dolt_conflicts_t;" "1" "$DB"
-run_test "view_their_id" "SELECT their_id FROM dolt_conflicts_t;" "1" "$DB"
-# User columns are projected individually now (Dolt-compatible schema).
-# The v column is declared TEXT so typeof(base_v) is "text".
-run_test_match "view_base_val" "SELECT typeof(base_v) FROM dolt_conflicts_t;" "text|null" "$DB"
-run_test_match "view_their_val" "SELECT typeof(their_v) FROM dolt_conflicts_t;" "text" "$DB"
-
-rm -f "$DB"
-
-# ============================================================
-# DELETE resolves individual conflict (keeps ours)
-# ============================================================
-
-DB=/tmp/test_cfrow_del_$$.db
-setup_conflict "$DB"
-
-echo "DELETE FROM dolt_conflicts_t WHERE base_id=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
-
-# After deleting all conflicts, the conflict table module is removed
-run_test "del_summary_cleared" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
-run_test "del_ours_kept" "SELECT v FROM t WHERE id=1;" "main_val" "$DB"
-run_test "del_other_ok" "SELECT v FROM t WHERE id=2;" "keep" "$DB"
-# Merge commit was already created; no new commit needed after resolving
-run_test "del_clean" "SELECT count(*) FROM dolt_status;" "0" "$DB"
-
-rm -f "$DB"
-
-# ============================================================
-# --ours resolution clears per-table (not all)
-# ============================================================
-
-DB=/tmp/test_cfrow_ours_$$.db
-setup_conflict "$DB"
-
-echo "SELECT dolt_conflicts_resolve('--ours','t');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
-run_test "ours_cleared" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
-run_test "ours_val" "SELECT v FROM t WHERE id=1;" "main_val" "$DB"
-
-rm -f "$DB"
-
-# ============================================================
-# Conflict table not present when no conflicts
-# ============================================================
-
-DB=/tmp/test_cfrow_noconf_$$.db; rm -f "$DB"
-echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
-INSERT INTO t VALUES(1,'a');
-SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
-run_test "noconf_table" "SELECT count(*) FROM dolt_conflicts_t;" "0" "$DB"
-run_test "noconf_summary" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
-
-rm -f "$DB"
-
-# ============================================================
-# Conflict table persists across reopen
-# ============================================================
-
-DB=/tmp/test_cfrow_persist_$$.db
-setup_conflict "$DB"
-
-# Reopen — conflicts visible
-run_test "persist_summary" "SELECT count(*) FROM dolt_conflicts;" "1" "$DB"
-run_test "persist_rows" "SELECT count(*) FROM dolt_conflicts_t;" "1" "$DB"
-run_test "persist_rowid" "SELECT base_id FROM dolt_conflicts_t;" "1" "$DB"
-
-# Delete via new session
-echo "DELETE FROM dolt_conflicts_t WHERE base_id=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
-
-# Verify cleared after another reopen
-run_test "persist_after_del" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
-
-rm -f "$DB"
-
-# ============================================================
-# DELETE with no matching row is a no-op
-# ============================================================
-
-DB=/tmp/test_cfrow_noop_$$.db
-setup_conflict "$DB"
-
-echo "DELETE FROM dolt_conflicts_t WHERE base_id=999;" | $DOLTLITE "$DB" > /dev/null 2>&1
-
-run_test "noop_still_there" "SELECT count(*) FROM dolt_conflicts_t;" "1" "$DB"
-run_test "noop_rowid" "SELECT base_id FROM dolt_conflicts_t;" "1" "$DB"
-
-rm -f "$DB"
-
-# ============================================================
-# Cherry-pick conflict with per-row resolution
-# ============================================================
-
-DB=/tmp/test_cfrow_cp_$$.db; rm -f "$DB"
-echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+setup_delete_conflict_repo() {
+  local DB="$1"
+  rm -f "$DB"
+  echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+CREATE TABLE trig_log(note TEXT);
 INSERT INTO t VALUES(1,'orig');
 SELECT dolt_commit('-A','-m','init');
-SELECT dolt_branch('feat');
-SELECT dolt_checkout('feat');
-UPDATE t SET v='feat_val' WHERE id=1;
-SELECT dolt_commit('-A','-m','feat');
+SELECT dolt_branch('hf');
+SELECT dolt_checkout('hf');
+DELETE FROM t WHERE id=1;
+SELECT dolt_commit('-A','-m','hf delete');
 SELECT dolt_checkout('main');
 UPDATE t SET v='main_val' WHERE id=1;
-SELECT dolt_commit('-A','-m','main');
-SELECT dolt_cherry_pick((SELECT hash FROM dolt_branches WHERE name='feat'));" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-A','-m','main update');" | $DOLTLITE "$DB" > /dev/null 2>&1
+}
 
-run_test "cp_has_conflict" "SELECT count(*) FROM dolt_conflicts_t;" "1" "$DB"
-
-echo "DELETE FROM dolt_conflicts_t WHERE base_id=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
-run_test "cp_resolved" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
-run_test "cp_val" "SELECT v FROM t WHERE id=1;" "main_val" "$DB"
-
-rm -f "$DB"
-
-# ============================================================
-# Conflict on non-trivial rowid
-# ============================================================
-
-DB=/tmp/test_cfrow_bigid_$$.db; rm -f "$DB"
-echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
-INSERT INTO t VALUES(1000,'orig');
-SELECT dolt_commit('-A','-m','init');
-SELECT dolt_branch('hf');
-SELECT dolt_checkout('hf');
-UPDATE t SET v='hf_val' WHERE id=1000;
-SELECT dolt_commit('-A','-m','hf');
-SELECT dolt_checkout('main');
-UPDATE t SET v='main_val' WHERE id=1000;
-SELECT dolt_commit('-A','-m','main');
-SELECT dolt_merge('hf');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
-run_test "bigid_rowid" "SELECT base_id FROM dolt_conflicts_t;" "1000" "$DB"
-
-echo "DELETE FROM dolt_conflicts_t WHERE base_id=1000;" | $DOLTLITE "$DB" > /dev/null 2>&1
-run_test "bigid_cleared" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
-run_test "bigid_val" "SELECT v FROM t WHERE id=1000;" "main_val" "$DB"
-
-rm -f "$DB"
-
-# ============================================================
-# DELETE resolves targeted TEXT PK conflict row
-# ============================================================
-
-DB=/tmp/test_cfrow_textpk_$$.db; rm -f "$DB"
-echo "CREATE TABLE t(id VARCHAR(32) PRIMARY KEY, v TEXT);
-INSERT INTO t VALUES('alice','orig');
-INSERT INTO t VALUES('bob','keep');
-SELECT dolt_commit('-A','-m','init');
-SELECT dolt_branch('hf');
-SELECT dolt_checkout('hf');
-UPDATE t SET v='hf_alice' WHERE id='alice';
-UPDATE t SET v='hf_bob' WHERE id='bob';
-SELECT dolt_commit('-A','-m','hf');
-SELECT dolt_checkout('main');
-UPDATE t SET v='main_alice' WHERE id='alice';
-UPDATE t SET v='main_bob' WHERE id='bob';
-SELECT dolt_commit('-A','-m','main');
-SELECT dolt_merge('hf');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
-run_test "textpk_conflict_rows" "SELECT count(*) FROM dolt_conflicts_t;" "2" "$DB"
-echo "DELETE FROM dolt_conflicts_t WHERE our_id='alice';" | $DOLTLITE "$DB" > /dev/null 2>&1
-run_test "textpk_one_conflict_left" "SELECT count(*) FROM dolt_conflicts_t;" "1" "$DB"
-run_test "textpk_remaining_conflict" "SELECT our_id FROM dolt_conflicts_t;" "bob" "$DB"
-run_test "textpk_deleted_row_kept_ours" "SELECT v FROM t WHERE id='alice';" "main_alice" "$DB"
-run_test "textpk_remaining_row_still_conflicted" "SELECT v FROM t WHERE id='bob';" "main_bob" "$DB"
-
-rm -f "$DB"
-
-# ============================================================
-# DELETE ALL resolves all TEXT PK conflict rows
-# ============================================================
-
-DB=/tmp/test_cfrow_textpk_all_$$.db; rm -f "$DB"
-echo "CREATE TABLE t(id VARCHAR(32) PRIMARY KEY, v TEXT);
-INSERT INTO t VALUES('alice','orig');
-INSERT INTO t VALUES('bob','keep');
-SELECT dolt_commit('-A','-m','init');
-SELECT dolt_branch('hf');
-SELECT dolt_checkout('hf');
-UPDATE t SET v='hf_alice' WHERE id='alice';
-UPDATE t SET v='hf_bob' WHERE id='bob';
-SELECT dolt_commit('-A','-m','hf');
-SELECT dolt_checkout('main');
-UPDATE t SET v='main_alice' WHERE id='alice';
-UPDATE t SET v='main_bob' WHERE id='bob';
-SELECT dolt_commit('-A','-m','main');
-SELECT dolt_merge('hf');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
-echo "DELETE FROM dolt_conflicts_t;" | $DOLTLITE "$DB" > /dev/null 2>&1
-run_test "textpk_all_conflicts_cleared" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
-run_test "textpk_all_kept_ours_alice" "SELECT v FROM t WHERE id='alice';" "main_alice" "$DB"
-run_test "textpk_all_kept_ours_bob" "SELECT v FROM t WHERE id='bob';" "main_bob" "$DB"
-
-rm -f "$DB"
-
-# ============================================================
-# DELETE resolves targeted composite PK conflict row
-# ============================================================
-
-DB=/tmp/test_cfrow_compoundpk_$$.db; rm -f "$DB"
-echo "CREATE TABLE t(a INT, b INT, v TEXT, PRIMARY KEY(a,b));
-INSERT INTO t VALUES(1,1,'orig11');
-INSERT INTO t VALUES(1,2,'orig12');
-SELECT dolt_commit('-A','-m','init');
-SELECT dolt_branch('hf');
-SELECT dolt_checkout('hf');
-UPDATE t SET v='hf11' WHERE a=1 AND b=1;
-UPDATE t SET v='hf12' WHERE a=1 AND b=2;
-SELECT dolt_commit('-A','-m','hf');
-SELECT dolt_checkout('main');
-UPDATE t SET v='main11' WHERE a=1 AND b=1;
-UPDATE t SET v='main12' WHERE a=1 AND b=2;
-SELECT dolt_commit('-A','-m','main');
-SELECT dolt_merge('hf');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
-run_test "compoundpk_conflict_rows" "SELECT count(*) FROM dolt_conflicts_t;" "2" "$DB"
-echo "DELETE FROM dolt_conflicts_t WHERE our_a=1 AND our_b=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
-run_test "compoundpk_one_conflict_left" "SELECT count(*) FROM dolt_conflicts_t;" "1" "$DB"
-run_test "compoundpk_remaining_conflict" "SELECT our_a || ':' || our_b FROM dolt_conflicts_t;" "1:2" "$DB"
-run_test "compoundpk_deleted_row_kept_ours" "SELECT v FROM t WHERE a=1 AND b=1;" "main11" "$DB"
-run_test "compoundpk_remaining_row_still_conflicted" "SELECT v FROM t WHERE a=1 AND b=2;" "main12" "$DB"
-
-rm -f "$DB"
-
-# ============================================================
-# DELETE ALL resolves all composite PK conflict rows
-# ============================================================
-
-DB=/tmp/test_cfrow_compoundpk_all_$$.db; rm -f "$DB"
-echo "CREATE TABLE t(a INT, b INT, v TEXT, PRIMARY KEY(a,b));
-INSERT INTO t VALUES(1,1,'orig11');
-INSERT INTO t VALUES(1,2,'orig12');
-SELECT dolt_commit('-A','-m','init');
-SELECT dolt_branch('hf');
-SELECT dolt_checkout('hf');
-UPDATE t SET v='hf11' WHERE a=1 AND b=1;
-UPDATE t SET v='hf12' WHERE a=1 AND b=2;
-SELECT dolt_commit('-A','-m','hf');
-SELECT dolt_checkout('main');
-UPDATE t SET v='main11' WHERE a=1 AND b=1;
-UPDATE t SET v='main12' WHERE a=1 AND b=2;
-SELECT dolt_commit('-A','-m','main');
-SELECT dolt_merge('hf');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
-echo "DELETE FROM dolt_conflicts_t;" | $DOLTLITE "$DB" > /dev/null 2>&1
-run_test "compoundpk_all_conflicts_cleared" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
-run_test "compoundpk_all_kept_ours_11" "SELECT v FROM t WHERE a=1 AND b=1;" "main11" "$DB"
-run_test "compoundpk_all_kept_ours_12" "SELECT v FROM t WHERE a=1 AND b=2;" "main12" "$DB"
-
-rm -f "$DB"
-
-# ============================================================
-# Resolve, then make new commit, then verify log
-# ============================================================
-
-DB=/tmp/test_cfrow_fullflow_$$.db
-setup_conflict "$DB"
-
-echo "DELETE FROM dolt_conflicts_t WHERE base_id=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
-
-# Conflicts resolved but merge not committed yet — user must commit
-run_test "flow_val" "SELECT v FROM t WHERE id=1;" "main_val" "$DB"
-run_test "flow_no_conflicts" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
-
-# Commit the resolved merge
-echo "SELECT dolt_commit('-A','-m','Merge resolved');" | $DOLTLITE "$DB" > /dev/null 2>&1
-run_test_match "flow_log" "SELECT message FROM dolt_log LIMIT 1;" "Merge" "$DB"
-
-rm -f "$DB"
-
-# ============================================================
-# Text PK conflicts delete by synthetic rowid
-# ============================================================
-
-DB=/tmp/test_cfrow_textpk_$$.db; rm -f "$DB"
-echo "CREATE TABLE t(id TEXT PRIMARY KEY, v TEXT);
+setup_text_pk_conflict_repo() {
+  local DB="$1"
+  rm -f "$DB"
+  echo "CREATE TABLE t(id TEXT PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES('a','orig_a'),('b','orig_b');
 SELECT dolt_commit('-A','-m','init');
 SELECT dolt_branch('hf');
@@ -325,24 +58,13 @@ SELECT dolt_commit('-A','-m','hf');
 SELECT dolt_checkout('main');
 UPDATE t SET v='main_a' WHERE id='a';
 UPDATE t SET v='main_b' WHERE id='b';
-SELECT dolt_commit('-A','-m','main');
-SELECT dolt_merge('hf');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-A','-m','main');" | $DOLTLITE "$DB" > /dev/null 2>&1
+}
 
-run_test "textpk_conflict_count" "SELECT count(*) FROM dolt_conflicts_t;" "2" "$DB"
-echo "DELETE FROM dolt_conflicts_t WHERE base_id='a';" | $DOLTLITE "$DB" > /dev/null 2>&1
-run_test "textpk_target_delete_leaves_one" "SELECT count(*) FROM dolt_conflicts_t;" "1" "$DB"
-run_test "textpk_target_delete_keeps_b" "SELECT base_id FROM dolt_conflicts_t;" "b" "$DB"
-echo "DELETE FROM dolt_conflicts_t;" | $DOLTLITE "$DB" > /dev/null 2>&1
-run_test "textpk_full_delete_clears" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
-
-rm -f "$DB"
-
-# ============================================================
-# Composite PK conflicts delete by synthetic rowid
-# ============================================================
-
-DB=/tmp/test_cfrow_compositepk_$$.db; rm -f "$DB"
-echo "CREATE TABLE t(a INT, b INT, v TEXT, PRIMARY KEY(a,b));
+setup_composite_pk_conflict_repo() {
+  local DB="$1"
+  rm -f "$DB"
+  echo "CREATE TABLE t(a INT, b INT, v TEXT, PRIMARY KEY(a,b));
 INSERT INTO t VALUES(1,1,'orig_a'),(2,2,'orig_b');
 SELECT dolt_commit('-A','-m','init');
 SELECT dolt_branch('hf');
@@ -353,21 +75,85 @@ SELECT dolt_commit('-A','-m','hf');
 SELECT dolt_checkout('main');
 UPDATE t SET v='main_a' WHERE a=1 AND b=1;
 UPDATE t SET v='main_b' WHERE a=2 AND b=2;
-SELECT dolt_commit('-A','-m','main');
-SELECT dolt_merge('hf');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-A','-m','main');" | $DOLTLITE "$DB" > /dev/null 2>&1
+}
 
-run_test "compositepk_conflict_count" "SELECT count(*) FROM dolt_conflicts_t;" "2" "$DB"
-echo "DELETE FROM dolt_conflicts_t WHERE base_a=1 AND base_b=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
-run_test "compositepk_target_delete_leaves_one" "SELECT count(*) FROM dolt_conflicts_t;" "1" "$DB"
-run_test "compositepk_target_delete_keeps_other" "SELECT base_a || ',' || base_b FROM dolt_conflicts_t;" "2,2" "$DB"
-echo "DELETE FROM dolt_conflicts_t;" | $DOLTLITE "$DB" > /dev/null 2>&1
-run_test "compositepk_full_delete_clears" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
-
+# View individual conflict rows
+DB=/tmp/test_cfrow_view_$$.db
+setup_row_conflict_repo "$DB"
+run_test_match "view_count" "SELECT dolt_merge('hf'); SELECT 'VC|' || count(*) FROM dolt_conflicts_t;" "^VC\\|1$" "$DB"
+run_test_match "view_base_id" "SELECT dolt_merge('hf'); SELECT 'VB|' || base_id FROM dolt_conflicts_t;" "^VB\\|1$" "$DB"
+run_test_match "view_our_id" "SELECT dolt_merge('hf'); SELECT 'VO|' || our_id FROM dolt_conflicts_t;" "^VO\\|1$" "$DB"
+run_test_match "view_their_id" "SELECT dolt_merge('hf'); SELECT 'VT|' || their_id FROM dolt_conflicts_t;" "^VT\\|1$" "$DB"
+run_test_match "view_base_val" "SELECT dolt_merge('hf'); SELECT 'VBT|' || typeof(base_v) FROM dolt_conflicts_t;" "^VBT\\|(text|null)$" "$DB"
+run_test_match "view_their_val" "SELECT dolt_merge('hf'); SELECT 'VTT|' || typeof(their_v) FROM dolt_conflicts_t;" "^VTT\\|text$" "$DB"
 rm -f "$DB"
 
-# ============================================================
-# Done
-# ============================================================
+# DELETE resolves individual conflict (keeps ours)
+DB=/tmp/test_cfrow_del_$$.db
+setup_row_conflict_repo "$DB"
+run_test_match "del_summary_cleared" "SELECT dolt_merge('hf'); DELETE FROM dolt_conflicts_t WHERE base_id=1; SELECT 'DC|' || count(*) FROM dolt_conflicts;" "^DC\\|0$" "$DB"
+run_test_match "del_ours_kept" "SELECT dolt_merge('hf'); DELETE FROM dolt_conflicts_t WHERE base_id=1; SELECT 'DV|' || v FROM t WHERE id=1;" "^DV\\|main_val$" "$DB"
+run_test_match "del_other_ok" "SELECT dolt_merge('hf'); DELETE FROM dolt_conflicts_t WHERE base_id=1; SELECT 'DK|' || v FROM t WHERE id=2;" "^DK\\|keep$" "$DB"
+run_test_match "del_clean" "SELECT dolt_merge('hf'); DELETE FROM dolt_conflicts_t WHERE base_id=1; SELECT 'DS|' || count(*) FROM dolt_status;" "^DS\\|0$" "$DB"
+rm -f "$DB"
+
+# --ours resolution clears per-table
+DB=/tmp/test_cfrow_ours_$$.db
+setup_row_conflict_repo "$DB"
+run_test_match "ours_cleared" "SELECT dolt_merge('hf'); SELECT dolt_conflicts_resolve('--ours','t'); SELECT 'OC|' || count(*) FROM dolt_conflicts;" "^OC\\|0$" "$DB"
+run_test_match "ours_val" "SELECT dolt_merge('hf'); SELECT dolt_conflicts_resolve('--ours','t'); SELECT 'OV|' || v FROM t WHERE id=1;" "^OV\\|main_val$" "$DB"
+rm -f "$DB"
+
+# No conflict table when no conflicts
+DB=/tmp/test_cfrow_noconf_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
+run_test "noconf_table" "SELECT count(*) FROM dolt_conflicts_t;" "0" "$DB"
+run_test "noconf_summary" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
+rm -f "$DB"
+
+# Conflict rows do not persist across reopen after autocommit rollback
+DB=/tmp/test_cfrow_persist_$$.db
+setup_row_conflict_repo "$DB"
+echo "SELECT dolt_merge('hf');" | $DOLTLITE "$DB" > /dev/null 2>&1
+run_test "persist_summary" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
+run_test "persist_rows" "SELECT count(*) FROM dolt_conflicts_t;" "0" "$DB"
+rm -f "$DB"
+
+# DELETE with no matching row is a no-op
+DB=/tmp/test_cfrow_noop_$$.db
+setup_row_conflict_repo "$DB"
+run_test_match "noop_still_there" "BEGIN; SELECT dolt_merge('hf'); DELETE FROM dolt_conflicts_t WHERE base_id=999; SELECT 'NC|' || count(*) FROM dolt_conflicts_t; ROLLBACK;" "^NC\\|1$" "$DB"
+run_test_match "noop_rowid" "BEGIN; SELECT dolt_merge('hf'); DELETE FROM dolt_conflicts_t WHERE base_id=999; SELECT 'NR|' || base_id FROM dolt_conflicts_t; ROLLBACK;" "^NR\\|1$" "$DB"
+rm -f "$DB"
+
+# Delete/delete conflict with --theirs keeps delete and skips triggers
+DB=/tmp/test_cfrow_delete_$$.db
+setup_delete_conflict_repo "$DB"
+run_test_match "theirs_delete_clears" "BEGIN; SELECT dolt_merge('hf'); SELECT dolt_conflicts_resolve('--theirs','t'); SELECT 'TC|' || count(*) FROM dolt_conflicts; ROLLBACK;" "^TC\\|0$" "$DB"
+run_test_match "theirs_delete_removes_row" "BEGIN; SELECT dolt_merge('hf'); CREATE TRIGGER audit_delete BEFORE DELETE ON t BEGIN INSERT INTO trig_log VALUES('fired'); END; SELECT dolt_conflicts_resolve('--theirs','t'); SELECT 'TD|' || count(*) FROM t WHERE id=1; ROLLBACK;" "^TD\\|0$" "$DB"
+run_test_match "theirs_delete_trigger_skipped" "BEGIN; SELECT dolt_merge('hf'); CREATE TRIGGER audit_delete BEFORE DELETE ON t BEGIN INSERT INTO trig_log VALUES('fired'); END; SELECT dolt_conflicts_resolve('--theirs','t'); SELECT 'TT|' || count(*) FROM trig_log; ROLLBACK;" "^TT\\|0$" "$DB"
+rm -f "$DB"
+
+# Text PK conflicts delete by synthetic rowid
+DB=/tmp/test_cfrow_textpk_$$.db
+setup_text_pk_conflict_repo "$DB"
+run_test_match "textpk_conflict_count" "SELECT dolt_merge('hf'); SELECT 'TC|' || count(*) FROM dolt_conflicts_t;" "^TC\\|2$" "$DB"
+run_test_match "textpk_target_delete_leaves_one" "BEGIN; SELECT dolt_merge('hf'); DELETE FROM dolt_conflicts_t WHERE base_id='a'; SELECT 'TL|' || count(*) FROM dolt_conflicts_t; ROLLBACK;" "^TL\\|1$" "$DB"
+run_test_match "textpk_target_delete_keeps_b" "BEGIN; SELECT dolt_merge('hf'); DELETE FROM dolt_conflicts_t WHERE base_id='a'; SELECT 'TK|' || base_id FROM dolt_conflicts_t; ROLLBACK;" "^TK\\|b$" "$DB"
+run_test_match "textpk_full_delete_clears" "BEGIN; SELECT dolt_merge('hf'); DELETE FROM dolt_conflicts_t; SELECT 'TF|' || count(*) FROM dolt_conflicts; ROLLBACK;" "^TF\\|0$" "$DB"
+rm -f "$DB"
+
+# Composite PK conflicts delete by synthetic rowid
+DB=/tmp/test_cfrow_compositepk_$$.db
+setup_composite_pk_conflict_repo "$DB"
+run_test_match "compositepk_conflict_count" "SELECT dolt_merge('hf'); SELECT 'CC|' || count(*) FROM dolt_conflicts_t;" "^CC\\|2$" "$DB"
+run_test_match "compositepk_target_delete_leaves_one" "BEGIN; SELECT dolt_merge('hf'); DELETE FROM dolt_conflicts_t WHERE base_a=1 AND base_b=1; SELECT 'CL|' || count(*) FROM dolt_conflicts_t; ROLLBACK;" "^CL\\|1$" "$DB"
+run_test_match "compositepk_target_delete_keeps_other" "BEGIN; SELECT dolt_merge('hf'); DELETE FROM dolt_conflicts_t WHERE base_a=1 AND base_b=1; SELECT 'CK|' || base_a || ',' || base_b FROM dolt_conflicts_t; ROLLBACK;" "^CK\\|2,2$" "$DB"
+run_test_match "compositepk_full_delete_clears" "BEGIN; SELECT dolt_merge('hf'); DELETE FROM dolt_conflicts_t; SELECT 'CF|' || count(*) FROM dolt_conflicts; ROLLBACK;" "^CF\\|0$" "$DB"
+rm -f "$DB"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/doltlite_conflicts.sh
+++ b/test/doltlite_conflicts.sh
@@ -7,7 +7,7 @@ run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -
 echo "=== Doltlite Conflicts Tests ==="
 echo ""
 
-# Test 1: Merge with conflict → dolt_conflicts shows it
+# Test 1: Autocommit merge with conflict surfaces conflict state in-session
 DB=/tmp/test_cf_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'orig'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -15,18 +15,25 @@ echo "UPDATE t SET v='main'; SELECT dolt_commit('-A','-m','main');" | $DOLTLITE 
 echo "SELECT dolt_checkout('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "UPDATE t SET v='feat'; SELECT dolt_commit('-A','-m','feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
-echo "SELECT dolt_merge('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
+run_test_match "conflicts_table" \
+  "SELECT dolt_merge('feature'); SELECT 'CT|' || \"table\" FROM dolt_conflicts;" \
+  "^CT\\|t$" "$DB"
+run_test_match "conflicts_count" \
+  "SELECT dolt_merge('feature'); SELECT 'CC|' || num_conflicts FROM dolt_conflicts;" \
+  "^CC\\|1$" "$DB"
 
-run_test "conflicts_table" "SELECT \"table\" FROM dolt_conflicts;" "t" "$DB"
-run_test "conflicts_count" "SELECT num_conflicts FROM dolt_conflicts;" "1" "$DB"
+# Test 2: Commit blocked with conflicts in the same SQL session
+run_test_match "commit_blocked" \
+  "SELECT dolt_merge('feature'); SELECT dolt_commit('-A','-m','fail');" \
+  "unresolved merge conflicts" "$DB"
 
-# Test 2: Commit blocked with conflicts
-run_test_match "commit_blocked" "SELECT dolt_commit('-A','-m','fail');" "unresolved merge conflicts" "$DB"
-
-# Test 3: Resolve --ours keeps our value
-echo "SELECT dolt_conflicts_resolve('--ours','t');" | $DOLTLITE "$DB" > /dev/null 2>&1
-run_test "resolved_no_conflicts" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
-run_test "ours_value_kept" "SELECT v FROM t;" "main" "$DB"
+# Test 3: Resolve --ours keeps our value in-session
+run_test_match "resolved_no_conflicts" \
+  "SELECT dolt_merge('feature'); SELECT dolt_conflicts_resolve('--ours','t'); SELECT 'RC|' || count(*) FROM dolt_conflicts; SELECT 'RV|' || v FROM t;" \
+  "^RC\\|0$" "$DB"
+run_test_match "ours_value_kept" \
+  "SELECT dolt_merge('feature'); SELECT dolt_conflicts_resolve('--ours','t'); SELECT 'RV|' || v FROM t;" \
+  "^RV\\|main$" "$DB"
 
 # Test 4: Resolve --theirs (new scenario)
 DB2=/tmp/test_cf2_$$.db; rm -f "$DB2"
@@ -36,10 +43,12 @@ echo "UPDATE t SET v='main2'; SELECT dolt_commit('-A','-m','main');" | $DOLTLITE
 echo "SELECT dolt_checkout('feature');" | $DOLTLITE "$DB2" > /dev/null 2>&1
 echo "UPDATE t SET v='feat2'; SELECT dolt_commit('-A','-m','feat');" | $DOLTLITE "$DB2" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB2" > /dev/null 2>&1
-echo "SELECT dolt_merge('feature');" | $DOLTLITE "$DB2" > /dev/null 2>&1
-run_test "theirs_has_conflict" "SELECT num_conflicts FROM dolt_conflicts;" "1" "$DB2"
-echo "SELECT dolt_conflicts_resolve('--theirs','t');" | $DOLTLITE "$DB2" > /dev/null 2>&1
-run_test "theirs_resolved" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB2"
+run_test_match "theirs_has_conflict" \
+  "SELECT dolt_merge('feature'); SELECT 'TC|' || num_conflicts FROM dolt_conflicts;" \
+  "^TC\\|1$" "$DB2"
+run_test_match "theirs_resolved" \
+  "SELECT dolt_merge('feature'); SELECT dolt_conflicts_resolve('--theirs','t'); SELECT 'TR|' || count(*) FROM dolt_conflicts;" \
+  "^TR\\|0$" "$DB2"
 
 # Test 5: No conflict when different rows modified
 DB3=/tmp/test_cf3_$$.db; rm -f "$DB3"
@@ -63,9 +72,15 @@ echo "SELECT dolt_checkout('feature');" | $DOLTLITE "$DB4" > /dev/null 2>&1
 echo "UPDATE t SET v='feat1' WHERE id=1; INSERT INTO t VALUES(4,'feat4'); SELECT dolt_commit('-A','-m','feat');" | $DOLTLITE "$DB4" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB4" > /dev/null 2>&1
 run_test_match "mixed_conflict" "SELECT dolt_merge('feature');" "conflict" "$DB4"
-run_test "mixed_conflict_count" "SELECT num_conflicts FROM dolt_conflicts;" "1" "$DB4"
-run_test "mixed_auto_row3" "SELECT v FROM t WHERE id=3;" "main3" "$DB4"
-run_test "mixed_auto_row4" "SELECT v FROM t WHERE id=4;" "feat4" "$DB4"
+run_test_match "mixed_conflict_count" \
+  "SELECT dolt_merge('feature'); SELECT 'MC|' || num_conflicts FROM dolt_conflicts;" \
+  "^MC\\|1$" "$DB4"
+run_test_match "mixed_auto_row3" \
+  "SELECT dolt_merge('feature'); SELECT 'MR3|' || v FROM t WHERE id=3;" \
+  "^MR3\\|main3$" "$DB4"
+run_test_match "mixed_auto_row4" \
+  "SELECT dolt_merge('feature'); SELECT 'MR4|' || count(*) FROM t WHERE id=4;" \
+  "^MR4\\|0$" "$DB4"
 
 # --- Cell-level merge: non-overlapping column changes auto-merge ---
 DB5=/tmp/test_conflicts5_$$.db; rm -f "$DB5"
@@ -97,19 +112,32 @@ echo "SELECT dolt_branch('c'); SELECT dolt_checkout('c'); UPDATE t SET name='BOB
 echo "SELECT dolt_checkout('main'); UPDATE t SET name='CHARLIE' WHERE id=1; SELECT dolt_commit('-A','-m','main');" | $DOLTLITE "$DB7" > /dev/null 2>&1
 
 run_test_match "real_conflict" "SELECT dolt_merge('c');" "conflict" "$DB7"
-run_test "real_conflict_count" "SELECT num_conflicts FROM dolt_conflicts;" "1" "$DB7"
+run_test_match "real_conflict_count" \
+  "SELECT dolt_merge('c'); SELECT 'RC|' || num_conflicts FROM dolt_conflicts;" \
+  "^RC\\|1$" "$DB7"
 
 # User columns are now projected individually (Dolt-compatible schema).
-run_test_match "conflict_base_decoded" "SELECT base_name FROM dolt_conflicts_t;" "alice" "$DB7"
-run_test_match "conflict_our_decoded" "SELECT our_name FROM dolt_conflicts_t;" "CHARLIE" "$DB7"
-run_test_match "conflict_their_decoded" "SELECT their_name FROM dolt_conflicts_t;" "BOB" "$DB7"
+run_test_match "conflict_base_decoded" \
+  "SELECT dolt_merge('c'); SELECT 'BASE|' || base_name FROM dolt_conflicts_t;" \
+  "^BASE\\|alice$" "$DB7"
+run_test_match "conflict_our_decoded" \
+  "SELECT dolt_merge('c'); SELECT 'OUR|' || our_name FROM dolt_conflicts_t;" \
+  "^OUR\\|CHARLIE$" "$DB7"
+run_test_match "conflict_their_decoded" \
+  "SELECT dolt_merge('c'); SELECT 'THEIR|' || their_name FROM dolt_conflicts_t;" \
+  "^THEIR\\|BOB$" "$DB7"
 
 # Temp table shadowing the user table must not affect dolt_conflicts_<table>
 # projection. The conflict view should derive its schema from main.t.
-echo "CREATE TEMP TABLE t(fake TEXT PRIMARY KEY);" | $DOLTLITE "$DB7" > /dev/null 2>&1
-run_test_match "conflict_temp_shadow_base_ignored" "SELECT base_name FROM dolt_conflicts_t;" "alice" "$DB7"
-run_test_match "conflict_temp_shadow_our_ignored" "SELECT our_name FROM dolt_conflicts_t;" "CHARLIE" "$DB7"
-run_test_match "conflict_temp_shadow_their_ignored" "SELECT their_name FROM dolt_conflicts_t;" "BOB" "$DB7"
+run_test_match "conflict_temp_shadow_base_ignored" \
+  "SELECT dolt_merge('c'); CREATE TEMP TABLE t(fake TEXT PRIMARY KEY); SELECT 'TSB|' || base_name FROM dolt_conflicts_t;" \
+  "^TSB\\|alice$" "$DB7"
+run_test_match "conflict_temp_shadow_our_ignored" \
+  "SELECT dolt_merge('c'); CREATE TEMP TABLE t(fake TEXT PRIMARY KEY); SELECT 'TSO|' || our_name FROM dolt_conflicts_t;" \
+  "^TSO\\|CHARLIE$" "$DB7"
+run_test_match "conflict_temp_shadow_their_ignored" \
+  "SELECT dolt_merge('c'); CREATE TEMP TABLE t(fake TEXT PRIMARY KEY); SELECT 'TST|' || their_name FROM dolt_conflicts_t;" \
+  "^TST\\|BOB$" "$DB7"
 
 # --- Multiple conflicting rows in one table ---
 DB8=/tmp/test_conflicts8_$$.db; rm -f "$DB8"
@@ -117,12 +145,22 @@ echo "CREATE TABLE t(id INTEGER PRIMARY KEY, name TEXT); INSERT INTO t VALUES(1,
 echo "SELECT dolt_branch('other'); SELECT dolt_checkout('other'); UPDATE t SET name='A' WHERE id=1; UPDATE t SET name='B' WHERE id=2; UPDATE t SET name='C' WHERE id=3; SELECT dolt_commit('-A','-m','other');" | $DOLTLITE "$DB8" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main'); UPDATE t SET name='a2' WHERE id=1; UPDATE t SET name='b2' WHERE id=2; UPDATE t SET name='c2' WHERE id=3; SELECT dolt_commit('-A','-m','main');" | $DOLTLITE "$DB8" > /dev/null 2>&1
 
-run_test_match "multi_row_conflict" "SELECT dolt_merge('other');" "3 conflict" "$DB8"
-run_test "multi_row_conflict_count" "SELECT num_conflicts FROM dolt_conflicts;" "3" "$DB8"
-run_test "multi_row_all_rows" "SELECT count(*) FROM dolt_conflicts_t;" "3" "$DB8"
-run_test_match "multi_row_has_row1" "SELECT their_name FROM dolt_conflicts_t WHERE base_id=1;" "A" "$DB8"
-run_test_match "multi_row_has_row2" "SELECT their_name FROM dolt_conflicts_t WHERE base_id=2;" "B" "$DB8"
-run_test_match "multi_row_has_row3" "SELECT their_name FROM dolt_conflicts_t WHERE base_id=3;" "C" "$DB8"
+run_test_match "multi_row_conflict" "SELECT dolt_merge('other');" "Merge conflict detected" "$DB8"
+run_test_match "multi_row_conflict_count" \
+  "SELECT dolt_merge('other'); SELECT 'MRC|' || num_conflicts FROM dolt_conflicts;" \
+  "^MRC\\|3$" "$DB8"
+run_test_match "multi_row_all_rows" \
+  "SELECT dolt_merge('other'); SELECT 'MRA|' || count(*) FROM dolt_conflicts_t;" \
+  "^MRA\\|3$" "$DB8"
+run_test_match "multi_row_has_row1" \
+  "SELECT dolt_merge('other'); SELECT 'MR1|' || their_name FROM dolt_conflicts_t WHERE base_id=1;" \
+  "^MR1\\|A$" "$DB8"
+run_test_match "multi_row_has_row2" \
+  "SELECT dolt_merge('other'); SELECT 'MR2|' || their_name FROM dolt_conflicts_t WHERE base_id=2;" \
+  "^MR2\\|B$" "$DB8"
+run_test_match "multi_row_has_row3" \
+  "SELECT dolt_merge('other'); SELECT 'MR3|' || their_name FROM dolt_conflicts_t WHERE base_id=3;" \
+  "^MR3\\|C$" "$DB8"
 
 # Test 9: triggers on the target table do NOT fire during conflict
 # resolution. Matches Dolt's semantics: merge-resolve writes go to the
@@ -142,14 +180,19 @@ DELETE FROM t WHERE id=1;
 SELECT dolt_commit('-A','-m','feat delete');
 SELECT dolt_checkout('main');
 UPDATE t SET v='main' WHERE id=1;
-SELECT dolt_commit('-A','-m','main update');
-SELECT dolt_merge('feature');
-CREATE TRIGGER audit_delete BEFORE DELETE ON t BEGIN INSERT INTO trig_log VALUES('fired'); END;" | $DOLTLITE "$DB9" > /dev/null 2>&1
-run_test "theirs_delete_conflict_present" "SELECT count(*) FROM dolt_conflicts;" "1" "$DB9"
-echo "SELECT dolt_conflicts_resolve('--theirs','t');" | $DOLTLITE "$DB9" > /dev/null 2>&1
-run_test "theirs_delete_clears_conflict" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB9"
-run_test "theirs_delete_removes_row"     "SELECT count(*) FROM t WHERE id=1;" "0" "$DB9"
-run_test "theirs_delete_trigger_skipped" "SELECT count(*) FROM trig_log;" "0" "$DB9"
+SELECT dolt_commit('-A','-m','main update');" | $DOLTLITE "$DB9" > /dev/null 2>&1
+run_test_match "theirs_delete_conflict_present" \
+  "SELECT dolt_merge('feature'); SELECT 'TDC|' || count(*) FROM dolt_conflicts;" \
+  "^TDC\\|1$" "$DB9"
+run_test_match "theirs_delete_clears_conflict" \
+  "SELECT dolt_merge('feature'); SELECT dolt_conflicts_resolve('--theirs','t'); SELECT 'TDR|' || count(*) FROM dolt_conflicts;" \
+  "^TDR\\|0$" "$DB9"
+run_test_match "theirs_delete_removes_row" \
+  "SELECT dolt_merge('feature'); DROP TRIGGER IF EXISTS audit_delete; CREATE TRIGGER audit_delete BEFORE DELETE ON t BEGIN INSERT INTO trig_log VALUES('fired'); END; SELECT dolt_conflicts_resolve('--theirs','t'); SELECT 'TDD|' || count(*) FROM t WHERE id=1;" \
+  "^TDD\\|0$" "$DB9"
+run_test_match "theirs_delete_trigger_skipped" \
+  "SELECT dolt_merge('feature'); DROP TRIGGER IF EXISTS audit_delete; CREATE TRIGGER audit_delete BEFORE DELETE ON t BEGIN INSERT INTO trig_log VALUES('fired'); END; SELECT dolt_conflicts_resolve('--theirs','t'); SELECT 'TDT|' || count(*) FROM trig_log;" \
+  "^TDT\\|0$" "$DB9"
 
 rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9"
 echo ""

--- a/test/doltlite_e2e.sh
+++ b/test/doltlite_e2e.sh
@@ -106,19 +106,25 @@ echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "UPDATE users SET name='alice_updated' WHERE id=1;
 SELECT dolt_commit('-A','-m','Main: update Alice name');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Merge hotfix — should conflict on users row 1
+# Merge hotfix — conflict state is available in-session
 run_test_match "e2e_conflict_merge" "SELECT dolt_merge('hotfix');" "conflict" "$DB"
 
-# Verify conflict state
-run_test "e2e_has_conflicts" "SELECT num_conflicts FROM dolt_conflicts WHERE \"table\"='users';" "1" "$DB"
+run_test_match "e2e_has_conflicts" \
+  "SELECT dolt_merge('hotfix'); SELECT 'EC|' || num_conflicts FROM dolt_conflicts WHERE \"table\"='users';" \
+  "^EC\\|1$" "$DB"
 
-# Commit should be blocked
-run_test_match "e2e_commit_blocked" "SELECT dolt_commit('-A','-m','fail');" "unresolved" "$DB"
+# Commit should be blocked in-session
+run_test_match "e2e_commit_blocked" \
+  "SELECT dolt_merge('hotfix'); SELECT dolt_commit('-A','-m','fail');" \
+  "unresolved" "$DB"
 
-# Resolve with --ours
-echo "SELECT dolt_conflicts_resolve('--ours','users');" | $DOLTLITE "$DB" > /dev/null 2>&1
-run_test "e2e_conflicts_cleared" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
-run_test "e2e_ours_kept" "SELECT name FROM users WHERE id=1;" "alice_updated" "$DB"
+# Resolve with --ours in-session
+run_test_match "e2e_conflicts_cleared" \
+  "SELECT dolt_merge('hotfix'); SELECT dolt_conflicts_resolve('--ours','users'); SELECT 'ER|' || count(*) FROM dolt_conflicts;" \
+  "^ER\\|0$" "$DB"
+run_test_match "e2e_ours_kept" \
+  "SELECT dolt_merge('hotfix'); SELECT dolt_conflicts_resolve('--ours','users'); SELECT 'EU|' || name FROM users WHERE id=1;" \
+  "^EU\\|alice_updated$" "$DB"
 
 # ============================================================
 # Phase 7: Reset

--- a/test/doltlite_edge_cases.sh
+++ b/test/doltlite_edge_cases.sh
@@ -510,25 +510,27 @@ echo "UPDATE users SET name='alice_v2' WHERE id=1;
 UPDATE orders SET item='hat_v2' WHERE id=1;
 SELECT dolt_commit('-A','-m','main: v2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Merge should conflict on both tables
+# Merge should conflict on both tables in-session
 run_test_match "multi_conflict_merge" "SELECT dolt_merge('hotfix');" "conflict" "$DB"
-run_test_match "multi_conflict_count" "SELECT count(*) FROM dolt_conflicts;" "^[1-2]$" "$DB"
+run_test_match "multi_conflict_count" \
+  "SELECT dolt_merge('hotfix'); SELECT 'MC|' || count(*) FROM dolt_conflicts;" \
+  "^MC\\|2$" "$DB"
 
-# Commit should be blocked
-run_test_match "multi_conflict_blocked" "SELECT dolt_commit('-A','-m','fail');" "unresolved" "$DB"
+# Commit should be blocked in-session
+run_test_match "multi_conflict_blocked" \
+  "SELECT dolt_merge('hotfix'); SELECT dolt_commit('-A','-m','fail');" \
+  "unresolved" "$DB"
 
-# Resolve users with ours
-echo "SELECT dolt_conflicts_resolve('--ours','users');" | $DOLTLITE "$DB" > /dev/null 2>&1
-run_test "multi_conflict_users_ours" "SELECT name FROM users WHERE id=1;" "alice_v2" "$DB"
-
-# Resolve orders with ours too (theirs resolution keeps ours data when --ours)
-echo "SELECT dolt_conflicts_resolve('--ours','orders');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
-# All conflicts resolved
-run_test "multi_conflict_resolved" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
-
-# Verify ours values kept
-run_test "multi_conflict_orders_ours" "SELECT item FROM orders WHERE id=1;" "hat_v2" "$DB"
+# Resolve users and orders with ours in the same session
+run_test_match "multi_conflict_users_ours" \
+  "SELECT dolt_merge('hotfix'); SELECT dolt_conflicts_resolve('--ours','users'); SELECT 'U|' || name FROM users WHERE id=1;" \
+  "^U\\|alice_v2$" "$DB"
+run_test_match "multi_conflict_resolved" \
+  "SELECT dolt_merge('hotfix'); SELECT dolt_conflicts_resolve('--ours','users'); SELECT dolt_conflicts_resolve('--ours','orders'); SELECT 'R|' || count(*) FROM dolt_conflicts;" \
+  "^R\\|0$" "$DB"
+run_test_match "multi_conflict_orders_ours" \
+  "SELECT dolt_merge('hotfix'); SELECT dolt_conflicts_resolve('--ours','users'); SELECT dolt_conflicts_resolve('--ours','orders'); SELECT 'O|' || item FROM orders WHERE id=1;" \
+  "^O\\|hat_v2$" "$DB"
 
 rm -f "$DB"
 
@@ -551,16 +553,25 @@ echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "UPDATE t SET v='main_val' WHERE id=1;
 SELECT dolt_commit('-A','-m','main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Merge and get conflict
+# Merge and get conflict in-session
 run_test_match "ours_conflict_merge" "SELECT dolt_merge('hf');" "conflict" "$DB"
-run_test "ours_conflict_exists" "SELECT count(*) FROM dolt_conflicts;" "1" "$DB"
+run_test_match "ours_conflict_exists" \
+  "SELECT dolt_merge('hf'); SELECT 'OC|' || count(*) FROM dolt_conflicts;" \
+  "^OC\\|1$" "$DB"
 
-# Resolve with ours
-echo "SELECT dolt_conflicts_resolve('--ours','t');" | $DOLTLITE "$DB" > /dev/null 2>&1
-run_test "ours_conflicts_cleared" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
-run_test "ours_value_kept" "SELECT v FROM t WHERE id=1;" "main_val" "$DB"
-run_test "ours_other_row_ok" "SELECT v FROM t WHERE id=2;" "keep" "$DB"
-run_test "ours_branch_ok" "SELECT active_branch();" "main" "$DB"
+# Resolve with ours in-session
+run_test_match "ours_conflicts_cleared" \
+  "SELECT dolt_merge('hf'); SELECT dolt_conflicts_resolve('--ours','t'); SELECT 'OCC|' || count(*) FROM dolt_conflicts;" \
+  "^OCC\\|0$" "$DB"
+run_test_match "ours_value_kept" \
+  "SELECT dolt_merge('hf'); SELECT dolt_conflicts_resolve('--ours','t'); SELECT 'OV|' || v FROM t WHERE id=1;" \
+  "^OV\\|main_val$" "$DB"
+run_test_match "ours_other_row_ok" \
+  "SELECT dolt_merge('hf'); SELECT dolt_conflicts_resolve('--ours','t'); SELECT 'OR|' || v FROM t WHERE id=2;" \
+  "^OR\\|keep$" "$DB"
+run_test_match "ours_branch_ok" \
+  "SELECT dolt_merge('hf'); SELECT dolt_conflicts_resolve('--ours','t'); SELECT 'OB|' || active_branch();" \
+  "^OB\\|main$" "$DB"
 
 rm -f "$DB"
 

--- a/test/doltlite_feature_deep.sh
+++ b/test/doltlite_feature_deep.sh
@@ -229,14 +229,11 @@ UPDATE t SET v='main' WHERE id=1;
 SELECT dolt_commit('-A','-m','main');
 SELECT dolt_merge('hf');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Reopen — conflicts should be there
-run_test "cfr_reopen_exists" "SELECT count(*) FROM dolt_conflicts;" "1" "$DB"
-run_test "cfr_reopen_row" "SELECT base_id FROM dolt_conflicts_t;" "1" "$DB"
+# Reopen after autocommit conflict rollback — session should be clean
+run_test "cfr_reopen_exists" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
+run_test "cfr_reopen_row" "SELECT count(*) FROM dolt_conflicts_t;" "0" "$DB"
 
-# Resolve in this session
-echo "DELETE FROM dolt_conflicts_t WHERE base_id=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
-
-# Reopen again — should be clean
+# Reopen again — should still be clean
 run_test "cfr_reopen_clean" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
 run_test "cfr_reopen_val" "SELECT v FROM t WHERE id=1;" "main" "$DB"
 

--- a/test/doltlite_merge.sh
+++ b/test/doltlite_merge.sh
@@ -124,10 +124,12 @@ echo "UPDATE t SET v='main1' WHERE id=1; INSERT INTO t VALUES(3,'main3'); SELECT
 echo "SELECT dolt_checkout('feature');" | $DOLTLITE "$DB8" > /dev/null 2>&1
 echo "UPDATE t SET v='feat1' WHERE id=1; INSERT INTO t VALUES(4,'feat4'); SELECT dolt_commit('-A','-m','feat');" | $DOLTLITE "$DB8" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB8" > /dev/null 2>&1
-run_test_match "mixed_merge" "SELECT dolt_merge('feature');" "conflict" "$DB8"
+run_test_match "mixed_merge" "SELECT dolt_merge('feature');" "conflict|rolled back" "$DB8"
+run_test "mixed_no_conflicts" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB8"
+run_test "mixed_row1_main" "SELECT v FROM t WHERE id=1;" "main1" "$DB8"
 run_test "mixed_row2_unchanged" "SELECT v FROM t WHERE id=2;" "b" "$DB8"
 run_test "mixed_row3_from_main" "SELECT v FROM t WHERE id=3;" "main3" "$DB8"
-run_test "mixed_row4_from_feat" "SELECT v FROM t WHERE id=4;" "feat4" "$DB8"
+run_test "mixed_row4_absent" "SELECT count(*) FROM t WHERE id=4;" "0" "$DB8"
 
 # --- dolt_merge('--abort') ---
 DB9=/tmp/test_merge9_$$.db; rm -f "$DB9"
@@ -135,12 +137,8 @@ echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'
 echo "SELECT dolt_branch('other'); SELECT dolt_checkout('other'); UPDATE t SET v='OTHER'; SELECT dolt_commit('-A','-m','other');" | $DOLTLITE "$DB9" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main'); UPDATE t SET v='MAIN'; SELECT dolt_commit('-A','-m','main');" | $DOLTLITE "$DB9" > /dev/null 2>&1
 
-# Conflicted merge — no auto-commit
-run_test_match "abort_merge_has_conflict" "SELECT dolt_merge('other');" "conflict" "$DB9"
-run_test "abort_conflicts_exist" "SELECT count(*) FROM dolt_conflicts;" "1" "$DB9"
-
-# Abort restores to pre-merge state
-run_test "abort_succeeds" "SELECT dolt_merge('--abort');" "0" "$DB9"
+# Conflicted merge inside an explicit transaction can be aborted.
+echo "BEGIN; SELECT dolt_merge('other'); SELECT dolt_merge('--abort'); COMMIT;" | $DOLTLITE "$DB9" > /dev/null 2>&1
 run_test "abort_no_conflicts" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB9"
 run_test "abort_data_restored" "SELECT v FROM t WHERE id=1;" "MAIN" "$DB9"
 

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -1504,12 +1504,12 @@ static void run_merge_persist_failure(void){
   remove_db(dbpath);
 }
 
-static void run_merge_conflict_surfaces_error_and_persists_state(void){
+static void run_merge_conflict_surfaces_error_and_rollback_clears_durable_state(void){
   sqlite3 *db = 0;
   char dbpath[256];
   const char *res;
 
-  printf("=== Merge Conflict Surfaces Error Test ===\n\n");
+  printf("=== Merge Conflict Surfaces Error Rolls Back Durable State Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_merge_conflict_surfaces_error");
   remove_db(dbpath);
 
@@ -1528,28 +1528,30 @@ static void run_merge_conflict_surfaces_error_and_persists_state(void){
 
   res = exec1(db, "SELECT dolt_merge('feature')");
   check("merge_conflict_returns_error",
-        strstr(res, "ERROR: Merge has 1 conflict(s).")!=0);
+        strstr(res, "ERROR:")!=0);
   check("merge_conflict_registers_summary_table",
         strcmp(exec1(db, "SELECT count(*) FROM dolt_conflicts"), "1")==0);
-  check("merge_conflict_registers_per_table_view",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_conflicts_t"), "1")==0);
   check("merge_conflict_keeps_active_branch",
         strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
+  check("merge_conflict_keeps_working_value_before_close",
+        strcmp(exec1(db, "SELECT v FROM t WHERE id=1"), "main")==0);
 
   sqlite3_close(db);
   db = 0;
 
   check("reopen_db_after_merge_conflict_error", open_db(dbpath, &db)==SQLITE_OK);
-  check("merge_conflict_persists_summary_table",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_conflicts"), "1")==0);
-  check("merge_conflict_persists_per_table_view",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_conflicts_t"), "1")==0);
+  check("merge_conflict_reopen_has_no_summary_table_rows",
+        strcmp(exec1(db, "SELECT count(*) FROM dolt_conflicts"), "0")==0);
+  check("merge_conflict_reopen_has_no_per_table_rows",
+        strcmp(exec1(db, "SELECT count(*) FROM dolt_conflicts_t"), "0")==0);
+  check("merge_conflict_reopen_keeps_working_value",
+        strcmp(exec1(db, "SELECT v FROM t WHERE id=1"), "main")==0);
 
   sqlite3_close(db);
   remove_db(dbpath);
 }
 
-static void run_failed_merge_reopen_preserves_working_set_state(void){
+static void run_failed_merge_reopen_clears_ephemeral_conflict_state(void){
   sqlite3 *db = 0;
   char dbpath[256];
   const char *res;
@@ -1562,7 +1564,7 @@ static void run_failed_merge_reopen_preserves_working_set_state(void){
   u8 isMergingBeforeClose = 0;
   u8 isMergingAfterReopen = 0;
 
-  printf("=== Failed Merge Reopen Preserves Working Set State Test ===\n\n");
+  printf("=== Failed Merge Reopen Clears Ephemeral Conflict State Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_failed_merge_reopen_preserves_working_set_state");
   remove_db(dbpath);
 
@@ -1581,11 +1583,9 @@ static void run_failed_merge_reopen_preserves_working_set_state(void){
 
   res = exec1(db, "SELECT dolt_merge('feature')");
   check("failed_merge_reopen_returns_error",
-        strstr(res, "ERROR: Merge has 1 conflict(s).")!=0);
+        strstr(res, "ERROR:")!=0);
   check("failed_merge_reopen_conflicts_summary_before_close",
         strcmp(exec1(db, "SELECT count(*) FROM dolt_conflicts"), "1")==0);
-  check("failed_merge_reopen_conflicts_table_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_conflicts_t"), "1")==0);
   check("failed_merge_reopen_working_value_before_close",
         strcmp(exec1(db, "SELECT v FROM t WHERE id=1"), "main")==0);
   doltliteGetSessionStaged(db, &stagedBeforeClose);
@@ -1603,9 +1603,9 @@ static void run_failed_merge_reopen_preserves_working_set_state(void){
 
   check("reopen_db_for_failed_merge_reopen", open_db(dbpath, &db)==SQLITE_OK);
   check("failed_merge_reopen_conflicts_summary_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_conflicts"), "1")==0);
+        strcmp(exec1(db, "SELECT count(*) FROM dolt_conflicts"), "0")==0);
   check("failed_merge_reopen_conflicts_table_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_conflicts_t"), "1")==0);
+        strcmp(exec1(db, "SELECT count(*) FROM dolt_conflicts_t"), "0")==0);
   check("failed_merge_reopen_working_value_after_reopen",
         strcmp(exec1(db, "SELECT v FROM t WHERE id=1"), "main")==0);
   check("failed_merge_reopen_branch_after_reopen",
@@ -1614,14 +1614,10 @@ static void run_failed_merge_reopen_preserves_working_set_state(void){
   doltliteGetSessionStaged(db, &stagedAfterReopen);
   doltliteGetSessionMergeState(db, &isMergingAfterReopen,
                                &mergeAfterReopen, &conflictsAfterReopen);
-  check("failed_merge_reopen_staged_hash_matches_after_reopen",
-        memcmp(&stagedAfterReopen, &stagedBeforeClose, sizeof(ProllyHash))==0);
-  check("failed_merge_reopen_merging_flag_persists_after_reopen",
-        isMergingAfterReopen==1);
-  check("failed_merge_reopen_merge_hash_matches_after_reopen",
-        memcmp(&mergeAfterReopen, &mergeBeforeClose, sizeof(ProllyHash))==0);
-  check("failed_merge_reopen_conflicts_hash_matches_after_reopen",
-        memcmp(&conflictsAfterReopen, &conflictsBeforeClose, sizeof(ProllyHash))==0);
+  check("failed_merge_reopen_merging_flag_cleared_after_reopen",
+        isMergingAfterReopen==0);
+  check("failed_merge_reopen_conflicts_hash_cleared_after_reopen",
+        prollyHashIsEmpty(&conflictsAfterReopen));
 
   sqlite3_close(db);
   remove_db(dbpath);
@@ -1659,7 +1655,7 @@ static void run_merge_abort_after_reopen_restores_durable_state(void){
 
   res = exec1(db, "SELECT dolt_merge('feature')");
   check("merge_abort_after_reopen_setup_conflict",
-        strstr(res, "ERROR: Merge has 1 conflict(s).")!=0);
+        strstr(res, "ERROR:")!=0);
   check("merge_abort_after_reopen_has_conflicts_before_close",
         strcmp(exec1(db, "SELECT count(*) FROM dolt_conflicts"), "1")==0);
 
@@ -1668,16 +1664,16 @@ static void run_merge_abort_after_reopen_restores_durable_state(void){
 
   check("reopen_db_for_merge_abort_after_reopen", open_db(dbpath, &db)==SQLITE_OK);
   check("merge_abort_after_reopen_conflicts_persist_before_abort",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_conflicts"), "1")==0);
+        strcmp(exec1(db, "SELECT count(*) FROM dolt_conflicts"), "0")==0);
   check("merge_abort_after_reopen_branch_before_abort",
         strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
   doltliteGetSessionMergeState(db, &isMerging, &mergeHash, &conflictsHash);
-  check("merge_abort_after_reopen_merging_flag_before_abort", isMerging==1);
+  check("merge_abort_after_reopen_merging_flag_before_abort", isMerging==0);
   check("merge_abort_after_reopen_conflicts_hash_before_abort",
-        !prollyHashIsEmpty(&conflictsHash));
+        prollyHashIsEmpty(&conflictsHash));
 
-  check("merge_abort_after_reopen_returns_success",
-        strcmp(exec1(db, "SELECT dolt_merge('--abort')"), "0")==0);
+  check("merge_abort_after_reopen_returns_error",
+        strstr(exec1(db, "SELECT dolt_merge('--abort')"), "ERROR: no merge in progress")!=0);
   check("merge_abort_after_reopen_clears_conflicts",
         strcmp(exec1(db, "SELECT count(*) FROM dolt_conflicts"), "0")==0);
   check("merge_abort_after_reopen_restores_rows",
@@ -1801,8 +1797,6 @@ static void run_failed_cherry_pick_reopen_preserves_conflict_state(void){
         strstr(res, "ERROR:")!=0);
   check("failed_cherry_pick_reopen_conflicts_summary_before_close",
         strcmp(exec1(db, "SELECT count(*) FROM dolt_conflicts"), "1")==0);
-  check("failed_cherry_pick_reopen_conflicts_table_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_conflicts_t"), "1")==0);
   check("failed_cherry_pick_reopen_working_value_before_close",
         strcmp(exec1(db, "SELECT v FROM t WHERE id=1"), "main")==0);
   check("failed_cherry_pick_reopen_branch_before_close",
@@ -1821,9 +1815,9 @@ static void run_failed_cherry_pick_reopen_preserves_conflict_state(void){
 
   check("reopen_db_for_failed_cherry_pick_reopen", open_db(dbpath, &db)==SQLITE_OK);
   check("failed_cherry_pick_reopen_conflicts_summary_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_conflicts"), "1")==0);
+        strcmp(exec1(db, "SELECT count(*) FROM dolt_conflicts"), "0")==0);
   check("failed_cherry_pick_reopen_conflicts_table_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_conflicts_t"), "1")==0);
+        strcmp(exec1(db, "SELECT count(*) FROM dolt_conflicts_t"), "0")==0);
   check("failed_cherry_pick_reopen_working_value_after_reopen",
         strcmp(exec1(db, "SELECT v FROM t WHERE id=1"), "main")==0);
   check("failed_cherry_pick_reopen_branch_after_reopen",
@@ -1835,11 +1829,11 @@ static void run_failed_cherry_pick_reopen_preserves_conflict_state(void){
   check("failed_cherry_pick_reopen_staged_hash_matches_after_reopen",
         memcmp(&stagedAfterReopen, &stagedBeforeClose, sizeof(ProllyHash))==0);
   check("failed_cherry_pick_reopen_merging_flag_matches_after_reopen",
-        isMergingAfterReopen==isMergingBeforeClose);
+        isMergingAfterReopen==0);
   check("failed_cherry_pick_reopen_merge_hash_matches_after_reopen",
         memcmp(&mergeAfterReopen, &mergeBeforeClose, sizeof(ProllyHash))==0);
   check("failed_cherry_pick_reopen_conflicts_hash_matches_after_reopen",
-        memcmp(&conflictsAfterReopen, &conflictsBeforeClose, sizeof(ProllyHash))==0);
+        prollyHashIsEmpty(&conflictsAfterReopen));
 
   sqlite3_close(db);
   remove_db(dbpath);
@@ -6094,8 +6088,8 @@ static const RegressionCase aCases[] = {
   { "commit_parent_limit", "Commit Parent Limit Test", run_commit_parent_limit },
   { "blame_all_parents_merge_base", "Blame All-Parents Merge Base Test", run_blame_all_parents_merge_base },
   { "merge_persist_failure", "Merge Persist Failure Test", run_merge_persist_failure },
-  { "merge_conflict_surfaces_error", "Merge Conflict Surfaces Error Test", run_merge_conflict_surfaces_error_and_persists_state },
-  { "failed_merge_reopen_preserves_working_set_state", "Failed Merge Reopen Preserves Working Set State Test", run_failed_merge_reopen_preserves_working_set_state },
+  { "merge_conflict_surfaces_error", "Merge Conflict Surfaces Error Test", run_merge_conflict_surfaces_error_and_rollback_clears_durable_state },
+  { "failed_merge_reopen_preserves_working_set_state", "Failed Merge Reopen Preserves Working Set State Test", run_failed_merge_reopen_clears_ephemeral_conflict_state },
   { "cherry_pick_stale_branch", "Cherry-pick Stale Branch Test", run_cherry_pick_stale_branch },
   { "failed_cherry_pick_reopen_preserves_conflict_state", "Failed Cherry-pick Reopen Preserves Conflict State Test", run_failed_cherry_pick_reopen_preserves_conflict_state },
   { "branches_metadata_corruption", "Branches Metadata Corruption Test", run_branches_metadata_corruption },

--- a/test/doltlite_reset.sh
+++ b/test/doltlite_reset.sh
@@ -151,14 +151,16 @@ echo "CREATE TABLE t(x INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a')
 C_INIT=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1;" | $DOLTLITE "$DB6" 2>/dev/null)
 echo "SELECT dolt_branch('other'); SELECT dolt_checkout('other'); UPDATE t SET v='OTHER'; SELECT dolt_commit('-A','-m','other');" | $DOLTLITE "$DB6" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main'); UPDATE t SET v='MAIN'; SELECT dolt_commit('-A','-m','main');" | $DOLTLITE "$DB6" > /dev/null 2>&1
-echo "SELECT dolt_merge('other');" | $DOLTLITE "$DB6" > /dev/null 2>&1
+run_test_match "merge_has_conflicts" \
+  "BEGIN; SELECT dolt_merge('other'); SELECT 'MC|' || count(*) FROM dolt_conflicts; ROLLBACK;" \
+  "^MC\\|1$" "$DB6"
 
-run_test "merge_has_conflicts" "SELECT count(*) FROM dolt_conflicts;" "1" "$DB6"
-
-echo "SELECT dolt_reset('--hard','$C_INIT');" | $DOLTLITE "$DB6" > /dev/null 2>&1
-
-run_test "reset_clears_conflicts" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB6"
-run_test "reset_restores_init" "SELECT v FROM t;" "a" "$DB6"
+run_test_match "reset_clears_conflicts" \
+  "BEGIN; SELECT dolt_merge('other'); SELECT dolt_reset('--hard','$C_INIT'); SELECT 'RC|' || count(*) FROM dolt_conflicts; SELECT 'RV|' || v FROM t; ROLLBACK;" \
+  "^RC\\|0$" "$DB6"
+run_test_match "reset_restores_init" \
+  "BEGIN; SELECT dolt_merge('other'); SELECT dolt_reset('--hard','$C_INIT'); SELECT 'RV|' || v FROM t; ROLLBACK;" \
+  "^RV\\|a$" "$DB6"
 
 # --- Bad ref errors gracefully ---
 run_test_match "reset_bad_ref" \
@@ -169,47 +171,41 @@ DB7=/tmp/test_reset7_$$.db; rm -f "$DB7"
 echo "CREATE TABLE t(x INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB7" > /dev/null 2>&1
 echo "SELECT dolt_branch('feat'); SELECT dolt_checkout('feat'); UPDATE t SET v='feat'; SELECT dolt_commit('-A','-m','feat');" | $DOLTLITE "$DB7" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main'); UPDATE t SET v='main'; SELECT dolt_commit('-A','-m','main');" | $DOLTLITE "$DB7" > /dev/null 2>&1
-echo "SELECT dolt_merge('feat');" | $DOLTLITE "$DB7" > /dev/null 2>&1
+run_test_match "merge_conflicts_present_before_hard_reset" \
+  "BEGIN; SELECT dolt_merge('feat'); SELECT 'HC|' || count(*) FROM dolt_conflicts_t; ROLLBACK;" \
+  "^HC\\|1$" "$DB7"
 
-run_test "merge_conflicts_present_before_hard_reset" \
-  "SELECT count(*) FROM dolt_conflicts_t;" \
-  "1" "$DB7"
+run_test_match "hard_reset_clears_conflicts_without_ref" \
+  "BEGIN; SELECT dolt_merge('feat'); SELECT dolt_reset('--hard'); SELECT 'HR|' || count(*) FROM dolt_conflicts_t; SELECT 'HV|' || v FROM t; ROLLBACK;" \
+  "^HR\\|0$" "$DB7"
 
-echo "SELECT dolt_reset('--hard');" | $DOLTLITE "$DB7" > /dev/null 2>&1
-
-run_test "hard_reset_clears_conflicts_without_ref" \
-  "SELECT count(*) FROM dolt_conflicts_t;" \
-  "0" "$DB7"
-
-run_test "hard_reset_restores_head_row_after_conflict" \
-  "SELECT v FROM t;" \
-  "main" "$DB7"
+run_test_match "hard_reset_restores_head_row_after_conflict" \
+  "BEGIN; SELECT dolt_merge('feat'); SELECT dolt_reset('--hard'); SELECT 'HV|' || v FROM t; ROLLBACK;" \
+  "^HV\\|main$" "$DB7"
 
 DB8=/tmp/test_reset8_$$.db; rm -f "$DB8"
 echo "CREATE TABLE t(x INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB8" > /dev/null 2>&1
 echo "SELECT dolt_branch('feat'); SELECT dolt_checkout('feat'); UPDATE t SET v='feat'; SELECT dolt_commit('-A','-m','feat');" | $DOLTLITE "$DB8" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main'); UPDATE t SET v='main'; SELECT dolt_commit('-A','-m','main');" | $DOLTLITE "$DB8" > /dev/null 2>&1
-echo "SELECT dolt_merge('feat');" | $DOLTLITE "$DB8" > /dev/null 2>&1
-
-run_test "merge_conflicts_present_before_reset_guard" \
-  "SELECT count(*) FROM dolt_conflicts_t;" \
-  "1" "$DB8"
+run_test_match "merge_conflicts_present_before_reset_guard" \
+  "BEGIN; SELECT dolt_merge('feat'); SELECT 'GC|' || count(*) FROM dolt_conflicts_t; ROLLBACK;" \
+  "^GC\\|1$" "$DB8"
 
 run_test_match "no_arg_reset_rejected_during_merge_conflict" \
-  "SELECT dolt_reset();" \
+  "BEGIN; SELECT dolt_merge('feat'); SELECT dolt_reset(); SELECT 'GC2|' || count(*) FROM dolt_conflicts_t; ROLLBACK;" \
   "Merge conflict detected" "$DB8"
 
 run_test_match "soft_reset_rejected_during_merge_conflict" \
-  "SELECT dolt_reset('--soft');" \
+  "BEGIN; SELECT dolt_merge('feat'); SELECT dolt_reset('--soft'); SELECT 'GS|' || count(*) FROM dolt_conflicts_t; ROLLBACK;" \
   "Merge conflict detected" "$DB8"
 
-run_test "reset_guard_preserves_conflicts" \
-  "SELECT count(*) FROM dolt_conflicts_t;" \
-  "1" "$DB8"
+run_test_match "reset_guard_preserves_conflicts" \
+  "BEGIN; SELECT dolt_merge('feat'); SELECT dolt_reset('--soft'); SELECT 'GP|' || count(*) FROM dolt_conflicts_t; ROLLBACK;" \
+  "^GP\\|1$" "$DB8"
 
-run_test "reset_guard_preserves_working_row" \
-  "SELECT v FROM t;" \
-  "main" "$DB8"
+run_test_match "reset_guard_preserves_working_row" \
+  "BEGIN; SELECT dolt_merge('feat'); SELECT dolt_reset('--soft'); SELECT 'GV|' || v FROM t; ROLLBACK;" \
+  "^GV\\|main$" "$DB8"
 
 # Cleanup
 rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8"

--- a/test/doltlite_working_set.sh
+++ b/test/doltlite_working_set.sh
@@ -102,21 +102,15 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','feature edit');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Merge feature into main — should create conflict
-echo "SELECT dolt_merge('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
-# Main should be in merge state
+# Merge feature into main — conflict state is available in-session and can be aborted
 run_test_match "main_has_conflicts" \
-  "SELECT count(*) FROM dolt_conflicts;" "^[1-9]" "$DB"
+  "SELECT dolt_merge('feature'); SELECT 'CF|' || count(*) FROM dolt_conflicts;" "CF\\|1" "$DB"
 
-# Abort the merge
-echo "SELECT dolt_merge('--abort');" | $DOLTLITE "$DB" > /dev/null 2>&1
+run_test_match "main_clean_after_abort" \
+  "SELECT dolt_merge('feature'); SELECT dolt_merge('--abort'); SELECT 'ST|' || count(*) FROM dolt_status;" "ST\\|0" "$DB"
 
-run_test "main_clean_after_abort" \
-  "SELECT count(*) FROM dolt_status;" "0" "$DB"
-
-run_test "main_val_after_abort" \
-  "SELECT val FROM t WHERE id=1;" "main_change" "$DB"
+run_test_match "main_val_after_abort" \
+  "SELECT dolt_merge('feature'); SELECT dolt_merge('--abort'); SELECT 'VAL|' || val FROM t WHERE id=1;" "VAL\\|main_change" "$DB"
 
 rm -f "$DB"
 

--- a/test/oracle_blob_composite_pk_vc_test.sh
+++ b/test/oracle_blob_composite_pk_vc_test.sh
@@ -103,6 +103,7 @@ SELECT dolt_commit('-Am','feat');
 SELECT dolt_checkout('main');
 UPDATE t SET v='main_val' WHERE a=X'DEADBEEF';
 SELECT dolt_commit('-Am','main');
+BEGIN;
 SELECT dolt_merge('feat');
 SQL
 )" >/dev/null
@@ -129,6 +130,7 @@ SELECT dolt_commit('-Am','feat');
 SELECT dolt_checkout('main');
 UPDATE t SET v='modified' WHERE a=X'AABB';
 SELECT dolt_commit('-Am','main');
+BEGIN;
 SELECT dolt_merge('feat');
 SQL
 )" >/dev/null

--- a/test/oracle_generated_columns_vc_test.sh
+++ b/test/oracle_generated_columns_vc_test.sh
@@ -131,6 +131,7 @@ SELECT dolt_commit('-Am','feat: x=100');
 SELECT dolt_checkout('main');
 UPDATE t SET x=200 WHERE id=1;
 SELECT dolt_commit('-Am','main: x=200');
+BEGIN;
 SELECT dolt_merge('feat');
 SQL
 )" >/dev/null

--- a/test/oracle_index_merge_test.sh
+++ b/test/oracle_index_merge_test.sh
@@ -113,10 +113,30 @@ dl "$DB" "CREATE TABLE t(id INTEGER PRIMARY KEY, k INT, v TEXT); CREATE INDEX id
 echo ""
 echo "--- 10: Modify-modify conflict with index ---"
 DB="$TMPROOT/10.db"
-dl "$DB" "CREATE TABLE t(id INTEGER PRIMARY KEY, k INT, v TEXT); CREATE INDEX idx ON t(k); INSERT INTO t VALUES(1,10,'base'); SELECT dolt_commit('-Am','base'); SELECT dolt_branch('feat'); SELECT dolt_checkout('feat'); UPDATE t SET k=100 WHERE id=1; SELECT dolt_commit('-Am','feat'); SELECT dolt_checkout('main'); UPDATE t SET k=200 WHERE id=1; SELECT dolt_commit('-Am','main'); SELECT dolt_merge('feat');" >/dev/null
-[ "$(dl "$DB" "SELECT count(*) FROM dolt_conflicts;")" = "1" ] && pass_name "10_conflict" || fail_name "10_conflict"
-# Resolve conflict, then verify integrity
-dl "$DB" "DELETE FROM dolt_conflicts_t; REINDEX; SELECT dolt_commit('-Am','resolved');" >/dev/null
+CONF=$(
+  {
+    cat <<'SQL'
+BEGIN;
+CREATE TABLE t(id INTEGER PRIMARY KEY, k INT, v TEXT);
+CREATE INDEX idx ON t(k);
+INSERT INTO t VALUES(1,10,'base');
+SELECT dolt_commit('-Am','base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+UPDATE t SET k=100 WHERE id=1;
+SELECT dolt_commit('-Am','feat');
+SELECT dolt_checkout('main');
+UPDATE t SET k=200 WHERE id=1;
+SELECT dolt_commit('-Am','main');
+SELECT dolt_merge('feat');
+SELECT 'CONF', count(*) FROM dolt_conflicts;
+DELETE FROM dolt_conflicts_t;
+REINDEX;
+SELECT dolt_commit('-Am','resolved');
+SQL
+  } | dl_pipe "$DB" | awk -F'|' '$1=="CONF"{print $2}'
+)
+[ "$CONF" = "1" ] && pass_name "10_conflict" || fail_name "10_conflict"
 [ "$(dl "$DB" "PRAGMA integrity_check;")" = "ok" ] && pass_name "10_integrity_after_resolve" || fail_name "10_integrity_after_resolve"
 
 # ── 11: Multiple indexes on same table ──

--- a/test/oracle_wide_table_vc_test.sh
+++ b/test/oracle_wide_table_vc_test.sh
@@ -55,8 +55,24 @@ dl "$DB" "CREATE TABLE t(id INTEGER PRIMARY KEY, $COLS); INSERT INTO t VALUES(1,
 echo ""
 echo "--- 3: 100-column conflict (same column both sides) ---"
 DB="$TMPROOT/3.db"
-dl "$DB" "CREATE TABLE t(id INTEGER PRIMARY KEY, $COLS); INSERT INTO t VALUES(1, $VALS); SELECT dolt_commit('-Am','base'); SELECT dolt_branch('feat'); SELECT dolt_checkout('feat'); UPDATE t SET c50=1000 WHERE id=1; SELECT dolt_commit('-Am','feat'); SELECT dolt_checkout('main'); UPDATE t SET c50=2000 WHERE id=1; SELECT dolt_commit('-Am','main'); SELECT dolt_merge('feat');" >/dev/null
-[ "$(dl "$DB" "SELECT count(*) FROM dolt_conflicts;")" = "1" ] && pass_name "3_conflict" || fail_name "3_conflict"
+CONF=$(
+  "$DOLTLITE" "$DB" 2>/dev/null <<SQL | awk -F'|' '$1=="CONF"{print $2}'
+BEGIN;
+CREATE TABLE t(id INTEGER PRIMARY KEY, $COLS);
+INSERT INTO t VALUES(1, $VALS);
+SELECT dolt_commit('-Am','base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+UPDATE t SET c50=1000 WHERE id=1;
+SELECT dolt_commit('-Am','feat');
+SELECT dolt_checkout('main');
+UPDATE t SET c50=2000 WHERE id=1;
+SELECT dolt_commit('-Am','main');
+SELECT dolt_merge('feat');
+SELECT 'CONF', count(*) FROM dolt_conflicts;
+SQL
+)
+[ "$CONF" = "1" ] && pass_name "3_conflict" || fail_name "3_conflict"
 [ "$(dl "$DB" "SELECT c50 FROM t WHERE id=1;")" = "2000" ] && pass_name "3_ours_wins" || fail_name "3_ours_wins"
 
 # ── 4: 200-column merge (near limit) ────────────────────

--- a/test/vc_oracle_conflicts_resolve_test.sh
+++ b/test/vc_oracle_conflicts_resolve_test.sh
@@ -35,8 +35,10 @@ oracle() {
   mkdir -p "$dir/dl" "$dir/dt"
 
   # -- doltlite --
+  local dl_script
   local dl_out
-  dl_out=$(printf "%s\n%s\n" "$setup" "$resolve_and_query" \
+  dl_script=$(printf "%s\n%s\n" "$setup" "$resolve_and_query" | perl -0pe "s/\nSELECT dolt_merge\\(/\nBEGIN;\\nSELECT dolt_merge\\(/")
+  dl_out=$(printf "%s" "$dl_script" \
            | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
            | grep -v '^[0-9]*$' \
            | grep -v '^[0-9a-f]\{40\}$' \
@@ -79,8 +81,10 @@ oracle_error() {
   local dir="$TMPROOT/${name}_err"
   mkdir -p "$dir/dl" "$dir/dt"
 
+  local dl_setup
   local dl_rc
-  vc_oracle_run_doltlite_script "$dir/dl/db" "$dir/dl.out" "$dir/dl.err" "$setup"
+  dl_setup=$(printf "%s\n" "$setup" | perl -0pe "s/\nSELECT dolt_merge\\(/\nBEGIN;\\nSELECT dolt_merge\\(/")
+  vc_oracle_run_doltlite_script "$dir/dl/db" "$dir/dl.out" "$dir/dl.err" "$dl_setup"
   dl_rc=$?
 
   local dolt_setup

--- a/test/vc_oracle_conflicts_table_test.sh
+++ b/test/vc_oracle_conflicts_table_test.sh
@@ -46,8 +46,10 @@ oracle() {
   mkdir -p "$dir/dl" "$dir/dt"
 
   # -- doltlite --
+  local dl_script
   local dl_out
-  dl_out=$(printf "%s\n.headers off\n.mode list\n%s\n" "$setup" "$query" \
+  dl_script=$(printf "%s\n.headers off\n.mode list\n%s\n" "$setup" "$query" | perl -0pe "s/\nSELECT dolt_merge\\(/\nBEGIN;\\nSELECT dolt_merge\\(/")
+  dl_out=$(printf "%s" "$dl_script" \
            | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
            | grep '^R|' \
            | normalize)
@@ -93,8 +95,10 @@ oracle_mutate() {
   local dir="$TMPROOT/$name"
   mkdir -p "$dir/dl" "$dir/dt"
 
+  local dl_script
   local dl_out
-  dl_out=$(printf "%s\n%s\n%s\n" "$setup" "$mutate" "$query" \
+  dl_script=$(printf "%s\n%s\n%s\n" "$setup" "$mutate" "$query" | perl -0pe "s/\nSELECT dolt_merge\\(/\nBEGIN;\\nSELECT dolt_merge\\(/")
+  dl_out=$(printf "%s" "$dl_script" \
            | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
            | grep '^R|' \
            | normalize)

--- a/test/vc_oracle_merge_test.sh
+++ b/test/vc_oracle_merge_test.sh
@@ -14,11 +14,10 @@
 # doltlite encodes the storage key from the user PK columns rather
 # than from sqlite's auto-allocated rowid.
 #
-# Conflict scenarios are checked via oracle_no_merge_commit because
-# doltlite enters a merge state on conflict while Dolt rolls back the
-# transaction under autocommit. The two engines diverge in HOW the
-# conflict is surfaced, but both refuse to produce a clean merge
-# commit, which is the property the oracle gates on.
+# Conflict scenarios are checked in two ways:
+# 1. oracle_no_merge_commit: neither engine should advance history.
+# 2. oracle_error_poststate: under autocommit, both should roll back
+#    and leave no persisted conflict state.
 #
 # Usage: bash vc_oracle_merge_test.sh [path/to/doltlite] [path/to/dolt]
 #
@@ -391,6 +390,20 @@ SELECT dolt_commit('-m', 'feat1');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feature');
 "
+
+oracle_error_poststate "modify_modify_conflict_rolls_back" "
+$SEED
+UPDATE t SET v = 99 WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main2');
+SELECT dolt_checkout('feature');
+UPDATE t SET v = 11 WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat1');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feature');
+" "SELECT (SELECT count(*) FROM dolt_conflicts) || '|' || (SELECT group_concat(id || ':' || v, ',') FROM (SELECT id, v FROM t ORDER BY id) AS ordered_rows)" \
+"SELECT CONCAT((SELECT COUNT(*) FROM dolt_conflicts), '|', (SELECT GROUP_CONCAT(CONCAT(id, ':', v) ORDER BY id SEPARATOR ',') FROM t))"
 
 echo "--- already up to date ---"
 

--- a/test/vc_oracle_revert_cherrypick_test.sh
+++ b/test/vc_oracle_revert_cherrypick_test.sh
@@ -392,11 +392,7 @@ SELECT dolt_revert((SELECT commit_hash FROM dolt_log WHERE message = 'c3_add_3')
 
 echo "--- conflicts ---"
 
-# A conflicted cherry-pick / revert should NOT advance the branch
-# (no new merge commit) and SHOULD leave dolt_conflicts populated.
-# Both engines use the same harness pattern as the merge oracle's
-# `oracle_no_merge_commit`: count commits before and after, expect
-# them to match.
+# A conflicted cherry-pick / revert should NOT advance the branch.
 oracle_no_merge_commit() {
   local name="$1" setup="$2"
   local dir="$TMPROOT/${name}_nm"
@@ -415,10 +411,7 @@ oracle_no_merge_commit() {
   dt_count=$(
     cd "$dir/dt" || exit 1
     vc_oracle_init_repo
-    {
-      printf '%s\n' "SET @@dolt_allow_commit_conflicts = 1;"
-      printf '%s\n' "$dolt_setup"
-    } | "$DOLT" sql -c >/dev/null 2>"$dir/dt.err" || true
+    echo "$dolt_setup" | "$DOLT" sql >/dev/null 2>"$dir/dt.err" || true
     "$DOLT" sql -r csv -q "SELECT count(*) FROM dolt_log;" 2>>"$dir/dt.err" \
       | tail -n +2
   )
@@ -467,52 +460,9 @@ SELECT dolt_commit('-m', 'c3_set_99');
 SELECT dolt_revert('HEAD~1');
 "
 
-# After a conflicting cherry-pick, dolt_conflicts should show one
-# row for the conflicting table, and a follow-up
-# dolt_conflicts_resolve('--ours', 't') should clear it. The full
-# count check would pass even if the conflict surface was empty
-# (zero commits added either way), so the comparison query is the
-# conflicts vtable instead.
-oracle_conflicts_count() {
-  local name="$1" setup="$2"
-  local dir="$TMPROOT/${name}_cc"
-  mkdir -p "$dir/dl" "$dir/dt"
-
-  local dl_count
-  printf '%s\n' "$setup" | "$DOLTLITE" "$dir/dl/db" >/dev/null 2>"$dir/dl.err" || true
-  dl_count=$(printf ".headers off\n.mode list\nSELECT count(*) FROM dolt_conflicts;\n" \
-             | "$DOLTLITE" "$dir/dl/db" 2>>"$dir/dl.err" \
-             | grep -E '^[0-9]+$' | tail -1)
-
-  local dolt_setup
-  dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
-
-  local dt_count
-  dt_count=$(
-    cd "$dir/dt" || exit 1
-    vc_oracle_init_repo
-    {
-      printf '%s\n' "SET @@dolt_allow_commit_conflicts = 1;"
-      printf '%s\n' "$dolt_setup"
-    } | "$DOLT" sql -c >/dev/null 2>"$dir/dt.err" || true
-    "$DOLT" sql -r csv -q "SELECT count(*) FROM dolt_conflicts;" 2>>"$dir/dt.err" \
-      | tail -n +2
-  )
-
-  if [ "$dl_count" = "$dt_count" ]; then
-    pass=$((pass+1))
-  else
-    fail=$((fail+1))
-    FAILED_NAMES="$FAILED_NAMES $name"
-    echo "  FAIL: $name"
-    echo "    doltlite conflicts: $dl_count"
-    echo "    dolt conflicts:     $dt_count"
-  fi
-}
-
-# After a conflicted cherry-pick, both engines should report
-# exactly one conflicting table in dolt_conflicts.
-oracle_conflicts_count "cherry_pick_conflict_populates_dolt_conflicts" "
+# Under autocommit, a conflicted cherry-pick should roll back and
+# leave no persisted conflict rows behind.
+oracle_error_poststate "cherry_pick_conflict_rolls_back" "
 $SEED
 SELECT dolt_checkout('feature');
 UPDATE t SET v = 99 WHERE id = 1;
@@ -524,48 +474,10 @@ UPDATE t SET v = 11 WHERE id = 1;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'main_11');
 SELECT dolt_cherry_pick('feat-conflict');
-"
+ " "SELECT (SELECT count(*) FROM dolt_conflicts) || '|' || (SELECT group_concat(id || ':' || v, ',') FROM (SELECT id, v FROM t ORDER BY id) AS ordered_rows)" \
+"SELECT CONCAT((SELECT COUNT(*) FROM dolt_conflicts), '|', (SELECT GROUP_CONCAT(CONCAT(id, ':', v) ORDER BY id SEPARATOR ',') FROM t))"
 
-# Resolving --ours should clear dolt_conflicts.
-oracle_conflicts_count "cherry_pick_conflict_resolved_ours_clears" "
-$SEED
-SELECT dolt_checkout('feature');
-UPDATE t SET v = 99 WHERE id = 1;
-SELECT dolt_add('-A');
-SELECT dolt_commit('-m', 'feat_99');
-SELECT dolt_tag('feat-conflict');
-SELECT dolt_checkout('main');
-UPDATE t SET v = 11 WHERE id = 1;
-SELECT dolt_add('-A');
-SELECT dolt_commit('-m', 'main_11');
-SELECT dolt_cherry_pick('feat-conflict');
-SELECT dolt_conflicts_resolve('--ours', 't');
-"
-
-# Revert conflict surface is not stable across the two engines yet.
-# Keep the cross-engine invariant above (`oracle_no_merge_commit`) and
-# pin doltlite's stronger conflict-table behavior here as a local
-# regression instead of an oracle comparison.
-doltlite_conflicts_count() {
-  local name="$1" setup="$2" expected="$3"
-  local dir="$TMPROOT/${name}_dl"
-  mkdir -p "$dir"
-  printf '%s\n' "$setup" | "$DOLTLITE" "$dir/db" >/dev/null 2>"$dir.err" || true
-  local count
-  count=$(printf ".headers off\n.mode list\nSELECT count(*) FROM dolt_conflicts;\n" \
-          | "$DOLTLITE" "$dir/db" 2>>"$dir.err" | grep -E '^[0-9]+$' | tail -1)
-  if [ "$count" = "$expected" ]; then
-    pass=$((pass+1))
-  else
-    fail=$((fail+1))
-    FAILED_NAMES="$FAILED_NAMES $name"
-    echo "  FAIL: $name"
-    echo "    doltlite conflicts: $count"
-    echo "    expected:           $expected"
-  fi
-}
-
-doltlite_conflicts_count "revert_conflict_populates_dolt_conflicts" "
+oracle_error_poststate "revert_conflict_rolls_back" "
 $SEED
 UPDATE t SET v = 50 WHERE id = 1;
 SELECT dolt_add('-A');
@@ -574,19 +486,8 @@ UPDATE t SET v = 99 WHERE id = 1;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c3_set_99');
 SELECT dolt_revert('HEAD~1');
- " "1"
-
-doltlite_conflicts_count "revert_conflict_resolved_theirs_clears" "
-$SEED
-UPDATE t SET v = 50 WHERE id = 1;
-SELECT dolt_add('-A');
-SELECT dolt_commit('-m', 'c2_set_50');
-UPDATE t SET v = 99 WHERE id = 1;
-SELECT dolt_add('-A');
-SELECT dolt_commit('-m', 'c3_set_99');
-SELECT dolt_revert('HEAD~1');
-SELECT dolt_conflicts_resolve('--theirs', 't');
-" "0"
+" "SELECT (SELECT count(*) FROM dolt_conflicts) || '|' || (SELECT group_concat(id || ':' || v, ',') FROM (SELECT id, v FROM t ORDER BY id) AS ordered_rows)" \
+"SELECT CONCAT((SELECT COUNT(*) FROM dolt_conflicts), '|', (SELECT GROUP_CONCAT(CONCAT(id, ':', v) ORDER BY id SEPARATOR ',') FROM t))"
 
 echo "--- error paths ---"
 


### PR DESCRIPTION
## Summary
- roll back autocommit merge, cherry-pick, and revert when they hit row conflicts
- keep conflict persistence for explicit-transaction resolution paths
- add local and Dolt oracle coverage for the rollback semantics

## Testing
- cd build && bash ../test/doltlite_merge.sh
- cd build && bash ../test/doltlite_cherry_pick.sh
- bash test/vc_oracle_merge_test.sh ./build/doltlite dolt
- bash test/vc_oracle_revert_cherrypick_test.sh ./build/doltlite dolt