### PR TITLE
Add FK self-ref and chain replay coverage

### DIFF
--- a/test/doltlite_cherry_pick.sh
+++ b/test/doltlite_cherry_pick.sh
@@ -550,6 +550,66 @@ run_test "cp_fk_tables_fk" "SELECT count(*) FROM pragma_foreign_key_list('c');" 
 
 rm -f "$DB"
 
+DB=/tmp/test_cp_self_ref_fk_$$.db; rm -f "$DB"
+echo "PRAGMA foreign_keys=ON;
+CREATE TABLE t(id INTEGER PRIMARY KEY, parent_id INT, FOREIGN KEY(parent_id) REFERENCES t(id) ON DELETE CASCADE);
+INSERT INTO t VALUES(1,NULL),(2,1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES(3,2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat_add_descendant');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(10,NULL);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main_add_root');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test_match "cp_self_ref_fk_hash" \
+  "PRAGMA foreign_keys=ON; SELECT dolt_cherry_pick('feat');" \
+  "^[0-9a-f]{40}$" "$DB"
+run_test "cp_self_ref_fk_delete_cascades" \
+  "PRAGMA foreign_keys=ON; DELETE FROM t WHERE id=1; SELECT group_concat(id || ':' || ifnull(parent_id,-1), ',') FROM (SELECT id,parent_id FROM t ORDER BY id);" \
+  "10:-1" "$DB"
+run_test "cp_self_ref_fk_reopen_state" \
+  "PRAGMA foreign_keys=ON; SELECT group_concat(id || ':' || ifnull(parent_id,-1), ',') FROM (SELECT id,parent_id FROM t ORDER BY id);" \
+  "10:-1" "$DB"
+
+rm -f "$DB"
+
+DB=/tmp/test_cp_fk_chain_$$.db; rm -f "$DB"
+echo "PRAGMA foreign_keys=ON;
+CREATE TABLE gp(id INTEGER PRIMARY KEY);
+CREATE TABLE p(id INTEGER PRIMARY KEY, gp_id INT, FOREIGN KEY(gp_id) REFERENCES gp(id) ON DELETE CASCADE);
+CREATE TABLE c(id INTEGER PRIMARY KEY, p_id INT, FOREIGN KEY(p_id) REFERENCES p(id) ON DELETE CASCADE);
+INSERT INTO gp VALUES(1);
+INSERT INTO p VALUES(1,1);
+INSERT INTO c VALUES(1,1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO c VALUES(2,1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat_add_child');
+SELECT dolt_checkout('main');
+INSERT INTO gp VALUES(2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main_add_root');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test_match "cp_fk_chain_hash" \
+  "PRAGMA foreign_keys=ON; SELECT dolt_cherry_pick('feat');" \
+  "^[0-9a-f]{40}$" "$DB"
+run_test "cp_fk_chain_delete_cascades" \
+  "PRAGMA foreign_keys=ON; DELETE FROM gp WHERE id=1; SELECT (SELECT count(*) FROM gp) || '|' || (SELECT count(*) FROM p) || '|' || (SELECT count(*) FROM c);" \
+  "1|0|0" "$DB"
+run_test "cp_fk_chain_reopen_state" \
+  "PRAGMA foreign_keys=ON; SELECT (SELECT count(*) FROM gp) || '|' || (SELECT count(*) FROM p) || '|' || (SELECT count(*) FROM c);" \
+  "1|0|0" "$DB"
+
+rm -f "$DB"
+
 DB=/tmp/test_rv_violation_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, u INT UNIQUE, v TEXT);
 INSERT INTO t VALUES(1,1,'base1'),(2,2,'base2');

--- a/test/doltlite_merge.sh
+++ b/test/doltlite_merge.sh
@@ -290,7 +290,27 @@ run_test "fk_tables_plus_check_parent_visible" "SELECT count(*) FROM p;" "1" "$D
 run_test "fk_tables_plus_check_child_visible" "SELECT count(*) FROM c;" "1" "$DB20"
 run_test "fk_tables_plus_check_fk_visible" "SELECT count(*) FROM pragma_foreign_key_list('c');" "1" "$DB20"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB8B" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18" "$DB19" "$DB20"
+# Self-referential FK cascade should remain valid after merge and reopen.
+DB21=/tmp/test_merge21_$$.db; rm -f "$DB21"
+echo "PRAGMA foreign_keys=ON; CREATE TABLE t(id INTEGER PRIMARY KEY, parent_id INT, FOREIGN KEY(parent_id) REFERENCES t(id) ON DELETE CASCADE); INSERT INTO t VALUES(1,NULL),(2,1); SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');" | $DOLTLITE "$DB21" > /dev/null 2>&1
+echo "SELECT dolt_branch('feat'); SELECT dolt_checkout('feat'); INSERT INTO t VALUES(3,2); SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_add_descendant');" | $DOLTLITE "$DB21" > /dev/null 2>&1
+echo "SELECT dolt_checkout('main'); INSERT INTO t VALUES(10,NULL); SELECT dolt_add('-A'); SELECT dolt_commit('-m','main_add_root');" | $DOLTLITE "$DB21" > /dev/null 2>&1
+run_test_match "self_ref_fk_merge_hash" "PRAGMA foreign_keys=ON; SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB21"
+run_test "self_ref_fk_delete_cascades_same_session" "PRAGMA foreign_keys=ON; DELETE FROM t WHERE id=1; SELECT group_concat(id || ':' || ifnull(parent_id,-1), ',') FROM (SELECT id,parent_id FROM t ORDER BY id);" "10:-1" "$DB21"
+run_test "self_ref_fk_reopen_state" "PRAGMA foreign_keys=ON; SELECT group_concat(id || ':' || ifnull(parent_id,-1), ',') FROM (SELECT id,parent_id FROM t ORDER BY id);" "10:-1" "$DB21"
+run_test "self_ref_fk_reopen_delete_last_root" "PRAGMA foreign_keys=ON; DELETE FROM t WHERE id=10; SELECT count(*) FROM t;" "0" "$DB21"
+
+# Multi-level FK chain cascade should remain valid after merge and reopen.
+DB22=/tmp/test_merge22_$$.db; rm -f "$DB22"
+echo "PRAGMA foreign_keys=ON; CREATE TABLE gp(id INTEGER PRIMARY KEY); CREATE TABLE p(id INTEGER PRIMARY KEY, gp_id INT, FOREIGN KEY(gp_id) REFERENCES gp(id) ON DELETE CASCADE); CREATE TABLE c(id INTEGER PRIMARY KEY, p_id INT, FOREIGN KEY(p_id) REFERENCES p(id) ON DELETE CASCADE); INSERT INTO gp VALUES(1); INSERT INTO p VALUES(1,1); INSERT INTO c VALUES(1,1); SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');" | $DOLTLITE "$DB22" > /dev/null 2>&1
+echo "SELECT dolt_branch('feat'); SELECT dolt_checkout('feat'); INSERT INTO c VALUES(2,1); SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_add_child');" | $DOLTLITE "$DB22" > /dev/null 2>&1
+echo "SELECT dolt_checkout('main'); INSERT INTO gp VALUES(2); SELECT dolt_add('-A'); SELECT dolt_commit('-m','main_add_root');" | $DOLTLITE "$DB22" > /dev/null 2>&1
+run_test_match "fk_chain_merge_hash" "PRAGMA foreign_keys=ON; SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB22"
+run_test "fk_chain_delete_cascades_same_session" "PRAGMA foreign_keys=ON; DELETE FROM gp WHERE id=1; SELECT (SELECT count(*) FROM gp) || '|' || (SELECT count(*) FROM p) || '|' || (SELECT count(*) FROM c);" "1|0|0" "$DB22"
+run_test "fk_chain_reopen_state" "PRAGMA foreign_keys=ON; SELECT (SELECT count(*) FROM gp) || '|' || (SELECT count(*) FROM p) || '|' || (SELECT count(*) FROM c);" "1|0|0" "$DB22"
+run_test "fk_chain_reopen_delete_last_root" "PRAGMA foreign_keys=ON; DELETE FROM gp WHERE id=2; SELECT (SELECT count(*) FROM gp) || '|' || (SELECT count(*) FROM p) || '|' || (SELECT count(*) FROM c);" "0|0|0" "$DB22"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB8B" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18" "$DB19" "$DB20" "$DB21" "$DB22"
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
 if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi

--- a/test/doltlite_rebase_schema.sh
+++ b/test/doltlite_rebase_schema.sh
@@ -175,6 +175,78 @@ SELECT dolt_rebase('main');
 SELECT count(*) FROM pragma_foreign_key_list('c');
 " "1"
 
+SELF_REF_SETUP="
+PRAGMA foreign_keys = ON;
+CREATE TABLE t(
+  id INTEGER PRIMARY KEY,
+  parent_id INTEGER,
+  FOREIGN KEY (parent_id) REFERENCES t(id) ON DELETE CASCADE
+);
+INSERT INTO t VALUES (1, NULL), (2, 1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','init');
+SELECT dolt_branch('feat');
+INSERT INTO t VALUES (10, NULL);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main root');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES (3, 2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat descendant');
+"
+
+run_db_match "rebase_schema_self_ref_fk_hash" "
+$SELF_REF_SETUP
+SELECT dolt_rebase('main');
+" "Successfully rebased|^[0-9a-f]{40}$"
+
+run_db_eq "rebase_schema_self_ref_fk_cascade" "
+$SELF_REF_SETUP
+SELECT dolt_rebase('main');
+DELETE FROM t WHERE id = 1;
+SELECT group_concat(id || ':' || ifnull(parent_id, -1), ',') FROM (SELECT id, parent_id FROM t ORDER BY id);
+" "10:-1"
+
+CHAIN_SETUP="
+PRAGMA foreign_keys = ON;
+CREATE TABLE gp(id INTEGER PRIMARY KEY);
+CREATE TABLE p(
+  id INTEGER PRIMARY KEY,
+  gp_id INTEGER,
+  FOREIGN KEY (gp_id) REFERENCES gp(id) ON DELETE CASCADE
+);
+CREATE TABLE c(
+  id INTEGER PRIMARY KEY,
+  p_id INTEGER,
+  FOREIGN KEY (p_id) REFERENCES p(id) ON DELETE CASCADE
+);
+INSERT INTO gp VALUES (1);
+INSERT INTO p VALUES (1, 1);
+INSERT INTO c VALUES (1, 1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','init');
+SELECT dolt_branch('feat');
+INSERT INTO gp VALUES (2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main root');
+SELECT dolt_checkout('feat');
+INSERT INTO c VALUES (2, 1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat child');
+"
+
+run_db_match "rebase_schema_fk_chain_hash" "
+$CHAIN_SETUP
+SELECT dolt_rebase('main');
+" "Successfully rebased|^[0-9a-f]{40}$"
+
+run_db_eq "rebase_schema_fk_chain_cascade" "
+$CHAIN_SETUP
+SELECT dolt_rebase('main');
+DELETE FROM gp WHERE id = 1;
+SELECT (SELECT count(*) FROM gp) || '|' || (SELECT count(*) FROM p) || '|' || (SELECT count(*) FROM c);
+" "1|0|0"
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
 if [ $FAIL -gt 0 ]; then

--- a/test/vc_oracle_merge_test.sh
+++ b/test/vc_oracle_merge_test.sh
@@ -884,6 +884,132 @@ SELECT dolt_merge('feat');
           (SELECT count(*) FROM pragma_foreign_key_list('c'))" \
   "SELECT CONCAT('Q', CHAR(9), (SELECT COUNT(*) FROM p), '|', (SELECT COUNT(*) FROM c), '|', (SELECT COUNT(*) FROM information_schema.KEY_COLUMN_USAGE WHERE table_name = 'c' AND referenced_table_name = 'p'))"
 
+oracle_same_session "merge_self_ref_fk_cascade_same_session" "
+PRAGMA foreign_keys = ON;
+CREATE TABLE t(
+  id INTEGER PRIMARY KEY,
+  parent_id INTEGER,
+  FOREIGN KEY (parent_id) REFERENCES t(id) ON DELETE CASCADE
+);
+INSERT INTO t VALUES (1, NULL), (2, 1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES (3, 2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat_add_descendant');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES (10, NULL);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main_add_root');
+SELECT dolt_merge('feat');
+DELETE FROM t WHERE id = 1;
+" "SELECT 'Q' || char(9) ||
+          (SELECT count(*) FROM t) || '|' ||
+          (SELECT group_concat(id || ':' || ifnull(parent_id, -1), ',') FROM (SELECT id, parent_id FROM t ORDER BY id))" \
+  "SELECT CONCAT('Q', CHAR(9), (SELECT COUNT(*) FROM t), '|', (SELECT GROUP_CONCAT(CONCAT(id, ':', IFNULL(parent_id, -1)) ORDER BY id SEPARATOR ',') FROM t))"
+
+oracle_reopen_state "merge_self_ref_fk_cascade_reopen" "
+PRAGMA foreign_keys = ON;
+CREATE TABLE t(
+  id INTEGER PRIMARY KEY,
+  parent_id INTEGER,
+  FOREIGN KEY (parent_id) REFERENCES t(id) ON DELETE CASCADE
+);
+INSERT INTO t VALUES (1, NULL), (2, 1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES (3, 2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat_add_descendant');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES (10, NULL);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main_add_root');
+SELECT dolt_merge('feat');
+DELETE FROM t WHERE id = 1;
+" "PRAGMA foreign_keys = ON;
+SELECT 'Q' || char(9) ||
+          (SELECT count(*) FROM t) || '|' ||
+          (SELECT group_concat(id || ':' || ifnull(parent_id, -1), ',') FROM (SELECT id, parent_id FROM t ORDER BY id))" \
+  "SET @@foreign_key_checks = 1;
+SELECT CONCAT('Q', CHAR(9), (SELECT COUNT(*) FROM t), '|', (SELECT GROUP_CONCAT(CONCAT(id, ':', IFNULL(parent_id, -1)) ORDER BY id SEPARATOR ',') FROM t))"
+
+oracle_same_session "merge_fk_chain_cascade_same_session" "
+PRAGMA foreign_keys = ON;
+CREATE TABLE gp(id INTEGER PRIMARY KEY);
+CREATE TABLE p(
+  id INTEGER PRIMARY KEY,
+  gp_id INTEGER,
+  FOREIGN KEY (gp_id) REFERENCES gp(id) ON DELETE CASCADE
+);
+CREATE TABLE c(
+  id INTEGER PRIMARY KEY,
+  p_id INTEGER,
+  FOREIGN KEY (p_id) REFERENCES p(id) ON DELETE CASCADE
+);
+INSERT INTO gp VALUES (1);
+INSERT INTO p VALUES (1, 1);
+INSERT INTO c VALUES (1, 1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO c VALUES (2, 1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat_add_child');
+SELECT dolt_checkout('main');
+INSERT INTO gp VALUES (2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main_add_root');
+SELECT dolt_merge('feat');
+DELETE FROM gp WHERE id = 1;
+" "SELECT 'Q' || char(9) ||
+          (SELECT count(*) FROM gp) || '|' ||
+          (SELECT count(*) FROM p) || '|' ||
+          (SELECT count(*) FROM c)" \
+  "SELECT CONCAT('Q', CHAR(9), (SELECT COUNT(*) FROM gp), '|', (SELECT COUNT(*) FROM p), '|', (SELECT COUNT(*) FROM c))"
+
+oracle_reopen_state "merge_fk_chain_cascade_reopen" "
+PRAGMA foreign_keys = ON;
+CREATE TABLE gp(id INTEGER PRIMARY KEY);
+CREATE TABLE p(
+  id INTEGER PRIMARY KEY,
+  gp_id INTEGER,
+  FOREIGN KEY (gp_id) REFERENCES gp(id) ON DELETE CASCADE
+);
+CREATE TABLE c(
+  id INTEGER PRIMARY KEY,
+  p_id INTEGER,
+  FOREIGN KEY (p_id) REFERENCES p(id) ON DELETE CASCADE
+);
+INSERT INTO gp VALUES (1);
+INSERT INTO p VALUES (1, 1);
+INSERT INTO c VALUES (1, 1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO c VALUES (2, 1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat_add_child');
+SELECT dolt_checkout('main');
+INSERT INTO gp VALUES (2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main_add_root');
+SELECT dolt_merge('feat');
+DELETE FROM gp WHERE id = 1;
+" "PRAGMA foreign_keys = ON;
+SELECT 'Q' || char(9) ||
+          (SELECT count(*) FROM gp) || '|' ||
+          (SELECT count(*) FROM p) || '|' ||
+          (SELECT count(*) FROM c)" \
+  "SET @@foreign_key_checks = 1;
+SELECT CONCAT('Q', CHAR(9), (SELECT COUNT(*) FROM gp), '|', (SELECT COUNT(*) FROM p), '|', (SELECT COUNT(*) FROM c))"
+
 echo "--- non-branch merge sources ---"
 
 # Merge from a tag instead of a branch. Tags were promoted to first-

--- a/test/vc_oracle_rebase_test.sh
+++ b/test/vc_oracle_rebase_test.sh
@@ -396,6 +396,57 @@ SELECT dolt_rebase('main');
           (SELECT count(*) FROM pragma_foreign_key_list('c'))" \
   "SELECT CONCAT((SELECT COUNT(*) FROM p), '|', (SELECT COUNT(*) FROM c), '|', (SELECT COUNT(*) FROM information_schema.KEY_COLUMN_USAGE WHERE table_name = 'c' AND referenced_table_name = 'p'))"
 
+oracle_poststate "rebase_self_ref_fk_cascade" "
+PRAGMA foreign_keys = ON;
+CREATE TABLE t(
+  id INTEGER PRIMARY KEY,
+  parent_id INTEGER,
+  FOREIGN KEY (parent_id) REFERENCES t(id) ON DELETE CASCADE
+);
+INSERT INTO t VALUES (1, NULL), (2, 1);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');
+SELECT dolt_branch('feat');
+INSERT INTO t VALUES (10, NULL);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'main_add_root');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES (3, 2);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'feat_add_descendant');
+SELECT dolt_rebase('main');
+DELETE FROM t WHERE id = 1;
+" "SELECT (SELECT count(*) FROM t) || '|' ||
+          (SELECT group_concat(id || ':' || ifnull(parent_id, -1), ',') FROM (SELECT id, parent_id FROM t ORDER BY id) AS ordered_rows)" \
+  "SELECT CONCAT((SELECT COUNT(*) FROM t), '|', (SELECT GROUP_CONCAT(CONCAT(id, ':', IFNULL(parent_id, -1)) ORDER BY id SEPARATOR ',') FROM t))"
+
+oracle_poststate "rebase_fk_chain_cascade" "
+PRAGMA foreign_keys = ON;
+CREATE TABLE gp(id INTEGER PRIMARY KEY);
+CREATE TABLE p(
+  id INTEGER PRIMARY KEY,
+  gp_id INTEGER,
+  FOREIGN KEY (gp_id) REFERENCES gp(id) ON DELETE CASCADE
+);
+CREATE TABLE c(
+  id INTEGER PRIMARY KEY,
+  p_id INTEGER,
+  FOREIGN KEY (p_id) REFERENCES p(id) ON DELETE CASCADE
+);
+INSERT INTO gp VALUES (1);
+INSERT INTO p VALUES (1, 1);
+INSERT INTO c VALUES (1, 1);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');
+SELECT dolt_branch('feat');
+INSERT INTO gp VALUES (2);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'main_add_root');
+SELECT dolt_checkout('feat');
+INSERT INTO c VALUES (2, 1);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'feat_add_child');
+SELECT dolt_rebase('main');
+DELETE FROM gp WHERE id = 1;
+" "SELECT (SELECT count(*) FROM gp) || '|' ||
+          (SELECT count(*) FROM p) || '|' ||
+          (SELECT count(*) FROM c)" \
+  "SELECT CONCAT((SELECT COUNT(*) FROM gp), '|', (SELECT COUNT(*) FROM p), '|', (SELECT COUNT(*) FROM c))"
+
 oracle_error_reopen "rebase_fk_violation_rolls_back" "
 CREATE TABLE parent(pk INTEGER PRIMARY KEY, u INT UNIQUE);
 CREATE TABLE child(pk INTEGER PRIMARY KEY, u INT, FOREIGN KEY (u) REFERENCES parent(u));

--- a/test/vc_oracle_revert_cherrypick_test.sh
+++ b/test/vc_oracle_revert_cherrypick_test.sh
@@ -413,6 +413,65 @@ SELECT dolt_cherry_pick('feat');
           (SELECT count(*) FROM pragma_foreign_key_list('c'))" \
   "SELECT CONCAT((SELECT COUNT(*) FROM p), '|', (SELECT COUNT(*) FROM c), '|', (SELECT COUNT(*) FROM information_schema.KEY_COLUMN_USAGE WHERE table_name = 'c' AND referenced_table_name = 'p'))"
 
+oracle_poststate "cherry_pick_self_ref_fk_cascade" "
+PRAGMA foreign_keys = ON;
+CREATE TABLE t(
+  id INTEGER PRIMARY KEY,
+  parent_id INTEGER,
+  FOREIGN KEY (parent_id) REFERENCES t(id) ON DELETE CASCADE
+);
+INSERT INTO t VALUES (1, NULL), (2, 1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES (3, 2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat_add_descendant');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES (10, NULL);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main_add_root');
+SELECT dolt_cherry_pick('feat');
+DELETE FROM t WHERE id = 1;
+" "SELECT (SELECT count(*) FROM t) || '|' ||
+          (SELECT group_concat(id || ':' || ifnull(parent_id, -1), ',') FROM (SELECT id, parent_id FROM t ORDER BY id) AS ordered_rows)" \
+  "SELECT CONCAT((SELECT COUNT(*) FROM t), '|', (SELECT GROUP_CONCAT(CONCAT(id, ':', IFNULL(parent_id, -1)) ORDER BY id SEPARATOR ',') FROM t))"
+
+oracle_poststate "cherry_pick_fk_chain_cascade" "
+PRAGMA foreign_keys = ON;
+CREATE TABLE gp(id INTEGER PRIMARY KEY);
+CREATE TABLE p(
+  id INTEGER PRIMARY KEY,
+  gp_id INTEGER,
+  FOREIGN KEY (gp_id) REFERENCES gp(id) ON DELETE CASCADE
+);
+CREATE TABLE c(
+  id INTEGER PRIMARY KEY,
+  p_id INTEGER,
+  FOREIGN KEY (p_id) REFERENCES p(id) ON DELETE CASCADE
+);
+INSERT INTO gp VALUES (1);
+INSERT INTO p VALUES (1, 1);
+INSERT INTO c VALUES (1, 1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO c VALUES (2, 1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat_add_child');
+SELECT dolt_checkout('main');
+INSERT INTO gp VALUES (2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main_add_root');
+SELECT dolt_cherry_pick('feat');
+DELETE FROM gp WHERE id = 1;
+" "SELECT (SELECT count(*) FROM gp) || '|' ||
+          (SELECT count(*) FROM p) || '|' ||
+          (SELECT count(*) FROM c)" \
+  "SELECT CONCAT((SELECT COUNT(*) FROM gp), '|', (SELECT COUNT(*) FROM p), '|', (SELECT COUNT(*) FROM c))"
+
 echo "--- revert: basic ---"
 
 # Revert the most recent commit. Should produce a new commit that


### PR DESCRIPTION
## Summary
- add self-referential FK cascade replay coverage for merge, cherry-pick, and rebase
- add multi-level FK chain cascade replay coverage for merge, cherry-pick, and rebase
- keep all FK enforcement expectations explicit behind `PRAGMA foreign_keys=ON`

## Testing
- bash test/vc_oracle_merge_test.sh ./doltlite dolt
- bash test/vc_oracle_revert_cherrypick_test.sh ./doltlite dolt
- bash test/vc_oracle_rebase_test.sh ./doltlite dolt
- bash test/doltlite_merge.sh
- bash test/doltlite_cherry_pick.sh
- bash test/doltlite_rebase_schema.sh ./doltlite