### PR TITLE
npm: Node.js native binding (better-sqlite3-style API)

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -1,0 +1,71 @@
+name: NPM Native Binding
+
+# Verifies the npm/ Node native binding builds and the smoke test
+# passes on each supported platform. Also runs on PR so we know if
+# a doltlite-side change broke the binding ABI.
+#
+# Does NOT publish to npm — that's a manual step on tagged releases.
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'npm/**'
+      - 'src/**'
+      - 'main.mk'
+      - '.github/workflows/npm.yml'
+  pull_request:
+    paths:
+      - 'npm/**'
+      - 'src/**'
+      - 'main.mk'
+      - '.github/workflows/npm.yml'
+
+jobs:
+  build-and-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: linux-x64
+          - os: macos-latest
+            target: osx-arm64
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
+    - name: Install dependencies (Linux)
+      if: runner.os == 'Linux'
+      run: sudo apt-get update && sudo apt-get install -y build-essential zlib1g-dev tcl-dev
+
+    - name: Install dependencies (macOS)
+      if: runner.os == 'macOS'
+      run: brew install zlib tcl-tk || true
+
+    - name: Build libdoltlite
+      run: |
+        mkdir -p build && cd build
+        ../configure
+        make -j$(nproc 2>/dev/null || sysctl -n hw.ncpu) doltlite-lib
+
+    - name: Build npm binding
+      env:
+        DOLTLITE_BUILD: ${{ github.workspace }}/build
+      run: |
+        cd npm
+        npm install
+        ls -la build/Release/doltlite.node
+
+    - name: Run smoke test
+      env:
+        DOLTLITE_BUILD: ${{ github.workspace }}/build
+      run: |
+        cd npm
+        node test/basic.js

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -1,10 +1,8 @@
 name: NPM Native Binding
 
-# Verifies the npm/ Node native binding builds and the smoke test
-# passes on each supported platform. Also runs on PR so we know if
-# a doltlite-side change broke the binding ABI.
-#
-# Does NOT publish to npm — that's a manual step on tagged releases.
+# Builds prebuilds for each supported platform/arch and runs the
+# smoke test against each. On a tagged release (release.yml) these
+# prebuilds are aggregated into the npm package and published.
 
 on:
   push:
@@ -20,18 +18,28 @@ on:
       - 'src/**'
       - 'main.mk'
       - '.github/workflows/npm.yml'
+  workflow_call:  # so release.yml can invoke this and reuse artifacts
 
 jobs:
-  build-and-test:
+  build-prebuild:
     strategy:
       fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
             target: linux-x64
+            shell: bash
+          - os: ubuntu-24.04-arm
+            target: linux-arm64
+            shell: bash
           - os: macos-latest
-            target: osx-arm64
+            target: darwin-arm64
+            shell: bash
+          - os: windows-latest
+            target: win32-x64
+            shell: 'msys2 {0}'
 
+    name: prebuild ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -49,23 +57,100 @@ jobs:
       if: runner.os == 'macOS'
       run: brew install zlib tcl-tk || true
 
-    - name: Build libdoltlite
+    # Windows: MSYS2/MinGW64 builds libdoltlite the same way release.yml
+    # does. The resulting libdoltlite.a is a MinGW64 archive and the
+    # binding is built with the same MinGW64 gcc so symbols line up.
+    # The .node file is a Windows DLL with N-API entry points and
+    # loads in standard MSVC-built Node on Windows.
+    - name: Setup MSYS2 (Windows)
+      if: runner.os == 'Windows'
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: MINGW64
+        update: true
+        install: >-
+          mingw-w64-x86_64-gcc
+          mingw-w64-x86_64-zlib
+          make
+          tcl
+          zip
+
+    - name: Build libdoltlite (Unix)
+      if: runner.os != 'Windows'
+      shell: ${{ matrix.shell }}
       run: |
         mkdir -p build && cd build
         ../configure
         make -j$(nproc 2>/dev/null || sysctl -n hw.ncpu) doltlite-lib
 
-    - name: Build npm binding
+    - name: Build libdoltlite (Windows MSYS2)
+      if: runner.os == 'Windows'
+      shell: ${{ matrix.shell }}
+      run: |
+        mkdir -p build && cd build
+        ../configure
+        make -j$(nproc) doltlite-lib
+
+    - name: Build prebuild
+      shell: ${{ matrix.shell }}
       env:
         DOLTLITE_BUILD: ${{ github.workspace }}/build
       run: |
         cd npm
-        npm install
-        ls -la build/Release/doltlite.node
+        npm install --ignore-scripts
+        npx prebuildify --napi --strip
+        ls -la prebuilds/
 
     - name: Run smoke test
+      shell: ${{ matrix.shell }}
       env:
         DOLTLITE_BUILD: ${{ github.workspace }}/build
       run: |
         cd npm
+        # Force the prebuild path (delete the from-source build if any).
+        rm -rf build/Release || true
         node test/basic.js
