### PR TITLE
Seal VC metadata mutations across savepoint rollback

### DIFF
--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -46,6 +46,16 @@ static void branchResultError(
 static int branchRestartTxnIfNeeded(sqlite3 *db){
   int rc;
   if( db->autoCommit ) return SQLITE_OK;
+  if( db->pSavepoint ){
+    while( db->pSavepoint ){
+      char *zSql = sqlite3_mprintf("RELEASE SAVEPOINT \"%w\"", db->pSavepoint->zName);
+      if( !zSql ) return SQLITE_NOMEM;
+      rc = sqlite3_exec(db, zSql, 0, 0, 0);
+      sqlite3_free(zSql);
+      if( rc!=SQLITE_OK ) return rc;
+    }
+    return SQLITE_OK;
+  }
   rc = sqlite3_exec(db, "COMMIT", 0, 0, 0);
   if( rc!=SQLITE_OK ) return rc;
   rc = sqlite3_exec(db, "BEGIN", 0, 0, 0);
@@ -423,6 +433,7 @@ static int checkoutRestoreDurableState(
 
 static int checkoutMutateRefs(sqlite3 *db, ChunkStore *cs, void *pArg){
   CheckoutMutationCtx *p = (CheckoutMutationCtx*)pArg;
+  int bSavepoint = db->pSavepoint!=0;
   int rc;
 
   rc = chunkStoreFindBranch(cs, p->zTargetBranch, &p->targetCommit);
@@ -447,11 +458,13 @@ static int checkoutMutateRefs(sqlite3 *db, ChunkStore *cs, void *pArg){
     }
   }
 
-  rc = chunkStoreSetDefaultBranch(cs, p->zTargetBranch);
-  if( rc!=SQLITE_OK ) return rc;
+  if( !bSavepoint ){
+    rc = chunkStoreSetDefaultBranch(cs, p->zTargetBranch);
+    if( rc!=SQLITE_OK ) return rc;
 
-  rc = doltliteSaveWorkingSet(db);
-  if( rc!=SQLITE_OK ) return rc;
+    rc = doltliteSaveWorkingSet(db);
+    if( rc!=SQLITE_OK ) return rc;
+  }
 
   if( p->haveOldState ){
     rc = doltliteUpdateBranchWorkingState(db, p->zCurrentBranch,
@@ -462,10 +475,12 @@ static int checkoutMutateRefs(sqlite3 *db, ChunkStore *cs, void *pArg){
     }
   }
 
-  rc = doltliteUpdateBranchWorkingState(db, p->zTargetBranch,
-                                        &p->targetCatHash, &p->targetCommit);
-  if( rc!=SQLITE_OK ){
-    checkoutRestoreSession(db, p);
+  if( !bSavepoint ){
+    rc = doltliteUpdateBranchWorkingState(db, p->zTargetBranch,
+                                          &p->targetCatHash, &p->targetCommit);
+    if( rc!=SQLITE_OK ){
+      checkoutRestoreSession(db, p);
+    }
   }
   return rc;
 }

--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -43,6 +43,15 @@ static void branchResultError(
   }
 }
 
+static int branchRestartTxnIfNeeded(sqlite3 *db){
+  int rc;
+  if( db->autoCommit ) return SQLITE_OK;
+  rc = sqlite3_exec(db, "COMMIT", 0, 0, 0);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = sqlite3_exec(db, "BEGIN", 0, 0, 0);
+  return rc;
+}
+
 static int mutateBranchRef(sqlite3 *db, ChunkStore *cs, void *pArg){
   BranchMutationCtx *p = (BranchMutationCtx*)pArg;
   int rc;
@@ -121,6 +130,7 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
   int force = 0;
   const char *aPositional[3] = {0, 0, 0};
   int nPositional = 0;
+  int hadExplicitTxn = !db->autoCommit;
   int i, rc;
 
   if( !cs ){ sqlite3_result_error(ctx, "no database", -1); return; }
@@ -310,6 +320,13 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
     }
   }
 
+  if( hadExplicitTxn ){
+    rc = branchRestartTxnIfNeeded(db);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(ctx, rc);
+      return;
+    }
+  }
   sqlite3_result_int(ctx, 0);
 }
 
