### PR TITLE
sysbench: add TEXT PK write benchmarks (reporting only)

### DIFF
--- a/test/sysbench_compare.sh
+++ b/test/sysbench_compare.sh
@@ -89,6 +89,19 @@ def prep_with_types(f):
     write_prepare(f)
     write_prepare_types(f)
 
+def write_prepare_textpk(f):
+    # Same shape as sbtest1, but PK is a 32-char hex string (UUID-shaped).
+    # Lights up the non-INTKEY mutmap-flush path (issue #718).
+    f.write("CREATE TABLE sbtest_textpk(id TEXT PRIMARY KEY, k INTEGER NOT NULL DEFAULT 0, c TEXT NOT NULL DEFAULT '', pad TEXT NOT NULL DEFAULT '');\n")
+    f.write("CREATE INDEX k_idx_textpk ON sbtest_textpk(k);\n")
+    f.write("BEGIN;\n")
+    for i in range(1, R+1):
+        f.write(f"INSERT INTO sbtest_textpk VALUES('{i:032x}',{rint(1,R)},'{rstr(60)}','{rstr(30)}');\n")
+    f.write("COMMIT;\n")
+
+def prep_textpk(f):
+    write_prepare_textpk(f)
+
 # --- Tests ---
 
 def w_bulk_insert(f):
@@ -337,6 +350,41 @@ def w_read_write_autocommit(f):
         f.write(f"DELETE FROM sbtest1 WHERE id={id};\n")
         f.write(f"INSERT OR REPLACE INTO sbtest1 VALUES({id},{rint(1,R)},'{rstr(60)}','{rstr(30)}');\n")
 
+# TEXT-PK writes: same workload shapes as the INTEGER-PK writes, but the
+# PK is a 32-char hex string. Issue #718: non-INTKEY tables route through
+# mergeWalk on every flush, which is 10-1000x slower than streamingMerge.
+# Reporting only (not gated) until the fix lands.
+def w_update_index_textpk(f):
+    f.write("BEGIN;\n")
+    for _ in range(10000):
+        f.write(f"UPDATE sbtest_textpk SET k={rint(1,R)} WHERE id='{rint(1,R):032x}';\n")
+    f.write("COMMIT;\n")
+
+def w_update_non_index_textpk(f):
+    f.write("BEGIN;\n")
+    for _ in range(10000):
+        f.write(f"UPDATE sbtest_textpk SET c='{rstr(60)}' WHERE id='{rint(1,R):032x}';\n")
+    f.write("COMMIT;\n")
+
+def w_oltp_insert_textpk(f):
+    f.write("BEGIN;\n")
+    for i in range(R+1, R+5001):
+        f.write(f"INSERT INTO sbtest_textpk VALUES('{i:032x}',{rint(1,R)},'{rstr(60)}','{rstr(30)}');\n")
+    f.write("COMMIT;\n")
+
+def w_delete_insert_textpk(f):
+    f.write("BEGIN;\n")
+    for _ in range(5000):
+        i = rint(1, R)
+        f.write(f"DELETE FROM sbtest_textpk WHERE id='{i:032x}';\n")
+        f.write(f"INSERT OR REPLACE INTO sbtest_textpk VALUES('{i:032x}',{rint(1,R)},'{rstr(60)}','{rstr(30)}');\n")
+    f.write("COMMIT;\n")
+
+make_test("oltp_update_index_textpk",     prep_textpk, w_update_index_textpk)
+make_test("oltp_update_non_index_textpk", prep_textpk, w_update_non_index_textpk)
+make_test("oltp_insert_textpk",           prep_textpk, w_oltp_insert_textpk)
+make_test("oltp_delete_insert_textpk",    prep_textpk, w_delete_insert_textpk)
+
 make_test("oltp_bulk_insert_ac",      prep_main, w_bulk_insert_autocommit)
 make_test("oltp_insert_ac",           prep_main, w_oltp_insert_autocommit)
 make_test("oltp_update_index_ac",     prep_main, w_update_index_autocommit)
