### PR TITLE
Skip index tree seek for exact mutmap hits

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -5653,6 +5653,41 @@ static int prollyBtCursorIndexMoveto(
     if( rc!=SQLITE_OK ) return rc;
     pSortKey = pCur->pSeekSortKey;
 
+    if( pCur->pKeyInfo
+     && pIdxKey->nField >= pCur->pKeyInfo->nAllField ){
+      struct TableEntry *pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
+      ProllyMutMap *pPending = pTE ? (ProllyMutMap*)pTE->pPending : 0;
+      ProllyMutMapEntry *pEntry = 0;
+      if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
+        rc = prollyMutMapFindRc(pCur->pMutMap, pSortKey, nSortKey, 0, &pEntry);
+        if( rc!=SQLITE_OK ) return rc;
+        if( pEntry && pEntry->op==PROLLY_EDIT_INSERT ){
+          setCursorToMutMapEntryPhys(
+              pCur, (int)(pEntry - pCur->pMutMap->aEntries));
+          *pRes = 0;
+          pIdxKey->eqSeen = 1;
+          return SQLITE_OK;
+        }
+      }
+      if( pPending && pPending!=pCur->pMutMap
+       && !prollyMutMapIsEmpty(pPending) ){
+        rc = prollyMutMapFindRc(pPending, pSortKey, nSortKey, 0, &pEntry);
+        if( rc!=SQLITE_OK ) return rc;
+        if( pEntry && pEntry->op==PROLLY_EDIT_INSERT ){
+          if( pEntry->nVal>0 && pEntry->pVal ){
+            rc = cacheCursorPayloadCopy(pCur, pEntry->pVal, pEntry->nVal);
+          }else{
+            rc = cacheCursorPayloadReconstructed(
+                pCur, pEntry->pKey, pEntry->nKey);
+          }
+          if( rc!=SQLITE_OK ) return rc;
+          pCur->eState = CURSOR_VALID;
+          *pRes = 0;
+          pIdxKey->eqSeen = 1;
+          return SQLITE_OK;
+        }
+      }
+    }
 
     rc = prollyCursorSeekBlob(&pCur->pCur, pSortKey, nSortKey, &(int){0});
     if( rc==SQLITE_OK && pCur->pCur.eState==PROLLY_CURSOR_VALID ){

--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -93,6 +93,17 @@ static ProllyMutMapEntry *entryAtOrder(ProllyMutMap *mm, int idx){
   return &mm->aEntries[mm->aOrder[idx]];
 }
 
+static int compareEntryToKey(
+  const ProllyMutMapEntry *e,
+  const u8 *pKey, int nKey,
+  u64 keyPrefix
+){
+  if( e->keyPrefix != keyPrefix ){
+    return e->keyPrefix < keyPrefix ? -1 : 1;
+  }
+  return compareEntries(e->pKey, e->nKey, pKey, nKey);
+}
+
 static u32 hashKey(const u8 *pKey, int nKey){
   u32 h = 2166136261u;
   int i;
@@ -195,7 +206,7 @@ static int mutmapSortOrder(ProllyMutMap *mm){
   scratch = (OrderPair*)mm->aSortScratch;
   for(i=0; i<n; i++){
     ProllyMutMapEntry *e = &mm->aEntries[i];
-    scratch[i].prefix = keyPrefix64(e->pKey, e->nKey);
+    scratch[i].prefix = e->keyPrefix;
     scratch[i].phys = i;
     scratch[i].pad = 0;
   }
@@ -223,6 +234,7 @@ static void freeEntryData(ProllyMutMapEntry *e){
   e->pKey = 0;
   e->pVal = 0;
   e->nKey = 0;
+  e->keyPrefix = 0;
   e->keyHash = 0;
   e->nVal = 0;
   e->nValAlloc = 0;
@@ -233,6 +245,7 @@ static int copyEntryData(ProllyMutMap *mm, ProllyMutMapEntry *e,
                          const u8 *pVal, int nVal){
   e->pKey = 0;
   e->nKey = 0;
+  e->keyPrefix = 0;
   e->keyHash = 0;
   e->pVal = 0;
   e->nVal = 0;
@@ -241,6 +254,7 @@ static int copyEntryData(ProllyMutMap *mm, ProllyMutMapEntry *e,
     if( !e->pKey ) return SQLITE_NOMEM;
     memcpy(e->pKey, pKey, nKey);
     e->nKey = nKey;
+    e->keyPrefix = keyPrefix64(pKey, nKey);
     e->keyHash = hashKey(pKey, nKey);
   }
   if( pVal && nVal>0 ){
@@ -280,11 +294,12 @@ static int bsearch_key(ProllyMutMap *mm,
                        const u8 *pKey, int nKey,
                        int *pFound){
   int lo = 0, hi = mm->nEntries;
+  u64 prefix = keyPrefix64(pKey, nKey);
   *pFound = 0;
   while( lo < hi ){
     int mid = lo + (hi - lo) / 2;
     ProllyMutMapEntry *e = entryAtOrder(mm, mid);
-    int c = compareEntries(e->pKey, e->nKey, pKey, nKey);
+    int c = compareEntryToKey(e, pKey, nKey, prefix);
     if( c < 0 ){
       lo = mid + 1;
     }else if( c > 0 ){
@@ -940,6 +955,7 @@ int prollyMutMapClone(ProllyMutMap **out, const ProllyMutMap *src){
       de->op = se->op;
       de->bornAt = se->bornAt;
       de->nKey = 0;
+      de->keyPrefix = 0;
       de->keyHash = 0;
       de->nVal = 0;
       de->nValAlloc = 0;
@@ -955,6 +971,7 @@ int prollyMutMapClone(ProllyMutMap **out, const ProllyMutMap *src){
         }
         memcpy(de->pKey, se->pKey, se->nKey);
         de->nKey = se->nKey;
+        de->keyPrefix = se->keyPrefix;
         de->keyHash = se->keyHash;
       }
       if( se->pVal && se->nVal > 0 ){

--- a/src/prolly_mutmap.h
+++ b/src/prolly_mutmap.h
@@ -14,6 +14,7 @@ struct ProllyMutMapEntry {
   u8 op;
   u8 *pKey;
   int nKey;
+  u64 keyPrefix;
   u32 keyHash;
   u8 *pVal;
   int nVal;


### PR DESCRIPTION
## Summary
- skip the prolly tree seek in index Moveto when a full index key already has an exact inserted entry in the cursor/pending mutmap
- cache an 8-byte key prefix on mutmap entries so sorted mutmap binary search can reject most comparisons before memcmp

## Profiling
Focused `UPDATE sbtest1 SET k=? WHERE id=?` profile moved the exact pending-index-edit path away from `prollyCursorSeekBlob` / `prollyNodeSearchBlob`; remaining time is mostly mutmap lookup and index Moveto bookkeeping.

## Benchmarks
`BENCH_RUNS=5 BENCH_ROWS=10000 BENCH_SECTION_MODE=wrapped bash ../test/sysbench_compare.sh`

Clean patch highlights from the run before splitting this branch from landed #767:
- file-backed `oltp_update_index`: Doltlite 40,992us, multiplier 1.46
- in-memory `oltp_update_index`: Doltlite 38,976us, multiplier 1.56
- file-backed write average multiplier: 1.29
- in-memory write average multiplier: 1.34

Compared with the prior #767 run, file-backed `oltp_update_index` moved from 44,992us to 40,992us, about 8.9% faster. Compared with the master comparison run, it moved from 44,000us to 40,992us, about 6.8% faster.

## Tests
- `make -C build libdoltlite.a doltlite`
- `cc -g -I. -I../src -o doltlite_regression_test_c ../test/doltlite_regression_test_c.c libdoltlite.a -lz -lpthread -lm && ./doltlite_regression_test_c all`
- full C regression: 107862 passed, 0 failed
- wrapped sysbench: all tests within ceilings
