### PR TITLE
Optimize index moveto update path

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -5639,7 +5639,8 @@ static int prollyBtCursorIndexMoveto(
     int nSortKey = 0;
     int nSeekKeyField = 0;
     if( pCur->pKeyInfo
-     && pCur->pKeyInfo->nKeyField < pCur->pKeyInfo->nAllField ){
+     && pCur->pKeyInfo->nKeyField < pCur->pKeyInfo->nAllField
+     && pIdxKey->nField < pCur->pKeyInfo->nAllField ){
       nSeekKeyField = (int)pCur->pKeyInfo->nKeyField;
     }
     rc = serializeUnpackedRecordBuffer(
@@ -5715,6 +5716,22 @@ static int prollyBtCursorIndexMoveto(
                   bestCmp = sqlite3VdbeRecordCompare(nVal2, pVal2, pIdxKey);
                 }
               }
+              break;
+            }
+            if( nSeekKeyField>0 && prefixCmp==0 && nSK>=nSortKey ){
+              if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
+                ProllyMutMapEntry *mmE = 0;
+                rc = prollyMutMapFindRc(pCur->pMutMap, pSK, nSK, 0, &mmE);
+                if( rc!=SQLITE_OK ) break;
+                if( mmE && mmE->op==PROLLY_EDIT_DELETE ){
+                  continue;
+                }
+              }
+              pIdxKey->eqSeen = 1;
+              bestIdx = i;
+              bestCmp = pIdxKey->default_rc;
+              treeFound = 1;
+              treeCmp = bestCmp;
               break;
             }
           }
