### PR TITLE
Resolve tracking refs in dolt_checkout

### DIFF
--- a/src/doltlite_ref.c
+++ b/src/doltlite_ref.c
@@ -55,6 +55,22 @@ static int doltliteResolveBaseRef(
     return rc;
   }
 
+  {
+    const char *zSlash = strchr(zRef, '/');
+    if( zSlash && zSlash!=zRef && zSlash[1] ){
+      char *zRemote = sqlite3_mprintf("%.*s", (int)(zSlash - zRef), zRef);
+      const char *zBranch = zSlash + 1;
+      if( !zRemote ) return SQLITE_NOMEM;
+      rc = chunkStoreFindTracking(cs, zRemote, zBranch, pCommit);
+      sqlite3_free(zRemote);
+      if( rc==SQLITE_OK && !prollyHashIsEmpty(pCommit) ){
+        rc = doltliteValidateCommitHash(db, pCommit);
+        if( rc==SQLITE_OK ) return SQLITE_OK;
+        return rc;
+      }
+    }
+  }
+
 
   rc = chunkStoreFindTag(cs, zRef, pCommit);
   if( rc==SQLITE_OK && !prollyHashIsEmpty(pCommit) ){

--- a/test/remote_test.sh
+++ b/test/remote_test.sh
@@ -496,6 +496,12 @@ done
 result=$("$DB" "$TMPDIR/div_clone.db" "SELECT dolt_fetch('origin','branchA');")
 check "incremental fetch returns 0" "0" "$result"
 
+# Fetched tracking branch should be usable as a checkout start point
+result=$("$DB" "$TMPDIR/div_clone.db" "SELECT dolt_checkout('-b','trackA','origin/branchA'); SELECT active_branch(); SELECT count(*) FROM items;")
+check "checkout from fetched tracking branch" "0
+trackA
+16" "$result"
+
 # Pull to see new data
 "$DB" "$TMPDIR/div_clone.db" "SELECT dolt_checkout('branchA');" > /dev/null
 result=$("$DB" "$TMPDIR/div_clone.db/branchA" "SELECT dolt_pull('origin','branchA'); SELECT count(*) FROM items;")

--- a/test/vc_oracle_remotes_test.sh
+++ b/test/vc_oracle_remotes_test.sh
@@ -256,6 +256,96 @@ SQL
   fi
 }
 
+oracle_fetch_checkout_tracking_poststate() {
+  local name="$1"
+  local dir="$TMPROOT/${name}_fetch_checkout"
+  local dl_remote_url="file://$dir/dl_remote.db"
+  local dt_remote_dir="$dir/dt_remote"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_post dt_post
+
+  cat >"$dir/dl_setup.sql" <<SQL
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'base');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'init');
+SELECT dolt_remote('add', 'origin', '$dl_remote_url');
+SELECT dolt_push('origin', 'main');
+SELECT dolt_branch('branchA');
+SELECT dolt_checkout('branchA');
+INSERT INTO t VALUES (2, 'branchA');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'branchA');
+SELECT dolt_push('origin', 'branchA');
+SELECT dolt_checkout('main');
+SQL
+  "$DOLTLITE" "$dir/dl/db" <"$dir/dl_setup.sql" >/dev/null 2>"$dir/dl_setup.err"
+
+  cat >"$dir/dl_clone.sql" <<SQL
+SELECT dolt_clone('$dl_remote_url');
+SQL
+  "$DOLTLITE" "$dir/dl_clone.db" <"$dir/dl_clone.sql" >/dev/null 2>"$dir/dl_clone.err"
+
+  cat >"$dir/dl_test.sql" <<SQL
+SELECT dolt_fetch('origin', 'branchA');
+SELECT dolt_checkout('-b', 'topic', 'origin/branchA');
+SQL
+  vc_oracle_run_doltlite_script "$dir/dl_clone.db" "$dir/dl.out" "$dir/dl.err" "$(cat "$dir/dl_test.sql")"
+  dl_post=$(printf ".headers off\n.mode list\n.separator '\t'\nSELECT active_branch() || char(9) || count(*) FROM t;\n" \
+            | "$DOLTLITE" "$dir/dl_clone.db" 2>>"$dir/dl.err" \
+            | tr -d '\r')
+
+  mkdir -p "$dt_remote_dir"
+  (
+    cd "$dt_remote_dir" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+  )
+  (
+    cd "$dir/dt" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    cat >setup.sql <<SQL
+CREATE TABLE t(id INT PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'base');
+CALL dolt_add('-A');
+CALL dolt_commit('-m', 'init');
+CALL dolt_remote('add', 'origin', 'file://$dt_remote_dir');
+CALL dolt_push('origin', 'main');
+CALL dolt_branch('branchA');
+CALL dolt_checkout('branchA');
+INSERT INTO t VALUES (2, 'branchA');
+CALL dolt_add('-A');
+CALL dolt_commit('-m', 'branchA');
+CALL dolt_push('origin', 'branchA');
+CALL dolt_checkout('main');
+SQL
+    "$DOLT" sql -c < setup.sql >/dev/null 2>"$dir/dt_setup.err"
+  )
+  (
+    cd "$dir" || exit 1
+    "$DOLT" clone "file://$dt_remote_dir" dt_clone >/dev/null 2>&1
+    cd dt_clone || exit 1
+    cat >test.sql <<SQL
+CALL dolt_fetch('origin', 'branchA');
+CALL dolt_checkout('-b', 'topic', 'origin/branchA');
+SQL
+    "$DOLT" sql -c < test.sql >/dev/null 2>"$dir/dt.err"
+    dt_post=$("$DOLT" sql -r csv -q "SELECT concat(active_branch(), char(9), count(*)) FROM t;" 2>>"$dir/dt.err" | tail -n +2 | tr -d '\"\r')
+    printf "%s\n" "$dt_post" >"$dir/dt.post"
+  )
+  dt_post=$(cat "$dir/dt.post")
+
+  if [ "$dl_post" = "$dt_post" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite post:"; echo "$dl_post" | sed 's/^/      /'
+    echo "    dolt post:"; echo "$dt_post" | sed 's/^/      /'
+  fi
+}
+
 echo "=== Version Control Oracle Tests: dolt_remotes ==="
 echo ""
 
@@ -381,6 +471,7 @@ ROLLBACK TO sp1;
 " "SELECT active_branch();"
 
 oracle_nested_pull_rollback_poststate "pull_nested_savepoint_rollback_restores_state"
+oracle_fetch_checkout_tracking_poststate "fetch_then_checkout_remote_tracking_branch"
 
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="


### PR DESCRIPTION
## Summary
- teach `dolt_checkout()` start-point resolution to understand fetched tracking refs like `origin/branchA`
- add a local remote regression covering `fetch` followed by `checkout -b ... origin/branchA`
- add a Dolt oracle case for the same fetch-to-checkout tracking flow

## Testing
- bash test/remote_test.sh ./doltlite
- bash test/vc_oracle_remotes_test.sh ./doltlite dolt