### PR TITLE
Invalidate savepoints on clone errors

### DIFF
--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -131,6 +131,7 @@ static void remoteSqlRestoreAndReport(
     sqlite3_result_error_code(ctx, restoreRc);
     return;
   }
+  (void)doltliteVcSealSavepointError(db);
   remoteSqlResultError(ctx, opRc, zMsg);
 }
 
@@ -679,24 +680,28 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   RemoteSqlState savedState;
   int rc;
 
-  if( !cs ){ sqlite3_result_error(ctx, "no database", -1); return; }
+  if( !cs ){ (void)doltliteVcSealSavepointError(db); sqlite3_result_error(ctx, "no database", -1); return; }
   if( argc<1 ){
+    (void)doltliteVcSealSavepointError(db);
     sqlite3_result_error(ctx, "usage: dolt_clone(url)", -1);
     return;
   }
 
   zUrl = (const char*)sqlite3_value_text(argv[0]);
   if( !zUrl ){
+    (void)doltliteVcSealSavepointError(db);
     sqlite3_result_error(ctx, "url required", -1);
     return;
   }
   if( argc>1 ){
+    (void)doltliteVcSealSavepointError(db);
     sqlite3_result_error(ctx, "too many arguments", -1);
     return;
   }
   memset(&savedState, 0, sizeof(savedState));
 
   if( doltliteHasUncommittedChanges(db) ){
+    (void)doltliteVcSealSavepointError(db);
     sqlite3_result_error(ctx,
       "database has uncommitted changes — clone into a fresh database", -1);
     return;
@@ -714,6 +719,7 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
       doltliteCommitClear(&c);
     }
     if( !virgin ){
+      (void)doltliteVcSealSavepointError(db);
       sqlite3_result_error(ctx, "database is not empty — clone into a fresh database", -1);
       return;
     }
@@ -721,6 +727,7 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
 
   rc = remoteSqlStateSave(db, cs, &savedState);
   if( rc!=SQLITE_OK ){
+    (void)doltliteVcSealSavepointError(db);
     sqlite3_result_error_code(ctx, rc);
     return;
   }

--- a/test/doltlite_savepoint.sh
+++ b/test/doltlite_savepoint.sh
@@ -348,7 +348,13 @@ run_test_match "pull_missing_remote_savepoint_rollback_to_errors" \
 run_test_match "pull_missing_remote_savepoint_branch_stays_main" \
   "SELECT active_branch();" \
   "^main$" "$DB6g9"
-
+DB6g10=/tmp/test_savepoint6g10_$$.db; rm -f "$DB6g10"
+run_test_match "clone_bad_url_savepoint_rollback_to_errors" \
+  "SAVEPOINT sp1; SELECT dolt_clone('bogus://remote'); ROLLBACK TO sp1;" \
+  "no such savepoint: sp1" "$DB6g10"
+run_test_match "clone_bad_url_savepoint_branch_stays_main" \
+  "SELECT active_branch();" \
+  "^main$" "$DB6g10"
 DB6h=/tmp/test_savepoint6h_$$.db; rm -f "$DB6h"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'main'); SELECT dolt_commit('-A','-m','init'); SELECT dolt_branch('other'); SELECT dolt_checkout('other'); UPDATE t SET v='other'; SELECT dolt_commit('-A','-m','other'); SELECT dolt_checkout('main');" | $DOLTLITE "$DB6h" > /dev/null 2>&1
 run_test_match "checkout_savepoint_rollback_to_errors" \
@@ -486,7 +492,7 @@ run_test_match "branch_name_after_rollback" \
 # Cleanup
 # ============================================================
 rm -f "$DB1" "$DB2" "$DB3" "$DB4" "$DB4b" "$DB5" "$DB6" "$DB6b" "$DB7" "$DB8" \
-  "$DB6g2" "$DB6g3" "$DB6g4" "$DB6g5" "$DB6g6" "$DB6g7" "$DB6g8" "$DB6g9"
+  "$DB6g2" "$DB6g3" "$DB6g4" "$DB6g5" "$DB6g6" "$DB6g7" "$DB6g8" "$DB6g9" "$DB6g10"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/vc_oracle_remotes_test.sh
+++ b/test/vc_oracle_remotes_test.sh
@@ -130,6 +130,36 @@ oracle_savepoint_remote_poststate() {
   fi
 }
 
+oracle_savepoint_clone_poststate() {
+  local name="$1" setup="$2" query="$3"
+  local dir="$TMPROOT/${name}_clone_sp"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_rc dt_rc dl_post dt_post
+
+  vc_oracle_run_doltlite_script "$dir/dl/db" "$dir/dl.out" "$dir/dl.err" "$setup"
+  dl_rc=$?
+  dl_post=$(printf ".headers off\n.mode list\n%s\n" "$query" \
+            | "$DOLTLITE" "$dir/dl/db" 2>>"$dir/dl.err" \
+            | tr -d '\r')
+
+  local dolt_setup
+  dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
+  vc_oracle_run_dolt_script_for_error "$dir/dt" "$dir/dt.out" "$dir/dt.err" "$dolt_setup"
+  dt_rc=$?
+  dt_post=$(cd "$dir/dt" && "$DOLT" sql -r csv -q "$query" 2>>"$dir/dt.err" | tail -n +2 | tr -d '"\r')
+
+  if [ "$dl_rc" -ne 0 ] && [ "$dt_rc" -ne 0 ] && [ "$dl_post" = "$dt_post" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite rc/post:"; { echo "$dl_rc"; echo "$dl_post"; } | sed 's/^/      /'
+    echo "    dolt rc/post:"; { echo "$dt_rc"; echo "$dt_post"; } | sed 's/^/      /'
+  fi
+}
+
 echo "=== Version Control Oracle Tests: dolt_remotes ==="
 echo ""
 
@@ -247,6 +277,12 @@ SAVEPOINT sp1;
 SELECT dolt_pull('missing', 'main');
 ROLLBACK TO sp1;
 "
+
+oracle_savepoint_clone_poststate "clone_bad_url_inside_savepoint_invalidates" "
+SAVEPOINT sp1;
+SELECT dolt_clone('bogus://remote');
+ROLLBACK TO sp1;
+" "SELECT active_branch();"
 
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="


### PR DESCRIPTION
## Summary
- invalidate active savepoints when `dolt_clone()` restores and reports an error
- add local savepoint coverage for bad-url clone inside a savepoint
- add remotes oracle coverage for the same savepoint invalidation case

## Testing
- bash test/doltlite_savepoint.sh ./doltlite
- bash test/vc_oracle_remotes_test.sh ./doltlite dolt
- bash test/vc_oracle_error_recovery_test.sh ./doltlite dolt