+
+    - name: Upload prebuild artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: prebuild-${{ matrix.target }}
+        path: npm/prebuilds/
+        if-no-files-found: error
+
+  # Aggregate all prebuilds. Useful as a smoke check that the matrix
+  # produced everything we expect; release.yml downloads these to
+  # assemble the published package.
+  aggregate:
+    needs: build-prebuild
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Download all prebuilds
+      uses: actions/download-artifact@v4
+      with:
+        path: npm/prebuilds-staging
+        pattern: prebuild-*
+        merge-multiple: false
+
+    - name: Assemble prebuilds tree
+      run: |
+        cd npm
+        mkdir -p prebuilds
+        # Each prebuild-<target> artifact contains its <target>/ subdir
+        # at top level. Move them all into npm/prebuilds/.
+        for d in prebuilds-staging/prebuild-*/*; do
+          if [ -d "$d" ]; then
+            cp -r "$d" prebuilds/
+          fi
+        done
+        ls -la prebuilds/
+        find prebuilds -type f -name '*.node' | xargs ls -la
+
+    - name: Upload aggregated prebuilds
+      uses: actions/upload-artifact@v4
+      with:
+        name: npm-prebuilds-all
+        path: npm/prebuilds/
+        if-no-files-found: error

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -63,6 +63,10 @@ jobs:
       with:
         msystem: MINGW64
         update: true
+        # Inherit Windows PATH so the MSYS2 shell can find `npm` (installed
+        # by actions/setup-node into the runner's tool cache, not into
+        # MSYS2's own PATH).
+        path-type: inherit
         install: >-
           mingw-w64-x86_64-gcc
           mingw-w64-x86_64-zlib

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -18,7 +18,6 @@ on:
       - 'src/**'
       - 'main.mk'
       - '.github/workflows/npm.yml'
-  workflow_call:  # so release.yml can invoke this and reuse artifacts
 
 jobs:
   build-prebuild:

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -27,16 +27,12 @@ jobs:
         include:
           - os: ubuntu-latest
             target: linux-x64
-            shell: bash
           - os: ubuntu-24.04-arm
             target: linux-arm64
-            shell: bash
           - os: macos-latest
             target: darwin-arm64
-            shell: bash
           - os: windows-latest
             target: win32-x64
-            shell: 'msys2 {0}'
 
     name: prebuild ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
@@ -76,7 +72,7 @@ jobs:
 
     - name: Build libdoltlite (Unix)
       if: runner.os != 'Windows'
-      shell: ${{ matrix.shell }}
+      shell: bash
       run: |
         mkdir -p build && cd build
         ../configure
@@ -84,14 +80,15 @@ jobs:
 
     - name: Build libdoltlite (Windows MSYS2)
       if: runner.os == 'Windows'
-      shell: ${{ matrix.shell }}
+      shell: 'msys2 {0}'
       run: |
         mkdir -p build && cd build
         ../configure
         make -j$(nproc) doltlite-lib
 
-    - name: Build prebuild
-      shell: ${{ matrix.shell }}
+    - name: Build prebuild (Unix)
+      if: runner.os != 'Windows'
+      shell: bash
       env:
         DOLTLITE_BUILD: ${{ github.workspace }}/build
       run: |
@@ -100,13 +97,34 @@ jobs:
         npx prebuildify --napi --strip
         ls -la prebuilds/
 
-    - name: Run smoke test
-      shell: ${{ matrix.shell }}
+    - name: Build prebuild (Windows MSYS2)
+      if: runner.os == 'Windows'
+      shell: 'msys2 {0}'
       env:
         DOLTLITE_BUILD: ${{ github.workspace }}/build
       run: |
         cd npm
-        # Force the prebuild path (delete the from-source build if any).
+        npm install --ignore-scripts
+        npx prebuildify --napi --strip
+        ls -la prebuilds/
+
+    - name: Run smoke test (Unix)
+      if: runner.os != 'Windows'
+      shell: bash
+      env:
+        DOLTLITE_BUILD: ${{ github.workspace }}/build
+      run: |
+        cd npm
+        rm -rf build/Release || true
+        node test/basic.js
+
+    - name: Run smoke test (Windows MSYS2)
+      if: runner.os == 'Windows'
+      shell: 'msys2 {0}'
+      env:
+        DOLTLITE_BUILD: ${{ github.workspace }}/build
+      run: |
+        cd npm
         rm -rf build/Release || true
         node test/basic.js
 

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -31,8 +31,14 @@ jobs:
             target: linux-arm64
           - os: macos-latest
             target: darwin-arm64
-          - os: windows-latest
-            target: win32-x64
+          # win32-x64 is deferred. The doltlite build is unix-y
+          # (autosetup, lemon, tcl) and needs MSYS2/MinGW to compile;
+          # node-gyp on Windows defaults to MSVC and can't link a
+          # MinGW-built libdoltlite.a (different archive format and
+          # C ABI). Supporting Windows requires either porting the
+          # doltlite build to MSVC or moving the binding to cmake-js
+          # — both out of scope for the initial publish. WSL2 works
+          # in the meantime.
 
     name: prebuild ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
@@ -52,46 +58,14 @@ jobs:
       if: runner.os == 'macOS'
       run: brew install zlib tcl-tk || true
 
-    # Windows: MSYS2/MinGW64 builds libdoltlite the same way release.yml
-    # does. The resulting libdoltlite.a is a MinGW64 archive and the
-    # binding is built with the same MinGW64 gcc so symbols line up.
-    # The .node file is a Windows DLL with N-API entry points and
-    # loads in standard MSVC-built Node on Windows.
-    - name: Setup MSYS2 (Windows)
-      if: runner.os == 'Windows'
-      uses: msys2/setup-msys2@v2
-      with:
-        msystem: MINGW64
-        update: true
-        # Inherit Windows PATH so the MSYS2 shell can find `npm` (installed
-        # by actions/setup-node into the runner's tool cache, not into
-        # MSYS2's own PATH).
-        path-type: inherit
-        install: >-
-          mingw-w64-x86_64-gcc
-          mingw-w64-x86_64-zlib
-          make
-          tcl
-          zip
-
-    - name: Build libdoltlite (Unix)
-      if: runner.os != 'Windows'
+    - name: Build libdoltlite
       shell: bash
       run: |
         mkdir -p build && cd build
         ../configure
         make -j$(nproc 2>/dev/null || sysctl -n hw.ncpu) doltlite-lib
 
-    - name: Build libdoltlite (Windows MSYS2)
-      if: runner.os == 'Windows'
-      shell: 'msys2 {0}'
-      run: |
-        mkdir -p build && cd build
-        ../configure
-        make -j$(nproc) doltlite-lib
-
-    - name: Build prebuild (Unix)
-      if: runner.os != 'Windows'
+    - name: Build prebuild
       shell: bash
       env:
         DOLTLITE_BUILD: ${{ github.workspace }}/build
@@ -101,30 +75,8 @@ jobs:
         npx prebuildify --napi --strip
         ls -la prebuilds/
 
-    - name: Build prebuild (Windows MSYS2)
-      if: runner.os == 'Windows'
-      shell: 'msys2 {0}'
-      env:
-        DOLTLITE_BUILD: ${{ github.workspace }}/build
-      run: |
-        cd npm
-        npm install --ignore-scripts
-        npx prebuildify --napi --strip
-        ls -la prebuilds/
-
-    - name: Run smoke test (Unix)
-      if: runner.os != 'Windows'
+    - name: Run smoke test
       shell: bash
-      env:
-        DOLTLITE_BUILD: ${{ github.workspace }}/build
-      run: |
-        cd npm
-        rm -rf build/Release || true
-        node test/basic.js
-
-    - name: Run smoke test (Windows MSYS2)
-      if: runner.os == 'Windows'
-      shell: 'msys2 {0}'
       env:
         DOLTLITE_BUILD: ${{ github.workspace }}/build
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,6 +200,143 @@ jobs:
         name: benchmark
         path: /tmp/bench_file.md
 
+  # ── npm prebuilds (per-platform .node) ────────────────────
+  # Mirrors the matrix in .github/workflows/npm.yml. Kept inline
+  # here so the release flow doesn't depend on cross-workflow
+  # artifact passing — at release time we want everything in one
+  # workflow run for atomicity.
+  npm-prebuild:
+    if: github.event_name != 'workflow_dispatch'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: linux-x64
+            shell: bash
+          - os: ubuntu-24.04-arm
+            target: linux-arm64
+            shell: bash
+          - os: macos-latest
+            target: darwin-arm64
+            shell: bash
+          - os: windows-latest
+            target: win32-x64
+            shell: 'msys2 {0}'
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
+    - name: Install dependencies (Linux)
+      if: runner.os == 'Linux'
+      run: sudo apt-get update && sudo apt-get install -y build-essential zlib1g-dev tcl-dev
+
+    - name: Install dependencies (macOS)
+      if: runner.os == 'macOS'
+      run: brew install zlib tcl-tk || true
+
+    - name: Setup MSYS2 (Windows)
+      if: runner.os == 'Windows'
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: MINGW64
+        update: true
+        install: >-
+          mingw-w64-x86_64-gcc
+          mingw-w64-x86_64-zlib
+          make
+          tcl
+          zip
+
+    - name: Build libdoltlite
+      shell: ${{ matrix.shell }}
+      run: |
+        mkdir -p build && cd build
+        ../configure
+        make -j$(nproc 2>/dev/null || sysctl -n hw.ncpu) doltlite-lib
+
+    - name: Build prebuild
+      shell: ${{ matrix.shell }}
+      env:
+        DOLTLITE_BUILD: ${{ github.workspace }}/build
+      run: |
+        cd npm
+        npm install --ignore-scripts
+        npx prebuildify --napi --strip
+
+    - name: Upload prebuild
+      uses: actions/upload-artifact@v4
+      with:
+        name: npm-prebuild-${{ matrix.target }}
+        path: npm/prebuilds/
+        if-no-files-found: error
+
+  # ── npm publish ───────────────────────────────────────────
+  # Aggregates the prebuilds, sets package.json version from the
+  # tag, then publishes to the public npm registry. Requires an
+  # NPM_TOKEN secret with publish access to the `doltlite` package.
+  npm-publish:
+    if: github.event_name != 'workflow_dispatch'
+    needs: [npm-prebuild]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        registry-url: 'https://registry.npmjs.org'
+
+    - name: Download all npm prebuilds
+      uses: actions/download-artifact@v4
+      with:
+        path: npm/prebuilds-staging
+        pattern: npm-prebuild-*
+        merge-multiple: false
+
+    - name: Assemble prebuilds tree
+      run: |
+        cd npm
+        mkdir -p prebuilds
+        # Each artifact contains its <target>/ subdir at top level.
+        for d in prebuilds-staging/npm-prebuild-*/*; do
+          if [ -d "$d" ]; then
+            cp -r "$d" prebuilds/
+          fi
+        done
+        echo "Final prebuilds layout:"
+        find prebuilds -type f | sort
+
+    - name: Set package version from git tag
+      run: |
+        cd npm
+        VERSION=${GITHUB_REF_NAME#v}
+        # In-place update of package.json's version field.
+        node -e "
+          const fs = require('fs');
+          const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+          pkg.version = '${VERSION}';
+          fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+        "
+        echo "Set version to ${VERSION}"
+        node -p "require('./package.json').version"
+
+    - name: Publish
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      run: |
+        cd npm
+        # --access public is required the first time a new scoped or
+        # unscoped public package is pushed to the registry. Subsequent
+        # publishes don't need it but it's harmless.
+        npm publish --access public
+
   # ── Create GitHub release ─────────────────────────────────
   release:
     if: github.event_name != 'workflow_dispatch'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,6 +243,9 @@ jobs:
       with:
         msystem: MINGW64
         update: true
+        # Inherit Windows PATH so the MSYS2 shell can find `npm`
+        # installed by actions/setup-node.
+        path-type: inherit
         install: >-
           mingw-w64-x86_64-gcc
           mingw-w64-x86_64-zlib

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,16 +213,12 @@ jobs:
         include:
           - os: ubuntu-latest
             target: linux-x64
-            shell: bash
           - os: ubuntu-24.04-arm
             target: linux-arm64
-            shell: bash
           - os: macos-latest
             target: darwin-arm64
-            shell: bash
           - os: windows-latest
             target: win32-x64
-            shell: 'msys2 {0}'
 
     runs-on: ${{ matrix.os }}
 
@@ -254,15 +250,35 @@ jobs:
           tcl
           zip
 
-    - name: Build libdoltlite
-      shell: ${{ matrix.shell }}
+    - name: Build libdoltlite (Unix)
+      if: runner.os != 'Windows'
+      shell: bash
       run: |
         mkdir -p build && cd build
         ../configure
         make -j$(nproc 2>/dev/null || sysctl -n hw.ncpu) doltlite-lib
 
-    - name: Build prebuild
-      shell: ${{ matrix.shell }}
+    - name: Build libdoltlite (Windows MSYS2)
+      if: runner.os == 'Windows'
+      shell: 'msys2 {0}'
+      run: |
+        mkdir -p build && cd build
+        ../configure
+        make -j$(nproc) doltlite-lib
+
+    - name: Build prebuild (Unix)
+      if: runner.os != 'Windows'
+      shell: bash
+      env:
+        DOLTLITE_BUILD: ${{ github.workspace }}/build
+      run: |
+        cd npm
+        npm install --ignore-scripts
+        npx prebuildify --napi --strip
+
+    - name: Build prebuild (Windows MSYS2)
+      if: runner.os == 'Windows'
+      shell: 'msys2 {0}'
       env:
         DOLTLITE_BUILD: ${{ github.workspace }}/build
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -217,8 +217,7 @@ jobs:
             target: linux-arm64
           - os: macos-latest
             target: darwin-arm64
-          - os: windows-latest
-            target: win32-x64
+          # win32-x64 deferred — see comment in npm.yml.
 
     runs-on: ${{ matrix.os }}
 
@@ -237,51 +236,15 @@ jobs:
       if: runner.os == 'macOS'
       run: brew install zlib tcl-tk || true
 
-    - name: Setup MSYS2 (Windows)
-      if: runner.os == 'Windows'
-      uses: msys2/setup-msys2@v2
-      with:
-        msystem: MINGW64
-        update: true
-        # Inherit Windows PATH so the MSYS2 shell can find `npm`
-        # installed by actions/setup-node.
-        path-type: inherit
-        install: >-
-          mingw-w64-x86_64-gcc
-          mingw-w64-x86_64-zlib
-          make
-          tcl
-          zip
-
-    - name: Build libdoltlite (Unix)
-      if: runner.os != 'Windows'
+    - name: Build libdoltlite
       shell: bash
       run: |
         mkdir -p build && cd build
         ../configure
         make -j$(nproc 2>/dev/null || sysctl -n hw.ncpu) doltlite-lib
 
-    - name: Build libdoltlite (Windows MSYS2)
-      if: runner.os == 'Windows'
-      shell: 'msys2 {0}'
-      run: |
-        mkdir -p build && cd build
-        ../configure
-        make -j$(nproc) doltlite-lib
-
-    - name: Build prebuild (Unix)
-      if: runner.os != 'Windows'
+    - name: Build prebuild
       shell: bash
-      env:
-        DOLTLITE_BUILD: ${{ github.workspace }}/build
-      run: |
-        cd npm
-        npm install --ignore-scripts
-        npx prebuildify --napi --strip
-
-    - name: Build prebuild (Windows MSYS2)
-      if: runner.os == 'Windows'
-      shell: 'msys2 {0}'
       env:
         DOLTLITE_BUILD: ${{ github.workspace }}/build
       run: |

--- a/npm/.gitignore
+++ b/npm/.gitignore
@@ -1,0 +1,5 @@
+build/
+node_modules/
+package-lock.json
+prebuilds/
+*.node

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,76 @@
+# doltlite
+
+Node.js native binding for [DoltLite](https://github.com/dolthub/doltlite) — SQLite with Dolt-style version control.
+
+API mirrors a subset of [`better-sqlite3`](https://github.com/WiseLibs/better-sqlite3): synchronous, prepared-statement-driven, no callbacks.
+
+## Install
+
+```bash
+npm install doltlite
+```
+
+The native binding is built from the vendored DoltLite amalgamation at install time, so you'll need a working C/C++ toolchain (`gcc`/`clang` on Linux/macOS, MSVC or MinGW on Windows). Pre-built binaries will land in a future release.
+
+## Usage
+
+```javascript
+const Database = require('doltlite');
+
+const db = new Database('app.db');
+
+db.exec(`CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT)`);
+db.prepare(`INSERT INTO users(name) VALUES (?)`).run('alice');
+
+// Standard SQLite queries.
+const rows = db.prepare(`SELECT * FROM users`).all();
+console.log(rows);  // [{ id: 1, name: 'alice' }]
+
+// DoltLite version-control procedures, exposed via the same surface.
+db.exec(`SELECT dolt_commit('-A', '-m', 'initial users')`);
+db.exec(`SELECT dolt_branch('feat')`);
+db.exec(`SELECT dolt_checkout('feat')`);
+
+db.prepare(`INSERT INTO users(name) VALUES (?)`).run('bob');
+db.exec(`SELECT dolt_commit('-A', '-m', 'add bob')`);
+
+db.exec(`SELECT dolt_checkout('main')`);
+db.exec(`SELECT dolt_merge('feat')`);
+
+// Inspect the log.
+const log = db.prepare(`SELECT message FROM dolt_log ORDER BY date DESC`).all();
+```
+
+## API
+
+### `new Database(path)`
+
+Opens or creates a database at the given filesystem path. Use `':memory:'` for an in-memory database.
+
+### `db.prepare(sql)` → `Statement`
+
+Compile a SQL statement. The returned `Statement` has `.run()`, `.get()`, `.all()`, and `.finalize()`.
+
+### `db.exec(sql)` → `db`
+
+Execute one or more SQL statements without returning results. Useful for DDL and `SELECT dolt_commit(...)`-style fire-and-forget calls.
+
+### `db.close()` → `db`
+
+Close the underlying handle.
+
+### `stmt.run(...params)` → `{ changes, lastInsertRowid }`
+
+Execute a write statement with positional `?` bindings.
+
+### `stmt.get(...params)` → `Object | undefined`
+
+Execute a read statement and return the first row as a plain object, or `undefined` if no rows match.
+
+### `stmt.all(...params)` → `Array<Object>`
+
+Execute a read statement and return all rows as an array of plain objects.
+
+## License
+
+Apache-2.0. See [LICENSE](https://github.com/dolthub/doltlite/blob/master/LICENSE) in the parent repo.

--- a/npm/README.md
+++ b/npm/README.md
@@ -19,9 +19,10 @@ Pre-built binaries ship for:
 - `linux-x64`
 - `linux-arm64`
 - `darwin-arm64`  (Apple Silicon)
-- `win32-x64`     (built with MSYS2/MinGW; loads in stock Node for Windows)
 
 If you're on one of those, no toolchain is needed.
+
+**Windows is not supported in 0.x.** The DoltLite build is unix-y (`autosetup` + `lemon` + `tcl`) and requires MSYS2/MinGW to compile, but `node-gyp` on Windows defaults to MSVC and can't link MinGW-built archives. WSL2 works as a workaround. Native Windows support is on the roadmap (likely via cmake-js once the binding stabilizes).
 
 For other platforms (e.g. `darwin-x64`, `linux-musl`, BSD), the package falls back to building from source via `node-gyp`. That requires a checkout of the DoltLite source tree at `../build` (or path set via `DOLTLITE_BUILD`), with `libdoltlite.a` already built — `make doltlite-lib` from a configured doltlite build dir.
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -4,10 +4,14 @@ Node.js native binding for [DoltLite](https://github.com/dolthub/doltlite) — S
 
 API mirrors a subset of [`better-sqlite3`](https://github.com/WiseLibs/better-sqlite3): synchronous, prepared-statement-driven, no callbacks.
 
+## Status
+
+Pre-`1.0`. Released alongside the parent DoltLite repo on tag pushes; each tag triggers prebuilds for all supported platforms and an `npm publish`.
+
 ## Install
 
 ```bash
-npm install doltlite
+npm install @dolthub/doltlite
 ```
 
 Pre-built binaries ship for:
@@ -24,7 +28,7 @@ For other platforms (e.g. `darwin-x64`, `linux-musl`, BSD), the package falls ba
 ## Usage
 
 ```javascript
-const Database = require('doltlite');
+const Database = require('@dolthub/doltlite');
 
 const db = new Database('app.db');
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -10,7 +10,16 @@ API mirrors a subset of [`better-sqlite3`](https://github.com/WiseLibs/better-sq
 npm install doltlite
 ```
 
-The native binding is built from the vendored DoltLite amalgamation at install time, so you'll need a working C/C++ toolchain (`gcc`/`clang` on Linux/macOS, MSVC or MinGW on Windows). Pre-built binaries will land in a future release.
+Pre-built binaries ship for:
+
+- `linux-x64`
+- `linux-arm64`
+- `darwin-arm64`  (Apple Silicon)
+- `win32-x64`     (built with MSYS2/MinGW; loads in stock Node for Windows)
+
+If you're on one of those, no toolchain is needed.
+
+For other platforms (e.g. `darwin-x64`, `linux-musl`, BSD), the package falls back to building from source via `node-gyp`. That requires a checkout of the DoltLite source tree at `../build` (or path set via `DOLTLITE_BUILD`), with `libdoltlite.a` already built — `make doltlite-lib` from a configured doltlite build dir.
 
 ## Usage
 

--- a/npm/binding.gyp
+++ b/npm/binding.gyp
@@ -1,0 +1,47 @@
+{
+  "variables": {
+    # Where to find libdoltlite.a + sqlite3.h. Defaults to the in-tree
+    # build dir (../build); override with --doltlite_build=/path/to/build
+    # or DOLTLITE_BUILD env var when consuming the published package.
+    "doltlite_build%": "<!(node -e \"const p=require('path');console.log(process.env.DOLTLITE_BUILD||p.resolve(__dirname,'..','build'));\" 2>/dev/null || echo ../build)"
+  },
+  "targets": [
+    {
+      "target_name": "doltlite",
+      "sources": [
+        "src/binding.cc",
+        "src/database.cc",
+        "src/statement.cc"
+      ],
+      "include_dirs": [
+        "<!@(node -p \"require('node-addon-api').include\")",
+        "<(doltlite_build)"
+      ],
+      "libraries": [
+        "<(doltlite_build)/libdoltlite.a",
+        "-lz"
+      ],
+      "defines": [
+        "NAPI_DISABLE_CPP_EXCEPTIONS",
+        "NAPI_VERSION=8"
+      ],
+      "cflags_cc": ["-fno-exceptions", "-std=c++17"],
+      "conditions": [
+        ["OS=='mac'", {
+          "xcode_settings": {
+            "GCC_ENABLE_CPP_EXCEPTIONS": "NO",
+            "CLANG_CXX_LANGUAGE_STANDARD": "c++17"
+          }
+        }],
+        ["OS=='win'", {
+          "msvs_settings": {
+            "VCCLCompilerTool": {
+              "ExceptionHandling": 0,
+              "AdditionalOptions": ["/std:c++17"]
+            }
+          }
+        }]
+      ]
+    }
+  ]
+}

--- a/npm/lib/index.d.ts
+++ b/npm/lib/index.d.ts
@@ -1,0 +1,20 @@
+declare class Statement {
+  run(...params: any[]): { changes: number; lastInsertRowid: number };
+  get(...params: any[]): Record<string, any> | undefined;
+  all(...params: any[]): Array<Record<string, any>>;
+  finalize(): this;
+}
+
+declare class Database {
+  constructor(path: string);
+  readonly open: boolean;
+  readonly memory: boolean;
+  prepare(sql: string): Statement;
+  exec(sql: string): this;
+  close(): this;
+}
+
+declare const version: () => string;
+
+export = Database;
+export { Database, Statement, version };

--- a/npm/lib/index.js
+++ b/npm/lib/index.js
@@ -1,7 +1,11 @@
 'use strict';
 
-// Native binding compiled by node-gyp at install time.
-const binding = require('../build/Release/doltlite.node');
+// node-gyp-build looks for a prebuild matching process.platform +
+// process.arch first; if none exists, it falls back to a from-source
+// build via node-gyp using binding.gyp. This is what lets the same
+// package work on every supported platform without users needing a
+// C toolchain when a prebuild is shipped.
+const binding = require('node-gyp-build')(__dirname + '/..');
 
 const { Database, Statement, version } = binding;
 

--- a/npm/lib/index.js
+++ b/npm/lib/index.js
@@ -1,0 +1,11 @@
+'use strict';
+
+// Native binding compiled by node-gyp at install time.
+const binding = require('../build/Release/doltlite.node');
+
+const { Database, Statement, version } = binding;
+
+module.exports = Database;
+module.exports.Database = Database;
+module.exports.Statement = Statement;
+module.exports.version = version;

--- a/npm/package.json
+++ b/npm/package.json
@@ -5,15 +5,19 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "install": "node-gyp rebuild",
+    "install": "node-gyp-build",
+    "rebuild": "node-gyp rebuild",
+    "prebuild": "prebuildify --napi --strip",
     "test": "node test/basic.js"
   },
   "gypfile": true,
   "dependencies": {
-    "node-addon-api": "^7.1.0"
+    "node-addon-api": "^7.1.0",
+    "node-gyp-build": "^4.8.1"
   },
   "devDependencies": {
-    "node-gyp": "^10.0.0"
+    "node-gyp": "^10.0.0",
+    "prebuildify": "^6.0.1"
   },
   "engines": {
     "node": ">=18.0.0"
@@ -37,9 +41,7 @@
     "binding.gyp",
     "src/",
     "lib/",
-    "vendor/sqlite3.c",
-    "vendor/sqlite3.h",
-    "vendor/sqlite3ext.h",
+    "prebuilds/",
     "README.md"
   ]
 }

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "doltlite",
+  "version": "0.0.1",
+  "description": "Node native binding for DoltLite — SQLite with Dolt-style version control",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "scripts": {
+    "install": "node-gyp rebuild",
+    "test": "node test/basic.js"
+  },
+  "gypfile": true,
+  "dependencies": {
+    "node-addon-api": "^7.1.0"
+  },
+  "devDependencies": {
+    "node-gyp": "^10.0.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "keywords": [
+    "sqlite",
+    "doltlite",
+    "dolt",
+    "version-control",
+    "database",
+    "embedded"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dolthub/doltlite.git",
+    "directory": "npm"
+  },
+  "license": "Apache-2.0",
+  "author": "DoltHub",
+  "files": [
+    "binding.gyp",
+    "src/",
+    "lib/",
+    "vendor/sqlite3.c",
+    "vendor/sqlite3.h",
+    "vendor/sqlite3ext.h",
+    "README.md"
+  ]
+}

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "doltlite",
+  "name": "@dolthub/doltlite",
   "version": "0.0.1",
   "description": "Node native binding for DoltLite — SQLite with Dolt-style version control",
   "main": "lib/index.js",

--- a/npm/src/binding.cc
+++ b/npm/src/binding.cc
@@ -1,0 +1,17 @@
+#include <napi.h>
+#include "database.h"
+#include "statement.h"
+#include "sqlite3.h"
+
+static Napi::Value Version(const Napi::CallbackInfo& info) {
+  return Napi::String::New(info.Env(), sqlite3_libversion());
+}
+
+Napi::Object Init(Napi::Env env, Napi::Object exports) {
+  exports.Set("Database", Database::Init(env));
+  exports.Set("Statement", Statement::Init(env));
+  exports.Set("version", Napi::Function::New(env, Version));
+  return exports;
+}
+
+NODE_API_MODULE(doltlite, Init)

--- a/npm/src/database.cc
+++ b/npm/src/database.cc
@@ -1,0 +1,104 @@
+#include "database.h"
+#include "statement.h"
+
+Napi::FunctionReference Database::constructor;
+
+Napi::Function Database::Init(Napi::Env env) {
+  Napi::Function func = DefineClass(env, "Database", {
+    InstanceMethod<&Database::Prepare>("prepare"),
+    InstanceMethod<&Database::Exec>("exec"),
+    InstanceMethod<&Database::Close>("close"),
+    InstanceAccessor<&Database::OpenGetter>("open"),
+    InstanceAccessor<&Database::MemoryGetter>("memory"),
+  });
+  constructor = Napi::Persistent(func);
+  constructor.SuppressDestruct();
+  return func;
+}
+
+Database::Database(const Napi::CallbackInfo& info)
+  : Napi::ObjectWrap<Database>(info), db_(nullptr), memory_(false) {
+  Napi::Env env = info.Env();
+
+  if (info.Length() < 1 || !info[0].IsString()) {
+    Napi::TypeError::New(env, "Database(path) requires a string path").ThrowAsJavaScriptException();
+    return;
+  }
+
+  std::string path = info[0].As<Napi::String>().Utf8Value();
+  memory_ = (path == ":memory:");
+
+  int rc = sqlite3_open(path.c_str(), &db_);
+  if (rc != SQLITE_OK) {
+    std::string msg = std::string("failed to open database: ") + sqlite3_errmsg(db_);
+    sqlite3_close(db_);
+    db_ = nullptr;
+    Napi::Error::New(env, msg).ThrowAsJavaScriptException();
+    return;
+  }
+}
+
+Database::~Database() {
+  if (db_) {
+    sqlite3_close(db_);
+    db_ = nullptr;
+  }
+}
+
+void Database::Throw(const Napi::Env& env, const char* msg) {
+  Napi::Error::New(env, msg).ThrowAsJavaScriptException();
+}
+
+Napi::Value Database::Prepare(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 1 || !info[0].IsString()) {
+    Throw(env, "prepare(sql) requires a string");
+    return env.Undefined();
+  }
+  if (!db_) {
+    Throw(env, "database is closed");
+    return env.Undefined();
+  }
+  // Hand off to Statement constructor, which prepares the SQL and
+  // stashes the sqlite3* + the prepared sqlite3_stmt*.
+  Napi::Object stmt = Statement::constructor.New({info.This(), info[0]});
+  return stmt;
+}
+
+Napi::Value Database::Exec(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 1 || !info[0].IsString()) {
+    Throw(env, "exec(sql) requires a string");
+    return env.Undefined();
+  }
+  if (!db_) {
+    Throw(env, "database is closed");
+    return env.Undefined();
+  }
+  std::string sql = info[0].As<Napi::String>().Utf8Value();
+  char* err = nullptr;
+  int rc = sqlite3_exec(db_, sql.c_str(), nullptr, nullptr, &err);
+  if (rc != SQLITE_OK) {
+    std::string msg = err ? err : "exec failed";
+    sqlite3_free(err);
+    Throw(env, msg.c_str());
+    return env.Undefined();
+  }
+  return info.This();
+}
+
+Napi::Value Database::Close(const Napi::CallbackInfo& info) {
+  if (db_) {
+    sqlite3_close(db_);
+    db_ = nullptr;
+  }
+  return info.This();
+}
+
+Napi::Value Database::OpenGetter(const Napi::CallbackInfo& info) {
+  return Napi::Boolean::New(info.Env(), db_ != nullptr);
+}
+
+Napi::Value Database::MemoryGetter(const Napi::CallbackInfo& info) {
+  return Napi::Boolean::New(info.Env(), memory_);
+}

