### PR TITLE
Fix downstack error masking

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -127,7 +127,7 @@ static int csReadIndex(ChunkStore *cs);
 static int csDeserializeRefs(ChunkStore *cs, const u8 *data, int nData);
 static int csSearchIndex(const ChunkIndexEntry *aIdx, int nIdx,
                          const ProllyHash *pHash);
-static int csSearchPending(ChunkStore *cs, const ProllyHash *pHash);
+static int csSearchPending(ChunkStore *cs, const ProllyHash *pHash, int *pIdx);
 static int csIndexEntryCmp(const void *a, const void *b);
 void csSerializeManifest(const ChunkStore *cs, u8 *aBuf);
 static void csDeserializeIndexEntry(const u8 *aBuf, ChunkIndexEntry *e);
@@ -539,7 +539,7 @@ static int csRollbackFailedAppend(ChunkStore *cs, i64 origFileSize){
   sqlite3_int64 sizeNow = -1;
   int rc = SQLITE_OK;
 
-  if( !cs->pFile ) return SQLITE_OK;
+  if( !cs->pFile ) return SQLITE_IOERR;
 
   rc = sqlite3OsTruncate(cs->pFile, origFileSize);
   if( rc==SQLITE_OK ){
@@ -677,23 +677,31 @@ static int csPendHTEnsure(ChunkStore *cs){
   return SQLITE_OK;
 }
 
-static int csSearchPending(ChunkStore *cs, const ProllyHash *pHash){
-  int i; u32 b;
-  if( cs->nPending==0 ) return -1;
-  if( csPendHTEnsure(cs)!=SQLITE_OK ){
+static int csSearchPending(ChunkStore *cs, const ProllyHash *pHash, int *pIdx){
+  int i; u32 b; int rc;
+  *pIdx = -1;
+  if( cs->nPending==0 ) return SQLITE_OK;
+  rc = csPendHTEnsure(cs);
+  if( rc!=SQLITE_OK ){
 
     for(i=0; i<cs->nPending; i++){
-      if( prollyHashCompare(&cs->aPending[i].hash, pHash)==0 ) return i;
+      if( prollyHashCompare(&cs->aPending[i].hash, pHash)==0 ){
+        *pIdx = i;
+        return SQLITE_OK;
+      }
     }
-    return -1;
+    return rc;
   }
   b = csPendBucket(pHash, cs->nPendingHTSize - 1);
   i = cs->aPendingHT[b];
   while( i>=0 ){
-    if( prollyHashCompare(&cs->aPending[i].hash, pHash)==0 ) return i;
+    if( prollyHashCompare(&cs->aPending[i].hash, pHash)==0 ){
+      *pIdx = i;
+      return SQLITE_OK;
+    }
     i = cs->aPendingHTNext[i];
   }
-  return -1;
+  return SQLITE_OK;
 }
 
 void csSerializeManifest(const ChunkStore *cs, u8 *aBuf){
@@ -1536,7 +1544,10 @@ int chunkStoreDeleteTracking(ChunkStore *cs, const char *zRemote,
 int chunkStoreHasMany(ChunkStore *cs, const ProllyHash *aHash, int nHash, u8 *aResult){
   int i;
   for(i=0; i<nHash; i++){
-    aResult[i] = chunkStoreHas(cs, &aHash[i]) ? 1 : 0;
+    int has = 0;
+    int rc = chunkStoreHas(cs, &aHash[i], &has);
+    if( rc!=SQLITE_OK ) return rc;
+    aResult[i] = has ? 1 : 0;
   }
   return SQLITE_OK;
 }
@@ -1861,10 +1872,18 @@ int chunkStoreSerializeRefsToBlob(ChunkStore *cs, u8 **ppOut, int *pnOut){
   return csSerializeRefsBlob(cs, ppOut, pnOut);
 }
 
-int chunkStoreHas(ChunkStore *cs, const ProllyHash *hash){
-  if( csSearchIndex(cs->aIndex, cs->nIndex, hash) >= 0 ) return 1;
-  if( csSearchPending(cs, hash) >= 0 ) return 1;
-  return 0;
+int chunkStoreHas(ChunkStore *cs, const ProllyHash *hash, int *pHas){
+  int idx = -1;
+  int rc;
+  *pHas = 0;
+  if( csSearchIndex(cs->aIndex, cs->nIndex, hash) >= 0 ){
+    *pHas = 1;
+    return SQLITE_OK;
+  }
+  rc = csSearchPending(cs, hash, &idx);
+  if( rc!=SQLITE_OK ) return rc;
+  if( idx >= 0 ) *pHas = 1;
+  return SQLITE_OK;
 }
 
 /* Lookup order matters: pending (uncommitted write buffer) first,
@@ -1882,7 +1901,8 @@ int chunkStoreGet(
   *ppData = 0;
   *pnData = 0;
 
-  idx = csSearchPending(cs, hash);
+  rc = csSearchPending(cs, hash, &idx);
+  if( rc!=SQLITE_OK ) return rc;
   if( idx >= 0 ){
     ChunkIndexEntry *e = &cs->aPending[idx];
     i64 off = e->offset;
@@ -1969,7 +1989,12 @@ int chunkStorePut(
 
 
   if( csSearchIndex(cs->aIndex, cs->nIndex, &h) >= 0 ) return SQLITE_OK;
-  if( csSearchPending(cs, &h) >= 0 ) return SQLITE_OK;
+  {
+    int idx = -1;
+    rc = csSearchPending(cs, &h, &idx);
+    if( rc!=SQLITE_OK ) return rc;
+    if( idx >= 0 ) return SQLITE_OK;
+  }
 
   rc = csGrowPending(cs);
   if( rc != SQLITE_OK ) return rc;
@@ -2353,8 +2378,12 @@ static int csDetectExternalChanges(ChunkStore *cs, int *pChanged){
     if( rc!=SQLITE_OK ) return rc;
     if( exists ){
       struct stat mainStat;
-      if( stat(cs->zFilename, &mainStat)==0 && mainStat.st_size > 0 ){
-        *pChanged = 1;
+      if( stat(cs->zFilename, &mainStat)==0 ){
+        if( mainStat.st_size > 0 ){
+          *pChanged = 1;
+        }
+      }else{
+        return SQLITE_IOERR;
       }
     }
     return SQLITE_OK;

--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -287,7 +287,7 @@ int chunkStoreSerializeRefsToBlob(ChunkStore *cs, u8 **ppOut, int *pnOut);
 
 int chunkStoreHasMany(ChunkStore *cs, const ProllyHash *aHash, int nHash, u8 *aResult);
 
-int chunkStoreHas(ChunkStore *cs, const ProllyHash *hash);
+int chunkStoreHas(ChunkStore *cs, const ProllyHash *hash, int *pHas);
 
 int chunkStoreGet(ChunkStore *cs, const ProllyHash *hash,
                   u8 **ppData, int *pnData);

--- a/src/doltlite_remote.c
+++ b/src/doltlite_remote.c
@@ -254,7 +254,10 @@ static int fsHasChunks(DoltliteRemote *pRemote, const ProllyHash *aHash,
   FsRemote *p = (FsRemote*)pRemote;
   int i;
   for(i=0; i<nHash; i++){
-    aResult[i] = chunkStoreHas(&p->store, &aHash[i]) ? 1 : 0;
+    int has = 0;
+    int rc = chunkStoreHas(&p->store, &aHash[i], &has);
+    if( rc!=SQLITE_OK ) return rc;
+    aResult[i] = has ? 1 : 0;
   }
   return SQLITE_OK;
 }
@@ -358,7 +361,10 @@ static int localHasChunks(DoltliteRemote *pRemote, const ProllyHash *aHash,
   LocalAsRemote *p = (LocalAsRemote*)pRemote;
   int i;
   for(i=0; i<nHash; i++){
-    aResult[i] = chunkStoreHas(p->pStore, &aHash[i]) ? 1 : 0;
+    int has = 0;
+    int rc = chunkStoreHas(p->pStore, &aHash[i], &has);
+    if( rc!=SQLITE_OK ) return rc;
+    aResult[i] = has ? 1 : 0;
   }
   return SQLITE_OK;
 }

--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -624,15 +624,6 @@ int prollyMutMapFindRc(
   return SQLITE_OK;
 }
 
-ProllyMutMapEntry *prollyMutMapFind(ProllyMutMap *mm,
-                                     const u8 *pKey, int nKey, i64 intKey){
-  ProllyMutMapEntry *pEntry = 0;
-  if( prollyMutMapFindRc(mm, pKey, nKey, intKey, &pEntry)!=SQLITE_OK ){
-    return 0;
-  }
-  return pEntry;
-}
-
 ProllyMutMapEntry *prollyMutMapEntryAt(ProllyMutMap *mm, int idx){
   ensureOrder(mm);
   return entryAtOrder(mm, idx);

--- a/src/prolly_mutmap.h
+++ b/src/prolly_mutmap.h
@@ -64,9 +64,6 @@ int prollyMutMapInsert(ProllyMutMap *mm,
 int prollyMutMapDelete(ProllyMutMap *mm,
                        const u8 *pKey, int nKey, i64 intKey);
 
-ProllyMutMapEntry *prollyMutMapFind(ProllyMutMap *mm,
-                                     const u8 *pKey, int nKey, i64 intKey);
-
 int prollyMutMapFindRc(
   ProllyMutMap *mm,
   const u8 *pKey, int nKey, i64 intKey,

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -5308,6 +5308,7 @@ static int mutmapAssertMatchesModel(
   for(i=0; i<pModel->n; i++){
     ProllyMutMapEntry *pEntry;
     ProllyMutMapEntry *pFind;
+    int rc;
     if( !prollyMutMapIterValid(&it) ) return 0;
     pEntry = prollyMutMapIterEntry(&it);
     if( !pEntry ) return 0;
@@ -5317,14 +5318,18 @@ static int mutmapAssertMatchesModel(
              || (pEntry->nVal==(int)sizeof(int) && memcmp(pEntry->pVal, &pModel->a[i].val, sizeof(int))==0));
     ok = ok && prollyMutMapEntryAt(pMap, i)==pEntry;
     ok = ok && prollyMutMapOrderIndexFromEntry(pMap, pEntry)==i;
-    pFind = prollyMutMapFind(pMap, 0, 0, pModel->a[i].key);
+    rc = prollyMutMapFindRc(pMap, 0, 0, pModel->a[i].key, &pFind);
+    ok = ok && rc==SQLITE_OK;
     ok = ok && pFind==pEntry;
     prollyMutMapIterNext(&it);
   }
   ok = ok && !prollyMutMapIterValid(&it);
   for(i=0; i<8; i++){
     i64 miss = 1000 + i;
-    ok = ok && prollyMutMapFind(pMap, 0, 0, miss)==0;
+    ProllyMutMapEntry *pFind = 0;
+    int rc = prollyMutMapFindRc(pMap, 0, 0, miss, &pFind);
+    ok = ok && rc==SQLITE_OK;
+    ok = ok && pFind==0;
   }
   return ok;
 }
@@ -5712,16 +5717,25 @@ static void run_remotesrv_chunk_commit_failure_clears_pending(void){
         chunkStoreCommit(&cs)==SQLITE_OK);
   check("queue_pending_chunk_for_remotesrv_chunk_commit",
         chunkStorePut(&cs, aChunk, (int)sizeof(aChunk), &chunkHash)==SQLITE_OK);
-  check("pending_chunk_visible_before_failed_commit",
-        chunkStoreHas(&cs, &chunkHash));
+  {
+    int hasChunk = 0;
+    check("pending_chunk_visible_before_failed_commit_rc",
+          chunkStoreHas(&cs, &chunkHash, &hasChunk)==SQLITE_OK);
+    check("pending_chunk_visible_before_failed_commit", hasChunk);
+  }
 
   gFailHits = 0;
   gFailSyncOnce = 1;
   rc = doltliteRemoteSrvCommitPendingForTest(&cs);
   check("remotesrv_chunk_commit_failure_injected", gFailHits>0);
   check("remotesrv_chunk_commit_failure_surfaces", rc!=SQLITE_OK);
-  check("remotesrv_chunk_commit_rolls_back_pending_visibility",
-        !chunkStoreHas(&cs, &chunkHash));
+  {
+    int hasChunk = 1;
+    check("remotesrv_chunk_commit_rolls_back_pending_visibility_rc",
+          chunkStoreHas(&cs, &chunkHash, &hasChunk)==SQLITE_OK);
+    check("remotesrv_chunk_commit_rolls_back_pending_visibility",
+          !hasChunk);
+  }
   check("remotesrv_chunk_commit_clears_pending_count", cs.nPending==0);
 
   gFailSyncOnce = 0;
@@ -5731,8 +5745,13 @@ static void run_remotesrv_chunk_commit_failure_clears_pending(void){
         chunkStoreSerializeRefs(&cs)==SQLITE_OK);
   check("commit_followup_refs_for_remotesrv_chunk_commit",
         chunkStoreCommit(&cs)==SQLITE_OK);
-  check("failed_chunk_not_visible_after_followup_commit",
-        !chunkStoreHas(&cs, &chunkHash));
+  {
+    int hasChunk = 1;
+    check("failed_chunk_not_visible_after_followup_commit_rc",
+          chunkStoreHas(&cs, &chunkHash, &hasChunk)==SQLITE_OK);
+    check("failed_chunk_not_visible_after_followup_commit",
+          !hasChunk);
+  }
 
   chunkStoreClose(&cs);
   check("reopen_store_after_remotesrv_chunk_commit_failure",
@@ -5740,8 +5759,13 @@ static void run_remotesrv_chunk_commit_failure_clears_pending(void){
           SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB)==SQLITE_OK);
   check("reopened_store_after_remotesrv_chunk_commit_has_tag",
         chunkStoreFindTag(&reopened, "v1", &foundHash)==SQLITE_OK);
-  check("reopened_store_after_remotesrv_chunk_commit_has_no_failed_chunk",
-        !chunkStoreHas(&reopened, &chunkHash));
+  {
+    int hasChunk = 1;
+    check("reopened_store_after_remotesrv_chunk_commit_has_no_failed_chunk_rc",
+          chunkStoreHas(&reopened, &chunkHash, &hasChunk)==SQLITE_OK);
+    check("reopened_store_after_remotesrv_chunk_commit_has_no_failed_chunk",
+          !hasChunk);
+  }
   chunkStoreClose(&reopened);
   remove_db(dbpath);
 }


### PR DESCRIPTION
## Summary
- stop chunk-store pending lookups from flattening internal failures into false negatives
- remove the lossy prollyMutMapFind() wrapper and use the rc-returning API in tests
- surface stat/rollback failures instead of reporting success

## Testing
- make -j4 doltlite
- bash test/review_regression_test.sh