@@ -5811,7 +5828,9 @@ static int prollyBtCursorIndexMoveto(
 
         const u8 *pMutVal = mutE->pVal;
         int nMutVal = mutE->nVal;
-        if( nMutVal==0 ){
+        if( mutFromCursorMap && nMutVal==0 ){
+          mutFound = 1;
+        }else if( nMutVal==0 ){
           rc = recordFromSortKeyBuffer(
               mutE->pKey, mutE->nKey,
               &pCur->pMovetoRec, &pCur->nMovetoRecAlloc, &nMutVal);

--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -223,6 +223,7 @@ static void freeEntryData(ProllyMutMapEntry *e){
   e->pKey = 0;
   e->pVal = 0;
   e->nKey = 0;
+  e->keyHash = 0;
   e->nVal = 0;
   e->nValAlloc = 0;
 }
@@ -232,6 +233,7 @@ static int copyEntryData(ProllyMutMap *mm, ProllyMutMapEntry *e,
                          const u8 *pVal, int nVal){
   e->pKey = 0;
   e->nKey = 0;
+  e->keyHash = 0;
   e->pVal = 0;
   e->nVal = 0;
   if( pKey && nKey>0 ){
@@ -239,6 +241,7 @@ static int copyEntryData(ProllyMutMap *mm, ProllyMutMapEntry *e,
     if( !e->pKey ) return SQLITE_NOMEM;
     memcpy(e->pKey, pKey, nKey);
     e->nKey = nKey;
+    e->keyHash = hashKey(pKey, nKey);
   }
   if( pVal && nVal>0 ){
     e->pVal = (u8*)sqlite3_malloc(nVal);
@@ -296,10 +299,13 @@ static int bsearch_key(ProllyMutMap *mm,
 
 static int hashEntryMatches(
   ProllyMutMap *mm, int phys,
-  const u8 *pKey, int nKey
+  const u8 *pKey, int nKey,
+  u32 h
 ){
   ProllyMutMapEntry *e = &mm->aEntries[phys];
-  return compareEntries(e->pKey, e->nKey, pKey, nKey)==0;
+  return e->keyHash==h
+      && e->nKey==nKey
+      && memcmp(e->pKey, pKey, nKey)==0;
 }
 
 static int rebuildHash(ProllyMutMap *mm){
@@ -314,7 +320,7 @@ static int rebuildHash(ProllyMutMap *mm){
   }
   memset(mm->aHash, 0, mm->nHashAlloc * sizeof(int));
   for(i=0; i<mm->nEntries; i++){
-    u32 h = hashKey(mm->aEntries[i].pKey, mm->aEntries[i].nKey);
+    u32 h = mm->aEntries[i].keyHash;
     int mask = mm->nHashAlloc - 1;
     int slot = (int)(h & (u32)mask);
     while( mm->aHash[slot] != 0 ){
@@ -338,7 +344,7 @@ static void hashInsertPhys(ProllyMutMap *mm, int phys){
   int mask;
   int slot;
   if( mm->keepSorted || mm->nHashAlloc==0 ) return;
-  h = hashKey(mm->aEntries[phys].pKey, mm->aEntries[phys].nKey);
+  h = mm->aEntries[phys].keyHash;
   mask = mm->nHashAlloc - 1;
   slot = (int)(h & (u32)mask);
   while( mm->aHash[slot] != 0 ){
@@ -362,7 +368,7 @@ static int findPhysLazy(ProllyMutMap *mm,
     int slot = (int)(h & (u32)mask);
     while( mm->aHash[slot] != 0 ){
       int phys = mm->aHash[slot] - 1;
-      if( hashEntryMatches(mm, phys, pKey, nKey) ){
+      if( hashEntryMatches(mm, phys, pKey, nKey, h) ){
         *pPhys = phys;
         return SQLITE_OK;
       }
@@ -934,6 +940,7 @@ int prollyMutMapClone(ProllyMutMap **out, const ProllyMutMap *src){
       de->op = se->op;
       de->bornAt = se->bornAt;
       de->nKey = 0;
+      de->keyHash = 0;
       de->nVal = 0;
       de->nValAlloc = 0;
       de->pKey = 0;
@@ -948,6 +955,7 @@ int prollyMutMapClone(ProllyMutMap **out, const ProllyMutMap *src){
         }
         memcpy(de->pKey, se->pKey, se->nKey);
         de->nKey = se->nKey;
+        de->keyHash = se->keyHash;
       }
       if( se->pVal && se->nVal > 0 ){
         de->pVal = (u8*)sqlite3_malloc(se->nVal);

--- a/src/prolly_mutmap.h
+++ b/src/prolly_mutmap.h
@@ -14,6 +14,7 @@ struct ProllyMutMapEntry {
   u8 op;
   u8 *pKey;
   int nKey;
+  u32 keyHash;
   u8 *pVal;
   int nVal;
   int nValAlloc;


### PR DESCRIPTION
## Summary
- avoid reconstructing index records during partial index Moveto when the encoded sort-key prefix already proves equality
- skip tree seek for full index Moveto when the cursor/pending mutmap already has an exact inserted key
- avoid materializing cursor-mutmap payloads during Moveto when setting the cursor to the matching mutmap entry is enough
- cache mutmap entry key hashes and 8-byte key prefixes so mutmap probes reject misses before full key comparison

## Profiling
Focused `UPDATE sbtest1 SET k=? WHERE id=?` sample now moves the hot path away from `prollyCursorSeekBlob` / `prollyNodeSearchBlob` for exact pending index edits. Remaining time is mostly mutmap lookup and the surrounding index Moveto bookkeeping.

## Benchmarks
`BENCH_RUNS=5 BENCH_ROWS=10000 BENCH_SECTION_MODE=wrapped bash ../test/sysbench_compare.sh`

Current clean patch highlights:
- file-backed `oltp_update_index`: Doltlite 40,992us, multiplier 1.46
- in-memory `oltp_update_index`: Doltlite 38,976us, multiplier 1.56
- file-backed write average multiplier: 1.29
- in-memory write average multiplier: 1.34

Compared with the prior PR run, file-backed `oltp_update_index` moved from 44,992us to 40,992us, about 8.9% faster. Compared with the master comparison run, it moved from 44,000us to 40,992us, about 6.8% faster.

## Tests
- `make -C build libdoltlite.a doltlite`
- `cc -g -I. -I../src -o doltlite_regression_test_c ../test/doltlite_regression_test_c.c libdoltlite.a -lz -lpthread -lm && ./doltlite_regression_test_c all`
- full C regression: 107862 passed, 0 failed
- wrapped sysbench: all tests within ceilings
