### PR TITLE
Enforce rebase plan action values

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -3416,7 +3416,7 @@ static int doltliteValidateRebasePlanTable(sqlite3 *db, char **pzErr){
       "dolt_rebase has an unexpected schema; expected: "
       "CREATE TABLE dolt_rebase("
       "rebase_order REAL PRIMARY KEY, "
-      "action TEXT, "
+      "action TEXT CHECK(action IN ('pick','drop','reword','squash','fixup')), "
       "commit_hash TEXT, "
       "commit_message TEXT)");
   }
@@ -3525,7 +3525,7 @@ static int rebaseCreateAndPopulatePlanTable(
   rc = sqlite3_exec(db,
     "CREATE TABLE main.dolt_rebase("
     "  rebase_order REAL PRIMARY KEY,"
-    "  action TEXT,"
+    "  action TEXT CHECK(action IN ('pick','drop','reword','squash','fixup')),"
     "  commit_hash TEXT,"
     "  commit_message TEXT"
     ")", 0, 0, 0);

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -4249,12 +4249,11 @@ static void run_rebase_continue_invalid_plan_preserves_durable_state(void){
     "INSERT INTO t VALUES (10, 10);"
     "SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'm');"
     "SELECT dolt_checkout('feat');"
-    "SELECT dolt_rebase('-i', 'main');"
-    "UPDATE dolt_rebase SET action = 'oops' WHERE commit_message = 'f1';")==SQLITE_OK);
+    "SELECT dolt_rebase('-i', 'main');")==SQLITE_OK);
 
-  res = exec1(db, "SELECT dolt_rebase('--continue')");
+  res = exec1(db, "UPDATE dolt_rebase SET action = 'oops' WHERE commit_message = 'f1'");
   check("rebase_invalid_plan_returns_error",
-        strstr(res, "ERROR: first non-drop action must be pick or reword")!=0);
+        strstr(res, "ERROR: CHECK constraint failed")!=0);
   check("rebase_invalid_plan_keeps_working_branch",
         strcmp(exec1(db, "SELECT active_branch()"), "dolt_rebase_feat")==0);
   check("rebase_invalid_plan_keeps_plan_table",


### PR DESCRIPTION
## Summary
Make `dolt_rebase.action` enforce the same allowed values as Dolt.

## Bug
On interactive rebase, Dolt rejects:
- `UPDATE dolt_rebase SET action = 'oops' ...`

DoltLite allowed the invalid value into the plan table and only failed later in `dolt_rebase('--continue')`.

## Fix
Add a `CHECK` constraint to the generated `dolt_rebase` table so invalid actions are rejected at update time.

## Verification
- `bash test/vc_oracle_rebase_test.sh ./doltlite dolt`
- `make -j4 libdoltlite.a && cd test && cc -g -I.. -I../src -o doltlite_regression_test_c ../test/doltlite_regression_test_c.c ../libdoltlite.a -lz -lpthread -lm && ./doltlite_regression_test_c rebase_continue_invalid_plan_preserves_durable_state`
