### PR TITLE
fix #790: dolt_reset --soft preserves staged set

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -2429,7 +2429,15 @@ static void doltliteResetFunc(
     }
   }
 
-  doltliteSetSessionStaged(db, &targetCatHash);
+  /* --soft preserves the existing staged set so the changes that were
+  ** in the orphaned commit can be re-committed (the canonical
+  ** "amend a commit message" / "rewrite the last commit" flow:
+  ** soft-reset, then re-commit with corrections). --mixed (the
+  ** no-flag form) and --hard both reset staged to the target. See
+  ** issue #790. */
+  if( !isSoft ){
+    doltliteSetSessionStaged(db, &targetCatHash);
+  }
 
   if( isHard ){
 

--- a/test/vc_oracle_feature_interaction_test.sh
+++ b/test/vc_oracle_feature_interaction_test.sh
@@ -9447,6 +9447,65 @@ SELECT dolt_commit('-m','c2');
 SELECT dolt_reset('--soft','HEAD~1');
 " "SELECT id FROM t ORDER BY id;"
 
+# Issue #790 regression coverage: --soft must preserve the staged set
+# so the canonical "amend by soft-reset + recommit" flow works without
+# an explicit re-stage. Previously dolt_reset --soft realigned staged
+# to the target catalog, which made the next dolt_commit fail with
+# "nothing to commit" because the diff against staged was empty.
+
+oracle "soft_reset_recommit_no_explicit_add" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','original');
+INSERT INTO t VALUES(2,'b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','wrong message');
+SELECT dolt_reset('--soft','HEAD~1');
+SELECT dolt_commit('-m','amended');
+" "SELECT count(*) FROM dolt_log WHERE message IN ('original','amended','wrong message');"
+
+oracle "soft_reset_recommit_amended_data_present" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','original');
+INSERT INTO t VALUES(2,'b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','wrong message');
+SELECT dolt_reset('--soft','HEAD~1');
+SELECT dolt_commit('-m','amended');
+" "SELECT id, v FROM t ORDER BY id;"
+
+oracle "soft_reset_two_levels_recommit_no_add" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+INSERT INTO t VALUES(1,1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c1');
+INSERT INTO t VALUES(2,2);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c2');
+INSERT INTO t VALUES(3,3);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','c3');
+SELECT dolt_reset('--soft','HEAD~2');
+SELECT dolt_commit('-m','squashed');
+" "SELECT count(*) FROM dolt_log;"
+
+oracle "soft_reset_recommit_combines_prior_stage" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','original');
+INSERT INTO t VALUES(2,'b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','wrong message');
+SELECT dolt_reset('--soft','HEAD~1');
+INSERT INTO t VALUES(3,'c');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','amended_with_extra');
+" "SELECT id, v FROM t ORDER BY id;"
+
 # ═══════════════════════════════════════════════════════════════════
 # Section 228: JSON functions after merge
 # ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Fixes #790. \`doltliteResetFunc\` unconditionally reset the staged catalog hash to the target commit's catalog regardless of mode. For \`--hard\` and \`--mixed\` (no-flag) that's the right behavior — staged should be realigned to the target. For \`--soft\` it nuked the staged delta against the target, so the canonical "amend by soft-reset + recommit" flow failed: the orphaned commit's changes stayed in the working tree (correctly, \`--soft\` preserves working) but were no longer staged, and the next \`dolt_commit\` reported \`"nothing to commit, working tree clean"\`.

Skip the staged-reset on \`--soft\`. HEAD and the branch ref still move; the working tree is untouched; and the staged set retains the diff the user just unwound — exactly Git's \`--soft\` semantics.

## Repro from #790

Before this PR:
```
... (snip) ...
Error in 2nd command line argument: nothing to commit, working tree clean (use dolt_add to stage changes)
1
```

After this PR:
```
... (snip) ...
2
```

## Tests

Added four new oracle tests covering this seam in \`test/vc_oracle_feature_interaction_test.sh\`:

- \`soft_reset_recommit_no_explicit_add\` — soft-reset, recommit without re-staging, count=2
- \`soft_reset_recommit_amended_data_present\` — soft-reset, recommit, amended commit contains the data
- \`soft_reset_two_levels_recommit_no_add\` — soft-reset HEAD~2, single squashed commit replaces two
- \`soft_reset_recommit_combines_prior_stage\` — soft-reset preserves prior staged + new working changes get committed together

All four pass against the fix locally. \`--hard\` and the no-flag (unstage-all) form are unaffected. All 107,878 regression tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)