### PR TITLE
Fix merge UNIQUE violation detection to respect NULL != NULL (closes #573)

### DIFF
--- a/src/doltlite_merge_constraints.c
+++ b/src/doltlite_merge_constraints.c
@@ -890,6 +890,20 @@ static int appendUniqueViolationByPk(
   return rc;
 }
 
+/* Return 1 if any column in [colFirst, colLast) of the current
+** row is NULL. Per SQL standard, a row with NULL in any column
+** of a UNIQUE index is exempt from that uniqueness check
+** (NULL != NULL for UNIQUE). Such rows cannot participate in a
+** duplicate group and must be skipped by the merge-time dup
+** detection below. */
+static int uniqueIndexRowHasNull(sqlite3_stmt *pScan, int colFirst, int colLast){
+  int i;
+  for(i=colFirst; i<colLast; i++){
+    if( sqlite3_column_type(pScan, i) == SQLITE_NULL ) return 1;
+  }
+  return 0;
+}
+
 /* Walk every row in zTable and look for duplicate values on the
 ** given UNIQUE index columns. When a duplicate group is found,
 ** every merge-introduced row in that group is recorded in
@@ -933,18 +947,16 @@ static int detectUniqueViolationsForIndex(
     sqlite3_int64 rowid = sqlite3_column_int64(pScan, 0);
     int nc = sqlite3_column_count(pScan);
     int i;
-    sqlite3_str *pS = sqlite3_str_new(0);
+    sqlite3_str *pS;
     char *zRowKey;
     int isDup;
 
+    if( uniqueIndexRowHasNull(pScan, 1, nc) ) continue;
+
+    pS = sqlite3_str_new(0);
     for(i=1; i<nc; i++){
       const char *zV = (const char*)sqlite3_column_text(pScan, i);
-      int type = sqlite3_column_type(pScan, i);
-      if( type == SQLITE_NULL ){
-        sqlite3_str_appendf(pS, "%sNULL", i>1?"|":"");
-      }else{
-        sqlite3_str_appendf(pS, "%s%Q", i>1?"|":"", zV ? zV : "");
-      }
+      sqlite3_str_appendf(pS, "%s%Q", i>1?"|":"", zV ? zV : "");
     }
     zRowKey = sqlite3_str_finish(pS);
     if( !zRowKey ){ rc = SQLITE_NOMEM; break; }
@@ -1014,18 +1026,16 @@ static int detectUniqueViolationsForIndexWithoutRowid(
   while( (rc = sqlite3_step(pScan)) == SQLITE_ROW ){
     int nc = sqlite3_column_count(pScan);
     int nDupKeyCol = nc - pPk->nPk;
-    sqlite3_str *pS = sqlite3_str_new(0);
+    sqlite3_str *pS;
     char *zRowKey = 0;
     int i, isDup;
 
+    if( uniqueIndexRowHasNull(pScan, 0, nDupKeyCol) ) continue;
+
+    pS = sqlite3_str_new(0);
     for(i=0; i<nDupKeyCol; i++){
       const char *zV = (const char*)sqlite3_column_text(pScan, i);
-      int type = sqlite3_column_type(pScan, i);
-      if( type == SQLITE_NULL ){
-        sqlite3_str_appendf(pS, "%sNULL", i>0?"|":"");
-      }else{
-        sqlite3_str_appendf(pS, "%s%Q", i>0?"|":"", zV ? zV : "");
-      }
+      sqlite3_str_appendf(pS, "%s%Q", i>0?"|":"", zV ? zV : "");
     }
     zRowKey = sqlite3_str_finish(pS);
     if( !zRowKey ){ rc = SQLITE_NOMEM; break; }

--- a/test/vc_oracle_feature_interaction_test.sh
+++ b/test/vc_oracle_feature_interaction_test.sh
@@ -7274,14 +7274,41 @@ SELECT dolt_commit('-m','newer c2');
 # ═══════════════════════════════════════════════════════════════════
 echo "--- NULL + UNIQUE merge probes ---"
 
-# NOTE: unique_allows_multiple_nulls_merge is a known doltlite bug —
-# when two branches each add a row with NULL in a UNIQUE column,
-# doltlite's merge constraint-violation check treats the NULLs as
-# equal and rolls back, violating the SQL standard (NULL != NULL for
-# UNIQUE). Plain INSERT of multiple NULLs works correctly; the bug is
-# only in the merge-time constraint check. Omitted from suite pending
-# fix. Minimal repro: base=(1,'a'); feat adds (2,NULL); main adds
-# (3,NULL); merge feat.
+oracle "unique_allows_multiple_nulls_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, code VARCHAR(32) UNIQUE);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(2,NULL);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(3,NULL);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main');
+SELECT dolt_merge('feat');
+" "SELECT id, code FROM t ORDER BY id;"
+
+# A multi-column UNIQUE index with one column NULL per row also
+# must not flag a duplicate — SQL standard exempts any row with a
+# NULL in any of the index columns.
+oracle "unique_multi_col_with_one_null_merge" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, a VARCHAR(8), b VARCHAR(8), UNIQUE(a,b));
+INSERT INTO t VALUES(1,'x','y');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(2,'x',NULL);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(3,'x',NULL);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main');
+SELECT dolt_merge('feat');
+" "SELECT count(*) FROM t;"
+
 
 # ═══════════════════════════════════════════════════════════════════
 # Section 187: Merging a branch whose only change is an alter


### PR DESCRIPTION
## Summary
Fixes #573. `detectUniqueViolationsForIndex` and its `WITHOUT ROWID` twin stringified SQLite `NULL` columns as the literal text `"NULL"` when building the dup-group key used by the merge-time duplicate scan. Two rows with `NULL` in the UNIQUE-index columns would then compare equal under `strcmp` and get flagged as a duplicate group, rolling the merge back.

Per SQL standard, a row with `NULL` in any column of a UNIQUE index is exempt from the uniqueness check (`NULL != NULL` in this context).

## The fix
- Factor the null-any-col check into a small `uniqueIndexRowHasNull` helper shared by both dup-detect functions.
- Early-`continue` on matching rows so they neither become the group-winner nor match one.
- Drop the `"NULL"` stringification branch — once NULL-bearing rows are skipped, the grouping key only has to encode non-null values.

## Repro (before / after)
```sql
CREATE TABLE t(id INTEGER PRIMARY KEY, code VARCHAR(32) UNIQUE);
INSERT INTO t VALUES(1,'a');
SELECT dolt_add('-A'); SELECT dolt_commit('-m','base');
SELECT dolt_checkout('-b','feat');
INSERT INTO t VALUES(2,NULL);
SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat');
SELECT dolt_checkout('main');
INSERT INTO t VALUES(3,NULL);
SELECT dolt_add('-A'); SELECT dolt_commit('-m','main');
SELECT dolt_merge('feat');
SELECT id, code FROM t ORDER BY id;
```

### Before
```
Error near line 13: Committing this transaction resulted in a working set with
constraint violations, transaction rolled back.
1|a
3|
```

### After
```
1|a
2|
3|
```

## Tests
- **Re-enabled** `unique_allows_multiple_nulls_merge` (was NOTE'd out awaiting this fix).
- **Added** `unique_multi_col_with_one_null_merge` — composite `UNIQUE(a,b)` with `NULL` in `b` on both sides. Exercises the exemption for per-column NULLs (not just single-column UNIQUE).
- Full suites green:
  - `vc_oracle_feature_interaction_test.sh` — 743/743
  - `vc_oracle_error_recovery_test.sh` — 260/260
  - `vc_oracle_fk_merge_test.sh` — 29/29
  - `vc_oracle_merge_test.sh` — 39/39

## Scope
Surgical: only the merge-time violation-detection stringification changes. No change to the prolly merge strategy itself — the merge produces the correct combined table; only the post-merge dup scan was misjudging NULLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)