@@ -604,15 +621,6 @@ static int doltliteCheckoutTables(
   return rc;
 }
 
-static int checkoutRestartTxnIfNeeded(sqlite3 *db){
-  int rc;
-  if( db->autoCommit ) return SQLITE_OK;
-  rc = sqlite3_exec(db, "COMMIT", 0, 0, 0);
-  if( rc!=SQLITE_OK ) return rc;
-  rc = sqlite3_exec(db, "BEGIN", 0, 0, 0);
-  return rc;
-}
-
 static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
   ChunkStore *cs = doltliteGetChunkStore(db);
@@ -695,7 +703,7 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
       return;
     }
     if( hadExplicitTxn ){
-      rc = checkoutRestartTxnIfNeeded(db);
+      rc = branchRestartTxnIfNeeded(db);
       if( rc!=SQLITE_OK ){
         sqlite3_result_error_code(ctx, rc);
         return;
@@ -777,7 +785,7 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
     return;
   }
   if( hadExplicitTxn ){
-    rc = checkoutRestartTxnIfNeeded(db);
+    rc = branchRestartTxnIfNeeded(db);
     if( rc!=SQLITE_OK ){
       sqlite3_result_error_code(ctx, rc);
       return;

--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -604,6 +604,15 @@ static int doltliteCheckoutTables(
   return rc;
 }
 
+static int checkoutRestartTxnIfNeeded(sqlite3 *db){
+  int rc;
+  if( db->autoCommit ) return SQLITE_OK;
+  rc = sqlite3_exec(db, "COMMIT", 0, 0, 0);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = sqlite3_exec(db, "BEGIN", 0, 0, 0);
+  return rc;
+}
+
 static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
   ChunkStore *cs = doltliteGetChunkStore(db);
@@ -612,6 +621,7 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
   const char *zBranch;
   char *zCurrentBranch = 0;
   int isCreateAndSwitch = 0;
+  int hadExplicitTxn = !db->autoCommit;
   int rc;
 
   if( !cs ){ sqlite3_result_error(ctx, "no database", -1); return; }
@@ -683,6 +693,13 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
     if( rc!=SQLITE_OK ){
       sqlite3_result_error_code(ctx, rc);
       return;
+    }
+    if( hadExplicitTxn ){
+      rc = checkoutRestartTxnIfNeeded(db);
+      if( rc!=SQLITE_OK ){
+        sqlite3_result_error_code(ctx, rc);
+        return;
+      }
     }
     sqlite3_result_int(ctx, 0);
     return;
@@ -758,6 +775,13 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
   if( rc!=SQLITE_OK ){
     sqlite3_result_error(ctx, "checkout failed", -1);
     return;
+  }
+  if( hadExplicitTxn ){
+    rc = checkoutRestartTxnIfNeeded(db);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(ctx, rc);
+      return;
+    }
   }
   sqlite3_result_int(ctx, 0);
 }

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -117,6 +117,17 @@ static void remoteSqlResultError(
   }
 }
 
+static int remoteSqlReleaseSavepoints(sqlite3 *db){
+  int rc = SQLITE_OK;
+  while( rc==SQLITE_OK && db->pSavepoint ){
+    char *zSql = sqlite3_mprintf("RELEASE SAVEPOINT \"%w\"", db->pSavepoint->zName);
+    if( !zSql ) return SQLITE_NOMEM;
+    rc = sqlite3_exec(db, zSql, 0, 0, 0);
+    sqlite3_free(zSql);
+  }
+  return rc;
+}
+
 static void remoteSqlRestoreAndReport(
   sqlite3_context *ctx,
   sqlite3 *db,
@@ -269,6 +280,11 @@ static void doltRemoteFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
     return;
   }
 
