### PR TITLE
Add history replay coverage

### DIFF
--- a/test/doltlite_history.sh
+++ b/test/doltlite_history.sh
@@ -198,6 +198,93 @@ run_test "history_filter_second_parent_hash" "SELECT count(DISTINCT commit_hash)
 rm -f "$DB"
 
 # ============================================================
+# History after schema replay ops
+# ============================================================
+
+DB=/tmp/test_hist_merge_replay_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'base');
+SELECT dolt_commit('-A','-m','c1');
+SELECT dolt_checkout('-b','feat');
+CREATE TABLE u(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO u VALUES(1,'feat');
+SELECT dolt_commit('-A','-m','feat_add_u');
+SELECT dolt_checkout('main');
+CREATE TABLE t_new(id INTEGER PRIMARY KEY, v TEXT CHECK (length(v) > 0));
+INSERT INTO t_new SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t_new RENAME TO t;
+SELECT dolt_commit('-A','-m','main_check');
+SELECT dolt_merge('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test "history_merge_replay_u_rows" "SELECT count(*) FROM dolt_history_u;" "2" "$DB"
+run_test "history_merge_replay_u_distinct_commits" "SELECT count(DISTINCT commit_hash) FROM dolt_history_u;" "2" "$DB"
+
+rm -f "$DB"
+
+DB=/tmp/test_hist_cherrypick_replay_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'base');
+SELECT dolt_commit('-A','-m','c1');
+SELECT dolt_checkout('-b','feat');
+CREATE TABLE u(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO u VALUES(1,'feat');
+SELECT dolt_commit('-A','-m','feat_add_u');
+SELECT dolt_checkout('main');
+CREATE TABLE t_new(id INTEGER PRIMARY KEY, v TEXT CHECK (length(v) > 0));
+INSERT INTO t_new SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t_new RENAME TO t;
+SELECT dolt_commit('-A','-m','main_check');
+SELECT dolt_cherry_pick((SELECT hash FROM dolt_branches WHERE name='feat'));" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test "history_cherrypick_replay_u_rows" "SELECT count(*) FROM dolt_history_u;" "1" "$DB"
+run_test "history_cherrypick_replay_u_distinct_commits" "SELECT count(DISTINCT commit_hash) FROM dolt_history_u;" "1" "$DB"
+
+rm -f "$DB"
+
+DB=/tmp/test_hist_revert_replay_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'base');
+SELECT dolt_commit('-A','-m','c1');
+CREATE TABLE t_new(id INTEGER PRIMARY KEY, v TEXT CHECK (length(v) > 0));
+INSERT INTO t_new SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t_new RENAME TO t;
+SELECT dolt_commit('-A','-m','main_check');
+CREATE TABLE u(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO u VALUES(1,'later');
+SELECT dolt_commit('-A','-m','add_u');
+SELECT dolt_revert((SELECT commit_hash FROM dolt_log WHERE message='main_check' LIMIT 1));" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test "history_revert_replay_u_rows" "SELECT count(*) FROM dolt_history_u;" "2" "$DB"
+run_test "history_revert_replay_u_distinct_commits" "SELECT count(DISTINCT commit_hash) FROM dolt_history_u;" "2" "$DB"
+
+rm -f "$DB"
+
+DB=/tmp/test_hist_rebase_replay_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'base');
+SELECT dolt_commit('-A','-m','c1');
+SELECT dolt_checkout('-b','feat');
+CREATE TABLE u(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO u VALUES(1,'feat');
+SELECT dolt_commit('-A','-m','feat_add_u');
+SELECT dolt_checkout('main');
+CREATE TABLE t_new(id INTEGER PRIMARY KEY, v TEXT CHECK (length(v) > 0));
+INSERT INTO t_new SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t_new RENAME TO t;
+SELECT dolt_commit('-A','-m','main_check');
+SELECT dolt_checkout('feat');
+SELECT dolt_rebase('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test "history_rebase_replay_u_rows" "SELECT count(*) FROM dolt_history_u;" "1" "$DB/feat"
+run_test "history_rebase_replay_u_distinct_commits" "SELECT count(DISTINCT commit_hash) FROM dolt_history_u;" "1" "$DB/feat"
+
+rm -f "$DB"
+
+# ============================================================
 # Empty table has no history
 # ============================================================
 

--- a/test/vc_oracle_history_test.sh
+++ b/test/vc_oracle_history_test.sh
@@ -48,6 +48,10 @@ normalize_history() {
           v   = $4
           msg = $5
           who = $6
+          if (msg ~ /^Revert "/) {
+            sub(/^Revert "/, "Revert ", msg)
+            sub(/"$/, "", msg)
+          }
           if (who == "" \
            || who == "root" \
            || who == "oracle" \
@@ -300,6 +304,87 @@ SELECT dolt_merge('feature');
 SELECT dolt_branch('from_p2', 'HEAD^2');
 SELECT dolt_checkout('from_p2');
 "
+
+# Replay a disjoint add-table commit through merge while the main
+# side independently rewrites another table's schema.
+oracle "history_replay_merge_add_table_plus_check" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'base');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_checkout('-b', 'feat');
+CREATE TABLE u(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO u VALUES (1, 'feat');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat_add_u');
+SELECT dolt_checkout('main');
+CREATE TABLE t_new(id INTEGER PRIMARY KEY, v TEXT CHECK (length(v) > 0));
+INSERT INTO t_new SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t_new RENAME TO t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main_check');
+SELECT dolt_merge('feat');
+" "u"
+
+oracle "history_replay_cherrypick_add_table_plus_check" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'base');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_checkout('-b', 'feat');
+CREATE TABLE u(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO u VALUES (1, 'feat');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat_add_u');
+SELECT dolt_checkout('main');
+CREATE TABLE t_new(id INTEGER PRIMARY KEY, v TEXT CHECK (length(v) > 0));
+INSERT INTO t_new SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t_new RENAME TO t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main_check');
+SELECT dolt_cherry_pick((SELECT hash FROM dolt_branches WHERE name='feat'));
+" "u"
+
+oracle "history_replay_revert_schema_change_with_later_added_table" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'base');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+CREATE TABLE t_new(id INTEGER PRIMARY KEY, v TEXT CHECK (length(v) > 0));
+INSERT INTO t_new SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t_new RENAME TO t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main_check');
+CREATE TABLE u(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO u VALUES (1, 'later');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'add_u');
+SELECT dolt_revert((SELECT commit_hash FROM dolt_log WHERE message='main_check' LIMIT 1));
+" "u"
+
+oracle "history_replay_rebase_add_table_plus_check" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'base');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_checkout('-b', 'feat');
+CREATE TABLE u(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO u VALUES (1, 'feat');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat_add_u');
+SELECT dolt_checkout('main');
+CREATE TABLE t_new(id INTEGER PRIMARY KEY, v TEXT CHECK (length(v) > 0));
+INSERT INTO t_new SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t_new RENAME TO t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main_check');
+SELECT dolt_checkout('feat');
+SELECT dolt_rebase('main');
+" "u"
 
 echo "--- edge cases ---"
 


### PR DESCRIPTION
## Summary
- add `dolt_history_<table>` oracle coverage for replay after merge, cherry-pick, revert, and rebase
- add local history regressions for the same replay shapes
- normalize revert-message punctuation in the oracle so it compares behavior instead of quoting style

## Verification
- `bash test/vc_oracle_history_test.sh ./doltlite dolt` -> `24 passed, 0 failed`
- `bash test/doltlite_history.sh` -> `40 passed, 0 failed`