### PR TITLE
Fix interactive rebase conflict abort cleanup

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -3513,6 +3513,26 @@ static int rebaseCheckoutBranch(sqlite3 *db, const char *zBranch){
   return rc;
 }
 
+static int rebaseRestoreBranchState(sqlite3 *db, const char *zBranch){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  ProllyHash headHash;
+  DoltliteCommit headCommit;
+  int rc;
+
+  if( !cs || !zBranch || !zBranch[0] ) return SQLITE_ERROR;
+  rc = chunkStoreFindBranch(cs, zBranch, &headHash);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = doltliteLoadCommit(db, &headHash, &headCommit);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = doltliteSwitchCatalog(db, &headCommit.catalogHash);
+  if( rc!=SQLITE_OK ) return rc;
+  doltliteSetSessionBranch(db, zBranch);
+  doltliteSetSessionHead(db, &headHash);
+  doltliteSetSessionStaged(db, &headCommit.catalogHash);
+  doltliteClearSessionMergeState(db);
+  return SQLITE_OK;
+}
+
 static int rebaseCreateAndPopulatePlanTable(
   sqlite3 *db,
   const ProllyHash *aReplay,
@@ -3669,7 +3689,32 @@ static void rebaseDiscardWorkingBranch(
   (void)doltlitePersistWorkingSet(db);
 
   if( zOrigBranch && zOrigBranch[0] ){
-    (void)rebaseCheckoutBranch(db, zOrigBranch);
+    if( rebaseCheckoutBranch(db, zOrigBranch)!=SQLITE_OK ){
+      (void)rebaseRestoreBranchState(db, zOrigBranch);
+    }
+  }
+  if( cs && zWorkingBranch && zWorkingBranch[0] ){
+    (void)chunkStoreDeleteBranch(cs, zWorkingBranch);
+    (void)chunkStoreSerializeRefs(cs);
+    (void)chunkStoreCommit(cs);
+    (void)doltlitePersistWorkingSet(db);
+  }
+}
+
+static void rebaseAbortConflictedContinue(
+  sqlite3 *db,
+  const char *zOrigBranch,
+  const char *zWorkingBranch
+){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+
+  (void)sqlite3_exec(db, "DROP TABLE IF EXISTS main.dolt_rebase", 0, 0, 0);
+  doltliteClearSessionRebaseState(db);
+  doltliteClearSessionMergeState(db);
+  if( zOrigBranch && zOrigBranch[0] ){
+    (void)rebaseRestoreBranchState(db, zOrigBranch);
+    doltliteClearSessionRebaseState(db);
+    if( cs ) (void)chunkStoreSetDefaultBranch(cs, zOrigBranch);
   }
   if( cs && zWorkingBranch && zWorkingBranch[0] ){
     (void)chunkStoreDeleteBranch(cs, zWorkingBranch);
@@ -3993,7 +4038,10 @@ static void doltliteRebaseInteractiveContinue(
 
 abort_err_conflict:
   rebaseFreePlan(aPlan, nPlan);
-  rebaseDiscardWorkingBranch(db, zOrigBranch, zWorking);
+  rebaseAbortConflictedContinue(db, zOrigBranch, zWorking);
+  if( doltliteVcTxnMode(db)==DOLTLITE_VC_TXN_AUTOCOMMIT_LIKE ){
+    (void)sqlite3_exec(db, "COMMIT", 0, 0, 0);
+  }
   sqlite3_free(zOrigBranch);
   sqlite3_free(zWorking);
   sqlite3_result_error(context,

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -484,6 +484,40 @@ static int doltliteReportConstraintViolations(
   return SQLITE_OK;
 }
 
+static int doltliteDetectPostMergeConstraintViolations(
+  sqlite3 *db,
+  const ProllyHash *pAncCatHash,
+  int *pnViolations
+){
+  extern int doltliteDetectMergeFkViolations(
+      sqlite3*, const ProllyHash*, char**, int*);
+  extern int doltliteDetectMergeUniqueViolations(
+      sqlite3*, const ProllyHash*, char**, int*);
+  extern int doltliteDetectMergeCheckViolations(
+      sqlite3*, const ProllyHash*, char**, int*);
+  int nViolations = 0;
+  int nUnique = 0;
+  int nCheck = 0;
+  char *zDetectErrMsg = 0;
+  int rc;
+
+  rc = doltliteDetectMergeFkViolations(db, pAncCatHash,
+                                       &zDetectErrMsg, &nViolations);
+  if( rc==SQLITE_OK ){
+    rc = doltliteDetectMergeUniqueViolations(db, pAncCatHash,
+                                             &zDetectErrMsg, &nUnique);
+  }
+  if( rc==SQLITE_OK ){
+    rc = doltliteDetectMergeCheckViolations(db, pAncCatHash,
+                                            &zDetectErrMsg, &nCheck);
+  }
+  sqlite3_free(zDetectErrMsg);
+  if( rc!=SQLITE_OK ) return rc;
+
+  if( pnViolations ) *pnViolations = nViolations + nUnique + nCheck;
+  return SQLITE_OK;
+}
+
 static int doltliteSavepointIsTopLevelTxn(sqlite3 *db){
   return db->pSavepoint!=0 && db->nSavepoint==0;
 }
@@ -3516,6 +3550,7 @@ static int rebaseCheckoutBranch(sqlite3 *db, const char *zBranch){
 static int rebaseRestoreBranchState(sqlite3 *db, const char *zBranch){
   ChunkStore *cs = doltliteGetChunkStore(db);
   ProllyHash headHash;
+  ProllyHash emptyHash;
   DoltliteCommit headCommit;
   int rc;
 
@@ -3530,6 +3565,8 @@ static int rebaseRestoreBranchState(sqlite3 *db, const char *zBranch){
   doltliteSetSessionHead(db, &headHash);
   doltliteSetSessionStaged(db, &headCommit.catalogHash);
   doltliteClearSessionMergeState(db);
+  memset(&emptyHash, 0, sizeof(emptyHash));
+  doltliteSetSessionConstraintViolationsCatalog(db, &emptyHash);
   return SQLITE_OK;
 }
 
@@ -3586,6 +3623,7 @@ static int rebaseApplyPlanRowCatalog(
 ){
   DoltliteCommit parentC, replayC;
   int nConflicts = 0;
+  int nViolations = 0;
   int rc;
 
   memset(&parentC, 0, sizeof(parentC));
@@ -3606,10 +3644,18 @@ static int rebaseApplyPlanRowCatalog(
   rc = doltliteMergeCatalogs(db, &parentC.catalogHash, pCurCat,
                              &replayC.catalogHash, pMergedCat,
                              &nConflicts, 0, 0, 0);
+  if( rc==SQLITE_OK && nConflicts==0 ){
+    rc = doltliteSwitchCatalog(db, pMergedCat);
+  }
+  if( rc==SQLITE_OK && nConflicts==0 ){
+    rc = doltliteDetectPostMergeConstraintViolations(db,
+                                                     &parentC.catalogHash,
+                                                     &nViolations);
+  }
   doltliteCommitClear(&parentC);
   doltliteCommitClear(&replayC);
   if( rc!=SQLITE_OK ) return rc;
-  if( nConflicts>0 ) return SQLITE_CONSTRAINT;
+  if( nConflicts>0 || nViolations>0 ) return SQLITE_CONSTRAINT;
   return SQLITE_OK;
 }
 

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -4474,6 +4474,70 @@ static void run_rebase_temp_shadow_ignored(void){
   remove_db(dbpath);
 }
 
+static void run_rebase_continue_conflict_abort_restores_durable_state(void){
+  sqlite3 *db = 0;
+  char dbpath[256];
+  const char *res;
+  u8 isRebasing = 0;
+  const char *zOrigBranch = 0;
+
+  printf("=== Rebase Continue Conflict Abort Restores Durable State Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath),
+              "test_rebase_continue_conflict_abort_restores_durable_state");
+  remove_db(dbpath);
+
+  check("open_db_for_rebase_continue_conflict_abort", open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_repo_for_rebase_continue_conflict_abort", execsql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);"
+    "INSERT INTO t VALUES (1, 1);"
+    "SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');"
+    "SELECT dolt_checkout('-b', 'feat');"
+    "UPDATE t SET v = 2 WHERE id = 1;"
+    "SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'f1');"
+    "SELECT dolt_checkout('main');"
+    "UPDATE t SET v = 3 WHERE id = 1;"
+    "SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'm1');"
+    "SELECT dolt_checkout('feat');")==SQLITE_OK);
+
+  check("start_interactive_rebase_for_conflict_abort",
+        strstr(exec1(db, "SELECT dolt_rebase('-i', 'main')"),
+               "interactive rebase started on branch dolt_rebase_feat")!=0);
+
+  res = exec1(db, "SELECT dolt_rebase('--continue')");
+  check("rebase_continue_conflict_abort_returns_error",
+        strstr(res, "data conflicts from rebase")!=0);
+  check("rebase_continue_conflict_abort_restores_branch_same_session",
+        strcmp(exec1(db, "SELECT active_branch()"), "feat")==0);
+  check("rebase_continue_conflict_abort_drops_plan_same_session",
+        strcmp(exec1(db,
+          "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='dolt_rebase'"), "0")==0);
+  check("rebase_continue_conflict_abort_clears_conflicts_same_session",
+        strcmp(exec1(db, "SELECT count(*) FROM dolt_conflicts"), "0")==0);
+  check("rebase_continue_conflict_abort_restores_row_same_session",
+        strcmp(exec1(db, "SELECT v FROM t WHERE id=1"), "2")==0);
+  doltliteGetSessionRebaseState(db, &isRebasing, 0, 0, &zOrigBranch);
+  check("rebase_continue_conflict_abort_clears_flag_same_session", isRebasing==0);
+
+  sqlite3_close(db);
+  db = 0;
+
+  check("reopen_db_for_rebase_continue_conflict_abort", open_db(dbpath, &db)==SQLITE_OK);
+  check("rebase_continue_conflict_abort_restores_branch_after_reopen",
+        strcmp(exec1(db, "SELECT active_branch()"), "feat")==0);
+  check("rebase_continue_conflict_abort_drops_plan_after_reopen",
+        strcmp(exec1(db,
+          "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='dolt_rebase'"), "0")==0);
+  check("rebase_continue_conflict_abort_clears_conflicts_after_reopen",
+        strcmp(exec1(db, "SELECT count(*) FROM dolt_conflicts"), "0")==0);
+  check("rebase_continue_conflict_abort_restores_row_after_reopen",
+        strcmp(exec1(db, "SELECT v FROM t WHERE id=1"), "2")==0);
+  doltliteGetSessionRebaseState(db, &isRebasing, 0, 0, &zOrigBranch);
+  check("rebase_continue_conflict_abort_clears_flag_after_reopen", isRebasing==0);
+
+  sqlite3_close(db);
+  remove_db(dbpath);
+}
+
 static void run_branch_copy_existing_dest_preserves_durable_state(void){
   sqlite3 *db = 0;
   char dbpath[256];
@@ -6138,6 +6202,7 @@ static const RegressionCase aCases[] = {
   { "merge_abort_after_reopen_restores_durable_state", "Merge Abort After Reopen Restores Durable State Test", run_merge_abort_after_reopen_restores_durable_state },
   { "rebase_continue_without_active_preserves_durable_state", "Rebase Continue Without Active Preserves Durable State Test", run_rebase_continue_without_active_preserves_durable_state },
   { "rebase_abort_after_reopen_restores_durable_state", "Rebase Abort After Reopen Restores Durable State Test", run_rebase_abort_after_reopen_restores_durable_state },
+  { "rebase_continue_conflict_abort_restores_durable_state", "Rebase Continue Conflict Abort Restores Durable State Test", run_rebase_continue_conflict_abort_restores_durable_state },
   { "rebase_main_table_schema_guard", "Rebase Main Table Schema Guard Test", run_rebase_main_table_schema_guard },
   { "rebase_temp_shadow_ignored", "Rebase Temp Shadow Ignored Test", run_rebase_temp_shadow_ignored },
   { "remote_add_duplicate_preserves_durable_state", "Remote Add Duplicate Preserves Durable State Test", run_remote_add_duplicate_preserves_durable_state },

--- a/test/vc_oracle_rebase_test.sh
+++ b/test/vc_oracle_rebase_test.sh
@@ -147,6 +147,47 @@ oracle_savepoint_abort_poststate() {
   fi
 }
 
+oracle_error_reopen() {
+  local name="$1" setup="$2" query="$3"
+  local dir="$TMPROOT/${name}_reopen"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_rc
+  vc_oracle_run_doltlite_script "$dir/dl/db" "$dir/dl.out" "$dir/dl.err" "$setup"
+  dl_rc=$?
+  local dl_out
+  dl_out=$(printf ".headers off\n.mode list\n%s\n" "$query" \
+           | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.post.err" \
+           | tr -d '\r' \
+           | grep '^LOG|')
+
+  local dolt_setup
+  dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
+  local dt_rc
+  vc_oracle_run_dolt_script_for_error "$dir/dt" "$dir/dt.out" "$dir/dt.err" "$dolt_setup"
+  dt_rc=$?
+  local dt_out
+  (
+    cd "$dir/dt" || exit 1
+    printf "%s\n" "$query" | "$DOLT" sql -c -r csv 2>"$dir/dt.post.err"
+  ) > "$dir/dt.raw"
+  dt_out=$(tr -d '"\r' < "$dir/dt.raw" | grep '^LOG|')
+
+  if [ "$dl_rc" -ne 0 ] && [ "$dt_rc" -ne 0 ] && [ "$dl_out" = "$dt_out" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite rc: $dl_rc"
+    echo "    dolt rc:     $dt_rc"
+    echo "    doltlite:"
+    echo "$dl_out" | sed 's/^/      /'
+    echo "    dolt:"
+    echo "$dt_out" | sed 's/^/      /'
+  fi
+}
+
 echo "=== Version Control Oracle Tests: dolt_rebase ==="
 echo ""
 
@@ -457,6 +498,26 @@ SELECT dolt_rebase('--continue');
 oracle_error "interactive_too_many_args" "
 $INTERACTIVE_SETUP
 SELECT dolt_rebase('-i', 'main', 'extra');
+"
+
+oracle_error_reopen "interactive_continue_conflict_abort_poststate" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 1);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');
+SELECT dolt_checkout('-b', 'feat');
+UPDATE t SET v = 2 WHERE id = 1;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'f1');
+SELECT dolt_checkout('main');
+UPDATE t SET v = 3 WHERE id = 1;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'm1');
+SELECT dolt_checkout('feat');
+SELECT dolt_rebase('-i', 'main');
+SELECT dolt_rebase('--continue');
+" "
+SELECT CONCAT('LOG|B|', active_branch());
+SELECT CONCAT('LOG|W|', count(*)) FROM dolt_branches WHERE name='dolt_rebase_feat';
+SELECT CONCAT('LOG|C|', count(*)) FROM dolt_conflicts;
+SELECT CONCAT('LOG|V|', v) FROM t WHERE id = 1;
 "
 
 echo ""

--- a/test/vc_oracle_rebase_test.sh
+++ b/test/vc_oracle_rebase_test.sh
@@ -520,6 +520,26 @@ SELECT CONCAT('LOG|C|', count(*)) FROM dolt_conflicts;
 SELECT CONCAT('LOG|V|', v) FROM t WHERE id = 1;
 "
 
+oracle_error_reopen "interactive_continue_constraint_abort_poststate" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, u INT UNIQUE, v INT);
+INSERT INTO t VALUES (1, 1, 1);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');
+SELECT dolt_checkout('-b', 'feat');
+INSERT INTO t VALUES (2, 2, 2);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'f1');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES (3, 2, 3);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'm1');
+SELECT dolt_checkout('feat');
+SELECT dolt_rebase('-i', 'main');
+SELECT dolt_rebase('--continue');
+" "
+SELECT CONCAT('LOG|B|', active_branch());
+SELECT CONCAT('LOG|W|', count(*)) FROM dolt_branches WHERE name='dolt_rebase_feat';
+SELECT CONCAT('LOG|CV|', count(*)) FROM dolt_constraint_violations;
+SELECT CONCAT('LOG|T|', count(*)) FROM t;
+"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then


### PR DESCRIPTION
## Summary
- restore interactive rebase state cleanly when `dolt_rebase("--continue")` aborts on conflicts
- reset the temp rebase branch cleanup path so user-visible reopen state matches Dolt
- add reopen-state oracle and regression coverage for the conflict-abort path

## Testing
- bash test/vc_oracle_rebase_test.sh ./doltlite dolt
- bash test/doltlite_savepoint.sh ./doltlite
- ./test/doltlite_regression_test_c rebase_continue_conflict_abort_restores_durable_state