### PR TITLE
Use mutmap lower bound for TEXT key matching

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -5621,7 +5621,7 @@ static int findMatchingMutMapEntry(
   ** seen and stays. Freed once at function exit. */
   u8 *pRecBuf = 0;
   int nRecBufAlloc = 0;
-  int lo, hi;
+  int lo = 0, found = 0;
 
   *ppMatch = 0;
   *pCmp = 0;
@@ -5640,43 +5640,24 @@ static int findMatchingMutMapEntry(
     return SQLITE_OK;
   }
 
-  lo = 0;
-  hi = pMap->nEntries;
-  while( lo < hi ){
-    int mid = lo + (hi - lo) / 2;
-    ProllyMutMapEntry *pEntry = prollyMutMapEntryAt(pMap, mid);
-    const u8 *pRec = pEntry->pVal;
-    int nRec = pEntry->nVal;
-    int isLess;
-
-    if( pMap->isIntKey ){
-      lo = mid + 1;
-      continue;
-    }
-    if( nRec==0 ){
-      rc = recordFromSortKeyBuffer(pEntry->pKey, pEntry->nKey,
-                                    &pRecBuf, &nRecBufAlloc, &nRec);
-      if( rc!=SQLITE_OK ) break;
-      pRec = pRecBuf;
-    }
-    pIdxKey->eqSeen = 0;
-    cmp = sqlite3VdbeRecordCompare(nRec, pRec, pIdxKey);
-    isLess = (cmp<0 && !pIdxKey->eqSeen);
-    if( isLess ){
-      lo = mid + 1;
-    }else{
-      hi = mid;
-    }
-  }
+  rc = prollyMutMapResolveSortedPos(pMap, pSortKey, nSortKey, 0,
+                                    &lo, &found);
 
   while( rc==SQLITE_OK && lo < pMap->nEntries ){
     ProllyMutMapEntry *pEntry = prollyMutMapEntryAt(pMap, lo);
     const u8 *pRec = pEntry->pVal;
     int nRec = pEntry->nVal;
+    int cmpLen;
+    int prefixCmp;
 
     if( pMap->isIntKey ){
       lo++;
       continue;
+    }
+    cmpLen = pEntry->nKey < nSortKey ? pEntry->nKey : nSortKey;
+    prefixCmp = memcmp(pEntry->pKey, pSortKey, cmpLen);
+    if( prefixCmp>0 || (prefixCmp==0 && pEntry->nKey < nSortKey) ){
+      break;
     }
     if( nRec==0 ){
       rc = recordFromSortKeyBuffer(pEntry->pKey, pEntry->nKey,


### PR DESCRIPTION
## Summary

- use the mutmap's sort-key lower bound in `findMatchingMutMapEntry()`
- avoid binary-searching TEXT/index mutmap entries with reconstructed record compares
- keep record comparison for the nearby candidate scan where it is still needed

## Benchmark

Rebased on current `master` after #780. TEXT-PK suite passed ceilings:

```text
BENCH_RUNS=3 BENCH_ROWS=1000 bash ../test/sysbench_compare_textpk.sh
```

File-backed wrapped writes on this branch:

```text
oltp_bulk_insert       3,008 us   1.01x
oltp_insert           19,008 us   1.27x
oltp_update_index     40,032 us   1.29x
oltp_update_non_index 29,952 us   1.25x
oltp_delete_insert    35,968 us   1.44x
oltp_write_only       17,024 us   1.41x
types_delete_insert   15,968 us   1.06x
oltp_read_write       96,000 us   1.28x
```

File-backed autocommit writes on this branch:

```text
oltp_bulk_insert_ac      24,032 us   0.44x
oltp_insert_ac           36,960 us   0.58x
oltp_update_index_ac     40,032 us   0.63x
oltp_update_non_index_ac 28,000 us   0.54x
oltp_delete_insert_ac    38,976 us   0.59x
oltp_write_only_ac       35,008 us   0.56x
types_delete_insert_ac   24,992 us   0.45x
oltp_read_write_ac       39,008 us   0.62x
```

## Validation

- `make -j8`
- `./savepoint_catalog_restore_test`
- `./prepared_stmt_reuse_test`
- `./concurrent_refs_test`
- `./checkout_persist_failure_test`
- `BENCH_RUNS=3 BENCH_ROWS=1000 bash ../test/sysbench_compare_textpk.sh`
- `git diff --check -- src/prolly_btree.c`
