### PR TITLE
Invalidate savepoints on VC lookup errors

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -500,6 +500,13 @@ int doltliteVcSealActiveSavepoints(sqlite3 *db){
   return rc;
 }
 
+int doltliteVcSealSavepointError(sqlite3 *db){
+  if( db->pSavepoint ){
+    return doltliteVcSealActiveSavepoints(db);
+  }
+  return SQLITE_OK;
+}
+
 int doltliteVcSealBranchStyleTxn(sqlite3 *db){
   int rc;
   if( db->autoCommit ) return SQLITE_OK;

--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -679,10 +679,10 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
   int hadExplicitTxn = !db->autoCommit;
   int rc;
 
-  if( !cs ){ sqlite3_result_error(ctx, "no database", -1); return; }
-  if( argc<1 ){ sqlite3_result_error(ctx, "branch name required", -1); return; }
+  if( !cs ){ (void)doltliteVcSealSavepointError(db); sqlite3_result_error(ctx, "no database", -1); return; }
+  if( argc<1 ){ (void)doltliteVcSealSavepointError(db); sqlite3_result_error(ctx, "branch name required", -1); return; }
   zBranch = (const char*)sqlite3_value_text(argv[0]);
-  if( !zBranch ){ sqlite3_result_error(ctx, "branch name required", -1); return; }
+  if( !zBranch ){ (void)doltliteVcSealSavepointError(db); sqlite3_result_error(ctx, "branch name required", -1); return; }
 
   memset(&m, 0, sizeof(m));
   memset(&branchCreate, 0, sizeof(branchCreate));
@@ -692,6 +692,7 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
     u8 isMerging = 0;
     doltliteGetSessionMergeState(db, &isMerging, 0, 0);
     if( isMerging ){
+      (void)doltliteVcSealSavepointError(db);
       sqlite3_result_error(ctx, "unresolved merge conflicts \xe2\x80\x94 commit or abort first", -1);
       return;
     }
@@ -699,25 +700,28 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
 
 
   if( strcmp(zBranch, "-b")==0 ){
-    if( argc<2 ){ sqlite3_result_error(ctx, "branch name required after -b", -1); return; }
-    if( argc>3 ){ sqlite3_result_error(ctx, "too many arguments", -1); return; }
+    if( argc<2 ){ (void)doltliteVcSealSavepointError(db); sqlite3_result_error(ctx, "branch name required after -b", -1); return; }
+    if( argc>3 ){ (void)doltliteVcSealSavepointError(db); sqlite3_result_error(ctx, "too many arguments", -1); return; }
     zBranch = (const char*)sqlite3_value_text(argv[1]);
-    if( branchNameEmpty(zBranch) ){ sqlite3_result_error(ctx, "branch name required after -b", -1); return; }
+    if( branchNameEmpty(zBranch) ){ (void)doltliteVcSealSavepointError(db); sqlite3_result_error(ctx, "branch name required after -b", -1); return; }
 
     if( argc>=3 ){
       const char *zStart = (const char*)sqlite3_value_text(argv[2]);
       if( !zStart ){
+        (void)doltliteVcSealSavepointError(db);
         sqlite3_result_error(ctx, "start point not found", -1);
         return;
       }
       rc = doltliteResolveRef(db, zStart, &branchCreate.head);
       if( rc!=SQLITE_OK ){
+        (void)doltliteVcSealSavepointError(db);
         sqlite3_result_error(ctx, "start point not found", -1);
         return;
       }
     }else{
       doltliteGetSessionHead(db, &branchCreate.head);
       if( prollyHashIsEmpty(&branchCreate.head) ){
+        (void)doltliteVcSealSavepointError(db);
         sqlite3_result_error(ctx, "no commits yet — commit first", -1);
         return;
       }
@@ -725,6 +729,7 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
     branchCreate.zName = zBranch;
     rc = doltliteMutateRefs(db, mutateBranchRef, &branchCreate);
     if( rc!=SQLITE_OK ){
+      (void)doltliteVcSealSavepointError(db);
       sqlite3_result_error(ctx, "branch already exists", -1);
       return;
     }
@@ -741,11 +746,13 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
     if( rc==SQLITE_NOTFOUND ){
       char *zErr = sqlite3_mprintf(
           "no such branch or table: %s", zBranch);
+      (void)doltliteVcSealSavepointError(db);
       sqlite3_result_error(ctx, zErr ? zErr : "no such branch or table", -1);
       sqlite3_free(zErr);
       return;
     }
     if( rc!=SQLITE_OK ){
+      (void)doltliteVcSealSavepointError(db);
       sqlite3_result_error_code(ctx, rc);
       return;
     }
@@ -766,12 +773,14 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
   doltliteGetSessionHead(db, &m.oldCommitHash);
   zCurrentBranch = sqlite3_mprintf("%s", doltliteGetSessionBranch(db));
   if( !zCurrentBranch ){
+      (void)doltliteVcSealSavepointError(db);
       sqlite3_result_error_nomem(ctx);
       return;
     }
     rc = doltliteFlushAndSerializeCatalog(db, &oldCatData, &nOldCat);
     if( rc!=SQLITE_OK ){
       sqlite3_free(zCurrentBranch);
+      (void)doltliteVcSealSavepointError(db);
       sqlite3_result_error(ctx, "failed to snapshot current branch state", -1);
       return;
     }
@@ -779,6 +788,7 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
     sqlite3_free(oldCatData);
     if( rc!=SQLITE_OK ){
       sqlite3_free(zCurrentBranch);
+      (void)doltliteVcSealSavepointError(db);
       sqlite3_result_error(ctx, "failed to snapshot current branch state", -1);
       return;
     }
@@ -808,11 +818,13 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
     if( rc==SQLITE_NOTFOUND ){
       char *zErr = sqlite3_mprintf(
           "no such branch or table: %s", zBranch);
+      (void)doltliteVcSealSavepointError(db);
       sqlite3_result_error(ctx, zErr ? zErr : "no such branch or table", -1);
       sqlite3_free(zErr);
       return;
     }
     if( rc!=SQLITE_OK ){
+      (void)doltliteVcSealSavepointError(db);
       sqlite3_result_error_code(ctx, rc);
       return;
     }
@@ -820,14 +832,17 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
     return;
   }
   if( rc==SQLITE_EMPTY ){
+    (void)doltliteVcSealSavepointError(db);
     sqlite3_result_error(ctx, "target branch has no commits", -1);
     return;
   }
   if( rc==SQLITE_BUSY ){
+    (void)doltliteVcSealSavepointError(db);
     sqlite3_result_error(ctx, "database is locked by another connection", -1);
     return;
   }
   if( rc!=SQLITE_OK ){
+    (void)doltliteVcSealSavepointError(db);
     sqlite3_result_error(ctx, "checkout failed", -1);
     return;
   }

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -163,6 +163,7 @@ int doltlitePersistWorkingSet(sqlite3 *db);
 int doltliteLoadWorkingSet(sqlite3 *db, const char *zBranch);
 DoltliteVcTxnMode doltliteVcTxnMode(sqlite3 *db);
 int doltliteVcSealActiveSavepoints(sqlite3 *db);
+int doltliteVcSealSavepointError(sqlite3 *db);
 int doltliteVcSealBranchStyleTxn(sqlite3 *db);
 
 typedef int (*DoltliteRefsMutation)(sqlite3 *db, ChunkStore *cs, void *pArg);

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -216,14 +216,23 @@ static void doltRemoteFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
   const char *zName;
   int rc;
 
-  if( !cs ){ sqlite3_result_error(ctx, "no database", -1); return; }
-  if( argc<2 ){ sqlite3_result_error(ctx, "usage: dolt_remote(action, name [, url])", -1); return; }
+  if( !cs ){
+    (void)doltliteVcSealSavepointError(db);
+    sqlite3_result_error(ctx, "no database", -1);
+    return;
+  }
+  if( argc<2 ){
+    (void)doltliteVcSealSavepointError(db);
+    sqlite3_result_error(ctx, "usage: dolt_remote(action, name [, url])", -1);
+    return;
+  }
 
   memset(&m, 0, sizeof(m));
 
   zAction = (const char*)sqlite3_value_text(argv[0]);
   zName = (const char*)sqlite3_value_text(argv[1]);
   if( !zAction || !zName ){
+    (void)doltliteVcSealSavepointError(db);
     sqlite3_result_error(ctx, "action and name required", -1);
     return;
   }
@@ -231,15 +240,18 @@ static void doltRemoteFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
   if( strcmp(zAction, "add")==0 ){
     const char *zUrl;
     if( argc<3 ){
+      (void)doltliteVcSealSavepointError(db);
       sqlite3_result_error(ctx, "url required for add", -1);
       return;
     }
     if( argc>3 ){
+      (void)doltliteVcSealSavepointError(db);
       sqlite3_result_error(ctx, "too many arguments", -1);
       return;
     }
     zUrl = (const char*)sqlite3_value_text(argv[2]);
     if( !zUrl ){
+      (void)doltliteVcSealSavepointError(db);
       sqlite3_result_error(ctx, "url required for add", -1);
       return;
     }
@@ -247,12 +259,14 @@ static void doltRemoteFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
     m.zUrl = zUrl;
     rc = doltliteMutateRefs(db, mutateRemoteRef, &m);
     if( rc!=SQLITE_OK ){
+      (void)doltliteVcSealSavepointError(db);
       remoteSqlResultError(ctx, rc,
         rc==SQLITE_ERROR ? "remote already exists" : 0);
       return;
     }
   }else if( strcmp(zAction, "remove")==0 ){
     if( argc>2 ){
+      (void)doltliteVcSealSavepointError(db);
       sqlite3_result_error(ctx, "too many arguments", -1);
       return;
     }
@@ -260,11 +274,13 @@ static void doltRemoteFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
     m.isDelete = 1;
     rc = doltliteMutateRefs(db, mutateRemoteRef, &m);
     if( rc!=SQLITE_OK ){
+      (void)doltliteVcSealSavepointError(db);
       remoteSqlResultError(ctx, rc,
         rc==SQLITE_NOTFOUND ? "remote not found" : 0);
       return;
     }
   }else{
+    (void)doltliteVcSealSavepointError(db);
     sqlite3_result_error(ctx, "unknown action: use 'add' or 'remove'", -1);
     return;
   }

--- a/src/doltlite_tag.c
+++ b/src/doltlite_tag.c
@@ -35,6 +35,11 @@ static void tagResultError(
   }
 }
 
+static void tagSealSavepointError(sqlite3_context *ctx){
+  sqlite3 *db = sqlite3_context_db_handle(ctx);
+  (void)doltliteVcSealSavepointError(db);
+}
+
 static int mutateTagRef(sqlite3 *db, ChunkStore *cs, void *pArg){
   TagMutationCtx *p = (TagMutationCtx*)pArg;
   (void)db;
@@ -56,28 +61,30 @@ static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   char *zParsedEmail = 0;
   int rc, i;
 
-  if( !cs ){ sqlite3_result_error(ctx, "no database", -1); return; }
-  if( argc<1 ){ sqlite3_result_error(ctx, "tag name required", -1); return; }
+  if( !cs ){ tagSealSavepointError(ctx); sqlite3_result_error(ctx, "no database", -1); return; }
+  if( argc<1 ){ tagSealSavepointError(ctx); sqlite3_result_error(ctx, "tag name required", -1); return; }
 
   memset(&m, 0, sizeof(m));
 
   arg0 = (const char*)sqlite3_value_text(argv[0]);
-  if( !arg0 ){ sqlite3_result_error(ctx, "tag name required", -1); return; }
+  if( !arg0 ){ tagSealSavepointError(ctx); sqlite3_result_error(ctx, "tag name required", -1); return; }
 
 
   if( strcmp(arg0, "-d")==0 || strcmp(arg0, "--delete")==0 ){
     const char *zName;
-    if( argc<2 ){ sqlite3_result_error(ctx, "tag name required for delete", -1); return; }
+    if( argc<2 ){ tagSealSavepointError(ctx); sqlite3_result_error(ctx, "tag name required for delete", -1); return; }
     if( argc!=2 ){
+      tagSealSavepointError(ctx);
       sqlite3_result_error(ctx, "too many positional arguments to dolt_tag", -1);
       return;
     }
     zName = (const char*)sqlite3_value_text(argv[1]);
-    if( !zName ){ sqlite3_result_error(ctx, "tag name required", -1); return; }
+    if( !zName ){ tagSealSavepointError(ctx); sqlite3_result_error(ctx, "tag name required", -1); return; }
     m.zName = zName;
     m.isDelete = 1;
     rc = doltliteMutateRefs(db, mutateTagRef, &m);
     if( rc!=SQLITE_OK ){
+      tagSealSavepointError(ctx);
       tagResultError(ctx, rc, "tag not found", 0);
       return;
     }
@@ -96,13 +103,14 @@ static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     if( !arg ) continue;
     if( strcmp(arg, "-m")==0 || strcmp(arg, "--message")==0 ){
       if( i+1<argc ) zMessage = (const char*)sqlite3_value_text(argv[++i]);
-      else{ sqlite3_result_error(ctx, "-m requires a message", -1); return; }
+      else{ tagSealSavepointError(ctx); sqlite3_result_error(ctx, "-m requires a message", -1); return; }
     }else if( strcmp(arg, "--author")==0 ){
       if( i+1<argc ) zAuthor = (const char*)sqlite3_value_text(argv[++i]);
-      else{ sqlite3_result_error(ctx, "--author requires 'name <email>'", -1); return; }
+      else{ tagSealSavepointError(ctx); sqlite3_result_error(ctx, "--author requires 'name <email>'", -1); return; }
     }else if( arg[0]=='-' ){
       char *zErr = sqlite3_mprintf("unknown option `%s`", arg);
       if( zErr ){
+        tagSealSavepointError(ctx);
         sqlite3_result_error(ctx, zErr, -1);
         sqlite3_free(zErr);
       }else{
@@ -112,6 +120,7 @@ static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     }else if( !zCommitRef ){
       zCommitRef = arg;
     }else{
+      tagSealSavepointError(ctx);
       sqlite3_result_error(ctx, "too many positional arguments to dolt_tag", -1);
       return;
     }
@@ -120,12 +129,14 @@ static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   if( zCommitRef ){
     rc = doltliteResolveRef(db, zCommitRef, &m.commitHash);
     if( rc!=SQLITE_OK ){
+      tagSealSavepointError(ctx);
       sqlite3_result_error(ctx, "commit not found", -1);
       return;
     }
   }else{
     doltliteGetSessionHead(db, &m.commitHash);
     if( prollyHashIsEmpty(&m.commitHash) ){
+      tagSealSavepointError(ctx);
       sqlite3_result_error(ctx, "no commits to tag", -1);
       return;
     }
@@ -146,6 +157,7 @@ static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     if( !zParsedTagger || !zParsedEmail ){
       sqlite3_free(zParsedTagger);
       sqlite3_free(zParsedEmail);
+      tagSealSavepointError(ctx);
       sqlite3_result_error_nomem(ctx);
       return;
     }
@@ -163,6 +175,7 @@ static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3_free(zParsedTagger);
   sqlite3_free(zParsedEmail);
   if( rc!=SQLITE_OK ){
+    tagSealSavepointError(ctx);
     tagResultError(ctx, rc, "tag not found", "tag already exists");
     return;
   }

--- a/test/doltlite_savepoint.sh
+++ b/test/doltlite_savepoint.sh
@@ -295,6 +295,33 @@ run_test_match "branch_delete_missing_savepoint_branch_stays_main" \
   "SELECT active_branch();" \
   "^main$" "$DB6g3"
 
+DB6g4=/tmp/test_savepoint6g4_$$.db; rm -f "$DB6g4"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'main'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6g4" > /dev/null 2>&1
+run_test_match "tag_delete_missing_savepoint_rollback_to_errors" \
+  "SAVEPOINT sp1; SELECT dolt_tag('-d','missing'); ROLLBACK TO sp1;" \
+  "no such savepoint: sp1" "$DB6g4"
+run_test_match "tag_delete_missing_savepoint_branch_stays_main" \
+  "SELECT active_branch();" \
+  "^main$" "$DB6g4"
+
+DB6g5=/tmp/test_savepoint6g5_$$.db; rm -f "$DB6g5"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'main'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6g5" > /dev/null 2>&1
+run_test_match "remote_delete_missing_savepoint_rollback_to_errors" \
+  "SAVEPOINT sp1; SELECT dolt_remote('remove','missing'); ROLLBACK TO sp1;" \
+  "no such savepoint: sp1" "$DB6g5"
+run_test_match "remote_delete_missing_savepoint_branch_stays_main" \
+  "SELECT active_branch();" \
+  "^main$" "$DB6g5"
+
+DB6g6=/tmp/test_savepoint6g6_$$.db; rm -f "$DB6g6"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'main'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6g6" > /dev/null 2>&1
+run_test_match "checkout_missing_savepoint_rollback_to_errors" \
+  "SAVEPOINT sp1; SELECT dolt_checkout('missing'); ROLLBACK TO sp1;" \
+  "no such savepoint: sp1" "$DB6g6"
+run_test_match "checkout_missing_savepoint_branch_stays_main" \
+  "SELECT active_branch();" \
+  "^main$" "$DB6g6"
+
 DB6h=/tmp/test_savepoint6h_$$.db; rm -f "$DB6h"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'main'); SELECT dolt_commit('-A','-m','init'); SELECT dolt_branch('other'); SELECT dolt_checkout('other'); UPDATE t SET v='other'; SELECT dolt_commit('-A','-m','other'); SELECT dolt_checkout('main');" | $DOLTLITE "$DB6h" > /dev/null 2>&1
 run_test_match "checkout_savepoint_rollback_to_errors" \
@@ -432,7 +459,7 @@ run_test_match "branch_name_after_rollback" \
 # Cleanup
 # ============================================================
 rm -f "$DB1" "$DB2" "$DB3" "$DB4" "$DB4b" "$DB5" "$DB6" "$DB6b" "$DB7" "$DB8" \
-  "$DB6g2" "$DB6g3"
+  "$DB6g2" "$DB6g3" "$DB6g4" "$DB6g5" "$DB6g6"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/vc_oracle_checkout_test.sh
+++ b/test/vc_oracle_checkout_test.sh
@@ -375,6 +375,13 @@ SELECT dolt_checkout('-b', 'side');
 ROLLBACK TO sp1;
 " "SELECT concat(active_branch(), char(9), (SELECT v FROM t WHERE id=1), char(9), (SELECT group_concat(name, ',') FROM dolt_branches));"
 
+oracle_savepoint_poststate "savepoint_checkout_missing_invalidates" "
+$SEED
+SAVEPOINT sp1;
+SELECT dolt_checkout('does-not-exist');
+ROLLBACK TO sp1;
+" "SELECT active_branch();"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then

--- a/test/vc_oracle_remotes_test.sh
+++ b/test/vc_oracle_remotes_test.sh
@@ -208,6 +208,16 @@ SELECT dolt_remote('add', 'origin', 'file:///tmp/oracle_origin');
 ROLLBACK TO sp1;
 "
 
+oracle_savepoint_remote_poststate "remote_remove_missing_inside_savepoint_invalidates" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'main');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'first');
+SAVEPOINT sp1;
+SELECT dolt_remote('remove', 'missing');
+ROLLBACK TO sp1;
+"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then

--- a/test/vc_oracle_tags_test.sh
+++ b/test/vc_oracle_tags_test.sh
@@ -215,6 +215,16 @@ SELECT dolt_tag('v1');
 ROLLBACK TO sp1;
 "
 
+oracle_savepoint_tag_poststate "tag_delete_missing_inside_savepoint_invalidates" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'main');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'first');
+SAVEPOINT sp1;
+SELECT dolt_tag('-d', 'missing');
+ROLLBACK TO sp1;
+"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then


### PR DESCRIPTION
## Summary
- seal active savepoints when `dolt_tag`, `dolt_remote`, or `dolt_checkout` error inside a savepoint
- add direct savepoint regressions for missing-tag, missing-remote, and missing-checkout targets
- add Dolt oracle coverage for the same same-session savepoint parity cases

## Testing
- bash test/doltlite_savepoint.sh ./doltlite
- bash test/vc_oracle_tags_test.sh ./doltlite dolt
- bash test/vc_oracle_remotes_test.sh ./doltlite dolt
- bash test/vc_oracle_checkout_test.sh ./doltlite dolt