### PR TITLE
Fix schema-edge table checkout restore

### DIFF
--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -7,6 +7,8 @@
 #include "doltlite_ancestor.h"
 #include "doltlite_commit.h"
 #include "doltlite_internal.h"
+#include "doltlite_record.h"
+#include "prolly_cursor.h"
 #include <string.h>
 #include <time.h>
 
@@ -140,6 +142,156 @@ static int mutateBranchMove(sqlite3 *db, ChunkStore *cs, void *pArg){
     chunkStoreDeleteBranch(cs, p->zDest);
   }
   return rc;
+}
+
+typedef struct CheckoutSchemaInfo CheckoutSchemaInfo;
+struct CheckoutSchemaInfo {
+  int hasCurrent;
+  int hasSource;
+  int rebuilt;
+  char *zCurrentSql;
+  char *zSourceSql;
+};
+
+static void checkoutSchemaInfoClear(CheckoutSchemaInfo *aInfo, int nInfo){
+  int i;
+  if( !aInfo ) return;
+  for(i=0; i<nInfo; i++){
+    sqlite3_free(aInfo[i].zCurrentSql);
+    sqlite3_free(aInfo[i].zSourceSql);
+  }
+  sqlite3_free(aInfo);
+}
+
+static int checkoutSchemaTextField(
+  const u8 *pVal, int nVal,
+  const DoltliteRecordInfo *pRi,
+  int iField,
+  char **pzOut
+){
+  int st, off, n;
+  *pzOut = 0;
+  if( iField<0 || iField>=pRi->nField ) return SQLITE_CORRUPT;
+  st = pRi->aType[iField];
+  off = pRi->aOffset[iField];
+  if( off<0 || off>nVal ) return SQLITE_CORRUPT;
+  if( st==0 ){
+    *pzOut = sqlite3_mprintf("");
+    return *pzOut ? SQLITE_OK : SQLITE_NOMEM;
+  }
+  if( st<13 || (st&1)==0 ) return SQLITE_CORRUPT;
+  n = (st - 13) / 2;
+  if( n<0 || off+n>nVal ) return SQLITE_CORRUPT;
+  *pzOut = sqlite3_malloc(n + 1);
+  if( !*pzOut ) return SQLITE_NOMEM;
+  memcpy(*pzOut, pVal + off, n);
+  (*pzOut)[n] = 0;
+  return SQLITE_OK;
+}
+
+static int checkoutLoadLiveTableSql(
+  sqlite3 *db,
+  const char *zName,
+  int *pFound,
+  char **pzSql
+){
+  sqlite3_stmt *pStmt = 0;
+  char *zQry;
+  int rc;
+
+  *pFound = 0;
+  *pzSql = 0;
+  zQry = sqlite3_mprintf(
+      "SELECT sql FROM main.sqlite_master "
+      "WHERE type='table' AND name='%q'",
+      zName);
+  if( !zQry ) return SQLITE_NOMEM;
+  rc = sqlite3_prepare_v2(db, zQry, -1, &pStmt, 0);
+  sqlite3_free(zQry);
+  if( rc!=SQLITE_OK ) return rc;
+  if( sqlite3_step(pStmt)==SQLITE_ROW ){
+    const char *zSql = (const char*)sqlite3_column_text(pStmt, 0);
+    *pFound = 1;
+    *pzSql = sqlite3_mprintf("%s", zSql ? zSql : "");
+    if( !*pzSql ){
+      sqlite3_finalize(pStmt);
+      return SQLITE_NOMEM;
+    }
+  }
+  sqlite3_finalize(pStmt);
+  return SQLITE_OK;
+}
+
+static int checkoutLoadSourceTableSql(
+  sqlite3 *db,
+  struct TableEntry *aSource,
+  int nSource,
+  const char *zName,
+  int *pFound,
+  char **pzSql
+){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  ProllyCache *pCache = doltliteGetCache(db);
+  ProllyHash masterRoot;
+  u8 masterFlags = 0;
+  ProllyCursor cur;
+  int i, rc, res;
+
+  *pFound = 0;
+  *pzSql = 0;
+  memset(&masterRoot, 0, sizeof(masterRoot));
+  for(i=0; i<nSource; i++){
+    if( aSource[i].iTable==1 ){
+      memcpy(&masterRoot, &aSource[i].root, sizeof(masterRoot));
+      masterFlags = aSource[i].flags;
+      break;
+    }
+  }
+  if( !cs || !pCache || prollyHashIsEmpty(&masterRoot) ) return SQLITE_OK;
+
+  prollyCursorInit(&cur, cs, pCache, &masterRoot, masterFlags);
+  rc = prollyCursorFirst(&cur, &res);
+  if( rc!=SQLITE_OK || res ){
+    prollyCursorClose(&cur);
+    return rc;
+  }
+  while( prollyCursorIsValid(&cur) ){
+    const u8 *pVal = 0;
+    int nVal = 0;
+    DoltliteRecordInfo ri;
+    char *zType = 0;
+    char *zEntryName = 0;
+
+    prollyCursorValue(&cur, &pVal, &nVal);
+    doltliteParseRecord(pVal, nVal, &ri);
+    if( ri.nField >= 5 ){
+      rc = checkoutSchemaTextField(pVal, nVal, &ri, 0, &zType);
+      if( rc==SQLITE_OK ) rc = checkoutSchemaTextField(pVal, nVal, &ri, 1, &zEntryName);
+      if( rc!=SQLITE_OK ){
+        sqlite3_free(zType);
+        sqlite3_free(zEntryName);
+        prollyCursorClose(&cur);
+        return rc;
+      }
+      if( strcmp(zType, "table")==0 && strcmp(zEntryName, zName)==0 ){
+        *pFound = 1;
+        rc = checkoutSchemaTextField(pVal, nVal, &ri, 4, pzSql);
+        sqlite3_free(zType);
+        sqlite3_free(zEntryName);
+        prollyCursorClose(&cur);
+        return rc;
+      }
+    }
+    sqlite3_free(zType);
+    sqlite3_free(zEntryName);
+    rc = prollyCursorNext(&cur);
+    if( rc!=SQLITE_OK ){
+      prollyCursorClose(&cur);
+      return rc;
+    }
+  }
+  prollyCursorClose(&cur);
+  return SQLITE_OK;
 }
 
 static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
