### PR TITLE
Improve sysbench timing resolution

### DIFF
--- a/.github/workflows/benchmark-extra.yml
+++ b/.github/workflows/benchmark-extra.yml
@@ -52,6 +52,8 @@ jobs:
         cd build
         make doltlite
         make DOLTLITE_PROLLY=0 sqlite3
+        cc -O2 -I. -I../src -o bench_timer_doltlite ../test/sysbench_timer.c libdoltlite.a -lpthread -lz -lm
+        cc -O2 -I. -I../src -o bench_timer_sqlite ../test/sysbench_timer.c sqlite3.o -lpthread -lz -lm
 
     - name: Run benchmarks
       id: bench

--- a/.github/workflows/benchmark-extra.yml
+++ b/.github/workflows/benchmark-extra.yml
@@ -51,8 +51,9 @@ jobs:
       run: |
         cd build
         make doltlite
-        make DOLTLITE_PROLLY=0 sqlite3
+        make doltlite-lib
         cc -O2 -I. -I../src -o bench_timer_doltlite ../test/sysbench_timer.c libdoltlite.a -lpthread -lz -lm
+        make DOLTLITE_PROLLY=0 sqlite3 sqlite3.o
         cc -O2 -I. -I../src -o bench_timer_sqlite ../test/sysbench_timer.c sqlite3.o -lpthread -lz -lm
 
     - name: Run benchmarks

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -38,6 +38,8 @@ jobs:
         cd build
         make doltlite
         make DOLTLITE_PROLLY=0 sqlite3
+        cc -O2 -I. -I../src -o bench_timer_doltlite ../test/sysbench_timer.c libdoltlite.a -lpthread -lz -lm
+        cc -O2 -I. -I../src -o bench_timer_sqlite ../test/sysbench_timer.c sqlite3.o -lpthread -lz -lm
 
     - name: Run benchmark
       id: bench

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -37,8 +37,9 @@ jobs:
       run: |
         cd build
         make doltlite
-        make DOLTLITE_PROLLY=0 sqlite3
+        make doltlite-lib
         cc -O2 -I. -I../src -o bench_timer_doltlite ../test/sysbench_timer.c libdoltlite.a -lpthread -lz -lm
+        make DOLTLITE_PROLLY=0 sqlite3 sqlite3.o
         cc -O2 -I. -I../src -o bench_timer_sqlite ../test/sysbench_timer.c sqlite3.o -lpthread -lz -lm
 
     - name: Run benchmark

--- a/test/sysbench_compare.sh
+++ b/test/sysbench_compare.sh
@@ -9,6 +9,8 @@ set -e
 
 DOLTLITE=${DOLTLITE:-./doltlite}
 SQLITE3=${SQLITE3:-./sqlite3}
+BENCH_TIMER_SQLITE=${BENCH_TIMER_SQLITE:-./bench_timer_sqlite}
+BENCH_TIMER_DOLTLITE=${BENCH_TIMER_DOLTLITE:-./bench_timer_doltlite}
 ROWS=${BENCH_ROWS:-10000}
 SEED=42
 TMPDIR=$(mktemp -d)
@@ -349,7 +351,8 @@ make_test("oltp_read_write_ac",       prep_main, w_read_write_autocommit)
 PYEOF
 
 # ============================================================
