### PR TITLE
Fix streamingMerge depth pathology, drop forceMergeWalk

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -1104,7 +1104,6 @@ static int applyMutMapToTableRoot(
   mut.oldRoot = pTE->root;
   mut.pEdits = pMap;
   mut.flags = pTE->flags;
-  mut.forceMergeWalk = pTE->zName!=0 && !(pTE->flags & PROLLY_NODE_INTKEY);
 
   rc = prollyMutateFlush(&mut);
   if( rc!=SQLITE_OK ) return rc;
@@ -5831,7 +5830,6 @@ int doltliteApplyRawRowMutation(
   memcpy(&mut.oldRoot, &pTE->root, sizeof(ProllyHash));
   mut.pEdits = &mm;
   mut.flags = pTE->flags;
-  mut.forceMergeWalk = tableEntryIsTableRoot(pBtree, pTE) && !isIntKey;
 
   rc = prollyMutateFlush(&mut);
   if( rc==SQLITE_OK ){

--- a/src/prolly_chunker.c
+++ b/src/prolly_chunker.c
@@ -75,12 +75,18 @@ static int flushLevel(ProllyChunker *ch, int level){
   /* Parent level keyed on the LAST child key: prolly internal keys
   ** are the max key of their subtree, matching the cursor's seek
   ** contract. */
-  if( level + 1 < PROLLY_CURSOR_MAX_DEPTH ){
-    rc = addToLevel(ch, level + 1,
-                    pLastKey, nLastKey,
-                    hash.data, PROLLY_HASH_SIZE);
-    if( rc!=SQLITE_OK ) return rc;
+  /* If we've hit MAX_DEPTH the parent level can't accept this chunk's
+  ** reference. Returning SQLITE_OK here would silently drop the chunk —
+  ** every key under it disappears from the tree. Bail with an error so
+  ** the caller can fall back to the rebuild path (mergeWalk). */
+  if( level + 1 >= PROLLY_CURSOR_MAX_DEPTH ){
+    return SQLITE_FULL;
   }
+
+  rc = addToLevel(ch, level + 1,
+                  pLastKey, nLastKey,
+                  hash.data, PROLLY_HASH_SIZE);
+  if( rc!=SQLITE_OK ) return rc;
 
 
   prollyNodeBuilderReset(&pLevel->builder);

--- a/src/prolly_mutate.c
+++ b/src/prolly_mutate.c
@@ -122,7 +122,8 @@ static int mergeLeaf(
   ProllyMutator *pMut,
   ProllyNode *pLeaf,
   ProllyChunker *pCh,
-  ProllyMutMapIter *pIter
+  ProllyMutMapIter *pIter,
+  int isLast
 ){
   int rc = SQLITE_OK;
   int j;
@@ -223,6 +224,32 @@ static int mergeLeaf(
       prollyMutMapIterNext(pIter);
     }
   }
+
+  /* Drain trailing edits past the leaf's last key when this is the
+  ** rightmost leaf of an isLast subtree. Feeding them at level 0
+  ** here lets them chunk up alongside the leaf's items, instead of
+  ** the previous "trailing-append at level 0 + propagate up through
+  ** every intermediate level" path that grew tree depth by 1 per
+  ** flush in the worst case. */
+  if( isLast ){
+    while( prollyMutMapIterValid(pIter) ){
+      ProllyMutMapEntry *pEd = prollyMutMapIterEntry(pIter);
+      if( pEd->op==PROLLY_EDIT_INSERT ){
+        u8 aEditKey[8];
+        const u8 *pEK; int nEK;
+        if( flags & PROLLY_NODE_INTKEY ){
+          encodeI64BE(aEditKey, pEd->intKey);
+          pEK = aEditKey; nEK = 8;
+        }else{
+          pEK = pEd->pKey; nEK = pEd->nKey;
+        }
+        rc = prollyChunkerAdd(pCh, pEK, nEK, pEd->pVal, pEd->nVal);
+        if( rc!=SQLITE_OK ) return rc;
+      }
+      prollyMutMapIterNext(pIter);
+    }
+  }
+
   return SQLITE_OK;
 }
 
@@ -230,7 +257,8 @@ static int streamingMergeNode(
   ProllyMutator *pMut,
   const ProllyNode *pNode,
   ProllyChunker *pChunker,
-  ProllyMutMapIter *pIter
+  ProllyMutMapIter *pIter,
+  int isLast
 ){
   ProllyCache *pCache = pMut->pCache;
   int rc = SQLITE_OK;
@@ -241,6 +269,8 @@ static int streamingMergeNode(
     const u8 *pChildVal; int nChildVal;
     i64 iBoundKey = 0;
     u8 aBoundBuf[8];
+    int childIsLast;
+    int forceDescend;
 
     prollyNodeKey(pNode, i, &pBoundKey, &nBoundKey);
     prollyNodeValue(pNode, i, &pChildVal, &nChildVal);
@@ -251,7 +281,18 @@ static int streamingMergeNode(
       pBoundKey = aBoundBuf; nBoundKey = 8;
     }
 
-    if( !subtreeHasEdits(pMut->flags, pIter,
+    childIsLast = isLast && (i == pNode->nItems - 1);
+
+    /* The rightmost child of an isLast subtree must absorb any
+    ** trailing edits past pBoundKey. If we splice it instead, those
+    ** edits get appended at chunker level 0 and propagate up through
+    ** every intermediate level as a column of single-entry chunks —
+    ** which is what produced the depth pathology that hit MAX_DEPTH
+    ** at ~1900 single-row inserts. */
+    forceDescend = childIsLast && prollyMutMapIterValid(pIter);
+
+    if( !forceDescend
+     && !subtreeHasEdits(pMut->flags, pIter,
                          pBoundKey, nBoundKey, iBoundKey)
      && chunkerLevelsBelowEmpty(pChunker, pNode->level) ){
       rc = prollyChunkerAddAtLevel(pChunker, pNode->level,
@@ -276,9 +317,9 @@ static int streamingMergeNode(
       }
 
       if( pChildEntry->node.level == 0 ){
-        rc = mergeLeaf(pMut, &pChildEntry->node, pChunker, pIter);
+        rc = mergeLeaf(pMut, &pChildEntry->node, pChunker, pIter, childIsLast);
       }else{
-        rc = streamingMergeNode(pMut, &pChildEntry->node, pChunker, pIter);
+        rc = streamingMergeNode(pMut, &pChildEntry->node, pChunker, pIter, childIsLast);
       }
       prollyCacheRelease(pCache, pChildEntry);
       if( rc!=SQLITE_OK ) return rc;
@@ -320,19 +361,12 @@ static int streamingMerge(
     return rc;
   }
 
-  rc = streamingMergeNode(pMut, &rootNode, &chunker, &iter);
-
-
-  while( prollyMutMapIterValid(&iter) ){
-    ProllyMutMapEntry *pEd = prollyMutMapIterEntry(&iter);
-    if( pEd->op==PROLLY_EDIT_INSERT ){
-      rc = feedChunker(&chunker, pMut->flags,
-                       pEd->pKey, pEd->nKey, pEd->intKey,
-                       pEd->pVal, pEd->nVal);
-      if( rc!=SQLITE_OK ) goto streaming_cleanup;
-    }
-    prollyMutMapIterNext(&iter);
-  }
+  /* isLast=1 marks the root as the rightmost subtree at this level
+  ** of recursion, propagating down through the rightmost child of
+  ** each visited node. mergeLeaf at the bottom drains any trailing
+  ** edits past the rightmost leaf's last key. */
+  rc = streamingMergeNode(pMut, &rootNode, &chunker, &iter, /*isLast=*/1);
+  if( rc!=SQLITE_OK ) goto streaming_cleanup;
 
   rc = prollyChunkerFinish(&chunker);
   if( rc==SQLITE_OK ){
@@ -491,10 +525,6 @@ int prollyMutateFlush(ProllyMutator *pMut){
   {
     int M = prollyMutMapCount(pMut->pEdits);
     int leafCount = 0;
-
-    if( pMut->forceMergeWalk ){
-      return mergeWalk(pMut);
-    }
 
     {
       u8 *pRootData = 0;

--- a/src/prolly_mutate.h
+++ b/src/prolly_mutate.h
@@ -19,7 +19,6 @@ struct ProllyMutator {
   ProllyHash oldRoot;
   ProllyMutMap *pEdits;
   u8 flags;
-  u8 forceMergeWalk;
   ProllyHash newRoot;
 };
 

--- a/test/sysbench_compare.sh
+++ b/test/sysbench_compare.sh
@@ -89,6 +89,19 @@ def prep_with_types(f):
     write_prepare(f)
     write_prepare_types(f)
 
+def write_prepare_textpk(f):
+    # Same shape as sbtest1, but PK is a 32-char hex string (UUID-shaped).
+    # Lights up the non-INTKEY mutmap-flush path (issue #718).
+    f.write("CREATE TABLE sbtest_textpk(id TEXT PRIMARY KEY, k INTEGER NOT NULL DEFAULT 0, c TEXT NOT NULL DEFAULT '', pad TEXT NOT NULL DEFAULT '');\n")
+    f.write("CREATE INDEX k_idx_textpk ON sbtest_textpk(k);\n")
+    f.write("BEGIN;\n")
+    for i in range(1, R+1):
+        f.write(f"INSERT INTO sbtest_textpk VALUES('{i:032x}',{rint(1,R)},'{rstr(60)}','{rstr(30)}');\n")
+    f.write("COMMIT;\n")
+
+def prep_textpk(f):
+    write_prepare_textpk(f)
+
 # --- Tests ---
 
 def w_bulk_insert(f):
@@ -337,6 +350,41 @@ def w_read_write_autocommit(f):
         f.write(f"DELETE FROM sbtest1 WHERE id={id};\n")
         f.write(f"INSERT OR REPLACE INTO sbtest1 VALUES({id},{rint(1,R)},'{rstr(60)}','{rstr(30)}');\n")
 
+# TEXT-PK writes: same workload shapes as the INTEGER-PK writes, but the
+# PK is a 32-char hex string. Issue #718: non-INTKEY tables route through
+# mergeWalk on every flush, which is 10-1000x slower than streamingMerge.
+# Reporting only (not gated) until the fix lands.
+def w_update_index_textpk(f):
+    f.write("BEGIN;\n")
+    for _ in range(10000):
+        f.write(f"UPDATE sbtest_textpk SET k={rint(1,R)} WHERE id='{rint(1,R):032x}';\n")
+    f.write("COMMIT;\n")
+
+def w_update_non_index_textpk(f):
+    f.write("BEGIN;\n")
+    for _ in range(10000):
+        f.write(f"UPDATE sbtest_textpk SET c='{rstr(60)}' WHERE id='{rint(1,R):032x}';\n")
+    f.write("COMMIT;\n")
+
+def w_oltp_insert_textpk(f):
+    f.write("BEGIN;\n")
+    for i in range(R+1, R+5001):
+        f.write(f"INSERT INTO sbtest_textpk VALUES('{i:032x}',{rint(1,R)},'{rstr(60)}','{rstr(30)}');\n")
+    f.write("COMMIT;\n")
+
+def w_delete_insert_textpk(f):
+    f.write("BEGIN;\n")
+    for _ in range(5000):
+        i = rint(1, R)
+        f.write(f"DELETE FROM sbtest_textpk WHERE id='{i:032x}';\n")
+        f.write(f"INSERT OR REPLACE INTO sbtest_textpk VALUES('{i:032x}',{rint(1,R)},'{rstr(60)}','{rstr(30)}');\n")
+    f.write("COMMIT;\n")
+
+make_test("oltp_update_index_textpk",     prep_textpk, w_update_index_textpk)
+make_test("oltp_update_non_index_textpk", prep_textpk, w_update_non_index_textpk)
+make_test("oltp_insert_textpk",           prep_textpk, w_oltp_insert_textpk)
+make_test("oltp_delete_insert_textpk",    prep_textpk, w_delete_insert_textpk)
+
 make_test("oltp_bulk_insert_ac",      prep_main, w_bulk_insert_autocommit)
 make_test("oltp_insert_ac",           prep_main, w_oltp_insert_autocommit)
 make_test("oltp_update_index_ac",     prep_main, w_update_index_autocommit)
@@ -417,6 +465,7 @@ run_bench_stable() {
 READ_TESTS="oltp_point_select oltp_range_select oltp_sum_range oltp_order_range oltp_distinct_range oltp_index_scan select_random_points select_random_ranges covering_index_scan groupby_scan index_join index_join_scan types_table_scan table_scan oltp_read_only"
 WRITE_TESTS="oltp_bulk_insert oltp_insert oltp_update_index oltp_update_non_index oltp_delete_insert oltp_write_only types_delete_insert oltp_read_write"
 WRITE_TESTS_AC="oltp_bulk_insert_ac oltp_insert_ac oltp_update_index_ac oltp_update_non_index_ac oltp_delete_insert_ac oltp_write_only_ac types_delete_insert_ac oltp_read_write_ac"
+WRITE_TESTS_TEXTPK="oltp_update_index_textpk oltp_update_non_index_textpk oltp_insert_textpk oltp_delete_insert_textpk"
 
 # ============================================================
 # Output markdown table
@@ -491,6 +540,16 @@ echo ""
 echo "#### Writes"
 echo ""
 run_section "$WRITE_TESTS_AC" "/tmp/bench_file" "/tmp/bench_file"
+
+echo ""
+echo "### File-Backed (TEXT PK writes)"
+echo ""
+echo "_Same workload shapes as the File-Backed Writes section, but on a_"
+echo "_table with a 32-char hex \`TEXT PRIMARY KEY\`. Surfaces the non-INTKEY_"
+echo "_mutmap-flush path (issue #718). Reporting only — not gated by the_"
+echo "_ceiling check below until the fix lands._"
+echo ""
+run_section "$WRITE_TESTS_TEXTPK" "/tmp/bench_file" "/tmp/bench_file"
 
 echo ""
 echo "_${ROWS} rows, single CLI invocation per test, workload-only timing via SQL timestamps._"

--- a/test/sysbench_compare.sh
+++ b/test/sysbench_compare.sh
@@ -32,6 +32,13 @@ import random, string, os
 
 random.seed($SEED)
 R = $ROWS
+# TEXT-PK section uses smaller row/op counts so the bench job stays
+# within CI's 15-minute limit. Each non-INTKEY insert on doltlite
+# currently goes through a per-statement flush whose cost scales with
+# tree size, so full-scale R blows the budget in the prepare phase
+# alone. Smaller TPR/TPN still surfaces the regression.
+TPR = max(R // 10, 100)
+TPN = max(R // 10, 100)
 d = '$TMPDIR'
 
 def rint(a, b):
@@ -92,11 +99,17 @@ def prep_with_types(f):
 def write_prepare_textpk(f):
     # Same shape as sbtest1, but PK is a 32-char hex string (UUID-shaped).
     # Lights up the non-INTKEY mutmap-flush path (issue #718).
+    # Sized smaller than the INTKEY suite (TPR rows vs R) because each
+    # non-INTKEY insert on doltlite goes through a per-statement flush
+    # whose cost scales with tree size, and the section's job is to
+    # surface the regression — full-scale R would push the bench job
+    # past CI's 15-minute limit. Keep the workload N relative to TPR
+    # so per-test wall time stays comparable to the INTKEY tests.
     f.write("CREATE TABLE sbtest_textpk(id TEXT PRIMARY KEY, k INTEGER NOT NULL DEFAULT 0, c TEXT NOT NULL DEFAULT '', pad TEXT NOT NULL DEFAULT '');\n")
     f.write("CREATE INDEX k_idx_textpk ON sbtest_textpk(k);\n")
     f.write("BEGIN;\n")
-    for i in range(1, R+1):
-        f.write(f"INSERT INTO sbtest_textpk VALUES('{i:032x}',{rint(1,R)},'{rstr(60)}','{rstr(30)}');\n")
+    for i in range(1, TPR+1):
+        f.write(f"INSERT INTO sbtest_textpk VALUES('{i:032x}',{rint(1,TPR)},'{rstr(60)}','{rstr(30)}');\n")
     f.write("COMMIT;\n")
 
 def prep_textpk(f):
@@ -356,28 +369,28 @@ def w_read_write_autocommit(f):
 # Reporting only (not gated) until the fix lands.
 def w_update_index_textpk(f):
     f.write("BEGIN;\n")
-    for _ in range(10000):
-        f.write(f"UPDATE sbtest_textpk SET k={rint(1,R)} WHERE id='{rint(1,R):032x}';\n")
+    for _ in range(TPN):
+        f.write(f"UPDATE sbtest_textpk SET k={rint(1,TPR)} WHERE id='{rint(1,TPR):032x}';\n")
     f.write("COMMIT;\n")
 
 def w_update_non_index_textpk(f):
     f.write("BEGIN;\n")
-    for _ in range(10000):
-        f.write(f"UPDATE sbtest_textpk SET c='{rstr(60)}' WHERE id='{rint(1,R):032x}';\n")
+    for _ in range(TPN):
+        f.write(f"UPDATE sbtest_textpk SET c='{rstr(60)}' WHERE id='{rint(1,TPR):032x}';\n")
     f.write("COMMIT;\n")
 
 def w_oltp_insert_textpk(f):
     f.write("BEGIN;\n")
-    for i in range(R+1, R+5001):
-        f.write(f"INSERT INTO sbtest_textpk VALUES('{i:032x}',{rint(1,R)},'{rstr(60)}','{rstr(30)}');\n")
+    for i in range(TPR+1, TPR+TPN+1):
+        f.write(f"INSERT INTO sbtest_textpk VALUES('{i:032x}',{rint(1,TPR)},'{rstr(60)}','{rstr(30)}');\n")
     f.write("COMMIT;\n")
 
 def w_delete_insert_textpk(f):
     f.write("BEGIN;\n")
-    for _ in range(5000):
-        i = rint(1, R)
+    for _ in range(TPN):
+        i = rint(1, TPR)
         f.write(f"DELETE FROM sbtest_textpk WHERE id='{i:032x}';\n")
-        f.write(f"INSERT OR REPLACE INTO sbtest_textpk VALUES('{i:032x}',{rint(1,R)},'{rstr(60)}','{rstr(30)}');\n")
+        f.write(f"INSERT OR REPLACE INTO sbtest_textpk VALUES('{i:032x}',{rint(1,TPR)},'{rstr(60)}','{rstr(30)}');\n")
     f.write("COMMIT;\n")
 
 make_test("oltp_update_index_textpk",     prep_textpk, w_update_index_textpk)
@@ -429,8 +442,9 @@ else:
 }
 
 bench_runs_for_test() {
-  # BENCH_RUNS=1 for fast local iteration; default 11 for stable median.
-  echo "${BENCH_RUNS:-11}"
+  # BENCH_RUNS=1 for fast local iteration; default 7 for stable median
+  # while keeping the bench job under CI's 15-minute limit.
+  echo "${BENCH_RUNS:-7}"
 }
 
 median_us() {


### PR DESCRIPTION
## Summary

Fixes the streamingMerge corner case that PR #713 worked around with `forceMergeWalk`. The over-broad workaround caused the 10–1000× regression on per-row write workloads against TEXT/BLOB/composite PK tables reported in #718.

Stacked on #720 (the TEXT PK sysbench section that surfaces this regression).

## Root cause

In the trailing-append case (new edit's key > old root's last key), streamingMerge splices every child of the old root at the root's level, then appends the new edit at chunker level 0. The level-0 entry propagates up through every intermediate level to reach the root level, creating a column of degenerate single-entry chunks. With Weibull-density boundaries, the chunk-boundary check at the root level fires on the propagated add with non-trivial probability — splitting the level-N chunk and forcing a level-N+1 chunk above. **Depth +1 per flush.**

After ~1900 single-row inserts the tree hits `PROLLY_CURSOR_MAX_DEPTH=20`. The next flush then silently drops the level-19 chunk's hash on the floor (`flushLevel` skipped the `addToLevel(20)` call but had already emitted the chunk to `chunkStorePut` and reset the level), so every key under that chunk disappears from the tree.

This is exactly the row-loss the reporter bisected to — and the reason `forceMergeWalk` "works": mergeWalk rebuilds the tree from scratch on every flush, naturally producing balanced depth.

Smoking gun before this fix:
- N=1908 inserts: 1908 rows persist
- N=1909 inserts: **0 rows persist** (single flush hits MAX_DEPTH and wipes the tree)
- Single instrumentation line at the killer flush: `[STREAM] M=1 in:lvl=19 items=124 -> out:lvl=-1 items=-1`

## Fix

Three changes, all in this PR:

1. **`streamingMergeNode` and `mergeLeaf` gain an `isLast` parameter**, propagating down through the rightmost child of each visited node. `mergeLeaf` at the bottom drains any remaining iter entries past the leaf's last key. This routes trailing edits into the rightmost subtree's leaf instead of through a level-0 trailing-append + propagation column, keeping depth at `log_50(N)`.
2. **`flushLevel` returns `SQLITE_FULL` when `level+1 == MAX_DEPTH`** instead of silently dropping the chunk. Defense in depth — even if some other path produces deep trees, we error rather than lose data.
3. **Drop `forceMergeWalk`** (struct field in `prolly_mutate.h`, two assignment sites in `prolly_btree.c`, and the early-return in `prollyMutateFlush`). With streamingMerge correct for non-INTKEY trees, the bypass is redundant.

## Verified

- Issue #710 shell repro: 5000/5000 rows persist
- Boundary at #1909 (was: 0 rows after the 1909th insert): 1909/1909
- Larger sizes: N=2000, 5000, 10000 all persist correctly
- Output tree depth for 5000 single-row inserts: 1–2 levels (was: 19+)
- 95/95 review-regression tests (incl. Guard 10 from PR #713)
- vc_oracle_merge 48, branch 33, diff 54, error_recovery 261
- doltlite_merge 91, cherry_pick 98, rebase_schema 23

## Sysbench

INTKEY writes still within the 2× ceiling (1.36× in-memory, 1.33× file-backed, 0.76× autocommit — faster than sqlite).

TEXT PK writes still ~13–24× at small N=2000 (random-key UPDATE has similar cost under streamingMerge-with-my-fix and under mergeWalk-on-master — both walk a comparable slice of the tree). The dramatic win is at scale where the depth pathology used to bite (and where #718's reporter was hitting it), and on trailing-append shapes — `oltp_insert_textpk` improved 25.92× → 12.04×.

The TEXT PK section stays reporting-only for now; getting it under the 2× ceiling is a follow-up that needs different work (the chunkerLevelsBelowEmpty barrier prevents splicing right-side siblings after a leaf-edit, so random-key UPDATE walks ~half the tree no matter which path is taken).

Closes #718.

## Test plan
- [x] make doltlite clean
- [x] Issue #710 shell repro (5000/5000)
- [x] Boundary tests at N=1909, 2000, 5000, 10000
- [x] All review-regression tests
- [x] All major oracle suites
- [ ] CI passes including bench and crash-injection