### PR TITLE
Tighten prolly and chunk store cleanup

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -143,6 +143,7 @@ static int csDeserializeRefsIntoTemp(ChunkStore *pTmp, const u8 *data, int nData
 static void csAdoptRefsState(ChunkStore *pDst, ChunkStore *pSrc);
 static int csReplaceRefsStateFromBlob(ChunkStore *cs, const u8 *data, int nData,
                                       int markCommitted);
+static int csEnsureDefaultBranch(ChunkStore *cs);
 static int csReloadFromDisk(ChunkStore *cs);
 static int csDetectExternalChanges(ChunkStore *cs, int *pChanged);
 
@@ -516,6 +517,14 @@ static void csFreeRefsState(ChunkStore *cs){
   cs->zDefaultBranch = 0;
 }
 
+static int csEnsureDefaultBranch(ChunkStore *cs){
+  if( !cs->zDefaultBranch ){
+    cs->zDefaultBranch = sqlite3_mprintf("main");
+    if( !cs->zDefaultBranch ) return SQLITE_NOMEM;
+  }
+  return SQLITE_OK;
+}
+
 #define CS_INIT_PENDING_ALLOC 16
 #define CS_INIT_WRITEBUF_SIZE 4096
 
@@ -576,11 +585,7 @@ static int csRestoreCommittedRefsState(ChunkStore *cs){
     csFreeTags(cs);
     csFreeRemotes(cs);
     csFreeTracking(cs);
-    if( !cs->zDefaultBranch ){
-      cs->zDefaultBranch = sqlite3_mprintf("main");
-      if( !cs->zDefaultBranch ) return SQLITE_NOMEM;
-    }
-    return SQLITE_OK;
+    return csEnsureDefaultBranch(cs);
   }
   return chunkStoreReloadRefs(cs);
 }
@@ -1067,13 +1072,8 @@ static int csReplayWal(ChunkStore *cs){
     csAdoptRefsState(cs, &tmpRefs);
     haveTmpRefs = 0;
   }
-  if( !cs->zDefaultBranch ){
-    cs->zDefaultBranch = sqlite3_mprintf("main");
-    if( !cs->zDefaultBranch ){
-      rc = SQLITE_NOMEM;
-      goto replay_error;
-    }
-  }
+  rc = csEnsureDefaultBranch(cs);
+  if( rc!=SQLITE_OK ) goto replay_error;
 
   csReleaseReplayState(cs, &saved);
   return SQLITE_OK;
@@ -1237,7 +1237,11 @@ int chunkStoreOpen(
         return rc;
       }
     }
-    if( !cs->zDefaultBranch ) cs->zDefaultBranch = sqlite3_mprintf("main");
+    rc = csEnsureDefaultBranch(cs);
+    if( rc!=SQLITE_OK ){
+      chunkStoreClose(cs);
+      return rc;
+    }
   }else{
     if( !(flags & SQLITE_OPEN_CREATE) ){
       sqlite3_free(cs->zFilename);

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -1338,7 +1338,6 @@ static int flushPendingForTable(
   pTE->pendingFlushSeekEdits = 0;
   return SQLITE_OK;
 }
-
 static int syncSavepoints(BtCursor *pCur){
   Btree *pBtree = pCur->pBtree;
   sqlite3 *db = pBtree ? pBtree->db : 0;
@@ -3721,18 +3720,12 @@ static int mergeLast(BtCursor *pCur, int *pRes){
   return mergeScan(pCur, -1, pRes);
 }
 
-static int flushTablePending(BtCursor *pCur){
-  struct TableEntry *pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
-  return flushPendingForTable(pCur->pBtree, pCur->pBt, pTE, 1);
-}
-
 static int prollyBtCursorFirst(BtCursor *pCur, int *pRes){
   int rc;
   CLEAR_CACHED_PAYLOAD(pCur);
   /* Per-table mutmap: pCur aliases pTE->pPending so other cursors'
   ** edits are immediately visible via the shared buffer. The old
-  ** flushTablePending + flushOtherCursorPending pair was the per-
-  ** cursor-visibility dance — applying pending edits to the tree
+  ** per-cursor visibility dance applied pending edits to the tree
   ** before reading. With shared mutmap there's nothing to flush:
   ** the merge cursor reads tree + pTE->pPending directly. */
   refreshCursorRoot(pCur);
@@ -5175,9 +5168,30 @@ struct Pager *sqlite3BtreePager(Btree *p){
 }
 
 static int prollyBtCursorCount(sqlite3 *db, BtCursor *pCur, i64 *pnEntry){
+  struct TableEntry *pTE;
   (void)db;
 
-  flushTablePending(pCur);
+  pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
+  if( pTE && pTE->pPending ){
+    ProllyMutMap *pMap = (ProllyMutMap*)pTE->pPending;
+    if( !prollyMutMapIsEmpty(pMap) ){
+      ProllyMutMap *pFlushMap = pMap;
+      int captured = 0;
+      int rc = snapshotPendingForFlush(pCur->pBtree, pCur->pgnoRoot,
+                                       (ProllyMutMap**)&pTE->pPending,
+                                       &pFlushMap, &captured);
+      if( rc!=SQLITE_OK ) return rc;
+      if( captured ){
+        refreshCursorMutMapAliases(pCur->pBt, pCur->pgnoRoot,
+                                   (ProllyMutMap*)pTE->pPending);
+      }
+      rc = applyMutMapToTableRoot(pCur->pBt, pTE, pFlushMap);
+      if( rc!=SQLITE_OK ) return rc;
+      if( pTE->pPending==pMap ){
+        prollyMutMapClear(pMap);
+      }
+    }
+  }
   flushIfNeeded(pCur);
   return countTreeEntries(pCur->pBtree, pCur->pgnoRoot, pnEntry);
 }


### PR DESCRIPTION
## Summary
- remove the remaining dead flush helper from prolly_btree and inline the last one-call flush wrapper
- tighten the shared-mutmap comment so it describes the current visibility model instead of deleted helper names
- factor chunk_store default-branch initialization behind one helper so replay, open, and rollback paths stop repeating it

## Testing
- make -C /private/tmp/doltlite-master-latest -j4 doltlite
- bash test/doltlite_savepoint.sh /private/tmp/doltlite-master-latest/doltlite
- bash test/review_regression_test.sh