### PR TITLE
fix #739: oracle coverage for multi-table schema diffs (no filter)

### DIFF
--- a/test/vc_oracle_schema_diff_test.sh
+++ b/test/vc_oracle_schema_diff_test.sh
@@ -382,6 +382,46 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'multi');
 " "HEAD~1" "HEAD"
 
+# Issue #739 wants to enumerate "which tables changed?" without a
+# table_name filter. Cover the combinations a consumer needs to
+# handle: add+drop+modify in one commit, two modifications side-
+# by-side, rename column with a peer change.
+oracle "multi_change_add_drop_modify" "
+$SEED
+CREATE TABLE u(id INTEGER PRIMARY KEY, x INT);
+INSERT INTO u VALUES(1,10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'add_u');
+ALTER TABLE t ADD COLUMN extra TEXT;
+DROP TABLE u;
+CREATE TABLE w(id INTEGER PRIMARY KEY, z TEXT);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'add_drop_modify');
+" "HEAD~1" "HEAD"
+
+# Modify two existing tables in one commit. Rename column on one,
+# add column on another. Both rows must appear in a no-filter diff.
+oracle "modify_two_tables_one_commit" "
+$SEED
+CREATE TABLE u(id INTEGER PRIMARY KEY, x INT);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'add_u');
+ALTER TABLE t RENAME COLUMN v TO vv;
+ALTER TABLE u ADD COLUMN y TEXT;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'modify_two');
+" "HEAD~1" "HEAD"
+
+# Rename a column AND add another in the same table in the same
+# commit. Should emit a single 'modified' row for that table.
+oracle "rename_and_add_col_same_commit" "
+$SEED
+ALTER TABLE t RENAME COLUMN v TO vv;
+ALTER TABLE t ADD COLUMN extra TEXT;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'rename_plus_add');
+" "HEAD~1" "HEAD"
+
 echo "--- no changes ---"
 
 oracle "no_changes" "


### PR DESCRIPTION
Closes #739.

## Why this is small

Issue #739 reports `dolt_schema_diff` errors with `unknown operation` when queried without a `table_name` filter. That cryptic string was the SQLite shell's rendering of bare `SQLITE_NOTFOUND` from ref resolution — same root cause as #738.

The fix already merged in [#754](https://github.com/dolthub/doltlite/pull/754) translates ref-resolution failures into a clear `dolt_schema_diff: ref 'X' could not be resolved` message. That closes #739 too — the no-filter case now succeeds when refs resolve, and errors with a useful message when they don't.

This PR adds the oracle scenarios #739 was implicitly asking for: the consumer pattern of "enumerate which tables changed between A and B" without a `table_name` filter.

## New scenarios

| name | covers |
|---|---|
| `multi_change_add_drop_modify` | add + drop + modify in a single commit — the most permissive diff shape a no-filter consumer has to handle |
| `modify_two_tables_one_commit` | two existing tables modified side-by-side (rename col on one, add col on another) |
| `rename_and_add_col_same_commit` | multiple alters on the **same** table in one commit; should emit a single `modified` row |

## Local results

| suite | result |
|---|---|
| `vc_oracle_schema_diff_test.sh` (vs Dolt 1.87.0) | **48 / 48** (was 45 / 45) |

Issue's exact repro now produces matching output with and without the `table_name` filter:

```
$ doltlite -csv -header probe.dl \
    "SELECT * FROM dolt_schema_diff WHERE from_ref='$SEED' AND to_ref='$RENAME'"
from_table_name,to_table_name,from_create_statement,to_create_statement
t,t,"CREATE TABLE t(...,name TEXT)","CREATE TABLE t(...,label TEXT)"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)