### PR TITLE
Fix multi-table checkout dispatch

### DIFF
--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -795,10 +795,18 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
   }
 
   if( argc>1 && !isCreateAndSwitch ){
-    rc = doltliteCheckoutTables(db, zBranch, argv, 1, argc-1);
+    ProllyHash sourceRef;
+    int bHasSourceRef = 0;
+    rc = doltliteResolveRef(db, zBranch, &sourceRef);
+    if( rc==SQLITE_OK ){
+      bHasSourceRef = 1;
+      rc = doltliteCheckoutTables(db, zBranch, argv, 1, argc-1);
+    }else{
+      rc = doltliteCheckoutTables(db, 0, argv, 0, argc);
+    }
     if( rc==SQLITE_NOTFOUND ){
-      char *zErr = sqlite3_mprintf(
-          "no such branch or table: %s", zBranch);
+      const char *zMissing = bHasSourceRef ? zBranch : zBranch;
+      char *zErr = sqlite3_mprintf("no such branch or table: %s", zMissing);
       (void)doltliteVcSealSavepointError(db);
       sqlite3_result_error(ctx, zErr ? zErr : "no such branch or table", -1);
       sqlite3_free(zErr);

--- a/test/vc_oracle_checkout_test.sh
+++ b/test/vc_oracle_checkout_test.sh
@@ -281,6 +281,23 @@ UPDATE t SET v='dirty' WHERE id=1;
 SELECT dolt_checkout('t');
 "
 
+oracle "revert_multiple_tables_working" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, v TEXT);
+CREATE TABLE b(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO a VALUES (1, 'base_a');
+INSERT INTO b VALUES (1, 'base_b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+UPDATE a SET v='dirty_a' WHERE id=1;
+UPDATE b SET v='dirty_b' WHERE id=1;
+SELECT dolt_checkout('a', 'b');
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t
+SELECT id, v FROM a
+UNION ALL
+SELECT id + 10, v FROM b;
+"
+
 oracle "revert_table_with_uncommitted_insert" "
 $SEED
 INSERT INTO t VALUES (2, 'uncommitted');
@@ -305,6 +322,28 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c2_feat');
 SELECT dolt_checkout('main');
 SELECT dolt_checkout('feature', 't');
+"
+
+oracle "checkout_multiple_tables_from_branch_ref" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, v TEXT);
+CREATE TABLE b(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO a VALUES (1, 'base_a');
+INSERT INTO b VALUES (1, 'base_b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+INSERT INTO a VALUES (2, 'feature_a');
+INSERT INTO b VALUES (2, 'feature_b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2_feat');
+SELECT dolt_checkout('main');
+SELECT dolt_checkout('feature', 'a', 'b');
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t
+SELECT id, v FROM a
+UNION ALL
+SELECT id + 10, v FROM b;
 "
 
 echo "--- error paths ---"

--- a/test/vc_oracle_remotes_test.sh
+++ b/test/vc_oracle_remotes_test.sh
@@ -512,6 +512,93 @@ SQL
   fi
 }
 
+oracle_fetch_ref_multitable_reopen_poststate() {
+  local name="$1" dl_test_sql="$2" dt_test_sql="$3" query="$4"
+  local dir="$TMPROOT/${name}_fetch_multitable_reopen"
+  local dl_remote_url="file://$dir/dl_remote.db"
+  local dt_remote_dir="$dir/dt_remote"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_post dt_post
+
+  cat >"$dir/dl_setup.sql" <<SQL
+CREATE TABLE a(id INTEGER PRIMARY KEY, v TEXT);
+CREATE TABLE b(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO a VALUES (1, 'base_a');
+INSERT INTO b VALUES (1, 'base_b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'init');
+SELECT dolt_remote('add', 'origin', '$dl_remote_url');
+SELECT dolt_push('origin', 'main');
+SELECT dolt_branch('branchA');
+SELECT dolt_checkout('branchA');
+INSERT INTO a VALUES (2, 'branchA_a');
+INSERT INTO b VALUES (2, 'branchA_b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'branchA');
+SELECT dolt_push('origin', 'branchA');
+SELECT dolt_checkout('main');
+SQL
+  "$DOLTLITE" "$dir/dl/db" <"$dir/dl_setup.sql" >/dev/null 2>"$dir/dl_setup.err"
+  "$DOLTLITE" "$dir/dl_clone.db" "SELECT dolt_clone('$dl_remote_url');" >/dev/null 2>"$dir/dl_clone.err"
+
+  vc_oracle_run_doltlite_script "$dir/dl_clone.db" "$dir/dl.out" "$dir/dl.err" "$dl_test_sql"
+  dl_post=$(printf ".headers off\n.mode list\n%s\n" "$query" \
+            | "$DOLTLITE" "$dir/dl_clone.db" 2>>"$dir/dl.err" \
+            | tr -d '\r')
+
+  mkdir -p "$dt_remote_dir"
+  (
+    cd "$dt_remote_dir" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+  )
+  (
+    cd "$dir/dt" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    cat >setup.sql <<SQL
+CREATE TABLE a(id INT PRIMARY KEY, v TEXT);
+CREATE TABLE b(id INT PRIMARY KEY, v TEXT);
+INSERT INTO a VALUES (1, 'base_a');
+INSERT INTO b VALUES (1, 'base_b');
+CALL dolt_add('-A');
+CALL dolt_commit('-m', 'init');
+CALL dolt_remote('add', 'origin', 'file://$dt_remote_dir');
+CALL dolt_push('origin', 'main');
+CALL dolt_branch('branchA');
+CALL dolt_checkout('branchA');
+INSERT INTO a VALUES (2, 'branchA_a');
+INSERT INTO b VALUES (2, 'branchA_b');
+CALL dolt_add('-A');
+CALL dolt_commit('-m', 'branchA');
+CALL dolt_push('origin', 'branchA');
+CALL dolt_checkout('main');
+SQL
+    "$DOLT" sql -c < setup.sql >/dev/null 2>"$dir/dt_setup.err"
+  )
+  (
+    cd "$dir" || exit 1
+    "$DOLT" clone "file://$dt_remote_dir" dt_clone >/dev/null 2>&1
+    cd dt_clone || exit 1
+    cat >test.sql <<SQL
+$dt_test_sql
+SQL
+    "$DOLT" sql -c < test.sql >/dev/null 2>"$dir/dt.err" || true
+    dt_post=$("$DOLT" sql -r csv -q "$query" 2>>"$dir/dt.err" | tail -n +2 | tr -d '\"\r')
+    printf "%s\n" "$dt_post" >"$dir/dt.post"
+  )
+  dt_post=$(cat "$dir/dt.post")
+
+  if [ "$dl_post" = "$dt_post" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite post:"; echo "$dl_post" | sed 's/^/      /'
+    echo "    dolt post:"; echo "$dt_post" | sed 's/^/      /'
+  fi
+}
+
 oracle_fetch_refresh_ref_consumer_poststate() {
   local name="$1" dl_test_sql="$2" dt_test_sql="$3" query="$4"
   local dir="$TMPROOT/${name}_fetch_refresh"
@@ -831,6 +918,13 @@ SELECT dolt_checkout('origin/branchA', 't');" \
   "CALL dolt_fetch('origin', 'branchA');
 CALL dolt_checkout('origin/branchA', 't');" \
   "SELECT concat(active_branch(), char(9), count(*), char(9), (SELECT count(*)-1 FROM dolt_log)) FROM t;"
+oracle_fetch_ref_multitable_reopen_poststate \
+  "fetch_then_checkout_multiple_tables_remote_tracking_ref_reopens" \
+  "SELECT dolt_fetch('origin', 'branchA');
+SELECT dolt_checkout('origin/branchA', 'a', 'b');" \
+  "CALL dolt_fetch('origin', 'branchA');
+CALL dolt_checkout('origin/branchA', 'a', 'b');" \
+  "SELECT concat(active_branch(), char(9), (SELECT count(*) FROM a), char(9), (SELECT count(*) FROM b), char(9), (SELECT count(*)-1 FROM dolt_log));"
 oracle_fetch_refresh_ref_consumer_poststate \
   "fetch_refresh_then_branch_tracking_ref_then_checkout" \
   "SELECT dolt_fetch('origin', 'branchA');


### PR DESCRIPTION
## Summary
- fix `dolt_checkout` so multi-table calls without an explicit source ref fall back to table-checkout mode instead of treating the first table name as a branch/ref
- add checkout oracle coverage for local multi-table checkout and branch-ref multi-table checkout
- add remote oracle coverage for fetched tracking-ref multi-table checkout durability

## Testing
- bash test/vc_oracle_checkout_test.sh /private/tmp/doltlite-master-38151e1f8-pr626/doltlite dolt
- bash test/vc_oracle_remotes_test.sh /private/tmp/doltlite-master-38151e1f8-pr626/doltlite dolt