+  rc = remoteSqlReleaseSavepoints(db);
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error_code(ctx, rc);
+    return;
+  }
   sqlite3_result_int(ctx, 0);
 }
 

--- a/src/doltlite_tag.c
+++ b/src/doltlite_tag.c
@@ -44,6 +44,17 @@ static int mutateTagRef(sqlite3 *db, ChunkStore *cs, void *pArg){
                               p->timestamp, p->zMessage);
 }
 
+static int tagReleaseSavepoints(sqlite3 *db){
+  int rc = SQLITE_OK;
+  while( rc==SQLITE_OK && db->pSavepoint ){
+    char *zSql = sqlite3_mprintf("RELEASE SAVEPOINT \"%w\"", db->pSavepoint->zName);
+    if( !zSql ) return SQLITE_NOMEM;
+    rc = sqlite3_exec(db, zSql, 0, 0, 0);
+    sqlite3_free(zSql);
+  }
+  return rc;
+}
+
 static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
   ChunkStore *cs = doltliteGetChunkStore(db);
@@ -79,6 +90,11 @@ static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     rc = doltliteMutateRefs(db, mutateTagRef, &m);
     if( rc!=SQLITE_OK ){
       tagResultError(ctx, rc, "tag not found", 0);
+      return;
+    }
+    rc = tagReleaseSavepoints(db);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(ctx, rc);
       return;
     }
     sqlite3_result_int(ctx, 0);
@@ -159,6 +175,11 @@ static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3_free(zParsedEmail);
   if( rc!=SQLITE_OK ){
     tagResultError(ctx, rc, "tag not found", "tag already exists");
+    return;
+  }
+  rc = tagReleaseSavepoints(db);
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error_code(ctx, rc);
     return;
   }
   sqlite3_result_int(ctx, 0);

--- a/test/doltlite_savepoint.sh
+++ b/test/doltlite_savepoint.sh
@@ -261,6 +261,33 @@ run_test_match "remote_savepoint_remote_persists" \
   "SELECT group_concat(name, ',') FROM dolt_remotes;" \
   "^origin$" "$DB6g"
 
+DB6h=/tmp/test_savepoint6h_$$.db; rm -f "$DB6h"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'main'); SELECT dolt_commit('-A','-m','init'); SELECT dolt_branch('other'); SELECT dolt_checkout('other'); UPDATE t SET v='other'; SELECT dolt_commit('-A','-m','other'); SELECT dolt_checkout('main');" | $DOLTLITE "$DB6h" > /dev/null 2>&1
+run_test_match "checkout_savepoint_rollback_to_errors" \
+  "SAVEPOINT sp1; UPDATE t SET v='dirty'; SELECT dolt_checkout('other'); ROLLBACK TO sp1;" \
+  "no such savepoint: sp1" "$DB6h"
+run_test_match "checkout_savepoint_branch_reopens_on_main" \
+  "SELECT active_branch();" \
+  "^main$" "$DB6h"
+run_test_match "checkout_savepoint_row_reopens_dirty" \
+  "SELECT v FROM t WHERE id=1;" \
+  "^dirty$" "$DB6h"
+
+DB6i=/tmp/test_savepoint6i_$$.db; rm -f "$DB6i"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'main'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6i" > /dev/null 2>&1
+run_test_match "checkout_b_savepoint_rollback_to_errors" \
+  "SAVEPOINT sp1; UPDATE t SET v='dirty'; SELECT dolt_checkout('-b','side'); ROLLBACK TO sp1;" \
+  "no such savepoint: sp1" "$DB6i"
+run_test_match "checkout_b_savepoint_branch_reopens_on_main" \
+  "SELECT active_branch();" \
+  "^main$" "$DB6i"
+run_test_match "checkout_b_savepoint_row_reopens_dirty" \
+  "SELECT v FROM t WHERE id=1;" \
+  "^dirty$" "$DB6i"
+run_test_match "checkout_b_savepoint_branch_created" \
+  "SELECT group_concat(name, ',') FROM dolt_branches;" \
+  "^main,side$|^side,main$" "$DB6i"
+
 # ============================================================
 # Test 7: dolt_merge inside a BEGIN/COMMIT block
 # Expected: dolt_merge operates at the dolt storage layer. It should

