### PR TITLE
Preserve nested txns on dolt_commit errors

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -984,6 +984,7 @@ static void doltliteCommitFunc(
   ProllyHash sessionHeadBeforeLock;
   char hexBuf[PROLLY_HASH_SIZE*2+1];
   i64 explicitTimestamp = 0;
+  int sealTopLevel = doltliteSavepointIsTopLevelTxn(db);
   int rc;
   int i;
 
@@ -992,11 +993,13 @@ static void doltliteCommitFunc(
     return;
   }
 
-  /* Implicitly commit any open SQL transaction so that all pending
-  ** DML is flushed before the version-control commit runs.  Matches
-  ** Dolt, where dolt_commit() closes the SQL transaction — a
-  ** subsequent ROLLBACK becomes a no-op. */
-  (void)sqlite3_exec(db, "COMMIT", 0, 0, 0);
+  /* Top-level SAVEPOINT acts as the transaction boundary. Dolt seals
+  ** that boundary even when dolt_commit() later errors, so persist it
+  ** up front. Plain BEGIN / nested SAVEPOINT cases defer COMMIT until
+  ** after argument validation succeeds. */
+  if( sealTopLevel ){
+    (void)sqlite3_exec(db, "COMMIT", 0, 0, 0);
+  }
 
   for(i=0; i<argc; i++){
     const char *arg = (const char*)sqlite3_value_text(argv[i]);
@@ -1132,6 +1135,12 @@ static void doltliteCommitFunc(
     sqlite3_result_error(context,
       "dolt_commit requires a message: SELECT dolt_commit('-m', 'msg')", -1);
     return;
+  }
+
+  if( !sealTopLevel ){
+    /* For BEGIN / nested SAVEPOINT, only close the SQL transaction once
+    ** dolt_commit() has survived argument parsing and basic validation. */
+    (void)sqlite3_exec(db, "COMMIT", 0, 0, 0);
   }
 
   if( addAll ){

--- a/test/doltlite_savepoint.sh
+++ b/test/doltlite_savepoint.sh
@@ -310,6 +310,21 @@ run_test_match "add_savepoint_missing_table_row_persists" \
   "SELECT count(*) FROM t;" \
   "^2$" "$DB6g1c"
 
+DB6g1d=/tmp/test_savepoint6g1d_$$.db; rm -f "$DB6g1d"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'main'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6g1d" > /dev/null 2>&1
+run_test_match "commit_nested_savepoint_bad_option_rollback_to_succeeds" \
+  "BEGIN; SAVEPOINT sp1; INSERT INTO t VALUES(2,'dirty'); SELECT dolt_commit('--bogus'); ROLLBACK TO sp1; SELECT count(*) FROM t; ROLLBACK;" \
+  "^1$" "$DB6g1d"
+
+DB6g1e=/tmp/test_savepoint6g1e_$$.db; rm -f "$DB6g1e"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'main'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6g1e" > /dev/null 2>&1
+run_test_match "commit_begin_bad_option_reopen_row_rolled_back" \
+  "BEGIN; INSERT INTO t VALUES(2,'dirty'); SELECT dolt_commit('--bogus');" \
+  "unknown option \`--bogus\`" "$DB6g1e"
+run_test_match "commit_begin_bad_option_count_after_reopen" \
+  "SELECT count(*) FROM t;" \
+  "^1$" "$DB6g1e"
+
 DB6g2=/tmp/test_savepoint6g2_$$.db; rm -f "$DB6g2"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'main'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6g2" > /dev/null 2>&1
 run_test_match "branch_delete_current_savepoint_rollback_to_errors" \

--- a/test/vc_oracle_txn_commit_test.sh
+++ b/test/vc_oracle_txn_commit_test.sh
@@ -249,6 +249,100 @@ else
   echo "    expected 1, got $DL_G"
 fi
 
+# ── Test H: BEGIN + bad dolt_commit option should not persist txn ──
+echo ""
+echo "--- BEGIN + bad dolt_commit option ---"
+
+DB="$TMPROOT/h.db"
+rm -f "$DB"
+dl_query "$DB" "$(cat <<'SQL'
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'base');
+SELECT dolt_commit('-Am','c1');
+BEGIN;
+INSERT INTO t VALUES(2,'dirty');
+SELECT dolt_commit('--bogus');
+SQL
+)" >/dev/null
+DL_H=$(dl_query "$DB" "SELECT count(*) FROM t;")
+
+if [ -n "$DOLT" ]; then
+  DOLT_H_DIR="$TMPROOT/dolt_h"
+  mkdir -p "$DOLT_H_DIR" && cd "$DOLT_H_DIR" && dolt init >/dev/null 2>&1
+  dolt sql 2>/dev/null <<'SQL'
+CREATE TABLE t(id INT PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'base');
+CALL dolt_commit('-Am','c1');
+BEGIN;
+INSERT INTO t VALUES(2,'dirty');
+CALL dolt_commit('--bogus');
+SQL
+  DOLT_H=$(dolt_query "$DOLT_H_DIR" "SELECT count(*) FROM t")
+  cd - >/dev/null
+
+  if [ "$DL_H" = "$DOLT_H" ]; then
+    pass_name "begin_bad_commit_option_matches_dolt"
+  else
+    fail_name "begin_bad_commit_option_matches_dolt"
+    echo "    doltlite=$DL_H dolt=$DOLT_H"
+  fi
+fi
+
+if [ "$DL_H" = "1" ]; then
+  pass_name "begin_bad_commit_option_rolls_back_on_reopen"
+else
+  fail_name "begin_bad_commit_option_rolls_back_on_reopen"
+  echo "    expected 1, got $DL_H"
+fi
+
+# ── Test I: Nested savepoint + bad dolt_commit option ───────
+echo ""
+echo "--- Nested savepoint + bad dolt_commit option ---"
+
+DB="$TMPROOT/i.db"
+rm -f "$DB"
+dl_query "$DB" "$(cat <<'SQL'
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'base');
+SELECT dolt_commit('-Am','c1');
+BEGIN;
+SAVEPOINT sp1;
+INSERT INTO t VALUES(2,'dirty');
+SELECT dolt_commit('--bogus');
+SQL
+)" >/dev/null
+DL_I=$(dl_query "$DB" "SELECT count(*) FROM t;")
+
+if [ -n "$DOLT" ]; then
+  DOLT_I_DIR="$TMPROOT/dolt_i"
+  mkdir -p "$DOLT_I_DIR" && cd "$DOLT_I_DIR" && dolt init >/dev/null 2>&1
+  dolt sql 2>/dev/null <<'SQL'
+CREATE TABLE t(id INT PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'base');
+CALL dolt_commit('-Am','c1');
+BEGIN;
+SAVEPOINT sp1;
+INSERT INTO t VALUES(2,'dirty');
+CALL dolt_commit('--bogus');
+SQL
+  DOLT_I=$(dolt_query "$DOLT_I_DIR" "SELECT count(*) FROM t")
+  cd - >/dev/null
+
+  if [ "$DL_I" = "$DOLT_I" ]; then
+    pass_name "nested_savepoint_bad_commit_option_matches_dolt"
+  else
+    fail_name "nested_savepoint_bad_commit_option_matches_dolt"
+    echo "    doltlite=$DL_I dolt=$DOLT_I"
+  fi
+fi
+
+if [ "$DL_I" = "1" ]; then
+  pass_name "nested_savepoint_bad_commit_option_rolls_back_on_reopen"
+else
+  fail_name "nested_savepoint_bad_commit_option_rolls_back_on_reopen"
+  echo "    expected 1, got $DL_I"
+fi
+
 echo ""
 echo "======================================="
 echo "Results: $pass passed, $fail failed"


### PR DESCRIPTION
## Summary
- defer closing plain BEGIN / nested SAVEPOINT transactions until dolt_commit has passed validation
- keep top-level SAVEPOINT error behavior unchanged so dirty rows still persist there
- add reconnect-based regression coverage for bad-option dolt_commit under BEGIN and nested SAVEPOINT

## Testing
- bash test/doltlite_savepoint.sh ./doltlite
- bash test/vc_oracle_txn_commit_test.sh ./doltlite dolt