--- a/npm/src/database.h
+++ b/npm/src/database.h
@@ -1,0 +1,30 @@
+#ifndef DOLTLITE_NPM_DATABASE_H
+#define DOLTLITE_NPM_DATABASE_H
+
+#include <napi.h>
+#include "sqlite3.h"
+
+class Database : public Napi::ObjectWrap<Database> {
+ public:
+  static Napi::Function Init(Napi::Env env);
+  static Napi::FunctionReference constructor;
+
+  Database(const Napi::CallbackInfo& info);
+  ~Database();
+
+  sqlite3* Handle() const { return db_; }
+
+ private:
+  Napi::Value Prepare(const Napi::CallbackInfo& info);
+  Napi::Value Exec(const Napi::CallbackInfo& info);
+  Napi::Value Close(const Napi::CallbackInfo& info);
+  Napi::Value OpenGetter(const Napi::CallbackInfo& info);
+  Napi::Value MemoryGetter(const Napi::CallbackInfo& info);
+
+  void Throw(const Napi::Env& env, const char* msg);
+
+  sqlite3* db_;
+  bool memory_;
+};
+
+#endif

--- a/npm/src/statement.cc
+++ b/npm/src/statement.cc
@@ -1,0 +1,208 @@
+#include "statement.h"
+#include "database.h"
+#include <cstring>
+
+Napi::FunctionReference Statement::constructor;
+
+Napi::Function Statement::Init(Napi::Env env) {
+  Napi::Function func = DefineClass(env, "Statement", {
+    InstanceMethod<&Statement::Run>("run"),
+    InstanceMethod<&Statement::Get>("get"),
+    InstanceMethod<&Statement::All>("all"),
+    InstanceMethod<&Statement::Finalize_>("finalize"),
+  });
+  constructor = Napi::Persistent(func);
+  constructor.SuppressDestruct();
+  return func;
+}
+
+Statement::Statement(const Napi::CallbackInfo& info)
+  : Napi::ObjectWrap<Statement>(info), stmt_(nullptr), db_(nullptr) {
+  Napi::Env env = info.Env();
+
+  // Constructor invoked by Database::Prepare with (databaseObject, sqlString).
+  if (info.Length() < 2 || !info[0].IsObject() || !info[1].IsString()) {
+    Napi::TypeError::New(env, "Statement is created via Database.prepare(sql)")
+        .ThrowAsJavaScriptException();
+    return;
+  }
+
+  Database* dbWrap = Napi::ObjectWrap<Database>::Unwrap(info[0].As<Napi::Object>());
+  if (!dbWrap || !dbWrap->Handle()) {
+    Napi::Error::New(env, "database is closed").ThrowAsJavaScriptException();
+    return;
+  }
+  db_ = dbWrap->Handle();
+
+  std::string sql = info[1].As<Napi::String>().Utf8Value();
+  int rc = sqlite3_prepare_v2(db_, sql.c_str(), -1, &stmt_, nullptr);
+  if (rc != SQLITE_OK) {
+    std::string msg = std::string("prepare failed: ") + sqlite3_errmsg(db_);
+    Napi::Error::New(env, msg).ThrowAsJavaScriptException();
+    stmt_ = nullptr;
+    return;
+  }
+}
+
+Statement::~Statement() {
+  if (stmt_) {
+    sqlite3_finalize(stmt_);
+    stmt_ = nullptr;
+  }
+}
+
+// Bind args from the JS call into the prepared statement. Each arg
+// becomes a positional ?N binding. Arrays/objects pass through as JSON
+// strings (caller's responsibility — keep the binding minimal). Returns
+// false on a binding error (and throws).
+bool Statement::BindArgs(const Napi::CallbackInfo& info, Napi::Env env) {
+  if (!stmt_) {
+    Napi::Error::New(env, "statement has been finalized").ThrowAsJavaScriptException();
+    return false;
+  }
+  sqlite3_reset(stmt_);
+  sqlite3_clear_bindings(stmt_);
+
+  for (size_t i = 0; i < info.Length(); i++) {
+    int idx = (int)i + 1;
+    Napi::Value v = info[i];
+    int rc;
+    if (v.IsNull() || v.IsUndefined()) {
+      rc = sqlite3_bind_null(stmt_, idx);
+    } else if (v.IsBoolean()) {
+      rc = sqlite3_bind_int(stmt_, idx, v.As<Napi::Boolean>().Value() ? 1 : 0);
+    } else if (v.IsNumber()) {
+      double d = v.As<Napi::Number>().DoubleValue();
+      // Use INTEGER bind if the JS number is an integer in i64 range.
+      if (d == (double)(int64_t)d && d >= (double)INT64_MIN && d <= (double)INT64_MAX) {
+        rc = sqlite3_bind_int64(stmt_, idx, (int64_t)d);
+      } else {
+        rc = sqlite3_bind_double(stmt_, idx, d);
+      }
+    } else if (v.IsBigInt()) {
+      bool lossless = false;
+      int64_t big = v.As<Napi::BigInt>().Int64Value(&lossless);
+      rc = sqlite3_bind_int64(stmt_, idx, big);
+    } else if (v.IsString()) {
+      std::string s = v.As<Napi::String>().Utf8Value();
+      rc = sqlite3_bind_text(stmt_, idx, s.c_str(), (int)s.size(), SQLITE_TRANSIENT);
+    } else if (v.IsBuffer()) {
+      Napi::Buffer<uint8_t> buf = v.As<Napi::Buffer<uint8_t>>();
+      rc = sqlite3_bind_blob(stmt_, idx, buf.Data(), (int)buf.Length(), SQLITE_TRANSIENT);
+    } else {
+      Napi::TypeError::New(env, "unsupported bind type at parameter "
+                                + std::to_string(idx)).ThrowAsJavaScriptException();
+      return false;
+    }
+    if (rc != SQLITE_OK) {
+      std::string msg = std::string("bind failed: ") + sqlite3_errmsg(db_);
+      Napi::Error::New(env, msg).ThrowAsJavaScriptException();
+      return false;
+    }
+  }
+  return true;
+}
+
+// Pull the current row out of stmt_ into a JS object keyed by column name.
+Napi::Value Statement::RowToObject(Napi::Env env) {
+  Napi::Object row = Napi::Object::New(env);
+  int n = sqlite3_column_count(stmt_);
+  for (int i = 0; i < n; i++) {
+    const char* name = sqlite3_column_name(stmt_, i);
+    if (!name) name = "";
+    int type = sqlite3_column_type(stmt_, i);
+    switch (type) {
+      case SQLITE_NULL:
+        row.Set(name, env.Null());
+        break;
+      case SQLITE_INTEGER: {
+        sqlite3_int64 v = sqlite3_column_int64(stmt_, i);
+        // JS numbers lose precision past 2^53 — return a BigInt above.
+        if (v <= 9007199254740992LL && v >= -9007199254740992LL) {
+          row.Set(name, Napi::Number::New(env, (double)v));
+        } else {
+          row.Set(name, Napi::BigInt::New(env, (int64_t)v));
+        }
+        break;
+      }
+      case SQLITE_FLOAT:
+        row.Set(name, Napi::Number::New(env, sqlite3_column_double(stmt_, i)));
+        break;
+      case SQLITE_TEXT: {
+        const unsigned char* t = sqlite3_column_text(stmt_, i);
+        int sz = sqlite3_column_bytes(stmt_, i);
+        row.Set(name, Napi::String::New(env, (const char*)t, (size_t)sz));
+        break;
+      }
+      case SQLITE_BLOB: {
+        const void* b = sqlite3_column_blob(stmt_, i);
+        int sz = sqlite3_column_bytes(stmt_, i);
+        row.Set(name, Napi::Buffer<uint8_t>::Copy(env, (const uint8_t*)b, (size_t)sz));
+        break;
+      }
+    }
+  }
+  return row;
+}
+
+Napi::Value Statement::Run(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (!BindArgs(info, env)) return env.Undefined();
+
+  int rc = sqlite3_step(stmt_);
+  if (rc != SQLITE_DONE && rc != SQLITE_ROW) {
+    std::string msg = std::string("run failed: ") + sqlite3_errmsg(db_);
+    Napi::Error::New(env, msg).ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+
+  Napi::Object result = Napi::Object::New(env);
+  result.Set("changes", Napi::Number::New(env, sqlite3_changes(db_)));
+  result.Set("lastInsertRowid",
+             Napi::Number::New(env, (double)sqlite3_last_insert_rowid(db_)));
+  return result;
+}
+
+Napi::Value Statement::Get(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (!BindArgs(info, env)) return env.Undefined();
+
+  int rc = sqlite3_step(stmt_);
+  if (rc == SQLITE_ROW) {
+    return RowToObject(env);
+  }
+  if (rc == SQLITE_DONE) {
+    return env.Undefined();
+  }
+  std::string msg = std::string("get failed: ") + sqlite3_errmsg(db_);
+  Napi::Error::New(env, msg).ThrowAsJavaScriptException();
+  return env.Undefined();
+}
+
+Napi::Value Statement::All(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (!BindArgs(info, env)) return env.Undefined();
+
+  Napi::Array out = Napi::Array::New(env);
+  uint32_t i = 0;
+  for (;;) {
+    int rc = sqlite3_step(stmt_);
+    if (rc == SQLITE_ROW) {
+      out.Set(i++, RowToObject(env));
+      continue;
+    }
+    if (rc == SQLITE_DONE) break;
+    std::string msg = std::string("all failed: ") + sqlite3_errmsg(db_);
+    Napi::Error::New(env, msg).ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+  return out;
+}
+
+Napi::Value Statement::Finalize_(const Napi::CallbackInfo& info) {
+  if (stmt_) {
+    sqlite3_finalize(stmt_);
+    stmt_ = nullptr;
+  }
+  return info.This();
+}

--- a/npm/src/statement.h
+++ b/npm/src/statement.h
@@ -1,0 +1,28 @@
+#ifndef DOLTLITE_NPM_STATEMENT_H
+#define DOLTLITE_NPM_STATEMENT_H
+
+#include <napi.h>
+#include "sqlite3.h"
+
+class Statement : public Napi::ObjectWrap<Statement> {
+ public:
+  static Napi::Function Init(Napi::Env env);
+  static Napi::FunctionReference constructor;
+
+  Statement(const Napi::CallbackInfo& info);
+  ~Statement();
+
+ private:
+  Napi::Value Run(const Napi::CallbackInfo& info);
+  Napi::Value Get(const Napi::CallbackInfo& info);
+  Napi::Value All(const Napi::CallbackInfo& info);
+  Napi::Value Finalize_(const Napi::CallbackInfo& info);
+
+  bool BindArgs(const Napi::CallbackInfo& info, Napi::Env env);
+  Napi::Value RowToObject(Napi::Env env);
+
+  sqlite3_stmt* stmt_;
+  sqlite3* db_;  // weak reference, owned by Database
+};
+
+#endif

--- a/npm/test/basic.js
+++ b/npm/test/basic.js
@@ -1,0 +1,76 @@
+'use strict';
+
+const Database = require('../lib');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+let pass = 0, fail = 0;
+function assert(cond, msg) {
+  if (cond) { pass++; }
+  else { fail++; console.error('  FAIL:', msg); }
+}
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'doltlite-test-'));
+const dbpath = path.join(tmp, 'test.db');
+
+console.log('=== doltlite npm binding smoke test ===');
+console.log('SQLite version:', Database.version());
+console.log('DB path:', dbpath);
+console.log();
+
+// 1. Open and basic SQL.
+const db = new Database(dbpath);
+assert(db.open, 'db.open is true after construction');
+db.exec(`CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT, age INT)`);
+const insert = db.prepare(`INSERT INTO users(name, age) VALUES (?, ?)`);
+const r1 = insert.run('alice', 30);
+assert(r1.changes === 1, 'INSERT alice changes=1');
+assert(r1.lastInsertRowid === 1, 'INSERT alice rowid=1');
+const r2 = insert.run('bob', 25);
+assert(r2.lastInsertRowid === 2, 'INSERT bob rowid=2');
+
+// 2. Select via prepare + all/get.
+const all = db.prepare(`SELECT * FROM users ORDER BY id`).all();
+assert(all.length === 2, 'all() returns 2 rows');
+assert(all[0].name === 'alice' && all[0].age === 30, 'row 0 correct');
+assert(all[1].name === 'bob' && all[1].age === 25, 'row 1 correct');
+
+const one = db.prepare(`SELECT name FROM users WHERE id = ?`).get(2);
+assert(one && one.name === 'bob', 'get(2).name === bob');
+
+const none = db.prepare(`SELECT name FROM users WHERE id = ?`).get(999);
+assert(none === undefined, 'get(non-existent) === undefined');
+
+// 3. dolt_commit / dolt_log — the whole point of doltlite.
+db.exec(`SELECT dolt_commit('-A', '-m', 'initial users')`);
+const log = db.prepare(`SELECT message FROM dolt_log ORDER BY date DESC`).all();
+assert(log.length >= 2, 'dolt_log has at least seed + first commit');
+assert(log[0].message === 'initial users',
+       `latest commit message = "${log[0].message}"`);
+
+// 4. Branch.
+db.exec(`SELECT dolt_branch('feat')`);
+db.exec(`SELECT dolt_checkout('feat')`);
+db.prepare(`INSERT INTO users(name, age) VALUES (?, ?)`).run('carol', 40);
+db.exec(`SELECT dolt_commit('-A', '-m', 'add carol')`);
+const branchAll = db.prepare(`SELECT count(*) AS n FROM users`).get();
+assert(branchAll.n === 3, 'feat has 3 users');
+
+db.exec(`SELECT dolt_checkout('main')`);
+const mainAll = db.prepare(`SELECT count(*) AS n FROM users`).get();
+assert(mainAll.n === 2, 'main still has 2 users');
+
+// 5. Merge feat back into main.
+db.exec(`SELECT dolt_merge('feat')`);
+const merged = db.prepare(`SELECT count(*) AS n FROM users`).get();
+assert(merged.n === 3, 'after merge main has 3 users');
+
+// 6. close() cleanup.
+db.close();
+assert(!db.open, 'db.open is false after close()');
+
+console.log();
+console.log(`=== Results: ${pass} passed, ${fail} failed ===`);
+fs.rmSync(tmp, { recursive: true, force: true });
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
Closes #629.

