### PR TITLE
Clean up prolly and chunk store cruft

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -141,6 +141,8 @@ static int csReplayWal(ChunkStore *cs);
 static void csFreeRefsState(ChunkStore *cs);
 static int csDeserializeRefsIntoTemp(ChunkStore *pTmp, const u8 *data, int nData);
 static void csAdoptRefsState(ChunkStore *pDst, ChunkStore *pSrc);
+static int csReplaceRefsStateFromBlob(ChunkStore *cs, const u8 *data, int nData,
+                                      int markCommitted);
 static int csReloadFromDisk(ChunkStore *cs);
 static int csDetectExternalChanges(ChunkStore *cs, int *pChanged);
 
@@ -896,6 +898,8 @@ static int csReplayWal(ChunkStore *cs){
   int haveTmpRefs = 0;
   int rc = SQLITE_OK;
 
+  memset(&tmpRefs, 0, sizeof(tmpRefs));
+
   csCaptureReplayState(cs, &saved);
 
   if( cs->iWalOffset <= 0 || !cs->pFile ) return SQLITE_OK;
@@ -1046,10 +1050,9 @@ static int csReplayWal(ChunkStore *cs){
     int nRefsData = 0;
     int rc2 = chunkStoreGet(cs, &cs->refsHash, &refsData, &nRefsData);
     if( rc2==SQLITE_OK && refsData ){
-      rc2 = csDeserializeRefsIntoTemp(&tmpRefs, refsData, nRefsData);
+      rc2 = csReplaceRefsStateFromBlob(&tmpRefs, refsData, nRefsData, 0);
       sqlite3_free(refsData);
       if( rc2!=SQLITE_OK ){
-        csFreeRefsState(&tmpRefs);
         rc = rc2;
         goto replay_error;
       }
@@ -1841,7 +1844,12 @@ static void csAdoptRefsState(ChunkStore *pDst, ChunkStore *pSrc){
   pSrc->nTracking = 0;
 }
 
-int chunkStoreLoadRefsFromBlob(ChunkStore *cs, const u8 *data, int nData){
+static int csReplaceRefsStateFromBlob(
+  ChunkStore *cs,
+  const u8 *data,
+  int nData,
+  int markCommitted
+){
   ChunkStore tmp;
   int rc = csDeserializeRefsIntoTemp(&tmp, data, nData);
   if( rc!=SQLITE_OK ){
@@ -1850,8 +1858,14 @@ int chunkStoreLoadRefsFromBlob(ChunkStore *cs, const u8 *data, int nData){
   }
   csFreeRefsState(cs);
   csAdoptRefsState(cs, &tmp);
-  csMarkRefsCommitted(cs);
+  if( markCommitted ){
+    csMarkRefsCommitted(cs);
+  }
   return SQLITE_OK;
+}
+
+int chunkStoreLoadRefsFromBlob(ChunkStore *cs, const u8 *data, int nData){
+  return csReplaceRefsStateFromBlob(cs, data, nData, 1);
 }
 
 int chunkStoreSerializeRefsToBlob(ChunkStore *cs, u8 **ppOut, int *pnOut){
@@ -2302,7 +2316,6 @@ void chunkStoreClearRefs(ChunkStore *cs){
 int chunkStoreReloadRefs(ChunkStore *cs){
   u8 *refsData = 0;
   int nRefsData = 0;
-  ChunkStore tmp;
   int rc;
 
   if( prollyHashIsEmpty(&cs->refsHash) ) return SQLITE_OK;
@@ -2310,16 +2323,9 @@ int chunkStoreReloadRefs(ChunkStore *cs){
   rc = chunkStoreGet(cs, &cs->refsHash, &refsData, &nRefsData);
   if( rc!=SQLITE_OK ) return rc;
 
-  rc = csDeserializeRefsIntoTemp(&tmp, refsData, nRefsData);
+  rc = csReplaceRefsStateFromBlob(cs, refsData, nRefsData, 0);
   sqlite3_free(refsData);
-  if( rc!=SQLITE_OK ){
-    csFreeRefsState(&tmp);
-    return rc;
-  }
-
-  csFreeRefsState(cs);
-  csAdoptRefsState(cs, &tmp);
-  return SQLITE_OK;
+  return rc;
 }
 
 const char *chunkStoreFilename(ChunkStore *cs){

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -374,6 +374,8 @@ static void getCursorPayload(BtCursor *pCur, const u8 **ppData, int *pnData);
 static int flushIfNeeded(BtCursor *pCur);
 static int flushAllPending(BtShared *pBt, Pgno iTable);
 static int applyMutMapToTableRoot(BtShared *pBt, struct TableEntry *pTE, ProllyMutMap *pMap);
+static int flushPendingForTable(Btree *pBtree, BtShared *pBt,
+                                struct TableEntry *pTE, int clearInPlace);
 static int cacheCursorPayloadCopy(BtCursor *pCur, const u8 *pData, int nData);
 static int serializeUnpackedRecordBuffer(
   UnpackedRecord *pRec, u8 **ppBuf, int *pnAlloc, int *pnOut
@@ -417,10 +419,6 @@ static int btreeLoadWorkingSetBlob(
   ProllyHash *pConstraintViolations
 );
 
-static int canReadCursorOwnPending(BtShared *pBt, struct TableEntry *pTE){
-  if( !pBt || !pBt->db || !pTE || !pTE->zName ) return 0;
-  return sqlite3ShadowTableName(pBt->db, pTE->zName)==0;
-}
 static int btreeStoreWorkingSetBlob(
   ChunkStore *cs,
   const char *zBranch,
@@ -1299,50 +1297,45 @@ static int flushMutMap(BtCursor *pCur){
   return SQLITE_OK;
 }
 
-static int flushOtherCursorPending(BtCursor *pCur){
-  struct TableEntry *pTE;
-  BtCursor *p;
+static int flushPendingForTable(
+  Btree *pBtree,
+  BtShared *pBt,
+  struct TableEntry *pTE,
+  int clearInPlace
+){
+  ProllyMutMap *pMap;
+  ProllyMutMap *pFlushMap;
+  int captured = 0;
   int rc;
 
-  pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
-  if( pTE && pTE->pPending ){
-    ProllyMutMap *pMap = (ProllyMutMap*)pTE->pPending;
-    if( !prollyMutMapIsEmpty(pMap) ){
-      ProllyMutMap *pFlushMap = pMap;
-      int captured = 0;
-      rc = snapshotPendingForFlush(pCur->pBtree, pCur->pgnoRoot,
-                                   (ProllyMutMap**)&pTE->pPending,
-                                   &pFlushMap, &captured);
-      if( rc!=SQLITE_OK ) return rc;
-      rc = applyMutMapToTableRoot(pCur->pBt, pTE, pFlushMap);
-      if( rc!=SQLITE_OK ) return rc;
-    }
-    if( pTE->pPending==pMap ){
-      /* Free the now-applied buffer; all cursors that aliased it
-      ** need their alias cleared so they don't dereference freed
-      ** memory on next access. */
+  if( !pTE || !pTE->pPending ) return SQLITE_OK;
+  pMap = (ProllyMutMap*)pTE->pPending;
+  if( prollyMutMapIsEmpty(pMap) ) return SQLITE_OK;
+
+  pFlushMap = pMap;
+  rc = snapshotPendingForFlush(pBtree, pTE->iTable,
+                               (ProllyMutMap**)&pTE->pPending,
+                               &pFlushMap, &captured);
+  if( rc!=SQLITE_OK ) return rc;
+  if( captured ){
+    refreshCursorMutMapAliases(pBt, pTE->iTable,
+                               (ProllyMutMap*)pTE->pPending);
+  }
+
+  rc = applyMutMapToTableRoot(pBt, pTE, pFlushMap);
+  if( rc!=SQLITE_OK ) return rc;
+
+  if( pTE->pPending==pMap ){
+    if( clearInPlace ){
+      prollyMutMapClear(pMap);
+    }else{
       prollyMutMapFree(pMap);
       sqlite3_free(pMap);
       pTE->pPending = 0;
-      refreshCursorMutMapAliases(pCur->pBt, pCur->pgnoRoot, 0);
-    }else{
-      /* snapshotPendingForFlush captured pMap into a savepoint and
-      ** swapped in a fresh empty map; refresh aliases to point at
-      ** the new map. */
-      refreshCursorMutMapAliases(pCur->pBt, pCur->pgnoRoot,
-                                 (ProllyMutMap*)pTE->pPending);
-    }
-    pTE->pendingFlushSeekEdits = 0;
-  }
-
-  /* Invalidate other cursors' tree-side state — the underlying tree
-  ** root just changed. The shared mutmap alias is already correct
-  ** (refreshed above). */
-  for(p = pCur->pBt->pCursor; p; p = p->pNext){
-    if( p!=pCur && p->pgnoRoot==pCur->pgnoRoot ){
-      p->eState = CURSOR_INVALID;
+      refreshCursorMutMapAliases(pBt, pTE->iTable, 0);
     }
   }
+  pTE->pendingFlushSeekEdits = 0;
   return SQLITE_OK;
 }
 
@@ -3730,34 +3723,7 @@ static int mergeLast(BtCursor *pCur, int *pRes){
 
 static int flushTablePending(BtCursor *pCur){
   struct TableEntry *pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
-  if( pTE && pTE->pPending ){
-    ProllyMutMap *pMap = (ProllyMutMap*)pTE->pPending;
-    if( prollyMutMapIsEmpty(pMap) ){
-      return SQLITE_OK;
-    }
-    {
-      ProllyMutMap *pFlushMap = pMap;
-      int captured = 0;
-      int rc = snapshotPendingForFlush(pCur->pBtree, pCur->pgnoRoot,
-                                       (ProllyMutMap**)&pTE->pPending,
-                                       &pFlushMap, &captured);
-      if( rc!=SQLITE_OK ) return rc;
-      if( captured ){
-        refreshCursorMutMapAliases(pCur->pBt, pCur->pgnoRoot,
-                                   (ProllyMutMap*)pTE->pPending);
-      }
-      rc = applyMutMapToTableRoot(pCur->pBt, pTE, pFlushMap);
-      if( rc!=SQLITE_OK ) return rc;
-      if( pTE->pPending==pMap ){
-        /* Not captured — pMap is still pTE->pPending. Clear in
-        ** place so cursor aliases stay valid pointing at the now-
-        ** empty buffer; saves the alias-refresh dance and avoids
-        ** any "dangling alias" race during iteration. */
-        prollyMutMapClear(pMap);
-      }
-    }
-  }
-  return SQLITE_OK;
+  return flushPendingForTable(pCur->pBtree, pCur->pBt, pTE, 1);
 }
 
 static int prollyBtCursorFirst(BtCursor *pCur, int *pRes){
@@ -4872,29 +4838,8 @@ static int flushDeferredEdits(BtShared *pBt){
     int i;
     for(i=0; i<pBtree->cat.n; i++){
       struct TableEntry *pTE = &pBtree->cat.a[i];
-      if( pTE->pPending && !prollyMutMapIsEmpty((ProllyMutMap*)pTE->pPending) ){
-        ProllyMutMap *pMap = (ProllyMutMap*)pTE->pPending;
-        ProllyMutMap *pFlushMap = pMap;
-        int captured = 0;
-        rc = snapshotPendingForFlush(pBtree, pTE->iTable,
-                                     (ProllyMutMap**)&pTE->pPending,
-                                     &pFlushMap, &captured);
-        if( rc!=SQLITE_OK ) return rc;
-        if( captured ){
-          refreshCursorMutMapAliases(pBt, pTE->iTable,
-                                     (ProllyMutMap*)pTE->pPending);
-        }
-        rc = applyMutMapToTableRoot(pBt, pTE, pFlushMap);
-        if( pTE->pPending==pMap ){
-          /* Not captured — same map applied. Free it and clear cursor
-          ** aliases that pointed at it. */
-          prollyMutMapFree(pMap);
-          sqlite3_free(pMap);
-          pTE->pPending = 0;
-          refreshCursorMutMapAliases(pBt, pTE->iTable, 0);
-        }
-        if( rc!=SQLITE_OK ) return rc;
-      }
+      rc = flushPendingForTable(pBtree, pBt, pTE, 0);
+      if( rc!=SQLITE_OK ) return rc;
     }
   }
   return rc;
@@ -5772,24 +5717,8 @@ int doltliteApplyRawRowMutation(
   if( !pTE ) return SQLITE_NOTFOUND;
 
 
-  if( pTE->pPending ){
-    ProllyMutMap *pPend = (ProllyMutMap*)pTE->pPending;
-    if( !prollyMutMapIsEmpty(pPend) ){
-      ProllyMutMap *pFlushMap = pPend;
-      int captured = 0;
-      rc = snapshotPendingForFlush(pBtree, pTE->iTable, &pTE->pPending,
-                                   &pFlushMap, &captured);
-      if( rc!=SQLITE_OK ) return rc;
-      rc = applyMutMapToTableRoot(pBt, pTE, pFlushMap);
-      if( rc!=SQLITE_OK ) return rc;
-    }
-    if( pTE->pPending==pPend ){
-      prollyMutMapFree(pPend);
-      sqlite3_free(pPend);
-      pTE->pPending = 0;
-    }
-    pTE->pendingFlushSeekEdits = 0;
-  }
+  rc = flushPendingForTable(pBtree, pBt, pTE, 0);
+  if( rc!=SQLITE_OK ) return rc;
 
   isIntKey = (pTE->flags & PROLLY_NODE_INTKEY) ? 1 : 0;
   rc = prollyMutMapInit(&mm, isIntKey);

--- a/src/prolly_mutate.c
+++ b/src/prolly_mutate.c
@@ -4,20 +4,6 @@
 #include "prolly_mutate.h"
 #include <string.h>
 
-/* Big-endian with sign bit flipped: memcmp on the encoded bytes
-** then gives correct signed ordering. */
-static void encodeI64BE(u8 *buf, i64 v){
-  u64 u = (u64)v ^ ((u64)1 << 63);
-  buf[0] = (u8)(u >> 56);
-  buf[1] = (u8)(u >> 48);
-  buf[2] = (u8)(u >> 40);
-  buf[3] = (u8)(u >> 32);
-  buf[4] = (u8)(u >> 24);
-  buf[5] = (u8)(u >> 16);
-  buf[6] = (u8)(u >> 8);
-  buf[7] = (u8)(u);
-}
-
 #define PROLLY_EST_ENTRIES_PER_LEAF 50
 
 static int compareKeys(
@@ -30,14 +16,6 @@ static int compareKeys(
   if( nKey1 < nKey2 ) return -1;
   if( nKey1 > nKey2 ) return 1;
   return 0;
-}
-
-static int feedChunker(
-  ProllyChunker *pCh,
-  const u8 *pKey, int nKey,
-  const u8 *pVal, int nVal
-){
-  return prollyChunkerAdd(pCh, pKey, nKey, pVal, nVal);
 }
 
 static int buildFromEdits(
@@ -54,8 +32,8 @@ static int buildFromEdits(
   while( prollyMutMapIterValid(&iter) ){
     ProllyMutMapEntry *pEntry = prollyMutMapIterEntry(&iter);
     if( pEntry->op==PROLLY_EDIT_INSERT ){
-      rc = feedChunker(&chunker, pEntry->pKey, pEntry->nKey,
-                       pEntry->pVal, pEntry->nVal);
+      rc = prollyChunkerAdd(&chunker, pEntry->pKey, pEntry->nKey,
+                            pEntry->pVal, pEntry->nVal);
       if( rc!=SQLITE_OK ){
         prollyChunkerFree(&chunker);
         return rc;


### PR DESCRIPTION
## Summary
- remove dead prolly helpers left behind by the shared-mutmap and unified streaming-merge transitions
- consolidate duplicated pending-flush logic in prolly_btree into one helper with explicit ownership behavior
- consolidate duplicated chunk-store refs replacement logic behind one helper used by replay, reload, and blob load paths

## Testing
- make -C /private/tmp/doltlite-master-latest -j4 doltlite
- bash test/doltlite_savepoint.sh /private/tmp/doltlite-master-latest/doltlite
- bash test/review_regression_test.sh