### PR TITLE
fix #738: clearer dolt_schema_diff error when ref resolution fails + drop adjacency oracles

### DIFF
--- a/src/doltlite_schema_diff.c
+++ b/src/doltlite_schema_diff.c
@@ -504,18 +504,45 @@ static int sdResolveRefs(
   }
 
   rc = doltliteResolveRef(db, zFromRef, &commitHash);
-  if( rc!=SQLITE_OK ) return rc;
+  if( rc!=SQLITE_OK ){
+    /* Translate SQLITE_NOTFOUND ("unknown operation") and any other
+    ** ref-resolution failure into a vtable error with a usable
+    ** message — the bare SQLITE_NOTFOUND gets mapped to the cryptic
+    ** "unknown operation" string by the SQLite shell, which is
+    ** what surfaced in dolthub/doltlite#738. */
+    sqlite3_free(pVtab->zErrMsg);
+    pVtab->zErrMsg = sqlite3_mprintf(
+      "dolt_schema_diff: from_ref '%s' could not be resolved", zFromRef);
+    return SQLITE_ERROR;
+  }
   memset(&commit, 0, sizeof(commit));
   rc = doltliteLoadCommit(db, &commitHash, &commit);
-  if( rc!=SQLITE_OK ) return rc;
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(pVtab->zErrMsg);
+    pVtab->zErrMsg = sqlite3_mprintf(
+      "dolt_schema_diff: from_ref '%s' resolved to a hash but the "
+      "commit could not be loaded", zFromRef);
+    return SQLITE_ERROR;
+  }
   memcpy(pFromCatHash, &commit.catalogHash, sizeof(ProllyHash));
   doltliteCommitClear(&commit);
 
   rc = doltliteResolveRef(db, zToRef, &commitHash);
-  if( rc!=SQLITE_OK ) return rc;
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(pVtab->zErrMsg);
+    pVtab->zErrMsg = sqlite3_mprintf(
+      "dolt_schema_diff: to_ref '%s' could not be resolved", zToRef);
+    return SQLITE_ERROR;
+  }
   memset(&commit, 0, sizeof(commit));
   rc = doltliteLoadCommit(db, &commitHash, &commit);
-  if( rc!=SQLITE_OK ) return rc;
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(pVtab->zErrMsg);
+    pVtab->zErrMsg = sqlite3_mprintf(
+      "dolt_schema_diff: to_ref '%s' resolved to a hash but the "
+      "commit could not be loaded", zToRef);
+    return SQLITE_ERROR;
+  }
   memcpy(pToCatHash, &commit.catalogHash, sizeof(ProllyHash));
   doltliteCommitClear(&commit);
 

--- a/test/vc_oracle_schema_diff_test.sh
+++ b/test/vc_oracle_schema_diff_test.sh
@@ -190,6 +190,85 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'drop_t');
 " "HEAD~1" "HEAD"
 
+# Two tables exist; drop one. Issue #738 boiled down: this exact
+# shape was reported as 'unknown operation'. Now expected: one row
+# with from_table_name='t', empty to_create_statement; the surviving
+# 'u' table doesn't appear.
+oracle "drop_one_of_two_tables" "
+$SEED
+CREATE TABLE u(id INTEGER PRIMARY KEY, x TEXT);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'add_u');
+DROP TABLE t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'drop_t');
+" "HEAD~1" "HEAD"
+
+# Two tables dropped in a single commit.
+oracle "drop_multiple_in_one_commit" "
+$SEED
+CREATE TABLE u(id INTEGER PRIMARY KEY, x TEXT);
+CREATE TABLE w(id INTEGER PRIMARY KEY, y TEXT);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'add_u_w');
+DROP TABLE t;
+DROP TABLE u;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'drop_t_u');
+" "HEAD~1" "HEAD"
+
+# Drop a populated table — schema diff is data-agnostic, the row
+# count shouldn't affect output.
+oracle "drop_table_with_data" "
+$SEED
+INSERT INTO t VALUES (2, 20), (3, 30), (4, 40);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'add_rows');
+DROP TABLE t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'drop_with_data');
+" "HEAD~1" "HEAD"
+
+# Drop using the single-arg range-syntax form 'from..to'.
+# oracle_query is needed because the standard 'oracle' helper always
+# passes at least two arguments to dolt_schema_diff(...).
+oracle_query "drop_via_range_syntax" "
+$SEED
+DROP TABLE t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'drop_t');
+" "SELECT CONCAT('ROW|', from_table_name, '|', to_table_name, '|',
+       CASE WHEN from_create_statement IS NULL OR from_create_statement='' THEN 'N' ELSE 'Y' END, '|',
+       CASE WHEN to_create_statement   IS NULL OR to_create_statement=''   THEN 'N' ELSE 'Y' END
+     ) FROM dolt_schema_diff('HEAD~1..HEAD');"
+
+# Issue #738's exact shape: filter the diff by table_name. dolt-
+# replay needs this filter so it can ask 'is THIS named table
+# dropped between these two refs?' without paging through the
+# whole diff.
+oracle "drop_filter_by_table_name" "
+$SEED
+CREATE TABLE u(id INTEGER PRIMARY KEY, x TEXT);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'add_u');
+DROP TABLE t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'drop_t');
+" "HEAD~1" "HEAD" "t"
+
+# Drop a table the filter is asking about, BUT also keep an unrelated
+# table around. Filter should suppress the unrelated row too.
+oracle "drop_filter_excludes_other_changes" "
+$SEED
+CREATE TABLE u(id INTEGER PRIMARY KEY, x TEXT);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'add_u');
+DROP TABLE t;
+ALTER TABLE u ADD COLUMN extra TEXT;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'drop_t_alter_u');
+" "HEAD~1" "HEAD" "t"
+
 echo "--- modified table (add column) ---"
 
 oracle "modified_add_col" "