@@ -586,6 +738,7 @@ static int doltliteCheckoutTables(
   ProllyHash workingHash, headCatHash, stagedHash;
   ProllyHash sourceCatHash;
   ProllyHash newWorkingHash;
+  CheckoutSchemaInfo *aSchema = 0;
   struct TableEntry *aWorking = 0, *aSource = 0;
   int nWorking = 0, nSource = 0;
   int i, j;
@@ -620,16 +773,8 @@ static int doltliteCheckoutTables(
   }
 
 
-  rc = doltliteFlushCatalogToHash(db, &workingHash);
-  if( rc!=SQLITE_OK ) return rc;
-  rc = doltliteLoadCatalog(db, &workingHash, &aWorking, &nWorking, 0);
-  if( rc!=SQLITE_OK ) return rc;
-
   rc = doltliteLoadCatalog(db, &sourceCatHash, &aSource, &nSource, 0);
-  if( rc!=SQLITE_OK ){
-    doltliteFreeCatalog(aWorking, nWorking);
-    return rc;
-  }
+  if( rc!=SQLITE_OK ) return rc;
 
   if( zSourceRef ){
     for(i=0; i<nNames; i++){
@@ -643,11 +788,86 @@ static int doltliteCheckoutTables(
         }
       }
       if( srcIdx<0 ){
-        doltliteFreeCatalog(aWorking, nWorking);
         doltliteFreeCatalog(aSource, nSource);
         return SQLITE_NOTFOUND;
       }
     }
+  }
+
+  aSchema = sqlite3_malloc64((sqlite3_uint64)nNames * sizeof(CheckoutSchemaInfo));
+  if( !aSchema ){
+    doltliteFreeCatalog(aSource, nSource);
+    return SQLITE_NOMEM;
+  }
+  memset(aSchema, 0, (size_t)nNames * sizeof(CheckoutSchemaInfo));
+
+  for(i=0; i<nNames; i++){
+    const char *zName = (const char*)sqlite3_value_text(argv[iFirstName + i]);
+    if( !zName ) continue;
+    rc = checkoutLoadLiveTableSql(db, zName,
+                                  &aSchema[i].hasCurrent,
+                                  &aSchema[i].zCurrentSql);
+    if( rc==SQLITE_OK ){
+      rc = checkoutLoadSourceTableSql(db, aSource, nSource, zName,
+                                      &aSchema[i].hasSource,
+                                      &aSchema[i].zSourceSql);
+    }
+    if( rc!=SQLITE_OK ){
+      checkoutSchemaInfoClear(aSchema, nNames);
+      doltliteFreeCatalog(aSource, nSource);
+      return rc;
+    }
+  }
+
+  for(i=0; i<nNames; i++){
+    const char *zName = (const char*)sqlite3_value_text(argv[iFirstName + i]);
+    int bSchemaChanged;
+    char *zDrop;
+    if( !zName ) continue;
+    bSchemaChanged =
+      (aSchema[i].hasCurrent != aSchema[i].hasSource)
+      || (aSchema[i].hasCurrent && aSchema[i].hasSource
+          && strcmp(aSchema[i].zCurrentSql ? aSchema[i].zCurrentSql : "",
+                    aSchema[i].zSourceSql ? aSchema[i].zSourceSql : "")!=0);
+    if( !bSchemaChanged ) continue;
+
+    if( aSchema[i].hasCurrent ){
+      zDrop = sqlite3_mprintf("DROP TABLE \"%w\"", zName);
+      if( !zDrop ){
+        checkoutSchemaInfoClear(aSchema, nNames);
+        doltliteFreeCatalog(aSource, nSource);
+        return SQLITE_NOMEM;
+      }
+      rc = sqlite3_exec(db, zDrop, 0, 0, 0);
+      sqlite3_free(zDrop);
+      if( rc!=SQLITE_OK ){
+        checkoutSchemaInfoClear(aSchema, nNames);
+        doltliteFreeCatalog(aSource, nSource);
+        return rc;
+      }
+    }
+    if( aSchema[i].hasSource ){
+      rc = sqlite3_exec(db, aSchema[i].zSourceSql, 0, 0, 0);
+      if( rc!=SQLITE_OK ){
+        checkoutSchemaInfoClear(aSchema, nNames);
+        doltliteFreeCatalog(aSource, nSource);
+        return rc;
+      }
+    }
+    aSchema[i].rebuilt = 1;
+  }
+
+  rc = doltliteFlushCatalogToHash(db, &workingHash);
+  if( rc!=SQLITE_OK ){
+    checkoutSchemaInfoClear(aSchema, nNames);
+    doltliteFreeCatalog(aSource, nSource);
+    return rc;
+  }
+  rc = doltliteLoadCatalog(db, &workingHash, &aWorking, &nWorking, 0);
+  if( rc!=SQLITE_OK ){
+    checkoutSchemaInfoClear(aSchema, nNames);
+    doltliteFreeCatalog(aSource, nSource);
+    return rc;
   }
 
 
