### PR TITLE
Centralize VC transaction policy helpers

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -479,15 +479,17 @@ static int doltliteSavepointIsTopLevelTxn(sqlite3 *db){
   return db->pSavepoint!=0 && db->isTransactionSavepoint && db->nSavepoint==0;
 }
 
-static int doltliteMergeActsAutocommitLike(sqlite3 *db){
-  return db->autoCommit || doltliteSavepointIsTopLevelTxn(db);
+DoltliteVcTxnMode doltliteVcTxnMode(sqlite3 *db){
+  if( db->autoCommit || doltliteSavepointIsTopLevelTxn(db) ){
+    return DOLTLITE_VC_TXN_AUTOCOMMIT_LIKE;
+  }
+  if( db->pSavepoint ){
+    return DOLTLITE_VC_TXN_NESTED_SAVEPOINT;
+  }
+  return DOLTLITE_VC_TXN_PLAIN;
 }
 
-static int doltliteHasNestedSavepoint(sqlite3 *db){
-  return db->pSavepoint!=0 && !doltliteSavepointIsTopLevelTxn(db);
-}
-
-static int doltliteReleaseActiveSavepoints(sqlite3 *db){
+int doltliteVcSealActiveSavepoints(sqlite3 *db){
   int rc = SQLITE_OK;
   while( rc==SQLITE_OK && db->pSavepoint ){
     char *zSql = sqlite3_mprintf("RELEASE SAVEPOINT \"%w\"", db->pSavepoint->zName);
@@ -496,6 +498,17 @@ static int doltliteReleaseActiveSavepoints(sqlite3 *db){
     sqlite3_free(zSql);
   }
   return rc;
+}
+
+int doltliteVcSealBranchStyleTxn(sqlite3 *db){
+  int rc;
+  if( db->autoCommit ) return SQLITE_OK;
+  if( db->pSavepoint ){
+    return doltliteVcSealActiveSavepoints(db);
+  }
+  rc = sqlite3_exec(db, "COMMIT", 0, 0, 0);
+  if( rc!=SQLITE_OK ) return rc;
+  return sqlite3_exec(db, "BEGIN", 0, 0, 0);
 }
 
 static void doltliteReportAutocommitConflictRollback(sqlite3_context *ctx){
@@ -1611,7 +1624,7 @@ static int mergeAbortInPlace(sqlite3 *db){
   }
   rc = doltlitePersistWorkingSet(db);
   if( rc!=SQLITE_OK ) return rc;
-  return doltliteReleaseActiveSavepoints(db);
+  return doltliteVcSealActiveSavepoints(db);
 }
 
 static int mergeFastForward(
@@ -1672,7 +1685,7 @@ static int mergeFastForward(
         doltliteRestoreTxnStateOnFailure(db, &savedState, rc));
     return rc;
   }
-  rc = doltliteReleaseActiveSavepoints(db);
+  rc = doltliteVcSealActiveSavepoints(db);
   if( rc!=SQLITE_OK ){
     doltliteCommitClear(&theirCommit);
     sqlite3_result_error_code(context, rc);
@@ -2362,7 +2375,8 @@ static void doltliteMergeFunc(
     }
     sqlite3_free(zDetectErrMsg);
     if( nViolations + nUnique + nCheck > 0 ){
-      if( doltliteMergeActsAutocommitLike(db) ){
+      switch( doltliteVcTxnMode(db) ){
+      case DOLTLITE_VC_TXN_AUTOCOMMIT_LIKE:
         rc = doltliteHardReset(db, &savedState.sessionCatalogHash);
         if( rc==SQLITE_OK ){
           doltliteSetSessionBranch(db, savedState.zSessionBranch);
@@ -2383,7 +2397,8 @@ static void doltliteMergeFunc(
             "Committing this transaction resulted in a working set with "
             "constraint violations, transaction rolled back.", -1);
         }
-      }else if( doltliteHasNestedSavepoint(db) ){
+        break;
+      case DOLTLITE_VC_TXN_NESTED_SAVEPOINT:
         rc = doltliteRestoreTxnStateOnFailure(db, &savedState, SQLITE_OK);
         if( rc!=SQLITE_OK ){
           sqlite3_result_error_code(context, rc);
@@ -2393,7 +2408,8 @@ static void doltliteMergeFunc(
             "dolt_constraint_violations and then commit with dolt_commit.",
             -1);
         }
-      }else{
+        break;
+      case DOLTLITE_VC_TXN_PLAIN:
         rc = doltliteReportConstraintViolations(db, context, "Merge");
         if( rc!=SQLITE_OK ){
           sqlite3_result_error_code(context,
@@ -2401,6 +2417,7 @@ static void doltliteMergeFunc(
           return;
         }
         doltliteTxnStateClear(&savedState);
+        break;
       }
       return;
     }
@@ -2411,14 +2428,14 @@ static void doltliteMergeFunc(
       chunkStoreUnlock(cs);
       graphLocked = 0;
     }
-    if( doltliteMergeActsAutocommitLike(db) ){
+    switch( doltliteVcTxnMode(db) ){
+    case DOLTLITE_VC_TXN_AUTOCOMMIT_LIKE:
       rc = doltliteRollbackAutocommitConflict(db, context, &savedState);
       if( rc!=SQLITE_OK ){
         sqlite3_result_error_code(context, rc);
       }
       return;
-    }
-    if( doltliteHasNestedSavepoint(db) ){
+    case DOLTLITE_VC_TXN_NESTED_SAVEPOINT:
       rc = doltliteRestoreTxnStateOnFailure(db, &savedState, SQLITE_OK);
       if( rc!=SQLITE_OK ){
         sqlite3_result_error_code(context, rc);
@@ -2430,14 +2447,16 @@ static void doltliteMergeFunc(
         sqlite3_result_error(context, msg, -1);
       }
       return;
+    case DOLTLITE_VC_TXN_PLAIN:
+      rc = doltliteReportConflicts(db, context, nMergeConflicts, "Merge");
+      if( rc!=SQLITE_OK ){
+        sqlite3_result_error_code(context,
+            doltliteRestoreTxnStateOnFailure(db, &savedState, rc));
+        return;
+      }
+      doltliteTxnStateClear(&savedState);
+      break;
     }
-    rc = doltliteReportConflicts(db, context, nMergeConflicts, "Merge");
-    if( rc!=SQLITE_OK ){
-      sqlite3_result_error_code(context,
-          doltliteRestoreTxnStateOnFailure(db, &savedState, rc));
-      return;
-    }
-    doltliteTxnStateClear(&savedState);
   }else{
     ProllyHash commitHash;
     char hexBuf[PROLLY_HASH_SIZE*2+1];
@@ -2468,7 +2487,7 @@ static void doltliteMergeFunc(
           doltliteRestoreTxnStateOnFailure(db, &savedState, rc));
       return;
     }
-    rc = doltliteReleaseActiveSavepoints(db);
+    rc = doltliteVcSealActiveSavepoints(db);
     if( rc!=SQLITE_OK ){
       sqlite3_result_error_code(context, rc);
       return;
@@ -2604,7 +2623,8 @@ static int applyMergedCatalogAndCommit(
     sqlite3_free(zDetectErrMsg);
 
     if( nViolations + nUnique + nCheck > 0 ){
-      if( db->autoCommit ){
+      switch( doltliteVcTxnMode(db) ){
+      case DOLTLITE_VC_TXN_AUTOCOMMIT_LIKE:
         rc = doltliteHardReset(db, &savedState.sessionCatalogHash);
         if( rc==SQLITE_OK ){
           doltliteSetSessionBranch(db, savedState.zSessionBranch);
@@ -2626,23 +2646,24 @@ static int applyMergedCatalogAndCommit(
         sqlite3_result_error(context,
           "Committing this transaction resulted in a working set with "
           "constraint violations, transaction rolled back.", -1);
-      }else{
+        break;
+      case DOLTLITE_VC_TXN_PLAIN:
         rc = doltliteReportConstraintViolations(db, context,
                                  sqlite3_strnicmp(zMessage, "Revert", 6)==0
                                    ? "Revert" : "Cherry-pick");
         if( rc!=SQLITE_OK ) goto apply_rollback;
-        while( rc==SQLITE_OK && db->pSavepoint ){
-          char *zSql = sqlite3_mprintf("RELEASE SAVEPOINT \"%w\"",
-                                       db->pSavepoint->zName);
-          if( !zSql ){
-            rc = SQLITE_NOMEM;
-            break;
-          }
-          rc = sqlite3_exec(db, zSql, 0, 0, 0);
-          sqlite3_free(zSql);
-        }
+        rc = doltliteVcSealActiveSavepoints(db);
         if( rc!=SQLITE_OK ) goto apply_rollback;
         doltliteTxnStateClear(&savedState);
+        break;
+      case DOLTLITE_VC_TXN_NESTED_SAVEPOINT:
+        rc = doltliteRestoreTxnStateOnFailure(db, &savedState, SQLITE_OK);
+        if( rc!=SQLITE_OK ) return rc;
+        sqlite3_result_error(context,
+          "Merge resulted in constraint violations. Resolve the rows in "
+          "dolt_constraint_violations and then commit with dolt_commit.",
+          -1);
+        break;
       }
       return SQLITE_OK;
     }
@@ -2653,28 +2674,33 @@ static int applyMergedCatalogAndCommit(
       chunkStoreUnlock(cs);
       graphLocked = 0;
     }
-    if( db->autoCommit ){
+    switch( doltliteVcTxnMode(db) ){
+    case DOLTLITE_VC_TXN_AUTOCOMMIT_LIKE:
       rc = doltliteRollbackAutocommitConflict(db, context, &savedState);
       if( rc!=SQLITE_OK ) return rc;
       return SQLITE_OK;
-    }
-    rc = doltliteReportConflicts(db, context, *pnConflicts,
-                                 sqlite3_strnicmp(zMessage, "Revert", 6)==0
-                                   ? "Revert" : "Cherry-pick");
-    if( rc!=SQLITE_OK ) goto apply_rollback;
-    while( rc==SQLITE_OK && db->pSavepoint ){
-      char *zSql = sqlite3_mprintf("RELEASE SAVEPOINT \"%w\"",
-                                   db->pSavepoint->zName);
-      if( !zSql ){
-        rc = SQLITE_NOMEM;
-        break;
+    case DOLTLITE_VC_TXN_PLAIN:
+      rc = doltliteReportConflicts(db, context, *pnConflicts,
+                                   sqlite3_strnicmp(zMessage, "Revert", 6)==0
+                                     ? "Revert" : "Cherry-pick");
+      if( rc!=SQLITE_OK ) goto apply_rollback;
+      rc = doltliteVcSealActiveSavepoints(db);
+      if( rc!=SQLITE_OK ) goto apply_rollback;
+      doltliteTxnStateClear(&savedState);
+      return SQLITE_OK;
+    case DOLTLITE_VC_TXN_NESTED_SAVEPOINT:
+      rc = doltliteRestoreTxnStateOnFailure(db, &savedState, SQLITE_OK);
+      if( rc!=SQLITE_OK ) return rc;
+      {
+        char msg[256];
+        sqlite3_snprintf(sizeof(msg), msg,
+          "%s has %d conflict(s). Resolve and then commit with dolt_commit.",
+          sqlite3_strnicmp(zMessage, "Revert", 6)==0 ? "Revert" : "Cherry-pick",
+          *pnConflicts);
+        sqlite3_result_error(context, msg, -1);
       }
-      rc = sqlite3_exec(db, zSql, 0, 0, 0);
-      sqlite3_free(zSql);
+      return SQLITE_OK;
     }
-    if( rc!=SQLITE_OK ) goto apply_rollback;
-    doltliteTxnStateClear(&savedState);
-    return SQLITE_OK;
   }
 
   rc = doltliteCreateAndStoreCommit(db, ourHead, &mergedCatHash,
@@ -2684,16 +2710,7 @@ static int applyMergedCatalogAndCommit(
   rc = doltliteAdvanceBranch(db, &commitHash, &mergedCatHash);
   if( rc!=SQLITE_OK ) goto apply_rollback;
 
-  while( rc==SQLITE_OK && db->pSavepoint ){
-    char *zSql = sqlite3_mprintf("RELEASE SAVEPOINT \"%w\"",
-                                 db->pSavepoint->zName);
-    if( !zSql ){
-      rc = SQLITE_NOMEM;
-      break;
-    }
-    rc = sqlite3_exec(db, zSql, 0, 0, 0);
-    sqlite3_free(zSql);
-  }
+  rc = doltliteVcSealActiveSavepoints(db);
   if( rc!=SQLITE_OK ) goto apply_rollback;
 
   if( graphLocked ){

--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -43,25 +43,6 @@ static void branchResultError(
   }
 }
 
-static int branchRestartTxnIfNeeded(sqlite3 *db){
-  int rc;
-  if( db->autoCommit ) return SQLITE_OK;
-  if( db->pSavepoint ){
-    while( db->pSavepoint ){
-      char *zSql = sqlite3_mprintf("RELEASE SAVEPOINT \"%w\"", db->pSavepoint->zName);
-      if( !zSql ) return SQLITE_NOMEM;
-      rc = sqlite3_exec(db, zSql, 0, 0, 0);
-      sqlite3_free(zSql);
-      if( rc!=SQLITE_OK ) return rc;
-    }
-    return SQLITE_OK;
-  }
-  rc = sqlite3_exec(db, "COMMIT", 0, 0, 0);
-  if( rc!=SQLITE_OK ) return rc;
-  rc = sqlite3_exec(db, "BEGIN", 0, 0, 0);
-  return rc;
-}
-
 static int mutateBranchRef(sqlite3 *db, ChunkStore *cs, void *pArg){
   BranchMutationCtx *p = (BranchMutationCtx*)pArg;
   int rc;
@@ -352,7 +333,7 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
   }
 
   if( hadExplicitTxn ){
-    rc = branchRestartTxnIfNeeded(db);
+    rc = doltliteVcSealBranchStyleTxn(db);
     if( rc!=SQLITE_OK ){
       sqlite3_result_error_code(ctx, rc);
       return;
@@ -739,7 +720,7 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
       return;
     }
     if( hadExplicitTxn ){
-      rc = branchRestartTxnIfNeeded(db);
+      rc = doltliteVcSealBranchStyleTxn(db);
       if( rc!=SQLITE_OK ){
         sqlite3_result_error_code(ctx, rc);
         return;
@@ -821,7 +802,7 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
     return;
   }
   if( hadExplicitTxn ){
-    rc = branchRestartTxnIfNeeded(db);
+    rc = doltliteVcSealBranchStyleTxn(db);
     if( rc!=SQLITE_OK ){
       sqlite3_result_error_code(ctx, rc);
       return;

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -9,6 +9,13 @@
 typedef struct BtShared BtShared;
 typedef struct ProllyCache ProllyCache;
 
+typedef enum DoltliteVcTxnMode DoltliteVcTxnMode;
+enum DoltliteVcTxnMode {
+  DOLTLITE_VC_TXN_PLAIN = 0,
+  DOLTLITE_VC_TXN_AUTOCOMMIT_LIKE = 1,
+  DOLTLITE_VC_TXN_NESTED_SAVEPOINT = 2
+};
+
 /* iTable is the rowid-alias of the table in sqlite_master and
 ** survives renames (used by dolt_status to detect renames as same
 ** iTable + different name). pPending is the in-memory ProllyMutMap
@@ -154,6 +161,9 @@ int doltliteGetSessionTableRoot(sqlite3 *db, Pgno iTable,
 int doltliteSaveWorkingSet(sqlite3 *db);
 int doltlitePersistWorkingSet(sqlite3 *db);
 int doltliteLoadWorkingSet(sqlite3 *db, const char *zBranch);
+DoltliteVcTxnMode doltliteVcTxnMode(sqlite3 *db);
+int doltliteVcSealActiveSavepoints(sqlite3 *db);
+int doltliteVcSealBranchStyleTxn(sqlite3 *db);
 
 typedef int (*DoltliteRefsMutation)(sqlite3 *db, ChunkStore *cs, void *pArg);
 int doltliteMutateRefs(sqlite3 *db, DoltliteRefsMutation xMutate, void *pArg);

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -117,17 +117,6 @@ static void remoteSqlResultError(
   }
 }
 
-static int remoteSqlReleaseSavepoints(sqlite3 *db){
-  int rc = SQLITE_OK;
-  while( rc==SQLITE_OK && db->pSavepoint ){
-    char *zSql = sqlite3_mprintf("RELEASE SAVEPOINT \"%w\"", db->pSavepoint->zName);
-    if( !zSql ) return SQLITE_NOMEM;
-    rc = sqlite3_exec(db, zSql, 0, 0, 0);
-    sqlite3_free(zSql);
-  }
-  return rc;
-}
-
 static void remoteSqlRestoreAndReport(
   sqlite3_context *ctx,
   sqlite3 *db,
@@ -280,7 +269,7 @@ static void doltRemoteFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
     return;
   }
 
-  rc = remoteSqlReleaseSavepoints(db);
+  rc = doltliteVcSealActiveSavepoints(db);
   if( rc!=SQLITE_OK ){
     sqlite3_result_error_code(ctx, rc);
     return;

--- a/src/doltlite_tag.c
+++ b/src/doltlite_tag.c
@@ -44,17 +44,6 @@ static int mutateTagRef(sqlite3 *db, ChunkStore *cs, void *pArg){
                               p->timestamp, p->zMessage);
 }
 
-static int tagReleaseSavepoints(sqlite3 *db){
-  int rc = SQLITE_OK;
-  while( rc==SQLITE_OK && db->pSavepoint ){
-    char *zSql = sqlite3_mprintf("RELEASE SAVEPOINT \"%w\"", db->pSavepoint->zName);
-    if( !zSql ) return SQLITE_NOMEM;
-    rc = sqlite3_exec(db, zSql, 0, 0, 0);
-    sqlite3_free(zSql);
-  }
-  return rc;
-}
-
 static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
   ChunkStore *cs = doltliteGetChunkStore(db);
@@ -92,7 +81,7 @@ static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
       tagResultError(ctx, rc, "tag not found", 0);
       return;
     }
-    rc = tagReleaseSavepoints(db);
+    rc = doltliteVcSealActiveSavepoints(db);
     if( rc!=SQLITE_OK ){
       sqlite3_result_error_code(ctx, rc);
       return;
@@ -177,7 +166,7 @@ static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     tagResultError(ctx, rc, "tag not found", "tag already exists");
     return;
   }
-  rc = tagReleaseSavepoints(db);
+  rc = doltliteVcSealActiveSavepoints(db);
   if( rc!=SQLITE_OK ){
     sqlite3_result_error_code(ctx, rc);
     return;


### PR DESCRIPTION
## Summary
- centralize VC transaction/savepoint classification and sealing helpers
- switch merge and replay to a shared transaction-mode policy
- reuse the shared helpers from branch, tag, and remote ref mutations

## Testing
- bash test/vc_oracle_merge_test.sh ./doltlite dolt
- bash test/vc_oracle_revert_cherrypick_test.sh ./doltlite dolt
- bash test/vc_oracle_branch_test.sh ./doltlite dolt
- bash test/vc_oracle_tags_test.sh ./doltlite dolt
- bash test/vc_oracle_remotes_test.sh ./doltlite dolt
- bash test/doltlite_savepoint.sh ./doltlite
- bash test/doltlite_branch.sh ./doltlite
- bash test/remote_test.sh ./doltlite