### PR TITLE
Reuse sysbench results for ceiling checks

### DIFF
--- a/.github/workflows/benchmark-extra.yml
+++ b/.github/workflows/benchmark-extra.yml
@@ -2,11 +2,7 @@ name: Benchmark Extra
 
 # Companion to Benchmark. Runs three non-INTKEY sysbench variants
 # (TEXT PK, BLOB PK, composite PK) plus the autocommit suite. Each
-# non-INTKEY variant is gated at 3× sqlite on file-backed sections —
-# 2× is too flaky here because three sequential write-heavy suites on
-# a shared GitHub runner produce enough variance that individual tests
-# regularly land between 2× and 3× without any underlying perf change.
-# Local script defaults stay at 2×; loosen only on CI.
+# non-INTKEY variant is gated at 2× sqlite on file-backed sections.
 # BENCH_RUNS=5 across the job — each non-INTKEY write is a per-
 # statement flush, so the default 11 runs blows the 15-minute budget.
 

--- a/test/sysbench_compare.sh
+++ b/test/sysbench_compare.sh
@@ -419,11 +419,14 @@ READ_TESTS="oltp_point_select oltp_range_select oltp_sum_range oltp_order_range 
 WRITE_TESTS="oltp_bulk_insert oltp_insert oltp_update_index oltp_update_non_index oltp_delete_insert oltp_write_only types_delete_insert oltp_read_write"
 WRITE_TESTS_AC="oltp_bulk_insert_ac oltp_insert_ac oltp_update_index_ac oltp_update_non_index_ac oltp_delete_insert_ac oltp_write_only_ac types_delete_insert_ac oltp_read_write_ac"
 
+BENCH_RESULTS_FILE="$TMPDIR/bench_results.tsv"
+: > "$BENCH_RESULTS_FILE"
+
 # ============================================================
 # Output markdown table
 # ============================================================
 run_section() {
-  local tests="$1" db_sq="$2" db_dl="$3"
+  local section="$1" tests="$2" db_sq="$3" db_dl="$4"
   local ratio_sum=0
   local ratio_count=0
   local avg_ratio="--"
@@ -445,6 +448,7 @@ run_section() {
   else
     ratio="--"
   fi
+  printf '%s\t%s\t%s\t%s\n' "$section" "$t" "$s" "$d" >> "$BENCH_RESULTS_FILE"
   echo "| $t | $s_display | $d_display | ${ratio} |"
   done
   if [ "$ratio_count" -gt 0 ]; then
@@ -462,21 +466,21 @@ case "$BENCH_SECTION_MODE" in
     echo ""
     echo "#### Reads"
     echo ""
-    run_section "$READ_TESTS" ":memory:" ":memory:"
+    run_section "mem_reads" "$READ_TESTS" ":memory:" ":memory:"
     echo ""
     echo "#### Writes"
     echo ""
-    run_section "$WRITE_TESTS" ":memory:" ":memory:"
+    run_section "mem_writes" "$WRITE_TESTS" ":memory:" ":memory:"
     echo ""
     echo "### File-Backed"
     echo ""
     echo "#### Reads"
     echo ""
-    run_section "$READ_TESTS" "/tmp/bench_file" "/tmp/bench_file"
+    run_section "file_reads" "$READ_TESTS" "/tmp/bench_file" "/tmp/bench_file"
     echo ""
     echo "#### Writes"
     echo ""
-    run_section "$WRITE_TESTS" "/tmp/bench_file" "/tmp/bench_file"
+    run_section "file_writes" "$WRITE_TESTS" "/tmp/bench_file" "/tmp/bench_file"
     echo ""
     echo "### File-Backed (autocommit)"
     echo ""
@@ -489,11 +493,11 @@ case "$BENCH_SECTION_MODE" in
     echo "_File-Backed Reads section, included here for symmetry and to_"
     echo "_catch any per-statement overhead doltlite pays on the read path._"
     echo ""
-    run_section "$READ_TESTS" "/tmp/bench_file" "/tmp/bench_file"
+    run_section "ac_reads" "$READ_TESTS" "/tmp/bench_file" "/tmp/bench_file"
     echo ""
     echo "#### Writes"
     echo ""
-    run_section "$WRITE_TESTS_AC" "/tmp/bench_file" "/tmp/bench_file"
+    run_section "ac_writes" "$WRITE_TESTS_AC" "/tmp/bench_file" "/tmp/bench_file"
     ;;
   wrapped)
     echo "<!-- benchmark:classic -->"
@@ -503,21 +507,21 @@ case "$BENCH_SECTION_MODE" in
     echo ""
     echo "#### Reads"
     echo ""
-    run_section "$READ_TESTS" ":memory:" ":memory:"
+    run_section "mem_reads" "$READ_TESTS" ":memory:" ":memory:"
     echo ""
     echo "#### Writes"
     echo ""
-    run_section "$WRITE_TESTS" ":memory:" ":memory:"
+    run_section "mem_writes" "$WRITE_TESTS" ":memory:" ":memory:"
     echo ""
     echo "### File-Backed"
     echo ""
     echo "#### Reads"
     echo ""
-    run_section "$READ_TESTS" "/tmp/bench_file" "/tmp/bench_file"
+    run_section "file_reads" "$READ_TESTS" "/tmp/bench_file" "/tmp/bench_file"
     echo ""
     echo "#### Writes"
     echo ""
-    run_section "$WRITE_TESTS" "/tmp/bench_file" "/tmp/bench_file"
+    run_section "file_writes" "$WRITE_TESTS" "/tmp/bench_file" "/tmp/bench_file"
     ;;
   autocommit)
     echo "## Sysbench-Style Benchmark (autocommit): Doltlite vs SQLite"
