### PR TITLE
Fix rebase abort explicit transaction state

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -3968,6 +3968,14 @@ static void doltliteRebaseInteractiveAbort(
   ** doesn't leak stale values. */
   rebaseDiscardWorkingBranch(db, zOrigBranch, zWorking);
 
+  rc = doltliteVcSealBranchStyleTxn(db);
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(zOrigBranch);
+    sqlite3_free(zWorking);
+    sqlite3_result_error_code(context, rc);
+    return;
+  }
+
   sqlite3_free(zOrigBranch);
   sqlite3_free(zWorking);
   sqlite3_result_text(context, "Interactive rebase aborted", -1, SQLITE_STATIC);

--- a/test/doltlite_savepoint.sh
+++ b/test/doltlite_savepoint.sh
@@ -678,6 +678,33 @@ run_test "rebase_abort_savepoint_reopen_no_plan_table" \
   "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='dolt_rebase';" \
   "0" "$DB7e"
 
+DB7e1=/tmp/test_savepoint7e1_$$.db; rm -f "$DB7e1"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT); INSERT INTO t VALUES(1,1); SELECT dolt_add('-A'); SELECT dolt_commit('-m','init'); SELECT dolt_checkout('-b','feat'); INSERT INTO t VALUES(2,2); SELECT dolt_add('-A'); SELECT dolt_commit('-m','f1'); SELECT dolt_checkout('main'); INSERT INTO t VALUES(10,10); SELECT dolt_add('-A'); SELECT dolt_commit('-m','m1'); SELECT dolt_checkout('feat'); SELECT dolt_rebase('-i','main'); BEGIN; SELECT dolt_rebase('--abort'); COMMIT;" | $DOLTLITE "$DB7e1" > /dev/null 2>&1
+run_test "rebase_abort_explicit_txn_reopen_main" \
+  "SELECT active_branch();" \
+  "main" "$DB7e1"
+run_test "rebase_abort_explicit_txn_reopen_no_rebase_branch" \
+  "SELECT count(*) FROM dolt_branches WHERE name='dolt_rebase_feat';" \
+  "0" "$DB7e1"
+run_test "rebase_abort_explicit_txn_reopen_main_rows" \
+  "SELECT count(*) FROM t;" \
+  "2" "$DB7e1"
+
+DB7e2=/tmp/test_savepoint7e2_$$.db; rm -f "$DB7e2"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT); INSERT INTO t VALUES(1,1); SELECT dolt_add('-A'); SELECT dolt_commit('-m','init'); SELECT dolt_checkout('-b','feat'); UPDATE t SET v=2 WHERE id=1; SELECT dolt_add('-A'); SELECT dolt_commit('-m','f1'); SELECT dolt_checkout('main'); UPDATE t SET v=3 WHERE id=1; SELECT dolt_add('-A'); SELECT dolt_commit('-m','m1'); SELECT dolt_checkout('feat'); SELECT dolt_rebase('-i','main'); SELECT dolt_conflicts_resolve('--theirs','t'); BEGIN; SELECT dolt_rebase('--abort'); COMMIT;" | $DOLTLITE "$DB7e2" > /dev/null 2>&1
+run_test "rebase_abort_after_resolve_explicit_txn_reopen_main" \
+  "SELECT active_branch();" \
+  "main" "$DB7e2"
+run_test "rebase_abort_after_resolve_explicit_txn_reopen_no_rebase_branch" \
+  "SELECT count(*) FROM dolt_branches WHERE name='dolt_rebase_feat';" \
+  "0" "$DB7e2"
+run_test "rebase_abort_after_resolve_explicit_txn_reopen_no_conflicts" \
+  "SELECT count(*) FROM dolt_conflicts;" \
+  "0" "$DB7e2"
+run_test "rebase_abort_after_resolve_explicit_txn_reopen_main_value" \
+  "SELECT v FROM t WHERE id=1;" \
+  "3" "$DB7e2"
+
 DB7f=/tmp/test_savepoint7f_$$.db; rm -f "$DB7f"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT); INSERT INTO t VALUES(1,1); SELECT dolt_add('-A'); SELECT dolt_commit('-m','init'); SELECT dolt_checkout('-b','feat'); INSERT INTO t VALUES(2,2); SELECT dolt_add('-A'); SELECT dolt_commit('-m','f1'); SELECT dolt_checkout('main'); INSERT INTO t VALUES(10,10); SELECT dolt_add('-A'); SELECT dolt_commit('-m','m1'); SELECT dolt_checkout('feat'); SAVEPOINT sp1; SELECT dolt_rebase('-i','main'); SELECT dolt_rebase('--continue'); ROLLBACK TO sp1;" | $DOLTLITE "$DB7f" > /dev/null 2>&1
 run_test "rebase_continue_top_savepoint_reopen_main" \

--- a/test/vc_oracle_rebase_test.sh
+++ b/test/vc_oracle_rebase_test.sh
@@ -529,6 +529,43 @@ SELECT dolt_rebase('--abort');
 ROLLBACK TO sp1;
 "
 
+oracle_reopen "interactive_abort_explicit_txn_reopen" "
+$INTERACTIVE_SETUP
+SELECT dolt_rebase('-i', 'main');
+BEGIN;
+SELECT dolt_rebase('--abort');
+COMMIT;
+" "
+SELECT CONCAT('LOG|B|', active_branch());
+SELECT CONCAT('LOG|W|', count(*)) FROM dolt_branches WHERE name='dolt_rebase_feat';
+SELECT CONCAT('LOG|T|', count(*)) FROM t;
+SELECT CONCAT('LOG|L|', count(*)-1) FROM dolt_log;
+"
+
+oracle_reopen "interactive_abort_after_resolve_explicit_txn_reopen" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 1);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');
+SELECT dolt_checkout('-b', 'feat');
+UPDATE t SET v = 2 WHERE id = 1;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'f1');
+SELECT dolt_checkout('main');
+UPDATE t SET v = 3 WHERE id = 1;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'm1');
+SELECT dolt_checkout('feat');
+SELECT dolt_rebase('-i', 'main');
+SELECT dolt_conflicts_resolve('--theirs', 't');
+BEGIN;
+SELECT dolt_rebase('--abort');
+COMMIT;
+" "
+SELECT CONCAT('LOG|B|', active_branch());
+SELECT CONCAT('LOG|W|', count(*)) FROM dolt_branches WHERE name='dolt_rebase_feat';
+SELECT CONCAT('LOG|C|', count(*)) FROM dolt_conflicts;
+SELECT CONCAT('LOG|V|', v) FROM t WHERE id = 1;
+SELECT CONCAT('LOG|L|', count(*)-1) FROM dolt_log;
+"
+
 # --continue is an error when not in an interactive rebase.
 oracle_error "continue_without_active" "
 CREATE TABLE t(id INTEGER PRIMARY KEY);


### PR DESCRIPTION
## Summary
- make interactive rebase abort follow branch-style transaction semantics in explicit transactions
- fix durable reopen state after abort in both plain interactive and conflict-resolved interactive flows
- add oracle and savepoint regressions for explicit-transaction abort poststate

## Testing
- bash test/vc_oracle_rebase_test.sh ./doltlite dolt
- bash test/doltlite_savepoint.sh ./doltlite