### PR TITLE
Fix C99 -Wdeclaration-after-statement warnings

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -992,9 +992,10 @@ static int csReplayWal(ChunkStore *cs){
         break;
       }
       {
+        u32 magic;
         rc = sqlite3OsRead(cs->pFile, m, sizeof(m), cs->iWalOffset + pos);
         if( rc != SQLITE_OK ) goto replay_error;
-        u32 magic = CS_READ_U32(m);
+        magic = CS_READ_U32(m);
         if( magic != CHUNK_STORE_MAGIC ){
           /* Corrupt root record — torn write garbled the
           ** magic. Content-addressing protects us: any refs

--- a/src/doltlite_merge_constraints.c
+++ b/src/doltlite_merge_constraints.c
@@ -219,10 +219,11 @@ static int fkRefreshCandidateTables(sqlite3 *db, int *pChanged){
   }
 
   for(i=0; i<nNames; i++){
+    char *zSql;
     if( !tableHasRowid(db, azNames[i]) ){
       continue;
     }
-    char *zSql = sqlite3_mprintf("REINDEX \"%w\"", azNames[i]);
+    zSql = sqlite3_mprintf("REINDEX \"%w\"", azNames[i]);
     if( !zSql ){
       fkRefreshFreeNames(azNames, nNames);
       return SQLITE_NOMEM;


### PR DESCRIPTION
## Summary
- Hoist two declarations to the top of their enclosing block so the build is warning-clean under `-Wdeclaration-after-statement`.
  - `src/chunk_store.c`: `u32 magic` in the WAL root-record replay block.
  - `src/doltlite_merge_constraints.c`: `char *zSql` in the REINDEX loop body.

## Test plan
- [x] `make doltlite` — no warnings, no errors