### PR TITLE
Fix disjoint FK replay schema families

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -2400,11 +2400,6 @@ static void doltliteMergeFunc(
 
 
     rc = doltliteSwitchCatalog(db, &mergedCatHash);
-    if( rc==SQLITE_OK ){
-      doltliteSetSessionStaged(db, &mergedCatHash);
-      rc = doltliteUpdateBranchWorkingState(db,
-          doltliteGetSessionBranch(db), &mergedCatHash, NULL);
-    }
     doltliteCommitClear(&ourCommit);
     doltliteCommitClear(&theirCommit);
     if( rc!=SQLITE_OK ){
@@ -2433,6 +2428,25 @@ static void doltliteMergeFunc(
             doltliteRestoreTxnStateOnFailure(db, &savedState, rc));
         return;
       }
+    }
+
+    rc = doltliteFlushCatalogToHash(db, &mergedCatHash);
+    if( rc==SQLITE_OK ){
+      rc = doltliteSwitchCatalog(db, &mergedCatHash);
+    }
+    if( rc==SQLITE_OK ){
+      doltliteSetSessionStaged(db, &mergedCatHash);
+      rc = doltliteUpdateBranchWorkingState(db,
+          doltliteGetSessionBranch(db), &mergedCatHash, NULL);
+    }
+    if( rc!=SQLITE_OK ){
+      if( graphLocked ){
+        chunkStoreUnlock(cs);
+        graphLocked = 0;
+      }
+      sqlite3_result_error_code(context,
+          doltliteRestoreTxnStateOnFailure(db, &savedState, rc));
+      return;
     }
   }
 
