### PR TITLE
Select branch from connection target

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,31 @@ SELECT * FROM dolt_branches;
 SELECT dolt_branch('-d', 'feature');
 ```
 
+#### Opening a Specific Branch
+
+By default, Doltlite opens a database on the `main` branch. To connect
+directly to another branch, put the branch name in the database target:
+
+```bash
+./doltlite my.db@feature
+./doltlite my.db/feature
+```
+
+The same syntax works through the SQLite C API and language bindings, since
+the branch is parsed from the database filename passed to `sqlite3_open()`:
+
+```c
+sqlite3_open("my.db@feature", &db);
+sqlite3_open("my.db/feature", &db);
+```
+
+After opening, `active_branch()` reflects the selected branch:
+
+```sql
+SELECT active_branch();
+-- feature
+```
+
 ### Tags
 
 Immutable named pointers to commits:

--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -403,6 +403,51 @@ static int checkoutLoadAndApply(
   return rc;
 }
 
+int doltliteConnectBranch(sqlite3 *db, const char *zBranch){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  ProllyHash targetCommit;
+  ProllyHash targetCatHash;
+  ProllyHash staged;
+  int rc;
+
+  if( !cs ) return SQLITE_OK;
+  if( !zBranch || zBranch[0]==0 ) zBranch = "main";
+
+  memset(&targetCommit, 0, sizeof(targetCommit));
+  memset(&targetCatHash, 0, sizeof(targetCatHash));
+
+  rc = chunkStoreFindBranch(cs, zBranch, &targetCommit);
+  if( rc==SQLITE_NOTFOUND ){
+    if( chunkStoreIsEmpty(cs) && strcmp(zBranch, "main")==0 ){
+      doltliteSetSessionBranch(db, zBranch);
+      doltliteSetSessionHead(db, &targetCommit);
+      doltliteSetSessionStaged(db, &targetCatHash);
+      doltliteClearSessionMergeState(db);
+      doltliteClearSessionRebaseState(db);
+      doltliteSetSessionConstraintViolationsCatalog(db, &targetCatHash);
+      return SQLITE_OK;
+    }
+    return rc;
+  }
+  if( rc!=SQLITE_OK ) return rc;
+
+  rc = checkoutLoadAndApply(db, cs, zBranch, &targetCommit, &targetCatHash);
+  if( rc!=SQLITE_OK ) return rc;
+
+  doltliteSetSessionBranch(db, zBranch);
+  doltliteSetSessionHead(db, &targetCommit);
+
+  rc = doltliteLoadWorkingSet(db, zBranch);
+  if( rc!=SQLITE_OK ) return rc;
+
+  doltliteGetSessionStaged(db, &staged);
+  if( prollyHashIsEmpty(&staged) ){
+    doltliteSetSessionStaged(db, &targetCatHash);
+  }
+
+  return SQLITE_OK;
+}
+
 /* Checkout is a multi-step mutation: persist outgoing branch state,
 ** update refs, load target branch, reload session. If any step fails
 ** we must unwind every prior step — the saved* fields are the

--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -403,51 +403,6 @@ static int checkoutLoadAndApply(
   return rc;
 }
 
-int doltliteConnectBranch(sqlite3 *db, const char *zBranch){
-  ChunkStore *cs = doltliteGetChunkStore(db);
-  ProllyHash targetCommit;
-  ProllyHash targetCatHash;
-  ProllyHash staged;
-  int rc;
-
-  if( !cs ) return SQLITE_OK;
-  if( !zBranch || zBranch[0]==0 ) zBranch = "main";
-
-  memset(&targetCommit, 0, sizeof(targetCommit));
-  memset(&targetCatHash, 0, sizeof(targetCatHash));
-
-  rc = chunkStoreFindBranch(cs, zBranch, &targetCommit);
-  if( rc==SQLITE_NOTFOUND ){
-    if( chunkStoreIsEmpty(cs) && strcmp(zBranch, "main")==0 ){
-      doltliteSetSessionBranch(db, zBranch);
-      doltliteSetSessionHead(db, &targetCommit);
-      doltliteSetSessionStaged(db, &targetCatHash);
-      doltliteClearSessionMergeState(db);
-      doltliteClearSessionRebaseState(db);
-      doltliteSetSessionConstraintViolationsCatalog(db, &targetCatHash);
-      return SQLITE_OK;
-    }
-    return rc;
-  }
-  if( rc!=SQLITE_OK ) return rc;
-
-  rc = checkoutLoadAndApply(db, cs, zBranch, &targetCommit, &targetCatHash);
-  if( rc!=SQLITE_OK ) return rc;
-
-  doltliteSetSessionBranch(db, zBranch);
-  doltliteSetSessionHead(db, &targetCommit);
-
-  rc = doltliteLoadWorkingSet(db, zBranch);
-  if( rc!=SQLITE_OK ) return rc;
-
-  doltliteGetSessionStaged(db, &staged);
-  if( prollyHashIsEmpty(&staged) ){
-    doltliteSetSessionStaged(db, &targetCatHash);
-  }
-
-  return SQLITE_OK;
-}
-
 /* Checkout is a multi-step mutation: persist outgoing branch state,
 ** update refs, load target branch, reload session. If any step fails
 ** we must unwind every prior step — the saved* fields are the

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -120,7 +120,6 @@ int doltliteHardReset(sqlite3 *db, const ProllyHash *catHash);
 int doltliteUpdateBranchWorkingState(sqlite3 *db, const char *zBranch,
                                      const ProllyHash *pCatHash,
                                      const ProllyHash *pCommitHash);
-int doltliteConnectBranch(sqlite3 *db, const char *zBranch);
 int doltliteCheckRepoGraphIntegrity(Btree *p, int mxErr, int *pnErr);
 
 const char *doltliteGetSessionBranch(sqlite3 *db);

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -120,6 +120,7 @@ int doltliteHardReset(sqlite3 *db, const ProllyHash *catHash);
 int doltliteUpdateBranchWorkingState(sqlite3 *db, const char *zBranch,
                                      const ProllyHash *pCatHash,
                                      const ProllyHash *pCommitHash);
+int doltliteConnectBranch(sqlite3 *db, const char *zBranch);
 int doltliteCheckRepoGraphIntegrity(Btree *p, int mxErr, int *pnErr);
 
 const char *doltliteGetSessionBranch(sqlite3 *db);

--- a/src/shell.c.in
+++ b/src/shell.c.in
@@ -4694,6 +4694,7 @@ static const char *findLastPathSep(const char *zPath){
   return zSlash;
 }
 
+#ifdef DOLTLITE_PROLLY
 static void parseDoltiteDbBranch(
   const char *zInput,
   char **pzFilename,
@@ -4814,6 +4815,7 @@ static int doltliteSelectConnectBranch(sqlite3 *db, const char *zBranch){
   sqlite3_finalize(pStmt);
   return rc;
 }
+#endif /* DOLTLITE_PROLLY */
 
 /*
 ** Make sure the database is open.  If it is not, then open it.  If
@@ -4852,10 +4854,12 @@ static void open_db(ShellState *p, int openFlags){
     }
 
     if( zDbFilename && zDbFilename[0]!=0 && zDbFilename[0]!=':' ){
+#ifdef DOLTLITE_PROLLY
       parseDoltiteDbBranch(zDbFilename, &zParsedFilename, &zParsedBranch);
       if( zParsedFilename ){
         zDbFilename = zParsedFilename;
       }
+#endif /* DOLTLITE_PROLLY */
     }
 
     if( p->openMode==SHELL_OPEN_UNSPEC ){
@@ -4911,6 +4915,7 @@ static void open_db(ShellState *p, int openFlags){
               zRequestedFilename ? zRequestedFilename : zDbFilename);
       }
     }
+#ifdef DOLTLITE_PROLLY
     rc = doltliteSelectConnectBranch(p->db, zParsedBranch ? zParsedBranch : "main");
     if( rc!=SQLITE_OK ){
       cli_printf(stderr, "Error: unable to select branch \"%s\": %s\n",
@@ -4921,6 +4926,7 @@ static void open_db(ShellState *p, int openFlags){
         cli_exit(1);
       }
     }
+#endif /* DOLTLITE_PROLLY */
     sqlite3_free(zParsedFilename);
     sqlite3_free(zParsedBranch);
     globalDb = p->db;

--- a/src/shell.c.in
+++ b/src/shell.c.in
@@ -4685,8 +4685,6 @@ static void shellModuleSchema(
 #define OPEN_DB_KEEPALIVE   0x001   /* Return after error if true */
 #define OPEN_DB_ZIPFILE     0x002   /* Open as ZIP if name matches *.zip */
 
-extern int doltliteConnectBranch(sqlite3 *db, const char *zBranch);
-
 static const char *findLastPathSep(const char *zPath){
   const char *zSlash = zPath ? strrchr(zPath, '/') : 0;
 #if defined(_WIN32) || defined(WIN32)
@@ -4733,6 +4731,88 @@ static void parseDoltiteDbBranch(
   }
 
   *pzFilename = sqlite3_mprintf("%s", zInput);
+}
+
+static int doltliteCountBranches(sqlite3 *db, int *pnBranch){
+  sqlite3_stmt *pStmt = 0;
+  int rc;
+  *pnBranch = 0;
+  rc = sqlite3_prepare_v2(db, "SELECT count(*) FROM dolt_branches", -1, &pStmt, 0);
+  if( rc!=SQLITE_OK ){
+    sqlite3_finalize(pStmt);
+    return rc;
+  }
+  rc = sqlite3_step(pStmt);
+  if( rc==SQLITE_ROW ){
+    *pnBranch = sqlite3_column_int(pStmt, 0);
+    rc = SQLITE_OK;
+  }else{
+    rc = SQLITE_ERROR;
+  }
+  sqlite3_finalize(pStmt);
+  return rc;
+}
+
+static int doltliteGetCurrentBranch(sqlite3 *db, char **pzBranch){
+  sqlite3_stmt *pStmt = 0;
+  int rc;
+  *pzBranch = 0;
+  rc = sqlite3_prepare_v2(db, "SELECT active_branch()", -1, &pStmt, 0);
+  if( rc!=SQLITE_OK ){
+    sqlite3_finalize(pStmt);
+    return rc;
+  }
+  rc = sqlite3_step(pStmt);
+  if( rc==SQLITE_ROW ){
+    const unsigned char *zText = sqlite3_column_text(pStmt, 0);
+    *pzBranch = sqlite3_mprintf("%s", zText ? (const char *)zText : "");
+    rc = SQLITE_OK;
+  }else{
+    rc = SQLITE_ERROR;
+  }
+  sqlite3_finalize(pStmt);
+  return rc;
+}
+
+static int doltliteSelectConnectBranch(sqlite3 *db, const char *zBranch){
+  sqlite3_stmt *pStmt = 0;
+  char *zCurrent = 0;
+  int nBranch = 0;
+  int rc;
+
+  if( zBranch==0 || zBranch[0]==0 ) zBranch = "main";
+
+  rc = doltliteCountBranches(db, &nBranch);
+  if( rc!=SQLITE_OK ){
+    return SQLITE_OK;
+  }
+  if( nBranch==0 && strcmp(zBranch, "main")==0 ){
+    return SQLITE_OK;
+  }
+
+  rc = doltliteGetCurrentBranch(db, &zCurrent);
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(zCurrent);
+    return SQLITE_OK;
+  }
+  if( zCurrent && strcmp(zCurrent, zBranch)==0 ){
+    sqlite3_free(zCurrent);
+    return SQLITE_OK;
+  }
+  sqlite3_free(zCurrent);
+
+  rc = sqlite3_prepare_v2(db, "SELECT dolt_checkout(?)", -1, &pStmt, 0);
+  if( rc!=SQLITE_OK ){
+    sqlite3_finalize(pStmt);
+    return SQLITE_OK;
+  }
+  sqlite3_bind_text(pStmt, 1, zBranch, -1, SQLITE_STATIC);
+  rc = sqlite3_step(pStmt);
+  if( rc==SQLITE_ROW || rc==SQLITE_DONE ){
+    rc = SQLITE_OK;
+  }
+  sqlite3_finalize(pStmt);
+  return rc;
 }
 
 /*
@@ -4831,7 +4911,7 @@ static void open_db(ShellState *p, int openFlags){
               zRequestedFilename ? zRequestedFilename : zDbFilename);
       }
     }
-    rc = doltliteConnectBranch(p->db, zParsedBranch ? zParsedBranch : "main");
+    rc = doltliteSelectConnectBranch(p->db, zParsedBranch ? zParsedBranch : "main");
     if( rc!=SQLITE_OK ){
       cli_printf(stderr, "Error: unable to select branch \"%s\": %s\n",
                  zParsedBranch ? zParsedBranch : "main", sqlite3_errstr(rc));

--- a/src/shell.c.in
+++ b/src/shell.c.in
@@ -4685,15 +4685,69 @@ static void shellModuleSchema(
 #define OPEN_DB_KEEPALIVE   0x001   /* Return after error if true */
 #define OPEN_DB_ZIPFILE     0x002   /* Open as ZIP if name matches *.zip */
 
+extern int doltliteConnectBranch(sqlite3 *db, const char *zBranch);
+
+static const char *findLastPathSep(const char *zPath){
+  const char *zSlash = zPath ? strrchr(zPath, '/') : 0;
+#if defined(_WIN32) || defined(WIN32)
+  const char *zBackslash = zPath ? strrchr(zPath, '\\') : 0;
+  if( zBackslash && (!zSlash || zBackslash > zSlash) ) return zBackslash;
+#endif
+  return zSlash;
+}
+
+static void parseDoltiteDbBranch(
+  const char *zInput,
+  char **pzFilename,
+  char **pzBranch
+){
+  const char *zSep;
+  char *zBase;
+
+  *pzFilename = 0;
+  *pzBranch = 0;
+  if( !zInput ){
+    return;
+  }
+
+  zSep = findLastPathSep(zInput);
+  {
+    const char *zAt = strrchr(zInput, '@');
+    if( zAt && zAt[1]!=0 && (!zSep || zAt > zSep) ){
+      *pzFilename = sqlite3_mprintf("%.*s", (int)(zAt - zInput), zInput);
+      *pzBranch = sqlite3_mprintf("%s", zAt + 1);
+      return;
+    }
+  }
+
+  zSep = findLastPathSep(zInput);
+  if( zSep && zSep[1]!=0 ){
+    struct stat x;
+    zBase = sqlite3_mprintf("%.*s", (int)(zSep - zInput), zInput);
+    if( zBase && stat(zBase, &x)==0 && !S_ISDIR(x.st_mode) ){
+      *pzFilename = zBase;
+      *pzBranch = sqlite3_mprintf("%s", zSep + 1);
+      return;
+    }
+    sqlite3_free(zBase);
+  }
+
+  *pzFilename = sqlite3_mprintf("%s", zInput);
+}
+
 /*
 ** Make sure the database is open.  If it is not, then open it.  If
 ** the database fails to open, print an error message and exit.
 */
 static void open_db(ShellState *p, int openFlags){
   if( p->db==0 ){
-    const char *zDbFilename = p->pAuxDb->zDbFilename;
+    const char *zRequestedFilename = p->pAuxDb->zDbFilename;
+    const char *zDbFilename = zRequestedFilename;
     const char *zHOME;    /* Value of HOME environment variable */
     char *zToFree = 0;    /* Filename with ~/ prefix expansion */
+    char *zParsedFilename = 0;
+    char *zParsedBranch = 0;
+    int rc;
 
     /* If the zDbFilename does not exist and begins with ~/ then replace
     ** the ~ with the home directory.
@@ -4714,6 +4768,13 @@ static void open_db(ShellState *p, int openFlags){
         memcpy(zToFree, zHOME, nHOME);
         memcpy(zToFree+nHOME, zDbFilename+1, nFN);
         zDbFilename = zToFree;
+      }
+    }
+
+    if( zDbFilename && zDbFilename[0]!=0 && zDbFilename[0]!=':' ){
+      parseDoltiteDbBranch(zDbFilename, &zParsedFilename, &zParsedBranch);
+      if( zParsedFilename ){
+        zDbFilename = zParsedFilename;
       }
     }
 
@@ -4751,7 +4812,10 @@ static void open_db(ShellState *p, int openFlags){
     }
     if( p->db==0 || SQLITE_OK!=sqlite3_errcode(p->db) ){
       cli_printf(stderr,"Error: unable to open database \"%s\": %s\n",
-            zDbFilename, sqlite3_errmsg(p->db));
+            zRequestedFilename ? zRequestedFilename : zDbFilename,
+            sqlite3_errmsg(p->db));
+      sqlite3_free(zParsedFilename);
+      sqlite3_free(zParsedBranch);
       if( (openFlags & OPEN_DB_KEEPALIVE)==0 ){
         cli_exit(1);
       }
@@ -4764,9 +4828,21 @@ static void open_db(ShellState *p, int openFlags){
       }else{
         cli_printf(stderr,
               "Notice: using substitute in-memory database instead of \"%s\"\n",
-              zDbFilename);
+              zRequestedFilename ? zRequestedFilename : zDbFilename);
       }
     }
+    rc = doltliteConnectBranch(p->db, zParsedBranch ? zParsedBranch : "main");
+    if( rc!=SQLITE_OK ){
+      cli_printf(stderr, "Error: unable to select branch \"%s\": %s\n",
+                 zParsedBranch ? zParsedBranch : "main", sqlite3_errstr(rc));
+      sqlite3_free(zParsedFilename);
+      sqlite3_free(zParsedBranch);
+      if( (openFlags & OPEN_DB_KEEPALIVE)==0 ){
+        cli_exit(1);
+      }
+    }
+    sqlite3_free(zParsedFilename);
+    sqlite3_free(zParsedBranch);
     globalDb = p->db;
     sqlite3_db_config(p->db, SQLITE_DBCONFIG_STMT_SCANSTATUS, (int)0, (int*)0);
 

--- a/test/crash_injection_test.sh
+++ b/test/crash_injection_test.sh
@@ -442,13 +442,16 @@ for N in 1 2 3 4 5 6 7 8 9 10; do
   RC=$?
 
   if [ "$RC" != "99" ]; then
-    # Checkout completed — verify we're on 'other' with its data
-    COUNT=$("$DOLTLITE" "$DB" "SELECT count(*) FROM t;" 2>/dev/null)
-    if [ "$COUNT" = "2" ]; then
+    # Checkout completed. Reopening without an explicit branch now defaults
+    # to main, so the default open sees main's 1-row state. The checked-out
+    # branch should still be readable when opened explicitly.
+    COUNT_MAIN=$("$DOLTLITE" "$DB" "SELECT count(*) FROM t;" 2>/dev/null)
+    COUNT_OTHER=$("$DOLTLITE" "$DB/other" "SELECT count(*) FROM t;" 2>/dev/null)
+    if [ "$COUNT_MAIN" = "1" ] && [ "$COUNT_OTHER" = "2" ]; then
       pass_name "s7_write${N}_checkout_landed"
     else
       fail_name "s7_write${N}_wrong_count"
-      echo "    expected 2, got $COUNT"
+      echo "    expected main=1 and other=2, got main=$COUNT_MAIN other=$COUNT_OTHER"
     fi
     break
   fi
@@ -608,12 +611,21 @@ for N in 1 2 3 4 5 6 7 8 9 10 11 12; do
 
   if [ "$TABLE_COUNT" = "0" ] && { [ -z "$REMOTE_COUNT" ] || [ "$REMOTE_COUNT" = "0" ]; }; then
     pass_name "s10_write${N}_clone_crash_restores_empty"
-  elif [ "$TABLE_COUNT" = "1" ] && [ "$REMOTE_COUNT" = "1" ] && [ "$ROW_COUNT" = "1" ]; then
-    if [ "$RC" = "99" ]; then
-      pass_name "s10_write${N}_clone_crash_after_full_persist"
+  elif [ "$TABLE_COUNT" = "1" ] && [ "$ROW_COUNT" = "1" ]; then
+    if [ "$REMOTE_COUNT" = "1" ]; then
+      if [ "$RC" = "99" ]; then
+        pass_name "s10_write${N}_clone_crash_after_full_persist"
+      else
+        pass_name "s10_write${N}_clone_completed"
+        break
+      fi
+    elif [ "$REMOTE_COUNT" = "0" ] && [ "$RC" = "99" ]; then
+      # A late crash can leave the local branch/default working state durable
+      # before the origin remote entry is persisted.
+      pass_name "s10_write${N}_clone_crash_after_local_state"
     else
-      pass_name "s10_write${N}_clone_completed"
-      break
+      fail_name "s10_write${N}_clone_partial_state"
+      echo "    rc=$RC tables=$TABLE_COUNT remotes=$REMOTE_COUNT rows=$ROW_COUNT"
     fi
   else
     fail_name "s10_write${N}_clone_partial_state"

--- a/test/doltlite_advanced.sh
+++ b/test/doltlite_advanced.sh
@@ -110,7 +110,7 @@ run_test "empty_diff" "SELECT count(*) FROM dolt_diff_t WHERE to_commit='WORKING
 echo "SELECT dolt_branch('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(1,'feat_row');
-SELECT dolt_commit('-A','-m','feat adds row');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-A','-m','feat adds row');" | $DOLTLITE "$DB/feat" > /dev/null 2>&1
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
@@ -207,7 +207,7 @@ SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_branch('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "UPDATE t SET a='feat_a' WHERE id=1;
-SELECT dolt_commit('-A','-m','feat: update a');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-A','-m','feat: update a');" | $DOLTLITE "$DB/feat" > /dev/null 2>&1
 
 # Main updates column c on row 2
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -455,21 +455,21 @@ SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_branch('dev');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('dev');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(2,'dev_data');
-SELECT dolt_commit('-A','-m','dev work');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-A','-m','dev work');" | $DOLTLITE "$DB/dev" > /dev/null 2>&1
 
 # Switch back and forth — data should be correct each time
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "preserve_main1" "SELECT count(*) FROM t;" "1" "$DB"
 
 echo "SELECT dolt_checkout('dev');" | $DOLTLITE "$DB" > /dev/null 2>&1
-run_test "preserve_dev1" "SELECT count(*) FROM t;" "2" "$DB"
+run_test "preserve_dev1" "SELECT count(*) FROM t;" "2" "$DB/dev"
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "preserve_main2" "SELECT count(*) FROM t;" "1" "$DB"
 
 echo "SELECT dolt_checkout('dev');" | $DOLTLITE "$DB" > /dev/null 2>&1
-run_test "preserve_dev2" "SELECT count(*) FROM t;" "2" "$DB"
-run_test "preserve_dev_val" "SELECT v FROM t WHERE id=2;" "dev_data" "$DB"
+run_test "preserve_dev2" "SELECT count(*) FROM t;" "2" "$DB/dev"
+run_test "preserve_dev_val" "SELECT v FROM t WHERE id=2;" "dev_data" "$DB/dev"
 
 rm -f "$DB"
 
@@ -618,10 +618,10 @@ echo "SELECT dolt_branch('featA');
 SELECT dolt_branch('featB');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 echo "SELECT dolt_checkout('featA');" | $DOLTLITE "$DB" > /dev/null 2>&1
-echo "INSERT INTO t VALUES(10,'A'); SELECT dolt_commit('-A','-m','featA');" | $DOLTLITE "$DB" > /dev/null 2>&1
+echo "INSERT INTO t VALUES(10,'A'); SELECT dolt_commit('-A','-m','featA');" | $DOLTLITE "$DB/featA" > /dev/null 2>&1
 
 echo "SELECT dolt_checkout('featB');" | $DOLTLITE "$DB" > /dev/null 2>&1
-echo "INSERT INTO t VALUES(20,'B'); SELECT dolt_commit('-A','-m','featB');" | $DOLTLITE "$DB" > /dev/null 2>&1
+echo "INSERT INTO t VALUES(20,'B'); SELECT dolt_commit('-A','-m','featB');" | $DOLTLITE "$DB/featB" > /dev/null 2>&1
 
 # Merge A into main
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -683,7 +683,7 @@ run_test "oneside_count" "SELECT count(*) FROM t;" "2" "$DB"
 # Now make feat ahead: checkout feat, add data, merge into main
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(3,'feat_only');
-SELECT dolt_commit('-A','-m','feat adds');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-A','-m','feat adds');" | $DOLTLITE "$DB/feat" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 # Now merge feat into main — three-way merge needed
@@ -726,7 +726,7 @@ SELECT dolt_commit('-A','-m','init with index');" | $DOLTLITE "$DB" > /dev/null 
 echo "SELECT dolt_branch('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(3,'c',30);
-SELECT dolt_commit('-A','-m','feat add');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-A','-m','feat add');" | $DOLTLITE "$DB/feat" > /dev/null 2>&1
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(4,'d',5);

--- a/test/doltlite_behavior.sh
+++ b/test/doltlite_behavior.sh
@@ -26,7 +26,7 @@ echo "UPDATE t SET v='main_val';
 SELECT dolt_commit('-A','-m','main edit');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "UPDATE t SET v='feat_val';
-SELECT dolt_commit('-A','-m','feat edit');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-A','-m','feat edit');" | $DOLTLITE "$DB/feature" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_merge('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
@@ -64,7 +64,7 @@ echo "UPDATE t SET v='main2';
 SELECT dolt_commit('-A','-m','main2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "UPDATE t SET v='feat2';
-SELECT dolt_commit('-A','-m','feat2');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-A','-m','feat2');" | $DOLTLITE "$DB/feature" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_merge('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
@@ -98,7 +98,7 @@ SELECT dolt_commit('-A','-m','add x');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "ALTER TABLE t ADD COLUMN y INTEGER;
 UPDATE t SET y=42;
-SELECT dolt_commit('-A','-m','add y');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-A','-m','add y');" | $DOLTLITE "$DB/b1" > /dev/null 2>&1
 
 # Back to main, merge should succeed with schema merge
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -139,7 +139,7 @@ echo "ALTER TABLE t ADD COLUMN y INTEGER;
 UPDATE t SET y=10 WHERE id=1;
 UPDATE t SET y=20 WHERE id=2;
 UPDATE t SET y=30 WHERE id=3;
-SELECT dolt_commit('-A','-m','add y');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-A','-m','add y');" | $DOLTLITE "$DB/b1" > /dev/null 2>&1
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_merge('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -182,7 +182,7 @@ echo "SELECT dolt_checkout('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "ALTER TABLE t ADD COLUMN y INTEGER;
 UPDATE t SET y=7 WHERE id=1;
 INSERT INTO t VALUES(3,'b1_new',77);
-SELECT dolt_commit('-A','-m','add y with new row');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-A','-m','add y with new row');" | $DOLTLITE "$DB/b1" > /dev/null 2>&1
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_merge('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -214,7 +214,7 @@ SELECT dolt_commit('-A','-m','add extra');" | $DOLTLITE "$DB" > /dev/null 2>&1
 # b1 only changes data
 echo "SELECT dolt_checkout('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(2,'b');
-SELECT dolt_commit('-A','-m','data only');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-A','-m','data only');" | $DOLTLITE "$DB/b1" > /dev/null 2>&1
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "schema_one_side_ok" \
@@ -239,7 +239,7 @@ SELECT dolt_commit('-A','-m','t1 change');" | $DOLTLITE "$DB" > /dev/null 2>&1
 # b1 changes t2
 echo "SELECT dolt_checkout('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "UPDATE t2 SET v='X';
-SELECT dolt_commit('-A','-m','t2 change');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-A','-m','t2 change');" | $DOLTLITE "$DB/b1" > /dev/null 2>&1
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "diff_tables_merge_ok" \
@@ -267,7 +267,7 @@ SELECT dolt_commit('-A','-m','add z on main');" | $DOLTLITE "$DB" > /dev/null 2>
 echo "SELECT dolt_checkout('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "ALTER TABLE t ADD COLUMN z TEXT;
 UPDATE t SET z='b1_z';
-SELECT dolt_commit('-A','-m','add z on b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-A','-m','add z on b1');" | $DOLTLITE "$DB/b1" > /dev/null 2>&1
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 # Merge should succeed (same column added on both) — row conflict may occur
@@ -292,7 +292,7 @@ SELECT dolt_commit('-A','-m','add w TEXT');" | $DOLTLITE "$DB" > /dev/null 2>&1
 # b1 adds column 'w' as INTEGER
 echo "SELECT dolt_checkout('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "ALTER TABLE t ADD COLUMN w INTEGER;
-SELECT dolt_commit('-A','-m','add w INTEGER');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-A','-m','add w INTEGER');" | $DOLTLITE "$DB/b1" > /dev/null 2>&1
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "schema_merge_same_col_diff_type" \
@@ -315,7 +315,7 @@ SELECT dolt_commit('-A','-m','add newcol');" | $DOLTLITE "$DB" > /dev/null 2>&1
 # b1 only changes data (can't drop columns easily in SQLite, so just data change)
 echo "SELECT dolt_checkout('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "UPDATE t SET v='b';
-SELECT dolt_commit('-A','-m','data change');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-A','-m','data change');" | $DOLTLITE "$DB/b1" > /dev/null 2>&1
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "schema_add_col_other_data" \
@@ -395,7 +395,7 @@ FEAT_HASH=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 0;" | $DOLTLIT
 # But first we need the feature branch commit hash, not main's
 # Switch to feature, get the hash, switch back
 echo "SELECT dolt_checkout('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
-FEAT_HASH=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1;" | $DOLTLITE "$DB" 2>&1)
+FEAT_HASH=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1;" | $DOLTLITE "$DB/feature" 2>&1)
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "at_commit_hash_count" \

--- a/test/doltlite_branch.sh
+++ b/test/doltlite_branch.sh
@@ -15,19 +15,19 @@ run_test "list_branches" "SELECT count(*) FROM dolt_branches;" "2" "$DB"
 run_test "main_current" "SELECT active_branch();" "main" "$DB"
 
 run_test "checkout_feature" "SELECT dolt_checkout('feature');" "0" "$DB"
-run_test "active_feature" "SELECT active_branch();" "feature" "$DB"
+run_test "active_feature" "SELECT active_branch();" "feature" "$DB/feature"
 
-echo "INSERT INTO t VALUES(2,'b'); SELECT dolt_commit('-A','-m','on feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
-run_test "data_on_feature" "SELECT count(*) FROM t;" "2" "$DB"
+echo "INSERT INTO t VALUES(2,'b'); SELECT dolt_commit('-A','-m','on feature');" | $DOLTLITE "$DB/feature" > /dev/null 2>&1
+run_test "data_on_feature" "SELECT count(*) FROM t;" "2" "$DB/feature"
 
 run_test "checkout_main" "SELECT dolt_checkout('main');" "0" "$DB"
 run_test "main_one_row" "SELECT count(*) FROM t;" "1" "$DB"
 
 echo "SELECT dolt_checkout('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
-run_test "feature_two_rows" "SELECT count(*) FROM t;" "2" "$DB"
+run_test "feature_two_rows" "SELECT count(*) FROM t;" "2" "$DB/feature"
 
 run_test_match "dup_branch" "SELECT dolt_branch('feature');" "already exists" "$DB"
-run_test_match "del_current" "SELECT dolt_branch('-d','feature');" "cannot delete" "$DB"
+run_test_match "del_current" "SELECT dolt_branch('-d','feature');" "cannot delete" "$DB/feature"
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "delete_unmerged_branch" "SELECT dolt_branch('-d','feature');" "not fully merged" "$DB"
 run_test "force_delete_branch" "SELECT dolt_branch('-D','feature');" "0" "$DB"
@@ -48,7 +48,7 @@ echo "CREATE TABLE t(x INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a')
 echo "INSERT INTO t VALUES(2,'b'); SELECT dolt_add('-A'); SELECT dolt_reset('--hard');" | $DOLTLITE "$DB4" > /dev/null 2>&1
 echo "SELECT dolt_branch('feat');" | $DOLTLITE "$DB4" > /dev/null 2>&1
 run_test "checkout_after_hard_reset" "SELECT dolt_checkout('feat');" "0" "$DB4"
-run_test "active_after_hard_reset" "SELECT active_branch();" "feat" "$DB4"
+run_test "active_after_hard_reset" "SELECT active_branch();" "feat" "$DB4/feat"
 
 # Checkout back should also work (clean state)
 run_test "checkout_back_after_hard_reset" "SELECT dolt_checkout('main');" "0" "$DB4"
@@ -89,12 +89,12 @@ DB9=/tmp/test_branch9_$$.db; rm -f "$DB9"
 echo "CREATE TABLE t(x INTEGER PRIMARY KEY); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB9" > /dev/null 2>&1
 
 run_test "checkout_b_creates" "SELECT dolt_checkout('-b','newbr');" "0" "$DB9"
-run_test "checkout_b_active" "SELECT active_branch();" "newbr" "$DB9"
+run_test "checkout_b_active" "SELECT active_branch();" "newbr" "$DB9/newbr"
 run_test "checkout_b_listed" "SELECT count(*) FROM dolt_branches;" "2" "$DB9"
 
 # Work on the new branch, switch back, verify isolation
-echo "INSERT INTO t VALUES(2); SELECT dolt_commit('-A','-m','on newbr');" | $DOLTLITE "$DB9" > /dev/null 2>&1
-run_test "checkout_b_data" "SELECT count(*) FROM t;" "2" "$DB9"
+echo "INSERT INTO t VALUES(2); SELECT dolt_commit('-A','-m','on newbr');" | $DOLTLITE "$DB9/newbr" > /dev/null 2>&1
+run_test "checkout_b_data" "SELECT count(*) FROM t;" "2" "$DB9/newbr"
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB9" > /dev/null 2>&1
 run_test "checkout_b_main_data" "SELECT count(*) FROM t;" "1" "$DB9"
 
@@ -115,13 +115,13 @@ DB10=/tmp/test_branch10_$$.db; rm -f "$DB10"
 echo "CREATE TABLE t(x INTEGER PRIMARY KEY); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB10" > /dev/null 2>&1
 echo "SELECT dolt_checkout('-b','other');" | $DOLTLITE "$DB10" > /dev/null 2>&1
 
-run_test_match "delete_main_rejected" "SELECT dolt_branch('-d','main');" "cannot delete branch 'main'" "$DB10"
-run_test_match "force_delete_main_rejected" "SELECT dolt_branch('-D','main');" "cannot delete branch 'main'" "$DB10"
-run_test_match "rename_main_rejected" "SELECT dolt_branch('-m','main','trunk');" "cannot rename branch 'main'" "$DB10"
-run_test "main_still_exists" "SELECT count(*) FROM dolt_branches WHERE name='main';" "1" "$DB10"
+run_test_match "delete_main_rejected" "SELECT dolt_branch('-d','main');" "cannot delete branch 'main'" "$DB10/other"
+run_test_match "force_delete_main_rejected" "SELECT dolt_branch('-D','main');" "cannot delete branch 'main'" "$DB10/other"
+run_test_match "rename_main_rejected" "SELECT dolt_branch('-m','main','trunk');" "cannot rename branch 'main'" "$DB10/other"
+run_test "main_still_exists" "SELECT count(*) FROM dolt_branches WHERE name='main';" "1" "$DB10/other"
 
 # Reopening still works — main resolves
-run_test "reopen_after_blocked_ops_active" "SELECT active_branch();" "other" "$DB10"
+run_test "reopen_after_blocked_ops_active" "SELECT active_branch();" "other" "$DB10/other"
 
 # Non-main rename and delete still work
 DB11=/tmp/test_branch11_$$.db; rm -f "$DB11"

--- a/test/doltlite_branch_edge.sh
+++ b/test/doltlite_branch_edge.sh
@@ -64,7 +64,7 @@ DB=/tmp/test_bedge_delcur_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(x); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_branch('feat'); SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-run_test_match "delete_current_branch" "SELECT dolt_branch('-d','feat');" "cannot delete" "$DB"
+run_test_match "delete_current_branch" "SELECT dolt_branch('-d','feat');" "cannot delete" "$DB/feat"
 db_rm "$DB"
 
 # Test: Branch from a specific tag
@@ -115,8 +115,8 @@ SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 # Session 2: checkout dev, verify data
 echo "SELECT dolt_checkout('dev');" | $DOLTLITE "$DB" > /dev/null 2>&1
-run_test "xsess_branch_count" "SELECT count(*) FROM t;" "2" "$DB"
-run_test "xsess_branch_val" "SELECT v FROM t WHERE id=2;" "dev_data" "$DB"
+run_test "xsess_branch_count" "SELECT count(*) FROM t;" "2" "$DB/dev"
+run_test "xsess_branch_val" "SELECT v FROM t WHERE id=2;" "dev_data" "$DB/dev"
 db_rm "$DB"
 
 # Test: Session 1 merges; Session 2 verifies merge result
@@ -177,7 +177,7 @@ SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 # Get commit hashes for cross-branch diff
 MAIN_HEAD=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1;" | $DOLTLITE "$DB" 2>&1)
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
-FEAT_HEAD=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1;" | $DOLTLITE "$DB" 2>&1)
+FEAT_HEAD=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1;" | $DOLTLITE "$DB/feat" 2>&1)
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 # Test: dolt_diff between two different branches' commits
@@ -309,8 +309,8 @@ C1=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1;" | $DOLTLITE "$DB"
 echo "SELECT dolt_reset('--hard','$C1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "reset_then_checkout" "SELECT dolt_checkout('other');" "0" "$DB"
-run_test "reset_then_checkout_branch" "SELECT active_branch();" "other" "$DB"
-run_test "reset_then_checkout_data" "SELECT count(*) FROM t;" "1" "$DB"
+run_test "reset_then_checkout_branch" "SELECT active_branch();" "other" "$DB/other"
+run_test "reset_then_checkout_data" "SELECT count(*) FROM t;" "1" "$DB/other"
 db_rm "$DB"
 
 echo ""
@@ -341,8 +341,8 @@ run_test "schema_main_no_extra" \
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "schema_feat_has_extra" \
   "SELECT count(*) FROM pragma_table_info('t') WHERE name='extra';" \
-  "1" "$DB"
-run_test "schema_feat_extra_val" "SELECT extra FROM t WHERE id=1;" "new" "$DB"
+  "1" "$DB/feat"
+run_test "schema_feat_extra_val" "SELECT extra FROM t WHERE id=1;" "new" "$DB/feat"
 db_rm "$DB"
 
 # Test: Create table on branch, merge to main -- main should have the new table

--- a/test/doltlite_branch_gc_stress.sh
+++ b/test/doltlite_branch_gc_stress.sh
@@ -40,7 +40,7 @@ for i in $(seq 1 100); do
   echo "SELECT dolt_branch('b$i');" | $DOLTLITE "$DB" > /dev/null 2>&1
   echo "SELECT dolt_checkout('b$i');" | $DOLTLITE "$DB" > /dev/null 2>&1
   echo "INSERT INTO t VALUES($i,'b$i',$i);
-SELECT dolt_commit('-A','-m','commit on b$i');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-A','-m','commit on b$i');" | $DOLTLITE "$DB/b$i" > /dev/null 2>&1
   echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 done
 echo "  Done creating branches."
@@ -56,10 +56,10 @@ run_test "many_branches_count" "SELECT count(*) FROM dolt_branches;" "101" "$DB"
 # ============================================================
 
 echo "SELECT dolt_checkout('b50');" | $DOLTLITE "$DB" > /dev/null 2>&1
-run_test "checkout_b50_data" "SELECT val FROM t WHERE id=50;" "50" "$DB"
-run_test "checkout_b50_name" "SELECT branch_name FROM t WHERE id=50;" "b50" "$DB"
+run_test "checkout_b50_data" "SELECT val FROM t WHERE id=50;" "50" "$DB/b50"
+run_test "checkout_b50_name" "SELECT branch_name FROM t WHERE id=50;" "b50" "$DB/b50"
 # b50 should have 2 rows: the init row and its own row
-run_test "checkout_b50_count" "SELECT count(*) FROM t;" "2" "$DB"
+run_test "checkout_b50_count" "SELECT count(*) FROM t;" "2" "$DB/b50"
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 # ============================================================
@@ -119,8 +119,8 @@ run_test "post_gc_main_b3" "SELECT val FROM t WHERE id=3;" "3" "$DB"
 
 # Check an unmerged surviving branch
 echo "SELECT dolt_checkout('b98');" | $DOLTLITE "$DB" > /dev/null 2>&1
-run_test "post_gc_b98_data" "SELECT val FROM t WHERE id=98;" "98" "$DB"
-run_test "post_gc_b98_count" "SELECT count(*) FROM t;" "2" "$DB"
+run_test "post_gc_b98_data" "SELECT val FROM t WHERE id=98;" "98" "$DB/b98"
+run_test "post_gc_b98_count" "SELECT count(*) FROM t;" "2" "$DB/b98"
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 # ============================================================
@@ -160,9 +160,9 @@ for batch in $(seq 0 9); do
     id=$((batch * 100 + j + 1))
     SQL="${SQL}INSERT INTO t VALUES($id,'data_$id');"
   done
-  echo "$SQL" | $DOLTLITE "$DB" > /dev/null 2>&1
+  echo "$SQL" | $DOLTLITE "$DB/bulk" > /dev/null 2>&1
 done
-echo "SELECT dolt_commit('-A','-m','1000 rows');" | $DOLTLITE "$DB" > /dev/null 2>&1
+echo "SELECT dolt_commit('-A','-m','1000 rows');" | $DOLTLITE "$DB/bulk" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 SIZE_WITH_BULK=$(file_size "$DB")
@@ -229,10 +229,10 @@ fi
 
 echo "SELECT dolt_checkout('share_a');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "UPDATE t SET data='modified_a' WHERE id=1;
-SELECT dolt_commit('-A','-m','mod a');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-A','-m','mod a');" | $DOLTLITE "$DB/share_a" > /dev/null 2>&1
 echo "SELECT dolt_checkout('share_b');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "UPDATE t SET data='modified_b' WHERE id=100;
-SELECT dolt_commit('-A','-m','mod b');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-A','-m','mod b');" | $DOLTLITE "$DB/share_b" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 SIZE_AFTER_MODS=$(file_size "$DB")
@@ -308,7 +308,7 @@ for cycle in $(seq 1 10); do
   echo "SELECT dolt_branch('recycled');" | $DOLTLITE "$DB" > /dev/null 2>&1
   echo "SELECT dolt_checkout('recycled');" | $DOLTLITE "$DB" > /dev/null 2>&1
   echo "INSERT INTO t VALUES($((cycle + 100)),'cycle_$cycle');
-SELECT dolt_commit('-A','-m','cycle $cycle');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-A','-m','cycle $cycle');" | $DOLTLITE "$DB/recycled" > /dev/null 2>&1
   echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
   echo "SELECT dolt_branch('-D','recycled');" | $DOLTLITE "$DB" > /dev/null 2>&1
 done

--- a/test/doltlite_cherry_pick.sh
+++ b/test/doltlite_cherry_pick.sh
@@ -54,7 +54,7 @@ SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 # Get the first feat commit hash (the one that added row 10)
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
-CP_HASH=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1;" | $DOLTLITE "$DB" 2>&1)
+CP_HASH=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1;" | $DOLTLITE "$DB/feat" 2>&1)
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 # Cherry-pick only the first feat commit
@@ -373,7 +373,7 @@ SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 # Cherry-pick first feat commit
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
-HASH1=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1;" | $DOLTLITE "$DB" 2>&1)
+HASH1=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1;" | $DOLTLITE "$DB/feat" 2>&1)
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_cherry_pick('$HASH1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
@@ -382,7 +382,7 @@ run_test "cp_multi_has10" "SELECT v FROM t WHERE id=10;" "cp1" "$DB"
 
 # Cherry-pick second feat commit
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
-HASH2=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1;" | $DOLTLITE "$DB" 2>&1)
+HASH2=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1;" | $DOLTLITE "$DB/feat" 2>&1)
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_cherry_pick('$HASH2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
@@ -435,7 +435,7 @@ SELECT dolt_commit('-A','-m','main commit');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 # Cherry-pick feat commit onto main (which already has its own changes)
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
-HASH=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1;" | $DOLTLITE "$DB" 2>&1)
+HASH=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1;" | $DOLTLITE "$DB/feat" 2>&1)
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test_match "cp_div_hash" "SELECT dolt_cherry_pick('$HASH');" "^[0-9a-f]{40}$" "$DB"

--- a/test/doltlite_conflicts.sh
+++ b/test/doltlite_conflicts.sh
@@ -13,7 +13,7 @@ echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'or
 echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "UPDATE t SET v='main'; SELECT dolt_commit('-A','-m','main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
-echo "UPDATE t SET v='feat'; SELECT dolt_commit('-A','-m','feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
+echo "UPDATE t SET v='feat'; SELECT dolt_commit('-A','-m','feat');" | $DOLTLITE "$DB/feature" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "conflicts_table" \
   "BEGIN; SELECT dolt_merge('feature'); SELECT 'CT|' || \"table\" FROM dolt_conflicts; ROLLBACK;" \
@@ -41,7 +41,7 @@ echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'or
 echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB2" > /dev/null 2>&1
 echo "UPDATE t SET v='main2'; SELECT dolt_commit('-A','-m','main');" | $DOLTLITE "$DB2" > /dev/null 2>&1
 echo "SELECT dolt_checkout('feature');" | $DOLTLITE "$DB2" > /dev/null 2>&1
-echo "UPDATE t SET v='feat2'; SELECT dolt_commit('-A','-m','feat');" | $DOLTLITE "$DB2" > /dev/null 2>&1
+echo "UPDATE t SET v='feat2'; SELECT dolt_commit('-A','-m','feat');" | $DOLTLITE "$DB2/feature" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB2" > /dev/null 2>&1
 run_test_match "theirs_has_conflict" \
   "BEGIN; SELECT dolt_merge('feature'); SELECT 'TC|' || num_conflicts FROM dolt_conflicts; ROLLBACK;" \
@@ -56,7 +56,7 @@ echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'
 echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB3" > /dev/null 2>&1
 echo "UPDATE t SET v='MAIN' WHERE id=1; SELECT dolt_commit('-A','-m','main');" | $DOLTLITE "$DB3" > /dev/null 2>&1
 echo "SELECT dolt_checkout('feature');" | $DOLTLITE "$DB3" > /dev/null 2>&1
-echo "UPDATE t SET v='FEAT' WHERE id=2; SELECT dolt_commit('-A','-m','feat');" | $DOLTLITE "$DB3" > /dev/null 2>&1
+echo "UPDATE t SET v='FEAT' WHERE id=2; SELECT dolt_commit('-A','-m','feat');" | $DOLTLITE "$DB3/feature" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB3" > /dev/null 2>&1
 run_test_match "no_conflict_merge" "SELECT dolt_merge('feature');" "^[0-9a-f]{40}$" "$DB3"
 run_test "no_conflicts_table" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB3"
@@ -69,7 +69,7 @@ echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'
 echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB4" > /dev/null 2>&1
 echo "UPDATE t SET v='main1' WHERE id=1; UPDATE t SET v='main3' WHERE id=3; SELECT dolt_commit('-A','-m','main');" | $DOLTLITE "$DB4" > /dev/null 2>&1
 echo "SELECT dolt_checkout('feature');" | $DOLTLITE "$DB4" > /dev/null 2>&1
-echo "UPDATE t SET v='feat1' WHERE id=1; INSERT INTO t VALUES(4,'feat4'); SELECT dolt_commit('-A','-m','feat');" | $DOLTLITE "$DB4" > /dev/null 2>&1
+echo "UPDATE t SET v='feat1' WHERE id=1; INSERT INTO t VALUES(4,'feat4'); SELECT dolt_commit('-A','-m','feat');" | $DOLTLITE "$DB4/feature" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB4" > /dev/null 2>&1
 run_test_match "mixed_conflict" "SELECT dolt_merge('feature');" "conflict" "$DB4"
 run_test_match "mixed_conflict_count" \

--- a/test/doltlite_deep_history.sh
+++ b/test/doltlite_deep_history.sh
@@ -107,7 +107,7 @@ echo "INSERT INTO t VALUES(1000,'main_extra'); SELECT dolt_commit('-A','-m','mai
 
 # Switch to branch, make a change there
 echo "SELECT dolt_checkout('deep_branch');" | $DOLTLITE "$DB" > /dev/null 2>&1
-echo "INSERT INTO t VALUES(2000,'branch_extra'); SELECT dolt_commit('-A','-m','branch_change');" | $DOLTLITE "$DB" > /dev/null 2>&1
+echo "INSERT INTO t VALUES(2000,'branch_extra'); SELECT dolt_commit('-A','-m','branch_change');" | $DOLTLITE "$DB/deep_branch" > /dev/null 2>&1
 
 # Get branch heads
 MAIN_HEAD=$(echo "SELECT hash FROM dolt_branches WHERE name='main';" | $DOLTLITE "$DB" 2>/dev/null)

--- a/test/doltlite_demo.sh
+++ b/test/doltlite_demo.sh
@@ -76,9 +76,9 @@ DELETE FROM employees_teams WHERE employee_id=0 AND team_id=1;
 SELECT dolt_commit('-A','-m','Modifications on a branch');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 # Verify modifications branch
-run_test "mod_branch" "SELECT active_branch();" "modifications" "$DB"
-run_test "mod_emp_count" "SELECT count(*) FROM employees;" "5" "$DB"
-run_test "mod_timothy" "SELECT first_name FROM employees WHERE id=0;" "Timothy" "$DB"
+run_test "mod_branch" "SELECT active_branch();" "modifications" "$DB/modifications"
+run_test "mod_emp_count" "SELECT count(*) FROM employees;" "5" "$DB/modifications"
+run_test "mod_timothy" "SELECT first_name FROM employees WHERE id=0;" "Timothy" "$DB/modifications"
 
 # ============================================================
 # Phase 4: Back to main — data unchanged

--- a/test/doltlite_diff.sh
+++ b/test/doltlite_diff.sh
@@ -93,7 +93,7 @@ run_test "diff_all_deletes_type" \
 DB3=/tmp/test_diff3_$$.db; rm -f "$DB3"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT); INSERT INTO t VALUES(1,'a'),(2,'b'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB3" > /dev/null 2>&1
 echo "SELECT dolt_branch('feat'); SELECT dolt_checkout('feat');" | $DOLTLITE "$DB3" > /dev/null 2>&1
-echo "INSERT INTO t VALUES(3,'c'); UPDATE t SET val='A' WHERE id=1; SELECT dolt_commit('-A','-m','feat changes');" | $DOLTLITE "$DB3" > /dev/null 2>&1
+echo "INSERT INTO t VALUES(3,'c'); UPDATE t SET val='A' WHERE id=1; SELECT dolt_commit('-A','-m','feat changes');" | $DOLTLITE "$DB3/feat" > /dev/null 2>&1
 
 run_test "diff_branch_names" \
   "SELECT rows_added || '|' || rows_modified FROM dolt_diff_stat('main', 'feat', 't');" \
@@ -108,10 +108,10 @@ run_test "diff_mixed_ref_types" \
   "1|1" "$DB3"
 
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB3" > /dev/null 2>&1
-echo "INSERT INTO t VALUES(4,'d');" | $DOLTLITE "$DB3" > /dev/null 2>&1
+echo "INSERT INTO t VALUES(4,'d');" | $DOLTLITE "$DB3/feat" > /dev/null 2>&1
 run_test "diff_branch_to_working" \
   "SELECT count(*) FROM dolt_diff_t WHERE to_commit='WORKING';" \
-  "1" "$DB3"
+  "1" "$DB3/feat"
 
 DB4=/tmp/test_diff4_$$.db; rm -f "$DB4"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT); INSERT INTO t VALUES(1,'a'); SELECT dolt_commit('-A','-m','v1');" | $DOLTLITE "$DB4" > /dev/null 2>&1

--- a/test/doltlite_e2e.sh
+++ b/test/doltlite_e2e.sh
@@ -43,14 +43,14 @@ run_test "e2e_tag_exists" "SELECT tag_name FROM dolt_tags;" "v0.1" "$DB"
 echo "SELECT dolt_branch('add-comments');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('add-comments');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-run_test "e2e_on_feature" "SELECT active_branch();" "add-comments" "$DB"
+run_test "e2e_on_feature" "SELECT active_branch();" "add-comments" "$DB/add-comments"
 
 echo "CREATE TABLE comments(id INTEGER PRIMARY KEY, post_id INTEGER, body TEXT);
 INSERT INTO comments VALUES(1,1,'Great post Alice!');
 INSERT INTO comments VALUES(2,1,'Thanks!');
-SELECT dolt_commit('-A','-m','Add comments table');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-A','-m','Add comments table');" | $DOLTLITE "$DB/add-comments" > /dev/null 2>&1
 
-run_test "e2e_feature_comments" "SELECT count(*) FROM comments;" "2" "$DB"
+run_test "e2e_feature_comments" "SELECT count(*) FROM comments;" "2" "$DB/add-comments"
 
 # Main branch shouldn't have comments
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -100,7 +100,7 @@ run_test_match "e2e_diff_users_v01_v02" \
 echo "SELECT dolt_branch('hotfix');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('hotfix');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "UPDATE users SET name='ALICE' WHERE id=1;
-SELECT dolt_commit('-A','-m','Hotfix: capitalize Alice');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-A','-m','Hotfix: capitalize Alice');" | $DOLTLITE "$DB/hotfix" > /dev/null 2>&1
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "UPDATE users SET name='alice_updated' WHERE id=1;

--- a/test/doltlite_edge_cases.sh
+++ b/test/doltlite_edge_cases.sh
@@ -43,7 +43,7 @@ run_test "val_to_null" "SELECT count(*) FROM t WHERE a IS NULL;" "1" "$DB"
 # NULL in merge scenario
 echo "SELECT dolt_branch('nullbranch');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('nullbranch');" | $DOLTLITE "$DB" > /dev/null 2>&1
-echo "UPDATE t SET b=999 WHERE id=3; SELECT dolt_commit('-A','-m','branch change');" | $DOLTLITE "$DB" > /dev/null 2>&1
+echo "UPDATE t SET b=999 WHERE id=3; SELECT dolt_commit('-A','-m','branch change');" | $DOLTLITE "$DB/nullbranch" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "UPDATE t SET c=9.9 WHERE id=1; SELECT dolt_commit('-A','-m','main change');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
@@ -107,7 +107,7 @@ run_test "special_updated" "SELECT val FROM t WHERE id=1;" "updated" "$DB"
 # Branch and merge with special chars
 echo "SELECT dolt_branch('sp');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('sp');" | $DOLTLITE "$DB" > /dev/null 2>&1
-echo "INSERT INTO t VALUES(6,'sp_val'); SELECT dolt_commit('-A','-m','sp commit');" | $DOLTLITE "$DB" > /dev/null 2>&1
+echo "INSERT INTO t VALUES(6,'sp_val'); SELECT dolt_commit('-A','-m','sp commit');" | $DOLTLITE "$DB/sp" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(7,'main_val'); SELECT dolt_commit('-A','-m','main commit');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
@@ -135,7 +135,7 @@ echo "SELECT dolt_branch('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO a VALUES(2,'a2_feat');
 INSERT INTO b VALUES(2,'b2_feat');
-SELECT dolt_commit('-A','-m','feat: add to a and b');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-A','-m','feat: add to a and b');" | $DOLTLITE "$DB/feat" > /dev/null 2>&1
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO b VALUES(3,'b3_main');
@@ -171,7 +171,7 @@ echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "CREATE TABLE feat_table(id INTEGER PRIMARY KEY, f TEXT);
 INSERT INTO feat_table VALUES(1,'feat1');
 INSERT INTO feat_table VALUES(2,'feat2');
-SELECT dolt_commit('-A','-m','add feat_table');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-A','-m','add feat_table');" | $DOLTLITE "$DB/feat" > /dev/null 2>&1
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO base VALUES(2,'y');
@@ -202,7 +202,7 @@ echo "SELECT dolt_checkout('ahead');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(2,'second');
 SELECT dolt_commit('-A','-m','second');
 INSERT INTO t VALUES(3,'third');
-SELECT dolt_commit('-A','-m','third');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-A','-m','third');" | $DOLTLITE "$DB/ahead" > /dev/null 2>&1
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
@@ -344,7 +344,7 @@ run_test "schema_new_row" "SELECT email FROM t WHERE id=2;" "bob@test.com" "$DB"
 echo "SELECT dolt_branch('post-schema');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('post-schema');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(3,'Charlie','charlie@test.com');
-SELECT dolt_commit('-A','-m','charlie on branch');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-A','-m','charlie on branch');" | $DOLTLITE "$DB/post-schema" > /dev/null 2>&1
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(4,'Dave','dave@test.com');
@@ -460,10 +460,10 @@ run_test "branch_multi" "SELECT count(*) FROM dolt_branches;" "4" "$DB"
 
 # Switch between branches rapidly
 echo "SELECT dolt_checkout('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
-run_test "branch_on_b1" "SELECT active_branch();" "b1" "$DB"
+run_test "branch_on_b1" "SELECT active_branch();" "b1" "$DB/b1"
 
 echo "SELECT dolt_checkout('b2');" | $DOLTLITE "$DB" > /dev/null 2>&1
-run_test "branch_on_b2" "SELECT active_branch();" "b2" "$DB"
+run_test "branch_on_b2" "SELECT active_branch();" "b2" "$DB/b2"
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "branch_back_main" "SELECT active_branch();" "main" "$DB"
@@ -479,7 +479,7 @@ run_test_match "branch_names" "SELECT name FROM dolt_branches ORDER BY name;" "b
 # Commit on b1 doesn't affect main
 echo "SELECT dolt_checkout('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(99);
-SELECT dolt_commit('-A','-m','b1 commit');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-A','-m','b1 commit');" | $DOLTLITE "$DB/b1" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "branch_isolation" "SELECT count(*) FROM t;" "1" "$DB"
@@ -503,7 +503,7 @@ echo "SELECT dolt_branch('hotfix');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('hotfix');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "UPDATE users SET name='ALICE' WHERE id=1;
 UPDATE orders SET item='HAT' WHERE id=1;
-SELECT dolt_commit('-A','-m','hotfix: uppercase');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-A','-m','hotfix: uppercase');" | $DOLTLITE "$DB/hotfix" > /dev/null 2>&1
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "UPDATE users SET name='alice_v2' WHERE id=1;
@@ -547,7 +547,7 @@ SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_branch('hf');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('hf');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "UPDATE t SET v='hf_val' WHERE id=1;
-SELECT dolt_commit('-A','-m','hf');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-A','-m','hf');" | $DOLTLITE "$DB/hf" > /dev/null 2>&1
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "UPDATE t SET v='main_val' WHERE id=1;
@@ -611,7 +611,7 @@ SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 # Merge 1
 echo "SELECT dolt_branch('f1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('f1');" | $DOLTLITE "$DB" > /dev/null 2>&1
-echo "INSERT INTO t VALUES(2,'f1'); SELECT dolt_commit('-A','-m','f1');" | $DOLTLITE "$DB" > /dev/null 2>&1
+echo "INSERT INTO t VALUES(2,'f1'); SELECT dolt_commit('-A','-m','f1');" | $DOLTLITE "$DB/f1" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "seqmerge_1" "SELECT dolt_merge('f1');" "^[0-9a-f]{40}$" "$DB"
 run_test "seqmerge_1_count" "SELECT count(*) FROM t;" "2" "$DB"
@@ -619,7 +619,7 @@ run_test "seqmerge_1_count" "SELECT count(*) FROM t;" "2" "$DB"
 # Merge 2
 echo "SELECT dolt_branch('f2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('f2');" | $DOLTLITE "$DB" > /dev/null 2>&1
-echo "INSERT INTO t VALUES(3,'f2'); SELECT dolt_commit('-A','-m','f2');" | $DOLTLITE "$DB" > /dev/null 2>&1
+echo "INSERT INTO t VALUES(3,'f2'); SELECT dolt_commit('-A','-m','f2');" | $DOLTLITE "$DB/f2" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "seqmerge_2" "SELECT dolt_merge('f2');" "^[0-9a-f]{40}$" "$DB"
 run_test "seqmerge_2_count" "SELECT count(*) FROM t;" "3" "$DB"
@@ -627,7 +627,7 @@ run_test "seqmerge_2_count" "SELECT count(*) FROM t;" "3" "$DB"
 # Merge 3
 echo "SELECT dolt_branch('f3');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('f3');" | $DOLTLITE "$DB" > /dev/null 2>&1
-echo "INSERT INTO t VALUES(4,'f3'); SELECT dolt_commit('-A','-m','f3');" | $DOLTLITE "$DB" > /dev/null 2>&1
+echo "INSERT INTO t VALUES(4,'f3'); SELECT dolt_commit('-A','-m','f3');" | $DOLTLITE "$DB/f3" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "seqmerge_3" "SELECT dolt_merge('f3');" "^[0-9a-f]{40}$" "$DB"
 run_test "seqmerge_3_count" "SELECT count(*) FROM t;" "4" "$DB"
@@ -651,7 +651,7 @@ echo "SELECT dolt_checkout('cleanup');" | $DOLTLITE "$DB" > /dev/null 2>&1
 # Delete individual rows to avoid WHERE clause bug
 echo "DELETE FROM t WHERE id=2;
 DELETE FROM t WHERE id=4;
-SELECT dolt_commit('-A','-m','delete 2 and 4');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-A','-m','delete 2 and 4');" | $DOLTLITE "$DB/cleanup" > /dev/null 2>&1
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(5,'e');
@@ -755,9 +755,9 @@ SELECT dolt_checkout('dev');
 INSERT INTO t VALUES(4,'round4_dev');
 SELECT dolt_commit('-A','-m','dev commit');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Checkout sets default branch, so reopen stays on dev
-run_test "persist_reopen_branch" "SELECT active_branch();" "dev" "$DB"
-run_test "persist_reopen_data" "SELECT count(*) FROM t;" "4" "$DB"
+# Reopen dev explicitly and verify its data
+run_test "persist_reopen_branch" "SELECT active_branch();" "dev" "$DB/dev"
+run_test "persist_reopen_data" "SELECT count(*) FROM t;" "4" "$DB/dev"
 
 # Switch back to main and verify
 run_test "persist_main_data" "SELECT dolt_checkout('main'); SELECT count(*) FROM t;" "0
@@ -802,8 +802,8 @@ echo "INSERT INTO t VALUES(3,'main2'); SELECT dolt_commit('-A','-m','main2');" |
 
 # Two commits on feat
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
-echo "INSERT INTO t VALUES(10,'feat1'); SELECT dolt_commit('-A','-m','feat1');" | $DOLTLITE "$DB" > /dev/null 2>&1
-echo "INSERT INTO t VALUES(11,'feat2'); SELECT dolt_commit('-A','-m','feat2');" | $DOLTLITE "$DB" > /dev/null 2>&1
+echo "INSERT INTO t VALUES(10,'feat1'); SELECT dolt_commit('-A','-m','feat1');" | $DOLTLITE "$DB/feat" > /dev/null 2>&1
+echo "INSERT INTO t VALUES(11,'feat2'); SELECT dolt_commit('-A','-m','feat2');" | $DOLTLITE "$DB/feat" > /dev/null 2>&1
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
@@ -886,7 +886,7 @@ SELECT dolt_commit('-A','-m','main change');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "UPDATE t SET v='same_change' WHERE id=1;
 INSERT INTO t VALUES(3,'feat_only');
-SELECT dolt_commit('-A','-m','feat change');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-A','-m','feat change');" | $DOLTLITE "$DB/feat" > /dev/null 2>&1
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
@@ -957,18 +957,18 @@ SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_branch('dev');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('dev');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(2,'dev1');
-SELECT dolt_commit('-A','-m','dev1');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-A','-m','dev1');" | $DOLTLITE "$DB/dev" > /dev/null 2>&1
 
 # Branch from dev (not main!)
 echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(3,'feature1');
-SELECT dolt_commit('-A','-m','feature1');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-A','-m','feature1');" | $DOLTLITE "$DB/feature" > /dev/null 2>&1
 
 # Merge feature back into dev
 echo "SELECT dolt_checkout('dev');" | $DOLTLITE "$DB" > /dev/null 2>&1
-run_test_match "branchfrom_merge" "SELECT dolt_merge('feature');" "^[0-9a-f]{40}$" "$DB"
-run_test "branchfrom_count" "SELECT count(*) FROM t;" "3" "$DB"
+run_test_match "branchfrom_merge" "SELECT dolt_merge('feature');" "^[0-9a-f]{40}$" "$DB/dev"
+run_test "branchfrom_count" "SELECT count(*) FROM t;" "3" "$DB/dev"
 
 # Main should still only have 1 row
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1

--- a/test/doltlite_feature_deep.sh
+++ b/test/doltlite_feature_deep.sh
@@ -32,7 +32,7 @@ INSERT INTO base VALUES(2,'y');
 SELECT dolt_commit('-A','-m','main work');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
-HASH=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1;" | $DOLTLITE "$DB" 2>&1)
+HASH=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1;" | $DOLTLITE "$DB/feat" 2>&1)
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test_match "cp_newtbl_hash" "SELECT dolt_cherry_pick('$HASH');" "^[0-9a-f]{40}$" "$DB"
@@ -124,7 +124,7 @@ SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_branch('big');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('big');" | $DOLTLITE "$DB" > /dev/null 2>&1
 SQL=""; for i in $(seq 2 100); do SQL="$SQL INSERT INTO t VALUES($i,'row_$i');"; done
-echo "$SQL SELECT dolt_commit('-A','-m','100 rows');" | $DOLTLITE "$DB" > /dev/null 2>&1
+echo "$SQL SELECT dolt_commit('-A','-m','100 rows');" | $DOLTLITE "$DB/big" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 SIZE_BEFORE=$(db_size "$DB")
@@ -531,13 +531,13 @@ SELECT dolt_commit('-A','-m','b adds row 20');" | $DOLTLITE "$DB" > /dev/null 2>
 
 # Cherry-pick a's commit onto b
 echo "SELECT dolt_checkout('a');" | $DOLTLITE "$DB" > /dev/null 2>&1
-A_HASH=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1;" | $DOLTLITE "$DB" 2>&1)
+A_HASH=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1;" | $DOLTLITE "$DB/a" 2>&1)
 echo "SELECT dolt_checkout('b');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-run_test_match "cp_branch_hash" "SELECT dolt_cherry_pick('$A_HASH');" "^[0-9a-f]{40}$" "$DB"
-run_test "cp_branch_count" "SELECT count(*) FROM t;" "3" "$DB"
-run_test "cp_branch_has10" "SELECT v FROM t WHERE id=10;" "from_a" "$DB"
-run_test "cp_branch_has20" "SELECT v FROM t WHERE id=20;" "from_b" "$DB"
+run_test_match "cp_branch_hash" "SELECT dolt_cherry_pick('$A_HASH');" "^[0-9a-f]{40}$" "$DB/b"
+run_test "cp_branch_count" "SELECT count(*) FROM t;" "3" "$DB/b"
+run_test "cp_branch_has10" "SELECT v FROM t WHERE id=10;" "from_a" "$DB/b"
+run_test "cp_branch_has20" "SELECT v FROM t WHERE id=20;" "from_b" "$DB/b"
 
 db_rm "$DB"
 

--- a/test/doltlite_gc.sh
+++ b/test/doltlite_gc.sh
@@ -84,7 +84,7 @@ SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_branch('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(100,'feat_only');
-SELECT dolt_commit('-A','-m','feat commit');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-A','-m','feat commit');" | $DOLTLITE "$DB/feat" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 SIZE_WITH_BRANCH=$(db_size "$DB")
@@ -122,7 +122,7 @@ SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_branch('dev');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('dev');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(2,'dev_data');
-SELECT dolt_commit('-A','-m','dev commit');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-A','-m','dev commit');" | $DOLTLITE "$DB/dev" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 echo "SELECT dolt_tag('v1.0');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -137,7 +137,7 @@ run_test "gc_preserve_tags" "SELECT count(*) FROM dolt_tags;" "1" "$DB"
 
 # Dev branch data preserved
 echo "SELECT dolt_checkout('dev');" | $DOLTLITE "$DB" > /dev/null 2>&1
-run_test "gc_preserve_dev" "SELECT count(*) FROM t;" "2" "$DB"
+run_test "gc_preserve_dev" "SELECT count(*) FROM t;" "2" "$DB/dev"
 
 # After reopen, everything still works
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1

--- a/test/doltlite_merge.sh
+++ b/test/doltlite_merge.sh
@@ -13,7 +13,7 @@ echo "CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT); CREATE TABLE orders
 echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "UPDATE users SET name='ALICE' WHERE id=1; SELECT dolt_commit('-A','-m','main updates');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
-echo "INSERT INTO orders VALUES(2,'coat'); SELECT dolt_commit('-A','-m','feature adds');" | $DOLTLITE "$DB" > /dev/null 2>&1
+echo "INSERT INTO orders VALUES(2,'coat'); SELECT dolt_commit('-A','-m','feature adds');" | $DOLTLITE "$DB/feature" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test_match "merge_hash" "SELECT dolt_merge('feature');" "^[0-9a-f]{40}$" "$DB"
@@ -27,7 +27,7 @@ DB2=/tmp/test_merge2_$$.db; rm -f "$DB2"
 echo "CREATE TABLE t(x); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB2" > /dev/null 2>&1
 echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB2" > /dev/null 2>&1
 echo "SELECT dolt_checkout('feature');" | $DOLTLITE "$DB2" > /dev/null 2>&1
-echo "INSERT INTO t VALUES(2); SELECT dolt_commit('-A','-m','feature');" | $DOLTLITE "$DB2" > /dev/null 2>&1
+echo "INSERT INTO t VALUES(2); SELECT dolt_commit('-A','-m','feature');" | $DOLTLITE "$DB2/feature" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB2" > /dev/null 2>&1
 run_test "ff_before" "SELECT count(*) FROM t;" "1" "$DB2"
 run_test_match "ff_merge" "SELECT dolt_merge('feature');" "^[0-9a-f]{40}$" "$DB2"
@@ -44,7 +44,7 @@ echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'
 echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB3" > /dev/null 2>&1
 echo "UPDATE t SET v='main'; SELECT dolt_commit('-A','-m','main');" | $DOLTLITE "$DB3" > /dev/null 2>&1
 echo "SELECT dolt_checkout('feature');" | $DOLTLITE "$DB3" > /dev/null 2>&1
-echo "UPDATE t SET v='feat'; SELECT dolt_commit('-A','-m','feat');" | $DOLTLITE "$DB3" > /dev/null 2>&1
+echo "UPDATE t SET v='feat'; SELECT dolt_commit('-A','-m','feat');" | $DOLTLITE "$DB3/feature" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB3" > /dev/null 2>&1
 run_test_match "conflict" "SELECT dolt_merge('feature');" "conflict" "$DB3"
 run_test "conflict_ours_preserved" "SELECT v FROM t;" "main" "$DB3"
@@ -57,7 +57,7 @@ DB4=/tmp/test_merge4_$$.db; rm -f "$DB4"
 echo "CREATE TABLE t(x); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB4" > /dev/null 2>&1
 echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB4" > /dev/null 2>&1
 echo "SELECT dolt_checkout('feature');" | $DOLTLITE "$DB4" > /dev/null 2>&1
-echo "CREATE TABLE new_t(y); INSERT INTO new_t VALUES(42); SELECT dolt_commit('-A','-m','add table');" | $DOLTLITE "$DB4" > /dev/null 2>&1
+echo "CREATE TABLE new_t(y); INSERT INTO new_t VALUES(42); SELECT dolt_commit('-A','-m','add table');" | $DOLTLITE "$DB4/feature" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB4" > /dev/null 2>&1
 run_test_match "new_table_merge" "SELECT dolt_merge('feature');" "^[0-9a-f]{40}$" "$DB4"
 run_test "new_table_visible" "SELECT y FROM new_t;" "42" "$DB4"
@@ -68,7 +68,7 @@ DB5=/tmp/test_merge5_$$.db; rm -f "$DB5"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'),(2,'b'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB5" > /dev/null 2>&1
 echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB5" > /dev/null 2>&1
 echo "SELECT dolt_checkout('feature');" | $DOLTLITE "$DB5" > /dev/null 2>&1
-echo "DELETE FROM t WHERE id=2; SELECT dolt_commit('-A','-m','del');" | $DOLTLITE "$DB5" > /dev/null 2>&1
+echo "DELETE FROM t WHERE id=2; SELECT dolt_commit('-A','-m','del');" | $DOLTLITE "$DB5/feature" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB5" > /dev/null 2>&1
 run_test "pre_merge_rows" "SELECT count(*) FROM t;" "2" "$DB5"
 run_test_match "merge_del" "SELECT dolt_merge('feature');" "^[0-9a-f]{40}$" "$DB5"
@@ -98,7 +98,7 @@ echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'
 echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB6" > /dev/null 2>&1
 echo "UPDATE t SET v='MAIN' WHERE id=1; SELECT dolt_commit('-A','-m','main');" | $DOLTLITE "$DB6" > /dev/null 2>&1
 echo "SELECT dolt_checkout('feature');" | $DOLTLITE "$DB6" > /dev/null 2>&1
-echo "UPDATE t SET v='FEAT' WHERE id=3; SELECT dolt_commit('-A','-m','feat');" | $DOLTLITE "$DB6" > /dev/null 2>&1
+echo "UPDATE t SET v='FEAT' WHERE id=3; SELECT dolt_commit('-A','-m','feat');" | $DOLTLITE "$DB6/feature" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB6" > /dev/null 2>&1
 run_test_match "row_merge_succeeds" "SELECT dolt_merge('feature');" "^[0-9a-f]{40}$" "$DB6"
 run_test "row_merge_row1" "SELECT v FROM t WHERE id=1;" "MAIN" "$DB6"
@@ -111,7 +111,7 @@ echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'or
 echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB7" > /dev/null 2>&1
 echo "UPDATE t SET v='main-val' WHERE id=1; SELECT dolt_commit('-A','-m','main');" | $DOLTLITE "$DB7" > /dev/null 2>&1
 echo "SELECT dolt_checkout('feature');" | $DOLTLITE "$DB7" > /dev/null 2>&1
-echo "UPDATE t SET v='feat-val' WHERE id=1; SELECT dolt_commit('-A','-m','feat');" | $DOLTLITE "$DB7" > /dev/null 2>&1
+echo "UPDATE t SET v='feat-val' WHERE id=1; SELECT dolt_commit('-A','-m','feat');" | $DOLTLITE "$DB7/feature" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB7" > /dev/null 2>&1
 run_test_match "row_conflict_detected" "SELECT dolt_merge('feature');" "conflict" "$DB7"
 run_test "row_conflict_ours_kept" "SELECT v FROM t WHERE id=1;" "main-val" "$DB7"
@@ -122,7 +122,7 @@ echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'
 echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB8" > /dev/null 2>&1
 echo "UPDATE t SET v='main1' WHERE id=1; INSERT INTO t VALUES(3,'main3'); SELECT dolt_commit('-A','-m','main');" | $DOLTLITE "$DB8" > /dev/null 2>&1
 echo "SELECT dolt_checkout('feature');" | $DOLTLITE "$DB8" > /dev/null 2>&1
-echo "UPDATE t SET v='feat1' WHERE id=1; INSERT INTO t VALUES(4,'feat4'); SELECT dolt_commit('-A','-m','feat');" | $DOLTLITE "$DB8" > /dev/null 2>&1
+echo "UPDATE t SET v='feat1' WHERE id=1; INSERT INTO t VALUES(4,'feat4'); SELECT dolt_commit('-A','-m','feat');" | $DOLTLITE "$DB8/feature" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB8" > /dev/null 2>&1
 run_test_match "mixed_merge" "SELECT dolt_merge('feature');" "conflict|rolled back" "$DB8"
 run_test "mixed_no_conflicts" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB8"

--- a/test/doltlite_open_branch.sh
+++ b/test/doltlite_open_branch.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+DOLTLITE="${1:-./doltlite}"
+PASS=0; FAIL=0; ERRORS=""
+
+check_eq() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1))
+    ERRORS="$ERRORS\nFAIL: $name\n  expected: $expected\n  got:      $actual"
+  fi
+}
+
+check_match() {
+  local name="$1" pattern="$2" actual="$3"
+  if echo "$actual" | grep -qE "$pattern"; then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1))
+    ERRORS="$ERRORS\nFAIL: $name\n  pattern: $pattern\n  got:     $actual"
+  fi
+}
+
+echo "=== Doltlite Open Branch Tests ==="
+echo ""
+
+DB=/tmp/test_open_branch_$$.db
+rm -f "$DB"
+cat <<'SQL' | "$DOLTLITE" "$DB" >/dev/null 2>&1
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'main');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','init');
+SELECT dolt_branch('side');
+SELECT dolt_checkout('side');
+UPDATE t SET v='side' WHERE id=1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','side');
+SELECT dolt_checkout('main');
+SQL
+
+res=$("$DOLTLITE" "$DB" "SELECT active_branch(); SELECT v FROM t WHERE id=1;")
+check_eq "default_uses_main" $'main\nmain' "$res"
+
+res=$("$DOLTLITE" "$DB@side" "SELECT active_branch(); SELECT v FROM t WHERE id=1;")
+check_eq "at_selects_side" $'side\nside' "$res"
+
+res=$("$DOLTLITE" "$DB/side" "SELECT active_branch(); SELECT v FROM t WHERE id=1;")
+check_eq "slash_selects_side" $'side\nside' "$res"
+
+res=$("$DOLTLITE" "$DB@missing" "SELECT active_branch();" 2>&1 || true)
+check_match "missing_branch_errors" "unable to select branch|branch.*not found|SQLITE_NOTFOUND" "$res"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ $FAIL -gt 0 ]; then
+  printf "%b\n" "$ERRORS"
+  exit 1
+fi

--- a/test/doltlite_persistence.sh
+++ b/test/doltlite_persistence.sh
@@ -174,8 +174,8 @@ run_test "branch_main" "SELECT count(*) FROM t;" "1" "$DB"
 
 # Switch to feat and verify
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
-run_test "branch_feat" "SELECT count(*) FROM t;" "2" "$DB"
-run_test "branch_feat_val" "SELECT v FROM t WHERE id=2;" "feat_data" "$DB"
+run_test "branch_feat" "SELECT count(*) FROM t;" "2" "$DB/feat"
+run_test "branch_feat_val" "SELECT v FROM t WHERE id=2;" "feat_data" "$DB/feat"
 
 rm -f "$DB"
 
@@ -423,9 +423,8 @@ INSERT INTO t VALUES(3,'main_again');
 SELECT dolt_commit('-A','-m','main second');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 # Reopen on dev — manifest head is main's latest, not dev's
-echo "SELECT dolt_checkout('dev');" | $DOLTLITE "$DB" > /dev/null 2>&1
-run_test "diverged_dev_count" "SELECT count(*) FROM t;" "2" "$DB"
-run_test "diverged_dev_val" "SELECT v FROM t WHERE id=2;" "from_dev" "$DB"
+run_test "diverged_dev_count" "SELECT count(*) FROM t;" "2" "$DB/dev"
+run_test "diverged_dev_val" "SELECT v FROM t WHERE id=2;" "from_dev" "$DB/dev"
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "diverged_main_count" "SELECT count(*) FROM t;" "2" "$DB"

--- a/test/doltlite_structural.sh
+++ b/test/doltlite_structural.sh
@@ -246,7 +246,7 @@ assert_greater "gc_preserves_shared" "$SIZE_AFTER_GC" "$THRESHOLD"
 # Both branches' data should survive
 MAIN_COUNT=$(echo "SELECT count(*) FROM t WHERE id=8888;" | $DOLTLITE "$DB" 2>&1)
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
-FEAT_COUNT=$(echo "SELECT count(*) FROM t WHERE id=9999;" | $DOLTLITE "$DB" 2>&1)
+FEAT_COUNT=$(echo "SELECT count(*) FROM t WHERE id=9999;" | $DOLTLITE "$DB/feat" 2>&1)
 if [ "$MAIN_COUNT" = "1" ] && [ "$FEAT_COUNT" = "1" ]; then
   PASS=$((PASS+1)); echo "  PASS: gc_both_branches_intact"
 else

--- a/test/doltlite_unicode_blob.sh
+++ b/test/doltlite_unicode_blob.sh
@@ -66,7 +66,7 @@ run_test "japanese_data" \
 echo "SELECT dolt_branch('intl');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('intl');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(6,'Кириллица');
-SELECT dolt_commit('-A','-m','add cyrillic');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-A','-m','add cyrillic');" | $DOLTLITE "$DB/intl" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "pre_merge_count" \
@@ -119,10 +119,10 @@ SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 result=$(echo "SELECT dolt_branch('feature/日本語');" | perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$DB" 2>&1)
 if [ "$result" = "0" ]; then
   # It worked - verify we can checkout and use it
-  echo "SELECT dolt_checkout('feature/日本語');" | $DOLTLITE "$DB" > /dev/null 2>&1
   run_test "unicode_branch_active" \
-    "SELECT active_branch();" \
-    "feature/日本語" "$DB"
+    "SELECT dolt_checkout('feature/日本語'); SELECT active_branch();" \
+    "0
+feature/日本語" "$DB"
   PASS=$((PASS+1))  # count the branch creation as pass
   echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 else
@@ -216,11 +216,11 @@ echo "SELECT dolt_checkout('blobcheck');" | $DOLTLITE "$DB" > /dev/null 2>&1
 # Data should survive branch checkout
 run_test "1mb_blob_on_branch" \
   "SELECT length(data) FROM t WHERE id=1;" \
-  "1048576" "$DB"
+  "1048576" "$DB/blobcheck"
 
 # Add more data on branch, merge back
 echo "INSERT INTO t VALUES(2, randomblob(512));
-SELECT dolt_commit('-A','-m','add small blob');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-A','-m','add small blob');" | $DOLTLITE "$DB/blobcheck" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_merge('blobcheck');" | $DOLTLITE "$DB" > /dev/null 2>&1
 

--- a/test/doltlite_working_set.sh
+++ b/test/doltlite_working_set.sh
@@ -47,20 +47,20 @@ run_test "main_committed" \
 echo "SELECT dolt_checkout('feature');
 INSERT INTO t VALUES(3,'c');
 SELECT dolt_add('-A');
-SELECT dolt_commit('-m','feature add');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-m','feature add');" | $DOLTLITE "$DB/feature" > /dev/null 2>&1
 
 run_test "feature_committed" \
   "SELECT count(*) FROM dolt_status;" "0" "$DB"
 
 # Now stage but DON'T commit on feature
 echo "INSERT INTO t VALUES(4,'d');
-SELECT dolt_add('t');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_add('t');" | $DOLTLITE "$DB/feature" > /dev/null 2>&1
 
 run_test "feature_has_staged" \
-  "SELECT count(*) FROM dolt_status WHERE staged=1;" "1" "$DB"
+  "SELECT count(*) FROM dolt_status WHERE staged=1;" "1" "$DB/feature"
 
 # Commit on feature so we can switch
-echo "SELECT dolt_commit('-m','feature staged');" | $DOLTLITE "$DB" > /dev/null 2>&1
+echo "SELECT dolt_commit('-m','feature staged');" | $DOLTLITE "$DB/feature" > /dev/null 2>&1
 
 # Switch back to main — main should be clean
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -73,11 +73,11 @@ echo "SELECT dolt_checkout('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 # Feature was committed clean — should be clean
 run_test "feature_clean_after_switch" \
-  "SELECT count(*) FROM dolt_status;" "0" "$DB"
+  "SELECT count(*) FROM dolt_status;" "0" "$DB/feature"
 
 # Verify data: feature should have rows 1-4
 run_test "feature_data_count" \
-  "SELECT count(*) FROM t;" "4" "$DB"
+  "SELECT count(*) FROM t;" "4" "$DB/feature"
 
 rm -f "$DB"
 
@@ -205,12 +205,12 @@ SELECT dolt_branch('b2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('b1');
 UPDATE t SET val='b1_val' WHERE id=1;
 SELECT dolt_add('-A');
-SELECT dolt_commit('-m','b1 edit');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-m','b1 edit');" | $DOLTLITE "$DB/b1" > /dev/null 2>&1
 
 echo "SELECT dolt_checkout('b2');
 INSERT INTO t VALUES(2,'b2_new');
 SELECT dolt_add('-A');
-SELECT dolt_commit('-m','b2 add');" | $DOLTLITE "$DB" > /dev/null 2>&1
+SELECT dolt_commit('-m','b2 add');" | $DOLTLITE "$DB/b2" > /dev/null 2>&1
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
@@ -221,18 +221,18 @@ run_test "multi_main_count" \
 echo "SELECT dolt_checkout('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "multi_b1_val" \
-  "SELECT val FROM t WHERE id=1;" "b1_val" "$DB"
+  "SELECT val FROM t WHERE id=1;" "b1_val" "$DB/b1"
 
 run_test "multi_b1_count" \
-  "SELECT count(*) FROM t;" "1" "$DB"
+  "SELECT count(*) FROM t;" "1" "$DB/b1"
 
 echo "SELECT dolt_checkout('b2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "multi_b2_count" \
-  "SELECT count(*) FROM t;" "2" "$DB"
+  "SELECT count(*) FROM t;" "2" "$DB/b2"
 
 run_test "multi_b2_new_row" \
-  "SELECT val FROM t WHERE id=2;" "b2_new" "$DB"
+  "SELECT val FROM t WHERE id=2;" "b2_new" "$DB/b2"
 
 rm -f "$DB"
 

--- a/test/oracle_generated_columns_vc_test.sh
+++ b/test/oracle_generated_columns_vc_test.sh
@@ -212,8 +212,7 @@ R3=$(dl "$DB" "SELECT y FROM t WHERE id=3;")
 [ "$R3" = "90" ] && pass_name "h_main_expression" || fail_name "h_main_expression; got $R3"
 
 # Switch to other and check
-dl "$DB" "SELECT dolt_checkout('other');" >/dev/null
-R2=$(dl "$DB" "SELECT y FROM t WHERE id=2;")
+R2=$(dl "$DB/other" "SELECT y FROM t WHERE id=2;")
 [ "$R2" = "60" ] && pass_name "h_other_expression" || fail_name "h_other_expression; got $R2"
 
 # ── I: Convergent merge (both sides same update) ──────────

--- a/test/remote_test.sh
+++ b/test/remote_test.sh
@@ -304,7 +304,7 @@ check "pull with non-first-parent ancestry succeeds" "0
 0
 3" "$result"
 
-result=$("$DB" "$TMPDIR/anc_src.db" "SELECT v FROM t ORDER BY id;")
+result=$("$DB" "$TMPDIR/anc_src.db/side" "SELECT v FROM t ORDER BY id;")
 check "pull with non-first-parent ancestry brings merged rows" "base
 side
 main" "$result"
@@ -445,13 +445,13 @@ ENDSQL
 # Build 10 commits on branchA
 "$DB" "$TMPDIR/div_src.db" "SELECT dolt_checkout('branchA');" > /dev/null
 for i in $(seq 2 11); do
-  "$DB" "$TMPDIR/div_src.db" "INSERT INTO items VALUES($i,'A_$i'); SELECT dolt_add('-A'); SELECT dolt_commit('-m','A step $i');" > /dev/null
+  "$DB" "$TMPDIR/div_src.db/branchA" "INSERT INTO items VALUES($i,'A_$i'); SELECT dolt_add('-A'); SELECT dolt_commit('-m','A step $i');" > /dev/null
 done
 
 # Build 10 different commits on branchB
 "$DB" "$TMPDIR/div_src.db" "SELECT dolt_checkout('branchB');" > /dev/null
 for i in $(seq 100 109); do
-  "$DB" "$TMPDIR/div_src.db" "INSERT INTO items VALUES($i,'B_$i'); SELECT dolt_add('-A'); SELECT dolt_commit('-m','B step $i');" > /dev/null
+  "$DB" "$TMPDIR/div_src.db/branchB" "INSERT INTO items VALUES($i,'B_$i'); SELECT dolt_add('-A'); SELECT dolt_commit('-m','B step $i');" > /dev/null
 done
 
 # Push all three branches
@@ -488,9 +488,9 @@ echo "=== 23. Incremental fetch: push more, fetch only new ==="
 # Add 5 more commits on branchA in source
 "$DB" "$TMPDIR/div_src.db" "SELECT dolt_checkout('branchA');" > /dev/null
 for i in $(seq 12 16); do
-  "$DB" "$TMPDIR/div_src.db" "INSERT INTO items VALUES($i,'A_$i'); SELECT dolt_add('-A'); SELECT dolt_commit('-m','A step $i');" > /dev/null
+  "$DB" "$TMPDIR/div_src.db/branchA" "INSERT INTO items VALUES($i,'A_$i'); SELECT dolt_add('-A'); SELECT dolt_commit('-m','A step $i');" > /dev/null
 done
-"$DB" "$TMPDIR/div_src.db" "SELECT dolt_push('origin','branchA');" > /dev/null
+"$DB" "$TMPDIR/div_src.db/branchA" "SELECT dolt_push('origin','branchA');" > /dev/null
 
 # Fetch in clone (should only transfer 5 new commits, not all)
 result=$("$DB" "$TMPDIR/div_clone.db" "SELECT dolt_fetch('origin','branchA');")
@@ -498,7 +498,7 @@ check "incremental fetch returns 0" "0" "$result"
 
 # Pull to see new data
 "$DB" "$TMPDIR/div_clone.db" "SELECT dolt_checkout('branchA');" > /dev/null
-result=$("$DB" "$TMPDIR/div_clone.db" "SELECT dolt_pull('origin','branchA'); SELECT count(*) FROM items;")
+result=$("$DB" "$TMPDIR/div_clone.db/branchA" "SELECT dolt_pull('origin','branchA'); SELECT count(*) FROM items;")
 check "incremental pull has 16 items" "0
 16" "$result"
 

--- a/test/review_regression_test.sh
+++ b/test/review_regression_test.sh
@@ -162,9 +162,8 @@ INSERT INTO t VALUES(3,'main_again');
 SELECT dolt_commit('-A','-m','main second');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 # Reopen on dev — manifest head is main's latest, not dev's
-echo "SELECT dolt_checkout('dev');" | $DOLTLITE "$DB" > /dev/null 2>&1
-run_test "diverged_dev_count" "SELECT count(*) FROM t;" "2" "$DB"
-run_test "diverged_dev_val" "SELECT v FROM t WHERE id=2;" "from_dev" "$DB"
+run_test "diverged_dev_count" "SELECT count(*) FROM t;" "2" "$DB/dev"
+run_test "diverged_dev_val" "SELECT v FROM t WHERE id=2;" "from_dev" "$DB/dev"
 
 rm -f "$DB"
 

--- a/test/vc_oracle_connection_branch_test.sh
+++ b/test/vc_oracle_connection_branch_test.sh
@@ -69,9 +69,9 @@ CALL dolt_checkout('main');
 SQL
   (
     cd "$dir/dt" &&
+    "$DOLT" config --global --add user.name "CI" >/dev/null &&
+    "$DOLT" config --global --add user.email "ci@example.com" >/dev/null &&
     "$DOLT" init >/dev/null &&
-    "$DOLT" config --local --add user.name "CI" >/dev/null &&
-    "$DOLT" config --local --add user.email "ci@example.com" >/dev/null &&
     "$DOLT" sql <"$dir/setup_dt.sql" >/dev/null 2>"$dir/dt.err"
   )
 }

--- a/test/vc_oracle_connection_branch_test.sh
+++ b/test/vc_oracle_connection_branch_test.sh
@@ -67,7 +67,13 @@ UPDATE t SET v='side' WHERE id=1;
 CALL dolt_commit('-Am', 'side');
 CALL dolt_checkout('main');
 SQL
-  ( cd "$dir/dt" && "$DOLT" init >/dev/null && "$DOLT" sql <"$dir/setup_dt.sql" >/dev/null 2>"$dir/dt.err" )
+  (
+    cd "$dir/dt" &&
+    "$DOLT" init >/dev/null &&
+    "$DOLT" config --local --add user.name "CI" >/dev/null &&
+    "$DOLT" config --local --add user.email "ci@example.com" >/dev/null &&
+    "$DOLT" sql <"$dir/setup_dt.sql" >/dev/null 2>"$dir/dt.err"
+  )
 }
 
 oracle() {

--- a/test/vc_oracle_connection_branch_test.sh
+++ b/test/vc_oracle_connection_branch_test.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+#
+# Oracle test: connection-time branch selection.
+#
+# DoltLite selects a branch from the database path using either:
+#   db.sqlite@branch
+#   db.sqlite/branch
+# and defaults to main when no branch is specified.
+#
+# Dolt exposes the same branch-selection semantics as a global CLI flag:
+#   dolt --branch <branch> sql ...
+#
+# This oracle compares the resulting active_branch() and visible table
+# contents across both engines.
+#
+
+set -u
+set -o pipefail
+
+DOLTLITE="${1:-./doltlite}"
+DOLT="${2:-dolt}"
+TMPROOT=$(mktemp -d)
+trap "rm -rf $TMPROOT" EXIT
+pass=0; fail=0
+FAILED_NAMES=""
+
+run_dl() {
+  local dbspec="$1" query="$2"
+  printf ".headers off\n.mode list\n%s\n" "$query" \
+    | "$DOLTLITE" "$dbspec"
+}
+
+run_dt() {
+  local repo="$1" branch="$2" query="$3"
+  local parent repo_name
+  parent=$(dirname "$repo")
+  repo_name=$(basename "$repo")
+  ( cd "$parent" && "$DOLT" --use-db "$repo_name/$branch" sql -r csv -q "$query" ) \
+    | tail -n +2 | tr -d '"' | tr -d '\r'
+}
+
+setup_pair() {
+  local dir="$1"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  cat >"$dir/setup_dl.sql" <<'SQL'
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'main');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'init');
+SELECT dolt_branch('side');
+SELECT dolt_checkout('side');
+UPDATE t SET v='side' WHERE id=1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'side');
+SELECT dolt_checkout('main');
+SQL
+  "$DOLTLITE" "$dir/dl/db.sqlite" <"$dir/setup_dl.sql" >/dev/null 2>"$dir/dl.err"
+
+  cat >"$dir/setup_dt.sql" <<'SQL'
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'main');
+CALL dolt_commit('-Am', 'init');
+CALL dolt_branch('side');
+CALL dolt_checkout('side');
+UPDATE t SET v='side' WHERE id=1;
+CALL dolt_commit('-Am', 'side');
+CALL dolt_checkout('main');
+SQL
+  ( cd "$dir/dt" && "$DOLT" init >/dev/null && "$DOLT" sql <"$dir/setup_dt.sql" >/dev/null 2>"$dir/dt.err" )
+}
+
+oracle() {
+  local name="$1" dbspec="$2" branch="$3"
+  local dir="$TMPROOT/$name"
+  local q="SELECT active_branch() AS value UNION ALL SELECT v FROM t WHERE id=1;"
+  local dl_out dt_out
+
+  setup_pair "$dir"
+
+  dl_out=$(run_dl "$dbspec" "$q" 2>>"$dir/dl.err" | tr -d '\r')
+  dt_out=$(run_dt "$dir/dt" "$branch" "$q" 2>>"$dir/dt.err")
+
+  if [ "$dl_out" = "$dt_out" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite:"; echo "$dl_out" | sed 's/^/      /'
+    echo "    dolt:";     echo "$dt_out" | sed 's/^/      /'
+  fi
+}
+
+echo "=== Oracle Tests: Connection Branch Selection ==="
+echo ""
+
+oracle "default_open_uses_main" "$TMPROOT/default_open_uses_main/dl/db.sqlite" "main"
+oracle "at_branch_selects_branch" "$TMPROOT/at_branch_selects_branch/dl/db.sqlite@side" "side"
+oracle "slash_branch_selects_branch" "$TMPROOT/slash_branch_selects_branch/dl/db.sqlite/side" "side"
+
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+if [ $fail -gt 0 ]; then
+  echo "Failed:$FAILED_NAMES"
+  exit 1
+fi


### PR DESCRIPTION
Summary:
- select the session branch from the connection target, defaulting to `main`
- support both `db@branch` and `db/branch` connection syntax in the shell
- add direct and Dolt oracle coverage for open-time branch selection

Testing:
- bash test/doltlite_open_branch.sh ./build/doltlite
- bash test/vc_oracle_connection_branch_test.sh ./build/doltlite dolt