### PR TITLE
Oracle tests: +29 (string funcs, CTE HAVING, catch-up merge) — 858/1000

### DIFF
--- a/test/vc_oracle_error_recovery_test.sh
+++ b/test/vc_oracle_error_recovery_test.sh
@@ -3632,6 +3632,177 @@ INSERT INTO t VALUES(2);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM v_good;"
+# Section 127: UPDATE with invalid SET expression
+# ═══════════════════════════════════════════════════════════════════
+echo "--- UPDATE invalid SET probes ---"
+
+oracle "update_set_nonexistent_col_assigned_then_ok" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+INSERT INTO t VALUES(1,10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+UPDATE t SET bogus=99 WHERE id=1;
+UPDATE t SET v=99 WHERE id=1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2');
+" "SELECT id, v FROM t;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 128: INSERT with wrong arity
+# ═══════════════════════════════════════════════════════════════════
+echo "--- INSERT arity probes ---"
+
+oracle "insert_too_few_values_then_ok" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, a INTEGER, b INTEGER);
+INSERT INTO t VALUES(1,10,100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+INSERT INTO t VALUES(2,20);
+INSERT INTO t VALUES(3,30,300);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2');
+" "SELECT id, a, b FROM t ORDER BY id;"
+
+oracle "insert_too_many_values_then_ok" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+INSERT INTO t VALUES(1,10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+INSERT INTO t VALUES(2,20,30,40);
+INSERT INTO t VALUES(3,30);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2');
+" "SELECT id, v FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 129: WHERE with bogus function
+# ═══════════════════════════════════════════════════════════════════
+echo "--- WHERE bogus func ---"
+
+oracle "where_bogus_func_then_ok_insert" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT id FROM t WHERE bogus_function(id)>0;
+INSERT INTO t VALUES(2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2');
+" "SELECT id FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 130: CREATE TABLE with bad column list
+# ═══════════════════════════════════════════════════════════════════
+echo "--- CREATE TABLE bad cols ---"
+
+oracle "create_table_bad_syntax_then_good" "
+CREATE TABLE keep(id INTEGER PRIMARY KEY);
+INSERT INTO keep VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+CREATE TABLE bad(,,);
+CREATE TABLE good(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO good VALUES(1,'a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2');
+" "SELECT count(*) FROM good;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 131: Nested transaction confusion
+# ═══════════════════════════════════════════════════════════════════
+echo "--- nested txn probes ---"
+
+oracle "begin_begin_then_ok" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c1');
+BEGIN;
+BEGIN;
+INSERT INTO t VALUES(2);
+COMMIT;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2');
+" "SELECT id FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 132: Error during CTE
+# ═══════════════════════════════════════════════════════════════════
+echo "--- CTE error probes ---"
+
+oracle "cte_with_bogus_inner_ref_then_ok" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+INSERT INTO t VALUES(1,10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+WITH x AS (SELECT bogus FROM t) SELECT * FROM x;
+INSERT INTO t VALUES(2,20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2');
+" "SELECT id, v FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 133: Errors during add specific tables
+# ═══════════════════════════════════════════════════════════════════
+echo "--- dolt_add specific errors ---"
+
+oracle "add_mix_of_good_bad_tables_then_commit_a" "
+CREATE TABLE t1(id INTEGER PRIMARY KEY);
+CREATE TABLE t2(id INTEGER PRIMARY KEY);
+INSERT INTO t1 VALUES(1);
+INSERT INTO t2 VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+INSERT INTO t1 VALUES(2);
+INSERT INTO t2 VALUES(2);
+SELECT dolt_add('t1','nonexistent','t2');
+SELECT dolt_commit('-m','c2');
+" "SELECT count(*) FROM dolt_log;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 134: Errors after dolt_checkout to existing
+# ═══════════════════════════════════════════════════════════════════
+echo "--- checkout existing probes ---"
+
+oracle "checkout_existing_twice_with_errors" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c1');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES(2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('feat');
+SELECT dolt_checkout('bogus');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES(3);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat c2');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "SELECT id FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 135: Errors with mixed DDL
+# ═══════════════════════════════════════════════════════════════════
+echo "--- mixed DDL error probes ---"
+
+oracle "ddl_mix_with_errors_then_ok" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+CREATE TABLE bad(;
+ALTER TABLE bogus ADD COLUMN x INTEGER;
+CREATE INDEX bad_idx ON bogus(x);
+DROP TABLE bogus;
+INSERT INTO t VALUES(2,'b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2');
+" "SELECT id, v FROM t ORDER BY id;"
+# ═══════════════════════════════════════════════════════════════════
 # ═══════════════════════════════════════════════════════════════════
 # Results
 # ═══════════════════════════════════════════════════════════════════

--- a/test/vc_oracle_feature_interaction_test.sh
+++ b/test/vc_oracle_feature_interaction_test.sh
@@ -11934,6 +11934,408 @@ UPDATE t SET v=99 WHERE id=1;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(DISTINCT commit_hash) FROM dolt_log;"
+# Section 326: String functions deeper
+# ═══════════════════════════════════════════════════════════════════
+echo "--- string func deeper ---"
+
+oracle "upper_lower_projection_after_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'Hello'),(2,'World');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(3,'Goodbye');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "SELECT id, UPPER(v) AS u, LOWER(v) AS l FROM t ORDER BY id;"
+
+oracle "substr_and_length_after_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'abcdef'),(2,'xyz');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(3,'longer_string');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "SELECT id, SUBSTR(v, 1, 3) AS p, length(v) AS L FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 327: INSERT SELECT from computed rows
+# ═══════════════════════════════════════════════════════════════════
+echo "--- INSERT SELECT computed probes ---"
+
+oracle "insert_select_arithmetic_row_merge" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, v INTEGER);
+CREATE TABLE b(id INTEGER PRIMARY KEY);
+INSERT INTO a VALUES(1,10);
+INSERT INTO b VALUES(1),(2),(3);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO a SELECT id+10, id*100 FROM b;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+INSERT INTO b VALUES(4);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main');
+SELECT dolt_merge('feat');
+" "SELECT id, v FROM a ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 328: Reset variants revisited
+# ═══════════════════════════════════════════════════════════════════
+echo "--- reset variant revisit ---"
+
+oracle "reset_hard_tag_then_reset_hard_branch" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c1');
+SELECT dolt_tag('tag1','HEAD');
+INSERT INTO t VALUES(2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2');
+SELECT dolt_branch('snap');
+INSERT INTO t VALUES(3);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c3');
+SELECT dolt_reset('--hard','tag1');
+SELECT dolt_reset('--hard','snap');
+" "SELECT id FROM t ORDER BY id;"
+
+oracle "reset_hard_head_same_hash" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c1');
+INSERT INTO t VALUES(2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2');
+SELECT dolt_reset('--hard','HEAD');
+" "SELECT id FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 329: Conflict detection + resolve variations
+# ═══════════════════════════════════════════════════════════════════
+echo "--- conflict resolve patterns ---"
+
+oracle "conflict_inspect_via_dolt_conflicts_count" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'base');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+UPDATE t SET v='feat' WHERE id=1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+UPDATE t SET v='main' WHERE id=1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main');
+BEGIN;
+SELECT dolt_merge('feat');
+DELETE FROM dolt_conflicts_t;
+UPDATE t SET v='resolved' WHERE id=1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','resolved');
+COMMIT;
+" "SELECT id, v FROM t;"
+
+oracle "merge_then_resolve_with_delete_row" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'base1'),(2,'keep');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+UPDATE t SET v='f1' WHERE id=1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+UPDATE t SET v='m1' WHERE id=1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main');
+BEGIN;
+SELECT dolt_merge('feat');
+DELETE FROM t WHERE id=1;
+DELETE FROM dolt_conflicts_t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','resolved by delete');
+COMMIT;
+" "SELECT id, v FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 330: Multi-table merges with FK
+# ═══════════════════════════════════════════════════════════════════
+echo "--- multi-table FK merge ---"
+
+oracle "three_table_fk_chain_add_leaves_both_sides" "
+PRAGMA foreign_keys=1;
+CREATE TABLE a(id INTEGER PRIMARY KEY);
+CREATE TABLE b(id INTEGER PRIMARY KEY, aid INTEGER REFERENCES a(id));
+CREATE TABLE c(id INTEGER PRIMARY KEY, bid INTEGER REFERENCES b(id));
+INSERT INTO a VALUES(1);
+INSERT INTO b VALUES(1,1);
+INSERT INTO c VALUES(1,1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO c VALUES(2,1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat leaf');
+SELECT dolt_checkout('main');
+INSERT INTO c VALUES(3,1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main leaf');
+SELECT dolt_merge('feat');
+" "SELECT count(*) FROM c;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 331: Long-running branch catch-up merge
+# ═══════════════════════════════════════════════════════════════════
+echo "--- long-running branch probes ---"
+
+oracle "feat_behind_main_pull_main_via_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c1');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(10,'feat_only');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat1');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(2,'m2');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','m2');
+INSERT INTO t VALUES(3,'m3');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','m3');
+SELECT dolt_checkout('feat');
+SELECT dolt_merge('main');
+INSERT INTO t VALUES(11,'feat_after_catchup');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat2');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "SELECT id, v FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 332: CTEs with aggregation
+# ═══════════════════════════════════════════════════════════════════
+echo "--- CTE aggregation ---"
+
+oracle "cte_with_having_after_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, grp TEXT, n INTEGER);
+INSERT INTO t VALUES(1,'a',10),(2,'a',20),(3,'b',5);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(4,'a',30),(5,'b',100),(6,'c',1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "WITH totals AS (SELECT grp, sum(n) AS s FROM t GROUP BY grp) SELECT grp, s FROM totals WHERE s > 10 ORDER BY grp;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 333: Index on expression-like column
+# ═══════════════════════════════════════════════════════════════════
+echo "--- index usage probes ---"
+
+oracle "unique_index_lookup_after_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, code VARCHAR(32));
+CREATE UNIQUE INDEX uc ON t(code);
+INSERT INTO t VALUES(1,'A'),(2,'B');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(3,'C'),(4,'D');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "SELECT id FROM t WHERE code IN ('B','D') ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 334: Repeated merge from feat
+# ═══════════════════════════════════════════════════════════════════
+echo "--- repeated merge from feat ---"
+
+oracle "three_updates_three_merges_from_feat" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+INSERT INTO t VALUES(1,0);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+UPDATE t SET v=1 WHERE id=1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','f1');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+SELECT dolt_checkout('feat');
+UPDATE t SET v=2 WHERE id=1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','f2');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+SELECT dolt_checkout('feat');
+UPDATE t SET v=3 WHERE id=1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','f3');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "SELECT id, v FROM t;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 335: Empty row edge
+# ═══════════════════════════════════════════════════════════════════
+echo "--- empty row edges ---"
+
+oracle "all_columns_null_except_pk_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, a TEXT, b TEXT, c INTEGER);
+INSERT INTO t VALUES(1,NULL,NULL,NULL);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(2,NULL,NULL,NULL);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+UPDATE t SET a='alpha' WHERE id=1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main');
+SELECT dolt_merge('feat');
+" "SELECT id, a, b, c FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 336: Query against dolt_history_<table>
+# ═══════════════════════════════════════════════════════════════════
+echo "--- dolt_history_<table> probes ---"
+
+oracle "history_table_after_updates" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+INSERT INTO t VALUES(1,1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c1');
+UPDATE t SET v=2 WHERE id=1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2');
+UPDATE t SET v=3 WHERE id=1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c3');
+" "SELECT count(DISTINCT v) FROM dolt_history_t WHERE id=1;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 337: Aggregates across multi-table
+# ═══════════════════════════════════════════════════════════════════
+echo "--- multi-table agg ---"
+
+oracle "sum_across_join_after_merge" "
+CREATE TABLE orders(id INTEGER PRIMARY KEY, customer_id INTEGER, amount INTEGER);
+CREATE TABLE customers(id INTEGER PRIMARY KEY, name TEXT);
+INSERT INTO customers VALUES(1,'alice'),(2,'bob');
+INSERT INTO orders VALUES(1,1,100),(2,1,200),(3,2,50);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO orders VALUES(4,1,300),(5,2,75);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "SELECT c.name, sum(o.amount) AS total FROM customers c JOIN orders o ON c.id=o.customer_id GROUP BY c.name ORDER BY c.name;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 338: Deep history reset by SHA
+# ═══════════════════════════════════════════════════════════════════
+echo "--- reset to intermediate commit ---"
+
+oracle "reset_to_headTilde_3_deep" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c1');
+INSERT INTO t VALUES(2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2');
+INSERT INTO t VALUES(3);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c3');
+INSERT INTO t VALUES(4);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c4');
+INSERT INTO t VALUES(5);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c5');
+SELECT dolt_reset('--hard','HEAD~3');
+" "SELECT count(*) FROM t;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 339: Post-merge WHERE by computed expression
+# ═══════════════════════════════════════════════════════════════════
+echo "--- computed WHERE probes ---"
+
+oracle "where_by_mod_expression_after_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, n INTEGER);
+INSERT INTO t VALUES(1,10),(2,15),(3,20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(4,25),(5,33);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "SELECT id FROM t WHERE n % 5 = 0 ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 340: Log queries from a specific branch
+# ═══════════════════════════════════════════════════════════════════
+echo "--- per-branch log probes ---"
+
+oracle "log_from_after_merge_sees_both_sides" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat_c');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(3);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main_c');
+SELECT dolt_merge('feat','--no-ff','-m','m_merge');
+" "SELECT count(*) FROM dolt_log WHERE message IN ('base','feat_c','main_c','m_merge');"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 341: INSERT with default + explicit + subquery
+# ═══════════════════════════════════════════════════════════════════
+echo "--- INSERT partial cols + subquery ---"
+
+oracle "insert_partial_then_subquery_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER DEFAULT 10, s INTEGER);
+INSERT INTO t(id, s) VALUES(1,100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t(id, v, s) VALUES(2, (SELECT sum(v) FROM t) + 5, 200);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+INSERT INTO t(id, s) VALUES(3, 300);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main');
+SELECT dolt_merge('feat');
+" "SELECT id, v, s FROM t ORDER BY id;"
+# ═══════════════════════════════════════════════════════════════════
 # ═══════════════════════════════════════════════════════════════════
 # Results
 # ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- Error recovery: **199 → 209** (+10)
- Feature interaction: **602 → 621** (+19)
- Combined: **858/1000** (870 in flight if #596 also merges)
- All tests pass on doltlite + Dolt 1.86.3

## Feature interaction additions
- **String funcs deeper (2)** — UPPER/LOWER projection, SUBSTR + length.
- **INSERT SELECT computed rows (1)**.
- **Reset tag-then-branch (2)**.
- **Conflict resolve patterns (2)** — UPDATE + DELETE dolt_conflicts_t; resolve by deleting the row.
- **Three-table FK chain leaves both sides (1)**.
- **Feat catches up from main then merges back (1)**.
- **CTE + HAVING (1)**.
- **Unique-index lookup after merge (1)**.
- **Three updates / three merges from feat (1)**.
- **All-columns-NULL-except-PK merge (1)**.
- **`dolt_history_<table>` after updates (1)**.
- **Sum across JOIN after merge (1)**.
- **Reset to HEAD~3 (1)**.
- **WHERE by MOD expression (1)**.
- **Log counts across regular + merge commits (1)**.
- **INSERT partial cols + subquery (1)**.

## Error recovery additions
- UPDATE SET nonexistent col.
- INSERT too few / too many values (2).
- WHERE with bogus function.
- CREATE TABLE bad syntax then good.
- BEGIN-BEGIN nested then commit.
- CTE with bogus inner ref.
- `dolt_add` mix of good/bad table names.
- Checkout existing twice with bogus in between.
- Mixed DDL errors (bad create/drop/alter).

## Test plan
- [x] `bash test/vc_oracle_error_recovery_test.sh ./doltlite dolt` — 209/209
- [x] `bash test/vc_oracle_feature_interaction_test.sh ./doltlite dolt` — 621/621
- [ ] CI oracle-tests job green

🤖 Generated with [Claude Code](https://claude.com/claude-code)