### PR TITLE
Eager payload cache for non-INTKEY clean cursor reads

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -445,6 +445,10 @@ static SQLITE_INLINE void cursorCurrentTreeValue(
   *pnData = (int)(off1 - off0);
 }
 
+static int cacheCursorPayloadReconstructed(
+  BtCursor *pCur, const u8 *pSortKey, int nSortKey
+);
+
 static SQLITE_INLINE void cacheCurrentTreePayloadIfIntKey(BtCursor *pCur){
   if( pCur->curIntKey ){
     const u8 *pVal; int nVal;
@@ -454,6 +458,28 @@ static SQLITE_INLINE void cacheCurrentTreePayloadIfIntKey(BtCursor *pCur){
       pCur->nCachedPayload = nVal;
       pCur->cachedPayloadOwned = 0;
     }
+  }
+}
+
+/* Non-INTKEY clean-cursor variant: index entries store data in the
+** sort-key with an empty value field. Reconstruct the record once into
+** pCur->pReconPayload so the per-row xPayloadSize + xPayloadFetch pair
+** from covering / range index scans both hit the early-return at the
+** top of getCursorPayload. Errors are best-effort — leave the cache
+** empty and let the lazy path retry / propagate. */
+static void cacheCurrentTreePayloadNonIntKey(BtCursor *pCur){
+  const u8 *pVal; int nVal;
+  cursorCurrentTreeValue(pCur, &pVal, &nVal);
+  if( nVal > 0 ){
+    pCur->pCachedPayload = (u8*)pVal;
+    pCur->nCachedPayload = nVal;
+    pCur->cachedPayloadOwned = 0;
+    return;
+  }
+  {
+    const u8 *pKey; int nKey;
+    prollyCursorKey(&pCur->pCur, &pKey, &nKey);
+    (void)cacheCursorPayloadReconstructed(pCur, pKey, nKey);
   }
 }
 
@@ -5280,7 +5306,11 @@ static int prollyBtCursorNext(BtCursor *pCur, int flags){
     if( rc==SQLITE_OK ){
       if( pCur->pCur.eState==PROLLY_CURSOR_VALID ){
         pCur->eState = CURSOR_VALID;
-        cacheCurrentTreePayloadIfIntKey(pCur);
+        if( pCur->curIntKey ){
+          cacheCurrentTreePayloadIfIntKey(pCur);
+        }else{
+          cacheCurrentTreePayloadNonIntKey(pCur);
+        }
       } else {
         pCur->eState = CURSOR_INVALID;
         return SQLITE_DONE;
@@ -5341,7 +5371,11 @@ static int prollyBtCursorNext(BtCursor *pCur, int flags){
       if( rc==SQLITE_OK ){
         if( pCur->pCur.eState==PROLLY_CURSOR_VALID ){
           pCur->eState = CURSOR_VALID;
-          cacheCurrentTreePayloadIfIntKey(pCur);
+          if( pCur->curIntKey ){
+            cacheCurrentTreePayloadIfIntKey(pCur);
+          }else{
+            cacheCurrentTreePayloadNonIntKey(pCur);
+          }
         } else {
           pCur->eState = CURSOR_INVALID;
           return SQLITE_DONE;


### PR DESCRIPTION
## Summary
PRs #770 / #773 populate `pCachedPayload` for INTKEY tables on the no-mutmap fast-path so per-row `xPayloadSize` + `xPayloadFetch` hit the early-return at the top of `getCursorPayload`. Non-INTKEY index cursors were left out: covering / range index scans were paying a multi-branch trip through `getCursorPayload` twice per row, the first call reaching `cacheCursorPayloadReconstructed` lazily.

In-memory profiling of `oltp_covering_index_scan` showed `recordFromSortKeyBuffer` at 13% of CPU and `getCursorPayload`'s branch chain at another ~5%. The reconstruction itself can't be avoided (non-INTKEY index entries store data in the sort-key with empty value), but doing it once eagerly after the cursor advances lets both per-row `PayloadSize` and `PayloadFetch` hit the fast-path early-return.

## Why two helpers?
A naive single helper that merged INTKEY + non-INTKEY into one path regressed point_select-style INTKEY-only workloads (the unified function was apparently losing inlining of the small INTKEY hot path). Splitting into `cacheCurrentTreePayloadIfIntKey` (unchanged) + `cacheCurrentTreePayloadNonIntKey` (new) and branching on `pCur->curIntKey` at the call site preserves the INTKEY fast path bit-for-bit and adds the non-INTKEY eager path only where it applies.

## Benchmarks (arm64 macOS, NEON BLAKE3)

### In-memory reads (best of 8)
| Test | master | this PR | Δ |
|------|--------|---------|---|
| oltp_covering_index_scan | 0.882s | 0.868s | **−1.6%** |
| oltp_index_scan | 0.083s | 0.081s | **−2.4%** |
| oltp_index_join_scan | 0.098s | 0.097s | **−1.0%** |
| oltp_table_scan | 1.469s | 1.462s | −0.5% |
| (others) | | | flat / noise |

### File-backed sanity (best of 5)
| Test | master | this PR | Δ |
|------|--------|---------|---|
| oltp_covering_index_scan | 0.914s | 0.896s | **−2.0%** |
| oltp_table_scan | 1.452s | 1.441s | −0.8% |
| Writes (update_index, insert, delete_insert) | | | flat |

## Tests
- [x] \`make doltlite\` — clean build
- [x] \`make libdoltlite.a && ./doltlite_regression_test_c all\` — 107,866 / 107,866 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)