@@ -417,6 +465,7 @@ run_bench_stable() {
 READ_TESTS="oltp_point_select oltp_range_select oltp_sum_range oltp_order_range oltp_distinct_range oltp_index_scan select_random_points select_random_ranges covering_index_scan groupby_scan index_join index_join_scan types_table_scan table_scan oltp_read_only"
 WRITE_TESTS="oltp_bulk_insert oltp_insert oltp_update_index oltp_update_non_index oltp_delete_insert oltp_write_only types_delete_insert oltp_read_write"
 WRITE_TESTS_AC="oltp_bulk_insert_ac oltp_insert_ac oltp_update_index_ac oltp_update_non_index_ac oltp_delete_insert_ac oltp_write_only_ac types_delete_insert_ac oltp_read_write_ac"
+WRITE_TESTS_TEXTPK="oltp_update_index_textpk oltp_update_non_index_textpk oltp_insert_textpk oltp_delete_insert_textpk"
 
 # ============================================================
 # Output markdown table
@@ -491,6 +540,16 @@ echo ""
 echo "#### Writes"
 echo ""
 run_section "$WRITE_TESTS_AC" "/tmp/bench_file" "/tmp/bench_file"
+
+echo ""
+echo "### File-Backed (TEXT PK writes)"
+echo ""
+echo "_Same workload shapes as the File-Backed Writes section, but on a_"
+echo "_table with a 32-char hex \`TEXT PRIMARY KEY\`. Surfaces the non-INTKEY_"
+echo "_mutmap-flush path (issue #718). Reporting only — not gated by the_"
+echo "_ceiling check below until the fix lands._"
+echo ""
+run_section "$WRITE_TESTS_TEXTPK" "/tmp/bench_file" "/tmp/bench_file"
 
 echo ""
 echo "_${ROWS} rows, single CLI invocation per test, workload-only timing via SQL timestamps._"


### PR DESCRIPTION
## Summary
- Add a File-Backed (TEXT PK writes) section to the sysbench harness, mirroring the four INTEGER-PK write workloads (`oltp_update_index`, `oltp_update_non_index`, `oltp_insert`, `oltp_delete_insert`) on a table with a 32-char hex `TEXT PRIMARY KEY`.
- Reporting only — **not** added to the ceiling check.

## Why

PR #713 closed #710 by routing every non-INTKEY table through `mergeWalk` on every flush (`forceMergeWalk` in `prolly_mutate.c:495` + `prolly_btree.c:1107,5834`). Issue #718 reports a 10–1000× regression on per-row write workloads against tables with TEXT, BLOB, or composite primary keys as a result. The existing sysbench suite is INTEGER-PK only, so the regression isn't visible in CI.

Adding these four tests now (without gating) lets every subsequent PR show a TEXT-PK number in the bench output, so we can track the fix's progress and prevent future re-regressions once the streamingMerge corner case is addressed.

## Numbers (local, BENCH_ROWS=200, BENCH_RUNS=1)

| Test | Multiplier |
|---|---:|
| `oltp_update_index_textpk` | 12.40× |
| `oltp_update_non_index_textpk` | 15.52× |
| `oltp_insert_textpk` | 25.92× |
| `oltp_delete_insert_textpk` | 17.85× |

Matches the ballpark of LaPingvino's PK-type matrix in #718 (TEXT PK 32-hex at 17.4 ms/upd, ~900× headline ratio).

## Why not gate

Current master is well above the 2× ceiling on these. Adding them to the gate now would break CI on master without a fix in hand. Pattern matches #676 (autocommit section also landed reporting-only first, then got gated by #679 once the perf fix was in).

## Test plan
- [x] Local smoke: `BENCH_ROWS=200 BENCH_RUNS=1 bash test/sysbench_compare.sh` — section renders, ceiling check still passes
- [ ] CI bench job stays green