### PR TITLE
Oracle tests: +31 — 918/1000 (hashof_db, ROW_NUMBER, recursive CTE gen, BLOB, unicode)

### DIFF
--- a/test/vc_oracle_error_recovery_test.sh
+++ b/test/vc_oracle_error_recovery_test.sh
@@ -4146,6 +4146,187 @@ SELECT dolt_checkout('nonexistent');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','kept');
 " "SELECT id FROM t ORDER BY id;"
+# Section 154: Errors with recursive CTE
+# ═══════════════════════════════════════════════════════════════════
+echo "--- recursive CTE error probes ---"
+
+oracle "recursive_cte_self_ref_bogus_col_then_ok" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+WITH RECURSIVE x(n) AS (SELECT 1 UNION ALL SELECT bogus FROM x) SELECT * FROM x LIMIT 5;
+INSERT INTO t VALUES(2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2');
+" "SELECT count(*) FROM t;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 155: Errors during ORDER BY expressions
+# ═══════════════════════════════════════════════════════════════════
+echo "--- ORDER BY error probes ---"
+
+oracle "order_by_bogus_expression_then_ok" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+INSERT INTO t VALUES(1,10),(2,20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT id FROM t ORDER BY bogus_fn(v);
+INSERT INTO t VALUES(3,30);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2');
+" "SELECT id, v FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 156: Error on window function with bad OVER clause
+# ═══════════════════════════════════════════════════════════════════
+echo "--- window bad OVER ---"
+
+oracle "window_bad_over_clause_then_ok" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+INSERT INTO t VALUES(1,10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT id, ROW_NUMBER() OVER (PARTITION bogus ORDER BY v) FROM t;
+INSERT INTO t VALUES(2,20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2');
+" "SELECT count(*) FROM t;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 157: Errors inside nested transactions
+# ═══════════════════════════════════════════════════════════════════
+echo "--- nested txn error probes ---"
+
+oracle "savepoint_error_storm_then_clean_commit" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c1');
+BEGIN;
+SAVEPOINT sp1;
+INSERT INTO t VALUES(2);
+SELECT * FROM bogus;
+SELECT dolt_cherry_pick('bogus');
+SELECT * FROM bogus;
+COMMIT;
+INSERT INTO t VALUES(3);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','post');
+" "SELECT count(*) FROM t;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 158: INSERT INTO nonexistent cols
+# ═══════════════════════════════════════════════════════════════════
+echo "--- INSERT bogus cols ---"
+
+oracle "insert_targeting_bogus_col_then_ok" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+INSERT INTO t(id, bogus) VALUES(2,'x');
+INSERT INTO t(id, v) VALUES(2,'b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2');
+" "SELECT id, v FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 159: Merge with bogus commit-hash ref
+# ═══════════════════════════════════════════════════════════════════
+echo "--- merge bogus hash probes ---"
+
+oracle "merge_bogus_hash_like_ref_then_ok" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('abc1234567890');
+SELECT dolt_merge('0000000000000000000000000000000000000000');
+SELECT dolt_merge('feat');
+" "SELECT id FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 160: GC during uncommitted work
+# ═══════════════════════════════════════════════════════════════════
+echo "--- gc edge probes ---"
+
+# NOTE: gc_after_reset_then_commit omitted — doltlite's dolt_gc()
+# returns a human-readable status string ("N chunks removed, M kept"),
+# Dolt returns an empty row. Diverges on output format only; not a
+# real behavioral divergence.
+oracle "reset_hard_then_commit_no_gc" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c1');
+INSERT INTO t VALUES(2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2');
+SELECT dolt_reset('--hard','HEAD~1');
+INSERT INTO t VALUES(3);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','post');
+" "SELECT id FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 161: Errors on multi-statement boundaries
+# ═══════════════════════════════════════════════════════════════════
+echo "--- multi-stmt error boundary ---"
+
+oracle "unterminated_statement_then_ok" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c1');
+SELECT bogus FROM
+INSERT INTO t VALUES(2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2');
+" "SELECT id FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 162: Tag error deep sequence
+# ═══════════════════════════════════════════════════════════════════
+echo "--- tag deep error sequence ---"
+
+oracle "tag_error_storm_then_good" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c1');
+SELECT dolt_tag('v1','HEAD');
+SELECT dolt_tag('v1','HEAD');
+SELECT dolt_tag('','HEAD');
+SELECT dolt_tag('v2','bogus_ref');
+SELECT dolt_tag('-d','nonexistent');
+SELECT dolt_tag('-d','v1');
+SELECT dolt_tag('v3','HEAD');
+" "SELECT tag_name FROM dolt_tags ORDER BY tag_name;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 163: UPDATE + DELETE bad chain
+# ═══════════════════════════════════════════════════════════════════
+echo "--- UPDATE+DELETE bad chain ---"
+
+oracle "update_delete_bogus_interleaved_then_ok" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+INSERT INTO t VALUES(1,10),(2,20),(3,30);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+UPDATE t SET v=99 WHERE bogus=1;
+DELETE FROM t WHERE bogus=2;
+UPDATE t SET v=99 WHERE id=1;
+DELETE FROM t WHERE id=3;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2');
+" "SELECT id, v FROM t ORDER BY id;"
+# ═══════════════════════════════════════════════════════════════════
 # ═══════════════════════════════════════════════════════════════════
 # Results
 # ═══════════════════════════════════════════════════════════════════

--- a/test/vc_oracle_feature_interaction_test.sh
+++ b/test/vc_oracle_feature_interaction_test.sh
@@ -13074,6 +13074,446 @@ SELECT dolt_commit('-m','feat ops');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t;"
+# Section 373: Commit + dolt_hashof variants
+# ═══════════════════════════════════════════════════════════════════
+echo "--- hashof variants ---"
+
+oracle "hashof_db_differs_across_commits" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c1');
+INSERT INTO t VALUES(2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2');
+INSERT INTO t VALUES(3);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c3');
+" "SELECT CASE WHEN length(dolt_hashof_db()) > 0 THEN 1 ELSE 0 END;"
+
+oracle "hashof_db_stable_for_empty_select" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c1');
+SELECT 1;
+SELECT 2;
+" "SELECT count(*) FROM dolt_log WHERE commit_hash = dolt_hashof('HEAD');"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 374: ROW_NUMBER after merge
+# ═══════════════════════════════════════════════════════════════════
+echo "--- ROW_NUMBER probes ---"
+
+oracle "row_number_per_group_after_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, grp TEXT, score INTEGER);
+INSERT INTO t VALUES(1,'a',10),(2,'a',20),(3,'b',15);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(4,'a',5),(5,'b',25);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "SELECT id, ROW_NUMBER() OVER (PARTITION BY grp ORDER BY score DESC) AS rn FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 375: Many-row cell merge
+# ═══════════════════════════════════════════════════════════════════
+echo "--- cell merge many rows ---"
+
+oracle "cell_merge_20_rows_disjoint" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, a INTEGER, b INTEGER);
+INSERT INTO t VALUES(1,0,0),(2,0,0),(3,0,0),(4,0,0),(5,0,0);
+INSERT INTO t VALUES(6,0,0),(7,0,0),(8,0,0),(9,0,0),(10,0,0);
+INSERT INTO t VALUES(11,0,0),(12,0,0),(13,0,0),(14,0,0),(15,0,0);
+INSERT INTO t VALUES(16,0,0),(17,0,0),(18,0,0),(19,0,0),(20,0,0);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+UPDATE t SET a=1 WHERE id<=10;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat a');
+SELECT dolt_checkout('main');
+UPDATE t SET b=2 WHERE id>10;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main b');
+SELECT dolt_merge('feat');
+" "SELECT sum(a) AS sa, sum(b) AS sb FROM t;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 376: Recursive CTE — generator
+# ═══════════════════════════════════════════════════════════════════
+echo "--- recursive CTE generator ---"
+
+oracle "recursive_cte_series_join_post_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, label TEXT);
+INSERT INTO t VALUES(3,'three'),(5,'five');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(7,'seven');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "WITH RECURSIVE nums(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM nums WHERE n<10) SELECT n, COALESCE((SELECT label FROM t WHERE t.id=nums.n),'none') AS lbl FROM nums ORDER BY n;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 377: UPDATE affecting nothing
+# ═══════════════════════════════════════════════════════════════════
+echo "--- update affecting nothing ---"
+
+oracle "update_where_false_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+INSERT INTO t VALUES(1,10),(2,20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+UPDATE t SET v=999 WHERE id=999;
+INSERT INTO t VALUES(3,30);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+UPDATE t SET v=v WHERE id=1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main');
+SELECT dolt_merge('feat');
+" "SELECT id, v FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 378: ORDER + LIMIT 1 (max-like)
+# ═══════════════════════════════════════════════════════════════════
+echo "--- order+limit probes ---"
+
+oracle "max_via_order_limit_after_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+INSERT INTO t VALUES(1,30),(2,10),(3,20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(4,100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(5,50);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main');
+SELECT dolt_merge('feat');
+" "SELECT id FROM t ORDER BY v DESC LIMIT 1;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 379: Wide FK graph
+# ═══════════════════════════════════════════════════════════════════
+echo "--- wide FK graph ---"
+
+oracle "one_parent_three_child_tables_merge" "
+PRAGMA foreign_keys=1;
+CREATE TABLE p(id INTEGER PRIMARY KEY);
+CREATE TABLE c1(id INTEGER PRIMARY KEY, pid INTEGER REFERENCES p(id));
+CREATE TABLE c2(id INTEGER PRIMARY KEY, pid INTEGER REFERENCES p(id));
+CREATE TABLE c3(id INTEGER PRIMARY KEY, pid INTEGER REFERENCES p(id));
+INSERT INTO p VALUES(1);
+INSERT INTO c1 VALUES(1,1);
+INSERT INTO c2 VALUES(1,1);
+INSERT INTO c3 VALUES(1,1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO p VALUES(2);
+INSERT INTO c1 VALUES(2,2);
+INSERT INTO c2 VALUES(2,2);
+INSERT INTO c3 VALUES(2,2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+INSERT INTO c1 VALUES(10,1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main');
+SELECT dolt_merge('feat');
+" "SELECT 'c1' AS tbl, count(*) AS n FROM c1 UNION ALL SELECT 'c2', count(*) FROM c2 UNION ALL SELECT 'c3', count(*) FROM c3 ORDER BY 1;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 380: Deep diamond merge
+# ═══════════════════════════════════════════════════════════════════
+echo "--- deep diamond probes ---"
+
+oracle "diamond_with_3_commits_per_side_noff" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+INSERT INTO t VALUES(1,1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','left');
+INSERT INTO t VALUES(2,10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','l1');
+INSERT INTO t VALUES(3,20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','l2');
+INSERT INTO t VALUES(4,30);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','l3');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(10,100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','m1');
+INSERT INTO t VALUES(11,200);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','m2');
+INSERT INTO t VALUES(12,300);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','m3');
+SELECT dolt_merge('left','--no-ff','-m','merged');
+" "SELECT count(*) AS n, sum(v) AS s FROM t;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 381: Aggregates with ORDER in subquery
+# ═══════════════════════════════════════════════════════════════════
+echo "--- agg in subquery ---"
+
+oracle "subquery_with_order_in_agg" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, grp TEXT, v INTEGER);
+INSERT INTO t VALUES(1,'a',10),(2,'a',30),(3,'b',20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(4,'a',25),(5,'b',40);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "SELECT grp, max(v) AS mx FROM t GROUP BY grp ORDER BY grp;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 382: Triple-branch parallel + merge all
+# ═══════════════════════════════════════════════════════════════════
+echo "--- triple parallel merges ---"
+
+oracle "three_branch_parallel_then_merge_all" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(0,'base');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','f1');
+INSERT INTO t VALUES(1,'f1a'),(2,'f1b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','f1');
+SELECT dolt_checkout('main');
+SELECT dolt_checkout('-b','f2');
+INSERT INTO t VALUES(3,'f2a'),(4,'f2b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','f2');
+SELECT dolt_checkout('main');
+SELECT dolt_checkout('-b','f3');
+INSERT INTO t VALUES(5,'f3a'),(6,'f3b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','f3');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('f1');
+SELECT dolt_merge('f2');
+SELECT dolt_merge('f3');
+" "SELECT count(*) FROM t;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 383: Text encoding
+# ═══════════════════════════════════════════════════════════════════
+echo "--- text encoding probes ---"
+
+oracle "unicode_accented_text_through_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'café'),(2,'naïve');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(3,'résumé');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(4,'über');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main');
+SELECT dolt_merge('feat');
+" "SELECT id, v FROM t ORDER BY id;"
+
+oracle "emoji_in_text_through_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'hello 👋');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(2,'party 🎉');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "SELECT id, v FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 384: BLOB operations
+# ═══════════════════════════════════════════════════════════════════
+echo "--- BLOB through merge ---"
+
+oracle "blob_update_one_side_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, b BLOB, tag TEXT);
+INSERT INTO t VALUES(1, X'DEADBEEF', 'initial');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+UPDATE t SET b=X'CAFEBABE' WHERE id=1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat blob');
+SELECT dolt_checkout('main');
+UPDATE t SET tag='main' WHERE id=1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main tag');
+SELECT dolt_merge('feat');
+" "SELECT id, hex(b), tag FROM t;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 385: Long-chain cherry-pick
+# ═══════════════════════════════════════════════════════════════════
+echo "--- long-chain cherry-pick ---"
+
+oracle "cherry_pick_6_sequential_from_feat" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+INSERT INTO t VALUES(0,0);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(1,1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','f1');
+INSERT INTO t VALUES(2,2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','f2');
+INSERT INTO t VALUES(3,3);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','f3');
+INSERT INTO t VALUES(4,4);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','f4');
+INSERT INTO t VALUES(5,5);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','f5');
+INSERT INTO t VALUES(6,6);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','f6');
+SELECT dolt_checkout('main');
+SELECT dolt_cherry_pick('feat~5');
+SELECT dolt_cherry_pick('feat~4');
+SELECT dolt_cherry_pick('feat~3');
+SELECT dolt_cherry_pick('feat~2');
+SELECT dolt_cherry_pick('feat~1');
+SELECT dolt_cherry_pick('feat');
+" "SELECT count(*) AS n, sum(v) AS s FROM t;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 386: Mixed index types
+# ═══════════════════════════════════════════════════════════════════
+echo "--- mixed index types ---"
+
+oracle "unique_plus_non_unique_index_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, code VARCHAR(16), category TEXT);
+CREATE UNIQUE INDEX uc ON t(code);
+CREATE INDEX idx_cat ON t(category);
+INSERT INTO t VALUES(1,'X','a'),(2,'Y','b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(3,'Z','a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(4,'W','c');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main');
+SELECT dolt_merge('feat');
+" "SELECT category, count(*) AS n FROM t GROUP BY category ORDER BY category;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 387: Schema diff after merge
+# ═══════════════════════════════════════════════════════════════════
+echo "--- schema diff count after merge ---"
+
+oracle "schema_diff_commit_count_after_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+ALTER TABLE t ADD COLUMN c1 INTEGER;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c1 added');
+ALTER TABLE t ADD COLUMN c2 INTEGER;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2 added');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+" "SELECT count(*) AS n FROM dolt_log WHERE message IN ('c1 added','c2 added');"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 388: UPDATE with CTE source
+# ═══════════════════════════════════════════════════════════════════
+echo "--- UPDATE cte source ---"
+
+oracle "update_via_cte_subquery_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+INSERT INTO t VALUES(1,0),(2,0),(3,0);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+UPDATE t SET v = (WITH c AS (SELECT max(id) AS mx FROM t) SELECT mx+id FROM c);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(4,99);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main');
+SELECT dolt_merge('feat');
+" "SELECT id, v FROM t ORDER BY id;"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 389: dolt_status detail
+# ═══════════════════════════════════════════════════════════════════
+echo "--- dolt_status detail ---"
+
+oracle "dolt_status_new_table_shows" "
+CREATE TABLE existing(id INTEGER PRIMARY KEY);
+INSERT INTO existing VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+CREATE TABLE new_tbl(id INTEGER PRIMARY KEY);
+INSERT INTO new_tbl VALUES(1);
+" "SELECT count(*) FROM dolt_status WHERE table_name='new_tbl';"
+
+oracle "dolt_status_modified_shows" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+UPDATE t SET v='b' WHERE id=1;
+" "SELECT count(*) FROM dolt_status WHERE table_name='t';"
+
+# ═══════════════════════════════════════════════════════════════════
+# Section 390: Commit after many no-ops
+# ═══════════════════════════════════════════════════════════════════
+echo "--- commit after noops ---"
+
+oracle "many_select_then_commit_stable" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c1');
+SELECT 1;
+SELECT 1+2;
+SELECT id FROM t;
+SELECT count(*) FROM dolt_log;
+INSERT INTO t VALUES(2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2');
+" "SELECT count(*) FROM dolt_log;"
+# ═══════════════════════════════════════════════════════════════════
 # ═══════════════════════════════════════════════════════════════════
 # Results
 # ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- Error recovery: **231 → 241** (+10)
- Feature interaction: **656 → 677** (+21)
- Combined: **918/1000**
- All tests pass on doltlite + Dolt 1.86.3

## Feature interaction additions
- `dolt_hashof_db()` presence / stability (2)
- ROW_NUMBER per group after merge
- 20-row cell merge disjoint across sides
- Recursive CTE generator joined with table
- UPDATE affecting nothing (WHERE 999 / WHERE v=v)
- Max via ORDER BY + LIMIT 1
- 1-parent / 3-child FK fan-out merge (`PRAGMA foreign_keys=1`)
- Diamond with 3 commits per side, no-ff
- `max(v) GROUP BY grp` after merge
- Three parallel branches all merged
- Accented text + emoji survive merge
- BLOB update on one side merge
- Cherry-pick 6 sequentially from feat
- Mixed unique + non-unique index merge
- Schema diff commit count across ADD COLUMN chain
- UPDATE via CTE in SET subquery
- `dolt_status` shows new / modified (2)
- Commit after many no-op reads

## Error recovery additions
- Recursive CTE with bogus self-ref
- ORDER BY bogus function
- Window function with bad OVER clause
- Savepoint error storm inside BEGIN/COMMIT
- INSERT targeting bogus col
- Merge against bogus hash-like ref
- Reset + commit post-reset
- Unterminated statement mid-script
- Tag error storm + recovery
- UPDATE / DELETE interleaved good + bogus

## Omitted (dialect/format divergence, not behavior)
- `length(v)` on emoji/unicode — SQLite counts chars (7), MySQL counts bytes (10). Switched to projecting `v` directly.
- `dolt_gc()` output — doltlite returns status string "N chunks removed, M kept", Dolt returns empty row. Test reshaped to `reset_hard_then_commit_no_gc` without the GC call.

## Test plan
- [x] `bash test/vc_oracle_error_recovery_test.sh ./doltlite dolt` — 241/241
- [x] `bash test/vc_oracle_feature_interaction_test.sh ./doltlite dolt` — 677/677
- [ ] CI oracle-tests job green

🤖 Generated with [Claude Code](https://claude.com/claude-code)