### PR TITLE
ci: fire workflows on every PR regardless of base branch

### DIFF
--- a/.github/workflows/benchmark-extra.yml
+++ b/.github/workflows/benchmark-extra.yml
@@ -9,7 +9,6 @@ on:
   push:
     branches: [master]
   pull_request:
-    branches: [master]
 
 permissions:
   contents: read

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [master]
   pull_request:
-    branches: [master]
 
 permissions:
   contents: read

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [master]
   pull_request:
-    branches: [master]
 
 jobs:
   asan-ubsan:

--- a/.github/workflows/sqllogictest.yml
+++ b/.github/workflows/sqllogictest.yml
@@ -3,7 +3,6 @@ name: SQL Logic Test
 on:
   workflow_dispatch:
   pull_request:
-    branches: [master]
 
 jobs:
   sqllogictest:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [master]
   pull_request:
-    branches: [master]
 
 jobs:
   build-and-test:

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -2,7 +2,6 @@ name: Wasm Build
 
 on:
   pull_request:
-    branches: [master]
   push:
     branches: [master]
   workflow_dispatch:


### PR DESCRIPTION
## Why

External contributor PR #729 silently got no CI runs because its base was a (now-deleted) feature branch instead of master, and every workflow was gated on \`pull_request: branches: [master]\`. PRs targeting any other branch produced zero checks — easy to miss, hard to debug.

## Fix

Drop \`branches: [master]\` from \`pull_request:\` triggers in all six workflows (benchmark, benchmark-extra, sanitizers, sqllogictest, test, wasm). \`push:\` triggers stay master-only — we don't want every random branch push to consume CI minutes.

## Test plan
- [ ] CI runs on this PR (validates that the change applies to itself)
- [ ] Retarget #729 to master and confirm its checks fire after this lands