### PR TITLE
Add DDL history independence coverage

### DIFF
--- a/src/doltlite_hashof.c
+++ b/src/doltlite_hashof.c
@@ -8,6 +8,7 @@
 #include "doltlite_internal.h"
 
 #include <string.h>
+#include <ctype.h>
 
 /* dolt_hashof(ref) → commit hash hex for the named ref. Accepts
 ** branch names, tag names, raw commit hashes, HEAD, and HEAD~N /
@@ -73,6 +74,343 @@ static int hashofTableInCatalog(
   doltliteFreeCatalog(aTables, nTables);
   if( rc!=SQLITE_OK ) return rc;
   doltliteHashToHex(&rootHash, pHex);
+  return SQLITE_OK;
+}
+
+static int ciStartsWith(const char *z, const char *zPrefix){
+  while( *zPrefix ){
+    if( sqlite3Tolower((unsigned char)*z) != sqlite3Tolower((unsigned char)*zPrefix) ){
+      return 0;
+    }
+    z++;
+    zPrefix++;
+  }
+  return 1;
+}
+
+static char *canonicalizeSchemaSql(const char *zSql, const char *zName){
+  sqlite3_str *pStr;
+  const char *z = zSql;
+  int inSingle = 0;
+  int inDouble = 0;
+  int pendingSpace = 0;
+  int rc;
+
+  if( !zSql ) return sqlite3_mprintf("");
+  pStr = sqlite3_str_new(0);
+  if( !pStr ) return 0;
+
+  if( zName && ciStartsWith(z, "CREATE TABLE") ){
+    sqlite3_str_appendall(pStr, "CREATE TABLE ");
+    sqlite3_str_appendf(pStr, "%s", zName);
+    z += 12;
+    while( *z && isspace((unsigned char)*z) ) z++;
+    if( *z=='"' || *z=='`' || *z=='[' ){
+      char end = (*z=='[') ? ']' : *z;
+      z++;
+      while( *z && *z!=end ) z++;
+      if( *z==end ) z++;
+    }else{
+      while( *z && !isspace((unsigned char)*z) && *z!='(' ) z++;
+    }
+  }else if( zName && ciStartsWith(z, "CREATE UNIQUE INDEX") ){
+    sqlite3_str_appendall(pStr, "CREATE UNIQUE INDEX ");
+    sqlite3_str_appendf(pStr, "%s", zName);
+    z += 19;
+    while( *z && isspace((unsigned char)*z) ) z++;
+    if( *z=='"' || *z=='`' || *z=='[' ){
+      char end = (*z=='[') ? ']' : *z;
+      z++;
+      while( *z && *z!=end ) z++;
+      if( *z==end ) z++;
+    }else{
+      while( *z && !isspace((unsigned char)*z) && *z!='(' ) z++;
+    }
+  }else if( zName && ciStartsWith(z, "CREATE INDEX") ){
+    sqlite3_str_appendall(pStr, "CREATE INDEX ");
+    sqlite3_str_appendf(pStr, "%s", zName);
+    z += 12;
+    while( *z && isspace((unsigned char)*z) ) z++;
+    if( *z=='"' || *z=='`' || *z=='[' ){
+      char end = (*z=='[') ? ']' : *z;
+      z++;
+      while( *z && *z!=end ) z++;
+      if( *z==end ) z++;
+    }else{
+      while( *z && !isspace((unsigned char)*z) && *z!='(' ) z++;
+    }
+  }
+
+  for(; *z; z++){
+    unsigned char c = (unsigned char)*z;
+    if( inSingle ){
+      sqlite3_str_appendchar(pStr, 1, (char)c);
+      if( c=='\'' ){
+        if( z[1]=='\'' ){
+          sqlite3_str_appendchar(pStr, 1, '\'');
+          z++;
+        }else{
+          inSingle = 0;
+        }
+      }
+      continue;
+    }
+    if( inDouble ){
+      sqlite3_str_appendchar(pStr, 1, (char)c);
+      if( c=='"' ) inDouble = 0;
+      continue;
+    }
+    if( c=='\'' ){
+      if( pendingSpace && sqlite3_str_length(pStr)>0 ){
+        sqlite3_str_appendchar(pStr, 1, ' ');
+      }
+      pendingSpace = 0;
+      inSingle = 1;
+      sqlite3_str_appendchar(pStr, 1, '\'');
+      continue;
+    }
+    if( c=='"' ){
+      if( pendingSpace && sqlite3_str_length(pStr)>0 ){
+        sqlite3_str_appendchar(pStr, 1, ' ');
+      }
+      pendingSpace = 0;
+      inDouble = 1;
+      sqlite3_str_appendchar(pStr, 1, '"');
+      continue;
+    }
+    if( isspace(c) ){
+      pendingSpace = 1;
+      continue;
+    }
+    if( c=='(' || c==')' || c==',' ){
+      pendingSpace = 0;
+      sqlite3_str_appendchar(pStr, 1, (char)c);
+      continue;
+    }
+    if( pendingSpace && sqlite3_str_length(pStr)>0 ){
+      sqlite3_str_appendchar(pStr, 1, ' ');
+    }
+    pendingSpace = 0;
+    sqlite3_str_appendchar(pStr, 1, (char)c);
+  }
+
+  rc = sqlite3_str_errcode(pStr);
+  if( rc!=SQLITE_OK ){
+    sqlite3_str_finish(pStr);
+    return 0;
+  }
+  return sqlite3_str_finish(pStr);
+}
+
+static int schemaEntryCmp(const void *a, const void *b){
+  const SchemaEntry *ea = (const SchemaEntry*)a;
+  const SchemaEntry *eb = (const SchemaEntry*)b;
+  int c;
+  const char *za = ea->zType ? ea->zType : "";
+  const char *zb = eb->zType ? eb->zType : "";
+  c = strcmp(za, zb);
+  if( c ) return c;
+  za = ea->zName ? ea->zName : "";
+  zb = eb->zName ? eb->zName : "";
+  c = strcmp(za, zb);
+  if( c ) return c;
+  za = ea->zTblName ? ea->zTblName : "";
+  zb = eb->zTblName ? eb->zTblName : "";
+  return strcmp(za, zb);
+}
+
+static int tableEntryLogicalCmp(const void *a, const void *b){
+  const struct TableEntry *ea = (const struct TableEntry *)a;
+  const struct TableEntry *eb = (const struct TableEntry *)b;
+  const char *za = ea->zName ? ea->zName : "";
+  const char *zb = eb->zName ? eb->zName : "";
+  int c;
+  if( ea->iTable==1 && eb->iTable!=1 ) return -1;
+  if( ea->iTable!=1 && eb->iTable==1 ) return 1;
+  c = (int)ea->flags - (int)eb->flags;
+  if( c ) return c;
+  c = strcmp(za, zb);
+  if( c ) return c;
+  c = memcmp(ea->root.data, eb->root.data, PROLLY_HASH_SIZE);
+  if( c ) return c;
+  c = memcmp(ea->schemaHash.data, eb->schemaHash.data, PROLLY_HASH_SIZE);
+  if( c ) return c;
+  if( ea->iTable < eb->iTable ) return -1;
+  if( ea->iTable > eb->iTable ) return 1;
+  return 0;
+}
+
+static int canonicalizeCatalogForDbHash(
+  sqlite3 *db,
+  const ProllyHash *pCatHash,
+  struct TableEntry *aTables,
+  int nTables
+){
+  ChunkStore *cs;
+  ProllyCache *cache;
+  SchemaEntry *aSchema = 0;
+  SchemaEntry *aSorted = 0;
+  int nSchema = 0;
+  int i;
+  sqlite3_str *pStr = 0;
+  char *zCanon = 0;
+  int rc;
+
+  cs = doltliteGetChunkStore(db);
+  cache = doltliteGetCache(db);
+  if( !cs || !cache ) return SQLITE_ERROR;
+
+  rc = loadSchemaFromCatalog(db, cs, cache, pCatHash, &aSchema, &nSchema);
+  if( rc!=SQLITE_OK ) return rc;
+
+  for(i=0; i<nSchema; i++){
+    if( aSchema[i].zType && strcmp(aSchema[i].zType, "table")==0 && aSchema[i].zName ){
+      struct TableEntry *pTE = doltliteFindTableByName(aTables, nTables, aSchema[i].zName);
+      if( pTE ){
+        ProllyHash h;
+        zCanon = canonicalizeSchemaSql(aSchema[i].zSql, aSchema[i].zName);
+        if( !zCanon ){
+          freeSchemaEntries(aSchema, nSchema);
+          return SQLITE_NOMEM;
+        }
+        prollyHashCompute(zCanon, (int)strlen(zCanon), &h);
+        sqlite3_free(zCanon);
+        zCanon = 0;
+        memcpy(&pTE->schemaHash, &h, sizeof(h));
+      }
+    }
+  }
+
+  if( nSchema>0 ){
+    aSorted = sqlite3_malloc64((sqlite3_uint64)nSchema * sizeof(SchemaEntry));
+    if( !aSorted ){
+      freeSchemaEntries(aSchema, nSchema);
+      return SQLITE_NOMEM;
+    }
+    memcpy(aSorted, aSchema, (sqlite3_uint64)nSchema * sizeof(SchemaEntry));
+    qsort(aSorted, nSchema, sizeof(SchemaEntry), schemaEntryCmp);
+  }
+
+  pStr = sqlite3_str_new(0);
+  if( !pStr ){
+    sqlite3_free(aSorted);
+    freeSchemaEntries(aSchema, nSchema);
+    return SQLITE_NOMEM;
+  }
+  for(i=0; i<nSchema; i++){
+    const char *zType = aSorted[i].zType ? aSorted[i].zType : "";
+    const char *zName = aSorted[i].zName ? aSorted[i].zName : "";
+    const char *zTbl = aSorted[i].zTblName ? aSorted[i].zTblName : "";
+    zCanon = canonicalizeSchemaSql(aSorted[i].zSql, aSorted[i].zName);
+    if( !zCanon ){
+      sqlite3_str_finish(pStr);
+      sqlite3_free(aSorted);
+      freeSchemaEntries(aSchema, nSchema);
+      return SQLITE_NOMEM;
+    }
+    sqlite3_str_appendf(pStr, "%s|%s|%s|%s\n", zType, zName, zTbl, zCanon);
+    sqlite3_free(zCanon);
+    zCanon = 0;
+    if( sqlite3_str_errcode(pStr)!=SQLITE_OK ){
+      sqlite3_str_finish(pStr);
+      sqlite3_free(aSorted);
+      freeSchemaEntries(aSchema, nSchema);
+      return SQLITE_NOMEM;
+    }
+  }
+  zCanon = sqlite3_str_finish(pStr);
+  pStr = 0;
+  if( !zCanon && nSchema>0 ){
+    sqlite3_free(aSorted);
+    freeSchemaEntries(aSchema, nSchema);
+    return SQLITE_NOMEM;
+  }
+
+  for(i=0; i<nTables; i++){
+    if( aTables[i].iTable==1 ){
+      ProllyHash h;
+      prollyHashCompute(zCanon ? zCanon : "", zCanon ? (int)strlen(zCanon) : 0, &h);
+      memcpy(&aTables[i].root, &h, sizeof(h));
+      memcpy(&aTables[i].schemaHash, &h, sizeof(h));
+      break;
+    }
+  }
+
+  sqlite3_free(zCanon);
+  sqlite3_free(aSorted);
+  freeSchemaEntries(aSchema, nSchema);
+  return SQLITE_OK;
+}
+
+static int canonicalizeTableNumbersForDbHash(
+  struct TableEntry *aTables,
+  int nTables
+){
+  struct TableEntry *aSorted = 0;
+  Pgno *aOldIds = 0;
+  int i;
+  Pgno iNext = 2;
+
+  if( nTables<=0 ) return SQLITE_OK;
+  aSorted = sqlite3_malloc64((sqlite3_uint64)nTables * sizeof(struct TableEntry));
+  aOldIds = sqlite3_malloc64((sqlite3_uint64)nTables * sizeof(Pgno));
+  if( !aSorted || !aOldIds ){
+    sqlite3_free(aSorted);
+    sqlite3_free(aOldIds);
+    return SQLITE_NOMEM;
+  }
+  memcpy(aSorted, aTables, (sqlite3_uint64)nTables * sizeof(struct TableEntry));
+  qsort(aSorted, nTables, sizeof(struct TableEntry), tableEntryLogicalCmp);
+
+  for(i=0; i<nTables; i++){
+    aOldIds[i] = aSorted[i].iTable;
+    if( aSorted[i].iTable==1 ) continue;
+    aSorted[i].iTable = iNext++;
+  }
+  for(i=0; i<nTables; i++){
+    int j;
+    for(j=0; j<nTables; j++){
+      if( aTables[i].iTable==aOldIds[j] ){
+        aTables[i].iTable = aSorted[j].iTable;
+        break;
+      }
+    }
+  }
+  sqlite3_free(aOldIds);
+  sqlite3_free(aSorted);
+  return SQLITE_OK;
+}
+
+static int hashofDbInCatalog(
+  sqlite3 *db,
+  const ProllyHash *pCatHash,
+  char *pHex
+){
+  struct TableEntry *aTables = 0;
+  int nTables = 0;
+  u8 *pCatData = 0;
+  int nCatData = 0;
+  ProllyHash h;
+  int rc;
+
+  rc = doltliteLoadCatalog(db, pCatHash, &aTables, &nTables, 0);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = canonicalizeCatalogForDbHash(db, pCatHash, aTables, nTables);
+  if( rc!=SQLITE_OK ){
+    doltliteFreeCatalog(aTables, nTables);
+    return rc;
+  }
+  rc = canonicalizeTableNumbersForDbHash(aTables, nTables);
+  if( rc!=SQLITE_OK ){
+    doltliteFreeCatalog(aTables, nTables);
+    return rc;
+  }
+  rc = doltliteSerializeCatalogEntries(0, aTables, nTables, &pCatData, &nCatData);
+  doltliteFreeCatalog(aTables, nTables);
+  if( rc!=SQLITE_OK ) return rc;
+  prollyHashCompute(pCatData, nCatData, &h);
+  sqlite3_free(pCatData);
+  doltliteHashToHex(&h, pHex);
   return SQLITE_OK;
 }
 
@@ -223,7 +561,11 @@ static void doltliteHashofDbFunc(sqlite3_context *ctx, int argc, sqlite3_value *
     doltliteCommitClear(&commit);
   }
 
-  doltliteHashToHex(&catHash, hex);
+  rc = hashofDbInCatalog(db, &catHash, hex);
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error(ctx, "dolt_hashof_db: catalog hash failed", -1);
+    return;
+  }
   sqlite3_result_text(ctx, hex, PROLLY_HASH_SIZE*2, SQLITE_TRANSIENT);
 }
 

--- a/src/doltlite_hashof.c
+++ b/src/doltlite_hashof.c
@@ -10,6 +10,8 @@
 #include <string.h>
 #include <ctype.h>
 
+static char *canonicalizeSchemaSql(const char *zSql, const char *zName);
+
 /* dolt_hashof(ref) → commit hash hex for the named ref. Accepts
 ** branch names, tag names, raw commit hashes, HEAD, and HEAD~N /
 ** HEAD^N shorthand — whatever doltliteResolveRef understands.
@@ -64,16 +66,58 @@ static int hashofTableInCatalog(
   char *pHex
 ){
   struct TableEntry *aTables = 0;
+  struct TableEntry *pTE = 0;
+  ChunkStore *cs;
+  ProllyCache *cache;
+  SchemaEntry *aSchema = 0;
+  SchemaEntry *pSchema = 0;
   int nTables = 0;
-  ProllyHash rootHash;
+  int nSchema = 0;
+  ProllyHash schemaHash;
+  ProllyHash tableHash;
+  u8 aBuf[PROLLY_HASH_SIZE*2];
   int rc;
 
   rc = doltliteLoadCatalog(db, pCatHash, &aTables, &nTables, 0);
   if( rc!=SQLITE_OK ) return rc;
-  rc = doltliteFindTableRootByName(aTables, nTables, zTable, &rootHash, 0);
+  pTE = doltliteFindTableByName(aTables, nTables, zTable);
+  if( !pTE ){
+    doltliteFreeCatalog(aTables, nTables);
+    return SQLITE_NOTFOUND;
+  }
+
+  cs = doltliteGetChunkStore(db);
+  cache = doltliteGetCache(db);
+  if( !cs || !cache ){
+    doltliteFreeCatalog(aTables, nTables);
+    return SQLITE_ERROR;
+  }
+
+  rc = loadSchemaFromCatalog(db, cs, cache, pCatHash, &aSchema, &nSchema);
+  if( rc!=SQLITE_OK ){
+    doltliteFreeCatalog(aTables, nTables);
+    return rc;
+  }
+  pSchema = findSchemaEntry(aSchema, nSchema, zTable);
+  if( pSchema ){
+    char *zCanon = canonicalizeSchemaSql(pSchema->zSql, pSchema->zName);
+    if( !zCanon ){
+      freeSchemaEntries(aSchema, nSchema);
+      doltliteFreeCatalog(aTables, nTables);
+      return SQLITE_NOMEM;
+    }
+    prollyHashCompute(zCanon, (int)strlen(zCanon), &schemaHash);
+    sqlite3_free(zCanon);
+  }else{
+    schemaHash = pTE->schemaHash;
+  }
+
+  memcpy(aBuf, pTE->root.data, PROLLY_HASH_SIZE);
+  memcpy(aBuf + PROLLY_HASH_SIZE, schemaHash.data, PROLLY_HASH_SIZE);
+  prollyHashCompute(aBuf, sizeof(aBuf), &tableHash);
+  freeSchemaEntries(aSchema, nSchema);
   doltliteFreeCatalog(aTables, nTables);
-  if( rc!=SQLITE_OK ) return rc;
-  doltliteHashToHex(&rootHash, pHex);
+  doltliteHashToHex(&tableHash, pHex);
   return SQLITE_OK;
 }
 
@@ -417,16 +461,23 @@ static int hashofDbInCatalog(
 /* dolt_hashof_table(name)
 ** dolt_hashof_table(name, ref)
 **
-** 1-arg form returns the current working-catalog hash of the
-** table's prolly root — so it tracks uncommitted edits via
-** doltliteFlushCatalogToHash. 2-arg form resolves the ref, loads
-** its committed catalog, and reads the table root from there.
+** 1-arg form returns a logical table identity hash for the current
+** working catalog. 2-arg form resolves the ref, loads its committed
+** catalog, and computes the same logical table identity there.
+**
+** The identity currently folds:
+**   - the table prolly root hash
+**   - the canonicalized table schema hash
+**
+** so DML-only equivalent histories and DDL-equivalent histories both
+** converge.
 **
 ** History-independence invariant: for two rowsets that reduce to
-** the same set of (key,value) pairs, this function must return
-** byte-identical hashes regardless of insert order, transient
-** deletions, commit chain, or branch. The oracle in
-** test/vc_oracle_hashof_test.sh exercises every flavour. */
+** the same set of rows and the same logical schema, this function
+** must return byte-identical hashes regardless of insert order,
+** transient deletions, commit chain, or equivalent DDL spellings.
+** The oracles in test/vc_oracle_hashof_test.sh and
+** test/history_independence_test.sh exercise those properties. */
 static void doltliteHashofTableFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db;
   const char *zTable;