--- a/test/doltlite_savepoint.sh
+++ b/test/doltlite_savepoint.sh
@@ -249,6 +249,18 @@ run_test_match "tag_savepoint_tag_persists" \
   "SELECT group_concat(tag_name, ',') FROM dolt_tags;" \
   "^v1$" "$DB6f"
 
+DB6g=/tmp/test_savepoint6g_$$.db; rm -f "$DB6g"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'main'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6g" > /dev/null 2>&1
+run_test_match "remote_savepoint_rollback_to_errors" \
+  "SAVEPOINT sp1; UPDATE t SET v='dirty'; SELECT dolt_remote('add','origin','file:///tmp/savepoint-remote'); ROLLBACK TO sp1;" \
+  "no such savepoint: sp1" "$DB6g"
+run_test_match "remote_savepoint_row_persists" \
+  "SELECT v FROM t WHERE id=1;" \
+  "^dirty$" "$DB6g"
+run_test_match "remote_savepoint_remote_persists" \
+  "SELECT group_concat(name, ',') FROM dolt_remotes;" \
+  "^origin$" "$DB6g"
+
 # ============================================================
 # Test 7: dolt_merge inside a BEGIN/COMMIT block
 # Expected: dolt_merge operates at the dolt storage layer. It should

--- a/test/doltlite_savepoint.sh
+++ b/test/doltlite_savepoint.sh
@@ -237,6 +237,18 @@ run_test_match "branch_dirty_rollback_data" \
   "BEGIN; UPDATE t SET v='dirty'; SELECT dolt_branch('txb'); ROLLBACK; SELECT v FROM t WHERE id=1;" \
   "^dirty$" "$DB6e"
 
+DB6f=/tmp/test_savepoint6f_$$.db; rm -f "$DB6f"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'main'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6f" > /dev/null 2>&1
+run_test_match "tag_savepoint_rollback_to_errors" \
+  "SAVEPOINT sp1; UPDATE t SET v='dirty'; SELECT dolt_tag('v1'); ROLLBACK TO sp1;" \
+  "no such savepoint: sp1" "$DB6f"
+run_test_match "tag_savepoint_row_persists" \
+  "SELECT v FROM t WHERE id=1;" \
+  "^dirty$" "$DB6f"
+run_test_match "tag_savepoint_tag_persists" \
+  "SELECT group_concat(tag_name, ',') FROM dolt_tags;" \
+  "^v1$" "$DB6f"
+
 # ============================================================
 # Test 7: dolt_merge inside a BEGIN/COMMIT block
 # Expected: dolt_merge operates at the dolt storage layer. It should

--- a/test/doltlite_savepoint.sh
+++ b/test/doltlite_savepoint.sh
@@ -225,6 +225,18 @@ run_test_match "checkout_dirty_rollback_data" \
   "BEGIN; UPDATE t SET v='dirty'; SELECT dolt_checkout('other'); ROLLBACK; SELECT v FROM t WHERE id=1;" \
   "^other$" "$DB6c"
 
+DB6d=/tmp/test_savepoint6d_$$.db; rm -f "$DB6d"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'main'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6d" > /dev/null 2>&1
+run_test_match "branch_dirty_rollback_branch" \
+  "BEGIN; UPDATE t SET v='dirty'; SELECT dolt_branch('txb'); ROLLBACK; SELECT group_concat(name, ',') FROM dolt_branches;" \
+  "^main,txb$|^txb,main$" "$DB6d"
+
+DB6e=/tmp/test_savepoint6e_$$.db; rm -f "$DB6e"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'main'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6e" > /dev/null 2>&1
+run_test_match "branch_dirty_rollback_data" \
+  "BEGIN; UPDATE t SET v='dirty'; SELECT dolt_branch('txb'); ROLLBACK; SELECT v FROM t WHERE id=1;" \
+  "^dirty$" "$DB6e"
+
 # ============================================================
 # Test 7: dolt_merge inside a BEGIN/COMMIT block
 # Expected: dolt_merge operates at the dolt storage layer. It should

