### PR TITLE
Fix rename-after-column history independence

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -483,6 +483,10 @@ int doltliteFlushCatalogToHash(sqlite3 *db, ProllyHash *pHash){
   return rc;
 }
 
+static int doltlitePrepareCatalogForPersistence(sqlite3 *db){
+  return doltliteMaterializeDefaultColumns(db);
+}
+
 void freeSchemaMergeActions(SchemaMergeAction *a, int n){
   int i, j;
   for(i=0; i<n; i++){
@@ -1274,6 +1278,12 @@ static int doltliteStageArgsAndPersist(
 
   doltliteGetSessionStaged(db, &savedStaged);
 
+  rc = doltlitePrepareCatalogForPersistence(db);
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error(context, "failed to prepare catalog", -1);
+    return rc;
+  }
+
   rc = doltliteFlushCatalogToHash(db, &workingHash);
   if( rc!=SQLITE_OK ){
     sqlite3_result_error(context, "failed to flush", -1);
@@ -1544,6 +1554,12 @@ static void doltliteCommitFunc(
     /* For BEGIN / nested SAVEPOINT, only close the SQL transaction once
     ** dolt_commit() has survived argument parsing and basic validation. */
     (void)sqlite3_exec(db, "COMMIT", 0, 0, 0);
+  }
+
+  rc = doltlitePrepareCatalogForPersistence(db);
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error(context, "failed to prepare catalog", -1);
+    return;
   }
 
   if( addAll ){

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -321,18 +321,27 @@ int doltliteMaterializeDefaultColumns(sqlite3 *db){
   const char *zName;
   int rc = SQLITE_OK;
   while( (zName = doltliteNextTableForSchema(db, &idx, &iTable)) != 0 ){
+    char *zLiveName = 0;
+    const char *zTableName = zName;
     sqlite3_stmt *pStmt = 0;
     char *zPragma = 0;
     char *zUpdate = 0;
     sqlite3_str *pSet = 0;
     int nCols = 0;
-    (void)iTable;
+    zLiveName = doltliteResolveTableNumber(db, iTable);
+    if( zLiveName ) zTableName = zLiveName;
 
-    zPragma = sqlite3_mprintf("PRAGMA main.table_info(%Q)", zName);
-    if( !zPragma ) return SQLITE_NOMEM;
+    zPragma = sqlite3_mprintf("PRAGMA main.table_info(%Q)", zTableName);
+    if( !zPragma ){
+      sqlite3_free(zLiveName);
+      return SQLITE_NOMEM;
+    }
     rc = sqlite3_prepare_v2(db, zPragma, -1, &pStmt, 0);
     sqlite3_free(zPragma);
-    if( rc!=SQLITE_OK ) return rc;
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(zLiveName);
+      return rc;
+    }
 
     while( (rc = sqlite3_step(pStmt))==SQLITE_ROW ){
       const char *zCol = (const char*)sqlite3_column_text(pStmt, 1);
@@ -342,6 +351,7 @@ int doltliteMaterializeDefaultColumns(sqlite3 *db){
           pSet = sqlite3_str_new(db);
           if( !pSet ){
             sqlite3_finalize(pStmt);
+            sqlite3_free(zLiveName);
             return SQLITE_NOMEM;
           }
         }
@@ -353,19 +363,30 @@ int doltliteMaterializeDefaultColumns(sqlite3 *db){
     if( rc!=SQLITE_DONE ){
       sqlite3_finalize(pStmt);
       if( pSet ) sqlite3_str_finish(pSet);
+      sqlite3_free(zLiveName);
       return rc;
     }
     sqlite3_finalize(pStmt);
     if( nCols>0 ){
       char *zSet = sqlite3_str_finish(pSet);
-      if( !zSet ) return SQLITE_NOMEM;
-      zUpdate = sqlite3_mprintf("UPDATE \"%w\" SET %s", zName, zSet);
+      if( !zSet ){
+        sqlite3_free(zLiveName);
+        return SQLITE_NOMEM;
+      }
+      zUpdate = sqlite3_mprintf("UPDATE \"%w\" SET %s", zTableName, zSet);
       sqlite3_free(zSet);
-      if( !zUpdate ) return SQLITE_NOMEM;
+      if( !zUpdate ){
+        sqlite3_free(zLiveName);
+        return SQLITE_NOMEM;
+      }
       rc = sqlite3_exec(db, zUpdate, 0, 0, 0);
       sqlite3_free(zUpdate);
-      if( rc!=SQLITE_OK ) return rc;
+      if( rc!=SQLITE_OK ){
+        sqlite3_free(zLiveName);
+        return rc;
+      }
     }
+    sqlite3_free(zLiveName);
   }
   return SQLITE_OK;
 }
@@ -560,7 +581,9 @@ static int doltliteAdvanceBranch(
 
   if( cs->nBranches==0 ){
     rc = chunkStoreAddBranch(cs, branch, pNewHead);
-    if( rc==SQLITE_OK ) rc = chunkStoreSetDefaultBranch(cs, branch);
+    if( rc==SQLITE_OK ){
+      rc = chunkStoreSetDefaultBranch(cs, branch);
+    }
   }else{
     rc = chunkStoreUpdateBranch(cs, branch, pNewHead);
   }
@@ -4026,6 +4049,27 @@ static int rebaseApplyPlanRowCatalog(
   return SQLITE_OK;
 }
 
+static int rebaseAdvanceWorkingBranch(
+  sqlite3 *db,
+  const ProllyHash *pNewHead,
+  const ProllyHash *pCatalogHash
+){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  const char *zBranch = doltliteGetSessionBranch(db);
+  int rc;
+
+  if( !cs ) return SQLITE_ERROR;
+  rc = chunkStoreUpdateBranch(cs, zBranch, pNewHead);
+  if( rc!=SQLITE_OK ) return rc;
+
+  doltliteSetSessionHead(db, pNewHead);
+  doltliteSetSessionStaged(db, pCatalogHash);
+  rc = doltliteSwitchCatalog(db, pCatalogHash);
+  if( rc!=SQLITE_OK ) return rc;
+
+  return doltlitePersistWorkingSetWithHash(db, 0);
+}
+
 static int rebaseReplayPlanGroup(
   sqlite3 *db,
   RebasePlanRow *aPlan,
@@ -4086,7 +4130,7 @@ static int rebaseReplayPlanGroup(
       doltliteSetSessionStaged(db, pCurCat);
     }
     if( rc==SQLITE_OK ){
-      rc = doltliteAdvanceBranch(db, &newCommit, pCurCat, 0);
+      rc = rebaseAdvanceWorkingBranch(db, &newCommit, pCurCat);
     }
     if( rc==SQLITE_OK ) *pCurHead = newCommit;
   }

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -86,6 +86,8 @@ extern void doltliteSetTableSchemaHash(sqlite3 *db, Pgno iTable, const ProllyHas
 
 int doltliteFlushCatalogToHash(sqlite3 *db, ProllyHash *pHash);
 
+int doltliteMaterializeDefaultColumns(sqlite3 *db);
+
 typedef struct DoltliteTxnState DoltliteTxnState;
 struct DoltliteTxnState {
   ProllyHash refsHash;
@@ -311,6 +313,61 @@ void doltliteUpdateSchemaHashes(sqlite3 *db){
       sqlite3_finalize(pStmt);
     }
   }
+}
+
+int doltliteMaterializeDefaultColumns(sqlite3 *db){
+  int idx = 0;
+  Pgno iTable;
+  const char *zName;
+  int rc = SQLITE_OK;
+  while( (zName = doltliteNextTableForSchema(db, &idx, &iTable)) != 0 ){
+    sqlite3_stmt *pStmt = 0;
+    char *zPragma = 0;
+    char *zUpdate = 0;
+    sqlite3_str *pSet = 0;
+    int nCols = 0;
+    (void)iTable;
+
+    zPragma = sqlite3_mprintf("PRAGMA main.table_info(%Q)", zName);
+    if( !zPragma ) return SQLITE_NOMEM;
+    rc = sqlite3_prepare_v2(db, zPragma, -1, &pStmt, 0);
+    sqlite3_free(zPragma);
+    if( rc!=SQLITE_OK ) return rc;
+
+    while( (rc = sqlite3_step(pStmt))==SQLITE_ROW ){
+      const char *zCol = (const char*)sqlite3_column_text(pStmt, 1);
+      const char *zDflt = (const char*)sqlite3_column_text(pStmt, 4);
+      if( zCol && zDflt ){
+        if( !pSet ){
+          pSet = sqlite3_str_new(db);
+          if( !pSet ){
+            sqlite3_finalize(pStmt);
+            return SQLITE_NOMEM;
+          }
+        }
+        if( nCols>0 ) sqlite3_str_appendall(pSet, ", ");
+        sqlite3_str_appendf(pSet, "\"%w\"=\"%w\"", zCol, zCol);
+        nCols++;
+      }
+    }
+    if( rc!=SQLITE_DONE ){
+      sqlite3_finalize(pStmt);
+      if( pSet ) sqlite3_str_finish(pSet);
+      return rc;
+    }
+    sqlite3_finalize(pStmt);
+    if( nCols>0 ){
+      char *zSet = sqlite3_str_finish(pSet);
+      if( !zSet ) return SQLITE_NOMEM;
+      zUpdate = sqlite3_mprintf("UPDATE \"%w\" SET %s", zName, zSet);
+      sqlite3_free(zSet);
+      if( !zUpdate ) return SQLITE_NOMEM;
+      rc = sqlite3_exec(db, zUpdate, 0, 0, 0);
+      sqlite3_free(zUpdate);
+      if( rc!=SQLITE_OK ) return rc;
+    }
+  }
+  return SQLITE_OK;
 }
 
 int doltliteLoadLiveSchemaSql(

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -7194,16 +7194,9 @@ const char *doltliteNextTableForSchema(sqlite3 *db, int *pIdx, Pgno *piTable){
   pBtree = db->aDb[0].pBt;
   while( *pIdx < pBtree->cat.n ){
     int i = (*pIdx)++;
-    if( pBtree->cat.a[i].iTable>1 ){
-      char *zLive = resolveLiveSchemaTableNumber(db, pBtree->cat.a[i].iTable);
-      if( zLive ){
-        sqlite3_free(pBtree->cat.a[i].zName);
-        pBtree->cat.a[i].zName = zLive;
-      }
-      if( pBtree->cat.a[i].zName ){
-        *piTable = pBtree->cat.a[i].iTable;
-        return pBtree->cat.a[i].zName;
-      }
+    if( pBtree->cat.a[i].iTable>1 && pBtree->cat.a[i].zName ){
+      *piTable = pBtree->cat.a[i].iTable;
+      return pBtree->cat.a[i].zName;
     }
   }
   return 0;

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -2974,6 +2974,21 @@ static int findTableIndexInArray(
   return -1;
 }
 
+static char *resolveLiveSchemaTableNumber(sqlite3 *db, Pgno iTable){
+  Schema *pSchema;
+  HashElem *k;
+  if( !db || db->nDb<=0 ) return 0;
+  pSchema = db->aDb[0].pSchema;
+  if( !pSchema ) return 0;
+  for(k=sqliteHashFirst(&pSchema->tblHash); k; k=sqliteHashNext(k)){
+    Table *pTab = (Table*)sqliteHashData(k);
+    if( pTab && pTab->tnum==(Pgno)iTable ){
+      return sqlite3_mprintf("%s", pTab->zName);
+    }
+  }
+  return 0;
+}
+
 static int findSavepointTableIndexInArray(
   SavepointTableEntry *aTables,
   int nTables,
@@ -7179,9 +7194,16 @@ const char *doltliteNextTableForSchema(sqlite3 *db, int *pIdx, Pgno *piTable){
   pBtree = db->aDb[0].pBt;
   while( *pIdx < pBtree->cat.n ){
     int i = (*pIdx)++;
-    if( pBtree->cat.a[i].iTable>1 && pBtree->cat.a[i].zName ){
-      *piTable = pBtree->cat.a[i].iTable;
-      return pBtree->cat.a[i].zName;
+    if( pBtree->cat.a[i].iTable>1 ){
+      char *zLive = resolveLiveSchemaTableNumber(db, pBtree->cat.a[i].iTable);
+      if( zLive ){
+        sqlite3_free(pBtree->cat.a[i].zName);
+        pBtree->cat.a[i].zName = zLive;
+      }
+      if( pBtree->cat.a[i].zName ){
+        *piTable = pBtree->cat.a[i].iTable;
+        return pBtree->cat.a[i].zName;
+      }
     }
   }
   return 0;
@@ -7192,6 +7214,11 @@ int doltliteFlushAndSerializeCatalog(sqlite3 *db, u8 **ppOut, int *pnOut){
   int rc;
   if( !pBt ) return SQLITE_ERROR;
   if( !db || db->nDb<=0 || !db->aDb[0].pBt ) return SQLITE_ERROR;
+  {
+    extern int doltliteMaterializeDefaultColumns(sqlite3 *db);
+    rc = doltliteMaterializeDefaultColumns(db);
+    if( rc!=SQLITE_OK ) return rc;
+  }
   rc = flushAllPending(pBt, 0);
   if( rc!=SQLITE_OK ) return rc;
 
@@ -7330,24 +7357,18 @@ int doltliteResolveTableName(sqlite3 *db, const char *zTable, Pgno *piTable){
 
 char *doltliteResolveTableNumber(sqlite3 *db, Pgno iTable){
   Btree *pBtree;
-  Schema *pSchema;
-  HashElem *k;
   int i;
   if( !db || db->nDb<=0 ) return 0;
+  {
+    char *zLive = resolveLiveSchemaTableNumber(db, iTable);
+    if( zLive ) return zLive;
+  }
   pBtree = db->aDb[0].pBt;
   if( pBtree && pBtree->cat.a ){
     for(i=0; i<pBtree->cat.n; i++){
       if( pBtree->cat.a[i].iTable==iTable && pBtree->cat.a[i].zName ){
         return sqlite3_mprintf("%s", pBtree->cat.a[i].zName);
       }
-    }
-  }
-  pSchema = db->aDb[0].pSchema;
-  if( !pSchema ) return 0;
-  for(k=sqliteHashFirst(&pSchema->tblHash); k; k=sqliteHashNext(k)){
-    Table *pTab = (Table*)sqliteHashData(k);
-    if( pTab && pTab->tnum==(Pgno)iTable ){
-      return sqlite3_mprintf("%s", pTab->zName);
     }
   }
   return 0;

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -7207,11 +7207,6 @@ int doltliteFlushAndSerializeCatalog(sqlite3 *db, u8 **ppOut, int *pnOut){
   int rc;
   if( !pBt ) return SQLITE_ERROR;
   if( !db || db->nDb<=0 || !db->aDb[0].pBt ) return SQLITE_ERROR;
-  {
-    extern int doltliteMaterializeDefaultColumns(sqlite3 *db);
-    rc = doltliteMaterializeDefaultColumns(db);
-    if( rc!=SQLITE_OK ) return rc;
-  }
   rc = flushAllPending(pBt, 0);
   if( rc!=SQLITE_OK ) return rc;
 
@@ -7352,10 +7347,6 @@ char *doltliteResolveTableNumber(sqlite3 *db, Pgno iTable){
   Btree *pBtree;
   int i;
   if( !db || db->nDb<=0 ) return 0;
-  {
-    char *zLive = resolveLiveSchemaTableNumber(db, iTable);
-    if( zLive ) return zLive;
-  }
   pBtree = db->aDb[0].pBt;
   if( pBtree && pBtree->cat.a ){
     for(i=0; i<pBtree->cat.n; i++){
@@ -7363,6 +7354,10 @@ char *doltliteResolveTableNumber(sqlite3 *db, Pgno iTable){
         return sqlite3_mprintf("%s", pBtree->cat.a[i].zName);
       }
     }
+  }
+  {
+    char *zLive = resolveLiveSchemaTableNumber(db, iTable);
+    if( zLive ) return zLive;
   }
   return 0;
 }

--- a/test/history_independence_test.sh
+++ b/test/history_independence_test.sh
@@ -2604,6 +2604,190 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'final');
 "
 
+run_ddl_case \
+  "ddl_rename_after_column_int_pk" \
+  "SELECT printf('%d|%s|%d|%s', id, payload, n, extra) FROM t ORDER BY id;" \
+  "
+SELECT printf('col|%d|%s|%s|%d|%s|%d', cid, name, type, \"notnull\", COALESCE(dflt_value,'NULL'), pk) FROM pragma_table_info('t') ORDER BY cid;
+SELECT printf('idx|%s|%d|%s|%d', name, \"unique\", origin, partial) FROM pragma_index_list('t') WHERE origin!='pk' ORDER BY name;
+SELECT printf('idxcol|idx_t_payload|%d|%s', seqno, name) FROM pragma_index_info('idx_t_payload') ORDER BY seqno;
+SELECT printf('idxcol|idx_t_n|%d|%s', seqno, name) FROM pragma_index_info('idx_t_n') ORDER BY seqno;
+" \
+  "
+CREATE TABLE t(id INTEGER PRIMARY KEY, payload TEXT, n INTEGER, extra TEXT DEFAULT 'seed');
+CREATE INDEX idx_t_payload ON t(payload);
+CREATE INDEX idx_t_n ON t(n);
+INSERT INTO t VALUES (1, 'alpha', 10, 'seed');
+INSERT INTO t VALUES (2, 'bravo', 20, 'seed');
+INSERT INTO t VALUES (3, 'charlie', 30, 'seed');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+" \
+  "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT, n INTEGER);
+INSERT INTO t VALUES (1, 'alpha', 10);
+INSERT INTO t VALUES (2, 'bravo', 20);
+INSERT INTO t VALUES (3, 'charlie', 30);
+ALTER TABLE t RENAME COLUMN v TO payload;
+ALTER TABLE t ADD COLUMN extra TEXT DEFAULT 'seed';
+CREATE INDEX idx_t_payload ON t(payload);
+CREATE INDEX idx_t_n ON t(n);
+UPDATE t SET extra = 'seed';
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+" \
+  "
+CREATE TABLE orig(id INTEGER PRIMARY KEY, v TEXT, n INTEGER);
+INSERT INTO orig VALUES (1, 'alpha', 10);
+INSERT INTO orig VALUES (2, 'bravo', 20);
+INSERT INTO orig VALUES (3, 'charlie', 30);
+ALTER TABLE orig RENAME COLUMN v TO payload;
+ALTER TABLE orig ADD COLUMN extra TEXT DEFAULT 'seed';
+ALTER TABLE orig RENAME TO t;
+CREATE INDEX idx_t_n ON t(n);
+CREATE INDEX idx_t_payload ON t(payload);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+"
+
+run_ddl_case \
+  "ddl_rename_after_column_text_pk" \
+  "SELECT printf('%s|%s|%d|%s', id, payload, n, extra) FROM t ORDER BY id;" \
+  "
+SELECT printf('col|%d|%s|%s|%d|%s|%d', cid, name, type, \"notnull\", COALESCE(dflt_value,'NULL'), pk) FROM pragma_table_info('t') ORDER BY cid;
+SELECT printf('idx|%s|%d|%s|%d', name, \"unique\", origin, partial) FROM pragma_index_list('t') WHERE origin!='pk' ORDER BY name;
+SELECT printf('idxcol|idx_t_payload|%d|%s', seqno, name) FROM pragma_index_info('idx_t_payload') ORDER BY seqno;
+SELECT printf('idxcol|idx_t_n|%d|%s', seqno, name) FROM pragma_index_info('idx_t_n') ORDER BY seqno;
+" \
+  "
+CREATE TABLE t(id TEXT PRIMARY KEY, payload TEXT, n INTEGER, extra TEXT DEFAULT 'seed');
+CREATE INDEX idx_t_payload ON t(payload);
+CREATE INDEX idx_t_n ON t(n);
+INSERT INTO t VALUES ('a-key', 'alpha', 10, 'seed');
+INSERT INTO t VALUES ('b-key', 'bravo', 20, 'seed');
+INSERT INTO t VALUES ('c-key', 'charlie', 30, 'seed');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+" \
+  "
+CREATE TABLE t(id TEXT PRIMARY KEY, v TEXT, n INTEGER);
+INSERT INTO t VALUES ('a-key', 'alpha', 10);
+INSERT INTO t VALUES ('b-key', 'bravo', 20);
+INSERT INTO t VALUES ('c-key', 'charlie', 30);
+ALTER TABLE t RENAME COLUMN v TO payload;
+ALTER TABLE t ADD COLUMN extra TEXT DEFAULT 'seed';
+CREATE INDEX idx_t_payload ON t(payload);
+CREATE INDEX idx_t_n ON t(n);
+UPDATE t SET extra = 'seed';
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+" \
+  "
+CREATE TABLE orig(id TEXT PRIMARY KEY, v TEXT, n INTEGER);
+INSERT INTO orig VALUES ('a-key', 'alpha', 10);
+INSERT INTO orig VALUES ('b-key', 'bravo', 20);
+INSERT INTO orig VALUES ('c-key', 'charlie', 30);
+ALTER TABLE orig RENAME COLUMN v TO payload;
+ALTER TABLE orig ADD COLUMN extra TEXT DEFAULT 'seed';
+ALTER TABLE orig RENAME TO t;
+CREATE INDEX idx_t_n ON t(n);
+CREATE INDEX idx_t_payload ON t(payload);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+"
+
+run_ddl_case \
+  "ddl_rename_after_column_blob_pk" \
+  "SELECT printf('%s|%s|%d|%s', hex(id), payload, n, extra) FROM t ORDER BY id;" \
+  "
+SELECT printf('col|%d|%s|%s|%d|%s|%d', cid, name, type, \"notnull\", COALESCE(dflt_value,'NULL'), pk) FROM pragma_table_info('t') ORDER BY cid;
+SELECT printf('idx|%s|%d|%s|%d', name, \"unique\", origin, partial) FROM pragma_index_list('t') WHERE origin!='pk' ORDER BY name;
+SELECT printf('idxcol|idx_t_payload|%d|%s', seqno, name) FROM pragma_index_info('idx_t_payload') ORDER BY seqno;
+SELECT printf('idxcol|idx_t_n|%d|%s', seqno, name) FROM pragma_index_info('idx_t_n') ORDER BY seqno;
+" \
+  "
+CREATE TABLE t(id BLOB PRIMARY KEY, payload TEXT, n INTEGER, extra TEXT DEFAULT 'seed');
+CREATE INDEX idx_t_payload ON t(payload);
+CREATE INDEX idx_t_n ON t(n);
+INSERT INTO t VALUES (x'01', 'alpha', 10, 'seed');
+INSERT INTO t VALUES (x'02', 'bravo', 20, 'seed');
+INSERT INTO t VALUES (x'03', 'charlie', 30, 'seed');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+" \
+  "
+CREATE TABLE t(id BLOB PRIMARY KEY, v TEXT, n INTEGER);
+INSERT INTO t VALUES (x'01', 'alpha', 10);
+INSERT INTO t VALUES (x'02', 'bravo', 20);
+INSERT INTO t VALUES (x'03', 'charlie', 30);
+ALTER TABLE t RENAME COLUMN v TO payload;
+ALTER TABLE t ADD COLUMN extra TEXT DEFAULT 'seed';
+CREATE INDEX idx_t_payload ON t(payload);
+CREATE INDEX idx_t_n ON t(n);
+UPDATE t SET extra = 'seed';
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+" \
+  "
+CREATE TABLE orig(id BLOB PRIMARY KEY, v TEXT, n INTEGER);
+INSERT INTO orig VALUES (x'01', 'alpha', 10);
+INSERT INTO orig VALUES (x'02', 'bravo', 20);
+INSERT INTO orig VALUES (x'03', 'charlie', 30);
+ALTER TABLE orig RENAME COLUMN v TO payload;
+ALTER TABLE orig ADD COLUMN extra TEXT DEFAULT 'seed';
+ALTER TABLE orig RENAME TO t;
+CREATE INDEX idx_t_n ON t(n);
+CREATE INDEX idx_t_payload ON t(payload);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+"
+
+run_ddl_case \
+  "ddl_rename_after_column_composite_pk" \
+  "SELECT printf('%s|%d|%s|%d|%s', a, b, payload, n, extra) FROM t ORDER BY a, b;" \
+  "
+SELECT printf('col|%d|%s|%s|%d|%s|%d', cid, name, type, \"notnull\", COALESCE(dflt_value,'NULL'), pk) FROM pragma_table_info('t') ORDER BY cid;
+SELECT printf('idx|%s|%d|%s|%d', name, \"unique\", origin, partial) FROM pragma_index_list('t') WHERE origin!='pk' ORDER BY name;
+SELECT printf('idxcol|idx_t_payload|%d|%s', seqno, name) FROM pragma_index_info('idx_t_payload') ORDER BY seqno;
+SELECT printf('idxcol|idx_t_n|%d|%s', seqno, name) FROM pragma_index_info('idx_t_n') ORDER BY seqno;
+" \
+  "
+CREATE TABLE t(a TEXT, b INTEGER, payload TEXT, n INTEGER, extra TEXT DEFAULT 'seed', PRIMARY KEY(a, b));
+CREATE INDEX idx_t_payload ON t(payload);
+CREATE INDEX idx_t_n ON t(n);
+INSERT INTO t VALUES ('a', 1, 'alpha', 10, 'seed');
+INSERT INTO t VALUES ('b', 2, 'bravo', 20, 'seed');
+INSERT INTO t VALUES ('c', 3, 'charlie', 30, 'seed');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+" \
+  "
+CREATE TABLE t(a TEXT, b INTEGER, v TEXT, n INTEGER, PRIMARY KEY(a, b));
+INSERT INTO t VALUES ('a', 1, 'alpha', 10);
+INSERT INTO t VALUES ('b', 2, 'bravo', 20);
+INSERT INTO t VALUES ('c', 3, 'charlie', 30);
+ALTER TABLE t RENAME COLUMN v TO payload;
+ALTER TABLE t ADD COLUMN extra TEXT DEFAULT 'seed';
+CREATE INDEX idx_t_payload ON t(payload);
+CREATE INDEX idx_t_n ON t(n);
+UPDATE t SET extra = 'seed';
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+" \
+  "
+CREATE TABLE orig(a TEXT, b INTEGER, v TEXT, n INTEGER, PRIMARY KEY(a, b));
+INSERT INTO orig VALUES ('a', 1, 'alpha', 10);
+INSERT INTO orig VALUES ('b', 2, 'bravo', 20);
+INSERT INTO orig VALUES ('c', 3, 'charlie', 30);
+ALTER TABLE orig RENAME COLUMN v TO payload;
+ALTER TABLE orig ADD COLUMN extra TEXT DEFAULT 'seed';
+ALTER TABLE orig RENAME TO t;
+CREATE INDEX idx_t_n ON t(n);
+CREATE INDEX idx_t_payload ON t(payload);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+"
+
 echo "======================================="
 echo "Results: $PASS passed, $FAIL failed"
 echo "======================================="

--- a/test/history_independence_test.sh
+++ b/test/history_independence_test.sh
@@ -2240,6 +2240,370 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'final');
 "
 
+run_ddl_case \
+  "ddl_index_order_int_pk" \
+  "SELECT printf('%d|%s|%d|%s', id, payload, n, extra) FROM t ORDER BY id;" \
+  "
+SELECT printf('col|%d|%s|%s|%d|%s|%d', cid, name, type, \"notnull\", COALESCE(dflt_value,'NULL'), pk) FROM pragma_table_info('t') ORDER BY cid;
+SELECT printf('idx|%s|%d|%s|%d', name, \"unique\", origin, partial) FROM pragma_index_list('t') WHERE origin!='pk' ORDER BY name;
+SELECT printf('idxcol|idx_t_n|%d|%s', seqno, name) FROM pragma_index_info('idx_t_n') ORDER BY seqno;
+SELECT printf('idxcol|idx_t_payload|%d|%s', seqno, name) FROM pragma_index_info('idx_t_payload') ORDER BY seqno;
+" \
+  "
+CREATE TABLE t(id INTEGER PRIMARY KEY, payload TEXT, n INTEGER, extra TEXT DEFAULT 'seed');
+CREATE INDEX idx_t_payload ON t(payload);
+CREATE INDEX idx_t_n ON t(n);
+INSERT INTO t VALUES (1, 'alpha', 10, 'seed');
+INSERT INTO t VALUES (2, 'bravo', 20, 'seed');
+INSERT INTO t VALUES (3, 'charlie', 30, 'seed');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+" \
+  "
+CREATE TABLE t(id INTEGER PRIMARY KEY, payload TEXT, n INTEGER, extra TEXT DEFAULT 'seed');
+CREATE INDEX idx_t_n ON t(n);
+CREATE INDEX idx_t_payload ON t(payload);
+INSERT INTO t VALUES (1, 'alpha', 10, 'seed');
+INSERT INTO t VALUES (2, 'bravo', 20, 'seed');
+INSERT INTO t VALUES (3, 'charlie', 30, 'seed');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+" \
+  "
+CREATE TABLE t(id INTEGER PRIMARY KEY, payload TEXT, n INTEGER, extra TEXT DEFAULT 'seed');
+CREATE INDEX idx_temp_payload ON t(payload, n);
+CREATE INDEX idx_t_payload ON t(payload);
+CREATE INDEX idx_t_n ON t(n);
+DROP INDEX idx_temp_payload;
+INSERT INTO t VALUES (1, 'alpha', 10, 'seed');
+INSERT INTO t VALUES (2, 'bravo', 20, 'seed');
+INSERT INTO t VALUES (3, 'charlie', 30, 'seed');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+"
+
+run_ddl_case \
+  "ddl_index_order_text_pk" \
+  "SELECT printf('%s|%s|%d|%s', id, payload, n, extra) FROM t ORDER BY id;" \
+  "
+SELECT printf('col|%d|%s|%s|%d|%s|%d', cid, name, type, \"notnull\", COALESCE(dflt_value,'NULL'), pk) FROM pragma_table_info('t') ORDER BY cid;
+SELECT printf('idx|%s|%d|%s|%d', name, \"unique\", origin, partial) FROM pragma_index_list('t') WHERE origin!='pk' ORDER BY name;
+SELECT printf('idxcol|idx_t_n|%d|%s', seqno, name) FROM pragma_index_info('idx_t_n') ORDER BY seqno;
+SELECT printf('idxcol|idx_t_payload|%d|%s', seqno, name) FROM pragma_index_info('idx_t_payload') ORDER BY seqno;
+" \
+  "
+CREATE TABLE t(id TEXT PRIMARY KEY, payload TEXT, n INTEGER, extra TEXT DEFAULT 'seed');
+CREATE INDEX idx_t_payload ON t(payload);
+CREATE INDEX idx_t_n ON t(n);
+INSERT INTO t VALUES ('a-key', 'alpha', 10, 'seed');
+INSERT INTO t VALUES ('b-key', 'bravo', 20, 'seed');
+INSERT INTO t VALUES ('c-key', 'charlie', 30, 'seed');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+" \
+  "
+CREATE TABLE t(id TEXT PRIMARY KEY, payload TEXT, n INTEGER, extra TEXT DEFAULT 'seed');
+CREATE INDEX idx_t_n ON t(n);
+CREATE INDEX idx_t_payload ON t(payload);
+INSERT INTO t VALUES ('a-key', 'alpha', 10, 'seed');
+INSERT INTO t VALUES ('b-key', 'bravo', 20, 'seed');
+INSERT INTO t VALUES ('c-key', 'charlie', 30, 'seed');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+" \
+  "
+CREATE TABLE t(id TEXT PRIMARY KEY, payload TEXT, n INTEGER, extra TEXT DEFAULT 'seed');
+CREATE INDEX idx_temp_payload ON t(payload, n);
+CREATE INDEX idx_t_payload ON t(payload);
+CREATE INDEX idx_t_n ON t(n);
+DROP INDEX idx_temp_payload;
+INSERT INTO t VALUES ('a-key', 'alpha', 10, 'seed');
+INSERT INTO t VALUES ('b-key', 'bravo', 20, 'seed');
+INSERT INTO t VALUES ('c-key', 'charlie', 30, 'seed');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+"
+
+run_ddl_case \
+  "ddl_index_order_blob_pk" \
+  "SELECT printf('%s|%s|%d|%s', hex(id), payload, n, extra) FROM t ORDER BY id;" \
+  "
+SELECT printf('col|%d|%s|%s|%d|%s|%d', cid, name, type, \"notnull\", COALESCE(dflt_value,'NULL'), pk) FROM pragma_table_info('t') ORDER BY cid;
+SELECT printf('idx|%s|%d|%s|%d', name, \"unique\", origin, partial) FROM pragma_index_list('t') WHERE origin!='pk' ORDER BY name;
+SELECT printf('idxcol|idx_t_n|%d|%s', seqno, name) FROM pragma_index_info('idx_t_n') ORDER BY seqno;
+SELECT printf('idxcol|idx_t_payload|%d|%s', seqno, name) FROM pragma_index_info('idx_t_payload') ORDER BY seqno;
+" \
+  "
+CREATE TABLE t(id BLOB PRIMARY KEY, payload TEXT, n INTEGER, extra TEXT DEFAULT 'seed');
+CREATE INDEX idx_t_payload ON t(payload);
+CREATE INDEX idx_t_n ON t(n);
+INSERT INTO t VALUES (x'01', 'alpha', 10, 'seed');
+INSERT INTO t VALUES (x'02', 'bravo', 20, 'seed');
+INSERT INTO t VALUES (x'03', 'charlie', 30, 'seed');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+" \
+  "
+CREATE TABLE t(id BLOB PRIMARY KEY, payload TEXT, n INTEGER, extra TEXT DEFAULT 'seed');
+CREATE INDEX idx_t_n ON t(n);
+CREATE INDEX idx_t_payload ON t(payload);
+INSERT INTO t VALUES (x'01', 'alpha', 10, 'seed');
+INSERT INTO t VALUES (x'02', 'bravo', 20, 'seed');
+INSERT INTO t VALUES (x'03', 'charlie', 30, 'seed');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+" \
+  "
+CREATE TABLE t(id BLOB PRIMARY KEY, payload TEXT, n INTEGER, extra TEXT DEFAULT 'seed');
+CREATE INDEX idx_temp_payload ON t(payload, n);
+CREATE INDEX idx_t_payload ON t(payload);
+CREATE INDEX idx_t_n ON t(n);
+DROP INDEX idx_temp_payload;
+INSERT INTO t VALUES (x'01', 'alpha', 10, 'seed');
+INSERT INTO t VALUES (x'02', 'bravo', 20, 'seed');
+INSERT INTO t VALUES (x'03', 'charlie', 30, 'seed');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+"
+
+run_ddl_case \
+  "ddl_index_order_composite_pk" \
+  "SELECT printf('%s|%d|%s|%d|%s', a, b, payload, n, extra) FROM t ORDER BY a, b;" \
+  "
+SELECT printf('col|%d|%s|%s|%d|%s|%d', cid, name, type, \"notnull\", COALESCE(dflt_value,'NULL'), pk) FROM pragma_table_info('t') ORDER BY cid;
+SELECT printf('idx|%s|%d|%s|%d', name, \"unique\", origin, partial) FROM pragma_index_list('t') WHERE origin!='pk' ORDER BY name;
+SELECT printf('idxcol|idx_t_n|%d|%s', seqno, name) FROM pragma_index_info('idx_t_n') ORDER BY seqno;
+SELECT printf('idxcol|idx_t_payload|%d|%s', seqno, name) FROM pragma_index_info('idx_t_payload') ORDER BY seqno;
+" \
+  "
+CREATE TABLE t(a TEXT, b INTEGER, payload TEXT, n INTEGER, extra TEXT DEFAULT 'seed', PRIMARY KEY(a, b));
+CREATE INDEX idx_t_payload ON t(payload);
+CREATE INDEX idx_t_n ON t(n);
+INSERT INTO t VALUES ('a', 1, 'alpha', 10, 'seed');
+INSERT INTO t VALUES ('b', 2, 'bravo', 20, 'seed');
+INSERT INTO t VALUES ('c', 3, 'charlie', 30, 'seed');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+" \
+  "
+CREATE TABLE t(a TEXT, b INTEGER, payload TEXT, n INTEGER, extra TEXT DEFAULT 'seed', PRIMARY KEY(a, b));
+CREATE INDEX idx_t_n ON t(n);
+CREATE INDEX idx_t_payload ON t(payload);
+INSERT INTO t VALUES ('a', 1, 'alpha', 10, 'seed');
+INSERT INTO t VALUES ('b', 2, 'bravo', 20, 'seed');
+INSERT INTO t VALUES ('c', 3, 'charlie', 30, 'seed');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+" \
+  "
+CREATE TABLE t(a TEXT, b INTEGER, payload TEXT, n INTEGER, extra TEXT DEFAULT 'seed', PRIMARY KEY(a, b));
+CREATE INDEX idx_temp_payload ON t(payload, n);
+CREATE INDEX idx_t_payload ON t(payload);
+CREATE INDEX idx_t_n ON t(n);
+DROP INDEX idx_temp_payload;
+INSERT INTO t VALUES ('a', 1, 'alpha', 10, 'seed');
+INSERT INTO t VALUES ('b', 2, 'bravo', 20, 'seed');
+INSERT INTO t VALUES ('c', 3, 'charlie', 30, 'seed');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+"
+
+run_ddl_case \
+  "ddl_rename_chain_int_pk" \
+  "SELECT printf('%d|%s|%d|%s', id, payload, n, extra) FROM t ORDER BY id;" \
+  "
+SELECT printf('col|%d|%s|%s|%d|%s|%d', cid, name, type, \"notnull\", COALESCE(dflt_value,'NULL'), pk) FROM pragma_table_info('t') ORDER BY cid;
+SELECT printf('idx|%s|%d|%s|%d', name, \"unique\", origin, partial) FROM pragma_index_list('t') WHERE origin!='pk' ORDER BY name;
+SELECT printf('idxcol|idx_t_payload|%d|%s', seqno, name) FROM pragma_index_info('idx_t_payload') ORDER BY seqno;
+SELECT printf('idxcol|idx_t_n|%d|%s', seqno, name) FROM pragma_index_info('idx_t_n') ORDER BY seqno;
+" \
+  "
+CREATE TABLE t(id INTEGER PRIMARY KEY, payload TEXT, n INTEGER, extra TEXT DEFAULT 'seed');
+CREATE INDEX idx_t_payload ON t(payload);
+CREATE INDEX idx_t_n ON t(n);
+INSERT INTO t VALUES (1, 'alpha', 10, 'seed');
+INSERT INTO t VALUES (2, 'bravo', 20, 'seed');
+INSERT INTO t VALUES (3, 'charlie', 30, 'seed');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+" \
+  "
+CREATE TABLE seed(id INTEGER PRIMARY KEY, v TEXT, n INTEGER);
+INSERT INTO seed VALUES (1, 'alpha', 10);
+INSERT INTO seed VALUES (2, 'bravo', 20);
+INSERT INTO seed VALUES (3, 'charlie', 30);
+ALTER TABLE seed RENAME TO mid;
+ALTER TABLE mid RENAME COLUMN v TO payload;
+ALTER TABLE mid ADD COLUMN extra TEXT DEFAULT 'seed';
+ALTER TABLE mid RENAME TO t;
+CREATE INDEX idx_t_payload ON t(payload);
+CREATE INDEX idx_t_n ON t(n);
+UPDATE t SET extra = 'seed';
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+" \
+  "
+CREATE TABLE orig(id INTEGER PRIMARY KEY, v TEXT, n INTEGER);
+INSERT INTO orig VALUES (1, 'alpha', 10);
+INSERT INTO orig VALUES (2, 'bravo', 20);
+INSERT INTO orig VALUES (3, 'charlie', 30);
+ALTER TABLE orig RENAME TO t;
+ALTER TABLE t RENAME COLUMN v TO payload;
+ALTER TABLE t ADD COLUMN extra TEXT DEFAULT 'seed';
+CREATE INDEX idx_t_n ON t(n);
+CREATE INDEX idx_t_payload ON t(payload);
+UPDATE t SET extra = 'seed';
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+"
+
+run_ddl_case \
+  "ddl_rename_chain_text_pk" \
+  "SELECT printf('%s|%s|%d|%s', id, payload, n, extra) FROM t ORDER BY id;" \
+  "
+SELECT printf('col|%d|%s|%s|%d|%s|%d', cid, name, type, \"notnull\", COALESCE(dflt_value,'NULL'), pk) FROM pragma_table_info('t') ORDER BY cid;
+SELECT printf('idx|%s|%d|%s|%d', name, \"unique\", origin, partial) FROM pragma_index_list('t') WHERE origin!='pk' ORDER BY name;
+SELECT printf('idxcol|idx_t_payload|%d|%s', seqno, name) FROM pragma_index_info('idx_t_payload') ORDER BY seqno;
+SELECT printf('idxcol|idx_t_n|%d|%s', seqno, name) FROM pragma_index_info('idx_t_n') ORDER BY seqno;
+" \
+  "
+CREATE TABLE t(id TEXT PRIMARY KEY, payload TEXT, n INTEGER, extra TEXT DEFAULT 'seed');
+CREATE INDEX idx_t_payload ON t(payload);
+CREATE INDEX idx_t_n ON t(n);
+INSERT INTO t VALUES ('a-key', 'alpha', 10, 'seed');
+INSERT INTO t VALUES ('b-key', 'bravo', 20, 'seed');
+INSERT INTO t VALUES ('c-key', 'charlie', 30, 'seed');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+" \
+  "
+CREATE TABLE seed(id TEXT PRIMARY KEY, v TEXT, n INTEGER);
+INSERT INTO seed VALUES ('a-key', 'alpha', 10);
+INSERT INTO seed VALUES ('b-key', 'bravo', 20);
+INSERT INTO seed VALUES ('c-key', 'charlie', 30);
+ALTER TABLE seed RENAME TO mid;
+ALTER TABLE mid RENAME COLUMN v TO payload;
+ALTER TABLE mid ADD COLUMN extra TEXT DEFAULT 'seed';
+ALTER TABLE mid RENAME TO t;
+CREATE INDEX idx_t_payload ON t(payload);
+CREATE INDEX idx_t_n ON t(n);
+UPDATE t SET extra = 'seed';
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+" \
+  "
+CREATE TABLE orig(id TEXT PRIMARY KEY, v TEXT, n INTEGER);
+INSERT INTO orig VALUES ('a-key', 'alpha', 10);
+INSERT INTO orig VALUES ('b-key', 'bravo', 20);
+INSERT INTO orig VALUES ('c-key', 'charlie', 30);
+ALTER TABLE orig RENAME TO t;
+ALTER TABLE t RENAME COLUMN v TO payload;
+ALTER TABLE t ADD COLUMN extra TEXT DEFAULT 'seed';
+CREATE INDEX idx_t_n ON t(n);
+CREATE INDEX idx_t_payload ON t(payload);
+UPDATE t SET extra = 'seed';
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+"
+
+run_ddl_case \
+  "ddl_rename_chain_blob_pk" \
+  "SELECT printf('%s|%s|%d|%s', hex(id), payload, n, extra) FROM t ORDER BY id;" \
+  "
+SELECT printf('col|%d|%s|%s|%d|%s|%d', cid, name, type, \"notnull\", COALESCE(dflt_value,'NULL'), pk) FROM pragma_table_info('t') ORDER BY cid;
+SELECT printf('idx|%s|%d|%s|%d', name, \"unique\", origin, partial) FROM pragma_index_list('t') WHERE origin!='pk' ORDER BY name;
+SELECT printf('idxcol|idx_t_payload|%d|%s', seqno, name) FROM pragma_index_info('idx_t_payload') ORDER BY seqno;
+SELECT printf('idxcol|idx_t_n|%d|%s', seqno, name) FROM pragma_index_info('idx_t_n') ORDER BY seqno;
+" \
+  "
+CREATE TABLE t(id BLOB PRIMARY KEY, payload TEXT, n INTEGER, extra TEXT DEFAULT 'seed');
+CREATE INDEX idx_t_payload ON t(payload);
+CREATE INDEX idx_t_n ON t(n);
+INSERT INTO t VALUES (x'01', 'alpha', 10, 'seed');
+INSERT INTO t VALUES (x'02', 'bravo', 20, 'seed');
+INSERT INTO t VALUES (x'03', 'charlie', 30, 'seed');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+" \
+  "
+CREATE TABLE seed(id BLOB PRIMARY KEY, v TEXT, n INTEGER);
+INSERT INTO seed VALUES (x'01', 'alpha', 10);
+INSERT INTO seed VALUES (x'02', 'bravo', 20);
+INSERT INTO seed VALUES (x'03', 'charlie', 30);
+ALTER TABLE seed RENAME TO mid;
+ALTER TABLE mid RENAME COLUMN v TO payload;
+ALTER TABLE mid ADD COLUMN extra TEXT DEFAULT 'seed';
+ALTER TABLE mid RENAME TO t;
+CREATE INDEX idx_t_payload ON t(payload);
+CREATE INDEX idx_t_n ON t(n);
+UPDATE t SET extra = 'seed';
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+" \
+  "
+CREATE TABLE orig(id BLOB PRIMARY KEY, v TEXT, n INTEGER);
+INSERT INTO orig VALUES (x'01', 'alpha', 10);
+INSERT INTO orig VALUES (x'02', 'bravo', 20);
+INSERT INTO orig VALUES (x'03', 'charlie', 30);
+ALTER TABLE orig RENAME TO t;
+ALTER TABLE t RENAME COLUMN v TO payload;
+ALTER TABLE t ADD COLUMN extra TEXT DEFAULT 'seed';
+CREATE INDEX idx_t_n ON t(n);
+CREATE INDEX idx_t_payload ON t(payload);
+UPDATE t SET extra = 'seed';
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+"
+
+run_ddl_case \
+  "ddl_rename_chain_composite_pk" \
+  "SELECT printf('%s|%d|%s|%d|%s', a, b, payload, n, extra) FROM t ORDER BY a, b;" \
+  "
+SELECT printf('col|%d|%s|%s|%d|%s|%d', cid, name, type, \"notnull\", COALESCE(dflt_value,'NULL'), pk) FROM pragma_table_info('t') ORDER BY cid;
+SELECT printf('idx|%s|%d|%s|%d', name, \"unique\", origin, partial) FROM pragma_index_list('t') WHERE origin!='pk' ORDER BY name;
+SELECT printf('idxcol|idx_t_payload|%d|%s', seqno, name) FROM pragma_index_info('idx_t_payload') ORDER BY seqno;
+SELECT printf('idxcol|idx_t_n|%d|%s', seqno, name) FROM pragma_index_info('idx_t_n') ORDER BY seqno;
+" \
+  "
+CREATE TABLE t(a TEXT, b INTEGER, payload TEXT, n INTEGER, extra TEXT DEFAULT 'seed', PRIMARY KEY(a, b));
+CREATE INDEX idx_t_payload ON t(payload);
+CREATE INDEX idx_t_n ON t(n);
+INSERT INTO t VALUES ('a', 1, 'alpha', 10, 'seed');
+INSERT INTO t VALUES ('b', 2, 'bravo', 20, 'seed');
+INSERT INTO t VALUES ('c', 3, 'charlie', 30, 'seed');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+" \
+  "
+CREATE TABLE seed(a TEXT, b INTEGER, v TEXT, n INTEGER, PRIMARY KEY(a, b));
+INSERT INTO seed VALUES ('a', 1, 'alpha', 10);
+INSERT INTO seed VALUES ('b', 2, 'bravo', 20);
+INSERT INTO seed VALUES ('c', 3, 'charlie', 30);
+ALTER TABLE seed RENAME TO mid;
+ALTER TABLE mid RENAME COLUMN v TO payload;
+ALTER TABLE mid ADD COLUMN extra TEXT DEFAULT 'seed';
+ALTER TABLE mid RENAME TO t;
+CREATE INDEX idx_t_payload ON t(payload);
+CREATE INDEX idx_t_n ON t(n);
+UPDATE t SET extra = 'seed';
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+" \
+  "
+CREATE TABLE orig(a TEXT, b INTEGER, v TEXT, n INTEGER, PRIMARY KEY(a, b));
+INSERT INTO orig VALUES ('a', 1, 'alpha', 10);
+INSERT INTO orig VALUES ('b', 2, 'bravo', 20);
+INSERT INTO orig VALUES ('c', 3, 'charlie', 30);
+ALTER TABLE orig RENAME TO t;
+ALTER TABLE t RENAME COLUMN v TO payload;
+ALTER TABLE t ADD COLUMN extra TEXT DEFAULT 'seed';
+CREATE INDEX idx_t_n ON t(n);
+CREATE INDEX idx_t_payload ON t(payload);
+UPDATE t SET extra = 'seed';
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'final');
+"
+
 echo "======================================="
 echo "Results: $PASS passed, $FAIL failed"
 echo "======================================="


### PR DESCRIPTION
This follow-up extends the DDL history-independence coverage with the original rename-after-column cases that were still divergent.

It fixes the remaining seam where logically equivalent histories matched on visible schema and data, but still diverged in stored table, database, and catalog hashes after a rename-column + add-column-default + rename-table sequence.

The fix refreshes live table-name resolution from the runtime schema and materializes defaulted added columns before catalog serialization so equivalent histories converge on the same persisted identity.