### PR TITLE
Reuse mutmap value buffers

### DIFF
--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -104,6 +104,7 @@ static void freeEntryData(ProllyMutMapEntry *e){
   e->pVal = 0;
   e->nKey = 0;
   e->nVal = 0;
+  e->nValAlloc = 0;
 }
 
 static int copyEntryData(ProllyMutMap *mm, ProllyMutMapEntry *e,
@@ -128,7 +129,27 @@ static int copyEntryData(ProllyMutMap *mm, ProllyMutMapEntry *e,
     }
     memcpy(e->pVal, pVal, nVal);
     e->nVal = nVal;
+    e->nValAlloc = nVal;
   }
+  return SQLITE_OK;
+}
+
+static int replaceEntryValue(ProllyMutMapEntry *e, const u8 *pVal, int nVal){
+  if( !pVal || nVal<=0 ){
+    sqlite3_free(e->pVal);
+    e->pVal = 0;
+    e->nVal = 0;
+    e->nValAlloc = 0;
+    return SQLITE_OK;
+  }
+  if( e->nValAlloc < nVal ){
+    u8 *pNew = (u8*)sqlite3_realloc(e->pVal, nVal);
+    if( !pNew ) return SQLITE_NOMEM;
+    e->pVal = pNew;
+    e->nValAlloc = nVal;
+  }
+  memcpy(e->pVal, pVal, nVal);
+  e->nVal = nVal;
   return SQLITE_OK;
 }
 
@@ -370,15 +391,8 @@ int prollyMutMapInsert(
       if( rc!=SQLITE_OK ) return rc;
     }
     e->op = PROLLY_EDIT_INSERT;
-    sqlite3_free(e->pVal);
-    e->pVal = 0;
-    e->nVal = 0;
-    if( pVal && nVal>0 ){
-      e->pVal = (u8*)sqlite3_malloc(nVal);
-      if( !e->pVal ) return SQLITE_NOMEM;
-      memcpy(e->pVal, pVal, nVal);
-      e->nVal = nVal;
-    }
+    rc = replaceEntryValue(e, pVal, nVal);
+    if( rc!=SQLITE_OK ) return rc;
     e->bornAt = encodeLevel(mm, mm->currentSavepointLevel);
     return SQLITE_OK;
   }
@@ -459,6 +473,7 @@ int prollyMutMapDelete(
       sqlite3_free(e->pVal);
       e->pVal = 0;
       e->nVal = 0;
+      e->nValAlloc = 0;
       e->bornAt = encodeLevel(mm, mm->currentSavepointLevel);
       return SQLITE_OK;
     }
