### PR TITLE
Enable foreign keys by default

### DIFF
--- a/src/shell.c.in
+++ b/src/shell.c.in
@@ -4930,6 +4930,13 @@ static void open_db(ShellState *p, int openFlags){
     sqlite3_free(zParsedFilename);
     sqlite3_free(zParsedBranch);
     globalDb = p->db;
+
+#ifdef DOLTLITE_PROLLY
+    /* DoltLite should enforce foreign keys by default on user-facing
+    ** connections, even if stock SQLite would default them off. */
+    sqlite3_db_config(p->db, SQLITE_DBCONFIG_ENABLE_FKEY, 1, 0);
+#endif
+
     sqlite3_db_config(p->db, SQLITE_DBCONFIG_STMT_SCANSTATUS, (int)0, (int*)0);
 
     /* Reflect the use or absence of --unsafe-testing invocation. */

--- a/test/doltlite_foreign_keys_default.sh
+++ b/test/doltlite_foreign_keys_default.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -u
+
+DOLTLITE="${1:-./doltlite}"
+PASS=0
+FAIL=0
+ERRORS=""
+
+run_test() {
+  local name="$1" sql="$2" expected="$3" db="$4"
+  local got
+  got=$(printf "%s\n" "$sql" | "$DOLTLITE" "$db" 2>&1)
+  if [ "$got" = "$expected" ]; then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1))
+    ERRORS="$ERRORS\nFAIL: $name\n  expected: $expected\n  got:      $got"
+  fi
+}
+
+run_test_match() {
+  local name="$1" sql="$2" pattern="$3" db="$4"
+  local got
+  got=$(printf "%s\n" "$sql" | "$DOLTLITE" "$db" 2>&1)
+  if printf "%s\n" "$got" | grep -qE "$pattern"; then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1))
+    ERRORS="$ERRORS\nFAIL: $name\n  pattern:  $pattern\n  got:      $got"
+  fi
+}
+
+echo "=== Doltlite Default Foreign Key Tests ==="
+
+DB1=/tmp/doltlite_fk_default_$$.db; rm -f "$DB1"
+run_test "foreign_keys_default_on" "PRAGMA foreign_keys;" "1" "$DB1"
+
+DB2=/tmp/doltlite_fk_pk_$$.db; rm -f "$DB2"
+run_test_match "fk_pk_parent_default_rejected" "
+CREATE TABLE parent(id INTEGER PRIMARY KEY);
+CREATE TABLE child(id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id));
+INSERT INTO child VALUES (1,999);
+" "FOREIGN KEY constraint failed" "$DB2"
+run_test "fk_pk_parent_no_rows" "SELECT count(*) FROM child;" "0" "$DB2"
+
+DB3=/tmp/doltlite_fk_unique_$$.db; rm -f "$DB3"
+run_test_match "fk_unique_parent_default_rejected" "
+CREATE TABLE parent(id INTEGER PRIMARY KEY, u INTEGER UNIQUE);
+CREATE TABLE child(id INTEGER PRIMARY KEY, u INTEGER REFERENCES parent(u));
+INSERT INTO child VALUES (1,999);
+" "FOREIGN KEY constraint failed" "$DB3"
+run_test "fk_unique_parent_no_rows" "SELECT count(*) FROM child;" "0" "$DB3"
+
+rm -f "$DB1" "$DB2" "$DB3"
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+if [ "$FAIL" -ne 0 ]; then
+  printf "%b\n" "$ERRORS"
+  exit 1
+fi

--- a/test/oracle_foreign_keys_test.sh
+++ b/test/oracle_foreign_keys_test.sh
@@ -15,8 +15,9 @@
 # storage layer (prolly btree vs stock btree).
 #
 # Coverage:
-#   - PRAGMA foreign_keys = ON is set by every scenario
-#     (SQLite defaults to OFF; doltlite matches that default)
+#   - PRAGMA foreign_keys = ON is set by every cross-engine scenario
+#     (SQLite defaults to OFF; DoltLite now enables FK checks by
+#     default, but the oracle still sets it explicitly for parity)
 #   - Basic INSERT / UPDATE / DELETE with valid / invalid references
 #   - ON DELETE actions: NO ACTION, RESTRICT, CASCADE, SET NULL,
 #     SET DEFAULT

--- a/test/vc_oracle_error_recovery_test.sh
+++ b/test/vc_oracle_error_recovery_test.sh
@@ -744,9 +744,14 @@ SELECT dolt_commit('-m','after unique violation');
 " "SELECT id, val FROM t ORDER BY id;"
 
 oracle "fk_violation_doesnt_break_commit" "
-CREATE TABLE parent(id INTEGER PRIMARY KEY, name TEXT);
-CREATE TABLE child(id INTEGER PRIMARY KEY, pid INTEGER REFERENCES parent(id), val TEXT);
-INSERT INTO parent VALUES(1,'p1');
+CREATE TABLE parent(id INTEGER PRIMARY KEY, u INTEGER UNIQUE, name TEXT);
+CREATE TABLE child(
+  id INTEGER PRIMARY KEY,
+  u INTEGER,
+  val TEXT,
+  FOREIGN KEY (u) REFERENCES parent(u)
+);
+INSERT INTO parent VALUES(1,1,'p1');
 INSERT INTO child VALUES(1,1,'c1');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','base');


### PR DESCRIPTION
## Summary
- enable foreign key checks by default for DoltLite shell connections
- add a DoltLite regression covering default FK enforcement for both PK-parent and UNIQUE-parent refs
- update the FK error recovery oracle to avoid Dolt's inline REFERENCES bug by using explicit FOREIGN KEY syntax

## Testing
- make -j4 doltlite
- bash test/doltlite_foreign_keys_default.sh ./doltlite
- bash test/vc_oracle_error_recovery_test.sh ./doltlite dolt