### PR TITLE
chunk_store: round 2 vestigial cleanup

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -169,10 +169,8 @@ struct ChunkStoreReplayState {
   int nChunks;
   ChunkIndexEntry *aIndex;
   int nIndex;
-  int nIndexAlloc;
-  /* Carried alongside aIndex so save/restore knows whether the
-  ** snapshotted pointer was mmapped or malloc'd. NULL/0 means
-  ** malloc'd. See csReleaseIndexBuf. */
+  /* aIndexMmapBase is the page-aligned base when aIndex is mmapped
+  ** (NULL/0 when malloc'd) — csReleaseIndexBuf branches on it. */
   void *aIndexMmapBase;
   i64 aIndexMmapSize;
   SavedRefsState refs;
@@ -416,7 +414,6 @@ static void csCaptureReplayState(ChunkStore *cs, ChunkStoreReplayState *pSaved){
   pSaved->nChunks = cs->nChunks;
   pSaved->aIndex = cs->aIndex;
   pSaved->nIndex = cs->nIndex;
-  pSaved->nIndexAlloc = cs->nIndexAlloc;
   pSaved->aIndexMmapBase = cs->aIndexMmapBase;
   pSaved->aIndexMmapSize = cs->aIndexMmapSize;
   csCaptureSavedRefsState(cs, &pSaved->refs);
@@ -427,7 +424,6 @@ static void csRestoreReplayState(ChunkStore *cs, const ChunkStoreReplayState *pS
   cs->nChunks = pSaved->nChunks;
   cs->aIndex = pSaved->aIndex;
   cs->nIndex = pSaved->nIndex;
-  cs->nIndexAlloc = pSaved->nIndexAlloc;
   cs->aIndexMmapBase = pSaved->aIndexMmapBase;
   cs->aIndexMmapSize = pSaved->aIndexMmapSize;
   csRestoreSavedRefsState(cs, &pSaved->refs);
@@ -479,7 +475,6 @@ static void csAdoptOpenedStoreState(ChunkStore *pDst, ChunkStore *pSrc){
   pDst->iFileSize = pSrc->iFileSize;
   pDst->aIndex = pSrc->aIndex;
   pDst->nIndex = pSrc->nIndex;
-  pDst->nIndexAlloc = pSrc->nIndexAlloc;
   pDst->aIndexMmapBase = pSrc->aIndexMmapBase;
   pDst->aIndexMmapSize = pSrc->aIndexMmapSize;
   pDst->nWalData = pSrc->nWalData;
@@ -496,7 +491,6 @@ static void csAdoptOpenedStoreState(ChunkStore *pDst, ChunkStore *pSrc){
   pSrc->pFile = 0;
   pSrc->aIndex = 0;
   pSrc->nIndex = 0;
-  pSrc->nIndexAlloc = 0;
   pSrc->aIndexMmapBase = 0;
   pSrc->aIndexMmapSize = 0;
   pSrc->nWalData = 0;
@@ -811,7 +805,6 @@ static int csReadIndex(ChunkStore *cs){
                   &pMapBase, &nMapSize, &pMapData) == SQLITE_OK ){
     cs->aIndex = (ChunkIndexEntry *)pMapData;
     cs->nIndex = nEntries;
-    cs->nIndexAlloc = nEntries;
     cs->aIndexMmapBase = pMapBase;
     cs->aIndexMmapSize = nMapSize;
     return SQLITE_OK;
@@ -822,7 +815,6 @@ static int csReadIndex(ChunkStore *cs){
   );
   if( cs->aIndex == 0 ) return SQLITE_NOMEM;
   cs->nIndex = nEntries;
-  cs->nIndexAlloc = nEntries;
   cs->aIndexMmapBase = 0;
   cs->aIndexMmapSize = 0;
 
@@ -1060,7 +1052,6 @@ static int csReplayWal(ChunkStore *cs){
     ** tracking so cs reflects the new malloc'd merged array. */
     cs->aIndex = aMerged;
     cs->nIndex = nMerged;
-    cs->nIndexAlloc = nMerged;
     cs->aIndexMmapBase = 0;
     cs->aIndexMmapSize = 0;
     cs->nPending = 0;
@@ -2026,7 +2017,6 @@ static int csCommitToMemory(ChunkStore *cs){
     csReleaseIndexBuf(cs->aIndex, cs->aIndexMmapBase, cs->aIndexMmapSize);
     cs->aIndex = aMem;
     cs->nIndex = nMem;
-    cs->nIndexAlloc = nMem;
     cs->aIndexMmapBase = 0;
     cs->aIndexMmapSize = 0;
     cs->nPending = 0;
@@ -2254,7 +2244,6 @@ commit_done:
     csReleaseIndexBuf(cs->aIndex, cs->aIndexMmapBase, cs->aIndexMmapSize);
     cs->aIndex = aMerged;
     cs->nIndex = nMerged;
-    cs->nIndexAlloc = nMerged;
     cs->aIndexMmapBase = 0;
     cs->aIndexMmapSize = 0;
     cs->nWalData = newWalSize;

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -322,15 +322,6 @@ static void csReleaseIndexBuf(ChunkIndexEntry *aIndex,
   }
 }
 
-static void csReleaseLiveIndex(ChunkStore *cs){
-  csReleaseIndexBuf(cs->aIndex, cs->aIndexMmapBase, cs->aIndexMmapSize);
-  cs->aIndex = 0;
-  cs->aIndexMmapBase = 0;
-  cs->aIndexMmapSize = 0;
-  cs->nIndex = 0;
-  cs->nIndexAlloc = 0;
-}
-
 static void csFreeBranches(ChunkStore *cs){
   int k;
   for(k=0; k<cs->nBranches; k++) sqlite3_free(cs->aBranches[k].zName);

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -165,8 +165,6 @@ struct SavedRefsState {
 };
 
 struct ChunkStoreReplayState {
-  i64 nWalData;
-  int nChunks;
   ChunkIndexEntry *aIndex;
   int nIndex;
   /* aIndexMmapBase is the page-aligned base when aIndex is mmapped
@@ -410,8 +408,6 @@ static void csFreeSavedRefsState(SavedRefsState *pSaved){
 
 static void csCaptureReplayState(ChunkStore *cs, ChunkStoreReplayState *pSaved){
   memset(pSaved, 0, sizeof(*pSaved));
-  pSaved->nWalData = cs->nWalData;
-  pSaved->nChunks = cs->nChunks;
   pSaved->aIndex = cs->aIndex;
   pSaved->nIndex = cs->nIndex;
   pSaved->aIndexMmapBase = cs->aIndexMmapBase;
@@ -420,8 +416,6 @@ static void csCaptureReplayState(ChunkStore *cs, ChunkStoreReplayState *pSaved){
 }
 
 static void csRestoreReplayState(ChunkStore *cs, const ChunkStoreReplayState *pSaved){
-  cs->nWalData = pSaved->nWalData;
-  cs->nChunks = pSaved->nChunks;
   cs->aIndex = pSaved->aIndex;
   cs->nIndex = pSaved->nIndex;
   cs->aIndexMmapBase = pSaved->aIndexMmapBase;

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -138,8 +138,7 @@ static int csGrowPending(ChunkStore *cs);
 static int csGrowWriteBuf(ChunkStore *cs, int nNeeded);
 static void csPendHTClear(ChunkStore *cs);
 
-static int csReplayWalRegion(ChunkStore *cs, int updateManifest);
-static int csReplayWal(ChunkStore *cs){ return csReplayWalRegion(cs, 1); }
+static int csReplayWal(ChunkStore *cs);
 static void csFreeRefsState(ChunkStore *cs);
 static int csDeserializeRefsIntoTemp(ChunkStore *pTmp, const u8 *data, int nData);
 static void csAdoptRefsState(ChunkStore *pDst, ChunkStore *pSrc);
@@ -895,7 +894,7 @@ static int csGrowWriteBuf(ChunkStore *cs, int nNeeded){
 ** common chunkStoreGet pread path serves them with no special-casing.
 ** ROOT records do NOT update iWalOffset / iIndexOffset — those describe
 ** the compacted region on disk and only move on GC. */
-static int csReplayWalRegion(ChunkStore *cs, int updateManifest){
+static int csReplayWal(ChunkStore *cs){
   i64 walSize;
   u8 *walData;
   ChunkStoreReplayState saved;
@@ -927,7 +926,7 @@ static int csReplayWalRegion(ChunkStore *cs, int updateManifest){
     ** For (b), the manifest's refs hash may point to a chunk that
     ** was prepared but never committed. Reset it. For (a), the
     ** manifest is correct — leave it alone. */
-    if( updateManifest && cs->nIndex==0 && cs->nChunks==0
+    if( cs->nIndex==0 && cs->nChunks==0
      && !prollyHashIsEmpty(&cs->refsHash) ){
       memset(cs->refsHash.data, 0, PROLLY_HASH_SIZE);
     }
@@ -1009,7 +1008,7 @@ static int csReplayWalRegion(ChunkStore *cs, int updateManifest){
         ** point write. Stop and use the previous root. */
         break;
       }
-      if( updateManifest ){
+      {
         u8 *m = walData + pos;
         u32 magic = CS_READ_U32(m);
         if( magic != CHUNK_STORE_MAGIC ){
@@ -1023,7 +1022,6 @@ static int csReplayWalRegion(ChunkStore *cs, int updateManifest){
         cs->nChunks = (int)CS_READ_U32(m + 28);
 
         memcpy(cs->refsHash.data, m + 104, PROLLY_HASH_SIZE);
-
       }
       pos += CHUNK_MANIFEST_SIZE;
       nRootedPending = cs->nPending;
@@ -1046,7 +1044,7 @@ static int csReplayWalRegion(ChunkStore *cs, int updateManifest){
   ** through GC (nIndex > 0), the WAL may be empty because all
   ** data was compacted into the main body — the manifest is
   ** authoritative in that case. */
-  if( nRootRecordsSeen == 0 && updateManifest
+  if( nRootRecordsSeen == 0
    && nPendingBefore == 0 && cs->nIndex == 0 ){
     memset(cs->refsHash.data, 0, PROLLY_HASH_SIZE);
     cs->nChunks = 0;

--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -197,7 +197,6 @@ struct ChunkStore {
 
   ChunkIndexEntry *aIndex;
   int nIndex;
-  int nIndexAlloc;
 
   /* When the persisted index is mmapped, aIndexMmapBase is the page-
   ** aligned base of the mapping (which can differ from aIndex if

--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -464,7 +464,6 @@ static int gcSweep(
     sqlite3_free(cs->aIndex);
     cs->aIndex = aNewIndex;
     cs->nIndex = nNewIndex;
-    cs->nIndexAlloc = nNewIndex;
     cs->nChunks = nNewIndex;
     cs->iIndexOffset = CHUNK_MANIFEST_SIZE + nBuf;
     cs->nIndexSize = indexSize;


### PR DESCRIPTION
## Summary
Audit follow-up after the WAL drop (#678) and refsHash drop (#680). Four small cleanups, one commit each so any can be reverted independently.

1. **Drop dead \`csReleaseLiveIndex\` helper** — defined, never called.
2. **Drop dead \`updateManifest\` parameter** — always 1 from the only caller; the \`csReplayWal\` wrapper existed only to fix it. Inline the wrapper, simplify three conditionals.
3. **Drop write-only \`nIndexAlloc\` field** — every assignment sets it equal to \`nIndex\`; nothing ever reads it (\`aIndex\` is replaced wholesale on growth, never realloc'd in place). The struct comment claiming it tracked malloc-vs-mmap was also wrong — that's \`aIndexMmapBase\`'s job.
4. **Drop \`nWalData\`/\`nChunks\` save+restore in \`ChunkStoreReplayState\`** — same vestigial pattern as #680's refsHash drop. The only failure path tears the store down; nothing reads either field after a failed open. \`aIndex\` stays in the saved state because the free path needs to know which pointer is the pre-replay one.

Net: -34 lines.

## Test plan
- [x] \`make doltlite\` clean across all four commits
- [x] \`doltlite_regression_test_c all\` — 107795 passed, 0 failed
- [x] \`vc_oracle_merge_test.sh\` — 41 passed
- [x] \`vc_oracle_branch_test.sh\` — 33 passed
- [x] \`vc_oracle_diff_test.sh\` — 41 passed
- [x] \`vc_oracle_error_recovery_test.sh\` — 261 passed
- [x] \`chunk_distribution_test.sh\` — all assertions pass
- [ ] CI sanitizer + crash-injection durability suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)