### PR TITLE
Tighten non-int sysbench ceiling

### DIFF
--- a/.github/workflows/benchmark-extra.yml
+++ b/.github/workflows/benchmark-extra.yml
@@ -22,7 +22,7 @@ permissions:
 
 env:
   BENCH_RUNS: 5
-  BENCH_MAX_MULTIPLIER: 3
+  BENCH_MAX_MULTIPLIER: 2
 
 jobs:
   benchmark-extra:

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -5983,6 +5983,7 @@ static int prollyBtCursorIndexMoveto(
     if( treeFound ){
       *pRes = treeCmp;
       pCur->eState = CURSOR_VALID;
+      cacheCurrentTreePayloadNonIntKey(pCur);
       return SQLITE_OK;
     }
   }
@@ -5996,6 +5997,7 @@ no_match:
     if( lastRes==0 ){
       pCur->eState = CURSOR_VALID;
       *pRes = -1;
+      cacheCurrentTreePayloadNonIntKey(pCur);
     } else {
       pCur->eState = CURSOR_INVALID;
       *pRes = -1;


### PR DESCRIPTION
## Summary
- cache reconstructed non-INTKEY payloads immediately after successful index seeks
- lower the non-INTKEY CI sysbench ceiling from 3x to 2x
- reuse the displayed sysbench median results for ceiling checks instead of rerunning benchmark rows

## Benchmarks
From the same commit before rebranching, with `SQLITE3=/usr/bin/sqlite3 BENCH_MAX_MULTIPLIER=2 BENCH_RUNS=5 BENCH_ROWS=1000`:

BLOB PK:
- file-backed `covering_index_scan`: 12,992us, 1.00x vs SQLite
- file-backed `index_join_scan`: 3,040us, 1.51x vs SQLite
- autocommit read `covering_index_scan`: 12,992us, 1.00x vs SQLite
- autocommit read `index_join_scan`: 3,008us, 1.49x vs SQLite
- all BLOB-PK tests within 2x ceilings

TEXT PK:
- file-backed `covering_index_scan`: 11,968us, 0.86x vs SQLite
- file-backed `index_join_scan`: 3,008us, 1.00x vs SQLite
- autocommit read `covering_index_scan`: 11,040us, 0.79x vs SQLite
- autocommit read `index_join_scan`: 2,976us, 0.99x vs SQLite
- all TEXT-PK tests within 2x ceilings

Composite PK:
- file-backed `covering_index_scan`: 11,968us, 0.92x vs SQLite
- file-backed `index_join_scan`: 3,008us, 1.01x vs SQLite
- autocommit read `covering_index_scan`: 12,992us, 1.08x vs SQLite
- autocommit read `index_join_scan`: 3,008us, 1.49x vs SQLite
- all Composite-PK tests within 2x ceilings

Note: in-memory sections are reporting-only in these scripts. Local in-memory TEXT `index_join_scan` remains noisy because SQLite completes that tiny case in about 1ms; the file-backed gated sections are under 2x.

## Validation
- `make -j8`
- focused sort-key C regressions for numeric+BLOB, numeric+TEXT, and two-numeric roundtrips
- `bash -n test/sysbench_compare.sh test/sysbench_compare_textpk.sh test/sysbench_compare_blobpk.sh test/sysbench_compare_compositepk.sh`
- `git diff --check`
- `SQLITE3=/usr/bin/sqlite3 BENCH_RUNS=1 BENCH_ROWS=50 BENCH_MAX_MULTIPLIER=999 BENCH_SECTION_MODE=wrapped bash test/sysbench_compare.sh`
- `SQLITE3=/usr/bin/sqlite3 BENCH_RUNS=1 BENCH_ROWS=50 BENCH_MAX_MULTIPLIER=999 bash test/sysbench_compare_textpk.sh`
- `SQLITE3=/usr/bin/sqlite3 BENCH_RUNS=1 BENCH_ROWS=50 BENCH_MAX_MULTIPLIER=999 bash test/sysbench_compare_blobpk.sh`
- `SQLITE3=/usr/bin/sqlite3 BENCH_RUNS=1 BENCH_ROWS=50 BENCH_MAX_MULTIPLIER=999 bash test/sysbench_compare_compositepk.sh`
- `SQLITE3=/usr/bin/sqlite3 BENCH_MAX_MULTIPLIER=2 BENCH_RUNS=5 BENCH_ROWS=1000 bash test/sysbench_compare_textpk.sh`
- `SQLITE3=/usr/bin/sqlite3 BENCH_MAX_MULTIPLIER=2 BENCH_RUNS=5 BENCH_ROWS=1000 bash test/sysbench_compare_blobpk.sh`
- `SQLITE3=/usr/bin/sqlite3 BENCH_MAX_MULTIPLIER=2 BENCH_RUNS=5 BENCH_ROWS=1000 bash test/sysbench_compare_compositepk.sh`
