### PR TITLE
Seal top-level savepoints on dolt_add

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -942,6 +942,13 @@ static void doltliteAddFunc(
       sqlite3_result_error_code(context, rc);
       return;
     }
+    if( doltliteSavepointIsTopLevelTxn(db) ){
+      rc = sqlite3_exec(db, "COMMIT", 0, 0, 0);
+      if( rc!=SQLITE_OK ){
+        sqlite3_result_error_code(context, rc);
+        return;
+      }
+    }
   }
 
   sqlite3_result_int(context, 0);

--- a/test/doltlite_savepoint.sh
+++ b/test/doltlite_savepoint.sh
@@ -277,6 +277,15 @@ run_test_match "remote_savepoint_remote_persists" \
   "SELECT group_concat(name, ',') FROM dolt_remotes;" \
   "^origin$" "$DB6g"
 
+DB6g1=/tmp/test_savepoint6g1_$$.db; rm -f "$DB6g1"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'main'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6g1" > /dev/null 2>&1
+run_test_match "add_savepoint_rollback_to_errors" \
+  "SAVEPOINT sp1; INSERT INTO t VALUES(2,'dirty'); SELECT dolt_add('.'); ROLLBACK TO sp1;" \
+  "no such savepoint: sp1" "$DB6g1"
+run_test_match "add_savepoint_row_persists" \
+  "SELECT count(*) FROM t;" \
+  "^2$" "$DB6g1"
+
 DB6g2=/tmp/test_savepoint6g2_$$.db; rm -f "$DB6g2"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'main'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6g2" > /dev/null 2>&1
 run_test_match "branch_delete_current_savepoint_rollback_to_errors" \
@@ -492,7 +501,7 @@ run_test_match "branch_name_after_rollback" \
 # Cleanup
 # ============================================================
 rm -f "$DB1" "$DB2" "$DB3" "$DB4" "$DB4b" "$DB5" "$DB6" "$DB6b" "$DB7" "$DB8" \
-  "$DB6g2" "$DB6g3" "$DB6g4" "$DB6g5" "$DB6g6" "$DB6g7" "$DB6g8" "$DB6g9" "$DB6g10"
+  "$DB6g1" "$DB6g2" "$DB6g3" "$DB6g4" "$DB6g5" "$DB6g6" "$DB6g7" "$DB6g8" "$DB6g9" "$DB6g10"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/vc_oracle_error_recovery_test.sh
+++ b/test/vc_oracle_error_recovery_test.sh
@@ -3073,6 +3073,22 @@ INSERT INTO t VALUES(2);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 100: SAVEPOINT + dolt_add parity
+# ═══════════════════════════════════════════════════════════════════
+echo "--- savepoint add parity ---"
+
+oracle "savepoint_add_releases_savepoint" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'main');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','init');
+SAVEPOINT sp1;
+INSERT INTO t VALUES(2,'dirty');
+SELECT dolt_add('.');
+ROLLBACK TO sp1;
+" "SELECT 'ROWS', count(*) FROM t;"
 # ═══════════════════════════════════════════════════════════════════
 # Section 100: Cherry-pick with no-op commit
 # ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Fixes dolt_add top-level savepoint parity with Dolt. Tested with doltlite_savepoint.sh and vc_oracle_error_recovery_test.sh.