### PR TITLE
Add history ref branch coverage

### DIFF
--- a/test/doltlite_history.sh
+++ b/test/doltlite_history.sh
@@ -158,6 +158,46 @@ run_test_match "merge_count" "SELECT count(*) FROM dolt_history_t;" "^[6-9]" "$D
 rm -f "$DB"
 
 # ============================================================
+# History on branches created from tags and merge parents
+# ============================================================
+
+DB=/tmp/test_hist_ref_branches_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'base');
+SELECT dolt_commit('-A','-m','c1');
+INSERT INTO t VALUES(2,'c2');
+SELECT dolt_commit('-A','-m','c2');
+SELECT dolt_tag('v1','HEAD~1');
+SELECT dolt_branch('from_tag','v1');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test "history_from_tag_branch_reopen_distinct_commits" "SELECT count(DISTINCT commit_hash) FROM dolt_history_t;" "1" "$DB/from_tag"
+
+rm -f "$DB"
+
+DB=/tmp/test_hist_parent_branches_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'base');
+SELECT dolt_commit('-A','-m','c1');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES(2,'feat');
+SELECT dolt_commit('-A','-m','feat1');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(3,'main');
+SELECT dolt_commit('-A','-m','main2');
+SELECT dolt_merge('feat');
+SELECT dolt_branch('from_p1','HEAD^1');
+SELECT dolt_branch('from_p2','HEAD^2');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test "history_from_first_parent_branch_reopen_distinct_commits" "SELECT count(DISTINCT commit_hash) FROM dolt_history_t;" "2" "$DB/from_p1"
+run_test "history_from_second_parent_branch_reopen_distinct_commits" "SELECT count(DISTINCT commit_hash) FROM dolt_history_t;" "2" "$DB/from_p2"
+
+HASH=$(echo "SELECT dolt_hashof('HEAD^2');" | $DOLTLITE "$DB" 2>&1)
+run_test "history_filter_second_parent_hash" "SELECT count(DISTINCT commit_hash) FROM dolt_history_t WHERE commit_hash='$HASH';" "1" "$DB"
+
+rm -f "$DB"
+
+# ============================================================
 # Empty table has no history
 # ============================================================
 

--- a/test/vc_oracle_history_test.sh
+++ b/test/vc_oracle_history_test.sh
@@ -243,6 +243,16 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'feat1');
 "
 
+oracle "history_on_branch_created_from_tag" "
+$SEED
+INSERT INTO t VALUES (3, 30);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c2');
+SELECT dolt_tag('v1', 'HEAD~1');
+SELECT dolt_branch('from_tag', 'v1');
+SELECT dolt_checkout('from_tag');
+"
+
 # After a merge, history on main includes commits from both sides
 # (including the merge commit itself).
 oracle "history_after_merge" "
@@ -257,6 +267,38 @@ INSERT INTO t VALUES (4, 40);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'main2');
 SELECT dolt_merge('feature');
+"
+
+oracle "history_on_branch_created_from_first_parent" "
+$SEED
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (3, 30);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat1');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES (4, 40);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main2');
+SELECT dolt_merge('feature');
+SELECT dolt_branch('from_p1', 'HEAD^1');
+SELECT dolt_checkout('from_p1');
+"
+
+oracle "history_on_branch_created_from_second_parent" "
+$SEED
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+INSERT INTO t VALUES (3, 30);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat1');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES (4, 40);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main2');
+SELECT dolt_merge('feature');
+SELECT dolt_branch('from_p2', 'HEAD^2');
+SELECT dolt_checkout('from_p2');
 "
 
 echo "--- edge cases ---"


### PR DESCRIPTION
## Summary
- add dolt_history oracle coverage for branches created from tag refs and merge parent refs
- add local reopen coverage for dolt_history on branches created from tags and merge parents
- add a raw second-parent hash filter check for history rows

## Testing
- bash test/vc_oracle_history_test.sh /private/tmp/doltlite-master-nextmenu/doltlite dolt
- bash test/doltlite_history.sh