### PR TITLE
Collapse schema-only status into modified

### DIFF
--- a/src/doltlite_status.c
+++ b/src/doltlite_status.c
@@ -155,15 +155,15 @@ static int compareCatalogs(
       }
       rc = addRow(pCur, zName, staged, "new table");
     }else{
+      int bRootChanged =
+        prollyHashCompare(&pFrom->root, &aTo[i].root)!=0;
+      int bSchemaChanged =
+        !prollyHashIsEmpty(&pFrom->schemaHash)
+        && !prollyHashIsEmpty(&aTo[i].schemaHash)
+        && prollyHashCompare(&pFrom->schemaHash, &aTo[i].schemaHash)!=0;
       rc = SQLITE_OK;
-      if(prollyHashCompare(&pFrom->root, &aTo[i].root)!=0){
+      if( bRootChanged || bSchemaChanged ){
         rc = addRow(pCur, zName, staged, "modified");
-      }
-      if(rc==SQLITE_OK
-       && !prollyHashIsEmpty(&pFrom->schemaHash)
-       && !prollyHashIsEmpty(&aTo[i].schemaHash)
-       && prollyHashCompare(&pFrom->schemaHash, &aTo[i].schemaHash)!=0){
-        rc = addRow(pCur, zName, staged, "schema modified");
       }
     }
     sqlite3_free(zName);

--- a/test/doltlite_reset.sh
+++ b/test/doltlite_reset.sh
@@ -207,8 +207,26 @@ run_test_match "reset_guard_preserves_working_row" \
   "BEGIN; SELECT dolt_merge('feat'); SELECT dolt_reset('--soft'); SELECT 'GV|' || v FROM t; ROLLBACK;" \
   "^GV\\|main$" "$DB8"
 
+DB9=/tmp/test_reset9_$$.db; rm -f "$DB9"
+echo "CREATE TABLE a(id INTEGER PRIMARY KEY, s TEXT); INSERT INTO a VALUES(1,'base'); SELECT dolt_commit('-A','-m','c1'); DROP TABLE a; SELECT dolt_reset('a');" | $DOLTLITE "$DB9" > /dev/null 2>&1
+run_test "path_reset_dropped_table_stays_dropped" \
+  "SELECT count(*) FROM dolt_status WHERE table_name='a' AND staged=0 AND status='deleted';" \
+  "1" "$DB9"
+run_test "path_reset_dropped_table_not_restored_on_reopen" \
+  "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='a';" \
+  "0" "$DB9"
+
+DB10=/tmp/test_reset10_$$.db; rm -f "$DB10"
+echo "CREATE TABLE a(id INTEGER PRIMARY KEY, s TEXT); INSERT INTO a VALUES(1,'base'); SELECT dolt_commit('-A','-m','c1'); DROP TABLE a; CREATE TABLE a(k INTEGER PRIMARY KEY, n INTEGER); INSERT INTO a VALUES(7,70); SELECT dolt_reset('a');" | $DOLTLITE "$DB10" > /dev/null 2>&1
+run_test "path_reset_recreated_table_keeps_live_schema" \
+  "SELECT group_concat(name || ':' || type, '|') FROM pragma_table_info('a');" \
+  "k:INTEGER|n:INTEGER" "$DB10"
+run_test "path_reset_recreated_table_keeps_live_row" \
+  "SELECT k || '|' || n FROM a;" \
+  "7|70" "$DB10"
+
 # Cleanup
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8"
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/vc_oracle_reset_test.sh
+++ b/test/vc_oracle_reset_test.sh
@@ -342,6 +342,52 @@ SELECT dolt_add('-A');
 SELECT dolt_reset('a');
 "
 
+oracle_same_session "reset_path_dropped_table_stays_dropped" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, s TEXT);
+INSERT INTO a VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+DROP TABLE a;
+SELECT dolt_reset('a');
+" "SELECT 'Q|' || count(*) FROM dolt_status
+      WHERE table_name='a' AND staged=0 AND status='deleted';
+SELECT 'Q|' || count(*) FROM dolt_status
+      WHERE table_name='a' AND staged=1;" \
+"CREATE TABLE a(id INTEGER PRIMARY KEY, s TEXT);
+INSERT INTO a VALUES (1, 10);
+CALL dolt_add('-A');
+CALL dolt_commit('-m', 'c1');
+DROP TABLE a;
+CALL dolt_reset('a');
+" "SELECT concat('Q|', count(*)) FROM dolt_status
+      WHERE table_name='a' AND staged=false AND status='deleted';
+SELECT concat('Q|', count(*)) FROM dolt_status
+      WHERE table_name='a' AND staged=true;"
+
+oracle_same_session "reset_path_recreated_table_stays_recreated" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, s TEXT);
+INSERT INTO a VALUES (1, 'base');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+DROP TABLE a;
+CREATE TABLE a(k INTEGER PRIMARY KEY, n INTEGER);
+INSERT INTO a VALUES (7, 70);
+SELECT dolt_reset('a');
+" "SELECT 'Q|' || k || '|' || n FROM a;
+SELECT 'Q|' || count(*) FROM dolt_status
+      WHERE table_name='a' AND staged=0 AND status='modified';" \
+"CREATE TABLE a(id INTEGER PRIMARY KEY, s TEXT);
+INSERT INTO a VALUES (1, 'base');
+CALL dolt_add('-A');
+CALL dolt_commit('-m', 'c1');
+DROP TABLE a;
+CREATE TABLE a(k INTEGER PRIMARY KEY, n INTEGER);
+INSERT INTO a VALUES (7, 70);
+CALL dolt_reset('a');
+" "SELECT concat('Q|', k, '|', n) FROM a;
+SELECT concat('Q|', count(*)) FROM dolt_status
+      WHERE table_name='a' AND staged=false AND status='modified';"
+
 echo "--- error paths ---"
 
 oracle_error "reset_to_nonexistent_ref" "

