### PR TITLE
Invalidate savepoints after replay ops

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -2572,6 +2572,17 @@ static int applyMergedCatalogAndCommit(
                                  sqlite3_strnicmp(zMessage, "Revert", 6)==0
                                    ? "Revert" : "Cherry-pick");
         if( rc!=SQLITE_OK ) goto apply_rollback;
+        while( rc==SQLITE_OK && db->pSavepoint ){
+          char *zSql = sqlite3_mprintf("RELEASE SAVEPOINT \"%w\"",
+                                       db->pSavepoint->zName);
+          if( !zSql ){
+            rc = SQLITE_NOMEM;
+            break;
+          }
+          rc = sqlite3_exec(db, zSql, 0, 0, 0);
+          sqlite3_free(zSql);
+        }
+        if( rc!=SQLITE_OK ) goto apply_rollback;
         doltliteTxnStateClear(&savedState);
       }
       return SQLITE_OK;
@@ -2592,6 +2603,17 @@ static int applyMergedCatalogAndCommit(
                                  sqlite3_strnicmp(zMessage, "Revert", 6)==0
                                    ? "Revert" : "Cherry-pick");
     if( rc!=SQLITE_OK ) goto apply_rollback;
+    while( rc==SQLITE_OK && db->pSavepoint ){
+      char *zSql = sqlite3_mprintf("RELEASE SAVEPOINT \"%w\"",
+                                   db->pSavepoint->zName);
+      if( !zSql ){
+        rc = SQLITE_NOMEM;
+        break;
+      }
+      rc = sqlite3_exec(db, zSql, 0, 0, 0);
+      sqlite3_free(zSql);
+    }
+    if( rc!=SQLITE_OK ) goto apply_rollback;
     doltliteTxnStateClear(&savedState);
     return SQLITE_OK;
   }
