### PR TITLE
chunk_store: drop dead csSerializeIndexEntry helper

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -130,7 +130,6 @@ static int csSearchIndex(const ChunkIndexEntry *aIdx, int nIdx,
 static int csSearchPending(ChunkStore *cs, const ProllyHash *pHash);
 static int csIndexEntryCmp(const void *a, const void *b);
 void csSerializeManifest(const ChunkStore *cs, u8 *aBuf);
-static void csSerializeIndexEntry(const ChunkIndexEntry *e, u8 *aBuf);
 static void csDeserializeIndexEntry(const u8 *aBuf, ChunkIndexEntry *e);
 static int csMergeIndex(ChunkStore *cs, ChunkIndexEntry **ppMerged,
                         int *pnMerged);
@@ -709,12 +708,6 @@ void csSerializeManifest(const ChunkStore *cs, u8 *aBuf){
 
   CS_WRITE_I64(aBuf + 84, cs->iWalOffset);
   memcpy(aBuf + 104, cs->refsHash.data, PROLLY_HASH_SIZE);
-}
-
-static void csSerializeIndexEntry(const ChunkIndexEntry *e, u8 *aBuf){
-  memcpy(aBuf, e->hash.data, PROLLY_HASH_SIZE);
-  CS_WRITE_I64(aBuf + PROLLY_HASH_SIZE, e->offset);
-  CS_WRITE_U32(aBuf + PROLLY_HASH_SIZE + 8, (u32)e->size);
 }
 
 static void csDeserializeIndexEntry(const u8 *aBuf, ChunkIndexEntry *e){


### PR DESCRIPTION
## Summary
Round 9 deep-pass through \`chunk_store.c\` (2426 lines). One real find: \`csSerializeIndexEntry\`. Five-line static helper, forward-declared at line 133, defined at line 714, called by **nothing** in src/ or test/.

The serialize/deserialize pair was probably symmetric at one point. Today only the deserialize half is live (used by \`csReadIndex\` on big-endian hosts where the mmap fast-path doesn't apply). The serialize half is dead — the chunk index gets persisted via direct memcpy in \`doltlite_gc.c::gcRewriteFile\` (which writes the entry layout inline rather than calling a helper).

## What else I checked
- All 30 public exports — every one has ≥3 callers
- All 40 static defs — only csSerializeIndexEntry has zero callers
- All 39 ChunkStore fields — all read at least once
- ChunkStoreReplayState, ChunkStoreReloadState, SavedRefsState — all fields meaningful
- 10 \`CS_*\` macros + 4 \`CHUNK_*\` macros — all used
- Conditional compile blocks (\`_WIN32\`, \`CHUNK_STORE_LE_PACKING\`, \`SQLITE_TEST\`) — all reachable
- Lock helpers (csFileLock/Unlock/LockNB) and mmap helpers (csMapIndex/csUnmapIndex) — all live
- Comments referencing removed symbols (pWalData, nIndexAlloc, etc.) — none

The well in chunk_store.c is genuinely tapped after rounds 2–6 and 9.

## Test plan
- [x] \`make doltlite\` clean
- [x] \`doltlite_regression_test_c all\` — 107795 passed, 0 failed
- [ ] CI sanitizer + crash-injection durability suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)