### PR TITLE
Add checkout merge-parent oracle coverage

### DIFF
--- a/test/doltlite_branch.sh
+++ b/test/doltlite_branch.sh
@@ -50,6 +50,18 @@ DB2D=/tmp/test_branch2d_$$.db; rm -f "$DB2D"
 echo "CREATE TABLE a(id INTEGER PRIMARY KEY, v TEXT); CREATE TABLE b(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO a VALUES(1,'base_a'); INSERT INTO b VALUES(1,'base_b'); SELECT dolt_commit('-A','-m','init'); UPDATE a SET v='main_a' WHERE id=1; UPDATE b SET v='main_b' WHERE id=1; SELECT dolt_commit('-A','-m','c2'); SELECT dolt_checkout(dolt_hashof('HEAD~1'),'a','b'); CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t SELECT id, v FROM a UNION ALL SELECT id+10, v FROM b;" | $DOLTLITE "$DB2D" > /dev/null 2>&1
 run_test "checkout_table_from_raw_hash_persists_across_reopen" "SELECT group_concat(v, ',') FROM (SELECT v FROM t ORDER BY id);" "base_a,base_b" "$DB2D"
 
+DB2E=/tmp/test_branch2e_$$.db; rm -f "$DB2E"
+echo "CREATE TABLE a(id INTEGER PRIMARY KEY, v TEXT); CREATE TABLE b(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO a VALUES(1,'base_a'); INSERT INTO b VALUES(1,'base_b'); SELECT dolt_commit('-A','-m','init'); UPDATE a SET v='main_a' WHERE id=1; UPDATE b SET v='main_b' WHERE id=1; SELECT dolt_commit('-A','-m','c2'); SELECT dolt_checkout('HEAD^1','a','b'); CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t SELECT id, v FROM a UNION ALL SELECT id+10, v FROM b;" | $DOLTLITE "$DB2E" > /dev/null 2>&1
+run_test "checkout_table_from_first_parent_ref_persists_across_reopen" "SELECT group_concat(v, ',') FROM (SELECT v FROM t ORDER BY id);" "base_a,base_b" "$DB2E"
+
+DB2F=/tmp/test_branch2f_$$.db; rm -f "$DB2F"
+echo "CREATE TABLE a(id INTEGER PRIMARY KEY, v TEXT); CREATE TABLE b(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO a VALUES(1,'base_a'); INSERT INTO b VALUES(1,'base_b'); SELECT dolt_commit('-A','-m','init'); SELECT dolt_checkout('-b','feature'); INSERT INTO a VALUES(2,'feat_a'); INSERT INTO b VALUES(2,'feat_b'); SELECT dolt_commit('-A','-m','c2f'); SELECT dolt_checkout('main'); INSERT INTO a VALUES(3,'main_a'); INSERT INTO b VALUES(3,'main_b'); SELECT dolt_commit('-A','-m','c2m'); SELECT dolt_merge('feature'); SELECT dolt_checkout('HEAD^2','a','b'); CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t SELECT id, v FROM a UNION ALL SELECT id+10, v FROM b;" | $DOLTLITE "$DB2F" > /dev/null 2>&1
+run_test "checkout_table_from_second_parent_ref_persists_across_reopen" "SELECT group_concat(v, ',') FROM (SELECT v FROM t ORDER BY id);" "base_a,feat_a,base_b,feat_b" "$DB2F"
+
+DB2G=/tmp/test_branch2g_$$.db; rm -f "$DB2G"
+echo "CREATE TABLE a(id INTEGER PRIMARY KEY, v TEXT); CREATE TABLE b(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO a VALUES(1,'base_a'); INSERT INTO b VALUES(1,'base_b'); SELECT dolt_commit('-A','-m','init'); SELECT dolt_checkout('-b','feature'); INSERT INTO a VALUES(2,'feat_a'); INSERT INTO b VALUES(2,'feat_b'); SELECT dolt_commit('-A','-m','c2f'); SELECT dolt_checkout('main'); INSERT INTO a VALUES(3,'main_a'); INSERT INTO b VALUES(3,'main_b'); SELECT dolt_commit('-A','-m','c2m'); SELECT dolt_merge('feature'); SELECT dolt_checkout(dolt_hashof('HEAD^2'),'a','b'); CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t SELECT id, v FROM a UNION ALL SELECT id+10, v FROM b;" | $DOLTLITE "$DB2G" > /dev/null 2>&1
+run_test "checkout_table_from_raw_second_parent_hash_persists_across_reopen" "SELECT group_concat(v, ',') FROM (SELECT v FROM t ORDER BY id);" "base_a,feat_a,base_b,feat_b" "$DB2G"
+
 DB3=/tmp/test_branch3_$$.db; rm -f "$DB3"
 echo "CREATE TABLE t(x); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','i');" | $DOLTLITE "$DB3" > /dev/null 2>&1
 echo "SELECT dolt_branch('b2');" | $DOLTLITE "$DB3" > /dev/null 2>&1

