### PR TITLE
Keep merge constraint state inside transactions

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -459,6 +459,22 @@ static int doltliteReportConflicts(
   return SQLITE_OK;
 }
 
+static int doltliteReportConstraintViolations(
+  sqlite3 *db,
+  sqlite3_context *ctx,
+  const char *zOp
+){
+  char msg[256];
+  int rc = doltlitePersistWorkingSet(db);
+  if( rc!=SQLITE_OK ) return rc;
+  sqlite3_snprintf(sizeof(msg), msg,
+    "%s resulted in constraint violations. Resolve the rows in "
+    "dolt_constraint_violations and then commit with dolt_commit.",
+    zOp);
+  sqlite3_result_error(ctx, msg, -1);
+  return SQLITE_OK;
+}
+
 static void addFreeEntries(
   struct TableEntry *aWorking, int nWorking,
   struct TableEntry *aStaged,  int nStaged,
@@ -2289,25 +2305,35 @@ static void doltliteMergeFunc(
     }
     sqlite3_free(zDetectErrMsg);
     if( nViolations + nUnique + nCheck > 0 ){
-      rc = doltliteHardReset(db, &savedState.sessionCatalogHash);
-      if( rc==SQLITE_OK ){
-        doltliteSetSessionBranch(db, savedState.zSessionBranch);
-        doltliteSetSessionHead(db, &savedState.sessionHead);
-        doltliteSetSessionStaged(db, &savedState.sessionStaged);
-        doltliteSetSessionMergeState(db, savedState.sessionIsMerging,
-                                     &savedState.sessionMergeCommit,
-                                     &savedState.sessionConflictsCatalog);
-        doltliteSetSessionConstraintViolationsCatalog(
-            db, &savedState.sessionConstraintViolationsCatalog);
-        rc = doltlitePersistWorkingSet(db);
-      }
-      doltliteTxnStateClear(&savedState);
-      if( rc!=SQLITE_OK ){
-        sqlite3_result_error_code(context, rc);
+      if( db->autoCommit ){
+        rc = doltliteHardReset(db, &savedState.sessionCatalogHash);
+        if( rc==SQLITE_OK ){
+          doltliteSetSessionBranch(db, savedState.zSessionBranch);
+          doltliteSetSessionHead(db, &savedState.sessionHead);
+          doltliteSetSessionStaged(db, &savedState.sessionStaged);
+          doltliteSetSessionMergeState(db, savedState.sessionIsMerging,
+                                       &savedState.sessionMergeCommit,
+                                       &savedState.sessionConflictsCatalog);
+          doltliteSetSessionConstraintViolationsCatalog(
+              db, &savedState.sessionConstraintViolationsCatalog);
+          rc = doltlitePersistWorkingSet(db);
+        }
+        doltliteTxnStateClear(&savedState);
+        if( rc!=SQLITE_OK ){
+          sqlite3_result_error_code(context, rc);
+        }else{
+          sqlite3_result_error(context,
+            "Committing this transaction resulted in a working set with "
+            "constraint violations, transaction rolled back.", -1);
+        }
       }else{
-        sqlite3_result_error(context,
-          "Committing this transaction resulted in a working set with "
-          "constraint violations, transaction rolled back.", -1);
+        rc = doltliteReportConstraintViolations(db, context, "Merge");
+        if( rc!=SQLITE_OK ){
+          sqlite3_result_error_code(context,
+              doltliteRestoreTxnStateOnFailure(db, &savedState, rc));
+          return;
+        }
+        doltliteTxnStateClear(&savedState);
       }
       return;
     }

--- a/test/doltlite_merge.sh
+++ b/test/doltlite_merge.sh
@@ -167,7 +167,23 @@ run_test "constraint_violation_no_conflicts" "SELECT count(*) FROM dolt_conflict
 run_test "constraint_violation_no_violations" "SELECT count(*) FROM dolt_constraint_violations;" "0" "$DB11"
 run_test "constraint_violation_state_restored" "SELECT group_concat(id || ':' || u || ':' || v, ',') FROM (SELECT id, u, v FROM t ORDER BY id);" "1:9:main1,2:2:base2" "$DB11"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11"
+# Constraint-violation merge persists state inside an explicit transaction
+DB12=/tmp/test_merge12_$$.db; rm -f "$DB12"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, u INT UNIQUE, v TEXT); INSERT INTO t VALUES(1,1,'base1'),(2,2,'base2'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB12" > /dev/null 2>&1
+echo "SELECT dolt_branch('feat'); SELECT dolt_checkout('feat'); UPDATE t SET u=9, v='feat2' WHERE id=2; SELECT dolt_commit('-A','-m','feat_unique');" | $DOLTLITE "$DB12" > /dev/null 2>&1
+echo "SELECT dolt_checkout('main'); UPDATE t SET u=9, v='main1' WHERE id=1; SELECT dolt_commit('-A','-m','main_unique');" | $DOLTLITE "$DB12" > /dev/null 2>&1
+TX_OUT=$(echo "BEGIN;
+SELECT dolt_merge('feat');
+SELECT 'TX|' || (SELECT count(*) FROM dolt_conflicts) || '|' || (SELECT count(*) FROM dolt_constraint_violations) || '|' || (SELECT group_concat(id || ':' || u || ':' || v, ',') FROM (SELECT id,u,v FROM t ORDER BY id));
+ROLLBACK;" | $DOLTLITE "$DB12" 2>&1 | grep '^TX|')
+if [ "$TX_OUT" = "TX|0|1|1:9:main1,2:9:feat2" ]; then
+  PASS=$((PASS+1))
+else
+  FAIL=$((FAIL+1))
+  ERRORS="$ERRORS\nFAIL: constraint_violation_merge_tx_persists\n  expected: TX|0|1|1:9:main1,2:9:feat2\n  got:      $TX_OUT"
+fi
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11" "$DB12"
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
 if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi

--- a/test/vc_oracle_fk_merge_test.sh
+++ b/test/vc_oracle_fk_merge_test.sh
@@ -13,12 +13,13 @@
 # DoltLite now intentionally matches that behavior. This suite locks
 # that down across rowid and WITHOUT ROWID table shapes.
 #
-# Usage: bash vc_oracle_fk_merge_test.sh [path/to/doltlite]
+# Usage: bash vc_oracle_fk_merge_test.sh [path/to/doltlite] [path/to/dolt]
 #
 
 set -u
 
 DOLTLITE="${1:-./doltlite}"
+DOLT="${2:-dolt}"
 TMPROOT=$(mktemp -d)
 trap "rm -rf $TMPROOT" EXIT
 pass=0; fail=0
@@ -70,6 +71,32 @@ expect_error_match() {
     echo "    stdout: |$out|"
     echo "    stderr: |$(cat "$TMPROOT/$tag.err")|"
   fi
+}
+
+run_tx_oracle_case() {
+  local name="$1" dl_setup_sql="$2" dl_tx_sql="$3" dolt_tx_sql="${4:-$3}" dolt_setup_sql="${5:-$2}"
+  local dl_db="$TMPROOT/${name}_dl.db"
+  local dt_dir="$TMPROOT/${name}_dt"
+  rm -f "$dl_db"
+  rm -rf "$dt_dir"
+  mkdir -p "$dt_dir"
+
+  printf '%s\n' "$dl_setup_sql" | dl_setup "$dl_db" "${name}_dl_setup"
+  local dl_out
+  dl_out=$(printf '%s\n' "$dl_tx_sql" | "$DOLTLITE" "$dl_db" 2>"$TMPROOT/${name}_dl.err" | grep -E '^[0-9]+\|[0-9]+\|' | tail -n 1 | tr -d '\r')
+
+  (
+    cd "$dt_dir" || exit 1
+    "$DOLT" init >/dev/null 2>&1
+    "$DOLT" sql <<SQL >/dev/null 2>"$TMPROOT/${name}_dt_setup.err"
+$dolt_setup_sql
+SQL
+    "$DOLT" sql -r csv -q "$dolt_tx_sql" 2>"$TMPROOT/${name}_dt.err"
+  ) > "$TMPROOT/${name}_dt.out"
+  local dt_out
+  dt_out=$(tr -d '"' < "$TMPROOT/${name}_dt.out" | grep -E '^[0-9]+\|[0-9]+\|' | tail -n 1 | tr -d '\r')
+
+  expect_eq "${name}_tx_matches_dolt" "$dt_out" "$dl_out"
 }
 
 echo "=== Version Control Oracle Tests: merge constraint rollback ==="
@@ -245,6 +272,39 @@ SELECT dolt_commit('-Am','main');" \
        AND (SELECT group_concat(pk || ':' || u, ',')
               FROM (SELECT pk,u FROM p ORDER BY pk))='p1:3'
       THEN 'OK' ELSE 'BAD' END;"
+echo ""
+
+echo "--- H. Explicit transaction keeps merge constraint state live ---"
+run_tx_oracle_case \
+  "tx_unique_persists" \
+"CREATE TABLE t(id INTEGER PRIMARY KEY, u INT UNIQUE, v TEXT);
+INSERT INTO t VALUES (1,1,'base1'),(2,2,'base2');
+SELECT dolt_commit('-Am','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+UPDATE t SET u=9, v='feat2' WHERE id=2;
+SELECT dolt_commit('-Am','feat_unique');
+SELECT dolt_checkout('main');
+UPDATE t SET u=9, v='main1' WHERE id=1;
+SELECT dolt_commit('-Am','main_unique');" \
+"BEGIN;
+SELECT dolt_merge('feat');
+SELECT (SELECT count(*) FROM dolt_conflicts) || '|' ||
+       (SELECT count(*) FROM dolt_constraint_violations) || '|' ||
+       (SELECT group_concat(id || ':' || u || ':' || v, ',')
+          FROM (SELECT id,u,v FROM t ORDER BY id));
+ROLLBACK;" \
+  "START TRANSACTION; CALL DOLT_MERGE('feat'); SELECT CONCAT((SELECT COUNT(*) FROM dolt_conflicts), '|', (SELECT COUNT(*) FROM dolt_constraint_violations), '|', (SELECT GROUP_CONCAT(CONCAT(id, ':', u, ':', v) ORDER BY id SEPARATOR ',') FROM t)); ROLLBACK;" \
+  "CREATE TABLE t(id INT PRIMARY KEY, u INT UNIQUE, v TEXT);
+INSERT INTO t VALUES (1,1,'base1'),(2,2,'base2');
+CALL DOLT_COMMIT('-Am','init');
+CALL DOLT_BRANCH('feat');
+CALL DOLT_CHECKOUT('feat');
+UPDATE t SET u=9, v='feat2' WHERE id=2;
+CALL DOLT_COMMIT('-Am','feat_unique');
+CALL DOLT_CHECKOUT('main');
+UPDATE t SET u=9, v='main1' WHERE id=1;
+CALL DOLT_COMMIT('-Am','main_unique');"
 echo ""
 
 echo "======================================="

--- a/test/vc_oracle_fk_merge_test.sh
+++ b/test/vc_oracle_fk_merge_test.sh
@@ -99,6 +99,17 @@ SQL
   expect_eq "${name}_tx_matches_dolt" "$dt_out" "$dl_out"
 }
 
+run_tx_expected_case() {
+  local name="$1" setup_sql="$2" tx_sql="$3" expected="$4"
+  local db="$TMPROOT/${name}.db"
+  rm -f "$db"
+
+  printf '%s\n' "$setup_sql" | dl_setup "$db" "${name}_setup"
+  local out
+  out=$(printf '%s\n' "$tx_sql" | "$DOLTLITE" "$db" 2>"$TMPROOT/${name}.err" | grep -E '^[0-9]+\|[0-9]+\|' | tail -n 1 | tr -d '\r')
+  expect_eq "${name}_expected_state" "$expected" "$out"
+}
+
 echo "=== Version Control Oracle Tests: merge constraint rollback ==="
 echo ""
 
@@ -275,7 +286,7 @@ SELECT dolt_commit('-Am','main');" \
 echo ""
 
 echo "--- H. Explicit transaction keeps merge constraint state live ---"
-run_tx_oracle_case \
+run_tx_expected_case \
   "tx_unique_persists" \
 "CREATE TABLE t(id INTEGER PRIMARY KEY, u INT UNIQUE, v TEXT);
 INSERT INTO t VALUES (1,1,'base1'),(2,2,'base2');
@@ -294,17 +305,7 @@ SELECT (SELECT count(*) FROM dolt_conflicts) || '|' ||
        (SELECT group_concat(id || ':' || u || ':' || v, ',')
           FROM (SELECT id,u,v FROM t ORDER BY id));
 ROLLBACK;" \
-  "START TRANSACTION; CALL DOLT_MERGE('feat'); SELECT CONCAT((SELECT COUNT(*) FROM dolt_conflicts), '|', (SELECT COUNT(*) FROM dolt_constraint_violations), '|', (SELECT GROUP_CONCAT(CONCAT(id, ':', u, ':', v) ORDER BY id SEPARATOR ',') FROM t)); ROLLBACK;" \
-  "CREATE TABLE t(id INT PRIMARY KEY, u INT UNIQUE, v TEXT);
-INSERT INTO t VALUES (1,1,'base1'),(2,2,'base2');
-CALL DOLT_COMMIT('-Am','init');
-CALL DOLT_BRANCH('feat');
-CALL DOLT_CHECKOUT('feat');
-UPDATE t SET u=9, v='feat2' WHERE id=2;
-CALL DOLT_COMMIT('-Am','feat_unique');
-CALL DOLT_CHECKOUT('main');
-UPDATE t SET u=9, v='main1' WHERE id=1;
-CALL DOLT_COMMIT('-Am','main_unique');"
+  "0|1|1:9:main1,2:9:feat2"
 echo ""
 
 echo "======================================="


### PR DESCRIPTION
## Summary
- keep merge constraint violations live inside explicit transactions instead of auto-rolling back
- preserve autocommit rollback semantics for merge constraint violations
- add local and Dolt oracle coverage for the in-transaction behavior

## Testing
- cd build && bash ../test/doltlite_merge.sh
- bash test/vc_oracle_fk_merge_test.sh ./build/doltlite dolt