### PR TITLE
Seal rebase conflict resolve savepoints

### DIFF
--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -277,6 +277,7 @@ static int storeUpdatedConflicts(
 ){
   int totalConflicts = 0;
   int i;
+  DoltliteVcTxnMode mode;
   for(i=0; i<nTables; i++) totalConflicts += aTables[i].nConflicts;
 
   {
@@ -294,8 +295,11 @@ static int storeUpdatedConflicts(
       doltliteSetSessionConflictsCatalog(db, &newHash);
       doltliteSetSessionMergeState(db, 1, 0, &newHash);
     }
-    if( doltliteVcTxnMode(db)==DOLTLITE_VC_TXN_AUTOCOMMIT_LIKE ){
-      return doltlitePersistWorkingSet(db);
+    mode = doltliteVcTxnMode(db);
+    if( mode==DOLTLITE_VC_TXN_AUTOCOMMIT_LIKE ){
+      rc = doltlitePersistWorkingSet(db);
+      if( rc!=SQLITE_OK ) return rc;
+      return doltliteVcSealActiveSavepoints(db);
     }
     return doltliteSaveWorkingSet(db);
   }
@@ -716,6 +720,13 @@ static int conflictsResolveTableExists(sqlite3 *db, const char *zTable, int *pEx
   return rc;
 }
 
+static int conflictsResolveSealSuccessfulTopSavepoint(sqlite3 *db){
+  if( doltliteVcTxnMode(db)==DOLTLITE_VC_TXN_AUTOCOMMIT_LIKE ){
+    return doltliteVcSealActiveSavepoints(db);
+  }
+  return SQLITE_OK;
+}
+
 static void conflictsResolveFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
   ChunkStore *cs = doltliteGetChunkStore(db);
@@ -761,6 +772,11 @@ static void conflictsResolveFunc(sqlite3_context *ctx, int argc, sqlite3_value *
         return;
       }
       if( tableExists ){
+        rc = conflictsResolveSealSuccessfulTopSavepoint(db);
+        if( rc!=SQLITE_OK ){
+          sqlite3_result_error_code(ctx, rc);
+          return;
+        }
         sqlite3_result_int(ctx, 0);
         return;
       }
@@ -805,6 +821,11 @@ static void conflictsResolveFunc(sqlite3_context *ctx, int argc, sqlite3_value *
         return;
       }
       if( tableExists ){
+        rc = conflictsResolveSealSuccessfulTopSavepoint(db);
+        if( rc!=SQLITE_OK ){
+          sqlite3_result_error_code(ctx, rc);
+          return;
+        }
         sqlite3_result_int(ctx, 0);
         return;
       }

--- a/test/doltlite_savepoint.sh
+++ b/test/doltlite_savepoint.sh
@@ -426,6 +426,21 @@ run_test_match "rebase_continue_preexisting_savepoint_log_persists" \
   "SELECT count(*)-1 FROM dolt_log;" \
   "^2$" "$DB6g1w"
 
+DB6g1x=/tmp/test_savepoint6g1x_$$.db; rm -f "$DB6g1x"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT); INSERT INTO t VALUES(1,1); SELECT dolt_add('-A'); SELECT dolt_commit('-m','init'); SELECT dolt_checkout('-b','feat'); UPDATE t SET v=2 WHERE id=1; SELECT dolt_add('-A'); SELECT dolt_commit('-m','f1'); SELECT dolt_checkout('main'); UPDATE t SET v=3 WHERE id=1; SELECT dolt_add('-A'); SELECT dolt_commit('-m','m1'); SELECT dolt_checkout('feat');" | $DOLTLITE "$DB6g1x" > /dev/null 2>&1
+run_test_match "rebase_resolve_theirs_top_savepoint_rollback_to_errors" \
+  "SELECT dolt_rebase('-i','main'); SAVEPOINT sp1; SELECT dolt_conflicts_resolve('--theirs','t'); ROLLBACK TO sp1;" \
+  "no such savepoint: sp1" "$DB6g1x/feat"
+run_test_match "rebase_resolve_theirs_top_savepoint_reopen_main" \
+  "SELECT active_branch();" \
+  "^main$" "$DB6g1x"
+run_test_match "rebase_resolve_theirs_top_savepoint_temp_branch_survives" \
+  "SELECT count(*) FROM dolt_branches WHERE name='dolt_rebase_feat';" \
+  "^1$" "$DB6g1x"
+run_test_match "rebase_resolve_theirs_top_savepoint_reopen_no_conflicts" \
+  "SELECT count(*) FROM dolt_conflicts;" \
+  "^0$" "$DB6g1x"
+
 DB6g2=/tmp/test_savepoint6g2_$$.db; rm -f "$DB6g2"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'main'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6g2" > /dev/null 2>&1
 run_test_match "branch_delete_current_savepoint_rollback_to_errors" \

--- a/test/vc_oracle_rebase_test.sh
+++ b/test/vc_oracle_rebase_test.sh
@@ -581,6 +581,28 @@ SELECT CONCAT('LOG|CV|', count(*)) FROM dolt_constraint_violations;
 SELECT CONCAT('LOG|T|', count(*)) FROM t;
 "
 
+oracle_error_reopen "interactive_resolve_theirs_top_savepoint_poststate" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 1);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');
+SELECT dolt_checkout('-b', 'feat');
+UPDATE t SET v = 2 WHERE id = 1;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'f1');
+SELECT dolt_checkout('main');
+UPDATE t SET v = 3 WHERE id = 1;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'm1');
+SELECT dolt_checkout('feat');
+SELECT dolt_rebase('-i', 'main');
+SAVEPOINT sp1;
+SELECT dolt_conflicts_resolve('--theirs', 't');
+ROLLBACK TO sp1;
+" "
+SELECT CONCAT('LOG|B|', active_branch());
+SELECT CONCAT('LOG|W|', count(*)) FROM dolt_branches WHERE name='dolt_rebase_feat';
+SELECT CONCAT('LOG|C|', count(*)) FROM dolt_conflicts;
+SELECT CONCAT('LOG|V|', v) FROM t WHERE id = 1;
+"
+
 oracle_reopen "interactive_continue_nested_savepoint_success_reopen" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 1);


### PR DESCRIPTION
## Summary
- seal top-level savepoints after successful conflict resolution updates in interactive rebase flows
- cover the no-op resolve path that still invalidates the caller savepoint in Dolt
- add rebase oracle and local savepoint regressions for the reopen poststate

## Testing
- bash test/vc_oracle_rebase_test.sh ./doltlite dolt
- bash test/doltlite_savepoint.sh ./doltlite