### PR TITLE
chore: doltlite_ orphans — dead pk-field helper and version alias

### DIFF
--- a/src/doltlite_commit.h
+++ b/src/doltlite_commit.h
@@ -6,7 +6,6 @@
 #include "prolly_hash.h"
 
 #define DOLTLITE_COMMIT_V2 2
-#define DOLTLITE_COMMIT_VERSION DOLTLITE_COMMIT_V2
 
 #define DOLTLITE_MAX_PARENTS 8
 

--- a/src/doltlite_record.c
+++ b/src/doltlite_record.c
@@ -354,23 +354,6 @@ void doltliteResultField(
   sqlite3_result_null(ctx);
 }
 
-void doltliteResultRecordPkField(
-  sqlite3_context *ctx, const u8 *pData, int nData, int iPkField
-){
-  DoltliteRecordInfo ri;
-  if( !pData || nData<1 || iPkField<0 ){
-    sqlite3_result_null(ctx);
-    return;
-  }
-  doltliteParseRecord(pData, nData, &ri);
-  if( iPkField>=ri.nField ){
-    sqlite3_result_null(ctx);
-    return;
-  }
-  doltliteResultField(ctx, pData, nData,
-                      ri.aType[iPkField], ri.aOffset[iPkField]);
-}
-
 void doltliteResultUserCol(
   sqlite3_context *ctx,
   const DoltliteColInfo *ci,

--- a/src/doltlite_record.h
+++ b/src/doltlite_record.h
@@ -47,9 +47,6 @@ void doltliteFreeColInfo(DoltliteColInfo *ci);
 
 void doltliteResultField(sqlite3_context *ctx, const u8 *pData, int nData,
                          int serialType, int offset);
-void doltliteResultRecordPkField(sqlite3_context *ctx,
-                                 const u8 *pData, int nData,
-                                 int iPkField);
 
 /* Project a user-schema column into a SQLite result context.
 **


### PR DESCRIPTION
## Summary
Round 13 — same audit playbook applied to the doltlite_*.c/.h layer (31 files, ~24k lines).

**Two finds:**

1. \`doltlite_record::doltliteResultRecordPkField\` — 16-line public helper that parses a record then projects a single PK field into the SQL result context. Declared, defined, **called by no one** in src/ or test/.

2. \`doltlite_commit.h::DOLTLITE_COMMIT_VERSION\` — macro alias for \`DOLTLITE_COMMIT_V2\` with zero call sites. The actual consumers (\`csCommitSerialize\`/\`Deserialize\`) use \`DOLTLITE_COMMIT_V2\` directly. Just a leftover indirection.

## What else I checked
- **569 static helpers** across 31 .c files — all have callers (round 3 caught the dead ones)
- **89 public exports** declared in doltlite_*.h — all have callers
- **39 macros** — all used (one orphan = the V2 alias, found above)
- **12 typedef-struct decls** — all referenced
- **Forward decls in .c files** — all live

The doltlite_ layer turns out to be well-maintained. The cascade-orphan pattern from round 6 (where deletes seeded new dead code) didn't yield new finds after rounds 9–12 merged.

Net: -21 lines.

## Test plan
- [x] \`make doltlite\` clean
- [x] \`doltlite_regression_test_c all\` — 107795 passed, 0 failed
- [ ] CI sanitizer + crash-injection durability suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)