@@ -2601,6 +2623,18 @@ static int applyMergedCatalogAndCommit(
   if( rc!=SQLITE_OK ) goto apply_rollback;
 
   rc = doltliteAdvanceBranch(db, &commitHash, &mergedCatHash);
+  if( rc!=SQLITE_OK ) goto apply_rollback;
+
+  while( rc==SQLITE_OK && db->pSavepoint ){
+    char *zSql = sqlite3_mprintf("RELEASE SAVEPOINT \"%w\"",
+                                 db->pSavepoint->zName);
+    if( !zSql ){
+      rc = SQLITE_NOMEM;
+      break;
+    }
+    rc = sqlite3_exec(db, zSql, 0, 0, 0);
+    sqlite3_free(zSql);
+  }
   if( rc!=SQLITE_OK ) goto apply_rollback;
 
   if( graphLocked ){

--- a/test/doltlite_savepoint.sh
+++ b/test/doltlite_savepoint.sh
@@ -288,6 +288,30 @@ run_test_match "checkout_b_savepoint_branch_created" \
   "SELECT group_concat(name, ',') FROM dolt_branches;" \
   "^main,side$|^side,main$" "$DB6i"
 
+DB6j=/tmp/test_savepoint6j_$$.db; rm -f "$DB6j"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'main'); SELECT dolt_commit('-A','-m','init'); SELECT dolt_branch('feat'); SELECT dolt_checkout('feat'); INSERT INTO t VALUES(2,'feat'); SELECT dolt_commit('-A','-m','feat'); SELECT dolt_checkout('main');" | $DOLTLITE "$DB6j" > /dev/null 2>&1
+run_test_match "cherry_pick_savepoint_rollback_to_errors" \
+  "SAVEPOINT sp1; SELECT dolt_cherry_pick('feat'); ROLLBACK TO sp1;" \
+  "no such savepoint: sp1" "$DB6j"
+run_test_match "cherry_pick_savepoint_rows_persist" \
+  "SELECT group_concat(id || ':' || v, ',') FROM (SELECT id, v FROM t ORDER BY id) AS ordered;" \
+  "^1:main,2:feat$" "$DB6j"
+run_test_match "cherry_pick_savepoint_log_persists" \
+  "SELECT count(*) FROM dolt_log;" \
+  "^3$" "$DB6j"
+
+DB6k=/tmp/test_savepoint6k_$$.db; rm -f "$DB6k"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','c1'); UPDATE t SET v='c2' WHERE id=1; SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB6k" > /dev/null 2>&1
+run_test_match "revert_savepoint_rollback_to_errors" \
+  "SAVEPOINT sp1; SELECT dolt_revert('HEAD'); ROLLBACK TO sp1;" \
+  "no such savepoint: sp1" "$DB6k"
+run_test_match "revert_savepoint_rows_persist" \
+  "SELECT group_concat(id || ':' || v, ',') FROM (SELECT id, v FROM t ORDER BY id) AS ordered;" \
+  "^1:base$" "$DB6k"
+run_test_match "revert_savepoint_log_persists" \
+  "SELECT count(*) FROM dolt_log;" \
+  "^4$" "$DB6k"
+
 # ============================================================
 # Test 7: dolt_merge inside a BEGIN/COMMIT block
 # Expected: dolt_merge operates at the dolt storage layer. It should

--- a/test/vc_oracle_revert_cherrypick_test.sh
+++ b/test/vc_oracle_revert_cherrypick_test.sh
@@ -607,6 +607,39 @@ SELECT dolt_revert('HEAD~1');
 " "SELECT (SELECT count(*) FROM dolt_constraint_violations) || '|' || (SELECT group_concat(id || ':' || u || ':' || v, ',') FROM (SELECT id,u,v FROM t ORDER BY id) AS ordered_rows)" \
 "SELECT CONCAT((SELECT COUNT(*) FROM dolt_constraint_violations), '|', (SELECT GROUP_CONCAT(CONCAT(id, ':', u, ':', v) ORDER BY id SEPARATOR ',') FROM t))"
 
+echo "--- savepoint parity ---"
+
+oracle_error_poststate "cherry_pick_savepoint_invalidated" "
+$SEED
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat_add_2');
+SELECT dolt_checkout('main');
+SAVEPOINT sp1;
+SELECT dolt_cherry_pick('feature');
+ROLLBACK TO sp1;
+" "SELECT active_branch() || '|' ||
+          (SELECT group_concat(id || ':' || v, ',') FROM (SELECT id, v FROM t ORDER BY id) AS ordered) || '|' ||
+          (SELECT count(*) FROM dolt_log);" \
+  "SELECT CONCAT(active_branch(), '|', (SELECT GROUP_CONCAT(CONCAT(id, ':', v) ORDER BY id SEPARATOR ',') FROM t), '|', (SELECT COUNT(*) FROM dolt_log))"
+
+oracle_error_poststate "revert_savepoint_invalidated" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+UPDATE t SET v = 20 WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2');
+SAVEPOINT sp1;
+SELECT dolt_revert('HEAD');
+ROLLBACK TO sp1;
+" "SELECT active_branch() || '|' ||
+          (SELECT group_concat(id || ':' || v, ',') FROM (SELECT id, v FROM t ORDER BY id) AS ordered) || '|' ||
+          (SELECT count(*) FROM dolt_log);" \
+  "SELECT CONCAT(active_branch(), '|', (SELECT GROUP_CONCAT(CONCAT(id, ':', v) ORDER BY id SEPARATOR ',') FROM t), '|', (SELECT COUNT(*) FROM dolt_log))"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then


### PR DESCRIPTION
## Summary
- release active savepoints after successful cherry-pick and revert operations
- add local savepoint regressions for replay operations
- add Dolt oracle coverage for replay savepoint invalidation parity

## Testing
- cd build && bash ../test/doltlite_savepoint.sh
- bash test/vc_oracle_revert_cherrypick_test.sh ./build/doltlite dolt