### PR TITLE
Add schema-edge add oracle coverage

### DIFF
--- a/test/vc_oracle_add_test.sh
+++ b/test/vc_oracle_add_test.sh
@@ -89,6 +89,47 @@ oracle_error() {
   fi
 }
 
+oracle_error_poststate() {
+  local name="$1" setup="$2" dl_query="$3" dolt_query="${4:-$3}"
+  local dir="$TMPROOT/${name}_post"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_rc
+  vc_oracle_run_doltlite_script "$dir/dl/db" "$dir/dl.out" "$dir/dl.err" "$setup"
+  dl_rc=$?
+  local dl_post
+  dl_post=$(
+    {
+      printf ".headers off\n.mode list\n.separator '\t'\n%s\n" "$dl_query"
+    } | "$DOLTLITE" "$dir/dl/db" 2>>"$dir/dl.err" \
+      | normalize
+  )
+
+  local dolt_setup
+  dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
+  local dt_rc
+  vc_oracle_run_dolt_script_for_error "$dir/dt" "$dir/dt.out" "$dir/dt.err" "$dolt_setup"
+  dt_rc=$?
+  local dt_post
+  dt_post=$(
+    cd "$dir/dt" || exit 1
+    "$DOLT" sql -r csv -q "$dolt_query" 2>>"$dir/dt.err" \
+      | tail -n +2 | tr -d '"' | normalize
+  )
+
+  if [ "$dl_rc" -ne 0 ] && [ "$dt_rc" -ne 0 ] && [ "$dl_post" = "$dt_post" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite rc: $dl_rc"
+    echo "    dolt rc:     $dt_rc"
+    echo "    doltlite post:"; echo "$dl_post" | sed 's/^/      /'
+    echo "    dolt post:";     echo "$dt_post" | sed 's/^/      /'
+  fi
+}
+
 echo "=== Version Control Oracle Tests: dolt_add ==="
 echo ""
 
@@ -178,6 +219,16 @@ SELECT dolt_add('t');
 INSERT INTO t VALUES (3, 30);
 "
 
+oracle "stage_renamed_and_modified_table" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, s TEXT);
+INSERT INTO a VALUES (1, 'base');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'seed');
+ALTER TABLE a RENAME TO b;
+INSERT INTO b VALUES (2, 'x');
+SELECT dolt_add('b');
+"
+
 echo "--- staging deletions ---"
 
 oracle "stage_dropped_table" "
@@ -195,6 +246,29 @@ INSERT INTO t VALUES (1);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'seed');
 DROP TABLE t;
+SELECT dolt_add('-A');
+"
+
+oracle "stage_recreated_table_as_modified" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, s TEXT);
+INSERT INTO a VALUES (1, 'base');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'seed');
+DROP TABLE a;
+CREATE TABLE a(k INTEGER PRIMARY KEY, n INTEGER);
+INSERT INTO a VALUES (7, 70);
+SELECT dolt_add('a');
+"
+
+oracle "stage_mixed_deleted_and_modified" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, s TEXT);
+CREATE TABLE b(id INTEGER PRIMARY KEY, s TEXT);
+INSERT INTO a VALUES (1, 'base');
+INSERT INTO b VALUES (1, 'base');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'seed');
+DROP TABLE a;
+INSERT INTO b VALUES (2, 'x');
 SELECT dolt_add('-A');
 "
 
@@ -223,6 +297,23 @@ CREATE TABLE t(id INTEGER PRIMARY KEY);
 INSERT INTO t VALUES (1);
 SELECT dolt_add('nonexistent');
 "
+
+oracle_error_poststate "missing_with_valid_path_preserves_unstaged_state" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, s TEXT);
+CREATE TABLE b(id INTEGER PRIMARY KEY, s TEXT);
+INSERT INTO a VALUES (1, 'base');
+INSERT INTO b VALUES (1, 'base');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'seed');
+DROP TABLE a;
+INSERT INTO b VALUES (2, 'x');
+SELECT dolt_add('a', 'missing');
+" "SELECT table_name || char(9) || staged || char(9) || status
+     FROM dolt_status
+    ORDER BY table_name, staged, status;" \
+"SELECT concat(table_name, char(9), staged, char(9), status)
+   FROM dolt_status
+  ORDER BY table_name, staged, status;"
 
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="


### PR DESCRIPTION
## Summary
- add schema-edge oracle coverage for `dolt_add`
- cover renamed+modified staging, drop/recreate same-name staging, mixed deleted+modified staging, and error poststate for valid+missing path mixes
- lock down that failed mixed-path add leaves changes unstaged on both engines

## Testing
- bash test/vc_oracle_add_test.sh /private/tmp/doltlite-master-status-rename2/doltlite dolt
