### PR TITLE
Skip un-escape loop in TEXT/BLOB record reconstruction when clean

### DIFF
--- a/src/sortkey.c
+++ b/src/sortkey.c
@@ -411,6 +411,13 @@ int recordFromSortKeyBuffer(
   u32 aLen[64];
 
   const u8 *aFieldPtr[64];
+  /* Encoded byte-length of each TEXT/BLOB field in the sort-key, NOT
+  ** including the 0x00 0x00 terminator. Equal to aLen[i] when the
+  ** field has no 0x00 0x01 escapes — the common case for ASCII /
+  ** hex / utf-8 keys without embedded NULs — letting the data-write
+  ** loop below replace its byte-by-byte un-escape with a single
+  ** memcpy. Set to 0 for non-text fields (unused). */
+  int aEncLen[64];
   u8 aIntBuf[64][8];
   int nFields = 0;
   int pos = 0;
@@ -447,6 +454,7 @@ int recordFromSortKeyBuffer(
       aType[nFields] = 0;
       aLen[nFields] = 0;
       aFieldPtr[nFields] = 0;
+      aEncLen[nFields] = 0;
       nFields++;
 
     }else if( tag == SORTKEY_NUM ){
@@ -457,6 +465,7 @@ int recordFromSortKeyBuffer(
                                    aIntBuf[nFields]);
       pos += 8;
       aFieldPtr[nFields] = aIntBuf[nFields];
+      aEncLen[nFields] = 0;
       nFields++;
 
     }else if( tag == SORTKEY_TEXT || tag == SORTKEY_BLOB ){
@@ -492,6 +501,11 @@ int recordFromSortKeyBuffer(
 
 
       aFieldPtr[nFields] = pSortKey + start;
+      /* Encoded length excludes the trailing 0x00 0x00 terminator
+      ** (subtract 2 from pos). Equal to dataLen iff no escape
+      ** sequences appeared — that case skips the byte-by-byte
+      ** un-escape loop below. */
+      aEncLen[nFields] = (pos - 2) - start;
       nFields++;
 
     }else{
@@ -541,6 +555,12 @@ int recordFromSortKeyBuffer(
       if( serialType <= 6 || serialType == 7 ){
 
         memcpy(pOut + off, aIntBuf[i], fieldLen);
+        off += (int)fieldLen;
+      }else if( (u32)aEncLen[i] == fieldLen ){
+        /* No escape sequences in the encoded text — most common
+        ** case for ASCII / hex / utf-8 keys without embedded NULs.
+        ** Skip the byte-by-byte un-escape loop and copy directly. */
+        memcpy(pOut + off, aFieldPtr[i], fieldLen);
         off += (int)fieldLen;
       }else{
 


### PR DESCRIPTION
## Summary

Profiling TEXT-PK \`oltp_covering_index_scan\` (in-memory) showed it at **~2.1× SQLite** — \`recordFromSortKeyBuffer\` alone burning **39% of CPU**. The hot inner spot was the byte-by-byte un-escape loop that decodes TEXT/BLOB sort-key fields back to record form: it walks every byte of the encoded field checking for the \`0x00 0x01\` escape pair (which encodes an embedded NUL in the original data).

For ASCII / hex / utf-8 keys without embedded NULs — the common case for IDs, UUIDs, hex-encoded hashes, etc. — there are zero escapes in the encoded form, and the loop is just a slow byte-by-byte memcpy.

This PR tracks the encoded byte length per field during the (already-running) decode pass. When the encoded length equals the un-escaped data length, no escapes are present and the data write becomes a single \`memcpy\`. The branchy loop only runs for fields that actually contain escapes.

## Benchmarks (best of 5, arm64 macOS, NEON BLAKE3)

### In-memory reads
| Test | master | this PR | vs SQLite |
|------|--------|---------|-----------|
| textpk_covering_scan | 0.617s | 0.533s | **1.96× → 1.70×** (−13.6%) |
| textpk_point_select | 0.166s | 0.166s | flat (path not exercised) |

INTEGER-PK reads, file-backed reads, writes: flat or in noise band.

## Tests
- [x] \`make doltlite\` — clean build
- [x] \`make libdoltlite.a && ./doltlite_regression_test_c all\` — 107,866 / 107,866 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)