### PR TITLE
Optimize TEXT and BLOB PK index scan decoding

### DIFF
--- a/src/sortkey.c
+++ b/src/sortkey.c
@@ -403,6 +403,64 @@ static int recordFromTwoNumericSortKeyBuffer(
   return SQLITE_OK;
 }
 
+static int recordFromNumericTextSortKeyBuffer(
+  const u8 *pSortKey, int nSortKey,
+  u8 **ppBuf, int *pnAlloc, int *pnOut
+){
+  u32 aType0;
+  u32 aLen0;
+  u32 aType1;
+  u32 aLen1;
+  u8 aBuf0[8];
+  int nHdr;
+  int nTotal;
+  int off;
+  u8 *pOut;
+  const u8 *pZero;
+
+  if( nSortKey<12
+   || pSortKey[0]!=SORTKEY_NUM
+   || pSortKey[9]!=SORTKEY_TEXT
+   || pSortKey[nSortKey-2]!=0x00
+   || pSortKey[nSortKey-1]!=0x00 ){
+    return SQLITE_NOTFOUND;
+  }
+
+  aLen1 = (u32)(nSortKey - 12);
+  pZero = (const u8*)memchr(pSortKey + 10, 0x00, (size_t)(aLen1 + 2));
+  if( pZero!=(pSortKey + nSortKey - 2) ){
+    return SQLITE_NOTFOUND;
+  }
+
+  decodeNumericSortKeyToRecord(pSortKey + 1, &aType0, &aLen0, aBuf0);
+  aType1 = aLen1 * 2 + 13;
+
+  nHdr = 1 + sqlite3VarintLen(aType0) + sqlite3VarintLen(aType1);
+  if( nHdr > 126 ) nHdr++;
+  nTotal = nHdr + (int)aLen0 + (int)aLen1;
+  if( *pnAlloc < nTotal ){
+    u8 *pNew = (u8*)sqlite3_realloc(*ppBuf, nTotal);
+    if( !pNew ) return SQLITE_NOMEM;
+    *ppBuf = pNew;
+    *pnAlloc = nTotal;
+  }
+  pOut = *ppBuf;
+
+  off = putVarint32(pOut, (u32)nHdr);
+  off += putVarint32(pOut + off, aType0);
+  off += putVarint32(pOut + off, aType1);
+  if( aLen0>0 ){
+    memcpy(pOut + off, aBuf0, aLen0);
+    off += (int)aLen0;
+  }
+  if( aLen1>0 ){
+    memcpy(pOut + off, pSortKey + 10, aLen1);
+  }
+
+  *pnOut = nTotal;
+  return SQLITE_OK;
+}
+
 int recordFromSortKeyBuffer(
   const u8 *pSortKey, int nSortKey,
   u8 **ppBuf, int *pnAlloc, int *pnOut
@@ -443,6 +501,11 @@ int recordFromSortKeyBuffer(
   {
     int rc = recordFromTwoNumericSortKeyBuffer(pSortKey, nSortKey,
                                                ppBuf, pnAlloc, pnOut);
+    if( rc!=SQLITE_NOTFOUND ) return rc;
+  }
+  {
+    int rc = recordFromNumericTextSortKeyBuffer(pSortKey, nSortKey,
+                                                ppBuf, pnAlloc, pnOut);
     if( rc!=SQLITE_NOTFOUND ) return rc;
   }
 

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -1977,6 +1977,55 @@ static void run_sortkey_two_numeric_roundtrip(void){
   sqlite3_free(pRoundTrip);
 }
 
+static void run_sortkey_numeric_text_roundtrip(void){
+  static const u8 fastRecord[] = {
+    0x03,       /* header size */
+    0x01,       /* 1-byte integer */
+    0x13,       /* 3-byte text */
+    0x7b,       /* 123 */
+    'a', 'b', 'c'
+  };
+  static const u8 escapedRecord[] = {
+    0x03,       /* header size */
+    0x01,       /* 1-byte integer */
+    0x13,       /* 3-byte text */
+    0x7b,       /* 123 */
+    'x', 0x00, 'y'
+  };
+  const u8 *aRecord[] = { fastRecord, escapedRecord };
+  int aRecordSize[] = { (int)sizeof(fastRecord), (int)sizeof(escapedRecord) };
+  const char *aName[] = { "numeric_text_fast", "numeric_text_escaped" };
+  int i;
+
+  printf("=== Sortkey Numeric Text Roundtrip Test ===\n\n");
+
+  for(i=0; i<2; i++){
+    u8 *pSortKey = 0;
+    u8 *pRoundTrip = 0;
+    char zCheck[80];
+    int nSortKey = 0;
+    int nRoundTrip = 0;
+    int rc;
+
+    rc = sortKeyFromRecord(aRecord[i], aRecordSize[i], &pSortKey, &nSortKey);
+    sqlite3_snprintf(sizeof(zCheck), zCheck, "%s_sortkey_encode_ok", aName[i]);
+    check(zCheck, rc==SQLITE_OK);
+
+    if( rc==SQLITE_OK ){
+      rc = recordFromSortKey(pSortKey, nSortKey, &pRoundTrip, &nRoundTrip);
+      sqlite3_snprintf(sizeof(zCheck), zCheck, "%s_sortkey_decode_ok", aName[i]);
+      check(zCheck, rc==SQLITE_OK);
+      sqlite3_snprintf(sizeof(zCheck), zCheck, "%s_sortkey_roundtrips", aName[i]);
+      check(zCheck,
+        nRoundTrip==aRecordSize[i]
+        && memcmp(pRoundTrip, aRecord[i], (size_t)aRecordSize[i])==0);
+    }
+
+    sqlite3_free(pSortKey);
+    sqlite3_free(pRoundTrip);
+  }
+}
+
 static void run_reload_refs_transactional(void){
   ChunkStore cs;
   ProllyHash emptyHash;
@@ -6383,6 +6432,7 @@ static const RegressionCase aCases[] = {
   { "gc_rewrite_failure", "GC Rewrite Failure Test", run_gc_rewrite_failure },
   { "record_decode_corruption", "Record Decode Corruption Test", run_record_decode_corruption },
   { "sortkey_two_numeric_roundtrip", "Sortkey Two Numeric Roundtrip Test", run_sortkey_two_numeric_roundtrip },
+  { "sortkey_numeric_text_roundtrip", "Sortkey Numeric Text Roundtrip Test", run_sortkey_numeric_text_roundtrip },
   { "reload_refs_transactional", "Reload Refs Transactional Test", run_reload_refs_transactional },
   { "refresh_refs_corruption_preserves_state", "Refresh Corrupt Refs State Preservation Test", run_refresh_refs_corruption_preserves_state },
   { "prolly_node_corruption", "Prolly Node Corruption Test", run_prolly_node_corruption },


### PR DESCRIPTION
## Summary
- add a fast path for decoding secondary-index sort keys shaped like numeric indexed column + TEXT/BLOB primary key
- keep the no-escape TEXT case on a memchr terminator path and use a byte-loop fallback for escaped BLOB/TEXT values
- add regression coverage for numeric+TEXT and numeric+BLOB sort-key round trips, including escaped fallback cases

## Benchmarks
TEXT-PK sysbench, BENCH_RUNS=3 BENCH_ROWS=1000:
- file-backed covering_index_scan: 10,976us final, 0.91x vs SQLite
- file-backed oltp_index_scan: 4,992us final, 0.62x vs SQLite
- all tests within ceilings

BLOB-PK sysbench, BENCH_RUNS=3 BENCH_ROWS=1000:
- in-memory covering_index_scan improved from ~25ms before the escaped-BLOB fix to ~12ms final
- file-backed covering_index_scan improved from ~26ms before the escaped-BLOB fix to 12,992us final, 1.18x vs SQLite
- file-backed autocommit covering_index_scan: 12,992us final, 1.08x vs SQLite
- all tests within ceilings

## Validation
- make -j8
- ./doltlite_regression_test_c sortkey_numeric_text_roundtrip
- ./doltlite_regression_test_c sortkey_numeric_blob_roundtrip
- ./doltlite_regression_test_c sortkey_two_numeric_roundtrip
- ./savepoint_catalog_restore_test && ./prepared_stmt_reuse_test && ./concurrent_refs_test && ./checkout_persist_failure_test
- BENCH_RUNS=3 BENCH_ROWS=1000 bash ../test/sysbench_compare_textpk.sh
- BENCH_RUNS=3 BENCH_ROWS=1000 bash ../test/sysbench_compare_blobpk.sh
- git diff --check