### PR TITLE
README: link to the Why DoltLite? blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ above SQLite's `btree.h` interface (VDBE, query planner, parser) is untouched.
 Everything below it -- the pager and on-disk format -- is replaced with a
 prolly tree engine backed by a single-file content-addressed chunk store.
 
+[Why DoltLite?](https://www.dolthub.com/blog/2026-04-27-why-doltlite/) DoltLite
+can be embedded in any language enabling local-first use cases for Dolt.
+
 ## Building
 
 ### macOS / Linux


### PR DESCRIPTION
## Summary

Adds a one-line link to the [Why DoltLite?](https://www.dolthub.com/blog/2026-04-27-why-doltlite/) blog post as a second paragraph in the opening, right after the technical "what this is" paragraph and before `## Building`.

Kept it as a paragraph rather than a `## Why DoltLite?` section to avoid inserting a heading between the intro and the build instructions — the existing flow stays intact and a reader gets one click out to the motivation if they want it.

## Test plan

- [ ] Render check on github.com/dolthub/doltlite

🤖 Generated with [Claude Code](https://claude.com/claude-code)