--- a/test/vc_oracle_status_test.sh
+++ b/test/vc_oracle_status_test.sh
@@ -125,6 +125,42 @@ SELECT dolt_add('t');
 INSERT INTO t VALUES (3, 30);
 "
 
+oracle "schema_only_unstaged_is_modified" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, s TEXT);
+INSERT INTO a VALUES (1, 10);
+SELECT dolt_add('a');
+SELECT dolt_commit('-m', 'seed');
+ALTER TABLE a ADD COLUMN n INT;
+"
+
+oracle "schema_only_staged_is_modified" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, s TEXT);
+INSERT INTO a VALUES (1, 10);
+SELECT dolt_add('a');
+SELECT dolt_commit('-m', 'seed');
+ALTER TABLE a ADD COLUMN n INT;
+SELECT dolt_add('a');
+"
+
+oracle "schema_and_data_unstaged_is_modified" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, s TEXT);
+INSERT INTO a VALUES (1, 10);
+SELECT dolt_add('a');
+SELECT dolt_commit('-m', 'seed');
+UPDATE a SET s = 'x' WHERE id = 1;
+ALTER TABLE a ADD COLUMN n INT;
+"
+
+oracle "drop_recreate_unstaged_is_modified" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, s TEXT);
+INSERT INTO a VALUES (1, 10);
+SELECT dolt_add('a');
+SELECT dolt_commit('-m', 'seed');
+DROP TABLE a;
+CREATE TABLE a(k INTEGER PRIMARY KEY, n INTEGER);
+INSERT INTO a VALUES (7, 70);
+"
+
 echo "--- deletions ---"
 
 oracle "deleted_unstaged" "


### PR DESCRIPTION
## Summary
- collapse schema-only working/staged status diffs into `modified` to match Dolt
- add direct status oracle coverage for schema-only, schema+data, and drop-recreate cases
- add reset coverage proving path-limited reset preserves dropped/recreated working tables as Dolt does

## Testing
- bash test/vc_oracle_status_test.sh ./doltlite dolt
- bash test/vc_oracle_reset_test.sh ./doltlite dolt
- bash test/doltlite_reset.sh