### PR TITLE
prolly_btree/prolly_cursor: more dead-code spelunking

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -440,7 +440,7 @@ static int btreeWriteWorkingState(
   const ProllyHash *pCatHash,
   const ProllyHash *pCommitHash
 );
-static int btreeDeleteImmediate(BtCursor *pCur, const u8 *pKey, int nKey, i64 iKey);
+static int btreeDeleteImmediate(BtCursor *pCur);
 
 /*
 ** Bound deferred per-table edit growth by forcing a mutmap drain once the
@@ -4924,11 +4924,8 @@ static int flushDeferredEdits(BtShared *pBt){
   return rc;
 }
 
-static int btreeDeleteImmediate(BtCursor *pCur, const u8 *pKey, int nKey, i64 iKey){
+static int btreeDeleteImmediate(BtCursor *pCur){
   int rc;
-  (void)pKey;
-  (void)nKey;
-  (void)iKey;
 
   rc = flushMutMap(pCur);
   if( rc!=SQLITE_OK ){
@@ -5086,7 +5083,7 @@ static int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
   }
 
 
-  rc = btreeDeleteImmediate(pCur, pKey, nKey, iKey);
+  rc = btreeDeleteImmediate(pCur);
   if( rc!=SQLITE_OK ) return rc;
 
   if( flags & BTREE_SAVEPOSITION ){
@@ -5412,7 +5409,6 @@ int sqlite3BtreeIntegrityCheck(
   }
 
   (void)aCnt;
-  (void)mxErr;
 
   if( !p->pBt ){
     if( pnErr ) *pnErr = 0;
@@ -5663,7 +5659,7 @@ sqlite3_uint64 sqlite3BtreeSeekCount(Btree *p){
 
 #ifdef SQLITE_TEST
 int sqlite3BtreeCursorInfo(BtCursor *pCur, int *aResult, int upCnt){
-  (void)pCur; (void)upCnt;
+  (void)pCur;
   if( aResult ){
     aResult[0] = 0;
     aResult[1] = 0;

--- a/src/prolly_cursor.c
+++ b/src/prolly_cursor.c
@@ -59,7 +59,6 @@ static int initCursorAtRoot(ProllyCursor *cur, ProllyCacheEntry **ppRoot){
   if( rc!=SQLITE_OK ) return rc;
 
   cur->iLevel = 0;
-  cur->nLevel = 1;
   cur->aLevel[0].pEntry = pRoot;
   cur->aLevel[0].idx = 0;
   if( ppRoot ) *ppRoot = pRoot;
@@ -85,7 +84,6 @@ static int descendToChild(ProllyCursor *cur, int childSlot,
 
   cur->aLevel[cur->iLevel].pEntry = pChild;
   cur->aLevel[cur->iLevel].idx = childIdx;
-  cur->nLevel = cur->iLevel + 1;
   if( ppChild ) *ppChild = pChild;
   return SQLITE_OK;
 }
@@ -378,7 +376,6 @@ void prollyCursorReleaseAll(ProllyCursor *cur){
       cur->aLevel[i].idx = 0;
     }
   }
-  cur->nLevel = 0;
   cur->iLevel = 0;
 
   cur->eState = PROLLY_CURSOR_INVALID;

--- a/src/prolly_cursor.h
+++ b/src/prolly_cursor.h
@@ -18,9 +18,9 @@ struct ProllyCursorLevel {
   int idx;
 };
 
-/* iLevel is the CURRENT depth (leaf when fully descended), nLevel is
-** the depth the tree was loaded to. aLevel[0..iLevel] each hold a
-** pinned ProllyCacheEntry — they must be released on cursor close or
+/* iLevel is the current cursor depth (0 = root, iLevel = leaf when
+** fully descended). aLevel[0..iLevel] each hold a pinned
+** ProllyCacheEntry — they must be released on cursor close or
 ** re-seek or the cache entries leak their node buffer. */
 struct ProllyCursor {
   ChunkStore *pStore;
@@ -28,7 +28,6 @@ struct ProllyCursor {
   ProllyHash root;
   u8 flags;
 
-  int nLevel;
   int iLevel;
   ProllyCursorLevel aLevel[PROLLY_CURSOR_MAX_DEPTH];
 


### PR DESCRIPTION
## Summary
Round 8. The deeper sweep through prolly_btree.c found smaller stuff but each one is real.

### Commit 1: \`prolly_btree.c\` — dead params and stale (void) suppressions
- \`btreeDeleteImmediate\` took (pCur, pKey, nKey, iKey) and immediately did \`(void)pKey; (void)nKey; (void)iKey;\`. Static, single caller. Three dead params and three dead suppressions out, single caller updated.
- \`sqlite3BtreeIntegrityCheck\` had \`(void)mxErr;\` directly above \`ctx.mxErr = mxErr;\`. Bullshit suppression — the param has been used the whole time.
- \`sqlite3BtreeCursorInfo\` had \`(void)upCnt;\` while the body uses \`upCnt\` in two if-conditions. Same kind of stale lie.

### Commit 2: \`prolly_cursor\` — drop write-only \`nLevel\` field
\`ProllyCursor.nLevel\` set in three places, read in zero. Struct comment lovingly described it as "the depth the tree was loaded to" — distinct from \`iLevel\` — but no one ever checked.

Net: -15 lines.

## Test plan
- [x] \`make doltlite\` clean
- [x] \`doltlite_regression_test_c all\` — 107795 passed, 0 failed
- [x] vc_oracle_merge / branch / diff / error_recovery — 41 / 33 / 48 / 261 passed
- [x] chunk_distribution — clean
- [ ] CI sanitizer + crash-injection durability suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)