--- a/test/doltlite_savepoint.sh
+++ b/test/doltlite_savepoint.sh
@@ -212,6 +212,19 @@ run_test "checkout_dirty_in_txn" \
   "BEGIN; INSERT INTO t VALUES(2,'dirty'); SELECT dolt_checkout('other'); COMMIT;" \
   "0" "$DB6b"
 
+DB6c=/tmp/test_savepoint6c_$$.db; rm -f "$DB6c"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'main'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6c" > /dev/null 2>&1
+echo "SELECT dolt_branch('other');" | $DOLTLITE "$DB6c" > /dev/null 2>&1
+echo "SELECT dolt_checkout('other'); UPDATE t SET v='other'; SELECT dolt_commit('-A','-m','other'); SELECT dolt_checkout('main');" | $DOLTLITE "$DB6c" > /dev/null 2>&1
+
+run_test_match "checkout_dirty_rollback_branch" \
+  "BEGIN; UPDATE t SET v='dirty'; SELECT dolt_checkout('other'); ROLLBACK; SELECT active_branch();" \
+  "^other$" "$DB6c"
+
+run_test_match "checkout_dirty_rollback_data" \
+  "BEGIN; UPDATE t SET v='dirty'; SELECT dolt_checkout('other'); ROLLBACK; SELECT v FROM t WHERE id=1;" \
+  "^other$" "$DB6c"
+
 # ============================================================
 # Test 7: dolt_merge inside a BEGIN/COMMIT block
 # Expected: dolt_merge operates at the dolt storage layer. It should

--- a/test/vc_oracle_branch_test.sh
+++ b/test/vc_oracle_branch_test.sh
@@ -104,6 +104,62 @@ oracle_error() {
   fi
 }
 