@@ -2728,6 +2742,9 @@ static int applyMergedCatalogAndCommit(
   if( rc!=SQLITE_OK ) goto apply_rollback;
 
   rc = doltliteFlushCatalogToHash(db, &liveMergedCatHash);
+  if( rc==SQLITE_OK ){
+    rc = doltliteSwitchCatalog(db, &liveMergedCatHash);
+  }
   if( rc!=SQLITE_OK ) goto apply_rollback;
 
   doltliteSetSessionStaged(db, &liveMergedCatHash);

--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -1184,7 +1184,7 @@ static int serializeMergedCatalog(
   (void)oursCatHash;
   (void)iNextTable;
 
-  rc = doltliteSerializeCatalogEntries(db, aMerged, nMerged, &buf, &nBuf);
+  rc = doltliteSerializeCatalogEntries(NULL, aMerged, nMerged, &buf, &nBuf);
   if( rc!=SQLITE_OK ) return rc;
 
   rc = chunkStorePut(cs, buf, nBuf, pOutHash);
@@ -1473,7 +1473,15 @@ static u8 *buildSchemaCatalogRecord(
   aMem[1].eType = SQLITE_TEXT;    aMem[1].p = zName;    aMem[1].n = (int)strlen(zName);
   aMem[2].eType = SQLITE_TEXT;    aMem[2].p = zTblName; aMem[2].n = (int)strlen(zTblName);
   aMem[3].eType = SQLITE_INTEGER; aMem[3].i = iRootpage;
-  aMem[4].eType = SQLITE_TEXT;    aMem[4].p = zSql;     aMem[4].n = (int)strlen(zSql);
+  if( zSql ){
+    aMem[4].eType = SQLITE_TEXT;
+    aMem[4].p = zSql;
+    aMem[4].n = (int)strlen(zSql);
+  }else{
+    aMem[4].eType = SQLITE_NULL;
+    aMem[4].p = 0;
+    aMem[4].n = 0;
+  }
 
   for(i=0; i<5; i++){
     aType[i] = mergeCatalogSerialType(&aMem[i], &aLen[i]);
@@ -1532,7 +1540,7 @@ static int appendMergedSchemaCatalogRecord(
   int nRec = 0;
   int rc;
 
-  if( !pSe || !pSe->zName || !pSe->zType || !pSe->zSql ) return SQLITE_OK;
+  if( !pSe || !pSe->zName || !pSe->zType ) return SQLITE_OK;
   pRec = buildSchemaCatalogRecord(pSe->zType, pSe->zName,
                                   pSe->zTblName ? pSe->zTblName : pSe->zName,
                                   (i64)iRootpage, pSe->zSql, &nRec);
@@ -2013,6 +2021,27 @@ static int mergeCatalogPass2(
       ** iTable, it's a new index from theirs — add it. */
       if( !findTableEntry(aOurs, nOurs, aTheirs[i].iTable) ){
         struct TableEntry newEntry = aTheirs[i];
+        int j, conflict = 0;
+        Pgno oldPg = newEntry.iTable;
+        int forceRemap = bDisjointSchemaChanges;
+        for(j=0; j<*pnMerged; j++){
+          if( aMerged[j].iTable==newEntry.iTable ){
+            conflict = 1;
+            break;
+          }
+        }
+        if( conflict || forceRemap ){
+          SchemaRootpageRemap *aNew;
+          int nOld = *pnRemap;
+          newEntry.iTable = (*piNextMerged)++;
+          aNew = sqlite3_realloc(*ppaRemap,
+                                 (nOld+1)*(int)sizeof(SchemaRootpageRemap));
+          if( !aNew ) return SQLITE_NOMEM;
+          *ppaRemap = aNew;
+          aNew[nOld].oldPg = oldPg;
+          aNew[nOld].newPg = newEntry.iTable;
+          *pnRemap = nOld + 1;
+        }
         if( newEntry.iTable >= *piNextMerged ) *piNextMerged = newEntry.iTable + 1;
         aMerged[(*pnMerged)++] = newEntry;
       }else if( bDisjointSchemaChanges ){
@@ -2046,12 +2075,13 @@ static int mergeCatalogPass2(
       if( !ancEntry ){
 
         struct TableEntry newEntry = aTheirs[i];
+        int forceRemap = bDisjointSchemaChanges;
         {
           int j, conflict = 0;
           for(j=0; j<*pnMerged; j++){
             if( aMerged[j].iTable==newEntry.iTable ){ conflict = 1; break; }
           }
-          if( conflict ) newEntry.iTable = (*piNextMerged)++;
+          if( conflict || forceRemap ) newEntry.iTable = (*piNextMerged)++;
         }
         if( newEntry.iTable >= *piNextMerged ) *piNextMerged = newEntry.iTable + 1;
 

--- a/src/doltlite_merge_constraints.c
+++ b/src/doltlite_merge_constraints.c
@@ -1614,6 +1614,7 @@ int doltliteDetectMergeFkViolations(
   char **pzErrMsg,
   int *pnFound
 ){
+  sqlite3_stmt *pQuick = 0;
   sqlite3_stmt *pTbls = 0;
   struct TableEntry *aAnc = 0;
   int nAnc = 0;
@@ -1626,6 +1627,20 @@ int doltliteDetectMergeFkViolations(
   (void)pzErrMsg;
 
   if( pnFound ) *pnFound = 0;
+
+  rc = sqlite3_prepare_v2(db, "PRAGMA main.foreign_key_check", -1, &pQuick, 0);
+  if( rc!=SQLITE_OK ){
+    return rc;
+  }
+  stepRc = sqlite3_step(pQuick);
+  sqlite3_finalize(pQuick);
+  pQuick = 0;
+  if( stepRc==SQLITE_DONE ){
+    return SQLITE_OK;
+  }
+  if( stepRc!=SQLITE_ROW ){
+    return stepRc;
+  }
 
   if( pAncCatHash && !prollyHashIsEmpty(pAncCatHash) ){
     if( doltliteLoadCatalog(db, pAncCatHash, &aAnc, &nAnc, &iNextAnc)==SQLITE_OK ){

--- a/test/doltlite_cherry_pick.sh
+++ b/test/doltlite_cherry_pick.sh
@@ -520,6 +520,36 @@ run_test "cp_violation_state" \
 
 rm -f "$DB"
 
+DB=/tmp/test_cp_fk_tables_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1,10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+CREATE TABLE p(id INTEGER PRIMARY KEY, u INT UNIQUE);
+CREATE TABLE c(id INTEGER PRIMARY KEY, u INT, FOREIGN KEY(u) REFERENCES p(u));
+INSERT INTO p VALUES(1,100);
+INSERT INTO c VALUES(1,100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat_add_fk_tables');
+SELECT dolt_checkout('main');
+CREATE TABLE t_new(id INTEGER PRIMARY KEY, v INT CHECK(v > 0));
+INSERT INTO t_new SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t_new RENAME TO t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main_check');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test_match "cp_fk_tables_hash" \
+  "SELECT dolt_cherry_pick('feat');" \
+  "^[0-9a-f]{40}$" "$DB"
+run_test "cp_fk_tables_parent" "SELECT count(*) FROM p;" "1" "$DB"
+run_test "cp_fk_tables_child" "SELECT count(*) FROM c;" "1" "$DB"
+run_test "cp_fk_tables_fk" "SELECT count(*) FROM pragma_foreign_key_list('c');" "1" "$DB"
+
+rm -f "$DB"
+
 DB=/tmp/test_rv_violation_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, u INT UNIQUE, v TEXT);
 INSERT INTO t VALUES(1,1,'base1'),(2,2,'base2');

--- a/test/doltlite_merge.sh
+++ b/test/doltlite_merge.sh
@@ -279,7 +279,18 @@ run_test_match "table_plus_recreate_merge_hash" "SELECT dolt_merge('feat');" "^[
 run_test "table_plus_recreate_feat_visible" "SELECT count(*) FROM feat_tbl;" "1" "$DB19"
 run_test "table_plus_recreate_schema_visible" "SELECT instr(sql,'k INTEGER PRIMARY KEY')>0 FROM sqlite_master WHERE type='table' AND name='churn';" "1" "$DB19"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB8B" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18" "$DB19"
+# New FK-bearing parent/child tables on one branch plus unrelated CHECK
+# change on the other should auto-merge and remain visible.
+DB20=/tmp/test_merge20_$$.db; rm -f "$DB20"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT); INSERT INTO t VALUES(1,10); SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');" | $DOLTLITE "$DB20" > /dev/null 2>&1
+echo "SELECT dolt_branch('feat'); SELECT dolt_checkout('feat'); CREATE TABLE p(id INTEGER PRIMARY KEY, u INT UNIQUE); CREATE TABLE c(id INTEGER PRIMARY KEY, u INT, FOREIGN KEY(u) REFERENCES p(u)); INSERT INTO p VALUES(1,100); INSERT INTO c VALUES(1,100); SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_add_fk_tables');" | $DOLTLITE "$DB20" > /dev/null 2>&1
+echo "SELECT dolt_checkout('main'); CREATE TABLE t_new(id INTEGER PRIMARY KEY, v INT CHECK(v > 0)); INSERT INTO t_new SELECT * FROM t; DROP TABLE t; ALTER TABLE t_new RENAME TO t; SELECT dolt_add('-A'); SELECT dolt_commit('-m','main_check');" | $DOLTLITE "$DB20" > /dev/null 2>&1
+run_test_match "fk_tables_plus_check_merge_hash" "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB20"
+run_test "fk_tables_plus_check_parent_visible" "SELECT count(*) FROM p;" "1" "$DB20"
+run_test "fk_tables_plus_check_child_visible" "SELECT count(*) FROM c;" "1" "$DB20"
+run_test "fk_tables_plus_check_fk_visible" "SELECT count(*) FROM pragma_foreign_key_list('c');" "1" "$DB20"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB8B" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18" "$DB19" "$DB20"
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
 if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi

--- a/test/doltlite_rebase_schema.sh
+++ b/test/doltlite_rebase_schema.sh
@@ -131,6 +131,50 @@ SELECT dolt_rebase('main');" | perl -e 'alarm(10);exec @ARGV' "$DOLTLITE" "$db" 
   fi
 }
 
+FK_TABLES_SETUP="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1,10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','init');
+SELECT dolt_branch('feat');
+CREATE TABLE t_new(id INTEGER PRIMARY KEY, v INT CHECK (v > 0));
+INSERT INTO t_new SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t_new RENAME TO t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main check');
+SELECT dolt_checkout('feat');
+CREATE TABLE p(id INTEGER PRIMARY KEY, u INT UNIQUE);
+CREATE TABLE c(id INTEGER PRIMARY KEY, u INT, FOREIGN KEY(u) REFERENCES p(u));
+INSERT INTO p VALUES(1,100);
+INSERT INTO c VALUES(1,100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat fk tables');
+"
+
+run_db_match "rebase_schema_fk_tables_hash" "
+$FK_TABLES_SETUP
+SELECT dolt_rebase('main');
+" "Successfully rebased|^[0-9a-f]{40}$"
+
+run_db_eq "rebase_schema_fk_tables_parent" "
+$FK_TABLES_SETUP
+SELECT dolt_rebase('main');
+SELECT count(*) FROM p;
+" "1"
+
+run_db_eq "rebase_schema_fk_tables_child" "
+$FK_TABLES_SETUP
+SELECT dolt_rebase('main');
+SELECT count(*) FROM c;
+" "1"
+
+run_db_eq "rebase_schema_fk_tables_fk" "
+$FK_TABLES_SETUP
+SELECT dolt_rebase('main');
+SELECT count(*) FROM pragma_foreign_key_list('c');
+" "1"
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
 if [ $FAIL -gt 0 ]; then

--- a/test/vc_oracle_merge_test.sh
+++ b/test/vc_oracle_merge_test.sh
@@ -830,6 +830,60 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feature');
 "
 
+oracle_same_session "merge_disjoint_fk_tables_plus_check_same_session" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+CREATE TABLE p(id INTEGER PRIMARY KEY, u INT UNIQUE);
+CREATE TABLE c(id INTEGER PRIMARY KEY, u INT, FOREIGN KEY (u) REFERENCES p(u));
+INSERT INTO p VALUES (1, 100);
+INSERT INTO c VALUES (1, 100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat_add_fk_tables');
+SELECT dolt_checkout('main');
+CREATE TABLE t_new(id INTEGER PRIMARY KEY, v INT CHECK (v > 0));
+INSERT INTO t_new SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t_new RENAME TO t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main_check');
+SELECT dolt_merge('feat');
+" "SELECT 'Q' || char(9) ||
+          (SELECT count(*) FROM p) || '|' ||
+          (SELECT count(*) FROM c) || '|' ||
+          (SELECT count(*) FROM pragma_foreign_key_list('c'))" \
+  "SELECT CONCAT('Q', CHAR(9), (SELECT COUNT(*) FROM p), '|', (SELECT COUNT(*) FROM c), '|', (SELECT COUNT(*) FROM information_schema.KEY_COLUMN_USAGE WHERE table_name = 'c' AND referenced_table_name = 'p'))"
+
+oracle_reopen_state "merge_disjoint_fk_tables_plus_check_reopen" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+CREATE TABLE p(id INTEGER PRIMARY KEY, u INT UNIQUE);
+CREATE TABLE c(id INTEGER PRIMARY KEY, u INT, FOREIGN KEY (u) REFERENCES p(u));
+INSERT INTO p VALUES (1, 100);
+INSERT INTO c VALUES (1, 100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat_add_fk_tables');
+SELECT dolt_checkout('main');
+CREATE TABLE t_new(id INTEGER PRIMARY KEY, v INT CHECK (v > 0));
+INSERT INTO t_new SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t_new RENAME TO t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main_check');
+SELECT dolt_merge('feat');
+" "SELECT 'Q' || char(9) ||
+          (SELECT count(*) FROM p) || '|' ||
+          (SELECT count(*) FROM c) || '|' ||
+          (SELECT count(*) FROM pragma_foreign_key_list('c'))" \
+  "SELECT CONCAT('Q', CHAR(9), (SELECT COUNT(*) FROM p), '|', (SELECT COUNT(*) FROM c), '|', (SELECT COUNT(*) FROM information_schema.KEY_COLUMN_USAGE WHERE table_name = 'c' AND referenced_table_name = 'p'))"
+
 echo "--- non-branch merge sources ---"
 
 # Merge from a tag instead of a branch. Tags were promoted to first-

--- a/test/vc_oracle_rebase_test.sh
+++ b/test/vc_oracle_rebase_test.sh
@@ -374,6 +374,28 @@ SELECT dolt_rebase('main');
           (SELECT count(*) FROM pragma_index_list('b') WHERE name='idx_b_v')" \
   "SELECT CONCAT((SELECT COUNT(*) FROM information_schema.statistics WHERE table_name='a' AND index_name='idx_a_v'), '|', (SELECT COUNT(*) FROM information_schema.statistics WHERE table_name='b' AND index_name='idx_b_v'))"
 
+oracle_poststate "rebase_disjoint_fk_tables_plus_check" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');
+SELECT dolt_branch('feat');
+CREATE TABLE t_new(id INTEGER PRIMARY KEY, v INT CHECK (v > 0));
+INSERT INTO t_new SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t_new RENAME TO t;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'main check');
+SELECT dolt_checkout('feat');
+CREATE TABLE p(id INTEGER PRIMARY KEY, u INT UNIQUE);
+CREATE TABLE c(id INTEGER PRIMARY KEY, u INT, FOREIGN KEY (u) REFERENCES p(u));
+INSERT INTO p VALUES (1, 100);
+INSERT INTO c VALUES (1, 100);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'feat fk tables');
+SELECT dolt_rebase('main');
+" "SELECT (SELECT count(*) FROM p) || '|' ||
+          (SELECT count(*) FROM c) || '|' ||
+          (SELECT count(*) FROM pragma_foreign_key_list('c'))" \
+  "SELECT CONCAT((SELECT COUNT(*) FROM p), '|', (SELECT COUNT(*) FROM c), '|', (SELECT COUNT(*) FROM information_schema.KEY_COLUMN_USAGE WHERE table_name = 'c' AND referenced_table_name = 'p'))"
+
 echo "--- error paths ---"
 
 oracle_error "no_divergent_commits" "

--- a/test/vc_oracle_revert_cherrypick_test.sh
+++ b/test/vc_oracle_revert_cherrypick_test.sh
@@ -387,6 +387,32 @@ SELECT dolt_cherry_pick('feat');
           (SELECT count(*) FROM pragma_index_list('b') WHERE name = 'idx_b_v')" \
   "SELECT CONCAT((SELECT COUNT(*) FROM information_schema.statistics WHERE table_name = 'a' AND index_name = 'idx_a_v'), '|', (SELECT COUNT(*) FROM information_schema.statistics WHERE table_name = 'b' AND index_name = 'idx_b_v'))"
 
+oracle_poststate "cherry_pick_disjoint_fk_tables_plus_check" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+CREATE TABLE p(id INTEGER PRIMARY KEY, u INT UNIQUE);
+CREATE TABLE c(id INTEGER PRIMARY KEY, u INT, FOREIGN KEY (u) REFERENCES p(u));
+INSERT INTO p VALUES (1, 100);
+INSERT INTO c VALUES (1, 100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat_add_fk_tables');
+SELECT dolt_checkout('main');
+CREATE TABLE t_new(id INTEGER PRIMARY KEY, v INT CHECK (v > 0));
+INSERT INTO t_new SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t_new RENAME TO t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main_check');
+SELECT dolt_cherry_pick('feat');
+" "SELECT (SELECT count(*) FROM p) || '|' ||
+          (SELECT count(*) FROM c) || '|' ||
+          (SELECT count(*) FROM pragma_foreign_key_list('c'))" \
+  "SELECT CONCAT((SELECT COUNT(*) FROM p), '|', (SELECT COUNT(*) FROM c), '|', (SELECT COUNT(*) FROM information_schema.KEY_COLUMN_USAGE WHERE table_name = 'c' AND referenced_table_name = 'p'))"
+
 echo "--- revert: basic ---"
 
 # Revert the most recent commit. Should produce a new commit that


### PR DESCRIPTION
## Summary
- fix merge/cherry-pick/rebase replay of disjoint FK-bearing schema families
- allocate fresh rootpages for added-theirs schema objects during disjoint replay so tables and companion autoindexes stay consistent
- add local and oracle coverage for merge, cherry-pick, and rebase of FK tables plus unrelated schema churn

## Testing
- bash test/doltlite_merge.sh
- bash test/doltlite_cherry_pick.sh
- bash test/doltlite_rebase_schema.sh ./doltlite
- bash test/vc_oracle_merge_test.sh ./doltlite dolt
- bash test/vc_oracle_revert_cherrypick_test.sh ./doltlite dolt
- bash test/vc_oracle_rebase_test.sh ./doltlite dolt