### PR TITLE
Add physical chunk deduplication scanner

### DIFF
--- a/test/chunk_physical_dups_test.sh
+++ b/test/chunk_physical_dups_test.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+#
+# Physical chunk deduplication test.
+#
+# Content-addressed storage must not physically store multiple chunk records for
+# the same hash. This scans both compacted index entries and append-only WAL
+# chunk records so it catches duplicate bytes, not just duplicate reachable
+# index entries.
+#
+# Usage: bash chunk_physical_dups_test.sh [path/to/doltlite]
+#
+
+set -euo pipefail
+
+DOLTLITE="${1:-./doltlite}"
+DBFILE=$(mktemp)
+TMPROOT=$(mktemp -d)
+trap 'rm -f "$DBFILE"; rm -rf "$TMPROOT"' EXIT
+
+THIS_DIR=$(cd "$(dirname "$0")" && pwd)
+SCANNER="$THIS_DIR/tools/chunk_physical_dups.py"
+
+if [ ! -x "$DOLTLITE" ]; then
+  echo "doltlite binary not found at $DOLTLITE"
+  exit 1
+fi
+if [ ! -f "$SCANNER" ]; then
+  echo "scanner not found at $SCANNER"
+  exit 1
+fi
+
+pass=0
+fail=0
+failed=""
+
+scan_value() {
+  local key="$1"
+  python3 "$SCANNER" "$DBFILE" --json \
+    | python3 -c "import json,sys; print(json.load(sys.stdin)['$key'])"
+}
+
+check_eq() {
+  local name="$1"
+  local got="$2"
+  local want="$3"
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1))
+    echo "  PASS: $name ($got)"
+  else
+    fail=$((fail + 1))
+    failed="$failed $name"
+    echo "  FAIL: $name"
+    echo "    got=$got"
+    echo "    want=$want"
+  fi
+}
+
+check_gt() {
+  local name="$1"
+  local got="$2"
+  local min="$3"
+  if [ "$got" -gt "$min" ]; then
+    pass=$((pass + 1))
+    echo "  PASS: $name ($got)"
+  else
+    fail=$((fail + 1))
+    failed="$failed $name"
+    echo "  FAIL: $name"
+    echo "    got=$got"
+    echo "    expected > $min"
+  fi
+}
+
+echo "=== Physical Chunk Deduplication Test ==="
+echo
+
+rm -f "$DBFILE"
+"$DOLTLITE" "$DBFILE" >/dev/null <<'SQL'
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT, pad TEXT);
+WITH RECURSIVE seq(x) AS (
+  SELECT 1
+  UNION ALL
+  SELECT x + 1 FROM seq WHERE x < 1500
+)
+INSERT INTO t
+SELECT x, printf('v%04d', x), hex(zeroblob(80)) FROM seq;
+SELECT dolt_commit('-Am', 'base');
+
+SELECT dolt_branch('left');
+SELECT dolt_branch('right');
+
+SELECT dolt_checkout('left');
+UPDATE t SET v = 'left' WHERE id = 10;
+SELECT dolt_commit('-Am', 'left edit');
+UPDATE t SET v = printf('v%04d', id) WHERE id = 10;
+SELECT dolt_commit('-Am', 'left restores base bytes');
+
+SELECT dolt_checkout('right');
+UPDATE t SET v = 'right' WHERE id = 1490;
+SELECT dolt_commit('-Am', 'right edit');
+UPDATE t SET v = printf('v%04d', id) WHERE id = 1490;
+SELECT dolt_commit('-Am', 'right restores base bytes');
+
+SELECT dolt_checkout('main');
+SELECT dolt_merge('left');
+SELECT dolt_merge('right');
+
+CREATE TABLE u(id INTEGER PRIMARY KEY, v TEXT, pad TEXT);
+INSERT INTO u SELECT * FROM t;
+SELECT dolt_commit('-Am', 'transient duplicate-looking table');
+DROP TABLE u;
+SELECT dolt_commit('-Am', 'remove transient table');
+SQL
+
+before_records=$(scan_value physical_records)
+before_distinct=$(scan_value distinct_hashes)
+before_dups=$(scan_value duplicate_hashes)
+before_dup_records=$(scan_value duplicate_records)
+
+check_gt "pre_gc_physical_records" "$before_records" 0
+check_eq "pre_gc_records_match_distinct_hashes" "$before_records" "$before_distinct"
+check_eq "pre_gc_duplicate_hashes" "$before_dups" 0
+check_eq "pre_gc_duplicate_records" "$before_dup_records" 0
+
+"$DOLTLITE" "$DBFILE" "SELECT dolt_gc();" >"$TMPROOT/gc.out"
+
+after_records=$(scan_value physical_records)
+after_distinct=$(scan_value distinct_hashes)
+after_dups=$(scan_value duplicate_hashes)
+after_dup_records=$(scan_value duplicate_records)
+
+check_gt "post_gc_physical_records" "$after_records" 0
+check_eq "post_gc_records_match_distinct_hashes" "$after_records" "$after_distinct"
+check_eq "post_gc_duplicate_hashes" "$after_dups" 0
+check_eq "post_gc_duplicate_records" "$after_dup_records" 0
+
+echo
+echo "======================================="
+echo "Results: $pass passed, $fail failed"
+echo "======================================="
+if [ "$fail" -gt 0 ]; then
+  echo "Failed:$failed"
+  echo
+  python3 "$SCANNER" "$DBFILE"
+  exit 1
+fi

