### PR TITLE
Invalidate savepoints on remote op errors

### DIFF
--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -303,8 +303,9 @@ static void doltPushFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   int bForce = 0;
   int rc;
 
-  if( !cs ){ sqlite3_result_error(ctx, "no database", -1); return; }
+  if( !cs ){ (void)doltliteVcSealSavepointError(db); sqlite3_result_error(ctx, "no database", -1); return; }
   if( argc<2 ){
+    (void)doltliteVcSealSavepointError(db);
     sqlite3_result_error(ctx, "usage: dolt_push(remote, branch [, '--force'])", -1);
     return;
   }
@@ -312,6 +313,7 @@ static void doltPushFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   zRemoteName = (const char*)sqlite3_value_text(argv[0]);
   zBranch = (const char*)sqlite3_value_text(argv[1]);
   if( !zRemoteName || !zBranch ){
+    (void)doltliteVcSealSavepointError(db);
     sqlite3_result_error(ctx, "remote and branch required", -1);
     return;
   }
@@ -319,6 +321,7 @@ static void doltPushFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   if( argc>=3 ){
     const char *zOpt = (const char*)sqlite3_value_text(argv[2]);
     if( argc>3 ){
+      (void)doltliteVcSealSavepointError(db);
       sqlite3_result_error(ctx, "too many arguments", -1);
       return;
     }
@@ -327,6 +330,7 @@ static void doltPushFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     }else{
       char *zErr = sqlite3_mprintf("unknown option `%s`", zOpt ? zOpt : "");
       if( zErr ){
+        (void)doltliteVcSealSavepointError(db);
         sqlite3_result_error(ctx, zErr, -1);
         sqlite3_free(zErr);
       }else{
@@ -338,12 +342,14 @@ static void doltPushFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
 
   rc = chunkStoreFindRemote(cs, zRemoteName, &zUrl);
   if( rc!=SQLITE_OK || !zUrl ){
+    (void)doltliteVcSealSavepointError(db);
     sqlite3_result_error(ctx, "remote not found", -1);
     return;
   }
 
   pRemote = openRemoteByUrl(cs->pVfs, zUrl);
   if( !pRemote ){
+    (void)doltliteVcSealSavepointError(db);
     sqlite3_result_error(ctx, "failed to open remote (URL must start with file://)", -1);
     return;
   }
@@ -352,6 +358,7 @@ static void doltPushFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   pRemote->xClose(pRemote);
 
   if( rc!=SQLITE_OK ){
+    (void)doltliteVcSealSavepointError(db);
     remoteSqlResultError(ctx, rc,
       rc==SQLITE_ERROR ? "push failed (not a fast-forward?)" : 0);
     return;
@@ -431,30 +438,35 @@ static void doltFetchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   const char *zRemoteName;
   int rc;
 
-  if( !cs ){ sqlite3_result_error(ctx, "no database", -1); return; }
+  if( !cs ){ (void)doltliteVcSealSavepointError(db); sqlite3_result_error(ctx, "no database", -1); return; }
   if( argc<1 ){
+    (void)doltliteVcSealSavepointError(db);
     sqlite3_result_error(ctx, "usage: dolt_fetch(remote [, branch])", -1);
     return;
   }
 
   zRemoteName = (const char*)sqlite3_value_text(argv[0]);
   if( !zRemoteName ){
+    (void)doltliteVcSealSavepointError(db);
     sqlite3_result_error(ctx, "remote name required", -1);
     return;
   }
   if( argc>2 ){
+    (void)doltliteVcSealSavepointError(db);
     sqlite3_result_error(ctx, "too many arguments", -1);
     return;
   }
 
   rc = chunkStoreFindRemote(cs, zRemoteName, &zUrl);
   if( rc!=SQLITE_OK || !zUrl ){
+    (void)doltliteVcSealSavepointError(db);
     sqlite3_result_error(ctx, "remote not found", -1);
     return;
   }
 
   pRemote = openRemoteByUrl(cs->pVfs, zUrl);
   if( !pRemote ){
+    (void)doltliteVcSealSavepointError(db);
     sqlite3_result_error(ctx, "failed to open remote (URL must start with file://)", -1);
     return;
   }
@@ -464,12 +476,14 @@ static void doltFetchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     const char *zBranch = (const char*)sqlite3_value_text(argv[1]);
     if( !zBranch ){
       pRemote->xClose(pRemote);
+      (void)doltliteVcSealSavepointError(db);
       sqlite3_result_error(ctx, "branch name required", -1);
       return;
     }
     rc = doltliteFetch(cs, pRemote, zRemoteName, zBranch);
     if( rc!=SQLITE_OK ){
       pRemote->xClose(pRemote);
+      (void)doltliteVcSealSavepointError(db);
       remoteSqlResultError(ctx, rc,
         rc==SQLITE_NOTFOUND ? "fetch failed: branch not found on remote" : 0);
       return;
@@ -483,6 +497,7 @@ static void doltFetchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     rc = parseRemoteBranchNames(pRemote, &azNames, &nNames);
     if( rc!=SQLITE_OK ){
       pRemote->xClose(pRemote);
+      (void)doltliteVcSealSavepointError(db);
       sqlite3_result_error(ctx, "failed to read remote refs", -1);
       return;
     }
@@ -495,6 +510,7 @@ static void doltFetchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
       DoltliteRemote *pBrRemote = openRemoteByUrl(cs->pVfs, zUrl);
       if( !pBrRemote ){
         freeNameList(azNames, nNames);
+        (void)doltliteVcSealSavepointError(db);
         sqlite3_result_error(ctx, "failed to open remote (URL must start with file://)", -1);
         return;
       }
@@ -502,6 +518,7 @@ static void doltFetchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
       pBrRemote->xClose(pBrRemote);
       if( rc!=SQLITE_OK ){
         freeNameList(azNames, nNames);
+        (void)doltliteVcSealSavepointError(db);
         remoteSqlResultError(ctx, rc, "fetch failed");
         return;
       }
@@ -524,8 +541,9 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   RemoteSqlState savedState;
   int rc;
 
-  if( !cs ){ sqlite3_result_error(ctx, "no database", -1); return; }
+  if( !cs ){ (void)doltliteVcSealSavepointError(db); sqlite3_result_error(ctx, "no database", -1); return; }
   if( argc<2 ){
+    (void)doltliteVcSealSavepointError(db);
     sqlite3_result_error(ctx, "usage: dolt_pull(remote, branch)", -1);
     return;
   }
@@ -533,10 +551,12 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   zRemoteName = (const char*)sqlite3_value_text(argv[0]);
   zBranch = (const char*)sqlite3_value_text(argv[1]);
   if( !zRemoteName || !zBranch ){
+    (void)doltliteVcSealSavepointError(db);
     sqlite3_result_error(ctx, "remote and branch required", -1);
     return;
   }
   if( argc>2 ){
+    (void)doltliteVcSealSavepointError(db);
     sqlite3_result_error(ctx, "too many arguments", -1);
     return;
   }
@@ -544,17 +564,20 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
 
   rc = remoteSqlStateSave(db, cs, &savedState);
   if( rc!=SQLITE_OK ){
+    (void)doltliteVcSealSavepointError(db);
     sqlite3_result_error_code(ctx, rc);
     return;
   }
 
   rc = remoteSqlOpenNamedRemote(cs, zRemoteName, &zUrl, &pRemote);
   if( rc==SQLITE_NOTFOUND ){
+    (void)doltliteVcSealSavepointError(db);
     remoteSqlStateClear(&savedState);
     sqlite3_result_error(ctx, "remote not found", -1);
     return;
   }
   if( rc==SQLITE_CANTOPEN ){
+    (void)doltliteVcSealSavepointError(db);
     remoteSqlStateClear(&savedState);
     sqlite3_result_error(ctx, "failed to open remote (URL must start with file://)", -1);
     return;

--- a/test/doltlite_savepoint.sh
+++ b/test/doltlite_savepoint.sh
@@ -322,6 +322,33 @@ run_test_match "checkout_missing_savepoint_branch_stays_main" \
   "SELECT active_branch();" \
   "^main$" "$DB6g6"
 
+DB6g7=/tmp/test_savepoint6g7_$$.db; rm -f "$DB6g7"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'main'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6g7" > /dev/null 2>&1
+run_test_match "push_missing_remote_savepoint_rollback_to_errors" \
+  "SAVEPOINT sp1; SELECT dolt_push('missing','main'); ROLLBACK TO sp1;" \
+  "no such savepoint: sp1" "$DB6g7"
+run_test_match "push_missing_remote_savepoint_branch_stays_main" \
+  "SELECT active_branch();" \
+  "^main$" "$DB6g7"
+
+DB6g8=/tmp/test_savepoint6g8_$$.db; rm -f "$DB6g8"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'main'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6g8" > /dev/null 2>&1
+run_test_match "fetch_missing_remote_savepoint_rollback_to_errors" \
+  "SAVEPOINT sp1; SELECT dolt_fetch('missing'); ROLLBACK TO sp1;" \
+  "no such savepoint: sp1" "$DB6g8"
+run_test_match "fetch_missing_remote_savepoint_branch_stays_main" \
+  "SELECT active_branch();" \
+  "^main$" "$DB6g8"
+
+DB6g9=/tmp/test_savepoint6g9_$$.db; rm -f "$DB6g9"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'main'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6g9" > /dev/null 2>&1
+run_test_match "pull_missing_remote_savepoint_rollback_to_errors" \
+  "SAVEPOINT sp1; SELECT dolt_pull('missing','main'); ROLLBACK TO sp1;" \
+  "no such savepoint: sp1" "$DB6g9"
+run_test_match "pull_missing_remote_savepoint_branch_stays_main" \
+  "SELECT active_branch();" \
+  "^main$" "$DB6g9"
+
 DB6h=/tmp/test_savepoint6h_$$.db; rm -f "$DB6h"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'main'); SELECT dolt_commit('-A','-m','init'); SELECT dolt_branch('other'); SELECT dolt_checkout('other'); UPDATE t SET v='other'; SELECT dolt_commit('-A','-m','other'); SELECT dolt_checkout('main');" | $DOLTLITE "$DB6h" > /dev/null 2>&1
 run_test_match "checkout_savepoint_rollback_to_errors" \
@@ -459,7 +486,7 @@ run_test_match "branch_name_after_rollback" \
 # Cleanup
 # ============================================================
 rm -f "$DB1" "$DB2" "$DB3" "$DB4" "$DB4b" "$DB5" "$DB6" "$DB6b" "$DB7" "$DB8" \
-  "$DB6g2" "$DB6g3" "$DB6g4" "$DB6g5" "$DB6g6"
+  "$DB6g2" "$DB6g3" "$DB6g4" "$DB6g5" "$DB6g6" "$DB6g7" "$DB6g8" "$DB6g9"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/vc_oracle_remotes_test.sh
+++ b/test/vc_oracle_remotes_test.sh
@@ -218,6 +218,36 @@ SELECT dolt_remote('remove', 'missing');
 ROLLBACK TO sp1;
 "
 
+oracle_savepoint_remote_poststate "push_missing_remote_inside_savepoint_invalidates" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'main');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'first');
+SAVEPOINT sp1;
+SELECT dolt_push('missing', 'main');
+ROLLBACK TO sp1;
+"
+
+oracle_savepoint_remote_poststate "fetch_missing_remote_inside_savepoint_invalidates" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'main');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'first');
+SAVEPOINT sp1;
+SELECT dolt_fetch('missing');
+ROLLBACK TO sp1;
+"
+
+oracle_savepoint_remote_poststate "pull_missing_remote_inside_savepoint_invalidates" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'main');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'first');
+SAVEPOINT sp1;
+SELECT dolt_pull('missing', 'main');
+ROLLBACK TO sp1;
+"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then


### PR DESCRIPTION
## Summary
- invalidate active savepoints when `dolt_push`, `dolt_fetch`, or `dolt_pull` error inside a savepoint
- add direct savepoint regressions for missing-remote push/fetch/pull cases
- add Dolt oracle coverage for the same same-session savepoint parity cases

## Testing
- bash test/doltlite_savepoint.sh ./doltlite
- bash test/vc_oracle_remotes_test.sh ./doltlite dolt