@@ -519,6 +534,7 @@ void prollyMutMapPushSavepoint(ProllyMutMap *mm, int level){
 ** undo record gets applied, losing the restored state. */
 int prollyMutMapRollbackToSavepoint(ProllyMutMap *mm, int level){
   int i;
+  int rc;
   if( !mm ) return SQLITE_OK;
 
   while( mm->nUndo > 0
@@ -529,15 +545,8 @@ int prollyMutMapRollbackToSavepoint(ProllyMutMap *mm, int level){
       ProllyMutMapEntry *e = &mm->aEntries[idx];
       e->op = rec->prevOp;
       e->bornAt = encodeLevel(mm, rec->prevBornAt);
-      sqlite3_free(e->pVal);
-      e->pVal = 0;
-      e->nVal = 0;
-      if( rec->prevVal && rec->nPrevVal > 0 ){
-        e->pVal = (u8*)sqlite3_malloc(rec->nPrevVal);
-        if( !e->pVal ) return SQLITE_NOMEM;
-        memcpy(e->pVal, rec->prevVal, rec->nPrevVal);
-        e->nVal = rec->nPrevVal;
-      }
+      rc = replaceEntryValue(e, rec->prevVal, rec->nPrevVal);
+      if( rc!=SQLITE_OK ) return rc;
     }
     sqlite3_free(rec->prevVal);
     rec->prevVal = 0;
@@ -815,6 +824,7 @@ int prollyMutMapClone(ProllyMutMap **out, const ProllyMutMap *src){
       de->bornAt = se->bornAt;
       de->nKey = 0;
       de->nVal = 0;
+      de->nValAlloc = 0;
       de->pKey = 0;
       de->pVal = 0;
       if( se->pKey && se->nKey > 0 ){
@@ -840,6 +850,7 @@ int prollyMutMapClone(ProllyMutMap **out, const ProllyMutMap *src){
         }
         memcpy(de->pVal, se->pVal, se->nVal);
         de->nVal = se->nVal;
+        de->nValAlloc = se->nVal;
       }
       dst->nEntries++;
     }

--- a/src/prolly_mutmap.h
+++ b/src/prolly_mutmap.h
@@ -16,6 +16,7 @@ struct ProllyMutMapEntry {
   int nKey;
   u8 *pVal;
   int nVal;
+  int nValAlloc;
   int bornAt;
 };
 

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -5160,6 +5160,38 @@ static void run_mutmap_empty_reverse_iter(void){
   prollyMutMapFree(&mm);
 }
 
+static void run_mutmap_delete_reinsert_reuses_entry(void){
+  int mode;
+  static const u8 aFirst[] = { 1, 2, 3, 4 };
+  static const u8 aSecond[] = { 5, 6, 7, 8 };
+
+  printf("=== MutMap Delete Reinsert Reuses Entry Test ===\n\n");
+  for( mode = 0; mode < 2; mode++ ){
+    ProllyMutMap mm;
+    ProllyMutMapEntry *e = 0;
+    int rc;
+
+    check("mutmap_delete_reinsert_init",
+          prollyMutMapInitMode(&mm, 1, (u8)mode)==SQLITE_OK);
+    check("mutmap_delete_reinsert_insert",
+          prollyMutMapInsert(&mm, 0, 0, 42, aFirst, sizeof(aFirst))==SQLITE_OK);
+    check("mutmap_delete_reinsert_delete",
+          prollyMutMapDelete(&mm, 0, 0, 42)==SQLITE_OK);
+    check("mutmap_delete_reinsert_insert_again",
+          prollyMutMapInsert(&mm, 0, 0, 42, aSecond, sizeof(aSecond))==SQLITE_OK);
+
+    rc = prollyMutMapFindRc(&mm, 0, 0, 42, &e);
+    check("mutmap_delete_reinsert_find", rc==SQLITE_OK && e!=0);
+    check("mutmap_delete_reinsert_value",
+          e!=0
+       && e->op==PROLLY_EDIT_INSERT
+       && e->nVal==(int)sizeof(aSecond)
+       && memcmp(e->pVal, aSecond, sizeof(aSecond))==0);
+
+    prollyMutMapFree(&mm);
+  }
+}
+
 typedef struct MutMapModelEntry MutMapModelEntry;
 struct MutMapModelEntry {
   i64 key;
@@ -6347,6 +6379,7 @@ static const RegressionCase aCases[] = {
   { "checkout_dash_b_existing_branch_preserves_durable_state", "Checkout -b Existing Branch Preserves Durable State Test", run_checkout_dash_b_existing_branch_preserves_durable_state },
   { "reset_bad_ref_failure_preserves_durable_state", "Reset Bad Ref Failure Preserves Durable State Test", run_reset_bad_ref_failure_preserves_durable_state },
   { "mutmap_empty_reverse_iter", "MutMap Empty Reverse Iterator Test", run_mutmap_empty_reverse_iter },
+  { "mutmap_delete_reinsert_reuses_entry", "MutMap Delete Reinsert Reuses Entry Test", run_mutmap_delete_reinsert_reuses_entry },
   { "mutmap_resolve_sorted_pos", "MutMap ResolveSortedPos Test", run_mutmap_resolve_sorted_pos },
   { "mutmap_differential_randomized", "MutMap Differential Randomized Test", run_mutmap_differential_randomized },
   { "prolly_mutate_skip_subtree_order", "Prolly Mutate Skipped Subtree Order Test", run_prolly_mutate_preserves_order_across_skipped_subtrees },


### PR DESCRIPTION
## Summary
- retain allocated value-buffer capacity on mutmap entries
- reuse existing value buffers for in-place mutmap updates and savepoint rollback restores
- add a regression test for delete-then-reinsert on the same mutmap key in sorted and lazy modes

## Profiling notes
- file-backed wrapped sysbench write profiling showed allocator churn in repeated update paths under prollyMutMapInsert value replacement
- after this change, comparable BENCH_RUNS=1 BENCH_ROWS=10000 BENCH_SECTION_MODE=wrapped file-backed write average improved from about 1.46x SQLite to 1.32x SQLite
- notable movement: oltp_update_non_index 1.80x -> 1.58x, oltp_update_index 1.71x -> 1.64x, oltp_write_only 1.46x -> 1.29x

## Tests
- make -C build libdoltlite.a doltlite
- bash ../test/doltlite_regression_test_c.sh (from build/)
- BENCH_RUNS=1 BENCH_ROWS=10000 BENCH_SECTION_MODE=wrapped BENCH_MAX_MULTIPLIER=999 DOLTLITE=./build/doltlite SQLITE3=./build/sqlite3 bash test/sysbench_compare.sh