### PR TITLE
Cache payload after prollyBtCursorNext for INTKEY tables

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -5254,6 +5254,23 @@ static int prollyBtCursorNext(BtCursor *pCur, int flags){
       if( rc==SQLITE_OK ){
         if( pCur->pCur.eState==PROLLY_CURSOR_VALID ){
           pCur->eState = CURSOR_VALID;
+          /* Table scans call xPayloadSize then xPayloadFetch on every
+          ** advanced row. Both go through getCursorPayload which has
+          ** a multi-branch chain (cache, mutmap, intkey). Cache the
+          ** (pData, nData) pair eagerly here so both subsequent
+          ** trips hit the early-return at the top of getCursorPayload.
+          ** The pointer borrows the leaf node memory; the cache is
+          ** invalidated by CLEAR_CACHED_PAYLOAD on the next move.
+          ** INTKEY-only — non-INTKEY may need reconstruction which
+          ** the original path handles. */
+          if( pCur->curIntKey ){
+            const u8 *pVal; int nVal;
+            prollyCursorValue(&pCur->pCur, &pVal, &nVal);
+            if( nVal > 0 ){
+              pCur->pCachedPayload = (u8*)pVal;
+              pCur->nCachedPayload = nVal;
+            }
+          }
         } else {
           pCur->eState = CURSOR_INVALID;
           return SQLITE_DONE;


### PR DESCRIPTION
## Summary
Table scans (and any \"advance then read columns\" iteration) call `sqlite3BtreePayloadSize` then `sqlite3BtreePayloadFetch` on every advanced row. Both go through `getCursorPayload`, which has a multi-branch chain: cached-payload check, mutmap-active check, mergeSrc check, INTKEY/blob branch, then `prollyCursorValue`. Two trips through that chain per row × 10K rows × scan-heavy queries adds up.

This change eagerly populates `pCachedPayload` from the new tree entry once after `Next` succeeds in the simple INTKEY (no-mutmap) path. Both subsequent calls short-circuit at the early-return at the top of `getCursorPayload`. The pointer borrows the leaf node memory (kept alive via the cursor's leaf reference); the existing `CLEAR_CACHED_PAYLOAD` on the next move keeps it valid for exactly one row.

## Benchmarks
Best-of-5 file-backed (5× scaled, arm64 macOS, NEON BLAKE3):

| Test | master | this PR | Δ |
|------|--------|---------|---|
| oltp_table_scan | 1.517s | 1.472s | **−3.0%** |
| oltp_order_range | 0.075s | 0.071s | **−5.3%** |
| oltp_range_select | 0.300s | 0.293s | **−2.3%** |
| oltp_update_index | 1.819s | 1.747s | **−4.0%** (UPDATE seeks first) |
| oltp_oltp_insert | 0.772s | 0.762s | −1.3% |

Other read/write tests: flat or in noise band.

vs vanilla SQLite on `table_scan`: 1.18× → 1.14× — closes ~25% of the gap.

## Tests
- [x] \`make doltlite\` — clean build
- [x] \`make libdoltlite.a && ./doltlite_regression_test_c all\` — 107,855 / 107,855 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)