### PR TITLE
Add tag ref and reopen coverage

### DIFF
--- a/test/doltlite_tag.sh
+++ b/test/doltlite_tag.sh
@@ -19,7 +19,24 @@ run_test "tag_message" "SELECT message FROM dolt_tags;" "release one" "$DB"
 echo "INSERT INTO t VALUES(2); SELECT dolt_commit('-A','-m','second');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "tag_specific" \
   "SELECT dolt_tag('v0.9', (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1));" "0" "$DB"
-run_test "two_tags" "SELECT count(*) FROM dolt_tags;" "2" "$DB"
+run_test "tag_head_parent" \
+  "SELECT dolt_tag('parent','HEAD^1');" "0" "$DB"
+run_test "tag_head_tilde" \
+  "SELECT dolt_tag('parenttilde','HEAD~1');" "0" "$DB"
+run_test "four_tags" "SELECT count(*) FROM dolt_tags;" "4" "$DB"
+
+# Branch ref target
+DB2=/tmp/test_tag_branch_$$.db; rm -f "$DB2"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'base');
+SELECT dolt_commit('-A','-m','base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES(2,'feat');
+SELECT dolt_commit('-A','-m','feat');
+SELECT dolt_checkout('main');
+SELECT dolt_tag('feat-tag','feat');" | $DOLTLITE "$DB2" > /dev/null 2>&1
+run_test "tag_branch_ref" "SELECT count(*) FROM dolt_tags WHERE tag_name='feat-tag';" "1" "$DB2"
 
 # Duplicate tag error
 run_test_match "dup_tag" "SELECT dolt_tag('v1.0');" "already exists" "$DB"
@@ -31,7 +48,9 @@ run_test_match "tag_missing_commit" \
 
 # Delete tag
 run_test "delete_tag" "SELECT dolt_tag('-d','v0.9');" "0" "$DB"
-run_test "one_tag_left" "SELECT count(*) FROM dolt_tags;" "1" "$DB"
+run_test "delete_and_recreate_same_name" "SELECT dolt_tag('-d','parenttilde'); SELECT dolt_tag('parenttilde');" "0
+0" "$DB"
+run_test "three_tags_left" "SELECT count(*) FROM dolt_tags;" "3" "$DB"
 run_test_match "delete_tag_extra_arg" \
   "SELECT dolt_tag('-d','v1.0','extra');" \
   "too many positional arguments to dolt_tag" "$DB"
@@ -42,9 +61,11 @@ run_test "delete_extra_arg_keeps_tag" \
 run_test_match "delete_missing" "SELECT dolt_tag('-d','nope');" "not found" "$DB"
 
 # Tag persists across reopen
-run_test "tag_persists" "SELECT tag_name FROM dolt_tags;" "v1.0" "$DB"
+run_test "tag_persists" "SELECT tag_name FROM dolt_tags ORDER BY tag_name;" "parent
+parenttilde
+v1.0" "$DB"
 
-rm -f "$DB"
+rm -f "$DB" "$DB2"
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
 if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi

--- a/test/vc_oracle_tags_test.sh
+++ b/test/vc_oracle_tags_test.sh
@@ -181,6 +181,42 @@ SELECT dolt_commit('-m', 'c2');
 SELECT dolt_tag('historical', (SELECT commit_hash FROM dolt_log WHERE message='c1'));
 "
 
+oracle "tag_parent_ref_head_parent" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+INSERT INTO t VALUES (2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2');
+SELECT dolt_tag('parent', 'HEAD^1');
+"
+
+oracle "tag_parent_ref_head_tilde" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+INSERT INTO t VALUES (2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2');
+SELECT dolt_tag('parenttilde', 'HEAD~1');
+"
+
+oracle "tag_branch_ref" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'base');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES (2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat');
+SELECT dolt_checkout('main');
+SELECT dolt_tag('feat-tag', 'feat');
+"
+
 echo "--- deletion ---"
 
 oracle "delete_tag" "
@@ -200,6 +236,16 @@ SELECT dolt_commit('-m', 'first');
 SELECT dolt_tag('keep');
 SELECT dolt_tag('drop');
 SELECT dolt_tag('-d', 'drop');
+"
+
+oracle "delete_and_recreate_same_name" "
+CREATE TABLE t(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES (1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'first');
+SELECT dolt_tag('temp');
+SELECT dolt_tag('-d', 'temp');
+SELECT dolt_tag('temp');
 "
 
 echo "--- savepoint parity ---"


### PR DESCRIPTION
## Summary
- add `dolt_tag` coverage for parent-ref targets, branch-ref targets, delete/recreate, and reopen persistence
- expand the cross-engine tags oracle and the local tag regression script

## Testing
- bash test/vc_oracle_tags_test.sh /private/tmp/doltlite-master-nextmenu/doltlite dolt
- bash test/doltlite_tag.sh