### PR TITLE
Add rebase schema replay parity coverage

### DIFF
--- a/test/doltlite_rebase_schema.sh
+++ b/test/doltlite_rebase_schema.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+#
+# Local regressions for schema-edge non-interactive rebase behavior.
+#
+set -u
+set -o pipefail
+
+DOLTLITE="${1:-./doltlite}"
+PASS=0; FAIL=0; ERRORS=""
+
+run_db_match() {
+  local n="$1" s="$2" p="$3"
+  local db="/tmp/${n}_$$.db"
+  rm -f "$db"
+  local r
+  r=$(echo "$s" | perl -e 'alarm(10);exec @ARGV' "$DOLTLITE" "$db" 2>&1)
+  rm -f "$db"
+  if echo "$r" | grep -qE "$p"; then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1))
+    ERRORS="$ERRORS\nFAIL: $n\n  pattern: $p\n  got:     $r"
+  fi
+}
+
+run_db_eq() {
+  local n="$1" s="$2" e="$3"
+  local db="/tmp/${n}_$$.db"
+  rm -f "$db"
+  local r
+  r=$(echo "$s" | perl -e 'alarm(10);exec @ARGV' "$DOLTLITE" "$db" 2>&1 | tail -n 1)
+  rm -f "$db"
+  if [ "$r" = "$e" ]; then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1))
+    ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"
+  fi
+}
+
+echo "=== Doltlite Rebase Schema Tests ==="
+echo ""
+
+TABLE_CHECK_SETUP="
+CREATE TABLE base(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO base VALUES(1,1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','init');
+SELECT dolt_branch('feat');
+CREATE TABLE base_new(id INTEGER PRIMARY KEY, v INT CHECK (v > 0));
+INSERT INTO base_new SELECT * FROM base;
+DROP TABLE base;
+ALTER TABLE base_new RENAME TO base;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main check');
+SELECT dolt_checkout('feat');
+CREATE TABLE feat_tbl(k INTEGER PRIMARY KEY, w TEXT);
+INSERT INTO feat_tbl VALUES(1,'x');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat table');
+"
+
+run_db_match "rebase_schema_table_check_hash" "
+$TABLE_CHECK_SETUP
+SELECT dolt_rebase('main');
+" "Successfully rebased|^[0-9a-f]{40}$"
+
+run_db_eq "rebase_schema_table_check_feat_tbl" "
+$TABLE_CHECK_SETUP
+SELECT dolt_rebase('main');
+SELECT count(*) FROM feat_tbl;
+" "1"
+
+run_db_eq "rebase_schema_table_check_base" "
+$TABLE_CHECK_SETUP
+SELECT dolt_rebase('main');
+SELECT count(*) FROM base;
+" "1"
+
+INDEX_SETUP="
+CREATE TABLE a(id INTEGER PRIMARY KEY, v INT);
+CREATE TABLE b(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO a VALUES(1,10);
+INSERT INTO b VALUES(1,20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','init');
+SELECT dolt_branch('feat');
+CREATE INDEX idx_a_v ON a(v);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main idx');
+SELECT dolt_checkout('feat');
+CREATE INDEX idx_b_v ON b(v);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat idx');
+"
+
+run_db_match "rebase_schema_disjoint_idx_hash" "
+$INDEX_SETUP
+SELECT dolt_rebase('main');
+" "Successfully rebased|^[0-9a-f]{40}$"
+
+run_db_eq "rebase_schema_disjoint_idx_main" "
+$INDEX_SETUP
+SELECT dolt_rebase('main');
+SELECT count(*) FROM pragma_index_list('a') WHERE name='idx_a_v';
+" "1"
+
+run_db_eq "rebase_schema_disjoint_idx_feat_same_session_current_dolt_behavior" "
+$INDEX_SETUP
+SELECT dolt_rebase('main');
+SELECT count(*) FROM pragma_index_list('b') WHERE name='idx_b_v';
+" "1"
+
+run_db_eq "rebase_schema_disjoint_idx_feat_reopen_current_dolt_behavior" "
+$INDEX_SETUP
+SELECT dolt_rebase('main');
+" "Successfully rebased and updated refs/heads/feat"
+
+{
+  db="/tmp/rebase_schema_disjoint_idx_feat_reopen_current_dolt_behavior_$$.db"
+  rm -f "$db"
+  echo "$INDEX_SETUP
+SELECT dolt_rebase('main');" | perl -e 'alarm(10);exec @ARGV' "$DOLTLITE" "$db" >/dev/null 2>&1
+  r=$(printf ".headers off\n.mode list\nSELECT count(*) FROM pragma_index_list('b') WHERE name='idx_b_v';\n" | "$DOLTLITE" "$db" 2>&1 | tail -n 1)
+  rm -f "$db"
+  if [ "$r" = "0" ]; then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1))
+    ERRORS="$ERRORS\nFAIL: rebase_schema_disjoint_idx_feat_reopen_current_dolt_behavior\n  expected: 0\n  got:      $r"
+  fi
+}
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
+if [ $FAIL -gt 0 ]; then
+  echo -e "$ERRORS"
+  exit 1
+fi

--- a/test/vc_oracle_rebase_test.sh
+++ b/test/vc_oracle_rebase_test.sh
@@ -229,6 +229,44 @@ oracle_reopen() {
   fi
 }
 
+oracle_poststate() {
+  local name="$1" setup="$2" dl_query="$3" dolt_query="${4:-$3}"
+  local dir="$TMPROOT/${name}_post"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_rc
+  vc_oracle_run_doltlite_script "$dir/dl/db" "$dir/dl.out" "$dir/dl.err" "$setup"
+  dl_rc=$?
+  local dl_out
+  dl_out=$(printf ".headers off\n.mode list\n%s\n" "$dl_query" \
+           | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.post.err" \
+           | tr -d '\r')
+
+  local dolt_setup
+  dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
+  local dt_rc
+  vc_oracle_run_dolt_script "$dir/dt" "$dir/dt.out" "$dir/dt.err" "$dolt_setup"
+  dt_rc=$?
+  local dt_out
+  (
+    cd "$dir/dt" || exit 1
+    "$DOLT" sql -r csv -q "$dolt_query" 2>"$dir/dt.post.err"
+  ) > "$dir/dt.raw"
+  dt_out=$(tail -n +2 "$dir/dt.raw" | tr -d '"\r')
+
+  if [ "$dl_rc" -eq 0 ] && [ "$dt_rc" -eq 0 ] && [ "$dl_out" = "$dt_out" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name"
+    echo "    doltlite rc: $dl_rc"
+    echo "    dolt rc:     $dt_rc"
+    echo "    doltlite: |$dl_out|"
+    echo "    dolt:     |$dt_out|"
+  fi
+}
+
 echo "=== Version Control Oracle Tests: dolt_rebase ==="
 echo ""
 
@@ -296,6 +334,45 @@ oracle "multi_commit_log" "$MULTI_SETUP" \
 
 oracle "multi_commit_table" "$MULTI_SETUP" \
   "SELECT CONCAT('LOG|', id) FROM t ORDER BY id;"
+
+echo "--- schema-edge replay ---"
+
+oracle_poststate "rebase_disjoint_add_table_plus_check" "
+CREATE TABLE base(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO base VALUES (1, 1);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');
+SELECT dolt_branch('feat');
+CREATE TABLE base_new(id INTEGER PRIMARY KEY, v INT CHECK (v > 0));
+INSERT INTO base_new SELECT * FROM base;
+DROP TABLE base;
+ALTER TABLE base_new RENAME TO base;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'main check');
+SELECT dolt_checkout('feat');
+CREATE TABLE feat_tbl(k INTEGER PRIMARY KEY, w TEXT);
+INSERT INTO feat_tbl VALUES (1, 'x');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'feat table');
+SELECT dolt_rebase('main');
+" "SELECT (SELECT count(*) FROM sqlite_master WHERE type='table' AND name='feat_tbl') || '|' ||
+          (SELECT count(*) FROM feat_tbl) || '|' ||
+          (SELECT count(*) FROM base)" \
+  "SELECT CONCAT((SELECT COUNT(*) FROM information_schema.tables WHERE table_name='feat_tbl'), '|', (SELECT COUNT(*) FROM feat_tbl), '|', (SELECT COUNT(*) FROM base))"
+
+oracle_poststate "rebase_disjoint_add_indexes_current_dolt_behavior" "
+CREATE TABLE a(id INTEGER PRIMARY KEY, v INT);
+CREATE TABLE b(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO a VALUES (1, 10);
+INSERT INTO b VALUES (1, 20);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');
+SELECT dolt_branch('feat');
+CREATE INDEX idx_a_v ON a(v);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'main idx');
+SELECT dolt_checkout('feat');
+CREATE INDEX idx_b_v ON b(v);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'feat idx');
+SELECT dolt_rebase('main');
+" "SELECT (SELECT count(*) FROM pragma_index_list('a') WHERE name='idx_a_v') || '|' ||
+          (SELECT count(*) FROM pragma_index_list('b') WHERE name='idx_b_v')" \
+  "SELECT CONCAT((SELECT COUNT(*) FROM information_schema.statistics WHERE table_name='a' AND index_name='idx_a_v'), '|', (SELECT COUNT(*) FROM information_schema.statistics WHERE table_name='b' AND index_name='idx_b_v'))"
 
 echo "--- error paths ---"
 


### PR DESCRIPTION
## Summary
- add cross-engine rebase coverage for disjoint schema replay cases
- add local rebase schema regressions for same-session vs reopen behavior
- document current Dolt behavior for disjoint index replay during non-interactive rebase

## Notes
- the suspected same-session index disappearance bug turned out to match Dolt: same session keeps `1|1`, reopen shows `1|0`
- likely Dolt semantic issue for the dropped replayed index is filed separately in dolt#10961

## Testing
- bash test/vc_oracle_rebase_test.sh ./doltlite dolt
- bash test/doltlite_rebase_schema.sh ./doltlite