### PR TITLE
Add branch-source checkout oracle coverage

### DIFF
--- a/test/vc_oracle_checkout_test.sh
+++ b/test/vc_oracle_checkout_test.sh
@@ -479,6 +479,43 @@ SELECT dolt_commit('-m', 'c2');
 SELECT dolt_checkout('v1', 'a', 'missing');
 " "SELECT concat((SELECT v FROM a WHERE id=1), char(9), (SELECT v FROM b WHERE id=1));"
 
+oracle_error_poststate "checkout_branch_source_missing_table_no_partial_mutation" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, v TEXT);
+CREATE TABLE b(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO a VALUES (1, 'base_a');
+INSERT INTO b VALUES (1, 'base_b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+UPDATE a SET v='feature_a' WHERE id=1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2_feat');
+SELECT dolt_checkout('main');
+UPDATE a SET v='dirty_a' WHERE id=1;
+UPDATE b SET v='dirty_b' WHERE id=1;
+SELECT dolt_checkout('feature', 'a', 'missing');
+" "SELECT concat((SELECT v FROM a WHERE id=1), char(9), (SELECT v FROM b WHERE id=1));"
+
+oracle_error_poststate "checkout_branch_source_missing_table_preserves_staged_and_working_state" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, v TEXT);
+CREATE TABLE b(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO a VALUES (1, 'base_a');
+INSERT INTO b VALUES (1, 'base_b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+UPDATE a SET v='feature_a' WHERE id=1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2_feat');
+SELECT dolt_checkout('main');
+UPDATE a SET v='stage_a' WHERE id=1;
+UPDATE b SET v='dirty_b' WHERE id=1;
+SELECT dolt_add('a');
+SELECT dolt_checkout('feature', 'a', 'missing');
+" "SELECT concat((SELECT v FROM a WHERE id=1), char(9), (SELECT v FROM b WHERE id=1), char(9), (SELECT count(*) FROM dolt_status WHERE table_name='a' AND staged=1 AND status='modified'), char(9), (SELECT count(*) FROM dolt_status WHERE table_name='b' AND staged=0 AND status='modified'));"
+
 echo "--- savepoint parity ---"
 
 oracle_savepoint_poststate "savepoint_checkout_existing_branch_reopens_on_original_branch" "
@@ -524,6 +561,27 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c2');
 SAVEPOINT sp1;
 SELECT dolt_checkout('v1', 'a', 'b');
+ROLLBACK TO sp1;
+" "SELECT concat((SELECT v FROM a WHERE id=1), char(9), (SELECT v FROM b WHERE id=1));"
+
+oracle_savepoint_poststate "savepoint_checkout_branch_source_invalidates" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, v TEXT);
+CREATE TABLE b(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO a VALUES (1, 'base_a');
+INSERT INTO b VALUES (1, 'base_b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+UPDATE a SET v='feature_a' WHERE id=1;
+UPDATE b SET v='feature_b' WHERE id=1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2_feat');
+SELECT dolt_checkout('main');
+UPDATE a SET v='dirty_a' WHERE id=1;
+UPDATE b SET v='dirty_b' WHERE id=1;
+SAVEPOINT sp1;
+SELECT dolt_checkout('feature', 'a', 'b');
 ROLLBACK TO sp1;
 " "SELECT concat((SELECT v FROM a WHERE id=1), char(9), (SELECT v FROM b WHERE id=1));"
 


### PR DESCRIPTION
## Summary
- add branch-source checkout error-poststate coverage when a requested table is missing
- add branch-source checkout savepoint invalidation coverage for explicit-source table checkout

## Testing
- bash test/vc_oracle_checkout_test.sh /private/tmp/doltlite-master-checkout-explicit-src/doltlite dolt