### PR TITLE
prolly_mutate: drop strategy heuristic + byte-uniform INT/BLOB cleanup

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -1241,7 +1241,7 @@ static void setCursorToMutMapEntryPhys(BtCursor *pCur, int physIdx){
   pCur->eState = CURSOR_VALID;
   pCur->curFlags &= ~BTCF_AtLast;
   if( pCur->curIntKey ){
-    pCur->cachedIntKey = pEntry->intKey;
+    pCur->cachedIntKey = prollyMutMapEntryIntKey(pEntry);
     pCur->curFlags |= BTCF_ValidNKey;
   }else{
     pCur->curFlags &= ~BTCF_ValidNKey;
@@ -1389,7 +1389,7 @@ static int saveCursorPosition(BtCursor *pCur){
   if( pCur->curIntKey ){
     if( pCur->mmActive
      && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
-      pCur->nKey = currentMutMapEntry(pCur)->intKey;
+      pCur->nKey = prollyMutMapEntryIntKey(currentMutMapEntry(pCur));
     }else{
       pCur->nKey = prollyCursorIntKey(&pCur->pCur);
     }
@@ -3587,8 +3587,9 @@ int sqlite3BtreeClosesWithCursor(Btree *p, BtCursor *pCur){
 static int mergeCompare(BtCursor *pCur, ProllyMutMapEntry *e){
   if( pCur->curIntKey ){
     i64 tk = prollyCursorIntKey(&pCur->pCur);
-    if( tk < e->intKey ) return -1;
-    if( tk > e->intKey ) return 1;
+    i64 ek = prollyMutMapEntryIntKey(e);
+    if( tk < ek ) return -1;
+    if( tk > ek ) return 1;
     return 0;
   }else{
     const u8 *pK; int nK;
@@ -4508,7 +4509,7 @@ static i64 prollyBtCursorIntegerKey(BtCursor *pCur){
 
   if( pCur->mmActive
    && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
-    return currentMutMapEntry(pCur)->intKey;
+    return prollyMutMapEntryIntKey(currentMutMapEntry(pCur));
   }
   if( !prollyCursorIsValid(&pCur->pCur)
    && (pCur->curFlags & BTCF_ValidNKey) ){
@@ -4985,7 +4986,7 @@ static int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
     if( pCur->curIntKey ){
       if( pCur->mmActive
        && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
-        savedIntKey = currentMutMapEntry(pCur)->intKey;
+        savedIntKey = prollyMutMapEntryIntKey(currentMutMapEntry(pCur));
         hasSavedKey = 1;
       }else if( !prollyCursorIsValid(&pCur->pCur)
        && (pCur->curFlags & BTCF_ValidNKey) ){

--- a/src/prolly_cursor.c
+++ b/src/prolly_cursor.c
@@ -270,36 +270,13 @@ int prollyCursorPrev(ProllyCursor *cur){
 }
 
 int prollyCursorSeekInt(ProllyCursor *cur, i64 intKey, int *pRes){
-  int rc;
-  ProllyCacheEntry *pEntry = 0;
-  int leafRes;
-  int leafIdx;
-
-  rc = initCursorAtRoot(cur, &pEntry);
-  if( rc!=SQLITE_OK ) return rc;
-  if( cur->eState==PROLLY_CURSOR_EOF ){
-    cur->eState = PROLLY_CURSOR_INVALID;
-    *pRes = -1;
-    return SQLITE_OK;
-  }
-
-
-  while( pEntry->node.level>0 ){
-    int searchRes;
-    int idx = prollyNodeSearchInt(&pEntry->node, intKey, &searchRes);
-    idx = childIndexForSearchResult(idx, searchRes, pEntry->node.nItems);
-    cur->aLevel[cur->iLevel].idx = idx;
-    rc = descendToChild(cur, idx, 0, &pEntry);
-    if( rc!=SQLITE_OK ) return rc;
-  }
-
-  if( pEntry->node.nItems==0 ){
-    cur->eState = PROLLY_CURSOR_EOF;
-    *pRes = -1;
-    return SQLITE_OK;
-  }
-  leafIdx = prollyNodeSearchInt(&pEntry->node, intKey, &leafRes);
-  return finalizeSeekOnLeaf(cur, pEntry, leafIdx, leafRes, pRes);
+  /* INT keys live on disk as sortable 8-byte big-endian bytes (see
+  ** prollyNodeIntKey/prollyEncodeIntKey), so an int seek is just a
+  ** blob seek over the encoded form — same algorithm, no separate
+  ** descent path. */
+  u8 keyBuf[8];
+  prollyEncodeIntKey(intKey, keyBuf);
+  return prollyCursorSeekBlob(cur, keyBuf, 8, pRes);
 }
 
 int prollyCursorSeekBlob(ProllyCursor *cur,

--- a/src/prolly_diff.c
+++ b/src/prolly_diff.c
@@ -35,17 +35,11 @@ static void diffFillKey(
   ProllyCursor *pCur,
   u8 flags
 ){
-  if( flags & PROLLY_NODE_INTKEY ){
-    pChange->intKey = prollyCursorIntKey(pCur);
-    pChange->pKey   = 0;
-    pChange->nKey   = 0;
-  }else{
-    const u8 *pKey; int nKey;
-    prollyCursorKey(pCur, &pKey, &nKey);
-    pChange->pKey   = pKey;
-    pChange->nKey   = nKey;
-    pChange->intKey = 0;
-  }
+  const u8 *pKey; int nKey;
+  prollyCursorKey(pCur, &pKey, &nKey);
+  pChange->pKey   = pKey;
+  pChange->nKey   = nKey;
+  pChange->intKey = (flags & PROLLY_NODE_INTKEY) ? prollyCursorIntKey(pCur) : 0;
 }
 
 static int diffIterCopyKey(
@@ -54,26 +48,19 @@ static int diffIterCopyKey(
   ProllyCursor *pCur,
   u8 flags
 ){
-  if( flags & PROLLY_NODE_INTKEY ){
-    pChange->intKey = prollyCursorIntKey(pCur);
-    pChange->pKey = 0;
-    pChange->nKey = 0;
-    return SQLITE_OK;
-  }else{
-    const u8 *pKey;
-    int nKey;
-    prollyCursorKey(pCur, &pKey, &nKey);
-    if( nKey>0 ){
-      pIter->pKeyCopy = sqlite3_malloc(nKey);
-      if( !pIter->pKeyCopy ) return SQLITE_NOMEM;
-      memcpy(pIter->pKeyCopy, pKey, nKey);
-      pIter->nKeyCopy = nKey;
-    }
-    pChange->pKey = pIter->pKeyCopy;
-    pChange->nKey = pIter->nKeyCopy;
-    pChange->intKey = 0;
-    return SQLITE_OK;
+  const u8 *pKey;
+  int nKey;
+  prollyCursorKey(pCur, &pKey, &nKey);
+  if( nKey>0 ){
+    pIter->pKeyCopy = sqlite3_malloc(nKey);
+    if( !pIter->pKeyCopy ) return SQLITE_NOMEM;
+    memcpy(pIter->pKeyCopy, pKey, nKey);
+    pIter->nKeyCopy = nKey;
   }
+  pChange->pKey = pIter->pKeyCopy;
+  pChange->nKey = pIter->nKeyCopy;
+  pChange->intKey = (flags & PROLLY_NODE_INTKEY) ? prollyCursorIntKey(pCur) : 0;
+  return SQLITE_OK;
 }
 
 static int diffEmitDelete(
@@ -348,6 +335,20 @@ static int diffNodeKeyCmp(
   return diffBlobKeyCmp(pKA, nKA, pKB, nKB);
 }
 
+/* Populates a ProllyDiffChange's key fields from a node entry.
+** Always sets pKey/nKey to the on-disk key bytes (which for INT mode
+** is the sortable 8-byte BE form, see prolly_node.c). For INT mode
+** also sets intKey to the decoded i64 — preserves the long-standing
+** consumer contract while letting internal compare go byte-only. */
+static void diffEmitKey(ProllyDiffChange *ch, const ProllyNode *pN, int i, u8 flags){
+  prollyNodeKey(pN, i, &ch->pKey, &ch->nKey);
+  if( flags & PROLLY_NODE_INTKEY ){
+    ch->intKey = prollyNodeIntKey(pN, i);
+  }else{
+    ch->intKey = 0;
+  }
+}
+
 static int diffLeaves(
   const ProllyNode *pOld, const ProllyNode *pNew, u8 flags,
   ProllyDiffCallback xCb, void *pCtx
@@ -367,8 +368,7 @@ static int diffLeaves(
       ProllyDiffChange ch; const u8 *pV; int nV;
       memset(&ch, 0, sizeof(ch));
       ch.type = PROLLY_DIFF_DELETE;
-      if( flags & PROLLY_NODE_INTKEY ) ch.intKey = prollyNodeIntKey(pOld, i);
-      else prollyNodeKey(pOld, i, &ch.pKey, &ch.nKey);
+      diffEmitKey(&ch, pOld, i, flags);
       prollyNodeValue(pOld, i, &pV, &nV);
       ch.pOldVal = pV; ch.nOldVal = nV;
       rc = xCb(pCtx, &ch); i++;
@@ -376,8 +376,7 @@ static int diffLeaves(
       ProllyDiffChange ch; const u8 *pV; int nV;
       memset(&ch, 0, sizeof(ch));
       ch.type = PROLLY_DIFF_ADD;
-      if( flags & PROLLY_NODE_INTKEY ) ch.intKey = prollyNodeIntKey(pNew, j);
-      else prollyNodeKey(pNew, j, &ch.pKey, &ch.nKey);
+      diffEmitKey(&ch, pNew, j, flags);
       prollyNodeValue(pNew, j, &pV, &nV);
       ch.pNewVal = pV; ch.nNewVal = nV;
       rc = xCb(pCtx, &ch); j++;
@@ -393,8 +392,7 @@ static int diffLeaves(
         ProllyDiffChange ch;
         memset(&ch, 0, sizeof(ch));
         ch.type = PROLLY_DIFF_MODIFY;
-        if( flags & PROLLY_NODE_INTKEY ) ch.intKey = prollyNodeIntKey(pNew, j);
-        else prollyNodeKey(pNew, j, &ch.pKey, &ch.nKey);
+        diffEmitKey(&ch, pNew, j, flags);
         ch.pOldVal = pOV; ch.nOldVal = nOV;
         ch.pNewVal = pNV; ch.nNewVal = nNV;
         rc = xCb(pCtx, &ch);
@@ -408,8 +406,7 @@ static int diffLeaves(
     ProllyDiffChange ch; const u8 *pV; int nV;
     memset(&ch, 0, sizeof(ch));
     ch.type = PROLLY_DIFF_DELETE;
-    if( flags & PROLLY_NODE_INTKEY ) ch.intKey = prollyNodeIntKey(pOld, i);
-    else prollyNodeKey(pOld, i, &ch.pKey, &ch.nKey);
+    diffEmitKey(&ch, pOld, i, flags);
     prollyNodeValue(pOld, i, &pV, &nV);
     ch.pOldVal = pV; ch.nOldVal = nV;
     rc = xCb(pCtx, &ch); i++;
@@ -418,8 +415,7 @@ static int diffLeaves(
     ProllyDiffChange ch; const u8 *pV; int nV;
     memset(&ch, 0, sizeof(ch));
     ch.type = PROLLY_DIFF_ADD;
-    if( flags & PROLLY_NODE_INTKEY ) ch.intKey = prollyNodeIntKey(pNew, j);
-    else prollyNodeKey(pNew, j, &ch.pKey, &ch.nKey);
+    diffEmitKey(&ch, pNew, j, flags);
     prollyNodeValue(pNew, j, &pV, &nV);
     ch.pNewVal = pV; ch.nNewVal = nV;
     rc = xCb(pCtx, &ch); j++;

--- a/src/prolly_diff.c
+++ b/src/prolly_diff.c
@@ -22,19 +22,12 @@ static void diffCompareKeys(
   u8 flags,
   int *pCmp
 ){
-  if( flags & PROLLY_NODE_INTKEY ){
-    i64 iOld = prollyCursorIntKey(pOld);
-    i64 iNew = prollyCursorIntKey(pNew);
-    if( iOld < iNew )      *pCmp = -1;
-    else if( iOld > iNew )  *pCmp =  1;
-    else                     *pCmp =  0;
-  }else{
-    const u8 *pKeyOld; int nKeyOld;
-    const u8 *pKeyNew; int nKeyNew;
-    prollyCursorKey(pOld, &pKeyOld, &nKeyOld);
-    prollyCursorKey(pNew, &pKeyNew, &nKeyNew);
-    *pCmp = diffBlobKeyCmp(pKeyOld, nKeyOld, pKeyNew, nKeyNew);
-  }
+  const u8 *pKeyOld; int nKeyOld;
+  const u8 *pKeyNew; int nKeyNew;
+  (void)flags;
+  prollyCursorKey(pOld, &pKeyOld, &nKeyOld);
+  prollyCursorKey(pNew, &pKeyNew, &nKeyNew);
+  *pCmp = diffBlobKeyCmp(pKeyOld, nKeyOld, pKeyNew, nKeyNew);
 }
 
 static void diffFillKey(
@@ -347,17 +340,12 @@ static int diffNodeKeyCmp(
   const ProllyNode *pB, int iB,
   u8 flags
 ){
-  if( flags & PROLLY_NODE_INTKEY ){
-    i64 a = prollyNodeIntKey(pA, iA);
-    i64 b = prollyNodeIntKey(pB, iB);
-    return (a < b) ? -1 : (a > b) ? 1 : 0;
-  }else{
-    const u8 *pKA; int nKA;
-    const u8 *pKB; int nKB;
-    prollyNodeKey(pA, iA, &pKA, &nKA);
-    prollyNodeKey(pB, iB, &pKB, &nKB);
-    return diffBlobKeyCmp(pKA, nKA, pKB, nKB);
-  }
+  const u8 *pKA; int nKA;
+  const u8 *pKB; int nKB;
+  (void)flags;
+  prollyNodeKey(pA, iA, &pKA, &nKA);
+  prollyNodeKey(pB, iB, &pKB, &nKB);
+  return diffBlobKeyCmp(pKA, nKA, pKB, nKB);
 }
 
 static int diffLeaves(
@@ -368,11 +356,7 @@ static int diffLeaves(
 
   while( i < (int)pOld->nItems && j < (int)pNew->nItems ){
     int cmp;
-    if( flags & PROLLY_NODE_INTKEY ){
-      i64 ik = prollyNodeIntKey(pOld, i);
-      i64 jk = prollyNodeIntKey(pNew, j);
-      cmp = (ik < jk) ? -1 : (ik > jk) ? 1 : 0;
-    }else{
+    {
       const u8 *pKA; int nKA; const u8 *pKB; int nKB;
       prollyNodeKey(pOld, i, &pKA, &nKA);
       prollyNodeKey(pNew, j, &pKB, &nKB);

--- a/src/prolly_mutate.c
+++ b/src/prolly_mutate.c
@@ -21,38 +21,23 @@ static void encodeI64BE(u8 *buf, i64 v){
 #define PROLLY_EST_ENTRIES_PER_LEAF 50
 
 static int compareKeys(
-  u8 flags,
-  const u8 *pKey1, int nKey1, i64 iKey1,
-  const u8 *pKey2, int nKey2, i64 iKey2
+  const u8 *pKey1, int nKey1,
+  const u8 *pKey2, int nKey2
 ){
-  if( flags & PROLLY_NODE_INTKEY ){
-    if( iKey1 < iKey2 ) return -1;
-    if( iKey1 > iKey2 ) return +1;
-    return 0;
-  }else{
-    int n = nKey1 < nKey2 ? nKey1 : nKey2;
-    int c = memcmp(pKey1, pKey2, n);
-    if( c != 0 ) return c;
-    if( nKey1 < nKey2 ) return -1;
-    if( nKey1 > nKey2 ) return 1;
-    return 0;
-  }
+  int n = nKey1 < nKey2 ? nKey1 : nKey2;
+  int c = memcmp(pKey1, pKey2, n);
+  if( c != 0 ) return c;
+  if( nKey1 < nKey2 ) return -1;
+  if( nKey1 > nKey2 ) return 1;
+  return 0;
 }
 
 static int feedChunker(
   ProllyChunker *pCh,
-  u8 flags,
-  const u8 *pKey, int nKey, i64 intKey,
+  const u8 *pKey, int nKey,
   const u8 *pVal, int nVal
 ){
-  if( flags & PROLLY_NODE_INTKEY ){
-
-    u8 aKeyBuf[8];
-    encodeI64BE(aKeyBuf, intKey);
-    return prollyChunkerAdd(pCh, aKeyBuf, 8, pVal, nVal);
-  }else{
-    return prollyChunkerAdd(pCh, pKey, nKey, pVal, nVal);
-  }
+  return prollyChunkerAdd(pCh, pKey, nKey, pVal, nVal);
 }
 
 static int buildFromEdits(
@@ -69,9 +54,7 @@ static int buildFromEdits(
   while( prollyMutMapIterValid(&iter) ){
     ProllyMutMapEntry *pEntry = prollyMutMapIterEntry(&iter);
     if( pEntry->op==PROLLY_EDIT_INSERT ){
-      rc = feedChunker(&chunker, pMut->flags,
-                       pEntry->pKey, pEntry->nKey,
-                       prollyMutMapEntryIntKey(pEntry),
+      rc = feedChunker(&chunker, pEntry->pKey, pEntry->nKey,
                        pEntry->pVal, pEntry->nVal);
       if( rc!=SQLITE_OK ){
         prollyChunkerFree(&chunker);
@@ -93,16 +76,14 @@ static int buildFromEdits(
 /* mergeWalk removed: streamingMerge now handles all flush shapes. */
 
 static int subtreeHasEdits(
-  u8 flags,
   ProllyMutMapIter *pIter,
-  const u8 *pBoundKey, int nBoundKey, i64 iBoundKey
+  const u8 *pBoundKey, int nBoundKey
 ){
   ProllyMutMapEntry *pEd;
   int cmp;
   if( !prollyMutMapIterValid(pIter) ) return 0;
   pEd = prollyMutMapIterEntry(pIter);
-  cmp = compareKeys(flags, pEd->pKey, pEd->nKey, prollyMutMapEntryIntKey(pEd),
-                    pBoundKey, nBoundKey, iBoundKey);
+  cmp = compareKeys(pEd->pKey, pEd->nKey, pBoundKey, nBoundKey);
   return (cmp <= 0);
 }
 
@@ -136,16 +117,9 @@ static int mergeLeaf(
 
     const u8 *pCurKey; int nCurKey;
     i64 iCurKey = 0;
-    u8 aKeyBuf[8];
     int cmp;
 
-    if( flags & PROLLY_NODE_INTKEY ){
-      iCurKey = prollyNodeIntKey(pLeaf, j);
-      encodeI64BE(aKeyBuf, iCurKey);
-      pCurKey = aKeyBuf; nCurKey = 8;
-    }else{
-      prollyNodeKey(pLeaf, j, &pCurKey, &nCurKey);
-    }
+    prollyNodeKey(pLeaf, j, &pCurKey, &nCurKey);
 
     if( !haveEdit ){
 
@@ -160,18 +134,9 @@ static int mergeLeaf(
 
     {
       const u8 *pLastKey; int nLastKey;
-      i64 iLastKey = 0;
-      u8 aLastBuf[8];
       int pastLeaf;
-      if( flags & PROLLY_NODE_INTKEY ){
-        iLastKey = prollyNodeIntKey(pLeaf, pLeaf->nItems - 1);
-        encodeI64BE(aLastBuf, iLastKey);
-        pLastKey = aLastBuf; nLastKey = 8;
-      }else{
-        prollyNodeKey(pLeaf, pLeaf->nItems - 1, &pLastKey, &nLastKey);
-      }
-      pastLeaf = compareKeys(flags, pEd->pKey, pEd->nKey, prollyMutMapEntryIntKey(pEd),
-                                 pLastKey, nLastKey, iLastKey);
+      prollyNodeKey(pLeaf, pLeaf->nItems - 1, &pLastKey, &nLastKey);
+      pastLeaf = compareKeys(pEd->pKey, pEd->nKey, pLastKey, nLastKey);
       if( pastLeaf > 0 ){
 
         const u8 *pVal; int nVal;
@@ -183,8 +148,7 @@ static int mergeLeaf(
       }
     }
 
-    cmp = compareKeys(flags, pCurKey, nCurKey, iCurKey,
-                          pEd->pKey, pEd->nKey, prollyMutMapEntryIntKey(pEd));
+    cmp = compareKeys(pCurKey, nCurKey, pEd->pKey, pEd->nKey);
     if( cmp < 0 ){
 
       const u8 *pVal; int nVal;
@@ -195,15 +159,7 @@ static int mergeLeaf(
     }else if( cmp == 0 ){
 
       if( pEd->op==PROLLY_EDIT_INSERT ){
-        u8 aEditKey[8];
-        const u8 *pEK; int nEK;
-        if( flags & PROLLY_NODE_INTKEY ){
-          encodeI64BE(aEditKey, prollyMutMapEntryIntKey(pEd));
-          pEK = aEditKey; nEK = 8;
-        }else{
-          pEK = pEd->pKey; nEK = pEd->nKey;
-        }
-        rc = prollyChunkerAdd(pCh, pEK, nEK, pEd->pVal, pEd->nVal);
+        rc = prollyChunkerAdd(pCh, pEd->pKey, pEd->nKey, pEd->pVal, pEd->nVal);
         if( rc!=SQLITE_OK ) return rc;
       }
       j++;
@@ -211,15 +167,7 @@ static int mergeLeaf(
     }else{
 
       if( pEd->op==PROLLY_EDIT_INSERT ){
-        u8 aEditKey[8];
-        const u8 *pEK; int nEK;
-        if( flags & PROLLY_NODE_INTKEY ){
-          encodeI64BE(aEditKey, prollyMutMapEntryIntKey(pEd));
-          pEK = aEditKey; nEK = 8;
-        }else{
-          pEK = pEd->pKey; nEK = pEd->nKey;
-        }
-        rc = prollyChunkerAdd(pCh, pEK, nEK, pEd->pVal, pEd->nVal);
+        rc = prollyChunkerAdd(pCh, pEd->pKey, pEd->nKey, pEd->pVal, pEd->nVal);
         if( rc!=SQLITE_OK ) return rc;
       }
       prollyMutMapIterNext(pIter);
@@ -236,15 +184,7 @@ static int mergeLeaf(
     while( prollyMutMapIterValid(pIter) ){
       ProllyMutMapEntry *pEd = prollyMutMapIterEntry(pIter);
       if( pEd->op==PROLLY_EDIT_INSERT ){
-        u8 aEditKey[8];
-        const u8 *pEK; int nEK;
-        if( flags & PROLLY_NODE_INTKEY ){
-          encodeI64BE(aEditKey, prollyMutMapEntryIntKey(pEd));
-          pEK = aEditKey; nEK = 8;
-        }else{
-          pEK = pEd->pKey; nEK = pEd->nKey;
-        }
-        rc = prollyChunkerAdd(pCh, pEK, nEK, pEd->pVal, pEd->nVal);
+        rc = prollyChunkerAdd(pCh, pEd->pKey, pEd->nKey, pEd->pVal, pEd->nVal);
         if( rc!=SQLITE_OK ) return rc;
       }
       prollyMutMapIterNext(pIter);
@@ -268,19 +208,11 @@ static int streamingMergeNode(
   for( i = 0; i < pNode->nItems; i++ ){
     const u8 *pBoundKey; int nBoundKey;
     const u8 *pChildVal; int nChildVal;
-    i64 iBoundKey = 0;
-    u8 aBoundBuf[8];
     int childIsLast;
     int forceDescend;
 
     prollyNodeKey(pNode, i, &pBoundKey, &nBoundKey);
     prollyNodeValue(pNode, i, &pChildVal, &nChildVal);
-
-    if( pMut->flags & PROLLY_NODE_INTKEY ){
-      iBoundKey = prollyNodeIntKey(pNode, i);
-      encodeI64BE(aBoundBuf, iBoundKey);
-      pBoundKey = aBoundBuf; nBoundKey = 8;
-    }
 
     childIsLast = isLast && (i == pNode->nItems - 1);
 
@@ -293,8 +225,7 @@ static int streamingMergeNode(
     forceDescend = childIsLast && prollyMutMapIterValid(pIter);
 
     if( !forceDescend
-     && !subtreeHasEdits(pMut->flags, pIter,
-                         pBoundKey, nBoundKey, iBoundKey)
+     && !subtreeHasEdits(pIter, pBoundKey, nBoundKey)
      && chunkerLevelsBelowEmpty(pChunker, pNode->level) ){
       rc = prollyChunkerAddAtLevel(pChunker, pNode->level,
                                     pBoundKey, nBoundKey,

--- a/src/prolly_mutate.c
+++ b/src/prolly_mutate.c
@@ -116,7 +116,6 @@ static int mergeLeaf(
     ProllyMutMapEntry *pEd = haveEdit ? prollyMutMapIterEntry(pIter) : 0;
 
     const u8 *pCurKey; int nCurKey;
-    i64 iCurKey = 0;
     int cmp;
 
     prollyNodeKey(pLeaf, j, &pCurKey, &nCurKey);

--- a/src/prolly_mutate.c
+++ b/src/prolly_mutate.c
@@ -89,7 +89,7 @@ static int buildFromEdits(
   return rc;
 }
 
-static int mergeWalk(ProllyMutator *pMut);
+/* mergeWalk removed: streamingMerge now handles all flush shapes. */
 
 static int subtreeHasEdits(
   u8 flags,
@@ -349,11 +349,6 @@ static int streamingMerge(
   }
 
 
-  if( rootNode.level == 0 ){
-    sqlite3_free(pRootData);
-    return mergeWalk(pMut);
-  }
-
   prollyMutMapIterFirst(&iter, pMut->pEdits);
   rc = prollyChunkerInit(&chunker, pMut->pStore, pMut->flags);
   if( rc!=SQLITE_OK ){
@@ -364,8 +359,16 @@ static int streamingMerge(
   /* isLast=1 marks the root as the rightmost subtree at this level
   ** of recursion, propagating down through the rightmost child of
   ** each visited node. mergeLeaf at the bottom drains any trailing
-  ** edits past the rightmost leaf's last key. */
-  rc = streamingMergeNode(pMut, &rootNode, &chunker, &iter, /*isLast=*/1);
+  ** edits past the rightmost leaf's last key.
+  **
+  ** A root that is itself a leaf (level == 0) is just the rightmost
+  ** leaf at the top of the tree — drain edits into it via mergeLeaf
+  ** directly, no need for streamingMergeNode's child-iteration. */
+  if( rootNode.level == 0 ){
+    rc = mergeLeaf(pMut, &rootNode, &chunker, &iter, /*isLast=*/1);
+  }else{
+    rc = streamingMergeNode(pMut, &rootNode, &chunker, &iter, /*isLast=*/1);
+  }
   if( rc!=SQLITE_OK ) goto streaming_cleanup;
 
   rc = prollyChunkerFinish(&chunker);
@@ -379,139 +382,17 @@ streaming_cleanup:
   return rc;
 }
 
-static int mergeWalk(
-  ProllyMutator *pMut
-){
-  ProllyCursor cur;
-  ProllyMutMapIter iter;
-  ProllyChunker chunker;
-  int rc;
-  int curEmpty = 0;
-  int curValid;
-  int iterValid;
 
-
-  prollyCursorInit(&cur, pMut->pStore, pMut->pCache,
-                   &pMut->oldRoot, pMut->flags);
-  rc = prollyCursorFirst(&cur, &curEmpty);
-  if( rc!=SQLITE_OK ){
-    prollyCursorClose(&cur);
-    return rc;
-  }
-  if( curEmpty ){
-    prollyCursorClose(&cur);
-    return buildFromEdits(pMut);
-  }
-
-  prollyMutMapIterFirst(&iter, pMut->pEdits);
-
-  rc = prollyChunkerInit(&chunker, pMut->pStore, pMut->flags);
-  if( rc!=SQLITE_OK ){
-    prollyCursorClose(&cur);
-    return rc;
-  }
-
-  for(;;){
-    curValid = prollyCursorIsValid(&cur);
-    iterValid = prollyMutMapIterValid(&iter);
-    if( !curValid && !iterValid ) break;
-
-    if( curValid && !iterValid ){
-      const u8 *pKey; int nKey;
-      const u8 *pVal; int nVal;
-      i64 intKey = 0;
-      if( pMut->flags & PROLLY_NODE_INTKEY ){
-        intKey = prollyCursorIntKey(&cur);
-        pKey = 0; nKey = 0;
-      }else{
-        prollyCursorKey(&cur, &pKey, &nKey);
-      }
-      prollyCursorValue(&cur, &pVal, &nVal);
-      rc = feedChunker(&chunker, pMut->flags, pKey, nKey, intKey, pVal, nVal);
-      if( rc!=SQLITE_OK ) goto merge_cleanup;
-      rc = prollyCursorNext(&cur);
-      if( rc!=SQLITE_OK ) goto merge_cleanup;
-      continue;
-    }
-
-    if( !curValid && iterValid ){
-      ProllyMutMapEntry *pEntry = prollyMutMapIterEntry(&iter);
-      if( pEntry->op==PROLLY_EDIT_INSERT ){
-        rc = feedChunker(&chunker, pMut->flags,
-                         pEntry->pKey, pEntry->nKey, pEntry->intKey,
-                         pEntry->pVal, pEntry->nVal);
-        if( rc!=SQLITE_OK ) goto merge_cleanup;
-      }
-      prollyMutMapIterNext(&iter);
-      continue;
-    }
-
-    {
-      ProllyMutMapEntry *pEntry = prollyMutMapIterEntry(&iter);
-      const u8 *pCurKey; int nCurKey;
-      i64 iCurKey = 0;
-      int cmp;
-
-      if( pMut->flags & PROLLY_NODE_INTKEY ){
-        iCurKey = prollyCursorIntKey(&cur);
-        pCurKey = 0; nCurKey = 0;
-      }else{
-        prollyCursorKey(&cur, &pCurKey, &nCurKey);
-      }
-
-      cmp = compareKeys(pMut->flags,
-                         pCurKey, nCurKey, iCurKey,
-                         pEntry->pKey, pEntry->nKey, pEntry->intKey);
-
-      if( cmp < 0 ){
-        const u8 *pVal; int nVal;
-        prollyCursorValue(&cur, &pVal, &nVal);
-        rc = feedChunker(&chunker, pMut->flags,
-                         pCurKey, nCurKey, iCurKey, pVal, nVal);
-        if( rc!=SQLITE_OK ) goto merge_cleanup;
-        rc = prollyCursorNext(&cur);
-        if( rc!=SQLITE_OK ) goto merge_cleanup;
-      }else if( cmp == 0 ){
-        if( pEntry->op==PROLLY_EDIT_INSERT ){
-          rc = feedChunker(&chunker, pMut->flags,
-                           pEntry->pKey, pEntry->nKey, pEntry->intKey,
-                           pEntry->pVal, pEntry->nVal);
-          if( rc!=SQLITE_OK ) goto merge_cleanup;
-        }
-        rc = prollyCursorNext(&cur);
-        if( rc!=SQLITE_OK ) goto merge_cleanup;
-        prollyMutMapIterNext(&iter);
-      }else{
-        if( pEntry->op==PROLLY_EDIT_INSERT ){
-          rc = feedChunker(&chunker, pMut->flags,
-                           pEntry->pKey, pEntry->nKey, pEntry->intKey,
-                           pEntry->pVal, pEntry->nVal);
-          if( rc!=SQLITE_OK ) goto merge_cleanup;
-        }
-        prollyMutMapIterNext(&iter);
-      }
-    }
-  }
-
-  rc = prollyChunkerFinish(&chunker);
-  if( rc==SQLITE_OK ){
-    prollyChunkerGetRoot(&chunker, &pMut->newRoot);
-  }
-
-merge_cleanup:
-  prollyChunkerFree(&chunker);
-  prollyCursorClose(&cur);
-  return rc;
-}
-
-/* streamingMerge skips unchanged subtrees by re-splicing them into a
-** new chunker at their original level. Fast for sparse edits, but
-** because the splice happens at the source level it can accumulate
-** extra depth over many sessions. mergeWalk rebuilds the whole tree
-** so depth stays optimal. Heuristic below uses streamingMerge only
-** when edits are a tiny fraction of leaves AND the absolute count is
-** small — batch inserts always fall through to mergeWalk so the
-** common case stays clean. */
+/* streamingMerge is now the only flush strategy. It walks the tree once,
+** splicing unchanged subtrees by re-emitting their hash references at the
+** matched level (Dolt's chunker.advanceTo equivalent), and drains trailing
+** edits into the rightmost leaf to avoid the depth pathology that the
+** earlier mergeWalk fallback was guarding against. With those correctness
+** properties in place there is no shape on which a full-rebuild walk would
+** be required for correctness, so the per-flush strategy choice (which had
+** been pessimizing toward mergeWalk for any non-trivial edit ratio) is
+** dropped in favor of the unified path — matching Dolt's "one algorithm,
+** no INTKEY/non-INTKEY split" property. */
 int prollyMutateFlush(ProllyMutator *pMut){
   if( prollyMutMapIsEmpty(pMut->pEdits) ){
     memcpy(&pMut->newRoot, &pMut->oldRoot, sizeof(ProllyHash));
@@ -522,39 +403,7 @@ int prollyMutateFlush(ProllyMutator *pMut){
     return buildFromEdits(pMut);
   }
 
-  {
-    int M = prollyMutMapCount(pMut->pEdits);
-    int leafCount = 0;
-
-    {
-      u8 *pRootData = 0;
-      int nRootData = 0;
-      int rcEst = chunkStoreGet(pMut->pStore, &pMut->oldRoot,
-                                &pRootData, &nRootData);
-      if( rcEst==SQLITE_OK && pRootData ){
-        ProllyNode rootNode;
-        if( prollyNodeParse(&rootNode, pRootData, nRootData)==SQLITE_OK ){
-          if( rootNode.level==0 ){
-            leafCount = rootNode.nItems;
-          }else{
-            leafCount = rootNode.nItems * PROLLY_EST_ENTRIES_PER_LEAF;
-            /* Cap at two levels of fan-out; overestimating picks
-            ** streamingMerge too aggressively and deepens the tree. */
-            if( rootNode.level > 1 && leafCount < 0x7FFFFFFF / PROLLY_EST_ENTRIES_PER_LEAF ){
-              leafCount *= PROLLY_EST_ENTRIES_PER_LEAF;
-            }
-          }
-        }
-        sqlite3_free(pRootData);
-      }
-    }
-
-    if( leafCount <= 0 || M > leafCount / 100 || M > 10000 ){
-      return mergeWalk(pMut);
-    }else{
-      return streamingMerge(pMut);
-    }
-  }
+  return streamingMerge(pMut);
 }
 
 int prollyMutateInsert(

--- a/src/prolly_mutate.c
+++ b/src/prolly_mutate.c
@@ -70,7 +70,8 @@ static int buildFromEdits(
     ProllyMutMapEntry *pEntry = prollyMutMapIterEntry(&iter);
     if( pEntry->op==PROLLY_EDIT_INSERT ){
       rc = feedChunker(&chunker, pMut->flags,
-                       pEntry->pKey, pEntry->nKey, pEntry->intKey,
+                       pEntry->pKey, pEntry->nKey,
+                       prollyMutMapEntryIntKey(pEntry),
                        pEntry->pVal, pEntry->nVal);
       if( rc!=SQLITE_OK ){
         prollyChunkerFree(&chunker);
@@ -100,7 +101,7 @@ static int subtreeHasEdits(
   int cmp;
   if( !prollyMutMapIterValid(pIter) ) return 0;
   pEd = prollyMutMapIterEntry(pIter);
-  cmp = compareKeys(flags, pEd->pKey, pEd->nKey, pEd->intKey,
+  cmp = compareKeys(flags, pEd->pKey, pEd->nKey, prollyMutMapEntryIntKey(pEd),
                     pBoundKey, nBoundKey, iBoundKey);
   return (cmp <= 0);
 }
@@ -169,7 +170,7 @@ static int mergeLeaf(
       }else{
         prollyNodeKey(pLeaf, pLeaf->nItems - 1, &pLastKey, &nLastKey);
       }
-      pastLeaf = compareKeys(flags, pEd->pKey, pEd->nKey, pEd->intKey,
+      pastLeaf = compareKeys(flags, pEd->pKey, pEd->nKey, prollyMutMapEntryIntKey(pEd),
                                  pLastKey, nLastKey, iLastKey);
       if( pastLeaf > 0 ){
 
@@ -183,7 +184,7 @@ static int mergeLeaf(
     }
 
     cmp = compareKeys(flags, pCurKey, nCurKey, iCurKey,
-                          pEd->pKey, pEd->nKey, pEd->intKey);
+                          pEd->pKey, pEd->nKey, prollyMutMapEntryIntKey(pEd));
     if( cmp < 0 ){
 
       const u8 *pVal; int nVal;
@@ -197,7 +198,7 @@ static int mergeLeaf(
         u8 aEditKey[8];
         const u8 *pEK; int nEK;
         if( flags & PROLLY_NODE_INTKEY ){
-          encodeI64BE(aEditKey, pEd->intKey);
+          encodeI64BE(aEditKey, prollyMutMapEntryIntKey(pEd));
           pEK = aEditKey; nEK = 8;
         }else{
           pEK = pEd->pKey; nEK = pEd->nKey;
@@ -213,7 +214,7 @@ static int mergeLeaf(
         u8 aEditKey[8];
         const u8 *pEK; int nEK;
         if( flags & PROLLY_NODE_INTKEY ){
-          encodeI64BE(aEditKey, pEd->intKey);
+          encodeI64BE(aEditKey, prollyMutMapEntryIntKey(pEd));
           pEK = aEditKey; nEK = 8;
         }else{
           pEK = pEd->pKey; nEK = pEd->nKey;
@@ -238,7 +239,7 @@ static int mergeLeaf(
         u8 aEditKey[8];
         const u8 *pEK; int nEK;
         if( flags & PROLLY_NODE_INTKEY ){
-          encodeI64BE(aEditKey, pEd->intKey);
+          encodeI64BE(aEditKey, prollyMutMapEntryIntKey(pEd));
           pEK = aEditKey; nEK = 8;
         }else{
           pEK = pEd->pKey; nEK = pEd->nKey;

--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -34,17 +34,26 @@ static void encodeIntKeyBE(i64 v, u8 buf[8]){
   buf[7] = (u8)u;
 }
 
-/* Rebinds (pKey, nKey) to point at a sortable encoding of intKey when
-** the map is in INT mode and the caller passed only the integer value.
-** Callers that already supplied byte-form keys are passed through. */
+/* Rebinds (pKey, nKey) to a sortable encoding of intKey when the map is
+** in INT mode. INT-mode callers MUST pass (NULL, 0, intKey) — passing
+** byte-form keys with a meaningful intKey alongside is ambiguous and
+** would silently let bytes win, corrupting key order. The assert catches
+** that misuse during development; for INT-mode entries originating from
+** Merge re-insert (where pKey is already the encoded 8 bytes) callers
+** pass intKey=0 and the assert holds. */
 static void prepKey(ProllyMutMap *mm,
                     const u8 **ppKey, int *pnKey,
                     i64 intKey, u8 buf[8]){
-  if( mm->isIntKey && (*ppKey == 0 || *pnKey == 0) ){
-    encodeIntKeyBE(intKey, buf);
-    *ppKey = buf;
-    *pnKey = 8;
+  if( !mm->isIntKey ) return;
+  if( *ppKey != 0 && *pnKey > 0 ){
+    /* Caller passed pre-encoded bytes (Merge re-insert path). intKey
+    ** must be 0 by convention so we don't have two key sources. */
+    assert( intKey == 0 );
+    return;
   }
+  encodeIntKeyBE(intKey, buf);
+  *ppKey = buf;
+  *pnKey = 8;
 }
 
 static int compareEntries(

--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -13,6 +13,15 @@
 ** flipped so unsigned byte-lex order matches signed integer order.
 ** Matches the on-disk INTKEY layout in prolly_node.c (see
 ** prollyNodeIntKey, which decodes via `u ^ (1<<63)`). */
+i64 prollyMutMapEntryIntKey(const ProllyMutMapEntry *e){
+  const u8 *p = e->pKey;
+  u64 u;
+  if( e->nKey != 8 || p == 0 ) return 0;
+  u = ((u64)p[0]<<56) | ((u64)p[1]<<48) | ((u64)p[2]<<40) | ((u64)p[3]<<32)
+    | ((u64)p[4]<<24) | ((u64)p[5]<<16) | ((u64)p[6]<<8) | (u64)p[7];
+  return (i64)(u ^ ((u64)1 << 63));
+}
+
 static void encodeIntKeyBE(i64 v, u8 buf[8]){
   u64 u = ((u64)v) ^ ((u64)1 << 63);
   buf[0] = (u8)(u >> 56);
@@ -377,7 +386,6 @@ int prollyMutMapInsert(
     e = &mm->aEntries[phys];
     memset(e, 0, sizeof(*e));
     e->op = PROLLY_EDIT_INSERT;
-    e->intKey = intKey;
     e->bornAt = encodeLevel(mm, mm->currentSavepointLevel);
     rc = copyEntryData(mm, e, pKey, nKey, pVal, nVal);
     if( rc!=SQLITE_OK ){
@@ -457,7 +465,6 @@ int prollyMutMapDelete(
     e = &mm->aEntries[phys];
     memset(e, 0, sizeof(*e));
     e->op = PROLLY_EDIT_DELETE;
-    e->intKey = intKey;
     e->bornAt = encodeLevel(mm, mm->currentSavepointLevel);
     rc = copyEntryData(mm, e, pKey, nKey, 0, 0);
     if( rc!=SQLITE_OK ){
@@ -764,7 +771,6 @@ int prollyMutMapClone(ProllyMutMap **out, const ProllyMutMap *src){
       ProllyMutMapEntry *se = &src->aEntries[i];
       ProllyMutMapEntry *de = &dst->aEntries[i];
       de->op = se->op;
-      de->intKey = se->intKey;
       de->bornAt = se->bornAt;
       de->nKey = 0;
       de->nVal = 0;
@@ -857,11 +863,13 @@ int prollyMutMapMerge(ProllyMutMap *pDst, ProllyMutMap *pSrc){
   int i, rc;
   for(i=0; i<pSrc->nEntries; i++){
     ProllyMutMapEntry *e = &pSrc->aEntries[i];
+    /* Entry's pKey/nKey are already in encoded byte form for both INT
+    ** and BLOB maps, so prepKey in the callee is a no-op. */
     if( e->op==PROLLY_EDIT_INSERT ){
-      rc = prollyMutMapInsert(pDst, e->pKey, e->nKey, e->intKey,
+      rc = prollyMutMapInsert(pDst, e->pKey, e->nKey, 0,
                                e->pVal, e->nVal);
     }else{
-      rc = prollyMutMapDelete(pDst, e->pKey, e->nKey, e->intKey);
+      rc = prollyMutMapDelete(pDst, e->pKey, e->nKey, 0);
     }
     if( rc!=SQLITE_OK ) return rc;
   }

--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -8,42 +8,61 @@
 
 #define MUTMAP_INIT_CAP 16
 #define MUTMAP_MIN_HASH 32
+
+/* Sortable 8-byte big-endian encoding of an i64 — the high bit is
+** flipped so unsigned byte-lex order matches signed integer order.
+** Matches the on-disk INTKEY layout in prolly_node.c (see
+** prollyNodeIntKey, which decodes via `u ^ (1<<63)`). */
+static void encodeIntKeyBE(i64 v, u8 buf[8]){
+  u64 u = ((u64)v) ^ ((u64)1 << 63);
+  buf[0] = (u8)(u >> 56);
+  buf[1] = (u8)(u >> 48);
+  buf[2] = (u8)(u >> 40);
+  buf[3] = (u8)(u >> 32);
+  buf[4] = (u8)(u >> 24);
+  buf[5] = (u8)(u >> 16);
+  buf[6] = (u8)(u >> 8);
+  buf[7] = (u8)u;
+}
+
+/* Rebinds (pKey, nKey) to point at a sortable encoding of intKey when
+** the map is in INT mode and the caller passed only the integer value.
+** Callers that already supplied byte-form keys are passed through. */
+static void prepKey(ProllyMutMap *mm,
+                    const u8 **ppKey, int *pnKey,
+                    i64 intKey, u8 buf[8]){
+  if( mm->isIntKey && (*ppKey == 0 || *pnKey == 0) ){
+    encodeIntKeyBE(intKey, buf);
+    *ppKey = buf;
+    *pnKey = 8;
+  }
+}
+
 static int compareEntries(
-  u8 isIntKey,
-  const u8 *pKeyA, int nKeyA, i64 intKeyA,
-  const u8 *pKeyB, int nKeyB, i64 intKeyB
+  const u8 *pKeyA, int nKeyA,
+  const u8 *pKeyB, int nKeyB
 ){
-  u8 flags = isIntKey ? PROLLY_NODE_INTKEY : PROLLY_NODE_BLOBKEY;
-  return prollyCompareKeys(flags, pKeyA, nKeyA, intKeyA,
-                           pKeyB, nKeyB, intKeyB);
+  int n = nKeyA < nKeyB ? nKeyA : nKeyB;
+  int c = memcmp(pKeyA, pKeyB, n);
+  if( c != 0 ) return c;
+  if( nKeyA < nKeyB ) return -1;
+  if( nKeyA > nKeyB ) return 1;
+  return 0;
 }
 
 static ProllyMutMapEntry *entryAtOrder(ProllyMutMap *mm, int idx){
   return &mm->aEntries[mm->aOrder[idx]];
 }
 
-static u32 hashKey(
-  u8 isIntKey,
-  const u8 *pKey, int nKey, i64 intKey
-){
+static u32 hashKey(const u8 *pKey, int nKey){
   u32 h = 2166136261u;
-  if( isIntKey ){
-    u64 x = (u64)intKey;
-    int i;
-    for(i=0; i<8; i++){
-      h ^= (u8)(x & 0xff);
-      h *= 16777619u;
-      x >>= 8;
-    }
-  }else{
-    int i;
-    for(i=0; i<nKey; i++){
-      h ^= pKey[i];
-      h *= 16777619u;
-    }
-    h ^= (u32)nKey;
+  int i;
+  for(i=0; i<nKey; i++){
+    h ^= pKey[i];
     h *= 16777619u;
   }
+  h ^= (u32)nKey;
+  h *= 16777619u;
   return h;
 }
 
@@ -76,7 +95,7 @@ static int copyEntryData(ProllyMutMap *mm, ProllyMutMapEntry *e,
   e->nKey = 0;
   e->pVal = 0;
   e->nVal = 0;
-  if( !mm->isIntKey && pKey && nKey>0 ){
+  if( pKey && nKey>0 ){
     e->pKey = (u8*)sqlite3_malloc(nKey);
     if( !e->pKey ) return SQLITE_NOMEM;
     memcpy(e->pKey, pKey, nKey);
@@ -96,16 +115,14 @@ static int copyEntryData(ProllyMutMap *mm, ProllyMutMapEntry *e,
 }
 
 static int bsearch_key(ProllyMutMap *mm,
-                       const u8 *pKey, int nKey, i64 intKey,
+                       const u8 *pKey, int nKey,
                        int *pFound){
   int lo = 0, hi = mm->nEntries;
   *pFound = 0;
   while( lo < hi ){
     int mid = lo + (hi - lo) / 2;
     ProllyMutMapEntry *e = entryAtOrder(mm, mid);
-    int c = compareEntries(mm->isIntKey,
-                           e->pKey, e->nKey, e->intKey,
-                           pKey, nKey, intKey);
+    int c = compareEntries(e->pKey, e->nKey, pKey, nKey);
     if( c < 0 ){
       lo = mid + 1;
     }else if( c > 0 ){
@@ -120,12 +137,10 @@ static int bsearch_key(ProllyMutMap *mm,
 
 static int hashEntryMatches(
   ProllyMutMap *mm, int phys,
-  const u8 *pKey, int nKey, i64 intKey
+  const u8 *pKey, int nKey
 ){
   ProllyMutMapEntry *e = &mm->aEntries[phys];
-  return compareEntries(mm->isIntKey,
-                        e->pKey, e->nKey, e->intKey,
-                        pKey, nKey, intKey)==0;
+  return compareEntries(e->pKey, e->nKey, pKey, nKey)==0;
 }
 
 static int rebuildHash(ProllyMutMap *mm){
@@ -140,8 +155,7 @@ static int rebuildHash(ProllyMutMap *mm){
   }
   memset(mm->aHash, 0, mm->nHashAlloc * sizeof(int));
   for(i=0; i<mm->nEntries; i++){
-    u32 h = hashKey(mm->isIntKey,
-                    mm->aEntries[i].pKey, mm->aEntries[i].nKey, mm->aEntries[i].intKey);
+    u32 h = hashKey(mm->aEntries[i].pKey, mm->aEntries[i].nKey);
     int mask = mm->nHashAlloc - 1;
     int slot = (int)(h & (u32)mask);
     while( mm->aHash[slot] != 0 ){
@@ -165,9 +179,7 @@ static void hashInsertPhys(ProllyMutMap *mm, int phys){
   int mask;
   int slot;
   if( mm->keepSorted || mm->nHashAlloc==0 ) return;
-  h = hashKey(mm->isIntKey,
-              mm->aEntries[phys].pKey, mm->aEntries[phys].nKey,
-              mm->aEntries[phys].intKey);
+  h = hashKey(mm->aEntries[phys].pKey, mm->aEntries[phys].nKey);
   mask = mm->nHashAlloc - 1;
   slot = (int)(h & (u32)mask);
   while( mm->aHash[slot] != 0 ){
@@ -177,7 +189,7 @@ static void hashInsertPhys(ProllyMutMap *mm, int phys){
 }
 
 static int findPhysLazy(ProllyMutMap *mm,
-                        const u8 *pKey, int nKey, i64 intKey,
+                        const u8 *pKey, int nKey,
                         int *pPhys){
   *pPhys = -1;
   if( mm->nEntries==0 ) return SQLITE_OK;
@@ -186,12 +198,12 @@ static int findPhysLazy(ProllyMutMap *mm,
     if( rc!=SQLITE_OK ) return rc;
   }
   {
-    u32 h = hashKey(mm->isIntKey, pKey, nKey, intKey);
+    u32 h = hashKey(pKey, nKey);
     int mask = mm->nHashAlloc - 1;
     int slot = (int)(h & (u32)mask);
     while( mm->aHash[slot] != 0 ){
       int phys = mm->aHash[slot] - 1;
-      if( hashEntryMatches(mm, phys, pKey, nKey, intKey) ){
+      if( hashEntryMatches(mm, phys, pKey, nKey) ){
         *pPhys = phys;
         return SQLITE_OK;
       }
@@ -207,9 +219,7 @@ static int compareOrderIndexes(const void *a, const void *b){
   int ib = *(const int*)b;
   ProllyMutMapEntry *ea = &mm->aEntries[ia];
   ProllyMutMapEntry *eb = &mm->aEntries[ib];
-  return compareEntries(mm->isIntKey,
-                        ea->pKey, ea->nKey, ea->intKey,
-                        eb->pKey, eb->nKey, eb->intKey);
+  return compareEntries(ea->pKey, ea->nKey, eb->pKey, eb->nKey);
 }
 
 static int ensureOrder(ProllyMutMap *mm){
@@ -234,10 +244,8 @@ static int rankEntryWithoutOrder(ProllyMutMap *mm, int phys){
   int i;
   for(i=0; i<mm->nEntries; i++){
     if( i==phys ) continue;
-    if( compareEntries(mm->isIntKey,
-                       mm->aEntries[i].pKey, mm->aEntries[i].nKey,
-                       mm->aEntries[i].intKey,
-                       target->pKey, target->nKey, target->intKey) < 0 ){
+    if( compareEntries(mm->aEntries[i].pKey, mm->aEntries[i].nKey,
+                       target->pKey, target->nKey) < 0 ){
       rank++;
     }
   }
@@ -321,14 +329,16 @@ int prollyMutMapInsert(
   const u8 *pVal, int nVal
 ){
   int found = 0, idx = 0, rc, phys = -1;
+  u8 keyBuf[8];
+  prepKey(mm, &pKey, &nKey, intKey, keyBuf);
 
   if( mm->keepSorted ){
-    idx = bsearch_key(mm, pKey, nKey, intKey, &found);
+    idx = bsearch_key(mm, pKey, nKey, &found);
     if( found ){
       phys = mm->aOrder[idx];
     }
   }else{
-    rc = findPhysLazy(mm, pKey, nKey, intKey, &phys);
+    rc = findPhysLazy(mm, pKey, nKey, &phys);
     if( rc!=SQLITE_OK ) return rc;
     found = (phys >= 0);
   }
@@ -402,14 +412,16 @@ int prollyMutMapDelete(
   const u8 *pKey, int nKey, i64 intKey
 ){
   int found = 0, idx = 0, rc, phys = -1;
+  u8 keyBuf[8];
+  prepKey(mm, &pKey, &nKey, intKey, keyBuf);
 
   if( mm->keepSorted ){
-    idx = bsearch_key(mm, pKey, nKey, intKey, &found);
+    idx = bsearch_key(mm, pKey, nKey, &found);
     if( found ){
       phys = mm->aOrder[idx];
     }
   }else{
-    rc = findPhysLazy(mm, pKey, nKey, intKey, &phys);
+    rc = findPhysLazy(mm, pKey, nKey, &phys);
     if( rc!=SQLITE_OK ) return rc;
     found = (phys >= 0);
   }
@@ -611,14 +623,16 @@ int prollyMutMapFindRc(
   ProllyMutMapEntry **ppEntry
 ){
   int found, idx, phys, rc;
+  u8 keyBuf[8];
   *ppEntry = 0;
   if( mm->nEntries==0 ) return SQLITE_OK;
+  prepKey(mm, &pKey, &nKey, intKey, keyBuf);
   if( mm->keepSorted ){
-    idx = bsearch_key(mm, pKey, nKey, intKey, &found);
+    idx = bsearch_key(mm, pKey, nKey, &found);
     *ppEntry = found ? entryAtOrder(mm, idx) : 0;
     return SQLITE_OK;
   }
-  rc = findPhysLazy(mm, pKey, nKey, intKey, &phys);
+  rc = findPhysLazy(mm, pKey, nKey, &phys);
   if( rc!=SQLITE_OK ) return rc;
   *ppEntry = phys >= 0 ? &mm->aEntries[phys] : 0;
   return SQLITE_OK;
@@ -668,9 +682,11 @@ ProllyMutMapEntry *prollyMutMapIterEntry(ProllyMutMapIter *it){
 void prollyMutMapIterSeek(ProllyMutMapIter *it, ProllyMutMap *mm,
                           const u8 *pKey, int nKey, i64 intKey){
   int found = 0;
+  u8 keyBuf[8];
   ensureOrder(mm);
+  prepKey(mm, &pKey, &nKey, intKey, keyBuf);
   it->pMap = mm;
-  it->idx = bsearch_key(mm, pKey, nKey, intKey, &found);
+  it->idx = bsearch_key(mm, pKey, nKey, &found);
 }
 
 void prollyMutMapIterLast(ProllyMutMapIter *it, ProllyMutMap *mm){

--- a/src/prolly_mutmap.h
+++ b/src/prolly_mutmap.h
@@ -12,13 +12,17 @@ typedef struct ProllyMutMapIter ProllyMutMapIter;
 
 struct ProllyMutMapEntry {
   u8 op;
-  i64 intKey;
   u8 *pKey;
   int nKey;
   u8 *pVal;
   int nVal;
   int bornAt;
 };
+
+/* Decodes a sortable 8-byte BE entry key back to i64. Only valid for
+** entries in an INT-mode map; the bytes layout matches the on-disk
+** PROLLY_NODE_INTKEY encoding (sign-flipped big-endian). */
+i64 prollyMutMapEntryIntKey(const ProllyMutMapEntry *e);
 
 /* Lazy — allocated only when an in-place mutation under an active
 ** savepoint is about to overwrite the previous (op, value). */

--- a/src/prolly_node.c
+++ b/src/prolly_node.c
@@ -130,6 +130,18 @@ void prollyNodeValue(const ProllyNode *pNode, int i, const u8 **ppVal, int *pnVa
   *pnVal = (int)(off1 - off0);
 }
 
+void prollyEncodeIntKey(i64 v, u8 buf[8]){
+  u64 u = ((u64)v) ^ ((u64)1 << 63);
+  buf[0] = (u8)(u >> 56);
+  buf[1] = (u8)(u >> 48);
+  buf[2] = (u8)(u >> 40);
+  buf[3] = (u8)(u >> 32);
+  buf[4] = (u8)(u >> 24);
+  buf[5] = (u8)(u >> 16);
+  buf[6] = (u8)(u >> 8);
+  buf[7] = (u8)u;
+}
+
 i64 prollyNodeIntKey(const ProllyNode *pNode, int i){
   u32 off;
   const u8 *p;

--- a/src/prolly_node.h
+++ b/src/prolly_node.h
@@ -47,6 +47,12 @@ int prollyNodeSearchBlob(const ProllyNode *pNode,
 
 int prollyNodeSearchInt(const ProllyNode *pNode, i64 intKey, int *pRes);
 
+/* Encodes an i64 into the sortable 8-byte big-endian form used by
+** PROLLY_NODE_INTKEY on-disk layout (sign-flipped, so unsigned byte
+** lex order matches signed integer order). The inverse of
+** prollyNodeIntKey at the byte level. */
+void prollyEncodeIntKey(i64 v, u8 buf[8]);
+
 typedef struct ProllyNodeBuilder ProllyNodeBuilder;
 struct ProllyNodeBuilder {
   u8 level;

--- a/src/prolly_three_way_diff.c
+++ b/src/prolly_three_way_diff.c
@@ -22,16 +22,13 @@ static int diffChangeKeyCmp(
   const ProllyDiffChange *pB,
   u8 flags
 ){
-  if( flags & PROLLY_NODE_INTKEY ){
-    if( pA->intKey < pB->intKey ) return -1;
-    if( pA->intKey > pB->intKey ) return 1;
-    return 0;
-  }else{
-    int n = (pA->nKey < pB->nKey) ? pA->nKey : pB->nKey;
-    int c = memcmp(pA->pKey, pB->pKey, n);
-    if( c ) return c;
-    return pA->nKey - pB->nKey;
-  }
+  int n;
+  int c;
+  (void)flags;
+  n = (pA->nKey < pB->nKey) ? pA->nKey : pB->nKey;
+  c = memcmp(pA->pKey, pB->pKey, n);
+  if( c ) return c;
+  return pA->nKey - pB->nKey;
 }
 
 static void fillKeyFromChange(ThreeWayChange *pOut,

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -5312,7 +5312,7 @@ static int mutmapAssertMatchesModel(
     if( !prollyMutMapIterValid(&it) ) return 0;
     pEntry = prollyMutMapIterEntry(&it);
     if( !pEntry ) return 0;
-    ok = ok && pEntry->intKey==pModel->a[i].key;
+    ok = ok && prollyMutMapEntryIntKey(pEntry)==pModel->a[i].key;
     ok = ok && pEntry->op==pModel->a[i].op;
     ok = ok && ((pEntry->op==PROLLY_EDIT_DELETE)
              || (pEntry->nVal==(int)sizeof(int) && memcmp(pEntry->pVal, &pModel->a[i].val, sizeof(int))==0));


### PR DESCRIPTION
## TL;DR

Two layered changes:

1. **`a19009e0d`** drops the per-shape strategy heuristic in `prollyMutateFlush` and routes all flushes through `streamingMerge`. **This is where the perf win lives.** On real bahaiwritings history: 18× faster on the worst commit (75.14s → 4.26s on a 36K-row bulk INSERT into a populated TEXT-PK table), -22% aggregate chunk-apply time across the full 780-commit replay.

2. **The remaining 6 commits** unify the residual INT-vs-BLOB code-path divergence in mutmap, flush, diff, three-way diff, and cursor seek into a single byte-uniform path. Real structural cleanup (~250 lines net, 173 → 84 lines containing `isIntKey`/`PROLLY_NODE_INTKEY`/`intKey`) but contributes only ~5% incremental on aggregate chunk-apply and ~1% on worst case — basically noise on perf, real value as cleanup.

The two are bundled because the byte-uniform path was originally motivated as the structural foundation Tim asked for ("there is no reason INT keys should be treated differently than other keys") and the strategy-drop wanted that foundation to land alongside it. They can be split into separate PRs if preferred.

## Headline measurement: full bahaiwritings replay (780 commits, real production history, three-way bench)

| Metric | master | a19009e0d only | this branch | strategy-drop alone | unification incremental |
|---|---:|---:|---:|---:|---:|
| Chunk apply max | 75.14s | 4.26s | 4.13s | **17.6× faster** | 1.03× faster |
| Chunk apply total | 326.1s | 252.9s | 239.3s | **-22%** | -5% |
| Chunk apply mean | 0.99s | 0.77s | 0.73s | -22% | -5% |
| dolt_commit total | 427.8s | (similar) | 423.7s | within noise | within noise |
| Wall time | 25.5min | 25.1min | 24.3min | -1.7% | -3.1% |
| Final DB size | 1.366GB | 1.366GB | 1.366GB | identical | identical |

The 75-second outlier on master is commit `i9u99ijkv6`: *\"Add 36K writing entries from bahaiprayers.net API\"* — bulk INSERT into a populated TEXT-PK table. Master's chunker hits the old `edits > 1% of leaves → mergeWalk` heuristic and spends 75 seconds; the strategy-drop sends it through streamingMerge in 4.26.

## Why three-way bench, and what it caught

I initially attributed the 18× to the byte-uniform unification work in this PR's description. A code-review subagent proposed the falsifying experiment: build a third binary at `a19009e0d` only (no unification commits), run i9u99ijkv6 on it. If the strategy-drop alone produces 4s, the unification isn't where the perf came from. It does. So the headline attribution had to be corrected.

The unification work was correct framing of the broader code health goal (Tim's parity mission) but it doesn't produce the perf number. It produces the *structural* result: 173 → 84 lines of `isIntKey`/`PROLLY_NODE_INTKEY`/`intKey` across the prolly tree files, single byte-uniform code path through mutmap/flush/diff/cursor.

## Why synthetic micro-benches missed this

Earlier in this PR's history I A/B'd master vs branch on synthetic linear-INSERT workloads at 10K / 50K / 100K rows. Numbers came out close to noise, with parity actually 25-29% slower on the small synthetics. I (wrongly) concluded the cleanup had no perf benefit.

The cause: empty-table linear inserts hit a fast path that bypasses the mutmap-flush merge entirely. The strategy heuristic is never tripped because the tree has no leaves. Real-world commits that merge new data into populated trees DO hit it, and that's where the 17.6× shows up. The bahaiwritings replay against real history is the only measurement that exposed this.

## What this PR actually does (structural)

Drops 89 lines containing `isIntKey` / `intKey` / `PROLLY_NODE_INTKEY` (155 → 76 lines containing one or more occurrences; 173 → 84 raw occurrences). The remaining occurrences are mostly:
- Function parameter signatures still passing `isIntKey`/`intKey` (cosmetic — values flow through one code path now)
- Dead helpers (`prollyNodeSearchInt`, `prollyCompareKeys`) kept for API stability
- Type-flag constants and comments

| Layer | Before | After |
|---|---|---|
| Strategy choice in flush | Heuristic: `edits > 1% of leaves → mergeWalk; else streamingMerge` | Always streamingMerge |
| Mutmap storage | INT path stored i64 + maybe bytes; BLOB path stored bytes | One byte path; INT keys encoded sortably at API entry |
| Mutmap compare / hash | Branched on `isIntKey` | Lexicographic memcmp / FNV-1a over bytes |
| Streaming-merge flush | Decoded INT to i64 per key, re-encoded to bytes for chunker | Pass-through bytes |
| Diff walker compare | Branched per-flag | One byte path |
| Diff emit | Branched per-flag, filled either intKey or pKey | Helper fills both for INT mode (consumer compat) |
| Three-way diff compare | Branched per-flag | One byte path |
| Cursor seek (INT) | Separate descent + `prollyNodeSearchInt` at every level | 4-line wrapper around `SeekBlob` over encoded form |

Plus a tightening commit (`a08d34b91`): `prepKey`'s contract is now `assert(intKey == 0)` when caller passes pre-encoded bytes, so the convention becomes enforceable rather than convention-by-comment. Caught by the same code-review subagent pass.

## Methodology notes

- All three binaries built from this checkout (master at `dff55e83f`, intermediate at `a19009e0d`, branch at `a08d34b91`)
- Replays run on the real bahaiwritings DB (780 commits, table=writings, defaults), measured from same dolt-replay invocation
- Final databases byte-identical across all three (1,365,849,745 bytes), confirming the structural changes don't alter on-disk output
- Three-way bench was suggested by an independent code-review pass that flagged the original \"18× from unification\" attribution as not isolating the variable

## Commits

```
a08d34b91 prolly_mutmap, prolly_mutate: tighten prepKey contract, drop dead var
c28d0bc56 prolly_cursor: prollyCursorSeekInt becomes wrapper around SeekBlob
0470cd412 prolly_diff: byte-uniform emit, three_way_diff: byte-uniform compare
cd42cad86 prolly_diff: byte-uniform key comparison
76ff4f3c3 prolly_mutate: byte-uniform flush path, drop INTKEY branches
066c7001d prolly_mutmap: drop intKey field from ProllyMutMapEntry
3ce9caa91 prolly_mutmap: byte-uniform internal storage and comparison
a19009e0d prolly_mutate: drop strategy heuristic, always streamingMerge   ← perf source
```

## Test plan

- [x] Build clean (no new warnings)
- [x] Negative-key correctness (5K rows + negative INT keys): inserts, point lookups, range scans, IN with negatives, UPDATEs and DELETEs across negative ranges, commit round-trip
- [x] Edge i64 values (INT64_MIN, INT64_MAX, 0, -1, 1): sortable BE encoding sorts correctly across full range
- [x] dolt_diff_t / dolt_diff_s: 2-commit diff with negative INT keys produces correct add/modify/remove
- [x] dolt_merge: 3-way merge across feature/main divergence reconciles correctly
- [x] Cursor seek (5K rows + negatives): point lookups for positive and negative IDs, range scans
- [x] **Full bahaiwritings replay, three-way (master / a19009e0d-only / branch): properly attributes the 17.6× win to the strategy-drop commit; final DBs byte-identical across all three**

## What's NOT done

- API parameter signatures (`isIntKey` / `intKey` args) still exist for source compat — could be cleaned up in a follow-up; doesn't affect behavior
- Dead helpers (`prollyNodeSearchInt`, `prollyCompareKeys`) still exported; can be removed once you're confident no external consumers depend on them
- No sysbench rerun yet — sysbench's int-pk-only-update workload may not exercise the merge path; the bahaiwritings replay is the load-bearing measurement

## Recommendation

Take the strategy-drop commit unconditionally — the perf number on real workloads is real and large. The unification work is independent value (structural cleanup that makes future prolly tree work safer to reason about) and can be evaluated on its own merits; it doesn't move perf measurably but does shrink the surface area substantially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)