### PR TITLE
Invalidate top savepoints on conflict rollback

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -551,6 +551,7 @@ static int doltliteRollbackAutocommitConflict(
   DoltliteTxnState *pSaved
 ){
   int rc;
+  int hadTopLevelSavepoint = db->pSavepoint!=0 && db->nSavepoint==0;
   sqlite3RollbackAll(db, SQLITE_OK);
   rc = doltliteRestoreTxnState(db, pSaved);
   if( rc==SQLITE_OK ){
@@ -561,6 +562,9 @@ static int doltliteRollbackAutocommitConflict(
         db, &pSaved->sessionConstraintViolationsCatalog);
   }
   doltliteTxnStateClear(pSaved);
+  if( rc==SQLITE_OK && hadTopLevelSavepoint ){
+    rc = doltliteVcSealTopLevelSavepointTxn(db);
+  }
   if( rc==SQLITE_OK ){
     doltliteReportAutocommitConflictRollback(ctx);
   }

--- a/test/vc_oracle_merge_test.sh
+++ b/test/vc_oracle_merge_test.sh
@@ -564,6 +564,28 @@ SELECT 'Q' || char(9) || (SELECT v FROM t WHERE id = 1);" \
 "SELECT concat('Q', char(9), (SELECT count(*) FROM dolt_conflicts));
 SELECT concat('Q', char(9), (SELECT v FROM t WHERE id = 1));"
 
+oracle_same_session "merge_conflict_top_savepoint_invalidated" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'base');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'base');
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+UPDATE t SET v = 'feat' WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat');
+SELECT dolt_checkout('main');
+UPDATE t SET v = 'main' WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main');
+SAVEPOINT sp1;
+SELECT dolt_merge('feature');
+ROLLBACK TO sp1;
+" "SELECT 'Q' || char(9) || (SELECT count(*) FROM dolt_conflicts);
+SELECT 'Q' || char(9) || (SELECT v FROM t WHERE id = 1);" \
+"SELECT concat('Q', char(9), (SELECT count(*) FROM dolt_conflicts));
+SELECT concat('Q', char(9), (SELECT v FROM t WHERE id = 1));"
+
 echo "--- already up to date ---"
 
 oracle "merge_same_branch_no_op" "

--- a/test/vc_oracle_revert_cherrypick_test.sh
+++ b/test/vc_oracle_revert_cherrypick_test.sh
@@ -640,6 +640,48 @@ ROLLBACK TO sp1;
           (SELECT count(*) FROM dolt_log);" \
   "SELECT CONCAT(active_branch(), '|', (SELECT GROUP_CONCAT(CONCAT(id, ':', v) ORDER BY id SEPARATOR ',') FROM t), '|', (SELECT COUNT(*) FROM dolt_log))"
 
+oracle_error_poststate "cherry_pick_conflict_top_savepoint_invalidated" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'base');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'init');
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+UPDATE t SET v = 'feature' WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feature edit');
+SELECT dolt_tag('feat-conflict');
+SELECT dolt_checkout('main');
+UPDATE t SET v = 'main' WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main edit');
+SAVEPOINT sp1;
+SELECT dolt_cherry_pick('feat-conflict');
+ROLLBACK TO sp1;
+" "SELECT active_branch() || '|' ||
+          (SELECT group_concat(id || ':' || v, ',') FROM (SELECT id, v FROM t ORDER BY id) AS ordered) || '|' ||
+          (SELECT count(*) FROM dolt_conflicts);" \
+  "SELECT CONCAT(active_branch(), '|', (SELECT GROUP_CONCAT(CONCAT(id, ':', v) ORDER BY id SEPARATOR ',') FROM t), '|', (SELECT COUNT(*) FROM dolt_conflicts))"
+
+oracle_error_poststate "revert_conflict_top_savepoint_invalidated" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'base');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'init');
+UPDATE t SET v = 'mid' WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'mid edit');
+UPDATE t SET v = 'head' WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'head edit');
+SAVEPOINT sp1;
+SELECT dolt_revert('HEAD~1');
+ROLLBACK TO sp1;
+" "SELECT active_branch() || '|' ||
+          (SELECT group_concat(id || ':' || v, ',') FROM (SELECT id, v FROM t ORDER BY id) AS ordered) || '|' ||
+          (SELECT count(*) FROM dolt_conflicts);" \
+  "SELECT CONCAT(active_branch(), '|', (SELECT GROUP_CONCAT(CONCAT(id, ':', v) ORDER BY id SEPARATOR ',') FROM t), '|', (SELECT COUNT(*) FROM dolt_conflicts))"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then


### PR DESCRIPTION
## Summary
- invalidate top-level savepoints when autocommit-like merge / cherry-pick / revert conflicts roll back
- add merge oracle coverage for top-savepoint conflict invalidation
- add replay oracle coverage for cherry-pick / revert top-savepoint conflict invalidation

## Verification
- bash test/doltlite_savepoint.sh ./doltlite
- bash test/vc_oracle_merge_test.sh ./doltlite dolt
- bash test/vc_oracle_revert_cherrypick_test.sh ./doltlite dolt