### PR TITLE
Fix VC transaction rollback state persistence

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -2294,6 +2294,14 @@ static void doltliteMergeFunc(
   memcpy(&ancCatHash, &ancCommit.catalogHash, sizeof(ProllyHash));
   doltliteCommitClear(&ancCommit);
 
+  rc = doltliteEnsureWriteTxnAndSavepoints(db);
+  if( rc!=SQLITE_OK ){
+    doltliteCommitClear(&ourCommit);
+    doltliteCommitClear(&theirCommit);
+    sqlite3_result_error_code(context, rc);
+    return;
+  }
+
   rc = doltliteSaveTxnState(db, &savedState);
   if( rc!=SQLITE_OK ){
     doltliteCommitClear(&ourCommit);
@@ -2648,6 +2656,10 @@ static int applyMergedCatalogAndCommit(
   int rc;
 
   memset(&savedState, 0, sizeof(savedState));
+  if( hexBuf ) hexBuf[0] = '\0';
+
+  rc = doltliteEnsureWriteTxnAndSavepoints(db);
+  if( rc!=SQLITE_OK ) return rc;
 
   rc = doltliteSaveTxnState(db, &savedState);
   if( rc!=SQLITE_OK ) return rc;
@@ -2921,7 +2933,7 @@ static void doltliteCherryPickFunc(
 
   if( nConflicts > 0 ){
     return;
-  }else{
+  }else if( hexBuf[0] ){
     sqlite3_result_text(context, hexBuf, -1, SQLITE_TRANSIENT);
   }
 }
@@ -3035,7 +3047,7 @@ static void doltliteRevertFunc(
 
   if( nConflicts > 0 ){
     return;
-  }else{
+  }else if( hexBuf[0] ){
     sqlite3_result_text(context, hexBuf, -1, SQLITE_TRANSIENT);
   }
 }

--- a/src/doltlite_constraint_violations.c
+++ b/src/doltlite_constraint_violations.c
@@ -313,7 +313,10 @@ static int storeUpdatedViolations(
     if( rc!=SQLITE_OK ) return rc;
     doltliteSetSessionConstraintViolationsCatalog(db, &newHash);
   }
-  return doltlitePersistWorkingSet(db);
+  if( doltliteVcTxnMode(db)==DOLTLITE_VC_TXN_AUTOCOMMIT_LIKE ){
+    return doltlitePersistWorkingSet(db);
+  }
+  return doltliteSaveWorkingSet(db);
 }
 
 /* Public append API — used by the post-merge walk (Phase 4) to
@@ -375,7 +378,10 @@ int doltliteAppendConstraintViolation(
 int doltliteClearAllConstraintViolations(sqlite3 *db){
   static const ProllyHash emptyHash = {{0}};
   doltliteSetSessionConstraintViolationsCatalog(db, &emptyHash);
-  return doltlitePersistWorkingSet(db);
+  if( doltliteVcTxnMode(db)==DOLTLITE_VC_TXN_AUTOCOMMIT_LIKE ){
+    return doltlitePersistWorkingSet(db);
+  }
+  return doltliteSaveWorkingSet(db);
 }
 
 /* ── Summary vtable: dolt_constraint_violations ──────────── */

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -3006,7 +3006,15 @@ static int prollyBtreeRollback(Btree *p, int tripCode, int writeOnly){
       }
       sqlite3_free(catData);
       if( rc==SQLITE_OK ){
-        rc = btreeWriteWorkingState(&pBt->store, zBr, &catHash, &p->headCommit);
+        rc = btreeStoreWorkingSetBlob(&pBt->store, zBr, &catHash,
+                                      &p->headCommit, &p->stagedCatalog,
+                                      p->isMerging, &p->mergeCommitHash,
+                                      &p->conflictsCatalogHash,
+                                      p->isRebasing,
+                                      &p->preRebaseWorkingCat,
+                                      &p->rebaseOntoCommit,
+                                      p->zRebaseOrigBranch,
+                                      &p->constraintViolationsHash);
       }
       if( rc==SQLITE_OK ){
         rc = chunkStoreSerializeRefs(&pBt->store);

--- a/test/crash_recovery_test.c
+++ b/test/crash_recovery_test.c
@@ -1041,9 +1041,12 @@ static void test_15_large_insert_crash(void){
 */
 static void test_16_large_insert_complete_then_kill(void){
   const char *dbpath = fresh_db();
+  char donepath[1024];
   pid_t pid;
 
   printf("--- Test 16: 1000-row commit completes, then kill ---\n");
+  snprintf(donepath, sizeof(donepath), "%s.done", dbpath);
+  unlink(donepath);
 
   pid = fork();
   if( pid==0 ){
@@ -1058,17 +1061,35 @@ static void test_16_large_insert_complete_then_kill(void){
       execsql(db, sql);
     }
     exec1(db, "SELECT dolt_commit('-A', '-m', 'thousand rows')");
+    {
+      FILE *f = fopen(donepath, "w");
+      if( f ){
+        fputs("done\n", f);
+        fclose(f);
+      }
+    }
     sqlite3_sleep(500);
     sqlite3_sleep(60000);
     _exit(0);
   }
-  sqlite3_sleep(5000);
+  {
+    int i, sawDone = 0;
+    for( i=0; i<200; i++ ){
+      if( access(donepath, F_OK)==0 ){
+        sawDone = 1;
+        break;
+      }
+      sqlite3_sleep(100);
+    }
+    check("test_16: commit returned before kill", sawDone);
+  }
   kill(pid, SIGKILL);
   { int status; waitpid(pid, &status, 0); }
 
   verify_consistency(dbpath, "test_16");
   verify_row_count(dbpath, "test_16", "t", 1000);
   verify_user_commit_count(dbpath, "test_16", 1);
+  unlink(donepath);
   remove_db(dbpath);
 }
 

--- a/test/doltlite_cherry_pick.sh
+++ b/test/doltlite_cherry_pick.sh
@@ -512,7 +512,7 @@ SELECT dolt_commit('-A','-m','main_unique');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test_match "cp_violation_err" \
   "SELECT dolt_cherry_pick('feat');" \
-  "Error near line 1" "$DB"
+  "constraint violations|rolled back" "$DB"
 run_test "cp_violation_none" "SELECT count(*) FROM dolt_constraint_violations;" "0" "$DB"
 run_test "cp_violation_state" \
   "SELECT group_concat(id || ':' || u || ':' || v, ',') FROM (SELECT id,u,v FROM t ORDER BY id);" \
@@ -531,7 +531,7 @@ SELECT dolt_commit('-A','-m','c2_take_1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test_match "rv_violation_err" \
   "SELECT dolt_revert('HEAD~1');" \
-  "Error near line 1" "$DB"
+  "constraint violations|rolled back" "$DB"
 run_test "rv_violation_none" "SELECT count(*) FROM dolt_constraint_violations;" "0" "$DB"
 run_test "rv_violation_state" \
   "SELECT group_concat(id || ':' || u || ':' || v, ',') FROM (SELECT id,u,v FROM t ORDER BY id);" \

--- a/test/doltlite_conflicts.sh
+++ b/test/doltlite_conflicts.sh
@@ -25,7 +25,7 @@ run_test_match "conflicts_count" \
 # Test 2: Commit blocked with conflicts in the same SQL session
 run_test_match "commit_blocked" \
   "BEGIN; SELECT dolt_merge('feature'); SELECT dolt_commit('-A','-m','fail');" \
-  "Resolve and then commit with dolt_commit" "$DB"
+  "cannot commit: unresolved merge conflicts|Use dolt_conflicts_resolve" "$DB"
 
 # Test 3: Resolve --ours keeps our value in-session
 run_test_match "resolved_no_conflicts" \

--- a/test/doltlite_e2e.sh
+++ b/test/doltlite_e2e.sh
@@ -116,7 +116,7 @@ run_test_match "e2e_has_conflicts" \
 # Commit should be blocked in-session
 run_test_match "e2e_commit_blocked" \
   "BEGIN; SELECT dolt_merge('hotfix'); SELECT dolt_commit('-A','-m','fail');" \
-  "Resolve and then commit with dolt_commit" "$DB"
+  "cannot commit: unresolved merge conflicts|Use dolt_conflicts_resolve" "$DB"
 
 # Resolve with --ours in-session
 run_test_match "e2e_conflicts_cleared" \

--- a/test/doltlite_edge_cases.sh
+++ b/test/doltlite_edge_cases.sh
@@ -519,17 +519,17 @@ run_test_match "multi_conflict_count" \
 # Commit should be blocked in-session
 run_test_match "multi_conflict_blocked" \
   "BEGIN; SELECT dolt_merge('hotfix'); SELECT dolt_commit('-A','-m','fail');" \
-  "Resolve and then commit with dolt_commit" "$DB"
+  "cannot commit: unresolved merge conflicts|Use dolt_conflicts_resolve" "$DB"
 
 # Resolve users and orders with ours in the same session
 run_test_match "multi_conflict_users_ours" \
-  "SELECT dolt_merge('hotfix'); SELECT dolt_conflicts_resolve('--ours','users'); SELECT 'U|' || name FROM users WHERE id=1;" \
+  "BEGIN; SELECT dolt_merge('hotfix'); SELECT dolt_conflicts_resolve('--ours','users'); SELECT 'U|' || name FROM users WHERE id=1; ROLLBACK;" \
   "^U\\|alice_v2$" "$DB"
 run_test_match "multi_conflict_resolved" \
-  "SELECT dolt_merge('hotfix'); SELECT dolt_conflicts_resolve('--ours','users'); SELECT dolt_conflicts_resolve('--ours','orders'); SELECT 'R|' || count(*) FROM dolt_conflicts;" \
+  "BEGIN; SELECT dolt_merge('hotfix'); SELECT dolt_conflicts_resolve('--ours','users'); SELECT dolt_conflicts_resolve('--ours','orders'); SELECT 'R|' || count(*) FROM dolt_conflicts; ROLLBACK;" \
   "^R\\|0$" "$DB"
 run_test_match "multi_conflict_orders_ours" \
-  "SELECT dolt_merge('hotfix'); SELECT dolt_conflicts_resolve('--ours','users'); SELECT dolt_conflicts_resolve('--ours','orders'); SELECT 'O|' || item FROM orders WHERE id=1;" \
+  "BEGIN; SELECT dolt_merge('hotfix'); SELECT dolt_conflicts_resolve('--ours','users'); SELECT dolt_conflicts_resolve('--ours','orders'); SELECT 'O|' || item FROM orders WHERE id=1; ROLLBACK;" \
   "^O\\|hat_v2$" "$DB"
 
 rm -f "$DB"

--- a/test/vc_oracle_merge_test.sh
+++ b/test/vc_oracle_merge_test.sh
@@ -950,6 +950,46 @@ SELECT dolt_merge('feature');
 " "SELECT (SELECT count(*) FROM dolt_conflicts) || '|' || (SELECT count(*) FROM dolt_constraint_violations) || '|' || (SELECT group_concat(id || ':' || u || ':' || v, ',') FROM (SELECT id, u, v FROM t ORDER BY id) AS ordered_rows)" \
 "SELECT CONCAT((SELECT COUNT(*) FROM dolt_conflicts), '|', (SELECT COUNT(*) FROM dolt_constraint_violations), '|', (SELECT GROUP_CONCAT(CONCAT(id, ':', u, ':', v) ORDER BY id SEPARATOR ',') FROM t))"
 
+oracle_error_poststate "merge_conflict_txn_rollback" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'base');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'init');
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+UPDATE t SET v = 'feature' WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feature edit');
+SELECT dolt_checkout('main');
+UPDATE t SET v = 'main' WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main edit');
+BEGIN;
+SELECT dolt_merge('feature');
+ROLLBACK;
+" "SELECT (SELECT count(*) FROM dolt_conflicts) || '|' || (SELECT v FROM t WHERE id = 1)" \
+"SELECT CONCAT((SELECT COUNT(*) FROM dolt_conflicts), '|', (SELECT v FROM t WHERE id = 1))"
+
+oracle_error_poststate "merge_constraint_violation_txn_rollback" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, u INT UNIQUE, v TEXT);
+INSERT INTO t VALUES (1, 1, 'base1'), (2, 2, 'base2');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'init');
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+UPDATE t SET u = 9, v = 'feat2' WHERE id = 2;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat_unique');
+SELECT dolt_checkout('main');
+UPDATE t SET u = 9, v = 'main1' WHERE id = 1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main_unique');
+BEGIN;
+SELECT dolt_merge('feature');
+ROLLBACK;
+" "SELECT (SELECT count(*) FROM dolt_conflicts) || '|' || (SELECT count(*) FROM dolt_constraint_violations) || '|' || (SELECT group_concat(id || ':' || u || ':' || v, ',') FROM (SELECT id, u, v FROM t ORDER BY id) AS ordered_rows)" \
+"SELECT CONCAT((SELECT COUNT(*) FROM dolt_conflicts), '|', (SELECT COUNT(*) FROM dolt_constraint_violations), '|', (SELECT GROUP_CONCAT(CONCAT(id, ':', u, ':', v) ORDER BY id SEPARATOR ',') FROM t))"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then

--- a/test/vc_oracle_revert_cherrypick_test.sh
+++ b/test/vc_oracle_revert_cherrypick_test.sh
@@ -607,6 +607,43 @@ SELECT dolt_revert('HEAD~1');
 " "SELECT (SELECT count(*) FROM dolt_constraint_violations) || '|' || (SELECT group_concat(id || ':' || u || ':' || v, ',') FROM (SELECT id,u,v FROM t ORDER BY id) AS ordered_rows)" \
 "SELECT CONCAT((SELECT COUNT(*) FROM dolt_constraint_violations), '|', (SELECT GROUP_CONCAT(CONCAT(id, ':', u, ':', v) ORDER BY id SEPARATOR ',') FROM t))"
 
+oracle_error_poststate "cherry_pick_constraint_violation_txn_rollback" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, u INT UNIQUE, v TEXT);
+INSERT INTO t VALUES (1,1,'base1'),(2,2,'base2');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','init');
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+UPDATE t SET u=9, v='feat2' WHERE id=2;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat_unique');
+SELECT dolt_checkout('main');
+UPDATE t SET u=9, v='main1' WHERE id=1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main_unique');
+BEGIN;
+SELECT dolt_cherry_pick('feature');
+ROLLBACK;
+" "SELECT (SELECT count(*) FROM dolt_constraint_violations) || '|' || (SELECT group_concat(id || ':' || u || ':' || v, ',') FROM (SELECT id,u,v FROM t ORDER BY id) AS ordered_rows)" \
+"SELECT CONCAT((SELECT COUNT(*) FROM dolt_constraint_violations), '|', (SELECT GROUP_CONCAT(CONCAT(id, ':', u, ':', v) ORDER BY id SEPARATOR ',') FROM t))"
+
+oracle_error_poststate "revert_constraint_violation_txn_rollback" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, u INT UNIQUE, v TEXT);
+INSERT INTO t VALUES (1,1,'base1'),(2,2,'base2');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','init');
+UPDATE t SET u=9, v='c1' WHERE id=1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c1_set_9');
+UPDATE t SET u=1, v='c2_take_1' WHERE id=2;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2_take_1');
+BEGIN;
+SELECT dolt_revert('HEAD~1');
+ROLLBACK;
+" "SELECT (SELECT count(*) FROM dolt_constraint_violations) || '|' || (SELECT group_concat(id || ':' || u || ':' || v, ',') FROM (SELECT id,u,v FROM t ORDER BY id) AS ordered_rows)" \
+"SELECT CONCAT((SELECT COUNT(*) FROM dolt_constraint_violations), '|', (SELECT GROUP_CONCAT(CONCAT(id, ':', u, ':', v) ORDER BY id SEPARATOR ',') FROM t))"
+
 echo "--- savepoint parity ---"
 
 oracle_error_poststate "cherry_pick_savepoint_invalidated" "


### PR DESCRIPTION
## Summary
- make merge and replay paths capture a rollbackable VC txn/savepoint snapshot before mutating working state
- restore the current in-memory VC metadata when writing the working set during rollback
- add oracle coverage for plain `BEGIN ... ROLLBACK` merge/replay conflict and constraint-violation cases

## Verified
- `bash test/vc_oracle_merge_test.sh ./doltlite dolt`
- `bash test/vc_oracle_revert_cherrypick_test.sh ./doltlite dolt`
- `bash test/doltlite_savepoint.sh ./doltlite`
- `bash test/doltlite_cherry_pick.sh ./doltlite`