### PR TITLE
Fast path same-leaf cursor next

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -456,6 +456,17 @@ static SQLITE_INLINE void cacheCurrentTreePayloadIfIntKey(BtCursor *pCur){
     }
   }
 }
+
+static SQLITE_INLINE int prollyCursorNextFastLeaf(ProllyCursor *pCur){
+  ProllyCursorLevel *pLevel = &pCur->aLevel[pCur->iLevel];
+  ProllyCacheEntry *pLeaf = pLevel->pEntry;
+  assert( pCur->eState==PROLLY_CURSOR_VALID );
+  if( pLevel->idx < pLeaf->node.nItems - 1 ){
+    pLevel->idx++;
+    return SQLITE_OK;
+  }
+  return prollyCursorNext(pCur);
+}
 static int flushDeferredEdits(BtShared *pBt);
 static int ensureMutMap(BtCursor *pCur);
 static int saveCursorPosition(BtCursor *pCur);
@@ -5265,7 +5276,7 @@ static int prollyBtCursorNext(BtCursor *pCur, int flags){
   }
 
   if( !pCur->mmActive && pCur->pMutMap==0 ){
-    rc = prollyCursorNext(&pCur->pCur);
+    rc = prollyCursorNextFastLeaf(&pCur->pCur);
     if( rc==SQLITE_OK ){
       if( pCur->pCur.eState==PROLLY_CURSOR_VALID ){
         pCur->eState = CURSOR_VALID;
@@ -5326,7 +5337,7 @@ static int prollyBtCursorNext(BtCursor *pCur, int flags){
         pCur->eState = CURSOR_VALID;
       }
     }else{
-      rc = prollyCursorNext(&pCur->pCur);
+      rc = prollyCursorNextFastLeaf(&pCur->pCur);
       if( rc==SQLITE_OK ){
         if( pCur->pCur.eState==PROLLY_CURSOR_VALID ){
           pCur->eState = CURSOR_VALID;


### PR DESCRIPTION
## Summary

Add a small same-leaf fast path for clean cursor `Next` calls.

During scans, most `prollyBtCursorNext()` calls only advance to the next item in the current leaf. This avoids calling the full `prollyCursorNext()` path until the current leaf is exhausted, while preserving the existing full walk at leaf boundaries.

## Validation

- `git diff --check`
- `make -C build libdoltlite.a doltlite`
- `cd build && cc -g -I. -I../src -o doltlite_regression_test_c ../test/doltlite_regression_test_c.c libdoltlite.a -lz -lpthread -lm && ./doltlite_regression_test_c all`
  - `107866 passed, 0 failed`

## Profiling / Benchmarks

Table-scan profile:

- `prollyCursorNext` top-stack samples before: about `66`
- `prollyCursorNext` top-stack samples after: about `6`

Wrapped sysbench, file-backed reads:

- `table_scan`: `144,000 us`
- Recent prior runs on master/near-master were in the `146k-149k us` range

I also tried a more aggressive payload-size/cache folding follow-up, but it worsened file-backed `table_scan` / `oltp_read_only`, so this PR keeps only the lower-risk same-leaf cursor advance.