--- a/test/history_independence_test.sh
+++ b/test/history_independence_test.sh
@@ -7,7 +7,7 @@
 #   identical regardless of the SQL history used to produce that state.
 #
 # Current phase:
-#   - DML only
+#   - DML and initial DDL coverage
 #   - small datasets for PR-speed baseline coverage
 #   - direct-write and branch/merge histories
 #   - key families:
@@ -21,11 +21,8 @@
 #   2. dolt_hashof_db() matches across distinct histories
 #
 # Planned expansion phases:
-#   - branch / merge histories
-#   - large database variants
-#   - .read / streamed import variants
-#   - secondary-index-heavy variants
-#   - DDL history independence
+#   - richer DDL branch / merge histories
+#   - larger DDL recreate / rename matrices
 #   - clone / fetch / push / pull histories
 #
 
@@ -278,6 +275,54 @@ run_index_case() {
   assert_hash_shape "${family}_idx_db_hash_shape_c" "$hash_c"
   assert_equal "${family}_idx_db_hash_a_vs_b" "$hash_a" "$hash_b"
   assert_equal "${family}_idx_db_hash_a_vs_c" "$hash_a" "$hash_c"
+
+  echo ""
+}
+
+run_ddl_case() {
+  local family="$1"
+  local data_sql="$2"
+  local schema_sql="$3"
+  local history_a="$4"
+  local history_b="$5"
+  local history_c="$6"
+
+  local db_a="$TMPROOT/${family}_ddl_a.db"
+  local db_b="$TMPROOT/${family}_ddl_b.db"
+  local db_c="$TMPROOT/${family}_ddl_c.db"
+
+  echo "--- $family ddl histories ---"
+
+  run_setup "$db_a" "${family}_ddl_a" "$history_a"
+  run_setup "$db_b" "${family}_ddl_b" "$history_b"
+  run_setup "$db_c" "${family}_ddl_c" "$history_c"
+
+  local data_a data_b data_c
+  data_a=$(canonical_digest "$db_a" "${family}_ddl_a_data" "$data_sql")
+  data_b=$(canonical_digest "$db_b" "${family}_ddl_b_data" "$data_sql")
+  data_c=$(canonical_digest "$db_c" "${family}_ddl_c_data" "$data_sql")
+
+  assert_equal "${family}_ddl_data_a_vs_b" "$data_a" "$data_b"
+  assert_equal "${family}_ddl_data_a_vs_c" "$data_a" "$data_c"
+
+  local schema_a schema_b schema_c
+  schema_a=$(canonical_digest "$db_a" "${family}_ddl_a_schema" "$schema_sql")
+  schema_b=$(canonical_digest "$db_b" "${family}_ddl_b_schema" "$schema_sql")
+  schema_c=$(canonical_digest "$db_c" "${family}_ddl_c_schema" "$schema_sql")
+
+  assert_equal "${family}_ddl_schema_a_vs_b" "$schema_a" "$schema_b"
+  assert_equal "${family}_ddl_schema_a_vs_c" "$schema_a" "$schema_c"
+
+  local hash_a hash_b hash_c
+  hash_a=$(db_hash "$db_a" "${family}_ddl_a_hash")
+  hash_b=$(db_hash "$db_b" "${family}_ddl_b_hash")
+  hash_c=$(db_hash "$db_c" "${family}_ddl_c_hash")
+
+  assert_hash_shape "${family}_ddl_db_hash_shape_a" "$hash_a"
+  assert_hash_shape "${family}_ddl_db_hash_shape_b" "$hash_b"
+  assert_hash_shape "${family}_ddl_db_hash_shape_c" "$hash_c"
+  assert_equal "${family}_ddl_db_hash_a_vs_b" "$hash_a" "$hash_b"
+  assert_equal "${family}_ddl_db_hash_a_vs_c" "$hash_a" "$hash_c"
 
   echo ""
 }
