### PR TITLE
Oracle tests: +32 (window frames, multi-CTE, RIGHT JOIN, round-trip)

### DIFF
--- a/test/vc_oracle_error_recovery_test.sh
+++ b/test/vc_oracle_error_recovery_test.sh
@@ -3074,6 +3074,172 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id FROM t ORDER BY id;"
 # ═══════════════════════════════════════════════════════════════════
+# Section 100: Cherry-pick with no-op commit
+# ═══════════════════════════════════════════════════════════════════
+echo "--- cherry-pick no-op probes ---"
+
+oracle "cherry_pick_then_cherry_pick_noop" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(2,'feat');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+SELECT dolt_cherry_pick('feat');
+SELECT dolt_cherry_pick('feat');
+INSERT INTO t VALUES(3,'post');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','post');
+" "SELECT id, v FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 101: ALTER errors during merge prep
+# ═══════════════════════════════════════════════════════════════════
+echo "--- alter errors ---"
+
+oracle "alter_bad_keyword_then_ok_commit" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+ALTER TABLE t BOGUS_KEYWORD extra INTEGER;
+INSERT INTO t VALUES(2,'b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2');
+" "SELECT id, v FROM t ORDER BY id;"
+
+oracle "add_col_name_clash_then_ok" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+ALTER TABLE t ADD COLUMN id INTEGER;
+INSERT INTO t VALUES(2,'b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','after dup col');
+" "SELECT id, v FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 102: DROP INDEX cases
+# ═══════════════════════════════════════════════════════════════════
+echo "--- drop index probes ---"
+
+oracle "drop_index_twice_then_ok" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+CREATE INDEX idx ON t(v);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+DROP INDEX idx;
+DROP INDEX idx;
+INSERT INTO t VALUES(2,'b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2');
+" "SELECT id, v FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 103: Window function with syntax errors
+# ═══════════════════════════════════════════════════════════════════
+echo "--- bad window funcs ---"
+
+oracle "bad_window_partition_then_ok" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, n INTEGER);
+INSERT INTO t VALUES(1,10),(2,20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT id, ROW_NUMBER() OVER (PARTITION BY nonexistent) FROM t;
+INSERT INTO t VALUES(3,30);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2');
+" "SELECT count(*) FROM t;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 104: Errors with UNION of different-arity selects
+# ═══════════════════════════════════════════════════════════════════
+echo "--- UNION arity error probes ---"
+
+oracle "union_arity_mismatch_then_ok" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT id FROM t UNION SELECT id, v FROM t;
+INSERT INTO t VALUES(2,'b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2');
+" "SELECT id, v FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 105: Invalid CTE then ok
+# ═══════════════════════════════════════════════════════════════════
+echo "--- CTE error probes ---"
+
+oracle "bad_cte_self_ref_then_ok" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+WITH bad AS (SELECT id FROM bad) SELECT * FROM bad;
+INSERT INTO t VALUES(2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2');
+" "SELECT count(*) FROM t;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 106: Error during JOIN on nonexistent col
+# ═══════════════════════════════════════════════════════════════════
+echo "--- JOIN errors ---"
+
+oracle "join_on_nonexistent_col_then_ok" "
+CREATE TABLE a(id INTEGER PRIMARY KEY);
+CREATE TABLE b(id INTEGER PRIMARY KEY);
+INSERT INTO a VALUES(1);
+INSERT INTO b VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT a.id FROM a JOIN b ON a.bogus=b.id;
+INSERT INTO a VALUES(2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2');
+" "SELECT id FROM a ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 107: Error storms around dolt_add
+# ═══════════════════════════════════════════════════════════════════
+echo "--- dolt_add error probes ---"
+
+oracle "many_bad_adds_then_ok" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('nonexistent1');
+SELECT dolt_add('nonexistent2');
+SELECT dolt_add('nonexistent3');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','survived');
+" "SELECT count(*) FROM dolt_log;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 108: Errors in dolt_log-aware workflows
+# ═══════════════════════════════════════════════════════════════════
+echo "--- log-aware workflow errors ---"
+
+oracle "log_query_after_bad_ref_check" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c1');
+INSERT INTO t VALUES(2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2');
+SELECT commit_hash FROM dolt_log WHERE commit_hash = 'not_a_real_hash';
+INSERT INTO t VALUES(3);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c3');
+" "SELECT count(*) FROM dolt_log;"
+# ═══════════════════════════════════════════════════════════════════
 # Results
 # ═══════════════════════════════════════════════════════════════════
 echo ""

--- a/test/vc_oracle_error_recovery_test.sh
+++ b/test/vc_oracle_error_recovery_test.sh
@@ -2892,6 +2892,188 @@ SELECT dolt_revert('HEAD');
 SELECT dolt_revert('bogus2');
 " "SELECT id, v FROM t ORDER BY id;"
 # ═══════════════════════════════════════════════════════════════════
+# Section 90: Set operation errors
+# ═══════════════════════════════════════════════════════════════════
+echo "--- set op error probes ---"
+
+oracle "bad_union_then_ok_commit" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c1');
+SELECT v FROM t UNION SELECT bogus FROM nonexistent;
+INSERT INTO t VALUES(2,'b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2');
+" "SELECT id, v FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 91: Error between successive commits
+# ═══════════════════════════════════════════════════════════════════
+echo "--- error between commits ---"
+
+oracle "error_right_after_commit_then_commit" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c1');
+SELECT * FROM bogus;
+INSERT INTO t VALUES(2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2');
+SELECT * FROM bogus;
+INSERT INTO t VALUES(3);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c3');
+" "SELECT count(*) FROM dolt_log;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 92: Error on UPDATE with bad subquery
+# ═══════════════════════════════════════════════════════════════════
+echo "--- UPDATE with bad subquery probes ---"
+
+oracle "update_subquery_bogus_col_then_ok" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+INSERT INTO t VALUES(1,10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+UPDATE t SET v = (SELECT bogus_col FROM t LIMIT 1);
+UPDATE t SET v = 99 WHERE id=1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2');
+" "SELECT id, v FROM t;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 93: Error on CAST / arithmetic
+# ═══════════════════════════════════════════════════════════════════
+echo "--- arithmetic error probes ---"
+
+oracle "divide_by_zero_update_skipped" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, n INTEGER);
+INSERT INTO t VALUES(1,10),(2,20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+UPDATE t SET n = n / (SELECT count(*) - 2 FROM t) WHERE id=1;
+INSERT INTO t VALUES(3,30);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2');
+" "SELECT count(*) FROM t;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 94: Error with nonexistent tag in reset
+# ═══════════════════════════════════════════════════════════════════
+echo "--- reset to nonexistent tag ---"
+
+oracle "reset_to_deleted_tag_then_ok" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c1');
+SELECT dolt_tag('snap','HEAD');
+SELECT dolt_tag('-d','snap');
+INSERT INTO t VALUES(2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2');
+SELECT dolt_reset('--hard','snap');
+INSERT INTO t VALUES(3);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c3');
+" "SELECT id FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 95: Error on merge_base bogus branches
+# ═══════════════════════════════════════════════════════════════════
+echo "--- bad merge_base args ---"
+
+oracle "merge_base_bogus_then_ok" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c1');
+SELECT dolt_merge_base('main','bogus');
+SELECT dolt_merge_base('bogus','main');
+INSERT INTO t VALUES(2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2');
+" "SELECT count(*) FROM t;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 96: Error on INSERT into view
+# ═══════════════════════════════════════════════════════════════════
+echo "--- INSERT into view probes ---"
+
+oracle "insert_into_view_then_ok" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+CREATE VIEW v_pos AS SELECT id, v FROM t WHERE id > 0;
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c1');
+INSERT INTO v_pos VALUES(2,'b');
+INSERT INTO t VALUES(2,'b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2');
+" "SELECT id, v FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 97: Error on DROP VIEW nonexistent
+# ═══════════════════════════════════════════════════════════════════
+echo "--- drop view errors ---"
+
+oracle "drop_nonexistent_view_then_ok" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c1');
+DROP VIEW nonexistent_view;
+INSERT INTO t VALUES(2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2');
+" "SELECT id FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 98: Error storm on merge operations
+# ═══════════════════════════════════════════════════════════════════
+echo "--- merge error storm ---"
+
+oracle "ten_bogus_merges_then_real" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('b1');
+SELECT dolt_merge('b2');
+SELECT dolt_merge('b3');
+SELECT dolt_merge('b4');
+SELECT dolt_merge('b5');
+SELECT dolt_merge('b6');
+SELECT dolt_merge('b7');
+SELECT dolt_merge('b8');
+SELECT dolt_merge('b9');
+SELECT dolt_merge('b10');
+SELECT dolt_merge('feat');
+" "SELECT count(*) FROM t;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 99: Error on wrong arity dolt functions
+# ═══════════════════════════════════════════════════════════════════
+echo "--- wrong arity probes ---"
+
+oracle "hashof_no_args_then_ok" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c1');
+SELECT dolt_hashof();
+INSERT INTO t VALUES(2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2');
+" "SELECT id FROM t ORDER BY id;"
+# ═══════════════════════════════════════════════════════════════════
 # Results
 # ═══════════════════════════════════════════════════════════════════
 echo ""

--- a/test/vc_oracle_feature_interaction_test.sh
+++ b/test/vc_oracle_feature_interaction_test.sh
@@ -10317,6 +10317,437 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 # ═══════════════════════════════════════════════════════════════════
+# Section 265: Set operations (UNION/INTERSECT/EXCEPT) after merge
+# ═══════════════════════════════════════════════════════════════════
+echo "--- set ops after merge ---"
+
+oracle "union_distinct_after_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+INSERT INTO t VALUES(1,10),(2,10),(3,20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(4,30),(5,10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "SELECT v FROM t UNION SELECT v FROM t ORDER BY v;"
+
+oracle "intersect_across_tables_after_merge" "
+CREATE TABLE t1(id INTEGER PRIMARY KEY, v INTEGER);
+CREATE TABLE t2(id INTEGER PRIMARY KEY, v INTEGER);
+INSERT INTO t1 VALUES(1,10),(2,20);
+INSERT INTO t2 VALUES(1,20),(2,30);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t1 VALUES(3,40);
+INSERT INTO t2 VALUES(3,40);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "SELECT v FROM t1 INTERSECT SELECT v FROM t2 ORDER BY v;"
+
+oracle "except_across_tables_after_merge" "
+CREATE TABLE a(v INTEGER);
+CREATE TABLE b(v INTEGER);
+INSERT INTO a VALUES(1),(2),(3);
+INSERT INTO b VALUES(2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO a VALUES(4);
+INSERT INTO b VALUES(3);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "SELECT v FROM a EXCEPT SELECT v FROM b ORDER BY v;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 266: Case-insensitive search (via LOWER/UPPER) after merge
+# ═══════════════════════════════════════════════════════════════════
+echo "--- case-insensitive lookup ---"
+
+oracle "lower_lookup_after_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'Alpha'),(2,'beta'),(3,'GAMMA');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(4,'Delta');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "SELECT id FROM t WHERE LOWER(v) IN ('alpha','beta','delta') ORDER BY id;"
+
+oracle "upper_filter_with_like_after_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'red apple'),(2,'RED BERRY'),(3,'Green apple');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(4,'RED GRAPE');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "SELECT id FROM t WHERE UPPER(v) LIKE 'RED%' ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 267: Multi-index table + merge
+# ═══════════════════════════════════════════════════════════════════
+echo "--- multi-index probes ---"
+
+oracle "two_indexes_both_queried_after_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, a INTEGER, b INTEGER);
+CREATE INDEX idx_a ON t(a);
+CREATE INDEX idx_b ON t(b);
+INSERT INTO t VALUES(1,10,100),(2,20,200);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(3,30,300),(4,40,400);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "SELECT id FROM t WHERE a > 15 AND b < 350 ORDER BY id;"
+
+oracle "unique_index_distinct_cols_after_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, code TEXT);
+CREATE UNIQUE INDEX idx_code ON t(code);
+INSERT INTO t VALUES(1,'X'),(2,'Y');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(3,'Z');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "SELECT count(DISTINCT code) FROM t;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 268: dolt_branches column shape
+# ═══════════════════════════════════════════════════════════════════
+echo "--- dolt_branches column shape ---"
+
+oracle "branches_dirty_flag_is_boolean" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c1');
+SELECT dolt_branch('clean');
+" "SELECT count(*) FROM dolt_branches WHERE dirty IN (0,1);"
+
+oracle "branches_latest_commit_hash_nonempty" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c1');
+SELECT dolt_branch('b1');
+" "SELECT count(*) FROM dolt_branches WHERE length(hash) > 0;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 269: dolt_log parent traversal
+# ═══════════════════════════════════════════════════════════════════
+echo "--- dolt_log parent traversal ---"
+
+oracle "log_has_expected_number_of_merge_commits" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(3);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main');
+SELECT dolt_merge('feat','--no-ff','-m','merge_c');
+" "SELECT count(*) FROM dolt_log WHERE message='merge_c';"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 270: Complex UPDATE with multiple subqueries
+# ═══════════════════════════════════════════════════════════════════
+echo "--- complex UPDATE probes ---"
+
+oracle "update_with_min_subquery_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, n INTEGER);
+INSERT INTO t VALUES(1,100),(2,50),(3,75);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+UPDATE t SET n = n - (SELECT min(n) FROM t);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat normalize');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(4,200);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main');
+SELECT dolt_merge('feat');
+" "SELECT id, n FROM t ORDER BY id;"
+
+oracle "update_exists_filter_then_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT, active INTEGER);
+CREATE TABLE ids(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1,'a',0),(2,'b',0),(3,'c',0);
+INSERT INTO ids VALUES(1),(3);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+UPDATE t SET active=1 WHERE EXISTS (SELECT 1 FROM ids WHERE ids.id=t.id);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat activate');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(4,'d',0);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main');
+SELECT dolt_merge('feat');
+" "SELECT id, v, active FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 271: Large-ish multi-table merges
+# ═══════════════════════════════════════════════════════════════════
+echo "--- large multi-table merge probes ---"
+
+oracle "four_tables_each_touched_merge" "
+CREATE TABLE t1(id INTEGER PRIMARY KEY, v INTEGER);
+CREATE TABLE t2(id INTEGER PRIMARY KEY, v INTEGER);
+CREATE TABLE t3(id INTEGER PRIMARY KEY, v INTEGER);
+CREATE TABLE t4(id INTEGER PRIMARY KEY, v INTEGER);
+INSERT INTO t1 VALUES(1,1);
+INSERT INTO t2 VALUES(1,2);
+INSERT INTO t3 VALUES(1,3);
+INSERT INTO t4 VALUES(1,4);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t1 VALUES(2,10);
+INSERT INTO t2 VALUES(2,20);
+INSERT INTO t3 VALUES(2,30);
+INSERT INTO t4 VALUES(2,40);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+INSERT INTO t1 VALUES(3,100);
+INSERT INTO t2 VALUES(3,200);
+INSERT INTO t3 VALUES(3,300);
+INSERT INTO t4 VALUES(3,400);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main');
+SELECT dolt_merge('feat');
+" "SELECT 't1' AS tbl, sum(v) AS s FROM t1 UNION ALL SELECT 't2', sum(v) FROM t2 UNION ALL SELECT 't3', sum(v) FROM t3 UNION ALL SELECT 't4', sum(v) FROM t4 ORDER BY 1;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 272: Boolean-like flags through merge
+# ═══════════════════════════════════════════════════════════════════
+echo "--- boolean-like flags through merge ---"
+
+oracle "zero_one_flags_toggled_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, active INTEGER);
+INSERT INTO t VALUES(1,0),(2,1),(3,0),(4,1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+UPDATE t SET active = 1 - active WHERE id IN (1,3);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat toggled');
+SELECT dolt_checkout('main');
+UPDATE t SET active = 0 WHERE id=2;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main');
+SELECT dolt_merge('feat');
+" "SELECT id, active FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 273: Commit message exact preservation
+# ═══════════════════════════════════════════════════════════════════
+echo "--- commit message preservation ---"
+
+oracle "message_with_equals_and_slash" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','k=v/a=b');
+INSERT INTO t VALUES(2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','path/to/file');
+" "SELECT count(*) FROM dolt_log WHERE message IN ('k=v/a=b','path/to/file');"
+
+oracle "message_with_numbers" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','v1.2.3');
+INSERT INTO t VALUES(2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','#123 fix');
+" "SELECT count(*) FROM dolt_log WHERE message IN ('v1.2.3','#123 fix');"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 274: INSERT with column subset + DEFAULT
+# ═══════════════════════════════════════════════════════════════════
+echo "--- INSERT col subset probes ---"
+
+oracle "insert_subset_cols_different_on_branches" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, a TEXT DEFAULT 'da', b TEXT DEFAULT 'db', c TEXT DEFAULT 'dc');
+INSERT INTO t(id) VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t(id,a) VALUES(2,'fa2');
+INSERT INTO t(id,b) VALUES(3,'fb3');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+INSERT INTO t(id,c) VALUES(10,'mc10');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main');
+SELECT dolt_merge('feat');
+" "SELECT id, a, b, c FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 275: Diamond with convergent delete
+# ═══════════════════════════════════════════════════════════════════
+echo "--- diamond convergent delete ---"
+
+oracle "diamond_convergent_delete_same_row" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'keep'),(2,'del'),(3,'keep2');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','left');
+DELETE FROM t WHERE id=2;
+INSERT INTO t VALUES(10,'left');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','left');
+SELECT dolt_checkout('main');
+SELECT dolt_checkout('-b','right');
+DELETE FROM t WHERE id=2;
+INSERT INTO t VALUES(20,'right');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','right');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('left');
+SELECT dolt_merge('right');
+" "SELECT id, v FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 276: Very long commit messages
+# ═══════════════════════════════════════════════════════════════════
+echo "--- long messages ---"
+
+oracle "long_message_survives_commit_and_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','this is a fairly long commit message that describes several things about the change and has some detail');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "SELECT count(*) FROM dolt_log WHERE length(message) > 50;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 277: dolt_hashof across merges
+# ═══════════════════════════════════════════════════════════════════
+echo "--- hashof across merges ---"
+
+oracle "hashof_changes_after_noff_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(3);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main');
+SELECT dolt_merge('feat','--no-ff','-m','merge');
+" "SELECT count(DISTINCT commit_hash) FROM dolt_log;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 278: Checkout back-and-forth with work on both
+# ═══════════════════════════════════════════════════════════════════
+echo "--- alternating work + checkout ---"
+
+oracle "alternate_commits_both_branches_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, owner TEXT);
+INSERT INTO t VALUES(1,'base');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(2,'f');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','f1');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(10,'m');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','m1');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES(3,'f');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','f2');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(11,'m');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','m2');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES(4,'f');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','f3');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "SELECT owner, count(*) FROM t GROUP BY owner ORDER BY owner;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 279: Tag listing stability
+# ═══════════════════════════════════════════════════════════════════
+echo "--- tag list stability ---"
+
+oracle "multiple_tags_listed_in_order" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c1');
+SELECT dolt_tag('z_last','HEAD');
+SELECT dolt_tag('a_first','HEAD');
+SELECT dolt_tag('m_mid','HEAD');
+" "SELECT tag_name FROM dolt_tags ORDER BY tag_name;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 280: Large string values through merge
+# ═══════════════════════════════════════════════════════════════════
+echo "--- long string payload probes ---"
+
+oracle "long_string_update_one_side_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'short');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+UPDATE t SET v='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' WHERE id=1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat long');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(2,'other');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main');
+SELECT dolt_merge('feat');
+" "SELECT id, length(v) AS L FROM t ORDER BY id;"
+# ═══════════════════════════════════════════════════════════════════
 # Results
 # ═══════════════════════════════════════════════════════════════════
 echo ""

--- a/test/vc_oracle_feature_interaction_test.sh
+++ b/test/vc_oracle_feature_interaction_test.sh
@@ -10748,6 +10748,406 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, length(v) AS L FROM t ORDER BY id;"
 # ═══════════════════════════════════════════════════════════════════
+# Section 281: Window function deeper patterns
+# ═══════════════════════════════════════════════════════════════════
+echo "--- window deeper ---"
+
+oracle "partition_by_frame_after_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, grp INTEGER, v INTEGER);
+INSERT INTO t VALUES(1,1,10),(2,1,20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(3,2,30),(4,2,40);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "SELECT id, SUM(v) OVER (PARTITION BY grp ORDER BY id ROWS UNBOUNDED PRECEDING) AS rsum FROM t ORDER BY id;"
+
+oracle "dense_rank_after_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, s INTEGER);
+INSERT INTO t VALUES(1,10),(2,10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(3,20),(4,30);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "SELECT id, DENSE_RANK() OVER (ORDER BY s) AS r FROM t ORDER BY id;"
+
+oracle "first_value_after_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+INSERT INTO t VALUES(1,100),(2,200);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(3,300),(4,400);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "SELECT id, FIRST_VALUE(v) OVER (ORDER BY id) AS fv FROM t ORDER BY id;"
+
+oracle "lead_window_after_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+INSERT INTO t VALUES(1,10),(2,20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(3,30),(4,40);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "SELECT id, COALESCE(LEAD(v) OVER (ORDER BY id), -1) AS nxt FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 282: Multi-CTE patterns
+# ═══════════════════════════════════════════════════════════════════
+echo "--- multi-CTE probes ---"
+
+oracle "chained_ctes_across_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, n INTEGER);
+INSERT INTO t VALUES(1,10),(2,20),(3,30);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(4,40),(5,50);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "WITH low AS (SELECT id, n FROM t WHERE n < 25), high AS (SELECT id, n FROM t WHERE n >= 25) SELECT id, n FROM low UNION ALL SELECT id, n FROM high ORDER BY id;"
+
+oracle "cte_referencing_another_cte" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, n INTEGER);
+INSERT INTO t VALUES(1,5),(2,10),(3,15);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(4,20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "WITH doubled AS (SELECT id, n*2 AS d FROM t), filtered AS (SELECT id, d FROM doubled WHERE d > 15) SELECT id, d FROM filtered ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 283: RIGHT JOIN after merge
+# ═══════════════════════════════════════════════════════════════════
+echo "--- RIGHT JOIN probes ---"
+
+oracle "right_join_after_merge" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, tag TEXT);
+CREATE TABLE b(id INTEGER PRIMARY KEY, tag TEXT);
+INSERT INTO a VALUES(1,'a1'),(2,'a2');
+INSERT INTO b VALUES(2,'b2'),(3,'b3');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO b VALUES(4,'b4');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "SELECT COALESCE(a.tag, 'none') AS at, b.tag AS bt FROM a RIGHT JOIN b ON a.id=b.id ORDER BY b.tag;"
+
+oracle "left_join_count_after_merge" "
+CREATE TABLE owners(id INTEGER PRIMARY KEY);
+CREATE TABLE items(id INTEGER PRIMARY KEY, owner_id INTEGER);
+INSERT INTO owners VALUES(1),(2),(3);
+INSERT INTO items VALUES(1,1),(2,1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO items VALUES(3,2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "SELECT owners.id, count(items.id) AS cnt FROM owners LEFT JOIN items ON owners.id=items.owner_id GROUP BY owners.id ORDER BY owners.id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 284: Boolean expressions in SELECT
+# ═══════════════════════════════════════════════════════════════════
+echo "--- boolean expressions in SELECT ---"
+
+oracle "comparison_result_as_column" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, n INTEGER);
+INSERT INTO t VALUES(1,5),(2,15),(3,25);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(4,35);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "SELECT id, CASE WHEN n > 20 THEN 1 ELSE 0 END AS big FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 285: INSERT with computed values
+# ═══════════════════════════════════════════════════════════════════
+echo "--- computed-value INSERT probes ---"
+
+oracle "insert_values_with_subquery_after_merge" "
+CREATE TABLE src(id INTEGER PRIMARY KEY, n INTEGER);
+CREATE TABLE counts(label VARCHAR(32) PRIMARY KEY, n INTEGER);
+INSERT INTO src VALUES(1,10),(2,20),(3,30);
+INSERT INTO counts VALUES('seed', 0);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO counts VALUES('feat_cnt', (SELECT count(*) FROM src));
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat counts');
+SELECT dolt_checkout('main');
+INSERT INTO counts VALUES('main_cnt', 99);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main');
+SELECT dolt_merge('feat');
+" "SELECT label, n FROM counts ORDER BY label;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 286: DELETE with JOIN-like WHERE subquery
+# ═══════════════════════════════════════════════════════════════════
+echo "--- DELETE with subquery ---"
+
+oracle "delete_where_in_select_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+CREATE TABLE blocklist(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1,'a'),(2,'b'),(3,'c'),(4,'d');
+INSERT INTO blocklist VALUES(2),(4);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+DELETE FROM t WHERE id IN (SELECT id FROM blocklist);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat deletes blocked');
+SELECT dolt_checkout('main');
+INSERT INTO blocklist VALUES(5);
+INSERT INTO t VALUES(5,'e');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main');
+SELECT dolt_merge('feat');
+" "SELECT id, v FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 287: Schema-only modifications across branches
+# ═══════════════════════════════════════════════════════════════════
+echo "--- schema-only modifications ---"
+
+oracle "add_then_drop_col_same_branch_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+ALTER TABLE t ADD COLUMN tmp INTEGER DEFAULT 0;
+ALTER TABLE t DROP COLUMN tmp;
+INSERT INTO t VALUES(2,'feat');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat noop schema');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(3,'main');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main');
+SELECT dolt_merge('feat');
+" "SELECT id, v FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 288: Max/min with tie-breaking after merge
+# ═══════════════════════════════════════════════════════════════════
+echo "--- max/min tie-breaking ---"
+
+oracle "min_tie_break_by_id_after_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, score INTEGER);
+INSERT INTO t VALUES(1,50),(2,50),(3,40);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(4,40);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "SELECT id FROM t WHERE score = (SELECT min(score) FROM t) ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 289: Mixed COUNT variants after merge
+# ═══════════════════════════════════════════════════════════════════
+echo "--- count variants ---"
+
+oracle "count_star_vs_count_col_with_nulls" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a'),(2,NULL),(3,'c');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(4,NULL),(5,'e');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "SELECT count(*) AS c_all, count(v) AS c_nn, count(DISTINCT v) AS c_dist FROM t;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 290: Cherry-pick then revert then re-cherry-pick
+# ═══════════════════════════════════════════════════════════════════
+echo "--- cherry/revert round-trip ---"
+
+oracle "cherry_pick_revert_cherry_pick_same_commit" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(2,'feat');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat c');
+SELECT dolt_checkout('main');
+SELECT dolt_cherry_pick('feat');
+SELECT dolt_revert('HEAD');
+SELECT dolt_cherry_pick('feat');
+" "SELECT id, v FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 291: Multi-column UPDATE with computed values
+# ═══════════════════════════════════════════════════════════════════
+echo "--- multi-col computed UPDATE ---"
+
+oracle "update_ab_from_c_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, a INTEGER, b INTEGER, c INTEGER);
+INSERT INTO t VALUES(1,0,0,5),(2,0,0,10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+UPDATE t SET a = c*2, b = c+1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat compute');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(3,7,8,9);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main');
+SELECT dolt_merge('feat');
+" "SELECT id, a, b, c FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 292: Dirty branch detection through merge
+# ═══════════════════════════════════════════════════════════════════
+echo "--- dirty branch detection ---"
+
+oracle "branch_dirty_after_uncommitted_insert" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c1');
+INSERT INTO t VALUES(2);
+" "SELECT count(*) FROM dolt_branches WHERE name='main' AND dirty IN (1,'true');"
+
+oracle "branch_clean_after_commit" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c1');
+INSERT INTO t VALUES(2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2');
+" "SELECT count(*) FROM dolt_branches WHERE name='main' AND dirty IN (0,'false');"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 293: Commit order stability
+# ═══════════════════════════════════════════════════════════════════
+echo "--- commit order probes ---"
+
+oracle "log_ordered_by_commit_order" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','first_commit_abc');
+INSERT INTO t VALUES(2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','second_commit_abc');
+INSERT INTO t VALUES(3);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','third_commit_abc');
+" "SELECT count(*) FROM dolt_log WHERE message LIKE '%commit_abc';"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 294: Merge preserves row-level integrity
+# ═══════════════════════════════════════════════════════════════════
+echo "--- row-level integrity ---"
+
+oracle "sum_preserved_across_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, n INTEGER);
+INSERT INTO t VALUES(1,100),(2,200),(3,300);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+UPDATE t SET n=n+1 WHERE id=1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+UPDATE t SET n=n+10 WHERE id=3;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main');
+SELECT dolt_merge('feat');
+" "SELECT sum(n) FROM t;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 295: ALTER after merge
+# ═══════════════════════════════════════════════════════════════════
+echo "--- alter after merge ---"
+
+oracle "alter_add_col_after_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(2,'feat');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+ALTER TABLE t ADD COLUMN tag INTEGER DEFAULT 99;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','post-merge alter');
+" "SELECT id, v, tag FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 296: Multiple simultaneous conflicts in txn resolve
+# ═══════════════════════════════════════════════════════════════════
+echo "--- multi-conflict txn resolve ---"
+
+oracle "resolve_three_conflicts_via_ours" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'base1'),(2,'base2'),(3,'base3');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+UPDATE t SET v='f1' WHERE id=1;
+UPDATE t SET v='f2' WHERE id=2;
+UPDATE t SET v='f3' WHERE id=3;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+UPDATE t SET v='m1' WHERE id=1;
+UPDATE t SET v='m2' WHERE id=2;
+UPDATE t SET v='m3' WHERE id=3;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main');
+BEGIN;
+SELECT dolt_merge('feat');
+DELETE FROM dolt_conflicts_t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','kept ours');
+COMMIT;
+" "SELECT id, v FROM t ORDER BY id;"
+# ═══════════════════════════════════════════════════════════════════
 # Results
 # ═══════════════════════════════════════════════════════════════════
 echo ""


### PR DESCRIPTION
## Summary
- Error recovery: **178 → 188** (+10)
- Feature interaction: **561 → 583** (+22)
- Combined: **771/1000**
- All tests pass on doltlite + Dolt 1.86.3

## Feature interaction additions
- **Window deeper (4)** — `PARTITION BY … ROWS UNBOUNDED PRECEDING`, `DENSE_RANK`, `FIRST_VALUE`, `LEAD`.
- **Multi-CTE (2)** — chained CTEs, CTE that references another CTE.
- **RIGHT JOIN + LEFT JOIN count (2)**.
- **Boolean CASE in SELECT (1)**.
- **INSERT VALUES with subquery (1)** — uses `VARCHAR(32) PRIMARY KEY` since `TEXT PK` fails in Dolt.
- **DELETE WHERE IN subquery (1)**.
- **ADD+DROP col in same commit (1)**.
- **Min tie-break / COUNT variants with NULLs (2)**.
- **Cherry-pick → revert → cherry-pick round-trip (1)**.
- **Multi-col computed UPDATE (1)**.
- **`dolt_branches.dirty` via `IN (1,'true')` / `IN (0,'false')` (2)** — engines emit `0/1` vs `true/false`, matching via `IN` list normalizes.
- **Log ordering / LIKE (1)**.
- **Sum preserved through 3-way merge (1)**.
- **ALTER ADD COL after merge (1)**.
- **Multi-row conflict resolve via `DELETE dolt_conflicts_t` (1)**.

## Error recovery additions
- Cherry-pick twice (second is no-op).
- ALTER bogus keyword; ALTER dup column name.
- DROP INDEX twice.
- Window function with nonexistent PARTITION column.
- UNION with arity mismatch.
- Bad self-referencing CTE.
- JOIN ON nonexistent column.
- Many bad `dolt_add` targets.
- Log query with a nonexistent commit hash filter.

## Test plan
- [x] `bash test/vc_oracle_error_recovery_test.sh ./doltlite dolt` — 188/188
- [x] `bash test/vc_oracle_feature_interaction_test.sh ./doltlite dolt` — 583/583
- [ ] CI oracle-tests job green

🤖 Generated with [Claude Code](https://claude.com/claude-code)