### PR TITLE
ci: read bench body from file in PR-comment step

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -41,23 +41,20 @@ jobs:
         make DOLTLITE_PROLLY=0 sqlite3
 
     - name: Run benchmark
-      id: bench
       run: |
         cd build
-        bash ../test/sysbench_compare.sh > /tmp/bench_results.md
-        cat /tmp/bench_results.md
-        {
-          echo "results<<EOF"
-          cat /tmp/bench_results.md
-          echo "EOF"
-        } >> "$GITHUB_OUTPUT"
+        bash ../test/sysbench_compare.sh | tee /tmp/bench_results.md
 
     - name: Comment PR with results
       continue-on-error: true
       uses: actions/github-script@v7
       with:
         script: |
-          const body = `${{ steps.bench.outputs.results }}`;
+          // Read from file so the multi-line markdown (and any backticks /
+          // template-literal-unsafe chars in it) never has to round-trip
+          // through YAML scalars or JS template-literal parsing.
+          const fs = require('fs');
+          const body = fs.readFileSync('/tmp/bench_results.md', 'utf8');
 
           if (!context.issue.number) {
             console.log('No PR context (push event) — skipping comment');


### PR DESCRIPTION
## Summary

The bench workflow's PR-comment step interpolated `\${{ steps.bench.outputs.results }}` straight into a JavaScript template literal. The first backtick in the markdown output (introduced by #722's TEXT PK section description, around `` `TEXT PRIMARY KEY` ``) terminates the template literal, causing a SyntaxError that silently skipped the comment.

After #722 merged into master, no PR has gotten a benchmark comment.

## Fix

Skip the GITHUB_OUTPUT round-trip entirely. Write the bench markdown to a file in the run step and read it with `fs.readFileSync` in the JS step. The bench output never has to pass through YAML scalar parsing or JavaScript string parsing, so backticks (or any other special characters added later) can't break the comment step.

## Test plan
- [ ] Benchmark workflow runs on this PR (was failing at workflow parse before)
- [ ] Comment posts with the benchmark table