### PR TITLE
Make dolt_hashof_table schema-aware

### DIFF
--- a/src/doltlite_hashof.c
+++ b/src/doltlite_hashof.c
@@ -10,6 +10,8 @@
 #include <string.h>
 #include <ctype.h>
 
+static char *canonicalizeSchemaSql(const char *zSql, const char *zName);
+
 /* dolt_hashof(ref) → commit hash hex for the named ref. Accepts
 ** branch names, tag names, raw commit hashes, HEAD, and HEAD~N /
 ** HEAD^N shorthand — whatever doltliteResolveRef understands.
@@ -64,16 +66,58 @@ static int hashofTableInCatalog(
   char *pHex
 ){
   struct TableEntry *aTables = 0;
+  struct TableEntry *pTE = 0;
+  ChunkStore *cs;
+  ProllyCache *cache;
+  SchemaEntry *aSchema = 0;
+  SchemaEntry *pSchema = 0;
   int nTables = 0;
-  ProllyHash rootHash;
+  int nSchema = 0;
+  ProllyHash schemaHash;
+  ProllyHash tableHash;
+  u8 aBuf[PROLLY_HASH_SIZE*2];
   int rc;
 
   rc = doltliteLoadCatalog(db, pCatHash, &aTables, &nTables, 0);
   if( rc!=SQLITE_OK ) return rc;
-  rc = doltliteFindTableRootByName(aTables, nTables, zTable, &rootHash, 0);
+  pTE = doltliteFindTableByName(aTables, nTables, zTable);
+  if( !pTE ){
+    doltliteFreeCatalog(aTables, nTables);
+    return SQLITE_NOTFOUND;
+  }
+
+  cs = doltliteGetChunkStore(db);
+  cache = doltliteGetCache(db);
+  if( !cs || !cache ){
+    doltliteFreeCatalog(aTables, nTables);
+    return SQLITE_ERROR;
+  }
+
+  rc = loadSchemaFromCatalog(db, cs, cache, pCatHash, &aSchema, &nSchema);
+  if( rc!=SQLITE_OK ){
+    doltliteFreeCatalog(aTables, nTables);
+    return rc;
+  }
+  pSchema = findSchemaEntry(aSchema, nSchema, zTable);
+  if( pSchema ){
+    char *zCanon = canonicalizeSchemaSql(pSchema->zSql, pSchema->zName);
+    if( !zCanon ){
+      freeSchemaEntries(aSchema, nSchema);
+      doltliteFreeCatalog(aTables, nTables);
+      return SQLITE_NOMEM;
+    }
+    prollyHashCompute(zCanon, (int)strlen(zCanon), &schemaHash);
+    sqlite3_free(zCanon);
+  }else{
+    schemaHash = pTE->schemaHash;
+  }
+
+  memcpy(aBuf, pTE->root.data, PROLLY_HASH_SIZE);
+  memcpy(aBuf + PROLLY_HASH_SIZE, schemaHash.data, PROLLY_HASH_SIZE);
+  prollyHashCompute(aBuf, sizeof(aBuf), &tableHash);
+  freeSchemaEntries(aSchema, nSchema);
   doltliteFreeCatalog(aTables, nTables);
-  if( rc!=SQLITE_OK ) return rc;
-  doltliteHashToHex(&rootHash, pHex);
+  doltliteHashToHex(&tableHash, pHex);
   return SQLITE_OK;
 }
 
@@ -417,16 +461,23 @@ static int hashofDbInCatalog(
 /* dolt_hashof_table(name)
 ** dolt_hashof_table(name, ref)
 **
-** 1-arg form returns the current working-catalog hash of the
-** table's prolly root — so it tracks uncommitted edits via
-** doltliteFlushCatalogToHash. 2-arg form resolves the ref, loads
-** its committed catalog, and reads the table root from there.
+** 1-arg form returns a logical table identity hash for the current
+** working catalog. 2-arg form resolves the ref, loads its committed
+** catalog, and computes the same logical table identity there.
+**
+** The identity currently folds:
+**   - the table prolly root hash
+**   - the canonicalized table schema hash
+**
+** so DML-only equivalent histories and DDL-equivalent histories both
+** converge.
 **
 ** History-independence invariant: for two rowsets that reduce to
-** the same set of (key,value) pairs, this function must return
-** byte-identical hashes regardless of insert order, transient
-** deletions, commit chain, or branch. The oracle in
-** test/vc_oracle_hashof_test.sh exercises every flavour. */
+** the same set of rows and the same logical schema, this function
+** must return byte-identical hashes regardless of insert order,
+** transient deletions, commit chain, or equivalent DDL spellings.
+** The oracles in test/vc_oracle_hashof_test.sh and
+** test/history_independence_test.sh exercise those properties. */
 static void doltliteHashofTableFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db;
   const char *zTable;

--- a/test/history_independence_test.sh
+++ b/test/history_independence_test.sh
@@ -84,6 +84,12 @@ db_hash() {
   run_query "$db" "$name" "SELECT dolt_hashof_db();" | tr -d '\n'
 }
 
