### PR TITLE
Fast path cached payload fetch

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -6075,6 +6075,9 @@ static u32 prollyBtCursorPayloadSize(BtCursor *pCur){
   const u8 *pData;
   int nData;
   assert( pCur->eState==CURSOR_VALID );
+  if( pCur->pCachedPayload && pCur->nCachedPayload > 0 ){
+    return (u32)pCur->nCachedPayload;
+  }
   getCursorPayload(pCur, &pData, &nData);
   return (u32)nData;
 }
@@ -6106,6 +6109,10 @@ static const void *prollyBtCursorPayloadFetch(BtCursor *pCur, u32 *pAmt){
   int nData;
 
   assert( pCur->eState==CURSOR_VALID );
+  if( pCur->pCachedPayload && pCur->nCachedPayload > 0 ){
+    if( pAmt ) *pAmt = (u32)pCur->nCachedPayload;
+    return (const void*)pCur->pCachedPayload;
+  }
   getCursorPayload(pCur, &pData, &nData);
 
   if( pAmt ) *pAmt = (u32)nData;


### PR DESCRIPTION
## Summary

Use the cached table payload directly from `xPayloadSize` and `xPayloadFetch` when `Next` has already populated it.

The read cursor now eagerly caches the current INTKEY row payload on common scan paths. `OP_Column` calls `sqlite3BtreePayloadSize()` and `sqlite3BtreePayloadFetch()` immediately after cursor movement, so this avoids another trip through `getCursorPayload()` for the cached case.

## Validation

- `git diff --check`
- `make -C build libdoltlite.a doltlite`
- `cd build && cc -g -I. -I../src -o doltlite_regression_test_c ../test/doltlite_regression_test_c.c libdoltlite.a -lz -lpthread -lm && ./doltlite_regression_test_c all`
  - `107866 passed, 0 failed`

## Profiling / Benchmarks

Table-scan profile confirms `getCursorPayload` is no longer a top frame after the cached fetch/size shortcut.

Current `origin/master` detached-worktree comparison, file-backed DoltLite read rows:

| Test | master | this branch | delta |
|---|---:|---:|---:|
| `table_scan` | `148,032 us` | `141,984 us` | `4.1% faster` |
| `oltp_point_select` | `37,024 us` | `33,024 us` | `10.8% faster` |
| `oltp_range_select` | `30,016 us` | `28,000 us` | `6.7% faster` |
| `oltp_read_only` | `168,032 us` | `170,976 us` | `1.8% slower` |

The broad read path still looks noisy, but scan and payload-heavy paths moved in the right direction.