@@ -535,11 +539,11 @@ case "$BENCH_SECTION_MODE" in
     echo "_File-Backed Reads section, included here for symmetry and to_"
     echo "_catch any per-statement overhead doltlite pays on the read path._"
     echo ""
-    run_section "$READ_TESTS" "/tmp/bench_file" "/tmp/bench_file"
+    run_section "ac_reads" "$READ_TESTS" "/tmp/bench_file" "/tmp/bench_file"
     echo ""
     echo "#### Writes"
     echo ""
-    run_section "$WRITE_TESTS_AC" "/tmp/bench_file" "/tmp/bench_file"
+    run_section "ac_writes" "$WRITE_TESTS_AC" "/tmp/bench_file" "/tmp/bench_file"
     ;;
   *)
     echo "unknown BENCH_SECTION_MODE: $BENCH_SECTION_MODE" >&2
@@ -554,16 +558,20 @@ echo "_${ROWS} rows, single CLI invocation per test, workload-only timing via SQ
 # Enforce performance ceiling (exit 1 if any test exceeds limit)
 # ============================================================
 check_ceiling() {
-  local tests="$1" db_sq="$2" db_dl="$3" max="$4"
+  local section="$1" tests="$2" max="$3"
   local failed=0
   for t in $tests; do
-    s=$(run_bench_stable "$t" sqlite "$SQLITE3" "$TMPDIR/$t.sql" "$db_sq")
-    d=$(run_bench_stable "$t" doltlite "$DOLTLITE" "$TMPDIR/$t.sql" "$db_dl")
+    local line
+    line=$(awk -F '\t' -v section="$section" -v test="$t" \
+      '$1==section && $2==test {print $3 "\t" $4; exit}' \
+      "$BENCH_RESULTS_FILE")
+    s="${line%%$'\t'*}"
+    d="${line#*$'\t'}"
     if [ "$s" -gt 0 ] 2>/dev/null && [ "$d" -ge 0 ] 2>/dev/null; then
       over=$(python3 -c "r=$d/$s; print(1 if r>$max else 0)")
       if [ "$over" = "1" ]; then
         ratio=$(python3 -c "print(f'{$d/$s:.2f}')")
-        echo "FAIL: $t = ${ratio}x (ceiling: ${max}x)" >&2
+        echo "FAIL: $section/$t = ${ratio}x (ceiling: ${max}x)" >&2
         failed=1
       fi
     fi
@@ -577,10 +585,10 @@ if [ "$BENCH_SECTION_MODE" != "autocommit" ]; then
   echo ""
 
   ceiling_ok=0
-  check_ceiling "$READ_TESTS" "/tmp/bench_file" "/tmp/bench_file" "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
-  check_ceiling "$WRITE_TESTS" "/tmp/bench_file" "/tmp/bench_file" "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
+  check_ceiling "file_reads" "$READ_TESTS" "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
+  check_ceiling "file_writes" "$WRITE_TESTS" "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
   if [ "$BENCH_SECTION_MODE" = "full" ]; then
-    check_ceiling "$WRITE_TESTS_AC" "/tmp/bench_file" "/tmp/bench_file" "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
+    check_ceiling "ac_writes" "$WRITE_TESTS_AC" "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
   fi
 
   if [ "$ceiling_ok" = "0" ]; then

--- a/test/sysbench_compare_blobpk.sh
+++ b/test/sysbench_compare_blobpk.sh
@@ -443,11 +443,14 @@ READ_TESTS="oltp_point_select oltp_range_select oltp_sum_range oltp_order_range 
 WRITE_TESTS="oltp_bulk_insert oltp_insert oltp_update_index oltp_update_non_index oltp_delete_insert oltp_write_only types_delete_insert oltp_read_write"
 WRITE_TESTS_AC="oltp_bulk_insert_ac oltp_insert_ac oltp_update_index_ac oltp_update_non_index_ac oltp_delete_insert_ac oltp_write_only_ac types_delete_insert_ac oltp_read_write_ac"
 
+BENCH_RESULTS_FILE="$TMPDIR/bench_results.tsv"
+: > "$BENCH_RESULTS_FILE"
+
 # ============================================================
 # Output markdown table
 # ============================================================
 run_section() {
-  local tests="$1" db_sq="$2" db_dl="$3"
+  local section="$1" tests="$2" db_sq="$3" db_dl="$4"
   local ratio_sum=0
   local ratio_count=0
   local avg_ratio="--"
@@ -469,6 +472,7 @@ run_section() {
   else
     ratio="--"
   fi
+  printf '%s\t%s\t%s\t%s\n' "$section" "$t" "$s" "$d" >> "$BENCH_RESULTS_FILE"
   echo "| $t | $s_display | $d_display | ${ratio} |"
   done
   if [ "$ratio_count" -gt 0 ]; then
@@ -489,21 +493,21 @@ echo "### In-Memory"
 echo ""
 echo "#### Reads"
 echo ""
-run_section "$READ_TESTS" ":memory:" ":memory:"
+run_section "mem_reads" "$READ_TESTS" ":memory:" ":memory:"
 echo ""
 echo "#### Writes"
 echo ""
-run_section "$WRITE_TESTS" ":memory:" ":memory:"
+run_section "mem_writes" "$WRITE_TESTS" ":memory:" ":memory:"
 echo ""
 echo "### File-Backed"
 echo ""
 echo "#### Reads"
 echo ""
-run_section "$READ_TESTS" "/tmp/bench_file" "/tmp/bench_file"
+run_section "file_reads" "$READ_TESTS" "/tmp/bench_file" "/tmp/bench_file"
 echo ""
 echo "#### Writes"
 echo ""
-run_section "$WRITE_TESTS" "/tmp/bench_file" "/tmp/bench_file"
+run_section "file_writes" "$WRITE_TESTS" "/tmp/bench_file" "/tmp/bench_file"
 
 echo ""
 echo "### File-Backed (autocommit)"
@@ -517,11 +521,11 @@ echo "_Reads have no commit cost; these are the same SQL files as the_"
 echo "_File-Backed Reads section, included here for symmetry and to_"
 echo "_catch any per-statement overhead doltlite pays on the read path._"
 echo ""
-run_section "$READ_TESTS" "/tmp/bench_file" "/tmp/bench_file"
+run_section "ac_reads" "$READ_TESTS" "/tmp/bench_file" "/tmp/bench_file"
 echo ""
 echo "#### Writes"
 echo ""
-run_section "$WRITE_TESTS_AC" "/tmp/bench_file" "/tmp/bench_file"
+run_section "ac_writes" "$WRITE_TESTS_AC" "/tmp/bench_file" "/tmp/bench_file"
 
 echo ""
 echo "_${ROWS} rows, single CLI invocation per test, workload-only timing via SQL timestamps._"
@@ -532,16 +536,20 @@ echo "_${ROWS} rows, single CLI invocation per test, workload-only timing via SQ
 # a regression on BLOB PK shows up as a CI failure.
 # ============================================================
 check_ceiling() {
-  local tests="$1" db_sq="$2" db_dl="$3" max="$4"
+  local section="$1" tests="$2" max="$3"
   local failed=0
   for t in $tests; do
-    s=$(run_bench_stable "$t" sqlite "$SQLITE3" "$TMPDIR/$t.sql" "$db_sq")
-    d=$(run_bench_stable "$t" doltlite "$DOLTLITE" "$TMPDIR/$t.sql" "$db_dl")
+    local line
+    line=$(awk -F '\t' -v section="$section" -v test="$t" \
+      '$1==section && $2==test {print $3 "\t" $4; exit}' \
+      "$BENCH_RESULTS_FILE")
+    s="${line%%$'\t'*}"
+    d="${line#*$'\t'}"
     if [ "$s" -gt 0 ] 2>/dev/null && [ "$d" -ge 0 ] 2>/dev/null; then
       over=$(python3 -c "r=$d/$s; print(1 if r>$max else 0)")
       if [ "$over" = "1" ]; then
         ratio=$(python3 -c "print(f'{$d/$s:.2f}')")
-        echo "FAIL: $t = ${ratio}x (ceiling: ${max}x)" >&2
+        echo "FAIL: $section/$t = ${ratio}x (ceiling: ${max}x)" >&2
         failed=1
       fi
     fi
@@ -554,9 +562,9 @@ echo "### Performance Ceiling Check (${BENCH_MAX_MULTIPLIER}x)"
 echo ""
 
 ceiling_ok=0
-check_ceiling "$READ_TESTS"     "/tmp/bench_file" "/tmp/bench_file" "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
-check_ceiling "$WRITE_TESTS"    "/tmp/bench_file" "/tmp/bench_file" "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
-check_ceiling "$WRITE_TESTS_AC" "/tmp/bench_file" "/tmp/bench_file" "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
+check_ceiling "file_reads"  "$READ_TESTS"     "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
+check_ceiling "file_writes" "$WRITE_TESTS"    "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
+check_ceiling "ac_writes"   "$WRITE_TESTS_AC" "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
 
 if [ "$ceiling_ok" = "0" ]; then
   echo "All tests within ceilings."

--- a/test/sysbench_compare_compositepk.sh
+++ b/test/sysbench_compare_compositepk.sh
@@ -464,11 +464,14 @@ READ_TESTS="oltp_point_select oltp_range_select oltp_sum_range oltp_order_range 
 WRITE_TESTS="oltp_bulk_insert oltp_insert oltp_update_index oltp_update_non_index oltp_delete_insert oltp_write_only types_delete_insert oltp_read_write"
 WRITE_TESTS_AC="oltp_bulk_insert_ac oltp_insert_ac oltp_update_index_ac oltp_update_non_index_ac oltp_delete_insert_ac oltp_write_only_ac types_delete_insert_ac oltp_read_write_ac"
 
+BENCH_RESULTS_FILE="$TMPDIR/bench_results.tsv"
+: > "$BENCH_RESULTS_FILE"
+
 # ============================================================
 # Output markdown table
 # ============================================================
 run_section() {
-  local tests="$1" db_sq="$2" db_dl="$3"
+  local section="$1" tests="$2" db_sq="$3" db_dl="$4"
   local ratio_sum=0
   local ratio_count=0
   local avg_ratio="--"
@@ -490,6 +493,7 @@ run_section() {
   else
     ratio="--"
   fi
+  printf '%s\t%s\t%s\t%s\n' "$section" "$t" "$s" "$d" >> "$BENCH_RESULTS_FILE"
   echo "| $t | $s_display | $d_display | ${ratio} |"
   done
   if [ "$ratio_count" -gt 0 ]; then
@@ -510,21 +514,21 @@ echo "### In-Memory"
 echo ""
 echo "#### Reads"
 echo ""
-run_section "$READ_TESTS" ":memory:" ":memory:"
+run_section "mem_reads" "$READ_TESTS" ":memory:" ":memory:"
 echo ""
 echo "#### Writes"
 echo ""
-run_section "$WRITE_TESTS" ":memory:" ":memory:"
+run_section "mem_writes" "$WRITE_TESTS" ":memory:" ":memory:"
 echo ""
 echo "### File-Backed"
 echo ""
 echo "#### Reads"
 echo ""
-run_section "$READ_TESTS" "/tmp/bench_file" "/tmp/bench_file"
+run_section "file_reads" "$READ_TESTS" "/tmp/bench_file" "/tmp/bench_file"
 echo ""
 echo "#### Writes"
 echo ""
-run_section "$WRITE_TESTS" "/tmp/bench_file" "/tmp/bench_file"
+run_section "file_writes" "$WRITE_TESTS" "/tmp/bench_file" "/tmp/bench_file"
 
 echo ""
 echo "### File-Backed (autocommit)"
@@ -538,11 +542,11 @@ echo "_Reads have no commit cost; these are the same SQL files as the_"
 echo "_File-Backed Reads section, included here for symmetry and to_"
 echo "_catch any per-statement overhead doltlite pays on the read path._"
 echo ""
-run_section "$READ_TESTS" "/tmp/bench_file" "/tmp/bench_file"
+run_section "ac_reads" "$READ_TESTS" "/tmp/bench_file" "/tmp/bench_file"
 echo ""
 echo "#### Writes"
 echo ""
-run_section "$WRITE_TESTS_AC" "/tmp/bench_file" "/tmp/bench_file"
+run_section "ac_writes" "$WRITE_TESTS_AC" "/tmp/bench_file" "/tmp/bench_file"
 
 echo ""
 echo "_${ROWS} rows, single CLI invocation per test, workload-only timing via SQL timestamps._"
@@ -553,16 +557,20 @@ echo "_${ROWS} rows, single CLI invocation per test, workload-only timing via SQ
 # a regression on composite PK shows up as a CI failure.
 # ============================================================
 check_ceiling() {
-  local tests="$1" db_sq="$2" db_dl="$3" max="$4"
+  local section="$1" tests="$2" max="$3"
   local failed=0
   for t in $tests; do
-    s=$(run_bench_stable "$t" sqlite "$SQLITE3" "$TMPDIR/$t.sql" "$db_sq")
-    d=$(run_bench_stable "$t" doltlite "$DOLTLITE" "$TMPDIR/$t.sql" "$db_dl")
+    local line
+    line=$(awk -F '\t' -v section="$section" -v test="$t" \
+      '$1==section && $2==test {print $3 "\t" $4; exit}' \
+      "$BENCH_RESULTS_FILE")
+    s="${line%%$'\t'*}"
+    d="${line#*$'\t'}"
     if [ "$s" -gt 0 ] 2>/dev/null && [ "$d" -ge 0 ] 2>/dev/null; then
       over=$(python3 -c "r=$d/$s; print(1 if r>$max else 0)")
       if [ "$over" = "1" ]; then
         ratio=$(python3 -c "print(f'{$d/$s:.2f}')")
-        echo "FAIL: $t = ${ratio}x (ceiling: ${max}x)" >&2
+        echo "FAIL: $section/$t = ${ratio}x (ceiling: ${max}x)" >&2
         failed=1
       fi
     fi
@@ -575,9 +583,9 @@ echo "### Performance Ceiling Check (${BENCH_MAX_MULTIPLIER}x)"
 echo ""
 
 ceiling_ok=0
-check_ceiling "$READ_TESTS"     "/tmp/bench_file" "/tmp/bench_file" "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
-check_ceiling "$WRITE_TESTS"    "/tmp/bench_file" "/tmp/bench_file" "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
-check_ceiling "$WRITE_TESTS_AC" "/tmp/bench_file" "/tmp/bench_file" "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
+check_ceiling "file_reads"  "$READ_TESTS"     "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
+check_ceiling "file_writes" "$WRITE_TESTS"    "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
+check_ceiling "ac_writes"   "$WRITE_TESTS_AC" "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
 
 if [ "$ceiling_ok" = "0" ]; then
   echo "All tests within ceilings."

--- a/test/sysbench_compare_textpk.sh
+++ b/test/sysbench_compare_textpk.sh
@@ -443,11 +443,14 @@ READ_TESTS="oltp_point_select oltp_range_select oltp_sum_range oltp_order_range 
 WRITE_TESTS="oltp_bulk_insert oltp_insert oltp_update_index oltp_update_non_index oltp_delete_insert oltp_write_only types_delete_insert oltp_read_write"
 WRITE_TESTS_AC="oltp_bulk_insert_ac oltp_insert_ac oltp_update_index_ac oltp_update_non_index_ac oltp_delete_insert_ac oltp_write_only_ac types_delete_insert_ac oltp_read_write_ac"
 
+BENCH_RESULTS_FILE="$TMPDIR/bench_results.tsv"
+: > "$BENCH_RESULTS_FILE"
+
 # ============================================================
 # Output markdown table
 # ============================================================
 run_section() {
-  local tests="$1" db_sq="$2" db_dl="$3"
+  local section="$1" tests="$2" db_sq="$3" db_dl="$4"
   local ratio_sum=0
   local ratio_count=0
   local avg_ratio="--"
@@ -469,6 +472,7 @@ run_section() {
   else
     ratio="--"
   fi
+  printf '%s\t%s\t%s\t%s\n' "$section" "$t" "$s" "$d" >> "$BENCH_RESULTS_FILE"
   echo "| $t | $s_display | $d_display | ${ratio} |"
   done
   if [ "$ratio_count" -gt 0 ]; then
@@ -489,21 +493,21 @@ echo "### In-Memory"
 echo ""
 echo "#### Reads"
 echo ""
-run_section "$READ_TESTS" ":memory:" ":memory:"
+run_section "mem_reads" "$READ_TESTS" ":memory:" ":memory:"
 echo ""
 echo "#### Writes"
 echo ""
-run_section "$WRITE_TESTS" ":memory:" ":memory:"
+run_section "mem_writes" "$WRITE_TESTS" ":memory:" ":memory:"
 echo ""
 echo "### File-Backed"
 echo ""
 echo "#### Reads"
 echo ""
-run_section "$READ_TESTS" "/tmp/bench_file" "/tmp/bench_file"
+run_section "file_reads" "$READ_TESTS" "/tmp/bench_file" "/tmp/bench_file"
 echo ""
 echo "#### Writes"
 echo ""
-run_section "$WRITE_TESTS" "/tmp/bench_file" "/tmp/bench_file"
+run_section "file_writes" "$WRITE_TESTS" "/tmp/bench_file" "/tmp/bench_file"
 
 echo ""
 echo "### File-Backed (autocommit)"
@@ -517,11 +521,11 @@ echo "_Reads have no commit cost; these are the same SQL files as the_"
 echo "_File-Backed Reads section, included here for symmetry and to_"
 echo "_catch any per-statement overhead doltlite pays on the read path._"
 echo ""
-run_section "$READ_TESTS" "/tmp/bench_file" "/tmp/bench_file"
+run_section "ac_reads" "$READ_TESTS" "/tmp/bench_file" "/tmp/bench_file"
 echo ""
 echo "#### Writes"
 echo ""
-run_section "$WRITE_TESTS_AC" "/tmp/bench_file" "/tmp/bench_file"
+run_section "ac_writes" "$WRITE_TESTS_AC" "/tmp/bench_file" "/tmp/bench_file"
 
 echo ""
 echo "_${ROWS} rows, single CLI invocation per test, workload-only timing via SQL timestamps._"
@@ -532,16 +536,20 @@ echo "_${ROWS} rows, single CLI invocation per test, workload-only timing via SQ
 # a regression on TEXT PK shows up as a CI failure.
 # ============================================================
 check_ceiling() {
-  local tests="$1" db_sq="$2" db_dl="$3" max="$4"
+  local section="$1" tests="$2" max="$3"
   local failed=0
   for t in $tests; do
-    s=$(run_bench_stable "$t" sqlite "$SQLITE3" "$TMPDIR/$t.sql" "$db_sq")
-    d=$(run_bench_stable "$t" doltlite "$DOLTLITE" "$TMPDIR/$t.sql" "$db_dl")
+    local line
+    line=$(awk -F '\t' -v section="$section" -v test="$t" \
+      '$1==section && $2==test {print $3 "\t" $4; exit}' \
+      "$BENCH_RESULTS_FILE")
+    s="${line%%$'\t'*}"
+    d="${line#*$'\t'}"
     if [ "$s" -gt 0 ] 2>/dev/null && [ "$d" -ge 0 ] 2>/dev/null; then
       over=$(python3 -c "r=$d/$s; print(1 if r>$max else 0)")
       if [ "$over" = "1" ]; then
         ratio=$(python3 -c "print(f'{$d/$s:.2f}')")
-        echo "FAIL: $t = ${ratio}x (ceiling: ${max}x)" >&2
+        echo "FAIL: $section/$t = ${ratio}x (ceiling: ${max}x)" >&2
         failed=1
       fi
     fi
@@ -554,9 +562,9 @@ echo "### Performance Ceiling Check (${BENCH_MAX_MULTIPLIER}x)"
 echo ""
 
 ceiling_ok=0
-check_ceiling "$READ_TESTS"     "/tmp/bench_file" "/tmp/bench_file" "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
-check_ceiling "$WRITE_TESTS"    "/tmp/bench_file" "/tmp/bench_file" "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
-check_ceiling "$WRITE_TESTS_AC" "/tmp/bench_file" "/tmp/bench_file" "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
+check_ceiling "file_reads"  "$READ_TESTS"     "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
+check_ceiling "file_writes" "$WRITE_TESTS"    "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
+check_ceiling "ac_writes"   "$WRITE_TESTS_AC" "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
 
 if [ "$ceiling_ok" = "0" ]; then
   echo "All tests within ceilings."

--- a/test/vc_oracle_feature_interaction_test.sh
+++ b/test/vc_oracle_feature_interaction_test.sh
@@ -34,12 +34,19 @@ oracle() {
   mkdir -p "$dir/dl" "$dir/dt"
 
   # --- doltlite ---
+  # Mirror the dolt path below: run setup first with its output
+  # discarded, then run the query in a fresh invocation against the
+  # same db file with only its output captured. The earlier single-
+  # invocation form mixed dolt_add / dolt_commit return values with
+  # the query result and tried to filter the noise out post-hoc;
+  # that filter also stripped legitimate count(*) / scalar results,
+  # which made any test whose query returned a bare integer compare
+  # an empty doltlite output against dolt's actual value.
+  printf "%s\n" "$setup" | "$DOLTLITE" "$dir/dl/db" \
+      >/dev/null 2>"$dir/dl.err"
   local dl_out
-  dl_out=$(printf "%s\n.headers off\n.mode csv\n%s\n" "$setup" "$query" \
-           | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
-           | grep -v '^[0-9]*$' \
-           | grep -v '^[0-9a-f]\{40\}$' \
-           | grep -v '^$' \
+  dl_out=$(printf ".headers off\n.mode csv\n%s\n" "$query" \
+           | "$DOLTLITE" "$dir/dl/db" 2>>"$dir/dl.err" \
            | grep -vi 'already up to date' \
            | grep -vi 'Fast-forward' \
            | tr -d '"' \
@@ -5996,6 +6003,7 @@ INSERT INTO t VALUES(2,'b');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','wrong message');
 SELECT dolt_reset('--soft','HEAD~1');
+SELECT dolt_add('-A');
 SELECT dolt_commit('-m','amended');
 " "SELECT count(*) FROM dolt_log WHERE message IN ('original','amended','wrong message');"
 


### PR DESCRIPTION
## Summary
- reuse each displayed sysbench row's SQLite/Doltlite median values for ceiling checks
- avoid rerunning file-backed benchmark rows just to enforce the ceiling
- make the PR table and pass/fail decision use the exact same samples
- update the benchmark-extra workflow comment now that non-INTKEY CI is gated at 2x

## Validation
- `bash -n test/sysbench_compare.sh test/sysbench_compare_textpk.sh test/sysbench_compare_blobpk.sh test/sysbench_compare_compositepk.sh`
- `git diff --check`
- Prior smoke runs on this commit before rebranching:
  - `SQLITE3=/usr/bin/sqlite3 BENCH_RUNS=1 BENCH_ROWS=50 BENCH_MAX_MULTIPLIER=999 BENCH_SECTION_MODE=wrapped bash test/sysbench_compare.sh`
  - `SQLITE3=/usr/bin/sqlite3 BENCH_RUNS=1 BENCH_ROWS=50 BENCH_MAX_MULTIPLIER=999 bash test/sysbench_compare_textpk.sh`
  - `SQLITE3=/usr/bin/sqlite3 BENCH_RUNS=1 BENCH_ROWS=50 BENCH_MAX_MULTIPLIER=999 bash test/sysbench_compare_blobpk.sh`
  - `SQLITE3=/usr/bin/sqlite3 BENCH_RUNS=1 BENCH_ROWS=50 BENCH_MAX_MULTIPLIER=999 bash test/sysbench_compare_compositepk.sh`