+table_hash() {
+  local db="$1"
+  local name="$2"
+  run_query "$db" "$name" "SELECT dolt_hashof_table('t');" | tr -d '\n'
+}
+
 assert_equal() {
   local name="$1"
   local a="$2"
@@ -312,6 +318,17 @@ run_ddl_case() {
 
   assert_equal "${family}_ddl_schema_a_vs_b" "$schema_a" "$schema_b"
   assert_equal "${family}_ddl_schema_a_vs_c" "$schema_a" "$schema_c"
+
+  local table_a table_b table_c
+  table_a=$(table_hash "$db_a" "${family}_ddl_a_table_hash")
+  table_b=$(table_hash "$db_b" "${family}_ddl_b_table_hash")
+  table_c=$(table_hash "$db_c" "${family}_ddl_c_table_hash")
+
+  assert_hash_shape "${family}_ddl_table_hash_shape_a" "$table_a"
+  assert_hash_shape "${family}_ddl_table_hash_shape_b" "$table_b"
+  assert_hash_shape "${family}_ddl_table_hash_shape_c" "$table_c"
+  assert_equal "${family}_ddl_table_hash_a_vs_b" "$table_a" "$table_b"
+  assert_equal "${family}_ddl_table_hash_a_vs_c" "$table_a" "$table_c"
 
   local hash_a hash_b hash_c
   hash_a=$(db_hash "$db_a" "${family}_ddl_a_hash")

--- a/test/vc_oracle_hashof_test.sh
+++ b/test/vc_oracle_hashof_test.sh
@@ -51,6 +51,10 @@
 #      altering a schema all MUST change the table hash. If
 #      they don't, the hash is stale and worthless.
 #
+#   7b. Equivalent DDL histories: if two histories converge on the
+#      same logical schema and rowset, dolt_hashof_table must also
+#      converge even if one path used ALTER or recreate/copy/rename.
+#
 #   8. Ref resolution: dolt_hashof accepts branch names, tag
 #      names, commit hashes, and HEAD~N shorthand. Missing refs
 #      return NULL or an error (we accept either, as long as it
@@ -381,6 +385,49 @@ H_ALT=$(run_hash "neg_alt" "$ALTER_SCHEMA" "SELECT dolt_hashof_table('t');")
 different "add_row_changes_table_hash"   "$H_BASE" "$H_ADD"
 different "update_cell_changes_table_hash" "$H_BASE" "$H_UPD"
 different "alter_schema_changes_table_hash" "$H_BASE" "$H_ALT"
+
+echo ""
+
+# ── 7b. Equivalent DDL histories converge ─────────────────
+echo "--- 7b. Equivalent DDL histories converge ---"
+
+DDL_DIRECT="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT, n INTEGER, extra TEXT DEFAULT 'seed');
+CREATE INDEX idx_t_v ON t(v);
+CREATE INDEX idx_t_n ON t(n);
+INSERT INTO t VALUES (1, 'one', 10, 'seed'), (2, 'two', 20, 'seed');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'direct');
+"
+
+DDL_ALTER="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT, n INTEGER);
+INSERT INTO t VALUES (1, 'one', 10), (2, 'two', 20);
+ALTER TABLE t ADD COLUMN extra TEXT DEFAULT 'seed';
+CREATE INDEX idx_t_v ON t(v);
+CREATE INDEX idx_t_n ON t(n);
+UPDATE t SET extra = 'seed';
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'alter');
+"
+
+DDL_RECREATE="
+CREATE TABLE t_old(id INTEGER PRIMARY KEY, v TEXT, n INTEGER);
+INSERT INTO t_old VALUES (1, 'one', 10), (2, 'two', 20);
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT, n INTEGER, extra TEXT DEFAULT 'seed');
+INSERT INTO t SELECT id, v, n, 'seed' FROM t_old;
+CREATE INDEX idx_t_v ON t(v);
+CREATE INDEX idx_t_n ON t(n);
+DROP TABLE t_old;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'recreate');
+"
+
+H_DDL_DIRECT=$(run_hash "ddl_direct" "$DDL_DIRECT" "SELECT dolt_hashof_table('t');")
+H_DDL_ALTER=$(run_hash "ddl_alter" "$DDL_ALTER" "SELECT dolt_hashof_table('t');")
+H_DDL_RECREATE=$(run_hash "ddl_recreate" "$DDL_RECREATE" "SELECT dolt_hashof_table('t');")
+same "ddl_direct_vs_alter_table_hash" "$H_DDL_DIRECT" "$H_DDL_ALTER"
+same "ddl_direct_vs_recreate_table_hash" "$H_DDL_DIRECT" "$H_DDL_RECREATE"
 
 echo ""
 


### PR DESCRIPTION
## Summary
- make `dolt_hashof_table()` hash both table data and canonicalized table schema
- extend the history-independence suite so DDL-equivalent histories also assert table-hash convergence
- add focused `dolt_hashof_table()` oracle coverage for equivalent DDL histories

## Testing
- `bash test/vc_oracle_hashof_test.sh ./doltlite`
- `bash test/history_independence_test.sh ./doltlite`
