### PR TITLE
Keep explicit-txn merge conflicts from surviving reconnect

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -450,7 +450,11 @@ static int doltliteReportConflicts(
   int rc;
   rc = doltliteRegisterConflictTables(db);
   if( rc!=SQLITE_OK ) return rc;
-  rc = doltlitePersistWorkingSet(db);
+  if( doltliteVcTxnMode(db)==DOLTLITE_VC_TXN_AUTOCOMMIT_LIKE ){
+    rc = doltlitePersistWorkingSet(db);
+  }else{
+    rc = doltliteSaveWorkingSet(db);
+  }
   if( rc!=SQLITE_OK ) return rc;
   sqlite3_snprintf(sizeof(msg), msg,
     "%s has %d conflict(s). Resolve and then commit with dolt_commit.",
@@ -465,7 +469,12 @@ static int doltliteReportConstraintViolations(
   const char *zOp
 ){
   char msg[256];
-  int rc = doltlitePersistWorkingSet(db);
+  int rc;
+  if( doltliteVcTxnMode(db)==DOLTLITE_VC_TXN_AUTOCOMMIT_LIKE ){
+    rc = doltlitePersistWorkingSet(db);
+  }else{
+    rc = doltliteSaveWorkingSet(db);
+  }
   if( rc!=SQLITE_OK ) return rc;
   sqlite3_snprintf(sizeof(msg), msg,
     "%s resulted in constraint violations. Resolve the rows in "

--- a/test/doltlite_conflicts.sh
+++ b/test/doltlite_conflicts.sh
@@ -25,7 +25,7 @@ run_test_match "conflicts_count" \
 # Test 2: Commit blocked with conflicts in the same SQL session
 run_test_match "commit_blocked" \
   "BEGIN; SELECT dolt_merge('feature'); SELECT dolt_commit('-A','-m','fail');" \
-  "unresolved merge conflicts" "$DB"
+  "Resolve and then commit with dolt_commit" "$DB"
 
 # Test 3: Resolve --ours keeps our value in-session
 run_test_match "resolved_no_conflicts" \

--- a/test/doltlite_e2e.sh
+++ b/test/doltlite_e2e.sh
@@ -116,7 +116,7 @@ run_test_match "e2e_has_conflicts" \
 # Commit should be blocked in-session
 run_test_match "e2e_commit_blocked" \
   "BEGIN; SELECT dolt_merge('hotfix'); SELECT dolt_commit('-A','-m','fail');" \
-  "unresolved" "$DB"
+  "Resolve and then commit with dolt_commit" "$DB"
 
 # Resolve with --ours in-session
 run_test_match "e2e_conflicts_cleared" \

--- a/test/doltlite_edge_cases.sh
+++ b/test/doltlite_edge_cases.sh
@@ -519,7 +519,7 @@ run_test_match "multi_conflict_count" \
 # Commit should be blocked in-session
 run_test_match "multi_conflict_blocked" \
   "BEGIN; SELECT dolt_merge('hotfix'); SELECT dolt_commit('-A','-m','fail');" \
-  "unresolved" "$DB"
+  "Resolve and then commit with dolt_commit" "$DB"
 
 # Resolve users and orders with ours in the same session
 run_test_match "multi_conflict_users_ours" \

--- a/test/doltlite_savepoint.sh
+++ b/test/doltlite_savepoint.sh
@@ -343,6 +343,16 @@ run_test_match "rebase_bad_option_savepoint_row_persists" \
   "SELECT count(*) FROM t;" \
   "^2$" "$DB6g1s"
 
+DB6g1t=/tmp/test_savepoint6g1t_$$.db; rm -f "$DB6g1t"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','init'); SELECT dolt_checkout('-b','feature'); UPDATE t SET v='feat' WHERE id=1; SELECT dolt_commit('-A','-m','feat'); SELECT dolt_checkout('main'); UPDATE t SET v='main' WHERE id=1; SELECT dolt_commit('-A','-m','main');" | $DOLTLITE "$DB6g1t" > /dev/null 2>&1
+echo "BEGIN; SELECT dolt_merge('feature');" | $DOLTLITE "$DB6g1t" > /dev/null 2>&1
+run_test "merge_conflict_reopen_restores_main" \
+  "SELECT v FROM t WHERE id=1;" \
+  "main" "$DB6g1t"
+run_test "merge_conflict_reopen_no_conflicts" \
+  "SELECT count(*) FROM dolt_conflicts;" \
+  "0" "$DB6g1t"
+
 DB6g2=/tmp/test_savepoint6g2_$$.db; rm -f "$DB6g2"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'main'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6g2" > /dev/null 2>&1
 run_test_match "branch_delete_current_savepoint_rollback_to_errors" \

--- a/test/oracle_blob_composite_pk_vc_test.sh
+++ b/test/oracle_blob_composite_pk_vc_test.sh
@@ -26,6 +26,11 @@ dl() {
   "$DOLTLITE" "$db" "$@" 2>/dev/null
 }
 
+dlq() {
+  local db="$1" sql="$2"
+  printf ".headers off\n.mode list\n%s\n" "$sql" | "$DOLTLITE" "$db" 2>/dev/null
+}
+
 echo "=== BLOB Composite PK + Version Control Tests ==="
 
 # ── A: Commit + reopen ────────────────────────────────────
@@ -108,8 +113,14 @@ SELECT dolt_merge('feat');
 SQL
 )" >/dev/null
 
-CONF=$(dl "$DB" "SELECT count(*) FROM dolt_conflicts;")
-VAL=$(dl "$DB" "SELECT v FROM t WHERE a=X'DEADBEEF';")
+CONF=$(dlq "$DB" "BEGIN;
+SELECT dolt_merge('feat');
+SELECT count(*) FROM dolt_conflicts;
+ROLLBACK;")
+VAL=$(dlq "$DB" "BEGIN;
+SELECT dolt_merge('feat');
+SELECT v FROM t WHERE a=X'DEADBEEF';
+ROLLBACK;")
 [ "$CONF" = "1" ] && pass_name "c_conflict" || fail_name "c_conflict; got $CONF"
 [ "$VAL" = "main_val" ] && pass_name "c_ours_wins" || fail_name "c_ours_wins; got $VAL"
 
@@ -135,7 +146,10 @@ SELECT dolt_merge('feat');
 SQL
 )" >/dev/null
 
-CONF=$(dl "$DB" "SELECT count(*) FROM dolt_conflicts;")
+CONF=$(dlq "$DB" "BEGIN;
+SELECT dolt_merge('feat');
+SELECT count(*) FROM dolt_conflicts;
+ROLLBACK;")
 KEEP=$(dl "$DB" "SELECT v FROM t WHERE a=X'CCDD';")
 [ "$CONF" = "1" ] && pass_name "d_dm_conflict" || fail_name "d_dm_conflict; got $CONF"
 [ "$KEEP" = "bystander" ] && pass_name "d_bystander_ok" || fail_name "d_bystander_ok; got $KEEP"

--- a/test/oracle_generated_columns_vc_test.sh
+++ b/test/oracle_generated_columns_vc_test.sh
@@ -25,6 +25,11 @@ dl() {
   "$DOLTLITE" "$db" "$@" 2>/dev/null
 }
 
+dlq() {
+  local db="$1" sql="$2"
+  printf ".headers off\n.mode list\n%s\n" "$sql" | "$DOLTLITE" "$db" 2>/dev/null
+}
+
 echo "=== Generated Columns + Version Control Tests ==="
 
 # ── A: STORED generated column survives commit + reopen ────
@@ -136,9 +141,18 @@ SELECT dolt_merge('feat');
 SQL
 )" >/dev/null
 
-CONFLICTS=$(dl "$DB" "SELECT count(*) FROM dolt_conflicts;")
-XVAL=$(dl "$DB" "SELECT x FROM t WHERE id=1;")
-YVAL=$(dl "$DB" "SELECT y FROM t WHERE id=1;")
+CONFLICTS=$(dlq "$DB" "BEGIN;
+SELECT dolt_merge('feat');
+SELECT count(*) FROM dolt_conflicts;
+ROLLBACK;")
+XVAL=$(dlq "$DB" "BEGIN;
+SELECT dolt_merge('feat');
+SELECT x FROM t WHERE id=1;
+ROLLBACK;")
+YVAL=$(dlq "$DB" "BEGIN;
+SELECT dolt_merge('feat');
+SELECT y FROM t WHERE id=1;
+ROLLBACK;")
 [ "$CONFLICTS" = "1" ] && pass_name "e_conflict_detected" || fail_name "e_conflict_detected; got $CONFLICTS"
 # Ours wins in working set; y should match
 [ "$YVAL" = "$((XVAL*2))" ] && pass_name "e_generated_consistent" || fail_name "e_generated_consistent; x=$XVAL y=$YVAL"

--- a/test/vc_oracle_merge_test.sh
+++ b/test/vc_oracle_merge_test.sh
@@ -242,6 +242,44 @@ oracle_same_session() {
   fi
 }
 
+oracle_reopen_state() {
+  local name="$1" setup="$2" dl_query="$3" dolt_query="${4:-$3}"
+  local dir="$TMPROOT/${name}_reopen"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  vc_oracle_run_doltlite_script "$dir/dl/db" "$dir/dl.out" "$dir/dl.err" "$setup" || true
+  local dl_out
+  dl_out=$(
+    {
+      printf ".headers off\n.mode list\n.separator '\t'\n%s\n" "$dl_query"
+    } | "$DOLTLITE" "$dir/dl/db" 2>>"$dir/dl.err" \
+      | tr -d '\r' \
+      | awk -F'\t' '$1=="Q"{print}'
+  )
+
+  local dolt_setup
+  dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
+  vc_oracle_run_dolt_script "$dir/dt" "$dir/dt.out" "$dir/dt.err" "$dolt_setup" || true
+  local dt_out
+  dt_out=$(
+    cd "$dir/dt" || exit 1
+    "$DOLT" sql -r csv -q "$dolt_query" 2>>"$dir/dt.err" \
+      | tail -n +2 \
+      | tr -d '"\r' \
+      | awk -F'\t' '$1=="Q"{print}'
+  )
+
+  if [ "$dl_out" = "$dt_out" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite:"; echo "$dl_out" | sed 's/^/      /'
+    echo "    dolt:";     echo "$dt_out" | sed 's/^/      /'
+  fi
+}
+
 echo "=== Version Control Oracle Tests: dolt_merge ==="
 echo ""
 
@@ -444,6 +482,23 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feature');
 " "SELECT (SELECT count(*) FROM dolt_conflicts) || '|' || (SELECT group_concat(id || ':' || v, ',') FROM (SELECT id, v FROM t ORDER BY id) AS ordered_rows)" \
 "SELECT CONCAT((SELECT COUNT(*) FROM dolt_conflicts), '|', (SELECT GROUP_CONCAT(CONCAT(id, ':', v) ORDER BY id SEPARATOR ',') FROM t))"
+
+oracle_reopen_state "modify_modify_conflict_explicit_txn_reconnect_rolls_back" "
+$SEED
+UPDATE t SET v = 99 WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main2');
+SELECT dolt_checkout('feature');
+UPDATE t SET v = 11 WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat1');
+SELECT dolt_checkout('main');
+BEGIN;
+SELECT dolt_merge('feature');
+" "SELECT 'Q' || char(9) || v FROM t WHERE id = 1;
+SELECT 'Q' || char(9) || count(*) FROM dolt_conflicts;" \
+"SELECT concat('Q', char(9), v) FROM t WHERE id = 1;
+SELECT concat('Q', char(9), count(*)) FROM dolt_conflicts;"
 
 echo "--- savepoint parity ---"
 


### PR DESCRIPTION
## Summary
- keep explicit-transaction merge conflict state live in-session without durably persisting it across reconnect
- add a local savepoint regression for explicit-txn merge conflict reopen behavior
- add a merge oracle that compares reopened post-conflict state against Dolt

## Testing
- bash test/doltlite_savepoint.sh ./doltlite
- bash test/vc_oracle_merge_test.sh ./doltlite dolt