--- a/test/run_doltlite_tests.sh
+++ b/test/run_doltlite_tests.sh
@@ -34,6 +34,7 @@ TESTS=(
   doltlite_branding.sh
   doltlite_gc.sh
   doltlite_structural.sh
+  chunk_physical_dups_test.sh
   doltlite_savepoint.sh
   doltlite_schema_merge.sh
   doltlite_branch_gc_stress.sh

--- a/test/tools/chunk_physical_dups.py
+++ b/test/tools/chunk_physical_dups.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Scan a DoltLite chunk-store file for duplicate physical chunk hashes.
+
+The DB file is the chunk store. This walks compacted index entries and
+append-only WAL chunk records, groups physical records by content hash, and
+reports hashes stored more than once.
+"""
+import argparse
+import json
+import struct
+import sys
+from collections import defaultdict
+
+MANIFEST_SIZE = 168
+INDEX_ENTRY_SIZE = 32
+HASH_SIZE = 20
+WAL_TAG_CHUNK = 0x01
+WAL_TAG_ROOT = 0x02
+
+
+def read_manifest(f):
+    f.seek(0)
+    buf = f.read(MANIFEST_SIZE)
+    if len(buf) < MANIFEST_SIZE:
+        raise SystemExit("file too short for manifest")
+    magic = struct.unpack_from("<I", buf, 0)[0]
+    version = struct.unpack_from("<I", buf, 4)[0]
+    if magic != 0x444C5443:
+        raise SystemExit(f"bad magic 0x{magic:08x} (not a DoltLite chunk store)")
+    return {
+        "version": version,
+        "n_chunks": struct.unpack_from("<I", buf, 28)[0],
+        "index_offset": struct.unpack_from("<q", buf, 32)[0],
+        "index_size": struct.unpack_from("<I", buf, 40)[0],
+        "wal_offset": struct.unpack_from("<q", buf, 84)[0],
+    }
+
+
+def scan_index(f, manifest):
+    records = []
+    index_size = manifest["index_size"]
+    if index_size == 0:
+        return records
+    if index_size % INDEX_ENTRY_SIZE != 0:
+        raise SystemExit("index size is not a multiple of index entry size")
+
+    f.seek(manifest["index_offset"])
+    buf = f.read(index_size)
+    if len(buf) != index_size:
+        raise SystemExit("short read while reading index")
+
+    for off in range(0, len(buf), INDEX_ENTRY_SIZE):
+        h = buf[off:off + HASH_SIZE].hex()
+        file_offset = struct.unpack_from("<q", buf, off + HASH_SIZE)[0]
+        size = struct.unpack_from("<I", buf, off + HASH_SIZE + 8)[0]
+        records.append({
+            "hash": h,
+            "source": "index",
+            "record_offset": file_offset,
+            "data_size": size,
+        })
+    return records
+
+
+def scan_wal(f, manifest):
+    records = []
+    wal_offset = manifest["wal_offset"]
+    if wal_offset == 0:
+        return records
+
+    f.seek(0, 2)
+    eof = f.tell()
+    pos = wal_offset
+    f.seek(pos)
+
+    while pos < eof:
+        tag = f.read(1)
+        if not tag:
+            break
+        pos += 1
+
+        if tag[0] == WAL_TAG_CHUNK:
+            h = f.read(HASH_SIZE)
+            length_buf = f.read(4)
+            if len(h) != HASH_SIZE or len(length_buf) != 4:
+                break
+            n = struct.unpack("<I", length_buf)[0]
+            records.append({
+                "hash": h.hex(),
+                "source": "wal",
+                "record_offset": pos - 1,
+                "data_size": n,
+            })
+            f.seek(n, 1)
+            pos += HASH_SIZE + 4 + n
+        elif tag[0] == WAL_TAG_ROOT:
+            f.seek(MANIFEST_SIZE, 1)
+            pos += MANIFEST_SIZE
+        else:
+            break
+
+    return records
+
+
+def summarize(records, manifest):
+    by_hash = defaultdict(list)
+    for rec in records:
+        by_hash[rec["hash"]].append(rec)
+
+    duplicates = {
+        h: recs for h, recs in by_hash.items()
+        if len(recs) > 1
+    }
+    duplicate_records = sum(len(recs) - 1 for recs in duplicates.values())
+    max_records_per_hash = max((len(recs) for recs in by_hash.values()), default=0)
+
+    return {
+        "manifest_version": manifest["version"],
+        "manifest_index_chunks": manifest["n_chunks"],
+        "physical_records": len(records),
+        "distinct_hashes": len(by_hash),
+        "duplicate_hashes": len(duplicates),
+        "duplicate_records": duplicate_records,
+        "max_records_per_hash": max_records_per_hash,
+        "index_records": sum(1 for rec in records if rec["source"] == "index"),
+        "wal_records": sum(1 for rec in records if rec["source"] == "wal"),
+        "duplicates": {
+            h: recs for h, recs in sorted(duplicates.items())
+        },
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("dbfile")
+    ap.add_argument("--json", action="store_true")
+    ap.add_argument("--fail-on-dups", action="store_true")
+    args = ap.parse_args()
+
+    with open(args.dbfile, "rb") as f:
+        manifest = read_manifest(f)
+        records = scan_index(f, manifest) + scan_wal(f, manifest)
+
+    stats = summarize(records, manifest)
+    if args.json:
+        print(json.dumps(stats, indent=2))
+    else:
+        print(f"DoltLite chunk store: {args.dbfile}")
+        print(f"  physical records:     {stats['physical_records']}")
+        print(f"  distinct hashes:       {stats['distinct_hashes']}")
+        print(f"  duplicate hashes:      {stats['duplicate_hashes']}")
+        print(f"  duplicate records:     {stats['duplicate_records']}")
+        print(f"  max records per hash:  {stats['max_records_per_hash']}")
+        print(f"  index/wal records:     {stats['index_records']} / {stats['wal_records']}")
+
+    if args.fail_on_dups and stats["duplicate_hashes"] != 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a chunk-store physical duplicate scanner for compacted index and WAL records
- add a structural sharing test that asserts zero duplicate physical chunk hashes before and after dolt_gc()
- include the new test in the DoltLite shell test runner

## Test
- bash test/chunk_physical_dups_test.sh ./build/doltlite