### PR TITLE
Fix diff stat schema-only replay rows

### DIFF
--- a/src/doltlite_diff_stat.c
+++ b/src/doltlite_diff_stat.c
@@ -81,6 +81,36 @@ cleanup:
   return SQLITE_OK;
 }
 
+static int dsLoadCreateSql(
+  sqlite3 *db,
+  const ProllyHash *pCatHash,
+  const char *zTableName,
+  char **pzSqlOut
+){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  ProllyCache *pCache = doltliteGetCache(db);
+  SchemaEntry *aSchemas = 0;
+  int nSchemas = 0;
+  SchemaEntry *pEntry;
+  int rc;
+
+  *pzSqlOut = 0;
+  if( prollyHashIsEmpty(pCatHash) ) return SQLITE_OK;
+
+  rc = loadSchemaFromCatalog(db, cs, pCache, pCatHash, &aSchemas, &nSchemas);
+  if( rc!=SQLITE_OK ) return rc;
+  pEntry = findSchemaEntry(aSchemas, nSchemas, zTableName);
+  if( pEntry && pEntry->zSql ){
+    *pzSqlOut = sqlite3_mprintf("%s", pEntry->zSql);
+    if( !*pzSqlOut ){
+      freeSchemaEntries(aSchemas, nSchemas);
+      return SQLITE_NOMEM;
+    }
+  }
+  freeSchemaEntries(aSchemas, nSchemas);
+  return SQLITE_OK;
+}
+
 static void dsFreeColNames(char **az, int n){
   int i;
   for(i=0; i<n; i++) sqlite3_free(az[i]);
@@ -208,6 +238,7 @@ static int dsCountChangedCells(
 typedef struct DsStatRow DsStatRow;
 struct DsStatRow {
   char *zTableName;
+  int schemaChanged;
   i64 rowsUnmodified;
   i64 rowsAdded;
   i64 rowsDeleted;
@@ -268,8 +299,10 @@ static int dsComputeTableStats(
   int nFromCat = 0, nToCat = 0;
   struct TableEntry *pFromEntry, *pToEntry;
   int hasFrom = 0, hasTo = 0;
+  int schemaChanged = 0;
   ProllyHash fromRoot, toRoot;
   u8 fromFlags = 0, toFlags = 0;
+  char *zFromSql = 0, *zToSql = 0;
   char **azFromCols = 0, **azToCols = 0;
   int nFromCols = 0, nToCols = 0;
   i64 oldCount = 0, newCount = 0;
@@ -309,16 +342,23 @@ static int dsComputeTableStats(
 
 
   if( hasFrom ){
-    rc = dsLoadColNames(db, pFromCatHash, zTableName, &azFromCols, &nFromCols);
+    rc = dsLoadCreateSql(db, pFromCatHash, zTableName, &zFromSql);
     if( rc!=SQLITE_OK ) return rc;
+    rc = dsLoadColNames(db, pFromCatHash, zTableName, &azFromCols, &nFromCols);
+    if( rc!=SQLITE_OK ) goto done;
   }
   if( hasTo ){
+    rc = dsLoadCreateSql(db, pToCatHash, zTableName, &zToSql);
+    if( rc!=SQLITE_OK ) goto done;
     rc = dsLoadColNames(db, pToCatHash, zTableName, &azToCols, &nToCols);
     if( rc!=SQLITE_OK ){
-      dsFreeColNames(azFromCols, nFromCols);
-      return rc;
+      goto done;
     }
   }
+
+  schemaChanged =
+    hasFrom && hasTo &&
+    strcmp(zFromSql ? zFromSql : "", zToSql ? zToSql : "")!=0;
 
 
   if( hasFrom ){
@@ -398,6 +438,7 @@ static int dsComputeTableStats(
   }
 
   pOut->zTableName     = sqlite3_mprintf("%s", zTableName);
+  pOut->schemaChanged  = schemaChanged;
   pOut->rowsAdded      = rowsAdd;
   pOut->rowsDeleted    = rowsDel;
   pOut->rowsModified   = rowsMod;
@@ -411,7 +452,19 @@ static int dsComputeTableStats(
   pOut->oldCellCount   = (i64)oldCount * nFromCols;
   pOut->newCellCount   = (i64)newCount * nToCols;
 
+  if( schemaChanged
+   && rowsAdd==0 && rowsDel==0 && rowsMod==0
+   && cellsAdd==0 && cellsDel==0 && cellsMod==0 ){
+    pOut->rowsUnmodified = 0;
+    pOut->oldRowCount = 0;
+    pOut->newRowCount = 0;
+    pOut->oldCellCount = 0;
+    pOut->newCellCount = 0;
+  }
+
 done:
+  sqlite3_free(zFromSql);
+  sqlite3_free(zToSql);
   dsFreeColNames(azFromCols, nFromCols);
   dsFreeColNames(azToCols, nToCols);
   return rc;
@@ -692,8 +745,10 @@ static int dstFilter(sqlite3_vtab_cursor *cur,
 
     if( row.rowsAdded==0 && row.rowsDeleted==0 && row.rowsModified==0
      && row.cellsAdded==0 && row.cellsDeleted==0 && row.cellsModified==0 ){
-      sqlite3_free(row.zTableName);
-      continue;
+      if( !row.schemaChanged ){
+        sqlite3_free(row.zTableName);
+        continue;
+      }
     }
     rc = dstAppend(c, &row);
     if( rc!=SQLITE_OK ){ sqlite3_free(row.zTableName); goto done; }

--- a/test/doltlite_diff.sh
+++ b/test/doltlite_diff.sh
@@ -151,7 +151,47 @@ run_test "diff_rename_recreate_family_count" \
   "SELECT count(*) FROM dolt_diff_stat('HEAD~1', 'HEAD');" \
   "2" "$DB7"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7"
+DB8=/tmp/test_diff8_$$.db; rm -f "$DB8"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','c1'); SELECT dolt_checkout('-b','feat'); CREATE TABLE u(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO u VALUES(1,'feat'); SELECT dolt_commit('-A','-m','feat_add_u'); SELECT dolt_checkout('main'); CREATE TABLE t_new(id INTEGER PRIMARY KEY, v TEXT CHECK (length(v) > 0)); INSERT INTO t_new SELECT * FROM t; DROP TABLE t; ALTER TABLE t_new RENAME TO t; SELECT dolt_commit('-A','-m','main_check'); SELECT dolt_merge('feat');" | $DOLTLITE "$DB8" > /dev/null 2>&1
+
+run_test "diff_merge_replay_stat" \
+  "SELECT rows_added || '|' || rows_modified || '|' || rows_deleted FROM dolt_diff_stat('HEAD^1', 'HEAD', 'u');" \
+  "1|0|0" "$DB8"
+run_test "diff_merge_replay_summary" \
+  "SELECT coalesce(from_table_name,'') || '|' || coalesce(to_table_name,'') || '|' || diff_type || '|' || data_change || '|' || schema_change FROM dolt_diff_summary('HEAD^1', 'HEAD', 'u');" \
+  "|u|added|1|1" "$DB8"
+
+DB9=/tmp/test_diff9_$$.db; rm -f "$DB9"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','c1'); SELECT dolt_checkout('-b','feat'); CREATE TABLE u(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO u VALUES(1,'feat'); SELECT dolt_commit('-A','-m','feat_add_u'); SELECT dolt_checkout('main'); CREATE TABLE t_new(id INTEGER PRIMARY KEY, v TEXT CHECK (length(v) > 0)); INSERT INTO t_new SELECT * FROM t; DROP TABLE t; ALTER TABLE t_new RENAME TO t; SELECT dolt_commit('-A','-m','main_check'); SELECT dolt_cherry_pick((SELECT hash FROM dolt_branches WHERE name='feat'));" | $DOLTLITE "$DB9" > /dev/null 2>&1
+
+run_test "diff_cherrypick_replay_stat" \
+  "SELECT rows_added || '|' || rows_modified || '|' || rows_deleted FROM dolt_diff_stat('HEAD~1', 'HEAD', 'u');" \
+  "1|0|0" "$DB9"
+run_test "diff_cherrypick_replay_summary" \
+  "SELECT coalesce(from_table_name,'') || '|' || coalesce(to_table_name,'') || '|' || diff_type || '|' || data_change || '|' || schema_change FROM dolt_diff_summary('HEAD~1', 'HEAD', 'u');" \
+  "|u|added|1|1" "$DB9"
+
+DB10=/tmp/test_diff10_$$.db; rm -f "$DB10"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','c1'); SELECT dolt_checkout('-b','feat'); CREATE TABLE u(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO u VALUES(1,'feat'); SELECT dolt_commit('-A','-m','feat_add_u'); SELECT dolt_checkout('main'); CREATE TABLE t_new(id INTEGER PRIMARY KEY, v TEXT CHECK (length(v) > 0)); INSERT INTO t_new SELECT * FROM t; DROP TABLE t; ALTER TABLE t_new RENAME TO t; SELECT dolt_commit('-A','-m','main_check'); SELECT dolt_checkout('feat'); SELECT dolt_rebase('main');" | $DOLTLITE "$DB10" > /dev/null 2>&1
+
+run_test "diff_rebase_replay_stat" \
+  "SELECT rows_added || '|' || rows_modified || '|' || rows_deleted FROM dolt_diff_stat('main', 'feat', 'u');" \
+  "1|0|0" "$DB10/feat"
+run_test "diff_rebase_replay_summary" \
+  "SELECT coalesce(from_table_name,'') || '|' || coalesce(to_table_name,'') || '|' || diff_type || '|' || data_change || '|' || schema_change FROM dolt_diff_summary('main', 'feat', 'u');" \
+  "|u|added|1|1" "$DB10/feat"
+
+DB11=/tmp/test_diff11_$$.db; rm -f "$DB11"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','c1'); CREATE TABLE t_new(id INTEGER PRIMARY KEY, v TEXT CHECK (length(v) > 0)); INSERT INTO t_new SELECT * FROM t; DROP TABLE t; ALTER TABLE t_new RENAME TO t; SELECT dolt_commit('-A','-m','main_check'); CREATE TABLE u(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO u VALUES(1,'later'); SELECT dolt_commit('-A','-m','add_u'); SELECT dolt_revert((SELECT commit_hash FROM dolt_log WHERE message='main_check' LIMIT 1));" | $DOLTLITE "$DB11" > /dev/null 2>&1
+
+run_test "diff_revert_schema_only_replay_stat_count" \
+  "SELECT count(*) FROM dolt_diff_stat('HEAD~1', 'HEAD');" \
+  "1" "$DB11"
+run_test "diff_revert_schema_only_replay_stat_row" \
+  "SELECT table_name || '|' || rows_added || '|' || rows_modified || '|' || rows_deleted FROM dolt_diff_stat('HEAD~1', 'HEAD');" \
+  "t|0|0|0" "$DB11"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/vc_oracle_diff_stat_test.sh
+++ b/test/vc_oracle_diff_stat_test.sh
@@ -363,6 +363,87 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c2');
 " "HEAD~1" "HEAD"
 
+echo "--- replay after schema changes ---"
+
+oracle_both "diff_stat_merge_replay_add_table_plus_check" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'base');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_checkout('-b', 'feat');
+CREATE TABLE u(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO u VALUES (1, 'feat');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat_add_u');
+SELECT dolt_checkout('main');
+CREATE TABLE t_new(id INTEGER PRIMARY KEY, v TEXT CHECK (length(v) > 0));
+INSERT INTO t_new SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t_new RENAME TO t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main_check');
+SELECT dolt_merge('feat');
+" "HEAD^1" "HEAD" "u"
+
+oracle_both "diff_stat_cherrypick_replay_add_table_plus_check" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'base');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_checkout('-b', 'feat');
+CREATE TABLE u(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO u VALUES (1, 'feat');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat_add_u');
+SELECT dolt_checkout('main');
+CREATE TABLE t_new(id INTEGER PRIMARY KEY, v TEXT CHECK (length(v) > 0));
+INSERT INTO t_new SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t_new RENAME TO t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main_check');
+SELECT dolt_cherry_pick((SELECT hash FROM dolt_branches WHERE name='feat'));
+" "HEAD~1" "HEAD" "u"
+
+oracle_both "diff_stat_rebase_replay_add_table_plus_check" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'base');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_checkout('-b', 'feat');
+CREATE TABLE u(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO u VALUES (1, 'feat');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat_add_u');
+SELECT dolt_checkout('main');
+CREATE TABLE t_new(id INTEGER PRIMARY KEY, v TEXT CHECK (length(v) > 0));
+INSERT INTO t_new SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t_new RENAME TO t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main_check');
+SELECT dolt_checkout('feat');
+SELECT dolt_rebase('main');
+" "main" "feat" "u"
+
+oracle_both "diff_stat_revert_schema_change_with_later_added_table" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'base');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+CREATE TABLE t_new(id INTEGER PRIMARY KEY, v TEXT CHECK (length(v) > 0));
+INSERT INTO t_new SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t_new RENAME TO t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main_check');
+CREATE TABLE u(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO u VALUES (1, 'later');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'add_u');
+SELECT dolt_revert((SELECT commit_hash FROM dolt_log WHERE message='main_check' LIMIT 1));
+" "HEAD~1" "HEAD"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then


### PR DESCRIPTION
## Summary
- fix `dolt_diff_stat` so schema-only replay changes on an existing table still emit the zero-count row Dolt reports
- add replay-after-schema coverage for merge, cherry-pick, revert, and rebase to the diff stat oracle and local regressions
- keep empty-table create/drop behavior unchanged while matching Dolt on same-table schema-only replay

## Verification
- `bash test/vc_oracle_diff_stat_test.sh ./doltlite dolt` -> `50 passed, 0 failed`
- `bash test/doltlite_diff.sh` -> `32 passed, 0 failed`