### PR TITLE
Invalidate savepoints on branch errors

### DIFF
--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -43,6 +43,34 @@ static void branchResultError(
   }
 }
 
+static void branchSealSavepointsOnError(sqlite3_context *ctx, int bHadSavepoint){
+  if( bHadSavepoint ){
+    sqlite3 *db = sqlite3_context_db_handle(ctx);
+    (void)doltliteVcSealActiveSavepoints(db);
+  }
+}
+
+static void branchError(sqlite3_context *ctx, int bHadSavepoint, const char *zErr){
+  branchSealSavepointsOnError(ctx, bHadSavepoint);
+  sqlite3_result_error(ctx, zErr, -1);
+}
+
+static void branchErrorCode(sqlite3_context *ctx, int bHadSavepoint, int rc){
+  branchSealSavepointsOnError(ctx, bHadSavepoint);
+  sqlite3_result_error_code(ctx, rc);
+}
+
+static void branchNamedResultError(
+  sqlite3_context *ctx,
+  int bHadSavepoint,
+  int rc,
+  const char *zNotFound,
+  const char *zExists
+){
+  branchSealSavepointsOnError(ctx, bHadSavepoint);
+  branchResultError(ctx, rc, zNotFound, zExists);
+}
+
 static int mutateBranchRef(sqlite3 *db, ChunkStore *cs, void *pArg){
   BranchMutationCtx *p = (BranchMutationCtx*)pArg;
   int rc;
@@ -122,10 +150,11 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
   const char *aPositional[3] = {0, 0, 0};
   int nPositional = 0;
   int hadExplicitTxn = !db->autoCommit;
+  int hadSavepoint = db->pSavepoint!=0;
   int i, rc;
 
-  if( !cs ){ sqlite3_result_error(ctx, "no database", -1); return; }
-  if( argc<1 ){ sqlite3_result_error(ctx, "dolt_branch requires arguments", -1); return; }
+  if( !cs ){ branchError(ctx, hadSavepoint, "no database"); return; }
+  if( argc<1 ){ branchError(ctx, hadSavepoint, "dolt_branch requires arguments"); return; }
 
 
   for(i=0; i<argc; i++){
@@ -133,24 +162,24 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
     if( !arg ) continue;
     if( strcmp(arg, "-d")==0 || strcmp(arg, "--delete")==0 ){
       if( mode!=MODE_CREATE ){
-        sqlite3_result_error(ctx, "conflicting flags", -1); return;
+        branchError(ctx, hadSavepoint, "conflicting flags"); return;
       }
       mode = MODE_DELETE;
     }else if( strcmp(arg, "-D")==0 ){
 
       if( mode!=MODE_CREATE ){
-        sqlite3_result_error(ctx, "conflicting flags", -1); return;
+        branchError(ctx, hadSavepoint, "conflicting flags"); return;
       }
       mode = MODE_DELETE;
       force = 1;
     }else if( strcmp(arg, "-c")==0 || strcmp(arg, "--copy")==0 ){
       if( mode!=MODE_CREATE ){
-        sqlite3_result_error(ctx, "conflicting flags", -1); return;
+        branchError(ctx, hadSavepoint, "conflicting flags"); return;
       }
       mode = MODE_COPY;
     }else if( strcmp(arg, "-m")==0 || strcmp(arg, "--move")==0 ){
       if( mode!=MODE_CREATE ){
-        sqlite3_result_error(ctx, "conflicting flags", -1); return;
+        branchError(ctx, hadSavepoint, "conflicting flags"); return;
       }
       mode = MODE_MOVE;
     }else if( strcmp(arg, "-f")==0 || strcmp(arg, "--force")==0 ){
@@ -158,7 +187,7 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
     }else if( arg[0]=='-' ){
       char *zErr = sqlite3_mprintf("unknown option `%s`", arg);
       if( zErr ){
-        sqlite3_result_error(ctx, zErr, -1);
+        branchError(ctx, hadSavepoint, zErr);
         sqlite3_free(zErr);
       }else{
         sqlite3_result_error_nomem(ctx);
@@ -166,7 +195,7 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
       return;
     }else{
       if( nPositional >= 3 ){
-        sqlite3_result_error(ctx, "too many arguments", -1); return;
+        branchError(ctx, hadSavepoint, "too many arguments"); return;
       }
       aPositional[nPositional++] = arg;
     }
@@ -177,17 +206,17 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
       BranchMutationCtx m;
       ProllyHash branchHead, currentHead, ancestor;
       if( nPositional>1 ){
-        sqlite3_result_error(ctx, "too many arguments", -1);
+        branchError(ctx, hadSavepoint, "too many arguments");
         return;
       }
       if( nPositional<1 ){
-        sqlite3_result_error(ctx, "branch name required", -1); return;
+        branchError(ctx, hadSavepoint, "branch name required"); return;
       }
       if( branchNameEmpty(aPositional[0]) ){
-        sqlite3_result_error(ctx, "branch name required", -1); return;
+        branchError(ctx, hadSavepoint, "branch name required"); return;
       }
       if( strcmp(aPositional[0], doltliteGetSessionBranch(db))==0 ){
-        sqlite3_result_error(ctx, "cannot delete the current branch", -1);
+        branchError(ctx, hadSavepoint, "cannot delete the current branch");
         return;
       }
       /* Short-term guard: doltlite does not yet have stable default-branch
@@ -197,21 +226,20 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
       ** session pointing at a nonexistent branch. Reject until we have real
       ** default-branch logic. */
       if( strcmp(aPositional[0], "main")==0 ){
-        sqlite3_result_error(ctx,
-          "cannot delete branch 'main' (doltlite requires main to exist)",
-          -1);
+        branchError(ctx, hadSavepoint,
+          "cannot delete branch 'main' (doltlite requires main to exist)");
         return;
       }
       if( !force ){
         rc = chunkStoreFindBranch(cs, aPositional[0], &branchHead);
         if( rc!=SQLITE_OK ){
-          branchResultError(ctx, rc, "branch not found", 0);
+          branchNamedResultError(ctx, hadSavepoint, rc, "branch not found", 0);
           return;
         }
         doltliteGetSessionHead(db, &currentHead);
         rc = doltliteFindAncestor(db, &currentHead, &branchHead, &ancestor);
         if( rc!=SQLITE_OK || prollyHashCompare(&ancestor, &branchHead)!=0 ){
-          sqlite3_result_error(ctx, "branch is not fully merged", -1);
+          branchError(ctx, hadSavepoint, "branch is not fully merged");
           return;
         }
       }
@@ -220,7 +248,7 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
       m.isDelete = 1;
       rc = doltliteMutateRefs(db, mutateBranchRef, &m);
       if( rc!=SQLITE_OK ){
-        branchResultError(ctx, rc, "branch not found", 0);
+        branchNamedResultError(ctx, hadSavepoint, rc, "branch not found", 0);
         return;
       }
       break;
@@ -229,15 +257,15 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
     case MODE_COPY: {
       BranchCopyCtx m;
       if( nPositional>2 ){
-        sqlite3_result_error(ctx, "too many arguments", -1);
+        branchError(ctx, hadSavepoint, "too many arguments");
         return;
       }
       if( nPositional<2 ){
-        sqlite3_result_error(ctx, "copy requires source and destination", -1);
+        branchError(ctx, hadSavepoint, "copy requires source and destination");
         return;
       }
       if( branchNameEmpty(aPositional[0]) || branchNameEmpty(aPositional[1]) ){
-        sqlite3_result_error(ctx, "branch name required", -1);
+        branchError(ctx, hadSavepoint, "branch name required");
         return;
       }
       memset(&m, 0, sizeof(m));
@@ -246,7 +274,8 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
       m.force = force;
       rc = doltliteMutateRefs(db, mutateBranchCopy, &m);
       if( rc!=SQLITE_OK ){
-        branchResultError(ctx, rc, "source branch not found", "branch already exists");
+        branchNamedResultError(ctx, hadSavepoint, rc,
+          "source branch not found", "branch already exists");
         return;
       }
       break;
@@ -256,15 +285,15 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
       BranchMoveCtx m;
       int renamingCurrent;
       if( nPositional>2 ){
-        sqlite3_result_error(ctx, "too many arguments", -1);
+        branchError(ctx, hadSavepoint, "too many arguments");
         return;
       }
       if( nPositional<2 ){
-        sqlite3_result_error(ctx, "move requires source and destination", -1);
+        branchError(ctx, hadSavepoint, "move requires source and destination");
         return;
       }
       if( branchNameEmpty(aPositional[0]) || branchNameEmpty(aPositional[1]) ){
-        sqlite3_result_error(ctx, "branch name required", -1);
+        branchError(ctx, hadSavepoint, "branch name required");
         return;
       }
       memset(&m, 0, sizeof(m));
@@ -274,15 +303,15 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
       ** repo with no main branch, and reopening would fail to resolve a
       ** session branch. Reject until default-branch logic is reworked. */
       if( strcmp(m.zSrc, "main")==0 ){
-        sqlite3_result_error(ctx,
-          "cannot rename branch 'main' (doltlite requires main to exist)",
-          -1);
+        branchError(ctx, hadSavepoint,
+          "cannot rename branch 'main' (doltlite requires main to exist)");
         return;
       }
       renamingCurrent = strcmp(m.zSrc, doltliteGetSessionBranch(db))==0;
       rc = doltliteMutateRefs(db, mutateBranchMove, &m);
       if( rc!=SQLITE_OK ){
-        branchResultError(ctx, rc, "source branch not found", "destination already exists");
+        branchNamedResultError(ctx, hadSavepoint, rc,
+          "source branch not found", "destination already exists");
         return;
       }
       if( renamingCurrent ){
@@ -296,28 +325,28 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
       BranchMutationCtx m;
       const char *zName, *zStart;
       if( nPositional>2 ){
-        sqlite3_result_error(ctx, "too many arguments", -1);
+        branchError(ctx, hadSavepoint, "too many arguments");
         return;
       }
       if( nPositional<1 ){
-        sqlite3_result_error(ctx, "branch name required", -1); return;
+        branchError(ctx, hadSavepoint, "branch name required"); return;
       }
       zName = aPositional[0];
       if( branchNameEmpty(zName) ){
-        sqlite3_result_error(ctx, "branch name required", -1); return;
+        branchError(ctx, hadSavepoint, "branch name required"); return;
       }
       zStart = nPositional>=2 ? aPositional[1] : 0;
       memset(&m, 0, sizeof(m));
       if( zStart ){
         rc = doltliteResolveRef(db, zStart, &m.head);
         if( rc!=SQLITE_OK ){
-          sqlite3_result_error(ctx, "start point not found", -1);
+          branchError(ctx, hadSavepoint, "start point not found");
           return;
         }
       }else{
         doltliteGetSessionHead(db, &m.head);
         if( prollyHashIsEmpty(&m.head) ){
-          sqlite3_result_error(ctx, "no commits yet — commit first", -1);
+          branchError(ctx, hadSavepoint, "no commits yet — commit first");
           return;
         }
       }
@@ -325,7 +354,8 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
       m.force = force;
       rc = doltliteMutateRefs(db, mutateBranchRef, &m);
       if( rc!=SQLITE_OK ){
-        branchResultError(ctx, rc, "branch not found", "branch already exists");
+        branchNamedResultError(ctx, hadSavepoint, rc,
+          "branch not found", "branch already exists");
         return;
       }
       break;
@@ -335,7 +365,7 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
   if( hadExplicitTxn ){
     rc = doltliteVcSealBranchStyleTxn(db);
     if( rc!=SQLITE_OK ){
-      sqlite3_result_error_code(ctx, rc);
+      branchErrorCode(ctx, hadSavepoint, rc);
       return;
     }
   }

--- a/test/doltlite_savepoint.sh
+++ b/test/doltlite_savepoint.sh
@@ -261,6 +261,24 @@ run_test_match "remote_savepoint_remote_persists" \
   "SELECT group_concat(name, ',') FROM dolt_remotes;" \
   "^origin$" "$DB6g"
 
+DB6g2=/tmp/test_savepoint6g2_$$.db; rm -f "$DB6g2"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'main'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6g2" > /dev/null 2>&1
+run_test_match "branch_delete_current_savepoint_rollback_to_errors" \
+  "SAVEPOINT sp1; SELECT dolt_branch('-d','main'); ROLLBACK TO sp1;" \
+  "no such savepoint: sp1" "$DB6g2"
+run_test_match "branch_delete_current_savepoint_branch_stays_main" \
+  "SELECT active_branch();" \
+  "^main$" "$DB6g2"
+
+DB6g3=/tmp/test_savepoint6g3_$$.db; rm -f "$DB6g3"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'main'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6g3" > /dev/null 2>&1
+run_test_match "branch_delete_missing_savepoint_rollback_to_errors" \
+  "SAVEPOINT sp1; SELECT dolt_branch('-d','nope'); ROLLBACK TO sp1;" \
+  "no such savepoint: sp1" "$DB6g3"
+run_test_match "branch_delete_missing_savepoint_branch_stays_main" \
+  "SELECT active_branch();" \
+  "^main$" "$DB6g3"
+
 DB6h=/tmp/test_savepoint6h_$$.db; rm -f "$DB6h"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'main'); SELECT dolt_commit('-A','-m','init'); SELECT dolt_branch('other'); SELECT dolt_checkout('other'); UPDATE t SET v='other'; SELECT dolt_commit('-A','-m','other'); SELECT dolt_checkout('main');" | $DOLTLITE "$DB6h" > /dev/null 2>&1
 run_test_match "checkout_savepoint_rollback_to_errors" \
@@ -397,7 +415,8 @@ run_test_match "branch_name_after_rollback" \
 # ============================================================
 # Cleanup
 # ============================================================
-rm -f "$DB1" "$DB2" "$DB3" "$DB4" "$DB4b" "$DB5" "$DB6" "$DB6b" "$DB7" "$DB8"
+rm -f "$DB1" "$DB2" "$DB3" "$DB4" "$DB4b" "$DB5" "$DB6" "$DB6b" "$DB7" "$DB8" \
+  "$DB6g2" "$DB6g3"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/vc_oracle_branch_test.sh
+++ b/test/vc_oracle_branch_test.sh
@@ -160,6 +160,52 @@ oracle_with_rows() {
   fi
 }
 
+oracle_same_session() {
+  local name="$1" setup="$2" dl_query="${3:-}"
+  local dolt_query="${4:-$dl_query}"
+  local dir="$TMPROOT/${name}_ss"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_out
+  dl_out=$(
+    {
+      printf "%s\n.headers off\n.mode list\n.separator '\t'\n" "$setup"
+      if [ -n "$dl_query" ]; then
+        printf "%s\n" "$dl_query"
+      fi
+    } | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
+      | tr -d '\r' \
+      | awk -F'\t' '$1=="Q"{print}'
+  )
+
+  local dolt_setup
+  dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
+  local dt_out
+  dt_out=$(
+    cd "$dir/dt" || exit 1
+    vc_oracle_init_repo
+    {
+      printf "%s\n" "$dolt_setup"
+      if [ -n "$dolt_query" ]; then
+        printf "%s\n" "$dolt_query"
+      fi
+    } | "$DOLT" sql -c -r csv 2>"$dir/dt.err" \
+      | tail -n +2 \
+      | tr -d '"\r' \
+      | awk -F'\t' '$1=="Q"{print}'
+  )
+
+  if [ "$dl_out" = "$dt_out" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite: |$dl_out|"
+    echo "    dolt:     |$dt_out|"
+  fi
+}
+
 echo "=== Version Control Oracle Tests: dolt_branch ==="
 echo ""
 
@@ -274,6 +320,30 @@ UPDATE t SET v = 11 WHERE id = 1;
 SELECT dolt_branch('txb');
 ROLLBACK;
 "
+
+echo "--- savepoint error parity ---"
+
+oracle_same_session "delete_current_inside_savepoint_invalidates" "
+$SEED
+SAVEPOINT sp1;
+SELECT dolt_branch('-d', 'main');
+SELECT 'Q' || char(9) || 'after_delete' || char(9) || active_branch();
+ROLLBACK TO sp1;
+SELECT 'Q' || char(9) || 'after_rb' || char(9) || active_branch();
+" "" "SELECT concat('Q', char(9), 'after_delete', char(9), active_branch());
+ROLLBACK TO sp1;
+SELECT concat('Q', char(9), 'after_rb', char(9), active_branch());"
+
+oracle_same_session "delete_missing_inside_savepoint_invalidates" "
+$SEED
+SAVEPOINT sp1;
+SELECT dolt_branch('-d', 'nope');
+SELECT 'Q' || char(9) || 'after_delete' || char(9) || active_branch();
+ROLLBACK TO sp1;
+SELECT 'Q' || char(9) || 'after_rb' || char(9) || active_branch();
+" "" "SELECT concat('Q', char(9), 'after_delete', char(9), active_branch());
+ROLLBACK TO sp1;
+SELECT concat('Q', char(9), 'after_rb', char(9), active_branch());"
 
 echo "--- error paths ---"
 


### PR DESCRIPTION
## Summary
- invalidate active savepoints when `dolt_branch()` returns an error inside a savepoint
- add direct savepoint regressions for delete-current and delete-missing branch cases
- add same-session Dolt oracle coverage for the same parity cases

## Testing
- bash test/doltlite_savepoint.sh ./doltlite
- bash test/vc_oracle_branch_test.sh ./doltlite dolt