### PR TITLE
Defer tree seek for exact mutmap table hits

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -375,6 +375,7 @@ struct BtCursor {
   int mmPhysIdx;
   u8 mmActive;
   u8 mmPhysActive;
+  u8 deferredTreeSeek;
 #define MERGE_SRC_TREE  0
 #define MERGE_SRC_MUT   1
 #define MERGE_SRC_BOTH  2
@@ -2297,6 +2298,7 @@ static void clearMergeCursorState(BtCursor *pCur){
   pCur->mmPhysIdx = -1;
   pCur->mmActive = 0;
   pCur->mmPhysActive = 0;
+  pCur->deferredTreeSeek = 0;
   pCur->mergeSrc = MERGE_SRC_TREE;
 }
 
@@ -2314,6 +2316,7 @@ static void setCursorToMutMapEntryPhys(BtCursor *pCur, int physIdx){
   pCur->mmPhysIdx = physIdx;
   pCur->mmActive = 1;
   pCur->mmPhysActive = 1;
+  pCur->deferredTreeSeek = 0;
   pCur->mergeSrc = MERGE_SRC_MUT;
   pCur->eState = CURSOR_VALID;
   pCur->curFlags &= ~BTCF_AtLast;
@@ -2447,6 +2450,7 @@ static void refreshCursorMutMapAliases(BtShared *pBt, Pgno iTable,
       ** another cursor may have added. */
       p->mmActive = 0;
       p->mmPhysActive = 0;
+      p->deferredTreeSeek = 0;
       p->mmIdx = -1;
       p->mmPhysIdx = -1;
     }
@@ -2544,6 +2548,7 @@ static int saveCursorPosition(BtCursor *pCur){
   }
 
   prollyCursorReleaseAll(&pCur->pCur);
+  pCur->deferredTreeSeek = 0;
 
   pCur->eState = CURSOR_REQUIRESEEK;
   return SQLITE_OK;
@@ -5053,9 +5058,32 @@ static void cursorNormalizeMmPhys(BtCursor *pCur){
   }
 }
 
+static int materializeDeferredTreeSeek(BtCursor *pCur, int dir){
+  int rc;
+  int res = 0;
+  if( !pCur->deferredTreeSeek ) return SQLITE_OK;
+  pCur->deferredTreeSeek = 0;
+  refreshCursorRoot(pCur);
+  rc = prollyCursorSeekInt(&pCur->pCur, pCur->cachedIntKey, &res);
+  if( rc!=SQLITE_OK ) return rc;
+  if( res==0 ){
+    pCur->mergeSrc = MERGE_SRC_BOTH;
+  }else{
+    pCur->mergeSrc = MERGE_SRC_MUT;
+    if( dir>0 && res<0 && prollyCursorIsValid(&pCur->pCur) ){
+      rc = prollyCursorNext(&pCur->pCur);
+    }else if( dir<0 && res>0 && prollyCursorIsValid(&pCur->pCur) ){
+      rc = prollyCursorPrev(&pCur->pCur);
+    }
+  }
+  return rc;
+}
+
 static int mergeStepForward(BtCursor *pCur){
   int rc = SQLITE_OK;
   cursorNormalizeMmPhys(pCur);
+  rc = materializeDeferredTreeSeek(pCur, 1);
+  if( rc!=SQLITE_OK ) return rc;
   if( pCur->mergeSrc==MERGE_SRC_TREE || pCur->mergeSrc==MERGE_SRC_BOTH ){
     rc = advanceTreeCursor(pCur, 1);
     if( rc!=SQLITE_OK ) return rc;
@@ -5068,6 +5096,8 @@ static int mergeStepForward(BtCursor *pCur){
 static int mergeStepBackward(BtCursor *pCur){
   int rc = SQLITE_OK;
   cursorNormalizeMmPhys(pCur);
+  rc = materializeDeferredTreeSeek(pCur, -1);
+  if( rc!=SQLITE_OK ) return rc;
   if( pCur->mergeSrc==MERGE_SRC_TREE || pCur->mergeSrc==MERGE_SRC_BOTH ){
     rc = advanceTreeCursor(pCur, -1);
     if( rc!=SQLITE_OK ) return rc;
@@ -5406,13 +5436,8 @@ static int prollyBtCursorTableMoveto(
     if( pEntry ){
       if( pEntry->op == PROLLY_EDIT_INSERT ){
         *pRes = 0;
-        refreshCursorRoot(pCur);
-        {
-          int seekRes = 0;
-          rc = prollyCursorSeekInt(&pCur->pCur, intKey, &seekRes);
-          if( rc!=SQLITE_OK ) return rc;
-        }
         setCursorToMutMapEntryPhys(pCur, (int)(pEntry - pCur->pMutMap->aEntries));
+        pCur->deferredTreeSeek = 1;
         return SQLITE_OK;
       } else {
 

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -2846,6 +2846,39 @@ static void run_table_moveto_mutmap_delete_preserves_neighbors(void){
   remove_db(dbpath);
 }
 
+static void run_table_moveto_mutmap_exact_keeps_iteration_aligned(void){
+  sqlite3 *db = 0;
+  char dbpath[256];
+
+  printf("=== Table Moveto MutMap Exact Keeps Iteration Aligned Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_table_moveto_mutmap_exact_keeps_iteration_aligned");
+  remove_db(dbpath);
+
+  check("open_db_for_table_moveto_exact", open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_table_for_table_moveto_exact", execsql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'a');"
+    "INSERT INTO t VALUES(2,'b');"
+    "INSERT INTO t VALUES(3,'c');")==SQLITE_OK);
+  check("begin_txn_for_table_moveto_exact", execsql(db, "BEGIN IMMEDIATE;")==SQLITE_OK);
+  check("update_existing_row_for_table_moveto_exact",
+        execsql(db, "UPDATE t SET v='bb' WHERE id=2;")==SQLITE_OK);
+  check("table_moveto_exact_forward_iteration",
+        strcmp(exec1(db,
+          "SELECT group_concat(id || ':' || v, ',') "
+          "FROM (SELECT id, v FROM t WHERE id>=2 ORDER BY id)"),
+          "2:bb,3:c")==0);
+  check("table_moveto_exact_reverse_iteration",
+        strcmp(exec1(db,
+          "SELECT group_concat(id || ':' || v, ',') "
+          "FROM (SELECT id, v FROM t WHERE id<=2 ORDER BY id DESC)"),
+          "2:bb,1:a")==0);
+  check("rollback_table_moveto_exact_txn", execsql(db, "ROLLBACK;")==SQLITE_OK);
+
+  sqlite3_close(db);
+  remove_db(dbpath);
+}
+
 static void run_index_moveto_mutmap_exact_keeps_iteration_aligned(void){
   sqlite3 *db = 0;
   sqlite3_stmt *stmt = 0;
@@ -6305,6 +6338,7 @@ static const RegressionCase aCases[] = {
   { "diff_stat_requires_refs", "Diff Stat Requires Refs Test", run_diff_stat_requires_refs },
   { "diff_stat_surfaces_corrupt_root", "Diff Stat Surfaces Corrupt Root Test", run_diff_stat_surfaces_corrupt_root },
   { "table_moveto_mutmap_delete_preserves_neighbors", "Table Moveto MutMap Delete Preserves Neighbors Test", run_table_moveto_mutmap_delete_preserves_neighbors },
+  { "table_moveto_mutmap_exact_keeps_iteration_aligned", "Table Moveto MutMap Exact Keeps Iteration Aligned Test", run_table_moveto_mutmap_exact_keeps_iteration_aligned },
   { "index_moveto_mutmap_exact_keeps_iteration_aligned", "Index Moveto MutMap Exact Keeps Iteration Aligned Test", run_index_moveto_mutmap_exact_keeps_iteration_aligned },
   { "btree_commit_failure_transactional", "Btree Commit Failure Transaction Test", run_btree_commit_failure_transactional },
   { "savepoint_restores_session_metadata", "Savepoint Restores Session Metadata Test", run_savepoint_restores_session_metadata },


### PR DESCRIPTION
## Summary
- skip the immediate prolly tree seek when table moveto finds an exact INSERT entry in the mutmap
- defer tree positioning until cursor iteration actually steps
- materialize deferred seeks directionally so forward/reverse scans stay aligned and tree+mutmap overlap advances as BOTH
- add a regression test for forward and reverse rowid iteration after an in-transaction update

## Tests
- make -C build libdoltlite.a doltlite
- cc -g -I. -I../src -o doltlite_regression_test_c ../test/doltlite_regression_test_c.c libdoltlite.a -lz -lpthread -lm && ./doltlite_regression_test_c all
- BENCH_RUNS=1 BENCH_ROWS=10000 BENCH_SECTION_MODE=wrapped BENCH_MAX_MULTIPLIER=999 DOLTLITE=./build/doltlite SQLITE3=./build/sqlite3 bash test/sysbench_compare.sh