### PR TITLE
Reject delete/rename of main branch (short-term guard)

### DIFF
--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -189,6 +189,18 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
         sqlite3_result_error(ctx, "cannot delete the current branch", -1);
         return;
       }
+      /* Short-term guard: doltlite does not yet have stable default-branch
+      ** resolution, so on reopen p->zBranch initializes from the last-active
+      ** branch (tracked via chunkStoreGetDefaultBranch, which dolt_checkout
+      ** updates). If "main" is deleted, opening the DB would leave the
+      ** session pointing at a nonexistent branch. Reject until we have real
+      ** default-branch logic. */
+      if( strcmp(aPositional[0], "main")==0 ){
+        sqlite3_result_error(ctx,
+          "cannot delete branch 'main' (doltlite requires main to exist)",
+          -1);
+        return;
+      }
       if( !force ){
         rc = chunkStoreFindBranch(cs, aPositional[0], &branchHead);
         if( rc!=SQLITE_OK ){
@@ -257,6 +269,15 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
       memset(&m, 0, sizeof(m));
       m.zSrc = aPositional[0];
       m.zDest = aPositional[1];
+      /* Same guard as MODE_DELETE: renaming "main" away would leave the
+      ** repo with no main branch, and reopening would fail to resolve a
+      ** session branch. Reject until default-branch logic is reworked. */
+      if( strcmp(m.zSrc, "main")==0 ){
+        sqlite3_result_error(ctx,
+          "cannot rename branch 'main' (doltlite requires main to exist)",
+          -1);
+        return;
+      }
       renamingCurrent = strcmp(m.zSrc, doltliteGetSessionBranch(db))==0;
       rc = doltliteMutateRefs(db, mutateBranchMove, &m);
       if( rc!=SQLITE_OK ){

--- a/test/doltlite_branch.sh
+++ b/test/doltlite_branch.sh
@@ -107,7 +107,34 @@ run_test_match "move_empty_source" "SELECT dolt_branch('-m','','renamed');" "bra
 run_test_match "move_empty_dest" "SELECT dolt_branch('-m','main','');" "branch name required" "$DB9"
 run_test_match "checkout_b_empty_name" "SELECT dolt_checkout('-b','');" "branch name required" "$DB9"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9"
+# --- main protection: cannot delete or rename main ---
+# doltlite's session-branch resolver falls back to literal "main" on reopen,
+# so allowing main to go away would leave the repo unopenable. Reject until
+# proper default-branch logic lands.
+DB10=/tmp/test_branch10_$$.db; rm -f "$DB10"
+echo "CREATE TABLE t(x INTEGER PRIMARY KEY); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB10" > /dev/null 2>&1
+echo "SELECT dolt_checkout('-b','other');" | $DOLTLITE "$DB10" > /dev/null 2>&1
+
+run_test_match "delete_main_rejected" "SELECT dolt_branch('-d','main');" "cannot delete branch 'main'" "$DB10"
+run_test_match "force_delete_main_rejected" "SELECT dolt_branch('-D','main');" "cannot delete branch 'main'" "$DB10"
+run_test_match "rename_main_rejected" "SELECT dolt_branch('-m','main','trunk');" "cannot rename branch 'main'" "$DB10"
+run_test "main_still_exists" "SELECT count(*) FROM dolt_branches WHERE name='main';" "1" "$DB10"
+
+# Reopening still works — main resolves
+run_test "reopen_after_blocked_ops_active" "SELECT active_branch();" "other" "$DB10"
+
+# Non-main rename and delete still work
+DB11=/tmp/test_branch11_$$.db; rm -f "$DB11"
+echo "CREATE TABLE t(x INTEGER PRIMARY KEY); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB11" > /dev/null 2>&1
+echo "SELECT dolt_branch('feat');" | $DOLTLITE "$DB11" > /dev/null 2>&1
+run_test "rename_non_main_works" "SELECT dolt_branch('-m','feat','renamed');" "0" "$DB11"
+run_test "renamed_listed" "SELECT count(*) FROM dolt_branches WHERE name='renamed';" "1" "$DB11"
+run_test "delete_non_main_works" "SELECT dolt_branch('-d','renamed');" "0" "$DB11"
+
+# Copy from main is still allowed — it doesn't remove main
+run_test "copy_from_main_works" "SELECT dolt_branch('-c','main','snapshot');" "0" "$DB11"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11"
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
 if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi

--- a/test/vc_oracle_branch_test.sh
+++ b/test/vc_oracle_branch_test.sh
@@ -187,7 +187,9 @@ SELECT dolt_branch('-m', 'feature', 'renamed');
 
 oracle "move_current_branch" "
 $SEED
-SELECT dolt_branch('-m', 'main', 'trunk');
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+SELECT dolt_branch('-m', 'feature', 'renamed');
 "
 
 oracle "move_long_flag" "


### PR DESCRIPTION
## Summary
Until doltlite grows real default-branch logic, guard against a corrupt state where deleting or renaming \`main\` leaves the repo unopenable.

## The bug

doltlite's session branch resolver initializes \`p->zBranch\` from \`chunkStoreGetDefaultBranch\`, which actually tracks the last-active branch (because \`dolt_checkout\` updates it), not a stable repo-level default. If \`main\` is deleted or renamed away:

1. Fresh session opens → \`p->zBranch\` defaults to \`"main"\` (the hardcoded fallback).
2. No \`main\` exists in refs → \`p->headCommit\` stays empty.
3. Queries fail: \`Parse error near line N: no such table: t\`.

**Minimal repro (before this change):**
\`\`\`sql
CREATE TABLE t(id INTEGER PRIMARY KEY);
INSERT INTO t VALUES(1);
SELECT dolt_add('-A'); SELECT dolt_commit('-m','base');
SELECT dolt_branch('-m','main','trunk');
\`\`\`
Close the DB, reopen:
\`\`\`sql
SELECT active_branch();   -- "main"   (but only "trunk" exists in dolt_branches)
SELECT id FROM t;         -- Parse error near line 1: no such table: t
\`\`\`

## The fix
Reject these three operations with a clear error:
- \`dolt_branch('-d','main')\`
- \`dolt_branch('-D','main')\` (force doesn't bypass)
- \`dolt_branch('-m','main', ...)\`

Copy from main (\`dolt_branch('-c','main',...)\`) and rename/delete of any non-main branch remain unaffected.

Dolt allows deleting main (though Dolt's CLI then errors on \`dolt branch\` with "cannot resolve default branch head"). This PR is deliberately stricter than Dolt until doltlite's resolver is reworked — the guard prevents the unopenable state entirely.

## Tests
- \`test/doltlite_branch.sh\`: 36 → 45 (new tests cover the three rejections, that main still exists afterward, that reopen still works, and that non-main renames/deletes and copy-from-main still succeed)
- \`vc_oracle_branch_test.sh\` \`move_current_branch\` adjusted to rename a feature branch so the oracle still covers "move the current branch" semantics without touching main
- \`vc_oracle_branch_test.sh\`: 27/27, \`vc_oracle_branches_test.sh\`: 15/15, \`vc_oracle_checkout_test.sh\`: 21/21, \`doltlite_branch_edge.sh\`: 71/71 all pass

## Follow-up
Real fix: introduce a stable \`initialBranch\` / \`defaultBranch\` pointer distinct from the last-active branch cache, persisted in refs and NOT updated by \`dolt_checkout\`. Once that's in place, this guard can be relaxed to match Dolt's behavior of allowing main to be deleted/renamed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)