### PR TITLE
chore: clean up orphans left by prior cleanup rounds

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -515,7 +515,6 @@ static void csFreeRefsState(ChunkStore *cs){
   cs->zDefaultBranch = 0;
 }
 
-#define CS_INIT_INDEX_ALLOC   64
 #define CS_INIT_PENDING_ALLOC 16
 #define CS_INIT_WRITEBUF_SIZE 4096
 

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -3543,21 +3543,6 @@ fail:
   return rc;
 }
 
-/* Checkout helper used by rebase to switch the session back to the
-** original branch after --continue or --abort. Delegates to the
-** existing dolt_checkout function so we don't reimplement the full
-** state transition (working set load, catalog switch, branch ref
-** lookup, etc.). */
-static int rebaseCheckoutBranch(sqlite3 *db, const char *zBranch){
-  char *zSql;
-  int rc;
-  zSql = sqlite3_mprintf("SELECT dolt_checkout('%q')", zBranch);
-  if( !zSql ) return SQLITE_NOMEM;
-  rc = sqlite3_exec(db, zSql, 0, 0, 0);
-  sqlite3_free(zSql);
-  return rc;
-}
-
 static int rebaseRestoreBranchState(sqlite3 *db, const char *zBranch){
   ChunkStore *cs = doltliteGetChunkStore(db);
   ProllyHash headHash;

--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -1257,22 +1257,6 @@ static int recordSchemaAddColumns(
   return SQLITE_OK;
 }
 
-static int schemaHasTableNamed(
-  SchemaEntry *aSchema, int nSchema,
-  const char *zName
-){
-  int i;
-  for(i=0; i<nSchema; i++){
-    if( aSchema[i].zName
-     && aSchema[i].zType
-     && strcmp(aSchema[i].zType, "table")==0
-     && strcmp(aSchema[i].zName, zName)==0 ){
-      return 1;
-    }
-  }
-  return 0;
-}
-
 static int schemaEntryChangedByName(
   SchemaEntry *aAnc, int nAnc,
   SchemaEntry *aSide, int nSide,


### PR DESCRIPTION
## Summary
Three orphans surfaced by re-grepping after PRs #682 and #685 merged:

1. **\`schemaHasTableNamed\`** (doltlite_merge.c, −14 lines) — was only called by \`catalogHasDisjointNewTables\`, which #685 deleted. Helper got orphaned the moment its parent went.
2. **\`rebaseCheckoutBranch\`** (doltlite.c, −15 lines incl. comment) — static helper that wrapped a \`SELECT dolt_checkout(...)\` exec. Defined, commented, unused. Refactor leftover.
3. **\`CS_INIT_INDEX_ALLOC\`** macro (chunk_store.c, −1 line) — partner of the \`nIndexAlloc\` field that #682 dropped. Macro went stale but stayed.

Net: −32 lines, no behavior change. Each is a separate cascade from a previous round's deletion — proof that one cleanup round seeds the next.

## Test plan
- [x] \`make doltlite\` clean
- [x] \`doltlite_regression_test_c all\` — 107795 passed, 0 failed
- [ ] CI sanitizer + crash-injection durability suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)