### PR TITLE
Fix rebase abort savepoint reopen state

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -3663,7 +3663,6 @@ static void rebaseDiscardWorkingBranch(
   const char *zWorkingBranch
 ){
   ChunkStore *cs = doltliteGetChunkStore(db);
-  char *zErr = 0;
 
   (void)sqlite3_exec(db, "DROP TABLE IF EXISTS main.dolt_rebase", 0, 0, 0);
   doltliteClearSessionRebaseState(db);
@@ -3676,6 +3675,11 @@ static void rebaseDiscardWorkingBranch(
     (void)chunkStoreDeleteBranch(cs, zWorkingBranch);
     (void)chunkStoreSerializeRefs(cs);
     (void)chunkStoreCommit(cs);
+    /* Refresh the surviving branch's working-set blob against the final
+    ** post-delete ref graph. Without this, rebase abort under savepoint can
+    ** reopen with stale metadata that still references the discarded temp
+    ** branch state. */
+    (void)doltlitePersistWorkingSet(db);
   }
 }
 

--- a/test/doltlite_savepoint.sh
+++ b/test/doltlite_savepoint.sh
@@ -621,6 +621,24 @@ run_test_match "merge_conflict_nested_savepoint_allows_rollback" \
   "0
 main$" "$DB7d"
 
+DB7e=/tmp/test_savepoint7e_$$.db; rm -f "$DB7e"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT); INSERT INTO t VALUES(1,1); SELECT dolt_add('-A'); SELECT dolt_commit('-m','init'); SELECT dolt_checkout('-b','feat'); INSERT INTO t VALUES(2,2); SELECT dolt_add('-A'); SELECT dolt_commit('-m','f1'); INSERT INTO t VALUES(3,3); SELECT dolt_add('-A'); SELECT dolt_commit('-m','f2'); INSERT INTO t VALUES(4,4); SELECT dolt_add('-A'); SELECT dolt_commit('-m','f3'); SELECT dolt_checkout('main'); INSERT INTO t VALUES(10,10); SELECT dolt_add('-A'); SELECT dolt_commit('-m','m'); SELECT dolt_checkout('feat');" | $DOLTLITE "$DB7e" > /dev/null 2>&1
+run_test_match "rebase_abort_savepoint_rollback_to_errors" \
+  "SAVEPOINT sp1; SELECT dolt_rebase('-i','main'); SELECT dolt_rebase('--abort'); ROLLBACK TO sp1;" \
+  "no such savepoint: sp1" "$DB7e"
+run_test "rebase_abort_savepoint_reopen_main" \
+  "SELECT active_branch();" \
+  "main" "$DB7e"
+run_test "rebase_abort_savepoint_reopen_no_rebase_branch" \
+  "SELECT count(*) FROM dolt_branches WHERE name='dolt_rebase_feat';" \
+  "0" "$DB7e"
+run_test "rebase_abort_savepoint_reopen_main_rows" \
+  "SELECT count(*) FROM t;" \
+  "2" "$DB7e"
+run_test "rebase_abort_savepoint_reopen_no_plan_table" \
+  "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='dolt_rebase';" \
+  "0" "$DB7e"
+
 # ============================================================
 # Test 8: Large deferred mutmap drains must still rollback correctly
 # Expected: once pending edits cross the internal drain threshold, the
@@ -671,7 +689,8 @@ run_test_match "branch_name_after_rollback" \
 # Cleanup
 # ============================================================
 rm -f "$DB1" "$DB2" "$DB3" "$DB4" "$DB4b" "$DB5" "$DB6" "$DB6b" "$DB7" "$DB8" "$DB9" \
-  "$DB6g1" "$DB6g2" "$DB6g3" "$DB6g4" "$DB6g5" "$DB6g6" "$DB6g7" "$DB6g8" "$DB6g9" "$DB6g10"
+  "$DB6g1" "$DB6g2" "$DB6g3" "$DB6g4" "$DB6g5" "$DB6g6" "$DB6g7" "$DB6g8" "$DB6g9" "$DB6g10" \
+  "$DB7d" "$DB7e"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/vc_oracle_rebase_test.sh
+++ b/test/vc_oracle_rebase_test.sh
@@ -110,6 +110,43 @@ oracle_error() {
   fi
 }
 
+oracle_savepoint_abort_poststate() {
+  local name="$1" setup="$2"
+  local dir="$TMPROOT/${name}_sp"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_out dolt_setup dt_out
+
+  vc_oracle_run_doltlite_script "$dir/dl/db" "$dir/dl.out" "$dir/dl.err" "$setup"
+  dl_out=$(printf ".headers off\n.mode list\nSELECT active_branch() || '|AB';\nSELECT count(*) || '|RB' FROM dolt_branches WHERE name='dolt_rebase_feat';\nSELECT count(*) || '|T' FROM t;\n" \
+           | "$DOLTLITE" "$dir/dl/db" 2>>"$dir/dl.err" \
+           | tr -d '\r')
+
+  dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
+  vc_oracle_run_dolt_script "$dir/dt" "$dir/dt.out" "$dir/dt.err" "$dolt_setup"
+  (
+    cd "$dir/dt" || exit 1
+    {
+      "$DOLT" sql -r csv -q "SELECT active_branch();" 2>>"$dir/dt.err" | tail -n +2 | tr -d '"'
+      "$DOLT" sql -r csv -q "SELECT count(*) FROM dolt_branches WHERE name='dolt_rebase_feat';" 2>>"$dir/dt.err" | tail -n +2 | tr -d '"'
+      "$DOLT" sql -r csv -q "SELECT count(*) FROM t;" 2>>"$dir/dt.err" | tail -n +2 | tr -d '"'
+    } > "$dir/dt.post"
+  )
+  dt_out=$(awk 'NR==1{print $0 "|AB"} NR==2{print $0 "|RB"} NR==3{print $0 "|T"}' "$dir/dt.post")
+
+  if [ "$dl_out" = "$dt_out" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite:"
+    echo "$dl_out" | sed 's/^/      /'
+    echo "    dolt:"
+    echo "$dt_out" | sed 's/^/      /'
+  fi
+}
+
 echo "=== Version Control Oracle Tests: dolt_rebase ==="
 echo ""
 
@@ -401,6 +438,14 @@ $INTERACTIVE_SETUP
 SELECT dolt_rebase('-i', 'main');
 SELECT dolt_rebase('--abort');
 " "SELECT CONCAT('LOG|', active_branch());"
+
+oracle_savepoint_abort_poststate "interactive_abort_savepoint_poststate" "
+$INTERACTIVE_SETUP
+SAVEPOINT sp1;
+SELECT dolt_rebase('-i', 'main');
+SELECT dolt_rebase('--abort');
+ROLLBACK TO sp1;
+"
 
 # --continue is an error when not in an interactive rebase.
 oracle_error "continue_without_active" "


### PR DESCRIPTION
## Summary
Fix interactive rebase abort under savepoints so reopened state matches Dolt.

## Bug
After:
- `SAVEPOINT sp1;`
- `SELECT dolt_rebase('-i', 'main');`
- `SELECT dolt_rebase('--abort');`
- `ROLLBACK TO sp1;` (which errors because the savepoint is invalidated)

DoltLite could reopen with broken branch/session state instead of cleanly reopening on `main` with the temp rebase branch removed.

## Fix
After discarding the working rebase branch, repersist the surviving branch's working-set blob against the final ref graph.

## Tests
- `bash test/doltlite_savepoint.sh ./doltlite`
- `bash test/vc_oracle_rebase_test.sh ./doltlite dolt`
