### PR TITLE
prolly_node: drop dead ProllyNode.addr field

### DIFF
--- a/src/prolly_node.h
+++ b/src/prolly_node.h
@@ -30,7 +30,6 @@ struct ProllyNode {
   const u32 *aValOff;
   const u8 *pKeyData;
   const u8 *pValData;
-  ProllyHash addr;
 };
 
 int prollyNodeParse(ProllyNode *pNode, const u8 *pData, int nData);


### PR DESCRIPTION
## Summary
\`ProllyNode.addr\` (a \`ProllyHash\`, so 20 bytes) is declared in the struct but never read or written **anywhere** in src/. Checked all the prolly modules (node, btree, cursor, diff, chunker, mutate, three_way_diff, mutmap), chunk_store, and the doltlite_* layer. Zero accesses.

The leftover is from an earlier design where each in-memory parsed node carried its own content hash. The codebase moved to passing the hash separately when needed (\`prollyNodeChildHash\` for child references, the cache stores hash → entry, etc.) and never wired \`pNode->addr\` into anything.

Net: -1 line (just the field declaration), 20 bytes off the in-memory ProllyNode, no behavior change.

## Test plan
- [x] \`make doltlite\` clean
- [x] \`doltlite_regression_test_c all\` — 107795 passed, 0 failed
- [ ] CI sanitizer + crash-injection durability suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)