### PR TITLE
chore: drop four unused BTS_* flag macros

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -68,11 +68,7 @@ char *doltliteResolveTableNumber(sqlite3 *db, Pgno iTable);
 #define BTCF_Pinned     0x40
 
 #define BTS_READ_ONLY       0x0001
-#define BTS_PAGESIZE_FIXED  0x0002
-#define BTS_SECURE_DELETE   0x0004
-#define BTS_OVERWRITE       0x0008
 #define BTS_INITIALLY_EMPTY 0x0010
-#define BTS_NO_WAL          0x0020
 
 #define CLEAR_CACHED_PAYLOAD(pCur) do{ \
   if( (pCur)->cachedPayloadOwned && (pCur)->pCachedPayload ){ \


### PR DESCRIPTION
## Summary
Last small thing flagged in round 5 but skipped at the time. Four \`BTS_*\` macros in \`prolly_btree.c\` were copied from SQLite's \`btreeInt.h\` for bit-position alignment, but prolly_btree honors only two of them (\`BTS_READ_ONLY\`, \`BTS_INITIALLY_EMPTY\`). The other four — \`PAGESIZE_FIXED\`, \`SECURE_DELETE\`, \`OVERWRITE\`, \`NO_WAL\` — never appeared in any conditional or assignment. Just sitting there.

\`SAVEPOINT_RELEASE\` (also flagged earlier) stays — it's part of an \`#ifndef SAVEPOINT_BEGIN\` trio with \`SAVEPOINT_BEGIN\` and \`SAVEPOINT_ROLLBACK\` that picks up SQLite's values when the headers are present, falls back to ours otherwise. Splitting the trio asymmetrically would be worse than leaving it alone.

## Test plan
- [x] \`make doltlite\` clean
- [x] \`doltlite_regression_test_c all\` — 107795 passed, 0 failed
- [ ] CI sanitizer + crash-injection durability suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)