### PR TITLE
Fix shared mutmap cleanup gaps

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -1616,15 +1616,9 @@ static int captureSavepointTables(
 
 static void pushSavepointOnMutMaps(Btree *pBtree, int level){
   int k;
-  BtCursor *p;
   for(k=0; k<pBtree->cat.n; k++){
     ProllyMutMap *pMap = (ProllyMutMap*)pBtree->cat.a[k].pPending;
     if( pMap ) prollyMutMapPushSavepoint(pMap, level);
-  }
-  for(p = pBtree->pBt->pCursor; p; p = p->pNext){
-    if( p->pBtree==pBtree && p->pMutMap ){
-      prollyMutMapPushSavepoint(p->pMutMap, level);
-    }
   }
 }
 
@@ -1729,7 +1723,6 @@ static int inheritPendingSnapshots(
 static int rollbackMutMapsToSavepoint(Btree *pBtree, int level,
                                        int iFromSavepoint){
   int k, rc;
-  BtCursor *p;
   for(k=0; k<pBtree->cat.n; k++){
     struct TableEntry *pTE = &pBtree->cat.a[k];
     ProllyMutMap *pMap = (ProllyMutMap*)pTE->pPending;
@@ -1752,26 +1745,14 @@ static int rollbackMutMapsToSavepoint(Btree *pBtree, int level,
       if( rc!=SQLITE_OK ) return rc;
     }
   }
-  for(p = pBtree->pBt->pCursor; p; p = p->pNext){
-    if( p->pBtree==pBtree && p->pMutMap ){
-      rc = prollyMutMapRollbackToSavepoint(p->pMutMap, level);
-      if( rc!=SQLITE_OK ) return rc;
-    }
-  }
   return SQLITE_OK;
 }
 
 static void releaseMutMapsToSavepoint(Btree *pBtree, int level){
   int k;
-  BtCursor *p;
   for(k=0; k<pBtree->cat.n; k++){
     ProllyMutMap *pMap = (ProllyMutMap*)pBtree->cat.a[k].pPending;
     if( pMap ) prollyMutMapReleaseSavepoint(pMap, level);
-  }
-  for(p = pBtree->pBt->pCursor; p; p = p->pNext){
-    if( p->pBtree==pBtree && p->pMutMap ){
-      prollyMutMapReleaseSavepoint(p->pMutMap, level);
-    }
   }
 }
 
@@ -3418,7 +3399,6 @@ static int prollyBtreeCursor(
 ){
   BtShared *pBt = p->pBt;
   struct TableEntry *pTE;
-  int hasPeerCursor = 0;
 
   assert( p->inTrans>=TRANS_READ );
 
@@ -3443,19 +3423,6 @@ static int prollyBtreeCursor(
     pCur->curFlags = BTCF_WriteFlag;
   }
 
-
-  /* Per-table mutmap: peer cursors all alias the same pTE->pPending.
-  ** The old per-cursor flush of every peer (to make their edits
-  ** visible to the new cursor's reads) is redundant. */
-  {
-    BtCursor *pOther;
-    for(pOther = pBt->pCursor; pOther; pOther = pOther->pNext){
-      if( pOther->pgnoRoot==iTable ){
-        hasPeerCursor = 1;
-        break;
-      }
-    }
-  }
   /* Per-table mutmap: pTE->pPending is the canonical edit buffer
   ** owned by pTE for the lifetime of the transaction. The new cursor
   ** simply aliases the existing buffer (no ownership transfer). The

--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -793,6 +793,7 @@ int prollyMutMapClone(ProllyMutMap **out, const ProllyMutMap *src){
   dst->orderDirty = src->orderDirty;
   dst->levelBase = src->levelBase;
   dst->currentSavepointLevel = src->currentSavepointLevel;
+  dst->generation = src->generation;
 
   if( src->nEntries > 0 ){
     dst->aEntries = (ProllyMutMapEntry*)sqlite3_malloc(

--- a/src/prolly_mutmap.h
+++ b/src/prolly_mutmap.h
@@ -61,9 +61,8 @@ struct ProllyMutMap {
   ** entries). NOT bumped by in-place value updates or savepoint
   ** release (which only relabels bornAt). Cursors snapshot this value
   ** when they record an mmIdx, then re-resolve their position by key
-  ** if the snapshot is stale. Staleness is impossible while the
-  ** mutmap has a single owning cursor (today's per-cursor model) but
-  ** matters once the mutmap is shared across cursors. */
+  ** if the snapshot is stale. This matters now that per-table mutmaps
+  ** are shared across cursors. */
   u32 generation;
 };
 


### PR DESCRIPTION
This cleans up a few loose ends from the shared mutmap / text-key performance work.

## What changed
- remove duplicate savepoint push / rollback / release walks over cursor aliases now that per-table mutmaps are shared
- remove dead peer-cursor detection left over from the pre-shared-mutmap cursor-open path
- preserve `generation` in `prollyMutMapClone()` so cloned mutmaps fully copy stale-position invalidation state
- update the stale `generation` comment to describe the current shared-mutmap model

## Verification
- `bash test/doltlite_savepoint.sh ./doltlite`
- `bash test/review_regression_test.sh`