### PR TITLE
Add schema diff replay coverage

### DIFF
--- a/test/doltlite_schema_diff.sh
+++ b/test/doltlite_schema_diff.sh
@@ -369,6 +369,108 @@ run_test_match "drop_recreate_to_stmt" \
 rm -f "$DB"
 
 # ============================================================
+# Replay after schema changes
+# ============================================================
+
+DB=/tmp/test_sd_merge_replay_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1,10);
+SELECT dolt_commit('-A','-m','c1');
+SELECT dolt_checkout('-b','feat');
+CREATE TABLE u(id INTEGER PRIMARY KEY, w TEXT);
+INSERT INTO u VALUES(1,'x');
+SELECT dolt_commit('-A','-m','feat add u');
+SELECT dolt_checkout('main');
+CREATE TABLE t_new(id INTEGER PRIMARY KEY, v INT CHECK (v > 0));
+INSERT INTO t_new SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t_new RENAME TO t;
+SELECT dolt_commit('-A','-m','main check');
+SELECT dolt_merge('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test "merge_replay_u_count" \
+  "SELECT count(*) FROM dolt_schema_diff('HEAD^1','HEAD','u');" "1" "$DB"
+run_test_match "merge_replay_u_to_stmt" \
+  "SELECT to_create_statement FROM dolt_schema_diff('HEAD^1','HEAD','u');" \
+  "CREATE TABLE u.*w TEXT" "$DB"
+
+rm -f "$DB"
+
+DB=/tmp/test_sd_cherrypick_replay_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1,10);
+SELECT dolt_commit('-A','-m','c1');
+SELECT dolt_checkout('-b','feat');
+CREATE TABLE u(id INTEGER PRIMARY KEY, w TEXT);
+INSERT INTO u VALUES(1,'x');
+SELECT dolt_commit('-A','-m','feat add u');
+SELECT dolt_checkout('main');
+CREATE TABLE t_new(id INTEGER PRIMARY KEY, v INT CHECK (v > 0));
+INSERT INTO t_new SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t_new RENAME TO t;
+SELECT dolt_commit('-A','-m','main check');
+SELECT dolt_cherry_pick((SELECT hash FROM dolt_branches WHERE name='feat'));" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test "cherrypick_replay_u_count" \
+  "SELECT count(*) FROM dolt_schema_diff('HEAD~1','HEAD','u');" "1" "$DB"
+run_test_match "cherrypick_replay_u_to_stmt" \
+  "SELECT to_create_statement FROM dolt_schema_diff('HEAD~1','HEAD','u');" \
+  "CREATE TABLE u.*w TEXT" "$DB"
+
+rm -f "$DB"
+
+DB=/tmp/test_sd_revert_replay_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1,10);
+SELECT dolt_commit('-A','-m','c1');
+CREATE TABLE t_new(id INTEGER PRIMARY KEY, v INT CHECK (v > 0));
+INSERT INTO t_new SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t_new RENAME TO t;
+SELECT dolt_commit('-A','-m','main check');
+CREATE TABLE u(id INTEGER PRIMARY KEY, w TEXT);
+INSERT INTO u VALUES(1,'x');
+SELECT dolt_commit('-A','-m','add u');
+SELECT dolt_revert((SELECT commit_hash FROM dolt_log WHERE message='main check' LIMIT 1));" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test "revert_replay_t_count" \
+  "SELECT count(*) FROM dolt_schema_diff('HEAD~1','HEAD','t');" "1" "$DB"
+run_test_match "revert_replay_from_stmt" \
+  "SELECT from_create_statement FROM dolt_schema_diff('HEAD~1','HEAD','t');" \
+  "CHECK \\(v > 0\\)" "$DB"
+run_test_match "revert_replay_to_stmt" \
+  "SELECT to_create_statement FROM dolt_schema_diff('HEAD~1','HEAD','t');" \
+  "CREATE TABLE t.*v INT\\)" "$DB"
+
+rm -f "$DB"
+
+DB=/tmp/test_sd_rebase_replay_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1,10);
+SELECT dolt_commit('-A','-m','c1');
+SELECT dolt_checkout('-b','feat');
+CREATE TABLE u(id INTEGER PRIMARY KEY, w TEXT);
+INSERT INTO u VALUES(1,'x');
+SELECT dolt_commit('-A','-m','feat add u');
+SELECT dolt_checkout('main');
+CREATE TABLE t_new(id INTEGER PRIMARY KEY, v INT CHECK (v > 0));
+INSERT INTO t_new SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t_new RENAME TO t;
+SELECT dolt_commit('-A','-m','main check');
+SELECT dolt_checkout('feat');
+SELECT dolt_rebase('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test "rebase_replay_u_count" \
+  "SELECT count(*) FROM dolt_schema_diff('main','feat','u');" "1" "$DB"
+run_test_match "rebase_replay_u_to_stmt" \
+  "SELECT to_create_statement FROM dolt_schema_diff('main','feat','u');" \
+  "CREATE TABLE u.*w TEXT" "$DB"
+
+rm -f "$DB"
+
+# ============================================================
 # Done
 # ============================================================
 

--- a/test/vc_oracle_schema_diff_test.sh
+++ b/test/vc_oracle_schema_diff_test.sh
@@ -420,6 +420,87 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'recreate_t');
 " "HEAD~1" "HEAD"
 
