### PR TITLE
Fix status rename classification after edits

### DIFF
--- a/src/doltlite_status.c
+++ b/src/doltlite_status.c
@@ -8,6 +8,7 @@
 #include "doltlite_commit.h"
 #include "doltlite_internal.h"
 #include "doltlite_ignore.h"
+#include "prolly_cursor.h"
 
 typedef struct StatusRow StatusRow;
 struct StatusRow {
@@ -155,6 +156,52 @@ static int statusSchemaHashMatchesRename(
   return 0;
 }
 
+static int statusRootsShareAnyKey(
+  sqlite3 *db,
+  const struct TableEntry *pOld,
+  const struct TableEntry *pNew
+){
+  ChunkStore *cs;
+  ProllyCache *cache;
+  ProllyCursor curOld, curNew;
+  int rc, res;
+
+  if( !pOld || !pNew ) return 0;
+  if( prollyHashIsEmpty(&pOld->root) || prollyHashIsEmpty(&pNew->root) ) return 0;
+
+  cs = doltliteGetChunkStore(db);
+  cache = doltliteGetCache(db);
+  if( !cs || !cache ) return 0;
+
+  prollyCursorInit(&curOld, cs, cache, &pOld->root, pOld->flags);
+  rc = prollyCursorFirst(&curOld, &res);
+  if( rc!=SQLITE_OK || res!=0 || !prollyCursorIsValid(&curOld) ){
+    prollyCursorClose(&curOld);
+    return 0;
+  }
+
+  prollyCursorInit(&curNew, cs, cache, &pNew->root, pNew->flags);
+  if( pOld->flags & BTREE_INTKEY ){
+    i64 iKey = prollyCursorIntKey(&curOld);
+    rc = prollyCursorSeekInt(&curNew, iKey, &res);
+  }else{
+    const u8 *pKey = 0;
+    int nKey = 0;
+    prollyCursorKey(&curOld, &pKey, &nKey);
+    rc = prollyCursorSeekBlob(&curNew, pKey, nKey, &res);
+  }
+
+  prollyCursorClose(&curOld);
+  if( rc!=SQLITE_OK ){
+    prollyCursorClose(&curNew);
+    return 0;
+  }
+
+  rc = (res==0 && prollyCursorIsValid(&curNew));
+  prollyCursorClose(&curNew);
+  return rc;
+}
+
 /* Detect a rename by stable table identity plus name-insensitive CREATE
 ** TABLE SQL. This preserves rename+edit classification while rejecting
 ** drop+create churn that happens to reuse the same table number. */
@@ -180,8 +227,8 @@ static int isRenamePair(
 
   rc = statusLoadLiveTableSql(db, pB->zName, &foundLive, &zLiveSql);
   if( rc!=SQLITE_OK || !foundLive ) goto rename_done;
-  if( statusCreateNameQuoted(zLiveSql)
-   && statusSchemaHashMatchesRename(&pA->schemaHash, zLiveSql, pA->zName) ){
+  if( statusSchemaHashMatchesRename(&pA->schemaHash, zLiveSql, pA->zName)
+   && statusRootsShareAnyKey(db, pA, pB) ){
     bMatch = 1;
   }
 

--- a/test/vc_oracle_status_test.sh
+++ b/test/vc_oracle_status_test.sh
@@ -209,6 +209,44 @@ INSERT INTO b VALUES (2, 20);
 SELECT dolt_add('b');
 "
 
+oracle "renamed_staged" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('t');
+SELECT dolt_commit('-m', 'seed');
+ALTER TABLE t RENAME TO t2;
+SELECT dolt_add('t2');
+"
+
+oracle "renamed_staged_then_modified_again" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('t');
+SELECT dolt_commit('-m', 'seed');
+ALTER TABLE t RENAME TO t2;
+SELECT dolt_add('t2');
+INSERT INTO t2 VALUES (2, 20);
+"
+
+oracle "rename_chain_unstaged" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1);
+SELECT dolt_add('t');
+SELECT dolt_commit('-m', 'seed');
+ALTER TABLE t RENAME TO t2;
+ALTER TABLE t2 RENAME TO t3;
+"
+
+oracle "rename_chain_staged" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1);
+SELECT dolt_add('t');
+SELECT dolt_commit('-m', 'seed');
+ALTER TABLE t RENAME TO t2;
+ALTER TABLE t2 RENAME TO t3;
+SELECT dolt_add('t3');
+"
+
 echo "--- multi-table ---"
 
 oracle "multi_table_mixed_states" "
@@ -231,6 +269,22 @@ SELECT dolt_add('b');
 SELECT dolt_commit('-m', 'seed');
 DROP TABLE b;
 CREATE TABLE c(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO c VALUES (2, 20);
+"
+
+oracle "multi_table_rename_drop_create_mix" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, v INT);
+CREATE TABLE b(id INTEGER PRIMARY KEY, v INT);
+CREATE TABLE c(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO a VALUES (1, 10);
+INSERT INTO b VALUES (1, 10);
+INSERT INTO c VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'seed');
+ALTER TABLE a RENAME TO a2;
+DROP TABLE b;
+CREATE TABLE d(id INTEGER PRIMARY KEY);
+INSERT INTO d VALUES (1);
 INSERT INTO c VALUES (2, 20);
 "
 


### PR DESCRIPTION
## Summary
- classify renamed-and-edited tables as `renamed` instead of `deleted` + `new table`
- keep same-schema drop/recreate churn classified as `deleted` + `new table`
- add broader rename/mixed-state status oracle coverage

## Testing
- bash test/vc_oracle_status_test.sh ./doltlite dolt