### PR TITLE
Drain large mutmaps during deferred writes

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -460,6 +460,18 @@ static int btreeWriteWorkingState(
 );
 static int btreeDeleteImmediate(BtCursor *pCur, const u8 *pKey, int nKey, i64 iKey);
 
+/*
+** Bound deferred per-table edit growth by forcing a mutmap drain once the
+** pending delta becomes large. flushMutMap() already snapshots mid-savepoint
+** state, so early drains remain rollback-safe.
+*/
+#define PROLLY_MUTMAP_PENDING_FLUSH_LIMIT 65536
+
+static int mutMapShouldDrain(BtCursor *pCur){
+  return pCur && pCur->pMutMap
+      && prollyMutMapCount(pCur->pMutMap) >= PROLLY_MUTMAP_PENDING_FLUSH_LIMIT;
+}
+
 static int prollyBtreeClose(Btree*);
 static int prollyBtreeNewDb(Btree*);
 static int prollyBtreeSetCacheSize(Btree*, int);
@@ -4734,44 +4746,46 @@ static int prollyBtCursorInsert(
 
   {
     int canDefer = (pCur->pgnoRoot > 1);
-      if( canDefer ){
-        if( (flags & BTREE_SAVEPOSITION) && pCur->curIntKey ){
+    if( canDefer && mutMapShouldDrain(pCur) ){
+      canDefer = 0;
+    }
+    if( canDefer ){
+      if( (flags & BTREE_SAVEPOSITION) && pCur->curIntKey ){
 
-        ProllyMutMapEntry *pEntry = 0;
-        rc = prollyMutMapFindRc(pCur->pMutMap, NULL, 0, pPayload->nKey, &pEntry);
-        if( rc!=SQLITE_OK ) return rc;
-        pCur->eState = CURSOR_VALID;
-        pCur->curFlags |= BTCF_ValidNKey;
-        pCur->cachedIntKey = pPayload->nKey;
-        rc = cacheCursorPayloadCopy(
-            pCur,
-            (pEntry && pEntry->nVal > 0 && pEntry->pVal) ? pEntry->pVal : 0,
-            (pEntry && pEntry->nVal > 0 && pEntry->pVal) ? pEntry->nVal : 0);
-        if( rc!=SQLITE_OK ) return rc;
+      ProllyMutMapEntry *pEntry = 0;
+      rc = prollyMutMapFindRc(pCur->pMutMap, NULL, 0, pPayload->nKey, &pEntry);
+      if( rc!=SQLITE_OK ) return rc;
+      pCur->eState = CURSOR_VALID;
+      pCur->curFlags |= BTCF_ValidNKey;
+      pCur->cachedIntKey = pPayload->nKey;
+      rc = cacheCursorPayloadCopy(
+          pCur,
+          (pEntry && pEntry->nVal > 0 && pEntry->pVal) ? pEntry->pVal : 0,
+          (pEntry && pEntry->nVal > 0 && pEntry->pVal) ? pEntry->nVal : 0);
+      if( rc!=SQLITE_OK ) return rc;
 
-        pCur->mmActive = 0;
-        pCur->flushSeekEdits = 0;
-      } else if( (flags & BTREE_SAVEPOSITION) && !pCur->curIntKey ){
+      pCur->mmActive = 0;
+      pCur->flushSeekEdits = 0;
+    } else if( (flags & BTREE_SAVEPOSITION) && !pCur->curIntKey ){
 
-        CLEAR_CACHED_PAYLOAD(pCur);
-        if( prollyCursorIsValid(&pCur->pCur) ){
-          int trc = prollyCursorNext(&pCur->pCur);
-          if( trc==SQLITE_OK
-           && pCur->pCur.eState==PROLLY_CURSOR_VALID ){
-            pCur->eState = CURSOR_SKIPNEXT;
-            pCur->skipNext = 1;
-          } else {
-            pCur->eState = CURSOR_INVALID;
-          }
+      CLEAR_CACHED_PAYLOAD(pCur);
+      if( prollyCursorIsValid(&pCur->pCur) ){
+        int trc = prollyCursorNext(&pCur->pCur);
+        if( trc==SQLITE_OK
+         && pCur->pCur.eState==PROLLY_CURSOR_VALID ){
+          pCur->eState = CURSOR_SKIPNEXT;
+          pCur->skipNext = 1;
         } else {
           pCur->eState = CURSOR_INVALID;
         }
-        pCur->mmActive = 0;
-        pCur->flushSeekEdits = 0;
       } else {
         pCur->eState = CURSOR_INVALID;
-        pCur->flushSeekEdits = 0;
       }
+      pCur->mmActive = 0;
+      pCur->flushSeekEdits = 0;
+    } else {
+      pCur->eState = CURSOR_INVALID;
+      pCur->flushSeekEdits = 0;
       return SQLITE_OK;
     }
   }
@@ -5071,6 +5085,9 @@ static int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
 
   {
     int canDefer = (pCur->pgnoRoot > 1);
+    if( canDefer && mutMapShouldDrain(pCur) ){
+      canDefer = 0;
+    }
     if( canDefer ){
       CLEAR_CACHED_PAYLOAD(pCur);
       pCur->curFlags &= ~(BTCF_ValidNKey|BTCF_AtLast);

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -4751,41 +4751,40 @@ static int prollyBtCursorInsert(
     }
     if( canDefer ){
       if( (flags & BTREE_SAVEPOSITION) && pCur->curIntKey ){
+        ProllyMutMapEntry *pEntry = 0;
+        rc = prollyMutMapFindRc(pCur->pMutMap, NULL, 0, pPayload->nKey, &pEntry);
+        if( rc!=SQLITE_OK ) return rc;
+        pCur->eState = CURSOR_VALID;
+        pCur->curFlags |= BTCF_ValidNKey;
+        pCur->cachedIntKey = pPayload->nKey;
+        rc = cacheCursorPayloadCopy(
+            pCur,
+            (pEntry && pEntry->nVal > 0 && pEntry->pVal) ? pEntry->pVal : 0,
+            (pEntry && pEntry->nVal > 0 && pEntry->pVal) ? pEntry->nVal : 0);
+        if( rc!=SQLITE_OK ) return rc;
 
-      ProllyMutMapEntry *pEntry = 0;
-      rc = prollyMutMapFindRc(pCur->pMutMap, NULL, 0, pPayload->nKey, &pEntry);
-      if( rc!=SQLITE_OK ) return rc;
-      pCur->eState = CURSOR_VALID;
-      pCur->curFlags |= BTCF_ValidNKey;
-      pCur->cachedIntKey = pPayload->nKey;
-      rc = cacheCursorPayloadCopy(
-          pCur,
-          (pEntry && pEntry->nVal > 0 && pEntry->pVal) ? pEntry->pVal : 0,
-          (pEntry && pEntry->nVal > 0 && pEntry->pVal) ? pEntry->nVal : 0);
-      if( rc!=SQLITE_OK ) return rc;
-
-      pCur->mmActive = 0;
-      pCur->flushSeekEdits = 0;
-    } else if( (flags & BTREE_SAVEPOSITION) && !pCur->curIntKey ){
-
-      CLEAR_CACHED_PAYLOAD(pCur);
-      if( prollyCursorIsValid(&pCur->pCur) ){
-        int trc = prollyCursorNext(&pCur->pCur);
-        if( trc==SQLITE_OK
-         && pCur->pCur.eState==PROLLY_CURSOR_VALID ){
-          pCur->eState = CURSOR_SKIPNEXT;
-          pCur->skipNext = 1;
+        pCur->mmActive = 0;
+        pCur->flushSeekEdits = 0;
+      } else if( (flags & BTREE_SAVEPOSITION) && !pCur->curIntKey ){
+        CLEAR_CACHED_PAYLOAD(pCur);
+        if( prollyCursorIsValid(&pCur->pCur) ){
+          int trc = prollyCursorNext(&pCur->pCur);
+          if( trc==SQLITE_OK
+           && pCur->pCur.eState==PROLLY_CURSOR_VALID ){
+            pCur->eState = CURSOR_SKIPNEXT;
+            pCur->skipNext = 1;
+          } else {
+            pCur->eState = CURSOR_INVALID;
+          }
         } else {
           pCur->eState = CURSOR_INVALID;
         }
+        pCur->mmActive = 0;
+        pCur->flushSeekEdits = 0;
       } else {
         pCur->eState = CURSOR_INVALID;
+        pCur->flushSeekEdits = 0;
       }
-      pCur->mmActive = 0;
-      pCur->flushSeekEdits = 0;
-    } else {
-      pCur->eState = CURSOR_INVALID;
-      pCur->flushSeekEdits = 0;
       return SQLITE_OK;
     }
   }

--- a/test/doltlite_savepoint.sh
+++ b/test/doltlite_savepoint.sh
@@ -593,32 +593,55 @@ run_test_match "merge_conflict_nested_savepoint_allows_rollback" \
 main$" "$DB7d"
 
 # ============================================================
-# Test 8: ROLLBACK after dolt_branch — does the branch creation persist?
+# Test 8: Large deferred mutmap drains must still rollback correctly
+# Expected: once pending edits cross the internal drain threshold, the
+# mutmap flushes to the prolly tree mid-savepoint. ROLLBACK TO must still
+# restore the pre-savepoint state even after that early flush.
+# ============================================================
+DB8=/tmp/test_savepoint8_$$.db; rm -f "$DB8"
+run_test "bulk_threshold_savepoint_rollback" \
+  "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+   BEGIN;
+   SAVEPOINT sp1;
+   WITH RECURSIVE gen(x) AS (
+     VALUES(1)
+     UNION ALL
+     SELECT x+1 FROM gen WHERE x<66000
+   )
+   INSERT INTO t
+   SELECT x, printf('row-%d', x) FROM gen;
+   ROLLBACK TO sp1;
+   COMMIT;
+   SELECT count(*) FROM t;" \
+  "0" "$DB8"
+
+# ============================================================
+# Test 9: ROLLBACK after dolt_branch — does the branch creation persist?
 # Expected: dolt_branch creates a branch at the storage layer.
 # A SQLite ROLLBACK should not undo the branch creation since
 # it's a dolt metadata operation, not a SQL data change.
 # ============================================================
-DB8=/tmp/test_savepoint8_$$.db; rm -f "$DB8"
-echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB8" > /dev/null 2>&1
+DB9=/tmp/test_savepoint9_$$.db; rm -f "$DB9"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB9" > /dev/null 2>&1
 
 # Create branch inside a transaction, then rollback
-echo "BEGIN; SELECT dolt_branch('ephemeral'); ROLLBACK;" | $DOLTLITE "$DB8" > /dev/null 2>&1
+echo "BEGIN; SELECT dolt_branch('ephemeral'); ROLLBACK;" | $DOLTLITE "$DB9" > /dev/null 2>&1
 
 # Check if the branch persists despite the rollback
 # Expected: branch persists because dolt_branch is a storage-level operation
 run_test_match "branch_survives_rollback" \
   "SELECT count(*) FROM dolt_branches;" \
-  "^[12]$" "$DB8"
+  "^[12]$" "$DB9"
 
 # If branch survived, verify by name
 run_test_match "branch_name_after_rollback" \
   "SELECT name FROM dolt_branches ORDER BY name;" \
-  "main" "$DB8"
+  "main" "$DB9"
 
 # ============================================================
 # Cleanup
 # ============================================================
-rm -f "$DB1" "$DB2" "$DB3" "$DB4" "$DB4b" "$DB5" "$DB6" "$DB6b" "$DB7" "$DB8" \
+rm -f "$DB1" "$DB2" "$DB3" "$DB4" "$DB4b" "$DB5" "$DB6" "$DB6b" "$DB7" "$DB8" "$DB9" \
   "$DB6g1" "$DB6g2" "$DB6g3" "$DB6g4" "$DB6g5" "$DB6g6" "$DB6g7" "$DB6g8" "$DB6g9" "$DB6g10"
 
 echo ""


### PR DESCRIPTION
## Summary
- force deferred per-table mutmaps to drain once they reach 64k pending edits
- reuse the existing mid-savepoint flush snapshot path so `ROLLBACK TO` remains correct after an early drain
- add a 66k-row savepoint rollback regression to prove forced drains still restore pre-savepoint state

## Testing
- bash test/doltlite_savepoint.sh ./doltlite
