### PR TITLE
prolly_diff: drop dead ProllyDiff typedef

### DIFF
--- a/src/prolly_diff.h
+++ b/src/prolly_diff.h
@@ -13,7 +13,6 @@
 #define PROLLY_DIFF_DELETE  2
 #define PROLLY_DIFF_MODIFY  3
 
-typedef struct ProllyDiff ProllyDiff;
 typedef struct ProllyDiffChange ProllyDiffChange;
 
 struct ProllyDiffChange {


### PR DESCRIPTION
## Summary
Round 12 sweep through the remaining prolly modules: \`prolly_chunker\`, \`prolly_diff\`, \`prolly_three_way_diff\`, \`prolly_mutate\`, \`prolly_cache\`. Combined ~2500 lines.

**One real find:** \`ProllyDiff\` typedef in \`prolly_diff.h\` declares an opaque \`struct ProllyDiff\` that has no definition anywhere and is referenced nowhere. The actual diff types are \`ProllyDiffChange\` and \`ProllyDiffIter\`, both wired up with multiple callers.

## What else I checked
- 53 static helpers across the 5 .c files — all have callers
- 12 public exports across the 5 .h files — all have ≥4 uses
- All struct fields in: \`ProllyChunkerLevel\`, \`ProllyChunker\`, \`ProllyDiffChange\`, \`ProllyDiffIter\`, \`ThreeWayChange\`, \`ProllyMutator\`, \`ProllyCacheEntry\`, \`ProllyCache\` — all read at least once
- THREE_WAY_* enum values — all 9 used
- \`PROLLY_CHUNK_MIN\`, \`PROLLY_CHUNK_MAX\`, \`PROLLY_EST_ENTRIES_PER_LEAF\` — all used
- Comments referencing removed concepts — none

These modules are well-maintained — the prolly tree code as a whole has been kept tight.

Net: -1 line.

## Test plan
- [x] \`make doltlite\` clean
- [x] \`doltlite_regression_test_c all\` — 107795 passed, 0 failed
- [ ] CI sanitizer + crash-injection durability suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)