+oracle_with_rows() {
+  local name="$1" setup="$2"
+  local dir="$TMPROOT/${name}_rows"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local q_br='SELECT name || char(9) || hash || char(9) || dirty FROM dolt_branches ORDER BY name'
+  local q_rows="SELECT id || char(9) || v FROM t ORDER BY id"
+
+  local dl_br dl_rows
+  dl_br=$(printf "%s\n.headers off\n.mode list\n.separator '\t'\n%s;\n" "$setup" "$q_br" \
+          | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
+          | grep -v '^[0-9]*$' \
+          | grep -v '^[0-9a-f]\{40\}$' \
+          | normalize)
+  dl_rows=$(printf "%s\n.headers off\n.mode list\n.separator '\t'\n%s;\n" "$setup" "$q_rows" \
+            | "$DOLTLITE" "$dir/dl/db.rows" 2>>"$dir/dl.err" \
+            | grep -v '^[0-9]*$' \
+            | grep -v '^[0-9a-f]\{40\}$')
+
+  local dolt_setup
+  dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
+  (
+    cd "$dir/dt" || exit 1
+    vc_oracle_init_repo
+    {
+      echo "$dolt_setup"
+      echo "SELECT concat(name, char(9), hash, char(9), dirty) FROM dolt_branches ORDER BY name;"
+      echo "SELECT concat(id, char(9), v) FROM t ORDER BY id;"
+    } | "$DOLT" sql -c -r csv 2>"$dir/dt.err"
+  ) > "$dir/dt.raw"
+
+  local dt_br dt_rows
+  dt_br=$(tr -d '"' < "$dir/dt.raw" \
+          | awk -F'\t' 'NF==3 && $1 !~ /^[0-9]+$/ {print}' \
+          | sed -E 's/\ttrue$/\t1/; s/\tfalse$/\t0/' \
+          | normalize)
+  dt_rows=$(tr -d '"' < "$dir/dt.raw" \
+            | awk -F'\t' 'NF==2 && $1 ~ /^[0-9]+$/ {print}')
+
+  local dl_combined dt_combined
+  dl_combined="$dl_br"$'\n'"$dl_rows"
+  dt_combined="$dt_br"$'\n'"$dt_rows"
+
+  if [ "$dl_combined" = "$dt_combined" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite branches:"; echo "$dl_br" | sed 's/^/      /'
+    echo "    dolt branches:"; echo "$dt_br" | sed 's/^/      /'
+    echo "    doltlite rows:"; echo "$dl_rows" | sed 's/^/      /'
+    echo "    dolt rows:"; echo "$dt_rows" | sed 's/^/      /'
+  fi
+}
+
 echo "=== Version Control Oracle Tests: dolt_branch ==="
 echo ""
 
@@ -205,6 +261,16 @@ INSERT INTO t VALUES (2, 20);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c2');
 SELECT dolt_branch('-f', 'feature');
+"
+
+echo "--- explicit transaction parity ---"
+
+oracle_with_rows "branch_create_inside_txn_seals_row_state" "
+$SEED
+BEGIN;
+UPDATE t SET v = 11 WHERE id = 1;
+SELECT dolt_branch('txb');
+ROLLBACK;
 "
 
 echo "--- error paths ---"

--- a/test/vc_oracle_checkout_test.sh
+++ b/test/vc_oracle_checkout_test.sh
@@ -142,6 +142,36 @@ oracle_error() {
   fi
 }
 
+oracle_savepoint_poststate() {
+  local name="$1" setup="$2" query="$3"
+  local dir="$TMPROOT/${name}_sp"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_rc dt_rc dl_post dt_post
+
+  vc_oracle_run_doltlite_script "$dir/dl/db" "$dir/dl.out" "$dir/dl.err" "$setup"
+  dl_rc=$?
+  dl_post=$(printf ".headers off\n.mode list\n.separator '\t'\n%s\n" "$query" \
+            | "$DOLTLITE" "$dir/dl/db" 2>>"$dir/dl.err" \
+            | tr -d '\r')
+
+  local dolt_setup
+  dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
+  vc_oracle_run_dolt_script_for_error "$dir/dt" "$dir/dt.out" "$dir/dt.err" "$dolt_setup"
+  dt_rc=$?
+  dt_post=$(cd "$dir/dt" && "$DOLT" sql -r csv -q "$query" 2>>"$dir/dt.err" | tail -n +2 | tr -d '"' | tr -d '\r')
+
+  if [ "$dl_rc" -ne 0 ] && [ "$dt_rc" -ne 0 ] && [ "$dl_post" = "$dt_post" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite rc/post:"; { echo "$dl_rc"; echo "$dl_post"; } | sed 's/^/      /'
+    echo "    dolt rc/post:"; { echo "$dt_rc"; echo "$dt_post"; } | sed 's/^/      /'
+  fi
+}
+
 echo "=== Version Control Oracle Tests: dolt_checkout ==="
 echo ""
 
@@ -320,6 +350,30 @@ $SEED
 SELECT dolt_branch('feature');
 SELECT dolt_checkout('feature', 'nope');
 "
+
+echo "--- savepoint parity ---"
+
+oracle_savepoint_poststate "savepoint_checkout_existing_branch_reopens_on_original_branch" "
+$SEED
+SELECT dolt_branch('other');
+SELECT dolt_checkout('other');
+UPDATE t SET v='other' WHERE id=1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'other');
+SELECT dolt_checkout('main');
+SAVEPOINT sp1;
+UPDATE t SET v='dirty' WHERE id=1;
+SELECT dolt_checkout('other');
+ROLLBACK TO sp1;
+" "SELECT concat(active_branch(), char(9), (SELECT v FROM t WHERE id=1));"
+
+oracle_savepoint_poststate "savepoint_checkout_dash_b_keeps_new_branch_but_reopens_original_branch" "
+$SEED
+SAVEPOINT sp1;
+UPDATE t SET v='dirty' WHERE id=1;
+SELECT dolt_checkout('-b', 'side');
+ROLLBACK TO sp1;
+" "SELECT concat(active_branch(), char(9), (SELECT v FROM t WHERE id=1), char(9), (SELECT group_concat(name, ',') FROM dolt_branches));"
 
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="

--- a/test/vc_oracle_checkout_test.sh
+++ b/test/vc_oracle_checkout_test.sh
@@ -194,6 +194,20 @@ SELECT dolt_commit('-m', 'c2_feat');
 SELECT dolt_checkout('main');
 "
 
+oracle "txn_checkout_rollback_keeps_checked_out_branch_state" "
+$SEED
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+UPDATE t SET v='feature_v' WHERE id=1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2_feat');
+SELECT dolt_checkout('main');
+BEGIN;
+UPDATE t SET v='dirty' WHERE id=1;
+SELECT dolt_checkout('feature');
+ROLLBACK;
+"
+
 echo "--- create-and-switch (-b) ---"
 
 oracle "dash_b_creates_and_switches" "

--- a/test/vc_oracle_remotes_test.sh
+++ b/test/vc_oracle_remotes_test.sh
@@ -98,6 +98,38 @@ oracle_error() {
   fi
 }
 
+oracle_savepoint_remote_poststate() {
+  local name="$1" setup="$2"
+  local dir="$TMPROOT/${name}_sp"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_rc dt_rc dl_v dl_remotes dt_v dt_remotes
+
+  vc_oracle_run_doltlite_script "$dir/dl/db" "$dir/dl.out" "$dir/dl.err" "$setup"
+  dl_rc=$?
+  dl_v=$(printf ".headers off\n.mode list\nSELECT v FROM t WHERE id=1;\n" \
+         | "$DOLTLITE" "$dir/dl/db" 2>>"$dir/dl.err")
+  dl_remotes=$(printf ".headers off\n.mode list\nSELECT coalesce(group_concat(name, ','), '') FROM dolt_remotes;\n" \
+               | "$DOLTLITE" "$dir/dl/db" 2>>"$dir/dl.err")
+
+  local dolt_setup
+  dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
+  vc_oracle_run_dolt_script_for_error "$dir/dt" "$dir/dt.out" "$dir/dt.err" "$dolt_setup"
+  dt_rc=$?
+  dt_v=$(cd "$dir/dt" && "$DOLT" sql -r csv -q "SELECT v FROM t WHERE id=1;" 2>>"$dir/dt.err" | tail -n +2 | tr -d '"')
+  dt_remotes=$(cd "$dir/dt" && "$DOLT" sql -r csv -q "SELECT coalesce(group_concat(name, ','), '') FROM dolt_remotes;" 2>>"$dir/dt.err" | tail -n +2 | tr -d '"')
+
+  if [ "$dl_rc" -ne 0 ] && [ "$dt_rc" -ne 0 ] && [ "$dl_v" = "$dt_v" ] && [ "$dl_remotes" = "$dt_remotes" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite rc/v/remotes:"; { echo "$dl_rc"; echo "$dl_v"; echo "$dl_remotes"; } | sed 's/^/      /'
+    echo "    dolt rc/v/remotes:"; { echo "$dt_rc"; echo "$dt_v"; echo "$dt_remotes"; } | sed 's/^/      /'
+  fi
+}
+
 echo "=== Version Control Oracle Tests: dolt_remotes ==="
 echo ""
 
@@ -161,6 +193,19 @@ SELECT dolt_remote('remove', 'nonexistent');
 
 oracle_error "unknown_action" "
 SELECT dolt_remote('whatever', 'origin', 'file:///tmp/oracle_origin');
+"
+
+echo "--- savepoint parity ---"
+
+oracle_savepoint_remote_poststate "remote_add_inside_savepoint_releases_savepoint" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'main');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'first');
+SAVEPOINT sp1;
+UPDATE t SET v='dirty' WHERE id=1;
+SELECT dolt_remote('add', 'origin', 'file:///tmp/oracle_origin');
+ROLLBACK TO sp1;
 "
 
 echo ""

