### PR TITLE
chore: delete 8 dead static helpers across doltlite sources

### DIFF
--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -32,17 +32,6 @@ static void freeConflictRow(struct ConflictRow *pRow){
   memset(pRow, 0, sizeof(*pRow));
 }
 
-static int dupConflictBytes(const u8 *pIn, int nIn, u8 **ppOut){
-  u8 *pCopy;
-  *ppOut = 0;
-  if( !pIn || nIn<=0 ) return SQLITE_OK;
-  pCopy = sqlite3_malloc(nIn);
-  if( !pCopy ) return SQLITE_NOMEM;
-  memcpy(pCopy, pIn, nIn);
-  *ppOut = pCopy;
-  return SQLITE_OK;
-}
-
 static void removeConflictRow(ConflictTableInfo *pTable, int iRow){
   if( !pTable || iRow<0 || iRow>=pTable->nConflicts ) return;
   freeConflictRow(&pTable->aRows[iRow]);

--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -140,47 +140,6 @@ struct DiffTblCursor {
 #define DT_IDX_TO_COMMIT_EQ  0x01
 #define DT_IDX_SLICE         0x02
 
-static int diffRecordField(
-  const u8 *pData,
-  int nData,
-  int iField,
-  int *pType,
-  int *pOff
-){
-  const u8 *p = pData;
-  const u8 *pEnd = pData + nData;
-  const u8 *pHdrEnd;
-  u64 hdrSize;
-  int hdrBytes;
-  int off;
-  int i;
-
-  if( !pData || nData < 1 || iField < 0 ) return SQLITE_CORRUPT;
-  hdrBytes = dlReadVarint(p, pEnd, &hdrSize);
-  if( hdrBytes <= 0 || hdrSize < (u64)hdrBytes || hdrSize > (u64)nData ){
-    return SQLITE_CORRUPT;
-  }
-  p += hdrBytes;
-  pHdrEnd = pData + (int)hdrSize;
-  off = (int)hdrSize;
-  for(i=0; p < pHdrEnd; i++){
-    u64 st;
-    int stBytes = dlReadVarint(p, pHdrEnd, &st);
-    int len;
-    if( stBytes <= 0 ) return SQLITE_CORRUPT;
-    p += stBytes;
-    len = dlSerialTypeLen(st);
-    if( off < 0 || off + len > nData ) return SQLITE_CORRUPT;
-    if( i==iField ){
-      *pType = (int)st;
-      *pOff = off;
-      return SQLITE_OK;
-    }
-    off += len;
-  }
-  return SQLITE_NOTFOUND;
-}
-
 static void clearAuditRow(AuditRow *r){
   memset(r, 0, sizeof(*r));
 }

--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -1273,54 +1273,6 @@ static int schemaHasTableNamed(
   return 0;
 }
 
-static int catalogHasDisjointNewTables(
-  sqlite3 *db,
-  const ProllyHash *pCatAnc,
-  const ProllyHash *pCatOurs,
-  const ProllyHash *pCatTheirs
-){
-  ChunkStore *cs = doltliteGetChunkStore(db);
-  ProllyCache *pCache = doltliteGetCache(db);
-  SchemaEntry *aAncSchema = 0, *aOursSchema = 0, *aTheirsSchema = 0;
-  int nAncSchema = 0, nOursSchema = 0, nTheirsSchema = 0;
-  int i, rc;
-  int sawOursNew = 0, sawTheirsNew = 0;
-  int result = 0;
-
-  if( !cs || !pCache ) return 0;
-  rc = loadSchemaFromCatalog(db, cs, pCache, pCatAnc, &aAncSchema, &nAncSchema);
-  if( rc!=SQLITE_OK ) goto done;
-  rc = loadSchemaFromCatalog(db, cs, pCache, pCatOurs, &aOursSchema, &nOursSchema);
-  if( rc!=SQLITE_OK ) goto done;
-  rc = loadSchemaFromCatalog(db, cs, pCache, pCatTheirs, &aTheirsSchema, &nTheirsSchema);
-  if( rc!=SQLITE_OK ) goto done;
-
-  for(i=0; i<nOursSchema; i++){
-    const char *zName = aOursSchema[i].zName;
-    if( !zName || !aOursSchema[i].zType ) continue;
-    if( strcmp(aOursSchema[i].zType, "table")!=0 ) continue;
-    if( schemaHasTableNamed(aAncSchema, nAncSchema, zName) ) continue;
-    sawOursNew = 1;
-    if( schemaHasTableNamed(aTheirsSchema, nTheirsSchema, zName) ) goto done;
-  }
-
-  for(i=0; i<nTheirsSchema; i++){
-    const char *zName = aTheirsSchema[i].zName;
-    if( !zName || !aTheirsSchema[i].zType ) continue;
-    if( strcmp(aTheirsSchema[i].zType, "table")!=0 ) continue;
-    if( schemaHasTableNamed(aAncSchema, nAncSchema, zName) ) continue;
-    sawTheirsNew = 1;
-    if( schemaHasTableNamed(aOursSchema, nOursSchema, zName) ) goto done;
-  }
-
-  result = sawOursNew && sawTheirsNew;
-done:
-  freeSchemaEntries(aAncSchema, nAncSchema);
-  freeSchemaEntries(aOursSchema, nOursSchema);
-  freeSchemaEntries(aTheirsSchema, nTheirsSchema);
-  return result;
-}
-
 static int schemaEntryChangedByName(
   SchemaEntry *aAnc, int nAnc,
   SchemaEntry *aSide, int nSide,

--- a/src/doltlite_merge_constraints.c
+++ b/src/doltlite_merge_constraints.c
@@ -693,35 +693,6 @@ static int tableHasRowid(sqlite3 *db, const char *zTable){
   return rc == SQLITE_OK ? 1 : 0;
 }
 
-/* Emit a descriptive error and return SQLITE_ERROR. Used when a
-** walker refuses to process a WITHOUT ROWID table. Writes a
-** user-facing message into *ppzErrMsg (owned by sqlite3_free)
-** so the merge function can surface it via sqlite3_result_error
-** instead of falling back to the generic "SQL logic error"
-** text. Safe to pass a NULL ppzErrMsg. */
-static int refuseWithoutRowid(
-  sqlite3 *db,
-  char **ppzErrMsg,
-  const char *zTable,
-  const char *zWhich
-){
-  char *zMsg = sqlite3_mprintf(
-      "constraint-violation detection on WITHOUT ROWID tables is not "
-      "yet supported (%s check on \"%s\"); see GitHub issue #495. "
-      "Drop WITHOUT ROWID or use INTEGER PRIMARY KEY to keep merges flowing.",
-      zWhich, zTable);
-  if( zMsg ){
-    sqlite3_log(SQLITE_ERROR, "%s", zMsg);
-    if( ppzErrMsg && !*ppzErrMsg ){
-      *ppzErrMsg = zMsg;
-    }else{
-      sqlite3_free(zMsg);
-    }
-  }
-  (void)db;
-  return SQLITE_ERROR;
-}
-
 /* Resolve a (zTable, rowid) pair to the raw prolly row by looking
 ** the table up in the current btree's catalog via the public
 ** doltliteGetSessionTableRoot accessor and walking its prolly

--- a/src/doltlite_status.c
+++ b/src/doltlite_status.c
@@ -111,19 +111,6 @@ static int statusLoadLiveTableSql(
   return SQLITE_OK;
 }
 
-static int statusCreateNameQuoted(const char *zSql){
-  const char *z = zSql;
-  if( !z ) return 0;
-  if( sqlite3_strnicmp(z, "CREATE TABLE", 12)!=0 ) return 0;
-  z += 12;
-  while( sqlite3Isspace(*z) ) z++;
-  if( sqlite3_strnicmp(z, "IF NOT EXISTS", 13)==0 ){
-    z += 13;
-    while( sqlite3Isspace(*z) ) z++;
-  }
-  return *z=='"' || *z=='`' || *z=='[';
-}
-
 static int statusSchemaHashMatchesRename(
   const ProllyHash *pOldSchemaHash,
   const char *zCurrentSql,

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -1266,24 +1266,6 @@ static void setCursorToMutMapEntryPhys(BtCursor *pCur, int physIdx){
   }
 }
 
-static void setCursorToMutMapEntry(BtCursor *pCur, int idx){
-  ProllyMutMapEntry *pEntry = prollyMutMapEntryAt(pCur->pMutMap, idx);
-  CLEAR_CACHED_PAYLOAD(pCur);
-  pCur->mmIdx = idx;
-  pCur->mmPhysIdx = -1;
-  pCur->mmActive = 1;
-  pCur->mmPhysActive = 0;
-  pCur->mergeSrc = MERGE_SRC_MUT;
-  pCur->eState = CURSOR_VALID;
-  pCur->curFlags &= ~BTCF_AtLast;
-  if( pCur->curIntKey ){
-    pCur->cachedIntKey = pEntry->intKey;
-    pCur->curFlags |= BTCF_ValidNKey;
-  }else{
-    pCur->curFlags &= ~BTCF_ValidNKey;
-  }
-}
-
 static int advanceTreeCursor(BtCursor *pCur, int dir){
   if( dir>0 ){
     return prollyCursorNext(&pCur->pCur);
@@ -4156,12 +4138,6 @@ static u32 btreeSerialType(Mem *pMem, u32 *pLen){
     return n*2 + SERIAL_TYPE_BLOB_BASE;
   }
   *pLen = 0; return SERIAL_TYPE_NULL;
-}
-
-static int serializeUnpackedRecord(UnpackedRecord *pRec, u8 **ppOut, int *pnOut){
-  int nAlloc = 0;
-  *ppOut = 0;
-  return serializeUnpackedRecordBuffer(pRec, ppOut, &nAlloc, pnOut);
 }
 
 static int findMatchingMutMapEntry(

--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -315,15 +315,6 @@ static int appendUndoRec(ProllyMutMap *mm, int idx){
   return SQLITE_OK;
 }
 
-static void shiftUndoIndices(ProllyMutMap *mm, int idx, int delta){
-  int i;
-  for(i=0; i<mm->nUndo; i++){
-    if( mm->aUndo[i].entryIdx >= idx ){
-      mm->aUndo[i].entryIdx += delta;
-    }
-  }
-}
-
 int prollyMutMapInsert(
   ProllyMutMap *mm,
   const u8 *pKey, int nKey, i64 intKey,


### PR DESCRIPTION
## Summary
Eight static helper functions, each defined exactly once and called nowhere — refactor leftovers in seven different files. -175 lines, zero behavior change.

| File | Function | Lines |
|---|---|---:|
| doltlite_conflicts.c | dupConflictBytes | 10 |
| doltlite_diff_table.c | diffRecordField | 40 |
| doltlite_merge_constraints.c | refuseWithoutRowid | 28 |
| doltlite_merge.c | catalogHasDisjointNewTables | 47 |
| doltlite_status.c | statusCreateNameQuoted | 12 |
| prolly_btree.c | serializeUnpackedRecord | 5 |
| prolly_btree.c | setCursorToMutMapEntry | 17 |
| prolly_mutmap.c | shiftUndoIndices | 8 |

Each was confirmed dead by:
1. Whole-tree \`grep -wn\` finds exactly one occurrence (the definition itself)
2. No header re-exports the symbol
3. None registered via function-pointer table

## Test plan
- [x] \`make doltlite\` clean
- [x] \`doltlite_regression_test_c all\` — 107795 passed, 0 failed
- [x] vc_oracle_merge / branch / diff / error_recovery — 41 / 33 / 41 / 261 passed
- [ ] CI sanitizer + crash-injection durability suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)