### PR TITLE
Fix bulk .read INSERT VALUES row loss

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -1104,6 +1104,7 @@ static int applyMutMapToTableRoot(
   mut.oldRoot = pTE->root;
   mut.pEdits = pMap;
   mut.flags = pTE->flags;
+  mut.forceMergeWalk = pTE->zName!=0 && !(pTE->flags & PROLLY_NODE_INTKEY);
 
   rc = prollyMutateFlush(&mut);
   if( rc!=SQLITE_OK ) return rc;
@@ -5830,6 +5831,7 @@ int doltliteApplyRawRowMutation(
   memcpy(&mut.oldRoot, &pTE->root, sizeof(ProllyHash));
   mut.pEdits = &mm;
   mut.flags = pTE->flags;
+  mut.forceMergeWalk = tableEntryIsTableRoot(pBtree, pTE) && !isIntKey;
 
   rc = prollyMutateFlush(&mut);
   if( rc==SQLITE_OK ){

--- a/src/prolly_mutate.c
+++ b/src/prolly_mutate.c
@@ -492,7 +492,7 @@ int prollyMutateFlush(ProllyMutator *pMut){
     int M = prollyMutMapCount(pMut->pEdits);
     int leafCount = 0;
 
-    if( (pMut->flags & PROLLY_NODE_INTKEY)==0 ){
+    if( pMut->forceMergeWalk ){
       return mergeWalk(pMut);
     }
 

--- a/src/prolly_mutate.c
+++ b/src/prolly_mutate.c
@@ -492,6 +492,10 @@ int prollyMutateFlush(ProllyMutator *pMut){
     int M = prollyMutMapCount(pMut->pEdits);
     int leafCount = 0;
 
+    if( (pMut->flags & PROLLY_NODE_INTKEY)==0 ){
+      return mergeWalk(pMut);
+    }
+
     {
       u8 *pRootData = 0;
       int nRootData = 0;

--- a/src/prolly_mutate.h
+++ b/src/prolly_mutate.h
@@ -19,6 +19,7 @@ struct ProllyMutator {
   ProllyHash oldRoot;
   ProllyMutMap *pEdits;
   u8 flags;
+  u8 forceMergeWalk;
   ProllyHash newRoot;
 };
 

--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -571,18 +571,23 @@ void prollyMutMapReleaseSavepoint(ProllyMutMap *mm, int level){
   if( !mm ) return;
   target = level - 1;
 
+  if( level==1 && target==0 ){
+    for(i=0; i<mm->nUndo; i++){
+      sqlite3_free(mm->aUndo[i].prevVal);
+      mm->aUndo[i].prevVal = 0;
+    }
+    mm->nUndo = 0;
+    mm->levelBase++;
+    mm->currentSavepointLevel = 0;
+    return;
+  }
+
   if( target == 0 ){
     for(i=0; i<mm->nUndo; i++){
       sqlite3_free(mm->aUndo[i].prevVal);
       mm->aUndo[i].prevVal = 0;
     }
     mm->nUndo = 0;
-    for(i=0; i<mm->nEntries; i++){
-      mm->aEntries[i].bornAt = 0;
-    }
-    mm->levelBase = 0;
-    mm->currentSavepointLevel = 0;
-    return;
   }else{
     for(i=0; i<mm->nUndo; i++){
       if( mm->aUndo[i].level >= level ){

--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -571,23 +571,18 @@ void prollyMutMapReleaseSavepoint(ProllyMutMap *mm, int level){
   if( !mm ) return;
   target = level - 1;
 
-  if( level==1 && target==0 ){
-    for(i=0; i<mm->nUndo; i++){
-      sqlite3_free(mm->aUndo[i].prevVal);
-      mm->aUndo[i].prevVal = 0;
-    }
-    mm->nUndo = 0;
-    mm->levelBase++;
-    mm->currentSavepointLevel = 0;
-    return;
-  }
-
   if( target == 0 ){
     for(i=0; i<mm->nUndo; i++){
       sqlite3_free(mm->aUndo[i].prevVal);
       mm->aUndo[i].prevVal = 0;
     }
     mm->nUndo = 0;
+    for(i=0; i<mm->nEntries; i++){
+      mm->aEntries[i].bornAt = 0;
+    }
+    mm->levelBase = 0;
+    mm->currentSavepointLevel = 0;
+    return;
   }else{
     for(i=0; i<mm->nUndo; i++){
       if( mm->aUndo[i].level >= level ){

--- a/test/review_regression_test.sh
+++ b/test/review_regression_test.sh
@@ -298,6 +298,50 @@ run_test "gc_reopen_data" "SELECT count(*) FROM t;" "2" "$DB"
 rm -f "$DB"
 
 # ============================================================
+# GUARD 10: .read bulk INSERT VALUES preserves all rows
+# Bug: repeated INSERT ... VALUES statements streamed through
+#      the shell could silently drop older rows in composite-PK
+#      tables once sparse blob-key edits were applied one row at a time.
+# Fix: avoid the streaming sparse-edit path for non-intkey roots and
+#      flatten released savepoint bornAt state back to level 0.
+# ============================================================
+
+echo "--- Guard 10: .read bulk INSERT VALUES ---"
+
+TMPROOT=$(mktemp -d)
+DB="$TMPROOT/bulk_read.db"
+SQL="$TMPROOT/bulk_read.sql"
+
+echo "CREATE TABLE t(
+  a INTEGER NOT NULL,
+  b INTEGER NOT NULL,
+  c INTEGER,
+  d INTEGER,
+  e TEXT,
+  PRIMARY KEY(a,b)
+);" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+{
+  echo "BEGIN;"
+  for i in $(seq 1 5000); do
+    echo "INSERT INTO t(a,b,c,d,e) VALUES($i,$i,$i,$i,NULL);"
+  done
+  echo "COMMIT;"
+} > "$SQL"
+
+$DOLTLITE -bail "$DB" -cmd ".read $SQL" \
+  "SELECT dolt_commit('-A','-m','bulk read');" > /dev/null 2>&1
+
+run_test "bulk_read_row_count" \
+  "SELECT COUNT(*) FROM t;" "5000" "$DB"
+run_test "bulk_read_min_pk" \
+  "SELECT MIN(a) FROM t;" "1" "$DB"
+run_test "bulk_read_max_pk" \
+  "SELECT MAX(a) FROM t;" "5000" "$DB"
+
+rm -rf "$TMPROOT"
+
+# ============================================================
 # Done
 # ============================================================
 


### PR DESCRIPTION
## Summary
- fix streamed `.read` `INSERT ... VALUES` row loss on composite-PK / blob-key tables
- force the mutator to use `mergeWalk` for non-`INTKEY` roots instead of the sparse streaming path
- flatten released mutmap savepoint metadata back to level `0` and add a direct shell regression for issue #710

## Testing
- shell repro from #710: `5000|1|5000`
- `bash test/review_regression_test.sh`
- `bash test/doltlite_merge.sh`
- `bash test/doltlite_cherry_pick.sh`
- `bash test/doltlite_rebase_schema.sh ./doltlite`
- `bash test/vc_oracle_merge_test.sh ./doltlite dolt`

Closes #710.