### PR TITLE
Fix FK replay recreate-family false violations

### DIFF
--- a/src/doltlite_merge_constraints.c
+++ b/src/doltlite_merge_constraints.c
@@ -159,6 +159,81 @@ static int fetchRowByBlobKey(
   return rc;
 }
 
+static int fkRefreshAppendName(char ***pazNames, int *pnNames, const char *zName){
+  char **azNames = *pazNames;
+  int nNames = *pnNames;
+  int i;
+  char **azNew;
+
+  if( !zName || !zName[0] ) return SQLITE_OK;
+  for(i=0; i<nNames; i++){
+    if( strcmp(azNames[i], zName)==0 ) return SQLITE_OK;
+  }
+
+  azNew = sqlite3_realloc64(azNames, (sqlite3_uint64)(nNames+1) * sizeof(char*));
+  if( !azNew ) return SQLITE_NOMEM;
+  azNames = azNew;
+  azNames[nNames] = sqlite3_mprintf("%s", zName);
+  if( !azNames[nNames] ) return SQLITE_NOMEM;
+  *pazNames = azNames;
+  *pnNames = nNames + 1;
+  return SQLITE_OK;
+}
+
+static void fkRefreshFreeNames(char **azNames, int nNames){
+  int i;
+  for(i=0; i<nNames; i++) sqlite3_free(azNames[i]);
+  sqlite3_free(azNames);
+}
+
+/* Same-name drop/recreate replay can leave parent unique indexes stale until
+** reopen. If FK check reports rows, rebuild just the child/parent tables
+** mentioned there and re-check before treating them as real violations. */
+static int fkRefreshCandidateTables(sqlite3 *db, int *pChanged){
+  sqlite3_stmt *pStmt = 0;
+  char **azNames = 0;
+  int nNames = 0;
+  int rc, stepRc, i;
+
+  if( pChanged ) *pChanged = 0;
+
+  rc = sqlite3_prepare_v2(db, "PRAGMA main.foreign_key_check", -1, &pStmt, 0);
+  if( rc!=SQLITE_OK ) return rc;
+  while( (stepRc = sqlite3_step(pStmt))==SQLITE_ROW ){
+    const char *zChild = (const char*)sqlite3_column_text(pStmt, 0);
+    const char *zParent = (const char*)sqlite3_column_text(pStmt, 2);
+    rc = fkRefreshAppendName(&azNames, &nNames, zChild);
+    if( rc==SQLITE_OK ) rc = fkRefreshAppendName(&azNames, &nNames, zParent);
+    if( rc!=SQLITE_OK ){
+      sqlite3_finalize(pStmt);
+      fkRefreshFreeNames(azNames, nNames);
+      return rc;
+    }
+  }
+  sqlite3_finalize(pStmt);
+  if( stepRc!=SQLITE_DONE ){
+    fkRefreshFreeNames(azNames, nNames);
+    return stepRc;
+  }
+
+  for(i=0; i<nNames; i++){
+    char *zSql = sqlite3_mprintf("REINDEX \"%w\"", azNames[i]);
+    if( !zSql ){
+      fkRefreshFreeNames(azNames, nNames);
+      return SQLITE_NOMEM;
+    }
+    rc = sqlite3_exec(db, zSql, 0, 0, 0);
+    sqlite3_free(zSql);
+    if( rc!=SQLITE_OK ){
+      fkRefreshFreeNames(azNames, nNames);
+      return rc;
+    }
+  }
+  fkRefreshFreeNames(azNames, nNames);
+  if( pChanged ) *pChanged = (nNames>0);
+  return SQLITE_OK;
+}
+
 typedef struct MergePkInfo MergePkInfo;
 struct MergePkInfo {
   int nPk;
@@ -1640,6 +1715,29 @@ int doltliteDetectMergeFkViolations(
   }
   if( stepRc!=SQLITE_ROW ){
     return stepRc;
+  }
+
+  {
+    int didRefresh = 0;
+    rc = fkRefreshCandidateTables(db, &didRefresh);
+    if( rc!=SQLITE_OK ){
+      return rc;
+    }
+    if( didRefresh ){
+      rc = sqlite3_prepare_v2(db, "PRAGMA main.foreign_key_check", -1, &pQuick, 0);
+      if( rc!=SQLITE_OK ){
+        return rc;
+      }
+      stepRc = sqlite3_step(pQuick);
+      sqlite3_finalize(pQuick);
+      pQuick = 0;
+      if( stepRc==SQLITE_DONE ){
+        return SQLITE_OK;
+      }
+      if( stepRc!=SQLITE_ROW ){
+        return stepRc;
+      }
+    }
   }
 
   if( pAncCatHash && !prollyHashIsEmpty(pAncCatHash) ){

--- a/src/doltlite_merge_constraints.c
+++ b/src/doltlite_merge_constraints.c
@@ -159,6 +159,8 @@ static int fetchRowByBlobKey(
   return rc;
 }
 
+static int tableHasRowid(sqlite3 *db, const char *zTable);
+
 static int fkRefreshAppendName(char ***pazNames, int *pnNames, const char *zName){
   char **azNames = *pazNames;
   int nNames = *pnNames;
@@ -217,6 +219,9 @@ static int fkRefreshCandidateTables(sqlite3 *db, int *pChanged){
   }
 
   for(i=0; i<nNames; i++){
+    if( !tableHasRowid(db, azNames[i]) ){
+      continue;
+    }
     char *zSql = sqlite3_mprintf("REINDEX \"%w\"", azNames[i]);
     if( !zSql ){
       fkRefreshFreeNames(azNames, nNames);

--- a/test/doltlite_cherry_pick.sh
+++ b/test/doltlite_cherry_pick.sh
@@ -550,6 +550,45 @@ run_test "cp_fk_tables_fk" "SELECT count(*) FROM pragma_foreign_key_list('c');" 
 
 rm -f "$DB"
 
+DB=/tmp/test_cp_recreate_fk_family_$$.db; rm -f "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1,10);
+CREATE TABLE p(id INTEGER PRIMARY KEY, u INT UNIQUE);
+CREATE TABLE c(id INTEGER PRIMARY KEY, u INT, FOREIGN KEY(u) REFERENCES p(u));
+INSERT INTO p VALUES(1,100);
+INSERT INTO c VALUES(1,100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+DROP TABLE c;
+DROP TABLE p;
+CREATE TABLE p(id INTEGER PRIMARY KEY, u INT UNIQUE, label TEXT);
+CREATE TABLE c(id INTEGER PRIMARY KEY, u INT, FOREIGN KEY(u) REFERENCES p(u));
+INSERT INTO p VALUES(2,200,'x');
+INSERT INTO c VALUES(2,200);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat_recreate_fk_family');
+SELECT dolt_checkout('main');
+CREATE TABLE t_new(id INTEGER PRIMARY KEY, v INT CHECK(v > 0));
+INSERT INTO t_new SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t_new RENAME TO t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main_check');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test_match "cp_recreate_fk_family_hash" \
+  "SELECT dolt_cherry_pick('feat');" \
+  "^[0-9a-f]{40}$" "$DB"
+run_test "cp_recreate_fk_family_parent" "SELECT count(*) FROM p;" "1" "$DB"
+run_test "cp_recreate_fk_family_child" "SELECT count(*) FROM c;" "1" "$DB"
+run_test "cp_recreate_fk_family_fk" "SELECT count(*) FROM pragma_foreign_key_list('c');" "1" "$DB"
+run_test "cp_recreate_fk_family_schema" "SELECT instr(sql,'label TEXT')>0 FROM sqlite_master WHERE type='table' AND name='p';" "1" "$DB"
+run_test "cp_recreate_fk_family_parent_unique_index_live" "SELECT count(*) FROM p INDEXED BY sqlite_autoindex_p_1 WHERE u=200;" "1" "$DB"
+run_test "cp_recreate_fk_family_fk_check_clean" "SELECT count(*) FROM pragma_foreign_key_check;" "0" "$DB"
+
+rm -f "$DB"
+
 DB=/tmp/test_cp_self_ref_fk_$$.db; rm -f "$DB"
 echo "PRAGMA foreign_keys=ON;
 CREATE TABLE t(id INTEGER PRIMARY KEY, parent_id INT, FOREIGN KEY(parent_id) REFERENCES t(id) ON DELETE CASCADE);

--- a/test/doltlite_merge.sh
+++ b/test/doltlite_merge.sh
@@ -290,6 +290,20 @@ run_test "fk_tables_plus_check_parent_visible" "SELECT count(*) FROM p;" "1" "$D
 run_test "fk_tables_plus_check_child_visible" "SELECT count(*) FROM c;" "1" "$DB20"
 run_test "fk_tables_plus_check_fk_visible" "SELECT count(*) FROM pragma_foreign_key_list('c');" "1" "$DB20"
 
+# Same-name FK family recreate on one branch plus unrelated check on the other
+# should merge cleanly and keep the recreated parent's unique index live.
+DB20B=/tmp/test_merge20b_$$.db; rm -f "$DB20B"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT); INSERT INTO t VALUES(1,10); CREATE TABLE p(id INTEGER PRIMARY KEY, u INT UNIQUE); CREATE TABLE c(id INTEGER PRIMARY KEY, u INT, FOREIGN KEY(u) REFERENCES p(u)); INSERT INTO p VALUES(1,100); INSERT INTO c VALUES(1,100); SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');" | $DOLTLITE "$DB20B" > /dev/null 2>&1
+echo "SELECT dolt_branch('feat'); SELECT dolt_checkout('feat'); DROP TABLE c; DROP TABLE p; CREATE TABLE p(id INTEGER PRIMARY KEY, u INT UNIQUE, label TEXT); CREATE TABLE c(id INTEGER PRIMARY KEY, u INT, FOREIGN KEY(u) REFERENCES p(u)); INSERT INTO p VALUES(2,200,'x'); INSERT INTO c VALUES(2,200); SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_recreate_fk_family');" | $DOLTLITE "$DB20B" > /dev/null 2>&1
+echo "SELECT dolt_checkout('main'); CREATE TABLE t_new(id INTEGER PRIMARY KEY, v INT CHECK(v > 0)); INSERT INTO t_new SELECT * FROM t; DROP TABLE t; ALTER TABLE t_new RENAME TO t; SELECT dolt_add('-A'); SELECT dolt_commit('-m','main_check');" | $DOLTLITE "$DB20B" > /dev/null 2>&1
+run_test_match "recreate_fk_family_merge_hash" "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB20B"
+run_test "recreate_fk_family_parent_visible" "SELECT count(*) FROM p;" "1" "$DB20B"
+run_test "recreate_fk_family_child_visible" "SELECT count(*) FROM c;" "1" "$DB20B"
+run_test "recreate_fk_family_fk_visible" "SELECT count(*) FROM pragma_foreign_key_list('c');" "1" "$DB20B"
+run_test "recreate_fk_family_parent_schema_visible" "SELECT instr(sql,'label TEXT')>0 FROM sqlite_master WHERE type='table' AND name='p';" "1" "$DB20B"
+run_test "recreate_fk_family_parent_unique_index_live" "SELECT count(*) FROM p INDEXED BY sqlite_autoindex_p_1 WHERE u=200;" "1" "$DB20B"
+run_test "recreate_fk_family_fk_check_clean" "SELECT count(*) FROM pragma_foreign_key_check;" "0" "$DB20B"
+
 # Self-referential FK cascade should remain valid after merge and reopen.
 DB21=/tmp/test_merge21_$$.db; rm -f "$DB21"
 echo "PRAGMA foreign_keys=ON; CREATE TABLE t(id INTEGER PRIMARY KEY, parent_id INT, FOREIGN KEY(parent_id) REFERENCES t(id) ON DELETE CASCADE); INSERT INTO t VALUES(1,NULL),(2,1); SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');" | $DOLTLITE "$DB21" > /dev/null 2>&1
@@ -310,7 +324,7 @@ run_test "fk_chain_delete_cascades_same_session" "PRAGMA foreign_keys=ON; DELETE
 run_test "fk_chain_reopen_state" "PRAGMA foreign_keys=ON; SELECT (SELECT count(*) FROM gp) || '|' || (SELECT count(*) FROM p) || '|' || (SELECT count(*) FROM c);" "1|0|0" "$DB22"
 run_test "fk_chain_reopen_delete_last_root" "PRAGMA foreign_keys=ON; DELETE FROM gp WHERE id=2; SELECT (SELECT count(*) FROM gp) || '|' || (SELECT count(*) FROM p) || '|' || (SELECT count(*) FROM c);" "0|0|0" "$DB22"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB8B" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18" "$DB19" "$DB20" "$DB21" "$DB22"
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB8B" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18" "$DB19" "$DB20" "$DB20B" "$DB21" "$DB22"
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
 if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi

--- a/test/doltlite_rebase_schema.sh
+++ b/test/doltlite_rebase_schema.sh
@@ -175,6 +175,74 @@ SELECT dolt_rebase('main');
 SELECT count(*) FROM pragma_foreign_key_list('c');
 " "1"
 
+RECREATE_FK_SETUP="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1,10);
+CREATE TABLE p(id INTEGER PRIMARY KEY, u INT UNIQUE);
+CREATE TABLE c(id INTEGER PRIMARY KEY, u INT, FOREIGN KEY(u) REFERENCES p(u));
+INSERT INTO p VALUES(1,100);
+INSERT INTO c VALUES(1,100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','init');
+SELECT dolt_branch('feat');
+CREATE TABLE t_new(id INTEGER PRIMARY KEY, v INT CHECK (v > 0));
+INSERT INTO t_new SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t_new RENAME TO t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main_check');
+SELECT dolt_checkout('feat');
+DROP TABLE c;
+DROP TABLE p;
+CREATE TABLE p(id INTEGER PRIMARY KEY, u INT UNIQUE, label TEXT);
+CREATE TABLE c(id INTEGER PRIMARY KEY, u INT, FOREIGN KEY(u) REFERENCES p(u));
+INSERT INTO p VALUES(2,200,'x');
+INSERT INTO c VALUES(2,200);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat_recreate_fk_family');
+"
+
+run_db_match "rebase_schema_recreate_fk_family_hash" "
+$RECREATE_FK_SETUP
+SELECT dolt_rebase('main');
+" "Successfully rebased|^[0-9a-f]{40}$"
+
+run_db_eq "rebase_schema_recreate_fk_family_parent" "
+$RECREATE_FK_SETUP
+SELECT dolt_rebase('main');
+SELECT count(*) FROM p;
+" "1"
+
+run_db_eq "rebase_schema_recreate_fk_family_child" "
+$RECREATE_FK_SETUP
+SELECT dolt_rebase('main');
+SELECT count(*) FROM c;
+" "1"
+
+run_db_eq "rebase_schema_recreate_fk_family_fk" "
+$RECREATE_FK_SETUP
+SELECT dolt_rebase('main');
+SELECT count(*) FROM pragma_foreign_key_list('c');
+" "1"
+
+run_db_eq "rebase_schema_recreate_fk_family_schema" "
+$RECREATE_FK_SETUP
+SELECT dolt_rebase('main');
+SELECT instr(sql,'label TEXT')>0 FROM sqlite_master WHERE type='table' AND name='p';
+" "1"
+
+run_db_eq "rebase_schema_recreate_fk_family_parent_unique_index_live" "
+$RECREATE_FK_SETUP
+SELECT dolt_rebase('main');
+SELECT count(*) FROM p INDEXED BY sqlite_autoindex_p_1 WHERE u=200;
+" "1"
+
+run_db_eq "rebase_schema_recreate_fk_family_fk_check_clean" "
+$RECREATE_FK_SETUP
+SELECT dolt_rebase('main');
+SELECT count(*) FROM pragma_foreign_key_check;
+" "0"
+
 SELF_REF_SETUP="
 PRAGMA foreign_keys = ON;
 CREATE TABLE t(

--- a/test/vc_oracle_merge_test.sh
+++ b/test/vc_oracle_merge_test.sh
@@ -884,6 +884,39 @@ SELECT dolt_merge('feat');
           (SELECT count(*) FROM pragma_foreign_key_list('c'))" \
   "SELECT CONCAT('Q', CHAR(9), (SELECT COUNT(*) FROM p), '|', (SELECT COUNT(*) FROM c), '|', (SELECT COUNT(*) FROM information_schema.KEY_COLUMN_USAGE WHERE table_name = 'c' AND referenced_table_name = 'p'))"
 
+oracle_same_session "merge_recreate_fk_family_plus_check_same_session" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+CREATE TABLE p(id INTEGER PRIMARY KEY, u INT UNIQUE);
+CREATE TABLE c(id INTEGER PRIMARY KEY, u INT, FOREIGN KEY (u) REFERENCES p(u));
+INSERT INTO p VALUES (1, 100);
+INSERT INTO c VALUES (1, 100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+DROP TABLE c;
+DROP TABLE p;
+CREATE TABLE p(id INTEGER PRIMARY KEY, u INT UNIQUE, label TEXT);
+CREATE TABLE c(id INTEGER PRIMARY KEY, u INT, FOREIGN KEY (u) REFERENCES p(u));
+INSERT INTO p VALUES (2, 200, 'x');
+INSERT INTO c VALUES (2, 200);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat_recreate_fk_family');
+SELECT dolt_checkout('main');
+CREATE TABLE t_new(id INTEGER PRIMARY KEY, v INT CHECK (v > 0));
+INSERT INTO t_new SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t_new RENAME TO t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main_check');
+SELECT dolt_merge('feat');
+" "SELECT 'Q' || char(9) ||
+          (SELECT count(*) FROM p) || '|' ||
+          (SELECT count(*) FROM c) || '|' ||
+          (SELECT count(*) FROM pragma_foreign_key_list('c'))" \
+  "SELECT CONCAT('Q', CHAR(9), (SELECT COUNT(*) FROM p), '|', (SELECT COUNT(*) FROM c), '|', (SELECT COUNT(*) FROM information_schema.KEY_COLUMN_USAGE WHERE table_name = 'c' AND referenced_table_name = 'p'))"
+
 oracle_same_session "merge_self_ref_fk_cascade_same_session" "
 PRAGMA foreign_keys = ON;
 CREATE TABLE t(

--- a/test/vc_oracle_rebase_test.sh
+++ b/test/vc_oracle_rebase_test.sh
@@ -396,6 +396,34 @@ SELECT dolt_rebase('main');
           (SELECT count(*) FROM pragma_foreign_key_list('c'))" \
   "SELECT CONCAT((SELECT COUNT(*) FROM p), '|', (SELECT COUNT(*) FROM c), '|', (SELECT COUNT(*) FROM information_schema.KEY_COLUMN_USAGE WHERE table_name = 'c' AND referenced_table_name = 'p'))"
 
+oracle_poststate "rebase_recreate_fk_family_plus_check" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+CREATE TABLE p(id INTEGER PRIMARY KEY, u INT UNIQUE);
+CREATE TABLE c(id INTEGER PRIMARY KEY, u INT, FOREIGN KEY (u) REFERENCES p(u));
+INSERT INTO p VALUES (1, 100);
+INSERT INTO c VALUES (1, 100);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');
+SELECT dolt_branch('feat');
+CREATE TABLE t_new(id INTEGER PRIMARY KEY, v INT CHECK (v > 0));
+INSERT INTO t_new SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t_new RENAME TO t;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'main_check');
+SELECT dolt_checkout('feat');
+DROP TABLE c;
+DROP TABLE p;
+CREATE TABLE p(id INTEGER PRIMARY KEY, u INT UNIQUE, label TEXT);
+CREATE TABLE c(id INTEGER PRIMARY KEY, u INT, FOREIGN KEY (u) REFERENCES p(u));
+INSERT INTO p VALUES (2, 200, 'x');
+INSERT INTO c VALUES (2, 200);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'feat_recreate_fk_family');
+SELECT dolt_rebase('main');
+" "SELECT (SELECT count(*) FROM p) || '|' ||
+          (SELECT count(*) FROM c) || '|' ||
+          (SELECT count(*) FROM pragma_foreign_key_list('c'))" \
+  "SELECT CONCAT((SELECT COUNT(*) FROM p), '|', (SELECT COUNT(*) FROM c), '|', (SELECT COUNT(*) FROM information_schema.KEY_COLUMN_USAGE WHERE table_name = 'c' AND referenced_table_name = 'p'))"
+
 oracle_poststate "rebase_self_ref_fk_cascade" "
 PRAGMA foreign_keys = ON;
 CREATE TABLE t(

--- a/test/vc_oracle_revert_cherrypick_test.sh
+++ b/test/vc_oracle_revert_cherrypick_test.sh
@@ -413,6 +413,38 @@ SELECT dolt_cherry_pick('feat');
           (SELECT count(*) FROM pragma_foreign_key_list('c'))" \
   "SELECT CONCAT((SELECT COUNT(*) FROM p), '|', (SELECT COUNT(*) FROM c), '|', (SELECT COUNT(*) FROM information_schema.KEY_COLUMN_USAGE WHERE table_name = 'c' AND referenced_table_name = 'p'))"
 
+oracle_poststate "cherry_pick_recreate_fk_family_plus_check" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+CREATE TABLE p(id INTEGER PRIMARY KEY, u INT UNIQUE);
+CREATE TABLE c(id INTEGER PRIMARY KEY, u INT, FOREIGN KEY (u) REFERENCES p(u));
+INSERT INTO p VALUES (1, 100);
+INSERT INTO c VALUES (1, 100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+DROP TABLE c;
+DROP TABLE p;
+CREATE TABLE p(id INTEGER PRIMARY KEY, u INT UNIQUE, label TEXT);
+CREATE TABLE c(id INTEGER PRIMARY KEY, u INT, FOREIGN KEY (u) REFERENCES p(u));
+INSERT INTO p VALUES (2, 200, 'x');
+INSERT INTO c VALUES (2, 200);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat_recreate_fk_family');
+SELECT dolt_checkout('main');
+CREATE TABLE t_new(id INTEGER PRIMARY KEY, v INT CHECK (v > 0));
+INSERT INTO t_new SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t_new RENAME TO t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main_check');
+SELECT dolt_cherry_pick('feat');
+" "SELECT (SELECT count(*) FROM p) || '|' ||
+          (SELECT count(*) FROM c) || '|' ||
+          (SELECT count(*) FROM pragma_foreign_key_list('c'))" \
+  "SELECT CONCAT((SELECT COUNT(*) FROM p), '|', (SELECT COUNT(*) FROM c), '|', (SELECT COUNT(*) FROM information_schema.KEY_COLUMN_USAGE WHERE table_name = 'c' AND referenced_table_name = 'p'))"
+
 oracle_poststate "cherry_pick_self_ref_fk_cascade" "
 PRAGMA foreign_keys = ON;
 CREATE TABLE t(


### PR DESCRIPTION
## Summary
- fix false foreign-key violations after replaying same-name parent/child FK family recreates
- refresh only the FK child/parent tables named by `foreign_key_check` before treating in-session orphan rows as real
- add merge, cherry-pick, and rebase regressions for recreated FK families plus unrelated schema rewrites

## Testing
- make -j4 doltlite
- bash test/doltlite_merge.sh
- bash test/doltlite_cherry_pick.sh
- bash test/doltlite_rebase_schema.sh ./doltlite
- bash test/vc_oracle_merge_test.sh ./doltlite dolt
- bash test/vc_oracle_revert_cherrypick_test.sh ./doltlite dolt
- bash test/vc_oracle_rebase_test.sh ./doltlite dolt