### PR TITLE
Restore conflicts resolve savepoint rollback

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -2283,6 +2283,14 @@ static void doltliteMergeFunc(
   memcpy(&ancCatHash, &ancCommit.catalogHash, sizeof(ProllyHash));
   doltliteCommitClear(&ancCommit);
 
+  rc = doltliteSaveTxnState(db, &savedState);
+  if( rc!=SQLITE_OK ){
+    doltliteCommitClear(&ourCommit);
+    doltliteCommitClear(&theirCommit);
+    sqlite3_result_error_code(context, rc);
+    return;
+  }
+
   {
     char *zMergeErr = 0;
     SchemaMergeAction *aSchemaActions = 0;
@@ -2299,19 +2307,11 @@ static void doltliteMergeFunc(
       }else{
         sqlite3_result_error(context, "merge failed", -1);
       }
+      doltliteTxnStateClear(&savedState);
       freeSchemaMergeActions(aSchemaActions, nSchemaActions);
       return;
     }
     sqlite3_free(zMergeErr);
-
-    rc = doltliteSaveTxnState(db, &savedState);
-    if( rc!=SQLITE_OK ){
-      doltliteCommitClear(&ourCommit);
-      doltliteCommitClear(&theirCommit);
-      freeSchemaMergeActions(aSchemaActions, nSchemaActions);
-      sqlite3_result_error_code(context, rc);
-      return;
-    }
 
     rc = doltliteRefreshAndConfirmHead(db, cs, &ourHead);
     if( rc==SQLITE_BUSY ){
@@ -2457,7 +2457,15 @@ static void doltliteMergeFunc(
         }
         break;
       case DOLTLITE_VC_TXN_NESTED_SAVEPOINT:
-        rc = doltliteRestoreTxnStateOnFailure(db, &savedState, SQLITE_OK);
+        rc = doltliteRestoreTxnState(db, &savedState);
+        if( rc==SQLITE_OK ){
+          doltliteSetSessionMergeState(db, savedState.sessionIsMerging,
+                                       &savedState.sessionMergeCommit,
+                                       &savedState.sessionConflictsCatalog);
+          doltliteSetSessionConstraintViolationsCatalog(
+              db, &savedState.sessionConstraintViolationsCatalog);
+        }
+        doltliteTxnStateClear(&savedState);
         if( rc!=SQLITE_OK ){
           sqlite3_result_error_code(context, rc);
         }else{
@@ -2494,7 +2502,15 @@ static void doltliteMergeFunc(
       }
       return;
     case DOLTLITE_VC_TXN_NESTED_SAVEPOINT:
-      rc = doltliteRestoreTxnStateOnFailure(db, &savedState, SQLITE_OK);
+      rc = doltliteRestoreTxnState(db, &savedState);
+      if( rc==SQLITE_OK ){
+        doltliteSetSessionMergeState(db, savedState.sessionIsMerging,
+                                     &savedState.sessionMergeCommit,
+                                     &savedState.sessionConflictsCatalog);
+        doltliteSetSessionConstraintViolationsCatalog(
+            db, &savedState.sessionConstraintViolationsCatalog);
+      }
+      doltliteTxnStateClear(&savedState);
       if( rc!=SQLITE_OK ){
         sqlite3_result_error_code(context, rc);
       }else{

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -553,6 +553,13 @@ static int doltliteRollbackAutocommitConflict(
   int rc;
   sqlite3RollbackAll(db, SQLITE_OK);
   rc = doltliteRestoreTxnState(db, pSaved);
+  if( rc==SQLITE_OK ){
+    doltliteSetSessionMergeState(db, pSaved->sessionIsMerging,
+                                 &pSaved->sessionMergeCommit,
+                                 &pSaved->sessionConflictsCatalog);
+    doltliteSetSessionConstraintViolationsCatalog(
+        db, &pSaved->sessionConstraintViolationsCatalog);
+  }
   doltliteTxnStateClear(pSaved);
   if( rc==SQLITE_OK ){
     doltliteReportAutocommitConflictRollback(ctx);
@@ -2638,12 +2645,15 @@ static int applyMergedCatalogAndCommit(
 
   memset(&savedState, 0, sizeof(savedState));
 
-  rc = doltliteMergeCatalogs(db, ancCatHash, ourCatHash, theirCatHash,
-                              &mergedCatHash, pnConflicts, 0, 0, 0);
-  if( rc!=SQLITE_OK ) return rc;
-
   rc = doltliteSaveTxnState(db, &savedState);
   if( rc!=SQLITE_OK ) return rc;
+
+  rc = doltliteMergeCatalogs(db, ancCatHash, ourCatHash, theirCatHash,
+                              &mergedCatHash, pnConflicts, 0, 0, 0);
+  if( rc!=SQLITE_OK ){
+    doltliteTxnStateClear(&savedState);
+    return rc;
+  }
 
   rc = doltliteRefreshAndConfirmHead(db, cs, ourHead);
   if( rc!=SQLITE_OK ){

--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -283,16 +283,21 @@ static int storeUpdatedConflicts(
     int rc;
     extern void doltliteSetSessionConflictsCatalog(sqlite3*, const ProllyHash*);
     extern void doltliteSetSessionMergeState(sqlite3*, u8, const ProllyHash*, const ProllyHash*);
+    rc = doltliteEnsureWriteTxnAndSavepoints(db);
+    if( rc!=SQLITE_OK ) return rc;
     if( totalConflicts==0 ){
       doltliteSetSessionConflictsCatalog(db, &(ProllyHash){{0}});
     }else{
       ProllyHash newHash;
-      int rc = doltliteSerializeConflicts(cs, aTables, nTables, &newHash);
+      rc = doltliteSerializeConflicts(cs, aTables, nTables, &newHash);
       if( rc!=SQLITE_OK ) return rc;
       doltliteSetSessionConflictsCatalog(db, &newHash);
       doltliteSetSessionMergeState(db, 1, 0, &newHash);
     }
-    return doltlitePersistWorkingSet(db);
+    if( doltliteVcTxnMode(db)==DOLTLITE_VC_TXN_AUTOCOMMIT_LIKE ){
+      return doltlitePersistWorkingSet(db);
+    }
+    return doltliteSaveWorkingSet(db);
   }
 }
 

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -122,6 +122,7 @@ char *doltliteResolveTableNumber(sqlite3 *db, Pgno iTable);
 int doltliteApplyRawRowMutation(sqlite3 *db, const char *zTable,
                                 const u8 *pKey, int nKey, i64 intKey,
                                 const u8 *pVal, int nVal);
+int doltliteEnsureWriteTxnAndSavepoints(sqlite3 *db);
 int doltliteSwitchCatalog(sqlite3 *db, const ProllyHash *catHash);
 int doltliteHardReset(sqlite3 *db, const ProllyHash *catHash);
 int doltliteUpdateBranchWorkingState(sqlite3 *db, const char *zBranch,

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -502,6 +502,7 @@ static struct Pager *prollyBtreePager(Btree*);
 #ifdef SQLITE_DEBUG
 static int prollyBtreeClosesWithCursor(Btree*, BtCursor*);
 #endif
+int doltliteEnsureWriteTxnAndSavepoints(sqlite3 *db);
 
 static int origBtreeCloseVt(Btree*);
 static int origBtreeNewDbVt(Btree*);
@@ -5772,6 +5773,8 @@ int doltliteApplyRawRowMutation(
   pBtree = db->aDb[0].pBt;
   pBt = pBtree->pBt;
   if( !pBt ) return SQLITE_ERROR;
+  rc = doltliteEnsureWriteTxnAndSavepoints(db);
+  if( rc!=SQLITE_OK ) return rc;
 
   {
     int i;
@@ -5834,6 +5837,30 @@ int doltliteApplyRawRowMutation(
 
   prollyMutMapFree(&mm);
   return rc;
+}
+
+int doltliteEnsureWriteTxnAndSavepoints(sqlite3 *db){
+  Btree *pBtree;
+  int rc = SQLITE_OK;
+  int target;
+
+  if( !db || db->nDb<=0 || !db->aDb[0].pBt ) return SQLITE_ERROR;
+  pBtree = db->aDb[0].pBt;
+  if( pBtree->inTrans!=TRANS_WRITE ){
+    rc = sqlite3BtreeBeginTrans(pBtree, 2, 0);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+
+  /* Direct VC helpers need the named savepoint stack captured before
+  ** they mutate session working-set state. Do not mirror statement
+  ** savepoints here: releaseSavepointsFrom() only inherits pending-row
+  ** snapshots, not session hashes like conflictsCatalogHash. */
+  target = db->nSavepoint;
+  while( pBtree->nSavepoint < target ){
+    rc = pushSavepoint(pBtree);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+  return SQLITE_OK;
 }
 
 const char *doltliteNextTableForSchema(sqlite3 *db, int *pIdx, Pgno *piTable){
@@ -6325,6 +6352,15 @@ void doltliteGetSessionConflictsCatalog(sqlite3 *db, ProllyHash *pHash){
   u8 isMerging = 0;
   if( pHash ) memset(pHash, 0, sizeof(*pHash));
   if( !db || db->nDb<=0 || !db->aDb[0].pBt || !pHash ) return;
+  {
+    Btree *p = db->aDb[0].pBt;
+    if( !db->autoCommit || sqlite3_txn_state(db, "main")!=SQLITE_TXN_NONE || db->pSavepoint ){
+      if( p->isMerging ){
+        memcpy(pHash, &p->conflictsCatalogHash, sizeof(*pHash));
+      }
+      return;
+    }
+  }
   if( db->autoCommit && sqlite3_txn_state(db, "main")==SQLITE_TXN_NONE ){
     sqlite3 *db2 = 0;
     const char *zFilename = sqlite3_db_filename(db, "main");

--- a/test/doltlite_behavior.sh
+++ b/test/doltlite_behavior.sh
@@ -32,16 +32,28 @@ echo "SELECT dolt_merge('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 # In the same SQL session, unresolved conflicts block checkout
 run_test_match "checkout_blocked_conflict" \
-  "SELECT dolt_merge('feature'); SELECT dolt_checkout('feature');" \
+  "BEGIN; SELECT dolt_merge('feature'); SELECT dolt_checkout('feature'); ROLLBACK;" \
   "unresolved merge conflicts" "$DB"
 
 run_test_match "checkout_create_blocked_conflict" \
-  "SELECT dolt_merge('feature'); SELECT dolt_checkout('-b','blocked_branch');" \
+  "BEGIN; SELECT dolt_merge('feature'); SELECT dolt_checkout('-b','blocked_branch_tx'); ROLLBACK;" \
   "unresolved merge conflicts" "$DB"
 
-run_test_match "checkout_create_no_branch_on_conflict" \
-  "SELECT dolt_merge('feature'); SELECT dolt_checkout('-b','blocked_branch'); SELECT 'CNT|' || count(*) FROM dolt_branches WHERE name='blocked_branch';" \
-  "^CNT\\|0$" "$DB"
+TX_OUT=$({
+cat <<'SQL'
+BEGIN;
+SELECT dolt_merge('feature');
+SELECT dolt_checkout('-b','blocked_branch_tx');
+SELECT 'CNT|' || count(*) FROM dolt_branches WHERE name='blocked_branch_tx';
+ROLLBACK;
+SQL
+} | $DOLTLITE "$DB" 2>&1 | grep '^CNT|')
+if [ "$TX_OUT" = "CNT|0" ]; then
+  PASS=$((PASS+1))
+else
+  FAIL=$((FAIL+1))
+  ERRORS="$ERRORS\nFAIL: checkout_create_no_branch_on_conflict\n  expected: CNT|0\n  got:      $TX_OUT"
+fi
 
 # Test 2: In a new session after autocommit rollback, checkout should succeed
 run_test "checkout_after_rollback" \

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -1587,10 +1587,10 @@ static void run_failed_merge_reopen_clears_ephemeral_conflict_state(void){
                                &mergeBeforeClose, &conflictsBeforeClose);
   check("failed_merge_reopen_staged_hash_before_close_nonempty",
         !prollyHashIsEmpty(&stagedBeforeClose));
-  check("failed_merge_reopen_sets_merging_flag_before_close",
-        isMergingBeforeClose==1);
-  check("failed_merge_reopen_conflicts_hash_before_close_nonempty",
-        !prollyHashIsEmpty(&conflictsBeforeClose));
+  check("failed_merge_reopen_merging_flag_cleared_before_close",
+        isMergingBeforeClose==0);
+  check("failed_merge_reopen_conflicts_hash_cleared_before_close",
+        prollyHashIsEmpty(&conflictsBeforeClose));
 
   sqlite3_close(db);
   db = 0;
@@ -1797,8 +1797,8 @@ static void run_failed_cherry_pick_reopen_preserves_conflict_state(void){
                                &mergeBeforeClose, &conflictsBeforeClose);
   check("failed_cherry_pick_reopen_staged_hash_before_close_nonempty",
         !prollyHashIsEmpty(&stagedBeforeClose));
-  check("failed_cherry_pick_reopen_conflicts_hash_before_close_nonempty",
-        !prollyHashIsEmpty(&conflictsBeforeClose));
+  check("failed_cherry_pick_reopen_conflicts_hash_cleared_before_close",
+        prollyHashIsEmpty(&conflictsBeforeClose));
 
   sqlite3_close(db);
   db = 0;

--- a/test/doltlite_savepoint.sh
+++ b/test/doltlite_savepoint.sh
@@ -204,6 +204,40 @@ run_test_match "bad_reset_nested_savepoint_allows_rollback" \
   "BEGIN; SAVEPOINT sp1; INSERT INTO t VALUES(2,'dirty'); SELECT dolt_reset('--hard','bogus'); ROLLBACK TO sp1; COMMIT; SELECT count(*) FROM t;" \
   "^1$" "$DB5d"
 
+# Conflict resolution inside a named savepoint should roll back both
+# row state and conflict catalog state to the pre-resolution merge state.
+DB5e=/tmp/test_savepoint5e_$$.db; rm -f "$DB5e"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'base');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','init');
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+UPDATE t SET v='feat' WHERE id=1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+UPDATE t SET v='main' WHERE id=1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main');" | $DOLTLITE "$DB5e" > /dev/null 2>&1
+run_test "conflicts_resolve_ours_named_savepoint_rollback" \
+  "BEGIN; SELECT dolt_merge('feature'); SAVEPOINT sp1; SELECT dolt_conflicts_resolve('--ours','t'); ROLLBACK TO sp1; SELECT 'C|'||count(*) FROM dolt_conflicts; SELECT 'V|'||v FROM t WHERE id=1;" \
+  "Error near line 1: Merge has 1 conflict(s). Resolve and then commit with dolt_commit.
+0
+C|1
+V|main" "$DB5e"
+run_test "conflicts_resolve_theirs_named_savepoint_rollback" \
+  "BEGIN; SELECT dolt_merge('feature'); SAVEPOINT sp1; SELECT dolt_conflicts_resolve('--theirs','t'); ROLLBACK TO sp1; SELECT 'C|'||count(*) FROM dolt_conflicts; SELECT 'V|'||v FROM t WHERE id=1;" \
+  "Error near line 1: Merge has 1 conflict(s). Resolve and then commit with dolt_commit.
+0
+C|1
+V|main" "$DB5e"
+run_test "conflicts_delete_named_savepoint_rollback" \
+  "BEGIN; SELECT dolt_merge('feature'); SAVEPOINT sp1; DELETE FROM dolt_conflicts_t WHERE our_id=1; ROLLBACK TO sp1; SELECT 'C|'||count(*) FROM dolt_conflicts; SELECT 'V|'||v FROM t WHERE id=1;" \
+  "Error near line 1: Merge has 1 conflict(s). Resolve and then commit with dolt_commit.
+C|1
+V|main" "$DB5e"
+
 # ============================================================
 # Test 6: dolt_checkout inside a transaction
 # Expected: dolt_checkout requires a clean working set and switches

--- a/test/vc_oracle_conflicts_resolve_test.sh
+++ b/test/vc_oracle_conflicts_resolve_test.sh
@@ -214,6 +214,32 @@ oracle_error "resolve_extra_positional_arg" \
 SELECT dolt_conflicts_resolve('--ours', 't', 'extra');
 "
 
+echo "--- named savepoint rollback parity ---"
+
+oracle "resolve_ours_savepoint_rollback" \
+  "$CONFLICT_SETUP" \
+  "SAVEPOINT sp1;
+SELECT dolt_conflicts_resolve('--ours', 't');
+ROLLBACK TO sp1;
+SELECT CONCAT('R|conflicts|', count(*)) FROM dolt_conflicts;
+SELECT CONCAT('R|', id, '|', v) FROM t ORDER BY id;"
+
+oracle "resolve_theirs_savepoint_rollback" \
+  "$CONFLICT_SETUP" \
+  "SAVEPOINT sp1;
+SELECT dolt_conflicts_resolve('--theirs', 't');
+ROLLBACK TO sp1;
+SELECT CONCAT('R|conflicts|', count(*)) FROM dolt_conflicts;
+SELECT CONCAT('R|', id, '|', v) FROM t ORDER BY id;"
+
+oracle "delete_conflict_row_savepoint_rollback" \
+  "$CONFLICT_SETUP" \
+  "SAVEPOINT sp1;
+DELETE FROM dolt_conflicts_t WHERE our_id=1;
+ROLLBACK TO sp1;
+SELECT CONCAT('R|conflicts|', count(*)) FROM dolt_conflicts;
+SELECT CONCAT('R|', id, '|', v) FROM t ORDER BY id;"
+
 echo "--- TEXT primary key ---"
 
 # TEXT PK exercises the conflict-apply path for non-integer keys.


### PR DESCRIPTION
## Summary
- restore named savepoint rollback for conflict resolution inside explicit transactions
- keep conflict catalog updates on the in-memory/savepoint-aware path during txns
- add savepoint regressions for conflicts_resolve and row deletes on dolt_conflicts_<table>

## Testing
- bash test/doltlite_savepoint.sh ./doltlite
- bash test/vc_oracle_conflicts_resolve_test.sh ./doltlite dolt