### PR TITLE
Reuse buffers in TEXT-PK write paths

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -5568,7 +5568,14 @@ static int findMatchingMutMapEntry(
   int rc = SQLITE_OK;
   int cmp = 0;
   ProllyMutMapEntry *pMatch = 0;
+  /* Single scratch reused across both the binary-search and post-scan
+  ** linear loops. The original code freed and re-allocated per mid
+  ** iteration; for index seeks against an N-entry mutmap that's
+  ** ~log2(N) malloc/free pairs and ~log2(N) sort-key→record transcodes
+  ** per Seek. With reuse, the buffer grows to fit the largest record
+  ** seen and stays. Freed once at function exit. */
   u8 *pRecBuf = 0;
+  int nRecBufAlloc = 0;
   int lo, hi;
 
   *ppMatch = 0;
@@ -5602,9 +5609,8 @@ static int findMatchingMutMapEntry(
       continue;
     }
     if( nRec==0 ){
-      sqlite3_free(pRecBuf);
-      pRecBuf = 0;
-      rc = recordFromSortKey(pEntry->pKey, pEntry->nKey, &pRecBuf, &nRec);
+      rc = recordFromSortKeyBuffer(pEntry->pKey, pEntry->nKey,
+                                    &pRecBuf, &nRecBufAlloc, &nRec);
       if( rc!=SQLITE_OK ) break;
       pRec = pRecBuf;
     }
@@ -5628,9 +5634,8 @@ static int findMatchingMutMapEntry(
       continue;
     }
     if( nRec==0 ){
-      sqlite3_free(pRecBuf);
-      pRecBuf = 0;
-      rc = recordFromSortKey(pEntry->pKey, pEntry->nKey, &pRecBuf, &nRec);
+      rc = recordFromSortKeyBuffer(pEntry->pKey, pEntry->nKey,
+                                    &pRecBuf, &nRecBufAlloc, &nRec);
       if( rc!=SQLITE_OK ) break;
       pRec = pRecBuf;
     }
@@ -6165,7 +6170,6 @@ static int prollyBtCursorInsert(
     sqlite3_free(pBuf);
   } else {
 
-    u8 *pSortKey = 0;
     int nSortKey = 0;
     int nKeyField = 0;
     int splitKey = 0;
@@ -6184,22 +6188,24 @@ static int prollyBtCursorInsert(
         isIndex = (pTE && !tableEntryIsTableRoot(pCur->pBtree, pTE));
       }
     }
-    rc = sortKeyFromRecordPrefixColl((const u8*)pPayload->pKey,
-                                      (int)pPayload->nKey,
-                                      isIndex ? 0 : (splitKey ? nKeyField : 0),
-                                      pCur->pKeyInfo,
-                                      &pSortKey, &nSortKey);
+    /* Reuse the cursor's scratch sort-key buffer (also used by
+    ** IndexMoveto) so transaction-scale Insert loops avoid a
+    ** malloc/free pair per row. Owned by the cursor; freed at close. */
+    rc = sortKeyFromRecordPrefixCollBuffer(
+        (const u8*)pPayload->pKey, (int)pPayload->nKey,
+        isIndex ? 0 : (splitKey ? nKeyField : 0),
+        pCur->pKeyInfo,
+        &pCur->pSeekSortKey, &pCur->nSeekSortKeyAlloc, &nSortKey);
     if( rc==SQLITE_OK ){
       if( splitKey ){
         rc = prollyMutMapInsert(pCur->pMutMap,
-                                 pSortKey, nSortKey, 0,
+                                 pCur->pSeekSortKey, nSortKey, 0,
                                  (const u8*)pPayload->pKey, (int)pPayload->nKey);
       }else{
         rc = prollyMutMapInsert(pCur->pMutMap,
-                                 pSortKey, nSortKey, 0,
+                                 pCur->pSeekSortKey, nSortKey, 0,
                                  NULL, 0);
       }
-      sqlite3_free(pSortKey);
     }
   }
 


### PR DESCRIPTION
## Summary
Following up on the TEXT-PK write-path investigation: profiling showed `prollyBtCursorInsert` and `findMatchingMutMapEntry` both allocating + freeing scratch buffers per row inside transaction-scale loops.

- **prollyBtCursorInsert**: encoded a fresh sort-key per non-INTKEY row, malloc'd at line 6207 and free'd at the end. For 50K-row TEXT-PK Insert loops that's 50K malloc/free pairs.
- **findMatchingMutMapEntry**: the binary-search loop free'd and re-allocated `pRecBuf` per mid iteration when transcoding sort-key entries back to records. ~log2(N) malloc/free pairs per Seek.

Switched both to the existing buffered variants:
- Insert reuses `pCur->pSeekSortKey` (cursor-owned, also used by IndexMoveto). One scratch per cursor, freed at close.
- `findMatchingMutMapEntry` uses a single `pRecBuf` grown to fit the largest record across both binary-search and post-scan loops; freed once at function exit. Removes the per-mid free+alloc.

Note: the Delete path and `OP_NotExists` pre-encode also allocate per-call, but converting them needs more scaffolding (Delete tracks an alias/owned distinction); leaving those for a follow-up.

The full \"2× TEXT-PK\" antipattern Tim suspected didn't show up at this scale — the TEXT-PK file-backed wrapped-write average is now 1.26× SQLite (down from earlier states). Most of the heavy lifting was already done by PRs #765–#774.

## Benchmarks
Best-of-5 file-backed TEXT-PK writes (10K rows, 50K ops, arm64 macOS, NEON BLAKE3):

| Test | master | this PR | vs SQLite (was→now) |
|------|--------|---------|---------------------|
| textpk_update_index | 1.221s | 1.189s | 1.39× → 1.35× |
| textpk_delete_insert | 1.047s | 1.034s | 1.54× → 1.53× |
| textpk_insert | 0.549s | 0.527s | 1.09× → **1.04×** |
| textpk_update_non_index | 0.860s | 0.852s | 1.35× → 1.34× |

INTEGER-PK sanity (best-of-3): flat or small wins, no regressions.

## Tests
- [x] \`make doltlite\` — clean build
- [x] \`make libdoltlite.a && ./doltlite_regression_test_c all\` — 107,866 / 107,866 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)