### PR TITLE
Fix disjoint schema merge followups

### DIFF
--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -179,8 +179,10 @@ void doltliteSetAuthorEmail(sqlite3 *db, const char *zEmail);
 typedef struct SchemaEntry SchemaEntry;
 struct SchemaEntry {
   char *zName;
+  char *zTblName;
   char *zSql;
   char *zType;
+  Pgno iRootpage;
 };
 
 int loadSchemaFromCatalog(sqlite3 *db, ChunkStore *cs, ProllyCache *pCache,

--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -1321,6 +1321,140 @@ done:
   return result;
 }
 
+static int schemaEntryChangedByName(
+  SchemaEntry *aAnc, int nAnc,
+  SchemaEntry *aSide, int nSide,
+  const char *zName
+){
+  SchemaEntry *pAnc = findSchemaEntry(aAnc, nAnc, zName);
+  SchemaEntry *pSide = findSchemaEntry(aSide, nSide, zName);
+  if( pAnc==0 && pSide==0 ) return 0;
+  if( pAnc==0 || pSide==0 ) return 1;
+  if( pAnc->zType && pSide->zType
+   && strcmp(pAnc->zType, pSide->zType)!=0 ) return 1;
+  if( pAnc->zTblName && pSide->zTblName
+   && strcmp(pAnc->zTblName, pSide->zTblName)!=0 ) return 1;
+  if( (pAnc->zSql==0) != (pSide->zSql==0) ) return 1;
+  if( pAnc->zSql && strcmp(pAnc->zSql, pSide->zSql)!=0 ) return 1;
+  return 0;
+}
+
+static int schemaChangesOverlapByName(
+  SchemaEntry *aAnc, int nAnc,
+  SchemaEntry *aOurs, int nOurs,
+  SchemaEntry *aTheirs, int nTheirs
+){
+  int i;
+  for(i=0; i<nOurs; i++){
+    const char *zName = aOurs[i].zName;
+    if( !zName ) continue;
+    if( schemaEntryChangedByName(aAnc, nAnc, aOurs, nOurs, zName)
+     && schemaEntryChangedByName(aAnc, nAnc, aTheirs, nTheirs, zName) ){
+      return 1;
+    }
+  }
+  for(i=0; i<nAnc; i++){
+    const char *zName = aAnc[i].zName;
+    if( !zName ) continue;
+    if( findSchemaEntry(aOurs, nOurs, zName) ) continue;
+    if( schemaEntryChangedByName(aAnc, nAnc, aTheirs, nTheirs, zName) ){
+      return 1;
+    }
+  }
+  return 0;
+}
+
+static int catalogHasDisjointSchemaChanges(
+  sqlite3 *db,
+  const ProllyHash *pCatAnc,
+  const ProllyHash *pCatOurs,
+  const ProllyHash *pCatTheirs
+){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  ProllyCache *pCache = doltliteGetCache(db);
+  SchemaEntry *aAncSchema = 0, *aOursSchema = 0, *aTheirsSchema = 0;
+  int nAncSchema = 0, nOursSchema = 0, nTheirsSchema = 0;
+  int i, rc;
+  int sawOursChanged = 0, sawTheirsChanged = 0;
+  int result = 0;
+
+  if( !cs || !pCache ) return 0;
+  rc = loadSchemaFromCatalog(db, cs, pCache, pCatAnc, &aAncSchema, &nAncSchema);
+  if( rc!=SQLITE_OK ) goto done;
+  rc = loadSchemaFromCatalog(db, cs, pCache, pCatOurs, &aOursSchema, &nOursSchema);
+  if( rc!=SQLITE_OK ) goto done;
+  rc = loadSchemaFromCatalog(db, cs, pCache, pCatTheirs, &aTheirsSchema, &nTheirsSchema);
+  if( rc!=SQLITE_OK ) goto done;
+
+  for(i=0; i<nOursSchema; i++){
+    if( aOursSchema[i].zName
+     && schemaEntryChangedByName(aAncSchema, nAncSchema,
+                                 aOursSchema, nOursSchema,
+                                 aOursSchema[i].zName) ){
+      sawOursChanged = 1;
+      break;
+    }
+  }
+  if( !sawOursChanged ){
+    for(i=0; i<nAncSchema; i++){
+      if( aAncSchema[i].zName
+       && !findSchemaEntry(aOursSchema, nOursSchema, aAncSchema[i].zName) ){
+        sawOursChanged = 1;
+        break;
+      }
+    }
+  }
+
+  for(i=0; i<nTheirsSchema; i++){
+    if( aTheirsSchema[i].zName
+     && schemaEntryChangedByName(aAncSchema, nAncSchema,
+                                 aTheirsSchema, nTheirsSchema,
+                                 aTheirsSchema[i].zName) ){
+      sawTheirsChanged = 1;
+      break;
+    }
+  }
+  if( !sawTheirsChanged ){
+    for(i=0; i<nAncSchema; i++){
+      if( aAncSchema[i].zName
+       && !findSchemaEntry(aTheirsSchema, nTheirsSchema, aAncSchema[i].zName) ){
+        sawTheirsChanged = 1;
+        break;
+      }
+    }
+  }
+
+  if( sawOursChanged && sawTheirsChanged
+   && !schemaChangesOverlapByName(aAncSchema, nAncSchema,
+                                  aOursSchema, nOursSchema,
+                                  aTheirsSchema, nTheirsSchema) ){
+    result = 1;
+  }
+done:
+  freeSchemaEntries(aAncSchema, nAncSchema);
+  freeSchemaEntries(aOursSchema, nOursSchema);
+  freeSchemaEntries(aTheirsSchema, nTheirsSchema);
+  return result;
+}
+
+typedef struct SchemaRootpageRemap SchemaRootpageRemap;
+struct SchemaRootpageRemap {
+  Pgno oldPg;
+  Pgno newPg;
+};
+
+static Pgno remapSchemaRootpage(
+  SchemaRootpageRemap *aRemap,
+  int nRemap,
+  Pgno iRootpage
+){
+  int i;
+  for(i=0; i<nRemap; i++){
+    if( aRemap[i].oldPg==iRootpage ) return aRemap[i].newPg;
+  }
+  return iRootpage;
+}
+
 typedef struct MergeFieldValue MergeFieldValue;
 struct MergeFieldValue {
   int eType;
@@ -1429,20 +1563,62 @@ static u8 *buildSchemaCatalogRecord(
   return pOut;
 }
 
-static int mergeDisjointNewTableSchemaRows(
+static SchemaEntry *mergedSchemaChoice(
+  SchemaEntry *aAncSchema, int nAncSchema,
+  SchemaEntry *aOursSchema, int nOursSchema,
+  SchemaEntry *aTheirsSchema, int nTheirsSchema,
+  const char *zName
+){
+  SchemaEntry *pAnc = findSchemaEntry(aAncSchema, nAncSchema, zName);
+  SchemaEntry *pOurs = findSchemaEntry(aOursSchema, nOursSchema, zName);
+  SchemaEntry *pTheirs = findSchemaEntry(aTheirsSchema, nTheirsSchema, zName);
+  int oursChanged = schemaEntryChangedByName(aAncSchema, nAncSchema,
+                                             aOursSchema, nOursSchema, zName);
+  int theirsChanged = schemaEntryChangedByName(aAncSchema, nAncSchema,
+                                               aTheirsSchema, nTheirsSchema, zName);
+  if( oursChanged && !theirsChanged ) return pOurs;
+  if( theirsChanged && !oursChanged ) return pTheirs;
+  if( pOurs ) return pOurs;
+  if( pTheirs ) return pTheirs;
+  return pAnc;
+}
+
+static int appendMergedSchemaCatalogRecord(
+  sqlite3 *db,
+  ProllyHash *pRoot,
+  u8 flags,
+  const SchemaEntry *pSe,
+  Pgno iRootpage
+){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  ProllyCache *pCache = doltliteGetCache(db);
+  u8 *pRec = 0;
+  int nRec = 0;
+  int rc;
+
+  if( !pSe || !pSe->zName || !pSe->zType || !pSe->zSql ) return SQLITE_OK;
+  pRec = buildSchemaCatalogRecord(pSe->zType, pSe->zName,
+                                  pSe->zTblName ? pSe->zTblName : pSe->zName,
+                                  (i64)iRootpage, pSe->zSql, &nRec);
+  if( !pRec ) return SQLITE_NOMEM;
+  rc = prollyMutateInsert(cs, pCache, pRoot, flags, 0, 0,
+                          (i64)iRootpage, pRec, nRec, pRoot);
+  sqlite3_free(pRec);
+  return rc;
+}
+
+static int rebuildDisjointSchemaRows(
   sqlite3 *db,
   struct TableEntry *aMerged, int nMerged,
   SchemaEntry *aTheirsSchema, int nTheirsSchema,
   SchemaEntry *aAncSchema, int nAncSchema,
-  SchemaEntry *aOursSchema, int nOursSchema
+  SchemaEntry *aOursSchema, int nOursSchema,
+  SchemaRootpageRemap *aRemap, int nRemap
 ){
-  ChunkStore *cs = doltliteGetChunkStore(db);
-  ProllyCache *pCache = doltliteGetCache(db);
   struct TableEntry *pMaster = 0;
   ProllyHash root;
   int i, rc = SQLITE_OK;
 
-  if( !cs || !pCache ) return SQLITE_OK;
   for(i=0; i<nMerged; i++){
     if( aMerged[i].iTable==1 ){
       pMaster = &aMerged[i];
@@ -1455,23 +1631,49 @@ static int mergeDisjointNewTableSchemaRows(
   for(i=0; i<nMerged; i++){
     const char *zName = aMerged[i].zName;
     SchemaEntry *pSe = 0;
-    u8 *pRec = 0;
-    int nRec = 0;
 
     if( aMerged[i].iTable<=1 || !zName ) continue;
-    pSe = findSchemaEntry(aOursSchema, nOursSchema, zName);
-    if( !pSe ) pSe = findSchemaEntry(aTheirsSchema, nTheirsSchema, zName);
-    if( !pSe ) pSe = findSchemaEntry(aAncSchema, nAncSchema, zName);
-    if( !pSe || !pSe->zType || !pSe->zSql ) continue;
-    if( strcmp(pSe->zType, "table")!=0 ) continue;
+    pSe = mergedSchemaChoice(aAncSchema, nAncSchema,
+                             aOursSchema, nOursSchema,
+                             aTheirsSchema, nTheirsSchema,
+                             zName);
+    rc = appendMergedSchemaCatalogRecord(db, &root, pMaster->flags,
+                                         pSe, aMerged[i].iTable);
+    if( rc!=SQLITE_OK ) return rc;
+  }
 
-    pRec = buildSchemaCatalogRecord("table", zName, zName,
-                                    (i64)aMerged[i].iTable,
-                                    pSe->zSql, &nRec);
-    if( !pRec ) return SQLITE_NOMEM;
-    rc = prollyMutateInsert(cs, pCache, &root, pMaster->flags,
-                            0, 0, (i64)aMerged[i].iTable, pRec, nRec, &root);
-    sqlite3_free(pRec);
+  for(i=0; i<nOursSchema; i++){
+    SchemaEntry *pSe = &aOursSchema[i];
+    if( !pSe->zName || !pSe->zType ) continue;
+    if( strcmp(pSe->zType, "index")!=0 ) continue;
+    if( !schemaEntryChangedByName(aAncSchema, nAncSchema,
+                                  aOursSchema, nOursSchema,
+                                  pSe->zName) ){
+      continue;
+    }
+    rc = appendMergedSchemaCatalogRecord(db, &root, pMaster->flags,
+                                         pSe, pSe->iRootpage);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+
+  for(i=0; i<nTheirsSchema; i++){
+    SchemaEntry *pSe = &aTheirsSchema[i];
+    Pgno iRootpage;
+    if( !pSe->zName || !pSe->zType ) continue;
+    if( strcmp(pSe->zType, "index")!=0 ) continue;
+    if( !schemaEntryChangedByName(aAncSchema, nAncSchema,
+                                  aTheirsSchema, nTheirsSchema,
+                                  pSe->zName) ){
+      continue;
+    }
+    if( schemaEntryChangedByName(aAncSchema, nAncSchema,
+                                 aOursSchema, nOursSchema,
+                                 pSe->zName) ){
+      continue;
+    }
+    iRootpage = remapSchemaRootpage(aRemap, nRemap, pSe->iRootpage);
+    rc = appendMergedSchemaCatalogRecord(db, &root, pMaster->flags,
+                                         pSe, iRootpage);
     if( rc!=SQLITE_OK ) return rc;
   }
 
@@ -1590,7 +1792,8 @@ static int mergeCatalogPass1(
   const ProllyHash *pCatAnc,
   const ProllyHash *pCatOurs,
   const ProllyHash *pCatTheirs,
-  SchemaMergeAction **ppSchemaActions, int *pnSchemaActions
+  SchemaMergeAction **ppSchemaActions, int *pnSchemaActions,
+  int bDisjointSchemaChanges
 ){
   int i, rc = SQLITE_OK;
   int iTable1Idx = -1;
@@ -1627,6 +1830,11 @@ do_merge_entry:
     if( !ancEntry ){
 
       if( theirsEntry ){
+
+        if( !zName && bDisjointSchemaChanges ){
+          aMerged[(*pnMerged)++] = aOurs[i];
+          continue;
+        }
 
         if( prollyHashCompare(&aOurs[i].root, &theirsEntry->root)!=0
          || prollyHashCompare(&aOurs[i].schemaHash, &theirsEntry->schemaHash)!=0 ){
@@ -1791,13 +1999,10 @@ do_merge_entry:
     }else{
       int oursChanged = prollyHashCompare(&aOurs[iTable1Idx].root, &ancEntry->root)!=0;
       int theirsChanged = prollyHashCompare(&theirsEntry->root, &ancEntry->root)!=0;
-      int disjointNewNamedEntries = catalogHasDisjointNewTables(
-          db, pCatAnc, pCatOurs, pCatTheirs);
-
       if( oursChanged && theirsChanged && hasSchemaActions ){
 
         aMerged[(*pnMerged)++] = aOurs[iTable1Idx];
-      }else if( oursChanged && theirsChanged && disjointNewNamedEntries ){
+      }else if( oursChanged && theirsChanged && bDisjointSchemaChanges ){
 
         aMerged[(*pnMerged)++] = aOurs[iTable1Idx];
       }else if( oursChanged && theirsChanged ){
@@ -1854,7 +2059,10 @@ static int mergeCatalogPass2(
   struct TableEntry *aOurs, int nOurs,
   struct TableEntry *aTheirs, int nTheirs,
   struct TableEntry *aMerged, int *pnMerged,
-  Pgno *piNextMerged
+  Pgno *piNextMerged,
+  int bDisjointSchemaChanges,
+  SchemaRootpageRemap **ppaRemap,
+  int *pnRemap
 ){
   int i;
 
@@ -1871,6 +2079,25 @@ static int mergeCatalogPass2(
         struct TableEntry newEntry = aTheirs[i];
         if( newEntry.iTable >= *piNextMerged ) *piNextMerged = newEntry.iTable + 1;
         aMerged[(*pnMerged)++] = newEntry;
+      }else if( bDisjointSchemaChanges ){
+        struct TableEntry *oursIdx = findTableEntry(aOurs, nOurs, aTheirs[i].iTable);
+        struct TableEntry *ancIdx = findTableEntry(aAnc, nAnc, aTheirs[i].iTable);
+        if( oursIdx && !ancIdx
+         && (prollyHashCompare(&oursIdx->root, &aTheirs[i].root)!=0
+             || prollyHashCompare(&oursIdx->schemaHash, &aTheirs[i].schemaHash)!=0) ){
+          struct TableEntry newEntry = aTheirs[i];
+          SchemaRootpageRemap *aNew;
+          int nOld = *pnRemap;
+          newEntry.iTable = (*piNextMerged)++;
+          aMerged[(*pnMerged)++] = newEntry;
+          aNew = sqlite3_realloc(*ppaRemap,
+                                 (nOld+1)*(int)sizeof(SchemaRootpageRemap));
+          if( !aNew ) return SQLITE_NOMEM;
+          *ppaRemap = aNew;
+          aNew[nOld].oldPg = aTheirs[i].iTable;
+          aNew[nOld].newPg = newEntry.iTable;
+          *pnRemap = nOld + 1;
+        }
       }
       continue;
     }
@@ -1987,6 +2214,9 @@ int doltliteMergeCatalogs(
   Pgno iNextMerged;
   int rc;
   int totalConflicts = 0;
+  int bDisjointSchemaChanges = 0;
+  SchemaRootpageRemap *aRemap = 0;
+  int nRemap = 0;
 
   MergeConflictTable *aConflictTables = 0;
   int nConflictTables = 0;
@@ -2003,6 +2233,7 @@ int doltliteMergeCatalogs(
 
 
   iNextMerged = iNextOurs > iNextTheirs ? iNextOurs : iNextTheirs;
+  bDisjointSchemaChanges = catalogHasDisjointSchemaChanges(db, ancestor, ours, theirs);
 
 
 
@@ -2011,7 +2242,8 @@ int doltliteMergeCatalogs(
                           &aConflictTables, &nConflictTables,
                           &totalConflicts, pzErrMsg,
                           ancestor, ours, theirs,
-                          ppActions, pnActions);
+                          ppActions, pnActions,
+                          bDisjointSchemaChanges);
   if( rc!=SQLITE_OK ){
     /* pass1 shallow-copies zName pointers from aOurs into aMerged.
     ** The strdup loop below (which breaks the aliasing) hasn't run
@@ -2043,10 +2275,12 @@ int doltliteMergeCatalogs(
   }
 
   rc = mergeCatalogPass2(aAnc, nAnc, aOurs, nOurs, aTheirs, nTheirs,
-                          aMerged, &nMerged, &iNextMerged);
+                          aMerged, &nMerged, &iNextMerged,
+                          bDisjointSchemaChanges,
+                          &aRemap, &nRemap);
   if( rc!=SQLITE_OK ) goto merge_cleanup;
 
-  if( catalogHasDisjointNewTables(db, ancestor, ours, theirs) ){
+  if( bDisjointSchemaChanges ){
     ChunkStore *cs = doltliteGetChunkStore(db);
     ProllyCache *pCache = doltliteGetCache(db);
     SchemaEntry *aAncSchema = 0, *aOursSchema = 0, *aTheirsSchema = 0;
@@ -2056,10 +2290,11 @@ int doltliteMergeCatalogs(
     if( rc==SQLITE_OK ) rc = loadSchemaFromCatalog(db, cs, pCache, ours, &aOursSchema, &nOursSchema);
     if( rc==SQLITE_OK ) rc = loadSchemaFromCatalog(db, cs, pCache, theirs, &aTheirsSchema, &nTheirsSchema);
     if( rc==SQLITE_OK ){
-      rc = mergeDisjointNewTableSchemaRows(db, aMerged, nMerged,
-                                           aTheirsSchema, nTheirsSchema,
-                                           aAncSchema, nAncSchema,
-                                           aOursSchema, nOursSchema);
+      rc = rebuildDisjointSchemaRows(db, aMerged, nMerged,
+                                     aTheirsSchema, nTheirsSchema,
+                                     aAncSchema, nAncSchema,
+                                     aOursSchema, nOursSchema,
+                                     aRemap, nRemap);
     }
     freeSchemaEntries(aAncSchema, nAncSchema);
     freeSchemaEntries(aOursSchema, nOursSchema);
@@ -2077,6 +2312,7 @@ int doltliteMergeCatalogs(
   }
 
 merge_cleanup:
+  sqlite3_free(aRemap);
   freeConflictTables(aConflictTables, nConflictTables);
   doltliteFreeCatalog(aAnc, nAnc);
   doltliteFreeCatalog(aOurs, nOurs);

--- a/src/doltlite_schema_diff.c
+++ b/src/doltlite_schema_diff.c
@@ -60,6 +60,40 @@ static int schemaTextField(
   return SQLITE_OK;
 }
 
+static i64 schemaIntField(
+  const u8 *pVal,
+  int nVal,
+  DoltliteRecordInfo *pRi,
+  int iField
+){
+  const u8 *pBody;
+  int st, off, nByte, i;
+  i64 v;
+
+  if( iField>=pRi->nField ) return 0;
+  st = pRi->aType[iField];
+  off = pRi->aOffset[iField];
+  switch( st ){
+    case 0:
+    case 8: return 0;
+    case 9: return 1;
+    case 1: nByte = 1; break;
+    case 2: nByte = 2; break;
+    case 3: nByte = 3; break;
+    case 4: nByte = 4; break;
+    case 5: nByte = 6; break;
+    case 6: nByte = 8; break;
+    default: return 0;
+  }
+  if( off<0 || off+nByte>nVal ) return 0;
+  pBody = pVal + off;
+  v = (pBody[0] & 0x80) ? -1 : 0;
+  for(i=0; i<nByte; i++){
+    v = (v << 8) | pBody[i];
+  }
+  return v;
+}
+
 static void freeSchemaDiffRows(SdCursor *c){
   int i;
   for(i=0; i<c->nRows; i++){
@@ -79,8 +113,10 @@ static int appendSchemaEntry(
   int *pnEntries,
   int *pnAlloc,
   char *zName,
+  char *zTblName,
   char *zSql,
-  char *zType
+  char *zType,
+  Pgno iRootpage
 ){
   SchemaEntry *aEntries = *paEntries;
   int nEntries = *pnEntries;
@@ -93,8 +129,10 @@ static int appendSchemaEntry(
     nAlloc = nNew;
   }
   aEntries[nEntries].zName = zName;
+  aEntries[nEntries].zTblName = zTblName;
   aEntries[nEntries].zSql = zSql;
   aEntries[nEntries].zType = zType;
+  aEntries[nEntries].iRootpage = iRootpage;
   *paEntries = aEntries;
   *pnEntries = nEntries + 1;
   *pnAlloc = nAlloc;
@@ -191,7 +229,8 @@ int loadSchemaFromCatalog(
         rc = SQLITE_CORRUPT;
         goto load_schema_done;
       }else{
-        char *zType = 0, *zName = 0, *zSql = 0;
+        char *zType = 0, *zName = 0, *zTblName = 0, *zSql = 0;
+        i64 iRootpage = 0;
 
         rc = schemaTextField(pVal, nVal, &ri, 0, &zType);
         if( rc!=SQLITE_OK ) goto load_schema_done;
@@ -200,22 +239,34 @@ int loadSchemaFromCatalog(
           sqlite3_free(zType);
           goto load_schema_done;
         }
-        rc = schemaTextField(pVal, nVal, &ri, 4, &zSql);
+        rc = schemaTextField(pVal, nVal, &ri, 2, &zTblName);
         if( rc!=SQLITE_OK ){
           sqlite3_free(zType);
           sqlite3_free(zName);
           goto load_schema_done;
         }
+        iRootpage = schemaIntField(pVal, nVal, &ri, 3);
+        rc = schemaTextField(pVal, nVal, &ri, 4, &zSql);
+        if( rc!=SQLITE_OK ){
+          sqlite3_free(zType);
+          sqlite3_free(zName);
+          sqlite3_free(zTblName);
+          goto load_schema_done;
+        }
 
         if( zName ){
-          rc = appendSchemaEntry(&aEntries, &nEntries, &nAlloc, zName, zSql, zType);
+          rc = appendSchemaEntry(&aEntries, &nEntries, &nAlloc,
+                                 zName, zTblName, zSql, zType,
+                                 (Pgno)iRootpage);
           if( rc!=SQLITE_OK ) goto load_schema_done;
           zName = 0;
+          zTblName = 0;
           zSql = 0;
           zType = 0;
         }
         sqlite3_free(zType);
         sqlite3_free(zName);
+        sqlite3_free(zTblName);
         sqlite3_free(zSql);
       }
     }
@@ -241,6 +292,7 @@ void freeSchemaEntries(SchemaEntry *a, int n){
   int i;
   for(i=0; i<n; i++){
     sqlite3_free(a[i].zName);
+    sqlite3_free(a[i].zTblName);
     sqlite3_free(a[i].zSql);
     sqlite3_free(a[i].zType);
   }

--- a/test/doltlite_merge.sh
+++ b/test/doltlite_merge.sh
@@ -220,7 +220,66 @@ run_test "disjoint_new_tables_feat_present" "SELECT v FROM feat_tbl;" "f" "$DB13
 run_test "disjoint_new_tables_reopen_main" "SELECT v FROM main_tbl;" "m" "$DB13"
 run_test "disjoint_new_tables_reopen_feat" "SELECT v FROM feat_tbl;" "f" "$DB13"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB8B" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13"
+# Disjoint index additions on different existing tables should auto-merge.
+DB14=/tmp/test_merge14_$$.db; rm -f "$DB14"
+echo "CREATE TABLE a(id INTEGER PRIMARY KEY, v INT); CREATE TABLE b(id INTEGER PRIMARY KEY, v INT); INSERT INTO a VALUES(1,10); INSERT INTO b VALUES(1,20); SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');" | $DOLTLITE "$DB14" > /dev/null 2>&1
+echo "SELECT dolt_branch('feat'); CREATE INDEX idx_a_v ON a(v); SELECT dolt_add('-A'); SELECT dolt_commit('-m','main_idx');" | $DOLTLITE "$DB14" > /dev/null 2>&1
+echo "SELECT dolt_checkout('feat'); CREATE INDEX idx_b_v ON b(v); SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_idx');" | $DOLTLITE "$DB14" > /dev/null 2>&1
+echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB14" > /dev/null 2>&1
+run_test_match "disjoint_indexes_merge_hash" "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB14"
+run_test "disjoint_indexes_visible" "SELECT count(*) FROM sqlite_master WHERE type='index' AND name IN ('idx_a_v','idx_b_v');" "2" "$DB14"
+run_test "disjoint_indexes_reopen_data_a" "SELECT count(*) FROM a;" "1" "$DB14"
+run_test "disjoint_indexes_reopen_data_b" "SELECT count(*) FROM b;" "1" "$DB14"
+
+# Disjoint foreign-key additions on different existing tables should auto-merge.
+DB15=/tmp/test_merge15_$$.db; rm -f "$DB15"
+echo "CREATE TABLE p1(id INTEGER PRIMARY KEY); CREATE TABLE c1(id INTEGER PRIMARY KEY, p1_id INT); CREATE TABLE p2(id INTEGER PRIMARY KEY); CREATE TABLE c2(id INTEGER PRIMARY KEY, p2_id INT); INSERT INTO p1 VALUES(1); INSERT INTO p2 VALUES(1); SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');" | $DOLTLITE "$DB15" > /dev/null 2>&1
+echo "SELECT dolt_branch('feat'); ALTER TABLE c1 RENAME TO c1_old; CREATE TABLE c1(id INTEGER PRIMARY KEY, p1_id INT, CONSTRAINT fk_c1 FOREIGN KEY (p1_id) REFERENCES p1(id)); INSERT INTO c1 SELECT id,p1_id FROM c1_old; DROP TABLE c1_old; SELECT dolt_add('-A'); SELECT dolt_commit('-m','main_fk');" | $DOLTLITE "$DB15" > /dev/null 2>&1
+echo "SELECT dolt_checkout('feat'); ALTER TABLE c2 RENAME TO c2_old; CREATE TABLE c2(id INTEGER PRIMARY KEY, p2_id INT, CONSTRAINT fk_c2 FOREIGN KEY (p2_id) REFERENCES p2(id)); INSERT INTO c2 SELECT id,p2_id FROM c2_old; DROP TABLE c2_old; SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_fk');" | $DOLTLITE "$DB15" > /dev/null 2>&1
+echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB15" > /dev/null 2>&1
+run_test_match "disjoint_fks_merge_hash" "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB15"
+run_test "disjoint_fks_c1" "SELECT count(*) FROM pragma_foreign_key_list('c1');" "1" "$DB15"
+run_test "disjoint_fks_c2" "SELECT count(*) FROM pragma_foreign_key_list('c2');" "1" "$DB15"
+
+# New table on one branch plus index on an existing table on the other should auto-merge.
+DB16=/tmp/test_merge16_$$.db; rm -f "$DB16"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT); INSERT INTO t VALUES(1,10); SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');" | $DOLTLITE "$DB16" > /dev/null 2>&1
+echo "SELECT dolt_branch('feat'); SELECT dolt_checkout('feat'); CREATE INDEX idx_t_v ON t(v); SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_idx');" | $DOLTLITE "$DB16" > /dev/null 2>&1
+echo "SELECT dolt_checkout('main'); CREATE TABLE main_only(id INTEGER PRIMARY KEY, v INT); INSERT INTO main_only VALUES(1,11); SELECT dolt_add('-A'); SELECT dolt_commit('-m','main_add_table');" | $DOLTLITE "$DB16" > /dev/null 2>&1
+run_test_match "table_plus_index_merge_hash" "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB16"
+run_test "table_plus_index_table_visible" "SELECT count(*) FROM main_only;" "1" "$DB16"
+run_test "table_plus_index_index_visible" "SELECT count(*) FROM sqlite_master WHERE type='index' AND name='idx_t_v';" "1" "$DB16"
+
+# New table on one branch plus unrelated CHECK constraint change on the other should auto-merge.
+DB17=/tmp/test_merge17_$$.db; rm -f "$DB17"
+echo "CREATE TABLE base(id INTEGER PRIMARY KEY, v INT); INSERT INTO base VALUES(1,1); SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');" | $DOLTLITE "$DB17" > /dev/null 2>&1
+echo "SELECT dolt_branch('feat'); SELECT dolt_checkout('feat'); CREATE TABLE feat_tbl(id INTEGER PRIMARY KEY, v INT); INSERT INTO feat_tbl VALUES(1,2); SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_add_table');" | $DOLTLITE "$DB17" > /dev/null 2>&1
+echo "SELECT dolt_checkout('main'); ALTER TABLE base RENAME TO base_old; CREATE TABLE base(id INTEGER PRIMARY KEY, v INT, CONSTRAINT chk_base CHECK (v > 0)); INSERT INTO base SELECT * FROM base_old; DROP TABLE base_old; SELECT dolt_add('-A'); SELECT dolt_commit('-m','main_add_check');" | $DOLTLITE "$DB17" > /dev/null 2>&1
+run_test_match "table_plus_check_merge_hash" "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB17"
+run_test "table_plus_check_table_visible" "SELECT count(*) FROM feat_tbl;" "1" "$DB17"
+run_test "table_plus_check_constraint_visible" "SELECT instr(sql,'CHECK')>0 FROM sqlite_master WHERE type='table' AND name='base';" "1" "$DB17"
+
+# New table on one branch plus unrelated rename on the other should auto-merge.
+DB18=/tmp/test_merge18_$$.db; rm -f "$DB18"
+echo "CREATE TABLE base(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO base VALUES(1,'x'); CREATE TABLE keep_main(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO keep_main VALUES(1,'m'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB18" > /dev/null 2>&1
+echo "SELECT dolt_branch('feat'); ALTER TABLE keep_main RENAME TO renamed_main; SELECT dolt_add('-A'); SELECT dolt_commit('-m','main_rename');" | $DOLTLITE "$DB18" > /dev/null 2>&1
+echo "SELECT dolt_checkout('feat'); CREATE TABLE feat_tbl(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO feat_tbl VALUES(1,'f'); SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_add_table');" | $DOLTLITE "$DB18" > /dev/null 2>&1
+echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB18" > /dev/null 2>&1
+run_test_match "table_plus_rename_merge_hash" "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB18"
+run_test "table_plus_rename_feat_visible" "SELECT count(*) FROM feat_tbl;" "1" "$DB18"
+run_test "table_plus_rename_new_name_visible" "SELECT count(*) FROM renamed_main;" "1" "$DB18"
+
+# New table on one branch plus unrelated drop/recreate on the other should auto-merge.
+DB19=/tmp/test_merge19_$$.db; rm -f "$DB19"
+echo "CREATE TABLE base(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO base VALUES(1,'x'); CREATE TABLE churn(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO churn VALUES(1,'m'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB19" > /dev/null 2>&1
+echo "SELECT dolt_branch('feat'); DROP TABLE churn; CREATE TABLE churn(k INTEGER PRIMARY KEY, n INT); INSERT INTO churn VALUES(7,70); SELECT dolt_add('-A'); SELECT dolt_commit('-m','main_recreate');" | $DOLTLITE "$DB19" > /dev/null 2>&1
+echo "SELECT dolt_checkout('feat'); CREATE TABLE feat_tbl(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO feat_tbl VALUES(1,'f'); SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_add_table');" | $DOLTLITE "$DB19" > /dev/null 2>&1
+echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB19" > /dev/null 2>&1
+run_test_match "table_plus_recreate_merge_hash" "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB19"
+run_test "table_plus_recreate_feat_visible" "SELECT count(*) FROM feat_tbl;" "1" "$DB19"
+run_test "table_plus_recreate_schema_visible" "SELECT instr(sql,'k INTEGER PRIMARY KEY')>0 FROM sqlite_master WHERE type='table' AND name='churn';" "1" "$DB19"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB8B" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18" "$DB19"
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
 if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi


### PR DESCRIPTION
## Summary
- fix false schema conflicts for disjoint merge-time schema changes on unrelated objects
- rebuild merged sqlite_master state for disjoint schema-name changes, including remapped secondary-index rootpages when both branches add different indexes
- add merge regressions for disjoint indexes, foreign keys, new-table-plus-index, new-table-plus-check, and new-table-plus rename/recreate

## Testing
- make clean && make -j4 doltlite && bash test/doltlite_merge.sh
- bash test/vc_oracle_merge_test.sh ./doltlite dolt