### PR TITLE
Replace static-pattern buzhash with Weibull splitter (port from Dolt)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,10 @@ jobs:
       run: cd build && bash ../test/large_scale_test.sh ./doltlite --quick
       timeout-minutes: 5
 
+    - name: Chunk size distribution
+      run: cd build && bash ../test/chunk_distribution_test.sh ./doltlite
+      timeout-minutes: 5
+
     - name: Multi-table test
       run: cd build && bash ../test/multi_table_test.sh ./doltlite --quick
       timeout-minutes: 5

--- a/main.mk
+++ b/main.mk
@@ -551,7 +551,7 @@ LIBOBJS0 = alter.o analyze.o attach.o auth.o \
 #
 # Prolly tree engine objects (when DOLTLITE_PROLLY=1)
 #
-PROLLY_OBJS = prolly_hash.o prolly_hashset.o prolly_arena.o prolly_node.o prolly_cache.o \
+PROLLY_OBJS = prolly_hash.o prolly_xxhash.o prolly_hashset.o prolly_arena.o prolly_node.o prolly_cache.o \
               chunk_store.o prolly_cursor.o prolly_mutmap.o prolly_chunker.o \
               prolly_mutate.o prolly_diff.o prolly_three_way_diff.o prolly_btree.o pager_shim.o sortkey.o \
               doltlite.o doltlite_commit.o doltlite_ref.o doltlite_log.o doltlite_status.o \
@@ -723,6 +723,8 @@ SRC = \
 SRC += \
   $(TOP)/src/prolly_hash.c \
   $(TOP)/src/prolly_hash.h \
+  $(TOP)/src/prolly_xxhash.c \
+  $(TOP)/src/prolly_xxhash.h \
   $(TOP)/src/prolly_arena.c \
   $(TOP)/src/prolly_arena.h \
   $(TOP)/src/prolly_node.c \
@@ -976,6 +978,7 @@ HDR = \
 # Prolly tree engine headers
 HDR += \
    $(TOP)/src/prolly_hash.h \
+   $(TOP)/src/prolly_xxhash.h \
    $(TOP)/src/prolly_arena.h \
    $(TOP)/src/prolly_node.h \
    $(TOP)/src/prolly_cache.h \
@@ -1283,6 +1286,9 @@ btree.o:	$(TOP)/src/btree.c $(DEPS_OBJ_COMMON) $(TOP)/src/pager.h
 # Prolly tree engine compilation rules
 prolly_hash.o:	$(TOP)/src/prolly_hash.c $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/prolly_hash.c
+
+prolly_xxhash.o:	$(TOP)/src/prolly_xxhash.c $(DEPS_OBJ_COMMON)
+	$(T.cc.sqlite) -c $(TOP)/src/prolly_xxhash.c
 
 prolly_hashset.o:	$(TOP)/src/prolly_hashset.c $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/prolly_hashset.c

--- a/src/prolly_chunker.c
+++ b/src/prolly_chunker.c
@@ -3,11 +3,10 @@
 
 #include "prolly_chunker.h"
 #include "prolly_cursor.h"
+#include "prolly_xxhash.h"
 
 #include <string.h>
 #include <assert.h>
-
-#define CHUNKER_WINDOW_SIZE 64
 
 static int initLevel(ProllyChunker *ch, int level);
 static int flushLevel(ProllyChunker *ch, int level);
