### PR TITLE
Match Dolt reset multi-path semantics

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -1978,6 +1978,15 @@ static void doltliteResetFunc(
     goto reset_cleanup;
   }
 
+  /* Dolt's SQL reset only has true path-limited semantics for the
+  ** single-path form. With multiple positional paths it falls back to
+  ** the no-arg unstage-all behavior, even if some names are missing.
+  ** Match that contract instead of treating multi-path reset as an
+  ** atomic per-path operation. */
+  if( nPaths>1 && !isHard && !isSoft && !zRef ){
+    nPaths = 0;
+  }
+
   if( nPaths>0 ){
     if( isHard || isSoft || zRef ){
       sqlite3_result_error(context,

--- a/test/doltlite_reset.sh
+++ b/test/doltlite_reset.sh
@@ -117,6 +117,21 @@ run_test "default_is_soft" \
   "SELECT staged FROM dolt_status;" \
   "0" "$DB3"
 
+DB3B=/tmp/test_reset3b_$$.db; rm -f "$DB3B"
+echo "CREATE TABLE a(x); CREATE TABLE b(y); INSERT INTO a VALUES(1); INSERT INTO b VALUES(1); SELECT dolt_commit('-A','-m','init'); INSERT INTO a VALUES(2); INSERT INTO b VALUES(2); SELECT dolt_add('-A'); SELECT dolt_reset('a','nope');" | $DOLTLITE "$DB3B" > /dev/null 2>&1
+run_test "multipath_reset_with_missing_unstages_all" \
+  "SELECT count(*) FROM dolt_status WHERE staged=1;" \
+  "0" "$DB3B"
+run_test "multipath_reset_with_missing_leaves_both_unstaged" \
+  "SELECT count(*) FROM dolt_status WHERE staged=0;" \
+  "2" "$DB3B"
+
+DB3C=/tmp/test_reset3c_$$.db; rm -f "$DB3C"
+echo "CREATE TABLE a(x); INSERT INTO a VALUES(1); SELECT dolt_commit('-A','-m','init'); INSERT INTO a VALUES(2); SELECT dolt_add('-A'); SELECT dolt_reset('nope','nope2');" | $DOLTLITE "$DB3C" > /dev/null 2>&1
+run_test "multipath_reset_all_missing_unstages_all" \
+  "SELECT count(*) FROM dolt_status WHERE staged=1;" \
+  "0" "$DB3C"
+
 # --- Hard reset persists across reopen ---
 DB4=/tmp/test_reset4_$$.db; rm -f "$DB4"
 echo "CREATE TABLE t(x); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB4" > /dev/null 2>&1
@@ -226,7 +241,7 @@ run_test "path_reset_recreated_table_keeps_live_row" \
   "7|70" "$DB10"
 
 # Cleanup
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10"
+rm -f "$DB" "$DB2" "$DB3" "$DB3B" "$DB3C" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/vc_oracle_reset_test.sh
+++ b/test/vc_oracle_reset_test.sh
@@ -342,6 +342,42 @@ SELECT dolt_add('-A');
 SELECT dolt_reset('a');
 "
 
+oracle "reset_multiple_paths_unstages_all" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, v INT);
+CREATE TABLE b(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO a VALUES (1, 10);
+INSERT INTO b VALUES (1, 100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+INSERT INTO a VALUES (2, 20);
+INSERT INTO b VALUES (2, 200);
+SELECT dolt_add('-A');
+SELECT dolt_reset('a', 'b');
+"
+
+oracle "reset_multiple_paths_with_missing_unstages_all" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, v INT);
+CREATE TABLE b(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO a VALUES (1, 10);
+INSERT INTO b VALUES (1, 100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+INSERT INTO a VALUES (2, 20);
+INSERT INTO b VALUES (2, 200);
+SELECT dolt_add('-A');
+SELECT dolt_reset('a', 'nope');
+"
+
+oracle "reset_multiple_missing_paths_unstages_all" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO a VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+INSERT INTO a VALUES (2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_reset('nope', 'nope2');
+"
+
 oracle_same_session "reset_path_dropped_table_stays_dropped" "
 CREATE TABLE a(id INTEGER PRIMARY KEY, s TEXT);
 INSERT INTO a VALUES (1, 10);


### PR DESCRIPTION
## Summary
- match Dolt's SQL `dolt_reset` behavior for multi-path calls
- treat multi-path path resets as no-arg unstage-all instead of per-path atomic reset
- add oracle and local coverage for valid+missing and all-missing multi-path cases

## Testing
- bash test/vc_oracle_reset_test.sh ./doltlite dolt
- bash test/doltlite_reset.sh