### PR TITLE
Restore eager payload cache on the no-mutmap Next fast-path

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -5257,6 +5257,23 @@ static int prollyBtCursorNext(BtCursor *pCur, int flags){
     if( rc==SQLITE_OK ){
       if( pCur->pCur.eState==PROLLY_CURSOR_VALID ){
         pCur->eState = CURSOR_VALID;
+        /* Pre-populate the payload cache for INTKEY clean-read scans
+        ** (same idea as PR #770, restored on Tim's no-mutmap fast
+        ** path). xPayloadSize then xPayloadFetch are both called per
+        ** row during OP_Column / table scans; both go through
+        ** getCursorPayload's multi-branch chain. Caching the
+        ** (pData, nData) pair here makes both subsequent trips hit
+        ** the early-return at the top of getCursorPayload. The
+        ** pointer borrows the leaf node memory; CLEAR_CACHED_PAYLOAD
+        ** on the next move keeps it valid for exactly one row. */
+        if( pCur->curIntKey ){
+          const u8 *pVal; int nVal;
+          cursorCurrentTreeValue(pCur, &pVal, &nVal);
+          if( nVal > 0 ){
+            pCur->pCachedPayload = (u8*)pVal;
+            pCur->nCachedPayload = nVal;
+          }
+        }
       } else {
         pCur->eState = CURSOR_INVALID;
         return SQLITE_DONE;


### PR DESCRIPTION
## Summary
PR #772 added a clean-read fast-path in `prollyBtCursorNext` that short-circuits the mutmap setup when no mutmap is in play. The short-circuit also bypassed the eager payload cache populate that PR #770 added, so `xPayloadSize` and `xPayloadFetch` on table-scan rows went back to walking `getCursorPayload`'s branch chain twice per row instead of hitting the early-return cache.

This PR restores the cache populate inside the fast-path. `cursorCurrentTreeValue` (Tim's inlined helper from PR #772) gives us the leaf `(pVal, nVal)` pair without re-entering `prollyCursorValue`.

## Benchmarks (best-of-5, arm64 macOS, NEON BLAKE3)

| Test | master | this PR | Δ |
|------|--------|---------|---|
| oltp_table_scan | 1.541s | 1.494s | **−3.0%** |
| oltp_range_select | 0.288s | 0.281s | −2.4% |
| oltp_index_join_scan | 0.080s | 0.078s | −2.5% |

Other read tests: flat or in noise band.

## Tests
- [x] \`make doltlite\` — clean build
- [x] \`make libdoltlite.a && ./doltlite_regression_test_c all\` — 107,866 / 107,866 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)