### PR TITLE
Optimize numeric sortkey read path

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -4098,6 +4098,9 @@ static int prollyBtreeBeginTrans(Btree *p, int wrFlag, int *pSchemaVersion){
     return SQLITE_OK;
   }
 
+  if( p->inTrans==TRANS_READ && !wrFlag ){
+    return SQLITE_OK;
+  }
 
   rc = btreeRefreshFromDisk(p);
   if( rc!=SQLITE_OK ) return rc;

--- a/src/sortkey.c
+++ b/src/sortkey.c
@@ -321,6 +321,88 @@ static void writeIntBE(u8 *p, i64 v, int nByte){
   }
 }
 
+static SQLITE_INLINE void decodeNumericSortKeyToRecord(
+  const u8 *pIn,
+  u32 *pType,
+  u32 *pLen,
+  u8 *pOut
+){
+  u8 buf[8];
+  double d;
+  u64 x;
+  int i;
+
+  memcpy(buf, pIn, 8);
+  if( buf[0] & 0x80 ){
+    buf[0] ^= 0x80;
+  }else{
+    for(i = 0; i < 8; i++) buf[i] = ~buf[i];
+  }
+
+  x = ((u64)buf[0] << 56) | ((u64)buf[1] << 48)
+    | ((u64)buf[2] << 40) | ((u64)buf[3] << 32)
+    | ((u64)buf[4] << 24) | ((u64)buf[5] << 16)
+    | ((u64)buf[6] << 8)  | (u64)buf[7];
+  memcpy(&d, &x, 8);
+
+  {
+    i64 iv = (i64)d;
+    if( (double)iv == d && d >= -9.22e18 && d <= 9.22e18 ){
+      intSerialType(iv, pType, pLen);
+      writeIntBE(pOut, iv, (int)*pLen);
+    }else{
+      *pType = 7;
+      *pLen = 8;
+      memcpy(pOut, buf, 8);
+    }
+  }
+}
+
+static int recordFromTwoNumericSortKeyBuffer(
+  const u8 *pSortKey, int nSortKey,
+  u8 **ppBuf, int *pnAlloc, int *pnOut
+){
+  u32 aType[2];
+  u32 aLen[2];
+  u8 aBuf[2][8];
+  int nTotal;
+  int off;
+  u8 *pOut;
+
+  if( nSortKey!=18
+   || pSortKey[0]!=SORTKEY_NUM
+   || pSortKey[9]!=SORTKEY_NUM ){
+    return SQLITE_NOTFOUND;
+  }
+
+  decodeNumericSortKeyToRecord(pSortKey + 1, &aType[0], &aLen[0], aBuf[0]);
+  decodeNumericSortKeyToRecord(pSortKey + 10, &aType[1], &aLen[1], aBuf[1]);
+
+  nTotal = 3 + (int)aLen[0] + (int)aLen[1];
+  if( *pnAlloc < nTotal ){
+    u8 *pNew = (u8*)sqlite3_realloc(*ppBuf, nTotal);
+    if( !pNew ) return SQLITE_NOMEM;
+    *ppBuf = pNew;
+    *pnAlloc = nTotal;
+  }
+  pOut = *ppBuf;
+
+  pOut[0] = 3;
+  pOut[1] = (u8)aType[0];
+  pOut[2] = (u8)aType[1];
+  off = 3;
+  if( aLen[0]>0 ){
+    memcpy(pOut + off, aBuf[0], aLen[0]);
+    off += (int)aLen[0];
+  }
+  if( aLen[1]>0 ){
+    memcpy(pOut + off, aBuf[1], aLen[1]);
+  }
+
+  *pnOut = nTotal;
+  return SQLITE_OK;
+}
+
 int recordFromSortKeyBuffer(
   const u8 *pSortKey, int nSortKey,
   u8 **ppBuf, int *pnAlloc, int *pnOut
@@ -351,6 +433,12 @@ int recordFromSortKeyBuffer(
     return SQLITE_OK;
   }
 
+  {
+    int rc = recordFromTwoNumericSortKeyBuffer(pSortKey, nSortKey,
+                                               ppBuf, pnAlloc, pnOut);
+    if( rc!=SQLITE_NOTFOUND ) return rc;
+  }
+
 
   while( pos < nSortKey && nFields < 64 ){
     u8 tag = pSortKey[pos++];
@@ -363,42 +451,12 @@ int recordFromSortKeyBuffer(
 
     }else if( tag == SORTKEY_NUM ){
 
-      u8 buf[8];
-      double d;
-      u64 x;
       if( pos + 8 > nSortKey ) return SQLITE_CORRUPT;
-      memcpy(buf, pSortKey + pos, 8);
+      decodeNumericSortKeyToRecord(pSortKey + pos,
+                                   &aType[nFields], &aLen[nFields],
+                                   aIntBuf[nFields]);
       pos += 8;
-
-      if( buf[0] & 0x80 ){
-
-        buf[0] ^= 0x80;
-      }else{
-
-        for(i = 0; i < 8; i++) buf[i] = ~buf[i];
-      }
-
-      x = ((u64)buf[0] << 56) | ((u64)buf[1] << 48)
-        | ((u64)buf[2] << 40) | ((u64)buf[3] << 32)
-        | ((u64)buf[4] << 24) | ((u64)buf[5] << 16)
-        | ((u64)buf[6] << 8)  | (u64)buf[7];
-      memcpy(&d, &x, 8);
-
-      {
-        i64 iv = (i64)d;
-        if( (double)iv == d && d >= -9.22e18 && d <= 9.22e18 ){
-
-          intSerialType(iv, &aType[nFields], &aLen[nFields]);
-          writeIntBE(aIntBuf[nFields], iv, (int)aLen[nFields]);
-          aFieldPtr[nFields] = aIntBuf[nFields];
-        }else{
-
-          aType[nFields] = 7;
-          aLen[nFields] = 8;
-          memcpy(aIntBuf[nFields], buf, 8);
-          aFieldPtr[nFields] = aIntBuf[nFields];
-        }
-      }
+      aFieldPtr[nFields] = aIntBuf[nFields];
       nFields++;
 
     }else if( tag == SORTKEY_TEXT || tag == SORTKEY_BLOB ){

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -67,6 +67,7 @@
 #include "prolly_mutate.h"
 #include "prolly_node.h"
 #include "prolly_mutmap.h"
+#include "sortkey.h"
 
 typedef unsigned char u8;
 typedef unsigned int Pgno;
@@ -1942,6 +1943,38 @@ static void run_record_decode_corruption(void){
   z = doltliteDecodeRecord(badRecord, (int)sizeof(badRecord));
   check("corrupt_record_decodes_to_null", z==0);
   sqlite3_free(z);
+}
+
+static void run_sortkey_two_numeric_roundtrip(void){
+  static const u8 record[] = {
+    0x03,       /* header size */
+    0x01,       /* 1-byte integer */
+    0x03,       /* 3-byte integer */
+    0x7b,       /* 123 */
+    0x06, 0xf8, 0x55  /* 456789 */
+  };
+  u8 *pSortKey = 0;
+  u8 *pRoundTrip = 0;
+  int nSortKey = 0;
+  int nRoundTrip = 0;
+  int rc;
+
+  printf("=== Sortkey Two Numeric Roundtrip Test ===\n\n");
+
+  rc = sortKeyFromRecord(record, (int)sizeof(record), &pSortKey, &nSortKey);
+  check("two_numeric_sortkey_encode_ok", rc==SQLITE_OK);
+  check("two_numeric_sortkey_has_expected_width", nSortKey==18);
+
+  if( rc==SQLITE_OK ){
+    rc = recordFromSortKey(pSortKey, nSortKey, &pRoundTrip, &nRoundTrip);
+    check("two_numeric_sortkey_decode_ok", rc==SQLITE_OK);
+    check("two_numeric_sortkey_roundtrips",
+      nRoundTrip==(int)sizeof(record)
+      && memcmp(pRoundTrip, record, sizeof(record))==0);
+  }
+
+  sqlite3_free(pSortKey);
+  sqlite3_free(pRoundTrip);
 }
 
 static void run_reload_refs_transactional(void){
@@ -6349,6 +6382,7 @@ static const RegressionCase aCases[] = {
   { "branches_metadata_corruption", "Branches Metadata Corruption Test", run_branches_metadata_corruption },
   { "gc_rewrite_failure", "GC Rewrite Failure Test", run_gc_rewrite_failure },
   { "record_decode_corruption", "Record Decode Corruption Test", run_record_decode_corruption },
+  { "sortkey_two_numeric_roundtrip", "Sortkey Two Numeric Roundtrip Test", run_sortkey_two_numeric_roundtrip },
   { "reload_refs_transactional", "Reload Refs Transactional Test", run_reload_refs_transactional },
   { "refresh_refs_corruption_preserves_state", "Refresh Corrupt Refs State Preservation Test", run_refresh_refs_corruption_preserves_state },
   { "prolly_node_corruption", "Prolly Node Corruption Test", run_prolly_node_corruption },


### PR DESCRIPTION
## Summary
- skip refresh work when a btree is already in a read transaction
- add a narrow two-numeric-field sortkey reconstruction fast path for secondary index payloads
- add focused roundtrip regression coverage for the two-numeric sortkey path

## Benchmarks
File-backed wrapped sysbench, 10k rows, 5 runs:
- read average multiplier: 1.15x clean baseline -> 1.08x
- covering_index_scan: 13,984us -> 12,000us
- index_join: 7,008us -> 5,984us
- index_join_scan: 4,000us -> 3,008us

Profile sample:
- recordFromSortKeyBuffer top-stack samples on covering_index_scan dropped from ~1907 to ~1200 after narrowing the fast path

## Tests
- make -C build libdoltlite.a doltlite
- cd build && cc -g -I. -I../src -o doltlite_regression_test_c ../test/doltlite_regression_test_c.c libdoltlite.a -lz -lpthread -lm
- ./doltlite_regression_test_c sortkey_two_numeric_roundtrip
- ./doltlite_regression_test_c all: 107866 passed, 0 failed
- BENCH_RUNS=5 BENCH_ROWS=10000 BENCH_SECTION_MODE=wrapped bash ../test/sysbench_compare.sh