--- a/test/vc_oracle_tags_test.sh
+++ b/test/vc_oracle_tags_test.sh
@@ -78,6 +78,38 @@ oracle() {
   fi
 }
 
+oracle_savepoint_tag_poststate() {
+  local name="$1" setup="$2"
+  local dir="$TMPROOT/${name}_sp"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_rc dt_rc dl_v dl_tags dt_v dt_tags
+
+  vc_oracle_run_doltlite_script "$dir/dl/db" "$dir/dl.out" "$dir/dl.err" "$setup"
+  dl_rc=$?
+  dl_v=$(printf ".headers off\n.mode list\nSELECT v FROM t WHERE id=1;\n" \
+         | "$DOLTLITE" "$dir/dl/db" 2>>"$dir/dl.err")
+  dl_tags=$(printf ".headers off\n.mode list\nSELECT coalesce(group_concat(tag_name, ','), '') FROM dolt_tags;\n" \
+            | "$DOLTLITE" "$dir/dl/db" 2>>"$dir/dl.err")
+
+  local dolt_setup
+  dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
+  vc_oracle_run_dolt_script_for_error "$dir/dt" "$dir/dt.out" "$dir/dt.err" "$dolt_setup"
+  dt_rc=$?
+  dt_v=$(cd "$dir/dt" && "$DOLT" sql -r csv -q "SELECT v FROM t WHERE id=1;" 2>>"$dir/dt.err" | tail -n +2 | tr -d '"')
+  dt_tags=$(cd "$dir/dt" && "$DOLT" sql -r csv -q "SELECT coalesce(group_concat(tag_name, ','), '') FROM dolt_tags;" 2>>"$dir/dt.err" | tail -n +2 | tr -d '"')
+
+  if [ "$dl_rc" -ne 0 ] && [ "$dt_rc" -ne 0 ] && [ "$dl_v" = "$dt_v" ] && [ "$dl_tags" = "$dt_tags" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite rc/v/tags:"; { echo "$dl_rc"; echo "$dl_v"; echo "$dl_tags"; } | sed 's/^/      /'
+    echo "    dolt rc/v/tags:"; { echo "$dt_rc"; echo "$dt_v"; echo "$dt_tags"; } | sed 's/^/      /'
+  fi
+}
+
 echo "=== Version Control Oracle Tests: dolt_tags ==="
 echo ""
 
@@ -168,6 +200,19 @@ SELECT dolt_commit('-m', 'first');
 SELECT dolt_tag('keep');
 SELECT dolt_tag('drop');
 SELECT dolt_tag('-d', 'drop');
+"
+
+echo "--- savepoint parity ---"
+
+oracle_savepoint_tag_poststate "tag_inside_savepoint_releases_savepoint" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'main');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'first');
+SAVEPOINT sp1;
+UPDATE t SET v='dirty' WHERE id=1;
+SELECT dolt_tag('v1');
+ROLLBACK TO sp1;
 "
 
 echo ""


### PR DESCRIPTION
Fixes explicit-transaction/savepoint parity for VC metadata mutations.

Included so far:
- seal checkout state across transaction rollback
- seal branch state across transaction rollback
- release savepoints after successful tag mutation
- release savepoints after successful remote mutation

Verified:
- bash test/vc_oracle_checkout_test.sh ./build/doltlite dolt
- bash test/vc_oracle_branch_test.sh ./build/doltlite dolt
- bash test/vc_oracle_tags_test.sh ./build/doltlite dolt
- bash test/vc_oracle_remotes_test.sh ./build/doltlite dolt
- cd build && bash ../test/doltlite_savepoint.sh