@@ -1314,6 +1359,276 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'final');
 " \
   "SELECT printf('%s|%d|%s|%d', a, b, v, n) FROM t INDEXED BY idx_v WHERE v IN ('v00001','v01000','v02500','v05000') ORDER BY v;"
+
+echo "--- ddl histories ---"
+
+run_ddl_case \
+  "ddl_int_pk" \
+  "SELECT printf('%d|%s|%d|%s', id, v, n, extra) FROM t ORDER BY id;" \
+  "
+SELECT printf('col|%d|%s|%s|%d|%s|%d', cid, name, type, \"notnull\", COALESCE(dflt_value,'NULL'), pk) FROM pragma_table_info('t') ORDER BY cid;
+SELECT printf('idx|%s|%d|%s|%d', name, \"unique\", origin, partial) FROM pragma_index_list('t') WHERE origin!='pk' ORDER BY name;
+SELECT printf('idxcol|idx_t_v|%d|%s', seqno, name) FROM pragma_index_info('idx_t_v') ORDER BY seqno;
+SELECT printf('idxcol|idx_t_n|%d|%s', seqno, name) FROM pragma_index_info('idx_t_n') ORDER BY seqno;
+" \
+  "
+CREATE TABLE t(
+  id INTEGER PRIMARY KEY,
+  v TEXT,
+  n INTEGER,
+  extra TEXT DEFAULT 'seed'
+);
+CREATE INDEX idx_t_v ON t(v);
+CREATE INDEX idx_t_n ON t(n);
+INSERT INTO t VALUES (1, 'alpha', 10, 'seed');
+INSERT INTO t VALUES (2, 'bravo', 20, 'seed');
+INSERT INTO t VALUES (3, 'charlie', 30, 'seed');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+" \
+  "
+CREATE TABLE t(
+  id INTEGER PRIMARY KEY,
+  v TEXT,
+  n INTEGER
+);
+INSERT INTO t(id, v, n) VALUES (1, 'alpha', 10);
+INSERT INTO t(id, v, n) VALUES (2, 'bravo', 20);
+INSERT INTO t(id, v, n) VALUES (3, 'charlie', 30);
+ALTER TABLE t ADD COLUMN extra TEXT DEFAULT 'seed';
+CREATE INDEX idx_t_v ON t(v);
+CREATE INDEX idx_t_n ON t(n);
+UPDATE t SET extra = 'seed';
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+" \
+  "
+CREATE TABLE t_old(
+  id INTEGER PRIMARY KEY,
+  v TEXT,
+  n INTEGER
+);
+INSERT INTO t_old VALUES (1, 'alpha', 10);
+INSERT INTO t_old VALUES (2, 'bravo', 20);
+INSERT INTO t_old VALUES (3, 'charlie', 30);
+CREATE TABLE t_new(
+  id INTEGER PRIMARY KEY,
+  v TEXT,
+  n INTEGER,
+  extra TEXT DEFAULT 'seed'
+);
+INSERT INTO t_new(id, v, n, extra)
+SELECT id, v, n, 'seed' FROM t_old;
+DROP TABLE t_old;
+ALTER TABLE t_new RENAME TO t;
+CREATE INDEX idx_t_v ON t(v);
+CREATE INDEX idx_t_n ON t(n);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+"
+
+run_ddl_case \
+  "ddl_text_pk" \
+  "SELECT printf('%s|%s|%d|%s', id, v, n, extra) FROM t ORDER BY id;" \
+  "
+SELECT printf('col|%d|%s|%s|%d|%s|%d', cid, name, type, \"notnull\", COALESCE(dflt_value,'NULL'), pk) FROM pragma_table_info('t') ORDER BY cid;
+SELECT printf('idx|%s|%d|%s|%d', name, \"unique\", origin, partial) FROM pragma_index_list('t') WHERE origin!='pk' ORDER BY name;
+SELECT printf('idxcol|idx_t_v|%d|%s', seqno, name) FROM pragma_index_info('idx_t_v') ORDER BY seqno;
+SELECT printf('idxcol|idx_t_n|%d|%s', seqno, name) FROM pragma_index_info('idx_t_n') ORDER BY seqno;
+" \
+  "
+CREATE TABLE t(
+  id TEXT PRIMARY KEY,
+  v TEXT,
+  n INTEGER,
+  extra TEXT DEFAULT 'seed'
+);
+CREATE INDEX idx_t_v ON t(v);
+CREATE INDEX idx_t_n ON t(n);
+INSERT INTO t VALUES ('a-key', 'alpha', 10, 'seed');
+INSERT INTO t VALUES ('b-key', 'bravo', 20, 'seed');
+INSERT INTO t VALUES ('c-key', 'charlie', 30, 'seed');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+" \
+  "
+CREATE TABLE t(
+  id TEXT PRIMARY KEY,
+  v TEXT,
+  n INTEGER
+);
+INSERT INTO t(id, v, n) VALUES ('a-key', 'alpha', 10);
+INSERT INTO t(id, v, n) VALUES ('b-key', 'bravo', 20);
+INSERT INTO t(id, v, n) VALUES ('c-key', 'charlie', 30);
+ALTER TABLE t ADD COLUMN extra TEXT DEFAULT 'seed';
+CREATE INDEX idx_t_v ON t(v);
+CREATE INDEX idx_t_n ON t(n);
+UPDATE t SET extra = 'seed';
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+" \
+  "
+CREATE TABLE t_old(
+  id TEXT PRIMARY KEY,
+  v TEXT,
+  n INTEGER
+);
+INSERT INTO t_old VALUES ('a-key', 'alpha', 10);
+INSERT INTO t_old VALUES ('b-key', 'bravo', 20);
+INSERT INTO t_old VALUES ('c-key', 'charlie', 30);
+CREATE TABLE t_new(
+  id TEXT PRIMARY KEY,
+  v TEXT,
+  n INTEGER,
+  extra TEXT DEFAULT 'seed'
+);
+INSERT INTO t_new(id, v, n, extra)
+SELECT id, v, n, 'seed' FROM t_old;
+DROP TABLE t_old;
+ALTER TABLE t_new RENAME TO t;
+CREATE INDEX idx_t_v ON t(v);
+CREATE INDEX idx_t_n ON t(n);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+"
+
+run_ddl_case \
+  "ddl_blob_pk" \
+  "SELECT printf('%s|%s|%d|%s', hex(id), v, n, extra) FROM t ORDER BY id;" \
+  "
+SELECT printf('col|%d|%s|%s|%d|%s|%d', cid, name, type, \"notnull\", COALESCE(dflt_value,'NULL'), pk) FROM pragma_table_info('t') ORDER BY cid;
+SELECT printf('idx|%s|%d|%s|%d', name, \"unique\", origin, partial) FROM pragma_index_list('t') WHERE origin!='pk' ORDER BY name;
+SELECT printf('idxcol|idx_t_v|%d|%s', seqno, name) FROM pragma_index_info('idx_t_v') ORDER BY seqno;
+SELECT printf('idxcol|idx_t_n|%d|%s', seqno, name) FROM pragma_index_info('idx_t_n') ORDER BY seqno;
+" \
+  "
+CREATE TABLE t(
+  id BLOB PRIMARY KEY,
+  v TEXT,
+  n INTEGER,
+  extra TEXT DEFAULT 'seed'
+);
+CREATE INDEX idx_t_v ON t(v);
+CREATE INDEX idx_t_n ON t(n);
+INSERT INTO t VALUES (x'01', 'alpha', 10, 'seed');
+INSERT INTO t VALUES (x'02', 'bravo', 20, 'seed');
+INSERT INTO t VALUES (x'03', 'charlie', 30, 'seed');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+" \
+  "
+CREATE TABLE t(
+  id BLOB PRIMARY KEY,
+  v TEXT,
+  n INTEGER
+);
+INSERT INTO t(id, v, n) VALUES (x'01', 'alpha', 10);
+INSERT INTO t(id, v, n) VALUES (x'02', 'bravo', 20);
+INSERT INTO t(id, v, n) VALUES (x'03', 'charlie', 30);
+ALTER TABLE t ADD COLUMN extra TEXT DEFAULT 'seed';
+CREATE INDEX idx_t_v ON t(v);
+CREATE INDEX idx_t_n ON t(n);
+UPDATE t SET extra = 'seed';
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+" \
+  "
+CREATE TABLE t_old(
+  id BLOB PRIMARY KEY,
+  v TEXT,
+  n INTEGER
+);
+INSERT INTO t_old VALUES (x'01', 'alpha', 10);
+INSERT INTO t_old VALUES (x'02', 'bravo', 20);
+INSERT INTO t_old VALUES (x'03', 'charlie', 30);
+CREATE TABLE t_new(
+  id BLOB PRIMARY KEY,
+  v TEXT,
+  n INTEGER,
+  extra TEXT DEFAULT 'seed'
+);
+INSERT INTO t_new(id, v, n, extra)
+SELECT id, v, n, 'seed' FROM t_old;
+DROP TABLE t_old;
+ALTER TABLE t_new RENAME TO t;
+CREATE INDEX idx_t_v ON t(v);
+CREATE INDEX idx_t_n ON t(n);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+"
+
+run_ddl_case \
+  "ddl_composite_pk" \
+  "SELECT printf('%s|%d|%s|%d|%s', a, b, v, n, extra) FROM t ORDER BY a, b;" \
+  "
+SELECT printf('col|%d|%s|%s|%d|%s|%d', cid, name, type, \"notnull\", COALESCE(dflt_value,'NULL'), pk) FROM pragma_table_info('t') ORDER BY cid;
+SELECT printf('idx|%s|%d|%s|%d', name, \"unique\", origin, partial) FROM pragma_index_list('t') WHERE origin!='pk' ORDER BY name;
+SELECT printf('idxcol|idx_t_v|%d|%s', seqno, name) FROM pragma_index_info('idx_t_v') ORDER BY seqno;
+SELECT printf('idxcol|idx_t_n|%d|%s', seqno, name) FROM pragma_index_info('idx_t_n') ORDER BY seqno;
+" \
+  "
+CREATE TABLE t(
+  a TEXT,
+  b INTEGER,
+  v TEXT,
+  n INTEGER,
+  extra TEXT DEFAULT 'seed',
+  PRIMARY KEY(a, b)
+);
+CREATE INDEX idx_t_v ON t(v);
+CREATE INDEX idx_t_n ON t(n);
+INSERT INTO t VALUES ('a', 1, 'alpha', 10, 'seed');
+INSERT INTO t VALUES ('b', 2, 'bravo', 20, 'seed');
+INSERT INTO t VALUES ('c', 3, 'charlie', 30, 'seed');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+" \
+  "
+CREATE TABLE t(
+  a TEXT,
+  b INTEGER,
+  v TEXT,
+  n INTEGER,
+  PRIMARY KEY(a, b)
+);
+INSERT INTO t(a, b, v, n) VALUES ('a', 1, 'alpha', 10);
+INSERT INTO t(a, b, v, n) VALUES ('b', 2, 'bravo', 20);
+INSERT INTO t(a, b, v, n) VALUES ('c', 3, 'charlie', 30);
+ALTER TABLE t ADD COLUMN extra TEXT DEFAULT 'seed';
+CREATE INDEX idx_t_v ON t(v);
+CREATE INDEX idx_t_n ON t(n);
+UPDATE t SET extra = 'seed';
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+" \
+  "
+CREATE TABLE t_old(
+  a TEXT,
+  b INTEGER,
+  v TEXT,
+  n INTEGER,
+  PRIMARY KEY(a, b)
+);
+INSERT INTO t_old VALUES ('a', 1, 'alpha', 10);
+INSERT INTO t_old VALUES ('b', 2, 'bravo', 20);
+INSERT INTO t_old VALUES ('c', 3, 'charlie', 30);
+CREATE TABLE t_new(
+  a TEXT,
+  b INTEGER,
+  v TEXT,
+  n INTEGER,
+  extra TEXT DEFAULT 'seed',
+  PRIMARY KEY(a, b)
+);
+INSERT INTO t_new(a, b, v, n, extra)
+SELECT a, b, v, n, 'seed' FROM t_old;
+DROP TABLE t_old;
+ALTER TABLE t_new RENAME TO t;
+CREATE INDEX idx_t_v ON t(v);
+CREATE INDEX idx_t_n ON t(n);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+"
 
 echo "======================================="
 echo "Results: $PASS passed, $FAIL failed"

--- a/test/history_independence_test.sh
+++ b/test/history_independence_test.sh
@@ -84,6 +84,12 @@ db_hash() {
   run_query "$db" "$name" "SELECT dolt_hashof_db();" | tr -d '\n'
 }
 
+table_hash() {
+  local db="$1"
+  local name="$2"
+  run_query "$db" "$name" "SELECT dolt_hashof_table('t');" | tr -d '\n'
+}
+
 assert_equal() {
   local name="$1"
   local a="$2"
@@ -312,6 +318,17 @@ run_ddl_case() {
 
   assert_equal "${family}_ddl_schema_a_vs_b" "$schema_a" "$schema_b"
   assert_equal "${family}_ddl_schema_a_vs_c" "$schema_a" "$schema_c"
+
+  local table_a table_b table_c
+  table_a=$(table_hash "$db_a" "${family}_ddl_a_table_hash")
+  table_b=$(table_hash "$db_b" "${family}_ddl_b_table_hash")
+  table_c=$(table_hash "$db_c" "${family}_ddl_c_table_hash")
+
+  assert_hash_shape "${family}_ddl_table_hash_shape_a" "$table_a"
+  assert_hash_shape "${family}_ddl_table_hash_shape_b" "$table_b"
+  assert_hash_shape "${family}_ddl_table_hash_shape_c" "$table_c"
+  assert_equal "${family}_ddl_table_hash_a_vs_b" "$table_a" "$table_b"
+  assert_equal "${family}_ddl_table_hash_a_vs_c" "$table_a" "$table_c"
 
   local hash_a hash_b hash_c
   hash_a=$(db_hash "$db_a" "${family}_ddl_a_hash")

--- a/test/vc_oracle_hashof_test.sh
+++ b/test/vc_oracle_hashof_test.sh
@@ -51,6 +51,10 @@
 #      altering a schema all MUST change the table hash. If
 #      they don't, the hash is stale and worthless.
 #
+#   7b. Equivalent DDL histories: if two histories converge on the
+#      same logical schema and rowset, dolt_hashof_table must also
+#      converge even if one path used ALTER or recreate/copy/rename.
+#
 #   8. Ref resolution: dolt_hashof accepts branch names, tag
 #      names, commit hashes, and HEAD~N shorthand. Missing refs
 #      return NULL or an error (we accept either, as long as it
@@ -381,6 +385,49 @@ H_ALT=$(run_hash "neg_alt" "$ALTER_SCHEMA" "SELECT dolt_hashof_table('t');")
 different "add_row_changes_table_hash"   "$H_BASE" "$H_ADD"
 different "update_cell_changes_table_hash" "$H_BASE" "$H_UPD"
 different "alter_schema_changes_table_hash" "$H_BASE" "$H_ALT"
+
+echo ""
+
+# ── 7b. Equivalent DDL histories converge ─────────────────
+echo "--- 7b. Equivalent DDL histories converge ---"
+
+DDL_DIRECT="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT, n INTEGER, extra TEXT DEFAULT 'seed');
+CREATE INDEX idx_t_v ON t(v);
+CREATE INDEX idx_t_n ON t(n);
+INSERT INTO t VALUES (1, 'one', 10, 'seed'), (2, 'two', 20, 'seed');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'direct');
+"
+
+DDL_ALTER="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT, n INTEGER);
+INSERT INTO t VALUES (1, 'one', 10), (2, 'two', 20);
+ALTER TABLE t ADD COLUMN extra TEXT DEFAULT 'seed';
+CREATE INDEX idx_t_v ON t(v);
+CREATE INDEX idx_t_n ON t(n);
+UPDATE t SET extra = 'seed';
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'alter');
+"
+
+DDL_RECREATE="
+CREATE TABLE t_old(id INTEGER PRIMARY KEY, v TEXT, n INTEGER);
+INSERT INTO t_old VALUES (1, 'one', 10), (2, 'two', 20);
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT, n INTEGER, extra TEXT DEFAULT 'seed');
+INSERT INTO t SELECT id, v, n, 'seed' FROM t_old;
+CREATE INDEX idx_t_v ON t(v);
+CREATE INDEX idx_t_n ON t(n);
+DROP TABLE t_old;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'recreate');
+"
+
+H_DDL_DIRECT=$(run_hash "ddl_direct" "$DDL_DIRECT" "SELECT dolt_hashof_table('t');")
+H_DDL_ALTER=$(run_hash "ddl_alter" "$DDL_ALTER" "SELECT dolt_hashof_table('t');")
+H_DDL_RECREATE=$(run_hash "ddl_recreate" "$DDL_RECREATE" "SELECT dolt_hashof_table('t');")
+same "ddl_direct_vs_alter_table_hash" "$H_DDL_DIRECT" "$H_DDL_ALTER"
+same "ddl_direct_vs_recreate_table_hash" "$H_DDL_DIRECT" "$H_DDL_RECREATE"
 
 echo ""
 


### PR DESCRIPTION
## Summary
- extend the history-independence suite with equivalent-DDL cases for int, text, blob, and composite PK tables
- fix `dolt_hashof_db()` so logically equivalent schema histories converge even when raw `sqlite_master` SQL text or physical root allocation differs
- keep the existing DML, branch, large, `.read`, and indexed history-independence coverage green

## Testing
- `bash test/history_independence_test.sh ./doltlite`
