### PR TITLE
Preserve nested savepoints on reset errors

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -479,6 +479,13 @@ static int doltliteSavepointIsTopLevelTxn(sqlite3 *db){
   return db->pSavepoint!=0 && db->isTransactionSavepoint && db->nSavepoint==0;
 }
 
+static int doltliteVcSealTopLevelSavepointTxn(sqlite3 *db){
+  if( doltliteSavepointIsTopLevelTxn(db) ){
+    return sqlite3_exec(db, "COMMIT", 0, 0, 0);
+  }
+  return SQLITE_OK;
+}
+
 DoltliteVcTxnMode doltliteVcTxnMode(sqlite3 *db){
   if( db->autoCommit || doltliteSavepointIsTopLevelTxn(db) ){
     return DOLTLITE_VC_TXN_AUTOCOMMIT_LIKE;
@@ -1830,6 +1837,7 @@ static void doltliteResetFunc(
   int i;
   int graphLocked = 0;
   u8 isMerging = 0;
+  int bSucceeded = 0;
 
   if( !cs ){
     sqlite3_result_error(context, "no database open", -1);
@@ -2050,12 +2058,17 @@ static void doltliteResetFunc(
   }
 
   sqlite3_result_int(context, 0);
+  bSucceeded = 1;
 reset_cleanup:
   sqlite3_free(azPaths);
   if( graphLocked ){
     chunkStoreUnlock(cs);
   }
-  rc = doltliteVcSealActiveSavepoints(db);
+  if( bSucceeded ){
+    rc = doltliteVcSealActiveSavepoints(db);
+  }else{
+    rc = doltliteVcSealTopLevelSavepointTxn(db);
+  }
   if( rc!=SQLITE_OK ){
     sqlite3_result_error_code(context, rc);
   }

--- a/test/doltlite_savepoint.sh
+++ b/test/doltlite_savepoint.sh
@@ -198,6 +198,12 @@ run_test "bad_reset_savepoint_row_persists" \
   "SELECT v FROM t WHERE id=1;" \
   "dirty" "$DB5c"
 
+DB5d=/tmp/test_savepoint5d_$$.db; rm -f "$DB5d"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB5d" > /dev/null 2>&1
+run_test_match "bad_reset_nested_savepoint_allows_rollback" \
+  "BEGIN; SAVEPOINT sp1; INSERT INTO t VALUES(2,'dirty'); SELECT dolt_reset('--hard','bogus'); ROLLBACK TO sp1; COMMIT; SELECT count(*) FROM t;" \
+  "^1$" "$DB5d"
+
 # ============================================================
 # Test 6: dolt_checkout inside a transaction
 # Expected: dolt_checkout requires a clean working set and switches

--- a/test/vc_oracle_reset_test.sh
+++ b/test/vc_oracle_reset_test.sh
@@ -448,6 +448,28 @@ CALL dolt_reset('--hard', 'bogus');
 " "SELECT concat('Q|', v) FROM t;
 ROLLBACK TO sp1;"
 
+oracle_same_session "reset_bad_ref_nested_savepoint_rolls_back_locally" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'base');
+SELECT dolt_commit('-A', '-m', 'c1');
+BEGIN;
+SAVEPOINT sp1;
+INSERT INTO t VALUES (2, 'dirty');
+SELECT dolt_reset('--hard', 'bogus');
+" "ROLLBACK TO sp1;
+COMMIT;
+SELECT 'Q|' || count(*) FROM t;" \
+"CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'base');
+CALL dolt_commit('-A', '-m', 'c1');
+BEGIN;
+SAVEPOINT sp1;
+INSERT INTO t VALUES (2, 'dirty');
+CALL dolt_reset('--hard', 'bogus');
+" "ROLLBACK TO sp1;
+COMMIT;
+SELECT concat('Q|', count(*)) FROM t;"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then


### PR DESCRIPTION
Fix nested-savepoint parity for dolt_reset error paths. Successful resets still seal savepoints; nested savepoints now remain rollbackable on reset errors, matching Dolt. Tested with doltlite_savepoint.sh and vc_oracle_reset_test.sh.