### PR TITLE
prolly_mutmap: drop redundant per-entry isIntKey

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -4154,7 +4154,7 @@ static int findMatchingMutMapEntry(
     int nRec = pEntry->nVal;
     int isLess;
 
-    if( pEntry->isIntKey ){
+    if( pMap->isIntKey ){
       lo = mid + 1;
       continue;
     }
@@ -4180,7 +4180,7 @@ static int findMatchingMutMapEntry(
     const u8 *pRec = pEntry->pVal;
     int nRec = pEntry->nVal;
 
-    if( pEntry->isIntKey ){
+    if( pMap->isIntKey ){
       lo++;
       continue;
     }

--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -69,14 +69,14 @@ static void freeEntryData(ProllyMutMapEntry *e){
   e->nVal = 0;
 }
 
-static int copyEntryData(ProllyMutMapEntry *e,
+static int copyEntryData(ProllyMutMap *mm, ProllyMutMapEntry *e,
                          const u8 *pKey, int nKey,
                          const u8 *pVal, int nVal){
   e->pKey = 0;
   e->nKey = 0;
   e->pVal = 0;
   e->nVal = 0;
-  if( !e->isIntKey && pKey && nKey>0 ){
+  if( !mm->isIntKey && pKey && nKey>0 ){
     e->pKey = (u8*)sqlite3_malloc(nKey);
     if( !e->pKey ) return SQLITE_NOMEM;
     memcpy(e->pKey, pKey, nKey);
@@ -367,10 +367,9 @@ int prollyMutMapInsert(
     e = &mm->aEntries[phys];
     memset(e, 0, sizeof(*e));
     e->op = PROLLY_EDIT_INSERT;
-    e->isIntKey = mm->isIntKey;
     e->intKey = intKey;
     e->bornAt = encodeLevel(mm, mm->currentSavepointLevel);
-    rc = copyEntryData(e, pKey, nKey, pVal, nVal);
+    rc = copyEntryData(mm, e, pKey, nKey, pVal, nVal);
     if( rc!=SQLITE_OK ){
       return rc;
     }
@@ -446,10 +445,9 @@ int prollyMutMapDelete(
     e = &mm->aEntries[phys];
     memset(e, 0, sizeof(*e));
     e->op = PROLLY_EDIT_DELETE;
-    e->isIntKey = mm->isIntKey;
     e->intKey = intKey;
     e->bornAt = encodeLevel(mm, mm->currentSavepointLevel);
-    rc = copyEntryData(e, pKey, nKey, 0, 0);
+    rc = copyEntryData(mm, e, pKey, nKey, 0, 0);
     if( rc!=SQLITE_OK ){
       return rc;
     }
@@ -759,7 +757,6 @@ int prollyMutMapClone(ProllyMutMap **out, const ProllyMutMap *src){
       ProllyMutMapEntry *se = &src->aEntries[i];
       ProllyMutMapEntry *de = &dst->aEntries[i];
       de->op = se->op;
-      de->isIntKey = se->isIntKey;
       de->intKey = se->intKey;
       de->bornAt = se->bornAt;
       de->nKey = 0;

--- a/src/prolly_mutmap.h
+++ b/src/prolly_mutmap.h
@@ -12,7 +12,6 @@ typedef struct ProllyMutMapIter ProllyMutMapIter;
 
 struct ProllyMutMapEntry {
   u8 op;
-  u8 isIntKey;
   i64 intKey;
   u8 *pKey;
   int nKey;


### PR DESCRIPTION
## Summary
\`ProllyMutMapEntry.isIntKey\` duplicated \`ProllyMutMap.isIntKey\`. Every entry in a given map shares the parent's key type by construction — the field never disagreed with the parent. Five write sites all set it to \`mm->isIntKey\` (or transitively from a source whose own value came from the same parent); three read sites can just consult \`mm->isIntKey\` directly.

### Changes
- \`prolly_mutmap.c::copyEntryData\` now takes \`ProllyMutMap*\` and reads \`mm->isIntKey\` instead of \`e->isIntKey\`.
- \`prolly_btree.c::IndexMoveto\` two binary-search arms — replace \`pEntry->isIntKey\` with \`pMap->isIntKey\`.
- Drop the field from \`struct ProllyMutMapEntry\`, drop the three writes (\`prollyMutMapInsert\`, \`prollyMutMapDelete\`, \`prollyMutMapClone\`).

Net: -4 lines, one fewer byte per entry (or 4 with padding), no behavior change.

## Test plan
- [x] \`make doltlite\` clean
- [x] \`doltlite_regression_test_c all\` — 107795 passed, 0 failed
- [x] vc_oracle_merge / branch / diff / error_recovery — 41 / 33 / 48 / 261 passed
- [ ] CI sanitizer + crash-injection durability suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)