### PR TITLE
Optimize BLOB PK index scan decoding

### DIFF
--- a/src/sortkey.c
+++ b/src/sortkey.c
@@ -403,7 +403,7 @@ static int recordFromTwoNumericSortKeyBuffer(
   return SQLITE_OK;
 }
 
-static int recordFromNumericTextSortKeyBuffer(
+static int recordFromNumericVarlenSortKeyBuffer(
   const u8 *pSortKey, int nSortKey,
   u8 **ppBuf, int *pnAlloc, int *pnOut
 ){
@@ -412,28 +412,64 @@ static int recordFromNumericTextSortKeyBuffer(
   u32 aType1;
   u32 aLen1;
   u8 aBuf0[8];
+  u8 tag1;
+  const u8 *pData1;
+  int nEnc1;
+  int hasEscape = 0;
   int nHdr;
   int nTotal;
   int off;
   u8 *pOut;
-  const u8 *pZero;
+  int pos;
 
   if( nSortKey<12
    || pSortKey[0]!=SORTKEY_NUM
-   || pSortKey[9]!=SORTKEY_TEXT
    || pSortKey[nSortKey-2]!=0x00
    || pSortKey[nSortKey-1]!=0x00 ){
     return SQLITE_NOTFOUND;
   }
+  tag1 = pSortKey[9];
+  if( tag1!=SORTKEY_TEXT && tag1!=SORTKEY_BLOB ){
+    return SQLITE_NOTFOUND;
+  }
 
-  aLen1 = (u32)(nSortKey - 12);
-  pZero = (const u8*)memchr(pSortKey + 10, 0x00, (size_t)(aLen1 + 2));
-  if( pZero!=(pSortKey + nSortKey - 2) ){
+  pData1 = pSortKey + 10;
+  aLen1 = 0;
+  {
+    const u8 *pZero = (const u8*)memchr(pData1, 0x00,
+                                        (size_t)(nSortKey - 10));
+    if( pZero==0 ) return SQLITE_NOTFOUND;
+    if( pZero==pSortKey + nSortKey - 2 ){
+      nEnc1 = (int)(pZero - pData1);
+      aLen1 = (u32)nEnc1;
+      pos = nSortKey;
+    }else{
+      pos = 10;
+      while( pos < nSortKey ){
+        u8 b = pSortKey[pos++];
+        if( b==0x00 ){
+          if( pos >= nSortKey ) return SQLITE_NOTFOUND;
+          if( pSortKey[pos]==0x00 ){
+            nEnc1 = pos - 1 - 10;
+            pos++;
+            break;
+          }
+          if( pSortKey[pos]!=0x01 ){
+            return SQLITE_NOTFOUND;
+          }
+          hasEscape = 1;
+          pos++;
+        }
+        aLen1++;
+      }
+    }
+  }
+  if( pos!=nSortKey ){
     return SQLITE_NOTFOUND;
   }
 
   decodeNumericSortKeyToRecord(pSortKey + 1, &aType0, &aLen0, aBuf0);
-  aType1 = aLen1 * 2 + 13;
+  aType1 = aLen1 * 2 + (tag1==SORTKEY_TEXT ? 13 : 12);
 
   nHdr = 1 + sqlite3VarintLen(aType0) + sqlite3VarintLen(aType1);
   if( nHdr > 126 ) nHdr++;
@@ -454,7 +490,21 @@ static int recordFromNumericTextSortKeyBuffer(
     off += (int)aLen0;
   }
   if( aLen1>0 ){
-    memcpy(pOut + off, pSortKey + 10, aLen1);
+    if( !hasEscape ){
+      memcpy(pOut + off, pData1, aLen1);
+    }else{
+      const u8 *pSrc = pData1;
+      const u8 *pEnd = pData1 + nEnc1;
+      u8 *pDst = pOut + off;
+      while( pSrc < pEnd ){
+        if( pSrc+1 < pEnd && pSrc[0]==0x00 && pSrc[1]==0x01 ){
+          *pDst++ = 0x00;
+          pSrc += 2;
+        }else{
+          *pDst++ = *pSrc++;
+        }
+      }
+    }
   }
 
   *pnOut = nTotal;
@@ -504,8 +554,8 @@ int recordFromSortKeyBuffer(
     if( rc!=SQLITE_NOTFOUND ) return rc;
   }
   {
-    int rc = recordFromNumericTextSortKeyBuffer(pSortKey, nSortKey,
-                                                ppBuf, pnAlloc, pnOut);
+    int rc = recordFromNumericVarlenSortKeyBuffer(pSortKey, nSortKey,
+                                                  ppBuf, pnAlloc, pnOut);
     if( rc!=SQLITE_NOTFOUND ) return rc;
   }
 

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -2026,6 +2026,55 @@ static void run_sortkey_numeric_text_roundtrip(void){
   }
 }
 
+static void run_sortkey_numeric_blob_roundtrip(void){
+  static const u8 fastRecord[] = {
+    0x03,       /* header size */
+    0x01,       /* 1-byte integer */
+    0x12,       /* 3-byte blob */
+    0x7b,       /* 123 */
+    0x01, 0x02, 0x03
+  };
+  static const u8 escapedRecord[] = {
+    0x03,       /* header size */
+    0x01,       /* 1-byte integer */
+    0x12,       /* 3-byte blob */
+    0x7b,       /* 123 */
+    0x01, 0x00, 0x03
+  };
+  const u8 *aRecord[] = { fastRecord, escapedRecord };
+  int aRecordSize[] = { (int)sizeof(fastRecord), (int)sizeof(escapedRecord) };
+  const char *aName[] = { "numeric_blob_fast", "numeric_blob_escaped" };
+  int i;
+
+  printf("=== Sortkey Numeric Blob Roundtrip Test ===\n\n");
+
+  for(i=0; i<2; i++){
+    u8 *pSortKey = 0;
+    u8 *pRoundTrip = 0;
+    char zCheck[80];
+    int nSortKey = 0;
+    int nRoundTrip = 0;
+    int rc;
+
+    rc = sortKeyFromRecord(aRecord[i], aRecordSize[i], &pSortKey, &nSortKey);
+    sqlite3_snprintf(sizeof(zCheck), zCheck, "%s_sortkey_encode_ok", aName[i]);
+    check(zCheck, rc==SQLITE_OK);
+
+    if( rc==SQLITE_OK ){
+      rc = recordFromSortKey(pSortKey, nSortKey, &pRoundTrip, &nRoundTrip);
+      sqlite3_snprintf(sizeof(zCheck), zCheck, "%s_sortkey_decode_ok", aName[i]);
+      check(zCheck, rc==SQLITE_OK);
+      sqlite3_snprintf(sizeof(zCheck), zCheck, "%s_sortkey_roundtrips", aName[i]);
+      check(zCheck,
+        nRoundTrip==aRecordSize[i]
+        && memcmp(pRoundTrip, aRecord[i], (size_t)aRecordSize[i])==0);
+    }
+
+    sqlite3_free(pSortKey);
+    sqlite3_free(pRoundTrip);
+  }
+}
+
 static void run_reload_refs_transactional(void){
   ChunkStore cs;
   ProllyHash emptyHash;
@@ -6433,6 +6482,7 @@ static const RegressionCase aCases[] = {
   { "record_decode_corruption", "Record Decode Corruption Test", run_record_decode_corruption },
   { "sortkey_two_numeric_roundtrip", "Sortkey Two Numeric Roundtrip Test", run_sortkey_two_numeric_roundtrip },
   { "sortkey_numeric_text_roundtrip", "Sortkey Numeric Text Roundtrip Test", run_sortkey_numeric_text_roundtrip },
+  { "sortkey_numeric_blob_roundtrip", "Sortkey Numeric Blob Roundtrip Test", run_sortkey_numeric_blob_roundtrip },
   { "reload_refs_transactional", "Reload Refs Transactional Test", run_reload_refs_transactional },
   { "refresh_refs_corruption_preserves_state", "Refresh Corrupt Refs State Preservation Test", run_refresh_refs_corruption_preserves_state },
   { "prolly_node_corruption", "Prolly Node Corruption Test", run_prolly_node_corruption },


### PR DESCRIPTION
## Summary
- generalize the numeric+TEXT secondary-index sort-key decoder from #783 to numeric+TEXT/BLOB
- keep the no-escape TEXT case on the cheap memchr terminator path
- add an escaped varlen path for BLOB PK keys with leading zero bytes
- cache reconstructed non-INTKEY payloads immediately after successful index seeks
- lower the non-INTKEY CI sysbench ceiling from 3x to 2x
- add numeric+BLOB sort-key regression coverage

## Benchmarks
BLOB-PK sysbench, `SQLITE3=/usr/bin/sqlite3 BENCH_MAX_MULTIPLIER=2 BENCH_RUNS=5 BENCH_ROWS=1000`:
- in-memory `covering_index_scan`: 12,000us, 1.71x vs SQLite
- in-memory `index_join_scan`: 2,976us, 1.50x vs SQLite
- file-backed `covering_index_scan`: 12,992us, 1.00x vs SQLite
- file-backed `index_join_scan`: 3,040us, 1.51x vs SQLite
- autocommit read `covering_index_scan`: 12,992us, 1.00x vs SQLite
- autocommit read `index_join_scan`: 3,008us, 1.49x vs SQLite
- all BLOB-PK tests within 2x ceilings

TEXT-PK sysbench, `SQLITE3=/usr/bin/sqlite3 BENCH_MAX_MULTIPLIER=2 BENCH_RUNS=5 BENCH_ROWS=1000`:
- file-backed `covering_index_scan`: 11,968us, 0.86x vs SQLite
- file-backed `index_join_scan`: 3,008us, 1.00x vs SQLite
- autocommit read `covering_index_scan`: 11,040us, 0.79x vs SQLite
- autocommit read `index_join_scan`: 2,976us, 0.99x vs SQLite
- all TEXT-PK tests within 2x ceilings

Composite-PK sysbench, `SQLITE3=/usr/bin/sqlite3 BENCH_MAX_MULTIPLIER=2 BENCH_RUNS=5 BENCH_ROWS=1000`:
- file-backed `covering_index_scan`: 11,968us, 0.92x vs SQLite
- file-backed `index_join_scan`: 3,008us, 1.01x vs SQLite
- autocommit read `covering_index_scan`: 12,992us, 1.08x vs SQLite
- autocommit read `index_join_scan`: 3,008us, 1.49x vs SQLite
- all Composite-PK tests within 2x ceilings

Note: in-memory TEXT `index_join_scan` is reporting-only in the benchmark script and remains noisy locally because SQLite completes that tiny case in about 1ms; the gated file-backed sections are under 2x.

## Validation
- `make -j8`
- `cc -g -I. -Isrc -o /tmp/doltlite_regression_test_c test/doltlite_regression_test_c.c libdoltlite.a -lz -lpthread -lm && /tmp/doltlite_regression_test_c sortkey_numeric_blob_roundtrip`
- `cc -g -I. -Isrc -o /tmp/doltlite_regression_test_c_text test/doltlite_regression_test_c.c libdoltlite.a -lz -lpthread -lm && /tmp/doltlite_regression_test_c_text sortkey_numeric_text_roundtrip`
- `cc -g -I. -Isrc -o /tmp/doltlite_regression_test_c_num test/doltlite_regression_test_c.c libdoltlite.a -lz -lpthread -lm && /tmp/doltlite_regression_test_c_num sortkey_two_numeric_roundtrip`
- `git diff --check`
- `SQLITE3=/usr/bin/sqlite3 BENCH_MAX_MULTIPLIER=2 BENCH_RUNS=5 BENCH_ROWS=1000 bash test/sysbench_compare_textpk.sh`
- `SQLITE3=/usr/bin/sqlite3 BENCH_MAX_MULTIPLIER=2 BENCH_RUNS=5 BENCH_ROWS=1000 bash test/sysbench_compare_blobpk.sh`
- `SQLITE3=/usr/bin/sqlite3 BENCH_MAX_MULTIPLIER=2 BENCH_RUNS=5 BENCH_ROWS=1000 bash test/sysbench_compare_compositepk.sh`
