### PR TITLE
benchmark-extra: enforce 2× ceiling on TEXT PK file-backed sections

### DIFF
--- a/.github/workflows/benchmark-extra.yml
+++ b/.github/workflows/benchmark-extra.yml
@@ -45,11 +45,26 @@ jobs:
         make DOLTLITE_PROLLY=0 sqlite3
 
     - name: Run benchmarks
+      id: bench
       run: |
         cd build
+        # textpk script now enforces a 2× ceiling; capture its rc so we
+        # can propagate it after the PR-comment step. Autocommit run is
+        # reporting-only (sysbench_compare.sh skips ceiling on autocommit).
+        set +e
         bash ../test/sysbench_compare_textpk.sh > /tmp/bench_textpk_results.md
+        textpk_rc=$?
         BENCH_SECTION_MODE=autocommit bash ../test/sysbench_compare.sh > /tmp/bench_autocommit_results.md
-        cat /tmp/bench_textpk_results.md /tmp/bench_autocommit_results.md | tee /tmp/bench_textpk_results.md
+        ac_rc=$?
+        set -e
+        # Concatenate into the file the comment step reads from, then
+        # echo to the job log so results are visible on red builds.
+        cat /tmp/bench_textpk_results.md /tmp/bench_autocommit_results.md > /tmp/bench_combined.md
+        mv /tmp/bench_combined.md /tmp/bench_textpk_results.md
+        cat /tmp/bench_textpk_results.md
+        bench_rc=$textpk_rc
+        if [ "$bench_rc" = "0" ]; then bench_rc=$ac_rc; fi
+        echo "bench_rc=$bench_rc" >> "$GITHUB_OUTPUT"
 
     - name: Comment PR with results
       continue-on-error: true
@@ -93,3 +108,11 @@ jobs:
               body: body,
             });
           }
+
+    - name: Enforce ceiling
+      run: |
+        rc="${{ steps.bench.outputs.bench_rc }}"
+        if [ "$rc" != "0" ]; then
+          echo "Benchmark exceeded performance ceiling (rc=$rc)" >&2
+          exit "$rc"
+        fi

--- a/test/sysbench_compare_textpk.sh
+++ b/test/sysbench_compare_textpk.sh
@@ -11,14 +11,16 @@
 # path, and full-scale R blows the CI 15-minute budget in the prepare phase
 # alone.
 #
-# No ceiling enforcement — this suite is reporting-only until the perf work
-# brings the ratios in.
+# Ceiling enforced at BENCH_MAX_MULTIPLIER (default 2×) on file-backed
+# reads + writes (wrapped) and autocommit writes. In-memory and reads-
+# in-autocommit are reporting-only.
 #
 set -e
 
 DOLTLITE=${DOLTLITE:-./doltlite}
 SQLITE3=${SQLITE3:-./sqlite3}
 ROWS=${BENCH_ROWS:-1000}
+BENCH_MAX_MULTIPLIER=${BENCH_MAX_MULTIPLIER:-2}
 SEED=42
 TMPDIR=$(mktemp -d)
 
@@ -480,7 +482,8 @@ echo "## Sysbench-Style Benchmark (TEXT PK): Doltlite vs SQLite"
 echo ""
 echo "_Companion to the classic Sysbench-Style Benchmark. Every workload here"
 echo "runs against tables with a 32-char hex \`TEXT PRIMARY KEY\` (UUID-shaped)._"
-echo "_Reporting only — not gated by a ceiling check._"
+echo "_File-backed sections gated at ${BENCH_MAX_MULTIPLIER}× — in-memory_"
+echo "_and autocommit reads are reporting-only._"
 echo ""
 echo "### In-Memory"
 echo ""
@@ -522,3 +525,43 @@ run_section "$WRITE_TESTS_AC" "/tmp/bench_file" "/tmp/bench_file"
 
 echo ""
 echo "_${ROWS} rows, single CLI invocation per test, workload-only timing via SQL timestamps._"
+
+# ============================================================
+# Enforce performance ceiling — gates the same shape sysbench_compare.sh
+# does (file-backed wrapped reads + writes, plus autocommit writes), so
+# a regression on TEXT PK shows up as a CI failure.
+# ============================================================
+check_ceiling() {
+  local tests="$1" db_sq="$2" db_dl="$3" max="$4"
+  local failed=0
+  for t in $tests; do
+    s=$(run_bench_stable "$t" sqlite "$SQLITE3" "$TMPDIR/$t.sql" "$db_sq")
+    d=$(run_bench_stable "$t" doltlite "$DOLTLITE" "$TMPDIR/$t.sql" "$db_dl")
+    if [ "$s" -gt 0 ] 2>/dev/null && [ "$d" -ge 0 ] 2>/dev/null; then
+      over=$(python3 -c "r=$d/$s; print(1 if r>$max else 0)")
+      if [ "$over" = "1" ]; then
+        ratio=$(python3 -c "print(f'{$d/$s:.2f}')")
+        echo "FAIL: $t = ${ratio}x (ceiling: ${max}x)" >&2
+        failed=1
+      fi
+    fi
+  done
+  return $failed
+}
+
+echo ""
+echo "### Performance Ceiling Check (${BENCH_MAX_MULTIPLIER}x)"
+echo ""
+
+ceiling_ok=0
+check_ceiling "$READ_TESTS"     "/tmp/bench_file" "/tmp/bench_file" "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
+check_ceiling "$WRITE_TESTS"    "/tmp/bench_file" "/tmp/bench_file" "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
+check_ceiling "$WRITE_TESTS_AC" "/tmp/bench_file" "/tmp/bench_file" "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
+
+if [ "$ceiling_ok" = "0" ]; then
+  echo "All tests within ceilings."
+else
+  echo ""
+  echo "**FAILED**: One or more tests exceeded their ceiling."
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Gate the TEXT PK sysbench file-backed sections at 2× sqlite, matching the headline 0.9.3 result.
- File-Backed wrapped reads + writes + autocommit writes are gated. In-memory and autocommit reads stay reporting-only.
- Workflow had the same `... | tee` exit-code masking that `benchmark.yml` had — fixed the same way.

## Test plan

- [ ] `bash test/sysbench_compare_textpk.sh` exits 0 on master tip (locally: all sections within 2×).
- [ ] `BENCH_MAX_MULTIPLIER=0.5 bash test/sysbench_compare_textpk.sh` exits 1 (locally verified).
- [ ] CI benchmark-extra job goes red if a future PR regresses TEXT PK file-backed wrapped writes past 2×.

🤖 Generated with [Claude Code](https://claude.com/claude-code)