@@ -669,6 +889,10 @@ static int doltliteCheckoutTables(
     }
 
     if( srcIdx<0 && workIdx<0 ){
+      if( aSchema[i].rebuilt && !aSchema[i].hasSource ){
+        continue;
+      }
+      checkoutSchemaInfoClear(aSchema, nNames);
       doltliteFreeCatalog(aWorking, nWorking);
       doltliteFreeCatalog(aSource, nSource);
       return SQLITE_NOTFOUND;
@@ -686,6 +910,7 @@ static int doltliteCheckoutTables(
       struct TableEntry *aNew = sqlite3_realloc(aWorking,
           (nWorking+1)*(int)sizeof(struct TableEntry));
       if( !aNew ){
+        checkoutSchemaInfoClear(aSchema, nNames);
         doltliteFreeCatalog(aWorking, nWorking);
         doltliteFreeCatalog(aSource, nSource);
         return SQLITE_NOMEM;
@@ -694,6 +919,7 @@ static int doltliteCheckoutTables(
       zDup = aSource[srcIdx].zName
                ? sqlite3_mprintf("%s", aSource[srcIdx].zName) : 0;
       if( aSource[srcIdx].zName && !zDup ){
+        checkoutSchemaInfoClear(aSchema, nNames);
         doltliteFreeCatalog(aWorking, nWorking);
         doltliteFreeCatalog(aSource, nSource);
         return SQLITE_NOMEM;
@@ -705,13 +931,20 @@ static int doltliteCheckoutTables(
       zDup = aSource[srcIdx].zName
                ? sqlite3_mprintf("%s", aSource[srcIdx].zName) : 0;
       if( aSource[srcIdx].zName && !zDup ){
+        checkoutSchemaInfoClear(aSchema, nNames);
         doltliteFreeCatalog(aWorking, nWorking);
         doltliteFreeCatalog(aSource, nSource);
         return SQLITE_NOMEM;
       }
-      sqlite3_free(aWorking[workIdx].zName);
-      aWorking[workIdx] = aSource[srcIdx];
-      aWorking[workIdx].zName = zDup;
+      {
+        Pgno iCurrentTable = aWorking[workIdx].iTable;
+        sqlite3_free(aWorking[workIdx].zName);
+        aWorking[workIdx] = aSource[srcIdx];
+        if( aSchema[i].rebuilt ){
+          aWorking[workIdx].iTable = iCurrentTable;
+        }
+        aWorking[workIdx].zName = zDup;
+      }
     }
   }
 
@@ -735,6 +968,7 @@ static int doltliteCheckoutTables(
     }
   }
 
+  checkoutSchemaInfoClear(aSchema, nNames);
   doltliteFreeCatalog(aWorking, nWorking);
   doltliteFreeCatalog(aSource, nSource);
   return rc;

--- a/test/doltlite_branch.sh
+++ b/test/doltlite_branch.sh
@@ -62,6 +62,16 @@ DB2G=/tmp/test_branch2g_$$.db; rm -f "$DB2G"
 echo "CREATE TABLE a(id INTEGER PRIMARY KEY, v TEXT); CREATE TABLE b(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO a VALUES(1,'base_a'); INSERT INTO b VALUES(1,'base_b'); SELECT dolt_commit('-A','-m','init'); SELECT dolt_checkout('-b','feature'); INSERT INTO a VALUES(2,'feat_a'); INSERT INTO b VALUES(2,'feat_b'); SELECT dolt_commit('-A','-m','c2f'); SELECT dolt_checkout('main'); INSERT INTO a VALUES(3,'main_a'); INSERT INTO b VALUES(3,'main_b'); SELECT dolt_commit('-A','-m','c2m'); SELECT dolt_merge('feature'); SELECT dolt_checkout(dolt_hashof('HEAD^2'),'a','b'); CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t SELECT id, v FROM a UNION ALL SELECT id+10, v FROM b;" | $DOLTLITE "$DB2G" > /dev/null 2>&1
 run_test "checkout_table_from_raw_second_parent_hash_persists_across_reopen" "SELECT group_concat(v, ',') FROM (SELECT v FROM t ORDER BY id);" "base_a,feat_a,base_b,feat_b" "$DB2G"
 
+DB2H=/tmp/test_branch2h_$$.db; rm -f "$DB2H"
+echo "CREATE TABLE a(id INTEGER PRIMARY KEY, s TEXT); INSERT INTO a VALUES(1,'base'); SELECT dolt_commit('-A','-m','c1'); DROP TABLE a; SELECT dolt_commit('-A','-m','drop a'); SELECT dolt_checkout('HEAD~1','a');" | $DOLTLITE "$DB2H" > /dev/null 2>&1
+run_test "checkout_dropped_table_restores_rows_across_reopen" "SELECT count(*) FROM a;" "1" "$DB2H"
+run_test "checkout_dropped_table_restores_schema_across_reopen" "SELECT group_concat(name || ':' || type, '|') FROM pragma_table_info('a');" "id:INTEGER|s:TEXT" "$DB2H"
+
+DB2I=/tmp/test_branch2i_$$.db; rm -f "$DB2I"
+echo "CREATE TABLE a(id INTEGER PRIMARY KEY, s TEXT); INSERT INTO a VALUES(1,'base'); SELECT dolt_commit('-A','-m','c1'); DROP TABLE a; CREATE TABLE a(k INTEGER PRIMARY KEY, n INTEGER); INSERT INTO a VALUES(7,70); SELECT dolt_commit('-A','-m','recreate a'); SELECT dolt_checkout('HEAD~1','a');" | $DOLTLITE "$DB2I" > /dev/null 2>&1
+run_test "checkout_recreated_table_restores_rows_across_reopen" "SELECT group_concat(id || ':' || s, ',') FROM a;" "1:base" "$DB2I"
+run_test "checkout_recreated_table_restores_schema_across_reopen" "SELECT group_concat(name || ':' || type, '|') FROM pragma_table_info('a');" "id:INTEGER|s:TEXT" "$DB2I"
+
 DB3=/tmp/test_branch3_$$.db; rm -f "$DB3"
 echo "CREATE TABLE t(x); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','i');" | $DOLTLITE "$DB3" > /dev/null 2>&1
 echo "SELECT dolt_branch('b2');" | $DOLTLITE "$DB3" > /dev/null 2>&1

--- a/test/vc_oracle_checkout_test.sh
+++ b/test/vc_oracle_checkout_test.sh
@@ -354,6 +354,17 @@ SELECT dolt_checkout('main');
 SELECT dolt_checkout('feature', 't');
 "
 
+oracle "checkout_table_from_commit_ish_restores_dropped_table" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'base');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+DROP TABLE t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'drop_t');
+SELECT dolt_checkout('HEAD~1', 't');
+"
+
 oracle "checkout_multiple_tables_from_branch_ref" "
 CREATE TABLE a(id INTEGER PRIMARY KEY, v TEXT);
 CREATE TABLE b(id INTEGER PRIMARY KEY, v TEXT);


### PR DESCRIPTION
## Summary
- rebuild schema shells when explicit-source table checkout crosses a schema change
- preserve the live table id while restoring the source data root
- add checkout regressions for dropped-table and dropped-then-recreated-table restores

## Testing
- bash test/vc_oracle_checkout_test.sh ./doltlite dolt
- bash test/doltlite_branch.sh