### PR TITLE
Oracle tests: +31 (merge_base, RENAME COL/TABLE, views, cherry-pick)

### DIFF
--- a/test/vc_oracle_error_recovery_test.sh
+++ b/test/vc_oracle_error_recovery_test.sh
@@ -2745,6 +2745,153 @@ SELECT dolt_merge('feat');
 " "SELECT id FROM t ORDER BY id;"
 
 # ═══════════════════════════════════════════════════════════════════
+# Section 85: RENAME errors
+# ═══════════════════════════════════════════════════════════════════
+echo "--- rename error probes ---"
+
+oracle "rename_col_that_does_not_exist_then_ok" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+ALTER TABLE t RENAME COLUMN nonexistent TO val;
+INSERT INTO t VALUES(2,'b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','after bad rename');
+" "SELECT id, v FROM t ORDER BY id;"
+
+oracle "rename_table_that_does_not_exist" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+ALTER TABLE nonexistent RENAME TO something;
+INSERT INTO t VALUES(2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','after bad rename table');
+" "SELECT id FROM t ORDER BY id;"
+
+oracle "rename_table_to_existing_name" "
+CREATE TABLE t1(id INTEGER PRIMARY KEY);
+CREATE TABLE t2(id INTEGER PRIMARY KEY);
+INSERT INTO t1 VALUES(1);
+INSERT INTO t2 VALUES(10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+ALTER TABLE t1 RENAME TO t2;
+INSERT INTO t1 VALUES(2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','after bad rename');
+" "SELECT id FROM t1 ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 86: Errors on empty / fresh database
+# ═══════════════════════════════════════════════════════════════════
+echo "--- empty db error probes ---"
+
+oracle "merge_on_empty_repo" "
+SELECT dolt_merge('bogus');
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c1');
+" "SELECT count(*) FROM t;"
+
+oracle "tag_on_empty_repo_then_commit" "
+SELECT dolt_tag('premature','HEAD');
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c1');
+SELECT dolt_tag('now','HEAD');
+" "SELECT count(*) FROM dolt_tags;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 87: Errors during sequential merges
+# ═══════════════════════════════════════════════════════════════════
+echo "--- sequential merge error probes ---"
+
+oracle "bad_then_good_then_bad_then_good_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','b1');
+INSERT INTO t VALUES(2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','b1');
+SELECT dolt_checkout('main');
+SELECT dolt_checkout('-b','b2');
+INSERT INTO t VALUES(3);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','b2');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('bogus1');
+SELECT dolt_merge('b1');
+SELECT dolt_merge('bogus2');
+SELECT dolt_merge('b2');
+" "SELECT count(*) FROM t;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 88: Errors with DROP INDEX / DROP COLUMN
+# ═══════════════════════════════════════════════════════════════════
+echo "--- drop index/col error probes ---"
+
+oracle "drop_column_nonexistent_then_ok" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+ALTER TABLE t DROP COLUMN nonexistent;
+INSERT INTO t VALUES(2,'b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','after bad drop col');
+" "SELECT id, v FROM t ORDER BY id;"
+
+oracle "drop_index_nonexistent_then_ok" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+DROP INDEX IF EXISTS nonexistent_idx;
+INSERT INTO t VALUES(2,'b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','after drop idx');
+" "SELECT id, v FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 89: Errors after partial cherry-pick attempts
+# ═══════════════════════════════════════════════════════════════════
+echo "--- partial cherry-pick errors ---"
+
+oracle "cherry_pick_bad_then_good_chain" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(2,'feat');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+SELECT dolt_cherry_pick('bogus1');
+SELECT dolt_cherry_pick('feat');
+SELECT dolt_cherry_pick('bogus2');
+" "SELECT id, v FROM t ORDER BY id;"
+
+oracle "revert_bad_then_good_chain" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c1');
+INSERT INTO t VALUES(2,'b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2');
+SELECT dolt_revert('bogus1');
+SELECT dolt_revert('HEAD');
+SELECT dolt_revert('bogus2');
+" "SELECT id, v FROM t ORDER BY id;"
+# ═══════════════════════════════════════════════════════════════════
 # Results
 # ═══════════════════════════════════════════════════════════════════
 echo ""

--- a/test/vc_oracle_feature_interaction_test.sh
+++ b/test/vc_oracle_feature_interaction_test.sh
@@ -9893,6 +9893,430 @@ SELECT dolt_merge('feat');
 # already covers the upsert-on-conflict behavior and is exercised above.
 
 # ═══════════════════════════════════════════════════════════════════
+# Section 253: dolt_merge_base property tests
+# ═══════════════════════════════════════════════════════════════════
+echo "--- merge_base probes ---"
+
+oracle "merge_base_matches_log_row" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+" "SELECT count(*) FROM dolt_log WHERE commit_hash = dolt_merge_base('main','feat');"
+
+oracle "merge_base_symmetric" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(3);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main');
+" "SELECT CASE WHEN dolt_merge_base('main','feat') = dolt_merge_base('feat','main') THEN 1 ELSE 0 END;"
+
+oracle "merge_base_of_branch_with_itself_is_head" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c1');
+INSERT INTO t VALUES(2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2');
+" "SELECT CASE WHEN dolt_merge_base('main','main') = dolt_hashof('HEAD') THEN 1 ELSE 0 END;"
+
+oracle "merge_base_after_ff_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "SELECT CASE WHEN dolt_merge_base('main','feat') = dolt_hashof('HEAD') THEN 1 ELSE 0 END;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 254: ALTER TABLE RENAME COLUMN + merge
+# ═══════════════════════════════════════════════════════════════════
+echo "--- rename column probes ---"
+
+oracle "rename_column_on_feat_query_works_after_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a'),(2,'b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+ALTER TABLE t RENAME COLUMN v TO val;
+INSERT INTO t(id, val) VALUES(3,'c');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat rename');
+SELECT dolt_checkout('main');
+INSERT INTO t(id, v) VALUES(4,'main_d');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main');
+SELECT dolt_merge('feat');
+" "SELECT count(*) FROM t;"
+
+oracle "rename_column_on_main_and_insert_feat" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(2,'b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+ALTER TABLE t RENAME COLUMN v TO val;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main rename');
+SELECT dolt_merge('feat');
+" "SELECT count(*) FROM t;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 255: ALTER TABLE RENAME TO + merge
+# ═══════════════════════════════════════════════════════════════════
+echo "--- rename table probes ---"
+
+oracle "rename_table_on_feat_merge_to_main" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+CREATE TABLE other(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1,'a');
+INSERT INTO other VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+ALTER TABLE t RENAME TO renamed;
+INSERT INTO renamed VALUES(2,'feat');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat rename');
+SELECT dolt_checkout('main');
+INSERT INTO other VALUES(2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main');
+SELECT dolt_merge('feat');
+" "SELECT id FROM other ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 256: VIEW on JOIN through merge
+# ═══════════════════════════════════════════════════════════════════
+echo "--- view-join probes ---"
+
+oracle "view_on_left_join_after_merge" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, v TEXT);
+CREATE TABLE b(id INTEGER PRIMARY KEY, aid INTEGER, n INTEGER);
+INSERT INTO a VALUES(1,'x'),(2,'y');
+INSERT INTO b VALUES(1,1,10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+CREATE VIEW a_with_b AS SELECT a.id, a.v, b.n FROM a LEFT JOIN b ON a.id=b.aid;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat view');
+SELECT dolt_checkout('main');
+INSERT INTO b VALUES(2,2,20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main');
+SELECT dolt_merge('feat');
+" "SELECT id, v, n FROM a_with_b ORDER BY id;"
+
+oracle "view_with_aggregate_across_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, grp TEXT, amt INTEGER);
+INSERT INTO t VALUES(1,'a',10),(2,'a',20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+CREATE VIEW totals AS SELECT grp, sum(amt) AS total FROM t GROUP BY grp;
+INSERT INTO t VALUES(3,'b',5);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(4,'a',100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main');
+SELECT dolt_merge('feat');
+" "SELECT grp, total FROM totals ORDER BY grp;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 257: Multi-commit DML in one branch + merge
+# ═══════════════════════════════════════════════════════════════════
+echo "--- multi-commit DML probes ---"
+
+oracle "three_commits_feat_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+INSERT INTO t VALUES(1,1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(2,2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','f1');
+UPDATE t SET v=20 WHERE id=2;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','f2');
+INSERT INTO t VALUES(3,30);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','f3');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "SELECT id, v FROM t ORDER BY id;"
+
+oracle "interleaved_main_feat_commits_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+INSERT INTO t VALUES(1,1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(10,10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','f1');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(100,100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','m1');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES(11,11);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','f2');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(101,101);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','m2');
+SELECT dolt_merge('feat');
+" "SELECT count(*) AS n, sum(id) AS s FROM t;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 258: UPDATE with correlated subquery (deeper)
+# ═══════════════════════════════════════════════════════════════════
+echo "--- correlated subquery UPDATE deeper ---"
+
+oracle "update_running_total_via_subquery" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, n INTEGER, total INTEGER);
+INSERT INTO t VALUES(1,10,0),(2,20,0),(3,30,0);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+UPDATE t SET total = (SELECT sum(n) FROM t AS t2 WHERE t2.id <= t.id);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat totals');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(4,40,0);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main adds');
+SELECT dolt_merge('feat');
+" "SELECT id, n, total FROM t ORDER BY id;"
+
+oracle "update_set_count_from_other_table" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, cnt INTEGER);
+CREATE TABLE items(id INTEGER PRIMARY KEY, owner INTEGER);
+INSERT INTO t VALUES(1,0),(2,0);
+INSERT INTO items VALUES(1,1),(2,1),(3,2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+UPDATE t SET cnt = (SELECT count(*) FROM items WHERE owner = t.id);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat count');
+SELECT dolt_checkout('main');
+INSERT INTO items VALUES(4,2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main');
+SELECT dolt_merge('feat');
+" "SELECT id, cnt FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 259: Conflict resolution in txn with multiple rows
+# ═══════════════════════════════════════════════════════════════════
+echo "--- conflict resolve multi-row probes ---"
+
+oracle "resolve_multiple_conflicts_via_update" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'base1'),(2,'base2');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+UPDATE t SET v='feat1' WHERE id=1;
+UPDATE t SET v='feat2' WHERE id=2;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+UPDATE t SET v='main1' WHERE id=1;
+UPDATE t SET v='main2' WHERE id=2;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main');
+BEGIN;
+SELECT dolt_merge('feat');
+UPDATE t SET v='resolved1' WHERE id=1;
+UPDATE t SET v='resolved2' WHERE id=2;
+DELETE FROM dolt_conflicts_t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','resolved');
+COMMIT;
+" "SELECT id, v FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 260: Post-merge queries with table + FK joins
+# ═══════════════════════════════════════════════════════════════════
+echo "--- post-merge FK query probes ---"
+
+oracle "three_table_join_filter_after_merge" "
+PRAGMA foreign_keys=1;
+CREATE TABLE a(id INTEGER PRIMARY KEY, cat TEXT);
+CREATE TABLE b(id INTEGER PRIMARY KEY, aid INTEGER REFERENCES a(id), tag TEXT);
+CREATE TABLE c(id INTEGER PRIMARY KEY, bid INTEGER REFERENCES b(id), score INTEGER);
+INSERT INTO a VALUES(1,'x'),(2,'y');
+INSERT INTO b VALUES(1,1,'t1'),(2,2,'t2');
+INSERT INTO c VALUES(1,1,50),(2,2,75);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO a VALUES(3,'z');
+INSERT INTO b VALUES(3,3,'t3');
+INSERT INTO c VALUES(3,3,90);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+UPDATE c SET score=80 WHERE id=1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main');
+SELECT dolt_merge('feat');
+" "SELECT a.cat FROM c JOIN b ON c.bid=b.id JOIN a ON b.aid=a.id WHERE c.score > 60 ORDER BY a.cat;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 261: Ordering semantics through merge
+# ═══════════════════════════════════════════════════════════════════
+echo "--- ordering probes ---"
+
+oracle "order_by_desc_with_nulls_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, n INTEGER);
+INSERT INTO t VALUES(1,10),(2,NULL),(3,5);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(4,20),(5,NULL);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "SELECT id FROM t WHERE n IS NOT NULL ORDER BY n DESC, id;"
+
+oracle "order_by_multiple_keys_after_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, a TEXT, b INTEGER);
+INSERT INTO t VALUES(1,'x',10),(2,'x',20),(3,'y',5);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(4,'x',15),(5,'y',25);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "SELECT id FROM t ORDER BY a, b DESC;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 262: DML batch cherry-pick
+# ═══════════════════════════════════════════════════════════════════
+echo "--- cherry-pick DML batch probes ---"
+
+oracle "cherry_pick_batch_insert" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(2,'b'),(3,'c'),(4,'d'),(5,'e');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat batch');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(10,'main_row');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main');
+SELECT dolt_cherry_pick('feat');
+" "SELECT id, v FROM t ORDER BY id;"
+
+oracle "cherry_pick_mix_update_delete" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+INSERT INTO t VALUES(1,1),(2,2),(3,3);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+UPDATE t SET v=99 WHERE id=1;
+DELETE FROM t WHERE id=2;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat mix');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(4,4);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main');
+SELECT dolt_cherry_pick('feat');
+" "SELECT id, v FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 263: VC state after many commits on one branch
+# ═══════════════════════════════════════════════════════════════════
+echo "--- deep branch probes ---"
+
+oracle "deep_branch_ff_merge_count" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','f1');
+INSERT INTO t VALUES(3);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','f2');
+INSERT INTO t VALUES(4);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','f3');
+INSERT INTO t VALUES(5);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','f4');
+INSERT INTO t VALUES(6);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','f5');
+INSERT INTO t VALUES(7);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','f6');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "SELECT count(*) FROM dolt_log;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 264: Repeated REPLACE + merge
+# ═══════════════════════════════════════════════════════════════════
+echo "--- replace stability probes ---"
+
+oracle "replace_every_row_both_sides_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a'),(2,'b'),(3,'c');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+REPLACE INTO t VALUES(1,'f1'),(2,'f2'),(3,'f3');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat replaces');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(4,'main4');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main');
+SELECT dolt_merge('feat');
+" "SELECT id, v FROM t ORDER BY id;"
+# ═══════════════════════════════════════════════════════════════════
 # Results
 # ═══════════════════════════════════════════════════════════════════
 echo ""


### PR DESCRIPTION
## Summary
- Error recovery: **158 → 168** (+10)
- Feature interaction: **517 → 538** (+21)
- Combined: **706/1000** on cross-engine parity goal
- All tests pass on doltlite + Dolt 1.86.3

## Feature interaction additions
- **`dolt_merge_base` properties (4)** — matches a row in `dolt_log`, symmetric in args, branch-with-itself equals `HEAD`, after ff-merge equals `HEAD`.
- **`ALTER TABLE RENAME COLUMN` + merge (2)** — renamed on feat, renamed on main while feat inserts.
- **`ALTER TABLE RENAME TO` (1)** — table renamed on feat, sibling table still queryable after merge.
- **VIEW + JOIN / aggregate (2)** — LEFT JOIN view queryable after merge, aggregate view re-queried after both-side inserts.
- **Multi-commit DML merged (2)** — 3 commits on feat then ff merge, interleaved commits 3-way merged.
- **Correlated-subquery UPDATE deeper (2)** — running total, count-from-other-table.
- **Multi-row conflict resolution in explicit txn (1)** — resolve via UPDATE + `DELETE FROM dolt_conflicts_t` + `dolt_commit` inside `BEGIN/COMMIT`.
- **Three-table JOIN filter after merge (1)** — `PRAGMA foreign_keys=1`, FK chain a→b→c with WHERE filter on leaf.
- **ORDER BY with NULLs / multi-keys (2)**.
- **Cherry-pick DML batch + mixed update/delete (2)**.
- **Deep ff-branch log count (1)**.
- **REPLACE every row both sides (1)**.

## Error recovery additions
- **RENAME errors (3)** — nonexistent column, nonexistent table, rename-to-already-existing.
- **Empty-database errors (2)** — `dolt_merge('bogus')` on empty repo; `dolt_tag` on empty repo.
- **Bad/good/bad/good merge chain (1)**.
- **Drop nonexistent col / index (2)**.
- **Cherry-pick and revert bad-then-good chains (2)**.

## Test plan
- [x] `bash test/vc_oracle_error_recovery_test.sh ./doltlite dolt` — 168/168 pass
- [x] `bash test/vc_oracle_feature_interaction_test.sh ./doltlite dolt` — 538/538 pass
- [ ] CI oracle-tests job green

🤖 Generated with [Claude Code](https://claude.com/claude-code)