+echo "--- replay after schema changes ---"
+
+oracle "merge_replay_add_table_plus_check" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_checkout('-b', 'feat');
+CREATE TABLE u(id INTEGER PRIMARY KEY, w TEXT);
+INSERT INTO u VALUES (1, 'x');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat_add_u');
+SELECT dolt_checkout('main');
+CREATE TABLE t_new(id INTEGER PRIMARY KEY, v INT CHECK (v > 0));
+INSERT INTO t_new SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t_new RENAME TO t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main_check');
+SELECT dolt_merge('feat');
+" "HEAD^1" "HEAD" "u"
+
+oracle "cherrypick_replay_add_table_plus_check" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_checkout('-b', 'feat');
+CREATE TABLE u(id INTEGER PRIMARY KEY, w TEXT);
+INSERT INTO u VALUES (1, 'x');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat_add_u');
+SELECT dolt_checkout('main');
+CREATE TABLE t_new(id INTEGER PRIMARY KEY, v INT CHECK (v > 0));
+INSERT INTO t_new SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t_new RENAME TO t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main_check');
+SELECT dolt_cherry_pick((SELECT hash FROM dolt_branches WHERE name='feat'));
+" "HEAD~1" "HEAD" "u"
+
+oracle "revert_schema_change_with_later_added_table" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+CREATE TABLE t_new(id INTEGER PRIMARY KEY, v INT CHECK (v > 0));
+INSERT INTO t_new SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t_new RENAME TO t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main_check');
+CREATE TABLE u(id INTEGER PRIMARY KEY, w TEXT);
+INSERT INTO u VALUES (1, 'x');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'add_u');
+SELECT dolt_revert((SELECT commit_hash FROM dolt_log WHERE message='main_check' LIMIT 1));
+" "HEAD~1" "HEAD" "t"
+
+oracle "rebase_replay_add_table_plus_check" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_checkout('-b', 'feat');
+CREATE TABLE u(id INTEGER PRIMARY KEY, w TEXT);
+INSERT INTO u VALUES (1, 'x');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat_add_u');
+SELECT dolt_checkout('main');
+CREATE TABLE t_new(id INTEGER PRIMARY KEY, v INT CHECK (v > 0));
+INSERT INTO t_new SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t_new RENAME TO t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main_check');
+SELECT dolt_checkout('feat');
+SELECT dolt_rebase('main');
+" "main" "feat" "u"
+
 echo "--- error paths ---"
 
 oracle_error "bad_from_ref" "$SEED" \


### PR DESCRIPTION
## Summary
- add `dolt_schema_diff` oracle coverage for replay after merge, cherry-pick, revert, and rebase
- add local exact-schema regressions for the same replay shapes
- keep the new cases on the disjoint add-table plus unrelated check family that exposed recent replay bugs

## Verification
- `bash test/vc_oracle_schema_diff_test.sh ./doltlite dolt` -> `33 passed, 0 failed`
- `bash test/doltlite_schema_diff.sh` -> `49 passed, 0 failed`