### PR TITLE
Add nested transaction dolt_commit oracle tests

### DIFF
--- a/test/vc_oracle_txn_commit_test.sh
+++ b/test/vc_oracle_txn_commit_test.sh
@@ -343,6 +343,352 @@ else
   echo "    expected 1, got $DL_I"
 fi
 
+# ── Test J: Rollback inside nested savepoint before dolt_commit ──
+echo ""
+echo "--- ROLLBACK TO nested savepoint before dolt_commit ---"
+
+DB="$TMPROOT/j.db"
+rm -f "$DB"
+dl_query "$DB" "$(cat <<'SQL'
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'base');
+SELECT dolt_commit('-A','-m','base');
+BEGIN;
+INSERT INTO t VALUES(2,'outer');
+SAVEPOINT inner;
+INSERT INTO t VALUES(3,'inner');
+ROLLBACK TO inner;
+RELEASE inner;
+SELECT dolt_commit('-A','-m','outer-only');
+ROLLBACK;
+SQL
+)" >/dev/null
+DL_J=$(dl_query "$DB" "SELECT group_concat(id || ':' || v, ',') FROM (SELECT id, v FROM t ORDER BY id);")
+DL_J_STATUS=$(dl_query "$DB" "SELECT count(*) FROM dolt_status;")
+
+if [ "$DL_J" = "1:base,2:outer" ]; then
+  pass_name "nested_savepoint_rollback_before_commit_keeps_only_unrolled_rows"
+else
+  fail_name "nested_savepoint_rollback_before_commit_keeps_only_unrolled_rows"
+  echo "    expected 1:base,2:outer, got $DL_J"
+fi
+
+if [ "$DL_J_STATUS" = "0" ]; then
+  pass_name "nested_savepoint_rollback_before_commit_leaves_clean_status"
+else
+  fail_name "nested_savepoint_rollback_before_commit_leaves_clean_status"
+  echo "    expected clean status, got $DL_J_STATUS"
+fi
+
+# ── Test K: DDL inside nested savepoint committed by dolt_commit ──
+echo ""
+echo "--- DDL in nested savepoint + dolt_commit ---"
+
+DB="$TMPROOT/k.db"
+rm -f "$DB"
+dl_query "$DB" "$(cat <<'SQL'
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'base');
+SELECT dolt_commit('-A','-m','base');
+BEGIN;
+SAVEPOINT ddl_sp;
+CREATE TABLE u(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO u VALUES(10,'nested-ddl');
+SELECT dolt_commit('-A','-m','ddl');
+ROLLBACK TO ddl_sp;
+RELEASE ddl_sp;
+ROLLBACK;
+SQL
+)" >/dev/null
+DL_K=$(dl_query "$DB" "SELECT (SELECT count(*) FROM sqlite_schema WHERE type='table' AND name='u') || ':' || (SELECT count(*) FROM u);")
+DL_K_STATUS=$(dl_query "$DB" "SELECT count(*) FROM dolt_status;")
+DL_K_SIG=$(dl_query "$DB" "SELECT count(*) || ':' || sum(id) FROM u;")
+
+if [ -n "$DOLT" ]; then
+  DOLT_K_DIR="$TMPROOT/dolt_k"
+  mkdir -p "$DOLT_K_DIR"
+  (cd "$DOLT_K_DIR" && "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1)
+  (cd "$DOLT_K_DIR" && "$DOLT" sql -c -r csv <<'SQL' >/dev/null 2>/dev/null
+CREATE TABLE t(id INT PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'base');
+CALL dolt_commit('-A','-m','base');
+BEGIN;
+SAVEPOINT ddl_sp;
+CREATE TABLE u(id INT PRIMARY KEY, v TEXT);
+INSERT INTO u VALUES(10,'nested-ddl');
+CALL dolt_commit('-A','-m','ddl');
+ROLLBACK TO ddl_sp;
+RELEASE ddl_sp;
+ROLLBACK;
+SQL
+)
+  DOLT_K_SIG=$(dolt_query "$DOLT_K_DIR" "SELECT concat(count(*), ':', sum(id)) FROM u;")
+
+  if [ "$DL_K_SIG" = "$DOLT_K_SIG" ]; then
+    pass_name "nested_savepoint_ddl_commit_matches_dolt"
+  else
+    fail_name "nested_savepoint_ddl_commit_matches_dolt"
+    echo "    doltlite=$DL_K_SIG dolt=$DOLT_K_SIG"
+  fi
+fi
+
+if [ "$DL_K" = "1:1" ]; then
+  pass_name "nested_savepoint_ddl_commit_persists_schema_and_rows"
+else
+  fail_name "nested_savepoint_ddl_commit_persists_schema_and_rows"
+  echo "    expected 1:1, got $DL_K"
+fi
+
+if [ "$DL_K_STATUS" = "0" ]; then
+  pass_name "nested_savepoint_ddl_commit_leaves_clean_status"
+else
+  fail_name "nested_savepoint_ddl_commit_leaves_clean_status"
+  echo "    expected clean status, got $DL_K_STATUS"
+fi
+
+# ── Test L: Connection remains usable after nested savepoint commit ──
+echo ""
+echo "--- Reuse connection after nested savepoint + dolt_commit ---"
+
+DB="$TMPROOT/l.db"
+rm -f "$DB"
+dl_query "$DB" "$(cat <<'SQL'
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+BEGIN;
+SAVEPOINT outer_sp;
+INSERT INTO t VALUES(1,'outer');
+SAVEPOINT inner_sp;
+INSERT INTO t VALUES(2,'inner');
+SELECT dolt_commit('-A','-m','nested');
+BEGIN;
+INSERT INTO t VALUES(3,'rolled-back-after');
+ROLLBACK;
+BEGIN;
+INSERT INTO t VALUES(4,'committed-after');
+COMMIT;
+SELECT dolt_commit('-A','-m','after');
+SQL
+)" >/dev/null
+DL_L=$(dl_query "$DB" "SELECT group_concat(id || ':' || v, ',') FROM (SELECT id, v FROM t ORDER BY id);")
+DL_L_STATUS=$(dl_query "$DB" "SELECT count(*) FROM dolt_status;")
+DL_L_SIG=$(dl_query "$DB" "SELECT count(*) || ':' || sum(id) FROM t;")
+
+if [ -n "$DOLT" ]; then
+  DOLT_L_DIR="$TMPROOT/dolt_l"
+  mkdir -p "$DOLT_L_DIR"
+  (cd "$DOLT_L_DIR" && "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1)
+  (cd "$DOLT_L_DIR" && "$DOLT" sql -c -r csv <<'SQL' >/dev/null 2>/dev/null
+CREATE TABLE t(id INT PRIMARY KEY, v TEXT);
+BEGIN;
+SAVEPOINT outer_sp;
+INSERT INTO t VALUES(1,'outer');
+SAVEPOINT inner_sp;
+INSERT INTO t VALUES(2,'inner');
+CALL dolt_commit('-A','-m','nested');
+BEGIN;
+INSERT INTO t VALUES(3,'rolled-back-after');
+ROLLBACK;
+BEGIN;
+INSERT INTO t VALUES(4,'committed-after');
+COMMIT;
+CALL dolt_commit('-A','-m','after');
+SQL
+)
+  DOLT_L_SIG=$(dolt_query "$DOLT_L_DIR" "SELECT concat(count(*), ':', sum(id)) FROM t;")
+
+  if [ "$DL_L_SIG" = "$DOLT_L_SIG" ]; then
+    pass_name "nested_savepoint_commit_reuse_matches_dolt"
+  else
+    fail_name "nested_savepoint_commit_reuse_matches_dolt"
+    echo "    doltlite=$DL_L_SIG dolt=$DOLT_L_SIG"
+  fi
+fi
+
+if [ "$DL_L" = "1:outer,2:inner,4:committed-after" ]; then
+  pass_name "nested_savepoint_commit_allows_later_transactions"
+else
+  fail_name "nested_savepoint_commit_allows_later_transactions"
+  echo "    expected 1:outer,2:inner,4:committed-after, got $DL_L"
+fi
+
+if [ "$DL_L_STATUS" = "0" ]; then
+  pass_name "nested_savepoint_commit_later_transactions_leave_clean_status"
+else
+  fail_name "nested_savepoint_commit_later_transactions_leave_clean_status"
+  echo "    expected clean status, got $DL_L_STATUS"
+fi
+
+# ── Test M: BEGIN, BEGIN, COMMIT, dolt_commit ──────────────
+echo ""
+echo "--- BEGIN + BEGIN + COMMIT + dolt_commit ---"
+
+DB="$TMPROOT/m.db"
+rm -f "$DB"
+dl_query "$DB" "$(cat <<'SQL'
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+BEGIN;
+INSERT INTO t VALUES(1,'in-outer');
+BEGIN;
+INSERT INTO t VALUES(2,'after-bad-begin');
+COMMIT;
+SELECT dolt_commit('-A','-m','after-sql-commit');
+ROLLBACK;
+SQL
+)" >/dev/null
+DL_M=$(dl_query "$DB" "SELECT group_concat(id || ':' || v, ',') FROM (SELECT id, v FROM t ORDER BY id);")
+DL_M_STATUS=$(dl_query "$DB" "SELECT count(*) FROM dolt_status;")
+
+if [ "$DL_M" = "1:in-outer,2:after-bad-begin" ]; then
+  pass_name "begin_begin_commit_then_dolt_commit_keeps_sql_commit"
+else
+  fail_name "begin_begin_commit_then_dolt_commit_keeps_sql_commit"
+  echo "    expected 1:in-outer,2:after-bad-begin, got $DL_M"
+fi
+
+if [ "$DL_M_STATUS" = "0" ]; then
+  pass_name "begin_begin_commit_then_dolt_commit_leaves_clean_status"
+else
+  fail_name "begin_begin_commit_then_dolt_commit_leaves_clean_status"
+  echo "    expected clean status, got $DL_M_STATUS"
+fi
+
+# ── Test N: BEGIN, BEGIN, dolt_commit, COMMIT ──────────────
+echo ""
+echo "--- BEGIN + BEGIN + dolt_commit + COMMIT ---"
+
+DB="$TMPROOT/n.db"
+rm -f "$DB"
+dl_query "$DB" "$(cat <<'SQL'
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+BEGIN;
+INSERT INTO t VALUES(1,'in-outer');
+BEGIN;
+INSERT INTO t VALUES(2,'after-bad-begin');
+SELECT dolt_commit('-A','-m','during-sql-transaction');
+COMMIT;
+ROLLBACK;
+SQL
+)" >/dev/null
+DL_N=$(dl_query "$DB" "SELECT group_concat(id || ':' || v, ',') FROM (SELECT id, v FROM t ORDER BY id);")
+DL_N_STATUS=$(dl_query "$DB" "SELECT count(*) FROM dolt_status;")
+
+if [ "$DL_N" = "1:in-outer,2:after-bad-begin" ]; then
+  pass_name "begin_begin_dolt_commit_then_commit_keeps_dolt_commit"
+else
+  fail_name "begin_begin_dolt_commit_then_commit_keeps_dolt_commit"
+  echo "    expected 1:in-outer,2:after-bad-begin, got $DL_N"
+fi
+
+if [ "$DL_N_STATUS" = "0" ]; then
+  pass_name "begin_begin_dolt_commit_then_commit_leaves_clean_status"
+else
+  fail_name "begin_begin_dolt_commit_then_commit_leaves_clean_status"
+  echo "    expected clean status, got $DL_N_STATUS"
+fi
+
+# ── Test O: BEGIN IMMEDIATE, BEGIN, COMMIT, dolt_commit ────
+echo ""
+echo "--- BEGIN IMMEDIATE + BEGIN + COMMIT + dolt_commit ---"
+
+DB="$TMPROOT/o.db"
+rm -f "$DB"
+dl_query "$DB" "$(cat <<'SQL'
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+BEGIN IMMEDIATE;
+INSERT INTO t VALUES(1,'in-immediate');
+BEGIN;
+INSERT INTO t VALUES(2,'after-bad-begin');
+COMMIT;
+SELECT dolt_commit('-A','-m','after-sql-commit');
+ROLLBACK;
+SQL
+)" >/dev/null
+DL_O=$(dl_query "$DB" "SELECT group_concat(id || ':' || v, ',') FROM (SELECT id, v FROM t ORDER BY id);")
+DL_O_STATUS=$(dl_query "$DB" "SELECT count(*) FROM dolt_status;")
+
+if [ "$DL_O" = "1:in-immediate,2:after-bad-begin" ]; then
+  pass_name "begin_immediate_begin_commit_then_dolt_commit_keeps_sql_commit"
+else
+  fail_name "begin_immediate_begin_commit_then_dolt_commit_keeps_sql_commit"
+  echo "    expected 1:in-immediate,2:after-bad-begin, got $DL_O"
+fi
+
+if [ "$DL_O_STATUS" = "0" ]; then
+  pass_name "begin_immediate_begin_commit_then_dolt_commit_leaves_clean_status"
+else
+  fail_name "begin_immediate_begin_commit_then_dolt_commit_leaves_clean_status"
+  echo "    expected clean status, got $DL_O_STATUS"
+fi
+
+# ── Test P: BEGIN IMMEDIATE, BEGIN, dolt_commit, COMMIT ────
+echo ""
+echo "--- BEGIN IMMEDIATE + BEGIN + dolt_commit + COMMIT ---"
+
+DB="$TMPROOT/p.db"
+rm -f "$DB"
+dl_query "$DB" "$(cat <<'SQL'
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+BEGIN IMMEDIATE;
+INSERT INTO t VALUES(1,'in-immediate');
+BEGIN;
+INSERT INTO t VALUES(2,'after-bad-begin');
+SELECT dolt_commit('-A','-m','during-immediate-transaction');
+COMMIT;
+ROLLBACK;
+SQL
+)" >/dev/null
+DL_P=$(dl_query "$DB" "SELECT group_concat(id || ':' || v, ',') FROM (SELECT id, v FROM t ORDER BY id);")
+DL_P_STATUS=$(dl_query "$DB" "SELECT count(*) FROM dolt_status;")
+
+if [ "$DL_P" = "1:in-immediate,2:after-bad-begin" ]; then
+  pass_name "begin_immediate_begin_dolt_commit_then_commit_keeps_dolt_commit"
+else
+  fail_name "begin_immediate_begin_dolt_commit_then_commit_keeps_dolt_commit"
+  echo "    expected 1:in-immediate,2:after-bad-begin, got $DL_P"
+fi
+
+if [ "$DL_P_STATUS" = "0" ]; then
+  pass_name "begin_immediate_begin_dolt_commit_then_commit_leaves_clean_status"
+else
+  fail_name "begin_immediate_begin_dolt_commit_then_commit_leaves_clean_status"
+  echo "    expected clean status, got $DL_P_STATUS"
+fi
+
+# ── Test Q: BEGIN IMMEDIATE + nested savepoint + dolt_commit ──
+echo ""
+echo "--- BEGIN IMMEDIATE + nested savepoint + dolt_commit ---"
+
+DB="$TMPROOT/q.db"
+rm -f "$DB"
+dl_query "$DB" "$(cat <<'SQL'
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+BEGIN IMMEDIATE;
+INSERT INTO t VALUES(1,'in-immediate');
+SAVEPOINT inner;
+INSERT INTO t VALUES(2,'in-savepoint');
+SELECT dolt_commit('-A','-m','immediate-savepoint');
+ROLLBACK TO inner;
+COMMIT;
+ROLLBACK;
+SQL
+)" >/dev/null
+DL_Q=$(dl_query "$DB" "SELECT group_concat(id || ':' || v, ',') FROM (SELECT id, v FROM t ORDER BY id);")
+DL_Q_STATUS=$(dl_query "$DB" "SELECT count(*) FROM dolt_status;")
+
+if [ "$DL_Q" = "1:in-immediate,2:in-savepoint" ]; then
+  pass_name "begin_immediate_nested_savepoint_dolt_commit_keeps_all"
+else
+  fail_name "begin_immediate_nested_savepoint_dolt_commit_keeps_all"
+  echo "    expected 1:in-immediate,2:in-savepoint, got $DL_Q"
+fi
+
+if [ "$DL_Q_STATUS" = "0" ]; then
+  pass_name "begin_immediate_nested_savepoint_dolt_commit_leaves_clean_status"
+else
+  fail_name "begin_immediate_nested_savepoint_dolt_commit_leaves_clean_status"
+  echo "    expected clean status, got $DL_Q_STATUS"
+fi
+
 echo ""
 echo "======================================="
 echo "Results: $pass passed, $fail failed"


### PR DESCRIPTION
## Summary
- add oracle coverage for nested savepoints mixed with `dolt_commit`
- add the reported nested transaction boundary sequences:
  - `BEGIN; BEGIN; COMMIT; SELECT dolt_commit(...)`
  - `BEGIN; BEGIN; SELECT dolt_commit(...); COMMIT`
- add matching `BEGIN IMMEDIATE` variants, including a nested-savepoint case
- verify committed state and clean `dolt_status` after `dolt_commit` seals active SQL transaction boundaries

## Validation
- `bash test/vc_oracle_txn_commit_test.sh ./doltlite`
- `git diff --check`