@@ -30,12 +29,6 @@ static int initLevel(ProllyChunker *ch, int level){
 
 
   prollyNodeBuilderInit(&pLevel->builder, (u8)level, ch->flags);
-
-  rc = prollyRollingHashInit(&pLevel->rh, CHUNKER_WINDOW_SIZE);
-  if( rc!=SQLITE_OK ){
-    prollyNodeBuilderFree(&pLevel->builder);
-    return rc;
-  }
 
   pLevel->nItems = 0;
   pLevel->nBytes = 0;
@@ -91,7 +84,6 @@ static int flushLevel(ProllyChunker *ch, int level){
 
 
   prollyNodeBuilderReset(&pLevel->builder);
-  prollyRollingHashReset(&pLevel->rh);
   pLevel->nItems = 0;
   pLevel->nBytes = 0;
 
@@ -145,7 +137,6 @@ static int finishPropagateLevel(ProllyChunker *ch, int level){
   if( rc!=SQLITE_OK ) return rc;
 
   prollyNodeBuilderReset(&pLevel->builder);
-  prollyRollingHashReset(&pLevel->rh);
   pLevel->nItems = 0;
   pLevel->nBytes = 0;
   return SQLITE_OK;
@@ -156,7 +147,7 @@ static int addToLevel(ProllyChunker *ch, int level,
                       const u8 *pVal, int nVal){
   ProllyChunkerLevel *pLevel;
   int rc;
-  int i;
+  int thisSize;
 
   assert( level >= 0 && level < PROLLY_CURSOR_MAX_DEPTH );
 
@@ -177,22 +168,24 @@ static int addToLevel(ProllyChunker *ch, int level,
 
   pLevel->nItems++;
 
+  thisSize = nKey + nVal;
+  pLevel->nBytes += thisSize;
 
-  for(i = 0; i < nKey; i++){
-    prollyRollingHashUpdate(&pLevel->rh, pKey[i]);
-  }
-
-
-  pLevel->nBytes += nKey + nVal;
-
-  /* Content-defined chunking: the boundary depends on the rolling
-  ** hash of the key bytes, not the byte position. An insertion only
-  ** invalidates chunks whose content changed, not every chunk after
-  ** it — this is what gives prolly trees their structural sharing. */
+  /* Content-defined chunking via Weibull-distribution boundary check.
+  ** Hash is keyed on the row's key bytes (not value), salted by the
+  ** tree level so boundaries don't align across levels. Only chunks
+  ** whose contents changed get re-emitted on edit — this is what
+  ** gives prolly trees their structural sharing. */
   if( pLevel->nBytes >= PROLLY_CHUNK_MIN ){
-    int atBoundary = prollyRollingHashAtBoundary(&pLevel->rh,
-                                                  PROLLY_CHUNK_PATTERN);
-    if( atBoundary || pLevel->nBytes >= PROLLY_CHUNK_MAX ){
+    int atBoundary;
+    if( pLevel->nBytes >= PROLLY_CHUNK_MAX ){
+      atBoundary = 1;
+    } else {
+      u32 h = prollyXXH32(pKey, nKey, (u32)level);
+      atBoundary = prollyWeibullCheck((u32)pLevel->nBytes,
+                                       (u32)thisSize, h);
+    }
+    if( atBoundary ){
       rc = flushLevel(ch, level);
       if( rc!=SQLITE_OK ) return rc;
     }
@@ -258,7 +251,6 @@ int prollyChunkerFinish(ProllyChunker *ch){
 
 
         prollyNodeBuilderReset(&pLevel->builder);
-        prollyRollingHashReset(&pLevel->rh);
         pLevel->nItems = 0;
         pLevel->nBytes = 0;
         return SQLITE_OK;
@@ -293,7 +285,6 @@ void prollyChunkerFree(ProllyChunker *ch){
   int i;
   for(i = 0; i < ch->nLevels; i++){
     prollyNodeBuilderFree(&ch->aLevel[i].builder);
-    prollyRollingHashFree(&ch->aLevel[i].rh);
   }
   ch->nLevels = 0;
 }

--- a/src/prolly_chunker.h
+++ b/src/prolly_chunker.h
@@ -8,25 +8,20 @@
 #include "prolly_cursor.h"
 #include "chunk_store.h"
 
-/* Target is the expected chunk size; MIN/MAX bracket it so a
-** degenerate rolling hash (long runs of zero bytes, repeated keys)
-** still produces bounded chunks. PATTERN is the bitmask the rolling
-** hash is tested against: on average 1/(2^bits) positions match, so
-** 12 zero bits → ~4096 expected chunk size. Changing PATTERN here
-** re-hashes every tree on next write — it's part of the on-disk
-** content-addressing, not a tuning knob. */
-#define PROLLY_CHUNK_TARGET  4096
+/* MIN/MAX bracket the chunk size so degenerate inputs (adversarial
+** keys, hash collisions) still produce bounded chunks. Inside that
+** range, the boundary decision is made by prollyWeibullCheck which
+** biases the distribution toward 4096 bytes (PROLLY_WEIBULL_L in
+** prolly_hash.c). All three values are part of the on-disk content
+** addressing — changing them re-hashes every tree on next write. */
 #define PROLLY_CHUNK_MIN     512
 #define PROLLY_CHUNK_MAX     16384
-
-#define PROLLY_CHUNK_PATTERN 0x00000FFF
 
 typedef struct ProllyChunker ProllyChunker;
 typedef struct ProllyChunkerLevel ProllyChunkerLevel;
 
 struct ProllyChunkerLevel {
   ProllyNodeBuilder builder;
-  ProllyRollingHash rh;
   int nItems;
   int nBytes;
 };

--- a/src/prolly_hash.c
+++ b/src/prolly_hash.c
@@ -114,133 +114,48 @@ int prollyHashIsEmpty(const ProllyHash *h){
   return 1;
 }
 
-static const u32 buzHashTable[256] = {
-  0x6b326ac4U, 0x13f8e1a8U, 0xb240d8d2U, 0x9a7c5e3fU,
-  0x4e5d6c8aU, 0xd8f1b42eU, 0x2a93e670U, 0xf7d40bc1U,
-  0x81c6f09bU, 0x5419d7a3U, 0xc3a82546U, 0x67eb9315U,
-  0xa5f64d89U, 0x3b0e81f4U, 0xe9c23a67U, 0x0d74f6dbU,
-  0x7685ca12U, 0xc03b27e5U, 0x1ea9de90U, 0x8f57634cU,
-  0x42d8b1f7U, 0xfb6e4523U, 0x350c9a6eU, 0xa8e13fb8U,
-  0x5c92d074U, 0xe4ab87c9U, 0x097d5e31U, 0xb6c4a2f6U,
-  0x71384d5aU, 0xcd19e8bfU, 0x28f57603U, 0x946a3bc7U,
-  0xdf81c962U, 0x43b7e015U, 0xfa2d54a9U, 0x1696bf7cU,
-  0x8b4e13d8U, 0x6fd3a846U, 0xc5027f9bU, 0x32e9d160U,
-  0xa41b6523U, 0x587cfa97U, 0xed954e0bU, 0x01a8b3ceU,
-  0xbf632792U, 0x74d69c57U, 0xc8154fdbU, 0x234ae81eU,
-  0x9e8d7ba4U, 0x4cf13069U, 0xd72bc62dU, 0x6a9e51f0U,
-  0xb5040db4U, 0x18e7a279U, 0x8c73693dU, 0xf03cde00U,
-  0x53b814c4U, 0xa76f9b89U, 0x0b92574dU, 0xce26e310U,
-  0x62d18cd5U, 0xd90b4899U, 0x3d67a75cU, 0x81fc3e20U,
-  0xf4a5d1e5U, 0x48396fa9U, 0xbc8e036cU, 0x10c2b830U,
-  0x6517e4f5U, 0xd964a2b9U, 0x2dab5f7cU, 0x91f01b40U,
-  0xe53dc605U, 0x497b8dc9U, 0xbda6428cU, 0x01e3f950U,
-  0x562cae15U, 0xaa706bd9U, 0xfe8d209cU, 0x42c1d760U,
-  0x97148c25U, 0xeb5843e9U, 0x3f95f8acU, 0x83d2af70U,
-  0xd81f6435U, 0x2c5c1bf9U, 0x7098c9bcU, 0xc4d58080U,
-  0x19123745U, 0x6d4fee09U, 0xb18ca4ccU, 0x05c95b90U,
-  0x5a061255U, 0xae43c119U, 0xf28078dcU, 0x46bd2fa0U,
-  0x9afae665U, 0xef379d29U, 0x337454ecU, 0x87b10bb0U,
-  0xdbedc275U, 0x202a7939U, 0x746730fcU, 0xc8a4e7c0U,
-  0x1ce19e85U, 0x611e5549U, 0xb55b0c0cU, 0x0998c3d0U,
-  0x5dd57a95U, 0xa2123159U, 0xf64fe81cU, 0x4a8c9fe0U,
-  0x9ec956a5U, 0xe3060d69U, 0x3743c42cU, 0x8b807bf0U,
-  0xdfbd32b5U, 0x23fae979U, 0x7837a03cU, 0xcc745700U,
-  0x10b10ec5U, 0x64edc589U, 0xb92a7c4cU, 0x0d673310U,
-  0x51a4ead5U, 0xa5e1a199U, 0xfa1e585cU, 0x4e5b0f20U,
-  0xc19783acU, 0x15d43a70U, 0x6a11f135U, 0xbe4ea8f9U,
-  0x028b5fbcU, 0x56c81680U, 0xab05cd45U, 0xff428409U,
-  0x437f3bccU, 0x97bcf290U, 0xebf9a955U, 0x30366019U,
-  0x847317dcU, 0xd8b0cea0U, 0x2ced8565U, 0x712a3c29U,
-  0xc567f3ecU, 0x19a4aab0U, 0x6de16175U, 0xb21e1839U,
-  0x065bcffcU, 0x5a9886c0U, 0xaed53d85U, 0xf312f449U,
-  0x474fab0cU, 0x9b8c62d0U, 0xefc91995U, 0x3406d059U,
-  0x8843871cU, 0xdc803ee0U, 0x20bdf5a5U, 0x74faac69U,
-  0xc937632cU, 0x1d741af0U, 0x61b1d1b5U, 0xb5ee8879U,
-  0x0a2b3f3cU, 0x5e68f600U, 0xa2a5adc5U, 0xf6e26489U,
-  0x4b1f1b4cU, 0x9f5cd210U, 0xe39989d5U, 0x37d64099U,
-  0x8c13f75cU, 0xd050ae20U, 0x248d65e5U, 0x78ca1ca9U,
-  0xcd07d36cU, 0x11448a30U, 0x658140f5U, 0xb9bef7b9U,
-  0x0dfbae7cU, 0x52386540U, 0xa6751c05U, 0xfab2d3c9U,
-  0x4eef8a8cU, 0x932c4150U, 0xe769f815U, 0x3ba6afd9U,
-  0x8fe3669cU, 0xd4201d60U, 0x285dd425U, 0x7c9a8be9U,
-  0xc0d742acU, 0x1514f970U, 0x6951b035U, 0xbd8e67f9U,
-  0x01cb1ebcU, 0x5608d580U, 0xaa458c45U, 0xfe824309U,
-  0x42bffaccU, 0x96fcb190U, 0xeb396855U, 0x3f761f19U,
-  0x83b3d6dcU, 0xd7f08da0U, 0x2c2d4465U, 0x706afb29U,
-  0xc4a7b2ecU, 0x18e469b0U, 0x6d212075U, 0xb15ed739U,
-  0x059b8efcU, 0x59d845c0U, 0xae15fc85U, 0xf252b349U,
-  0x468f6a0cU, 0x9acc21d0U, 0xef09d895U, 0x33468f59U,
-  0x8783461cU, 0xdbc0fde0U, 0x2ffdb4a5U, 0x743a6b69U,
-  0xc877222cU, 0x1cb4d9f0U, 0x60f190b5U, 0xb52e4779U,
-  0x096bfe3cU, 0x5da8b500U, 0xa1e56cc5U, 0xf6222389U,
-  0x4a5fda4cU, 0x9e9c9110U, 0xe2d948d5U, 0x3716ff99U,
-  0x8b53b65cU, 0xdf906d20U, 0x23cd24e5U, 0x780adba9U,
-  0xcc47926cU, 0x10844930U, 0x64c100f5U, 0xb8feb7b9U,
-  0x0d3b6e7cU, 0x51782540U, 0xa5b5dc05U, 0xf9f293c9U,
-  0x4e2f4a8cU, 0x926c0150U, 0xe6a9b815U, 0x3ae66fd9U,
-};
+#include <math.h>
 
-int prollyRollingHashInit(ProllyRollingHash *rh, int windowSize){
-  memset(rh, 0, sizeof(*rh));
-  rh->windowSize = windowSize;
-  rh->window = (u8 *)sqlite3_malloc(windowSize);
-  if( rh->window == 0 ) return SQLITE_NOMEM;
-  memset(rh->window, 0, windowSize);
-  return SQLITE_OK;
-}
+/* Weibull-distribution chunk-boundary check.
+**
+** Ported from Dolt's keySplitter.weibullCheck
+** (go/store/prolly/tree/node_splitter.go). Given that we have not
+** split on any record up through |size - thisSize|, the conditional
+** probability that we should split on the current record is
+**
+**     (CDF(size) - CDF(size - thisSize)) / (1 - CDF(size - thisSize))
+**
+** where CDF is the Weibull CDF with shape K=4, scale L=4096:
+**
+**     CDF(x) = 1 - exp(-(x/L)^K)
+**
+** We split if the uniform sample |hash|/MAX_U32 falls within that
+** conditional probability. Result is a chunk-size distribution that
+** clusters around L (the target) with a much shorter tail than the
+** geometric distribution a static pattern produces.
+**
+** K is hand-unrolled (pow*pow*pow*pow) to avoid pow()/Gamma() calls
+** in the hot path, matching the Dolt implementation. */
+#define PROLLY_WEIBULL_L  4096.0
+#define PROLLY_MAX_U32    4294967295.0
 
-u32 prollyRollingHashUpdate(ProllyRollingHash *rh, u8 byte){
-  u8 outgoing;
-  u32 h;
+int prollyWeibullCheck(u32 size, u32 thisSize, u32 hash){
+  double pow;
+  double start, end;
+  double p, d, target;
 
-  outgoing = rh->window[rh->pos];
-  rh->window[rh->pos] = byte;
-  rh->pos = (rh->pos + 1) % rh->windowSize;
-  if( rh->filled < rh->windowSize ){
-    rh->filled++;
-  }
+  pow = (double)(size - thisSize) / PROLLY_WEIBULL_L;
+  start = -expm1(-(pow * pow * pow * pow));
 
+  pow = (double)size / PROLLY_WEIBULL_L;
+  end = -expm1(-(pow * pow * pow * pow));
 
-  h = rh->hash;
-  h = (h << 1) | (h >> 31);
+  p = (double)hash / PROLLY_MAX_U32;
+  d = 1.0 - start;
+  if( d <= 0.0 ) return 1;
 
-
-  {
-    /* `outHash >> (32 - rot)` is UB when rot == 0 (shift exponent
-    ** equals the full type width, C11 6.5.7/3). Masking with 31
-    ** makes rot=0 a no-op rotation without losing the standard
-    ** rol32 idiom the compiler recognizes for rot in [1, 31]. */
-    u32 outHash = buzHashTable[outgoing];
-    int rot = rh->windowSize % 32;
-    u32 rotatedOut = (outHash << rot) | (outHash >> ((32 - rot) & 31));
-    h ^= rotatedOut;
-  }
-
-
-  h ^= buzHashTable[byte];
-
-  rh->hash = h;
-  return h;
-}
-
-int prollyRollingHashAtBoundary(ProllyRollingHash *rh, u32 pattern){
-  return (rh->hash & pattern) == pattern;
-}
-
-void prollyRollingHashReset(ProllyRollingHash *rh){
-  rh->hash = 0;
-  rh->pos = 0;
-  rh->filled = 0;
-  if( rh->window ){
-    memset(rh->window, 0, rh->windowSize);
-  }
-}
-
-void prollyRollingHashFree(ProllyRollingHash *rh){
-  if( rh->window ){
-    sqlite3_free(rh->window);
-    rh->window = 0;
-  }
+  target = (end - start) / d;
+  return p < target;
 }
 
 #endif

--- a/src/prolly_hash.h
+++ b/src/prolly_hash.h
@@ -17,23 +17,17 @@ int prollyHashCompare(const ProllyHash *a, const ProllyHash *b);
 
 int prollyHashIsEmpty(const ProllyHash *h);
 
-typedef struct ProllyRollingHash ProllyRollingHash;
-struct ProllyRollingHash {
-  u32 hash;
-  int windowSize;
-  int pos;
-  int filled;
-  u8 *window;
-};
-
-int prollyRollingHashInit(ProllyRollingHash *rh, int windowSize);
-
-u32 prollyRollingHashUpdate(ProllyRollingHash *rh, u8 byte);
-
-int prollyRollingHashAtBoundary(ProllyRollingHash *rh, u32 pattern);
-
-void prollyRollingHashReset(ProllyRollingHash *rh);
-
-void prollyRollingHashFree(ProllyRollingHash *rh);
+/* Weibull-distribution chunk-boundary check.
+**
+** Returns 1 if a chunk should split at the current record. Treats
+** `hash` as a uniform random number in [0, 2^32). The probability of
+** splitting rises as `size` approaches the target chunk size, biasing
+** the resulting chunk-size distribution to a Weibull (K=4, L=4096)
+** rather than a geometric distribution. This tightens the cluster
+** around the target size and reduces upward boundary cascades on
+** edits.
+**
+** Ported from Dolt's keySplitter (go/store/prolly/tree/node_splitter.go). */
+int prollyWeibullCheck(u32 size, u32 thisSize, u32 hash);
 
 #endif

--- a/src/prolly_xxhash.c
+++ b/src/prolly_xxhash.c
@@ -1,0 +1,77 @@
+
+#ifdef DOLTLITE_PROLLY
+
+#include "prolly_xxhash.h"
+
+#define XXH_PRIME32_1  0x9E3779B1U
+#define XXH_PRIME32_2  0x85EBCA77U
+#define XXH_PRIME32_3  0xC2B2AE3DU
+#define XXH_PRIME32_4  0x27D4EB2FU
+#define XXH_PRIME32_5  0x165667B1U
+
+static u32 xxh_read32_le(const u8 *p){
+  return (u32)p[0]
+       | ((u32)p[1] << 8)
+       | ((u32)p[2] << 16)
+       | ((u32)p[3] << 24);
+}
+
+static u32 xxh_rotl32(u32 x, int r){
+  return (x << r) | (x >> (32 - r));
+}
+
+static u32 xxh_round(u32 acc, u32 input){
+  acc += input * XXH_PRIME32_2;
+  acc = xxh_rotl32(acc, 13);
+  acc *= XXH_PRIME32_1;
+  return acc;
+}
+
+u32 prollyXXH32(const u8 *p, int n, u32 seed){
+  const u8 *end = p + n;
+  u32 h32;
+
+  if( n >= 16 ){
+    const u8 *limit = end - 16;
+    u32 v1 = seed + XXH_PRIME32_1 + XXH_PRIME32_2;
+    u32 v2 = seed + XXH_PRIME32_2;
+    u32 v3 = seed + 0;
+    u32 v4 = seed - XXH_PRIME32_1;
+
+    do {
+      v1 = xxh_round(v1, xxh_read32_le(p)); p += 4;
+      v2 = xxh_round(v2, xxh_read32_le(p)); p += 4;
+      v3 = xxh_round(v3, xxh_read32_le(p)); p += 4;
+      v4 = xxh_round(v4, xxh_read32_le(p)); p += 4;
+    } while( p <= limit );
+
+    h32 = xxh_rotl32(v1, 1)  + xxh_rotl32(v2, 7)
+        + xxh_rotl32(v3, 12) + xxh_rotl32(v4, 18);
+  } else {
+    h32 = seed + XXH_PRIME32_5;
+  }
+
+  h32 += (u32)n;
+
+  while( p + 4 <= end ){
+    h32 += xxh_read32_le(p) * XXH_PRIME32_3;
+    h32 = xxh_rotl32(h32, 17) * XXH_PRIME32_4;
+    p += 4;
+  }
+
+  while( p < end ){
+    h32 += (u32)(*p) * XXH_PRIME32_5;
+    h32 = xxh_rotl32(h32, 11) * XXH_PRIME32_1;
+    p++;
+  }
+
+  /* final avalanche */
+  h32 ^= h32 >> 15;
+  h32 *= XXH_PRIME32_2;
+  h32 ^= h32 >> 13;
+  h32 *= XXH_PRIME32_3;
+  h32 ^= h32 >> 16;
+  return h32;
+}
+
+#endif

--- a/src/prolly_xxhash.h
+++ b/src/prolly_xxhash.h
@@ -1,0 +1,19 @@
+
+#ifndef SQLITE_PROLLY_XXHASH_H
+#define SQLITE_PROLLY_XXHASH_H
+
+#include "sqliteInt.h"
+
+/* XXH32: 32-bit non-cryptographic hash by Yann Collet.
+**
+** Used by the prolly chunker to derive a uniform u32 from a key, which
+** the Weibull-distribution chunk-boundary check (prollyWeibullCheck)
+** treats as a uniform random number in [0, 2^32).
+**
+** Salting is by `seed`. The chunker passes the tree level as seed so
+** boundaries at different levels don't align on the same keys.
+**
+** Adapted from upstream xxHash (Yann Collet, BSD-2-Clause). */
+u32 prollyXXH32(const u8 *p, int n, u32 seed);
+
+#endif

--- a/test/chunk_distribution_test.sh
+++ b/test/chunk_distribution_test.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+#
+# Chunk size distribution test.
+#
+# After porting Dolt's keySplitter (Weibull-distribution boundary
+# check) to DoltLite, prolly tree chunks should cluster tightly
+# around the 4096-byte target. This test materializes a moderately
+# large database, then walks the chunk store directly and asserts:
+#
+#   - mean prolly chunk size is in [3200, 4500]
+#   - stdev is below 1500 (tighter than the old geometric distribution)
+#   - max observed is below the MAX clamp (16384)
+#   - min observed is at or above the MIN clamp (512)
+#   - median is within 600 bytes of mean (roughly symmetric)
+#   - the bulk of chunks (p10..p90) span < 4000 bytes
+#
+# Usage: bash chunk_distribution_test.sh [path/to/doltlite]
+#
+
+set -u
+set -o pipefail
+
+DOLTLITE="${1:-./doltlite}"
+DBFILE=$(mktemp)
+trap "rm -f $DBFILE" EXIT
+THIS_DIR=$(cd "$(dirname "$0")" && pwd)
+ANALYZER="$THIS_DIR/tools/chunk_size_dist.py"
+
+if [ ! -x "$DOLTLITE" ]; then
+  echo "doltlite binary not found at $DOLTLITE"
+  exit 1
+fi
+if [ ! -f "$ANALYZER" ]; then
+  echo "analyzer not found at $ANALYZER"
+  exit 1
+fi
+
+echo "=== Chunk Distribution Test ==="
+echo
+
+echo "Materializing 50,000-row database..."
+rm -f "$DBFILE"
+"$DOLTLITE" "$DBFILE" >/dev/null <<EOF
+CREATE TABLE t(id INTEGER PRIMARY KEY, k TEXT, v TEXT);
+INSERT INTO t
+  SELECT value, hex(randomblob(20)), hex(randomblob(60))
+  FROM generate_series(1, 50000);
+SELECT dolt_commit('-Am','50k rows');
+EOF
+
+DB_BYTES=$(wc -c < "$DBFILE" | tr -d ' ')
+echo "  database size: $DB_BYTES bytes"
+echo
+
+STATS=$(python3 "$ANALYZER" "$DBFILE" --json)
+echo "$STATS"
+echo
+
+# Assertions
+fail=0
+check() {
+  local name="$1"
+  local expr="$2"
+  local got="$3"
+  if eval "$expr"; then
+    echo "  PASS  $name ($got)"
+  else
+    echo "  FAIL  $name ($got)"
+    fail=$((fail+1))
+  fi
+}
+
+mean=$(echo "$STATS" | python3 -c 'import sys,json;print(json.load(sys.stdin)["prolly_mean"])')
+stdev=$(echo "$STATS" | python3 -c 'import sys,json;print(json.load(sys.stdin)["prolly_stdev"])')
+median=$(echo "$STATS" | python3 -c 'import sys,json;print(json.load(sys.stdin)["prolly_median"])')
+pmin=$(echo "$STATS" | python3 -c 'import sys,json;print(json.load(sys.stdin)["prolly_min"])')
+pmax=$(echo "$STATS" | python3 -c 'import sys,json;print(json.load(sys.stdin)["prolly_max"])')
+p10=$(echo "$STATS" | python3 -c 'import sys,json;print(json.load(sys.stdin)["prolly_p10"])')
+p90=$(echo "$STATS" | python3 -c 'import sys,json;print(json.load(sys.stdin)["prolly_p90"])')
+n=$(echo "$STATS" | python3 -c 'import sys,json;print(json.load(sys.stdin)["prolly_chunks"])')
+
+echo "Assertions:"
+check "enough chunks for stats"           "[ $n -ge 500 ]"                     "$n chunks"
+check "mean in [3200, 4500]"              "python3 -c 'import sys; sys.exit(0 if 3200 <= $mean <= 4500 else 1)'" "mean=$mean"
+check "stdev < 1500"                       "python3 -c 'import sys; sys.exit(0 if $stdev < 1500 else 1)'"        "stdev=$stdev"
+check "max <= MAX clamp (16384)"          "[ $pmax -le 16384 ]"                "max=$pmax"
+check "min >= MIN clamp (512)"            "[ $pmin -ge 512 ]"                  "min=$pmin"
+check "|median - mean| < 600"             "python3 -c 'import sys; sys.exit(0 if abs($median - $mean) < 600 else 1)'" "median=$median, mean=$mean"
+check "p90 - p10 < 4000 (tight middle)"   "python3 -c 'import sys; sys.exit(0 if ($p90 - $p10) < 4000 else 1)'" "p10=$p10, p90=$p90"
+
+echo
+if [ "$fail" -eq 0 ]; then
+  echo "=== Results: all chunk distribution assertions passed ==="
+  exit 0
+else
+  echo "=== Results: $fail assertion(s) failed ==="
+  exit 1
+fi

--- a/test/tools/chunk_size_dist.py
+++ b/test/tools/chunk_size_dist.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Analyze chunk size distribution in a DoltLite database file.
+
+The DB file IS the chunk store. Layout (see src/chunk_store.h):
+
+    [Manifest: 168 bytes at offset 0]
+    [Chunk data region]
+    [Sorted index: nChunks * 32 bytes]
+        each entry: hash(20) + file_offset(8 LE) + data_size(4 LE)
+    [WAL region: append-only]
+        chunk record: tag(0x01) + hash(20) + len_le32(4) + data(len)
+        root record:  tag(0x02) + manifest_snapshot(168)
+
+Reads sizes from the index AND walks the WAL so chunks written since
+the last manifest checkpoint are also counted.
+
+Usage: chunk_size_dist.py <db-file> [--min MIN] [--max MAX]
+                                    [--target N] [--json]
+"""
+import argparse
+import json
+import struct
+import sys
+from statistics import mean, median, stdev
+
+MANIFEST_SIZE = 168
+INDEX_ENTRY_SIZE = 32
+HASH_SIZE = 20
+WAL_TAG_CHUNK = 0x01
+WAL_TAG_ROOT = 0x02
+
+
+def read_manifest(f):
+    f.seek(0)
+    buf = f.read(MANIFEST_SIZE)
+    if len(buf) < MANIFEST_SIZE:
+        raise SystemExit("file too short for manifest")
+    magic = struct.unpack_from("<I", buf, 0)[0]
+    version = struct.unpack_from("<I", buf, 4)[0]
+    if magic != 0x444C5443:
+        raise SystemExit(f"bad magic 0x{magic:08x} (not a DoltLite chunk store)")
+    n_chunks = struct.unpack_from("<I", buf, 28)[0]
+    i_index_offset = struct.unpack_from("<q", buf, 32)[0]
+    n_index_size = struct.unpack_from("<I", buf, 40)[0]
+    i_wal_offset = struct.unpack_from("<q", buf, 84)[0]
+    return {
+        "version": version,
+        "n_chunks": n_chunks,
+        "index_offset": i_index_offset,
+        "index_size": n_index_size,
+        "wal_offset": i_wal_offset,
+    }
+
+
+def read_index(f, manifest):
+    if manifest["index_size"] == 0:
+        return []
+    f.seek(manifest["index_offset"])
+    buf = f.read(manifest["index_size"])
+    sizes = []
+    for off in range(0, len(buf), INDEX_ENTRY_SIZE):
+        size = struct.unpack_from("<I", buf, off + HASH_SIZE + 8)[0]
+        sizes.append(size)
+    return sizes
+
+
+def read_wal_chunks(f, manifest):
+    """Walk the WAL appending chunk records since the last checkpoint."""
+    if manifest["wal_offset"] == 0:
+        return []
+    f.seek(0, 2)
+    eof = f.tell()
+    f.seek(manifest["wal_offset"])
+    sizes = []
+    while f.tell() < eof:
+        tag = f.read(1)
+        if not tag:
+            break
+        if tag[0] == WAL_TAG_CHUNK:
+            f.read(HASH_SIZE)
+            length_buf = f.read(4)
+            if len(length_buf) < 4:
+                break
+            n = struct.unpack("<I", length_buf)[0]
+            sizes.append(n)
+            f.seek(n, 1)
+        elif tag[0] == WAL_TAG_ROOT:
+            f.seek(MANIFEST_SIZE, 1)
+        else:
+            break
+    return sizes
+
+
+def percentile(sorted_xs, p):
+    if not sorted_xs:
+        return 0
+    k = (len(sorted_xs) - 1) * p / 100.0
+    f_idx = int(k)
+    c_idx = min(f_idx + 1, len(sorted_xs) - 1)
+    return sorted_xs[f_idx] + (sorted_xs[c_idx] - sorted_xs[f_idx]) * (k - f_idx)
+
+
+def histogram(sizes, n_buckets=20):
+    if not sizes:
+        return []
+    lo, hi = min(sizes), max(sizes)
+    if lo == hi:
+        return [(lo, hi, len(sizes))]
+    width = (hi - lo) / n_buckets
+    counts = [0] * n_buckets
+    for s in sizes:
+        i = min(int((s - lo) / width), n_buckets - 1)
+        counts[i] += 1
+    return [(int(lo + i * width), int(lo + (i + 1) * width), counts[i])
+            for i in range(n_buckets)]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("dbfile")
+    ap.add_argument("--min", type=int, default=512,
+                    help="prolly chunk MIN clamp (default 512)")
+    ap.add_argument("--max", type=int, default=16384,
+                    help="prolly chunk MAX clamp (default 16384)")
+    ap.add_argument("--target", type=int, default=4096,
+                    help="prolly chunk target / Weibull L (default 4096)")
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args()
+
+    with open(args.dbfile, "rb") as f:
+        manifest = read_manifest(f)
+        index_sizes = read_index(f, manifest)
+        wal_sizes = read_wal_chunks(f, manifest)
+
+    all_sizes = index_sizes + wal_sizes
+    if not all_sizes:
+        raise SystemExit("no chunks found")
+
+    # Separate "prolly-shaped" chunks (>= MIN) from small admin chunks
+    # (commit objects, working-set blobs, catalog, branch refs).
+    prolly_sizes = [s for s in all_sizes if s >= args.min]
+    admin_sizes = [s for s in all_sizes if s < args.min]
+    sorted_p = sorted(prolly_sizes)
+
+    stats = {
+        "total_chunks": len(all_sizes),
+        "index_chunks": len(index_sizes),
+        "wal_chunks": len(wal_sizes),
+        "admin_chunks": len(admin_sizes),
+        "prolly_chunks": len(prolly_sizes),
+        "min_observed": min(all_sizes),
+        "max_observed": max(all_sizes),
+    }
+    if prolly_sizes:
+        stats.update({
+            "prolly_mean": mean(prolly_sizes),
+            "prolly_median": median(prolly_sizes),
+            "prolly_stdev": stdev(prolly_sizes) if len(prolly_sizes) > 1 else 0.0,
+            "prolly_min": min(prolly_sizes),
+            "prolly_max": max(prolly_sizes),
+            "prolly_p10": percentile(sorted_p, 10),
+            "prolly_p50": percentile(sorted_p, 50),
+            "prolly_p90": percentile(sorted_p, 90),
+            "prolly_p99": percentile(sorted_p, 99),
+        })
+
+    if args.json:
+        print(json.dumps(stats, indent=2))
+        return
+
+    print(f"DoltLite chunk store: {args.dbfile}")
+    print(f"  manifest version:   {manifest['version']}")
+    print(f"  total chunks:       {stats['total_chunks']}"
+          f"  (index={stats['index_chunks']}, wal={stats['wal_chunks']})")
+    print(f"  admin chunks (<{args.min}B): {stats['admin_chunks']}")
+    print(f"  prolly chunks (>={args.min}B): {stats['prolly_chunks']}")
+    if not prolly_sizes:
+        return
+
+    print()
+    print("Prolly chunk size distribution:")
+    print(f"  mean:    {stats['prolly_mean']:8.1f} B"
+          f"   (target {args.target}, "
+          f"theoretical Weibull mean ~3713)")
+    print(f"  median:  {stats['prolly_median']:8.1f} B")
+    print(f"  stdev:   {stats['prolly_stdev']:8.1f} B"
+          f"   (Weibull theoretical ~1041)")
+    print(f"  min:     {stats['prolly_min']:8d} B   (clamp {args.min})")
+    print(f"  max:     {stats['prolly_max']:8d} B   (clamp {args.max})")
+    print(f"  p10/p50/p90/p99: {stats['prolly_p10']:.0f} / "
+          f"{stats['prolly_p50']:.0f} / "
+          f"{stats['prolly_p90']:.0f} / "
+          f"{stats['prolly_p99']:.0f}")
+
+    print()
+    print("Histogram (prolly chunks):")
+    hist = histogram(prolly_sizes, n_buckets=20)
+    max_count = max(h[2] for h in hist) or 1
+    for lo, hi, cnt in hist:
+        bar = "#" * int(40 * cnt / max_count)
+        print(f"  [{lo:5d}, {hi:5d}) {cnt:4d} {bar}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Ports Dolt's `keySplitter` (`go/store/prolly/tree/node_splitter.go`) to C. The previous DoltLite chunker used buzhash with a static 12-bit boundary pattern, which yields a **geometric** distribution of chunk sizes — heavy short tail, heavy long tail, and frequent upward boundary cascades on edits.

The new splitter:
- hashes each row's key with **xxhash32**, salted by tree level
- runs a **Weibull CDF** (K=4, L=4096) conditional-probability boundary check
- keeps the same MIN=512 / MAX=16384 clamps for degenerate input

Result: chunk sizes cluster tightly around 4096 bytes, with far fewer pathological short or long chunks. Small edits propagate fewer boundary changes upward. The chunking *shape* now aligns with Dolt's, which matters for read amplification, write amplification, and structural sharing across versions.

## Files

| File | Change |
|---|---|
| `src/prolly_xxhash.{h,c}` | new — vendored XXH32 (BSD-2 from upstream) |
| `src/prolly_hash.{h,c}` | added `prollyWeibullCheck`; removed `ProllyRollingHash` + 256-entry buzhash table + 5 rolling-hash functions |
| `src/prolly_chunker.{h,c}` | rewrote `addToLevel`; removed `rh` field, `PROLLY_CHUNK_PATTERN`, `CHUNKER_WINDOW_SIZE` |
| `main.mk` | `prolly_xxhash.o` wired into `PROLLY_OBJS`, `SRC`, `HDR`, build rule |

Net: +181 / -184.

## ⚠️ BREAKING CHANGE — on-disk format

Chunk boundaries fall at different positions now, so every prolly tree written by this build differs chunk-by-chunk from what older builds wrote. Content hashes for the same logical data are not the same → commit hashes are not stable across this change. **Existing DoltLite databases are not interoperable with this build.**

The next git tag should be `v1.0.0`.

## Local verification

- Build: clean, no warnings
- 10K-row insert + branch + merge smoke test: 10K rows, 5 commits
- `bash test/vc_oracle_merge_test.sh ./doltlite dolt`: 41/41 ✅
- `bash test/vc_oracle_diff_test.sh ./doltlite dolt`: 30/30 ✅
- `bash test/vc_oracle_branch_test.sh ./doltlite dolt`: 41/41 ✅

Version-control semantics are preserved; only the chunking layer is swapped.

## Test plan

- [ ] CI passes (build + full oracle suite + crash recovery)
- [ ] If green, tag merge commit as `v1.0.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)