### PR TITLE
Add FK replay rollback oracle coverage

### DIFF
--- a/test/vc_oracle_rebase_test.sh
+++ b/test/vc_oracle_rebase_test.sh
@@ -396,6 +396,27 @@ SELECT dolt_rebase('main');
           (SELECT count(*) FROM pragma_foreign_key_list('c'))" \
   "SELECT CONCAT((SELECT COUNT(*) FROM p), '|', (SELECT COUNT(*) FROM c), '|', (SELECT COUNT(*) FROM information_schema.KEY_COLUMN_USAGE WHERE table_name = 'c' AND referenced_table_name = 'p'))"
 
+oracle_error_reopen "rebase_fk_violation_rolls_back" "
+CREATE TABLE parent(pk INTEGER PRIMARY KEY, u INT UNIQUE);
+CREATE TABLE child(pk INTEGER PRIMARY KEY, u INT, FOREIGN KEY (u) REFERENCES parent(u));
+INSERT INTO parent VALUES (1,1),(2,2);
+INSERT INTO child VALUES (1,1);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');
+SELECT dolt_branch('feat');
+DELETE FROM parent WHERE pk=2;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'main_drop_parent');
+SELECT dolt_checkout('feat');
+INSERT INTO child VALUES (2,2);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'feat_add_child');
+SELECT dolt_rebase('main');
+" "
+SELECT CONCAT('LOG|B|', active_branch());
+SELECT CONCAT('LOG|W|', count(*)) FROM dolt_branches WHERE name='dolt_rebase_feat';
+SELECT CONCAT('LOG|CV|', count(*)) FROM dolt_constraint_violations;
+SELECT CONCAT('LOG|P|', pk, ':', u) FROM parent ORDER BY pk;
+SELECT CONCAT('LOG|C|', pk, ':', u) FROM child ORDER BY pk;
+"
+
 echo "--- error paths ---"
 
 oracle_error "no_divergent_commits" "

--- a/test/vc_oracle_revert_cherrypick_test.sh
+++ b/test/vc_oracle_revert_cherrypick_test.sh
@@ -798,6 +798,52 @@ ROLLBACK;
 " "SELECT (SELECT count(*) FROM dolt_constraint_violations) || '|' || (SELECT group_concat(id || ':' || u || ':' || v, ',') FROM (SELECT id,u,v FROM t ORDER BY id) AS ordered_rows)" \
 "SELECT CONCAT((SELECT COUNT(*) FROM dolt_constraint_violations), '|', (SELECT GROUP_CONCAT(CONCAT(id, ':', u, ':', v) ORDER BY id SEPARATOR ',') FROM t))"
 
+oracle_error_poststate "cherry_pick_fk_violation_rolls_back" "
+CREATE TABLE parent(pk INTEGER PRIMARY KEY, u INT UNIQUE);
+CREATE TABLE child(pk INTEGER PRIMARY KEY, u INT, FOREIGN KEY (u) REFERENCES parent(u));
+INSERT INTO parent VALUES (1,1),(2,2);
+INSERT INTO child VALUES (1,1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','init');
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+INSERT INTO child VALUES (2,2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat_add_child');
+SELECT dolt_checkout('main');
+DELETE FROM parent WHERE pk=2;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main_drop_parent');
+SELECT dolt_cherry_pick('feature');
+" "SELECT (SELECT count(*) FROM dolt_constraint_violations) || '|' ||
+          (SELECT group_concat(pk || ':' || u, ',') FROM (SELECT pk,u FROM parent ORDER BY pk) AS ordered_parent) || '|' ||
+          (SELECT group_concat(pk || ':' || u, ',') FROM (SELECT pk,u FROM child ORDER BY pk) AS ordered_child)" \
+"SELECT CONCAT((SELECT COUNT(*) FROM dolt_constraint_violations), '|', (SELECT GROUP_CONCAT(CONCAT(pk, ':', u) ORDER BY pk SEPARATOR ',') FROM parent), '|', (SELECT GROUP_CONCAT(CONCAT(pk, ':', u) ORDER BY pk SEPARATOR ',') FROM child))"
+
+oracle_error_poststate "cherry_pick_fk_violation_txn_rollback" "
+CREATE TABLE parent(pk INTEGER PRIMARY KEY, u INT UNIQUE);
+CREATE TABLE child(pk INTEGER PRIMARY KEY, u INT, FOREIGN KEY (u) REFERENCES parent(u));
+INSERT INTO parent VALUES (1,1),(2,2);
+INSERT INTO child VALUES (1,1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','init');
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+INSERT INTO child VALUES (2,2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat_add_child');
+SELECT dolt_checkout('main');
+DELETE FROM parent WHERE pk=2;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main_drop_parent');
+BEGIN;
+SELECT dolt_cherry_pick('feature');
+ROLLBACK;
+" "SELECT (SELECT count(*) FROM dolt_constraint_violations) || '|' ||
+          (SELECT group_concat(pk || ':' || u, ',') FROM (SELECT pk,u FROM parent ORDER BY pk) AS ordered_parent) || '|' ||
+          (SELECT group_concat(pk || ':' || u, ',') FROM (SELECT pk,u FROM child ORDER BY pk) AS ordered_child)" \
+"SELECT CONCAT((SELECT COUNT(*) FROM dolt_constraint_violations), '|', (SELECT GROUP_CONCAT(CONCAT(pk, ':', u) ORDER BY pk SEPARATOR ',') FROM parent), '|', (SELECT GROUP_CONCAT(CONCAT(pk, ':', u) ORDER BY pk SEPARATOR ',') FROM child))"
+
 echo "--- savepoint parity ---"
 
 oracle_error_poststate "cherry_pick_savepoint_invalidated" "


### PR DESCRIPTION
## Summary
- add FK orphan rollback coverage for failed cherry-pick replay
- add explicit transaction rollback coverage for failed FK cherry-pick replay
- add non-interactive rebase FK rollback/reopen coverage

## Testing
- bash test/vc_oracle_revert_cherrypick_test.sh ./doltlite dolt
- bash test/vc_oracle_rebase_test.sh ./doltlite dolt