### PR TITLE
Fix rebase continue nested savepoint reopen

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -4003,6 +4003,9 @@ static void doltliteRebaseInteractiveContinue(
   zWorking = sqlite3_mprintf("%s", doltliteGetSessionBranch(db));
   if( !zOrigBranch || !zWorking ){ rc = SQLITE_NOMEM; goto abort_err; }
 
+  rc = doltliteEnsureWriteTxnAndSavepoints(db);
+  if( rc!=SQLITE_OK ) goto abort_err;
+
   rc = doltliteValidateRebasePlanTable(db, &zPlanErr);
   if( rc!=SQLITE_OK ){
     if( zPlanErr ) sqlite3_result_error(context, zPlanErr, -1);
@@ -4063,6 +4066,8 @@ static void doltliteRebaseInteractiveContinue(
   doltliteClearSessionRebaseState(db);
   rc = doltlitePersistWorkingSet(db);
   if( rc!=SQLITE_OK ) goto abort_err;
+  rc = doltliteVcSealBranchStyleTxn(db);
+  if( rc!=SQLITE_OK ) goto abort_err;
 
   rc = rebaseCheckoutBranch(db, zOrigBranch);
   if( rc!=SQLITE_OK ) goto abort_err;
@@ -4070,6 +4075,10 @@ static void doltliteRebaseInteractiveContinue(
   (void)chunkStoreDeleteBranch(cs, zWorking);
   (void)chunkStoreSerializeRefs(cs);
   (void)chunkStoreCommit(cs);
+  /* Refresh the surviving branch's working-set blob against the final
+  ** ref graph after dropping the temp rebase branch. */
+  rc = doltlitePersistWorkingSet(db);
+  if( rc!=SQLITE_OK ) goto abort_err;
 
   rebaseFreePlan(aPlan, nPlan);
   {

--- a/test/doltlite_savepoint.sh
+++ b/test/doltlite_savepoint.sh
@@ -387,6 +387,21 @@ run_test "merge_conflict_reopen_no_conflicts" \
   "SELECT count(*) FROM dolt_conflicts;" \
   "0" "$DB6g1t"
 
+DB6g1u=/tmp/test_savepoint6g1u_$$.db; rm -f "$DB6g1u"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','init'); SELECT dolt_checkout('-b','feat'); INSERT INTO t VALUES(2,'feat'); SELECT dolt_commit('-A','-m','f1'); SELECT dolt_checkout('main'); INSERT INTO t VALUES(10,'main'); SELECT dolt_commit('-A','-m','m1'); SELECT dolt_checkout('feat'); SELECT dolt_rebase('-i','main'); BEGIN; SAVEPOINT sp1; SELECT dolt_rebase('--continue'); COMMIT;" | $DOLTLITE "$DB6g1u" > /dev/null 2>&1
+run_test_match "rebase_continue_nested_savepoint_reopens_main" \
+  "SELECT active_branch();" \
+  "^main$" "$DB6g1u"
+run_test_match "rebase_continue_nested_savepoint_no_temp_branch" \
+  "SELECT count(*) FROM dolt_branches WHERE name='dolt_rebase_feat';" \
+  "^0$" "$DB6g1u"
+run_test_match "rebase_continue_nested_savepoint_rows_persist" \
+  "SELECT count(*) FROM t;" \
+  "^2$" "$DB6g1u"
+run_test_match "rebase_continue_nested_savepoint_log_persists" \
+  "SELECT count(*)-1 FROM dolt_log;" \
+  "^2$" "$DB6g1u"
+
 DB6g2=/tmp/test_savepoint6g2_$$.db; rm -f "$DB6g2"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'main'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6g2" > /dev/null 2>&1
 run_test_match "branch_delete_current_savepoint_rollback_to_errors" \

--- a/test/vc_oracle_rebase_test.sh
+++ b/test/vc_oracle_rebase_test.sh
@@ -188,6 +188,47 @@ oracle_error_reopen() {
   fi
 }
 
+oracle_reopen() {
+  local name="$1" setup="$2" query="$3"
+  local dir="$TMPROOT/${name}_reopen_ok"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_rc
+  vc_oracle_run_doltlite_script "$dir/dl/db" "$dir/dl.out" "$dir/dl.err" "$setup"
+  dl_rc=$?
+  local dl_out
+  dl_out=$(printf ".headers off\n.mode list\n%s\n" "$query" \
+           | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.post.err" \
+           | tr -d '\r' \
+           | grep '^LOG|')
+
+  local dolt_setup
+  dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
+  local dt_rc
+  vc_oracle_run_dolt_script "$dir/dt" "$dir/dt.out" "$dir/dt.err" "$dolt_setup"
+  dt_rc=$?
+  local dt_out
+  (
+    cd "$dir/dt" || exit 1
+    printf "%s\n" "$query" | "$DOLT" sql -c -r csv 2>"$dir/dt.post.err"
+  ) > "$dir/dt.raw"
+  dt_out=$(tr -d '"\r' < "$dir/dt.raw" | grep '^LOG|')
+
+  if [ "$dl_rc" -eq 0 ] && [ "$dt_rc" -eq 0 ] && [ "$dl_out" = "$dt_out" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite rc: $dl_rc"
+    echo "    dolt rc:     $dt_rc"
+    echo "    doltlite:"
+    echo "$dl_out" | sed 's/^/      /'
+    echo "    dolt:"
+    echo "$dt_out" | sed 's/^/      /'
+  fi
+}
+
 echo "=== Version Control Oracle Tests: dolt_rebase ==="
 echo ""
 
@@ -538,6 +579,29 @@ SELECT CONCAT('LOG|B|', active_branch());
 SELECT CONCAT('LOG|W|', count(*)) FROM dolt_branches WHERE name='dolt_rebase_feat';
 SELECT CONCAT('LOG|CV|', count(*)) FROM dolt_constraint_violations;
 SELECT CONCAT('LOG|T|', count(*)) FROM t;
+"
+
+oracle_reopen "interactive_continue_nested_savepoint_success_reopen" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 1);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');
+SELECT dolt_checkout('-b', 'feat');
+INSERT INTO t VALUES (2, 2);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'f1');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES (10, 10);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'm1');
+SELECT dolt_checkout('feat');
+SELECT dolt_rebase('-i', 'main');
+BEGIN;
+SAVEPOINT sp1;
+SELECT dolt_rebase('--continue');
+COMMIT;
+" "
+SELECT CONCAT('LOG|B|', active_branch());
+SELECT CONCAT('LOG|W|', count(*)) FROM dolt_branches WHERE name='dolt_rebase_feat';
+SELECT CONCAT('LOG|T|', count(*)) FROM t;
+SELECT CONCAT('LOG|L|', count(*)-1) FROM dolt_log;
 "
 
 echo ""


### PR DESCRIPTION
## Summary
- fix successful interactive rebase continue under nested savepoints
- reset the branch-style transaction boundary before checking out the original branch
- add reopen regressions for nested-savepoint rebase continue success

## Testing
- bash test/vc_oracle_rebase_test.sh ./doltlite dolt
- bash test/doltlite_savepoint.sh ./doltlite