Ships a Node.js native binding under `npm/` that wraps `libdoltlite` through N-API. API follows a subset of [better-sqlite3](https://github.com/WiseLibs/better-sqlite3) — synchronous, prepared-statement-driven.

```javascript
const Database = require('doltlite');
const db = new Database('app.db');

db.exec(`CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)`);
db.prepare(`INSERT INTO t(v) VALUES (?)`).run('hello');
db.prepare(`SELECT * FROM t`).all();   // [{ id: 1, v: 'hello' }]

db.exec(`SELECT dolt_commit('-A','-m','init')`);
db.exec(`SELECT dolt_branch('feat')`);
db.exec(`SELECT dolt_checkout('feat')`);
// ...
```

The `dolt_*` procedures are reachable via the standard `prepare`/`run` surface — they're SQL functions, no special API needed.

## API covered

| Class | Methods / Properties |
|---|---|
| `Database` | `new Database(path)`, `prepare(sql)`, `exec(sql)`, `close()`, `open` (bool), `memory` (bool) |
| `Statement` | `run(...params)`, `get(...params)`, `all(...params)`, `finalize()` |
| Module | `version()` |

Bind types: `NULL`, `INTEGER` (int64), `REAL`, `TEXT`, `BLOB` (`Buffer`); `BigInt` for int64s past 2^53. Output rows are plain objects keyed by column name.

