### PR TITLE
Fix merge savepoint parity

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -483,6 +483,10 @@ static int doltliteMergeActsAutocommitLike(sqlite3 *db){
   return db->autoCommit || doltliteSavepointIsTopLevelTxn(db);
 }
 
+static int doltliteHasNestedSavepoint(sqlite3 *db){
+  return db->pSavepoint!=0 && !doltliteSavepointIsTopLevelTxn(db);
+}
+
 static int doltliteReleaseActiveSavepoints(sqlite3 *db){
   int rc = SQLITE_OK;
   while( rc==SQLITE_OK && db->pSavepoint ){
@@ -2379,12 +2383,18 @@ static void doltliteMergeFunc(
             "Committing this transaction resulted in a working set with "
             "constraint violations, transaction rolled back.", -1);
         }
+      }else if( doltliteHasNestedSavepoint(db) ){
+        rc = doltliteRestoreTxnStateOnFailure(db, &savedState, SQLITE_OK);
+        if( rc!=SQLITE_OK ){
+          sqlite3_result_error_code(context, rc);
+        }else{
+          sqlite3_result_error(context,
+            "Merge resulted in constraint violations. Resolve the rows in "
+            "dolt_constraint_violations and then commit with dolt_commit.",
+            -1);
+        }
       }else{
-        sqlite3_result_error(context,
-          "Merge resulted in constraint violations. Resolve the rows in "
-          "dolt_constraint_violations and then commit with dolt_commit.",
-          -1);
-        rc = SQLITE_OK;
+        rc = doltliteReportConstraintViolations(db, context, "Merge");
         if( rc!=SQLITE_OK ){
           sqlite3_result_error_code(context,
               doltliteRestoreTxnStateOnFailure(db, &savedState, rc));
@@ -2408,14 +2418,20 @@ static void doltliteMergeFunc(
       }
       return;
     }
-    rc = doltliteRegisterConflictTables(db);
-    if( rc==SQLITE_OK ){
-      char msg[256];
-      sqlite3_snprintf(sizeof(msg), msg,
-        "Merge has %d conflict(s). Resolve and then commit with dolt_commit.",
-        nMergeConflicts);
-      sqlite3_result_error(context, msg, -1);
+    if( doltliteHasNestedSavepoint(db) ){
+      rc = doltliteRestoreTxnStateOnFailure(db, &savedState, SQLITE_OK);
+      if( rc!=SQLITE_OK ){
+        sqlite3_result_error_code(context, rc);
+      }else{
+        char msg[256];
+        sqlite3_snprintf(sizeof(msg), msg,
+          "Merge has %d conflict(s). Resolve and then commit with dolt_commit.",
+          nMergeConflicts);
+        sqlite3_result_error(context, msg, -1);
+      }
+      return;
     }
+    rc = doltliteReportConflicts(db, context, nMergeConflicts, "Merge");
     if( rc!=SQLITE_OK ){
       sqlite3_result_error_code(context,
           doltliteRestoreTxnStateOnFailure(db, &savedState, rc));

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -475,6 +475,25 @@ static int doltliteReportConstraintViolations(
   return SQLITE_OK;
 }
 
+static int doltliteSavepointIsTopLevelTxn(sqlite3 *db){
+  return db->pSavepoint!=0 && db->isTransactionSavepoint && db->nSavepoint==0;
+}
+
+static int doltliteMergeActsAutocommitLike(sqlite3 *db){
+  return db->autoCommit || doltliteSavepointIsTopLevelTxn(db);
+}
+
+static int doltliteReleaseActiveSavepoints(sqlite3 *db){
+  int rc = SQLITE_OK;
+  while( rc==SQLITE_OK && db->pSavepoint ){
+    char *zSql = sqlite3_mprintf("RELEASE SAVEPOINT \"%w\"", db->pSavepoint->zName);
+    if( !zSql ) return SQLITE_NOMEM;
+    rc = sqlite3_exec(db, zSql, 0, 0, 0);
+    sqlite3_free(zSql);
+  }
+  return rc;
+}
+
 static void doltliteReportAutocommitConflictRollback(sqlite3_context *ctx){
   sqlite3_result_error(ctx,
     "Merge conflict detected, @autocommit transaction rolled back. "
@@ -1582,11 +1601,13 @@ static int mergeAbortInPlace(sqlite3 *db){
   doltliteClearSessionMergeState(db);
   {
     extern int doltliteClearAllConstraintViolations(sqlite3*);
-    if( doltliteSessionHasConstraintViolations(db) ){
+  if( doltliteSessionHasConstraintViolations(db) ){
       doltliteClearAllConstraintViolations(db);
     }
   }
-  return doltlitePersistWorkingSet(db);
+  rc = doltlitePersistWorkingSet(db);
+  if( rc!=SQLITE_OK ) return rc;
+  return doltliteReleaseActiveSavepoints(db);
 }
 
 static int mergeFastForward(
@@ -1645,6 +1666,12 @@ static int mergeFastForward(
     doltliteCommitClear(&theirCommit);
     sqlite3_result_error_code(context,
         doltliteRestoreTxnStateOnFailure(db, &savedState, rc));
+    return rc;
+  }
+  rc = doltliteReleaseActiveSavepoints(db);
+  if( rc!=SQLITE_OK ){
+    doltliteCommitClear(&theirCommit);
+    sqlite3_result_error_code(context, rc);
     return rc;
   }
   doltliteTxnStateClear(&savedState);
@@ -2331,7 +2358,7 @@ static void doltliteMergeFunc(
     }
     sqlite3_free(zDetectErrMsg);
     if( nViolations + nUnique + nCheck > 0 ){
-      if( db->autoCommit ){
+      if( doltliteMergeActsAutocommitLike(db) ){
         rc = doltliteHardReset(db, &savedState.sessionCatalogHash);
         if( rc==SQLITE_OK ){
           doltliteSetSessionBranch(db, savedState.zSessionBranch);
@@ -2353,7 +2380,11 @@ static void doltliteMergeFunc(
             "constraint violations, transaction rolled back.", -1);
         }
       }else{
-        rc = doltliteReportConstraintViolations(db, context, "Merge");
+        sqlite3_result_error(context,
+          "Merge resulted in constraint violations. Resolve the rows in "
+          "dolt_constraint_violations and then commit with dolt_commit.",
+          -1);
+        rc = SQLITE_OK;
         if( rc!=SQLITE_OK ){
           sqlite3_result_error_code(context,
               doltliteRestoreTxnStateOnFailure(db, &savedState, rc));
@@ -2370,14 +2401,21 @@ static void doltliteMergeFunc(
       chunkStoreUnlock(cs);
       graphLocked = 0;
     }
-    if( db->autoCommit ){
+    if( doltliteMergeActsAutocommitLike(db) ){
       rc = doltliteRollbackAutocommitConflict(db, context, &savedState);
       if( rc!=SQLITE_OK ){
         sqlite3_result_error_code(context, rc);
       }
       return;
     }
-    rc = doltliteReportConflicts(db, context, nMergeConflicts, "Merge");
+    rc = doltliteRegisterConflictTables(db);
+    if( rc==SQLITE_OK ){
+      char msg[256];
+      sqlite3_snprintf(sizeof(msg), msg,
+        "Merge has %d conflict(s). Resolve and then commit with dolt_commit.",
+        nMergeConflicts);
+      sqlite3_result_error(context, msg, -1);
+    }
     if( rc!=SQLITE_OK ){
       sqlite3_result_error_code(context,
           doltliteRestoreTxnStateOnFailure(db, &savedState, rc));
@@ -2412,6 +2450,11 @@ static void doltliteMergeFunc(
     if( rc!=SQLITE_OK ){
       sqlite3_result_error_code(context,
           doltliteRestoreTxnStateOnFailure(db, &savedState, rc));
+      return;
+    }
+    rc = doltliteReleaseActiveSavepoints(db);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(context, rc);
       return;
     }
     doltliteTxnStateClear(&savedState);

--- a/test/doltlite_savepoint.sh
+++ b/test/doltlite_savepoint.sh
@@ -240,6 +240,37 @@ run_test "merge_in_txn_log" \
   "SELECT message FROM dolt_log LIMIT 1;" \
   "feature work" "$DB7"
 
+DB7b=/tmp/test_savepoint7b_$$.db; rm -f "$DB7b"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','base'); SELECT dolt_branch('feat'); SELECT dolt_checkout('feat'); INSERT INTO t VALUES(2,'feat'); SELECT dolt_commit('-A','-m','feat'); SELECT dolt_checkout('main');" | $DOLTLITE "$DB7b" > /dev/null 2>&1
+run_test_match "merge_savepoint_success_rollback_to_errors" \
+  "SAVEPOINT sp1; SELECT dolt_merge('feat'); ROLLBACK TO sp1;" \
+  "no such savepoint: sp1" "$DB7b"
+run_test "merge_savepoint_success_rows_persist" \
+  "SELECT count(*) FROM t;" \
+  "2" "$DB7b"
+run_test "merge_savepoint_success_log_persists" \
+  "SELECT count(*) FROM dolt_log;" \
+  "3" "$DB7b"
+
+DB7c=/tmp/test_savepoint7c_$$.db; rm -f "$DB7c"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','base'); SELECT dolt_branch('feat'); SELECT dolt_checkout('feat'); UPDATE t SET v='feat' WHERE id=1; SELECT dolt_commit('-A','-m','feat'); SELECT dolt_checkout('main'); UPDATE t SET v='main' WHERE id=1; SELECT dolt_commit('-A','-m','main');" | $DOLTLITE "$DB7c" > /dev/null 2>&1
+run_test_match "merge_abort_savepoint_rollback_to_errors" \
+  "BEGIN; SELECT dolt_merge('feat'); SAVEPOINT sp1; SELECT dolt_merge('--abort'); ROLLBACK TO sp1;" \
+  "no such savepoint: sp1" "$DB7c"
+run_test "merge_abort_savepoint_clears_conflicts" \
+  "SELECT count(*) FROM dolt_conflicts;" \
+  "0" "$DB7c"
+run_test "merge_abort_savepoint_restores_rows" \
+  "SELECT v FROM t WHERE id=1;" \
+  "main" "$DB7c"
+
+DB7d=/tmp/test_savepoint7d_$$.db; rm -f "$DB7d"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','base'); SELECT dolt_branch('feat'); SELECT dolt_checkout('feat'); UPDATE t SET v='feat' WHERE id=1; SELECT dolt_commit('-A','-m','feat'); SELECT dolt_checkout('main'); UPDATE t SET v='main' WHERE id=1; SELECT dolt_commit('-A','-m','main');" | $DOLTLITE "$DB7d" > /dev/null 2>&1
+run_test_match "merge_conflict_nested_savepoint_allows_rollback" \
+  "BEGIN; SAVEPOINT sp1; SELECT dolt_merge('feat'); ROLLBACK TO sp1; SELECT count(*) FROM dolt_conflicts; SELECT v FROM t WHERE id=1;" \
+  "0
+main$" "$DB7d"
+
 # ============================================================
 # Test 8: ROLLBACK after dolt_branch — does the branch creation persist?
 # Expected: dolt_branch creates a branch at the storage layer.

--- a/test/vc_oracle_merge_test.sh
+++ b/test/vc_oracle_merge_test.sh
@@ -202,6 +202,46 @@ oracle_error_poststate() {
   fi
 }
 
+oracle_same_session() {
+  local name="$1" setup="$2" dl_query="$3" dolt_query="${4:-$3}"
+  local dir="$TMPROOT/${name}_ss"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_out
+  dl_out=$(
+    {
+      printf "%s\n.headers off\n.mode list\n.separator '\t'\n%s\n" "$setup" "$dl_query"
+    } | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
+      | tr -d '\r' \
+      | awk -F'\t' '$1=="Q"{print}'
+  )
+
+  local dolt_setup
+  dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
+  local dt_out
+  dt_out=$(
+    cd "$dir/dt" || exit 1
+    vc_oracle_init_repo
+    {
+      printf "%s\n" "$dolt_setup"
+      printf "%s\n" "$dolt_query"
+    } | "$DOLT" sql -c -r csv 2>"$dir/dt.err" \
+      | tail -n +2 \
+      | tr -d '"\r' \
+      | awk -F'\t' '$1=="Q"{print}'
+  )
+
+  if [ "$dl_out" = "$dt_out" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite: |$dl_out|"
+    echo "    dolt:     |$dt_out|"
+  fi
+}
+
 echo "=== Version Control Oracle Tests: dolt_merge ==="
 echo ""
 
@@ -404,6 +444,70 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feature');
 " "SELECT (SELECT count(*) FROM dolt_conflicts) || '|' || (SELECT group_concat(id || ':' || v, ',') FROM (SELECT id, v FROM t ORDER BY id) AS ordered_rows)" \
 "SELECT CONCAT((SELECT COUNT(*) FROM dolt_conflicts), '|', (SELECT GROUP_CONCAT(CONCAT(id, ':', v) ORDER BY id SEPARATOR ',') FROM t))"
+
+echo "--- savepoint parity ---"
+
+oracle_same_session "merge_savepoint_success_invalidated" "
+$SEED
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat1');
+SELECT dolt_checkout('main');
+SAVEPOINT sp1;
+SELECT dolt_merge('feature');
+ROLLBACK TO sp1;
+" "SELECT 'Q' || char(9) || count(*) FROM t;
+SELECT 'Q' || char(9) || count(*) FROM dolt_log;" \
+"SELECT concat('Q', char(9), count(*)) FROM t;
+SELECT concat('Q', char(9), count(*)) FROM dolt_log;"
+
+oracle_same_session "merge_abort_savepoint_invalidated" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'base');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'base');
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+UPDATE t SET v = 'feat' WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat');
+SELECT dolt_checkout('main');
+UPDATE t SET v = 'main' WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main');
+BEGIN;
+SELECT dolt_merge('feature');
+SAVEPOINT sp1;
+SELECT dolt_merge('--abort');
+ROLLBACK TO sp1;
+" "SELECT 'Q' || char(9) || (SELECT count(*) FROM dolt_conflicts);
+SELECT 'Q' || char(9) || (SELECT v FROM t WHERE id = 1);" \
+"SELECT concat('Q', char(9), (SELECT count(*) FROM dolt_conflicts));
+SELECT concat('Q', char(9), (SELECT v FROM t WHERE id = 1));"
+
+oracle_same_session "merge_conflict_nested_savepoint_rollback" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'base');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'base');
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+UPDATE t SET v = 'feat' WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat');
+SELECT dolt_checkout('main');
+UPDATE t SET v = 'main' WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main');
+BEGIN;
+SAVEPOINT sp1;
+SELECT dolt_merge('feature');
+ROLLBACK TO sp1;
+" "SELECT 'Q' || char(9) || (SELECT count(*) FROM dolt_conflicts);
+SELECT 'Q' || char(9) || (SELECT v FROM t WHERE id = 1);" \
+"SELECT concat('Q', char(9), (SELECT count(*) FROM dolt_conflicts));
+SELECT concat('Q', char(9), (SELECT v FROM t WHERE id = 1));"
 
 echo "--- already up to date ---"
 


### PR DESCRIPTION
## Summary
- make successful merge and merge --abort invalidate active savepoints like Dolt
- treat top-level savepoints like autocommit for conflicted merges
- preserve nested savepoint rollback semantics for conflicted merges inside explicit transactions

## Testing
- cd build && bash ../test/doltlite_savepoint.sh
- bash test/vc_oracle_merge_test.sh ./build/doltlite dolt