### PR TITLE
Use memchr to scan TEXT/BLOB sort-key fields during decode

### DIFF
--- a/src/sortkey.c
+++ b/src/sortkey.c
@@ -473,23 +473,31 @@ int recordFromSortKeyBuffer(
 
       int start = pos;
       int dataLen = 0;
+      /* Skip ahead to the next 0x00 sentinel via memchr — vectorized
+      ** on most platforms — instead of walking byte-by-byte. The 0x00
+      ** is either a terminator (followed by 0x00) or an escape
+      ** (followed by 0x01); only those positions need branch logic.
+      ** For ASCII / hex / utf-8 TEXT without embedded NULs the loop
+      ** runs exactly once: memchr finds the terminator, accumulate
+      ** dataLen, break. */
       while( pos < nSortKey ){
-        if( pSortKey[pos] == 0x00 ){
-          if( pos + 1 >= nSortKey ) return SQLITE_CORRUPT;
-          if( pSortKey[pos+1] == 0x00 ){
-
-            pos += 2;
-            break;
-          }else if( pSortKey[pos+1] == 0x01 ){
-
-            dataLen++;
-            pos += 2;
-          }else{
-            return SQLITE_CORRUPT;
-          }
-        }else{
+        const u8 *p0 = pSortKey + pos;
+        const u8 *pZero = (const u8*)memchr(p0, 0x00, (size_t)(nSortKey - pos));
+        if( pZero==0 ) return SQLITE_CORRUPT;
+        {
+          int gap = (int)(pZero - p0);
+          dataLen += gap;
+          pos += gap;
+        }
+        if( pos + 1 >= nSortKey ) return SQLITE_CORRUPT;
+        if( pSortKey[pos+1] == 0x00 ){
+          pos += 2;
+          break;
+        }else if( pSortKey[pos+1] == 0x01 ){
           dataLen++;
-          pos++;
+          pos += 2;
+        }else{
+          return SQLITE_CORRUPT;
         }
       }
       if( tag == SORTKEY_TEXT ){


### PR DESCRIPTION
## Summary

PR #779 cut TEXT-PK covering-index-scan time by short-circuiting the data-write un-escape loop when no escape sequences appeared. Profiling afterwards moved the hotspot to the FIRST pass — the byte-by-byte scan that finds each TEXT/BLOB field's terminator and counts data bytes for length / type computation.

For a 32-byte hex TEXT-PK field, that loop runs ~33 byte-by-byte iterations: 32 character checks plus the final \`0x00 0x00\` terminator detect.

Replace the byte walk with \`memchr\` to skip ahead to the next \`0x00\` sentinel — vectorized on most platforms. The branchy logic only runs at sentinel positions: either a terminator (followed by \`0x00\`) or an escape (followed by \`0x01\`). For ASCII / hex / utf-8 keys without embedded NULs the loop body executes exactly once: \`memchr\` finds the terminator, accumulate \`dataLen\`, break.

## Benchmarks (best of 5, arm64 macOS, NEON BLAKE3)

### In-memory TEXT-PK reads
| Test | master | this PR | vs SQLite |
|------|--------|---------|-----------|
| textpk_covering_scan | 0.555s | 0.492s | **1.77× → 1.57×** (−11.4%) |
| textpk_point_select | 0.167s | 0.167s | flat |

### Combined with PR #779
\`textpk_covering_scan\` is now **20% faster than master pre-#779**, going from **1.96× → 1.57× SQLite** (closed 40%+ of the gap in two PRs).

### Sanity
INTEGER-PK reads, file-backed paths, writes: flat (interleaved benchmark used to filter thermal / system noise from earlier readings).

## Tests
- [x] \`make doltlite\` — clean build
- [x] \`make libdoltlite.a && ./doltlite_regression_test_c all\` — 107,866 / 107,866 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)