### PR TITLE
chunk_store: drop refsHash save/restore in replay state

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -168,7 +168,6 @@ struct SavedRefsState {
 struct ChunkStoreReplayState {
   i64 nWalData;
   int nChunks;
-  ProllyHash refsHash;
   ChunkIndexEntry *aIndex;
   int nIndex;
   int nIndexAlloc;
@@ -425,7 +424,6 @@ static void csCaptureReplayState(ChunkStore *cs, ChunkStoreReplayState *pSaved){
   memset(pSaved, 0, sizeof(*pSaved));
   pSaved->nWalData = cs->nWalData;
   pSaved->nChunks = cs->nChunks;
-  pSaved->refsHash = cs->refsHash;
   pSaved->aIndex = cs->aIndex;
   pSaved->nIndex = cs->nIndex;
   pSaved->nIndexAlloc = cs->nIndexAlloc;
@@ -437,7 +435,6 @@ static void csCaptureReplayState(ChunkStore *cs, ChunkStoreReplayState *pSaved){
 static void csRestoreReplayState(ChunkStore *cs, const ChunkStoreReplayState *pSaved){
   cs->nWalData = pSaved->nWalData;
   cs->nChunks = pSaved->nChunks;
-  cs->refsHash = pSaved->refsHash;
   cs->aIndex = pSaved->aIndex;
   cs->nIndex = pSaved->nIndex;
   cs->nIndexAlloc = pSaved->nIndexAlloc;


### PR DESCRIPTION
## Summary
- \`cs->refsHash\` was being captured in \`ChunkStoreReplayState\` and restored on \`csReplayWalRegion\` failure. But the only caller (\`chunkStoreOpen\`) tears the store down on a replay error — nothing reads \`cs->refsHash\` after a failed open. The save/restore is the same vestigial pattern \`pWalData\` had.
- Drop the field from the struct and the two assignments. \`nWalData\`, \`nChunks\`, and \`aIndex\` stay — \`aIndex\` IS load-bearing because csReplayWalRegion swaps it for a merged array on success.

This is finding #1 from a post-#678 audit (#3 and #2 turned out to be wrong; this is the only real one).

## Test plan
- [x] \`make doltlite\` clean
- [x] \`doltlite_regression_test_c all\` — 107795 passed, 0 failed
- [x] \`vc_oracle_merge_test.sh\` — 41 passed
- [x] \`vc_oracle_branch_test.sh\` — 33 passed
- [x] \`vc_oracle_diff_test.sh\` — 41 passed
- [x] \`vc_oracle_error_recovery_test.sh\` — 261 passed
- [ ] CI sanitizer + crash-injection durability suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)