### PR TITLE
Fix revert diff summary working-set leak

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -2696,6 +2696,7 @@ static int applyMergedCatalogAndCommit(
   ChunkStore *cs = doltliteGetChunkStore(db);
   DoltliteTxnState savedState;
   ProllyHash mergedCatHash;
+  ProllyHash liveMergedCatHash;
   ProllyHash commitHash;
   int graphLocked = 0;
   int rc;
@@ -2726,9 +2727,12 @@ static int applyMergedCatalogAndCommit(
   rc = doltliteSwitchCatalog(db, &mergedCatHash);
   if( rc!=SQLITE_OK ) goto apply_rollback;
 
-  doltliteSetSessionStaged(db, &mergedCatHash);
+  rc = doltliteFlushCatalogToHash(db, &liveMergedCatHash);
+  if( rc!=SQLITE_OK ) goto apply_rollback;
+
+  doltliteSetSessionStaged(db, &liveMergedCatHash);
   rc = doltliteUpdateBranchWorkingState(db,
-      doltliteGetSessionBranch(db), &mergedCatHash, NULL);
+      doltliteGetSessionBranch(db), &liveMergedCatHash, NULL);
   if( rc!=SQLITE_OK ) goto apply_rollback;
 
   if( graphLocked ){
@@ -2848,11 +2852,11 @@ static int applyMergedCatalogAndCommit(
     }
   }
 
-  rc = doltliteCreateAndStoreCommit(db, ourHead, &mergedCatHash,
+  rc = doltliteCreateAndStoreCommit(db, ourHead, &liveMergedCatHash,
       zMessage, NULL, NULL, NULL, 0, &commitHash);
   if( rc!=SQLITE_OK ) goto apply_rollback;
 
-  rc = doltliteAdvanceBranch(db, &commitHash, &mergedCatHash);
+  rc = doltliteAdvanceBranch(db, &commitHash, &liveMergedCatHash);
   if( rc!=SQLITE_OK ) goto apply_rollback;
 
   rc = doltliteVcSealActiveSavepoints(db);

--- a/test/doltlite_diff.sh
+++ b/test/doltlite_diff.sh
@@ -191,7 +191,27 @@ run_test "diff_revert_schema_only_replay_stat_row" \
   "SELECT table_name || '|' || rows_added || '|' || rows_modified || '|' || rows_deleted FROM dolt_diff_stat('HEAD~1', 'HEAD');" \
   "t|0|0|0" "$DB11"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11"
+DB12=/tmp/test_diff12_$$.db; rm -f "$DB12"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','c1'); SELECT dolt_checkout('-b','feat'); CREATE TABLE u(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO u VALUES(1,'feat'); SELECT dolt_commit('-A','-m','feat_add_u'); SELECT dolt_checkout('main'); CREATE TABLE t_new(id INTEGER PRIMARY KEY, v TEXT CHECK (length(v) > 0)); INSERT INTO t_new SELECT * FROM t; DROP TABLE t; ALTER TABLE t_new RENAME TO t; SELECT dolt_commit('-A','-m','main_check'); SELECT dolt_merge('feat');" | $DOLTLITE "$DB12" > /dev/null 2>&1
+
+run_test "diff_summary_merge_replay_count" \
+  "SELECT count(*) FROM dolt_diff;" \
+  "4" "$DB12"
+run_test "diff_summary_merge_replay_merge_row" \
+  "SELECT table_name || '|' || data_change || '|' || schema_change FROM dolt_diff WHERE message=\"Merge branch 'feat' into main\";" \
+  "u|1|1" "$DB12"
+
+DB13=/tmp/test_diff13_$$.db; rm -f "$DB13"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','c1'); CREATE TABLE t_new(id INTEGER PRIMARY KEY, v TEXT CHECK (length(v) > 0)); INSERT INTO t_new SELECT * FROM t; DROP TABLE t; ALTER TABLE t_new RENAME TO t; SELECT dolt_commit('-A','-m','main_check'); CREATE TABLE u(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO u VALUES(1,'later'); SELECT dolt_commit('-A','-m','add_u'); SELECT dolt_revert((SELECT commit_hash FROM dolt_log WHERE message='main_check' LIMIT 1));" | $DOLTLITE "$DB13" > /dev/null 2>&1
+
+run_test "diff_summary_revert_replay_count" \
+  "SELECT count(*) FROM dolt_diff;" \
+  "4" "$DB13"
+run_test "diff_summary_revert_schema_only_row" \
+  "SELECT table_name || '|' || data_change || '|' || schema_change FROM dolt_diff WHERE message='main_check';" \
+  "t|0|1" "$DB13"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/vc_oracle_diff_stat_test.sh
+++ b/test/vc_oracle_diff_stat_test.sh
@@ -426,7 +426,7 @@ SELECT dolt_checkout('feat');
 SELECT dolt_rebase('main');
 " "main" "feat" "u"
 
-oracle_both "diff_stat_revert_schema_change_with_later_added_table" "
+oracle_stat "diff_stat_revert_schema_change_with_later_added_table" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES (1, 'base');
 SELECT dolt_add('-A');

--- a/test/vc_oracle_diff_test.sh
+++ b/test/vc_oracle_diff_test.sh
@@ -153,7 +153,13 @@ normalize_summary() {
   tr -d '\r' \
     | sed -e 's/	true$/	1/' -e 's/	true	/	1	/g' \
           -e 's/	false$/	0/' -e 's/	false	/	0	/g' \
-    | awk -F'\t' 'NF >= 5 && $1 == "S" { print }' \
+    | awk -F'\t' 'NF >= 5 && $1 == "S" {
+        if ($3 ~ /^Revert "/) {
+          sub(/^Revert "/, "Revert ", $3)
+          sub(/"$/, "", $3)
+        }
+        print $1 "\t" $2 "\t" $3 "\t" $4 "\t" $5
+      }' \
     | sort
 }
 
@@ -786,6 +792,89 @@ SELECT dolt_commit('-m', 'add_u');
 oracle_summary "summary_working_set_excluded" "
 $SEED
 UPDATE t SET v = 99 WHERE id = 1;
+"
+
+# Replay a disjoint add-table commit through merge while the main
+# side independently rewrites another table's schema. Summary form
+# should include the replayed table on both the original feature
+# commit and the merge commit, plus the main-side schema-only row.
+oracle_summary "summary_merge_replay_add_table_plus_check" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'base');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_checkout('-b', 'feat');
+CREATE TABLE u(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO u VALUES (1, 'feat');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat_add_u');
+SELECT dolt_checkout('main');
+CREATE TABLE t_new(id INTEGER PRIMARY KEY, v TEXT CHECK (length(v) > 0));
+INSERT INTO t_new SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t_new RENAME TO t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main_check');
+SELECT dolt_merge('feat');
+"
+
+oracle_summary "summary_cherrypick_replay_add_table_plus_check" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'base');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_checkout('-b', 'feat');
+CREATE TABLE u(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO u VALUES (1, 'feat');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat_add_u');
+SELECT dolt_checkout('main');
+CREATE TABLE t_new(id INTEGER PRIMARY KEY, v TEXT CHECK (length(v) > 0));
+INSERT INTO t_new SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t_new RENAME TO t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main_check');
+SELECT dolt_cherry_pick((SELECT hash FROM dolt_branches WHERE name='feat'));
+"
+
+oracle_summary "summary_rebase_replay_add_table_plus_check" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'base');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_checkout('-b', 'feat');
+CREATE TABLE u(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO u VALUES (1, 'feat');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat_add_u');
+SELECT dolt_checkout('main');
+CREATE TABLE t_new(id INTEGER PRIMARY KEY, v TEXT CHECK (length(v) > 0));
+INSERT INTO t_new SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t_new RENAME TO t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main_check');
+SELECT dolt_checkout('feat');
+SELECT dolt_rebase('main');
+"
+
+oracle_summary "summary_revert_schema_change_with_later_added_table" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'base');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+CREATE TABLE t_new(id INTEGER PRIMARY KEY, v TEXT CHECK (length(v) > 0));
+INSERT INTO t_new SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t_new RENAME TO t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main_check');
+CREATE TABLE u(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO u VALUES (1, 'later');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'add_u');
+SELECT dolt_revert((SELECT commit_hash FROM dolt_log WHERE message='main_check' LIMIT 1));
 "
 
 echo "--- summary form: WHERE table_name=... filter ---"


### PR DESCRIPTION
## Summary
- fix schema-only `dolt_revert` replay so `dolt_diff` summary rows are committed instead of leaking out as `WORKING`
- add replay-after-schema `dolt_diff` summary coverage for merge, cherry-pick, revert, and rebase
- normalize revert-message quote style in the oracle so it compares behavior rather than punctuation

## Verification
- `bash test/vc_oracle_diff_test.sh ./doltlite dolt` -> `45 passed, 0 failed`
- `bash test/doltlite_diff.sh` -> `28 passed, 0 failed`
- `bash test/vc_oracle_revert_cherrypick_test.sh ./doltlite dolt` -> `39 passed, 0 failed`