### PR TITLE
Seal dolt_add savepoints on errors

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -476,7 +476,7 @@ static int doltliteReportConstraintViolations(
 }
 
 static int doltliteSavepointIsTopLevelTxn(sqlite3 *db){
-  return db->pSavepoint!=0 && db->isTransactionSavepoint && db->nSavepoint==0;
+  return db->pSavepoint!=0 && db->nSavepoint==0;
 }
 
 static int doltliteVcSealTopLevelSavepointTxn(sqlite3 *db){
@@ -889,17 +889,18 @@ static void doltliteAddFunc(
 ){
   sqlite3 *db = sqlite3_context_db_handle(context);
   ChunkStore *cs = doltliteGetChunkStore(db);
+  int sealTopLevel = doltliteSavepointIsTopLevelTxn(db);
   int rc;
   int i;
   int stageAll = 0;
 
   if( !cs ){
     sqlite3_result_error(context, "no database open", -1);
-    return;
+    goto add_cleanup;
   }
   if( argc==0 ){
     sqlite3_result_error(context, "dolt_add requires table name or '-A'", -1);
-    return;
+    goto add_cleanup;
   }
 
 
@@ -919,7 +920,7 @@ static void doltliteAddFunc(
       }else{
         sqlite3_result_error_nomem(context);
       }
-      return;
+      goto add_cleanup;
     }
   }
 
@@ -932,33 +933,34 @@ static void doltliteAddFunc(
     rc = doltliteFlushCatalogToHash(db, &workingHash);
     if( rc!=SQLITE_OK ){
       sqlite3_result_error(context, "failed to flush", -1);
-      return;
+      goto add_cleanup;
     }
 
       if( stageAll ){
         rc = addStageAllTables(db, context, cs, &workingHash);
-        if( rc!=SQLITE_OK ) return;
+        if( rc!=SQLITE_OK ) goto add_cleanup;
       }else{
         rc = addStageNamedTables(db, context, cs, &workingHash, argc, argv);
-        if( rc!=SQLITE_OK ) return;
+        if( rc!=SQLITE_OK ) goto add_cleanup;
       }
 
     rc = doltlitePersistWorkingSet(db);
     if( rc!=SQLITE_OK ){
       doltliteSetSessionStaged(db, &savedStaged);
       sqlite3_result_error_code(context, rc);
-      return;
-    }
-    if( doltliteSavepointIsTopLevelTxn(db) ){
-      rc = sqlite3_exec(db, "COMMIT", 0, 0, 0);
-      if( rc!=SQLITE_OK ){
-        sqlite3_result_error_code(context, rc);
-        return;
-      }
+      goto add_cleanup;
     }
   }
 
   sqlite3_result_int(context, 0);
+
+add_cleanup:
+  if( sealTopLevel ){
+    rc = doltliteVcSealTopLevelSavepointTxn(db);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error_code(context, rc);
+    }
+  }
 }
 
 static void doltliteCommitFunc(

--- a/test/doltlite_savepoint.sh
+++ b/test/doltlite_savepoint.sh
@@ -292,6 +292,24 @@ run_test_match "add_savepoint_row_persists" \
   "SELECT count(*) FROM t;" \
   "^2$" "$DB6g1"
 
+DB6g1b=/tmp/test_savepoint6g1b_$$.db; rm -f "$DB6g1b"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'main'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6g1b" > /dev/null 2>&1
+run_test_match "add_savepoint_bad_option_rollback_to_errors" \
+  "SAVEPOINT sp1; INSERT INTO t VALUES(2,'dirty'); SELECT dolt_add('--bogus'); ROLLBACK TO sp1;" \
+  "no such savepoint: sp1" "$DB6g1b"
+run_test_match "add_savepoint_bad_option_row_persists" \
+  "SELECT count(*) FROM t;" \
+  "^2$" "$DB6g1b"
+
+DB6g1c=/tmp/test_savepoint6g1c_$$.db; rm -f "$DB6g1c"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'main'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6g1c" > /dev/null 2>&1
+run_test_match "add_savepoint_missing_table_rollback_to_errors" \
+  "SAVEPOINT sp1; INSERT INTO t VALUES(2,'dirty'); SELECT dolt_add('nope'); ROLLBACK TO sp1;" \
+  "no such savepoint: sp1" "$DB6g1c"
+run_test_match "add_savepoint_missing_table_row_persists" \
+  "SELECT count(*) FROM t;" \
+  "^2$" "$DB6g1c"
+
 DB6g2=/tmp/test_savepoint6g2_$$.db; rm -f "$DB6g2"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'main'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6g2" > /dev/null 2>&1
 run_test_match "branch_delete_current_savepoint_rollback_to_errors" \

--- a/test/vc_oracle_error_recovery_test.sh
+++ b/test/vc_oracle_error_recovery_test.sh
@@ -659,6 +659,17 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','works');
 " "SELECT id, val FROM t ORDER BY id;"
 
+oracle "add_top_level_savepoint_bad_option_persists_rows" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT);
+INSERT INTO t VALUES(1,'base');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SAVEPOINT sp1;
+INSERT INTO t VALUES(2,'dirty');
+SELECT dolt_add('--bogus');
+ROLLBACK TO sp1;
+" "SELECT count(*) FROM t;"
+
 # ═══════════════════════════════════════════════════════════════════
 # Section 17: Branch operations after errors
 # ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- invalidate top-level savepoints on dolt_add error paths to match Dolt
- add local savepoint regressions for bad-option and missing-table cases
- add an oracle regression for persisted state after a top-level savepoint dolt_add error

## Testing
- bash test/doltlite_savepoint.sh ./doltlite
- bash test/vc_oracle_error_recovery_test.sh ./doltlite dolt