-# Run each test: single CLI invocation, SQL timestamps for timing
+# Run each test: single invocation, host-clock timing when the timer
+# helper is available. Fall back to SQL timestamps for local ad hoc runs.
 # ============================================================
 run_bench() {
   local engine="$1" binary="$2" sql_file="$3" db_template="$4"
@@ -358,6 +361,17 @@ run_bench() {
   if [ "$db" != ":memory:" ]; then
     db="/tmp/bench_${engine}_${RANDOM}_$$.db"
     rm -f "$db"
+  fi
+  local timer=""
+  if [ "$engine" = "sqlite" ] && [ -x "$BENCH_TIMER_SQLITE" ]; then
+    timer="$BENCH_TIMER_SQLITE"
+  elif [ "$engine" = "doltlite" ] && [ -x "$BENCH_TIMER_DOLTLITE" ]; then
+    timer="$BENCH_TIMER_DOLTLITE"
+  fi
+  if [ -n "$timer" ]; then
+    "$timer" "$db" "$sql_file"
+    if [ "$db" != ":memory:" ]; then rm -f "$db"; fi
+    return
   fi
   local output
   output=$(sed \
@@ -548,7 +562,7 @@ case "$BENCH_SECTION_MODE" in
 esac
 
 echo ""
-echo "_${ROWS} rows, single CLI invocation per test, workload-only timing via SQL timestamps._"
+echo "_${ROWS} rows, single invocation per test, workload-only timing via host monotonic clock when available._"
 
 # ============================================================
 # Enforce performance ceiling (exit 1 if any test exceeds limit)

--- a/test/sysbench_compare_blobpk.sh
+++ b/test/sysbench_compare_blobpk.sh
@@ -20,6 +20,8 @@ set -e
 
 DOLTLITE=${DOLTLITE:-./doltlite}
 SQLITE3=${SQLITE3:-./sqlite3}
+BENCH_TIMER_SQLITE=${BENCH_TIMER_SQLITE:-./bench_timer_sqlite}
+BENCH_TIMER_DOLTLITE=${BENCH_TIMER_DOLTLITE:-./bench_timer_doltlite}
 ROWS=${BENCH_ROWS:-1000}
 BENCH_MAX_MULTIPLIER=${BENCH_MAX_MULTIPLIER:-2}
 SEED=42
@@ -370,7 +372,8 @@ make_test("oltp_read_write_ac",       prep_main, w_read_write_autocommit)
 PYEOF
 
 # ============================================================
-# Run each test: single CLI invocation, SQL timestamps for timing
+# Run each test: single invocation, host-clock timing when the timer
+# helper is available. Fall back to SQL timestamps for local ad hoc runs.
 # ============================================================
 run_bench() {
   local engine="$1" binary="$2" sql_file="$3" db_template="$4"
@@ -379,6 +382,17 @@ run_bench() {
   if [ "$db" != ":memory:" ]; then
     db="/tmp/bench_${engine}_${RANDOM}_$$.db"
     rm -f "$db"
+  fi
+  local timer=""
+  if [ "$engine" = "sqlite" ] && [ -x "$BENCH_TIMER_SQLITE" ]; then
+    timer="$BENCH_TIMER_SQLITE"
+  elif [ "$engine" = "doltlite" ] && [ -x "$BENCH_TIMER_DOLTLITE" ]; then
+    timer="$BENCH_TIMER_DOLTLITE"
+  fi
+  if [ -n "$timer" ]; then
+    "$timer" "$db" "$sql_file"
+    if [ "$db" != ":memory:" ]; then rm -f "$db"; fi
+    return
   fi
   local output
   output=$(sed \
@@ -524,7 +538,7 @@ echo ""
 run_section "$WRITE_TESTS_AC" "/tmp/bench_file" "/tmp/bench_file"
 
 echo ""
-echo "_${ROWS} rows, single CLI invocation per test, workload-only timing via SQL timestamps._"
+echo "_${ROWS} rows, single invocation per test, workload-only timing via host monotonic clock when available._"
 
 # ============================================================
 # Enforce performance ceiling — gates the same shape sysbench_compare.sh

--- a/test/sysbench_compare_compositepk.sh
+++ b/test/sysbench_compare_compositepk.sh
@@ -23,6 +23,8 @@ set -e
 
 DOLTLITE=${DOLTLITE:-./doltlite}
 SQLITE3=${SQLITE3:-./sqlite3}
+BENCH_TIMER_SQLITE=${BENCH_TIMER_SQLITE:-./bench_timer_sqlite}
+BENCH_TIMER_DOLTLITE=${BENCH_TIMER_DOLTLITE:-./bench_timer_doltlite}
 ROWS=${BENCH_ROWS:-1000}
 BENCH_MAX_MULTIPLIER=${BENCH_MAX_MULTIPLIER:-2}
 SEED=42
@@ -165,7 +167,7 @@ def w_distinct_range(f):
 
 def w_index_scan(f):
     for _ in range(1000):
-        f.write(f"SELECT id, c FROM sbtest1 WHERE k={rint(1,R)};\n")
+        f.write(f"SELECT a, b, c FROM sbtest1 WHERE k={rint(1,R)};\n")
 
 def w_update_index(f):
     f.write("BEGIN;\n")
@@ -391,7 +393,8 @@ make_test("oltp_read_write_ac",       prep_main, w_read_write_autocommit)
 PYEOF
 
 # ============================================================
-# Run each test: single CLI invocation, SQL timestamps for timing
+# Run each test: single invocation, host-clock timing when the timer
+# helper is available. Fall back to SQL timestamps for local ad hoc runs.
 # ============================================================
 run_bench() {
   local engine="$1" binary="$2" sql_file="$3" db_template="$4"
@@ -400,6 +403,17 @@ run_bench() {
   if [ "$db" != ":memory:" ]; then
     db="/tmp/bench_${engine}_${RANDOM}_$$.db"
     rm -f "$db"
+  fi
+  local timer=""
+  if [ "$engine" = "sqlite" ] && [ -x "$BENCH_TIMER_SQLITE" ]; then
+    timer="$BENCH_TIMER_SQLITE"
+  elif [ "$engine" = "doltlite" ] && [ -x "$BENCH_TIMER_DOLTLITE" ]; then
+    timer="$BENCH_TIMER_DOLTLITE"
+  fi
+  if [ -n "$timer" ]; then
+    "$timer" "$db" "$sql_file"
+    if [ "$db" != ":memory:" ]; then rm -f "$db"; fi
+    return
   fi
   local output
   output=$(sed \
@@ -545,7 +559,7 @@ echo ""
 run_section "$WRITE_TESTS_AC" "/tmp/bench_file" "/tmp/bench_file"
 
 echo ""
-echo "_${ROWS} rows, single CLI invocation per test, workload-only timing via SQL timestamps._"
+echo "_${ROWS} rows, single invocation per test, workload-only timing via host monotonic clock when available._"
 
 # ============================================================
 # Enforce performance ceiling — gates the same shape sysbench_compare.sh

--- a/test/sysbench_compare_textpk.sh
+++ b/test/sysbench_compare_textpk.sh
@@ -19,6 +19,8 @@ set -e
 
 DOLTLITE=${DOLTLITE:-./doltlite}
 SQLITE3=${SQLITE3:-./sqlite3}
+BENCH_TIMER_SQLITE=${BENCH_TIMER_SQLITE:-./bench_timer_sqlite}
+BENCH_TIMER_DOLTLITE=${BENCH_TIMER_DOLTLITE:-./bench_timer_doltlite}
 ROWS=${BENCH_ROWS:-1000}
 BENCH_MAX_MULTIPLIER=${BENCH_MAX_MULTIPLIER:-2}
 SEED=42
@@ -370,7 +372,8 @@ make_test("oltp_read_write_ac",       prep_main, w_read_write_autocommit)
 PYEOF
 
 # ============================================================
-# Run each test: single CLI invocation, SQL timestamps for timing
+# Run each test: single invocation, host-clock timing when the timer
+# helper is available. Fall back to SQL timestamps for local ad hoc runs.
 # ============================================================
 run_bench() {
   local engine="$1" binary="$2" sql_file="$3" db_template="$4"
@@ -379,6 +382,17 @@ run_bench() {
   if [ "$db" != ":memory:" ]; then
     db="/tmp/bench_${engine}_${RANDOM}_$$.db"
     rm -f "$db"
+  fi
+  local timer=""
+  if [ "$engine" = "sqlite" ] && [ -x "$BENCH_TIMER_SQLITE" ]; then
+    timer="$BENCH_TIMER_SQLITE"
+  elif [ "$engine" = "doltlite" ] && [ -x "$BENCH_TIMER_DOLTLITE" ]; then
+    timer="$BENCH_TIMER_DOLTLITE"
+  fi
+  if [ -n "$timer" ]; then
+    "$timer" "$db" "$sql_file"
+    if [ "$db" != ":memory:" ]; then rm -f "$db"; fi
+    return
   fi
   local output
   output=$(sed \
@@ -524,7 +538,7 @@ echo ""
 run_section "$WRITE_TESTS_AC" "/tmp/bench_file" "/tmp/bench_file"
 
 echo ""
-echo "_${ROWS} rows, single CLI invocation per test, workload-only timing via SQL timestamps._"
+echo "_${ROWS} rows, single invocation per test, workload-only timing via host monotonic clock when available._"
 
 # ============================================================
 # Enforce performance ceiling — gates the same shape sysbench_compare.sh

--- a/test/sysbench_timer.c
+++ b/test/sysbench_timer.c
@@ -1,0 +1,146 @@
+#include "sqlite3.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+typedef struct Str {
+  char *z;
+  size_t n;
+  size_t cap;
+} Str;
+
+static long long now_us(void){
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return (long long)ts.tv_sec * 1000000LL + ts.tv_nsec / 1000;
+}
+
+static int append(Str *s, const char *z){
+  size_t n = strlen(z);
+  if( s->n + n + 1 > s->cap ){
+    size_t cap = s->cap ? s->cap * 2 : 4096;
+    while( s->n + n + 1 > cap ) cap *= 2;
+    char *p = (char*)realloc(s->z, cap);
+    if( p==0 ) return 1;
+    s->z = p;
+    s->cap = cap;
+  }
+  memcpy(s->z + s->n, z, n);
+  s->n += n;
+  s->z[s->n] = 0;
+  return 0;
+}
+
+static int is_marker(const char *z, const char *marker){
+  size_t n = strlen(marker);
+  return strncmp(z, marker, n)==0 && (z[n]=='\n' || z[n]=='\r' || z[n]==0);
+}
+
+static int read_sections(const char *path, Str *setup, Str *workload, Str *teardown){
+  FILE *f = fopen(path, "r");
+  char line[65536];
+  int phase = 0;
+  int saw_start = 0;
+  int saw_end = 0;
+  if( f==0 ){
+    fprintf(stderr, "open %s: %s\n", path, strerror(errno));
+    return 1;
+  }
+  while( fgets(line, sizeof(line), f) ){
+    if( is_marker(line, ".print BENCH_START") ){
+      phase = 1;
+      saw_start = 1;
+      continue;
+    }
+    if( is_marker(line, ".print BENCH_END") ){
+      phase = 2;
+      saw_end = 1;
+      continue;
+    }
+    if( phase==0 ){
+      if( append(setup, line) ) goto oom;
+    }else if( phase==1 ){
+      if( append(workload, line) ) goto oom;
+    }else{
+      if( append(teardown, line) ) goto oom;
+    }
+  }
+  if( ferror(f) ){
+    fprintf(stderr, "read %s: %s\n", path, strerror(errno));
+    fclose(f);
+    return 1;
+  }
+  fclose(f);
+  if( !saw_start || !saw_end ){
+    fprintf(stderr, "%s: missing BENCH_START/BENCH_END markers\n", path);
+    return 1;
+  }
+  return 0;
+
+oom:
+  fprintf(stderr, "out of memory\n");
+  fclose(f);
+  return 1;
+}
+
+static int exec_sql(sqlite3 *db, const char *sql, const char *label){
+  char *err = 0;
+  int rc;
+  if( sql==0 || sql[0]==0 ) return SQLITE_OK;
+  rc = sqlite3_exec(db, sql, 0, 0, &err);
+  if( rc!=SQLITE_OK ){
+    fprintf(stderr, "%s: %s\n", label, err ? err : sqlite3_errmsg(db));
+    sqlite3_free(err);
+  }
+  return rc;
+}
+
+int main(int argc, char **argv){
+  sqlite3 *db = 0;
+  Str setup = {0,0,0};
+  Str workload = {0,0,0};
+  Str teardown = {0,0,0};
+  long long t0, t1;
+  int rc;
+
+  if( argc!=3 ){
+    fprintf(stderr, "usage: %s DB SQL_FILE\n", argv[0]);
+    printf("-1\n");
+    return 0;
+  }
+  if( read_sections(argv[2], &setup, &workload, &teardown) ){
+    printf("-1\n");
+    goto done;
+  }
+  rc = sqlite3_open(argv[1], &db);
+  if( rc!=SQLITE_OK ){
+    fprintf(stderr, "open %s: %s\n", argv[1], db ? sqlite3_errmsg(db) : "out of memory");
+    printf("-1\n");
+    goto done;
+  }
+  if( exec_sql(db, setup.z, "setup")!=SQLITE_OK ){
+    printf("-1\n");
+    goto done;
+  }
+  t0 = now_us();
+  if( exec_sql(db, workload.z, "workload")!=SQLITE_OK ){
+    printf("-1\n");
+    goto done;
+  }
+  t1 = now_us();
+  if( exec_sql(db, teardown.z, "teardown")!=SQLITE_OK ){
+    printf("-1\n");
+    goto done;
+  }
+  printf("%lld\n", t1 - t0);
+
+done:
+  if( db ) sqlite3_close(db);
+  free(setup.z);
+  free(workload.z);
+  free(teardown.z);
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add a small C sysbench timer that executes existing generated SQL workloads and measures the marked workload section with CLOCK_MONOTONIC
- wire benchmark CI to build timer binaries for both doltlite and stock SQLite, with shell scripts falling back to SQL timestamps when timers are absent
- compare autocommit sections against stock SQLite with journal_mode=WAL and synchronous=FULL, and print that durability note in benchmark comments
- fix composite-PK index_scan to select the real composite key columns instead of a missing id column

## Testing
- cc -O2 -I. -Isrc -o /tmp/bench_timer_doltlite test/sysbench_timer.c libdoltlite.a -lpthread -lz -lm
- cc -O2 -I. -Isrc -o /tmp/bench_timer_sqlite test/sysbench_timer.c sqlite3.o -lpthread -lz -lm
- BENCH_TIMER_SQLITE=/tmp/bench_timer_sqlite BENCH_TIMER_DOLTLITE=/tmp/bench_timer_doltlite BENCH_RUNS=1 BENCH_ROWS=200 BENCH_MAX_MULTIPLIER=999 BENCH_SECTION_MODE=wrapped bash test/sysbench_compare.sh
- BENCH_TIMER_SQLITE=/tmp/bench_timer_sqlite BENCH_TIMER_DOLTLITE=/tmp/bench_timer_doltlite BENCH_RUNS=1 BENCH_ROWS=200 BENCH_MAX_MULTIPLIER=2 BENCH_SECTION_MODE=autocommit bash test/sysbench_compare.sh
- BENCH_TIMER_SQLITE=/tmp/bench_timer_sqlite BENCH_TIMER_DOLTLITE=/tmp/bench_timer_doltlite BENCH_RUNS=5 BENCH_ROWS=1000 BENCH_MAX_MULTIPLIER=2 bash test/sysbench_compare_textpk.sh (autocommit 2x ceiling was tested and is not stable yet; left reporting-only)
- BENCH_TIMER_SQLITE=/tmp/bench_timer_sqlite BENCH_TIMER_DOLTLITE=/tmp/bench_timer_doltlite SQLITE_AUTOCOMMIT_PRAGMAS='PRAGMA journal_mode=WAL; PRAGMA synchronous=FULL;' BENCH_RUNS=1 BENCH_ROWS=200 BENCH_MAX_MULTIPLIER=999 bash test/sysbench_compare_blobpk.sh
- BENCH_TIMER_SQLITE=/tmp/bench_timer_sqlite BENCH_TIMER_DOLTLITE=/tmp/bench_timer_doltlite SQLITE_AUTOCOMMIT_PRAGMAS='PRAGMA journal_mode=WAL; PRAGMA synchronous=FULL;' BENCH_RUNS=1 BENCH_ROWS=200 BENCH_MAX_MULTIPLIER=999 bash test/sysbench_compare_compositepk.sh

Closes #788