### PR TITLE
prolly: drain-and-splice for non-INTKEY perf

### DIFF
--- a/src/prolly_chunker.c
+++ b/src/prolly_chunker.c
@@ -281,6 +281,18 @@ int prollyChunkerAddAtLevel(ProllyChunker *ch, int level,
   return addToLevel(ch, level, pKey, nKey, pVal, nVal);
 }
 
+int prollyChunkerDrainBelow(ProllyChunker *ch, int targetLevel){
+  int level;
+  int rc;
+  for( level = 0; level < targetLevel && level < ch->nLevels; level++ ){
+    while( ch->aLevel[level].builder.nItems > 0 ){
+      rc = flushLevel(ch, level);
+      if( rc!=SQLITE_OK ) return rc;
+    }
+  }
+  return SQLITE_OK;
+}
+
 void prollyChunkerFree(ProllyChunker *ch){
   int i;
   for(i = 0; i < ch->nLevels; i++){

--- a/src/prolly_chunker.h
+++ b/src/prolly_chunker.h
@@ -50,4 +50,18 @@ int prollyChunkerAddAtLevel(ProllyChunker *ch, int level,
                             const u8 *pKey, int nKey,
                             const u8 *pVal, int nVal);
 
+/* Force-flush any pending content at levels < targetLevel. Each
+** affected level emits a chunk (possibly below PROLLY_CHUNK_MIN —
+** the boundary here is "we need to splice at targetLevel" rather
+** than the natural Weibull split) and propagates its (lastKey, hash)
+** to the level above.
+**
+** streamingMergeNode calls this before splicing a right-side sibling
+** at the parent level after mergeLeaf has put content in level 0:
+** without it the chunker can't accept the splice (the existing splice
+** condition was `chunkerLevelsBelowEmpty`), so the loop falls through
+** to recurse — walking every right-side leaf instead of an O(1)
+** splice per sibling. */
+int prollyChunkerDrainBelow(ProllyChunker *ch, int targetLevel);
+
 #endif

--- a/src/prolly_mutate.c
+++ b/src/prolly_mutate.c
@@ -105,19 +105,6 @@ static int subtreeHasEdits(
   return (cmp <= 0);
 }
 
-static int chunkerLevelsBelowEmpty(
-  const ProllyChunker *pChunker,
-  int level
-){
-  int i;
-  for( i = 0; i < level && i < pChunker->nLevels; i++ ){
-    if( pChunker->aLevel[i].builder.nItems > 0 ){
-      return 0;
-    }
-  }
-  return 1;
-}
-
 static int mergeLeaf(
   ProllyMutator *pMut,
   ProllyNode *pLeaf,
@@ -293,8 +280,14 @@ static int streamingMergeNode(
 
     if( !forceDescend
      && !subtreeHasEdits(pMut->flags, pIter,
-                         pBoundKey, nBoundKey, iBoundKey)
-     && chunkerLevelsBelowEmpty(pChunker, pNode->level) ){
+                         pBoundKey, nBoundKey, iBoundKey) ){
+      /* Splice. After a previous mergeLeaf in this iteration, levels
+      ** below pNode->level can have pending content; the chunker
+      ** can't reach this level cleanly until that drains. Force the
+      ** drain so right-side siblings get O(1) splice instead of
+      ** falling through to the recurse branch and walking every leaf. */
+      rc = prollyChunkerDrainBelow(pChunker, pNode->level);
+      if( rc!=SQLITE_OK ) return rc;
       rc = prollyChunkerAddAtLevel(pChunker, pNode->level,
                                     pBoundKey, nBoundKey,
                                     pChildVal, nChildVal);


### PR DESCRIPTION
## Summary

Targeted fix for the non-INTKEY mutator-flush bottleneck (the slow path #720's bench-extra section was built to track). Replaces the `chunkerLevelsBelowEmpty` splice-gate in `streamingMergeNode` with a force-drain, so right-side siblings can be O(1) spliced after a mid-tree edit instead of falling through to the recurse branch and walking every leaf.

Stacks naturally on top of master — no format change, no API breakage outside the prolly layer.

## Bench-extra TEXT PK section (BENCH_ROWS=2000, BENCH_RUNS=5)

| Test | Before | After | Change |
|---|---:|---:|---:|
| `oltp_update_index_textpk` | 8.81× | 8.03× | ~9% |
| `oltp_update_non_index_textpk` | 7.81× | 7.06× | ~10% |
| `oltp_insert_textpk` | 6.06× | 6.06× | unchanged |
| `oltp_delete_insert_textpk` | 17.13× | **7.06×** | **2.4× speedup** |

The big win is on `delete_insert` — workloads that mix DELETE + INSERT hit the splice-after-mergeLeaf path on every other iteration, so the savings compound. Pure trailing-append (`insert`) is unchanged because it goes through the forceDescend rightmost-routing path from #722, not the splice path.

## Why this works

The splice-vs-recurse decision in `streamingMergeNode` previously required `chunkerLevelsBelowEmpty(pNode->level)` to be true for splice. After `mergeLeaf` modifies a subtree, level 0 has pending content; that condition stays false until level 0 drains naturally on a Weibull boundary. The "wait for natural drain" path is the recurse branch, which walks the right-sibling subtree entry-by-entry.

The fix: before splicing, call `prollyChunkerDrainBelow(pChunker, pNode->level)` — a force-flush of any pending content at lower levels. Each affected level emits a chunk (possibly below `PROLLY_CHUNK_MIN` at this boundary, which is the storage trade-off — at most one undersized chunk per touched subtree per flush) and propagates `(lastKey, hash)` to its parent. After the drain, the splice lands.

## Trade-off

Force-flushed chunks may be smaller than the natural Weibull split. That breaks structural sharing for those specific chunks: the merged-leaf chunk in the new tree won't byte-identical-match the old tree's chunk even when their content set is logically identical. Storage cost is bounded — one extra chunk per per-statement flush, GC'd over time.

Net: O(N/2) per random-key UPDATE → O(log N), with a small chunking inefficiency on edited subtree boundaries.

## INTKEY perf

Unchanged. Drain is a no-op when level 0 is empty (the common case for INTKEY workloads, which either trailing-append via forceDescend or are tightly packed enough that the chunker state stays clean across iterations).

## Validation

- 115/115 review-regression tests
- 48 vc_oracle_merge, 33 vc_oracle_branch, 54 vc_oracle_diff, 261 vc_oracle_error_recovery
- Classic sysbench section unchanged, all under 2× ceiling
- Bench-extra TEXT PK section: numbers above

## Test plan
- [ ] CI passes
- [ ] Bench-extra workflow comments the new TEXT PK numbers (after #724 merges)