## Build wiring

`binding.gyp` links against `libdoltlite.a` from the in-tree build dir. Path resolves via the `DOLTLITE_BUILD` env var, defaulting to `../build`. Future prebuild distribution will ship per-platform `.a` + `.node` artifacts with the package; for now the package is consumed from a doltlite source checkout:

```bash
cd build && ../configure && make doltlite-lib
cd ../npm && DOLTLITE_BUILD=$(pwd)/../build npm install
node test/basic.js
```

## Test plan

Local on macOS arm64:

| Suite | Result |
|---|---|
| `npm/test/basic.js` | **15 / 15 passed** |

Covers: `open`, `exec(DDL)`, `prepare`/`run` with positional `?`, `prepare`/`all`, `prepare`/`get` (hit + miss), `dolt_commit` + `dolt_log` readback, `dolt_branch` + `dolt_checkout`, cross-branch row count, `dolt_merge`, `close()`.

## CI

`.github/workflows/npm.yml` builds libdoltlite + the binding + runs the smoke test on `linux-x64` and `osx-arm64`. Triggers on PRs that touch `npm/`, `src/`, or `main.mk` so doltlite-side changes that break the binding ABI surface immediately.

Windows is deliberately deferred — landing on linux/macOS unblocks the customer first.

## What's next (separate PRs)

- Async query API (current binding is fully synchronous, matching better-sqlite3's design choice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)