### PR DESCRIPTION
Closes #738.

## Root cause

`dolt_schema_diff` was returning bare `SQLITE_NOTFOUND` when `from_ref`/`to_ref` couldn't be resolved. The SQLite shell renders that error code as the cryptic string **"unknown operation"** — which is what the issue reports.

The `DROP TABLE` schema diff path itself was always working correctly. The bug was the opaque error reporting — and the issue's reproduction hit it because `-csv` mode emits RFC 4180 CRLF row endings, and bash `$(...)` strips trailing `\n` but **not** `\r`, so a 40-char hash got fed back as a 41-char ref ending in `\r`. That fails the hex-hash strlen check inside `doltliteResolveRef`, falls through to branch/tag lookup, fails, returns `SQLITE_NOTFOUND`, surfaces as "unknown operation".

## Fix

In `sdResolveRefs`, translate ref-resolution and follow-up commit-load failures into vtable errors that include the offending ref string:

```
dolt_schema_diff: from_ref 'abc123…' could not be resolved
dolt_schema_diff: to_ref   '…' resolved to a hash but the commit could not be loaded
```

Surfaces as a proper `Error: …` line the caller can act on, instead of the generic 12-rc-mapped string.

## Issue's exact repro

After fix, with cleaned refs:

```
$ doltlite -csv -header probe.dl \
    "SELECT * FROM dolt_schema_diff WHERE from_ref='$SEED' AND to_ref='$DROP' AND table_name='t'"
from_table_name,to_table_name,from_create_statement,to_create_statement
t,"","CREATE TABLE t(id INTEGER PRIMARY KEY)",""
```

After fix, with the CRLF-contaminated ref the issue's bash repro produces:

```
Error in 4th command line argument: dolt_schema_diff: from_ref '500e8b9642…' could not be resolved
```

Caller can see exactly what was wrong.

## Adjacent oracle coverage

Added 6 scenarios to `vc_oracle_schema_diff_test.sh` covering drop adjacencies that didn't have explicit oracle pairs:

| scenario | what it covers |
|---|---|
| `drop_one_of_two_tables` | drop one, leave another, diff |
| `drop_multiple_in_one_commit` | two drops in same commit |
| `drop_table_with_data` | populated table — schema-diff is data-agnostic |
| `drop_via_range_syntax` | single-arg `HEAD~1..HEAD` form |
| `drop_filter_by_table_name` | **issue #738's exact shape** — `table_name='t'` filter on a drop diff |
| `drop_filter_excludes_other_changes` | drop t, alter u, filter on `t` suppresses u's row |

The range-syntax case uses `oracle_query` instead of the standard `oracle` helper because the one-arg call form needs to reach the vtable directly (the helper always passes ≥2 args).

## Local results vs Dolt 1.87.0

| suite | result | delta |
|---|---|---|
| `vc_oracle_schema_diff_test.sh` | **45 / 45** | +6 (was 39) |
| `run_doltlite_tests.sh` | 39 / 39 | unchanged |
| `vc_oracle_merge_test.sh` | 48 / 48 | unchanged |
| `sql_oracle_test.sh` | 526 / 526 | unchanged |

🤖 Generated with [Claude Code](https://claude.com/claude-code)