--- a/test/vc_oracle_checkout_test.sh
+++ b/test/vc_oracle_checkout_test.sh
@@ -467,6 +467,52 @@ SELECT dolt_checkout(dolt_hashof('HEAD^1'), 'a', 'b');
 SELECT (SELECT v FROM a WHERE id=1) AS id, (SELECT v FROM b WHERE id=1) AS v;
 "
 
+oracle "checkout_multitable_from_second_parent_ref" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, v TEXT);
+CREATE TABLE b(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO a VALUES (1, 'base_a');
+INSERT INTO b VALUES (1, 'base_b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_checkout('-b', 'feature');
+INSERT INTO a VALUES (2, 'feat_a');
+INSERT INTO b VALUES (2, 'feat_b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2f');
+SELECT dolt_checkout('main');
+INSERT INTO a VALUES (3, 'main_a');
+INSERT INTO b VALUES (3, 'main_b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2m');
+SELECT dolt_merge('feature');
+SELECT dolt_checkout('HEAD^2', 'a', 'b');
+SELECT (SELECT group_concat(v, ',') FROM (SELECT v FROM a ORDER BY id)) AS id,
+       (SELECT group_concat(v, ',') FROM (SELECT v FROM b ORDER BY id)) AS v;
+"
+
+oracle "checkout_multitable_from_raw_second_parent_hash" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, v TEXT);
+CREATE TABLE b(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO a VALUES (1, 'base_a');
+INSERT INTO b VALUES (1, 'base_b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_checkout('-b', 'feature');
+INSERT INTO a VALUES (2, 'feat_a');
+INSERT INTO b VALUES (2, 'feat_b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2f');
+SELECT dolt_checkout('main');
+INSERT INTO a VALUES (3, 'main_a');
+INSERT INTO b VALUES (3, 'main_b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2m');
+SELECT dolt_merge('feature');
+SELECT dolt_checkout(dolt_hashof('HEAD^2'), 'a', 'b');
+SELECT (SELECT group_concat(v, ',') FROM (SELECT v FROM a ORDER BY id)) AS id,
+       (SELECT group_concat(v, ',') FROM (SELECT v FROM b ORDER BY id)) AS v;
+"
+
 echo "--- error paths ---"
 
 oracle_error "checkout_nonexistent" "

--- a/test/vc_oracle_checkout_test.sh
+++ b/test/vc_oracle_checkout_test.sh
@@ -585,6 +585,20 @@ SELECT dolt_commit('-m', 'c2');
 SELECT dolt_checkout('v1', 'a', 'missing');
 " "SELECT concat((SELECT v FROM a WHERE id=1), char(9), (SELECT v FROM b WHERE id=1));"
 
+oracle_error_poststate "checkout_tag_source_missing_table_preserves_staged_and_working_state" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, v TEXT);
+CREATE TABLE b(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO a VALUES (1, 'base_a');
+INSERT INTO b VALUES (1, 'base_b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_tag('v1');
+UPDATE a SET v='stage_a' WHERE id=1;
+UPDATE b SET v='dirty_b' WHERE id=1;
+SELECT dolt_add('a');
+SELECT dolt_checkout('v1', 'a', 'missing');
+" "SELECT concat((SELECT v FROM a WHERE id=1), char(9), (SELECT v FROM b WHERE id=1), char(9), (SELECT count(*) FROM dolt_status WHERE table_name='a' AND staged=1 AND status='modified'), char(9), (SELECT count(*) FROM dolt_status WHERE table_name='b' AND staged=0 AND status='modified'));"
+
 oracle_error_poststate "checkout_branch_source_missing_table_no_partial_mutation" "
 CREATE TABLE a(id INTEGER PRIMARY KEY, v TEXT);
 CREATE TABLE b(id INTEGER PRIMARY KEY, v TEXT);
@@ -635,6 +649,61 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c2');
 SELECT dolt_checkout(dolt_hashof('HEAD~1'), 'a', 'missing');
 " "SELECT concat((SELECT v FROM a WHERE id=1), char(9), (SELECT v FROM b WHERE id=1));"
+
+oracle_error_poststate "checkout_raw_hash_source_missing_table_preserves_staged_and_working_state" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, v TEXT);
+CREATE TABLE b(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO a VALUES (1, 'base_a');
+INSERT INTO b VALUES (1, 'base_b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+UPDATE a SET v='stage_a' WHERE id=1;
+UPDATE b SET v='dirty_b' WHERE id=1;
+SELECT dolt_add('a');
+SELECT dolt_checkout(dolt_hashof('HEAD'), 'a', 'missing');
+" "SELECT concat((SELECT v FROM a WHERE id=1), char(9), (SELECT v FROM b WHERE id=1), char(9), (SELECT count(*) FROM dolt_status WHERE table_name='a' AND staged=1 AND status='modified'), char(9), (SELECT count(*) FROM dolt_status WHERE table_name='b' AND staged=0 AND status='modified'));"
+
+oracle_error_poststate "checkout_second_parent_source_missing_table_no_partial_mutation" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, v TEXT);
+CREATE TABLE b(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO a VALUES (1, 'base_a');
+INSERT INTO b VALUES (1, 'base_b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_checkout('-b', 'feature');
+INSERT INTO a VALUES (2, 'feat_a');
+INSERT INTO b VALUES (2, 'feat_b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2f');
+SELECT dolt_checkout('main');
+INSERT INTO a VALUES (3, 'main_a');
+INSERT INTO b VALUES (3, 'main_b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2m');
+SELECT dolt_merge('feature');
+SELECT dolt_checkout('HEAD^2', 'a', 'missing');
+" "SELECT concat((SELECT v FROM a WHERE id=1), char(9), (SELECT v FROM a WHERE id=2), char(9), (SELECT v FROM a WHERE id=3), char(9), (SELECT v FROM b WHERE id=1), char(9), (SELECT v FROM b WHERE id=2), char(9), (SELECT v FROM b WHERE id=3));"
+
+oracle_error_poststate "checkout_raw_second_parent_hash_missing_table_no_partial_mutation" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, v TEXT);
+CREATE TABLE b(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO a VALUES (1, 'base_a');
+INSERT INTO b VALUES (1, 'base_b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_checkout('-b', 'feature');
+INSERT INTO a VALUES (2, 'feat_a');
+INSERT INTO b VALUES (2, 'feat_b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2f');
+SELECT dolt_checkout('main');
+INSERT INTO a VALUES (3, 'main_a');
+INSERT INTO b VALUES (3, 'main_b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2m');
+SELECT dolt_merge('feature');
+SELECT dolt_checkout(dolt_hashof('HEAD^2'), 'a', 'missing');
+" "SELECT concat((SELECT v FROM a WHERE id=1), char(9), (SELECT v FROM a WHERE id=2), char(9), (SELECT v FROM a WHERE id=3), char(9), (SELECT v FROM b WHERE id=1), char(9), (SELECT v FROM b WHERE id=2), char(9), (SELECT v FROM b WHERE id=3));"
 
 echo "--- savepoint parity ---"
 
@@ -720,6 +789,52 @@ SAVEPOINT sp1;
 SELECT dolt_checkout(dolt_hashof('HEAD~1'), 'a', 'b');
 ROLLBACK TO sp1;
 " "SELECT concat((SELECT v FROM a WHERE id=1), char(9), (SELECT v FROM b WHERE id=1));"
+
+oracle_savepoint_poststate "savepoint_checkout_second_parent_source_invalidates" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, v TEXT);
+CREATE TABLE b(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO a VALUES (1, 'base_a');
+INSERT INTO b VALUES (1, 'base_b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_checkout('-b', 'feature');
+INSERT INTO a VALUES (2, 'feat_a');
+INSERT INTO b VALUES (2, 'feat_b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2f');
+SELECT dolt_checkout('main');
+INSERT INTO a VALUES (3, 'main_a');
+INSERT INTO b VALUES (3, 'main_b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2m');
+SELECT dolt_merge('feature');
+SAVEPOINT sp1;
+SELECT dolt_checkout('HEAD^2', 'a', 'b');
+ROLLBACK TO sp1;
+" "SELECT concat(active_branch(), char(9), IFNULL((SELECT v FROM a WHERE id=1), ''), char(9), IFNULL((SELECT v FROM a WHERE id=2), ''), char(9), IFNULL((SELECT v FROM a WHERE id=3), ''), char(9), IFNULL((SELECT v FROM b WHERE id=1), ''), char(9), IFNULL((SELECT v FROM b WHERE id=2), ''), char(9), IFNULL((SELECT v FROM b WHERE id=3), ''), char(9), (SELECT count(*) FROM dolt_status WHERE table_name='a' AND staged=1 AND status='modified'), char(9), (SELECT count(*) FROM dolt_status WHERE table_name='b' AND staged=1 AND status='modified'));"
+
+oracle_savepoint_poststate "savepoint_checkout_raw_second_parent_hash_invalidates" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, v TEXT);
+CREATE TABLE b(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO a VALUES (1, 'base_a');
+INSERT INTO b VALUES (1, 'base_b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_checkout('-b', 'feature');
+INSERT INTO a VALUES (2, 'feat_a');
+INSERT INTO b VALUES (2, 'feat_b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2f');
+SELECT dolt_checkout('main');
+INSERT INTO a VALUES (3, 'main_a');
+INSERT INTO b VALUES (3, 'main_b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2m');
+SELECT dolt_merge('feature');
+SAVEPOINT sp1;
+SELECT dolt_checkout(dolt_hashof('HEAD^2'), 'a', 'b');
+ROLLBACK TO sp1;
+" "SELECT concat(active_branch(), char(9), IFNULL((SELECT v FROM a WHERE id=1), ''), char(9), IFNULL((SELECT v FROM a WHERE id=2), ''), char(9), IFNULL((SELECT v FROM a WHERE id=3), ''), char(9), IFNULL((SELECT v FROM b WHERE id=1), ''), char(9), IFNULL((SELECT v FROM b WHERE id=2), ''), char(9), IFNULL((SELECT v FROM b WHERE id=3), ''), char(9), (SELECT count(*) FROM dolt_status WHERE table_name='a' AND staged=1 AND status='modified'), char(9), (SELECT count(*) FROM dolt_status WHERE table_name='b' AND staged=1 AND status='modified'));"
 
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="


### PR DESCRIPTION
## Summary
- add checkout oracle coverage for explicit-source table checkout from a merge commit's second parent
- cover both `HEAD^2` and raw hashes derived from `dolt_hashof('HEAD^2')`

## Testing
- bash test/vc_oracle_checkout_test.sh /private/tmp/doltlite-master-checkout-explicit-src/doltlite dolt