### PR TITLE
prolly_cursor: drop the half-dead Save mechanism

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -1383,8 +1383,6 @@ static int ensureMutMap(BtCursor *pCur){
 }
 
 static int saveCursorPosition(BtCursor *pCur){
-  int rc = SQLITE_OK;
-
   if( pCur->eState!=CURSOR_VALID && pCur->eState!=CURSOR_SKIPNEXT ){
     return SQLITE_OK;
   }
@@ -1439,10 +1437,7 @@ static int saveCursorPosition(BtCursor *pCur){
     }
   }
 
-  rc = prollyCursorSave(&pCur->pCur);
-  if( rc!=SQLITE_OK ){
-    return rc;
-  }
+  prollyCursorReleaseAll(&pCur->pCur);
 
   pCur->eState = CURSOR_REQUIRESEEK;
   return SQLITE_OK;

--- a/src/prolly_cursor.c
+++ b/src/prolly_cursor.c
@@ -369,47 +369,6 @@ void prollyCursorValue(ProllyCursor *cur, const u8 **ppVal, int *pnVal){
   prollyNodeValue(&pLeaf->node, idx, ppVal, pnVal);
 }
 
-int prollyCursorSave(ProllyCursor *cur){
-  if( cur->eState!=PROLLY_CURSOR_VALID ){
-    cur->hasSavedPosition = 0;
-    return SQLITE_OK;
-  }
-
-
-  if( cur->iLevel < 0 || cur->iLevel >= PROLLY_CURSOR_MAX_DEPTH
-   || !cur->aLevel[cur->iLevel].pEntry ){
-    cur->hasSavedPosition = 0;
-    cur->eState = PROLLY_CURSOR_INVALID;
-    return SQLITE_OK;
-  }
-
-
-  if( cur->flags & PROLLY_NODE_INTKEY ){
-    cur->iSavedIntKey = prollyCursorIntKey(cur);
-  } else {
-    const u8 *pKey;
-    int nKey;
-    prollyCursorKey(cur, &pKey, &nKey);
-    if( cur->pSavedKey ){
-      sqlite3_free(cur->pSavedKey);
-      cur->pSavedKey = 0;
-    }
-    cur->pSavedKey = (u8*)sqlite3_malloc(nKey);
-    if( cur->pSavedKey==0 ){
-      return SQLITE_NOMEM;
-    }
-    memcpy(cur->pSavedKey, pKey, nKey);
-    cur->nSavedKey = nKey;
-  }
-
-
-  prollyCursorReleaseAll(cur);
-
-  cur->hasSavedPosition = 1;
-  cur->eState = PROLLY_CURSOR_INVALID;
-  return SQLITE_OK;
-}
-
 void prollyCursorReleaseAll(ProllyCursor *cur){
   int i;
   for(i=0; i<PROLLY_CURSOR_MAX_DEPTH; i++){
@@ -427,13 +386,6 @@ void prollyCursorReleaseAll(ProllyCursor *cur){
 
 void prollyCursorClose(ProllyCursor *cur){
   prollyCursorReleaseAll(cur);
-  if( cur->pSavedKey ){
-    sqlite3_free(cur->pSavedKey);
-    cur->pSavedKey = 0;
-    cur->nSavedKey = 0;
-  }
-  cur->hasSavedPosition = 0;
-  cur->eState = PROLLY_CURSOR_INVALID;
 }
 
 #endif

--- a/src/prolly_cursor.h
+++ b/src/prolly_cursor.h
@@ -33,14 +33,6 @@ struct ProllyCursor {
   ProllyCursorLevel aLevel[PROLLY_CURSOR_MAX_DEPTH];
 
   u8 eState;
-
-  /* Saved logical position for prollyCursorSave/Restore. After a
-  ** write invalidates cache pointers, the cursor reseeks by key
-  ** rather than by cached node pointers. */
-  u8 *pSavedKey;
-  int nSavedKey;
-  i64 iSavedIntKey;
-  u8 hasSavedPosition;
 };
 
 #define PROLLY_CURSOR_VALID    0
@@ -70,8 +62,6 @@ void prollyCursorKey(ProllyCursor *cur, const u8 **ppKey, int *pnKey);
 i64 prollyCursorIntKey(ProllyCursor *cur);
 
 void prollyCursorValue(ProllyCursor *cur, const u8 **ppVal, int *pnVal);
-
-int prollyCursorSave(ProllyCursor *cur);
 
 void prollyCursorReleaseAll(ProllyCursor *cur);
 


### PR DESCRIPTION
## Summary
Round 5 follow-up to #689 — clean up the half-dead \`prollyCursorSave\` we explicitly noted there.

After \`prollyCursorRestore\` was deleted in #689, Save's saved-position output (\`pSavedKey\`, \`nSavedKey\`, \`iSavedIntKey\`, \`hasSavedPosition\`) became write-only. Save populated them, only Restore read them, and Restore is gone. Save still had a real second job — releasing cache page refs and marking the cursor invalid — but that work was buried under ~30 lines of dead malloc+memcpy.

### Changes
1. **\`prolly_btree.c::saveCursorPosition\`** — replace \`prollyCursorSave\` call with a direct \`prollyCursorReleaseAll\` call (which sets \`eState=INVALID\` for free), drop the now-unused \`rc\` variable.
2. **\`prollyCursorSave\`** — deleted entirely (function and header decl).
3. **\`ProllyCursor\` struct** — drop the four saved-position fields.
4. **\`prollyCursorClose\`** — collapses to a single-line \`prollyCursorReleaseAll\` call.

Net: **−63 lines, one fewer malloc + memcpy per cursor suspension** (used to copy the key on every \`saveCursorPosition\` call).

## Test plan
- [x] \`make doltlite\` clean
- [x] \`doltlite_regression_test_c all\` — 107795 passed
- [x] vc_oracle_merge / branch / diff / error_recovery — 41 / 33 / 44 / 261 passed
- [x] chunk_distribution — clean
- [ ] CI sanitizer + crash-injection durability suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)