### PR TITLE
Invalidate savepoints on dolt_reset

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -1826,7 +1826,7 @@ static void doltliteResetFunc(
 
   if( !cs ){
     sqlite3_result_error(context, "no database open", -1);
-    return;
+    goto reset_cleanup;
   }
 
 
@@ -1837,7 +1837,7 @@ static void doltliteResetFunc(
 
 
   azPaths = (const char**)sqlite3_malloc(sizeof(char*) * (argc>0?argc:1));
-  if( !azPaths ){ sqlite3_result_error_nomem(context); return; }
+  if( !azPaths ){ sqlite3_result_error_nomem(context); goto reset_cleanup; }
   for(i=0; i<argc; i++){
     const char *arg = (const char*)sqlite3_value_text(argv[i]);
     if( !arg ) continue;
@@ -1848,7 +1848,8 @@ static void doltliteResetFunc(
       sqlite3_result_error(context, zErr ? zErr : "unknown option", -1);
       sqlite3_free(zErr);
       sqlite3_free(azPaths);
-      return;
+      azPaths = 0;
+      goto reset_cleanup;
     }
     else if( !zRef ){
 
@@ -1873,19 +1874,21 @@ static void doltliteResetFunc(
     sqlite3_result_error(context,
       "--hard and --soft are mutually exclusive options.", -1);
     sqlite3_free(azPaths);
-    return;
+    azPaths = 0;
+    goto reset_cleanup;
   }
 
   doltliteGetSessionMergeState(db, &isMerging, 0, 0);
   if( isMerging && !isHard ){
     sqlite3_free(azPaths);
+    azPaths = 0;
     sqlite3_result_error(context,
       "Merge conflict detected, transaction rolled back. "
       "Merge conflicts must be resolved using the dolt_conflicts and "
       "dolt_schema_conflicts tables before committing a transaction. "
       "To commit transactions with merge conflicts, set "
       "@@dolt_allow_commit_conflicts = 1", -1);
-    return;
+    goto reset_cleanup;
   }
 
   if( nPaths>0 ){
@@ -1893,32 +1896,35 @@ static void doltliteResetFunc(
       sqlite3_result_error(context,
         "table paths cannot be combined with --hard / --soft or a target ref", -1);
       sqlite3_free(azPaths);
-      return;
+      azPaths = 0;
+      goto reset_cleanup;
     }
     rc = resetStageNamedPaths(db, cs, azPaths, nPaths);
     sqlite3_free(azPaths);
+    azPaths = 0;
     if( rc==SQLITE_NOTFOUND ){
       sqlite3_result_error(context, "table not found", -1);
-      return;
+      goto reset_cleanup;
     }
     if( rc!=SQLITE_OK ){
       sqlite3_result_error_code(context, rc);
-      return;
+      goto reset_cleanup;
     }
     rc = doltlitePersistWorkingSet(db);
     if( rc!=SQLITE_OK ){
       sqlite3_result_error_code(context, rc);
-      return;
+      goto reset_cleanup;
     }
     sqlite3_result_int(context, 0);
-    return;
+    goto reset_cleanup;
   }
   sqlite3_free(azPaths);
+  azPaths = 0;
 
 
   if( isSoft && !zRef ){
     sqlite3_result_int(context, 0);
-    return;
+    goto reset_cleanup;
   }
 
   if( zRef ){
@@ -1927,13 +1933,13 @@ static void doltliteResetFunc(
     rc = doltliteResolveRef(db,zRef, &targetCommit);
     if( rc!=SQLITE_OK ){
       sqlite3_result_error(context, "commit not found", -1);
-      return;
+      goto reset_cleanup;
     }
 
     rc = doltliteLoadCommit(db, &targetCommit, &commit);
     if( rc!=SQLITE_OK ){
       sqlite3_result_error(context, "failed to load commit", -1);
-      return;
+      goto reset_cleanup;
     }
     memcpy(&targetCatHash, &commit.catalogHash, sizeof(ProllyHash));
     doltliteCommitClear(&commit);
@@ -1944,11 +1950,11 @@ static void doltliteResetFunc(
       sqlite3_result_error(context,
         "reset conflict: another connection moved this branch. "
         "Please retry your transaction.", -1);
-      return;
+      goto reset_cleanup;
     }
     if( rc!=SQLITE_OK ){
       sqlite3_result_error_code(context, rc);
-      return;
+      goto reset_cleanup;
     }
     graphLocked = 1;
 
@@ -1964,7 +1970,7 @@ static void doltliteResetFunc(
     rc = doltliteGetHeadCatalogHash(db, &targetCatHash);
     if( rc!=SQLITE_OK ){
       sqlite3_result_error(context, "failed to read HEAD", -1);
-      return;
+      goto reset_cleanup;
     }
   }
 
@@ -2038,8 +2044,13 @@ static void doltliteResetFunc(
 
   sqlite3_result_int(context, 0);
 reset_cleanup:
+  sqlite3_free(azPaths);
   if( graphLocked ){
     chunkStoreUnlock(cs);
+  }
+  rc = doltliteVcSealActiveSavepoints(db);
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error_code(context, rc);
   }
 }
 

--- a/test/doltlite_savepoint.sh
+++ b/test/doltlite_savepoint.sh
@@ -182,6 +182,22 @@ run_test "hard_reset_in_txn_status_clean" \
   "SELECT count(*) FROM dolt_status;" \
   "0" "$DB5"
 
+# Savepoint around reset should be invalidated, matching Dolt.
+DB5b=/tmp/test_savepoint5b_$$.db; rm -f "$DB5b"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB5b" > /dev/null 2>&1
+run_test_match "hard_reset_savepoint_invalidated" \
+  "SAVEPOINT sp1; SELECT dolt_reset('--hard','HEAD'); ROLLBACK TO sp1;" \
+  "no such savepoint: sp1" "$DB5b"
+
+DB5c=/tmp/test_savepoint5c_$$.db; rm -f "$DB5c"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','init'); UPDATE t SET v='dirty';" | $DOLTLITE "$DB5c" > /dev/null 2>&1
+run_test_match "bad_reset_savepoint_invalidated" \
+  "SAVEPOINT sp1; SELECT dolt_reset('--hard','bogus'); ROLLBACK TO sp1;" \
+  "no such savepoint: sp1" "$DB5c"
+run_test "bad_reset_savepoint_row_persists" \
+  "SELECT v FROM t WHERE id=1;" \
+  "dirty" "$DB5c"
+
 # ============================================================
 # Test 6: dolt_checkout inside a transaction
 # Expected: dolt_checkout requires a clean working set and switches

--- a/test/vc_oracle_reset_test.sh
+++ b/test/vc_oracle_reset_test.sh
@@ -163,6 +163,44 @@ oracle_error_match() {
   fi
 }
 
+oracle_same_session() {
+  local name="$1" dl_setup="$2" dl_query="$3" dolt_setup="${4:-$2}" dolt_query="${5:-$3}"
+  local dir="$TMPROOT/${name}_ss"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_out
+  dl_out=$(
+    {
+      printf "%s\n.headers off\n.mode list\n.separator '\t'\n%s\n" "$dl_setup" "$dl_query"
+    } | "$DOLTLITE" "$dir/dl/db" 2>&1 \
+      | tr -d '\r' \
+      | awk '/^Q\|/ {print; next} /[Nn]o such savepoint:|SAVEPOINT .*does not exist/ {print "E|savepoint"}'
+  )
+
+  local dt_out
+  dt_out=$(
+    cd "$dir/dt" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    {
+      printf '%s\n' "$(vc_oracle_translate_for_dolt "$dolt_setup")"
+      printf '%s\n' "$dolt_query"
+    } | "$DOLT" sql -c -r csv 2>&1 \
+      | tail -n +2 \
+      | tr -d '"\r' \
+      | awk '/^Q\|/ {print; next} /[Nn]o such savepoint:|SAVEPOINT .*does not exist/ {print "E|savepoint"}'
+  )
+
+  if [ "$dl_out" = "$dt_out" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite:"; echo "$dl_out" | sed 's/^/      /'
+    echo "    dolt:";     echo "$dt_out" | sed 's/^/      /'
+  fi
+}
+
 echo "=== Version Control Oracle Tests: dolt_reset ==="
 echo ""
 
@@ -373,6 +411,42 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feature');
 SELECT dolt_reset('--soft');
 " "Merge conflict detected"
+
+echo "--- savepoint parity ---"
+
+oracle_same_session "reset_hard_savepoint_invalidated" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'base');
+SELECT dolt_commit('-A', '-m', 'c1');
+SAVEPOINT sp1;
+SELECT dolt_reset('--hard', 'HEAD');
+" "SELECT 'Q|' || v FROM t;
+ROLLBACK TO sp1;" \
+"CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'base');
+CALL dolt_commit('-A', '-m', 'c1');
+SAVEPOINT sp1;
+CALL dolt_reset('--hard', 'HEAD');
+" "SELECT concat('Q|', v) FROM t;
+ROLLBACK TO sp1;"
+
+oracle_same_session "reset_bad_ref_savepoint_invalidated" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'base');
+SELECT dolt_commit('-A', '-m', 'c1');
+UPDATE t SET v='dirty';
+SAVEPOINT sp1;
+SELECT dolt_reset('--hard', 'bogus');
+" "SELECT 'Q|' || v FROM t;
+ROLLBACK TO sp1;" \
+"CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'base');
+CALL dolt_commit('-A', '-m', 'c1');
+UPDATE t SET v='dirty';
+SAVEPOINT sp1;
+CALL dolt_reset('--hard', 'bogus');
+" "SELECT concat('Q|', v) FROM t;
+ROLLBACK TO sp1;"
 
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="


### PR DESCRIPTION
Summary:
- make dolt_reset seal active savepoints on both success and error paths
- add savepoint regressions for reset in the local shell suite
- add Dolt oracle coverage for reset savepoint parity

Testing:
- bash test/doltlite_savepoint.sh ./doltlite
- bash test/vc_oracle_reset_test.sh ./doltlite dolt
- bash test/vc_oracle_error_recovery_test.sh ./doltlite dolt