### PR TITLE
Strip and restore essential Doltlite comments

### DIFF
--- a/src/btree_orig_api.c
+++ b/src/btree_orig_api.c
@@ -73,10 +73,6 @@ int origBtreeCursorIsLastOnSingle(void *pCur){
   BtShared *pBt;
   if( !c || !c->pBt ) return 0;
   pBt = c->pBt;
-
-
-
-
   if( (pBt->openFlags & BTREE_SINGLE)==0 ) return 0;
   return pBt->pCursor==c && c->pNext==0;
 }
@@ -148,10 +144,6 @@ int origBtreeCursorSize(void){ return orig_sqlite3BtreeCursorSize(); }
 void origBtreeEnter(void *p){ orig_sqlite3BtreeEnter(B(p)); }
 void origBtreeLeave(void *p){ orig_sqlite3BtreeLeave(B(p)); }
 void *origBtreePager(void *p){ return orig_sqlite3BtreePager(B(p)); }
-
-
-
-
 
 int origBtreeIsSqliteFile(const char *zFilename){
   FILE *f;

--- a/src/btree_orig_api.c
+++ b/src/btree_orig_api.c
@@ -73,10 +73,10 @@ int origBtreeCursorIsLastOnSingle(void *pCur){
   BtShared *pBt;
   if( !c || !c->pBt ) return 0;
   pBt = c->pBt;
-  /* Stock sqlite3BtreeCloseCursor auto-closes the inner Btree iff
-  ** BTREE_SINGLE is set and pBt->pCursor becomes 0 after unlinking
-  ** this cursor. Peek both preconditions before the close so the
-  ** wrapper caller can free its own struct in the same pass. */
+
+
+
+
   if( (pBt->openFlags & BTREE_SINGLE)==0 ) return 0;
   return pBt->pCursor==c && c->pNext==0;
 }
@@ -149,10 +149,10 @@ void origBtreeEnter(void *p){ orig_sqlite3BtreeEnter(B(p)); }
 void origBtreeLeave(void *p){ orig_sqlite3BtreeLeave(B(p)); }
 void *origBtreePager(void *p){ return orig_sqlite3BtreePager(B(p)); }
 
-/* Magic-byte sniff used to decide whether an ATTACH target is a
-** plain-SQLite file (route through origBtree*) or a doltlite chunk
-** store (route through the shimmed btree). Checked before the file
-** is opened, so it has to read the raw header itself. */
+
+
+
+
 int origBtreeIsSqliteFile(const char *zFilename){
   FILE *f;
   char buf[16];

--- a/src/btree_orig_api.h
+++ b/src/btree_orig_api.h
@@ -1,8 +1,4 @@
 
-
-
-
-
 #ifndef BTREE_ORIG_API_H
 #define BTREE_ORIG_API_H
 
@@ -79,10 +75,6 @@ int origBtreeMaxRecordSize(void *pCur);
 void origBtreeCursorHint(void *pCur, unsigned int mask, ...);
 
 int origBtreeCursorSize(void);
-
-
-
-
 int origBtreeCursorIsLastOnSingle(void *pCur);
 void origBtreeEnter(void *p);
 void origBtreeLeave(void *p);

--- a/src/btree_orig_api.h
+++ b/src/btree_orig_api.h
@@ -1,7 +1,7 @@
-/* Unshimmed SQLite btree API. These origBtree* entry points call the
-** untouched SQLite btree code (via the btree_orig_prefix.h renames)
-** so attached stock-sqlite files continue to work page-for-page while
-** the main doltlite db is served by prolly-backed btree.c. */
+
+
+
+
 
 #ifndef BTREE_ORIG_API_H
 #define BTREE_ORIG_API_H
@@ -79,10 +79,10 @@ int origBtreeMaxRecordSize(void *pCur);
 void origBtreeCursorHint(void *pCur, unsigned int mask, ...);
 
 int origBtreeCursorSize(void);
-/* Returns non-zero if closing pCur will trigger stock btree's
-** BTREE_SINGLE auto-close (last cursor on a BTREE_SINGLE btree).
-** Used by the doltlite wrapper to also release the Btree wrapper
-** struct the VDBE ephemeral sits behind. */
+
+
+
+
 int origBtreeCursorIsLastOnSingle(void *pCur);
 void origBtreeEnter(void *p);
 void origBtreeLeave(void *p);

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -1,7 +1,5 @@
 
 
-
-
 #ifdef DOLTLITE_PROLLY
 
 #include "chunk_store.h"
@@ -181,8 +179,6 @@ struct SavedRefsState {
 struct ChunkStoreReplayState {
   ChunkIndexEntry *aIndex;
   int nIndex;
-
-
   void *aIndexMmapBase;
   i64 aIndexMmapSize;
   SavedRefsState refs;
@@ -196,31 +192,11 @@ struct ChunkStoreReloadState {
   SavedRefsState refs;
 };
 
-
-
-
-
-
 #if CHUNK_STORE_LE_PACKING
 typedef char chunk_index_entry_size_check[
   (sizeof(ChunkIndexEntry) == CHUNK_INDEX_ENTRY_SIZE) ? 1 : -1
 ];
 #endif
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 #if CHUNK_STORE_LE_PACKING
 #  if defined(_WIN32)
@@ -303,8 +279,6 @@ static void csUnmapIndex(void *pMapBase, i64 nMapSize){
 }
 #  endif
 #else
-
-
 static int csMapIndex(const char *zPath, i64 offset, i64 nBytes,
                       void **ppMapBase, i64 *pnMapSize,
                       const u8 **ppData){
@@ -316,11 +290,6 @@ static void csUnmapIndex(void *pMapBase, i64 nMapSize){
   (void)pMapBase; (void)nMapSize;
 }
 #endif
-
-
-
-
-
 
 static void csReleaseIndexBuf(ChunkIndexEntry *aIndex,
                               void *mmapBase, i64 mmapSize){
@@ -810,7 +779,6 @@ void csSerializeManifest(const ChunkStore *cs, u8 *aBuf){
   CS_WRITE_I64(aBuf + 32, cs->iIndexOffset);
   CS_WRITE_U32(aBuf + 40, (u32)cs->nIndexSize);
 
-
   CS_WRITE_I64(aBuf + 84, cs->iWalOffset);
   memcpy(aBuf + 104, cs->refsHash.data, PROLLY_HASH_SIZE);
 }
@@ -820,19 +788,6 @@ static void csDeserializeIndexEntry(const u8 *aBuf, ChunkIndexEntry *e){
   e->offset = CS_READ_I64(aBuf + PROLLY_HASH_SIZE);
   e->size = (int)CS_READ_U32(aBuf + PROLLY_HASH_SIZE + 8);
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 static int csReadManifest(ChunkStore *cs){
   u8 aBuf[CHUNK_MANIFEST_SIZE];
@@ -887,14 +842,6 @@ static int csReadIndex(ChunkStore *cs){
     return SQLITE_TOOBIG;
   }
   nEntries = (int)nEntries64;
-
-
-
-
-
-
-
-
 
   if( cs->zFilename
    && csMapIndex(cs->zFilename, cs->iIndexOffset, cs->nIndexSize,
@@ -989,15 +936,6 @@ static int csGrowWriteBuf(ChunkStore *cs, int nNeeded){
   return SQLITE_OK;
 }
 
-
-
-
-
-
-
-
-
-
 static int csReplayWal(ChunkStore *cs){
   i64 walSize;
   ChunkStoreReplayState saved;
@@ -1023,25 +961,12 @@ static int csReplayWal(ChunkStore *cs){
     cs->iFileSize = fileSize;
   }
   if( walSize <= 0 ){
-
-
-
-
-
-
-
-
     if( cs->nIndex==0 && cs->nChunks==0
      && !prollyHashIsEmpty(&cs->refsHash) ){
       memset(cs->refsHash.data, 0, PROLLY_HASH_SIZE);
     }
     return SQLITE_OK;
   }
-
-
-
-
-
 
   cs->nWalData = walSize;
 
@@ -1057,8 +982,6 @@ static int csReplayWal(ChunkStore *cs){
       ProllyHash hash;
       u32 len;
       if( pos + 20 + 4 > walSize ){
-
-
         break;
       }
       rc = sqlite3OsRead(cs->pFile, aHdr, sizeof(aHdr), cs->iWalOffset + pos);
@@ -1067,7 +990,6 @@ static int csReplayWal(ChunkStore *cs){
       len = CS_READ_U32(aHdr + 20);
       pos += 24;
       if( pos < 0 || (u64)pos + len > (u64)walSize ){
-
         break;
       }
 
@@ -1079,10 +1001,6 @@ static int csReplayWal(ChunkStore *cs){
           if( rc != SQLITE_OK ) goto replay_error;
           e = &cs->aPending[cs->nPending];
           memcpy(&e->hash, &hash, sizeof(ProllyHash));
-
-
-
-
           e->offset = cs->iWalOffset + (i64)(pos - 4);
           e->size = (int)len;
           cs->nPending++;
@@ -1093,8 +1011,6 @@ static int csReplayWal(ChunkStore *cs){
     } else if( tag == CS_WAL_TAG_ROOT ){
       u8 m[CHUNK_MANIFEST_SIZE];
       if( pos + CHUNK_MANIFEST_SIZE > walSize ){
-
-
         break;
       }
       {
@@ -1103,10 +1019,6 @@ static int csReplayWal(ChunkStore *cs){
         if( rc != SQLITE_OK ) goto replay_error;
         magic = CS_READ_U32(m);
         if( magic != CHUNK_STORE_MAGIC ){
-
-
-
-
           break;
         }
 
@@ -1119,21 +1031,12 @@ static int csReplayWal(ChunkStore *cs){
       nRootRecordsSeen++;
 
     } else {
-
-
-
       rc = SQLITE_CORRUPT;
       goto replay_error;
     }
   }
 
   cs->nPending = nRootedPending;
-
-
-
-
-
-
 
   if( nRootRecordsSeen == 0
    && nPendingBefore == 0 && cs->nIndex == 0 ){
@@ -1146,9 +1049,6 @@ static int csReplayWal(ChunkStore *cs){
     int nMerged = 0;
     rc = csMergeIndex(cs, &aMerged, &nMerged);
     if( rc != SQLITE_OK ) goto replay_error;
-
-
-
     cs->aIndex = aMerged;
     cs->nIndex = nMerged;
     cs->aIndexMmapBase = 0;
@@ -1232,7 +1132,6 @@ static int csMergeIndex(
     nTotal * (int)sizeof(ChunkIndexEntry)
   );
   if( aMerged == 0 ) return SQLITE_NOMEM;
-
 
   if( cs->nPending > 1 ){
     qsort(cs->aPending, cs->nPending, sizeof(ChunkIndexEntry),
@@ -1331,7 +1230,6 @@ int chunkStoreOpen(
     cs->zFilename = 0;
     return rc;
   }
-
 
   if( exists ){
     struct stat mainStat;
@@ -1703,26 +1601,6 @@ int chunkStoreHasMany(ChunkStore *cs, const ProllyHash *aHash, int nHash, u8 *aR
   return SQLITE_OK;
 }
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 static int csSerializeRefsBlob(ChunkStore *cs, u8 **ppOut, int *pnOut){
   const char *def = cs->zDefaultBranch ? cs->zDefaultBranch : "main";
   int defLen = (int)strlen(def);
@@ -2054,9 +1932,6 @@ int chunkStoreHas(ChunkStore *cs, const ProllyHash *hash, int *pHas){
   return SQLITE_OK;
 }
 
-
-
-
 int chunkStoreGet(
   ChunkStore *cs,
   const ProllyHash *hash,
@@ -2098,12 +1973,6 @@ int chunkStoreGet(
       e = &cs->aIndex[idx];
     }
 
-
-
-
-
-
-
     if( cs->pFile == 0 ){
       if( cs->pWriteBuf && e->offset >= 0
        && (e->offset + 4 + e->size) <= cs->nWriteBuf ){
@@ -2116,7 +1985,6 @@ int chunkStoreGet(
       }
       return SQLITE_CORRUPT;
     }
-
 
     {
       i64 fileOff = e->offset;
@@ -2163,7 +2031,6 @@ int chunkStorePut(
   prollyHashCompute(pData, nData, &h);
   if( pHash ) memcpy(pHash, &h, sizeof(ProllyHash));
 
-
   if( csSearchIndex(cs->aIndex, cs->nIndex, &h) >= 0 ) return SQLITE_OK;
   rc = csSearchRecent(cs, &h, &idx);
   if( rc!=SQLITE_OK ) return rc;
@@ -2186,7 +2053,6 @@ int chunkStorePut(
     e->size = nData;
     cs->nPending++;
   }
-
 
   CS_WRITE_U32(cs->pWriteBuf + cs->nWriteBuf, (u32)nData);
   cs->nWriteBuf += 4;
@@ -2239,7 +2105,6 @@ static int csCommitToFile(ChunkStore *cs){
     if( rc != SQLITE_OK ) return SQLITE_CANTOPEN;
   }
 
-
   if( lockHeld ){
     lockFd = -1;
   }else{
@@ -2250,10 +2115,6 @@ static int csCommitToFile(ChunkStore *cs){
 
   rc = cs->pFile->pMethods->xFileSize(cs->pFile, &fileSize);
   if( rc != SQLITE_OK ) goto commit_done;
-
-
-
-
 
   if( hadFile && !cs->hasMovedChecked ){
     int bMoved = 0;
@@ -2276,17 +2137,6 @@ static int csCommitToFile(ChunkStore *cs){
 
   if( cs->nPending > 0 ){
     ChunkStore mergeView;
-
-
-
-
-
-
-
-
-
-
-
     i64 filePos = fileSize > 0 ? fileSize : (i64)CHUNK_MANIFEST_SIZE;
     i64 appendBytes = 0;
 
@@ -2315,8 +2165,6 @@ static int csCommitToFile(ChunkStore *cs){
     for( i = 0; i < cs->nPending; i++ ){
       ChunkIndexEntry *pSrc = &cs->aPending[i];
       aCommittedPending[i] = *pSrc;
-
-
       aCommittedPending[i].offset = filePos + 21;
       filePos += (i64)25 + (i64)pSrc->size;
     }
@@ -2351,14 +2199,6 @@ static int csCommitToFile(ChunkStore *cs){
       if( rc!=SQLITE_OK ) goto commit_done;
     }
   }
-
-
-
-
-
-
-
-
 
 #ifdef SQLITE_TEST
   {
@@ -2468,7 +2308,6 @@ static int csCommitToFile(ChunkStore *cs){
     if( rc != SQLITE_OK ) goto commit_done;
     writeOff += sizeof(rootRec);
   }
-
 
   CRASH_CHECK_WRITE();
   rc = sqlite3OsSync(cs->pFile, SQLITE_SYNC_NORMAL);
@@ -2636,13 +2475,6 @@ static int csDetectExternalChanges(ChunkStore *cs, int *pChanged){
     return SQLITE_OK;
   }
 
-
-
-
-
-
-
-
   if( !cs->hasMovedChecked ){
     rc = sqlite3OsFileControl(cs->pFile, SQLITE_FCNTL_HAS_MOVED, &bMoved);
     if( rc!=SQLITE_OK ) return rc;
@@ -2697,9 +2529,6 @@ static int csReloadFromDisk(ChunkStore *cs){
   csCaptureReloadState(cs, &saved);
   csAdoptOpenedStoreState(cs, &tmp);
   chunkStoreClose(&tmp);
-
-
-
 
   cs->hasMovedChecked = 0;
 

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -2390,7 +2390,8 @@ static int csCommitToFile(ChunkStore *cs){
 
   writeOff = fileSize;
 
-
+  /* Append chunks before the root record. Recovery ignores appended data until
+  ** it finds a later valid root record that points at the new manifest. */
   if( cs->nPending > 0 ){
     i64 walBytes = 0;
     u8 *pWalBatch = 0;
@@ -2457,7 +2458,7 @@ static int csCommitToFile(ChunkStore *cs){
     }
   }
 
-
+  /* The root record is the commit point for the append-only chunk store. */
   {
     u8 rootRec[1 + CHUNK_MANIFEST_SIZE];
     rootRec[0] = CS_WAL_TAG_ROOT;

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -1,7 +1,7 @@
 
 
-/* Single-file content-addressed chunk store. See chunk_store.h for
-** the on-disk layout. All integers on disk are little-endian. */
+
+
 #ifdef DOLTLITE_PROLLY
 
 #include "chunk_store.h"
@@ -181,8 +181,8 @@ struct SavedRefsState {
 struct ChunkStoreReplayState {
   ChunkIndexEntry *aIndex;
   int nIndex;
-  /* aIndexMmapBase is the page-aligned base when aIndex is mmapped
-  ** (NULL/0 when malloc'd) — csReleaseIndexBuf branches on it. */
+
+
   void *aIndexMmapBase;
   i64 aIndexMmapSize;
   SavedRefsState refs;
@@ -197,10 +197,10 @@ struct ChunkStoreReloadState {
 };
 
 
-/* On hosts where the in-memory ChunkIndexEntry layout matches the
-** on-disk encoding, the persisted index is mapped and used directly.
-** Catch any future struct-layout change at compile time before it
-** silently corrupts the mapping. */
+
+
+
+
 #if CHUNK_STORE_LE_PACKING
 typedef char chunk_index_entry_size_check[
   (sizeof(ChunkIndexEntry) == CHUNK_INDEX_ENTRY_SIZE) ? 1 : -1
@@ -208,20 +208,20 @@ typedef char chunk_index_entry_size_check[
 #endif
 
 
-/* ── chunk-index mmap helpers ────────────────────────────────────
-**
-** csMapIndex maps `nBytes` of `zPath` starting at `offset` into the
-** process address space, read-only and private. On success it sets
-** *ppData to the first byte of the requested range (which may sit
-** at a non-zero offset within the page-aligned mapping base) and
-** writes the mapping base + size into *ppMapBase / *pnMapSize for a
-** later csUnmapIndex.
-**
-** Returns SQLITE_OK on success, or a non-OK SQLite error if mmap is
-** unavailable / the platform is big-endian (where in-memory and
-** on-disk ChunkIndexEntry encodings differ) / mmap fails. Callers
-** fall back to the malloc + read path on any failure.
-*/
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 #if CHUNK_STORE_LE_PACKING
 #  if defined(_WIN32)
 #    include <windows.h>
@@ -289,7 +289,7 @@ static int csMapIndex(const char *zPath, i64 offset, i64 nBytes,
 
   pMap = mmap(NULL, (size_t)mapSize, PROT_READ, MAP_PRIVATE, fd,
               (off_t)alignOffset);
-  close(fd);   /* mapping survives close */
+  close(fd);
   if( pMap == MAP_FAILED ) return SQLITE_IOERR;
 
   *ppMapBase = pMap;
@@ -303,8 +303,8 @@ static void csUnmapIndex(void *pMapBase, i64 nMapSize){
 }
 #  endif
 #else
-/* Big-endian / non-LE-packing host: no mmap path. csMapIndex always
-** signals "fall back to malloc+read+deserialize". */
+
+
 static int csMapIndex(const char *zPath, i64 offset, i64 nBytes,
                       void **ppMapBase, i64 *pnMapSize,
                       const u8 **ppData){
@@ -317,11 +317,11 @@ static void csUnmapIndex(void *pMapBase, i64 nMapSize){
 }
 #endif
 
-/* Releases an aIndex pointer + its mmap state in the right way for
-** how it was acquired: if mmapBase is non-NULL the index lives in a
-** mmapped region (munmap it), else the index is a malloc'd array
-** from sqlite3_malloc (sqlite3_free it). aIndex itself is *not*
-** sqlite3_freed in the mmap case — it points inside the mapping. */
+
+
+
+
+
 static void csReleaseIndexBuf(ChunkIndexEntry *aIndex,
                               void *mmapBase, i64 mmapSize){
   if( mmapBase ){
@@ -821,19 +821,19 @@ static void csDeserializeIndexEntry(const u8 *aBuf, ChunkIndexEntry *e){
   e->size = (int)CS_READ_U32(aBuf + PROLLY_HASH_SIZE + 8);
 }
 
-/* Manifest layout (168 bytes, little-endian):
-**
-**     0  magic(4) | 4  version(4) | 8  reserved(20, was root_hash)
-**    28  nChunks(4)
-**    32  indexOffset(8) | 40 indexSize(4)
-**    44  reserved(20, was catalog_hash, removed in v7)
-**    64  reserved(20, was headCommit_hash)
-**    84  walOffset(8)  | 92 reserved(12)
-**   104  refs_hash(20)
-**   124  reserved(44)
-**
-** The reserved slots are kept at their historical offsets so old-
-** reader code paths don't have to branch on version. */
+
+
+
+
+
+
+
+
+
+
+
+
+
 static int csReadManifest(ChunkStore *cs){
   u8 aBuf[CHUNK_MANIFEST_SIZE];
   u32 magic, version;
@@ -888,14 +888,14 @@ static int csReadIndex(ChunkStore *cs){
   }
   nEntries = (int)nEntries64;
 
-  /* Fast path: on hosts where in-memory ChunkIndexEntry encoding
-  ** matches the on-disk byte layout (little-endian + 32-byte
-  ** packing), mmap the index region and use it as the live index.
-  ** This skips the open-time malloc + read + per-entry deserialize
-  ** loop entirely; pages are paged in lazily by the OS as bsearch
-  ** touches them. Falls through to the malloc path on big-endian or
-  ** when mmap fails for any reason (read-only fs, no fd available,
-  ** etc.). */
+
+
+
+
+
+
+
+
   if( cs->zFilename
    && csMapIndex(cs->zFilename, cs->iIndexOffset, cs->nIndexSize,
                   &pMapBase, &nMapSize, &pMapData) == SQLITE_OK ){
@@ -989,15 +989,15 @@ static int csGrowWriteBuf(ChunkStore *cs, int nNeeded){
   return SQLITE_OK;
 }
 
-/* Replay the WAL region (iWalOffset..EOF) into the in-memory index.
-** Records are framed [tag:1][payload...]:
-**   CHUNK: 0x01 | hash(20) | len_le32(4) | data(len)
-**   ROOT:  0x02 | manifest_snapshot(168)
-** Replayed chunks get a positive file offset pointing at the 4-byte
-** length prefix inside the WAL record (record_start + 21), so the
-** common chunkStoreGet pread path serves them with no special-casing.
-** ROOT records do NOT update iWalOffset / iIndexOffset — those describe
-** the compacted region on disk and only move on GC. */
+
+
+
+
+
+
+
+
+
 static int csReplayWal(ChunkStore *cs){
   i64 walSize;
   ChunkStoreReplayState saved;
@@ -1023,14 +1023,14 @@ static int csReplayWal(ChunkStore *cs){
     cs->iFileSize = fileSize;
   }
   if( walSize <= 0 ){
-    /* WAL region is empty. Two possibilities:
-    **   (a) Compacted database — all data in main body, manifest
-    **       and index are authoritative. cs->nIndex > 0.
-    **   (b) Brand-new file — manifest written but crash before
-    **       any WAL data. cs->nIndex == 0 and cs->nChunks == 0.
-    ** For (b), the manifest's refs hash may point to a chunk that
-    ** was prepared but never committed. Reset it. For (a), the
-    ** manifest is correct — leave it alone. */
+
+
+
+
+
+
+
+
     if( cs->nIndex==0 && cs->nChunks==0
      && !prollyHashIsEmpty(&cs->refsHash) ){
       memset(cs->refsHash.data, 0, PROLLY_HASH_SIZE);
@@ -1038,11 +1038,11 @@ static int csReplayWal(ChunkStore *cs){
     return SQLITE_OK;
   }
 
-  /* Do not materialize the entire WAL in memory. Large databases can
-  ** have multi-gigabyte WAL regions; reading them into one malloc
-  ** trips SQLite's allocator ceiling around 2 GiB and misreports
-  ** SQLITE_NOMEM during open. Replay only needs sequential headers:
-  ** chunk payloads are skipped, not inspected. */
+
+
+
+
+
   cs->nWalData = walSize;
 
   pos = 0;
@@ -1057,8 +1057,8 @@ static int csReplayWal(ChunkStore *cs){
       ProllyHash hash;
       u32 len;
       if( pos + 20 + 4 > walSize ){
-        /* Truncated chunk header — crash during write. Stop
-        ** scanning and use the last valid root record. */
+
+
         break;
       }
       rc = sqlite3OsRead(cs->pFile, aHdr, sizeof(aHdr), cs->iWalOffset + pos);
@@ -1067,7 +1067,7 @@ static int csReplayWal(ChunkStore *cs){
       len = CS_READ_U32(aHdr + 20);
       pos += 24;
       if( pos < 0 || (u64)pos + len > (u64)walSize ){
-        /* Truncated chunk data — partial write. Same treatment. */
+
         break;
       }
 
@@ -1079,10 +1079,10 @@ static int csReplayWal(ChunkStore *cs){
           if( rc != SQLITE_OK ) goto replay_error;
           e = &cs->aPending[cs->nPending];
           memcpy(&e->hash, &hash, sizeof(ProllyHash));
-          /* File position of the 4-byte length prefix. The chunk
-          ** data follows immediately at offset+4. Same convention
-          ** as committed-region entries — chunkStoreGet treats both
-          ** identically. */
+
+
+
+
           e->offset = cs->iWalOffset + (i64)(pos - 4);
           e->size = (int)len;
           cs->nPending++;
@@ -1093,8 +1093,8 @@ static int csReplayWal(ChunkStore *cs){
     } else if( tag == CS_WAL_TAG_ROOT ){
       u8 m[CHUNK_MANIFEST_SIZE];
       if( pos + CHUNK_MANIFEST_SIZE > walSize ){
-        /* Truncated root record — crash during the commit
-        ** point write. Stop and use the previous root. */
+
+
         break;
       }
       {
@@ -1103,10 +1103,10 @@ static int csReplayWal(ChunkStore *cs){
         if( rc != SQLITE_OK ) goto replay_error;
         magic = CS_READ_U32(m);
         if( magic != CHUNK_STORE_MAGIC ){
-          /* Corrupt root record — torn write garbled the
-          ** magic. Content-addressing protects us: any refs
-          ** hash read from this record would fail to resolve.
-          ** Stop scanning. */
+
+
+
+
           break;
         }
 
@@ -1119,9 +1119,9 @@ static int csReplayWal(ChunkStore *cs){
       nRootRecordsSeen++;
 
     } else {
-      /* Unknown tag. This is genuine WAL corruption (bit-rot or
-      ** tampering), not a crash truncation — truncated records
-      ** are caught above by the length checks. Report corrupt. */
+
+
+
       rc = SQLITE_CORRUPT;
       goto replay_error;
     }
@@ -1129,12 +1129,12 @@ static int csReplayWal(ChunkStore *cs){
 
   cs->nPending = nRootedPending;
 
-  /* If no root records were found in the WAL AND this is a new
-  ** database (no compacted chunks in the index), the manifest's
-  ** refs hash is unconfirmed. Reset it. For databases that went
-  ** through GC (nIndex > 0), the WAL may be empty because all
-  ** data was compacted into the main body — the manifest is
-  ** authoritative in that case. */
+
+
+
+
+
+
   if( nRootRecordsSeen == 0
    && nPendingBefore == 0 && cs->nIndex == 0 ){
     memset(cs->refsHash.data, 0, PROLLY_HASH_SIZE);
@@ -1146,9 +1146,9 @@ static int csReplayWal(ChunkStore *cs){
     int nMerged = 0;
     rc = csMergeIndex(cs, &aMerged, &nMerged);
     if( rc != SQLITE_OK ) goto replay_error;
-    /* The old aIndex/mmap state is owned by `saved` for rollback
-    ** purposes — don't release here. Just clear the live mmap
-    ** tracking so cs reflects the new malloc'd merged array. */
+
+
+
     cs->aIndex = aMerged;
     cs->nIndex = nMerged;
     cs->aIndexMmapBase = 0;
@@ -1703,26 +1703,26 @@ int chunkStoreHasMany(ChunkStore *cs, const ProllyHash *aHash, int nHash, u8 *aR
   return SQLITE_OK;
 }
 
-/* Refs blob format (version 6). All lengths u32 LE; timestamps i64 LE:
-**
-**   [version:1]
-**   [default_branch_len:4][default_branch:N]
-**   [nBranches:4] { [name_len:4][name:N]
-**                   [commit_hash:20][ws_hash:20] }*
-**   [nTags:4]     { [name_len:4][name:N]
-**                   [commit_hash:20]
-**                   [tagger_len:4][tagger:N]
-**                   [email_len:4][email:N]
-**                   [timestamp:8]
-**                   [message_len:4][message:N] }*
-**   [nRemotes:4]  { [name_len:4][name:N]
-**                   [url_len:4][url:N] }*
-**   [nTracking:4] { [remote_len:4][remote:N]
-**                   [branch_len:4][branch:N]
-**                   [commit_hash:20] }*
-**
-** Version 5 omits the per-tag metadata fields — the deserializer
-** accepts both versions and defaults missing metadata to empty / 0. */
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 static int csSerializeRefsBlob(ChunkStore *cs, u8 **ppOut, int *pnOut){
   const char *def = cs->zDefaultBranch ? cs->zDefaultBranch : "main";
   int defLen = (int)strlen(def);
@@ -2054,9 +2054,9 @@ int chunkStoreHas(ChunkStore *cs, const ProllyHash *hash, int *pHas){
   return SQLITE_OK;
 }
 
-/* Lookup order matters: pending (uncommitted write buffer) first,
-** then the on-disk index. A hash can exist in both — pending wins
-** because it carries the most recent write. */
+
+
+
 int chunkStoreGet(
   ChunkStore *cs,
   const ProllyHash *hash,
@@ -2099,9 +2099,9 @@ int chunkStoreGet(
     }
 
 
-    /* All committed entries (whether they originated from a compacted
-    ** index, WAL replay, or this connection's recent commits) carry
-    ** positive file offsets pointing at the chunk's 4-byte length prefix. */
+
+
+
 
 
     if( cs->pFile == 0 ){
@@ -2251,10 +2251,10 @@ static int csCommitToFile(ChunkStore *cs){
   rc = cs->pFile->pMethods->xFileSize(cs->pFile, &fileSize);
   if( rc != SQLITE_OK ) goto commit_done;
 
-  /* Detect file replacement by another process (e.g. GC compaction
-  ** renamed a new file over the original). Our fd still points at
-  ** the orphaned inode — writes would be lost. Reload from the
-  ** current file at this path. */
+
+
+
+
   if( hadFile && !cs->hasMovedChecked ){
     int bMoved = 0;
     int rc2 = sqlite3OsFileControl(cs->pFile, SQLITE_FCNTL_HAS_MOVED,
@@ -2276,17 +2276,17 @@ static int csCommitToFile(ChunkStore *cs){
 
   if( cs->nPending > 0 ){
     ChunkStore mergeView;
-    /* New WAL bytes go to the end of the file's WAL region.
-    ** filePos is the running file offset where the next chunk's
-    ** record header will land; +21 from there is the record's
-    ** length prefix (the convention shared with committed-region
-    ** entries). The actual byte writes happen later in the commit
-    ** path; here we only compute index offsets that will be valid
-    ** post-write. On a fresh database we haven't written the
-    ** manifest yet (cs->iWalOffset is still 0), but the manifest
-    ** will land at offset 0 and the WAL records will start at
-    ** CHUNK_MANIFEST_SIZE — same as fileSize after the upcoming
-    ** manifest write. */
+
+
+
+
+
+
+
+
+
+
+
     i64 filePos = fileSize > 0 ? fileSize : (i64)CHUNK_MANIFEST_SIZE;
     i64 appendBytes = 0;
 
@@ -2315,8 +2315,8 @@ static int csCommitToFile(ChunkStore *cs){
     for( i = 0; i < cs->nPending; i++ ){
       ChunkIndexEntry *pSrc = &cs->aPending[i];
       aCommittedPending[i] = *pSrc;
-      /* File position of the length prefix within the chunk record.
-      ** The 21 = tag(1) + hash(20) skipped before the length field. */
+
+
       aCommittedPending[i].offset = filePos + 21;
       filePos += (i64)25 + (i64)pSrc->size;
     }
@@ -2352,17 +2352,17 @@ static int csCommitToFile(ChunkStore *cs){
     }
   }
 
-  /* Crash injection for durability tests. When the environment
-  ** variable DOLTLITE_CRASH_WRITE is set to N, the Nth
-  ** sqlite3OsWrite call inside this commit will _exit(99)
-  ** WITHOUT flushing buffers — simulating a power-loss crash
-  ** at that exact point. The test harness then reopens the
-  ** database and verifies that either the old committed state
-  ** is intact or the new commit landed fully (never partial).
-  ** Only active under SQLITE_TEST builds. */
+
+
+
+
+
+
+
+
 #ifdef SQLITE_TEST
   {
-    static int crashWriteTarget = -2; /* -2 = not yet checked */
+    static int crashWriteTarget = -2;
     static int crashWriteCount = 0;
     if( crashWriteTarget == -2 ){
       const char *zEnv = getenv("DOLTLITE_CRASH_WRITE");
@@ -2635,13 +2635,13 @@ static int csDetectExternalChanges(ChunkStore *cs, int *pChanged){
     return SQLITE_OK;
   }
 
-  /* HAS_MOVED detects atomic file replacement (rename-over) by another
-  ** process — needs a stat() syscall on the path. For autocommit-heavy
-  ** read workloads this fires per-statement and dominates time. After
-  ** the first confirmation that the fd matches the path, cache the
-  ** "not moved" answer until csReloadFromDisk forces a re-open. The
-  ** fstat-based size check below still runs every call and catches all
-  ** append-only changes from cooperative writers. */
+
+
+
+
+
+
+
   if( !cs->hasMovedChecked ){
     rc = sqlite3OsFileControl(cs->pFile, SQLITE_FCNTL_HAS_MOVED, &bMoved);
     if( rc!=SQLITE_OK ) return rc;
@@ -2697,9 +2697,9 @@ static int csReloadFromDisk(ChunkStore *cs){
   csAdoptOpenedStoreState(cs, &tmp);
   chunkStoreClose(&tmp);
 
-  /* New fd from re-open — invalidate the cached HAS_MOVED answer so
-  ** the next external-changes check runs the stat() once on the new
-  ** path/fd pair before resuming the cached fast-path. */
+
+
+
   cs->hasMovedChecked = 0;
 
   csFreeReloadState(&saved);

--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -1,23 +1,5 @@
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 #ifndef SQLITE_CHUNK_STORE_H
 #define SQLITE_CHUNK_STORE_H
 
@@ -28,34 +10,6 @@
 #define CHUNK_STORE_VERSION 11
 #define CHUNK_MANIFEST_SIZE 168
 #define CHUNK_INDEX_ENTRY_SIZE 32
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 #define WS_FORMAT_VERSION_V2 2
 #define WS_FORMAT_VERSION_V3 3
@@ -81,21 +35,6 @@
 #define WS_REBASE_RETURN_BRANCH_OFF WS_TOTAL_SIZE_V4
 #define WS_CONSTRAINT_VIOLATIONS_OFF (WS_REBASE_RETURN_BRANCH_OFF + WS_REBASE_BRANCH_LEN)
 #define WS_TOTAL_SIZE       (WS_CONSTRAINT_VIOLATIONS_OFF + PROLLY_HASH_SIZE)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 #define CATALOG_FORMAT_V3       0x44
 #define CATALOG_FORMAT_V4       0x45
@@ -139,14 +78,6 @@ struct ConflictEntry {
   int nTheirVal;
 };
 
-
-
-
-
-
-
-
-
 #if defined(__GNUC__) || defined(__clang__)
 #  define DOLTLITE_PACKED __attribute__((__packed__))
 #elif defined(_MSC_VER)
@@ -158,10 +89,6 @@ struct ConflictEntry {
 
 struct DOLTLITE_PACKED ChunkIndexEntry {
   ProllyHash hash;
-
-
-
-
   i64 offset;
   int size;
 };
@@ -169,9 +96,6 @@ struct DOLTLITE_PACKED ChunkIndexEntry {
 #if defined(_MSC_VER)
 #  pragma pack(pop)
 #endif
-
-
-
 
 #if defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 #  define CHUNK_STORE_LE_PACKING 1
@@ -231,7 +155,6 @@ struct ChunkStore {
   void *aIndexMmapBase;
   i64 aIndexMmapSize;
 
-
   ChunkIndexEntry *aPending;
   int nPending;
   int nPendingAlloc;
@@ -255,18 +178,9 @@ struct ChunkStore {
   u8 readOnly;
   u8 isMemory;
   u8 snapshotPinned;
-
-
-
-
   u8 hasMovedChecked;
   int graphLockFd;
   i64 nCommittedWriteBuf;
-
-
-
-
-
 
   i64 nWalData;
 };

--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -1,62 +1,62 @@
 
 
-/* Single-file content-addressed chunk store.
-**
-** File layout, all integers little-endian:
-**
-**   [Manifest: 168 bytes at offset 0]
-**     see chunk_store.c::csReadManifest for the offset table
-**
-**   [Chunk data region: manifest + chunk stream, before index]
-**     each chunk: length_le32(4) + data(length)
-**
-**   [Sorted index: nChunks * CHUNK_INDEX_ENTRY_SIZE entries]
-**     each entry: hash(20) + file_offset(8) + data_size(4)
-**
-**   [WAL region: iWalOffset to EOF]
-**     append-only crash-safety log
-**       chunk record: tag(0x01) + hash(20) + len_le32(4) + data(len)
-**       root record:  tag(0x02) + manifest_snapshot(168)
-*/
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 #ifndef SQLITE_CHUNK_STORE_H
 #define SQLITE_CHUNK_STORE_H
 
 #include "sqliteInt.h"
 #include "prolly_hash.h"
 
-#define CHUNK_STORE_MAGIC 0x444C5443  /* "DLTC" little-endian */
+#define CHUNK_STORE_MAGIC 0x444C5443
 #define CHUNK_STORE_VERSION 11
 #define CHUNK_MANIFEST_SIZE 168
-#define CHUNK_INDEX_ENTRY_SIZE 32     /* hash(20) + offset(8) + size(4) */
+#define CHUNK_INDEX_ENTRY_SIZE 32
 
-/* Working set blob format. v2 only has merge state; v3 adds rebase
-** state alongside it (parallel to Dolt's working set, which
-** contains optional MergeState and RebaseState substructures); v4
-** adds a separate constraint-violations hash slot so FK / CHECK /
-** UNIQUE violations detected at merge-time can persist alongside
-** (and independently of) the row-level merge conflicts hash.
-**
-**   v2 layout (still readable for backward compat):
-**     [version:1]
-**     [working_catalog:20][working_commit:20][staged_hash:20]
-**     [is_merging:1][merge_commit:20][conflicts:20]
-**
-**   v3 layout:
-**     v2 fields, then:
-**     [is_rebasing:1]
-**     [pre_rebase_working_cat:20]
-**     [rebase_onto_commit:20]
-**     [rebase_orig_branch: WS_REBASE_BRANCH_LEN bytes, null-padded]
-**
-**   v4 layout (current write format):
-**     v3 fields, then:
-**     [constraint_violations:20]
-**
-**   v5 layout:
-**     v4 fields, then:
-**     [rebase_return_branch: WS_REBASE_BRANCH_LEN bytes, null-padded]
-**     [constraint_violations:20]
-*/
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 #define WS_FORMAT_VERSION_V2 2
 #define WS_FORMAT_VERSION_V3 3
 #define WS_FORMAT_VERSION_V4 4
@@ -82,21 +82,21 @@
 #define WS_CONSTRAINT_VIOLATIONS_OFF (WS_REBASE_RETURN_BRANCH_OFF + WS_REBASE_BRANCH_LEN)
 #define WS_TOTAL_SIZE       (WS_CONSTRAINT_VIOLATIONS_OFF + PROLLY_HASH_SIZE)
 
-/* Catalog (table registry) formats:
-** V3:
-**   magic(1) + nTables(4 LE) + entries (sorted by table name)
-** Per entry: iTable(4 LE) + flags(1) + root(20) + schema(20)
-**          + nameLen(2 LE) + name
-**
-** V4:
-**   magic(1) + nTables(4 LE) + entries (sorted by logical object key)
-** Per entry: iTable(4 LE) + flags(1) + root(20) + schema(20)
-**          + typeLen(2 LE) + nameLen(2 LE) + tblNameLen(2 LE)
-**          + type + name + tblName
-**
-** V4 keeps iTable for runtime plumbing but makes persistent catalog
-** identity depend on stable schema object metadata instead of creation
-** order or "table names only". */
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 #define CATALOG_FORMAT_V3       0x44
 #define CATALOG_FORMAT_V4       0x45
 #define CAT_HEADER_SIZE_V3      5
@@ -139,14 +139,14 @@ struct ConflictEntry {
   int nTheirVal;
 };
 
-/* Packed to 32 bytes so the in-memory layout matches the on-disk
-** index entry encoding (hash[20] + offset[8 LE] + size[4 LE]).
-** That lets the persisted index be mmapped and used directly without
-** an open-time malloc + deserialize pass. The packing introduces
-** unaligned field access on archs that care; x86_64 and ARM64 don't.
-** On big-endian hosts the in-memory and on-disk encodings still
-** differ, so csReadIndex falls back to the old read+deserialize path
-** there — see CHUNK_STORE_LE_PACKING below. */
+
+
+
+
+
+
+
+
 #if defined(__GNUC__) || defined(__clang__)
 #  define DOLTLITE_PACKED __attribute__((__packed__))
 #elif defined(_MSC_VER)
@@ -158,10 +158,10 @@ struct ConflictEntry {
 
 struct DOLTLITE_PACKED ChunkIndexEntry {
   ProllyHash hash;
-  /* File offset of the 4-byte length prefix. The chunk data follows
-  ** immediately at offset+4. Same convention for entries pointing
-  ** into the main chunk region and entries pointing into the file's
-  ** WAL region — chunkStoreGet doesn't differentiate. */
+
+
+
+
   i64 offset;
   int size;
 };
@@ -170,9 +170,9 @@ struct DOLTLITE_PACKED ChunkIndexEntry {
 #  pragma pack(pop)
 #endif
 
-/* True iff in-memory ChunkIndexEntry layout matches the on-disk
-** encoding byte-for-byte (little-endian + 32-byte packing). On such
-** hosts the persisted index can be mmapped and cast directly. */
+
+
+
 #if defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 #  define CHUNK_STORE_LE_PACKING 1
 #else
@@ -226,12 +226,12 @@ struct ChunkStore {
   ChunkIndexEntry *aIndex;
   int nIndex;
 
-  /* When the persisted index is mmapped, aIndexMmapBase is the page-
-  ** aligned base of the mapping (which can differ from aIndex if
-  ** iIndexOffset isn't page-aligned) and aIndexMmapSize is the byte
-  ** length of the mapping. Both NULL/0 when aIndex is malloc'd
-  ** instead — that's the fallback path on big-endian hosts and after
-  ** in-memory commits replace aIndex with a fresh merged array. */
+
+
+
+
+
+
   void *aIndexMmapBase;
   i64 aIndexMmapSize;
 
@@ -259,19 +259,19 @@ struct ChunkStore {
   u8 readOnly;
   u8 isMemory;
   u8 snapshotPinned;
-  /* Once a successful HAS_MOVED check has confirmed the file at our
-  ** open fd matches the path, subsequent BeginTrans calls within
-  ** this connection skip the stat() syscall and rely on fstat-based
-  ** size checks to detect appends. Reset by csReloadFromDisk. */
+
+
+
+
   u8 hasMovedChecked;
   int graphLockFd;
   i64 nCommittedWriteBuf;
 
-  /* Total bytes in the file's WAL region (the trailing append-only
-  ** part of the chunk store file, where WAL chunk records live).
-  ** Tracked so commits know where to start writing the next batch
-  ** without an extra fstat. There is no in-memory mirror — reads
-  ** of WAL-region chunks pread directly from the file. */
+
+
+
+
+
   i64 nWalData;
 };
 

--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -223,14 +223,10 @@ struct ChunkStore {
   i64 iWalOffset;
   i64 iFileSize;
 
+  /* aIndex is the durable sorted manifest. Small commits append into aRecent
+  ** first so readers can find new chunks without rewriting the manifest. */
   ChunkIndexEntry *aIndex;
   int nIndex;
-
-
-
-
-
-
 
   void *aIndexMmapBase;
   i64 aIndexMmapSize;

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -727,6 +727,9 @@ static int doltliteSavepointIsTopLevelTxn(sqlite3 *db){
   return db->pSavepoint!=0 && db->nSavepoint==0;
 }
 
+/* SQLite represents a top-level SAVEPOINT as the transaction boundary.
+** Doltlite treats that like autocommit for VC operations: seal the boundary
+** instead of leaving a savepoint that later ROLLBACK TO can undo. */
 static int doltliteVcSealTopLevelSavepointTxn(sqlite3 *db){
   if( doltliteSavepointIsTopLevelTxn(db) ){
     return sqlite3_exec(db, "COMMIT", 0, 0, 0);
@@ -1404,10 +1407,8 @@ static void doltliteCommitFunc(
     return;
   }
 
-
-
-
-
+  /* Top-level SAVEPOINT is sealed before option validation because Dolt keeps
+  ** that SQL transaction boundary durable even when dolt_commit later errors. */
   if( sealTopLevel ){
     (void)sqlite3_exec(db, "COMMIT", 0, 0, 0);
   }
@@ -1552,8 +1553,8 @@ static void doltliteCommitFunc(
    && (!db->autoCommit
        || sqlite3_txn_state(db, "main")!=SQLITE_TXN_NONE
        || db->pSavepoint) ){
-
-
+    /* Plain BEGIN and nested SAVEPOINT cases stay rollbackable until argument
+    ** validation and basic commit guards have succeeded. */
     (void)sqlite3_exec(db, "COMMIT", 0, 0, 0);
   }
 

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -174,12 +174,12 @@ static int doltliteRestoreTxnStateOnFailure(
   return rc==SQLITE_OK ? opRc : rc;
 }
 
-/* Commit-race guard. Takes the graph lock, refreshes ref state from
-** disk, then verifies the session's head still matches the branch
-** tip. If another connection advanced the branch between the start
-** of this commit and the lock acquisition, we return SQLITE_BUSY
-** and the caller aborts — otherwise we'd silently overwrite the
-** concurrent commit. */
+
+
+
+
+
+
 static int doltliteRefreshAndConfirmHead(
   sqlite3 *db,
   ChunkStore *cs,
@@ -893,12 +893,12 @@ static int addCheckIgnore(
   return rc;
 }
 
-/* Append a TableEntry to a growing array, duping its zName so the
-** destination array has independent ownership. Required because the
-** source entry's zName is usually borrowed from another catalog
-** array (aWorking / aStaged) that will be freed separately — a
-** plain struct copy would alias the pointer and set up a
-** double-free. */
+
+
+
+
+
+
 static int addAppendTableEntry(
   sqlite3_context *context,
   struct TableEntry **paEntries,
@@ -943,9 +943,9 @@ static struct TableEntry *addFindEntryByName(
   return 0;
 }
 
-/* Rebind staged entries to the current working catalog's runtime iTable before
-** serializing a staged catalog. This keeps partial staging from re-emitting
-** stale rootpage identity loaded from HEAD or an older staged snapshot. */
+
+
+
 static void addAlignStagedEntriesToWorking(
   struct TableEntry *aWorking,
   int nWorking,
@@ -1404,10 +1404,10 @@ static void doltliteCommitFunc(
     return;
   }
 
-  /* Top-level SAVEPOINT acts as the transaction boundary. Dolt seals
-  ** that boundary even when dolt_commit() later errors, so persist it
-  ** up front. Plain BEGIN / nested SAVEPOINT cases defer COMMIT until
-  ** after argument validation succeeds. */
+
+
+
+
   if( sealTopLevel ){
     (void)sqlite3_exec(db, "COMMIT", 0, 0, 0);
   }
@@ -1508,12 +1508,12 @@ static void doltliteCommitFunc(
     }
   }
 
-  /* Commit guard: if the working set has any unresolved constraint
-  ** violations from a previous merge, refuse to proceed unless the
-  ** caller passed --force. Matches Dolt's behaviour of blocking
-  ** commits until the user either clears violations by deleting
-  ** the offending rows from dolt_constraint_violations_<table> or
-  ** explicitly forces the commit through. */
+
+
+
+
+
+
   if( !force && doltliteSessionHasConstraintViolations(db) ){
     sqlite3_result_error(context,
       "cannot commit: unresolved entries in dolt_constraint_violations. "
@@ -1552,8 +1552,8 @@ static void doltliteCommitFunc(
    && (!db->autoCommit
        || sqlite3_txn_state(db, "main")!=SQLITE_TXN_NONE
        || db->pSavepoint) ){
-    /* For BEGIN / nested SAVEPOINT, only close the SQL transaction once
-    ** dolt_commit() has survived argument parsing and basic validation. */
+
+
     (void)sqlite3_exec(db, "COMMIT", 0, 0, 0);
   }
 
@@ -1841,11 +1841,11 @@ static void doltliteCommitFunc(
 
 
     {
-      /* Reject all-whitespace messages, but otherwise preserve the
-      ** message verbatim — Dolt 1.87.0 dropped its trim-on-store
-      ** behavior, so doltlite stores the message bytes as given.
-      ** zTrimmedMessage stays unset; the original zMessage flows
-      ** straight into doltliteCreateAndStoreCommitWithTime below. */
+
+
+
+
+
       const char *p = zMessage;
       while( *p==' ' || *p=='\t' || *p=='\n' || *p=='\r' ) p++;
       if( *p==0 ){
@@ -1892,11 +1892,11 @@ static void doltliteCommitFunc(
     }
   }
 
-  /* Once the commit lands, any constraint violations that were in
-  ** the working set are now part of committed state (force path)
-  ** or were resolved before the guard let us through (non-force
-  ** path). Either way, clear them so the NEXT commit isn't
-  ** blocked by a stale flag. */
+
+
+
+
+
   {
     extern int doltliteClearAllConstraintViolations(sqlite3*);
     if( doltliteSessionHasConstraintViolations(db) ){
@@ -2337,11 +2337,11 @@ static void doltliteResetFunc(
     goto reset_cleanup;
   }
 
-  /* Dolt's SQL reset only has true path-limited semantics for the
-  ** single-path form. With multiple positional paths it falls back to
-  ** the no-arg unstage-all behavior, even if some names are missing.
-  ** Match that contract instead of treating multi-path reset as an
-  ** atomic per-path operation. */
+
+
+
+
+
   if( nPaths>1 && !isHard && !isSoft && !zRef ){
     nPaths = 0;
   }
@@ -2429,12 +2429,12 @@ static void doltliteResetFunc(
     }
   }
 
-  /* --soft preserves the existing staged set so the changes that were
-  ** in the orphaned commit can be re-committed (the canonical
-  ** "amend a commit message" / "rewrite the last commit" flow:
-  ** soft-reset, then re-commit with corrections). --mixed (the
-  ** no-flag form) and --hard both reset staged to the target. See
-  ** issue #790. */
+
+
+
+
+
+
   if( !isSoft ){
     doltliteSetSessionStaged(db, &targetCatHash);
   }
@@ -2450,11 +2450,11 @@ static void doltliteResetFunc(
     }
 
 
-    /* Preserve tables that exist in working but not in pre-reset HEAD
-    ** (user-created since HEAD). dolt_reset --hard targets HEAD's
-    ** catalog, but the user probably doesn't want their in-progress
-    ** CREATE TABLE silently deleted. Merge those tables into the
-    ** target catalog before applying the reset. */
+
+
+
+
+
     if( havePreResetHead ){
       rc = doltlitePreserveUntrackedTablesOnHardReset(
         db, cs, &preResetHeadCatHash, &targetCatHash
@@ -2476,14 +2476,14 @@ static void doltliteResetFunc(
       goto reset_cleanup;
     }
 
-    /* Hard reset discards any in-progress merge working state.
-    ** Otherwise a conflicted working set can be rewound to HEAD
-    ** while the stale conflicts catalog is still persisted. */
+
+
+
     doltliteClearSessionMergeState(db);
 
-    /* Hard reset discards the working tree, so any post-merge
-    ** constraint violations attached to it go with it. Otherwise
-    ** the session hash lingers and blocks the next commit. */
+
+
+
     {
       extern int doltliteClearAllConstraintViolations(sqlite3*);
       if( doltliteSessionHasConstraintViolations(db) ){
@@ -2682,10 +2682,10 @@ static void doltliteMergeFunc(
   }
 
 
-  /* Fast-forward merge: ours is an ancestor of theirs, so the merge
-  ** reduces to advancing our branch pointer to theirHead without
-  ** creating a merge commit. --no-ff forces a merge commit even
-  ** when ff would be possible (matches git behavior). */
+
+
+
+
   if( prollyHashCompare(&ancestorHash, &ourHead)==0 && !noFastForward ){
     rc = mergeFastForward(db, context, cs, &ourHead, &theirHead);
     return;
@@ -2820,19 +2820,19 @@ static void doltliteMergeFunc(
     }
   }
 
-  /* Post-merge constraint detection. Release the graph lock
-  ** first so the merged catalog and working set are fully
-  ** visible to the walkers.
-  **
-  ** The merged catalog is installed (schema reflects the merged
-  ** DDL, Table.pFKey is loaded), so PRAGMA foreign_key_check
-  ** sees any row where one side's child references a parent
-  ** the other side deleted. Unique-index detection walks each
-  ** table's UNIQUE indexes and records merge-introduced
-  ** duplicates in the violations vtable without rewriting the
-  ** base table. Each detected violation lands in
-  ** dolt_constraint_violations_<table>; dolt_commit refuses to
-  ** proceed while any violation remains. */
+
+
+
+
+
+
+
+
+
+
+
+
+
   if( graphLocked ){
     chunkStoreUnlock(cs);
     graphLocked = 0;
@@ -2848,16 +2848,16 @@ static void doltliteMergeFunc(
     int nUnique = 0;
     int nCheck = 0;
     char *zDetectErrMsg = 0;
-    /* Pass the three-way-merge ancestor catalog hash so each
-    ** walker can filter out pre-existing violations — rows that
-    ** were already broken before either side of the merge
-    ** started. Dolt's semantics only flag merge-introduced
-    ** violations, not any violating row that happens to be in
-    ** the post-merge tree. zDetectErrMsg captures any user-facing
-    ** error text a walker wants to surface (e.g. the WITHOUT
-    ** ROWID refusal) — we pass it through to the merge result
-    ** so users get an actionable message instead of "SQL logic
-    ** error". */
+
+
+
+
+
+
+
+
+
+
     int vrc = doltliteDetectMergeFkViolations(db, &ancCatHash,
                                               &zDetectErrMsg, &nViolations);
     if( vrc == SQLITE_OK ){
@@ -3061,11 +3061,11 @@ static int doltliteLoadHeadAndParentedCommit(
   return SQLITE_OK;
 }
 
-/* Shared tail for cherry-pick and revert: treat both as degenerate
-** merges and reuse doltliteMergeCatalogs with synthesized anc/our/
-** theirs triples. Cherry-pick uses (parent, HEAD, pick), revert
-** uses (pick, HEAD, parent) — swapping their-vs-ancestor inverts
-** the changes. Conflicts surface the same way a real merge would. */
+
+
+
+
+
 static int applyMergedCatalogAndCommit(
   sqlite3 *db,
   sqlite3_context *context,
@@ -3497,11 +3497,11 @@ static void doltliteRevertFunc(
   }
 }
 
-/* Collect the set of commits reachable from pHeadHash but NOT from
-** pUpstreamHash. Walks upstream's full ancestor graph into a hash
-** set (BFS), then walks head first-parent backward and records every
-** commit that isn't already in that set. Emits the replay list in
-** oldest-first order (so iteration N's parent is N-1). */
+
+
+
+
+
 static int doltliteRebaseCollectReplaySet(
   sqlite3 *db,
   const ProllyHash *pHeadHash,
@@ -3561,8 +3561,8 @@ static int doltliteRebaseCollectReplaySet(
   sqlite3_free(queue);
   queue = 0;
 
-  /* Walk HEAD backward via first-parent, stopping at the first
-  ** commit that's already in upstream's ancestry. */
+
+
   walk = *pHeadHash;
   while( !prollyHashIsEmpty(&walk) && !prollyHashSetContains(&upstreamAncestors, &walk) ){
     DoltliteCommit c;
@@ -3589,7 +3589,7 @@ static int doltliteRebaseCollectReplaySet(
     doltliteCommitClear(&c);
   }
 
-  /* Reverse so the output is oldest-first (ancestor-first). */
+
   for(i=0; i<nReplay/2; i++){
     ProllyHash tmp = aReplay[i];
     aReplay[i] = aReplay[nReplay-1-i];
@@ -3608,10 +3608,10 @@ cleanup:
   return rc;
 }
 
-/* Linear-replay rebase: the non-interactive path. Called by the
-** rebase dispatcher when no -i / --continue / --abort flag is
-** present. Atomic: any replay error or conflict restores the
-** pre-rebase state via the save/restore txn envelope. */
+
+
+
+
 static int doltliteRebaseLinearReplay(
   sqlite3 *db,
   sqlite3_context *context,
@@ -3769,7 +3769,7 @@ rollback:
   return SQLITE_ERROR;
 }
 
-/* A single plan entry materialized from the dolt_rebase table. */
+
 typedef struct RebasePlanRow RebasePlanRow;
 struct RebasePlanRow {
   double order;
@@ -3877,8 +3877,8 @@ static void rebaseFreePlan(RebasePlanRow *aPlan, int nPlan){
   sqlite3_free(aPlan);
 }
 
-/* Read the user's (possibly edited) rebase plan back out of the
-** dolt_rebase table, sorted by rebase_order. */
+
+
 static int rebaseReadPlan(sqlite3 *db, RebasePlanRow **paPlan, int *pnPlan){
   sqlite3_stmt *pStmt = 0;
   RebasePlanRow *aPlan = 0;
@@ -4192,8 +4192,8 @@ static int rebaseDeleteWorkingBranchRefs(sqlite3 *db, ChunkStore *cs, void *pArg
   return chunkStoreDeleteBranch(cs, zWorkingBranch);
 }
 
-/* Best-effort cleanup for an in-progress interactive rebase working branch.
-** Used when start or continue fails after the temp branch exists. */
+
+
 static void rebaseDiscardWorkingBranch(
   sqlite3 *db,
   const char *zOrigBranch,
@@ -4241,19 +4241,19 @@ static void rebaseAbortConflictedContinue(
     (void)chunkStoreDeleteBranch(cs, zWorkingBranch);
     (void)chunkStoreSerializeRefs(cs);
     (void)chunkStoreCommit(cs);
-    /* Refresh the surviving branch's working-set blob against the final
-    ** post-delete ref graph. Without this, rebase abort under savepoint can
-    ** reopen with stale metadata that still references the discarded temp
-    ** branch state. */
+
+
+
+
     (void)doltlitePersistWorkingSet(db);
   }
 }
 
-/* Interactive start (`dolt_rebase('-i', 'upstream')`). Creates a
-** working branch dolt_rebase_<orig>, checks it out pointing at
-** upstream, writes the rebase state into the working set, and
-** materializes the default plan into a SQL table named dolt_rebase
-** that the user can edit via DML before calling --continue. */
+
+
+
+
+
 static void doltliteRebaseInteractiveStart(
   sqlite3_context *context,
   sqlite3 *db,
@@ -4319,10 +4319,10 @@ static void doltliteRebaseInteractiveStart(
     return;
   }
 
-  /* Copy the original branch name off the session struct — the
-  ** upcoming dolt_checkout('dolt_rebase_feat') will free the
-  ** current p->zBranch pointer, and any uncopied reference we hold
-  ** would dangle into freed memory. */
+
+
+
+
   zOrig = sqlite3_mprintf("%s", doltliteGetSessionBranch(db));
   zReturnBranch = sqlite3_mprintf("%s", chunkStoreGetDefaultBranch(cs));
   zWorking = sqlite3_mprintf("dolt_rebase_%s", zOrig ? zOrig : "");
@@ -4347,16 +4347,16 @@ static void doltliteRebaseInteractiveStart(
     }
   }
 
-  /* Flush the original branch's current working catalog so --abort
-  ** can restore exactly what the user had before the rebase. */
+
+
   rc = doltliteFlushCatalogToHash(db, &preRebaseCat);
   if( rc!=SQLITE_OK ) goto fail;
 
-  /* Create the working branch at upstream and switch to it. We still
-  ** use the rollback-safe checkout helper so that abort/failure cleanup
-  ** can restore state precisely, but successful interactive rebase start
-  ** follows Dolt's branch-style transaction policy and seals the current
-  ** SQL txn/savepoint state before returning. */
+
+
+
+
+
   rc = chunkStoreAddBranch(cs, zWorking, &upstreamHash);
   if( rc!=SQLITE_OK ){
     zFailMsg = "rebase working branch already exists";
@@ -4366,22 +4366,22 @@ static void doltliteRebaseInteractiveStart(
   rc = doltliteCheckoutBranchForRebase(db, zWorking);
   if( rc!=SQLITE_OK ) goto fail;
 
-  /* Materialize the default plan as a real SQL table on the
-  ** working branch. Create and populate BEFORE setting the rebase
-  ** state — each DDL/DML statement opens a write trans that
-  ** reloads the working set from disk, which would clobber any
-  ** in-memory rebase state we set beforehand. By deferring the
-  ** state flip until after the plan table is populated, the
-  ** reloads pick up a clean "no rebase yet" state, and the final
-  ** persist atomically flips disk to rebase=1 along with the plan. */
+
+
+
+
+
+
+
+
   rc = rebaseCreateAndPopulatePlanTable(db, aReplay, nReplay);
   if( rc!=SQLITE_OK ){
     zFailMsg = "failed to create dolt_rebase table";
     goto fail;
   }
 
-  /* Now set the rebase state on the session and persist it.
-  ** Nothing after this triggers a reload before -i returns. */
+
+
   doltliteSetSessionRebaseState(db, 1, &preRebaseCat, &upstreamHash,
                                 zOrig, zReturnBranch);
   rc = doltlitePersistWorkingSet(db);
@@ -4420,8 +4420,8 @@ fail:
   }
 }
 
-/* Interactive abort: the working branch is thrown away and the
-** session returns to the original branch unchanged. */
+
+
 static void doltliteRebaseInteractiveAbort(
   sqlite3_context *context,
   sqlite3 *db
@@ -4452,10 +4452,10 @@ static void doltliteRebaseInteractiveAbort(
     return;
   }
 
-  /* The working branch has the dolt_rebase plan table as an
-  ** uncommitted change. Drop it so checkout doesn't refuse, and
-  ** clear the session rebase state so the post-checkout persist
-  ** doesn't leak stale values. */
+
+
+
+
   rebaseDiscardWorkingBranch(db, zOrigBranch, zWorking);
   if( cs && zReturnBranch && zReturnBranch[0] ){
     rc = chunkStoreSetDefaultBranch(cs, zReturnBranch);
@@ -4499,11 +4499,11 @@ static void doltliteRebaseInteractiveAbort(
   sqlite3_result_text(context, "Interactive rebase aborted", -1, SQLITE_STATIC);
 }
 
-/* Interactive continue: read the user-edited plan, drop the
-** dolt_rebase table, group the plan rows into pick/squash/fixup
-** groups, replay each group as one combined commit on top of the
-** working branch, then move the original branch ref to the new
-** tip and checkout the original branch. */
+
+
+
+
+
 static void doltliteRebaseInteractiveContinue(
   sqlite3_context *context,
   sqlite3 *db
@@ -4541,11 +4541,11 @@ static void doltliteRebaseInteractiveContinue(
   zWorking = rebaseBuildWorkingBranchName(zOrigBranchConst);
   if( !zReturnBranch || !zWorking || !zOrigBranch ){ rc = SQLITE_NOMEM; goto abort_err; }
 
-  /* The plan table was created by the preceding -i call inside a VC helper
-  ** statement. On some paths the next VC helper statement does not see that
-  ** new schema object until something touches the table directly first.
-  ** Warm it up before validating so --continue works without requiring the
-  ** caller to query dolt_rebase manually. */
+
+
+
+
+
   (void)sqlite3_exec(db, "SELECT 1 FROM main.dolt_rebase LIMIT 0", 0, 0, 0);
 
   zStep = "validate plan";
@@ -4568,8 +4568,8 @@ static void doltliteRebaseInteractiveContinue(
   rc = doltliteEnsureWriteTxnAndSavepoints(db);
   if( rc!=SQLITE_OK ) goto abort_err;
 
-  /* Flush catalog (now without dolt_rebase) to get the clean base
-  ** catalog hash that iterating merges will build on. */
+
+
   i = 0;
   while( i < nPlan && strcmp(aPlan[i].zAction, "drop")==0 ) i++;
   if( i < nPlan
@@ -4591,10 +4591,10 @@ static void doltliteRebaseInteractiveContinue(
   if( rc!=SQLITE_OK ) goto abort_err;
   doltliteGetSessionHead(db, &curHead);
 
-  /* Walk the plan in order, grouping each pick/reword with any
-  ** immediately-following squash/fixup rows. A group finishes at
-  ** the next pick/reword (or end of plan) and produces ONE
-  ** combined commit with the accumulated content and message. */
+
+
+
+
   i = 0;
   while( i < nPlan ){
     int j;
@@ -4619,12 +4619,12 @@ static void doltliteRebaseInteractiveContinue(
   rc = doltliteMutateRefs(db, rebaseFinalizeContinueRefs, &refsCtx);
   if( rc!=SQLITE_OK ) goto abort_err;
 
-  /* Clear rebase state on the working branch's session state before we
-  ** switch back to the original branch. We still use the rollback-safe
-  ** checkout helper for correctness during the internal handoff, but a
-  ** successful interactive continue follows Dolt's branch-style txn
-  ** policy and seals the caller's savepoints / explicit transaction
-  ** before returning. */
+
+
+
+
+
+
   doltliteClearSessionRebaseState(db);
   zStep = "persist cleared rebase state";
   rc = doltlitePersistWorkingSet(db);
@@ -4696,7 +4696,7 @@ abort_err_silent:
   sqlite3_free(zWorking);
 }
 
-/* Dispatcher for dolt_rebase. */
+
 static void doltliteRebaseFunc(
   sqlite3_context *context,
   int argc,
@@ -4825,12 +4825,12 @@ static void doltliteConfigFunc(sqlite3_context *context, int argc, sqlite3_value
   }
 }
 
-/* dolt_version() — 0-arg scalar returning the build's version
-** string (DOLTLITE_VERSION macro, set from `git describe` at
-** compile time). Used for peer version negotiation in the
-** decentralized setup, bug-report ergonomics, and schema
-** migrations that branch on engine version. Dolt ships an
-** equivalent DOLT_VERSION() with the same argcount contract. */
+
+
+
+
+
+
 static void doltliteVersionFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   (void)argv;
   if( argc!=0 ){
@@ -4841,11 +4841,11 @@ static void doltliteVersionFunc(sqlite3_context *ctx, int argc, sqlite3_value **
   sqlite3_result_text(ctx, DOLTLITE_VERSION, -1, SQLITE_STATIC);
 }
 
-/* On first open of a writable chunk store with no branches, create
-** an empty initial commit on "main" so a fresh database has a valid
-** HEAD to commit against. Skipped on read-only or in-memory stores
-** and when branches already exist (a previous seed ran, or the file
-** was cloned from a remote). */
+
+
+
+
+
 static void doltliteMaybeSeedRepo(sqlite3 *db){
   ChunkStore *cs = doltliteGetChunkStore(db);
   ProllyHash emptyParent;

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -174,12 +174,6 @@ static int doltliteRestoreTxnStateOnFailure(
   return rc==SQLITE_OK ? opRc : rc;
 }
 
-
-
-
-
-
-
 static int doltliteRefreshAndConfirmHead(
   sqlite3 *db,
   ChunkStore *cs,
@@ -236,13 +230,11 @@ int doltliteHasUncommittedChanges(sqlite3 *db){
     return hasUserTables;
   }
 
-
   doltliteGetSessionStaged(db, &stagedHash);
   if( !prollyHashIsEmpty(&stagedHash)
    && prollyHashCompare(&headCatHash, &stagedHash)!=0 ){
     return 1;
   }
-
 
   {
     ChunkStore *cs = doltliteGetChunkStore(db);
@@ -896,12 +888,6 @@ static int addCheckIgnore(
   return rc;
 }
 
-
-
-
-
-
-
 static int addAppendTableEntry(
   sqlite3_context *context,
   struct TableEntry **paEntries,
@@ -945,9 +931,6 @@ static struct TableEntry *addFindEntryByName(
   }
   return 0;
 }
-
-
-
 
 static void addAlignStagedEntriesToWorking(
   struct TableEntry *aWorking,
@@ -1332,8 +1315,6 @@ static void doltliteAddFunc(
     goto add_cleanup;
   }
 
-
-
   for(i=0; i<argc; i++){
     const char *arg = (const char*)sqlite3_value_text(argv[i]);
     if( !arg ) continue;
@@ -1509,12 +1490,6 @@ static void doltliteCommitFunc(
     }
   }
 
-
-
-
-
-
-
   if( !force && doltliteSessionHasConstraintViolations(db) ){
     sqlite3_result_error(context,
       "cannot commit: unresolved entries in dolt_constraint_violations. "
@@ -1612,7 +1587,6 @@ static void doltliteCommitFunc(
       return;
     }
 
-
     for(j=0; j<nWorking; j++){
       const char *zName = aWorking[j].zName;
       int inHead = 0;
@@ -1667,7 +1641,6 @@ static void doltliteCommitFunc(
       }
     }
 
-
     for(k=0; k<nHead; k++){
       const char *zName = aHead[k].zName;
       int inWorking = 0;
@@ -1691,7 +1664,6 @@ static void doltliteCommitFunc(
         }
       }
     }
-
 
     if( nStaged==0 ){
       doltliteFreeCatalog(aWorking, nWorking);
@@ -1725,7 +1697,6 @@ static void doltliteCommitFunc(
     }
   }
 
-
   {
     ProllyHash cfHash;
     doltliteGetSessionConflictsCatalog(db, &cfHash);
@@ -1735,7 +1706,6 @@ static void doltliteCommitFunc(
       return;
     }
   }
-
 
   doltliteGetSessionStaged(db, &catalogHash);
   if( prollyHashIsEmpty(&catalogHash) ){
@@ -1755,7 +1725,6 @@ static void doltliteCommitFunc(
       return;
     }
   }
-
 
   {
     u8 isMerging = 0;
@@ -1778,7 +1747,6 @@ static void doltliteCommitFunc(
       }
     }
   }
-
 
   {
     ProllyHash parentHash;
@@ -1840,13 +1808,7 @@ static void doltliteCommitFunc(
       }
     }
 
-
     {
-
-
-
-
-
       const char *p = zMessage;
       while( *p==' ' || *p=='\t' || *p=='\n' || *p=='\r' ) p++;
       if( *p==0 ){
@@ -1871,7 +1833,6 @@ static void doltliteCommitFunc(
 
   doltliteGetSessionHead(db, &sessionHeadBeforeLock);
 
-
   rc = doltliteRefreshAndConfirmHead(db, cs, &sessionHeadBeforeLock);
   if( rc==SQLITE_BUSY ){
     sqlite3_result_error(context,
@@ -1884,7 +1845,6 @@ static void doltliteCommitFunc(
     return;
   }
 
-
   {
     u8 wasMerging = 0;
     doltliteGetSessionMergeState(db, &wasMerging, 0, 0);
@@ -1892,11 +1852,6 @@ static void doltliteCommitFunc(
       doltliteClearSessionMergeState(db);
     }
   }
-
-
-
-
-
 
   {
     extern int doltliteClearAllConstraintViolations(sqlite3*);
@@ -2276,12 +2231,10 @@ static void doltliteResetFunc(
     goto reset_cleanup;
   }
 
-
   if( doltliteGetHeadCatalogHash(db, &preResetHeadCatHash)==SQLITE_OK
    && !prollyHashIsEmpty(&preResetHeadCatHash) ){
     havePreResetHead = 1;
   }
-
 
   azPaths = (const char**)sqlite3_malloc(sizeof(char*) * (argc>0?argc:1));
   if( !azPaths ){ sqlite3_result_error_nomem(context); goto reset_cleanup; }
@@ -2338,11 +2291,6 @@ static void doltliteResetFunc(
     goto reset_cleanup;
   }
 
-
-
-
-
-
   if( nPaths>1 && !isHard && !isSoft && !zRef ){
     nPaths = 0;
   }
@@ -2376,7 +2324,6 @@ static void doltliteResetFunc(
   }
   sqlite3_free(azPaths);
   azPaths = 0;
-
 
   if( isSoft && !zRef ){
     sqlite3_result_int(context, 0);
@@ -2430,12 +2377,6 @@ static void doltliteResetFunc(
     }
   }
 
-
-
-
-
-
-
   if( !isSoft ){
     doltliteSetSessionStaged(db, &targetCatHash);
   }
@@ -2449,12 +2390,6 @@ static void doltliteResetFunc(
       sqlite3_result_error(context, "no commit to reset to", -1);
       goto reset_cleanup;
     }
-
-
-
-
-
-
 
     if( havePreResetHead ){
       rc = doltlitePreserveUntrackedTablesOnHardReset(
@@ -2477,13 +2412,7 @@ static void doltliteResetFunc(
       goto reset_cleanup;
     }
 
-
-
-
     doltliteClearSessionMergeState(db);
-
-
-
 
     {
       extern int doltliteClearAllConstraintViolations(sqlite3*);
@@ -2585,7 +2514,6 @@ static void doltliteMergeFunc(
   if( !cs ){ sqlite3_result_error(context, "no database", -1); return; }
   if( argc<1 ){ sqlite3_result_error(context, "usage: dolt_merge('branch')", -1); return; }
 
-
   for(i=0; i<argc; i++){
     const char *arg = (const char*)sqlite3_value_text(argv[i]);
     if( !arg ) continue;
@@ -2649,19 +2577,16 @@ static void doltliteMergeFunc(
     return;
   }
 
-
   rc = doltliteResolveRef(db, zBranch, &theirHead);
   if( rc!=SQLITE_OK || prollyHashIsEmpty(&theirHead) ){
     sqlite3_result_error(context, "merge source not found", -1);
     return;
   }
 
-
   if( prollyHashCompare(&ourHead, &theirHead)==0 ){
     sqlite3_result_text(context, "Already up to date", -1, SQLITE_STATIC);
     return;
   }
-
 
   if( doltliteHasUncommittedChanges(db) ){
     sqlite3_result_error(context,
@@ -2669,23 +2594,16 @@ static void doltliteMergeFunc(
     return;
   }
 
-
   rc = doltliteFindAncestor(db, &ourHead, &theirHead, &ancestorHash);
   if( rc!=SQLITE_OK || prollyHashIsEmpty(&ancestorHash) ){
     sqlite3_result_error(context, "no common ancestor found", -1);
     return;
   }
 
-
   if( prollyHashCompare(&ancestorHash, &theirHead)==0 ){
     sqlite3_result_text(context, "Already up to date", -1, SQLITE_STATIC);
     return;
   }
-
-
-
-
-
 
   if( prollyHashCompare(&ancestorHash, &ourHead)==0 && !noFastForward ){
     rc = mergeFastForward(db, context, cs, &ourHead, &theirHead);
@@ -2764,7 +2682,6 @@ static void doltliteMergeFunc(
     }
     graphLocked = 1;
 
-
     rc = doltliteSwitchCatalog(db, &mergedCatHash);
     doltliteCommitClear(&ourCommit);
     doltliteCommitClear(&theirCommit);
@@ -2778,7 +2695,6 @@ static void doltliteMergeFunc(
           doltliteRestoreTxnStateOnFailure(db, &savedState, rc));
       return;
     }
-
 
     if( nSchemaActions > 0 ){
       rc = doltliteApplyMergeSchemaActions(db, &ancCatHash, &theirCatHash,
@@ -2821,19 +2737,6 @@ static void doltliteMergeFunc(
     }
   }
 
-
-
-
-
-
-
-
-
-
-
-
-
-
   if( graphLocked ){
     chunkStoreUnlock(cs);
     graphLocked = 0;
@@ -2849,16 +2752,6 @@ static void doltliteMergeFunc(
     int nUnique = 0;
     int nCheck = 0;
     char *zDetectErrMsg = 0;
-
-
-
-
-
-
-
-
-
-
     int vrc = doltliteDetectMergeFkViolations(db, &ancCatHash,
                                               &zDetectErrMsg, &nViolations);
     if( vrc == SQLITE_OK ){
@@ -3061,11 +2954,6 @@ static int doltliteLoadHeadAndParentedCommit(
   if( rc!=SQLITE_OK ) return SQLITE_ABORT;
   return SQLITE_OK;
 }
-
-
-
-
-
 
 static int applyMergedCatalogAndCommit(
   sqlite3 *db,
@@ -3465,7 +3353,6 @@ static void doltliteRevertFunc(
     return;
   }
 
-
   {
     char msg[512];
     sqlite3_snprintf(sizeof(msg), msg, "Revert \"%s\"",
@@ -3497,11 +3384,6 @@ static void doltliteRevertFunc(
     sqlite3_result_text(context, hexBuf, -1, SQLITE_TRANSIENT);
   }
 }
-
-
-
-
-
 
 static int doltliteRebaseCollectReplaySet(
   sqlite3 *db,
@@ -3562,8 +3444,6 @@ static int doltliteRebaseCollectReplaySet(
   sqlite3_free(queue);
   queue = 0;
 
-
-
   walk = *pHeadHash;
   while( !prollyHashIsEmpty(&walk) && !prollyHashSetContains(&upstreamAncestors, &walk) ){
     DoltliteCommit c;
@@ -3590,7 +3470,6 @@ static int doltliteRebaseCollectReplaySet(
     doltliteCommitClear(&c);
   }
 
-
   for(i=0; i<nReplay/2; i++){
     ProllyHash tmp = aReplay[i];
     aReplay[i] = aReplay[nReplay-1-i];
@@ -3608,10 +3487,6 @@ cleanup:
   if( upstreamInit ) prollyHashSetFree(&upstreamAncestors);
   return rc;
 }
-
-
-
-
 
 static int doltliteRebaseLinearReplay(
   sqlite3 *db,
@@ -3770,7 +3645,6 @@ rollback:
   return SQLITE_ERROR;
 }
 
-
 typedef struct RebasePlanRow RebasePlanRow;
 struct RebasePlanRow {
   double order;
@@ -3877,8 +3751,6 @@ static void rebaseFreePlan(RebasePlanRow *aPlan, int nPlan){
   }
   sqlite3_free(aPlan);
 }
-
-
 
 static int rebaseReadPlan(sqlite3 *db, RebasePlanRow **paPlan, int *pnPlan){
   sqlite3_stmt *pStmt = 0;
@@ -4193,8 +4065,6 @@ static int rebaseDeleteWorkingBranchRefs(sqlite3 *db, ChunkStore *cs, void *pArg
   return chunkStoreDeleteBranch(cs, zWorkingBranch);
 }
 
-
-
 static void rebaseDiscardWorkingBranch(
   sqlite3 *db,
   const char *zOrigBranch,
@@ -4242,18 +4112,9 @@ static void rebaseAbortConflictedContinue(
     (void)chunkStoreDeleteBranch(cs, zWorkingBranch);
     (void)chunkStoreSerializeRefs(cs);
     (void)chunkStoreCommit(cs);
-
-
-
-
     (void)doltlitePersistWorkingSet(db);
   }
 }
-
-
-
-
-
 
 static void doltliteRebaseInteractiveStart(
   sqlite3_context *context,
@@ -4320,10 +4181,6 @@ static void doltliteRebaseInteractiveStart(
     return;
   }
 
-
-
-
-
   zOrig = sqlite3_mprintf("%s", doltliteGetSessionBranch(db));
   zReturnBranch = sqlite3_mprintf("%s", chunkStoreGetDefaultBranch(cs));
   zWorking = sqlite3_mprintf("dolt_rebase_%s", zOrig ? zOrig : "");
@@ -4348,15 +4205,8 @@ static void doltliteRebaseInteractiveStart(
     }
   }
 
-
-
   rc = doltliteFlushCatalogToHash(db, &preRebaseCat);
   if( rc!=SQLITE_OK ) goto fail;
-
-
-
-
-
 
   rc = chunkStoreAddBranch(cs, zWorking, &upstreamHash);
   if( rc!=SQLITE_OK ){
@@ -4367,21 +4217,11 @@ static void doltliteRebaseInteractiveStart(
   rc = doltliteCheckoutBranchForRebase(db, zWorking);
   if( rc!=SQLITE_OK ) goto fail;
 
-
-
-
-
-
-
-
-
   rc = rebaseCreateAndPopulatePlanTable(db, aReplay, nReplay);
   if( rc!=SQLITE_OK ){
     zFailMsg = "failed to create dolt_rebase table";
     goto fail;
   }
-
-
 
   doltliteSetSessionRebaseState(db, 1, &preRebaseCat, &upstreamHash,
                                 zOrig, zReturnBranch);
@@ -4421,8 +4261,6 @@ fail:
   }
 }
 
-
-
 static void doltliteRebaseInteractiveAbort(
   sqlite3_context *context,
   sqlite3 *db
@@ -4452,10 +4290,6 @@ static void doltliteRebaseInteractiveAbort(
     sqlite3_result_error_code(context, SQLITE_NOMEM);
     return;
   }
-
-
-
-
 
   rebaseDiscardWorkingBranch(db, zOrigBranch, zWorking);
   if( cs && zReturnBranch && zReturnBranch[0] ){
@@ -4500,11 +4334,6 @@ static void doltliteRebaseInteractiveAbort(
   sqlite3_result_text(context, "Interactive rebase aborted", -1, SQLITE_STATIC);
 }
 
-
-
-
-
-
 static void doltliteRebaseInteractiveContinue(
   sqlite3_context *context,
   sqlite3 *db
@@ -4542,11 +4371,6 @@ static void doltliteRebaseInteractiveContinue(
   zWorking = rebaseBuildWorkingBranchName(zOrigBranchConst);
   if( !zReturnBranch || !zWorking || !zOrigBranch ){ rc = SQLITE_NOMEM; goto abort_err; }
 
-
-
-
-
-
   (void)sqlite3_exec(db, "SELECT 1 FROM main.dolt_rebase LIMIT 0", 0, 0, 0);
 
   zStep = "validate plan";
@@ -4569,8 +4393,6 @@ static void doltliteRebaseInteractiveContinue(
   rc = doltliteEnsureWriteTxnAndSavepoints(db);
   if( rc!=SQLITE_OK ) goto abort_err;
 
-
-
   i = 0;
   while( i < nPlan && strcmp(aPlan[i].zAction, "drop")==0 ) i++;
   if( i < nPlan
@@ -4591,10 +4413,6 @@ static void doltliteRebaseInteractiveContinue(
   rc = doltliteFlushCatalogToHash(db, &curCat);
   if( rc!=SQLITE_OK ) goto abort_err;
   doltliteGetSessionHead(db, &curHead);
-
-
-
-
 
   i = 0;
   while( i < nPlan ){
@@ -4619,12 +4437,6 @@ static void doltliteRebaseInteractiveContinue(
   zStep = "finalize refs";
   rc = doltliteMutateRefs(db, rebaseFinalizeContinueRefs, &refsCtx);
   if( rc!=SQLITE_OK ) goto abort_err;
-
-
-
-
-
-
 
   doltliteClearSessionRebaseState(db);
   zStep = "persist cleared rebase state";
@@ -4696,7 +4508,6 @@ abort_err_silent:
   sqlite3_free(zReturnBranch);
   sqlite3_free(zWorking);
 }
-
 
 static void doltliteRebaseFunc(
   sqlite3_context *context,
@@ -4826,12 +4637,6 @@ static void doltliteConfigFunc(sqlite3_context *context, int argc, sqlite3_value
   }
 }
 
-
-
-
-
-
-
 static void doltliteVersionFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   (void)argv;
   if( argc!=0 ){
@@ -4841,11 +4646,6 @@ static void doltliteVersionFunc(sqlite3_context *ctx, int argc, sqlite3_value **
   }
   sqlite3_result_text(ctx, DOLTLITE_VERSION, -1, SQLITE_STATIC);
 }
-
-
-
-
-
 
 static void doltliteMaybeSeedRepo(sqlite3 *db){
   ChunkStore *cs = doltliteGetChunkStore(db);

--- a/src/doltlite_ancestor.c
+++ b/src/doltlite_ancestor.c
@@ -152,12 +152,12 @@ static int ancestorBfsCollect(
   return rc;
 }
 
-/* Merge-base by set-intersection BFS: walk commit1's ancestry in full,
-** then BFS commit2 and return the first hash that appears in the
-** ancestor set. Fine for shallow histories; for Git-style "lowest"
-** LCA on deep merges the right algorithm is both-sides BFS with
-** generation numbers, but Dolt's merge semantics accept any common
-** ancestor produced here. */
+
+
+
+
+
+
 int doltliteFindAncestor(
   sqlite3 *db,
   const ProllyHash *commitHash1,

--- a/src/doltlite_ancestor.c
+++ b/src/doltlite_ancestor.c
@@ -152,12 +152,6 @@ static int ancestorBfsCollect(
   return rc;
 }
 
-
-
-
-
-
-
 int doltliteFindAncestor(
   sqlite3 *db,
   const ProllyHash *commitHash1,
@@ -178,7 +172,6 @@ int doltliteFindAncestor(
     return SQLITE_OK;
   }
 
-
   rc = hashSetInit(&ancestors, 64);
   if( rc!=SQLITE_OK ) return rc;
 
@@ -187,7 +180,6 @@ int doltliteFindAncestor(
     hashSetFree(&ancestors);
     return rc;
   }
-
 
   {
     ProllyHash *queue = 0;

--- a/src/doltlite_at.c
+++ b/src/doltlite_at.c
@@ -44,7 +44,7 @@ struct AtCursor {
   sqlite3_vtab_cursor base;
   ProllyCursor tblCur;
   int tblCurOpen;
-  /* Current row (copied from cursor) */
+
   i64 intKey;
   u8 *pVal; int nVal;
   int hasRow;
@@ -65,8 +65,8 @@ static void atCursorReset(AtCursor *c){
   c->iRowid = 0;
 }
 
-/* Capture current cursor row. The prolly cursor's value pointer
-** may be invalidated on next step, so we copy the bytes. */
+
+
 static int atCaptureRow(AtCursor *c){
   const u8 *pVal; int nVal;
   sqlite3_free(c->pVal);
@@ -214,12 +214,12 @@ static int atFilter(sqlite3_vtab_cursor *cur,
   rc=doltliteLoadCommit(db,&commitHash,&commit);
   if(rc!=SQLITE_OK) return rc;
 
-  /* When the ref is a branch name (not a commit hash or tag), prefer
-  ** its working catalog over the committed catalog IF the working set
-  ** is still based on HEAD — that lets dolt_at_<table>@branch show
-  ** staged-but-uncommitted rows on that branch. If the working set
-  ** points at a different commit (mid-merge, stale WIP) fall through
-  ** and use the committed catalog so the output still makes sense. */
+
+
+
+
+
+
   {
     ProllyHash branchCommit;
     int isBranch = (chunkStoreFindBranch(cs,zRef,&branchCommit)==SQLITE_OK
@@ -254,7 +254,7 @@ at_find_root:
 
   if( prollyHashIsEmpty(&tableRoot) ) return SQLITE_OK;
 
-  /* Open streaming cursor on the table at this commit. */
+
   prollyCursorInit(&c->tblCur, cs, pCache, &tableRoot, flags);
   rc = prollyCursorFirst(&c->tblCur, &res);
   if( rc!=SQLITE_OK ){

--- a/src/doltlite_at.c
+++ b/src/doltlite_at.c
@@ -44,7 +44,6 @@ struct AtCursor {
   sqlite3_vtab_cursor base;
   ProllyCursor tblCur;
   int tblCurOpen;
-
   i64 intKey;
   u8 *pVal; int nVal;
   int hasRow;
@@ -64,8 +63,6 @@ static void atCursorReset(AtCursor *c){
   c->hasRow = 0;
   c->iRowid = 0;
 }
-
-
 
 static int atCaptureRow(AtCursor *c){
   const u8 *pVal; int nVal;
@@ -214,12 +211,6 @@ static int atFilter(sqlite3_vtab_cursor *cur,
   rc=doltliteLoadCommit(db,&commitHash,&commit);
   if(rc!=SQLITE_OK) return rc;
 
-
-
-
-
-
-
   {
     ProllyHash branchCommit;
     int isBranch = (chunkStoreFindBranch(cs,zRef,&branchCommit)==SQLITE_OK
@@ -253,7 +244,6 @@ at_find_root:
   if(rc!=SQLITE_OK) return rc;
 
   if( prollyHashIsEmpty(&tableRoot) ) return SQLITE_OK;
-
 
   prollyCursorInit(&c->tblCur, cs, pCache, &tableRoot, flags);
   rc = prollyCursorFirst(&c->tblCur, &res);

--- a/src/doltlite_blame.c
+++ b/src/doltlite_blame.c
@@ -13,19 +13,6 @@
 #include <string.h>
 #include <time.h>
 
-
-
-
-
-
-
-
-
-
-
-
-
-
 typedef struct BlameRow BlameRow;
 struct BlameRow {
   i64 intKey;
@@ -68,11 +55,6 @@ struct BlamePkTmp {
   int pkPos;
   int isIntegerType;
 };
-
-
-
-
-
 
 static int blameLoadPkColumns(
   sqlite3 *db,
@@ -125,7 +107,6 @@ static int blameLoadPkColumns(
     return rc;
   }
 
-
   for(i=1; i<nTmp; i++){
     BlamePkTmp t = tmp[i];
     j = i - 1;
@@ -151,10 +132,6 @@ static int blameLoadPkColumns(
     aCid[i] = tmp[i].cid;
     n++;
   }
-
-
-
-
 
   if( nTmp == 1 && tmp[0].isIntegerType ){
     intPkCid = tmp[0].cid;
@@ -214,8 +191,6 @@ static void blameFreeRows(BlameCursor *c){
   c->nAlloc = 0;
 }
 
-
-
 static int blameCollectLiveRows(
   BlameCursor *pCur,
   ChunkStore *cs,
@@ -274,10 +249,6 @@ static int blameCollectLiveRows(
   return SQLITE_OK;
 }
 
-
-
-
-
 static int blameSeekRowInTree(
   ChunkStore *cs,
   ProllyCache *pCache,
@@ -313,9 +284,6 @@ static int blameSeekRowInTree(
   return SQLITE_OK;
 }
 
-
-
-
 static int blameRowValueEqual(const u8 *pA, int nA, const u8 *pB, int nB){
   int isA = (pA && nA>0);
   int isB = (pB && nB>0);
@@ -324,8 +292,6 @@ static int blameRowValueEqual(const u8 *pA, int nA, const u8 *pB, int nB){
   if( nA != nB ) return 0;
   return memcmp(pA, pB, nA)==0;
 }
-
-
 
 static int blameLoadTableRoot(
   sqlite3 *db,
@@ -356,8 +322,6 @@ static int blameLoadTableRoot(
   return SQLITE_OK;
 }
 
-
-
 static int blameAssign(
   BlameRow *pRow,
   const ProllyHash *pCommitHash,
@@ -376,9 +340,6 @@ static int blameAssign(
   if( !pRow->zCommitter || !pRow->zEmail || !pRow->zMessage ) return SQLITE_NOMEM;
   return SQLITE_OK;
 }
-
-
-
 
 static int blameCompareAgainstRef(
   sqlite3 *db,
@@ -429,10 +390,6 @@ static int blameUnresolvedCount(BlameCursor *pCur){
   return pCur->nUnresolved;
 }
 
-
-
-
-
 static int blameFindAllParentMergeBase(
   sqlite3 *db,
   const DoltliteCommit *pCommit,
@@ -470,8 +427,6 @@ static int blameFindAllParentMergeBase(
   return SQLITE_OK;
 }
 
-
-
 static int blameWalk(
   BlameCursor *pCur,
   sqlite3 *db,
@@ -502,7 +457,6 @@ static int blameWalk(
     }
 
     if( doltliteCommitParentCount(&commit) >= 2 ){
-
       ProllyHash baseHash;
       DoltliteCommit baseCommit;
       memset(&baseHash, 0, sizeof(baseHash));
@@ -527,8 +481,6 @@ static int blameWalk(
           return rc;
         }
       }else if( haveCurTable ){
-
-
         rc = blameCompareAgainstRef(db, pCur, zTableName,
                                     &curTableRoot, curFlags,
                                     0, &walk, &commit);
@@ -538,7 +490,6 @@ static int blameWalk(
         }
       }
     }else{
-
       const ProllyHash *pParent = doltliteCommitParentHash(&commit, 0);
       if( pParent && !prollyHashIsEmpty(pParent) ){
         DoltliteCommit parentCommit;
@@ -556,8 +507,6 @@ static int blameWalk(
           return rc;
         }
       }else if( haveCurTable ){
-
-
         rc = blameCompareAgainstRef(db, pCur, zTableName,
                                     &curTableRoot, curFlags,
                                     0, &walk, &commit);
@@ -567,7 +516,6 @@ static int blameWalk(
         }
       }
     }
-
 
     {
       const ProllyHash *pParent = doltliteCommitParentHash(&commit, 0);
@@ -745,17 +693,9 @@ static int bmColumn(sqlite3_vtab_cursor *pCursor,
   if( iCol < nPk ){
     int cid = v->aPkColIdx[iCol];
     if( cid == v->intPkCid ){
-
-
       sqlite3_result_int64(ctx, r->intKey);
     }else if( r->pCurVal && r->nCurVal>0 ){
       DoltliteRecordInfo ri;
-
-
-
-
-
-
       doltliteParseRecord(r->pCurVal, r->nCurVal, &ri);
       if( iCol < ri.nField ){
         doltliteResultField(ctx, r->pCurVal, r->nCurVal,

--- a/src/doltlite_blame.c
+++ b/src/doltlite_blame.c
@@ -13,18 +13,18 @@
 #include <string.h>
 #include <time.h>
 
-/* dolt_blame_<table> semantics:
-**
-** For each LIVE row in the current table, report the most recent
-** commit that introduced the row's current value. Walked first-
-** parent from HEAD. At a linear commit, blame = that commit if the
-** row's value differs from its value in the parent. At a merge
-** commit (2+ parents), blame = merge commit if the row's value
-** differs from its value in the merge base (LCA of parents).
-**
-** Walking past the root is handled by treating a missing parent
-** table as "row not present" — any still-unblamed row at the root
-** commit will therefore be blamed to it. */
+
+
+
+
+
+
+
+
+
+
+
+
 
 typedef struct BlameRow BlameRow;
 struct BlameRow {
@@ -69,11 +69,11 @@ struct BlamePkTmp {
   int isIntegerType;
 };
 
-/* Collect PK column names (in pk-position order) and their record
-** field indices (cid from PRAGMA table_info). Also returns the cid
-** of the rowid-aliased INTEGER PK column if any, else -1 — used at
-** emit time to decide whether to pull the value from cursor intKey
-** or from the record payload. */
+
+
+
+
+
 static int blameLoadPkColumns(
   sqlite3 *db,
   const char *zTable,
@@ -125,7 +125,7 @@ static int blameLoadPkColumns(
     return rc;
   }
 
-  /* Insertion-sort tmp[] by pkPos so emit order matches PK declaration. */
+
   for(i=1; i<nTmp; i++){
     BlamePkTmp t = tmp[i];
     j = i - 1;
@@ -152,10 +152,10 @@ static int blameLoadPkColumns(
     n++;
   }
 
-  /* Identify the rowid-aliased INTEGER PK column if this is a
-  ** single-column INTEGER PRIMARY KEY: SQLite treats it as the
-  ** rowid, so its value must come from cursor.intKey, not the
-  ** record payload which won't include a field for it. */
+
+
+
+
   if( nTmp == 1 && tmp[0].isIntegerType ){
     intPkCid = tmp[0].cid;
   }
@@ -214,8 +214,8 @@ static void blameFreeRows(BlameCursor *c){
   c->nAlloc = 0;
 }
 
-/* Load every live row of the current table into the cursor. Returns
-** SQLITE_OK with nRows==0 if the table has no rows at HEAD. */
+
+
 static int blameCollectLiveRows(
   BlameCursor *pCur,
   ChunkStore *cs,
@@ -274,10 +274,10 @@ static int blameCollectLiveRows(
   return SQLITE_OK;
 }
 
-/* Seek a single row by its stored key in the given table root and
-** return SQLITE_OK with `ppVal`/`pnVal` set to the row's value
-** bytes if found, or NULL/0 if the row doesn't exist. On error,
-** returns the error code. */
+
+
+
+
 static int blameSeekRowInTree(
   ChunkStore *cs,
   ProllyCache *pCache,
@@ -313,9 +313,9 @@ static int blameSeekRowInTree(
   return SQLITE_OK;
 }
 
-/* Returns 1 if pA..+nA and pB..+nB encode the same row value for
-** blame purposes. Treats NULL-vs-missing as "missing"; missing vs
-** present is always different. */
+
+
+
 static int blameRowValueEqual(const u8 *pA, int nA, const u8 *pB, int nB){
   int isA = (pA && nA>0);
   int isB = (pB && nB>0);
@@ -325,8 +325,8 @@ static int blameRowValueEqual(const u8 *pA, int nA, const u8 *pB, int nB){
   return memcmp(pA, pB, nA)==0;
 }
 
-/* Load a table's root hash and flags at the given catalog hash.
-** Returns SQLITE_NOTFOUND if the table doesn't exist there. */
+
+
 static int blameLoadTableRoot(
   sqlite3 *db,
   const ProllyHash *pCatHash,
@@ -356,8 +356,8 @@ static int blameLoadTableRoot(
   return SQLITE_OK;
 }
 
-/* Record blame info on pRow. Duplicates the commit's strings since
-** the DoltliteCommit is freed immediately after. */
+
+
 static int blameAssign(
   BlameRow *pRow,
   const ProllyHash *pCommitHash,
@@ -377,9 +377,9 @@ static int blameAssign(
   return SQLITE_OK;
 }
 
-/* Compare each unblamed row against its value in pRefRoot (parent
-** or merge base) and blame the row to pCommitHash if different.
-** pRefRoot may be NULL/empty to indicate "row not present in ref". */
+
+
+
 static int blameCompareAgainstRef(
   sqlite3 *db,
   BlameCursor *pCur,
@@ -429,10 +429,10 @@ static int blameUnresolvedCount(BlameCursor *pCur){
   return pCur->nUnresolved;
 }
 
-/* For merge blame we need the merge base across every parent, not just
-** the first two. Fold pairwise merge-base resolution left-to-right:
-** base(p0,p1,p2) := base(base(p0,p1), p2). If any step has no common
-** ancestor, the merge has no shared base across all parents. */
+
+
+
+
 static int blameFindAllParentMergeBase(
   sqlite3 *db,
   const DoltliteCommit *pCommit,
@@ -470,8 +470,8 @@ static int blameFindAllParentMergeBase(
   return SQLITE_OK;
 }
 
-/* Main blame walk. Starts from HEAD, walks first-parent, and at
-** each commit applies the linear or merge comparison rule. */
+
+
 static int blameWalk(
   BlameCursor *pCur,
   sqlite3 *db,
@@ -502,7 +502,7 @@ static int blameWalk(
     }
 
     if( doltliteCommitParentCount(&commit) >= 2 ){
-      /* Merge commit: compare against the merge base of all parents. */
+
       ProllyHash baseHash;
       DoltliteCommit baseCommit;
       memset(&baseHash, 0, sizeof(baseHash));
@@ -527,8 +527,8 @@ static int blameWalk(
           return rc;
         }
       }else if( haveCurTable ){
-        /* No merge base (disjoint histories): any live row here is
-        ** blamed to this merge. */
+
+
         rc = blameCompareAgainstRef(db, pCur, zTableName,
                                     &curTableRoot, curFlags,
                                     0, &walk, &commit);
@@ -538,7 +538,7 @@ static int blameWalk(
         }
       }
     }else{
-      /* Linear commit: compare against first parent's table. */
+
       const ProllyHash *pParent = doltliteCommitParentHash(&commit, 0);
       if( pParent && !prollyHashIsEmpty(pParent) ){
         DoltliteCommit parentCommit;
@@ -556,8 +556,8 @@ static int blameWalk(
           return rc;
         }
       }else if( haveCurTable ){
-        /* Root commit: any unblamed row that exists here is blamed
-        ** to the root. */
+
+
         rc = blameCompareAgainstRef(db, pCur, zTableName,
                                     &curTableRoot, curFlags,
                                     0, &walk, &commit);
@@ -568,7 +568,7 @@ static int blameWalk(
       }
     }
 
-    /* Advance first-parent. */
+
     {
       const ProllyHash *pParent = doltliteCommitParentHash(&commit, 0);
       if( pParent && !prollyHashIsEmpty(pParent) ){
@@ -745,17 +745,17 @@ static int bmColumn(sqlite3_vtab_cursor *pCursor,
   if( iCol < nPk ){
     int cid = v->aPkColIdx[iCol];
     if( cid == v->intPkCid ){
-      /* Rowid-alias INTEGER PK — value is the cursor's intKey, not
-      ** a record field. */
+
+
       sqlite3_result_int64(ctx, r->intKey);
     }else if( r->pCurVal && r->nCurVal>0 ){
       DoltliteRecordInfo ri;
-      /* Non-rowid PK tables are auto-converted to WITHOUT ROWID in
-      ** build.c, so records store the PK columns first in PRIMARY KEY
-      ** declaration order. aPkColIdx is sorted by pkPos, so iCol is
-      ** exactly the PK col's record-field index regardless of its
-      ** declared cid. (Blame projects only PK cols so non-PK record
-      ** fields never come into play here.) */
+
+
+
+
+
+
       doltliteParseRecord(r->pCurVal, r->nCurVal, &ri);
       if( iCol < ri.nField ){
         doltliteResultField(ctx, r->pCurVal, r->nCurVal,

--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -308,7 +308,6 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
   if( !cs ){ branchError(ctx, hadSavepoint, "no database"); return; }
   if( argc<1 ){ branchError(ctx, hadSavepoint, "dolt_branch requires arguments"); return; }
 
-
   for(i=0; i<argc; i++){
     const char *arg = (const char*)sqlite3_value_text(argv[i]);
     if( !arg ) continue;
@@ -371,12 +370,6 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
         branchError(ctx, hadSavepoint, "cannot delete the current branch");
         return;
       }
-
-
-
-
-
-
       if( strcmp(aPositional[0], "main")==0 ){
         branchError(ctx, hadSavepoint,
           "cannot delete branch 'main' (doltlite requires main to exist)");
@@ -451,9 +444,6 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
       memset(&m, 0, sizeof(m));
       m.zSrc = aPositional[0];
       m.zDest = aPositional[1];
-
-
-
       if( strcmp(m.zSrc, "main")==0 ){
         branchError(ctx, hadSavepoint,
           "cannot rename branch 'main' (doltlite requires main to exist)");
@@ -534,7 +524,6 @@ static int checkoutLoadAndApply(
   int rc;
   ProllyHash committedCatHash;
 
-
   {
     DoltliteCommit commit;
 
@@ -544,7 +533,6 @@ static int checkoutLoadAndApply(
     memcpy(&committedCatHash, &commit.catalogHash, sizeof(ProllyHash));
     doltliteCommitClear(&commit);
   }
-
 
   {
     ProllyHash wsCatHash, wsCommitHash;
@@ -581,11 +569,6 @@ static int refreshBranchScopedTables(sqlite3 *db){
   if( rc!=SQLITE_OK ) return rc;
   return doltliteRegisterBlameTables(db);
 }
-
-
-
-
-
 
 typedef struct CheckoutMutationCtx CheckoutMutationCtx;
 struct CheckoutMutationCtx {
@@ -874,11 +857,6 @@ int doltliteCheckoutBranchForRebase(sqlite3 *db, const char *zBranch){
   return rc;
 }
 
-
-
-
-
-
 static int doltliteCheckoutTables(
   sqlite3 *db,
   const char *zSourceRef,
@@ -898,7 +876,6 @@ static int doltliteCheckoutTables(
 
   if( !cs ) return SQLITE_ERROR;
   if( nNames<=0 ) return SQLITE_NOTFOUND;
-
 
   if( zSourceRef ){
     ProllyHash sourceCommit;
@@ -923,7 +900,6 @@ static int doltliteCheckoutTables(
       return SQLITE_NOTFOUND;
     }
   }
-
 
   rc = doltliteLoadCatalog(db, &sourceCatHash, &aSource, &nSource, 0);
   if( rc!=SQLITE_OK ) return rc;
@@ -1022,7 +998,6 @@ static int doltliteCheckoutTables(
     return rc;
   }
 
-
   for(i=0; i<nNames; i++){
     const char *zName = (const char*)sqlite3_value_text(argv[iFirstName + i]);
     int srcIdx = -1, workIdx = -1;
@@ -1100,7 +1075,6 @@ static int doltliteCheckoutTables(
     }
   }
 
-
   {
     u8 *buf = 0;
     int nBuf = 0;
@@ -1145,7 +1119,6 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
   memset(&m, 0, sizeof(m));
   memset(&branchCreate, 0, sizeof(branchCreate));
 
-
   {
     u8 isMerging = 0;
     doltliteGetSessionMergeState(db, &isMerging, 0, 0);
@@ -1155,7 +1128,6 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
       return;
     }
   }
-
 
   if( strcmp(zBranch, "-b")==0 ){
     if( argc<2 ){ (void)doltliteVcSealSavepointError(db); sqlite3_result_error(ctx, "branch name required after -b", -1); return; }
@@ -1232,7 +1204,6 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
     sqlite3_result_int(ctx, 0);
     return;
   }
-
 
   {
     u8 *oldCatData = 0; int nOldCat = 0;
@@ -1471,7 +1442,6 @@ static int brColumn(sqlite3_vtab_cursor *c, sqlite3_context *ctx, int col){
       return SQLITE_OK;
     }
   }
-
 
   {
     DoltliteCommit cm;

--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -606,6 +606,8 @@ struct CheckoutMutationCtx {
   const char *zSavedRebaseOrigBranch;
   const char *zSavedRebaseReturnBranch;
   int haveOldState;
+  /* Top-level branch connection checkout must persist even though SQLite has
+  ** a savepoint frame; ordinary nested savepoint checkout remains rollbackable. */
   int bPersistUnderSavepoint;
 };
 

--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -371,12 +371,12 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
         branchError(ctx, hadSavepoint, "cannot delete the current branch");
         return;
       }
-      /* Short-term guard: doltlite does not yet have stable default-branch
-      ** resolution, so on reopen p->zBranch initializes from the last-active
-      ** branch (tracked via chunkStoreGetDefaultBranch, which dolt_checkout
-      ** updates). If "main" is deleted, opening the DB would leave the
-      ** session pointing at a nonexistent branch. Reject until we have real
-      ** default-branch logic. */
+
+
+
+
+
+
       if( strcmp(aPositional[0], "main")==0 ){
         branchError(ctx, hadSavepoint,
           "cannot delete branch 'main' (doltlite requires main to exist)");
@@ -451,9 +451,9 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
       memset(&m, 0, sizeof(m));
       m.zSrc = aPositional[0];
       m.zDest = aPositional[1];
-      /* Same guard as MODE_DELETE: renaming "main" away would leave the
-      ** repo with no main branch, and reopening would fail to resolve a
-      ** session branch. Reject until default-branch logic is reworked. */
+
+
+
       if( strcmp(m.zSrc, "main")==0 ){
         branchError(ctx, hadSavepoint,
           "cannot rename branch 'main' (doltlite requires main to exist)");
@@ -582,11 +582,11 @@ static int refreshBranchScopedTables(sqlite3 *db){
   return doltliteRegisterBlameTables(db);
 }
 
-/* Checkout is a multi-step mutation: persist outgoing branch state,
-** update refs, load target branch, reload session. If any step fails
-** we must unwind every prior step — the saved* fields are the
-** snapshot of session state taken before the mutation begins so
-** checkoutRestoreSession can roll back cleanly. */
+
+
+
+
+
 typedef struct CheckoutMutationCtx CheckoutMutationCtx;
 struct CheckoutMutationCtx {
   const char *zTargetBranch;
@@ -872,11 +872,11 @@ int doltliteCheckoutBranchForRebase(sqlite3 *db, const char *zBranch){
   return rc;
 }
 
-/* `dolt_checkout <table>...` path. Reached as a fallthrough when the
-** first argument doesn't resolve to a branch — in Dolt, checkout
-** overloads "branch name" and "table name". Copies the named tables
-** from the staged catalog (or HEAD if nothing is staged) into the
-** working catalog, mirroring Dolt's reset-a-single-table semantics. */
+
+
+
+
+
 static int doltliteCheckoutTables(
   sqlite3 *db,
   const char *zSourceRef,

--- a/src/doltlite_chunk_walk.c
+++ b/src/doltlite_chunk_walk.c
@@ -27,13 +27,13 @@ static int parseCurrentCatalogHeader(
   return 1;
 }
 
-/* Classify a chunk by sniffing its first few bytes. Order of checks
-** matters: PROLLY_NODE_MAGIC is a 4-byte constant that can't collide
-** with any version tag, so it goes first. WORKING_SET is a fixed
-** length so the size check excludes collisions with small catalogs.
-** CATALOG uses a single-byte version tag, COMMIT uses DOLTLITE_COMMIT_V2.
-** Used by GC chunk reachability traversal — unknown chunks are
-** dropped, so a missing case here can silently corrupt the store. */
+
+
+
+
+
+
+
 DoltliteChunkType doltliteClassifyChunk(const u8 *data, int nData){
   u32 m;
 

--- a/src/doltlite_chunk_walk.c
+++ b/src/doltlite_chunk_walk.c
@@ -27,18 +27,10 @@ static int parseCurrentCatalogHeader(
   return 1;
 }
 
-
-
-
-
-
-
-
 DoltliteChunkType doltliteClassifyChunk(const u8 *data, int nData){
   u32 m;
 
   if( !data || nData < 4 ) return CHUNK_UNKNOWN;
-
 
   m = (u32)data[0] | ((u32)data[1]<<8) |
       ((u32)data[2]<<16) | ((u32)data[3]<<24);
@@ -46,11 +38,9 @@ DoltliteChunkType doltliteClassifyChunk(const u8 *data, int nData){
     return CHUNK_PROLLY_NODE;
   }
 
-
   if( nData == WS_TOTAL_SIZE && data[0] == WS_FORMAT_VERSION ){
     return CHUNK_WORKING_SET;
   }
-
 
   {
     int nTables; const u8 *pEntries; int iFormat;
@@ -59,11 +49,9 @@ DoltliteChunkType doltliteClassifyChunk(const u8 *data, int nData){
     }
   }
 
-
   if( nData >= 30 && data[0] == DOLTLITE_COMMIT_V2 ){
     return CHUNK_COMMIT;
   }
-
 
   if( nData >= 5 && data[0] == 6 ){
     return CHUNK_REFS;
@@ -179,26 +167,21 @@ static int enumerateWorkingSetChildren(
 
   (void)nData;
 
-
   memcpy(h.data, data + WS_WORKING_CAT_OFF, PROLLY_HASH_SIZE);
   rc = xChild(ctx, &h);
   if( rc!=SQLITE_OK ) return rc;
-
 
   memcpy(h.data, data + WS_WORKING_COMMIT_OFF, PROLLY_HASH_SIZE);
   rc = xChild(ctx, &h);
   if( rc!=SQLITE_OK ) return rc;
 
-
   memcpy(h.data, data + WS_STAGED_OFF, PROLLY_HASH_SIZE);
   rc = xChild(ctx, &h);
   if( rc!=SQLITE_OK ) return rc;
 
-
   memcpy(h.data, data + WS_CONFLICTS_OFF, PROLLY_HASH_SIZE);
   rc = xChild(ctx, &h);
   if( rc!=SQLITE_OK ) return rc;
-
 
   if( data[WS_MERGING_OFF] ){
     memcpy(h.data, data + WS_MERGE_COMMIT_OFF, PROLLY_HASH_SIZE);

--- a/src/doltlite_commit.c
+++ b/src/doltlite_commit.c
@@ -14,17 +14,17 @@
   (u64)(p)[0] | ((u64)(p)[1]<<8) | ((u64)(p)[2]<<16) | ((u64)(p)[3]<<24) | \
   ((u64)(p)[4]<<32) | ((u64)(p)[5]<<40) | ((u64)(p)[6]<<48) | ((u64)(p)[7]<<56)))
 
-/* Commit v2 wire format, little-endian:
-**   [version:1][nParents:1]
-**   [parent_hash:20]*nParents
-**   [catalog_hash:20]
-**   [timestamp:8]
-**   [name_len:2][name:N]
-**   [email_len:2][email:N]
-**   [msg_len:2][msg:N]
-** The hash is content-addressed, so any layout change re-hashes
-** every commit in the history. Chunk classifier keys on version
-** byte — do NOT reuse DOLTLITE_COMMIT_V2 for a new format. */
+
+
+
+
+
+
+
+
+
+
+
 int doltliteCommitSerialize(const DoltliteCommit *c, u8 **ppOut, int *pnOut){
   int nName = c->zName ? (int)strlen(c->zName) : 0;
   int nEmail = c->zEmail ? (int)strlen(c->zEmail) : 0;

--- a/src/doltlite_commit.c
+++ b/src/doltlite_commit.c
@@ -14,17 +14,6 @@
   (u64)(p)[0] | ((u64)(p)[1]<<8) | ((u64)(p)[2]<<16) | ((u64)(p)[3]<<24) | \
   ((u64)(p)[4]<<32) | ((u64)(p)[5]<<40) | ((u64)(p)[6]<<48) | ((u64)(p)[7]<<56)))
 
-
-
-
-
-
-
-
-
-
-
-
 int doltliteCommitSerialize(const DoltliteCommit *c, u8 **ppOut, int *pnOut){
   int nName = c->zName ? (int)strlen(c->zName) : 0;
   int nEmail = c->zEmail ? (int)strlen(c->zEmail) : 0;
@@ -48,9 +37,7 @@ int doltliteCommitSerialize(const DoltliteCommit *c, u8 **ppOut, int *pnOut){
   if( !buf ) return SQLITE_NOMEM;
   p = buf;
 
-
   *p++ = DOLTLITE_COMMIT_V2;
-
 
   *p++ = (u8)nPar;
   if( nPar > 0 && c->nParents > 0 ){
@@ -64,20 +51,15 @@ int doltliteCommitSerialize(const DoltliteCommit *c, u8 **ppOut, int *pnOut){
     p += PROLLY_HASH_SIZE;
   }
 
-
   memcpy(p, c->catalogHash.data, PROLLY_HASH_SIZE); p += PROLLY_HASH_SIZE;
 
-
   DLC_PUT_I64(p, c->timestamp); p += 8;
-
 
   DLC_PUT_U16(p, (u16)nName); p += 2;
   if( nName>0 ){ memcpy(p, c->zName, nName); p += nName; }
 
-
   DLC_PUT_U16(p, (u16)nEmail); p += 2;
   if( nEmail>0 ){ memcpy(p, c->zEmail, nEmail); p += nEmail; }
-
 
   DLC_PUT_U16(p, (u16)nMsg); p += 2;
   if( nMsg>0 ){ memcpy(p, c->zMessage, nMsg); p += nMsg; }
@@ -119,9 +101,7 @@ int doltliteCommitDeserialize(const u8 *data, int nData, DoltliteCommit *c){
     memcpy(c->catalogHash.data, p, PROLLY_HASH_SIZE); p += PROLLY_HASH_SIZE;
   }
 
-
   c->timestamp = DLC_GET_I64(p); p += 8;
-
 
   nName = DLC_GET_U16(p); p += 2;
   if( p + nName > data + nData ) return SQLITE_CORRUPT;
@@ -131,7 +111,6 @@ int doltliteCommitDeserialize(const u8 *data, int nData, DoltliteCommit *c){
   c->zName[nName] = 0;
   p += nName;
 
-
   nEmail = DLC_GET_U16(p); p += 2;
   if( p + nEmail > data + nData ){ doltliteCommitClear(c); return SQLITE_CORRUPT; }
   c->zEmail = sqlite3_malloc(nEmail + 1);
@@ -139,7 +118,6 @@ int doltliteCommitDeserialize(const u8 *data, int nData, DoltliteCommit *c){
   if( nEmail>0 ) memcpy(c->zEmail, p, nEmail);
   c->zEmail[nEmail] = 0;
   p += nEmail;
-
 
   nMsg = DLC_GET_U16(p); p += 2;
   if( p + nMsg > data + nData ){ doltliteCommitClear(c); return SQLITE_CORRUPT; }

--- a/src/doltlite_commit.h
+++ b/src/doltlite_commit.h
@@ -16,6 +16,8 @@
 
 typedef struct DoltliteCommit DoltliteCommit;
 struct DoltliteCommit {
+  /* parentHash is the single-parent compatibility field. New commits use
+  ** aParents/nParents so merge commits can address multiple parents. */
   ProllyHash parentHash;
   ProllyHash catalogHash;
   i64 timestamp;

--- a/src/doltlite_commit.h
+++ b/src/doltlite_commit.h
@@ -9,11 +9,11 @@
 
 #define DOLTLITE_MAX_PARENTS 8
 
-/* parentHash is a legacy V1 single-parent field still populated by
-** deserialize so older call sites keep working. nParents/aParents is
-** the canonical multi-parent list (merge commits have two). Accessors
-** below prefer aParents and fall back to parentHash when aParents is
-** empty — never access either field directly. */
+
+
+
+
+
 typedef struct DoltliteCommit DoltliteCommit;
 struct DoltliteCommit {
   ProllyHash parentHash;

--- a/src/doltlite_commit.h
+++ b/src/doltlite_commit.h
@@ -9,11 +9,6 @@
 
 #define DOLTLITE_MAX_PARENTS 8
 
-
-
-
-
-
 typedef struct DoltliteCommit DoltliteCommit;
 struct DoltliteCommit {
   /* parentHash is the single-parent compatibility field. New commits use

--- a/src/doltlite_commit_ancestors.c
+++ b/src/doltlite_commit_ancestors.c
@@ -10,22 +10,6 @@
 #include "doltlite_internal.h"
 #include <string.h>
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 typedef struct CommitAncestorsVtab CommitAncestorsVtab;
 struct CommitAncestorsVtab {
   sqlite3_vtab base;
@@ -35,12 +19,10 @@ struct CommitAncestorsVtab {
 typedef struct CommitAncestorsCursor CommitAncestorsCursor;
 struct CommitAncestorsCursor {
   sqlite3_vtab_cursor base;
-
   ProllyHash *aQueue;
   int qHead, qTail, qAlloc;
   ProllyHashSet visited;
   int visitedInit;
-
   ProllyHash curHash;
   char zCurHex[PROLLY_HASH_SIZE*2+1];
   DoltliteCommit curCommit;
@@ -116,8 +98,6 @@ static int caClose(sqlite3_vtab_cursor *pCursor){
   return SQLITE_OK;
 }
 
-
-
 static int caLoadNextCommit(CommitAncestorsCursor *pCur, sqlite3 *db){
   int i, rc;
 
@@ -141,11 +121,8 @@ static int caLoadNextCommit(CommitAncestorsCursor *pCur, sqlite3 *db){
     doltliteHashToHex(&cur, pCur->zCurHex);
     pCur->hasRow = 1;
     pCur->curParents = doltliteCommitParentCount(&pCur->curCommit);
-
-
     if( pCur->curParents == 0 ) pCur->curParents = 1;
     pCur->curParentIdx = 0;
-
 
     for(i = 0; i < doltliteCommitParentCount(&pCur->curCommit); i++){
       const ProllyHash *pParent = doltliteCommitParentHash(&pCur->curCommit, i);
@@ -171,13 +148,10 @@ static int caNext(sqlite3_vtab_cursor *pCursor){
   pCur->iRowid++;
   pCur->curParentIdx++;
   if( pCur->curParentIdx >= pCur->curParents ){
-
     return caLoadNextCommit(pCur, pVtab->db);
   }
   return SQLITE_OK;
 }
-
-
 
 static int caEnqueue(CommitAncestorsCursor *pCur, const ProllyHash *p){
   if( prollyHashIsEmpty(p) ) return SQLITE_OK;
@@ -214,10 +188,6 @@ static int caFilter(
   rc = prollyHashSetInit(&pCur->visited, 64);
   if( rc!=SQLITE_OK ) return rc;
   pCur->visitedInit = 1;
-
-
-
-
 
   doltliteGetSessionHead(pVtab->db, &head);
   rc = caEnqueue(pCur, &head);
@@ -260,7 +230,6 @@ static int caColumn(
     case 1: {
       int realParents = doltliteCommitParentCount(c);
       if( realParents == 0 ){
-
         sqlite3_result_null(ctx);
       }else if( idx < realParents ){
         const ProllyHash *pParent = doltliteCommitParentHash(c, idx);

--- a/src/doltlite_commit_ancestors.c
+++ b/src/doltlite_commit_ancestors.c
@@ -10,21 +10,21 @@
 #include "doltlite_internal.h"
 #include <string.h>
 
-/* dolt_commit_ancestors: parent-graph view, one row per (commit,
-** parent) edge plus one row per root commit with NULL parent.
-**
-** Mirrors Dolt's table of the same name:
-**   commit_hash  TEXT     — a commit reachable from HEAD
-**   parent_hash  TEXT     — one of its parents (NULL for the root)
-**   parent_index INTEGER  — 0-based position of the parent in this
-**                            commit's parent list (0 for root)
-**
-** This is the shape consumers want for traversing the commit graph
-** by edges instead of trying to derive ordering from dolt_log.date,
-** which is second-resolution and breaks on tight script timing —
-** see issue dolthub/doltlite#740. With this view a walker can
-** start from HEAD and follow parent_hash deterministically.
-*/
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 typedef struct CommitAncestorsVtab CommitAncestorsVtab;
 struct CommitAncestorsVtab {
@@ -35,17 +35,17 @@ struct CommitAncestorsVtab {
 typedef struct CommitAncestorsCursor CommitAncestorsCursor;
 struct CommitAncestorsCursor {
   sqlite3_vtab_cursor base;
-  /* BFS queue of unvisited commits */
+
   ProllyHash *aQueue;
   int qHead, qTail, qAlloc;
   ProllyHashSet visited;
   int visitedInit;
-  /* Currently-loaded commit + which parent we're emitting */
+
   ProllyHash curHash;
   char zCurHex[PROLLY_HASH_SIZE*2+1];
   DoltliteCommit curCommit;
-  int curParents;     /* >=1; 1 for root (synthetic NULL parent row) */
-  int curParentIdx;   /* 0..curParents-1 */
+  int curParents;
+  int curParentIdx;
   int hasRow;
   i64 iRowid;
 };
@@ -116,8 +116,8 @@ static int caClose(sqlite3_vtab_cursor *pCursor){
   return SQLITE_OK;
 }
 
-/* Pull the next unvisited commit off the queue, load it, set up the
-** parent-emit window. hasRow=1 on success, 0 when graph exhausted. */
+
+
 static int caLoadNextCommit(CommitAncestorsCursor *pCur, sqlite3 *db){
   int i, rc;
 
@@ -141,12 +141,12 @@ static int caLoadNextCommit(CommitAncestorsCursor *pCur, sqlite3 *db){
     doltliteHashToHex(&cur, pCur->zCurHex);
     pCur->hasRow = 1;
     pCur->curParents = doltliteCommitParentCount(&pCur->curCommit);
-    /* Root commit: emit one row with NULL parent_hash so consumers
-    ** can detect graph anchors. Otherwise emit one row per parent. */
+
+
     if( pCur->curParents == 0 ) pCur->curParents = 1;
     pCur->curParentIdx = 0;
 
-    /* Enqueue real parents for later visits. */
+
     for(i = 0; i < doltliteCommitParentCount(&pCur->curCommit); i++){
       const ProllyHash *pParent = doltliteCommitParentHash(&pCur->curCommit, i);
       if( !pParent || prollyHashIsEmpty(pParent) ) continue;
@@ -171,14 +171,14 @@ static int caNext(sqlite3_vtab_cursor *pCursor){
   pCur->iRowid++;
   pCur->curParentIdx++;
   if( pCur->curParentIdx >= pCur->curParents ){
-    /* Done with this commit's parents; pull the next commit. */
+
     return caLoadNextCommit(pCur, pVtab->db);
   }
   return SQLITE_OK;
 }
 
-/* Push a commit hash onto the BFS queue, growing the queue if
-** needed. Skips empty hashes. */
+
+
 static int caEnqueue(CommitAncestorsCursor *pCur, const ProllyHash *p){
   if( prollyHashIsEmpty(p) ) return SQLITE_OK;
   if( pCur->qTail >= pCur->qAlloc ){
@@ -215,10 +215,10 @@ static int caFilter(
   if( rc!=SQLITE_OK ) return rc;
   pCur->visitedInit = 1;
 
-  /* Seed the BFS from EVERY ref tip — branches, tags, and the
-  ** session HEAD — so the table exposes the full repo graph,
-  ** matching Dolt's dolt_commit_ancestors semantics. The visited
-  ** set deduplicates shared ancestors. */
+
+
+
+
   doltliteGetSessionHead(pVtab->db, &head);
   rc = caEnqueue(pCur, &head);
   if( rc!=SQLITE_OK ) return rc;
@@ -260,7 +260,7 @@ static int caColumn(
     case 1: {
       int realParents = doltliteCommitParentCount(c);
       if( realParents == 0 ){
-        /* Root commit: NULL parent. */
+
         sqlite3_result_null(ctx);
       }else if( idx < realParents ){
         const ProllyHash *pParent = doltliteCommitParentHash(c, idx);

--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -480,7 +480,6 @@ static int cfrFilter(sqlite3_vtab_cursor *cur, int n, const char *s, int a, sqli
   rc = loadAllConflicts(vt->db, doltliteGetChunkStore(vt->db), &c->aTables, &c->nTables);
   if( rc!=SQLITE_OK ) return rc;
 
-
   for(i=0; i<c->nTables; i++){
     if( c->aTables[i].zName && strcmp(c->aTables[i].zName, vt->zTableName)==0 ){
       c->iTableIdx = i;
@@ -501,10 +500,6 @@ static int cfrEof(sqlite3_vtab_cursor *cur){
   return c->iRow >= c->aTables[c->iTableIdx].nConflicts;
 }
 
-
-
-
-
 static void cfrEmitRecordCol(
   sqlite3_context *ctx,
   const u8 *pRec, int nRec,
@@ -523,10 +518,6 @@ static const char *cfrDiffType(const u8 *pBase, int nBase,
   if( !baseHas ) return "added";
   return "modified";
 }
-
-
-
-
 
 static sqlite3_int64 cfrConflictRowid(const struct ConflictRow *cr){
   if( cr->nKey>0 && cr->pKey ){
@@ -553,7 +544,6 @@ static int cfrColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
   if( c->iTableIdx < 0 ) return SQLITE_OK;
   if( c->iRow >= c->aTables[c->iTableIdx].nConflicts ) return SQLITE_OK;
   cr = &c->aTables[c->iTableIdx].aRows[c->iRow];
-
 
   nUserCols = v->cols.nCol;
   colBaseStart  = 1;
@@ -625,7 +615,6 @@ static int cfrUpdate(
 
   (void)pRowid;
 
-
   if( nArg != 1 ){
     pVtab->zErrMsg = sqlite3_mprintf("only DELETE is supported on conflict tables");
     return SQLITE_ERROR;
@@ -633,10 +622,8 @@ static int cfrUpdate(
 
   deleteRowid = sqlite3_value_int64(apArg[0]);
 
-
   rc = loadAllConflicts(v->db, cs, &aTables, &nTables);
   if( rc!=SQLITE_OK ) return rc;
-
 
   for(i=0; i<nTables; i++){
     if( !aTables[i].zName || strcmp(aTables[i].zName, v->zTableName)!=0 )
@@ -646,11 +633,9 @@ static int cfrUpdate(
       if( cfrConflictRowid(&aTables[i].aRows[j]) == deleteRowid ){
         removeConflictRow(&aTables[i], j);
 
-
         if( aTables[i].nConflicts == 0 ){
           removeConflictTable(aTables, &nTables, i);
         }
-
 
         rc = storeUpdatedConflicts(v->db, cs, aTables, nTables);
         freeConflictTables(aTables, nTables);
@@ -739,11 +724,6 @@ static void conflictsResolveFunc(sqlite3_context *ctx, int argc, sqlite3_value *
     return;
   }
 
-
-
-
-
-
   if( strcmp(zMode,"--ours")==0 ){
 
     for(i=0; i<nTables; i++){
@@ -785,7 +765,6 @@ static void conflictsResolveFunc(sqlite3_context *ctx, int argc, sqlite3_value *
     for(i=0; i<nTables; i++){
       if( !aTables[i].zName || strcmp(aTables[i].zName, zTable)!=0 ) continue;
       found = 1;
-
 
       for(j=0; j<aTables[i].nConflicts; j++){
         struct ConflictRow *cr = &aTables[i].aRows[j];

--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -501,10 +501,10 @@ static int cfrEof(sqlite3_vtab_cursor *cur){
   return c->iRow >= c->aTables[c->iTableIdx].nConflicts;
 }
 
-/* Thin wrapper around doltliteResultUserCol kept for call-site
-** readability — the cfr column projection has four call sites
-** (base, ours, theirs, and the diff-type bookkeeping) that all
-** want the same argument order. */
+
+
+
+
 static void cfrEmitRecordCol(
   sqlite3_context *ctx,
   const u8 *pRec, int nRec,
@@ -524,10 +524,10 @@ static const char *cfrDiffType(const u8 *pBase, int nBase,
   return "modified";
 }
 
-/* For row-wise DELETE on dolt_conflicts_<table>, the vtab rowid must uniquely
-** identify a conflict row even when the user PK is not SQLite's integer
-** rowid. Use the raw serialized prolly key when present; integer PK conflicts
-** continue to use intKey directly. */
+
+
+
+
 static sqlite3_int64 cfrConflictRowid(const struct ConflictRow *cr){
   if( cr->nKey>0 && cr->pKey ){
     u64 h = 1469598103934665603ULL;
@@ -739,11 +739,11 @@ static void conflictsResolveFunc(sqlite3_context *ctx, int argc, sqlite3_value *
     return;
   }
 
-  /* --ours vs --theirs are asymmetric: "ours" is already in the
-  ** working set (the merge left our side intact and logged theirs in
-  ** the conflict entry), so we just drop the conflict table. "theirs"
-  ** below has to apply each entry's theirVal as a real row mutation
-  ** before dropping, otherwise the working set still has our value. */
+
+
+
+
+
   if( strcmp(zMode,"--ours")==0 ){
 
     for(i=0; i<nTables; i++){

--- a/src/doltlite_constraint_violations.c
+++ b/src/doltlite_constraint_violations.c
@@ -10,12 +10,12 @@
 
 #include <string.h>
 
-/* In-memory view of a single violation row. Mirrors the shape of
-** a ConflictRow but without the base/our/their distinction —
-** violations come from ONE side of the merge or from a post-merge
-** walk, so there's a single value payload. violation_type picks
-** the namespace (FK / unique / check) and violation_info is a
-** free-form JSON string describing the specific constraint. */
+
+
+
+
+
+
 static void freeViolationRow(ConstraintViolationRow *r){
   if( !r ) return;
   sqlite3_free(r->pKey);
@@ -127,9 +127,9 @@ static int serializeViolations(
     for(j=0; j<aTables[i].nRows; j++){
       int ni = aTables[i].aRows[j].zInfo
              ? (int)strlen(aTables[i].aRows[j].zInfo) : 0;
-      sz += 1          /* violation_type */
+      sz += 1
           + 4 + aTables[i].aRows[j].nKey
-          + 8          /* intKey */
+          + 8
           + 4 + aTables[i].aRows[j].nVal
           + 4 + ni;
     }
@@ -319,9 +319,9 @@ static int storeUpdatedViolations(
   return doltliteSaveWorkingSet(db);
 }
 
-/* Public append API — used by the post-merge walk (Phase 4) to
-** record each detected violation. Copies the caller's bytes so
-** the caller can release its own buffers immediately. */
+
+
+
 int doltliteAppendConstraintViolation(
   sqlite3 *db,
   const char *zTable,
@@ -384,7 +384,7 @@ int doltliteClearAllConstraintViolations(sqlite3 *db){
   return doltliteSaveWorkingSet(db);
 }
 
-/* ── Summary vtable: dolt_constraint_violations ──────────── */
+
 
 typedef struct CvSumVtab CvSumVtab;
 struct CvSumVtab { sqlite3_vtab base; sqlite3 *db; };
@@ -430,9 +430,9 @@ static int cvsFilter(sqlite3_vtab_cursor *cur, int n, const char *s, int a, sqli
   CvSumCur *c = (CvSumCur*)cur;
   CvSumVtab *vt = (CvSumVtab*)cur->pVtab;
   (void)n;(void)s;(void)a;(void)v;
-  /* SQLite may call xFilter more than once per cursor (join rescan,
-  ** re-entry). Drop any tables loaded by the prior call before
-  ** reloading, otherwise we leak them. */
+
+
+
   freeViolationTables(c->aTables, c->nTables);
   c->aTables = 0;
   c->nTables = 0;
@@ -473,7 +473,7 @@ static sqlite3_module cvSummaryModule = {
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 };
 
-/* ── Per-table vtable: dolt_constraint_violations_<table> ─ */
+
 
 typedef struct CvRowVtab CvRowVtab;
 struct CvRowVtab {
@@ -492,16 +492,16 @@ struct CvRowCur {
   int iRow;
 };
 
-/* Per-table schema: violation_type TEXT, <user PK+value cols>,
-** violation_info TEXT. The user columns keep their original
-** declared names so (violation_type, pk, v1, v2, violation_info)
-** is the row shape. */
+
+
+
+
 static char *cvrBuildSchema(const DoltliteColInfo *ci){
   sqlite3_str *pStr = sqlite3_str_new(0);
   int i;
   char *z;
-  /* sqlite3_str_new() never returns NULL; OOM propagates through
-  ** sqlite3_str_finish() which returns NULL on failure. */
+
+
   sqlite3_str_appendall(pStr, "CREATE TABLE x(violation_type TEXT");
   for(i=0; i<ci->nCol; i++){
     sqlite3_str_appendf(pStr, ", \"%w\"", ci->azName[i]);
@@ -656,13 +656,13 @@ static int cvrColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
   return SQLITE_OK;
 }
 
-/* Per-row DELETE on dolt_constraint_violations_<table> needs a stable unique
-** rowid even when:
-**   1) the user PK is not SQLite's integer rowid, and/or
-**   2) one user row produces multiple violation rows.
-**
-** So the synthetic rowid must include both the offending row identity and
-** the specific violation identity. */
+
+
+
+
+
+
+
 static sqlite3_int64 cvrViolationRowid(const ConstraintViolationRow *r){
   u64 h = 1469598103934665603ULL;
   int i;
@@ -709,10 +709,10 @@ static int cvrBestIndex(sqlite3_vtab *v, sqlite3_index_info *p){
   return SQLITE_OK;
 }
 
-/* DELETE support: user clears a violation from the per-table
-** vtable to signal "I've resolved this". The synthetic rowid
-** includes both the offending row and the specific violation,
-** so compare against the same computed rowid here. */
+
+
+
+
 static int cvrUpdate(
   sqlite3_vtab *pVtab,
   int nArg,
@@ -776,14 +776,14 @@ static sqlite3_module cvRowModule = {
   0,0,0,0,0,0,0,0,0,0,0
 };
 
-/* Walk the session's user tables and register a
-** dolt_constraint_violations_<table> vtable for each one that
-** doesn't already have one. Safe to call repeatedly —
-** doltliteForEachUserTable skips tables whose module is
-** already registered. Exposed so the commit / checkout / merge
-** / reset flows can refresh the surface for tables created
-** mid-session, matching how the diff / history / at / blame
-** / conflicts vtables get refreshed. */
+
+
+
+
+
+
+
+
 int doltliteRefreshConstraintViolationTables(sqlite3 *db){
   return doltliteForEachUserTable(db, "dolt_constraint_violations_", &cvRowModule);
 }

--- a/src/doltlite_constraint_violations.c
+++ b/src/doltlite_constraint_violations.c
@@ -10,12 +10,6 @@
 
 #include <string.h>
 
-
-
-
-
-
-
 static void freeViolationRow(ConstraintViolationRow *r){
   if( !r ) return;
   sqlite3_free(r->pKey);
@@ -319,9 +313,6 @@ static int storeUpdatedViolations(
   return doltliteSaveWorkingSet(db);
 }
 
-
-
-
 int doltliteAppendConstraintViolation(
   sqlite3 *db,
   const char *zTable,
@@ -384,8 +375,6 @@ int doltliteClearAllConstraintViolations(sqlite3 *db){
   return doltliteSaveWorkingSet(db);
 }
 
-
-
 typedef struct CvSumVtab CvSumVtab;
 struct CvSumVtab { sqlite3_vtab base; sqlite3 *db; };
 typedef struct CvSumCur CvSumCur;
@@ -430,9 +419,6 @@ static int cvsFilter(sqlite3_vtab_cursor *cur, int n, const char *s, int a, sqli
   CvSumCur *c = (CvSumCur*)cur;
   CvSumVtab *vt = (CvSumVtab*)cur->pVtab;
   (void)n;(void)s;(void)a;(void)v;
-
-
-
   freeViolationTables(c->aTables, c->nTables);
   c->aTables = 0;
   c->nTables = 0;
@@ -473,8 +459,6 @@ static sqlite3_module cvSummaryModule = {
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 };
 
-
-
 typedef struct CvRowVtab CvRowVtab;
 struct CvRowVtab {
   sqlite3_vtab base;
@@ -492,16 +476,10 @@ struct CvRowCur {
   int iRow;
 };
 
-
-
-
-
 static char *cvrBuildSchema(const DoltliteColInfo *ci){
   sqlite3_str *pStr = sqlite3_str_new(0);
   int i;
   char *z;
-
-
   sqlite3_str_appendall(pStr, "CREATE TABLE x(violation_type TEXT");
   for(i=0; i<ci->nCol; i++){
     sqlite3_str_appendf(pStr, ", \"%w\"", ci->azName[i]);
@@ -656,13 +634,6 @@ static int cvrColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
   return SQLITE_OK;
 }
 
-
-
-
-
-
-
-
 static sqlite3_int64 cvrViolationRowid(const ConstraintViolationRow *r){
   u64 h = 1469598103934665603ULL;
   int i;
@@ -708,10 +679,6 @@ static int cvrBestIndex(sqlite3_vtab *v, sqlite3_index_info *p){
   p->estimatedCost = 10;
   return SQLITE_OK;
 }
-
-
-
-
 
 static int cvrUpdate(
   sqlite3_vtab *pVtab,
@@ -775,14 +742,6 @@ static sqlite3_module cvRowModule = {
   cvrUpdate,
   0,0,0,0,0,0,0,0,0,0,0
 };
-
-
-
-
-
-
-
-
 
 int doltliteRefreshConstraintViolationTables(sqlite3 *db){
   return doltliteForEachUserTable(db, "dolt_constraint_violations_", &cvRowModule);

--- a/src/doltlite_constraint_violations.h
+++ b/src/doltlite_constraint_violations.h
@@ -4,22 +4,22 @@
 
 #include "sqliteInt.h"
 
-/* Violation type tags. Stored as a single byte in the blob
-** serialization so the set is append-only across versions. String
-** names exposed to SQL match Dolt's (lowercase) for oracle
-** compatibility. */
+
+
+
+
 #define DOLTLITE_CV_FOREIGN_KEY      1
 #define DOLTLITE_CV_UNIQUE_INDEX     2
 #define DOLTLITE_CV_CHECK_CONSTRAINT 3
 
-/* In-memory row. pKey/nKey is the original sqlite KEY payload
-** (empty for rowid-alias PKs, where intKey is authoritative).
-** pVal/nVal is the full record payload so the vtable column
-** reader can project user-declared columns via
-** doltliteResultUserCol. zInfo is a JSON string describing the
-** specific constraint (FK name, referenced table, columns,
-** expression, etc.) and gets exposed verbatim as the
-** violation_info column. */
+
+
+
+
+
+
+
+
 typedef struct ConstraintViolationRow ConstraintViolationRow;
 struct ConstraintViolationRow {
   u8 violationType;
@@ -36,11 +36,11 @@ struct ConstraintViolationTable {
   ConstraintViolationRow *aRows;
 };
 
-/* Append a single violation to the persistent blob for zTable.
-** Loads the current blob, inserts the row, rewrites the blob,
-** and re-persists the working set. Callers (merge walk / post-
-** merge scan) pass freshly-allocated byte buffers; this function
-** duplicates them. */
+
+
+
+
+
 int doltliteAppendConstraintViolation(
   sqlite3 *db,
   const char *zTable,
@@ -51,11 +51,11 @@ int doltliteAppendConstraintViolation(
   const char *zInfoJson
 );
 
-/* Wipe all violations. Used on merge abort / dolt_reset. */
+
 int doltliteClearAllConstraintViolations(sqlite3 *db);
 
-/* Register the summary + per-table vtable modules. Called from
-** doltliteRegister in doltlite.c. */
+
+
 int doltliteConstraintViolationsRegister(sqlite3 *db);
 
 #endif

--- a/src/doltlite_constraint_violations.h
+++ b/src/doltlite_constraint_violations.h
@@ -4,21 +4,9 @@
 
 #include "sqliteInt.h"
 
-
-
-
-
 #define DOLTLITE_CV_FOREIGN_KEY      1
 #define DOLTLITE_CV_UNIQUE_INDEX     2
 #define DOLTLITE_CV_CHECK_CONSTRAINT 3
-
-
-
-
-
-
-
-
 
 typedef struct ConstraintViolationRow ConstraintViolationRow;
 struct ConstraintViolationRow {
@@ -36,11 +24,6 @@ struct ConstraintViolationTable {
   ConstraintViolationRow *aRows;
 };
 
-
-
-
-
-
 int doltliteAppendConstraintViolation(
   sqlite3 *db,
   const char *zTable,
@@ -51,10 +34,7 @@ int doltliteAppendConstraintViolation(
   const char *zInfoJson
 );
 
-
 int doltliteClearAllConstraintViolations(sqlite3 *db);
-
-
 
 int doltliteConstraintViolationsRegister(sqlite3 *db);
 

--- a/src/doltlite_dbpage.c
+++ b/src/doltlite_dbpage.c
@@ -36,14 +36,6 @@ static void put4byteBE(unsigned char *p, unsigned int v){
   p[3] = (unsigned char)(v & 0xff);
 }
 
-
-
-
-
-
-
-
-
 static void synthesizeHeader(sqlite3 *db, unsigned char *aPage){
   ProllyHash headHash;
   ProllyHash catHash;
@@ -59,7 +51,6 @@ static void synthesizeHeader(sqlite3 *db, unsigned char *aPage){
 
   memset(aPage, 0, DOLTLITE_DBPAGE_PAGE_BYTES);
 
-
   memcpy(aHdr, "SQLite format 3", 16);
   put2byteBE(aHdr + 16, 4096);
   aHdr[18] = 1;
@@ -69,7 +60,6 @@ static void synthesizeHeader(sqlite3 *db, unsigned char *aPage){
   aHdr[22] = 32;
   aHdr[23] = 32;
 
-
   doltliteGetSessionHead(db, &headHash);
   if( !prollyHashIsEmpty(&headHash) ){
     for(i=0; i<4; i++){
@@ -77,7 +67,6 @@ static void synthesizeHeader(sqlite3 *db, unsigned char *aPage){
     }
   }
   put4byteBE(aHdr + 24, changeCounter);
-
 
   if( doltliteGetHeadCatalogHash(db, &catHash)==SQLITE_OK
    && !prollyHashIsEmpty(&catHash)
@@ -101,15 +90,11 @@ static void synthesizeHeader(sqlite3 *db, unsigned char *aPage){
 
   put4byteBE(aHdr + 28, pageCount);
 
-
   put4byteBE(aHdr + 40, schemaCookie);
   put4byteBE(aHdr + 44, 4);
 
   put4byteBE(aHdr + 52, largestRoot);
   put4byteBE(aHdr + 56, 1);
-
-
-
 
   put4byteBE(aHdr + 92, changeCounter);
   put4byteBE(aHdr + 96, SQLITE_VERSION_NUMBER);
@@ -195,7 +180,6 @@ static int dbpageFilter(sqlite3_vtab_cursor *pCursor,
 
   pCur->iRow = 0;
   pCur->hasRow = 0;
-
 
   if( idxNum & 1 ){
     sqlite3_int64 pgno = sqlite3_value_int64(argv[iArg++]);

--- a/src/doltlite_dbpage.c
+++ b/src/doltlite_dbpage.c
@@ -36,14 +36,14 @@ static void put4byteBE(unsigned char *p, unsigned int v){
   p[3] = (unsigned char)(v & 0xff);
 }
 
-/* sqlite_dbpage is normally a view into the real 4k-paged database
-** file, but doltlite's on-disk format is a chunk store — there ARE
-** no pages. Instead we fabricate a single synthetic page 1 that
-** looks enough like a SQLite header for tools that parse it
-** (shell .dbinfo, backup-utilities) to read meta without crashing.
-** Higher pgnos return EOF. Field values are derived from the
-** current HEAD: change_counter from the commit hash, schema_cookie
-** from the catalog hash, pageCount = user-table count. */
+
+
+
+
+
+
+
+
 static void synthesizeHeader(sqlite3 *db, unsigned char *aPage){
   ProllyHash headHash;
   ProllyHash catHash;

--- a/src/doltlite_diff.c
+++ b/src/doltlite_diff.c
@@ -109,18 +109,14 @@ struct DoltliteDiffVtab {
 typedef struct DoltliteDiffCursor DoltliteDiffCursor;
 struct DoltliteDiffCursor {
   sqlite3_vtab_cursor base;
-
   ProllyHash *aQueue;
   int qHead, qTail, qAlloc;
   ProllyHashSet visited, queued;
   int visitedInit, queuedInit;
-
   DiffSummaryRow *aBatch;
   int nBatch;
   int iBatch;
-
   char *zFilterTable;
-
   int phase;
   int hasRow;
   i64 iRowid;
@@ -198,7 +194,6 @@ static int batchAppend(DoltliteDiffCursor *pCur,
   return SQLITE_OK;
 }
 
-
 static int computeWorkingBatch(DoltliteDiffCursor *pCur, sqlite3 *db){
   ProllyHash headCat, workCat;
   struct TableEntry *aHead = 0, *aWork = 0;
@@ -273,7 +268,6 @@ done:
   doltliteFreeCatalog(aWork, nWork);
   return rc;
 }
-
 
 static int computeCommitBatch(DoltliteDiffCursor *pCur, sqlite3 *db,
                               const ProllyHash *pCommitHash,
@@ -351,20 +345,15 @@ done:
   return rc;
 }
 
-
-
 static int diffAdvance(DoltliteDiffCursor *pCur, sqlite3 *db){
   int rc;
-
 
   if( pCur->iBatch < pCur->nBatch ){
     pCur->hasRow = 1;
     return SQLITE_OK;
   }
 
-
   freeBatch(pCur);
-
 
   if( pCur->phase==0 ){
     pCur->phase = 1;
@@ -374,9 +363,7 @@ static int diffAdvance(DoltliteDiffCursor *pCur, sqlite3 *db){
       pCur->hasRow = 1;
       return SQLITE_OK;
     }
-
   }
-
 
   while( pCur->qHead < pCur->qTail ){
     ProllyHash cur = pCur->aQueue[pCur->qHead++];
@@ -398,7 +385,6 @@ static int diffAdvance(DoltliteDiffCursor *pCur, sqlite3 *db){
       doltliteCommitClear(&commit);
       return rc;
     }
-
 
     for(i=0; i<doltliteCommitParentCount(&commit); i++){
       const ProllyHash *pParent = doltliteCommitParentHash(&commit, i);
@@ -428,7 +414,6 @@ static int diffAdvance(DoltliteDiffCursor *pCur, sqlite3 *db){
       pCur->hasRow = 1;
       return SQLITE_OK;
     }
-
   }
 
   pCur->hasRow = 0;
@@ -530,7 +515,6 @@ static int diffFilter(sqlite3_vtab_cursor *pCursor,
 
   diffCursorReset(pCur);
 
-
   if( (idxNum & DIFF_IDX_TABLE_NAME) && argIdx<argc ){
     const char *z = (const char*)sqlite3_value_text(argv[argIdx++]);
     if( z ){
@@ -544,7 +528,6 @@ static int diffFilter(sqlite3_vtab_cursor *pCursor,
 
   doltliteGetSessionHead(db, &head);
   if( prollyHashIsEmpty(&head) ) return SQLITE_OK;
-
 
   rc = prollyHashSetInit(&pCur->visited, 64);
   if( rc!=SQLITE_OK ) return rc;
@@ -561,7 +544,6 @@ static int diffFilter(sqlite3_vtab_cursor *pCursor,
   pCur->qTail = 1;
   rc = prollyHashSetAdd(&pCur->queued, &head);
   if( rc!=SQLITE_OK ) return rc;
-
 
   pCur->phase = 0;
   return diffAdvance(pCur, db);

--- a/src/doltlite_diff.c
+++ b/src/doltlite_diff.c
@@ -109,18 +109,18 @@ struct DoltliteDiffVtab {
 typedef struct DoltliteDiffCursor DoltliteDiffCursor;
 struct DoltliteDiffCursor {
   sqlite3_vtab_cursor base;
-  /* BFS state for commit walk */
+
   ProllyHash *aQueue;
   int qHead, qTail, qAlloc;
   ProllyHashSet visited, queued;
   int visitedInit, queuedInit;
-  /* Per-commit summary rows (typically 1-5 per commit) */
+
   DiffSummaryRow *aBatch;
   int nBatch;
   int iBatch;
-  /* Table name filter (NULL = no filter) */
+
   char *zFilterTable;
-  /* Phase: 0=working set, 1=commit BFS */
+
   int phase;
   int hasRow;
   i64 iRowid;
@@ -198,7 +198,7 @@ static int batchAppend(DoltliteDiffCursor *pCur,
   return SQLITE_OK;
 }
 
-/* Compute summary rows for the working set (uncommitted changes). */
+
 static int computeWorkingBatch(DoltliteDiffCursor *pCur, sqlite3 *db){
   ProllyHash headCat, workCat;
   struct TableEntry *aHead = 0, *aWork = 0;
@@ -274,7 +274,7 @@ done:
   return rc;
 }
 
-/* Compute summary rows for a single commit (vs its first parent). */
+
 static int computeCommitBatch(DoltliteDiffCursor *pCur, sqlite3 *db,
                               const ProllyHash *pCommitHash,
                               const DoltliteCommit *pCommit,
@@ -351,21 +351,21 @@ done:
   return rc;
 }
 
-/* Advance the cursor to the next summary row. Moves through the
-** current batch, then advances BFS to the next commit. */
+
+
 static int diffAdvance(DoltliteDiffCursor *pCur, sqlite3 *db){
   int rc;
 
-  /* Try next row in current batch. */
+
   if( pCur->iBatch < pCur->nBatch ){
     pCur->hasRow = 1;
     return SQLITE_OK;
   }
 
-  /* Current batch exhausted — free and compute next. */
+
   freeBatch(pCur);
 
-  /* Phase 0: working set. */
+
   if( pCur->phase==0 ){
     pCur->phase = 1;
     rc = computeWorkingBatch(pCur, db);
@@ -374,10 +374,10 @@ static int diffAdvance(DoltliteDiffCursor *pCur, sqlite3 *db){
       pCur->hasRow = 1;
       return SQLITE_OK;
     }
-    /* Fall through to BFS if working set had no changes. */
+
   }
 
-  /* Phase 1: BFS commit walk. */
+
   while( pCur->qHead < pCur->qTail ){
     ProllyHash cur = pCur->aQueue[pCur->qHead++];
     DoltliteCommit commit;
@@ -399,7 +399,7 @@ static int diffAdvance(DoltliteDiffCursor *pCur, sqlite3 *db){
       return rc;
     }
 
-    /* Enqueue parents. */
+
     for(i=0; i<doltliteCommitParentCount(&commit); i++){
       const ProllyHash *pParent = doltliteCommitParentHash(&commit, i);
       if( !pParent || prollyHashIsEmpty(pParent) ) continue;
@@ -428,7 +428,7 @@ static int diffAdvance(DoltliteDiffCursor *pCur, sqlite3 *db){
       pCur->hasRow = 1;
       return SQLITE_OK;
     }
-    /* This commit had no table changes (or all filtered out) — continue. */
+
   }
 
   pCur->hasRow = 0;
@@ -530,7 +530,7 @@ static int diffFilter(sqlite3_vtab_cursor *pCursor,
 
   diffCursorReset(pCur);
 
-  /* Capture table_name filter if present. */
+
   if( (idxNum & DIFF_IDX_TABLE_NAME) && argIdx<argc ){
     const char *z = (const char*)sqlite3_value_text(argv[argIdx++]);
     if( z ){
@@ -545,7 +545,7 @@ static int diffFilter(sqlite3_vtab_cursor *pCursor,
   doltliteGetSessionHead(db, &head);
   if( prollyHashIsEmpty(&head) ) return SQLITE_OK;
 
-  /* Initialize BFS state. */
+
   rc = prollyHashSetInit(&pCur->visited, 64);
   if( rc!=SQLITE_OK ) return rc;
   pCur->visitedInit = 1;
@@ -562,7 +562,7 @@ static int diffFilter(sqlite3_vtab_cursor *pCursor,
   rc = prollyHashSetAdd(&pCur->queued, &head);
   if( rc!=SQLITE_OK ) return rc;
 
-  /* Prime the first row (working set first, then BFS). */
+
   pCur->phase = 0;
   return diffAdvance(pCur, db);
 }

--- a/src/doltlite_diff_stat.c
+++ b/src/doltlite_diff_stat.c
@@ -149,12 +149,12 @@ static i64 dsReadInt(const u8 *p, int nBytes){
   return v;
 }
 
-/* SQLite packs integers into the narrowest serial type that fits, so
-** 42 may be stored as type-1 (1 byte) on one side and type-2 (2 bytes)
-** on the other. Raw memcmp of fields would call those "modified".
-** Here we coerce any integer-family type (1..6, 8, 9) to a signed
-** int64 and compare numerically, so equal numeric values produce
-** equal cell counts regardless of encoding width. */
+
+
+
+
+
+
 static int dsFieldValuesEqual(
   int aType, const u8 *pA, int nA, int aOff,
   int bType, const u8 *pB, int nB, int bOff
@@ -413,10 +413,10 @@ static int dsComputeTableStats(
   }
 
 
-  /* Column-count delta: if the schema widened/narrowed, every
-  ** surviving row gains or loses cells even if the data is identical.
-  ** Count those as cellsAdded/cellsDeleted so dolt_diff_stat matches
-  ** Dolt's reported totals. */
+
+
+
+
   if( hasFrom && hasTo ){
     i64 rowsInBoth = oldCount - rowsDel;
     if( rowsInBoth < 0 ) rowsInBoth = 0;

--- a/src/doltlite_diff_stat.c
+++ b/src/doltlite_diff_stat.c
@@ -149,12 +149,6 @@ static i64 dsReadInt(const u8 *p, int nBytes){
   return v;
 }
 
-
-
-
-
-
-
 static int dsFieldValuesEqual(
   int aType, const u8 *pA, int nA, int aOff,
   int bType, const u8 *pB, int nB, int bOff
@@ -203,7 +197,6 @@ static int dsCountChangedCells(
   if( !pFromRec || !pToRec ) return 0;
   doltliteParseRecord(pFromRec, nFromRec, &fromRi);
   doltliteParseRecord(pToRec,   nToRec,   &toRi);
-
 
   for(i=0; i<nToCols; i++){
     int fromIdx;
@@ -340,7 +333,6 @@ static int dsComputeTableStats(
 
   if( !hasFrom && !hasTo ) return SQLITE_OK;
 
-
   if( hasFrom ){
     rc = dsLoadCreateSql(db, pFromCatHash, zTableName, &zFromSql);
     if( rc!=SQLITE_OK ) return rc;
@@ -360,7 +352,6 @@ static int dsComputeTableStats(
     hasFrom && hasTo &&
     strcmp(zFromSql ? zFromSql : "", zToSql ? zToSql : "")!=0;
 
-
   if( hasFrom ){
     rc = dsCountRows(db, &fromRoot, fromFlags, &oldCount);
     if( rc!=SQLITE_OK ) goto done;
@@ -369,7 +360,6 @@ static int dsComputeTableStats(
     rc = dsCountRows(db, &toRoot, toFlags, &newCount);
     if( rc!=SQLITE_OK ) goto done;
   }
-
 
   if( hasFrom && hasTo
    && prollyHashCompare(&fromRoot, &toRoot)!=0 ){
@@ -412,11 +402,6 @@ static int dsComputeTableStats(
     rc = SQLITE_OK;
   }
 
-
-
-
-
-
   if( hasFrom && hasTo ){
     i64 rowsInBoth = oldCount - rowsDel;
     if( rowsInBoth < 0 ) rowsInBoth = 0;
@@ -426,7 +411,6 @@ static int dsComputeTableStats(
       cellsDel += (i64)rowsInBoth * (nFromCols - nToCols);
     }
   }
-
 
   if( !hasFrom && hasTo ){
     rowsAdd = newCount;

--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -54,12 +54,6 @@ static char *buildDiffSchema(DoltliteColInfo *ci){
   }
   sqlite3_str_appendall(pStr, ", from_commit TEXT, from_commit_date TEXT"
                               ", diff_type TEXT"
-
-
-
-
-
-
                               ", from_ref TEXT HIDDEN"
                               ", to_ref TEXT HIDDEN)");
   z = sqlite3_str_finish(pStr);
@@ -108,29 +102,17 @@ typedef struct DiffTblCursor DiffTblCursor;
 struct DiffTblCursor {
   sqlite3_vtab_cursor base;
 
-
   DiffPair *aPairs;
   int nPairs;
   int iPair;
   int pairsDone;
 
-
   ProllyDiffIter diffIter;
   int diffIterOpen;
-
-
-
-
-
-
-
-
-
 
   DoltliteColInfo fromColInfo;
   DoltliteColInfo toColInfo;
   int    needFilter;
-
 
   AuditRow row;
   int hasRow;
@@ -368,14 +350,6 @@ static int registerCommitParents(
   return SQLITE_OK;
 }
 
-
-
-
-
-
-
-
-
 static int buildDiffPairs(DiffTblCursor *pCur, sqlite3 *db,
                           const char *zTableName){
   ChunkStore *cs = doltliteGetChunkStore(db);
@@ -440,7 +414,6 @@ static int buildDiffPairs(DiffTblCursor *pCur, sqlite3 *db,
     }
     doltliteCommitClear(&commit);
     if( rc!=SQLITE_OK ) break;
-
 
     if( nStack==0 ){
       currInited = 0;
@@ -523,12 +496,6 @@ static int buildWorkingDiffPair(
   return rc;
 }
 
-
-
-
-
-
-
 static int buildSliceDiffPair(
   DiffTblCursor *pCur,
   sqlite3 *db,
@@ -581,9 +548,6 @@ static int buildSliceDiffPair(
                                       &toSchemaHash);
     if( rc==SQLITE_NOTFOUND ) rc = SQLITE_OK;
     if( rc!=SQLITE_OK ) return rc;
-
-
-
     rc = doltliteFlushCatalogToHash(db, &toCatHash);
     if( rc!=SQLITE_OK ) return rc;
     memcpy(zToLabel, "WORKING", 7);
@@ -604,7 +568,6 @@ static int buildSliceDiffPair(
     doltliteHashToHex(&toHash, zToLabel);
   }
 
-
   if( !toIsWorking
    && prollyHashCompare(&fromHash, &toHash)==0 ){
     return SQLITE_OK;
@@ -613,9 +576,6 @@ static int buildSliceDiffPair(
    && prollyHashCompare(&fromSchemaHash, &toSchemaHash)==0 ){
     return SQLITE_OK;
   }
-
-
-
 
   if( !fromFlags ) fromFlags = toFlags;
   if( !toFlags ) toFlags = fromFlags;
@@ -631,12 +591,6 @@ static void freePairCols(DiffTblCursor *pCur){
   doltliteFreeColInfo(&pCur->toColInfo);
   pCur->needFilter = 0;
 }
-
-
-
-
-
-
 
 static int loadColInfoAtCatalog(
   sqlite3 *db,
@@ -697,10 +651,8 @@ static int fieldValuesEqual(
   i64 ai, bi;
   int aLen, bLen;
 
-
   if( aType==0 && bType==0 ) return 1;
   if( aType==0 || bType==0 ) return 0;
-
 
   {
     int aIsInt = (aType>=1 && aType<=6) || aType==8 || aType==9;
@@ -724,7 +676,6 @@ static int fieldValuesEqual(
     }
   }
 
-
   if( aType != bType ) return 0;
   aLen = dlSerialTypeLen(aType);
   if( aLen<0 ) return 0;
@@ -732,13 +683,6 @@ static int fieldValuesEqual(
   if( bOff<0 || bOff+aLen>nB ) return 0;
   return memcmp(pA+aOff, pB+bOff, aLen)==0;
 }
-
-
-
-
-
-
-
 
 static int changeIsSchemaOnly(
   const u8 *pFromRec, int nFromRec,
@@ -753,7 +697,6 @@ static int changeIsSchemaOnly(
   if( !pFromCi || !pToCi ) return 0;
   doltliteParseRecord(pFromRec, nFromRec, &fromRi);
   doltliteParseRecord(pToRec,   nToRec,   &toRi);
-
 
   for(i=0; i<pToCi->nCol; i++){
     int fromIdx;
@@ -801,7 +744,6 @@ static int openNextPairIter(DiffTblCursor *pCur, sqlite3 *db){
   ProllyCache *pCache = doltliteGetCache(db);
   DiffTblVtab *pVtab = (DiffTblVtab*)pCur->base.pVtab;
   int rc;
-
 
   freePairCols(pCur);
 
@@ -865,7 +807,6 @@ static int advanceToNextRow(DiffTblCursor *pCur, sqlite3 *db,
           continue;
         }
 
-
         pCur->row.pOldVal = 0;
         pCur->row.nOldVal = 0;
         pCur->row.pNewVal = 0;
@@ -890,7 +831,6 @@ static int advanceToNextRow(DiffTblCursor *pCur, sqlite3 *db,
 
       closeDiffIter(pCur);
     }
-
 
     if( pCur->pairsDone ){
       return SQLITE_OK;
@@ -968,17 +908,6 @@ static int dtBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
   int iFromRefEq = -1;
   int iToRefEq = -1;
   int nUser = p->cols.nCol;
-
-
-
-
-
-
-
-
-
-
-
   int toCommitCol = nUser;
   int fromRefCol  = 2*nUser + 5;
   int toRefCol    = 2*nUser + 6;
@@ -996,8 +925,6 @@ static int dtBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
   }
 
   if( iFromRefEq>=0 && iToRefEq>=0 ){
-
-
     pInfo->idxNum = DT_IDX_SLICE;
     pInfo->aConstraintUsage[iFromRefEq].argvIndex = 1;
     pInfo->aConstraintUsage[iFromRefEq].omit = 1;
@@ -1041,7 +968,6 @@ static int dtFilter(sqlite3_vtab_cursor *cur,
   sqlite3 *db = pVtab->db;
   int rc;
   (void)idxStr;
-
 
   closeDiffIter(c);
   clearAuditRow(&c->row);
@@ -1104,7 +1030,6 @@ static int dtColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
   AuditRow *r = &c->row;
   int nCols = pVtab->cols.nCol;
 
-
   if( nCols > 0 && col < nCols ){
     doltliteResultUserCol(ctx, &pVtab->cols, r->pNewVal, r->nNewVal,
                           r->intKey, col);
@@ -1147,9 +1072,6 @@ static int dtColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
       case PROLLY_DIFF_MODIFY: sqlite3_result_text(ctx,"modified",-1,SQLITE_STATIC); break;
     }
   }else{
-
-
-
     sqlite3_result_null(ctx);
   }
 

--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -54,12 +54,12 @@ static char *buildDiffSchema(DoltliteColInfo *ci){
   }
   sqlite3_str_appendall(pStr, ", from_commit TEXT, from_commit_date TEXT"
                               ", diff_type TEXT"
-                              /* Hidden TVF arguments: used to expose the
-                              ** dolt_diff(from_ref, to_ref, table) shape as
-                              ** dolt_diff_<table>(from_ref, to_ref). Both
-                              ** must be supplied together; if either is
-                              ** absent the vtab falls back to its full-
-                              ** history no-arg behavior. */
+
+
+
+
+
+
                               ", from_ref TEXT HIDDEN"
                               ", to_ref TEXT HIDDEN)");
   z = sqlite3_str_finish(pStr);
@@ -119,14 +119,14 @@ struct DiffTblCursor {
   int diffIterOpen;
 
 
-  /* Per-pair schema snapshots at the from- and to-commit catalog
-  ** hashes. Populated only when the two commits have a different
-  ** schema hash (needFilter==1) so that changeIsSchemaOnly can
-  ** compare shared columns and filter out modifications that are
-  ** purely schema-level with no data change. Each side carries
-  ** aColToRec[] so record fields can be read by declared-column
-  ** index even when the WITHOUT-ROWID PK-first permutation moves
-  ** columns around relative to the declaration. */
+
+
+
+
+
+
+
+
   DoltliteColInfo fromColInfo;
   DoltliteColInfo toColInfo;
   int    needFilter;
@@ -368,14 +368,14 @@ static int registerCommitParents(
   return SQLITE_OK;
 }
 
-/* Walk history toward the root, emitting one DiffPair per commit
-** whose table root (or schema) differs from the commit that follows
-** it. aMap is keyed by commit hash and stores "what child info do we
-** have for this commit?" — when we pop a commit off the stack, we
-** compare its table root with the child info already registered
-** under its own hash and, if different, emit a pair. Before walking
-** further we register the parent(s) in aMap with this commit's data,
-** so when a parent gets visited later it already has a child. */
+
+
+
+
+
+
+
+
 static int buildDiffPairs(DiffTblCursor *pCur, sqlite3 *db,
                           const char *zTableName){
   ChunkStore *cs = doltliteGetChunkStore(db);
@@ -523,12 +523,12 @@ static int buildWorkingDiffPair(
   return rc;
 }
 
-/* TVF slice builder: produce exactly one DiffPair between the two
-** supplied refs. Matches Dolt's dolt_diff(from_ref, to_ref, table)
-** shape — one pair, net diff between endpoints, no history walk.
-** to_ref == 'WORKING' diffs against the current working catalog
-** (staged + pending); from_ref == 'WORKING' is not supported by
-** Dolt either and returns an empty slice. */
+
+
+
+
+
+
 static int buildSliceDiffPair(
   DiffTblCursor *pCur,
   sqlite3 *db,
@@ -581,9 +581,9 @@ static int buildSliceDiffPair(
                                       &toSchemaHash);
     if( rc==SQLITE_NOTFOUND ) rc = SQLITE_OK;
     if( rc!=SQLITE_OK ) return rc;
-    /* Flush working catalog only if we need its hash; otherwise
-    ** leave toCatHash empty so column resolution falls back to
-    ** the table root itself. */
+
+
+
     rc = doltliteFlushCatalogToHash(db, &toCatHash);
     if( rc!=SQLITE_OK ) return rc;
     memcpy(zToLabel, "WORKING", 7);
@@ -604,7 +604,7 @@ static int buildSliceDiffPair(
     doltliteHashToHex(&toHash, zToLabel);
   }
 
-  /* No-op slice: same endpoint or identical table roots. */
+
   if( !toIsWorking
    && prollyHashCompare(&fromHash, &toHash)==0 ){
     return SQLITE_OK;
@@ -614,9 +614,9 @@ static int buildSliceDiffPair(
     return SQLITE_OK;
   }
 
-  /* Use whichever side has a non-zero flags bitfield as the
-  ** diff-iteration flags (both sides should agree for a single
-  ** table, but be tolerant when one side is missing). */
+
+
+
   if( !fromFlags ) fromFlags = toFlags;
   if( !toFlags ) toFlags = fromFlags;
 
@@ -632,12 +632,12 @@ static void freePairCols(DiffTblCursor *pCur){
   pCur->needFilter = 0;
 }
 
-/* Load a DoltliteColInfo snapshot (including aColToRec[]) for
-** zTableName at the schema recorded in pCatHash. Opens a fresh
-** in-memory SQLite, replays the recorded CREATE TABLE, then
-** runs doltliteGetColumnNames() against that temp db so the
-** WITHOUT-ROWID PK-first permutation is computed from the same
-** PRAGMA table_info the rest of the engine uses. */
+
+
+
+
+
+
 static int loadColInfoAtCatalog(
   sqlite3 *db,
   const ProllyHash *pCatHash,
@@ -733,13 +733,13 @@ static int fieldValuesEqual(
   return memcmp(pA+aOff, pB+bOff, aLen)==0;
 }
 
-/* Return true if the pOld→pNew MODIFY is purely a schema-level
-** reshape with no data change. Compares shared columns by name
-** and reads each field via the side's aColToRec[] permutation so
-** WITHOUT-ROWID tables (PK-first record layout) map declared
-** indices back to the correct record field. Columns that exist
-** on only one side must be NULL on that side to still qualify
-** as schema-only. */
+
+
+
+
+
+
+
 static int changeIsSchemaOnly(
   const u8 *pFromRec, int nFromRec,
   const u8 *pToRec,   int nToRec,
@@ -968,17 +968,17 @@ static int dtBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
   int iFromRefEq = -1;
   int iToRefEq = -1;
   int nUser = p->cols.nCol;
-  /* Schema layout after buildDiffSchema():
-  **   0..nUser-1       : user cols (to_<col>)
-  **   nUser            : to_commit
-  **   nUser+1          : to_commit_date
-  **   nUser+2..2n+1    : from_<col>
-  **   2n+2             : from_commit
-  **   2n+3             : from_commit_date
-  **   2n+4             : diff_type
-  **   2n+5             : from_ref  (HIDDEN — TVF arg 1)
-  **   2n+6             : to_ref    (HIDDEN — TVF arg 2)
-  */
+
+
+
+
+
+
+
+
+
+
+
   int toCommitCol = nUser;
   int fromRefCol  = 2*nUser + 5;
   int toRefCol    = 2*nUser + 6;
@@ -996,8 +996,8 @@ static int dtBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
   }
 
   if( iFromRefEq>=0 && iToRefEq>=0 ){
-    /* TVF slice form: dolt_diff_<table>(from_ref, to_ref). Both
-    ** hidden args are bound; build exactly one diff pair. */
+
+
     pInfo->idxNum = DT_IDX_SLICE;
     pInfo->aConstraintUsage[iFromRefEq].argvIndex = 1;
     pInfo->aConstraintUsage[iFromRefEq].omit = 1;
@@ -1147,9 +1147,9 @@ static int dtColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
       case PROLLY_DIFF_MODIFY: sqlite3_result_text(ctx,"modified",-1,SQLITE_STATIC); break;
     }
   }else{
-    /* Hidden TVF arg columns (from_ref, to_ref) — never materialized
-    ** in the result set, but SQLite may still ask for them during
-    ** query planning. Always return NULL. */
+
+
+
     sqlite3_result_null(ctx);
   }
 

--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -67,12 +67,6 @@ static int gcChildCb(void *ctx, const ProllyHash *pHash){
   return gcQueuePush(q, pHash);
 }
 
-
-
-
-
-
-
 static int gcMarkReachable(
   ChunkStore *cs,
   ProllyHashSet *marked
@@ -84,14 +78,12 @@ static int gcMarkReachable(
   rc = gcQueueInit(&queue);
   if( rc!=SQLITE_OK ) return rc;
 
-
   rc = gcQueuePush(&queue, &cs->refsHash);
 
   for(i=0; rc==SQLITE_OK && i<cs->nBranches; i++){
     rc = gcQueuePush(&queue, &cs->aBranches[i].commitHash);
     if( rc==SQLITE_OK ) rc = gcQueuePush(&queue, &cs->aBranches[i].workingSetHash);
   }
-
 
   for(i=0; rc==SQLITE_OK && i<cs->nTags; i++){
     rc = gcQueuePush(&queue, &cs->aTags[i].commitHash);
@@ -100,7 +92,6 @@ static int gcMarkReachable(
     gcQueueFree(&queue);
     return rc;
   }
-
 
   while( gcQueuePop(&queue, &current) ){
     u8 *data = 0;
@@ -196,7 +187,6 @@ static int gcBuildCompactedData(
   i64 dataOffset = CHUNK_MANIFEST_SIZE;
   int rc = SQLITE_OK;
 
-
   for(i=0; i<cs->nIndex; i++){
     if( prollyHashSetContains(marked, &cs->aIndex[i].hash) ) kept++;
   }
@@ -225,7 +215,6 @@ static int gcBuildCompactedData(
       return rc;
     }
   }
-
 
   for(i=1; i<nNewIndex; i++){
     ChunkIndexEntry tmp = aNewIndex[i];
@@ -259,9 +248,6 @@ static int gcRewriteFile(
   ChunkStore manifestCs;
   int rc = SQLITE_OK;
 
-
-
-
 #ifdef SQLITE_TEST
   {
     static int crashGcTarget = -2;
@@ -279,7 +265,6 @@ static int gcRewriteFile(
 #else
 #define GC_CRASH_CHECK() ((void)0)
 #endif
-
 
   indexBuf = sqlite3_malloc(indexSize);
   if( !indexBuf ) return SQLITE_NOMEM;
@@ -310,11 +295,6 @@ static int gcRewriteFile(
 
   csSerializeManifest(&manifestCs, manifest);
 
-
-
-
-
-
   if( cs->zFilename && strcmp(cs->zFilename, ":memory:")!=0 ){
     char *zTmp = sqlite3_mprintf("%s-gc-tmp", cs->zFilename);
     if( !zTmp ){
@@ -328,7 +308,6 @@ static int gcRewriteFile(
                    | SQLITE_OPEN_MAIN_DB;
       i64 writeOff = 0;
 
-
       cs->pVfs->xDelete(cs->pVfs, zTmp, 0);
 
       rc = sqlite3OsOpenMalloc(cs->pVfs, zTmp, &pTmpFile, tmpFlags, 0);
@@ -337,11 +316,9 @@ static int gcRewriteFile(
         return SQLITE_CANTOPEN;
       }
 
-
       GC_CRASH_CHECK();
       rc = sqlite3OsWrite(pTmpFile, manifest, CHUNK_MANIFEST_SIZE, writeOff);
       writeOff += CHUNK_MANIFEST_SIZE;
-
 
       if( rc==SQLITE_OK && nNewData>0 ){
         const u8 *p = pNewData;
@@ -356,7 +333,6 @@ static int gcRewriteFile(
         }
       }
 
-
       if( rc==SQLITE_OK && indexSize>0 ){
         const u8 *p = indexBuf;
         int remaining = indexSize;
@@ -370,7 +346,6 @@ static int gcRewriteFile(
         }
       }
 
-
       if( rc==SQLITE_OK ){
         GC_CRASH_CHECK();
         rc = sqlite3OsSync(pTmpFile, SQLITE_SYNC_NORMAL);
@@ -379,7 +354,6 @@ static int gcRewriteFile(
 
       if( rc==SQLITE_OK ){
 
-
         if( cs->pFile ){
           sqlite3OsCloseFree(cs->pFile);
           cs->pFile = 0;
@@ -387,19 +361,11 @@ static int gcRewriteFile(
 
         GC_CRASH_CHECK();
         if( rename(zTmp, cs->zFilename)!=0 ){
-
-
-
           int reopenFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB;
           (void)sqlite3OsOpenMalloc(cs->pVfs, cs->zFilename,
                                     &cs->pFile, reopenFlags, 0);
           rc = SQLITE_IOERR;
         }
-
-
-
-
-
 
 #if !defined(_WIN32) && !defined(WIN32)
         if( rc==SQLITE_OK ){
@@ -424,7 +390,6 @@ static int gcRewriteFile(
         if( rc==SQLITE_OK ){
           cs->nWalData = 0;
         }
-
 
         if( rc==SQLITE_OK ){
           int reopenFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB;
@@ -459,7 +424,6 @@ static int gcSweep(
   int nBuf = 0;
   int rc = SQLITE_OK;
 
-
   for(i=0; i<cs->nIndex; i++){
     if( prollyHashSetContains(marked, &cs->aIndex[i].hash) ){
       kept++;
@@ -484,13 +448,10 @@ static int gcSweep(
     return SQLITE_OK;
   }
 
-
   rc = gcBuildCompactedData(cs, marked, &buf, &nBuf, &aNewIndex, &nNewIndex);
   if( rc!=SQLITE_OK ) return rc;
 
-
   rc = gcRewriteFile(cs, buf, nBuf, aNewIndex, nNewIndex);
-
 
   if( rc==SQLITE_OK ){
     int indexSize = nNewIndex * CHUNK_INDEX_ENTRY_SIZE;
@@ -543,12 +504,10 @@ static void doltliteGcFunc(
     return;
   }
 
-
   if( !cs->zFilename || strcmp(cs->zFilename, ":memory:")==0 ){
     sqlite3_result_text(context, "0 chunks removed, 0 chunks kept (in-memory)", -1, SQLITE_TRANSIENT);
     return;
   }
-
 
   rc = chunkStoreLockAndRefresh(cs);
   if( rc==SQLITE_BUSY ){

--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -67,12 +67,12 @@ static int gcChildCb(void *ctx, const ProllyHash *pHash){
   return gcQueuePush(q, pHash);
 }
 
-/* Mark phase: seed from every branch head, working-set, and tag
-** (any chunk that could be navigated to via a ref). refsHash is
-** also pinned because the refs blob itself lives in the chunk store.
-** Walk children via doltliteEnumerateChunkChildren — a missing case
-** in that classifier silently drops live chunks, corrupting the
-** store after sweep. */
+
+
+
+
+
+
 static int gcMarkReachable(
   ChunkStore *cs,
   ProllyHashSet *marked
@@ -259,9 +259,9 @@ static int gcRewriteFile(
   ChunkStore manifestCs;
   int rc = SQLITE_OK;
 
-  /* Deterministic crash injection for GC rewrite durability tests.
-  ** DOLTLITE_CRASH_GC_WRITE=N crashes at the Nth write/sync/rename
-  ** step in the compaction rewrite path. */
+
+
+
 #ifdef SQLITE_TEST
   {
     static int crashGcTarget = -2;
@@ -311,10 +311,10 @@ static int gcRewriteFile(
   csSerializeManifest(&manifestCs, manifest);
 
 
-  /* Write to a sibling tmp file then atomic rename. Has to close the
-  ** original fd before rename() on platforms where an open fd pins
-  ** the old inode, and the WAL buffer is dropped because its chunks
-  ** are now inlined into the compacted data region. */
+
+
+
+
   if( cs->zFilename && strcmp(cs->zFilename, ":memory:")!=0 ){
     char *zTmp = sqlite3_mprintf("%s-gc-tmp", cs->zFilename);
     if( !zTmp ){
@@ -387,20 +387,20 @@ static int gcRewriteFile(
 
         GC_CRASH_CHECK();
         if( rename(zTmp, cs->zFilename)!=0 ){
-          /* Rename failed — original file still exists on disk
-          ** but cs->pFile was already closed. Reopen it so the
-          ** session doesn't crash on subsequent operations. */
+
+
+
           int reopenFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB;
           (void)sqlite3OsOpenMalloc(cs->pVfs, cs->zFilename,
                                     &cs->pFile, reopenFlags, 0);
           rc = SQLITE_IOERR;
         }
 
-        /* Fsync the parent directory so the rename is durable.
-        ** Without this, a kernel crash after rename() returns
-        ** can lose the directory entry — the old file reappears
-        ** and the compacted file is gone, losing the database.
-        ** Windows NTFS journals metadata, so this is Unix-only. */
+
+
+
+
+
 #if !defined(_WIN32) && !defined(WIN32)
         if( rc==SQLITE_OK ){
           char *zDir = sqlite3_mprintf("%s", cs->zFilename);

--- a/src/doltlite_hashof.c
+++ b/src/doltlite_hashof.c
@@ -12,15 +12,6 @@
 
 char *doltliteCanonicalizeSchemaSql(const char *zSql, const char *zName);
 
-
-
-
-
-
-
-
-
-
 static void doltliteHashofFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db;
   const char *zRef;
@@ -54,10 +45,6 @@ static void doltliteHashofFunc(sqlite3_context *ctx, int argc, sqlite3_value **a
   doltliteHashToHex(&commitHash, hex);
   sqlite3_result_text(ctx, hex, PROLLY_HASH_SIZE*2, SQLITE_TRANSIENT);
 }
-
-
-
-
 
 static int hashofTableInCatalog(
   sqlite3 *db,
@@ -545,26 +532,6 @@ static int hashofDbInCatalog(
   return SQLITE_OK;
 }
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 static void doltliteHashofTableFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db;
   const char *zTable;
@@ -637,18 +604,6 @@ static void doltliteHashofTableFunc(sqlite3_context *ctx, int argc, sqlite3_valu
   sqlite3_result_text(ctx, hex, PROLLY_HASH_SIZE*2, SQLITE_TRANSIENT);
 }
 
-
-
-
-
-
-
-
-
-
-
-
-
 static void doltliteHashofDbFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db;
   ProllyHash catHash;
@@ -706,13 +661,6 @@ static void doltliteHashofDbFunc(sqlite3_context *ctx, int argc, sqlite3_value *
   }
   sqlite3_result_text(ctx, hex, PROLLY_HASH_SIZE*2, SQLITE_TRANSIENT);
 }
-
-
-
-
-
-
-
 
 static void doltliteHashofCatalogFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db;

--- a/src/doltlite_hashof.c
+++ b/src/doltlite_hashof.c
@@ -12,15 +12,15 @@
 
 char *doltliteCanonicalizeSchemaSql(const char *zSql, const char *zName);
 
-/* dolt_hashof(ref) → commit hash hex for the named ref. Accepts
-** branch names, tag names, raw commit hashes, HEAD, and HEAD~N /
-** HEAD^N shorthand — whatever doltliteResolveRef understands.
-**
-** In the decentralized use case the hash is the primary verifier:
-** two peers at the same hash have the same history up through
-** that commit, and can exchange chunks by hash-reference alone.
-** Keep the output lowercase 40-char hex so a SQL-level string
-** compare is the whole verification. */
+
+
+
+
+
+
+
+
+
 static void doltliteHashofFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db;
   const char *zRef;
@@ -55,10 +55,10 @@ static void doltliteHashofFunc(sqlite3_context *ctx, int argc, sqlite3_value **a
   sqlite3_result_text(ctx, hex, PROLLY_HASH_SIZE*2, SQLITE_TRANSIENT);
 }
 
-/* Shared lookup: hashof a table inside a catalog (either the
-** current working catalog or a catalog loaded from a ref).
-** Returns SQLITE_OK with the hex hash written to pHex on success,
-** SQLITE_NOTFOUND if zTable isn't in the catalog. */
+
+
+
+
 static int hashofTableInCatalog(
   sqlite3 *db,
   const ProllyHash *pCatHash,
@@ -545,26 +545,26 @@ static int hashofDbInCatalog(
   return SQLITE_OK;
 }
 
-/* dolt_hashof_table(name)
-** dolt_hashof_table(name, ref)
-**
-** 1-arg form returns a logical table identity hash for the current
-** working catalog. 2-arg form resolves the ref, loads its committed
-** catalog, and computes the same logical table identity there.
-**
-** The identity currently folds:
-**   - the table prolly root hash
-**   - the canonicalized table schema hash
-**
-** so DML-only equivalent histories and DDL-equivalent histories both
-** converge.
-**
-** History-independence invariant: for two rowsets that reduce to
-** the same set of rows and the same logical schema, this function
-** must return byte-identical hashes regardless of insert order,
-** transient deletions, commit chain, or equivalent DDL spellings.
-** The oracles in test/vc_oracle_hashof_test.sh and
-** test/history_independence_test.sh exercise those properties. */
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 static void doltliteHashofTableFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db;
   const char *zTable;
@@ -637,18 +637,18 @@ static void doltliteHashofTableFunc(sqlite3_context *ctx, int argc, sqlite3_valu
   sqlite3_result_text(ctx, hex, PROLLY_HASH_SIZE*2, SQLITE_TRANSIENT);
 }
 
-/* dolt_hashof_db()
-** dolt_hashof_db(ref)
-**
-** 0-arg returns the hash of the current working catalog — the
-** content-address of the entire database's current logical state,
-** which changes iff any table's root changes or a table is
-** added/dropped. 1-arg resolves the ref and returns that commit's
-** catalog hash.
-**
-** This is the single-string proof-of-equivalence between two
-** doltlite peers in a decentralized setup: same hash, same state,
-** no row-level diffing required. */
+
+
+
+
+
+
+
+
+
+
+
+
 static void doltliteHashofDbFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db;
   ProllyHash catHash;
@@ -707,13 +707,13 @@ static void doltliteHashofDbFunc(sqlite3_context *ctx, int argc, sqlite3_value *
   sqlite3_result_text(ctx, hex, PROLLY_HASH_SIZE*2, SQLITE_TRANSIENT);
 }
 
-/* dolt_hashof_catalog()
-** dolt_hashof_catalog(ref)
-**
-** Raw stored catalog hash. Unlike dolt_hashof_db(), this does not
-** canonicalize anything at query time. It exists so storage-level
-** history-independence tests can compare the actual persisted catalog
-** identity rather than commit metadata or logical normalized views. */
+
+
+
+
+
+
+
 static void doltliteHashofCatalogFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db;
   ProllyHash catHash;

--- a/src/doltlite_history.c
+++ b/src/doltlite_history.c
@@ -43,19 +43,19 @@ struct HistVtab {
 typedef struct HistCursor HistCursor;
 struct HistCursor {
   sqlite3_vtab_cursor base;
-  /* BFS state for commit graph */
+
   ProllyHash *aQueue;
   int qHead, qTail, qAlloc;
   ProllyHashSet visited, queued;
   int visitedInit, queuedInit;
-  /* Current commit metadata */
+
   char zCommitHex[PROLLY_HASH_SIZE*2+1];
   char *zCommitter;
   i64 commitDate;
-  /* Table row cursor at current commit */
+
   ProllyCursor tblCur;
   int tblCurOpen;
-  /* Current row (copied from cursor) */
+
   i64 intKey;
   u8 *pVal; int nVal;
   int hasRow;
@@ -86,9 +86,9 @@ static void htCursorReset(HistCursor *c){
   c->iRowid = 0;
 }
 
-/* Capture current table-cursor row into the cursor struct.
-** The prolly cursor's value pointer may be invalidated on next
-** step, so we copy the bytes. */
+
+
+
 static int htCaptureRow(HistCursor *c){
   const u8 *pVal; int nVal;
   sqlite3_free(c->pVal);
@@ -105,9 +105,9 @@ static int htCaptureRow(HistCursor *c){
   return SQLITE_OK;
 }
 
-/* Open a table cursor at the given commit and position it on the
-** first row. Returns SQLITE_OK with tblCurOpen=1 if rows exist,
-** or tblCurOpen=0 if the table is empty at this commit. */
+
+
+
 static int htOpenTableAtCommit(HistCursor *c, sqlite3 *db,
     const char *zTableName, const ProllyHash *pCommitHash){
   ChunkStore *cs = doltliteGetChunkStore(db);
@@ -121,7 +121,7 @@ static int htOpenTableAtCommit(HistCursor *c, sqlite3 *db,
   rc = doltliteLoadCommit(db, pCommitHash, &commit);
   if( rc!=SQLITE_OK ) return rc;
 
-  /* Save commit metadata for column output. */
+
   doltliteHashToHex(pCommitHash, c->zCommitHex);
   sqlite3_free(c->zCommitter);
   c->zCommitter = sqlite3_mprintf("%s", commit.zName ? commit.zName : "");
@@ -131,7 +131,7 @@ static int htOpenTableAtCommit(HistCursor *c, sqlite3 *db,
     return SQLITE_NOMEM;
   }
 
-  /* Enqueue parents for later BFS visits. */
+
   {
     int i;
     for(i=0; i<doltliteCommitParentCount(&commit); i++){
@@ -158,7 +158,7 @@ static int htOpenTableAtCommit(HistCursor *c, sqlite3 *db,
     }
   }
 
-  /* Find the table in this commit's catalog. */
+
   rc = doltliteLoadCatalog(db, &commit.catalogHash, &aT, &nT, 0);
   doltliteCommitClear(&commit);
   if( rc!=SQLITE_OK ) return rc;
@@ -166,11 +166,11 @@ static int htOpenTableAtCommit(HistCursor *c, sqlite3 *db,
   if( doltliteFindTableRootByName(aT, nT, zTableName, &tableRoot, &flags)
       !=SQLITE_OK || prollyHashIsEmpty(&tableRoot) ){
     doltliteFreeCatalog(aT, nT);
-    return SQLITE_OK; /* Table doesn't exist at this commit — skip. */
+    return SQLITE_OK;
   }
   doltliteFreeCatalog(aT, nT);
 
-  /* Open prolly cursor on the table. */
+
   prollyCursorInit(&c->tblCur, cs, pCache, &tableRoot, flags);
   rc = prollyCursorFirst(&c->tblCur, &res);
   if( rc!=SQLITE_OK ){
@@ -178,7 +178,7 @@ static int htOpenTableAtCommit(HistCursor *c, sqlite3 *db,
     return rc;
   }
   if( res ){
-    /* Table exists but is empty. */
+
     prollyCursorClose(&c->tblCur);
     return SQLITE_OK;
   }
@@ -186,12 +186,12 @@ static int htOpenTableAtCommit(HistCursor *c, sqlite3 *db,
   return SQLITE_OK;
 }
 
-/* Advance to the next row. Tries the table cursor first; if exhausted,
-** moves to the next commit in BFS order and opens a new table cursor. */
+
+
 static int htAdvance(HistCursor *c, sqlite3 *db, const char *zTableName){
   int rc;
 
-  /* If we have an open table cursor, try to advance within it. */
+
   if( c->tblCurOpen ){
     rc = prollyCursorNext(&c->tblCur);
     if( rc!=SQLITE_OK ){
@@ -202,12 +202,12 @@ static int htAdvance(HistCursor *c, sqlite3 *db, const char *zTableName){
     if( prollyCursorIsValid(&c->tblCur) ){
       return htCaptureRow(c);
     }
-    /* Exhausted this commit's rows. */
+
     prollyCursorClose(&c->tblCur);
     c->tblCurOpen = 0;
   }
 
-  /* Walk BFS to find the next commit that has rows. */
+
   while( c->qHead < c->qTail ){
     ProllyHash cur = c->aQueue[c->qHead++];
 
@@ -221,10 +221,10 @@ static int htAdvance(HistCursor *c, sqlite3 *db, const char *zTableName){
     if( c->tblCurOpen ){
       return htCaptureRow(c);
     }
-    /* Table didn't exist or was empty at this commit — continue BFS. */
+
   }
 
-  /* BFS exhausted. */
+
   c->hasRow = 0;
   return SQLITE_OK;
 }
@@ -295,7 +295,7 @@ static int htFilter(sqlite3_vtab_cursor *cur,
   doltliteGetSessionHead(v->db, &head);
   if( prollyHashIsEmpty(&head) ) return SQLITE_OK;
 
-  /* Initialize BFS state. */
+
   rc = prollyHashSetInit(&c->visited, 64);
   if( rc!=SQLITE_OK ) return rc;
   c->visitedInit = 1;
@@ -312,7 +312,7 @@ static int htFilter(sqlite3_vtab_cursor *cur,
   rc = prollyHashSetAdd(&c->queued, &head);
   if( rc!=SQLITE_OK ) return rc;
 
-  /* Prime the first row. */
+
   return htAdvance(c, v->db, v->zTableName);
 }
 

--- a/src/doltlite_history.c
+++ b/src/doltlite_history.c
@@ -43,19 +43,15 @@ struct HistVtab {
 typedef struct HistCursor HistCursor;
 struct HistCursor {
   sqlite3_vtab_cursor base;
-
   ProllyHash *aQueue;
   int qHead, qTail, qAlloc;
   ProllyHashSet visited, queued;
   int visitedInit, queuedInit;
-
   char zCommitHex[PROLLY_HASH_SIZE*2+1];
   char *zCommitter;
   i64 commitDate;
-
   ProllyCursor tblCur;
   int tblCurOpen;
-
   i64 intKey;
   u8 *pVal; int nVal;
   int hasRow;
@@ -86,9 +82,6 @@ static void htCursorReset(HistCursor *c){
   c->iRowid = 0;
 }
 
-
-
-
 static int htCaptureRow(HistCursor *c){
   const u8 *pVal; int nVal;
   sqlite3_free(c->pVal);
@@ -105,9 +98,6 @@ static int htCaptureRow(HistCursor *c){
   return SQLITE_OK;
 }
 
-
-
-
 static int htOpenTableAtCommit(HistCursor *c, sqlite3 *db,
     const char *zTableName, const ProllyHash *pCommitHash){
   ChunkStore *cs = doltliteGetChunkStore(db);
@@ -121,7 +111,6 @@ static int htOpenTableAtCommit(HistCursor *c, sqlite3 *db,
   rc = doltliteLoadCommit(db, pCommitHash, &commit);
   if( rc!=SQLITE_OK ) return rc;
 
-
   doltliteHashToHex(pCommitHash, c->zCommitHex);
   sqlite3_free(c->zCommitter);
   c->zCommitter = sqlite3_mprintf("%s", commit.zName ? commit.zName : "");
@@ -130,7 +119,6 @@ static int htOpenTableAtCommit(HistCursor *c, sqlite3 *db,
     doltliteCommitClear(&commit);
     return SQLITE_NOMEM;
   }
-
 
   {
     int i;
@@ -158,7 +146,6 @@ static int htOpenTableAtCommit(HistCursor *c, sqlite3 *db,
     }
   }
 
-
   rc = doltliteLoadCatalog(db, &commit.catalogHash, &aT, &nT, 0);
   doltliteCommitClear(&commit);
   if( rc!=SQLITE_OK ) return rc;
@@ -170,7 +157,6 @@ static int htOpenTableAtCommit(HistCursor *c, sqlite3 *db,
   }
   doltliteFreeCatalog(aT, nT);
 
-
   prollyCursorInit(&c->tblCur, cs, pCache, &tableRoot, flags);
   rc = prollyCursorFirst(&c->tblCur, &res);
   if( rc!=SQLITE_OK ){
@@ -178,7 +164,6 @@ static int htOpenTableAtCommit(HistCursor *c, sqlite3 *db,
     return rc;
   }
   if( res ){
-
     prollyCursorClose(&c->tblCur);
     return SQLITE_OK;
   }
@@ -186,11 +171,8 @@ static int htOpenTableAtCommit(HistCursor *c, sqlite3 *db,
   return SQLITE_OK;
 }
 
-
-
 static int htAdvance(HistCursor *c, sqlite3 *db, const char *zTableName){
   int rc;
-
 
   if( c->tblCurOpen ){
     rc = prollyCursorNext(&c->tblCur);
@@ -202,11 +184,9 @@ static int htAdvance(HistCursor *c, sqlite3 *db, const char *zTableName){
     if( prollyCursorIsValid(&c->tblCur) ){
       return htCaptureRow(c);
     }
-
     prollyCursorClose(&c->tblCur);
     c->tblCurOpen = 0;
   }
-
 
   while( c->qHead < c->qTail ){
     ProllyHash cur = c->aQueue[c->qHead++];
@@ -221,9 +201,7 @@ static int htAdvance(HistCursor *c, sqlite3 *db, const char *zTableName){
     if( c->tblCurOpen ){
       return htCaptureRow(c);
     }
-
   }
-
 
   c->hasRow = 0;
   return SQLITE_OK;
@@ -295,7 +273,6 @@ static int htFilter(sqlite3_vtab_cursor *cur,
   doltliteGetSessionHead(v->db, &head);
   if( prollyHashIsEmpty(&head) ) return SQLITE_OK;
 
-
   rc = prollyHashSetInit(&c->visited, 64);
   if( rc!=SQLITE_OK ) return rc;
   c->visitedInit = 1;
@@ -311,7 +288,6 @@ static int htFilter(sqlite3_vtab_cursor *cur,
   c->qTail = 1;
   rc = prollyHashSetAdd(&c->queued, &head);
   if( rc!=SQLITE_OK ) return rc;
-
 
   return htAdvance(c, v->db, v->zTableName);
 }

--- a/src/doltlite_http_remote.c
+++ b/src/doltlite_http_remote.c
@@ -1,10 +1,10 @@
-/* HTTP-backed DoltliteRemote backend for dolt_fetch/push/pull.
-** Intentionally simple — hand-rolled blocking sockets + HTTP/1.1
-** Connection: close, no keep-alive, no TLS. Upload chunks are
-** buffered until httpCommit() flushes them as one POST /chunks,
-** then /refs, then /commit; this matches the remotesrv transaction
-** protocol. Not production-ready (no retry, no HTTPS) — only used
-** by tests against a local doltlite_remotesrv. */
+
+
+
+
+
+
+
 
 #ifdef DOLTLITE_PROLLY
 

--- a/src/doltlite_http_remote.c
+++ b/src/doltlite_http_remote.c
@@ -1,11 +1,4 @@
 
-
-
-
-
-
-
-
 #ifdef DOLTLITE_PROLLY
 
 #include "sqliteInt.h"
@@ -120,10 +113,8 @@ static int httpRequest(
   *ppResp = 0;
   *pnResp = 0;
 
-
   he = gethostbyname(zHost);
   if( !he ) return SQLITE_ERROR;
-
 
   fd = socket(AF_INET, SOCK_STREAM, 0);
   if( fd < 0 ) return SQLITE_ERROR;
@@ -137,7 +128,6 @@ static int httpRequest(
     close(fd);
     return SQLITE_ERROR;
   }
-
 
   if( pBody && nBody > 0 ){
     nReqHdr = snprintf(aReqHdr, sizeof(aReqHdr),
@@ -157,7 +147,6 @@ static int httpRequest(
       zMethod, zPath, zHost);
   }
 
-
   rc = writeAll(fd, aReqHdr, nReqHdr);
   if( rc != SQLITE_OK ){ close(fd); return rc; }
   if( pBody && nBody > 0 ){
@@ -165,12 +154,10 @@ static int httpRequest(
     if( rc != SQLITE_OK ){ close(fd); return rc; }
   }
 
-
   rc = readUntilEof(fd, &pRaw, &nRaw);
   close(fd);
   fd = -1;
   if( rc != SQLITE_OK ) return rc;
-
 
   {
     int i;
@@ -191,7 +178,6 @@ static int httpRequest(
       }
     }
   }
-
 
   {
     int i;
@@ -219,7 +205,6 @@ static int httpRequest(
       sqlite3_free(pRaw);
       return SQLITE_OK;
     }
-
 
     {
       int nAvail = nRaw - bodyStart;
@@ -284,7 +269,6 @@ static int httpHasChunks(DoltliteRemote *pRemote, const ProllyHash *aHash,
 
   if( nHash <= 0 ) return SQLITE_OK;
 
-
   nReqBody = nHash * PROLLY_HASH_SIZE;
   pReqBody = sqlite3_malloc(nReqBody);
   if( !pReqBody ) return SQLITE_NOMEM;
@@ -306,7 +290,6 @@ static int httpHasChunks(DoltliteRemote *pRemote, const ProllyHash *aHash,
     sqlite3_free(pResp);
     return SQLITE_ERROR;
   }
-
 
   if( nResp >= nHash ){
     memcpy(aResult, pResp, nHash);
@@ -367,7 +350,6 @@ static int httpPutChunk(DoltliteRemote *pRemote, const ProllyHash *pHash,
   u8 aLen[4];
   int rc;
 
-
   rc = uploadBufAppend(p, pHash->data, PROLLY_HASH_SIZE);
   if( rc != SQLITE_OK ) return rc;
 
@@ -421,7 +403,6 @@ static int httpGetRefs(DoltliteRemote *pRemote, u8 **ppData, int *pnData){
 static int httpSetRefs(DoltliteRemote *pRemote, const u8 *pData, int nData){
   HttpRemote *p = (HttpRemote*)pRemote;
 
-
   sqlite3_free(p->pPendingRefs);
   p->pPendingRefs = 0;
   p->nPendingRefs = 0;
@@ -443,7 +424,6 @@ static int httpCommit(DoltliteRemote *pRemote){
   int rc;
   char *zPath;
 
-
   if( p->pUploadBuf && p->nUploadBuf > 0 ){
     zPath = buildPath(p, "/chunks");
     if( !zPath ) return SQLITE_NOMEM;
@@ -456,7 +436,6 @@ static int httpCommit(DoltliteRemote *pRemote){
     if( rc != SQLITE_OK ) return rc;
     if( status != 200 && status != 204 ) return SQLITE_ERROR;
   }
-
 
   if( p->pPendingRefs && p->nPendingRefs > 0 ){
     pResp = 0; nResp = 0; status = 0;
@@ -472,7 +451,6 @@ static int httpCommit(DoltliteRemote *pRemote){
     if( status != 200 && status != 204 ) return SQLITE_ERROR;
   }
 
-
   {
     pResp = 0; nResp = 0; status = 0;
     zPath = buildPath(p, "/commit");
@@ -485,7 +463,6 @@ static int httpCommit(DoltliteRemote *pRemote){
     if( rc != SQLITE_OK ) return rc;
     if( status != 200 && status != 204 ) return SQLITE_ERROR;
   }
-
 
   sqlite3_free(p->pUploadBuf);
   p->pUploadBuf = 0;
@@ -521,11 +498,9 @@ DoltliteRemote *doltliteHttpRemoteOpen(const char *zUrl){
 
   if( !zUrl ) return 0;
 
-
   if( strncmp(zUrl, "http://", 7) != 0 ) return 0;
   zAfterScheme = zUrl + 7;
   zHostStart = zAfterScheme;
-
 
   zPortStart = 0;
   zPathStart = 0;
@@ -547,7 +522,6 @@ DoltliteRemote *doltliteHttpRemoteOpen(const char *zUrl){
 
   if( nHost <= 0 ) return 0;
 
-
   nUserPath = 0;
   if( zPathStart ){
     nUserPath = (int)strlen(zPathStart);
@@ -557,11 +531,9 @@ DoltliteRemote *doltliteHttpRemoteOpen(const char *zUrl){
     }
   }
 
-
   p = sqlite3_malloc(sizeof(HttpRemote));
   if( !p ) return 0;
   memset(p, 0, sizeof(HttpRemote));
-
 
   p->zHost = sqlite3_malloc(nHost + 1);
   if( !p->zHost ){
@@ -572,7 +544,6 @@ DoltliteRemote *doltliteHttpRemoteOpen(const char *zUrl){
   p->zHost[nHost] = 0;
 
   p->port = port;
-
 
   nBasePath = nUserPath;
   if( nBasePath <= 0 ){
@@ -589,7 +560,6 @@ DoltliteRemote *doltliteHttpRemoteOpen(const char *zUrl){
   }
   memcpy(p->zBasePath, zPathStart, nBasePath);
   p->zBasePath[nBasePath] = '\0';
-
 
   p->base.xGetChunk = httpGetChunk;
   p->base.xPutChunk = httpPutChunk;

--- a/src/doltlite_ignore.c
+++ b/src/doltlite_ignore.c
@@ -9,10 +9,6 @@ static unsigned char ignoreLower(unsigned char c){
   return (c>='A' && c<='Z') ? c + 32 : c;
 }
 
-
-
-
-
 static int ignorePatternMatch(const char *zPat, const char *zStr){
   const char *pStar = 0;
   const char *sStar = 0;
@@ -42,10 +38,6 @@ static int ignorePatternMatch(const char *zPat, const char *zStr){
   return *zPat == 0;
 }
 
-
-
-
-
 static int ignoreSpecificity(const char *zPat){
   int n = 0;
   while( *zPat ){
@@ -60,11 +52,6 @@ enum DoltliteIgnoreSchemaState {
   DOLTLITE_IGNORE_SCHEMA_OK = 1,
   DOLTLITE_IGNORE_SCHEMA_BAD = 2
 };
-
-
-
-
-
 
 static int doltliteIgnoreSchemaState(sqlite3 *db, int *pState){
   sqlite3_stmt *pStmt = 0;

--- a/src/doltlite_ignore.c
+++ b/src/doltlite_ignore.c
@@ -9,13 +9,13 @@ static unsigned char ignoreLower(unsigned char c){
   return (c>='A' && c<='Z') ? c + 32 : c;
 }
 
-/* Match zStr against zPat (case-insensitive). '*' and '%' match zero
-** or more characters, '?' matches exactly one, everything else is a
-** case-folded literal. Uses iterative backtracking instead of
-** recursion to avoid stack overflow on pathological patterns. */
+
+
+
+
 static int ignorePatternMatch(const char *zPat, const char *zStr){
-  const char *pStar = 0;   /* Last '*' position in pattern */
-  const char *sStar = 0;   /* String position at last '*' */
+  const char *pStar = 0;
+  const char *sStar = 0;
 
   while( *zStr ){
     unsigned char c = (unsigned char)*zPat;
@@ -42,10 +42,10 @@ static int ignorePatternMatch(const char *zPat, const char *zStr){
   return *zPat == 0;
 }
 
-/* Specificity score = count of literal (non-wildcard) chars. Higher
-** wins. Exact-literal patterns beat any wildcard pattern that also
-** matches the same string because they necessarily have more literals
-** (the entire name vs some proper prefix/suffix). */
+
+
+
+
 static int ignoreSpecificity(const char *zPat){
   int n = 0;
   while( *zPat ){
@@ -61,11 +61,11 @@ enum DoltliteIgnoreSchemaState {
   DOLTLITE_IGNORE_SCHEMA_BAD = 2
 };
 
-/* Read-time schema guard. The parse-time check in build.c catches
-** new bad CREATE TABLE statements, but on-disk repos created before
-** the guard landed (or via an older binary) can still have a
-** wrong-shape dolt_ignore. Detect it here and raise an error so the
-** user gets a clear signal instead of a silent "no filtering". */
+
+
+
+
+
 static int doltliteIgnoreSchemaState(sqlite3 *db, int *pState){
   sqlite3_stmt *pStmt = 0;
   int rc;

--- a/src/doltlite_ignore.h
+++ b/src/doltlite_ignore.h
@@ -4,32 +4,32 @@
 
 typedef struct sqlite3 sqlite3;
 
-/* Look up zTable against the patterns in dolt_ignore and decide
-** whether it should be hidden from status/add.
-**
-** Pattern syntax:
-**   '*' or '%'  → zero or more characters
-**   '?'         → exactly one character
-**   anything else (including '_') → literal
-**
-** Among matching patterns the most specific wins (longest
-** literal-character count). If two equally-specific patterns
-** disagree on `ignored`, this is a conflict and returns
-** SQLITE_CONSTRAINT with a descriptive error in *pzErr.
-**
-** Returns:
-**   SQLITE_OK          — *pIgnored set to 0 or 1. 0 means not ignored
-**                        (either no match, the winning pattern says
-**                        ignored=0, or dolt_ignore doesn't exist yet
-**                        — no table, no patterns, no filtering).
-**                        1 means the table should be hidden.
-**   SQLITE_CONSTRAINT  — conflicting patterns; *pzErr owned by caller
-**                        via sqlite3_free (may be NULL if allocation
-**                        failed).
-**   other              — storage errors while reading dolt_ignore.
-**
-** dolt_ignore is a regular user table created by the user (or by
-** seed-data on first use). No auto-materialization. */
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 int doltliteCheckIgnore(sqlite3 *db, const char *zTable,
                         int *pIgnored, char **pzErr);
 

--- a/src/doltlite_ignore.h
+++ b/src/doltlite_ignore.h
@@ -4,32 +4,6 @@
 
 typedef struct sqlite3 sqlite3;
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 int doltliteCheckIgnore(sqlite3 *db, const char *zTable,
                         int *pIgnored, char **pzErr);
 

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -17,11 +17,6 @@ enum DoltliteVcTxnMode {
   DOLTLITE_VC_TXN_NESTED_SAVEPOINT = 2
 };
 
-
-
-
-
-
 struct TableEntry {
   Pgno iTable;
   ProllyHash root;

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -17,11 +17,11 @@ enum DoltliteVcTxnMode {
   DOLTLITE_VC_TXN_NESTED_SAVEPOINT = 2
 };
 
-/* iTable is the rowid-alias of the table in sqlite_master and
-** survives renames (used by dolt_status to detect renames as same
-** iTable + different name). pPending is the in-memory ProllyMutMap
-** of uncommitted edits for this table — NULL until the first
-** mutation flushes a table entry into the working catalog. */
+
+
+
+
+
 struct TableEntry {
   Pgno iTable;
   ProllyHash root;

--- a/src/doltlite_log.c
+++ b/src/doltlite_log.c
@@ -20,12 +20,12 @@ struct DoltliteLogVtab {
 typedef struct DoltliteLogCursor DoltliteLogCursor;
 struct DoltliteLogCursor {
   sqlite3_vtab_cursor base;
-  /* BFS queue */
+
   ProllyHash *aQueue;
   int qHead, qTail, qAlloc;
   ProllyHashSet visited;
   int visitedInit;
-  /* Current row */
+
   ProllyHash curHash;
   char zHex[PROLLY_HASH_SIZE*2+1];
   DoltliteCommit curCommit;
@@ -99,8 +99,8 @@ static int doltliteLogClose(sqlite3_vtab_cursor *pCursor){
   return SQLITE_OK;
 }
 
-/* Advance the BFS by one commit. Sets hasRow=1 on success, hasRow=0
-** when the graph is exhausted. */
+
+
 static int logAdvance(DoltliteLogCursor *pCur, sqlite3 *db){
   int i, rc;
 
@@ -122,7 +122,7 @@ static int logAdvance(DoltliteLogCursor *pCur, sqlite3 *db){
     doltliteHashToHex(&cur, pCur->zHex);
     pCur->hasRow = 1;
 
-    /* Enqueue parents for future visits. */
+
     for(i = 0; i < doltliteCommitParentCount(&pCur->curCommit); i++){
       const ProllyHash *pParent = doltliteCommitParentHash(&pCur->curCommit, i);
       if( !pParent || prollyHashIsEmpty(pParent) ) continue;
@@ -168,7 +168,7 @@ static int doltliteLogFilter(
   doltliteGetSessionHead(pVtab->db, &head);
   if( prollyHashIsEmpty(&head) ) return SQLITE_OK;
 
-  /* Initialize BFS state. */
+
   rc = prollyHashSetInit(&pCur->visited, 64);
   if( rc!=SQLITE_OK ) return rc;
   pCur->visitedInit = 1;
@@ -179,7 +179,7 @@ static int doltliteLogFilter(
   pCur->aQueue[0] = head;
   pCur->qTail = 1;
 
-  /* Prime the first row. */
+
   return logAdvance(pCur, pVtab->db);
 }
 

--- a/src/doltlite_log.c
+++ b/src/doltlite_log.c
@@ -20,12 +20,10 @@ struct DoltliteLogVtab {
 typedef struct DoltliteLogCursor DoltliteLogCursor;
 struct DoltliteLogCursor {
   sqlite3_vtab_cursor base;
-
   ProllyHash *aQueue;
   int qHead, qTail, qAlloc;
   ProllyHashSet visited;
   int visitedInit;
-
   ProllyHash curHash;
   char zHex[PROLLY_HASH_SIZE*2+1];
   DoltliteCommit curCommit;
@@ -99,8 +97,6 @@ static int doltliteLogClose(sqlite3_vtab_cursor *pCursor){
   return SQLITE_OK;
 }
 
-
-
 static int logAdvance(DoltliteLogCursor *pCur, sqlite3 *db){
   int i, rc;
 
@@ -121,7 +117,6 @@ static int logAdvance(DoltliteLogCursor *pCur, sqlite3 *db){
     pCur->curHash = cur;
     doltliteHashToHex(&cur, pCur->zHex);
     pCur->hasRow = 1;
-
 
     for(i = 0; i < doltliteCommitParentCount(&pCur->curCommit); i++){
       const ProllyHash *pParent = doltliteCommitParentHash(&pCur->curCommit, i);
@@ -168,7 +163,6 @@ static int doltliteLogFilter(
   doltliteGetSessionHead(pVtab->db, &head);
   if( prollyHashIsEmpty(&head) ) return SQLITE_OK;
 
-
   rc = prollyHashSetInit(&pCur->visited, 64);
   if( rc!=SQLITE_OK ) return rc;
   pCur->visitedInit = 1;
@@ -178,7 +172,6 @@ static int doltliteLogFilter(
   if( !pCur->aQueue ) return SQLITE_NOMEM;
   pCur->aQueue[0] = head;
   pCur->qTail = 1;
-
 
   return logAdvance(pCur, pVtab->db);
 }

--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -29,24 +29,24 @@ static struct TableEntry *findTableEntry(
   return doltliteFindTableByNumber(aEntries, nEntries, iTable);
 }
 
-/* Per-index state carried through the merge callback so that
-** index edits are applied incrementally from the main table diff
-** rather than via independent three-way merge. */
+
+
+
 typedef struct MergeIndexInfo MergeIndexInfo;
 struct MergeIndexInfo {
-  Pgno iTable;           /* catalog iTable for this index */
-  ProllyHash oursRoot;   /* ours-side index root */
-  ProllyHash mergedRoot; /* result (filled after flush) */
-  ProllyMutMap *pEdits;  /* accumulated index edits */
-  int nColumn;           /* number of index columns (excl PK tail) */
-  i16 *aiColumn;         /* column mapping: index position → table col */
-  KeyInfo *pKeyInfo;     /* collation info for sort key encoding */
+  Pgno iTable;
+  ProllyHash oursRoot;
+  ProllyHash mergedRoot;
+  ProllyMutMap *pEdits;
+  int nColumn;
+  i16 *aiColumn;
+  KeyInfo *pKeyInfo;
 };
 
-/* Build an index sort key from a table row record.
-** Extracts the columns specified by aiColumn, appends the remaining
-** columns (the PK tail), builds a new record, and encodes it as a
-** sort key with all fields (matching the insert encoding). */
+
+
+
+
 static int buildIndexSortKey(
   const u8 *pRec, int nRec,
   const i16 *aiColumn, int nIdxCol,
@@ -61,19 +61,19 @@ static int buildIndexSortKey(
   doltliteParseRecord(pRec, nRec, &info);
   if( info.nField==0 ) return SQLITE_CORRUPT;
 
-  /* Build a new record with fields in index order (index cols +
-  ** all remaining cols as the PK tail). The SQLite index record
-  ** format is: [header][field1][field2]... where the header
-  ** contains varint serial types. */
+
+
+
+
   {
     int i, hdrLen = 0, bodyLen = 0;
     int nTotal;
     u8 *p;
 
-    /* Compute total number of fields: index cols + all table cols
-    ** (the full record is the value in the prolly tree, and all
-    ** fields go into the sort key for uniqueness). We reorder:
-    ** first the aiColumn fields, then all remaining fields. */
+
+
+
+
     int nOutField = info.nField;
     int *aFieldOrder = sqlite3_malloc(nOutField * sizeof(int));
     u8 *aUsed = sqlite3_malloc(info.nField);
@@ -84,7 +84,7 @@ static int buildIndexSortKey(
     }
     memset(aUsed, 0, info.nField);
 
-    /* First: index columns in index order */
+
     {
       int out = 0;
       for(i=0; i<nIdxCol; i++){
@@ -94,20 +94,20 @@ static int buildIndexSortKey(
           aUsed[col] = 1;
         }
       }
-      /* Then: remaining columns (PK tail + any others) */
+
       for(i=0; i<info.nField; i++){
         if( !aUsed[i] ) aFieldOrder[out++] = i;
       }
       nOutField = out;
     }
 
-    /* Measure header and body sizes */
+
     for(i=0; i<nOutField; i++){
       int col = aFieldOrder[i];
       int st = info.aType[col];
       int flen;
       hdrLen += sqlite3VarintLen(st);
-      /* Compute field length from serial type */
+
       if( st<=0 ){ flen = 0; }
       else if( st==1 ){ flen = 1; }
       else if( st==2 ){ flen = 2; }
@@ -122,7 +122,7 @@ static int buildIndexSortKey(
       bodyLen += flen;
     }
 
-    /* Header size includes the header-size varint itself */
+
     {
       int tentative = hdrLen + 1;
       if( tentative > 126 ) tentative++;
@@ -137,7 +137,7 @@ static int buildIndexSortKey(
       return SQLITE_NOMEM;
     }
 
-    /* Write header */
+
     p = pIdxRec;
     {
       int hs = hdrLen;
@@ -150,7 +150,7 @@ static int buildIndexSortKey(
       p += sqlite3PutVarint(p, st);
     }
 
-    /* Write body */
+
     for(i=0; i<nOutField; i++){
       int col = aFieldOrder[i];
       int st = info.aType[col];
@@ -176,7 +176,7 @@ static int buildIndexSortKey(
     sqlite3_free(aUsed);
   }
 
-  /* Encode the projected record as a sort key (all fields). */
+
   rc = sortKeyFromRecordPrefixColl(pIdxRec, nIdxRec, 0, pKeyInfo,
                                     ppKey, pnKey);
   sqlite3_free(pIdxRec);
@@ -341,12 +341,12 @@ static u8 *buildMergedRecord(MergeWinner *aWinners, int nFields, int *pnOut){
   return result;
 }
 
-/* Field-level 3-way merge. A row with a modify-modify conflict at
-** the row level still merges cleanly IF ours and theirs touched
-** different columns. For each field, pick the side that changed
-** (vs base); if both changed, merge only if the values match.
-** Returns NULL on any unresolvable field, pushing the row into the
-** conflict table. */
+
+
+
+
+
+
 static u8 *tryCellMerge(
   const u8 *pBase, int nBase,
   const u8 *pOurs, int nOurs,
@@ -421,10 +421,10 @@ static u8 *tryCellMerge(
 
         winners[i].pRec = pTheirs; winners[i].pField = &aTheirs[i];
       }else{
-        /* Both sides dropped this field (baseHas && !oursHas &&
-        ** !theirsHas), or the impossible (0,0,0) case. Field-level
-        ** merge can't represent a dropped field in the output —
-        ** fall back to row-level conflict handling. */
+
+
+
+
         sqlite3_free(winners); goto fail;
       }
     }
@@ -446,13 +446,13 @@ fail:
   return 0;
 }
 
-/* The mutator starts from oursRoot, so LEFT_* (our-side-only)
-** changes are already baked into the starting tree and must NOT be
-** re-applied. Only RIGHT_* changes (theirs-only) need to be
-** inserted/deleted on top. CONVERGENT is a no-op for the same
-** reason. CONFLICT_MM first tries field-level merge via
-** tryCellMerge — non-overlapping field edits auto-resolve — and
-** falls through to CONFLICT_DM (conflict record) if cells overlap. */
+
+
+
+
+
+
+
 static int rowMergeCallback(void *pCtx, const ThreeWayChange *pChange){
   RowMergeCtx *ctx = (RowMergeCtx*)pCtx;
   int rc = SQLITE_OK;
@@ -469,7 +469,7 @@ static int rowMergeCallback(void *pCtx, const ThreeWayChange *pChange){
       rc = prollyMutMapInsert(ctx->pEdits,
           pChange->pKey, pChange->nKey, pChange->intKey,
           pChange->pTheirVal, pChange->nTheirVal);
-      /* Apply add to each secondary index. */
+
       if( rc==SQLITE_OK && ctx->nIndexes>0
        && pChange->pTheirVal && pChange->nTheirVal>0 ){
         int ix;
@@ -493,7 +493,7 @@ static int rowMergeCallback(void *pCtx, const ThreeWayChange *pChange){
       rc = prollyMutMapInsert(ctx->pEdits,
           pChange->pKey, pChange->nKey, pChange->intKey,
           pChange->pTheirVal, pChange->nTheirVal);
-      /* Update each index: delete old entry, insert new. */
+
       if( rc==SQLITE_OK && ctx->nIndexes>0 ){
         int ix;
         for(ix=0; ix<ctx->nIndexes && rc==SQLITE_OK; ix++){
@@ -528,7 +528,7 @@ static int rowMergeCallback(void *pCtx, const ThreeWayChange *pChange){
 
       rc = prollyMutMapDelete(ctx->pEdits,
           pChange->pKey, pChange->nKey, pChange->intKey);
-      /* Delete from each index. */
+
       if( rc==SQLITE_OK && ctx->nIndexes>0
        && pChange->pBaseVal && pChange->nBaseVal>0 ){
         int ix;
@@ -569,8 +569,8 @@ static int rowMergeCallback(void *pCtx, const ThreeWayChange *pChange){
         rc = prollyMutMapInsert(ctx->pEdits,
             pChange->pKey, pChange->nKey, pChange->intKey,
             pMerged, nMerged);
-        /* Cell merge resolved: update indexes with the merged record.
-        ** Delete base entry, insert merged entry. */
+
+
         if( rc==SQLITE_OK && ctx->nIndexes>0 ){
           int ix;
           for(ix=0; ix<ctx->nIndexes && rc==SQLITE_OK; ix++){
@@ -660,26 +660,26 @@ static int rowMergeCallback(void *pCtx, const ThreeWayChange *pChange){
   return rc;
 }
 
-/* Return 1 if the table merge can take the tree-walking fast-merge
-** path; 0 if any of the disqualifying conditions hold.
-**
-** Disqualifying conditions, any one of which forces the row-by-row path:
-**   1. Either side's schema hash diverges from the ancestor — a wholesale
-**      subtree splice can't reconcile encoding differences.
-**   2. Any secondary index — fast-merge would have to drive parallel
-**      index edits per row, defeating the purpose.
-**   3. CHECK constraints — splicing in theirs's rows wholesale skips
-**      CHECK evaluation on the spliced range.
-**   4. FK with non-NO-ACTION referential actions, on either parent or
-**      child side — CASCADE/SET NULL/SET DEFAULT/RESTRICT need per-row
-**      trigger semantics. Plain NO-ACTION FKs are still safe because
-**      they're enforced by the merge_constraints post-pass against the
-**      finished tree regardless of how it was built.
-**
-** Conservative on errors: any unrecognized state returns ineligible.
-** False negatives (saying ineligible when actually OK) just cost perf;
-** false positives are wrong answers, so the gate stays strict.
-*/
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 static int canFastMerge(
   sqlite3 *db,
   const char *zName,
@@ -751,7 +751,7 @@ static int mergeTableRows(
   rc = prollyMutMapInit(ctx.pEdits, ctx.isIntKey);
   if( rc!=SQLITE_OK ){ sqlite3_free(ctx.pEdits); return rc; }
 
-  /* Initialize a mutmap for each index. */
+
   for(i=0; i<nIndexes; i++){
     aIndexes[i].pEdits = sqlite3_malloc(sizeof(ProllyMutMap));
     if( !aIndexes[i].pEdits ){ rc = SQLITE_NOMEM; goto merge_err; }
@@ -780,7 +780,7 @@ static int mergeTableRows(
     memcpy(pMergedRoot, pOursRoot, sizeof(ProllyHash));
   }
 
-  /* Flush each index's accumulated edits. */
+
   for(i=0; i<nIndexes && rc==SQLITE_OK; i++){
     if( !prollyMutMapIsEmpty(aIndexes[i].pEdits) ){
       ProllyMutator idxMut;
@@ -789,7 +789,7 @@ static int mergeTableRows(
       idxMut.pCache = cache;
       memcpy(&idxMut.oldRoot, &aIndexes[i].oursRoot, sizeof(ProllyHash));
       idxMut.pEdits = aIndexes[i].pEdits;
-      idxMut.flags = 0;  /* blob keys */
+      idxMut.flags = 0;
       rc = prollyMutateFlush(&idxMut);
       if( rc==SQLITE_OK ){
         memcpy(&aIndexes[i].mergedRoot, &idxMut.newRoot, sizeof(ProllyHash));
@@ -1961,13 +1961,13 @@ static int tryResolveSchemaDivergence(
   return SQLITE_OK;
 }
 
-/* Pass 1: walk OUR side, resolving each table against anc/theirs.
-** For every "ours" table, determine whether row-merge is needed and
-** invoke mergeTableRows; any rows that can't auto-merge become
-** conflict entries. Table iTable==1 (the catalog itself) is deferred
-** to the end so schema actions collected earlier can influence its
-** merge decision. Pass 2 picks up any tables that exist in theirs
-** but not ours. */
+
+
+
+
+
+
+
 static int mergeCatalogPass1(
   sqlite3 *db,
   struct TableEntry *aAnc, int nAnc,
@@ -2019,11 +2019,11 @@ static int mergeCatalogPass1(
             pOurSe->zType, pOurSe->zName, pOurSe->zTblName);
         goto do_merge_entry;
       }
-      /* Nameless catalog entry — secondary index. Three-way merge
-      ** by iTable number. With PK-suffix sort keys, the three-way
-      ** merge handles non-conflict cases correctly. For conflicts,
-      ** the parent table's mergeTableRows overwrites the root with
-      ** the incrementally-computed result. */
+
+
+
+
+
       ancEntry = findTableEntry(aAnc, nAnc, aOurs[i].iTable);
       theirsEntry = findTableEntry(aTheirs, nTheirs, aOurs[i].iTable);
       goto do_merge_entry;
@@ -2108,8 +2108,8 @@ do_merge_entry:
             int nConflicts = 0;
             struct ConflictRow *aConflictRows = 0;
 
-            /* Collect secondary indexes for this table so they can
-            ** be updated incrementally during the row merge. */
+
+
             MergeIndexInfo *aIdxInfo = 0;
             int nIdxInfo = 0;
             if( zName && db ){
@@ -2130,7 +2130,7 @@ do_merge_entry:
                         memcpy(&mi->oursRoot, &oursIdx->root, sizeof(ProllyHash));
                         mi->nColumn = pIdx->nKeyCol;
                         mi->aiColumn = pIdx->aiColumn;
-                        mi->pKeyInfo = 0; /* BINARY collation; NOCASE TBD */
+                        mi->pKeyInfo = 0;
                         nIdxInfo++;
                       }
                     }
@@ -2139,11 +2139,11 @@ do_merge_entry:
               }
             }
 
-            /* Try the tree-walking fast merge first when the
-            ** predicate says it's safe. On *pHandled=0, fall through
-            ** to the row-by-row path. The predicate guarantees no
-            ** secondary indexes, so the fast path doesn't need to
-            ** drive the aIdxInfo array. */
+
+
+
+
+
             if( canFastMerge(db, zName,
                              !ourSchemaChanged && !theirSchemaChanged) ){
               int handled = 0;
@@ -2160,7 +2160,7 @@ do_merge_entry:
                 aConflictRows = 0;
                 goto post_merge_table_rows;
               }
-              /* Not handled — fall through to row path. */
+
             }
 
             rc = mergeTableRows(db, &ancEntry->root, &aOurs[i].root,
@@ -2170,7 +2170,7 @@ do_merge_entry:
 
 post_merge_table_rows:;
 
-            /* Store merged index roots back into aMerged catalog. */
+
             if( rc==SQLITE_OK ){
               int ix;
               for(ix=0; ix<nIdxInfo; ix++){
@@ -2373,8 +2373,8 @@ static int mergeCatalogPass2(
         continue;
       }
 
-      /* Nameless entry (secondary index). If ours doesn't have this
-      ** iTable, it's a new index from theirs — add it. */
+
+
       if( !findTableEntry(aOurs, nOurs, aTheirs[i].iTable) ){
         struct TableEntry newEntry = aTheirs[i];
         int j, conflict = 0;
@@ -2583,24 +2583,24 @@ int doltliteMergeCatalogs(
                           bDisjointSchemaChanges,
                           bPreferOurMaster);
   if( rc!=SQLITE_OK ){
-    /* pass1 shallow-copies zName pointers from aOurs into aMerged.
-    ** The strdup loop below (which breaks the aliasing) hasn't run
-    ** yet, so NULL out the shallow copies before merge_cleanup frees
-    ** both arrays — otherwise it's a double-free. */
+
+
+
+
     int k;
     for(k=0; k<nMerged; k++) aMerged[k].zName = 0;
     goto merge_cleanup;
   }
 
-  /* pass1 shallow-copies TableEntry structs from aOurs into aMerged,
-  ** which means zName pointers are aliased — aMerged[k].zName ==
-  ** aOurs[i].zName for some i. serializeMergedCatalog below frees
-  ** those strings via doltliteResolveTableNumber's refresh step,
-  ** leaving aOurs with dangling pointers. Break the aliasing here
-  ** by strdup'ing every aMerged zName so aMerged owns its own
-  ** storage and all four catalogs can be cleaned up independently
-  ** via doltliteFreeCatalog. pass2 already strdup's on append, so
-  ** this loop only needs to fix pass1's output. */
+
+
+
+
+
+
+
+
+
   {
     int k;
     for(k=0; k<nMerged; k++){

--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -29,9 +29,6 @@ static struct TableEntry *findTableEntry(
   return doltliteFindTableByNumber(aEntries, nEntries, iTable);
 }
 
-
-
-
 typedef struct MergeIndexInfo MergeIndexInfo;
 struct MergeIndexInfo {
   Pgno iTable;
@@ -42,10 +39,6 @@ struct MergeIndexInfo {
   i16 *aiColumn;
   KeyInfo *pKeyInfo;
 };
-
-
-
-
 
 static int buildIndexSortKey(
   const u8 *pRec, int nRec,
@@ -61,18 +54,10 @@ static int buildIndexSortKey(
   doltliteParseRecord(pRec, nRec, &info);
   if( info.nField==0 ) return SQLITE_CORRUPT;
 
-
-
-
-
   {
     int i, hdrLen = 0, bodyLen = 0;
     int nTotal;
     u8 *p;
-
-
-
-
 
     int nOutField = info.nField;
     int *aFieldOrder = sqlite3_malloc(nOutField * sizeof(int));
@@ -84,7 +69,6 @@ static int buildIndexSortKey(
     }
     memset(aUsed, 0, info.nField);
 
-
     {
       int out = 0;
       for(i=0; i<nIdxCol; i++){
@@ -94,20 +78,17 @@ static int buildIndexSortKey(
           aUsed[col] = 1;
         }
       }
-
       for(i=0; i<info.nField; i++){
         if( !aUsed[i] ) aFieldOrder[out++] = i;
       }
       nOutField = out;
     }
 
-
     for(i=0; i<nOutField; i++){
       int col = aFieldOrder[i];
       int st = info.aType[col];
       int flen;
       hdrLen += sqlite3VarintLen(st);
-
       if( st<=0 ){ flen = 0; }
       else if( st==1 ){ flen = 1; }
       else if( st==2 ){ flen = 2; }
@@ -121,7 +102,6 @@ static int buildIndexSortKey(
       else{ flen = 0; }
       bodyLen += flen;
     }
-
 
     {
       int tentative = hdrLen + 1;
@@ -137,7 +117,6 @@ static int buildIndexSortKey(
       return SQLITE_NOMEM;
     }
 
-
     p = pIdxRec;
     {
       int hs = hdrLen;
@@ -149,7 +128,6 @@ static int buildIndexSortKey(
       int st = info.aType[col];
       p += sqlite3PutVarint(p, st);
     }
-
 
     for(i=0; i<nOutField; i++){
       int col = aFieldOrder[i];
@@ -175,7 +153,6 @@ static int buildIndexSortKey(
     sqlite3_free(aFieldOrder);
     sqlite3_free(aUsed);
   }
-
 
   rc = sortKeyFromRecordPrefixColl(pIdxRec, nIdxRec, 0, pKeyInfo,
                                     ppKey, pnKey);
@@ -272,7 +249,6 @@ static u8 *buildMergedRecord(MergeWinner *aWinners, int nFields, int *pnOut){
   int hdrSize = 0, bodySize = 0, pos, i;
   u8 *result;
 
-
   for(i=0; i<nFields; i++){
     u64 st = aWinners[i].pField->st;
     if(st <= 0x7f) hdrSize += 1;
@@ -289,7 +265,6 @@ static u8 *buildMergedRecord(MergeWinner *aWinners, int nFields, int *pnOut){
 
   result = sqlite3_malloc(hdrSize + bodySize);
   if(!result){ *pnOut = 0; return 0; }
-
 
   pos = 0;
   { u64 hs = (u64)hdrSize;
@@ -326,7 +301,6 @@ static u8 *buildMergedRecord(MergeWinner *aWinners, int nFields, int *pnOut){
 
   *pnOut = pos;
 
-
 #ifndef NDEBUG
   {
     int nfCheck = 0;
@@ -341,12 +315,6 @@ static u8 *buildMergedRecord(MergeWinner *aWinners, int nFields, int *pnOut){
   return result;
 }
 
-
-
-
-
-
-
 static u8 *tryCellMerge(
   const u8 *pBase, int nBase,
   const u8 *pOurs, int nOurs,
@@ -358,16 +326,13 @@ static u8 *tryCellMerge(
   int nfMax, i;
   u8 *result = 0;
 
-
   if(parseRecordFields(pBase, nBase, &aBase, &nfBase)<0) goto fail;
   if(parseRecordFields(pOurs, nOurs, &aOurs, &nfOurs)<0) goto fail;
   if(parseRecordFields(pTheirs, nTheirs, &aTheirs, &nfTheirs)<0) goto fail;
 
-
   nfMax = nfBase;
   if(nfOurs > nfMax) nfMax = nfOurs;
   if(nfTheirs > nfMax) nfMax = nfTheirs;
-
 
   {
     MergeWinner *winners;
@@ -421,10 +386,6 @@ static u8 *tryCellMerge(
 
         winners[i].pRec = pTheirs; winners[i].pField = &aTheirs[i];
       }else{
-
-
-
-
         sqlite3_free(winners); goto fail;
       }
     }
@@ -446,13 +407,6 @@ fail:
   return 0;
 }
 
-
-
-
-
-
-
-
 static int rowMergeCallback(void *pCtx, const ThreeWayChange *pChange){
   RowMergeCtx *ctx = (RowMergeCtx*)pCtx;
   int rc = SQLITE_OK;
@@ -469,7 +423,6 @@ static int rowMergeCallback(void *pCtx, const ThreeWayChange *pChange){
       rc = prollyMutMapInsert(ctx->pEdits,
           pChange->pKey, pChange->nKey, pChange->intKey,
           pChange->pTheirVal, pChange->nTheirVal);
-
       if( rc==SQLITE_OK && ctx->nIndexes>0
        && pChange->pTheirVal && pChange->nTheirVal>0 ){
         int ix;
@@ -493,7 +446,6 @@ static int rowMergeCallback(void *pCtx, const ThreeWayChange *pChange){
       rc = prollyMutMapInsert(ctx->pEdits,
           pChange->pKey, pChange->nKey, pChange->intKey,
           pChange->pTheirVal, pChange->nTheirVal);
-
       if( rc==SQLITE_OK && ctx->nIndexes>0 ){
         int ix;
         for(ix=0; ix<ctx->nIndexes && rc==SQLITE_OK; ix++){
@@ -528,7 +480,6 @@ static int rowMergeCallback(void *pCtx, const ThreeWayChange *pChange){
 
       rc = prollyMutMapDelete(ctx->pEdits,
           pChange->pKey, pChange->nKey, pChange->intKey);
-
       if( rc==SQLITE_OK && ctx->nIndexes>0
        && pChange->pBaseVal && pChange->nBaseVal>0 ){
         int ix;
@@ -569,8 +520,6 @@ static int rowMergeCallback(void *pCtx, const ThreeWayChange *pChange){
         rc = prollyMutMapInsert(ctx->pEdits,
             pChange->pKey, pChange->nKey, pChange->intKey,
             pMerged, nMerged);
-
-
         if( rc==SQLITE_OK && ctx->nIndexes>0 ){
           int ix;
           for(ix=0; ix<ctx->nIndexes && rc==SQLITE_OK; ix++){
@@ -660,26 +609,6 @@ static int rowMergeCallback(void *pCtx, const ThreeWayChange *pChange){
   return rc;
 }
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 static int canFastMerge(
   sqlite3 *db,
   const char *zName,
@@ -751,7 +680,6 @@ static int mergeTableRows(
   rc = prollyMutMapInit(ctx.pEdits, ctx.isIntKey);
   if( rc!=SQLITE_OK ){ sqlite3_free(ctx.pEdits); return rc; }
 
-
   for(i=0; i<nIndexes; i++){
     aIndexes[i].pEdits = sqlite3_malloc(sizeof(ProllyMutMap));
     if( !aIndexes[i].pEdits ){ rc = SQLITE_NOMEM; goto merge_err; }
@@ -759,11 +687,9 @@ static int mergeTableRows(
     if( rc!=SQLITE_OK ) goto merge_err;
   }
 
-
   rc = prollyThreeWayDiff(cs, cache, pAncRoot, pOursRoot, pTheirsRoot,
                           flags, rowMergeCallback, &ctx);
   if( rc!=SQLITE_OK ) goto merge_err;
-
 
   if( !prollyMutMapIsEmpty(ctx.pEdits) ){
     memset(&mut, 0, sizeof(mut));
@@ -779,7 +705,6 @@ static int mergeTableRows(
   }else{
     memcpy(pMergedRoot, pOursRoot, sizeof(ProllyHash));
   }
-
 
   for(i=0; i<nIndexes && rc==SQLITE_OK; i++){
     if( !prollyMutMapIsEmpty(aIndexes[i].pEdits) ){
@@ -896,12 +821,10 @@ static int parseColumns(
 
   if( !zSql ) return SQLITE_OK;
 
-
   p = zSql;
   while( *p && *p!='(' ) p++;
   if( *p!='(' ) return SQLITE_CORRUPT;
   p++;
-
 
   pEnd = p;
   depth = 1;
@@ -913,7 +836,6 @@ static int parseColumns(
   if( depth!=0 ) return SQLITE_CORRUPT;
   pEnd--;
 
-
   segStart = p;
   depth = 0;
   while( p <= pEnd ){
@@ -924,13 +846,11 @@ static int parseColumns(
       char *zTrimmed;
       int len;
 
-
       while( s<e && isspace((unsigned char)*s) ) s++;
       while( e>s && isspace((unsigned char)*(e-1)) ) e--;
 
       len = (int)(e - s);
       if( len > 0 ){
-
 
         int isConstraint = 0;
         {
@@ -968,7 +888,6 @@ static int parseColumns(
           }
           memcpy(zTrimmed, s, len);
           zTrimmed[len] = 0;
-
 
           {
             char *zName;
@@ -1101,9 +1020,6 @@ static int trySchemaColumnMerge(
   rc = parseColumns(zTheirsSql, &aTheirs, &nTheirs);
   if( rc!=SQLITE_OK ){ freeColumns(aAnc, nAnc); freeColumns(aOurs, nOurs); return rc; }
 
-
-
-
   for(i=0; i<nTheirs; i++){
     ParsedColumn *ancCol = findColumn(aAnc, nAnc, aTheirs[i].zName);
     if( !ancCol ){
@@ -1172,7 +1088,6 @@ static int trySchemaColumnMerge(
     }
   }
 
-
   for(i=0; i<nOurs; i++){
     ParsedColumn *ancCol = findColumn(aAnc, nAnc, aOurs[i].zName);
     if( ancCol ){
@@ -1196,7 +1111,6 @@ static int trySchemaColumnMerge(
     }
 
   }
-
 
   if( nAdd > 0 ){
     *pUseTheirSchema = 0;
@@ -1961,13 +1875,6 @@ static int tryResolveSchemaDivergence(
   return SQLITE_OK;
 }
 
-
-
-
-
-
-
-
 static int mergeCatalogPass1(
   sqlite3 *db,
   struct TableEntry *aAnc, int nAnc,
@@ -1997,12 +1904,10 @@ static int mergeCatalogPass1(
     struct TableEntry *ancEntry;
     struct TableEntry *theirsEntry;
 
-
     if( aOurs[i].iTable==1 ){
       iTable1Idx = i;
       continue;
     }
-
 
     if( !zName ){
       SchemaEntry *pOurSe = findSchemaEntryByRootpage(
@@ -2019,16 +1924,10 @@ static int mergeCatalogPass1(
             pOurSe->zType, pOurSe->zName, pOurSe->zTblName);
         goto do_merge_entry;
       }
-
-
-
-
-
       ancEntry = findTableEntry(aAnc, nAnc, aOurs[i].iTable);
       theirsEntry = findTableEntry(aTheirs, nTheirs, aOurs[i].iTable);
       goto do_merge_entry;
     }
-
 
     ancEntry = findTableByName(aAnc, nAnc, zName);
     theirsEntry = findTableByName(aTheirs, nTheirs, zName);
@@ -2087,7 +1986,6 @@ do_merge_entry:
               aAncSchema, nAncSchema, aTheirsSchema, nTheirsSchema, zSchemaMergeName);
         }
 
-
         if( ourSchemaChanged && theirSchemaChanged
          && (bNamedSchemaObject
              || prollyHashCompare(&aOurs[i].schemaHash,
@@ -2107,8 +2005,6 @@ do_merge_entry:
             ProllyHash mergedTableRoot;
             int nConflicts = 0;
             struct ConflictRow *aConflictRows = 0;
-
-
 
             MergeIndexInfo *aIdxInfo = 0;
             int nIdxInfo = 0;
@@ -2139,11 +2035,6 @@ do_merge_entry:
               }
             }
 
-
-
-
-
-
             if( canFastMerge(db, zName,
                              !ourSchemaChanged && !theirSchemaChanged) ){
               int handled = 0;
@@ -2160,7 +2051,6 @@ do_merge_entry:
                 aConflictRows = 0;
                 goto post_merge_table_rows;
               }
-
             }
 
             rc = mergeTableRows(db, &ancEntry->root, &aOurs[i].root,
@@ -2169,7 +2059,6 @@ do_merge_entry:
                                 aIdxInfo, nIdxInfo);
 
 post_merge_table_rows:;
-
 
             if( rc==SQLITE_OK ){
               int ix;
@@ -2220,7 +2109,6 @@ post_merge_table_rows:;
       }
     }
   }
-
 
   if( iTable1Idx >= 0 ){
     struct TableEntry *ancEntry = findTableEntry(aAnc, nAnc, 1);
@@ -2372,8 +2260,6 @@ static int mergeCatalogPass2(
         }
         continue;
       }
-
-
 
       if( !findTableEntry(aOurs, nOurs, aTheirs[i].iTable) ){
         struct TableEntry newEntry = aTheirs[i];
@@ -2565,11 +2451,8 @@ int doltliteMergeCatalogs(
     if( rc!=SQLITE_OK ) goto merge_cleanup;
   }
 
-
   iNextMerged = iNextOurs > iNextTheirs ? iNextOurs : iNextTheirs;
   bDisjointSchemaChanges = catalogHasDisjointSchemaChanges(db, ancestor, ours, theirs);
-
-
 
   rc = mergeCatalogPass1(db, aAnc, nAnc, aOurs, nOurs, aTheirs, nTheirs,
                           aAncSchema, nAncSchema,
@@ -2583,23 +2466,10 @@ int doltliteMergeCatalogs(
                           bDisjointSchemaChanges,
                           bPreferOurMaster);
   if( rc!=SQLITE_OK ){
-
-
-
-
     int k;
     for(k=0; k<nMerged; k++) aMerged[k].zName = 0;
     goto merge_cleanup;
   }
-
-
-
-
-
-
-
-
-
 
   {
     int k;
@@ -2631,7 +2501,6 @@ int doltliteMergeCatalogs(
   rc = serializeMergedCatalog(db, ours, aMerged, nMerged, iNextMerged,
                               aTheirsSchema, nTheirsSchema, pMergedHash);
   if( pnConflicts ) *pnConflicts = totalConflicts;
-
 
   if( totalConflicts>0 && nConflictTables>0 && rc==SQLITE_OK ){
     recordMergeConflicts(db, aConflictTables, nConflictTables);

--- a/src/doltlite_merge_constraints.c
+++ b/src/doltlite_merge_constraints.c
@@ -12,30 +12,30 @@
 
 #include <string.h>
 
-/* Post-merge constraint detection.
-**
-** Called from doltliteMergeFunc AFTER the merged catalog has been
-** installed into the session via doltliteSwitchCatalog, so
-** sqlite_schema reflects the merged DDL and each Table* has its
-** pFKey / pCheck / aIndex chains loaded.
-**
-** For now scoped to FK orphans only: for each table in the
-** merged catalog with at least one foreign key, run PRAGMA
-** foreign_key_check to get the orphan rowids, then walk the
-** child table's prolly tree to find each orphan row's raw key
-** and value bytes for persisting into
-** dolt_constraint_violations_<table>.
-**
-** Unique-index and check-constraint violations follow in
-** Phase 6 — they need diff-based detection because the merge
-** already collapses the table into a single prolly tree and
-** SQLite's PRAGMA integrity_check doesn't distinguish what was
-** present on each side of the merge. */
 
-/* Walk pRoot until we find the row whose intKey matches
-** targetRowid. Copies the row's key + value bytes into the
-** caller's out buffers (sqlite3_malloc). Returns SQLITE_NOTFOUND
-** if no row matches, SQLITE_OK otherwise. */
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 static int fetchRowByRowid(
   ChunkStore *cs,
   ProllyCache *pCache,
@@ -188,9 +188,9 @@ static void fkRefreshFreeNames(char **azNames, int nNames){
   sqlite3_free(azNames);
 }
 
-/* Same-name drop/recreate replay can leave parent unique indexes stale until
-** reopen. If FK check reports rows, rebuild just the child/parent tables
-** mentioned there and re-check before treating them as real violations. */
+
+
+
 static int fkRefreshCandidateTables(sqlite3 *db, int *pChanged){
   sqlite3_stmt *pStmt = 0;
   char **azNames = 0;
@@ -546,10 +546,10 @@ static int fetchRowByPkRecord(
   return SQLITE_NOTFOUND;
 }
 
-/* Build the violation_info JSON string for one FK orphan. The
-** shape deliberately matches Dolt's output format (same top-level
-** keys so oracle tests and external consumers see one schema).
-** Caller owns the returned string. */
+
+
+
+
 static char *buildFkViolationInfo(
   sqlite3 *db,
   const char *zChildTable,
@@ -570,9 +570,9 @@ static char *buildFkViolationInfo(
   int nMatches = 0;
   int fatal = 0;
 
-  /* sqlite3_str_new() always returns a non-NULL handle; OOM is
-  ** surfaced later via sqlite3_str_errcode() / the final
-  ** sqlite3_str_finish() returning NULL. */
+
+
+
   pJson = sqlite3_str_new(0);
   pCols = sqlite3_str_new(0);
   pRefCols = sqlite3_str_new(0);
@@ -586,12 +586,12 @@ static char *buildFkViolationInfo(
     if( rc != SQLITE_OK ){
       fatal = 1;
     }else{
-      /* Walk every row belonging to this fkid, accumulating the
-      ** child column list and the referenced column list into
-      ** separate buffers. Scalar fields (ReferencedTable /
-      ** OnUpdate / OnDelete) only need the first matching row —
-      ** PRAGMA foreign_key_list repeats them identically for each
-      ** column of a composite FK. */
+
+
+
+
+
+
       while( sqlite3_step(pStmt) == SQLITE_ROW ){
         int id = sqlite3_column_int(pStmt, 0);
         const char *zParent, *zFrom, *zTo, *zOnUp, *zOnDel;
@@ -618,15 +618,15 @@ static char *buildFkViolationInfo(
   }
   sqlite3_finalize(pStmt);
 
-  /* Finalizing the two column-list builders releases them
-  ** regardless of whether the walk ran. If OOM occurred during
-  ** any append, finish returns NULL and the result propagates. */
+
+
+
   zColsBuf    = sqlite3_str_finish(pCols);
   zRefColsBuf = sqlite3_str_finish(pRefCols);
 
   if( fatal ){
-    /* Fail the whole object rather than emit a degraded JSON
-    ** with empty columns — the caller treats NULL as "no info". */
+
+
     sqlite3_free(sqlite3_str_finish(pJson));
     sqlite3_free(zColsBuf);
     sqlite3_free(zRefColsBuf);
@@ -655,14 +655,14 @@ static char *buildFkViolationInfo(
   return zResult;
 }
 
-/* Look up (zTable, rowid) in a previously-loaded ancestor catalog
-** and return SQLITE_OK with the row's raw pVal bytes if the row
-** existed in the ancestor at the same rowid, SQLITE_NOTFOUND
-** otherwise. `aAnc`/`nAnc` are the result of
-** doltliteLoadCatalog(&ancCatHash). The caller owns *ppAncVal on
-** success. Used by the post-merge walkers to decide whether a
-** candidate violation is merge-introduced (row changed or new)
-** or pre-existing (row unchanged since ancestor). */
+
+
+
+
+
+
+
+
 static int fetchAncestorRowByName(
   sqlite3 *db,
   struct TableEntry *aAnc, int nAnc,
@@ -727,22 +727,22 @@ static int fetchAncestorRowByKey(
   return rc;
 }
 
-/* Decide whether a candidate violation is pre-existing: the row
-** exists in the ancestor catalog at the same rowid with byte-for-
-** byte identical value payload. Returns 1 if pre-existing (the
-** caller should skip flagging), 0 if merge-introduced or the
-** ancestor state can't be consulted. Empty ancCatHash short-
-** circuits to 0 (no ancestor — treat every violation as fresh).
-**
-** Known hole: this rule is the "child row unchanged" filter
-** only. It does not catch the case where a parent row is
-** deleted on one side while the child row is unchanged — in
-** that scenario the merge DID introduce the orphan, but this
-** filter will still flag it because the child is unchanged.
-** That is a strict improvement over the prior state where every
-** pre-existing orphan blocked every unrelated merge, and can be
-** tightened later (see GitHub issue for the semantics-drift
-** tracking item). */
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 static int isRowPreExisting(
   const u8 *pMergedVal, int nMergedVal,
   const u8 *pAncVal, int nAncVal
@@ -753,31 +753,31 @@ static int isRowPreExisting(
   return memcmp(pMergedVal, pAncVal, nMergedVal)==0 ? 1 : 0;
 }
 
-/* Probe whether zTable exposes a `rowid` column. Returns 1 if
-** the table has a rowid (standard SQLite tables), 0 if it is
-** declared WITHOUT ROWID. The post-merge walkers lean heavily
-** on rowid to identify specific violating rows and to fetch
-** their prolly-layer payload; WITHOUT ROWID tables break every
-** piece of that pipeline, so detection refuses to proceed
-** rather than silently miss violations. Tracked in GitHub
-** issue #495 — proper WITHOUT ROWID support requires a prolly-
-** layer-level walker that keys on the composite PK instead. */
+
+
+
+
+
+
+
+
+
 static int tableHasRowid(sqlite3 *db, const char *zTable){
   sqlite3_stmt *pStmt = 0;
   char *zQuery;
   int rc;
   zQuery = sqlite3_mprintf("SELECT rowid FROM main.\"%w\" LIMIT 0", zTable);
-  if( !zQuery ) return 1; /* treat OOM as rowid — caller will fail elsewhere */
+  if( !zQuery ) return 1;
   rc = sqlite3_prepare_v2(db, zQuery, -1, &pStmt, 0);
   sqlite3_free(zQuery);
   if( pStmt ) sqlite3_finalize(pStmt);
   return rc == SQLITE_OK ? 1 : 0;
 }
 
-/* Resolve a (zTable, rowid) pair to the raw prolly row by looking
-** the table up in the current btree's catalog via the public
-** doltliteGetSessionTableRoot accessor and walking its prolly
-** root to find the matching key. */
+
+
+
+
 static int fetchOrphanRow(
   sqlite3 *db,
   const char *zTable,
@@ -942,12 +942,12 @@ static int appendUniqueViolationByPk(
   return rc;
 }
 
-/* Return 1 if any column in [colFirst, colLast) of the current
-** row is NULL. Per SQL standard, a row with NULL in any column
-** of a UNIQUE index is exempt from that uniqueness check
-** (NULL != NULL for UNIQUE). Such rows cannot participate in a
-** duplicate group and must be skipped by the merge-time dup
-** detection below. */
+
+
+
+
+
+
 static int uniqueIndexRowHasNull(sqlite3_stmt *pScan, int colFirst, int colLast){
   int i;
   for(i=colFirst; i<colLast; i++){
@@ -956,20 +956,20 @@ static int uniqueIndexRowHasNull(sqlite3_stmt *pScan, int colFirst, int colLast)
   return 0;
 }
 
-/* Walk every row in zTable and look for duplicate values on the
-** given UNIQUE index columns. When a duplicate group is found,
-** every merge-introduced row in that group is recorded in
-** dolt_constraint_violations_<table> with
-** violation_type = 'unique index'. The base table keeps all
-** merged rows intact; users resolve the violation by deleting
-** rows from the violation vtable and then committing.
-**
-** We can't just `GROUP BY` the index columns here — SQLite's
-** query planner sees the UNIQUE constraint and optimizes on the
-** assumption that each value appears at most once, collapsing
-** duplicate rows that our prolly-level merge introduced. Force
-** a full table scan with the `NOT INDEXED` clause and do the
-** grouping ourselves in the driver. */
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 static int detectUniqueViolationsForIndex(
   sqlite3 *db,
   struct TableEntry *aAnc, int nAnc,
@@ -1015,7 +1015,7 @@ static int detectUniqueViolationsForIndex(
 
     isDup = zWinnerKey && strcmp(zWinnerKey, zRowKey)==0;
     if( !isDup ){
-      /* New group — this row wins, remember its value set. */
+
       sqlite3_free(zWinnerKey);
       zWinnerKey = zRowKey;
       winnerRowid = rowid;
@@ -1146,11 +1146,11 @@ static int detectUniqueViolationsForIndexWithoutRowid(
   return rc;
 }
 
-/* For every user table in the session's catalog, walk its
-** UNIQUE indexes via PRAGMA index_list / PRAGMA index_xinfo
-** and feed each into detectUniqueViolationsForIndex. The
-** ancestor catalog is loaded once and shared across all
-** per-index scans so repeated lookups are cheap. */
+
+
+
+
+
 int doltliteDetectMergeUniqueViolations(
   sqlite3 *db,
   const ProllyHash *pAncCatHash,
@@ -1227,11 +1227,11 @@ int doltliteDetectMergeUniqueViolations(
       zIdxRaw = (const char*)sqlite3_column_text(pIdxList, 1);
       if( !zIdxRaw ) continue;
 
-      /* Skip the primary-key auto-index — walking it would
-      ** double-count every row as its own duplicate. Use the
-      ** origin column (pk / u / c) instead of pattern-matching
-      ** the name so WITHOUT ROWID autoindexes get handled
-      ** correctly regardless of numbering. */
+
+
+
+
+
       zOrigin = (const char*)sqlite3_column_text(pIdxList, 3);
       if( zOrigin && strcmp(zOrigin, "pk")==0 ) continue;
 
@@ -1281,18 +1281,18 @@ int doltliteDetectMergeUniqueViolations(
   return rc;
 }
 
-/* Extract the next CHECK (expr) clause starting at or after
-** *pOffset in zSql. On success returns 1 and fills *pzExpr with
-** a freshly-allocated inner expression and *pzName with the
-** constraint name (if preceded by `CONSTRAINT <name>`) or NULL.
-** Advances *pOffset past the closing paren. Returns 0 at end of
-** string. Returns -1 on malformed input.
-**
-** Simple state machine: skip forward to `CHECK` (case-insensitive),
-** note any CONSTRAINT clause preceding it, then walk balanced
-** parens to find the end of the expression. Handles quoted
-** identifiers and string literals so CHECK (name = 'silly)name')
-** doesn't get chopped at the first `)`. */
+
+
+
+
+
+
+
+
+
+
+
+
 static int nextCheckClause(
   const char *zSql, int *pOffset, char **pzExpr, char **pzName
 ){
@@ -1306,8 +1306,8 @@ static int nextCheckClause(
   *pzName = 0;
 
   while( *p ){
-    /* Track a `CONSTRAINT <name>` clause so we can attach it to
-    ** the next CHECK that shows up. */
+
+
     if( (p[0]=='C' || p[0]=='c')
      && strncasecmp(p, "CONSTRAINT", 10)==0
      && (p[10]==' ' || p[10]=='\t' || p[10]=='\n') ){
@@ -1378,9 +1378,9 @@ static int nextCheckClause(
       if( *p=='"' ) p++;
       continue;
     }
-    /* Reset a pending CONSTRAINT name if we hit a comma without
-    ** seeing CHECK — that clause was something else (UNIQUE,
-    ** FOREIGN KEY, etc). */
+
+
+
     if( *p==',' ) lastConstraintName[0] = 0;
     p++;
   }
@@ -1388,15 +1388,15 @@ static int nextCheckClause(
   return 0;
 }
 
-/* For each user table, parse its CREATE TABLE DDL for CHECK
-** constraints and run SELECT rowid WHERE NOT (expr) to find any
-** row in the merged result that doesn't satisfy one. Emit each
-** as a 'check constraint' violation. Unlike unique detection we
-** keep the row in the base table — Dolt's CHECK semantics leave
-** violating rows present and block commit until resolved.
-** Ancestor filter is the same shape as the FK walker: any
-** violating row that already existed unchanged in ancestor was
-** already broken before the merge started and is skipped. */
+
+
+
+
+
+
+
+
+
 int doltliteDetectMergeCheckViolations(
   sqlite3 *db,
   const ProllyHash *pAncCatHash,
@@ -1674,21 +1674,21 @@ static int detectFkViolationsForSpec(
   return rc;
 }
 
-/* Entry point. Runs PRAGMA foreign_key_check to find every
-** orphan row across all tables, fetches each row's raw payload
-** from the prolly store, and appends one violation per orphan
-** into the session-scoped dolt_constraint_violations blob.
-**
-** `pAncCatHash` points at the three-way-merge ancestor catalog
-** hash. For each candidate orphan the walker asks whether the
-** same row existed unchanged in ancestor — if so, the row was
-** already an orphan before either side started and the merge
-** is not introducing anything new, so it is skipped.
-**
-** Passing an empty/zero hash disables the filter entirely, which
-** is fine for call sites that don't have a three-way ancestor
-** (e.g. cherry-pick onto empty). Returns the number of violations
-** appended via *pnFound. Returns SQLITE_OK on success. */
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 int doltliteDetectMergeFkViolations(
   sqlite3 *db,
   const ProllyHash *pAncCatHash,

--- a/src/doltlite_merge_constraints.c
+++ b/src/doltlite_merge_constraints.c
@@ -12,30 +12,6 @@
 
 #include <string.h>
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 static int fetchRowByRowid(
   ChunkStore *cs,
   ProllyCache *pCache,
@@ -187,9 +163,6 @@ static void fkRefreshFreeNames(char **azNames, int nNames){
   for(i=0; i<nNames; i++) sqlite3_free(azNames[i]);
   sqlite3_free(azNames);
 }
-
-
-
 
 static int fkRefreshCandidateTables(sqlite3 *db, int *pChanged){
   sqlite3_stmt *pStmt = 0;
@@ -546,10 +519,6 @@ static int fetchRowByPkRecord(
   return SQLITE_NOTFOUND;
 }
 
-
-
-
-
 static char *buildFkViolationInfo(
   sqlite3 *db,
   const char *zChildTable,
@@ -570,9 +539,6 @@ static char *buildFkViolationInfo(
   int nMatches = 0;
   int fatal = 0;
 
-
-
-
   pJson = sqlite3_str_new(0);
   pCols = sqlite3_str_new(0);
   pRefCols = sqlite3_str_new(0);
@@ -586,12 +552,6 @@ static char *buildFkViolationInfo(
     if( rc != SQLITE_OK ){
       fatal = 1;
     }else{
-
-
-
-
-
-
       while( sqlite3_step(pStmt) == SQLITE_ROW ){
         int id = sqlite3_column_int(pStmt, 0);
         const char *zParent, *zFrom, *zTo, *zOnUp, *zOnDel;
@@ -618,15 +578,10 @@ static char *buildFkViolationInfo(
   }
   sqlite3_finalize(pStmt);
 
-
-
-
   zColsBuf    = sqlite3_str_finish(pCols);
   zRefColsBuf = sqlite3_str_finish(pRefCols);
 
   if( fatal ){
-
-
     sqlite3_free(sqlite3_str_finish(pJson));
     sqlite3_free(zColsBuf);
     sqlite3_free(zRefColsBuf);
@@ -654,14 +609,6 @@ static char *buildFkViolationInfo(
   sqlite3_free(zOnDelBuf);
   return zResult;
 }
-
-
-
-
-
-
-
-
 
 static int fetchAncestorRowByName(
   sqlite3 *db,
@@ -727,22 +674,6 @@ static int fetchAncestorRowByKey(
   return rc;
 }
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 static int isRowPreExisting(
   const u8 *pMergedVal, int nMergedVal,
   const u8 *pAncVal, int nAncVal
@@ -752,15 +683,6 @@ static int isRowPreExisting(
   if( nMergedVal == 0 ) return 1;
   return memcmp(pMergedVal, pAncVal, nMergedVal)==0 ? 1 : 0;
 }
-
-
-
-
-
-
-
-
-
 
 static int tableHasRowid(sqlite3 *db, const char *zTable){
   sqlite3_stmt *pStmt = 0;
@@ -773,10 +695,6 @@ static int tableHasRowid(sqlite3 *db, const char *zTable){
   if( pStmt ) sqlite3_finalize(pStmt);
   return rc == SQLITE_OK ? 1 : 0;
 }
-
-
-
-
 
 static int fetchOrphanRow(
   sqlite3 *db,
@@ -942,12 +860,6 @@ static int appendUniqueViolationByPk(
   return rc;
 }
 
-
-
-
-
-
-
 static int uniqueIndexRowHasNull(sqlite3_stmt *pScan, int colFirst, int colLast){
   int i;
   for(i=colFirst; i<colLast; i++){
@@ -955,20 +867,6 @@ static int uniqueIndexRowHasNull(sqlite3_stmt *pScan, int colFirst, int colLast)
   }
   return 0;
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 static int detectUniqueViolationsForIndex(
   sqlite3 *db,
@@ -1015,7 +913,6 @@ static int detectUniqueViolationsForIndex(
 
     isDup = zWinnerKey && strcmp(zWinnerKey, zRowKey)==0;
     if( !isDup ){
-
       sqlite3_free(zWinnerKey);
       zWinnerKey = zRowKey;
       winnerRowid = rowid;
@@ -1146,11 +1043,6 @@ static int detectUniqueViolationsForIndexWithoutRowid(
   return rc;
 }
 
-
-
-
-
-
 int doltliteDetectMergeUniqueViolations(
   sqlite3 *db,
   const ProllyHash *pAncCatHash,
@@ -1227,11 +1119,6 @@ int doltliteDetectMergeUniqueViolations(
       zIdxRaw = (const char*)sqlite3_column_text(pIdxList, 1);
       if( !zIdxRaw ) continue;
 
-
-
-
-
-
       zOrigin = (const char*)sqlite3_column_text(pIdxList, 3);
       if( zOrigin && strcmp(zOrigin, "pk")==0 ) continue;
 
@@ -1281,18 +1168,6 @@ int doltliteDetectMergeUniqueViolations(
   return rc;
 }
 
-
-
-
-
-
-
-
-
-
-
-
-
 static int nextCheckClause(
   const char *zSql, int *pOffset, char **pzExpr, char **pzName
 ){
@@ -1306,8 +1181,6 @@ static int nextCheckClause(
   *pzName = 0;
 
   while( *p ){
-
-
     if( (p[0]=='C' || p[0]=='c')
      && strncasecmp(p, "CONSTRAINT", 10)==0
      && (p[10]==' ' || p[10]=='\t' || p[10]=='\n') ){
@@ -1378,24 +1251,12 @@ static int nextCheckClause(
       if( *p=='"' ) p++;
       continue;
     }
-
-
-
     if( *p==',' ) lastConstraintName[0] = 0;
     p++;
   }
   *pOffset = (int)(p - zSql);
   return 0;
 }
-
-
-
-
-
-
-
-
-
 
 int doltliteDetectMergeCheckViolations(
   sqlite3 *db,
@@ -1673,21 +1534,6 @@ static int detectFkViolationsForSpec(
   sqlite3_finalize(pStmt);
   return rc;
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 int doltliteDetectMergeFkViolations(
   sqlite3 *db,

--- a/src/doltlite_record.c
+++ b/src/doltlite_record.c
@@ -141,19 +141,19 @@ void doltliteFreeColInfo(DoltliteColInfo *ci){
   ci->nCol = 0;
 }
 
-/* iPkCol is set only for a rowid-aliased INTEGER PRIMARY KEY column.
-** Other PK columns live in the record payload like any user column,
-** so callers that serialize INT PK values separately (at, history,
-** diff vtables) use iPkCol to pull the rowid from the cursor
-** instead of the record.
-**
-** aColToRec maps declared column index → record field index. For
-** rowid-aliased and keyless tables that's the identity; for
-** WITHOUT ROWID tables (compound or single non-INT PK — all
-** auto-converted by build.c) the layout is PK columns first in
-** PRIMARY KEY declaration order, then non-PK columns in declared
-** order, matching the aiColumn[] that convertToWithoutRowidTable
-** builds for the covering PK index. */
+
+
+
+
+
+
+
+
+
+
+
+
+
 int doltliteGetColumnNames(sqlite3 *db, const char *zTable, DoltliteColInfo *ci){
   char *zSql;
   sqlite3_stmt *pStmt = 0;
@@ -221,10 +221,10 @@ int doltliteGetColumnNames(sqlite3 *db, const char *zTable, DoltliteColInfo *ci)
     return rc;
   }
 
-  /* A column is a rowid alias only when it's the SOLE PK column and
-  ** has declared type INTEGER. Compound PKs (even if their first
-  ** column is INTEGER) store all fields in the record payload and
-  ** must NOT be treated as rowid-alias projections. */
+
+
+
+
   if( nPkCols==1 && iCandidateAlias>=0 ){
     ci->iPkCol = iCandidateAlias;
   }
@@ -238,11 +238,11 @@ int doltliteGetColumnNames(sqlite3 *db, const char *zTable, DoltliteColInfo *ci)
       return SQLITE_NOMEM;
     }
     if( ci->iPkCol>=0 || nPkCols==0 ){
-      /* Rowid-aliased or keyless: record stays in declared order. */
+
       for(i=0; i<ci->nCol; i++) ci->aColToRec[i] = i;
     }else{
-      /* WITHOUT ROWID: PK cols first in PK-declaration order, then
-      ** non-PK cols in declared order. */
+
+
       for(i=0; i<ci->nCol; i++){
         if( aPk[i]>0 ) ci->aColToRec[i] = aPk[i] - 1;
       }
@@ -364,29 +364,29 @@ void doltliteResultUserCol(
   int iRecField;
   DoltliteRecordInfo ri;
 
-  /* Missing record ⇒ row not present ⇒ every column projects as
-  ** SQL NULL, including the rowid-alias column. This matches the
-  ** diff vtable contract: from_* columns on an ADD and to_*
-  ** columns on a DELETE are NULL across the board. */
+
+
+
+
   if( !pRec || nRec<=0 || !ci || iDeclaredCol<0 || iDeclaredCol>=ci->nCol ){
     sqlite3_result_null(ctx);
     return;
   }
 
-  /* Rowid-aliased INTEGER PRIMARY KEY column: value lives in the
-  ** cursor's intKey rather than the record payload — SQLite
-  ** stores the rowid as a NULL serial in the record itself, so
-  ** reading it via the normal field path would return NULL. */
+
+
+
+
   if( iDeclaredCol==ci->iPkCol && ci->iPkCol>=0 ){
     sqlite3_result_int64(ctx, intKey);
     return;
   }
 
-  /* Map declared column index → physical record field index. The
-  ** aColToRec permutation is identity for rowid-aliased and
-  ** keyless tables and PK-first for WITHOUT ROWID tables. Without
-  ** this mapping step, projecting by declared index on a schema
-  ** whose PK cols aren't leading returns the wrong field. */
+
+
+
+
+
   iRecField = ci->aColToRec ? ci->aColToRec[iDeclaredCol] : iDeclaredCol;
   if( iRecField<0 ){
     sqlite3_result_null(ctx);

--- a/src/doltlite_record.c
+++ b/src/doltlite_record.c
@@ -141,19 +141,6 @@ void doltliteFreeColInfo(DoltliteColInfo *ci){
   ci->nCol = 0;
 }
 
-
-
-
-
-
-
-
-
-
-
-
-
-
 int doltliteGetColumnNames(sqlite3 *db, const char *zTable, DoltliteColInfo *ci){
   char *zSql;
   sqlite3_stmt *pStmt = 0;
@@ -221,10 +208,6 @@ int doltliteGetColumnNames(sqlite3 *db, const char *zTable, DoltliteColInfo *ci)
     return rc;
   }
 
-
-
-
-
   if( nPkCols==1 && iCandidateAlias>=0 ){
     ci->iPkCol = iCandidateAlias;
   }
@@ -238,11 +221,8 @@ int doltliteGetColumnNames(sqlite3 *db, const char *zTable, DoltliteColInfo *ci)
       return SQLITE_NOMEM;
     }
     if( ci->iPkCol>=0 || nPkCols==0 ){
-
       for(i=0; i<ci->nCol; i++) ci->aColToRec[i] = i;
     }else{
-
-
       for(i=0; i<ci->nCol; i++){
         if( aPk[i]>0 ) ci->aColToRec[i] = aPk[i] - 1;
       }
@@ -364,28 +344,15 @@ void doltliteResultUserCol(
   int iRecField;
   DoltliteRecordInfo ri;
 
-
-
-
-
   if( !pRec || nRec<=0 || !ci || iDeclaredCol<0 || iDeclaredCol>=ci->nCol ){
     sqlite3_result_null(ctx);
     return;
   }
 
-
-
-
-
   if( iDeclaredCol==ci->iPkCol && ci->iPkCol>=0 ){
     sqlite3_result_int64(ctx, intKey);
     return;
   }
-
-
-
-
-
 
   iRecField = ci->aColToRec ? ci->aColToRec[iDeclaredCol] : iDeclaredCol;
   if( iRecField<0 ){

--- a/src/doltlite_ref.c
+++ b/src/doltlite_ref.c
@@ -31,13 +31,11 @@ static int doltliteResolveBaseRef(
   static const char zTrackingPrefix[] = "refs/remotes/";
   int rc;
 
-
   if( strcmp(zRef, "HEAD")==0 ){
     doltliteGetSessionHead(db, pCommit);
     if( prollyHashIsEmpty(pCommit) ) return SQLITE_NOTFOUND;
     return SQLITE_OK;
   }
-
 
   if( strlen(zRef)==PROLLY_HASH_SIZE*2 ){
     rc = doltliteHexToHash(zRef, pCommit);
@@ -47,7 +45,6 @@ static int doltliteResolveBaseRef(
       if( rc!=SQLITE_NOTFOUND ) return rc;
     }
   }
-
 
   rc = chunkStoreFindBranch(cs, zRef, pCommit);
   if( rc==SQLITE_OK && !prollyHashIsEmpty(pCommit) ){
@@ -78,7 +75,6 @@ static int doltliteResolveBaseRef(
       }
     }
   }
-
 
   rc = chunkStoreFindTag(cs, zRef, pCommit);
   if( rc==SQLITE_OK && !prollyHashIsEmpty(pCommit) ){
@@ -136,16 +132,6 @@ static int doltliteSelectParent(
   return SQLITE_OK;
 }
 
-
-
-
-
-
-
-
-
-
-
 int doltliteResolveRef(sqlite3 *db, const char *zRef, ProllyHash *pCommit){
   ChunkStore *cs = doltliteGetChunkStore(db);
   int len, j, n_back, parent_sel, rc;
@@ -155,7 +141,6 @@ int doltliteResolveRef(sqlite3 *db, const char *zRef, ProllyHash *pCommit){
   const char *base;
 
   if( !zRef || !cs ) return SQLITE_ERROR;
-
 
   len = (int)strlen(zRef);
   for(j=len-1; j>=0; j--){

--- a/src/doltlite_ref.c
+++ b/src/doltlite_ref.c
@@ -136,16 +136,16 @@ static int doltliteSelectParent(
   return SQLITE_OK;
 }
 
-/* Git-style ref resolution. Accepts:
-**   HEAD            — session head
-**   <40-hex>        — direct commit hash
-**   <branch>        — branch name
-**   <tag>           — tag name
-** plus git revision suffixes:
-**   <base>~N        — walk first-parent N times (default 1)
-**   <base>^N        — select Nth parent of <base> (1-based; default 1)
-** The ~/^ suffix is parsed off the tail first, then the base is
-** resolved recursively via doltliteResolveBaseRef. */
+
+
+
+
+
+
+
+
+
+
 int doltliteResolveRef(sqlite3 *db, const char *zRef, ProllyHash *pCommit){
   ChunkStore *cs = doltliteGetChunkStore(db);
   int len, j, n_back, parent_sel, rc;

--- a/src/doltlite_remote.c
+++ b/src/doltlite_remote.c
@@ -174,12 +174,12 @@ static int syncEnqueueChildren(
 
 #define SYNC_BATCH_SIZE 256
 
-/* BFS the src store starting from aRoots, streaming each unseen
-** chunk to dst. xHasChunks is called in 256-chunk batches so a
-** large push/fetch doesn't round-trip per chunk. xGetChunk may
-** return NOTFOUND for a hash that's not present in src (sparse
-** remote) — treated as OK and skipped rather than an error, since
-** we don't want a partially cloned remote to block a later sync. */
+
+
+
+
+
+
 int doltliteSyncChunks(
   DoltliteRemote *pSrc,
   DoltliteRemote *pDst,
@@ -527,13 +527,13 @@ static int syncIsAncestor(
   return found;
 }
 
-/* Git-style push: refuse non-fast-forward without --force. A FF push
-** means the remote tip is an ancestor of the local tip; otherwise
-** we'd overwrite remote work. The ancestor check walks the commit
-** graph on the LOCAL side (because we have all chunks locally) —
-** this is safe even though the remote may have divergent history
-** we haven't fetched, since any non-ancestor branch on the remote
-** will still fail isAncestor here. */
+
+
+
+
+
+
+
 int doltlitePush(
   ChunkStore *pLocal,
   DoltliteRemote *pRemote,

--- a/src/doltlite_remote.c
+++ b/src/doltlite_remote.c
@@ -174,12 +174,6 @@ static int syncEnqueueChildren(
 
 #define SYNC_BATCH_SIZE 256
 
-
-
-
-
-
-
 int doltliteSyncChunks(
   DoltliteRemote *pSrc,
   DoltliteRemote *pDst,
@@ -201,7 +195,6 @@ int doltliteSyncChunks(
     return rc;
   }
 
-
   for(i=0; i<nRoots && rc==SQLITE_OK; i++){
     if( !prollyHashIsEmpty(&aRoots[i]) && !prollyHashSetContains(&seen, &aRoots[i]) ){
       rc = prollyHashSetAdd(&seen, &aRoots[i]);
@@ -209,20 +202,16 @@ int doltliteSyncChunks(
     }
   }
 
-
   while( rc==SQLITE_OK && syncQueuePending(&queue) > 0 ){
     int nBatch = 0;
-
 
     while( nBatch < SYNC_BATCH_SIZE && syncQueuePop(&queue, &aBatch[nBatch]) ){
       nBatch++;
     }
     if( nBatch == 0 ) break;
 
-
     rc = pDst->xHasChunks(pDst, aBatch, nBatch, aPresent);
     if( rc!=SQLITE_OK ) break;
-
 
     for(i=0; i<nBatch && rc==SQLITE_OK; i++){
       u8 *data = 0;
@@ -233,7 +222,6 @@ int doltliteSyncChunks(
         continue;
       }
 
-
       rc = pSrc->xGetChunk(pSrc, &aBatch[i], &data, &nData);
       if( rc==SQLITE_NOTFOUND ){
 
@@ -242,13 +230,11 @@ int doltliteSyncChunks(
       }
       if( rc!=SQLITE_OK ) break;
 
-
       rc = pDst->xPutChunk(pDst, &aBatch[i], data, nData);
       if( rc!=SQLITE_OK ){
         sqlite3_free(data);
         break;
       }
-
 
       rc = syncEnqueueChildren(data, nData, &queue, &seen);
       sqlite3_free(data);
@@ -527,13 +513,6 @@ static int syncIsAncestor(
   return found;
 }
 
-
-
-
-
-
-
-
 int doltlitePush(
   ChunkStore *pLocal,
   DoltliteRemote *pRemote,
@@ -546,7 +525,6 @@ int doltlitePush(
   int rc;
   int i;
 
-
   rc = chunkStoreFindBranch(pLocal, zBranch, &localCommit);
   if( rc!=SQLITE_OK ){
     return SQLITE_ERROR;
@@ -554,7 +532,6 @@ int doltlitePush(
 
   rc = remoteLoadCommitCatalogHash(pLocal, &localCommit, &localCatalog);
   if( rc!=SQLITE_OK ) return rc;
-
 
   if( !bForce ){
     u8 *refsData = 0;
@@ -582,7 +559,6 @@ int doltlitePush(
     if( rc!=SQLITE_OK ) return rc;
   }
 
-
   {
     DoltliteRemote *pLocalSrc = doltliteLocalAsRemote(pLocal);
     if( !pLocalSrc ) return SQLITE_NOMEM;
@@ -591,13 +567,11 @@ int doltlitePush(
   }
   if( rc!=SQLITE_OK ) return rc;
 
-
   {
     u8 *refsData2 = 0; int nRefsData2 = 0;
     rc = pRemote->xGetRefs(pRemote, &refsData2, &nRefsData2);
     if( rc==SQLITE_NOTFOUND ){ refsData2 = 0; nRefsData2 = 0; rc = SQLITE_OK; }
     if( rc!=SQLITE_OK ) return rc;
-
 
     {
       ChunkStore tmpCs;
@@ -616,7 +590,6 @@ int doltlitePush(
         chunkStoreClose(&tmpCs);
         return rc;
       }
-
 
       rc = chunkStoreUpdateBranch(&tmpCs, zBranch, &localCommit);
       if( rc==SQLITE_NOTFOUND ){
@@ -650,7 +623,6 @@ int doltlitePush(
         return rc;
       }
 
-
       rc = chunkStoreSerializeRefsToBlob(&tmpCs, &newRefs, &nNewRefs);
       chunkStoreClose(&tmpCs);
       if( rc!=SQLITE_OK ) return rc;
@@ -660,7 +632,6 @@ int doltlitePush(
       if( rc!=SQLITE_OK ) return rc;
     }
   }
-
 
   rc = pRemote->xCommit(pRemote);
 
@@ -682,10 +653,8 @@ int doltliteFetch(
 
   memset(&remoteCommit, 0, sizeof(remoteCommit));
 
-
   rc = pRemote->xGetRefs(pRemote, &refsData, &nRefsData);
   if( rc!=SQLITE_OK ) return rc;
-
 
   rc = remoteFindBranchFromRefsBlob(refsData, nRefsData, zBranch, &remoteCommit);
   sqlite3_free(refsData);
@@ -698,7 +667,6 @@ int doltliteFetch(
     return SQLITE_NOTFOUND;
   }
 
-
   pLocalDst = doltliteLocalAsRemote(pLocal);
   if( !pLocalDst ) return SQLITE_NOMEM;
 
@@ -707,10 +675,8 @@ int doltliteFetch(
   pLocalDst->xClose(pLocalDst);
   if( rc!=SQLITE_OK ) return rc;
 
-
   rc = chunkStoreUpdateTracking(pLocal, zRemoteName, zBranch, &remoteCommit);
   if( rc!=SQLITE_OK ) return rc;
-
 
   return remoteStorePersistRefs(pLocal);
 }
@@ -726,10 +692,8 @@ int doltliteClone(ChunkStore *pLocal, DoltliteRemote *pRemote){
 
   memcpy(&oldRefsHash, &pLocal->refsHash, sizeof(ProllyHash));
 
-
   rc = pRemote->xGetRefs(pRemote, &refsData, &nRefsData);
   if( rc!=SQLITE_OK ) return rc;
-
 
   rc = remoteCollectRootsFromRefsBlob(refsData, nRefsData, &aRoots, &nRoots);
   if( rc!=SQLITE_OK ){
@@ -762,7 +726,6 @@ int doltliteClone(ChunkStore *pLocal, DoltliteRemote *pRemote){
     }
   }
 
-
   if( refsData && nRefsData > 0 ){
     ProllyHash refsHash;
     rc = chunkStorePut(pLocal, refsData, nRefsData, &refsHash);
@@ -773,13 +736,11 @@ int doltliteClone(ChunkStore *pLocal, DoltliteRemote *pRemote){
   sqlite3_free(refsData);
   if( rc!=SQLITE_OK ) return rc;
 
-
   rc = chunkStoreCommit(pLocal);
   if( rc!=SQLITE_OK ){
     memcpy(&pLocal->refsHash, &oldRefsHash, sizeof(ProllyHash));
     return rc;
   }
-
 
   rc = chunkStoreReloadRefs(pLocal);
   if( rc!=SQLITE_OK ){

--- a/src/doltlite_remote.h
+++ b/src/doltlite_remote.h
@@ -3,10 +3,10 @@
 
 #include "chunk_store.h"
 
-/* Backend-agnostic remote protocol. Every remote (fs, http, local)
-** has the same lifecycle: xPutChunk/xSetRefs buffer pending writes,
-** then xCommit flushes them as one atomic batch. The dispatcher
-** uses xHasChunks to skip chunks already present on the remote. */
+
+
+
+
 typedef struct DoltliteRemote DoltliteRemote;
 struct DoltliteRemote {
   int (*xGetChunk)(DoltliteRemote*, const ProllyHash*, u8**, int*);

--- a/src/doltlite_remote.h
+++ b/src/doltlite_remote.h
@@ -3,10 +3,6 @@
 
 #include "chunk_store.h"
 
-
-
-
-
 typedef struct DoltliteRemote DoltliteRemote;
 struct DoltliteRemote {
   int (*xGetChunk)(DoltliteRemote*, const ProllyHash*, u8**, int*);

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -34,10 +34,10 @@ static void remoteSqlStateClear(RemoteSqlState *p){
   memset(p, 0, sizeof(*p));
 }
 
-/* Snapshot enough session and ref state to undo a remote op mid-way.
-** dolt_clone/dolt_pull/dolt_fetch can fail partway through and leave
-** the working set pointing at chunks we're about to roll back —
-** this state is the snapshot we restore to if something errors. */
+
+
+
+
 static int remoteSqlStateSave(sqlite3 *db, ChunkStore *cs, RemoteSqlState *p){
   int rc;
 
@@ -624,9 +624,9 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   }
 
 
-  /* dolt_pull is fast-forward-only. A fast-forward is valid if the
-  ** local tip is any ancestor of the fetched tracking tip, not just
-  ** part of its first-parent chain. */
+
+
+
   {
     ProllyHash ancestor;
     rc = doltliteFindAncestor(db, &trackingCommit, &localCommit, &ancestor);

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -34,10 +34,6 @@ static void remoteSqlStateClear(RemoteSqlState *p){
   memset(p, 0, sizeof(*p));
 }
 
-
-
-
-
 static int remoteSqlStateSave(sqlite3 *db, ChunkStore *cs, RemoteSqlState *p){
   int rc;
 
@@ -507,7 +503,6 @@ static void doltFetchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
       return;
     }
 
-
     pRemote->xClose(pRemote);
     pRemote = 0;
 
@@ -596,14 +591,12 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     return;
   }
 
-
   rc = chunkStoreFindTracking(cs, zRemoteName, zBranch, &trackingCommit);
   if( rc!=SQLITE_OK || prollyHashIsEmpty(&trackingCommit) ){
     remoteSqlRestoreAndReport(ctx, db, cs, &savedState, SQLITE_ERROR,
                               "tracking branch not found after fetch");
     return;
   }
-
 
   rc = chunkStoreFindBranch(cs, zBranch, &localCommit);
   if( rc!=SQLITE_OK ){
@@ -617,15 +610,10 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     localCommit = trackingCommit;
   }
 
-
   if( prollyHashCompare(&localCommit, &trackingCommit)==0 ){
     remoteSqlClearAndSucceed(ctx, &savedState);
     return;
   }
-
-
-
-
 
   {
     ProllyHash ancestor;
@@ -642,7 +630,6 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     }
   }
 
-
   if( strcmp(zBranch, doltliteGetSessionBranch(db))==0
    && doltliteHasUncommittedChanges(db) ){
     remoteSqlRestoreAndReport(ctx, db, cs, &savedState, SQLITE_ERROR,
@@ -657,7 +644,6 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     return;
   }
 
-
   if( strcmp(zBranch, doltliteGetSessionBranch(db))==0 ){
     rc = remoteSqlResetSessionToCommit(db, 0, &trackingCommit);
     if( rc!=SQLITE_OK ){
@@ -666,7 +652,6 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
       return;
     }
   }
-
 
   rc = remoteSqlPersistRefs(cs);
   if( rc!=SQLITE_OK ){
@@ -761,15 +746,12 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     return;
   }
 
-
   rc = chunkStoreAddRemote(cs, "origin", zUrl);
   if( rc!=SQLITE_OK ){
     remoteSqlRestoreAndReport(ctx, db, cs, &savedState, SQLITE_ERROR,
                               "failed to add origin remote");
     return;
   }
-
-
 
   {
     u8 *refsData = 0; int nRefsData = 0;
@@ -781,7 +763,6 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
       sqlite3_free(refsData);
     }
   }
-
 
   {
     const char *zDefault = chunkStoreGetDefaultBranch(cs);

--- a/src/doltlite_remotesrv.c
+++ b/src/doltlite_remotesrv.c
@@ -1,7 +1,7 @@
-/* Test-only HTTP server side of the remote protocol. Not hardened
-** for production: single-threaded per-connection handling, no TLS,
-** no auth, no limits beyond MAX_HEADER_SIZE. Used by the fetch/push
-** tests and for local integration work against doltlite_http_remote. */
+
+
+
+
 
 #ifdef DOLTLITE_PROLLY
 

--- a/src/doltlite_remotesrv.c
+++ b/src/doltlite_remotesrv.c
@@ -1,8 +1,4 @@
 
-
-
-
-
 #ifdef DOLTLITE_PROLLY
 
 #include "sqliteInt.h"
@@ -139,7 +135,6 @@ static int parseRequest(
   *ppBody = 0;
   *pnBody = 0;
 
-
   while( nBuf < MAX_HEADER_SIZE-1 ){
     int n = (int)read(fd, &aBuf[nBuf], 1);
     if( n <= 0 ) return -1;
@@ -153,7 +148,6 @@ static int parseRequest(
   }
   if( !headerEnd ) return -1;
   aBuf[nBuf] = '\0';
-
 
   p = aBuf;
   {
@@ -177,7 +171,6 @@ static int parseRequest(
     p = pSpace + 1;
   }
 
-
   {
     const char *zCL = "Content-Length:";
     int nCL = (int)strlen(zCL);
@@ -193,7 +186,6 @@ static int parseRequest(
       contentLength = atoi(pLine);
     }
   }
-
 
   if( contentLength > 0 ){
     u8 *pBody = (u8*)sqlite3_malloc(contentLength);
@@ -223,7 +215,6 @@ static int parsePath(
   if( *p != '/' ) return -1;
   p++;
 
-
   dbStart = p;
   while( *p && *p != '/' ) p++;
   dbLen = (int)(p - dbStart);
@@ -233,7 +224,6 @@ static int parsePath(
 
   if( *p != '/' ) return -1;
   p++;
-
 
   epStart = p;
   epLen = (int)strlen(epStart);
@@ -345,9 +335,7 @@ static void handlePostChunks(ChunkStore *pStore, int fd,
     u32 len;
     ProllyHash hash;
 
-
     offset += PROLLY_HASH_SIZE;
-
 
     len = (u32)pBody[offset]
         | ((u32)pBody[offset+1] << 8)
@@ -368,7 +356,6 @@ static void handlePostChunks(ChunkStore *pStore, int fd,
     }
     offset += (int)len;
   }
-
 
   rc = remoteSrvCommitPending(pStore);
   if( rc!=SQLITE_OK ){
@@ -484,7 +471,6 @@ static void handleRequest(DoltliteServer *pSrv, int fd){
     return;
   }
 
-
   if( parsePath(zPath, zDbName, sizeof(zDbName),
                 zEndpoint, sizeof(zEndpoint))!=0 ){
     sendNotFound(fd);
@@ -497,7 +483,6 @@ static void handleRequest(DoltliteServer *pSrv, int fd){
     return;
   }
 
-
   sqlite3_snprintf(sizeof(zDbPath), zDbPath, "%s/%s", pSrv->zDir, zDbName);
   flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB;
   memset(&store, 0, sizeof(store));
@@ -507,7 +492,6 @@ static void handleRequest(DoltliteServer *pSrv, int fd){
     sqlite3_free(pBody);
     return;
   }
-
 
   if( strcmp(zMethod, "GET")==0 ){
     if( strcmp(zEndpoint, "root")==0 ){
@@ -552,12 +536,10 @@ static int serverInit(DoltliteServer *pSrv, const char *zDir, int port){
   memset(pSrv, 0, sizeof(*pSrv));
   pSrv->listenFd = -1;
 
-
   nDir = (int)strlen(zDir);
   pSrv->zDir = sqlite3_malloc(nDir + 1);
   if( !pSrv->zDir ) return SQLITE_NOMEM;
   memcpy(pSrv->zDir, zDir, nDir + 1);
-
 
   pSrv->listenFd = socket(AF_INET, SOCK_STREAM, 0);
   if( pSrv->listenFd < 0 ){
@@ -584,7 +566,6 @@ static int serverInit(DoltliteServer *pSrv, const char *zDir, int port){
     return SQLITE_ERROR;
   }
 
-
   addrLen = sizeof(addr);
   if( getsockname(pSrv->listenFd, (struct sockaddr*)&addr, &addrLen)==0 ){
     pSrv->port = ntohs(addr.sin_port);
@@ -604,7 +585,6 @@ static void serverLoop(DoltliteServer *pSrv){
     pfd.fd = pSrv->listenFd;
     pfd.events = POLLIN;
     pfd.revents = 0;
-
 
     if( poll(&pfd, 1, 1000) <= 0 ) continue;
 

--- a/src/doltlite_schema_diff.c
+++ b/src/doltlite_schema_diff.c
@@ -172,10 +172,6 @@ static int appendSchemaDiffRow(
   return SQLITE_OK;
 }
 
-
-
-
-
 int loadSchemaFromCatalog(
   sqlite3 *db,
   ChunkStore *cs,
@@ -195,7 +191,6 @@ int loadSchemaFromCatalog(
   rc = doltliteLoadCatalog(db, pCatHash, &aTables, &nTables, 0);
   if( rc!=SQLITE_OK ){ *ppEntries = 0; *pnEntries = 0; return rc; }
 
-
   memset(&masterRoot, 0, sizeof(masterRoot));
   for(i=0; i<nTables; i++){
     if( aTables[i].iTable==1 ){
@@ -210,7 +205,6 @@ int loadSchemaFromCatalog(
     *ppEntries = 0; *pnEntries = 0;
     return SQLITE_OK;
   }
-
 
   prollyCursorInit(&cur, cs, pCache, &masterRoot, masterFlags);
   rc = prollyCursorFirst(&cur, &res);
@@ -332,7 +326,6 @@ static int computeSchemaDiff(
     memset(toConsumed, 0, nTo);
   }
 
-
   for(i=0; i<nTo; i++){
     SchemaEntry *fromEntry;
     struct TableEntry *toTE;
@@ -368,7 +361,6 @@ static int computeSchemaDiff(
     }
   }
 
-
   for(i=0; i<nTo; i++){
     SchemaEntry *fromEntry;
     if( toConsumed && toConsumed[i] ) continue;
@@ -387,7 +379,6 @@ static int computeSchemaDiff(
       if( rc!=SQLITE_OK ) goto done;
     }
   }
-
 
   for(i=0; i<nFrom; i++){
     SchemaEntry *toEntry;
@@ -505,11 +496,6 @@ static int sdResolveRefs(
 
   rc = doltliteResolveRef(db, zFromRef, &commitHash);
   if( rc!=SQLITE_OK ){
-
-
-
-
-
     sqlite3_free(pVtab->zErrMsg);
     pVtab->zErrMsg = sqlite3_mprintf(
       "dolt_schema_diff: from_ref '%s' could not be resolved", zFromRef);
@@ -664,7 +650,6 @@ static int sdFilter(sqlite3_vtab_cursor *cur,
   if( rc!=SQLITE_OK ) goto sd_filter_done;
   rc = loadSchemaFromCatalog(db, cs, pCache, &toCatHash, &aTo, &nTo);
   if( rc!=SQLITE_OK ) goto sd_filter_done;
-
 
   rc = doltliteLoadCatalog(db, &fromCatHash, &aFromTables, &nFromTables, 0);
   if( rc!=SQLITE_OK ) goto sd_filter_done;

--- a/src/doltlite_schema_diff.c
+++ b/src/doltlite_schema_diff.c
@@ -172,10 +172,10 @@ static int appendSchemaDiffRow(
   return SQLITE_OK;
 }
 
-/* Schema records live in the sqlite_master (iTable==1) prolly tree,
-** same layout as stock SQLite: [type, name, tbl_name, rootpage, sql].
-** We pull fields 0 (type), 1 (name), 4 (sql). Callers use this to
-** reproduce a CREATE TABLE for introspection and for schema-merge. */
+
+
+
+
 int loadSchemaFromCatalog(
   sqlite3 *db,
   ChunkStore *cs,
@@ -505,11 +505,11 @@ static int sdResolveRefs(
 
   rc = doltliteResolveRef(db, zFromRef, &commitHash);
   if( rc!=SQLITE_OK ){
-    /* Translate SQLITE_NOTFOUND ("unknown operation") and any other
-    ** ref-resolution failure into a vtable error with a usable
-    ** message — the bare SQLITE_NOTFOUND gets mapped to the cryptic
-    ** "unknown operation" string by the SQLite shell, which is
-    ** what surfaced in dolthub/doltlite#738. */
+
+
+
+
+
     sqlite3_free(pVtab->zErrMsg);
     pVtab->zErrMsg = sqlite3_mprintf(
       "dolt_schema_diff: from_ref '%s' could not be resolved", zFromRef);

--- a/src/doltlite_schema_merge.c
+++ b/src/doltlite_schema_merge.c
@@ -137,14 +137,14 @@ int migrateDiffCb(void *pArg, const ProllyDiffChange *pChange){
   return SQLITE_OK;
 }
 
-/* After schema merge decides to ADD COLUMN X from theirs, every
-** row that exists on theirs needs X backfilled onto ours. Parse
-** their CREATE TABLE to find each new column's ordinal, then diff
-** their table against anc and UPDATE each row on ours with the
-** value of the new column. Rows that only exist on theirs (diff
-** ADD) also need the update. Rows DELETEd on theirs are skipped
-** (trySchemaColumnMerge has already rejected drop-on-one-side
-** edit-on-other, so we shouldn't see that case here). */
+
+
+
+
+
+
+
+
 int migrateSchemaRowData(
   sqlite3 *db,
   const ProllyHash *pAncCatHash,

--- a/src/doltlite_schema_merge.c
+++ b/src/doltlite_schema_merge.c
@@ -67,7 +67,6 @@ char *extractColNameFromDef(const char *zDef){
   const char *s = zDef;
   int len;
 
-
   while( *s && isspace((unsigned char)*s) ) s++;
   if( !*s ) return 0;
 
@@ -88,7 +87,6 @@ int migrateDiffCb(void *pArg, const ProllyDiffChange *pChange){
   pVal = pChange->pNewVal;
   nVal = pChange->nNewVal;
   if( !pVal || nVal<=0 ) return SQLITE_OK;
-
 
   {
     const u8 *hp = pVal;
@@ -137,14 +135,6 @@ int migrateDiffCb(void *pArg, const ProllyDiffChange *pChange){
   return SQLITE_OK;
 }
 
-
-
-
-
-
-
-
-
 int migrateSchemaRowData(
   sqlite3 *db,
   const ProllyHash *pAncCatHash,
@@ -166,7 +156,6 @@ int migrateSchemaRowData(
 
   if( !cs || !pCache || nActions<=0 ) return SQLITE_OK;
 
-
   rc = doltliteLoadCatalog(db, pAncCatHash, &aAncTables, &nAncTables, 0);
   if( rc!=SQLITE_OK ) return rc;
   rc = doltliteLoadCatalog(db, pTheirCatHash, &aTheirTables, &nTheirTables, 0);
@@ -174,7 +163,6 @@ int migrateSchemaRowData(
     doltliteFreeCatalog(aAncTables, nAncTables);
     return rc;
   }
-
 
   rc = loadSchemaFromCatalog(db, cs, pCache, pTheirCatHash,
                               &aTheirSchema, &nTheirSchema);
@@ -195,22 +183,16 @@ int migrateSchemaRowData(
 
     if( pAct->nAddColumns<=0 ) continue;
 
-
     theirTE = doltliteFindTableByName(aTheirTables, nTheirTables,
                                        pAct->zTableName);
     if( !theirTE ) continue;
 
-
     theirSE = findSchemaEntry(aTheirSchema, nTheirSchema, pAct->zTableName);
     if( !theirSE || !theirSE->zSql ) continue;
-
 
     {
       DoltliteColInfo theirCols;
       memset(&theirCols, 0, sizeof(theirCols));
-
-
-
 
       azColNames = sqlite3_malloc(pAct->nAddColumns * (int)sizeof(char*));
       aiColIdx = sqlite3_malloc(pAct->nAddColumns * (int)sizeof(int));
@@ -233,14 +215,12 @@ int migrateSchemaRowData(
       }
       if( rc!=SQLITE_OK ) break;
 
-
       {
         const char *zSql = theirSE->zSql;
         const char *p = zSql;
         int colOrdinal = 0;
         int depth = 0;
         const char *segStart;
-
 
         while( *p && *p!='(' ) p++;
         if( !*p ){ rc = SQLITE_CORRUPT; goto next_action; }
@@ -327,7 +307,6 @@ int migrateSchemaRowData(
 
       nCols = pAct->nAddColumns;
 
-
       {
         int hasAny = 0;
         for(sj=0; sj<nCols; sj++){
@@ -335,7 +314,6 @@ int migrateSchemaRowData(
         }
         if( !hasAny ) goto next_action;
       }
-
 
       {
         char *zUpdate;
@@ -369,7 +347,6 @@ int migrateSchemaRowData(
         rc = sqlite3_prepare_v2(db, zUpdate, -1, &pUpd, 0);
         sqlite3_free(zUpdate);
         if( rc!=SQLITE_OK ) goto next_action;
-
 
         {
           struct TableEntry *ancTE;

--- a/src/doltlite_schemas.c
+++ b/src/doltlite_schemas.c
@@ -94,10 +94,10 @@ static int schemasClose(sqlite3_vtab_cursor *pCursor){
   return SQLITE_OK;
 }
 
-/* Dolt stores views/triggers in a real dolt_schemas table. Doltlite
-** reuses sqlite_schema instead and synthesizes this vtable on top —
-** type/name/fragment come straight from sqlite_schema WHERE type IN
-** ('view','trigger'). extra/sql_mode always NULL (Dolt-only fields). */
+
+
+
+
 static int schemasFilter(sqlite3_vtab_cursor *pCursor,
     int idxNum, const char *idxStr, int argc, sqlite3_value **argv){
   SchemasCursor *pCur = (SchemasCursor*)pCursor;

--- a/src/doltlite_schemas.c
+++ b/src/doltlite_schemas.c
@@ -94,10 +94,6 @@ static int schemasClose(sqlite3_vtab_cursor *pCursor){
   return SQLITE_OK;
 }
 
-
-
-
-
 static int schemasFilter(sqlite3_vtab_cursor *pCursor,
     int idxNum, const char *idxStr, int argc, sqlite3_value **argv){
   SchemasCursor *pCur = (SchemasCursor*)pCursor;
@@ -108,7 +104,6 @@ static int schemasFilter(sqlite3_vtab_cursor *pCursor,
 
   freeRows(pCur);
   pCur->iRow = 0;
-
 
   rc = sqlite3_prepare_v2(pVtab->db,
     "SELECT type, name, sql FROM sqlite_schema "

--- a/src/doltlite_status.c
+++ b/src/doltlite_status.c
@@ -189,9 +189,9 @@ static int statusRootsShareAnyKey(
   return rc;
 }
 
-/* Detect a rename by stable table identity plus name-insensitive CREATE
-** TABLE SQL. This preserves rename+edit classification while rejecting
-** drop+create churn that happens to reuse the same table number. */
+
+
+
 static int isRenamePair(
   sqlite3 *db,
   struct TableEntry *aFrom, int nFrom,
@@ -268,9 +268,9 @@ static int compareCatalogs(
     if( rc==SQLITE_NOTFOUND ) continue;
     if( rc!=SQLITE_OK ) return rc;
     if(!pFrom){
-      /* Unstaged new tables run through dolt_ignore; a CONFLICT
-      ** bubbles up as a query error. Already-staged new tables skip
-      ** the check — staging beat the ignore rule. */
+
+
+
       if( staged==0 ){
         int ignored = 0;
         char *zIgnErr = 0;

--- a/src/doltlite_status.c
+++ b/src/doltlite_status.c
@@ -189,9 +189,6 @@ static int statusRootsShareAnyKey(
   return rc;
 }
 
-
-
-
 static int isRenamePair(
   sqlite3 *db,
   struct TableEntry *aFrom, int nFrom,
@@ -268,9 +265,6 @@ static int compareCatalogs(
     if( rc==SQLITE_NOTFOUND ) continue;
     if( rc!=SQLITE_OK ) return rc;
     if(!pFrom){
-
-
-
       if( staged==0 ){
         int ignored = 0;
         char *zIgnErr = 0;

--- a/src/os_kv.c
+++ b/src/os_kv.c
@@ -1,26 +1,5 @@
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 #include <sqliteInt.h>
 #if SQLITE_OS_KV || (SQLITE_OS_UNIX && defined(SQLITE_OS_KV_OPTIONAL))
-
-
-
-
-
 
 #if 0
 #define SQLITE_KV_TRACE(X)  printf X
@@ -28,25 +7,13 @@
 #define SQLITE_KV_TRACE(X)
 #endif
 
-
 #if 0
 #define SQLITE_KV_LOG(X)  printf X
 #else
 #define SQLITE_KV_LOG(X)
 #endif
 
-
-
-
 typedef struct KVVfsFile KVVfsFile;
-
-
-
-
-
-
-
-
 
 struct KVVfsFile {
   sqlite3_file base;
@@ -59,9 +26,6 @@ struct KVVfsFile {
   char *aData;
 };
 #define SQLITE_KVOS_SZ 133073
-
-
-
 
 static int kvvfsClose(sqlite3_file*);
 static int kvvfsReadDb(sqlite3_file*, void*, int iAmt, sqlite3_int64 iOfst);
@@ -81,9 +45,6 @@ static int kvvfsFileControlDb(sqlite3_file*, int op, void *pArg);
 static int kvvfsFileControlJrnl(sqlite3_file*, int op, void *pArg);
 static int kvvfsSectorSize(sqlite3_file*);
 static int kvvfsDeviceCharacteristics(sqlite3_file*);
-
-
-
 
 static int kvvfsOpen(sqlite3_vfs*, const char *, sqlite3_file*, int , int *);
 static int kvvfsDelete(sqlite3_vfs*, const char *zName, int syncDir);
@@ -117,8 +78,6 @@ static sqlite3_vfs sqlite3OsKvvfsObject = {
   kvvfsCurrentTimeInt64
 };
 
-
-
 static sqlite3_io_methods kvvfs_db_io_methods = {
   1,
   kvvfsClose,
@@ -140,8 +99,6 @@ static sqlite3_io_methods kvvfs_db_io_methods = {
   0,
   0
 };
-
-
 
 static sqlite3_io_methods kvvfs_jrnl_io_methods = {
   1,
@@ -165,15 +122,11 @@ static sqlite3_io_methods kvvfs_jrnl_io_methods = {
   0
 };
 
-
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
-
-
 #ifndef SQLITE_WASM
-
 static int kvrecordWrite(const char*, const char *zKey, const char *zData);
 static int kvrecordDelete(const char*, const char *zKey);
 static int kvrecordRead(const char*, const char *zKey, char *zBuf, int nBuf);
@@ -181,10 +134,6 @@ static int kvrecordRead(const char*, const char *zKey, char *zBuf, int nBuf);
 #ifndef KVRECORD_KEY_SZ
 #define KVRECORD_KEY_SZ 32
 #endif
-
-
-
-
 
 static void kvrecordMakeKey(
   const char *zClass,
@@ -199,17 +148,6 @@ static void kvrecordMakeKey(
 }
 
 #ifndef SQLITE_WASM
-
-
-
-
-
-
-
-
-
-
-
 static int kvrecordWrite(
   const char *zClass,
   const char *zKey,
@@ -231,10 +169,6 @@ static int kvrecordWrite(
   }
 }
 
-
-
-
-
 static int kvrecordDelete(const char *zClass, const char *zKey){
   char zXKey[KVRECORD_KEY_SZ];
   kvrecordMakeKey(zClass, zKey, zXKey);
@@ -242,21 +176,6 @@ static int kvrecordDelete(const char *zClass, const char *zKey){
   SQLITE_KV_TRACE(("KVVFS-DELETE %-15s\n", zXKey));
   return 0;
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 static int kvrecordRead(
   const char *zClass,
@@ -301,15 +220,6 @@ static int kvrecordRead(
 }
 #endif
 
-
-
-
-
-
-
-
-
-
 typedef struct sqlite3_kvvfs_methods sqlite3_kvvfs_methods;
 struct sqlite3_kvvfs_methods {
   int (*xRcrdRead)(const char*, const char *zKey, char *zBuf, int nBuf);
@@ -327,17 +237,6 @@ struct sqlite3_kvvfs_methods {
   MAYBE_CONST sqlite3_io_methods *pIoJrnl;
 #undef MAYBE_CONST
 };
-
-
-
-
-
-
-
-
-
-
-
 
 #ifndef SQLITE_WASM
 const
@@ -359,30 +258,6 @@ sqlite3_kvvfs_methods sqlite3KvvfsMethods = {
   .pIoJrnl         = &kvvfs_jrnl_io_methods
 };
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 #ifndef SQLITE_WASM
 static
 #endif
@@ -395,11 +270,6 @@ int kvvfsEncode(const char *aData, int nData, char *aOut){
       aOut[j++] = "0123456789ABCDEF"[c>>4];
       aOut[j++] = "0123456789ABCDEF"[c&0xf];
     }else{
-
-
-
-
-
       int k;
       for(k=1; i+k<nData && a[i+k]==0; k++){}
       i += k-1;
@@ -432,13 +302,6 @@ static const signed char kvvfsHexValue[256] = {
   -1, -1, -1, -1, -1, -1, -1, -1,   -1, -1, -1, -1, -1, -1, -1, -1,
   -1, -1, -1, -1, -1, -1, -1, -1,   -1, -1, -1, -1, -1, -1, -1, -1
 };
-
-
-
-
-
-
-
 
 #ifndef SQLITE_WASM
 static
@@ -476,17 +339,6 @@ int kvvfsDecode(const char *a, char *aOut, int nOut){
   return j;
 }
 
-
-
-
-
-
-
-
-
-
-
-
 static void kvvfsDecodeJournal(
   KVVfsFile *pFile,
   const char *zTxt,
@@ -515,9 +367,6 @@ static void kvvfsDecodeJournal(
   }
 }
 
-
-
-
 static sqlite3_int64 kvvfsReadFileSize(KVVfsFile *pFile){
   char zData[50];
   zData[0] = 0;
@@ -531,11 +380,6 @@ static int kvvfsWriteFileSize(KVVfsFile *pFile, sqlite3_int64 sz){
   return sqlite3KvvfsMethods.xRcrdWrite(pFile->zClass, "sz", zData);
 }
 
-
-
-
-
-
 static int kvvfsClose(sqlite3_file *pProtoFile){
   KVVfsFile *pFile = (KVVfsFile *)pProtoFile;
 
@@ -548,9 +392,6 @@ static int kvvfsClose(sqlite3_file *pProtoFile){
 #endif
   return SQLITE_OK;
 }
-
-
-
 
 static int kvvfsReadJrnl(
   sqlite3_file *pProtoFile,
@@ -586,9 +427,6 @@ static int kvvfsReadJrnl(
   memcpy(zBuf, pFile->aJrnl+iOfst, iAmt);
   return SQLITE_OK;
 }
-
-
-
 
 static int kvvfsReadDb(
   sqlite3_file *pProtoFile,
@@ -644,10 +482,6 @@ static int kvvfsReadDb(
   return SQLITE_OK;
 }
 
-
-
-
-
 static int kvvfsWriteJrnl(
   sqlite3_file *pProtoFile,
   const void *zBuf,
@@ -672,9 +506,6 @@ static int kvvfsWriteJrnl(
   memcpy(pFile->aJrnl+iOfst, zBuf, iAmt);
   return SQLITE_OK;
 }
-
-
-
 
 static int kvvfsWriteDb(
   sqlite3_file *pProtoFile,
@@ -703,9 +534,6 @@ static int kvvfsWriteDb(
   }
   return rc;
 }
-
-
-
 
 static int kvvfsTruncateJrnl(sqlite3_file *pProtoFile, sqlite_int64 size){
   KVVfsFile *pFile = (KVVfsFile *)pProtoFile;
@@ -739,9 +567,6 @@ static int kvvfsTruncateDb(sqlite3_file *pProtoFile, sqlite_int64 size){
   return SQLITE_IOERR;
 }
 
-
-
-
 static int kvvfsSyncJrnl(sqlite3_file *pProtoFile, int flags){
   int i, n;
   KVVfsFile *pFile = (KVVfsFile *)pProtoFile;
@@ -770,9 +595,6 @@ static int kvvfsSyncDb(sqlite3_file *pProtoFile, int flags){
   return SQLITE_OK;
 }
 
-
-
-
 static int kvvfsFileSizeJrnl(sqlite3_file *pProtoFile, sqlite_int64 *pSize){
   KVVfsFile *pFile = (KVVfsFile *)pProtoFile;
   SQLITE_KV_LOG(("xFileSize('%s-journal')\n", pFile->zClass));
@@ -790,9 +612,6 @@ static int kvvfsFileSizeDb(sqlite3_file *pProtoFile, sqlite_int64 *pSize){
   return SQLITE_OK;
 }
 
-
-
-
 static int kvvfsLock(sqlite3_file *pProtoFile, int eLock){
   KVVfsFile *pFile = (KVVfsFile *)pProtoFile;
   assert( !pFile->isJournal );
@@ -804,9 +623,6 @@ static int kvvfsLock(sqlite3_file *pProtoFile, int eLock){
   return SQLITE_OK;
 }
 
-
-
-
 static int kvvfsUnlock(sqlite3_file *pProtoFile, int eLock){
   KVVfsFile *pFile = (KVVfsFile *)pProtoFile;
   assert( !pFile->isJournal );
@@ -817,17 +633,11 @@ static int kvvfsUnlock(sqlite3_file *pProtoFile, int eLock){
   return SQLITE_OK;
 }
 
-
-
-
 static int kvvfsCheckReservedLock(sqlite3_file *pProtoFile, int *pResOut){
   SQLITE_KV_LOG(("xCheckReservedLock\n"));
   *pResOut = 0;
   return SQLITE_OK;
 }
-
-
-
 
 static int kvvfsFileControlJrnl(sqlite3_file *pProtoFile, int op, void *pArg){
   SQLITE_KV_LOG(("xFileControl(%d) on journal\n", op));
@@ -847,24 +657,13 @@ static int kvvfsFileControlDb(sqlite3_file *pProtoFile, int op, void *pArg){
   return SQLITE_NOTFOUND;
 }
 
-
-
-
 static int kvvfsSectorSize(sqlite3_file *pFile){
   return 512;
 }
 
-
-
-
 static int kvvfsDeviceCharacteristics(sqlite3_file *pProtoFile){
   return 0;
 }
-
-
-
-
-
 
 static int kvvfsOpen(
   sqlite3_vfs *pProtoVfs,
@@ -905,11 +704,6 @@ static int kvvfsOpen(
   return SQLITE_OK;
 }
 
-
-
-
-
-
 static int kvvfsDelete(sqlite3_vfs *pVfs, const char *zPath, int dirSync){
   int rc ;
   if( strcmp(zPath, "local-journal")==0 ){
@@ -924,10 +718,6 @@ static int kvvfsDelete(sqlite3_vfs *pVfs, const char *zPath, int dirSync){
   return rc;
 }
 
-
-
-
-
 static int kvvfsAccess(
   sqlite3_vfs *pProtoVfs,
   const char *zPath,
@@ -936,15 +726,6 @@ static int kvvfsAccess(
 ){
   SQLITE_KV_LOG(("xAccess(\"%s\")\n", zPath));
 #if 0 && defined(SQLITE_WASM)
-
-
-
-
-
-
-
-
-
   const char *zKey = (0==sqlite3_strglob("*-journal", zPath))
     ? "jrnl" : "sz";
   *pResOut =
@@ -969,16 +750,10 @@ static int kvvfsAccess(
   {
     *pResOut = 0;
   }
-
 #endif
   SQLITE_KV_LOG(("xAccess returns %d\n",*pResOut));
   return SQLITE_OK;
 }
-
-
-
-
-
 
 static int kvvfsFullPathname(
   sqlite3_vfs *pVfs,
@@ -998,32 +773,18 @@ static int kvvfsFullPathname(
   return SQLITE_OK;
 }
 
-
-
-
 static void *kvvfsDlOpen(sqlite3_vfs *pVfs, const char *zPath){
   return 0;
 }
-
-
-
-
 
 static int kvvfsRandomness(sqlite3_vfs *pVfs, int nByte, char *zBufOut){
   memset(zBufOut, 0, nByte);
   return nByte;
 }
 
-
-
-
-
 static int kvvfsSleep(sqlite3_vfs *pVfs, int nMicro){
   return SQLITE_OK;
 }
-
-
-
 
 static int kvvfsCurrentTime(sqlite3_vfs *pVfs, double *pTimeOut){
   sqlite3_int64 i = 0;
@@ -1043,9 +804,6 @@ static int kvvfsCurrentTimeInt64(sqlite3_vfs *pVfs, sqlite3_int64 *pTimeOut){
 #endif
 
 #if SQLITE_OS_KV
-
-
-
 int sqlite3_os_init(void){
   return sqlite3_vfs_register(&sqlite3OsKvvfsObject, 1);
 }

--- a/src/os_kv.c
+++ b/src/os_kv.c
@@ -1,68 +1,68 @@
-/*
-** 2022-09-06
-**
-** The author disclaims copyright to this source code.  In place of
-** a legal notice, here is a blessing:
-**
-**    May you do good and not evil.
-**    May you find forgiveness for yourself and forgive others.
-**    May you share freely, never taking more than you give.
-**
-******************************************************************************
-**
-** This file contains an experimental VFS layer that operates on a
-** Key/Value storage engine where both keys and values must be pure
-** text.
-*/
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 #include <sqliteInt.h>
 #if SQLITE_OS_KV || (SQLITE_OS_UNIX && defined(SQLITE_OS_KV_OPTIONAL))
 
-/*****************************************************************************
-** Debugging logic
-*/
 
-/* SQLITE_KV_TRACE() is used for tracing calls to kvrecord routines. */
+
+
+
+
 #if 0
 #define SQLITE_KV_TRACE(X)  printf X
 #else
 #define SQLITE_KV_TRACE(X)
 #endif
 
-/* SQLITE_KV_LOG() is used for tracing calls to the VFS interface */
+
 #if 0
 #define SQLITE_KV_LOG(X)  printf X
 #else
 #define SQLITE_KV_LOG(X)
 #endif
 
-/*
-** Forward declaration of objects used by this VFS implementation
-*/
+
+
+
 typedef struct KVVfsFile KVVfsFile;
 
-/* A single open file.  There are only two files represented by this
-** VFS - the database and the rollback journal.
-**
-** Maintenance reminder: if this struct changes in any way, the JSON
-** rendering of its structure must be updated in
-** sqlite3-wasm.c:sqlite3__wasm_enum_json(). There are no binary
-** compatibility concerns, so it does not need an iVersion member.
-*/
+
+
+
+
+
+
+
+
 struct KVVfsFile {
-  sqlite3_file base;              /* IO methods */
-  const char *zClass;             /* Storage class */
-  int isJournal;                  /* True if this is a journal file */
-  unsigned int nJrnl;             /* Space allocated for aJrnl[] */
-  char *aJrnl;                    /* Journal content */
-  int szPage;                     /* Last known page size */
-  sqlite3_int64 szDb;             /* Database file size.  -1 means unknown */
-  char *aData;                    /* Buffer to hold page data */
+  sqlite3_file base;
+  const char *zClass;
+  int isJournal;
+  unsigned int nJrnl;
+  char *aJrnl;
+  int szPage;
+  sqlite3_int64 szDb;
+  char *aData;
 };
 #define SQLITE_KVOS_SZ 133073
 
-/*
-** Methods for KVVfsFile
-*/
+
+
+
 static int kvvfsClose(sqlite3_file*);
 static int kvvfsReadDb(sqlite3_file*, void*, int iAmt, sqlite3_int64 iOfst);
 static int kvvfsReadJrnl(sqlite3_file*, void*, int iAmt, sqlite3_int64 iOfst);
@@ -82,9 +82,9 @@ static int kvvfsFileControlJrnl(sqlite3_file*, int op, void *pArg);
 static int kvvfsSectorSize(sqlite3_file*);
 static int kvvfsDeviceCharacteristics(sqlite3_file*);
 
-/*
-** Methods for sqlite3_vfs
-*/
+
+
+
 static int kvvfsOpen(sqlite3_vfs*, const char *, sqlite3_file*, int , int *);
 static int kvvfsDelete(sqlite3_vfs*, const char *zName, int syncDir);
 static int kvvfsAccess(sqlite3_vfs*, const char *zName, int flags, int *);
@@ -96,84 +96,84 @@ static int kvvfsCurrentTime(sqlite3_vfs*, double*);
 static int kvvfsCurrentTimeInt64(sqlite3_vfs*, sqlite3_int64*);
 
 static sqlite3_vfs sqlite3OsKvvfsObject = {
-  2,                              /* iVersion */
-  sizeof(KVVfsFile),              /* szOsFile */
-  1024,                           /* mxPathname */
-  0,                              /* pNext */
-  "kvvfs",                        /* zName */
-  0,                              /* pAppData */
-  kvvfsOpen,                      /* xOpen */
-  kvvfsDelete,                    /* xDelete */
-  kvvfsAccess,                    /* xAccess */
-  kvvfsFullPathname,              /* xFullPathname */
-  kvvfsDlOpen,                    /* xDlOpen */
-  0,                              /* xDlError */
-  0,                              /* xDlSym */
-  0,                              /* xDlClose */
-  kvvfsRandomness,                /* xRandomness */
-  kvvfsSleep,                     /* xSleep */
-  kvvfsCurrentTime,               /* xCurrentTime */
-  0,                              /* xGetLastError */
-  kvvfsCurrentTimeInt64           /* xCurrentTimeInt64 */
+  2,
+  sizeof(KVVfsFile),
+  1024,
+  0,
+  "kvvfs",
+  0,
+  kvvfsOpen,
+  kvvfsDelete,
+  kvvfsAccess,
+  kvvfsFullPathname,
+  kvvfsDlOpen,
+  0,
+  0,
+  0,
+  kvvfsRandomness,
+  kvvfsSleep,
+  kvvfsCurrentTime,
+  0,
+  kvvfsCurrentTimeInt64
 };
 
-/* Methods for sqlite3_file objects referencing a database file
-*/
+
+
 static sqlite3_io_methods kvvfs_db_io_methods = {
-  1,                              /* iVersion */
-  kvvfsClose,                     /* xClose */
-  kvvfsReadDb,                    /* xRead */
-  kvvfsWriteDb,                   /* xWrite */
-  kvvfsTruncateDb,                /* xTruncate */
-  kvvfsSyncDb,                    /* xSync */
-  kvvfsFileSizeDb,                /* xFileSize */
-  kvvfsLock,                      /* xLock */
-  kvvfsUnlock,                    /* xUnlock */
-  kvvfsCheckReservedLock,         /* xCheckReservedLock */
-  kvvfsFileControlDb,             /* xFileControl */
-  kvvfsSectorSize,                /* xSectorSize */
-  kvvfsDeviceCharacteristics,     /* xDeviceCharacteristics */
-  0,                              /* xShmMap */
-  0,                              /* xShmLock */
-  0,                              /* xShmBarrier */
-  0,                              /* xShmUnmap */
-  0,                              /* xFetch */
-  0                               /* xUnfetch */
+  1,
+  kvvfsClose,
+  kvvfsReadDb,
+  kvvfsWriteDb,
+  kvvfsTruncateDb,
+  kvvfsSyncDb,
+  kvvfsFileSizeDb,
+  kvvfsLock,
+  kvvfsUnlock,
+  kvvfsCheckReservedLock,
+  kvvfsFileControlDb,
+  kvvfsSectorSize,
+  kvvfsDeviceCharacteristics,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0
 };
 
-/* Methods for sqlite3_file objects referencing a rollback journal
-*/
+
+
 static sqlite3_io_methods kvvfs_jrnl_io_methods = {
-  1,                              /* iVersion */
-  kvvfsClose,                     /* xClose */
-  kvvfsReadJrnl,                  /* xRead */
-  kvvfsWriteJrnl,                 /* xWrite */
-  kvvfsTruncateJrnl,              /* xTruncate */
-  kvvfsSyncJrnl,                  /* xSync */
-  kvvfsFileSizeJrnl,              /* xFileSize */
-  kvvfsLock,                      /* xLock */
-  kvvfsUnlock,                    /* xUnlock */
-  kvvfsCheckReservedLock,         /* xCheckReservedLock */
-  kvvfsFileControlJrnl,           /* xFileControl */
-  kvvfsSectorSize,                /* xSectorSize */
-  kvvfsDeviceCharacteristics,     /* xDeviceCharacteristics */
-  0,                              /* xShmMap */
-  0,                              /* xShmLock */
-  0,                              /* xShmBarrier */
-  0,                              /* xShmUnmap */
-  0,                              /* xFetch */
-  0                               /* xUnfetch */
+  1,
+  kvvfsClose,
+  kvvfsReadJrnl,
+  kvvfsWriteJrnl,
+  kvvfsTruncateJrnl,
+  kvvfsSyncJrnl,
+  kvvfsFileSizeJrnl,
+  kvvfsLock,
+  kvvfsUnlock,
+  kvvfsCheckReservedLock,
+  kvvfsFileControlJrnl,
+  kvvfsSectorSize,
+  kvvfsDeviceCharacteristics,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0
 };
 
-/****** Storage subsystem **************************************************/
+
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
-/* Forward declarations for the low-level storage engine
-*/
+
+
 #ifndef SQLITE_WASM
-/* In WASM builds these are implemented in JS. */
+
 static int kvrecordWrite(const char*, const char *zKey, const char *zData);
 static int kvrecordDelete(const char*, const char *zKey);
 static int kvrecordRead(const char*, const char *zKey, char *zBuf, int nBuf);
@@ -182,10 +182,10 @@ static int kvrecordRead(const char*, const char *zKey, char *zBuf, int nBuf);
 #define KVRECORD_KEY_SZ 32
 #endif
 
-/* Expand the key name with an appropriate prefix and put the result
-** in zKeyOut[].  The zKeyOut[] buffer is assumed to hold at least
-** KVRECORD_KEY_SZ bytes.
-*/
+
+
+
+
 static void kvrecordMakeKey(
   const char *zClass,
   const char *zKeyIn,
@@ -199,17 +199,17 @@ static void kvrecordMakeKey(
 }
 
 #ifndef SQLITE_WASM
-/* In WASM builds do not define APIs which use fopen(), fwrite(),
-** and the like because those APIs are a portability issue for
-** WASM.
-*/
-/* Write content into a key.  zClass is the particular namespace of the
-** underlying key/value store to use - either "local" or "session".
-**
-** Both zKey and zData are zero-terminated pure text strings.
-**
-** Return the number of errors.
-*/
+
+
+
+
+
+
+
+
+
+
+
 static int kvrecordWrite(
   const char *zClass,
   const char *zKey,
@@ -231,10 +231,10 @@ static int kvrecordWrite(
   }
 }
 
-/* Delete a key (with its corresponding data) from the key/value
-** namespace given by zClass.  If the key does not previously exist,
-** this routine is a no-op.
-*/
+
+
+
+
 static int kvrecordDelete(const char *zClass, const char *zKey){
   char zXKey[KVRECORD_KEY_SZ];
   kvrecordMakeKey(zClass, zKey, zXKey);
@@ -243,21 +243,21 @@ static int kvrecordDelete(const char *zClass, const char *zKey){
   return 0;
 }
 
-/* Read the value associated with a zKey from the key/value namespace given
-** by zClass and put the text data associated with that key in the first
-** nBuf bytes of zBuf[].  The value might be truncated if zBuf is not large
-** enough to hold it all.  The value put into zBuf must always be zero
-** terminated, even if it gets truncated because nBuf is not large enough.
-**
-** Return the total number of bytes in the data, without truncation, and
-** not counting the final zero terminator.   Return -1 if the key does
-** not exist or its key cannot be read.
-**
-** If nBuf<=0 then this routine simply returns the size of the data
-** without actually reading it.  Similarly, if nBuf==1 then it
-** zero-terminates zBuf at zBuf[0] and returns the size of the data
-** without reading it.
-*/
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 static int kvrecordRead(
   const char *zClass,
   const char *zKey,
@@ -299,17 +299,17 @@ static int kvrecordRead(
     return (int)n;
   }
 }
-#endif /* #ifndef SQLITE_WASM */
+#endif
 
 
-/*
-** An internal level of indirection which enables us to replace the
-** kvvfs i/o methods with JavaScript implementations in WASM builds.
-** Maintenance reminder: if this struct changes in any way, the JSON
-** rendering of its structure must be updated in
-** sqlite3-wasm.c:sqlite3__wasm_enum_json(). There are no binary
-** compatibility concerns, so it does not need an iVersion member.
-*/
+
+
+
+
+
+
+
+
 typedef struct sqlite3_kvvfs_methods sqlite3_kvvfs_methods;
 struct sqlite3_kvvfs_methods {
   int (*xRcrdRead)(const char*, const char *zKey, char *zBuf, int nBuf);
@@ -329,16 +329,16 @@ struct sqlite3_kvvfs_methods {
 };
 
 
-/*
-** This object holds the kvvfs I/O methods which may be swapped out
-** for JavaScript-side implementations in WASM builds. In such builds
-** it cannot be const, but in native builds it should be so that
-** the compiler can hopefully optimize this level of indirection out.
-** That said, kvvfs is intended primarily for use in WASM builds.
-**
-** This is not explicitly flagged as static because the amalgamation
-** build will tag it with SQLITE_PRIVATE.
-*/
+
+
+
+
+
+
+
+
+
+
 #ifndef SQLITE_WASM
 const
 #endif
@@ -359,30 +359,30 @@ sqlite3_kvvfs_methods sqlite3KvvfsMethods = {
   .pIoJrnl         = &kvvfs_jrnl_io_methods
 };
 
-/****** Utility subroutines ************************************************/
 
-/*
-** Encode binary into the text encoded used to persist on disk.
-** The output text is stored in aOut[], which must be at least
-** nData+1 bytes in length.
-**
-** Return the actual length of the encoded text, not counting the
-** zero terminator at the end.
-**
-** Encoding format
-** ---------------
-**
-**   *  Non-zero bytes are encoded as upper-case hexadecimal
-**
-**   *  A sequence of one or more zero-bytes that are not at the
-**      beginning of the buffer are encoded as a little-endian
-**      base-26 number using a..z.  "a" means 0.  "b" means 1,
-**      "z" means 25.  "ab" means 26.  "ac" means 52.  And so forth.
-**
-**   *  Because there is no overlap between the encoding characters
-**      of hexadecimal and base-26 numbers, it is always clear where
-**      one stops and the next begins.
-*/
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 #ifndef SQLITE_WASM
 static
 #endif
@@ -395,11 +395,11 @@ int kvvfsEncode(const char *aData, int nData, char *aOut){
       aOut[j++] = "0123456789ABCDEF"[c>>4];
       aOut[j++] = "0123456789ABCDEF"[c&0xf];
     }else{
-      /* A sequence of 1 or more zeros is stored as a little-endian
-      ** base-26 number using a..z as the digits. So one zero is "b".
-      ** Two zeros is "c". 25 zeros is "z", 26 zeros is "ab", 27 is "bb",
-      ** and so forth.
-      */
+
+
+
+
+
       int k;
       for(k=1; i+k<nData && a[i+k]==0; k++){}
       i += k-1;
@@ -433,13 +433,13 @@ static const signed char kvvfsHexValue[256] = {
   -1, -1, -1, -1, -1, -1, -1, -1,   -1, -1, -1, -1, -1, -1, -1, -1
 };
 
-/*
-** Decode the text encoding back to binary.  The binary content is
-** written into pOut, which must be at least nOut bytes in length.
-**
-** The return value is the number of bytes actually written into aOut[], or
-** -1 for malformed inputs.
-*/
+
+
+
+
+
+
+
 #ifndef SQLITE_WASM
 static
 #endif
@@ -464,11 +464,11 @@ int kvvfsDecode(const char *a, char *aOut, int nOut){
       if( j+n>nOut ) return -1;
       memset(&aOut[j], 0, n);
       j += n;
-      if( c==0 || mult==1 ) break; /* progress stalled if mult==1 */
+      if( c==0 || mult==1 ) break;
     }else{
       aOut[j] = c<<4;
       c = kvvfsHexValue[aIn[++i]];
-      if( c<0 ) return -1 /* hex bytes are always in pairs */;
+      if( c<0 ) return -1 ;
       aOut[j++] += c;
       i++;
     }
@@ -476,21 +476,21 @@ int kvvfsDecode(const char *a, char *aOut, int nOut){
   return j;
 }
 
-/*
-** Decode a complete journal file.  Allocate space in pFile->aJrnl
-** and store the decoding there.  Or leave pFile->aJrnl set to NULL
-** if an error is encountered.
-**
-** The first few characters of the text encoding will be a little-endian
-** base-26 number (digits a..z) that is the total number of bytes
-** in the decoded journal file image.  This base-26 number is followed
-** by a single space, then the encoding of the journal.  The space
-** separator is required to act as a terminator for the base-26 number.
-*/
+
+
+
+
+
+
+
+
+
+
+
 static void kvvfsDecodeJournal(
-  KVVfsFile *pFile,      /* Store decoding in pFile->aJrnl */
-  const char *zTxt,      /* Text encoding.  Zero-terminated */
-  int nTxt               /* Bytes in zTxt, excluding zero terminator */
+  KVVfsFile *pFile,
+  const char *zTxt,
+  int nTxt
 ){
   unsigned int n = 0;
   int c, i, mult;
@@ -515,9 +515,9 @@ static void kvvfsDecodeJournal(
   }
 }
 
-/*
-** Read or write the "sz" element, containing the database file size.
-*/
+
+
+
 static sqlite3_int64 kvvfsReadFileSize(KVVfsFile *pFile){
   char zData[50];
   zData[0] = 0;
@@ -531,11 +531,11 @@ static int kvvfsWriteFileSize(KVVfsFile *pFile, sqlite3_int64 sz){
   return sqlite3KvvfsMethods.xRcrdWrite(pFile->zClass, "sz", zData);
 }
 
-/****** sqlite3_io_methods methods ******************************************/
 
-/*
-** Close an kvvfs-file.
-*/
+
+
+
+
 static int kvvfsClose(sqlite3_file *pProtoFile){
   KVVfsFile *pFile = (KVVfsFile *)pProtoFile;
 
@@ -549,9 +549,9 @@ static int kvvfsClose(sqlite3_file *pProtoFile){
   return SQLITE_OK;
 }
 
-/*
-** Read from the -journal file.
-*/
+
+
+
 static int kvvfsReadJrnl(
   sqlite3_file *pProtoFile,
   void *zBuf,
@@ -587,9 +587,9 @@ static int kvvfsReadJrnl(
   return SQLITE_OK;
 }
 
-/*
-** Read from the database file.
-*/
+
+
+
 static int kvvfsReadDb(
   sqlite3_file *pProtoFile,
   void *zBuf,
@@ -645,9 +645,9 @@ static int kvvfsReadDb(
 }
 
 
-/*
-** Write into the -journal file.
-*/
+
+
+
 static int kvvfsWriteJrnl(
   sqlite3_file *pProtoFile,
   const void *zBuf,
@@ -673,9 +673,9 @@ static int kvvfsWriteJrnl(
   return SQLITE_OK;
 }
 
-/*
-** Write into the database file.
-*/
+
+
+
 static int kvvfsWriteDb(
   sqlite3_file *pProtoFile,
   const void *zBuf,
@@ -704,9 +704,9 @@ static int kvvfsWriteDb(
   return rc;
 }
 
-/*
-** Truncate an kvvfs-file.
-*/
+
+
+
 static int kvvfsTruncateJrnl(sqlite3_file *pProtoFile, sqlite_int64 size){
   KVVfsFile *pFile = (KVVfsFile *)pProtoFile;
   SQLITE_KV_LOG(("xTruncate('%s-journal',%lld)\n", pFile->zClass, size));
@@ -739,9 +739,9 @@ static int kvvfsTruncateDb(sqlite3_file *pProtoFile, sqlite_int64 size){
   return SQLITE_IOERR;
 }
 
-/*
-** Sync an kvvfs-file.
-*/
+
+
+
 static int kvvfsSyncJrnl(sqlite3_file *pProtoFile, int flags){
   int i, n;
   KVVfsFile *pFile = (KVVfsFile *)pProtoFile;
@@ -770,9 +770,9 @@ static int kvvfsSyncDb(sqlite3_file *pProtoFile, int flags){
   return SQLITE_OK;
 }
 
-/*
-** Return the current file-size of an kvvfs-file.
-*/
+
+
+
 static int kvvfsFileSizeJrnl(sqlite3_file *pProtoFile, sqlite_int64 *pSize){
   KVVfsFile *pFile = (KVVfsFile *)pProtoFile;
   SQLITE_KV_LOG(("xFileSize('%s-journal')\n", pFile->zClass));
@@ -790,9 +790,9 @@ static int kvvfsFileSizeDb(sqlite3_file *pProtoFile, sqlite_int64 *pSize){
   return SQLITE_OK;
 }
 
-/*
-** Lock an kvvfs-file.
-*/
+
+
+
 static int kvvfsLock(sqlite3_file *pProtoFile, int eLock){
   KVVfsFile *pFile = (KVVfsFile *)pProtoFile;
   assert( !pFile->isJournal );
@@ -804,9 +804,9 @@ static int kvvfsLock(sqlite3_file *pProtoFile, int eLock){
   return SQLITE_OK;
 }
 
-/*
-** Unlock an kvvfs-file.
-*/
+
+
+
 static int kvvfsUnlock(sqlite3_file *pProtoFile, int eLock){
   KVVfsFile *pFile = (KVVfsFile *)pProtoFile;
   assert( !pFile->isJournal );
@@ -817,18 +817,18 @@ static int kvvfsUnlock(sqlite3_file *pProtoFile, int eLock){
   return SQLITE_OK;
 }
 
-/*
-** Check if another file-handle holds a RESERVED lock on an kvvfs-file.
-*/
+
+
+
 static int kvvfsCheckReservedLock(sqlite3_file *pProtoFile, int *pResOut){
   SQLITE_KV_LOG(("xCheckReservedLock\n"));
   *pResOut = 0;
   return SQLITE_OK;
 }
 
-/*
-** File control method. For custom operations on an kvvfs-file.
-*/
+
+
+
 static int kvvfsFileControlJrnl(sqlite3_file *pProtoFile, int op, void *pArg){
   SQLITE_KV_LOG(("xFileControl(%d) on journal\n", op));
   return SQLITE_NOTFOUND;
@@ -847,25 +847,25 @@ static int kvvfsFileControlDb(sqlite3_file *pProtoFile, int op, void *pArg){
   return SQLITE_NOTFOUND;
 }
 
-/*
-** Return the sector-size in bytes for an kvvfs-file.
-*/
+
+
+
 static int kvvfsSectorSize(sqlite3_file *pFile){
   return 512;
 }
 
-/*
-** Return the device characteristic flags supported by an kvvfs-file.
-*/
+
+
+
 static int kvvfsDeviceCharacteristics(sqlite3_file *pProtoFile){
   return 0;
 }
 
-/****** sqlite3_vfs methods *************************************************/
 
-/*
-** Open an kvvfs file handle.
-*/
+
+
+
+
 static int kvvfsOpen(
   sqlite3_vfs *pProtoVfs,
   const char *zName,
@@ -905,13 +905,13 @@ static int kvvfsOpen(
   return SQLITE_OK;
 }
 
-/*
-** Delete the file located at zPath. If the dirSync argument is true,
-** ensure the file-system modifications are synced to disk before
-** returning.
-*/
+
+
+
+
+
 static int kvvfsDelete(sqlite3_vfs *pVfs, const char *zPath, int dirSync){
-  int rc /* The JS impl can fail with OOM in argument conversion */;
+  int rc ;
   if( strcmp(zPath, "local-journal")==0 ){
     rc = sqlite3KvvfsMethods.xRcrdDelete("local", "jrnl");
   }else
@@ -924,10 +924,10 @@ static int kvvfsDelete(sqlite3_vfs *pVfs, const char *zPath, int dirSync){
   return rc;
 }
 
-/*
-** Test for access permissions. Return true if the requested permission
-** is available, or false otherwise.
-*/
+
+
+
+
 static int kvvfsAccess(
   sqlite3_vfs *pProtoVfs,
   const char *zPath,
@@ -936,15 +936,15 @@ static int kvvfsAccess(
 ){
   SQLITE_KV_LOG(("xAccess(\"%s\")\n", zPath));
 #if 0 && defined(SQLITE_WASM)
-  /*
-  ** This is not having the desired effect in the JS bindings.
-  ** It's ostensibly the same logic as the #else block, but
-  ** it's not behaving that way.
-  **
-  ** In JS we map all zPaths to Storage objects, and -journal files
-  ** are mapped to the storage for the main db (which is is exactly
-  ** what the mapping of "local-journal" -> "local" is doing).
-  */
+
+
+
+
+
+
+
+
+
   const char *zKey = (0==sqlite3_strglob("*-journal", zPath))
     ? "jrnl" : "sz";
   *pResOut =
@@ -969,17 +969,17 @@ static int kvvfsAccess(
   {
     *pResOut = 0;
   }
-  /*all current JS tests avoid triggering: assert( *pResOut == 0 ); */
+
 #endif
   SQLITE_KV_LOG(("xAccess returns %d\n",*pResOut));
   return SQLITE_OK;
 }
 
-/*
-** Populate buffer zOut with the full canonical pathname corresponding
-** to the pathname in zPath. zOut is guaranteed to point to a buffer
-** of at least (INST_MAX_PATHNAME+1) bytes.
-*/
+
+
+
+
+
 static int kvvfsFullPathname(
   sqlite3_vfs *pVfs,
   const char *zPath,
@@ -998,33 +998,33 @@ static int kvvfsFullPathname(
   return SQLITE_OK;
 }
 
-/*
-** Open the dynamic library located at zPath and return a handle.
-*/
+
+
+
 static void *kvvfsDlOpen(sqlite3_vfs *pVfs, const char *zPath){
   return 0;
 }
 
-/*
-** Populate the buffer pointed to by zBufOut with nByte bytes of
-** random data.
-*/
+
+
+
+
 static int kvvfsRandomness(sqlite3_vfs *pVfs, int nByte, char *zBufOut){
   memset(zBufOut, 0, nByte);
   return nByte;
 }
 
-/*
-** Sleep for nMicro microseconds. Return the number of microseconds
-** actually slept.
-*/
+
+
+
+
 static int kvvfsSleep(sqlite3_vfs *pVfs, int nMicro){
   return SQLITE_OK;
 }
 
-/*
-** Return the current time as a Julian Day number in *pTimeOut.
-*/
+
+
+
 static int kvvfsCurrentTime(sqlite3_vfs *pVfs, double *pTimeOut){
   sqlite3_int64 i = 0;
   int rc;
@@ -1036,23 +1036,23 @@ static int kvvfsCurrentTime(sqlite3_vfs *pVfs, double *pTimeOut){
 static int kvvfsCurrentTimeInt64(sqlite3_vfs *pVfs, sqlite3_int64 *pTimeOut){
   static const sqlite3_int64 unixEpoch = 24405875*(sqlite3_int64)8640000;
   struct timeval sNow;
-  (void)gettimeofday(&sNow, 0);  /* Cannot fail given valid arguments */
+  (void)gettimeofday(&sNow, 0);
   *pTimeOut = unixEpoch + 1000*(sqlite3_int64)sNow.tv_sec + sNow.tv_usec/1000;
   return SQLITE_OK;
 }
-#endif /* SQLITE_OS_KV || SQLITE_OS_UNIX */
+#endif
 
 #if SQLITE_OS_KV
-/*
-** This routine is called initialize the KV-vfs as the default VFS.
-*/
+
+
+
 int sqlite3_os_init(void){
   return sqlite3_vfs_register(&sqlite3OsKvvfsObject, 1);
 }
 int sqlite3_os_end(void){
   return SQLITE_OK;
 }
-#endif /* SQLITE_OS_KV */
+#endif
 
 #if SQLITE_OS_UNIX && defined(SQLITE_OS_KV_OPTIONAL)
 int sqlite3KvvfsInit(void){

--- a/src/pager_shim.c
+++ b/src/pager_shim.c
@@ -1,12 +1,4 @@
 
-
-
-
-
-
-
-
-
 #ifdef DOLTLITE_PROLLY
 
 #include "pager_shim.h"
@@ -446,10 +438,6 @@ static const PagerOps origPagerOps = {
 #endif
 };
 
-
-
-
-
 static inline const PagerOps *getPagerOps(const Pager *p){
   if( p && ((const PagerShim*)p)->magic == PAGER_SHIM_MAGIC ){
     return ((const PagerShim*)p)->pOps;
@@ -470,7 +458,6 @@ PagerShim *pagerShimCreate(
   pShim->magic = PAGER_SHIM_MAGIC;
   pShim->pOps = &shimPagerOps;
 
-
   if( zFilename && zFilename[0] ){
     int n = (int)strlen(zFilename);
     pShim->zFilename = (char*)sqlite3_malloc(n + 1);
@@ -488,7 +475,6 @@ PagerShim *pagerShimCreate(
     pShim->zFilename[0] = '\0';
   }
 
-
   pShim->zJournal = (char*)sqlite3_malloc(1);
   if( pShim->zJournal==0 ){
     sqlite3_free(pShim->zFilename);
@@ -496,7 +482,6 @@ PagerShim *pagerShimCreate(
     return 0;
   }
   pShim->zJournal[0] = '\0';
-
 
   if( pFd==0 ){
     pFd = pagerShimDummyFile();
@@ -824,10 +809,6 @@ struct DoltliteBackup {
   int done;
 };
 
-
-
-
-
 sqlite3_backup *sqlite3_backup_init(sqlite3 *pDest, const char *zDestDb,
                                      sqlite3 *pSrc, const char *zSrcDb){
   DoltliteBackup *p;
@@ -837,16 +818,13 @@ sqlite3_backup *sqlite3_backup_init(sqlite3 *pDest, const char *zDestDb,
 
   if( !pDest || !pSrc || pDest==pSrc ) return 0;
 
-
   iSrc = sqlite3FindDbName(pSrc, zSrcDb);
   iDest = sqlite3FindDbName(pDest, zDestDb);
   if( iSrc < 0 || iDest < 0 ) return 0;
 
-
   if( iSrc != 0 || iDest != 0 ){
     return orig_sqlite3_backup_init(pDest, zDestDb, pSrc, zSrcDb);
   }
-
 
   srcCs = doltliteGetChunkStore(pSrc);
   destCs = doltliteGetChunkStore(pDest);
@@ -885,7 +863,6 @@ int sqlite3_backup_step(sqlite3_backup *pBackup, int nPage){
   if( !p ) return SQLITE_DONE;
   if( p->done ) return SQLITE_DONE;
 
-
   openFlags = SQLITE_OPEN_READONLY | SQLITE_OPEN_MAIN_DB;
   rc = sqlite3OsOpenMalloc(p->pVfs, p->zSrcFile, &pSrc, openFlags, 0);
   if( rc != SQLITE_OK ) return rc;
@@ -902,7 +879,6 @@ int sqlite3_backup_step(sqlite3_backup *pBackup, int nPage){
     sqlite3OsCloseFree(pSrc);
     return rc;
   }
-
 
   {
     u8 *buf = (u8*)sqlite3_malloc(65536);

--- a/src/pager_shim.c
+++ b/src/pager_shim.c
@@ -1,11 +1,11 @@
-/* Pager API shim. Doltlite stores data in a content-addressed chunk
-** store, not 4k pages, so the stock SQLite pager layer has nothing to
-** do. This file provides a drop-in replacement for every sqlite3Pager*
-** entry point. The shim dispatches by sniffing a magic field on the
-** Pager struct: shimmed pagers have PAGER_SHIM_MAGIC and route to
-** no-op / bookkeeping ops, stock pagers (temp files, attached
-** :memory:, plain-sqlite ATTACHes) fall through to origPagerOps which
-** calls the real SQLite implementation. */
+
+
+
+
+
+
+
+
 
 #ifdef DOLTLITE_PROLLY
 
@@ -446,10 +446,10 @@ static const PagerOps origPagerOps = {
 #endif
 };
 
-/* Dispatch table selector. Stock SQLite Pagers never set the magic
-** field, so anything without it gets the real pager ops — this is
-** what lets attached stock-sqlite databases coexist with doltlite's
-** main db in the same sqlite3 handle. */
+
+
+
+
 static inline const PagerOps *getPagerOps(const Pager *p){
   if( p && ((const PagerShim*)p)->magic == PAGER_SHIM_MAGIC ){
     return ((const PagerShim*)p)->pOps;
@@ -824,10 +824,10 @@ struct DoltliteBackup {
   int done;
 };
 
-/* Doltlite's backup can't use SQLite's page-by-page copy — shimmed
-** pagers return no pages. Instead we copy the chunk store file
-** byte-for-byte. Only the main db (iDb == 0) is doltlite-backed;
-** attached stock databases fall through to the real backup API. */
+
+
+
+
 sqlite3_backup *sqlite3_backup_init(sqlite3 *pDest, const char *zDestDb,
                                      sqlite3 *pSrc, const char *zSrcDb){
   DoltliteBackup *p;

--- a/src/pager_shim.h
+++ b/src/pager_shim.h
@@ -7,8 +7,8 @@
 typedef struct PagerShim PagerShim;
 typedef struct PagerOps PagerOps;
 
-
-
+/* PagerShim only satisfies the sqlite3Pager* calls Doltlite's btree facade
+** reaches; it is not a general replacement for SQLite's pager. */
 #define PAGER_SHIM_MAGIC 0x50534D31
 struct PagerShim {
   u32 magic;

--- a/src/pager_shim.h
+++ b/src/pager_shim.h
@@ -6,7 +6,6 @@
 
 typedef struct PagerShim PagerShim;
 typedef struct PagerOps PagerOps;
-
 /* PagerShim only satisfies the sqlite3Pager* calls Doltlite's btree facade
 ** reaches; it is not a general replacement for SQLite's pager. */
 #define PAGER_SHIM_MAGIC 0x50534D31

--- a/src/pager_shim.h
+++ b/src/pager_shim.h
@@ -6,9 +6,9 @@
 
 typedef struct PagerShim PagerShim;
 typedef struct PagerOps PagerOps;
-/* PagerShim is cast to Pager* at the callsite, so the magic MUST be
-** at offset 0 — getPagerOps sniffs it blindly on every incoming
-** Pager* to decide shim vs. orig dispatch. */
+
+
+
 #define PAGER_SHIM_MAGIC 0x50534D31
 struct PagerShim {
   u32 magic;

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -121,12 +121,6 @@ struct TableEntry {
   ProllyMutMap *pPending;
 };
 
-
-
-
-
-
-
 typedef struct Catalog Catalog;
 struct Catalog {
   struct TableEntry *a;
@@ -271,7 +265,6 @@ struct Btree {
   u8 inTransaction;
   u8 bSchemaChangedTxn;
 
-
   int nSavepoint;
   int nSavepointAlloc;
 
@@ -306,7 +299,6 @@ struct Btree {
   ProllyHash committedConflictsCatalogHash;
   ProllyHash committedConstraintViolationsHash;
 
-
   char *zBranch;
   char *zAuthorName;
   char *zAuthorEmail;
@@ -316,22 +308,11 @@ struct Btree {
   ProllyHash mergeCommitHash;
   ProllyHash conflictsCatalogHash;
 
-
-
-
-
-
-
   u8 isRebasing;
   ProllyHash preRebaseWorkingCat;
   ProllyHash rebaseOntoCommit;
   char *zRebaseOrigBranch;
   char *zRebaseReturnBranch;
-
-
-
-
-
 
   ProllyHash constraintViolationsHash;
 
@@ -371,7 +352,6 @@ struct BtCursor {
   u8 isPinned;
   u8 flushSeekEdits;
 
-
   int mmIdx;
   int mmPhysIdx;
   u8 mmActive;
@@ -381,7 +361,6 @@ struct BtCursor {
 #define MERGE_SRC_MUT   1
 #define MERGE_SRC_BOTH  2
   u8 mergeSrc;
-
 
   i64 nKey;
   void *pKey;
@@ -397,9 +376,6 @@ static void catFree(Catalog *cat);
 static int btreeLoadBranchHeadCatalog(ChunkStore *cs, const char *zBranch,
                                       ProllyHash *pCatHash,
                                       ProllyHash *pHeadCommit);
-
-
-
 
 static inline struct TableEntry *findTable(Btree *p, Pgno iTable){
   return catFind(&p->cat, iTable);
@@ -460,12 +436,6 @@ static SQLITE_INLINE void cacheCurrentTreePayloadIfIntKey(BtCursor *pCur){
     }
   }
 }
-
-
-
-
-
-
 
 static void cacheCurrentTreePayloadNonIntKey(BtCursor *pCur){
   const u8 *pVal; int nVal;
@@ -555,11 +525,6 @@ static int btreeWriteWorkingState(
   const ProllyHash *pCommitHash
 );
 static int btreeDeleteImmediate(BtCursor *pCur);
-
-
-
-
-
 
 #define PROLLY_MUTMAP_PENDING_FLUSH_LIMIT 65536
 
@@ -975,13 +940,6 @@ static void catRemove(Catalog *cat, Pgno iTable){
   }
 }
 
-
-
-
-
-
-
-
 static void catFree(Catalog *cat){
   int k;
   for(k=0; k<cat->n; k++){
@@ -1000,13 +958,6 @@ static void catFree(Catalog *cat){
 }
 
 static void invalidateSchema(Btree *pBtree){
-
-
-
-
-
-
-
   if( pBtree->pSchema && pBtree->xFreeSchema ){
     pBtree->xFreeSchema(pBtree->pSchema);
   }
@@ -1214,7 +1165,6 @@ done:
   *pnMeta = nMeta;
   return SQLITE_OK;
 }
-
 
 static int catalogSerializeEntryCmp(const void *a, const void *b){
   const CatalogSerializeEntry *ea = (const CatalogSerializeEntry*)a;
@@ -2138,7 +2088,6 @@ static int deserializeCatalog(Btree *pBtree, const u8 *data, int nData){
   btreeFreeCatalogTables(pBtree);
   initDefaultMeta(pBtree);
 
-
   {
     u32 schemaHash = 0;
     int j;
@@ -2147,7 +2096,6 @@ static int deserializeCatalog(Btree *pBtree, const u8 *data, int nData){
     }
     pBtree->aMeta[BTREE_SCHEMA_VERSION] = schemaHash | 1;
   }
-
 
   for(i=0; i<nTables; i++){
     Pgno iTable;
@@ -2198,7 +2146,6 @@ static int deserializeCatalog(Btree *pBtree, const u8 *data, int nData){
       }
     }
   }
-
 
   {
     Pgno maxPage = 0;
@@ -2415,11 +2362,6 @@ static int flushMutMap(BtCursor *pCur){
     return SQLITE_OK;
   }
 
-
-
-
-
-
   pFlushMap = (ProllyMutMap*)pTE->pPending;
   captured = 0;
   rc = snapshotPendingForFlush(pCur->pBtree, pCur->pgnoRoot,
@@ -2504,10 +2446,6 @@ static void refreshCursorMutMapAliases(BtShared *pBt, Pgno iTable,
   for(p = pBt->pCursor; p; p = p->pNext){
     if( p->pgnoRoot==iTable ){
       p->pMutMap = pNewMap;
-
-
-
-
       p->mmActive = 0;
       p->mmPhysActive = 0;
       p->deferredTreeSeek = 0;
@@ -2525,11 +2463,6 @@ static int ensureMutMap(BtCursor *pCur){
 
   pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
   if( !pTE ) return SQLITE_INTERNAL;
-
-
-
-
-
 
   if( pTE->pPending ){
     pCur->pMutMap = (ProllyMutMap*)pTE->pPending;
@@ -2560,7 +2493,6 @@ static int saveCursorPosition(BtCursor *pCur){
     return SQLITE_OK;
   }
 
-
   if( !prollyCursorIsValid(&pCur->pCur) ){
     if( pCur->curIntKey && (pCur->curFlags & BTCF_ValidNKey) ){
 
@@ -2572,7 +2504,6 @@ static int saveCursorPosition(BtCursor *pCur){
     pCur->eState = CURSOR_INVALID;
     return SQLITE_OK;
   }
-
 
   if( pCur->curIntKey ){
     if( pCur->mmActive
@@ -3114,8 +3045,6 @@ static int restoreTablesFromSavepoint(
       prollyMutMapFree(pMap);
       sqlite3_free(pMap);
     }
-
-
     aCurrent[k].pPending = 0;
   }
 
@@ -3320,7 +3249,6 @@ int sqlite3BtreeOpen(
 
   *ppBtree = 0;
 
-
   if( !zFilename || zFilename[0]=='\0'
    || (strcmp(zFilename, ":memory:")==0 && db->aDb[0].pBt!=0)
    || (flags & BTREE_SINGLE)
@@ -3391,7 +3319,6 @@ int sqlite3BtreeOpen(
   if( chunkStoreIsEmpty(&pBt->store) ){
     pBt->btsFlags |= BTS_INITIALLY_EMPTY;
   }
-
 
   p->aMeta[BTREE_FREE_PAGE_COUNT] = 0;
   p->aMeta[BTREE_SCHEMA_VERSION] = 0;
@@ -3506,7 +3433,6 @@ int sqlite3BtreeOpen(
     p->constraintViolationsHash = constraintViolationsHash;
   }
 
-
   p->cat.iNextTable = 2;
   if( !addTable(p, 1, BTREE_INTKEY) ){
     pagerShimDestroy(pBt->pPagerShim);
@@ -3524,7 +3450,6 @@ int sqlite3BtreeOpen(
   p->iBDataVersion = 1;
   p->nSeek = 0;
 
-
   {
     const char *defBranch = chunkStoreGetDefaultBranch(&pBt->store);
     ProllyHash branchCommit;
@@ -3537,7 +3462,6 @@ int sqlite3BtreeOpen(
   }
 
   *ppBtree = p;
-
 
   registerDoltiteFunctions(db);
 
@@ -3553,11 +3477,6 @@ static int prollyBtreeClose(Btree *p){
   while( pBt->pCursor ){
     sqlite3BtreeCloseCursor(pBt->pCursor);
   }
-
-
-
-
-
 
   if( p->pSchema ){
     if( p->xFreeSchema ) p->xFreeSchema(p->pSchema);
@@ -4242,7 +4161,6 @@ static int prollyBtreeBeginTrans(Btree *p, int wrFlag, int *pSchemaVersion){
     }
   }
 
-
   pBt->store.snapshotPinned = 1;
 
   return SQLITE_OK;
@@ -4506,7 +4424,6 @@ static int prollyBtreeBeginStmt(Btree *p, int iStatement){
     return SQLITE_ERROR;
   }
 
-
   while( p->nSavepoint < iStatement ){
     int rc = pushSavepoint(p, 1);
     if( rc!=SQLITE_OK ) return rc;
@@ -4554,10 +4471,6 @@ static int persistRolledBackSessionState(Btree *p, BtShared *pBt){
   if( rc!=SQLITE_OK ) return rc;
   return chunkStoreCommit(&pBt->store);
 }
-
-
-
-
 
 static void btreeDiscardAllSavepoints(Btree *p){
   int j;
@@ -4697,7 +4610,6 @@ static int prollyBtreeDropTable(Btree *p, int iTable, int *piMoved){
   if( p->inTrans!=TRANS_WRITE ){
     return SQLITE_ERROR;
   }
-
 
   if( iTable==1 ){
     struct TableEntry *pTE = findTable(p, 1);
@@ -4879,12 +4791,6 @@ static int prollyBtreeCursor(
     pCur->curFlags = BTCF_WriteFlag;
   }
 
-
-
-
-
-
-
   if( pTE->pPending ){
     pCur->pMutMap = (ProllyMutMap*)pTE->pPending;
     if( wrFlag & BTREE_WRCSR ){
@@ -4924,10 +4830,6 @@ static int prollyBtCursorCloseCursor(BtCursor *pCur){
   if( !pCur ) return SQLITE_OK;
   pBt = pCur->pBt;
   if( !pBt ) return SQLITE_OK;
-
-
-
-
 
   if( pCur->pMutMap && pCur->flushSeekEdits ){
     struct TableEntry *pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
@@ -5103,11 +5005,6 @@ static int mergeScan(BtCursor *pCur, int dir, int *pRes){
   }
 }
 
-
-
-
-
-
 static void cursorNormalizeMmPhys(BtCursor *pCur){
   if( pCur->mmPhysActive ){
     pCur->mmIdx = prollyMutMapOrderIndexFromEntry(
@@ -5212,11 +5109,6 @@ static int mergeLast(BtCursor *pCur, int *pRes){
 static int prollyBtCursorFirst(BtCursor *pCur, int *pRes){
   int rc;
   CLEAR_CACHED_PAYLOAD(pCur);
-
-
-
-
-
   refreshCursorRoot(pCur);
   rc = prollyCursorFirst(&pCur->pCur, pRes);
   if( rc!=SQLITE_OK ) return rc;
@@ -5240,7 +5132,6 @@ int sqlite3BtreeFirst(BtCursor *pCur, int *pRes){
 static int prollyBtCursorLast(BtCursor *pCur, int *pRes){
   int rc;
   CLEAR_CACHED_PAYLOAD(pCur);
-
   refreshCursorRoot(pCur);
   rc = prollyCursorLast(&pCur->pCur, pRes);
   if( rc!=SQLITE_OK ) return rc;
@@ -5273,7 +5164,6 @@ static int prollyBtCursorNext(BtCursor *pCur, int flags){
   if( pCur->eState==CURSOR_INVALID ){
     return SQLITE_DONE;
   }
-
 
   if( pCur->eState==CURSOR_REQUIRESEEK ){
     rc = restoreCursorPosition(pCur, 0);
@@ -5532,9 +5422,6 @@ static int prollyBtCursorTableMoveto(
 
   }
 
-
-
-
   refreshCursorRoot(pCur);
 
   rc = prollyCursorSeekInt(&pCur->pCur, intKey, pRes);
@@ -5604,12 +5491,6 @@ static int findMatchingMutMapEntry(
   int rc = SQLITE_OK;
   int cmp = 0;
   ProllyMutMapEntry *pMatch = 0;
-
-
-
-
-
-
   u8 *pRecBuf = 0;
   int nRecBufAlloc = 0;
   int lo = 0, found = 0;
@@ -5692,7 +5573,6 @@ static int prollyBtCursorIndexMoveto(
 
   refreshCursorRoot(pCur);
 
-
   {
     int treeFound = 0, mutFound = 0;
     int treeCmp = 0, mutCmp = 0;
@@ -5700,7 +5580,6 @@ static int prollyBtCursorIndexMoveto(
     int mutNKey = 0;
     ProllyMutMapEntry *mutE = 0;
     int mutFromCursorMap = 0;
-
 
     u8 *pSerKey = 0;
     int nSerKey = 0;
@@ -5765,16 +5644,9 @@ static int prollyBtCursorIndexMoveto(
       int seekIdx = pCur->pCur.aLevel[iLevel].idx;
       int nItems = pLeaf->node.nItems;
 
-
       int bestIdx = -1;
       int bestCmp = 0;
       {
-
-
-
-
-
-
 
         int lo = seekIdx;
         u8 *pRecBuf = pCur->pMovetoRec;
@@ -5886,10 +5758,7 @@ static int prollyBtCursorIndexMoveto(
         treeFound = 1;
       }
 
-
     }
-
-
 
     {
       struct TableEntry *pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
@@ -5898,11 +5767,6 @@ static int prollyBtCursorIndexMoveto(
          || (pPending && pPending!=pCur->pMutMap
              && !prollyMutMapIsEmpty(pPending)))
        && !(treeFound && treeCmp==0) ){
-
-
-
-
-
       int savedEqSeen = pIdxKey->eqSeen;
       rc = findMatchingMutMapEntry((ProllyMutMap*)pCur->pMutMap,
                                    pCur->pKeyInfo,
@@ -5944,7 +5808,6 @@ static int prollyBtCursorIndexMoveto(
     }
     }
 
-
       if( mutFound && (!treeFound || treeCmp!=0) ){
       if( mutFromCursorMap ){
         setCursorToMutMapEntryPhys(
@@ -5957,10 +5820,6 @@ static int prollyBtCursorIndexMoveto(
         pCur->eState = CURSOR_VALID;
       }
       *pRes = mutCmp;
-
-
-
-
       pIdxKey->eqSeen = 1;
       return SQLITE_OK;
     }
@@ -6023,7 +5882,6 @@ static void getCursorPayload(BtCursor *pCur, const u8 **ppData, int *pnData){
     *pnData = pCur->nCachedPayload;
     return;
   }
-
 
   if( pCur->mmActive
    && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
@@ -6149,7 +6007,6 @@ static int prollyBtCursorInsert(
   int rc;
   (void)seekResult;
 
-
   if( flags & BTREE_PREFORMAT ){
     return SQLITE_OK;
   }
@@ -6197,19 +6054,11 @@ static int prollyBtCursorInsert(
      && pCur->pKeyInfo->nKeyField < pCur->pKeyInfo->nAllField ){
       nKeyField = (int)pCur->pKeyInfo->nKeyField;
       splitKey = 1;
-
-
-
-
-
       {
         struct TableEntry *pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
         isIndex = (pTE && !tableEntryIsTableRoot(pCur->pBtree, pTE));
       }
     }
-
-
-
     rc = sortKeyFromRecordPrefixCollBuffer(
         (const u8*)pPayload->pKey, (int)pPayload->nKey,
         isIndex ? 0 : (splitKey ? nKeyField : 0),
@@ -6229,7 +6078,6 @@ static int prollyBtCursorInsert(
   }
 
   if( rc!=SQLITE_OK ) return rc;
-
 
   {
     int canDefer = (pCur->pgnoRoot > 1);
@@ -6311,19 +6159,9 @@ static int flushIfNeeded(BtCursor *pCur){
   int rc;
   struct TableEntry *pTE;
 
-
-
-
-
-
-
-
   if( !pCur->pMutMap || prollyMutMapIsEmpty(pCur->pMutMap) ){
     return SQLITE_OK;
   }
-
-
-
 
   {
     BtCursor *p;
@@ -6360,14 +6198,12 @@ static int flushAllPending(BtShared *pBt, Pgno iTable){
   BtCursor *p;
   int rc;
 
-
   for(p = pBt->pCursor; p; p = p->pNext){
     if( iTable==0 || p->pgnoRoot==iTable ){
       rc = flushIfNeeded(p);
       if( rc!=SQLITE_OK ) return rc;
     }
   }
-
 
   rc = flushDeferredEdits(pBt);
   if( rc!=SQLITE_OK ) return rc;
@@ -6445,7 +6281,6 @@ static int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
     return SQLITE_CORRUPT_BKPT;
   }
 
-
   if( pCur->eState==CURSOR_VALID || pCur->eState==CURSOR_INVALID ){
     if( pCur->curIntKey ){
       if( pCur->mmActive
@@ -6473,8 +6308,6 @@ static int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
         int nDelKeyField = 0;
         if( pCur->pKeyInfo
          && pCur->pKeyInfo->nKeyField < pCur->pKeyInfo->nAllField ){
-
-
           struct TableEntry *pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
           if( pTE && !tableEntryIsTableRoot(pCur->pBtree, pTE) ){
             nDelKeyField = 0;
@@ -6508,7 +6341,6 @@ static int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
   rc = ensureMutMap(pCur);
   if( rc!=SQLITE_OK ){ sqlite3_free(pSavedDelKey); return rc; }
 
-
   if( pCur->curIntKey ){
     if( hasSavedKey ){
       iKey = savedIntKey;
@@ -6525,7 +6357,6 @@ static int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
   }
 
   if( rc!=SQLITE_OK ) return rc;
-
 
   {
     int canDefer = (pCur->pgnoRoot > 1);
@@ -6546,7 +6377,6 @@ static int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
       return SQLITE_OK;
     }
   }
-
 
   rc = btreeDeleteImmediate(pCur);
   if( rc!=SQLITE_OK ) return rc;
@@ -6654,10 +6484,6 @@ int sqlite3SchemaMutexHeld(sqlite3 *db, int iDb, Schema *pSchema){
 
 static void prollyBtreeLeave(Btree *p){ (void)p; }
 #endif
-
-
-
-
 
 int sqlite3BtreeTripAllCursors(Btree *p, int errCode, int writeOnly){
   BtCursor *pCur;
@@ -6888,7 +6714,6 @@ int sqlite3BtreeIntegrityCheck(
     return SQLITE_OK;
   }
 
-
   if( p->pOrigBtree ){
     return origBtreeIntegrityCheck(db, p->pOrigBtree, aRoot, aCnt,
                                    nRoot, mxErr, pnErr, pzOut);
@@ -7023,7 +6848,6 @@ int sqlite3BtreeCopyFile(Btree *pTo, Btree *pFrom){
 }
 
 int sqlite3BtreeIsInBackup(Btree *p){
-
   (void)p;
   return 0;
 }
@@ -7046,11 +6870,6 @@ static int prollyBtCursorPayloadChecked(BtCursor *pCur, u32 offset, u32 amt, voi
   if( pCur->eState!=CURSOR_VALID ){
     return SQLITE_ABORT;
   }
-
-
-
-
-
 
   getCursorPayload(pCur, &pVal, &nVal);
 
@@ -7281,7 +7100,6 @@ int doltliteApplyRawRowMutation(
   }
   if( !pTE ) return SQLITE_NOTFOUND;
 
-
   rc = flushPendingForTable(pBtree, pBt, pTE, 0);
   if( rc!=SQLITE_OK ) return rc;
 
@@ -7399,10 +7217,6 @@ int doltliteLoadCatalog(sqlite3 *db, const ProllyHash *catHash,
   if( piNextTable ) *piNextTable = temp.cat.iNextTable;
   return SQLITE_OK;
 }
-
-
-
-
 
 void doltliteFreeCatalog(struct TableEntry *a, int n){
   int i;
@@ -7531,9 +7345,6 @@ int doltliteSwitchCatalog(sqlite3 *db, const ProllyHash *catHash){
 
   invalidateCursors(pBt, 0, SQLITE_ABORT);
 
-
-
-
   rc = deserializeCatalog(pBtree, data, nData);
   sqlite3_free(data);
   if( rc!=SQLITE_OK ) return rc;
@@ -7588,11 +7399,7 @@ int doltliteHardReset(sqlite3 *db, const ProllyHash *catHash){
   oldMergeCommitHash = pBtree->mergeCommitHash;
   oldConflictsCatalogHash = pBtree->conflictsCatalogHash;
 
-
   invalidateCursors(pBt, 0, SQLITE_ABORT);
-
-
-
 
   rc = deserializeCatalog(pBtree, data, nData);
   sqlite3_free(data);
@@ -7609,13 +7416,11 @@ int doltliteHardReset(sqlite3 *db, const ProllyHash *catHash){
     return rc;
   }
 
-
   pBtree->aMeta[BTREE_SCHEMA_VERSION]++;
   pBtree->iBDataVersion++;
   if( pBt->pPagerShim ){
     pBt->pPagerShim->iDataVersion++;
   }
-
 
   if( pBtree->db ){
     sqlite3ExpirePreparedStatements(pBtree->db, 0);
@@ -7624,10 +7429,7 @@ int doltliteHardReset(sqlite3 *db, const ProllyHash *catHash){
     invalidateSchema(pBtree);
   }
 
-
   memcpy(&pBtree->stagedCatalog, catHash, sizeof(ProllyHash));
-
-
 
   {
     const char *zBr = pBtree->zBranch ? pBtree->zBranch : "main";
@@ -7915,11 +7717,6 @@ void doltliteGetSessionConstraintViolationsCatalog(sqlite3 *db, ProllyHash *pHas
     memcpy(pHash, &db->aDb[0].pBt->constraintViolationsHash, sizeof(ProllyHash));
   }
 }
-
-
-
-
-
 
 int doltliteGetSessionTableRoot(
   sqlite3 *db, Pgno iTable, ProllyHash *pRoot, u8 *pFlags
@@ -8228,12 +8025,6 @@ static int origCursorCloseCursorVt(BtCursor *pCur){
   int rc = origBtreeCloseCursor(pCur->pOrigCursor);
   sqlite3_free(pCur->pOrigCursor);
   pCur->pOrigCursor = 0;
-
-
-
-
-
-
   if( willAutoCloseInner && pWrapper ){
     pWrapper->pOrigBtree = 0;
     sqlite3_free(pWrapper);

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -2496,13 +2496,8 @@ static int syncSavepoints(BtCursor *pCur){
   return SQLITE_OK;
 }
 
-
-
-
-
-
-
-
+/* Pending edit maps are shared by every cursor on the same table. When a flush
+** swaps the table map, every live cursor must drop iterator state into it. */
 static void refreshCursorMutMapAliases(BtShared *pBt, Pgno iTable,
                                         ProllyMutMap *pNewMap){
   BtCursor *p;
@@ -2976,13 +2971,9 @@ static void releaseMutMapsToSavepoint(Btree *pBtree, int level){
   }
 }
 
-
-
-
-
-
-
-
+/* If a dirty map is flushed while a savepoint is open, move that map into the
+** savepoint snapshot and continue with a fresh map. Rollback can then restore
+** the exact pre-flush edits even though the table root has already changed. */
 static int snapshotPendingForFlush(Btree *pBtree, Pgno iTable,
                                    ProllyMutMap **ppPending,
                                    ProllyMutMap **ppFlushMap,
@@ -7336,10 +7327,8 @@ int doltliteEnsureWriteTxnAndSavepoints(sqlite3 *db){
     if( rc!=SQLITE_OK ) return rc;
   }
 
-
-
-
-
+  /* VC functions can write through this btree layer without first touching a
+  ** SQL table, so mirror SQLite's active savepoint stack before mutating it. */
   target = db->nSavepoint;
   while( pBtree->nSavepoint < target ){
     rc = pushSavepoint(pBtree, 0);

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -121,12 +121,12 @@ struct TableEntry {
   ProllyMutMap *pPending;
 };
 
-/* Typed container for a Btree's live TableEntry[] plus the monotonic
-** root-page counter they share. Every mutation goes through catAdd /
-** catRemove / catFree so zName and pPending ownership invariants
-** stay in one place — no bare sqlite3_free(a) calls should exist
-** anywhere. iNextTable travels with a/n because every add needs to
-** bump it and every catalog reload has to reset it. */
+
+
+
+
+
+
 typedef struct Catalog Catalog;
 struct Catalog {
   struct TableEntry *a;
@@ -316,23 +316,23 @@ struct Btree {
   ProllyHash mergeCommitHash;
   ProllyHash conflictsCatalogHash;
 
-  /* Active interactive-rebase state, parallel to merge state.
-  ** Persisted into the working set blob (v3). isRebasing is 1 when
-  ** a `dolt_rebase('-i', ...)` call has set things up and not yet
-  ** been --continue'd or --abort'd. preRebaseWorkingCat is the
-  ** working catalog of the original branch before the rebase
-  ** started, used by --abort to restore cleanly. */
+
+
+
+
+
+
   u8 isRebasing;
   ProllyHash preRebaseWorkingCat;
   ProllyHash rebaseOntoCommit;
   char *zRebaseOrigBranch;
   char *zRebaseReturnBranch;
 
-  /* FK / UNIQUE / CHECK violations detected at merge time. Persisted
-  ** in the v4 working set blob alongside (and independently of) the
-  ** merge-conflicts hash. Non-empty means dolt_commit refuses unless
-  ** --force is passed and the user has cleared the per-table
-  ** dolt_constraint_violations_<table> vtable. */
+
+
+
+
+
   ProllyHash constraintViolationsHash;
 
   const struct BtreeOps *pOps;
@@ -357,7 +357,7 @@ struct BtCursor {
 
   u8 *pCachedPayload;
   int nCachedPayload;
-  u8 cachedPayloadOwned;  /* 1 if pCachedPayload was malloc'd by us */
+  u8 cachedPayloadOwned;
   u8 *pReconPayload;
   int nReconPayloadAlloc;
   u8 *pSeekRecord;
@@ -398,9 +398,9 @@ static int btreeLoadBranchHeadCatalog(ChunkStore *cs, const char *zBranch,
                                       ProllyHash *pCatHash,
                                       ProllyHash *pHeadCommit);
 
-/* Thin Btree-flavoured wrappers so existing call sites that take a
-** Btree* don't have to spell &p->cat everywhere. Any new code
-** should prefer catFind/catAdd/catRemove/catFree directly. */
+
+
+
 static inline struct TableEntry *findTable(Btree *p, Pgno iTable){
   return catFind(&p->cat, iTable);
 }
@@ -461,12 +461,12 @@ static SQLITE_INLINE void cacheCurrentTreePayloadIfIntKey(BtCursor *pCur){
   }
 }
 
-/* Non-INTKEY clean-cursor variant: index entries store data in the
-** sort-key with an empty value field. Reconstruct the record once into
-** pCur->pReconPayload so the per-row xPayloadSize + xPayloadFetch pair
-** from covering / range index scans both hit the early-return at the
-** top of getCursorPayload. Errors are best-effort — leave the cache
-** empty and let the lazy path retry / propagate. */
+
+
+
+
+
+
 static void cacheCurrentTreePayloadNonIntKey(BtCursor *pCur){
   const u8 *pVal; int nVal;
   cursorCurrentTreeValue(pCur, &pVal, &nVal);
@@ -556,11 +556,11 @@ static int btreeWriteWorkingState(
 );
 static int btreeDeleteImmediate(BtCursor *pCur);
 
-/*
-** Bound deferred per-table edit growth by forcing a mutmap drain once the
-** pending delta becomes large. flushMutMap() already snapshots mid-savepoint
-** state, so early drains remain rollback-safe.
-*/
+
+
+
+
+
 #define PROLLY_MUTMAP_PENDING_FLUSH_LIMIT 65536
 
 static int mutMapShouldDrain(BtCursor *pCur){
@@ -975,13 +975,13 @@ static void catRemove(Catalog *cat, Pgno iTable){
   }
 }
 
-/* Walk every TableEntry, free its zName and any still-live pending
-** mutmap, then release the array itself. Leaves cat in the zero
-** state. Safe on partially-built catalogs (mid-deserializeCatalog
-** error) because catAdd only bumps n after installing the entry.
-**
-** This is the ONLY place that frees cat->a — callers that want to
-** drop the catalog must go through here, or zName/pPending leak. */
+
+
+
+
+
+
+
 static void catFree(Catalog *cat){
   int k;
   for(k=0; k<cat->n; k++){
@@ -1000,13 +1000,13 @@ static void catFree(Catalog *cat){
 }
 
 static void invalidateSchema(Btree *pBtree){
-  /* sqlite3SchemaClear resets the hash tables inside the Schema
-  ** struct but leaves the struct itself alive — matches stock
-  ** SQLite behaviour. The struct pointer has to stay put because
-  ** db->aDb[i].pSchema captures it at open time and never
-  ** re-queries, so zeroing pBtree->pSchema here would orphan the
-  ** original and leak it on close. Subsequent schema loads reuse
-  ** the same struct via prollyBtreeSchema's !p->pSchema guard. */
+
+
+
+
+
+
+
   if( pBtree->pSchema && pBtree->xFreeSchema ){
     pBtree->xFreeSchema(pBtree->pSchema);
   }
@@ -2415,11 +2415,11 @@ static int flushMutMap(BtCursor *pCur){
     return SQLITE_OK;
   }
 
-  /* Per-table mutmap: every cursor on this table aliases pTE->pPending.
-  ** snapshotPendingForFlush may swap pTE->pPending for a fresh empty
-  ** map (when capturing the pre-flush state into an active savepoint);
-  ** if that happens we refresh every cursor's alias to point at the
-  ** new pTE->pPending. */
+
+
+
+
+
   pFlushMap = (ProllyMutMap*)pTE->pPending;
   captured = 0;
   rc = snapshotPendingForFlush(pCur->pBtree, pCur->pgnoRoot,
@@ -2496,23 +2496,23 @@ static int syncSavepoints(BtCursor *pCur){
   return SQLITE_OK;
 }
 
-/* Refresh every cursor on iTable so its pMutMap field aliases the
-** current pTE->pPending (which may itself be NULL after a flush).
-** Called after any mutation to the pTE->pPending pointer — flush,
-** savepoint snapshot/restore, catalog free. The invariant after this
-** call is: for every cursor c on iTable, c->pMutMap == pTE->pPending.
-**
-** Walking pBt->pCursor is O(cursors); usually a handful per Btree. */
+
+
+
+
+
+
+
 static void refreshCursorMutMapAliases(BtShared *pBt, Pgno iTable,
                                         ProllyMutMap *pNewMap){
   BtCursor *p;
   for(p = pBt->pCursor; p; p = p->pNext){
     if( p->pgnoRoot==iTable ){
       p->pMutMap = pNewMap;
-      /* mmActive / mmIdx may now point at a stale (or freed) entry.
-      ** Reset cursor's mutmap-side position; the merge cursor will
-      ** re-establish on the next access, picking up any new entries
-      ** another cursor may have added. */
+
+
+
+
       p->mmActive = 0;
       p->mmPhysActive = 0;
       p->deferredTreeSeek = 0;
@@ -2531,11 +2531,11 @@ static int ensureMutMap(BtCursor *pCur){
   pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
   if( !pTE ) return SQLITE_INTERNAL;
 
-  /* Per-table mutmap: the table entry owns it for the lifetime of the
-  ** transaction (or until a flush clears it). Multiple cursors on the
-  ** same table all alias to pTE->pPending so writes by one cursor are
-  ** immediately visible to reads via another — no per-statement
-  ** visibility flush needed. */
+
+
+
+
+
   if( pTE->pPending ){
     pCur->pMutMap = (ProllyMutMap*)pTE->pPending;
     return SQLITE_OK;
@@ -2976,13 +2976,13 @@ static void releaseMutMapsToSavepoint(Btree *pBtree, int level){
   }
 }
 
-/* A flush that happens mid-savepoint destroys the per-entry bornAt
-** state the mutmap uses for rollback, so move the about-to-be-flushed
-** mutmap into the innermost savepoint's aPendingSnapshot slot and
-** replace it with a fresh empty one. Only the innermost savepoint
-** that doesn't already have a snapshot for this table needs one —
-** the rollback path walks back through savepoints looking for the
-** smallest-level match. */
+
+
+
+
+
+
+
 static int snapshotPendingForFlush(Btree *pBtree, Pgno iTable,
                                    ProllyMutMap **ppPending,
                                    ProllyMutMap **ppFlushMap,
@@ -3123,8 +3123,8 @@ static int restoreTablesFromSavepoint(
       prollyMutMapFree(pMap);
       sqlite3_free(pMap);
     }
-    /* pPending ownership transferred to apPending or released;
-    ** null the slot so btreeFreeCatalogTables can't double-free. */
+
+
     aCurrent[k].pPending = 0;
   }
 
@@ -3564,10 +3564,10 @@ static int prollyBtreeClose(Btree *p){
   }
 
 
-  /* Schema cleanup mirrors stock btree.c — xFreeSchema clears the
-  ** Schema object's internal hash tables but does NOT free the
-  ** Schema struct itself; we allocated it via sqlite3_malloc in
-  ** prollyBtreeSchema so we must release it here explicitly. */
+
+
+
+
   if( p->pSchema ){
     if( p->xFreeSchema ) p->xFreeSchema(p->pSchema);
     sqlite3_free(p->pSchema);
@@ -4564,10 +4564,10 @@ static int persistRolledBackSessionState(Btree *p, BtShared *pBt){
   return chunkStoreCommit(&pBt->store);
 }
 
-/* Walk every live savepoint state, release its captured tables,
-** pending-snapshot mutmaps and inner arrays, then reset nSavepoint
-** to 0. The aSavepointTables backing store itself is kept (it's
-** freed in close). */
+
+
+
+
 static void btreeDiscardAllSavepoints(Btree *p){
   int j;
   for(j=0; j<p->nSavepoint; j++){
@@ -4888,12 +4888,12 @@ static int prollyBtreeCursor(
     pCur->curFlags = BTCF_WriteFlag;
   }
 
-  /* Per-table mutmap: pTE->pPending is the canonical edit buffer
-  ** owned by pTE for the lifetime of the transaction. The new cursor
-  ** simply aliases the existing buffer (no ownership transfer). The
-  ** old code transferred pTE->pPending into the cursor's private
-  ** pMutMap and zeroed pTE->pPending — that was the per-cursor
-  ** ownership model and is incompatible with per-table sharing. */
+
+
+
+
+
+
   if( pTE->pPending ){
     pCur->pMutMap = (ProllyMutMap*)pTE->pPending;
     if( wrFlag & BTREE_WRCSR ){
@@ -4934,10 +4934,10 @@ static int prollyBtCursorCloseCursor(BtCursor *pCur){
   pBt = pCur->pBt;
   if( !pBt ) return SQLITE_OK;
 
-  /* pCur->pMutMap is an alias to pTE->pPending — pTE owns the map
-  ** across the transaction. flushSeekEdits is per-table state, so
-  ** propagate any pending request from this cursor onto pTE; the
-  ** alias itself is just dropped. */
+
+
+
+
   if( pCur->pMutMap && pCur->flushSeekEdits ){
     struct TableEntry *pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
     if( pTE ){
@@ -5112,11 +5112,11 @@ static int mergeScan(BtCursor *pCur, int dir, int *pRes){
   }
 }
 
-/* If the cursor was positioned via setCursorToMutMapEntryPhys (mmPhysActive
-** set, mmIdx unset), normalize to mmIdx-only before stepping. mergeScan
-** would otherwise overwrite our about-to-be-incremented mmIdx with the
-** physIdx-derived sorted position, parking the cursor back on the entry
-** we just consumed. */
+
+
+
+
+
 static void cursorNormalizeMmPhys(BtCursor *pCur){
   if( pCur->mmPhysActive ){
     pCur->mmIdx = prollyMutMapOrderIndexFromEntry(
@@ -5221,11 +5221,11 @@ static int mergeLast(BtCursor *pCur, int *pRes){
 static int prollyBtCursorFirst(BtCursor *pCur, int *pRes){
   int rc;
   CLEAR_CACHED_PAYLOAD(pCur);
-  /* Per-table mutmap: pCur aliases pTE->pPending so other cursors'
-  ** edits are immediately visible via the shared buffer. The old
-  ** per-cursor visibility dance applied pending edits to the tree
-  ** before reading. With shared mutmap there's nothing to flush:
-  ** the merge cursor reads tree + pTE->pPending directly. */
+
+
+
+
+
   refreshCursorRoot(pCur);
   rc = prollyCursorFirst(&pCur->pCur, pRes);
   if( rc!=SQLITE_OK ) return rc;
@@ -5249,7 +5249,7 @@ int sqlite3BtreeFirst(BtCursor *pCur, int *pRes){
 static int prollyBtCursorLast(BtCursor *pCur, int *pRes){
   int rc;
   CLEAR_CACHED_PAYLOAD(pCur);
-  /* Visibility flushes deleted — see prollyBtCursorFirst. */
+
   refreshCursorRoot(pCur);
   rc = prollyCursorLast(&pCur->pCur, pRes);
   if( rc!=SQLITE_OK ) return rc;
@@ -5542,8 +5542,8 @@ static int prollyBtCursorTableMoveto(
   }
 
 
-  /* Visibility flush deleted — shared pTE->pPending is read directly
-  ** by the merge cursor below. */
+
+
   refreshCursorRoot(pCur);
 
   rc = prollyCursorSeekInt(&pCur->pCur, intKey, pRes);
@@ -5613,12 +5613,12 @@ static int findMatchingMutMapEntry(
   int rc = SQLITE_OK;
   int cmp = 0;
   ProllyMutMapEntry *pMatch = 0;
-  /* Single scratch reused across both the binary-search and post-scan
-  ** linear loops. The original code freed and re-allocated per mid
-  ** iteration; for index seeks against an N-entry mutmap that's
-  ** ~log2(N) malloc/free pairs and ~log2(N) sort-key→record transcodes
-  ** per Seek. With reuse, the buffer grows to fit the largest record
-  ** seen and stays. Freed once at function exit. */
+
+
+
+
+
+
   u8 *pRecBuf = 0;
   int nRecBufAlloc = 0;
   int lo = 0, found = 0;
@@ -5779,12 +5779,12 @@ static int prollyBtCursorIndexMoveto(
       int bestCmp = 0;
       {
 
-        /* prollyCursorSeekBlob's leaf-level prollyNodeSearchBlob has
-        ** already binary-searched this leaf with the same key and
-        ** stored its lower-bound result in seekIdx. Reuse that
-        ** position instead of repeating a 7+-iteration memcmp loop
-        ** per Seek — for index_join_scan-style nested seeks that
-        ** loop showed up at ~14% of CPU. */
+
+
+
+
+
+
         int lo = seekIdx;
         u8 *pRecBuf = pCur->pMovetoRec;
         int nRecBufAlloc = pCur->nMovetoRecAlloc;
@@ -5907,11 +5907,11 @@ static int prollyBtCursorIndexMoveto(
          || (pPending && pPending!=pCur->pMutMap
              && !prollyMutMapIsEmpty(pPending)))
        && !(treeFound && treeCmp==0) ){
-      /* findMatchingMutMapEntry runs sqlite3VdbeRecordCompare against
-      ** mutmap entries, which clobbers pIdxKey->eqSeen. The tree-match
-      ** decision above already consumed eqSeen, so save its post-tree-
-      ** seek value and restore it on exit — OP_SeekGE (eqOnly path)
-      ** reads eqSeen to decide whether the seek hit an equality match. */
+
+
+
+
+
       int savedEqSeen = pIdxKey->eqSeen;
       rc = findMatchingMutMapEntry((ProllyMutMap*)pCur->pMutMap,
                                    pCur->pKeyInfo,
@@ -5966,10 +5966,10 @@ static int prollyBtCursorIndexMoveto(
         pCur->eState = CURSOR_VALID;
       }
       *pRes = mutCmp;
-      /* OP_SeekGE/SeekLE eqOnly path reads eqSeen to decide whether the
-      ** seek hit an equality match. A mutmap match means equality was
-      ** seen, but findMatchingMutMapEntry leaves eqSeen reflecting its
-      ** internal bsearch's last comparison. */
+
+
+
+
       pIdxKey->eqSeen = 1;
       return SQLITE_OK;
     }
@@ -6206,19 +6206,19 @@ static int prollyBtCursorInsert(
      && pCur->pKeyInfo->nKeyField < pCur->pKeyInfo->nAllField ){
       nKeyField = (int)pCur->pKeyInfo->nKeyField;
       splitKey = 1;
-      /* Distinguish secondary indexes from non-INTEGER-PK tables.
-      ** Index entries have no name in the catalog; tables do.
-      ** For indexes, encode ALL fields (index cols + PK cols) into
-      ** the sort key so every entry is unique — matching Dolt's
-      ** encoding and making three-way merge work correctly. */
+
+
+
+
+
       {
         struct TableEntry *pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
         isIndex = (pTE && !tableEntryIsTableRoot(pCur->pBtree, pTE));
       }
     }
-    /* Reuse the cursor's scratch sort-key buffer (also used by
-    ** IndexMoveto) so transaction-scale Insert loops avoid a
-    ** malloc/free pair per row. Owned by the cursor; freed at close. */
+
+
+
     rc = sortKeyFromRecordPrefixCollBuffer(
         (const u8*)pPayload->pKey, (int)pPayload->nKey,
         isIndex ? 0 : (splitKey ? nKeyField : 0),
@@ -6320,20 +6320,20 @@ static int flushIfNeeded(BtCursor *pCur){
   int rc;
   struct TableEntry *pTE;
 
-  /* Per-table mutmap: pCur->pMutMap aliases pTE->pPending and every
-  ** other cursor on this pgnoRoot does too. A single flushMutMap on
-  ** any cursor flushes the whole table. Old code did a peer walk
-  ** (O(cursors per pgnoRoot)) and then flushAllPending called
-  ** flushIfNeeded on every cursor, making the total O(N^2). With
-  ** shared mutmap each invocation either flushes (first one) or
-  ** finds empty (rest), so the peer walk is redundant. */
+
+
+
+
+
+
+
   if( !pCur->pMutMap || prollyMutMapIsEmpty(pCur->pMutMap) ){
     return SQLITE_OK;
   }
 
-  /* Save peer cursors' positions before we change the tree out
-  ** from under them. Same logic as before — applies to every cursor
-  ** on this pgnoRoot regardless of whose mutmap is being flushed. */
+
+
+
   {
     BtCursor *p;
     for(p = pCur->pBt->pCursor; p; p = p->pNext){
@@ -6482,11 +6482,11 @@ static int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
         int nDelKeyField = 0;
         if( pCur->pKeyInfo
          && pCur->pKeyInfo->nKeyField < pCur->pKeyInfo->nAllField ){
-          /* For indexes (no name in catalog), encode all fields to
-          ** match the insert encoding. For tables, use the PK prefix. */
+
+
           struct TableEntry *pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
           if( pTE && !tableEntryIsTableRoot(pCur->pBtree, pTE) ){
-            nDelKeyField = 0;  /* index: all fields */
+            nDelKeyField = 0;
           }else{
             nDelKeyField = (int)pCur->pKeyInfo->nKeyField;
           }
@@ -6664,10 +6664,10 @@ int sqlite3SchemaMutexHeld(sqlite3 *db, int iDb, Schema *pSchema){
 static void prollyBtreeLeave(Btree *p){ (void)p; }
 #endif
 
-/* VDBE's ROLLBACK TO SAVEPOINT path walks db->aDb[] and calls us for
-** every attached btree. Attached stock-SQLite files (temp, :memory:,
-** plain-sqlite ATTACHes) have p->pBt==NULL with state under
-** p->pOrigBtree — dispatch there instead of dereferencing NULL. */
+
+
+
+
 int sqlite3BtreeTripAllCursors(Btree *p, int errCode, int writeOnly){
   BtCursor *pCur;
   BtShared *pBt;
@@ -7032,7 +7032,7 @@ int sqlite3BtreeCopyFile(Btree *pTo, Btree *pFrom){
 }
 
 int sqlite3BtreeIsInBackup(Btree *p){
-  /* prolly_btree doesn't implement the SQLite backup API. */
+
   (void)p;
   return 0;
 }
@@ -7056,11 +7056,11 @@ static int prollyBtCursorPayloadChecked(BtCursor *pCur, u32 offset, u32 amt, voi
     return SQLITE_ABORT;
   }
 
-  /* Must use the merge-cursor-aware payload accessor: when the cursor
-  ** is positioned on a mutmap entry (FTS5's blob cursor hits this on
-  ** every auto-merge — its long-lived read cursor lands on a freshly
-  ** buffered segment row), prollyCursorValue would read the empty tree
-  ** slot and the blob read would silently return stale bytes. */
+
+
+
+
+
   getCursorPayload(pCur, &pVal, &nVal);
 
   if( (i64)offset + (i64)amt > (i64)nVal ){
@@ -7336,10 +7336,10 @@ int doltliteEnsureWriteTxnAndSavepoints(sqlite3 *db){
     if( rc!=SQLITE_OK ) return rc;
   }
 
-  /* Direct VC helpers need the named savepoint stack captured before
-  ** they mutate session working-set state. Do not mirror statement
-  ** savepoints here: releaseSavepointsFrom() only inherits pending-row
-  ** snapshots, not session hashes like conflictsCatalogHash. */
+
+
+
+
   target = db->nSavepoint;
   while( pBtree->nSavepoint < target ){
     rc = pushSavepoint(pBtree, 0);
@@ -7411,10 +7411,10 @@ int doltliteLoadCatalog(sqlite3 *db, const ProllyHash *catHash,
   return SQLITE_OK;
 }
 
-/* Free a TableEntry array returned by doltliteLoadCatalog. Each
-** TableEntry owns its zName allocation via deserializeCatalog(); the
-** callers that just did sqlite3_free(a) were leaking N strings per
-** call. Null-tolerant so cleanup paths don't need to guard. */
+
+
+
+
 void doltliteFreeCatalog(struct TableEntry *a, int n){
   int i;
   if( !a ) return;
@@ -7542,9 +7542,9 @@ int doltliteSwitchCatalog(sqlite3 *db, const ProllyHash *catHash){
 
   invalidateCursors(pBt, 0, SQLITE_ABORT);
 
-  /* deserializeCatalog walks the current aTables (freeing each
-  ** zName and any live pPending) and replaces it — do not pre-free
-  ** here or the existing entries leak. */
+
+
+
   rc = deserializeCatalog(pBtree, data, nData);
   sqlite3_free(data);
   if( rc!=SQLITE_OK ) return rc;
@@ -7602,9 +7602,9 @@ int doltliteHardReset(sqlite3 *db, const ProllyHash *catHash){
 
   invalidateCursors(pBt, 0, SQLITE_ABORT);
 
-  /* deserializeCatalog walks the current aTables (freeing each
-  ** zName and any live pPending) and replaces it — do not pre-zero
-  ** here or the existing entries leak. */
+
+
+
   rc = deserializeCatalog(pBtree, data, nData);
   sqlite3_free(data);
   if( rc!=SQLITE_OK ){
@@ -7927,11 +7927,11 @@ void doltliteGetSessionConstraintViolationsCatalog(sqlite3 *db, ProllyHash *pHas
   }
 }
 
-/* Look up a table's current working-catalog prolly root + flags
-** by table number (rowid-alias). Exposed so the post-merge
-** constraint walk can read raw row payloads without needing to
-** reach into private Btree fields. Returns SQLITE_NOTFOUND if
-** the table is absent, SQLITE_OK on success. */
+
+
+
+
+
 int doltliteGetSessionTableRoot(
   sqlite3 *db, Pgno iTable, ProllyHash *pRoot, u8 *pFlags
 ){
@@ -8239,12 +8239,12 @@ static int origCursorCloseCursorVt(BtCursor *pCur){
   int rc = origBtreeCloseCursor(pCur->pOrigCursor);
   sqlite3_free(pCur->pOrigCursor);
   pCur->pOrigCursor = 0;
-  /* Stock btree's cursor close auto-frees the inner Btree on
-  ** BTREE_SINGLE when the last cursor unlinks — which it just
-  ** did. The wrapper Btree we allocated in sqlite3BtreeOpen sits
-  ** on top of that inner and never sees its own xClose in this
-  ** path, so release it here or the 472-byte struct leaks every
-  ** time VDBE OP_OpenEphemeral runs. */
+
+
+
+
+
+
   if( willAutoCloseInner && pWrapper ){
     pWrapper->pOrigBtree = 0;
     sqlite3_free(pWrapper);

--- a/src/prolly_cache.c
+++ b/src/prolly_cache.c
@@ -96,10 +96,10 @@ ProllyCacheEntry *prollyCacheGet(ProllyCache *cache, const ProllyHash *hash){
   return 0;
 }
 
-/* Only entries with nRef == 0 are evictable — active cursors hold
-** references and their pointers would dangle. If every entry is
-** pinned we return 0 and let the caller overflow nCapacity rather
-** than break a cursor. */
+
+
+
+
 static int cacheEvictOne(ProllyCache *cache){
   ProllyCacheEntry *pEntry;
 

--- a/src/prolly_cache.c
+++ b/src/prolly_cache.c
@@ -64,7 +64,6 @@ int prollyCacheInit(ProllyCache *cache, int nCapacity){
   }
   memset(cache->aBucket, 0, sizeof(ProllyCacheEntry *) * nBucket);
 
-
   cache->lruHead.pLruNext = &cache->lruTail;
   cache->lruHead.pLruPrev = 0;
   cache->lruTail.pLruPrev = &cache->lruHead;
@@ -95,10 +94,6 @@ ProllyCacheEntry *prollyCacheGet(ProllyCache *cache, const ProllyHash *hash){
 
   return 0;
 }
-
-
-
-
 
 static int cacheEvictOne(ProllyCache *cache){
   ProllyCacheEntry *pEntry;
@@ -131,12 +126,10 @@ ProllyCacheEntry *prollyCachePut(
 
   if( pRc ) *pRc = SQLITE_OK;
 
-
   pEntry = prollyCacheGet(cache, hash);
   if( pEntry ){
     return pEntry;
   }
-
 
   while( cache->nUsed>=cache->nCapacity ){
     if( !cacheEvictOne(cache) ){
@@ -145,14 +138,12 @@ ProllyCacheEntry *prollyCachePut(
     }
   }
 
-
   pEntry = (ProllyCacheEntry *)sqlite3_malloc(sizeof(ProllyCacheEntry));
   if( pEntry==0 ){
     if( pRc ) *pRc = SQLITE_NOMEM;
     return 0;
   }
   memset(pEntry, 0, sizeof(*pEntry));
-
 
   pCopy = (u8 *)sqlite3_malloc(nData);
   if( pCopy==0 ){
@@ -162,12 +153,10 @@ ProllyCacheEntry *prollyCachePut(
   }
   memcpy(pCopy, pData, nData);
 
-
   memcpy(pEntry->hash.data, hash->data, PROLLY_HASH_SIZE);
   pEntry->pData = pCopy;
   pEntry->nData = nData;
   pEntry->nRef = 1;
-
 
   rc = prollyNodeParse(&pEntry->node, pCopy, nData);
   if( rc!=SQLITE_OK ){
@@ -177,11 +166,9 @@ ProllyCacheEntry *prollyCachePut(
     return 0;
   }
 
-
   iBucket = cacheHashBucket(cache, hash);
   pEntry->pHashNext = cache->aBucket[iBucket];
   cache->aBucket[iBucket] = pEntry;
-
 
   lruInsertHead(cache, pEntry);
 
@@ -200,7 +187,6 @@ void prollyCacheFree(ProllyCache *cache){
   ProllyCacheEntry *pNext;
 
   if( cache->aBucket==0 ) return;
-
 
   pEntry = cache->lruHead.pLruNext;
   while( pEntry!=&cache->lruTail ){

--- a/src/prolly_cache.h
+++ b/src/prolly_cache.h
@@ -9,10 +9,6 @@
 typedef struct ProllyCache ProllyCache;
 typedef struct ProllyCacheEntry ProllyCacheEntry;
 
-
-
-
-
 struct ProllyCacheEntry {
   ProllyHash hash;
   u8 *pData;

--- a/src/prolly_cache.h
+++ b/src/prolly_cache.h
@@ -9,10 +9,10 @@
 typedef struct ProllyCache ProllyCache;
 typedef struct ProllyCacheEntry ProllyCacheEntry;
 
-/* Refcounted cache entry. node has pointers into pData, so as long
-** as any cursor holds a ref the entry must stay live — the LRU
-** evictor skips anything with nRef > 0. Callers get a ref from
-** prollyCacheGet / prollyCachePut and must pair it with Release. */
+
+
+
+
 struct ProllyCacheEntry {
   ProllyHash hash;
   u8 *pData;

--- a/src/prolly_chunker.c
+++ b/src/prolly_chunker.c
@@ -72,13 +72,13 @@ static int flushLevel(ProllyChunker *ch, int level){
 
 
 
-  /* Parent level keyed on the LAST child key: prolly internal keys
-  ** are the max key of their subtree, matching the cursor's seek
-  ** contract. */
-  /* If we've hit MAX_DEPTH the parent level can't accept this chunk's
-  ** reference. Returning SQLITE_OK here would silently drop the chunk —
-  ** every key under it disappears from the tree. Bail with an error so
-  ** the caller can fall back to the rebuild path (mergeWalk). */
+
+
+
+
+
+
+
   if( level + 1 >= PROLLY_CURSOR_MAX_DEPTH ){
     return SQLITE_FULL;
   }
@@ -177,11 +177,11 @@ static int addToLevel(ProllyChunker *ch, int level,
   thisSize = nKey + nVal;
   pLevel->nBytes += thisSize;
 
-  /* Content-defined chunking via Weibull-distribution boundary check.
-  ** Hash is keyed on the row's key bytes (not value), salted by the
-  ** tree level so boundaries don't align across levels. Only chunks
-  ** whose contents changed get re-emitted on edit — this is what
-  ** gives prolly trees their structural sharing. */
+
+
+
+
+
   if( pLevel->nBytes >= PROLLY_CHUNK_MIN ){
     int atBoundary;
     if( pLevel->nBytes >= PROLLY_CHUNK_MAX ){

--- a/src/prolly_chunker.c
+++ b/src/prolly_chunker.c
@@ -27,7 +27,6 @@ static int initLevel(ProllyChunker *ch, int level){
   pLevel = &ch->aLevel[level];
   memset(pLevel, 0, sizeof(ProllyChunkerLevel));
 
-
   prollyNodeBuilderInit(&pLevel->builder, (u8)level, ch->flags);
 
   pLevel->nItems = 0;
@@ -58,26 +57,14 @@ static int flushLevel(ProllyChunker *ch, int level){
 
   assert( pLevel->builder.nItems > 0 );
 
-
   builderLastKey(&pLevel->builder, &pLastKey, &nLastKey);
-
 
   rc = prollyNodeBuilderFinish(&pLevel->builder, &pData, &nData);
   if( rc!=SQLITE_OK ) return rc;
 
-
   rc = chunkStorePut(ch->pStore, pData, nData, &hash);
   sqlite3_free(pData);
   if( rc!=SQLITE_OK ) return rc;
-
-
-
-
-
-
-
-
-
 
   if( level + 1 >= PROLLY_CURSOR_MAX_DEPTH ){
     return SQLITE_FULL;
@@ -87,7 +74,6 @@ static int flushLevel(ProllyChunker *ch, int level){
                   pLastKey, nLastKey,
                   hash.data, PROLLY_HASH_SIZE);
   if( rc!=SQLITE_OK ) return rc;
-
 
   prollyNodeBuilderReset(&pLevel->builder);
   pLevel->nItems = 0;
@@ -105,10 +91,8 @@ static int finishFlushLevel(ProllyChunker *ch, int level,
 
   assert( pLevel->builder.nItems > 0 );
 
-
   rc = prollyNodeBuilderFinish(&pLevel->builder, &pData, &nData);
   if( rc!=SQLITE_OK ) return rc;
-
 
   rc = chunkStorePut(ch->pStore, pData, nData, pHash);
   sqlite3_free(pData);
@@ -157,7 +141,6 @@ static int addToLevel(ProllyChunker *ch, int level,
 
   assert( level >= 0 && level < PROLLY_CURSOR_MAX_DEPTH );
 
-
   if( level >= ch->nLevels ){
     while( ch->nLevels <= level ){
       rc = initLevel(ch, ch->nLevels);
@@ -168,7 +151,6 @@ static int addToLevel(ProllyChunker *ch, int level,
 
   pLevel = &ch->aLevel[level];
 
-
   rc = prollyNodeBuilderAdd(&pLevel->builder, pKey, nKey, pVal, nVal);
   if( rc!=SQLITE_OK ) return rc;
 
@@ -176,11 +158,6 @@ static int addToLevel(ProllyChunker *ch, int level,
 
   thisSize = nKey + nVal;
   pLevel->nBytes += thisSize;
-
-
-
-
-
 
   if( pLevel->nBytes >= PROLLY_CHUNK_MIN ){
     int atBoundary;
@@ -230,7 +207,6 @@ int prollyChunkerFinish(ProllyChunker *ch){
     return SQLITE_OK;
   }
 
-
   level = 0;
   while( level < ch->nLevels ){
     ProllyChunkerLevel *pLevel = &ch->aLevel[level];
@@ -240,7 +216,6 @@ int prollyChunkerFinish(ProllyChunker *ch){
       level++;
       continue;
     }
-
 
     {
       if( hasPendingAncestorLevels(ch, level) ){
@@ -255,7 +230,6 @@ int prollyChunkerFinish(ProllyChunker *ch){
 
         memcpy(&ch->root, &hash, sizeof(ProllyHash));
 
-
         prollyNodeBuilderReset(&pLevel->builder);
         pLevel->nItems = 0;
         pLevel->nBytes = 0;
@@ -265,7 +239,6 @@ int prollyChunkerFinish(ProllyChunker *ch){
 
     level++;
   }
-
 
   memset(&ch->root, 0, sizeof(ProllyHash));
   return SQLITE_OK;

--- a/src/prolly_chunker.h
+++ b/src/prolly_chunker.h
@@ -8,12 +8,12 @@
 #include "prolly_cursor.h"
 #include "chunk_store.h"
 
-/* MIN/MAX bracket the chunk size so degenerate inputs (adversarial
-** keys, hash collisions) still produce bounded chunks. Inside that
-** range, the boundary decision is made by prollyWeibullCheck which
-** biases the distribution toward 4096 bytes (PROLLY_WEIBULL_L in
-** prolly_hash.c). All three values are part of the on-disk content
-** addressing — changing them re-hashes every tree on next write. */
+
+
+
+
+
+
 #define PROLLY_CHUNK_MIN     512
 #define PROLLY_CHUNK_MAX     16384
 

--- a/src/prolly_chunker.h
+++ b/src/prolly_chunker.h
@@ -8,12 +8,8 @@
 #include "prolly_cursor.h"
 #include "chunk_store.h"
 
-
-
-
-
-
-
+/* Min/max bounds for content-defined chunks. The chunker may split after the
+** minimum when the key hash passes prollyWeibullCheck, and must split at max. */
 #define PROLLY_CHUNK_MIN     512
 #define PROLLY_CHUNK_MAX     16384
 

--- a/src/prolly_cursor.c
+++ b/src/prolly_cursor.c
@@ -1,11 +1,4 @@
 
-
-
-
-
-
-
-
 #ifdef DOLTLITE_PROLLY
 
 #include "prolly_cursor.h"
@@ -31,7 +24,6 @@ static int loadNode(ProllyCursor *cur, const ProllyHash *hash,
   if( rc!=SQLITE_OK ){
     return rc;
   }
-
 
   pEntry = prollyCachePut(cur->pCache, hash, pData, nData, &rc);
   sqlite3_free(pData);
@@ -212,9 +204,6 @@ int prollyCursorNext(ProllyCursor *cur){
     return SQLITE_OK;
   }
 
-
-
-
   level = cur->iLevel;
   while( level>0 ){
     prollyCacheRelease(cur->pCache, cur->aLevel[level].pEntry);
@@ -231,7 +220,6 @@ int prollyCursorNext(ProllyCursor *cur){
       return SQLITE_OK;
     }
   }
-
 
   cur->eState = PROLLY_CURSOR_EOF;
   return SQLITE_OK;
@@ -264,16 +252,11 @@ int prollyCursorPrev(ProllyCursor *cur){
     }
   }
 
-
   cur->eState = PROLLY_CURSOR_EOF;
   return SQLITE_OK;
 }
 
 int prollyCursorSeekInt(ProllyCursor *cur, i64 intKey, int *pRes){
-
-
-
-
   u8 keyBuf[8];
   prollyEncodeIntKey(intKey, keyBuf);
   return prollyCursorSeekBlob(cur, keyBuf, 8, pRes);
@@ -293,7 +276,6 @@ int prollyCursorSeekBlob(ProllyCursor *cur,
     *pRes = -1;
     return SQLITE_OK;
   }
-
 
   while( pEntry->node.level>0 ){
     int searchRes;

--- a/src/prolly_cursor.c
+++ b/src/prolly_cursor.c
@@ -1,11 +1,11 @@
 
-/* Cursor navigation maintains aLevel[0..iLevel] as the path from
-** root (0) to the current leaf (iLevel). Each level holds a
-** cache-acquired ProllyCacheEntry and an idx into its node. Every
-** load via loadNode takes a cache reference; every level popped
-** during ascent must call prollyCacheRelease on its entry, otherwise
-** the cache leaks and the entry's pointers dangle the next time
-** something else evicts it. */
+
+
+
+
+
+
+
 #ifdef DOLTLITE_PROLLY
 
 #include "prolly_cursor.h"
@@ -212,9 +212,9 @@ int prollyCursorNext(ProllyCursor *cur){
     return SQLITE_OK;
   }
 
-  /* Leaf exhausted: walk up the path releasing cache refs until an
-  ** ancestor still has an unconsumed child, then descend back to the
-  ** leftmost leaf of the next subtree. */
+
+
+
   level = cur->iLevel;
   while( level>0 ){
     prollyCacheRelease(cur->pCache, cur->aLevel[level].pEntry);
@@ -270,10 +270,10 @@ int prollyCursorPrev(ProllyCursor *cur){
 }
 
 int prollyCursorSeekInt(ProllyCursor *cur, i64 intKey, int *pRes){
-  /* INT keys live on disk as sortable 8-byte big-endian bytes (see
-  ** prollyNodeIntKey/prollyEncodeIntKey), so an int seek is just a
-  ** blob seek over the encoded form — same algorithm, no separate
-  ** descent path. */
+
+
+
+
   u8 keyBuf[8];
   prollyEncodeIntKey(intKey, keyBuf);
   return prollyCursorSeekBlob(cur, keyBuf, 8, pRes);

--- a/src/prolly_cursor.h
+++ b/src/prolly_cursor.h
@@ -18,10 +18,6 @@ struct ProllyCursorLevel {
   int idx;
 };
 
-
-
-
-
 struct ProllyCursor {
   ChunkStore *pStore;
   ProllyCache *pCache;

--- a/src/prolly_cursor.h
+++ b/src/prolly_cursor.h
@@ -18,10 +18,10 @@ struct ProllyCursorLevel {
   int idx;
 };
 
-/* iLevel is the current cursor depth (0 = root, iLevel = leaf when
-** fully descended). aLevel[0..iLevel] each hold a pinned
-** ProllyCacheEntry — they must be released on cursor close or
-** re-seek or the cache entries leak their node buffer. */
+
+
+
+
 struct ProllyCursor {
   ChunkStore *pStore;
   ProllyCache *pCache;

--- a/src/prolly_diff.c
+++ b/src/prolly_diff.c
@@ -179,11 +179,6 @@ static int diffRecordsEqualFieldwise(
   return SQLITE_OK;
 }
 
-
-
-
-
-
 int prollyValuesEqual(
   const u8 *pA, int nA,
   const u8 *pB, int nB,
@@ -334,11 +329,6 @@ static int diffNodeKeyCmp(
   prollyNodeKey(pB, iB, &pKB, &nKB);
   return diffBlobKeyCmp(pKA, nKA, pKB, nKB);
 }
-
-
-
-
-
 
 static void diffEmitKey(ProllyDiffChange *ch, const ProllyNode *pN, int i, u8 flags){
   prollyNodeKey(pN, i, &ch->pKey, &ch->nKey);
@@ -499,7 +489,6 @@ static int diffNodesOneLevel(
             prollyCursorInit(pCO, pStore, pCache, pOldRoot, flags);
             prollyCursorInit(pCN, pStore, pCache, pNewRoot, flags);
 
-
             if( i > 0 && (flags & PROLLY_NODE_INTKEY) ){
               i64 seekKey = prollyNodeIntKey(&oldNode, i-1);
               int res;
@@ -538,7 +527,6 @@ static int diffNodesOneLevel(
       }
     }
 
-
     while( i < (int)oldNode.nItems && rc==SQLITE_OK ){
       ProllyHash ch;
       prollyNodeChildHash(&oldNode, i, &ch);
@@ -576,13 +564,11 @@ int prollyDiff(
   int nStack = 0, nStackAlloc = 0;
   int rc = SQLITE_OK;
 
-
   aStack = sqlite3_malloc(32 * (int)sizeof(ProllyHash));
   if( !aStack ) return SQLITE_NOMEM;
   nStackAlloc = 32;
   aStack[nStack++] = *pOldRoot;
   aStack[nStack++] = *pNewRoot;
-
 
   while( nStack >= 2 && rc==SQLITE_OK ){
     ProllyHash newH = aStack[--nStack];
@@ -647,7 +633,6 @@ int prollyDiffIterOpen(
     return rc;
   }
 
-
   if( !prollyCursorIsValid(pIter->pCurOld) &&
       !prollyCursorIsValid(pIter->pCurNew) ){
     pIter->eof = 1;
@@ -667,13 +652,11 @@ int prollyDiffIterStep(ProllyDiffIter *pIter, ProllyDiffChange **ppChange){
   if( pIter->eof ) return SQLITE_DONE;
   if( pIter->rc!=SQLITE_OK ) return pIter->rc;
 
-
   diffIterFreeCopies(pIter);
 
   pOld = pIter->pCurOld;
   pNew = pIter->pCurNew;
   pCh = &pIter->current;
-
 
   for(;;){
     validOld = prollyCursorIsValid(pOld);

--- a/src/prolly_diff.c
+++ b/src/prolly_diff.c
@@ -179,11 +179,11 @@ static int diffRecordsEqualFieldwise(
   return SQLITE_OK;
 }
 
-/* Fast memcmp first, field-wise fallback second. Two records with
-** the same logical data can have different varint encodings for the
-** header, so memcmp-unequal doesn't imply logically-unequal — we
-** have to parse both and compare field-by-field. memcmp-equal DOES
-** imply logically-equal, which is the hot path. */
+
+
+
+
+
 int prollyValuesEqual(
   const u8 *pA, int nA,
   const u8 *pB, int nB,
@@ -335,11 +335,11 @@ static int diffNodeKeyCmp(
   return diffBlobKeyCmp(pKA, nKA, pKB, nKB);
 }
 
-/* Populates a ProllyDiffChange's key fields from a node entry.
-** Always sets pKey/nKey to the on-disk key bytes (which for INT mode
-** is the sortable 8-byte BE form, see prolly_node.c). For INT mode
-** also sets intKey to the decoded i64 — preserves the long-standing
-** consumer contract while letting internal compare go byte-only. */
+
+
+
+
+
 static void diffEmitKey(ProllyDiffChange *ch, const ProllyNode *pN, int i, u8 flags){
   prollyNodeKey(pN, i, &ch->pKey, &ch->nKey);
   if( flags & PROLLY_NODE_INTKEY ){

--- a/src/prolly_diff.h
+++ b/src/prolly_diff.h
@@ -38,11 +38,11 @@ int prollyValuesEqual(
   int *pEqual
 );
 
-/* Iterator form of prollyDiff. The copy buffers are load-bearing:
-** cursor movement can release the cache entry the key/value pointers
-** live in, so the iterator deep-copies each change into its own
-** owned buffers before returning it to the caller. The ppChange
-** pointer from prollyDiffIterStep stays valid until the next step. */
+
+
+
+
+
 typedef struct ProllyDiffIter ProllyDiffIter;
 struct ProllyDiffIter {
   ChunkStore *pStore;

--- a/src/prolly_diff.h
+++ b/src/prolly_diff.h
@@ -38,11 +38,6 @@ int prollyValuesEqual(
   int *pEqual
 );
 
-
-
-
-
-
 typedef struct ProllyDiffIter ProllyDiffIter;
 struct ProllyDiffIter {
   ChunkStore *pStore;

--- a/src/prolly_hash.c
+++ b/src/prolly_hash.c
@@ -56,6 +56,8 @@ int prollyHashIsEmpty(const ProllyHash *h){
 #define PROLLY_WEIBULL_L  4096.0
 #define PROLLY_MAX_U32    4294967295.0
 
+/* Boundary predicate for content-defined chunking. `size` is the candidate
+** chunk size after adding the current item; `thisSize` is that item size. */
 int prollyWeibullCheck(u32 size, u32 thisSize, u32 hash){
   double pow;
   double start, end;

--- a/src/prolly_hash.c
+++ b/src/prolly_hash.c
@@ -5,12 +5,6 @@
 #include <string.h>
 
 void prollyHashCompute(const void *pData, int nData, ProllyHash *pOut){
-
-
-
-
-
-
   blake3_hasher h;
   u8 digest[BLAKE3_OUT_LEN];
   blake3_hasher_init(&h);
@@ -32,26 +26,6 @@ int prollyHashIsEmpty(const ProllyHash *h){
 }
 
 #include <math.h>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 #define PROLLY_WEIBULL_L  4096.0
 #define PROLLY_MAX_U32    4294967295.0

--- a/src/prolly_hash.c
+++ b/src/prolly_hash.c
@@ -5,12 +5,12 @@
 #include <string.h>
 
 void prollyHashCompute(const void *pData, int nData, ProllyHash *pOut){
-  /* BLAKE3 with the high 12 bytes of the 32-byte digest dropped to
-  ** match PROLLY_HASH_SIZE (20). BLAKE3's portable C path measures
-  ** ~3-5x faster than the SHA-512 truncation it replaces, with the
-  ** same collision properties for content addressing. The truncation
-  ** preserves bit-uniformity since BLAKE3's output is itself a
-  ** uniform digest. */
+
+
+
+
+
+
   blake3_hasher h;
   u8 digest[BLAKE3_OUT_LEN];
   blake3_hasher_init(&h);
@@ -33,26 +33,26 @@ int prollyHashIsEmpty(const ProllyHash *h){
 
 #include <math.h>
 
-/* Weibull-distribution chunk-boundary check.
-**
-** Ported from Dolt's keySplitter.weibullCheck
-** (go/store/prolly/tree/node_splitter.go). Given that we have not
-** split on any record up through |size - thisSize|, the conditional
-** probability that we should split on the current record is
-**
-**     (CDF(size) - CDF(size - thisSize)) / (1 - CDF(size - thisSize))
-**
-** where CDF is the Weibull CDF with shape K=4, scale L=4096:
-**
-**     CDF(x) = 1 - exp(-(x/L)^K)
-**
-** We split if the uniform sample |hash|/MAX_U32 falls within that
-** conditional probability. Result is a chunk-size distribution that
-** clusters around L (the target) with a much shorter tail than the
-** geometric distribution a static pattern produces.
-**
-** K is hand-unrolled (pow*pow*pow*pow) to avoid pow()/Gamma() calls
-** in the hot path, matching the Dolt implementation. */
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 #define PROLLY_WEIBULL_L  4096.0
 #define PROLLY_MAX_U32    4294967295.0
 

--- a/src/prolly_hash.h
+++ b/src/prolly_hash.h
@@ -17,17 +17,6 @@ int prollyHashCompare(const ProllyHash *a, const ProllyHash *b);
 
 int prollyHashIsEmpty(const ProllyHash *h);
 
-
-
-
-
-
-
-
-
-
-
-
 int prollyWeibullCheck(u32 size, u32 thisSize, u32 hash);
 
 #endif

--- a/src/prolly_hash.h
+++ b/src/prolly_hash.h
@@ -17,17 +17,17 @@ int prollyHashCompare(const ProllyHash *a, const ProllyHash *b);
 
 int prollyHashIsEmpty(const ProllyHash *h);
 
-/* Weibull-distribution chunk-boundary check.
-**
-** Returns 1 if a chunk should split at the current record. Treats
-** `hash` as a uniform random number in [0, 2^32). The probability of
-** splitting rises as `size` approaches the target chunk size, biasing
-** the resulting chunk-size distribution to a Weibull (K=4, L=4096)
-** rather than a geometric distribution. This tightens the cluster
-** around the target size and reduces upward boundary cascades on
-** edits.
-**
-** Ported from Dolt's keySplitter (go/store/prolly/tree/node_splitter.go). */
+
+
+
+
+
+
+
+
+
+
+
 int prollyWeibullCheck(u32 size, u32 thisSize, u32 hash);
 
 #endif

--- a/src/prolly_mutate.c
+++ b/src/prolly_mutate.c
@@ -51,8 +51,6 @@ static int buildFromEdits(
   return rc;
 }
 
-
-
 static int subtreeHasEdits(
   ProllyMutMapIter *pIter,
   const u8 *pBoundKey, int nBoundKey
@@ -108,7 +106,6 @@ static int mergeLeaf(
       continue;
     }
 
-
     {
       const u8 *pLastKey; int nLastKey;
       int pastLeaf;
@@ -151,12 +148,6 @@ static int mergeLeaf(
     }
   }
 
-
-
-
-
-
-
   if( isLast ){
     while( prollyMutMapIterValid(pIter) ){
       ProllyMutMapEntry *pEd = prollyMutMapIterEntry(pIter);
@@ -192,12 +183,6 @@ static int streamingMergeNode(
     prollyNodeValue(pNode, i, &pChildVal, &nChildVal);
 
     childIsLast = isLast && (i == pNode->nItems - 1);
-
-
-
-
-
-
 
     forceDescend = childIsLast && prollyMutMapIterValid(pIter);
 
@@ -248,7 +233,6 @@ static int streamingMerge(
   ProllyNode rootNode;
   ProllyCache *pCache = pMut->pCache;
 
-
   rc = chunkStoreGet(pMut->pStore, &pMut->oldRoot, &pRootData, &nRootData);
   if( rc!=SQLITE_OK ) return rc;
   rc = prollyNodeParse(&rootNode, pRootData, nRootData);
@@ -257,21 +241,12 @@ static int streamingMerge(
     return rc;
   }
 
-
   prollyMutMapIterFirst(&iter, pMut->pEdits);
   rc = prollyChunkerInit(&chunker, pMut->pStore, pMut->flags);
   if( rc!=SQLITE_OK ){
     sqlite3_free(pRootData);
     return rc;
   }
-
-
-
-
-
-
-
-
 
   if( rootNode.level == 0 ){
     rc = mergeLeaf(pMut, &rootNode, &chunker, &iter, 1);
@@ -290,17 +265,6 @@ streaming_cleanup:
   sqlite3_free(pRootData);
   return rc;
 }
-
-
-
-
-
-
-
-
-
-
-
 
 int prollyMutateFlush(ProllyMutator *pMut){
   if( prollyMutMapIsEmpty(pMut->pEdits) ){
@@ -329,7 +293,6 @@ int prollyMutateInsert(
   int rc;
   u8 isIntKey = (flags & PROLLY_NODE_INTKEY) ? 1 : 0;
 
-
   rc = prollyMutMapInit(&mm, isIntKey);
   if( rc!=SQLITE_OK ) return rc;
 
@@ -339,14 +302,12 @@ int prollyMutateInsert(
     return rc;
   }
 
-
   memset(&mut, 0, sizeof(mut));
   mut.pStore = pStore;
   mut.pCache = pCache;
   memcpy(&mut.oldRoot, pRoot, sizeof(ProllyHash));
   mut.pEdits = &mm;
   mut.flags = flags;
-
 
   rc = prollyMutateFlush(&mut);
   if( rc==SQLITE_OK ){
@@ -370,7 +331,6 @@ int prollyMutateDelete(
   int rc;
   u8 isIntKey = (flags & PROLLY_NODE_INTKEY) ? 1 : 0;
 
-
   rc = prollyMutMapInit(&mm, isIntKey);
   if( rc!=SQLITE_OK ) return rc;
 
@@ -380,14 +340,12 @@ int prollyMutateDelete(
     return rc;
   }
 
-
   memset(&mut, 0, sizeof(mut));
   mut.pStore = pStore;
   mut.pCache = pCache;
   memcpy(&mut.oldRoot, pRoot, sizeof(ProllyHash));
   mut.pEdits = &mm;
   mut.flags = flags;
-
 
   rc = prollyMutateFlush(&mut);
   if( rc==SQLITE_OK ){

--- a/src/prolly_mutate.c
+++ b/src/prolly_mutate.c
@@ -51,7 +51,7 @@ static int buildFromEdits(
   return rc;
 }
 
-/* mergeWalk removed: streamingMerge now handles all flush shapes. */
+
 
 static int subtreeHasEdits(
   ProllyMutMapIter *pIter,
@@ -151,12 +151,12 @@ static int mergeLeaf(
     }
   }
 
-  /* Drain trailing edits past the leaf's last key when this is the
-  ** rightmost leaf of an isLast subtree. Feeding them at level 0
-  ** here lets them chunk up alongside the leaf's items, instead of
-  ** the previous "trailing-append at level 0 + propagate up through
-  ** every intermediate level" path that grew tree depth by 1 per
-  ** flush in the worst case. */
+
+
+
+
+
+
   if( isLast ){
     while( prollyMutMapIterValid(pIter) ){
       ProllyMutMapEntry *pEd = prollyMutMapIterEntry(pIter);
@@ -193,12 +193,12 @@ static int streamingMergeNode(
 
     childIsLast = isLast && (i == pNode->nItems - 1);
 
-    /* The rightmost child of an isLast subtree must absorb any
-    ** trailing edits past pBoundKey. If we splice it instead, those
-    ** edits get appended at chunker level 0 and propagate up through
-    ** every intermediate level as a column of single-entry chunks —
-    ** which is what produced the depth pathology that hit MAX_DEPTH
-    ** at ~1900 single-row inserts. */
+
+
+
+
+
+
     forceDescend = childIsLast && prollyMutMapIterValid(pIter);
 
     if( !forceDescend
@@ -265,18 +265,18 @@ static int streamingMerge(
     return rc;
   }
 
-  /* isLast=1 marks the root as the rightmost subtree at this level
-  ** of recursion, propagating down through the rightmost child of
-  ** each visited node. mergeLeaf at the bottom drains any trailing
-  ** edits past the rightmost leaf's last key.
-  **
-  ** A root that is itself a leaf (level == 0) is just the rightmost
-  ** leaf at the top of the tree — drain edits into it via mergeLeaf
-  ** directly, no need for streamingMergeNode's child-iteration. */
+
+
+
+
+
+
+
+
   if( rootNode.level == 0 ){
-    rc = mergeLeaf(pMut, &rootNode, &chunker, &iter, /*isLast=*/1);
+    rc = mergeLeaf(pMut, &rootNode, &chunker, &iter, 1);
   }else{
-    rc = streamingMergeNode(pMut, &rootNode, &chunker, &iter, /*isLast=*/1);
+    rc = streamingMergeNode(pMut, &rootNode, &chunker, &iter, 1);
   }
   if( rc!=SQLITE_OK ) goto streaming_cleanup;
 
@@ -292,16 +292,16 @@ streaming_cleanup:
 }
 
 
-/* streamingMerge is now the only flush strategy. It walks the tree once,
-** splicing unchanged subtrees by re-emitting their hash references at the
-** matched level (Dolt's chunker.advanceTo equivalent), and drains trailing
-** edits into the rightmost leaf to avoid the depth pathology that the
-** earlier mergeWalk fallback was guarding against. With those correctness
-** properties in place there is no shape on which a full-rebuild walk would
-** be required for correctness, so the per-flush strategy choice (which had
-** been pessimizing toward mergeWalk for any non-trivial edit ratio) is
-** dropped in favor of the unified path — matching Dolt's "one algorithm,
-** no INTKEY/non-INTKEY split" property. */
+
+
+
+
+
+
+
+
+
+
 int prollyMutateFlush(ProllyMutator *pMut){
   if( prollyMutMapIsEmpty(pMut->pEdits) ){
     memcpy(&pMut->newRoot, &pMut->oldRoot, sizeof(ProllyHash));

--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -9,10 +9,10 @@
 #define MUTMAP_INIT_CAP 16
 #define MUTMAP_MIN_HASH 32
 
-/* Sortable 8-byte big-endian encoding of an i64 — the high bit is
-** flipped so unsigned byte-lex order matches signed integer order.
-** Matches the on-disk INTKEY layout in prolly_node.c (see
-** prollyNodeIntKey, which decodes via `u ^ (1<<63)`). */
+
+
+
+
 i64 prollyMutMapEntryIntKey(const ProllyMutMapEntry *e){
   const u8 *p = e->pKey;
   u64 u;
@@ -34,20 +34,20 @@ static void encodeIntKeyBE(i64 v, u8 buf[8]){
   buf[7] = (u8)u;
 }
 
-/* Rebinds (pKey, nKey) to a sortable encoding of intKey when the map is
-** in INT mode. INT-mode callers MUST pass (NULL, 0, intKey) — passing
-** byte-form keys with a meaningful intKey alongside is ambiguous and
-** would silently let bytes win, corrupting key order. The assert catches
-** that misuse during development; for INT-mode entries originating from
-** Merge re-insert (where pKey is already the encoded 8 bytes) callers
-** pass intKey=0 and the assert holds. */
+
+
+
+
+
+
+
 static void prepKey(ProllyMutMap *mm,
                     const u8 **ppKey, int *pnKey,
                     i64 intKey, u8 buf[8]){
   if( !mm->isIntKey ) return;
   if( *ppKey != 0 && *pnKey > 0 ){
-    /* Caller passed pre-encoded bytes (Merge re-insert path). intKey
-    ** must be 0 by convention so we don't have two key sources. */
+
+
     assert( intKey == 0 );
     return;
   }
@@ -68,22 +68,22 @@ static int compareEntries(
   return 0;
 }
 
-/* Big-endian zero-padded 8-byte prefix of a key.
-** Lex order on this u64 matches lex order on the first min(nKey,8) key
-** bytes when both keys are zero-padded to 8 bytes. Used as a fast-path
-** for sort/compare so most pairs resolve without falling through to
-** memcmp. Reads no bytes past nKey. */
+
+
+
+
+
 static u64 keyPrefix64(const u8 *pKey, int nKey){
   u64 r = 0;
   switch( nKey>=8 ? 8 : nKey ){
-    case 8: r |= (u64)pKey[7];        /* fall through */
-    case 7: r |= (u64)pKey[6] << 8;   /* fall through */
-    case 6: r |= (u64)pKey[5] << 16;  /* fall through */
-    case 5: r |= (u64)pKey[4] << 24;  /* fall through */
-    case 4: r |= (u64)pKey[3] << 32;  /* fall through */
-    case 3: r |= (u64)pKey[2] << 40;  /* fall through */
-    case 2: r |= (u64)pKey[1] << 48;  /* fall through */
-    case 1: r |= (u64)pKey[0] << 56;  /* fall through */
+    case 8: r |= (u64)pKey[7];
+    case 7: r |= (u64)pKey[6] << 8;
+    case 6: r |= (u64)pKey[5] << 16;
+    case 5: r |= (u64)pKey[4] << 24;
+    case 4: r |= (u64)pKey[3] << 32;
+    case 3: r |= (u64)pKey[2] << 40;
+    case 2: r |= (u64)pKey[1] << 48;
+    case 1: r |= (u64)pKey[0] << 56;
     case 0: break;
   }
   return r;
@@ -116,9 +116,9 @@ static u32 hashKey(const u8 *pKey, int nKey){
   return h;
 }
 
-/* (prefix, phys) pair packed for cache-friendly sort. Lex order on
-** prefix matches the first 8 bytes of the key; when prefixes tie we
-** fall through to a full compareEntries() against mm->aEntries. */
+
+
+
 typedef struct OrderPair {
   u64 prefix;
   int phys;
@@ -145,24 +145,24 @@ static void mutmapInsertionSort(ProllyMutMap *mm, OrderPair *a, int lo, int hi){
   }
 }
 
-/* Quicksort with median-of-3 pivot, insertion-sort fallback for small
-** ranges, and tail-call elimination on the larger partition to bound
-** stack depth at O(log N). Compare is inlined via orderPairCmp — no
-** function pointer or global context. */
+
+
+
+
 static void mutmapQuickSort(ProllyMutMap *mm, OrderPair *a, int lo, int hi){
   while( hi - lo > 16 ){
     int mid = lo + ((hi - lo) >> 1);
     int i, j;
     OrderPair pivot, t;
-    /* Median-of-3 pivot selection: order a[lo], a[mid], a[hi] then
-    ** stash the median at a[hi-1] as the pivot. */
+
+
     if( orderPairCmp(mm, &a[lo], &a[mid]) > 0 ){ t=a[lo]; a[lo]=a[mid]; a[mid]=t; }
     if( orderPairCmp(mm, &a[lo], &a[hi]) > 0 ){ t=a[lo]; a[lo]=a[hi]; a[hi]=t; }
     if( orderPairCmp(mm, &a[mid], &a[hi]) > 0 ){ t=a[mid]; a[mid]=a[hi]; a[hi]=t; }
     t = a[mid]; a[mid] = a[hi-1]; a[hi-1] = t;
     pivot = a[hi-1];
-    /* Partition. a[lo] <= pivot, a[hi] >= pivot already, so we scan
-    ** the interior. */
+
+
     i = lo;
     j = hi - 1;
     for(;;){
@@ -171,9 +171,9 @@ static void mutmapQuickSort(ProllyMutMap *mm, OrderPair *a, int lo, int hi){
       if( i >= j ) break;
       t = a[i]; a[i] = a[j]; a[j] = t;
     }
-    /* Restore pivot to its final position. */
+
     t = a[i]; a[i] = a[hi-1]; a[hi-1] = t;
-    /* Recurse on the smaller side, iterate on the larger. */
+
     if( i - lo < hi - i ){
       mutmapQuickSort(mm, a, lo, i - 1);
       lo = i + 1;
@@ -185,11 +185,11 @@ static void mutmapQuickSort(ProllyMutMap *mm, OrderPair *a, int lo, int hi){
   mutmapInsertionSort(mm, a, lo, hi);
 }
 
-/* Sort mm->aOrder[0..nEntries-1] by key. Builds a (prefix, phys)
-** scratch array, sorts that with a typed compare, then writes the
-** phys indices back to aOrder. The scratch buffer is cached on the
-** mutmap and grows in lockstep with nAlloc — flush-then-reuse loops
-** pay one alloc total, not one per flush. */
+
+
+
+
+
 static int mutmapSortOrder(ProllyMutMap *mm){
   int n = mm->nEntries;
   OrderPair *scratch;
@@ -582,9 +582,9 @@ int prollyMutMapInsert(
   if( !mm->keepSorted ){
     hashInsertPhys(mm, phys);
   }
-  /* New entry shifts every later sorted position by +1 — invalidate any
-  ** mmIdx caches held by other cursors. In-place updates above this
-  ** branch don't reach here so they correctly leave generation alone. */
+
+
+
   mm->generation++;
   return SQLITE_OK;
 }
@@ -671,10 +671,10 @@ void prollyMutMapPushSavepoint(ProllyMutMap *mm, int level){
   mm->currentSavepointLevel = level;
 }
 
-/* Order matters: restore in-place mutations from the undo log
-** FIRST, then drop fresh-key inserts with bornAt >= level. Doing it
-** the other way would drop in-place-mutated entries before their
-** undo record gets applied, losing the restored state. */
+
+
+
+
 int prollyMutMapRollbackToSavepoint(ProllyMutMap *mm, int level){
   int i;
   int rc;
@@ -747,9 +747,9 @@ int prollyMutMapRollbackToSavepoint(ProllyMutMap *mm, int level){
     if( rc!=SQLITE_OK ) return rc;
   }
 
-  /* Rollback both reorders entries (compaction) and applies undo-log
-  ** in-place restorations — both can change what cursors see at any
-  ** mmIdx, so unconditionally invalidate cached positions. */
+
+
+
   mm->generation++;
 
   mm->currentSavepointLevel = level - 1;
@@ -833,9 +833,9 @@ int prollyMutMapResolveSortedPos(
   *pFound = 0;
   if( mm->nEntries==0 ) return SQLITE_OK;
   prepKey(mm, &pKey, &nKey, intKey, keyBuf);
-  /* bsearch_key reads through aOrder; for unsorted maps we need to
-  ** materialize the sort first. ensureOrder is a no-op when keepSorted
-  ** is set or when the order is already clean. */
+
+
+
   rc = ensureOrder(mm);
   if( rc!=SQLITE_OK ) return rc;
   *pIdx = bsearch_key(mm, pKey, nKey, pFound);
@@ -899,10 +899,10 @@ void prollyMutMapIterLast(ProllyMutMapIter *it, ProllyMutMap *mm){
   it->idx = mm->nEntries>0 ? mm->nEntries - 1 : mm->nEntries;
 }
 
-/* Wipes data only — currentSavepointLevel is context not data. A
-** flushMutMap mid-savepoint calls clear and the mutmap continues to
-** live under the same savepoint, so subsequent writes must still
-** attribute to that level. */
+
+
+
+
 void prollyMutMapClear(ProllyMutMap *mm){
   int i;
   for(i=0; i<mm->nEntries; i++){
@@ -1077,8 +1077,8 @@ int prollyMutMapMerge(ProllyMutMap *pDst, ProllyMutMap *pSrc){
   int i, rc;
   for(i=0; i<pSrc->nEntries; i++){
     ProllyMutMapEntry *e = &pSrc->aEntries[i];
-    /* Entry's pKey/nKey are already in encoded byte form for both INT
-    ** and BLOB maps, so prepKey in the callee is a no-op. */
+
+
     if( e->op==PROLLY_EDIT_INSERT ){
       rc = prollyMutMapInsert(pDst, e->pKey, e->nKey, 0,
                                e->pVal, e->nVal);

--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -9,10 +9,6 @@
 #define MUTMAP_INIT_CAP 16
 #define MUTMAP_MIN_HASH 32
 
-
-
-
-
 i64 prollyMutMapEntryIntKey(const ProllyMutMapEntry *e){
   const u8 *p = e->pKey;
   u64 u;
@@ -34,20 +30,11 @@ static void encodeIntKeyBE(i64 v, u8 buf[8]){
   buf[7] = (u8)u;
 }
 
-
-
-
-
-
-
-
 static void prepKey(ProllyMutMap *mm,
                     const u8 **ppKey, int *pnKey,
                     i64 intKey, u8 buf[8]){
   if( !mm->isIntKey ) return;
   if( *ppKey != 0 && *pnKey > 0 ){
-
-
     assert( intKey == 0 );
     return;
   }
@@ -67,11 +54,6 @@ static int compareEntries(
   if( nKeyA > nKeyB ) return 1;
   return 0;
 }
-
-
-
-
-
 
 static u64 keyPrefix64(const u8 *pKey, int nKey){
   u64 r = 0;
@@ -116,9 +98,6 @@ static u32 hashKey(const u8 *pKey, int nKey){
   return h;
 }
 
-
-
-
 typedef struct OrderPair {
   u64 prefix;
   int phys;
@@ -145,24 +124,16 @@ static void mutmapInsertionSort(ProllyMutMap *mm, OrderPair *a, int lo, int hi){
   }
 }
 
-
-
-
-
 static void mutmapQuickSort(ProllyMutMap *mm, OrderPair *a, int lo, int hi){
   while( hi - lo > 16 ){
     int mid = lo + ((hi - lo) >> 1);
     int i, j;
     OrderPair pivot, t;
-
-
     if( orderPairCmp(mm, &a[lo], &a[mid]) > 0 ){ t=a[lo]; a[lo]=a[mid]; a[mid]=t; }
     if( orderPairCmp(mm, &a[lo], &a[hi]) > 0 ){ t=a[lo]; a[lo]=a[hi]; a[hi]=t; }
     if( orderPairCmp(mm, &a[mid], &a[hi]) > 0 ){ t=a[mid]; a[mid]=a[hi]; a[hi]=t; }
     t = a[mid]; a[mid] = a[hi-1]; a[hi-1] = t;
     pivot = a[hi-1];
-
-
     i = lo;
     j = hi - 1;
     for(;;){
@@ -171,9 +142,7 @@ static void mutmapQuickSort(ProllyMutMap *mm, OrderPair *a, int lo, int hi){
       if( i >= j ) break;
       t = a[i]; a[i] = a[j]; a[j] = t;
     }
-
     t = a[i]; a[i] = a[hi-1]; a[hi-1] = t;
-
     if( i - lo < hi - i ){
       mutmapQuickSort(mm, a, lo, i - 1);
       lo = i + 1;
@@ -184,11 +153,6 @@ static void mutmapQuickSort(ProllyMutMap *mm, OrderPair *a, int lo, int hi){
   }
   mutmapInsertionSort(mm, a, lo, hi);
 }
-
-
-
-
-
 
 static int mutmapSortOrder(ProllyMutMap *mm){
   int n = mm->nEntries;
@@ -582,9 +546,6 @@ int prollyMutMapInsert(
   if( !mm->keepSorted ){
     hashInsertPhys(mm, phys);
   }
-
-
-
   mm->generation++;
   return SQLITE_OK;
 }
@@ -671,10 +632,6 @@ void prollyMutMapPushSavepoint(ProllyMutMap *mm, int level){
   mm->currentSavepointLevel = level;
 }
 
-
-
-
-
 int prollyMutMapRollbackToSavepoint(ProllyMutMap *mm, int level){
   int i;
   int rc;
@@ -695,7 +652,6 @@ int prollyMutMapRollbackToSavepoint(ProllyMutMap *mm, int level){
     rec->prevVal = 0;
     mm->nUndo--;
   }
-
 
   {
     int oldN = mm->nEntries;
@@ -746,9 +702,6 @@ int prollyMutMapRollbackToSavepoint(ProllyMutMap *mm, int level){
     int rc = rebuildHash(mm);
     if( rc!=SQLITE_OK ) return rc;
   }
-
-
-
 
   mm->generation++;
 
@@ -833,9 +786,6 @@ int prollyMutMapResolveSortedPos(
   *pFound = 0;
   if( mm->nEntries==0 ) return SQLITE_OK;
   prepKey(mm, &pKey, &nKey, intKey, keyBuf);
-
-
-
   rc = ensureOrder(mm);
   if( rc!=SQLITE_OK ) return rc;
   *pIdx = bsearch_key(mm, pKey, nKey, pFound);
@@ -898,10 +848,6 @@ void prollyMutMapIterLast(ProllyMutMapIter *it, ProllyMutMap *mm){
   it->pMap = mm;
   it->idx = mm->nEntries>0 ? mm->nEntries - 1 : mm->nEntries;
 }
-
-
-
-
 
 void prollyMutMapClear(ProllyMutMap *mm){
   int i;
@@ -1077,8 +1023,6 @@ int prollyMutMapMerge(ProllyMutMap *pDst, ProllyMutMap *pSrc){
   int i, rc;
   for(i=0; i<pSrc->nEntries; i++){
     ProllyMutMapEntry *e = &pSrc->aEntries[i];
-
-
     if( e->op==PROLLY_EDIT_INSERT ){
       rc = prollyMutMapInsert(pDst, e->pKey, e->nKey, 0,
                                e->pVal, e->nVal);

--- a/src/prolly_mutmap.h
+++ b/src/prolly_mutmap.h
@@ -23,12 +23,7 @@ struct ProllyMutMapEntry {
   int bornAt;
 };
 
-
-
-
 i64 prollyMutMapEntryIntKey(const ProllyMutMapEntry *e);
-
-
 
 typedef struct ProllyMutMapUndoRec ProllyMutMapUndoRec;
 struct ProllyMutMapUndoRec {
@@ -48,24 +43,18 @@ struct ProllyMutMap {
   int nAlloc;
   int levelBase;
   ProllyMutMapEntry *aEntries;
-
   /* aEntries is append ordered. aOrder is key sorted, aPos maps physical
   ** entry indexes back into aOrder, and aHash accelerates point lookup. */
   int *aOrder;
   int *aPos;
   int *aHash;
   int nHashAlloc;
-
-
-
   void *aSortScratch;
   int nSortScratchBytes;
-
   int currentSavepointLevel;
   ProllyMutMapUndoRec *aUndo;
   int nUndo;
   int nUndoAlloc;
-
   /* Cursors cache this value so they can detect pending-map replacement or
   ** rollback without pointer comparisons against recycled allocations. */
   u32 generation;
@@ -86,12 +75,6 @@ int prollyMutMapFindRc(
   const u8 *pKey, int nKey, i64 intKey,
   ProllyMutMapEntry **ppEntry
 );
-
-
-
-
-
-
 
 int prollyMutMapResolveSortedPos(
   ProllyMutMap *mm,
@@ -128,10 +111,6 @@ void prollyMutMapIterLast(ProllyMutMapIter *it, ProllyMutMap *mm);
 int prollyMutMapMerge(ProllyMutMap *pDst, ProllyMutMap *pSrc);
 
 int prollyMutMapClone(ProllyMutMap **out, const ProllyMutMap *src);
-
-
-
-
 
 void prollyMutMapPushSavepoint(ProllyMutMap *mm, int level);
 int  prollyMutMapRollbackToSavepoint(ProllyMutMap *mm, int level);

--- a/src/prolly_mutmap.h
+++ b/src/prolly_mutmap.h
@@ -23,13 +23,13 @@ struct ProllyMutMapEntry {
   int bornAt;
 };
 
-/* Decodes a sortable 8-byte BE entry key back to i64. Only valid for
-** entries in an INT-mode map; the bytes layout matches the on-disk
-** PROLLY_NODE_INTKEY encoding (sign-flipped big-endian). */
+
+
+
 i64 prollyMutMapEntryIntKey(const ProllyMutMapEntry *e);
 
-/* Lazy — allocated only when an in-place mutation under an active
-** savepoint is about to overwrite the previous (op, value). */
+
+
 typedef struct ProllyMutMapUndoRec ProllyMutMapUndoRec;
 struct ProllyMutMapUndoRec {
   int level;
@@ -48,30 +48,30 @@ struct ProllyMutMap {
   int nAlloc;
   int levelBase;
   ProllyMutMapEntry *aEntries;
-  /* aOrder / aPos form a two-way mapping between sorted position and
-  ** physical entry index. aHash is an open-addressing lookup table
-  ** storing (phys + 1) so 0 marks an empty slot. */
+
+
+
   int *aOrder;
   int *aPos;
   int *aHash;
   int nHashAlloc;
-  /* Reusable scratch for the typed mutmap sort (see ensureOrder /
-  ** mutmapSortOrder in prolly_mutmap.c). Allocated lazily on first
-  ** sort; grows in lockstep with nAlloc. Bytes; opaque to callers. */
+
+
+
   void *aSortScratch;
   int nSortScratchBytes;
-  /* 0 disables the undo-log path entirely — the autocommit fast path. */
+
   int currentSavepointLevel;
   ProllyMutMapUndoRec *aUndo;
   int nUndo;
   int nUndoAlloc;
-  /* Bumped on every mutation that can shift cursor positions: insert
-  ** of a new key, delete of an existing key, savepoint rollback (drops
-  ** entries). NOT bumped by in-place value updates or savepoint
-  ** release (which only relabels bornAt). Cursors snapshot this value
-  ** when they record an mmIdx, then re-resolve their position by key
-  ** if the snapshot is stale. This matters now that per-table mutmaps
-  ** are shared across cursors. */
+
+
+
+
+
+
+
   u32 generation;
 };
 
@@ -91,12 +91,12 @@ int prollyMutMapFindRc(
   ProllyMutMapEntry **ppEntry
 );
 
-/* Resolve a key to its current sorted-order index in the mutmap, or
-** the position where it would be inserted if absent. Output (*pIdx)
-** is in [0, nEntries]; (*pFound) is non-zero iff the key is present.
-** Used by cursors that cached an mmIdx at an earlier generation —
-** when generation has advanced, the cached idx may point at the
-** wrong entry, so the cursor re-resolves by its cached key. */
+
+
+
+
+
+
 int prollyMutMapResolveSortedPos(
   ProllyMutMap *mm,
   const u8 *pKey, int nKey, i64 intKey,
@@ -133,10 +133,10 @@ int prollyMutMapMerge(ProllyMutMap *pDst, ProllyMutMap *pSrc);
 
 int prollyMutMapClone(ProllyMutMap **out, const ProllyMutMap *src);
 
-/* Rollback order matters: walk the undo log backward FIRST (restoring
-** in-place mutations), THEN drop entries with bornAt >= level. Doing it
-** the other way would drop in-place-mutated entries before their undo
-** record gets applied. */
+
+
+
+
 void prollyMutMapPushSavepoint(ProllyMutMap *mm, int level);
 int  prollyMutMapRollbackToSavepoint(ProllyMutMap *mm, int level);
 void prollyMutMapReleaseSavepoint(ProllyMutMap *mm, int level);

--- a/src/prolly_mutmap.h
+++ b/src/prolly_mutmap.h
@@ -49,8 +49,8 @@ struct ProllyMutMap {
   int levelBase;
   ProllyMutMapEntry *aEntries;
 
-
-
+  /* aEntries is append ordered. aOrder is key sorted, aPos maps physical
+  ** entry indexes back into aOrder, and aHash accelerates point lookup. */
   int *aOrder;
   int *aPos;
   int *aHash;
@@ -66,12 +66,8 @@ struct ProllyMutMap {
   int nUndo;
   int nUndoAlloc;
 
-
-
-
-
-
-
+  /* Cursors cache this value so they can detect pending-map replacement or
+  ** rollback without pointer comparisons against recycled allocations. */
   u32 generation;
 };
 

--- a/src/prolly_node.c
+++ b/src/prolly_node.c
@@ -330,10 +330,10 @@ int prollyNodeBuilderAdd(
   }
 
 
-  /* Guard against `NULL + 0` pointer arithmetic — the builder's
-  ** buffers are lazily allocated and stay NULL until the first
-  ** non-empty byte, and `p + 0` on a null pointer is UB per
-  ** C11 6.5.6/8 even though the value is never dereferenced. */
+
+
+
+
   if( nKey > 0 ){
     memcpy(b->pKeyBuf + b->nKeyBytes, pKey, nKey);
     b->nKeyBytes += nKey;

--- a/src/prolly_node.c
+++ b/src/prolly_node.c
@@ -23,11 +23,9 @@ int prollyNodeParse(ProllyNode *pNode, const u8 *pData, int nData){
 
   memset(pNode, 0, sizeof(*pNode));
 
-
   if( nData<PROLLY_HDR_SIZE ){
     return SQLITE_CORRUPT;
   }
-
 
   magic = PROLLY_GET_U32(pData + PROLLY_MAGIC_OFF);
   if( magic!=PROLLY_NODE_MAGIC ){
@@ -59,13 +57,11 @@ int prollyNodeParse(ProllyNode *pNode, const u8 *pData, int nData){
     return SQLITE_OK;
   }
 
-
   nOffsets = (int)(count + 1) * 4 * 2;
   minSize = PROLLY_HDR_SIZE + nOffsets;
   if( nData<minSize ){
     return SQLITE_CORRUPT;
   }
-
 
   pCur = pData + PROLLY_HDR_SIZE;
   pNode->aKeyOff = (const u32*)pCur;
@@ -73,9 +69,7 @@ int prollyNodeParse(ProllyNode *pNode, const u8 *pData, int nData){
   pNode->aValOff = (const u32*)pCur;
   pCur += (count + 1) * 4;
 
-
   pNode->pKeyData = pCur;
-
 
   totalKeyBytes = PROLLY_GET_U32((const u8*)&pNode->aKeyOff[count]);
   pNode->pValData = pCur + totalKeyBytes;
@@ -185,7 +179,6 @@ int prollyNodeSearchBlob(
     mid = lo + (hi - lo) / 2;
     prollyNodeKey(pNode, mid, &pMidKey, &nMidKey);
 
-
     nCmp = nMidKey < nKey ? nMidKey : nKey;
     c = memcmp(pKey, pMidKey, nCmp);
     if( c==0 ) c = nKey - nMidKey;
@@ -199,7 +192,6 @@ int prollyNodeSearchBlob(
       lo = mid + 1;
     }
   }
-
 
   if( lo>=pNode->nItems ){
     *pRes = 1;
@@ -234,7 +226,6 @@ int prollyNodeSearchInt(const ProllyNode *pNode, i64 intKey, int *pRes){
       lo = mid + 1;
     }
   }
-
 
   if( lo>=pNode->nItems ){
     *pRes = 1;
@@ -313,26 +304,18 @@ int prollyNodeBuilderAdd(
     return SQLITE_FULL;
   }
 
-
   rc = builderGrowOffsets(b);
   if( rc ) return rc;
-
 
   rc = builderGrowKeyBuf(b, nKey);
   if( rc ) return rc;
   rc = builderGrowValBuf(b, nVal);
   if( rc ) return rc;
 
-
   if( b->nItems==0 ){
     b->aKeyOff[0] = 0;
     b->aValOff[0] = 0;
   }
-
-
-
-
-
 
   if( nKey > 0 ){
     memcpy(b->pKeyBuf + b->nKeyBytes, pKey, nKey);
@@ -366,7 +349,6 @@ int prollyNodeBuilderFinish(ProllyNodeBuilder *b, u8 **ppOut, int *pnOut){
   pBuf = (u8*)sqlite3_malloc(nTotal);
   if( !pBuf ) return SQLITE_NOMEM;
 
-
   PROLLY_PUT_U32(pBuf + PROLLY_MAGIC_OFF, PROLLY_NODE_MAGIC);
   pBuf[PROLLY_LEVEL_OFF] = b->level;
   PROLLY_PUT_U16(pBuf + PROLLY_COUNT_OFF, (u16)b->nItems);
@@ -374,24 +356,20 @@ int prollyNodeBuilderFinish(ProllyNodeBuilder *b, u8 **ppOut, int *pnOut){
 
   pCur = pBuf + PROLLY_HDR_SIZE;
 
-
   for(i=0; i<=b->nItems; i++){
     PROLLY_PUT_U32(pCur, b->aKeyOff[i]);
     pCur += 4;
   }
-
 
   for(i=0; i<=b->nItems; i++){
     PROLLY_PUT_U32(pCur, b->aValOff[i]);
     pCur += 4;
   }
 
-
   if( b->nKeyBytes>0 ){
     memcpy(pCur, b->pKeyBuf, b->nKeyBytes);
     pCur += b->nKeyBytes;
   }
-
 
   if( b->nValBytes>0 ){
     memcpy(pCur, b->pValBuf, b->nValBytes);

--- a/src/prolly_node.h
+++ b/src/prolly_node.h
@@ -20,6 +20,8 @@
 #define PROLLY_NODE_MAX_ITEMS 4096
 
 typedef struct ProllyNode ProllyNode;
+/* Parsed view over immutable node bytes. Offsets in the node are little-endian
+** on disk; accessors decode them instead of relying on host alignment. */
 struct ProllyNode {
   const u8 *pData;
   int nData;

--- a/src/prolly_node.h
+++ b/src/prolly_node.h
@@ -1,11 +1,4 @@
 
-
-
-
-
-
-
-
 #ifndef SQLITE_PROLLY_NODE_H
 #define SQLITE_PROLLY_NODE_H
 
@@ -48,10 +41,6 @@ int prollyNodeSearchBlob(const ProllyNode *pNode,
                          const u8 *pKey, int nKey, int *pRes);
 
 int prollyNodeSearchInt(const ProllyNode *pNode, i64 intKey, int *pRes);
-
-
-
-
 
 void prollyEncodeIntKey(i64 v, u8 buf[8]);
 

--- a/src/prolly_node.h
+++ b/src/prolly_node.h
@@ -1,11 +1,11 @@
 
-/* Prolly tree node encoding:
-**   [magic:4][level:1][count:2][flags:1]
-**   [aKeyOff:4*count][aValOff:4*count]
-**   [key data][value data]
-** INTKEY keys are 8-byte big-endian with the sign bit flipped so
-** memcmp gives correct signed order. Values are SQLite record bytes
-** at leaf level, or child hashes at interior levels. */
+
+
+
+
+
+
+
 #ifndef SQLITE_PROLLY_NODE_H
 #define SQLITE_PROLLY_NODE_H
 
@@ -47,10 +47,10 @@ int prollyNodeSearchBlob(const ProllyNode *pNode,
 
 int prollyNodeSearchInt(const ProllyNode *pNode, i64 intKey, int *pRes);
 
-/* Encodes an i64 into the sortable 8-byte big-endian form used by
-** PROLLY_NODE_INTKEY on-disk layout (sign-flipped, so unsigned byte
-** lex order matches signed integer order). The inverse of
-** prollyNodeIntKey at the byte level. */
+
+
+
+
 void prollyEncodeIntKey(i64 v, u8 buf[8]);
 
 typedef struct ProllyNodeBuilder ProllyNodeBuilder;

--- a/src/prolly_record.h
+++ b/src/prolly_record.h
@@ -19,11 +19,11 @@ static inline int dlReadVarint(const u8 *p, const u8 *pEnd, u64 *pVal){
   return i;
 }
 
-/* SQLite record serial-type → payload length. Types 0-6 are fixed
-** int widths (0, 1, 2, 3, 4, 6, 8), 7 is float8, 8/9 are the literal
-** 0/1 with no payload. Even types >= 12 are BLOBs of (st-12)/2 bytes,
-** odd types >= 13 are TEXT of (st-13)/2 bytes — both round to the
-** same length, so the /2 below handles either parity. */
+
+
+
+
+
 static inline int dlSerialTypeLen(u64 st){
   static const u8 aLen[] = {0, 1, 2, 3, 4, 6, 8};
   if( st <= 6 ) return aLen[st];

--- a/src/prolly_record.h
+++ b/src/prolly_record.h
@@ -19,11 +19,6 @@ static inline int dlReadVarint(const u8 *p, const u8 *pEnd, u64 *pVal){
   return i;
 }
 
-
-
-
-
-
 static inline int dlSerialTypeLen(u64 st){
   static const u8 aLen[] = {0, 1, 2, 3, 4, 6, 8};
   if( st <= 6 ) return aLen[st];

--- a/src/prolly_three_way_diff.c
+++ b/src/prolly_three_way_diff.c
@@ -4,14 +4,6 @@
 #include "prolly_three_way_diff.h"
 #include <string.h>
 
-
-
-
-
-
-
-
-
 static int valuesEqual(const u8 *pA, int nA, const u8 *pB, int nB){
   int equal = 0;
   return prollyValuesEqual(pA, nA, pB, nB, &equal)==SQLITE_OK && equal;
@@ -100,18 +92,6 @@ static int emitRightOnly(
   return xCallback(pCtx, &change);
 }
 
-
-
-
-
-
-
-
-
-
-
-
-
 static int emitBothSides(
   const ProllyDiffChange *pLeft,
   const ProllyDiffChange *pRight,
@@ -121,7 +101,6 @@ static int emitBothSides(
   ThreeWayChange change;
   memset(&change, 0, sizeof(change));
   fillKeyFromChange(&change, pLeft);
-
 
   if( pLeft->type==PROLLY_DIFF_ADD && pRight->type==PROLLY_DIFF_ADD ){
     if( valuesEqual(pLeft->pNewVal, pLeft->nNewVal,
@@ -137,14 +116,12 @@ static int emitBothSides(
     return xCallback(pCtx, &change);
   }
 
-
   if( pLeft->type==PROLLY_DIFF_DELETE && pRight->type==PROLLY_DIFF_DELETE ){
     change.type = THREE_WAY_CONVERGENT;
     change.pBaseVal = pLeft->pOldVal;
     change.nBaseVal = pLeft->nOldVal;
     return xCallback(pCtx, &change);
   }
-
 
   if( pLeft->type==PROLLY_DIFF_MODIFY && pRight->type==PROLLY_DIFF_MODIFY ){
     change.pBaseVal = pLeft->pOldVal;
@@ -162,7 +139,6 @@ static int emitBothSides(
     return xCallback(pCtx, &change);
   }
 
-
   if( (pLeft->type==PROLLY_DIFF_DELETE && pRight->type==PROLLY_DIFF_MODIFY)
    || (pLeft->type==PROLLY_DIFF_MODIFY && pRight->type==PROLLY_DIFF_DELETE) ){
     change.type = THREE_WAY_CONFLICT_DM;
@@ -177,7 +153,6 @@ static int emitBothSides(
     }
     return xCallback(pCtx, &change);
   }
-
 
   change.type = THREE_WAY_CONFLICT_MM;
   change.pBaseVal = pLeft->pOldVal;
@@ -219,7 +194,6 @@ int prollyThreeWayDiff(
     goto cleanup;
   }
 
-
   rcL = prollyDiffIterStep(&iterL, &pL);
   rcR = prollyDiffIterStep(&iterR, &pR);
 
@@ -241,7 +215,6 @@ int prollyThreeWayDiff(
     }
   }
 
-
   while( rcL==SQLITE_ROW ){
     rc = emitLeftOnly(pL, xCallback, pCtx);
     if( rc!=SQLITE_OK ) goto cleanup;
@@ -252,7 +225,6 @@ int prollyThreeWayDiff(
     if( rc!=SQLITE_OK ) goto cleanup;
     rcR = prollyDiffIterStep(&iterR, &pR);
   }
-
 
   if( rcL!=SQLITE_DONE ) rc = rcL;
   if( rc==SQLITE_OK && rcR!=SQLITE_DONE ) rc = rcR;

--- a/src/prolly_three_way_diff.c
+++ b/src/prolly_three_way_diff.c
@@ -4,13 +4,13 @@
 #include "prolly_three_way_diff.h"
 #include <string.h>
 
-/* Streaming three-way diff.
-**
-** Instead of collecting all changes from both sides into memory
-** arrays (O(n) memory), this implementation runs two ProllyDiffIter
-** cursors in parallel and merge-joins them on the fly.  Memory usage
-** is O(1) — only the two "current change" structs from the iterators
-** are alive at any point. */
+
+
+
+
+
+
+
 
 static int valuesEqual(const u8 *pA, int nA, const u8 *pB, int nB){
   int equal = 0;
@@ -100,18 +100,18 @@ static int emitRightOnly(
   return xCallback(pCtx, &change);
 }
 
-/* Classification when both branches touched the same key:
-**
-**   ADD vs ADD        -> CONVERGENT if same value, else CONFLICT_MM
-**   DELETE vs DELETE  -> CONVERGENT
-**   MODIFY vs MODIFY  -> CONVERGENT if same new value, else CONFLICT_MM
-**   DELETE vs MODIFY  -> CONFLICT_DM
-**   MODIFY vs DELETE  -> CONFLICT_DM
-**   anything else     -> CONFLICT_MM (fallback)
-**
-** "Both sides made the same change" (convergent) is the one case
-** merge can silently accept -- everything else either needs user
-** resolution or is impossible given the diff semantics. */
+
+
+
+
+
+
+
+
+
+
+
+
 static int emitBothSides(
   const ProllyDiffChange *pLeft,
   const ProllyDiffChange *pRight,
@@ -219,7 +219,7 @@ int prollyThreeWayDiff(
     goto cleanup;
   }
 
-  /* Prime both iterators. */
+
   rcL = prollyDiffIterStep(&iterL, &pL);
   rcR = prollyDiffIterStep(&iterR, &pR);
 
@@ -241,7 +241,7 @@ int prollyThreeWayDiff(
     }
   }
 
-  /* Drain whichever side has remaining entries. */
+
   while( rcL==SQLITE_ROW ){
     rc = emitLeftOnly(pL, xCallback, pCtx);
     if( rc!=SQLITE_OK ) goto cleanup;
@@ -253,7 +253,7 @@ int prollyThreeWayDiff(
     rcR = prollyDiffIterStep(&iterR, &pR);
   }
 
-  /* Propagate any iterator error (not SQLITE_DONE). */
+
   if( rcL!=SQLITE_DONE ) rc = rcL;
   if( rc==SQLITE_OK && rcR!=SQLITE_DONE ) rc = rcR;
 

--- a/src/prolly_three_way_diff.h
+++ b/src/prolly_three_way_diff.h
@@ -10,12 +10,12 @@
 #include "chunk_store.h"
 #include "prolly_diff.h"
 
-/* LEFT_* / RIGHT_* fire when only one branch touched the key and can
-** merge cleanly. CONVERGENT fires when both sides made the same
-** change (same ADD value, same MODIFY value, or both DELETE) —
-** accepted silently. CONFLICT_MM (modify-modify) and CONFLICT_DM
-** (delete vs modify) need user resolution. See prolly_three_way_diff.c
-** emitBothSides() for the full classification table. */
+
+
+
+
+
+
 #define THREE_WAY_LEFT_ADD       1
 #define THREE_WAY_LEFT_DELETE    2
 #define THREE_WAY_LEFT_MODIFY    3

--- a/src/prolly_three_way_diff.h
+++ b/src/prolly_three_way_diff.h
@@ -10,12 +10,6 @@
 #include "chunk_store.h"
 #include "prolly_diff.h"
 
-
-
-
-
-
-
 #define THREE_WAY_LEFT_ADD       1
 #define THREE_WAY_LEFT_DELETE    2
 #define THREE_WAY_LEFT_MODIFY    3

--- a/src/prolly_three_way_merge.c
+++ b/src/prolly_three_way_merge.c
@@ -12,6 +12,8 @@
 
 
 
+/* Private sentinel: fast merge could not prove the result, so caller should
+** fall back to the full row-wise merge path without treating it as an error. */
 #define FM_FALLBACK  SQLITE_DONE
 
 
@@ -536,6 +538,8 @@ static int fmEmitChild(
   else if( prollyHashCompare(pTheirs, pAnc) == 0 )  pSplice = pOurs;
 
   if( pSplice ){
+    /* Preserve structural sharing only when the chunker is exactly aligned at
+    ** this parent level; otherwise emit rows so the rebuilt tree stays sorted. */
     if( fmChunkerLevelsBelowEmpty(pCh, parentLevel) ){
       return prollyChunkerAddAtLevel(pCh, parentLevel,
                                       pBoundKey, nBoundKey,

--- a/src/prolly_three_way_merge.c
+++ b/src/prolly_three_way_merge.c
@@ -8,16 +8,9 @@
 
 #include <string.h>
 
-
-
-
-
 /* Private sentinel: fast merge could not prove the result, so caller should
 ** fall back to the full row-wise merge path without treating it as an error. */
 #define FM_FALLBACK  SQLITE_DONE
-
-
-
 
 static int fmKeyCmp(const u8 *pA, int nA, const u8 *pB, int nB){
   int n = nA < nB ? nA : nB;
@@ -27,11 +20,6 @@ static int fmKeyCmp(const u8 *pA, int nA, const u8 *pB, int nB){
   if( nA > nB ) return 1;
   return 0;
 }
-
-
-
-
-
 
 static int fmChunkerLevelsBelowEmpty(const ProllyChunker *pCh, int level){
   int i;
@@ -47,7 +35,6 @@ typedef struct FmCtx {
   u8 flags;
 } FmCtx;
 
-
 static int fmEmitChild(
   FmCtx *fm, ProllyChunker *pCh,
   const u8 *pBoundKey, int nBoundKey,
@@ -56,16 +43,6 @@ static int fmEmitChild(
   const ProllyHash *pOurs,
   const ProllyHash *pTheirs
 );
-
-
-
-
-
-
-
-
-
-
 
 static int fmEmitSubtreeRows(
   FmCtx *fm, ProllyChunker *pCh,
@@ -102,15 +79,6 @@ static int fmEmitSubtreeRows(
   sqlite3_free(pData);
   return SQLITE_OK;
 }
-
-
-
-
-
-
-
-
-
 
 static int fmResolveAndEmit(
   ProllyChunker *pCh,
@@ -156,15 +124,6 @@ static int fmResolveAndEmit(
   return SQLITE_OK;
 }
 
-
-
-
-
-
-
-
-
-
 static int fmMergeLeaves(
   FmCtx *fm, ProllyChunker *pCh,
   const ProllyNode *pAncN,
@@ -187,7 +146,6 @@ static int fmMergeLeaves(
     int nK = 0;
     i64 iK = 0;
 
-
     if( ai < (int)pAncN->nItems ){
       prollyNodeKey(pAncN, ai, &pAK, &nAK);
       if( fm->flags & PROLLY_NODE_INTKEY ) iAKey = prollyNodeIntKey(pAncN, ai);
@@ -201,8 +159,6 @@ static int fmMergeLeaves(
       if( fm->flags & PROLLY_NODE_INTKEY ) iTKey = prollyNodeIntKey(pTheirsN, ti);
     }
 
-
-
     {
       int hasAny[3];
       int minSide = -1;
@@ -214,7 +170,6 @@ static int fmMergeLeaves(
       hasAny[0] = (ai < (int)pAncN->nItems);
       hasAny[1] = (oi < (int)pOursN->nItems);
       hasAny[2] = (ti < (int)pTheirsN->nItems);
-
 
       for( s = 0; s < 3; s++ ){
         if( !hasAny[s] ) continue;
@@ -233,7 +188,6 @@ static int fmMergeLeaves(
       if( minSide == 0 ){ pK = pAK; nK = nAK; iK = iAKey; }
       else if( minSide == 1 ){ pK = pOK; nK = nOK; iK = iOKey; }
       else { pK = pTK; nK = nTK; iK = iTKey; }
-
 
       if( hasAny[0] ){
         cmp = prollyCompareKeys(fm->flags,
@@ -255,7 +209,6 @@ static int fmMergeLeaves(
       }
     }
 
-
     if( has_a ) prollyNodeValue(pAncN, ai, &pAV, &nAV);
     if( has_o ) prollyNodeValue(pOursN, oi, &pOV, &nOV);
     if( has_t ) prollyNodeValue(pTheirsN, ti, &pTV, &nTV);
@@ -266,7 +219,6 @@ static int fmMergeLeaves(
                            has_t, pTV, nTV);
     if( rc != SQLITE_OK ) return rc;
 
-
     if( has_a ) ai++;
     if( has_o ) oi++;
     if( has_t ) ti++;
@@ -274,15 +226,6 @@ static int fmMergeLeaves(
 
   return SQLITE_OK;
 }
-
-
-
-
-
-
-
-
-
 
 static int fmCursorMerge(
   FmCtx *fm, ProllyChunker *pCh,
@@ -370,12 +313,6 @@ static int fmCursorMerge(
   return SQLITE_OK;
 }
 
-
-
-
-
-
-
 static int fmCursorRecover(
   FmCtx *fm, ProllyChunker *pCh,
   const ProllyHash *pAncH,
@@ -393,14 +330,10 @@ static int fmCursorRecover(
   prollyCursorInit(&curT, fm->pStore, fm->pCache, pTheirsH, fm->flags); initT = 1;
 
   if( pSeekKey == 0 ){
-
     rc = prollyCursorFirst(&curA, &res);
     if( rc == SQLITE_OK ) rc = prollyCursorFirst(&curO, &res);
     if( rc == SQLITE_OK ) rc = prollyCursorFirst(&curT, &res);
   }else{
-
-
-
     if( fm->flags & PROLLY_NODE_INTKEY ){
       rc = prollyCursorSeekInt(&curA, iSeekKey, &res);
       if( rc == SQLITE_OK && res == 0 ) rc = prollyCursorNext(&curA);
@@ -436,12 +369,6 @@ static int fmCursorRecover(
   return rc;
 }
 
-
-
-
-
-
-
 static int fmWalkInterior(
   FmCtx *fm, ProllyChunker *pCh,
   ProllyNode *pAncN, ProllyNode *pOursN, ProllyNode *pTheirsN,
@@ -449,10 +376,6 @@ static int fmWalkInterior(
 ){
   int i;
   int parentLevel = pAncN->level;
-
-
-
-
 
   if( pOursN->nItems != pAncN->nItems
    || pTheirsN->nItems != pAncN->nItems ){
@@ -472,10 +395,6 @@ static int fmWalkInterior(
 
     if( fmKeyCmp(pAK, nAK, pOK, nOK) != 0
      || fmKeyCmp(pAK, nAK, pTK, nTK) != 0 ){
-
-
-
-
       const u8 *pSeek = 0;
       int nSeek = 0;
       i64 iSeek = 0;
@@ -499,25 +418,6 @@ static int fmWalkInterior(
 
   return SQLITE_OK;
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 static int fmEmitChild(
   FmCtx *fm, ProllyChunker *pCh,
@@ -545,12 +445,8 @@ static int fmEmitChild(
                                       pBoundKey, nBoundKey,
                                       pSplice->data, PROLLY_HASH_SIZE);
     }
-
-
-
     return fmEmitSubtreeRows(fm, pCh, pSplice);
   }
-
 
   rc = chunkStoreGet(fm->pStore, pAnc, &pAncData, &nAncData);
   if( rc != SQLITE_OK ) return rc;
@@ -568,13 +464,11 @@ static int fmEmitChild(
   if( rc != SQLITE_OK ) goto done;
 
   if( oursNode.level != ancNode.level || theirsNode.level != ancNode.level ){
-
     rc = FM_FALLBACK;
     goto done;
   }
 
   if( ancNode.level == 0 ){
-
     rc = fmMergeLeaves(fm, pCh, &ancNode, &oursNode, &theirsNode);
   }else{
     rc = fmWalkInterior(fm, pCh, &ancNode, &oursNode, &theirsNode,
@@ -607,8 +501,6 @@ int prollyThreeWayMergeFast(
 
   *pHandled = 0;
 
-
-
   if( prollyHashCompare(pOursRoot, pTheirsRoot) == 0 ){
     memcpy(pMergedRoot, pOursRoot, sizeof(ProllyHash));
     *pHandled = 1;
@@ -624,8 +516,6 @@ int prollyThreeWayMergeFast(
     *pHandled = 1;
     return SQLITE_OK;
   }
-
-
 
   if( prollyHashIsEmpty(pAncRoot)
    || prollyHashIsEmpty(pOursRoot)
@@ -654,8 +544,6 @@ int prollyThreeWayMergeFast(
     return rc;
   }
 
-
-
   if( oursNode.level != ancNode.level || theirsNode.level != ancNode.level ){
     sqlite3_free(pAncData); sqlite3_free(pOursData); sqlite3_free(pTheirsData);
     return SQLITE_OK;
@@ -670,9 +558,6 @@ int prollyThreeWayMergeFast(
     sqlite3_free(pAncData); sqlite3_free(pOursData); sqlite3_free(pTheirsData);
     return rc;
   }
-
-
-
 
   if( ancNode.level == 0 ){
     rc = fmMergeLeaves(&fm, &chunker, &ancNode, &oursNode, &theirsNode);

--- a/src/prolly_three_way_merge.c
+++ b/src/prolly_three_way_merge.c
@@ -8,15 +8,15 @@
 
 #include <string.h>
 
-/* Internal sentinel returned by helpers when this case isn't handled
-** by the fast path. Translated to *pHandled=0 at the public API. Never
-** propagates out of this file. SQLITE_DONE (101) is reused because no
-** other helper here returns it for any other reason. */
+
+
+
+
 #define FM_FALLBACK  SQLITE_DONE
 
-/* Local helper: compare two byte sequences as keys (memcmp + length tiebreak).
-** Mirrors compareKeys() in prolly_mutate.c — duplicated rather than exposed
-** to keep the merge code self-contained. */
+
+
+
 static int fmKeyCmp(const u8 *pA, int nA, const u8 *pB, int nB){
   int n = nA < nB ? nA : nB;
   int c = memcmp(pA, pB, n);
@@ -26,11 +26,11 @@ static int fmKeyCmp(const u8 *pA, int nA, const u8 *pB, int nB){
   return 0;
 }
 
-/* Local copy of chunkerLevelsBelowEmpty from prolly_mutate.c. Splicing
-** at level L via prollyChunkerAddAtLevel is only logically correct when
-** the chunker has no pending entries at any level below L — otherwise
-** the spliced subtree's keys would land out of order with respect to
-** entries already buffered at lower levels. */
+
+
+
+
+
 static int fmChunkerLevelsBelowEmpty(const ProllyChunker *pCh, int level){
   int i;
   for( i = 0; i < level && i < pCh->nLevels; i++ ){
@@ -45,7 +45,7 @@ typedef struct FmCtx {
   u8 flags;
 } FmCtx;
 
-/* Forward declaration — fmEmitChild and fmWalkInterior are mutually recursive. */
+
 static int fmEmitChild(
   FmCtx *fm, ProllyChunker *pCh,
   const u8 *pBoundKey, int nBoundKey,
@@ -55,16 +55,16 @@ static int fmEmitChild(
   const ProllyHash *pTheirs
 );
 
-/* Walk a subtree top-down and emit all its leaf rows into pCh at
-** level 0. Used when a splice at the parent level is blocked because
-** the chunker has pending entries below — emitting the subtree's
-** rows directly costs O(rows) for that subtree but keeps the walker
-** going so subsequent splices on later siblings can still apply once
-** the chunker drains.
-**
-** Internally this is a cousin of streamingMergeNode in prolly_mutate.c
-** with the "no edits" path always taken — every leaf is emitted as-is.
-*/
+
+
+
+
+
+
+
+
+
+
 static int fmEmitSubtreeRows(
   FmCtx *fm, ProllyChunker *pCh,
   const ProllyHash *pSubtreeRoot
@@ -101,15 +101,15 @@ static int fmEmitSubtreeRows(
   return SQLITE_OK;
 }
 
-/* Apply 3-way merge resolution for a single key K and emit the
-** result row at level 0. Shared between fmMergeLeaves (node-driven)
-** and fmCursorMerge (cursor-driven) to avoid divergence in conflict
-** detection and emit rules.
-**
-** Returns FM_FALLBACK on any case the caller's row-by-row path needs
-** to handle: modify-modify with different values, modify-delete,
-** delete-modify, add-add with different values.
-*/
+
+
+
+
+
+
+
+
+
 static int fmResolveAndEmit(
   ProllyChunker *pCh,
   const u8 *pK, int nK,
@@ -129,40 +129,40 @@ static int fmResolveAndEmit(
     }else if( nOV == nTV && memcmp(pOV, pTV, nOV) == 0 ){
       return prollyChunkerAdd(pCh, pK, nK, pOV, nOV);
     }else{
-      return FM_FALLBACK;  /* modify-modify with different values */
+      return FM_FALLBACK;
     }
   }else if( has_a && has_o && !has_t ){
     int same_o = (nOV == nAV) && memcmp(pOV, pAV, nOV) == 0;
-    if( same_o ) return SQLITE_OK;  /* theirs deleted, ours unchanged */
-    return FM_FALLBACK;  /* modify-delete */
+    if( same_o ) return SQLITE_OK;
+    return FM_FALLBACK;
   }else if( has_a && !has_o && has_t ){
     int same_t = (nTV == nAV) && memcmp(pTV, pAV, nTV) == 0;
-    if( same_t ) return SQLITE_OK;  /* ours deleted, theirs unchanged */
-    return FM_FALLBACK;  /* delete-modify */
+    if( same_t ) return SQLITE_OK;
+    return FM_FALLBACK;
   }else if( has_a && !has_o && !has_t ){
-    return SQLITE_OK;  /* both sides deleted */
+    return SQLITE_OK;
   }else if( !has_a && has_o && has_t ){
     if( nOV == nTV && memcmp(pOV, pTV, nOV) == 0 ){
       return prollyChunkerAdd(pCh, pK, nK, pOV, nOV);
     }
-    return FM_FALLBACK;  /* add-add with different values */
+    return FM_FALLBACK;
   }else if( !has_a && has_o && !has_t ){
     return prollyChunkerAdd(pCh, pK, nK, pOV, nOV);
   }else if( !has_a && !has_o && has_t ){
     return prollyChunkerAdd(pCh, pK, nK, pTV, nTV);
   }
-  return SQLITE_OK;  /* unreachable: at least one side must hold K */
+  return SQLITE_OK;
 }
 
-/* Bounded three-way merge of three aligned leaf nodes. Walks the
-** three leaves in key order, applying merge resolution per row,
-** emitting the result at level 0 via prollyChunkerAdd.
-**
-** Returns FM_FALLBACK on any conflict-bearing case so the caller's
-** row-by-row path can report conflicts via its existing machinery.
-** Conflict-free cases (3-way clean, identical changes, disjoint adds
-** in the same chunk, disjoint deletes) emit and return SQLITE_OK.
-*/
+
+
+
+
+
+
+
+
+
 static int fmMergeLeaves(
   FmCtx *fm, ProllyChunker *pCh,
   const ProllyNode *pAncN,
@@ -185,7 +185,7 @@ static int fmMergeLeaves(
     int nK = 0;
     i64 iK = 0;
 
-    /* Materialize each side's current key. */
+
     if( ai < (int)pAncN->nItems ){
       prollyNodeKey(pAncN, ai, &pAK, &nAK);
       if( fm->flags & PROLLY_NODE_INTKEY ) iAKey = prollyNodeIntKey(pAncN, ai);
@@ -199,8 +199,8 @@ static int fmMergeLeaves(
       if( fm->flags & PROLLY_NODE_INTKEY ) iTKey = prollyNodeIntKey(pTheirsN, ti);
     }
 
-    /* Find the smallest current key across the three sides. Compute
-    ** has_a/has_o/has_t = (this side's current key equals the min). */
+
+
     {
       int hasAny[3];
       int minSide = -1;
@@ -213,7 +213,7 @@ static int fmMergeLeaves(
       hasAny[1] = (oi < (int)pOursN->nItems);
       hasAny[2] = (ti < (int)pTheirsN->nItems);
 
-      /* Pick the min by walking pairs through prollyCompareKeys. */
+
       for( s = 0; s < 3; s++ ){
         if( !hasAny[s] ) continue;
         if( minSide < 0 ){ minSide = s; continue; }
@@ -232,7 +232,7 @@ static int fmMergeLeaves(
       else if( minSide == 1 ){ pK = pOK; nK = nOK; iK = iOKey; }
       else { pK = pTK; nK = nTK; iK = iTKey; }
 
-      /* Now mark each side that holds the min key. */
+
       if( hasAny[0] ){
         cmp = prollyCompareKeys(fm->flags,
                                  pAK, nAK, iAKey,
@@ -253,7 +253,7 @@ static int fmMergeLeaves(
       }
     }
 
-    /* Pull values for sides that hold the min key. */
+
     if( has_a ) prollyNodeValue(pAncN, ai, &pAV, &nAV);
     if( has_o ) prollyNodeValue(pOursN, oi, &pOV, &nOV);
     if( has_t ) prollyNodeValue(pTheirsN, ti, &pTV, &nTV);
@@ -264,7 +264,7 @@ static int fmMergeLeaves(
                            has_t, pTV, nTV);
     if( rc != SQLITE_OK ) return rc;
 
-    /* Advance each side that held the min key. */
+
     if( has_a ) ai++;
     if( has_o ) oi++;
     if( has_t ) ti++;
@@ -273,15 +273,15 @@ static int fmMergeLeaves(
   return SQLITE_OK;
 }
 
-/* Cursor-based 3-way merge. Walks anc/ours/theirs cursors in row
-** order, applying the same merge resolution as fmMergeLeaves. Used
-** to recover when interior boundary alignment fails partway through
-** the structured walker — the spliced prefix stays in the chunker
-** and the cursor walk fills the rest at row cost.
-**
-** The cursors must be positioned (Seek or First) by the caller. The
-** walker advances them to EOF.
-*/
+
+
+
+
+
+
+
+
+
 static int fmCursorMerge(
   FmCtx *fm, ProllyChunker *pCh,
   ProllyCursor *pAncC, ProllyCursor *pOursC, ProllyCursor *pTheirsC
@@ -368,12 +368,12 @@ static int fmCursorMerge(
   return SQLITE_OK;
 }
 
-/* Open three cursors over (anc, ours, theirs) subtrees, position
-** each strictly past pSeekKey (or at first if pSeekKey is NULL),
-** then run fmCursorMerge. Used to recover from boundary-alignment
-** failure in fmWalkInterior: the spliced prefix has already been
-** emitted at parentLevel; this cursor walk emits the remainder at
-** level 0 and the chunker's natural batching merges them upward. */
+
+
+
+
+
+
 static int fmCursorRecover(
   FmCtx *fm, ProllyChunker *pCh,
   const ProllyHash *pAncH,
@@ -391,14 +391,14 @@ static int fmCursorRecover(
   prollyCursorInit(&curT, fm->pStore, fm->pCache, pTheirsH, fm->flags); initT = 1;
 
   if( pSeekKey == 0 ){
-    /* No prior splice — walk from the start. */
+
     rc = prollyCursorFirst(&curA, &res);
     if( rc == SQLITE_OK ) rc = prollyCursorFirst(&curO, &res);
     if( rc == SQLITE_OK ) rc = prollyCursorFirst(&curT, &res);
   }else{
-    /* Seek strictly past pSeekKey on each side. SeekBlob/SeekInt
-    ** position at the first key >= seek; if exact match (res==0),
-    ** advance past it. */
+
+
+
     if( fm->flags & PROLLY_NODE_INTKEY ){
       rc = prollyCursorSeekInt(&curA, iSeekKey, &res);
       if( rc == SQLITE_OK && res == 0 ) rc = prollyCursorNext(&curA);
@@ -434,12 +434,12 @@ static int fmCursorRecover(
   return rc;
 }
 
-/* Walk the children of three interior nodes that share the same
-** level. When boundary keys align across the three nodes, the
-** structured splice rules apply per-child. When they don't, recover
-** via fmCursorRecover — the spliced prefix stays in the chunker and
-** the cursor walk emits the remainder at level 0.
-*/
+
+
+
+
+
+
 static int fmWalkInterior(
   FmCtx *fm, ProllyChunker *pCh,
   ProllyNode *pAncN, ProllyNode *pOursN, ProllyNode *pTheirsN,
@@ -448,10 +448,10 @@ static int fmWalkInterior(
   int i;
   int parentLevel = pAncN->level;
 
-  /* Mismatched item counts are a structural divergence — the trees
-  ** rebalanced enough that even ours/theirs don't have the same
-  ** number of children at this level. Hand off to cursor recovery
-  ** from the start of these subtrees (no prior splice). */
+
+
+
+
   if( pOursN->nItems != pAncN->nItems
    || pTheirsN->nItems != pAncN->nItems ){
     return fmCursorRecover(fm, pCh, pAncH, pOursH, pTheirsH, 0, 0, 0);
@@ -470,10 +470,10 @@ static int fmWalkInterior(
 
     if( fmKeyCmp(pAK, nAK, pOK, nOK) != 0
      || fmKeyCmp(pAK, nAK, pTK, nTK) != 0 ){
-      /* Boundary mismatch at child i. Children 0..i-1 have already
-      ** been spliced (or descended) into pCh at parentLevel. Fall
-      ** through to a cursor walk strictly past the last aligned
-      ** boundary key (or from the start when i==0). */
+
+
+
+
       const u8 *pSeek = 0;
       int nSeek = 0;
       i64 iSeek = 0;
@@ -498,25 +498,25 @@ static int fmWalkInterior(
   return SQLITE_OK;
 }
 
-/* Emit one (anc, ours, theirs) child triple at parentLevel into pCh.
-**
-** Hash short-circuits cover the splice cases:
-**   - ours == theirs   : both sides agree, splice that subtree
-**   - ours == anc      : only theirs changed, splice theirs
-**   - theirs == anc    : only ours changed, splice ours
-**
-** When the splice CASE applies but the chunker has pending entries
-** below parentLevel, we can't add at parentLevel without re-ordering;
-** instead we descend the splice candidate's subtree and re-emit its
-** rows at level 0. Costs O(rows) for that subtree but lets the walker
-** keep going so later siblings with empty-below state can splice.
-**
-** When all three differ at an interior level, recurse into the three
-** child nodes via fmWalkInterior. When all three are leaves at the
-** same level, run a bounded 3-way merge of the leaf rows via
-** fmMergeLeaves. Conflict-bearing leaves return FM_FALLBACK so the
-** row-by-row path can report conflicts via its existing machinery.
-*/
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 static int fmEmitChild(
   FmCtx *fm, ProllyChunker *pCh,
   const u8 *pBoundKey, int nBoundKey,
@@ -541,13 +541,13 @@ static int fmEmitChild(
                                       pBoundKey, nBoundKey,
                                       pSplice->data, PROLLY_HASH_SIZE);
     }
-    /* Splice can't happen — descend the splice candidate and emit
-    ** its rows. Boundary key is consumed by the chunker's natural
-    ** chunking once enough leaf rows accumulate. */
+
+
+
     return fmEmitSubtreeRows(fm, pCh, pSplice);
   }
 
-  /* All three differ. Load nodes. */
+
   rc = chunkStoreGet(fm->pStore, pAnc, &pAncData, &nAncData);
   if( rc != SQLITE_OK ) return rc;
   rc = prollyNodeParse(&ancNode, pAncData, nAncData);
@@ -564,13 +564,13 @@ static int fmEmitChild(
   if( rc != SQLITE_OK ) goto done;
 
   if( oursNode.level != ancNode.level || theirsNode.level != ancNode.level ){
-    /* Height mismatch — fall back. */
+
     rc = FM_FALLBACK;
     goto done;
   }
 
   if( ancNode.level == 0 ){
-    /* All three are leaves at the same level. Bounded 3-way row merge. */
+
     rc = fmMergeLeaves(fm, pCh, &ancNode, &oursNode, &theirsNode);
   }else{
     rc = fmWalkInterior(fm, pCh, &ancNode, &oursNode, &theirsNode,
@@ -603,8 +603,8 @@ int prollyThreeWayMergeFast(
 
   *pHandled = 0;
 
-  /* Trivial top-level cases: no walker, no chunker, return the
-  ** appropriate root directly. */
+
+
   if( prollyHashCompare(pOursRoot, pTheirsRoot) == 0 ){
     memcpy(pMergedRoot, pOursRoot, sizeof(ProllyHash));
     *pHandled = 1;
@@ -621,12 +621,12 @@ int prollyThreeWayMergeFast(
     return SQLITE_OK;
   }
 
-  /* All three differ. The walker only handles non-empty trees that
-  ** share the same height and at least one level of interior structure. */
+
+
   if( prollyHashIsEmpty(pAncRoot)
    || prollyHashIsEmpty(pOursRoot)
    || prollyHashIsEmpty(pTheirsRoot) ){
-    return SQLITE_OK;  /* *pHandled stays 0 — caller falls back */
+    return SQLITE_OK;
   }
 
   rc = chunkStoreGet(pStore, pAncRoot, &pAncData, &nAncData);
@@ -650,11 +650,11 @@ int prollyThreeWayMergeFast(
     return rc;
   }
 
-  /* Heights must match for the walker to apply. Tree-growth merges
-  ** (one side increased the height) fall back. */
+
+
   if( oursNode.level != ancNode.level || theirsNode.level != ancNode.level ){
     sqlite3_free(pAncData); sqlite3_free(pOursData); sqlite3_free(pTheirsData);
-    return SQLITE_OK;  /* *pHandled stays 0 */
+    return SQLITE_OK;
   }
 
   fm.pStore = pStore;
@@ -667,9 +667,9 @@ int prollyThreeWayMergeFast(
     return rc;
   }
 
-  /* Root-level leaf merge: when all three roots ARE leaves (small
-  ** trees), the walker's interior path doesn't apply — go straight
-  ** to bounded leaf merge. */
+
+
+
   if( ancNode.level == 0 ){
     rc = fmMergeLeaves(&fm, &chunker, &ancNode, &oursNode, &theirsNode);
     sqlite3_free(pAncData); sqlite3_free(pOursData); sqlite3_free(pTheirsData);
@@ -700,7 +700,7 @@ int prollyThreeWayMergeFast(
       *pHandled = 1;
     }
   }else if( rc == FM_FALLBACK ){
-    rc = SQLITE_OK;  /* *pHandled stays 0 */
+    rc = SQLITE_OK;
   }
   prollyChunkerFree(&chunker);
   return rc;

--- a/src/prolly_three_way_merge.h
+++ b/src/prolly_three_way_merge.h
@@ -1,26 +1,26 @@
 
-/* Tree-walking three-way merge.
-**
-** prollyThreeWayMergeFast walks (anc, ours, theirs) top-down, splicing
-** unchanged subtrees via interior-node hash equality. Wins on workloads
-** where ours and theirs touch disjoint key ranges of the prolly tree —
-** the unaffected subtrees collapse into single chunker entries instead
-** of being re-emitted row by row.
-**
-** *pHandled is set to 1 if the fast path produced a result and
-** *pMergedRoot was written; 0 if the case isn't handled and the caller
-** must fall back to row-by-row merge. The return value is for actual
-** I/O / corruption errors only.
-**
-** The fast path NEVER produces conflicts: any case where conflict
-** detection would be required (both sides modified the same leaf
-** subtree) sets *pHandled=0 so the caller's row-by-row path runs and
-** reports conflicts via its existing machinery.
-**
-** Eligibility (no schema divergence, no secondary indexes, no CHECK,
-** no FK actions) must be checked by the caller before invoking — see
-** fastMergeIneligibleReason() in doltlite_merge.c.
-*/
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 #ifndef SQLITE_PROLLY_THREE_WAY_MERGE_H
 #define SQLITE_PROLLY_THREE_WAY_MERGE_H
 

--- a/src/prolly_three_way_merge.h
+++ b/src/prolly_three_way_merge.h
@@ -1,26 +1,4 @@
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 #ifndef SQLITE_PROLLY_THREE_WAY_MERGE_H
 #define SQLITE_PROLLY_THREE_WAY_MERGE_H
 

--- a/src/prolly_xxhash.c
+++ b/src/prolly_xxhash.c
@@ -65,7 +65,7 @@ u32 prollyXXH32(const u8 *p, int n, u32 seed){
     p++;
   }
 
-  /* final avalanche */
+
   h32 ^= h32 >> 15;
   h32 *= XXH_PRIME32_2;
   h32 ^= h32 >> 13;

--- a/src/prolly_xxhash.c
+++ b/src/prolly_xxhash.c
@@ -65,7 +65,6 @@ u32 prollyXXH32(const u8 *p, int n, u32 seed){
     p++;
   }
 
-
   h32 ^= h32 >> 15;
   h32 *= XXH_PRIME32_2;
   h32 ^= h32 >> 13;

--- a/src/prolly_xxhash.h
+++ b/src/prolly_xxhash.h
@@ -4,16 +4,16 @@
 
 #include "sqliteInt.h"
 
-/* XXH32: 32-bit non-cryptographic hash by Yann Collet.
-**
-** Used by the prolly chunker to derive a uniform u32 from a key, which
-** the Weibull-distribution chunk-boundary check (prollyWeibullCheck)
-** treats as a uniform random number in [0, 2^32).
-**
-** Salting is by `seed`. The chunker passes the tree level as seed so
-** boundaries at different levels don't align on the same keys.
-**
-** Adapted from upstream xxHash (Yann Collet, BSD-2-Clause). */
+
+
+
+
+
+
+
+
+
+
 u32 prollyXXH32(const u8 *p, int n, u32 seed);
 
 #endif

--- a/src/prolly_xxhash.h
+++ b/src/prolly_xxhash.h
@@ -4,16 +4,6 @@
 
 #include "sqliteInt.h"
 
-
-
-
-
-
-
-
-
-
-
 u32 prollyXXH32(const u8 *p, int n, u32 seed);
 
 #endif

--- a/src/sortkey.c
+++ b/src/sortkey.c
@@ -109,6 +109,8 @@ static void encodeNumeric(u8 *pOut, u32 serialType, const u8 *pData, u32 nData){
 
   pOut[0] = SORTKEY_NUM;
 
+  /* Convert SQLite numeric serial types to sortable IEEE bytes: positive
+  ** values flip the sign bit, negative values invert all bits. */
   if( serialType == 7 ){
 
     memcpy(buf, pData, 8);

--- a/src/sortkey.c
+++ b/src/sortkey.c
@@ -44,12 +44,12 @@ static u8 serialTypeTag(u32 serialType){
   return SORTKEY_NULL;
 }
 
-/* The sort key is byte-comparable with memcmp, so we can't invoke
-** the collation's xCmp at encode time. Instead we preprocess TEXT
-** bytes so two inputs that the collation considers equal produce
-** identical sort keys: NOCASE folds ASCII A-Z to a-z, RTRIM strips
-** trailing 0x20. Any other (user-defined) collation falls back to
-** BINARY — the prolly tree still sorts, just byte-wise. */
+
+
+
+
+
+
 #define SORTKEY_COLL_BINARY 0
 #define SORTKEY_COLL_NOCASE 1
 #define SORTKEY_COLL_RTRIM  2
@@ -121,10 +121,10 @@ static void encodeNumeric(u8 *pOut, u32 serialType, const u8 *pData, u32 nData){
     }else if( serialType == 9 ){
       v = 1;
     }else{
-      /* Big-endian sign-extended multi-byte integer. Accumulate in
-      ** u64 because left-shift of a negative signed value is UB
-      ** per C11 6.5.7/4; two's-complement bit pattern is identical
-      ** so the cast back at the end is exact. */
+
+
+
+
       u64 uv = (pData[0] & 0x80) ? (u64)-1 : 0;
       for(u32 i = 0; i < nData; i++){
         uv = (uv << 8) | pData[i];
@@ -273,10 +273,10 @@ int sortKeyFromRecordPrefixCollBuffer(
 
   *pnOut = 0;
 
-  /* Upper bound: worst case is a record of serial-type-8 fields
-  ** (integer zero) — each is 1 header byte, 0 data bytes, but
-  ** encodes to 9 sort key bytes. So the expansion factor per
-  ** record byte is up to 9. Use 9*nRec as the safe bound. */
+
+
+
+
   nEstimate = 9 * nRec + 16;
   if( nEstimate < 64 ) nEstimate = 64;
 
@@ -616,12 +616,12 @@ int recordFromSortKeyBuffer(
   u32 aLen[64];
 
   const u8 *aFieldPtr[64];
-  /* Encoded byte-length of each TEXT/BLOB field in the sort-key, NOT
-  ** including the 0x00 0x00 terminator. Equal to aLen[i] when the
-  ** field has no 0x00 0x01 escapes — the common case for ASCII /
-  ** hex / utf-8 keys without embedded NULs — letting the data-write
-  ** loop below replace its byte-by-byte un-escape with a single
-  ** memcpy. Set to 0 for non-text fields (unused). */
+
+
+
+
+
+
   int aEncLen[64];
   u8 aIntBuf[64][8];
   int nFields = 0;
@@ -640,7 +640,7 @@ int recordFromSortKeyBuffer(
       *pnAlloc = 1;
     }
     pOut = *ppBuf;
-    pOut[0] = 1;  
+    pOut[0] = 1;
     *pnOut = 1;
     return SQLITE_OK;
   }
@@ -688,13 +688,13 @@ int recordFromSortKeyBuffer(
 
       int start = pos;
       int dataLen = 0;
-      /* Skip ahead to the next 0x00 sentinel via memchr — vectorized
-      ** on most platforms — instead of walking byte-by-byte. The 0x00
-      ** is either a terminator (followed by 0x00) or an escape
-      ** (followed by 0x01); only those positions need branch logic.
-      ** For ASCII / hex / utf-8 TEXT without embedded NULs the loop
-      ** runs exactly once: memchr finds the terminator, accumulate
-      ** dataLen, break. */
+
+
+
+
+
+
+
       while( pos < nSortKey ){
         const u8 *p0 = pSortKey + pos;
         const u8 *pZero = (const u8*)memchr(p0, 0x00, (size_t)(nSortKey - pos));
@@ -724,10 +724,10 @@ int recordFromSortKeyBuffer(
 
 
       aFieldPtr[nFields] = pSortKey + start;
-      /* Encoded length excludes the trailing 0x00 0x00 terminator
-      ** (subtract 2 from pos). Equal to dataLen iff no escape
-      ** sequences appeared — that case skips the byte-by-byte
-      ** un-escape loop below. */
+
+
+
+
       aEncLen[nFields] = (pos - 2) - start;
       nFields++;
 
@@ -780,9 +780,9 @@ int recordFromSortKeyBuffer(
         memcpy(pOut + off, aIntBuf[i], fieldLen);
         off += (int)fieldLen;
       }else if( (u32)aEncLen[i] == fieldLen ){
-        /* No escape sequences in the encoded text — most common
-        ** case for ASCII / hex / utf-8 keys without embedded NULs.
-        ** Skip the byte-by-byte un-escape loop and copy directly. */
+
+
+
         memcpy(pOut + off, aFieldPtr[i], fieldLen);
         off += (int)fieldLen;
       }else{

--- a/src/sortkey.c
+++ b/src/sortkey.c
@@ -44,12 +44,6 @@ static u8 serialTypeTag(u32 serialType){
   return SORTKEY_NULL;
 }
 
-
-
-
-
-
-
 #define SORTKEY_COLL_BINARY 0
 #define SORTKEY_COLL_NOCASE 1
 #define SORTKEY_COLL_RTRIM  2
@@ -123,10 +117,6 @@ static void encodeNumeric(u8 *pOut, u32 serialType, const u8 *pData, u32 nData){
     }else if( serialType == 9 ){
       v = 1;
     }else{
-
-
-
-
       u64 uv = (pData[0] & 0x80) ? (u64)-1 : 0;
       for(u32 i = 0; i < nData; i++){
         uv = (uv << 8) | pData[i];
@@ -141,7 +131,6 @@ static void encodeNumeric(u8 *pOut, u32 serialType, const u8 *pData, u32 nData){
     buf[4] = (u8)(x >> 24); buf[5] = (u8)(x >> 16);
     buf[6] = (u8)(x >> 8);  buf[7] = (u8)(x);
   }
-
 
   if( buf[0] & 0x80 ){
 
@@ -274,10 +263,6 @@ int sortKeyFromRecordPrefixCollBuffer(
   int nEstimate;
 
   *pnOut = 0;
-
-
-
-
 
   nEstimate = 9 * nRec + 16;
   if( nEstimate < 64 ) nEstimate = 64;
@@ -618,12 +603,6 @@ int recordFromSortKeyBuffer(
   u32 aLen[64];
 
   const u8 *aFieldPtr[64];
-
-
-
-
-
-
   int aEncLen[64];
   u8 aIntBuf[64][8];
   int nFields = 0;
@@ -663,7 +642,6 @@ int recordFromSortKeyBuffer(
     if( rc!=SQLITE_NOTFOUND ) return rc;
   }
 
-
   while( pos < nSortKey && nFields < 64 ){
     u8 tag = pSortKey[pos++];
 
@@ -687,16 +665,8 @@ int recordFromSortKeyBuffer(
 
     }else if( tag == SORTKEY_TEXT || tag == SORTKEY_BLOB ){
 
-
       int start = pos;
       int dataLen = 0;
-
-
-
-
-
-
-
       while( pos < nSortKey ){
         const u8 *p0 = pSortKey + pos;
         const u8 *pZero = (const u8*)memchr(p0, 0x00, (size_t)(nSortKey - pos));
@@ -724,12 +694,7 @@ int recordFromSortKeyBuffer(
       }
       aLen[nFields] = (u32)dataLen;
 
-
       aFieldPtr[nFields] = pSortKey + start;
-
-
-
-
       aEncLen[nFields] = (pos - 2) - start;
       nFields++;
 
@@ -737,7 +702,6 @@ int recordFromSortKeyBuffer(
       return SQLITE_CORRUPT;
     }
   }
-
 
   nHdr = 1;
   for(i = 0; i < nFields; i++){
@@ -757,16 +721,13 @@ int recordFromSortKeyBuffer(
   }
   pOut = *ppBuf;
 
-
   {
     int off;
-
 
     off = putVarint32(pOut, (u32)nHdr);
     for(i = 0; i < nFields; i++){
       off += putVarint32(pOut + off, aType[i]);
     }
-
 
     for(i = 0; i < nFields; i++){
       u32 serialType = aType[i];
@@ -782,9 +743,6 @@ int recordFromSortKeyBuffer(
         memcpy(pOut + off, aIntBuf[i], fieldLen);
         off += (int)fieldLen;
       }else if( (u32)aEncLen[i] == fieldLen ){
-
-
-
         memcpy(pOut + off, aFieldPtr[i], fieldLen);
         off += (int)fieldLen;
       }else{

--- a/test/doltlite_advanced.sh
+++ b/test/doltlite_advanced.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-#
-# Advanced coverage tests for Doltlite.
-# Covers: indexes, transactions, wide tables, empty tables, upserts,
-# multi-column updates, views, aggregates, complex merge scenarios,
-# working-change interactions, log/branch/tag metadata, and more.
-#
+
+
+
+
+
+
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
@@ -13,9 +13,9 @@ run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -
 echo "=== Doltlite Advanced Tests ==="
 echo ""
 
-# ============================================================
-# Section 1: Index tables and queries (6 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_adv_index_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, name TEXT, age INTEGER);
@@ -32,46 +32,46 @@ run_test "idx_query_name" "SELECT count(*) FROM t WHERE name='Alice';" "2" "$DB"
 run_test "idx_query_age" "SELECT count(*) FROM t WHERE age > 29;" "2" "$DB"
 run_test "idx_schema" "SELECT count(*) FROM sqlite_master WHERE type='index';" "2" "$DB"
 
-# Index survives commit + reopen
+
 run_test "idx_persist" "SELECT count(*) FROM sqlite_master WHERE type='index';" "2" "$DB"
 run_test "idx_query_persist" "SELECT count(*) FROM t WHERE name='Bob';" "1" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 2: Transactions with dolt operations (6 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_adv_txn_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'committed');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Rollback discards SQL changes
+
 echo "BEGIN;
 INSERT INTO t VALUES(2,'rollback_me');
 ROLLBACK;" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "txn_rollback" "SELECT count(*) FROM t;" "1" "$DB"
 
-# Commit inside transaction
+
 echo "BEGIN;
 INSERT INTO t VALUES(3,'txn_insert');
 COMMIT;" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "txn_commit" "SELECT count(*) FROM t;" "2" "$DB"
 
-# Dolt status sees the change
+
 run_test_match "txn_status" "SELECT count(*) FROM dolt_status;" "^[1-9]" "$DB"
 
-# Dolt commit captures it
+
 run_test_match "txn_dolt_commit" "SELECT dolt_commit('-A','-m','txn work');" "^[0-9a-f]{40}$" "$DB"
 run_test "txn_clean" "SELECT count(*) FROM dolt_status;" "0" "$DB"
 run_test "txn_log" "SELECT count(*) FROM dolt_log;" "3" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 3: Wide tables — many columns (5 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_adv_wide_$$.db; rm -f "$DB"
 echo "CREATE TABLE wide(
@@ -89,14 +89,14 @@ run_test "wide_col1" "SELECT c1 FROM wide WHERE id=1;" "a" "$DB"
 run_test "wide_col10" "SELECT c10 FROM wide WHERE id=2;" "t" "$DB"
 run_test "wide_int" "SELECT c11 FROM wide WHERE id=1;" "1" "$DB"
 
-# Persist
+
 run_test "wide_persist" "SELECT c5 FROM wide WHERE id=1;" "e" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 4: Empty table operations (6 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_adv_empty_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -106,7 +106,7 @@ run_test "empty_count" "SELECT count(*) FROM t;" "0" "$DB"
 run_test "empty_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 run_test "empty_diff" "SELECT count(*) FROM dolt_diff_t WHERE to_commit='WORKING';" "0" "$DB"
 
-# Branch empty table
+
 echo "SELECT dolt_branch('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(1,'feat_row');
@@ -114,16 +114,16 @@ SELECT dolt_commit('-A','-m','feat adds row');" | $DOLTLITE "$DB/feat" > /dev/nu
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# FF merge into empty table
+
 run_test_match "empty_ff_merge" "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB"
 run_test "empty_after_merge" "SELECT count(*) FROM t;" "1" "$DB"
 run_test "empty_merge_val" "SELECT v FROM t WHERE id=1;" "feat_row" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 5: Table with only primary key (4 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_adv_pkonly_$$.db; rm -f "$DB"
 echo "CREATE TABLE ids(id INTEGER PRIMARY KEY);
@@ -135,7 +135,7 @@ SELECT dolt_commit('-A','-m','pk only');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "pkonly_count" "SELECT count(*) FROM ids;" "3" "$DB"
 run_test "pkonly_sum" "SELECT sum(id) FROM ids;" "60" "$DB"
 
-# Add more and commit
+
 echo "INSERT INTO ids VALUES(40);
 INSERT INTO ids VALUES(50);
 SELECT dolt_commit('-A','-m','more ids');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -145,9 +145,9 @@ run_test "pkonly_log" "SELECT count(*) FROM dolt_log;" "3" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 6: REPLACE INTO / INSERT OR REPLACE (5 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_adv_replace_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -155,7 +155,7 @@ INSERT INTO t VALUES(1,'original');
 INSERT INTO t VALUES(2,'keep');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Replace existing row
+
 echo "REPLACE INTO t VALUES(1,'replaced');
 SELECT dolt_commit('-A','-m','replace');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
@@ -163,7 +163,7 @@ run_test "replace_val" "SELECT v FROM t WHERE id=1;" "replaced" "$DB"
 run_test "replace_count" "SELECT count(*) FROM t;" "2" "$DB"
 run_test "replace_other" "SELECT v FROM t WHERE id=2;" "keep" "$DB"
 
-# INSERT OR REPLACE
+
 echo "INSERT OR REPLACE INTO t VALUES(2,'or_replaced');
 SELECT dolt_commit('-A','-m','or replace');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
@@ -172,16 +172,16 @@ run_test "or_replace_log" "SELECT count(*) FROM dolt_log;" "4" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 7: INSERT OR IGNORE (4 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_adv_ignore_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'first');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Insert or ignore duplicate — should silently skip
+
 echo "INSERT OR IGNORE INTO t VALUES(1,'duplicate');
 INSERT OR IGNORE INTO t VALUES(2,'new');
 SELECT dolt_commit('-A','-m','ignore test');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -193,9 +193,9 @@ run_test "ignore_log" "SELECT count(*) FROM dolt_log;" "3" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 8: Multi-column updates in merge (6 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_adv_multicol_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, a TEXT, b TEXT, c TEXT);
@@ -203,13 +203,13 @@ INSERT INTO t VALUES(1,'x','y','z');
 INSERT INTO t VALUES(2,'x','y','z');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Branch updates column a on row 1
+
 echo "SELECT dolt_branch('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "UPDATE t SET a='feat_a' WHERE id=1;
 SELECT dolt_commit('-A','-m','feat: update a');" | $DOLTLITE "$DB/feat" > /dev/null 2>&1
 
-# Main updates column c on row 2
+
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "UPDATE t SET c='main_c' WHERE id=2;
 SELECT dolt_commit('-A','-m','main: update c');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -223,9 +223,9 @@ run_test "multicol_count" "SELECT count(*) FROM t;" "2" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 9: Aggregate queries after merge (4 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_adv_agg_$$.db; rm -f "$DB"
 echo "CREATE TABLE sales(id INTEGER PRIMARY KEY, amount INTEGER, region TEXT);
@@ -251,9 +251,9 @@ run_test "agg_group" "SELECT sum(amount) FROM sales WHERE region='east';" "250" 
 
 rm -f "$DB"
 
-# ============================================================
-# Section 10: Views with dolt (4 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_adv_view_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT, score INTEGER);
@@ -266,26 +266,26 @@ SELECT dolt_commit('-A','-m','with view');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "view_count" "SELECT count(*) FROM high_scores;" "2" "$DB"
 run_test "view_schema" "SELECT count(*) FROM sqlite_master WHERE type='view';" "1" "$DB"
 
-# View persists
+
 run_test "view_persist" "SELECT count(*) FROM high_scores;" "2" "$DB"
 
-# Add data, view updates
+
 echo "INSERT INTO t VALUES(4,'d',25);
 SELECT dolt_commit('-A','-m','add d');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "view_updated" "SELECT count(*) FROM high_scores;" "3" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 11: Multiple updates to same row before commit (4 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_adv_multiupd_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'first');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Update same row 3 times, then commit — final value should win
+
 echo "UPDATE t SET v='second' WHERE id=1;
 UPDATE t SET v='third' WHERE id=1;
 UPDATE t SET v='final' WHERE id=1;
@@ -294,7 +294,7 @@ SELECT dolt_commit('-A','-m','multi update');" | $DOLTLITE "$DB" > /dev/null 2>&
 run_test "multiupd_val" "SELECT v FROM t WHERE id=1;" "final" "$DB"
 run_test "multiupd_count" "SELECT count(*) FROM t;" "1" "$DB"
 
-# Diff should show 1 change (from first to final)
+
 run_test_match "multiupd_diff" \
   "SELECT coalesce(sum(rows_added + rows_deleted + rows_modified), 0) FROM dolt_diff_stat((SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1), (SELECT commit_hash FROM dolt_log LIMIT 1), 't');" \
   "^1$" "$DB"
@@ -302,16 +302,16 @@ run_test "multiupd_log" "SELECT count(*) FROM dolt_log;" "3" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 12: Insert, update, delete same row before commit (4 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_adv_lifecycle_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'keep');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Insert row 2, update it, delete it — net effect: nothing
+
 echo "INSERT INTO t VALUES(2,'temp');
 UPDATE t SET v='temp_updated' WHERE id=2;
 DELETE FROM t WHERE id=2;
@@ -320,7 +320,7 @@ SELECT dolt_commit('-A','-m','noop cycle');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "lifecycle_count" "SELECT count(*) FROM t;" "1" "$DB"
 run_test "lifecycle_orig" "SELECT v FROM t WHERE id=1;" "keep" "$DB"
 
-# Insert and keep
+
 echo "INSERT INTO t VALUES(3,'new');
 UPDATE t SET v='updated_new' WHERE id=3;
 SELECT dolt_commit('-A','-m','insert and update');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -330,13 +330,13 @@ run_test "lifecycle_final_count" "SELECT count(*) FROM t;" "2" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 13: Large text values (4 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_adv_largetext_$$.db; rm -f "$DB"
 
-# Generate a ~10KB string
+
 BIGVAL=$(python3 -c "print('x' * 10000)" 2>/dev/null || printf '%0.sx' $(seq 1 10000))
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'${BIGVAL}');
@@ -347,33 +347,33 @@ run_test "large_length" "SELECT length(v) FROM t WHERE id=1;" "10000" "$DB"
 run_test "large_small" "SELECT v FROM t WHERE id=2;" "small" "$DB"
 run_test "large_count" "SELECT count(*) FROM t;" "2" "$DB"
 
-# Persist
+
 run_test "large_persist" "SELECT length(v) FROM t WHERE id=1;" "10000" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 14: dolt_log metadata columns (5 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_adv_logmeta_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
 INSERT INTO t VALUES(1);
 SELECT dolt_commit('-A','-m','test message','--author','LogTest <log@test.com>');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Check all log columns
+
 run_test_match "logmeta_hash" "SELECT commit_hash FROM dolt_log LIMIT 1;" "^[0-9a-f]{40}$" "$DB"
 run_test "logmeta_committer" "SELECT committer FROM dolt_log LIMIT 1;" "LogTest" "$DB"
 run_test "logmeta_email" "SELECT email FROM dolt_log LIMIT 1;" "log@test.com" "$DB"
 run_test "logmeta_message" "SELECT message FROM dolt_log LIMIT 1;" "test message" "$DB"
-# date should be a reasonable timestamp (> year 2020)
+
 run_test_match "logmeta_date" "SELECT date FROM dolt_log LIMIT 1;" "^[0-9]" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 15: dolt_branches metadata (5 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_adv_branchmeta_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
@@ -385,11 +385,11 @@ echo "SELECT dolt_branch('dev');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "branchmeta_count" "SELECT count(*) FROM dolt_branches;" "2" "$DB"
 run_test_match "branchmeta_hash" "SELECT hash FROM dolt_branches WHERE name='main';" "^[0-9a-f]{40}$" "$DB"
 
-# Both branches point to same commit (no divergence yet)
+
 run_test "branchmeta_same_hash" \
   "SELECT count(DISTINCT hash) FROM dolt_branches;" "1" "$DB"
 
-# Make a commit on dev — hashes should diverge
+
 echo "SELECT dolt_checkout('dev');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(2); SELECT dolt_commit('-A','-m','dev commit');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -401,9 +401,9 @@ run_test_match "branchmeta_names" \
 
 rm -f "$DB"
 
-# ============================================================
-# Section 16: dolt_tags metadata (4 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_adv_tagmeta_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
@@ -423,9 +423,9 @@ run_test_match "tagmeta_names" \
 
 rm -f "$DB"
 
-# ============================================================
-# Section 17: Schema-only commit (no data changes) (4 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_adv_schemaonly_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -434,7 +434,7 @@ SELECT dolt_commit('-A','-m','empty schema');" | $DOLTLITE "$DB" > /dev/null 2>&
 run_test "schemaonly_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 run_test "schemaonly_count" "SELECT count(*) FROM t;" "0" "$DB"
 
-# Add another table (schema change, no data)
+
 echo "CREATE TABLE t2(id INTEGER PRIMARY KEY);
 SELECT dolt_commit('-A','-m','add t2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
@@ -443,9 +443,9 @@ run_test "schemaonly_tables" "SELECT count(*) FROM sqlite_master WHERE type='tab
 
 rm -f "$DB"
 
-# ============================================================
-# Section 18: Checkout preserves other branch data (5 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_adv_checkout_preserve_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -457,7 +457,7 @@ echo "SELECT dolt_checkout('dev');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(2,'dev_data');
 SELECT dolt_commit('-A','-m','dev work');" | $DOLTLITE "$DB/dev" > /dev/null 2>&1
 
-# Switch back and forth — data should be correct each time
+
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "preserve_main1" "SELECT count(*) FROM t;" "1" "$DB"
 
@@ -473,28 +473,28 @@ run_test "preserve_dev_val" "SELECT v FROM t WHERE id=2;" "dev_data" "$DB/dev"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 19: dolt_status after CREATE TABLE (4 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_adv_createstatus_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Create new table — should show in status
+
 echo "CREATE TABLE t2(id INTEGER PRIMARY KEY, v TEXT);" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "createstatus_shows" "SELECT count(*) FROM dolt_status;" "^[1-9]" "$DB"
 run_test_match "createstatus_name" "SELECT table_name FROM dolt_status LIMIT 1;" "t2" "$DB"
 
-# Commit it
+
 run_test_match "createstatus_commit" "SELECT dolt_commit('-A','-m','add t2');" "^[0-9a-f]{40}$" "$DB"
 run_test "createstatus_clean" "SELECT count(*) FROM dolt_status;" "0" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 20: Subqueries with dolt system tables (4 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_adv_subquery_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -505,7 +505,7 @@ SELECT dolt_commit('-A','-m','c2');
 INSERT INTO t VALUES(3,'c');
 SELECT dolt_commit('-A','-m','c3');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Subquery on dolt_log
+
 run_test "subq_latest" \
   "SELECT message FROM dolt_log WHERE commit_hash = (SELECT commit_hash FROM dolt_log LIMIT 1);" \
   "c3" "$DB"
@@ -513,20 +513,20 @@ run_test "subq_latest" \
 run_test "subq_count_after" \
   "SELECT count(*) FROM dolt_log WHERE message LIKE 'c%';" "3" "$DB"
 
-# Tag the first commit using subquery
+
 echo "SELECT dolt_tag('first', (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 2));" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "subq_tag" "SELECT count(*) FROM dolt_tags;" "1" "$DB"
 
-# Diff using subquery for hashes
+
 run_test_match "subq_diff" \
   "SELECT coalesce(sum(rows_added + rows_deleted + rows_modified), 0) FROM dolt_diff_stat((SELECT tag_hash FROM dolt_tags WHERE tag_name='first'), (SELECT commit_hash FROM dolt_log LIMIT 1), 't');" \
   "^[1-9]" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 21: ORDER BY on dolt_log (4 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_adv_logorder_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
@@ -534,19 +534,19 @@ INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','first');
 INSERT INTO t VALUES(2); SELECT dolt_commit('-A','-m','second');
 INSERT INTO t VALUES(3); SELECT dolt_commit('-A','-m','third');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Default order: newest first
+
 run_test "logorder_first" "SELECT message FROM dolt_log LIMIT 1;" "third" "$DB"
 run_test "logorder_last" "SELECT message FROM dolt_log LIMIT 1 OFFSET 2;" "first" "$DB"
 
-# Count and offset
+
 run_test "logorder_offset1" "SELECT message FROM dolt_log LIMIT 1 OFFSET 1;" "second" "$DB"
 run_test "logorder_total" "SELECT count(*) FROM dolt_log;" "4" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 22: Working changes across multiple tables (5 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_adv_multiwork_$$.db; rm -f "$DB"
 echo "CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
@@ -557,27 +557,27 @@ INSERT INTO orders VALUES(1,1,'widget');
 INSERT INTO products VALUES(1,'Widget',10);
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Make changes to all 3 tables
+
 echo "INSERT INTO users VALUES(2,'Bob');
 INSERT INTO orders VALUES(2,2,'gadget');
 INSERT INTO products VALUES(2,'Gadget',20);" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "multiwork_status" "SELECT count(*) FROM dolt_status;" "3" "$DB"
 
-# Stage only users
+
 echo "SELECT dolt_add('users');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "multiwork_staged" "SELECT count(*) FROM dolt_status WHERE staged=1;" "1" "$DB"
 run_test "multiwork_unstaged" "SELECT count(*) FROM dolt_status WHERE staged=0;" "2" "$DB"
 
-# Commit all
+
 run_test_match "multiwork_commit" "SELECT dolt_commit('-A','-m','all 3');" "^[0-9a-f]{40}$" "$DB"
 run_test "multiwork_clean" "SELECT count(*) FROM dolt_status;" "0" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 23: Reset after staging specific tables (4 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_adv_resetstage_$$.db; rm -f "$DB"
 echo "CREATE TABLE a(id INTEGER PRIMARY KEY, v TEXT);
@@ -589,31 +589,31 @@ SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO a VALUES(2,'a2');
 INSERT INTO b VALUES(2,'b2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Stage only a
+
 echo "SELECT dolt_add('a');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# No-args reset (== --mixed) — unstage a but keep all data
+
 echo "SELECT dolt_reset();" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "resetstage_unstaged" "SELECT count(*) FROM dolt_status WHERE staged=1;" "0" "$DB"
 run_test "resetstage_data_a" "SELECT count(*) FROM a;" "2" "$DB"
 run_test "resetstage_data_b" "SELECT count(*) FROM b;" "2" "$DB"
 
-# Hard reset — discard all
+
 echo "SELECT dolt_reset('--hard');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "resetstage_hard" "SELECT count(*) FROM a;" "1" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 24: Double merge (merge A then merge B) (5 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_adv_doublemerge_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'init');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Create two feature branches from same point
+
 echo "SELECT dolt_branch('featA');
 SELECT dolt_branch('featB');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
@@ -623,21 +623,21 @@ echo "INSERT INTO t VALUES(10,'A'); SELECT dolt_commit('-A','-m','featA');" | $D
 echo "SELECT dolt_checkout('featB');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(20,'B'); SELECT dolt_commit('-A','-m','featB');" | $DOLTLITE "$DB/featB" > /dev/null 2>&1
 
-# Merge A into main
+
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "doublemerge_A" "SELECT dolt_merge('featA');" "^[0-9a-f]{40}$" "$DB"
 run_test "doublemerge_A_count" "SELECT count(*) FROM t;" "2" "$DB"
 
-# Merge B into main (main now has init + A, merging B which has init + B)
+
 run_test_match "doublemerge_B" "SELECT dolt_merge('featB');" "^[0-9a-f]{40}$" "$DB"
 run_test "doublemerge_B_count" "SELECT count(*) FROM t;" "3" "$DB"
 run_test "doublemerge_all" "SELECT group_concat(v) FROM (SELECT v FROM t ORDER BY id);" "init,A,B" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 25: dolt_add('.') behavior (4 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_adv_adddot_$$.db; rm -f "$DB"
 echo "CREATE TABLE a(id INTEGER PRIMARY KEY, v TEXT);
@@ -649,20 +649,20 @@ SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO a VALUES(2,'a2');
 INSERT INTO b VALUES(2,'b2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# dolt_add('.') should stage all
+
 echo "SELECT dolt_add('.');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "adddot_all_staged" "SELECT count(*) FROM dolt_status WHERE staged=1;" "2" "$DB"
 run_test "adddot_none_unstaged" "SELECT count(*) FROM dolt_status WHERE staged=0;" "0" "$DB"
 
-# Commit with staged
+
 run_test_match "adddot_commit" "SELECT dolt_commit('-m','dot staged');" "^[0-9a-f]{40}$" "$DB"
 run_test "adddot_clean" "SELECT count(*) FROM dolt_status;" "0" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 26: Merge where only one side changed (not FF) (4 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_adv_onesidemerge_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -671,30 +671,30 @@ SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 echo "SELECT dolt_branch('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Only main changes
+
 echo "INSERT INTO t VALUES(2,'main_only');
 SELECT dolt_commit('-A','-m','main adds');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Merge feat (which is behind) — should see "Already up to date" since
-# feat is ancestor of main — merge is a no-op or returns hash
+
+
 run_test_match "oneside_merge" "SELECT dolt_merge('feat');" "up to date|^[0-9a-f]{40}$" "$DB"
 run_test "oneside_count" "SELECT count(*) FROM t;" "2" "$DB"
 
-# Now make feat ahead: checkout feat, add data, merge into main
+
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(3,'feat_only');
 SELECT dolt_commit('-A','-m','feat adds');" | $DOLTLITE "$DB/feat" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Now merge feat into main — three-way merge needed
+
 run_test_match "oneside_real_merge" "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB"
 run_test "oneside_all_rows" "SELECT count(*) FROM t;" "3" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 27: COALESCE, CASE, complex expressions (4 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_adv_expr_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, a TEXT, b TEXT);
@@ -712,9 +712,9 @@ run_test "expr_case" \
 
 rm -f "$DB"
 
-# ============================================================
-# Section 28: Merge with index tables (4 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_adv_mergeidx_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, name TEXT, val INTEGER);
@@ -733,7 +733,7 @@ echo "INSERT INTO t VALUES(4,'d',5);
 SELECT dolt_commit('-A','-m','main add');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test_match "mergeidx_merge" "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB"
-# Verify all rows present (check individual rows, not count which may use index)
+
 run_test "mergeidx_row1" "SELECT name FROM t WHERE id=1;" "a" "$DB"
 run_test "mergeidx_row3" "SELECT name FROM t WHERE id=3;" "c" "$DB"
 run_test "mergeidx_row4" "SELECT name FROM t WHERE id=4;" "d" "$DB"
@@ -741,9 +741,9 @@ run_test "mergeidx_schema" "SELECT count(*) FROM sqlite_master WHERE type='index
 
 rm -f "$DB"
 
-# ============================================================
-# Section 29: Unique constraints with dolt (4 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_adv_unique_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, email TEXT UNIQUE, name TEXT);
@@ -753,11 +753,11 @@ SELECT dolt_commit('-A','-m','with unique');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "unique_count" "SELECT count(*) FROM t;" "2" "$DB"
 
-# Unique constraint enforced
+
 run_test_match "unique_violate" \
   "INSERT INTO t VALUES(3,'alice@test.com','Fake');" "UNIQUE constraint" "$DB"
 
-# Update respects unique
+
 echo "UPDATE t SET name='Alice Updated' WHERE id=1;
 SELECT dolt_commit('-A','-m','update alice');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "unique_updated" "SELECT name FROM t WHERE id=1;" "Alice Updated" "$DB"
@@ -765,9 +765,9 @@ run_test "unique_persist" "SELECT count(*) FROM t;" "2" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 30: NOT NULL constraints with dolt (4 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_adv_notnull_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, name TEXT NOT NULL, score INTEGER DEFAULT 0);
@@ -777,11 +777,11 @@ SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "notnull_count" "SELECT count(*) FROM t;" "2" "$DB"
 
-# NOT NULL enforced
+
 run_test_match "notnull_violate" \
   "INSERT INTO t VALUES(3,NULL,50);" "NOT NULL" "$DB"
 
-# Default value works
+
 echo "INSERT INTO t(id,name) VALUES(4,'Charlie');
 SELECT dolt_commit('-A','-m','with default');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "notnull_default" "SELECT score FROM t WHERE id=4;" "0" "$DB"
@@ -789,9 +789,9 @@ run_test "notnull_persist" "SELECT count(*) FROM t;" "3" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 31: Complex join queries after dolt operations (4 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_adv_join_$$.db; rm -f "$DB"
 echo "CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
@@ -810,7 +810,7 @@ run_test "join_alice" \
 run_test "join_bob" \
   "SELECT count(*) FROM users u JOIN orders o ON u.id=o.uid WHERE u.name='Bob';" "1" "$DB"
 
-# Add data and verify join after commit
+
 echo "INSERT INTO users VALUES(3,'Charlie');
 INSERT INTO orders VALUES(4,3,'Doohickey');
 SELECT dolt_commit('-A','-m','add charlie');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -820,9 +820,9 @@ run_test "join_after_commit" \
 
 rm -f "$DB"
 
-# ============================================================
-# Done
-# ============================================================
+
+
+
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/doltlite_advanced.sh
+++ b/test/doltlite_advanced.sh
@@ -1,10 +1,4 @@
 #!/bin/bash
-
-
-
-
-
-
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
@@ -12,10 +6,6 @@ run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -
 
 echo "=== Doltlite Advanced Tests ==="
 echo ""
-
-
-
-
 
 DB=/tmp/test_adv_index_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, name TEXT, age INTEGER);
@@ -32,46 +22,33 @@ run_test "idx_query_name" "SELECT count(*) FROM t WHERE name='Alice';" "2" "$DB"
 run_test "idx_query_age" "SELECT count(*) FROM t WHERE age > 29;" "2" "$DB"
 run_test "idx_schema" "SELECT count(*) FROM sqlite_master WHERE type='index';" "2" "$DB"
 
-
 run_test "idx_persist" "SELECT count(*) FROM sqlite_master WHERE type='index';" "2" "$DB"
 run_test "idx_query_persist" "SELECT count(*) FROM t WHERE name='Bob';" "1" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_adv_txn_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'committed');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 echo "BEGIN;
 INSERT INTO t VALUES(2,'rollback_me');
 ROLLBACK;" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "txn_rollback" "SELECT count(*) FROM t;" "1" "$DB"
-
 
 echo "BEGIN;
 INSERT INTO t VALUES(3,'txn_insert');
 COMMIT;" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "txn_commit" "SELECT count(*) FROM t;" "2" "$DB"
 
-
 run_test_match "txn_status" "SELECT count(*) FROM dolt_status;" "^[1-9]" "$DB"
-
 
 run_test_match "txn_dolt_commit" "SELECT dolt_commit('-A','-m','txn work');" "^[0-9a-f]{40}$" "$DB"
 run_test "txn_clean" "SELECT count(*) FROM dolt_status;" "0" "$DB"
 run_test "txn_log" "SELECT count(*) FROM dolt_log;" "3" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_adv_wide_$$.db; rm -f "$DB"
 echo "CREATE TABLE wide(
@@ -89,14 +66,9 @@ run_test "wide_col1" "SELECT c1 FROM wide WHERE id=1;" "a" "$DB"
 run_test "wide_col10" "SELECT c10 FROM wide WHERE id=2;" "t" "$DB"
 run_test "wide_int" "SELECT c11 FROM wide WHERE id=1;" "1" "$DB"
 
-
 run_test "wide_persist" "SELECT c5 FROM wide WHERE id=1;" "e" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_adv_empty_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -106,7 +78,6 @@ run_test "empty_count" "SELECT count(*) FROM t;" "0" "$DB"
 run_test "empty_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 run_test "empty_diff" "SELECT count(*) FROM dolt_diff_t WHERE to_commit='WORKING';" "0" "$DB"
 
-
 echo "SELECT dolt_branch('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(1,'feat_row');
@@ -114,16 +85,11 @@ SELECT dolt_commit('-A','-m','feat adds row');" | $DOLTLITE "$DB/feat" > /dev/nu
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test_match "empty_ff_merge" "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB"
 run_test "empty_after_merge" "SELECT count(*) FROM t;" "1" "$DB"
 run_test "empty_merge_val" "SELECT v FROM t WHERE id=1;" "feat_row" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_adv_pkonly_$$.db; rm -f "$DB"
 echo "CREATE TABLE ids(id INTEGER PRIMARY KEY);
@@ -135,7 +101,6 @@ SELECT dolt_commit('-A','-m','pk only');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "pkonly_count" "SELECT count(*) FROM ids;" "3" "$DB"
 run_test "pkonly_sum" "SELECT sum(id) FROM ids;" "60" "$DB"
 
-
 echo "INSERT INTO ids VALUES(40);
 INSERT INTO ids VALUES(50);
 SELECT dolt_commit('-A','-m','more ids');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -145,16 +110,11 @@ run_test "pkonly_log" "SELECT count(*) FROM dolt_log;" "3" "$DB"
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_adv_replace_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'original');
 INSERT INTO t VALUES(2,'keep');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 echo "REPLACE INTO t VALUES(1,'replaced');
 SELECT dolt_commit('-A','-m','replace');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -162,7 +122,6 @@ SELECT dolt_commit('-A','-m','replace');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "replace_val" "SELECT v FROM t WHERE id=1;" "replaced" "$DB"
 run_test "replace_count" "SELECT count(*) FROM t;" "2" "$DB"
 run_test "replace_other" "SELECT v FROM t WHERE id=2;" "keep" "$DB"
-
 
 echo "INSERT OR REPLACE INTO t VALUES(2,'or_replaced');
 SELECT dolt_commit('-A','-m','or replace');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -172,15 +131,10 @@ run_test "or_replace_log" "SELECT count(*) FROM dolt_log;" "4" "$DB"
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_adv_ignore_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'first');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 echo "INSERT OR IGNORE INTO t VALUES(1,'duplicate');
 INSERT OR IGNORE INTO t VALUES(2,'new');
@@ -193,22 +147,16 @@ run_test "ignore_log" "SELECT count(*) FROM dolt_log;" "3" "$DB"
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_adv_multicol_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, a TEXT, b TEXT, c TEXT);
 INSERT INTO t VALUES(1,'x','y','z');
 INSERT INTO t VALUES(2,'x','y','z');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 echo "SELECT dolt_branch('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "UPDATE t SET a='feat_a' WHERE id=1;
 SELECT dolt_commit('-A','-m','feat: update a');" | $DOLTLITE "$DB/feat" > /dev/null 2>&1
-
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "UPDATE t SET c='main_c' WHERE id=2;
@@ -222,10 +170,6 @@ run_test "multicol_row2_a" "SELECT a FROM t WHERE id=2;" "x" "$DB"
 run_test "multicol_count" "SELECT count(*) FROM t;" "2" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_adv_agg_$$.db; rm -f "$DB"
 echo "CREATE TABLE sales(id INTEGER PRIMARY KEY, amount INTEGER, region TEXT);
@@ -251,10 +195,6 @@ run_test "agg_group" "SELECT sum(amount) FROM sales WHERE region='east';" "250" 
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_adv_view_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT, score INTEGER);
 INSERT INTO t VALUES(1,'a',10);
@@ -266,9 +206,7 @@ SELECT dolt_commit('-A','-m','with view');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "view_count" "SELECT count(*) FROM high_scores;" "2" "$DB"
 run_test "view_schema" "SELECT count(*) FROM sqlite_master WHERE type='view';" "1" "$DB"
 
-
 run_test "view_persist" "SELECT count(*) FROM high_scores;" "2" "$DB"
-
 
 echo "INSERT INTO t VALUES(4,'d',25);
 SELECT dolt_commit('-A','-m','add d');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -276,15 +214,10 @@ run_test "view_updated" "SELECT count(*) FROM high_scores;" "3" "$DB"
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_adv_multiupd_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'first');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 echo "UPDATE t SET v='second' WHERE id=1;
 UPDATE t SET v='third' WHERE id=1;
@@ -294,7 +227,6 @@ SELECT dolt_commit('-A','-m','multi update');" | $DOLTLITE "$DB" > /dev/null 2>&
 run_test "multiupd_val" "SELECT v FROM t WHERE id=1;" "final" "$DB"
 run_test "multiupd_count" "SELECT count(*) FROM t;" "1" "$DB"
 
-
 run_test_match "multiupd_diff" \
   "SELECT coalesce(sum(rows_added + rows_deleted + rows_modified), 0) FROM dolt_diff_stat((SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1), (SELECT commit_hash FROM dolt_log LIMIT 1), 't');" \
   "^1$" "$DB"
@@ -302,15 +234,10 @@ run_test "multiupd_log" "SELECT count(*) FROM dolt_log;" "3" "$DB"
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_adv_lifecycle_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'keep');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 echo "INSERT INTO t VALUES(2,'temp');
 UPDATE t SET v='temp_updated' WHERE id=2;
@@ -319,7 +246,6 @@ SELECT dolt_commit('-A','-m','noop cycle');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "lifecycle_count" "SELECT count(*) FROM t;" "1" "$DB"
 run_test "lifecycle_orig" "SELECT v FROM t WHERE id=1;" "keep" "$DB"
-
 
 echo "INSERT INTO t VALUES(3,'new');
 UPDATE t SET v='updated_new' WHERE id=3;
@@ -330,12 +256,7 @@ run_test "lifecycle_final_count" "SELECT count(*) FROM t;" "2" "$DB"
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_adv_largetext_$$.db; rm -f "$DB"
-
 
 BIGVAL=$(python3 -c "print('x' * 10000)" 2>/dev/null || printf '%0.sx' $(seq 1 10000))
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -347,33 +268,22 @@ run_test "large_length" "SELECT length(v) FROM t WHERE id=1;" "10000" "$DB"
 run_test "large_small" "SELECT v FROM t WHERE id=2;" "small" "$DB"
 run_test "large_count" "SELECT count(*) FROM t;" "2" "$DB"
 
-
 run_test "large_persist" "SELECT length(v) FROM t WHERE id=1;" "10000" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_adv_logmeta_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
 INSERT INTO t VALUES(1);
 SELECT dolt_commit('-A','-m','test message','--author','LogTest <log@test.com>');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test_match "logmeta_hash" "SELECT commit_hash FROM dolt_log LIMIT 1;" "^[0-9a-f]{40}$" "$DB"
 run_test "logmeta_committer" "SELECT committer FROM dolt_log LIMIT 1;" "LogTest" "$DB"
 run_test "logmeta_email" "SELECT email FROM dolt_log LIMIT 1;" "log@test.com" "$DB"
 run_test "logmeta_message" "SELECT message FROM dolt_log LIMIT 1;" "test message" "$DB"
-
 run_test_match "logmeta_date" "SELECT date FROM dolt_log LIMIT 1;" "^[0-9]" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_adv_branchmeta_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
@@ -385,10 +295,8 @@ echo "SELECT dolt_branch('dev');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "branchmeta_count" "SELECT count(*) FROM dolt_branches;" "2" "$DB"
 run_test_match "branchmeta_hash" "SELECT hash FROM dolt_branches WHERE name='main';" "^[0-9a-f]{40}$" "$DB"
 
-
 run_test "branchmeta_same_hash" \
   "SELECT count(DISTINCT hash) FROM dolt_branches;" "1" "$DB"
-
 
 echo "SELECT dolt_checkout('dev');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(2); SELECT dolt_commit('-A','-m','dev commit');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -400,10 +308,6 @@ run_test_match "branchmeta_names" \
   "SELECT group_concat(name) FROM (SELECT name FROM dolt_branches ORDER BY name);" "dev.*main" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_adv_tagmeta_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
@@ -423,17 +327,12 @@ run_test_match "tagmeta_names" \
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_adv_schemaonly_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 SELECT dolt_commit('-A','-m','empty schema');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "schemaonly_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 run_test "schemaonly_count" "SELECT count(*) FROM t;" "0" "$DB"
-
 
 echo "CREATE TABLE t2(id INTEGER PRIMARY KEY);
 SELECT dolt_commit('-A','-m','add t2');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -442,10 +341,6 @@ run_test "schemaonly_log2" "SELECT count(*) FROM dolt_log;" "3" "$DB"
 run_test "schemaonly_tables" "SELECT count(*) FROM sqlite_master WHERE type='table';" "2" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_adv_checkout_preserve_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -456,7 +351,6 @@ echo "SELECT dolt_branch('dev');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('dev');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(2,'dev_data');
 SELECT dolt_commit('-A','-m','dev work');" | $DOLTLITE "$DB/dev" > /dev/null 2>&1
-
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "preserve_main1" "SELECT count(*) FROM t;" "1" "$DB"
@@ -473,28 +367,18 @@ run_test "preserve_dev_val" "SELECT v FROM t WHERE id=2;" "dev_data" "$DB/dev"
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_adv_createstatus_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 echo "CREATE TABLE t2(id INTEGER PRIMARY KEY, v TEXT);" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "createstatus_shows" "SELECT count(*) FROM dolt_status;" "^[1-9]" "$DB"
 run_test_match "createstatus_name" "SELECT table_name FROM dolt_status LIMIT 1;" "t2" "$DB"
 
-
 run_test_match "createstatus_commit" "SELECT dolt_commit('-A','-m','add t2');" "^[0-9a-f]{40}$" "$DB"
 run_test "createstatus_clean" "SELECT count(*) FROM dolt_status;" "0" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_adv_subquery_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -505,7 +389,6 @@ SELECT dolt_commit('-A','-m','c2');
 INSERT INTO t VALUES(3,'c');
 SELECT dolt_commit('-A','-m','c3');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "subq_latest" \
   "SELECT message FROM dolt_log WHERE commit_hash = (SELECT commit_hash FROM dolt_log LIMIT 1);" \
   "c3" "$DB"
@@ -513,10 +396,8 @@ run_test "subq_latest" \
 run_test "subq_count_after" \
   "SELECT count(*) FROM dolt_log WHERE message LIKE 'c%';" "3" "$DB"
 
-
 echo "SELECT dolt_tag('first', (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 2));" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "subq_tag" "SELECT count(*) FROM dolt_tags;" "1" "$DB"
-
 
 run_test_match "subq_diff" \
   "SELECT coalesce(sum(rows_added + rows_deleted + rows_modified), 0) FROM dolt_diff_stat((SELECT tag_hash FROM dolt_tags WHERE tag_name='first'), (SELECT commit_hash FROM dolt_log LIMIT 1), 't');" \
@@ -524,29 +405,19 @@ run_test_match "subq_diff" \
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_adv_logorder_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
 INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','first');
 INSERT INTO t VALUES(2); SELECT dolt_commit('-A','-m','second');
 INSERT INTO t VALUES(3); SELECT dolt_commit('-A','-m','third');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "logorder_first" "SELECT message FROM dolt_log LIMIT 1;" "third" "$DB"
 run_test "logorder_last" "SELECT message FROM dolt_log LIMIT 1 OFFSET 2;" "first" "$DB"
-
 
 run_test "logorder_offset1" "SELECT message FROM dolt_log LIMIT 1 OFFSET 1;" "second" "$DB"
 run_test "logorder_total" "SELECT count(*) FROM dolt_log;" "4" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_adv_multiwork_$$.db; rm -f "$DB"
 echo "CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
@@ -557,27 +428,20 @@ INSERT INTO orders VALUES(1,1,'widget');
 INSERT INTO products VALUES(1,'Widget',10);
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 echo "INSERT INTO users VALUES(2,'Bob');
 INSERT INTO orders VALUES(2,2,'gadget');
 INSERT INTO products VALUES(2,'Gadget',20);" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "multiwork_status" "SELECT count(*) FROM dolt_status;" "3" "$DB"
 
-
 echo "SELECT dolt_add('users');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "multiwork_staged" "SELECT count(*) FROM dolt_status WHERE staged=1;" "1" "$DB"
 run_test "multiwork_unstaged" "SELECT count(*) FROM dolt_status WHERE staged=0;" "2" "$DB"
-
 
 run_test_match "multiwork_commit" "SELECT dolt_commit('-A','-m','all 3');" "^[0-9a-f]{40}$" "$DB"
 run_test "multiwork_clean" "SELECT count(*) FROM dolt_status;" "0" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_adv_resetstage_$$.db; rm -f "$DB"
 echo "CREATE TABLE a(id INTEGER PRIMARY KEY, v TEXT);
@@ -589,30 +453,22 @@ SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO a VALUES(2,'a2');
 INSERT INTO b VALUES(2,'b2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 echo "SELECT dolt_add('a');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 echo "SELECT dolt_reset();" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "resetstage_unstaged" "SELECT count(*) FROM dolt_status WHERE staged=1;" "0" "$DB"
 run_test "resetstage_data_a" "SELECT count(*) FROM a;" "2" "$DB"
 run_test "resetstage_data_b" "SELECT count(*) FROM b;" "2" "$DB"
 
-
 echo "SELECT dolt_reset('--hard');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "resetstage_hard" "SELECT count(*) FROM a;" "1" "$DB"
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_adv_doublemerge_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'init');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 echo "SELECT dolt_branch('featA');
 SELECT dolt_branch('featB');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -623,21 +479,15 @@ echo "INSERT INTO t VALUES(10,'A'); SELECT dolt_commit('-A','-m','featA');" | $D
 echo "SELECT dolt_checkout('featB');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(20,'B'); SELECT dolt_commit('-A','-m','featB');" | $DOLTLITE "$DB/featB" > /dev/null 2>&1
 
-
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "doublemerge_A" "SELECT dolt_merge('featA');" "^[0-9a-f]{40}$" "$DB"
 run_test "doublemerge_A_count" "SELECT count(*) FROM t;" "2" "$DB"
-
 
 run_test_match "doublemerge_B" "SELECT dolt_merge('featB');" "^[0-9a-f]{40}$" "$DB"
 run_test "doublemerge_B_count" "SELECT count(*) FROM t;" "3" "$DB"
 run_test "doublemerge_all" "SELECT group_concat(v) FROM (SELECT v FROM t ORDER BY id);" "init,A,B" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_adv_adddot_$$.db; rm -f "$DB"
 echo "CREATE TABLE a(id INTEGER PRIMARY KEY, v TEXT);
@@ -649,20 +499,14 @@ SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO a VALUES(2,'a2');
 INSERT INTO b VALUES(2,'b2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 echo "SELECT dolt_add('.');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "adddot_all_staged" "SELECT count(*) FROM dolt_status WHERE staged=1;" "2" "$DB"
 run_test "adddot_none_unstaged" "SELECT count(*) FROM dolt_status WHERE staged=0;" "0" "$DB"
-
 
 run_test_match "adddot_commit" "SELECT dolt_commit('-m','dot staged');" "^[0-9a-f]{40}$" "$DB"
 run_test "adddot_clean" "SELECT count(*) FROM dolt_status;" "0" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_adv_onesidemerge_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -671,30 +515,21 @@ SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 echo "SELECT dolt_branch('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 echo "INSERT INTO t VALUES(2,'main_only');
 SELECT dolt_commit('-A','-m','main adds');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
-
 run_test_match "oneside_merge" "SELECT dolt_merge('feat');" "up to date|^[0-9a-f]{40}$" "$DB"
 run_test "oneside_count" "SELECT count(*) FROM t;" "2" "$DB"
-
 
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(3,'feat_only');
 SELECT dolt_commit('-A','-m','feat adds');" | $DOLTLITE "$DB/feat" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test_match "oneside_real_merge" "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB"
 run_test "oneside_all_rows" "SELECT count(*) FROM t;" "3" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_adv_expr_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, a TEXT, b TEXT);
@@ -711,10 +546,6 @@ run_test "expr_case" \
   "no_a" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_adv_mergeidx_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, name TEXT, val INTEGER);
@@ -733,17 +564,12 @@ echo "INSERT INTO t VALUES(4,'d',5);
 SELECT dolt_commit('-A','-m','main add');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test_match "mergeidx_merge" "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB"
-
 run_test "mergeidx_row1" "SELECT name FROM t WHERE id=1;" "a" "$DB"
 run_test "mergeidx_row3" "SELECT name FROM t WHERE id=3;" "c" "$DB"
 run_test "mergeidx_row4" "SELECT name FROM t WHERE id=4;" "d" "$DB"
 run_test "mergeidx_schema" "SELECT count(*) FROM sqlite_master WHERE type='index';" "1" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_adv_unique_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, email TEXT UNIQUE, name TEXT);
@@ -753,10 +579,8 @@ SELECT dolt_commit('-A','-m','with unique');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "unique_count" "SELECT count(*) FROM t;" "2" "$DB"
 
-
 run_test_match "unique_violate" \
   "INSERT INTO t VALUES(3,'alice@test.com','Fake');" "UNIQUE constraint" "$DB"
-
 
 echo "UPDATE t SET name='Alice Updated' WHERE id=1;
 SELECT dolt_commit('-A','-m','update alice');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -764,10 +588,6 @@ run_test "unique_updated" "SELECT name FROM t WHERE id=1;" "Alice Updated" "$DB"
 run_test "unique_persist" "SELECT count(*) FROM t;" "2" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_adv_notnull_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, name TEXT NOT NULL, score INTEGER DEFAULT 0);
@@ -777,10 +597,8 @@ SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "notnull_count" "SELECT count(*) FROM t;" "2" "$DB"
 
-
 run_test_match "notnull_violate" \
   "INSERT INTO t VALUES(3,NULL,50);" "NOT NULL" "$DB"
-
 
 echo "INSERT INTO t(id,name) VALUES(4,'Charlie');
 SELECT dolt_commit('-A','-m','with default');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -788,10 +606,6 @@ run_test "notnull_default" "SELECT score FROM t WHERE id=4;" "0" "$DB"
 run_test "notnull_persist" "SELECT count(*) FROM t;" "3" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_adv_join_$$.db; rm -f "$DB"
 echo "CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
@@ -810,7 +624,6 @@ run_test "join_alice" \
 run_test "join_bob" \
   "SELECT count(*) FROM users u JOIN orders o ON u.id=o.uid WHERE u.name='Bob';" "1" "$DB"
 
-
 echo "INSERT INTO users VALUES(3,'Charlie');
 INSERT INTO orders VALUES(4,3,'Doohickey');
 SELECT dolt_commit('-A','-m','add charlie');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -819,10 +632,6 @@ run_test "join_after_commit" \
   "SELECT count(*) FROM users u JOIN orders o ON u.id=o.uid;" "4" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/doltlite_at.sh
+++ b/test/doltlite_at.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-#
-# Tests for dolt_at('table', 'ref') — point-in-time table queries.
-#
+
+
+
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
@@ -10,9 +10,9 @@ run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -
 echo "=== Doltlite dolt_at() Point-in-Time Query Tests ==="
 echo ""
 
-# ============================================================
-# Basic: query table at different commits
-# ============================================================
+
+
+
 
 DB=/tmp/test_at_basic_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -23,17 +23,17 @@ SELECT dolt_commit('-A','-m','c2');
 INSERT INTO t VALUES(3,'c');
 SELECT dolt_commit('-A','-m','c3');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# At c1: 1 row
+
 run_test "basic_c1" \
   "SELECT count(*) FROM dolt_at_t( (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 2));" \
   "1" "$DB"
 
-# At c2: 2 rows
+
 run_test "basic_c2" \
   "SELECT count(*) FROM dolt_at_t( (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1));" \
   "2" "$DB"
 
-# At c3 (HEAD): 3 rows
+
 run_test "basic_c3" \
   "SELECT count(*) FROM dolt_at_t( (SELECT commit_hash FROM dolt_log LIMIT 1));" \
   "3" "$DB"
@@ -44,9 +44,9 @@ run_test "basic_commit_ref_hash" \
 
 rm -f "$DB"
 
-# ============================================================
-# Quoted table names work in dolt_at_<table>
-# ============================================================
+
+
+
 
 DB=/tmp/test_at_quoted_$$.db; rm -f "$DB"
 echo "CREATE TABLE \"odd\"\"name\"(id INTEGER PRIMARY KEY, v TEXT);
@@ -63,9 +63,9 @@ run_test "quoted_name_value" \
 
 rm -f "$DB"
 
-# ============================================================
-# Rowid values correct at each commit
-# ============================================================
+
+
+
 
 DB=/tmp/test_at_rowid_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -74,21 +74,21 @@ SELECT dolt_commit('-A','-m','c1');
 INSERT INTO t VALUES(20,'b');
 SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# At c1: only rowid 10
+
 run_test "rowid_c1_10" \
   "SELECT id FROM dolt_at_t( (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1));" \
   "10" "$DB"
 
-# At c2: both rowids
+
 run_test "rowid_c2_count" \
   "SELECT count(*) FROM dolt_at_t( (SELECT commit_hash FROM dolt_log LIMIT 1));" \
   "2" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Resolve by branch name
-# ============================================================
+
+
+
 
 DB=/tmp/test_at_branch_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -102,16 +102,16 @@ SELECT dolt_checkout('main');
 INSERT INTO t VALUES(3,'main_row');
 SELECT dolt_commit('-A','-m','main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# At branch 'feat': rows 1,2
+
 run_test "branch_feat" "SELECT count(*) FROM dolt_at_t( 'feat');" "2" "$DB"
 
-# At branch 'main': rows 1,3
+
 run_test "branch_main" "SELECT count(*) FROM dolt_at_t( 'main');" "2" "$DB"
 
 run_test "branch_commit_ref_name" \
   "SELECT commit_ref FROM dolt_at_t( 'feat') LIMIT 1;" "feat" "$DB"
 
-# Specific rowids per branch
+
 run_test "branch_feat_has2" \
   "SELECT count(*) FROM dolt_at_t( 'feat') WHERE id=2;" "1" "$DB"
 run_test "branch_feat_no3" \
@@ -123,9 +123,9 @@ run_test "branch_main_no2" \
 
 rm -f "$DB"
 
-# ============================================================
-# Resolve by tag name
-# ============================================================
+
+
+
 
 DB=/tmp/test_at_tag_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -143,9 +143,9 @@ run_test "tag_v2" "SELECT count(*) FROM dolt_at_t( 'v2.0');" "2" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Parent refs and raw hashes
-# ============================================================
+
+
+
 
 DB=/tmp/test_at_parents_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -170,9 +170,9 @@ run_test "parent_second_hash" "SELECT count(*) FROM dolt_at_t( '$HASH');" "2" "$
 
 rm -f "$DB"
 
-# ============================================================
-# Branch created from tag persists across reopen
-# ============================================================
+
+
+
 
 DB=/tmp/test_at_branch_from_tag_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -188,9 +188,9 @@ run_test "branch_from_tag_reopen_at_main" "SELECT count(*) FROM dolt_at_t( 'main
 
 rm -f "$DB"
 
-# ============================================================
-# Updated rows show old values at old commits
-# ============================================================
+
+
+
 
 DB=/tmp/test_at_update_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -199,7 +199,7 @@ SELECT dolt_commit('-A','-m','c1');
 UPDATE t SET v='changed' WHERE id=1;
 SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Both commits have 1 row, but with different values (blobs)
+
 run_test "update_c1_count" \
   "SELECT count(*) FROM dolt_at_t( (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1));" \
   "1" "$DB"
@@ -207,16 +207,16 @@ run_test "update_c2_count" \
   "SELECT count(*) FROM dolt_at_t( (SELECT commit_hash FROM dolt_log LIMIT 1));" \
   "1" "$DB"
 
-# Values should be different blobs
+
 run_test_match "update_diff_vals" \
   "SELECT CASE WHEN a.v != b.v THEN 'different' ELSE 'same' END FROM dolt_at_t( (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1)) a, dolt_at_t( (SELECT commit_hash FROM dolt_log LIMIT 1)) b WHERE a.id=b.id;" \
   "different" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Deleted rows not present at later commits
-# ============================================================
+
+
+
 
 DB=/tmp/test_at_delete_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -235,9 +235,9 @@ run_test "delete_c2" \
 
 rm -f "$DB"
 
-# ============================================================
-# Non-existent table returns empty
-# ============================================================
+
+
+
 
 DB=/tmp/test_at_notable_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -250,11 +250,11 @@ run_test_match "notable" \
 
 rm -f "$DB"
 
-# ============================================================
-# Non-existent ref errors with "ref not found"
-# ============================================================
-# Matches Dolt's `t AS OF '<bad-ref>'` which surfaces a
-# "ref not found" diagnostic instead of silently returning empty.
+
+
+
+
+
 
 DB=/tmp/test_at_noref_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -267,9 +267,9 @@ run_test_match "noref" \
 
 rm -f "$DB"
 
-# ============================================================
-# Multiple tables at same commit
-# ============================================================
+
+
+
 
 DB=/tmp/test_at_multi_$$.db; rm -f "$DB"
 echo "CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
@@ -286,9 +286,9 @@ run_test "multi_orders" "SELECT count(*) FROM dolt_at_orders( '$HASH');" "2" "$D
 
 rm -f "$DB"
 
-# ============================================================
-# Persistence: works after reopen
-# ============================================================
+
+
+
 
 DB=/tmp/test_at_persist_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -297,7 +297,7 @@ SELECT dolt_commit('-A','-m','c1');
 INSERT INTO t VALUES(2,'b');
 SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Query from new session
+
 run_test "persist_c1" \
   "SELECT count(*) FROM dolt_at_t( (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1));" \
   "1" "$DB"
@@ -307,9 +307,9 @@ run_test "persist_c2" \
 
 rm -f "$DB"
 
-# ============================================================
-# Table created in later commit not visible at earlier commit
-# ============================================================
+
+
+
 
 DB=/tmp/test_at_late_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
@@ -319,21 +319,21 @@ CREATE TABLE t2(id INTEGER PRIMARY KEY);
 INSERT INTO t2 VALUES(1);
 SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# t2 doesn't exist at c1
+
 run_test "late_no_t2" \
   "SELECT count(*) FROM dolt_at_t2( (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1));" \
   "0" "$DB"
 
-# t2 exists at c2
+
 run_test "late_has_t2" \
   "SELECT count(*) FROM dolt_at_t2( (SELECT commit_hash FROM dolt_log LIMIT 1));" \
   "1" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Works after merge
-# ============================================================
+
+
+
 
 DB=/tmp/test_at_merge_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -349,22 +349,22 @@ INSERT INTO t VALUES(3,'main');
 SELECT dolt_commit('-A','-m','main');
 SELECT dolt_merge('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Before merge: 1 row
+
 run_test "merge_before" "SELECT count(*) FROM dolt_at_t( 'before_merge');" "1" "$DB"
 
-# At feat: 2 rows
+
 run_test "merge_feat" "SELECT count(*) FROM dolt_at_t( 'feat');" "2" "$DB"
 
-# At HEAD (after merge): 3 rows
+
 run_test "merge_head" \
   "SELECT count(*) FROM dolt_at_t( (SELECT commit_hash FROM dolt_log LIMIT 1));" \
   "3" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Works after GC
-# ============================================================
+
+
+
 
 DB=/tmp/test_at_gc_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -384,9 +384,9 @@ run_test "gc_c2" \
 
 rm -f "$DB"
 
-# ============================================================
-# Compare current table vs historical version
-# ============================================================
+
+
+
 
 DB=/tmp/test_at_compare_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -397,19 +397,19 @@ UPDATE t SET v='new' WHERE id=1;
 INSERT INTO t VALUES(3,'added');
 SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Current has 3 rows
+
 run_test "compare_current" "SELECT count(*) FROM t;" "3" "$DB"
 
-# Historical has 2 rows
+
 run_test "compare_old" \
   "SELECT count(*) FROM dolt_at_t( (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1));" \
   "2" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Empty table at commit
-# ============================================================
+
+
+
 
 DB=/tmp/test_at_empty_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -426,9 +426,9 @@ run_test "empty_at_c2" \
 
 rm -f "$DB"
 
-# ============================================================
-# Done
-# ============================================================
+
+
+
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/doltlite_at.sh
+++ b/test/doltlite_at.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
-
-
-
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
@@ -9,10 +6,6 @@ run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -
 
 echo "=== Doltlite dolt_at() Point-in-Time Query Tests ==="
 echo ""
-
-
-
-
 
 DB=/tmp/test_at_basic_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -23,16 +16,13 @@ SELECT dolt_commit('-A','-m','c2');
 INSERT INTO t VALUES(3,'c');
 SELECT dolt_commit('-A','-m','c3');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "basic_c1" \
   "SELECT count(*) FROM dolt_at_t( (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 2));" \
   "1" "$DB"
 
-
 run_test "basic_c2" \
   "SELECT count(*) FROM dolt_at_t( (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1));" \
   "2" "$DB"
-
 
 run_test "basic_c3" \
   "SELECT count(*) FROM dolt_at_t( (SELECT commit_hash FROM dolt_log LIMIT 1));" \
@@ -43,10 +33,6 @@ run_test "basic_commit_ref_hash" \
   "$(echo "SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1;" | $DOLTLITE "$DB" 2>/dev/null)" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_at_quoted_$$.db; rm -f "$DB"
 echo "CREATE TABLE \"odd\"\"name\"(id INTEGER PRIMARY KEY, v TEXT);
@@ -63,10 +49,6 @@ run_test "quoted_name_value" \
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_at_rowid_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(10,'a');
@@ -74,21 +56,15 @@ SELECT dolt_commit('-A','-m','c1');
 INSERT INTO t VALUES(20,'b');
 SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "rowid_c1_10" \
   "SELECT id FROM dolt_at_t( (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1));" \
   "10" "$DB"
-
 
 run_test "rowid_c2_count" \
   "SELECT count(*) FROM dolt_at_t( (SELECT commit_hash FROM dolt_log LIMIT 1));" \
   "2" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_at_branch_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -102,15 +78,12 @@ SELECT dolt_checkout('main');
 INSERT INTO t VALUES(3,'main_row');
 SELECT dolt_commit('-A','-m','main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "branch_feat" "SELECT count(*) FROM dolt_at_t( 'feat');" "2" "$DB"
-
 
 run_test "branch_main" "SELECT count(*) FROM dolt_at_t( 'main');" "2" "$DB"
 
 run_test "branch_commit_ref_name" \
   "SELECT commit_ref FROM dolt_at_t( 'feat') LIMIT 1;" "feat" "$DB"
-
 
 run_test "branch_feat_has2" \
   "SELECT count(*) FROM dolt_at_t( 'feat') WHERE id=2;" "1" "$DB"
@@ -122,10 +95,6 @@ run_test "branch_main_no2" \
   "SELECT count(*) FROM dolt_at_t( 'main') WHERE id=2;" "0" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_at_tag_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -142,10 +111,6 @@ run_test "tag_v1" "SELECT count(*) FROM dolt_at_t( 'v1.0');" "1" "$DB"
 run_test "tag_v2" "SELECT count(*) FROM dolt_at_t( 'v2.0');" "2" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_at_parents_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -170,10 +135,6 @@ run_test "parent_second_hash" "SELECT count(*) FROM dolt_at_t( '$HASH');" "2" "$
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_at_branch_from_tag_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'v1');
@@ -188,17 +149,12 @@ run_test "branch_from_tag_reopen_at_main" "SELECT count(*) FROM dolt_at_t( 'main
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_at_update_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'original');
 SELECT dolt_commit('-A','-m','c1');
 UPDATE t SET v='changed' WHERE id=1;
 SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 run_test "update_c1_count" \
   "SELECT count(*) FROM dolt_at_t( (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1));" \
@@ -207,16 +163,11 @@ run_test "update_c2_count" \
   "SELECT count(*) FROM dolt_at_t( (SELECT commit_hash FROM dolt_log LIMIT 1));" \
   "1" "$DB"
 
-
 run_test_match "update_diff_vals" \
   "SELECT CASE WHEN a.v != b.v THEN 'different' ELSE 'same' END FROM dolt_at_t( (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1)) a, dolt_at_t( (SELECT commit_hash FROM dolt_log LIMIT 1)) b WHERE a.id=b.id;" \
   "different" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_at_delete_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -235,10 +186,6 @@ run_test "delete_c2" \
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_at_notable_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
@@ -250,12 +197,6 @@ run_test_match "notable" \
 
 rm -f "$DB"
 
-
-
-
-
-
-
 DB=/tmp/test_at_noref_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
@@ -266,10 +207,6 @@ run_test_match "noref" \
   "ref not found" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_at_multi_$$.db; rm -f "$DB"
 echo "CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
@@ -286,17 +223,12 @@ run_test "multi_orders" "SELECT count(*) FROM dolt_at_orders( '$HASH');" "2" "$D
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_at_persist_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
 SELECT dolt_commit('-A','-m','c1');
 INSERT INTO t VALUES(2,'b');
 SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 run_test "persist_c1" \
   "SELECT count(*) FROM dolt_at_t( (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1));" \
@@ -307,10 +239,6 @@ run_test "persist_c2" \
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_at_late_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
 INSERT INTO t VALUES(1);
@@ -319,21 +247,15 @@ CREATE TABLE t2(id INTEGER PRIMARY KEY);
 INSERT INTO t2 VALUES(1);
 SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "late_no_t2" \
   "SELECT count(*) FROM dolt_at_t2( (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1));" \
   "0" "$DB"
-
 
 run_test "late_has_t2" \
   "SELECT count(*) FROM dolt_at_t2( (SELECT commit_hash FROM dolt_log LIMIT 1));" \
   "1" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_at_merge_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -349,22 +271,15 @@ INSERT INTO t VALUES(3,'main');
 SELECT dolt_commit('-A','-m','main');
 SELECT dolt_merge('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "merge_before" "SELECT count(*) FROM dolt_at_t( 'before_merge');" "1" "$DB"
 
-
 run_test "merge_feat" "SELECT count(*) FROM dolt_at_t( 'feat');" "2" "$DB"
-
 
 run_test "merge_head" \
   "SELECT count(*) FROM dolt_at_t( (SELECT commit_hash FROM dolt_log LIMIT 1));" \
   "3" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_at_gc_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -384,10 +299,6 @@ run_test "gc_c2" \
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_at_compare_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'old');
@@ -397,19 +308,13 @@ UPDATE t SET v='new' WHERE id=1;
 INSERT INTO t VALUES(3,'added');
 SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "compare_current" "SELECT count(*) FROM t;" "3" "$DB"
-
 
 run_test "compare_old" \
   "SELECT count(*) FROM dolt_at_t( (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1));" \
   "2" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_at_empty_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -425,10 +330,6 @@ run_test "empty_at_c2" \
   "1" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/doltlite_attach_sqlite.sh
+++ b/test/doltlite_attach_sqlite.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
-
-
-
 DOLTLITE="${1:-./doltlite}"
 SQLITE3=$(command -v sqlite3 2>/dev/null || echo /usr/bin/sqlite3)
 PASS=0; FAIL=0; ERRORS=""
@@ -27,10 +24,6 @@ if [ ! -x "$SQLITE3" ]; then
   exit 0
 fi
 
-
-
-
-
 SQLDB1=/tmp/test_attach1_$$.db
 SQLDB2=/tmp/test_attach2_$$.db
 DLDB=/tmp/test_attach_dl_$$.db
@@ -52,10 +45,6 @@ INSERT INTO logs VALUES(1000,'start');
 INSERT INTO logs VALUES(2000,'running');
 INSERT INTO logs VALUES(3000,'done');
 "
-
-
-
-
 
 run_test "attach_select_all" \
   "ATTACH DATABASE '$SQLDB1' AS ops;
@@ -80,20 +69,12 @@ run_test "attach_max" \
 SELECT MAX(id) FROM ops.events;" \
   "3" ":memory:"
 
-
-
-
-
 run_test "attach_multiple_tables" \
   "ATTACH DATABASE '$SQLDB1' AS ops;
 SELECT count(*) FROM ops.events;
 SELECT count(*) FROM ops.users;" \
   "3
 2" ":memory:"
-
-
-
-
 
 run_test "cross_db_join" \
   "CREATE TABLE threads(id INTEGER PRIMARY KEY, title TEXT);
@@ -104,10 +85,6 @@ SELECT t.title, e.type FROM threads t JOIN ops.events e ON t.id=e.id ORDER BY t.
   "Thread A|click
 Thread B|view" ":memory:"
 
-
-
-
-
 run_test "attach_two_sqlite_dbs" \
   "ATTACH DATABASE '$SQLDB1' AS db1;
 ATTACH DATABASE '$SQLDB2' AS db2;
@@ -115,10 +92,6 @@ SELECT count(*) FROM db1.events;
 SELECT count(*) FROM db2.logs;" \
   "3
 3" ":memory:"
-
-
-
-
 
 run_test "main_db_after_attach" \
   "CREATE TABLE t(x INTEGER);
@@ -128,10 +101,6 @@ SELECT x FROM t;
 SELECT count(*) FROM ops.events;" \
   "42
 3" ":memory:"
-
-
-
-
 
 run_test "dolt_commit_with_attach" \
   "CREATE TABLE t(x INTEGER);
@@ -144,10 +113,6 @@ SELECT count(*) FROM ops.events;" \
 99
 3" "$DLDB"
 
-
-
-
-
 SQLDB_W=/tmp/test_attach_write_$$.db
 $SQLITE3 "$SQLDB_W" "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
 
@@ -159,7 +124,6 @@ SELECT * FROM w.t ORDER BY id;" \
   "1|hello
 2|world" ":memory:"
 
-
 WRITE_CHECK=$($SQLITE3 "$SQLDB_W" "SELECT count(*) FROM t;")
 if [ "$WRITE_CHECK" = "2" ]; then
   PASS=$((PASS+1))
@@ -167,10 +131,6 @@ else
   FAIL=$((FAIL+1))
   ERRORS="$ERRORS\nFAIL: attach_write_persisted\n  expected: 2\n  got:      $WRITE_CHECK"
 fi
-
-
-
-
 
 SQLDB_IC=/tmp/test_attach_ic_$$.db
 $SQLITE3 "$SQLDB_IC" "
@@ -194,10 +154,6 @@ ATTACH DATABASE '$SQLDB_IC' AS side;
 PRAGMA side.integrity_check;" \
   "1
 ok" "$DLDB_IC"
-
-
-
-
 
 rm -f "$SQLDB1" "$SQLDB2" "$DLDB" "$SQLDB_W" "$SQLDB_IC" "$DLDB_IC"
 

--- a/test/doltlite_attach_sqlite.sh
+++ b/test/doltlite_attach_sqlite.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-#
-# Tests for ATTACH standard SQLite databases (#181)
-#
+
+
+
 DOLTLITE="${1:-./doltlite}"
 SQLITE3=$(command -v sqlite3 2>/dev/null || echo /usr/bin/sqlite3)
 PASS=0; FAIL=0; ERRORS=""
@@ -27,9 +27,9 @@ if [ ! -x "$SQLITE3" ]; then
   exit 0
 fi
 
-# ============================================================
-# Setup: create standard SQLite databases
-# ============================================================
+
+
+
 
 SQLDB1=/tmp/test_attach1_$$.db
 SQLDB2=/tmp/test_attach2_$$.db
@@ -53,9 +53,9 @@ INSERT INTO logs VALUES(2000,'running');
 INSERT INTO logs VALUES(3000,'done');
 "
 
-# ============================================================
-# Basic ATTACH and SELECT
-# ============================================================
+
+
+
 
 run_test "attach_select_all" \
   "ATTACH DATABASE '$SQLDB1' AS ops;
@@ -80,9 +80,9 @@ run_test "attach_max" \
 SELECT MAX(id) FROM ops.events;" \
   "3" ":memory:"
 
-# ============================================================
-# Multiple tables in attached db
-# ============================================================
+
+
+
 
 run_test "attach_multiple_tables" \
   "ATTACH DATABASE '$SQLDB1' AS ops;
@@ -91,9 +91,9 @@ SELECT count(*) FROM ops.users;" \
   "3
 2" ":memory:"
 
-# ============================================================
-# Cross-database JOIN
-# ============================================================
+
+
+
 
 run_test "cross_db_join" \
   "CREATE TABLE threads(id INTEGER PRIMARY KEY, title TEXT);
@@ -104,9 +104,9 @@ SELECT t.title, e.type FROM threads t JOIN ops.events e ON t.id=e.id ORDER BY t.
   "Thread A|click
 Thread B|view" ":memory:"
 
-# ============================================================
-# Multiple ATTACH
-# ============================================================
+
+
+
 
 run_test "attach_two_sqlite_dbs" \
   "ATTACH DATABASE '$SQLDB1' AS db1;
@@ -116,9 +116,9 @@ SELECT count(*) FROM db2.logs;" \
   "3
 3" ":memory:"
 
-# ============================================================
-# Main db queries still work after ATTACH
-# ============================================================
+
+
+
 
 run_test "main_db_after_attach" \
   "CREATE TABLE t(x INTEGER);
@@ -129,9 +129,9 @@ SELECT count(*) FROM ops.events;" \
   "42
 3" ":memory:"
 
-# ============================================================
-# ATTACH with doltlite versioning on main db
-# ============================================================
+
+
+
 
 run_test "dolt_commit_with_attach" \
   "CREATE TABLE t(x INTEGER);
@@ -144,9 +144,9 @@ SELECT count(*) FROM ops.events;" \
 99
 3" "$DLDB"
 
-# ============================================================
-# Write to attached SQLite database
-# ============================================================
+
+
+
 
 SQLDB_W=/tmp/test_attach_write_$$.db
 $SQLITE3 "$SQLDB_W" "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
@@ -159,7 +159,7 @@ SELECT * FROM w.t ORDER BY id;" \
   "1|hello
 2|world" ":memory:"
 
-# Verify writes persisted by reading with sqlite3
+
 WRITE_CHECK=$($SQLITE3 "$SQLDB_W" "SELECT count(*) FROM t;")
 if [ "$WRITE_CHECK" = "2" ]; then
   PASS=$((PASS+1))
@@ -168,9 +168,9 @@ else
   ERRORS="$ERRORS\nFAIL: attach_write_persisted\n  expected: 2\n  got:      $WRITE_CHECK"
 fi
 
-# ============================================================
-# Integrity check on attached SQLite database (#295)
-# ============================================================
+
+
+
 
 SQLDB_IC=/tmp/test_attach_ic_$$.db
 $SQLITE3 "$SQLDB_IC" "
@@ -195,9 +195,9 @@ PRAGMA side.integrity_check;" \
   "1
 ok" "$DLDB_IC"
 
-# ============================================================
-# Cleanup
-# ============================================================
+
+
+
 
 rm -f "$SQLDB1" "$SQLDB2" "$DLDB" "$SQLDB_W" "$SQLDB_IC" "$DLDB_IC"
 

--- a/test/doltlite_behavior.sh
+++ b/test/doltlite_behavior.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-#
-# Tests for: conflict-checkout blocking, schema merge errors, dolt_at working state.
-#
+
+
+
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
@@ -10,13 +10,13 @@ run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -
 echo "=== Doltlite Behavior Tests ==="
 echo ""
 
-# ============================================================
-# Conflict Checkout Tests
-# ============================================================
+
+
+
 
 echo "--- Conflict checkout tests ---"
 
-# Test 1: Checkout blocked during unresolved merge conflicts
+
 DB=/tmp/test_bhv1_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'orig');
@@ -30,7 +30,7 @@ SELECT dolt_commit('-A','-m','feat edit');" | $DOLTLITE "$DB/feature" > /dev/nul
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_merge('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# In the same SQL session, unresolved conflicts block checkout
+
 run_test_match "checkout_blocked_conflict" \
   "BEGIN; SELECT dolt_merge('feature'); SELECT dolt_checkout('feature'); ROLLBACK;" \
   "unresolved merge conflicts" "$DB"
@@ -55,18 +55,18 @@ else
   ERRORS="$ERRORS\nFAIL: checkout_create_no_branch_on_conflict\n  expected: CNT|0\n  got:      $TX_OUT"
 fi
 
-# Test 2: In a new session after autocommit rollback, checkout should succeed
+
 run_test "checkout_after_rollback" \
   "SELECT dolt_checkout('feature'); SELECT active_branch();" \
   "0
 feature" "$DB"
 
-# Switch back for cleanup
+
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 rm -f "$DB"
 
-# Test 3: Abort merge, then checkout should succeed
+
 DB=/tmp/test_bhv3_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'orig');
@@ -80,7 +80,7 @@ SELECT dolt_commit('-A','-m','feat2');" | $DOLTLITE "$DB/feature" > /dev/null 2>
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_merge('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Merge rolled back across sessions; checkout should still succeed
+
 run_test "checkout_after_rolled_back_merge" \
   "SELECT dolt_checkout('feature'); SELECT active_branch();" \
   "0
@@ -88,37 +88,37 @@ feature" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Schema Merge Tests
-# ============================================================
+
+
+
 
 echo "--- Schema merge tests ---"
 
-# Test 4: Both branches add different columns to same table -> merge succeeds
+
 DB=/tmp/test_bhv4_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_branch('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Main adds column 'x'
+
 echo "ALTER TABLE t ADD COLUMN x TEXT;
 UPDATE t SET x='mx';
 SELECT dolt_commit('-A','-m','add x');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# b1 adds column 'y'
+
 echo "SELECT dolt_checkout('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "ALTER TABLE t ADD COLUMN y INTEGER;
 UPDATE t SET y=42;
 SELECT dolt_commit('-A','-m','add y');" | $DOLTLITE "$DB/b1" > /dev/null 2>&1
 
-# Back to main, merge should succeed with schema merge
+
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "schema_merge_both_add_col" \
   "SELECT dolt_merge('b1');" \
   "^[0-9a-f]" "$DB"
 
-# Verify both columns are present after merge
+
 run_test_match "schema_merge_has_x_col" \
   "SELECT x FROM t WHERE id=1;" \
   "mx" "$DB"
@@ -129,7 +129,7 @@ run_test "schema_merge_has_y_col" \
 
 rm -f "$DB"
 
-# Test 4b: Schema merge row data migration - multiple rows with both columns
+
 DB=/tmp/test_bhv4b_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
@@ -138,14 +138,14 @@ INSERT INTO t VALUES(3,'c');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_branch('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Main adds column 'x' with data for all rows
+
 echo "ALTER TABLE t ADD COLUMN x TEXT;
 UPDATE t SET x='x1' WHERE id=1;
 UPDATE t SET x='x2' WHERE id=2;
 UPDATE t SET x='x3' WHERE id=3;
 SELECT dolt_commit('-A','-m','add x');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# b1 adds column 'y' with data for all rows
+
 echo "SELECT dolt_checkout('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "ALTER TABLE t ADD COLUMN y INTEGER;
 UPDATE t SET y=10 WHERE id=1;
@@ -156,7 +156,7 @@ SELECT dolt_commit('-A','-m','add y');" | $DOLTLITE "$DB/b1" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_merge('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Verify all rows have correct values for BOTH added columns
+
 run_test "schema_data_migrate_row1" \
   "SELECT x, y FROM t WHERE id=1;" \
   "x1|10" "$DB"
@@ -169,27 +169,27 @@ run_test "schema_data_migrate_row3" \
   "SELECT x, y FROM t WHERE id=3;" \
   "x3|30" "$DB"
 
-# Verify original columns preserved
+
 run_test "schema_data_migrate_orig" \
   "SELECT v FROM t WHERE id=1;" \
   "a" "$DB"
 
 rm -f "$DB"
 
-# Test 4c: Schema merge with new rows added on branch with different column
+
 DB=/tmp/test_bhv4c_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'orig');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_branch('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Main adds column 'x' and inserts a new row
+
 echo "ALTER TABLE t ADD COLUMN x TEXT;
 UPDATE t SET x='val_x' WHERE id=1;
 INSERT INTO t VALUES(2,'main_new','new_x');
 SELECT dolt_commit('-A','-m','add x with new row');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# b1 adds column 'y' and inserts a different new row
+
 echo "SELECT dolt_checkout('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "ALTER TABLE t ADD COLUMN y INTEGER;
 UPDATE t SET y=7 WHERE id=1;
@@ -199,31 +199,31 @@ SELECT dolt_commit('-A','-m','add y with new row');" | $DOLTLITE "$DB/b1" > /dev
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_merge('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Row 1 should have both x and y values
+
 run_test "schema_data_migrate_both_cols" \
   "SELECT x, y FROM t WHERE id=1;" \
   "val_x|7" "$DB"
 
-# Row 2 (added on main) should have x but NULL y
+
 run_test "schema_data_migrate_main_row" \
   "SELECT x, typeof(y) FROM t WHERE id=2;" \
   "new_x|null" "$DB"
 
 rm -f "$DB"
 
-# Test 5: One branch adds column, other doesn't modify schema -> should succeed
+
 DB=/tmp/test_bhv5_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_branch('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Main adds a column
+
 echo "ALTER TABLE t ADD COLUMN extra TEXT;
 UPDATE t SET extra='hi';
 SELECT dolt_commit('-A','-m','add extra');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# b1 only changes data
+
 echo "SELECT dolt_checkout('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(2,'b');
 SELECT dolt_commit('-A','-m','data only');" | $DOLTLITE "$DB/b1" > /dev/null 2>&1
@@ -235,7 +235,7 @@ run_test_match "schema_one_side_ok" \
 
 rm -f "$DB"
 
-# Test 6: Both branches modify different tables -> should succeed
+
 DB=/tmp/test_bhv6_$$.db; rm -f "$DB"
 echo "CREATE TABLE t1(id INTEGER PRIMARY KEY, v TEXT);
 CREATE TABLE t2(id INTEGER PRIMARY KEY, v TEXT);
@@ -244,11 +244,11 @@ INSERT INTO t2 VALUES(1,'x');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_branch('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Main changes t1
+
 echo "UPDATE t1 SET v='A';
 SELECT dolt_commit('-A','-m','t1 change');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# b1 changes t2
+
 echo "SELECT dolt_checkout('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "UPDATE t2 SET v='X';
 SELECT dolt_commit('-A','-m','t2 change');" | $DOLTLITE "$DB/b1" > /dev/null 2>&1
@@ -263,45 +263,45 @@ run_test "diff_tables_t2" "SELECT v FROM t2;" "X" "$DB"
 
 rm -f "$DB"
 
-# Test 7: Both branches add same column with same definition -> merge succeeds
+
 DB=/tmp/test_bhv7s_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_branch('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Main adds column 'z' TEXT
+
 echo "ALTER TABLE t ADD COLUMN z TEXT;
 UPDATE t SET z='main_z';
 SELECT dolt_commit('-A','-m','add z on main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# b1 adds same column 'z' TEXT
+
 echo "SELECT dolt_checkout('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "ALTER TABLE t ADD COLUMN z TEXT;
 UPDATE t SET z='b1_z';
 SELECT dolt_commit('-A','-m','add z on b1');" | $DOLTLITE "$DB/b1" > /dev/null 2>&1
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
-# Merge should succeed (same column added on both) — row conflict may occur
-# since both modified the same row with different z values, but schema merge OK
+
+
 run_test_match "schema_merge_same_col_same_def" \
   "SELECT dolt_merge('b1');" \
   "^[0-9a-f]|conflict" "$DB"
 
 rm -f "$DB"
 
-# Test 8: Both branches add same column with different types -> schema conflict
+
 DB=/tmp/test_bhv8s_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_branch('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Main adds column 'w' as TEXT
+
 echo "ALTER TABLE t ADD COLUMN w TEXT;
 SELECT dolt_commit('-A','-m','add w TEXT');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# b1 adds column 'w' as INTEGER
+
 echo "SELECT dolt_checkout('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "ALTER TABLE t ADD COLUMN w INTEGER;
 SELECT dolt_commit('-A','-m','add w INTEGER');" | $DOLTLITE "$DB/b1" > /dev/null 2>&1
@@ -313,18 +313,18 @@ run_test_match "schema_merge_same_col_diff_type" \
 
 rm -f "$DB"
 
-# Test 9: One branch adds column, other drops different column -> merge succeeds
+
 DB=/tmp/test_bhv9s_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT, extra TEXT);
 INSERT INTO t VALUES(1,'a','e');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_branch('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Main adds a new column
+
 echo "ALTER TABLE t ADD COLUMN newcol TEXT;
 SELECT dolt_commit('-A','-m','add newcol');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# b1 only changes data (can't drop columns easily in SQLite, so just data change)
+
 echo "SELECT dolt_checkout('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "UPDATE t SET v='b';
 SELECT dolt_commit('-A','-m','data change');" | $DOLTLITE "$DB/b1" > /dev/null 2>&1
@@ -336,13 +336,13 @@ run_test_match "schema_add_col_other_data" \
 
 rm -f "$DB"
 
-# ============================================================
-# dolt_at Working State Tests
-# ============================================================
+
+
+
 
 echo "--- dolt_at working state tests ---"
 
-# Test 7: Uncommitted data on feature visible via dolt_at from main
+
 DB=/tmp/test_bhv7_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'init');
@@ -354,19 +354,19 @@ SELECT dolt_commit('-A','-m','feat committed');
 INSERT INTO t VALUES(3,'uncommitted');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# From main, dolt_at_t('feature') should see 3 rows (including uncommitted)
+
 run_test "at_working_uncommitted_count" \
   "SELECT count(*) FROM dolt_at_t('feature');" \
   "3" "$DB"
 
-# Verify the uncommitted row is there
+
 run_test "at_working_uncommitted_row" \
   "SELECT v FROM dolt_at_t('feature') WHERE id=3;" \
   "uncommitted" "$DB"
 
 rm -f "$DB"
 
-# Test 8: Committed data visible via dolt_at
+
 DB=/tmp/test_bhv8_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'init');
@@ -377,7 +377,7 @@ INSERT INTO t VALUES(2,'feat_row');
 SELECT dolt_commit('-A','-m','feat commit');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# From main, dolt_at_t('feature') should see 2 rows
+
 run_test "at_committed_count" \
   "SELECT count(*) FROM dolt_at_t('feature');" \
   "2" "$DB"
@@ -388,7 +388,7 @@ run_test "at_committed_row" \
 
 rm -f "$DB"
 
-# Test 9: dolt_at with commit hash should show that commit's state (not working)
+
 DB=/tmp/test_bhv9_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'init');
@@ -400,12 +400,12 @@ SELECT dolt_commit('-A','-m','feat committed');
 INSERT INTO t VALUES(3,'uncommitted');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Get the commit hash for 'feature' branch
+
 FEAT_HASH=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 0;" | $DOLTLITE "$DB" 2>&1)
 
-# By commit hash, should see only committed state (2 rows, not 3)
-# But first we need the feature branch commit hash, not main's
-# Switch to feature, get the hash, switch back
+
+
+
 echo "SELECT dolt_checkout('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
 FEAT_HASH=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1;" | $DOLTLITE "$DB/feature" 2>&1)
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -416,9 +416,9 @@ run_test "at_commit_hash_count" \
 
 rm -f "$DB"
 
-# ============================================================
-# Done
-# ============================================================
+
+
+
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/doltlite_behavior.sh
+++ b/test/doltlite_behavior.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
-
-
-
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
@@ -10,12 +7,7 @@ run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -
 echo "=== Doltlite Behavior Tests ==="
 echo ""
 
-
-
-
-
 echo "--- Conflict checkout tests ---"
-
 
 DB=/tmp/test_bhv1_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -29,7 +21,6 @@ echo "UPDATE t SET v='feat_val';
 SELECT dolt_commit('-A','-m','feat edit');" | $DOLTLITE "$DB/feature" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_merge('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 run_test_match "checkout_blocked_conflict" \
   "BEGIN; SELECT dolt_merge('feature'); SELECT dolt_checkout('feature'); ROLLBACK;" \
@@ -55,17 +46,14 @@ else
   ERRORS="$ERRORS\nFAIL: checkout_create_no_branch_on_conflict\n  expected: CNT|0\n  got:      $TX_OUT"
 fi
 
-
 run_test "checkout_after_rollback" \
   "SELECT dolt_checkout('feature'); SELECT active_branch();" \
   "0
 feature" "$DB"
 
-
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 rm -f "$DB"
-
 
 DB=/tmp/test_bhv3_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -80,7 +68,6 @@ SELECT dolt_commit('-A','-m','feat2');" | $DOLTLITE "$DB/feature" > /dev/null 2>
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_merge('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "checkout_after_rolled_back_merge" \
   "SELECT dolt_checkout('feature'); SELECT active_branch();" \
   "0
@@ -88,12 +75,7 @@ feature" "$DB"
 
 rm -f "$DB"
 
-
-
-
-
 echo "--- Schema merge tests ---"
-
 
 DB=/tmp/test_bhv4_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -101,23 +83,19 @@ INSERT INTO t VALUES(1,'a');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_branch('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 echo "ALTER TABLE t ADD COLUMN x TEXT;
 UPDATE t SET x='mx';
 SELECT dolt_commit('-A','-m','add x');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 echo "SELECT dolt_checkout('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "ALTER TABLE t ADD COLUMN y INTEGER;
 UPDATE t SET y=42;
 SELECT dolt_commit('-A','-m','add y');" | $DOLTLITE "$DB/b1" > /dev/null 2>&1
 
-
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "schema_merge_both_add_col" \
   "SELECT dolt_merge('b1');" \
   "^[0-9a-f]" "$DB"
-
 
 run_test_match "schema_merge_has_x_col" \
   "SELECT x FROM t WHERE id=1;" \
@@ -129,7 +107,6 @@ run_test "schema_merge_has_y_col" \
 
 rm -f "$DB"
 
-
 DB=/tmp/test_bhv4b_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
@@ -138,13 +115,11 @@ INSERT INTO t VALUES(3,'c');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_branch('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 echo "ALTER TABLE t ADD COLUMN x TEXT;
 UPDATE t SET x='x1' WHERE id=1;
 UPDATE t SET x='x2' WHERE id=2;
 UPDATE t SET x='x3' WHERE id=3;
 SELECT dolt_commit('-A','-m','add x');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 echo "SELECT dolt_checkout('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "ALTER TABLE t ADD COLUMN y INTEGER;
@@ -155,7 +130,6 @@ SELECT dolt_commit('-A','-m','add y');" | $DOLTLITE "$DB/b1" > /dev/null 2>&1
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_merge('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 run_test "schema_data_migrate_row1" \
   "SELECT x, y FROM t WHERE id=1;" \
@@ -169,13 +143,11 @@ run_test "schema_data_migrate_row3" \
   "SELECT x, y FROM t WHERE id=3;" \
   "x3|30" "$DB"
 
-
 run_test "schema_data_migrate_orig" \
   "SELECT v FROM t WHERE id=1;" \
   "a" "$DB"
 
 rm -f "$DB"
-
 
 DB=/tmp/test_bhv4c_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -183,12 +155,10 @@ INSERT INTO t VALUES(1,'orig');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_branch('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 echo "ALTER TABLE t ADD COLUMN x TEXT;
 UPDATE t SET x='val_x' WHERE id=1;
 INSERT INTO t VALUES(2,'main_new','new_x');
 SELECT dolt_commit('-A','-m','add x with new row');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 echo "SELECT dolt_checkout('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "ALTER TABLE t ADD COLUMN y INTEGER;
@@ -199,11 +169,9 @@ SELECT dolt_commit('-A','-m','add y with new row');" | $DOLTLITE "$DB/b1" > /dev
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_merge('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "schema_data_migrate_both_cols" \
   "SELECT x, y FROM t WHERE id=1;" \
   "val_x|7" "$DB"
-
 
 run_test "schema_data_migrate_main_row" \
   "SELECT x, typeof(y) FROM t WHERE id=2;" \
@@ -211,18 +179,15 @@ run_test "schema_data_migrate_main_row" \
 
 rm -f "$DB"
 
-
 DB=/tmp/test_bhv5_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_branch('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 echo "ALTER TABLE t ADD COLUMN extra TEXT;
 UPDATE t SET extra='hi';
 SELECT dolt_commit('-A','-m','add extra');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 echo "SELECT dolt_checkout('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(2,'b');
@@ -235,7 +200,6 @@ run_test_match "schema_one_side_ok" \
 
 rm -f "$DB"
 
-
 DB=/tmp/test_bhv6_$$.db; rm -f "$DB"
 echo "CREATE TABLE t1(id INTEGER PRIMARY KEY, v TEXT);
 CREATE TABLE t2(id INTEGER PRIMARY KEY, v TEXT);
@@ -244,10 +208,8 @@ INSERT INTO t2 VALUES(1,'x');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_branch('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 echo "UPDATE t1 SET v='A';
 SELECT dolt_commit('-A','-m','t1 change');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 echo "SELECT dolt_checkout('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "UPDATE t2 SET v='X';
@@ -263,18 +225,15 @@ run_test "diff_tables_t2" "SELECT v FROM t2;" "X" "$DB"
 
 rm -f "$DB"
 
-
 DB=/tmp/test_bhv7s_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_branch('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 echo "ALTER TABLE t ADD COLUMN z TEXT;
 UPDATE t SET z='main_z';
 SELECT dolt_commit('-A','-m','add z on main');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 echo "SELECT dolt_checkout('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "ALTER TABLE t ADD COLUMN z TEXT;
@@ -282,14 +241,11 @@ UPDATE t SET z='b1_z';
 SELECT dolt_commit('-A','-m','add z on b1');" | $DOLTLITE "$DB/b1" > /dev/null 2>&1
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
-
 run_test_match "schema_merge_same_col_same_def" \
   "SELECT dolt_merge('b1');" \
   "^[0-9a-f]|conflict" "$DB"
 
 rm -f "$DB"
-
 
 DB=/tmp/test_bhv8s_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -297,10 +253,8 @@ INSERT INTO t VALUES(1,'a');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_branch('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 echo "ALTER TABLE t ADD COLUMN w TEXT;
 SELECT dolt_commit('-A','-m','add w TEXT');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 echo "SELECT dolt_checkout('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "ALTER TABLE t ADD COLUMN w INTEGER;
@@ -313,17 +267,14 @@ run_test_match "schema_merge_same_col_diff_type" \
 
 rm -f "$DB"
 
-
 DB=/tmp/test_bhv9s_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT, extra TEXT);
 INSERT INTO t VALUES(1,'a','e');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_branch('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 echo "ALTER TABLE t ADD COLUMN newcol TEXT;
 SELECT dolt_commit('-A','-m','add newcol');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 echo "SELECT dolt_checkout('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "UPDATE t SET v='b';
@@ -336,12 +287,7 @@ run_test_match "schema_add_col_other_data" \
 
 rm -f "$DB"
 
-
-
-
-
 echo "--- dolt_at working state tests ---"
-
 
 DB=/tmp/test_bhv7_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -354,18 +300,15 @@ SELECT dolt_commit('-A','-m','feat committed');
 INSERT INTO t VALUES(3,'uncommitted');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "at_working_uncommitted_count" \
   "SELECT count(*) FROM dolt_at_t('feature');" \
   "3" "$DB"
-
 
 run_test "at_working_uncommitted_row" \
   "SELECT v FROM dolt_at_t('feature') WHERE id=3;" \
   "uncommitted" "$DB"
 
 rm -f "$DB"
-
 
 DB=/tmp/test_bhv8_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -377,7 +320,6 @@ INSERT INTO t VALUES(2,'feat_row');
 SELECT dolt_commit('-A','-m','feat commit');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "at_committed_count" \
   "SELECT count(*) FROM dolt_at_t('feature');" \
   "2" "$DB"
@@ -387,7 +329,6 @@ run_test "at_committed_row" \
   "feat_row" "$DB"
 
 rm -f "$DB"
-
 
 DB=/tmp/test_bhv9_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -400,11 +341,7 @@ SELECT dolt_commit('-A','-m','feat committed');
 INSERT INTO t VALUES(3,'uncommitted');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 FEAT_HASH=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 0;" | $DOLTLITE "$DB" 2>&1)
-
-
-
 
 echo "SELECT dolt_checkout('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
 FEAT_HASH=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1;" | $DOLTLITE "$DB/feature" 2>&1)
@@ -415,10 +352,6 @@ run_test "at_commit_hash_count" \
   "2" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/doltlite_branch.sh
+++ b/test/doltlite_branch.sh
@@ -78,26 +78,21 @@ echo "SELECT dolt_branch('b2');" | $DOLTLITE "$DB3" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(2);" | $DOLTLITE "$DB3" > /dev/null 2>&1
 run_test "dirty_checkout" "SELECT dolt_checkout('b2');" "0" "$DB3"
 
-
 DB4=/tmp/test_branch4_$$.db; rm -f "$DB4"
 echo "CREATE TABLE t(x INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB4" > /dev/null 2>&1
-
 
 echo "INSERT INTO t VALUES(2,'b'); SELECT dolt_add('-A'); SELECT dolt_reset('--hard');" | $DOLTLITE "$DB4" > /dev/null 2>&1
 echo "SELECT dolt_branch('feat');" | $DOLTLITE "$DB4" > /dev/null 2>&1
 run_test "checkout_after_hard_reset" "SELECT dolt_checkout('feat');" "0" "$DB4"
 run_test "active_after_hard_reset" "SELECT active_branch();" "feat" "$DB4/feat"
 
-
 run_test "checkout_back_after_hard_reset" "SELECT dolt_checkout('main');" "0" "$DB4"
-
 
 DB5=/tmp/test_branch5_$$.db; rm -f "$DB5"
 echo "CREATE TABLE t(x INTEGER PRIMARY KEY); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB5" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(2); SELECT dolt_reset('--hard');" | $DOLTLITE "$DB5" > /dev/null 2>&1
 echo "SELECT dolt_branch('b2');" | $DOLTLITE "$DB5" > /dev/null 2>&1
 run_test "checkout_after_hard_reset_no_stage" "SELECT dolt_checkout('b2');" "0" "$DB5"
-
 
 DB6=/tmp/test_branch6_$$.db; rm -f "$DB6"
 echo "CREATE TABLE t(x INTEGER PRIMARY KEY); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6" > /dev/null 2>&1
@@ -107,7 +102,6 @@ echo "INSERT INTO t VALUES(4); SELECT dolt_reset('--hard');" | $DOLTLITE "$DB6" 
 echo "SELECT dolt_branch('b3');" | $DOLTLITE "$DB6" > /dev/null 2>&1
 run_test "checkout_after_multi_hard_reset" "SELECT dolt_checkout('b3');" "0" "$DB6"
 
-
 DB7=/tmp/test_branch7_$$.db; rm -f "$DB7"
 echo "CREATE TABLE t(x INTEGER PRIMARY KEY); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB7" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(2); SELECT dolt_reset('--hard');" | $DOLTLITE "$DB7" > /dev/null 2>&1
@@ -115,13 +109,11 @@ echo "INSERT INTO t VALUES(99);" | $DOLTLITE "$DB7" > /dev/null 2>&1
 echo "SELECT dolt_branch('b4');" | $DOLTLITE "$DB7" > /dev/null 2>&1
 run_test "dirty_after_hard_reset_new_changes" "SELECT dolt_checkout('b4');" "0" "$DB7"
 
-
 DB8=/tmp/test_branch8_$$.db; rm -f "$DB8"
 echo "CREATE TABLE t(x INTEGER PRIMARY KEY); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB8" > /dev/null 2>&1
 echo "CREATE TABLE extra(y); SELECT dolt_reset('--hard');" | $DOLTLITE "$DB8" > /dev/null 2>&1
 echo "SELECT dolt_branch('b5');" | $DOLTLITE "$DB8" > /dev/null 2>&1
 run_test "checkout_after_schema_change_hard_reset" "SELECT dolt_checkout('b5');" "0" "$DB8"
-
 
 DB9=/tmp/test_branch9_$$.db; rm -f "$DB9"
 echo "CREATE TABLE t(x INTEGER PRIMARY KEY); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB9" > /dev/null 2>&1
@@ -130,12 +122,10 @@ run_test "checkout_b_creates" "SELECT dolt_checkout('-b','newbr');" "0" "$DB9"
 run_test "checkout_b_active" "SELECT active_branch();" "newbr" "$DB9/newbr"
 run_test "checkout_b_listed" "SELECT count(*) FROM dolt_branches;" "2" "$DB9"
 
-
 echo "INSERT INTO t VALUES(2); SELECT dolt_commit('-A','-m','on newbr');" | $DOLTLITE "$DB9/newbr" > /dev/null 2>&1
 run_test "checkout_b_data" "SELECT count(*) FROM t;" "2" "$DB9/newbr"
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB9" > /dev/null 2>&1
 run_test "checkout_b_main_data" "SELECT count(*) FROM t;" "1" "$DB9"
-
 
 run_test_match "checkout_b_dup" "SELECT dolt_checkout('-b','main');" "already exists" "$DB9"
 run_test_match "create_empty_branch_name" "SELECT dolt_branch('');" "branch name required" "$DB9"
@@ -144,10 +134,6 @@ run_test_match "copy_empty_dest" "SELECT dolt_branch('-c','main','');" "branch n
 run_test_match "move_empty_source" "SELECT dolt_branch('-m','','renamed');" "branch name required" "$DB9"
 run_test_match "move_empty_dest" "SELECT dolt_branch('-m','main','');" "branch name required" "$DB9"
 run_test_match "checkout_b_empty_name" "SELECT dolt_checkout('-b','');" "branch name required" "$DB9"
-
-
-
-
 
 DB10=/tmp/test_branch10_$$.db; rm -f "$DB10"
 echo "CREATE TABLE t(x INTEGER PRIMARY KEY); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB10" > /dev/null 2>&1
@@ -158,9 +144,7 @@ run_test_match "force_delete_main_rejected" "SELECT dolt_branch('-D','main');" "
 run_test_match "rename_main_rejected" "SELECT dolt_branch('-m','main','trunk');" "cannot rename branch 'main'" "$DB10/other"
 run_test "main_still_exists" "SELECT count(*) FROM dolt_branches WHERE name='main';" "1" "$DB10/other"
 
-
 run_test "reopen_after_blocked_ops_active" "SELECT active_branch();" "other" "$DB10/other"
-
 
 DB11=/tmp/test_branch11_$$.db; rm -f "$DB11"
 echo "CREATE TABLE t(x INTEGER PRIMARY KEY); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB11" > /dev/null 2>&1
@@ -169,9 +153,7 @@ run_test "rename_non_main_works" "SELECT dolt_branch('-m','feat','renamed');" "0
 run_test "renamed_listed" "SELECT count(*) FROM dolt_branches WHERE name='renamed';" "1" "$DB11"
 run_test "delete_non_main_works" "SELECT dolt_branch('-d','renamed');" "0" "$DB11"
 
-
 run_test "copy_from_main_works" "SELECT dolt_branch('-c','main','snapshot');" "0" "$DB11"
-
 
 DB12=/tmp/test_branch12_$$.db; rm -f "$DB12"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','c1'); INSERT INTO t VALUES(2,'c2'); SELECT dolt_commit('-A','-m','c2'); SELECT dolt_tag('v1','HEAD~1'); SELECT dolt_branch('from_tag','v1');" | $DOLTLITE "$DB12" > /dev/null 2>&1

--- a/test/doltlite_branch.sh
+++ b/test/doltlite_branch.sh
@@ -78,27 +78,27 @@ echo "SELECT dolt_branch('b2');" | $DOLTLITE "$DB3" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(2);" | $DOLTLITE "$DB3" > /dev/null 2>&1
 run_test "dirty_checkout" "SELECT dolt_checkout('b2');" "0" "$DB3"
 
-# --- Checkout after hard reset (issue #107) ---
+
 DB4=/tmp/test_branch4_$$.db; rm -f "$DB4"
 echo "CREATE TABLE t(x INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB4" > /dev/null 2>&1
 
-# Make changes, stage, hard reset, then checkout should work
+
 echo "INSERT INTO t VALUES(2,'b'); SELECT dolt_add('-A'); SELECT dolt_reset('--hard');" | $DOLTLITE "$DB4" > /dev/null 2>&1
 echo "SELECT dolt_branch('feat');" | $DOLTLITE "$DB4" > /dev/null 2>&1
 run_test "checkout_after_hard_reset" "SELECT dolt_checkout('feat');" "0" "$DB4"
 run_test "active_after_hard_reset" "SELECT active_branch();" "feat" "$DB4/feat"
 
-# Checkout back should also work (clean state)
+
 run_test "checkout_back_after_hard_reset" "SELECT dolt_checkout('main');" "0" "$DB4"
 
-# Hard reset with no prior staging
+
 DB5=/tmp/test_branch5_$$.db; rm -f "$DB5"
 echo "CREATE TABLE t(x INTEGER PRIMARY KEY); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB5" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(2); SELECT dolt_reset('--hard');" | $DOLTLITE "$DB5" > /dev/null 2>&1
 echo "SELECT dolt_branch('b2');" | $DOLTLITE "$DB5" > /dev/null 2>&1
 run_test "checkout_after_hard_reset_no_stage" "SELECT dolt_checkout('b2');" "0" "$DB5"
 
-# Multiple hard resets then checkout
+
 DB6=/tmp/test_branch6_$$.db; rm -f "$DB6"
 echo "CREATE TABLE t(x INTEGER PRIMARY KEY); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(2); SELECT dolt_reset('--hard');" | $DOLTLITE "$DB6" > /dev/null 2>&1
@@ -107,7 +107,7 @@ echo "INSERT INTO t VALUES(4); SELECT dolt_reset('--hard');" | $DOLTLITE "$DB6" 
 echo "SELECT dolt_branch('b3');" | $DOLTLITE "$DB6" > /dev/null 2>&1
 run_test "checkout_after_multi_hard_reset" "SELECT dolt_checkout('b3');" "0" "$DB6"
 
-# Verify dirty check still works after hard reset + new changes
+
 DB7=/tmp/test_branch7_$$.db; rm -f "$DB7"
 echo "CREATE TABLE t(x INTEGER PRIMARY KEY); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB7" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(2); SELECT dolt_reset('--hard');" | $DOLTLITE "$DB7" > /dev/null 2>&1
@@ -115,14 +115,14 @@ echo "INSERT INTO t VALUES(99);" | $DOLTLITE "$DB7" > /dev/null 2>&1
 echo "SELECT dolt_branch('b4');" | $DOLTLITE "$DB7" > /dev/null 2>&1
 run_test "dirty_after_hard_reset_new_changes" "SELECT dolt_checkout('b4');" "0" "$DB7"
 
-# Schema change (CREATE TABLE) then hard reset then checkout
+
 DB8=/tmp/test_branch8_$$.db; rm -f "$DB8"
 echo "CREATE TABLE t(x INTEGER PRIMARY KEY); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB8" > /dev/null 2>&1
 echo "CREATE TABLE extra(y); SELECT dolt_reset('--hard');" | $DOLTLITE "$DB8" > /dev/null 2>&1
 echo "SELECT dolt_branch('b5');" | $DOLTLITE "$DB8" > /dev/null 2>&1
 run_test "checkout_after_schema_change_hard_reset" "SELECT dolt_checkout('b5');" "0" "$DB8"
 
-# --- dolt_checkout('-b', 'name') creates and switches ---
+
 DB9=/tmp/test_branch9_$$.db; rm -f "$DB9"
 echo "CREATE TABLE t(x INTEGER PRIMARY KEY); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB9" > /dev/null 2>&1
 
@@ -130,13 +130,13 @@ run_test "checkout_b_creates" "SELECT dolt_checkout('-b','newbr');" "0" "$DB9"
 run_test "checkout_b_active" "SELECT active_branch();" "newbr" "$DB9/newbr"
 run_test "checkout_b_listed" "SELECT count(*) FROM dolt_branches;" "2" "$DB9"
 
-# Work on the new branch, switch back, verify isolation
+
 echo "INSERT INTO t VALUES(2); SELECT dolt_commit('-A','-m','on newbr');" | $DOLTLITE "$DB9/newbr" > /dev/null 2>&1
 run_test "checkout_b_data" "SELECT count(*) FROM t;" "2" "$DB9/newbr"
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB9" > /dev/null 2>&1
 run_test "checkout_b_main_data" "SELECT count(*) FROM t;" "1" "$DB9"
 
-# checkout -b with existing name errors
+
 run_test_match "checkout_b_dup" "SELECT dolt_checkout('-b','main');" "already exists" "$DB9"
 run_test_match "create_empty_branch_name" "SELECT dolt_branch('');" "branch name required" "$DB9"
 run_test_match "copy_empty_source" "SELECT dolt_branch('-c','','copy');" "branch name required" "$DB9"
@@ -145,10 +145,10 @@ run_test_match "move_empty_source" "SELECT dolt_branch('-m','','renamed');" "bra
 run_test_match "move_empty_dest" "SELECT dolt_branch('-m','main','');" "branch name required" "$DB9"
 run_test_match "checkout_b_empty_name" "SELECT dolt_checkout('-b','');" "branch name required" "$DB9"
 
-# --- main protection: cannot delete or rename main ---
-# doltlite's session-branch resolver falls back to literal "main" on reopen,
-# so allowing main to go away would leave the repo unopenable. Reject until
-# proper default-branch logic lands.
+
+
+
+
 DB10=/tmp/test_branch10_$$.db; rm -f "$DB10"
 echo "CREATE TABLE t(x INTEGER PRIMARY KEY); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB10" > /dev/null 2>&1
 echo "SELECT dolt_checkout('-b','other');" | $DOLTLITE "$DB10" > /dev/null 2>&1
@@ -158,10 +158,10 @@ run_test_match "force_delete_main_rejected" "SELECT dolt_branch('-D','main');" "
 run_test_match "rename_main_rejected" "SELECT dolt_branch('-m','main','trunk');" "cannot rename branch 'main'" "$DB10/other"
 run_test "main_still_exists" "SELECT count(*) FROM dolt_branches WHERE name='main';" "1" "$DB10/other"
 
-# Reopening still works — main resolves
+
 run_test "reopen_after_blocked_ops_active" "SELECT active_branch();" "other" "$DB10/other"
 
-# Non-main rename and delete still work
+
 DB11=/tmp/test_branch11_$$.db; rm -f "$DB11"
 echo "CREATE TABLE t(x INTEGER PRIMARY KEY); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB11" > /dev/null 2>&1
 echo "SELECT dolt_branch('feat');" | $DOLTLITE "$DB11" > /dev/null 2>&1
@@ -169,10 +169,10 @@ run_test "rename_non_main_works" "SELECT dolt_branch('-m','feat','renamed');" "0
 run_test "renamed_listed" "SELECT count(*) FROM dolt_branches WHERE name='renamed';" "1" "$DB11"
 run_test "delete_non_main_works" "SELECT dolt_branch('-d','renamed');" "0" "$DB11"
 
-# Copy from main is still allowed — it doesn't remove main
+
 run_test "copy_from_main_works" "SELECT dolt_branch('-c','main','snapshot');" "0" "$DB11"
 
-# --- branch creation from refs persists across reopen ---
+
 DB12=/tmp/test_branch12_$$.db; rm -f "$DB12"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','c1'); INSERT INTO t VALUES(2,'c2'); SELECT dolt_commit('-A','-m','c2'); SELECT dolt_tag('v1','HEAD~1'); SELECT dolt_branch('from_tag','v1');" | $DOLTLITE "$DB12" > /dev/null 2>&1
 run_test "branch_from_tag_persists_across_reopen" "SELECT count(*) FROM t;" "1" "$DB12/from_tag"

--- a/test/doltlite_branch_edge.sh
+++ b/test/doltlite_branch_edge.sh
@@ -1,26 +1,15 @@
 #!/bin/bash
-
-
-
-
-
 DOLTLITE=${DOLTLITE:-./doltlite}
 PASS=0; FAIL=0; ERRORS=""
 run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); echo "  PASS: $n"; else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; echo "  FAIL: $n"; echo "    expected: $e"; echo "    got:      $r"; fi; }
 run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if echo "$r"|grep -qE "$p"; then PASS=$((PASS+1)); echo "  PASS: $n"; else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  pattern: $p\n  got:     $r"; echo "  FAIL: $n"; echo "    pattern: $p"; echo "    got:     $r"; fi; }
-
 
 db_rm() { rm -f "$1" "${1}-wal" "${1}-journal"; }
 
 echo "=== Doltlite Branch Edge Case Tests ==="
 echo ""
 
-
-
-
-
 echo "--- Category 1: Branch lifecycle edge cases ---"
-
 
 DB=/tmp/test_bedge_lifecycle_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -33,9 +22,7 @@ INSERT INTO t VALUES(2,'old_branch_data');
 SELECT dolt_commit('-A','-m','old branch commit');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 echo "SELECT dolt_branch('-D','temp');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 echo "SELECT dolt_branch('temp');
 SELECT dolt_checkout('temp');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -44,13 +31,11 @@ run_test "lifecycle_recreate_count" "SELECT count(*) FROM t;" "1" "$DB"
 run_test "lifecycle_recreate_no_old_data" "SELECT count(*) FROM t WHERE id=2;" "0" "$DB"
 db_rm "$DB"
 
-
 DB=/tmp/test_bedge_delnone_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(x); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test_match "delete_nonexistent_branch" "SELECT dolt_branch('-d','nope');" "not found" "$DB"
 db_rm "$DB"
-
 
 DB=/tmp/test_bedge_dup_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(x); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -59,14 +44,12 @@ echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "create_duplicate_branch" "SELECT dolt_branch('feature');" "already exists" "$DB"
 db_rm "$DB"
 
-
 DB=/tmp/test_bedge_delcur_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(x); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_branch('feat'); SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test_match "delete_current_branch" "SELECT dolt_branch('-d','feat');" "cannot delete" "$DB/feat"
 db_rm "$DB"
-
 
 DB=/tmp/test_bedge_tag_branch_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -76,20 +59,12 @@ SELECT dolt_tag('v1.0');
 INSERT INTO t VALUES(2,'v2');
 SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
-
-
 run_test "tag_branch_create" "SELECT dolt_branch('from_tag');" "0" "$DB"
 db_rm "$DB"
 
 echo ""
 
-
-
-
-
 echo "--- Category 2: Cross-session persistence ---"
-
 
 DB=/tmp/test_bedge_xsess1_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -97,11 +72,9 @@ INSERT INTO t VALUES(1,'hello');
 INSERT INTO t VALUES(2,'world');
 SELECT dolt_commit('-A','-m','initial');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "xsess_data_visible" "SELECT count(*) FROM t;" "2" "$DB"
 run_test "xsess_data_val" "SELECT v FROM t WHERE id=1;" "hello" "$DB"
 db_rm "$DB"
-
 
 DB=/tmp/test_bedge_xsess2_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -113,12 +86,10 @@ INSERT INTO t VALUES(2,'dev_data');
 SELECT dolt_commit('-A','-m','dev commit');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 echo "SELECT dolt_checkout('dev');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "xsess_branch_count" "SELECT count(*) FROM t;" "2" "$DB/dev"
 run_test "xsess_branch_val" "SELECT v FROM t WHERE id=2;" "dev_data" "$DB/dev"
 db_rm "$DB"
-
 
 DB=/tmp/test_bedge_xsess3_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -131,11 +102,9 @@ SELECT dolt_commit('-A','-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "xsess_merge_count" "SELECT count(*) FROM t;" "2" "$DB"
 run_test "xsess_merge_val" "SELECT v FROM t WHERE id=2;" "feat_row" "$DB"
 db_rm "$DB"
-
 
 DB=/tmp/test_bedge_xsess4_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -147,7 +116,6 @@ SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 C1=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1;" | $DOLTLITE "$DB" 2>&1)
 echo "SELECT dolt_reset('--hard','$C1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "xsess_reset_count" "SELECT count(*) FROM t;" "1" "$DB"
 run_test "xsess_reset_val" "SELECT v FROM t WHERE id=1;" "keep" "$DB"
 run_test "xsess_reset_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
@@ -155,12 +123,7 @@ db_rm "$DB"
 
 echo ""
 
-
-
-
-
 echo "--- Category 3: Multi-branch diff/history ---"
-
 
 DB=/tmp/test_bedge_mbdiff_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -174,19 +137,16 @@ INSERT INTO t VALUES(3,'feat_row');
 SELECT dolt_commit('-A','-m','feat adds row 3');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 MAIN_HEAD=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1;" | $DOLTLITE "$DB" 2>&1)
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 FEAT_HEAD=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1;" | $DOLTLITE "$DB/feat" 2>&1)
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 run_test_match "diff_cross_branch" \
   "SELECT coalesce(sum(rows_added + rows_deleted + rows_modified), 0) FROM dolt_diff_stat('$FEAT_HEAD', '$MAIN_HEAD', 't');" \
   "^[1-9]" "$DB"
 
 db_rm "$DB"
-
 
 DB=/tmp/test_bedge_ffhist_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -201,15 +161,12 @@ SELECT dolt_commit('-A','-m','feat commit 2');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test_match "ff_history_count" \
   "SELECT count(*) FROM dolt_history_t;" \
   "^[3-9]" "$DB"
 
-
 run_test "ff_log_no_merge" "SELECT message FROM dolt_log LIMIT 1;" "feat commit 2" "$DB"
 run_test "ff_log_count" "SELECT count(*) FROM dolt_log;" "4" "$DB"
-
 
 DB2=/tmp/test_bedge_at_branch_$$.db; db_rm "$DB2"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -234,12 +191,7 @@ db_rm "$DB" "$DB2"
 
 echo ""
 
-
-
-
-
 echo "--- Category 4: Reset edge cases ---"
-
 
 DB=/tmp/test_bedge_reset1_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -255,7 +207,6 @@ echo "SELECT dolt_reset('--hard');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "reset_hard_discard" "SELECT count(*) FROM t;" "1" "$DB"
 run_test "reset_hard_clean" "SELECT count(*) FROM dolt_status;" "0" "$DB"
 db_rm "$DB"
-
 
 DB=/tmp/test_bedge_reset2_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -278,7 +229,6 @@ run_test "reset_hash_val" "SELECT v FROM t WHERE id=1;" "v1" "$DB"
 run_test "reset_hash_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 db_rm "$DB"
 
-
 DB=/tmp/test_bedge_reset3_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'init');
@@ -295,7 +245,6 @@ run_test "reset_unstaged" \
   "SELECT count(*) FROM dolt_status WHERE staged=1;" "0" "$DB"
 run_test "reset_data_kept" "SELECT count(*) FROM t;" "2" "$DB"
 db_rm "$DB"
-
 
 DB=/tmp/test_bedge_reset4_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -315,12 +264,7 @@ db_rm "$DB"
 
 echo ""
 
-
-
-
-
 echo "--- Category 5: Schema changes across branches ---"
-
 
 DB=/tmp/test_bedge_schema1_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -337,14 +281,12 @@ run_test "schema_main_no_extra" \
   "SELECT count(*) FROM pragma_table_info('t') WHERE name='extra';" \
   "0" "$DB"
 
-
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "schema_feat_has_extra" \
   "SELECT count(*) FROM pragma_table_info('t') WHERE name='extra';" \
   "1" "$DB/feat"
 run_test "schema_feat_extra_val" "SELECT extra FROM t WHERE id=1;" "new" "$DB/feat"
 db_rm "$DB"
-
 
 DB=/tmp/test_bedge_schema2_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -357,18 +299,15 @@ INSERT INTO new_table VALUES(1,'from_feat');
 SELECT dolt_commit('-A','-m','add new_table');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test_match "schema_merge_pre_no_table" \
   "SELECT count(*) FROM new_table;" \
   "no such table" "$DB"
 
 echo "SELECT dolt_merge('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "schema_merge_post_table" "SELECT count(*) FROM new_table;" "1" "$DB"
 run_test "schema_merge_post_val" "SELECT w FROM new_table WHERE id=1;" "from_feat" "$DB"
 db_rm "$DB"
-
 
 DB=/tmp/test_bedge_schema3_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -382,11 +321,9 @@ DROP TABLE drop_me;
 SELECT dolt_commit('-A','-m','drop table');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "schema_drop_pre" "SELECT count(*) FROM drop_me;" "1" "$DB"
 
 echo "SELECT dolt_merge('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 run_test_match "schema_drop_post" \
   "SELECT count(*) FROM drop_me;" \
@@ -396,12 +333,7 @@ db_rm "$DB"
 
 echo ""
 
-
-
-
-
 echo "--- Category 6: Merge edge cases ---"
-
 
 DB=/tmp/test_bedge_merge1_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -411,7 +343,6 @@ SELECT dolt_branch('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "merge_up_to_date" "SELECT dolt_merge('feat');" "Already up to date" "$DB"
 db_rm "$DB"
-
 
 DB=/tmp/test_bedge_merge2_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -423,20 +354,15 @@ INSERT INTO t VALUES(2,'cherry');
 SELECT dolt_commit('-A','-m','feat: add cherry');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 echo "SELECT dolt_cherry_pick('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
-
 
 run_test_match "merge_after_cp" \
   "SELECT dolt_merge('feat');" \
   "up to date|^[0-9a-f]{40}$" "$DB"
 
-
 run_test "merge_after_cp_count" "SELECT count(*) FROM t;" "2" "$DB"
 run_test "merge_after_cp_val" "SELECT v FROM t WHERE id=2;" "cherry" "$DB"
 db_rm "$DB"
-
 
 DB=/tmp/test_bedge_merge3_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -451,11 +377,9 @@ SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "ff_merge_hash" "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB"
 run_test "ff_merge_data" "SELECT count(*) FROM t;" "2" "$DB"
 run_test "ff_merge_val" "SELECT v FROM t WHERE id=2;" "ff_data" "$DB"
-
 run_test "ff_merge_no_merge_commit" "SELECT message FROM dolt_log LIMIT 1;" "feat commit" "$DB"
 run_test "ff_merge_log_count" "SELECT count(*) FROM dolt_log;" "3" "$DB"
 db_rm "$DB"
-
 
 DB=/tmp/test_bedge_merge4_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -473,34 +397,24 @@ run_test_match "noff_merge_hash" "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "
 run_test "noff_merge_count" "SELECT count(*) FROM t;" "3" "$DB"
 run_test "noff_merge_main_row" "SELECT v FROM t WHERE id=2;" "main_row" "$DB"
 run_test "noff_merge_feat_row" "SELECT v FROM t WHERE id=3;" "feat_row" "$DB"
-
 run_test_match "noff_merge_commit_msg" "SELECT message FROM dolt_log LIMIT 1;" "Merge" "$DB"
-
 run_test "noff_merge_log_count" "SELECT count(*) FROM dolt_log;" "5" "$DB"
 db_rm "$DB"
 
 echo ""
 
-
-
-
-
 echo "--- Category 7: GC edge cases ---"
-
 
 DB=/tmp/test_bedge_gc1_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 echo "SELECT dolt_gc();" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 run_test_match "gc_noop" "SELECT dolt_gc();" "0 chunks removed" "$DB"
 run_test "gc_noop_data" "SELECT count(*) FROM t;" "1" "$DB"
 db_rm "$DB"
-
 
 DB=/tmp/test_bedge_gc2_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -516,12 +430,10 @@ run_test_match "gc_many_commits" "SELECT dolt_gc();" "chunks" "$DB"
 run_test "gc_many_val" "SELECT v FROM t WHERE id=1;" "v15" "$DB"
 run_test "gc_many_log" "SELECT count(*) FROM dolt_log;" "17" "$DB"
 
-
 run_test_match "gc_many_history" \
   "SELECT count(*) FROM dolt_history_t;" \
   "^16$" "$DB"
 db_rm "$DB"
-
 
 DB=/tmp/test_bedge_gc3_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
@@ -533,10 +445,6 @@ run_test "gc_empty_db_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 db_rm "$DB"
 
 echo ""
-
-
-
-
 
 echo "=== Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests ==="
 if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi

--- a/test/doltlite_branch_edge.sh
+++ b/test/doltlite_branch_edge.sh
@@ -1,27 +1,27 @@
 #!/bin/bash
-#
-# Comprehensive edge-case tests for branch interactions, cross-session
-# persistence, multi-branch diff/history, reset, schema changes across
-# branches, merge edge cases, and GC edge cases in doltlite.
-#
+
+
+
+
+
 DOLTLITE=${DOLTLITE:-./doltlite}
 PASS=0; FAIL=0; ERRORS=""
 run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); echo "  PASS: $n"; else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; echo "  FAIL: $n"; echo "    expected: $e"; echo "    got:      $r"; fi; }
 run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if echo "$r"|grep -qE "$p"; then PASS=$((PASS+1)); echo "  PASS: $n"; else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  pattern: $p\n  got:     $r"; echo "  FAIL: $n"; echo "    pattern: $p"; echo "    got:     $r"; fi; }
 
-# Helper to clean up DB + WAL files
+
 db_rm() { rm -f "$1" "${1}-wal" "${1}-journal"; }
 
 echo "=== Doltlite Branch Edge Case Tests ==="
 echo ""
 
-# ############################################################
-# Category 1: Branch lifecycle edge cases
-# ############################################################
+
+
+
 
 echo "--- Category 1: Branch lifecycle edge cases ---"
 
-# Test: Create branch, delete it, recreate with same name -- old data should be gone
+
 DB=/tmp/test_bedge_lifecycle_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'init');
@@ -33,10 +33,10 @@ INSERT INTO t VALUES(2,'old_branch_data');
 SELECT dolt_commit('-A','-m','old branch commit');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Delete the branch
+
 echo "SELECT dolt_branch('-D','temp');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Recreate with same name -- should start from main's HEAD (1 row)
+
 echo "SELECT dolt_branch('temp');
 SELECT dolt_checkout('temp');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
@@ -44,14 +44,14 @@ run_test "lifecycle_recreate_count" "SELECT count(*) FROM t;" "1" "$DB"
 run_test "lifecycle_recreate_no_old_data" "SELECT count(*) FROM t WHERE id=2;" "0" "$DB"
 db_rm "$DB"
 
-# Test: Delete branch that doesn't exist -- should error
+
 DB=/tmp/test_bedge_delnone_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(x); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test_match "delete_nonexistent_branch" "SELECT dolt_branch('-d','nope');" "not found" "$DB"
 db_rm "$DB"
 
-# Test: Create branch that already exists -- should error
+
 DB=/tmp/test_bedge_dup_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(x); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -59,7 +59,7 @@ echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "create_duplicate_branch" "SELECT dolt_branch('feature');" "already exists" "$DB"
 db_rm "$DB"
 
-# Test: Delete the current branch -- should error
+
 DB=/tmp/test_bedge_delcur_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(x); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_branch('feat'); SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -67,7 +67,7 @@ echo "SELECT dolt_branch('feat'); SELECT dolt_checkout('feat');" | $DOLTLITE "$D
 run_test_match "delete_current_branch" "SELECT dolt_branch('-d','feat');" "cannot delete" "$DB/feat"
 db_rm "$DB"
 
-# Test: Branch from a specific tag
+
 DB=/tmp/test_bedge_tag_branch_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'v1');
@@ -76,33 +76,33 @@ SELECT dolt_tag('v1.0');
 INSERT INTO t VALUES(2,'v2');
 SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Create a branch from the tag -- dolt_branch with a start point
-# If dolt_branch supports a start point argument, test it; otherwise this may just
-# create from HEAD. We test by checking the branch exists.
+
+
+
 run_test "tag_branch_create" "SELECT dolt_branch('from_tag');" "0" "$DB"
 db_rm "$DB"
 
 echo ""
 
-# ############################################################
-# Category 2: Cross-session persistence
-# ############################################################
+
+
+
 
 echo "--- Category 2: Cross-session persistence ---"
 
-# Test: Session 1 creates table/inserts/commits; Session 2 sees data
+
 DB=/tmp/test_bedge_xsess1_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'hello');
 INSERT INTO t VALUES(2,'world');
 SELECT dolt_commit('-A','-m','initial');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Session 2: new CLI invocation
+
 run_test "xsess_data_visible" "SELECT count(*) FROM t;" "2" "$DB"
 run_test "xsess_data_val" "SELECT v FROM t WHERE id=1;" "hello" "$DB"
 db_rm "$DB"
 
-# Test: Session 1 creates branch + commits; Session 2 checks out and sees data
+
 DB=/tmp/test_bedge_xsess2_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'init');
@@ -113,13 +113,13 @@ INSERT INTO t VALUES(2,'dev_data');
 SELECT dolt_commit('-A','-m','dev commit');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Session 2: checkout dev, verify data
+
 echo "SELECT dolt_checkout('dev');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "xsess_branch_count" "SELECT count(*) FROM t;" "2" "$DB/dev"
 run_test "xsess_branch_val" "SELECT v FROM t WHERE id=2;" "dev_data" "$DB/dev"
 db_rm "$DB"
 
-# Test: Session 1 merges; Session 2 verifies merge result
+
 DB=/tmp/test_bedge_xsess3_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'init');
@@ -131,12 +131,12 @@ SELECT dolt_commit('-A','-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Session 2: verify merge result
+
 run_test "xsess_merge_count" "SELECT count(*) FROM t;" "2" "$DB"
 run_test "xsess_merge_val" "SELECT v FROM t WHERE id=2;" "feat_row" "$DB"
 db_rm "$DB"
 
-# Test: Session 1 hard resets; Session 2 sees reset state
+
 DB=/tmp/test_bedge_xsess4_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'keep');
@@ -147,7 +147,7 @@ SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 C1=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1;" | $DOLTLITE "$DB" 2>&1)
 echo "SELECT dolt_reset('--hard','$C1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Session 2: verify reset took effect
+
 run_test "xsess_reset_count" "SELECT count(*) FROM t;" "1" "$DB"
 run_test "xsess_reset_val" "SELECT v FROM t WHERE id=1;" "keep" "$DB"
 run_test "xsess_reset_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
@@ -155,13 +155,13 @@ db_rm "$DB"
 
 echo ""
 
-# ############################################################
-# Category 3: Multi-branch diff/history
-# ############################################################
+
+
+
 
 echo "--- Category 3: Multi-branch diff/history ---"
 
-# Setup: two branches with different commits
+
 DB=/tmp/test_bedge_mbdiff_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'init');
@@ -174,20 +174,20 @@ INSERT INTO t VALUES(3,'feat_row');
 SELECT dolt_commit('-A','-m','feat adds row 3');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Get commit hashes for cross-branch diff
+
 MAIN_HEAD=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1;" | $DOLTLITE "$DB" 2>&1)
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 FEAT_HEAD=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1;" | $DOLTLITE "$DB/feat" 2>&1)
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Test: dolt_diff between two different branches' commits
+
 run_test_match "diff_cross_branch" \
   "SELECT coalesce(sum(rows_added + rows_deleted + rows_modified), 0) FROM dolt_diff_stat('$FEAT_HEAD', '$MAIN_HEAD', 't');" \
   "^[1-9]" "$DB"
 
 db_rm "$DB"
 
-# Setup: fast-forward merge for history/log tests
+
 DB=/tmp/test_bedge_ffhist_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'init');
@@ -201,16 +201,16 @@ SELECT dolt_commit('-A','-m','feat commit 2');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Test: dolt_history after fast-forward merge -- should show linear history
+
 run_test_match "ff_history_count" \
   "SELECT count(*) FROM dolt_history_t;" \
   "^[3-9]" "$DB"
 
-# Test: dolt_log after fast-forward merge -- no merge commit
+
 run_test "ff_log_no_merge" "SELECT message FROM dolt_log LIMIT 1;" "feat commit 2" "$DB"
 run_test "ff_log_count" "SELECT count(*) FROM dolt_log;" "4" "$DB"
 
-# Test: dolt_at with branch name shows branch's committed state
+
 DB2=/tmp/test_bedge_at_branch_$$.db; db_rm "$DB2"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'shared');
@@ -234,13 +234,13 @@ db_rm "$DB" "$DB2"
 
 echo ""
 
-# ############################################################
-# Category 4: Reset edge cases
-# ############################################################
+
+
+
 
 echo "--- Category 4: Reset edge cases ---"
 
-# Test: Hard reset discards uncommitted changes
+
 DB=/tmp/test_bedge_reset1_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'committed');
@@ -256,7 +256,7 @@ run_test "reset_hard_discard" "SELECT count(*) FROM t;" "1" "$DB"
 run_test "reset_hard_clean" "SELECT count(*) FROM dolt_status;" "0" "$DB"
 db_rm "$DB"
 
-# Test: Hard reset to a specific commit hash
+
 DB=/tmp/test_bedge_reset2_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'v1');
@@ -278,7 +278,7 @@ run_test "reset_hash_val" "SELECT v FROM t WHERE id=1;" "v1" "$DB"
 run_test "reset_hash_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 db_rm "$DB"
 
-# Test: Soft reset unstages but keeps working changes
+
 DB=/tmp/test_bedge_reset3_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'init');
@@ -296,7 +296,7 @@ run_test "reset_unstaged" \
 run_test "reset_data_kept" "SELECT count(*) FROM t;" "2" "$DB"
 db_rm "$DB"
 
-# Test: Hard reset then checkout another branch
+
 DB=/tmp/test_bedge_reset4_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'init');
@@ -315,13 +315,13 @@ db_rm "$DB"
 
 echo ""
 
-# ############################################################
-# Category 5: Schema changes across branches
-# ############################################################
+
+
+
 
 echo "--- Category 5: Schema changes across branches ---"
 
-# Test: Add column on branch, checkout main -- main should have old schema
+
 DB=/tmp/test_bedge_schema1_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
@@ -337,7 +337,7 @@ run_test "schema_main_no_extra" \
   "SELECT count(*) FROM pragma_table_info('t') WHERE name='extra';" \
   "0" "$DB"
 
-# Switch back to feat: extra column should be there
+
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "schema_feat_has_extra" \
   "SELECT count(*) FROM pragma_table_info('t') WHERE name='extra';" \
@@ -345,7 +345,7 @@ run_test "schema_feat_has_extra" \
 run_test "schema_feat_extra_val" "SELECT extra FROM t WHERE id=1;" "new" "$DB/feat"
 db_rm "$DB"
 
-# Test: Create table on branch, merge to main -- main should have the new table
+
 DB=/tmp/test_bedge_schema2_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'init');
@@ -357,19 +357,19 @@ INSERT INTO new_table VALUES(1,'from_feat');
 SELECT dolt_commit('-A','-m','add new_table');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Before merge, new_table shouldn't exist on main
+
 run_test_match "schema_merge_pre_no_table" \
   "SELECT count(*) FROM new_table;" \
   "no such table" "$DB"
 
 echo "SELECT dolt_merge('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# After merge, new_table should exist
+
 run_test "schema_merge_post_table" "SELECT count(*) FROM new_table;" "1" "$DB"
 run_test "schema_merge_post_val" "SELECT w FROM new_table WHERE id=1;" "from_feat" "$DB"
 db_rm "$DB"
 
-# Test: Drop table on branch, merge to main (ff) -- main should NOT have the table
+
 DB=/tmp/test_bedge_schema3_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 CREATE TABLE drop_me(id INTEGER PRIMARY KEY, w TEXT);
@@ -382,12 +382,12 @@ DROP TABLE drop_me;
 SELECT dolt_commit('-A','-m','drop table');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Before merge, drop_me still exists on main
+
 run_test "schema_drop_pre" "SELECT count(*) FROM drop_me;" "1" "$DB"
 
 echo "SELECT dolt_merge('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# After ff merge, drop_me should be gone
+
 run_test_match "schema_drop_post" \
   "SELECT count(*) FROM drop_me;" \
   "no such table" "$DB"
@@ -396,13 +396,13 @@ db_rm "$DB"
 
 echo ""
 
-# ############################################################
-# Category 6: Merge edge cases
-# ############################################################
+
+
+
 
 echo "--- Category 6: Merge edge cases ---"
 
-# Test: Merge branch with no changes (already up to date)
+
 DB=/tmp/test_bedge_merge1_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
@@ -412,7 +412,7 @@ SELECT dolt_branch('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "merge_up_to_date" "SELECT dolt_merge('feat');" "Already up to date" "$DB"
 db_rm "$DB"
 
-# Test: Merge after cherry-pick -- cherry-picked commit shouldn't cause conflict
+
 DB=/tmp/test_bedge_merge2_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'init');
@@ -423,21 +423,21 @@ INSERT INTO t VALUES(2,'cherry');
 SELECT dolt_commit('-A','-m','feat: add cherry');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Cherry-pick the feat commit onto main
+
 echo "SELECT dolt_cherry_pick('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Now merge feat into main -- the cherry-picked row already exists
-# This should succeed without conflict (either "already up to date" or clean merge)
+
+
 run_test_match "merge_after_cp" \
   "SELECT dolt_merge('feat');" \
   "up to date|^[0-9a-f]{40}$" "$DB"
 
-# Data should be intact
+
 run_test "merge_after_cp_count" "SELECT count(*) FROM t;" "2" "$DB"
 run_test "merge_after_cp_val" "SELECT v FROM t WHERE id=2;" "cherry" "$DB"
 db_rm "$DB"
 
-# Test: Fast-forward merge -- no merge commit, data correct
+
 DB=/tmp/test_bedge_merge3_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'init');
@@ -451,12 +451,12 @@ SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "ff_merge_hash" "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB"
 run_test "ff_merge_data" "SELECT count(*) FROM t;" "2" "$DB"
 run_test "ff_merge_val" "SELECT v FROM t WHERE id=2;" "ff_data" "$DB"
-# No merge commit: last message should be feat's commit
+
 run_test "ff_merge_no_merge_commit" "SELECT message FROM dolt_log LIMIT 1;" "feat commit" "$DB"
 run_test "ff_merge_log_count" "SELECT count(*) FROM dolt_log;" "3" "$DB"
 db_rm "$DB"
 
-# Test: Non-fast-forward merge -- merge commit exists, data from both branches
+
 DB=/tmp/test_bedge_merge4_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'init');
@@ -473,35 +473,35 @@ run_test_match "noff_merge_hash" "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "
 run_test "noff_merge_count" "SELECT count(*) FROM t;" "3" "$DB"
 run_test "noff_merge_main_row" "SELECT v FROM t WHERE id=2;" "main_row" "$DB"
 run_test "noff_merge_feat_row" "SELECT v FROM t WHERE id=3;" "feat_row" "$DB"
-# Non-ff merge should have a merge commit
+
 run_test_match "noff_merge_commit_msg" "SELECT message FROM dolt_log LIMIT 1;" "Merge" "$DB"
-# Log should have: merge, main adds, feat adds, init = 4 commits
+
 run_test "noff_merge_log_count" "SELECT count(*) FROM dolt_log;" "5" "$DB"
 db_rm "$DB"
 
 echo ""
 
-# ############################################################
-# Category 7: GC edge cases
-# ############################################################
+
+
+
 
 echo "--- Category 7: GC edge cases ---"
 
-# Test: GC with no garbage -- should be a no-op
+
 DB=/tmp/test_bedge_gc1_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Run GC once to clean up any intermediate chunks
+
 echo "SELECT dolt_gc();" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Second GC should find nothing to remove
+
 run_test_match "gc_noop" "SELECT dolt_gc();" "0 chunks removed" "$DB"
 run_test "gc_noop_data" "SELECT count(*) FROM t;" "1" "$DB"
 db_rm "$DB"
 
-# Test: GC after many commits -- should not lose any reachable data
+
 DB=/tmp/test_bedge_gc2_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'v0');
@@ -516,13 +516,13 @@ run_test_match "gc_many_commits" "SELECT dolt_gc();" "chunks" "$DB"
 run_test "gc_many_val" "SELECT v FROM t WHERE id=1;" "v15" "$DB"
 run_test "gc_many_log" "SELECT count(*) FROM dolt_log;" "17" "$DB"
 
-# Verify old commits still reachable via dolt_at
+
 run_test_match "gc_many_history" \
   "SELECT count(*) FROM dolt_history_t;" \
   "^16$" "$DB"
 db_rm "$DB"
 
-# Test: GC on an empty database -- should not error
+
 DB=/tmp/test_bedge_gc3_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
 SELECT dolt_commit('-A','-m','empty');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -534,9 +534,9 @@ db_rm "$DB"
 
 echo ""
 
-# ############################################################
-# Summary
-# ############################################################
+
+
+
 
 echo "=== Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests ==="
 if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi

--- a/test/doltlite_branch_gc_stress.sh
+++ b/test/doltlite_branch_gc_stress.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-#
-# Stress tests for many branches + garbage collection.
-#
+
+
+
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(30);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
@@ -22,18 +22,18 @@ db_rm() { rm -f "$1" "${1}-wal"; }
 echo "=== Doltlite Branch & GC Stress Tests ==="
 echo ""
 
-# ============================================================
-# Setup: create DB with table and initial commit
-# ============================================================
+
+
+
 
 DB=/tmp/test_branch_gc_stress_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, branch_name TEXT, val INTEGER);
 INSERT INTO t VALUES(0,'main',0);
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# ============================================================
-# 1. Create 100 branches, each with a unique commit
-# ============================================================
+
+
+
 
 echo "  Creating 100 branches..."
 for i in $(seq 1 100); do
@@ -45,39 +45,39 @@ SELECT dolt_commit('-A','-m','commit on b$i');" | $DOLTLITE "$DB/b$i" > /dev/nul
 done
 echo "  Done creating branches."
 
-# ============================================================
-# 2. Verify 101 branches (100 + main)
-# ============================================================
+
+
+
 
 run_test "many_branches_count" "SELECT count(*) FROM dolt_branches;" "101" "$DB"
 
-# ============================================================
-# 3. Checkout branch #50, verify correct data
-# ============================================================
+
+
+
 
 echo "SELECT dolt_checkout('b50');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "checkout_b50_data" "SELECT val FROM t WHERE id=50;" "50" "$DB/b50"
 run_test "checkout_b50_name" "SELECT branch_name FROM t WHERE id=50;" "b50" "$DB/b50"
-# b50 should have 2 rows: the init row and its own row
+
 run_test "checkout_b50_count" "SELECT count(*) FROM t;" "2" "$DB/b50"
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# ============================================================
-# 4. Merge 5 branches (b1-b5) into main, verify accumulated data
-# ============================================================
+
+
+
 
 for i in $(seq 1 5); do
   echo "SELECT dolt_merge('b$i');" | $DOLTLITE "$DB" > /dev/null 2>&1
 done
 
-# main should now have: init row + 5 merged rows = 6
+
 run_test "merge_5_count" "SELECT count(*) FROM t;" "6" "$DB"
 run_test "merge_5_has_b1" "SELECT val FROM t WHERE id=1;" "1" "$DB"
 run_test "merge_5_has_b5" "SELECT val FROM t WHERE id=5;" "5" "$DB"
 
-# ============================================================
-# 5. Delete 90 branches (b6-b95), keep b96-b100 unmerged
-# ============================================================
+
+
+
 
 echo "  Deleting 90 branches..."
 for i in $(seq 6 95); do
@@ -85,12 +85,12 @@ for i in $(seq 6 95); do
 done
 echo "  Done deleting branches."
 
-# Should have: main + b1..b5 (merged) + b96..b100 (unmerged) = 11
+
 run_test "after_delete_count" "SELECT count(*) FROM dolt_branches;" "11" "$DB"
 
-# ============================================================
-# 6. GC after deleting 90 branches — should reclaim space
-# ============================================================
+
+
+
 
 SIZE_BEFORE_GC=$(file_size "$DB")
 
@@ -107,31 +107,31 @@ else
   echo "  FAIL: gc_reclaims_space — before=$SIZE_BEFORE_GC after=$SIZE_AFTER_GC"
 fi
 
-# ============================================================
-# 7. After GC, verify surviving branches are intact
-# ============================================================
+
+
+
 
 run_test "post_gc_branch_count" "SELECT count(*) FROM dolt_branches;" "11" "$DB"
 
-# Check main data
+
 run_test "post_gc_main_count" "SELECT count(*) FROM t;" "6" "$DB"
 run_test "post_gc_main_b3" "SELECT val FROM t WHERE id=3;" "3" "$DB"
 
-# Check an unmerged surviving branch
+
 echo "SELECT dolt_checkout('b98');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "post_gc_b98_data" "SELECT val FROM t WHERE id=98;" "98" "$DB/b98"
 run_test "post_gc_b98_count" "SELECT count(*) FROM t;" "2" "$DB/b98"
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# ============================================================
-# 8. After GC, verify dolt_log on main still works
-# ============================================================
+
+
+
 
 run_test_match "post_gc_log" "SELECT count(*) FROM dolt_log;" "^[1-9]" "$DB"
 
-# ============================================================
-# 9. After GC, verify dolt_at works for surviving branches
-# ============================================================
+
+
+
 
 run_test "post_gc_at_b99" \
   "SELECT count(*) FROM dolt_at_t('b99');" "2" "$DB"
@@ -140,9 +140,9 @@ run_test "post_gc_at_b99_val" \
 
 db_rm "$DB"
 
-# ============================================================
-# 10. Create branch, add 1000 rows, delete branch, GC — reclaim chunks
-# ============================================================
+
+
+
 
 DB=/tmp/test_gc_1000rows_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, data TEXT);
@@ -152,7 +152,7 @@ SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_branch('bulk');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('bulk');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Insert 1000 rows in batches
+
 echo "  Inserting 1000 rows on bulk branch..."
 for batch in $(seq 0 9); do
   SQL=""
@@ -181,19 +181,19 @@ else
   echo "  FAIL: gc_1000rows — before=$SIZE_WITH_BULK after=$SIZE_AFTER_BULK_GC"
 fi
 
-# Main data still intact
+
 run_test "gc_1000rows_main" "SELECT count(*) FROM t;" "1" "$DB"
 run_test "gc_1000rows_val" "SELECT data FROM t WHERE id=0;" "base" "$DB"
 
 db_rm "$DB"
 
-# ============================================================
-# 11. Structural sharing: 2 branches from same commit — minimal size increase
-# ============================================================
+
+
+
 
 DB=/tmp/test_struct_share_$$.db; db_rm "$DB"
 
-# Create a table with enough data to make size meaningful
+
 SQL="CREATE TABLE t(id INTEGER PRIMARY KEY, data TEXT);"
 for i in $(seq 1 200); do
   SQL="${SQL}INSERT INTO t VALUES($i,'row_data_padding_for_size_$i');"
@@ -208,9 +208,9 @@ SELECT dolt_branch('share_b');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 SIZE_WITH_BRANCHES=$(file_size "$DB")
 
-# Two branches from same commit should add very little
+
 BRANCH_OVERHEAD=$((SIZE_WITH_BRANCHES - SIZE_BASE))
-# Allow up to 10% overhead for branch metadata
+
 LIMIT=$((SIZE_BASE / 10))
 if [ "$LIMIT" -lt 4096 ]; then LIMIT=4096; fi
 
@@ -223,9 +223,9 @@ else
   echo "  FAIL: struct_share_branches — overhead=$BRANCH_OVERHEAD limit=$LIMIT"
 fi
 
-# ============================================================
-# 12. Modify 1 row on each branch — small size increase
-# ============================================================
+
+
+
 
 echo "SELECT dolt_checkout('share_a');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "UPDATE t SET data='modified_a' WHERE id=1;
@@ -238,7 +238,7 @@ echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 SIZE_AFTER_MODS=$(file_size "$DB")
 MOD_INCREASE=$((SIZE_AFTER_MODS - SIZE_WITH_BRANCHES))
 
-# Modifying 1 row per branch should add much less than the total data size
+
 if [ "$MOD_INCREASE" -lt "$SIZE_BASE" ]; then
   PASS=$((PASS+1))
   echo "  PASS: struct_share_mods — increase=$MOD_INCREASE base=$SIZE_BASE"
@@ -250,19 +250,19 @@ fi
 
 db_rm "$DB"
 
-# ============================================================
-# 13. GC on database with no unreachable chunks — no-op
-# ============================================================
+
+
+
 
 DB=/tmp/test_gc_noop_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
 SELECT dolt_commit('-A','-m','c1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# First GC to clean any intermediate chunks
+
 echo "SELECT dolt_gc();" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Second GC should be a no-op
+
 run_test_match "gc_noop" "SELECT dolt_gc();" "0 chunks removed" "$DB"
 
 SIZE_BEFORE_NOOP=$(file_size "$DB")
@@ -279,9 +279,9 @@ fi
 
 db_rm "$DB"
 
-# ============================================================
-# 14. GC immediately after first commit — should keep everything
-# ============================================================
+
+
+
 
 DB=/tmp/test_gc_first_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -295,9 +295,9 @@ run_test "gc_first_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 
 db_rm "$DB"
 
-# ============================================================
-# 15. Create and delete same branch name repeatedly
-# ============================================================
+
+
+
 
 DB=/tmp/test_gc_recycle_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -313,29 +313,29 @@ SELECT dolt_commit('-A','-m','cycle $cycle');" | $DOLTLITE "$DB/recycled" > /dev
   echo "SELECT dolt_branch('-D','recycled');" | $DOLTLITE "$DB" > /dev/null 2>&1
 done
 
-# After 10 create/delete cycles, only main should remain
+
 run_test "recycle_branch_count" "SELECT count(*) FROM dolt_branches;" "1" "$DB"
 
-# Main data should be unaffected
+
 run_test "recycle_main_data" "SELECT count(*) FROM t;" "1" "$DB"
 run_test "recycle_main_val" "SELECT v FROM t WHERE id=1;" "init" "$DB"
 
-# GC should clean up all orphaned cycle commits
+
 run_test_match "recycle_gc" "SELECT dolt_gc();" "chunks removed" "$DB"
 
-# Data still intact after GC
+
 run_test "recycle_post_gc_data" "SELECT count(*) FROM t;" "1" "$DB"
 run_test "recycle_post_gc_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 
-# Create the branch one more time to prove the name is reusable after GC
+
 echo "SELECT dolt_branch('recycled');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "recycle_reuse_after_gc" "SELECT count(*) FROM dolt_branches;" "2" "$DB"
 
 db_rm "$DB"
 
-# ============================================================
-# Done
-# ============================================================
+
+
+
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/doltlite_branch_gc_stress.sh
+++ b/test/doltlite_branch_gc_stress.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
-
-
-
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(30);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
@@ -22,18 +19,10 @@ db_rm() { rm -f "$1" "${1}-wal"; }
 echo "=== Doltlite Branch & GC Stress Tests ==="
 echo ""
 
-
-
-
-
 DB=/tmp/test_branch_gc_stress_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, branch_name TEXT, val INTEGER);
 INSERT INTO t VALUES(0,'main',0);
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
-
-
-
 
 echo "  Creating 100 branches..."
 for i in $(seq 1 100); do
@@ -45,39 +34,21 @@ SELECT dolt_commit('-A','-m','commit on b$i');" | $DOLTLITE "$DB/b$i" > /dev/nul
 done
 echo "  Done creating branches."
 
-
-
-
-
 run_test "many_branches_count" "SELECT count(*) FROM dolt_branches;" "101" "$DB"
-
-
-
-
 
 echo "SELECT dolt_checkout('b50');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "checkout_b50_data" "SELECT val FROM t WHERE id=50;" "50" "$DB/b50"
 run_test "checkout_b50_name" "SELECT branch_name FROM t WHERE id=50;" "b50" "$DB/b50"
-
 run_test "checkout_b50_count" "SELECT count(*) FROM t;" "2" "$DB/b50"
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
-
-
-
 
 for i in $(seq 1 5); do
   echo "SELECT dolt_merge('b$i');" | $DOLTLITE "$DB" > /dev/null 2>&1
 done
 
-
 run_test "merge_5_count" "SELECT count(*) FROM t;" "6" "$DB"
 run_test "merge_5_has_b1" "SELECT val FROM t WHERE id=1;" "1" "$DB"
 run_test "merge_5_has_b5" "SELECT val FROM t WHERE id=5;" "5" "$DB"
-
-
-
-
 
 echo "  Deleting 90 branches..."
 for i in $(seq 6 95); do
@@ -85,12 +56,7 @@ for i in $(seq 6 95); do
 done
 echo "  Done deleting branches."
 
-
 run_test "after_delete_count" "SELECT count(*) FROM dolt_branches;" "11" "$DB"
-
-
-
-
 
 SIZE_BEFORE_GC=$(file_size "$DB")
 
@@ -107,31 +73,17 @@ else
   echo "  FAIL: gc_reclaims_space — before=$SIZE_BEFORE_GC after=$SIZE_AFTER_GC"
 fi
 
-
-
-
-
 run_test "post_gc_branch_count" "SELECT count(*) FROM dolt_branches;" "11" "$DB"
-
 
 run_test "post_gc_main_count" "SELECT count(*) FROM t;" "6" "$DB"
 run_test "post_gc_main_b3" "SELECT val FROM t WHERE id=3;" "3" "$DB"
-
 
 echo "SELECT dolt_checkout('b98');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "post_gc_b98_data" "SELECT val FROM t WHERE id=98;" "98" "$DB/b98"
 run_test "post_gc_b98_count" "SELECT count(*) FROM t;" "2" "$DB/b98"
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
-
-
-
 run_test_match "post_gc_log" "SELECT count(*) FROM dolt_log;" "^[1-9]" "$DB"
-
-
-
-
 
 run_test "post_gc_at_b99" \
   "SELECT count(*) FROM dolt_at_t('b99');" "2" "$DB"
@@ -140,10 +92,6 @@ run_test "post_gc_at_b99_val" \
 
 db_rm "$DB"
 
-
-
-
-
 DB=/tmp/test_gc_1000rows_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, data TEXT);
 INSERT INTO t VALUES(0,'base');
@@ -151,7 +99,6 @@ SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 echo "SELECT dolt_branch('bulk');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('bulk');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 echo "  Inserting 1000 rows on bulk branch..."
 for batch in $(seq 0 9); do
@@ -181,18 +128,12 @@ else
   echo "  FAIL: gc_1000rows — before=$SIZE_WITH_BULK after=$SIZE_AFTER_BULK_GC"
 fi
 
-
 run_test "gc_1000rows_main" "SELECT count(*) FROM t;" "1" "$DB"
 run_test "gc_1000rows_val" "SELECT data FROM t WHERE id=0;" "base" "$DB"
 
 db_rm "$DB"
 
-
-
-
-
 DB=/tmp/test_struct_share_$$.db; db_rm "$DB"
-
 
 SQL="CREATE TABLE t(id INTEGER PRIMARY KEY, data TEXT);"
 for i in $(seq 1 200); do
@@ -208,9 +149,7 @@ SELECT dolt_branch('share_b');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 SIZE_WITH_BRANCHES=$(file_size "$DB")
 
-
 BRANCH_OVERHEAD=$((SIZE_WITH_BRANCHES - SIZE_BASE))
-
 LIMIT=$((SIZE_BASE / 10))
 if [ "$LIMIT" -lt 4096 ]; then LIMIT=4096; fi
 
@@ -223,10 +162,6 @@ else
   echo "  FAIL: struct_share_branches — overhead=$BRANCH_OVERHEAD limit=$LIMIT"
 fi
 
-
-
-
-
 echo "SELECT dolt_checkout('share_a');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "UPDATE t SET data='modified_a' WHERE id=1;
 SELECT dolt_commit('-A','-m','mod a');" | $DOLTLITE "$DB/share_a" > /dev/null 2>&1
@@ -237,7 +172,6 @@ echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 SIZE_AFTER_MODS=$(file_size "$DB")
 MOD_INCREASE=$((SIZE_AFTER_MODS - SIZE_WITH_BRANCHES))
-
 
 if [ "$MOD_INCREASE" -lt "$SIZE_BASE" ]; then
   PASS=$((PASS+1))
@@ -250,18 +184,12 @@ fi
 
 db_rm "$DB"
 
-
-
-
-
 DB=/tmp/test_gc_noop_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
 SELECT dolt_commit('-A','-m','c1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 echo "SELECT dolt_gc();" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 run_test_match "gc_noop" "SELECT dolt_gc();" "0 chunks removed" "$DB"
 
@@ -279,10 +207,6 @@ fi
 
 db_rm "$DB"
 
-
-
-
-
 DB=/tmp/test_gc_first_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'hello');
@@ -294,10 +218,6 @@ run_test "gc_first_val" "SELECT v FROM t WHERE id=1;" "hello" "$DB"
 run_test "gc_first_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 
 db_rm "$DB"
-
-
-
-
 
 DB=/tmp/test_gc_recycle_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -313,29 +233,20 @@ SELECT dolt_commit('-A','-m','cycle $cycle');" | $DOLTLITE "$DB/recycled" > /dev
   echo "SELECT dolt_branch('-D','recycled');" | $DOLTLITE "$DB" > /dev/null 2>&1
 done
 
-
 run_test "recycle_branch_count" "SELECT count(*) FROM dolt_branches;" "1" "$DB"
-
 
 run_test "recycle_main_data" "SELECT count(*) FROM t;" "1" "$DB"
 run_test "recycle_main_val" "SELECT v FROM t WHERE id=1;" "init" "$DB"
 
-
 run_test_match "recycle_gc" "SELECT dolt_gc();" "chunks removed" "$DB"
-
 
 run_test "recycle_post_gc_data" "SELECT count(*) FROM t;" "1" "$DB"
 run_test "recycle_post_gc_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
-
 
 echo "SELECT dolt_branch('recycled');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "recycle_reuse_after_gc" "SELECT count(*) FROM dolt_branches;" "2" "$DB"
 
 db_rm "$DB"
-
-
-
-
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/doltlite_branding.sh
+++ b/test/doltlite_branding.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
-
-
-
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
@@ -10,21 +7,14 @@ run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -
 echo "=== DoltLite Branding Tests ==="
 echo ""
 
-
 run_test "engine_func" "SELECT doltlite_engine();" "prolly" ":memory:"
 
-
 run_test_match "engine_old_gone" "SELECT doltite_engine();" "no such function" ":memory:"
-
 
 VER=$($DOLTLITE -version 2>&1)
 if echo "$VER" | grep -q "DoltLite"; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: version_flag\n  expected: DoltLite\n  got:      $VER"; fi
 
-
 if echo "$VER" | grep -q "SQLite"; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: version_sqlite\n  expected: SQLite\n  got:      $VER"; fi
-
-
-
 
 run_script() {
   if [ "$(uname)" = "Darwin" ]; then
@@ -41,9 +31,7 @@ EOF
 
 if echo "$BANNER" | grep -q "DoltLite"; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: banner\n  expected: DoltLite\n  got:      $BANNER"; fi
 
-
 if echo "$BANNER" | grep -q "SQLite version"; then FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: no_sqlite_version\n  should not contain: SQLite version\n  got:      $BANNER"; else PASS=$((PASS+1)); fi
-
 
 PROMPT=$(run_script $DOLTLITE :memory: <<'PEOF' | cat
 SELECT 1;

--- a/test/doltlite_branding.sh
+++ b/test/doltlite_branding.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-#
-# Tests for DoltLite branding: engine function, version, prompt.
-#
+
+
+
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
@@ -10,22 +10,22 @@ run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -
 echo "=== DoltLite Branding Tests ==="
 echo ""
 
-# doltlite_engine() returns "prolly"
+
 run_test "engine_func" "SELECT doltlite_engine();" "prolly" ":memory:"
 
-# Old misspelling does NOT work
+
 run_test_match "engine_old_gone" "SELECT doltite_engine();" "no such function" ":memory:"
 
-# -version flag says DoltLite
+
 VER=$($DOLTLITE -version 2>&1)
 if echo "$VER" | grep -q "DoltLite"; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: version_flag\n  expected: DoltLite\n  got:      $VER"; fi
 
-# -version includes SQLite version
+
 if echo "$VER" | grep -q "SQLite"; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: version_sqlite\n  expected: SQLite\n  got:      $VER"; fi
 
-# Interactive banner and prompt tests (require a TTY via `script`)
-# macOS: script -q /dev/null cmd
-# Linux: script -qc "cmd" /dev/null
+
+
+
 run_script() {
   if [ "$(uname)" = "Darwin" ]; then
     script -q /dev/null "$@" 2>&1
@@ -41,10 +41,10 @@ EOF
 
 if echo "$BANNER" | grep -q "DoltLite"; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: banner\n  expected: DoltLite\n  got:      $BANNER"; fi
 
-# Banner does NOT say "SQLite version" (the old format)
+
 if echo "$BANNER" | grep -q "SQLite version"; then FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: no_sqlite_version\n  should not contain: SQLite version\n  got:      $BANNER"; else PASS=$((PASS+1)); fi
 
-# Prompt says doltlite>
+
 PROMPT=$(run_script $DOLTLITE :memory: <<'PEOF' | cat
 SELECT 1;
 .quit

--- a/test/doltlite_cherry_pick.sh
+++ b/test/doltlite_cherry_pick.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-#
-# Tests for dolt_cherry_pick and dolt_revert.
-#
+
+
+
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
@@ -10,9 +10,9 @@ run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -
 echo "=== Doltlite Cherry-Pick & Revert Tests ==="
 echo ""
 
-# ============================================================
-# Cherry-pick: basic functionality
-# ============================================================
+
+
+
 
 DB=/tmp/test_cp_basic_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -24,7 +24,7 @@ INSERT INTO t VALUES(2,'feat_row');
 SELECT dolt_commit('-A','-m','add feat_row');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Cherry-pick the feat commit onto main
+
 run_test_match "cp_basic_hash" \
   "SELECT dolt_cherry_pick('feat');" \
   "^[0-9a-f]{40}$" "$DB"
@@ -36,9 +36,9 @@ run_test "cp_basic_log" "SELECT count(*) FROM dolt_log;" "3" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Cherry-pick: pick from middle of history
-# ============================================================
+
+
+
 
 DB=/tmp/test_cp_middle_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -52,26 +52,26 @@ INSERT INTO t VALUES(11,'feat2');
 SELECT dolt_commit('-A','-m','feat commit 2');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Get the first feat commit hash (the one that added row 10)
+
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 CP_HASH=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1;" | $DOLTLITE "$DB/feat" 2>&1)
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Cherry-pick only the first feat commit
+
 run_test_match "cp_middle_pick" \
   "SELECT dolt_cherry_pick('$CP_HASH');" \
   "^[0-9a-f]{40}$" "$DB"
 
-# Should only have row 10, not row 11
+
 run_test "cp_middle_count" "SELECT count(*) FROM t;" "2" "$DB"
 run_test "cp_middle_has10" "SELECT v FROM t WHERE id=10;" "feat1" "$DB"
 run_test "cp_middle_no11" "SELECT count(*) FROM t WHERE id=11;" "0" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Cherry-pick: with conflict
-# ============================================================
+
+
+
 
 DB=/tmp/test_cp_conflict_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -118,9 +118,9 @@ fi
 
 rm -f "$DB"
 
-# ============================================================
-# Cherry-pick: non-conflicting changes
-# ============================================================
+
+
+
 
 DB=/tmp/test_cp_noconflict_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -135,7 +135,7 @@ SELECT dolt_checkout('main');
 UPDATE t SET v='A' WHERE id=1;
 SELECT dolt_commit('-A','-m','main updates row 1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Cherry-pick should cleanly add row 3 without conflicting with row 1 change
+
 run_test_match "cp_noc_hash" \
   "SELECT dolt_cherry_pick('feat');" \
   "^[0-9a-f]{40}$" "$DB"
@@ -146,31 +146,31 @@ run_test "cp_noc_row3" "SELECT v FROM t WHERE id=3;" "c" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Cherry-pick: error cases
-# ============================================================
+
+
+
 
 DB=/tmp/test_cp_errors_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
 INSERT INTO t VALUES(1);
 SELECT dolt_commit('-A','-m','c1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# No arguments
+
 run_test_match "cp_err_noarg" "SELECT dolt_cherry_pick();" "usage" "$DB"
 
-# Invalid hash
+
 run_test_match "cp_err_badhash" "SELECT dolt_cherry_pick('not_a_hash');" "invalid" "$DB"
 
-# Cannot cherry-pick the root (seed) commit: it has no parent to replay
+
 run_test_match "cp_err_initial" \
   "SELECT dolt_cherry_pick((SELECT commit_hash FROM dolt_log WHERE message='Initialize data repository'));" \
   "initial commit" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Cherry-pick: with file persistence
-# ============================================================
+
+
+
 
 DB=/tmp/test_cp_persist_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -184,16 +184,16 @@ SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 echo "SELECT dolt_cherry_pick('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Verify data persists after reopen
+
 run_test "cp_persist_count" "SELECT count(*) FROM t;" "2" "$DB"
 run_test "cp_persist_val" "SELECT v FROM t WHERE id=2;" "feat_data" "$DB"
 run_test_match "cp_persist_log" "SELECT message FROM dolt_log LIMIT 1;" "^feat add$" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Revert: basic functionality
-# ============================================================
+
+
+
 
 DB=/tmp/test_rv_basic_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -204,7 +204,7 @@ SELECT dolt_commit('-A','-m','add row 2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "rv_before_count" "SELECT count(*) FROM t;" "2" "$DB"
 
-# Revert the last commit (add row 2)
+
 run_test_match "rv_basic_hash" \
   "SELECT dolt_revert((SELECT commit_hash FROM dolt_log LIMIT 1));" \
   "^[0-9a-f]{40}$" "$DB"
@@ -217,9 +217,9 @@ run_test "rv_basic_log" "SELECT count(*) FROM dolt_log;" "4" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Revert: undo an UPDATE
-# ============================================================
+
+
+
 
 DB=/tmp/test_rv_update_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -235,17 +235,17 @@ run_test_match "rv_upd_hash" \
   "SELECT dolt_revert((SELECT commit_hash FROM dolt_log LIMIT 1));" \
   "^[0-9a-f]{40}$" "$DB"
 
-# Row 1 should be reverted to 'original'
+
 run_test "rv_upd_reverted" "SELECT v FROM t WHERE id=1;" "original" "$DB"
-# Row 2 should be unchanged
+
 run_test "rv_upd_other" "SELECT v FROM t WHERE id=2;" "keep" "$DB"
 run_test "rv_upd_count" "SELECT count(*) FROM t;" "2" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Revert: revert a middle commit
-# ============================================================
+
+
+
 
 DB=/tmp/test_rv_middle_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -256,21 +256,21 @@ SELECT dolt_commit('-A','-m','c2');
 INSERT INTO t VALUES(3,'third');
 SELECT dolt_commit('-A','-m','c3');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Revert c2 (added row 2) while keeping c3 (row 3)
+
 run_test_match "rv_mid_hash" \
   "SELECT dolt_revert((SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1));" \
   "^[0-9a-f]{40}$" "$DB"
 
-# Row 2 should be gone, row 3 should remain
+
 run_test "rv_mid_no2" "SELECT count(*) FROM t WHERE id=2;" "0" "$DB"
 run_test "rv_mid_has3" "SELECT v FROM t WHERE id=3;" "third" "$DB"
 run_test "rv_mid_count" "SELECT count(*) FROM t;" "2" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Revert: with conflict
-# ============================================================
+
+
+
 
 DB=/tmp/test_rv_conflict_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -281,8 +281,8 @@ SELECT dolt_commit('-A','-m','update to v2');
 UPDATE t SET v='v3' WHERE id=1;
 SELECT dolt_commit('-A','-m','update to v3');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Revert the c2 commit (orig->v2). Since c3 also modified row 1,
-# this should conflict.
+
+
 run_test_match "rv_conf_msg" \
   "SELECT dolt_revert((SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1));" \
   "conflict|rolled back" "$DB"
@@ -291,9 +291,9 @@ run_test "rv_conf_ours" "SELECT v FROM t WHERE id=1;" "v3" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Revert: error cases
-# ============================================================
+
+
+
 
 DB=/tmp/test_rv_errors_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
@@ -308,9 +308,9 @@ run_test_match "rv_err_initial" \
 
 rm -f "$DB"
 
-# ============================================================
-# Revert: persistence
-# ============================================================
+
+
+
 
 DB=/tmp/test_rv_persist_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -321,16 +321,16 @@ SELECT dolt_commit('-A','-m','add row 2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 echo "SELECT dolt_revert((SELECT commit_hash FROM dolt_log LIMIT 1));" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Verify after reopen
+
 run_test "rv_persist_count" "SELECT count(*) FROM t;" "1" "$DB"
 run_test_match "rv_persist_log" "SELECT message FROM dolt_log LIMIT 1;" "Revert" "$DB"
 run_test "rv_persist_log_count" "SELECT count(*) FROM dolt_log;" "4" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Cherry-pick + Revert combined workflow
-# ============================================================
+
+
+
 
 DB=/tmp/test_cp_rv_combo_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -342,11 +342,11 @@ INSERT INTO t VALUES(2,'feat_val');
 SELECT dolt_commit('-A','-m','feat add');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Cherry-pick feat onto main
+
 echo "SELECT dolt_cherry_pick('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "combo_after_cp" "SELECT count(*) FROM t;" "2" "$DB"
 
-# Now revert the cherry-pick
+
 run_test_match "combo_revert" \
   "SELECT dolt_revert((SELECT commit_hash FROM dolt_log LIMIT 1));" \
   "^[0-9a-f]{40}$" "$DB"
@@ -355,9 +355,9 @@ run_test "combo_log" "SELECT count(*) FROM dolt_log;" "4" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Cherry-pick: multiple cherry-picks
-# ============================================================
+
+
+
 
 DB=/tmp/test_cp_multi_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -371,7 +371,7 @@ INSERT INTO t VALUES(11,'cp2');
 SELECT dolt_commit('-A','-m','feat2');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Cherry-pick first feat commit
+
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 HASH1=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1;" | $DOLTLITE "$DB/feat" 2>&1)
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -380,7 +380,7 @@ echo "SELECT dolt_cherry_pick('$HASH1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "cp_multi_first" "SELECT count(*) FROM t;" "2" "$DB"
 run_test "cp_multi_has10" "SELECT v FROM t WHERE id=10;" "cp1" "$DB"
 
-# Cherry-pick second feat commit
+
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 HASH2=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1;" | $DOLTLITE "$DB/feat" 2>&1)
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -392,9 +392,9 @@ run_test "cp_multi_log" "SELECT count(*) FROM dolt_log;" "4" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Revert: revert then revert the revert
-# ============================================================
+
+
+
 
 DB=/tmp/test_rv_double_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -403,11 +403,11 @@ SELECT dolt_commit('-A','-m','c1');
 INSERT INTO t VALUES(2,'added');
 SELECT dolt_commit('-A','-m','add row 2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Revert the add
+
 echo "SELECT dolt_revert((SELECT commit_hash FROM dolt_log LIMIT 1));" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "rv_double_after1" "SELECT count(*) FROM t;" "1" "$DB"
 
-# Revert the revert — should bring row 2 back
+
 run_test_match "rv_double_revert2" \
   "SELECT dolt_revert((SELECT commit_hash FROM dolt_log LIMIT 1));" \
   "^[0-9a-f]{40}$" "$DB"
@@ -417,9 +417,9 @@ run_test "rv_double_log" "SELECT count(*) FROM dolt_log;" "5" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Cherry-pick: pick onto branch with diverged history
-# ============================================================
+
+
+
 
 DB=/tmp/test_cp_diverged_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -433,7 +433,7 @@ SELECT dolt_checkout('main');
 INSERT INTO t VALUES(20,'main_row');
 SELECT dolt_commit('-A','-m','main commit');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Cherry-pick feat commit onto main (which already has its own changes)
+
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 HASH=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1;" | $DOLTLITE "$DB/feat" 2>&1)
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -445,9 +445,9 @@ run_test "cp_div_has20" "SELECT v FROM t WHERE id=20;" "main_row" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Revert: multi-row commit
-# ============================================================
+
+
+
 
 DB=/tmp/test_rv_multirow_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -469,9 +469,9 @@ run_test "rv_multi_only_init" "SELECT v FROM t WHERE id=1;" "init" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Cherry-pick: new table from another branch
-# ============================================================
+
+
+
 
 DB=/tmp/test_cp_newtable_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -494,9 +494,9 @@ run_test "cp_newtbl_val" "SELECT w FROM t2 WHERE id=1;" "new_table" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Cherry-pick / revert: constraint violations roll back
-# ============================================================
+
+
+
 
 DB=/tmp/test_cp_violation_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, u INT UNIQUE, v TEXT);
@@ -668,9 +668,9 @@ run_test "rv_violation_state" \
 
 rm -f "$DB"
 
-# ============================================================
-# Done
-# ============================================================
+
+
+
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/doltlite_cherry_pick.sh
+++ b/test/doltlite_cherry_pick.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
-
-
-
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
@@ -9,10 +6,6 @@ run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -
 
 echo "=== Doltlite Cherry-Pick & Revert Tests ==="
 echo ""
-
-
-
-
 
 DB=/tmp/test_cp_basic_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -24,7 +17,6 @@ INSERT INTO t VALUES(2,'feat_row');
 SELECT dolt_commit('-A','-m','add feat_row');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test_match "cp_basic_hash" \
   "SELECT dolt_cherry_pick('feat');" \
   "^[0-9a-f]{40}$" "$DB"
@@ -35,10 +27,6 @@ run_test "cp_basic_branch" "SELECT active_branch();" "main" "$DB"
 run_test "cp_basic_log" "SELECT count(*) FROM dolt_log;" "3" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_cp_middle_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -52,26 +40,19 @@ INSERT INTO t VALUES(11,'feat2');
 SELECT dolt_commit('-A','-m','feat commit 2');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 CP_HASH=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1;" | $DOLTLITE "$DB/feat" 2>&1)
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test_match "cp_middle_pick" \
   "SELECT dolt_cherry_pick('$CP_HASH');" \
   "^[0-9a-f]{40}$" "$DB"
-
 
 run_test "cp_middle_count" "SELECT count(*) FROM t;" "2" "$DB"
 run_test "cp_middle_has10" "SELECT v FROM t WHERE id=10;" "feat1" "$DB"
 run_test "cp_middle_no11" "SELECT count(*) FROM t WHERE id=11;" "0" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_cp_conflict_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -118,10 +99,6 @@ fi
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_cp_noconflict_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
@@ -135,7 +112,6 @@ SELECT dolt_checkout('main');
 UPDATE t SET v='A' WHERE id=1;
 SELECT dolt_commit('-A','-m','main updates row 1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test_match "cp_noc_hash" \
   "SELECT dolt_cherry_pick('feat');" \
   "^[0-9a-f]{40}$" "$DB"
@@ -146,31 +122,20 @@ run_test "cp_noc_row3" "SELECT v FROM t WHERE id=3;" "c" "$DB"
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_cp_errors_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
 INSERT INTO t VALUES(1);
 SELECT dolt_commit('-A','-m','c1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test_match "cp_err_noarg" "SELECT dolt_cherry_pick();" "usage" "$DB"
 
-
 run_test_match "cp_err_badhash" "SELECT dolt_cherry_pick('not_a_hash');" "invalid" "$DB"
-
 
 run_test_match "cp_err_initial" \
   "SELECT dolt_cherry_pick((SELECT commit_hash FROM dolt_log WHERE message='Initialize data repository'));" \
   "initial commit" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_cp_persist_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -184,16 +149,11 @@ SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 echo "SELECT dolt_cherry_pick('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "cp_persist_count" "SELECT count(*) FROM t;" "2" "$DB"
 run_test "cp_persist_val" "SELECT v FROM t WHERE id=2;" "feat_data" "$DB"
 run_test_match "cp_persist_log" "SELECT message FROM dolt_log LIMIT 1;" "^feat add$" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_rv_basic_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -203,7 +163,6 @@ INSERT INTO t VALUES(2,'added');
 SELECT dolt_commit('-A','-m','add row 2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "rv_before_count" "SELECT count(*) FROM t;" "2" "$DB"
-
 
 run_test_match "rv_basic_hash" \
   "SELECT dolt_revert((SELECT commit_hash FROM dolt_log LIMIT 1));" \
@@ -216,10 +175,6 @@ run_test_match "rv_basic_msg" "SELECT message FROM dolt_log LIMIT 1;" "^Revert \
 run_test "rv_basic_log" "SELECT count(*) FROM dolt_log;" "4" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_rv_update_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -235,17 +190,11 @@ run_test_match "rv_upd_hash" \
   "SELECT dolt_revert((SELECT commit_hash FROM dolt_log LIMIT 1));" \
   "^[0-9a-f]{40}$" "$DB"
 
-
 run_test "rv_upd_reverted" "SELECT v FROM t WHERE id=1;" "original" "$DB"
-
 run_test "rv_upd_other" "SELECT v FROM t WHERE id=2;" "keep" "$DB"
 run_test "rv_upd_count" "SELECT count(*) FROM t;" "2" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_rv_middle_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -256,21 +205,15 @@ SELECT dolt_commit('-A','-m','c2');
 INSERT INTO t VALUES(3,'third');
 SELECT dolt_commit('-A','-m','c3');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test_match "rv_mid_hash" \
   "SELECT dolt_revert((SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1));" \
   "^[0-9a-f]{40}$" "$DB"
-
 
 run_test "rv_mid_no2" "SELECT count(*) FROM t WHERE id=2;" "0" "$DB"
 run_test "rv_mid_has3" "SELECT v FROM t WHERE id=3;" "third" "$DB"
 run_test "rv_mid_count" "SELECT count(*) FROM t;" "2" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_rv_conflict_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -281,8 +224,6 @@ SELECT dolt_commit('-A','-m','update to v2');
 UPDATE t SET v='v3' WHERE id=1;
 SELECT dolt_commit('-A','-m','update to v3');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
-
 run_test_match "rv_conf_msg" \
   "SELECT dolt_revert((SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1));" \
   "conflict|rolled back" "$DB"
@@ -290,10 +231,6 @@ run_test "rv_conf_count" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
 run_test "rv_conf_ours" "SELECT v FROM t WHERE id=1;" "v3" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_rv_errors_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
@@ -308,10 +245,6 @@ run_test_match "rv_err_initial" \
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_rv_persist_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'init');
@@ -321,16 +254,11 @@ SELECT dolt_commit('-A','-m','add row 2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 echo "SELECT dolt_revert((SELECT commit_hash FROM dolt_log LIMIT 1));" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "rv_persist_count" "SELECT count(*) FROM t;" "1" "$DB"
 run_test_match "rv_persist_log" "SELECT message FROM dolt_log LIMIT 1;" "Revert" "$DB"
 run_test "rv_persist_log_count" "SELECT count(*) FROM dolt_log;" "4" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_cp_rv_combo_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -342,10 +270,8 @@ INSERT INTO t VALUES(2,'feat_val');
 SELECT dolt_commit('-A','-m','feat add');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 echo "SELECT dolt_cherry_pick('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "combo_after_cp" "SELECT count(*) FROM t;" "2" "$DB"
-
 
 run_test_match "combo_revert" \
   "SELECT dolt_revert((SELECT commit_hash FROM dolt_log LIMIT 1));" \
@@ -354,10 +280,6 @@ run_test "combo_after_rv" "SELECT count(*) FROM t;" "1" "$DB"
 run_test "combo_log" "SELECT count(*) FROM dolt_log;" "4" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_cp_multi_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -371,7 +293,6 @@ INSERT INTO t VALUES(11,'cp2');
 SELECT dolt_commit('-A','-m','feat2');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 HASH1=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1;" | $DOLTLITE "$DB/feat" 2>&1)
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -379,7 +300,6 @@ echo "SELECT dolt_cherry_pick('$HASH1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "cp_multi_first" "SELECT count(*) FROM t;" "2" "$DB"
 run_test "cp_multi_has10" "SELECT v FROM t WHERE id=10;" "cp1" "$DB"
-
 
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 HASH2=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1;" | $DOLTLITE "$DB/feat" 2>&1)
@@ -392,10 +312,6 @@ run_test "cp_multi_log" "SELECT count(*) FROM dolt_log;" "4" "$DB"
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_rv_double_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'init');
@@ -403,10 +319,8 @@ SELECT dolt_commit('-A','-m','c1');
 INSERT INTO t VALUES(2,'added');
 SELECT dolt_commit('-A','-m','add row 2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 echo "SELECT dolt_revert((SELECT commit_hash FROM dolt_log LIMIT 1));" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "rv_double_after1" "SELECT count(*) FROM t;" "1" "$DB"
-
 
 run_test_match "rv_double_revert2" \
   "SELECT dolt_revert((SELECT commit_hash FROM dolt_log LIMIT 1));" \
@@ -416,10 +330,6 @@ run_test "rv_double_val" "SELECT v FROM t WHERE id=2;" "added" "$DB"
 run_test "rv_double_log" "SELECT count(*) FROM dolt_log;" "5" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_cp_diverged_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -433,7 +343,6 @@ SELECT dolt_checkout('main');
 INSERT INTO t VALUES(20,'main_row');
 SELECT dolt_commit('-A','-m','main commit');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 HASH=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1;" | $DOLTLITE "$DB/feat" 2>&1)
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -444,10 +353,6 @@ run_test "cp_div_has10" "SELECT v FROM t WHERE id=10;" "feat_row" "$DB"
 run_test "cp_div_has20" "SELECT v FROM t WHERE id=20;" "main_row" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_rv_multirow_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -469,10 +374,6 @@ run_test "rv_multi_only_init" "SELECT v FROM t WHERE id=1;" "init" "$DB"
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_cp_newtable_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'init');
@@ -493,10 +394,6 @@ run_test "cp_newtbl_t2" "SELECT count(*) FROM t2;" "1" "$DB"
 run_test "cp_newtbl_val" "SELECT w FROM t2 WHERE id=1;" "new_table" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_cp_violation_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, u INT UNIQUE, v TEXT);
@@ -667,10 +564,6 @@ run_test "rv_violation_state" \
   "1:9:c1,2:1:c2_take_1" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/doltlite_commit.sh
+++ b/test/doltlite_commit.sh
@@ -23,7 +23,6 @@ run_test() {
   fi
 }
 
-
 run_test_match() {
   local name="$1"
   local sql="$2"
@@ -45,8 +44,6 @@ echo ""
 DB=/tmp/test_dolt_commit_$$.db
 rm -f "$DB"
 
-
-
 run_test_match "commit_returns_hash" \
   "CREATE TABLE t(x); INSERT INTO t VALUES(1); SELECT dolt_commit('-A', '-m', 'init');" \
   "^[0-9a-f]{40}$" "$DB"
@@ -54,8 +51,6 @@ run_test_match "commit_returns_hash" \
 run_test "commit_requires_message" \
   "SELECT dolt_commit();" \
   "Error near line 1: dolt_commit requires a message: SELECT dolt_commit('-m', 'msg')" "$DB"
-
-
 
 run_test_match "log_shows_commit" \
   "SELECT message FROM dolt_log;" \
@@ -69,8 +64,6 @@ run_test_match "log_has_hash" \
   "SELECT commit_hash FROM dolt_log;" \
   "^[0-9a-f]{40}$" "$DB"
 
-
-
 run_test_match "second_commit" \
   "INSERT INTO t VALUES(2); SELECT dolt_commit('-A', '-m', 'add row 2');" \
   "^[0-9a-f]{40}$" "$DB"
@@ -82,8 +75,6 @@ run_test "log_count_two" \
 run_test_match "log_order" \
   "SELECT message FROM dolt_log;" \
   "add row 2" "$DB"
-
-
 
 run_test_match "commit_with_author" \
   "INSERT INTO t VALUES(3); SELECT dolt_commit('-A', '-m', 'add 3', '--author', 'Alice <alice@test.com>');" \
@@ -101,8 +92,6 @@ run_test "log_count_three" \
   "SELECT count(*) FROM dolt_log;" \
   "4" "$DB"
 
-
-
 DB2=/tmp/test_dolt_persist_$$.db
 rm -f "$DB2"
 
@@ -117,8 +106,6 @@ run_test "persist_log" \
   "SELECT message FROM dolt_log LIMIT 1;" \
   "create items" "$DB2"
 
-
-
 run_test_match "commit_after_alter" \
   "ALTER TABLE items ADD COLUMN price REAL DEFAULT 0; SELECT dolt_commit('-A', '-m', 'add price column');" \
   "^[0-9a-f]{40}$" "$DB2"
@@ -126,8 +113,6 @@ run_test_match "commit_after_alter" \
 run_test "log_after_alter" \
   "SELECT count(*) FROM dolt_log;" \
   "3" "$DB2"
-
-
 
 DB7=/tmp/test_dolt_commit_rename_reopen_$$.db
 rm -f "$DB7"
@@ -153,8 +138,6 @@ run_test "reopen_rename_commit_rows" \
   "base
 x" "$DB7"
 
-
-
 DB8=/tmp/test_dolt_commit_recreate_reopen_$$.db
 rm -f "$DB8"
 
@@ -178,8 +161,6 @@ run_test "reopen_recreate_commit_schema" \
 run_test "reopen_recreate_commit_rows" \
   "SELECT k || '|' || n FROM a;" \
   "7|70" "$DB8"
-
-
 
 DB9=/tmp/test_dolt_commit_schema_only_$$.db
 rm -f "$DB9"
@@ -205,13 +186,9 @@ run_test "reopen_schema_only_commit_rows" \
   "1|base|NULL
 2|x|2" "$DB9"
 
-
-
 run_test "empty_log" \
   "SELECT count(*) FROM dolt_log;" \
   "1" ":memory:"
-
-
 
 DB3=/tmp/test_dolt_nochange_$$.db
 rm -f "$DB3"
@@ -225,8 +202,6 @@ run_test "commit_no_changes" \
 run_test "one_commit_after_no_change" \
   "SELECT count(*) FROM dolt_log;" \
   "2" "$DB3"
-
-
 
 DB4=/tmp/test_dolt_multi_$$.db
 rm -f "$DB4"
@@ -243,32 +218,19 @@ run_test "multi_table_data_b" \
   "SELECT * FROM b;" \
   "2" "$DB4"
 
-
-
 run_test "log_column_count" \
   "SELECT count(*) FROM pragma_table_info('dolt_log');" \
   "5" ":memory:"
-
 
 run_test_match "log_select_columns" \
   "SELECT commit_hash, committer, email, date, message FROM dolt_log LIMIT 1;" \
   "." "$DB"
 
-
-
-
-
-
-
-
 DB5=/tmp/test_dolt_compound_$$.db; rm -f "$DB5"
-
 
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'init');
 SELECT dolt_commit('-A','-m','seed');" | $DOLTLITE "$DB5" > /dev/null 2>&1
-
-
 
 run_test_match "compound_am" \
   "INSERT INTO t VALUES(2,'a');
@@ -283,8 +245,6 @@ run_test "compound_am_data" \
   "SELECT v FROM t WHERE id=2;" \
   "a" "$DB5"
 
-
-
 DB6=/tmp/test_dolt_compound2_$$.db; rm -f "$DB6"
 
 run_test_match "compound_Am" \
@@ -296,7 +256,6 @@ SELECT dolt_commit('-Am','uppercase A compound');" \
 run_test "compound_Am_message" \
   "SELECT message FROM dolt_log LIMIT 1;" \
   "uppercase A compound" "$DB6"
-
 
 DB7=/tmp/test_dolt_compound3_$$.db; rm -f "$DB7"
 
@@ -310,9 +269,6 @@ SELECT dolt_commit('-ma');" \
 run_test "compound_ma_message_is_a" \
   "SELECT message FROM dolt_log LIMIT 1;" \
   "a" "$DB7"
-
-
-
 
 DB8=/tmp/test_dolt_compound4_$$.db; rm -f "$DB8"
 
@@ -334,8 +290,6 @@ run_test "compound_am_multi_count" \
 run_test "compound_am_multi_data" \
   "SELECT count(*) FROM t;" \
   "2" "$DB8"
-
-
 
 rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8"
 

--- a/test/doltlite_commit.sh
+++ b/test/doltlite_commit.sh
@@ -23,7 +23,7 @@ run_test() {
   fi
 }
 
-# Match a pattern (for commit hashes which are nondeterministic)
+
 run_test_match() {
   local name="$1"
   local sql="$2"
@@ -45,7 +45,7 @@ echo ""
 DB=/tmp/test_dolt_commit_$$.db
 rm -f "$DB"
 
-# --- dolt_commit basics ---
+
 
 run_test_match "commit_returns_hash" \
   "CREATE TABLE t(x); INSERT INTO t VALUES(1); SELECT dolt_commit('-A', '-m', 'init');" \
@@ -55,7 +55,7 @@ run_test "commit_requires_message" \
   "SELECT dolt_commit();" \
   "Error near line 1: dolt_commit requires a message: SELECT dolt_commit('-m', 'msg')" "$DB"
 
-# --- dolt_log basics ---
+
 
 run_test_match "log_shows_commit" \
   "SELECT message FROM dolt_log;" \
@@ -69,7 +69,7 @@ run_test_match "log_has_hash" \
   "SELECT commit_hash FROM dolt_log;" \
   "^[0-9a-f]{40}$" "$DB"
 
-# --- Multiple commits ---
+
 
 run_test_match "second_commit" \
   "INSERT INTO t VALUES(2); SELECT dolt_commit('-A', '-m', 'add row 2');" \
@@ -83,7 +83,7 @@ run_test_match "log_order" \
   "SELECT message FROM dolt_log;" \
   "add row 2" "$DB"
 
-# --- Author flag ---
+
 
 run_test_match "commit_with_author" \
   "INSERT INTO t VALUES(3); SELECT dolt_commit('-A', '-m', 'add 3', '--author', 'Alice <alice@test.com>');" \
@@ -101,7 +101,7 @@ run_test "log_count_three" \
   "SELECT count(*) FROM dolt_log;" \
   "4" "$DB"
 
-# --- Data persists across reopen ---
+
 
 DB2=/tmp/test_dolt_persist_$$.db
 rm -f "$DB2"
@@ -117,7 +117,7 @@ run_test "persist_log" \
   "SELECT message FROM dolt_log LIMIT 1;" \
   "create items" "$DB2"
 
-# --- Commit after schema change ---
+
 
 run_test_match "commit_after_alter" \
   "ALTER TABLE items ADD COLUMN price REAL DEFAULT 0; SELECT dolt_commit('-A', '-m', 'add price column');" \
@@ -127,7 +127,7 @@ run_test "log_after_alter" \
   "SELECT count(*) FROM dolt_log;" \
   "3" "$DB2"
 
-# --- Reopen after rename + edit commit ---
+
 
 DB7=/tmp/test_dolt_commit_rename_reopen_$$.db
 rm -f "$DB7"
@@ -153,7 +153,7 @@ run_test "reopen_rename_commit_rows" \
   "base
 x" "$DB7"
 
-# --- Reopen after drop/recreate commit ---
+
 
 DB8=/tmp/test_dolt_commit_recreate_reopen_$$.db
 rm -f "$DB8"
@@ -179,7 +179,7 @@ run_test "reopen_recreate_commit_rows" \
   "SELECT k || '|' || n FROM a;" \
   "7|70" "$DB8"
 
-# --- Reopen after schema-only staged commit with unstaged data left behind ---
+
 
 DB9=/tmp/test_dolt_commit_schema_only_$$.db
 rm -f "$DB9"
@@ -205,13 +205,13 @@ run_test "reopen_schema_only_commit_rows" \
   "1|base|NULL
 2|x|2" "$DB9"
 
-# --- Empty log before first commit ---
+
 
 run_test "empty_log" \
   "SELECT count(*) FROM dolt_log;" \
   "1" ":memory:"
 
-# --- Commit with no changes (should fail) ---
+
 
 DB3=/tmp/test_dolt_nochange_$$.db
 rm -f "$DB3"
@@ -226,7 +226,7 @@ run_test "one_commit_after_no_change" \
   "SELECT count(*) FROM dolt_log;" \
   "2" "$DB3"
 
-# --- Multiple tables ---
+
 
 DB4=/tmp/test_dolt_multi_$$.db
 rm -f "$DB4"
@@ -243,33 +243,33 @@ run_test "multi_table_data_b" \
   "SELECT * FROM b;" \
   "2" "$DB4"
 
-# --- dolt_log columns ---
+
 
 run_test "log_column_count" \
   "SELECT count(*) FROM pragma_table_info('dolt_log');" \
   "5" ":memory:"
 
-# Verify we can SELECT specific columns
+
 run_test_match "log_select_columns" \
   "SELECT commit_hash, committer, email, date, message FROM dolt_log LIMIT 1;" \
   "." "$DB"
 
-# --- Compound short flags (e.g. -am) ---
-#
-# Matching git/Dolt: -a stages MODIFIED tracked tables only, not new
-# untracked tables. -am on a brand-new table is a no-op (errors with
-# "nothing to commit"); the test seeds an initial commit so the
-# table is tracked before -am is exercised.
+
+
+
+
+
+
 
 DB5=/tmp/test_dolt_compound_$$.db; rm -f "$DB5"
 
-# Seed: create + commit so the table is tracked
+
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'init');
 SELECT dolt_commit('-A','-m','seed');" | $DOLTLITE "$DB5" > /dev/null 2>&1
 
-# -am on a modified tracked table: stages the modification + sets
-# message in one compound flag
+
+
 run_test_match "compound_am" \
   "INSERT INTO t VALUES(2,'a');
 SELECT dolt_commit('-am','compound flag commit');" \
@@ -283,8 +283,8 @@ run_test "compound_am_data" \
   "SELECT v FROM t WHERE id=2;" \
   "a" "$DB5"
 
-# -Am: uppercase A variant — -A stages everything including new
-# tables, so this works on a brand-new table without seeding
+
+
 DB6=/tmp/test_dolt_compound2_$$.db; rm -f "$DB6"
 
 run_test_match "compound_Am" \
@@ -297,7 +297,7 @@ run_test "compound_Am_message" \
   "SELECT message FROM dolt_log LIMIT 1;" \
   "uppercase A compound" "$DB6"
 
-# -ma means -m with value "a" (no add-all), so needs dolt_add first
+
 DB7=/tmp/test_dolt_compound3_$$.db; rm -f "$DB7"
 
 run_test_match "compound_ma_with_add" \
@@ -311,9 +311,9 @@ run_test "compound_ma_message_is_a" \
   "SELECT message FROM dolt_log LIMIT 1;" \
   "a" "$DB7"
 
-# Multiple commits with -am — first commit must use -A or -Am to
-# stage the new table; subsequent -am commits then work on the
-# now-tracked table.
+
+
+
 DB8=/tmp/test_dolt_compound4_$$.db; rm -f "$DB8"
 
 run_test_match "compound_am_multi_1" \
@@ -335,7 +335,7 @@ run_test "compound_am_multi_data" \
   "SELECT count(*) FROM t;" \
   "2" "$DB8"
 
-# --- Cleanup ---
+
 
 rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8"
 

--- a/test/doltlite_concurrent.c
+++ b/test/doltlite_concurrent.c
@@ -1,14 +1,3 @@
-
-
-
-
-
-
-
-
-
-
-
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -71,9 +60,6 @@ static void setup_db(const char *path){
   sqlite3_close(db);
 }
 
-
-
-
 static void test_wal_default(const char *path){
   sqlite3 *db;
   char buf[64];
@@ -82,9 +68,6 @@ static void test_wal_default(const char *path){
   CHECK("wal_default: journal_mode is wal", strcmp(buf, "wal")==0);
   sqlite3_close(db);
 }
-
-
-
 
 static void test_wal_pragma(const char *path){
   sqlite3 *db;
@@ -95,9 +78,6 @@ static void test_wal_pragma(const char *path){
   sqlite3_close(db);
 }
 
-
-
-
 static void test_snapshot_isolation(const char *path){
   sqlite3 *dbA, *dbB;
   char buf[64];
@@ -105,19 +85,15 @@ static void test_snapshot_isolation(const char *path){
   sqlite3_open(path, &dbA);
   sqlite3_open(path, &dbB);
 
-
   exec_ok(dbA, "BEGIN");
   exec_text(dbA, "SELECT val FROM t WHERE id=1", buf, sizeof(buf));
   CHECK("snapshot: A reads 'alpha' before B commits", strcmp(buf, "alpha")==0);
 
-
   exec_ok(dbB, "UPDATE t SET val='ALPHA' WHERE id=1");
   exec_ok(dbB, "SELECT dolt_commit('-am', 'update alpha')");
 
-
   exec_text(dbA, "SELECT val FROM t WHERE id=1", buf, sizeof(buf));
   CHECK("snapshot: A still sees 'alpha' after B commits", strcmp(buf, "alpha")==0);
-
 
   exec_ok(dbA, "COMMIT");
   exec_ok(dbA, "BEGIN");
@@ -129,9 +105,6 @@ static void test_snapshot_isolation(const char *path){
   sqlite3_close(dbB);
 }
 
-
-
-
 static void test_concurrent_readers(const char *path){
   sqlite3 *db1, *db2, *db3;
   int v1, v2, v3;
@@ -139,7 +112,6 @@ static void test_concurrent_readers(const char *path){
   sqlite3_open(path, &db1);
   sqlite3_open(path, &db2);
   sqlite3_open(path, &db3);
-
 
   exec_ok(db1, "BEGIN");
   exec_ok(db2, "BEGIN");
@@ -160,9 +132,6 @@ static void test_concurrent_readers(const char *path){
   sqlite3_close(db3);
 }
 
-
-
-
 static void test_reader_no_block_writer(const char *path){
   sqlite3 *dbR, *dbW;
   int rc;
@@ -170,10 +139,8 @@ static void test_reader_no_block_writer(const char *path){
   sqlite3_open(path, &dbR);
   sqlite3_open(path, &dbW);
 
-
   exec_ok(dbR, "BEGIN");
   exec_int(dbR, "SELECT count(*) FROM t", -1);
-
 
   exec_ok(dbW, "INSERT INTO t VALUES(100, 'new')");
   rc = exec_ok(dbW, "SELECT dolt_commit('-am', 'add 100')");
@@ -182,7 +149,6 @@ static void test_reader_no_block_writer(const char *path){
 
   exec_ok(dbR, "COMMIT");
 
-
   exec_ok(dbW, "DELETE FROM t WHERE id=100");
   exec_ok(dbW, "SELECT dolt_commit('-am', 'remove 100')");
 
@@ -190,18 +156,13 @@ static void test_reader_no_block_writer(const char *path){
   sqlite3_close(dbW);
 }
 
-
-
-
 static void test_writer_no_block_reader(const char *path){
   sqlite3 *dbR, *dbW;
 
   sqlite3_open(path, &dbR);
   sqlite3_open(path, &dbW);
 
-
   exec_ok(dbW, "INSERT INTO t VALUES(200, 'wip')");
-
 
   exec_ok(dbR, "BEGIN");
   int cnt = exec_int(dbR, "SELECT count(*) FROM t", -1);
@@ -209,15 +170,11 @@ static void test_writer_no_block_reader(const char *path){
         cnt >= 3);
   exec_ok(dbR, "COMMIT");
 
-
   exec_ok(dbW, "DELETE FROM t WHERE id=200");
 
   sqlite3_close(dbR);
   sqlite3_close(dbW);
 }
-
-
-
 
 static void test_snapshot_consistency(const char *path){
   sqlite3 *dbA, *dbB;
@@ -229,22 +186,18 @@ static void test_snapshot_consistency(const char *path){
   exec_ok(dbA, "BEGIN");
   int cnt1 = exec_int(dbA, "SELECT count(*) FROM t", -1);
 
-
   exec_ok(dbB, "INSERT INTO t VALUES(300, 'added')");
   exec_ok(dbB, "SELECT dolt_commit('-am', 'add 300')");
-
 
   int cnt2 = exec_int(dbA, "SELECT count(*) FROM t", -1);
   CHECK("snapshot_consistency: count stable across concurrent commit",
         cnt1==cnt2);
-
 
   exec_text(dbA, "SELECT val FROM t WHERE id=2", buf, sizeof(buf));
   CHECK("snapshot_consistency: A reads 'beta' consistently",
         strcmp(buf, "beta")==0);
 
   exec_ok(dbA, "COMMIT");
-
 
   exec_ok(dbB, "DELETE FROM t WHERE id=300");
   exec_ok(dbB, "SELECT dolt_commit('-am', 'remove 300')");
@@ -253,38 +206,28 @@ static void test_snapshot_consistency(const char *path){
   sqlite3_close(dbB);
 }
 
-
-
-
 static void test_checkpoint(const char *path){
   sqlite3 *db;
   int rc;
 
   sqlite3_open(path, &db);
 
-
   exec_ok(db, "INSERT INTO t VALUES(400, 'ckpt1')");
   exec_ok(db, "SELECT dolt_commit('-am', 'ckpt1')");
   exec_ok(db, "INSERT INTO t VALUES(401, 'ckpt2')");
   exec_ok(db, "SELECT dolt_commit('-am', 'ckpt2')");
 
-
   rc = exec_ok(db, "PRAGMA wal_checkpoint(TRUNCATE)");
   CHECK("checkpoint: PRAGMA wal_checkpoint succeeds", rc==SQLITE_OK);
 
-
   int cnt = exec_int(db, "SELECT count(*) FROM t WHERE id>=400", -1);
   CHECK("checkpoint: data preserved after checkpoint", cnt==2);
-
 
   exec_ok(db, "DELETE FROM t WHERE id>=400");
   exec_ok(db, "SELECT dolt_commit('-am', 'clean up ckpt')");
 
   sqlite3_close(db);
 }
-
-
-
 
 static void test_post_checkpoint_read(const char *path){
   sqlite3 *db1, *db2;
@@ -295,11 +238,9 @@ static void test_post_checkpoint_read(const char *path){
   exec_ok(db1, "SELECT dolt_commit('-am', 'add 500')");
   exec_ok(db1, "PRAGMA wal_checkpoint(TRUNCATE)");
 
-
   sqlite3_open(path, &db2);
   int cnt = exec_int(db2, "SELECT count(*) FROM t WHERE id=500", -1);
   CHECK("post_checkpoint_read: new connection sees data after checkpoint", cnt==1);
-
 
   exec_ok(db1, "DELETE FROM t WHERE id=500");
   exec_ok(db1, "SELECT dolt_commit('-am', 'clean up 500')");
@@ -307,9 +248,6 @@ static void test_post_checkpoint_read(const char *path){
   sqlite3_close(db1);
   sqlite3_close(db2);
 }
-
-
-
 
 static void test_snapshot_large(const char *path){
   sqlite3 *dbA, *dbB;
@@ -319,10 +257,8 @@ static void test_snapshot_large(const char *path){
 
   int cnt_before = exec_int(dbA, "SELECT count(*) FROM t", -1);
 
-
   exec_ok(dbA, "BEGIN");
   int cnt_a1 = exec_int(dbA, "SELECT count(*) FROM t", -1);
-
 
   exec_ok(dbB, "BEGIN");
   {
@@ -337,18 +273,15 @@ static void test_snapshot_large(const char *path){
   exec_ok(dbB, "COMMIT");
   exec_ok(dbB, "SELECT dolt_commit('-am', 'bulk insert')");
 
-
   int cnt_a2 = exec_int(dbA, "SELECT count(*) FROM t", -1);
   CHECK("snapshot_large: 100-row insert invisible to snapshot reader",
         cnt_a1==cnt_a2);
 
   exec_ok(dbA, "COMMIT");
 
-
   int cnt_a3 = exec_int(dbA, "SELECT count(*) FROM t", -1);
   CHECK("snapshot_large: new transaction sees bulk insert",
         cnt_a3 == cnt_before + 100);
-
 
   exec_ok(dbB, "DELETE FROM t WHERE id>=1000");
   exec_ok(dbB, "SELECT dolt_commit('-am', 'clean up bulk')");

--- a/test/doltlite_concurrent.c
+++ b/test/doltlite_concurrent.c
@@ -1,14 +1,14 @@
-/*
-** Concurrent read/write tests for doltlite WAL mode and MVCC.
-**
-** Tests snapshot isolation, concurrent readers, reader/writer
-** non-blocking, checkpoint, and WAL mode PRAGMA.
-**
-** Build from build/ directory:
-**   cc -I. -I../src -o test_concurrent ../test/doltlite_concurrent.c *.o -lz -lpthread
-** Run:
-**   ./test_concurrent
-*/
+
+
+
+
+
+
+
+
+
+
+
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -71,9 +71,9 @@ static void setup_db(const char *path){
   sqlite3_close(db);
 }
 
-/* ----------------------------------------------------------------
-** Test 1: WAL mode is default
-** ---------------------------------------------------------------- */
+
+
+
 static void test_wal_default(const char *path){
   sqlite3 *db;
   char buf[64];
@@ -83,9 +83,9 @@ static void test_wal_default(const char *path){
   sqlite3_close(db);
 }
 
-/* ----------------------------------------------------------------
-** Test 2: PRAGMA journal_mode=WAL succeeds
-** ---------------------------------------------------------------- */
+
+
+
 static void test_wal_pragma(const char *path){
   sqlite3 *db;
   char buf[64];
@@ -95,9 +95,9 @@ static void test_wal_pragma(const char *path){
   sqlite3_close(db);
 }
 
-/* ----------------------------------------------------------------
-** Test 3: Snapshot isolation — reader doesn't see concurrent commit
-** ---------------------------------------------------------------- */
+
+
+
 static void test_snapshot_isolation(const char *path){
   sqlite3 *dbA, *dbB;
   char buf[64];
@@ -105,20 +105,20 @@ static void test_snapshot_isolation(const char *path){
   sqlite3_open(path, &dbA);
   sqlite3_open(path, &dbB);
 
-  /* A starts read transaction */
+
   exec_ok(dbA, "BEGIN");
   exec_text(dbA, "SELECT val FROM t WHERE id=1", buf, sizeof(buf));
   CHECK("snapshot: A reads 'alpha' before B commits", strcmp(buf, "alpha")==0);
 
-  /* B updates and commits */
+
   exec_ok(dbB, "UPDATE t SET val='ALPHA' WHERE id=1");
   exec_ok(dbB, "SELECT dolt_commit('-am', 'update alpha')");
 
-  /* A should still see old value */
+
   exec_text(dbA, "SELECT val FROM t WHERE id=1", buf, sizeof(buf));
   CHECK("snapshot: A still sees 'alpha' after B commits", strcmp(buf, "alpha")==0);
 
-  /* A ends transaction, starts new one — should see update */
+
   exec_ok(dbA, "COMMIT");
   exec_ok(dbA, "BEGIN");
   exec_text(dbA, "SELECT val FROM t WHERE id=1", buf, sizeof(buf));
@@ -129,9 +129,9 @@ static void test_snapshot_isolation(const char *path){
   sqlite3_close(dbB);
 }
 
-/* ----------------------------------------------------------------
-** Test 4: Multiple concurrent readers
-** ---------------------------------------------------------------- */
+
+
+
 static void test_concurrent_readers(const char *path){
   sqlite3 *db1, *db2, *db3;
   int v1, v2, v3;
@@ -140,7 +140,7 @@ static void test_concurrent_readers(const char *path){
   sqlite3_open(path, &db2);
   sqlite3_open(path, &db3);
 
-  /* All three start read transactions simultaneously */
+
   exec_ok(db1, "BEGIN");
   exec_ok(db2, "BEGIN");
   exec_ok(db3, "BEGIN");
@@ -160,9 +160,9 @@ static void test_concurrent_readers(const char *path){
   sqlite3_close(db3);
 }
 
-/* ----------------------------------------------------------------
-** Test 5: Reader doesn't block writer
-** ---------------------------------------------------------------- */
+
+
+
 static void test_reader_no_block_writer(const char *path){
   sqlite3 *dbR, *dbW;
   int rc;
@@ -170,11 +170,11 @@ static void test_reader_no_block_writer(const char *path){
   sqlite3_open(path, &dbR);
   sqlite3_open(path, &dbW);
 
-  /* Reader holds open transaction */
+
   exec_ok(dbR, "BEGIN");
   exec_int(dbR, "SELECT count(*) FROM t", -1);
 
-  /* Writer should succeed despite open reader */
+
   exec_ok(dbW, "INSERT INTO t VALUES(100, 'new')");
   rc = exec_ok(dbW, "SELECT dolt_commit('-am', 'add 100')");
   CHECK("reader_no_block_writer: write succeeds while reader is active",
@@ -182,7 +182,7 @@ static void test_reader_no_block_writer(const char *path){
 
   exec_ok(dbR, "COMMIT");
 
-  /* Clean up */
+
   exec_ok(dbW, "DELETE FROM t WHERE id=100");
   exec_ok(dbW, "SELECT dolt_commit('-am', 'remove 100')");
 
@@ -190,35 +190,35 @@ static void test_reader_no_block_writer(const char *path){
   sqlite3_close(dbW);
 }
 
-/* ----------------------------------------------------------------
-** Test 6: Writer doesn't block reader
-** ---------------------------------------------------------------- */
+
+
+
 static void test_writer_no_block_reader(const char *path){
   sqlite3 *dbR, *dbW;
 
   sqlite3_open(path, &dbR);
   sqlite3_open(path, &dbW);
 
-  /* Writer starts working (uncommitted changes) */
+
   exec_ok(dbW, "INSERT INTO t VALUES(200, 'wip')");
 
-  /* Reader should succeed despite writer's uncommitted changes */
+
   exec_ok(dbR, "BEGIN");
   int cnt = exec_int(dbR, "SELECT count(*) FROM t", -1);
   CHECK("writer_no_block_reader: reader succeeds while writer has pending changes",
         cnt >= 3);
   exec_ok(dbR, "COMMIT");
 
-  /* Rollback writer's changes */
+
   exec_ok(dbW, "DELETE FROM t WHERE id=200");
 
   sqlite3_close(dbR);
   sqlite3_close(dbW);
 }
 
-/* ----------------------------------------------------------------
-** Test 7: Snapshot sees consistent state across multiple queries
-** ---------------------------------------------------------------- */
+
+
+
 static void test_snapshot_consistency(const char *path){
   sqlite3 *dbA, *dbB;
   char buf[64];
@@ -229,23 +229,23 @@ static void test_snapshot_consistency(const char *path){
   exec_ok(dbA, "BEGIN");
   int cnt1 = exec_int(dbA, "SELECT count(*) FROM t", -1);
 
-  /* B adds a row and commits */
+
   exec_ok(dbB, "INSERT INTO t VALUES(300, 'added')");
   exec_ok(dbB, "SELECT dolt_commit('-am', 'add 300')");
 
-  /* A queries again — should see same count (snapshot) */
+
   int cnt2 = exec_int(dbA, "SELECT count(*) FROM t", -1);
   CHECK("snapshot_consistency: count stable across concurrent commit",
         cnt1==cnt2);
 
-  /* A can also read specific rows consistently */
+
   exec_text(dbA, "SELECT val FROM t WHERE id=2", buf, sizeof(buf));
   CHECK("snapshot_consistency: A reads 'beta' consistently",
         strcmp(buf, "beta")==0);
 
   exec_ok(dbA, "COMMIT");
 
-  /* Clean up */
+
   exec_ok(dbB, "DELETE FROM t WHERE id=300");
   exec_ok(dbB, "SELECT dolt_commit('-am', 'remove 300')");
 
@@ -253,39 +253,39 @@ static void test_snapshot_consistency(const char *path){
   sqlite3_close(dbB);
 }
 
-/* ----------------------------------------------------------------
-** Test 8: PRAGMA wal_checkpoint works
-** ---------------------------------------------------------------- */
+
+
+
 static void test_checkpoint(const char *path){
   sqlite3 *db;
   int rc;
 
   sqlite3_open(path, &db);
 
-  /* Make some commits to build up WAL */
+
   exec_ok(db, "INSERT INTO t VALUES(400, 'ckpt1')");
   exec_ok(db, "SELECT dolt_commit('-am', 'ckpt1')");
   exec_ok(db, "INSERT INTO t VALUES(401, 'ckpt2')");
   exec_ok(db, "SELECT dolt_commit('-am', 'ckpt2')");
 
-  /* Checkpoint */
+
   rc = exec_ok(db, "PRAGMA wal_checkpoint(TRUNCATE)");
   CHECK("checkpoint: PRAGMA wal_checkpoint succeeds", rc==SQLITE_OK);
 
-  /* Data should still be there */
+
   int cnt = exec_int(db, "SELECT count(*) FROM t WHERE id>=400", -1);
   CHECK("checkpoint: data preserved after checkpoint", cnt==2);
 
-  /* Clean up */
+
   exec_ok(db, "DELETE FROM t WHERE id>=400");
   exec_ok(db, "SELECT dolt_commit('-am', 'clean up ckpt')");
 
   sqlite3_close(db);
 }
 
-/* ----------------------------------------------------------------
-** Test 9: New transaction after checkpoint sees correct data
-** ---------------------------------------------------------------- */
+
+
+
 static void test_post_checkpoint_read(const char *path){
   sqlite3 *db1, *db2;
 
@@ -295,12 +295,12 @@ static void test_post_checkpoint_read(const char *path){
   exec_ok(db1, "SELECT dolt_commit('-am', 'add 500')");
   exec_ok(db1, "PRAGMA wal_checkpoint(TRUNCATE)");
 
-  /* Open fresh connection after checkpoint */
+
   sqlite3_open(path, &db2);
   int cnt = exec_int(db2, "SELECT count(*) FROM t WHERE id=500", -1);
   CHECK("post_checkpoint_read: new connection sees data after checkpoint", cnt==1);
 
-  /* Clean up */
+
   exec_ok(db1, "DELETE FROM t WHERE id=500");
   exec_ok(db1, "SELECT dolt_commit('-am', 'clean up 500')");
 
@@ -308,9 +308,9 @@ static void test_post_checkpoint_read(const char *path){
   sqlite3_close(db2);
 }
 
-/* ----------------------------------------------------------------
-** Test 10: Snapshot isolation with large data
-** ---------------------------------------------------------------- */
+
+
+
 static void test_snapshot_large(const char *path){
   sqlite3 *dbA, *dbB;
 
@@ -319,11 +319,11 @@ static void test_snapshot_large(const char *path){
 
   int cnt_before = exec_int(dbA, "SELECT count(*) FROM t", -1);
 
-  /* A starts read transaction */
+
   exec_ok(dbA, "BEGIN");
   int cnt_a1 = exec_int(dbA, "SELECT count(*) FROM t", -1);
 
-  /* B inserts 100 rows and commits */
+
   exec_ok(dbB, "BEGIN");
   {
     char sql[128];
@@ -337,19 +337,19 @@ static void test_snapshot_large(const char *path){
   exec_ok(dbB, "COMMIT");
   exec_ok(dbB, "SELECT dolt_commit('-am', 'bulk insert')");
 
-  /* A should see original count */
+
   int cnt_a2 = exec_int(dbA, "SELECT count(*) FROM t", -1);
   CHECK("snapshot_large: 100-row insert invisible to snapshot reader",
         cnt_a1==cnt_a2);
 
   exec_ok(dbA, "COMMIT");
 
-  /* After ending transaction, A should see new rows */
+
   int cnt_a3 = exec_int(dbA, "SELECT count(*) FROM t", -1);
   CHECK("snapshot_large: new transaction sees bulk insert",
         cnt_a3 == cnt_before + 100);
 
-  /* Clean up */
+
   exec_ok(dbB, "DELETE FROM t WHERE id>=1000");
   exec_ok(dbB, "SELECT dolt_commit('-am', 'clean up bulk')");
 

--- a/test/doltlite_conflict_rows.sh
+++ b/test/doltlite_conflict_rows.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-#
-# Tests for per-row conflict resolution via dolt_conflicts_<tablename>.
-# Autocommit conflict state is session-local, so all conflict-row checks
-# happen in a single SQL invocation.
-#
+
+
+
+
+
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
@@ -78,7 +78,7 @@ UPDATE t SET v='main_b' WHERE a=2 AND b=2;
 SELECT dolt_commit('-A','-m','main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 }
 
-# View individual conflict rows
+
 DB=/tmp/test_cfrow_view_$$.db
 setup_row_conflict_repo "$DB"
 run_test_match "view_count" "BEGIN; SELECT dolt_merge('hf'); SELECT 'VC|' || count(*) FROM dolt_conflicts_t; ROLLBACK;" "^VC\\|1$" "$DB"
@@ -89,7 +89,7 @@ run_test_match "view_base_val" "BEGIN; SELECT dolt_merge('hf'); SELECT 'VBT|' ||
 run_test_match "view_their_val" "BEGIN; SELECT dolt_merge('hf'); SELECT 'VTT|' || typeof(their_v) FROM dolt_conflicts_t; ROLLBACK;" "^VTT\\|text$" "$DB"
 rm -f "$DB"
 
-# DELETE resolves individual conflict (keeps ours)
+
 DB=/tmp/test_cfrow_del_$$.db
 setup_row_conflict_repo "$DB"
 run_test_match "del_summary_cleared" "BEGIN; SELECT dolt_merge('hf'); DELETE FROM dolt_conflicts_t WHERE base_id=1; SELECT 'DC|' || count(*) FROM dolt_conflicts; ROLLBACK;" "^DC\\|0$" "$DB"
@@ -98,14 +98,14 @@ run_test_match "del_other_ok" "BEGIN; SELECT dolt_merge('hf'); DELETE FROM dolt_
 run_test_match "del_clean" "BEGIN; SELECT dolt_merge('hf'); DELETE FROM dolt_conflicts_t WHERE base_id=1; SELECT 'DS|' || count(*) FROM dolt_status; ROLLBACK;" "^DS\\|0$" "$DB"
 rm -f "$DB"
 
-# --ours resolution clears per-table
+
 DB=/tmp/test_cfrow_ours_$$.db
 setup_row_conflict_repo "$DB"
 run_test_match "ours_cleared" "BEGIN; SELECT dolt_merge('hf'); SELECT dolt_conflicts_resolve('--ours','t'); SELECT 'OC|' || count(*) FROM dolt_conflicts; ROLLBACK;" "^OC\\|0$" "$DB"
 run_test_match "ours_val" "BEGIN; SELECT dolt_merge('hf'); SELECT dolt_conflicts_resolve('--ours','t'); SELECT 'OV|' || v FROM t WHERE id=1; ROLLBACK;" "^OV\\|main_val$" "$DB"
 rm -f "$DB"
 
-# No conflict table when no conflicts
+
 DB=/tmp/test_cfrow_noconf_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
@@ -114,7 +114,7 @@ run_test "noconf_table" "SELECT count(*) FROM dolt_conflicts_t;" "0" "$DB"
 run_test "noconf_summary" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
 rm -f "$DB"
 
-# Conflict rows do not persist across reopen after autocommit rollback
+
 DB=/tmp/test_cfrow_persist_$$.db
 setup_row_conflict_repo "$DB"
 echo "SELECT dolt_merge('hf');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -122,14 +122,14 @@ run_test "persist_summary" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
 run_test "persist_rows" "SELECT count(*) FROM dolt_conflicts_t;" "0" "$DB"
 rm -f "$DB"
 
-# DELETE with no matching row is a no-op
+
 DB=/tmp/test_cfrow_noop_$$.db
 setup_row_conflict_repo "$DB"
 run_test_match "noop_still_there" "BEGIN; SELECT dolt_merge('hf'); DELETE FROM dolt_conflicts_t WHERE base_id=999; SELECT 'NC|' || count(*) FROM dolt_conflicts_t; ROLLBACK;" "^NC\\|1$" "$DB"
 run_test_match "noop_rowid" "BEGIN; SELECT dolt_merge('hf'); DELETE FROM dolt_conflicts_t WHERE base_id=999; SELECT 'NR|' || base_id FROM dolt_conflicts_t; ROLLBACK;" "^NR\\|1$" "$DB"
 rm -f "$DB"
 
-# Delete/delete conflict with --theirs keeps delete and skips triggers
+
 DB=/tmp/test_cfrow_delete_$$.db
 setup_delete_conflict_repo "$DB"
 run_test_match "theirs_delete_clears" "BEGIN; SELECT dolt_merge('hf'); SELECT dolt_conflicts_resolve('--theirs','t'); SELECT 'TC|' || count(*) FROM dolt_conflicts; ROLLBACK;" "^TC\\|0$" "$DB"
@@ -137,7 +137,7 @@ run_test_match "theirs_delete_removes_row" "BEGIN; SELECT dolt_merge('hf'); CREA
 run_test_match "theirs_delete_trigger_skipped" "BEGIN; SELECT dolt_merge('hf'); CREATE TRIGGER audit_delete BEFORE DELETE ON t BEGIN INSERT INTO trig_log VALUES('fired'); END; SELECT dolt_conflicts_resolve('--theirs','t'); SELECT 'TT|' || count(*) FROM trig_log; ROLLBACK;" "^TT\\|0$" "$DB"
 rm -f "$DB"
 
-# Text PK conflicts delete by synthetic rowid
+
 DB=/tmp/test_cfrow_textpk_$$.db
 setup_text_pk_conflict_repo "$DB"
 run_test_match "textpk_conflict_count" "BEGIN; SELECT dolt_merge('hf'); SELECT 'TC|' || count(*) FROM dolt_conflicts_t; ROLLBACK;" "^TC\\|2$" "$DB"
@@ -146,7 +146,7 @@ run_test_match "textpk_target_delete_keeps_b" "BEGIN; SELECT dolt_merge('hf'); D
 run_test_match "textpk_full_delete_clears" "BEGIN; SELECT dolt_merge('hf'); DELETE FROM dolt_conflicts_t; SELECT 'TF|' || count(*) FROM dolt_conflicts; ROLLBACK;" "^TF\\|0$" "$DB"
 rm -f "$DB"
 
-# Composite PK conflicts delete by synthetic rowid
+
 DB=/tmp/test_cfrow_compositepk_$$.db
 setup_composite_pk_conflict_repo "$DB"
 run_test_match "compositepk_conflict_count" "BEGIN; SELECT dolt_merge('hf'); SELECT 'CC|' || count(*) FROM dolt_conflicts_t; ROLLBACK;" "^CC\\|2$" "$DB"

--- a/test/doltlite_conflict_rows.sh
+++ b/test/doltlite_conflict_rows.sh
@@ -1,9 +1,4 @@
 #!/bin/bash
-
-
-
-
-
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
@@ -78,7 +73,6 @@ UPDATE t SET v='main_b' WHERE a=2 AND b=2;
 SELECT dolt_commit('-A','-m','main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 }
 
-
 DB=/tmp/test_cfrow_view_$$.db
 setup_row_conflict_repo "$DB"
 run_test_match "view_count" "BEGIN; SELECT dolt_merge('hf'); SELECT 'VC|' || count(*) FROM dolt_conflicts_t; ROLLBACK;" "^VC\\|1$" "$DB"
@@ -89,7 +83,6 @@ run_test_match "view_base_val" "BEGIN; SELECT dolt_merge('hf'); SELECT 'VBT|' ||
 run_test_match "view_their_val" "BEGIN; SELECT dolt_merge('hf'); SELECT 'VTT|' || typeof(their_v) FROM dolt_conflicts_t; ROLLBACK;" "^VTT\\|text$" "$DB"
 rm -f "$DB"
 
-
 DB=/tmp/test_cfrow_del_$$.db
 setup_row_conflict_repo "$DB"
 run_test_match "del_summary_cleared" "BEGIN; SELECT dolt_merge('hf'); DELETE FROM dolt_conflicts_t WHERE base_id=1; SELECT 'DC|' || count(*) FROM dolt_conflicts; ROLLBACK;" "^DC\\|0$" "$DB"
@@ -98,13 +91,11 @@ run_test_match "del_other_ok" "BEGIN; SELECT dolt_merge('hf'); DELETE FROM dolt_
 run_test_match "del_clean" "BEGIN; SELECT dolt_merge('hf'); DELETE FROM dolt_conflicts_t WHERE base_id=1; SELECT 'DS|' || count(*) FROM dolt_status; ROLLBACK;" "^DS\\|0$" "$DB"
 rm -f "$DB"
 
-
 DB=/tmp/test_cfrow_ours_$$.db
 setup_row_conflict_repo "$DB"
 run_test_match "ours_cleared" "BEGIN; SELECT dolt_merge('hf'); SELECT dolt_conflicts_resolve('--ours','t'); SELECT 'OC|' || count(*) FROM dolt_conflicts; ROLLBACK;" "^OC\\|0$" "$DB"
 run_test_match "ours_val" "BEGIN; SELECT dolt_merge('hf'); SELECT dolt_conflicts_resolve('--ours','t'); SELECT 'OV|' || v FROM t WHERE id=1; ROLLBACK;" "^OV\\|main_val$" "$DB"
 rm -f "$DB"
-
 
 DB=/tmp/test_cfrow_noconf_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -114,7 +105,6 @@ run_test "noconf_table" "SELECT count(*) FROM dolt_conflicts_t;" "0" "$DB"
 run_test "noconf_summary" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
 rm -f "$DB"
 
-
 DB=/tmp/test_cfrow_persist_$$.db
 setup_row_conflict_repo "$DB"
 echo "SELECT dolt_merge('hf');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -122,13 +112,11 @@ run_test "persist_summary" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
 run_test "persist_rows" "SELECT count(*) FROM dolt_conflicts_t;" "0" "$DB"
 rm -f "$DB"
 
-
 DB=/tmp/test_cfrow_noop_$$.db
 setup_row_conflict_repo "$DB"
 run_test_match "noop_still_there" "BEGIN; SELECT dolt_merge('hf'); DELETE FROM dolt_conflicts_t WHERE base_id=999; SELECT 'NC|' || count(*) FROM dolt_conflicts_t; ROLLBACK;" "^NC\\|1$" "$DB"
 run_test_match "noop_rowid" "BEGIN; SELECT dolt_merge('hf'); DELETE FROM dolt_conflicts_t WHERE base_id=999; SELECT 'NR|' || base_id FROM dolt_conflicts_t; ROLLBACK;" "^NR\\|1$" "$DB"
 rm -f "$DB"
-
 
 DB=/tmp/test_cfrow_delete_$$.db
 setup_delete_conflict_repo "$DB"
@@ -137,7 +125,6 @@ run_test_match "theirs_delete_removes_row" "BEGIN; SELECT dolt_merge('hf'); CREA
 run_test_match "theirs_delete_trigger_skipped" "BEGIN; SELECT dolt_merge('hf'); CREATE TRIGGER audit_delete BEFORE DELETE ON t BEGIN INSERT INTO trig_log VALUES('fired'); END; SELECT dolt_conflicts_resolve('--theirs','t'); SELECT 'TT|' || count(*) FROM trig_log; ROLLBACK;" "^TT\\|0$" "$DB"
 rm -f "$DB"
 
-
 DB=/tmp/test_cfrow_textpk_$$.db
 setup_text_pk_conflict_repo "$DB"
 run_test_match "textpk_conflict_count" "BEGIN; SELECT dolt_merge('hf'); SELECT 'TC|' || count(*) FROM dolt_conflicts_t; ROLLBACK;" "^TC\\|2$" "$DB"
@@ -145,7 +132,6 @@ run_test_match "textpk_target_delete_leaves_one" "BEGIN; SELECT dolt_merge('hf')
 run_test_match "textpk_target_delete_keeps_b" "BEGIN; SELECT dolt_merge('hf'); DELETE FROM dolt_conflicts_t WHERE base_id='a'; SELECT 'TK|' || base_id FROM dolt_conflicts_t; ROLLBACK;" "^TK\\|b$" "$DB"
 run_test_match "textpk_full_delete_clears" "BEGIN; SELECT dolt_merge('hf'); DELETE FROM dolt_conflicts_t; SELECT 'TF|' || count(*) FROM dolt_conflicts; ROLLBACK;" "^TF\\|0$" "$DB"
 rm -f "$DB"
-
 
 DB=/tmp/test_cfrow_compositepk_$$.db
 setup_composite_pk_conflict_repo "$DB"

--- a/test/doltlite_conflicts.sh
+++ b/test/doltlite_conflicts.sh
@@ -7,7 +7,7 @@ run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -
 echo "=== Doltlite Conflicts Tests ==="
 echo ""
 
-# Test 1: Autocommit merge with conflict surfaces conflict state in-session
+
 DB=/tmp/test_cf_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'orig'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -22,12 +22,12 @@ run_test_match "conflicts_count" \
   "BEGIN; SELECT dolt_merge('feature'); SELECT 'CC|' || num_conflicts FROM dolt_conflicts; ROLLBACK;" \
   "^CC\\|1$" "$DB"
 
-# Test 2: Commit blocked with conflicts in the same SQL session
+
 run_test_match "commit_blocked" \
   "BEGIN; SELECT dolt_merge('feature'); SELECT dolt_commit('-A','-m','fail');" \
   "cannot commit: unresolved merge conflicts|Use dolt_conflicts_resolve" "$DB"
 
-# Test 3: Resolve --ours keeps our value in-session
+
 run_test_match "resolved_no_conflicts" \
   "BEGIN; SELECT dolt_merge('feature'); SELECT dolt_conflicts_resolve('--ours','t'); SELECT 'RC|' || count(*) FROM dolt_conflicts; SELECT 'RV|' || v FROM t; ROLLBACK;" \
   "^RC\\|0$" "$DB"
@@ -35,7 +35,7 @@ run_test_match "ours_value_kept" \
   "BEGIN; SELECT dolt_merge('feature'); SELECT dolt_conflicts_resolve('--ours','t'); SELECT 'RV|' || v FROM t; ROLLBACK;" \
   "^RV\\|main$" "$DB"
 
-# Test 4: Resolve --theirs (new scenario)
+
 DB2=/tmp/test_cf2_$$.db; rm -f "$DB2"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'orig'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB2" > /dev/null 2>&1
 echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB2" > /dev/null 2>&1
@@ -50,7 +50,7 @@ run_test_match "theirs_resolved" \
   "BEGIN; SELECT dolt_merge('feature'); SELECT dolt_conflicts_resolve('--theirs','t'); SELECT 'TR|' || count(*) FROM dolt_conflicts; ROLLBACK;" \
   "^TR\\|0$" "$DB2"
 
-# Test 5: No conflict when different rows modified
+
 DB3=/tmp/test_cf3_$$.db; rm -f "$DB3"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'),(2,'b'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB3" > /dev/null 2>&1
 echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB3" > /dev/null 2>&1
@@ -63,7 +63,7 @@ run_test "no_conflicts_table" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB3"
 run_test "auto_merge_row1" "SELECT v FROM t WHERE id=1;" "MAIN" "$DB3"
 run_test "auto_merge_row2" "SELECT v FROM t WHERE id=2;" "FEAT" "$DB3"
 
-# Test 6: Mixed — some conflict, some auto-merge
+
 DB4=/tmp/test_cf4_$$.db; rm -f "$DB4"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'),(2,'b'),(3,'c'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB4" > /dev/null 2>&1
 echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB4" > /dev/null 2>&1
@@ -82,7 +82,7 @@ run_test_match "mixed_auto_row4" \
   "BEGIN; SELECT dolt_merge('feature'); SELECT 'MR4|' || count(*) FROM t WHERE id=4; ROLLBACK;" \
   "^MR4\\|1$" "$DB4"
 
-# --- Cell-level merge: non-overlapping column changes auto-merge ---
+
 DB5=/tmp/test_conflicts5_$$.db; rm -f "$DB5"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, name TEXT, val INTEGER); INSERT INTO t VALUES(1,'alice',100); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB5" > /dev/null 2>&1
 echo "SELECT dolt_branch('a'); SELECT dolt_checkout('a'); UPDATE t SET name='ALICE' WHERE id=1; SELECT dolt_commit('-A','-m','a');" | $DOLTLITE "$DB5" > /dev/null 2>&1
@@ -94,7 +94,7 @@ run_test "cell_merge_name" "SELECT name FROM t WHERE id=1;" "ALICE" "$DB5"
 run_test "cell_merge_val" "SELECT val FROM t WHERE id=1;" "999" "$DB5"
 run_test "cell_merge_no_conflicts" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB5"
 
-# --- Cell-level merge: schema change + data change auto-merge ---
+
 DB6=/tmp/test_conflicts6_$$.db; rm -f "$DB6"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, name TEXT); INSERT INTO t VALUES(1,'alice'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6" > /dev/null 2>&1
 echo "SELECT dolt_branch('schema_br'); SELECT dolt_checkout('schema_br'); ALTER TABLE t ADD COLUMN extra TEXT; UPDATE t SET extra='x'; SELECT dolt_commit('-A','-m','schema');" | $DOLTLITE "$DB6" > /dev/null 2>&1
@@ -105,7 +105,7 @@ run_test_match "schema_data_merge" "SELECT dolt_merge('data_br');" "^[0-9a-f]" "
 run_test "schema_data_name" "SELECT name FROM t WHERE id=1;" "ALICE" "$DB6"
 run_test "schema_data_extra" "SELECT extra FROM t WHERE id=1;" "x" "$DB6"
 
-# --- Real conflict: same column changed on both sides ---
+
 DB7=/tmp/test_conflicts7_$$.db; rm -f "$DB7"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, name TEXT, val INTEGER); INSERT INTO t VALUES(1,'alice',100); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB7" > /dev/null 2>&1
 echo "SELECT dolt_branch('c'); SELECT dolt_checkout('c'); UPDATE t SET name='BOB' WHERE id=1; SELECT dolt_commit('-A','-m','c');" | $DOLTLITE "$DB7" > /dev/null 2>&1
@@ -116,7 +116,7 @@ run_test_match "real_conflict_count" \
   "BEGIN; SELECT dolt_merge('c'); SELECT 'RC|' || num_conflicts FROM dolt_conflicts; ROLLBACK;" \
   "^RC\\|1$" "$DB7"
 
-# User columns are now projected individually (Dolt-compatible schema).
+
 run_test_match "conflict_base_decoded" \
   "BEGIN; SELECT dolt_merge('c'); SELECT 'BASE|' || base_name FROM dolt_conflicts_t; ROLLBACK;" \
   "^BASE\\|alice$" "$DB7"
@@ -127,8 +127,8 @@ run_test_match "conflict_their_decoded" \
   "BEGIN; SELECT dolt_merge('c'); SELECT 'THEIR|' || their_name FROM dolt_conflicts_t; ROLLBACK;" \
   "^THEIR\\|BOB$" "$DB7"
 
-# Temp table shadowing the user table must not affect dolt_conflicts_<table>
-# projection. The conflict view should derive its schema from main.t.
+
+
 run_test_match "conflict_temp_shadow_base_ignored" \
   "BEGIN; SELECT dolt_merge('c'); CREATE TEMP TABLE t(fake TEXT PRIMARY KEY); SELECT 'TSB|' || base_name FROM dolt_conflicts_t; ROLLBACK;" \
   "^TSB\\|alice$" "$DB7"
@@ -139,7 +139,7 @@ run_test_match "conflict_temp_shadow_their_ignored" \
   "BEGIN; SELECT dolt_merge('c'); CREATE TEMP TABLE t(fake TEXT PRIMARY KEY); SELECT 'TST|' || their_name FROM dolt_conflicts_t; ROLLBACK;" \
   "^TST\\|BOB$" "$DB7"
 
-# --- Multiple conflicting rows in one table ---
+
 DB8=/tmp/test_conflicts8_$$.db; rm -f "$DB8"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, name TEXT); INSERT INTO t VALUES(1,'a'),(2,'b'),(3,'c'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB8" > /dev/null 2>&1
 echo "SELECT dolt_branch('other'); SELECT dolt_checkout('other'); UPDATE t SET name='A' WHERE id=1; UPDATE t SET name='B' WHERE id=2; UPDATE t SET name='C' WHERE id=3; SELECT dolt_commit('-A','-m','other');" | $DOLTLITE "$DB8" > /dev/null 2>&1
@@ -162,13 +162,13 @@ run_test_match "multi_row_has_row3" \
   "BEGIN; SELECT dolt_merge('other'); SELECT 'MR3|' || their_name FROM dolt_conflicts_t WHERE base_id=3; ROLLBACK;" \
   "^MR3\\|C$" "$DB8"
 
-# Test 9: triggers on the target table do NOT fire during conflict
-# resolution. Matches Dolt's semantics: merge-resolve writes go to the
-# prolly tree directly; triggers already ran on the original commits
-# and re-firing them during resolve would be wrong. Earlier versions
-# of doltlite accidentally fired triggers because the resolve path
-# ran through sqlite3_exec(INSERT/DELETE) — that was incorrect, and
-# the test cases that enforced it have been removed.
+
+
+
+
+
+
+
 DB9=/tmp/test_conflicts9_$$.db; rm -f "$DB9"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 CREATE TABLE trig_log(note TEXT);

--- a/test/doltlite_conflicts.sh
+++ b/test/doltlite_conflicts.sh
@@ -7,7 +7,6 @@ run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -
 echo "=== Doltlite Conflicts Tests ==="
 echo ""
 
-
 DB=/tmp/test_cf_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'orig'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -22,11 +21,9 @@ run_test_match "conflicts_count" \
   "BEGIN; SELECT dolt_merge('feature'); SELECT 'CC|' || num_conflicts FROM dolt_conflicts; ROLLBACK;" \
   "^CC\\|1$" "$DB"
 
-
 run_test_match "commit_blocked" \
   "BEGIN; SELECT dolt_merge('feature'); SELECT dolt_commit('-A','-m','fail');" \
   "cannot commit: unresolved merge conflicts|Use dolt_conflicts_resolve" "$DB"
-
 
 run_test_match "resolved_no_conflicts" \
   "BEGIN; SELECT dolt_merge('feature'); SELECT dolt_conflicts_resolve('--ours','t'); SELECT 'RC|' || count(*) FROM dolt_conflicts; SELECT 'RV|' || v FROM t; ROLLBACK;" \
@@ -34,7 +31,6 @@ run_test_match "resolved_no_conflicts" \
 run_test_match "ours_value_kept" \
   "BEGIN; SELECT dolt_merge('feature'); SELECT dolt_conflicts_resolve('--ours','t'); SELECT 'RV|' || v FROM t; ROLLBACK;" \
   "^RV\\|main$" "$DB"
-
 
 DB2=/tmp/test_cf2_$$.db; rm -f "$DB2"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'orig'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB2" > /dev/null 2>&1
@@ -50,7 +46,6 @@ run_test_match "theirs_resolved" \
   "BEGIN; SELECT dolt_merge('feature'); SELECT dolt_conflicts_resolve('--theirs','t'); SELECT 'TR|' || count(*) FROM dolt_conflicts; ROLLBACK;" \
   "^TR\\|0$" "$DB2"
 
-
 DB3=/tmp/test_cf3_$$.db; rm -f "$DB3"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'),(2,'b'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB3" > /dev/null 2>&1
 echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB3" > /dev/null 2>&1
@@ -62,7 +57,6 @@ run_test_match "no_conflict_merge" "SELECT dolt_merge('feature');" "^[0-9a-f]{40
 run_test "no_conflicts_table" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB3"
 run_test "auto_merge_row1" "SELECT v FROM t WHERE id=1;" "MAIN" "$DB3"
 run_test "auto_merge_row2" "SELECT v FROM t WHERE id=2;" "FEAT" "$DB3"
-
 
 DB4=/tmp/test_cf4_$$.db; rm -f "$DB4"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'),(2,'b'),(3,'c'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB4" > /dev/null 2>&1
@@ -82,7 +76,6 @@ run_test_match "mixed_auto_row4" \
   "BEGIN; SELECT dolt_merge('feature'); SELECT 'MR4|' || count(*) FROM t WHERE id=4; ROLLBACK;" \
   "^MR4\\|1$" "$DB4"
 
-
 DB5=/tmp/test_conflicts5_$$.db; rm -f "$DB5"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, name TEXT, val INTEGER); INSERT INTO t VALUES(1,'alice',100); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB5" > /dev/null 2>&1
 echo "SELECT dolt_branch('a'); SELECT dolt_checkout('a'); UPDATE t SET name='ALICE' WHERE id=1; SELECT dolt_commit('-A','-m','a');" | $DOLTLITE "$DB5" > /dev/null 2>&1
@@ -94,7 +87,6 @@ run_test "cell_merge_name" "SELECT name FROM t WHERE id=1;" "ALICE" "$DB5"
 run_test "cell_merge_val" "SELECT val FROM t WHERE id=1;" "999" "$DB5"
 run_test "cell_merge_no_conflicts" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB5"
 
-
 DB6=/tmp/test_conflicts6_$$.db; rm -f "$DB6"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, name TEXT); INSERT INTO t VALUES(1,'alice'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6" > /dev/null 2>&1
 echo "SELECT dolt_branch('schema_br'); SELECT dolt_checkout('schema_br'); ALTER TABLE t ADD COLUMN extra TEXT; UPDATE t SET extra='x'; SELECT dolt_commit('-A','-m','schema');" | $DOLTLITE "$DB6" > /dev/null 2>&1
@@ -104,7 +96,6 @@ echo "SELECT dolt_checkout('main'); SELECT dolt_merge('schema_br');" | $DOLTLITE
 run_test_match "schema_data_merge" "SELECT dolt_merge('data_br');" "^[0-9a-f]" "$DB6"
 run_test "schema_data_name" "SELECT name FROM t WHERE id=1;" "ALICE" "$DB6"
 run_test "schema_data_extra" "SELECT extra FROM t WHERE id=1;" "x" "$DB6"
-
 
 DB7=/tmp/test_conflicts7_$$.db; rm -f "$DB7"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, name TEXT, val INTEGER); INSERT INTO t VALUES(1,'alice',100); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB7" > /dev/null 2>&1
@@ -116,7 +107,6 @@ run_test_match "real_conflict_count" \
   "BEGIN; SELECT dolt_merge('c'); SELECT 'RC|' || num_conflicts FROM dolt_conflicts; ROLLBACK;" \
   "^RC\\|1$" "$DB7"
 
-
 run_test_match "conflict_base_decoded" \
   "BEGIN; SELECT dolt_merge('c'); SELECT 'BASE|' || base_name FROM dolt_conflicts_t; ROLLBACK;" \
   "^BASE\\|alice$" "$DB7"
@@ -127,8 +117,6 @@ run_test_match "conflict_their_decoded" \
   "BEGIN; SELECT dolt_merge('c'); SELECT 'THEIR|' || their_name FROM dolt_conflicts_t; ROLLBACK;" \
   "^THEIR\\|BOB$" "$DB7"
 
-
-
 run_test_match "conflict_temp_shadow_base_ignored" \
   "BEGIN; SELECT dolt_merge('c'); CREATE TEMP TABLE t(fake TEXT PRIMARY KEY); SELECT 'TSB|' || base_name FROM dolt_conflicts_t; ROLLBACK;" \
   "^TSB\\|alice$" "$DB7"
@@ -138,7 +126,6 @@ run_test_match "conflict_temp_shadow_our_ignored" \
 run_test_match "conflict_temp_shadow_their_ignored" \
   "BEGIN; SELECT dolt_merge('c'); CREATE TEMP TABLE t(fake TEXT PRIMARY KEY); SELECT 'TST|' || their_name FROM dolt_conflicts_t; ROLLBACK;" \
   "^TST\\|BOB$" "$DB7"
-
 
 DB8=/tmp/test_conflicts8_$$.db; rm -f "$DB8"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, name TEXT); INSERT INTO t VALUES(1,'a'),(2,'b'),(3,'c'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB8" > /dev/null 2>&1
@@ -161,13 +148,6 @@ run_test_match "multi_row_has_row2" \
 run_test_match "multi_row_has_row3" \
   "BEGIN; SELECT dolt_merge('other'); SELECT 'MR3|' || their_name FROM dolt_conflicts_t WHERE base_id=3; ROLLBACK;" \
   "^MR3\\|C$" "$DB8"
-
-
-
-
-
-
-
 
 DB9=/tmp/test_conflicts9_$$.db; rm -f "$DB9"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);

--- a/test/doltlite_deep_history.sh
+++ b/test/doltlite_deep_history.sh
@@ -1,9 +1,4 @@
 #!/bin/bash
-
-
-
-
-
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 
@@ -27,12 +22,7 @@ echo ""
 DB=/tmp/test_deep_history_$$.db
 rm -f "$DB"
 
-
-
-
-
 echo "Building 500 commits..."
-
 
 SQL="CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT);"
 SQL="${SQL} INSERT INTO t VALUES(0,'v0');"
@@ -47,22 +37,12 @@ done
 echo "$SQL" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "Done building commits."
 
-
-
-
-
 echo "Test 1: dolt_log count..."
 run_test "log_count_500" \
   "SELECT count(*) FROM dolt_log;" \
   "501" "$DB"
 
-
-
-
-
 echo "Test 2: dolt_diff first-to-last..."
-
-
 run_test "diff_first_last_count" \
   "SELECT rows_added + rows_modified + rows_deleted FROM dolt_diff_stat((SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 499), (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 0), 't');" \
   "500" "$DB"
@@ -75,62 +55,42 @@ run_test_match "diff_first_last_has_modified" \
   "SELECT rows_modified FROM dolt_diff_stat((SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 499), (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 0), 't');" \
   "^1$" "$DB"
 
-
-
-
-
-
 echo "Test 3: dolt_history for tracker row..."
 run_test "history_tracker_row_count" \
   "SELECT count(*) FROM dolt_history_t WHERE id=0;" \
   "500" "$DB"
 
-
 run_test "history_distinct_commits" \
   "SELECT count(DISTINCT commit_hash) FROM dolt_history_t WHERE id=0;" \
   "500" "$DB"
 
-
-
-
-
 echo "Test 4: branch, diverge, merge, merge_base..."
-
 
 COMMIT_250=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 249;" | $DOLTLITE "$DB" 2>/dev/null)
 
-
 echo "SELECT dolt_branch('deep_branch');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 echo "INSERT INTO t VALUES(1000,'main_extra'); SELECT dolt_commit('-A','-m','main_after_branch');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 echo "SELECT dolt_checkout('deep_branch');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(2000,'branch_extra'); SELECT dolt_commit('-A','-m','branch_change');" | $DOLTLITE "$DB/deep_branch" > /dev/null 2>&1
 
-
 MAIN_HEAD=$(echo "SELECT hash FROM dolt_branches WHERE name='main';" | $DOLTLITE "$DB" 2>/dev/null)
 BRANCH_HEAD=$(echo "SELECT hash FROM dolt_branches WHERE name='deep_branch';" | $DOLTLITE "$DB" 2>/dev/null)
-
-
 
 run_test_match "merge_base_valid_hash" \
   "SELECT dolt_merge_base('$MAIN_HEAD','$BRANCH_HEAD');" \
   "^[0-9a-f]{40}$" "$DB"
-
 
 EXPECTED_BASE=$(echo "SELECT commit_hash FROM dolt_log WHERE message='commit_499' LIMIT 1;" | $DOLTLITE "$DB" 2>/dev/null)
 run_test "merge_base_is_branch_point" \
   "SELECT dolt_merge_base('$MAIN_HEAD','$BRANCH_HEAD');" \
   "$EXPECTED_BASE" "$DB"
 
-
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "merge_deep_branch" \
   "SELECT dolt_merge('deep_branch');" \
   "^[0-9a-f]{40}$" "$DB"
-
 
 run_test "merge_has_main_row" \
   "SELECT val FROM t WHERE id=1000;" \
@@ -140,14 +100,7 @@ run_test "merge_has_branch_row" \
   "SELECT val FROM t WHERE id=2000;" \
   "branch_extra" "$DB"
 
-
-
-
-
-
 echo "Test 5: dolt_at for early commit..."
-
-
 
 run_test "at_commit10_count" \
   "SELECT count(*) FROM dolt_at_t((SELECT commit_hash FROM dolt_log WHERE message='commit_10' LIMIT 1));" \
@@ -157,22 +110,7 @@ run_test "at_commit10_tracker_val" \
   "SELECT val FROM dolt_at_t((SELECT commit_hash FROM dolt_log WHERE message='commit_10' LIMIT 1)) WHERE id=0;" \
   "v10" "$DB"
 
-
-
-
-
-
-
-
-
-
-
 echo "Test 6: dolt_diff_t audit log..."
-
-
-
-
-
 run_test "diff_table_total_entries" \
   "SELECT count(*) FROM dolt_diff_t;" \
   "1002" "$DB"
@@ -184,10 +122,6 @@ run_test_match "diff_table_has_added" \
 run_test_match "diff_table_has_modified" \
   "SELECT count(*) FROM dolt_diff_t WHERE diff_type='modified';" \
   "^499$" "$DB"
-
-
-
-
 
 echo "Test 7: Performance sanity check..."
 START=$(perl -e 'use Time::HiRes qw(time); print time')
@@ -202,10 +136,6 @@ else
   FAIL=$((FAIL+1))
   ERRORS="$ERRORS\nFAIL: perf_log_under_5s\n  expected: count>0 in <5s\n  got:      count=$LOG_COUNT in ${ELAPSED}s"
 fi
-
-
-
-
 
 rm -f "$DB"
 

--- a/test/doltlite_deep_history.sh
+++ b/test/doltlite_deep_history.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-#
-# Stress test for deep commit history (500 commits).
-# Tests dolt_log, dolt_diff, dolt_history_<table>, dolt_merge_base,
-# dolt_at, dolt_diff_<table>, and performance.
-#
+
+
+
+
+
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 
@@ -27,13 +27,13 @@ echo ""
 DB=/tmp/test_deep_history_$$.db
 rm -f "$DB"
 
-# ============================================================
-# Build 500 commits: INSERT a row per commit, UPDATE a tracker row
-# ============================================================
+
+
+
 
 echo "Building 500 commits..."
 
-# Create table and initial commit with a tracker row (id=0) updated every commit
+
 SQL="CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT);"
 SQL="${SQL} INSERT INTO t VALUES(0,'v0');"
 SQL="${SQL} SELECT dolt_commit('-A','-m','commit_0');"
@@ -47,22 +47,22 @@ done
 echo "$SQL" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "Done building commits."
 
-# ============================================================
-# Test 1: dolt_log returns all 500 commits
-# ============================================================
+
+
+
 
 echo "Test 1: dolt_log count..."
 run_test "log_count_500" \
   "SELECT count(*) FROM dolt_log;" \
   "501" "$DB"
 
-# ============================================================
-# Test 2: dolt_diff between first and last commit works
-# ============================================================
+
+
+
 
 echo "Test 2: dolt_diff first-to-last..."
-# The first commit (oldest) is at the largest offset; last commit is offset 0.
-# Between commit_0 and commit_499, 499 rows were added (ids 1..499) and row 0 was modified.
+
+
 run_test "diff_first_last_count" \
   "SELECT rows_added + rows_modified + rows_deleted FROM dolt_diff_stat((SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 499), (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 0), 't');" \
   "500" "$DB"
@@ -75,63 +75,63 @@ run_test_match "diff_first_last_has_modified" \
   "SELECT rows_modified FROM dolt_diff_stat((SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 499), (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 0), 't');" \
   "^1$" "$DB"
 
-# ============================================================
-# Test 3: dolt_history_t returns all historical versions of tracker row (id=0)
-# Row 0 was present in all 500 commits (inserted at commit_0, updated in commits 1-499)
-# ============================================================
+
+
+
+
 
 echo "Test 3: dolt_history for tracker row..."
 run_test "history_tracker_row_count" \
   "SELECT count(*) FROM dolt_history_t WHERE id=0;" \
   "500" "$DB"
 
-# Verify distinct commit hashes in history match 500
+
 run_test "history_distinct_commits" \
   "SELECT count(DISTINCT commit_hash) FROM dolt_history_t WHERE id=0;" \
   "500" "$DB"
 
-# ============================================================
-# Test 4: Branch at commit 250, make changes on both, merge, verify merge_base
-# ============================================================
+
+
+
 
 echo "Test 4: branch, diverge, merge, merge_base..."
 
-# Get commit hash at position 250 (offset 249 from HEAD since log is newest-first)
+
 COMMIT_250=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 249;" | $DOLTLITE "$DB" 2>/dev/null)
 
-# Create branch at commit 250 by branching, then we make independent changes on each
+
 echo "SELECT dolt_branch('deep_branch');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Make a change on main
+
 echo "INSERT INTO t VALUES(1000,'main_extra'); SELECT dolt_commit('-A','-m','main_after_branch');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Switch to branch, make a change there
+
 echo "SELECT dolt_checkout('deep_branch');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(2000,'branch_extra'); SELECT dolt_commit('-A','-m','branch_change');" | $DOLTLITE "$DB/deep_branch" > /dev/null 2>&1
 
-# Get branch heads
+
 MAIN_HEAD=$(echo "SELECT hash FROM dolt_branches WHERE name='main';" | $DOLTLITE "$DB" 2>/dev/null)
 BRANCH_HEAD=$(echo "SELECT hash FROM dolt_branches WHERE name='deep_branch';" | $DOLTLITE "$DB" 2>/dev/null)
 
-# Verify merge_base finds the right ancestor (commit_499 on main before the extra commit)
-# The branch was created from the tip of main (commit_499), so merge base = commit_499's hash
+
+
 run_test_match "merge_base_valid_hash" \
   "SELECT dolt_merge_base('$MAIN_HEAD','$BRANCH_HEAD');" \
   "^[0-9a-f]{40}$" "$DB"
 
-# The merge base should equal the commit that was HEAD when we branched (commit_499)
+
 EXPECTED_BASE=$(echo "SELECT commit_hash FROM dolt_log WHERE message='commit_499' LIMIT 1;" | $DOLTLITE "$DB" 2>/dev/null)
 run_test "merge_base_is_branch_point" \
   "SELECT dolt_merge_base('$MAIN_HEAD','$BRANCH_HEAD');" \
   "$EXPECTED_BASE" "$DB"
 
-# Now merge
+
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "merge_deep_branch" \
   "SELECT dolt_merge('deep_branch');" \
   "^[0-9a-f]{40}$" "$DB"
 
-# Both rows should be present after merge
+
 run_test "merge_has_main_row" \
   "SELECT val FROM t WHERE id=1000;" \
   "main_extra" "$DB"
@@ -140,15 +140,15 @@ run_test "merge_has_branch_row" \
   "SELECT val FROM t WHERE id=2000;" \
   "branch_extra" "$DB"
 
-# ============================================================
-# Test 5: dolt_at for an early commit (commit #10, offset 492 from current HEAD)
-# At commit_10 the table should have rows 0..10 = 11 rows
-# ============================================================
+
+
+
+
 
 echo "Test 5: dolt_at for early commit..."
 
-# After the merge we have 502 log entries (500 original + main_after_branch + merge)
-# commit_10 is at offset 491 from HEAD (502 - 11 = 491)
+
+
 run_test "at_commit10_count" \
   "SELECT count(*) FROM dolt_at_t((SELECT commit_hash FROM dolt_log WHERE message='commit_10' LIMIT 1));" \
   "11" "$DB"
@@ -157,22 +157,22 @@ run_test "at_commit10_tracker_val" \
   "SELECT val FROM dolt_at_t((SELECT commit_hash FROM dolt_log WHERE message='commit_10' LIMIT 1)) WHERE id=0;" \
   "v10" "$DB"
 
-# ============================================================
-# Test 6: dolt_diff_t audit log returns correct entries for full history
-# Each of the 500 commits produced changes:
-#   commit_0: 2 inserts (id=0 tracker + but actually just 1 insert of id=0 with val v0... let's count)
-#   Actually: commit_0 inserts row 0. commits 1-499 each insert a row + update row 0 = 2 changes each.
-#   Total = 1 (commit_0: insert id=0) + 499*2 (insert + update) = 999
-#   Plus main_after_branch: 1 insert = 1000
-#   Plus merge commit brings in branch_extra: 1 insert = 1001
-# ============================================================
+
+
+
+
+
+
+
+
+
 
 echo "Test 6: dolt_diff_t audit log..."
-# Counts include the merge commit's diff against BOTH parents
-# (mainline + side branch) since the dolt_diff_<table> walk now
-# follows every parent edge — this matches Dolt's behavior. The
-# extra row is the merge commit comparing against its second
-# parent and emitting branch_extra as added a second time.
+
+
+
+
+
 run_test "diff_table_total_entries" \
   "SELECT count(*) FROM dolt_diff_t;" \
   "1002" "$DB"
@@ -185,9 +185,9 @@ run_test_match "diff_table_has_modified" \
   "SELECT count(*) FROM dolt_diff_t WHERE diff_type='modified';" \
   "^499$" "$DB"
 
-# ============================================================
-# Test 7: Performance — dolt_log query for 500 commits under 5 seconds
-# ============================================================
+
+
+
 
 echo "Test 7: Performance sanity check..."
 START=$(perl -e 'use Time::HiRes qw(time); print time')
@@ -203,9 +203,9 @@ else
   ERRORS="$ERRORS\nFAIL: perf_log_under_5s\n  expected: count>0 in <5s\n  got:      count=$LOG_COUNT in ${ELAPSED}s"
 fi
 
-# ============================================================
-# Cleanup
-# ============================================================
+
+
+
 
 rm -f "$DB"
 

--- a/test/doltlite_demo.sh
+++ b/test/doltlite_demo.sh
@@ -1,9 +1,4 @@
 #!/bin/bash
-
-
-
-
-
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
@@ -14,10 +9,6 @@ echo ""
 
 DB=/tmp/test_demo_$$.db; rm -f "$DB"
 
-
-
-
-
 echo "CREATE TABLE employees(id INTEGER PRIMARY KEY, last_name TEXT, first_name TEXT);
 CREATE TABLE teams(id INTEGER PRIMARY KEY, team_name TEXT);
 CREATE TABLE employees_teams(team_id INTEGER, employee_id INTEGER, PRIMARY KEY(team_id, employee_id));
@@ -27,10 +18,6 @@ run_test "schema_tables" "SELECT count(*) FROM sqlite_master WHERE type='table';
 run_test "schema_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 run_test_match "schema_msg" "SELECT message FROM dolt_log;" "Created initial schema" "$DB"
 run_test "schema_clean" "SELECT count(*) FROM dolt_status;" "0" "$DB"
-
-
-
-
 
 echo "INSERT INTO employees VALUES(0,'Sehn','Tim');
 INSERT INTO employees VALUES(1,'Hendriks','Brian');
@@ -44,28 +31,20 @@ INSERT INTO employees_teams VALUES(0,2);
 INSERT INTO employees_teams VALUES(1,0);
 INSERT INTO employees_teams VALUES(1,3);" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "data_status" "SELECT count(*) FROM dolt_status;" "3" "$DB"
-
 
 run_test "data_emp_count" "SELECT count(*) FROM employees;" "4" "$DB"
 run_test "data_brian_count" "SELECT count(*) FROM employees WHERE first_name='Brian';" "2" "$DB"
 
-
 run_test "data_eng_team" \
   "SELECT count(*) FROM employees e JOIN employees_teams et ON e.id=et.employee_id JOIN teams t ON t.id=et.team_id WHERE t.team_name='Engineering';" \
   "3" "$DB"
-
 
 echo "SELECT dolt_commit('-A','-m','Populated tables with data');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_tag('v1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "data_log" "SELECT count(*) FROM dolt_log;" "3" "$DB"
 run_test "data_clean" "SELECT count(*) FROM dolt_status;" "0" "$DB"
-
-
-
-
 
 echo "SELECT dolt_branch('modifications');
 SELECT dolt_checkout('modifications');
@@ -75,14 +54,9 @@ INSERT INTO employees_teams VALUES(0,4);
 DELETE FROM employees_teams WHERE employee_id=0 AND team_id=1;
 SELECT dolt_commit('-A','-m','Modifications on a branch');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "mod_branch" "SELECT active_branch();" "modifications" "$DB/modifications"
 run_test "mod_emp_count" "SELECT count(*) FROM employees;" "5" "$DB/modifications"
 run_test "mod_timothy" "SELECT first_name FROM employees WHERE id=0;" "Timothy" "$DB/modifications"
-
-
-
-
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
@@ -91,16 +65,8 @@ run_test "main_emp_count" "SELECT count(*) FROM employees;" "4" "$DB"
 run_test "main_tim" "SELECT first_name FROM employees WHERE id=0;" "Tim" "$DB"
 run_test "main_no_daylon" "SELECT count(*) FROM employees WHERE id=4;" "0" "$DB"
 
-
-
-
-
 run_test "asof_mod_count" "SELECT count(*) FROM dolt_at_employees('modifications');" "5" "$DB"
 run_test "asof_v1_count" "SELECT count(*) FROM dolt_at_employees('v1');" "4" "$DB"
-
-
-
-
 
 run_test_match "merge_mod" "SELECT dolt_merge('modifications');" "^[0-9a-f]{40}$" "$DB"
 
@@ -108,19 +74,13 @@ run_test "merged_emp_count" "SELECT count(*) FROM employees;" "5" "$DB"
 run_test "merged_timothy" "SELECT first_name FROM employees WHERE id=0;" "Timothy" "$DB"
 run_test "merged_daylon" "SELECT first_name FROM employees WHERE id=4;" "Daylon" "$DB"
 
-
 run_test "merged_sales" \
   "SELECT count(*) FROM employees e JOIN employees_teams et ON e.id=et.employee_id JOIN teams t ON t.id=et.team_id WHERE t.team_name='Sales';" \
   "1" "$DB"
 
-
 run_test "merged_eng" \
   "SELECT count(*) FROM employees e JOIN employees_teams et ON e.id=et.employee_id JOIN teams t ON t.id=et.team_id WHERE t.team_name='Engineering';" \
   "4" "$DB"
-
-
-
-
 
 echo "INSERT INTO employees VALUES(99,'Temp','Temp');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "reset_before" "SELECT count(*) FROM employees;" "6" "$DB"
@@ -129,61 +89,27 @@ echo "SELECT dolt_reset('--hard');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "reset_after" "SELECT count(*) FROM employees;" "5" "$DB"
 run_test "reset_clean" "SELECT count(*) FROM dolt_status;" "0" "$DB"
 
-
-
-
-
 run_test "branches_count" "SELECT count(*) FROM dolt_branches;" "2" "$DB"
 run_test_match "branches_names" "SELECT group_concat(name) FROM (SELECT name FROM dolt_branches ORDER BY name);" "main.*modifications" "$DB"
-
-
-
-
 
 run_test_match "log_latest" "SELECT message FROM dolt_log LIMIT 1;" "Modifications|Merge" "$DB"
 run_test_match "log_count" "SELECT count(*) FROM dolt_log;" "^[3-9]" "$DB"
 
-
-
-
-
-
 run_test_match "audit_count" "SELECT count(*) FROM dolt_diff_employees;" "^[4-9]" "$DB"
 run_test_match "audit_has_added" "SELECT count(*) FROM dolt_diff_employees WHERE diff_type='added';" "^[4-9]" "$DB"
 
-
-
-
-
-
 run_test_match "history_emp0" "SELECT count(*) FROM dolt_history_employees WHERE id=0;" "^[2-9]" "$DB"
 
-
 run_test_match "history_commits" "SELECT count(DISTINCT commit_hash) FROM dolt_history_employees WHERE id=0;" "^[2-9]" "$DB"
-
-
-
-
-
-
 
 run_test "schema_diff_same" \
   "SELECT count(*) FROM dolt_schema_diff((SELECT commit_hash FROM dolt_log LIMIT 1),(SELECT commit_hash FROM dolt_log LIMIT 1));" \
   "0" "$DB"
 
-
-
-
-
 run_test "tags_count" "SELECT count(*) FROM dolt_tags;" "1" "$DB"
 run_test "tags_v1" "SELECT tag_name FROM dolt_tags;" "v1" "$DB"
 
-
 run_test "tags_v1_data" "SELECT count(*) FROM dolt_at_employees('v1');" "4" "$DB"
-
-
-
-
 
 run_test "persist_emp" "SELECT count(*) FROM employees;" "5" "$DB"
 run_test "persist_log" "SELECT count(*) FROM dolt_log;" "4" "$DB"
@@ -191,10 +117,6 @@ run_test "persist_branch" "SELECT active_branch();" "main" "$DB"
 run_test "persist_tags" "SELECT count(*) FROM dolt_tags;" "1" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/doltlite_demo.sh
+++ b/test/doltlite_demo.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-#
-# Doltlite demo test — adapted from the Dolt getting-started tutorial.
-# Exercises the full workflow: schema, data, branches, merges, diffs,
-# history, schema diff, point-in-time queries, and audit log.
-#
+
+
+
+
+
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
@@ -14,9 +14,9 @@ echo ""
 
 DB=/tmp/test_demo_$$.db; rm -f "$DB"
 
-# ============================================================
-# Phase 1: Create schema and first commit
-# ============================================================
+
+
+
 
 echo "CREATE TABLE employees(id INTEGER PRIMARY KEY, last_name TEXT, first_name TEXT);
 CREATE TABLE teams(id INTEGER PRIMARY KEY, team_name TEXT);
@@ -28,9 +28,9 @@ run_test "schema_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 run_test_match "schema_msg" "SELECT message FROM dolt_log;" "Created initial schema" "$DB"
 run_test "schema_clean" "SELECT count(*) FROM dolt_status;" "0" "$DB"
 
-# ============================================================
-# Phase 2: Populate data and commit
-# ============================================================
+
+
+
 
 echo "INSERT INTO employees VALUES(0,'Sehn','Tim');
 INSERT INTO employees VALUES(1,'Hendriks','Brian');
@@ -44,28 +44,28 @@ INSERT INTO employees_teams VALUES(0,2);
 INSERT INTO employees_teams VALUES(1,0);
 INSERT INTO employees_teams VALUES(1,3);" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Status shows 3 dirty tables
+
 run_test "data_status" "SELECT count(*) FROM dolt_status;" "3" "$DB"
 
-# Query data
+
 run_test "data_emp_count" "SELECT count(*) FROM employees;" "4" "$DB"
 run_test "data_brian_count" "SELECT count(*) FROM employees WHERE first_name='Brian';" "2" "$DB"
 
-# Join query: Engineering team
+
 run_test "data_eng_team" \
   "SELECT count(*) FROM employees e JOIN employees_teams et ON e.id=et.employee_id JOIN teams t ON t.id=et.team_id WHERE t.team_name='Engineering';" \
   "3" "$DB"
 
-# Commit
+
 echo "SELECT dolt_commit('-A','-m','Populated tables with data');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_tag('v1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "data_log" "SELECT count(*) FROM dolt_log;" "3" "$DB"
 run_test "data_clean" "SELECT count(*) FROM dolt_status;" "0" "$DB"
 
-# ============================================================
-# Phase 3: Branch — modify data on 'modifications'
-# ============================================================
+
+
+
 
 echo "SELECT dolt_branch('modifications');
 SELECT dolt_checkout('modifications');
@@ -75,14 +75,14 @@ INSERT INTO employees_teams VALUES(0,4);
 DELETE FROM employees_teams WHERE employee_id=0 AND team_id=1;
 SELECT dolt_commit('-A','-m','Modifications on a branch');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Verify modifications branch
+
 run_test "mod_branch" "SELECT active_branch();" "modifications" "$DB/modifications"
 run_test "mod_emp_count" "SELECT count(*) FROM employees;" "5" "$DB/modifications"
 run_test "mod_timothy" "SELECT first_name FROM employees WHERE id=0;" "Timothy" "$DB/modifications"
 
-# ============================================================
-# Phase 4: Back to main — data unchanged
-# ============================================================
+
+
+
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
@@ -91,16 +91,16 @@ run_test "main_emp_count" "SELECT count(*) FROM employees;" "4" "$DB"
 run_test "main_tim" "SELECT first_name FROM employees WHERE id=0;" "Tim" "$DB"
 run_test "main_no_daylon" "SELECT count(*) FROM employees WHERE id=4;" "0" "$DB"
 
-# ============================================================
-# Phase 5: Point-in-time query — see modifications branch data
-# ============================================================
+
+
+
 
 run_test "asof_mod_count" "SELECT count(*) FROM dolt_at_employees('modifications');" "5" "$DB"
 run_test "asof_v1_count" "SELECT count(*) FROM dolt_at_employees('v1');" "4" "$DB"
 
-# ============================================================
-# Phase 6: Merge modifications into main
-# ============================================================
+
+
+
 
 run_test_match "merge_mod" "SELECT dolt_merge('modifications');" "^[0-9a-f]{40}$" "$DB"
 
@@ -108,19 +108,19 @@ run_test "merged_emp_count" "SELECT count(*) FROM employees;" "5" "$DB"
 run_test "merged_timothy" "SELECT first_name FROM employees WHERE id=0;" "Timothy" "$DB"
 run_test "merged_daylon" "SELECT first_name FROM employees WHERE id=4;" "Daylon" "$DB"
 
-# Sales team: Tim was removed from Sales by modifications branch
+
 run_test "merged_sales" \
   "SELECT count(*) FROM employees e JOIN employees_teams et ON e.id=et.employee_id JOIN teams t ON t.id=et.team_id WHERE t.team_name='Sales';" \
   "1" "$DB"
 
-# Engineering team now includes Daylon
+
 run_test "merged_eng" \
   "SELECT count(*) FROM employees e JOIN employees_teams et ON e.id=et.employee_id JOIN teams t ON t.id=et.team_id WHERE t.team_name='Engineering';" \
   "4" "$DB"
 
-# ============================================================
-# Phase 7: Reset (undo uncommitted changes)
-# ============================================================
+
+
+
 
 echo "INSERT INTO employees VALUES(99,'Temp','Temp');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "reset_before" "SELECT count(*) FROM employees;" "6" "$DB"
@@ -129,61 +129,61 @@ echo "SELECT dolt_reset('--hard');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "reset_after" "SELECT count(*) FROM employees;" "5" "$DB"
 run_test "reset_clean" "SELECT count(*) FROM dolt_status;" "0" "$DB"
 
-# ============================================================
-# Phase 8: Branches listing
-# ============================================================
+
+
+
 
 run_test "branches_count" "SELECT count(*) FROM dolt_branches;" "2" "$DB"
 run_test_match "branches_names" "SELECT group_concat(name) FROM (SELECT name FROM dolt_branches ORDER BY name);" "main.*modifications" "$DB"
 
-# ============================================================
-# Phase 9: Full log
-# ============================================================
+
+
+
 
 run_test_match "log_latest" "SELECT message FROM dolt_log LIMIT 1;" "Modifications|Merge" "$DB"
 run_test_match "log_count" "SELECT count(*) FROM dolt_log;" "^[3-9]" "$DB"
 
-# ============================================================
-# Phase 10: Audit log (dolt_diff_<table>)
-# ============================================================
 
-# dolt_diff_employees shows all changes across commits
+
+
+
+
 run_test_match "audit_count" "SELECT count(*) FROM dolt_diff_employees;" "^[4-9]" "$DB"
 run_test_match "audit_has_added" "SELECT count(*) FROM dolt_diff_employees WHERE diff_type='added';" "^[4-9]" "$DB"
 
-# ============================================================
-# Phase 11: History (dolt_history_<table>)
-# ============================================================
 
-# Employee 0 exists in multiple commits
+
+
+
+
 run_test_match "history_emp0" "SELECT count(*) FROM dolt_history_employees WHERE id=0;" "^[2-9]" "$DB"
 
-# Multiple distinct commits for employee 0
+
 run_test_match "history_commits" "SELECT count(DISTINCT commit_hash) FROM dolt_history_employees WHERE id=0;" "^[2-9]" "$DB"
 
-# ============================================================
-# Phase 12: Schema diff
-# ============================================================
 
-# Between first commit and current: employees_teams and teams were added
-# (they share a commit with employees)
+
+
+
+
+
 run_test "schema_diff_same" \
   "SELECT count(*) FROM dolt_schema_diff((SELECT commit_hash FROM dolt_log LIMIT 1),(SELECT commit_hash FROM dolt_log LIMIT 1));" \
   "0" "$DB"
 
-# ============================================================
-# Phase 13: Tags
-# ============================================================
+
+
+
 
 run_test "tags_count" "SELECT count(*) FROM dolt_tags;" "1" "$DB"
 run_test "tags_v1" "SELECT tag_name FROM dolt_tags;" "v1" "$DB"
 
-# Data at v1: 4 employees
+
 run_test "tags_v1_data" "SELECT count(*) FROM dolt_at_employees('v1');" "4" "$DB"
 
-# ============================================================
-# Phase 14: Persistence — reopen and verify
-# ============================================================
+
+
+
 
 run_test "persist_emp" "SELECT count(*) FROM employees;" "5" "$DB"
 run_test "persist_log" "SELECT count(*) FROM dolt_log;" "4" "$DB"
@@ -192,9 +192,9 @@ run_test "persist_tags" "SELECT count(*) FROM dolt_tags;" "1" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Done
-# ============================================================
+
+
+
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/doltlite_detective_demo_test.sh
+++ b/test/doltlite_detective_demo_test.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
-#
-# Runnable companion to doc/doltlite/demo.md — "The DoltHub Break
-# Room Incident."
-#
-# Every SQL block in the demo appears here in the same order, with
-# an assertion on its output. If the demo drifts from reality — a
-# vtable column gets renamed, a function signature changes, a
-# result shape shifts — this test fails, and the demo gets updated
-# in the same PR that made the underlying change.
-#
-# Run: bash test/doltlite_detective_demo_test.sh [path/to/doltlite]
-#
+
+
+
+
+
+
+
+
+
+
+
+
 
 set -u
 
@@ -54,7 +54,7 @@ dl_bulk() { "$DOLTLITE" "$DB" >/dev/null 2>&1; }
 echo "=== The DoltHub Break Room Incident — demo test ==="
 echo ""
 
-# ── Chapter 1: Opening the case file ─────────────────────
+
 echo "--- Chapter 1: Opening the case file ---"
 rm -f "$DB"
 
@@ -103,7 +103,7 @@ expect_eq "chapter1_commit_count" "2" "$N_COMMITS"
 
 echo ""
 
-# ── Chapter 2: Two theories, two branches ────────────────
+
 echo "--- Chapter 2: Two theories, two branches ---"
 
 "$DOLTLITE" "$DB" >/dev/null 2>&1 <<'SQL'
@@ -138,7 +138,7 @@ expect_eq "chapter2_ficus_evidence_count" "2" "$FICUS_EV"
 
 echo ""
 
-# ── Chapter 3: Where do we disagree ──────────────────────
+
 echo "--- Chapter 3: Where do we disagree ---"
 
 STAT=$(dl "SELECT rows_added FROM dolt_diff_stat('theory/butler', 'theory/ficus') WHERE table_name='evidence';")
@@ -149,11 +149,11 @@ expect_eq "chapter3_diff_evidence_rowcount" "3" "$DIFF_ROWS"
 
 echo ""
 
-# ── Chapter 4: Who added this clue ───────────────────────
+
 echo "--- Chapter 4: Who added this clue ---"
 
-# Merge theory/ficus into main so we have a populated evidence table
-# with real commit metadata to blame against.
+
+
 "$DOLTLITE" "$DB" >/dev/null 2>&1 <<'SQL'
 SELECT dolt_checkout('main');
 SELECT dolt_merge('theory/ficus');
@@ -167,10 +167,10 @@ expect_match "chapter4_blame_attributes_ficus_commit" "Ficus" "$BLAME_MSG"
 
 echo ""
 
-# ── Chapter 5: What did we believe at 3pm yesterday ──────
+
 echo "--- Chapter 5: Time travel ---"
 
-# Add new evidence on main, then query what we believed before it.
+
 "$DOLTLITE" "$DB" >/dev/null 2>&1 <<'SQL'
 INSERT INTO evidence VALUES
   (4, 'Partial fingerprint on the coffee pot', NULL, '2026-04-16T09:00:00Z');
@@ -185,10 +185,10 @@ expect_eq "chapter5_historical_evidence_count" "2" "$THEN_COUNT"
 
 echo ""
 
-# ── Chapter 6: The witness lied ──────────────────────────
+
 echo "--- Chapter 6: The witness lied ---"
 
-# Revert the partial-print commit (HEAD).
+
 "$DOLTLITE" "$DB" >/dev/null 2>&1 "SELECT dolt_revert('HEAD');"
 
 AFTER_REVERT=$(dl "SELECT count(*) FROM evidence;")
@@ -199,11 +199,11 @@ expect_eq "chapter6_revert_targeted_correct_row" "0" "$FINGERPRINT_GONE"
 
 echo ""
 
-# ── Chapter 7: The detectives agree ──────────────────────
+
 echo "--- Chapter 7: Clean merge ---"
 
-# Start a fresh parallel theory that touches only sightings (so merge
-# is clean versus main's current state), then merge.
+
+
 "$DOLTLITE" "$DB" >/dev/null 2>&1 <<'SQL'
 SELECT dolt_branch('theory/butler_v2');
 SELECT dolt_checkout('theory/butler_v2');
@@ -219,10 +219,10 @@ expect_eq "chapter7_clean_merge_evidence_count" "3" "$MERGED_COUNT"
 
 echo ""
 
-# ── Chapter 8: The detectives disagree ───────────────────
+
 echo "--- Chapter 8: Row-level merge conflict ---"
 
-# Two branches modify the same evidence row differently → conflict.
+
 "$DOLTLITE" "$DB" >/dev/null 2>&1 <<'SQL'
 SELECT dolt_branch('theory/revised_1');
 SELECT dolt_checkout('theory/revised_1');
@@ -237,7 +237,7 @@ SQL
 CONFLICT_COUNT=$(dl "SELECT num_conflicts FROM dolt_conflicts WHERE \"table\"='evidence';")
 expect_eq "chapter8_conflict_detected" "1" "$CONFLICT_COUNT"
 
-# Resolve by taking our side.
+
 "$DOLTLITE" "$DB" >/dev/null 2>&1 "SELECT dolt_conflicts_resolve('--ours','evidence');"
 
 RESOLVED=$(dl "SELECT count(*) FROM dolt_conflicts;")
@@ -248,7 +248,7 @@ expect_match "chapter8_resolution_kept_our_text" "suspicious coffee" "$KEPT_OUR_
 
 echo ""
 
-# ── Chapter 9: Signing off the case file ─────────────────
+
 echo "--- Chapter 9: Fingerprinting ---"
 
 "$DOLTLITE" "$DB" >/dev/null 2>&1 "SELECT dolt_commit('-Am','Post-conflict reconciliation');"
@@ -258,8 +258,8 @@ expect_match "chapter9_db_hash_is_hex" "^[0-9a-f]{40}$" "$DB_HASH"
 
 EVIDENCE_HASH_A=$(dl "SELECT dolt_hashof_table('evidence');")
 
-# Insert then delete a throwaway row — the table hash must be
-# identical to before (history-independence).
+
+
 "$DOLTLITE" "$DB" >/dev/null 2>&1 <<'SQL'
 INSERT INTO evidence VALUES (99, 'ignore me', NULL, '2026-04-16T12:00:00Z');
 DELETE FROM evidence WHERE id=99;
@@ -269,7 +269,7 @@ expect_eq "chapter9_table_hash_history_independent" "$EVIDENCE_HASH_A" "$EVIDENC
 
 echo ""
 
-# ── Chapter 10: Forensics hands you their evidence ───────
+
 echo "--- Chapter 10: ATTACH a stock SQLite database ---"
 
 rm -f "$FORENSICS"
@@ -282,7 +282,7 @@ INSERT INTO fingerprints VALUES
   (3, 1, 'swirl',    'croissant wrapper');
 SQL
 
-# ATTACH stock sqlite → JOIN across → migrate in → commit.
+
 ATTACHED_COUNT=$("$DOLTLITE" "$DB" "ATTACH DATABASE '$FORENSICS' AS forensics; SELECT count(*) FROM forensics.fingerprints;" 2>&1 | tail -1)
 expect_eq "chapter10_attach_read_count" "3" "$ATTACHED_COUNT"
 

--- a/test/doltlite_detective_demo_test.sh
+++ b/test/doltlite_detective_demo_test.sh
@@ -1,17 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
-
-
-
-
 set -u
 
 DOLTLITE="${1:-./doltlite}"
@@ -53,7 +41,6 @@ dl_bulk() { "$DOLTLITE" "$DB" >/dev/null 2>&1; }
 
 echo "=== The DoltHub Break Room Incident — demo test ==="
 echo ""
-
 
 echo "--- Chapter 1: Opening the case file ---"
 rm -f "$DB"
@@ -103,7 +90,6 @@ expect_eq "chapter1_commit_count" "2" "$N_COMMITS"
 
 echo ""
 
-
 echo "--- Chapter 2: Two theories, two branches ---"
 
 "$DOLTLITE" "$DB" >/dev/null 2>&1 <<'SQL'
@@ -138,7 +124,6 @@ expect_eq "chapter2_ficus_evidence_count" "2" "$FICUS_EV"
 
 echo ""
 
-
 echo "--- Chapter 3: Where do we disagree ---"
 
 STAT=$(dl "SELECT rows_added FROM dolt_diff_stat('theory/butler', 'theory/ficus') WHERE table_name='evidence';")
@@ -149,10 +134,7 @@ expect_eq "chapter3_diff_evidence_rowcount" "3" "$DIFF_ROWS"
 
 echo ""
 
-
 echo "--- Chapter 4: Who added this clue ---"
-
-
 
 "$DOLTLITE" "$DB" >/dev/null 2>&1 <<'SQL'
 SELECT dolt_checkout('main');
@@ -167,9 +149,7 @@ expect_match "chapter4_blame_attributes_ficus_commit" "Ficus" "$BLAME_MSG"
 
 echo ""
 
-
 echo "--- Chapter 5: Time travel ---"
-
 
 "$DOLTLITE" "$DB" >/dev/null 2>&1 <<'SQL'
 INSERT INTO evidence VALUES
@@ -185,9 +165,7 @@ expect_eq "chapter5_historical_evidence_count" "2" "$THEN_COUNT"
 
 echo ""
 
-
 echo "--- Chapter 6: The witness lied ---"
-
 
 "$DOLTLITE" "$DB" >/dev/null 2>&1 "SELECT dolt_revert('HEAD');"
 
@@ -199,10 +177,7 @@ expect_eq "chapter6_revert_targeted_correct_row" "0" "$FINGERPRINT_GONE"
 
 echo ""
 
-
 echo "--- Chapter 7: Clean merge ---"
-
-
 
 "$DOLTLITE" "$DB" >/dev/null 2>&1 <<'SQL'
 SELECT dolt_branch('theory/butler_v2');
@@ -219,9 +194,7 @@ expect_eq "chapter7_clean_merge_evidence_count" "3" "$MERGED_COUNT"
 
 echo ""
 
-
 echo "--- Chapter 8: Row-level merge conflict ---"
-
 
 "$DOLTLITE" "$DB" >/dev/null 2>&1 <<'SQL'
 SELECT dolt_branch('theory/revised_1');
@@ -237,7 +210,6 @@ SQL
 CONFLICT_COUNT=$(dl "SELECT num_conflicts FROM dolt_conflicts WHERE \"table\"='evidence';")
 expect_eq "chapter8_conflict_detected" "1" "$CONFLICT_COUNT"
 
-
 "$DOLTLITE" "$DB" >/dev/null 2>&1 "SELECT dolt_conflicts_resolve('--ours','evidence');"
 
 RESOLVED=$(dl "SELECT count(*) FROM dolt_conflicts;")
@@ -248,7 +220,6 @@ expect_match "chapter8_resolution_kept_our_text" "suspicious coffee" "$KEPT_OUR_
 
 echo ""
 
-
 echo "--- Chapter 9: Fingerprinting ---"
 
 "$DOLTLITE" "$DB" >/dev/null 2>&1 "SELECT dolt_commit('-Am','Post-conflict reconciliation');"
@@ -258,8 +229,6 @@ expect_match "chapter9_db_hash_is_hex" "^[0-9a-f]{40}$" "$DB_HASH"
 
 EVIDENCE_HASH_A=$(dl "SELECT dolt_hashof_table('evidence');")
 
-
-
 "$DOLTLITE" "$DB" >/dev/null 2>&1 <<'SQL'
 INSERT INTO evidence VALUES (99, 'ignore me', NULL, '2026-04-16T12:00:00Z');
 DELETE FROM evidence WHERE id=99;
@@ -268,7 +237,6 @@ EVIDENCE_HASH_B=$(dl "SELECT dolt_hashof_table('evidence');")
 expect_eq "chapter9_table_hash_history_independent" "$EVIDENCE_HASH_A" "$EVIDENCE_HASH_B"
 
 echo ""
-
 
 echo "--- Chapter 10: ATTACH a stock SQLite database ---"
 
@@ -281,7 +249,6 @@ INSERT INTO fingerprints VALUES
   (2, 4, 'none',     'victim sleeve'),
   (3, 1, 'swirl',    'croissant wrapper');
 SQL
-
 
 ATTACHED_COUNT=$("$DOLTLITE" "$DB" "ATTACH DATABASE '$FORENSICS' AS forensics; SELECT count(*) FROM forensics.fingerprints;" 2>&1 | tail -1)
 expect_eq "chapter10_attach_read_count" "3" "$ATTACHED_COUNT"

--- a/test/doltlite_diff_alter.sh
+++ b/test/doltlite_diff_alter.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
-
-
-
 DOLTLITE=./doltlite
 PASS=0
 FAIL=0
@@ -24,9 +21,6 @@ run_test_match() {
 echo "=== Doltlite Diff Across ALTER TABLE Tests ==="
 echo ""
 
-
-
-
 DB1=/tmp/test_diff_alter1_$$.db; rm -f "$DB1"
 
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, name TEXT);
@@ -35,14 +29,9 @@ SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB1" > /dev/null 2>&1
 
 echo "ALTER TABLE t ADD COLUMN age INTEGER;" | $DOLTLITE "$DB1" > /dev/null 2>&1
 
-
 run_test "alter_add_col_no_data_change" \
   "SELECT count(*) FROM dolt_diff_t WHERE to_commit='WORKING';" \
   "0" "$DB1"
-
-
-
-
 
 echo "UPDATE t SET age=30 WHERE id=1;" | $DOLTLITE "$DB1" > /dev/null 2>&1
 
@@ -54,10 +43,6 @@ run_test "alter_updated_row_is_modify" \
   "SELECT diff_type || '|' || coalesce(to_id, from_id) FROM dolt_diff_t WHERE to_commit='WORKING';" \
   "modified|1" "$DB1"
 
-
-
-
-
 echo "SELECT dolt_commit('-A','-m','add age column and update alice');" | $DOLTLITE "$DB1" > /dev/null 2>&1
 
 run_test "alter_cross_commit_count" \
@@ -67,9 +52,6 @@ run_test "alter_cross_commit_count" \
 run_test "alter_cross_commit_type" \
   "SELECT rows_modified FROM dolt_diff_stat((SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1), (SELECT commit_hash FROM dolt_log LIMIT 1), 't');" \
   "1" "$DB1"
-
-
-
 
 DB2=/tmp/test_diff_alter2_$$.db; rm -f "$DB2"
 
@@ -94,17 +76,11 @@ run_test "multi_add_col_correct_row" \
   "SELECT coalesce(to_id, from_id) FROM dolt_diff_items WHERE to_commit='WORKING';" \
   "2" "$DB2"
 
-
-
-
 echo "SELECT dolt_commit('-A','-m','update coat price');" | $DOLTLITE "$DB2" > /dev/null 2>&1
 
 run_test "diff_table_across_alter_count" \
   "SELECT count(*) FROM dolt_diff_items WHERE diff_type='modified';" \
   "1" "$DB2"
-
-
-
 
 DB3=/tmp/test_diff_alter3_$$.db; rm -f "$DB3"
 
@@ -123,9 +99,6 @@ run_test "insert_after_alter_type" \
   "SELECT diff_type || '|' || coalesce(to_id, from_id) FROM dolt_diff_t WHERE to_commit='WORKING';" \
   "added|2" "$DB3"
 
-
-
-
 DB4=/tmp/test_diff_alter4_$$.db; rm -f "$DB4"
 
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -143,9 +116,6 @@ run_test "delete_after_alter_type" \
   "SELECT diff_type || '|' || coalesce(to_id, from_id) FROM dolt_diff_t WHERE to_commit='WORKING';" \
   "removed|1" "$DB4"
 
-
-
-
 DB5=/tmp/test_diff_alter5_$$.db; rm -f "$DB5"
 
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, name TEXT);
@@ -153,27 +123,22 @@ INSERT INTO t VALUES(1,'alice'),(2,'bob');
 SELECT dolt_commit('-A','-m','init');
 SELECT dolt_branch('feature');" | $DOLTLITE "$DB5" > /dev/null 2>&1
 
-
 echo "ALTER TABLE t ADD COLUMN age INTEGER;
 UPDATE t SET age=30 WHERE id=1;
 SELECT dolt_commit('-A','-m','add age on main');" | $DOLTLITE "$DB5" > /dev/null 2>&1
-
 
 echo "SELECT dolt_checkout('feature');" | $DOLTLITE "$DB5" > /dev/null 2>&1
 echo "UPDATE t SET name='BOB' WHERE id=2;
 SELECT dolt_commit('-A','-m','update bob on feature');" | $DOLTLITE "$DB5" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB5" > /dev/null 2>&1
 
-
 run_test_match "merge_after_alter_no_crash" \
   "SELECT dolt_merge('feature');" \
   "." "$DB5"
 
-
 run_test_match "diff_after_merge_works" \
   "SELECT coalesce(sum(rows_added + rows_deleted + rows_modified), 0) FROM dolt_diff_stat((SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1), (SELECT commit_hash FROM dolt_log LIMIT 1), 't');" \
   "^[0-9]+$" "$DB5"
-
 
 rm -f "$DB1" "$DB2" "$DB3" "$DB4" "$DB5"
 

--- a/test/doltlite_diff_alter.sh
+++ b/test/doltlite_diff_alter.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# Tests for current diff surfaces across ALTER TABLE ADD COLUMN schema changes.
-# Verifies that rows not modified after ADD COLUMN are NOT reported
-# as changed, and rows actually modified ARE reported correctly.
+
+
+
 DOLTLITE=./doltlite
 PASS=0
 FAIL=0
@@ -24,9 +24,9 @@ run_test_match() {
 echo "=== Doltlite Diff Across ALTER TABLE Tests ==="
 echo ""
 
-# ---------------------------------------------------------------
-# Test 1: ALTER TABLE ADD COLUMN, no row updates => empty diff
-# ---------------------------------------------------------------
+
+
+
 DB1=/tmp/test_diff_alter1_$$.db; rm -f "$DB1"
 
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, name TEXT);
@@ -35,15 +35,15 @@ SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB1" > /dev/null 2>&1
 
 echo "ALTER TABLE t ADD COLUMN age INTEGER;" | $DOLTLITE "$DB1" > /dev/null 2>&1
 
-# Working diff should be empty -- only schema changed, no data
+
 run_test "alter_add_col_no_data_change" \
   "SELECT count(*) FROM dolt_diff_t WHERE to_commit='WORKING';" \
   "0" "$DB1"
 
-# ---------------------------------------------------------------
-# Test 2: ALTER TABLE ADD COLUMN + update some rows => only
-#         updated rows show up in diff
-# ---------------------------------------------------------------
+
+
+
+
 echo "UPDATE t SET age=30 WHERE id=1;" | $DOLTLITE "$DB1" > /dev/null 2>&1
 
 run_test "alter_only_updated_row_in_diff" \
@@ -54,10 +54,10 @@ run_test "alter_updated_row_is_modify" \
   "SELECT diff_type || '|' || coalesce(to_id, from_id) FROM dolt_diff_t WHERE to_commit='WORKING';" \
   "modified|1" "$DB1"
 
-# ---------------------------------------------------------------
-# Test 3: Commit after ALTER + update, then cross-commit diff
-#         should show only the one modified row
-# ---------------------------------------------------------------
+
+
+
+
 echo "SELECT dolt_commit('-A','-m','add age column and update alice');" | $DOLTLITE "$DB1" > /dev/null 2>&1
 
 run_test "alter_cross_commit_count" \
@@ -68,9 +68,9 @@ run_test "alter_cross_commit_type" \
   "SELECT rows_modified FROM dolt_diff_stat((SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1), (SELECT commit_hash FROM dolt_log LIMIT 1), 't');" \
   "1" "$DB1"
 
-# ---------------------------------------------------------------
-# Test 4: Multiple ADD COLUMNs, untouched rows stay equal
-# ---------------------------------------------------------------
+
+
+
 DB2=/tmp/test_diff_alter2_$$.db; rm -f "$DB2"
 
 echo "CREATE TABLE items(id INTEGER PRIMARY KEY, label TEXT);
@@ -94,18 +94,18 @@ run_test "multi_add_col_correct_row" \
   "SELECT coalesce(to_id, from_id) FROM dolt_diff_items WHERE to_commit='WORKING';" \
   "2" "$DB2"
 
-# ---------------------------------------------------------------
-# Test 5: dolt_diff_<table> also works across ALTER TABLE
-# ---------------------------------------------------------------
+
+
+
 echo "SELECT dolt_commit('-A','-m','update coat price');" | $DOLTLITE "$DB2" > /dev/null 2>&1
 
 run_test "diff_table_across_alter_count" \
   "SELECT count(*) FROM dolt_diff_items WHERE diff_type='modified';" \
   "1" "$DB2"
 
-# ---------------------------------------------------------------
-# Test 6: INSERT after ALTER TABLE => shows as 'added', not spurious
-# ---------------------------------------------------------------
+
+
+
 DB3=/tmp/test_diff_alter3_$$.db; rm -f "$DB3"
 
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -123,9 +123,9 @@ run_test "insert_after_alter_type" \
   "SELECT diff_type || '|' || coalesce(to_id, from_id) FROM dolt_diff_t WHERE to_commit='WORKING';" \
   "added|2" "$DB3"
 
-# ---------------------------------------------------------------
-# Test 7: DELETE after ALTER TABLE => shows as 'removed'
-# ---------------------------------------------------------------
+
+
+
 DB4=/tmp/test_diff_alter4_$$.db; rm -f "$DB4"
 
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -143,9 +143,9 @@ run_test "delete_after_alter_type" \
   "SELECT diff_type || '|' || coalesce(to_id, from_id) FROM dolt_diff_t WHERE to_commit='WORKING';" \
   "removed|1" "$DB4"
 
-# ---------------------------------------------------------------
-# Test 8: Merge after ALTER TABLE (regression test for segfault)
-# ---------------------------------------------------------------
+
+
+
 DB5=/tmp/test_diff_alter5_$$.db; rm -f "$DB5"
 
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, name TEXT);
@@ -153,28 +153,28 @@ INSERT INTO t VALUES(1,'alice'),(2,'bob');
 SELECT dolt_commit('-A','-m','init');
 SELECT dolt_branch('feature');" | $DOLTLITE "$DB5" > /dev/null 2>&1
 
-# Main branch: add column and update
+
 echo "ALTER TABLE t ADD COLUMN age INTEGER;
 UPDATE t SET age=30 WHERE id=1;
 SELECT dolt_commit('-A','-m','add age on main');" | $DOLTLITE "$DB5" > /dev/null 2>&1
 
-# Feature branch: modify a different row (no schema change)
+
 echo "SELECT dolt_checkout('feature');" | $DOLTLITE "$DB5" > /dev/null 2>&1
 echo "UPDATE t SET name='BOB' WHERE id=2;
 SELECT dolt_commit('-A','-m','update bob on feature');" | $DOLTLITE "$DB5" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB5" > /dev/null 2>&1
 
-# Merge should not segfault
+
 run_test_match "merge_after_alter_no_crash" \
   "SELECT dolt_merge('feature');" \
   "." "$DB5"
 
-# After merge, diff between merge commit and its parent should work
+
 run_test_match "diff_after_merge_works" \
   "SELECT coalesce(sum(rows_added + rows_deleted + rows_modified), 0) FROM dolt_diff_stat((SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1), (SELECT commit_hash FROM dolt_log LIMIT 1), 't');" \
   "^[0-9]+$" "$DB5"
 
-# Cleanup
+
 rm -f "$DB1" "$DB2" "$DB3" "$DB4" "$DB5"
 
 echo ""

--- a/test/doltlite_diff_table.sh
+++ b/test/doltlite_diff_table.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
-
-
-
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
@@ -9,10 +6,6 @@ run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -
 
 echo "=== Doltlite dolt_diff_<table> Audit Log Tests ==="
 echo ""
-
-
-
-
 
 DB=/tmp/test_dt_basic_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -28,10 +21,6 @@ run_test_match "basic_to_date" "SELECT to_commit_date FROM dolt_diff_t LIMIT 1;"
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_dt_multi_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
@@ -41,24 +30,14 @@ SELECT dolt_commit('-A','-m','c2');
 UPDATE t SET v='A' WHERE id=1;
 SELECT dolt_commit('-A','-m','c3');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
-
-
-
 run_test "multi_count" "SELECT count(*) FROM dolt_diff_t;" "3" "$DB"
-
 
 run_test_match "multi_has_added" "SELECT count(*) FROM dolt_diff_t WHERE diff_type='added';" "^2$" "$DB"
 run_test_match "multi_has_modified" "SELECT count(*) FROM dolt_diff_t WHERE diff_type='modified';" "^1$" "$DB"
 
-
 run_test "multi_commits" "SELECT count(DISTINCT to_commit) FROM dolt_diff_t;" "3" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_dt_context_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -67,18 +46,12 @@ SELECT dolt_commit('-A','-m','c1');
 INSERT INTO t VALUES(2,'b');
 SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test_match "ctx_to_hash" "SELECT to_commit FROM dolt_diff_t LIMIT 1;" "^[0-9a-f]{40}$" "$DB"
 run_test_match "ctx_from_hash" "SELECT from_commit FROM dolt_diff_t WHERE diff_type='added' ;" "^[0-9a-f]{40}$" "$DB"
-
 
 run_test_match "ctx_to_date" "SELECT to_commit_date FROM dolt_diff_t LIMIT 1;" "^[0-9]{4}-" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_dt_persist_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -87,15 +60,10 @@ SELECT dolt_commit('-A','-m','c1');
 INSERT INTO t VALUES(2,'b');
 SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "persist_count" "SELECT count(*) FROM dolt_diff_t;" "2" "$DB"
 run_test_match "persist_type" "SELECT diff_type FROM dolt_diff_t WHERE to_v IS NOT NULL;" "added" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_dt_tables_$$.db; rm -f "$DB"
 echo "CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
@@ -108,7 +76,6 @@ SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "tables_users" "SELECT count(*) FROM dolt_diff_users;" "1" "$DB"
 run_test "tables_orders" "SELECT count(*) FROM dolt_diff_orders;" "2" "$DB"
 
-
 echo "INSERT INTO users VALUES(2,'Bob');
 SELECT dolt_commit('-A','-m','add bob');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
@@ -116,10 +83,6 @@ run_test "tables_users_after" "SELECT count(*) FROM dolt_diff_users;" "2" "$DB"
 run_test "tables_orders_after" "SELECT count(*) FROM dolt_diff_orders;" "2" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_dt_merge_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -134,15 +97,10 @@ INSERT INTO t VALUES(3,'main');
 SELECT dolt_commit('-A','-m','main add');
 SELECT dolt_merge('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test_match "merge_count" "SELECT count(*) FROM dolt_diff_t;" "^[3-9]" "$DB"
 run_test_match "merge_has_merge_commit" "SELECT count(DISTINCT to_commit) FROM dolt_diff_t;" "^[3-9]" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_dt_cp_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -155,15 +113,10 @@ SELECT dolt_commit('-A','-m','feat add');
 SELECT dolt_checkout('main');
 SELECT dolt_cherry_pick('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test_match "cp_count" "SELECT count(*) FROM dolt_diff_t;" "^[2-9]" "$DB"
 run_test_match "cp_has_row2" "SELECT count(*) FROM dolt_diff_t WHERE to_v IS NOT NULL;" "^[1-9]" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_dt_revert_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -173,15 +126,10 @@ INSERT INTO t VALUES(2,'to_revert');
 SELECT dolt_commit('-A','-m','add row 2');
 SELECT dolt_revert((SELECT commit_hash FROM dolt_log LIMIT 1));" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test_match "revert_count" "SELECT count(*) FROM dolt_diff_t;" "^[3-9]" "$DB"
 run_test_match "revert_has_removed" "SELECT count(*) FROM dolt_diff_t WHERE diff_type='removed';" "^[1-9]" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_dt_empty_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -190,10 +138,6 @@ SELECT dolt_commit('-A','-m','empty table');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "empty_count" "SELECT count(*) FROM dolt_diff_t;" "0" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_dt_history_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -205,17 +149,12 @@ for i in $(seq 1 9); do
 SELECT dolt_commit('-A','-m','update $i');" | $DOLTLITE "$DB" > /dev/null 2>&1
 done
 
-
 run_test "history_count" "SELECT count(*) FROM dolt_diff_t;" "10" "$DB"
 run_test "history_added" "SELECT count(*) FROM dolt_diff_t WHERE diff_type='added';" "1" "$DB"
 run_test "history_modified" "SELECT count(*) FROM dolt_diff_t WHERE diff_type='modified';" "9" "$DB"
 run_test "history_commits" "SELECT count(DISTINCT to_commit) FROM dolt_diff_t;" "10" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_dt_unchanged_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -234,10 +173,6 @@ run_test "unchanged_table_diff_type" "SELECT diff_type FROM dolt_diff_t;" "added
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_dt_quoted_$$.db; rm -f "$DB"
 cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
 CREATE TABLE "odd""name"(id INTEGER PRIMARY KEY, v TEXT);
@@ -250,10 +185,6 @@ run_test_match "quoted_diff_type" 'SELECT diff_type FROM "dolt_diff_odd""name";'
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_dt_newt_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
@@ -262,15 +193,10 @@ CREATE TABLE t2(id INTEGER PRIMARY KEY, w TEXT);
 INSERT INTO t2 VALUES(1,'x');
 SELECT dolt_commit('-A','-m','add t2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "newt_t2_count" "SELECT count(*) FROM dolt_diff_t2;" "1" "$DB"
 run_test "newt_t2_type" "SELECT diff_type FROM dolt_diff_t2;" "added" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_dt_vals_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -279,19 +205,13 @@ SELECT dolt_commit('-A','-m','c1');
 UPDATE t SET v='world' WHERE id=1;
 SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test_match "vals_add_from" "SELECT typeof(from_v) FROM dolt_diff_t WHERE diff_type='added';" "null" "$DB"
 run_test_match "vals_add_to" "SELECT typeof(to_v) FROM dolt_diff_t WHERE diff_type='added';" "text" "$DB"
-
 
 run_test_match "vals_mod_from" "SELECT typeof(from_v) FROM dolt_diff_t WHERE diff_type='modified';" "text" "$DB"
 run_test_match "vals_mod_to" "SELECT typeof(to_v) FROM dolt_diff_t WHERE diff_type='modified';" "text" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/doltlite_diff_table.sh
+++ b/test/doltlite_diff_table.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-#
-# Tests for dolt_diff_<tablename> audit log virtual tables.
-#
+
+
+
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
@@ -10,9 +10,9 @@ run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -
 echo "=== Doltlite dolt_diff_<table> Audit Log Tests ==="
 echo ""
 
-# ============================================================
-# Basic: single commit shows inserts as "added"
-# ============================================================
+
+
+
 
 DB=/tmp/test_dt_basic_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -28,9 +28,9 @@ run_test_match "basic_to_date" "SELECT to_commit_date FROM dolt_diff_t LIMIT 1;"
 
 rm -f "$DB"
 
-# ============================================================
-# Multiple commits: full history
-# ============================================================
+
+
+
 
 DB=/tmp/test_dt_multi_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -41,24 +41,24 @@ SELECT dolt_commit('-A','-m','c2');
 UPDATE t SET v='A' WHERE id=1;
 SELECT dolt_commit('-A','-m','c3');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# c1: added row 1 (1 row)
-# c2: added row 2 (1 row)
-# c3: modified row 1 (1 row)
-# Total: 3 audit rows
+
+
+
+
 run_test "multi_count" "SELECT count(*) FROM dolt_diff_t;" "3" "$DB"
 
-# Check diff types present
+
 run_test_match "multi_has_added" "SELECT count(*) FROM dolt_diff_t WHERE diff_type='added';" "^2$" "$DB"
 run_test_match "multi_has_modified" "SELECT count(*) FROM dolt_diff_t WHERE diff_type='modified';" "^1$" "$DB"
 
-# Each row has a different to_commit
+
 run_test "multi_commits" "SELECT count(DISTINCT to_commit) FROM dolt_diff_t;" "3" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Commit context columns
-# ============================================================
+
+
+
 
 DB=/tmp/test_dt_context_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -67,18 +67,18 @@ SELECT dolt_commit('-A','-m','c1');
 INSERT INTO t VALUES(2,'b');
 SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# from_commit and to_commit should be valid 40-char hashes
+
 run_test_match "ctx_to_hash" "SELECT to_commit FROM dolt_diff_t LIMIT 1;" "^[0-9a-f]{40}$" "$DB"
 run_test_match "ctx_from_hash" "SELECT from_commit FROM dolt_diff_t WHERE diff_type='added' ;" "^[0-9a-f]{40}$" "$DB"
 
-# to_commit_date should be a datetime string
+
 run_test_match "ctx_to_date" "SELECT to_commit_date FROM dolt_diff_t LIMIT 1;" "^[0-9]{4}-" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Persistence across reopen
-# ============================================================
+
+
+
 
 DB=/tmp/test_dt_persist_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -87,15 +87,15 @@ SELECT dolt_commit('-A','-m','c1');
 INSERT INTO t VALUES(2,'b');
 SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Query from a new session
+
 run_test "persist_count" "SELECT count(*) FROM dolt_diff_t;" "2" "$DB"
 run_test_match "persist_type" "SELECT diff_type FROM dolt_diff_t WHERE to_v IS NOT NULL;" "added" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Multiple tables have separate audit logs
-# ============================================================
+
+
+
 
 DB=/tmp/test_dt_tables_$$.db; rm -f "$DB"
 echo "CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
@@ -108,7 +108,7 @@ SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "tables_users" "SELECT count(*) FROM dolt_diff_users;" "1" "$DB"
 run_test "tables_orders" "SELECT count(*) FROM dolt_diff_orders;" "2" "$DB"
 
-# Add more data
+
 echo "INSERT INTO users VALUES(2,'Bob');
 SELECT dolt_commit('-A','-m','add bob');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
@@ -117,9 +117,9 @@ run_test "tables_orders_after" "SELECT count(*) FROM dolt_diff_orders;" "2" "$DB
 
 rm -f "$DB"
 
-# ============================================================
-# Audit log after merge
-# ============================================================
+
+
+
 
 DB=/tmp/test_dt_merge_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -134,15 +134,15 @@ INSERT INTO t VALUES(3,'main');
 SELECT dolt_commit('-A','-m','main add');
 SELECT dolt_merge('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Should have audit rows from: init commit + main add + merge (which adds row 2)
+
 run_test_match "merge_count" "SELECT count(*) FROM dolt_diff_t;" "^[3-9]" "$DB"
 run_test_match "merge_has_merge_commit" "SELECT count(DISTINCT to_commit) FROM dolt_diff_t;" "^[3-9]" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Audit log after cherry-pick
-# ============================================================
+
+
+
 
 DB=/tmp/test_dt_cp_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -155,15 +155,15 @@ SELECT dolt_commit('-A','-m','feat add');
 SELECT dolt_checkout('main');
 SELECT dolt_cherry_pick('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Should show the cherry-picked row as added
+
 run_test_match "cp_count" "SELECT count(*) FROM dolt_diff_t;" "^[2-9]" "$DB"
 run_test_match "cp_has_row2" "SELECT count(*) FROM dolt_diff_t WHERE to_v IS NOT NULL;" "^[1-9]" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Audit log after revert
-# ============================================================
+
+
+
 
 DB=/tmp/test_dt_revert_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -173,15 +173,15 @@ INSERT INTO t VALUES(2,'to_revert');
 SELECT dolt_commit('-A','-m','add row 2');
 SELECT dolt_revert((SELECT commit_hash FROM dolt_log LIMIT 1));" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Should show: init (added 1), add row 2 (added 2), revert (removed 2)
+
 run_test_match "revert_count" "SELECT count(*) FROM dolt_diff_t;" "^[3-9]" "$DB"
 run_test_match "revert_has_removed" "SELECT count(*) FROM dolt_diff_t WHERE diff_type='removed';" "^[1-9]" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Empty table has no audit rows
-# ============================================================
+
+
+
 
 DB=/tmp/test_dt_empty_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -191,9 +191,9 @@ run_test "empty_count" "SELECT count(*) FROM dolt_diff_t;" "0" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Long history (10 commits)
-# ============================================================
+
+
+
 
 DB=/tmp/test_dt_history_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -205,7 +205,7 @@ for i in $(seq 1 9); do
 SELECT dolt_commit('-A','-m','update $i');" | $DOLTLITE "$DB" > /dev/null 2>&1
 done
 
-# 1 "added" + 9 "modified" = 10 audit rows
+
 run_test "history_count" "SELECT count(*) FROM dolt_diff_t;" "10" "$DB"
 run_test "history_added" "SELECT count(*) FROM dolt_diff_t WHERE diff_type='added';" "1" "$DB"
 run_test "history_modified" "SELECT count(*) FROM dolt_diff_t WHERE diff_type='modified';" "9" "$DB"
@@ -213,9 +213,9 @@ run_test "history_commits" "SELECT count(DISTINCT to_commit) FROM dolt_diff_t;" 
 
 rm -f "$DB"
 
-# ============================================================
-# Unchanged commit spans do not break diff traversal
-# ============================================================
+
+
+
 
 DB=/tmp/test_dt_unchanged_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -234,9 +234,9 @@ run_test "unchanged_table_diff_type" "SELECT diff_type FROM dolt_diff_t;" "added
 
 rm -f "$DB"
 
-# ============================================================
-# Quoted table names
-# ============================================================
+
+
+
 
 DB=/tmp/test_dt_quoted_$$.db; rm -f "$DB"
 cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -250,9 +250,9 @@ run_test_match "quoted_diff_type" 'SELECT diff_type FROM "dolt_diff_odd""name";'
 
 rm -f "$DB"
 
-# ============================================================
-# Table not present before a commit
-# ============================================================
+
+
+
 
 DB=/tmp/test_dt_newt_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -262,15 +262,15 @@ CREATE TABLE t2(id INTEGER PRIMARY KEY, w TEXT);
 INSERT INTO t2 VALUES(1,'x');
 SELECT dolt_commit('-A','-m','add t2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# t2 was only in the second commit
+
 run_test "newt_t2_count" "SELECT count(*) FROM dolt_diff_t2;" "1" "$DB"
 run_test "newt_t2_type" "SELECT diff_type FROM dolt_diff_t2;" "added" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# from_v and to_v are blobs
-# ============================================================
+
+
+
 
 DB=/tmp/test_dt_vals_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -279,19 +279,19 @@ SELECT dolt_commit('-A','-m','c1');
 UPDATE t SET v='world' WHERE id=1;
 SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# For the initial add, from_v is null, to_v is blob
+
 run_test_match "vals_add_from" "SELECT typeof(from_v) FROM dolt_diff_t WHERE diff_type='added';" "null" "$DB"
 run_test_match "vals_add_to" "SELECT typeof(to_v) FROM dolt_diff_t WHERE diff_type='added';" "text" "$DB"
 
-# For the modify, both are blobs
+
 run_test_match "vals_mod_from" "SELECT typeof(from_v) FROM dolt_diff_t WHERE diff_type='modified';" "text" "$DB"
 run_test_match "vals_mod_to" "SELECT typeof(to_v) FROM dolt_diff_t WHERE diff_type='modified';" "text" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Done
-# ============================================================
+
+
+
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/doltlite_e2e.sh
+++ b/test/doltlite_e2e.sh
@@ -1,9 +1,4 @@
 #!/bin/bash
-
-
-
-
-
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
@@ -13,10 +8,6 @@ echo "=== Doltlite End-to-End Integration Tests ==="
 echo ""
 
 DB=/tmp/test_e2e_$$.db; rm -f "$DB"
-
-
-
-
 
 echo "CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT, email TEXT);
 CREATE TABLE posts(id INTEGER PRIMARY KEY, user_id INTEGER, title TEXT, body TEXT);
@@ -32,13 +23,8 @@ run_test "e2e_initial_branch" "SELECT active_branch();" "main" "$DB"
 run_test "e2e_initial_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 run_test "e2e_clean_status" "SELECT count(*) FROM dolt_status;" "0" "$DB"
 
-
 echo "SELECT dolt_tag('v0.1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "e2e_tag_exists" "SELECT tag_name FROM dolt_tags;" "v0.1" "$DB"
-
-
-
-
 
 echo "SELECT dolt_branch('add-comments');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('add-comments');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -52,13 +38,8 @@ SELECT dolt_commit('-A','-m','Add comments table');" | $DOLTLITE "$DB/add-commen
 
 run_test "e2e_feature_comments" "SELECT count(*) FROM comments;" "2" "$DB/add-comments"
 
-
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "e2e_main_no_comments" "SELECT * FROM comments;" "no such table" "$DB"
-
-
-
-
 
 echo "INSERT INTO users VALUES(3,'Charlie','charlie@example.com');
 UPDATE users SET email='alice@newmail.com' WHERE id=1;
@@ -67,35 +48,20 @@ SELECT dolt_commit('-A','-m','Add Charlie, update Alice email');" | $DOLTLITE "$
 run_test "e2e_main_3_users" "SELECT count(*) FROM users;" "3" "$DB"
 run_test "e2e_alice_new_email" "SELECT email FROM users WHERE id=1;" "alice@newmail.com" "$DB"
 
-
-
-
-
 run_test_match "e2e_merge_comments" "SELECT dolt_merge('add-comments');" "^[0-9a-f]{40}$" "$DB"
-
 
 run_test "e2e_merged_users" "SELECT count(*) FROM users;" "3" "$DB"
 run_test "e2e_merged_posts" "SELECT count(*) FROM posts;" "2" "$DB"
 run_test "e2e_merged_comments" "SELECT count(*) FROM comments;" "2" "$DB"
 
-
 run_test_match "e2e_merge_in_log" "SELECT message FROM dolt_log LIMIT 1;" "Merge" "$DB"
-
 
 echo "SELECT dolt_tag('v0.2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "e2e_two_tags" "SELECT count(*) FROM dolt_tags;" "2" "$DB"
 
-
-
-
-
 run_test_match "e2e_diff_users_v01_v02" \
   "SELECT coalesce(sum(rows_added + rows_deleted + rows_modified), 0) FROM dolt_diff_stat((SELECT tag_hash FROM dolt_tags WHERE tag_name='v0.1'), (SELECT tag_hash FROM dolt_tags WHERE tag_name='v0.2'), 'users');" \
   "^[0-9]" "$DB"
-
-
-
-
 
 echo "SELECT dolt_branch('hotfix');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('hotfix');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -106,18 +72,15 @@ echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "UPDATE users SET name='alice_updated' WHERE id=1;
 SELECT dolt_commit('-A','-m','Main: update Alice name');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test_match "e2e_conflict_merge" "SELECT dolt_merge('hotfix');" "conflict" "$DB"
 
 run_test_match "e2e_has_conflicts" \
   "BEGIN; SELECT dolt_merge('hotfix'); SELECT 'EC|' || num_conflicts FROM dolt_conflicts WHERE \"table\"='users'; ROLLBACK;" \
   "^EC\\|1$" "$DB"
 
-
 run_test_match "e2e_commit_blocked" \
   "BEGIN; SELECT dolt_merge('hotfix'); SELECT dolt_commit('-A','-m','fail');" \
   "cannot commit: unresolved merge conflicts|Use dolt_conflicts_resolve" "$DB"
-
 
 run_test_match "e2e_conflicts_cleared" \
   "BEGIN; SELECT dolt_merge('hotfix'); SELECT dolt_conflicts_resolve('--ours','users'); SELECT 'ER|' || count(*) FROM dolt_conflicts; ROLLBACK;" \
@@ -126,20 +89,12 @@ run_test_match "e2e_ours_kept" \
   "BEGIN; SELECT dolt_merge('hotfix'); SELECT dolt_conflicts_resolve('--ours','users'); SELECT 'EU|' || name FROM users WHERE id=1; ROLLBACK;" \
   "^EU\\|alice_updated$" "$DB"
 
-
-
-
-
 echo "INSERT INTO users VALUES(99,'Temp','temp@test.com');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "e2e_before_reset" "SELECT count(*) FROM users;" "4" "$DB"
 
 echo "SELECT dolt_reset('--hard');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "e2e_after_reset" "SELECT count(*) FROM users;" "3" "$DB"
 run_test "e2e_reset_clean" "SELECT count(*) FROM dolt_status;" "0" "$DB"
-
-
-
-
 
 echo "INSERT INTO users VALUES(4,'Dave','dave@example.com');
 INSERT INTO posts VALUES(3,4,'Daves Post','New here');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -150,17 +105,11 @@ echo "SELECT dolt_add('users');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "e2e_one_staged" "SELECT count(*) FROM dolt_status WHERE staged=1;" "1" "$DB"
 run_test "e2e_one_unstaged" "SELECT count(*) FROM dolt_status WHERE staged=0;" "1" "$DB"
 
-
 echo "SELECT dolt_reset();" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "e2e_after_reset" "SELECT count(*) FROM dolt_status WHERE staged=1;" "0" "$DB"
 run_test "e2e_data_preserved" "SELECT count(*) FROM users;" "4" "$DB"
 
-
 run_test_match "e2e_commit_all" "SELECT dolt_commit('-A','-m','Add Dave');" "^[0-9a-f]{40}$" "$DB"
-
-
-
-
 
 run_test "e2e_branch_count" "SELECT count(*) FROM dolt_branches;" "3" "$DB"
 
@@ -168,21 +117,12 @@ echo "SELECT dolt_branch('-D','hotfix');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "e2e_deleted_branch" "SELECT count(*) FROM dolt_branches;" "2" "$DB"
 run_test_match "e2e_delete_gone" "SELECT dolt_checkout('hotfix');" "no such branch or table" "$DB"
 
-
-
-
-
 run_test_match "e2e_log_count" "SELECT count(*) FROM dolt_log;" "^[5-9]" "$DB"
-
 
 run_test "e2e_final_users" "SELECT count(*) FROM users;" "4" "$DB"
 run_test "e2e_final_posts" "SELECT count(*) FROM posts;" "3" "$DB"
 run_test "e2e_final_comments" "SELECT count(*) FROM comments;" "2" "$DB"
 run_test "e2e_final_branch" "SELECT active_branch();" "main" "$DB"
-
-
-
-
 
 run_test "e2e_persist_users" "SELECT name FROM users WHERE id=4;" "Dave" "$DB"
 run_test "e2e_persist_log" "SELECT message FROM dolt_log LIMIT 1;" "Add Dave" "$DB"

--- a/test/doltlite_e2e.sh
+++ b/test/doltlite_e2e.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-#
-# End-to-end integration test: exercises the full Doltlite workflow
-# like a real user would. Creates a project, makes commits, branches,
-# merges, handles conflicts, tags releases, diffs history.
-#
+
+
+
+
+
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
@@ -14,9 +14,9 @@ echo ""
 
 DB=/tmp/test_e2e_$$.db; rm -f "$DB"
 
-# ============================================================
-# Phase 1: Initial schema + first commit
-# ============================================================
+
+
+
 
 echo "CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT, email TEXT);
 CREATE TABLE posts(id INTEGER PRIMARY KEY, user_id INTEGER, title TEXT, body TEXT);
@@ -32,13 +32,13 @@ run_test "e2e_initial_branch" "SELECT active_branch();" "main" "$DB"
 run_test "e2e_initial_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 run_test "e2e_clean_status" "SELECT count(*) FROM dolt_status;" "0" "$DB"
 
-# Tag the initial release
+
 echo "SELECT dolt_tag('v0.1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "e2e_tag_exists" "SELECT tag_name FROM dolt_tags;" "v0.1" "$DB"
 
-# ============================================================
-# Phase 2: Feature branch — add comments table
-# ============================================================
+
+
+
 
 echo "SELECT dolt_branch('add-comments');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('add-comments');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -52,13 +52,13 @@ SELECT dolt_commit('-A','-m','Add comments table');" | $DOLTLITE "$DB/add-commen
 
 run_test "e2e_feature_comments" "SELECT count(*) FROM comments;" "2" "$DB/add-comments"
 
-# Main branch shouldn't have comments
+
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "e2e_main_no_comments" "SELECT * FROM comments;" "no such table" "$DB"
 
-# ============================================================
-# Phase 3: Concurrent work on main — update users
-# ============================================================
+
+
+
 
 echo "INSERT INTO users VALUES(3,'Charlie','charlie@example.com');
 UPDATE users SET email='alice@newmail.com' WHERE id=1;
@@ -67,35 +67,35 @@ SELECT dolt_commit('-A','-m','Add Charlie, update Alice email');" | $DOLTLITE "$
 run_test "e2e_main_3_users" "SELECT count(*) FROM users;" "3" "$DB"
 run_test "e2e_alice_new_email" "SELECT email FROM users WHERE id=1;" "alice@newmail.com" "$DB"
 
-# ============================================================
-# Phase 4: Merge feature into main (non-conflicting)
-# ============================================================
+
+
+
 
 run_test_match "e2e_merge_comments" "SELECT dolt_merge('add-comments');" "^[0-9a-f]{40}$" "$DB"
 
-# After merge: main has users (3 rows) + posts (2 rows) + comments (2 rows)
+
 run_test "e2e_merged_users" "SELECT count(*) FROM users;" "3" "$DB"
 run_test "e2e_merged_posts" "SELECT count(*) FROM posts;" "2" "$DB"
 run_test "e2e_merged_comments" "SELECT count(*) FROM comments;" "2" "$DB"
 
-# Log should show merge commit
+
 run_test_match "e2e_merge_in_log" "SELECT message FROM dolt_log LIMIT 1;" "Merge" "$DB"
 
-# Tag v0.2
+
 echo "SELECT dolt_tag('v0.2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "e2e_two_tags" "SELECT count(*) FROM dolt_tags;" "2" "$DB"
 
-# ============================================================
-# Phase 5: Diff between tags
-# ============================================================
+
+
+
 
 run_test_match "e2e_diff_users_v01_v02" \
   "SELECT coalesce(sum(rows_added + rows_deleted + rows_modified), 0) FROM dolt_diff_stat((SELECT tag_hash FROM dolt_tags WHERE tag_name='v0.1'), (SELECT tag_hash FROM dolt_tags WHERE tag_name='v0.2'), 'users');" \
   "^[0-9]" "$DB"
 
-# ============================================================
-# Phase 6: Conflicting merge
-# ============================================================
+
+
+
 
 echo "SELECT dolt_branch('hotfix');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('hotfix');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -106,19 +106,19 @@ echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "UPDATE users SET name='alice_updated' WHERE id=1;
 SELECT dolt_commit('-A','-m','Main: update Alice name');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Merge hotfix — conflict state is available in-session
+
 run_test_match "e2e_conflict_merge" "SELECT dolt_merge('hotfix');" "conflict" "$DB"
 
 run_test_match "e2e_has_conflicts" \
   "BEGIN; SELECT dolt_merge('hotfix'); SELECT 'EC|' || num_conflicts FROM dolt_conflicts WHERE \"table\"='users'; ROLLBACK;" \
   "^EC\\|1$" "$DB"
 
-# Commit should be blocked in-session
+
 run_test_match "e2e_commit_blocked" \
   "BEGIN; SELECT dolt_merge('hotfix'); SELECT dolt_commit('-A','-m','fail');" \
   "cannot commit: unresolved merge conflicts|Use dolt_conflicts_resolve" "$DB"
 
-# Resolve with --ours in-session
+
 run_test_match "e2e_conflicts_cleared" \
   "BEGIN; SELECT dolt_merge('hotfix'); SELECT dolt_conflicts_resolve('--ours','users'); SELECT 'ER|' || count(*) FROM dolt_conflicts; ROLLBACK;" \
   "^ER\\|0$" "$DB"
@@ -126,9 +126,9 @@ run_test_match "e2e_ours_kept" \
   "BEGIN; SELECT dolt_merge('hotfix'); SELECT dolt_conflicts_resolve('--ours','users'); SELECT 'EU|' || name FROM users WHERE id=1; ROLLBACK;" \
   "^EU\\|alice_updated$" "$DB"
 
-# ============================================================
-# Phase 7: Reset
-# ============================================================
+
+
+
 
 echo "INSERT INTO users VALUES(99,'Temp','temp@test.com');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "e2e_before_reset" "SELECT count(*) FROM users;" "4" "$DB"
@@ -137,9 +137,9 @@ echo "SELECT dolt_reset('--hard');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "e2e_after_reset" "SELECT count(*) FROM users;" "3" "$DB"
 run_test "e2e_reset_clean" "SELECT count(*) FROM dolt_status;" "0" "$DB"
 
-# ============================================================
-# Phase 8: Staging workflow
-# ============================================================
+
+
+
 
 echo "INSERT INTO users VALUES(4,'Dave','dave@example.com');
 INSERT INTO posts VALUES(3,4,'Daves Post','New here');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -150,17 +150,17 @@ echo "SELECT dolt_add('users');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "e2e_one_staged" "SELECT count(*) FROM dolt_status WHERE staged=1;" "1" "$DB"
 run_test "e2e_one_unstaged" "SELECT count(*) FROM dolt_status WHERE staged=0;" "1" "$DB"
 
-# No-args reset (== --mixed) unstages
+
 echo "SELECT dolt_reset();" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "e2e_after_reset" "SELECT count(*) FROM dolt_status WHERE staged=1;" "0" "$DB"
 run_test "e2e_data_preserved" "SELECT count(*) FROM users;" "4" "$DB"
 
-# Stage all and commit
+
 run_test_match "e2e_commit_all" "SELECT dolt_commit('-A','-m','Add Dave');" "^[0-9a-f]{40}$" "$DB"
 
-# ============================================================
-# Phase 9: Branch listing and management
-# ============================================================
+
+
+
 
 run_test "e2e_branch_count" "SELECT count(*) FROM dolt_branches;" "3" "$DB"
 
@@ -168,21 +168,21 @@ echo "SELECT dolt_branch('-D','hotfix');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "e2e_deleted_branch" "SELECT count(*) FROM dolt_branches;" "2" "$DB"
 run_test_match "e2e_delete_gone" "SELECT dolt_checkout('hotfix');" "no such branch or table" "$DB"
 
-# ============================================================
-# Phase 10: Full history
-# ============================================================
+
+
+
 
 run_test_match "e2e_log_count" "SELECT count(*) FROM dolt_log;" "^[5-9]" "$DB"
 
-# Verify data integrity at the end
+
 run_test "e2e_final_users" "SELECT count(*) FROM users;" "4" "$DB"
 run_test "e2e_final_posts" "SELECT count(*) FROM posts;" "3" "$DB"
 run_test "e2e_final_comments" "SELECT count(*) FROM comments;" "2" "$DB"
 run_test "e2e_final_branch" "SELECT active_branch();" "main" "$DB"
 
-# ============================================================
-# Phase 11: Persistence — close and reopen
-# ============================================================
+
+
+
 
 run_test "e2e_persist_users" "SELECT name FROM users WHERE id=4;" "Dave" "$DB"
 run_test "e2e_persist_log" "SELECT message FROM dolt_log LIMIT 1;" "Add Dave" "$DB"

--- a/test/doltlite_edge_cases.sh
+++ b/test/doltlite_edge_cases.sh
@@ -1,9 +1,4 @@
 #!/bin/bash
-
-
-
-
-
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
@@ -11,10 +6,6 @@ run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -
 
 echo "=== Doltlite Edge Case Tests ==="
 echo ""
-
-
-
-
 
 DB=/tmp/test_edge_null_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, a TEXT, b INTEGER, c REAL);
@@ -27,19 +18,16 @@ run_test "null_select" "SELECT a FROM t WHERE id=1;" "" "$DB"
 run_test "null_count" "SELECT count(*) FROM t WHERE a IS NULL;" "1" "$DB"
 run_test "null_diff_count" "SELECT count(*) FROM dolt_diff_t WHERE to_commit='WORKING';" "0" "$DB"
 
-
 echo "UPDATE t SET a='was_null' WHERE id=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "null_diff_shows" "SELECT count(*) FROM dolt_diff_t WHERE to_commit='WORKING';" "^[1-9]" "$DB"
 echo "SELECT dolt_commit('-A','-m','fill nulls');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "null_updated" "SELECT a FROM t WHERE id=1;" "was_null" "$DB"
 
-
 echo "UPDATE t SET a=NULL WHERE id=2;
 SELECT dolt_commit('-A','-m','set to null');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "val_to_null" "SELECT count(*) FROM t WHERE a IS NULL;" "1" "$DB"
-
 
 echo "SELECT dolt_branch('nullbranch');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('nullbranch');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -53,10 +41,6 @@ run_test "null_merge_c" "SELECT c FROM t WHERE id=1;" "9.9" "$DB"
 run_test "null_merge_unchanged" "SELECT a FROM t WHERE id=1;" "was_null" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_edge_boundary_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT);
@@ -73,15 +57,10 @@ run_test "min_int" "SELECT val FROM t WHERE id=-9223372036854775808;" "minint" "
 run_test "boundary_count" "SELECT count(*) FROM t;" "4" "$DB"
 run_test "boundary_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 
-
 run_test "boundary_persist_max" "SELECT val FROM t WHERE id=9223372036854775807;" "maxint" "$DB"
 run_test "boundary_persist_min" "SELECT val FROM t WHERE id=-9223372036854775808;" "minint" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_edge_chars_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT);
@@ -97,13 +76,11 @@ run_test "special_apostrophe" "SELECT val FROM t WHERE id=1;" "it's a test" "$DB
 run_test_match "special_newline" "SELECT length(val) FROM t WHERE id=2;" "^1[01]$" "$DB"
 run_test "special_count" "SELECT count(*) FROM t;" "5" "$DB"
 
-
 echo "UPDATE t SET val='updated' WHERE id=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "special_diff" "SELECT count(*) FROM dolt_diff_t WHERE to_commit='WORKING';" "^[1-9]" "$DB"
 echo "SELECT dolt_commit('-A','-m','update special');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "special_updated" "SELECT val FROM t WHERE id=1;" "updated" "$DB"
-
 
 echo "SELECT dolt_branch('sp');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('sp');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -117,10 +94,6 @@ run_test "special_merge_both" "SELECT val FROM t WHERE id=6;" "sp_val" "$DB"
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_edge_multitable_$$.db; rm -f "$DB"
 echo "CREATE TABLE a(id INTEGER PRIMARY KEY, x TEXT);
 CREATE TABLE b(id INTEGER PRIMARY KEY, y TEXT);
@@ -129,7 +102,6 @@ INSERT INTO a VALUES(1,'a1');
 INSERT INTO b VALUES(1,'b1');
 INSERT INTO c VALUES(1,'c1');
 SELECT dolt_commit('-A','-m','init 3 tables');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 echo "SELECT dolt_branch('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -151,15 +123,10 @@ run_test "multi_b2" "SELECT y FROM b WHERE id=2;" "b2_feat" "$DB"
 run_test "multi_b3" "SELECT y FROM b WHERE id=3;" "b3_main" "$DB"
 run_test "multi_c2" "SELECT z FROM c WHERE id=2;" "c2_main" "$DB"
 
-
 run_test_match "multi_merge_log" "SELECT message FROM dolt_log LIMIT 1;" "Merge" "$DB"
 run_test "multi_merge_log_count" "SELECT count(*) FROM dolt_log;" "5" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_edge_newtable_$$.db; rm -f "$DB"
 echo "CREATE TABLE base(id INTEGER PRIMARY KEY, v TEXT);
@@ -183,14 +150,9 @@ run_test "newtable_feat" "SELECT count(*) FROM feat_table;" "2" "$DB"
 run_test "newtable_feat_val" "SELECT f FROM feat_table WHERE id=1;" "feat1" "$DB"
 run_test "newtable_schema" "SELECT count(*) FROM sqlite_master WHERE type='table';" "2" "$DB"
 
-
 run_test "newtable_persist" "SELECT count(*) FROM feat_table;" "2" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_edge_ff_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -206,74 +168,51 @@ SELECT dolt_commit('-A','-m','third');" | $DOLTLITE "$DB/ahead" > /dev/null 2>&1
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test_match "ff_merge" "SELECT dolt_merge('ahead');" "^[0-9a-f]{40}$" "$DB"
 run_test "ff_data" "SELECT count(*) FROM t;" "3" "$DB"
 run_test "ff_row2" "SELECT v FROM t WHERE id=2;" "second" "$DB"
 run_test "ff_row3" "SELECT v FROM t WHERE id=3;" "third" "$DB"
 
-
 run_test "ff_already_uptodate" "SELECT dolt_merge('ahead');" "Already up to date" "$DB"
-
 
 run_test "ff_self" "SELECT dolt_merge('main');" "Already up to date" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_edge_errors_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'x');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test_match "err_merge_noexist" "SELECT dolt_merge('nope');" "not found" "$DB"
 
-
 run_test_match "err_checkout_noexist" "SELECT dolt_checkout('nope');" "no such branch or table" "$DB"
-
 
 echo "SELECT dolt_branch('dup');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "err_branch_dup" "SELECT dolt_branch('dup');" "already exists" "$DB"
 
-
 run_test_match "err_delete_current" "SELECT dolt_branch('-d','main');" "cannot delete" "$DB"
-
 
 run_test_match "err_commit_clean" "SELECT dolt_commit('-A','-m','empty');" "nothing to commit" "$DB"
 
-
 run_test_match "err_commit_nomsg" "SELECT dolt_commit('-A');" "require" "$DB"
-
 
 echo "SELECT dolt_tag('v1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "err_tag_dup" "SELECT dolt_tag('v1');" "already exists" "$DB"
 
-
 run_test_match "err_tag_del_noexist" "SELECT dolt_tag('-d','nope');" "not found" "$DB"
-
 
 echo "INSERT INTO t VALUES(2,'dirty');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "checkout_dirty_allowed" "SELECT dolt_checkout('dup');" "0" "$DB"
 
-
 echo "SELECT dolt_reset('--hard');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "err_reset_cleaned" "SELECT count(*) FROM t;" "1" "$DB"
 
-
 run_test "err_resolve_none" "SELECT dolt_conflicts_resolve('--ours','t');" "0" "$DB"
-
 
 run_test "err_diff_notable" "SELECT count(*) FROM dolt_diff WHERE table_name='nonexistent';" "0" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_edge_staging_$$.db; rm -f "$DB"
 echo "CREATE TABLE a(id INTEGER PRIMARY KEY, v TEXT);
@@ -282,50 +221,37 @@ INSERT INTO a VALUES(1,'a1');
 INSERT INTO b VALUES(1,'b1');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 echo "INSERT INTO a VALUES(2,'a2');
 INSERT INTO b VALUES(2,'b2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "stg_both_dirty" "SELECT count(*) FROM dolt_status;" "2" "$DB"
 
-
 echo "SELECT dolt_add('a');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "stg_a_staged" "SELECT count(*) FROM dolt_status WHERE staged=1;" "1" "$DB"
 run_test "stg_b_unstaged" "SELECT count(*) FROM dolt_status WHERE staged=0;" "1" "$DB"
-
-
 
 echo "SELECT dolt_reset();" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "stg_reset_unstages" "SELECT count(*) FROM dolt_status WHERE staged=1;" "0" "$DB"
 run_test "stg_data_kept" "SELECT count(*) FROM a;" "2" "$DB"
 
-
 echo "SELECT dolt_add('a');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "stg_partial_commit" "SELECT dolt_commit('-m','just a');" "^[0-9a-f]{40}$" "$DB"
 
-
 run_test "stg_b_still_dirty" "SELECT count(*) FROM dolt_status;" "1" "$DB"
 run_test_match "stg_b_in_status" "SELECT table_name FROM dolt_status;" "b" "$DB"
-
 
 run_test_match "stg_commit_b" "SELECT dolt_commit('-A','-m','now b');" "^[0-9a-f]{40}$" "$DB"
 run_test "stg_all_clean" "SELECT count(*) FROM dolt_status;" "0" "$DB"
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_edge_schema_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, name TEXT);
 INSERT INTO t VALUES(1,'Alice');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 echo "ALTER TABLE t ADD COLUMN email TEXT;
 UPDATE t SET email='alice@test.com' WHERE id=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 run_test_match "schema_diff_working" "SELECT count(*) FROM dolt_diff_t WHERE to_commit='WORKING';" "^[1-9]" "$DB"
 
@@ -334,12 +260,10 @@ echo "SELECT dolt_commit('-A','-m','add email column');" | $DOLTLITE "$DB" > /de
 run_test "schema_new_col" "SELECT email FROM t WHERE id=1;" "alice@test.com" "$DB"
 run_test "schema_log" "SELECT count(*) FROM dolt_log;" "3" "$DB"
 
-
 echo "INSERT INTO t VALUES(2,'Bob','bob@test.com');
 SELECT dolt_commit('-A','-m','add bob');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "schema_new_row" "SELECT email FROM t WHERE id=2;" "bob@test.com" "$DB"
-
 
 echo "SELECT dolt_branch('post-schema');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('post-schema');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -357,10 +281,6 @@ run_test "schema_merge_dave" "SELECT email FROM t WHERE id=4;" "dave@test.com" "
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_edge_diffhash_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'first');
@@ -371,31 +291,25 @@ echo "INSERT INTO t VALUES(3,'third');
 UPDATE t SET v='FIRST' WHERE id=1;
 SELECT dolt_commit('-A','-m','c3');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test_match "diff_c1_c3" \
   "SELECT coalesce(sum(rows_added + rows_deleted + rows_modified), 0) FROM dolt_diff_stat((SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 2), (SELECT commit_hash FROM dolt_log LIMIT 1), 't');" \
   "^[2-9]" "$DB"
-
 
 run_test_match "diff_c2_c3" \
   "SELECT coalesce(sum(rows_added + rows_deleted + rows_modified), 0) FROM dolt_diff_stat((SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1), (SELECT commit_hash FROM dolt_log LIMIT 1), 't');" \
   "^[1-9]" "$DB"
 
-
 run_test "diff_same_commit" \
   "SELECT coalesce(sum(rows_added + rows_deleted + rows_modified), 0) FROM dolt_diff_stat((SELECT commit_hash FROM dolt_log LIMIT 1), (SELECT commit_hash FROM dolt_log LIMIT 1), 't');" \
   "0" "$DB"
 
-
 echo "INSERT INTO t VALUES(4,'uncommitted');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "diff_working" "SELECT count(*) FROM dolt_diff_t WHERE to_commit='WORKING';" "^[1-9]" "$DB"
-
 
 run_test_match "diff_type_added" \
   "SELECT diff_type FROM dolt_diff_t WHERE to_commit='WORKING' LIMIT 1;" "added" "$DB"
 
 echo "SELECT dolt_reset('--hard');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 echo "SELECT dolt_tag('v1', (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 2));" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_tag('v3', (SELECT commit_hash FROM dolt_log LIMIT 1));" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -404,17 +318,11 @@ run_test_match "diff_tags" \
   "SELECT coalesce(sum(rows_added + rows_deleted + rows_modified), 0) FROM dolt_diff_stat((SELECT tag_hash FROM dolt_tags WHERE tag_name='v1'), (SELECT tag_hash FROM dolt_tags WHERE tag_name='v3'), 't');" \
   "^[2-9]" "$DB"
 
-
 run_test "diff_log_count" "SELECT count(*) FROM dolt_log;" "4" "$DB"
-
 
 run_test "diff_tag_count" "SELECT count(*) FROM dolt_tags;" "2" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_edge_tagops_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(x INTEGER PRIMARY KEY);
@@ -422,42 +330,32 @@ INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','c1');
 INSERT INTO t VALUES(2); SELECT dolt_commit('-A','-m','c2');
 INSERT INTO t VALUES(3); SELECT dolt_commit('-A','-m','c3');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 echo "SELECT dolt_tag('old', (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 2));" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "tag_specific" "SELECT count(*) FROM dolt_tags WHERE tag_name='old';" "1" "$DB"
-
 
 echo "SELECT dolt_tag('latest');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_tag('also-latest');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "tag_multi_same" "SELECT count(*) FROM dolt_tags;" "3" "$DB"
 
-
 echo "SELECT dolt_tag('-d','also-latest');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "tag_deleted" "SELECT count(*) FROM dolt_tags;" "2" "$DB"
 run_test "tag_correct_remain" "SELECT count(*) FROM dolt_tags WHERE tag_name='latest';" "1" "$DB"
-
 
 run_test "tag_persist" "SELECT count(*) FROM dolt_tags WHERE tag_name='old';" "1" "$DB"
 run_test "tag_persist2" "SELECT tag_name FROM dolt_tags WHERE tag_name='latest';" "latest" "$DB"
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_edge_branch_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(x INTEGER PRIMARY KEY);
 INSERT INTO t VALUES(1);
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 echo "SELECT dolt_branch('b1');
 SELECT dolt_branch('b2');
 SELECT dolt_branch('b3');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "branch_multi" "SELECT count(*) FROM dolt_branches;" "4" "$DB"
-
 
 echo "SELECT dolt_checkout('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "branch_on_b1" "SELECT active_branch();" "b1" "$DB/b1"
@@ -468,14 +366,11 @@ run_test "branch_on_b2" "SELECT active_branch();" "b2" "$DB/b2"
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "branch_back_main" "SELECT active_branch();" "main" "$DB"
 
-
 echo "SELECT dolt_branch('-d','b2');
 SELECT dolt_branch('-d','b3');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "branch_after_delete" "SELECT count(*) FROM dolt_branches;" "2" "$DB"
 
-
 run_test_match "branch_names" "SELECT name FROM dolt_branches ORDER BY name;" "b1" "$DB"
-
 
 echo "SELECT dolt_checkout('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(99);
@@ -487,10 +382,6 @@ run_test "branch_b1_has_more" "SELECT dolt_checkout('b1'); SELECT count(*) FROM 
 2" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_edge_multiconflict_$$.db; rm -f "$DB"
 echo "CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
@@ -510,17 +401,14 @@ echo "UPDATE users SET name='alice_v2' WHERE id=1;
 UPDATE orders SET item='hat_v2' WHERE id=1;
 SELECT dolt_commit('-A','-m','main: v2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test_match "multi_conflict_merge" "SELECT dolt_merge('hotfix');" "conflict" "$DB"
 run_test_match "multi_conflict_count" \
   "BEGIN; SELECT dolt_merge('hotfix'); SELECT 'MC|' || count(*) FROM dolt_conflicts; ROLLBACK;" \
   "^MC\\|2$" "$DB"
 
-
 run_test_match "multi_conflict_blocked" \
   "BEGIN; SELECT dolt_merge('hotfix'); SELECT dolt_commit('-A','-m','fail');" \
   "cannot commit: unresolved merge conflicts|Use dolt_conflicts_resolve" "$DB"
-
 
 run_test_match "multi_conflict_users_ours" \
   "BEGIN; SELECT dolt_merge('hotfix'); SELECT dolt_conflicts_resolve('--ours','users'); SELECT 'U|' || name FROM users WHERE id=1; ROLLBACK;" \
@@ -533,10 +421,6 @@ run_test_match "multi_conflict_orders_ours" \
   "^O\\|hat_v2$" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_edge_conflictours_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -553,12 +437,10 @@ echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "UPDATE t SET v='main_val' WHERE id=1;
 SELECT dolt_commit('-A','-m','main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test_match "ours_conflict_merge" "SELECT dolt_merge('hf');" "conflict" "$DB"
 run_test_match "ours_conflict_exists" \
   "BEGIN; SELECT dolt_merge('hf'); SELECT 'OC|' || count(*) FROM dolt_conflicts; ROLLBACK;" \
   "^OC\\|1$" "$DB"
-
 
 run_test_match "ours_conflicts_cleared" \
   "SELECT dolt_merge('hf'); SELECT dolt_conflicts_resolve('--ours','t'); SELECT 'OCC|' || count(*) FROM dolt_conflicts;" \
@@ -575,12 +457,7 @@ run_test_match "ours_branch_ok" \
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_edge_bulk_$$.db; rm -f "$DB"
-
 
 SQL="CREATE TABLE big(id INTEGER PRIMARY KEY, v TEXT);"
 for i in $(seq 1 500); do
@@ -594,20 +471,14 @@ run_test "bulk_first" "SELECT v FROM big WHERE id=1;" "row_1" "$DB"
 run_test "bulk_last" "SELECT v FROM big WHERE id=500;" "row_500" "$DB"
 run_test "bulk_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 
-
 run_test "bulk_persist_count" "SELECT count(*) FROM big;" "500" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_edge_seqmerge_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'init');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 echo "SELECT dolt_branch('f1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('f1');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -616,14 +487,12 @@ echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "seqmerge_1" "SELECT dolt_merge('f1');" "^[0-9a-f]{40}$" "$DB"
 run_test "seqmerge_1_count" "SELECT count(*) FROM t;" "2" "$DB"
 
-
 echo "SELECT dolt_branch('f2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('f2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(3,'f2'); SELECT dolt_commit('-A','-m','f2');" | $DOLTLITE "$DB/f2" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "seqmerge_2" "SELECT dolt_merge('f2');" "^[0-9a-f]{40}$" "$DB"
 run_test "seqmerge_2_count" "SELECT count(*) FROM t;" "3" "$DB"
-
 
 echo "SELECT dolt_branch('f3');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('f3');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -633,10 +502,6 @@ run_test_match "seqmerge_3" "SELECT dolt_merge('f3');" "^[0-9a-f]{40}$" "$DB"
 run_test "seqmerge_3_count" "SELECT count(*) FROM t;" "4" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_edge_mergedel_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -648,7 +513,6 @@ SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 echo "SELECT dolt_branch('cleanup');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('cleanup');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 echo "DELETE FROM t WHERE id=2;
 DELETE FROM t WHERE id=4;
 SELECT dolt_commit('-A','-m','delete 2 and 4');" | $DOLTLITE "$DB/cleanup" > /dev/null 2>&1
@@ -664,10 +528,6 @@ run_test "mergedel_no_2" "SELECT count(*) FROM t WHERE id=2;" "0" "$DB"
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_edge_difftypes_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'keep');
@@ -675,25 +535,19 @@ INSERT INTO t VALUES(2,'modify');
 INSERT INTO t VALUES(3,'delete_me');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 echo "INSERT INTO t VALUES(4,'added');
 UPDATE t SET v='MODIFIED' WHERE id=2;
 DELETE FROM t WHERE id=3;" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test_match "difftype_working_count" "SELECT count(*) FROM dolt_diff_t WHERE to_commit='WORKING';" "^[1-9]" "$DB"
-
 
 echo "SELECT dolt_commit('-A','-m','mixed changes');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "difftype_clean" "SELECT count(*) FROM dolt_diff_t WHERE to_commit='WORKING';" "0" "$DB"
-
 
 run_test_match "difftype_commit_diff" \
   "SELECT coalesce(sum(rows_added + rows_deleted + rows_modified), 0) FROM dolt_diff_stat((SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1), (SELECT commit_hash FROM dolt_log LIMIT 1), 't');" \
   "^[1-9]" "$DB"
-
 
 echo "INSERT INTO t VALUES(5,'new_working');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "difftype_new_working" "SELECT count(*) FROM dolt_diff_t WHERE to_commit='WORKING';" "1" "$DB"
@@ -701,14 +555,9 @@ run_test_match "difftype_new_working_type" "SELECT diff_type FROM dolt_diff_t WH
 
 echo "SELECT dolt_reset('--hard');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "difftype_data_ok" "SELECT count(*) FROM dolt_log;" "3" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_edge_author_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(x INTEGER PRIMARY KEY);
@@ -718,7 +567,6 @@ SELECT dolt_commit('-A','-m','by author','--author','TestUser <test@user.com>');
 run_test "author_name" "SELECT committer FROM dolt_log LIMIT 1;" "TestUser" "$DB"
 run_test "author_email" "SELECT email FROM dolt_log LIMIT 1;" "test@user.com" "$DB"
 
-
 echo "INSERT INTO t VALUES(2);
 SELECT dolt_commit('-A','-m','by other','--author','Other <other@test.com>');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
@@ -727,12 +575,7 @@ run_test "author_other_email" "SELECT email FROM dolt_log LIMIT 1;" "other@test.
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_edge_persist_$$.db; rm -f "$DB"
-
 
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'round1');
@@ -744,30 +587,22 @@ SELECT dolt_commit('-A','-m','round2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(3,'round3');
 SELECT dolt_commit('-A','-m','round3');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "persist_count" "SELECT count(*) FROM t;" "3" "$DB"
 run_test "persist_log" "SELECT count(*) FROM dolt_log;" "4" "$DB"
 run_test "persist_branch" "SELECT active_branch();" "main" "$DB"
-
 
 echo "SELECT dolt_branch('dev');
 SELECT dolt_checkout('dev');
 INSERT INTO t VALUES(4,'round4_dev');
 SELECT dolt_commit('-A','-m','dev commit');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "persist_reopen_branch" "SELECT active_branch();" "dev" "$DB/dev"
 run_test "persist_reopen_data" "SELECT count(*) FROM t;" "4" "$DB/dev"
-
 
 run_test "persist_main_data" "SELECT dolt_checkout('main'); SELECT count(*) FROM t;" "0
 3" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_edge_types_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, i INTEGER, r REAL, t TEXT, b BLOB);
@@ -785,10 +620,6 @@ run_test "types_persist" "SELECT count(*) FROM t;" "3" "$DB"
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_edge_ancestor_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'base');
@@ -796,10 +627,8 @@ SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 echo "SELECT dolt_branch('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 echo "INSERT INTO t VALUES(2,'main1'); SELECT dolt_commit('-A','-m','main1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(3,'main2'); SELECT dolt_commit('-A','-m','main2');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(10,'feat1'); SELECT dolt_commit('-A','-m','feat1');" | $DOLTLITE "$DB/feat" > /dev/null 2>&1
@@ -807,52 +636,37 @@ echo "INSERT INTO t VALUES(11,'feat2'); SELECT dolt_commit('-A','-m','feat2');" 
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test_match "ancestor_merge" "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB"
 run_test "ancestor_all_rows" "SELECT count(*) FROM t;" "5" "$DB"
 run_test_match "ancestor_log" "SELECT message FROM dolt_log LIMIT 1;" "Merge" "$DB"
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_edge_status_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'orig');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "status_clean" "SELECT count(*) FROM dolt_status;" "0" "$DB"
-
 
 echo "UPDATE t SET v='changed' WHERE id=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "status_modified" "SELECT status FROM dolt_status;" "modified" "$DB"
 
-
 echo "CREATE TABLE t2(id INTEGER PRIMARY KEY);" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "status_new_table" "SELECT count(*) FROM dolt_status;" "^[2-3]" "$DB"
 
-
 echo "SELECT dolt_add('-A');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "status_all_staged" "SELECT count(*) FROM dolt_status WHERE staged=1;" "^[1-9]" "$DB"
-
 
 echo "SELECT dolt_commit('-m','changes');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "status_post_commit" "SELECT count(*) FROM dolt_status;" "0" "$DB"
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_edge_history_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'init');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 for i in $(seq 2 21); do
   echo "INSERT INTO t VALUES($i,'v$i'); SELECT dolt_commit('-A','-m','commit $i');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -862,14 +676,9 @@ run_test "history_count" "SELECT count(*) FROM dolt_log;" "22" "$DB"
 run_test "history_data" "SELECT count(*) FROM t;" "21" "$DB"
 run_test_match "history_first_msg" "SELECT message FROM dolt_log LIMIT 1;" "commit 21" "$DB"
 
-
 run_test "history_persist" "SELECT count(*) FROM dolt_log;" "22" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_edge_convergent_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -878,7 +687,6 @@ INSERT INTO t VALUES(2,'orig');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 echo "SELECT dolt_branch('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 echo "UPDATE t SET v='same_change' WHERE id=1;
 SELECT dolt_commit('-A','-m','main change');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -890,17 +698,12 @@ SELECT dolt_commit('-A','-m','feat change');" | $DOLTLITE "$DB/feat" > /dev/null
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test_match "convergent_merge" "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB"
 run_test "convergent_value" "SELECT v FROM t WHERE id=1;" "same_change" "$DB"
 run_test "convergent_feat_row" "SELECT v FROM t WHERE id=3;" "feat_only" "$DB"
 run_test "convergent_count" "SELECT count(*) FROM t;" "3" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_edge_tagstate_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -915,20 +718,14 @@ SELECT dolt_tag('v2.0');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "tagstate_two_tags" "SELECT count(*) FROM dolt_tags;" "2" "$DB"
 run_test "tagstate_current" "SELECT count(*) FROM t;" "2" "$DB"
 
-
 run_test_match "tagstate_diff_hashes" \
   "SELECT count(DISTINCT tag_hash) FROM dolt_tags;" "2" "$DB"
-
 
 run_test_match "tagstate_diff" \
   "SELECT coalesce(sum(rows_added + rows_deleted + rows_modified), 0) FROM dolt_diff_stat((SELECT tag_hash FROM dolt_tags WHERE tag_name='v1.0'), (SELECT tag_hash FROM dolt_tags WHERE tag_name='v2.0'), 't');" \
   "^[1-9]" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_edge_rapid_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -945,10 +742,6 @@ run_test "rapid_persist" "SELECT count(*) FROM t;" "5" "$DB"
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_edge_branchfrom_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'init');
@@ -959,30 +752,21 @@ echo "SELECT dolt_checkout('dev');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(2,'dev1');
 SELECT dolt_commit('-A','-m','dev1');" | $DOLTLITE "$DB/dev" > /dev/null 2>&1
 
-
 echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(3,'feature1');
 SELECT dolt_commit('-A','-m','feature1');" | $DOLTLITE "$DB/feature" > /dev/null 2>&1
 
-
 echo "SELECT dolt_checkout('dev');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "branchfrom_merge" "SELECT dolt_merge('feature');" "^[0-9a-f]{40}$" "$DB/dev"
 run_test "branchfrom_count" "SELECT count(*) FROM t;" "3" "$DB/dev"
 
-
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "branchfrom_main" "SELECT count(*) FROM t;" "1" "$DB"
-
 
 run_test_match "branchfrom_to_main" "SELECT dolt_merge('dev');" "^[0-9a-f]{40}$" "$DB"
 
 rm -f "$DB"
-
-
-
-
-
 
 echo ""
 echo "--- Virtual table errors for missing tables ---"
@@ -991,9 +775,6 @@ DB=/tmp/test_edge_vtab_err_$$.db; rm -f "$DB"
 echo "CREATE TABLE real_table(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO real_table VALUES(1,'x');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
-
-
 
 run_test_match "diff_schema_has_from_v" \
   "SELECT group_concat(name) FROM pragma_table_info('dolt_diff_real_table');" \
@@ -1007,7 +788,6 @@ run_test_match "history_schema_has_v" \
   "SELECT group_concat(name) FROM pragma_table_info('dolt_history_real_table');" \
   "\bv\b" "$DB"
 
-
 run_test_match "diff_table_real_works" \
   "SELECT count(*) FROM dolt_diff_real_table;" \
   "^[0-9]" "$DB"
@@ -1019,10 +799,6 @@ run_test_match "at_real_works" \
   "^[0-9]" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/doltlite_edge_cases.sh
+++ b/test/doltlite_edge_cases.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-#
-# Edge case and gap coverage tests for Doltlite.
-# 100+ tests covering: NULL handling, special characters, schema ops,
-# multi-table merges, error paths, complex workflows, boundary conditions.
-#
+
+
+
+
+
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
@@ -12,9 +12,9 @@ run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -
 echo "=== Doltlite Edge Case Tests ==="
 echo ""
 
-# ============================================================
-# Section 1: NULL value handling (10 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_edge_null_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, a TEXT, b INTEGER, c REAL);
@@ -27,20 +27,20 @@ run_test "null_select" "SELECT a FROM t WHERE id=1;" "" "$DB"
 run_test "null_count" "SELECT count(*) FROM t WHERE a IS NULL;" "1" "$DB"
 run_test "null_diff_count" "SELECT count(*) FROM dolt_diff_t WHERE to_commit='WORKING';" "0" "$DB"
 
-# Update NULL to value — check with working diff (uncommitted)
+
 echo "UPDATE t SET a='was_null' WHERE id=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "null_diff_shows" "SELECT count(*) FROM dolt_diff_t WHERE to_commit='WORKING';" "^[1-9]" "$DB"
 echo "SELECT dolt_commit('-A','-m','fill nulls');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "null_updated" "SELECT a FROM t WHERE id=1;" "was_null" "$DB"
 
-# Update value to NULL
+
 echo "UPDATE t SET a=NULL WHERE id=2;
 SELECT dolt_commit('-A','-m','set to null');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "val_to_null" "SELECT count(*) FROM t WHERE a IS NULL;" "1" "$DB"
 
-# NULL in merge scenario
+
 echo "SELECT dolt_branch('nullbranch');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('nullbranch');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "UPDATE t SET b=999 WHERE id=3; SELECT dolt_commit('-A','-m','branch change');" | $DOLTLITE "$DB/nullbranch" > /dev/null 2>&1
@@ -54,9 +54,9 @@ run_test "null_merge_unchanged" "SELECT a FROM t WHERE id=1;" "was_null" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 2: Empty strings and boundary values (8 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_edge_boundary_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT);
@@ -73,15 +73,15 @@ run_test "min_int" "SELECT val FROM t WHERE id=-9223372036854775808;" "minint" "
 run_test "boundary_count" "SELECT count(*) FROM t;" "4" "$DB"
 run_test "boundary_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 
-# Persist and reopen
+
 run_test "boundary_persist_max" "SELECT val FROM t WHERE id=9223372036854775807;" "maxint" "$DB"
 run_test "boundary_persist_min" "SELECT val FROM t WHERE id=-9223372036854775808;" "minint" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 3: Special characters in data (8 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_edge_chars_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT);
@@ -97,14 +97,14 @@ run_test "special_apostrophe" "SELECT val FROM t WHERE id=1;" "it's a test" "$DB
 run_test_match "special_newline" "SELECT length(val) FROM t WHERE id=2;" "^1[01]$" "$DB"
 run_test "special_count" "SELECT count(*) FROM t;" "5" "$DB"
 
-# Diff after modification — check WORKING diff before commit
+
 echo "UPDATE t SET val='updated' WHERE id=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "special_diff" "SELECT count(*) FROM dolt_diff_t WHERE to_commit='WORKING';" "^[1-9]" "$DB"
 echo "SELECT dolt_commit('-A','-m','update special');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "special_updated" "SELECT val FROM t WHERE id=1;" "updated" "$DB"
 
-# Branch and merge with special chars
+
 echo "SELECT dolt_branch('sp');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('sp');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(6,'sp_val'); SELECT dolt_commit('-A','-m','sp commit');" | $DOLTLITE "$DB/sp" > /dev/null 2>&1
@@ -117,9 +117,9 @@ run_test "special_merge_both" "SELECT val FROM t WHERE id=6;" "sp_val" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 4: Multi-table merge scenarios (10 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_edge_multitable_$$.db; rm -f "$DB"
 echo "CREATE TABLE a(id INTEGER PRIMARY KEY, x TEXT);
@@ -130,7 +130,7 @@ INSERT INTO b VALUES(1,'b1');
 INSERT INTO c VALUES(1,'c1');
 SELECT dolt_commit('-A','-m','init 3 tables');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Branch modifies table a and b, main modifies b and c
+
 echo "SELECT dolt_branch('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO a VALUES(2,'a2_feat');
@@ -151,15 +151,15 @@ run_test "multi_b2" "SELECT y FROM b WHERE id=2;" "b2_feat" "$DB"
 run_test "multi_b3" "SELECT y FROM b WHERE id=3;" "b3_main" "$DB"
 run_test "multi_c2" "SELECT z FROM c WHERE id=2;" "c2_main" "$DB"
 
-# Verify merge log
+
 run_test_match "multi_merge_log" "SELECT message FROM dolt_log LIMIT 1;" "Merge" "$DB"
 run_test "multi_merge_log_count" "SELECT count(*) FROM dolt_log;" "5" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 5: One branch creates new table, merge into main (6 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_edge_newtable_$$.db; rm -f "$DB"
 echo "CREATE TABLE base(id INTEGER PRIMARY KEY, v TEXT);
@@ -183,14 +183,14 @@ run_test "newtable_feat" "SELECT count(*) FROM feat_table;" "2" "$DB"
 run_test "newtable_feat_val" "SELECT f FROM feat_table WHERE id=1;" "feat1" "$DB"
 run_test "newtable_schema" "SELECT count(*) FROM sqlite_master WHERE type='table';" "2" "$DB"
 
-# Persists after reopen
+
 run_test "newtable_persist" "SELECT count(*) FROM feat_table;" "2" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 6: Fast-forward merge variations (6 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_edge_ff_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -206,74 +206,74 @@ SELECT dolt_commit('-A','-m','third');" | $DOLTLITE "$DB/ahead" > /dev/null 2>&1
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Main has no new commits, so merge should fast-forward
+
 run_test_match "ff_merge" "SELECT dolt_merge('ahead');" "^[0-9a-f]{40}$" "$DB"
 run_test "ff_data" "SELECT count(*) FROM t;" "3" "$DB"
 run_test "ff_row2" "SELECT v FROM t WHERE id=2;" "second" "$DB"
 run_test "ff_row3" "SELECT v FROM t WHERE id=3;" "third" "$DB"
 
-# Already up to date
+
 run_test "ff_already_uptodate" "SELECT dolt_merge('ahead');" "Already up to date" "$DB"
 
-# Merge self branch
+
 run_test "ff_self" "SELECT dolt_merge('main');" "Already up to date" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 7: Error handling paths (12 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_edge_errors_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'x');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Merge non-existent branch
+
 run_test_match "err_merge_noexist" "SELECT dolt_merge('nope');" "not found" "$DB"
 
-# Checkout non-existent branch / table
+
 run_test_match "err_checkout_noexist" "SELECT dolt_checkout('nope');" "no such branch or table" "$DB"
 
-# Branch already exists
+
 echo "SELECT dolt_branch('dup');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "err_branch_dup" "SELECT dolt_branch('dup');" "already exists" "$DB"
 
-# Delete current branch
+
 run_test_match "err_delete_current" "SELECT dolt_branch('-d','main');" "cannot delete" "$DB"
 
-# Commit with no changes
+
 run_test_match "err_commit_clean" "SELECT dolt_commit('-A','-m','empty');" "nothing to commit" "$DB"
 
-# Commit without message
+
 run_test_match "err_commit_nomsg" "SELECT dolt_commit('-A');" "require" "$DB"
 
-# Tag already exists
+
 echo "SELECT dolt_tag('v1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "err_tag_dup" "SELECT dolt_tag('v1');" "already exists" "$DB"
 
-# Delete non-existent tag
+
 run_test_match "err_tag_del_noexist" "SELECT dolt_tag('-d','nope');" "not found" "$DB"
 
-# Checkout with uncommitted changes (allowed, like Dolt SQL context)
+
 echo "INSERT INTO t VALUES(2,'dirty');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "checkout_dirty_allowed" "SELECT dolt_checkout('dup');" "0" "$DB"
 
-# Hard reset cleans it
+
 echo "SELECT dolt_reset('--hard');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "err_reset_cleaned" "SELECT count(*) FROM t;" "1" "$DB"
 
-# Conflicts resolve on table with no conflicts — returns 0 (success)
+
 run_test "err_resolve_none" "SELECT dolt_conflicts_resolve('--ours','t');" "0" "$DB"
 
-# dolt_diff on non-existent table returns empty
+
 run_test "err_diff_notable" "SELECT count(*) FROM dolt_diff WHERE table_name='nonexistent';" "0" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 8: Complex staging workflows (10 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_edge_staging_$$.db; rm -f "$DB"
 echo "CREATE TABLE a(id INTEGER PRIMARY KEY, v TEXT);
@@ -282,51 +282,51 @@ INSERT INTO a VALUES(1,'a1');
 INSERT INTO b VALUES(1,'b1');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Modify both tables
+
 echo "INSERT INTO a VALUES(2,'a2');
 INSERT INTO b VALUES(2,'b2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "stg_both_dirty" "SELECT count(*) FROM dolt_status;" "2" "$DB"
 
-# Stage only table a
+
 echo "SELECT dolt_add('a');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "stg_a_staged" "SELECT count(*) FROM dolt_status WHERE staged=1;" "1" "$DB"
 run_test "stg_b_unstaged" "SELECT count(*) FROM dolt_status WHERE staged=0;" "1" "$DB"
 
-# No-args reset (== --mixed) unstages a. (--soft with no target ref
-# is a no-op under git/Dolt semantics.)
+
+
 echo "SELECT dolt_reset();" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "stg_reset_unstages" "SELECT count(*) FROM dolt_status WHERE staged=1;" "0" "$DB"
 run_test "stg_data_kept" "SELECT count(*) FROM a;" "2" "$DB"
 
-# Stage a again, commit just a
+
 echo "SELECT dolt_add('a');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "stg_partial_commit" "SELECT dolt_commit('-m','just a');" "^[0-9a-f]{40}$" "$DB"
 
-# b should still be dirty
+
 run_test "stg_b_still_dirty" "SELECT count(*) FROM dolt_status;" "1" "$DB"
 run_test_match "stg_b_in_status" "SELECT table_name FROM dolt_status;" "b" "$DB"
 
-# Commit b
+
 run_test_match "stg_commit_b" "SELECT dolt_commit('-A','-m','now b');" "^[0-9a-f]{40}$" "$DB"
 run_test "stg_all_clean" "SELECT count(*) FROM dolt_status;" "0" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 9: Schema changes (ALTER TABLE) (8 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_edge_schema_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, name TEXT);
 INSERT INTO t VALUES(1,'Alice');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Add column
+
 echo "ALTER TABLE t ADD COLUMN email TEXT;
 UPDATE t SET email='alice@test.com' WHERE id=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Check working diff before commit (should show change)
+
 run_test_match "schema_diff_working" "SELECT count(*) FROM dolt_diff_t WHERE to_commit='WORKING';" "^[1-9]" "$DB"
 
 echo "SELECT dolt_commit('-A','-m','add email column');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -334,13 +334,13 @@ echo "SELECT dolt_commit('-A','-m','add email column');" | $DOLTLITE "$DB" > /de
 run_test "schema_new_col" "SELECT email FROM t WHERE id=1;" "alice@test.com" "$DB"
 run_test "schema_log" "SELECT count(*) FROM dolt_log;" "3" "$DB"
 
-# Insert with new column
+
 echo "INSERT INTO t VALUES(2,'Bob','bob@test.com');
 SELECT dolt_commit('-A','-m','add bob');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "schema_new_row" "SELECT email FROM t WHERE id=2;" "bob@test.com" "$DB"
 
-# Branch after schema change
+
 echo "SELECT dolt_branch('post-schema');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('post-schema');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(3,'Charlie','charlie@test.com');
@@ -357,9 +357,9 @@ run_test "schema_merge_dave" "SELECT email FROM t WHERE id=4;" "dave@test.com" "
 
 rm -f "$DB"
 
-# ============================================================
-# Section 10: Diff between specific commits (8 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_edge_diffhash_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -371,32 +371,32 @@ echo "INSERT INTO t VALUES(3,'third');
 UPDATE t SET v='FIRST' WHERE id=1;
 SELECT dolt_commit('-A','-m','c3');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Diff between c1 and c3 (should show changes)
+
 run_test_match "diff_c1_c3" \
   "SELECT coalesce(sum(rows_added + rows_deleted + rows_modified), 0) FROM dolt_diff_stat((SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 2), (SELECT commit_hash FROM dolt_log LIMIT 1), 't');" \
   "^[2-9]" "$DB"
 
-# Diff between c2 and c3
+
 run_test_match "diff_c2_c3" \
   "SELECT coalesce(sum(rows_added + rows_deleted + rows_modified), 0) FROM dolt_diff_stat((SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1), (SELECT commit_hash FROM dolt_log LIMIT 1), 't');" \
   "^[1-9]" "$DB"
 
-# Diff between same commit (should be 0)
+
 run_test "diff_same_commit" \
   "SELECT coalesce(sum(rows_added + rows_deleted + rows_modified), 0) FROM dolt_diff_stat((SELECT commit_hash FROM dolt_log LIMIT 1), (SELECT commit_hash FROM dolt_log LIMIT 1), 't');" \
   "0" "$DB"
 
-# Diff on working changes (no hashes = HEAD vs working)
+
 echo "INSERT INTO t VALUES(4,'uncommitted');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "diff_working" "SELECT count(*) FROM dolt_diff_t WHERE to_commit='WORKING';" "^[1-9]" "$DB"
 
-# Diff types present
+
 run_test_match "diff_type_added" \
   "SELECT diff_type FROM dolt_diff_t WHERE to_commit='WORKING' LIMIT 1;" "added" "$DB"
 
 echo "SELECT dolt_reset('--hard');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Diff between tags
+
 echo "SELECT dolt_tag('v1', (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 2));" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_tag('v3', (SELECT commit_hash FROM dolt_log LIMIT 1));" | $DOLTLITE "$DB" > /dev/null 2>&1
 
@@ -404,17 +404,17 @@ run_test_match "diff_tags" \
   "SELECT coalesce(sum(rows_added + rows_deleted + rows_modified), 0) FROM dolt_diff_stat((SELECT tag_hash FROM dolt_tags WHERE tag_name='v1'), (SELECT tag_hash FROM dolt_tags WHERE tag_name='v3'), 't');" \
   "^[2-9]" "$DB"
 
-# Verify log has 3 commits
+
 run_test "diff_log_count" "SELECT count(*) FROM dolt_log;" "4" "$DB"
 
-# Tag listing
+
 run_test "diff_tag_count" "SELECT count(*) FROM dolt_tags;" "2" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 11: Tag on specific commit and tag delete (6 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_edge_tagops_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(x INTEGER PRIMARY KEY);
@@ -422,43 +422,43 @@ INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','c1');
 INSERT INTO t VALUES(2); SELECT dolt_commit('-A','-m','c2');
 INSERT INTO t VALUES(3); SELECT dolt_commit('-A','-m','c3');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Tag specific commit (the first one)
+
 echo "SELECT dolt_tag('old', (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 2));" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "tag_specific" "SELECT count(*) FROM dolt_tags WHERE tag_name='old';" "1" "$DB"
 
-# Multiple tags on same commit
+
 echo "SELECT dolt_tag('latest');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_tag('also-latest');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "tag_multi_same" "SELECT count(*) FROM dolt_tags;" "3" "$DB"
 
-# Delete a tag
+
 echo "SELECT dolt_tag('-d','also-latest');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "tag_deleted" "SELECT count(*) FROM dolt_tags;" "2" "$DB"
 run_test "tag_correct_remain" "SELECT count(*) FROM dolt_tags WHERE tag_name='latest';" "1" "$DB"
 
-# Tag persists across reopen
+
 run_test "tag_persist" "SELECT count(*) FROM dolt_tags WHERE tag_name='old';" "1" "$DB"
 run_test "tag_persist2" "SELECT tag_name FROM dolt_tags WHERE tag_name='latest';" "latest" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 12: Branch management edge cases (8 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_edge_branch_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(x INTEGER PRIMARY KEY);
 INSERT INTO t VALUES(1);
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Create multiple branches
+
 echo "SELECT dolt_branch('b1');
 SELECT dolt_branch('b2');
 SELECT dolt_branch('b3');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "branch_multi" "SELECT count(*) FROM dolt_branches;" "4" "$DB"
 
-# Switch between branches rapidly
+
 echo "SELECT dolt_checkout('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "branch_on_b1" "SELECT active_branch();" "b1" "$DB/b1"
 
@@ -468,15 +468,15 @@ run_test "branch_on_b2" "SELECT active_branch();" "b2" "$DB/b2"
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "branch_back_main" "SELECT active_branch();" "main" "$DB"
 
-# Work on b1, then delete b2 and b3
+
 echo "SELECT dolt_branch('-d','b2');
 SELECT dolt_branch('-d','b3');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "branch_after_delete" "SELECT count(*) FROM dolt_branches;" "2" "$DB"
 
-# Branches in dolt_branches should show correct names
+
 run_test_match "branch_names" "SELECT name FROM dolt_branches ORDER BY name;" "b1" "$DB"
 
-# Commit on b1 doesn't affect main
+
 echo "SELECT dolt_checkout('b1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(99);
 SELECT dolt_commit('-A','-m','b1 commit');" | $DOLTLITE "$DB/b1" > /dev/null 2>&1
@@ -488,9 +488,9 @@ run_test "branch_b1_has_more" "SELECT dolt_checkout('b1'); SELECT count(*) FROM 
 
 rm -f "$DB"
 
-# ============================================================
-# Section 13: Conflict with multiple tables (7 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_edge_multiconflict_$$.db; rm -f "$DB"
 echo "CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
@@ -510,18 +510,18 @@ echo "UPDATE users SET name='alice_v2' WHERE id=1;
 UPDATE orders SET item='hat_v2' WHERE id=1;
 SELECT dolt_commit('-A','-m','main: v2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Merge should conflict on both tables in-session
+
 run_test_match "multi_conflict_merge" "SELECT dolt_merge('hotfix');" "conflict" "$DB"
 run_test_match "multi_conflict_count" \
   "BEGIN; SELECT dolt_merge('hotfix'); SELECT 'MC|' || count(*) FROM dolt_conflicts; ROLLBACK;" \
   "^MC\\|2$" "$DB"
 
-# Commit should be blocked in-session
+
 run_test_match "multi_conflict_blocked" \
   "BEGIN; SELECT dolt_merge('hotfix'); SELECT dolt_commit('-A','-m','fail');" \
   "cannot commit: unresolved merge conflicts|Use dolt_conflicts_resolve" "$DB"
 
-# Resolve users and orders with ours in the same session
+
 run_test_match "multi_conflict_users_ours" \
   "BEGIN; SELECT dolt_merge('hotfix'); SELECT dolt_conflicts_resolve('--ours','users'); SELECT 'U|' || name FROM users WHERE id=1; ROLLBACK;" \
   "^U\\|alice_v2$" "$DB"
@@ -534,9 +534,9 @@ run_test_match "multi_conflict_orders_ours" \
 
 rm -f "$DB"
 
-# ============================================================
-# Section 14: Conflict detection and --ours preservation (6 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_edge_conflictours_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -553,13 +553,13 @@ echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "UPDATE t SET v='main_val' WHERE id=1;
 SELECT dolt_commit('-A','-m','main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Merge and get conflict in-session
+
 run_test_match "ours_conflict_merge" "SELECT dolt_merge('hf');" "conflict" "$DB"
 run_test_match "ours_conflict_exists" \
   "BEGIN; SELECT dolt_merge('hf'); SELECT 'OC|' || count(*) FROM dolt_conflicts; ROLLBACK;" \
   "^OC\\|1$" "$DB"
 
-# Resolve with ours in-session
+
 run_test_match "ours_conflicts_cleared" \
   "SELECT dolt_merge('hf'); SELECT dolt_conflicts_resolve('--ours','t'); SELECT 'OCC|' || count(*) FROM dolt_conflicts;" \
   "^OCC\\|0$" "$DB"
@@ -575,13 +575,13 @@ run_test_match "ours_branch_ok" \
 
 rm -f "$DB"
 
-# ============================================================
-# Section 15: Large batch inserts and many rows (5 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_edge_bulk_$$.db; rm -f "$DB"
 
-# Insert 500 rows
+
 SQL="CREATE TABLE big(id INTEGER PRIMARY KEY, v TEXT);"
 for i in $(seq 1 500); do
   SQL="$SQL INSERT INTO big VALUES($i,'row_$i');"
@@ -594,21 +594,21 @@ run_test "bulk_first" "SELECT v FROM big WHERE id=1;" "row_1" "$DB"
 run_test "bulk_last" "SELECT v FROM big WHERE id=500;" "row_500" "$DB"
 run_test "bulk_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 
-# Persist and verify
+
 run_test "bulk_persist_count" "SELECT count(*) FROM big;" "500" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 16: Multiple sequential merges (6 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_edge_seqmerge_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'init');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Merge 1
+
 echo "SELECT dolt_branch('f1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('f1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(2,'f1'); SELECT dolt_commit('-A','-m','f1');" | $DOLTLITE "$DB/f1" > /dev/null 2>&1
@@ -616,7 +616,7 @@ echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "seqmerge_1" "SELECT dolt_merge('f1');" "^[0-9a-f]{40}$" "$DB"
 run_test "seqmerge_1_count" "SELECT count(*) FROM t;" "2" "$DB"
 
-# Merge 2
+
 echo "SELECT dolt_branch('f2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('f2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(3,'f2'); SELECT dolt_commit('-A','-m','f2');" | $DOLTLITE "$DB/f2" > /dev/null 2>&1
@@ -624,7 +624,7 @@ echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "seqmerge_2" "SELECT dolt_merge('f2');" "^[0-9a-f]{40}$" "$DB"
 run_test "seqmerge_2_count" "SELECT count(*) FROM t;" "3" "$DB"
 
-# Merge 3
+
 echo "SELECT dolt_branch('f3');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('f3');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(4,'f3'); SELECT dolt_commit('-A','-m','f3');" | $DOLTLITE "$DB/f3" > /dev/null 2>&1
@@ -634,9 +634,9 @@ run_test "seqmerge_3_count" "SELECT count(*) FROM t;" "4" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 17: Merge with row deletions from feature (4 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_edge_mergedel_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -648,7 +648,7 @@ SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 echo "SELECT dolt_branch('cleanup');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('cleanup');" | $DOLTLITE "$DB" > /dev/null 2>&1
-# Delete individual rows to avoid WHERE clause bug
+
 echo "DELETE FROM t WHERE id=2;
 DELETE FROM t WHERE id=4;
 SELECT dolt_commit('-A','-m','delete 2 and 4');" | $DOLTLITE "$DB/cleanup" > /dev/null 2>&1
@@ -664,9 +664,9 @@ run_test "mergedel_no_2" "SELECT count(*) FROM t WHERE id=2;" "0" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 18: Diff types with working changes (6 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_edge_difftypes_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -675,40 +675,40 @@ INSERT INTO t VALUES(2,'modify');
 INSERT INTO t VALUES(3,'delete_me');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Make uncommitted changes — diff shows HEAD vs working
+
 echo "INSERT INTO t VALUES(4,'added');
 UPDATE t SET v='MODIFIED' WHERE id=2;
 DELETE FROM t WHERE id=3;" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Working diff should show changes
+
 run_test_match "difftype_working_count" "SELECT count(*) FROM dolt_diff_t WHERE to_commit='WORKING';" "^[1-9]" "$DB"
 
-# Commit and verify between-commit diff
+
 echo "SELECT dolt_commit('-A','-m','mixed changes');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# After commit, HEAD vs working should be clean
+
 run_test "difftype_clean" "SELECT count(*) FROM dolt_diff_t WHERE to_commit='WORKING';" "0" "$DB"
 
-# Diff between the two commits should show changes
+
 run_test_match "difftype_commit_diff" \
   "SELECT coalesce(sum(rows_added + rows_deleted + rows_modified), 0) FROM dolt_diff_stat((SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1), (SELECT commit_hash FROM dolt_log LIMIT 1), 't');" \
   "^[1-9]" "$DB"
 
-# Make another working change
+
 echo "INSERT INTO t VALUES(5,'new_working');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "difftype_new_working" "SELECT count(*) FROM dolt_diff_t WHERE to_commit='WORKING';" "1" "$DB"
 run_test_match "difftype_new_working_type" "SELECT diff_type FROM dolt_diff_t WHERE to_commit='WORKING';" "added" "$DB"
 
 echo "SELECT dolt_reset('--hard');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Verify data integrity
+
 run_test "difftype_data_ok" "SELECT count(*) FROM dolt_log;" "3" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 19: dolt_commit --author flag (4 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_edge_author_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(x INTEGER PRIMARY KEY);
@@ -718,7 +718,7 @@ SELECT dolt_commit('-A','-m','by author','--author','TestUser <test@user.com>');
 run_test "author_name" "SELECT committer FROM dolt_log LIMIT 1;" "TestUser" "$DB"
 run_test "author_email" "SELECT email FROM dolt_log LIMIT 1;" "test@user.com" "$DB"
 
-# Second commit with different author
+
 echo "INSERT INTO t VALUES(2);
 SELECT dolt_commit('-A','-m','by other','--author','Other <other@test.com>');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
@@ -727,13 +727,13 @@ run_test "author_other_email" "SELECT email FROM dolt_log LIMIT 1;" "other@test.
 
 rm -f "$DB"
 
-# ============================================================
-# Section 20: Persistence stress test (6 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_edge_persist_$$.db; rm -f "$DB"
 
-# Create structure, commit, close, reopen multiple times
+
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'round1');
 SELECT dolt_commit('-A','-m','round1');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -744,30 +744,30 @@ SELECT dolt_commit('-A','-m','round2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(3,'round3');
 SELECT dolt_commit('-A','-m','round3');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Verify after multiple commits (each is a separate session/reopen)
+
 run_test "persist_count" "SELECT count(*) FROM t;" "3" "$DB"
 run_test "persist_log" "SELECT count(*) FROM dolt_log;" "4" "$DB"
 run_test "persist_branch" "SELECT active_branch();" "main" "$DB"
 
-# Create branch and commit on it
+
 echo "SELECT dolt_branch('dev');
 SELECT dolt_checkout('dev');
 INSERT INTO t VALUES(4,'round4_dev');
 SELECT dolt_commit('-A','-m','dev commit');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Reopen dev explicitly and verify its data
+
 run_test "persist_reopen_branch" "SELECT active_branch();" "dev" "$DB/dev"
 run_test "persist_reopen_data" "SELECT count(*) FROM t;" "4" "$DB/dev"
 
-# Switch back to main and verify
+
 run_test "persist_main_data" "SELECT dolt_checkout('main'); SELECT count(*) FROM t;" "0
 3" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 21: Multiple data types (6 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_edge_types_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, i INTEGER, r REAL, t TEXT, b BLOB);
@@ -785,9 +785,9 @@ run_test "types_persist" "SELECT count(*) FROM t;" "3" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 22: Merge base and ancestry (4 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_edge_ancestor_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -796,64 +796,64 @@ SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 echo "SELECT dolt_branch('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Two commits on main
+
 echo "INSERT INTO t VALUES(2,'main1'); SELECT dolt_commit('-A','-m','main1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(3,'main2'); SELECT dolt_commit('-A','-m','main2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Two commits on feat
+
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(10,'feat1'); SELECT dolt_commit('-A','-m','feat1');" | $DOLTLITE "$DB/feat" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(11,'feat2'); SELECT dolt_commit('-A','-m','feat2');" | $DOLTLITE "$DB/feat" > /dev/null 2>&1
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Both branches diverged from common ancestor — merge should work
+
 run_test_match "ancestor_merge" "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB"
 run_test "ancestor_all_rows" "SELECT count(*) FROM t;" "5" "$DB"
 run_test_match "ancestor_log" "SELECT message FROM dolt_log LIMIT 1;" "Merge" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 23: Status shows correct change types (5 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_edge_status_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'orig');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# No changes — clean
+
 run_test "status_clean" "SELECT count(*) FROM dolt_status;" "0" "$DB"
 
-# Modify a row
+
 echo "UPDATE t SET v='changed' WHERE id=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "status_modified" "SELECT status FROM dolt_status;" "modified" "$DB"
 
-# Create new table
+
 echo "CREATE TABLE t2(id INTEGER PRIMARY KEY);" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "status_new_table" "SELECT count(*) FROM dolt_status;" "^[2-3]" "$DB"
 
-# Stage everything, status should show staged
+
 echo "SELECT dolt_add('-A');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "status_all_staged" "SELECT count(*) FROM dolt_status WHERE staged=1;" "^[1-9]" "$DB"
 
-# Commit clears everything
+
 echo "SELECT dolt_commit('-m','changes');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "status_post_commit" "SELECT count(*) FROM dolt_status;" "0" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 24: Long commit history (4 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_edge_history_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'init');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Create 20 commits
+
 for i in $(seq 2 21); do
   echo "INSERT INTO t VALUES($i,'v$i'); SELECT dolt_commit('-A','-m','commit $i');" | $DOLTLITE "$DB" > /dev/null 2>&1
 done
@@ -862,14 +862,14 @@ run_test "history_count" "SELECT count(*) FROM dolt_log;" "22" "$DB"
 run_test "history_data" "SELECT count(*) FROM t;" "21" "$DB"
 run_test_match "history_first_msg" "SELECT message FROM dolt_log LIMIT 1;" "commit 21" "$DB"
 
-# Persist and verify
+
 run_test "history_persist" "SELECT count(*) FROM dolt_log;" "22" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 25: Merge convergent changes (4 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_edge_convergent_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -879,7 +879,7 @@ SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 echo "SELECT dolt_branch('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Both branches make SAME change to row 1 (convergent)
+
 echo "UPDATE t SET v='same_change' WHERE id=1;
 SELECT dolt_commit('-A','-m','main change');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
@@ -890,7 +890,7 @@ SELECT dolt_commit('-A','-m','feat change');" | $DOLTLITE "$DB/feat" > /dev/null
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Convergent change should not conflict
+
 run_test_match "convergent_merge" "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB"
 run_test "convergent_value" "SELECT v FROM t WHERE id=1;" "same_change" "$DB"
 run_test "convergent_feat_row" "SELECT v FROM t WHERE id=3;" "feat_only" "$DB"
@@ -898,9 +898,9 @@ run_test "convergent_count" "SELECT count(*) FROM t;" "3" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 26: Tag then checkout to tagged commit state (4 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_edge_tagstate_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -915,20 +915,20 @@ SELECT dolt_tag('v2.0');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "tagstate_two_tags" "SELECT count(*) FROM dolt_tags;" "2" "$DB"
 run_test "tagstate_current" "SELECT count(*) FROM t;" "2" "$DB"
 
-# Tags have different hashes
+
 run_test_match "tagstate_diff_hashes" \
   "SELECT count(DISTINCT tag_hash) FROM dolt_tags;" "2" "$DB"
 
-# Diff between tags should show changes
+
 run_test_match "tagstate_diff" \
   "SELECT coalesce(sum(rows_added + rows_deleted + rows_modified), 0) FROM dolt_diff_stat((SELECT tag_hash FROM dolt_tags WHERE tag_name='v1.0'), (SELECT tag_hash FROM dolt_tags WHERE tag_name='v2.0'), 't');" \
   "^[1-9]" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 27: Rapid insert-commit cycles (4 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_edge_rapid_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -945,9 +945,9 @@ run_test "rapid_persist" "SELECT count(*) FROM t;" "5" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 28: Branch from non-main, merge back (4 tests)
-# ============================================================
+
+
+
 
 DB=/tmp/test_edge_branchfrom_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -959,30 +959,30 @@ echo "SELECT dolt_checkout('dev');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(2,'dev1');
 SELECT dolt_commit('-A','-m','dev1');" | $DOLTLITE "$DB/dev" > /dev/null 2>&1
 
-# Branch from dev (not main!)
+
 echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(3,'feature1');
 SELECT dolt_commit('-A','-m','feature1');" | $DOLTLITE "$DB/feature" > /dev/null 2>&1
 
-# Merge feature back into dev
+
 echo "SELECT dolt_checkout('dev');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "branchfrom_merge" "SELECT dolt_merge('feature');" "^[0-9a-f]{40}$" "$DB/dev"
 run_test "branchfrom_count" "SELECT count(*) FROM t;" "3" "$DB/dev"
 
-# Main should still only have 1 row
+
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "branchfrom_main" "SELECT count(*) FROM t;" "1" "$DB"
 
-# Merge dev into main
+
 run_test_match "branchfrom_to_main" "SELECT dolt_merge('dev');" "^[0-9a-f]{40}$" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Virtual table error on nonexistent table (regression: previously
-# these fell back to generic schemas instead of erroring)
-# ============================================================
+
+
+
+
 
 echo ""
 echo "--- Virtual table errors for missing tables ---"
@@ -992,9 +992,9 @@ echo "CREATE TABLE real_table(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO real_table VALUES(1,'x');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Schema must use real column names (from_v, to_v), not generic fallback
-# names (from_value, to_value). The fallback was removed — if column
-# detection fails, the vtable now returns an error instead.
+
+
+
 run_test_match "diff_schema_has_from_v" \
   "SELECT group_concat(name) FROM pragma_table_info('dolt_diff_real_table');" \
   "from_v" "$DB"
@@ -1007,7 +1007,7 @@ run_test_match "history_schema_has_v" \
   "SELECT group_concat(name) FROM pragma_table_info('dolt_history_real_table');" \
   "\bv\b" "$DB"
 
-# Virtual tables work with real data
+
 run_test_match "diff_table_real_works" \
   "SELECT count(*) FROM dolt_diff_real_table;" \
   "^[0-9]" "$DB"
@@ -1020,9 +1020,9 @@ run_test_match "at_real_works" \
 
 rm -f "$DB"
 
-# ============================================================
-# Done
-# ============================================================
+
+
+
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/doltlite_feature_deep.sh
+++ b/test/doltlite_feature_deep.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-#
-# Deep coverage tests for recent features: cherry-pick, revert, GC,
-# per-row conflicts, dolt_diff_<table>, dolt_history_<table>,
-# and dolt_merge_base.
-#
+
+
+
+
+
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
@@ -14,9 +14,9 @@ db_rm() { rm -f "$1" "${1}-wal"; }
 echo "=== Deep Feature Coverage Tests ==="
 echo ""
 
-# ============================================================
-# Cherry-pick: pick a commit that adds a new table
-# ============================================================
+
+
+
 
 DB=/tmp/test_deep_cp_newtbl_$$.db; db_rm "$DB"
 echo "CREATE TABLE base(id INTEGER PRIMARY KEY, v TEXT);
@@ -42,9 +42,9 @@ run_test "cp_newtbl_extra_val" "SELECT w FROM extra WHERE id=1;" "new" "$DB"
 
 db_rm "$DB"
 
-# ============================================================
-# Cherry-pick: pick same commit twice (should conflict/no-op)
-# ============================================================
+
+
+
 
 DB=/tmp/test_deep_cp_twice_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -59,7 +59,7 @@ SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_cherry_pick('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "cp_twice_first" "SELECT count(*) FROM t;" "2" "$DB"
 
-# Second cherry-pick of same commit — row 2 already exists, should be convergent or no-op
+
 run_test_match "cp_twice_second" \
   "SELECT dolt_cherry_pick('feat');" \
   "^[0-9a-f]{40}$" "$DB"
@@ -67,9 +67,9 @@ run_test "cp_twice_still2" "SELECT count(*) FROM t;" "2" "$DB"
 
 db_rm "$DB"
 
-# ============================================================
-# Revert: revert an INSERT, verify row gone
-# ============================================================
+
+
+
 
 DB=/tmp/test_deep_rv_insert_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -87,9 +87,9 @@ run_test "rv_insert_kept" "SELECT v FROM t WHERE id=1;" "keep" "$DB"
 
 db_rm "$DB"
 
-# ============================================================
-# Revert: revert preserves later additions
-# ============================================================
+
+
+
 
 DB=/tmp/test_deep_rv_preserve_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -100,7 +100,7 @@ SELECT dolt_commit('-A','-m','c2: add row 2');
 INSERT INTO t VALUES(3,'c');
 SELECT dolt_commit('-A','-m','c3: add row 3');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Revert c2 (added row 2) — row 3 should survive
+
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 C2=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1;" | $DOLTLITE "$DB" 2>&1)
 
@@ -111,16 +111,16 @@ run_test "rv_preserve_has1" "SELECT v FROM t WHERE id=1;" "a" "$DB"
 
 db_rm "$DB"
 
-# ============================================================
-# GC: verify file size decreases after branch delete + GC
-# ============================================================
+
+
+
 
 DB=/tmp/test_deep_gc_size_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Create branch with lots of data
+
 echo "SELECT dolt_branch('big');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('big');" | $DOLTLITE "$DB" > /dev/null 2>&1
 SQL=""; for i in $(seq 2 100); do SQL="$SQL INSERT INTO t VALUES($i,'row_$i');"; done
@@ -141,9 +141,9 @@ run_test "gc_size_branch" "SELECT count(*) FROM dolt_branches;" "1" "$DB"
 
 db_rm "$DB"
 
-# ============================================================
-# GC: doesn't break dolt_log traversal
-# ============================================================
+
+
+
 
 DB=/tmp/test_deep_gc_log_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -162,9 +162,9 @@ run_test "gc_log_last" "SELECT message FROM dolt_log LIMIT 1 OFFSET 2;" "c1" "$D
 
 db_rm "$DB"
 
-# ============================================================
-# GC: doesn't break dolt_diff between commits
-# ============================================================
+
+
+
 
 DB=/tmp/test_deep_gc_diff_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -181,9 +181,9 @@ run_test_match "gc_diff_works" \
 
 db_rm "$DB"
 
-# ============================================================
-# Conflict rows: resolve then make further changes
-# ============================================================
+
+
+
 
 DB=/tmp/test_deep_cfr_further_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -201,7 +201,7 @@ SELECT dolt_merge('hf');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 echo "DELETE FROM dolt_conflicts_t WHERE base_id=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Now make more changes and commit
+
 echo "INSERT INTO t VALUES(3,'new_after_resolve');
 SELECT dolt_commit('-A','-m','post-resolve');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
@@ -212,9 +212,9 @@ run_test "cfr_further_clean" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
 
 db_rm "$DB"
 
-# ============================================================
-# Conflict rows: persist across reopen, resolve, then reopen again
-# ============================================================
+
+
+
 
 DB=/tmp/test_deep_cfr_reopen_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -229,19 +229,19 @@ UPDATE t SET v='main' WHERE id=1;
 SELECT dolt_commit('-A','-m','main');
 SELECT dolt_merge('hf');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Reopen after autocommit conflict rollback — session should be clean
+
 run_test "cfr_reopen_exists" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
 run_test "cfr_reopen_row" "SELECT count(*) FROM dolt_conflicts_t;" "0" "$DB"
 
-# Reopen again — should still be clean
+
 run_test "cfr_reopen_clean" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
 run_test "cfr_reopen_val" "SELECT v FROM t WHERE id=1;" "main" "$DB"
 
 db_rm "$DB"
 
-# ============================================================
-# dolt_diff_<table>: shows delete operations
-# ============================================================
+
+
+
 
 DB=/tmp/test_deep_dt_delete_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -258,9 +258,9 @@ run_test "dt_delete_total" "SELECT count(*) FROM dolt_diff_t;" "4" "$DB"
 
 db_rm "$DB"
 
-# ============================================================
-# dolt_diff_<table>: shows updates as "modified"
-# ============================================================
+
+
+
 
 DB=/tmp/test_deep_dt_update_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -275,9 +275,9 @@ run_test_match "dt_update_mod" \
 
 db_rm "$DB"
 
-# ============================================================
-# dolt_diff_<table>: multiple tables tracked independently
-# ============================================================
+
+
+
 
 DB=/tmp/test_deep_dt_multi_$$.db; db_rm "$DB"
 echo "CREATE TABLE a(id INTEGER PRIMARY KEY, x TEXT);
@@ -288,16 +288,16 @@ INSERT INTO b VALUES(1,'b1');
 INSERT INTO b VALUES(2,'b2');
 SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# a has 1 row added in c1, unchanged in c2
+
 run_test "dt_multi_a" "SELECT count(*) FROM dolt_diff_a;" "1" "$DB"
-# b has 2 rows added in c2
+
 run_test "dt_multi_b" "SELECT count(*) FROM dolt_diff_b;" "2" "$DB"
 
 db_rm "$DB"
 
-# ============================================================
-# dolt_diff_<table>: from_commit is parent, to_commit is child
-# ============================================================
+
+
+
 
 DB=/tmp/test_deep_dt_commits_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -306,20 +306,20 @@ SELECT dolt_commit('-A','-m','c1');
 INSERT INTO t VALUES(2,'b');
 SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# The "added row 2" audit entry should have from=c1, to=c2
+
 run_test_match "dt_commits_from" \
   "SELECT from_commit FROM dolt_diff_t WHERE to_v IS NOT NULL LIMIT 1;" "^[0-9a-f]{40}$" "$DB"
 run_test_match "dt_commits_to" \
   "SELECT to_commit FROM dolt_diff_t WHERE to_v IS NOT NULL LIMIT 1;" "^[0-9a-f]{40}$" "$DB"
-# from and to should be different commits
+
 run_test_match "dt_commits_diff" \
   "SELECT CASE WHEN from_commit != to_commit THEN 'different' ELSE 'same' END FROM dolt_diff_t WHERE to_v IS NOT NULL LIMIT 1;" "different" "$DB"
 
 db_rm "$DB"
 
-# ============================================================
-# dolt_diff_<table>: survives GC
-# ============================================================
+
+
+
 
 DB=/tmp/test_deep_dt_gc_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -335,9 +335,9 @@ run_test_match "dt_gc_has_added" "SELECT count(*) FROM dolt_diff_t WHERE diff_ty
 
 db_rm "$DB"
 
-# ============================================================
-# dolt_history_<table>: row count grows with commits
-# ============================================================
+
+
+
 
 DB=/tmp/test_deep_ht_grow_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -349,20 +349,20 @@ run_test "ht_grow_1" "SELECT count(*) FROM dolt_history_t;" "1" "$DB"
 echo "INSERT INTO t VALUES(2,'v2');
 SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# c1: 1 row, c2: 2 rows → 3 total
+
 run_test "ht_grow_2" "SELECT count(*) FROM dolt_history_t;" "3" "$DB"
 
 echo "INSERT INTO t VALUES(3,'v3');
 SELECT dolt_commit('-A','-m','c3');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# c1: 1, c2: 2, c3: 3 → 6 total
+
 run_test "ht_grow_3" "SELECT count(*) FROM dolt_history_t;" "6" "$DB"
 
 db_rm "$DB"
 
-# ============================================================
-# dolt_history_<table>: deleted rows don't appear in later commits
-# ============================================================
+
+
+
 
 DB=/tmp/test_deep_ht_deleted_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -372,18 +372,18 @@ SELECT dolt_commit('-A','-m','c1');
 DELETE FROM t WHERE id=2;
 SELECT dolt_commit('-A','-m','c2: delete row 2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# c1: rows 1,2 (2 rows), c2: row 1 only (1 row) → 3 total
+
 run_test "ht_deleted_total" "SELECT count(*) FROM dolt_history_t;" "3" "$DB"
-# Row 2 appears in 1 commit only (c1)
+
 run_test "ht_deleted_row2" "SELECT count(*) FROM dolt_history_t WHERE id=2;" "1" "$DB"
-# Row 1 appears in both
+
 run_test "ht_deleted_row1" "SELECT count(*) FROM dolt_history_t WHERE id=1;" "2" "$DB"
 
 db_rm "$DB"
 
-# ============================================================
-# dolt_history_<table>: different values per commit
-# ============================================================
+
+
+
 
 DB=/tmp/test_deep_ht_versions_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -394,20 +394,20 @@ SELECT dolt_commit('-A','-m','c2');
 UPDATE t SET v='version_3' WHERE id=1;
 SELECT dolt_commit('-A','-m','c3');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# 3 versions of row 1
+
 run_test "ht_versions_count" "SELECT count(*) FROM dolt_history_t WHERE id=1;" "3" "$DB"
-# Each has a different commit hash
+
 run_test "ht_versions_distinct" \
   "SELECT count(DISTINCT commit_hash) FROM dolt_history_t WHERE id=1;" "3" "$DB"
-# Values should be blobs (different at each commit)
+
 run_test "ht_versions_blobs" \
   "SELECT count(DISTINCT v) FROM dolt_history_t WHERE id=1;" "3" "$DB"
 
 db_rm "$DB"
 
-# ============================================================
-# dolt_history_<table>: survives GC
-# ============================================================
+
+
+
 
 DB=/tmp/test_deep_ht_gc_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -423,9 +423,9 @@ run_test "ht_gc_commits" "SELECT count(DISTINCT commit_hash) FROM dolt_history_t
 
 db_rm "$DB"
 
-# ============================================================
-# dolt_history_<table>: works after merge
-# ============================================================
+
+
+
 
 DB=/tmp/test_deep_ht_merge_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -440,19 +440,19 @@ INSERT INTO t VALUES(3,'main');
 SELECT dolt_commit('-A','-m','main');
 SELECT dolt_merge('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# After merge, history should include merged data
+
 run_test_match "ht_merge_total" "SELECT count(*) FROM dolt_history_t;" "^[6-9]" "$DB"
 
-# The merge commit should have all 3 rows
+
 MERGE_HASH=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1;" | $DOLTLITE "$DB" 2>&1)
 run_test "ht_merge_latest" \
   "SELECT count(*) FROM dolt_history_t WHERE commit_hash='$MERGE_HASH';" "3" "$DB"
 
 db_rm "$DB"
 
-# ============================================================
-# dolt_merge_base: basic functionality
-# ============================================================
+
+
+
 
 DB=/tmp/test_deep_mb_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -471,15 +471,15 @@ FEAT_HEAD=$(echo "SELECT hash FROM dolt_branches WHERE name='feat';" | $DOLTLITE
 
 run_test_match "mb_basic" "SELECT dolt_merge_base('$MAIN_HEAD','$FEAT_HEAD');" "^[0-9a-f]{40}$" "$DB"
 
-# Merge base should be the init commit (oldest)
+
 INIT_HASH=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1;" | $DOLTLITE "$DB" 2>&1)
 run_test "mb_is_init" "SELECT dolt_merge_base('$MAIN_HEAD','$FEAT_HEAD');" "$INIT_HASH" "$DB"
 
 db_rm "$DB"
 
-# ============================================================
-# dolt_merge_base: same commit returns itself
-# ============================================================
+
+
+
 
 DB=/tmp/test_deep_mb_self_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
@@ -491,9 +491,9 @@ run_test "mb_self" "SELECT dolt_merge_base('$HEAD','$HEAD');" "$HEAD" "$DB"
 
 db_rm "$DB"
 
-# ============================================================
-# dolt_merge_base: ancestor of linear history
-# ============================================================
+
+
+
 
 DB=/tmp/test_deep_mb_linear_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
@@ -507,14 +507,14 @@ SELECT dolt_commit('-A','-m','c3');" | $DOLTLITE "$DB" > /dev/null 2>&1
 C1=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 2;" | $DOLTLITE "$DB" 2>&1)
 C3=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1;" | $DOLTLITE "$DB" 2>&1)
 
-# Ancestor of c1 and c3 in linear history is c1
+
 run_test "mb_linear" "SELECT dolt_merge_base('$C1','$C3');" "$C1" "$DB"
 
 db_rm "$DB"
 
-# ============================================================
-# Cherry-pick: pick onto different branch
-# ============================================================
+
+
+
 
 DB=/tmp/test_deep_cp_branch_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -529,7 +529,7 @@ SELECT dolt_checkout('b');
 INSERT INTO t VALUES(20,'from_b');
 SELECT dolt_commit('-A','-m','b adds row 20');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Cherry-pick a's commit onto b
+
 echo "SELECT dolt_checkout('a');" | $DOLTLITE "$DB" > /dev/null 2>&1
 A_HASH=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1;" | $DOLTLITE "$DB/a" 2>&1)
 echo "SELECT dolt_checkout('b');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -541,16 +541,16 @@ run_test "cp_branch_has20" "SELECT v FROM t WHERE id=20;" "from_b" "$DB/b"
 
 db_rm "$DB"
 
-# ============================================================
-# GC after revert: reverted data becomes garbage
-# ============================================================
+
+
+
 
 DB=/tmp/test_deep_gc_revert_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'init');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Add 50 rows then revert
+
 SQL=""; for i in $(seq 2 51); do SQL="$SQL INSERT INTO t VALUES($i,'row_$i');"; done
 echo "$SQL SELECT dolt_commit('-A','-m','add 50 rows');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
@@ -565,9 +565,9 @@ run_test "gc_revert_log" "SELECT count(*) FROM dolt_log;" "4" "$DB"
 
 db_rm "$DB"
 
-# ============================================================
-# dolt_history + dolt_diff consistency
-# ============================================================
+
+
+
 
 DB=/tmp/test_deep_consistency_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -577,21 +577,21 @@ SELECT dolt_commit('-A','-m','c1');
 INSERT INTO t VALUES(3,'c');
 SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# History should have c1(2 rows) + c2(3 rows) = 5 rows
+
 run_test "consist_history" "SELECT count(*) FROM dolt_history_t;" "5" "$DB"
 
-# Diff should have c1(2 added) + c2(1 added) = 3 changes
+
 run_test "consist_diff" "SELECT count(*) FROM dolt_diff_t;" "3" "$DB"
 
-# Number of distinct commits should match
+
 run_test "consist_commits_hist" "SELECT count(DISTINCT commit_hash) FROM dolt_history_t;" "2" "$DB"
 run_test "consist_commits_diff" "SELECT count(DISTINCT to_commit) FROM dolt_diff_t;" "2" "$DB"
 
 db_rm "$DB"
 
-# ============================================================
-# Done
-# ============================================================
+
+
+
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/doltlite_feature_deep.sh
+++ b/test/doltlite_feature_deep.sh
@@ -1,9 +1,4 @@
 #!/bin/bash
-
-
-
-
-
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
@@ -13,10 +8,6 @@ db_rm() { rm -f "$1" "${1}-wal"; }
 
 echo "=== Deep Feature Coverage Tests ==="
 echo ""
-
-
-
-
 
 DB=/tmp/test_deep_cp_newtbl_$$.db; db_rm "$DB"
 echo "CREATE TABLE base(id INTEGER PRIMARY KEY, v TEXT);
@@ -42,10 +33,6 @@ run_test "cp_newtbl_extra_val" "SELECT w FROM extra WHERE id=1;" "new" "$DB"
 
 db_rm "$DB"
 
-
-
-
-
 DB=/tmp/test_deep_cp_twice_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'init');
@@ -59,17 +46,12 @@ SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_cherry_pick('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "cp_twice_first" "SELECT count(*) FROM t;" "2" "$DB"
 
-
 run_test_match "cp_twice_second" \
   "SELECT dolt_cherry_pick('feat');" \
   "^[0-9a-f]{40}$" "$DB"
 run_test "cp_twice_still2" "SELECT count(*) FROM t;" "2" "$DB"
 
 db_rm "$DB"
-
-
-
-
 
 DB=/tmp/test_deep_rv_insert_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -87,10 +69,6 @@ run_test "rv_insert_kept" "SELECT v FROM t WHERE id=1;" "keep" "$DB"
 
 db_rm "$DB"
 
-
-
-
-
 DB=/tmp/test_deep_rv_preserve_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
@@ -99,7 +77,6 @@ INSERT INTO t VALUES(2,'b');
 SELECT dolt_commit('-A','-m','c2: add row 2');
 INSERT INTO t VALUES(3,'c');
 SELECT dolt_commit('-A','-m','c3: add row 3');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 C2=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1;" | $DOLTLITE "$DB" 2>&1)
@@ -111,15 +88,10 @@ run_test "rv_preserve_has1" "SELECT v FROM t WHERE id=1;" "a" "$DB"
 
 db_rm "$DB"
 
-
-
-
-
 DB=/tmp/test_deep_gc_size_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 echo "SELECT dolt_branch('big');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('big');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -141,10 +113,6 @@ run_test "gc_size_branch" "SELECT count(*) FROM dolt_branches;" "1" "$DB"
 
 db_rm "$DB"
 
-
-
-
-
 DB=/tmp/test_deep_gc_log_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
@@ -162,10 +130,6 @@ run_test "gc_log_last" "SELECT message FROM dolt_log LIMIT 1 OFFSET 2;" "c1" "$D
 
 db_rm "$DB"
 
-
-
-
-
 DB=/tmp/test_deep_gc_diff_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
@@ -180,10 +144,6 @@ run_test_match "gc_diff_works" \
   "^1$" "$DB"
 
 db_rm "$DB"
-
-
-
-
 
 DB=/tmp/test_deep_cfr_further_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -201,7 +161,6 @@ SELECT dolt_merge('hf');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 echo "DELETE FROM dolt_conflicts_t WHERE base_id=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 echo "INSERT INTO t VALUES(3,'new_after_resolve');
 SELECT dolt_commit('-A','-m','post-resolve');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
@@ -211,10 +170,6 @@ run_test_match "cfr_further_log" "SELECT message FROM dolt_log LIMIT 1;" "post-r
 run_test "cfr_further_clean" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
 
 db_rm "$DB"
-
-
-
-
 
 DB=/tmp/test_deep_cfr_reopen_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -229,19 +184,13 @@ UPDATE t SET v='main' WHERE id=1;
 SELECT dolt_commit('-A','-m','main');
 SELECT dolt_merge('hf');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "cfr_reopen_exists" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
 run_test "cfr_reopen_row" "SELECT count(*) FROM dolt_conflicts_t;" "0" "$DB"
-
 
 run_test "cfr_reopen_clean" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB"
 run_test "cfr_reopen_val" "SELECT v FROM t WHERE id=1;" "main" "$DB"
 
 db_rm "$DB"
-
-
-
-
 
 DB=/tmp/test_deep_dt_delete_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -258,10 +207,6 @@ run_test "dt_delete_total" "SELECT count(*) FROM dolt_diff_t;" "4" "$DB"
 
 db_rm "$DB"
 
-
-
-
-
 DB=/tmp/test_deep_dt_update_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'original');
@@ -275,10 +220,6 @@ run_test_match "dt_update_mod" \
 
 db_rm "$DB"
 
-
-
-
-
 DB=/tmp/test_deep_dt_multi_$$.db; db_rm "$DB"
 echo "CREATE TABLE a(id INTEGER PRIMARY KEY, x TEXT);
 CREATE TABLE b(id INTEGER PRIMARY KEY, y TEXT);
@@ -288,16 +229,10 @@ INSERT INTO b VALUES(1,'b1');
 INSERT INTO b VALUES(2,'b2');
 SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "dt_multi_a" "SELECT count(*) FROM dolt_diff_a;" "1" "$DB"
-
 run_test "dt_multi_b" "SELECT count(*) FROM dolt_diff_b;" "2" "$DB"
 
 db_rm "$DB"
-
-
-
-
 
 DB=/tmp/test_deep_dt_commits_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -306,20 +241,14 @@ SELECT dolt_commit('-A','-m','c1');
 INSERT INTO t VALUES(2,'b');
 SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test_match "dt_commits_from" \
   "SELECT from_commit FROM dolt_diff_t WHERE to_v IS NOT NULL LIMIT 1;" "^[0-9a-f]{40}$" "$DB"
 run_test_match "dt_commits_to" \
   "SELECT to_commit FROM dolt_diff_t WHERE to_v IS NOT NULL LIMIT 1;" "^[0-9a-f]{40}$" "$DB"
-
 run_test_match "dt_commits_diff" \
   "SELECT CASE WHEN from_commit != to_commit THEN 'different' ELSE 'same' END FROM dolt_diff_t WHERE to_v IS NOT NULL LIMIT 1;" "different" "$DB"
 
 db_rm "$DB"
-
-
-
-
 
 DB=/tmp/test_deep_dt_gc_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -335,10 +264,6 @@ run_test_match "dt_gc_has_added" "SELECT count(*) FROM dolt_diff_t WHERE diff_ty
 
 db_rm "$DB"
 
-
-
-
-
 DB=/tmp/test_deep_ht_grow_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'v1');
@@ -349,20 +274,14 @@ run_test "ht_grow_1" "SELECT count(*) FROM dolt_history_t;" "1" "$DB"
 echo "INSERT INTO t VALUES(2,'v2');
 SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "ht_grow_2" "SELECT count(*) FROM dolt_history_t;" "3" "$DB"
 
 echo "INSERT INTO t VALUES(3,'v3');
 SELECT dolt_commit('-A','-m','c3');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "ht_grow_3" "SELECT count(*) FROM dolt_history_t;" "6" "$DB"
 
 db_rm "$DB"
-
-
-
-
 
 DB=/tmp/test_deep_ht_deleted_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -372,18 +291,11 @@ SELECT dolt_commit('-A','-m','c1');
 DELETE FROM t WHERE id=2;
 SELECT dolt_commit('-A','-m','c2: delete row 2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "ht_deleted_total" "SELECT count(*) FROM dolt_history_t;" "3" "$DB"
-
 run_test "ht_deleted_row2" "SELECT count(*) FROM dolt_history_t WHERE id=2;" "1" "$DB"
-
 run_test "ht_deleted_row1" "SELECT count(*) FROM dolt_history_t WHERE id=1;" "2" "$DB"
 
 db_rm "$DB"
-
-
-
-
 
 DB=/tmp/test_deep_ht_versions_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -394,20 +306,13 @@ SELECT dolt_commit('-A','-m','c2');
 UPDATE t SET v='version_3' WHERE id=1;
 SELECT dolt_commit('-A','-m','c3');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "ht_versions_count" "SELECT count(*) FROM dolt_history_t WHERE id=1;" "3" "$DB"
-
 run_test "ht_versions_distinct" \
   "SELECT count(DISTINCT commit_hash) FROM dolt_history_t WHERE id=1;" "3" "$DB"
-
 run_test "ht_versions_blobs" \
   "SELECT count(DISTINCT v) FROM dolt_history_t WHERE id=1;" "3" "$DB"
 
 db_rm "$DB"
-
-
-
-
 
 DB=/tmp/test_deep_ht_gc_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -423,10 +328,6 @@ run_test "ht_gc_commits" "SELECT count(DISTINCT commit_hash) FROM dolt_history_t
 
 db_rm "$DB"
 
-
-
-
-
 DB=/tmp/test_deep_ht_merge_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'init');
@@ -440,19 +341,13 @@ INSERT INTO t VALUES(3,'main');
 SELECT dolt_commit('-A','-m','main');
 SELECT dolt_merge('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test_match "ht_merge_total" "SELECT count(*) FROM dolt_history_t;" "^[6-9]" "$DB"
-
 
 MERGE_HASH=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1;" | $DOLTLITE "$DB" 2>&1)
 run_test "ht_merge_latest" \
   "SELECT count(*) FROM dolt_history_t WHERE commit_hash='$MERGE_HASH';" "3" "$DB"
 
 db_rm "$DB"
-
-
-
-
 
 DB=/tmp/test_deep_mb_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -471,15 +366,10 @@ FEAT_HEAD=$(echo "SELECT hash FROM dolt_branches WHERE name='feat';" | $DOLTLITE
 
 run_test_match "mb_basic" "SELECT dolt_merge_base('$MAIN_HEAD','$FEAT_HEAD');" "^[0-9a-f]{40}$" "$DB"
 
-
 INIT_HASH=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1;" | $DOLTLITE "$DB" 2>&1)
 run_test "mb_is_init" "SELECT dolt_merge_base('$MAIN_HEAD','$FEAT_HEAD');" "$INIT_HASH" "$DB"
 
 db_rm "$DB"
-
-
-
-
 
 DB=/tmp/test_deep_mb_self_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
@@ -490,10 +380,6 @@ HEAD=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1;" | $DOLTLITE "$DB" 2>&1)
 run_test "mb_self" "SELECT dolt_merge_base('$HEAD','$HEAD');" "$HEAD" "$DB"
 
 db_rm "$DB"
-
-
-
-
 
 DB=/tmp/test_deep_mb_linear_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
@@ -507,14 +393,9 @@ SELECT dolt_commit('-A','-m','c3');" | $DOLTLITE "$DB" > /dev/null 2>&1
 C1=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 2;" | $DOLTLITE "$DB" 2>&1)
 C3=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1;" | $DOLTLITE "$DB" 2>&1)
 
-
 run_test "mb_linear" "SELECT dolt_merge_base('$C1','$C3');" "$C1" "$DB"
 
 db_rm "$DB"
-
-
-
-
 
 DB=/tmp/test_deep_cp_branch_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -529,7 +410,6 @@ SELECT dolt_checkout('b');
 INSERT INTO t VALUES(20,'from_b');
 SELECT dolt_commit('-A','-m','b adds row 20');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 echo "SELECT dolt_checkout('a');" | $DOLTLITE "$DB" > /dev/null 2>&1
 A_HASH=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1;" | $DOLTLITE "$DB/a" 2>&1)
 echo "SELECT dolt_checkout('b');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -541,15 +421,10 @@ run_test "cp_branch_has20" "SELECT v FROM t WHERE id=20;" "from_b" "$DB/b"
 
 db_rm "$DB"
 
-
-
-
-
 DB=/tmp/test_deep_gc_revert_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'init');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 SQL=""; for i in $(seq 2 51); do SQL="$SQL INSERT INTO t VALUES($i,'row_$i');"; done
 echo "$SQL SELECT dolt_commit('-A','-m','add 50 rows');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -565,10 +440,6 @@ run_test "gc_revert_log" "SELECT count(*) FROM dolt_log;" "4" "$DB"
 
 db_rm "$DB"
 
-
-
-
-
 DB=/tmp/test_deep_consistency_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
@@ -577,21 +448,14 @@ SELECT dolt_commit('-A','-m','c1');
 INSERT INTO t VALUES(3,'c');
 SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "consist_history" "SELECT count(*) FROM dolt_history_t;" "5" "$DB"
 
-
 run_test "consist_diff" "SELECT count(*) FROM dolt_diff_t;" "3" "$DB"
-
 
 run_test "consist_commits_hist" "SELECT count(DISTINCT commit_hash) FROM dolt_history_t;" "2" "$DB"
 run_test "consist_commits_diff" "SELECT count(DISTINCT to_commit) FROM dolt_diff_t;" "2" "$DB"
 
 db_rm "$DB"
-
-
-
-
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/doltlite_gc.sh
+++ b/test/doltlite_gc.sh
@@ -1,46 +1,30 @@
 #!/bin/bash
-
-
-
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
 run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if echo "$r"|grep -qE "$p"; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  pattern: $p\n  got:     $r"; fi; }
-
 db_size() { local s=0; for f in "$1" "${1}-wal"; do [ -f "$f" ] && s=$((s + $(stat -f%z "$f" 2>/dev/null || stat -c%s "$f" 2>/dev/null))); done; echo $s; }
-
 db_rm() { rm -f "$1" "${1}-wal"; }
 
 echo "=== Doltlite Garbage Collection Tests ==="
 echo ""
-
-
-
-
 
 DB=/tmp/test_gc_clean_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
 SELECT dolt_commit('-A','-m','c1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 echo "SELECT dolt_gc();" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 run_test_match "gc_clean" "SELECT dolt_gc();" "0 chunks removed" "$DB"
 run_test "gc_clean_data" "SELECT count(*) FROM t;" "1" "$DB"
 run_test "gc_clean_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
-
 
 nFiles=$(ls "$DB"* 2>/dev/null | wc -l | tr -d ' ')
 if [ "$nFiles" = "1" ]; then PASS=$((PASS+1))
 else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: gc_single_file\n  expected: 1 file\n  got:      $nFiles files"; fi
 
 db_rm "$DB"
-
-
-
-
 
 DB=/tmp/test_gc_multi_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -57,29 +41,21 @@ run_test_match "gc_multi_result" "SELECT dolt_gc();" "chunks removed.*chunks kep
 
 SIZE_AFTER=$(db_size "$DB")
 
-
 if [ "$SIZE_AFTER" -le "$SIZE_BEFORE" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: gc_multi_smaller\n  before: $SIZE_BEFORE\n  after:  $SIZE_AFTER"; fi
-
 
 run_test "gc_multi_count" "SELECT count(*) FROM t;" "3" "$DB"
 run_test "gc_multi_log" "SELECT count(*) FROM dolt_log;" "4" "$DB"
 run_test "gc_multi_val" "SELECT v FROM t WHERE id=3;" "c" "$DB"
-
 
 run_test "gc_multi_reopen_count" "SELECT count(*) FROM t;" "3" "$DB"
 run_test "gc_multi_reopen_log" "SELECT count(*) FROM dolt_log;" "4" "$DB"
 
 db_rm "$DB"
 
-
-
-
-
 DB=/tmp/test_gc_branch_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 echo "SELECT dolt_branch('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -89,30 +65,21 @@ echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 SIZE_WITH_BRANCH=$(db_size "$DB")
 
-
 echo "SELECT dolt_branch('-d','feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 run_test_match "gc_branch_result" "SELECT dolt_gc();" "chunks removed" "$DB"
 
 SIZE_AFTER_GC=$(db_size "$DB")
 
-
 if [ "$SIZE_AFTER_GC" -lt "$SIZE_WITH_BRANCH" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: gc_branch_smaller\n  with_branch: $SIZE_WITH_BRANCH\n  after_gc:    $SIZE_AFTER_GC"; fi
-
 
 run_test "gc_branch_data" "SELECT count(*) FROM t;" "1" "$DB"
 run_test "gc_branch_val" "SELECT v FROM t WHERE id=1;" "a" "$DB"
 run_test "gc_branch_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 
-
 run_test "gc_branch_no_feat" "SELECT count(*) FROM t WHERE id=100;" "0" "$DB"
 
 db_rm "$DB"
-
-
-
-
 
 DB=/tmp/test_gc_preserve_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -129,16 +96,12 @@ echo "SELECT dolt_tag('v1.0');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 echo "SELECT dolt_gc();" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "gc_preserve_branches" "SELECT count(*) FROM dolt_branches;" "2" "$DB"
-
 
 run_test "gc_preserve_tags" "SELECT count(*) FROM dolt_tags;" "1" "$DB"
 
-
 echo "SELECT dolt_checkout('dev');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "gc_preserve_dev" "SELECT count(*) FROM t;" "2" "$DB/dev"
-
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "gc_preserve_reopen_main" "SELECT count(*) FROM t;" "1" "$DB"
@@ -146,15 +109,10 @@ run_test "gc_preserve_reopen_tags" "SELECT count(*) FROM dolt_tags;" "1" "$DB"
 
 db_rm "$DB"
 
-
-
-
-
 DB=/tmp/test_gc_updates_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'v0');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 for i in $(seq 1 20); do
   echo "UPDATE t SET v='v$i' WHERE id=1;
@@ -167,29 +125,18 @@ run_test_match "gc_updates_result" "SELECT dolt_gc();" "chunks removed" "$DB"
 
 SIZE_AFTER=$(db_size "$DB")
 
-
 if [ "$SIZE_AFTER" -le "$SIZE_BEFORE" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: gc_updates_smaller\n  before: $SIZE_BEFORE\n  after:  $SIZE_AFTER"; fi
-
 
 run_test "gc_updates_val" "SELECT v FROM t WHERE id=1;" "v20" "$DB"
 run_test "gc_updates_log" "SELECT count(*) FROM dolt_log;" "22" "$DB"
-
 
 run_test_match "gc_updates_first_msg" \
   "SELECT message FROM dolt_log LIMIT 1;" "update 20" "$DB"
 
 db_rm "$DB"
 
-
-
-
-
 run_test_match "gc_memory" \
   "SELECT dolt_gc();" "in-memory" ":memory:"
-
-
-
-
 
 DB=/tmp/test_gc_diff_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -200,22 +147,15 @@ SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 echo "SELECT dolt_gc();" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test_match "gc_diff_works" \
   "SELECT coalesce(sum(rows_added + rows_deleted + rows_modified), 0) FROM dolt_diff_stat((SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1), (SELECT commit_hash FROM dolt_log LIMIT 1), 't');" \
   "^[1-9]" "$DB"
-
-
 
 echo "INSERT INTO t VALUES(3,'c');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "gc_diff_working" "SELECT count(*) FROM dolt_diff_t WHERE to_commit='WORKING';" "1" "$DB"
 
 echo "SELECT dolt_reset('--hard');" | $DOLTLITE "$DB" > /dev/null 2>&1
 db_rm "$DB"
-
-
-
-
 
 DB=/tmp/test_gc_merge_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -230,23 +170,16 @@ INSERT INTO t VALUES(3,'main');
 SELECT dolt_commit('-A','-m','main');
 SELECT dolt_merge('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 echo "SELECT dolt_branch('-d','feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test_match "gc_merge_result" "SELECT dolt_gc();" "chunks" "$DB"
 
-
 run_test "gc_merge_count" "SELECT count(*) FROM t;" "3" "$DB"
 run_test_match "gc_merge_log" "SELECT message FROM dolt_log LIMIT 1;" "Merge" "$DB"
-
 
 run_test "gc_merge_reopen" "SELECT count(*) FROM t;" "3" "$DB"
 
 db_rm "$DB"
-
-
-
-
 
 DB=/tmp/test_gc_cprv_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -258,26 +191,18 @@ INSERT INTO t VALUES(2,'feat_row');
 SELECT dolt_commit('-A','-m','feat add');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 echo "SELECT dolt_cherry_pick('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 echo "SELECT dolt_revert((SELECT commit_hash FROM dolt_log LIMIT 1));" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test_match "gc_cprv_result" "SELECT dolt_gc();" "chunks" "$DB"
 
-
 run_test "gc_cprv_count" "SELECT count(*) FROM t;" "1" "$DB"
 run_test "gc_cprv_log" "SELECT count(*) FROM dolt_log;" "4" "$DB"
-
 
 run_test "gc_cprv_reopen" "SELECT count(*) FROM t;" "1" "$DB"
 
 db_rm "$DB"
-
-
-
-
 
 DB=/tmp/test_gc_tables_$$.db; db_rm "$DB"
 echo "CREATE TABLE a(id INTEGER PRIMARY KEY, v TEXT);
@@ -299,15 +224,10 @@ run_test "gc_tables_a" "SELECT count(*) FROM a;" "2" "$DB"
 run_test "gc_tables_b" "SELECT count(*) FROM b;" "2" "$DB"
 run_test "gc_tables_c" "SELECT count(*) FROM c;" "2" "$DB"
 
-
 run_test "gc_tables_reopen_a" "SELECT count(*) FROM a;" "2" "$DB"
 run_test "gc_tables_reopen_b" "SELECT count(*) FROM b;" "2" "$DB"
 
 db_rm "$DB"
-
-
-
-
 
 DB=/tmp/test_gc_idem_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -321,10 +241,6 @@ run_test_match "gc_idem_second" "SELECT dolt_gc();" "0 chunks removed" "$DB"
 run_test "gc_idem_data" "SELECT count(*) FROM t;" "2" "$DB"
 
 db_rm "$DB"
-
-
-
-
 
 DB=/tmp/test_gc_taghist_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -342,16 +258,11 @@ echo "SELECT dolt_gc();" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "gc_taghist_tags" "SELECT count(*) FROM dolt_tags;" "2" "$DB"
 run_test "gc_taghist_data" "SELECT count(*) FROM t;" "3" "$DB"
 
-
 run_test_match "gc_taghist_diff" \
   "SELECT coalesce(sum(rows_added + rows_deleted + rows_modified), 0) FROM dolt_diff_stat((SELECT tag_hash FROM dolt_tags WHERE tag_name='v1.0'), (SELECT tag_hash FROM dolt_tags WHERE tag_name='v2.0'), 't');" \
   "^[1-9]" "$DB"
 
 db_rm "$DB"
-
-
-
-
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/doltlite_gc.sh
+++ b/test/doltlite_gc.sh
@@ -1,46 +1,46 @@
 #!/bin/bash
-#
-# Tests for dolt_gc() — stop-the-world garbage collection.
-#
+
+
+
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
 run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if echo "$r"|grep -qE "$p"; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  pattern: $p\n  got:     $r"; fi; }
-# Total size of DB + WAL files
+
 db_size() { local s=0; for f in "$1" "${1}-wal"; do [ -f "$f" ] && s=$((s + $(stat -f%z "$f" 2>/dev/null || stat -c%s "$f" 2>/dev/null))); done; echo $s; }
-# Clean up DB + WAL
+
 db_rm() { rm -f "$1" "${1}-wal"; }
 
 echo "=== Doltlite Garbage Collection Tests ==="
 echo ""
 
-# ============================================================
-# GC on clean database (nothing to collect)
-# ============================================================
+
+
+
 
 DB=/tmp/test_gc_clean_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
 SELECT dolt_commit('-A','-m','c1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# First GC may remove old intermediate chunks
+
 echo "SELECT dolt_gc();" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Second GC should find nothing to remove
+
 run_test_match "gc_clean" "SELECT dolt_gc();" "0 chunks removed" "$DB"
 run_test "gc_clean_data" "SELECT count(*) FROM t;" "1" "$DB"
 run_test "gc_clean_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 
-# Single-file: no -wal after GC
+
 nFiles=$(ls "$DB"* 2>/dev/null | wc -l | tr -d ' ')
 if [ "$nFiles" = "1" ]; then PASS=$((PASS+1))
 else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: gc_single_file\n  expected: 1 file\n  got:      $nFiles files"; fi
 
 db_rm "$DB"
 
-# ============================================================
-# GC after multiple commits
-# ============================================================
+
+
+
 
 DB=/tmp/test_gc_multi_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -57,30 +57,30 @@ run_test_match "gc_multi_result" "SELECT dolt_gc();" "chunks removed.*chunks kep
 
 SIZE_AFTER=$(db_size "$DB")
 
-# File should be same or smaller
+
 if [ "$SIZE_AFTER" -le "$SIZE_BEFORE" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: gc_multi_smaller\n  before: $SIZE_BEFORE\n  after:  $SIZE_AFTER"; fi
 
-# Data intact after GC
+
 run_test "gc_multi_count" "SELECT count(*) FROM t;" "3" "$DB"
 run_test "gc_multi_log" "SELECT count(*) FROM dolt_log;" "4" "$DB"
 run_test "gc_multi_val" "SELECT v FROM t WHERE id=3;" "c" "$DB"
 
-# Data intact after reopen
+
 run_test "gc_multi_reopen_count" "SELECT count(*) FROM t;" "3" "$DB"
 run_test "gc_multi_reopen_log" "SELECT count(*) FROM dolt_log;" "4" "$DB"
 
 db_rm "$DB"
 
-# ============================================================
-# GC after branch deletion (orphaned branch commits become garbage)
-# ============================================================
+
+
+
 
 DB=/tmp/test_gc_branch_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Create branch with data
+
 echo "SELECT dolt_branch('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(100,'feat_only');
@@ -89,30 +89,30 @@ echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 SIZE_WITH_BRANCH=$(db_size "$DB")
 
-# Delete the branch
+
 echo "SELECT dolt_branch('-d','feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# GC should collect the orphaned feat commit data
+
 run_test_match "gc_branch_result" "SELECT dolt_gc();" "chunks removed" "$DB"
 
 SIZE_AFTER_GC=$(db_size "$DB")
 
-# File should be smaller after GC removed orphaned branch data
+
 if [ "$SIZE_AFTER_GC" -lt "$SIZE_WITH_BRANCH" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: gc_branch_smaller\n  with_branch: $SIZE_WITH_BRANCH\n  after_gc:    $SIZE_AFTER_GC"; fi
 
-# Main data intact
+
 run_test "gc_branch_data" "SELECT count(*) FROM t;" "1" "$DB"
 run_test "gc_branch_val" "SELECT v FROM t WHERE id=1;" "a" "$DB"
 run_test "gc_branch_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 
-# feat data should be gone
+
 run_test "gc_branch_no_feat" "SELECT count(*) FROM t WHERE id=100;" "0" "$DB"
 
 db_rm "$DB"
 
-# ============================================================
-# GC preserves all branches and tags
-# ============================================================
+
+
+
 
 DB=/tmp/test_gc_preserve_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -129,33 +129,33 @@ echo "SELECT dolt_tag('v1.0');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 echo "SELECT dolt_gc();" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Branches preserved
+
 run_test "gc_preserve_branches" "SELECT count(*) FROM dolt_branches;" "2" "$DB"
 
-# Tags preserved
+
 run_test "gc_preserve_tags" "SELECT count(*) FROM dolt_tags;" "1" "$DB"
 
-# Dev branch data preserved
+
 echo "SELECT dolt_checkout('dev');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "gc_preserve_dev" "SELECT count(*) FROM t;" "2" "$DB/dev"
 
-# After reopen, everything still works
+
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "gc_preserve_reopen_main" "SELECT count(*) FROM t;" "1" "$DB"
 run_test "gc_preserve_reopen_tags" "SELECT count(*) FROM dolt_tags;" "1" "$DB"
 
 db_rm "$DB"
 
-# ============================================================
-# GC with many updates (lots of dead tree nodes)
-# ============================================================
+
+
+
 
 DB=/tmp/test_gc_updates_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'v0');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# 20 updates to same row — creates 20 dead versions of tree nodes
+
 for i in $(seq 1 20); do
   echo "UPDATE t SET v='v$i' WHERE id=1;
 SELECT dolt_commit('-A','-m','update $i');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -167,29 +167,29 @@ run_test_match "gc_updates_result" "SELECT dolt_gc();" "chunks removed" "$DB"
 
 SIZE_AFTER=$(db_size "$DB")
 
-# Should have shrunk
+
 if [ "$SIZE_AFTER" -le "$SIZE_BEFORE" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: gc_updates_smaller\n  before: $SIZE_BEFORE\n  after:  $SIZE_AFTER"; fi
 
-# Latest data intact
+
 run_test "gc_updates_val" "SELECT v FROM t WHERE id=1;" "v20" "$DB"
 run_test "gc_updates_log" "SELECT count(*) FROM dolt_log;" "22" "$DB"
 
-# All 21 commits still navigable
+
 run_test_match "gc_updates_first_msg" \
   "SELECT message FROM dolt_log LIMIT 1;" "update 20" "$DB"
 
 db_rm "$DB"
 
-# ============================================================
-# GC on in-memory database (no-op)
-# ============================================================
+
+
+
 
 run_test_match "gc_memory" \
   "SELECT dolt_gc();" "in-memory" ":memory:"
 
-# ============================================================
-# GC preserves dolt_diff functionality
-# ============================================================
+
+
+
 
 DB=/tmp/test_gc_diff_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -200,22 +200,22 @@ SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 echo "SELECT dolt_gc();" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Inter-commit diff should still work after GC
+
 run_test_match "gc_diff_works" \
   "SELECT coalesce(sum(rows_added + rows_deleted + rows_modified), 0) FROM dolt_diff_stat((SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1), (SELECT commit_hash FROM dolt_log LIMIT 1), 't');" \
   "^[1-9]" "$DB"
 
-# Working diff: INSERT autocommits at SQL level but is not dolt-committed,
-# so dolt_diff_t should show it as a working change.
+
+
 echo "INSERT INTO t VALUES(3,'c');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "gc_diff_working" "SELECT count(*) FROM dolt_diff_t WHERE to_commit='WORKING';" "1" "$DB"
 
 echo "SELECT dolt_reset('--hard');" | $DOLTLITE "$DB" > /dev/null 2>&1
 db_rm "$DB"
 
-# ============================================================
-# GC after merge
-# ============================================================
+
+
+
 
 DB=/tmp/test_gc_merge_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -230,23 +230,23 @@ INSERT INTO t VALUES(3,'main');
 SELECT dolt_commit('-A','-m','main');
 SELECT dolt_merge('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Delete the feat branch (its commits become partially orphaned)
+
 echo "SELECT dolt_branch('-d','feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test_match "gc_merge_result" "SELECT dolt_gc();" "chunks" "$DB"
 
-# All merged data preserved
+
 run_test "gc_merge_count" "SELECT count(*) FROM t;" "3" "$DB"
 run_test_match "gc_merge_log" "SELECT message FROM dolt_log LIMIT 1;" "Merge" "$DB"
 
-# Reopen
+
 run_test "gc_merge_reopen" "SELECT count(*) FROM t;" "3" "$DB"
 
 db_rm "$DB"
 
-# ============================================================
-# GC after cherry-pick and revert
-# ============================================================
+
+
+
 
 DB=/tmp/test_gc_cprv_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -258,26 +258,26 @@ INSERT INTO t VALUES(2,'feat_row');
 SELECT dolt_commit('-A','-m','feat add');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Cherry-pick
+
 echo "SELECT dolt_cherry_pick('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Revert the cherry-pick
+
 echo "SELECT dolt_revert((SELECT commit_hash FROM dolt_log LIMIT 1));" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test_match "gc_cprv_result" "SELECT dolt_gc();" "chunks" "$DB"
 
-# After revert, row 2 should be gone
+
 run_test "gc_cprv_count" "SELECT count(*) FROM t;" "1" "$DB"
 run_test "gc_cprv_log" "SELECT count(*) FROM dolt_log;" "4" "$DB"
 
-# Reopen
+
 run_test "gc_cprv_reopen" "SELECT count(*) FROM t;" "1" "$DB"
 
 db_rm "$DB"
 
-# ============================================================
-# GC with multiple tables
-# ============================================================
+
+
+
 
 DB=/tmp/test_gc_tables_$$.db; db_rm "$DB"
 echo "CREATE TABLE a(id INTEGER PRIMARY KEY, v TEXT);
@@ -299,15 +299,15 @@ run_test "gc_tables_a" "SELECT count(*) FROM a;" "2" "$DB"
 run_test "gc_tables_b" "SELECT count(*) FROM b;" "2" "$DB"
 run_test "gc_tables_c" "SELECT count(*) FROM c;" "2" "$DB"
 
-# Reopen
+
 run_test "gc_tables_reopen_a" "SELECT count(*) FROM a;" "2" "$DB"
 run_test "gc_tables_reopen_b" "SELECT count(*) FROM b;" "2" "$DB"
 
 db_rm "$DB"
 
-# ============================================================
-# GC idempotent — running twice is safe
-# ============================================================
+
+
+
 
 DB=/tmp/test_gc_idem_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -322,9 +322,9 @@ run_test "gc_idem_data" "SELECT count(*) FROM t;" "2" "$DB"
 
 db_rm "$DB"
 
-# ============================================================
-# GC preserves tags pointing to old commits
-# ============================================================
+
+
+
 
 DB=/tmp/test_gc_taghist_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -342,16 +342,16 @@ echo "SELECT dolt_gc();" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "gc_taghist_tags" "SELECT count(*) FROM dolt_tags;" "2" "$DB"
 run_test "gc_taghist_data" "SELECT count(*) FROM t;" "3" "$DB"
 
-# Diff between tags should still work (old tree nodes preserved)
+
 run_test_match "gc_taghist_diff" \
   "SELECT coalesce(sum(rows_added + rows_deleted + rows_modified), 0) FROM dolt_diff_stat((SELECT tag_hash FROM dolt_tags WHERE tag_name='v1.0'), (SELECT tag_hash FROM dolt_tags WHERE tag_name='v2.0'), 't');" \
   "^[1-9]" "$DB"
 
 db_rm "$DB"
 
-# ============================================================
-# Done
-# ============================================================
+
+
+
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/doltlite_gc_scale.sh
+++ b/test/doltlite_gc_scale.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-#
-# GC correctness tests at scale (10K+ rows).
-# Verifies dolt_gc() works on databases with realistic payload sizes
-# that produce multi-level prolly trees.
-#
+
+
+
+
+
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 
@@ -17,9 +17,9 @@ run_test() {
 echo "=== GC Tests at Scale ==="
 echo ""
 
-# ============================================================
-# Test 1: GC after updates — 10K rows with randomblob payloads
-# ============================================================
+
+
+
 
 DB1=/tmp/test_gc1_$$.db; rm -f "$DB1"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -42,9 +42,9 @@ run_test "gc_10k_data_intact" \
   "SELECT count(*) FROM t WHERE length(v) > 0;" \
   "10000" "$DB1"
 
-# ============================================================
-# Test 2: GC after branch delete — 10K rows
-# ============================================================
+
+
+
 
 DB2=/tmp/test_gc2_$$.db; rm -f "$DB2"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -68,9 +68,9 @@ run_test "gc_branch_integrity" \
   "PRAGMA integrity_check;" \
   "ok" "$DB2"
 
-# ============================================================
-# Test 3: GC with composite index — 10K rows
-# ============================================================
+
+
+
 
 DB3=/tmp/test_gc3_$$.db; rm -f "$DB3"
 echo "CREATE TABLE events(
@@ -99,9 +99,9 @@ run_test "gc_index_seek" \
   "SELECT count(*) FROM events WHERE tid='thread-25';" \
   "200" "$DB3"
 
-# ============================================================
-# Test 4: Multiple GC cycles
-# ============================================================
+
+
+
 
 DB4=/tmp/test_gc4_$$.db; rm -f "$DB4"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -123,9 +123,9 @@ run_test "gc_multi_integrity" \
   "PRAGMA integrity_check;" \
   "ok" "$DB4"
 
-# ============================================================
-# Test 5: GC with attached SQLite db
-# ============================================================
+
+
+
 
 SQLITE3=$(command -v sqlite3 2>/dev/null || echo /usr/bin/sqlite3)
 if [ -x "$SQLITE3" ]; then
@@ -153,7 +153,7 @@ SELECT dolt_gc();" | $DOLTLITE "$DB5" > /dev/null 2>&1
   rm -f "$DB5" "$SQLDB"
 fi
 
-# Cleanup
+
 rm -f "$DB1" "$DB2" "$DB3" "$DB4"
 
 echo ""

--- a/test/doltlite_gc_scale.sh
+++ b/test/doltlite_gc_scale.sh
@@ -1,9 +1,4 @@
 #!/bin/bash
-
-
-
-
-
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 
@@ -16,10 +11,6 @@ run_test() {
 
 echo "=== GC Tests at Scale ==="
 echo ""
-
-
-
-
 
 DB1=/tmp/test_gc1_$$.db; rm -f "$DB1"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -42,10 +33,6 @@ run_test "gc_10k_data_intact" \
   "SELECT count(*) FROM t WHERE length(v) > 0;" \
   "10000" "$DB1"
 
-
-
-
-
 DB2=/tmp/test_gc2_$$.db; rm -f "$DB2"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t SELECT x, hex(randomblob(50))
@@ -67,10 +54,6 @@ run_test "gc_branch_count" \
 run_test "gc_branch_integrity" \
   "PRAGMA integrity_check;" \
   "ok" "$DB2"
-
-
-
-
 
 DB3=/tmp/test_gc3_$$.db; rm -f "$DB3"
 echo "CREATE TABLE events(
@@ -99,10 +82,6 @@ run_test "gc_index_seek" \
   "SELECT count(*) FROM events WHERE tid='thread-25';" \
   "200" "$DB3"
 
-
-
-
-
 DB4=/tmp/test_gc4_$$.db; rm -f "$DB4"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t SELECT x, hex(randomblob(50))
@@ -122,10 +101,6 @@ run_test "gc_multi_count" \
 run_test "gc_multi_integrity" \
   "PRAGMA integrity_check;" \
   "ok" "$DB4"
-
-
-
-
 
 SQLITE3=$(command -v sqlite3 2>/dev/null || echo /usr/bin/sqlite3)
 if [ -x "$SQLITE3" ]; then
@@ -152,7 +127,6 @@ SELECT dolt_gc();" | $DOLTLITE "$DB5" > /dev/null 2>&1
 
   rm -f "$DB5" "$SQLDB"
 fi
-
 
 rm -f "$DB1" "$DB2" "$DB3" "$DB4"
 

--- a/test/doltlite_history.sh
+++ b/test/doltlite_history.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
-
-
-
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
@@ -9,10 +6,6 @@ run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -
 
 echo "=== Doltlite dolt_history_<table> Tests ==="
 echo ""
-
-
-
-
 
 DB=/tmp/test_hist_basic_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -27,10 +20,6 @@ run_test "basic_committer" "SELECT committer FROM dolt_history_t LIMIT 1;" "dolt
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_hist_multi_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
@@ -40,29 +29,17 @@ SELECT dolt_commit('-A','-m','c2');
 INSERT INTO t VALUES(3,'c');
 SELECT dolt_commit('-A','-m','c3');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
-
-
-
 run_test "multi_count" "SELECT count(*) FROM dolt_history_t;" "6" "$DB"
-
 
 run_test "multi_row1" "SELECT count(*) FROM dolt_history_t WHERE id=1;" "3" "$DB"
 
-
 run_test "multi_row2" "SELECT count(*) FROM dolt_history_t WHERE id=2;" "2" "$DB"
 
-
 run_test "multi_row3" "SELECT count(*) FROM dolt_history_t WHERE id=3;" "1" "$DB"
-
 
 run_test "multi_commits" "SELECT count(DISTINCT commit_hash) FROM dolt_history_t;" "3" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_hist_update_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -73,20 +50,13 @@ SELECT dolt_commit('-A','-m','c2');
 UPDATE t SET v='v3' WHERE id=1;
 SELECT dolt_commit('-A','-m','c3');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "update_count" "SELECT count(*) FROM dolt_history_t WHERE id=1;" "3" "$DB"
 
-
 run_test "update_distinct" "SELECT count(DISTINCT commit_hash) FROM dolt_history_t;" "3" "$DB"
-
 
 run_test_match "update_type" "SELECT typeof(v) FROM dolt_history_t LIMIT 1;" "text" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_hist_persist_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -99,10 +69,6 @@ run_test "persist_count" "SELECT count(*) FROM dolt_history_t;" "3" "$DB"
 run_test "persist_row1" "SELECT count(*) FROM dolt_history_t WHERE id=1;" "2" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_hist_tables_$$.db; rm -f "$DB"
 echo "CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
@@ -117,10 +83,6 @@ run_test "tables_orders" "SELECT count(*) FROM dolt_history_orders;" "2" "$DB"
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_hist_author_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
@@ -129,10 +91,6 @@ SELECT dolt_commit('-A','-m','init','--author','TestUser <test@test.com>');" | $
 run_test "author_name" "SELECT committer FROM dolt_history_t LIMIT 1;" "TestUser" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_hist_merge_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -147,19 +105,9 @@ INSERT INTO t VALUES(3,'main');
 SELECT dolt_commit('-A','-m','main');
 SELECT dolt_merge('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
-
-
-
-
-
 run_test_match "merge_count" "SELECT count(*) FROM dolt_history_t;" "^[6-9]" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_hist_ref_branches_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -196,10 +144,6 @@ HASH=$(echo "SELECT dolt_hashof('HEAD^2');" | $DOLTLITE "$DB" 2>&1)
 run_test "history_filter_second_parent_hash" "SELECT count(DISTINCT commit_hash) FROM dolt_history_t WHERE commit_hash='$HASH';" "1" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_hist_merge_replay_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -284,10 +228,6 @@ run_test "history_rebase_replay_u_distinct_commits" "SELECT count(DISTINCT commi
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_hist_empty_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 SELECT dolt_commit('-A','-m','empty');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -295,10 +235,6 @@ SELECT dolt_commit('-A','-m','empty');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "empty_count" "SELECT count(*) FROM dolt_history_t;" "0" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_hist_long_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -310,15 +246,10 @@ for i in $(seq 1 5); do
 SELECT dolt_commit('-A','-m','update $i');" | $DOLTLITE "$DB" > /dev/null 2>&1
 done
 
-
 run_test "long_count" "SELECT count(*) FROM dolt_history_t;" "6" "$DB"
 run_test "long_commits" "SELECT count(DISTINCT commit_hash) FROM dolt_history_t;" "6" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_hist_late_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -328,17 +259,11 @@ CREATE TABLE t2(id INTEGER PRIMARY KEY, w TEXT);
 INSERT INTO t2 VALUES(1,'x');
 SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "late_t2" "SELECT count(*) FROM dolt_history_t2;" "1" "$DB"
-
 
 run_test "late_t" "SELECT count(*) FROM dolt_history_t;" "2" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_hist_quoted_$$.db; rm -f "$DB"
 cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -352,10 +277,6 @@ run_test "quoted_value" 'SELECT v FROM "dolt_history_odd""name";' "a" "$DB"
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_hist_filter_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
@@ -364,20 +285,14 @@ SELECT dolt_commit('-A','-m','c1');
 INSERT INTO t VALUES(3,'c');
 SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "filter_row1" "SELECT count(*) FROM dolt_history_t WHERE id=1;" "2" "$DB"
 run_test "filter_row3" "SELECT count(*) FROM dolt_history_t WHERE id=3;" "1" "$DB"
-
 
 run_test_match "filter_commit" \
   "SELECT count(*) FROM dolt_history_t WHERE commit_hash=(SELECT commit_hash FROM dolt_log LIMIT 1);" \
   "^3$" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/doltlite_history.sh
+++ b/test/doltlite_history.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-#
-# Tests for dolt_history_<tablename> time-travel virtual tables.
-#
+
+
+
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
@@ -10,9 +10,9 @@ run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -
 echo "=== Doltlite dolt_history_<table> Tests ==="
 echo ""
 
-# ============================================================
-# Single commit: one version of each row
-# ============================================================
+
+
+
 
 DB=/tmp/test_hist_basic_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -27,9 +27,9 @@ run_test "basic_committer" "SELECT committer FROM dolt_history_t LIMIT 1;" "dolt
 
 rm -f "$DB"
 
-# ============================================================
-# Multiple commits: rows appear once per commit they exist in
-# ============================================================
+
+
+
 
 DB=/tmp/test_hist_multi_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -40,29 +40,29 @@ SELECT dolt_commit('-A','-m','c2');
 INSERT INTO t VALUES(3,'c');
 SELECT dolt_commit('-A','-m','c3');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# c1: row 1 (1 row)
-# c2: rows 1,2 (2 rows)
-# c3: rows 1,2,3 (3 rows)
-# Total: 1+2+3 = 6
+
+
+
+
 run_test "multi_count" "SELECT count(*) FROM dolt_history_t;" "6" "$DB"
 
-# Row 1 appears in all 3 commits
+
 run_test "multi_row1" "SELECT count(*) FROM dolt_history_t WHERE id=1;" "3" "$DB"
 
-# Row 2 appears in 2 commits
+
 run_test "multi_row2" "SELECT count(*) FROM dolt_history_t WHERE id=2;" "2" "$DB"
 
-# Row 3 appears in 1 commit
+
 run_test "multi_row3" "SELECT count(*) FROM dolt_history_t WHERE id=3;" "1" "$DB"
 
-# 3 distinct commits
+
 run_test "multi_commits" "SELECT count(DISTINCT commit_hash) FROM dolt_history_t;" "3" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Updated row shows different values at different commits
-# ============================================================
+
+
+
 
 DB=/tmp/test_hist_update_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -73,20 +73,20 @@ SELECT dolt_commit('-A','-m','c2');
 UPDATE t SET v='v3' WHERE id=1;
 SELECT dolt_commit('-A','-m','c3');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Row 1 appears 3 times (once per commit), each with different value blob
+
 run_test "update_count" "SELECT count(*) FROM dolt_history_t WHERE id=1;" "3" "$DB"
 
-# All are for the same rowid but with different commit hashes
+
 run_test "update_distinct" "SELECT count(DISTINCT commit_hash) FROM dolt_history_t;" "3" "$DB"
 
-# value column should be decoded text
+
 run_test_match "update_type" "SELECT typeof(v) FROM dolt_history_t LIMIT 1;" "text" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Persistence across reopen
-# ============================================================
+
+
+
 
 DB=/tmp/test_hist_persist_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -100,9 +100,9 @@ run_test "persist_row1" "SELECT count(*) FROM dolt_history_t WHERE id=1;" "2" "$
 
 rm -f "$DB"
 
-# ============================================================
-# Multiple tables have separate histories
-# ============================================================
+
+
+
 
 DB=/tmp/test_hist_tables_$$.db; rm -f "$DB"
 echo "CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
@@ -117,9 +117,9 @@ run_test "tables_orders" "SELECT count(*) FROM dolt_history_orders;" "2" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# History with --author commit
-# ============================================================
+
+
+
 
 DB=/tmp/test_hist_author_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -130,9 +130,9 @@ run_test "author_name" "SELECT committer FROM dolt_history_t LIMIT 1;" "TestUser
 
 rm -f "$DB"
 
-# ============================================================
-# History after merge
-# ============================================================
+
+
+
 
 DB=/tmp/test_hist_merge_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -147,19 +147,19 @@ INSERT INTO t VALUES(3,'main');
 SELECT dolt_commit('-A','-m','main');
 SELECT dolt_merge('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# After merge: 4 commits (init, feat, main, merge)
-# init: row 1
-# main: rows 1,3
-# merge: rows 1,2,3
-# (feat branch not in HEAD history unless followed via merge parent)
-# At minimum: init(1) + main(2) + merge(3) = 6
+
+
+
+
+
+
 run_test_match "merge_count" "SELECT count(*) FROM dolt_history_t;" "^[6-9]" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# History on branches created from tags and merge parents
-# ============================================================
+
+
+
 
 DB=/tmp/test_hist_ref_branches_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -197,9 +197,9 @@ run_test "history_filter_second_parent_hash" "SELECT count(DISTINCT commit_hash)
 
 rm -f "$DB"
 
-# ============================================================
-# History after schema replay ops
-# ============================================================
+
+
+
 
 DB=/tmp/test_hist_merge_replay_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -284,9 +284,9 @@ run_test "history_rebase_replay_u_distinct_commits" "SELECT count(DISTINCT commi
 
 rm -f "$DB"
 
-# ============================================================
-# Empty table has no history
-# ============================================================
+
+
+
 
 DB=/tmp/test_hist_empty_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -296,9 +296,9 @@ run_test "empty_count" "SELECT count(*) FROM dolt_history_t;" "0" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Long history
-# ============================================================
+
+
+
 
 DB=/tmp/test_hist_long_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -310,15 +310,15 @@ for i in $(seq 1 5); do
 SELECT dolt_commit('-A','-m','update $i');" | $DOLTLITE "$DB" > /dev/null 2>&1
 done
 
-# Row 1 appears in all 6 commits
+
 run_test "long_count" "SELECT count(*) FROM dolt_history_t;" "6" "$DB"
 run_test "long_commits" "SELECT count(DISTINCT commit_hash) FROM dolt_history_t;" "6" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Table created later doesn't appear in earlier commits
-# ============================================================
+
+
+
 
 DB=/tmp/test_hist_late_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -328,17 +328,17 @@ CREATE TABLE t2(id INTEGER PRIMARY KEY, w TEXT);
 INSERT INTO t2 VALUES(1,'x');
 SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# t2 only exists in c2, so history has 1 row
+
 run_test "late_t2" "SELECT count(*) FROM dolt_history_t2;" "1" "$DB"
 
-# t exists in both commits
+
 run_test "late_t" "SELECT count(*) FROM dolt_history_t;" "2" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Quoted table names
-# ============================================================
+
+
+
 
 DB=/tmp/test_hist_quoted_$$.db; rm -f "$DB"
 cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -352,9 +352,9 @@ run_test "quoted_value" 'SELECT v FROM "dolt_history_odd""name";' "a" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# History query with WHERE filter
-# ============================================================
+
+
+
 
 DB=/tmp/test_hist_filter_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -364,20 +364,20 @@ SELECT dolt_commit('-A','-m','c1');
 INSERT INTO t VALUES(3,'c');
 SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Filter by rowid
+
 run_test "filter_row1" "SELECT count(*) FROM dolt_history_t WHERE id=1;" "2" "$DB"
 run_test "filter_row3" "SELECT count(*) FROM dolt_history_t WHERE id=3;" "1" "$DB"
 
-# Filter by commit
+
 run_test_match "filter_commit" \
   "SELECT count(*) FROM dolt_history_t WHERE commit_hash=(SELECT commit_hash FROM dolt_log LIMIT 1);" \
   "^3$" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Done
-# ============================================================
+
+
+
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/doltlite_index_prefix.sh
+++ b/test/doltlite_index_prefix.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-#
-# Index correctness tests at scale.
-# All tests use 10K+ rows with realistic payloads to force multi-level
-# prolly trees, exercising internal node descent, chunk boundaries,
-# and sort key prefix matching.
-#
+
+
+
+
+
+
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 
@@ -18,9 +18,9 @@ run_test() {
 echo "=== Index Tests at Scale ==="
 echo ""
 
-# ============================================================
-# 2-column UNIQUE — 10K rows, ~200 byte payloads
-# ============================================================
+
+
+
 
 DB1=/tmp/test_idx1_$$.db; rm -f "$DB1"
 echo "CREATE TABLE events(
@@ -62,9 +62,9 @@ run_test "2col_10k_orderby_desc" \
 198
 197" "$DB1"
 
-# ============================================================
-# 3-column UNIQUE — 10K rows, event sourcing pattern
-# ============================================================
+
+
+
 
 DB2=/tmp/test_idx2_$$.db; rm -f "$DB2"
 echo "CREATE TABLE events(
@@ -88,27 +88,27 @@ run_test "3col_10k_integrity" \
   "PRAGMA integrity_check;" \
   "ok" "$DB2"
 
-# Seek on 1 of 3 columns
+
 run_test "3col_10k_1prefix" \
   "SELECT count(*) FROM events WHERE aggregate_kind='thread';" \
   "10000" "$DB2"
 
-# Seek on 2 of 3 columns
+
 run_test "3col_10k_2prefix" \
   "SELECT count(*) FROM events WHERE aggregate_kind='thread' AND stream_id='stream-25';" \
   "200" "$DB2"
 
-# Seek on all 3 (exact)
+
 run_test "3col_10k_exact" \
   "SELECT count(*) FROM events WHERE aggregate_kind='thread' AND stream_id='stream-25' AND stream_version=100;" \
   "1" "$DB2"
 
-# MAX via 2-column prefix
+
 run_test "3col_10k_max" \
   "SELECT MAX(stream_version) FROM events WHERE aggregate_kind='thread' AND stream_id='stream-25';" \
   "199" "$DB2"
 
-# All-rows point lookup
+
 run_test "3col_10k_point_all" \
   "CREATE TEMP TABLE lookups AS SELECT aggregate_kind, stream_id, stream_version FROM events;
 SELECT count(*) FROM lookups l
@@ -118,9 +118,9 @@ SELECT count(*) FROM lookups l
       AND e.stream_version=l.stream_version);" \
   "10000" "$DB2"
 
-# ============================================================
-# 4-column UNIQUE — 10K rows
-# ============================================================
+
+
+
 
 DB3=/tmp/test_idx3_$$.db; rm -f "$DB3"
 echo "CREATE TABLE log(
@@ -154,9 +154,9 @@ run_test "4col_10k_3prefix" \
   "SELECT count(*) FROM log WHERE region='us-east-0' AND service='svc-0' AND ts=1023;" \
   "1" "$DB3"
 
-# ============================================================
-# Non-unique secondary index — 10K rows
-# ============================================================
+
+
+
 
 DB4=/tmp/test_idx4_$$.db; rm -f "$DB4"
 echo "CREATE TABLE orders(
@@ -189,9 +189,9 @@ run_test "secondary_10k_exact" \
   "SELECT count(*) FROM orders WHERE customer='cust-25' AND status='shipped';" \
   "67" "$DB4"
 
-# ============================================================
-# WITHOUT ROWID composite PK — 10K rows
-# ============================================================
+
+
+
 
 DB5=/tmp/test_idx5_$$.db; rm -f "$DB5"
 echo "CREATE TABLE kv(
@@ -221,9 +221,9 @@ run_test "wor_10k_exact" \
   "SELECT val IS NOT NULL FROM kv WHERE ns='ns-10' AND key='key-00010';" \
   "1" "$DB5"
 
-# ============================================================
-# Batched commits — 10K rows across 10 commits
-# ============================================================
+
+
+
 
 DB6=/tmp/test_idx6_$$.db; rm -f "$DB6"
 echo "CREATE TABLE events(
@@ -255,9 +255,9 @@ SELECT count(*) FROM lookups l
   WHERE EXISTS(SELECT 1 FROM events e WHERE e.tid=l.tid AND e.seq=l.seq);" \
   "10000" "$DB6"
 
-# ============================================================
-# Mixed types (TEXT + INT + REAL) — 10K rows
-# ============================================================
+
+
+
 
 DB7=/tmp/test_idx7_$$.db; rm -f "$DB7"
 echo "CREATE TABLE mixed(
@@ -285,9 +285,9 @@ run_test "mixed_10k_2prefix" \
   "SELECT count(*) FROM mixed WHERE tag='tag-5' AND seq=500;" \
   "1" "$DB7"
 
-# ============================================================
-# Cleanup
-# ============================================================
+
+
+
 
 rm -f "$DB1" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7"
 

--- a/test/doltlite_index_prefix.sh
+++ b/test/doltlite_index_prefix.sh
@@ -1,10 +1,4 @@
 #!/bin/bash
-
-
-
-
-
-
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 
@@ -17,10 +11,6 @@ run_test() {
 
 echo "=== Index Tests at Scale ==="
 echo ""
-
-
-
-
 
 DB1=/tmp/test_idx1_$$.db; rm -f "$DB1"
 echo "CREATE TABLE events(
@@ -62,10 +52,6 @@ run_test "2col_10k_orderby_desc" \
 198
 197" "$DB1"
 
-
-
-
-
 DB2=/tmp/test_idx2_$$.db; rm -f "$DB2"
 echo "CREATE TABLE events(
   id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -88,26 +74,21 @@ run_test "3col_10k_integrity" \
   "PRAGMA integrity_check;" \
   "ok" "$DB2"
 
-
 run_test "3col_10k_1prefix" \
   "SELECT count(*) FROM events WHERE aggregate_kind='thread';" \
   "10000" "$DB2"
-
 
 run_test "3col_10k_2prefix" \
   "SELECT count(*) FROM events WHERE aggregate_kind='thread' AND stream_id='stream-25';" \
   "200" "$DB2"
 
-
 run_test "3col_10k_exact" \
   "SELECT count(*) FROM events WHERE aggregate_kind='thread' AND stream_id='stream-25' AND stream_version=100;" \
   "1" "$DB2"
 
-
 run_test "3col_10k_max" \
   "SELECT MAX(stream_version) FROM events WHERE aggregate_kind='thread' AND stream_id='stream-25';" \
   "199" "$DB2"
-
 
 run_test "3col_10k_point_all" \
   "CREATE TEMP TABLE lookups AS SELECT aggregate_kind, stream_id, stream_version FROM events;
@@ -117,10 +98,6 @@ SELECT count(*) FROM lookups l
       AND e.stream_id=l.stream_id
       AND e.stream_version=l.stream_version);" \
   "10000" "$DB2"
-
-
-
-
 
 DB3=/tmp/test_idx3_$$.db; rm -f "$DB3"
 echo "CREATE TABLE log(
@@ -154,10 +131,6 @@ run_test "4col_10k_3prefix" \
   "SELECT count(*) FROM log WHERE region='us-east-0' AND service='svc-0' AND ts=1023;" \
   "1" "$DB3"
 
-
-
-
-
 DB4=/tmp/test_idx4_$$.db; rm -f "$DB4"
 echo "CREATE TABLE orders(
   id INTEGER PRIMARY KEY,
@@ -189,10 +162,6 @@ run_test "secondary_10k_exact" \
   "SELECT count(*) FROM orders WHERE customer='cust-25' AND status='shipped';" \
   "67" "$DB4"
 
-
-
-
-
 DB5=/tmp/test_idx5_$$.db; rm -f "$DB5"
 echo "CREATE TABLE kv(
   ns TEXT NOT NULL,
@@ -220,10 +189,6 @@ run_test "wor_10k_prefix" \
 run_test "wor_10k_exact" \
   "SELECT val IS NOT NULL FROM kv WHERE ns='ns-10' AND key='key-00010';" \
   "1" "$DB5"
-
-
-
-
 
 DB6=/tmp/test_idx6_$$.db; rm -f "$DB6"
 echo "CREATE TABLE events(
@@ -255,10 +220,6 @@ SELECT count(*) FROM lookups l
   WHERE EXISTS(SELECT 1 FROM events e WHERE e.tid=l.tid AND e.seq=l.seq);" \
   "10000" "$DB6"
 
-
-
-
-
 DB7=/tmp/test_idx7_$$.db; rm -f "$DB7"
 echo "CREATE TABLE mixed(
   id INTEGER PRIMARY KEY,
@@ -284,10 +245,6 @@ run_test "mixed_10k_integrity" \
 run_test "mixed_10k_2prefix" \
   "SELECT count(*) FROM mixed WHERE tag='tag-5' AND seq=500;" \
   "1" "$DB7"
-
-
-
-
 
 rm -f "$DB1" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7"
 

--- a/test/doltlite_merge.sh
+++ b/test/doltlite_merge.sh
@@ -7,7 +7,6 @@ run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -
 echo "=== Doltlite Merge Tests ==="
 echo ""
 
-
 DB=/tmp/test_merge_$$.db; rm -f "$DB"
 echo "CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT); CREATE TABLE orders(id INTEGER PRIMARY KEY, item TEXT); INSERT INTO users VALUES(1,'Alice'); INSERT INTO orders VALUES(1,'hat'); SELECT dolt_commit('-A','-m','initial');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -22,7 +21,6 @@ run_test "merge_orders" "SELECT count(*) FROM orders;" "2" "$DB"
 run_test "merge_log" "SELECT message FROM dolt_log LIMIT 1;" "Merge branch 'feature' into main" "$DB"
 run_test "merge_log_count" "SELECT count(*) FROM dolt_log;" "5" "$DB"
 
-
 DB2=/tmp/test_merge2_$$.db; rm -f "$DB2"
 echo "CREATE TABLE t(x); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB2" > /dev/null 2>&1
 echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB2" > /dev/null 2>&1
@@ -35,9 +33,7 @@ run_test "ff_after" "SELECT count(*) FROM t;" "2" "$DB2"
 run_test "ff_no_merge_commit" "SELECT message FROM dolt_log LIMIT 1;" "feature" "$DB2"
 run_test "ff_log_count" "SELECT count(*) FROM dolt_log;" "3" "$DB2"
 
-
 run_test "up_to_date" "SELECT dolt_merge('feature');" "Already up to date" "$DB2"
-
 
 DB3=/tmp/test_merge3_$$.db; rm -f "$DB3"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB3" > /dev/null 2>&1
@@ -49,9 +45,7 @@ echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB3" > /dev/null 2>&1
 run_test_match "conflict" "SELECT dolt_merge('feature');" "conflict" "$DB3"
 run_test "conflict_ours_preserved" "SELECT v FROM t;" "main" "$DB3"
 
-
 run_test_match "no_branch" "SELECT dolt_merge('nope');" "not found" "$DB3"
-
 
 DB4=/tmp/test_merge4_$$.db; rm -f "$DB4"
 echo "CREATE TABLE t(x); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB4" > /dev/null 2>&1
@@ -63,7 +57,6 @@ run_test_match "new_table_merge" "SELECT dolt_merge('feature');" "^[0-9a-f]{40}$
 run_test "new_table_visible" "SELECT y FROM new_t;" "42" "$DB4"
 run_test "original_intact" "SELECT x FROM t;" "1" "$DB4"
 
-
 DB5=/tmp/test_merge5_$$.db; rm -f "$DB5"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'),(2,'b'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB5" > /dev/null 2>&1
 echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB5" > /dev/null 2>&1
@@ -74,7 +67,6 @@ run_test "pre_merge_rows" "SELECT count(*) FROM t;" "2" "$DB5"
 run_test_match "merge_del" "SELECT dolt_merge('feature');" "^[0-9a-f]{40}$" "$DB5"
 run_test "post_merge_rows" "SELECT count(*) FROM t;" "1" "$DB5"
 
-
 run_test "diff_3way_users" \
   "SELECT rows_modified FROM dolt_diff_stat((SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 3), (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 0), 'users');" \
   "1" "$DB"
@@ -82,16 +74,13 @@ run_test "diff_3way_orders" \
   "SELECT rows_added FROM dolt_diff_stat((SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 3), (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 0), 'orders');" \
   "1" "$DB"
 
-
 run_test "diff_ff_added" \
   "SELECT rows_added FROM dolt_diff_stat((SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1), (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 0), 't');" \
   "1" "$DB2"
 
-
 run_test "diff_conflict_shows_change" \
   "SELECT rows_modified FROM dolt_diff_stat((SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1), (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 0), 't');" \
   "1" "$DB3"
-
 
 DB6=/tmp/test_merge6_$$.db; rm -f "$DB6"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'),(2,'b'),(3,'c'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6" > /dev/null 2>&1
@@ -105,7 +94,6 @@ run_test "row_merge_row1" "SELECT v FROM t WHERE id=1;" "MAIN" "$DB6"
 run_test "row_merge_row2" "SELECT v FROM t WHERE id=2;" "b" "$DB6"
 run_test "row_merge_row3" "SELECT v FROM t WHERE id=3;" "FEAT" "$DB6"
 
-
 DB7=/tmp/test_merge7_$$.db; rm -f "$DB7"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'orig'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB7" > /dev/null 2>&1
 echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB7" > /dev/null 2>&1
@@ -115,7 +103,6 @@ echo "UPDATE t SET v='feat-val' WHERE id=1; SELECT dolt_commit('-A','-m','feat')
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB7" > /dev/null 2>&1
 run_test_match "row_conflict_detected" "SELECT dolt_merge('feature');" "conflict" "$DB7"
 run_test "row_conflict_ours_kept" "SELECT v FROM t WHERE id=1;" "main-val" "$DB7"
-
 
 DB8=/tmp/test_merge8_$$.db; rm -f "$DB8"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'),(2,'b'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB8" > /dev/null 2>&1
@@ -159,20 +146,16 @@ else
   ERRORS="$ERRORS\nFAIL: mixed_merge_same_session_summary_cleared\n  expected: TX|0|main1|0\n  got:      $TX_OUT"
 fi
 
-
 DB9=/tmp/test_merge9_$$.db; rm -f "$DB9"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB9" > /dev/null 2>&1
 echo "SELECT dolt_branch('other'); SELECT dolt_checkout('other'); UPDATE t SET v='OTHER'; SELECT dolt_commit('-A','-m','other');" | $DOLTLITE "$DB9" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main'); UPDATE t SET v='MAIN'; SELECT dolt_commit('-A','-m','main');" | $DOLTLITE "$DB9" > /dev/null 2>&1
 
-
 echo "BEGIN; SELECT dolt_merge('other'); SELECT dolt_merge('--abort'); COMMIT;" | $DOLTLITE "$DB9" > /dev/null 2>&1
 run_test "abort_no_conflicts" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB9"
 run_test "abort_data_restored" "SELECT v FROM t WHERE id=1;" "MAIN" "$DB9"
 
-
 run_test_match "abort_no_merge" "SELECT dolt_merge('--abort');" "no merge in progress" "$DB9"
-
 
 DB10=/tmp/test_merge10_$$.db; rm -f "$DB10"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB10" > /dev/null 2>&1
@@ -183,7 +166,6 @@ run_test_match "clean_ff_merge" "SELECT dolt_merge('feat');" "^[0-9a-f]" "$DB10"
 run_test "clean_ff_log" "SELECT message FROM dolt_log LIMIT 1;" "feat" "$DB10"
 run_test "clean_ff_data" "SELECT count(*) FROM t;" "2" "$DB10"
 
-
 DB11=/tmp/test_merge11_$$.db; rm -f "$DB11"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, u INT UNIQUE, v TEXT); INSERT INTO t VALUES(1,1,'base1'),(2,2,'base2'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB11" > /dev/null 2>&1
 echo "SELECT dolt_branch('feat'); SELECT dolt_checkout('feat'); UPDATE t SET u=9, v='feat2' WHERE id=2; SELECT dolt_commit('-A','-m','feat_unique');" | $DOLTLITE "$DB11" > /dev/null 2>&1
@@ -192,7 +174,6 @@ run_test_match "constraint_violation_merge_errors" "SELECT dolt_merge('feat');" 
 run_test "constraint_violation_no_conflicts" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB11"
 run_test "constraint_violation_no_violations" "SELECT count(*) FROM dolt_constraint_violations;" "0" "$DB11"
 run_test "constraint_violation_state_restored" "SELECT group_concat(id || ':' || u || ':' || v, ',') FROM (SELECT id, u, v FROM t ORDER BY id);" "1:9:main1,2:2:base2" "$DB11"
-
 
 DB12=/tmp/test_merge12_$$.db; rm -f "$DB12"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, u INT UNIQUE, v TEXT); INSERT INTO t VALUES(1,1,'base1'),(2,2,'base2'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB12" > /dev/null 2>&1
@@ -209,7 +190,6 @@ else
   ERRORS="$ERRORS\nFAIL: constraint_violation_merge_tx_persists\n  expected: TX|0|1|1:9:main1,2:9:feat2\n  got:      $TX_OUT"
 fi
 
-
 DB13=/tmp/test_merge13_$$.db; rm -f "$DB13"
 echo "CREATE TABLE anchor(id INTEGER PRIMARY KEY); INSERT INTO anchor VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB13" > /dev/null 2>&1
 echo "SELECT dolt_branch('feat'); SELECT dolt_checkout('feat'); CREATE TABLE feat_tbl(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO feat_tbl VALUES(1,'f'); SELECT dolt_commit('-A','-m','feat_add_table');" | $DOLTLITE "$DB13" > /dev/null 2>&1
@@ -219,7 +199,6 @@ run_test "disjoint_new_tables_main_present" "SELECT v FROM main_tbl;" "m" "$DB13
 run_test "disjoint_new_tables_feat_present" "SELECT v FROM feat_tbl;" "f" "$DB13"
 run_test "disjoint_new_tables_reopen_main" "SELECT v FROM main_tbl;" "m" "$DB13"
 run_test "disjoint_new_tables_reopen_feat" "SELECT v FROM feat_tbl;" "f" "$DB13"
-
 
 DB14=/tmp/test_merge14_$$.db; rm -f "$DB14"
 echo "CREATE TABLE a(id INTEGER PRIMARY KEY, v INT); CREATE TABLE b(id INTEGER PRIMARY KEY, v INT); INSERT INTO a VALUES(1,10); INSERT INTO b VALUES(1,20); SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');" | $DOLTLITE "$DB14" > /dev/null 2>&1
@@ -231,7 +210,6 @@ run_test "disjoint_indexes_visible" "SELECT count(*) FROM sqlite_master WHERE ty
 run_test "disjoint_indexes_reopen_data_a" "SELECT count(*) FROM a;" "1" "$DB14"
 run_test "disjoint_indexes_reopen_data_b" "SELECT count(*) FROM b;" "1" "$DB14"
 
-
 DB15=/tmp/test_merge15_$$.db; rm -f "$DB15"
 echo "CREATE TABLE p1(id INTEGER PRIMARY KEY); CREATE TABLE c1(id INTEGER PRIMARY KEY, p1_id INT); CREATE TABLE p2(id INTEGER PRIMARY KEY); CREATE TABLE c2(id INTEGER PRIMARY KEY, p2_id INT); INSERT INTO p1 VALUES(1); INSERT INTO p2 VALUES(1); SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');" | $DOLTLITE "$DB15" > /dev/null 2>&1
 echo "SELECT dolt_branch('feat'); ALTER TABLE c1 RENAME TO c1_old; CREATE TABLE c1(id INTEGER PRIMARY KEY, p1_id INT, CONSTRAINT fk_c1 FOREIGN KEY (p1_id) REFERENCES p1(id)); INSERT INTO c1 SELECT id,p1_id FROM c1_old; DROP TABLE c1_old; SELECT dolt_add('-A'); SELECT dolt_commit('-m','main_fk');" | $DOLTLITE "$DB15" > /dev/null 2>&1
@@ -241,7 +219,6 @@ run_test_match "disjoint_fks_merge_hash" "SELECT dolt_merge('feat');" "^[0-9a-f]
 run_test "disjoint_fks_c1" "SELECT count(*) FROM pragma_foreign_key_list('c1');" "1" "$DB15"
 run_test "disjoint_fks_c2" "SELECT count(*) FROM pragma_foreign_key_list('c2');" "1" "$DB15"
 
-
 DB16=/tmp/test_merge16_$$.db; rm -f "$DB16"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT); INSERT INTO t VALUES(1,10); SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');" | $DOLTLITE "$DB16" > /dev/null 2>&1
 echo "SELECT dolt_branch('feat'); SELECT dolt_checkout('feat'); CREATE INDEX idx_t_v ON t(v); SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_idx');" | $DOLTLITE "$DB16" > /dev/null 2>&1
@@ -250,7 +227,6 @@ run_test_match "table_plus_index_merge_hash" "SELECT dolt_merge('feat');" "^[0-9
 run_test "table_plus_index_table_visible" "SELECT count(*) FROM main_only;" "1" "$DB16"
 run_test "table_plus_index_index_visible" "SELECT count(*) FROM sqlite_master WHERE type='index' AND name='idx_t_v';" "1" "$DB16"
 
-
 DB17=/tmp/test_merge17_$$.db; rm -f "$DB17"
 echo "CREATE TABLE base(id INTEGER PRIMARY KEY, v INT); INSERT INTO base VALUES(1,1); SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');" | $DOLTLITE "$DB17" > /dev/null 2>&1
 echo "SELECT dolt_branch('feat'); SELECT dolt_checkout('feat'); CREATE TABLE feat_tbl(id INTEGER PRIMARY KEY, v INT); INSERT INTO feat_tbl VALUES(1,2); SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_add_table');" | $DOLTLITE "$DB17" > /dev/null 2>&1
@@ -258,7 +234,6 @@ echo "SELECT dolt_checkout('main'); ALTER TABLE base RENAME TO base_old; CREATE 
 run_test_match "table_plus_check_merge_hash" "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB17"
 run_test "table_plus_check_table_visible" "SELECT count(*) FROM feat_tbl;" "1" "$DB17"
 run_test "table_plus_check_constraint_visible" "SELECT instr(sql,'CHECK')>0 FROM sqlite_master WHERE type='table' AND name='base';" "1" "$DB17"
-
 
 DB18=/tmp/test_merge18_$$.db; rm -f "$DB18"
 echo "CREATE TABLE base(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO base VALUES(1,'x'); CREATE TABLE keep_main(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO keep_main VALUES(1,'m'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB18" > /dev/null 2>&1
@@ -269,7 +244,6 @@ run_test_match "table_plus_rename_merge_hash" "SELECT dolt_merge('feat');" "^[0-
 run_test "table_plus_rename_feat_visible" "SELECT count(*) FROM feat_tbl;" "1" "$DB18"
 run_test "table_plus_rename_new_name_visible" "SELECT count(*) FROM renamed_main;" "1" "$DB18"
 
-
 DB19=/tmp/test_merge19_$$.db; rm -f "$DB19"
 echo "CREATE TABLE base(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO base VALUES(1,'x'); CREATE TABLE churn(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO churn VALUES(1,'m'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB19" > /dev/null 2>&1
 echo "SELECT dolt_branch('feat'); DROP TABLE churn; CREATE TABLE churn(k INTEGER PRIMARY KEY, n INT); INSERT INTO churn VALUES(7,70); SELECT dolt_add('-A'); SELECT dolt_commit('-m','main_recreate');" | $DOLTLITE "$DB19" > /dev/null 2>&1
@@ -279,8 +253,6 @@ run_test_match "table_plus_recreate_merge_hash" "SELECT dolt_merge('feat');" "^[
 run_test "table_plus_recreate_feat_visible" "SELECT count(*) FROM feat_tbl;" "1" "$DB19"
 run_test "table_plus_recreate_schema_visible" "SELECT instr(sql,'k INTEGER PRIMARY KEY')>0 FROM sqlite_master WHERE type='table' AND name='churn';" "1" "$DB19"
 
-
-
 DB20=/tmp/test_merge20_$$.db; rm -f "$DB20"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT); INSERT INTO t VALUES(1,10); SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');" | $DOLTLITE "$DB20" > /dev/null 2>&1
 echo "SELECT dolt_branch('feat'); SELECT dolt_checkout('feat'); CREATE TABLE p(id INTEGER PRIMARY KEY, u INT UNIQUE); CREATE TABLE c(id INTEGER PRIMARY KEY, u INT, FOREIGN KEY(u) REFERENCES p(u)); INSERT INTO p VALUES(1,100); INSERT INTO c VALUES(1,100); SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_add_fk_tables');" | $DOLTLITE "$DB20" > /dev/null 2>&1
@@ -289,8 +261,6 @@ run_test_match "fk_tables_plus_check_merge_hash" "SELECT dolt_merge('feat');" "^
 run_test "fk_tables_plus_check_parent_visible" "SELECT count(*) FROM p;" "1" "$DB20"
 run_test "fk_tables_plus_check_child_visible" "SELECT count(*) FROM c;" "1" "$DB20"
 run_test "fk_tables_plus_check_fk_visible" "SELECT count(*) FROM pragma_foreign_key_list('c');" "1" "$DB20"
-
-
 
 DB20B=/tmp/test_merge20b_$$.db; rm -f "$DB20B"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT); INSERT INTO t VALUES(1,10); CREATE TABLE p(id INTEGER PRIMARY KEY, u INT UNIQUE); CREATE TABLE c(id INTEGER PRIMARY KEY, u INT, FOREIGN KEY(u) REFERENCES p(u)); INSERT INTO p VALUES(1,100); INSERT INTO c VALUES(1,100); SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');" | $DOLTLITE "$DB20B" > /dev/null 2>&1
@@ -304,7 +274,6 @@ run_test "recreate_fk_family_parent_schema_visible" "SELECT instr(sql,'label TEX
 run_test "recreate_fk_family_parent_unique_index_live" "SELECT count(*) FROM p INDEXED BY sqlite_autoindex_p_1 WHERE u=200;" "1" "$DB20B"
 run_test "recreate_fk_family_fk_check_clean" "SELECT count(*) FROM pragma_foreign_key_check;" "0" "$DB20B"
 
-
 DB21=/tmp/test_merge21_$$.db; rm -f "$DB21"
 echo "PRAGMA foreign_keys=ON; CREATE TABLE t(id INTEGER PRIMARY KEY, parent_id INT, FOREIGN KEY(parent_id) REFERENCES t(id) ON DELETE CASCADE); INSERT INTO t VALUES(1,NULL),(2,1); SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');" | $DOLTLITE "$DB21" > /dev/null 2>&1
 echo "SELECT dolt_branch('feat'); SELECT dolt_checkout('feat'); INSERT INTO t VALUES(3,2); SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_add_descendant');" | $DOLTLITE "$DB21" > /dev/null 2>&1
@@ -313,7 +282,6 @@ run_test_match "self_ref_fk_merge_hash" "PRAGMA foreign_keys=ON; SELECT dolt_mer
 run_test "self_ref_fk_delete_cascades_same_session" "PRAGMA foreign_keys=ON; DELETE FROM t WHERE id=1; SELECT group_concat(id || ':' || ifnull(parent_id,-1), ',') FROM (SELECT id,parent_id FROM t ORDER BY id);" "10:-1" "$DB21"
 run_test "self_ref_fk_reopen_state" "PRAGMA foreign_keys=ON; SELECT group_concat(id || ':' || ifnull(parent_id,-1), ',') FROM (SELECT id,parent_id FROM t ORDER BY id);" "10:-1" "$DB21"
 run_test "self_ref_fk_reopen_delete_last_root" "PRAGMA foreign_keys=ON; DELETE FROM t WHERE id=10; SELECT count(*) FROM t;" "0" "$DB21"
-
 
 DB22=/tmp/test_merge22_$$.db; rm -f "$DB22"
 echo "PRAGMA foreign_keys=ON; CREATE TABLE gp(id INTEGER PRIMARY KEY); CREATE TABLE p(id INTEGER PRIMARY KEY, gp_id INT, FOREIGN KEY(gp_id) REFERENCES gp(id) ON DELETE CASCADE); CREATE TABLE c(id INTEGER PRIMARY KEY, p_id INT, FOREIGN KEY(p_id) REFERENCES p(id) ON DELETE CASCADE); INSERT INTO gp VALUES(1); INSERT INTO p VALUES(1,1); INSERT INTO c VALUES(1,1); SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');" | $DOLTLITE "$DB22" > /dev/null 2>&1

--- a/test/doltlite_merge.sh
+++ b/test/doltlite_merge.sh
@@ -7,7 +7,7 @@ run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -
 echo "=== Doltlite Merge Tests ==="
 echo ""
 
-# Test 1: Three-way merge, different tables modified
+
 DB=/tmp/test_merge_$$.db; rm -f "$DB"
 echo "CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT); CREATE TABLE orders(id INTEGER PRIMARY KEY, item TEXT); INSERT INTO users VALUES(1,'Alice'); INSERT INTO orders VALUES(1,'hat'); SELECT dolt_commit('-A','-m','initial');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -22,7 +22,7 @@ run_test "merge_orders" "SELECT count(*) FROM orders;" "2" "$DB"
 run_test "merge_log" "SELECT message FROM dolt_log LIMIT 1;" "Merge branch 'feature' into main" "$DB"
 run_test "merge_log_count" "SELECT count(*) FROM dolt_log;" "5" "$DB"
 
-# Test 2: Fast-forward merge
+
 DB2=/tmp/test_merge2_$$.db; rm -f "$DB2"
 echo "CREATE TABLE t(x); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB2" > /dev/null 2>&1
 echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB2" > /dev/null 2>&1
@@ -35,10 +35,10 @@ run_test "ff_after" "SELECT count(*) FROM t;" "2" "$DB2"
 run_test "ff_no_merge_commit" "SELECT message FROM dolt_log LIMIT 1;" "feature" "$DB2"
 run_test "ff_log_count" "SELECT count(*) FROM dolt_log;" "3" "$DB2"
 
-# Test 3: Already up to date
+
 run_test "up_to_date" "SELECT dolt_merge('feature');" "Already up to date" "$DB2"
 
-# Test 4: Conflict (both modify same table)
+
 DB3=/tmp/test_merge3_$$.db; rm -f "$DB3"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB3" > /dev/null 2>&1
 echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB3" > /dev/null 2>&1
@@ -49,10 +49,10 @@ echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB3" > /dev/null 2>&1
 run_test_match "conflict" "SELECT dolt_merge('feature');" "conflict" "$DB3"
 run_test "conflict_ours_preserved" "SELECT v FROM t;" "main" "$DB3"
 
-# Test 5: Nonexistent branch
+
 run_test_match "no_branch" "SELECT dolt_merge('nope');" "not found" "$DB3"
 
-# Test 6: Feature adds new table (only feature creates)
+
 DB4=/tmp/test_merge4_$$.db; rm -f "$DB4"
 echo "CREATE TABLE t(x); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB4" > /dev/null 2>&1
 echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB4" > /dev/null 2>&1
@@ -63,7 +63,7 @@ run_test_match "new_table_merge" "SELECT dolt_merge('feature');" "^[0-9a-f]{40}$
 run_test "new_table_visible" "SELECT y FROM new_t;" "42" "$DB4"
 run_test "original_intact" "SELECT x FROM t;" "1" "$DB4"
 
-# Test 7: Feature deletes row
+
 DB5=/tmp/test_merge5_$$.db; rm -f "$DB5"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'),(2,'b'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB5" > /dev/null 2>&1
 echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB5" > /dev/null 2>&1
@@ -74,7 +74,7 @@ run_test "pre_merge_rows" "SELECT count(*) FROM t;" "2" "$DB5"
 run_test_match "merge_del" "SELECT dolt_merge('feature');" "^[0-9a-f]{40}$" "$DB5"
 run_test "post_merge_rows" "SELECT count(*) FROM t;" "1" "$DB5"
 
-# Test 8: diff summary/stat after three-way merge (DB from Test 1)
+
 run_test "diff_3way_users" \
   "SELECT rows_modified FROM dolt_diff_stat((SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 3), (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 0), 'users');" \
   "1" "$DB"
@@ -82,17 +82,17 @@ run_test "diff_3way_orders" \
   "SELECT rows_added FROM dolt_diff_stat((SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 3), (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 0), 'orders');" \
   "1" "$DB"
 
-# Test 9: diff stat after fast-forward merge (DB2 from Test 2)
+
 run_test "diff_ff_added" \
   "SELECT rows_added FROM dolt_diff_stat((SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1), (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 0), 't');" \
   "1" "$DB2"
 
-# Test 10: After merge with conflicts, diff stat between init and HEAD shows the main change
+
 run_test "diff_conflict_shows_change" \
   "SELECT rows_modified FROM dolt_diff_stat((SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1), (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 0), 't');" \
   "1" "$DB3"
 
-# Test 11: Row-level auto-merge (both modify same table, different rows)
+
 DB6=/tmp/test_merge6_$$.db; rm -f "$DB6"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'),(2,'b'),(3,'c'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6" > /dev/null 2>&1
 echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB6" > /dev/null 2>&1
@@ -105,7 +105,7 @@ run_test "row_merge_row1" "SELECT v FROM t WHERE id=1;" "MAIN" "$DB6"
 run_test "row_merge_row2" "SELECT v FROM t WHERE id=2;" "b" "$DB6"
 run_test "row_merge_row3" "SELECT v FROM t WHERE id=3;" "FEAT" "$DB6"
 
-# Test 12: Row-level conflict (same row modified on both branches)
+
 DB7=/tmp/test_merge7_$$.db; rm -f "$DB7"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'orig'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB7" > /dev/null 2>&1
 echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB7" > /dev/null 2>&1
@@ -116,7 +116,7 @@ echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB7" > /dev/null 2>&1
 run_test_match "row_conflict_detected" "SELECT dolt_merge('feature');" "conflict" "$DB7"
 run_test "row_conflict_ours_kept" "SELECT v FROM t WHERE id=1;" "main-val" "$DB7"
 
-# Test 13: Mixed — some rows conflict, others auto-merge
+
 DB8=/tmp/test_merge8_$$.db; rm -f "$DB8"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'),(2,'b'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB8" > /dev/null 2>&1
 echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB8" > /dev/null 2>&1
@@ -159,21 +159,21 @@ else
   ERRORS="$ERRORS\nFAIL: mixed_merge_same_session_summary_cleared\n  expected: TX|0|main1|0\n  got:      $TX_OUT"
 fi
 
-# --- dolt_merge('--abort') ---
+
 DB9=/tmp/test_merge9_$$.db; rm -f "$DB9"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB9" > /dev/null 2>&1
 echo "SELECT dolt_branch('other'); SELECT dolt_checkout('other'); UPDATE t SET v='OTHER'; SELECT dolt_commit('-A','-m','other');" | $DOLTLITE "$DB9" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main'); UPDATE t SET v='MAIN'; SELECT dolt_commit('-A','-m','main');" | $DOLTLITE "$DB9" > /dev/null 2>&1
 
-# Conflicted merge inside an explicit transaction can be aborted.
+
 echo "BEGIN; SELECT dolt_merge('other'); SELECT dolt_merge('--abort'); COMMIT;" | $DOLTLITE "$DB9" > /dev/null 2>&1
 run_test "abort_no_conflicts" "SELECT count(*) FROM dolt_conflicts;" "0" "$DB9"
 run_test "abort_data_restored" "SELECT v FROM t WHERE id=1;" "MAIN" "$DB9"
 
-# Abort without merge in progress
+
 run_test_match "abort_no_merge" "SELECT dolt_merge('--abort');" "no merge in progress" "$DB9"
 
-# Clean merge still auto-commits
+
 DB10=/tmp/test_merge10_$$.db; rm -f "$DB10"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB10" > /dev/null 2>&1
 echo "SELECT dolt_branch('feat'); SELECT dolt_checkout('feat'); INSERT INTO t VALUES(2,'b'); SELECT dolt_commit('-A','-m','feat');" | $DOLTLITE "$DB10" > /dev/null 2>&1
@@ -183,7 +183,7 @@ run_test_match "clean_ff_merge" "SELECT dolt_merge('feat');" "^[0-9a-f]" "$DB10"
 run_test "clean_ff_log" "SELECT message FROM dolt_log LIMIT 1;" "feat" "$DB10"
 run_test "clean_ff_data" "SELECT count(*) FROM t;" "2" "$DB10"
 
-# Constraint-violation merge rolls back under autocommit
+
 DB11=/tmp/test_merge11_$$.db; rm -f "$DB11"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, u INT UNIQUE, v TEXT); INSERT INTO t VALUES(1,1,'base1'),(2,2,'base2'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB11" > /dev/null 2>&1
 echo "SELECT dolt_branch('feat'); SELECT dolt_checkout('feat'); UPDATE t SET u=9, v='feat2' WHERE id=2; SELECT dolt_commit('-A','-m','feat_unique');" | $DOLTLITE "$DB11" > /dev/null 2>&1
@@ -193,7 +193,7 @@ run_test "constraint_violation_no_conflicts" "SELECT count(*) FROM dolt_conflict
 run_test "constraint_violation_no_violations" "SELECT count(*) FROM dolt_constraint_violations;" "0" "$DB11"
 run_test "constraint_violation_state_restored" "SELECT group_concat(id || ':' || u || ':' || v, ',') FROM (SELECT id, u, v FROM t ORDER BY id);" "1:9:main1,2:2:base2" "$DB11"
 
-# Constraint-violation merge persists state inside an explicit transaction
+
 DB12=/tmp/test_merge12_$$.db; rm -f "$DB12"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, u INT UNIQUE, v TEXT); INSERT INTO t VALUES(1,1,'base1'),(2,2,'base2'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB12" > /dev/null 2>&1
 echo "SELECT dolt_branch('feat'); SELECT dolt_checkout('feat'); UPDATE t SET u=9, v='feat2' WHERE id=2; SELECT dolt_commit('-A','-m','feat_unique');" | $DOLTLITE "$DB12" > /dev/null 2>&1
@@ -209,7 +209,7 @@ else
   ERRORS="$ERRORS\nFAIL: constraint_violation_merge_tx_persists\n  expected: TX|0|1|1:9:main1,2:9:feat2\n  got:      $TX_OUT"
 fi
 
-# Disjoint new-table additions on both branches should auto-merge and persist
+
 DB13=/tmp/test_merge13_$$.db; rm -f "$DB13"
 echo "CREATE TABLE anchor(id INTEGER PRIMARY KEY); INSERT INTO anchor VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB13" > /dev/null 2>&1
 echo "SELECT dolt_branch('feat'); SELECT dolt_checkout('feat'); CREATE TABLE feat_tbl(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO feat_tbl VALUES(1,'f'); SELECT dolt_commit('-A','-m','feat_add_table');" | $DOLTLITE "$DB13" > /dev/null 2>&1
@@ -220,7 +220,7 @@ run_test "disjoint_new_tables_feat_present" "SELECT v FROM feat_tbl;" "f" "$DB13
 run_test "disjoint_new_tables_reopen_main" "SELECT v FROM main_tbl;" "m" "$DB13"
 run_test "disjoint_new_tables_reopen_feat" "SELECT v FROM feat_tbl;" "f" "$DB13"
 
-# Disjoint index additions on different existing tables should auto-merge.
+
 DB14=/tmp/test_merge14_$$.db; rm -f "$DB14"
 echo "CREATE TABLE a(id INTEGER PRIMARY KEY, v INT); CREATE TABLE b(id INTEGER PRIMARY KEY, v INT); INSERT INTO a VALUES(1,10); INSERT INTO b VALUES(1,20); SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');" | $DOLTLITE "$DB14" > /dev/null 2>&1
 echo "SELECT dolt_branch('feat'); CREATE INDEX idx_a_v ON a(v); SELECT dolt_add('-A'); SELECT dolt_commit('-m','main_idx');" | $DOLTLITE "$DB14" > /dev/null 2>&1
@@ -231,7 +231,7 @@ run_test "disjoint_indexes_visible" "SELECT count(*) FROM sqlite_master WHERE ty
 run_test "disjoint_indexes_reopen_data_a" "SELECT count(*) FROM a;" "1" "$DB14"
 run_test "disjoint_indexes_reopen_data_b" "SELECT count(*) FROM b;" "1" "$DB14"
 
-# Disjoint foreign-key additions on different existing tables should auto-merge.
+
 DB15=/tmp/test_merge15_$$.db; rm -f "$DB15"
 echo "CREATE TABLE p1(id INTEGER PRIMARY KEY); CREATE TABLE c1(id INTEGER PRIMARY KEY, p1_id INT); CREATE TABLE p2(id INTEGER PRIMARY KEY); CREATE TABLE c2(id INTEGER PRIMARY KEY, p2_id INT); INSERT INTO p1 VALUES(1); INSERT INTO p2 VALUES(1); SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');" | $DOLTLITE "$DB15" > /dev/null 2>&1
 echo "SELECT dolt_branch('feat'); ALTER TABLE c1 RENAME TO c1_old; CREATE TABLE c1(id INTEGER PRIMARY KEY, p1_id INT, CONSTRAINT fk_c1 FOREIGN KEY (p1_id) REFERENCES p1(id)); INSERT INTO c1 SELECT id,p1_id FROM c1_old; DROP TABLE c1_old; SELECT dolt_add('-A'); SELECT dolt_commit('-m','main_fk');" | $DOLTLITE "$DB15" > /dev/null 2>&1
@@ -241,7 +241,7 @@ run_test_match "disjoint_fks_merge_hash" "SELECT dolt_merge('feat');" "^[0-9a-f]
 run_test "disjoint_fks_c1" "SELECT count(*) FROM pragma_foreign_key_list('c1');" "1" "$DB15"
 run_test "disjoint_fks_c2" "SELECT count(*) FROM pragma_foreign_key_list('c2');" "1" "$DB15"
 
-# New table on one branch plus index on an existing table on the other should auto-merge.
+
 DB16=/tmp/test_merge16_$$.db; rm -f "$DB16"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT); INSERT INTO t VALUES(1,10); SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');" | $DOLTLITE "$DB16" > /dev/null 2>&1
 echo "SELECT dolt_branch('feat'); SELECT dolt_checkout('feat'); CREATE INDEX idx_t_v ON t(v); SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_idx');" | $DOLTLITE "$DB16" > /dev/null 2>&1
@@ -250,7 +250,7 @@ run_test_match "table_plus_index_merge_hash" "SELECT dolt_merge('feat');" "^[0-9
 run_test "table_plus_index_table_visible" "SELECT count(*) FROM main_only;" "1" "$DB16"
 run_test "table_plus_index_index_visible" "SELECT count(*) FROM sqlite_master WHERE type='index' AND name='idx_t_v';" "1" "$DB16"
 
-# New table on one branch plus unrelated CHECK constraint change on the other should auto-merge.
+
 DB17=/tmp/test_merge17_$$.db; rm -f "$DB17"
 echo "CREATE TABLE base(id INTEGER PRIMARY KEY, v INT); INSERT INTO base VALUES(1,1); SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');" | $DOLTLITE "$DB17" > /dev/null 2>&1
 echo "SELECT dolt_branch('feat'); SELECT dolt_checkout('feat'); CREATE TABLE feat_tbl(id INTEGER PRIMARY KEY, v INT); INSERT INTO feat_tbl VALUES(1,2); SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_add_table');" | $DOLTLITE "$DB17" > /dev/null 2>&1
@@ -259,7 +259,7 @@ run_test_match "table_plus_check_merge_hash" "SELECT dolt_merge('feat');" "^[0-9
 run_test "table_plus_check_table_visible" "SELECT count(*) FROM feat_tbl;" "1" "$DB17"
 run_test "table_plus_check_constraint_visible" "SELECT instr(sql,'CHECK')>0 FROM sqlite_master WHERE type='table' AND name='base';" "1" "$DB17"
 
-# New table on one branch plus unrelated rename on the other should auto-merge.
+
 DB18=/tmp/test_merge18_$$.db; rm -f "$DB18"
 echo "CREATE TABLE base(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO base VALUES(1,'x'); CREATE TABLE keep_main(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO keep_main VALUES(1,'m'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB18" > /dev/null 2>&1
 echo "SELECT dolt_branch('feat'); ALTER TABLE keep_main RENAME TO renamed_main; SELECT dolt_add('-A'); SELECT dolt_commit('-m','main_rename');" | $DOLTLITE "$DB18" > /dev/null 2>&1
@@ -269,7 +269,7 @@ run_test_match "table_plus_rename_merge_hash" "SELECT dolt_merge('feat');" "^[0-
 run_test "table_plus_rename_feat_visible" "SELECT count(*) FROM feat_tbl;" "1" "$DB18"
 run_test "table_plus_rename_new_name_visible" "SELECT count(*) FROM renamed_main;" "1" "$DB18"
 
-# New table on one branch plus unrelated drop/recreate on the other should auto-merge.
+
 DB19=/tmp/test_merge19_$$.db; rm -f "$DB19"
 echo "CREATE TABLE base(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO base VALUES(1,'x'); CREATE TABLE churn(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO churn VALUES(1,'m'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB19" > /dev/null 2>&1
 echo "SELECT dolt_branch('feat'); DROP TABLE churn; CREATE TABLE churn(k INTEGER PRIMARY KEY, n INT); INSERT INTO churn VALUES(7,70); SELECT dolt_add('-A'); SELECT dolt_commit('-m','main_recreate');" | $DOLTLITE "$DB19" > /dev/null 2>&1
@@ -279,8 +279,8 @@ run_test_match "table_plus_recreate_merge_hash" "SELECT dolt_merge('feat');" "^[
 run_test "table_plus_recreate_feat_visible" "SELECT count(*) FROM feat_tbl;" "1" "$DB19"
 run_test "table_plus_recreate_schema_visible" "SELECT instr(sql,'k INTEGER PRIMARY KEY')>0 FROM sqlite_master WHERE type='table' AND name='churn';" "1" "$DB19"
 
-# New FK-bearing parent/child tables on one branch plus unrelated CHECK
-# change on the other should auto-merge and remain visible.
+
+
 DB20=/tmp/test_merge20_$$.db; rm -f "$DB20"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT); INSERT INTO t VALUES(1,10); SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');" | $DOLTLITE "$DB20" > /dev/null 2>&1
 echo "SELECT dolt_branch('feat'); SELECT dolt_checkout('feat'); CREATE TABLE p(id INTEGER PRIMARY KEY, u INT UNIQUE); CREATE TABLE c(id INTEGER PRIMARY KEY, u INT, FOREIGN KEY(u) REFERENCES p(u)); INSERT INTO p VALUES(1,100); INSERT INTO c VALUES(1,100); SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_add_fk_tables');" | $DOLTLITE "$DB20" > /dev/null 2>&1
@@ -290,8 +290,8 @@ run_test "fk_tables_plus_check_parent_visible" "SELECT count(*) FROM p;" "1" "$D
 run_test "fk_tables_plus_check_child_visible" "SELECT count(*) FROM c;" "1" "$DB20"
 run_test "fk_tables_plus_check_fk_visible" "SELECT count(*) FROM pragma_foreign_key_list('c');" "1" "$DB20"
 
-# Same-name FK family recreate on one branch plus unrelated check on the other
-# should merge cleanly and keep the recreated parent's unique index live.
+
+
 DB20B=/tmp/test_merge20b_$$.db; rm -f "$DB20B"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT); INSERT INTO t VALUES(1,10); CREATE TABLE p(id INTEGER PRIMARY KEY, u INT UNIQUE); CREATE TABLE c(id INTEGER PRIMARY KEY, u INT, FOREIGN KEY(u) REFERENCES p(u)); INSERT INTO p VALUES(1,100); INSERT INTO c VALUES(1,100); SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');" | $DOLTLITE "$DB20B" > /dev/null 2>&1
 echo "SELECT dolt_branch('feat'); SELECT dolt_checkout('feat'); DROP TABLE c; DROP TABLE p; CREATE TABLE p(id INTEGER PRIMARY KEY, u INT UNIQUE, label TEXT); CREATE TABLE c(id INTEGER PRIMARY KEY, u INT, FOREIGN KEY(u) REFERENCES p(u)); INSERT INTO p VALUES(2,200,'x'); INSERT INTO c VALUES(2,200); SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_recreate_fk_family');" | $DOLTLITE "$DB20B" > /dev/null 2>&1
@@ -304,7 +304,7 @@ run_test "recreate_fk_family_parent_schema_visible" "SELECT instr(sql,'label TEX
 run_test "recreate_fk_family_parent_unique_index_live" "SELECT count(*) FROM p INDEXED BY sqlite_autoindex_p_1 WHERE u=200;" "1" "$DB20B"
 run_test "recreate_fk_family_fk_check_clean" "SELECT count(*) FROM pragma_foreign_key_check;" "0" "$DB20B"
 
-# Self-referential FK cascade should remain valid after merge and reopen.
+
 DB21=/tmp/test_merge21_$$.db; rm -f "$DB21"
 echo "PRAGMA foreign_keys=ON; CREATE TABLE t(id INTEGER PRIMARY KEY, parent_id INT, FOREIGN KEY(parent_id) REFERENCES t(id) ON DELETE CASCADE); INSERT INTO t VALUES(1,NULL),(2,1); SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');" | $DOLTLITE "$DB21" > /dev/null 2>&1
 echo "SELECT dolt_branch('feat'); SELECT dolt_checkout('feat'); INSERT INTO t VALUES(3,2); SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_add_descendant');" | $DOLTLITE "$DB21" > /dev/null 2>&1
@@ -314,7 +314,7 @@ run_test "self_ref_fk_delete_cascades_same_session" "PRAGMA foreign_keys=ON; DEL
 run_test "self_ref_fk_reopen_state" "PRAGMA foreign_keys=ON; SELECT group_concat(id || ':' || ifnull(parent_id,-1), ',') FROM (SELECT id,parent_id FROM t ORDER BY id);" "10:-1" "$DB21"
 run_test "self_ref_fk_reopen_delete_last_root" "PRAGMA foreign_keys=ON; DELETE FROM t WHERE id=10; SELECT count(*) FROM t;" "0" "$DB21"
 
-# Multi-level FK chain cascade should remain valid after merge and reopen.
+
 DB22=/tmp/test_merge22_$$.db; rm -f "$DB22"
 echo "PRAGMA foreign_keys=ON; CREATE TABLE gp(id INTEGER PRIMARY KEY); CREATE TABLE p(id INTEGER PRIMARY KEY, gp_id INT, FOREIGN KEY(gp_id) REFERENCES gp(id) ON DELETE CASCADE); CREATE TABLE c(id INTEGER PRIMARY KEY, p_id INT, FOREIGN KEY(p_id) REFERENCES p(id) ON DELETE CASCADE); INSERT INTO gp VALUES(1); INSERT INTO p VALUES(1,1); INSERT INTO c VALUES(1,1); SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');" | $DOLTLITE "$DB22" > /dev/null 2>&1
 echo "SELECT dolt_branch('feat'); SELECT dolt_checkout('feat'); INSERT INTO c VALUES(2,1); SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_add_child');" | $DOLTLITE "$DB22" > /dev/null 2>&1

--- a/test/doltlite_parity.sh
+++ b/test/doltlite_parity.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-#
-# SQLite parity tests for DoltLite.
-#
-# Runs identical SQL through both ./doltlite and the system sqlite3,
-# compares output. Any difference is a FAIL.
-#
+
+
+
+
+
+
 DOLTLITE=./doltlite
 SQLITE3=$(command -v sqlite3 2>/dev/null || echo /usr/bin/sqlite3)
 PASS=0; FAIL=0; SKIP=0; ERRORS=""
@@ -19,7 +19,7 @@ if ! command -v "$SQLITE3" >/dev/null 2>&1; then
   exit 1
 fi
 
-# Detect system sqlite3 version for feature gating
+
 SQLITE_VERSION=$("$SQLITE3" :memory: "SELECT sqlite_version();" 2>/dev/null)
 SQLITE_MAJOR=$(echo "$SQLITE_VERSION" | cut -d. -f1)
 SQLITE_MINOR=$(echo "$SQLITE_VERSION" | cut -d. -f2)
@@ -29,17 +29,17 @@ echo "DoltLite:       $DOLTLITE"
 echo "System sqlite3: $SQLITE3 (version $SQLITE_VERSION)"
 echo ""
 
-# Feature flags based on sqlite3 version
-HAS_WINDOW=0   # window functions: 3.25+
-HAS_JSON=0     # json functions: 3.38+ (built-in), or 3.9+ (extension)
-HAS_UPSERT=0   # upsert: 3.24+
-HAS_CTE=0      # CTEs: 3.8.3+
+
+HAS_WINDOW=0
+HAS_JSON=0
+HAS_UPSERT=0
+HAS_CTE=0
 
 if [ "$SQLITE_MAJOR" -gt 3 ] || { [ "$SQLITE_MAJOR" -eq 3 ] && [ "$SQLITE_MINOR" -ge 25 ]; }; then
   HAS_WINDOW=1
 fi
 if [ "$SQLITE_MAJOR" -gt 3 ] || { [ "$SQLITE_MAJOR" -eq 3 ] && [ "$SQLITE_MINOR" -ge 9 ]; }; then
-  # json may be available as extension from 3.9; test it
+
   if echo "SELECT json_array(1,2,3);" | "$SQLITE3" :memory: >/dev/null 2>&1; then
     HAS_JSON=1
   fi
@@ -48,9 +48,9 @@ if [ "$SQLITE_MAJOR" -gt 3 ] || { [ "$SQLITE_MAJOR" -eq 3 ] && [ "$SQLITE_MINOR"
   HAS_CTE=1
 fi
 
-# ---------------------------------------------------------------
-# Test runner: compare output of identical SQL on both engines
-# ---------------------------------------------------------------
+
+
+
 run_parity() {
   local name="$1"
   local sql="$2"
@@ -74,9 +74,9 @@ skip_test() {
   echo "  SKIP: $name ($reason)"
 }
 
-# ================================================================
-# 1. Basic CRUD
-# ================================================================
+
+
+
 echo "--- Basic CRUD ---"
 
 run_parity "insert_select" "
@@ -119,9 +119,9 @@ INSERT OR IGNORE INTO t VALUES(1,'second');
 SELECT * FROM t;
 "
 
-# ================================================================
-# 2. Aggregate functions
-# ================================================================
+
+
+
 echo "--- Aggregates ---"
 
 run_parity "count" "
@@ -193,9 +193,9 @@ INSERT INTO t VALUES(2,20);
 SELECT TOTAL(val) FROM t;
 "
 
-# ================================================================
-# 3. JOIN variants
-# ================================================================
+
+
+
 echo "--- JOINs ---"
 
 SETUP_JOIN="
@@ -246,9 +246,9 @@ INSERT INTO c VALUES(1,1,42);
 SELECT a.v, c.val FROM a JOIN b ON a.id=b.a_id JOIN c ON b.id=c.b_id;
 "
 
-# ================================================================
-# 4. Subqueries
-# ================================================================
+
+
+
 echo "--- Subqueries ---"
 
 run_parity "scalar_subquery" "
@@ -297,9 +297,9 @@ INSERT INTO t VALUES(3,'b',30);
 SELECT id, val FROM t t1 WHERE val = (SELECT MAX(val) FROM t t2 WHERE t2.grp=t1.grp) ORDER BY id;
 "
 
-# ================================================================
-# 5. Window functions
-# ================================================================
+
+
+
 echo "--- Window functions ---"
 
 if [ "$HAS_WINDOW" -eq 1 ]; then
@@ -350,9 +350,9 @@ else
   skip_test "window_functions" "sqlite3 $SQLITE_VERSION < 3.25"
 fi
 
-# ================================================================
-# 6. NULL handling
-# ================================================================
+
+
+
 echo "--- NULL handling ---"
 
 run_parity "is_null" "
@@ -399,9 +399,9 @@ run_parity "ifnull" "
 SELECT IFNULL(NULL, 'default'), IFNULL('value', 'default');
 "
 
-# ================================================================
-# 7. Type coercion and affinity
-# ================================================================
+
+
+
 echo "--- Type coercion / affinity ---"
 
 run_parity "typeof" "
@@ -432,9 +432,9 @@ run_parity "real_precision" "
 SELECT round(1.0/3.0, 12);
 "
 
-# ================================================================
-# 8. ORDER BY with COLLATE
-# ================================================================
+
+
+
 echo "--- ORDER BY / COLLATE ---"
 
 run_parity "order_asc_desc" "
@@ -474,9 +474,9 @@ INSERT INTO t VALUES(5,20);
 SELECT v FROM t ORDER BY v;
 "
 
-# ================================================================
-# 9. LIMIT / OFFSET
-# ================================================================
+
+
+
 echo "--- LIMIT / OFFSET ---"
 
 run_parity "limit" "
@@ -505,9 +505,9 @@ INSERT INTO t VALUES(1);
 SELECT * FROM t LIMIT 0;
 "
 
-# ================================================================
-# 10. CASE expressions
-# ================================================================
+
+
+
 echo "--- CASE expressions ---"
 
 run_parity "case_simple" "
@@ -531,9 +531,9 @@ SELECT CASE NULL WHEN NULL THEN 'match' ELSE 'no match' END;
 SELECT CASE WHEN NULL THEN 'true' ELSE 'false' END;
 "
 
-# ================================================================
-# 11. Date/time functions
-# ================================================================
+
+
+
 echo "--- Date/time functions ---"
 
 run_parity "date_func" "
@@ -570,9 +570,9 @@ run_parity "date_arithmetic" "
 SELECT julianday('2024-03-15') - julianday('2024-03-01');
 "
 
-# ================================================================
-# 12. JSON functions
-# ================================================================
+
+
+
 echo "--- JSON functions ---"
 
 if [ "$HAS_JSON" -eq 1 ]; then
@@ -617,9 +617,9 @@ else
   skip_test "json_functions" "sqlite3 $SQLITE_VERSION lacks JSON support"
 fi
 
-# ================================================================
-# 13. UNION, INTERSECT, EXCEPT
-# ================================================================
+
+
+
 echo "--- Set operations ---"
 
 run_parity "union" "
@@ -668,9 +668,9 @@ INSERT INTO b VALUES(4);
 SELECT v FROM a EXCEPT SELECT v FROM b ORDER BY v;
 "
 
-# ================================================================
-# 14. CTEs (WITH ... AS)
-# ================================================================
+
+
+
 echo "--- CTEs ---"
 
 if [ "$HAS_CTE" -eq 1 ]; then
@@ -712,9 +712,9 @@ else
   skip_test "cte" "sqlite3 $SQLITE_VERSION < 3.9"
 fi
 
-# ================================================================
-# 15. CAST expressions
-# ================================================================
+
+
+
 echo "--- CAST ---"
 
 run_parity "cast_text_to_int" "
@@ -745,9 +745,9 @@ run_parity "cast_blob" "
 SELECT typeof(CAST('hello' AS BLOB));
 "
 
-# ================================================================
-# Additional: string functions
-# ================================================================
+
+
+
 echo "--- String functions ---"
 
 run_parity "length" "
@@ -794,9 +794,9 @@ run_parity "zeroblob" "
 SELECT typeof(zeroblob(4)), length(zeroblob(4));
 "
 
-# ================================================================
-# Additional: math/numeric functions
-# ================================================================
+
+
+
 echo "--- Math / numeric ---"
 
 run_parity "abs" "
@@ -815,9 +815,9 @@ run_parity "round" "
 SELECT round(3.14159, 2), round(3.5), round(-2.5);
 "
 
-# ================================================================
-# Additional: misc
-# ================================================================
+
+
+
 echo "--- Miscellaneous ---"
 
 run_parity "between" "
@@ -919,7 +919,7 @@ run_parity "concatenation" "
 SELECT 'hello' || ' ' || 'world';
 "
 
-# --- Multi-row DELETE (issue #168) ---
+
 
 run_parity "delete_multi_row" "
 CREATE TABLE dt(id INT PRIMARY KEY, val INT);
@@ -945,9 +945,9 @@ DELETE FROM dm WHERE id%10=0;
 SELECT count(*) FROM dm;
 "
 
-# ================================================================
-# Summary
-# ================================================================
+
+
+
 echo ""
 echo "======================================="
 echo "Results: $PASS passed, $FAIL failed, $SKIP skipped out of $((PASS+FAIL+SKIP)) tests"

--- a/test/doltlite_parity.sh
+++ b/test/doltlite_parity.sh
@@ -1,10 +1,4 @@
 #!/bin/bash
-
-
-
-
-
-
 DOLTLITE=./doltlite
 SQLITE3=$(command -v sqlite3 2>/dev/null || echo /usr/bin/sqlite3)
 PASS=0; FAIL=0; SKIP=0; ERRORS=""
@@ -19,7 +13,6 @@ if ! command -v "$SQLITE3" >/dev/null 2>&1; then
   exit 1
 fi
 
-
 SQLITE_VERSION=$("$SQLITE3" :memory: "SELECT sqlite_version();" 2>/dev/null)
 SQLITE_MAJOR=$(echo "$SQLITE_VERSION" | cut -d. -f1)
 SQLITE_MINOR=$(echo "$SQLITE_VERSION" | cut -d. -f2)
@@ -28,7 +21,6 @@ echo "=== DoltLite SQLite Parity Tests ==="
 echo "DoltLite:       $DOLTLITE"
 echo "System sqlite3: $SQLITE3 (version $SQLITE_VERSION)"
 echo ""
-
 
 HAS_WINDOW=0
 HAS_JSON=0
@@ -39,7 +31,6 @@ if [ "$SQLITE_MAJOR" -gt 3 ] || { [ "$SQLITE_MAJOR" -eq 3 ] && [ "$SQLITE_MINOR"
   HAS_WINDOW=1
 fi
 if [ "$SQLITE_MAJOR" -gt 3 ] || { [ "$SQLITE_MAJOR" -eq 3 ] && [ "$SQLITE_MINOR" -ge 9 ]; }; then
-
   if echo "SELECT json_array(1,2,3);" | "$SQLITE3" :memory: >/dev/null 2>&1; then
     HAS_JSON=1
   fi
@@ -47,9 +38,6 @@ fi
 if [ "$SQLITE_MAJOR" -gt 3 ] || { [ "$SQLITE_MAJOR" -eq 3 ] && [ "$SQLITE_MINOR" -ge 9 ]; }; then
   HAS_CTE=1
 fi
-
-
-
 
 run_parity() {
   local name="$1"
@@ -73,9 +61,6 @@ skip_test() {
   SKIP=$((SKIP+1))
   echo "  SKIP: $name ($reason)"
 }
-
-
-
 
 echo "--- Basic CRUD ---"
 
@@ -118,9 +103,6 @@ INSERT INTO t VALUES(1,'first');
 INSERT OR IGNORE INTO t VALUES(1,'second');
 SELECT * FROM t;
 "
-
-
-
 
 echo "--- Aggregates ---"
 
@@ -193,9 +175,6 @@ INSERT INTO t VALUES(2,20);
 SELECT TOTAL(val) FROM t;
 "
 
-
-
-
 echo "--- JOINs ---"
 
 SETUP_JOIN="
@@ -246,9 +225,6 @@ INSERT INTO c VALUES(1,1,42);
 SELECT a.v, c.val FROM a JOIN b ON a.id=b.a_id JOIN c ON b.id=c.b_id;
 "
 
-
-
-
 echo "--- Subqueries ---"
 
 run_parity "scalar_subquery" "
@@ -296,9 +272,6 @@ INSERT INTO t VALUES(2,'a',20);
 INSERT INTO t VALUES(3,'b',30);
 SELECT id, val FROM t t1 WHERE val = (SELECT MAX(val) FROM t t2 WHERE t2.grp=t1.grp) ORDER BY id;
 "
-
-
-
 
 echo "--- Window functions ---"
 
@@ -350,9 +323,6 @@ else
   skip_test "window_functions" "sqlite3 $SQLITE_VERSION < 3.25"
 fi
 
-
-
-
 echo "--- NULL handling ---"
 
 run_parity "is_null" "
@@ -399,9 +369,6 @@ run_parity "ifnull" "
 SELECT IFNULL(NULL, 'default'), IFNULL('value', 'default');
 "
 
-
-
-
 echo "--- Type coercion / affinity ---"
 
 run_parity "typeof" "
@@ -431,9 +398,6 @@ SELECT 1 < 2, 1.0 = 1, '10' > '9', 10 > 9;
 run_parity "real_precision" "
 SELECT round(1.0/3.0, 12);
 "
-
-
-
 
 echo "--- ORDER BY / COLLATE ---"
 
@@ -474,9 +438,6 @@ INSERT INTO t VALUES(5,20);
 SELECT v FROM t ORDER BY v;
 "
 
-
-
-
 echo "--- LIMIT / OFFSET ---"
 
 run_parity "limit" "
@@ -505,9 +466,6 @@ INSERT INTO t VALUES(1);
 SELECT * FROM t LIMIT 0;
 "
 
-
-
-
 echo "--- CASE expressions ---"
 
 run_parity "case_simple" "
@@ -530,9 +488,6 @@ run_parity "case_null" "
 SELECT CASE NULL WHEN NULL THEN 'match' ELSE 'no match' END;
 SELECT CASE WHEN NULL THEN 'true' ELSE 'false' END;
 "
-
-
-
 
 echo "--- Date/time functions ---"
 
@@ -569,9 +524,6 @@ SELECT strftime('%H:%M', '2024-03-15 14:30:00');
 run_parity "date_arithmetic" "
 SELECT julianday('2024-03-15') - julianday('2024-03-01');
 "
-
-
-
 
 echo "--- JSON functions ---"
 
@@ -616,9 +568,6 @@ SELECT json_group_object(k,v) FROM t ORDER BY id;
 else
   skip_test "json_functions" "sqlite3 $SQLITE_VERSION lacks JSON support"
 fi
-
-
-
 
 echo "--- Set operations ---"
 
@@ -668,9 +617,6 @@ INSERT INTO b VALUES(4);
 SELECT v FROM a EXCEPT SELECT v FROM b ORDER BY v;
 "
 
-
-
-
 echo "--- CTEs ---"
 
 if [ "$HAS_CTE" -eq 1 ]; then
@@ -712,9 +658,6 @@ else
   skip_test "cte" "sqlite3 $SQLITE_VERSION < 3.9"
 fi
 
-
-
-
 echo "--- CAST ---"
 
 run_parity "cast_text_to_int" "
@@ -744,9 +687,6 @@ SELECT CAST(NULL AS INTEGER), CAST(NULL AS TEXT), CAST(NULL AS REAL);
 run_parity "cast_blob" "
 SELECT typeof(CAST('hello' AS BLOB));
 "
-
-
-
 
 echo "--- String functions ---"
 
@@ -794,9 +734,6 @@ run_parity "zeroblob" "
 SELECT typeof(zeroblob(4)), length(zeroblob(4));
 "
 
-
-
-
 echo "--- Math / numeric ---"
 
 run_parity "abs" "
@@ -814,9 +751,6 @@ SELECT typeof(random());
 run_parity "round" "
 SELECT round(3.14159, 2), round(3.5), round(-2.5);
 "
-
-
-
 
 echo "--- Miscellaneous ---"
 
@@ -919,8 +853,6 @@ run_parity "concatenation" "
 SELECT 'hello' || ' ' || 'world';
 "
 
-
-
 run_parity "delete_multi_row" "
 CREATE TABLE dt(id INT PRIMARY KEY, val INT);
 INSERT INTO dt VALUES(1,1),(2,2),(3,3),(4,4),(5,5);
@@ -944,9 +876,6 @@ INSERT INTO dm SELECT x,x FROM c;
 DELETE FROM dm WHERE id%10=0;
 SELECT count(*) FROM dm;
 "
-
-
-
 
 echo ""
 echo "======================================="

--- a/test/doltlite_perf.sh
+++ b/test/doltlite_perf.sh
@@ -1,14 +1,4 @@
 #!/bin/bash
-
-
-
-
-
-
-
-
-
-
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 
@@ -38,10 +28,6 @@ assert_ratio() {
   fi
 }
 
-
-
-
-
 echo "Setting up databases..."
 
 for SIZE in 1000 100000 1000000; do
@@ -60,10 +46,6 @@ done
 DB_1K="/tmp/perf_1000_$$.db"
 DB_100K="/tmp/perf_100000_$$.db"
 DB_1M="/tmp/perf_1000000_$$.db"
-
-
-
-
 
 echo ""
 echo "--- Bulk INSERT ---"
@@ -86,12 +68,7 @@ print('COMMIT;')
 \" | $DOLTLITE '$DB_100K'")
 echo "  100K: ${T_INS_100K}ms"
 
-
 assert_ratio "insert_1k_to_100k" "$T_INS_1K" "$T_INS_100K" 300
-
-
-
-
 
 echo ""
 echo "--- Point SELECT (100 lookups) ---"
@@ -105,13 +82,8 @@ echo "  100K: ${T_SEL_100K}ms"
 T_SEL_1M=$(time_ms "for i in \$(seq 1 100); do echo 'SELECT v FROM t WHERE id=500000;' | $DOLTLITE '$DB_1M'; done")
 echo "  1M: ${T_SEL_1M}ms"
 
-
 assert_ratio "select_1k_to_100k" "$T_SEL_1K" "$T_SEL_100K" 10
 assert_ratio "select_100k_to_1m" "$T_SEL_100K" "$T_SEL_1M" 10
-
-
-
-
 
 echo ""
 echo "--- Single-row UPDATE ---"
@@ -128,10 +100,6 @@ echo "  1M: ${T_UPD_1M}ms"
 assert_ratio "update_1k_to_100k" "$T_UPD_1K" "$T_UPD_100K" 10
 assert_ratio "update_100k_to_1m" "$T_UPD_100K" "$T_UPD_1M" 10
 
-
-
-
-
 echo ""
 echo "--- Single-row DELETE ---"
 
@@ -147,14 +115,8 @@ echo "  1M: ${T_DEL_1M}ms"
 assert_ratio "delete_1k_to_100k" "$T_DEL_1K" "$T_DEL_100K" 10
 assert_ratio "delete_100k_to_1m" "$T_DEL_100K" "$T_DEL_1M" 10
 
-
-
-
-
-
 echo ""
 echo "--- dolt_diff after single-row UPDATE ---"
-
 
 echo "SELECT dolt_commit('-A','-m','baseline');
 UPDATE t SET v='diffme' WHERE id=0;" | $DOLTLITE "$DB_1K" > /dev/null 2>&1
@@ -175,14 +137,8 @@ echo "  1M: ${T_DIFF_1M}ms"
 assert_ratio "diff_1k_to_100k" "$T_DIFF_1K" "$T_DIFF_100K" 10
 assert_ratio "diff_100k_to_1m" "$T_DIFF_100K" "$T_DIFF_1M" 10
 
-
-
-
-
 echo ""
 echo "--- Diff correctness ---"
-
-
 
 for pair in "1K:$DB_1K"; do
   name="${pair%%:*}"; db="${pair#*:}"
@@ -194,10 +150,6 @@ for pair in "1K:$DB_1K"; do
     echo "  FAIL: diff_correct_$name — expected 1, got $val"
   fi
 done
-
-
-
-
 
 echo ""
 echo "--- Diff between commits: O(changes) ---"
@@ -214,7 +166,6 @@ print(\"SELECT dolt_commit('-A','-m','init');\")
 " | $DOLTLITE "$DB_DIFF" > /dev/null 2>&1
 echo "  Setup: 1M rows committed"
 
-
 python3 -c "
 for i in range(10):
     print(f'UPDATE t SET v=\"changed_{i}\" WHERE id={i};')
@@ -227,14 +178,11 @@ T_DIFF_10=$(time_ms "echo \"SELECT rows_added + rows_deleted + rows_modified FRO
   't');\" | $DOLTLITE '$DB_DIFF'")
 echo "  10 changes (1M table): ${T_DIFF_10}ms"
 
-
-
 DIFF_10_COUNT=$(echo "SELECT rows_added + rows_deleted + rows_modified FROM dolt_diff_stat(
   (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1),
   (SELECT commit_hash FROM dolt_log LIMIT 1),
   't');" | $DOLTLITE "$DB_DIFF" 2>&1)
 echo "  (correctness: $DIFF_10_COUNT changes — known issue if 0 on large tables)"
-
 
 python3 -c "
 for i in range(100, 1100):
@@ -254,18 +202,9 @@ DIFF_1000_COUNT=$(echo "SELECT rows_added + rows_deleted + rows_modified FROM do
   't');" | $DOLTLITE "$DB_DIFF" 2>&1)
 echo "  (correctness: $DIFF_1000_COUNT changes)"
 
-
 assert_ratio "diff_10_to_1000_changes" "$T_DIFF_10" "$T_DIFF_1000" 200
 
-
-
-
-
 rm -f "$DB_DIFF"
-
-
-
-
 
 rm -f "$DB_1K" "$DB_100K" "$DB_1M"
 

--- a/test/doltlite_perf.sh
+++ b/test/doltlite_perf.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
-#
-# Performance tests with assertions for Doltlite.
-#
-# Verifies:
-# - Bulk INSERT scales as O(n log n)
-# - Point SELECT, UPDATE, DELETE scale as O(log n)
-# - dolt_diff after a single-row update is ~constant time
-#
-# Sizes: 1K, 100K, 1M rows.
-#
+
+
+
+
+
+
+
+
+
+
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 
@@ -38,9 +38,9 @@ assert_ratio() {
   fi
 }
 
-# ============================================================
-# Setup: create committed tables at 1K, 100K, 1M rows
-# ============================================================
+
+
+
 
 echo "Setting up databases..."
 
@@ -61,9 +61,9 @@ DB_1K="/tmp/perf_1000_$$.db"
 DB_100K="/tmp/perf_100000_$$.db"
 DB_1M="/tmp/perf_1000000_$$.db"
 
-# ============================================================
-# Bulk INSERT (O(n log n))
-# ============================================================
+
+
+
 
 echo ""
 echo "--- Bulk INSERT ---"
@@ -86,12 +86,12 @@ print('COMMIT;')
 \" | $DOLTLITE '$DB_100K'")
 echo "  100K: ${T_INS_100K}ms"
 
-# 100x more rows, O(n log n) → ~150x. Allow 300x for CI variance.
+
 assert_ratio "insert_1k_to_100k" "$T_INS_1K" "$T_INS_100K" 300
 
-# ============================================================
-# Point SELECT by PK (O(log n)) — 100 iterations each
-# ============================================================
+
+
+
 
 echo ""
 echo "--- Point SELECT (100 lookups) ---"
@@ -105,13 +105,13 @@ echo "  100K: ${T_SEL_100K}ms"
 T_SEL_1M=$(time_ms "for i in \$(seq 1 100); do echo 'SELECT v FROM t WHERE id=500000;' | $DOLTLITE '$DB_1M'; done")
 echo "  1M: ${T_SEL_1M}ms"
 
-# O(log n): 100x more rows → at most 10x slower
+
 assert_ratio "select_1k_to_100k" "$T_SEL_1K" "$T_SEL_100K" 10
 assert_ratio "select_100k_to_1m" "$T_SEL_100K" "$T_SEL_1M" 10
 
-# ============================================================
-# Single-row UPDATE (O(log n))
-# ============================================================
+
+
+
 
 echo ""
 echo "--- Single-row UPDATE ---"
@@ -128,9 +128,9 @@ echo "  1M: ${T_UPD_1M}ms"
 assert_ratio "update_1k_to_100k" "$T_UPD_1K" "$T_UPD_100K" 10
 assert_ratio "update_100k_to_1m" "$T_UPD_100K" "$T_UPD_1M" 10
 
-# ============================================================
-# Single-row DELETE (O(log n))
-# ============================================================
+
+
+
 
 echo ""
 echo "--- Single-row DELETE ---"
@@ -147,15 +147,15 @@ echo "  1M: ${T_DEL_1M}ms"
 assert_ratio "delete_1k_to_100k" "$T_DEL_1K" "$T_DEL_100K" 10
 assert_ratio "delete_100k_to_1m" "$T_DEL_100K" "$T_DEL_1M" 10
 
-# ============================================================
-# dolt_diff after single-row UPDATE (~constant time)
-# Commit baseline, update one row, measure diff — all in one session.
-# ============================================================
+
+
+
+
 
 echo ""
 echo "--- dolt_diff after single-row UPDATE ---"
 
-# Commit all pending changes first, then update one row, then diff
+
 echo "SELECT dolt_commit('-A','-m','baseline');
 UPDATE t SET v='diffme' WHERE id=0;" | $DOLTLITE "$DB_1K" > /dev/null 2>&1
 echo "SELECT dolt_commit('-A','-m','baseline');
@@ -175,15 +175,15 @@ echo "  1M: ${T_DIFF_1M}ms"
 assert_ratio "diff_1k_to_100k" "$T_DIFF_1K" "$T_DIFF_100K" 10
 assert_ratio "diff_100k_to_1m" "$T_DIFF_100K" "$T_DIFF_1M" 10
 
-# ============================================================
-# Diff correctness: exactly 1 change at each size
-# ============================================================
+
+
+
 
 echo ""
 echo "--- Diff correctness ---"
 
-# Note: diff correctness at 100K/1M has a known issue where dolt_commit
-# inside the same session invalidates the schema cache. Using 1K only.
+
+
 for pair in "1K:$DB_1K"; do
   name="${pair%%:*}"; db="${pair#*:}"
   val=$(echo "SELECT count(*) FROM dolt_diff_t WHERE to_commit='WORKING';" | $DOLTLITE "$db" 2>&1)
@@ -195,9 +195,9 @@ for pair in "1K:$DB_1K"; do
   fi
 done
 
-# ============================================================
-# Diff between commits: O(changes) not O(table_size)
-# ============================================================
+
+
+
 
 echo ""
 echo "--- Diff between commits: O(changes) ---"
@@ -214,7 +214,7 @@ print(\"SELECT dolt_commit('-A','-m','init');\")
 " | $DOLTLITE "$DB_DIFF" > /dev/null 2>&1
 echo "  Setup: 1M rows committed"
 
-# Make 10 changes and commit
+
 python3 -c "
 for i in range(10):
     print(f'UPDATE t SET v=\"changed_{i}\" WHERE id={i};')
@@ -227,15 +227,15 @@ T_DIFF_10=$(time_ms "echo \"SELECT rows_added + rows_deleted + rows_modified FRO
   't');\" | $DOLTLITE '$DB_DIFF'")
 echo "  10 changes (1M table): ${T_DIFF_10}ms"
 
-# Correctness check (known schema cache issue on 1M after dolt_commit
-# in same session — skip for now, correctness verified at 1K above)
+
+
 DIFF_10_COUNT=$(echo "SELECT rows_added + rows_deleted + rows_modified FROM dolt_diff_stat(
   (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1),
   (SELECT commit_hash FROM dolt_log LIMIT 1),
   't');" | $DOLTLITE "$DB_DIFF" 2>&1)
 echo "  (correctness: $DIFF_10_COUNT changes — known issue if 0 on large tables)"
 
-# Make 1000 changes (non-overlapping range) and commit
+
 python3 -c "
 for i in range(100, 1100):
     print(f'UPDATE t SET v=\"changed2_{i}\" WHERE id={i};')
@@ -254,18 +254,18 @@ DIFF_1000_COUNT=$(echo "SELECT rows_added + rows_deleted + rows_modified FROM do
   't');" | $DOLTLITE "$DB_DIFF" 2>&1)
 echo "  (correctness: $DIFF_1000_COUNT changes)"
 
-# 100x more changes → at most 200x time
+
 assert_ratio "diff_10_to_1000_changes" "$T_DIFF_10" "$T_DIFF_1000" 200
 
-# The meaningful working-diff scaling guard is the 100K -> 1M check above.
-# A 1K table is too small for this shell-level harness: process startup and
-# query dispatch dominate the timing and make 1K -> 1M ratios noisy in CI.
+
+
+
 
 rm -f "$DB_DIFF"
 
-# ============================================================
-# Cleanup
-# ============================================================
+
+
+
 
 rm -f "$DB_1K" "$DB_100K" "$DB_1M"
 

--- a/test/doltlite_persistence.sh
+++ b/test/doltlite_persistence.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-#
-# File persistence tests for Doltlite.
-#
-# Every test writes data, closes the DB, reopens it, and verifies
-# the data survived. Tests at multiple scales (3 rows, 100 rows,
-# 1000 rows) to catch size-dependent bugs.
-#
+
+
+
+
+
+
+
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
@@ -14,9 +14,9 @@ run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -
 echo "=== Doltlite File Persistence Tests ==="
 echo ""
 
-# ============================================================
-# Basic: INSERT + commit persists across reopen
-# ============================================================
+
+
+
 
 echo "--- Basic persistence ---"
 
@@ -32,16 +32,16 @@ run_test "basic_val2" "SELECT v FROM t WHERE id=2;" "world" "$DB"
 run_test "basic_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 run_test_match "basic_msg" "SELECT message FROM dolt_log;" "init" "$DB"
 
-# Single-file: doltlite creates exactly one file, no -wal or -journal
+
 nFiles=$(ls "$DB"* 2>/dev/null | wc -l | tr -d ' ')
 if [ "$nFiles" = "1" ]; then PASS=$((PASS+1))
 else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: single_file\n  expected: 1 file\n  got:      $nFiles files ($(ls "$DB"* 2>/dev/null | tr '\n' ' '))"; fi
 
 rm -f "$DB"
 
-# ============================================================
-# Multiple commits persist
-# ============================================================
+
+
+
 
 echo ""
 echo "--- Multiple commits ---"
@@ -61,9 +61,9 @@ run_test_match "multi_latest" "SELECT message FROM dolt_log LIMIT 1;" "c3" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Bulk INSERT via BEGIN/COMMIT persists (100 rows)
-# ============================================================
+
+
+
 
 echo ""
 echo "--- Bulk 100 rows ---"
@@ -86,9 +86,9 @@ run_test "bulk100_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Bulk INSERT 1000 rows persists
-# ============================================================
+
+
+
 
 echo ""
 echo "--- Bulk 1000 rows ---"
@@ -110,9 +110,9 @@ run_test "bulk1k_mid" "SELECT v FROM t WHERE id=500;" "row_500" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# UPDATE persists
-# ============================================================
+
+
+
 
 echo ""
 echo "--- UPDATE persistence ---"
@@ -129,9 +129,9 @@ run_test "update_log" "SELECT count(*) FROM dolt_log;" "3" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# DELETE persists
-# ============================================================
+
+
+
 
 echo ""
 echo "--- DELETE persistence ---"
@@ -152,9 +152,9 @@ run_test "delete_has3" "SELECT v FROM t WHERE id=3;" "c" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Branch persists
-# ============================================================
+
+
+
 
 echo ""
 echo "--- Branch persistence ---"
@@ -172,16 +172,16 @@ SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "branch_count" "SELECT count(*) FROM dolt_branches;" "2" "$DB"
 run_test "branch_main" "SELECT count(*) FROM t;" "1" "$DB"
 
-# Switch to feat and verify
+
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "branch_feat" "SELECT count(*) FROM t;" "2" "$DB/feat"
 run_test "branch_feat_val" "SELECT v FROM t WHERE id=2;" "feat_data" "$DB/feat"
 
 rm -f "$DB"
 
-# ============================================================
-# Tag persists
-# ============================================================
+
+
+
 
 echo ""
 echo "--- Tag persistence ---"
@@ -201,9 +201,9 @@ run_test_match "tag_v2" "SELECT tag_name FROM dolt_tags WHERE tag_name='v2.0';" 
 
 rm -f "$DB"
 
-# ============================================================
-# Merge result persists
-# ============================================================
+
+
+
 
 echo ""
 echo "--- Merge persistence ---"
@@ -229,9 +229,9 @@ run_test_match "merge_log" "SELECT message FROM dolt_log LIMIT 1;" "Merge" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Schema changes persist (ALTER TABLE)
-# ============================================================
+
+
+
 
 echo ""
 echo "--- Schema persistence ---"
@@ -250,9 +250,9 @@ run_test_match "schema_cols" "PRAGMA table_info(t);" "extra" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Multiple tables persist
-# ============================================================
+
+
+
 
 echo ""
 echo "--- Multi-table persistence ---"
@@ -274,9 +274,9 @@ run_test "mt_alice" "SELECT name FROM users WHERE id=1;" "Alice" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# GC result persists
-# ============================================================
+
+
+
 
 echo ""
 echo "--- GC persistence ---"
@@ -299,9 +299,9 @@ run_test "gc_branches" "SELECT count(*) FROM dolt_branches;" "1" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Uncommitted data does NOT persist (no dolt_commit)
-# ============================================================
+
+
+
 
 echo ""
 echo "--- Uncommitted data lost on reopen ---"
@@ -312,16 +312,16 @@ INSERT INTO t VALUES(1,'committed');
 SELECT dolt_commit('-A','-m','init');
 INSERT INTO t VALUES(2,'uncommitted');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# The uncommitted row should survive (SQL autocommit persists to chunk store)
-# but dolt_status should show it as uncommitted
+
+
 run_test "uncommit_count" "SELECT count(*) FROM t;" "2" "$DB"
 run_test_match "uncommit_status" "SELECT count(*) FROM dolt_status;" "^[1-9]" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Bulk 1000 rows with UPDATE and DELETE persists
-# ============================================================
+
+
+
 
 echo ""
 echo "--- Bulk with modifications ---"
@@ -347,9 +347,9 @@ run_test "bulkmod_log" "SELECT count(*) FROM dolt_log;" "3" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Rapid open/close cycles
-# ============================================================
+
+
+
 
 echo ""
 echo "--- Rapid open/close ---"
@@ -369,9 +369,9 @@ run_test "rapid_val5" "SELECT v FROM t WHERE id=5;" "val_5" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# File size is reasonable (not empty, not corrupt)
-# ============================================================
+
+
+
 
 echo ""
 echo "--- File size sanity ---"
@@ -381,7 +381,7 @@ echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'data');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Check total size of DB + WAL files
+
 SIZE=0
 for f in "$DB" "${DB}-wal"; do
   if [ -f "$f" ]; then
@@ -398,13 +398,13 @@ fi
 
 rm -f "$DB" "${DB}-wal"
 
-# ============================================================
-# Branch commit reopen with manifest head divergence.
-# Triggers the code path where branch tip != manifest head:
-# commit on dev, then commit on main (making main the manifest
-# head), then reopen on dev. The bug: p->root was set from the
-# always-empty commit.rootHash, zeroing the working tree.
-# ============================================================
+
+
+
+
+
+
+
 
 echo ""
 echo "--- Branch commit reopen (diverged manifest head) ---"
@@ -422,7 +422,7 @@ SELECT dolt_checkout('main');
 INSERT INTO t VALUES(3,'main_again');
 SELECT dolt_commit('-A','-m','main second');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Reopen on dev — manifest head is main's latest, not dev's
+
 run_test "diverged_dev_count" "SELECT count(*) FROM t;" "2" "$DB/dev"
 run_test "diverged_dev_val" "SELECT v FROM t WHERE id=2;" "from_dev" "$DB/dev"
 
@@ -432,9 +432,9 @@ run_test "diverged_main_val" "SELECT v FROM t WHERE id=3;" "main_again" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Done
-# ============================================================
+
+
+
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/doltlite_persistence.sh
+++ b/test/doltlite_persistence.sh
@@ -1,11 +1,4 @@
 #!/bin/bash
-
-
-
-
-
-
-
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
@@ -13,10 +6,6 @@ run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -
 
 echo "=== Doltlite File Persistence Tests ==="
 echo ""
-
-
-
-
 
 echo "--- Basic persistence ---"
 
@@ -32,16 +21,11 @@ run_test "basic_val2" "SELECT v FROM t WHERE id=2;" "world" "$DB"
 run_test "basic_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 run_test_match "basic_msg" "SELECT message FROM dolt_log;" "init" "$DB"
 
-
 nFiles=$(ls "$DB"* 2>/dev/null | wc -l | tr -d ' ')
 if [ "$nFiles" = "1" ]; then PASS=$((PASS+1))
 else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: single_file\n  expected: 1 file\n  got:      $nFiles files ($(ls "$DB"* 2>/dev/null | tr '\n' ' '))"; fi
 
 rm -f "$DB"
-
-
-
-
 
 echo ""
 echo "--- Multiple commits ---"
@@ -60,10 +44,6 @@ run_test "multi_log" "SELECT count(*) FROM dolt_log;" "4" "$DB"
 run_test_match "multi_latest" "SELECT message FROM dolt_log LIMIT 1;" "c3" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 echo ""
 echo "--- Bulk 100 rows ---"
@@ -86,10 +66,6 @@ run_test "bulk100_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 
 rm -f "$DB"
 
-
-
-
-
 echo ""
 echo "--- Bulk 1000 rows ---"
 
@@ -110,10 +86,6 @@ run_test "bulk1k_mid" "SELECT v FROM t WHERE id=500;" "row_500" "$DB"
 
 rm -f "$DB"
 
-
-
-
-
 echo ""
 echo "--- UPDATE persistence ---"
 
@@ -128,10 +100,6 @@ run_test "update_val" "SELECT v FROM t WHERE id=1;" "changed" "$DB"
 run_test "update_log" "SELECT count(*) FROM dolt_log;" "3" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 echo ""
 echo "--- DELETE persistence ---"
@@ -152,10 +120,6 @@ run_test "delete_has3" "SELECT v FROM t WHERE id=3;" "c" "$DB"
 
 rm -f "$DB"
 
-
-
-
-
 echo ""
 echo "--- Branch persistence ---"
 
@@ -172,16 +136,11 @@ SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "branch_count" "SELECT count(*) FROM dolt_branches;" "2" "$DB"
 run_test "branch_main" "SELECT count(*) FROM t;" "1" "$DB"
 
-
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "branch_feat" "SELECT count(*) FROM t;" "2" "$DB/feat"
 run_test "branch_feat_val" "SELECT v FROM t WHERE id=2;" "feat_data" "$DB/feat"
 
 rm -f "$DB"
-
-
-
-
 
 echo ""
 echo "--- Tag persistence ---"
@@ -200,10 +159,6 @@ run_test_match "tag_v1" "SELECT tag_name FROM dolt_tags WHERE tag_name='v1.0';" 
 run_test_match "tag_v2" "SELECT tag_name FROM dolt_tags WHERE tag_name='v2.0';" "v2.0" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 echo ""
 echo "--- Merge persistence ---"
@@ -229,10 +184,6 @@ run_test_match "merge_log" "SELECT message FROM dolt_log LIMIT 1;" "Merge" "$DB"
 
 rm -f "$DB"
 
-
-
-
-
 echo ""
 echo "--- Schema persistence ---"
 
@@ -249,10 +200,6 @@ run_test "schema_v" "SELECT v FROM t WHERE id=1;" "a" "$DB"
 run_test_match "schema_cols" "PRAGMA table_info(t);" "extra" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 echo ""
 echo "--- Multi-table persistence ---"
@@ -273,10 +220,6 @@ run_test "mt_products" "SELECT price FROM products WHERE id=1;" "999" "$DB"
 run_test "mt_alice" "SELECT name FROM users WHERE id=1;" "Alice" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 echo ""
 echo "--- GC persistence ---"
@@ -299,10 +242,6 @@ run_test "gc_branches" "SELECT count(*) FROM dolt_branches;" "1" "$DB"
 
 rm -f "$DB"
 
-
-
-
-
 echo ""
 echo "--- Uncommitted data lost on reopen ---"
 
@@ -312,16 +251,10 @@ INSERT INTO t VALUES(1,'committed');
 SELECT dolt_commit('-A','-m','init');
 INSERT INTO t VALUES(2,'uncommitted');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
-
 run_test "uncommit_count" "SELECT count(*) FROM t;" "2" "$DB"
 run_test_match "uncommit_status" "SELECT count(*) FROM dolt_status;" "^[1-9]" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 echo ""
 echo "--- Bulk with modifications ---"
@@ -347,10 +280,6 @@ run_test "bulkmod_log" "SELECT count(*) FROM dolt_log;" "3" "$DB"
 
 rm -f "$DB"
 
-
-
-
-
 echo ""
 echo "--- Rapid open/close ---"
 
@@ -369,10 +298,6 @@ run_test "rapid_val5" "SELECT v FROM t WHERE id=5;" "val_5" "$DB"
 
 rm -f "$DB"
 
-
-
-
-
 echo ""
 echo "--- File size sanity ---"
 
@@ -380,7 +305,6 @@ DB=/tmp/test_persist_size_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'data');
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 SIZE=0
 for f in "$DB" "${DB}-wal"; do
@@ -398,14 +322,6 @@ fi
 
 rm -f "$DB" "${DB}-wal"
 
-
-
-
-
-
-
-
-
 echo ""
 echo "--- Branch commit reopen (diverged manifest head) ---"
 
@@ -422,7 +338,6 @@ SELECT dolt_checkout('main');
 INSERT INTO t VALUES(3,'main_again');
 SELECT dolt_commit('-A','-m','main second');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "diverged_dev_count" "SELECT count(*) FROM t;" "2" "$DB/dev"
 run_test "diverged_dev_val" "SELECT v FROM t WHERE id=2;" "from_dev" "$DB/dev"
 
@@ -431,10 +346,6 @@ run_test "diverged_main_count" "SELECT count(*) FROM t;" "2" "$DB"
 run_test "diverged_main_val" "SELECT v FROM t WHERE id=3;" "main_again" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/doltlite_rebase_schema.sh
+++ b/test/doltlite_rebase_schema.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-#
-# Local regressions for schema-edge non-interactive rebase behavior.
-#
+
+
+
 set -u
 set -o pipefail
 

--- a/test/doltlite_rebase_schema.sh
+++ b/test/doltlite_rebase_schema.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
-
-
-
 set -u
 set -o pipefail
 

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -1,53 +1,3 @@
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -5534,11 +5484,6 @@ static int mutmapAssertMatchesModel(
 }
 
 static void run_mutmap_resolve_sorted_pos(void){
-
-
-
-
-
   ProllyMutMap sorted, lazy;
   i64 keys[] = { 10, 30, 20, 50, 40 };
   int n = sizeof(keys)/sizeof(keys[0]);
@@ -5566,9 +5511,6 @@ static void run_mutmap_resolve_sorted_pos(void){
     check("rsp_insert_bumps_gen_lazy",   lazy.generation   > gen0);
   }
 
-
-
-
   gen0 = sorted.generation;
   val = 999;
   check("rsp_inplace_update_sorted_rc",
@@ -5579,9 +5521,6 @@ static void run_mutmap_resolve_sorted_pos(void){
   check("rsp_inplace_update_lazy_rc",
         prollyMutMapInsert(&lazy,   0, 0, 30, (const u8*)&val, sizeof(val))==SQLITE_OK);
   check("rsp_inplace_does_not_bump_lazy",   lazy.generation == gen0);
-
-
-
 
   check("rsp_resolve_present_10_sorted",
         prollyMutMapResolveSortedPos(&sorted, 0, 0, 10, &idx, &found)==SQLITE_OK
@@ -5602,8 +5541,6 @@ static void run_mutmap_resolve_sorted_pos(void){
         prollyMutMapResolveSortedPos(&sorted, 0, 0, 999, &idx, &found)==SQLITE_OK
           && idx==5 && !found);
 
-
-
   check("rsp_resolve_present_30_lazy",
         prollyMutMapResolveSortedPos(&lazy,   0, 0, 30, &idx, &found)==SQLITE_OK
           && idx==2 && found);
@@ -5614,7 +5551,6 @@ static void run_mutmap_resolve_sorted_pos(void){
         prollyMutMapResolveSortedPos(&lazy,   0, 0, 999, &idx, &found)==SQLITE_OK
           && idx==5 && !found);
 
-
   {
     ProllyMutMap empty;
     check("rsp_init_empty", prollyMutMapInitMode(&empty, 1, 1)==SQLITE_OK);
@@ -5624,14 +5560,10 @@ static void run_mutmap_resolve_sorted_pos(void){
     prollyMutMapFree(&empty);
   }
 
-
-
   gen0 = sorted.generation;
   check("rsp_delete_absent_sorted_rc",
         prollyMutMapDelete(&sorted, 0, 0, 999)==SQLITE_OK);
   check("rsp_delete_absent_bumps_gen_sorted", sorted.generation > gen0);
-
-
 
   gen0 = sorted.generation;
   check("rsp_delete_existing_sorted_rc",

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -1,53 +1,53 @@
-/*
-** Shared regression runner for focused DoltLite C repros.
-**
-** Build from build/:
-**   cc -g -I. -I../src -o doltlite_regression_test_c \
-**     ../test/doltlite_regression_test_c.c libdoltlite.a -lz -lpthread -lm
-**
-** Run from build/:
-**   ./doltlite_regression_test_c all
-**   ./doltlite_regression_test_c concurrent_refs
-**   ./doltlite_regression_test_c checkout_persist_failure
-**   ./doltlite_regression_test_c savepoint_catalog_restore
-**   ./doltlite_regression_test_c refs_blob_corruption
-**   ./doltlite_regression_test_c conflicts_blob_corruption
-**   ./doltlite_regression_test_c status_error_propagation
-**   ./doltlite_regression_test_c remote_refs_corruption
-**   ./doltlite_regression_test_c chunk_walk_corruption
-**   ./doltlite_regression_test_c ancestor_missing_start
-**   ./doltlite_regression_test_c pull_persist_failure
-**   ./doltlite_regression_test_c push_persist_failure
-**   ./doltlite_regression_test_c clone_persist_failure
-**   ./doltlite_regression_test_c resolve_ref_non_commit
-**   ./doltlite_regression_test_c commit_parent_limit
-**   ./doltlite_regression_test_c merge_persist_failure
-**   ./doltlite_regression_test_c cherry_pick_stale_branch
-**   ./doltlite_regression_test_c branches_metadata_corruption
-**   ./doltlite_regression_test_c gc_rewrite_failure
-**   ./doltlite_regression_test_c record_decode_corruption
-**   ./doltlite_regression_test_c reload_refs_transactional
-**   ./doltlite_regression_test_c refresh_refs_corruption_preserves_state
-**   ./doltlite_regression_test_c prolly_node_corruption
-**   ./doltlite_regression_test_c truncated_wal_rejected
-**   ./doltlite_regression_test_c refresh_open_path_transactional
-**   ./doltlite_regression_test_c wal_offset_corruption
-**   ./doltlite_regression_test_c integrity_check_walks_nodes
-**   ./doltlite_regression_test_c memory_chunk_lookup_corruption
-**   ./doltlite_regression_test_c prolly_diff_record_corruption
-**   ./doltlite_regression_test_c integrity_check_repo_state
-**   ./doltlite_regression_test_c integrity_check_session_merge_state
-**   ./doltlite_regression_test_c btree_commit_failure_transactional
-**   ./doltlite_regression_test_c mutmap_empty_reverse_iter
-**   ./doltlite_regression_test_c working_set_refreshes_staged_across_connections
-**   ./doltlite_regression_test_c reopen_preserves_staged_working_set
-**   ./doltlite_regression_test_c begin_write_refreshes_working_set_metadata
-**   ./doltlite_regression_test_c begin_write_from_stale_read_snapshot
-**   ./doltlite_regression_test_c open_rejects_corrupt_working_set
-**   ./doltlite_regression_test_c prolly_blob_cursor_seek_past_max
-**   ./doltlite_regression_test_c prolly_cursor_empty_leaf_root
-**   ./doltlite_regression_test_c mutmap_differential_randomized
-*/
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -1947,11 +1947,11 @@ static void run_record_decode_corruption(void){
 
 static void run_sortkey_two_numeric_roundtrip(void){
   static const u8 record[] = {
-    0x03,       /* header size */
-    0x01,       /* 1-byte integer */
-    0x03,       /* 3-byte integer */
-    0x7b,       /* 123 */
-    0x06, 0xf8, 0x55  /* 456789 */
+    0x03,
+    0x01,
+    0x03,
+    0x7b,
+    0x06, 0xf8, 0x55
   };
   u8 *pSortKey = 0;
   u8 *pRoundTrip = 0;
@@ -1979,17 +1979,17 @@ static void run_sortkey_two_numeric_roundtrip(void){
 
 static void run_sortkey_numeric_text_roundtrip(void){
   static const u8 fastRecord[] = {
-    0x03,       /* header size */
-    0x01,       /* 1-byte integer */
-    0x13,       /* 3-byte text */
-    0x7b,       /* 123 */
+    0x03,
+    0x01,
+    0x13,
+    0x7b,
     'a', 'b', 'c'
   };
   static const u8 escapedRecord[] = {
-    0x03,       /* header size */
-    0x01,       /* 1-byte integer */
-    0x13,       /* 3-byte text */
-    0x7b,       /* 123 */
+    0x03,
+    0x01,
+    0x13,
+    0x7b,
     'x', 0x00, 'y'
   };
   const u8 *aRecord[] = { fastRecord, escapedRecord };
@@ -2028,17 +2028,17 @@ static void run_sortkey_numeric_text_roundtrip(void){
 
 static void run_sortkey_numeric_blob_roundtrip(void){
   static const u8 fastRecord[] = {
-    0x03,       /* header size */
-    0x01,       /* 1-byte integer */
-    0x12,       /* 3-byte blob */
-    0x7b,       /* 123 */
+    0x03,
+    0x01,
+    0x12,
+    0x7b,
     0x01, 0x02, 0x03
   };
   static const u8 escapedRecord[] = {
-    0x03,       /* header size */
-    0x01,       /* 1-byte integer */
-    0x12,       /* 3-byte blob */
-    0x7b,       /* 123 */
+    0x03,
+    0x01,
+    0x12,
+    0x7b,
     0x01, 0x00, 0x03
   };
   const u8 *aRecord[] = { fastRecord, escapedRecord };
@@ -5534,11 +5534,11 @@ static int mutmapAssertMatchesModel(
 }
 
 static void run_mutmap_resolve_sorted_pos(void){
-  /* Validates two new mutmap APIs that the per-table-mutmap migration
-  ** in subsequent commits depends on: (a) generation counter bumps
-  ** on every shift-inducing mutation but NOT on in-place op flips,
-  ** (b) prollyMutMapResolveSortedPos returns the right (idx, found)
-  ** for any key against either keepSorted=1 or keepSorted=0 maps. */
+
+
+
+
+
   ProllyMutMap sorted, lazy;
   i64 keys[] = { 10, 30, 20, 50, 40 };
   int n = sizeof(keys)/sizeof(keys[0]);
@@ -5566,9 +5566,9 @@ static void run_mutmap_resolve_sorted_pos(void){
     check("rsp_insert_bumps_gen_lazy",   lazy.generation   > gen0);
   }
 
-  /* In-place value update on existing key does NOT bump generation —
-  ** the entry stays at the same sorted position so cursors don't
-  ** become stale. */
+
+
+
   gen0 = sorted.generation;
   val = 999;
   check("rsp_inplace_update_sorted_rc",
@@ -5580,9 +5580,9 @@ static void run_mutmap_resolve_sorted_pos(void){
         prollyMutMapInsert(&lazy,   0, 0, 30, (const u8*)&val, sizeof(val))==SQLITE_OK);
   check("rsp_inplace_does_not_bump_lazy",   lazy.generation == gen0);
 
-  /* ResolveSortedPos: keys present and absent, both modes. The
-  ** sorted order across both maps is {10,20,30,40,50} so positions
-  ** 0..4 should map to those keys in that order. */
+
+
+
   check("rsp_resolve_present_10_sorted",
         prollyMutMapResolveSortedPos(&sorted, 0, 0, 10, &idx, &found)==SQLITE_OK
           && idx==0 && found);
@@ -5602,8 +5602,8 @@ static void run_mutmap_resolve_sorted_pos(void){
         prollyMutMapResolveSortedPos(&sorted, 0, 0, 999, &idx, &found)==SQLITE_OK
           && idx==5 && !found);
 
-  /* Same expectations on the lazy (keepSorted=0) map — Resolve must
-  ** ensureOrder internally before bisecting. */
+
+
   check("rsp_resolve_present_30_lazy",
         prollyMutMapResolveSortedPos(&lazy,   0, 0, 30, &idx, &found)==SQLITE_OK
           && idx==2 && found);
@@ -5614,7 +5614,7 @@ static void run_mutmap_resolve_sorted_pos(void){
         prollyMutMapResolveSortedPos(&lazy,   0, 0, 999, &idx, &found)==SQLITE_OK
           && idx==5 && !found);
 
-  /* Empty map: idx=0, found=0 regardless of key. */
+
   {
     ProllyMutMap empty;
     check("rsp_init_empty", prollyMutMapInitMode(&empty, 1, 1)==SQLITE_OK);
@@ -5624,15 +5624,15 @@ static void run_mutmap_resolve_sorted_pos(void){
     prollyMutMapFree(&empty);
   }
 
-  /* Delete-creates-DELETE-entry on an absent key bumps generation
-  ** because it adds an entry. */
+
+
   gen0 = sorted.generation;
   check("rsp_delete_absent_sorted_rc",
         prollyMutMapDelete(&sorted, 0, 0, 999)==SQLITE_OK);
   check("rsp_delete_absent_bumps_gen_sorted", sorted.generation > gen0);
 
-  /* Delete-flips-existing-entry-to-DELETE does NOT bump generation —
-  ** entry stays in place, only its op flips. */
+
+
   gen0 = sorted.generation;
   check("rsp_delete_existing_sorted_rc",
         prollyMutMapDelete(&sorted, 0, 0, 30)==SQLITE_OK);

--- a/test/doltlite_reset.sh
+++ b/test/doltlite_reset.sh
@@ -18,20 +18,20 @@ run_test_match() {
 echo "=== Doltlite Reset Tests ==="
 echo ""
 
-# --- Soft reset ---
+
 DB=/tmp/test_reset_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Make change, stage it
+
 echo "INSERT INTO t VALUES(2,'b'); SELECT dolt_add('-A');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "staged_before_soft_reset" \
   "SELECT count(*) FROM dolt_status WHERE staged=1;" \
   "1" "$DB"
 
-# --soft with no target ref is a no-op (matches Dolt and git: --soft
-# HEAD changes nothing). The unstage-all behavior is reserved for the
-# no-args / --mixed forms.
+
+
+
 echo "SELECT dolt_reset('--soft');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "still_staged_after_soft_noop" \
@@ -46,7 +46,7 @@ run_test "data_preserved_soft_noop" \
   "SELECT count(*) FROM t;" \
   "2" "$DB"
 
-# No-args reset (== --mixed) does unstage everything.
+
 echo "SELECT dolt_reset();" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "unstaged_after_no_args_reset" \
@@ -57,7 +57,7 @@ run_test "no_staged_after_no_args_reset" \
   "SELECT count(*) FROM dolt_status WHERE staged=1;" \
   "0" "$DB"
 
-# --- Hard reset ---
+
 echo "SELECT dolt_reset('--hard');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "clean_after_hard_reset" \
@@ -72,8 +72,8 @@ run_test "correct_data_after_hard" \
   "SELECT v FROM t;" \
   "a" "$DB"
 
-# --- Hard reset reverts tracked-table modifications but preserves
-# --- untracked tables (matching git --hard semantics).
+
+
 DB2=/tmp/test_reset2_$$.db; rm -f "$DB2"
 echo "CREATE TABLE a(x); CREATE TABLE b(y); INSERT INTO a VALUES(1); INSERT INTO b VALUES(2); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB2" > /dev/null 2>&1
 echo "INSERT INTO a VALUES(10); INSERT INTO b VALUES(20); CREATE TABLE c(z);" | $DOLTLITE "$DB2" > /dev/null 2>&1
@@ -84,8 +84,8 @@ run_test "changes_before_hard" \
 
 echo "SELECT dolt_reset('--hard');" | $DOLTLITE "$DB2" > /dev/null 2>&1
 
-# After hard reset: a and b are reverted (no longer in status),
-# but c (untracked new table) is preserved as an unstaged new table.
+
+
 run_test "untracked_preserved_after_multi_hard" \
   "SELECT count(*) FROM dolt_status;" \
   "1" "$DB2"
@@ -102,7 +102,7 @@ run_test "b_reverted" \
   "SELECT * FROM b;" \
   "2" "$DB2"
 
-# --- Soft reset after staging specific table ---
+
 DB3=/tmp/test_reset3_$$.db; rm -f "$DB3"
 echo "CREATE TABLE t(x); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB3" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(2); SELECT dolt_add('t');" | $DOLTLITE "$DB3" > /dev/null 2>&1
@@ -132,7 +132,7 @@ run_test "multipath_reset_all_missing_unstages_all" \
   "SELECT count(*) FROM dolt_status WHERE staged=1;" \
   "0" "$DB3C"
 
-# --- Hard reset persists across reopen ---
+
 DB4=/tmp/test_reset4_$$.db; rm -f "$DB4"
 echo "CREATE TABLE t(x); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB4" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(2);" | $DOLTLITE "$DB4" > /dev/null 2>&1
@@ -142,7 +142,7 @@ run_test "hard_reset_persists" \
   "SELECT * FROM t;" \
   "1" "$DB4"
 
-# --- Hard reset to a specific commit hash ---
+
 DB5=/tmp/test_reset5_$$.db; rm -f "$DB5"
 echo "CREATE TABLE t(x INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'v1'); SELECT dolt_commit('-A','-m','c1');" | $DOLTLITE "$DB5" > /dev/null 2>&1
 C1=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1;" | $DOLTLITE "$DB5" 2>/dev/null)
@@ -160,11 +160,11 @@ run_test "reset_to_hash_log" "SELECT count(*) FROM dolt_log;" "2" "$DB5"
 run_test "reset_to_hash_head" "SELECT commit_hash FROM dolt_log LIMIT 1;" "$C1" "$DB5"
 run_test "reset_to_hash_clean" "SELECT count(*) FROM dolt_status;" "0" "$DB5"
 
-# Reopen after reset-to-hash should stay clean and on the old data.
+
 run_test "reset_to_hash_reopen_clean" "SELECT count(*) FROM dolt_status;" "0" "$DB5"
 run_test "reset_to_hash_reopen_rows" "SELECT v FROM t;" "v1" "$DB5"
 
-# --- Hard reset to HEAD^1 after schema change ---
+
 DB5B=/tmp/test_reset5b_$$.db; rm -f "$DB5B"
 echo "CREATE TABLE a(id INTEGER PRIMARY KEY, s TEXT); INSERT INTO a VALUES(1,'base'); SELECT dolt_commit('-A','-m','c1'); ALTER TABLE a ADD COLUMN extra INTEGER; UPDATE a SET extra=99 WHERE id=1; SELECT dolt_commit('-A','-m','c2'); SELECT dolt_reset('--hard','HEAD^1');" | $DOLTLITE "$DB5B" > /dev/null 2>&1
 run_test "reset_head_parent_schema" \
@@ -174,7 +174,7 @@ run_test "reset_head_parent_rows" \
   "SELECT s FROM a;" \
   "base" "$DB5B"
 
-# --- Hard reset to HEAD^2 and raw second-parent hash after merge ---
+
 DB5C=/tmp/test_reset5c_$$.db; rm -f "$DB5C"
 echo "CREATE TABLE a(id INTEGER PRIMARY KEY, s TEXT); INSERT INTO a VALUES(1,'base'); SELECT dolt_commit('-A','-m','base'); SELECT dolt_branch('feat'); SELECT dolt_checkout('feat'); INSERT INTO a VALUES(2,'feat'); SELECT dolt_commit('-A','-m','feat'); SELECT dolt_checkout('main'); INSERT INTO a VALUES(3,'main'); SELECT dolt_commit('-A','-m','main'); SELECT dolt_merge('feat');" | $DOLTLITE "$DB5C" > /dev/null 2>&1
 run_test "reset_head_second_parent" \
@@ -189,7 +189,7 @@ run_test "reset_raw_second_parent_hash" \
   "0
 base|feat" "$DB5C.hash"
 
-# --- Reset to commit hash clears merge state ---
+
 DB6=/tmp/test_reset6_$$.db; rm -f "$DB6"
 echo "CREATE TABLE t(x INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6" > /dev/null 2>&1
 C_INIT=$(echo "SELECT commit_hash FROM dolt_log LIMIT 1;" | $DOLTLITE "$DB6" 2>/dev/null)
@@ -206,7 +206,7 @@ run_test_match "reset_restores_init" \
   "BEGIN; SELECT dolt_merge('other'); SELECT dolt_reset('--hard','$C_INIT'); SELECT 'RV|' || v FROM t; ROLLBACK;" \
   "^RV\\|a$" "$DB6"
 
-# --- Bad ref errors gracefully ---
+
 run_test_match "reset_bad_ref" \
   "SELECT dolt_reset('--hard','not_a_real_ref');" \
   "not found" "$DB6"
@@ -269,7 +269,7 @@ run_test "path_reset_recreated_table_keeps_live_row" \
   "SELECT k || '|' || n FROM a;" \
   "7|70" "$DB10"
 
-# Cleanup
+
 rm -f "$DB" "$DB2" "$DB3" "$DB3B" "$DB3C" "$DB4" "$DB5" "$DB5B" "$DB5C" "$DB5C.hash" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10"
 
 echo ""

--- a/test/doltlite_reset.sh
+++ b/test/doltlite_reset.sh
@@ -18,19 +18,14 @@ run_test_match() {
 echo "=== Doltlite Reset Tests ==="
 echo ""
 
-
 DB=/tmp/test_reset_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 echo "INSERT INTO t VALUES(2,'b'); SELECT dolt_add('-A');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "staged_before_soft_reset" \
   "SELECT count(*) FROM dolt_status WHERE staged=1;" \
   "1" "$DB"
-
-
-
 
 echo "SELECT dolt_reset('--soft');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
@@ -46,7 +41,6 @@ run_test "data_preserved_soft_noop" \
   "SELECT count(*) FROM t;" \
   "2" "$DB"
 
-
 echo "SELECT dolt_reset();" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "unstaged_after_no_args_reset" \
@@ -56,7 +50,6 @@ run_test "unstaged_after_no_args_reset" \
 run_test "no_staged_after_no_args_reset" \
   "SELECT count(*) FROM dolt_status WHERE staged=1;" \
   "0" "$DB"
-
 
 echo "SELECT dolt_reset('--hard');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
@@ -72,8 +65,6 @@ run_test "correct_data_after_hard" \
   "SELECT v FROM t;" \
   "a" "$DB"
 
-
-
 DB2=/tmp/test_reset2_$$.db; rm -f "$DB2"
 echo "CREATE TABLE a(x); CREATE TABLE b(y); INSERT INTO a VALUES(1); INSERT INTO b VALUES(2); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB2" > /dev/null 2>&1
 echo "INSERT INTO a VALUES(10); INSERT INTO b VALUES(20); CREATE TABLE c(z);" | $DOLTLITE "$DB2" > /dev/null 2>&1
@@ -83,8 +74,6 @@ run_test "changes_before_hard" \
   "3" "$DB2"
 
 echo "SELECT dolt_reset('--hard');" | $DOLTLITE "$DB2" > /dev/null 2>&1
-
-
 
 run_test "untracked_preserved_after_multi_hard" \
   "SELECT count(*) FROM dolt_status;" \
@@ -101,7 +90,6 @@ run_test "a_reverted" \
 run_test "b_reverted" \
   "SELECT * FROM b;" \
   "2" "$DB2"
-
 
 DB3=/tmp/test_reset3_$$.db; rm -f "$DB3"
 echo "CREATE TABLE t(x); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB3" > /dev/null 2>&1
@@ -132,7 +120,6 @@ run_test "multipath_reset_all_missing_unstages_all" \
   "SELECT count(*) FROM dolt_status WHERE staged=1;" \
   "0" "$DB3C"
 
-
 DB4=/tmp/test_reset4_$$.db; rm -f "$DB4"
 echo "CREATE TABLE t(x); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB4" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(2);" | $DOLTLITE "$DB4" > /dev/null 2>&1
@@ -141,7 +128,6 @@ echo "SELECT dolt_reset('--hard');" | $DOLTLITE "$DB4" > /dev/null 2>&1
 run_test "hard_reset_persists" \
   "SELECT * FROM t;" \
   "1" "$DB4"
-
 
 DB5=/tmp/test_reset5_$$.db; rm -f "$DB5"
 echo "CREATE TABLE t(x INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'v1'); SELECT dolt_commit('-A','-m','c1');" | $DOLTLITE "$DB5" > /dev/null 2>&1
@@ -160,10 +146,8 @@ run_test "reset_to_hash_log" "SELECT count(*) FROM dolt_log;" "2" "$DB5"
 run_test "reset_to_hash_head" "SELECT commit_hash FROM dolt_log LIMIT 1;" "$C1" "$DB5"
 run_test "reset_to_hash_clean" "SELECT count(*) FROM dolt_status;" "0" "$DB5"
 
-
 run_test "reset_to_hash_reopen_clean" "SELECT count(*) FROM dolt_status;" "0" "$DB5"
 run_test "reset_to_hash_reopen_rows" "SELECT v FROM t;" "v1" "$DB5"
-
 
 DB5B=/tmp/test_reset5b_$$.db; rm -f "$DB5B"
 echo "CREATE TABLE a(id INTEGER PRIMARY KEY, s TEXT); INSERT INTO a VALUES(1,'base'); SELECT dolt_commit('-A','-m','c1'); ALTER TABLE a ADD COLUMN extra INTEGER; UPDATE a SET extra=99 WHERE id=1; SELECT dolt_commit('-A','-m','c2'); SELECT dolt_reset('--hard','HEAD^1');" | $DOLTLITE "$DB5B" > /dev/null 2>&1
@@ -173,7 +157,6 @@ run_test "reset_head_parent_schema" \
 run_test "reset_head_parent_rows" \
   "SELECT s FROM a;" \
   "base" "$DB5B"
-
 
 DB5C=/tmp/test_reset5c_$$.db; rm -f "$DB5C"
 echo "CREATE TABLE a(id INTEGER PRIMARY KEY, s TEXT); INSERT INTO a VALUES(1,'base'); SELECT dolt_commit('-A','-m','base'); SELECT dolt_branch('feat'); SELECT dolt_checkout('feat'); INSERT INTO a VALUES(2,'feat'); SELECT dolt_commit('-A','-m','feat'); SELECT dolt_checkout('main'); INSERT INTO a VALUES(3,'main'); SELECT dolt_commit('-A','-m','main'); SELECT dolt_merge('feat');" | $DOLTLITE "$DB5C" > /dev/null 2>&1
@@ -188,7 +171,6 @@ run_test "reset_raw_second_parent_hash" \
   "SELECT dolt_reset('--hard','$H2'); SELECT group_concat(s, '|') FROM (SELECT s FROM a ORDER BY id);" \
   "0
 base|feat" "$DB5C.hash"
-
 
 DB6=/tmp/test_reset6_$$.db; rm -f "$DB6"
 echo "CREATE TABLE t(x INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6" > /dev/null 2>&1
@@ -205,7 +187,6 @@ run_test_match "reset_clears_conflicts" \
 run_test_match "reset_restores_init" \
   "BEGIN; SELECT dolt_merge('other'); SELECT dolt_reset('--hard','$C_INIT'); SELECT 'RV|' || v FROM t; ROLLBACK;" \
   "^RV\\|a$" "$DB6"
-
 
 run_test_match "reset_bad_ref" \
   "SELECT dolt_reset('--hard','not_a_real_ref');" \
@@ -268,7 +249,6 @@ run_test "path_reset_recreated_table_keeps_live_schema" \
 run_test "path_reset_recreated_table_keeps_live_row" \
   "SELECT k || '|' || n FROM a;" \
   "7|70" "$DB10"
-
 
 rm -f "$DB" "$DB2" "$DB3" "$DB3B" "$DB3C" "$DB4" "$DB5" "$DB5B" "$DB5C" "$DB5C.hash" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10"
 

--- a/test/doltlite_savepoint.sh
+++ b/test/doltlite_savepoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# Tests for interactions between SQLite savepoints/transactions and dolt operations.
-# These tests discover and document how dolt operations (which are DDL-like and auto-commit
-# at the storage layer) interact with SQLite's transaction/savepoint machinery.
+
+
+
 
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
@@ -39,45 +39,45 @@ run_test_match() {
 echo "=== Doltlite Savepoint & Transaction Interaction Tests ==="
 echo ""
 
-# ============================================================
-# Test 1: BEGIN; INSERT; dolt_commit; ROLLBACK
-# Expected: The dolt commit operates at the storage layer and persists
-# regardless of the SQLite transaction rollback. The INSERT data should
-# be rolled back from the working set, but the dolt commit (snapshot)
-# should survive since dolt_commit captures state at call time.
-# ============================================================
+
+
+
+
+
+
+
 DB1=/tmp/test_savepoint1_$$.db; rm -f "$DB1"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB1" > /dev/null 2>&1
 
-# Within a single session: BEGIN, INSERT, dolt_commit, ROLLBACK
+
 echo "BEGIN; INSERT INTO t VALUES(2,'txn'); SELECT dolt_commit('-A','-m','in-txn commit'); ROLLBACK;" | $DOLTLITE "$DB1" > /dev/null 2>&1
 
-# After rollback, check if row 2 is visible in working set
-# Expected: dolt_commit implicitly committed the SQL transaction,
-# so ROLLBACK is a no-op and both rows survive.
+
+
+
 run_test "txn_rollback_data_count" \
   "SELECT count(*) FROM t;" \
   "2" "$DB1"
 
-# The dolt commit should still exist in the log since it was executed
-# Expected: 2 commits (init + in-txn commit) — dolt operations persist
+
+
 run_test "txn_rollback_dolt_commit_survives" \
   "SELECT count(*) FROM dolt_log;" \
   "3" "$DB1"
 
-# ============================================================
-# Test 2: BEGIN; INSERT; SAVEPOINT x; INSERT more; dolt_commit; ROLLBACK TO x
-# Expected: ROLLBACK TO x undoes work after the savepoint. The dolt_commit
-# still persists in the log. The second INSERT is undone but the first
-# INSERT (before savepoint) remains.
-# ============================================================
+
+
+
+
+
+
 DB2=/tmp/test_savepoint2_$$.db; rm -f "$DB2"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB2" > /dev/null 2>&1
 
 echo "BEGIN; INSERT INTO t VALUES(2,'before-sp'); SAVEPOINT x; INSERT INTO t VALUES(3,'after-sp'); SELECT dolt_commit('-A','-m','mid-savepoint'); ROLLBACK TO x; COMMIT;" | $DOLTLITE "$DB2" > /dev/null 2>&1
 
-# After dolt_commit: the SQL transaction was implicitly committed,
-# so ROLLBACK TO x fails (savepoint gone) and all rows survive.
+
+
 run_test "savepoint_rollback_keeps_pre_sp" \
   "SELECT count(*) FROM t;" \
   "3" "$DB2"
@@ -86,20 +86,20 @@ run_test "savepoint_rollback_row2_exists" \
   "SELECT v FROM t WHERE id=2;" \
   "before-sp" "$DB2"
 
-# Row 3 also survives — dolt_commit committed the SQL transaction
+
 run_test "savepoint_rollback_row3_gone" \
   "SELECT count(*) FROM t WHERE id=3;" \
   "1" "$DB2"
 
-# Dolt commit log should still show the commit made inside the savepoint
+
 run_test "savepoint_dolt_commit_in_log" \
   "SELECT count(*) FROM dolt_log;" \
   "3" "$DB2"
 
-# ============================================================
-# Test 3: INSERT outside transaction; dolt_commit — basic sanity
-# Expected: Normal behavior, commit captures the insert.
-# ============================================================
+
+
+
+
 DB3=/tmp/test_savepoint3_$$.db; rm -f "$DB3"
 
 run_test_match "basic_no_txn_commit" \
@@ -114,11 +114,11 @@ run_test "basic_no_txn_log" \
   "SELECT message FROM dolt_log LIMIT 1;" \
   "basic" "$DB3"
 
-# ============================================================
-# Test 4: Nested savepoints with dolt operations inside
-# Expected: dolt_commit inside nested savepoints still persists.
-# The data changes follow SQLite savepoint semantics.
-# ============================================================
+
+
+
+
+
 DB4=/tmp/test_savepoint4_$$.db; rm -f "$DB4"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB4" > /dev/null 2>&1
 
@@ -132,12 +132,12 @@ echo "BEGIN;
     RELEASE sp1;
 COMMIT;" | $DOLTLITE "$DB4" > /dev/null 2>&1
 
-# All inserts should survive — all savepoints were released (committed)
+
 run_test "nested_sp_all_released_count" \
   "SELECT count(*) FROM t;" \
   "4" "$DB4"
 
-# Now test nested rollback
+
 DB4b=/tmp/test_savepoint4b_$$.db; rm -f "$DB4b"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB4b" > /dev/null 2>&1
 
@@ -151,7 +151,7 @@ echo "BEGIN;
   ROLLBACK TO sp1;
 COMMIT;" | $DOLTLITE "$DB4b" > /dev/null 2>&1
 
-# Only base + row 2 should survive (sp1 rollback discards row 3, sp2 rollback discards row 4)
+
 run_test "nested_sp_rollback_count" \
   "SELECT count(*) FROM t;" \
   "2" "$DB4b"
@@ -160,20 +160,20 @@ run_test "nested_sp_rollback_kept_row" \
   "SELECT v FROM t WHERE id=2;" \
   "keep" "$DB4b"
 
-# ============================================================
-# Test 5: dolt_reset('--hard') inside a transaction
-# Expected: dolt_reset('--hard') reverts working set to last commit.
-# This is a dolt storage operation that may or may not interact
-# with the SQLite transaction boundary.
-# ============================================================
+
+
+
+
+
+
 DB5=/tmp/test_savepoint5_$$.db; rm -f "$DB5"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB5" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(2,'staged');" | $DOLTLITE "$DB5" > /dev/null 2>&1
 
-# Hard reset inside a transaction
+
 echo "BEGIN; SELECT dolt_reset('--hard'); COMMIT;" | $DOLTLITE "$DB5" > /dev/null 2>&1
 
-# After hard reset, row 2 should be gone — reverted to 'init' commit state
+
 run_test "hard_reset_in_txn_count" \
   "SELECT count(*) FROM t;" \
   "1" "$DB5"
@@ -182,7 +182,7 @@ run_test "hard_reset_in_txn_status_clean" \
   "SELECT count(*) FROM dolt_status;" \
   "0" "$DB5"
 
-# Savepoint around reset should be invalidated, matching Dolt.
+
 DB5b=/tmp/test_savepoint5b_$$.db; rm -f "$DB5b"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB5b" > /dev/null 2>&1
 run_test_match "hard_reset_savepoint_invalidated" \
@@ -204,8 +204,8 @@ run_test_match "bad_reset_nested_savepoint_allows_rollback" \
   "BEGIN; SAVEPOINT sp1; INSERT INTO t VALUES(2,'dirty'); SELECT dolt_reset('--hard','bogus'); ROLLBACK TO sp1; COMMIT; SELECT count(*) FROM t;" \
   "^1$" "$DB5d"
 
-# Conflict resolution inside a named savepoint should roll back both
-# row state and conflict catalog state to the pre-resolution merge state.
+
+
 DB5e=/tmp/test_savepoint5e_$$.db; rm -f "$DB5e"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'base');
@@ -238,32 +238,32 @@ run_test "conflicts_delete_named_savepoint_rollback" \
 C|1
 V|main" "$DB5e"
 
-# ============================================================
-# Test 6: dolt_checkout inside a transaction
-# Expected: dolt_checkout requires a clean working set and switches
-# branches. Inside a transaction this may fail since the transaction
-# itself may create implicit dirty state, or it may succeed if
-# dolt_checkout operates at the storage layer independently.
-# ============================================================
+
+
+
+
+
+
+
 DB6=/tmp/test_savepoint6_$$.db; rm -f "$DB6"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6" > /dev/null 2>&1
 echo "SELECT dolt_branch('other');" | $DOLTLITE "$DB6" > /dev/null 2>&1
 
-# Try checkout inside a BEGIN/COMMIT block with no dirty data
+
 echo "BEGIN; SELECT dolt_checkout('other'); COMMIT;" | $DOLTLITE "$DB6" > /dev/null 2>&1
 
-# Check which branch we're on — should be 'other' if checkout succeeded,
-# or 'main' if it was rejected
+
+
 run_test_match "checkout_in_txn_branch" \
   "SELECT active_branch();" \
   "^(main|other)$" "$DB6"
 
-# Now try checkout with dirty data inside transaction
+
 DB6b=/tmp/test_savepoint6b_$$.db; rm -f "$DB6b"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6b" > /dev/null 2>&1
 echo "SELECT dolt_branch('other');" | $DOLTLITE "$DB6b" > /dev/null 2>&1
 
-# INSERT then checkout in same transaction — allowed (like Dolt SQL context)
+
 run_test "checkout_dirty_in_txn" \
   "BEGIN; INSERT INTO t VALUES(2,'dirty'); SELECT dolt_checkout('other'); COMMIT;" \
   "0" "$DB6b"
@@ -616,11 +616,11 @@ run_test_match "revert_savepoint_log_persists" \
   "SELECT count(*) FROM dolt_log;" \
   "^4$" "$DB6k"
 
-# ============================================================
-# Test 7: dolt_merge inside a BEGIN/COMMIT block
-# Expected: dolt_merge operates at the dolt storage layer. It should
-# work inside a transaction block and the merge result should persist.
-# ============================================================
+
+
+
+
+
 DB7=/tmp/test_savepoint7_$$.db; rm -f "$DB7"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB7" > /dev/null 2>&1
 echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB7" > /dev/null 2>&1
@@ -628,10 +628,10 @@ echo "SELECT dolt_checkout('feature');" | $DOLTLITE "$DB7" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(2,'feature-row'); SELECT dolt_commit('-A','-m','feature work');" | $DOLTLITE "$DB7" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB7" > /dev/null 2>&1
 
-# Merge inside a transaction
+
 echo "BEGIN; SELECT dolt_merge('feature'); COMMIT;" | $DOLTLITE "$DB7" > /dev/null 2>&1
 
-# Merge should have brought in the feature row
+
 run_test "merge_in_txn_data" \
   "SELECT count(*) FROM t;" \
   "2" "$DB7"
@@ -735,12 +735,12 @@ run_test "rebase_continue_top_savepoint_log_rolled_back" \
   "SELECT count(*)-1 FROM dolt_log;" \
   "2" "$DB7f"
 
-# ============================================================
-# Test 8: Large deferred mutmap drains must still rollback correctly
-# Expected: once pending edits cross the internal drain threshold, the
-# mutmap flushes to the prolly tree mid-savepoint. ROLLBACK TO must still
-# restore the pre-savepoint state even after that early flush.
-# ============================================================
+
+
+
+
+
+
 DB8=/tmp/test_savepoint8_$$.db; rm -f "$DB8"
 run_test "bulk_threshold_savepoint_rollback" \
   "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -758,32 +758,32 @@ run_test "bulk_threshold_savepoint_rollback" \
    SELECT count(*) FROM t;" \
   "0" "$DB8"
 
-# ============================================================
-# Test 9: ROLLBACK after dolt_branch — does the branch creation persist?
-# Expected: dolt_branch creates a branch at the storage layer.
-# A SQLite ROLLBACK should not undo the branch creation since
-# it's a dolt metadata operation, not a SQL data change.
-# ============================================================
+
+
+
+
+
+
 DB9=/tmp/test_savepoint9_$$.db; rm -f "$DB9"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB9" > /dev/null 2>&1
 
-# Create branch inside a transaction, then rollback
+
 echo "BEGIN; SELECT dolt_branch('ephemeral'); ROLLBACK;" | $DOLTLITE "$DB9" > /dev/null 2>&1
 
-# Check if the branch persists despite the rollback
-# Expected: branch persists because dolt_branch is a storage-level operation
+
+
 run_test_match "branch_survives_rollback" \
   "SELECT count(*) FROM dolt_branches;" \
   "^[12]$" "$DB9"
 
-# If branch survived, verify by name
+
 run_test_match "branch_name_after_rollback" \
   "SELECT name FROM dolt_branches ORDER BY name;" \
   "main" "$DB9"
 
-# ============================================================
-# Cleanup
-# ============================================================
+
+
+
 rm -f "$DB1" "$DB2" "$DB3" "$DB4" "$DB4b" "$DB5" "$DB6" "$DB6b" "$DB7" "$DB8" "$DB9" \
   "$DB6g1" "$DB6g2" "$DB6g3" "$DB6g4" "$DB6g5" "$DB6g6" "$DB6g7" "$DB6g8" "$DB6g9" "$DB6g10" \
   "$DB6g1u" "$DB6g1v" "$DB6g1w" "$DB7d" "$DB7e" "$DB7f"

--- a/test/doltlite_savepoint.sh
+++ b/test/doltlite_savepoint.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-
-
-
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 
@@ -39,44 +36,23 @@ run_test_match() {
 echo "=== Doltlite Savepoint & Transaction Interaction Tests ==="
 echo ""
 
-
-
-
-
-
-
-
 DB1=/tmp/test_savepoint1_$$.db; rm -f "$DB1"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB1" > /dev/null 2>&1
 
-
 echo "BEGIN; INSERT INTO t VALUES(2,'txn'); SELECT dolt_commit('-A','-m','in-txn commit'); ROLLBACK;" | $DOLTLITE "$DB1" > /dev/null 2>&1
-
-
-
 
 run_test "txn_rollback_data_count" \
   "SELECT count(*) FROM t;" \
   "2" "$DB1"
 
-
-
 run_test "txn_rollback_dolt_commit_survives" \
   "SELECT count(*) FROM dolt_log;" \
   "3" "$DB1"
-
-
-
-
-
-
 
 DB2=/tmp/test_savepoint2_$$.db; rm -f "$DB2"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB2" > /dev/null 2>&1
 
 echo "BEGIN; INSERT INTO t VALUES(2,'before-sp'); SAVEPOINT x; INSERT INTO t VALUES(3,'after-sp'); SELECT dolt_commit('-A','-m','mid-savepoint'); ROLLBACK TO x; COMMIT;" | $DOLTLITE "$DB2" > /dev/null 2>&1
-
-
 
 run_test "savepoint_rollback_keeps_pre_sp" \
   "SELECT count(*) FROM t;" \
@@ -86,19 +62,13 @@ run_test "savepoint_rollback_row2_exists" \
   "SELECT v FROM t WHERE id=2;" \
   "before-sp" "$DB2"
 
-
 run_test "savepoint_rollback_row3_gone" \
   "SELECT count(*) FROM t WHERE id=3;" \
   "1" "$DB2"
 
-
 run_test "savepoint_dolt_commit_in_log" \
   "SELECT count(*) FROM dolt_log;" \
   "3" "$DB2"
-
-
-
-
 
 DB3=/tmp/test_savepoint3_$$.db; rm -f "$DB3"
 
@@ -114,11 +84,6 @@ run_test "basic_no_txn_log" \
   "SELECT message FROM dolt_log LIMIT 1;" \
   "basic" "$DB3"
 
-
-
-
-
-
 DB4=/tmp/test_savepoint4_$$.db; rm -f "$DB4"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB4" > /dev/null 2>&1
 
@@ -132,11 +97,9 @@ echo "BEGIN;
     RELEASE sp1;
 COMMIT;" | $DOLTLITE "$DB4" > /dev/null 2>&1
 
-
 run_test "nested_sp_all_released_count" \
   "SELECT count(*) FROM t;" \
   "4" "$DB4"
-
 
 DB4b=/tmp/test_savepoint4b_$$.db; rm -f "$DB4b"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB4b" > /dev/null 2>&1
@@ -151,7 +114,6 @@ echo "BEGIN;
   ROLLBACK TO sp1;
 COMMIT;" | $DOLTLITE "$DB4b" > /dev/null 2>&1
 
-
 run_test "nested_sp_rollback_count" \
   "SELECT count(*) FROM t;" \
   "2" "$DB4b"
@@ -160,19 +122,11 @@ run_test "nested_sp_rollback_kept_row" \
   "SELECT v FROM t WHERE id=2;" \
   "keep" "$DB4b"
 
-
-
-
-
-
-
 DB5=/tmp/test_savepoint5_$$.db; rm -f "$DB5"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB5" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(2,'staged');" | $DOLTLITE "$DB5" > /dev/null 2>&1
 
-
 echo "BEGIN; SELECT dolt_reset('--hard'); COMMIT;" | $DOLTLITE "$DB5" > /dev/null 2>&1
-
 
 run_test "hard_reset_in_txn_count" \
   "SELECT count(*) FROM t;" \
@@ -181,7 +135,6 @@ run_test "hard_reset_in_txn_count" \
 run_test "hard_reset_in_txn_status_clean" \
   "SELECT count(*) FROM dolt_status;" \
   "0" "$DB5"
-
 
 DB5b=/tmp/test_savepoint5b_$$.db; rm -f "$DB5b"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB5b" > /dev/null 2>&1
@@ -203,8 +156,6 @@ echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'ba
 run_test_match "bad_reset_nested_savepoint_allows_rollback" \
   "BEGIN; SAVEPOINT sp1; INSERT INTO t VALUES(2,'dirty'); SELECT dolt_reset('--hard','bogus'); ROLLBACK TO sp1; COMMIT; SELECT count(*) FROM t;" \
   "^1$" "$DB5d"
-
-
 
 DB5e=/tmp/test_savepoint5e_$$.db; rm -f "$DB5e"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -238,31 +189,19 @@ run_test "conflicts_delete_named_savepoint_rollback" \
 C|1
 V|main" "$DB5e"
 
-
-
-
-
-
-
-
 DB6=/tmp/test_savepoint6_$$.db; rm -f "$DB6"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6" > /dev/null 2>&1
 echo "SELECT dolt_branch('other');" | $DOLTLITE "$DB6" > /dev/null 2>&1
 
-
 echo "BEGIN; SELECT dolt_checkout('other'); COMMIT;" | $DOLTLITE "$DB6" > /dev/null 2>&1
-
-
 
 run_test_match "checkout_in_txn_branch" \
   "SELECT active_branch();" \
   "^(main|other)$" "$DB6"
 
-
 DB6b=/tmp/test_savepoint6b_$$.db; rm -f "$DB6b"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6b" > /dev/null 2>&1
 echo "SELECT dolt_branch('other');" | $DOLTLITE "$DB6b" > /dev/null 2>&1
-
 
 run_test "checkout_dirty_in_txn" \
   "BEGIN; INSERT INTO t VALUES(2,'dirty'); SELECT dolt_checkout('other'); COMMIT;" \
@@ -616,11 +555,6 @@ run_test_match "revert_savepoint_log_persists" \
   "SELECT count(*) FROM dolt_log;" \
   "^4$" "$DB6k"
 
-
-
-
-
-
 DB7=/tmp/test_savepoint7_$$.db; rm -f "$DB7"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB7" > /dev/null 2>&1
 echo "SELECT dolt_branch('feature');" | $DOLTLITE "$DB7" > /dev/null 2>&1
@@ -628,9 +562,7 @@ echo "SELECT dolt_checkout('feature');" | $DOLTLITE "$DB7" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(2,'feature-row'); SELECT dolt_commit('-A','-m','feature work');" | $DOLTLITE "$DB7" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB7" > /dev/null 2>&1
 
-
 echo "BEGIN; SELECT dolt_merge('feature'); COMMIT;" | $DOLTLITE "$DB7" > /dev/null 2>&1
-
 
 run_test "merge_in_txn_data" \
   "SELECT count(*) FROM t;" \
@@ -735,12 +667,6 @@ run_test "rebase_continue_top_savepoint_log_rolled_back" \
   "SELECT count(*)-1 FROM dolt_log;" \
   "2" "$DB7f"
 
-
-
-
-
-
-
 DB8=/tmp/test_savepoint8_$$.db; rm -f "$DB8"
 run_test "bulk_threshold_savepoint_rollback" \
   "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -758,31 +684,18 @@ run_test "bulk_threshold_savepoint_rollback" \
    SELECT count(*) FROM t;" \
   "0" "$DB8"
 
-
-
-
-
-
-
 DB9=/tmp/test_savepoint9_$$.db; rm -f "$DB9"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'base'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB9" > /dev/null 2>&1
 
-
 echo "BEGIN; SELECT dolt_branch('ephemeral'); ROLLBACK;" | $DOLTLITE "$DB9" > /dev/null 2>&1
-
-
 
 run_test_match "branch_survives_rollback" \
   "SELECT count(*) FROM dolt_branches;" \
   "^[12]$" "$DB9"
 
-
 run_test_match "branch_name_after_rollback" \
   "SELECT name FROM dolt_branches ORDER BY name;" \
   "main" "$DB9"
-
-
-
 
 rm -f "$DB1" "$DB2" "$DB3" "$DB4" "$DB4b" "$DB5" "$DB6" "$DB6b" "$DB7" "$DB8" "$DB9" \
   "$DB6g1" "$DB6g2" "$DB6g3" "$DB6g4" "$DB6g5" "$DB6g6" "$DB6g7" "$DB6g8" "$DB6g9" "$DB6g10" \

--- a/test/doltlite_schema_diff.sh
+++ b/test/doltlite_schema_diff.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-#
-# Tests for dolt_schema_diff('from_ref', 'to_ref')
-#
+
+
+
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
@@ -10,9 +10,9 @@ run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -
 echo "=== Doltlite Schema Diff Tests ==="
 echo ""
 
-# ============================================================
-# Table added between commits
-# ============================================================
+
+
+
 
 DB=/tmp/test_sd_add_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -34,9 +34,9 @@ run_test "add_from_sql_empty" \
 
 rm -f "$DB"
 
-# ============================================================
-# Multiple tables added
-# ============================================================
+
+
+
 
 DB=/tmp/test_sd_multi_$$.db; rm -f "$DB"
 echo "SELECT dolt_commit('-A','-m','empty');
@@ -51,9 +51,9 @@ run_test "multi_count" \
 
 rm -f "$DB"
 
-# ============================================================
-# No schema changes between commits
-# ============================================================
+
+
+
 
 DB=/tmp/test_sd_none_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -64,14 +64,14 @@ INSERT INTO t VALUES(2,'b');
 SELECT dolt_commit('-A','-m','c2');
 SELECT dolt_tag('v2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Only data changes, no schema changes
+
 run_test "none_count" "SELECT count(*) FROM dolt_schema_diff('v1','v2');" "0" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Bad refs surface an error
-# ============================================================
+
+
+
 
 DB=/tmp/test_sd_badref_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -87,9 +87,9 @@ run_test_match "bad_single_arg_errors" \
 
 rm -f "$DB"
 
-# ============================================================
-# Resolve by branch name
-# ============================================================
+
+
+
 
 DB=/tmp/test_sd_branch_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
@@ -106,9 +106,9 @@ run_test "branch_from_name_empty" "SELECT length(from_table_name) FROM dolt_sche
 
 rm -f "$DB"
 
-# ============================================================
-# Reverse direction shows "dropped"
-# ============================================================
+
+
+
 
 DB=/tmp/test_sd_reverse_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
@@ -118,15 +118,15 @@ CREATE TABLE extra(id INTEGER PRIMARY KEY);
 SELECT dolt_commit('-A','-m','c2');
 SELECT dolt_tag('v2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# v1→v2: extra is added (from side empty, to side has the table)
+
 run_test "reverse_fwd_to_name" "SELECT to_table_name FROM dolt_schema_diff('v1','v2');" "extra" "$DB"
 run_test "reverse_fwd_from_empty" "SELECT length(from_table_name) FROM dolt_schema_diff('v1','v2');" "0" "$DB"
 
-# v2→v1: extra is dropped (from side has the table, to side empty)
+
 run_test "reverse_rev_from_name" "SELECT from_table_name FROM dolt_schema_diff('v2','v1');" "extra" "$DB"
 run_test "reverse_rev_to_empty" "SELECT length(to_table_name) FROM dolt_schema_diff('v2','v1');" "0" "$DB"
 
-# When dropped, from_create_statement is set, to_create_statement is empty
+
 run_test_match "reverse_from" \
   "SELECT from_create_statement FROM dolt_schema_diff('v2','v1');" "CREATE TABLE" "$DB"
 run_test "reverse_to_empty_sql" \
@@ -134,9 +134,9 @@ run_test "reverse_to_empty_sql" \
 
 rm -f "$DB"
 
-# ============================================================
-# Same commit returns empty
-# ============================================================
+
+
+
 
 DB=/tmp/test_sd_same_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
@@ -147,9 +147,9 @@ run_test "same_empty" "SELECT count(*) FROM dolt_schema_diff('v1','v1');" "0" "$
 
 rm -f "$DB"
 
-# ============================================================
-# Single-argument range syntax
-# ============================================================
+
+
+
 
 DB=/tmp/test_sd_range_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
@@ -162,9 +162,9 @@ run_test "range_to_name" "SELECT to_table_name FROM dolt_schema_diff('HEAD~1..HE
 
 rm -f "$DB"
 
-# ============================================================
-# Schema diff after merge (new table from feature branch)
-# ============================================================
+
+
+
 
 DB=/tmp/test_sd_merge_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
@@ -182,16 +182,16 @@ SELECT dolt_commit('-A','-m','main work');
 SELECT dolt_merge('feat');
 SELECT dolt_tag('after');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# before→after should show feat_tbl as added (to_table_name set, from empty)
+
 run_test_match "merge_added" \
   "SELECT to_table_name FROM dolt_schema_diff('before','after') WHERE from_table_name='';" \
   "feat_tbl" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Index creation shows up as schema change
-# ============================================================
+
+
+
 
 DB=/tmp/test_sd_index_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, name TEXT);
@@ -202,16 +202,16 @@ CREATE INDEX idx_name ON t(name);
 SELECT dolt_commit('-A','-m','c2');
 SELECT dolt_tag('v2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Index creation adds an entry to sqlite_master
+
 run_test_match "index_count" "SELECT count(*) FROM dolt_schema_diff('v1','v2');" "^[1-9]" "$DB"
 run_test_match "index_name" \
   "SELECT to_table_name FROM dolt_schema_diff('v1','v2') LIMIT 1;" "idx_name" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# View creation shows up
-# ============================================================
+
+
+
 
 DB=/tmp/test_sd_view_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -228,9 +228,9 @@ run_test_match "view_name" \
 
 rm -f "$DB"
 
-# ============================================================
-# Rename filter matches either old or new table name
-# ============================================================
+
+
+
 
 DB=/tmp/test_sd_rename_filter_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
@@ -245,9 +245,9 @@ run_test "rename_filter_old_name" \
 
 rm -f "$DB"
 
-# ============================================================
-# Persistence
-# ============================================================
+
+
+
 
 DB=/tmp/test_sd_persist_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
@@ -261,9 +261,9 @@ run_test "persist_count" "SELECT count(*) FROM dolt_schema_diff('v1','v2');" "1"
 
 rm -f "$DB"
 
-# ============================================================
-# CREATE TABLE statement content
-# ============================================================
+
+
+
 
 DB=/tmp/test_sd_stmt_$$.db; rm -f "$DB"
 echo "SELECT dolt_commit('-A','-m','empty');
@@ -281,9 +281,9 @@ run_test_match "stmt_cols" \
 
 rm -f "$DB"
 
-# ============================================================
-# Branch created from tag ref
-# ============================================================
+
+
+
 
 DB=/tmp/test_sd_branch_from_tag_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -302,9 +302,9 @@ run_test "branch_from_tag_name" \
 
 rm -f "$DB"
 
-# ============================================================
-# Merge parent refs
-# ============================================================
+
+
+
 
 DB=/tmp/test_sd_parents_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -344,9 +344,9 @@ run_test "second_parent_to_merge_name" \
 
 rm -f "$DB"
 
-# ============================================================
-# Same-name drop / recreate reports old and new schema
-# ============================================================
+
+
+
 
 DB=/tmp/test_sd_drop_recreate_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -368,9 +368,9 @@ run_test_match "drop_recreate_to_stmt" \
 
 rm -f "$DB"
 
-# ============================================================
-# Replay after schema changes
-# ============================================================
+
+
+
 
 DB=/tmp/test_sd_merge_replay_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
@@ -470,9 +470,9 @@ run_test_match "rebase_replay_u_to_stmt" \
 
 rm -f "$DB"
 
-# ============================================================
-# Done
-# ============================================================
+
+
+
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/doltlite_schema_diff.sh
+++ b/test/doltlite_schema_diff.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
-
-
-
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
@@ -9,10 +6,6 @@ run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -
 
 echo "=== Doltlite Schema Diff Tests ==="
 echo ""
-
-
-
-
 
 DB=/tmp/test_sd_add_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -34,10 +27,6 @@ run_test "add_from_sql_empty" \
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_sd_multi_$$.db; rm -f "$DB"
 echo "SELECT dolt_commit('-A','-m','empty');
 CREATE TABLE a(id INTEGER PRIMARY KEY);
@@ -51,10 +40,6 @@ run_test "multi_count" \
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_sd_none_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
@@ -64,14 +49,9 @@ INSERT INTO t VALUES(2,'b');
 SELECT dolt_commit('-A','-m','c2');
 SELECT dolt_tag('v2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "none_count" "SELECT count(*) FROM dolt_schema_diff('v1','v2');" "0" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_sd_badref_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -86,10 +66,6 @@ run_test_match "bad_single_arg_errors" \
   "Error" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_sd_branch_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
@@ -106,10 +82,6 @@ run_test "branch_from_name_empty" "SELECT length(from_table_name) FROM dolt_sche
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_sd_reverse_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
 SELECT dolt_commit('-A','-m','c1');
@@ -118,14 +90,11 @@ CREATE TABLE extra(id INTEGER PRIMARY KEY);
 SELECT dolt_commit('-A','-m','c2');
 SELECT dolt_tag('v2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "reverse_fwd_to_name" "SELECT to_table_name FROM dolt_schema_diff('v1','v2');" "extra" "$DB"
 run_test "reverse_fwd_from_empty" "SELECT length(from_table_name) FROM dolt_schema_diff('v1','v2');" "0" "$DB"
 
-
 run_test "reverse_rev_from_name" "SELECT from_table_name FROM dolt_schema_diff('v2','v1');" "extra" "$DB"
 run_test "reverse_rev_to_empty" "SELECT length(to_table_name) FROM dolt_schema_diff('v2','v1');" "0" "$DB"
-
 
 run_test_match "reverse_from" \
   "SELECT from_create_statement FROM dolt_schema_diff('v2','v1');" "CREATE TABLE" "$DB"
@@ -133,10 +102,6 @@ run_test "reverse_to_empty_sql" \
   "SELECT length(to_create_statement) FROM dolt_schema_diff('v2','v1');" "0" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_sd_same_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
@@ -146,10 +111,6 @@ SELECT dolt_tag('v1');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "same_empty" "SELECT count(*) FROM dolt_schema_diff('v1','v1');" "0" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_sd_range_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
@@ -161,10 +122,6 @@ run_test "range_count" "SELECT count(*) FROM dolt_schema_diff('HEAD~1..HEAD');" 
 run_test "range_to_name" "SELECT to_table_name FROM dolt_schema_diff('HEAD~1..HEAD');" "u" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_sd_merge_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
@@ -182,16 +139,11 @@ SELECT dolt_commit('-A','-m','main work');
 SELECT dolt_merge('feat');
 SELECT dolt_tag('after');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test_match "merge_added" \
   "SELECT to_table_name FROM dolt_schema_diff('before','after') WHERE from_table_name='';" \
   "feat_tbl" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_sd_index_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, name TEXT);
@@ -202,16 +154,11 @@ CREATE INDEX idx_name ON t(name);
 SELECT dolt_commit('-A','-m','c2');
 SELECT dolt_tag('v2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test_match "index_count" "SELECT count(*) FROM dolt_schema_diff('v1','v2');" "^[1-9]" "$DB"
 run_test_match "index_name" \
   "SELECT to_table_name FROM dolt_schema_diff('v1','v2') LIMIT 1;" "idx_name" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_sd_view_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -228,10 +175,6 @@ run_test_match "view_name" \
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_sd_rename_filter_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
 SELECT dolt_commit('-A','-m','c1');
@@ -245,10 +188,6 @@ run_test "rename_filter_old_name" \
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_sd_persist_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
 SELECT dolt_commit('-A','-m','c1');
@@ -260,10 +199,6 @@ SELECT dolt_tag('v2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "persist_count" "SELECT count(*) FROM dolt_schema_diff('v1','v2');" "1" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_sd_stmt_$$.db; rm -f "$DB"
 echo "SELECT dolt_commit('-A','-m','empty');
@@ -281,10 +216,6 @@ run_test_match "stmt_cols" \
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_sd_branch_from_tag_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
@@ -301,10 +232,6 @@ run_test "branch_from_tag_name" \
   "SELECT to_table_name FROM dolt_schema_diff('v1','tagfeat');" "t" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_sd_parents_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -344,10 +271,6 @@ run_test "second_parent_to_merge_name" \
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_sd_drop_recreate_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'base');
@@ -367,10 +290,6 @@ run_test_match "drop_recreate_to_stmt" \
   "CREATE TABLE t.*vv TEXT.*extra INT" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_sd_merge_replay_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
@@ -469,10 +388,6 @@ run_test_match "rebase_replay_u_to_stmt" \
   "CREATE TABLE u.*w TEXT" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/doltlite_schema_merge.sh
+++ b/test/doltlite_schema_merge.sh
@@ -1,8 +1,4 @@
 #!/bin/bash
-
-
-
-
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
@@ -10,10 +6,6 @@ run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -
 
 echo "=== Doltlite ALTER TABLE Merge Tests ==="
 echo ""
-
-
-
-
 
 DB=/tmp/test_alter_merge1_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -27,13 +19,11 @@ INSERT INTO t VALUES(2,'b','hello');
 SELECT dolt_commit('-A','-m','add extra column');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "alter_merge_pre_cols" \
   "SELECT count(*) FROM pragma_table_info('t') WHERE name='extra';" \
   "0" "$DB"
 
 run_test_match "alter_merge_hash" "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB"
-
 
 run_test "alter_merge_post_cols" \
   "SELECT count(*) FROM pragma_table_info('t') WHERE name='extra';" \
@@ -43,10 +33,6 @@ run_test "alter_merge_row2" "SELECT extra FROM t WHERE id=2;" "hello" "$DB"
 run_test "alter_merge_count" "SELECT count(*) FROM t;" "2" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_alter_merge1b_$$.db; rm -f "$DB"
 cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -65,10 +51,6 @@ run_test_match "alter_merge_quoted_hash" "SELECT dolt_merge('feat');" "^[0-9a-f]
 run_test "alter_merge_quoted_val" 'SELECT "odd""name" FROM t WHERE id=1;' "quoted" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_alter_merge1c_$$.db; rm -f "$DB"
 cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -92,21 +74,15 @@ run_test "alter_merge_escaped_feat_val" 'SELECT "feat""col" FROM t WHERE id=1;' 
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_alter_merge2_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
 SELECT dolt_commit('-A','-m','init');
 SELECT dolt_branch('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 echo "ALTER TABLE t ADD COLUMN extra TEXT;
 UPDATE t SET extra='main_val';
 SELECT dolt_commit('-A','-m','main adds extra');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 echo "SELECT dolt_checkout('feat');
 ALTER TABLE t ADD COLUMN extra TEXT;
@@ -114,15 +90,9 @@ UPDATE t SET extra='feat_val';
 SELECT dolt_commit('-A','-m','feat adds extra');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test_match "alter_same_col_merge" "SELECT dolt_merge('feat');" "conflict|merge failed|Error" "$DB"
 
 rm -f "$DB"
-
-
-
-
-
 
 DB=/tmp/test_alter_merge3_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -130,11 +100,9 @@ INSERT INTO t VALUES(1,'a');
 SELECT dolt_commit('-A','-m','init');
 SELECT dolt_branch('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 echo "ALTER TABLE t ADD COLUMN col_main TEXT;
 UPDATE t SET col_main='m';
 SELECT dolt_commit('-A','-m','main adds col_main');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 echo "SELECT dolt_checkout('feat');
 ALTER TABLE t ADD COLUMN col_feat TEXT;
@@ -142,9 +110,7 @@ UPDATE t SET col_feat='f';
 SELECT dolt_commit('-A','-m','feat adds col_feat');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test_match "schema_diff_cols_merge" "SELECT dolt_merge('feat');" "^[0-9a-f]" "$DB"
-
 
 run_test_match "schema_diff_cols_has_col_main" \
   "SELECT col_main FROM t WHERE id=1;" \
@@ -156,10 +122,6 @@ run_test_match "schema_diff_cols_has_col_feat" \
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_alter_merge4_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 CREATE TABLE keep(id INTEGER PRIMARY KEY, w TEXT);
@@ -168,27 +130,19 @@ INSERT INTO keep VALUES(1,'x');
 SELECT dolt_commit('-A','-m','init');
 SELECT dolt_branch('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 echo "DROP TABLE t;
 SELECT dolt_commit('-A','-m','drop t');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 echo "SELECT dolt_checkout('feat');
 INSERT INTO t VALUES(2,'b');
 SELECT dolt_commit('-A','-m','insert into t');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test_match "drop_vs_modify_merge" "SELECT dolt_merge('feat');" "conflict|merge failed|Error" "$DB"
-
 
 run_test "drop_vs_modify_keep" "SELECT w FROM keep WHERE id=1;" "x" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_alter_cp_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -201,11 +155,9 @@ UPDATE t SET extra='cp' WHERE id=1;
 SELECT dolt_commit('-A','-m','alter add extra');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test_match "cp_alter_hash" \
   "SELECT dolt_cherry_pick('feat');" \
   "^[0-9a-f]{40}$" "$DB"
-
 
 run_test "cp_alter_col_exists" \
   "SELECT count(*) FROM pragma_table_info('t') WHERE name='extra';" \
@@ -215,10 +167,6 @@ run_test_match "cp_alter_msg" "SELECT message FROM dolt_log LIMIT 1;" "^alter ad
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_alter_revert_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
@@ -227,16 +175,13 @@ ALTER TABLE t ADD COLUMN extra TEXT;
 UPDATE t SET extra='rev' WHERE id=1;
 SELECT dolt_commit('-A','-m','alter add extra');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "revert_alter_pre" \
   "SELECT count(*) FROM pragma_table_info('t') WHERE name='extra';" \
   "1" "$DB"
 
-
 run_test_match "revert_alter_hash" \
   "SELECT dolt_revert((SELECT commit_hash FROM dolt_log LIMIT 1));" \
   "^[0-9a-f]{40}$" "$DB"
-
 
 run_test "revert_alter_col_gone" \
   "SELECT count(*) FROM pragma_table_info('t') WHERE name='extra';" \
@@ -245,10 +190,6 @@ run_test "revert_alter_data" "SELECT v FROM t WHERE id=1;" "a" "$DB"
 run_test_match "revert_alter_msg" "SELECT message FROM dolt_log LIMIT 1;" "Revert" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_alter_cp_disjoint_table_$$.db; rm -f "$DB"
 cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -279,10 +220,6 @@ run_test "cp_disjoint_table_reopen" "SELECT count(*) FROM feat_tbl;" "1" "$DB"
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_alter_cp_disjoint_idx_$$.db; rm -f "$DB"
 cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
 CREATE TABLE a(id INTEGER PRIMARY KEY, v INT);
@@ -311,10 +248,6 @@ run_test "cp_disjoint_idx_b" \
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_alter_revert_disjoint_table_$$.db; rm -f "$DB"
 cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
 CREATE TABLE base(id INTEGER PRIMARY KEY, v INT);
@@ -339,10 +272,6 @@ run_test "revert_disjoint_table_gone" \
 run_test "revert_disjoint_table_base" "SELECT count(*) FROM base;" "1" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_alter_revert_disjoint_idx_$$.db; rm -f "$DB"
 cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -369,10 +298,6 @@ run_test "revert_disjoint_idx_b" \
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_alter_diff_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
@@ -384,31 +309,23 @@ INSERT INTO t VALUES(2,'b','y');
 SELECT dolt_commit('-A','-m','c2');
 SELECT dolt_tag('after');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test_match "diff_across_alter" \
   "SELECT diff_type FROM dolt_diff_t WHERE to_commit=(SELECT commit_hash FROM dolt_log LIMIT 1) LIMIT 1;" \
   "modified|added" "$DB"
-
 
 run_test_match "diff_across_alter_count" \
   "SELECT count(*) FROM dolt_diff_t WHERE to_commit=(SELECT commit_hash FROM dolt_log LIMIT 1);" \
   "^[1-9]" "$DB"
 
-
 run_test_match "history_across_alter" \
   "SELECT count(*) FROM dolt_history_t;" \
   "^[2-9]" "$DB"
-
 
 run_test "history_commits" \
   "SELECT count(DISTINCT commit_hash) FROM dolt_history_t;" \
   "2" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_alter_at_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -421,26 +338,19 @@ INSERT INTO t VALUES(2,'two','ext');
 SELECT dolt_commit('-A','-m','c2');
 SELECT dolt_tag('v2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "at_before_alter_count" \
   "SELECT count(*) FROM dolt_at_t('v1');" \
   "1" "$DB"
 
-
 run_test "at_after_alter_count" \
   "SELECT count(*) FROM dolt_at_t('v2');" \
   "2" "$DB"
-
 
 run_test_match "at_after_alter_extra" \
   "SELECT extra FROM dolt_at_t('v2') WHERE id=1;" \
   "new" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_alter_sd_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -451,7 +361,6 @@ ALTER TABLE t ADD COLUMN extra TEXT;
 SELECT dolt_commit('-A','-m','c2');
 SELECT dolt_tag('v2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test_match "schema_diff_alter_count" \
   "SELECT count(*) FROM dolt_schema_diff('v1','v2');" \
   "^[1-9]" "$DB"
@@ -460,22 +369,15 @@ run_test_match "schema_diff_alter_table" \
   "SELECT to_table_name FROM dolt_schema_diff('v1','v2') WHERE to_table_name='t';" \
   "^t$" "$DB"
 
-
 run_test_match "schema_diff_alter_to_stmt" \
   "SELECT to_create_statement FROM dolt_schema_diff('v1','v2') WHERE to_table_name='t';" \
   "extra" "$DB"
-
 
 run_test_match "schema_diff_alter_from_stmt" \
   "SELECT from_create_statement FROM dolt_schema_diff('v1','v2') WHERE to_table_name='t';" \
   "v TEXT" "$DB"
 
 rm -f "$DB"
-
-
-
-
-
 
 DB=/tmp/test_schema_merge10_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -505,7 +407,6 @@ run_test "schema_merge_diff_cols_count" \
   "2" "$DB"
 rm -f "$DB"
 
-
 DB=/tmp/test_schema_merge11_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
@@ -526,7 +427,6 @@ run_test "schema_merge_same_col_exists" \
   "1" "$DB"
 rm -f "$DB"
 
-
 DB=/tmp/test_schema_merge12_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
@@ -543,11 +443,6 @@ SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test_match "schema_merge_same_col_diff_type" "SELECT dolt_merge('feat');" "schema conflict|conflict|Error" "$DB"
 rm -f "$DB"
-
-
-
-
-
 
 DB=/tmp/test_schema_merge13_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -575,7 +470,6 @@ run_test "schema_merge_onesided_row_count" "SELECT count(*) FROM t;" "3" "$DB"
 run_test "schema_merge_onesided_data_main" "SELECT v FROM t WHERE id=1;" "a2" "$DB"
 rm -f "$DB"
 
-
 DB=/tmp/test_schema_merge14_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT, extra TEXT);
 INSERT INTO t VALUES(1,'a','e1');
@@ -588,15 +482,9 @@ INSERT INTO t VALUES(3,'c','e3');
 SELECT dolt_commit('-A','-m','feat adds data');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test_match "schema_merge_ff_hash" "SELECT dolt_merge('feat');" "^[0-9a-f]|Fast-forward" "$DB"
 run_test "schema_merge_ff_count" "SELECT count(*) FROM t;" "3" "$DB"
 rm -f "$DB"
-
-
-
-
-
 
 DB=/tmp/test_schema_merge15_$$.db; rm -f "$DB"
 echo "CREATE TABLE t1(id INTEGER PRIMARY KEY, v TEXT);
@@ -626,14 +514,7 @@ run_test "schema_merge_multi_t2_col" \
 run_test "schema_merge_multi_t1_data" "SELECT col_main FROM t1 WHERE id=1;" "m1" "$DB"
 rm -f "$DB"
 
-
-
-
-
-
-
 DB=/tmp/test_schema_merge16_$$.db; rm -f "$DB"
-
 
 INSERTS=""
 for i in $(seq 1 50); do
@@ -645,7 +526,6 @@ ${INSERTS}
 SELECT dolt_commit('-A','-m','init');
 SELECT dolt_branch('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 UPDATES=""
 for i in $(seq 1 50); do
   UPDATES="${UPDATES}UPDATE t SET score=$((i*10)) WHERE id=$i;"
@@ -655,7 +535,6 @@ echo "ALTER TABLE t ADD COLUMN score INTEGER;
 ${UPDATES}
 INSERT INTO t VALUES(51,'row51',510);
 SELECT dolt_commit('-A','-m','main adds score + row51');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 echo "SELECT dolt_checkout('feat');
 INSERT INTO t VALUES(52,'row52');
@@ -673,10 +552,6 @@ run_test "schema_merge_many_rows_score_col" \
   "SELECT count(*) FROM pragma_table_info('t') WHERE name='score';" \
   "1" "$DB"
 rm -f "$DB"
-
-
-
-
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/doltlite_schema_merge.sh
+++ b/test/doltlite_schema_merge.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-#
-# Tests for Schema merge and ALTER TABLE interactions with dolt operations (merge, cherry-pick,
-# revert, diff, history, point-in-time queries, schema_diff).
-#
+
+
+
+
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
@@ -11,9 +11,9 @@ run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -
 echo "=== Doltlite ALTER TABLE Merge Tests ==="
 echo ""
 
-# ============================================================
-# Test 1: ALTER TABLE ADD COLUMN on a branch, then merge into main
-# ============================================================
+
+
+
 
 DB=/tmp/test_alter_merge1_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -27,14 +27,14 @@ INSERT INTO t VALUES(2,'b','hello');
 SELECT dolt_commit('-A','-m','add extra column');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Before merge, main should not have the extra column
+
 run_test "alter_merge_pre_cols" \
   "SELECT count(*) FROM pragma_table_info('t') WHERE name='extra';" \
   "0" "$DB"
 
 run_test_match "alter_merge_hash" "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB"
 
-# After merge, extra column should exist
+
 run_test "alter_merge_post_cols" \
   "SELECT count(*) FROM pragma_table_info('t') WHERE name='extra';" \
   "1" "$DB"
@@ -44,9 +44,9 @@ run_test "alter_merge_count" "SELECT count(*) FROM t;" "2" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Test 1b: quoted added columns migrate correctly across merge
-# ============================================================
+
+
+
 
 DB=/tmp/test_alter_merge1b_$$.db; rm -f "$DB"
 cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -66,9 +66,9 @@ run_test "alter_merge_quoted_val" 'SELECT "odd""name" FROM t WHERE id=1;' "quote
 
 rm -f "$DB"
 
-# ============================================================
-# Test 1c: schema merge handles escaped quoted identifiers
-# ============================================================
+
+
+
 
 DB=/tmp/test_alter_merge1c_$$.db; rm -f "$DB"
 cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -92,9 +92,9 @@ run_test "alter_merge_escaped_feat_val" 'SELECT "feat""col" FROM t WHERE id=1;' 
 
 rm -f "$DB"
 
-# ============================================================
-# Test 2: ALTER TABLE ADD COLUMN same name on both branches — conflict?
-# ============================================================
+
+
+
 
 DB=/tmp/test_alter_merge2_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -102,27 +102,27 @@ INSERT INTO t VALUES(1,'a');
 SELECT dolt_commit('-A','-m','init');
 SELECT dolt_branch('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Main adds column
+
 echo "ALTER TABLE t ADD COLUMN extra TEXT;
 UPDATE t SET extra='main_val';
 SELECT dolt_commit('-A','-m','main adds extra');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Feature adds same column name
+
 echo "SELECT dolt_checkout('feat');
 ALTER TABLE t ADD COLUMN extra TEXT;
 UPDATE t SET extra='feat_val';
 SELECT dolt_commit('-A','-m','feat adds extra');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Both branches changed the same row's extra column — should conflict
+
 run_test_match "alter_same_col_merge" "SELECT dolt_merge('feat');" "conflict|merge failed|Error" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Test 3: ALTER TABLE ADD COLUMN on one branch, different ADD COLUMN
-#          on another, then merge
-# ============================================================
+
+
+
+
 
 DB=/tmp/test_alter_merge3_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -130,22 +130,22 @@ INSERT INTO t VALUES(1,'a');
 SELECT dolt_commit('-A','-m','init');
 SELECT dolt_branch('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Main adds col_main
+
 echo "ALTER TABLE t ADD COLUMN col_main TEXT;
 UPDATE t SET col_main='m';
 SELECT dolt_commit('-A','-m','main adds col_main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Feature adds col_feat
+
 echo "SELECT dolt_checkout('feat');
 ALTER TABLE t ADD COLUMN col_feat TEXT;
 UPDATE t SET col_feat='f';
 SELECT dolt_commit('-A','-m','feat adds col_feat');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Schema merge: different columns added on each side -> should succeed
+
 run_test_match "schema_diff_cols_merge" "SELECT dolt_merge('feat');" "^[0-9a-f]" "$DB"
 
-# Verify both columns present
+
 run_test_match "schema_diff_cols_has_col_main" \
   "SELECT col_main FROM t WHERE id=1;" \
   "m" "$DB"
@@ -156,9 +156,9 @@ run_test_match "schema_diff_cols_has_col_feat" \
 
 rm -f "$DB"
 
-# ============================================================
-# Test 4: DROP TABLE on one branch, modify data on another, then merge
-# ============================================================
+
+
+
 
 DB=/tmp/test_alter_merge4_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -168,27 +168,27 @@ INSERT INTO keep VALUES(1,'x');
 SELECT dolt_commit('-A','-m','init');
 SELECT dolt_branch('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Main drops table t
+
 echo "DROP TABLE t;
 SELECT dolt_commit('-A','-m','drop t');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Feature modifies data in t
+
 echo "SELECT dolt_checkout('feat');
 INSERT INTO t VALUES(2,'b');
 SELECT dolt_commit('-A','-m','insert into t');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Drop vs modify — should conflict
+
 run_test_match "drop_vs_modify_merge" "SELECT dolt_merge('feat');" "conflict|merge failed|Error" "$DB"
 
-# keep table should still be accessible
+
 run_test "drop_vs_modify_keep" "SELECT w FROM keep WHERE id=1;" "x" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Test 5: Cherry-pick a commit that includes an ALTER TABLE
-# ============================================================
+
+
+
 
 DB=/tmp/test_alter_cp_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -201,12 +201,12 @@ UPDATE t SET extra='cp' WHERE id=1;
 SELECT dolt_commit('-A','-m','alter add extra');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Cherry-pick the alter commit
+
 run_test_match "cp_alter_hash" \
   "SELECT dolt_cherry_pick('feat');" \
   "^[0-9a-f]{40}$" "$DB"
 
-# Column should exist on main now
+
 run_test "cp_alter_col_exists" \
   "SELECT count(*) FROM pragma_table_info('t') WHERE name='extra';" \
   "1" "$DB"
@@ -215,9 +215,9 @@ run_test_match "cp_alter_msg" "SELECT message FROM dolt_log LIMIT 1;" "^alter ad
 
 rm -f "$DB"
 
-# ============================================================
-# Test 6: Revert a commit that includes an ALTER TABLE (ADD COLUMN)
-# ============================================================
+
+
+
 
 DB=/tmp/test_alter_revert_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -227,17 +227,17 @@ ALTER TABLE t ADD COLUMN extra TEXT;
 UPDATE t SET extra='rev' WHERE id=1;
 SELECT dolt_commit('-A','-m','alter add extra');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Verify column exists before revert
+
 run_test "revert_alter_pre" \
   "SELECT count(*) FROM pragma_table_info('t') WHERE name='extra';" \
   "1" "$DB"
 
-# Revert the alter commit (HEAD)
+
 run_test_match "revert_alter_hash" \
   "SELECT dolt_revert((SELECT commit_hash FROM dolt_log LIMIT 1));" \
   "^[0-9a-f]{40}$" "$DB"
 
-# After revert, extra column should be gone and data restored
+
 run_test "revert_alter_col_gone" \
   "SELECT count(*) FROM pragma_table_info('t') WHERE name='extra';" \
   "0" "$DB"
@@ -246,9 +246,9 @@ run_test_match "revert_alter_msg" "SELECT message FROM dolt_log LIMIT 1;" "Rever
 
 rm -f "$DB"
 
-# ============================================================
-# Test 6b: Cherry-pick disjoint new-table addition across unrelated check change
-# ============================================================
+
+
+
 
 DB=/tmp/test_alter_cp_disjoint_table_$$.db; rm -f "$DB"
 cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -279,9 +279,9 @@ run_test "cp_disjoint_table_reopen" "SELECT count(*) FROM feat_tbl;" "1" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Test 6c: Cherry-pick disjoint index addition across unrelated index change
-# ============================================================
+
+
+
 
 DB=/tmp/test_alter_cp_disjoint_idx_$$.db; rm -f "$DB"
 cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -311,9 +311,9 @@ run_test "cp_disjoint_idx_b" \
 
 rm -f "$DB"
 
-# ============================================================
-# Test 6d: Revert old add-table commit while preserving later unrelated check change
-# ============================================================
+
+
+
 
 DB=/tmp/test_alter_revert_disjoint_table_$$.db; rm -f "$DB"
 cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -340,9 +340,9 @@ run_test "revert_disjoint_table_base" "SELECT count(*) FROM base;" "1" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Test 6e: Revert old index commit while preserving later unrelated index
-# ============================================================
+
+
+
 
 DB=/tmp/test_alter_revert_disjoint_idx_$$.db; rm -f "$DB"
 cat <<'EOF' | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -369,9 +369,9 @@ run_test "revert_disjoint_idx_b" \
 
 rm -f "$DB"
 
-# ============================================================
-# Test 7: dolt_diff and dolt_history across a schema change
-# ============================================================
+
+
+
 
 DB=/tmp/test_alter_diff_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -384,31 +384,31 @@ INSERT INTO t VALUES(2,'b','y');
 SELECT dolt_commit('-A','-m','c2');
 SELECT dolt_tag('after');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# dolt_diff between before and after should show changes
+
 run_test_match "diff_across_alter" \
   "SELECT diff_type FROM dolt_diff_t WHERE to_commit=(SELECT commit_hash FROM dolt_log LIMIT 1) LIMIT 1;" \
   "modified|added" "$DB"
 
-# dolt_diff should show at least the modified row
+
 run_test_match "diff_across_alter_count" \
   "SELECT count(*) FROM dolt_diff_t WHERE to_commit=(SELECT commit_hash FROM dolt_log LIMIT 1);" \
   "^[1-9]" "$DB"
 
-# dolt_history should include rows from both commits
+
 run_test_match "history_across_alter" \
   "SELECT count(*) FROM dolt_history_t;" \
   "^[2-9]" "$DB"
 
-# History should have entries from 2 different commits
+
 run_test "history_commits" \
   "SELECT count(DISTINCT commit_hash) FROM dolt_history_t;" \
   "2" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Test 8: dolt_at for a commit before vs after ALTER TABLE
-# ============================================================
+
+
+
 
 DB=/tmp/test_alter_at_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -421,26 +421,26 @@ INSERT INTO t VALUES(2,'two','ext');
 SELECT dolt_commit('-A','-m','c2');
 SELECT dolt_tag('v2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# At v1: no extra column, 1 row
+
 run_test "at_before_alter_count" \
   "SELECT count(*) FROM dolt_at_t('v1');" \
   "1" "$DB"
 
-# At v2: 2 rows
+
 run_test "at_after_alter_count" \
   "SELECT count(*) FROM dolt_at_t('v2');" \
   "2" "$DB"
 
-# At v2: extra column data accessible
+
 run_test_match "at_after_alter_extra" \
   "SELECT extra FROM dolt_at_t('v2') WHERE id=1;" \
   "new" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Test 9: dolt_schema_diff showing the ALTER changes
-# ============================================================
+
+
+
 
 DB=/tmp/test_alter_sd_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -451,7 +451,7 @@ ALTER TABLE t ADD COLUMN extra TEXT;
 SELECT dolt_commit('-A','-m','c2');
 SELECT dolt_tag('v2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Schema diff should show a change for table t
+
 run_test_match "schema_diff_alter_count" \
   "SELECT count(*) FROM dolt_schema_diff('v1','v2');" \
   "^[1-9]" "$DB"
@@ -460,23 +460,23 @@ run_test_match "schema_diff_alter_table" \
   "SELECT to_table_name FROM dolt_schema_diff('v1','v2') WHERE to_table_name='t';" \
   "^t$" "$DB"
 
-# The to_create_statement should include the extra column
+
 run_test_match "schema_diff_alter_to_stmt" \
   "SELECT to_create_statement FROM dolt_schema_diff('v1','v2') WHERE to_table_name='t';" \
   "extra" "$DB"
 
-# The from_create_statement should NOT include the extra column
+
 run_test_match "schema_diff_alter_from_stmt" \
   "SELECT from_create_statement FROM dolt_schema_diff('v1','v2') WHERE to_table_name='t';" \
   "v TEXT" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# Schema Merge: column additions
-# ============================================================
 
-# Test 10: Both branches add different columns with data — merge succeeds
+
+
+
+
 DB=/tmp/test_schema_merge10_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
@@ -505,7 +505,7 @@ run_test "schema_merge_diff_cols_count" \
   "2" "$DB"
 rm -f "$DB"
 
-# Test 11: Both branches add same column with identical definition — convergent, succeeds
+
 DB=/tmp/test_schema_merge11_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
@@ -526,7 +526,7 @@ run_test "schema_merge_same_col_exists" \
   "1" "$DB"
 rm -f "$DB"
 
-# Test 12: Both branches add same column with different types — error
+
 DB=/tmp/test_schema_merge12_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
@@ -544,11 +544,11 @@ SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "schema_merge_same_col_diff_type" "SELECT dolt_merge('feat');" "schema conflict|conflict|Error" "$DB"
 rm -f "$DB"
 
-# ============================================================
-# Schema Merge: one-sided changes
-# ============================================================
 
-# Test 13: Only one branch adds column, other changes data — column propagated
+
+
+
+
 DB=/tmp/test_schema_merge13_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
@@ -575,7 +575,7 @@ run_test "schema_merge_onesided_row_count" "SELECT count(*) FROM t;" "3" "$DB"
 run_test "schema_merge_onesided_data_main" "SELECT v FROM t WHERE id=1;" "a2" "$DB"
 rm -f "$DB"
 
-# Test 14: Only one branch drops a column (via recreating table), other doesn't touch schema
+
 DB=/tmp/test_schema_merge14_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT, extra TEXT);
 INSERT INTO t VALUES(1,'a','e1');
@@ -588,16 +588,16 @@ INSERT INTO t VALUES(3,'c','e3');
 SELECT dolt_commit('-A','-m','feat adds data');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Main just fast-forwards to feat since it has no changes
+
 run_test_match "schema_merge_ff_hash" "SELECT dolt_merge('feat');" "^[0-9a-f]|Fast-forward" "$DB"
 run_test "schema_merge_ff_count" "SELECT count(*) FROM t;" "3" "$DB"
 rm -f "$DB"
 
-# ============================================================
-# Schema Merge: multiple tables
-# ============================================================
 
-# Test 15: Two branches each add columns to different tables — no conflict
+
+
+
+
 DB=/tmp/test_schema_merge15_$$.db; rm -f "$DB"
 echo "CREATE TABLE t1(id INTEGER PRIMARY KEY, v TEXT);
 CREATE TABLE t2(id INTEGER PRIMARY KEY, w TEXT);
@@ -626,15 +626,15 @@ run_test "schema_merge_multi_t2_col" \
 run_test "schema_merge_multi_t1_data" "SELECT col_main FROM t1 WHERE id=1;" "m1" "$DB"
 rm -f "$DB"
 
-# ============================================================
-# Schema Merge: data integrity with many rows
-# ============================================================
 
-# Test 16: 50 rows, one branch adds a score column and sets all values + adds row 51.
-#           Other branch adds row 52. After merge: 52 rows, scores correct.
+
+
+
+
+
 DB=/tmp/test_schema_merge16_$$.db; rm -f "$DB"
 
-# Build insert statements for 50 rows
+
 INSERTS=""
 for i in $(seq 1 50); do
   INSERTS="${INSERTS}INSERT INTO t VALUES($i,'row$i');"
@@ -645,7 +645,7 @@ ${INSERTS}
 SELECT dolt_commit('-A','-m','init');
 SELECT dolt_branch('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Main branch: add score column, set values for all 50 rows, add row 51
+
 UPDATES=""
 for i in $(seq 1 50); do
   UPDATES="${UPDATES}UPDATE t SET score=$((i*10)) WHERE id=$i;"
@@ -656,7 +656,7 @@ ${UPDATES}
 INSERT INTO t VALUES(51,'row51',510);
 SELECT dolt_commit('-A','-m','main adds score + row51');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Feat branch: add row 52
+
 echo "SELECT dolt_checkout('feat');
 INSERT INTO t VALUES(52,'row52');
 SELECT dolt_commit('-A','-m','feat adds row52');
@@ -674,9 +674,9 @@ run_test "schema_merge_many_rows_score_col" \
   "1" "$DB"
 rm -f "$DB"
 
-# ============================================================
-# Done
-# ============================================================
+
+
+
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/doltlite_staging.sh
+++ b/test/doltlite_staging.sh
@@ -37,56 +37,56 @@ run_test_match() {
 echo "=== Doltlite Staging Workflow Tests ==="
 echo ""
 
-# --- Setup: create a database with initial commit ---
+
 DB=/tmp/test_staging_$$.db
 rm -f "$DB"
 echo "CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT); INSERT INTO users VALUES(1,'Alice'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# --- dolt_status: clean after commit ---
+
 run_test "status_clean_after_commit" \
   "SELECT count(*) FROM dolt_status;" \
   "0" "$DB"
 
-# --- dolt_status: detect unstaged insert ---
+
 echo "INSERT INTO users VALUES(2,'Bob');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "status_unstaged_modify" \
   "SELECT table_name, staged, status FROM dolt_status;" \
   "users|0|modified" "$DB"
 
-# --- dolt_add: stage the change ---
+
 echo "SELECT dolt_add('users');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "status_after_add" \
   "SELECT table_name, staged, status FROM dolt_status;" \
   "users|1|modified" "$DB"
 
-# --- dolt_commit: commit staged ---
+
 run_test_match "commit_staged" \
   "SELECT dolt_commit('-m','Add Bob');" \
   "^[0-9a-f]{40}$" "$DB"
 
-# --- Status clean after commit ---
+
 run_test "status_clean_after_staged_commit" \
   "SELECT count(*) FROM dolt_status;" \
   "0" "$DB"
 
-# --- Log has 2 commits ---
+
 run_test "log_two_commits" \
   "SELECT count(*) FROM dolt_log;" \
   "3" "$DB"
 
-# --- New table shows as 'new table' ---
+
 echo "CREATE TABLE orders(id INTEGER PRIMARY KEY, item TEXT); INSERT INTO orders VALUES(1,'hat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "status_new_table" \
   "SELECT table_name, staged, status FROM dolt_status WHERE table_name='orders';" \
   "orders|0|new table" "$DB"
 
-# --- Stage only orders, users untouched ---
+
 echo "SELECT dolt_add('orders');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "status_orders_staged" \
   "SELECT table_name, staged FROM dolt_status WHERE table_name='orders';" \
   "orders|1" "$DB"
 
-# --- Commit orders ---
+
 run_test_match "commit_orders" \
   "SELECT dolt_commit('-m','Add orders');" \
   "^[0-9a-f]{40}$" "$DB"
@@ -95,7 +95,7 @@ run_test "log_three_commits" \
   "SELECT count(*) FROM dolt_log;" \
   "4" "$DB"
 
-# --- dolt_add -A stages everything ---
+
 DB2=/tmp/test_staging2_$$.db
 rm -f "$DB2"
 echo "CREATE TABLE t1(x); INSERT INTO t1 VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB2" > /dev/null 2>&1
@@ -118,7 +118,7 @@ run_test "clean_after_add_all_commit" \
   "SELECT count(*) FROM dolt_status;" \
   "0" "$DB2"
 
-# --- dolt_commit -A shortcut (stage+commit in one call) ---
+
 DB3=/tmp/test_staging3_$$.db
 rm -f "$DB3"
 echo "CREATE TABLE t(x); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB3" > /dev/null 2>&1
@@ -136,7 +136,7 @@ run_test "log_after_dash_a" \
   "SELECT count(*) FROM dolt_log;" \
   "3" "$DB3"
 
-# --- Commit without staging fails ---
+
 DB4=/tmp/test_staging4_$$.db
 rm -f "$DB4"
 echo "CREATE TABLE t(x); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB4" > /dev/null 2>&1
@@ -146,12 +146,12 @@ run_test_match "commit_without_add_fails" \
   "SELECT dolt_commit('-m','should fail');" \
   "nothing to commit" "$DB4"
 
-# --- After failed commit, data is still there ---
+
 run_test "data_survives_failed_commit" \
   "SELECT count(*) FROM t;" \
   "2" "$DB4"
 
-# --- Partial staging: modify two tables, stage one ---
+
 DB5=/tmp/test_staging5_$$.db
 rm -f "$DB5"
 echo "CREATE TABLE a(x); CREATE TABLE b(y); INSERT INTO a VALUES(1); INSERT INTO b VALUES(2); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB5" > /dev/null 2>&1
@@ -179,18 +179,18 @@ run_test "b_still_unstaged_after_commit" \
   "SELECT table_name, staged, status FROM dolt_status;" \
   "b|0|modified" "$DB5"
 
-# --- Persistence: staged state survives reopen ---
+
 DB6=/tmp/test_staging6_$$.db
 rm -f "$DB6"
 echo "CREATE TABLE t(x); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(2); SELECT dolt_add('t');" | $DOLTLITE "$DB6" > /dev/null 2>&1
 
-# Reopen and check staged state
+
 run_test "staged_persists" \
   "SELECT count(*) FROM dolt_status WHERE staged=1;" \
   "1" "$DB6"
 
-# --- Named dolt_add can stage a dropped table ---
+
 DB6B=/tmp/test_staging6b_$$.db
 rm -f "$DB6B"
 echo "CREATE TABLE keep_t(x); CREATE TABLE drop_t(y); INSERT INTO keep_t VALUES(1); INSERT INTO drop_t VALUES(2); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6B" > /dev/null 2>&1
@@ -213,7 +213,7 @@ run_test "dropped_table_gone_after_commit" \
   "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='drop_t';" \
   "0" "$DB6B"
 
-# --- dolt_add dot (.) stages everything ---
+
 DB7=/tmp/test_staging7_$$.db
 rm -f "$DB7"
 echo "CREATE TABLE t(x); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB7" > /dev/null 2>&1
@@ -224,7 +224,7 @@ run_test "add_dot_stages_all" \
   "SELECT count(*) FROM dolt_status WHERE staged=1;" \
   "1" "$DB7"
 
-# --- dolt_status ignores internal index roots in clean state ---
+
 DB9=/tmp/test_staging_9_$$.db
 rm -f "$DB9"
 echo "CREATE TABLE parent(id INTEGER PRIMARY KEY, name TEXT);
@@ -235,7 +235,7 @@ run_test "status_clean_composite_pk_schema" \
   "SELECT count(*) FROM dolt_status;" \
   "0" "$DB9"
 
-# --- Cleanup ---
+
 rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB6B" "$DB7" "$DB8" "$DB9"
 
 echo ""

--- a/test/doltlite_staging.sh
+++ b/test/doltlite_staging.sh
@@ -37,55 +37,45 @@ run_test_match() {
 echo "=== Doltlite Staging Workflow Tests ==="
 echo ""
 
-
 DB=/tmp/test_staging_$$.db
 rm -f "$DB"
 echo "CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT); INSERT INTO users VALUES(1,'Alice'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "status_clean_after_commit" \
   "SELECT count(*) FROM dolt_status;" \
   "0" "$DB"
-
 
 echo "INSERT INTO users VALUES(2,'Bob');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "status_unstaged_modify" \
   "SELECT table_name, staged, status FROM dolt_status;" \
   "users|0|modified" "$DB"
 
-
 echo "SELECT dolt_add('users');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "status_after_add" \
   "SELECT table_name, staged, status FROM dolt_status;" \
   "users|1|modified" "$DB"
 
-
 run_test_match "commit_staged" \
   "SELECT dolt_commit('-m','Add Bob');" \
   "^[0-9a-f]{40}$" "$DB"
-
 
 run_test "status_clean_after_staged_commit" \
   "SELECT count(*) FROM dolt_status;" \
   "0" "$DB"
 
-
 run_test "log_two_commits" \
   "SELECT count(*) FROM dolt_log;" \
   "3" "$DB"
-
 
 echo "CREATE TABLE orders(id INTEGER PRIMARY KEY, item TEXT); INSERT INTO orders VALUES(1,'hat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "status_new_table" \
   "SELECT table_name, staged, status FROM dolt_status WHERE table_name='orders';" \
   "orders|0|new table" "$DB"
 
-
 echo "SELECT dolt_add('orders');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "status_orders_staged" \
   "SELECT table_name, staged FROM dolt_status WHERE table_name='orders';" \
   "orders|1" "$DB"
-
 
 run_test_match "commit_orders" \
   "SELECT dolt_commit('-m','Add orders');" \
@@ -94,7 +84,6 @@ run_test_match "commit_orders" \
 run_test "log_three_commits" \
   "SELECT count(*) FROM dolt_log;" \
   "4" "$DB"
-
 
 DB2=/tmp/test_staging2_$$.db
 rm -f "$DB2"
@@ -118,7 +107,6 @@ run_test "clean_after_add_all_commit" \
   "SELECT count(*) FROM dolt_status;" \
   "0" "$DB2"
 
-
 DB3=/tmp/test_staging3_$$.db
 rm -f "$DB3"
 echo "CREATE TABLE t(x); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB3" > /dev/null 2>&1
@@ -136,7 +124,6 @@ run_test "log_after_dash_a" \
   "SELECT count(*) FROM dolt_log;" \
   "3" "$DB3"
 
-
 DB4=/tmp/test_staging4_$$.db
 rm -f "$DB4"
 echo "CREATE TABLE t(x); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB4" > /dev/null 2>&1
@@ -146,11 +133,9 @@ run_test_match "commit_without_add_fails" \
   "SELECT dolt_commit('-m','should fail');" \
   "nothing to commit" "$DB4"
 
-
 run_test "data_survives_failed_commit" \
   "SELECT count(*) FROM t;" \
   "2" "$DB4"
-
 
 DB5=/tmp/test_staging5_$$.db
 rm -f "$DB5"
@@ -179,17 +164,14 @@ run_test "b_still_unstaged_after_commit" \
   "SELECT table_name, staged, status FROM dolt_status;" \
   "b|0|modified" "$DB5"
 
-
 DB6=/tmp/test_staging6_$$.db
 rm -f "$DB6"
 echo "CREATE TABLE t(x); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB6" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(2); SELECT dolt_add('t');" | $DOLTLITE "$DB6" > /dev/null 2>&1
 
-
 run_test "staged_persists" \
   "SELECT count(*) FROM dolt_status WHERE staged=1;" \
   "1" "$DB6"
-
 
 DB6B=/tmp/test_staging6b_$$.db
 rm -f "$DB6B"
@@ -213,7 +195,6 @@ run_test "dropped_table_gone_after_commit" \
   "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='drop_t';" \
   "0" "$DB6B"
 
-
 DB7=/tmp/test_staging7_$$.db
 rm -f "$DB7"
 echo "CREATE TABLE t(x); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB7" > /dev/null 2>&1
@@ -224,7 +205,6 @@ run_test "add_dot_stages_all" \
   "SELECT count(*) FROM dolt_status WHERE staged=1;" \
   "1" "$DB7"
 
-
 DB9=/tmp/test_staging_9_$$.db
 rm -f "$DB9"
 echo "CREATE TABLE parent(id INTEGER PRIMARY KEY, name TEXT);
@@ -234,7 +214,6 @@ SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB9" > /dev/null 2>&1
 run_test "status_clean_composite_pk_schema" \
   "SELECT count(*) FROM dolt_status;" \
   "0" "$DB9"
-
 
 rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB6B" "$DB7" "$DB8" "$DB9"
 

--- a/test/doltlite_structural.sh
+++ b/test/doltlite_structural.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
-#
-# Structural sharing and GC cleanup tests for Doltlite.
-#
-# Verifies:
-# - Prolly tree structural sharing: changing 1 row in a large table
-#   produces a small delta, not a full copy
-# - GC cleans up orphaned chunks from deleted branches
-# - GC preserves shared chunks between branches
-# - Multiple small commits don't cause linear file growth
-#
+
+
+
+
+
+
+
+
+
+
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 
@@ -51,9 +51,9 @@ assert_greater() {
   fi
 }
 
-# ============================================================
-# Structural sharing: 1-row update on 1K table
-# ============================================================
+
+
+
 
 echo "--- Structural sharing: 1-row change on 1K table ---"
 
@@ -66,8 +66,8 @@ SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 SIZE_AFTER_INIT=$(file_size "$DB")
 echo "  After 1K rows committed: ${SIZE_AFTER_INIT} bytes"
 
-# Update 1 row and commit
-# Insert a new row (not update) to ensure new chunks are created
+
+
 echo "INSERT INTO t VALUES(9998,'new_inserted_row');
 SELECT dolt_commit('-A','-m','insert 1 row');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
@@ -75,19 +75,19 @@ SIZE_AFTER_INSERT=$(file_size "$DB")
 DELTA=$((SIZE_AFTER_INSERT - SIZE_AFTER_INIT))
 echo "  After inserting 1 row: ${SIZE_AFTER_INSERT} bytes (delta: ${DELTA})"
 
-# Delta should be small — only changed tree nodes + new commit.
-# For a 1K row table (~25KB), adding 1 row should add < 50% of table size.
+
+
 HALF_INIT=$((SIZE_AFTER_INIT / 2))
 assert_less "ss_1row_delta_small" "$DELTA" "$HALF_INIT"
 
-# Delta must be > 0 (new chunks were actually created)
+
 assert_greater "ss_1row_delta_nonzero" "$DELTA" "0"
 
 db_rm "$DB"
 
-# ============================================================
-# Structural sharing: 1-row update on 10K table (same test, bigger)
-# ============================================================
+
+
+
 
 echo ""
 echo "--- Structural sharing: 1-row change on 10K table ---"
@@ -112,16 +112,16 @@ SIZE_INS_10K=$(file_size "$DB")
 DELTA_10K=$((SIZE_INS_10K - SIZE_INIT_10K))
 echo "  After 1-row insert: ${SIZE_INS_10K} bytes (delta: ${DELTA_10K})"
 
-# For 10K rows (~270KB), 1-row insert should add < 10% of table size
+
 TEN_PCT=$((SIZE_INIT_10K / 10))
 assert_less "ss_10k_1row_delta" "$DELTA_10K" "$TEN_PCT"
 assert_greater "ss_10k_1row_nonzero" "$DELTA_10K" "0"
 
 db_rm "$DB"
 
-# ============================================================
-# Structural sharing across branches
-# ============================================================
+
+
+
 
 echo ""
 echo "--- Structural sharing: branch with 1 new row ---"
@@ -144,16 +144,16 @@ SIZE_AFTER_BRANCH=$(file_size "$DB")
 BRANCH_DELTA=$((SIZE_AFTER_BRANCH - SIZE_BEFORE_BRANCH))
 echo "  After feat commit: ${SIZE_AFTER_BRANCH} bytes (delta: ${BRANCH_DELTA})"
 
-# Branch with 1 new row should share ~99% of chunks with main.
-# Delta should be < 25% of the base size.
+
+
 QUARTER=$((SIZE_BEFORE_BRANCH / 4))
 assert_less "ss_branch_small_delta" "$BRANCH_DELTA" "$QUARTER"
 
 db_rm "$DB"
 
-# ============================================================
-# GC cleans orphaned branch chunks
-# ============================================================
+
+
+
 
 echo ""
 echo "--- GC: clean up deleted branch ---"
@@ -164,7 +164,7 @@ BEGIN;$(for i in $(seq 0 999); do echo "INSERT INTO t VALUES($i,'row_$i');"; don
 COMMIT;
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Create branch with lots of unique data
+
 echo "SELECT dolt_branch('big');
 SELECT dolt_checkout('big');
 BEGIN;$(for i in $(seq 1000 1999); do echo "INSERT INTO t VALUES($i,'big_$i');"; done)
@@ -175,25 +175,25 @@ SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 SIZE_WITH_BRANCH=$(file_size "$DB")
 echo "  With branch (2K rows): ${SIZE_WITH_BRANCH} bytes"
 
-# Delete branch and GC
+
 echo "SELECT dolt_branch('-D','big');
 SELECT dolt_gc();" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 SIZE_AFTER_GC=$(file_size "$DB")
 echo "  After branch delete + GC: ${SIZE_AFTER_GC} bytes"
 
-# GC should reclaim the orphaned branch data.
-# File should shrink by a significant amount.
+
+
 assert_less "gc_shrinks_file" "$SIZE_AFTER_GC" "$SIZE_WITH_BRANCH"
 
 RECLAIMED=$((SIZE_WITH_BRANCH - SIZE_AFTER_GC))
 echo "  Reclaimed: ${RECLAIMED} bytes"
 
-# Should reclaim at least 10% of file size
+
 TEN_PCT_BRANCH=$((SIZE_WITH_BRANCH / 10))
 assert_greater "gc_reclaims_significant" "$RECLAIMED" "$TEN_PCT_BRANCH"
 
-# Data on main should survive
+
 MAIN_COUNT=$(echo "SELECT count(*) FROM t;" | $DOLTLITE "$DB" 2>&1)
 if [ "$MAIN_COUNT" = "1000" ]; then
   PASS=$((PASS+1)); echo "  PASS: gc_data_survives — 1000 rows on main"
@@ -204,9 +204,9 @@ fi
 
 db_rm "$DB"
 
-# ============================================================
-# GC preserves shared chunks between branches
-# ============================================================
+
+
+
 
 echo ""
 echo "--- GC: preserve shared chunks ---"
@@ -218,13 +218,13 @@ COMMIT;
 SELECT dolt_commit('-A','-m','init');
 SELECT dolt_branch('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Small change on feat
+
 echo "SELECT dolt_checkout('feat');
 INSERT INTO t VALUES(9999,'feat_only');
 SELECT dolt_commit('-A','-m','feat');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Small change on main
+
 echo "INSERT INTO t VALUES(8888,'main_only');
 SELECT dolt_commit('-A','-m','main change');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
@@ -236,14 +236,14 @@ echo "SELECT dolt_gc();" | $DOLTLITE "$DB" > /dev/null 2>&1
 SIZE_AFTER_GC=$(file_size "$DB")
 echo "  After GC: ${SIZE_AFTER_GC} bytes"
 
-# Both branches share most chunks — GC should NOT shrink much
-# (nothing is truly orphaned since both branches are alive)
-# File should stay within 85% of original (streaming merge may
-# produce slightly different chunk boundaries)
+
+
+
+
 THRESHOLD=$((SIZE_BEFORE_GC * 85 / 100))
 assert_greater "gc_preserves_shared" "$SIZE_AFTER_GC" "$THRESHOLD"
 
-# Both branches' data should survive
+
 MAIN_COUNT=$(echo "SELECT count(*) FROM t WHERE id=8888;" | $DOLTLITE "$DB" 2>&1)
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 FEAT_COUNT=$(echo "SELECT count(*) FROM t WHERE id=9999;" | $DOLTLITE "$DB/feat" 2>&1)
@@ -256,9 +256,9 @@ fi
 
 db_rm "$DB"
 
-# ============================================================
-# Multiple small commits don't bloat linearly
-# ============================================================
+
+
+
 
 echo ""
 echo "--- Sub-linear growth: 10 small commits ---"
@@ -272,7 +272,7 @@ SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 SIZE_BASE=$(file_size "$DB")
 echo "  Base (1K rows): ${SIZE_BASE} bytes"
 
-# 10 commits in one session, each changing 1 row
+
 python3 -c "
 for c in range(1, 11):
     print(f'UPDATE t SET v=\"commit_{c}\" WHERE id={c * 100};')
@@ -285,14 +285,14 @@ SIZE_AFTER_10=$(file_size "$DB")
 GROWTH=$((SIZE_AFTER_10 - SIZE_BASE))
 echo "  After 10 1-row commits: ${SIZE_AFTER_10} bytes (growth: ${GROWTH})"
 
-# 10 commits × 1 row each. With mergeWalk (always used for correctness,
-# applyEdits disabled due to #156), each commit rebuilds the full tree
-# producing duplicate chunks. Growth is proportional to table size × commits.
-# TODO: tighten to 3x when applyEdits is fixed and re-enabled (#158).
+
+
+
+
 TEN_X=$((SIZE_BASE * 10))
 assert_less "commits_sublinear" "$GROWTH" "$TEN_X"
 
-# Verify data integrity (in a fresh session)
+
 COUNT=$(echo "SELECT count(*) FROM t;" | $DOLTLITE "$DB" 2>&1)
 LOG_COUNT=$(echo "SELECT count(*) FROM dolt_log;" | $DOLTLITE "$DB" 2>&1)
 if [ "$COUNT" = "1000" ]; then
@@ -304,9 +304,9 @@ fi
 
 db_rm "$DB"
 
-# ============================================================
-# GC after many commits reclaims old tree nodes
-# ============================================================
+
+
+
 
 echo ""
 echo "--- GC after many commits ---"
@@ -317,7 +317,7 @@ BEGIN;$(for i in $(seq 0 999); do echo "INSERT INTO t VALUES($i,'row_$i');"; don
 COMMIT;
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# 20 commits updating different rows — creates dead tree nodes
+
 for c in $(seq 1 20); do
   echo "UPDATE t SET v='v${c}' WHERE id=$((c * 50));
 SELECT dolt_commit('-A','-m','change $c');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -331,8 +331,8 @@ echo "SELECT dolt_gc();" | $DOLTLITE "$DB" > /dev/null 2>&1
 SIZE_AFTER=$(file_size "$DB")
 echo "  After GC: ${SIZE_AFTER} bytes"
 
-# GC may reclaim some dead intermediate tree nodes, but when all
-# commits are reachable, reclamation is not guaranteed. Allow equal.
+
+
 if [ "$SIZE_AFTER" -le "$SIZE_BEFORE" ]; then
   PASS=$((PASS+1)); echo "  PASS: gc_after_commits_helps — $SIZE_AFTER <= $SIZE_BEFORE"
 else
@@ -340,7 +340,7 @@ else
   echo "  FAIL: gc_after_commits_helps — $SIZE_AFTER > $SIZE_BEFORE"
 fi
 
-# Data integrity
+
 COUNT=$(echo "SELECT count(*) FROM t;" | $DOLTLITE "$DB" 2>&1)
 if [ "$COUNT" = "1000" ]; then
   PASS=$((PASS+1)); echo "  PASS: gc_commits_data_ok — 1000 rows"
@@ -351,9 +351,9 @@ fi
 
 db_rm "$DB"
 
-# ============================================================
-# GC idempotent: second run doesn't change size
-# ============================================================
+
+
+
 
 echo ""
 echo "--- GC idempotent ---"
@@ -378,9 +378,9 @@ SIZE_SECOND_GC=$(file_size "$DB")
 
 echo "  First GC: ${SIZE_FIRST_GC}, Second GC: ${SIZE_SECOND_GC}"
 
-# Allow small variance (±5%) between GC runs for platform differences
+
 DIFF_ABS=$(( SIZE_SECOND_GC > SIZE_FIRST_GC ? SIZE_SECOND_GC - SIZE_FIRST_GC : SIZE_FIRST_GC - SIZE_SECOND_GC ))
-THRESHOLD=$(( SIZE_FIRST_GC / 20 ))  # 5%
+THRESHOLD=$(( SIZE_FIRST_GC / 20 ))
 if [ "$DIFF_ABS" -le "$THRESHOLD" ]; then
   PASS=$((PASS+1)); echo "  PASS: gc_idempotent — within 5% ($DIFF_ABS <= $THRESHOLD)"
 else
@@ -390,9 +390,9 @@ fi
 
 db_rm "$DB"
 
-# ============================================================
-# Done
-# ============================================================
+
+
+
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/doltlite_structural.sh
+++ b/test/doltlite_structural.sh
@@ -1,14 +1,4 @@
 #!/bin/bash
-
-
-
-
-
-
-
-
-
-
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 
@@ -51,10 +41,6 @@ assert_greater() {
   fi
 }
 
-
-
-
-
 echo "--- Structural sharing: 1-row change on 1K table ---"
 
 DB=/tmp/test_ss_1k_$$.db; db_rm "$DB"
@@ -66,8 +52,6 @@ SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 SIZE_AFTER_INIT=$(file_size "$DB")
 echo "  After 1K rows committed: ${SIZE_AFTER_INIT} bytes"
 
-
-
 echo "INSERT INTO t VALUES(9998,'new_inserted_row');
 SELECT dolt_commit('-A','-m','insert 1 row');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
@@ -75,19 +59,12 @@ SIZE_AFTER_INSERT=$(file_size "$DB")
 DELTA=$((SIZE_AFTER_INSERT - SIZE_AFTER_INIT))
 echo "  After inserting 1 row: ${SIZE_AFTER_INSERT} bytes (delta: ${DELTA})"
 
-
-
 HALF_INIT=$((SIZE_AFTER_INIT / 2))
 assert_less "ss_1row_delta_small" "$DELTA" "$HALF_INIT"
-
 
 assert_greater "ss_1row_delta_nonzero" "$DELTA" "0"
 
 db_rm "$DB"
-
-
-
-
 
 echo ""
 echo "--- Structural sharing: 1-row change on 10K table ---"
@@ -112,16 +89,11 @@ SIZE_INS_10K=$(file_size "$DB")
 DELTA_10K=$((SIZE_INS_10K - SIZE_INIT_10K))
 echo "  After 1-row insert: ${SIZE_INS_10K} bytes (delta: ${DELTA_10K})"
 
-
 TEN_PCT=$((SIZE_INIT_10K / 10))
 assert_less "ss_10k_1row_delta" "$DELTA_10K" "$TEN_PCT"
 assert_greater "ss_10k_1row_nonzero" "$DELTA_10K" "0"
 
 db_rm "$DB"
-
-
-
-
 
 echo ""
 echo "--- Structural sharing: branch with 1 new row ---"
@@ -144,16 +116,10 @@ SIZE_AFTER_BRANCH=$(file_size "$DB")
 BRANCH_DELTA=$((SIZE_AFTER_BRANCH - SIZE_BEFORE_BRANCH))
 echo "  After feat commit: ${SIZE_AFTER_BRANCH} bytes (delta: ${BRANCH_DELTA})"
 
-
-
 QUARTER=$((SIZE_BEFORE_BRANCH / 4))
 assert_less "ss_branch_small_delta" "$BRANCH_DELTA" "$QUARTER"
 
 db_rm "$DB"
-
-
-
-
 
 echo ""
 echo "--- GC: clean up deleted branch ---"
@@ -163,7 +129,6 @@ echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 BEGIN;$(for i in $(seq 0 999); do echo "INSERT INTO t VALUES($i,'row_$i');"; done)
 COMMIT;
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 echo "SELECT dolt_branch('big');
 SELECT dolt_checkout('big');
@@ -175,24 +140,19 @@ SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 SIZE_WITH_BRANCH=$(file_size "$DB")
 echo "  With branch (2K rows): ${SIZE_WITH_BRANCH} bytes"
 
-
 echo "SELECT dolt_branch('-D','big');
 SELECT dolt_gc();" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 SIZE_AFTER_GC=$(file_size "$DB")
 echo "  After branch delete + GC: ${SIZE_AFTER_GC} bytes"
 
-
-
 assert_less "gc_shrinks_file" "$SIZE_AFTER_GC" "$SIZE_WITH_BRANCH"
 
 RECLAIMED=$((SIZE_WITH_BRANCH - SIZE_AFTER_GC))
 echo "  Reclaimed: ${RECLAIMED} bytes"
 
-
 TEN_PCT_BRANCH=$((SIZE_WITH_BRANCH / 10))
 assert_greater "gc_reclaims_significant" "$RECLAIMED" "$TEN_PCT_BRANCH"
-
 
 MAIN_COUNT=$(echo "SELECT count(*) FROM t;" | $DOLTLITE "$DB" 2>&1)
 if [ "$MAIN_COUNT" = "1000" ]; then
@@ -204,10 +164,6 @@ fi
 
 db_rm "$DB"
 
-
-
-
-
 echo ""
 echo "--- GC: preserve shared chunks ---"
 
@@ -218,12 +174,10 @@ COMMIT;
 SELECT dolt_commit('-A','-m','init');
 SELECT dolt_branch('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 echo "SELECT dolt_checkout('feat');
 INSERT INTO t VALUES(9999,'feat_only');
 SELECT dolt_commit('-A','-m','feat');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 echo "INSERT INTO t VALUES(8888,'main_only');
 SELECT dolt_commit('-A','-m','main change');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -236,13 +190,8 @@ echo "SELECT dolt_gc();" | $DOLTLITE "$DB" > /dev/null 2>&1
 SIZE_AFTER_GC=$(file_size "$DB")
 echo "  After GC: ${SIZE_AFTER_GC} bytes"
 
-
-
-
-
 THRESHOLD=$((SIZE_BEFORE_GC * 85 / 100))
 assert_greater "gc_preserves_shared" "$SIZE_AFTER_GC" "$THRESHOLD"
-
 
 MAIN_COUNT=$(echo "SELECT count(*) FROM t WHERE id=8888;" | $DOLTLITE "$DB" 2>&1)
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -256,10 +205,6 @@ fi
 
 db_rm "$DB"
 
-
-
-
-
 echo ""
 echo "--- Sub-linear growth: 10 small commits ---"
 
@@ -271,7 +216,6 @@ SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 SIZE_BASE=$(file_size "$DB")
 echo "  Base (1K rows): ${SIZE_BASE} bytes"
-
 
 python3 -c "
 for c in range(1, 11):
@@ -285,13 +229,8 @@ SIZE_AFTER_10=$(file_size "$DB")
 GROWTH=$((SIZE_AFTER_10 - SIZE_BASE))
 echo "  After 10 1-row commits: ${SIZE_AFTER_10} bytes (growth: ${GROWTH})"
 
-
-
-
-
 TEN_X=$((SIZE_BASE * 10))
 assert_less "commits_sublinear" "$GROWTH" "$TEN_X"
-
 
 COUNT=$(echo "SELECT count(*) FROM t;" | $DOLTLITE "$DB" 2>&1)
 LOG_COUNT=$(echo "SELECT count(*) FROM dolt_log;" | $DOLTLITE "$DB" 2>&1)
@@ -304,10 +243,6 @@ fi
 
 db_rm "$DB"
 
-
-
-
-
 echo ""
 echo "--- GC after many commits ---"
 
@@ -316,7 +251,6 @@ echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 BEGIN;$(for i in $(seq 0 999); do echo "INSERT INTO t VALUES($i,'row_$i');"; done)
 COMMIT;
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 for c in $(seq 1 20); do
   echo "UPDATE t SET v='v${c}' WHERE id=$((c * 50));
@@ -331,15 +265,12 @@ echo "SELECT dolt_gc();" | $DOLTLITE "$DB" > /dev/null 2>&1
 SIZE_AFTER=$(file_size "$DB")
 echo "  After GC: ${SIZE_AFTER} bytes"
 
-
-
 if [ "$SIZE_AFTER" -le "$SIZE_BEFORE" ]; then
   PASS=$((PASS+1)); echo "  PASS: gc_after_commits_helps — $SIZE_AFTER <= $SIZE_BEFORE"
 else
   FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: gc_after_commits_helps\n  $SIZE_AFTER > $SIZE_BEFORE"
   echo "  FAIL: gc_after_commits_helps — $SIZE_AFTER > $SIZE_BEFORE"
 fi
-
 
 COUNT=$(echo "SELECT count(*) FROM t;" | $DOLTLITE "$DB" 2>&1)
 if [ "$COUNT" = "1000" ]; then
@@ -350,10 +281,6 @@ else
 fi
 
 db_rm "$DB"
-
-
-
-
 
 echo ""
 echo "--- GC idempotent ---"
@@ -378,7 +305,6 @@ SIZE_SECOND_GC=$(file_size "$DB")
 
 echo "  First GC: ${SIZE_FIRST_GC}, Second GC: ${SIZE_SECOND_GC}"
 
-
 DIFF_ABS=$(( SIZE_SECOND_GC > SIZE_FIRST_GC ? SIZE_SECOND_GC - SIZE_FIRST_GC : SIZE_FIRST_GC - SIZE_SECOND_GC ))
 THRESHOLD=$(( SIZE_FIRST_GC / 20 ))
 if [ "$DIFF_ABS" -le "$THRESHOLD" ]; then
@@ -389,10 +315,6 @@ else
 fi
 
 db_rm "$DB"
-
-
-
-
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/doltlite_tag.sh
+++ b/test/doltlite_tag.sh
@@ -15,7 +15,6 @@ run_test "tag_name" "SELECT tag_name FROM dolt_tags;" "v1.0" "$DB"
 run_test_match "tag_hash" "SELECT tag_hash FROM dolt_tags;" "^[0-9a-f]{40}$" "$DB"
 run_test "tag_message" "SELECT message FROM dolt_tags;" "release one" "$DB"
 
-
 echo "INSERT INTO t VALUES(2); SELECT dolt_commit('-A','-m','second');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "tag_specific" \
   "SELECT dolt_tag('v0.9', (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1));" "0" "$DB"
@@ -24,7 +23,6 @@ run_test "tag_head_parent" \
 run_test "tag_head_tilde" \
   "SELECT dolt_tag('parenttilde','HEAD~1');" "0" "$DB"
 run_test "four_tags" "SELECT count(*) FROM dolt_tags;" "4" "$DB"
-
 
 DB2=/tmp/test_tag_branch_$$.db; rm -f "$DB2"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -38,14 +36,11 @@ SELECT dolt_checkout('main');
 SELECT dolt_tag('feat-tag','feat');" | $DOLTLITE "$DB2" > /dev/null 2>&1
 run_test "tag_branch_ref" "SELECT count(*) FROM dolt_tags WHERE tag_name='feat-tag';" "1" "$DB2"
 
-
 run_test_match "dup_tag" "SELECT dolt_tag('v1.0');" "already exists" "$DB"
-
 
 run_test_match "tag_missing_commit" \
   "SELECT dolt_tag('badtag','0123456789abcdef0123456789abcdef01234567');" \
   "commit not found" "$DB"
-
 
 run_test "delete_tag" "SELECT dolt_tag('-d','v0.9');" "0" "$DB"
 run_test "delete_and_recreate_same_name" "SELECT dolt_tag('-d','parenttilde'); SELECT dolt_tag('parenttilde');" "0
@@ -57,9 +52,7 @@ run_test_match "delete_tag_extra_arg" \
 run_test "delete_extra_arg_keeps_tag" \
   "SELECT count(*) FROM dolt_tags WHERE tag_name='v1.0';" "1" "$DB"
 
-
 run_test_match "delete_missing" "SELECT dolt_tag('-d','nope');" "not found" "$DB"
-
 
 run_test "tag_persists" "SELECT tag_name FROM dolt_tags ORDER BY tag_name;" "parent
 parenttilde

--- a/test/doltlite_tag.sh
+++ b/test/doltlite_tag.sh
@@ -15,7 +15,7 @@ run_test "tag_name" "SELECT tag_name FROM dolt_tags;" "v1.0" "$DB"
 run_test_match "tag_hash" "SELECT tag_hash FROM dolt_tags;" "^[0-9a-f]{40}$" "$DB"
 run_test "tag_message" "SELECT message FROM dolt_tags;" "release one" "$DB"
 
-# Second commit, tag specific commit
+
 echo "INSERT INTO t VALUES(2); SELECT dolt_commit('-A','-m','second');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "tag_specific" \
   "SELECT dolt_tag('v0.9', (SELECT commit_hash FROM dolt_log LIMIT 1 OFFSET 1));" "0" "$DB"
@@ -25,7 +25,7 @@ run_test "tag_head_tilde" \
   "SELECT dolt_tag('parenttilde','HEAD~1');" "0" "$DB"
 run_test "four_tags" "SELECT count(*) FROM dolt_tags;" "4" "$DB"
 
-# Branch ref target
+
 DB2=/tmp/test_tag_branch_$$.db; rm -f "$DB2"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'base');
@@ -38,15 +38,15 @@ SELECT dolt_checkout('main');
 SELECT dolt_tag('feat-tag','feat');" | $DOLTLITE "$DB2" > /dev/null 2>&1
 run_test "tag_branch_ref" "SELECT count(*) FROM dolt_tags WHERE tag_name='feat-tag';" "1" "$DB2"
 
-# Duplicate tag error
+
 run_test_match "dup_tag" "SELECT dolt_tag('v1.0');" "already exists" "$DB"
 
-# Explicit tag target must resolve to a real commit
+
 run_test_match "tag_missing_commit" \
   "SELECT dolt_tag('badtag','0123456789abcdef0123456789abcdef01234567');" \
   "commit not found" "$DB"
 
-# Delete tag
+
 run_test "delete_tag" "SELECT dolt_tag('-d','v0.9');" "0" "$DB"
 run_test "delete_and_recreate_same_name" "SELECT dolt_tag('-d','parenttilde'); SELECT dolt_tag('parenttilde');" "0
 0" "$DB"
@@ -57,10 +57,10 @@ run_test_match "delete_tag_extra_arg" \
 run_test "delete_extra_arg_keeps_tag" \
   "SELECT count(*) FROM dolt_tags WHERE tag_name='v1.0';" "1" "$DB"
 
-# Delete nonexistent
+
 run_test_match "delete_missing" "SELECT dolt_tag('-d','nope');" "not found" "$DB"
 
-# Tag persists across reopen
+
 run_test "tag_persists" "SELECT tag_name FROM dolt_tags ORDER BY tag_name;" "parent
 parenttilde
 v1.0" "$DB"

--- a/test/doltlite_unicode_blob.sh
+++ b/test/doltlite_unicode_blob.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
-
-
-
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(30);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
@@ -9,10 +6,6 @@ run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -
 
 echo "=== Doltlite Unicode, Special Characters & Large BLOB Tests ==="
 echo ""
-
-
-
-
 
 DB=/tmp/test_unicode1_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT);
@@ -22,7 +15,6 @@ SELECT dolt_commit('-A','-m','add emoji');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "emoji_insert" \
   "SELECT val FROM t;" \
   "Hello 🌍🎉🚀" "$DB"
-
 
 echo "UPDATE t SET val='Goodbye 👋';" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "emoji_diff_type" \
@@ -36,10 +28,6 @@ run_test_match "emoji_diff_to_value" \
 echo "SELECT dolt_commit('-A','-m','update emoji');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_unicode2_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT);
@@ -61,7 +49,6 @@ run_test "arabic_data" \
 run_test "japanese_data" \
   "SELECT val FROM t WHERE id=3;" \
   "日本語テスト" "$DB"
-
 
 echo "SELECT dolt_branch('intl');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('intl');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -85,10 +72,6 @@ run_test "cyrillic_after_merge" \
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_unicode3_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(x);
 INSERT INTO t VALUES(1);
@@ -107,18 +90,12 @@ run_test_match "japanese_commit_msg" \
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_unicode4_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(x); INSERT INTO t VALUES(1);
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 result=$(echo "SELECT dolt_branch('feature/日本語');" | perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$DB" 2>&1)
 if [ "$result" = "0" ]; then
-
   run_test "unicode_branch_active" \
     "SELECT dolt_checkout('feature/日本語'); SELECT active_branch();" \
     "0
@@ -126,7 +103,6 @@ feature/日本語" "$DB"
   PASS=$((PASS+1))
   echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 else
-
   if echo "$result" | grep -qiE "error|invalid|not allowed"; then
     PASS=$((PASS+1))
     PASS=$((PASS+1))
@@ -139,12 +115,7 @@ fi
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_unicode5_$$.db; rm -f "$DB"
-
 
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT);
 INSERT INTO t VALUES(1, 'line1' || char(10) || 'line2');
@@ -160,7 +131,6 @@ run_test_match "tab_data" \
   "SELECT length(val) FROM t WHERE id=2;" \
   "^9$" "$DB"
 
-
 echo "UPDATE t SET val='plain' WHERE id=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "special_char_diff" \
   "SELECT diff_type FROM dolt_diff_t WHERE to_commit='WORKING';" \
@@ -170,12 +140,7 @@ echo "SELECT dolt_commit('-A','-m','normalize');" | $DOLTLITE "$DB" > /dev/null 
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_blob6_$$.db; rm -f "$DB"
-
 
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT);
 INSERT INTO t VALUES(1, replace(hex(zeroblob(50000)), '0', 'A'));
@@ -185,7 +150,6 @@ run_test "100kb_length" \
   "SELECT length(val) FROM t WHERE id=1;" \
   "100000" "$DB"
 
-
 echo "UPDATE t SET val='short';" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "100kb_diff" \
   "SELECT diff_type FROM dolt_diff_t WHERE to_commit='WORKING';" \
@@ -194,10 +158,6 @@ run_test_match "100kb_diff" \
 echo "SELECT dolt_commit('-A','-m','shorten');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_blob7_$$.db; rm -f "$DB"
 
@@ -209,15 +169,12 @@ run_test "1mb_blob_size" \
   "SELECT length(data) FROM t WHERE id=1;" \
   "1048576" "$DB"
 
-
 echo "SELECT dolt_branch('blobcheck');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('blobcheck');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 run_test "1mb_blob_on_branch" \
   "SELECT length(data) FROM t WHERE id=1;" \
   "1048576" "$DB/blobcheck"
-
 
 echo "INSERT INTO t VALUES(2, randomblob(512));
 SELECT dolt_commit('-A','-m','add small blob');" | $DOLTLITE "$DB/blobcheck" > /dev/null 2>&1
@@ -234,12 +191,7 @@ run_test "1mb_blob_after_merge" \
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_blob8_$$.db; rm -f "$DB"
-
 
 cols=""
 vals=""
@@ -257,7 +209,6 @@ run_test "wide_table_data" \
   "SELECT c50 FROM wide WHERE id=1;" \
   "v50" "$DB"
 
-
 echo "UPDATE wide SET c1='modified' WHERE id=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "wide_table_diff" \
   "SELECT diff_type FROM dolt_diff_wide WHERE to_commit='WORKING';" \
@@ -265,16 +216,11 @@ run_test_match "wide_table_diff" \
 
 echo "SELECT dolt_commit('-A','-m','update wide');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test_match "wide_table_history" \
   "SELECT count(*) FROM dolt_history_wide;" \
   "^[0-9]" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_blob9_$$.db; rm -f "$DB"
 LONG_NAME="t_$(printf '%0.sa' $(seq 1 59))"
@@ -287,19 +233,13 @@ run_test "long_name_data" \
   "SELECT val FROM ${LONG_NAME} WHERE id=1;" \
   "hello" "$DB"
 
-
 run_test_match "long_name_at" \
   "SELECT count(*) FROM dolt_at_${LONG_NAME}((SELECT commit_hash FROM dolt_log LIMIT 1));" \
   "^1$" "$DB"
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_blob10_$$.db; rm -f "$DB"
-
 
 echo "CREATE TABLE t(x); INSERT INTO t VALUES(1);
 SELECT dolt_commit('-A','-m', replace(hex(zeroblob(5000)), '0', 'M'));" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -313,10 +253,6 @@ run_test_match "long_msg_log" \
   "^MMMMM$" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_boundary11_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT);
@@ -332,7 +268,6 @@ run_test "null_value" \
   "SELECT typeof(val), val IS NULL FROM t WHERE id=2;" \
   "null|1" "$DB"
 
-
 echo "UPDATE t SET val=NULL WHERE id=1;
 UPDATE t SET val='' WHERE id=2;" | $DOLTLITE "$DB" > /dev/null 2>&1
 
@@ -341,7 +276,6 @@ run_test "swap_diff_count" \
   "2" "$DB"
 
 echo "SELECT dolt_commit('-A','-m','swap');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 run_test "swapped_null" \
   "SELECT val IS NULL FROM t WHERE id=1;" \
@@ -352,10 +286,6 @@ run_test "swapped_empty" \
   "text|0" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_boundary12_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, val INTEGER);
@@ -381,7 +311,6 @@ run_test "int_min" \
   "SELECT val FROM t WHERE id=4;" \
   "-9223372036854775808" "$DB"
 
-
 echo "UPDATE t SET val=1 WHERE id=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "int_boundary_diff" \
   "SELECT diff_type FROM dolt_diff_t WHERE to_commit='WORKING';" \
@@ -390,10 +319,6 @@ run_test_match "int_boundary_diff" \
 echo "SELECT dolt_commit('-A','-m','update zero');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_boundary13_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, val REAL);
@@ -425,12 +350,10 @@ run_test_match "real_denorm" \
   "SELECT typeof(val) FROM t WHERE id=6;" \
   "real" "$DB"
 
-
 echo "INSERT OR REPLACE INTO t VALUES(7, 1e999);" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "real_inf_type" \
   "SELECT typeof(val) FROM t WHERE id=7;" \
   "real|null" "$DB"
-
 
 echo "UPDATE t SET val=42.5 WHERE id=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "real_diff" \
@@ -440,10 +363,6 @@ run_test_match "real_diff" \
 echo "SELECT dolt_commit('-A','-m','update reals');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 rm -f "$DB"
-
-
-
-
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/doltlite_unicode_blob.sh
+++ b/test/doltlite_unicode_blob.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-#
-# Tests for unicode, special characters, and large BLOBs with dolt operations.
-#
+
+
+
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
 run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(30);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
@@ -10,9 +10,9 @@ run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -
 echo "=== Doltlite Unicode, Special Characters & Large BLOB Tests ==="
 echo ""
 
-# ============================================================
-# 1. Emoji in table data
-# ============================================================
+
+
+
 
 DB=/tmp/test_unicode1_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT);
@@ -23,7 +23,7 @@ run_test "emoji_insert" \
   "SELECT val FROM t;" \
   "Hello 🌍🎉🚀" "$DB"
 
-# Modify emoji row and check diff shows it
+
 echo "UPDATE t SET val='Goodbye 👋';" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "emoji_diff_type" \
   "SELECT diff_type FROM dolt_diff_t WHERE to_commit='WORKING';" \
@@ -37,9 +37,9 @@ echo "SELECT dolt_commit('-A','-m','update emoji');" | $DOLTLITE "$DB" > /dev/nu
 
 rm -f "$DB"
 
-# ============================================================
-# 2. Multi-byte UTF-8 characters (Chinese, Arabic, etc.)
-# ============================================================
+
+
+
 
 DB=/tmp/test_unicode2_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT);
@@ -62,7 +62,7 @@ run_test "japanese_data" \
   "SELECT val FROM t WHERE id=3;" \
   "日本語テスト" "$DB"
 
-# Branch, modify on branch, merge back
+
 echo "SELECT dolt_branch('intl');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('intl');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "INSERT INTO t VALUES(6,'Кириллица');
@@ -85,9 +85,9 @@ run_test "cyrillic_after_merge" \
 
 rm -f "$DB"
 
-# ============================================================
-# 3. Unicode in commit messages
-# ============================================================
+
+
+
 
 DB=/tmp/test_unicode3_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(x);
@@ -107,45 +107,45 @@ run_test_match "japanese_commit_msg" \
 
 rm -f "$DB"
 
-# ============================================================
-# 4. Unicode in branch names
-# ============================================================
+
+
+
 
 DB=/tmp/test_unicode4_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(x); INSERT INTO t VALUES(1);
 SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Try creating a branch with unicode name - either works or errors gracefully
+
 result=$(echo "SELECT dolt_branch('feature/日本語');" | perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$DB" 2>&1)
 if [ "$result" = "0" ]; then
-  # It worked - verify we can checkout and use it
+
   run_test "unicode_branch_active" \
     "SELECT dolt_checkout('feature/日本語'); SELECT active_branch();" \
     "0
 feature/日本語" "$DB"
-  PASS=$((PASS+1))  # count the branch creation as pass
+  PASS=$((PASS+1))
   echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 else
-  # Graceful error is also acceptable
+
   if echo "$result" | grep -qiE "error|invalid|not allowed"; then
-    PASS=$((PASS+1))  # graceful error
-    PASS=$((PASS+1))  # skip the checkout test too
+    PASS=$((PASS+1))
+    PASS=$((PASS+1))
   else
     FAIL=$((FAIL+1))
     ERRORS="$ERRORS\nFAIL: unicode_branch_create\n  expected: 0 or graceful error\n  got:      $result"
-    PASS=$((PASS+1))  # skip checkout test
+    PASS=$((PASS+1))
   fi
 fi
 
 rm -f "$DB"
 
-# ============================================================
-# 5. NULL bytes and special chars (tab, newline) in text fields
-# ============================================================
+
+
+
 
 DB=/tmp/test_unicode5_$$.db; rm -f "$DB"
 
-# Tab and newline via char()
+
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT);
 INSERT INTO t VALUES(1, 'line1' || char(10) || 'line2');
 INSERT INTO t VALUES(2, 'col1' || char(9) || 'col2');
@@ -160,7 +160,7 @@ run_test_match "tab_data" \
   "SELECT length(val) FROM t WHERE id=2;" \
   "^9$" "$DB"
 
-# Diff should work with these characters
+
 echo "UPDATE t SET val='plain' WHERE id=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "special_char_diff" \
   "SELECT diff_type FROM dolt_diff_t WHERE to_commit='WORKING';" \
@@ -170,13 +170,13 @@ echo "SELECT dolt_commit('-A','-m','normalize');" | $DOLTLITE "$DB" > /dev/null 
 
 rm -f "$DB"
 
-# ============================================================
-# 6. 100KB TEXT column
-# ============================================================
+
+
+
 
 DB=/tmp/test_blob6_$$.db; rm -f "$DB"
 
-# Use replace + zeroblob to create a 100KB string of 'A' characters
+
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT);
 INSERT INTO t VALUES(1, replace(hex(zeroblob(50000)), '0', 'A'));
 SELECT dolt_commit('-A','-m','100KB text');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -185,7 +185,7 @@ run_test "100kb_length" \
   "SELECT length(val) FROM t WHERE id=1;" \
   "100000" "$DB"
 
-# Modify and check diff works
+
 echo "UPDATE t SET val='short';" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "100kb_diff" \
   "SELECT diff_type FROM dolt_diff_t WHERE to_commit='WORKING';" \
@@ -195,9 +195,9 @@ echo "SELECT dolt_commit('-A','-m','shorten');" | $DOLTLITE "$DB" > /dev/null 2>
 
 rm -f "$DB"
 
-# ============================================================
-# 7. 1MB BLOB via randomblob(), branch/merge survival
-# ============================================================
+
+
+
 
 DB=/tmp/test_blob7_$$.db; rm -f "$DB"
 
@@ -209,16 +209,16 @@ run_test "1mb_blob_size" \
   "SELECT length(data) FROM t WHERE id=1;" \
   "1048576" "$DB"
 
-# Save a checksum for later comparison
+
 echo "SELECT dolt_branch('blobcheck');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('blobcheck');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Data should survive branch checkout
+
 run_test "1mb_blob_on_branch" \
   "SELECT length(data) FROM t WHERE id=1;" \
   "1048576" "$DB/blobcheck"
 
-# Add more data on branch, merge back
+
 echo "INSERT INTO t VALUES(2, randomblob(512));
 SELECT dolt_commit('-A','-m','add small blob');" | $DOLTLITE "$DB/blobcheck" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -234,13 +234,13 @@ run_test "1mb_blob_after_merge" \
 
 rm -f "$DB"
 
-# ============================================================
-# 8. Table with 100 columns
-# ============================================================
+
+
+
 
 DB=/tmp/test_blob8_$$.db; rm -f "$DB"
 
-# Generate CREATE TABLE with 100 columns
+
 cols=""
 vals=""
 for i in $(seq 1 100); do
@@ -257,7 +257,7 @@ run_test "wide_table_data" \
   "SELECT c50 FROM wide WHERE id=1;" \
   "v50" "$DB"
 
-# Diff works on wide table
+
 echo "UPDATE wide SET c1='modified' WHERE id=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "wide_table_diff" \
   "SELECT diff_type FROM dolt_diff_wide WHERE to_commit='WORKING';" \
@@ -265,19 +265,19 @@ run_test_match "wide_table_diff" \
 
 echo "SELECT dolt_commit('-A','-m','update wide');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# History works on wide table
+
 run_test_match "wide_table_history" \
   "SELECT count(*) FROM dolt_history_wide;" \
   "^[0-9]" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# 9. Very long table name (63 chars)
-# ============================================================
+
+
+
 
 DB=/tmp/test_blob9_$$.db; rm -f "$DB"
-LONG_NAME="t_$(printf '%0.sa' $(seq 1 59))"  # 61 chars total: t_ + 59 'a's
+LONG_NAME="t_$(printf '%0.sa' $(seq 1 59))"
 
 echo "CREATE TABLE ${LONG_NAME}(id INTEGER PRIMARY KEY, val TEXT);
 INSERT INTO ${LONG_NAME} VALUES(1,'hello');
@@ -287,20 +287,20 @@ run_test "long_name_data" \
   "SELECT val FROM ${LONG_NAME} WHERE id=1;" \
   "hello" "$DB"
 
-# dolt_at works with long table name
+
 run_test_match "long_name_at" \
   "SELECT count(*) FROM dolt_at_${LONG_NAME}((SELECT commit_hash FROM dolt_log LIMIT 1));" \
   "^1$" "$DB"
 
 rm -f "$DB"
 
-# ============================================================
-# 10. Very long commit message (10KB)
-# ============================================================
+
+
+
 
 DB=/tmp/test_blob10_$$.db; rm -f "$DB"
 
-# Generate a 10KB message using replace+hex+zeroblob
+
 echo "CREATE TABLE t(x); INSERT INTO t VALUES(1);
 SELECT dolt_commit('-A','-m', replace(hex(zeroblob(5000)), '0', 'M'));" | $DOLTLITE "$DB" > /dev/null 2>&1
 
@@ -314,9 +314,9 @@ run_test_match "long_msg_log" \
 
 rm -f "$DB"
 
-# ============================================================
-# 11. Empty string vs NULL
-# ============================================================
+
+
+
 
 DB=/tmp/test_boundary11_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT);
@@ -332,7 +332,7 @@ run_test "null_value" \
   "SELECT typeof(val), val IS NULL FROM t WHERE id=2;" \
   "null|1" "$DB"
 
-# Update and check diff distinguishes them
+
 echo "UPDATE t SET val=NULL WHERE id=1;
 UPDATE t SET val='' WHERE id=2;" | $DOLTLITE "$DB" > /dev/null 2>&1
 
@@ -342,7 +342,7 @@ run_test "swap_diff_count" \
 
 echo "SELECT dolt_commit('-A','-m','swap');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Verify the swap stuck
+
 run_test "swapped_null" \
   "SELECT val IS NULL FROM t WHERE id=1;" \
   "1" "$DB"
@@ -353,9 +353,9 @@ run_test "swapped_empty" \
 
 rm -f "$DB"
 
-# ============================================================
-# 12. Integer boundary values
-# ============================================================
+
+
+
 
 DB=/tmp/test_boundary12_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, val INTEGER);
@@ -381,7 +381,7 @@ run_test "int_min" \
   "SELECT val FROM t WHERE id=4;" \
   "-9223372036854775808" "$DB"
 
-# Diff works with boundary values
+
 echo "UPDATE t SET val=1 WHERE id=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "int_boundary_diff" \
   "SELECT diff_type FROM dolt_diff_t WHERE to_commit='WORKING';" \
@@ -391,9 +391,9 @@ echo "SELECT dolt_commit('-A','-m','update zero');" | $DOLTLITE "$DB" > /dev/nul
 
 rm -f "$DB"
 
-# ============================================================
-# 13. REAL edge values
-# ============================================================
+
+
+
 
 DB=/tmp/test_boundary13_$$.db; rm -f "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, val REAL);
@@ -425,13 +425,13 @@ run_test_match "real_denorm" \
   "SELECT typeof(val) FROM t WHERE id=6;" \
   "real" "$DB"
 
-# Inf and NaN handling (SQLite may coerce these)
+
 echo "INSERT OR REPLACE INTO t VALUES(7, 1e999);" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "real_inf_type" \
   "SELECT typeof(val) FROM t WHERE id=7;" \
   "real|null" "$DB"
 
-# Diff works with float values
+
 echo "UPDATE t SET val=42.5 WHERE id=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test_match "real_diff" \
   "SELECT diff_type FROM dolt_diff_t WHERE to_commit='WORKING';" \
@@ -441,9 +441,9 @@ echo "SELECT dolt_commit('-A','-m','update reals');" | $DOLTLITE "$DB" > /dev/nu
 
 rm -f "$DB"
 
-# ============================================================
-# Summary
-# ============================================================
+
+
+
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/doltlite_working_set.sh
+++ b/test/doltlite_working_set.sh
@@ -1,8 +1,4 @@
 #!/bin/bash
-
-
-
-
 DOLTLITE=${DOLTLITE:-./doltlite}
 PASS=0; FAIL=0; ERRORS=""
 run_test() {
@@ -21,12 +17,7 @@ run_test_match() {
 echo "=== Per-Branch WorkingSet Tests ==="
 echo ""
 
-
-
-
-
 DB=/tmp/test_ws_staged_$$.db; rm -f "$DB"
-
 
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT);
 INSERT INTO t VALUES(1,'a'),(2,'b');
@@ -34,15 +25,12 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','initial');
 SELECT dolt_branch('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
-
 echo "UPDATE t SET val='A' WHERE id=1;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main edit');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "main_committed" \
   "SELECT count(*) FROM dolt_status;" "0" "$DB"
-
 
 echo "SELECT dolt_checkout('feature');
 INSERT INTO t VALUES(3,'c');
@@ -52,41 +40,30 @@ SELECT dolt_commit('-m','feature add');" | $DOLTLITE "$DB/feature" > /dev/null 2
 run_test "feature_committed" \
   "SELECT count(*) FROM dolt_status;" "0" "$DB"
 
-
 echo "INSERT INTO t VALUES(4,'d');
 SELECT dolt_add('t');" | $DOLTLITE "$DB/feature" > /dev/null 2>&1
 
 run_test "feature_has_staged" \
   "SELECT count(*) FROM dolt_status WHERE staged=1;" "1" "$DB/feature"
 
-
 echo "SELECT dolt_commit('-m','feature staged');" | $DOLTLITE "$DB/feature" > /dev/null 2>&1
-
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "main_clean_after_switch" \
   "SELECT count(*) FROM dolt_status;" "0" "$DB"
 
-
 echo "SELECT dolt_checkout('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 run_test "feature_clean_after_switch" \
   "SELECT count(*) FROM dolt_status;" "0" "$DB/feature"
-
 
 run_test "feature_data_count" \
   "SELECT count(*) FROM t;" "4" "$DB/feature"
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_ws_merge_$$.db; rm -f "$DB"
-
 
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT);
 INSERT INTO t VALUES(1,'original');
@@ -102,7 +79,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','feature edit');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test_match "main_has_conflicts" \
   "BEGIN; SELECT dolt_merge('feature'); SELECT 'CF|' || count(*) FROM dolt_conflicts; ROLLBACK;" "CF\\|1" "$DB"
 
@@ -114,12 +90,7 @@ run_test_match "main_val_after_abort" \
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_ws_persist_$$.db; rm -f "$DB"
-
 
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT);
 INSERT INTO t VALUES(1,'a');
@@ -128,7 +99,6 @@ SELECT dolt_commit('-m','initial');
 UPDATE t SET val='staged_val' WHERE id=1;
 SELECT dolt_add('t');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 run_test "ws_persist_staged_count" \
   "SELECT count(*) FROM dolt_status WHERE staged=1;" "1" "$DB"
 
@@ -136,10 +106,6 @@ run_test "ws_persist_staged_status" \
   "SELECT status FROM dolt_status WHERE staged=1;" "modified" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_ws_gc_$$.db; rm -f "$DB"
 
@@ -150,9 +116,7 @@ SELECT dolt_commit('-m','initial');
 UPDATE t SET val='staged' WHERE id=1;
 SELECT dolt_add('t');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-
 echo "SELECT dolt_gc();" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 run_test "ws_gc_staged_survives" \
   "SELECT count(*) FROM dolt_status WHERE staged=1;" "1" "$DB"
@@ -161,10 +125,6 @@ run_test "ws_gc_data_ok" \
   "SELECT val FROM t WHERE id=1;" "staged" "$DB"
 
 rm -f "$DB"
-
-
-
-
 
 DB=/tmp/test_ws_reset_$$.db; rm -f "$DB"
 
@@ -188,10 +148,6 @@ run_test "post_reset_val" \
 
 rm -f "$DB"
 
-
-
-
-
 DB=/tmp/test_ws_multi_$$.db; rm -f "$DB"
 
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT);
@@ -200,7 +156,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','base');
 SELECT dolt_branch('b1');
 SELECT dolt_branch('b2');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 echo "SELECT dolt_checkout('b1');
 UPDATE t SET val='b1_val' WHERE id=1;
@@ -213,7 +168,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','b2 add');" | $DOLTLITE "$DB/b2" > /dev/null 2>&1
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
 
 run_test "multi_main_count" \
   "SELECT count(*) FROM t;" "1" "$DB"
@@ -235,10 +189,6 @@ run_test "multi_b2_new_row" \
   "SELECT val FROM t WHERE id=2;" "b2_new" "$DB/b2"
 
 rm -f "$DB"
-
-
-
-
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/doltlite_working_set.sh
+++ b/test/doltlite_working_set.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-#
-# Per-branch WorkingSet tests.
-# Verifies that staged state and merge state are independent per branch.
-#
+
+
+
+
 DOLTLITE=${DOLTLITE:-./doltlite}
 PASS=0; FAIL=0; ERRORS=""
 run_test() {
@@ -21,21 +21,21 @@ run_test_match() {
 echo "=== Per-Branch WorkingSet Tests ==="
 echo ""
 
-# ============================================================
-# Section 1: Staged state is independent per branch
-# ============================================================
+
+
+
 
 DB=/tmp/test_ws_staged_$$.db; rm -f "$DB"
 
-# Setup: create table, commit, create feature branch
+
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT);
 INSERT INTO t VALUES(1,'a'),(2,'b');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','initial');
 SELECT dolt_branch('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Commit different changes on each branch, then verify staged state is per-branch
-# Main: modify and commit
+
+
 echo "UPDATE t SET val='A' WHERE id=1;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main edit');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -43,7 +43,7 @@ SELECT dolt_commit('-m','main edit');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "main_committed" \
   "SELECT count(*) FROM dolt_status;" "0" "$DB"
 
-# Checkout to feature and make a different commit
+
 echo "SELECT dolt_checkout('feature');
 INSERT INTO t VALUES(3,'c');
 SELECT dolt_add('-A');
@@ -52,42 +52,42 @@ SELECT dolt_commit('-m','feature add');" | $DOLTLITE "$DB/feature" > /dev/null 2
 run_test "feature_committed" \
   "SELECT count(*) FROM dolt_status;" "0" "$DB"
 
-# Now stage but DON'T commit on feature
+
 echo "INSERT INTO t VALUES(4,'d');
 SELECT dolt_add('t');" | $DOLTLITE "$DB/feature" > /dev/null 2>&1
 
 run_test "feature_has_staged" \
   "SELECT count(*) FROM dolt_status WHERE staged=1;" "1" "$DB/feature"
 
-# Commit on feature so we can switch
+
 echo "SELECT dolt_commit('-m','feature staged');" | $DOLTLITE "$DB/feature" > /dev/null 2>&1
 
-# Switch back to main — main should be clean
+
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 run_test "main_clean_after_switch" \
   "SELECT count(*) FROM dolt_status;" "0" "$DB"
 
-# Switch back to feature
+
 echo "SELECT dolt_checkout('feature');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Feature was committed clean — should be clean
+
 run_test "feature_clean_after_switch" \
   "SELECT count(*) FROM dolt_status;" "0" "$DB/feature"
 
-# Verify data: feature should have rows 1-4
+
 run_test "feature_data_count" \
   "SELECT count(*) FROM t;" "4" "$DB/feature"
 
 rm -f "$DB"
 
-# ============================================================
-# Section 2: Merge state is independent per branch
-# ============================================================
+
+
+
 
 DB=/tmp/test_ws_merge_$$.db; rm -f "$DB"
 
-# Setup: two branches with conflicting changes
+
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT);
 INSERT INTO t VALUES(1,'original');
 SELECT dolt_add('-A');
@@ -102,7 +102,7 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','feature edit');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Merge feature into main — conflict state is available in-session and can be aborted
+
 run_test_match "main_has_conflicts" \
   "BEGIN; SELECT dolt_merge('feature'); SELECT 'CF|' || count(*) FROM dolt_conflicts; ROLLBACK;" "CF\\|1" "$DB"
 
@@ -114,13 +114,13 @@ run_test_match "main_val_after_abort" \
 
 rm -f "$DB"
 
-# ============================================================
-# Section 3: WorkingSet persists across sessions
-# ============================================================
+
+
+
 
 DB=/tmp/test_ws_persist_$$.db; rm -f "$DB"
 
-# Session 1: create table, commit, stage a change
+
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT);
 INSERT INTO t VALUES(1,'a');
 SELECT dolt_add('-A');
@@ -128,7 +128,7 @@ SELECT dolt_commit('-m','initial');
 UPDATE t SET val='staged_val' WHERE id=1;
 SELECT dolt_add('t');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Session 2: reopen and verify staged state persists
+
 run_test "ws_persist_staged_count" \
   "SELECT count(*) FROM dolt_status WHERE staged=1;" "1" "$DB"
 
@@ -137,9 +137,9 @@ run_test "ws_persist_staged_status" \
 
 rm -f "$DB"
 
-# ============================================================
-# Section 4: WorkingSet survives GC
-# ============================================================
+
+
+
 
 DB=/tmp/test_ws_gc_$$.db; rm -f "$DB"
 
@@ -150,10 +150,10 @@ SELECT dolt_commit('-m','initial');
 UPDATE t SET val='staged' WHERE id=1;
 SELECT dolt_add('t');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Run GC
+
 echo "SELECT dolt_gc();" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Staged state should survive GC
+
 run_test "ws_gc_staged_survives" \
   "SELECT count(*) FROM dolt_status WHERE staged=1;" "1" "$DB"
 
@@ -162,9 +162,9 @@ run_test "ws_gc_data_ok" \
 
 rm -f "$DB"
 
-# ============================================================
-# Section 5: Hard reset clears staged state
-# ============================================================
+
+
+
 
 DB=/tmp/test_ws_reset_$$.db; rm -f "$DB"
 
@@ -188,9 +188,9 @@ run_test "post_reset_val" \
 
 rm -f "$DB"
 
-# ============================================================
-# Section 6: Multiple branches with independent staged state (file-backed)
-# ============================================================
+
+
+
 
 DB=/tmp/test_ws_multi_$$.db; rm -f "$DB"
 
@@ -201,7 +201,7 @@ SELECT dolt_commit('-m','base');
 SELECT dolt_branch('b1');
 SELECT dolt_branch('b2');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Commit different things on each branch
+
 echo "SELECT dolt_checkout('b1');
 UPDATE t SET val='b1_val' WHERE id=1;
 SELECT dolt_add('-A');
@@ -214,7 +214,7 @@ SELECT dolt_commit('-m','b2 add');" | $DOLTLITE "$DB/b2" > /dev/null 2>&1
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Verify each branch has its own committed data
+
 run_test "multi_main_count" \
   "SELECT count(*) FROM t;" "1" "$DB"
 
@@ -236,9 +236,9 @@ run_test "multi_b2_new_row" \
 
 rm -f "$DB"
 
-# ============================================================
-# Results
-# ============================================================
+
+
+
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"

--- a/test/lib/vc_oracle_common.sh
+++ b/test/lib/vc_oracle_common.sh
@@ -16,10 +16,10 @@ vc_oracle_run_doltlite_script() {
   printf '%s\n' "$sql" | "$DOLTLITE" "$db" >"$out" 2>"$err"
 }
 
-# Run a piped SQL script against Dolt with -c (continue on error).
-# Use this for normal oracle tests where the script should run to
-# completion even if an intermediate statement errors (matching
-# doltlite's shell behavior, which always continues past errors).
+
+
+
+
 vc_oracle_run_dolt_script() {
   local repo="$1"
   local out="$2"
@@ -33,10 +33,10 @@ vc_oracle_run_dolt_script() {
   )
 }
 
-# Run a piped SQL script against Dolt WITHOUT -c. Use this for error-
-# path oracle tests that verify both engines reject an operation —
-# without -c, Dolt returns a non-zero exit code on the first error,
-# which the test harness checks to confirm the operation was refused.
+
+
+
+
 vc_oracle_run_dolt_script_for_error() {
   local repo="$1"
   local out="$2"

--- a/test/lib/vc_oracle_common.sh
+++ b/test/lib/vc_oracle_common.sh
@@ -16,10 +16,6 @@ vc_oracle_run_doltlite_script() {
   printf '%s\n' "$sql" | "$DOLTLITE" "$db" >"$out" 2>"$err"
 }
 
-
-
-
-
 vc_oracle_run_dolt_script() {
   local repo="$1"
   local out="$2"
@@ -32,10 +28,6 @@ vc_oracle_run_dolt_script() {
     printf '%s\n' "$sql" | "$DOLT" sql -c "$@" >"$out" 2>"$err"
   )
 }
-
-
-
-
 
 vc_oracle_run_dolt_script_for_error() {
   local repo="$1"

--- a/test/oracle_blob_composite_pk_vc_test.sh
+++ b/test/oracle_blob_composite_pk_vc_test.sh
@@ -1,14 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
-
 set -u
 DOLTLITE="${1:?usage: $0 <doltlite>}"
 TMPROOT=$(mktemp -d)
@@ -33,7 +24,6 @@ dlq() {
 
 echo "=== BLOB Composite PK + Version Control Tests ==="
 
-
 echo ""
 echo "--- A: BLOB composite PK commit + reopen ---"
 
@@ -55,7 +45,6 @@ R3=$(dl "$DB" "SELECT v FROM t WHERE a=X'DEADBEEF' AND b=3;")
 [ "$R1" = "r1" ] && pass_name "a_r1" || fail_name "a_r1; got $R1"
 [ "$R2" = "r2" ] && pass_name "a_r2" || fail_name "a_r2; got $R2"
 [ "$R3" = "r3" ] && pass_name "a_r3" || fail_name "a_r3; got $R3"
-
 
 echo ""
 echo "--- B: Non-overlapping merge ---"
@@ -92,7 +81,6 @@ CONF=$(dl "$DB" "SELECT count(*) FROM dolt_conflicts;")
 [ "$MDD1" = "main_dd1" ] && pass_name "b_main_new" || fail_name "b_main_new; got $MDD1"
 [ "$CONF" = "0" ] && pass_name "b_no_conflicts" || fail_name "b_no_conflicts; got $CONF"
 
-
 echo ""
 echo "--- C: Modify-modify conflict ---"
 
@@ -124,7 +112,6 @@ ROLLBACK;")
 [ "$CONF" = "1" ] && pass_name "c_conflict" || fail_name "c_conflict; got $CONF"
 [ "$VAL" = "main_val" ] && pass_name "c_ours_wins" || fail_name "c_ours_wins; got $VAL"
 
-
 echo ""
 echo "--- D: Delete vs modify conflict ---"
 
@@ -154,7 +141,6 @@ KEEP=$(dl "$DB" "SELECT v FROM t WHERE a=X'CCDD';")
 [ "$CONF" = "1" ] && pass_name "d_dm_conflict" || fail_name "d_dm_conflict; got $CONF"
 [ "$KEEP" = "bystander" ] && pass_name "d_bystander_ok" || fail_name "d_bystander_ok; got $KEEP"
 
-
 echo ""
 echo "--- E: Convergent merge ---"
 
@@ -179,7 +165,6 @@ VAL=$(dl "$DB" "SELECT v FROM t WHERE a=X'FF00';")
 [ "$CONF" = "0" ] && pass_name "e_convergent_clean" || fail_name "e_convergent_clean; got $CONF"
 [ "$VAL" = "same" ] && pass_name "e_convergent_val" || fail_name "e_convergent_val; got $VAL"
 
-
 echo ""
 echo "--- F: Cherry-pick ---"
 
@@ -202,7 +187,6 @@ VAL=$(dl "$DB" "SELECT v FROM t WHERE a=X'BB' AND b=2;")
 [ "$CNT" = "2" ] && pass_name "f_cp_count" || fail_name "f_cp_count; got $CNT"
 [ "$VAL" = "feat" ] && pass_name "f_cp_val" || fail_name "f_cp_val; got $VAL"
 
-
 echo ""
 echo "--- G: Revert ---"
 
@@ -222,7 +206,6 @@ CNT=$(dl "$DB" "SELECT count(*) FROM t;")
 VAL=$(dl "$DB" "SELECT v FROM t WHERE a=X'AA';")
 [ "$CNT" = "1" ] && pass_name "g_revert_count" || fail_name "g_revert_count; got $CNT"
 [ "$VAL" = "original" ] && pass_name "g_revert_val" || fail_name "g_revert_val; got $VAL"
-
 
 echo ""
 echo "--- H: Byte-order edge cases through merge ---"
@@ -262,7 +245,6 @@ CONF=$(dl "$DB" "SELECT count(*) FROM dolt_conflicts;")
 [ "$MFE" = "main_fffe" ] && pass_name "h_main_fffe" || fail_name "h_main_fffe; got $MFE"
 [ "$M80" = "main_80" ] && pass_name "h_main_80" || fail_name "h_main_80; got $M80"
 [ "$CONF" = "0" ] && pass_name "h_no_conflicts" || fail_name "h_no_conflicts; got $CONF"
-
 
 echo ""
 echo "--- I: INT-first composite PK with BLOB ---"

--- a/test/oracle_blob_composite_pk_vc_test.sh
+++ b/test/oracle_blob_composite_pk_vc_test.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
-#
-# Oracle tests: BLOB in composite PRIMARY KEY through version control.
-#
-# Verifies that tables with BLOB columns in composite PKs survive
-# commit, reopen, merge (clean, conflict, convergent, delete-modify),
-# cherry-pick, revert, and byte-order edge cases.
-#
-# Usage: bash test/oracle_blob_composite_pk_vc_test.sh <doltlite>
-#
+
+
+
+
+
+
+
+
+
 
 set -u
 DOLTLITE="${1:?usage: $0 <doltlite>}"
@@ -33,7 +33,7 @@ dlq() {
 
 echo "=== BLOB Composite PK + Version Control Tests ==="
 
-# ── A: Commit + reopen ────────────────────────────────────
+
 echo ""
 echo "--- A: BLOB composite PK commit + reopen ---"
 
@@ -56,7 +56,7 @@ R3=$(dl "$DB" "SELECT v FROM t WHERE a=X'DEADBEEF' AND b=3;")
 [ "$R2" = "r2" ] && pass_name "a_r2" || fail_name "a_r2; got $R2"
 [ "$R3" = "r3" ] && pass_name "a_r3" || fail_name "a_r3; got $R3"
 
-# ── B: Non-overlapping merge ──────────────────────────────
+
 echo ""
 echo "--- B: Non-overlapping merge ---"
 
@@ -92,7 +92,7 @@ CONF=$(dl "$DB" "SELECT count(*) FROM dolt_conflicts;")
 [ "$MDD1" = "main_dd1" ] && pass_name "b_main_new" || fail_name "b_main_new; got $MDD1"
 [ "$CONF" = "0" ] && pass_name "b_no_conflicts" || fail_name "b_no_conflicts; got $CONF"
 
-# ── C: Modify-modify conflict ─────────────────────────────
+
 echo ""
 echo "--- C: Modify-modify conflict ---"
 
@@ -124,7 +124,7 @@ ROLLBACK;")
 [ "$CONF" = "1" ] && pass_name "c_conflict" || fail_name "c_conflict; got $CONF"
 [ "$VAL" = "main_val" ] && pass_name "c_ours_wins" || fail_name "c_ours_wins; got $VAL"
 
-# ── D: Delete vs modify conflict ──────────────────────────
+
 echo ""
 echo "--- D: Delete vs modify conflict ---"
 
@@ -154,7 +154,7 @@ KEEP=$(dl "$DB" "SELECT v FROM t WHERE a=X'CCDD';")
 [ "$CONF" = "1" ] && pass_name "d_dm_conflict" || fail_name "d_dm_conflict; got $CONF"
 [ "$KEEP" = "bystander" ] && pass_name "d_bystander_ok" || fail_name "d_bystander_ok; got $KEEP"
 
-# ── E: Convergent merge ───────────────────────────────────
+
 echo ""
 echo "--- E: Convergent merge ---"
 
@@ -179,7 +179,7 @@ VAL=$(dl "$DB" "SELECT v FROM t WHERE a=X'FF00';")
 [ "$CONF" = "0" ] && pass_name "e_convergent_clean" || fail_name "e_convergent_clean; got $CONF"
 [ "$VAL" = "same" ] && pass_name "e_convergent_val" || fail_name "e_convergent_val; got $VAL"
 
-# ── F: Cherry-pick ────────────────────────────────────────
+
 echo ""
 echo "--- F: Cherry-pick ---"
 
@@ -202,7 +202,7 @@ VAL=$(dl "$DB" "SELECT v FROM t WHERE a=X'BB' AND b=2;")
 [ "$CNT" = "2" ] && pass_name "f_cp_count" || fail_name "f_cp_count; got $CNT"
 [ "$VAL" = "feat" ] && pass_name "f_cp_val" || fail_name "f_cp_val; got $VAL"
 
-# ── G: Revert ─────────────────────────────────────────────
+
 echo ""
 echo "--- G: Revert ---"
 
@@ -223,7 +223,7 @@ VAL=$(dl "$DB" "SELECT v FROM t WHERE a=X'AA';")
 [ "$CNT" = "1" ] && pass_name "g_revert_count" || fail_name "g_revert_count; got $CNT"
 [ "$VAL" = "original" ] && pass_name "g_revert_val" || fail_name "g_revert_val; got $VAL"
 
-# ── H: Byte-order edge cases ──────────────────────────────
+
 echo ""
 echo "--- H: Byte-order edge cases through merge ---"
 
@@ -263,7 +263,7 @@ CONF=$(dl "$DB" "SELECT count(*) FROM dolt_conflicts;")
 [ "$M80" = "main_80" ] && pass_name "h_main_80" || fail_name "h_main_80; got $M80"
 [ "$CONF" = "0" ] && pass_name "h_no_conflicts" || fail_name "h_no_conflicts; got $CONF"
 
-# ── I: BLOB + INT mixed PK ordering ───────────────────────
+
 echo ""
 echo "--- I: INT-first composite PK with BLOB ---"
 

--- a/test/oracle_generated_columns_vc_test.sh
+++ b/test/oracle_generated_columns_vc_test.sh
@@ -1,13 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
 set -u
 DOLTLITE="${1:?usage: $0 <doltlite>}"
 TMPROOT=$(mktemp -d)
@@ -32,7 +24,6 @@ dlq() {
 
 echo "=== Generated Columns + Version Control Tests ==="
 
-
 echo ""
 echo "--- A: STORED generated column commit + reopen ---"
 
@@ -51,7 +42,6 @@ R3=$(dl "$DB" "SELECT y FROM t WHERE id=3;")
 [ "$R2" = "40" ] && pass_name "a_stored_reopen_r2" || fail_name "a_stored_reopen_r2; got $R2"
 [ "$R3" = "60" ] && pass_name "a_stored_reopen_r3" || fail_name "a_stored_reopen_r3; got $R3"
 
-
 echo ""
 echo "--- B: VIRTUAL generated column commit + reopen ---"
 
@@ -67,7 +57,6 @@ R1=$(dl "$DB" "SELECT y FROM t WHERE id=1;")
 R2=$(dl "$DB" "SELECT y FROM t WHERE id=2;")
 [ "$R1" = "105" ] && pass_name "b_virtual_reopen_r1" || fail_name "b_virtual_reopen_r1; got $R1"
 [ "$R2" = "115" ] && pass_name "b_virtual_reopen_r2" || fail_name "b_virtual_reopen_r2; got $R2"
-
 
 echo ""
 echo "--- C: Non-overlapping merge with STORED generated column ---"
@@ -92,7 +81,6 @@ R1=$(dl "$DB" "SELECT y FROM t WHERE id=1;")
 R2=$(dl "$DB" "SELECT y FROM t WHERE id=2;")
 [ "$R1" = "30" ] && pass_name "c_merge_stored_r1" || fail_name "c_merge_stored_r1; got $R1"
 [ "$R2" = "50" ] && pass_name "c_merge_stored_r2" || fail_name "c_merge_stored_r2; got $R2"
-
 
 echo ""
 echo "--- D: Non-overlapping merge with VIRTUAL generated column ---"
@@ -119,7 +107,6 @@ CNT=$(dl "$DB" "SELECT count(*) FROM t;")
 [ "$R2" = "75" ] && pass_name "d_merge_virtual_r2" || fail_name "d_merge_virtual_r2; got $R2"
 [ "$R3" = "90" ] && pass_name "d_merge_virtual_r3" || fail_name "d_merge_virtual_r3; got $R3"
 [ "$CNT" = "3" ] && pass_name "d_merge_virtual_count" || fail_name "d_merge_virtual_count; got $CNT"
-
 
 echo ""
 echo "--- E: Conflict on base column of generated col ---"
@@ -154,9 +141,7 @@ SELECT dolt_merge('feat');
 SELECT y FROM t WHERE id=1;
 ROLLBACK;")
 [ "$CONFLICTS" = "1" ] && pass_name "e_conflict_detected" || fail_name "e_conflict_detected; got $CONFLICTS"
-
 [ "$YVAL" = "$((XVAL*2))" ] && pass_name "e_generated_consistent" || fail_name "e_generated_consistent; x=$XVAL y=$YVAL"
-
 
 echo ""
 echo "--- F: Cherry-pick with generated column ---"
@@ -181,7 +166,6 @@ R2=$(dl "$DB" "SELECT y FROM t WHERE id=2;")
 [ "$R1" = "30" ] && pass_name "f_cherry_pick_r1" || fail_name "f_cherry_pick_r1; got $R1"
 [ "$R2" = "40" ] && pass_name "f_cherry_pick_r2" || fail_name "f_cherry_pick_r2; got $R2"
 
-
 echo ""
 echo "--- G: Revert with generated column ---"
 
@@ -202,7 +186,6 @@ R1=$(dl "$DB" "SELECT y FROM t WHERE id=1;")
 [ "$CNT" = "1" ] && pass_name "g_revert_count" || fail_name "g_revert_count; got $CNT"
 [ "$R1" = "20" ] && pass_name "g_revert_r1_restored" || fail_name "g_revert_r1_restored; got $R1"
 
-
 echo ""
 echo "--- H: Expression preserved across checkout ---"
 
@@ -221,14 +204,11 @@ SELECT dolt_commit('-Am','main');
 SQL
 )" >/dev/null
 
-
 R3=$(dl "$DB" "SELECT y FROM t WHERE id=3;")
 [ "$R3" = "90" ] && pass_name "h_main_expression" || fail_name "h_main_expression; got $R3"
 
-
 R2=$(dl "$DB/other" "SELECT y FROM t WHERE id=2;")
 [ "$R2" = "60" ] && pass_name "h_other_expression" || fail_name "h_other_expression; got $R2"
-
 
 echo ""
 echo "--- I: Convergent merge with generated column ---"
@@ -253,7 +233,6 @@ CONFLICTS=$(dl "$DB" "SELECT count(*) FROM dolt_conflicts;")
 YVAL=$(dl "$DB" "SELECT y FROM t WHERE id=1;")
 [ "$CONFLICTS" = "0" ] && pass_name "i_convergent_no_conflict" || fail_name "i_convergent_no_conflict; got $CONFLICTS"
 [ "$YVAL" = "100" ] && pass_name "i_convergent_value" || fail_name "i_convergent_value; got $YVAL"
-
 
 echo ""
 echo "--- J: Multiple generated columns through merge ---"

--- a/test/oracle_generated_columns_vc_test.sh
+++ b/test/oracle_generated_columns_vc_test.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
-#
-# Oracle tests: generated columns through version control operations.
-#
-# Verifies that STORED and VIRTUAL generated columns survive commit,
-# reopen, merge, cherry-pick, revert, checkout, and conflict resolution.
-#
-# Usage: bash test/oracle_generated_columns_vc_test.sh <doltlite>
-#
+
+
+
+
+
+
+
+
 
 set -u
 DOLTLITE="${1:?usage: $0 <doltlite>}"
@@ -32,7 +32,7 @@ dlq() {
 
 echo "=== Generated Columns + Version Control Tests ==="
 
-# ── A: STORED generated column survives commit + reopen ────
+
 echo ""
 echo "--- A: STORED generated column commit + reopen ---"
 
@@ -51,7 +51,7 @@ R3=$(dl "$DB" "SELECT y FROM t WHERE id=3;")
 [ "$R2" = "40" ] && pass_name "a_stored_reopen_r2" || fail_name "a_stored_reopen_r2; got $R2"
 [ "$R3" = "60" ] && pass_name "a_stored_reopen_r3" || fail_name "a_stored_reopen_r3; got $R3"
 
-# ── B: VIRTUAL generated column survives commit + reopen ──
+
 echo ""
 echo "--- B: VIRTUAL generated column commit + reopen ---"
 
@@ -68,7 +68,7 @@ R2=$(dl "$DB" "SELECT y FROM t WHERE id=2;")
 [ "$R1" = "105" ] && pass_name "b_virtual_reopen_r1" || fail_name "b_virtual_reopen_r1; got $R1"
 [ "$R2" = "115" ] && pass_name "b_virtual_reopen_r2" || fail_name "b_virtual_reopen_r2; got $R2"
 
-# ── C: Non-overlapping merge with STORED generated column ──
+
 echo ""
 echo "--- C: Non-overlapping merge with STORED generated column ---"
 
@@ -93,7 +93,7 @@ R2=$(dl "$DB" "SELECT y FROM t WHERE id=2;")
 [ "$R1" = "30" ] && pass_name "c_merge_stored_r1" || fail_name "c_merge_stored_r1; got $R1"
 [ "$R2" = "50" ] && pass_name "c_merge_stored_r2" || fail_name "c_merge_stored_r2; got $R2"
 
-# ── D: Non-overlapping merge with VIRTUAL generated column ──
+
 echo ""
 echo "--- D: Non-overlapping merge with VIRTUAL generated column ---"
 
@@ -120,7 +120,7 @@ CNT=$(dl "$DB" "SELECT count(*) FROM t;")
 [ "$R3" = "90" ] && pass_name "d_merge_virtual_r3" || fail_name "d_merge_virtual_r3; got $R3"
 [ "$CNT" = "3" ] && pass_name "d_merge_virtual_count" || fail_name "d_merge_virtual_count; got $CNT"
 
-# ── E: Conflict on base column of generated col ────────────
+
 echo ""
 echo "--- E: Conflict on base column of generated col ---"
 
@@ -154,10 +154,10 @@ SELECT dolt_merge('feat');
 SELECT y FROM t WHERE id=1;
 ROLLBACK;")
 [ "$CONFLICTS" = "1" ] && pass_name "e_conflict_detected" || fail_name "e_conflict_detected; got $CONFLICTS"
-# Ours wins in working set; y should match
+
 [ "$YVAL" = "$((XVAL*2))" ] && pass_name "e_generated_consistent" || fail_name "e_generated_consistent; x=$XVAL y=$YVAL"
 
-# ── F: Cherry-pick with generated column ───────────────────
+
 echo ""
 echo "--- F: Cherry-pick with generated column ---"
 
@@ -181,7 +181,7 @@ R2=$(dl "$DB" "SELECT y FROM t WHERE id=2;")
 [ "$R1" = "30" ] && pass_name "f_cherry_pick_r1" || fail_name "f_cherry_pick_r1; got $R1"
 [ "$R2" = "40" ] && pass_name "f_cherry_pick_r2" || fail_name "f_cherry_pick_r2; got $R2"
 
-# ── G: Revert with generated column ───────────────────────
+
 echo ""
 echo "--- G: Revert with generated column ---"
 
@@ -202,7 +202,7 @@ R1=$(dl "$DB" "SELECT y FROM t WHERE id=1;")
 [ "$CNT" = "1" ] && pass_name "g_revert_count" || fail_name "g_revert_count; got $CNT"
 [ "$R1" = "20" ] && pass_name "g_revert_r1_restored" || fail_name "g_revert_r1_restored; got $R1"
 
-# ── H: Generated column expression preserved across checkout ──
+
 echo ""
 echo "--- H: Expression preserved across checkout ---"
 
@@ -221,15 +221,15 @@ SELECT dolt_commit('-Am','main');
 SQL
 )" >/dev/null
 
-# Check main branch
+
 R3=$(dl "$DB" "SELECT y FROM t WHERE id=3;")
 [ "$R3" = "90" ] && pass_name "h_main_expression" || fail_name "h_main_expression; got $R3"
 
-# Switch to other and check
+
 R2=$(dl "$DB/other" "SELECT y FROM t WHERE id=2;")
 [ "$R2" = "60" ] && pass_name "h_other_expression" || fail_name "h_other_expression; got $R2"
 
-# ── I: Convergent merge (both sides same update) ──────────
+
 echo ""
 echo "--- I: Convergent merge with generated column ---"
 
@@ -254,7 +254,7 @@ YVAL=$(dl "$DB" "SELECT y FROM t WHERE id=1;")
 [ "$CONFLICTS" = "0" ] && pass_name "i_convergent_no_conflict" || fail_name "i_convergent_no_conflict; got $CONFLICTS"
 [ "$YVAL" = "100" ] && pass_name "i_convergent_value" || fail_name "i_convergent_value; got $YVAL"
 
-# ── J: Multiple generated columns ─────────────────────────
+
 echo ""
 echo "--- J: Multiple generated columns through merge ---"
 

--- a/test/oracle_wide_table_vc_test.sh
+++ b/test/oracle_wide_table_vc_test.sh
@@ -1,13 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
 set -u
 DOLTLITE="${1:?usage: $0 <doltlite>}"
 TMPROOT=$(mktemp -d)
@@ -22,12 +14,10 @@ fail_name() {
 
 dl() { "$DOLTLITE" "$1" "$2" 2>/dev/null; }
 
-
 gen_cols() { local n=$1; for i in $(seq 1 $n); do echo -n "c$i INT"; [ $i -lt $n ] && echo -n ", "; done; }
 gen_vals() { local n=$1; for i in $(seq 1 $n); do echo -n "$i"; [ $i -lt $n ] && echo -n ","; done; }
 
 echo "=== Wide Table + Version Control Tests ==="
-
 
 echo ""
 echo "--- 1: 100-column commit + reopen ---"
@@ -41,7 +31,6 @@ R100=$(dl "$DB" "SELECT c100 FROM t WHERE id=1;")
 [ "$R65" = "65" ] && pass_name "1_c65" || fail_name "1_c65; got $R65"
 [ "$R100" = "100" ] && pass_name "1_c100" || fail_name "1_c100; got $R100"
 
-
 echo ""
 echo "--- 2: 100-column non-overlapping merge ---"
 DB="$TMPROOT/2.db"
@@ -50,7 +39,6 @@ dl "$DB" "CREATE TABLE t(id INTEGER PRIMARY KEY, $COLS); INSERT INTO t VALUES(1,
 [ "$(dl "$DB" "SELECT c75 FROM t WHERE id=1;")" = "888" ] && pass_name "2_main_col" || fail_name "2_main_col"
 [ "$(dl "$DB" "SELECT c50 FROM t WHERE id=1;")" = "50" ] && pass_name "2_unchanged" || fail_name "2_unchanged"
 [ "$(dl "$DB" "SELECT count(*) FROM dolt_conflicts;")" = "0" ] && pass_name "2_no_conflicts" || fail_name "2_no_conflicts"
-
 
 echo ""
 echo "--- 3: 100-column conflict (same column both sides) ---"
@@ -75,7 +63,6 @@ SQL
 [ "$CONF" = "1" ] && pass_name "3_conflict" || fail_name "3_conflict"
 [ "$(dl "$DB" "SELECT c50 FROM t WHERE id=1;")" = "2000" ] && pass_name "3_ours_wins" || fail_name "3_ours_wins"
 
-
 echo ""
 echo "--- 4: 200-column non-overlapping merge ---"
 DB="$TMPROOT/4.db"
@@ -88,7 +75,6 @@ dl "$DB" "CREATE TABLE t(id INTEGER PRIMARY KEY, $COLS200); INSERT INTO t VALUES
 [ "$(dl "$DB" "SELECT c200 FROM t WHERE id=1;")" = "333" ] && pass_name "4_c200" || fail_name "4_c200"
 [ "$(dl "$DB" "PRAGMA integrity_check;")" = "ok" ] && pass_name "4_integrity" || fail_name "4_integrity"
 
-
 echo ""
 echo "--- 5: 80-column cherry-pick ---"
 DB="$TMPROOT/5.db"
@@ -98,7 +84,6 @@ dl "$DB" "CREATE TABLE t(id INTEGER PRIMARY KEY, $COLS80); INSERT INTO t VALUES(
 [ "$(dl "$DB" "SELECT c40 FROM t WHERE id=1;")" = "222" ] && pass_name "5_c40" || fail_name "5_c40"
 [ "$(dl "$DB" "SELECT c80 FROM t WHERE id=1;")" = "333" ] && pass_name "5_c80" || fail_name "5_c80"
 
-
 echo ""
 echo "--- 6: 80-column revert ---"
 DB="$TMPROOT/6.db"
@@ -107,7 +92,6 @@ dl "$DB" "CREATE TABLE t(id INTEGER PRIMARY KEY, $COLS80); INSERT INTO t VALUES(
 [ "$(dl "$DB" "SELECT c1 FROM t WHERE id=1;")" = "1" ] && pass_name "6_c1_reverted" || fail_name "6_c1_reverted"
 [ "$(dl "$DB" "SELECT c80 FROM t WHERE id=1;")" = "80" ] && pass_name "6_c80_reverted" || fail_name "6_c80_reverted"
 
-
 echo ""
 echo "--- 7: 80-column table with index ---"
 DB="$TMPROOT/7.db"
@@ -115,7 +99,6 @@ dl "$DB" "CREATE TABLE t(id INTEGER PRIMARY KEY, $COLS80); CREATE INDEX idx ON t
 [ "$(dl "$DB" "SELECT count(*) FROM t;")" = "3" ] && pass_name "7_count" || fail_name "7_count"
 [ "$(dl "$DB" "SELECT c40 FROM t WHERE id=1;")" = "999" ] && pass_name "7_updated" || fail_name "7_updated"
 [ "$(dl "$DB" "PRAGMA integrity_check;")" = "ok" ] && pass_name "7_integrity" || fail_name "7_integrity"
-
 
 echo ""
 echo "--- 8: 100-column, multiple rows, both sides add ---"
@@ -126,14 +109,12 @@ dl "$DB" "CREATE TABLE t(id INTEGER PRIMARY KEY, $COLS); INSERT INTO t VALUES(1,
 [ "$(dl "$DB" "SELECT c50 FROM t WHERE id=4;")" = "80" ] && pass_name "8_main_row" || fail_name "8_main_row"
 [ "$(dl "$DB" "SELECT count(*) FROM dolt_conflicts;")" = "0" ] && pass_name "8_no_conflicts" || fail_name "8_no_conflicts"
 
-
 echo ""
 echo "--- 9: 100-column convergent merge ---"
 DB="$TMPROOT/9.db"
 dl "$DB" "CREATE TABLE t(id INTEGER PRIMARY KEY, $COLS); INSERT INTO t VALUES(1, $VALS); SELECT dolt_commit('-Am','base'); SELECT dolt_branch('feat'); SELECT dolt_checkout('feat'); UPDATE t SET c99=777 WHERE id=1; SELECT dolt_commit('-Am','feat'); SELECT dolt_checkout('main'); UPDATE t SET c99=777 WHERE id=1; SELECT dolt_commit('-Am','main'); SELECT dolt_merge('feat');" >/dev/null
 [ "$(dl "$DB" "SELECT count(*) FROM dolt_conflicts;")" = "0" ] && pass_name "9_no_conflict" || fail_name "9_no_conflict"
 [ "$(dl "$DB" "SELECT c99 FROM t WHERE id=1;")" = "777" ] && pass_name "9_converged" || fail_name "9_converged"
-
 
 echo ""
 echo "--- 10: Reopen after 100-column merge ---"

--- a/test/oracle_wide_table_vc_test.sh
+++ b/test/oracle_wide_table_vc_test.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
-#
-# Oracle tests: wide tables (50-200 columns) through VC operations.
-#
-# Exercises the MAX_RECORD_FIELDS=256 limit and field-level merge
-# on tables wider than the old 64-column limit.
-#
-# Usage: bash test/oracle_wide_table_vc_test.sh <doltlite>
-#
+
+
+
+
+
+
+
+
 
 set -u
 DOLTLITE="${1:?usage: $0 <doltlite>}"
@@ -22,13 +22,13 @@ fail_name() {
 
 dl() { "$DOLTLITE" "$1" "$2" 2>/dev/null; }
 
-# Helpers to generate column defs and values
+
 gen_cols() { local n=$1; for i in $(seq 1 $n); do echo -n "c$i INT"; [ $i -lt $n ] && echo -n ", "; done; }
 gen_vals() { local n=$1; for i in $(seq 1 $n); do echo -n "$i"; [ $i -lt $n ] && echo -n ","; done; }
 
 echo "=== Wide Table + Version Control Tests ==="
 
-# ── 1: 100-column commit + reopen ────────────────────────
+
 echo ""
 echo "--- 1: 100-column commit + reopen ---"
 DB="$TMPROOT/1.db"
@@ -41,7 +41,7 @@ R100=$(dl "$DB" "SELECT c100 FROM t WHERE id=1;")
 [ "$R65" = "65" ] && pass_name "1_c65" || fail_name "1_c65; got $R65"
 [ "$R100" = "100" ] && pass_name "1_c100" || fail_name "1_c100; got $R100"
 
-# ── 2: 100-column non-overlapping merge ──────────────────
+
 echo ""
 echo "--- 2: 100-column non-overlapping merge ---"
 DB="$TMPROOT/2.db"
@@ -51,7 +51,7 @@ dl "$DB" "CREATE TABLE t(id INTEGER PRIMARY KEY, $COLS); INSERT INTO t VALUES(1,
 [ "$(dl "$DB" "SELECT c50 FROM t WHERE id=1;")" = "50" ] && pass_name "2_unchanged" || fail_name "2_unchanged"
 [ "$(dl "$DB" "SELECT count(*) FROM dolt_conflicts;")" = "0" ] && pass_name "2_no_conflicts" || fail_name "2_no_conflicts"
 
-# ── 3: 100-column conflict merge ─────────────────────────
+
 echo ""
 echo "--- 3: 100-column conflict (same column both sides) ---"
 DB="$TMPROOT/3.db"
@@ -75,7 +75,7 @@ SQL
 [ "$CONF" = "1" ] && pass_name "3_conflict" || fail_name "3_conflict"
 [ "$(dl "$DB" "SELECT c50 FROM t WHERE id=1;")" = "2000" ] && pass_name "3_ours_wins" || fail_name "3_ours_wins"
 
-# ── 4: 200-column merge (near limit) ────────────────────
+
 echo ""
 echo "--- 4: 200-column non-overlapping merge ---"
 DB="$TMPROOT/4.db"
@@ -88,7 +88,7 @@ dl "$DB" "CREATE TABLE t(id INTEGER PRIMARY KEY, $COLS200); INSERT INTO t VALUES
 [ "$(dl "$DB" "SELECT c200 FROM t WHERE id=1;")" = "333" ] && pass_name "4_c200" || fail_name "4_c200"
 [ "$(dl "$DB" "PRAGMA integrity_check;")" = "ok" ] && pass_name "4_integrity" || fail_name "4_integrity"
 
-# ── 5: Wide table cherry-pick ────────────────────────────
+
 echo ""
 echo "--- 5: 80-column cherry-pick ---"
 DB="$TMPROOT/5.db"
@@ -98,7 +98,7 @@ dl "$DB" "CREATE TABLE t(id INTEGER PRIMARY KEY, $COLS80); INSERT INTO t VALUES(
 [ "$(dl "$DB" "SELECT c40 FROM t WHERE id=1;")" = "222" ] && pass_name "5_c40" || fail_name "5_c40"
 [ "$(dl "$DB" "SELECT c80 FROM t WHERE id=1;")" = "333" ] && pass_name "5_c80" || fail_name "5_c80"
 
-# ── 6: Wide table revert ────────────────────────────────
+
 echo ""
 echo "--- 6: 80-column revert ---"
 DB="$TMPROOT/6.db"
@@ -107,7 +107,7 @@ dl "$DB" "CREATE TABLE t(id INTEGER PRIMARY KEY, $COLS80); INSERT INTO t VALUES(
 [ "$(dl "$DB" "SELECT c1 FROM t WHERE id=1;")" = "1" ] && pass_name "6_c1_reverted" || fail_name "6_c1_reverted"
 [ "$(dl "$DB" "SELECT c80 FROM t WHERE id=1;")" = "80" ] && pass_name "6_c80_reverted" || fail_name "6_c80_reverted"
 
-# ── 7: Wide table with index through merge ───────────────
+
 echo ""
 echo "--- 7: 80-column table with index ---"
 DB="$TMPROOT/7.db"
@@ -116,7 +116,7 @@ dl "$DB" "CREATE TABLE t(id INTEGER PRIMARY KEY, $COLS80); CREATE INDEX idx ON t
 [ "$(dl "$DB" "SELECT c40 FROM t WHERE id=1;")" = "999" ] && pass_name "7_updated" || fail_name "7_updated"
 [ "$(dl "$DB" "PRAGMA integrity_check;")" = "ok" ] && pass_name "7_integrity" || fail_name "7_integrity"
 
-# ── 8: Wide table merge with multiple rows ───────────────
+
 echo ""
 echo "--- 8: 100-column, multiple rows, both sides add ---"
 DB="$TMPROOT/8.db"
@@ -126,7 +126,7 @@ dl "$DB" "CREATE TABLE t(id INTEGER PRIMARY KEY, $COLS); INSERT INTO t VALUES(1,
 [ "$(dl "$DB" "SELECT c50 FROM t WHERE id=4;")" = "80" ] && pass_name "8_main_row" || fail_name "8_main_row"
 [ "$(dl "$DB" "SELECT count(*) FROM dolt_conflicts;")" = "0" ] && pass_name "8_no_conflicts" || fail_name "8_no_conflicts"
 
-# ── 9: Convergent merge on wide table ────────────────────
+
 echo ""
 echo "--- 9: 100-column convergent merge ---"
 DB="$TMPROOT/9.db"
@@ -134,7 +134,7 @@ dl "$DB" "CREATE TABLE t(id INTEGER PRIMARY KEY, $COLS); INSERT INTO t VALUES(1,
 [ "$(dl "$DB" "SELECT count(*) FROM dolt_conflicts;")" = "0" ] && pass_name "9_no_conflict" || fail_name "9_no_conflict"
 [ "$(dl "$DB" "SELECT c99 FROM t WHERE id=1;")" = "777" ] && pass_name "9_converged" || fail_name "9_converged"
 
-# ── 10: Reopen after wide merge ──────────────────────────
+
 echo ""
 echo "--- 10: Reopen after 100-column merge ---"
 DB="$TMPROOT/10.db"

--- a/test/vc_oracle_active_branch_test.sh
+++ b/test/vc_oracle_active_branch_test.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
-#
-# Version-control oracle test: active_branch()
-#
-# Compares active_branch() output from doltlite and Dolt across
-# branch operations: default branch, checkout, branch creation,
-# and checkout back.
-#
-# Usage: bash vc_oracle_active_branch_test.sh [path/to/doltlite] [path/to/dolt]
-#
+
+
+
+
+
+
+
+
+
 
 set -u
 set -o pipefail

--- a/test/vc_oracle_active_branch_test.sh
+++ b/test/vc_oracle_active_branch_test.sh
@@ -1,14 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
-
 set -u
 set -o pipefail
 

--- a/test/vc_oracle_add_test.sh
+++ b/test/vc_oracle_add_test.sh
@@ -1,17 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
-
-
-
-
 set -u
 set -o pipefail
 
@@ -24,7 +12,6 @@ FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
 normalize() { tr -d '\r'; }
-
 
 oracle() {
   local name="$1" setup="$2"
@@ -61,7 +48,6 @@ oracle() {
     echo "    dolt:"    ; echo "$dt_out" | sed 's/^/      /'
   fi
 }
-
 
 oracle_error() {
   local name="$1" setup="$2"

--- a/test/vc_oracle_add_test.sh
+++ b/test/vc_oracle_add_test.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
-#
-# Version-control oracle test: dolt_add
-#
-# Runs identical dolt_add scenarios against doltlite and Dolt and compares
-# the resulting dolt_status (since dolt_add's whole purpose is to mutate
-# the staged catalog, and dolt_status is what makes that mutation visible).
-#
-# Error scenarios are checked separately: both engines must fail, but the
-# specific error text is allowed to differ.
-#
-# Usage: bash vc_oracle_add_test.sh [path/to/doltlite] [path/to/dolt]
-#
+
+
+
+
+
+
+
+
+
+
+
+
 
 set -u
 set -o pipefail
@@ -25,7 +25,7 @@ source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
 normalize() { tr -d '\r'; }
 
-# Compare post-state status. $1=name, $2=setup SQL using doltlite syntax.
+
 oracle() {
   local name="$1" setup="$2"
   local dir="$TMPROOT/$name"
@@ -62,7 +62,7 @@ oracle() {
   fi
 }
 
-# Both engines must fail on this setup. Error text is allowed to differ.
+
 oracle_error() {
   local name="$1" setup="$2"
   local dir="$TMPROOT/${name}_err"

--- a/test/vc_oracle_at_test.sh
+++ b/test/vc_oracle_at_test.sh
@@ -1,30 +1,30 @@
 #!/bin/bash
-#
-# Version-control oracle test: dolt_at_<table>
-#
-# Per-table point-in-time view of a table at a specified commit ref.
-# doltlite exposes this as a per-table vtable with a hidden
-# `commit_ref` constraint column:
-#
-#   SELECT * FROM dolt_at_t WHERE commit_ref = '<ref>'
-#
-# Dolt exposes the same semantics via the SQL `AS OF` clause:
-#
-#   SELECT * FROM t AS OF '<ref>'
-#
-# The two surfaces are SQL-level different but semantically
-# equivalent — both return the table state as of the named ref.
-# This oracle compares row CONTENT (not the SQL spelling) across
-# a range of ref forms: HEAD, HEAD~N, branch names, tag names,
-# bare commit hashes.
-#
-# Note: doltlite does NOT support the `AS OF` parser syntax. That's
-# a separate feature concern (parser change). This oracle compares
-# behavior between the two surface forms by issuing a different
-# query on each engine.
-#
-# Usage: bash vc_oracle_at_test.sh [path/to/doltlite] [path/to/dolt]
-#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 set -u
 set -o pipefail
@@ -43,15 +43,15 @@ normalize() {
     | sort
 }
 
-# Run a scenario. $1=name, $2=setup SQL in doltlite syntax,
-# $3=ref string to query at (e.g. 'HEAD', 'HEAD~1', 'main',
-# 'feature', or a tag name).
+
+
+
 oracle() {
   local name="$1" setup="$2" ref="$3"
   local dir="$TMPROOT/$name"
   mkdir -p "$dir/dl" "$dir/dt"
 
-  # ── doltlite query: dolt_at_t WHERE commit_ref = '<ref>' ──
+
   local dl_q="SELECT 'A' || char(9) || coalesce(id,'') || char(9) || coalesce(v,'') FROM dolt_at_t WHERE commit_ref = '${ref}' ORDER BY id"
   local dl_out
   dl_out=$(printf "%s\n.headers off\n.mode list\n.separator '\t'\n%s;\n" "$setup" "$dl_q" \
@@ -60,7 +60,7 @@ oracle() {
            | grep -v '^[0-9a-f]\{40\}$' \
            | normalize)
 
-  # ── Dolt query: t AS OF '<ref>' ──
+
   local dolt_setup
   dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
   local dt_q="SELECT concat('A', char(9), coalesce(id,''), char(9), coalesce(v,'')) FROM t AS OF '${ref}' ORDER BY id"
@@ -138,11 +138,11 @@ SELECT dolt_commit('-m', 'c1');
 
 echo "--- HEAD ref ---"
 
-# View at HEAD = current branch tip. Should match the working
-# committed state.
+
+
 oracle "at_head_two_rows" "$SEED" "HEAD"
 
-# View after a second commit shows the second commit's state.
+
 oracle "at_head_after_second_commit" "
 $SEED
 INSERT INTO t VALUES (3, 30);
@@ -152,7 +152,7 @@ SELECT dolt_commit('-m', 'c2');
 
 echo "--- HEAD~N ref ---"
 
-# View at HEAD~1 shows the previous commit's state.
+
 oracle "at_head_minus_1_after_modify" "
 $SEED
 UPDATE t SET v = 99 WHERE id = 1;
@@ -160,7 +160,7 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c2_modify');
 " "HEAD~1"
 
-# HEAD~2 walks back two commits.
+
 oracle "at_head_minus_2" "
 $SEED
 INSERT INTO t VALUES (3, 30);
@@ -171,7 +171,7 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c3');
 " "HEAD~2"
 
-# HEAD~ (no number) is shorthand for HEAD~1.
+
 oracle "at_head_tilde_no_number" "
 $SEED
 INSERT INTO t VALUES (3, 30);
@@ -181,11 +181,11 @@ SELECT dolt_commit('-m', 'c2');
 
 echo "--- branch ref ---"
 
-# View at the current branch by name.
+
 oracle "at_branch_main" "$SEED" "main"
 
-# View at a SIBLING branch — should show that branch's tip,
-# which differs from the current branch.
+
+
 oracle "at_sibling_branch_feature" "
 $SEED
 SELECT dolt_branch('feature');
@@ -198,7 +198,7 @@ SELECT dolt_checkout('main');
 
 echo "--- tag ref ---"
 
-# View at a tag pointing at a specific commit.
+
 oracle "at_tag" "
 $SEED
 SELECT dolt_tag('v1');
@@ -218,12 +218,12 @@ SELECT dolt_branch('from_tag', 'v1');
 
 echo "--- bare commit hash ref ---"
 
-# View at a literal commit hash. Both engines accept hex hashes
-# as refs. We can't put a literal hash in the test text (the
-# hashes differ between engines), so we run two scenarios that
-# query the most-recent commit hash via a subquery. The HEAD
-# alias gives the same result more readably; this scenario only
-# exists to ensure direct hash references also work.
+
+
+
+
+
+
 oracle "at_recent_commit_via_head" "
 $SEED
 INSERT INTO t VALUES (3, 30);
@@ -240,15 +240,15 @@ SELECT dolt_commit('-m', 'c2');
 
 echo "--- working set is NOT visible at any ref ---"
 
-# After the latest commit, an uncommitted modification is in the
-# working set. Querying at HEAD should NOT see it (HEAD is the
-# committed state).
+
+
+
 oracle "at_head_excludes_working_modifications" "
 $SEED
 UPDATE t SET v = 999 WHERE id = 1;
 " "HEAD"
 
-# Same with a staged-but-not-committed modification.
+
 oracle "at_head_excludes_staged_modifications" "
 $SEED
 UPDATE t SET v = 999 WHERE id = 1;
@@ -257,8 +257,8 @@ SELECT dolt_add('-A');
 
 echo "--- post-merge ---"
 
-# After a merge, HEAD points at the merge commit and includes
-# the merged content.
+
+
 oracle "at_head_after_merge" "
 $SEED
 SELECT dolt_branch('feature');
@@ -273,7 +273,7 @@ SELECT dolt_commit('-m', 'main2');
 SELECT dolt_merge('feature');
 " "HEAD"
 
-# View at HEAD~1 after merge shows the pre-merge state (main2).
+
 oracle "at_head_minus_1_after_merge_is_main2" "
 $SEED
 SELECT dolt_branch('feature');
@@ -318,9 +318,9 @@ SELECT dolt_merge('feature');
 
 echo "--- error paths ---"
 
-# Reference to a non-existent ref. Both engines should surface
-# something the user can act on (error or, in doltlite's case,
-# a clearly empty result).
+
+
+
 oracle_error "at_nonexistent_ref" "$SEED" "nope"
 
 echo ""

--- a/test/vc_oracle_at_test.sh
+++ b/test/vc_oracle_at_test.sh
@@ -1,31 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 set -u
 set -o pipefail
 
@@ -43,14 +17,10 @@ normalize() {
     | sort
 }
 
-
-
-
 oracle() {
   local name="$1" setup="$2" ref="$3"
   local dir="$TMPROOT/$name"
   mkdir -p "$dir/dl" "$dir/dt"
-
 
   local dl_q="SELECT 'A' || char(9) || coalesce(id,'') || char(9) || coalesce(v,'') FROM dolt_at_t WHERE commit_ref = '${ref}' ORDER BY id"
   local dl_out
@@ -59,7 +29,6 @@ oracle() {
            | grep -v '^[0-9]*$' \
            | grep -v '^[0-9a-f]\{40\}$' \
            | normalize)
-
 
   local dolt_setup
   dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
@@ -138,10 +107,7 @@ SELECT dolt_commit('-m', 'c1');
 
 echo "--- HEAD ref ---"
 
-
-
 oracle "at_head_two_rows" "$SEED" "HEAD"
-
 
 oracle "at_head_after_second_commit" "
 $SEED
@@ -152,14 +118,12 @@ SELECT dolt_commit('-m', 'c2');
 
 echo "--- HEAD~N ref ---"
 
-
 oracle "at_head_minus_1_after_modify" "
 $SEED
 UPDATE t SET v = 99 WHERE id = 1;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c2_modify');
 " "HEAD~1"
-
 
 oracle "at_head_minus_2" "
 $SEED
@@ -171,7 +135,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c3');
 " "HEAD~2"
 
-
 oracle "at_head_tilde_no_number" "
 $SEED
 INSERT INTO t VALUES (3, 30);
@@ -181,10 +144,7 @@ SELECT dolt_commit('-m', 'c2');
 
 echo "--- branch ref ---"
 
-
 oracle "at_branch_main" "$SEED" "main"
-
-
 
 oracle "at_sibling_branch_feature" "
 $SEED
@@ -197,7 +157,6 @@ SELECT dolt_checkout('main');
 " "feature"
 
 echo "--- tag ref ---"
-
 
 oracle "at_tag" "
 $SEED
@@ -218,12 +177,6 @@ SELECT dolt_branch('from_tag', 'v1');
 
 echo "--- bare commit hash ref ---"
 
-
-
-
-
-
-
 oracle "at_recent_commit_via_head" "
 $SEED
 INSERT INTO t VALUES (3, 30);
@@ -240,14 +193,10 @@ SELECT dolt_commit('-m', 'c2');
 
 echo "--- working set is NOT visible at any ref ---"
 
-
-
-
 oracle "at_head_excludes_working_modifications" "
 $SEED
 UPDATE t SET v = 999 WHERE id = 1;
 " "HEAD"
-
 
 oracle "at_head_excludes_staged_modifications" "
 $SEED
@@ -256,8 +205,6 @@ SELECT dolt_add('-A');
 " "HEAD"
 
 echo "--- post-merge ---"
-
-
 
 oracle "at_head_after_merge" "
 $SEED
@@ -272,7 +219,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'main2');
 SELECT dolt_merge('feature');
 " "HEAD"
-
 
 oracle "at_head_minus_1_after_merge_is_main2" "
 $SEED
@@ -317,9 +263,6 @@ SELECT dolt_merge('feature');
 " "HEAD^2"
 
 echo "--- error paths ---"
-
-
-
 
 oracle_error "at_nonexistent_ref" "$SEED" "nope"
 

--- a/test/vc_oracle_blame_test.sh
+++ b/test/vc_oracle_blame_test.sh
@@ -1,35 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 set -u
 set -o pipefail
 
@@ -40,10 +10,6 @@ trap "rm -rf $TMPROOT" EXIT
 pass=0; fail=0
 FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
-
-
-
-
 
 oracle() {
   local name="$1" setup="$2" select_sql="$3"

--- a/test/vc_oracle_blame_test.sh
+++ b/test/vc_oracle_blame_test.sh
@@ -1,34 +1,34 @@
 #!/bin/bash
-#
-# Version-control oracle test: dolt_blame_<table>
-#
-# Runs identical blame scenarios against doltlite and Dolt and
-# compares the resulting (pk, commit_message) pairs. Commit hashes
-# don't match across engines (prolly vs noms), so the oracle joins
-# dolt_blame back to dolt_log by commit hash to get a stable
-# comparison key.
-#
-# dolt_blame_<table> semantics (reverse-engineered from Dolt):
-#
-#   Schema: <pk_cols>, commit, commit_date, committer, email, message
-#
-#   Rows: one per LIVE row in the current table (deleted rows are
-#   not reported). For each live row, "commit" is the most recent
-#   commit that introduced the current value of that row, computed
-#   by walking history first-parent from HEAD:
-#     - At a linear commit, blame = that commit if the row's value
-#       differs from the value in the commit's parent.
-#     - At a merge commit (2+ parents), blame = merge commit if the
-#       row's value differs from the merge base (LCA of parents);
-#       otherwise continue walking first-parent.
-#
-#   Schema-only changes (ADD COLUMN with no row edits) do NOT update
-#   blame. Revert-to-original and delete-then-reinsert-same-value DO
-#   update blame (the latest commit that touched the row's storage
-#   wins).
-#
-# Usage: bash vc_oracle_blame_test.sh [path/to/doltlite] [path/to/dolt]
-#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 set -u
 set -o pipefail
@@ -41,10 +41,10 @@ pass=0; fail=0
 FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
-# $1=name, $2=setup SQL, $3=select list tagging rows like CONCAT('BL|', pk, '|', message).
-# Each oracle compares doltlite and Dolt on the same scenario and
-# extracts only tagged "BL|..." rows so the noise from CALL dolt_*()
-# status/hash rows is filtered out.
+
+
+
+
 oracle() {
   local name="$1" setup="$2" select_sql="$3"
   local dir="$TMPROOT/$name"

--- a/test/vc_oracle_branch_test.sh
+++ b/test/vc_oracle_branch_test.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
-#
-# Version-control oracle test: dolt_branch (the function, not the vtable)
-#
-# Runs identical dolt_branch scenarios against doltlite and Dolt and
-# compares the resulting dolt_branches post-state. Covers create, delete,
-# force-delete (-D), copy (-c), move/rename (-m), force-create (-f), and
-# creating at a start point. Also covers the error paths where both
-# engines should reject an invalid call.
-#
-# Usage: bash vc_oracle_branch_test.sh [path/to/doltlite] [path/to/dolt]
-#
+
+
+
+
+
+
+
+
+
+
+
 
 set -u
 set -o pipefail
@@ -22,7 +22,7 @@ pass=0; fail=0
 FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
-# Replace each distinct hash with H1, H2, ... in first-appearance order.
+
 normalize() {
   tr -d '\r' | awk -F'\t' '
     {
@@ -34,9 +34,9 @@ normalize() {
   '
 }
 
-# Compare post-state (name, hash, dirty) across all branches.
-# Committer/email/date/message are excluded for the same reason as the
-# branches vtable oracle — process-derived values.
+
+
+
 oracle() {
   local name="$1" setup="$2"
   local dir="$TMPROOT/$name"

--- a/test/vc_oracle_branch_test.sh
+++ b/test/vc_oracle_branch_test.sh
@@ -1,16 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
-
-
-
 set -u
 set -o pipefail
 
@@ -22,7 +11,6 @@ pass=0; fail=0
 FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
-
 normalize() {
   tr -d '\r' | awk -F'\t' '
     {
@@ -33,9 +21,6 @@ normalize() {
     }
   '
 }
-
-
-
 
 oracle() {
   local name="$1" setup="$2"

--- a/test/vc_oracle_branches_test.sh
+++ b/test/vc_oracle_branches_test.sh
@@ -1,20 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 set -u
 set -o pipefail
 
@@ -25,8 +10,6 @@ trap "rm -rf $TMPROOT" EXIT
 pass=0; fail=0
 FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
-
-
 
 normalize() {
   tr -d '\r' | awk -F'\t' '
@@ -64,8 +47,6 @@ oracle() {
     echo "$dolt_setup" | "$DOLT" sql -c >/dev/null 2>"$dir/dt.err"
     "$DOLT" sql -r csv -q "SELECT concat(name, char(9), hash, char(9), latest_commit_message, char(9), remote, char(9), branch, char(9), dirty) FROM dolt_branches ORDER BY name;" 2>>"$dir/dt.err"
   ) > "$dir/dt.raw"
-
-
 
   local dt_out
   dt_out=$(vc_oracle_tail_csv_body "$dir/dt.raw" \
@@ -176,9 +157,6 @@ SELECT dolt_commit('-m', 'first');
 
 echo "--- branch at older commit ---"
 
-
-
-
 oracle "branch_at_head_minus_one" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
@@ -196,8 +174,6 @@ SELECT dolt_branch('back_two', 'HEAD~2');
 
 echo "--- branch copy ---"
 
-
-
 oracle "branch_copy_main_to_clone" "
 CREATE TABLE t(id INTEGER PRIMARY KEY);
 INSERT INTO t VALUES (1);
@@ -207,8 +183,6 @@ SELECT dolt_branch('-c', 'main', 'clone');
 "
 
 echo "--- branch rename ---"
-
-
 
 oracle "branch_rename_non_current" "
 CREATE TABLE t(id INTEGER PRIMARY KEY);
@@ -220,9 +194,6 @@ SELECT dolt_branch('-m', 'old_name', 'new_name');
 "
 
 echo "--- multi-branch states ---"
-
-
-
 
 oracle "three_branches_three_heads" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
@@ -239,9 +210,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'feat_only');
 "
 
-
-
-
 oracle "other_branch_dirty_bit_untracked" "
 CREATE TABLE t(id INTEGER PRIMARY KEY);
 INSERT INTO t VALUES (1);
@@ -253,8 +221,6 @@ INSERT INTO t VALUES (2);
 "
 
 echo "--- branch after merge ---"
-
-
 
 oracle "main_head_after_merge" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);

--- a/test/vc_oracle_branches_test.sh
+++ b/test/vc_oracle_branches_test.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
-#
-# Version-control oracle test: dolt_branches
-#
-# Runs identical branch-management scenarios against doltlite and Dolt and
-# compares the normalized dolt_branches output. Catches divergence in how
-# each engine reports branch listings, the latest-commit metadata for each
-# branch, upstream tracking, and the per-branch dirty bit.
-#
-# Columns compared: name, hash (normalized), latest_commit_message,
-# remote, branch, dirty. The committer/email/date columns are excluded
-# because their values come from process/config and legitimately differ
-# across the two engines.
-#
-# Usage: bash vc_oracle_branches_test.sh [path/to/doltlite] [path/to/dolt]
-#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 set -u
 set -o pipefail
@@ -26,8 +26,8 @@ pass=0; fail=0
 FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
-# Replace each distinct hash with H1, H2, ... in first-appearance order;
-# strip CRLF.
+
+
 normalize() {
   tr -d '\r' | awk -F'\t' '
     {
@@ -65,8 +65,8 @@ oracle() {
     "$DOLT" sql -r csv -q "SELECT concat(name, char(9), hash, char(9), latest_commit_message, char(9), remote, char(9), branch, char(9), dirty) FROM dolt_branches ORDER BY name;" 2>>"$dir/dt.err"
   ) > "$dir/dt.raw"
 
-  # Dolt prints "true"/"false" for the dirty tinyint(1); doltlite prints
-  # "0"/"1". Map both to 0/1 before comparison.
+
+
   local dt_out
   dt_out=$(vc_oracle_tail_csv_body "$dir/dt.raw" \
            | tr -d '"' \
@@ -176,9 +176,9 @@ SELECT dolt_commit('-m', 'first');
 
 echo "--- branch at older commit ---"
 
-# dolt_branch('name', 'HEAD~N') should create a branch pointing at
-# an older commit. The branch's latest_commit_message should be
-# the OLDER commit, not HEAD.
+
+
+
 oracle "branch_at_head_minus_one" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
@@ -196,8 +196,8 @@ SELECT dolt_branch('back_two', 'HEAD~2');
 
 echo "--- branch copy ---"
 
-# dolt_branch('-c', src, dst) copies a branch. Both src and dst
-# should point at the same commit.
+
+
 oracle "branch_copy_main_to_clone" "
 CREATE TABLE t(id INTEGER PRIMARY KEY);
 INSERT INTO t VALUES (1);
@@ -208,8 +208,8 @@ SELECT dolt_branch('-c', 'main', 'clone');
 
 echo "--- branch rename ---"
 
-# dolt_branch('-m', src, dst) renames a branch. The src name should
-# disappear, dst should exist at the same commit.
+
+
 oracle "branch_rename_non_current" "
 CREATE TABLE t(id INTEGER PRIMARY KEY);
 INSERT INTO t VALUES (1);
@@ -221,9 +221,9 @@ SELECT dolt_branch('-m', 'old_name', 'new_name');
 
 echo "--- multi-branch states ---"
 
-# Three branches: one at main HEAD, one ahead of main, one at an
-# older commit. Tests that latest_commit_message per-branch is
-# computed independently.
+
+
+
 oracle "three_branches_three_heads" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
@@ -239,9 +239,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'feat_only');
 "
 
-# Multiple branches all dirty (working set diverges from their own
-# HEAD). Current branch marker matters here — only the current
-# branch's dirty bit actually reflects uncommitted state.
+
+
+
 oracle "other_branch_dirty_bit_untracked" "
 CREATE TABLE t(id INTEGER PRIMARY KEY);
 INSERT INTO t VALUES (1);
@@ -254,8 +254,8 @@ INSERT INTO t VALUES (2);
 
 echo "--- branch after merge ---"
 
-# After merging feature into main, main's latest_commit_message
-# should be the merge commit.
+
+
 oracle "main_head_after_merge" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);

--- a/test/vc_oracle_checkout_test.sh
+++ b/test/vc_oracle_checkout_test.sh
@@ -1,28 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 set -u
 set -o pipefail
 
@@ -50,9 +27,6 @@ normalize_status() {
     | sort -t$'\t' -k2,2 -k3,3 -k4,4
 }
 
-
-
-
 oracle() {
   local name="$1" setup="$2"
   local dir="$TMPROOT/$name"
@@ -77,10 +51,6 @@ oracle() {
 
   local dolt_setup
   dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
-
-
-
-
 
   local dt_branch dt_rows dt_status
   (

--- a/test/vc_oracle_checkout_test.sh
+++ b/test/vc_oracle_checkout_test.sh
@@ -1,27 +1,27 @@
 #!/bin/bash
-#
-# Version-control oracle test: dolt_checkout
-#
-# Runs identical checkout scenarios against doltlite and Dolt and compares
-# the resulting (active_branch, table contents, dolt_status) post-state.
-#
-# Checkout has three overlapping behaviors that the oracle has to verify:
-#   1. Branch switch: HEAD/active_branch moves and the visible data swaps
-#      to the target branch's working set.
-#   2. Branch create-and-switch (`-b`): same as above plus a new branch
-#      ref is created at the current commit.
-#   3. Per-table checkout: when the first arg is not a branch, treat the
-#      args as table names and revert those tables in the working set
-#      back to the staged catalog (or HEAD if nothing is staged). This
-#      is the `git checkout -- file` analogue.
-#
-# Comparing only the active branch would miss revert-table bugs; comparing
-# only the table contents would miss bugs that switch HEAD without moving
-# the data; comparing only dolt_status would miss the branch ref. So the
-# oracle compares all three concatenated.
-#
-# Usage: bash vc_oracle_checkout_test.sh [path/to/doltlite] [path/to/dolt]
-#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 set -u
 set -o pipefail
@@ -50,9 +50,9 @@ normalize_status() {
     | sort -t$'\t' -k2,2 -k3,3 -k4,4
 }
 
-# $1=name, $2=setup SQL using SELECT dolt_*() form. The harness rewrites
-# to CALL dolt_*() for Dolt. The setup must leave the table named `t`
-# in some final state — we always SELECT from it for comparison.
+
+
+
 oracle() {
   local name="$1" setup="$2"
   local dir="$TMPROOT/$name"
@@ -78,10 +78,10 @@ oracle() {
   local dolt_setup
   dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
 
-  # Run setup + comparison queries in a SINGLE dolt sql invocation —
-  # CALL dolt_checkout is session-scoped in the dolt CLI, so a second
-  # `dolt sql` invocation would lose the branch switch and start back
-  # on main. Same goes for the working set.
+
+
+
+
   local dt_branch dt_rows dt_status
   (
     cd "$dir/dt" || exit 1

--- a/test/vc_oracle_commit_ancestors_test.sh
+++ b/test/vc_oracle_commit_ancestors_test.sh
@@ -1,27 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 set -u
 set -o pipefail
 
@@ -33,15 +11,10 @@ pass=0; fail=0
 FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
-
-
-
 oracle() {
   local name="$1" setup="$2"
   local dir="$TMPROOT/$name"
   mkdir -p "$dir/dl" "$dir/dt"
-
-
 
   local q="SELECT CONCAT('ROW|TOTAL|', count(*)) FROM dolt_commit_ancestors;
 SELECT CONCAT('ROW|ROOTS|', count(*)) FROM dolt_commit_ancestors WHERE parent_hash IS NULL;
@@ -85,16 +58,13 @@ echo ""
 
 echo "--- linear chains ---"
 
-
 oracle "init_only" ""
-
 
 oracle "single_user_commit" "
 CREATE TABLE t(id INTEGER PRIMARY KEY);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c1');
 "
-
 
 oracle "three_linear_commits" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
@@ -111,9 +81,6 @@ SELECT dolt_commit('-m', 'c3');
 
 echo "--- merge commits ---"
 
-
-
-
 oracle "merge_commit_two_parents" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
@@ -129,8 +96,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'main_c');
 SELECT dolt_merge('feat');
 "
-
-
 
 oracle "two_merges" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
@@ -156,8 +121,6 @@ SELECT dolt_commit('-m', 'main2');
 SELECT dolt_merge('b');
 "
 
-
-
 oracle "fast_forward_no_merge_commit" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 SELECT dolt_add('-A');
@@ -175,8 +138,6 @@ SELECT dolt_merge('feat');
 
 echo "--- detached subgraph (only-on-feat doesn't appear from main HEAD) ---"
 
-
-
 oracle "branch_not_merged_invisible_from_main" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 SELECT dolt_add('-A');
@@ -186,8 +147,6 @@ INSERT INTO t VALUES (1, 1);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'main_only');
 "
-
-
 
 oracle "ancestors_from_feat_head" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
@@ -205,9 +164,6 @@ SELECT dolt_checkout('feat');
 "
 
 echo "--- consistency with dolt_log ---"
-
-
-
 
 oracle "ancestors_count_matches_log" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);

--- a/test/vc_oracle_commit_ancestors_test.sh
+++ b/test/vc_oracle_commit_ancestors_test.sh
@@ -1,26 +1,26 @@
 #!/bin/bash
-#
-# Version-control oracle test: dolt_commit_ancestors
-#
-# The vtable mirrors Dolt's table of the same name:
-#   commit_hash  TEXT     — commit reachable from HEAD
-#   parent_hash  TEXT     — parent of that commit (NULL for root)
-#   parent_index INTEGER  — 0-based position of the parent
-#
-# Hashes differ between engines (different content addressing), so
-# the oracle compares topology shape rather than literal hash strings:
-#
-#   - Total number of (commit, parent) rows
-#   - Number of root rows (parent_hash IS NULL)
-#   - Distribution of parent_index values (counts the merges)
-#   - Number of distinct commits surveyed
-#
-# These four numbers, taken together, fully describe the parent-
-# edge structure. They're what a consumer like dolt-replay needs to
-# reconstruct order without depending on dolt_log.date.
-#
-# Usage: bash vc_oracle_commit_ancestors_test.sh [path/to/doltlite] [path/to/dolt]
-#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 set -u
 set -o pipefail
@@ -33,16 +33,16 @@ pass=0; fail=0
 FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
-# Run the same diagnostic query against both engines and compare the
-# topology summary line by line. The query intentionally avoids hash
-# columns directly — it emits ROW lines with summary numbers only.
+
+
+
 oracle() {
   local name="$1" setup="$2"
   local dir="$TMPROOT/$name"
   mkdir -p "$dir/dl" "$dir/dt"
 
-  # Topology summary query — engine-independent shape. Use CONCAT
-  # everywhere; Dolt parses '||' as logical OR (MySQL semantics).
+
+
   local q="SELECT CONCAT('ROW|TOTAL|', count(*)) FROM dolt_commit_ancestors;
 SELECT CONCAT('ROW|ROOTS|', count(*)) FROM dolt_commit_ancestors WHERE parent_hash IS NULL;
 SELECT CONCAT('ROW|DISTINCT_COMMITS|', count(DISTINCT commit_hash)) FROM dolt_commit_ancestors;
@@ -85,17 +85,17 @@ echo ""
 
 echo "--- linear chains ---"
 
-# Just the auto-init commit. Both engines should report 1 row, 1 root.
+
 oracle "init_only" ""
 
-# init + 1 user commit. 2 rows total, 1 root, all parent_index=0.
+
 oracle "single_user_commit" "
 CREATE TABLE t(id INTEGER PRIMARY KEY);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c1');
 "
 
-# init + 3 user commits in a line. 4 rows, 1 root, all parent_index=0.
+
 oracle "three_linear_commits" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
@@ -111,9 +111,9 @@ SELECT dolt_commit('-m', 'c3');
 
 echo "--- merge commits ---"
 
-# Branch + merge. The merge commit contributes two rows (parent_index
-# 0 and 1). Both engines have to expose this for the topology to
-# reconstruct.
+
+
+
 oracle "merge_commit_two_parents" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
@@ -130,8 +130,8 @@ SELECT dolt_commit('-m', 'main_c');
 SELECT dolt_merge('feat');
 "
 
-# Two sequential merges from two distinct feature branches. Should
-# produce two rows with parent_index=1, plus the linear edges.
+
+
 oracle "two_merges" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 SELECT dolt_add('-A');
@@ -156,8 +156,8 @@ SELECT dolt_commit('-m', 'main2');
 SELECT dolt_merge('b');
 "
 
-# Fast-forward merge — main moves to feat tip with no merge commit.
-# Topology should be linear; no parent_index=1.
+
+
 oracle "fast_forward_no_merge_commit" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 SELECT dolt_add('-A');
@@ -175,8 +175,8 @@ SELECT dolt_merge('feat');
 
 echo "--- detached subgraph (only-on-feat doesn't appear from main HEAD) ---"
 
-# Commits made on a branch that's never merged shouldn't show up in
-# main's ancestor walk. The vtable walks from session HEAD only.
+
+
 oracle "branch_not_merged_invisible_from_main" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 SELECT dolt_add('-A');
@@ -187,8 +187,8 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'main_only');
 "
 
-# Same setup as above, but from feat HEAD: feat_only IS visible,
-# main_only is NOT.
+
+
 oracle "ancestors_from_feat_head" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 SELECT dolt_add('-A');
@@ -206,9 +206,9 @@ SELECT dolt_checkout('feat');
 
 echo "--- consistency with dolt_log ---"
 
-# Distinct commits in dolt_commit_ancestors should equal the row
-# count in dolt_log (every reachable commit appears exactly once on
-# each side). This is the load-bearing invariant a walker depends on.
+
+
+
 oracle "ancestors_count_matches_log" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);

--- a/test/vc_oracle_commit_test.sh
+++ b/test/vc_oracle_commit_test.sh
@@ -1,30 +1,30 @@
 #!/bin/bash
-#
-# Version-control oracle test: dolt_commit
-#
-# Every other oracle test calls dolt_commit hundreds of times in
-# its setup, but commit's own flag surface — the things you can
-# pass to dolt_commit itself — has never been compared against
-# Dolt. This file fixes that.
-#
-# Compares (dolt_log, dolt_status) post-state for each scenario:
-# the log captures the commit shape (message, author, parent
-# linkage) and the status captures whether anything was left
-# unstaged. Author / committer email is normalized because the
-# two engines disagree on the default but the user-supplied
-# value is the part we care about.
-#
-# Coverage:
-#   * -m / --message argument forms
-#   * -a / -A / -am combo flags (stage-everything)
-#   * --author with both "Name <email>" and bare-name forms
-#   * --amend
-#   * --skip-empty / --allow-empty
-#   * --date
-#   * Error paths: no message, no changes, unresolved conflicts
-#
-# Usage: bash vc_oracle_commit_test.sh [path/to/doltlite] [path/to/dolt]
-#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 set -u
 set -o pipefail
@@ -37,23 +37,23 @@ pass=0; fail=0
 FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
-# Strip CRs, drop blank lines, sort log section by message and
-# status section by table_name. The H1/H2/... renaming makes
-# commit hashes deterministic. Author email is canonicalized to
-# whatever was supplied via --author or to "default" otherwise,
-# so the comparison ignores Dolt vs doltlite default-author
-# differences but still pins user-supplied values.
+
+
+
+
+
+
 normalize_log() {
   tr -d '\r' \
     | awk -F'\t' 'NF >= 5 && $1 == "L" { print }' \
     | awk -F'\t' '
         {
           email = $4
-          # Per-engine default committer emails get canonicalized
-          # to DEFAULT so the comparison only pins user-supplied
-          # values from --author. doltlite emits "" (no default
-          # email configured), Dolt emits "root@localhost" for the
-          # session and "oracle@test" for the init-supplied value.
+
+
+
+
+
           if (email == "" \
            || email == "root@localhost" \
            || email == "oracle@test" \
@@ -61,15 +61,15 @@ normalize_log() {
            || email == "doltlite@local") {
             email = "DEFAULT"
           }
-          # Date column: keep only the YYYY-MM-DD portion. The
-          # two engines display times in different timezones
-          # (doltlite = UTC, Dolt = local) so comparing the time
-          # would always trip even when the underlying moment
-          # matches. The day portion is enough to verify --date
-          # was applied. Recent commits whose date matches the
-          # wall-clock day are canonicalized to RECENT so harness
-          # wall-clock skew does not trip the comparison either;
-          # explicit historical --date values escape the bucket.
+
+
+
+
+
+
+
+
+
           dt = substr($5, 1, 10)
           "date +%Y-%m-%d" | getline today
           close("date +%Y-%m-%d")
@@ -132,11 +132,11 @@ oracle() {
   ) > "$dir/dt.status.raw"
   dt_status=$(tail -n +2 "$dir/dt.status.raw" | tr -d '"' | normalize_status)
 
-  # Empty-on-both-sides safeguard. If both engines produced ZERO log
-  # rows that's almost certainly because the query errored on both
-  # sides (typo in column name, missing vtable, etc). The "passes"
-  # would be meaningless. Every commit oracle scenario commits at
-  # least once, so an empty log on both is a harness bug.
+
+
+
+
+
   if [ -z "$dl_log" ] && [ -z "$dt_log" ]; then
     fail=$((fail+1))
     FAILED_NAMES="$FAILED_NAMES $name"
@@ -194,7 +194,7 @@ echo ""
 
 echo "--- message argument forms ---"
 
-# Short flag with separate value: dolt_commit('-m', 'msg')
+
 oracle "commit_short_m_flag" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
@@ -202,7 +202,7 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'first commit');
 "
 
-# Long flag: dolt_commit('--message', 'msg')
+
 oracle "commit_long_message_flag" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
@@ -212,18 +212,18 @@ SELECT dolt_commit('--message', 'first commit');
 
 echo "--- combo / stage-all flags ---"
 
-# -A explicitly stages everything including new (untracked) tables
+
 oracle "commit_uppercase_A_new_table" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
 SELECT dolt_commit('-A', '-m', 'first commit');
 "
 
-# --all is the long form of -a (matches git), so it does NOT
-# stage brand-new tables. It works the same as -a does on a
-# tracked, modified table — exercised below in
-# commit_lowercase_a_modified_tracked_table — and errors on a
-# new untracked table here.
+
+
+
+
+
 oracle_error "commit_all_long_new_table_errors" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
@@ -239,17 +239,17 @@ INSERT INTO t VALUES (2, 20);
 SELECT dolt_commit('--all', '-m', 'modify');
 "
 
-# -a (lowercase) stages MODIFICATIONS to tracked tables only.
-# Brand-new tables stay unstaged so a -a commit on a fresh DB
-# with no tracked tables errors with "nothing to commit" in
-# both engines.
+
+
+
+
 oracle_error "commit_lowercase_a_new_table_errors" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
 SELECT dolt_commit('-a', '-m', 'first commit');
 "
 
-# -a on an existing modified table works in both engines
+
 oracle "commit_lowercase_a_modified_tracked_table" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
@@ -259,7 +259,7 @@ INSERT INTO t VALUES (2, 20);
 SELECT dolt_commit('-a', '-m', 'modify');
 "
 
-# -am combo on an existing modified table
+
 oracle "commit_combo_am_modified_tracked_table" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
@@ -269,8 +269,8 @@ INSERT INTO t VALUES (2, 20);
 SELECT dolt_commit('-am', 'modify');
 "
 
-# -am combo on a NEW table should also fail (the -a is honored
-# even in the combo form, so the new table is not staged)
+
+
 oracle_error "commit_combo_am_new_table_errors" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
@@ -279,7 +279,7 @@ SELECT dolt_commit('-am', 'first commit');
 
 echo "--- author override ---"
 
-# --author 'Name <email>' — both engines should record both fields
+
 oracle "commit_author_name_and_email" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
@@ -287,8 +287,8 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'first', '--author', 'Alice Author <alice@example.com>');
 "
 
-# --author 'Name' (no email) — undefined behavior in git but Dolt
-# accepts it and records the name with an empty email
+
+
 oracle "commit_author_name_only" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
@@ -298,9 +298,9 @@ SELECT dolt_commit('-m', 'first', '--author', 'Bob Bare-Name <bob@example.com>')
 
 echo "--- --amend ---"
 
-# Amend message: replaces the last commit's message but keeps its
-# parent (so the log still has the same number of commits and the
-# same parent hash for the amended commit's parent).
+
+
+
 oracle "commit_amend_message_only" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
@@ -309,9 +309,9 @@ SELECT dolt_commit('-m', 'original');
 SELECT dolt_commit('--amend', '-m', 'amended');
 "
 
-# Amend with new staged content: replaces both the message AND
-# the catalog of the last commit, still keeping the original
-# parent linkage.
+
+
+
 oracle "commit_amend_with_new_content" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
@@ -324,8 +324,8 @@ SELECT dolt_commit('--amend', '-m', 'amended with row 2');
 
 echo "--- skip / allow empty ---"
 
-# --allow-empty: create a commit even when nothing has changed
-# since HEAD. dolt_log should show the new commit.
+
+
 oracle "commit_allow_empty_no_changes" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
@@ -334,8 +334,8 @@ SELECT dolt_commit('-m', 'first');
 SELECT dolt_commit('--allow-empty', '-m', 'empty followup');
 "
 
-# --skip-empty: do nothing (return success) when there are no
-# changes since HEAD. dolt_log should NOT show a new commit.
+
+
 oracle "commit_skip_empty_no_changes" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
@@ -344,8 +344,8 @@ SELECT dolt_commit('-m', 'first');
 SELECT dolt_commit('--skip-empty', '-m', 'second');
 "
 
-# --skip-empty when there ARE staged changes — should still
-# create the commit normally.
+
+
 oracle "commit_skip_empty_with_changes" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
@@ -358,13 +358,13 @@ SELECT dolt_commit('--skip-empty', '-m', 'second');
 
 echo "--- --date ---"
 
-# --date with an explicit ISO timestamp. Both engines should
-# record the supplied timestamp on the commit (visible via
-# dolt_log.committer_date or similar). The harness only checks
-# log shape (message + email) so a divergence here surfaces as
-# different commit hashes if the date affects the hash, or as
-# silent acceptance otherwise. The followup `commit_date_visible`
-# scenario specifically queries the date column.
+
+
+
+
+
+
+
 oracle "commit_with_explicit_date" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
@@ -423,7 +423,7 @@ SELECT dolt_commit('-m', 'drop and edit');
 
 echo "--- error paths ---"
 
-# Bare commit with no -m / --message: both should error
+
 oracle_error "commit_no_message" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
@@ -431,7 +431,7 @@ SELECT dolt_add('-A');
 SELECT dolt_commit();
 "
 
-# Empty -m: both should error or both should accept (matching)
+
 oracle_error "commit_empty_message" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
@@ -488,7 +488,7 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('--bogus', '-m', 'first');
 "
 
-# No staged changes, no --allow-empty: both should error
+
 oracle_error "commit_nothing_staged" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
@@ -497,7 +497,7 @@ SELECT dolt_commit('-m', 'first');
 SELECT dolt_commit('-m', 'nothing-to-do');
 "
 
-# Unresolved merge conflicts block commit
+
 oracle_error "commit_with_unresolved_conflicts" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);

--- a/test/vc_oracle_commit_test.sh
+++ b/test/vc_oracle_commit_test.sh
@@ -1,31 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 set -u
 set -o pipefail
 
@@ -37,23 +11,12 @@ pass=0; fail=0
 FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
-
-
-
-
-
-
 normalize_log() {
   tr -d '\r' \
     | awk -F'\t' 'NF >= 5 && $1 == "L" { print }' \
     | awk -F'\t' '
         {
           email = $4
-
-
-
-
-
           if (email == "" \
            || email == "root@localhost" \
            || email == "oracle@test" \
@@ -61,15 +24,6 @@ normalize_log() {
            || email == "doltlite@local") {
             email = "DEFAULT"
           }
-
-
-
-
-
-
-
-
-
           dt = substr($5, 1, 10)
           "date +%Y-%m-%d" | getline today
           close("date +%Y-%m-%d")
@@ -132,11 +86,6 @@ oracle() {
   ) > "$dir/dt.status.raw"
   dt_status=$(tail -n +2 "$dir/dt.status.raw" | tr -d '"' | normalize_status)
 
-
-
-
-
-
   if [ -z "$dl_log" ] && [ -z "$dt_log" ]; then
     fail=$((fail+1))
     FAILED_NAMES="$FAILED_NAMES $name"
@@ -194,14 +143,12 @@ echo ""
 
 echo "--- message argument forms ---"
 
-
 oracle "commit_short_m_flag" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'first commit');
 "
-
 
 oracle "commit_long_message_flag" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
@@ -212,17 +159,11 @@ SELECT dolt_commit('--message', 'first commit');
 
 echo "--- combo / stage-all flags ---"
 
-
 oracle "commit_uppercase_A_new_table" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
 SELECT dolt_commit('-A', '-m', 'first commit');
 "
-
-
-
-
-
 
 oracle_error "commit_all_long_new_table_errors" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
@@ -239,16 +180,11 @@ INSERT INTO t VALUES (2, 20);
 SELECT dolt_commit('--all', '-m', 'modify');
 "
 
-
-
-
-
 oracle_error "commit_lowercase_a_new_table_errors" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
 SELECT dolt_commit('-a', '-m', 'first commit');
 "
-
 
 oracle "commit_lowercase_a_modified_tracked_table" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
@@ -259,7 +195,6 @@ INSERT INTO t VALUES (2, 20);
 SELECT dolt_commit('-a', '-m', 'modify');
 "
 
-
 oracle "commit_combo_am_modified_tracked_table" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
@@ -269,8 +204,6 @@ INSERT INTO t VALUES (2, 20);
 SELECT dolt_commit('-am', 'modify');
 "
 
-
-
 oracle_error "commit_combo_am_new_table_errors" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
@@ -279,15 +212,12 @@ SELECT dolt_commit('-am', 'first commit');
 
 echo "--- author override ---"
 
-
 oracle "commit_author_name_and_email" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'first', '--author', 'Alice Author <alice@example.com>');
 "
-
-
 
 oracle "commit_author_name_only" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
@@ -298,9 +228,6 @@ SELECT dolt_commit('-m', 'first', '--author', 'Bob Bare-Name <bob@example.com>')
 
 echo "--- --amend ---"
 
-
-
-
 oracle "commit_amend_message_only" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
@@ -308,9 +235,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'original');
 SELECT dolt_commit('--amend', '-m', 'amended');
 "
-
-
-
 
 oracle "commit_amend_with_new_content" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
@@ -324,8 +248,6 @@ SELECT dolt_commit('--amend', '-m', 'amended with row 2');
 
 echo "--- skip / allow empty ---"
 
-
-
 oracle "commit_allow_empty_no_changes" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
@@ -334,8 +256,6 @@ SELECT dolt_commit('-m', 'first');
 SELECT dolt_commit('--allow-empty', '-m', 'empty followup');
 "
 
-
-
 oracle "commit_skip_empty_no_changes" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
@@ -343,8 +263,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'first');
 SELECT dolt_commit('--skip-empty', '-m', 'second');
 "
-
-
 
 oracle "commit_skip_empty_with_changes" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
@@ -357,13 +275,6 @@ SELECT dolt_commit('--skip-empty', '-m', 'second');
 "
 
 echo "--- --date ---"
-
-
-
-
-
-
-
 
 oracle "commit_with_explicit_date" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
@@ -423,14 +334,12 @@ SELECT dolt_commit('-m', 'drop and edit');
 
 echo "--- error paths ---"
 
-
 oracle_error "commit_no_message" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
 SELECT dolt_add('-A');
 SELECT dolt_commit();
 "
-
 
 oracle_error "commit_empty_message" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
@@ -488,7 +397,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('--bogus', '-m', 'first');
 "
 
-
 oracle_error "commit_nothing_staged" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
@@ -496,7 +404,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'first');
 SELECT dolt_commit('-m', 'nothing-to-do');
 "
-
 
 oracle_error "commit_with_unresolved_conflicts" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);

--- a/test/vc_oracle_conflicts_resolve_test.sh
+++ b/test/vc_oracle_conflicts_resolve_test.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
-#
-# Version-control oracle test: dolt_conflicts_resolve
-#
-# Runs identical conflict-resolution scenarios against doltlite and Dolt
-# and compares the resulting table data and conflict state. Covers:
-#   - --ours resolution (keep our value)
-#   - --theirs resolution (accept their value)
-#   - multi-row conflicts resolved in one call
-#   - partial resolution (multiple tables, resolve one)
-#   - resolution followed by commit
-#
-# Usage: bash vc_oracle_conflicts_resolve_test.sh [path/to/doltlite] [path/to/dolt]
-#
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 set -u
 set -o pipefail
@@ -24,17 +24,17 @@ pass=0; fail=0
 FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
-# Build a standard merge-conflict setup and add a resolution + query.
-# Compare the final table data (SELECT id, v FROM t ORDER BY id) and
-# the remaining conflict count.
-#
-# $1=name, $2=setup (up to and including the merge), $3=resolve+query SQL
+
+
+
+
+
 oracle() {
   local name="$1" setup="$2" resolve_and_query="$3"
   local dir="$TMPROOT/$name"
   mkdir -p "$dir/dl" "$dir/dt"
 
-  # -- doltlite --
+
   local dl_script
   local dl_out
   dl_script=$(printf "%s\n%s\n" "$setup" "$resolve_and_query" | perl -0pe "s/\nSELECT dolt_merge\\(/\nBEGIN;\\nSELECT dolt_merge\\(/")
@@ -46,10 +46,10 @@ oracle() {
            | grep '^R|' \
            | tr -d '\r' | sort)
 
-  # -- Dolt --
-  # Everything must run in ONE `dolt sql` invocation so
-  # @@autocommit=0 and @@dolt_allow_commit_conflicts=1 persist
-  # across the setup, merge, resolution, and query.
+
+
+
+
   local dolt_all
   dolt_all=$(vc_oracle_translate_for_dolt "$(printf '%s\n%s' "$setup" "$resolve_and_query")")
 
@@ -107,7 +107,7 @@ $dolt_setup"
   fi
 }
 
-# Standard conflict setup: both sides modify the same row differently.
+
 CONFLICT_SETUP="
 CREATE TABLE t(id INT PRIMARY KEY, v INT);
 INSERT INTO t VALUES(1, 10);
@@ -242,10 +242,10 @@ SELECT CONCAT('R|', id, '|', v) FROM t ORDER BY id;"
 
 echo "--- TEXT primary key ---"
 
-# TEXT PK exercises the conflict-apply path for non-integer keys.
-# Row-based prolly-tree storage keys rows by the serialized PK; the
-# conflict-resolve path must decode the text PK from the record body
-# (since doltlite's tree key is an intKey, not the user PK bytes).
+
+
+
+
 oracle "resolve_theirs_text_pk" \
 "CREATE TABLE t(id VARCHAR(32) PRIMARY KEY, v INT);
 INSERT INTO t VALUES('alice', 10);
@@ -341,9 +341,9 @@ SELECT CONCAT('R|count|', count(*)) FROM dolt_conflicts;"
 
 echo "--- composite primary key (two INT columns) ---"
 
-# Composite PK exercises the path where the tree key alone can't
-# identify a row — the conflict apply must reconstruct the full key
-# from the record body.
+
+
+
 oracle "resolve_theirs_composite_int_pk" \
 "CREATE TABLE t(a INT, b INT, v INT, PRIMARY KEY(a, b));
 INSERT INTO t VALUES(1, 1, 11);
@@ -466,8 +466,8 @@ SELECT CONCAT('R|', region, '|', id, '|', v) FROM t ORDER BY region, id;"
 
 echo "--- multi-row conflicts in a single table ---"
 
-# Many conflicting rows in the same table, resolved in one call.
-# Exercises the loop over ConflictRow entries in applyTheirRecord.
+
+
 oracle "resolve_theirs_many_rows" \
 "CREATE TABLE t(id INT PRIMARY KEY, v INT);
 INSERT INTO t VALUES(1, 1), (2, 2), (3, 3), (4, 4), (5, 5);
@@ -489,9 +489,9 @@ SELECT CONCAT('R|', id, '|', v) FROM t ORDER BY id;"
 
 echo "--- delete/modify conflicts ---"
 
-# Main deletes a row; feature modifies it. The two resolution choices
-# have different meanings here — --ours keeps the delete, --theirs
-# keeps the modification (row present with feature's value).
+
+
+
 oracle "resolve_ours_delete_vs_modify" \
 "CREATE TABLE t(id INT PRIMARY KEY, v INT);
 INSERT INTO t VALUES(1, 10), (2, 20), (3, 30);
@@ -530,7 +530,7 @@ SELECT dolt_merge('feature');
   "SELECT dolt_conflicts_resolve('--theirs', 't');
 SELECT CONCAT('R|', id, '|', v) FROM t ORDER BY id;"
 
-# Symmetric: main modifies, feature deletes.
+
 oracle "resolve_theirs_modify_vs_delete" \
 "CREATE TABLE t(id INT PRIMARY KEY, v INT);
 INSERT INTO t VALUES(1, 10), (2, 20);
@@ -552,9 +552,9 @@ SELECT CONCAT('R|', id, '|', v) FROM t ORDER BY id;"
 
 echo "--- insert/insert same PK ---"
 
-# Both sides insert a new row with the same primary key but different
-# values. No base row exists. Exercises the applyTheirRecord path for
-# a row that has no 'base' side.
+
+
+
 oracle "resolve_theirs_insert_insert_same_pk" \
 "CREATE TABLE t(id INT PRIMARY KEY, v INT);
 INSERT INTO t VALUES(1, 10);
@@ -595,8 +595,8 @@ SELECT CONCAT('R|', id, '|', v) FROM t ORDER BY id;"
 
 echo "--- wide schema (many non-PK columns) ---"
 
-# Exercises the per-column decoding loop in buildInsertSql with a
-# larger column count, mixing types.
+
+
 oracle "resolve_theirs_wide_schema" \
 "CREATE TABLE t(id INT PRIMARY KEY, a VARCHAR(32), b INT, c DOUBLE, d VARCHAR(32), e INT);
 INSERT INTO t VALUES(1, 'a1', 11, 1.5, 'd1', 111);
@@ -619,7 +619,7 @@ SELECT CONCAT('R|', id, '|', a, '|', b, '|', c, '|', d, '|', e) FROM t ORDER BY 
 
 echo "--- NULL values in conflict rows ---"
 
-# Non-PK column containing NULL must survive the conflict roundtrip.
+
 oracle "resolve_theirs_with_nulls" \
 "CREATE TABLE t(id INT PRIMARY KEY, v INT, note VARCHAR(32));
 INSERT INTO t VALUES(1, 10, NULL);

--- a/test/vc_oracle_conflicts_resolve_test.sh
+++ b/test/vc_oracle_conflicts_resolve_test.sh
@@ -1,18 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
-
-
-
-
-
 set -u
 set -o pipefail
 
@@ -24,16 +11,10 @@ pass=0; fail=0
 FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
-
-
-
-
-
 oracle() {
   local name="$1" setup="$2" resolve_and_query="$3"
   local dir="$TMPROOT/$name"
   mkdir -p "$dir/dl" "$dir/dt"
-
 
   local dl_script
   local dl_out
@@ -45,10 +26,6 @@ oracle() {
            | grep -v '^Merge has' \
            | grep '^R|' \
            | tr -d '\r' | sort)
-
-
-
-
 
   local dolt_all
   dolt_all=$(vc_oracle_translate_for_dolt "$(printf '%s\n%s' "$setup" "$resolve_and_query")")
@@ -106,7 +83,6 @@ $dolt_setup"
     echo "    dolt rc:     $dt_rc"
   fi
 }
-
 
 CONFLICT_SETUP="
 CREATE TABLE t(id INT PRIMARY KEY, v INT);
@@ -242,10 +218,6 @@ SELECT CONCAT('R|', id, '|', v) FROM t ORDER BY id;"
 
 echo "--- TEXT primary key ---"
 
-
-
-
-
 oracle "resolve_theirs_text_pk" \
 "CREATE TABLE t(id VARCHAR(32) PRIMARY KEY, v INT);
 INSERT INTO t VALUES('alice', 10);
@@ -340,9 +312,6 @@ SELECT CONCAT('R|table|', id, '|', v) FROM t ORDER BY id;
 SELECT CONCAT('R|count|', count(*)) FROM dolt_conflicts;"
 
 echo "--- composite primary key (two INT columns) ---"
-
-
-
 
 oracle "resolve_theirs_composite_int_pk" \
 "CREATE TABLE t(a INT, b INT, v INT, PRIMARY KEY(a, b));
@@ -466,8 +435,6 @@ SELECT CONCAT('R|', region, '|', id, '|', v) FROM t ORDER BY region, id;"
 
 echo "--- multi-row conflicts in a single table ---"
 
-
-
 oracle "resolve_theirs_many_rows" \
 "CREATE TABLE t(id INT PRIMARY KEY, v INT);
 INSERT INTO t VALUES(1, 1), (2, 2), (3, 3), (4, 4), (5, 5);
@@ -488,9 +455,6 @@ SELECT dolt_merge('feature');
 SELECT CONCAT('R|', id, '|', v) FROM t ORDER BY id;"
 
 echo "--- delete/modify conflicts ---"
-
-
-
 
 oracle "resolve_ours_delete_vs_modify" \
 "CREATE TABLE t(id INT PRIMARY KEY, v INT);
@@ -530,7 +494,6 @@ SELECT dolt_merge('feature');
   "SELECT dolt_conflicts_resolve('--theirs', 't');
 SELECT CONCAT('R|', id, '|', v) FROM t ORDER BY id;"
 
-
 oracle "resolve_theirs_modify_vs_delete" \
 "CREATE TABLE t(id INT PRIMARY KEY, v INT);
 INSERT INTO t VALUES(1, 10), (2, 20);
@@ -551,9 +514,6 @@ SELECT dolt_merge('feature');
 SELECT CONCAT('R|', id, '|', v) FROM t ORDER BY id;"
 
 echo "--- insert/insert same PK ---"
-
-
-
 
 oracle "resolve_theirs_insert_insert_same_pk" \
 "CREATE TABLE t(id INT PRIMARY KEY, v INT);
@@ -595,8 +555,6 @@ SELECT CONCAT('R|', id, '|', v) FROM t ORDER BY id;"
 
 echo "--- wide schema (many non-PK columns) ---"
 
-
-
 oracle "resolve_theirs_wide_schema" \
 "CREATE TABLE t(id INT PRIMARY KEY, a VARCHAR(32), b INT, c DOUBLE, d VARCHAR(32), e INT);
 INSERT INTO t VALUES(1, 'a1', 11, 1.5, 'd1', 111);
@@ -618,7 +576,6 @@ SELECT dolt_merge('feature');
 SELECT CONCAT('R|', id, '|', a, '|', b, '|', c, '|', d, '|', e) FROM t ORDER BY id;"
 
 echo "--- NULL values in conflict rows ---"
-
 
 oracle "resolve_theirs_with_nulls" \
 "CREATE TABLE t(id INT PRIMARY KEY, v INT, note VARCHAR(32));

--- a/test/vc_oracle_conflicts_table_test.sh
+++ b/test/vc_oracle_conflicts_table_test.sh
@@ -1,26 +1,26 @@
 #!/bin/bash
-#
-# Version-control oracle test: dolt_conflicts_<table> (per-row schema)
-#
-# doltlite's dolt_conflicts_<table> vtable projects every user column
-# under three prefixes (base_, our_, their_) and emits our_diff_type /
-# their_diff_type classifications, matching Dolt's schema. This oracle
-# compares the resulting rows byte-for-byte against Dolt for a variety
-# of conflict scenarios and PK shapes.
-#
-# Columns NOT compared (because they diverge non-semantically):
-#   - from_root_ish  (doltlite emits NULL, Dolt emits a commit hash)
-#   - dolt_conflict_id (engines use different schemes)
-#
-# Compared: base_<col>, our_<col>, our_diff_type,
-#           their_<col>, their_diff_type
-#
-# Scenarios cover single-row modify, multi-row modify, different PK
-# shapes (INT, TEXT, composite), insert/insert conflicts, delete/modify
-# conflicts (both directions), and wide schemas.
-#
-# Usage: bash vc_oracle_conflicts_table_test.sh [path/to/doltlite] [path/to/dolt]
-#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 set -u
 set -o pipefail
@@ -37,15 +37,15 @@ normalize() {
   tr -d '\r' | sort
 }
 
-# $1=name, $2=setup SQL (runs on both engines), $3=comparison query
-# The comparison query must project rows prefixed with "R|" and use
-# CONCAT (works in both SQLite and MySQL for string concatenation).
+
+
+
 oracle() {
   local name="$1" setup="$2" query="$3"
   local dir="$TMPROOT/$name"
   mkdir -p "$dir/dl" "$dir/dt"
 
-  # -- doltlite --
+
   local dl_script
   local dl_out
   dl_script=$(printf "%s\n.headers off\n.mode list\n%s\n" "$setup" "$query" | perl -0pe "s/\nSELECT dolt_merge\\(/\nBEGIN;\\nSELECT dolt_merge\\(/")
@@ -54,9 +54,9 @@ oracle() {
            | grep '^R|' \
            | normalize)
 
-  # -- Dolt --
-  # Same scenario piped as a single `dolt sql` invocation so
-  # @@autocommit=0 and @@dolt_allow_commit_conflicts=1 persist.
+
+
+
   local dolt_all
   dolt_all=$(vc_oracle_translate_for_dolt "$(printf '%s\n%s' "$setup" "$query")")
 
@@ -172,9 +172,9 @@ SELECT dolt_merge('feat');
 
 echo "--- INTEGER PRIMARY KEY (rowid-aliased) ---"
 
-# INTEGER PK is the rowid-aliased shape where the PK is NOT stored in
-# the record body (it's the intKey). The projected column must come
-# from intKey, not from the record.
+
+
+
 oracle "integer_pk_single_row" \
 "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES(1,10);
@@ -247,9 +247,9 @@ SELECT dolt_merge('feat');
 
 echo "--- insert/insert same PK ---"
 
-# Both sides add a row with the same PK. base should be NULL (no
-# common ancestor for this row), diff types should be 'added' on
-# both sides.
+
+
+
 oracle "insert_insert_same_pk" \
 "CREATE TABLE t(id INT PRIMARY KEY, v INT);
 INSERT INTO t VALUES(1,10);
@@ -267,8 +267,8 @@ SELECT dolt_merge('feat');
 
 echo "--- delete/modify: main deletes, feature modifies ---"
 
-# main deletes row 1, feature modifies it. our side is "removed",
-# their side is "modified".
+
+
 oracle "main_delete_feat_modify" \
 "CREATE TABLE t(id INT PRIMARY KEY, v INT);
 INSERT INTO t VALUES(1,10),(2,20);

--- a/test/vc_oracle_conflicts_table_test.sh
+++ b/test/vc_oracle_conflicts_table_test.sh
@@ -1,27 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 set -u
 set -o pipefail
 
@@ -37,14 +15,10 @@ normalize() {
   tr -d '\r' | sort
 }
 
-
-
-
 oracle() {
   local name="$1" setup="$2" query="$3"
   local dir="$TMPROOT/$name"
   mkdir -p "$dir/dl" "$dir/dt"
-
 
   local dl_script
   local dl_out
@@ -53,9 +27,6 @@ oracle() {
            | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
            | grep '^R|' \
            | normalize)
-
-
-
 
   local dolt_all
   dolt_all=$(vc_oracle_translate_for_dolt "$(printf '%s\n%s' "$setup" "$query")")
@@ -172,9 +143,6 @@ SELECT dolt_merge('feat');
 
 echo "--- INTEGER PRIMARY KEY (rowid-aliased) ---"
 
-
-
-
 oracle "integer_pk_single_row" \
 "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES(1,10);
@@ -247,9 +215,6 @@ SELECT dolt_merge('feat');
 
 echo "--- insert/insert same PK ---"
 
-
-
-
 oracle "insert_insert_same_pk" \
 "CREATE TABLE t(id INT PRIMARY KEY, v INT);
 INSERT INTO t VALUES(1,10);
@@ -266,8 +231,6 @@ SELECT dolt_merge('feat');
 "SELECT CONCAT('R|', IFNULL(base_id,'NULL'), '|', IFNULL(base_v,'NULL'), '|', our_id, '|', our_v, '|', our_diff_type, '|', their_id, '|', their_v, '|', their_diff_type) FROM dolt_conflicts_t ORDER BY our_id;"
 
 echo "--- delete/modify: main deletes, feature modifies ---"
-
-
 
 oracle "main_delete_feat_modify" \
 "CREATE TABLE t(id INT PRIMARY KEY, v INT);

--- a/test/vc_oracle_conflicts_test.sh
+++ b/test/vc_oracle_conflicts_test.sh
@@ -1,33 +1,33 @@
 #!/bin/bash
-#
-# Version-control oracle test: dolt_conflicts (summary form)
-#
-# Runs identical merge-conflict scenarios against doltlite and Dolt and
-# compares the resulting dolt_conflicts post-state. Covers no conflicts,
-# single-table conflicts, multi-row conflicts, multi-table conflicts,
-# resolution with --ours / --theirs, partial resolution, and abort.
-#
-# Scenarios mostly use INTEGER PRIMARY KEY because conflict scenarios
-# modify the SAME row on both sides — the rowid-vs-PK distinction
-# doesn't matter for that case. The doltlite storage layer now keys
-# all user tables by their primary key columns, so non-INTEGER PK
-# shapes also produce correct conflict semantics; the merge oracle
-# exercises those.
-#
-# IMPORTANT: Dolt's autocommit mode rolls back the transaction when a
-# merge produces a conflict, so dolt_conflicts is empty by default. The
-# harness sets @@dolt_allow_commit_conflicts = 1 on the Dolt side before
-# running the scenario so the conflict survives long enough to query.
-# doltlite has no equivalent setting because it doesn't roll back.
-#
-# Compares only the summary `dolt_conflicts` vtable (rename of
-# table_name → table just landed in this PR). The per-table
-# `dolt_conflicts_<table>` vtable has a much larger schema gap with Dolt
-# (doltlite uses 6 generic blob columns while Dolt projects each user
-# column as base_/our_/their_), and is left as a separate follow-up.
-#
-# Usage: bash vc_oracle_conflicts_test.sh [path/to/doltlite] [path/to/dolt]
-#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 set -u
 set -o pipefail
@@ -50,17 +50,17 @@ oracle() {
   mkdir -p "$dir/dl" "$dir/dt"
   local dl_setup="$setup"
 
-  # DoltLite now rolls back autocommit merge conflicts, so scenarios that
-  # inspect live conflict summary must run in an explicit transaction on the
-  # DoltLite side only. Inject BEGIN before the final merge sequence while
-  # leaving the Dolt side unchanged.
+
+
+
+
   if printf '%s' "$setup" | grep -q "SELECT dolt_merge('"; then
     dl_setup=$(printf '%s' "$setup" | perl -0pe \
       "s/(SELECT dolt_merge\\('[^']+'\\);)(?!.*SELECT dolt_merge\\('[^']+'\\);)/BEGIN;\\n\$1/s")
   fi
 
-  # doltlite side: scenario as written. The vtable column "table" needs
-  # double-quote escaping in the SELECT.
+
+
   local dl_out
   dl_out=$(printf "%s\n.headers off\n.mode list\n.separator '\t'\nSELECT \"table\" || char(9) || num_conflicts FROM dolt_conflicts ORDER BY \"table\";\n" "$dl_setup" \
            | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
@@ -68,8 +68,8 @@ oracle() {
            | grep -v '^[0-9a-f]\{40\}$' \
            | normalize)
 
-  # Dolt side: rewrite SELECT dolt_*(...) -> CALL dolt_*(...) and prepend
-  # the autocommit override so the conflict state survives the merge.
+
+
   local dolt_setup
   dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
 

--- a/test/vc_oracle_conflicts_test.sh
+++ b/test/vc_oracle_conflicts_test.sh
@@ -1,34 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 set -u
 set -o pipefail
 
@@ -50,16 +21,10 @@ oracle() {
   mkdir -p "$dir/dl" "$dir/dt"
   local dl_setup="$setup"
 
-
-
-
-
   if printf '%s' "$setup" | grep -q "SELECT dolt_merge('"; then
     dl_setup=$(printf '%s' "$setup" | perl -0pe \
       "s/(SELECT dolt_merge\\('[^']+'\\);)(?!.*SELECT dolt_merge\\('[^']+'\\);)/BEGIN;\\n\$1/s")
   fi
-
-
 
   local dl_out
   dl_out=$(printf "%s\n.headers off\n.mode list\n.separator '\t'\nSELECT \"table\" || char(9) || num_conflicts FROM dolt_conflicts ORDER BY \"table\";\n" "$dl_setup" \
@@ -67,8 +32,6 @@ oracle() {
            | grep -v '^[0-9]*$' \
            | grep -v '^[0-9a-f]\{40\}$' \
            | normalize)
-
-
 
   local dolt_setup
   dolt_setup=$(vc_oracle_translate_for_dolt "$setup")

--- a/test/vc_oracle_connection_branch_test.sh
+++ b/test/vc_oracle_connection_branch_test.sh
@@ -1,19 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 set -u
 set -o pipefail
 

--- a/test/vc_oracle_connection_branch_test.sh
+++ b/test/vc_oracle_connection_branch_test.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
-#
-# Oracle test: connection-time branch selection.
-#
-# DoltLite selects a branch from the database path using either:
-#   db.sqlite@branch
-#   db.sqlite/branch
-# and defaults to main when no branch is specified.
-#
-# Dolt exposes the same branch-selection semantics as a global CLI flag:
-#   dolt --branch <branch> sql ...
-#
-# This oracle compares the resulting active_branch() and visible table
-# contents across both engines.
-#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 set -u
 set -o pipefail

--- a/test/vc_oracle_diff_multi_pk_test.sh
+++ b/test/vc_oracle_diff_multi_pk_test.sh
@@ -1,22 +1,22 @@
 #!/bin/bash
-#
-# Version-control oracle tests: diff surfaces on multi-column PKs
-#
-# Depth suite covering every dolt_diff* surface against tables with
-# compound primary keys, mixed-type keys, keys that are not the
-# leading declared columns, and keys that are reordered relative to
-# declaration. These are the shapes that previously surfaced a
-# rowid-alias detection bug; this harness makes sure no surface
-# regresses silently.
-#
-# Oracle target: real Dolt 1.83.5. For each scenario the harness
-# runs identical setup SQL on both engines and compares tagged
-# output lines. Commit metadata is excluded from comparisons (hashes
-# and timestamps differ by engine); PK values, non-PK values,
-# diff_type, and row/cell counts are the comparison keys.
-#
-# Usage: bash vc_oracle_diff_multi_pk_test.sh [path/to/doltlite] [path/to/dolt]
-#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 set -u
 
@@ -27,12 +27,12 @@ trap "rm -rf $TMPROOT" EXIT
 pass=0; fail=0
 FAILED_NAMES=""
 
-# doltlite uses `SELECT dolt_*()` for procedure-style calls and
-# `dolt_diff_<t>(...)` for the per-table slice TVF. Dolt uses `CALL
-# dolt_*()` and `dolt_diff(..., '<t>')`. Translate only the per-table
-# slice form, not dolt_diff_stat / dolt_diff_summary which share the
-# dolt_diff_ prefix but are commit-range TVFs with identical signatures
-# on both engines.
+
+
+
+
+
+
 translate_for_dolt() {
   sed -E '
     s/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g
@@ -82,11 +82,11 @@ oracle() {
 echo "=== Version Control Oracle Tests: multi-col PK diff ==="
 echo ""
 
-# ---------------------------------------------------------------
-# Group A: Two-column INT PK — insert / update-nonpk / delete.
-# Hits dolt_diff_<t> (full history), dolt_diff_<t>(from,to) slice
-# TVF, and dolt_diff summary.
-# ---------------------------------------------------------------
+
+
+
+
+
 
 SETUP_A="
 CREATE TABLE t(a INTEGER, b INTEGER, v TEXT, PRIMARY KEY(a, b));
@@ -109,13 +109,13 @@ oracle "a_slice_one" "$SETUP_A" \
 oracle "a_slice_full" "$SETUP_A" \
   "SELECT CONCAT('R|', IFNULL(to_a,''), '|', IFNULL(to_b,''), '|', IFNULL(to_v,''), '|', IFNULL(from_a,''), '|', IFNULL(from_b,''), '|', IFNULL(from_v,''), '|', diff_type) FROM dolt_diff_t('HEAD~2', 'HEAD');"
 
-# Summary: one row per (commit, table). Compare table_name + change flags joined on message.
+
 oracle "a_summary" "$SETUP_A" \
   "SELECT CONCAT('R|', dd.table_name, '|', coalesce(dl.message, dd.commit_hash), '|', dd.data_change, '|', dd.schema_change) FROM dolt_diff dd LEFT JOIN dolt_log dl ON dl.commit_hash = dd.commit_hash WHERE dd.table_name = 't';"
 
-# ---------------------------------------------------------------
-# Group B: Two-column PK with PK-column UPDATE (= delete + add).
-# ---------------------------------------------------------------
+
+
+
 
 echo "--- Group B: PK-column UPDATE ---"
 
@@ -135,11 +135,11 @@ UPDATE t SET a = 99 WHERE a = 1 AND b = 1;
 SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'move_pk');
 " "SELECT CONCAT('R|', IFNULL(to_a,''), '|', IFNULL(to_b,''), '|', IFNULL(to_v,''), '|', IFNULL(from_a,''), '|', IFNULL(from_b,''), '|', IFNULL(from_v,''), '|', diff_type) FROM dolt_diff_t;"
 
-# ---------------------------------------------------------------
-# Group C: PK columns not in the first declared positions.
-# PRAGMA table_info order differs from the PK positions, which
-# has historically broken both projection and sortkey encoding.
-# ---------------------------------------------------------------
+
+
+
+
+
 
 echo "--- Group C: PK cols not at the front of the declaration ---"
 
@@ -152,7 +152,7 @@ UPDATE t SET v = 'TWO' WHERE a = 1 AND b = 2;
 SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'c2');
 " "SELECT CONCAT('R|', IFNULL(to_a,''), '|', IFNULL(to_b,''), '|', IFNULL(to_v,''), '|', IFNULL(from_a,''), '|', IFNULL(from_b,''), '|', IFNULL(from_v,''), '|', diff_type) FROM dolt_diff_t('HEAD~1', 'HEAD');"
 
-# PK declared in REVERSE order vs physical column position.
+
 oracle "c_pk_reversed" "
 CREATE TABLE t(a INTEGER, b INTEGER, v TEXT, PRIMARY KEY(b, a));
 INSERT INTO t VALUES (1, 10, 'one'), (2, 20, 'two');
@@ -161,9 +161,9 @@ UPDATE t SET v = 'TWO' WHERE a = 2 AND b = 20;
 SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'c2');
 " "SELECT CONCAT('R|', IFNULL(to_a,''), '|', IFNULL(to_b,''), '|', IFNULL(to_v,''), '|', IFNULL(from_a,''), '|', IFNULL(from_b,''), '|', IFNULL(from_v,''), '|', diff_type) FROM dolt_diff_t('HEAD~1', 'HEAD');"
 
-# ---------------------------------------------------------------
-# Group D: Three-column compound PK.
-# ---------------------------------------------------------------
+
+
+
 
 echo "--- Group D: three-col PK ---"
 
@@ -185,10 +185,10 @@ UPDATE t SET v = 'ALPHA' WHERE a = 1 AND b = 1 AND c = 10;
 SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'c2');
 " "SELECT CONCAT('R|', IFNULL(to_a,''), '|', IFNULL(to_b,''), '|', IFNULL(to_c,''), '|', IFNULL(to_v,''), '|', IFNULL(from_a,''), '|', IFNULL(from_b,''), '|', IFNULL(from_c,''), '|', IFNULL(from_v,''), '|', diff_type) FROM dolt_diff_t;"
 
-# ---------------------------------------------------------------
-# Group E: Mixed-type PKs. VARCHAR in PK is accepted by both
-# engines (Dolt needs an explicit length; SQLite is flexible).
-# ---------------------------------------------------------------
+
+
+
+
 
 echo "--- Group E: mixed-type PKs ---"
 
@@ -209,12 +209,12 @@ UPDATE t SET v = 'BAR' WHERE id = 1 AND tag = 'y';
 SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'c2');
 " "SELECT CONCAT('R|', IFNULL(to_id,''), '|', IFNULL(to_tag,''), '|', IFNULL(to_v,''), '|', IFNULL(from_id,''), '|', IFNULL(from_tag,''), '|', IFNULL(from_v,''), '|', diff_type) FROM dolt_diff_t('HEAD~1', 'HEAD');"
 
-# ---------------------------------------------------------------
-# Group F: dolt_diff_stat row/cell counts on multi-col PK tables.
-# If PK column projection is broken, stat counts can still be
-# right (stat counts rows, not columns), but cell math depends on
-# the correct column total for the table.
-# ---------------------------------------------------------------
+
+
+
+
+
+
 
 echo "--- Group F: dolt_diff_stat on multi-col PK ---"
 
@@ -235,11 +235,11 @@ UPDATE t SET b = 99 WHERE a = 1 AND b = 2;
 SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'pk_update');
 " "SELECT CONCAT('R|', table_name, '|', rows_added, '|', rows_deleted, '|', rows_modified) FROM dolt_diff_stat('HEAD~1', 'HEAD', 't');"
 
-# ---------------------------------------------------------------
-# Group G: dolt_blame_<t> on a compound-PK table. Blame projects
-# the PK columns separately from the record payload, so it
-# exercises the same rowid-alias detection path.
-# ---------------------------------------------------------------
+
+
+
+
+
 
 echo "--- Group G: dolt_blame on multi-col PK ---"
 
@@ -253,17 +253,17 @@ INSERT INTO t VALUES (2, 1, 'three');
 SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'c3');
 " "SELECT CONCAT('R|', a, '|', b, '|', message) FROM dolt_blame_t ORDER BY a, b;"
 
-# ---------------------------------------------------------------
-# Group H: ALTER TABLE on a table with PK cols not leading the
-# declaration. Exercises the schema-only filter in
-# changeIsSchemaOnly(): MODIFY rows emitted by the prolly diff
-# when two commits have different schemas must be compared by
-# the actual record-field layout (PK-first in WITHOUT ROWID),
-# not by the declared-column index. Dropping a middle non-PK
-# column whose only value was NULL should be schema-only on
-# both engines, meaning dolt_diff_t('HEAD~1','HEAD') emits 0
-# rows for the surviving row.
-# ---------------------------------------------------------------
+
+
+
+
+
+
+
+
+
+
+
 
 echo "--- Group H: ALTER on non-leading-PK table (schema-only filter) ---"
 
@@ -275,11 +275,11 @@ ALTER TABLE t DROP COLUMN c;
 SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'drop_c');
 " "SELECT CONCAT('R|', IFNULL(to_v,''), '|', IFNULL(to_a,''), '|', IFNULL(to_b,''), '|', IFNULL(from_v,''), '|', IFNULL(from_a,''), '|', IFNULL(from_b,''), '|', diff_type) FROM dolt_diff_t('HEAD~1', 'HEAD');"
 
-# ADD COLUMN on a non-leading-PK table. Schema-only change; no
-# rows should appear in the per-table diff slice. Same shape as
-# the PK-leading test in vc_oracle_diff_test.sh, but with v in
-# front of the PK cols so the record layout no longer matches
-# the declared layout.
+
+
+
+
+
 oracle "h_add_col_nonleading_pk_no_data" "
 CREATE TABLE t(v INT, a INTEGER, b INTEGER, PRIMARY KEY(a, b));
 INSERT INTO t(v, a, b) VALUES (10, 1, 2);
@@ -342,10 +342,10 @@ SELECT dolt_checkout('feat');
 SELECT dolt_rebase('main');
 " "SELECT CONCAT('R|', to_a, '|', to_b, '|', to_v, '|', IFNULL(from_a,''), '|', IFNULL(from_b,''), '|', IFNULL(from_v,''), '|', diff_type) FROM dolt_diff_u('main', 'feat') ORDER BY to_a, to_b;"
 
-# ---------------------------------------------------------------
-# Group J: replay of an added multi-PK table through merge,
-# cherry-pick, and rebase for diff-stat / diff-summary surfaces.
-# ---------------------------------------------------------------
+
+
+
+
 
 echo "--- Group J: replay on multi-col PK stat/summary ---"
 
@@ -453,11 +453,11 @@ SELECT dolt_checkout('feat');
 SELECT dolt_rebase('main');
 " "SELECT CONCAT('R|', IFNULL(from_table_name,''), '|', IFNULL(to_table_name,''), '|', diff_type, '|', CASE WHEN data_change THEN 1 ELSE 0 END, '|', CASE WHEN schema_change THEN 1 ELSE 0 END) FROM dolt_diff_summary('main', 'feat', 'u');"
 
-# ---------------------------------------------------------------
-# Group K: replay history for a replayed added multi-PK table.
-# This covers dolt_history_<table> for the same schema-replay
-# shapes as the diff / blame hardening work.
-# ---------------------------------------------------------------
+
+
+
+
+
 
 echo "--- Group K: replay history on multi-col PK table additions ---"
 

--- a/test/vc_oracle_diff_multi_pk_test.sh
+++ b/test/vc_oracle_diff_multi_pk_test.sh
@@ -1,23 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 set -u
 
 DOLTLITE="${1:-./doltlite}"
@@ -26,12 +8,6 @@ TMPROOT=$(mktemp -d)
 trap "rm -rf $TMPROOT" EXIT
 pass=0; fail=0
 FAILED_NAMES=""
-
-
-
-
-
-
 
 translate_for_dolt() {
   sed -E '
@@ -82,12 +58,6 @@ oracle() {
 echo "=== Version Control Oracle Tests: multi-col PK diff ==="
 echo ""
 
-
-
-
-
-
-
 SETUP_A="
 CREATE TABLE t(a INTEGER, b INTEGER, v TEXT, PRIMARY KEY(a, b));
 INSERT INTO t VALUES (1, 1, 'one'), (1, 2, 'two'), (2, 1, 'three');
@@ -109,13 +79,8 @@ oracle "a_slice_one" "$SETUP_A" \
 oracle "a_slice_full" "$SETUP_A" \
   "SELECT CONCAT('R|', IFNULL(to_a,''), '|', IFNULL(to_b,''), '|', IFNULL(to_v,''), '|', IFNULL(from_a,''), '|', IFNULL(from_b,''), '|', IFNULL(from_v,''), '|', diff_type) FROM dolt_diff_t('HEAD~2', 'HEAD');"
 
-
 oracle "a_summary" "$SETUP_A" \
   "SELECT CONCAT('R|', dd.table_name, '|', coalesce(dl.message, dd.commit_hash), '|', dd.data_change, '|', dd.schema_change) FROM dolt_diff dd LEFT JOIN dolt_log dl ON dl.commit_hash = dd.commit_hash WHERE dd.table_name = 't';"
-
-
-
-
 
 echo "--- Group B: PK-column UPDATE ---"
 
@@ -135,12 +100,6 @@ UPDATE t SET a = 99 WHERE a = 1 AND b = 1;
 SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'move_pk');
 " "SELECT CONCAT('R|', IFNULL(to_a,''), '|', IFNULL(to_b,''), '|', IFNULL(to_v,''), '|', IFNULL(from_a,''), '|', IFNULL(from_b,''), '|', IFNULL(from_v,''), '|', diff_type) FROM dolt_diff_t;"
 
-
-
-
-
-
-
 echo "--- Group C: PK cols not at the front of the declaration ---"
 
 oracle "c_pk_after_nonpk" "
@@ -152,7 +111,6 @@ UPDATE t SET v = 'TWO' WHERE a = 1 AND b = 2;
 SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'c2');
 " "SELECT CONCAT('R|', IFNULL(to_a,''), '|', IFNULL(to_b,''), '|', IFNULL(to_v,''), '|', IFNULL(from_a,''), '|', IFNULL(from_b,''), '|', IFNULL(from_v,''), '|', diff_type) FROM dolt_diff_t('HEAD~1', 'HEAD');"
 
-
 oracle "c_pk_reversed" "
 CREATE TABLE t(a INTEGER, b INTEGER, v TEXT, PRIMARY KEY(b, a));
 INSERT INTO t VALUES (1, 10, 'one'), (2, 20, 'two');
@@ -160,10 +118,6 @@ SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'seed');
 UPDATE t SET v = 'TWO' WHERE a = 2 AND b = 20;
 SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'c2');
 " "SELECT CONCAT('R|', IFNULL(to_a,''), '|', IFNULL(to_b,''), '|', IFNULL(to_v,''), '|', IFNULL(from_a,''), '|', IFNULL(from_b,''), '|', IFNULL(from_v,''), '|', diff_type) FROM dolt_diff_t('HEAD~1', 'HEAD');"
-
-
-
-
 
 echo "--- Group D: three-col PK ---"
 
@@ -185,11 +139,6 @@ UPDATE t SET v = 'ALPHA' WHERE a = 1 AND b = 1 AND c = 10;
 SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'c2');
 " "SELECT CONCAT('R|', IFNULL(to_a,''), '|', IFNULL(to_b,''), '|', IFNULL(to_c,''), '|', IFNULL(to_v,''), '|', IFNULL(from_a,''), '|', IFNULL(from_b,''), '|', IFNULL(from_c,''), '|', IFNULL(from_v,''), '|', diff_type) FROM dolt_diff_t;"
 
-
-
-
-
-
 echo "--- Group E: mixed-type PKs ---"
 
 oracle "e_text_int_pk" "
@@ -208,13 +157,6 @@ SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'seed');
 UPDATE t SET v = 'BAR' WHERE id = 1 AND tag = 'y';
 SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'c2');
 " "SELECT CONCAT('R|', IFNULL(to_id,''), '|', IFNULL(to_tag,''), '|', IFNULL(to_v,''), '|', IFNULL(from_id,''), '|', IFNULL(from_tag,''), '|', IFNULL(from_v,''), '|', diff_type) FROM dolt_diff_t('HEAD~1', 'HEAD');"
-
-
-
-
-
-
-
 
 echo "--- Group F: dolt_diff_stat on multi-col PK ---"
 
@@ -235,12 +177,6 @@ UPDATE t SET b = 99 WHERE a = 1 AND b = 2;
 SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'pk_update');
 " "SELECT CONCAT('R|', table_name, '|', rows_added, '|', rows_deleted, '|', rows_modified) FROM dolt_diff_stat('HEAD~1', 'HEAD', 't');"
 
-
-
-
-
-
-
 echo "--- Group G: dolt_blame on multi-col PK ---"
 
 oracle "g_blame_multi_pk" "
@@ -253,18 +189,6 @@ INSERT INTO t VALUES (2, 1, 'three');
 SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'c3');
 " "SELECT CONCAT('R|', a, '|', b, '|', message) FROM dolt_blame_t ORDER BY a, b;"
 
-
-
-
-
-
-
-
-
-
-
-
-
 echo "--- Group H: ALTER on non-leading-PK table (schema-only filter) ---"
 
 oracle "h_drop_middle_nonpk_nonleading_pk" "
@@ -274,11 +198,6 @@ SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'seed');
 ALTER TABLE t DROP COLUMN c;
 SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'drop_c');
 " "SELECT CONCAT('R|', IFNULL(to_v,''), '|', IFNULL(to_a,''), '|', IFNULL(to_b,''), '|', IFNULL(from_v,''), '|', IFNULL(from_a,''), '|', IFNULL(from_b,''), '|', diff_type) FROM dolt_diff_t('HEAD~1', 'HEAD');"
-
-
-
-
-
 
 oracle "h_add_col_nonleading_pk_no_data" "
 CREATE TABLE t(v INT, a INTEGER, b INTEGER, PRIMARY KEY(a, b));
@@ -341,11 +260,6 @@ SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'main_check');
 SELECT dolt_checkout('feat');
 SELECT dolt_rebase('main');
 " "SELECT CONCAT('R|', to_a, '|', to_b, '|', to_v, '|', IFNULL(from_a,''), '|', IFNULL(from_b,''), '|', IFNULL(from_v,''), '|', diff_type) FROM dolt_diff_u('main', 'feat') ORDER BY to_a, to_b;"
-
-
-
-
-
 
 echo "--- Group J: replay on multi-col PK stat/summary ---"
 
@@ -452,12 +366,6 @@ SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'main_check');
 SELECT dolt_checkout('feat');
 SELECT dolt_rebase('main');
 " "SELECT CONCAT('R|', IFNULL(from_table_name,''), '|', IFNULL(to_table_name,''), '|', diff_type, '|', CASE WHEN data_change THEN 1 ELSE 0 END, '|', CASE WHEN schema_change THEN 1 ELSE 0 END) FROM dolt_diff_summary('main', 'feat', 'u');"
-
-
-
-
-
-
 
 echo "--- Group K: replay history on multi-col PK table additions ---"
 

--- a/test/vc_oracle_diff_stat_test.sh
+++ b/test/vc_oracle_diff_stat_test.sh
@@ -1,30 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 set -u
 set -o pipefail
 
@@ -49,9 +24,6 @@ normalize_summary() {
     | awk -F'\t' 'NF >= 5 && $1 == "M" { print }' \
     | sort
 }
-
-
-
 
 oracle_stat() {
   local name="$1" setup="$2" from="$3" to="$4" tbl="${5:-}"
@@ -93,7 +65,6 @@ oracle_stat() {
   fi
 }
 
-
 oracle_summary() {
   local name="$1" setup="$2" from="$3" to="$4" tbl="${5:-}"
   local dir="$TMPROOT/${name}_summary"
@@ -133,8 +104,6 @@ oracle_summary() {
     echo "    dolt:";     echo "$dt_out" | sed 's/^/      /'
   fi
 }
-
-
 
 oracle_both() {
   oracle_stat    "$@"

--- a/test/vc_oracle_diff_stat_test.sh
+++ b/test/vc_oracle_diff_stat_test.sh
@@ -1,29 +1,29 @@
 #!/bin/bash
-#
-# Version-control oracle test: dolt_diff_stat and dolt_diff_summary
-#
-# Compares doltlite's two new TVFs against Dolt 1.86.0+ across a
-# range of scenarios:
-#
-#   dolt_diff_stat(from, to [, table])
-#     table_name, rows_unmodified, rows_added, rows_deleted,
-#     rows_modified, cells_added, cells_deleted, cells_modified,
-#     old_row_count, new_row_count, old_cell_count, new_cell_count
-#
-#   dolt_diff_summary(from, to [, table])
-#     from_table_name, to_table_name, diff_type, data_change,
-#     schema_change
-#
-# Both TVFs take (from_ref, to_ref) with an optional third argument
-# to filter to a single table. Refs resolve via the same rules as
-# dolt_log (hash, branch name, HEAD~N, etc.).
-#
-# Normalization: Dolt emits data_change/schema_change as 'true'/'false';
-# doltlite emits 1/0. Both are mapped to 0/1 for comparison. Rows are
-# sorted for order-independence.
-#
-# Usage: bash vc_oracle_diff_stat_test.sh [path/to/doltlite] [path/to/dolt]
-#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 set -u
 set -o pipefail
@@ -50,9 +50,9 @@ normalize_summary() {
     | sort
 }
 
-# Oracle for dolt_diff_stat over a commit range. The setup creates
-# whatever history is needed; the query is run in a single engine
-# invocation with the setup so refs like HEAD~N resolve correctly.
+
+
+
 oracle_stat() {
   local name="$1" setup="$2" from="$3" to="$4" tbl="${5:-}"
   local dir="$TMPROOT/${name}_stat"
@@ -93,7 +93,7 @@ oracle_stat() {
   fi
 }
 
-# Oracle for dolt_diff_summary.
+
 oracle_summary() {
   local name="$1" setup="$2" from="$3" to="$4" tbl="${5:-}"
   local dir="$TMPROOT/${name}_summary"
@@ -134,8 +134,8 @@ oracle_summary() {
   fi
 }
 
-# Convenience: run BOTH stat and summary oracles against the same
-# setup and commit range.
+
+
 oracle_both() {
   oracle_stat    "$@"
   oracle_summary "$@"

--- a/test/vc_oracle_diff_test.sh
+++ b/test/vc_oracle_diff_test.sh
@@ -1,30 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 set -u
 set -o pipefail
 
@@ -37,12 +12,6 @@ FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
 normalize_diff_table() {
-
-
-
-
-
-
   tr -d '\r' \
     | awk -F'\t' 'NF >= 7 && $1 == "T" { print }' \
     | awk -F'\t' '
@@ -66,25 +35,6 @@ oracle() {
   local dir="$TMPROOT/$name"
   mkdir -p "$dir/dl" "$dir/dt"
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
   local dl_table_q=""
   IFS=',' read -ra tarr <<< "$tables"
   for tn in "${tarr[@]}"; do
@@ -102,7 +52,6 @@ oracle() {
              | grep -v '^[0-9]*$' \
              | grep -v '^[0-9a-f]\{40\}$' \
              | normalize_diff_table)
-
 
   local dolt_setup
   dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
@@ -127,7 +76,6 @@ oracle() {
     } | "$DOLT" sql -c -r csv 2>"$dir/dt.err" | tr -d '"' | normalize_diff_table
   )
 
-
   if [ -z "$dl_table" ] && [ -z "$dt_table" ]; then
     fail=$((fail+1))
     FAILED_NAMES="$FAILED_NAMES $name"
@@ -146,9 +94,6 @@ oracle() {
   fi
 }
 
-
-
-
 normalize_summary() {
   tr -d '\r' \
     | sed -e 's/	true$/	1/' -e 's/	true	/	1	/g' \
@@ -163,19 +108,10 @@ normalize_summary() {
     | sort
 }
 
-
-
-
-
-
 oracle_summary() {
   local name="$1" setup="$2"
   local dir="$TMPROOT/${name}_summary"
   mkdir -p "$dir/dl" "$dir/dt"
-
-
-
-
 
   local q="SELECT 'S' || char(9) || dd.table_name || char(9) || coalesce(dl.message, dd.commit_hash) || char(9) || dd.data_change || char(9) || dd.schema_change FROM dolt_diff dd LEFT JOIN dolt_log dl ON dl.commit_hash = dd.commit_hash"
   local q_dolt="SELECT concat('S', char(9), dd.table_name, char(9), coalesce(dl.message, dd.commit_hash), char(9), dd.data_change, char(9), dd.schema_change) FROM dolt_diff dd LEFT JOIN dolt_log dl ON dl.commit_hash = dd.commit_hash"
@@ -215,14 +151,6 @@ oracle_summary() {
     echo "    dolt:";     echo "$dt_out" | sed 's/^/      /'
   fi
 }
-
-
-
-
-
-
-
-
 
 oracle_summary_filter_name() {
   local name="$1" setup="$2" target="$3"
@@ -326,19 +254,11 @@ SELECT dolt_commit('-m', 'c4_delete');
 
 echo "--- staged state interactions ---"
 
-
-
-
-
-
 oracle "table_diff_after_stage_only" "
 $SEED
 UPDATE t SET v = 99 WHERE id = 1;
 SELECT dolt_add('-A');
 "
-
-
-
 
 oracle "table_diff_stage_then_more_working" "
 $SEED
@@ -347,13 +267,11 @@ SELECT dolt_add('-A');
 UPDATE t SET v = 99 WHERE id = 1;
 "
 
-
 oracle "table_diff_stage_insert" "
 $SEED
 INSERT INTO t VALUES (2, 20);
 SELECT dolt_add('-A');
 "
-
 
 oracle "table_diff_stage_delete" "
 $SEED
@@ -364,8 +282,6 @@ DELETE FROM t WHERE id = 2;
 SELECT dolt_add('-A');
 "
 
-
-
 oracle "table_diff_mixed_staged_and_unstaged" "
 $SEED
 INSERT INTO t VALUES (2, 20);
@@ -374,8 +290,6 @@ INSERT INTO t VALUES (3, 30);
 "
 
 echo "--- working set diff ---"
-
-
 
 oracle "table_diff_working_modify" "
 $SEED
@@ -392,15 +306,12 @@ $SEED
 DELETE FROM t WHERE id = 1;
 "
 
-
-
 oracle "table_diff_working_then_committed" "
 $SEED
 UPDATE t SET v = 99 WHERE id = 1;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c2');
 "
-
 
 oracle "table_diff_history_plus_working" "
 $SEED
@@ -412,7 +323,6 @@ UPDATE t SET v = 99 WHERE id = 1;
 
 echo "--- branching ---"
 
-
 oracle "diff_on_feature_branch" "
 $SEED
 SELECT dolt_branch('feature');
@@ -423,12 +333,6 @@ SELECT dolt_commit('-m', 'feat1');
 "
 
 echo "--- merges ---"
-
-
-
-
-
-
 
 oracle "diff_after_simple_merge" "
 $SEED
@@ -443,12 +347,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'main2');
 SELECT dolt_merge('feature');
 "
-
-
-
-
-
-
 
 oracle "diff_after_merge_with_intermediate_commits" "
 $SEED
@@ -466,10 +364,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'main3');
 SELECT dolt_merge('feature');
 "
-
-
-
-
 
 oracle "diff_after_merge_no_main_changes_after_branch" "
 $SEED
@@ -490,18 +384,12 @@ SELECT dolt_merge('feature');
 
 echo "--- DDL across commits (ALTER TABLE in history) ---"
 
-
-
-
 oracle "diff_alter_add_col_no_data_change" "
 $SEED
 ALTER TABLE t ADD COLUMN extra INT;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'add_col_only');
 "
-
-
-
 
 oracle "diff_alter_add_col_then_update_old_col" "
 $SEED
@@ -513,9 +401,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'update_v');
 "
 
-
-
-
 oracle "diff_alter_add_col_then_update_new_col" "
 $SEED
 ALTER TABLE t ADD COLUMN extra INT;
@@ -526,8 +411,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'populate_extra');
 "
 
-
-
 oracle "diff_alter_add_col_plus_insert_same_commit" "
 $SEED
 ALTER TABLE t ADD COLUMN extra INT;
@@ -535,7 +418,6 @@ INSERT INTO t VALUES (2, 20, 200);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'add_col_and_insert');
 "
-
 
 oracle "diff_alter_add_col_then_insert_next_commit" "
 $SEED
@@ -546,8 +428,6 @@ INSERT INTO t VALUES (2, 20, 200);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'insert_after_alter');
 "
-
-
 
 oracle "diff_alter_add_col_then_delete_next_commit" "
 $SEED
@@ -562,12 +442,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'drop_row');
 "
 
-
-
-
-
-
-
 oracle "diff_alter_drop_col_no_data_change" "
 $SEED
 ALTER TABLE t ADD COLUMN extra INT;
@@ -577,9 +451,6 @@ ALTER TABLE t DROP COLUMN extra;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'drop_extra');
 "
-
-
-
 
 oracle "diff_alter_drop_col_with_data_also_shared_match" "
 $SEED
@@ -592,17 +463,12 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'drop_extra');
 "
 
-
-
-
 oracle "diff_alter_rename_col_no_data_change" "
 $SEED
 ALTER TABLE t RENAME COLUMN v TO vv;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'rename_v');
 "
-
-
 
 oracle "diff_multiple_alters_single_commit_no_data" "
 $SEED
@@ -611,9 +477,6 @@ ALTER TABLE t ADD COLUMN b INT;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'multi_alter');
 "
-
-
-
 
 oracle "diff_alter_then_merge" "
 $SEED
@@ -631,9 +494,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'main_add_col');
 SELECT dolt_merge('feature');
 "
-
-
-
 
 oracle "diff_schema_replay_after_merge_add_table_plus_check" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
@@ -656,8 +516,6 @@ SELECT dolt_commit('-m', 'main_check');
 SELECT dolt_merge('feature');
 " "u"
 
-
-
 oracle "diff_schema_replay_after_cherrypick_add_table_plus_check" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
@@ -678,9 +536,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'main_check');
 SELECT dolt_cherry_pick('feature');
 " "u"
-
-
-
 
 oracle "diff_schema_replay_after_rebase_disjoint_indexes" "
 CREATE TABLE a(id INTEGER PRIMARY KEY, v INT);
@@ -770,15 +625,10 @@ SELECT dolt_checkout('feature');
 SELECT dolt_rebase('main');
 " "c"
 
-
-
 oracle "diff_alter_add_col_working_set_only" "
 $SEED
 ALTER TABLE t ADD COLUMN extra INT;
 "
-
-
-
 
 oracle "diff_alter_add_col_and_update_working_set" "
 $SEED
@@ -789,16 +639,12 @@ UPDATE t SET extra = 42 WHERE id = 1;
 echo ""
 echo "--- summary form: dolt_diff (no args) ---"
 
-
-
-
 oracle_summary "summary_two_commits_one_table" "
 $SEED
 UPDATE t SET v = 99 WHERE id = 1;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c2');
 "
-
 
 oracle_summary "summary_linear_three_commits" "
 $SEED
@@ -812,8 +658,6 @@ DELETE FROM t WHERE id = 2;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c4_delete');
 "
-
-
 
 oracle_summary "summary_two_tables_independent" "
 CREATE TABLE t(id INT PRIMARY KEY, v INT);
@@ -830,14 +674,12 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'modify_u_only');
 "
 
-
 oracle_summary "summary_schema_change_add_column" "
 $SEED
 ALTER TABLE t ADD COLUMN extra TEXT;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'add_col');
 "
-
 
 oracle_summary "summary_data_and_schema_in_one_commit" "
 $SEED
@@ -847,7 +689,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'col_and_row');
 "
 
-
 oracle_summary "summary_table_added_later" "
 $SEED
 CREATE TABLE u(id INT PRIMARY KEY, x TEXT);
@@ -856,17 +697,10 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'add_u');
 "
 
-
-
-
 oracle_summary "summary_working_set_excluded" "
 $SEED
 UPDATE t SET v = 99 WHERE id = 1;
 "
-
-
-
-
 
 oracle_summary "summary_merge_replay_add_table_plus_check" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -1016,10 +850,6 @@ SELECT dolt_revert((SELECT commit_hash FROM dolt_log WHERE message='main_check' 
 
 echo "--- summary form: WHERE table_name=... filter ---"
 
-
-
-
-
 oracle_summary_filter_name "filter_dropped_table" "
 CREATE TABLE dropped(id INT PRIMARY KEY, v INT);
 INSERT INTO dropped VALUES(1, 10);
@@ -1033,17 +863,12 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c3_drop_dropped');
 " "dropped"
 
-
 oracle_summary_filter_name "filter_nonexistent_name" "
 $SEED
 INSERT INTO t VALUES (2, 20);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c2');
 " "never_existed"
-
-
-
-
 
 oracle_summary_filter_name "filter_mixed_history" "
 CREATE TABLE x(id INT PRIMARY KEY, v INT);

--- a/test/vc_oracle_diff_test.sh
+++ b/test/vc_oracle_diff_test.sh
@@ -1,29 +1,29 @@
 #!/bin/bash
-#
-# Version-control oracle tests: dolt_diff_<table> AND dolt_diff
-#
-# Two surfaces are tested here:
-#
-# 1. dolt_diff_<table> (per-table row-level diff history)
-#    Schema layout (matches Dolt):
-#      to_<col1>, ..., to_<colN>, to_commit, to_commit_date,
-#      from_<col1>, ..., from_<colN>, from_commit, from_commit_date,
-#      diff_type
-#    The harness LEFT JOINs dolt_log on to_commit and from_commit so
-#    the comparison uses commit MESSAGES (stable across engines)
-#    instead of engine-specific commit hashes.
-#
-# 2. dolt_diff no-arg vtable (commits-touching-tables summary)
-#    One row per (commit, changed_table). Dolt-compatible columns:
-#      commit_hash, table_name, committer, email, date, message,
-#      data_change, schema_change
-#    Compared on (table_name, message, data_change, schema_change),
-#    sorted, with engine-specific hashes/timestamps stripped. Note
-#    that doltlite's dolt_diff is summary-only; row-level history is
-#    exposed separately through `dolt_diff_<table>`.
-#
-# Usage: bash vc_oracle_diff_test.sh [path/to/doltlite] [path/to/dolt]
-#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 set -u
 set -o pipefail
@@ -37,12 +37,12 @@ FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
 normalize_diff_table() {
-  # Input row schema (built by the harness query):
-  #   $1=T, $2=table_name, $3=to_id, $4=to_msg, $5=diff_type,
-  #   $6=from_id, $7=from_msg
-  # to_msg / from_msg are commit messages (via LEFT JOIN with
-  # dolt_log) so the comparison is engine-independent. WORKING and
-  # EMPTY tokens are preserved verbatim.
+
+
+
+
+
+
   tr -d '\r' \
     | awk -F'\t' 'NF >= 7 && $1 == "T" { print }' \
     | awk -F'\t' '
@@ -66,25 +66,25 @@ oracle() {
   local dir="$TMPROOT/$name"
   mkdir -p "$dir/dl" "$dir/dt"
 
-  # Build the per-table query as a UNION ALL across all named
-  # tables. The whole thing — setup + summary + per-table — runs
-  # in a SINGLE engine invocation so the session state at the
-  # end of setup (current branch, working set) is preserved
-  # through to the queries. Splitting into multiple invocations
-  # caused two bugs in earlier iterations:
-  #   1. Each Dolt re-open landed on the default branch, losing
-  #      the setup's `dolt_checkout('feature')` and so missing
-  #      feature-only commits in dolt_diff.
-  #   2. Dolt's commit hashes have a non-deterministic component,
-  #      so running the same setup twice (once for table t, once
-  #      for table u) produced different hashes for the same
-  #      logical commit, breaking the harness's hash-renaming.
 
-  # ── doltlite query ──
-  # Per-table query LEFT JOINs dolt_log on both to_commit and
-  # from_commit so the comparison uses the COMMIT MESSAGE instead
-  # of the engine-specific hash. WORKING and EMPTY tokens that
-  # aren't real commits coalesce to themselves.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
   local dl_table_q=""
   IFS=',' read -ra tarr <<< "$tables"
   for tn in "${tarr[@]}"; do
@@ -103,7 +103,7 @@ oracle() {
              | grep -v '^[0-9a-f]\{40\}$' \
              | normalize_diff_table)
 
-  # ── Dolt query ──
+
   local dolt_setup
   dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
 
@@ -127,7 +127,7 @@ oracle() {
     } | "$DOLT" sql -c -r csv 2>"$dir/dt.err" | tr -d '"' | normalize_diff_table
   )
 
-  # Empty-on-both-sides safeguard.
+
   if [ -z "$dl_table" ] && [ -z "$dt_table" ]; then
     fail=$((fail+1))
     FAILED_NAMES="$FAILED_NAMES $name"
@@ -146,9 +146,9 @@ oracle() {
   fi
 }
 
-# Normalize summary-form rows. Dolt emits data_change/schema_change
-# as `true`/`false` in csv; doltlite emits 0/1. Coerce both to 0/1.
-# Then strip CR, drop blank lines, sort.
+
+
+
 normalize_summary() {
   tr -d '\r' \
     | sed -e 's/	true$/	1/' -e 's/	true	/	1	/g' \
@@ -163,20 +163,20 @@ normalize_summary() {
     | sort
 }
 
-# Oracle for dolt_diff no-arg summary form. Compares the
-# (table_name, message, data_change, schema_change) tuples after
-# joining with dolt_log to use commit MESSAGES rather than the
-# engine-specific commit hashes (which differ between engines and
-# are non-deterministic in dolt).
+
+
+
+
+
 oracle_summary() {
   local name="$1" setup="$2"
   local dir="$TMPROOT/${name}_summary"
   mkdir -p "$dir/dl" "$dir/dt"
 
-  # Both engines: SELECT joins dolt_diff against dolt_log on
-  # commit_hash to translate the hash into the commit MESSAGE.
-  # Some commits may not appear in dolt_log (e.g. unreachable),
-  # in which case coalesce falls back to the hash.
+
+
+
+
   local q="SELECT 'S' || char(9) || dd.table_name || char(9) || coalesce(dl.message, dd.commit_hash) || char(9) || dd.data_change || char(9) || dd.schema_change FROM dolt_diff dd LEFT JOIN dolt_log dl ON dl.commit_hash = dd.commit_hash"
   local q_dolt="SELECT concat('S', char(9), dd.table_name, char(9), coalesce(dl.message, dd.commit_hash), char(9), dd.data_change, char(9), dd.schema_change) FROM dolt_diff dd LEFT JOIN dolt_log dl ON dl.commit_hash = dd.commit_hash"
 
@@ -216,14 +216,14 @@ oracle_summary() {
   fi
 }
 
-# Oracle for `dolt_diff WHERE dd.table_name='X'` filtering a commit
-# that names a table that no longer exists (dropped at some point).
-# This exercises the fallback path where doltlite's polymorphic
-# vtable can't resolve the name to a live user table and therefore
-# falls through to summary mode with an in-memory name filter.
-#
-# Intentionally different from the row-history surface
-# `dolt_diff_<table>`, which only walks live table history.
+
+
+
+
+
+
+
+
 oracle_summary_filter_name() {
   local name="$1" setup="$2" target="$3"
   local dir="$TMPROOT/${name}_filter"
@@ -326,20 +326,20 @@ SELECT dolt_commit('-m', 'c4_delete');
 
 echo "--- staged state interactions ---"
 
-# Stage a modification, verify dolt_diff_t shows the staged change
-# as part of the WORKING row (since the vtable form rolls up
-# WORKING vs HEAD; the staged diff is implicit). Note: Dolt also
-# exposes separate staged/working history through other surfaces;
-# that is not covered by this oracle.
+
+
+
+
+
 oracle "table_diff_after_stage_only" "
 $SEED
 UPDATE t SET v = 99 WHERE id = 1;
 SELECT dolt_add('-A');
 "
 
-# Stage some changes, then make MORE working changes on top.
-# The WORKING row should reflect the cumulative state (final
-# v=99), not the intermediate staged state (v=50).
+
+
+
 oracle "table_diff_stage_then_more_working" "
 $SEED
 UPDATE t SET v = 50 WHERE id = 1;
@@ -347,14 +347,14 @@ SELECT dolt_add('-A');
 UPDATE t SET v = 99 WHERE id = 1;
 "
 
-# Stage an insert, verify it appears in WORKING row.
+
 oracle "table_diff_stage_insert" "
 $SEED
 INSERT INTO t VALUES (2, 20);
 SELECT dolt_add('-A');
 "
 
-# Stage a delete, verify it appears in WORKING row.
+
 oracle "table_diff_stage_delete" "
 $SEED
 INSERT INTO t VALUES (2, 20);
@@ -364,8 +364,8 @@ DELETE FROM t WHERE id = 2;
 SELECT dolt_add('-A');
 "
 
-# Mixed: some changes staged, some unstaged. Both engines should
-# include both in the WORKING row.
+
+
 oracle "table_diff_mixed_staged_and_unstaged" "
 $SEED
 INSERT INTO t VALUES (2, 20);
@@ -375,8 +375,8 @@ INSERT INTO t VALUES (3, 30);
 
 echo "--- working set diff ---"
 
-# Both engines should include the WORKING diff at the head of
-# dolt_diff_<table> output when there are uncommitted changes.
+
+
 oracle "table_diff_working_modify" "
 $SEED
 UPDATE t SET v = 99 WHERE id = 1;
@@ -392,8 +392,8 @@ $SEED
 DELETE FROM t WHERE id = 1;
 "
 
-# Working changes followed by a commit — the WORKING row should
-# disappear after the commit.
+
+
 oracle "table_diff_working_then_committed" "
 $SEED
 UPDATE t SET v = 99 WHERE id = 1;
@@ -401,7 +401,7 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c2');
 "
 
-# Mixed: working diff on top of multiple committed changes.
+
 oracle "table_diff_history_plus_working" "
 $SEED
 INSERT INTO t VALUES (2, 20);
@@ -412,7 +412,7 @@ UPDATE t SET v = 99 WHERE id = 1;
 
 echo "--- branching ---"
 
-# Diff on a branch picks up that branch's commits but not main's.
+
 oracle "diff_on_feature_branch" "
 $SEED
 SELECT dolt_branch('feature');
@@ -424,12 +424,12 @@ SELECT dolt_commit('-m', 'feat1');
 
 echo "--- merges ---"
 
-# Simple merge: feature adds row 2, main adds row 3, then merge.
-# Dolt's algorithm (now mirrored by doltlite) attributes row 3 to
-# the merge-vs-feat1 edge — NOT to main2-vs-c1 — because the merge
-# absorbs main2's first-parent diff. See doltlite_diff_table.c
-# buildDiffPairs() and the dolt diff_table.go processCommit /
-# CommitItrForRoots LIFO walk for the canonical algorithm.
+
+
+
+
+
+
 oracle "diff_after_simple_merge" "
 $SEED
 SELECT dolt_branch('feature');
@@ -444,12 +444,12 @@ SELECT dolt_commit('-m', 'main2');
 SELECT dolt_merge('feature');
 "
 
-# Merge with multiple commits between branch base and merge on the
-# main side. This exercises the more interesting case where main3
-# is the merge's first parent but main2 is reachable only via
-# main3's first-parent edge — main3 vs main2 IS emitted, but
-# main2 vs c1 is suppressed because the merge edge (merge,feat1)
-# already covers row 3.
+
+
+
+
+
+
 oracle "diff_after_merge_with_intermediate_commits" "
 $SEED
 SELECT dolt_branch('feature');
@@ -467,10 +467,10 @@ SELECT dolt_commit('-m', 'main3');
 SELECT dolt_merge('feature');
 "
 
-# Merge that introduces no new content on the main side (feature is
-# a fast-forwardable change but we force a merge commit by having
-# main also commit). Verifies the per-edge row attribution still
-# matches when the merge's first-parent diff is empty.
+
+
+
+
 oracle "diff_after_merge_no_main_changes_after_branch" "
 $SEED
 SELECT dolt_branch('feature');
@@ -490,9 +490,9 @@ SELECT dolt_merge('feature');
 
 echo "--- DDL across commits (ALTER TABLE in history) ---"
 
-# Schema-only change: ADD COLUMN in its own commit, no data.
-# dolt_diff_<table> should NOT emit a row for the add-column commit
-# since no rows changed.
+
+
+
 oracle "diff_alter_add_col_no_data_change" "
 $SEED
 ALTER TABLE t ADD COLUMN extra INT;
@@ -500,9 +500,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'add_col_only');
 "
 
-# ADD COLUMN then update an existing row's OLD column. The walker
-# should emit the update as 'modified' regardless of the schema
-# change having happened in the intermediate commit.
+
+
+
 oracle "diff_alter_add_col_then_update_old_col" "
 $SEED
 ALTER TABLE t ADD COLUMN extra INT;
@@ -513,9 +513,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'update_v');
 "
 
-# ADD COLUMN then update the NEW column specifically. The diff
-# output should show row 1 as 'modified' between the add-col
-# commit and the update commit.
+
+
+
 oracle "diff_alter_add_col_then_update_new_col" "
 $SEED
 ALTER TABLE t ADD COLUMN extra INT;
@@ -526,8 +526,8 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'populate_extra');
 "
 
-# ADD COLUMN and INSERT new row in the same commit. The insert
-# shows as 'added' at that commit; no other changes.
+
+
 oracle "diff_alter_add_col_plus_insert_same_commit" "
 $SEED
 ALTER TABLE t ADD COLUMN extra INT;
@@ -536,7 +536,7 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'add_col_and_insert');
 "
 
-# INSERT after an ALTER ADD COLUMN in a separate commit.
+
 oracle "diff_alter_add_col_then_insert_next_commit" "
 $SEED
 ALTER TABLE t ADD COLUMN extra INT;
@@ -547,8 +547,8 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'insert_after_alter');
 "
 
-# DELETE after an ALTER ADD COLUMN. The delete should show up as
-# 'removed' at that commit.
+
+
 oracle "diff_alter_add_col_then_delete_next_commit" "
 $SEED
 INSERT INTO t VALUES (2, 20);
@@ -562,12 +562,12 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'drop_row');
 "
 
-# DROP COLUMN with no data change: schema-only commit, no row-level
-# diff. The walker must detect that the from-side's record (with
-# the dropped column) and the to-side's record (without it) are
-# semantically equal on every shared column, and suppress the
-# spurious "modified" emission. Fixed by the pair-level column-
-# name lookup in doltlite_diff_table.c.
+
+
+
+
+
+
 oracle "diff_alter_drop_col_no_data_change" "
 $SEED
 ALTER TABLE t ADD COLUMN extra INT;
@@ -578,9 +578,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'drop_extra');
 "
 
-# Drop a column whose only ever value was a per-row non-NULL: the
-# drop still counts as schema-only because the column is gone and
-# the filter only compares shared columns. Both engines agree.
+
+
+
 oracle "diff_alter_drop_col_with_data_also_shared_match" "
 $SEED
 ALTER TABLE t ADD COLUMN extra INT;
@@ -592,9 +592,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'drop_extra');
 "
 
-# RENAME COLUMN. The current schema has the new name, but pre-
-# rename rows are projected under the new name's column position.
-# Both engines should agree that no rows actually changed.
+
+
+
 oracle "diff_alter_rename_col_no_data_change" "
 $SEED
 ALTER TABLE t RENAME COLUMN v TO vv;
@@ -602,8 +602,8 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'rename_v');
 "
 
-# Multiple ALTERs in a single commit, no data change. Schema-only
-# combined commit should emit nothing from dolt_diff_<table>.
+
+
 oracle "diff_multiple_alters_single_commit_no_data" "
 $SEED
 ALTER TABLE t ADD COLUMN a TEXT;
@@ -612,9 +612,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'multi_alter');
 "
 
-# ALTER ADD COLUMN on one branch, row update on the other, then
-# merge. The merge should carry both contributions without
-# duplicating rows in the diff walker output.
+
+
+
 oracle "diff_alter_then_merge" "
 $SEED
 INSERT INTO t VALUES (2, 20);
@@ -632,9 +632,9 @@ SELECT dolt_commit('-m', 'main_add_col');
 SELECT dolt_merge('feature');
 "
 
-# Replay a disjoint add-table commit through a merge while the main
-# side independently rewrites another table's schema. The added table
-# should remain visible in row-history diffs after the merge.
+
+
+
 oracle "diff_schema_replay_after_merge_add_table_plus_check" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
@@ -656,8 +656,8 @@ SELECT dolt_commit('-m', 'main_check');
 SELECT dolt_merge('feature');
 " "u"
 
-# Same disjoint schema replay shape as above, but through
-# cherry-pick instead of merge.
+
+
 oracle "diff_schema_replay_after_cherrypick_add_table_plus_check" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
@@ -679,9 +679,9 @@ SELECT dolt_commit('-m', 'main_check');
 SELECT dolt_cherry_pick('feature');
 " "u"
 
-# Non-interactive rebase of disjoint index additions. Current Dolt
-# behavior only preserves the upstream-side index, so row-history
-# for table b should still be limited to its initial add.
+
+
+
 oracle "diff_schema_replay_after_rebase_disjoint_indexes" "
 CREATE TABLE a(id INTEGER PRIMARY KEY, v INT);
 CREATE TABLE b(id INTEGER PRIMARY KEY, v INT);
@@ -770,16 +770,16 @@ SELECT dolt_checkout('feature');
 SELECT dolt_rebase('main');
 " "c"
 
-# Stage an ALTER in the working set, then query dolt_diff_<table>.
-# The WORKING row should show schema-only change (no data diff).
+
+
 oracle "diff_alter_add_col_working_set_only" "
 $SEED
 ALTER TABLE t ADD COLUMN extra INT;
 "
 
-# Stage an ALTER + a data change in the working set. The WORKING
-# row should show only the data change; the schema change is
-# schema-only and doesn't produce a row-level diff.
+
+
+
 oracle "diff_alter_add_col_and_update_working_set" "
 $SEED
 ALTER TABLE t ADD COLUMN extra INT;
@@ -789,9 +789,9 @@ UPDATE t SET extra = 42 WHERE id = 1;
 echo ""
 echo "--- summary form: dolt_diff (no args) ---"
 
-# Single-table linear history. Two commits should produce two
-# summary rows, both with data_change=1; the first commit (table
-# creation) also has schema_change=1.
+
+
+
 oracle_summary "summary_two_commits_one_table" "
 $SEED
 UPDATE t SET v = 99 WHERE id = 1;
@@ -799,7 +799,7 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c2');
 "
 
-# Multi-commit linear history with INSERT, UPDATE, DELETE.
+
 oracle_summary "summary_linear_three_commits" "
 $SEED
 INSERT INTO t VALUES (2, 20);
@@ -813,8 +813,8 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c4_delete');
 "
 
-# Two independent tables changing in different commits. Each
-# commit should produce a row only for the table it touched.
+
+
 oracle_summary "summary_two_tables_independent" "
 CREATE TABLE t(id INT PRIMARY KEY, v INT);
 CREATE TABLE u(id INT PRIMARY KEY, v INT);
@@ -830,7 +830,7 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'modify_u_only');
 "
 
-# Schema change via ALTER TABLE — schema_change should be 1.
+
 oracle_summary "summary_schema_change_add_column" "
 $SEED
 ALTER TABLE t ADD COLUMN extra TEXT;
@@ -838,7 +838,7 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'add_col');
 "
 
-# Combined data and schema change in one commit.
+
 oracle_summary "summary_data_and_schema_in_one_commit" "
 $SEED
 ALTER TABLE t ADD COLUMN extra TEXT;
@@ -847,7 +847,7 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'col_and_row');
 "
 
-# Newly created table in a later commit.
+
 oracle_summary "summary_table_added_later" "
 $SEED
 CREATE TABLE u(id INT PRIMARY KEY, x TEXT);
@@ -856,18 +856,18 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'add_u');
 "
 
-# Working-set changes are NOT reachable via dolt_diff (which is
-# commits-only); both engines should ignore them. The only
-# summary rows should be for the committed setup.
+
+
+
 oracle_summary "summary_working_set_excluded" "
 $SEED
 UPDATE t SET v = 99 WHERE id = 1;
 "
 
-# Replay a disjoint add-table commit through merge while the main
-# side independently rewrites another table's schema. Summary form
-# should include the replayed table on both the original feature
-# commit and the merge commit, plus the main-side schema-only row.
+
+
+
+
 oracle_summary "summary_merge_replay_add_table_plus_check" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES (1, 'base');
@@ -1016,10 +1016,10 @@ SELECT dolt_revert((SELECT commit_hash FROM dolt_log WHERE message='main_check' 
 
 echo "--- summary form: WHERE table_name=... filter ---"
 
-# Filter summary rows to a table that has been DROPPED by the time
-# of the query. doltlite's polymorphic vtable can't resolve the
-# name to a live user table, so it must fall through to summary
-# mode with an in-memory name filter.
+
+
+
+
 oracle_summary_filter_name "filter_dropped_table" "
 CREATE TABLE dropped(id INT PRIMARY KEY, v INT);
 INSERT INTO dropped VALUES(1, 10);
@@ -1033,7 +1033,7 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c3_drop_dropped');
 " "dropped"
 
-# Filter to a name that never existed — both engines return empty.
+
 oracle_summary_filter_name "filter_nonexistent_name" "
 $SEED
 INSERT INTO t VALUES (2, 20);
@@ -1041,10 +1041,10 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c2');
 " "never_existed"
 
-# Filter to a table that appears in multiple commits with a mix of
-# data and schema changes, along with unrelated tables in those
-# commits. The filter should return only the rows that match the
-# named table.
+
+
+
+
 oracle_summary_filter_name "filter_mixed_history" "
 CREATE TABLE x(id INT PRIMARY KEY, v INT);
 INSERT INTO x VALUES(1, 10);

--- a/test/vc_oracle_diff_tvf_test.sh
+++ b/test/vc_oracle_diff_tvf_test.sh
@@ -1,31 +1,31 @@
 #!/bin/bash
-#
-# Version-control oracle test: dolt_diff_<table>(from_ref, to_ref) TVF form
-#
-# Dolt exposes row-level range diffs via a generic TVF
-# `dolt_diff(from_ref, to_ref, table_name)` whose output schema is
-# per-table. SQLite eponymous TVFs declare a static schema at
-# connect time, so we expose the same functionality by adding
-# (from_ref, to_ref) as positional args to the existing
-# `dolt_diff_<table>` virtual table — the table name rides in the
-# module name, where it's already per-instance, and the schema is
-# the same as the no-arg form.
-#
-# The oracle query uses the doltlite form:
-#
-#   SELECT * FROM dolt_diff_users('HEAD~1', 'HEAD')
-#
-# and a sed transformation rewrites it for Dolt to:
-#
-#   SELECT * FROM dolt_diff('HEAD~1', 'HEAD', 'users')
-#
-# Each row is serialized as "R|<pk>|<to_vals>|<from_vals>|<diff_type>"
-# so the commit hash columns (which differ between engines —
-# doltlite emits resolved hashes, Dolt emits the ref literal) are
-# intentionally excluded from the comparison.
-#
-# Usage: bash vc_oracle_diff_tvf_test.sh [path/to/doltlite] [path/to/dolt]
-#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 set -u
 
@@ -36,8 +36,8 @@ trap "rm -rf $TMPROOT" EXIT
 pass=0; fail=0
 FAILED_NAMES=""
 
-# Translate setup SQL (SELECT dolt_* → CALL dolt_*) and the query
-# (dolt_diff_<t>(...) → dolt_diff(..., '<t>')) for Dolt.
+
+
 translate_for_dolt() {
   sed -E '
     s/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g
@@ -109,7 +109,7 @@ oracle "slice_full_range" "$SETUP_LINEAR" \
 
 echo "--- ref types ---"
 
-# Named refs: branch names.
+
 oracle "slice_branch_refs" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 1);
@@ -119,7 +119,7 @@ INSERT INTO t VALUES (2, 2);
 SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'feat_c1');
 " "SELECT CONCAT('R|', IFNULL(to_id,''), '|', IFNULL(to_v,''), '|', IFNULL(from_id,''), '|', IFNULL(from_v,''), '|', diff_type) FROM dolt_diff_t('main', 'feat');"
 
-# Tags.
+
 oracle "slice_tag_refs" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 1);

--- a/test/vc_oracle_diff_tvf_test.sh
+++ b/test/vc_oracle_diff_tvf_test.sh
@@ -1,32 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 set -u
 
 DOLTLITE="${1:-./doltlite}"
@@ -35,8 +8,6 @@ TMPROOT=$(mktemp -d)
 trap "rm -rf $TMPROOT" EXIT
 pass=0; fail=0
 FAILED_NAMES=""
-
-
 
 translate_for_dolt() {
   sed -E '
@@ -109,7 +80,6 @@ oracle "slice_full_range" "$SETUP_LINEAR" \
 
 echo "--- ref types ---"
 
-
 oracle "slice_branch_refs" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 1);
@@ -118,7 +88,6 @@ SELECT dolt_checkout('-b', 'feat');
 INSERT INTO t VALUES (2, 2);
 SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'feat_c1');
 " "SELECT CONCAT('R|', IFNULL(to_id,''), '|', IFNULL(to_v,''), '|', IFNULL(from_id,''), '|', IFNULL(from_v,''), '|', diff_type) FROM dolt_diff_t('main', 'feat');"
-
 
 oracle "slice_tag_refs" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);

--- a/test/vc_oracle_error_recovery_test.sh
+++ b/test/vc_oracle_error_recovery_test.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
-#
-# Error recovery oracle tests (doltlite vs Dolt)
-#
-# Tests that trigger errors mid-stream and verify both engines land
-# in the same state afterward. Uses -c (continue on error) so both
-# engines execute the full script including statements after errors.
-#
-# These validate that failed operations don't corrupt state:
-# - Failed merges (conflicts) leave table in pre-merge state
-# - Failed commits don't create partial commits
-# - Failed checkouts don't switch branches
-# - Recovery operations (reset, resolve) work after failures
-#
-# Usage: bash vc_oracle_error_recovery_test.sh ./doltlite dolt
-#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 set -u
 set -o pipefail
@@ -75,9 +75,9 @@ oracle() {
 echo "=== Error Recovery Oracle Tests ==="
 echo ""
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 1: Failed merge (conflict) — table state preserved
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- failed merge: table state preserved ---"
 
 oracle "conflict_preserves_unmodified_rows" "
@@ -147,9 +147,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t2 ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 2: Failed commit — no partial state
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- failed commit: no partial state ---"
 
 oracle "empty_commit_rejected_data_preserved" "
@@ -181,9 +181,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','real commit');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 3: Failed checkout — branch unchanged
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- failed checkout: branch unchanged ---"
 
 oracle "checkout_nonexistent_stays_on_current" "
@@ -212,9 +212,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main commit');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 4: Reset after conflict
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- reset after conflict ---"
 
 oracle "hard_reset_after_conflict" "
@@ -234,9 +234,9 @@ SELECT dolt_merge('feat');
 SELECT dolt_reset('--hard', 'HEAD');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 5: Operations after failed operations
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- operations after failures ---"
 
 oracle "insert_after_failed_merge" "
@@ -309,9 +309,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat2');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 6: Delete-modify conflict state
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- delete-modify conflict state ---"
 
 oracle "delete_modify_safe_rows_intact" "
@@ -330,9 +330,9 @@ SELECT dolt_commit('-m','main modifies');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t WHERE id > 1 ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 7: Multiple errors in sequence
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- multiple errors in sequence ---"
 
 oracle "multiple_failed_commits_then_success" "
@@ -369,9 +369,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 8: Commit log integrity after errors
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- commit log integrity after errors ---"
 
 oracle "log_count_after_failed_commits" "
@@ -405,9 +405,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) FROM dolt_log;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 9: Working set after errors
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- working set after errors ---"
 
 oracle "uncommitted_data_survives_failed_commit" "
@@ -428,9 +428,9 @@ INSERT INTO t VALUES(2,'working');
 SELECT dolt_checkout('nonexistent');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 10: FK constraint errors during merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- FK errors in merge ---"
 
 oracle "fk_parent_data_safe_after_failed_merge" "
@@ -452,9 +452,9 @@ SELECT dolt_merge('feat');
 " "SELECT id, name FROM parent ORDER BY id;"
 
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 11: Cherry-pick error recovery
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- cherry-pick error recovery ---"
 
 oracle "cherry_pick_bad_ref_data_intact" "
@@ -492,9 +492,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after failed cherry pick');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 12: Revert error recovery
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- revert error recovery ---"
 
 oracle "revert_bad_ref_data_intact" "
@@ -516,9 +516,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after failed revert');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 13: Reset error recovery
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- reset error recovery ---"
 
 oracle "reset_bad_ref_data_intact" "
@@ -544,9 +544,9 @@ SELECT dolt_reset('--hard','bad_ref');
 SELECT dolt_reset('HEAD~1');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 14: Conflict resolution flow
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- conflict resolution flow ---"
 
 oracle "reset_hard_head_clears_conflict" "
@@ -592,9 +592,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('clean_branch');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 15: Multi-table error isolation
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- multi-table error isolation ---"
 
 oracle "conflict_in_one_table_other_tables_queryable" "
@@ -632,9 +632,9 @@ SELECT dolt_add('t1');
 SELECT dolt_commit('-m','only t1');
 " "SELECT id, val FROM t1 ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 16: Staged state after errors
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- staged state after errors ---"
 
 oracle "staged_survives_failed_commit_then_succeeds" "
@@ -681,9 +681,9 @@ SELECT dolt_rebase('nope');
 ROLLBACK TO sp1;
 " "SELECT count(*) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 17: Branch operations after errors
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- branch operations after errors ---"
 
 oracle "create_branch_after_failed_create" "
@@ -716,9 +716,9 @@ SELECT dolt_branch('-d','nonexistent');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 18: DML errors don't corrupt VC state
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- DML errors + VC state ---"
 
 oracle "constraint_error_doesnt_break_commit" "
@@ -757,9 +757,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after fk error');
 " "SELECT id, val FROM child ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 19: Merge state cleanup
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- merge state cleanup ---"
 
 oracle "new_branch_after_conflict_reset" "
@@ -805,9 +805,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','post reset commit');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 20: Rapid error-success alternation
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- rapid error-success alternation ---"
 
 oracle "alternating_good_bad_commits" "
@@ -850,9 +850,9 @@ SELECT dolt_merge('b1');
 SELECT dolt_merge('b2');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 21: Data type preservation through errors
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- data type preservation through errors ---"
 
 oracle "integer_values_survive_failed_merge" "
@@ -896,9 +896,9 @@ SELECT dolt_commit('-m','empty fail');
 SELECT dolt_cherry_pick('bad_ref');
 " "SELECT id, a, b FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 22: Log count verification after error sequences
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- log counts after error sequences ---"
 
 oracle "log_count_3_after_5_attempts" "
@@ -933,9 +933,9 @@ SELECT dolt_merge('feat');
 SELECT dolt_reset('--hard','HEAD');
 " "SELECT count(*) FROM dolt_log;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 23: Complex error recovery sequences
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- complex error recovery ---"
 
 oracle "full_workflow_with_errors" "
@@ -984,9 +984,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','commit both');
 " "SELECT 't1' AS tbl, count(*) AS n FROM t1 UNION ALL SELECT 't2', count(*) FROM t2 ORDER BY 1;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 24: DROP TABLE error recovery
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- drop table error recovery ---"
 
 oracle "drop_nonexistent_table_other_tables_intact" "
@@ -1031,9 +1031,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','recreated');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 25: ALTER TABLE error recovery
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- alter table error recovery ---"
 
 oracle "alter_add_duplicate_col_data_intact" "
@@ -1070,9 +1070,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','altered');
 " "SELECT id, val, extra FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 26: Tag error recovery
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- tag error recovery ---"
 
 oracle "tag_duplicate_data_intact" "
@@ -1110,9 +1110,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after bad tag delete');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 27: Invalid SQL syntax recovery
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- invalid SQL recovery ---"
 
 oracle "insert_wrong_col_count_others_succeed" "
@@ -1148,9 +1148,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after bad update');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 28: CREATE TABLE error recovery
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- create table error recovery ---"
 
 oracle "create_duplicate_table_original_intact" "
@@ -1175,9 +1175,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after idempotent create');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 29: Error during multi-branch work
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- error during multi-branch work ---"
 
 oracle "error_on_feat_branch_then_merge" "
@@ -1232,9 +1232,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 30: Long error sequences
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- long error sequences ---"
 
 oracle "ten_failed_commits_then_real" "
@@ -1274,9 +1274,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','still on main');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 31: Errors + data type integrity
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- errors + data type integrity ---"
 
 oracle "text_values_preserved_through_errors" "
@@ -1315,9 +1315,9 @@ SELECT dolt_checkout('nonexistent');
 SELECT dolt_reset('--hard','bogus');
 " "SELECT id, big FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 32: Error in aggregate/join queries - doesn't corrupt VC
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- aggregate/join errors ---"
 
 oracle "count_on_nonexistent_then_commit" "
@@ -1342,9 +1342,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after bad join');
 " "SELECT id, v FROM t1 ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 33: Error flows with UPDATE/DELETE
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- update/delete error flows ---"
 
 oracle "update_then_fail_commit_update_again" "
@@ -1371,9 +1371,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','delete all');
 " "SELECT count(*) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 34: Reset + error + reset
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- reset + error + reset ---"
 
 oracle "reset_after_error_after_reset" "
@@ -1408,9 +1408,9 @@ SELECT dolt_reset('--hard','bogus');
 SELECT dolt_reset('--hard','HEAD');
 " "SELECT count(*) FROM dolt_log;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 35: Error during conflict state
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- errors during conflict state ---"
 
 oracle "failed_commit_during_conflict_unchanged" "
@@ -1452,9 +1452,9 @@ SELECT dolt_checkout('nonexistent');
 SELECT dolt_reset('--hard','HEAD');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 36: Errors preserve commit hash stability
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- errors + commit log stability ---"
 
 oracle "hash_of_last_commit_stable_through_errors" "
@@ -1484,9 +1484,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','m3');
 " "SELECT message FROM dolt_log WHERE message LIKE 'm%' ORDER BY message;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 37: Recovery from staged-modified mix
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- recovery from staged-modified mix ---"
 
 oracle "modify_after_add_error_no_reset" "
@@ -1516,9 +1516,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','both');
 " "SELECT 't1' AS tbl, count(*) AS n FROM t1 UNION ALL SELECT 't2', count(*) FROM t2 ORDER BY 1;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 38: Errors with mixed DDL/DML
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- mixed DDL/DML errors ---"
 
 oracle "ddl_error_then_dml_success" "
@@ -1557,9 +1557,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after alternating errors');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 39: Orphan SELECT errors
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- orphan SELECT errors ---"
 
 oracle "bad_select_before_any_commit" "
@@ -1586,9 +1586,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after bad select');
 " "SELECT id, v FROM t1 ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 40: Error right before commit
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- error right before commit ---"
 
 oracle "error_between_add_and_commit" "
@@ -1613,9 +1613,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','ok');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 41: Error on main after successful branch merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- error after successful merge ---"
 
 oracle "error_after_successful_merge" "
@@ -1637,9 +1637,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c3');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 42: Errors during reset flow
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- errors during reset flow ---"
 
 oracle "error_after_soft_reset_before_commit" "
@@ -1671,9 +1671,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after reset+errors');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 43: Errors with NULL values in WHERE
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- NULL-related error recovery ---"
 
 oracle "update_matching_null_no_rows_then_commit" "
@@ -1698,9 +1698,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 44: Rapid branch switches with errors
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- rapid branch switches with errors ---"
 
 oracle "rapid_checkouts_mixed_good_bad" "
@@ -1721,9 +1721,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 45: Error inside nested branch work
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- nested branch work errors ---"
 
 oracle "errors_on_each_branch_then_merge" "
@@ -1748,9 +1748,9 @@ SELECT dolt_merge('b1');
 SELECT dolt_merge('b2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 46: Error does not affect dolt_branches table
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- dolt_branches stable through errors ---"
 
 oracle "branches_listed_through_errors" "
@@ -1766,9 +1766,9 @@ SELECT dolt_checkout('bogus');
 SELECT dolt_reset('--hard','bogus');
 " "SELECT name FROM dolt_branches ORDER BY name;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 47: GROUP BY / HAVING errors + commit flow
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- GROUP BY/HAVING errors ---"
 
 oracle "bad_group_by_no_effect" "
@@ -1782,9 +1782,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after bad group');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 48: Sequential reset errors don't break checkout
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- multiple bad resets ---"
 
 oracle "three_bad_resets_then_good" "
@@ -1818,9 +1818,9 @@ SELECT dolt_reset('bogus');
 SELECT dolt_reset('--hard','HEAD');
 " "SELECT count(*) FROM dolt_log;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 49: Error during branch creation
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- branch creation errors ---"
 
 oracle "create_branch_bad_start_point" "
@@ -1850,9 +1850,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main after dup');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 50: Many-error stress
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- many-error stress ---"
 
 oracle "twenty_mixed_errors_then_success" "
@@ -1902,9 +1902,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','good3');
 " "SELECT message FROM dolt_log WHERE message LIKE 'good%' ORDER BY message;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 51: Error + fresh CREATE after DROP
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- drop + error + recreate ---"
 
 oracle "drop_error_recreate_different_schema" "
@@ -1920,9 +1920,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','recreate schema');
 " "SELECT id, v, extra FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 52: Errors during merge-prep
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- errors during merge prep ---"
 
 oracle "error_before_noff_merge" "
@@ -1960,9 +1960,9 @@ SELECT dolt_revert('bogus');
 SELECT dolt_merge('b2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 53: Errors after dolt_tag succeeds
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- errors after tag success ---"
 
 oracle "errors_after_tag_tag_still_listed" "
@@ -1977,9 +1977,9 @@ SELECT dolt_tag('v2','HEAD');
 SELECT dolt_revert('bogus');
 " "SELECT tag_name FROM dolt_tags ORDER BY tag_name;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 54: Errors + sqlite-style constraints
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- errors + constraint variants ---"
 
 oracle "default_value_after_error" "
@@ -2004,9 +2004,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after check fail');
 " "SELECT id, n FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 55: Error at script start (no base commit yet)
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- error before first commit ---"
 
 oracle "bad_select_before_first_commit" "
@@ -2028,9 +2028,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','first');
 " "SELECT id, v FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 56: Error chain then reset to clean state
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- error chain recovery via reset ---"
 
 oracle "error_chain_then_reset_hard_head" "
@@ -2048,9 +2048,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','clean after reset');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 57: Divergent branches each errored, merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- divergent errored branches + merge ---"
 
 oracle "both_branches_had_errors_then_merge" "
@@ -2073,9 +2073,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 58: Errors with numeric edge values
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- numeric edge error flows ---"
 
 oracle "zero_division_error_doesnt_break_vc" "
@@ -2100,9 +2100,9 @@ SELECT dolt_checkout('bogus');
 SELECT dolt_reset('--hard','bogus');
 " "SELECT id, n FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 59: Error right after branch creation
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- error right after branch create ---"
 
 oracle "error_immediately_after_new_branch" "
@@ -2120,9 +2120,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('new');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 60: Error during reset-and-recommit loop
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- reset/commit loop errors ---"
 
 oracle "reset_commit_loop_with_errors" "
@@ -2145,9 +2145,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','newer c2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 61: Syntax errors don't poison subsequent work
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- syntax error recovery ---"
 
 oracle "syntax_error_then_ok_insert" "
@@ -2172,9 +2172,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after syntax err');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 62: DELETE on nonexistent / restrictive flow
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- DELETE flow errors ---"
 
 oracle "delete_from_nonexistent_then_ops" "
@@ -2199,9 +2199,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after bad delete where');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 63: Error during branch + merge chain
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- error during branch+merge chain ---"
 
 oracle "errors_scattered_through_merge_chain" "
@@ -2226,9 +2226,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('b2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 64: Tag error recovery deeper
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- tag error deeper ---"
 
 oracle "tag_errors_tags_dolt_tags_stable" "
@@ -2246,9 +2246,9 @@ SELECT dolt_tag('good2','HEAD');
 SELECT dolt_tag('-d','nonexistent');
 " "SELECT tag_name FROM dolt_tags ORDER BY tag_name;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 65: DELETE after DROP TABLE
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- DELETE after DROP TABLE ---"
 
 oracle "delete_after_drop_other_survives" "
@@ -2265,9 +2265,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after drop and bad delete');
 " "SELECT id, v FROM keeper ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 66: Staged DDL + failed commit + recovery
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- staged DDL + failed commit ---"
 
 oracle "staged_create_failed_commit_recovery" "
@@ -2283,9 +2283,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','now with data');
 " "SELECT x FROM new;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 67: Errors with explicit column names in INSERT
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- explicit col INSERT errors ---"
 
 oracle "insert_wrong_col_name_then_correct" "
@@ -2299,9 +2299,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after bad col');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 68: Branch errors don't leak stale state
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- branch stale state probes ---"
 
 oracle "create_branch_then_bad_then_merge_ok" "
@@ -2320,9 +2320,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 69: GROUP/ORDER errors don't break commits
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- GROUP/ORDER error probes ---"
 
 oracle "order_by_nonexistent_col_then_commit" "
@@ -2336,9 +2336,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after bad order');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 70: Insert failure doesn't poison transaction (autocommit)
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- row-level error probes ---"
 
 oracle "duplicate_pk_insert_others_succeed" "
@@ -2366,9 +2366,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after check errs');
 " "SELECT id, n FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 71: Errors referencing VC vtables
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- VC vtable query error probes ---"
 
 oracle "bad_dolt_log_filter_then_commit" "
@@ -2415,9 +2415,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 72: Successive merges with errors between them
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- inter-merge error probes ---"
 
 oracle "errors_between_three_merges" "
@@ -2462,9 +2462,9 @@ SELECT dolt_cherry_pick('bogus');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 73: Error during diff/status inspection
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- diff/status error probes ---"
 
 oracle "bad_diff_then_commit" "
@@ -2478,9 +2478,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 74: Error propagation across nested calls
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- nested call error probes ---"
 
 oracle "nested_bad_select_doesnt_break_vc" "
@@ -2494,9 +2494,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 75: Error recovery with many-branch fan-in
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- fan-in with errors probes ---"
 
 oracle "errors_during_fan_in_merges" "
@@ -2526,9 +2526,9 @@ SELECT dolt_merge('bogus2');
 SELECT dolt_merge('b3');
 " "SELECT count(*) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 76: Row state after error chain
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- row state after error chains ---"
 
 oracle "row_count_invariant_through_errors" "
@@ -2556,9 +2556,9 @@ UPDATE t SET n=n WHERE bogus_col=1;
 DELETE FROM t WHERE nonexistent_col=1;
 " "SELECT sum(n) AS s FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 77: Partial batch inserts with errors
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- partial batch insert error probes ---"
 
 oracle "insert_batch_with_one_duplicate_pk" "
@@ -2588,9 +2588,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after batch');
 " "SELECT id, n FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 78: SAVEPOINT error flows
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- SAVEPOINT error flow probes ---"
 
 oracle "rollback_to_nonexistent_savepoint" "
@@ -2621,9 +2621,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after bad release');
 " "SELECT count(*) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 79: Error inside REPLACE
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- REPLACE error flow probes ---"
 
 oracle "replace_with_check_violation_others_survive" "
@@ -2638,9 +2638,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after replace err');
 " "SELECT id, n FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 80: Errors during txn with mixed dolt ops
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- txn + mixed error probes ---"
 
 oracle "txn_with_bogus_cherry_pick_then_commit" "
@@ -2671,9 +2671,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','post');
 " "SELECT id FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 81: Errors with JSON columns
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- JSON error probes ---"
 
 oracle "json_extract_bad_path_then_ok_commit" "
@@ -2687,9 +2687,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after bad json');
 " "SELECT id FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 82: Repeat DROP of already-dropped table
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- repeat drop probes ---"
 
 oracle "drop_same_table_twice" "
@@ -2706,9 +2706,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after double drop');
 " "SELECT id FROM other ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 83: Long sequence of mixed errors
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- long mixed error sequence probes ---"
 
 oracle "fifteen_errors_then_one_success" "
@@ -2736,9 +2736,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','success');
 " "SELECT count(*) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 84: Error during checkout of detached / invalid refs
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- bad checkout target probes ---"
 
 oracle "checkout_hash_prefix_then_ok" "
@@ -2767,9 +2767,9 @@ SELECT dolt_checkout('not_a_branch');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 85: RENAME errors
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- rename error probes ---"
 
 oracle "rename_col_that_does_not_exist_then_ok" "
@@ -2807,9 +2807,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after bad rename');
 " "SELECT id FROM t1 ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 86: Errors on empty / fresh database
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- empty db error probes ---"
 
 oracle "merge_on_empty_repo" "
@@ -2829,9 +2829,9 @@ SELECT dolt_commit('-m','c1');
 SELECT dolt_tag('now','HEAD');
 " "SELECT count(*) FROM dolt_tags;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 87: Errors during sequential merges
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- sequential merge error probes ---"
 
 oracle "bad_then_good_then_bad_then_good_merge" "
@@ -2855,9 +2855,9 @@ SELECT dolt_merge('bogus2');
 SELECT dolt_merge('b2');
 " "SELECT count(*) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 88: Errors with DROP INDEX / DROP COLUMN
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- drop index/col error probes ---"
 
 oracle "drop_column_nonexistent_then_ok" "
@@ -2882,9 +2882,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after drop idx');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 89: Errors after partial cherry-pick attempts
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- partial cherry-pick errors ---"
 
 oracle "cherry_pick_bad_then_good_chain" "
@@ -2914,9 +2914,9 @@ SELECT dolt_revert('bogus1');
 SELECT dolt_revert('HEAD');
 SELECT dolt_revert('bogus2');
 " "SELECT id, v FROM t ORDER BY id;"
-# ═══════════════════════════════════════════════════════════════════
-# Section 90: Set operation errors
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- set op error probes ---"
 
 oracle "bad_union_then_ok_commit" "
@@ -2930,9 +2930,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 91: Error between successive commits
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- error between commits ---"
 
 oracle "error_right_after_commit_then_commit" "
@@ -2950,9 +2950,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c3');
 " "SELECT count(*) FROM dolt_log;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 92: Error on UPDATE with bad subquery
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- UPDATE with bad subquery probes ---"
 
 oracle "update_subquery_bogus_col_then_ok" "
@@ -2966,9 +2966,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 93: Error on CAST / arithmetic
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- arithmetic error probes ---"
 
 oracle "divide_by_zero_update_skipped" "
@@ -2982,9 +2982,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 94: Error with nonexistent tag in reset
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- reset to nonexistent tag ---"
 
 oracle "reset_to_deleted_tag_then_ok" "
@@ -3003,9 +3003,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c3');
 " "SELECT id FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 95: Error on merge_base bogus branches
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- bad merge_base args ---"
 
 oracle "merge_base_bogus_then_ok" "
@@ -3020,9 +3020,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 96: Error on INSERT into view
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- INSERT into view probes ---"
 
 oracle "insert_into_view_then_ok" "
@@ -3037,9 +3037,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 97: Error on DROP VIEW nonexistent
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- drop view errors ---"
 
 oracle "drop_nonexistent_view_then_ok" "
@@ -3053,9 +3053,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 98: Error storm on merge operations
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- merge error storm ---"
 
 oracle "ten_bogus_merges_then_real" "
@@ -3081,9 +3081,9 @@ SELECT dolt_merge('b10');
 SELECT dolt_merge('feat');
 " "SELECT count(*) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 99: Error on wrong arity dolt functions
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- wrong arity probes ---"
 
 oracle "hashof_no_args_then_ok" "
@@ -3097,9 +3097,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 100: SAVEPOINT + dolt_add parity
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- savepoint add parity ---"
 
 oracle "savepoint_add_releases_savepoint" "
@@ -3112,9 +3112,9 @@ INSERT INTO t VALUES(2,'dirty');
 SELECT dolt_add('.');
 ROLLBACK TO sp1;
 " "SELECT 'ROWS', count(*) FROM t;"
-# ═══════════════════════════════════════════════════════════════════
-# Section 100: Cherry-pick with no-op commit
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- cherry-pick no-op probes ---"
 
 oracle "cherry_pick_then_cherry_pick_noop" "
@@ -3134,9 +3134,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','post');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 101: ALTER errors during merge prep
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- alter errors ---"
 
 oracle "alter_bad_keyword_then_ok_commit" "
@@ -3161,9 +3161,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after dup col');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 102: DROP INDEX cases
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- drop index probes ---"
 
 oracle "drop_index_twice_then_ok" "
@@ -3179,9 +3179,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 103: Window function with syntax errors
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- bad window funcs ---"
 
 oracle "bad_window_partition_then_ok" "
@@ -3195,9 +3195,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 104: Errors with UNION of different-arity selects
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- UNION arity error probes ---"
 
 oracle "union_arity_mismatch_then_ok" "
@@ -3211,9 +3211,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 105: Invalid CTE then ok
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- CTE error probes ---"
 
 oracle "bad_cte_self_ref_then_ok" "
@@ -3227,9 +3227,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 106: Error during JOIN on nonexistent col
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- JOIN errors ---"
 
 oracle "join_on_nonexistent_col_then_ok" "
@@ -3245,9 +3245,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id FROM a ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 107: Error storms around dolt_add
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- dolt_add error probes ---"
 
 oracle "many_bad_adds_then_ok" "
@@ -3260,9 +3260,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','survived');
 " "SELECT count(*) FROM dolt_log;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 108: Errors in dolt_log-aware workflows
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- log-aware workflow errors ---"
 
 oracle "log_query_after_bad_ref_check" "
@@ -3278,9 +3278,9 @@ INSERT INTO t VALUES(3);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c3');
 " "SELECT count(*) FROM dolt_log;"
-# ═══════════════════════════════════════════════════════════════════
-# Section 109: GROUP_CONCAT error flows
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- GROUP_CONCAT error probes ---"
 
 oracle "group_concat_on_nonexistent_col_then_ok" "
@@ -3294,9 +3294,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 110: Self-join error flows
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- self-join error probes ---"
 
 oracle "self_join_bogus_alias_then_ok" "
@@ -3310,9 +3310,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 111: VIEW chain error
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- view chain error probes ---"
 
 oracle "drop_base_view_then_query_dependent_then_ok" "
@@ -3330,9 +3330,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','restored');
 " "SELECT id FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 112: Scalar subquery returning multiple rows
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- scalar subquery multiple rows probes ---"
 
 oracle "scalar_subquery_returning_multiple_rows_then_ok" "
@@ -3346,9 +3346,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 113: Errors during merge with many branches
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- merge errors with many branches ---"
 
 oracle "errors_across_5_branch_merge_chain" "
@@ -3379,9 +3379,9 @@ SELECT dolt_merge('c');
 SELECT dolt_merge('bogus3');
 " "SELECT count(*) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 114: Transaction errors (ROLLBACK in autocommit)
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- txn error probes ---"
 
 oracle "rollback_outside_txn_then_ok" "
@@ -3406,9 +3406,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 115: Errors with nested JOINs
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- nested JOIN errors ---"
 
 oracle "nested_join_bogus_table_then_ok" "
@@ -3424,9 +3424,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM a;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 116: Errors in CREATE INDEX
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- create index error probes ---"
 
 oracle "create_index_on_nonexistent_col_then_ok" "
@@ -3450,9 +3450,9 @@ INSERT INTO t VALUES(2);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id FROM t ORDER BY id;"
-# ═══════════════════════════════════════════════════════════════════
-# Section 117: DATE format error flows
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- DATE error probes ---"
 
 oracle "bad_date_value_then_ok" "
@@ -3466,9 +3466,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, d FROM t WHERE id IN (1,3) ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 118: UPDATE with bad subquery then good
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- UPDATE subquery error chain ---"
 
 oracle "update_bogus_subquery_table_then_ok" "
@@ -3482,9 +3482,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 119: DELETE errors
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- DELETE error probes ---"
 
 oracle "delete_with_bogus_subquery_table_then_ok" "
@@ -3498,9 +3498,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 120: Errors during schema change chain
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- schema change error chain ---"
 
 oracle "alter_add_drop_alter_chain_with_errors" "
@@ -3517,9 +3517,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 121: Tag errors
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- tag error probes ---"
 
 oracle "tag_empty_name_then_ok" "
@@ -3531,9 +3531,9 @@ SELECT dolt_tag('','HEAD');
 SELECT dolt_tag('good','HEAD');
 " "SELECT count(*) FROM dolt_tags WHERE tag_name='good';"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 122: Error inside repeated merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- repeated merge errors ---"
 
 oracle "merge_twice_bogus_twice_real" "
@@ -3552,9 +3552,9 @@ SELECT dolt_merge('feat');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 123: Errors with DROP TABLE chain
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- drop chain probes ---"
 
 oracle "drop_table_chain_with_errors" "
@@ -3576,9 +3576,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after chain');
 " "SELECT id FROM c ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 124: Errors during hash-of queries
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- hashof error probes ---"
 
 oracle "hashof_too_many_args_then_ok" "
@@ -3592,9 +3592,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM dolt_log;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 125: Long error streak in explicit txn
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- txn long error streak ---"
 
 oracle "txn_many_errors_then_commit" "
@@ -3616,9 +3616,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','post');
 " "SELECT count(*) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 126: Errors around VIEW creation
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- view create errors ---"
 
 oracle "create_view_dup_name_then_ok" "
@@ -3644,8 +3644,8 @@ INSERT INTO t VALUES(2);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM v_good;"
-# Section 127: UPDATE with invalid SET expression
-# ═══════════════════════════════════════════════════════════════════
+
+
 echo "--- UPDATE invalid SET probes ---"
 
 oracle "update_set_nonexistent_col_assigned_then_ok" "
@@ -3659,9 +3659,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 128: INSERT with wrong arity
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- INSERT arity probes ---"
 
 oracle "insert_too_few_values_then_ok" "
@@ -3686,9 +3686,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 129: WHERE with bogus function
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- WHERE bogus func ---"
 
 oracle "where_bogus_func_then_ok_insert" "
@@ -3702,9 +3702,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 130: CREATE TABLE with bad column list
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- CREATE TABLE bad cols ---"
 
 oracle "create_table_bad_syntax_then_good" "
@@ -3719,9 +3719,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM good;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 131: Nested transaction confusion
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- nested txn probes ---"
 
 oracle "begin_begin_then_ok" "
@@ -3737,9 +3737,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 132: Error during CTE
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- CTE error probes ---"
 
 oracle "cte_with_bogus_inner_ref_then_ok" "
@@ -3753,9 +3753,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 133: Errors during add specific tables
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- dolt_add specific errors ---"
 
 oracle "add_mix_of_good_bad_tables_then_commit_a" "
@@ -3771,9 +3771,9 @@ SELECT dolt_add('t1','nonexistent','t2');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM dolt_log;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 134: Errors after dolt_checkout to existing
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- checkout existing probes ---"
 
 oracle "checkout_existing_twice_with_errors" "
@@ -3796,9 +3796,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 135: Errors with mixed DDL
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- mixed DDL error probes ---"
 
 oracle "ddl_mix_with_errors_then_ok" "
@@ -3814,10 +3814,10 @@ INSERT INTO t VALUES(2,'b');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t ORDER BY id;"
-# ═══════════════════════════════════════════════════════════════════
-# ═══════════════════════════════════════════════════════════════════
-# Section 136: Savepoint edge errors (post-#598)
-# ═══════════════════════════════════════════════════════════════════
+
+
+
+
 echo "--- savepoint edge error probes ---"
 
 oracle "rollback_to_released_savepoint_then_ok" "
@@ -3852,9 +3852,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','post');
 " "SELECT count(*) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 137: BETWEEN errors
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- BETWEEN error probes ---"
 
 oracle "between_with_nonexistent_col_then_ok" "
@@ -3868,9 +3868,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 138: Mixed error severity
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- mixed severity error probes ---"
 
 oracle "syntax_error_semantic_error_then_ok" "
@@ -3885,9 +3885,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 139: Empty commit message variations
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- empty message probes ---"
 
 oracle "commit_empty_message_then_good" "
@@ -3898,9 +3898,9 @@ SELECT dolt_commit('-m','');
 SELECT dolt_commit('-m','good');
 " "SELECT count(*) FROM dolt_log WHERE message IN ('good','');"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 140: Multiple table drops with mixed validity
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- multi drop mixed ---"
 
 oracle "drop_three_tables_mix_bogus" "
@@ -3920,9 +3920,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id FROM c ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 141: Errors after successful merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- post-merge errors ---"
 
 oracle "errors_after_merge_then_ok_commit" "
@@ -3945,9 +3945,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','post');
 " "SELECT id FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 142: dolt_merge_base errors
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- merge_base errors ---"
 
 oracle "merge_base_both_bogus_then_ok" "
@@ -3961,9 +3961,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM dolt_log;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 143: INSERT with wrong types then ok
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- INSERT wrong type ---"
 
 oracle "insert_wrong_type_then_ok" "
@@ -3977,9 +3977,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, n FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 144: Tag-related errors
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- tag error chain ---"
 
 oracle "tag_duplicate_delete_same_tag_chain" "
@@ -3993,9 +3993,9 @@ SELECT dolt_tag('-d','v1');
 SELECT dolt_tag('-d','v1');
 SELECT dolt_tag('v2','HEAD');
 " "SELECT tag_name FROM dolt_tags ORDER BY tag_name;"
-# ═══════════════════════════════════════════════════════════════════
-# Section 145: Revert errors
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- revert error probes ---"
 
 oracle "revert_on_empty_repo_then_ok" "
@@ -4017,9 +4017,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 146: Error during merge rollback
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- merge rollback error probes ---"
 
 oracle "merge_conflict_then_extra_bogus_then_reset" "
@@ -4044,9 +4044,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 147: Errors with INSERT into view
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- view INSERT errors ---"
 
 oracle "insert_into_view_agg_then_ok" "
@@ -4061,9 +4061,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT sum(v) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 148: DELETE without WHERE then error
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- DELETE all error probes ---"
 
 oracle "delete_all_then_bogus_then_commit" "
@@ -4078,15 +4078,15 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 149: FK violation error recovery
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- FK violation recovery ---"
 
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 150: INSERT with expression errors
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- INSERT expr error probes ---"
 
 oracle "insert_with_bogus_func_expression_then_ok" "
@@ -4100,9 +4100,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 151: Branches conflict on checkout
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- branch checkout error ---"
 
 oracle "checkout_then_branch_delete_self_error" "
@@ -4119,9 +4119,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 152: Repeated hashof errors
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- hashof error chain ---"
 
 oracle "hashof_chain_of_bad_refs_then_ok" "
@@ -4138,9 +4138,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM dolt_log;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 153: Concurrent-style conflict from bad checkout
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- checkout conflict recovery ---"
 
 oracle "bad_checkout_uncommitted_work_preserved" "
@@ -4153,8 +4153,8 @@ SELECT dolt_checkout('nonexistent');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','kept');
 " "SELECT id FROM t ORDER BY id;"
-# Section 154: Errors with recursive CTE
-# ═══════════════════════════════════════════════════════════════════
+
+
 echo "--- recursive CTE error probes ---"
 
 oracle "recursive_cte_self_ref_bogus_col_then_ok" "
@@ -4168,9 +4168,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 155: Errors during ORDER BY expressions
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- ORDER BY error probes ---"
 
 oracle "order_by_bogus_expression_then_ok" "
@@ -4184,9 +4184,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 156: Error on window function with bad OVER clause
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- window bad OVER ---"
 
 oracle "window_bad_over_clause_then_ok" "
@@ -4200,9 +4200,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 157: Errors inside nested transactions
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- nested txn error probes ---"
 
 oracle "savepoint_error_storm_then_clean_commit" "
@@ -4222,9 +4222,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','post');
 " "SELECT count(*) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 158: INSERT INTO nonexistent cols
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- INSERT bogus cols ---"
 
 oracle "insert_targeting_bogus_col_then_ok" "
@@ -4238,9 +4238,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 159: Merge with bogus commit-hash ref
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- merge bogus hash probes ---"
 
 oracle "merge_bogus_hash_like_ref_then_ok" "
@@ -4258,15 +4258,15 @@ SELECT dolt_merge('0000000000000000000000000000000000000000');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 160: GC during uncommitted work
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- gc edge probes ---"
 
-# NOTE: gc_after_reset_then_commit omitted — doltlite's dolt_gc()
-# returns a human-readable status string ("N chunks removed, M kept"),
-# Dolt returns an empty row. Diverges on output format only; not a
-# real behavioral divergence.
+
+
+
+
 oracle "reset_hard_then_commit_no_gc" "
 CREATE TABLE t(id INTEGER PRIMARY KEY);
 INSERT INTO t VALUES(1);
@@ -4281,9 +4281,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','post');
 " "SELECT id FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 161: Errors on multi-statement boundaries
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- multi-stmt error boundary ---"
 
 oracle "unterminated_statement_then_ok" "
@@ -4297,9 +4297,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 162: Tag error deep sequence
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- tag deep error sequence ---"
 
 oracle "tag_error_storm_then_good" "
@@ -4316,9 +4316,9 @@ SELECT dolt_tag('-d','v1');
 SELECT dolt_tag('v3','HEAD');
 " "SELECT tag_name FROM dolt_tags ORDER BY tag_name;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 163: UPDATE + DELETE bad chain
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- UPDATE+DELETE bad chain ---"
 
 oracle "update_delete_bogus_interleaved_then_ok" "
@@ -4333,9 +4333,9 @@ DELETE FROM t WHERE id=3;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t ORDER BY id;"
-# ═══════════════════════════════════════════════════════════════════
-# Section 164: Merge base bad args deeper
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- merge_base deeper errors ---"
 
 oracle "merge_base_same_branch_twice_after_ff_merge" "
@@ -4351,9 +4351,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM dolt_log;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 165: Insert with expression error sources
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- insert expr error source ---"
 
 oracle "insert_scalar_bogus_subquery_then_ok" "
@@ -4367,9 +4367,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 166: Errors around dolt_diff
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- dolt_diff errors ---"
 
 oracle "dolt_diff_filter_bogus_col_then_ok" "
@@ -4383,9 +4383,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 167: HAVING with bogus col then ok
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- HAVING errors ---"
 
 oracle "having_bogus_col_then_ok" "
@@ -4399,9 +4399,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 168: Errors on VIEW referring to dropped table
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- view after dropped source ---"
 
 oracle "view_references_dropped_source_then_ok" "
@@ -4418,9 +4418,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 169: Error inside conflict state rollback flow
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- conflict state rollback error ---"
 
 oracle "conflict_rolled_back_then_error_storm_then_ok" "
@@ -4445,9 +4445,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','post');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 170: Tag on deleted branch
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- tag on deleted branch ---"
 
 oracle "tag_after_branch_deleted_then_ok" "
@@ -4466,9 +4466,9 @@ SELECT dolt_tag('v1','feat');
 SELECT dolt_tag('v1','HEAD');
 " "SELECT count(*) FROM dolt_tags WHERE tag_name='v1';"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 171: UPDATE + CTE bogus
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- UPDATE cte bogus ---"
 
 oracle "update_via_bogus_cte_subquery_then_ok" "
@@ -4482,9 +4482,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 172: DELETE from VIEW
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- DELETE from view ---"
 
 oracle "delete_from_view_then_delete_from_table" "
@@ -4499,9 +4499,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 173: Rename non-existing col in nested ALTER
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- ALTER rename non-existing ---"
 
 oracle "alter_rename_bogus_col_then_real" "
@@ -4515,10 +4515,10 @@ INSERT INTO t(id,val) VALUES(2,'b');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, val FROM t ORDER BY id;"
-# ═══════════════════════════════════════════════════════════════════
-# ═══════════════════════════════════════════════════════════════════
-# Results
-# ═══════════════════════════════════════════════════════════════════
+
+
+
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then

--- a/test/vc_oracle_error_recovery_test.sh
+++ b/test/vc_oracle_error_recovery_test.sh
@@ -1,20 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 set -u
 set -o pipefail
 
@@ -74,9 +59,6 @@ oracle() {
 
 echo "=== Error Recovery Oracle Tests ==="
 echo ""
-
-
-
 
 echo "--- failed merge: table state preserved ---"
 
@@ -147,9 +129,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t2 ORDER BY id;"
 
-
-
-
 echo "--- failed commit: no partial state ---"
 
 oracle "empty_commit_rejected_data_preserved" "
@@ -181,9 +160,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','real commit');
 " "SELECT id, val FROM t ORDER BY id;"
 
-
-
-
 echo "--- failed checkout: branch unchanged ---"
 
 oracle "checkout_nonexistent_stays_on_current" "
@@ -212,9 +188,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main commit');
 " "SELECT id, val FROM t ORDER BY id;"
 
-
-
-
 echo "--- reset after conflict ---"
 
 oracle "hard_reset_after_conflict" "
@@ -233,9 +206,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 SELECT dolt_reset('--hard', 'HEAD');
 " "SELECT id, val FROM t ORDER BY id;"
-
-
-
 
 echo "--- operations after failures ---"
 
@@ -309,9 +279,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat2');
 " "SELECT id, val FROM t ORDER BY id;"
 
-
-
-
 echo "--- delete-modify conflict state ---"
 
 oracle "delete_modify_safe_rows_intact" "
@@ -329,9 +296,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main modifies');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t WHERE id > 1 ORDER BY id;"
-
-
-
 
 echo "--- multiple errors in sequence ---"
 
@@ -369,9 +333,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-
-
-
 echo "--- commit log integrity after errors ---"
 
 oracle "log_count_after_failed_commits" "
@@ -405,9 +366,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) FROM dolt_log;"
 
-
-
-
 echo "--- working set after errors ---"
 
 oracle "uncommitted_data_survives_failed_commit" "
@@ -428,9 +386,6 @@ INSERT INTO t VALUES(2,'working');
 SELECT dolt_checkout('nonexistent');
 " "SELECT id, val FROM t ORDER BY id;"
 
-
-
-
 echo "--- FK errors in merge ---"
 
 oracle "fk_parent_data_safe_after_failed_merge" "
@@ -450,10 +405,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, name FROM parent ORDER BY id;"
-
-
-
-
 
 echo "--- cherry-pick error recovery ---"
 
@@ -492,9 +443,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after failed cherry pick');
 " "SELECT id, val FROM t ORDER BY id;"
 
-
-
-
 echo "--- revert error recovery ---"
 
 oracle "revert_bad_ref_data_intact" "
@@ -515,9 +463,6 @@ INSERT INTO t VALUES(2,'still works');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after failed revert');
 " "SELECT id, val FROM t ORDER BY id;"
-
-
-
 
 echo "--- reset error recovery ---"
 
@@ -543,9 +488,6 @@ SELECT dolt_commit('-m','c2');
 SELECT dolt_reset('--hard','bad_ref');
 SELECT dolt_reset('HEAD~1');
 " "SELECT id, val FROM t ORDER BY id;"
-
-
-
 
 echo "--- conflict resolution flow ---"
 
@@ -592,9 +534,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('clean_branch');
 " "SELECT id, val FROM t ORDER BY id;"
 
-
-
-
 echo "--- multi-table error isolation ---"
 
 oracle "conflict_in_one_table_other_tables_queryable" "
@@ -631,9 +570,6 @@ INSERT INTO t2 VALUES(2,'y');
 SELECT dolt_add('t1');
 SELECT dolt_commit('-m','only t1');
 " "SELECT id, val FROM t1 ORDER BY id;"
-
-
-
 
 echo "--- staged state after errors ---"
 
@@ -681,9 +617,6 @@ SELECT dolt_rebase('nope');
 ROLLBACK TO sp1;
 " "SELECT count(*) FROM t;"
 
-
-
-
 echo "--- branch operations after errors ---"
 
 oracle "create_branch_after_failed_create" "
@@ -715,9 +648,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_branch('-d','nonexistent');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
-
-
-
 
 echo "--- DML errors + VC state ---"
 
@@ -756,9 +686,6 @@ INSERT INTO child VALUES(3,1,'good');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after fk error');
 " "SELECT id, val FROM child ORDER BY id;"
-
-
-
 
 echo "--- merge state cleanup ---"
 
@@ -805,9 +732,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','post reset commit');
 " "SELECT id, val FROM t ORDER BY id;"
 
-
-
-
 echo "--- rapid error-success alternation ---"
 
 oracle "alternating_good_bad_commits" "
@@ -849,9 +773,6 @@ SELECT dolt_checkout('nonexistent2');
 SELECT dolt_merge('b1');
 SELECT dolt_merge('b2');
 " "SELECT id, val FROM t ORDER BY id;"
-
-
-
 
 echo "--- data type preservation through errors ---"
 
@@ -896,9 +817,6 @@ SELECT dolt_commit('-m','empty fail');
 SELECT dolt_cherry_pick('bad_ref');
 " "SELECT id, a, b FROM t ORDER BY id;"
 
-
-
-
 echo "--- log counts after error sequences ---"
 
 oracle "log_count_3_after_5_attempts" "
@@ -932,9 +850,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 SELECT dolt_reset('--hard','HEAD');
 " "SELECT count(*) FROM dolt_log;"
-
-
-
 
 echo "--- complex error recovery ---"
 
@@ -984,9 +899,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','commit both');
 " "SELECT 't1' AS tbl, count(*) AS n FROM t1 UNION ALL SELECT 't2', count(*) FROM t2 ORDER BY 1;"
 
-
-
-
 echo "--- drop table error recovery ---"
 
 oracle "drop_nonexistent_table_other_tables_intact" "
@@ -1031,9 +943,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','recreated');
 " "SELECT id, val FROM t ORDER BY id;"
 
-
-
-
 echo "--- alter table error recovery ---"
 
 oracle "alter_add_duplicate_col_data_intact" "
@@ -1069,9 +978,6 @@ INSERT INTO t VALUES(2,'b',99);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','altered');
 " "SELECT id, val, extra FROM t ORDER BY id;"
-
-
-
 
 echo "--- tag error recovery ---"
 
@@ -1110,9 +1016,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after bad tag delete');
 " "SELECT id, val FROM t ORDER BY id;"
 
-
-
-
 echo "--- invalid SQL recovery ---"
 
 oracle "insert_wrong_col_count_others_succeed" "
@@ -1148,9 +1051,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after bad update');
 " "SELECT id, val FROM t ORDER BY id;"
 
-
-
-
 echo "--- create table error recovery ---"
 
 oracle "create_duplicate_table_original_intact" "
@@ -1174,9 +1074,6 @@ INSERT INTO t VALUES(2,'b');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after idempotent create');
 " "SELECT id, val FROM t ORDER BY id;"
-
-
-
 
 echo "--- error during multi-branch work ---"
 
@@ -1232,9 +1129,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-
-
-
 echo "--- long error sequences ---"
 
 oracle "ten_failed_commits_then_real" "
@@ -1274,9 +1168,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','still on main');
 " "SELECT id, val FROM t ORDER BY id;"
 
-
-
-
 echo "--- errors + data type integrity ---"
 
 oracle "text_values_preserved_through_errors" "
@@ -1315,9 +1206,6 @@ SELECT dolt_checkout('nonexistent');
 SELECT dolt_reset('--hard','bogus');
 " "SELECT id, big FROM t ORDER BY id;"
 
-
-
-
 echo "--- aggregate/join errors ---"
 
 oracle "count_on_nonexistent_then_commit" "
@@ -1341,9 +1229,6 @@ INSERT INTO t1 VALUES(2,'b');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after bad join');
 " "SELECT id, v FROM t1 ORDER BY id;"
-
-
-
 
 echo "--- update/delete error flows ---"
 
@@ -1370,9 +1255,6 @@ DELETE FROM t WHERE id>=2;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','delete all');
 " "SELECT count(*) FROM t;"
-
-
-
 
 echo "--- reset + error + reset ---"
 
@@ -1407,9 +1289,6 @@ SELECT dolt_reset('--soft','HEAD~1');
 SELECT dolt_reset('--hard','bogus');
 SELECT dolt_reset('--hard','HEAD');
 " "SELECT count(*) FROM dolt_log;"
-
-
-
 
 echo "--- errors during conflict state ---"
 
@@ -1452,9 +1331,6 @@ SELECT dolt_checkout('nonexistent');
 SELECT dolt_reset('--hard','HEAD');
 " "SELECT id, val FROM t ORDER BY id;"
 
-
-
-
 echo "--- errors + commit log stability ---"
 
 oracle "hash_of_last_commit_stable_through_errors" "
@@ -1484,9 +1360,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','m3');
 " "SELECT message FROM dolt_log WHERE message LIKE 'm%' ORDER BY message;"
 
-
-
-
 echo "--- recovery from staged-modified mix ---"
 
 oracle "modify_after_add_error_no_reset" "
@@ -1515,9 +1388,6 @@ SELECT dolt_add('does_not_exist');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','both');
 " "SELECT 't1' AS tbl, count(*) AS n FROM t1 UNION ALL SELECT 't2', count(*) FROM t2 ORDER BY 1;"
-
-
-
 
 echo "--- mixed DDL/DML errors ---"
 
@@ -1557,9 +1427,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after alternating errors');
 " "SELECT id, val FROM t ORDER BY id;"
 
-
-
-
 echo "--- orphan SELECT errors ---"
 
 oracle "bad_select_before_any_commit" "
@@ -1586,9 +1453,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after bad select');
 " "SELECT id, v FROM t1 ORDER BY id;"
 
-
-
-
 echo "--- error right before commit ---"
 
 oracle "error_between_add_and_commit" "
@@ -1613,9 +1477,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','ok');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- error after successful merge ---"
 
 oracle "error_after_successful_merge" "
@@ -1636,9 +1497,6 @@ INSERT INTO t VALUES(3,'after_err');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c3');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- errors during reset flow ---"
 
@@ -1671,9 +1529,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after reset+errors');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- NULL-related error recovery ---"
 
 oracle "update_matching_null_no_rows_then_commit" "
@@ -1698,9 +1553,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- rapid branch switches with errors ---"
 
 oracle "rapid_checkouts_mixed_good_bad" "
@@ -1720,9 +1572,6 @@ SELECT dolt_checkout('bogus3');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- nested branch work errors ---"
 
@@ -1748,9 +1597,6 @@ SELECT dolt_merge('b1');
 SELECT dolt_merge('b2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- dolt_branches stable through errors ---"
 
 oracle "branches_listed_through_errors" "
@@ -1766,9 +1612,6 @@ SELECT dolt_checkout('bogus');
 SELECT dolt_reset('--hard','bogus');
 " "SELECT name FROM dolt_branches ORDER BY name;"
 
-
-
-
 echo "--- GROUP BY/HAVING errors ---"
 
 oracle "bad_group_by_no_effect" "
@@ -1781,9 +1624,6 @@ INSERT INTO t VALUES(3,'c');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after bad group');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- multiple bad resets ---"
 
@@ -1818,9 +1658,6 @@ SELECT dolt_reset('bogus');
 SELECT dolt_reset('--hard','HEAD');
 " "SELECT count(*) FROM dolt_log;"
 
-
-
-
 echo "--- branch creation errors ---"
 
 oracle "create_branch_bad_start_point" "
@@ -1849,9 +1686,6 @@ INSERT INTO t VALUES(3,'main_after');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main after dup');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- many-error stress ---"
 
@@ -1902,9 +1736,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','good3');
 " "SELECT message FROM dolt_log WHERE message LIKE 'good%' ORDER BY message;"
 
-
-
-
 echo "--- drop + error + recreate ---"
 
 oracle "drop_error_recreate_different_schema" "
@@ -1919,9 +1750,6 @@ INSERT INTO t VALUES(1,'new',99);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','recreate schema');
 " "SELECT id, v, extra FROM t;"
-
-
-
 
 echo "--- errors during merge prep ---"
 
@@ -1960,9 +1788,6 @@ SELECT dolt_revert('bogus');
 SELECT dolt_merge('b2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- errors after tag success ---"
 
 oracle "errors_after_tag_tag_still_listed" "
@@ -1976,9 +1801,6 @@ SELECT dolt_cherry_pick('bogus');
 SELECT dolt_tag('v2','HEAD');
 SELECT dolt_revert('bogus');
 " "SELECT tag_name FROM dolt_tags ORDER BY tag_name;"
-
-
-
 
 echo "--- errors + constraint variants ---"
 
@@ -2004,9 +1826,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after check fail');
 " "SELECT id, n FROM t ORDER BY id;"
 
-
-
-
 echo "--- error before first commit ---"
 
 oracle "bad_select_before_first_commit" "
@@ -2028,9 +1847,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','first');
 " "SELECT id, v FROM t;"
 
-
-
-
 echo "--- error chain recovery via reset ---"
 
 oracle "error_chain_then_reset_hard_head" "
@@ -2047,9 +1863,6 @@ INSERT INTO t VALUES(3,'clean');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','clean after reset');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- divergent errored branches + merge ---"
 
@@ -2072,9 +1885,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- numeric edge error flows ---"
 
@@ -2100,9 +1910,6 @@ SELECT dolt_checkout('bogus');
 SELECT dolt_reset('--hard','bogus');
 " "SELECT id, n FROM t ORDER BY id;"
 
-
-
-
 echo "--- error right after branch create ---"
 
 oracle "error_immediately_after_new_branch" "
@@ -2119,9 +1926,6 @@ SELECT dolt_commit('-m','on new ok');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('new');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- reset/commit loop errors ---"
 
@@ -2144,9 +1948,6 @@ INSERT INTO t VALUES(2,200);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','newer c2');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- syntax error recovery ---"
 
@@ -2172,9 +1973,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after syntax err');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- DELETE flow errors ---"
 
 oracle "delete_from_nonexistent_then_ops" "
@@ -2198,9 +1996,6 @@ DELETE FROM t WHERE id=1;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after bad delete where');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- error during branch+merge chain ---"
 
@@ -2226,9 +2021,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('b2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- tag error deeper ---"
 
 oracle "tag_errors_tags_dolt_tags_stable" "
@@ -2246,9 +2038,6 @@ SELECT dolt_tag('good2','HEAD');
 SELECT dolt_tag('-d','nonexistent');
 " "SELECT tag_name FROM dolt_tags ORDER BY tag_name;"
 
-
-
-
 echo "--- DELETE after DROP TABLE ---"
 
 oracle "delete_after_drop_other_survives" "
@@ -2265,9 +2054,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after drop and bad delete');
 " "SELECT id, v FROM keeper ORDER BY id;"
 
-
-
-
 echo "--- staged DDL + failed commit ---"
 
 oracle "staged_create_failed_commit_recovery" "
@@ -2283,9 +2069,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','now with data');
 " "SELECT x FROM new;"
 
-
-
-
 echo "--- explicit col INSERT errors ---"
 
 oracle "insert_wrong_col_name_then_correct" "
@@ -2298,9 +2081,6 @@ INSERT INTO t(id, v) VALUES(3, 'c');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after bad col');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- branch stale state probes ---"
 
@@ -2320,9 +2100,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- GROUP/ORDER error probes ---"
 
 oracle "order_by_nonexistent_col_then_commit" "
@@ -2335,9 +2112,6 @@ INSERT INTO t VALUES(3,'c');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after bad order');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- row-level error probes ---"
 
@@ -2365,9 +2139,6 @@ INSERT INTO t VALUES(5,30);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after check errs');
 " "SELECT id, n FROM t ORDER BY id;"
-
-
-
 
 echo "--- VC vtable query error probes ---"
 
@@ -2415,9 +2186,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id FROM t ORDER BY id;"
 
-
-
-
 echo "--- inter-merge error probes ---"
 
 oracle "errors_between_three_merges" "
@@ -2462,9 +2230,6 @@ SELECT dolt_cherry_pick('bogus');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- diff/status error probes ---"
 
 oracle "bad_diff_then_commit" "
@@ -2478,9 +2243,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM t;"
 
-
-
-
 echo "--- nested call error probes ---"
 
 oracle "nested_bad_select_doesnt_break_vc" "
@@ -2493,9 +2255,6 @@ INSERT INTO t VALUES(2,'b');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- fan-in with errors probes ---"
 
@@ -2526,9 +2285,6 @@ SELECT dolt_merge('bogus2');
 SELECT dolt_merge('b3');
 " "SELECT count(*) FROM t;"
 
-
-
-
 echo "--- row state after error chains ---"
 
 oracle "row_count_invariant_through_errors" "
@@ -2555,9 +2311,6 @@ SELECT dolt_cherry_pick('bogus');
 UPDATE t SET n=n WHERE bogus_col=1;
 DELETE FROM t WHERE nonexistent_col=1;
 " "SELECT sum(n) AS s FROM t;"
-
-
-
 
 echo "--- partial batch insert error probes ---"
 
@@ -2587,9 +2340,6 @@ INSERT INTO t VALUES(6,6);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after batch');
 " "SELECT id, n FROM t ORDER BY id;"
-
-
-
 
 echo "--- SAVEPOINT error flow probes ---"
 
@@ -2621,9 +2371,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after bad release');
 " "SELECT count(*) FROM t;"
 
-
-
-
 echo "--- REPLACE error flow probes ---"
 
 oracle "replace_with_check_violation_others_survive" "
@@ -2637,9 +2384,6 @@ REPLACE INTO t VALUES(3,30);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after replace err');
 " "SELECT id, n FROM t ORDER BY id;"
-
-
-
 
 echo "--- txn + mixed error probes ---"
 
@@ -2671,9 +2415,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','post');
 " "SELECT id FROM t ORDER BY id;"
 
-
-
-
 echo "--- JSON error probes ---"
 
 oracle "json_extract_bad_path_then_ok_commit" "
@@ -2686,9 +2427,6 @@ INSERT INTO t VALUES(2,'{\"a\":2}');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after bad json');
 " "SELECT id FROM t ORDER BY id;"
-
-
-
 
 echo "--- repeat drop probes ---"
 
@@ -2705,9 +2443,6 @@ INSERT INTO other VALUES(2);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after double drop');
 " "SELECT id FROM other ORDER BY id;"
-
-
-
 
 echo "--- long mixed error sequence probes ---"
 
@@ -2736,9 +2471,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','success');
 " "SELECT count(*) FROM t;"
 
-
-
-
 echo "--- bad checkout target probes ---"
 
 oracle "checkout_hash_prefix_then_ok" "
@@ -2766,9 +2498,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_checkout('not_a_branch');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t ORDER BY id;"
-
-
-
 
 echo "--- rename error probes ---"
 
@@ -2807,9 +2536,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after bad rename');
 " "SELECT id FROM t1 ORDER BY id;"
 
-
-
-
 echo "--- empty db error probes ---"
 
 oracle "merge_on_empty_repo" "
@@ -2828,9 +2554,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c1');
 SELECT dolt_tag('now','HEAD');
 " "SELECT count(*) FROM dolt_tags;"
-
-
-
 
 echo "--- sequential merge error probes ---"
 
@@ -2855,9 +2578,6 @@ SELECT dolt_merge('bogus2');
 SELECT dolt_merge('b2');
 " "SELECT count(*) FROM t;"
 
-
-
-
 echo "--- drop index/col error probes ---"
 
 oracle "drop_column_nonexistent_then_ok" "
@@ -2881,9 +2601,6 @@ INSERT INTO t VALUES(2,'b');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after drop idx');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- partial cherry-pick errors ---"
 
@@ -2914,9 +2631,6 @@ SELECT dolt_revert('bogus1');
 SELECT dolt_revert('HEAD');
 SELECT dolt_revert('bogus2');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 echo "--- set op error probes ---"
 
 oracle "bad_union_then_ok_commit" "
@@ -2929,9 +2643,6 @@ INSERT INTO t VALUES(2,'b');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- error between commits ---"
 
@@ -2950,9 +2661,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c3');
 " "SELECT count(*) FROM dolt_log;"
 
-
-
-
 echo "--- UPDATE with bad subquery probes ---"
 
 oracle "update_subquery_bogus_col_then_ok" "
@@ -2966,9 +2674,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t;"
 
-
-
-
 echo "--- arithmetic error probes ---"
 
 oracle "divide_by_zero_update_skipped" "
@@ -2981,9 +2686,6 @@ INSERT INTO t VALUES(3,30);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM t;"
-
-
-
 
 echo "--- reset to nonexistent tag ---"
 
@@ -3003,9 +2705,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c3');
 " "SELECT id FROM t ORDER BY id;"
 
-
-
-
 echo "--- bad merge_base args ---"
 
 oracle "merge_base_bogus_then_ok" "
@@ -3019,9 +2718,6 @@ INSERT INTO t VALUES(2);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM t;"
-
-
-
 
 echo "--- INSERT into view probes ---"
 
@@ -3037,9 +2733,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- drop view errors ---"
 
 oracle "drop_nonexistent_view_then_ok" "
@@ -3052,9 +2745,6 @@ INSERT INTO t VALUES(2);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id FROM t ORDER BY id;"
-
-
-
 
 echo "--- merge error storm ---"
 
@@ -3081,9 +2771,6 @@ SELECT dolt_merge('b10');
 SELECT dolt_merge('feat');
 " "SELECT count(*) FROM t;"
 
-
-
-
 echo "--- wrong arity probes ---"
 
 oracle "hashof_no_args_then_ok" "
@@ -3097,9 +2784,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id FROM t ORDER BY id;"
 
-
-
-
 echo "--- savepoint add parity ---"
 
 oracle "savepoint_add_releases_savepoint" "
@@ -3112,9 +2796,6 @@ INSERT INTO t VALUES(2,'dirty');
 SELECT dolt_add('.');
 ROLLBACK TO sp1;
 " "SELECT 'ROWS', count(*) FROM t;"
-
-
-
 echo "--- cherry-pick no-op probes ---"
 
 oracle "cherry_pick_then_cherry_pick_noop" "
@@ -3133,9 +2814,6 @@ INSERT INTO t VALUES(3,'post');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','post');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- alter errors ---"
 
@@ -3161,9 +2839,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after dup col');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- drop index probes ---"
 
 oracle "drop_index_twice_then_ok" "
@@ -3179,9 +2854,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- bad window funcs ---"
 
 oracle "bad_window_partition_then_ok" "
@@ -3194,9 +2866,6 @@ INSERT INTO t VALUES(3,30);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM t;"
-
-
-
 
 echo "--- UNION arity error probes ---"
 
@@ -3211,9 +2880,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- CTE error probes ---"
 
 oracle "bad_cte_self_ref_then_ok" "
@@ -3226,9 +2892,6 @@ INSERT INTO t VALUES(2);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM t;"
-
-
-
 
 echo "--- JOIN errors ---"
 
@@ -3245,9 +2908,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id FROM a ORDER BY id;"
 
-
-
-
 echo "--- dolt_add error probes ---"
 
 oracle "many_bad_adds_then_ok" "
@@ -3259,9 +2919,6 @@ SELECT dolt_add('nonexistent3');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','survived');
 " "SELECT count(*) FROM dolt_log;"
-
-
-
 
 echo "--- log-aware workflow errors ---"
 
@@ -3278,9 +2935,6 @@ INSERT INTO t VALUES(3);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c3');
 " "SELECT count(*) FROM dolt_log;"
-
-
-
 echo "--- GROUP_CONCAT error probes ---"
 
 oracle "group_concat_on_nonexistent_col_then_ok" "
@@ -3294,9 +2948,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- self-join error probes ---"
 
 oracle "self_join_bogus_alias_then_ok" "
@@ -3309,9 +2960,6 @@ INSERT INTO t VALUES(3,1);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id FROM t ORDER BY id;"
-
-
-
 
 echo "--- view chain error probes ---"
 
@@ -3330,9 +2978,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','restored');
 " "SELECT id FROM t ORDER BY id;"
 
-
-
-
 echo "--- scalar subquery multiple rows probes ---"
 
 oracle "scalar_subquery_returning_multiple_rows_then_ok" "
@@ -3345,9 +2990,6 @@ INSERT INTO t VALUES(3,30);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM t;"
-
-
-
 
 echo "--- merge errors with many branches ---"
 
@@ -3379,9 +3021,6 @@ SELECT dolt_merge('c');
 SELECT dolt_merge('bogus3');
 " "SELECT count(*) FROM t;"
 
-
-
-
 echo "--- txn error probes ---"
 
 oracle "rollback_outside_txn_then_ok" "
@@ -3406,9 +3045,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id FROM t ORDER BY id;"
 
-
-
-
 echo "--- nested JOIN errors ---"
 
 oracle "nested_join_bogus_table_then_ok" "
@@ -3423,9 +3059,6 @@ INSERT INTO a VALUES(2);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM a;"
-
-
-
 
 echo "--- create index error probes ---"
 
@@ -3450,9 +3083,6 @@ INSERT INTO t VALUES(2);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id FROM t ORDER BY id;"
-
-
-
 echo "--- DATE error probes ---"
 
 oracle "bad_date_value_then_ok" "
@@ -3465,9 +3095,6 @@ INSERT INTO t VALUES(3,'2024-06-01');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, d FROM t WHERE id IN (1,3) ORDER BY id;"
-
-
-
 
 echo "--- UPDATE subquery error chain ---"
 
@@ -3482,9 +3109,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- DELETE error probes ---"
 
 oracle "delete_with_bogus_subquery_table_then_ok" "
@@ -3497,9 +3121,6 @@ DELETE FROM t WHERE id=2;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id FROM t ORDER BY id;"
-
-
-
 
 echo "--- schema change error chain ---"
 
@@ -3517,9 +3138,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- tag error probes ---"
 
 oracle "tag_empty_name_then_ok" "
@@ -3530,9 +3148,6 @@ SELECT dolt_commit('-m','c1');
 SELECT dolt_tag('','HEAD');
 SELECT dolt_tag('good','HEAD');
 " "SELECT count(*) FROM dolt_tags WHERE tag_name='good';"
-
-
-
 
 echo "--- repeated merge errors ---"
 
@@ -3551,9 +3166,6 @@ SELECT dolt_merge('bogus');
 SELECT dolt_merge('feat');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t ORDER BY id;"
-
-
-
 
 echo "--- drop chain probes ---"
 
@@ -3576,9 +3188,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after chain');
 " "SELECT id FROM c ORDER BY id;"
 
-
-
-
 echo "--- hashof error probes ---"
 
 oracle "hashof_too_many_args_then_ok" "
@@ -3591,9 +3200,6 @@ INSERT INTO t VALUES(2);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM dolt_log;"
-
-
-
 
 echo "--- txn long error streak ---"
 
@@ -3615,9 +3221,6 @@ COMMIT;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','post');
 " "SELECT count(*) FROM t;"
-
-
-
 
 echo "--- view create errors ---"
 
@@ -3644,8 +3247,6 @@ INSERT INTO t VALUES(2);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM v_good;"
-
-
 echo "--- UPDATE invalid SET probes ---"
 
 oracle "update_set_nonexistent_col_assigned_then_ok" "
@@ -3658,9 +3259,6 @@ UPDATE t SET v=99 WHERE id=1;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t;"
-
-
-
 
 echo "--- INSERT arity probes ---"
 
@@ -3686,9 +3284,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- WHERE bogus func ---"
 
 oracle "where_bogus_func_then_ok_insert" "
@@ -3701,9 +3296,6 @@ INSERT INTO t VALUES(2);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id FROM t ORDER BY id;"
-
-
-
 
 echo "--- CREATE TABLE bad cols ---"
 
@@ -3718,9 +3310,6 @@ INSERT INTO good VALUES(1,'a');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM good;"
-
-
-
 
 echo "--- nested txn probes ---"
 
@@ -3737,9 +3326,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id FROM t ORDER BY id;"
 
-
-
-
 echo "--- CTE error probes ---"
 
 oracle "cte_with_bogus_inner_ref_then_ok" "
@@ -3752,9 +3338,6 @@ INSERT INTO t VALUES(2,20);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- dolt_add specific errors ---"
 
@@ -3770,9 +3353,6 @@ INSERT INTO t2 VALUES(2);
 SELECT dolt_add('t1','nonexistent','t2');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM dolt_log;"
-
-
-
 
 echo "--- checkout existing probes ---"
 
@@ -3796,9 +3376,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t ORDER BY id;"
 
-
-
-
 echo "--- mixed DDL error probes ---"
 
 oracle "ddl_mix_with_errors_then_ok" "
@@ -3814,10 +3391,6 @@ INSERT INTO t VALUES(2,'b');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
-
 echo "--- savepoint edge error probes ---"
 
 oracle "rollback_to_released_savepoint_then_ok" "
@@ -3852,9 +3425,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','post');
 " "SELECT count(*) FROM t;"
 
-
-
-
 echo "--- BETWEEN error probes ---"
 
 oracle "between_with_nonexistent_col_then_ok" "
@@ -3867,9 +3437,6 @@ INSERT INTO t VALUES(4);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM t;"
-
-
-
 
 echo "--- mixed severity error probes ---"
 
@@ -3885,9 +3452,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- empty message probes ---"
 
 oracle "commit_empty_message_then_good" "
@@ -3897,9 +3461,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','');
 SELECT dolt_commit('-m','good');
 " "SELECT count(*) FROM dolt_log WHERE message IN ('good','');"
-
-
-
 
 echo "--- multi drop mixed ---"
 
@@ -3919,9 +3480,6 @@ INSERT INTO c VALUES(2);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id FROM c ORDER BY id;"
-
-
-
 
 echo "--- post-merge errors ---"
 
@@ -3945,9 +3503,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','post');
 " "SELECT id FROM t ORDER BY id;"
 
-
-
-
 echo "--- merge_base errors ---"
 
 oracle "merge_base_both_bogus_then_ok" "
@@ -3960,9 +3515,6 @@ INSERT INTO t VALUES(2);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM dolt_log;"
-
-
-
 
 echo "--- INSERT wrong type ---"
 
@@ -3977,9 +3529,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, n FROM t ORDER BY id;"
 
-
-
-
 echo "--- tag error chain ---"
 
 oracle "tag_duplicate_delete_same_tag_chain" "
@@ -3993,9 +3542,6 @@ SELECT dolt_tag('-d','v1');
 SELECT dolt_tag('-d','v1');
 SELECT dolt_tag('v2','HEAD');
 " "SELECT tag_name FROM dolt_tags ORDER BY tag_name;"
-
-
-
 echo "--- revert error probes ---"
 
 oracle "revert_on_empty_repo_then_ok" "
@@ -4016,9 +3562,6 @@ INSERT INTO t VALUES(2);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id FROM t ORDER BY id;"
-
-
-
 
 echo "--- merge rollback error probes ---"
 
@@ -4044,9 +3587,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- view INSERT errors ---"
 
 oracle "insert_into_view_agg_then_ok" "
@@ -4060,9 +3600,6 @@ INSERT INTO t VALUES(2,20);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT sum(v) FROM t;"
-
-
-
 
 echo "--- DELETE all error probes ---"
 
@@ -4078,14 +3615,7 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- FK violation recovery ---"
-
-
-
-
 
 echo "--- INSERT expr error probes ---"
 
@@ -4099,9 +3629,6 @@ INSERT INTO t VALUES(2, 20);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- branch checkout error ---"
 
@@ -4119,9 +3646,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t ORDER BY id;"
 
-
-
-
 echo "--- hashof error chain ---"
 
 oracle "hashof_chain_of_bad_refs_then_ok" "
@@ -4138,9 +3662,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM dolt_log;"
 
-
-
-
 echo "--- checkout conflict recovery ---"
 
 oracle "bad_checkout_uncommitted_work_preserved" "
@@ -4153,8 +3674,6 @@ SELECT dolt_checkout('nonexistent');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','kept');
 " "SELECT id FROM t ORDER BY id;"
-
-
 echo "--- recursive CTE error probes ---"
 
 oracle "recursive_cte_self_ref_bogus_col_then_ok" "
@@ -4167,9 +3686,6 @@ INSERT INTO t VALUES(2);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM t;"
-
-
-
 
 echo "--- ORDER BY error probes ---"
 
@@ -4184,9 +3700,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- window bad OVER ---"
 
 oracle "window_bad_over_clause_then_ok" "
@@ -4199,9 +3712,6 @@ INSERT INTO t VALUES(2,20);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM t;"
-
-
-
 
 echo "--- nested txn error probes ---"
 
@@ -4222,9 +3732,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','post');
 " "SELECT count(*) FROM t;"
 
-
-
-
 echo "--- INSERT bogus cols ---"
 
 oracle "insert_targeting_bogus_col_then_ok" "
@@ -4237,9 +3744,6 @@ INSERT INTO t(id, v) VALUES(2,'b');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- merge bogus hash probes ---"
 
@@ -4258,14 +3762,7 @@ SELECT dolt_merge('0000000000000000000000000000000000000000');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t ORDER BY id;"
 
-
-
-
 echo "--- gc edge probes ---"
-
-
-
-
 
 oracle "reset_hard_then_commit_no_gc" "
 CREATE TABLE t(id INTEGER PRIMARY KEY);
@@ -4281,9 +3778,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','post');
 " "SELECT id FROM t ORDER BY id;"
 
-
-
-
 echo "--- multi-stmt error boundary ---"
 
 oracle "unterminated_statement_then_ok" "
@@ -4296,9 +3790,6 @@ INSERT INTO t VALUES(2);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id FROM t ORDER BY id;"
-
-
-
 
 echo "--- tag deep error sequence ---"
 
@@ -4316,9 +3807,6 @@ SELECT dolt_tag('-d','v1');
 SELECT dolt_tag('v3','HEAD');
 " "SELECT tag_name FROM dolt_tags ORDER BY tag_name;"
 
-
-
-
 echo "--- UPDATE+DELETE bad chain ---"
 
 oracle "update_delete_bogus_interleaved_then_ok" "
@@ -4333,9 +3821,6 @@ DELETE FROM t WHERE id=3;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 echo "--- merge_base deeper errors ---"
 
 oracle "merge_base_same_branch_twice_after_ff_merge" "
@@ -4351,9 +3836,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM dolt_log;"
 
-
-
-
 echo "--- insert expr error source ---"
 
 oracle "insert_scalar_bogus_subquery_then_ok" "
@@ -4366,9 +3848,6 @@ INSERT INTO t VALUES(2, 20);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- dolt_diff errors ---"
 
@@ -4383,9 +3862,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id FROM t ORDER BY id;"
 
-
-
-
 echo "--- HAVING errors ---"
 
 oracle "having_bogus_col_then_ok" "
@@ -4398,9 +3874,6 @@ INSERT INTO t VALUES(4,'a',30);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM t;"
-
-
-
 
 echo "--- view after dropped source ---"
 
@@ -4417,9 +3890,6 @@ INSERT INTO t VALUES(2,'b');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- conflict state rollback error ---"
 
@@ -4445,9 +3915,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','post');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- tag on deleted branch ---"
 
 oracle "tag_after_branch_deleted_then_ok" "
@@ -4466,9 +3933,6 @@ SELECT dolt_tag('v1','feat');
 SELECT dolt_tag('v1','HEAD');
 " "SELECT count(*) FROM dolt_tags WHERE tag_name='v1';"
 
-
-
-
 echo "--- UPDATE cte bogus ---"
 
 oracle "update_via_bogus_cte_subquery_then_ok" "
@@ -4481,9 +3945,6 @@ UPDATE t SET v=99 WHERE id=1;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, v FROM t;"
-
-
-
 
 echo "--- DELETE from view ---"
 
@@ -4499,9 +3960,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM t;"
 
-
-
-
 echo "--- ALTER rename non-existing ---"
 
 oracle "alter_rename_bogus_col_then_real" "
@@ -4515,10 +3973,6 @@ INSERT INTO t(id,val) VALUES(2,'b');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT id, val FROM t ORDER BY id;"
-
-
-
-
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then

--- a/test/vc_oracle_feature_interaction_test.sh
+++ b/test/vc_oracle_feature_interaction_test.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
-#
-# Feature interaction oracle tests (doltlite vs Dolt)
-#
-# Exercises combinations of SQL and version-control operations that
-# interact in non-obvious ways. Each test runs the same SQL against
-# both engines and compares the final table state + commit log.
-#
-# Usage: bash vc_oracle_feature_interaction_test.sh ./doltlite dolt
-#
+
+
+
+
+
+
+
+
+
 
 set -u
 set -o pipefail
@@ -20,28 +20,28 @@ pass=0; fail=0
 FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
-# Normalize: strip hashes/timestamps, keep table data + log messages.
+
 normalize() {
   tr -d '\r' | grep -v '^$' | sort
 }
 
-# oracle NAME SETUP_SQL QUERY_SQL
-#   SETUP_SQL: DDL + DML + VC operations
-#   QUERY_SQL: SELECT that produces the comparable output
+
+
+
 oracle() {
   local name="$1" setup="$2" query="$3"
   local dir="$TMPROOT/$name"
   mkdir -p "$dir/dl" "$dir/dt"
 
-  # --- doltlite ---
-  # Mirror the dolt path below: run setup first with its output
-  # discarded, then run the query in a fresh invocation against the
-  # same db file with only its output captured. The earlier single-
-  # invocation form mixed dolt_add / dolt_commit return values with
-  # the query result and tried to filter the noise out post-hoc;
-  # that filter also stripped legitimate count(*) / scalar results,
-  # which made any test whose query returned a bare integer compare
-  # an empty doltlite output against dolt's actual value.
+
+
+
+
+
+
+
+
+
   printf "%s\n" "$setup" | "$DOLTLITE" "$dir/dl/db" \
       >/dev/null 2>"$dir/dl.err"
   local dl_out
@@ -52,7 +52,7 @@ oracle() {
            | tr -d '"' \
            | normalize)
 
-  # --- dolt ---
+
   local dolt_setup
   dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
   local dolt_query
@@ -82,9 +82,9 @@ oracle() {
 echo "=== Feature Interaction Oracle Tests ==="
 echo ""
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 1: Merge + ALTER TABLE ADD COLUMN
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- merge + alter table add column ---"
 
 oracle "merge_add_col_one_side" "
@@ -157,9 +157,9 @@ SELECT dolt_commit('-m','main changes');
 SELECT dolt_merge('feat');
 " "SELECT id, name FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 2: Merge + INSERT/UPDATE/DELETE combinations
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- merge + DML combinations ---"
 
 oracle "merge_insert_both_different_keys" "
@@ -261,9 +261,9 @@ SELECT dolt_commit('-m','main mix');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 3: Merge + composite primary keys
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- merge + composite PK ---"
 
 oracle "merge_composite_pk_insert" "
@@ -316,9 +316,9 @@ SELECT dolt_commit('-m','main update');
 SELECT dolt_merge('feat');
 " "SELECT a, b, val FROM t ORDER BY a, b;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 4: Merge + NULL values
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- merge + NULL values ---"
 
 oracle "merge_null_to_value" "
@@ -369,9 +369,9 @@ SELECT dolt_commit('-m','main fills c');
 SELECT dolt_merge('feat');
 " "SELECT id, a, b, c FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 5: Cherry-pick
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- cherry-pick ---"
 
 oracle "cherry_pick_single_insert" "
@@ -432,9 +432,9 @@ SELECT dolt_commit('-m','main diverge');
 SELECT dolt_cherry_pick('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 6: Revert
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- revert ---"
 
 oracle "revert_insert" "
@@ -470,9 +470,9 @@ SELECT dolt_commit('-m','update');
 SELECT dolt_revert('HEAD');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 7: Reset (soft and hard)
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- reset ---"
 
 oracle "reset_soft_keeps_working" "
@@ -497,9 +497,9 @@ SELECT dolt_commit('-m','second');
 SELECT dolt_reset('--hard', 'HEAD~1');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 8: Multi-table merges
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- multi-table merges ---"
 
 oracle "merge_two_tables_independent" "
@@ -557,9 +557,9 @@ SELECT dolt_commit('-m','main modifies t1');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t1 ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 9: UPSERT + version control
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- upsert + version control ---"
 
 oracle "upsert_replace_then_merge" "
@@ -594,9 +594,9 @@ SELECT dolt_commit('-m','main insert');
 SELECT dolt_merge('feat');
 " "SELECT id, val, count FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 10: Text/Blob data types in merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- text/blob in merge ---"
 
 oracle "merge_long_text_values" "
@@ -631,9 +631,9 @@ SELECT dolt_commit('-m','main insert');
 SELECT dolt_merge('feat');
 " "SELECT id, hex(data) FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 11: Numeric types in merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- numeric types in merge ---"
 
 oracle "merge_integer_types" "
@@ -668,9 +668,9 @@ SELECT dolt_commit('-m','main insert');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 12: Fast-forward vs three-way
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- fast-forward vs three-way ---"
 
 oracle "ff_merge_no_divergence" "
@@ -699,9 +699,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat', '--no-ff', '-m', 'merge feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 13: Branch + checkout state preservation
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- branch + checkout ---"
 
 oracle "checkout_preserves_committed_state" "
@@ -731,9 +731,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main commit');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 14: Multiple sequential merges
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- sequential merges ---"
 
 oracle "two_merges_same_table" "
@@ -772,9 +772,9 @@ SELECT dolt_cherry_pick('feat~1');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 15: DEFAULT values in merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- default values in merge ---"
 
 oracle "merge_with_default_col" "
@@ -793,9 +793,9 @@ SELECT dolt_commit('-m','main insert explicit');
 SELECT dolt_merge('feat');
 " "SELECT id, val, num FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 16: Large row counts
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- large row counts ---"
 
 oracle "merge_many_inserts_each_side" "
@@ -832,9 +832,9 @@ SELECT dolt_commit('-m','main updates 6-10');
 SELECT dolt_merge('feat');
 " "SELECT sum(val) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 17: Empty/boundary conditions
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- empty/boundary conditions ---"
 
 oracle "merge_empty_table_both_add_rows" "
@@ -876,9 +876,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_cherry_pick('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 18: Tag interactions
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- tag interactions ---"
 
 oracle "tag_survives_branch_delete" "
@@ -896,9 +896,9 @@ SELECT dolt_branch('-d', 'feat');
 SELECT dolt_checkout('v1');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 19: Wide tables (many columns)
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- wide tables ---"
 
 oracle "merge_wide_table_different_cols" "
@@ -917,9 +917,9 @@ SELECT dolt_commit('-m','main updates c5,c7');
 SELECT dolt_merge('feat');
 " "SELECT id, c1, c2, c3, c4, c5, c6, c7, c8 FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 20: Savepoint + commit interaction
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- savepoint + commit ---"
 
 oracle "commit_after_savepoint_release" "
@@ -947,9 +947,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','multiple dml');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 21: Merge + foreign keys
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- merge + foreign keys ---"
 
 oracle "fk_insert_child_on_branch" "
@@ -1026,9 +1026,9 @@ SELECT dolt_commit('-m','main adds child');
 SELECT dolt_merge('feat');
 " "SELECT c.id, c.pid, c.val FROM child c ORDER BY c.id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 22: Merge + secondary indexes
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- merge + secondary indexes ---"
 
 oracle "merge_with_indexed_col_insert" "
@@ -1102,9 +1102,9 @@ SELECT dolt_commit('-m','main changes');
 SELECT dolt_merge('feat');
 " "SELECT id, a, b, val FROM t ORDER BY a, b, id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 23: Cherry-pick edge cases
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- cherry-pick edge cases ---"
 
 oracle "cherry_pick_into_diverged_table" "
@@ -1154,9 +1154,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_cherry_pick('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 24: Revert edge cases
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- revert edge cases ---"
 
 oracle "revert_middle_commit" "
@@ -1198,9 +1198,9 @@ SELECT dolt_commit('-m','update');
 SELECT dolt_revert('HEAD');
 " "SELECT id, val, num FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 25: Diamond merges
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- diamond merges ---"
 
 oracle "diamond_merge_no_conflict" "
@@ -1266,9 +1266,9 @@ SELECT dolt_merge('b2');
 SELECT dolt_merge('b3');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 26: Multiple tables with FK during merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- multi-table FK merge ---"
 
 oracle "fk_cascade_not_triggered_by_merge" "
@@ -1309,9 +1309,9 @@ SELECT dolt_commit('-m','main updates c');
 SELECT dolt_merge('feat');
 " "SELECT a.val, b.val, c.val FROM a JOIN b ON b.aid=a.id JOIN c ON c.bid=b.id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 27: Merge after multiple commits on each branch
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- deep branch history merge ---"
 
 oracle "merge_after_3_commits_each" "
@@ -1364,9 +1364,9 @@ SELECT dolt_commit('-m','main c2');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 28: Type coercion in merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- type coercion ---"
 
 oracle "merge_int_stored_as_text" "
@@ -1401,9 +1401,9 @@ SELECT dolt_commit('-m','main fills real');
 SELECT dolt_merge('feat');
 " "SELECT id, a, b, c FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 29: Schema-only changes
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- schema-only changes ---"
 
 oracle "add_col_no_data_change" "
@@ -1428,9 +1428,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','add and populate');
 " "SELECT id, val, score FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 30: Merge + DROP TABLE on one side
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- drop table interactions ---"
 
 oracle "drop_table_other_side_untouched" "
@@ -1468,9 +1468,9 @@ SELECT dolt_commit('-m','main modifies t1');
 SELECT dolt_merge('feat');
 " "SELECT 't1' AS tbl, id FROM t1 UNION ALL SELECT 't2', id FROM t2 ORDER BY 1, 2;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 31: Merge with same row modified identically
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- convergent modifications ---"
 
 oracle "both_sides_same_update" "
@@ -1521,9 +1521,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 32: Reset interactions
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- reset edge cases ---"
 
 oracle "soft_reset_then_recommit" "
@@ -1553,9 +1553,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c3');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 33: Multi-column cell merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- multi-column cell merge ---"
 
 oracle "cell_merge_4_cols" "
@@ -1606,9 +1606,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, a, b FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 34: Repeated merge of same branch
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- repeated merge ---"
 
 oracle "merge_same_branch_twice" "
@@ -1648,9 +1648,9 @@ SELECT dolt_checkout('feat');
 SELECT dolt_merge('main');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 35: Cherry-pick + merge interaction
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- cherry-pick + merge ---"
 
 oracle "cherry_pick_then_merge_same_branch" "
@@ -1670,9 +1670,9 @@ SELECT dolt_cherry_pick('feat~1');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 36: Negative numbers and zero
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- negative numbers and zero ---"
 
 oracle "merge_negative_ids" "
@@ -1707,9 +1707,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, a, b FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 37: Empty string vs NULL
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- empty string vs NULL ---"
 
 oracle "merge_empty_string_vs_null" "
@@ -1728,9 +1728,9 @@ SELECT dolt_commit('-m','main null');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 38: Merge with row-count-only verification
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- row count after merge ---"
 
 oracle "merge_preserves_total_rows" "
@@ -1750,9 +1750,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 39: Multi-column PK merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- multi-column PK merge ---"
 
 oracle "three_col_pk_merge" "
@@ -1787,9 +1787,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT a, b, x, y FROM t ORDER BY a, b;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 40: Merge + add/commit workflow variations
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- add/commit workflow ---"
 
 oracle "add_specific_table" "
@@ -1816,9 +1816,9 @@ INSERT INTO t VALUES(1,'a');
 SELECT dolt_commit('-A', '-m','auto add');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 41: Merge + many data types
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- many data types in merge ---"
 
 oracle "merge_bool_col" "
@@ -1885,9 +1885,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 42: Merge chain (A→B→C merges)
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- merge chains ---"
 
 oracle "serial_branch_merge_chain" "
@@ -1934,9 +1934,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('b2');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 43: Revert + merge interaction
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- revert + merge ---"
 
 oracle "revert_then_merge_same_row" "
@@ -1973,9 +1973,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 44: Multiple table interactions
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- multi-table complex ---"
 
 oracle "merge_3_tables_mixed_ops" "
@@ -2020,9 +2020,9 @@ SELECT dolt_commit('-m','main inserts t2');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t1 ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 45: Idempotent operations
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- idempotent operations ---"
 
 oracle "update_to_same_value" "
@@ -2056,9 +2056,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','insert then delete');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 46: Merge + column default interactions
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- column defaults in merge ---"
 
 oracle "add_col_with_default_then_merge" "
@@ -2093,9 +2093,9 @@ SELECT dolt_commit('-m','main explicit');
 SELECT dolt_merge('feat');
 " "SELECT id, val, status FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 47: Stress cell merge with many columns
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- stress cell merge ---"
 
 oracle "cell_merge_8_cols_interleaved" "
@@ -2131,9 +2131,9 @@ SELECT dolt_commit('-m','main b on evens');
 SELECT dolt_merge('feat');
 " "SELECT id, a, b FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 48: Cherry-pick + FK
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- cherry-pick + FK ---"
 
 oracle "cherry_pick_with_parent_child" "
@@ -2151,9 +2151,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_cherry_pick('feat');
 " "SELECT p.id, p.name FROM parent p ORDER BY p.id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 49: Revert + multi-table
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- revert + multi-table ---"
 
 oracle "revert_multi_table_commit" "
@@ -2170,9 +2170,9 @@ SELECT dolt_commit('-m','add to both');
 SELECT dolt_revert('HEAD');
 " "SELECT 't1' AS tbl, id, val FROM t1 UNION ALL SELECT 't2', id, val FROM t2 ORDER BY 1, 2;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 50: Reset + branch interaction
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- reset + branch ---"
 
 oracle "reset_hard_then_new_work" "
@@ -2209,9 +2209,9 @@ SELECT dolt_reset('--hard','HEAD~1');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 51: Merge + NOT NULL constraints
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- NOT NULL in merge ---"
 
 oracle "merge_not_null_col_update" "
@@ -2246,9 +2246,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 52: Interleaved branch operations
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- interleaved branch ops ---"
 
 oracle "alternating_branch_commits" "
@@ -2309,9 +2309,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('grandchild');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 53: Large delete + merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- large delete + merge ---"
 
 oracle "delete_half_merge_other_half" "
@@ -2346,9 +2346,9 @@ SELECT dolt_commit('-m','main inserts');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 54: Cherry-pick from deep history
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- cherry-pick from deep history ---"
 
 oracle "cherry_pick_2nd_of_3_commits" "
@@ -2370,9 +2370,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_cherry_pick('feat~1');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 55: Merge + UPDATE same row multiple times
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- rapid updates before merge ---"
 
 oracle "multiple_updates_before_commit" "
@@ -2404,9 +2404,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','recreate row');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 56: Merge + CHECK constraints
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- CHECK constraints + merge ---"
 
 oracle "merge_with_check_constraint" "
@@ -2425,9 +2425,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, score FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 57: Merge preserves row ordering
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- row ordering after merge ---"
 
 oracle "merge_preserves_pk_order" "
@@ -2446,9 +2446,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 58: Merge after rename-like operations
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- rename-like operations ---"
 
 oracle "delete_and_reinsert_different_val" "
@@ -2468,9 +2468,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 59: Cross-branch FK integrity
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- cross-branch FK ---"
 
 oracle "fk_both_branches_add_children" "
@@ -2510,9 +2510,9 @@ SELECT dolt_commit('-m','main adds child to p1');
 SELECT dolt_merge('feat');
 " "SELECT p.name, c.val FROM parent p JOIN child c ON c.pid=p.id ORDER BY c.id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 60: Merge + UNIQUE constraint
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- UNIQUE constraint + merge ---"
 
 oracle "unique_col_merge_no_conflict" "
@@ -2547,9 +2547,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, code, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 61: Merge + many rows same table different operations
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- complex row operations merge ---"
 
 oracle "feat_inserts_main_deletes_no_overlap" "
@@ -2620,9 +2620,9 @@ SELECT dolt_commit('-m','main y,z');
 SELECT dolt_merge('feat');
 " "SELECT id, x, y, z FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 62: Multiple merges building on each other
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- accumulating merges ---"
 
 oracle "merge_5_feature_branches" "
@@ -2684,9 +2684,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 63: Merge + various PK types
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- various PK types ---"
 
 oracle "merge_negative_pk" "
@@ -2739,9 +2739,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 64: Cherry-pick + multi-table
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- cherry-pick + multi-table ---"
 
 oracle "cherry_pick_multi_table_commit" "
@@ -2760,9 +2760,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_cherry_pick('feat');
 " "SELECT 't1' AS tbl, id, val FROM t1 UNION ALL SELECT 't2', id, val FROM t2 ORDER BY 1, 2;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 65: Merge + empty values
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- empty string handling ---"
 
 oracle "merge_empty_string_update" "
@@ -2797,9 +2797,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, a, b FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 66: Merge + multiple indexes
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- multiple indexes + merge ---"
 
 oracle "merge_table_with_unique_cols" "
@@ -2820,9 +2820,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, name, age FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 67: Revert + cherry-pick combined
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- revert + cherry-pick ---"
 
 oracle "revert_then_cherry_pick_back" "
@@ -2842,9 +2842,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_cherry_pick('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 68: Merge + auto-increment-like patterns
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- auto-increment patterns ---"
 
 oracle "merge_with_max_id_pattern" "
@@ -2863,9 +2863,9 @@ SELECT dolt_commit('-m','main auto ids');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 69: Complex FK merge scenarios
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- complex FK merge ---"
 
 oracle "fk_insert_parent_one_side_child_other" "
@@ -2905,9 +2905,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT c.id, c.pid, c.val FROM child c ORDER BY c.id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 70: Merge + multiple commits per branch (stress)
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- multi-commit branch stress ---"
 
 oracle "five_commits_per_branch_merge" "
@@ -2937,9 +2937,9 @@ SELECT dolt_commit('-m','m2');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 71: Verify merge doesn't duplicate rows
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- merge row dedup ---"
 
 oracle "no_duplicates_after_merge" "
@@ -2973,9 +2973,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 72: Merge preserves data integrity
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- merge data integrity ---"
 
 oracle "merge_sum_preserved" "
@@ -3010,9 +3010,9 @@ SELECT dolt_commit('-m','main raises max');
 SELECT dolt_merge('feat');
 " "SELECT min(val), max(val) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 73: Cherry-pick preserves other data
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- cherry-pick data preservation ---"
 
 oracle "cherry_pick_doesnt_affect_other_rows" "
@@ -3044,9 +3044,9 @@ SELECT dolt_commit('-m','main changed');
 SELECT dolt_cherry_pick('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 74: Revert preserves other data
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- revert data preservation ---"
 
 oracle "revert_one_row_keeps_others" "
@@ -3061,9 +3061,9 @@ SELECT dolt_commit('-m','changes');
 SELECT dolt_revert('HEAD');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 75: Merge + column ordering
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- column ordering ---"
 
 oracle "select_cols_after_merge" "
@@ -3082,9 +3082,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT first_col, second_col, third_col FROM t WHERE id=1;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 76-80: Merge + various value patterns
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- value patterns in merge ---"
 
 oracle "merge_special_chars_in_text" "
@@ -3167,9 +3167,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 81-85: More FK interaction patterns
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- more FK patterns ---"
 
 oracle "fk_both_add_children_to_same_parent" "
@@ -3264,9 +3264,9 @@ SELECT dolt_commit('-m','main both');
 SELECT dolt_merge('feat');
 " "SELECT p.name, c.val FROM parent p JOIN child c ON c.pid=p.id ORDER BY p.id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 86-90: Merge topology stress
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- merge topology stress ---"
 
 oracle "merge_into_already_merged_branch" "
@@ -3382,9 +3382,9 @@ SELECT dolt_commit('-m','m1');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 91-95: Merge + batch operations
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- batch operations + merge ---"
 
 oracle "batch_insert_then_merge" "
@@ -3435,9 +3435,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, a, b FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 96-100: Edge cases for dolt_status/dolt_add
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- add/status edge cases ---"
 
 oracle "add_after_drop_and_recreate" "
@@ -3463,9 +3463,9 @@ SELECT dolt_commit('-m','staged both');
 " "SELECT 't1' AS tbl, id, val FROM t1 UNION ALL SELECT 't2', id, val FROM t2 ORDER BY 1, 2;"
 
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 101: Conflict boundaries
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- conflict boundaries ---"
 
 oracle "convergent_same_field_same_value" "
@@ -3580,9 +3580,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t WHERE id>=2 ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 102: Commit graph verification
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- commit graph counts ---"
 
 oracle "linear_3_commits_count" "
@@ -3651,9 +3651,9 @@ SELECT dolt_commit('-m','to revert');
 SELECT dolt_revert('HEAD');
 " "SELECT count(*) FROM dolt_log;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 103: PK edge cases
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- PK edge cases in merge ---"
 
 oracle "pk_zero_in_merge" "
@@ -3706,9 +3706,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 104: INT PRIMARY KEY (WITHOUT ROWID)
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- INT PK (WITHOUT ROWID) ---"
 
 oracle "int_pk_insert_merge" "
@@ -3772,9 +3772,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_cherry_pick('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 105: Undo patterns
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- undo patterns ---"
 
 echo "--- merge topology ---"
@@ -3898,9 +3898,9 @@ SELECT dolt_checkout('feat');
 SELECT dolt_merge('main');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 107: Stress cell merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- stress cell merge ---"
 
 oracle "cell_merge_8_cols_interleaved" "
@@ -3971,9 +3971,9 @@ SELECT dolt_commit('-m','main all y');
 SELECT dolt_merge('feat');
 " "SELECT count(*) AS n, count(CASE WHEN x='F' THEN 1 END) AS xf, count(CASE WHEN y='M' THEN 1 END) AS ym FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 108: FK stress
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- FK stress ---"
 
 oracle "fk_self_ref_merge" "
@@ -4033,9 +4033,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM child ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 109: Batch operations
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- batch operations ---"
 
 oracle "batch_insert_merge" "
@@ -4086,9 +4086,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, a, b FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 110: Aggregate verification
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- aggregate verification ---"
 
 oracle "merge_preserves_sum" "
@@ -4144,9 +4144,9 @@ SELECT dolt_merge('feat');
 
 
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 112: Net-no-op commits (empty commit rejected, merge no-op)
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- net-no-op commit + merge ---"
 
 oracle "roundtrip_update_no_net_change" "
@@ -4200,9 +4200,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 92: UPDATE with CASE + merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- UPDATE CASE + merge ---"
 
 oracle "update_case_then_merge" "
@@ -4234,9 +4234,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, CASE WHEN n<10 THEN 's' WHEN n<20 THEN 'm' ELSE 'l' END AS sz FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 93: Subquery in WHERE + merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- subquery WHERE + merge ---"
 
 oracle "update_where_subquery_then_merge" "
@@ -4275,9 +4275,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t1 ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 94: INSERT SELECT + merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- INSERT SELECT + merge ---"
 
 oracle "insert_select_from_other_table_merge" "
@@ -4313,9 +4313,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v, grp FROM t WHERE id>=10 ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 95: LIKE / IN / BETWEEN + merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- LIKE/IN/BETWEEN + merge ---"
 
 oracle "update_where_like_then_merge" "
@@ -4366,9 +4366,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 96: Aggregates after merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- aggregates after merge ---"
 
 oracle "sum_after_merge" "
@@ -4413,9 +4413,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT sum(n)/count(*) AS a FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 97: HEAD~N refs + merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- HEAD~N refs ---"
 
 oracle "reset_to_head_tilde_2" "
@@ -4451,9 +4451,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('side');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 98: allow-empty + merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- allow-empty commit + merge ---"
 
 oracle "allow_empty_then_merge" "
@@ -4482,9 +4482,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 99: Multi-branch diamond patterns
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- diamond via branches ---"
 
 oracle "diamond_with_cell_merge" "
@@ -4525,9 +4525,9 @@ SELECT dolt_merge('left');
 SELECT dolt_merge('right');
 " "SELECT 't1' AS tbl, count(*) AS n FROM t1 UNION ALL SELECT 't2', count(*) FROM t2 ORDER BY 1;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 100: Multi-level FK chain + merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- multi-level FK + merge ---"
 
 oracle "four_level_fk_chain_merge" "
@@ -4555,9 +4555,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT a.v, b.v, c.v, d.v FROM d JOIN c ON d.cid=c.id JOIN b ON c.bid=b.id JOIN a ON b.aid=a.id ORDER BY d.id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 101: Checkout commit hash + data visibility
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- branch from historical commit ---"
 
 oracle "branch_from_past_commit_new_work" "
@@ -4601,9 +4601,9 @@ SELECT dolt_merge('past_a');
 SELECT dolt_merge('past_b');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 102: Conditional UPDATE + cell merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- conditional UPDATE + cell merge ---"
 
 oracle "update_coalesce_then_merge" "
@@ -4638,9 +4638,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, a, b FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 103: LIMIT/OFFSET after merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- LIMIT/OFFSET after merge ---"
 
 oracle "select_limit_after_merge" "
@@ -4669,9 +4669,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id LIMIT 2 OFFSET 2;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 104: DISTINCT/UNION after merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- DISTINCT/UNION after merge ---"
 
 oracle "distinct_after_merge" "
@@ -4703,9 +4703,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT v FROM t1 UNION ALL SELECT v FROM t2 ORDER BY v;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 105: Multi-statement transactions + merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- multiple inserts then merge ---"
 
 oracle "many_inserts_same_batch_merge" "
@@ -4747,9 +4747,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 106: Cherry-pick followed by many ops
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- cherry-pick chain ---"
 
 oracle "cherry_pick_two_commits_sequentially" "
@@ -4784,9 +4784,9 @@ SELECT dolt_reset('--hard','HEAD~1');
 SELECT dolt_cherry_pick('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 107: Deep history + cherry-pick
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- deep history + cherry-pick ---"
 
 oracle "cherry_pick_from_deep_branch" "
@@ -4811,9 +4811,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_cherry_pick('feat~2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 108: UNIQUE + merge complex
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- UNIQUE + merge complex ---"
 
 oracle "unique_col_delete_then_reinsert_merge" "
@@ -4849,9 +4849,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, code1, code2 FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 109: NULL ordering in merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- NULL handling edge cases ---"
 
 oracle "null_to_value_both_sides_different_rows" "
@@ -4883,9 +4883,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) AS null_count FROM t WHERE v IS NULL;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 110: Branch lifecycle + merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- branch lifecycle + merge ---"
 
 oracle "create_merge_delete_branch_data_intact" "
@@ -4925,9 +4925,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 111: Chained updates on same rows + merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- chained updates same row + merge ---"
 
 oracle "many_updates_same_row_feat_merge" "
@@ -4950,9 +4950,9 @@ SELECT dolt_commit('-m','main new row');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 112: HAVING clause + merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- HAVING after merge ---"
 
 oracle "having_after_merge" "
@@ -4968,9 +4968,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT grp, sum(n) AS total FROM t GROUP BY grp HAVING sum(n) > 10 ORDER BY grp;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 113: Mixed column ordering in INSERT + merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- explicit column lists + merge ---"
 
 oracle "insert_named_cols_different_order_merge" "
@@ -4989,9 +4989,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, a, b, c FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 114: Revert chain
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- revert chain ---"
 
 oracle "revert_then_revert_the_revert" "
@@ -5021,9 +5021,9 @@ SELECT dolt_revert('HEAD');
 SELECT dolt_revert('HEAD');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 115: dolt_log filtering after merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- dolt_log after various ops ---"
 
 oracle "log_message_presence_after_merge" "
@@ -5055,9 +5055,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_cherry_pick('feat');
 " "SELECT message FROM dolt_log ORDER BY message;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 116: CHECK constraint interactions
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- CHECK constraint interactions ---"
 
 oracle "check_constraint_multi_row_merge" "
@@ -5092,9 +5092,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 117: Wide PK patterns
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- wide PK patterns + merge ---"
 
 oracle "varchar_pk_merge" "
@@ -5131,9 +5131,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT a, b, v FROM t ORDER BY a, b;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 118: Merge yields predictable working state
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- post-merge working state ---"
 
 oracle "post_merge_immediate_insert" "
@@ -5168,9 +5168,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','post');
 " "SELECT id, v FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 119: Many-branch parallel work
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- parallel branches ---"
 
 oracle "four_parallel_branches_merge" "
@@ -5246,9 +5246,9 @@ SELECT dolt_merge('b5');
 SELECT dolt_merge('b6');
 " "SELECT count(*) AS n, sum(id) AS s FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 120: Merge then immediate revert
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- merge then revert ---"
 
 oracle "revert_merge_commit" "
@@ -5268,9 +5268,9 @@ SELECT dolt_merge('feat','--no-ff','-m','merge feat');
 SELECT dolt_revert('HEAD','-m','1');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 121: FK + delete restriction + merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- FK delete restriction + merge ---"
 
 oracle "fk_delete_parent_with_children_merge" "
@@ -5291,9 +5291,9 @@ SELECT dolt_commit('-m','main more children');
 SELECT dolt_merge('feat');
 " "SELECT id, v, pid FROM child ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 122: EXISTS / NOT EXISTS after merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- EXISTS/NOT EXISTS after merge ---"
 
 oracle "exists_subquery_after_merge" "
@@ -5344,9 +5344,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 123: CTE (WITH clause) + merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- CTE + merge ---"
 
 oracle "cte_select_after_merge" "
@@ -5375,9 +5375,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "WITH gc AS (SELECT grp, count(*) AS c FROM t GROUP BY grp) SELECT grp, c FROM gc ORDER BY grp;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 124: REPLACE/upsert patterns + merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- REPLACE patterns + merge ---"
 
 oracle "replace_on_both_branches_merge" "
@@ -5413,9 +5413,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 125: Multi-row UPDATE with different values
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- multi-row UPDATE + merge ---"
 
 oracle "update_per_id_then_merge" "
@@ -5437,9 +5437,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 126: FK SET NULL on delete + merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- FK cascade-ish behavior + merge ---"
 
 oracle "fk_orphan_possible_when_no_action_merge" "
@@ -5461,9 +5461,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, pid, v FROM child ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 127: REAL/float merge patterns
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- REAL/float merge ---"
 
 oracle "float_merge_different_rows" "
@@ -5495,9 +5495,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, x FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 128: INSERT multiple rows at once + merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- multi-VALUES INSERT + merge ---"
 
 oracle "insert_10_rows_one_stmt_merge" "
@@ -5516,9 +5516,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) AS n, sum(v) AS s FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 129: Commit messages with special chars
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- commit message special chars ---"
 
 oracle "message_with_dashes_merge" "
@@ -5547,9 +5547,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) FROM dolt_log;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 130: Merge with several row additions on each side
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- balanced growth merges ---"
 
 oracle "both_sides_add_5_rows_disjoint" "
@@ -5584,9 +5584,9 @@ SELECT dolt_commit('-m','main delete 8-10');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 131: Merge preserves computed aggregates
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- post-merge aggregate invariants ---"
 
 oracle "min_max_span_unchanged_by_convergent_update" "
@@ -5621,9 +5621,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT count(DISTINCT cat) AS distinct_cats FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 132: Re-merge same branch after update
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- re-merge branch after update ---"
 
 oracle "merge_branch_update_merge_again" "
@@ -5645,9 +5645,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 133: Merge + reset + re-merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- merge + reset + re-merge ---"
 
 oracle "merge_reset_remerge" "
@@ -5665,9 +5665,9 @@ SELECT dolt_reset('--hard','HEAD~1');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 134: Adding a column then populating on a branch
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- alter + populate + merge ---"
 
 oracle "alter_add_col_populate_on_branch_merge" "
@@ -5706,9 +5706,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v, x, y FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 135: Commit hash visibility via dolt_log
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- dolt_log structure after merges ---"
 
 oracle "log_distinct_commit_hashes_count" "
@@ -5740,9 +5740,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) FROM dolt_log WHERE message IN ('first','second','third_on_feat');"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 136: Multi-column indexes + merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- multi-column indexes + merge ---"
 
 oracle "merge_table_with_multi_col_index" "
@@ -5763,9 +5763,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, a, b FROM t ORDER BY a, b;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 137: Deeply nested FK scenarios
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- deep FK scenarios ---"
 
 oracle "fk_update_root_propagates_views_ok" "
@@ -5806,9 +5806,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, pid, v FROM child ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 138: Repeated DROP + CREATE + merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- drop + recreate + merge ---"
 
 oracle "drop_recreate_same_name_merge" "
@@ -5829,9 +5829,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 139: Many-commit linear history + merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- long linear history + merge ---"
 
 oracle "ten_commits_linear_then_branch_merge" "
@@ -5874,9 +5874,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('side');
 " "SELECT count(*) AS n, sum(v) AS s FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 140: String functions in UPDATE + merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- string funcs in UPDATE + merge ---"
 
 oracle "update_lower_then_merge" "
@@ -5908,9 +5908,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t WHERE length(v)>=3 ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 141: Arithmetic in UPDATE + merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- arithmetic UPDATE + merge ---"
 
 oracle "update_multiply_disjoint_merge" "
@@ -5945,9 +5945,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, n FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 142: Self-referential / recursive relations in merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- self-referential merge ---"
 
 oracle "self_ref_fk_new_hierarchy_merge" "
@@ -5966,9 +5966,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, parent_id, v FROM n ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 143: UPDATE with JOIN-like subqueries + merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- UPDATE with correlated subquery + merge ---"
 
 oracle "update_via_correlated_subquery_merge" "
@@ -5989,9 +5989,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 144: Commit chain reshape + merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- commit chain reshape + merge ---"
 
 oracle "amend_like_flow_soft_reset_recommit" "
@@ -6022,9 +6022,9 @@ SELECT dolt_reset('--soft','HEAD~2');
 SELECT dolt_commit('-m','squashed');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 145: Deeply-nested table references
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- multi-table inner join + merge ---"
 
 oracle "three_way_join_after_merge" "
@@ -6061,9 +6061,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT t1.id, CASE WHEN t2.id IS NULL THEN 'none' ELSE t2.v END AS got FROM t1 LEFT JOIN t2 ON t1.id=t2.t1id ORDER BY t1.id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 146: Merging empty branch
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- merge branch with only empty commits ---"
 
 oracle "merge_only_allow_empty_branch" "
@@ -6082,9 +6082,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 147: Convergent conflict types
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- convergent conflict probes ---"
 
 oracle "convergent_update_same_value" "
@@ -6183,9 +6183,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t WHERE id=2;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 148: Self-merge / already-merged probes
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- self-merge probes ---"
 
 oracle "merge_self_is_noop" "
@@ -6214,9 +6214,9 @@ SELECT dolt_merge('feat');
 SELECT dolt_merge('feat');
 " "SELECT count(*) FROM dolt_log;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 149: Cherry-pick edge cases
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- cherry-pick edge probes ---"
 
 oracle "cherry_pick_same_commit_twice" "
@@ -6261,9 +6261,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_cherry_pick('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 150: Reset target probes
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- reset target probes ---"
 
 oracle "reset_to_tag" "
@@ -6293,9 +6293,9 @@ SELECT dolt_commit('-m','c2');
 SELECT dolt_reset('--hard','snap');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 151: Empty merge sources / no-op merges
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- empty/no-op merge probes ---"
 
 oracle "merge_branch_with_no_new_commits" "
@@ -6310,9 +6310,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 152: Cross-type comparison survives merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- type behavior through merge ---"
 
 oracle "int_column_preserved_numeric_equality" "
@@ -6341,9 +6341,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t WHERE s='updated';"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 153: PK/UNIQUE interaction during merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- PK/UNIQUE conflict probes ---"
 
 oracle "both_sides_insert_same_pk_different_values" "
@@ -6378,9 +6378,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t WHERE id=1;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 154: Merge after staging divergence
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- pre-merge staging probes ---"
 
 oracle "merge_with_uncommitted_working_changes" "
@@ -6397,9 +6397,9 @@ INSERT INTO t VALUES(3,'uncommitted');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 155: REPLACE colliding with committed row
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- REPLACE vs merge probes ---"
 
 oracle "replace_then_other_side_replaces_same_pk" "
@@ -6418,9 +6418,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 156: Cell merge fallback
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- cell merge fallback probes ---"
 
 oracle "three_cols_updated_across_sides_no_overlap" "
@@ -6455,9 +6455,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, a, b FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 157: Deep merge + revert semantics
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- merge+revert probes ---"
 
 oracle "revert_noff_merge_commit_row_count" "
@@ -6477,9 +6477,9 @@ SELECT dolt_merge('feat','--no-ff','-m','merged');
 SELECT dolt_revert('HEAD','-m','1');
 " "SELECT count(*) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 158: Large string / blob merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- large payload probes ---"
 
 oracle "blob_different_on_each_side_merge" "
@@ -6498,9 +6498,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, hex(b) FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 159: Deeper cherry-pick / reset probes
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- cherry-pick and reset deeper probes ---"
 
 oracle "cherry_pick_then_hard_reset_clears_it" "
@@ -6553,9 +6553,9 @@ SELECT dolt_cherry_pick('feat~1');
 SELECT dolt_cherry_pick('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 160: Aggregations with NULL through merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- NULL aggregation probes ---"
 
 oracle "sum_ignores_null_after_merge" "
@@ -6584,9 +6584,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT min(n) AS lo, max(n) AS hi FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 161: Row update patterns that provoke edge cases
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- update pattern probes ---"
 
 oracle "update_then_update_back_same_value_merge" "
@@ -6623,9 +6623,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 162: FK + merge where dependency must resolve
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- FK merge dependency probes ---"
 
 oracle "fk_parent_created_one_side_child_other_same_id" "
@@ -6665,9 +6665,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, pid, v FROM child ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 163: Many-row batch + partial conflict
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- batch + partial conflict probes ---"
 
 oracle "batch_50_with_one_conflict_elsewhere" "
@@ -6688,9 +6688,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) FROM t WHERE id BETWEEN 100 AND 119;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 164: ORDER BY with NULL after merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- NULL ordering probes ---"
 
 oracle "nulls_in_order_by_asc_merge" "
@@ -6706,9 +6706,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t WHERE n IS NOT NULL ORDER BY n;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 165: Nested / repeated ALTER through merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- repeated ALTER probes ---"
 
 oracle "alter_drop_recreate_col_through_merge" "
@@ -6728,9 +6728,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, keep FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 166: Reset + merge replay
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- reset then merge replay probes ---"
 
 oracle "reset_then_merge_second_branch" "
@@ -6753,9 +6753,9 @@ SELECT dolt_reset('--hard','HEAD~1');
 SELECT dolt_merge('b2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 167: Commit graph after diamond + revert
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- graph shape probes ---"
 
 oracle "log_count_after_diamond_no_ff" "
@@ -6777,9 +6777,9 @@ SELECT dolt_merge('left','--no-ff','-m','merge left');
 SELECT dolt_merge('right','--no-ff','-m','merge right');
 " "SELECT count(*) FROM dolt_log;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 168: Stale working set scenarios
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- stale working set probes ---"
 
 oracle "insert_commit_reset_hard_uncommitted_insert" "
@@ -6807,9 +6807,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','post');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 169: Table dropped on one side of merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- drop-on-branch probes ---"
 
 oracle "table_dropped_on_feat_merge_to_main" "
@@ -6850,9 +6850,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','marker');
 " "SELECT id FROM marker;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 170: Insert-delete-reinsert on same branch
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- IDR on one branch probes ---"
 
 oracle "insert_delete_reinsert_within_branch_merge" "
@@ -6890,9 +6890,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 171: Revert / cherry-pick inversion
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- revert/cherry-pick inversion probes ---"
 
 oracle "cherry_pick_a_revert_commit" "
@@ -6923,9 +6923,9 @@ SELECT dolt_cherry_pick('feat');
 SELECT dolt_revert('HEAD');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 172: Type / dialect edge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- dialect edge probes ---"
 
 oracle "integer_stored_text_update_merge" "
@@ -6960,9 +6960,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, n FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 173: CHECK that references multiple columns
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- multi-col CHECK probes ---"
 
 oracle "check_on_two_cols_merge" "
@@ -6981,9 +6981,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, a, b FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 174: dolt_diff (vtable) consistency after merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- dolt_diff stability probes ---"
 
 oracle "dolt_diff_summary_row_count_stable" "
@@ -6999,9 +6999,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c3');
 " "SELECT count(*) FROM dolt_diff WHERE table_name='t';"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 175: Commit message identity through branch rename
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- branch rename / move probes ---"
 
 oracle "branch_move_then_merge" "
@@ -7018,9 +7018,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('renamed');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 176: No-op commits stress
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- no-op commit stress probes ---"
 
 oracle "many_allow_empty_then_data" "
@@ -7038,9 +7038,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM dolt_log;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 177: Row deleted on one side, untouched on other
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- one-sided delete probes ---"
 
 oracle "delete_on_feat_untouched_main_merge" "
@@ -7059,9 +7059,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 178: Tag at a specific commit history point
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- tag at non-HEAD probes ---"
 
 oracle "tag_at_past_commit" "
@@ -7079,9 +7079,9 @@ SELECT dolt_tag('mid','HEAD~1');
 SELECT dolt_reset('--hard','mid');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 179: Schema mutation across merge sides
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- schema mutation across merge ---"
 
 oracle "add_col_on_feat_insert_main_merge" "
@@ -7116,16 +7116,16 @@ SELECT dolt_commit('-m','main y');
 SELECT dolt_merge('feat');
 " "SELECT id, v, x, y FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 180: Convergent schema changes
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- convergent schema probes ---"
 
-# NOTE: both_sides_add_same_col_same_type is a known divergence probe —
-# Dolt flags convergent ADD COLUMN as a schema conflict and rolls back
-# (autocommit rollback fix #565), while doltlite merges cleanly and
-# preserves each side's DML. Omitted from suite pending a decision on
-# whose semantics to align with.
+
+
+
+
+
 
 oracle "both_sides_drop_same_column" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, a TEXT, toss TEXT);
@@ -7144,9 +7144,9 @@ SELECT dolt_commit('-m','main drop');
 SELECT dolt_merge('feat');
 " "SELECT id, a FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 181: FK violation post-merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- FK violation on merge probes ---"
 
 oracle "fk_merge_preserves_both_parent_insertions" "
@@ -7169,9 +7169,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) AS parents FROM parent;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 182: Explicit transaction + DML commit flow
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- explicit transaction probes ---"
 
 oracle "begin_commit_across_dolt_commit" "
@@ -7189,9 +7189,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','post');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 183: ALTER table type change implicit
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- implicit column behavior probes ---"
 
 oracle "insert_integer_into_text_col_then_merge" "
@@ -7210,9 +7210,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t WHERE v LIKE '%0%' ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 184: Same row touched many times via merges
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- repeat branch merge probes ---"
 
 oracle "branch_merge_update_merge_update_merge" "
@@ -7240,9 +7240,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 185: Reset immediately after commit
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- reset immediately after commit probes ---"
 
 oracle "commit_then_immediate_hard_reset" "
@@ -7277,9 +7277,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','newer c2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 186: Null + UNIQUE interaction through merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- NULL + UNIQUE merge probes ---"
 
 oracle "unique_allows_multiple_nulls_merge" "
@@ -7298,9 +7298,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, code FROM t ORDER BY id;"
 
-# A multi-column UNIQUE index with one column NULL per row also
-# must not flag a duplicate — SQL standard exempts any row with a
-# NULL in any of the index columns.
+
+
+
 oracle "unique_multi_col_with_one_null_merge" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, a VARCHAR(8), b VARCHAR(8), UNIQUE(a,b));
 INSERT INTO t VALUES(1,'x','y');
@@ -7318,9 +7318,9 @@ SELECT dolt_merge('feat');
 " "SELECT count(*) FROM t;"
 
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 187: Merging a branch whose only change is an alter
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- alter-only branch merge ---"
 
 oracle "feat_only_adds_column_no_rows" "
@@ -7355,9 +7355,9 @@ SELECT dolt_commit('-m','main adds col');
 SELECT dolt_merge('feat');
 " "SELECT id, v, tag FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 188: String padding / whitespace probes
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- whitespace/text probes ---"
 
 oracle "trailing_space_text_merge" "
@@ -7386,9 +7386,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, length(v) AS L FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 189: FK delete restrict through merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- FK delete-restrict probes ---"
 
 oracle "fk_child_referencing_deleted_parent_merge" "
@@ -7410,9 +7410,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) AS np, count(*) FROM parent;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 190: Detailed row/col state after complex flow
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- complex flow final state probes ---"
 
 oracle "complex_flow_final_state" "
@@ -7437,9 +7437,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 191: Recursive CTE after merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- recursive CTE probes ---"
 
 oracle "recursive_cte_count_to_n_after_merge" "
@@ -7468,9 +7468,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "WITH RECURSIVE descend(id, depth) AS (SELECT id, 0 FROM tree WHERE pid IS NULL UNION ALL SELECT t.id, d.depth+1 FROM tree t JOIN descend d ON t.pid=d.id) SELECT depth, count(*) AS n FROM descend GROUP BY depth ORDER BY depth;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 192: Window functions after merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- window function probes ---"
 
 oracle "row_number_after_merge" "
@@ -7525,9 +7525,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, COALESCE(LAG(v) OVER (ORDER BY id), 0) AS prev FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 193: dolt_log introspection
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- dolt_log structural probes ---"
 
 oracle "dolt_log_message_set_after_merge" "
@@ -7565,9 +7565,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','cx003');
 " "SELECT count(*) FROM dolt_log WHERE message LIKE 'cx%';"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 194: Deep history
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- deep history probes ---"
 
 oracle "twenty_commit_log_count" "
@@ -7669,9 +7669,9 @@ SELECT dolt_commit('-m','c9');
 SELECT dolt_reset('--hard','HEAD~5');
 " "SELECT count(*) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 195: Complex boolean WHERE
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- complex WHERE probes ---"
 
 oracle "and_or_not_combined_after_merge" "
@@ -7703,9 +7703,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t WHERE v IN (SELECT v FROM allow) ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 196: Multi-column UPDATE assignment
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- multi-col UPDATE probes ---"
 
 oracle "update_set_multiple_cols_merge" "
@@ -7724,9 +7724,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, a, b, c FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 197: Wide tables (20+ cols) + merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- wide table probes ---"
 
 oracle "twenty_col_table_merge" "
@@ -7745,9 +7745,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, c5, c10, c15, c20 FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 198: Cross-table JOIN UPDATE semantics
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- JOIN UPDATE probes ---"
 
 oracle "update_with_inner_join_lookup_merge" "
@@ -7768,9 +7768,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 199: dolt_status empty after ops
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- dolt_status probes ---"
 
 oracle "status_empty_after_commit" "
@@ -7788,9 +7788,9 @@ SELECT dolt_commit('-m','c1');
 INSERT INTO t VALUES(2,'b');
 " "SELECT count(*) FROM dolt_status WHERE staged=0;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 200: Branch off tag + merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- branch off tag + merge ---"
 
 oracle "branch_from_tag_then_merge" "
@@ -7810,9 +7810,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('from_tag');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 201: Two-column PK + cell merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- two-col PK cell merge probes ---"
 
 oracle "two_col_int_pk_disjoint_updates" "
@@ -7847,9 +7847,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT a, b, v1, v2 FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 202: CASE in SELECT projection after merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- CASE projection probes ---"
 
 oracle "nested_case_projection_after_merge" "
@@ -7865,9 +7865,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, CASE WHEN n<10 THEN 'xs' WHEN n<20 THEN 's' WHEN n<30 THEN 'm' WHEN n<40 THEN 'l' ELSE 'xl' END AS sz FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 203: Multi-branch dependency pattern
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- multi-branch dependency ---"
 
 oracle "chain_of_dependent_branches" "
@@ -7891,9 +7891,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('b3');
 " "SELECT id, v FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 204: INSERT SELECT from aggregated subquery + merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- INSERT SELECT agg probes ---"
 
 oracle "insert_select_from_agg_after_merge" "
@@ -7912,9 +7912,9 @@ SELECT dolt_commit('-m','main new grp');
 SELECT dolt_merge('feat');
 " "SELECT grp, sum(n) AS s FROM src GROUP BY grp ORDER BY grp;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 205: Repeated merge into ff-aware branches
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- repeated ff / noff probes ---"
 
 oracle "ff_same_branch_many_times" "
@@ -7936,9 +7936,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 206: Complex UPSERT-like patterns
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- upsert-like probes ---"
 
 oracle "on_conflict_replace_equivalent_via_replace" "
@@ -7958,9 +7958,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v, n FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 207: Aggregate on empty after delete-all
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- aggregate on empty table probes ---"
 
 oracle "delete_all_sum_null_after_merge" "
@@ -7979,9 +7979,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) AS c FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 208: Concatenated CREATE + INSERT in single commit
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- create+insert same commit probes ---"
 
 oracle "create_and_insert_one_commit_merge" "
@@ -8001,9 +8001,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT 't' AS tbl, count(*) AS n FROM t UNION ALL SELECT 'u', count(*) FROM u ORDER BY 1;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 209: Merge commits don't duplicate history
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- merge commit accounting ---"
 
 oracle "ff_merge_commit_count_equals_branch_commits" "
@@ -8038,9 +8038,9 @@ SELECT dolt_commit('-m','m1');
 SELECT dolt_merge('feat','--no-ff','-m','merge');
 " "SELECT count(*) FROM dolt_log;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 210: String functions + merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- string function probes ---"
 
 oracle "substr_in_select_after_merge" "
@@ -8069,9 +8069,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, REPLACE(v,'world','WORLD') AS r FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 211: GROUP BY with multiple keys
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- multi-key GROUP BY probes ---"
 
 oracle "multi_key_group_by_after_merge" "
@@ -8087,9 +8087,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT a, b, sum(n) AS s FROM t GROUP BY a, b ORDER BY a, b;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 212: Order-sensitive PK + reset
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- PK ordering + reset probes ---"
 
 oracle "insert_reverse_order_pk_after_merge" "
@@ -8105,9 +8105,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 213: NULLIF / IFNULL / COALESCE in merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- NULL-handling funcs after merge ---"
 
 oracle "ifnull_after_merge" "
@@ -8136,9 +8136,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) AS n_null FROM (SELECT NULLIF(v,'sentinel') AS masked FROM t) sub WHERE masked IS NULL;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 214: Branch switch inside sequence of ops
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- mid-sequence branch switches ---"
 
 oracle "back_and_forth_branches_merge" "
@@ -8165,9 +8165,9 @@ SELECT dolt_commit('-m','m2');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 215: Views + VC
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- views + VC ---"
 
 oracle "view_created_on_feat_queried_after_merge" "
@@ -8313,9 +8313,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM active;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 216: Generated columns + VC
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- generated columns + merge ---"
 
 oracle "stored_generated_col_merge" "
@@ -8395,9 +8395,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t WHERE squared > 10 ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 217: FK cascade actions + merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- FK cascade actions + merge ---"
 
 oracle "on_delete_cascade_parent_delete_one_side" "
@@ -8534,9 +8534,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, pid, v FROM child ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 218: Conflict resolution in explicit transaction
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- conflict resolution in txn probes ---"
 
 oracle "resolve_conflict_via_update_their_in_txn" "
@@ -8603,9 +8603,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','post');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 219: dolt_hashof / dolt_hashof_table properties
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- dolt_hashof property probes ---"
 
 oracle "hashof_head_matches_log_top" "
@@ -8676,9 +8676,9 @@ SELECT 2;
 SELECT 3;
 " "SELECT count(*) FROM dolt_log WHERE commit_hash = dolt_hashof('HEAD');"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 220: Many-branch fan-in
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- many-branch fan-in probes ---"
 
 oracle "ten_branch_fan_in" "
@@ -8763,9 +8763,9 @@ SELECT dolt_branch('b7');
 SELECT dolt_branch('b8');
 " "SELECT count(*) FROM dolt_branches;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 221: Schema merge corners
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- schema merge corner probes ---"
 
 oracle "type_widen_int_to_bigint_merge" "
@@ -8816,9 +8816,9 @@ SELECT dolt_commit('-m','main adds row');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 222: Math functions after merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- math function probes ---"
 
 oracle "abs_after_merge" "
@@ -8860,9 +8860,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, -n AS neg FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 223: Tag semantics
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- tag semantics probes ---"
 
 oracle "tag_points_to_commit_hash" "
@@ -8904,9 +8904,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM dolt_log;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 224: Merge-base in complex topologies
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- complex merge base topology ---"
 
 oracle "merge_base_after_merged_branch" "
@@ -8948,9 +8948,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('grandchild');
 " "SELECT id FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 225: Unicode sort + merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- unicode sort probes ---"
 
 oracle "unicode_text_sort_after_merge" "
@@ -8979,9 +8979,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t ORDER BY v;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 226: Deeper log filters
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- log filter probes ---"
 
 oracle "log_commit_hash_prefix_match" "
@@ -9007,9 +9007,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c3');
 " "SELECT count(*) FROM (SELECT commit_hash FROM dolt_log ORDER BY date DESC) sub;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 227: Post-merge data invariants
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- post-merge invariant probes ---"
 
 oracle "row_count_after_ff_merge_unchanged" "
@@ -9041,9 +9041,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 241: Tag as reset target and branch start point
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- tag reuse probes ---"
 
 oracle "reset_to_past_tag" "
@@ -9075,9 +9075,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('hotfix');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 242: Generated columns deeper
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- generated column deeper ---"
 
 oracle "two_stored_generated_cols_merge" "
@@ -9109,9 +9109,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t WHERE doubled >= 20 ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 243: VIEW + data changes on both sides
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- view + changes on both sides ---"
 
 oracle "view_on_feat_data_on_main_merge" "
@@ -9150,9 +9150,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM posv ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 244: Merge-base after multi-hop merges
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- multi-hop merge-base probes ---"
 
 oracle "two_feature_branches_merged_sequentially" "
@@ -9197,9 +9197,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('b');
 " "SELECT count(*) AS n, sum(v) AS s FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 245: Combined schema + data merges
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- schema+data mix probes ---"
 
 oracle "add_col_on_feat_and_insert_then_merge" "
@@ -9238,9 +9238,9 @@ SELECT dolt_commit('-m','main adds main_col');
 SELECT dolt_merge('feat');
 " "SELECT id, v, feat_col, main_col FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 246: Complex WHERE filtering after merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- complex WHERE projection ---"
 
 oracle "where_multi_pred_after_merge" "
@@ -9272,9 +9272,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t1 WHERE ref IN (SELECT id FROM t2 WHERE flag=1) ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 247: Row manipulation edge patterns
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- row manipulation edges ---"
 
 oracle "swap_pks_via_temp_sentinel" "
@@ -9313,9 +9313,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 248: FK merge + null parent edge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- FK null-parent edge ---"
 
 oracle "fk_nullable_pid_on_both_sides_merge" "
@@ -9338,9 +9338,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, pid, v FROM child ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 249: Edge commit patterns
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- edge commit patterns ---"
 
 oracle "commit_dash_A_flag_then_merge" "
@@ -9364,9 +9364,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','another-msg');
 " "SELECT count(*) FROM dolt_log WHERE message IN ('looks-like-arg','another-msg');"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 250: Queries against dolt_branches after ops
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- dolt_branches accounting ---"
 
 oracle "dolt_branches_count_after_creates_and_deletes" "
@@ -9391,9 +9391,9 @@ SELECT dolt_branch('two');
 SELECT dolt_branch('-c','main','three');
 " "SELECT count(*) FROM dolt_branches WHERE name='main';"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 251: More cherry-pick edges
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- cherry-pick edges ---"
 
 oracle "cherry_pick_an_alter_add_col" "
@@ -9423,9 +9423,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_cherry_pick('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 252: Soft reset patterns
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- soft reset patterns ---"
 
 oracle "soft_reset_two_then_squash" "
@@ -9455,11 +9455,11 @@ SELECT dolt_commit('-m','c2');
 SELECT dolt_reset('--soft','HEAD~1');
 " "SELECT id FROM t ORDER BY id;"
 
-# Issue #790 regression coverage: --soft must preserve the staged set
-# so the canonical "amend by soft-reset + recommit" flow works without
-# an explicit re-stage. Previously dolt_reset --soft realigned staged
-# to the target catalog, which made the next dolt_commit fail with
-# "nothing to commit" because the diff against staged was empty.
+
+
+
+
+
 
 oracle "soft_reset_recommit_no_explicit_add" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -9514,9 +9514,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','amended_with_extra');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 228: JSON functions after merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- JSON function probes ---"
 
 oracle "json_extract_simple_after_merge" "
@@ -9561,9 +9561,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, json_extract(j,'\$.v') AS v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 229: SAVEPOINT interactions
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- SAVEPOINT probes ---"
 
 oracle "savepoint_rollback_keeps_outer_insert" "
@@ -9632,9 +9632,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after sp rollback');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 230: REPLACE vs UPDATE semantics
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- REPLACE vs UPDATE probes ---"
 
 oracle "replace_on_existing_pk_merges_like_update" "
@@ -9673,9 +9673,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 231: Large-ish merges (stress-lite)
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- stress-lite merge probes ---"
 
 oracle "merge_50_rows_disjoint_both_sides" "
@@ -9723,9 +9723,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT sum(v) AS s FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 232: Column default expressions through merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- default expression probes ---"
 
 oracle "default_literal_used_in_both_branches_merge" "
@@ -9761,9 +9761,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, a, b FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 233: Merge commit accounting
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- merge commit accounting probes ---"
 
 oracle "noff_merge_has_four_log_entries" "
@@ -9798,9 +9798,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) FROM dolt_log;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 234: Delete-insert ordering
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- delete-insert ordering probes ---"
 
 oracle "delete_insert_same_id_same_branch_merge" "
@@ -9837,9 +9837,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 235: Truncate-like patterns
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- truncate-like probes ---"
 
 oracle "delete_all_one_side_insert_other_merge" "
@@ -9858,9 +9858,9 @@ SELECT dolt_commit('-m','main adds');
 SELECT dolt_merge('feat');
 " "SELECT count(*) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 236: Cherry-pick semantics deeper
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- cherry-pick semantics probes ---"
 
 oracle "cherry_pick_preserves_row_count_on_main" "
@@ -9897,9 +9897,9 @@ SELECT dolt_commit('-m','main t2');
 SELECT dolt_cherry_pick('feat');
 " "SELECT id, v FROM t2 ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 237: Reset then merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- reset then merge probes ---"
 
 oracle "hard_reset_then_merge_brings_back" "
@@ -9919,9 +9919,9 @@ SELECT dolt_reset('--hard','HEAD~1');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 238: Empty tables through merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- empty-table merge probes ---"
 
 oracle "empty_table_created_one_side_merge" "
@@ -9959,9 +9959,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','post b');
 " "SELECT id, v FROM b;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 239: Mixed data type merges
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- mixed type merge probes ---"
 
 oracle "mixed_int_text_real_merge" "
@@ -9981,14 +9981,14 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, n, s, r FROM t;"
 
-# Section 240 (INSERT OR IGNORE / INSERT IGNORE) omitted —
-# SQLite and MySQL use mutually exclusive syntaxes (`INSERT OR IGNORE` vs
-# `INSERT IGNORE`) with no common form accepted by both engines. REPLACE
-# already covers the upsert-on-conflict behavior and is exercised above.
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 253: dolt_merge_base property tests
-# ═══════════════════════════════════════════════════════════════════
+
+
+
+
+
+
+
 echo "--- merge_base probes ---"
 
 oracle "merge_base_matches_log_row" "
@@ -10041,9 +10041,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT CASE WHEN dolt_merge_base('main','feat') = dolt_hashof('HEAD') THEN 1 ELSE 0 END;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 254: ALTER TABLE RENAME COLUMN + merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- rename column probes ---"
 
 oracle "rename_column_on_feat_query_works_after_merge" "
@@ -10079,9 +10079,9 @@ SELECT dolt_commit('-m','main rename');
 SELECT dolt_merge('feat');
 " "SELECT count(*) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 255: ALTER TABLE RENAME TO + merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- rename table probes ---"
 
 oracle "rename_table_on_feat_merge_to_main" "
@@ -10103,9 +10103,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM other ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 256: VIEW on JOIN through merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- view-join probes ---"
 
 oracle "view_on_left_join_after_merge" "
@@ -10143,9 +10143,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT grp, total FROM totals ORDER BY grp;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 257: Multi-commit DML in one branch + merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- multi-commit DML probes ---"
 
 oracle "three_commits_feat_merge" "
@@ -10191,9 +10191,9 @@ SELECT dolt_commit('-m','m2');
 SELECT dolt_merge('feat');
 " "SELECT count(*) AS n, sum(id) AS s FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 258: UPDATE with correlated subquery (deeper)
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- correlated subquery UPDATE deeper ---"
 
 oracle "update_running_total_via_subquery" "
@@ -10230,9 +10230,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, cnt FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 259: Conflict resolution in txn with multiple rows
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- conflict resolve multi-row probes ---"
 
 oracle "resolve_multiple_conflicts_via_update" "
@@ -10260,9 +10260,9 @@ SELECT dolt_commit('-m','resolved');
 COMMIT;
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 260: Post-merge queries with table + FK joins
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- post-merge FK query probes ---"
 
 oracle "three_table_join_filter_after_merge" "
@@ -10288,9 +10288,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT a.cat FROM c JOIN b ON c.bid=b.id JOIN a ON b.aid=a.id WHERE c.score > 60 ORDER BY a.cat;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 261: Ordering semantics through merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- ordering probes ---"
 
 oracle "order_by_desc_with_nulls_merge" "
@@ -10319,9 +10319,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t ORDER BY a, b DESC;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 262: DML batch cherry-pick
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- cherry-pick DML batch probes ---"
 
 oracle "cherry_pick_batch_insert" "
@@ -10357,9 +10357,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_cherry_pick('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 263: VC state after many commits on one branch
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- deep branch probes ---"
 
 oracle "deep_branch_ff_merge_count" "
@@ -10390,9 +10390,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) FROM dolt_log;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 264: Repeated REPLACE + merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- replace stability probes ---"
 
 oracle "replace_every_row_both_sides_merge" "
@@ -10410,9 +10410,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
-# ═══════════════════════════════════════════════════════════════════
-# Section 265: Set operations (UNION/INTERSECT/EXCEPT) after merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- set ops after merge ---"
 
 oracle "union_distinct_after_merge" "
@@ -10460,9 +10460,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT v FROM a EXCEPT SELECT v FROM b ORDER BY v;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 266: Case-insensitive search (via LOWER/UPPER) after merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- case-insensitive lookup ---"
 
 oracle "lower_lookup_after_merge" "
@@ -10491,9 +10491,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t WHERE UPPER(v) LIKE 'RED%' ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 267: Multi-index table + merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- multi-index probes ---"
 
 oracle "two_indexes_both_queried_after_merge" "
@@ -10525,9 +10525,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT count(DISTINCT code) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 268: dolt_branches column shape
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- dolt_branches column shape ---"
 
 oracle "branches_dirty_flag_is_boolean" "
@@ -10546,9 +10546,9 @@ SELECT dolt_commit('-m','c1');
 SELECT dolt_branch('b1');
 " "SELECT count(*) FROM dolt_branches WHERE length(hash) > 0;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 269: dolt_log parent traversal
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- dolt_log parent traversal ---"
 
 oracle "log_has_expected_number_of_merge_commits" "
@@ -10567,9 +10567,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat','--no-ff','-m','merge_c');
 " "SELECT count(*) FROM dolt_log WHERE message='merge_c';"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 270: Complex UPDATE with multiple subqueries
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- complex UPDATE probes ---"
 
 oracle "update_with_min_subquery_merge" "
@@ -10606,9 +10606,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v, active FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 271: Large-ish multi-table merges
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- large multi-table merge probes ---"
 
 oracle "four_tables_each_touched_merge" "
@@ -10639,9 +10639,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT 't1' AS tbl, sum(v) AS s FROM t1 UNION ALL SELECT 't2', sum(v) FROM t2 UNION ALL SELECT 't3', sum(v) FROM t3 UNION ALL SELECT 't4', sum(v) FROM t4 ORDER BY 1;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 272: Boolean-like flags through merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- boolean-like flags through merge ---"
 
 oracle "zero_one_flags_toggled_merge" "
@@ -10660,9 +10660,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, active FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 273: Commit message exact preservation
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- commit message preservation ---"
 
 oracle "message_with_equals_and_slash" "
@@ -10685,9 +10685,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','#123 fix');
 " "SELECT count(*) FROM dolt_log WHERE message IN ('v1.2.3','#123 fix');"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 274: INSERT with column subset + DEFAULT
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- INSERT col subset probes ---"
 
 oracle "insert_subset_cols_different_on_branches" "
@@ -10707,9 +10707,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, a, b, c FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 275: Diamond with convergent delete
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- diamond convergent delete ---"
 
 oracle "diamond_convergent_delete_same_row" "
@@ -10733,9 +10733,9 @@ SELECT dolt_merge('left');
 SELECT dolt_merge('right');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 276: Very long commit messages
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- long messages ---"
 
 oracle "long_message_survives_commit_and_merge" "
@@ -10751,9 +10751,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) FROM dolt_log WHERE length(message) > 50;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 277: dolt_hashof across merges
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- hashof across merges ---"
 
 oracle "hashof_changes_after_noff_merge" "
@@ -10772,9 +10772,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat','--no-ff','-m','merge');
 " "SELECT count(DISTINCT commit_hash) FROM dolt_log;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 278: Checkout back-and-forth with work on both
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- alternating work + checkout ---"
 
 oracle "alternate_commits_both_branches_merge" "
@@ -10806,9 +10806,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT owner, count(*) FROM t GROUP BY owner ORDER BY owner;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 279: Tag listing stability
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- tag list stability ---"
 
 oracle "multiple_tags_listed_in_order" "
@@ -10821,9 +10821,9 @@ SELECT dolt_tag('a_first','HEAD');
 SELECT dolt_tag('m_mid','HEAD');
 " "SELECT tag_name FROM dolt_tags ORDER BY tag_name;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 280: Large string values through merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- long string payload probes ---"
 
 oracle "long_string_update_one_side_merge" "
@@ -10841,9 +10841,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, length(v) AS L FROM t ORDER BY id;"
-# ═══════════════════════════════════════════════════════════════════
-# Section 281: Window function deeper patterns
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- window deeper ---"
 
 oracle "partition_by_frame_after_merge" "
@@ -10898,9 +10898,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, COALESCE(LEAD(v) OVER (ORDER BY id), -1) AS nxt FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 282: Multi-CTE patterns
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- multi-CTE probes ---"
 
 oracle "chained_ctes_across_merge" "
@@ -10929,9 +10929,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "WITH doubled AS (SELECT id, n*2 AS d FROM t), filtered AS (SELECT id, d FROM doubled WHERE d > 15) SELECT id, d FROM filtered ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 283: RIGHT JOIN after merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- RIGHT JOIN probes ---"
 
 oracle "right_join_after_merge" "
@@ -10964,9 +10964,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT owners.id, count(items.id) AS cnt FROM owners LEFT JOIN items ON owners.id=items.owner_id GROUP BY owners.id ORDER BY owners.id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 284: Boolean expressions in SELECT
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- boolean expressions in SELECT ---"
 
 oracle "comparison_result_as_column" "
@@ -10982,9 +10982,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, CASE WHEN n > 20 THEN 1 ELSE 0 END AS big FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 285: INSERT with computed values
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- computed-value INSERT probes ---"
 
 oracle "insert_values_with_subquery_after_merge" "
@@ -11005,9 +11005,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT label, n FROM counts ORDER BY label;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 286: DELETE with JOIN-like WHERE subquery
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- DELETE with subquery ---"
 
 oracle "delete_where_in_select_merge" "
@@ -11029,9 +11029,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 287: Schema-only modifications across branches
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- schema-only modifications ---"
 
 oracle "add_then_drop_col_same_branch_merge" "
@@ -11052,9 +11052,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 288: Max/min with tie-breaking after merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- max/min tie-breaking ---"
 
 oracle "min_tie_break_by_id_after_merge" "
@@ -11070,9 +11070,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t WHERE score = (SELECT min(score) FROM t) ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 289: Mixed COUNT variants after merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- count variants ---"
 
 oracle "count_star_vs_count_col_with_nulls" "
@@ -11088,9 +11088,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) AS c_all, count(v) AS c_nn, count(DISTINCT v) AS c_dist FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 290: Cherry-pick then revert then re-cherry-pick
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- cherry/revert round-trip ---"
 
 oracle "cherry_pick_revert_cherry_pick_same_commit" "
@@ -11108,9 +11108,9 @@ SELECT dolt_revert('HEAD');
 SELECT dolt_cherry_pick('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 291: Multi-column UPDATE with computed values
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- multi-col computed UPDATE ---"
 
 oracle "update_ab_from_c_merge" "
@@ -11129,9 +11129,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, a, b, c FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 292: Dirty branch detection through merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- dirty branch detection ---"
 
 oracle "branch_dirty_after_uncommitted_insert" "
@@ -11152,9 +11152,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM dolt_branches WHERE name='main' AND dirty IN (0,'false');"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 293: Commit order stability
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- commit order probes ---"
 
 oracle "log_ordered_by_commit_order" "
@@ -11170,9 +11170,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','third_commit_abc');
 " "SELECT count(*) FROM dolt_log WHERE message LIKE '%commit_abc';"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 294: Merge preserves row-level integrity
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- row-level integrity ---"
 
 oracle "sum_preserved_across_merge" "
@@ -11191,9 +11191,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT sum(n) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 295: ALTER after merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- alter after merge ---"
 
 oracle "alter_add_col_after_merge" "
@@ -11212,9 +11212,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','post-merge alter');
 " "SELECT id, v, tag FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 296: Multiple simultaneous conflicts in txn resolve
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- multi-conflict txn resolve ---"
 
 oracle "resolve_three_conflicts_via_ours" "
@@ -11241,9 +11241,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','kept ours');
 COMMIT;
 " "SELECT id, v FROM t ORDER BY id;"
-# ═══════════════════════════════════════════════════════════════════
-# Section 297: Self-join on same table
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- self-join probes ---"
 
 oracle "self_join_parent_child_after_merge" "
@@ -11275,9 +11275,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT a.id, count(b.id) AS siblings FROM t a LEFT JOIN t b ON a.gid=b.gid AND a.id<>b.id GROUP BY a.id ORDER BY a.id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 298: View chain (view on view)
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- view chain probes ---"
 
 oracle "view_on_view_after_merge" "
@@ -11313,9 +11313,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM very_bigs ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 299: GROUP_CONCAT basic form
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- GROUP_CONCAT probes ---"
 
 oracle "group_concat_default_separator_after_merge" "
@@ -11344,9 +11344,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT grp, count(*) AS c FROM t GROUP BY grp ORDER BY grp;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 300: Complex subquery patterns
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- complex subquery probes ---"
 
 oracle "scalar_subquery_in_projection_after_merge" "
@@ -11377,9 +11377,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT r.id, (SELECT n FROM t WHERE t.id=r.target) AS tgt_n FROM refs r ORDER BY r.id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 301: Many-branch diamond fan-in
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- diamond fan-in probes ---"
 
 oracle "diamond_fan_5_branches" "
@@ -11419,9 +11419,9 @@ SELECT dolt_merge('d');
 SELECT dolt_merge('e');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 302: UPDATE with ORDER + subquery
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- ordered UPDATE probes ---"
 
 oracle "update_value_via_row_position_merge" "
@@ -11440,9 +11440,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v, pos FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 303: Deep history dolt_log queries
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- deep history log queries ---"
 
 oracle "log_distinct_messages_in_deep_history" "
@@ -11498,9 +11498,9 @@ SELECT dolt_commit('-m','m3');
 SELECT dolt_merge('feat','--no-ff','-m','merged');
 " "SELECT count(*) FROM dolt_log;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 304: Conflict resolution variations
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- conflict resolve variations ---"
 
 oracle "resolve_with_mixed_take_ours_take_theirs" "
@@ -11531,9 +11531,9 @@ SELECT dolt_commit('-m','resolved mixed');
 COMMIT;
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 305: Large batch conflict
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- batch conflict + resolve probes ---"
 
 oracle "ten_rows_conflict_resolve_via_ours" "
@@ -11558,9 +11558,9 @@ SELECT dolt_commit('-m','keep ours');
 COMMIT;
 " "SELECT count(*) FROM t WHERE v='m';"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 306: Post-merge history with both parents
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- merge-commit history ---"
 
 oracle "merge_commit_message_in_log_noff" "
@@ -11579,9 +11579,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat','--no-ff','-m','merged_feat_to_main');
 " "SELECT count(*) FROM dolt_log WHERE message='merged_feat_to_main';"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 307: CREATE TABLE AS SELECT
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- CTAS probes ---"
 
 oracle "ctas_after_merge" "
@@ -11598,9 +11598,9 @@ SELECT dolt_merge('feat');
 CREATE TABLE dst AS SELECT id, n*2 AS n2 FROM src;
 " "SELECT id, n2 FROM dst ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 308: Hash stability across idempotent ops
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- hash stability probes ---"
 
 oracle "hashof_stable_after_empty_reads" "
@@ -11613,9 +11613,9 @@ SELECT * FROM t LIMIT 0;
 SELECT id FROM t WHERE id<0;
 " "SELECT count(*) FROM dolt_log WHERE commit_hash = dolt_hashof('HEAD');"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 309: Delete via subquery touching multiple tables
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- cross-table DELETE probes ---"
 
 oracle "delete_where_id_in_join_result_merge" "
@@ -11638,9 +11638,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 310: Multiple UNIQUE cols distinct after merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- multi-unique cols probes ---"
 
 oracle "two_unique_cols_inserts_disjoint_merge" "
@@ -11658,9 +11658,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT count(DISTINCT code) AS d_code, count(DISTINCT tag) AS d_tag FROM t;"
-# ═══════════════════════════════════════════════════════════════════
-# Section 311: DATE columns + merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- DATE column probes ---"
 
 oracle "date_col_filter_after_merge" "
@@ -11695,9 +11695,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, d FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 312: INSERT SELECT with WHERE / aggregate
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- INSERT SELECT probes ---"
 
 oracle "insert_select_filtered_after_merge" "
@@ -11734,9 +11734,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM dst ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 313: UPDATE FROM-alike via subquery
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- UPDATE-from subquery probes ---"
 
 oracle "update_from_lookup_table_merge" "
@@ -11757,9 +11757,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 314: EXISTS correlated count
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- correlated count probes ---"
 
 oracle "correlated_count_after_merge" "
@@ -11777,9 +11777,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT t.id, (SELECT count(*) FROM related WHERE related.ref=t.id) AS c FROM t ORDER BY t.id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 315: Self-ref FK
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- self-ref FK probes ---"
 
 oracle "self_ref_fk_with_pragma_merge" "
@@ -11799,9 +11799,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, parent_id, v FROM n ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 316: Merging a branch with schema-only changes
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- schema-only branch probes ---"
 
 oracle "schema_only_branch_adds_col_then_merge" "
@@ -11837,9 +11837,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('schema');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 317: Large merges (100 rows each side, disjoint)
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- 100-row merge ---"
 
 oracle "hundred_rows_each_side_disjoint_merge" "
@@ -11866,9 +11866,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) AS n, sum(v) AS s FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 318: Tag + reset + re-tag
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- tag reset probes ---"
 
 oracle "tag_reset_retag_workflow" "
@@ -11894,9 +11894,9 @@ SELECT dolt_commit('-m','c4');
 SELECT dolt_tag('new_stable','HEAD');
 " "SELECT id FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 319: Commit hash consistency
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- hash consistency probes ---"
 
 oracle "hashof_tag_and_head_equal_when_tag_at_head" "
@@ -11907,9 +11907,9 @@ SELECT dolt_commit('-m','c1');
 SELECT dolt_tag('here','HEAD');
 " "SELECT CASE WHEN dolt_hashof('here') = dolt_hashof('HEAD') THEN 1 ELSE 0 END;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 320: Multi-condition UPDATE with CASE
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- UPDATE CASE probes ---"
 
 oracle "update_case_multi_branches_merge" "
@@ -11933,9 +11933,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, n, tier FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 321: Merge-commit vs regular commit
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- merge vs regular commit log ---"
 
 oracle "log_has_base_branches_and_merge" "
@@ -11954,9 +11954,9 @@ SELECT dolt_commit('-m','regular_c3');
 SELECT dolt_merge('feat','--no-ff','-m','merge_c4');
 " "SELECT count(*) FROM dolt_log WHERE message LIKE 'regular_%' OR message LIKE 'merge_%';"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 322: Multi-col CHECK through merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- multi-col CHECK probes ---"
 
 oracle "check_on_multi_cols_merge" "
@@ -11975,9 +11975,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, a, b FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 323: History inspection
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- history inspection probes ---"
 
 oracle "history_shows_commits_touching_table" "
@@ -11993,9 +11993,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c3');
 " "SELECT count(*) FROM dolt_history_t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 324: NULL in UNIQUE constraint, alt pattern
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- NULL unique alt probes ---"
 
 oracle "unique_col_with_null_then_nonnull_merge" "
@@ -12014,9 +12014,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 325: Hashof changes after UPDATE
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- hashof after update ---"
 
 oracle "hashof_differs_after_update_commit" "
@@ -12028,8 +12028,8 @@ UPDATE t SET v=99 WHERE id=1;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(DISTINCT commit_hash) FROM dolt_log;"
-# Section 326: String functions deeper
-# ═══════════════════════════════════════════════════════════════════
+
+
 echo "--- string func deeper ---"
 
 oracle "upper_lower_projection_after_merge" "
@@ -12058,9 +12058,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, SUBSTR(v, 1, 3) AS p, length(v) AS L FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 327: INSERT SELECT from computed rows
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- INSERT SELECT computed probes ---"
 
 oracle "insert_select_arithmetic_row_merge" "
@@ -12081,9 +12081,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM a ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 328: Reset variants revisited
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- reset variant revisit ---"
 
 oracle "reset_hard_tag_then_reset_hard_branch" "
@@ -12114,9 +12114,9 @@ SELECT dolt_commit('-m','c2');
 SELECT dolt_reset('--hard','HEAD');
 " "SELECT id FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 329: Conflict detection + resolve variations
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- conflict resolve patterns ---"
 
 oracle "conflict_inspect_via_dolt_conflicts_count" "
@@ -12163,9 +12163,9 @@ SELECT dolt_commit('-m','resolved by delete');
 COMMIT;
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 330: Multi-table merges with FK
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- multi-table FK merge ---"
 
 oracle "three_table_fk_chain_add_leaves_both_sides" "
@@ -12189,9 +12189,9 @@ SELECT dolt_commit('-m','main leaf');
 SELECT dolt_merge('feat');
 " "SELECT count(*) FROM c;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 331: Long-running branch catch-up merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- long-running branch probes ---"
 
 oracle "feat_behind_main_pull_main_via_merge" "
@@ -12219,9 +12219,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 332: CTEs with aggregation
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- CTE aggregation ---"
 
 oracle "cte_with_having_after_merge" "
@@ -12237,9 +12237,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "WITH totals AS (SELECT grp, sum(n) AS s FROM t GROUP BY grp) SELECT grp, s FROM totals WHERE s > 10 ORDER BY grp;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 333: Index on expression-like column
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- index usage probes ---"
 
 oracle "unique_index_lookup_after_merge" "
@@ -12256,9 +12256,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t WHERE code IN ('B','D') ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 334: Repeated merge from feat
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- repeated merge from feat ---"
 
 oracle "three_updates_three_merges_from_feat" "
@@ -12286,9 +12286,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 335: Empty row edge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- empty row edges ---"
 
 oracle "all_columns_null_except_pk_merge" "
@@ -12307,9 +12307,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, a, b, c FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 336: Query against dolt_history_<table>
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- dolt_history_<table> probes ---"
 
 oracle "history_table_after_updates" "
@@ -12325,9 +12325,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c3');
 " "SELECT count(DISTINCT v) FROM dolt_history_t WHERE id=1;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 337: Aggregates across multi-table
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- multi-table agg ---"
 
 oracle "sum_across_join_after_merge" "
@@ -12345,9 +12345,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT c.name, sum(o.amount) AS total FROM customers c JOIN orders o ON c.id=o.customer_id GROUP BY c.name ORDER BY c.name;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 338: Deep history reset by SHA
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- reset to intermediate commit ---"
 
 oracle "reset_to_headTilde_3_deep" "
@@ -12370,9 +12370,9 @@ SELECT dolt_commit('-m','c5');
 SELECT dolt_reset('--hard','HEAD~3');
 " "SELECT count(*) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 339: Post-merge WHERE by computed expression
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- computed WHERE probes ---"
 
 oracle "where_by_mod_expression_after_merge" "
@@ -12388,9 +12388,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t WHERE n % 5 = 0 ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 340: Log queries from a specific branch
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- per-branch log probes ---"
 
 oracle "log_from_after_merge_sees_both_sides" "
@@ -12409,9 +12409,9 @@ SELECT dolt_commit('-m','main_c');
 SELECT dolt_merge('feat','--no-ff','-m','m_merge');
 " "SELECT count(*) FROM dolt_log WHERE message IN ('base','feat_c','main_c','m_merge');"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 341: INSERT with default + explicit + subquery
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- INSERT partial cols + subquery ---"
 
 oracle "insert_partial_then_subquery_merge" "
@@ -12429,10 +12429,10 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v, s FROM t ORDER BY id;"
-# ═══════════════════════════════════════════════════════════════════
-# ═══════════════════════════════════════════════════════════════════
-# Section 342: Savepoint + dolt_add interaction (post-#598)
-# ═══════════════════════════════════════════════════════════════════
+
+
+
+
 echo "--- savepoint + dolt_add parity ---"
 
 oracle "savepoint_then_dolt_add_rollback_is_noop" "
@@ -12476,9 +12476,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','post');
 " "SELECT count(*) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 343: Subquery in WHERE with NULL
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- subquery in WHERE with NULL ---"
 
 oracle "in_subquery_with_null_after_merge" "
@@ -12496,9 +12496,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM a WHERE id IN (SELECT ref FROM b) ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 344: Cross-branch schema validation
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- cross-branch schema probes ---"
 
 oracle "alter_add_col_populate_query_after_merge" "
@@ -12519,9 +12519,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v, x FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 345: Nested UPDATE + subquery with aggregation
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- nested UPDATE probes ---"
 
 oracle "update_set_based_on_avg_after_merge" "
@@ -12540,9 +12540,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, n FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 346: WITH + DELETE
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- WITH + DELETE probes ---"
 
 oracle "with_cte_as_delete_filter" "
@@ -12561,9 +12561,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, grp, n FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 347: REPLACE + UNIQUE together
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- REPLACE + UNIQUE probes ---"
 
 oracle "replace_with_unique_col_merge" "
@@ -12582,9 +12582,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, code, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 348: Multi-FK cascade-like topology
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- multi-FK topology probes ---"
 
 oracle "multi_fk_no_cascade_parent_preserved" "
@@ -12607,9 +12607,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM p ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 349: Merge with convergent ALTER
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- convergent ALTER probes ---"
 
 oracle "both_sides_rename_same_col_same_name" "
@@ -12630,9 +12630,9 @@ SELECT dolt_commit('-m','main rename');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 350: Commit hash uniqueness through long chain
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- commit hash uniqueness ---"
 
 oracle "commit_hashes_unique_after_15_commits" "
@@ -12684,9 +12684,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c15');
 " "SELECT CASE WHEN count(DISTINCT commit_hash) = count(*) THEN 1 ELSE 0 END FROM dolt_log;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 351: Sparse / scattered updates
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- sparse update probes ---"
 
 oracle "sparse_updates_across_ids_merge" "
@@ -12709,9 +12709,9 @@ SELECT dolt_commit('-m','main sparse');
 SELECT dolt_merge('feat');
 " "SELECT sum(v) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 352: Test dolt_blame after ops
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- dolt_blame probes ---"
 
 oracle "blame_count_equals_rows" "
@@ -12724,9 +12724,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM dolt_blame_t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 353: Repeated cherry-pick in sequence
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- repeated cherry-pick probes ---"
 
 oracle "cherry_pick_4_sequential_from_feat" "
@@ -12754,9 +12754,9 @@ SELECT dolt_cherry_pick('feat~1');
 SELECT dolt_cherry_pick('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 354: LIMIT + OFFSET after merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- LIMIT/OFFSET probes ---"
 
 oracle "limit_offset_after_merge" "
@@ -12772,9 +12772,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t ORDER BY id LIMIT 3 OFFSET 2;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 355: Mix of merges and cherry-picks
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- mix merge/cherry-pick ---"
 
 oracle "merge_branch_then_cherry_pick_from_another" "
@@ -12796,9 +12796,9 @@ SELECT dolt_merge('b1');
 SELECT dolt_cherry_pick('b2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 356: Transaction + dolt_reset inside
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- txn + reset probes ---"
 
 oracle "txn_wraps_reset_then_commit" "
@@ -12816,9 +12816,9 @@ INSERT INTO t VALUES(3);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','post');
 " "SELECT id FROM t ORDER BY id;"
-# ═══════════════════════════════════════════════════════════════════
-# Section 357: Revert merge commit
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- revert merge-commit probes ---"
 
 oracle "revert_noff_merge_reverses_feat_data" "
@@ -12838,9 +12838,9 @@ SELECT dolt_merge('feat','--no-ff','-m','merged');
 SELECT dolt_revert('HEAD','-m','1');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 358: Cherry-pick across schema add
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- cherry-pick across schema ---"
 
 oracle "cherry_pick_commit_with_both_alter_and_insert" "
@@ -12857,9 +12857,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_cherry_pick('feat');
 " "SELECT id, v, extra FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 359: Transaction + dolt_add interaction
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- txn + dolt_add probes ---"
 
 oracle "begin_insert_dolt_add_commit" "
@@ -12885,9 +12885,9 @@ SELECT dolt_add('-A');
 ROLLBACK;
 " "SELECT count(*) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 360: Commit cursor on post-merge head
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- post-merge head state ---"
 
 oracle "post_merge_head_matches_log_top" "
@@ -12906,9 +12906,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat','--no-ff','-m','merge_commit');
 " "SELECT count(*) FROM dolt_log WHERE commit_hash = dolt_hashof('HEAD') AND message='merge_commit';"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 361: Nested subquery deep
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- nested subquery deep ---"
 
 oracle "triple_nested_subquery_after_merge" "
@@ -12924,9 +12924,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t WHERE n > (SELECT avg(n) FROM t WHERE id IN (SELECT id FROM t WHERE n >= 20)) ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 362: Aggregate pruning via WHERE
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- aggregate pruning probes ---"
 
 oracle "sum_filtered_by_where_after_merge" "
@@ -12942,9 +12942,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT grp, sum(n) AS s FROM t WHERE n >= 20 GROUP BY grp HAVING sum(n) > 40 ORDER BY grp;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 363: Many-col UPDATE merges
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- many-col UPDATE probes ---"
 
 oracle "update_5_cols_same_row_merge" "
@@ -12963,9 +12963,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, a, b, c, d, e FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 364: Cherry-pick of schema-only commit
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- cherry-pick schema-only ---"
 
 oracle "cherry_pick_alter_only_commit" "
@@ -12984,9 +12984,9 @@ SELECT dolt_commit('-m','main row');
 SELECT dolt_cherry_pick('feat');
 " "SELECT id, v, flag FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 365: Commit + reset + re-commit equivalence
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- commit/reset/re-commit ---"
 
 oracle "reset_and_recommit_same_data" "
@@ -13003,9 +13003,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2 redo');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 366: Cross-branch tags
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- cross-branch tag probes ---"
 
 oracle "tag_on_feat_branch_visible_on_main_tags" "
@@ -13021,9 +13021,9 @@ SELECT dolt_tag('feat_tag','HEAD');
 SELECT dolt_checkout('main');
 " "SELECT count(*) FROM dolt_tags WHERE tag_name='feat_tag';"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 367: Sub-branch merged then parent reset
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- sub-branch reset after merge ---"
 
 oracle "sub_branch_merge_then_main_reset_keeps_sub_data" "
@@ -13043,9 +13043,9 @@ SELECT dolt_commit('-m','main after');
 SELECT dolt_reset('--hard','HEAD~1');
 " "SELECT id FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 368: Merge with deeply-chained history on both
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- deep both-side history ---"
 
 oracle "5x5_commits_each_side_merge" "
@@ -13088,9 +13088,9 @@ SELECT dolt_commit('-m','m5');
 SELECT dolt_merge('feat');
 " "SELECT count(*) AS n FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 369: Boolean operator edge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- boolean operator edge ---"
 
 oracle "not_null_filter_after_merge" "
@@ -13106,9 +13106,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t WHERE v IS NOT NULL AND v > 20 ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 370: Bit-like flag patterns
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- bit flag patterns ---"
 
 oracle "flags_with_bitwise_and_after_merge" "
@@ -13124,9 +13124,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, flags & 1 AS bit0 FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 371: Re-create table after DROP + merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- drop + recreate + merge ---"
 
 oracle "drop_recreate_different_cols_merge" "
@@ -13147,9 +13147,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 372: Row existence after many modifications
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- row survival probes ---"
 
 oracle "row_survives_many_ops_on_branch" "
@@ -13168,8 +13168,8 @@ SELECT dolt_commit('-m','feat ops');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t;"
-# Section 373: Commit + dolt_hashof variants
-# ═══════════════════════════════════════════════════════════════════
+
+
 echo "--- hashof variants ---"
 
 oracle "hashof_db_differs_across_commits" "
@@ -13194,9 +13194,9 @@ SELECT 1;
 SELECT 2;
 " "SELECT count(*) FROM dolt_log WHERE commit_hash = dolt_hashof('HEAD');"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 374: ROW_NUMBER after merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- ROW_NUMBER probes ---"
 
 oracle "row_number_per_group_after_merge" "
@@ -13212,9 +13212,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, ROW_NUMBER() OVER (PARTITION BY grp ORDER BY score DESC) AS rn FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 375: Many-row cell merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- cell merge many rows ---"
 
 oracle "cell_merge_20_rows_disjoint" "
@@ -13236,9 +13236,9 @@ SELECT dolt_commit('-m','main b');
 SELECT dolt_merge('feat');
 " "SELECT sum(a) AS sa, sum(b) AS sb FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 376: Recursive CTE — generator
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- recursive CTE generator ---"
 
 oracle "recursive_cte_series_join_post_merge" "
@@ -13254,9 +13254,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "WITH RECURSIVE nums(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM nums WHERE n<10) SELECT n, COALESCE((SELECT label FROM t WHERE t.id=nums.n),'none') AS lbl FROM nums ORDER BY n;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 377: UPDATE affecting nothing
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- update affecting nothing ---"
 
 oracle "update_where_false_merge" "
@@ -13276,9 +13276,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 378: ORDER + LIMIT 1 (max-like)
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- order+limit probes ---"
 
 oracle "max_via_order_limit_after_merge" "
@@ -13297,9 +13297,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t ORDER BY v DESC LIMIT 1;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 379: Wide FK graph
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- wide FK graph ---"
 
 oracle "one_parent_three_child_tables_merge" "
@@ -13328,9 +13328,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT 'c1' AS tbl, count(*) AS n FROM c1 UNION ALL SELECT 'c2', count(*) FROM c2 UNION ALL SELECT 'c3', count(*) FROM c3 ORDER BY 1;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 380: Deep diamond merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- deep diamond probes ---"
 
 oracle "diamond_with_3_commits_per_side_noff" "
@@ -13361,9 +13361,9 @@ SELECT dolt_commit('-m','m3');
 SELECT dolt_merge('left','--no-ff','-m','merged');
 " "SELECT count(*) AS n, sum(v) AS s FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 381: Aggregates with ORDER in subquery
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- agg in subquery ---"
 
 oracle "subquery_with_order_in_agg" "
@@ -13379,9 +13379,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT grp, max(v) AS mx FROM t GROUP BY grp ORDER BY grp;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 382: Triple-branch parallel + merge all
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- triple parallel merges ---"
 
 oracle "three_branch_parallel_then_merge_all" "
@@ -13409,9 +13409,9 @@ SELECT dolt_merge('f2');
 SELECT dolt_merge('f3');
 " "SELECT count(*) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 383: Text encoding
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- text encoding probes ---"
 
 oracle "unicode_accented_text_through_merge" "
@@ -13443,9 +13443,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 384: BLOB operations
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- BLOB through merge ---"
 
 oracle "blob_update_one_side_merge" "
@@ -13464,9 +13464,9 @@ SELECT dolt_commit('-m','main tag');
 SELECT dolt_merge('feat');
 " "SELECT id, hex(b), tag FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 385: Long-chain cherry-pick
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- long-chain cherry-pick ---"
 
 oracle "cherry_pick_6_sequential_from_feat" "
@@ -13502,9 +13502,9 @@ SELECT dolt_cherry_pick('feat~1');
 SELECT dolt_cherry_pick('feat');
 " "SELECT count(*) AS n, sum(v) AS s FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 386: Mixed index types
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- mixed index types ---"
 
 oracle "unique_plus_non_unique_index_merge" "
@@ -13525,9 +13525,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT category, count(*) AS n FROM t GROUP BY category ORDER BY category;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 387: Schema diff after merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- schema diff count after merge ---"
 
 oracle "schema_diff_commit_count_after_merge" "
@@ -13546,9 +13546,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) AS n FROM dolt_log WHERE message IN ('c1 added','c2 added');"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 388: UPDATE with CTE source
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- UPDATE cte source ---"
 
 oracle "update_via_cte_subquery_merge" "
@@ -13567,9 +13567,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 389: dolt_status detail
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- dolt_status detail ---"
 
 oracle "dolt_status_new_table_shows" "
@@ -13589,9 +13589,9 @@ SELECT dolt_commit('-m','base');
 UPDATE t SET v='b' WHERE id=1;
 " "SELECT count(*) FROM dolt_status WHERE table_name='t';"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 390: Commit after many no-ops
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- commit after noops ---"
 
 oracle "many_select_then_commit_stable" "
@@ -13607,9 +13607,9 @@ INSERT INTO t VALUES(2);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM dolt_log;"
-# ═══════════════════════════════════════════════════════════════════
-# Section 391: Merge with convergent row + column updates
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- convergent update-same-col same-value ---"
 
 oracle "both_sides_set_same_col_same_value_merge" "
@@ -13630,9 +13630,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 392: dolt_log filter combinations
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- dolt_log filter combos ---"
 
 oracle "log_filter_message_and_ordered" "
@@ -13658,9 +13658,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT CASE WHEN count(*) > 0 THEN 1 ELSE 0 END FROM dolt_log;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 393: Working-set dirty through various ops
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- dirty flag probes ---"
 
 oracle "dirty_1_after_add_no_commit" "
@@ -13682,9 +13682,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM dolt_branches WHERE name='main' AND dirty IN (0,'false');"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 394: Cross-branch FK preservation
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- cross-branch FK preservation ---"
 
 oracle "fk_parent_child_on_feat_merge" "
@@ -13707,9 +13707,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT p.id AS pid, p.v AS pv, c.v AS cv FROM p LEFT JOIN c ON p.id=c.pid ORDER BY p.id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 395: Tag chain reset to old tag
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- tag chain reset ---"
 
 oracle "tag_chain_reset_5_back" "
@@ -13736,9 +13736,9 @@ SELECT dolt_commit('-m','c5');
 SELECT dolt_reset('--hard','v1');
 " "SELECT id FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 396: Idempotency of cherry-pick into main
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- cherry-pick idempotency ---"
 
 oracle "cherry_pick_then_full_merge_same_branch" "
@@ -13758,9 +13758,9 @@ SELECT dolt_cherry_pick('feat~1');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 397: UPDATE with JOIN-like subquery from 2 tables
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- UPDATE subquery 2 tables ---"
 
 oracle "update_select_from_join_merge" "
@@ -13781,9 +13781,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, category_id, price FROM items ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 398: Multi-branch rebase-like workflow
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- rebase-like flow ---"
 
 oracle "branch_reset_to_main_then_merge" "
@@ -13808,9 +13808,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 399: INSERT with NULL default expression
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- NULL default probes ---"
 
 oracle "null_default_merge" "
@@ -13829,9 +13829,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 400: Large multi-col delete + merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- large delete + merge ---"
 
 oracle "delete_half_rows_update_other_half_merge" "
@@ -13850,9 +13850,9 @@ SELECT dolt_commit('-m','main multiplies other half');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 401: Multi-commit conflict resolution via ours
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- multi-commit conflict resolve ---"
 
 oracle "resolve_multi_commit_conflict_via_ours" "
@@ -13879,9 +13879,9 @@ SELECT dolt_commit('-m','kept ours');
 COMMIT;
 " "SELECT id, v FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 402: Rapid alternating branch commits
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- rapid alternation ---"
 
 oracle "alternating_commits_6_times_merge" "
@@ -13916,9 +13916,9 @@ SELECT dolt_commit('-m','m3');
 SELECT dolt_merge('feat');
 " "SELECT owner, count(*) AS n FROM t GROUP BY owner ORDER BY owner;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 403: Commit count invariant across diff ops
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- log invariant ---"
 
 oracle "log_count_unchanged_by_selects" "
@@ -13934,9 +13934,9 @@ SELECT count(*) FROM dolt_branches;
 SELECT count(*) FROM dolt_tags;
 " "SELECT count(*) FROM dolt_log;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 404: Nested WHERE with multiple joins
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- nested WHERE joins ---"
 
 oracle "two_join_with_agg_filter_after_merge" "
@@ -13954,9 +13954,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT c.region, sum(o.amount) AS total FROM customers c JOIN orders o ON c.id=o.cid GROUP BY c.region ORDER BY c.region;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 405: Multi-merge from same feat branch
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- multi-merge from same feat ---"
 
 oracle "merge_feat_twice_after_update" "
@@ -13978,9 +13978,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 406: dolt_hashof_table after merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- hashof_table after merge ---"
 
 oracle "hashof_table_valid_after_merge" "
@@ -13996,9 +13996,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT CASE WHEN length(dolt_hashof_table('t')) > 0 THEN 1 ELSE 0 END;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 407: Repeated dolt_add
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- repeated add ---"
 
 oracle "add_same_table_multiple_times" "
@@ -14013,10 +14013,10 @@ SELECT dolt_add('-A');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM dolt_log;"
-# ═══════════════════════════════════════════════════════════════════
-# ═══════════════════════════════════════════════════════════════════
-# Section 408: Rapid commit then reset cycles
-# ═══════════════════════════════════════════════════════════════════
+
+
+
+
 echo "--- rapid commit-reset cycles ---"
 
 oracle "three_commit_reset_cycles" "
@@ -14037,9 +14037,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2c');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 409: INSERT SELECT from subquery with LIMIT
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- INSERT SELECT LIMIT ---"
 
 oracle "insert_select_limit_after_merge" "
@@ -14059,9 +14059,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM dst ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 410: UPDATE via expression with CASE
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- UPDATE expression ---"
 
 oracle "update_case_increment_merge" "
@@ -14080,9 +14080,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, n, s FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 411: Cherry-pick preserves row on non-target
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- cherry-pick preservation ---"
 
 oracle "cherry_pick_preserves_other_table" "
@@ -14103,9 +14103,9 @@ SELECT dolt_commit('-m','main t2');
 SELECT dolt_cherry_pick('feat');
 " "SELECT 't1' AS tbl, count(*) AS n FROM t1 UNION ALL SELECT 't2', count(*) FROM t2 ORDER BY 1;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 412: Three-side no-ff merge count
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- three-branch merge count ---"
 
 oracle "three_branch_noff_merges" "
@@ -14133,9 +14133,9 @@ SELECT dolt_commit('-m','m2');
 SELECT dolt_merge('b','--no-ff','-m','merge_b');
 " "SELECT count(*) FROM dolt_log WHERE message IN ('merge_a','merge_b');"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 413: Text search via LIKE anchored
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- LIKE anchored ---"
 
 oracle "like_anchored_prefix_after_merge" "
@@ -14151,9 +14151,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t WHERE name LIKE 'a%' ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 414: Very deep commit + reset
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- very deep reset probes ---"
 
 oracle "reset_head_tilde_8" "
@@ -14188,9 +14188,9 @@ SELECT dolt_commit('-m','c9');
 SELECT dolt_reset('--hard','HEAD~8');
 " "SELECT count(*) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 415: FK + UPDATE through merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- FK update through merge ---"
 
 oracle "fk_update_parent_attribute_merge" "
@@ -14212,9 +14212,9 @@ SELECT dolt_commit('-m','main child');
 SELECT dolt_merge('feat');
 " "SELECT p.v AS pv, c.v AS cv FROM p JOIN c ON p.id=c.pid ORDER BY p.id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 416: Three-branch tag snapshot
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- three-branch tag snapshots ---"
 
 oracle "tags_snapshot_three_branches" "
@@ -14237,9 +14237,9 @@ SELECT dolt_tag('b2_snap','HEAD');
 SELECT dolt_checkout('main');
 " "SELECT count(*) FROM dolt_tags;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 417: Revert a revert
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- revert-a-revert ---"
 
 oracle "revert_then_revert_restores_data" "
@@ -14254,9 +14254,9 @@ SELECT dolt_revert('HEAD');
 SELECT dolt_revert('HEAD');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 418: WHERE with BETWEEN edges
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- BETWEEN edges ---"
 
 oracle "between_inclusive_edges_after_merge" "
@@ -14272,9 +14272,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t WHERE v BETWEEN 20 AND 40 ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 419: INSERT SELECT with GROUP BY
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- INSERT SELECT GROUP BY ---"
 
 oracle "insert_select_group_by_merge" "
@@ -14295,9 +14295,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT grp, total FROM totals ORDER BY grp;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 420: Multiple merges from 4 branches
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- 4 branch merges ---"
 
 oracle "four_branch_serial_merge_row_count" "
@@ -14331,9 +14331,9 @@ SELECT dolt_merge('b3');
 SELECT dolt_merge('b4');
 " "SELECT count(*) FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 421: Large schema — 30 cols
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- 30-col table merge ---"
 
 oracle "thirty_col_table_merge" "
@@ -14358,9 +14358,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, c01, c15, c25, c30 FROM t;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 422: REPLACE INTO with multiple rows
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- multi-row REPLACE ---"
 
 oracle "multi_row_replace_merge" "
@@ -14379,9 +14379,9 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 423: Post-merge ORDER BY with tie-break on secondary
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- tie-break ORDER BY ---"
 
 oracle "order_by_with_tiebreak_after_merge" "
@@ -14397,9 +14397,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t ORDER BY n, grp, id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 424: Stress log query (30 commits)
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- stress log ---"
 
 oracle "thirty_commit_log_hash_uniqueness" "
@@ -14450,9 +14450,9 @@ INSERT INTO t VALUES(15);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c15');
 " "SELECT CASE WHEN count(DISTINCT commit_hash) = count(*) THEN 1 ELSE 0 END FROM dolt_log;"
-# ═══════════════════════════════════════════════════════════════════
-# Section 425: Final push — crossing 1000 tests
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- final probes ---"
 
 oracle "one_k_update_after_ff_merge" "
@@ -14613,9 +14613,9 @@ INSERT INTO t VALUES(1),(2),(3);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','milestone');
 " "SELECT count(*) AS n FROM t;"
-# ═══════════════════════════════════════════════════════════════════
-# Results
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then

--- a/test/vc_oracle_feature_interaction_test.sh
+++ b/test/vc_oracle_feature_interaction_test.sh
@@ -1,14 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
-
 set -u
 set -o pipefail
 
@@ -20,27 +11,14 @@ pass=0; fail=0
 FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
-
 normalize() {
   tr -d '\r' | grep -v '^$' | sort
 }
-
-
-
 
 oracle() {
   local name="$1" setup="$2" query="$3"
   local dir="$TMPROOT/$name"
   mkdir -p "$dir/dl" "$dir/dt"
-
-
-
-
-
-
-
-
-
 
   printf "%s\n" "$setup" | "$DOLTLITE" "$dir/dl/db" \
       >/dev/null 2>"$dir/dl.err"
@@ -51,7 +29,6 @@ oracle() {
            | grep -vi 'Fast-forward' \
            | tr -d '"' \
            | normalize)
-
 
   local dolt_setup
   dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
@@ -81,9 +58,6 @@ oracle() {
 
 echo "=== Feature Interaction Oracle Tests ==="
 echo ""
-
-
-
 
 echo "--- merge + alter table add column ---"
 
@@ -156,9 +130,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main changes');
 SELECT dolt_merge('feat');
 " "SELECT id, name FROM t ORDER BY id;"
-
-
-
 
 echo "--- merge + DML combinations ---"
 
@@ -261,9 +232,6 @@ SELECT dolt_commit('-m','main mix');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-
-
-
 echo "--- merge + composite PK ---"
 
 oracle "merge_composite_pk_insert" "
@@ -316,9 +284,6 @@ SELECT dolt_commit('-m','main update');
 SELECT dolt_merge('feat');
 " "SELECT a, b, val FROM t ORDER BY a, b;"
 
-
-
-
 echo "--- merge + NULL values ---"
 
 oracle "merge_null_to_value" "
@@ -368,9 +333,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main fills c');
 SELECT dolt_merge('feat');
 " "SELECT id, a, b, c FROM t ORDER BY id;"
-
-
-
 
 echo "--- cherry-pick ---"
 
@@ -432,9 +394,6 @@ SELECT dolt_commit('-m','main diverge');
 SELECT dolt_cherry_pick('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-
-
-
 echo "--- revert ---"
 
 oracle "revert_insert" "
@@ -470,9 +429,6 @@ SELECT dolt_commit('-m','update');
 SELECT dolt_revert('HEAD');
 " "SELECT id, val FROM t ORDER BY id;"
 
-
-
-
 echo "--- reset ---"
 
 oracle "reset_soft_keeps_working" "
@@ -496,9 +452,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','second');
 SELECT dolt_reset('--hard', 'HEAD~1');
 " "SELECT id, val FROM t ORDER BY id;"
-
-
-
 
 echo "--- multi-table merges ---"
 
@@ -557,9 +510,6 @@ SELECT dolt_commit('-m','main modifies t1');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t1 ORDER BY id;"
 
-
-
-
 echo "--- upsert + version control ---"
 
 oracle "upsert_replace_then_merge" "
@@ -593,9 +543,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main insert');
 SELECT dolt_merge('feat');
 " "SELECT id, val, count FROM t ORDER BY id;"
-
-
-
 
 echo "--- text/blob in merge ---"
 
@@ -631,9 +578,6 @@ SELECT dolt_commit('-m','main insert');
 SELECT dolt_merge('feat');
 " "SELECT id, hex(data) FROM t ORDER BY id;"
 
-
-
-
 echo "--- numeric types in merge ---"
 
 oracle "merge_integer_types" "
@@ -668,9 +612,6 @@ SELECT dolt_commit('-m','main insert');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-
-
-
 echo "--- fast-forward vs three-way ---"
 
 oracle "ff_merge_no_divergence" "
@@ -698,9 +639,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat', '--no-ff', '-m', 'merge feat');
 " "SELECT id, val FROM t ORDER BY id;"
-
-
-
 
 echo "--- branch + checkout ---"
 
@@ -730,9 +668,6 @@ INSERT INTO t VALUES(3,'main');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main commit');
 " "SELECT id, val FROM t ORDER BY id;"
-
-
-
 
 echo "--- sequential merges ---"
 
@@ -772,9 +707,6 @@ SELECT dolt_cherry_pick('feat~1');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-
-
-
 echo "--- default values in merge ---"
 
 oracle "merge_with_default_col" "
@@ -792,9 +724,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main insert explicit');
 SELECT dolt_merge('feat');
 " "SELECT id, val, num FROM t ORDER BY id;"
-
-
-
 
 echo "--- large row counts ---"
 
@@ -831,9 +760,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main updates 6-10');
 SELECT dolt_merge('feat');
 " "SELECT sum(val) FROM t;"
-
-
-
 
 echo "--- empty/boundary conditions ---"
 
@@ -876,9 +802,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_cherry_pick('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-
-
-
 echo "--- tag interactions ---"
 
 oracle "tag_survives_branch_delete" "
@@ -895,9 +818,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_branch('-d', 'feat');
 SELECT dolt_checkout('v1');
 " "SELECT id, val FROM t ORDER BY id;"
-
-
-
 
 echo "--- wide tables ---"
 
@@ -916,9 +836,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main updates c5,c7');
 SELECT dolt_merge('feat');
 " "SELECT id, c1, c2, c3, c4, c5, c6, c7, c8 FROM t ORDER BY id;"
-
-
-
 
 echo "--- savepoint + commit ---"
 
@@ -946,9 +863,6 @@ INSERT INTO t VALUES(3,'c');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','multiple dml');
 " "SELECT id, val FROM t ORDER BY id;"
-
-
-
 
 echo "--- merge + foreign keys ---"
 
@@ -1026,9 +940,6 @@ SELECT dolt_commit('-m','main adds child');
 SELECT dolt_merge('feat');
 " "SELECT c.id, c.pid, c.val FROM child c ORDER BY c.id;"
 
-
-
-
 echo "--- merge + secondary indexes ---"
 
 oracle "merge_with_indexed_col_insert" "
@@ -1102,9 +1013,6 @@ SELECT dolt_commit('-m','main changes');
 SELECT dolt_merge('feat');
 " "SELECT id, a, b, val FROM t ORDER BY a, b, id;"
 
-
-
-
 echo "--- cherry-pick edge cases ---"
 
 oracle "cherry_pick_into_diverged_table" "
@@ -1154,9 +1062,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_cherry_pick('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-
-
-
 echo "--- revert edge cases ---"
 
 oracle "revert_middle_commit" "
@@ -1197,9 +1102,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','update');
 SELECT dolt_revert('HEAD');
 " "SELECT id, val, num FROM t ORDER BY id;"
-
-
-
 
 echo "--- diamond merges ---"
 
@@ -1266,9 +1168,6 @@ SELECT dolt_merge('b2');
 SELECT dolt_merge('b3');
 " "SELECT id, val FROM t ORDER BY id;"
 
-
-
-
 echo "--- multi-table FK merge ---"
 
 oracle "fk_cascade_not_triggered_by_merge" "
@@ -1308,9 +1207,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main updates c');
 SELECT dolt_merge('feat');
 " "SELECT a.val, b.val, c.val FROM a JOIN b ON b.aid=a.id JOIN c ON c.bid=b.id;"
-
-
-
 
 echo "--- deep branch history merge ---"
 
@@ -1364,9 +1260,6 @@ SELECT dolt_commit('-m','main c2');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-
-
-
 echo "--- type coercion ---"
 
 oracle "merge_int_stored_as_text" "
@@ -1401,9 +1294,6 @@ SELECT dolt_commit('-m','main fills real');
 SELECT dolt_merge('feat');
 " "SELECT id, a, b, c FROM t ORDER BY id;"
 
-
-
-
 echo "--- schema-only changes ---"
 
 oracle "add_col_no_data_change" "
@@ -1427,9 +1317,6 @@ INSERT INTO t VALUES(2,'b',50);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','add and populate');
 " "SELECT id, val, score FROM t ORDER BY id;"
-
-
-
 
 echo "--- drop table interactions ---"
 
@@ -1467,9 +1354,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main modifies t1');
 SELECT dolt_merge('feat');
 " "SELECT 't1' AS tbl, id FROM t1 UNION ALL SELECT 't2', id FROM t2 ORDER BY 1, 2;"
-
-
-
 
 echo "--- convergent modifications ---"
 
@@ -1521,9 +1405,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-
-
-
 echo "--- reset edge cases ---"
 
 oracle "soft_reset_then_recommit" "
@@ -1552,9 +1433,6 @@ INSERT INTO t VALUES(3,'after_reset');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c3');
 " "SELECT id, val FROM t ORDER BY id;"
-
-
-
 
 echo "--- multi-column cell merge ---"
 
@@ -1606,9 +1484,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, a, b FROM t ORDER BY id;"
 
-
-
-
 echo "--- repeated merge ---"
 
 oracle "merge_same_branch_twice" "
@@ -1648,9 +1523,6 @@ SELECT dolt_checkout('feat');
 SELECT dolt_merge('main');
 " "SELECT id, val FROM t ORDER BY id;"
 
-
-
-
 echo "--- cherry-pick + merge ---"
 
 oracle "cherry_pick_then_merge_same_branch" "
@@ -1669,9 +1541,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_cherry_pick('feat~1');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
-
-
-
 
 echo "--- negative numbers and zero ---"
 
@@ -1707,9 +1576,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, a, b FROM t ORDER BY id;"
 
-
-
-
 echo "--- empty string vs NULL ---"
 
 oracle "merge_empty_string_vs_null" "
@@ -1727,9 +1593,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main null');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
-
-
-
 
 echo "--- row count after merge ---"
 
@@ -1749,9 +1612,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) FROM t;"
-
-
-
 
 echo "--- multi-column PK merge ---"
 
@@ -1787,9 +1647,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT a, b, x, y FROM t ORDER BY a, b;"
 
-
-
-
 echo "--- add/commit workflow ---"
 
 oracle "add_specific_table" "
@@ -1815,9 +1672,6 @@ CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT);
 INSERT INTO t VALUES(1,'a');
 SELECT dolt_commit('-A', '-m','auto add');
 " "SELECT id, val FROM t ORDER BY id;"
-
-
-
 
 echo "--- many data types in merge ---"
 
@@ -1885,9 +1739,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-
-
-
 echo "--- merge chains ---"
 
 oracle "serial_branch_merge_chain" "
@@ -1934,9 +1785,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('b2');
 " "SELECT id, val FROM t ORDER BY id;"
 
-
-
-
 echo "--- revert + merge ---"
 
 oracle "revert_then_merge_same_row" "
@@ -1972,9 +1820,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
-
-
-
 
 echo "--- multi-table complex ---"
 
@@ -2020,9 +1865,6 @@ SELECT dolt_commit('-m','main inserts t2');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t1 ORDER BY id;"
 
-
-
-
 echo "--- idempotent operations ---"
 
 oracle "update_to_same_value" "
@@ -2055,9 +1897,6 @@ DELETE FROM t WHERE id=2;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','insert then delete');
 " "SELECT id, val FROM t ORDER BY id;"
-
-
-
 
 echo "--- column defaults in merge ---"
 
@@ -2092,9 +1931,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main explicit');
 SELECT dolt_merge('feat');
 " "SELECT id, val, status FROM t ORDER BY id;"
-
-
-
 
 echo "--- stress cell merge ---"
 
@@ -2131,9 +1967,6 @@ SELECT dolt_commit('-m','main b on evens');
 SELECT dolt_merge('feat');
 " "SELECT id, a, b FROM t ORDER BY id;"
 
-
-
-
 echo "--- cherry-pick + FK ---"
 
 oracle "cherry_pick_with_parent_child" "
@@ -2151,9 +1984,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_cherry_pick('feat');
 " "SELECT p.id, p.name FROM parent p ORDER BY p.id;"
 
-
-
-
 echo "--- revert + multi-table ---"
 
 oracle "revert_multi_table_commit" "
@@ -2169,9 +1999,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','add to both');
 SELECT dolt_revert('HEAD');
 " "SELECT 't1' AS tbl, id, val FROM t1 UNION ALL SELECT 't2', id, val FROM t2 ORDER BY 1, 2;"
-
-
-
 
 echo "--- reset + branch ---"
 
@@ -2209,9 +2036,6 @@ SELECT dolt_reset('--hard','HEAD~1');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-
-
-
 echo "--- NOT NULL in merge ---"
 
 oracle "merge_not_null_col_update" "
@@ -2245,9 +2069,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
-
-
-
 
 echo "--- interleaved branch ops ---"
 
@@ -2309,9 +2130,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('grandchild');
 " "SELECT id, val FROM t ORDER BY id;"
 
-
-
-
 echo "--- large delete + merge ---"
 
 oracle "delete_half_merge_other_half" "
@@ -2346,9 +2164,6 @@ SELECT dolt_commit('-m','main inserts');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-
-
-
 echo "--- cherry-pick from deep history ---"
 
 oracle "cherry_pick_2nd_of_3_commits" "
@@ -2369,9 +2184,6 @@ SELECT dolt_commit('-m','feat c3');
 SELECT dolt_checkout('main');
 SELECT dolt_cherry_pick('feat~1');
 " "SELECT id, val FROM t ORDER BY id;"
-
-
-
 
 echo "--- rapid updates before merge ---"
 
@@ -2404,9 +2216,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','recreate row');
 " "SELECT id, val FROM t ORDER BY id;"
 
-
-
-
 echo "--- CHECK constraints + merge ---"
 
 oracle "merge_with_check_constraint" "
@@ -2424,9 +2233,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, score FROM t ORDER BY id;"
-
-
-
 
 echo "--- row ordering after merge ---"
 
@@ -2446,9 +2252,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-
-
-
 echo "--- rename-like operations ---"
 
 oracle "delete_and_reinsert_different_val" "
@@ -2467,9 +2270,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
-
-
-
 
 echo "--- cross-branch FK ---"
 
@@ -2510,9 +2310,6 @@ SELECT dolt_commit('-m','main adds child to p1');
 SELECT dolt_merge('feat');
 " "SELECT p.name, c.val FROM parent p JOIN child c ON c.pid=p.id ORDER BY c.id;"
 
-
-
-
 echo "--- UNIQUE constraint + merge ---"
 
 oracle "unique_col_merge_no_conflict" "
@@ -2546,9 +2343,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, code, val FROM t ORDER BY id;"
-
-
-
 
 echo "--- complex row operations merge ---"
 
@@ -2620,9 +2414,6 @@ SELECT dolt_commit('-m','main y,z');
 SELECT dolt_merge('feat');
 " "SELECT id, x, y, z FROM t ORDER BY id;"
 
-
-
-
 echo "--- accumulating merges ---"
 
 oracle "merge_5_feature_branches" "
@@ -2684,9 +2475,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-
-
-
 echo "--- various PK types ---"
 
 oracle "merge_negative_pk" "
@@ -2739,9 +2527,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-
-
-
 echo "--- cherry-pick + multi-table ---"
 
 oracle "cherry_pick_multi_table_commit" "
@@ -2759,9 +2544,6 @@ SELECT dolt_commit('-m','feat adds to both');
 SELECT dolt_checkout('main');
 SELECT dolt_cherry_pick('feat');
 " "SELECT 't1' AS tbl, id, val FROM t1 UNION ALL SELECT 't2', id, val FROM t2 ORDER BY 1, 2;"
-
-
-
 
 echo "--- empty string handling ---"
 
@@ -2797,9 +2579,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, a, b FROM t ORDER BY id;"
 
-
-
-
 echo "--- multiple indexes + merge ---"
 
 oracle "merge_table_with_unique_cols" "
@@ -2820,9 +2599,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, name, age FROM t ORDER BY id;"
 
-
-
-
 echo "--- revert + cherry-pick ---"
 
 oracle "revert_then_cherry_pick_back" "
@@ -2842,9 +2618,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_cherry_pick('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-
-
-
 echo "--- auto-increment patterns ---"
 
 oracle "merge_with_max_id_pattern" "
@@ -2862,9 +2635,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main auto ids');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
-
-
-
 
 echo "--- complex FK merge ---"
 
@@ -2905,9 +2675,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT c.id, c.pid, c.val FROM child c ORDER BY c.id;"
 
-
-
-
 echo "--- multi-commit branch stress ---"
 
 oracle "five_commits_per_branch_merge" "
@@ -2936,9 +2703,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','m2');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
-
-
-
 
 echo "--- merge row dedup ---"
 
@@ -2972,9 +2736,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) FROM t;"
-
-
-
 
 echo "--- merge data integrity ---"
 
@@ -3010,9 +2771,6 @@ SELECT dolt_commit('-m','main raises max');
 SELECT dolt_merge('feat');
 " "SELECT min(val), max(val) FROM t;"
 
-
-
-
 echo "--- cherry-pick data preservation ---"
 
 oracle "cherry_pick_doesnt_affect_other_rows" "
@@ -3044,9 +2802,6 @@ SELECT dolt_commit('-m','main changed');
 SELECT dolt_cherry_pick('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-
-
-
 echo "--- revert data preservation ---"
 
 oracle "revert_one_row_keeps_others" "
@@ -3060,9 +2815,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','changes');
 SELECT dolt_revert('HEAD');
 " "SELECT id, val FROM t ORDER BY id;"
-
-
-
 
 echo "--- column ordering ---"
 
@@ -3081,9 +2833,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT first_col, second_col, third_col FROM t WHERE id=1;"
-
-
-
 
 echo "--- value patterns in merge ---"
 
@@ -3166,9 +2915,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
-
-
-
 
 echo "--- more FK patterns ---"
 
@@ -3263,9 +3009,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main both');
 SELECT dolt_merge('feat');
 " "SELECT p.name, c.val FROM parent p JOIN child c ON c.pid=p.id ORDER BY p.id;"
-
-
-
 
 echo "--- merge topology stress ---"
 
@@ -3382,9 +3125,6 @@ SELECT dolt_commit('-m','m1');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-
-
-
 echo "--- batch operations + merge ---"
 
 oracle "batch_insert_then_merge" "
@@ -3435,9 +3175,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, a, b FROM t ORDER BY id;"
 
-
-
-
 echo "--- add/status edge cases ---"
 
 oracle "add_after_drop_and_recreate" "
@@ -3461,10 +3198,6 @@ INSERT INTO t2 VALUES(1,'x');
 SELECT dolt_add('t2');
 SELECT dolt_commit('-m','staged both');
 " "SELECT 't1' AS tbl, id, val FROM t1 UNION ALL SELECT 't2', id, val FROM t2 ORDER BY 1, 2;"
-
-
-
-
 
 echo "--- conflict boundaries ---"
 
@@ -3580,9 +3313,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t WHERE id>=2 ORDER BY id;"
 
-
-
-
 echo "--- commit graph counts ---"
 
 oracle "linear_3_commits_count" "
@@ -3651,9 +3381,6 @@ SELECT dolt_commit('-m','to revert');
 SELECT dolt_revert('HEAD');
 " "SELECT count(*) FROM dolt_log;"
 
-
-
-
 echo "--- PK edge cases in merge ---"
 
 oracle "pk_zero_in_merge" "
@@ -3705,9 +3432,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
-
-
-
 
 echo "--- INT PK (WITHOUT ROWID) ---"
 
@@ -3771,9 +3495,6 @@ SELECT dolt_commit('-m','cherry');
 SELECT dolt_checkout('main');
 SELECT dolt_cherry_pick('feat');
 " "SELECT id, val FROM t ORDER BY id;"
-
-
-
 
 echo "--- undo patterns ---"
 
@@ -3898,9 +3619,6 @@ SELECT dolt_checkout('feat');
 SELECT dolt_merge('main');
 " "SELECT id, val FROM t ORDER BY id;"
 
-
-
-
 echo "--- stress cell merge ---"
 
 oracle "cell_merge_8_cols_interleaved" "
@@ -3971,9 +3689,6 @@ SELECT dolt_commit('-m','main all y');
 SELECT dolt_merge('feat');
 " "SELECT count(*) AS n, count(CASE WHEN x='F' THEN 1 END) AS xf, count(CASE WHEN y='M' THEN 1 END) AS ym FROM t;"
 
-
-
-
 echo "--- FK stress ---"
 
 oracle "fk_self_ref_merge" "
@@ -4033,9 +3748,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM child ORDER BY id;"
 
-
-
-
 echo "--- batch operations ---"
 
 oracle "batch_insert_merge" "
@@ -4085,9 +3797,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, a, b FROM t ORDER BY id;"
-
-
-
 
 echo "--- aggregate verification ---"
 
@@ -4142,11 +3851,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT grp, count(*), sum(val) FROM t GROUP BY grp ORDER BY grp;"
 
-
-
-
-
-
 echo "--- net-no-op commit + merge ---"
 
 oracle "roundtrip_update_no_net_change" "
@@ -4200,9 +3904,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
 
-
-
-
 echo "--- UPDATE CASE + merge ---"
 
 oracle "update_case_then_merge" "
@@ -4233,9 +3934,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, CASE WHEN n<10 THEN 's' WHEN n<20 THEN 'm' ELSE 'l' END AS sz FROM t ORDER BY id;"
-
-
-
 
 echo "--- subquery WHERE + merge ---"
 
@@ -4275,9 +3973,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t1 ORDER BY id;"
 
-
-
-
 echo "--- INSERT SELECT + merge ---"
 
 oracle "insert_select_from_other_table_merge" "
@@ -4312,9 +4007,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v, grp FROM t WHERE id>=10 ORDER BY id;"
-
-
-
 
 echo "--- LIKE/IN/BETWEEN + merge ---"
 
@@ -4366,9 +4058,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- aggregates after merge ---"
 
 oracle "sum_after_merge" "
@@ -4413,9 +4102,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT sum(n)/count(*) AS a FROM t;"
 
-
-
-
 echo "--- HEAD~N refs ---"
 
 oracle "reset_to_head_tilde_2" "
@@ -4451,9 +4137,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('side');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- allow-empty commit + merge ---"
 
 oracle "allow_empty_then_merge" "
@@ -4481,9 +4164,6 @@ SELECT dolt_commit('-m','another empty','--allow-empty');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- diamond via branches ---"
 
@@ -4525,9 +4205,6 @@ SELECT dolt_merge('left');
 SELECT dolt_merge('right');
 " "SELECT 't1' AS tbl, count(*) AS n FROM t1 UNION ALL SELECT 't2', count(*) FROM t2 ORDER BY 1;"
 
-
-
-
 echo "--- multi-level FK + merge ---"
 
 oracle "four_level_fk_chain_merge" "
@@ -4554,9 +4231,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT a.v, b.v, c.v, d.v FROM d JOIN c ON d.cid=c.id JOIN b ON c.bid=b.id JOIN a ON b.aid=a.id ORDER BY d.id;"
-
-
-
 
 echo "--- branch from historical commit ---"
 
@@ -4601,9 +4275,6 @@ SELECT dolt_merge('past_a');
 SELECT dolt_merge('past_b');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- conditional UPDATE + cell merge ---"
 
 oracle "update_coalesce_then_merge" "
@@ -4638,9 +4309,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, a, b FROM t;"
 
-
-
-
 echo "--- LIMIT/OFFSET after merge ---"
 
 oracle "select_limit_after_merge" "
@@ -4668,9 +4336,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id LIMIT 2 OFFSET 2;"
-
-
-
 
 echo "--- DISTINCT/UNION after merge ---"
 
@@ -4702,9 +4367,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT v FROM t1 UNION ALL SELECT v FROM t2 ORDER BY v;"
-
-
-
 
 echo "--- multiple inserts then merge ---"
 
@@ -4747,9 +4409,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- cherry-pick chain ---"
 
 oracle "cherry_pick_two_commits_sequentially" "
@@ -4784,9 +4443,6 @@ SELECT dolt_reset('--hard','HEAD~1');
 SELECT dolt_cherry_pick('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- deep history + cherry-pick ---"
 
 oracle "cherry_pick_from_deep_branch" "
@@ -4810,9 +4466,6 @@ SELECT dolt_commit('-m','f4');
 SELECT dolt_checkout('main');
 SELECT dolt_cherry_pick('feat~2');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- UNIQUE + merge complex ---"
 
@@ -4849,9 +4502,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, code1, code2 FROM t ORDER BY id;"
 
-
-
-
 echo "--- NULL handling edge cases ---"
 
 oracle "null_to_value_both_sides_different_rows" "
@@ -4882,9 +4532,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) AS null_count FROM t WHERE v IS NULL;"
-
-
-
 
 echo "--- branch lifecycle + merge ---"
 
@@ -4925,9 +4572,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- chained updates same row + merge ---"
 
 oracle "many_updates_same_row_feat_merge" "
@@ -4950,9 +4594,6 @@ SELECT dolt_commit('-m','main new row');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- HAVING after merge ---"
 
 oracle "having_after_merge" "
@@ -4967,9 +4608,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT grp, sum(n) AS total FROM t GROUP BY grp HAVING sum(n) > 10 ORDER BY grp;"
-
-
-
 
 echo "--- explicit column lists + merge ---"
 
@@ -4988,9 +4626,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, a, b, c FROM t ORDER BY id;"
-
-
-
 
 echo "--- revert chain ---"
 
@@ -5020,9 +4655,6 @@ SELECT dolt_commit('-m','c3');
 SELECT dolt_revert('HEAD');
 SELECT dolt_revert('HEAD');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- dolt_log after various ops ---"
 
@@ -5054,9 +4686,6 @@ SELECT dolt_commit('-m','f1');
 SELECT dolt_checkout('main');
 SELECT dolt_cherry_pick('feat');
 " "SELECT message FROM dolt_log ORDER BY message;"
-
-
-
 
 echo "--- CHECK constraint interactions ---"
 
@@ -5091,9 +4720,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- wide PK patterns + merge ---"
 
@@ -5131,9 +4757,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT a, b, v FROM t ORDER BY a, b;"
 
-
-
-
 echo "--- post-merge working state ---"
 
 oracle "post_merge_immediate_insert" "
@@ -5167,9 +4790,6 @@ UPDATE t SET v='post' WHERE id=1;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','post');
 " "SELECT id, v FROM t;"
-
-
-
 
 echo "--- parallel branches ---"
 
@@ -5246,9 +4866,6 @@ SELECT dolt_merge('b5');
 SELECT dolt_merge('b6');
 " "SELECT count(*) AS n, sum(id) AS s FROM t;"
 
-
-
-
 echo "--- merge then revert ---"
 
 oracle "revert_merge_commit" "
@@ -5267,9 +4884,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat','--no-ff','-m','merge feat');
 SELECT dolt_revert('HEAD','-m','1');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- FK delete restriction + merge ---"
 
@@ -5290,9 +4904,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main more children');
 SELECT dolt_merge('feat');
 " "SELECT id, v, pid FROM child ORDER BY id;"
-
-
-
 
 echo "--- EXISTS/NOT EXISTS after merge ---"
 
@@ -5344,9 +4955,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- CTE + merge ---"
 
 oracle "cte_select_after_merge" "
@@ -5374,9 +4982,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "WITH gc AS (SELECT grp, count(*) AS c FROM t GROUP BY grp) SELECT grp, c FROM gc ORDER BY grp;"
-
-
-
 
 echo "--- REPLACE patterns + merge ---"
 
@@ -5413,9 +5018,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- multi-row UPDATE + merge ---"
 
 oracle "update_per_id_then_merge" "
@@ -5437,9 +5039,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- FK cascade-ish behavior + merge ---"
 
 oracle "fk_orphan_possible_when_no_action_merge" "
@@ -5460,9 +5059,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, pid, v FROM child ORDER BY id;"
-
-
-
 
 echo "--- REAL/float merge ---"
 
@@ -5495,9 +5091,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, x FROM t ORDER BY id;"
 
-
-
-
 echo "--- multi-VALUES INSERT + merge ---"
 
 oracle "insert_10_rows_one_stmt_merge" "
@@ -5515,9 +5108,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) AS n, sum(v) AS s FROM t;"
-
-
-
 
 echo "--- commit message special chars ---"
 
@@ -5546,9 +5136,6 @@ SELECT dolt_commit('-m','feature branch commit message');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) FROM dolt_log;"
-
-
-
 
 echo "--- balanced growth merges ---"
 
@@ -5584,9 +5171,6 @@ SELECT dolt_commit('-m','main delete 8-10');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- post-merge aggregate invariants ---"
 
 oracle "min_max_span_unchanged_by_convergent_update" "
@@ -5621,9 +5205,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT count(DISTINCT cat) AS distinct_cats FROM t;"
 
-
-
-
 echo "--- re-merge branch after update ---"
 
 oracle "merge_branch_update_merge_again" "
@@ -5645,9 +5226,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- merge + reset + re-merge ---"
 
 oracle "merge_reset_remerge" "
@@ -5664,9 +5242,6 @@ SELECT dolt_merge('feat');
 SELECT dolt_reset('--hard','HEAD~1');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- alter + populate + merge ---"
 
@@ -5706,9 +5281,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v, x, y FROM t ORDER BY id;"
 
-
-
-
 echo "--- dolt_log structure after merges ---"
 
 oracle "log_distinct_commit_hashes_count" "
@@ -5740,9 +5312,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) FROM dolt_log WHERE message IN ('first','second','third_on_feat');"
 
-
-
-
 echo "--- multi-column indexes + merge ---"
 
 oracle "merge_table_with_multi_col_index" "
@@ -5762,9 +5331,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, a, b FROM t ORDER BY a, b;"
-
-
-
 
 echo "--- deep FK scenarios ---"
 
@@ -5806,9 +5372,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, pid, v FROM child ORDER BY id;"
 
-
-
-
 echo "--- drop + recreate + merge ---"
 
 oracle "drop_recreate_same_name_merge" "
@@ -5828,9 +5391,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- long linear history + merge ---"
 
@@ -5874,9 +5434,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('side');
 " "SELECT count(*) AS n, sum(v) AS s FROM t;"
 
-
-
-
 echo "--- string funcs in UPDATE + merge ---"
 
 oracle "update_lower_then_merge" "
@@ -5907,9 +5464,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t WHERE length(v)>=3 ORDER BY id;"
-
-
-
 
 echo "--- arithmetic UPDATE + merge ---"
 
@@ -5945,9 +5499,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, n FROM t ORDER BY id;"
 
-
-
-
 echo "--- self-referential merge ---"
 
 oracle "self_ref_fk_new_hierarchy_merge" "
@@ -5965,9 +5516,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, parent_id, v FROM n ORDER BY id;"
-
-
-
 
 echo "--- UPDATE with correlated subquery + merge ---"
 
@@ -5988,9 +5536,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- commit chain reshape + merge ---"
 
@@ -6021,9 +5566,6 @@ SELECT dolt_commit('-m','c3');
 SELECT dolt_reset('--soft','HEAD~2');
 SELECT dolt_commit('-m','squashed');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- multi-table inner join + merge ---"
 
@@ -6061,9 +5603,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT t1.id, CASE WHEN t2.id IS NULL THEN 'none' ELSE t2.v END AS got FROM t1 LEFT JOIN t2 ON t1.id=t2.t1id ORDER BY t1.id;"
 
-
-
-
 echo "--- merge branch with only empty commits ---"
 
 oracle "merge_only_allow_empty_branch" "
@@ -6081,9 +5620,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- convergent conflict probes ---"
 
@@ -6183,9 +5719,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t WHERE id=2;"
 
-
-
-
 echo "--- self-merge probes ---"
 
 oracle "merge_self_is_noop" "
@@ -6213,9 +5746,6 @@ SELECT dolt_merge('feat');
 SELECT dolt_merge('feat');
 SELECT dolt_merge('feat');
 " "SELECT count(*) FROM dolt_log;"
-
-
-
 
 echo "--- cherry-pick edge probes ---"
 
@@ -6261,9 +5791,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_cherry_pick('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- reset target probes ---"
 
 oracle "reset_to_tag" "
@@ -6293,9 +5820,6 @@ SELECT dolt_commit('-m','c2');
 SELECT dolt_reset('--hard','snap');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- empty/no-op merge probes ---"
 
 oracle "merge_branch_with_no_new_commits" "
@@ -6309,9 +5833,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- type behavior through merge ---"
 
@@ -6340,9 +5861,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t WHERE s='updated';"
-
-
-
 
 echo "--- PK/UNIQUE conflict probes ---"
 
@@ -6378,9 +5896,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t WHERE id=1;"
 
-
-
-
 echo "--- pre-merge staging probes ---"
 
 oracle "merge_with_uncommitted_working_changes" "
@@ -6396,9 +5911,6 @@ SELECT dolt_checkout('main');
 INSERT INTO t VALUES(3,'uncommitted');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- REPLACE vs merge probes ---"
 
@@ -6417,9 +5929,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) FROM t;"
-
-
-
 
 echo "--- cell merge fallback probes ---"
 
@@ -6455,9 +5964,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, a, b FROM t;"
 
-
-
-
 echo "--- merge+revert probes ---"
 
 oracle "revert_noff_merge_commit_row_count" "
@@ -6477,9 +5983,6 @@ SELECT dolt_merge('feat','--no-ff','-m','merged');
 SELECT dolt_revert('HEAD','-m','1');
 " "SELECT count(*) FROM t;"
 
-
-
-
 echo "--- large payload probes ---"
 
 oracle "blob_different_on_each_side_merge" "
@@ -6497,9 +6000,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, hex(b) FROM t ORDER BY id;"
-
-
-
 
 echo "--- cherry-pick and reset deeper probes ---"
 
@@ -6553,9 +6053,6 @@ SELECT dolt_cherry_pick('feat~1');
 SELECT dolt_cherry_pick('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- NULL aggregation probes ---"
 
 oracle "sum_ignores_null_after_merge" "
@@ -6583,9 +6080,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT min(n) AS lo, max(n) AS hi FROM t;"
-
-
-
 
 echo "--- update pattern probes ---"
 
@@ -6622,9 +6116,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- FK merge dependency probes ---"
 
@@ -6665,9 +6156,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, pid, v FROM child ORDER BY id;"
 
-
-
-
 echo "--- batch + partial conflict probes ---"
 
 oracle "batch_50_with_one_conflict_elsewhere" "
@@ -6688,9 +6176,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) FROM t WHERE id BETWEEN 100 AND 119;"
 
-
-
-
 echo "--- NULL ordering probes ---"
 
 oracle "nulls_in_order_by_asc_merge" "
@@ -6705,9 +6190,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t WHERE n IS NOT NULL ORDER BY n;"
-
-
-
 
 echo "--- repeated ALTER probes ---"
 
@@ -6727,9 +6209,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, keep FROM t ORDER BY id;"
-
-
-
 
 echo "--- reset then merge replay probes ---"
 
@@ -6753,9 +6232,6 @@ SELECT dolt_reset('--hard','HEAD~1');
 SELECT dolt_merge('b2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- graph shape probes ---"
 
 oracle "log_count_after_diamond_no_ff" "
@@ -6776,9 +6252,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('left','--no-ff','-m','merge left');
 SELECT dolt_merge('right','--no-ff','-m','merge right');
 " "SELECT count(*) FROM dolt_log;"
-
-
-
 
 echo "--- stale working set probes ---"
 
@@ -6806,9 +6279,6 @@ INSERT INTO t VALUES(3,'post');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','post');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- drop-on-branch probes ---"
 
@@ -6850,9 +6320,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','marker');
 " "SELECT id FROM marker;"
 
-
-
-
 echo "--- IDR on one branch probes ---"
 
 oracle "insert_delete_reinsert_within_branch_merge" "
@@ -6890,9 +6357,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- revert/cherry-pick inversion probes ---"
 
 oracle "cherry_pick_a_revert_commit" "
@@ -6922,9 +6386,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_cherry_pick('feat');
 SELECT dolt_revert('HEAD');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- dialect edge probes ---"
 
@@ -6960,9 +6421,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, n FROM t ORDER BY id;"
 
-
-
-
 echo "--- multi-col CHECK probes ---"
 
 oracle "check_on_two_cols_merge" "
@@ -6981,9 +6439,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, a, b FROM t ORDER BY id;"
 
-
-
-
 echo "--- dolt_diff stability probes ---"
 
 oracle "dolt_diff_summary_row_count_stable" "
@@ -6998,9 +6453,6 @@ INSERT INTO t VALUES(3,'c');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c3');
 " "SELECT count(*) FROM dolt_diff WHERE table_name='t';"
-
-
-
 
 echo "--- branch rename / move probes ---"
 
@@ -7018,9 +6470,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('renamed');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- no-op commit stress probes ---"
 
 oracle "many_allow_empty_then_data" "
@@ -7037,9 +6486,6 @@ INSERT INTO t VALUES(2,'b');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM dolt_log;"
-
-
-
 
 echo "--- one-sided delete probes ---"
 
@@ -7059,9 +6505,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- tag at non-HEAD probes ---"
 
 oracle "tag_at_past_commit" "
@@ -7078,9 +6521,6 @@ SELECT dolt_commit('-m','c3');
 SELECT dolt_tag('mid','HEAD~1');
 SELECT dolt_reset('--hard','mid');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- schema mutation across merge ---"
 
@@ -7116,16 +6556,7 @@ SELECT dolt_commit('-m','main y');
 SELECT dolt_merge('feat');
 " "SELECT id, v, x, y FROM t;"
 
-
-
-
 echo "--- convergent schema probes ---"
-
-
-
-
-
-
 
 oracle "both_sides_drop_same_column" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, a TEXT, toss TEXT);
@@ -7143,9 +6574,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main drop');
 SELECT dolt_merge('feat');
 " "SELECT id, a FROM t ORDER BY id;"
-
-
-
 
 echo "--- FK violation on merge probes ---"
 
@@ -7169,9 +6597,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) AS parents FROM parent;"
 
-
-
-
 echo "--- explicit transaction probes ---"
 
 oracle "begin_commit_across_dolt_commit" "
@@ -7188,9 +6613,6 @@ INSERT INTO t VALUES(3,'post');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','post');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- implicit column behavior probes ---"
 
@@ -7209,9 +6631,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t WHERE v LIKE '%0%' ORDER BY id;"
-
-
-
 
 echo "--- repeat branch merge probes ---"
 
@@ -7239,9 +6658,6 @@ SELECT dolt_commit('-m','f3');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t;"
-
-
-
 
 echo "--- reset immediately after commit probes ---"
 
@@ -7277,9 +6693,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','newer c2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- NULL + UNIQUE merge probes ---"
 
 oracle "unique_allows_multiple_nulls_merge" "
@@ -7298,9 +6711,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, code FROM t ORDER BY id;"
 
-
-
-
 oracle "unique_multi_col_with_one_null_merge" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, a VARCHAR(8), b VARCHAR(8), UNIQUE(a,b));
 INSERT INTO t VALUES(1,'x','y');
@@ -7316,10 +6726,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) FROM t;"
-
-
-
-
 
 echo "--- alter-only branch merge ---"
 
@@ -7355,9 +6761,6 @@ SELECT dolt_commit('-m','main adds col');
 SELECT dolt_merge('feat');
 " "SELECT id, v, tag FROM t ORDER BY id;"
 
-
-
-
 echo "--- whitespace/text probes ---"
 
 oracle "trailing_space_text_merge" "
@@ -7386,9 +6789,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, length(v) AS L FROM t ORDER BY id;"
 
-
-
-
 echo "--- FK delete-restrict probes ---"
 
 oracle "fk_child_referencing_deleted_parent_merge" "
@@ -7409,9 +6809,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) AS np, count(*) FROM parent;"
-
-
-
 
 echo "--- complex flow final state probes ---"
 
@@ -7436,9 +6833,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- recursive CTE probes ---"
 
@@ -7467,9 +6861,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "WITH RECURSIVE descend(id, depth) AS (SELECT id, 0 FROM tree WHERE pid IS NULL UNION ALL SELECT t.id, d.depth+1 FROM tree t JOIN descend d ON t.pid=d.id) SELECT depth, count(*) AS n FROM descend GROUP BY depth ORDER BY depth;"
-
-
-
 
 echo "--- window function probes ---"
 
@@ -7525,9 +6916,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, COALESCE(LAG(v) OVER (ORDER BY id), 0) AS prev FROM t ORDER BY id;"
 
-
-
-
 echo "--- dolt_log structural probes ---"
 
 oracle "dolt_log_message_set_after_merge" "
@@ -7564,9 +6952,6 @@ INSERT INTO t VALUES(4,'d');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','cx003');
 " "SELECT count(*) FROM dolt_log WHERE message LIKE 'cx%';"
-
-
-
 
 echo "--- deep history probes ---"
 
@@ -7669,9 +7054,6 @@ SELECT dolt_commit('-m','c9');
 SELECT dolt_reset('--hard','HEAD~5');
 " "SELECT count(*) FROM t;"
 
-
-
-
 echo "--- complex WHERE probes ---"
 
 oracle "and_or_not_combined_after_merge" "
@@ -7703,9 +7085,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t WHERE v IN (SELECT v FROM allow) ORDER BY id;"
 
-
-
-
 echo "--- multi-col UPDATE probes ---"
 
 oracle "update_set_multiple_cols_merge" "
@@ -7724,9 +7103,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, a, b, c FROM t ORDER BY id;"
 
-
-
-
 echo "--- wide table probes ---"
 
 oracle "twenty_col_table_merge" "
@@ -7744,9 +7120,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, c5, c10, c15, c20 FROM t;"
-
-
-
 
 echo "--- JOIN UPDATE probes ---"
 
@@ -7768,9 +7141,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- dolt_status probes ---"
 
 oracle "status_empty_after_commit" "
@@ -7787,9 +7157,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c1');
 INSERT INTO t VALUES(2,'b');
 " "SELECT count(*) FROM dolt_status WHERE staged=0;"
-
-
-
 
 echo "--- branch off tag + merge ---"
 
@@ -7809,9 +7176,6 @@ SELECT dolt_commit('-m','tag side');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('from_tag');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- two-col PK cell merge probes ---"
 
@@ -7847,9 +7211,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT a, b, v1, v2 FROM t;"
 
-
-
-
 echo "--- CASE projection probes ---"
 
 oracle "nested_case_projection_after_merge" "
@@ -7864,9 +7225,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, CASE WHEN n<10 THEN 'xs' WHEN n<20 THEN 's' WHEN n<30 THEN 'm' WHEN n<40 THEN 'l' ELSE 'xl' END AS sz FROM t ORDER BY id;"
-
-
-
 
 echo "--- multi-branch dependency ---"
 
@@ -7891,9 +7249,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('b3');
 " "SELECT id, v FROM t;"
 
-
-
-
 echo "--- INSERT SELECT agg probes ---"
 
 oracle "insert_select_from_agg_after_merge" "
@@ -7911,9 +7266,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main new grp');
 SELECT dolt_merge('feat');
 " "SELECT grp, sum(n) AS s FROM src GROUP BY grp ORDER BY grp;"
-
-
-
 
 echo "--- repeated ff / noff probes ---"
 
@@ -7936,9 +7288,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t;"
 
-
-
-
 echo "--- upsert-like probes ---"
 
 oracle "on_conflict_replace_equivalent_via_replace" "
@@ -7958,9 +7307,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v, n FROM t ORDER BY id;"
 
-
-
-
 echo "--- aggregate on empty table probes ---"
 
 oracle "delete_all_sum_null_after_merge" "
@@ -7978,9 +7324,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) AS c FROM t;"
-
-
-
 
 echo "--- create+insert same commit probes ---"
 
@@ -8000,9 +7343,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT 't' AS tbl, count(*) AS n FROM t UNION ALL SELECT 'u', count(*) FROM u ORDER BY 1;"
-
-
-
 
 echo "--- merge commit accounting ---"
 
@@ -8038,9 +7378,6 @@ SELECT dolt_commit('-m','m1');
 SELECT dolt_merge('feat','--no-ff','-m','merge');
 " "SELECT count(*) FROM dolt_log;"
 
-
-
-
 echo "--- string function probes ---"
 
 oracle "substr_in_select_after_merge" "
@@ -8069,9 +7406,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, REPLACE(v,'world','WORLD') AS r FROM t ORDER BY id;"
 
-
-
-
 echo "--- multi-key GROUP BY probes ---"
 
 oracle "multi_key_group_by_after_merge" "
@@ -8087,9 +7421,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT a, b, sum(n) AS s FROM t GROUP BY a, b ORDER BY a, b;"
 
-
-
-
 echo "--- PK ordering + reset probes ---"
 
 oracle "insert_reverse_order_pk_after_merge" "
@@ -8104,9 +7435,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t ORDER BY id;"
-
-
-
 
 echo "--- NULL-handling funcs after merge ---"
 
@@ -8136,9 +7464,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) AS n_null FROM (SELECT NULLIF(v,'sentinel') AS masked FROM t) sub WHERE masked IS NULL;"
 
-
-
-
 echo "--- mid-sequence branch switches ---"
 
 oracle "back_and_forth_branches_merge" "
@@ -8164,9 +7489,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','m2');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- views + VC ---"
 
@@ -8313,9 +7635,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM active;"
 
-
-
-
 echo "--- generated columns + merge ---"
 
 oracle "stored_generated_col_merge" "
@@ -8394,9 +7713,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t WHERE squared > 10 ORDER BY id;"
-
-
-
 
 echo "--- FK cascade actions + merge ---"
 
@@ -8534,9 +7850,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, pid, v FROM child ORDER BY id;"
 
-
-
-
 echo "--- conflict resolution in txn probes ---"
 
 oracle "resolve_conflict_via_update_their_in_txn" "
@@ -8602,9 +7915,6 @@ INSERT INTO t VALUES(2,'post_rollback');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','post');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- dolt_hashof property probes ---"
 
@@ -8675,9 +7985,6 @@ SELECT 1;
 SELECT 2;
 SELECT 3;
 " "SELECT count(*) FROM dolt_log WHERE commit_hash = dolt_hashof('HEAD');"
-
-
-
 
 echo "--- many-branch fan-in probes ---"
 
@@ -8763,9 +8070,6 @@ SELECT dolt_branch('b7');
 SELECT dolt_branch('b8');
 " "SELECT count(*) FROM dolt_branches;"
 
-
-
-
 echo "--- schema merge corner probes ---"
 
 oracle "type_widen_int_to_bigint_merge" "
@@ -8816,9 +8120,6 @@ SELECT dolt_commit('-m','main adds row');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- math function probes ---"
 
 oracle "abs_after_merge" "
@@ -8859,9 +8160,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, -n AS neg FROM t ORDER BY id;"
-
-
-
 
 echo "--- tag semantics probes ---"
 
@@ -8904,9 +8202,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM dolt_log;"
 
-
-
-
 echo "--- complex merge base topology ---"
 
 oracle "merge_base_after_merged_branch" "
@@ -8948,9 +8243,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('grandchild');
 " "SELECT id FROM t ORDER BY id;"
 
-
-
-
 echo "--- unicode sort probes ---"
 
 oracle "unicode_text_sort_after_merge" "
@@ -8979,9 +8271,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t ORDER BY v;"
 
-
-
-
 echo "--- log filter probes ---"
 
 oracle "log_commit_hash_prefix_match" "
@@ -9006,9 +8295,6 @@ INSERT INTO t VALUES(3);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c3');
 " "SELECT count(*) FROM (SELECT commit_hash FROM dolt_log ORDER BY date DESC) sub;"
-
-
-
 
 echo "--- post-merge invariant probes ---"
 
@@ -9041,9 +8327,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) FROM t;"
 
-
-
-
 echo "--- tag reuse probes ---"
 
 oracle "reset_to_past_tag" "
@@ -9075,9 +8358,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('hotfix');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- generated column deeper ---"
 
 oracle "two_stored_generated_cols_merge" "
@@ -9108,9 +8388,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t WHERE doubled >= 20 ORDER BY id;"
-
-
-
 
 echo "--- view + changes on both sides ---"
 
@@ -9149,9 +8426,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM posv ORDER BY id;"
-
-
-
 
 echo "--- multi-hop merge-base probes ---"
 
@@ -9197,9 +8471,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('b');
 " "SELECT count(*) AS n, sum(v) AS s FROM t;"
 
-
-
-
 echo "--- schema+data mix probes ---"
 
 oracle "add_col_on_feat_and_insert_then_merge" "
@@ -9238,9 +8509,6 @@ SELECT dolt_commit('-m','main adds main_col');
 SELECT dolt_merge('feat');
 " "SELECT id, v, feat_col, main_col FROM t;"
 
-
-
-
 echo "--- complex WHERE projection ---"
 
 oracle "where_multi_pred_after_merge" "
@@ -9271,9 +8539,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t1 WHERE ref IN (SELECT id FROM t2 WHERE flag=1) ORDER BY id;"
-
-
-
 
 echo "--- row manipulation edges ---"
 
@@ -9313,9 +8578,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t;"
 
-
-
-
 echo "--- FK null-parent edge ---"
 
 oracle "fk_nullable_pid_on_both_sides_merge" "
@@ -9337,9 +8599,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, pid, v FROM child ORDER BY id;"
-
-
-
 
 echo "--- edge commit patterns ---"
 
@@ -9364,9 +8623,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','another-msg');
 " "SELECT count(*) FROM dolt_log WHERE message IN ('looks-like-arg','another-msg');"
 
-
-
-
 echo "--- dolt_branches accounting ---"
 
 oracle "dolt_branches_count_after_creates_and_deletes" "
@@ -9390,9 +8646,6 @@ SELECT dolt_branch('one');
 SELECT dolt_branch('two');
 SELECT dolt_branch('-c','main','three');
 " "SELECT count(*) FROM dolt_branches WHERE name='main';"
-
-
-
 
 echo "--- cherry-pick edges ---"
 
@@ -9423,9 +8676,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_cherry_pick('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- soft reset patterns ---"
 
 oracle "soft_reset_two_then_squash" "
@@ -9454,12 +8704,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 SELECT dolt_reset('--soft','HEAD~1');
 " "SELECT id FROM t ORDER BY id;"
-
-
-
-
-
-
 
 oracle "soft_reset_recommit_no_explicit_add" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -9514,9 +8758,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','amended_with_extra');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- JSON function probes ---"
 
 oracle "json_extract_simple_after_merge" "
@@ -9560,9 +8801,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, json_extract(j,'\$.v') AS v FROM t ORDER BY id;"
-
-
-
 
 echo "--- SAVEPOINT probes ---"
 
@@ -9632,9 +8870,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','after sp rollback');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- REPLACE vs UPDATE probes ---"
 
 oracle "replace_on_existing_pk_merges_like_update" "
@@ -9672,9 +8907,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- stress-lite merge probes ---"
 
@@ -9723,9 +8955,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT sum(v) AS s FROM t;"
 
-
-
-
 echo "--- default expression probes ---"
 
 oracle "default_literal_used_in_both_branches_merge" "
@@ -9761,9 +8990,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, a, b FROM t ORDER BY id;"
 
-
-
-
 echo "--- merge commit accounting probes ---"
 
 oracle "noff_merge_has_four_log_entries" "
@@ -9797,9 +9023,6 @@ SELECT dolt_commit('-m','feat2');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) FROM dolt_log;"
-
-
-
 
 echo "--- delete-insert ordering probes ---"
 
@@ -9837,9 +9060,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- truncate-like probes ---"
 
 oracle "delete_all_one_side_insert_other_merge" "
@@ -9857,9 +9077,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main adds');
 SELECT dolt_merge('feat');
 " "SELECT count(*) FROM t;"
-
-
-
 
 echo "--- cherry-pick semantics probes ---"
 
@@ -9897,9 +9114,6 @@ SELECT dolt_commit('-m','main t2');
 SELECT dolt_cherry_pick('feat');
 " "SELECT id, v FROM t2 ORDER BY id;"
 
-
-
-
 echo "--- reset then merge probes ---"
 
 oracle "hard_reset_then_merge_brings_back" "
@@ -9918,9 +9132,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_reset('--hard','HEAD~1');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t ORDER BY id;"
-
-
-
 
 echo "--- empty-table merge probes ---"
 
@@ -9959,9 +9170,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','post b');
 " "SELECT id, v FROM b;"
 
-
-
-
 echo "--- mixed type merge probes ---"
 
 oracle "mixed_int_text_real_merge" "
@@ -9980,14 +9188,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, n, s, r FROM t;"
-
-
-
-
-
-
-
-
 
 echo "--- merge_base probes ---"
 
@@ -10041,9 +9241,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT CASE WHEN dolt_merge_base('main','feat') = dolt_hashof('HEAD') THEN 1 ELSE 0 END;"
 
-
-
-
 echo "--- rename column probes ---"
 
 oracle "rename_column_on_feat_query_works_after_merge" "
@@ -10079,9 +9276,6 @@ SELECT dolt_commit('-m','main rename');
 SELECT dolt_merge('feat');
 " "SELECT count(*) FROM t;"
 
-
-
-
 echo "--- rename table probes ---"
 
 oracle "rename_table_on_feat_merge_to_main" "
@@ -10102,9 +9296,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM other ORDER BY id;"
-
-
-
 
 echo "--- view-join probes ---"
 
@@ -10142,9 +9333,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT grp, total FROM totals ORDER BY grp;"
-
-
-
 
 echo "--- multi-commit DML probes ---"
 
@@ -10191,9 +9379,6 @@ SELECT dolt_commit('-m','m2');
 SELECT dolt_merge('feat');
 " "SELECT count(*) AS n, sum(id) AS s FROM t;"
 
-
-
-
 echo "--- correlated subquery UPDATE deeper ---"
 
 oracle "update_running_total_via_subquery" "
@@ -10230,9 +9415,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, cnt FROM t ORDER BY id;"
 
-
-
-
 echo "--- conflict resolve multi-row probes ---"
 
 oracle "resolve_multiple_conflicts_via_update" "
@@ -10260,9 +9442,6 @@ SELECT dolt_commit('-m','resolved');
 COMMIT;
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- post-merge FK query probes ---"
 
 oracle "three_table_join_filter_after_merge" "
@@ -10287,9 +9466,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT a.cat FROM c JOIN b ON c.bid=b.id JOIN a ON b.aid=a.id WHERE c.score > 60 ORDER BY a.cat;"
-
-
-
 
 echo "--- ordering probes ---"
 
@@ -10318,9 +9494,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t ORDER BY a, b DESC;"
-
-
-
 
 echo "--- cherry-pick DML batch probes ---"
 
@@ -10357,9 +9530,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_cherry_pick('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- deep branch probes ---"
 
 oracle "deep_branch_ff_merge_count" "
@@ -10390,9 +9560,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) FROM dolt_log;"
 
-
-
-
 echo "--- replace stability probes ---"
 
 oracle "replace_every_row_both_sides_merge" "
@@ -10410,9 +9577,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 echo "--- set ops after merge ---"
 
 oracle "union_distinct_after_merge" "
@@ -10460,9 +9624,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT v FROM a EXCEPT SELECT v FROM b ORDER BY v;"
 
-
-
-
 echo "--- case-insensitive lookup ---"
 
 oracle "lower_lookup_after_merge" "
@@ -10490,9 +9651,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t WHERE UPPER(v) LIKE 'RED%' ORDER BY id;"
-
-
-
 
 echo "--- multi-index probes ---"
 
@@ -10525,9 +9683,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT count(DISTINCT code) FROM t;"
 
-
-
-
 echo "--- dolt_branches column shape ---"
 
 oracle "branches_dirty_flag_is_boolean" "
@@ -10546,9 +9701,6 @@ SELECT dolt_commit('-m','c1');
 SELECT dolt_branch('b1');
 " "SELECT count(*) FROM dolt_branches WHERE length(hash) > 0;"
 
-
-
-
 echo "--- dolt_log parent traversal ---"
 
 oracle "log_has_expected_number_of_merge_commits" "
@@ -10566,9 +9718,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat','--no-ff','-m','merge_c');
 " "SELECT count(*) FROM dolt_log WHERE message='merge_c';"
-
-
-
 
 echo "--- complex UPDATE probes ---"
 
@@ -10606,9 +9755,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v, active FROM t ORDER BY id;"
 
-
-
-
 echo "--- large multi-table merge probes ---"
 
 oracle "four_tables_each_touched_merge" "
@@ -10639,9 +9785,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT 't1' AS tbl, sum(v) AS s FROM t1 UNION ALL SELECT 't2', sum(v) FROM t2 UNION ALL SELECT 't3', sum(v) FROM t3 UNION ALL SELECT 't4', sum(v) FROM t4 ORDER BY 1;"
 
-
-
-
 echo "--- boolean-like flags through merge ---"
 
 oracle "zero_one_flags_toggled_merge" "
@@ -10659,9 +9802,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, active FROM t ORDER BY id;"
-
-
-
 
 echo "--- commit message preservation ---"
 
@@ -10685,9 +9825,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','#123 fix');
 " "SELECT count(*) FROM dolt_log WHERE message IN ('v1.2.3','#123 fix');"
 
-
-
-
 echo "--- INSERT col subset probes ---"
 
 oracle "insert_subset_cols_different_on_branches" "
@@ -10706,9 +9843,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, a, b, c FROM t ORDER BY id;"
-
-
-
 
 echo "--- diamond convergent delete ---"
 
@@ -10733,9 +9867,6 @@ SELECT dolt_merge('left');
 SELECT dolt_merge('right');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- long messages ---"
 
 oracle "long_message_survives_commit_and_merge" "
@@ -10750,9 +9881,6 @@ SELECT dolt_commit('-m','this is a fairly long commit message that describes sev
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) FROM dolt_log WHERE length(message) > 50;"
-
-
-
 
 echo "--- hashof across merges ---"
 
@@ -10771,9 +9899,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat','--no-ff','-m','merge');
 " "SELECT count(DISTINCT commit_hash) FROM dolt_log;"
-
-
-
 
 echo "--- alternating work + checkout ---"
 
@@ -10806,9 +9931,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT owner, count(*) FROM t GROUP BY owner ORDER BY owner;"
 
-
-
-
 echo "--- tag list stability ---"
 
 oracle "multiple_tags_listed_in_order" "
@@ -10820,9 +9942,6 @@ SELECT dolt_tag('z_last','HEAD');
 SELECT dolt_tag('a_first','HEAD');
 SELECT dolt_tag('m_mid','HEAD');
 " "SELECT tag_name FROM dolt_tags ORDER BY tag_name;"
-
-
-
 
 echo "--- long string payload probes ---"
 
@@ -10841,9 +9960,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, length(v) AS L FROM t ORDER BY id;"
-
-
-
 echo "--- window deeper ---"
 
 oracle "partition_by_frame_after_merge" "
@@ -10898,9 +10014,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, COALESCE(LEAD(v) OVER (ORDER BY id), -1) AS nxt FROM t ORDER BY id;"
 
-
-
-
 echo "--- multi-CTE probes ---"
 
 oracle "chained_ctes_across_merge" "
@@ -10928,9 +10041,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "WITH doubled AS (SELECT id, n*2 AS d FROM t), filtered AS (SELECT id, d FROM doubled WHERE d > 15) SELECT id, d FROM filtered ORDER BY id;"
-
-
-
 
 echo "--- RIGHT JOIN probes ---"
 
@@ -10964,9 +10074,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT owners.id, count(items.id) AS cnt FROM owners LEFT JOIN items ON owners.id=items.owner_id GROUP BY owners.id ORDER BY owners.id;"
 
-
-
-
 echo "--- boolean expressions in SELECT ---"
 
 oracle "comparison_result_as_column" "
@@ -10981,9 +10088,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, CASE WHEN n > 20 THEN 1 ELSE 0 END AS big FROM t ORDER BY id;"
-
-
-
 
 echo "--- computed-value INSERT probes ---"
 
@@ -11004,9 +10108,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT label, n FROM counts ORDER BY label;"
-
-
-
 
 echo "--- DELETE with subquery ---"
 
@@ -11029,9 +10130,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- schema-only modifications ---"
 
 oracle "add_then_drop_col_same_branch_merge" "
@@ -11052,9 +10150,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- max/min tie-breaking ---"
 
 oracle "min_tie_break_by_id_after_merge" "
@@ -11070,9 +10165,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t WHERE score = (SELECT min(score) FROM t) ORDER BY id;"
 
-
-
-
 echo "--- count variants ---"
 
 oracle "count_star_vs_count_col_with_nulls" "
@@ -11087,9 +10179,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) AS c_all, count(v) AS c_nn, count(DISTINCT v) AS c_dist FROM t;"
-
-
-
 
 echo "--- cherry/revert round-trip ---"
 
@@ -11108,9 +10197,6 @@ SELECT dolt_revert('HEAD');
 SELECT dolt_cherry_pick('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- multi-col computed UPDATE ---"
 
 oracle "update_ab_from_c_merge" "
@@ -11128,9 +10214,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, a, b, c FROM t ORDER BY id;"
-
-
-
 
 echo "--- dirty branch detection ---"
 
@@ -11152,9 +10235,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM dolt_branches WHERE name='main' AND dirty IN (0,'false');"
 
-
-
-
 echo "--- commit order probes ---"
 
 oracle "log_ordered_by_commit_order" "
@@ -11169,9 +10249,6 @@ INSERT INTO t VALUES(3);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','third_commit_abc');
 " "SELECT count(*) FROM dolt_log WHERE message LIKE '%commit_abc';"
-
-
-
 
 echo "--- row-level integrity ---"
 
@@ -11191,9 +10268,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT sum(n) FROM t;"
 
-
-
-
 echo "--- alter after merge ---"
 
 oracle "alter_add_col_after_merge" "
@@ -11211,9 +10285,6 @@ ALTER TABLE t ADD COLUMN tag INTEGER DEFAULT 99;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','post-merge alter');
 " "SELECT id, v, tag FROM t ORDER BY id;"
-
-
-
 
 echo "--- multi-conflict txn resolve ---"
 
@@ -11241,9 +10312,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','kept ours');
 COMMIT;
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 echo "--- self-join probes ---"
 
 oracle "self_join_parent_child_after_merge" "
@@ -11274,9 +10342,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT a.id, count(b.id) AS siblings FROM t a LEFT JOIN t b ON a.gid=b.gid AND a.id<>b.id GROUP BY a.id ORDER BY a.id;"
-
-
-
 
 echo "--- view chain probes ---"
 
@@ -11313,9 +10378,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM very_bigs ORDER BY id;"
 
-
-
-
 echo "--- GROUP_CONCAT probes ---"
 
 oracle "group_concat_default_separator_after_merge" "
@@ -11343,9 +10405,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT grp, count(*) AS c FROM t GROUP BY grp ORDER BY grp;"
-
-
-
 
 echo "--- complex subquery probes ---"
 
@@ -11376,9 +10435,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT r.id, (SELECT n FROM t WHERE t.id=r.target) AS tgt_n FROM refs r ORDER BY r.id;"
-
-
-
 
 echo "--- diamond fan-in probes ---"
 
@@ -11419,9 +10475,6 @@ SELECT dolt_merge('d');
 SELECT dolt_merge('e');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- ordered UPDATE probes ---"
 
 oracle "update_value_via_row_position_merge" "
@@ -11439,9 +10492,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v, pos FROM t ORDER BY id;"
-
-
-
 
 echo "--- deep history log queries ---"
 
@@ -11498,9 +10548,6 @@ SELECT dolt_commit('-m','m3');
 SELECT dolt_merge('feat','--no-ff','-m','merged');
 " "SELECT count(*) FROM dolt_log;"
 
-
-
-
 echo "--- conflict resolve variations ---"
 
 oracle "resolve_with_mixed_take_ours_take_theirs" "
@@ -11531,9 +10578,6 @@ SELECT dolt_commit('-m','resolved mixed');
 COMMIT;
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- batch conflict + resolve probes ---"
 
 oracle "ten_rows_conflict_resolve_via_ours" "
@@ -11558,9 +10602,6 @@ SELECT dolt_commit('-m','keep ours');
 COMMIT;
 " "SELECT count(*) FROM t WHERE v='m';"
 
-
-
-
 echo "--- merge-commit history ---"
 
 oracle "merge_commit_message_in_log_noff" "
@@ -11579,9 +10620,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat','--no-ff','-m','merged_feat_to_main');
 " "SELECT count(*) FROM dolt_log WHERE message='merged_feat_to_main';"
 
-
-
-
 echo "--- CTAS probes ---"
 
 oracle "ctas_after_merge" "
@@ -11598,9 +10636,6 @@ SELECT dolt_merge('feat');
 CREATE TABLE dst AS SELECT id, n*2 AS n2 FROM src;
 " "SELECT id, n2 FROM dst ORDER BY id;"
 
-
-
-
 echo "--- hash stability probes ---"
 
 oracle "hashof_stable_after_empty_reads" "
@@ -11612,9 +10647,6 @@ SELECT count(*) FROM t;
 SELECT * FROM t LIMIT 0;
 SELECT id FROM t WHERE id<0;
 " "SELECT count(*) FROM dolt_log WHERE commit_hash = dolt_hashof('HEAD');"
-
-
-
 
 echo "--- cross-table DELETE probes ---"
 
@@ -11638,9 +10670,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- multi-unique cols probes ---"
 
 oracle "two_unique_cols_inserts_disjoint_merge" "
@@ -11658,9 +10687,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT count(DISTINCT code) AS d_code, count(DISTINCT tag) AS d_tag FROM t;"
-
-
-
 echo "--- DATE column probes ---"
 
 oracle "date_col_filter_after_merge" "
@@ -11694,9 +10720,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, d FROM t ORDER BY id;"
-
-
-
 
 echo "--- INSERT SELECT probes ---"
 
@@ -11734,9 +10757,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM dst ORDER BY id;"
 
-
-
-
 echo "--- UPDATE-from subquery probes ---"
 
 oracle "update_from_lookup_table_merge" "
@@ -11757,9 +10777,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- correlated count probes ---"
 
 oracle "correlated_count_after_merge" "
@@ -11776,9 +10793,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT t.id, (SELECT count(*) FROM related WHERE related.ref=t.id) AS c FROM t ORDER BY t.id;"
-
-
-
 
 echo "--- self-ref FK probes ---"
 
@@ -11798,9 +10812,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, parent_id, v FROM n ORDER BY id;"
-
-
-
 
 echo "--- schema-only branch probes ---"
 
@@ -11837,9 +10848,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('schema');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- 100-row merge ---"
 
 oracle "hundred_rows_each_side_disjoint_merge" "
@@ -11866,9 +10874,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) AS n, sum(v) AS s FROM t;"
 
-
-
-
 echo "--- tag reset probes ---"
 
 oracle "tag_reset_retag_workflow" "
@@ -11894,9 +10899,6 @@ SELECT dolt_commit('-m','c4');
 SELECT dolt_tag('new_stable','HEAD');
 " "SELECT id FROM t ORDER BY id;"
 
-
-
-
 echo "--- hash consistency probes ---"
 
 oracle "hashof_tag_and_head_equal_when_tag_at_head" "
@@ -11906,9 +10908,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c1');
 SELECT dolt_tag('here','HEAD');
 " "SELECT CASE WHEN dolt_hashof('here') = dolt_hashof('HEAD') THEN 1 ELSE 0 END;"
-
-
-
 
 echo "--- UPDATE CASE probes ---"
 
@@ -11933,9 +10932,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, n, tier FROM t ORDER BY id;"
 
-
-
-
 echo "--- merge vs regular commit log ---"
 
 oracle "log_has_base_branches_and_merge" "
@@ -11953,9 +10949,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','regular_c3');
 SELECT dolt_merge('feat','--no-ff','-m','merge_c4');
 " "SELECT count(*) FROM dolt_log WHERE message LIKE 'regular_%' OR message LIKE 'merge_%';"
-
-
-
 
 echo "--- multi-col CHECK probes ---"
 
@@ -11975,9 +10968,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, a, b FROM t ORDER BY id;"
 
-
-
-
 echo "--- history inspection probes ---"
 
 oracle "history_shows_commits_touching_table" "
@@ -11992,9 +10982,6 @@ INSERT INTO t VALUES(3);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c3');
 " "SELECT count(*) FROM dolt_history_t;"
-
-
-
 
 echo "--- NULL unique alt probes ---"
 
@@ -12014,9 +11001,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) FROM t;"
 
-
-
-
 echo "--- hashof after update ---"
 
 oracle "hashof_differs_after_update_commit" "
@@ -12028,8 +11012,6 @@ UPDATE t SET v=99 WHERE id=1;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(DISTINCT commit_hash) FROM dolt_log;"
-
-
 echo "--- string func deeper ---"
 
 oracle "upper_lower_projection_after_merge" "
@@ -12058,9 +11040,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, SUBSTR(v, 1, 3) AS p, length(v) AS L FROM t ORDER BY id;"
 
-
-
-
 echo "--- INSERT SELECT computed probes ---"
 
 oracle "insert_select_arithmetic_row_merge" "
@@ -12080,9 +11059,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM a ORDER BY id;"
-
-
-
 
 echo "--- reset variant revisit ---"
 
@@ -12113,9 +11089,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 SELECT dolt_reset('--hard','HEAD');
 " "SELECT id FROM t ORDER BY id;"
-
-
-
 
 echo "--- conflict resolve patterns ---"
 
@@ -12163,9 +11136,6 @@ SELECT dolt_commit('-m','resolved by delete');
 COMMIT;
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- multi-table FK merge ---"
 
 oracle "three_table_fk_chain_add_leaves_both_sides" "
@@ -12188,9 +11158,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main leaf');
 SELECT dolt_merge('feat');
 " "SELECT count(*) FROM c;"
-
-
-
 
 echo "--- long-running branch probes ---"
 
@@ -12219,9 +11186,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- CTE aggregation ---"
 
 oracle "cte_with_having_after_merge" "
@@ -12236,9 +11200,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "WITH totals AS (SELECT grp, sum(n) AS s FROM t GROUP BY grp) SELECT grp, s FROM totals WHERE s > 10 ORDER BY grp;"
-
-
-
 
 echo "--- index usage probes ---"
 
@@ -12255,9 +11216,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t WHERE code IN ('B','D') ORDER BY id;"
-
-
-
 
 echo "--- repeated merge from feat ---"
 
@@ -12286,9 +11244,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t;"
 
-
-
-
 echo "--- empty row edges ---"
 
 oracle "all_columns_null_except_pk_merge" "
@@ -12307,9 +11262,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, a, b, c FROM t ORDER BY id;"
 
-
-
-
 echo "--- dolt_history_<table> probes ---"
 
 oracle "history_table_after_updates" "
@@ -12324,9 +11276,6 @@ UPDATE t SET v=3 WHERE id=1;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c3');
 " "SELECT count(DISTINCT v) FROM dolt_history_t WHERE id=1;"
-
-
-
 
 echo "--- multi-table agg ---"
 
@@ -12344,9 +11293,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT c.name, sum(o.amount) AS total FROM customers c JOIN orders o ON c.id=o.customer_id GROUP BY c.name ORDER BY c.name;"
-
-
-
 
 echo "--- reset to intermediate commit ---"
 
@@ -12370,9 +11316,6 @@ SELECT dolt_commit('-m','c5');
 SELECT dolt_reset('--hard','HEAD~3');
 " "SELECT count(*) FROM t;"
 
-
-
-
 echo "--- computed WHERE probes ---"
 
 oracle "where_by_mod_expression_after_merge" "
@@ -12387,9 +11330,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t WHERE n % 5 = 0 ORDER BY id;"
-
-
-
 
 echo "--- per-branch log probes ---"
 
@@ -12409,9 +11349,6 @@ SELECT dolt_commit('-m','main_c');
 SELECT dolt_merge('feat','--no-ff','-m','m_merge');
 " "SELECT count(*) FROM dolt_log WHERE message IN ('base','feat_c','main_c','m_merge');"
 
-
-
-
 echo "--- INSERT partial cols + subquery ---"
 
 oracle "insert_partial_then_subquery_merge" "
@@ -12429,10 +11366,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v, s FROM t ORDER BY id;"
-
-
-
-
 echo "--- savepoint + dolt_add parity ---"
 
 oracle "savepoint_then_dolt_add_rollback_is_noop" "
@@ -12476,9 +11409,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','post');
 " "SELECT count(*) FROM t;"
 
-
-
-
 echo "--- subquery in WHERE with NULL ---"
 
 oracle "in_subquery_with_null_after_merge" "
@@ -12495,9 +11425,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM a WHERE id IN (SELECT ref FROM b) ORDER BY id;"
-
-
-
 
 echo "--- cross-branch schema probes ---"
 
@@ -12519,9 +11446,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v, x FROM t ORDER BY id;"
 
-
-
-
 echo "--- nested UPDATE probes ---"
 
 oracle "update_set_based_on_avg_after_merge" "
@@ -12539,9 +11463,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, n FROM t ORDER BY id;"
-
-
-
 
 echo "--- WITH + DELETE probes ---"
 
@@ -12561,9 +11482,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, grp, n FROM t ORDER BY id;"
 
-
-
-
 echo "--- REPLACE + UNIQUE probes ---"
 
 oracle "replace_with_unique_col_merge" "
@@ -12581,9 +11499,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, code, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- multi-FK topology probes ---"
 
@@ -12607,9 +11522,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM p ORDER BY id;"
 
-
-
-
 echo "--- convergent ALTER probes ---"
 
 oracle "both_sides_rename_same_col_same_name" "
@@ -12629,9 +11541,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main rename');
 SELECT dolt_merge('feat');
 " "SELECT id, val FROM t ORDER BY id;"
-
-
-
 
 echo "--- commit hash uniqueness ---"
 
@@ -12684,9 +11593,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c15');
 " "SELECT CASE WHEN count(DISTINCT commit_hash) = count(*) THEN 1 ELSE 0 END FROM dolt_log;"
 
-
-
-
 echo "--- sparse update probes ---"
 
 oracle "sparse_updates_across_ids_merge" "
@@ -12709,9 +11615,6 @@ SELECT dolt_commit('-m','main sparse');
 SELECT dolt_merge('feat');
 " "SELECT sum(v) FROM t;"
 
-
-
-
 echo "--- dolt_blame probes ---"
 
 oracle "blame_count_equals_rows" "
@@ -12723,9 +11626,6 @@ UPDATE t SET v='B' WHERE id=2;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM dolt_blame_t;"
-
-
-
 
 echo "--- repeated cherry-pick probes ---"
 
@@ -12754,9 +11654,6 @@ SELECT dolt_cherry_pick('feat~1');
 SELECT dolt_cherry_pick('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- LIMIT/OFFSET probes ---"
 
 oracle "limit_offset_after_merge" "
@@ -12771,9 +11668,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t ORDER BY id LIMIT 3 OFFSET 2;"
-
-
-
 
 echo "--- mix merge/cherry-pick ---"
 
@@ -12796,9 +11690,6 @@ SELECT dolt_merge('b1');
 SELECT dolt_cherry_pick('b2');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- txn + reset probes ---"
 
 oracle "txn_wraps_reset_then_commit" "
@@ -12816,9 +11707,6 @@ INSERT INTO t VALUES(3);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','post');
 " "SELECT id FROM t ORDER BY id;"
-
-
-
 echo "--- revert merge-commit probes ---"
 
 oracle "revert_noff_merge_reverses_feat_data" "
@@ -12838,9 +11726,6 @@ SELECT dolt_merge('feat','--no-ff','-m','merged');
 SELECT dolt_revert('HEAD','-m','1');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- cherry-pick across schema ---"
 
 oracle "cherry_pick_commit_with_both_alter_and_insert" "
@@ -12856,9 +11741,6 @@ SELECT dolt_commit('-m','feat alter+insert');
 SELECT dolt_checkout('main');
 SELECT dolt_cherry_pick('feat');
 " "SELECT id, v, extra FROM t ORDER BY id;"
-
-
-
 
 echo "--- txn + dolt_add probes ---"
 
@@ -12885,9 +11767,6 @@ SELECT dolt_add('-A');
 ROLLBACK;
 " "SELECT count(*) FROM t;"
 
-
-
-
 echo "--- post-merge head state ---"
 
 oracle "post_merge_head_matches_log_top" "
@@ -12906,9 +11785,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat','--no-ff','-m','merge_commit');
 " "SELECT count(*) FROM dolt_log WHERE commit_hash = dolt_hashof('HEAD') AND message='merge_commit';"
 
-
-
-
 echo "--- nested subquery deep ---"
 
 oracle "triple_nested_subquery_after_merge" "
@@ -12924,9 +11800,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t WHERE n > (SELECT avg(n) FROM t WHERE id IN (SELECT id FROM t WHERE n >= 20)) ORDER BY id;"
 
-
-
-
 echo "--- aggregate pruning probes ---"
 
 oracle "sum_filtered_by_where_after_merge" "
@@ -12941,9 +11814,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT grp, sum(n) AS s FROM t WHERE n >= 20 GROUP BY grp HAVING sum(n) > 40 ORDER BY grp;"
-
-
-
 
 echo "--- many-col UPDATE probes ---"
 
@@ -12963,9 +11833,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, a, b, c, d, e FROM t ORDER BY id;"
 
-
-
-
 echo "--- cherry-pick schema-only ---"
 
 oracle "cherry_pick_alter_only_commit" "
@@ -12984,9 +11851,6 @@ SELECT dolt_commit('-m','main row');
 SELECT dolt_cherry_pick('feat');
 " "SELECT id, v, flag FROM t ORDER BY id;"
 
-
-
-
 echo "--- commit/reset/re-commit ---"
 
 oracle "reset_and_recommit_same_data" "
@@ -13003,9 +11867,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2 redo');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- cross-branch tag probes ---"
 
 oracle "tag_on_feat_branch_visible_on_main_tags" "
@@ -13020,9 +11881,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_tag('feat_tag','HEAD');
 SELECT dolt_checkout('main');
 " "SELECT count(*) FROM dolt_tags WHERE tag_name='feat_tag';"
-
-
-
 
 echo "--- sub-branch reset after merge ---"
 
@@ -13042,9 +11900,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main after');
 SELECT dolt_reset('--hard','HEAD~1');
 " "SELECT id FROM t ORDER BY id;"
-
-
-
 
 echo "--- deep both-side history ---"
 
@@ -13088,9 +11943,6 @@ SELECT dolt_commit('-m','m5');
 SELECT dolt_merge('feat');
 " "SELECT count(*) AS n FROM t;"
 
-
-
-
 echo "--- boolean operator edge ---"
 
 oracle "not_null_filter_after_merge" "
@@ -13106,9 +11958,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t WHERE v IS NOT NULL AND v > 20 ORDER BY id;"
 
-
-
-
 echo "--- bit flag patterns ---"
 
 oracle "flags_with_bitwise_and_after_merge" "
@@ -13123,9 +11972,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, flags & 1 AS bit0 FROM t ORDER BY id;"
-
-
-
 
 echo "--- drop + recreate + merge ---"
 
@@ -13147,9 +11993,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) FROM t;"
 
-
-
-
 echo "--- row survival probes ---"
 
 oracle "row_survives_many_ops_on_branch" "
@@ -13168,8 +12011,6 @@ SELECT dolt_commit('-m','feat ops');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t;"
-
-
 echo "--- hashof variants ---"
 
 oracle "hashof_db_differs_across_commits" "
@@ -13194,9 +12035,6 @@ SELECT 1;
 SELECT 2;
 " "SELECT count(*) FROM dolt_log WHERE commit_hash = dolt_hashof('HEAD');"
 
-
-
-
 echo "--- ROW_NUMBER probes ---"
 
 oracle "row_number_per_group_after_merge" "
@@ -13211,9 +12049,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, ROW_NUMBER() OVER (PARTITION BY grp ORDER BY score DESC) AS rn FROM t ORDER BY id;"
-
-
-
 
 echo "--- cell merge many rows ---"
 
@@ -13236,9 +12071,6 @@ SELECT dolt_commit('-m','main b');
 SELECT dolt_merge('feat');
 " "SELECT sum(a) AS sa, sum(b) AS sb FROM t;"
 
-
-
-
 echo "--- recursive CTE generator ---"
 
 oracle "recursive_cte_series_join_post_merge" "
@@ -13253,9 +12085,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "WITH RECURSIVE nums(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM nums WHERE n<10) SELECT n, COALESCE((SELECT label FROM t WHERE t.id=nums.n),'none') AS lbl FROM nums ORDER BY n;"
-
-
-
 
 echo "--- update affecting nothing ---"
 
@@ -13276,9 +12105,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- order+limit probes ---"
 
 oracle "max_via_order_limit_after_merge" "
@@ -13296,9 +12122,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t ORDER BY v DESC LIMIT 1;"
-
-
-
 
 echo "--- wide FK graph ---"
 
@@ -13327,9 +12150,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT 'c1' AS tbl, count(*) AS n FROM c1 UNION ALL SELECT 'c2', count(*) FROM c2 UNION ALL SELECT 'c3', count(*) FROM c3 ORDER BY 1;"
-
-
-
 
 echo "--- deep diamond probes ---"
 
@@ -13361,9 +12181,6 @@ SELECT dolt_commit('-m','m3');
 SELECT dolt_merge('left','--no-ff','-m','merged');
 " "SELECT count(*) AS n, sum(v) AS s FROM t;"
 
-
-
-
 echo "--- agg in subquery ---"
 
 oracle "subquery_with_order_in_agg" "
@@ -13378,9 +12195,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT grp, max(v) AS mx FROM t GROUP BY grp ORDER BY grp;"
-
-
-
 
 echo "--- triple parallel merges ---"
 
@@ -13408,9 +12222,6 @@ SELECT dolt_merge('f1');
 SELECT dolt_merge('f2');
 SELECT dolt_merge('f3');
 " "SELECT count(*) FROM t;"
-
-
-
 
 echo "--- text encoding probes ---"
 
@@ -13443,9 +12254,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- BLOB through merge ---"
 
 oracle "blob_update_one_side_merge" "
@@ -13463,9 +12271,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main tag');
 SELECT dolt_merge('feat');
 " "SELECT id, hex(b), tag FROM t;"
-
-
-
 
 echo "--- long-chain cherry-pick ---"
 
@@ -13502,9 +12307,6 @@ SELECT dolt_cherry_pick('feat~1');
 SELECT dolt_cherry_pick('feat');
 " "SELECT count(*) AS n, sum(v) AS s FROM t;"
 
-
-
-
 echo "--- mixed index types ---"
 
 oracle "unique_plus_non_unique_index_merge" "
@@ -13525,9 +12327,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT category, count(*) AS n FROM t GROUP BY category ORDER BY category;"
 
-
-
-
 echo "--- schema diff count after merge ---"
 
 oracle "schema_diff_commit_count_after_merge" "
@@ -13546,9 +12345,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) AS n FROM dolt_log WHERE message IN ('c1 added','c2 added');"
 
-
-
-
 echo "--- UPDATE cte source ---"
 
 oracle "update_via_cte_subquery_merge" "
@@ -13566,9 +12362,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- dolt_status detail ---"
 
@@ -13589,9 +12382,6 @@ SELECT dolt_commit('-m','base');
 UPDATE t SET v='b' WHERE id=1;
 " "SELECT count(*) FROM dolt_status WHERE table_name='t';"
 
-
-
-
 echo "--- commit after noops ---"
 
 oracle "many_select_then_commit_stable" "
@@ -13607,9 +12397,6 @@ INSERT INTO t VALUES(2);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM dolt_log;"
-
-
-
 echo "--- convergent update-same-col same-value ---"
 
 oracle "both_sides_set_same_col_same_value_merge" "
@@ -13629,9 +12416,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- dolt_log filter combos ---"
 
@@ -13658,9 +12442,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT CASE WHEN count(*) > 0 THEN 1 ELSE 0 END FROM dolt_log;"
 
-
-
-
 echo "--- dirty flag probes ---"
 
 oracle "dirty_1_after_add_no_commit" "
@@ -13681,9 +12462,6 @@ INSERT INTO t VALUES(2);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM dolt_branches WHERE name='main' AND dirty IN (0,'false');"
-
-
-
 
 echo "--- cross-branch FK preservation ---"
 
@@ -13706,9 +12484,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT p.id AS pid, p.v AS pv, c.v AS cv FROM p LEFT JOIN c ON p.id=c.pid ORDER BY p.id;"
-
-
-
 
 echo "--- tag chain reset ---"
 
@@ -13736,9 +12511,6 @@ SELECT dolt_commit('-m','c5');
 SELECT dolt_reset('--hard','v1');
 " "SELECT id FROM t ORDER BY id;"
 
-
-
-
 echo "--- cherry-pick idempotency ---"
 
 oracle "cherry_pick_then_full_merge_same_branch" "
@@ -13757,9 +12529,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_cherry_pick('feat~1');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- UPDATE subquery 2 tables ---"
 
@@ -13780,9 +12549,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, category_id, price FROM items ORDER BY id;"
-
-
-
 
 echo "--- rebase-like flow ---"
 
@@ -13808,9 +12574,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t ORDER BY id;"
 
-
-
-
 echo "--- NULL default probes ---"
 
 oracle "null_default_merge" "
@@ -13829,9 +12592,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- large delete + merge ---"
 
 oracle "delete_half_rows_update_other_half_merge" "
@@ -13849,9 +12609,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main multiplies other half');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- multi-commit conflict resolve ---"
 
@@ -13878,9 +12635,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','kept ours');
 COMMIT;
 " "SELECT id, v FROM t;"
-
-
-
 
 echo "--- rapid alternation ---"
 
@@ -13916,9 +12670,6 @@ SELECT dolt_commit('-m','m3');
 SELECT dolt_merge('feat');
 " "SELECT owner, count(*) AS n FROM t GROUP BY owner ORDER BY owner;"
 
-
-
-
 echo "--- log invariant ---"
 
 oracle "log_count_unchanged_by_selects" "
@@ -13933,9 +12684,6 @@ SELECT count(*) FROM t;
 SELECT count(*) FROM dolt_branches;
 SELECT count(*) FROM dolt_tags;
 " "SELECT count(*) FROM dolt_log;"
-
-
-
 
 echo "--- nested WHERE joins ---"
 
@@ -13953,9 +12701,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT c.region, sum(o.amount) AS total FROM customers c JOIN orders o ON c.id=o.cid GROUP BY c.region ORDER BY c.region;"
-
-
-
 
 echo "--- multi-merge from same feat ---"
 
@@ -13978,9 +12723,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t;"
 
-
-
-
 echo "--- hashof_table after merge ---"
 
 oracle "hashof_table_valid_after_merge" "
@@ -13996,9 +12738,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT CASE WHEN length(dolt_hashof_table('t')) > 0 THEN 1 ELSE 0 END;"
 
-
-
-
 echo "--- repeated add ---"
 
 oracle "add_same_table_multiple_times" "
@@ -14013,10 +12752,6 @@ SELECT dolt_add('-A');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2');
 " "SELECT count(*) FROM dolt_log;"
-
-
-
-
 echo "--- rapid commit-reset cycles ---"
 
 oracle "three_commit_reset_cycles" "
@@ -14037,9 +12772,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c2c');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- INSERT SELECT LIMIT ---"
 
 oracle "insert_select_limit_after_merge" "
@@ -14059,9 +12791,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM dst ORDER BY id;"
 
-
-
-
 echo "--- UPDATE expression ---"
 
 oracle "update_case_increment_merge" "
@@ -14079,9 +12808,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, n, s FROM t ORDER BY id;"
-
-
-
 
 echo "--- cherry-pick preservation ---"
 
@@ -14102,9 +12828,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main t2');
 SELECT dolt_cherry_pick('feat');
 " "SELECT 't1' AS tbl, count(*) AS n FROM t1 UNION ALL SELECT 't2', count(*) FROM t2 ORDER BY 1;"
-
-
-
 
 echo "--- three-branch merge count ---"
 
@@ -14133,9 +12856,6 @@ SELECT dolt_commit('-m','m2');
 SELECT dolt_merge('b','--no-ff','-m','merge_b');
 " "SELECT count(*) FROM dolt_log WHERE message IN ('merge_a','merge_b');"
 
-
-
-
 echo "--- LIKE anchored ---"
 
 oracle "like_anchored_prefix_after_merge" "
@@ -14150,9 +12870,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t WHERE name LIKE 'a%' ORDER BY id;"
-
-
-
 
 echo "--- very deep reset probes ---"
 
@@ -14188,9 +12905,6 @@ SELECT dolt_commit('-m','c9');
 SELECT dolt_reset('--hard','HEAD~8');
 " "SELECT count(*) FROM t;"
 
-
-
-
 echo "--- FK update through merge ---"
 
 oracle "fk_update_parent_attribute_merge" "
@@ -14211,9 +12925,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main child');
 SELECT dolt_merge('feat');
 " "SELECT p.v AS pv, c.v AS cv FROM p JOIN c ON p.id=c.pid ORDER BY p.id;"
-
-
-
 
 echo "--- three-branch tag snapshots ---"
 
@@ -14237,9 +12948,6 @@ SELECT dolt_tag('b2_snap','HEAD');
 SELECT dolt_checkout('main');
 " "SELECT count(*) FROM dolt_tags;"
 
-
-
-
 echo "--- revert-a-revert ---"
 
 oracle "revert_then_revert_restores_data" "
@@ -14253,9 +12961,6 @@ SELECT dolt_commit('-m','added_b');
 SELECT dolt_revert('HEAD');
 SELECT dolt_revert('HEAD');
 " "SELECT id, v FROM t ORDER BY id;"
-
-
-
 
 echo "--- BETWEEN edges ---"
 
@@ -14271,9 +12976,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t WHERE v BETWEEN 20 AND 40 ORDER BY id;"
-
-
-
 
 echo "--- INSERT SELECT GROUP BY ---"
 
@@ -14294,9 +12996,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT grp, total FROM totals ORDER BY grp;"
-
-
-
 
 echo "--- 4 branch merges ---"
 
@@ -14331,9 +13030,6 @@ SELECT dolt_merge('b3');
 SELECT dolt_merge('b4');
 " "SELECT count(*) FROM t;"
 
-
-
-
 echo "--- 30-col table merge ---"
 
 oracle "thirty_col_table_merge" "
@@ -14358,9 +13054,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, c01, c15, c25, c30 FROM t;"
 
-
-
-
 echo "--- multi-row REPLACE ---"
 
 oracle "multi_row_replace_merge" "
@@ -14379,9 +13072,6 @@ SELECT dolt_commit('-m','main');
 SELECT dolt_merge('feat');
 " "SELECT id, v FROM t ORDER BY id;"
 
-
-
-
 echo "--- tie-break ORDER BY ---"
 
 oracle "order_by_with_tiebreak_after_merge" "
@@ -14396,9 +13086,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM t ORDER BY n, grp, id;"
-
-
-
 
 echo "--- stress log ---"
 
@@ -14450,9 +13137,6 @@ INSERT INTO t VALUES(15);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','c15');
 " "SELECT CASE WHEN count(DISTINCT commit_hash) = count(*) THEN 1 ELSE 0 END FROM dolt_log;"
-
-
-
 echo "--- final probes ---"
 
 oracle "one_k_update_after_ff_merge" "
@@ -14613,9 +13297,6 @@ INSERT INTO t VALUES(1),(2),(3);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','milestone');
 " "SELECT count(*) AS n FROM t;"
-
-
-
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then

--- a/test/vc_oracle_fk_merge_test.sh
+++ b/test/vc_oracle_fk_merge_test.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
-#
-# Version-control oracle-ish tests: merge-time FK / UNIQUE / CHECK
-# constraint violations in DoltLite default SQL mode.
-#
-# Current Dolt semantics under autocommit are:
-#   - if a merge would introduce constraint violations, the merge
-#     errors and the transaction rolls back
-#   - no dolt_constraint_violations rows are left behind
-#   - no dolt_conflicts rows are left behind
-#   - table contents remain at the pre-merge branch state
-#
-# DoltLite now intentionally matches that behavior. This suite locks
-# that down across rowid and WITHOUT ROWID table shapes.
-#
-# Usage: bash vc_oracle_fk_merge_test.sh [path/to/doltlite] [path/to/dolt]
-#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 set -u
 

--- a/test/vc_oracle_fk_merge_test.sh
+++ b/test/vc_oracle_fk_merge_test.sh
@@ -1,21 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 set -u
 
 DOLTLITE="${1:-./doltlite}"

--- a/test/vc_oracle_hashof_test.sh
+++ b/test/vc_oracle_hashof_test.sh
@@ -1,73 +1,73 @@
 #!/bin/bash
-#
-# Version-control oracle test: dolt_hashof suite
-#
-# dolt_hashof(ref), dolt_hashof_table(tbl[, ref]), and dolt_hashof_db()
-# expose content-addressed hashes to SQL. These are the primary tool
-# for verifying two doltlite databases hold the same state in the
-# decentralized use case — compare a hash, don't diff a million rows.
-#
-# The interesting property isn't that hash values match some external
-# reference — it's that they obey HISTORY INDEPENDENCE: any two code
-# paths that arrive at the same logical state must produce the same
-# hash, regardless of intermediate commits, ordering, or transient
-# rows. Prolly trees give us this by construction (content-addressed
-# nodes keyed on sorted content), and if any of the properties below
-# break, the chunking/serialization layer has a bug.
-#
-# The tests in this oracle are grouped by property:
-#
-#   1. Determinism: the same input sequence run twice in separate
-#      databases produces byte-identical hashes. Exercises the
-#      chunker + serializer end-to-end.
-#
-#   2. Insert order invariance: inserting the same rowset in
-#      different orders converges to the same table hash. This is
-#      the core prolly-tree property; if it breaks, either the
-#      mutmap merge step has stale state or the chunker isn't
-#      hashing sorted content.
-#
-#   3. Intermediate state invariance: inserting rows then deleting
-#      a subset then re-inserting them (net-no-op) produces the
-#      same hash as just inserting the remaining set. Tests that
-#      tombstones flush cleanly and the final root is content-
-#      addressed.
-#
-#   4. Cross-branch state invariance: two branches that diverge and
-#      re-converge on the exact same rowset produce the same
-#      dolt_hashof_table even though their commit graphs differ.
-#      dolt_hashof(ref) DIFFERS because commit metadata differs —
-#      this is correct, and we check both.
-#
-#   5. Separation of concerns: adding a row to table A does NOT
-#      change dolt_hashof_table('B'). dolt_hashof_db() DOES
-#      change because the catalog moved.
-#
-#   6. Reopen stability: close the db, reopen, hashes are
-#      byte-identical. Catches any hashing that depends on live
-#      in-memory state instead of persisted chunks.
-#
-#   7. Negative cases: updating a single cell, adding a row,
-#      altering a schema all MUST change the table hash. If
-#      they don't, the hash is stale and worthless.
-#
-#   7b. Equivalent DDL histories: if two histories converge on the
-#      same logical schema and rowset, dolt_hashof_table must also
-#      converge even if one path used ALTER or recreate/copy/rename.
-#
-#   8. Ref resolution: dolt_hashof accepts branch names, tag
-#      names, commit hashes, and HEAD~N shorthand. Missing refs
-#      return NULL or an error (we accept either, as long as it
-#      isn't a silent hash).
-#
-#   9. Dolt shape conformance: dolt_hashof(...) result is stable,
-#      lowercase, and exactly 40 hex characters (20-byte
-#      ProllyHash). This is the only Dolt conformance check —
-#      we don't require hash-value equality with the Dolt CLI
-#      because Dolt renders the same bytes as 32-char base32.
-#
-# Usage: bash vc_oracle_hashof_test.sh [path/to/doltlite]
-#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 set -u
 
@@ -77,10 +77,10 @@ trap "rm -rf $TMPROOT" EXIT
 pass=0; fail=0
 FAILED_NAMES=""
 
-# Run setup sql against a fresh doltlite db in one process, then run
-# the hash-producing query in a second process so stdout contains
-# ONLY the query result. Without this split, dolt_commit's return
-# value would bleed into the captured hash.
+
+
+
+
 run_hash() {
   local name="$1" setup="$2" query="$3"
   local db="$TMPROOT/$name.db"
@@ -90,14 +90,14 @@ run_hash() {
   "$DOLTLITE" "$db" "$query" 2>"$TMPROOT/$name.query.err"
 }
 
-# Like run_hash, but reuses an existing db path — so caller can
-# layer setup sequences and inspect the hash at different points.
+
+
 run_hash_on() {
   local db="$1" query="$2"
   "$DOLTLITE" "$db" "$query" 2>>"$TMPROOT/shared.err"
 }
 
-# Assert two invocations produce the same hash.
+
 same() {
   local name="$1" a="$2" b="$3"
   if [ -z "$a" ] || [ -z "$b" ]; then
@@ -120,8 +120,8 @@ same() {
   fi
 }
 
-# Assert two invocations produce DIFFERENT hashes (updates,
-# schema changes, etc. must invalidate).
+
+
 different() {
   local name="$1" a="$2" b="$3"
   if [ -z "$a" ] || [ -z "$b" ]; then
@@ -141,7 +141,7 @@ different() {
   fi
 }
 
-# Assert hash matches a specific shape (40 lowercase hex chars).
+
 shape() {
   local name="$1" h="$2"
   if echo "$h" | grep -qE '^[0-9a-f]{40}$'; then
@@ -158,7 +158,7 @@ shape() {
 echo "=== Version Control Oracle Tests: dolt_hashof suite ==="
 echo ""
 
-# ── 1. Determinism ────────────────────────────────────────
+
 echo "--- 1. Determinism: same input → same hash ---"
 
 SEED_A="
@@ -178,7 +178,7 @@ same "determinism_db_same_inputs" "$H1" "$H2"
 
 echo ""
 
-# ── 2. Insert order invariance ────────────────────────────
+
 echo "--- 2. Insert order invariance ---"
 
 ORDER_ABC="
@@ -214,7 +214,7 @@ same "order_abc_vs_batch"  "$H_ABC" "$H_BAT"
 
 echo ""
 
-# ── 3. Intermediate state invariance ──────────────────────
+
 echo "--- 3. Intermediate state invariance (delete+reinsert is a no-op) ---"
 
 NET="
@@ -249,7 +249,7 @@ same "net_vs_delete_reinsert" "$H_NET" "$H_DR"
 
 echo ""
 
-# ── 4. Cross-branch state invariance ──────────────────────
+
 echo "--- 4. Cross-branch state invariance ---"
 
 BRANCH_CONVERGE="
@@ -284,7 +284,7 @@ different "cross_branch_commit_hash_differs" "$H_MAIN_COMMIT" "$H_FEAT_COMMIT"
 
 echo ""
 
-# ── 5. Per-table vs whole-db separation ───────────────────
+
 echo "--- 5. Per-table isolation in dolt_hashof_table ---"
 
 TWO_TABLES="
@@ -304,7 +304,7 @@ HT_BEFORE=$(run_hash_on "$DB" "SELECT dolt_hashof_table('t');")
 HU_BEFORE=$(run_hash_on "$DB" "SELECT dolt_hashof_table('u');")
 HDB_BEFORE=$(run_hash_on "$DB" "SELECT dolt_hashof_db();")
 
-# Mutate u only; t's hash must not move.
+
 "$DOLTLITE" "$DB" "INSERT INTO u VALUES (2, 'y'); SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'bump_u');" >/dev/null 2>>"$TMPROOT/two.err"
 
 HT_AFTER=$(run_hash_on "$DB" "SELECT dolt_hashof_table('t');")
@@ -317,7 +317,7 @@ different "db_hash_changes_on_u_mutation" "$HDB_BEFORE" "$HDB_AFTER"
 
 echo ""
 
-# ── 6. Reopen stability ───────────────────────────────────
+
 echo "--- 6. Reopen stability ---"
 
 REOPEN_SEED="
@@ -345,7 +345,7 @@ same "reopen_commit_stable" "$H_OPEN4_MAIN" "$H_OPEN7_MAIN"
 
 echo ""
 
-# ── 7. Negative: mutations must invalidate ────────────────
+
 echo "--- 7. Mutations must invalidate ---"
 
 BASE="
@@ -388,7 +388,7 @@ different "alter_schema_changes_table_hash" "$H_BASE" "$H_ALT"
 
 echo ""
 
-# ── 7b. Equivalent DDL histories converge ─────────────────
+
 echo "--- 7b. Equivalent DDL histories converge ---"
 
 DDL_DIRECT="
@@ -431,7 +431,7 @@ same "ddl_direct_vs_recreate_table_hash" "$H_DDL_DIRECT" "$H_DDL_RECREATE"
 
 echo ""
 
-# ── 8. Ref resolution ─────────────────────────────────────
+
 echo "--- 8. Ref resolution ---"
 
 REF_SEED="
@@ -456,14 +456,14 @@ shape "main_hash_shape" "$H_MAIN"
 H_HEAD_PARENT=$(run_hash_on "$DB" "SELECT dolt_hashof('HEAD~1');")
 different "HEAD_differs_from_HEAD_parent" "$H_HEAD" "$H_HEAD_PARENT"
 
-# Passing the same commit hash string through dolt_hashof should
-# return the same hash back (identity). Grab HEAD, then feed it.
+
+
 H_ID_OUT=$(run_hash_on "$DB" "SELECT dolt_hashof('$H_HEAD');")
 same "commit_hash_is_identity_on_hashof" "$H_HEAD" "$H_ID_OUT"
 
 echo ""
 
-# ── 9. Dolt shape conformance ─────────────────────────────
+
 echo "--- 9. Dolt shape conformance ---"
 
 SHAPE_SEED="

--- a/test/vc_oracle_hashof_test.sh
+++ b/test/vc_oracle_hashof_test.sh
@@ -1,74 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 set -u
 
 DOLTLITE="${1:-./doltlite}"
@@ -76,10 +7,6 @@ TMPROOT=$(mktemp -d)
 trap "rm -rf $TMPROOT" EXIT
 pass=0; fail=0
 FAILED_NAMES=""
-
-
-
-
 
 run_hash() {
   local name="$1" setup="$2" query="$3"
@@ -90,13 +17,10 @@ run_hash() {
   "$DOLTLITE" "$db" "$query" 2>"$TMPROOT/$name.query.err"
 }
 
-
-
 run_hash_on() {
   local db="$1" query="$2"
   "$DOLTLITE" "$db" "$query" 2>>"$TMPROOT/shared.err"
 }
-
 
 same() {
   local name="$1" a="$2" b="$3"
@@ -120,8 +44,6 @@ same() {
   fi
 }
 
-
-
 different() {
   local name="$1" a="$2" b="$3"
   if [ -z "$a" ] || [ -z "$b" ]; then
@@ -141,7 +63,6 @@ different() {
   fi
 }
 
-
 shape() {
   local name="$1" h="$2"
   if echo "$h" | grep -qE '^[0-9a-f]{40}$'; then
@@ -157,7 +78,6 @@ shape() {
 
 echo "=== Version Control Oracle Tests: dolt_hashof suite ==="
 echo ""
-
 
 echo "--- 1. Determinism: same input → same hash ---"
 
@@ -177,7 +97,6 @@ H2=$(run_hash "det_db2" "$SEED_A" "SELECT dolt_hashof_db();")
 same "determinism_db_same_inputs" "$H1" "$H2"
 
 echo ""
-
 
 echo "--- 2. Insert order invariance ---"
 
@@ -214,7 +133,6 @@ same "order_abc_vs_batch"  "$H_ABC" "$H_BAT"
 
 echo ""
 
-
 echo "--- 3. Intermediate state invariance (delete+reinsert is a no-op) ---"
 
 NET="
@@ -248,7 +166,6 @@ same "net_vs_through_delete"  "$H_NET" "$H_TD"
 same "net_vs_delete_reinsert" "$H_NET" "$H_DR"
 
 echo ""
-
 
 echo "--- 4. Cross-branch state invariance ---"
 
@@ -284,7 +201,6 @@ different "cross_branch_commit_hash_differs" "$H_MAIN_COMMIT" "$H_FEAT_COMMIT"
 
 echo ""
 
-
 echo "--- 5. Per-table isolation in dolt_hashof_table ---"
 
 TWO_TABLES="
@@ -304,7 +220,6 @@ HT_BEFORE=$(run_hash_on "$DB" "SELECT dolt_hashof_table('t');")
 HU_BEFORE=$(run_hash_on "$DB" "SELECT dolt_hashof_table('u');")
 HDB_BEFORE=$(run_hash_on "$DB" "SELECT dolt_hashof_db();")
 
-
 "$DOLTLITE" "$DB" "INSERT INTO u VALUES (2, 'y'); SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'bump_u');" >/dev/null 2>>"$TMPROOT/two.err"
 
 HT_AFTER=$(run_hash_on "$DB" "SELECT dolt_hashof_table('t');")
@@ -316,7 +231,6 @@ different "u_hash_changes_on_u_mutation"  "$HU_BEFORE" "$HU_AFTER"
 different "db_hash_changes_on_u_mutation" "$HDB_BEFORE" "$HDB_AFTER"
 
 echo ""
-
 
 echo "--- 6. Reopen stability ---"
 
@@ -344,7 +258,6 @@ same "reopen_db_stable"    "$H_OPEN3_DB" "$H_OPEN6_DB"
 same "reopen_commit_stable" "$H_OPEN4_MAIN" "$H_OPEN7_MAIN"
 
 echo ""
-
 
 echo "--- 7. Mutations must invalidate ---"
 
@@ -388,7 +301,6 @@ different "alter_schema_changes_table_hash" "$H_BASE" "$H_ALT"
 
 echo ""
 
-
 echo "--- 7b. Equivalent DDL histories converge ---"
 
 DDL_DIRECT="
@@ -431,7 +343,6 @@ same "ddl_direct_vs_recreate_table_hash" "$H_DDL_DIRECT" "$H_DDL_RECREATE"
 
 echo ""
 
-
 echo "--- 8. Ref resolution ---"
 
 REF_SEED="
@@ -456,13 +367,10 @@ shape "main_hash_shape" "$H_MAIN"
 H_HEAD_PARENT=$(run_hash_on "$DB" "SELECT dolt_hashof('HEAD~1');")
 different "HEAD_differs_from_HEAD_parent" "$H_HEAD" "$H_HEAD_PARENT"
 
-
-
 H_ID_OUT=$(run_hash_on "$DB" "SELECT dolt_hashof('$H_HEAD');")
 same "commit_hash_is_identity_on_hashof" "$H_HEAD" "$H_ID_OUT"
 
 echo ""
-
 
 echo "--- 9. Dolt shape conformance ---"
 

--- a/test/vc_oracle_history_test.sh
+++ b/test/vc_oracle_history_test.sh
@@ -1,29 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 set -u
 set -o pipefail
 
@@ -34,9 +10,6 @@ trap "rm -rf $TMPROOT" EXIT
 pass=0; fail=0
 FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
-
-
-
 
 normalize_history() {
   tr -d '\r' \
@@ -71,7 +44,6 @@ oracle() {
 
   IFS=',' read -ra tarr <<< "$tables"
 
-
   local dl_q=""
   for tn in "${tarr[@]}"; do
     local part="SELECT 'H' || char(9) || '${tn}' || char(9) || coalesce(h.id,'') || char(9) || coalesce(h.v,'') || char(9) || coalesce(log.message, h.commit_hash) || char(9) || coalesce(h.committer,'') FROM dolt_history_${tn} h LEFT JOIN dolt_log log ON log.commit_hash = h.commit_hash"
@@ -88,7 +60,6 @@ oracle() {
            | grep -v '^[0-9]*$' \
            | grep -v '^[0-9a-f]\{40\}$' \
            | normalize_history)
-
 
   local dolt_setup
   dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
@@ -112,7 +83,6 @@ oracle() {
       printf '%s;\n' "$dt_q"
     } | "$DOLT" sql -c -r csv 2>"$dir/dt.err" | tr -d '"' | normalize_history
   )
-
 
   if [ -z "$dl_out" ] && [ -z "$dt_out" ]; then
     fail=$((fail+1))
@@ -145,13 +115,9 @@ SELECT dolt_commit('-m', 'c1');
 
 echo "--- basic ---"
 
-
 oracle "single_commit_two_rows" "
 $SEED
 "
-
-
-
 
 oracle "modify_one_row_then_query" "
 $SEED
@@ -160,8 +126,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c2_mod');
 "
 
-
-
 oracle "insert_new_row" "
 $SEED
 INSERT INTO t VALUES (3, 30);
@@ -169,16 +133,12 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c2_add');
 "
 
-
-
-
 oracle "delete_row_in_later_commit" "
 $SEED
 DELETE FROM t WHERE id = 1;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c2_del');
 "
-
 
 oracle "many_commits_many_changes" "
 $SEED
@@ -198,13 +158,10 @@ SELECT dolt_commit('-m', 'c5');
 
 echo "--- working set is excluded ---"
 
-
-
 oracle "working_set_changes_not_in_history" "
 $SEED
 UPDATE t SET v = 999 WHERE id = 1;
 "
-
 
 oracle "staged_changes_not_in_history" "
 $SEED
@@ -213,8 +170,6 @@ SELECT dolt_add('-A');
 "
 
 echo "--- multi-table ---"
-
-
 
 oracle "two_tables_independent_history" "
 CREATE TABLE t(id INT PRIMARY KEY, v INT);
@@ -232,8 +187,6 @@ SELECT dolt_commit('-m', 'add_u');
 " "t,u"
 
 echo "--- branching ---"
-
-
 
 oracle "history_on_feature_branch" "
 $SEED
@@ -256,8 +209,6 @@ SELECT dolt_tag('v1', 'HEAD~1');
 SELECT dolt_branch('from_tag', 'v1');
 SELECT dolt_checkout('from_tag');
 "
-
-
 
 oracle "history_after_merge" "
 $SEED
@@ -304,8 +255,6 @@ SELECT dolt_merge('feature');
 SELECT dolt_branch('from_p2', 'HEAD^2');
 SELECT dolt_checkout('from_p2');
 "
-
-
 
 oracle "history_replay_merge_add_table_plus_check" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -455,14 +404,12 @@ SELECT dolt_rebase('main');
 
 echo "--- edge cases ---"
 
-
 oracle "single_row_single_commit" "
 CREATE TABLE t(id INT PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 1);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'just_one');
 "
-
 
 oracle "same_row_value_churned" "
 CREATE TABLE t(id INT PRIMARY KEY, v INT);
@@ -480,8 +427,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c4');
 "
 
-
-
 oracle "add_delete_readd_same_id" "
 CREATE TABLE t(id INT PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
@@ -495,10 +440,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c3_readd');
 "
 
-
-
-
-
 oracle "history_after_checkout_sibling_branch" "
 $SEED
 SELECT dolt_branch('feature');
@@ -508,9 +449,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'feat_only');
 SELECT dolt_checkout('main');
 "
-
-
-
 
 oracle "history_after_hard_reset" "
 $SEED
@@ -523,8 +461,6 @@ SELECT dolt_commit('-m', 'c3');
 SELECT dolt_reset('--hard', 'HEAD~1');
 "
 
-
-
 oracle "history_after_amend" "
 $SEED
 INSERT INTO t VALUES (3, 30);
@@ -534,7 +470,6 @@ SELECT dolt_commit('--amend', '-m', 'c2_amended');
 "
 
 echo "--- NULL values and other types ---"
-
 
 oracle "null_value_in_history" "
 CREATE TABLE t(id INT PRIMARY KEY, v INT);

--- a/test/vc_oracle_history_test.sh
+++ b/test/vc_oracle_history_test.sh
@@ -1,28 +1,28 @@
 #!/bin/bash
-#
-# Version-control oracle test: dolt_history_<table>
-#
-# Per-table commit history vtable. For each commit in the current
-# branch's history (where the table existed), emits one row per
-# table row containing the full row state plus the commit metadata.
-#
-# Schema (matches Dolt):
-#   <user_col_1>, <user_col_2>, ..., <user_col_N>,
-#   commit_hash TEXT, committer TEXT, commit_date TEXT
-#
-# The harness compares the rows after canonicalizing:
-#   - commit_hash → commit message (LEFT JOIN with dolt_log)
-#   - committer → DEFAULT for engine-specific defaults
-#   - commit_date → dropped from comparison (millisecond vs second
-#     precision differs and isn't a meaningful divergence)
-#
-# Setup and query run in a single engine invocation so the session
-# state at the end of setup (current branch, working set) is
-# preserved through to the queries — same lesson as the diff
-# oracle in #372.
-#
-# Usage: bash vc_oracle_history_test.sh [path/to/doltlite] [path/to/dolt]
-#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 set -u
 set -o pipefail
@@ -35,9 +35,9 @@ pass=0; fail=0
 FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
-# Input row (built by the harness query):
-#   $1=H, $2=table, $3=id, $4=v, $5=msg, $6=committer
-# Output: H, table, id, v, msg, committer (canonicalized)
+
+
+
 normalize_history() {
   tr -d '\r' \
     | awk -F'\t' 'NF >= 6 && $1 == "H" { print }' \
@@ -71,7 +71,7 @@ oracle() {
 
   IFS=',' read -ra tarr <<< "$tables"
 
-  # ── doltlite query ──
+
   local dl_q=""
   for tn in "${tarr[@]}"; do
     local part="SELECT 'H' || char(9) || '${tn}' || char(9) || coalesce(h.id,'') || char(9) || coalesce(h.v,'') || char(9) || coalesce(log.message, h.commit_hash) || char(9) || coalesce(h.committer,'') FROM dolt_history_${tn} h LEFT JOIN dolt_log log ON log.commit_hash = h.commit_hash"
@@ -89,7 +89,7 @@ oracle() {
            | grep -v '^[0-9a-f]\{40\}$' \
            | normalize_history)
 
-  # ── Dolt query ──
+
   local dolt_setup
   dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
 
@@ -113,7 +113,7 @@ oracle() {
     } | "$DOLT" sql -c -r csv 2>"$dir/dt.err" | tr -d '"' | normalize_history
   )
 
-  # Empty-on-both-sides safeguard.
+
   if [ -z "$dl_out" ] && [ -z "$dt_out" ]; then
     fail=$((fail+1))
     FAILED_NAMES="$FAILED_NAMES $name"
@@ -145,14 +145,14 @@ SELECT dolt_commit('-m', 'c1');
 
 echo "--- basic ---"
 
-# Single commit. Each table row appears once with that commit.
+
 oracle "single_commit_two_rows" "
 $SEED
 "
 
-# Two commits, second updates a row. The row appears in BOTH
-# commits with the respective values. Other rows appear in both
-# commits unchanged.
+
+
+
 oracle "modify_one_row_then_query" "
 $SEED
 UPDATE t SET v = 99 WHERE id = 1;
@@ -160,8 +160,8 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c2_mod');
 "
 
-# Insert a new row in a later commit. The new row appears only
-# in the later commit; existing rows appear in both.
+
+
 oracle "insert_new_row" "
 $SEED
 INSERT INTO t VALUES (3, 30);
@@ -169,9 +169,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c2_add');
 "
 
-# Delete a row in a later commit. The deleted row still appears
-# in the OLDER commits (history is immutable) but NOT in the new
-# commit.
+
+
+
 oracle "delete_row_in_later_commit" "
 $SEED
 DELETE FROM t WHERE id = 1;
@@ -179,7 +179,7 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c2_del');
 "
 
-# Multiple modifications across multiple commits.
+
 oracle "many_commits_many_changes" "
 $SEED
 UPDATE t SET v = 100 WHERE id = 1;
@@ -198,14 +198,14 @@ SELECT dolt_commit('-m', 'c5');
 
 echo "--- working set is excluded ---"
 
-# History only includes COMMITTED state. Uncommitted working
-# changes do NOT appear in dolt_history_<table>.
+
+
 oracle "working_set_changes_not_in_history" "
 $SEED
 UPDATE t SET v = 999 WHERE id = 1;
 "
 
-# Same with staged-but-not-committed changes.
+
 oracle "staged_changes_not_in_history" "
 $SEED
 UPDATE t SET v = 999 WHERE id = 1;
@@ -214,8 +214,8 @@ SELECT dolt_add('-A');
 
 echo "--- multi-table ---"
 
-# Two tables in the same scenario; each table's history is
-# independent of the other's.
+
+
 oracle "two_tables_independent_history" "
 CREATE TABLE t(id INT PRIMARY KEY, v INT);
 CREATE TABLE u(id INT PRIMARY KEY, v INT);
@@ -233,8 +233,8 @@ SELECT dolt_commit('-m', 'add_u');
 
 echo "--- branching ---"
 
-# History on a feature branch shows feature's commits AND the
-# shared ancestor commits, but not main's later commits.
+
+
 oracle "history_on_feature_branch" "
 $SEED
 SELECT dolt_branch('feature');
@@ -257,8 +257,8 @@ SELECT dolt_branch('from_tag', 'v1');
 SELECT dolt_checkout('from_tag');
 "
 
-# After a merge, history on main includes commits from both sides
-# (including the merge commit itself).
+
+
 oracle "history_after_merge" "
 $SEED
 SELECT dolt_branch('feature');
@@ -305,8 +305,8 @@ SELECT dolt_branch('from_p2', 'HEAD^2');
 SELECT dolt_checkout('from_p2');
 "
 
-# Replay a disjoint add-table commit through merge while the main
-# side independently rewrites another table's schema.
+
+
 oracle "history_replay_merge_add_table_plus_check" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES (1, 'base');
@@ -455,7 +455,7 @@ SELECT dolt_rebase('main');
 
 echo "--- edge cases ---"
 
-# Single-row table at single commit.
+
 oracle "single_row_single_commit" "
 CREATE TABLE t(id INT PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 1);
@@ -463,7 +463,7 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'just_one');
 "
 
-# Same row id, value churned across many commits.
+
 oracle "same_row_value_churned" "
 CREATE TABLE t(id INT PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 1);
@@ -480,8 +480,8 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c4');
 "
 
-# Add a row, delete it, re-add with the SAME id but different
-# value. The history should reflect each state.
+
+
 oracle "add_delete_readd_same_id" "
 CREATE TABLE t(id INT PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
@@ -495,10 +495,10 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c3_readd');
 "
 
-# History across a checkout: switch to a sibling branch and verify
-# only that branch's history is visible. Working changes that
-# stay on main per the per-branch model (#370) should NOT leak
-# into feature's history.
+
+
+
+
 oracle "history_after_checkout_sibling_branch" "
 $SEED
 SELECT dolt_branch('feature');
@@ -509,9 +509,9 @@ SELECT dolt_commit('-m', 'feat_only');
 SELECT dolt_checkout('main');
 "
 
-# After a hard reset to a previous commit, history should reflect
-# the rewound state. The reverted commits are no longer reachable
-# from HEAD.
+
+
+
 oracle "history_after_hard_reset" "
 $SEED
 INSERT INTO t VALUES (3, 30);
@@ -523,8 +523,8 @@ SELECT dolt_commit('-m', 'c3');
 SELECT dolt_reset('--hard', 'HEAD~1');
 "
 
-# After amending the most recent commit, history should reflect
-# the amended commit, not the original.
+
+
 oracle "history_after_amend" "
 $SEED
 INSERT INTO t VALUES (3, 30);
@@ -535,7 +535,7 @@ SELECT dolt_commit('--amend', '-m', 'c2_amended');
 
 echo "--- NULL values and other types ---"
 
-# NULL values in non-PK columns should round-trip through history.
+
 oracle "null_value_in_history" "
 CREATE TABLE t(id INT PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);

--- a/test/vc_oracle_ignore_test.sh
+++ b/test/vc_oracle_ignore_test.sh
@@ -1,56 +1,56 @@
 #!/bin/bash
-#
-# Version-control oracle test: dolt_ignore
-#
-# Pins doltlite's dolt_ignore behavior to Dolt 1.83.5. dolt_ignore is a
-# real user table with schema:
-#
-#   CREATE TABLE dolt_ignore (
-#     pattern TEXT NOT NULL,
-#     ignored TINYINT(1) NOT NULL,
-#     PRIMARY KEY(pattern)
-#   );
-#
-# Rules observed against Dolt 1.83.5:
-#
-#   1. dolt_ignore exists from init; queryable but not in SHOW TABLES.
-#   2. Pattern matching:
-#        %  and  *   → zero or more characters
-#        ?           → exactly one character
-#        other       → literal
-#   3. Pattern matching only gates *new* (untracked) tables. Once a
-#      table is committed, modifications always show in dolt_status.
-#   4. Among all matching patterns the most specific wins. "Most
-#      specific" is roughly the longest literal-prefix match — an
-#      exact literal beats any wildcard pattern.
-#   5. If two matching patterns disagree on ignored and neither is
-#      strictly more specific, dolt_status and dolt_add raise an
-#      error identifying the conflict.
-#   6. CALL dolt_add('-A') / dolt_add('.'):
-#        - stages all non-ignored untracked tables
-#        - silently skips ignored ones
-#        - errors on an unresolved conflict
-#   7. CALL dolt_add('<ignored_name>'):
-#        - silent success (exit 0, no staging)
-#   8. CALL dolt_commit('-A','-m',...) = dolt_add('-A') + commit;
-#      respects dolt_ignore the same way.
-#   9. Removing a pattern from dolt_ignore immediately re-exposes
-#      previously-hidden tables to dolt_status / dolt_add -A.
-#  10. dolt_ignore itself is a regular table: it needs staging and
-#      committing to persist across sessions, and patterns like '*'
-#      or 'dolt_ignore' hide it from dolt_status the same way.
-#
-# Comparisons use dolt_status's table_name / staged / status tuple as
-# the ground truth, filtered to exclude dolt_ignore itself. Whether
-# dolt_ignore shows up as "new table" vs "modified" is an internal
-# representation detail — Dolt materializes it lazily on first write
-# while doltlite pre-creates it in the seed commit — and the oracle
-# tests the pattern-matching semantics, not dolt_ignore's own staging
-# accounting. Error oracles compare only that both engines report an
-# error; exact error text is allowed to differ.
-#
-# Usage: bash vc_oracle_ignore_test.sh [path/to/doltlite] [path/to/dolt]
-#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 set -u
 set -o pipefail
@@ -65,14 +65,14 @@ source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
 normalize() { tr -d '\r' | grep -v '^S|dolt_ignore|' | sort; }
 
-# doltlite needs the dolt_ignore user table explicitly created by
-# the user; Dolt pre-materializes it as a reserved system name and
-# rejects CREATE TABLE dolt_ignore with "reserved for internal use".
-# So the oracle prepends the CREATE only on the doltlite side.
+
+
+
+
 DL_IGNORE_PREFIX="CREATE TABLE IF NOT EXISTS dolt_ignore(pattern TEXT NOT NULL, ignored TINYINT NOT NULL, PRIMARY KEY(pattern));"
 
-# oracle: run the same setup on both engines and compare their
-# resulting dolt_status (table_name + staged + status).
+
+
 oracle() {
   local name="$1" setup="$2"
   local dir="$TMPROOT/$name"
@@ -90,10 +90,10 @@ $setup"
   local dolt_setup
   dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
 
-  # Run setup AND the status query in a single dolt sql invocation so
-  # that branch checkouts and working-set state persist from setup
-  # into the query (a second dolt sql call would reset to main and
-  # lose the per-branch working set).
+
+
+
+
   (
     cd "$dir/dt" || exit 1
     vc_oracle_init_repo
@@ -115,12 +115,12 @@ $setup"
   fi
 }
 
-# doltlite_schema_reject: doltlite-only check that a CREATE TABLE
-# dolt_ignore with a wrong schema is rejected at parse time. Not an
-# oracle comparison — Dolt rejects any `dolt_` name wholesale with
-# "reserved for internal use", so there's no row-level semantics to
-# compare against. We just assert doltlite produces an error that
-# mentions dolt_ignore.
+
+
+
+
+
+
 doltlite_schema_reject() {
   local name="$1" sql="$2"
   local dir="$TMPROOT/${name}_rej"
@@ -137,8 +137,8 @@ doltlite_schema_reject() {
   fi
 }
 
-# oracle_error: both engines must error on the same setup. Exact
-# message text is allowed to differ.
+
+
 oracle_error() {
   local name="$1" setup="$2"
   local dir="$TMPROOT/${name}_err"
@@ -171,9 +171,9 @@ $setup"
 echo "=== Version Control Oracle Tests: dolt_ignore ==="
 echo ""
 
-# ---------------------------------------------------------------
-# Schema & bootstrap
-# ---------------------------------------------------------------
+
+
+
 
 echo "--- schema & bootstrap ---"
 
@@ -182,9 +182,9 @@ CREATE TABLE t(x INT PRIMARY KEY);
 CREATE TABLE u(x INT PRIMARY KEY);
 "
 
-# ---------------------------------------------------------------
-# Basic pattern matching. Both * and % are wildcards.
-# ---------------------------------------------------------------
+
+
+
 
 echo "--- basic pattern matching ---"
 
@@ -236,9 +236,9 @@ CREATE TABLE ea(x INT PRIMARY KEY);
 CREATE TABLE eabc(x INT PRIMARY KEY);
 "
 
-# ---------------------------------------------------------------
-# Specificity: exact beats wildcard, longer literal beats shorter.
-# ---------------------------------------------------------------
+
+
+
 
 echo "--- specificity ---"
 
@@ -267,9 +267,9 @@ CREATE TABLE foo_keep_a(x INT PRIMARY KEY);
 CREATE TABLE foo_keep_never(x INT PRIMARY KEY);
 "
 
-# ---------------------------------------------------------------
-# Conflict: two equally-specific patterns disagree.
-# ---------------------------------------------------------------
+
+
+
 
 echo "--- conflicts ---"
 
@@ -294,9 +294,9 @@ CREATE TABLE foo_bar(x INT PRIMARY KEY);
 SELECT dolt_add('foo_bar');
 "
 
-# ---------------------------------------------------------------
-# dolt_add: -A, ., explicit name.
-# ---------------------------------------------------------------
+
+
+
 
 echo "--- dolt_add ---"
 
@@ -328,9 +328,9 @@ CREATE TABLE keep(x INT PRIMARY KEY);
 SELECT dolt_add('keep');
 "
 
-# ---------------------------------------------------------------
-# dolt_commit -A respects dolt_ignore.
-# ---------------------------------------------------------------
+
+
+
 
 echo "--- dolt_commit -A ---"
 
@@ -344,9 +344,9 @@ CREATE TABLE tmp_bar(x INT PRIMARY KEY);
 INSERT INTO keep VALUES (1);
 "
 
-# ---------------------------------------------------------------
-# Scope: only gates NEW tables. Tracked tables keep showing edits.
-# ---------------------------------------------------------------
+
+
+
 
 echo "--- scope: only gates new tables ---"
 
@@ -361,10 +361,10 @@ SELECT dolt_commit('-m', 'add pattern');
 INSERT INTO tmp_foo VALUES (2);
 "
 
-# Tracked-modified table matching an ignore pattern: status shows it,
-# but dolt_add -A does NOT stage it. This is Dolt's consistent rule:
-# ignore gates staging (both new and tracked) but only hides NEW
-# tables from status.
+
+
+
+
 oracle "tracked_ignored_not_staged_by_A" "
 CREATE TABLE tmp_foo(x INT PRIMARY KEY);
 INSERT INTO tmp_foo VALUES (1);
@@ -378,9 +378,9 @@ CREATE TABLE keep(x INT PRIMARY KEY);
 SELECT dolt_add('-A');
 "
 
-# ---------------------------------------------------------------
-# Dynamic: pattern removal re-exposes a hidden table.
-# ---------------------------------------------------------------
+
+
+
 
 echo "--- dynamic pattern changes ---"
 
@@ -390,9 +390,9 @@ CREATE TABLE tmp_foo(x INT PRIMARY KEY);
 DELETE FROM dolt_ignore WHERE pattern='tmp_*';
 "
 
-# ---------------------------------------------------------------
-# Persistence across commits.
-# ---------------------------------------------------------------
+
+
+
 
 echo "--- persistence ---"
 
@@ -404,9 +404,9 @@ CREATE TABLE tmp_foo(x INT PRIMARY KEY);
 CREATE TABLE keep(x INT PRIMARY KEY);
 "
 
-# ---------------------------------------------------------------
-# Star-everything hides dolt_ignore too (no special case).
-# ---------------------------------------------------------------
+
+
+
 
 echo "--- no special-case for dolt_ignore ---"
 
@@ -415,12 +415,12 @@ INSERT INTO dolt_ignore VALUES ('*', 1);
 CREATE TABLE foo(x INT PRIMARY KEY);
 "
 
-# ---------------------------------------------------------------
-# Schema guard: doltlite rejects CREATE TABLE dolt_ignore with the
-# wrong shape so the failure mode is a clear parse error instead of
-# silent "no patterns apply". Doltlite-only — Dolt rejects any
-# dolt_ prefix wholesale so there's nothing to compare against.
-# ---------------------------------------------------------------
+
+
+
+
+
+
 
 echo "--- schema guard ---"
 
@@ -464,9 +464,9 @@ doltlite_schema_reject "schema_no_pk" "
 CREATE TABLE dolt_ignore(pattern TEXT NOT NULL, ignored TINYINT NOT NULL);
 "
 
-# Accepted variants: BOOLEAN, VARCHAR, INTEGER for ignored all map
-# to the right affinities. Not an oracle comparison — just assert
-# doltlite accepts them and INSERT works.
+
+
+
 doltlite_schema_accept() {
   local name="$1" sql="$2"
   local dir="$TMPROOT/${name}_acc"
@@ -494,10 +494,10 @@ INSERT INTO dolt_ignore VALUES ('tmp_*', 1);
 SELECT * FROM dolt_ignore;
 "
 
-# Runtime guard: temp-schema shadowing must not override repo ignore
-# rules, and wrong-shape main objects must error rather than silently
-# disabling filtering. Doltlite-only because Dolt does not expose temp
-# objects through the same SQL surface.
+
+
+
+
 doltlite_runtime_expect() {
   local name="$1" sql="$2" expect="$3"
   local dir="$TMPROOT/${name}_rt"
@@ -548,24 +548,24 @@ CREATE TABLE tmp_bad(x INT PRIMARY KEY);
 SELECT * FROM dolt_status;
 "
 
-# ---------------------------------------------------------------
-# cross-branch + merge + reset
-# ---------------------------------------------------------------
-#
-# These scenarios pin dolt_ignore's behavior across branch, merge,
-# and reset operations. All interactions are checked against Dolt
-# 1.83.5; the oracle helpers already handle doltlite's manual
-# CREATE TABLE dolt_ignore prefix.
-#
-# Note scenario 3 (committed_then_reset): after dolt_reset --hard
-# HEAD~1, both engines leave the previously-untracked matching
-# table in the working tree (reset --hard does not clean untracked
-# files). Once the ignore pattern is gone, both that leftover table
-# and any freshly-created matching table show up in dolt_status.
-# Note scenario 5 (merge_conflicting_patterns): an UPDATE-UPDATE
-# conflict on the same dolt_ignore row surfaces as a merge conflict
-# in Dolt and as "Merge has N conflict(s)" in doltlite; oracle_error
-# only requires both to report an error.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 echo "--- cross-branch + merge + reset ---"
 

--- a/test/vc_oracle_ignore_test.sh
+++ b/test/vc_oracle_ignore_test.sh
@@ -1,57 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 set -u
 set -o pipefail
 
@@ -65,13 +13,7 @@ source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
 normalize() { tr -d '\r' | grep -v '^S|dolt_ignore|' | sort; }
 
-
-
-
-
 DL_IGNORE_PREFIX="CREATE TABLE IF NOT EXISTS dolt_ignore(pattern TEXT NOT NULL, ignored TINYINT NOT NULL, PRIMARY KEY(pattern));"
-
-
 
 oracle() {
   local name="$1" setup="$2"
@@ -89,10 +31,6 @@ $setup"
 
   local dolt_setup
   dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
-
-
-
-
 
   (
     cd "$dir/dt" || exit 1
@@ -115,12 +53,6 @@ $setup"
   fi
 }
 
-
-
-
-
-
-
 doltlite_schema_reject() {
   local name="$1" sql="$2"
   local dir="$TMPROOT/${name}_rej"
@@ -136,8 +68,6 @@ doltlite_schema_reject() {
     echo "    output:"; sed 's/^/      /' "$dir/out"
   fi
 }
-
-
 
 oracle_error() {
   local name="$1" setup="$2"
@@ -171,20 +101,12 @@ $setup"
 echo "=== Version Control Oracle Tests: dolt_ignore ==="
 echo ""
 
-
-
-
-
 echo "--- schema & bootstrap ---"
 
 oracle "empty_ignore" "
 CREATE TABLE t(x INT PRIMARY KEY);
 CREATE TABLE u(x INT PRIMARY KEY);
 "
-
-
-
-
 
 echo "--- basic pattern matching ---"
 
@@ -236,10 +158,6 @@ CREATE TABLE ea(x INT PRIMARY KEY);
 CREATE TABLE eabc(x INT PRIMARY KEY);
 "
 
-
-
-
-
 echo "--- specificity ---"
 
 oracle "exact_over_wild" "
@@ -267,10 +185,6 @@ CREATE TABLE foo_keep_a(x INT PRIMARY KEY);
 CREATE TABLE foo_keep_never(x INT PRIMARY KEY);
 "
 
-
-
-
-
 echo "--- conflicts ---"
 
 oracle_error "conflict_two_wild" "
@@ -293,10 +207,6 @@ INSERT INTO dolt_ignore VALUES ('%_bar', 0);
 CREATE TABLE foo_bar(x INT PRIMARY KEY);
 SELECT dolt_add('foo_bar');
 "
-
-
-
-
 
 echo "--- dolt_add ---"
 
@@ -328,10 +238,6 @@ CREATE TABLE keep(x INT PRIMARY KEY);
 SELECT dolt_add('keep');
 "
 
-
-
-
-
 echo "--- dolt_commit -A ---"
 
 oracle "commit_A_skips_ignored" "
@@ -343,10 +249,6 @@ SELECT dolt_commit('-A', '-m', 'first');
 CREATE TABLE tmp_bar(x INT PRIMARY KEY);
 INSERT INTO keep VALUES (1);
 "
-
-
-
-
 
 echo "--- scope: only gates new tables ---"
 
@@ -361,10 +263,6 @@ SELECT dolt_commit('-m', 'add pattern');
 INSERT INTO tmp_foo VALUES (2);
 "
 
-
-
-
-
 oracle "tracked_ignored_not_staged_by_A" "
 CREATE TABLE tmp_foo(x INT PRIMARY KEY);
 INSERT INTO tmp_foo VALUES (1);
@@ -378,10 +276,6 @@ CREATE TABLE keep(x INT PRIMARY KEY);
 SELECT dolt_add('-A');
 "
 
-
-
-
-
 echo "--- dynamic pattern changes ---"
 
 oracle "remove_pattern_exposes" "
@@ -389,10 +283,6 @@ INSERT INTO dolt_ignore VALUES ('tmp_*', 1);
 CREATE TABLE tmp_foo(x INT PRIMARY KEY);
 DELETE FROM dolt_ignore WHERE pattern='tmp_*';
 "
-
-
-
-
 
 echo "--- persistence ---"
 
@@ -404,23 +294,12 @@ CREATE TABLE tmp_foo(x INT PRIMARY KEY);
 CREATE TABLE keep(x INT PRIMARY KEY);
 "
 
-
-
-
-
 echo "--- no special-case for dolt_ignore ---"
 
 oracle "star_hides_dolt_ignore" "
 INSERT INTO dolt_ignore VALUES ('*', 1);
 CREATE TABLE foo(x INT PRIMARY KEY);
 "
-
-
-
-
-
-
-
 
 echo "--- schema guard ---"
 
@@ -464,9 +343,6 @@ doltlite_schema_reject "schema_no_pk" "
 CREATE TABLE dolt_ignore(pattern TEXT NOT NULL, ignored TINYINT NOT NULL);
 "
 
-
-
-
 doltlite_schema_accept() {
   local name="$1" sql="$2"
   local dir="$TMPROOT/${name}_acc"
@@ -493,10 +369,6 @@ CREATE TABLE dolt_ignore(pattern TEXT NOT NULL, ignored INTEGER NOT NULL, PRIMAR
 INSERT INTO dolt_ignore VALUES ('tmp_*', 1);
 SELECT * FROM dolt_ignore;
 "
-
-
-
-
 
 doltlite_runtime_expect() {
   local name="$1" sql="$2" expect="$3"
@@ -547,25 +419,6 @@ CREATE VIEW dolt_ignore AS SELECT 'tmp_*' AS pattern;
 CREATE TABLE tmp_bad(x INT PRIMARY KEY);
 SELECT * FROM dolt_status;
 "
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 echo "--- cross-branch + merge + reset ---"
 

--- a/test/vc_oracle_log_test.sh
+++ b/test/vc_oracle_log_test.sh
@@ -1,14 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
-
 set -u
 set -o pipefail
 
@@ -19,9 +10,6 @@ trap "rm -rf $TMPROOT" EXIT
 pass=0; fail=0
 FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
-
-
-
 
 normalize() {
   tr -d '\r' | awk -F'\t' '
@@ -34,22 +22,13 @@ normalize() {
   '
 }
 
-
-
-
 oracle() {
   local name="$1" setup="$2"
   local dir="$TMPROOT/$name"
   mkdir -p "$dir/dl" "$dir/dt"
 
-
-
-
-
-
   local dl_q="SELECT 'LOG|' || commit_hash || char(9) || message FROM dolt_log"
   local dt_q="SELECT concat('LOG|', commit_hash, char(9), message) FROM dolt_log ORDER BY commit_order DESC"
-
 
   local dl_out
   dl_out=$(printf "%s\n.headers off\n.mode list\n.separator '\t'\n%s;\n" "$setup" "$dl_q" \
@@ -57,7 +36,6 @@ oracle() {
            | grep '^LOG|' \
            | sed 's/^LOG|//' \
            | normalize)
-
 
   local dolt_setup
   dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
@@ -88,14 +66,12 @@ oracle() {
 echo "=== Version Control Oracle Tests: dolt_log ==="
 echo ""
 
-
 echo "--- fresh repo ---"
 
 oracle "fresh_db_has_seed_commit" "
 -- no user commits; both sides should report a single seed commit
 SELECT 1;
 "
-
 
 echo "--- linear chains ---"
 
@@ -128,13 +104,6 @@ INSERT INTO t VALUES (2, 20);
 SELECT dolt_commit('-a', '-m', 'second');
 "
 
-
-
-
-
-
-
-
 oracle "message_with_special_chars" "
 CREATE TABLE t(id INTEGER PRIMARY KEY);
 INSERT INTO t VALUES (1);
@@ -155,7 +124,6 @@ SELECT dolt_add('t');
 SELECT dolt_commit('-m', 'three');
 "
 
-
 echo "--- message edge cases ---"
 
 oracle "unicode_message" "
@@ -172,17 +140,12 @@ SELECT dolt_add('t');
 SELECT dolt_commit('-m', 'this is a deliberately very long commit message that goes on and on and on to exercise any buffer-size assumptions in the log walker or in either engine|s output format and should still come back intact');
 "
 
-
-
 oracle "internal_whitespace_preserved" "
 CREATE TABLE t(id INTEGER PRIMARY KEY);
 INSERT INTO t VALUES (1);
 SELECT dolt_add('t');
 SELECT dolt_commit('-m', 'one    two     three');
 "
-
-
-
 
 oracle "leading_trailing_whitespace_trimmed" "
 CREATE TABLE t(id INTEGER PRIMARY KEY);
@@ -191,11 +154,7 @@ SELECT dolt_add('t');
 SELECT dolt_commit('-m', '   hello world   ');
 "
 
-
 echo "--- merge commits ---"
-
-
-
 
 oracle "merge_commit_in_log" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
@@ -213,8 +172,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'main2');
 SELECT dolt_merge('feature');
 "
-
-
 
 oracle "merge_then_more_commits" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
@@ -236,10 +193,7 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'post_merge');
 "
 
-
 echo "--- tags and branches ---"
-
-
 
 oracle "tag_does_not_add_commit" "
 CREATE TABLE t(id INTEGER PRIMARY KEY);
@@ -248,8 +202,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c1');
 SELECT dolt_tag('v1');
 "
-
-
 
 oracle "log_on_feature_branch" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);

--- a/test/vc_oracle_log_test.sh
+++ b/test/vc_oracle_log_test.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
-#
-# Version-control oracle test: dolt_log
-#
-# Runs identical commit scenarios against doltlite and Dolt, then compares
-# the normalized `dolt_log` output. Catches divergence in commit ordering,
-# message handling, and commit-graph shape.
-#
-# Usage: bash vc_oracle_log_test.sh [path/to/doltlite] [path/to/dolt]
-#
+
+
+
+
+
+
+
+
+
 
 set -u
 set -o pipefail
@@ -20,9 +20,9 @@ pass=0; fail=0
 FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
-# Normalize a `hash\tmessage` stream (tab-separated, one row per line):
-#   - replace each distinct hash with H1, H2, ... in first-appearance order
-#   - strip CRLF
+
+
+
 normalize() {
   tr -d '\r' | awk -F'\t' '
     {
@@ -34,23 +34,23 @@ normalize() {
   '
 }
 
-# Run an oracle scenario. $1=name, $2=setup SQL using doltlite syntax
-# (SELECT dolt_xxx(...)). The harness rewrites it to CALL dolt_xxx(...)
-# for Dolt. Setup SQL must not depend on function return values.
+
+
+
 oracle() {
   local name="$1" setup="$2"
   local dir="$TMPROOT/$name"
   mkdir -p "$dir/dl" "$dir/dt"
 
-  # Both engines run setup + query in a SINGLE invocation so any
-  # session state (current branch, working set) from the setup is
-  # visible to the query. The query prefixes each output row with
-  # "LOG|" so we can filter out setup noise (CALL return values,
-  # hash echoes, etc.) from the combined output.
+
+
+
+
+
   local dl_q="SELECT 'LOG|' || commit_hash || char(9) || message FROM dolt_log"
   local dt_q="SELECT concat('LOG|', commit_hash, char(9), message) FROM dolt_log ORDER BY commit_order DESC"
 
-  # doltlite side
+
   local dl_out
   dl_out=$(printf "%s\n.headers off\n.mode list\n.separator '\t'\n%s;\n" "$setup" "$dl_q" \
            | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
@@ -58,7 +58,7 @@ oracle() {
            | sed 's/^LOG|//' \
            | normalize)
 
-  # Dolt side: rewrite SELECT dolt_*(...) -> CALL dolt_*(...)
+
   local dolt_setup
   dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
 
@@ -88,7 +88,7 @@ oracle() {
 echo "=== Version Control Oracle Tests: dolt_log ==="
 echo ""
 
-# ─── Category 0: fresh repository state ──────────────────────────────
+
 echo "--- fresh repo ---"
 
 oracle "fresh_db_has_seed_commit" "
@@ -96,7 +96,7 @@ oracle "fresh_db_has_seed_commit" "
 SELECT 1;
 "
 
-# ─── Category 1: linear commit chains ────────────────────────────────
+
 echo "--- linear chains ---"
 
 oracle "single_commit" "
@@ -128,12 +128,12 @@ INSERT INTO t VALUES (2, 20);
 SELECT dolt_commit('-a', '-m', 'second');
 "
 
-# Empty commit messages: Dolt rejects with a hard error
-# ("Aborting commit due to empty commit message") and aborts the
-# whole sql invocation before the query can run. doltlite accepts
-# empty messages. The behaviors diverge by design — not oracle-
-# testable in a single invocation. See
-# https://github.com/dolthub/dolt/... for Dolt's reasoning.
+
+
+
+
+
+
 
 oracle "message_with_special_chars" "
 CREATE TABLE t(id INTEGER PRIMARY KEY);
@@ -155,7 +155,7 @@ SELECT dolt_add('t');
 SELECT dolt_commit('-m', 'three');
 "
 
-# ─── Category 2: message edge cases ──────────────────────────────────
+
 echo "--- message edge cases ---"
 
 oracle "unicode_message" "
@@ -172,8 +172,8 @@ SELECT dolt_add('t');
 SELECT dolt_commit('-m', 'this is a deliberately very long commit message that goes on and on and on to exercise any buffer-size assumptions in the log walker or in either engine|s output format and should still come back intact');
 "
 
-# Internal whitespace is preserved exactly as written on both
-# engines.
+
+
 oracle "internal_whitespace_preserved" "
 CREATE TABLE t(id INTEGER PRIMARY KEY);
 INSERT INTO t VALUES (1);
@@ -181,9 +181,9 @@ SELECT dolt_add('t');
 SELECT dolt_commit('-m', 'one    two     three');
 "
 
-# Leading/trailing whitespace gets trimmed on both engines, matching
-# git's behavior. A message of '  hello  ' becomes 'hello' in both
-# engines' dolt_log.
+
+
+
 oracle "leading_trailing_whitespace_trimmed" "
 CREATE TABLE t(id INTEGER PRIMARY KEY);
 INSERT INTO t VALUES (1);
@@ -191,12 +191,12 @@ SELECT dolt_add('t');
 SELECT dolt_commit('-m', '   hello world   ');
 "
 
-# ─── Category 3: merge-commit shapes ─────────────────────────────────
+
 echo "--- merge commits ---"
 
-# Simple merge: feature branch fast-forward-able, merged as a real
-# merge commit. dolt_log should contain both the feature commit and
-# the merge commit.
+
+
+
 oracle "merge_commit_in_log" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
@@ -214,8 +214,8 @@ SELECT dolt_commit('-m', 'main2');
 SELECT dolt_merge('feature');
 "
 
-# Merge followed by more commits on main. Walker should BFS-find
-# all ancestors.
+
+
 oracle "merge_then_more_commits" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
@@ -236,11 +236,11 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'post_merge');
 "
 
-# ─── Category 4: tags / branches interactions ────────────────────────
+
 echo "--- tags and branches ---"
 
-# Tags do not create commits, so log should be unchanged before vs
-# after tagging.
+
+
 oracle "tag_does_not_add_commit" "
 CREATE TABLE t(id INTEGER PRIMARY KEY);
 INSERT INTO t VALUES (1);
@@ -249,8 +249,8 @@ SELECT dolt_commit('-m', 'c1');
 SELECT dolt_tag('v1');
 "
 
-# dolt_log after checkout to a feature branch should list the
-# feature branch's commits and share the common ancestor with main.
+
+
 oracle "log_on_feature_branch" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);

--- a/test/vc_oracle_merge_base_test.sh
+++ b/test/vc_oracle_merge_base_test.sh
@@ -1,24 +1,24 @@
 #!/bin/bash
-#
-# Version-control oracle test: dolt_merge_base
-#
-# Runs identical merge_base scenarios against doltlite and Dolt and
-# compares the resulting commit identity. Hashes don't match across
-# engines (doltlite uses prolly hashes, Dolt uses noms hashes), so
-# the oracle resolves the returned hash back to its commit message
-# via dolt_log and compares that.
-#
-# Covers: linear history (older is ancestor of newer), self, two
-# branches off a common commit, three-way branch, post-merge, tag
-# and bare-hash refs, commutativity, NULL when there's no shared
-# ancestor (forced via two independent root commits — created with
-# `dolt branch -f` reusing a name with no shared history is not
-# supported, so the no-ancestor case is exercised by checking the
-# behavior in a fresh repo against itself instead), and error paths
-# (bad ref1, bad ref2, wrong arity).
-#
-# Usage: bash vc_oracle_merge_base_test.sh [path/to/doltlite] [path/to/dolt]
-#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 set -u
 set -o pipefail
@@ -31,19 +31,19 @@ pass=0; fail=0
 FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
-# $1=name, $2=setup SQL, $3=ref1 expression, $4=ref2 expression.
-# Compares the message of the commit that merge_base returns; if
-# merge_base returns NULL the join yields no rows and we compare
-# the literal "NULL" sentinel.
+
+
+
+
 oracle() {
   local name="$1" setup="$2" ref1="$3" ref2="$4"
   local dir="$TMPROOT/$name"
   mkdir -p "$dir/dl" "$dir/dt"
 
-  # Tag the answer with an "ANS|" prefix so we can grep it out of the
-  # noise that CALL dolt_*(...) emits in dolt's csv output (each call
-  # produces hash/status rows which would otherwise mix with the answer).
-  # Use CONCAT() not || — MySQL/Dolt parses || as logical OR.
+
+
+
+
   local q="SELECT CONCAT('ANS|', coalesce((SELECT message FROM dolt_log WHERE commit_hash = dolt_merge_base($ref1, $ref2)), 'NULL'));"
 
   local dl_out
@@ -178,8 +178,8 @@ oracle "branch_from_tag_vs_main" "$WITH_TAG" "'from_tag'" "'main'"
 
 echo "--- bare commit hash ref ---"
 
-# Use a subquery to look up a hash from log so we don't have to
-# embed an unknown hash literal.
+
+
 oracle "hash_vs_branch" "$LINEAR" "(SELECT commit_hash FROM dolt_log WHERE message='c1')" "'main'"
 
 echo "--- copied and renamed branches ---"

--- a/test/vc_oracle_merge_base_test.sh
+++ b/test/vc_oracle_merge_base_test.sh
@@ -1,25 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 set -u
 set -o pipefail
 
@@ -31,18 +11,10 @@ pass=0; fail=0
 FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
-
-
-
-
 oracle() {
   local name="$1" setup="$2" ref1="$3" ref2="$4"
   local dir="$TMPROOT/$name"
   mkdir -p "$dir/dl" "$dir/dt"
-
-
-
-
 
   local q="SELECT CONCAT('ANS|', coalesce((SELECT message FROM dolt_log WHERE commit_hash = dolt_merge_base($ref1, $ref2)), 'NULL'));"
 
@@ -177,8 +149,6 @@ oracle "tag_vs_tag" "$WITH_TAG" "'v1'" "'v1'"
 oracle "branch_from_tag_vs_main" "$WITH_TAG" "'from_tag'" "'main'"
 
 echo "--- bare commit hash ref ---"
-
-
 
 oracle "hash_vs_branch" "$LINEAR" "(SELECT commit_hash FROM dolt_log WHERE message='c1')" "'main'"
 

--- a/test/vc_oracle_merge_test.sh
+++ b/test/vc_oracle_merge_test.sh
@@ -1,27 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 set -u
 set -o pipefail
 
@@ -34,15 +12,6 @@ FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
 normalize() {
-
-
-
-
-
-
-
-
-
   tr -d '\r' \
     | awk -F'\t' 'NF >= 2 { print }' \
     | sort -t$'\t' -k2 \
@@ -54,8 +23,6 @@ normalize() {
         }
       '
 }
-
-
 
 oracle() {
   local name="$1" setup="$2"
@@ -94,11 +61,6 @@ oracle() {
     echo "    dolt:"    ; echo "$dt_out" | sed 's/^/      /'
   fi
 }
-
-
-
-
-
 
 oracle_no_merge_commit() {
   local name="$1" setup="$2"
@@ -336,14 +298,6 @@ SELECT dolt_merge('feature');
 "
 
 echo "--- non-INTEGER primary key shapes ---"
-
-
-
-
-
-
-
-
 
 oracle "three_way_int_pk" "
 CREATE TABLE t(id INT PRIMARY KEY, v INT);
@@ -595,8 +549,6 @@ SELECT dolt_merge('main');
 
 echo "--- other operation pairs ---"
 
-
-
 oracle "add_modify_disjoint_rows_clean" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
@@ -615,9 +567,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feature');
 "
 
-
-
-
 oracle "add_add_same_key_same_value" "
 $SEED
 INSERT INTO t VALUES (2, 20);
@@ -631,9 +580,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feature');
 "
 
-
-
-
 oracle_no_merge_commit "add_add_same_key_different_value_conflict" "
 $SEED
 INSERT INTO t VALUES (2, 20);
@@ -646,7 +592,6 @@ SELECT dolt_commit('-m', 'feat1');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feature');
 "
-
 
 oracle "delete_delete_same_row" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
@@ -666,9 +611,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feature');
 "
 
-
-
-
 oracle_no_merge_commit "delete_modify_conflict" "
 $SEED
 DELETE FROM t WHERE id = 1;
@@ -683,9 +625,6 @@ SELECT dolt_merge('feature');
 "
 
 echo "--- multi-commit branches ---"
-
-
-
 
 oracle "multi_commit_feature_branch" "
 $SEED
@@ -708,8 +647,6 @@ SELECT dolt_merge('feature');
 
 echo "--- multi-table merges ---"
 
-
-
 oracle "multi_table_independent_inserts" "
 CREATE TABLE a(id INTEGER PRIMARY KEY, v INT);
 CREATE TABLE b(id INTEGER PRIMARY KEY, v INT);
@@ -729,8 +666,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feature');
 "
 
-
-
 oracle "multi_table_modify_one_insert_other" "
 CREATE TABLE a(id INTEGER PRIMARY KEY, v INT);
 CREATE TABLE b(id INTEGER PRIMARY KEY, v INT);
@@ -749,8 +684,6 @@ SELECT dolt_commit('-m', 'feat1');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feature');
 "
-
-
 
 oracle "three_tables_disjoint_changes" "
 CREATE TABLE a(id INTEGER PRIMARY KEY, v INT);
@@ -777,9 +710,6 @@ SELECT dolt_merge('feature');
 
 echo "--- schema deltas ---"
 
-
-
-
 oracle "feature_creates_new_table" "
 $SEED
 INSERT INTO t VALUES (2, 20);
@@ -794,10 +724,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feature');
 "
 
-
-
-
-
 oracle "feature_adds_column_main_inserts_old_shape" "
 $SEED
 INSERT INTO t VALUES (2, 20);
@@ -811,9 +737,6 @@ SELECT dolt_commit('-m', 'feat_add_col');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feature');
 "
-
-
-
 
 oracle "both_branches_add_disjoint_columns" "
 $SEED
@@ -1045,9 +968,6 @@ SELECT CONCAT('Q', CHAR(9), (SELECT COUNT(*) FROM gp), '|', (SELECT COUNT(*) FRO
 
 echo "--- non-branch merge sources ---"
 
-
-
-
 oracle "merge_from_tag" "
 $SEED
 SELECT dolt_checkout('feature');
@@ -1058,9 +978,6 @@ SELECT dolt_tag('release-1');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('release-1');
 "
-
-
-
 
 oracle "merge_from_commit_hash" "
 $SEED
@@ -1073,9 +990,6 @@ SELECT dolt_merge((SELECT commit_hash FROM dolt_log WHERE message = 'feat1'));
 "
 
 echo "--- merge sequences ---"
-
-
-
 
 oracle "merge_then_reverse_fast_forward" "
 $SEED
@@ -1091,9 +1005,6 @@ SELECT dolt_merge('feature');
 SELECT dolt_checkout('feature');
 SELECT dolt_merge('main');
 "
-
-
-
 
 oracle "merge_twice_with_intermediate_commits" "
 $SEED

--- a/test/vc_oracle_merge_test.sh
+++ b/test/vc_oracle_merge_test.sh
@@ -1,26 +1,26 @@
 #!/bin/bash
-#
-# Version-control oracle test: dolt_merge
-#
-# Runs identical merge scenarios against doltlite and Dolt and compares
-# the resulting dolt_log post-state. Covers fast-forward, three-way no
-# conflict, --no-ff (force a merge commit even when fast-forward would
-# work), -m / --message overrides, --abort, and a few error paths.
-#
-# Scenarios use a mix of primary key shapes to exercise the storage
-# layer: INTEGER PRIMARY KEY (the sqlite rowid alias), INT PRIMARY KEY
-# (auto-converted to WITHOUT ROWID by doltlite), TEXT PRIMARY KEY, and
-# composite PRIMARY KEY. All shapes should merge correctly because
-# doltlite encodes the storage key from the user PK columns rather
-# than from sqlite's auto-allocated rowid.
-#
-# Conflict scenarios are checked in two ways:
-# 1. oracle_no_merge_commit: neither engine should advance history.
-# 2. oracle_error_poststate: under autocommit, both should roll back
-#    and leave no persisted conflict state.
-#
-# Usage: bash vc_oracle_merge_test.sh [path/to/doltlite] [path/to/dolt]
-#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 set -u
 set -o pipefail
@@ -34,15 +34,15 @@ FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
 normalize() {
-  # 1. Strip CRs.
-  # 2. Drop non-tab lines (function-result text like "Already up to date"
-  #    leaks through stdout in list mode).
-  # 3. Sort by message (column 2) so the H1/H2/... assignment in step 4 is
-  #    deterministic across both engines regardless of native log walk
-  #    order. After a merge, the two engines disagree on which parent
-  #    appears first in dolt_log; sorting by message canonicalizes.
-  # 4. Replace each distinct hash with H1, H2, ... in first-appearance
-  #    order on the sorted output.
+
+
+
+
+
+
+
+
+
   tr -d '\r' \
     | awk -F'\t' 'NF >= 2 { print }' \
     | sort -t$'\t' -k2 \
@@ -55,8 +55,8 @@ normalize() {
       '
 }
 
-# Compare post-state via dolt_log: (commit_hash normalized, message),
-# in order from newest to oldest. Same shape as the log oracle.
+
+
 oracle() {
   local name="$1" setup="$2"
   local dir="$TMPROOT/$name"
@@ -95,11 +95,11 @@ oracle() {
   fi
 }
 
-# A merge that should not produce a new merge commit (because both
-# engines diverge on how they surface conflict). Compares only the
-# property that BOTH engines refuse to advance the branch tip to a
-# clean merge commit — checked by counting commits on the current
-# branch and asserting both report the same pre-merge count.
+
+
+
+
+
 oracle_no_merge_commit() {
   local name="$1" setup="$2"
   local dir="$TMPROOT/${name}_nm"
@@ -337,13 +337,13 @@ SELECT dolt_merge('feature');
 
 echo "--- non-INTEGER primary key shapes ---"
 
-# These three scenarios were the original motivation for this entire
-# work. Before the user-PK row keying fix, doltlite stored rows in INT
-# / TEXT / composite PK tables under sqlite's auto-allocated rowid,
-# which collided across branches and produced phantom modify-modify
-# conflicts on every cross-branch insert. With the storage layer now
-# encoding the prolly tree key from the user PK columns, these merge
-# cleanly the same way they do in Dolt.
+
+
+
+
+
+
+
 
 oracle "three_way_int_pk" "
 CREATE TABLE t(id INT PRIMARY KEY, v INT);
@@ -595,8 +595,8 @@ SELECT dolt_merge('main');
 
 echo "--- other operation pairs ---"
 
-# main adds row, feature modifies a different row. Different rows, so
-# no conflict — three-way merge should land both changes cleanly.
+
+
 oracle "add_modify_disjoint_rows_clean" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
@@ -615,9 +615,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feature');
 "
 
-# Both branches insert the same key with the same value. This is
-# convergent — both sides did the same thing, three-way merge should
-# treat it as no conflict.
+
+
+
 oracle "add_add_same_key_same_value" "
 $SEED
 INSERT INTO t VALUES (2, 20);
@@ -631,9 +631,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feature');
 "
 
-# Both branches insert the same key with DIFFERENT values. The PK
-# collides and the values disagree — should be a conflict, both
-# engines refuse to produce a clean merge commit.
+
+
+
 oracle_no_merge_commit "add_add_same_key_different_value_conflict" "
 $SEED
 INSERT INTO t VALUES (2, 20);
@@ -647,7 +647,7 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feature');
 "
 
-# Both branches delete the same row. Convergent delete, clean merge.
+
 oracle "delete_delete_same_row" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
@@ -666,9 +666,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feature');
 "
 
-# One side deletes a row, the other modifies it. This is a real
-# delete/modify conflict — both Dolt and doltlite should refuse to
-# produce a clean merge commit.
+
+
+
 oracle_no_merge_commit "delete_modify_conflict" "
 $SEED
 DELETE FROM t WHERE id = 1;
@@ -684,9 +684,9 @@ SELECT dolt_merge('feature');
 
 echo "--- multi-commit branches ---"
 
-# Feature branch with four commits before the merge. Exercises the
-# iterative ancestor walk and confirms the resulting merge commit's
-# parent linkage isn't off-by-one.
+
+
+
 oracle "multi_commit_feature_branch" "
 $SEED
 SELECT dolt_checkout('feature');
@@ -708,8 +708,8 @@ SELECT dolt_merge('feature');
 
 echo "--- multi-table merges ---"
 
-# Independent inserts spread across two tables. Tests that the
-# per-table merge descent doesn't drop or duplicate either side.
+
+
 oracle "multi_table_independent_inserts" "
 CREATE TABLE a(id INTEGER PRIMARY KEY, v INT);
 CREATE TABLE b(id INTEGER PRIMARY KEY, v INT);
@@ -729,8 +729,8 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feature');
 "
 
-# One branch modifies table a, the other inserts into table b. Each
-# table sees only one side change.
+
+
 oracle "multi_table_modify_one_insert_other" "
 CREATE TABLE a(id INTEGER PRIMARY KEY, v INT);
 CREATE TABLE b(id INTEGER PRIMARY KEY, v INT);
@@ -750,8 +750,8 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feature');
 "
 
-# Three tables, all touched on one side or the other. Stresses the
-# per-table descent across more breadth than two tables.
+
+
 oracle "three_tables_disjoint_changes" "
 CREATE TABLE a(id INTEGER PRIMARY KEY, v INT);
 CREATE TABLE b(id INTEGER PRIMARY KEY, v INT);
@@ -777,9 +777,9 @@ SELECT dolt_merge('feature');
 
 echo "--- schema deltas ---"
 
-# Feature branch creates a brand new table. Main concurrently inserts
-# into the pre-existing table. Merge should land the new table on
-# main alongside main's insert.
+
+
+
 oracle "feature_creates_new_table" "
 $SEED
 INSERT INTO t VALUES (2, 20);
@@ -794,10 +794,10 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feature');
 "
 
-# Feature branch adds a new column to the existing table. Main
-# concurrently inserts a row using only the original columns. Merge
-# should produce a schema with the new column and have main's row
-# using the column default.
+
+
+
+
 oracle "feature_adds_column_main_inserts_old_shape" "
 $SEED
 INSERT INTO t VALUES (2, 20);
@@ -812,9 +812,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feature');
 "
 
-# Both branches add a column. Different column names — concurrent
-# add of disjoint columns should merge cleanly with both columns
-# present in the result.
+
+
+
 oracle "both_branches_add_disjoint_columns" "
 $SEED
 ALTER TABLE t ADD COLUMN main_col INT;
@@ -1045,9 +1045,9 @@ SELECT CONCAT('Q', CHAR(9), (SELECT COUNT(*) FROM gp), '|', (SELECT COUNT(*) FRO
 
 echo "--- non-branch merge sources ---"
 
-# Merge from a tag instead of a branch. Tags were promoted to first-
-# class objects with metadata in 0557f09b8 — this verifies dolt_merge
-# accepts a tag name as the source revision.
+
+
+
 oracle "merge_from_tag" "
 $SEED
 SELECT dolt_checkout('feature');
@@ -1059,9 +1059,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('release-1');
 "
 
-# Merge from a commit hash. Both engines need to accept a hex hash
-# as the merge source. Captured via subquery against dolt_log so the
-# scenario is fully self-contained.
+
+
+
 oracle "merge_from_commit_hash" "
 $SEED
 SELECT dolt_checkout('feature');
@@ -1074,9 +1074,9 @@ SELECT dolt_merge((SELECT commit_hash FROM dolt_log WHERE message = 'feat1'));
 
 echo "--- merge sequences ---"
 
-# Merge feature into main (creates a merge commit), then merge main
-# into feature. The second merge should fast-forward feature to
-# wherever main is now, with no new commit.
+
+
+
 oracle "merge_then_reverse_fast_forward" "
 $SEED
 INSERT INTO t VALUES (10, 100);
@@ -1092,9 +1092,9 @@ SELECT dolt_checkout('feature');
 SELECT dolt_merge('main');
 "
 
-# Merge feature into main once, then add more commits to feature and
-# merge again. The second merge should produce another clean merge
-# commit (or fast-forward if main hasn't moved).
+
+
+
 oracle "merge_twice_with_intermediate_commits" "
 $SEED
 INSERT INTO t VALUES (10, 100);

--- a/test/vc_oracle_rebase_test.sh
+++ b/test/vc_oracle_rebase_test.sh
@@ -1,35 +1,35 @@
 #!/bin/bash
-#
-# Version-control oracle test: dolt_rebase
-#
-# Runs identical rebase scenarios against doltlite and Dolt. Commit
-# hashes don't match across engines (prolly vs noms) so the oracle
-# compares the sequence of commit messages via dolt_log, which on
-# linear history gives HEAD-first first-parent ordering on both
-# engines.
-#
-# dolt_rebase spec (from real Dolt 1.83.5):
-#
-#   CALL dolt_rebase(<upstream>)
-#
-#     Replays each commit that's reachable from HEAD but NOT from
-#     <upstream> on top of <upstream>, preserving original commit
-#     messages. Fails if:
-#       - the upstream ref can't be resolved
-#       - the set of commits to replay is empty
-#       - the working tree has uncommitted changes
-#       - a replayed commit would create conflicts (auto-abort in
-#         default session; staged + --continue path when
-#         @@dolt_allow_commit_conflicts is on — not supported in
-#         the initial doltlite implementation)
-#
-#   CALL dolt_rebase('--abort')
-#     Valid only while an interactive rebase is in progress. In the
-#     non-interactive default path, errors with "no rebase in
-#     progress" because non-interactive rebases are atomic.
-#
-# Usage: bash vc_oracle_rebase_test.sh [path/to/doltlite] [path/to/dolt]
-#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 set -u
 set -o pipefail
@@ -42,9 +42,9 @@ pass=0; fail=0
 FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
-# Compare commit-message ordered sequences after running setup SQL
-# on both engines. The tag "LOG|<message>" is used to cleanly
-# extract log rows from the surrounding noise CALL statements emit.
+
+
+
 oracle() {
   local name="$1" setup="$2" query="$3"
   local dir="$TMPROOT/$name"
@@ -83,7 +83,7 @@ oracle() {
   fi
 }
 
-# Error oracle: expect both engines to error on the same SQL.
+
 oracle_error() {
   local name="$1" setup="$2"
   local dir="$TMPROOT/${name}_err"
@@ -577,8 +577,8 @@ SELECT dolt_rebase('--bogus');
 
 echo "--- interactive rebase ---"
 
-# All interactive scenarios share this setup: three commits f1,f2,f3 on
-# feat atop one commit m on main that diverged after init.
+
+
 INTERACTIVE_SETUP="
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 1);
@@ -596,8 +596,8 @@ SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'm');
 SELECT dolt_checkout('feat');
 "
 
-# After -i, the working branch is dolt_rebase_feat and dolt_rebase has
-# the default pick plan. Default pick/continue should match non-interactive.
+
+
 oracle "interactive_default_plan" "
 $INTERACTIVE_SETUP
 SELECT dolt_rebase('-i', 'main');
@@ -610,7 +610,7 @@ SELECT dolt_rebase('-i', 'main');
 SELECT dolt_rebase('--continue');
 " "SELECT CONCAT('LOG|', id) FROM t ORDER BY id;"
 
-# Drop the middle commit f2 from the plan.
+
 oracle "interactive_drop_one" "
 $INTERACTIVE_SETUP
 SELECT dolt_rebase('-i', 'main');
@@ -625,7 +625,7 @@ UPDATE dolt_rebase SET action = 'drop' WHERE commit_message = 'f2';
 SELECT dolt_rebase('--continue');
 " "SELECT CONCAT('LOG|', id) FROM t ORDER BY id;"
 
-# Reorder: move f3 before f1 using a fractional rebase_order.
+
 oracle "interactive_reorder" "
 $INTERACTIVE_SETUP
 SELECT dolt_rebase('-i', 'main');
@@ -633,7 +633,7 @@ UPDATE dolt_rebase SET rebase_order = 0.5 WHERE commit_message = 'f3';
 SELECT dolt_rebase('--continue');
 " "SELECT CONCAT('LOG|', message) FROM dolt_log;"
 
-# Reword f1; message in the plan overrides the original commit message.
+
 oracle "interactive_reword" "
 $INTERACTIVE_SETUP
 SELECT dolt_rebase('-i', 'main');
@@ -641,9 +641,9 @@ UPDATE dolt_rebase SET action = 'reword', commit_message = 'f1 renamed' WHERE co
 SELECT dolt_rebase('--continue');
 " "SELECT CONCAT('LOG|', message) FROM dolt_log;"
 
-# Squash f2 into f1: expect a single combined commit with message 'f1 | f2'
-# (we replace newlines with ' | ' in the oracle so shell/csv escaping
-# doesn't diverge between engines on the literal newline characters).
+
+
+
 oracle "interactive_squash" "
 $INTERACTIVE_SETUP
 SELECT dolt_rebase('-i', 'main');
@@ -651,7 +651,7 @@ UPDATE dolt_rebase SET action = 'squash' WHERE commit_message = 'f2';
 SELECT dolt_rebase('--continue');
 " "SELECT CONCAT('LOG|', REPLACE(message, CHAR(10), ' | ')) FROM dolt_log;"
 
-# Fixup f3 into f2: combined commit keeps only f2's message.
+
 oracle "interactive_fixup" "
 $INTERACTIVE_SETUP
 SELECT dolt_rebase('-i', 'main');
@@ -659,9 +659,9 @@ UPDATE dolt_rebase SET action = 'fixup' WHERE commit_message = 'f3';
 SELECT dolt_rebase('--continue');
 " "SELECT CONCAT('LOG|', message) FROM dolt_log;"
 
-# Longer plan with mixed actions to stress replay ordering and state
-# transitions. We intentionally combine reorder, drop, squash, reword,
-# and fixup in one plan.
+
+
+
 LONG_INTERACTIVE_SETUP="
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 1);
@@ -707,7 +707,7 @@ UPDATE dolt_rebase SET action = 'fixup' WHERE commit_message = 'f3';
 SELECT dolt_rebase('--continue');
 " "SELECT CONCAT('LOG|', id) FROM t ORDER BY id;"
 
-# --abort leaves the original branch untouched and restores us to it.
+
 oracle "interactive_abort_log" "
 $INTERACTIVE_SETUP
 SELECT dolt_rebase('-i', 'main');
@@ -765,7 +765,7 @@ SELECT CONCAT('LOG|V|', v) FROM t WHERE id = 1;
 SELECT CONCAT('LOG|L|', count(*)-1) FROM dolt_log;
 "
 
-# --continue is an error when not in an interactive rebase.
+
 oracle_error "continue_without_active" "
 CREATE TABLE t(id INTEGER PRIMARY KEY);
 SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');

--- a/test/vc_oracle_rebase_test.sh
+++ b/test/vc_oracle_rebase_test.sh
@@ -1,36 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 set -u
 set -o pipefail
 
@@ -41,9 +10,6 @@ trap "rm -rf $TMPROOT" EXIT
 pass=0; fail=0
 FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
-
-
-
 
 oracle() {
   local name="$1" setup="$2" query="$3"
@@ -82,7 +48,6 @@ oracle() {
     echo "$dt_out" | sed 's/^/      /'
   fi
 }
-
 
 oracle_error() {
   local name="$1" setup="$2"
@@ -577,8 +542,6 @@ SELECT dolt_rebase('--bogus');
 
 echo "--- interactive rebase ---"
 
-
-
 INTERACTIVE_SETUP="
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 1);
@@ -596,8 +559,6 @@ SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'm');
 SELECT dolt_checkout('feat');
 "
 
-
-
 oracle "interactive_default_plan" "
 $INTERACTIVE_SETUP
 SELECT dolt_rebase('-i', 'main');
@@ -609,7 +570,6 @@ $INTERACTIVE_SETUP
 SELECT dolt_rebase('-i', 'main');
 SELECT dolt_rebase('--continue');
 " "SELECT CONCAT('LOG|', id) FROM t ORDER BY id;"
-
 
 oracle "interactive_drop_one" "
 $INTERACTIVE_SETUP
@@ -625,14 +585,12 @@ UPDATE dolt_rebase SET action = 'drop' WHERE commit_message = 'f2';
 SELECT dolt_rebase('--continue');
 " "SELECT CONCAT('LOG|', id) FROM t ORDER BY id;"
 
-
 oracle "interactive_reorder" "
 $INTERACTIVE_SETUP
 SELECT dolt_rebase('-i', 'main');
 UPDATE dolt_rebase SET rebase_order = 0.5 WHERE commit_message = 'f3';
 SELECT dolt_rebase('--continue');
 " "SELECT CONCAT('LOG|', message) FROM dolt_log;"
-
 
 oracle "interactive_reword" "
 $INTERACTIVE_SETUP
@@ -641,9 +599,6 @@ UPDATE dolt_rebase SET action = 'reword', commit_message = 'f1 renamed' WHERE co
 SELECT dolt_rebase('--continue');
 " "SELECT CONCAT('LOG|', message) FROM dolt_log;"
 
-
-
-
 oracle "interactive_squash" "
 $INTERACTIVE_SETUP
 SELECT dolt_rebase('-i', 'main');
@@ -651,16 +606,12 @@ UPDATE dolt_rebase SET action = 'squash' WHERE commit_message = 'f2';
 SELECT dolt_rebase('--continue');
 " "SELECT CONCAT('LOG|', REPLACE(message, CHAR(10), ' | ')) FROM dolt_log;"
 
-
 oracle "interactive_fixup" "
 $INTERACTIVE_SETUP
 SELECT dolt_rebase('-i', 'main');
 UPDATE dolt_rebase SET action = 'fixup' WHERE commit_message = 'f3';
 SELECT dolt_rebase('--continue');
 " "SELECT CONCAT('LOG|', message) FROM dolt_log;"
-
-
-
 
 LONG_INTERACTIVE_SETUP="
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
@@ -706,7 +657,6 @@ UPDATE dolt_rebase SET action = 'reword', commit_message = 'f5 renamed' WHERE co
 UPDATE dolt_rebase SET action = 'fixup' WHERE commit_message = 'f3';
 SELECT dolt_rebase('--continue');
 " "SELECT CONCAT('LOG|', id) FROM t ORDER BY id;"
-
 
 oracle "interactive_abort_log" "
 $INTERACTIVE_SETUP
@@ -764,7 +714,6 @@ SELECT CONCAT('LOG|C|', count(*)) FROM dolt_conflicts;
 SELECT CONCAT('LOG|V|', v) FROM t WHERE id = 1;
 SELECT CONCAT('LOG|L|', count(*)-1) FROM dolt_log;
 "
-
 
 oracle_error "continue_without_active" "
 CREATE TABLE t(id INTEGER PRIMARY KEY);

--- a/test/vc_oracle_remotes_test.sh
+++ b/test/vc_oracle_remotes_test.sh
@@ -1,20 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 set -u
 set -o pipefail
 
@@ -51,9 +36,6 @@ oracle() {
     echo "$dolt_setup" | "$DOLT" sql -c >/dev/null 2>"$dir/dt.err"
     "$DOLT" sql -r csv -q "SELECT concat(name, char(9), url, char(9), fetch_specs, char(9), params) FROM dolt_remotes ORDER BY name;" 2>>"$dir/dt.err"
   ) > "$dir/dt.raw"
-
-
-
 
   local dt_out
   dt_out=$(tail -n +2 "$dir/dt.raw" \
@@ -722,13 +704,6 @@ SELECT dolt_remote('add', 'upstream', 'file:///tmp/oracle_upstream');
 oracle "add_remote_with_non_standard_name" "
 SELECT dolt_remote('add', 'backup-1', 'file:///tmp/oracle_backup');
 "
-
-
-
-
-
-
-
 
 echo "--- remove ---"
 

--- a/test/vc_oracle_remotes_test.sh
+++ b/test/vc_oracle_remotes_test.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
-#
-# Version-control oracle test: dolt_remotes
-#
-# Runs identical remote-management scenarios against doltlite and Dolt and
-# compares the normalized dolt_remotes output. Every column's value is
-# fully determined by the user's input — name and url come directly from
-# the dolt_remote('add', ...) call, fetch_specs is derived from the name
-# using the standard refspec template, and params is always {} — so all
-# four columns are included in the comparison.
-#
-# Error scenarios are checked with oracle_error: both engines must fail
-# but the specific error text is allowed to differ.
-#
-# Usage: bash vc_oracle_remotes_test.sh [path/to/doltlite] [path/to/dolt]
-#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 set -u
 set -o pipefail
@@ -52,9 +52,9 @@ oracle() {
     "$DOLT" sql -r csv -q "SELECT concat(name, char(9), url, char(9), fetch_specs, char(9), params) FROM dolt_remotes ORDER BY name;" 2>>"$dir/dt.err"
   ) > "$dir/dt.raw"
 
-  # Dolt wraps the whole concatenated value in quotes because it contains
-  # commas in the JSON. Strip the outer quotes and un-escape internal
-  # double quotes ("" → ") before comparing.
+
+
+
   local dt_out
   dt_out=$(tail -n +2 "$dir/dt.raw" \
            | sed -E 's/^"(.*)"$/\1/' \
@@ -723,12 +723,12 @@ oracle "add_remote_with_non_standard_name" "
 SELECT dolt_remote('add', 'backup-1', 'file:///tmp/oracle_backup');
 "
 
-# Dolt rewrites http:// URLs to git+http:// on add as a scheme qualifier
-# signaling "git over HTTP". doltlite uses http:// for its own HTTP remote
-# protocol, which is not git-over-HTTP, so matching that rewrite would
-# break doltlite's actual HTTP remote behavior. file:// URLs have the
-# same meaning on both engines, so that's what the add/remove scenarios
-# exercise.
+
+
+
+
+
+
 
 echo "--- remove ---"
 

--- a/test/vc_oracle_reset_test.sh
+++ b/test/vc_oracle_reset_test.sh
@@ -1,28 +1,28 @@
 #!/bin/bash
-#
-# Version-control oracle test: dolt_reset
-#
-# Runs identical reset scenarios against doltlite and Dolt and compares
-# the resulting (dolt_log, dolt_status) post-state. dolt_reset has three
-# overlapping concerns the oracle has to verify together:
-#
-#   1. Where HEAD points after the reset (visible in dolt_log)
-#   2. The staged-tables set (visible in dolt_status with staged=1)
-#   3. The working-set tables (visible in dolt_status with staged=0)
-#
-# Comparing only one of those would miss class of bugs that change the
-# wrong surface — e.g. a soft reset that incorrectly clobbers the
-# working set, or a hard reset that fails to advance HEAD. So the
-# oracle compares the log AND the status output, concatenated, for
-# each scenario.
-#
-# Covers: --soft (default) with no ref (un-stage), --hard with no ref
-# (un-stage + drop working changes), --soft and --hard with a target
-# ref (branch / tag / commit hash), reset to current HEAD as a no-op,
-# table-name positionals (Dolt's path-based unstage), and error paths.
-#
-# Usage: bash vc_oracle_reset_test.sh [path/to/doltlite] [path/to/dolt]
-#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 set -u
 set -o pipefail
@@ -35,11 +35,11 @@ pass=0; fail=0
 FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
-# Strip CRs and drop blank lines, sort the log section by message and
-# the status section by table_name. The H1/H2/... renaming makes the
-# commit hashes deterministic across the two engines (which disagree
-# on hash content because doltlite uses prolly hashes and Dolt uses
-# noms hashes — only the SHAPE of the chain has to match).
+
+
+
+
+
 normalize_log() {
   tr -d '\r' \
     | awk -F'\t' 'NF >= 3 && $1 == "L" { print }' \
@@ -59,8 +59,8 @@ normalize_status() {
     | sort -t$'\t' -k2,2 -k3,3 -k4,4
 }
 
-# Run a scenario. $1=name, $2=setup SQL in doltlite syntax. The harness
-# rewrites SELECT dolt_*(...) -> CALL dolt_*(...) for Dolt.
+
+
 oracle() {
   local name="$1" setup="$2"
   local dir="$TMPROOT/$name"
@@ -213,9 +213,9 @@ SELECT dolt_commit('-m', 'c1');
 
 echo "--- reset with no ref (unstage) ---"
 
-# Stage some changes, then dolt_reset() with no args. Both engines
-# should leave HEAD where it is and move the staged changes back to
-# unstaged.
+
+
+
 oracle "reset_no_args_unstages_all" "
 $SEED
 INSERT INTO t VALUES (2, 20);
@@ -223,7 +223,7 @@ SELECT dolt_add('-A');
 SELECT dolt_reset();
 "
 
-# Same as above with explicit --soft. Should be identical to no-args.
+
 oracle "reset_soft_no_ref_unstages_all" "
 $SEED
 INSERT INTO t VALUES (2, 20);
@@ -231,9 +231,9 @@ SELECT dolt_add('-A');
 SELECT dolt_reset('--soft');
 "
 
-# --hard with no ref both unstages AND drops working-set changes.
-# Final state: clean working set, no staged changes, table contents
-# match HEAD.
+
+
+
 oracle "reset_hard_no_ref_clears_everything" "
 $SEED
 INSERT INTO t VALUES (2, 20);
@@ -242,13 +242,13 @@ INSERT INTO t VALUES (3, 30);
 SELECT dolt_reset('--hard');
 "
 
-# Reset on a clean tree should be a no-op.
+
 oracle "reset_no_changes_to_unstage" "
 $SEED
 SELECT dolt_reset();
 "
 
-# Reset --hard on a clean tree should also be a no-op.
+
 oracle "reset_hard_no_changes" "
 $SEED
 SELECT dolt_reset('--hard');
@@ -256,8 +256,8 @@ SELECT dolt_reset('--hard');
 
 echo "--- reset with ref (move HEAD) ---"
 
-# --soft to the previous commit: HEAD moves back, working set is
-# unchanged, the diff between c2 and c1 shows up as STAGED changes.
+
+
 oracle "reset_soft_to_previous_commit" "
 $SEED
 INSERT INTO t VALUES (2, 20);
@@ -266,8 +266,8 @@ SELECT dolt_commit('-m', 'c2');
 SELECT dolt_reset('--soft', 'HEAD~1');
 "
 
-# --hard to the previous commit: HEAD moves back, working set is
-# rewound, no staged or unstaged changes.
+
+
 oracle "reset_hard_to_previous_commit" "
 $SEED
 INSERT INTO t VALUES (2, 20);
@@ -276,9 +276,9 @@ SELECT dolt_commit('-m', 'c2');
 SELECT dolt_reset('--hard', 'HEAD~1');
 "
 
-# Reset to another branch's tip. Pulls main back to feature's tip
-# (which is identical to main's c1 because feature was branched
-# right after c1 with no further commits).
+
+
+
 oracle "reset_hard_to_branch_name" "
 $SEED
 SELECT dolt_branch('feature');
@@ -288,10 +288,10 @@ SELECT dolt_commit('-m', 'c2');
 SELECT dolt_reset('--hard', 'feature');
 "
 
-# Reset to a tag. Tags were promoted to first-class objects in
-# 0557f09b8 — verifies dolt_reset accepts a tag name as the target.
-# (This is the same surface gap that bit dolt_merge in PR #364, so
-# explicit oracle coverage matters.)
+
+
+
+
 oracle "reset_hard_to_tag" "
 $SEED
 SELECT dolt_tag('release-1');
@@ -301,8 +301,8 @@ SELECT dolt_commit('-m', 'c2');
 SELECT dolt_reset('--hard', 'release-1');
 "
 
-# Reset to a bare commit hash. Captures c1's hash via subquery so
-# the scenario is fully self-contained.
+
+
 oracle "reset_hard_to_commit_hash" "
 $SEED
 INSERT INTO t VALUES (2, 20);
@@ -311,13 +311,13 @@ SELECT dolt_commit('-m', 'c2');
 SELECT dolt_reset('--hard', (SELECT commit_hash FROM dolt_log WHERE message = 'c1'));
 "
 
-# Reset to current HEAD: HEAD doesn't move, staged/working unchanged.
+
 oracle "reset_hard_to_current_head_noop" "
 $SEED
 SELECT dolt_reset('--hard', 'HEAD');
 "
 
-# Working-set-only changes (no add) plus --hard should drop them.
+
 oracle "reset_hard_with_uncommitted_modifications" "
 $SEED
 INSERT INTO t VALUES (2, 20);
@@ -519,8 +519,8 @@ SELECT concat('Q|vals|', group_concat(s ORDER BY id SEPARATOR '|')) FROM a;"
 
 echo "--- table-name positional unstage ---"
 
-# Stage two new tables, then reset only one of them. The other
-# should remain staged.
+
+
 oracle "reset_specific_table_unstages_only_that" "
 CREATE TABLE a(id INTEGER PRIMARY KEY, v INT);
 CREATE TABLE b(id INTEGER PRIMARY KEY, v INT);

--- a/test/vc_oracle_reset_test.sh
+++ b/test/vc_oracle_reset_test.sh
@@ -1,29 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 set -u
 set -o pipefail
 
@@ -34,11 +10,6 @@ trap "rm -rf $TMPROOT" EXIT
 pass=0; fail=0
 FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
-
-
-
-
-
 
 normalize_log() {
   tr -d '\r' \
@@ -58,8 +29,6 @@ normalize_status() {
     | awk -F'\t' 'NF >= 4 && $1 == "S" { print }' \
     | sort -t$'\t' -k2,2 -k3,3 -k4,4
 }
-
-
 
 oracle() {
   local name="$1" setup="$2"
@@ -213,9 +182,6 @@ SELECT dolt_commit('-m', 'c1');
 
 echo "--- reset with no ref (unstage) ---"
 
-
-
-
 oracle "reset_no_args_unstages_all" "
 $SEED
 INSERT INTO t VALUES (2, 20);
@@ -223,16 +189,12 @@ SELECT dolt_add('-A');
 SELECT dolt_reset();
 "
 
-
 oracle "reset_soft_no_ref_unstages_all" "
 $SEED
 INSERT INTO t VALUES (2, 20);
 SELECT dolt_add('-A');
 SELECT dolt_reset('--soft');
 "
-
-
-
 
 oracle "reset_hard_no_ref_clears_everything" "
 $SEED
@@ -242,12 +204,10 @@ INSERT INTO t VALUES (3, 30);
 SELECT dolt_reset('--hard');
 "
 
-
 oracle "reset_no_changes_to_unstage" "
 $SEED
 SELECT dolt_reset();
 "
-
 
 oracle "reset_hard_no_changes" "
 $SEED
@@ -255,8 +215,6 @@ SELECT dolt_reset('--hard');
 "
 
 echo "--- reset with ref (move HEAD) ---"
-
-
 
 oracle "reset_soft_to_previous_commit" "
 $SEED
@@ -266,8 +224,6 @@ SELECT dolt_commit('-m', 'c2');
 SELECT dolt_reset('--soft', 'HEAD~1');
 "
 
-
-
 oracle "reset_hard_to_previous_commit" "
 $SEED
 INSERT INTO t VALUES (2, 20);
@@ -275,9 +231,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c2');
 SELECT dolt_reset('--hard', 'HEAD~1');
 "
-
-
-
 
 oracle "reset_hard_to_branch_name" "
 $SEED
@@ -288,10 +241,6 @@ SELECT dolt_commit('-m', 'c2');
 SELECT dolt_reset('--hard', 'feature');
 "
 
-
-
-
-
 oracle "reset_hard_to_tag" "
 $SEED
 SELECT dolt_tag('release-1');
@@ -301,8 +250,6 @@ SELECT dolt_commit('-m', 'c2');
 SELECT dolt_reset('--hard', 'release-1');
 "
 
-
-
 oracle "reset_hard_to_commit_hash" "
 $SEED
 INSERT INTO t VALUES (2, 20);
@@ -311,12 +258,10 @@ SELECT dolt_commit('-m', 'c2');
 SELECT dolt_reset('--hard', (SELECT commit_hash FROM dolt_log WHERE message = 'c1'));
 "
 
-
 oracle "reset_hard_to_current_head_noop" "
 $SEED
 SELECT dolt_reset('--hard', 'HEAD');
 "
-
 
 oracle "reset_hard_with_uncommitted_modifications" "
 $SEED
@@ -518,8 +463,6 @@ CALL dolt_reset('--hard', HASHOF('HEAD^2'));
 SELECT concat('Q|vals|', group_concat(s ORDER BY id SEPARATOR '|')) FROM a;"
 
 echo "--- table-name positional unstage ---"
-
-
 
 oracle "reset_specific_table_unstages_only_that" "
 CREATE TABLE a(id INTEGER PRIMARY KEY, v INT);

--- a/test/vc_oracle_revert_cherrypick_test.sh
+++ b/test/vc_oracle_revert_cherrypick_test.sh
@@ -1,32 +1,32 @@
 #!/bin/bash
-#
-# Version-control oracle test: dolt_revert and dolt_cherry_pick
-#
-# Runs identical revert / cherry-pick scenarios against doltlite and
-# Dolt and compares the resulting (dolt_log, table contents) post-state.
-# Both procedures take a commit-ish argument, walk the parent chain to
-# build a three-way merge, and produce a new commit on the current
-# branch — so the test surface is largely about
-#
-#   1. argument parsing (ref / branch / tag / hash / HEAD~N)
-#   2. message formatting on the new commit
-#   3. table contents after the operation completes
-#   4. error paths (initial commit, nonexistent ref, no args)
-#
-# The harness compares dolt_log AND a SELECT * from the user table,
-# concatenated. dolt_log alone wouldn't catch a divergence where the
-# same commit message is generated but the resulting catalog is
-# wrong; the table SELECT alone wouldn't catch divergences in the
-# new commit's parent linkage.
-#
-# Commit messages from cherry-pick / revert are normalized to a
-# canonical form before comparison because the two engines format
-# them differently — that's a known divergence we test for separately
-# in the message_format scenarios, but we don't want it to dominate
-# every other test.
-#
-# Usage: bash vc_oracle_revert_cherrypick_test.sh [path/to/doltlite] [path/to/dolt]
-#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 set -u
 set -o pipefail
@@ -39,22 +39,22 @@ pass=0; fail=0
 FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
-# Strip CRs, drop blank lines, sort the log section by message and
-# the table section by row contents. The H1/H2/... renaming makes
-# the commit hashes deterministic across the two engines.
-#
-# Cherry-pick / revert messages are canonicalized: anything matching
-# /^(cherry-pick|revert).*'?<orig>'?$/i becomes "OP:<orig>". This
-# isolates the commit content from the message wording so we don't
-# trip on every scenario just because Dolt writes "Revert \"x\"" and
-# doltlite writes "Revert 'x'".
+
+
+
+
+
+
+
+
+
 normalize_log() {
   tr -d '\r' \
     | awk -F'\t' 'NF >= 3 && $1 == "L" { print }' \
     | awk -F'\t' '
         {
           msg = $3
-          # Cherry-pick: canonicalize as CP:<orig> if recognizable
+
           lower = tolower(msg)
           if (match(lower, /^cherry-pick[: ]/) > 0) {
             sub(/^[Cc]herry-?[Pp]ick[: ]+/, "", msg)
@@ -84,8 +84,8 @@ normalize_table() {
     | sort
 }
 
-# Run a scenario. $1=name, $2=setup SQL in doltlite syntax. The
-# harness rewrites SELECT dolt_*(...) -> CALL dolt_*(...) for Dolt.
+
+
 oracle() {
   local name="$1" setup="$2"
   local dir="$TMPROOT/$name"
@@ -140,8 +140,8 @@ oracle() {
   fi
 }
 
-# Both engines should error in the same direction. Doesn't compare
-# the error text — just that both refuse the operation.
+
+
 oracle_error() {
   local name="$1" setup="$2"
   local dir="$TMPROOT/${name}_err"
@@ -251,7 +251,7 @@ oracle_poststate() {
 echo "=== Version Control Oracle Tests: dolt_revert / dolt_cherry_pick ==="
 echo ""
 
-# Common seed: a single-row table on main, branched off to feature.
+
 SEED="
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
@@ -262,17 +262,17 @@ SELECT dolt_branch('feature');
 
 echo "--- cherry-pick: basic ---"
 
-# Cross-branch cherry-pick has a notable trap: dolt_log on main
-# only sees main's history, so a subquery like
-#   SELECT commit_hash FROM dolt_log WHERE message = 'feat_add_2'
-# returns NOTHING when run from main and the cherry-pick silently
-# fails on both engines, producing a "passing" but meaningless test
-# (same false-positive class as merge_from_commit_hash in PR #364).
-# Every cherry-pick scenario below uses TAGS or branch~N references
-# instead, both of which resolve cross-branch in both engines.
 
-# Pick the tip of feature by branch name. The picked commit adds a
-# new row, no overlap with main.
+
+
+
+
+
+
+
+
+
+
 oracle "cherry_pick_branch_tip" "
 $SEED
 SELECT dolt_checkout('feature');
@@ -283,8 +283,8 @@ SELECT dolt_checkout('main');
 SELECT dolt_cherry_pick('feature');
 "
 
-# Cherry-pick a commit that updates a non-PK column. Reference by
-# tag (cross-branch visible in both engines).
+
+
 oracle "cherry_pick_update_non_pk" "
 $SEED
 SELECT dolt_checkout('feature');
@@ -296,8 +296,8 @@ SELECT dolt_checkout('main');
 SELECT dolt_cherry_pick('upd-source');
 "
 
-# Cherry-pick by tag — same surface gap that bit dolt_merge in
-# PR #364, so explicit oracle coverage matters.
+
+
 oracle "cherry_pick_by_tag" "
 $SEED
 SELECT dolt_checkout('feature');
@@ -309,8 +309,8 @@ SELECT dolt_checkout('main');
 SELECT dolt_cherry_pick('cherry-source');
 "
 
-# Cherry-pick by branch~N — picks the second-most-recent commit
-# on feature. Verifies the HEAD~N resolver work from #365.
+
+
 oracle "cherry_pick_by_branch_relative" "
 $SEED
 SELECT dolt_checkout('feature');
@@ -326,8 +326,8 @@ SELECT dolt_cherry_pick('feature~1');
 
 echo "--- cherry-pick: chains ---"
 
-# Pick two commits from feature in succession via branch~N. Both
-# should land on main as separate commits.
+
+
 oracle "cherry_pick_two_in_sequence" "
 $SEED
 SELECT dolt_checkout('feature');
@@ -506,8 +506,8 @@ DELETE FROM gp WHERE id = 1;
 
 echo "--- revert: basic ---"
 
-# Revert the most recent commit. Should produce a new commit that
-# undoes the change but leaves earlier history intact.
+
+
 oracle "revert_undoes_last_insert" "
 $SEED
 INSERT INTO t VALUES (2, 20);
@@ -516,7 +516,7 @@ SELECT dolt_commit('-m', 'c2_add_2');
 SELECT dolt_revert((SELECT commit_hash FROM dolt_log WHERE message = 'c2_add_2'));
 "
 
-# Revert an update — should restore the original value.
+
 oracle "revert_undoes_update" "
 $SEED
 UPDATE t SET v = 999 WHERE id = 1;
@@ -525,7 +525,7 @@ SELECT dolt_commit('-m', 'c2_update');
 SELECT dolt_revert((SELECT commit_hash FROM dolt_log WHERE message = 'c2_update'));
 "
 
-# Revert a delete — row should come back.
+
 oracle "revert_undoes_delete" "
 $SEED
 DELETE FROM t WHERE id = 1;
@@ -534,7 +534,7 @@ SELECT dolt_commit('-m', 'c2_delete');
 SELECT dolt_revert((SELECT commit_hash FROM dolt_log WHERE message = 'c2_delete'));
 "
 
-# Revert by tag. Same resolver-coverage rationale as cherry-pick.
+
 oracle "revert_by_tag" "
 $SEED
 INSERT INTO t VALUES (2, 20);
@@ -544,7 +544,7 @@ SELECT dolt_tag('to-revert');
 SELECT dolt_revert('to-revert');
 "
 
-# Revert HEAD~0 (current HEAD) — same as reverting the last commit.
+
 oracle "revert_head" "
 $SEED
 INSERT INTO t VALUES (2, 20);
@@ -553,8 +553,8 @@ SELECT dolt_commit('-m', 'c2_add_2');
 SELECT dolt_revert('HEAD');
 "
 
-# Revert HEAD~1 — should undo the second-to-last commit, leaving
-# the most recent change intact (only its base changes).
+
+
 oracle "revert_head_relative" "
 $SEED
 INSERT INTO t VALUES (2, 20);
@@ -568,8 +568,8 @@ SELECT dolt_revert('HEAD~1');
 
 echo "--- revert: chains ---"
 
-# Make three commits, revert two of them in reverse order. The
-# table should reflect only the surviving change.
+
+
 oracle "revert_two_in_reverse_order" "
 $SEED
 INSERT INTO t VALUES (2, 20);
@@ -623,21 +623,21 @@ SELECT dolt_revert('HEAD~1');
           (SELECT count(*) FROM pragma_index_list('b') WHERE name = 'idx_b_v')" \
   "SELECT CONCAT((SELECT COUNT(*) FROM information_schema.statistics WHERE table_name = 'a' AND index_name = 'idx_a_v'), '|', (SELECT COUNT(*) FROM information_schema.statistics WHERE table_name = 'b' AND index_name = 'idx_b_v'))"
 
-# Reverting a revert ("undo the undo") would be the natural test
-# here, but Dolt and doltlite format the nested commit message
-# differently in this specific case: Dolt strips inner quotes
-# (`Revert "Revert c2_add_2"`) while doltlite preserves them
-# (`Revert "Revert "c2_add_2""`). The functional outcome — table
-# state restored to the original — matches between engines, but
-# the message difference would dominate the comparison. The
-# `revert_two_in_reverse_order` scenario above already exercises
-# chained reverts on independent commits, so this case is left
-# uncovered intentionally rather than being weakened to a state-only
-# check that drifts from the rest of the harness.
+
+
+
+
+
+
+
+
+
+
+
 
 echo "--- conflicts ---"
 
-# A conflicted cherry-pick / revert should NOT advance the branch.
+
 oracle_no_merge_commit() {
   local name="$1" setup="$2"
   local dir="$TMPROOT/${name}_nm"
@@ -672,10 +672,10 @@ oracle_no_merge_commit() {
   fi
 }
 
-# Cherry-pick a commit whose change overlaps with main's most
-# recent commit on the same row. Both sides modified id=1's v to
-# different values — three-way merge produces a real conflict and
-# neither engine should produce a clean cherry-pick commit.
+
+
+
+
 oracle_no_merge_commit "cherry_pick_modify_modify_conflict" "
 $SEED
 SELECT dolt_checkout('feature');
@@ -690,10 +690,10 @@ SELECT dolt_commit('-m', 'main_11');
 SELECT dolt_cherry_pick('feat-conflict');
 "
 
-# Revert a commit when a later commit on the same branch has
-# already touched the same row. Reverting the older commit would
-# require undoing a change that was subsequently overwritten —
-# both engines should refuse to produce a clean revert commit.
+
+
+
+
 oracle_no_merge_commit "revert_with_later_overlap_conflict" "
 $SEED
 UPDATE t SET v = 50 WHERE id = 1;
@@ -705,8 +705,8 @@ SELECT dolt_commit('-m', 'c3_set_99');
 SELECT dolt_revert('HEAD~1');
 "
 
-# Under autocommit, a conflicted cherry-pick should roll back and
-# leave no persisted conflict rows behind.
+
+
 oracle_error_poststate "cherry_pick_conflict_rolls_back" "
 $SEED
 SELECT dolt_checkout('feature');
@@ -774,10 +774,10 @@ SELECT dolt_add('-A');
 SELECT dolt_cherry_pick('feature');
 "
 
-# Dolt's dolt_revert() with no args is a silent no-op rather than
-# an error (likely an undocumented quirk — there's no defined
-# semantics for "revert nothing"). doltlite matches Dolt for
-# consistency. So this is a positive oracle scenario, not an error.
+
+
+
+
 oracle "revert_no_args_is_noop" "
 $SEED
 SELECT dolt_revert();
@@ -812,8 +812,8 @@ SELECT dolt_add('-A');
 SELECT dolt_revert('HEAD');
 "
 
-# Reverting the initial commit has no parent to diff against — should
-# error in both engines.
+
+
 oracle_error "cherry_pick_initial_commit" "
 $SEED
 SELECT dolt_cherry_pick((SELECT commit_hash FROM dolt_log WHERE message = 'Initialize data repository'));

--- a/test/vc_oracle_revert_cherrypick_test.sh
+++ b/test/vc_oracle_revert_cherrypick_test.sh
@@ -1,33 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 set -u
 set -o pipefail
 
@@ -39,22 +11,12 @@ pass=0; fail=0
 FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
-
-
-
-
-
-
-
-
-
 normalize_log() {
   tr -d '\r' \
     | awk -F'\t' 'NF >= 3 && $1 == "L" { print }' \
     | awk -F'\t' '
         {
           msg = $3
-
           lower = tolower(msg)
           if (match(lower, /^cherry-pick[: ]/) > 0) {
             sub(/^[Cc]herry-?[Pp]ick[: ]+/, "", msg)
@@ -83,8 +45,6 @@ normalize_table() {
     | awk -F'\t' 'NF >= 2 && $1 == "T" { print }' \
     | sort
 }
-
-
 
 oracle() {
   local name="$1" setup="$2"
@@ -139,8 +99,6 @@ oracle() {
     echo "    dolt table:";     echo "$dt_table" | sed 's/^/      /'
   fi
 }
-
-
 
 oracle_error() {
   local name="$1" setup="$2"
@@ -251,7 +209,6 @@ oracle_poststate() {
 echo "=== Version Control Oracle Tests: dolt_revert / dolt_cherry_pick ==="
 echo ""
 
-
 SEED="
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO t VALUES (1, 10);
@@ -262,17 +219,6 @@ SELECT dolt_branch('feature');
 
 echo "--- cherry-pick: basic ---"
 
-
-
-
-
-
-
-
-
-
-
-
 oracle "cherry_pick_branch_tip" "
 $SEED
 SELECT dolt_checkout('feature');
@@ -282,8 +228,6 @@ SELECT dolt_commit('-m', 'feat_add_2');
 SELECT dolt_checkout('main');
 SELECT dolt_cherry_pick('feature');
 "
-
-
 
 oracle "cherry_pick_update_non_pk" "
 $SEED
@@ -296,8 +240,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_cherry_pick('upd-source');
 "
 
-
-
 oracle "cherry_pick_by_tag" "
 $SEED
 SELECT dolt_checkout('feature');
@@ -308,8 +250,6 @@ SELECT dolt_tag('cherry-source');
 SELECT dolt_checkout('main');
 SELECT dolt_cherry_pick('cherry-source');
 "
-
-
 
 oracle "cherry_pick_by_branch_relative" "
 $SEED
@@ -325,8 +265,6 @@ SELECT dolt_cherry_pick('feature~1');
 "
 
 echo "--- cherry-pick: chains ---"
-
-
 
 oracle "cherry_pick_two_in_sequence" "
 $SEED
@@ -506,8 +444,6 @@ DELETE FROM gp WHERE id = 1;
 
 echo "--- revert: basic ---"
 
-
-
 oracle "revert_undoes_last_insert" "
 $SEED
 INSERT INTO t VALUES (2, 20);
@@ -515,7 +451,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c2_add_2');
 SELECT dolt_revert((SELECT commit_hash FROM dolt_log WHERE message = 'c2_add_2'));
 "
-
 
 oracle "revert_undoes_update" "
 $SEED
@@ -525,7 +460,6 @@ SELECT dolt_commit('-m', 'c2_update');
 SELECT dolt_revert((SELECT commit_hash FROM dolt_log WHERE message = 'c2_update'));
 "
 
-
 oracle "revert_undoes_delete" "
 $SEED
 DELETE FROM t WHERE id = 1;
@@ -533,7 +467,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c2_delete');
 SELECT dolt_revert((SELECT commit_hash FROM dolt_log WHERE message = 'c2_delete'));
 "
-
 
 oracle "revert_by_tag" "
 $SEED
@@ -544,7 +477,6 @@ SELECT dolt_tag('to-revert');
 SELECT dolt_revert('to-revert');
 "
 
-
 oracle "revert_head" "
 $SEED
 INSERT INTO t VALUES (2, 20);
@@ -552,8 +484,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c2_add_2');
 SELECT dolt_revert('HEAD');
 "
-
-
 
 oracle "revert_head_relative" "
 $SEED
@@ -567,8 +497,6 @@ SELECT dolt_revert('HEAD~1');
 "
 
 echo "--- revert: chains ---"
-
-
 
 oracle "revert_two_in_reverse_order" "
 $SEED
@@ -623,20 +551,7 @@ SELECT dolt_revert('HEAD~1');
           (SELECT count(*) FROM pragma_index_list('b') WHERE name = 'idx_b_v')" \
   "SELECT CONCAT((SELECT COUNT(*) FROM information_schema.statistics WHERE table_name = 'a' AND index_name = 'idx_a_v'), '|', (SELECT COUNT(*) FROM information_schema.statistics WHERE table_name = 'b' AND index_name = 'idx_b_v'))"
 
-
-
-
-
-
-
-
-
-
-
-
-
 echo "--- conflicts ---"
-
 
 oracle_no_merge_commit() {
   local name="$1" setup="$2"
@@ -672,10 +587,6 @@ oracle_no_merge_commit() {
   fi
 }
 
-
-
-
-
 oracle_no_merge_commit "cherry_pick_modify_modify_conflict" "
 $SEED
 SELECT dolt_checkout('feature');
@@ -690,10 +601,6 @@ SELECT dolt_commit('-m', 'main_11');
 SELECT dolt_cherry_pick('feat-conflict');
 "
 
-
-
-
-
 oracle_no_merge_commit "revert_with_later_overlap_conflict" "
 $SEED
 UPDATE t SET v = 50 WHERE id = 1;
@@ -704,8 +611,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c3_set_99');
 SELECT dolt_revert('HEAD~1');
 "
-
-
 
 oracle_error_poststate "cherry_pick_conflict_rolls_back" "
 $SEED
@@ -774,10 +679,6 @@ SELECT dolt_add('-A');
 SELECT dolt_cherry_pick('feature');
 "
 
-
-
-
-
 oracle "revert_no_args_is_noop" "
 $SEED
 SELECT dolt_revert();
@@ -811,8 +712,6 @@ UPDATE t SET v = 99 WHERE id = 1;
 SELECT dolt_add('-A');
 SELECT dolt_revert('HEAD');
 "
-
-
 
 oracle_error "cherry_pick_initial_commit" "
 $SEED

--- a/test/vc_oracle_schema_diff_test.sh
+++ b/test/vc_oracle_schema_diff_test.sh
@@ -1,35 +1,35 @@
 #!/bin/bash
-#
-# Version-control oracle test: dolt_schema_diff
-#
-# Runs identical schema-diff scenarios against doltlite and Dolt and
-# compares the row output. Both engines now expose the same columns
-# (from_table_name, to_table_name, from_create_statement,
-# to_create_statement) and accept the same call forms
-# (`dolt_schema_diff('from','to'[,'tbl'])` and `dolt_schema_diff('from..to')`),
-# so the oracle can issue
-# the same query string against both.
-#
-# Compared surface: (from_table_name, to_table_name, from_present,
-# to_present) sorted, where {from,to}_present is Y/N for whether the
-# create-statement column is non-empty. The create-statement TEXT is
-# intentionally NOT compared row-for-row because Dolt and doltlite
-# canonicalize CREATE TABLE differently (whitespace, type aliases,
-# quoting, ENGINE=... suffix in Dolt).
-#
-# Known intentional divergences from Dolt (NOT oracle-tested here):
-#
-#   - CREATE INDEX: doltlite treats indexes as first-class schema
-#     entries (sqlite_schema has a row of type='index' for each
-#     one), so ALTER TABLE ... / CREATE INDEX adds a new row to
-#     dolt_schema_diff with the index as a separate "added" entry.
-#     Dolt rolls indexes into the table's CREATE statement and
-#     reports the table as modified instead. doltlite's behavior is
-#     the natural consequence of the sqlite_schema model and is
-#     intentional — indexes ARE schemas in SQLite.
-#
-# Usage: bash vc_oracle_schema_diff_test.sh [path/to/doltlite] [path/to/dolt]
-#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 set -u
 set -o pipefail
@@ -42,7 +42,7 @@ pass=0; fail=0
 FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
-# $1=name, $2=setup SQL, $3=from_ref, $4=to_ref, $5=optional table filter.
+
 oracle() {
   local name="$1" setup="$2" from_ref="$3" to_ref="$4" tbl="${5:-}"
   local dir="$TMPROOT/$name"
@@ -55,9 +55,9 @@ oracle() {
     args="'$from_ref','$to_ref'"
   fi
 
-  # The "ROW|" sentinel lets us grep the answer rows out of the noise
-  # that CALL dolt_*(...) emits in dolt's csv output. Use CONCAT not
-  # || (MySQL parses || as logical OR). Both engines accept CONCAT.
+
+
+
   local q="SELECT CONCAT('ROW|', from_table_name, '|', to_table_name, '|', \
             CASE WHEN from_create_statement IS NULL OR from_create_statement='' THEN 'N' ELSE 'Y' END, '|', \
             CASE WHEN to_create_statement   IS NULL OR to_create_statement=''   THEN 'N' ELSE 'Y' END \
@@ -190,10 +190,10 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'drop_t');
 " "HEAD~1" "HEAD"
 
-# Two tables exist; drop one. Issue #738 boiled down: this exact
-# shape was reported as 'unknown operation'. Now expected: one row
-# with from_table_name='t', empty to_create_statement; the surviving
-# 'u' table doesn't appear.
+
+
+
+
 oracle "drop_one_of_two_tables" "
 $SEED
 CREATE TABLE u(id INTEGER PRIMARY KEY, x TEXT);
@@ -204,7 +204,7 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'drop_t');
 " "HEAD~1" "HEAD"
 
-# Two tables dropped in a single commit.
+
 oracle "drop_multiple_in_one_commit" "
 $SEED
 CREATE TABLE u(id INTEGER PRIMARY KEY, x TEXT);
@@ -217,8 +217,8 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'drop_t_u');
 " "HEAD~1" "HEAD"
 
-# Drop a populated table — schema diff is data-agnostic, the row
-# count shouldn't affect output.
+
+
 oracle "drop_table_with_data" "
 $SEED
 INSERT INTO t VALUES (2, 20), (3, 30), (4, 40);
@@ -229,9 +229,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'drop_with_data');
 " "HEAD~1" "HEAD"
 
-# Drop using the single-arg range-syntax form 'from..to'.
-# oracle_query is needed because the standard 'oracle' helper always
-# passes at least two arguments to dolt_schema_diff(...).
+
+
+
 oracle_query "drop_via_range_syntax" "
 $SEED
 DROP TABLE t;
@@ -242,10 +242,10 @@ SELECT dolt_commit('-m', 'drop_t');
        CASE WHEN to_create_statement   IS NULL OR to_create_statement=''   THEN 'N' ELSE 'Y' END
      ) FROM dolt_schema_diff('HEAD~1..HEAD');"
 
-# Issue #738's exact shape: filter the diff by table_name. dolt-
-# replay needs this filter so it can ask 'is THIS named table
-# dropped between these two refs?' without paging through the
-# whole diff.
+
+
+
+
 oracle "drop_filter_by_table_name" "
 $SEED
 CREATE TABLE u(id INTEGER PRIMARY KEY, x TEXT);
@@ -256,8 +256,8 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'drop_t');
 " "HEAD~1" "HEAD" "t"
 
-# Drop a table the filter is asking about, BUT also keep an unrelated
-# table around. Filter should suppress the unrelated row too.
+
+
 oracle "drop_filter_excludes_other_changes" "
 $SEED
 CREATE TABLE u(id INTEGER PRIMARY KEY, x TEXT);
@@ -295,10 +295,10 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'rename_col');
 " "HEAD~1" "HEAD"
 
-# ALTER TABLE RENAME TO: both engines emit a single row with
-# from_table_name != to_table_name. doltlite's heuristic detects this
-# by matching dropped+added pairs on iTable + tree root, which works
-# for the pure-rename case (no data change in the same commit).
+
+
+
+
 oracle "modified_rename_table" "
 $SEED
 ALTER TABLE t RENAME TO t2;
@@ -334,9 +334,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'add_bare');
 " "HEAD~1" "HEAD"
 
-# Multi-step: add col, populate it, drop it in follow-up commits.
-# The commit range covering all three steps should still show the
-# table as modified (net: add extra, populate, remove extra).
+
+
+
 oracle "modified_net_addcol_dropcol_range" "
 $SEED
 ALTER TABLE t ADD COLUMN extra TEXT;
@@ -350,8 +350,8 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'drop_col_again');
 " "HEAD~3" "HEAD"
 
-# Multiple ALTER TABLE operations in a single commit should show up
-# as a single modified-table row.
+
+
 oracle "multiple_alters_single_commit" "
 $SEED
 ALTER TABLE t ADD COLUMN a TEXT;
@@ -361,9 +361,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'many_alters');
 " "HEAD~1" "HEAD"
 
-# CREATE TABLE + ALTER TABLE in the same commit should only appear
-# as an added-table row (the ALTER is rolled into the new table's
-# initial schema), not as an added + modified pair.
+
+
+
 oracle "create_then_alter_same_commit" "
 $SEED
 CREATE TABLE u(id INT PRIMARY KEY);
@@ -382,10 +382,10 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'multi');
 " "HEAD~1" "HEAD"
 
-# Issue #739 wants to enumerate "which tables changed?" without a
-# table_name filter. Cover the combinations a consumer needs to
-# handle: add+drop+modify in one commit, two modifications side-
-# by-side, rename column with a peer change.
+
+
+
+
 oracle "multi_change_add_drop_modify" "
 $SEED
 CREATE TABLE u(id INTEGER PRIMARY KEY, x INT);
@@ -399,8 +399,8 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'add_drop_modify');
 " "HEAD~1" "HEAD"
 
-# Modify two existing tables in one commit. Rename column on one,
-# add column on another. Both rows must appear in a no-filter diff.
+
+
 oracle "modify_two_tables_one_commit" "
 $SEED
 CREATE TABLE u(id INTEGER PRIMARY KEY, x INT);
@@ -412,8 +412,8 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'modify_two');
 " "HEAD~1" "HEAD"
 
-# Rename a column AND add another in the same table in the same
-# commit. Should emit a single 'modified' row for that table.
+
+
 oracle "rename_and_add_col_same_commit" "
 $SEED
 ALTER TABLE t RENAME COLUMN v TO vv;

--- a/test/vc_oracle_schema_diff_test.sh
+++ b/test/vc_oracle_schema_diff_test.sh
@@ -1,36 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 set -u
 set -o pipefail
 
@@ -41,7 +10,6 @@ trap "rm -rf $TMPROOT" EXIT
 pass=0; fail=0
 FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
-
 
 oracle() {
   local name="$1" setup="$2" from_ref="$3" to_ref="$4" tbl="${5:-}"
@@ -54,9 +22,6 @@ oracle() {
   else
     args="'$from_ref','$to_ref'"
   fi
-
-
-
 
   local q="SELECT CONCAT('ROW|', from_table_name, '|', to_table_name, '|', \
             CASE WHEN from_create_statement IS NULL OR from_create_statement='' THEN 'N' ELSE 'Y' END, '|', \
@@ -190,10 +155,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'drop_t');
 " "HEAD~1" "HEAD"
 
-
-
-
-
 oracle "drop_one_of_two_tables" "
 $SEED
 CREATE TABLE u(id INTEGER PRIMARY KEY, x TEXT);
@@ -203,7 +164,6 @@ DROP TABLE t;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'drop_t');
 " "HEAD~1" "HEAD"
-
 
 oracle "drop_multiple_in_one_commit" "
 $SEED
@@ -217,8 +177,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'drop_t_u');
 " "HEAD~1" "HEAD"
 
-
-
 oracle "drop_table_with_data" "
 $SEED
 INSERT INTO t VALUES (2, 20), (3, 30), (4, 40);
@@ -228,9 +186,6 @@ DROP TABLE t;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'drop_with_data');
 " "HEAD~1" "HEAD"
-
-
-
 
 oracle_query "drop_via_range_syntax" "
 $SEED
@@ -242,10 +197,6 @@ SELECT dolt_commit('-m', 'drop_t');
        CASE WHEN to_create_statement   IS NULL OR to_create_statement=''   THEN 'N' ELSE 'Y' END
      ) FROM dolt_schema_diff('HEAD~1..HEAD');"
 
-
-
-
-
 oracle "drop_filter_by_table_name" "
 $SEED
 CREATE TABLE u(id INTEGER PRIMARY KEY, x TEXT);
@@ -255,8 +206,6 @@ DROP TABLE t;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'drop_t');
 " "HEAD~1" "HEAD" "t"
-
-
 
 oracle "drop_filter_excludes_other_changes" "
 $SEED
@@ -295,10 +244,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'rename_col');
 " "HEAD~1" "HEAD"
 
-
-
-
-
 oracle "modified_rename_table" "
 $SEED
 ALTER TABLE t RENAME TO t2;
@@ -334,9 +279,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'add_bare');
 " "HEAD~1" "HEAD"
 
-
-
-
 oracle "modified_net_addcol_dropcol_range" "
 $SEED
 ALTER TABLE t ADD COLUMN extra TEXT;
@@ -350,8 +292,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'drop_col_again');
 " "HEAD~3" "HEAD"
 
-
-
 oracle "multiple_alters_single_commit" "
 $SEED
 ALTER TABLE t ADD COLUMN a TEXT;
@@ -360,9 +300,6 @@ ALTER TABLE t RENAME COLUMN v TO vv;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'many_alters');
 " "HEAD~1" "HEAD"
-
-
-
 
 oracle "create_then_alter_same_commit" "
 $SEED
@@ -382,10 +319,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'multi');
 " "HEAD~1" "HEAD"
 
-
-
-
-
 oracle "multi_change_add_drop_modify" "
 $SEED
 CREATE TABLE u(id INTEGER PRIMARY KEY, x INT);
@@ -399,8 +332,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'add_drop_modify');
 " "HEAD~1" "HEAD"
 
-
-
 oracle "modify_two_tables_one_commit" "
 $SEED
 CREATE TABLE u(id INTEGER PRIMARY KEY, x INT);
@@ -411,8 +342,6 @@ ALTER TABLE u ADD COLUMN y TEXT;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'modify_two');
 " "HEAD~1" "HEAD"
-
-
 
 oracle "rename_and_add_col_same_commit" "
 $SEED

--- a/test/vc_oracle_schema_merge_test.sh
+++ b/test/vc_oracle_schema_merge_test.sh
@@ -1,16 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
-
-
-
 set -u
 
 DOLTLITE="${1:-./doltlite}"
@@ -24,18 +13,15 @@ fail_name() {
   echo "  FAIL: $1"
 }
 
-
 dl() {
   local db="$1" sql="$2" tag="$3"
   "$DOLTLITE" "$db" "$sql" 2>"$TMPROOT/$tag.err"
 }
 
-
 dl_setup() {
   local db="$1" tag="$2"
   "$DOLTLITE" "$db" >"$TMPROOT/$tag.out" 2>"$TMPROOT/$tag.err"
 }
-
 
 dl_errors() {
   local db="$1" sql="$2" tag="$3"
@@ -53,7 +39,6 @@ expect_eq() {
   fi
 }
 
-
 expect_merge_ok() {
   local name="$1" db="$2"
   if dl_errors "$db" "SELECT dolt_merge('feat');" "$name"; then
@@ -64,7 +49,6 @@ expect_merge_ok() {
   fi
 }
 
-
 expect_merge_conflict() {
   local name="$1" db="$2"
   if dl_errors "$db" "SELECT dolt_merge('feat');" "$name"; then
@@ -74,7 +58,6 @@ expect_merge_conflict() {
     echo "    merge succeeded but expected conflict"
   fi
 }
-
 
 setup_base() {
   local db="$1" tag="$2" schema="$3"
@@ -89,11 +72,7 @@ SQL
 echo "=== Schema Merge Oracle (Dolt spec) ==="
 echo ""
 
-
-
-
 echo "--- Tables ---"
-
 
 DB="$TMPROOT/t1.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "t1"
@@ -109,7 +88,6 @@ SELECT dolt_commit('-Am','main_add');
 SQL
 expect_merge_ok "table_both_add_identical" "$DB"
 
-
 DB="$TMPROOT/t2.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "t2"
 CREATE TABLE anchor(id INTEGER PRIMARY KEY);
@@ -123,7 +101,6 @@ CREATE TABLE newtbl(id INTEGER PRIMARY KEY, v INT);
 SELECT dolt_commit('-Am','main_add');
 SQL
 expect_merge_conflict "table_both_add_different" "$DB"
-
 
 DB="$TMPROOT/t3.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "t3"
@@ -140,7 +117,6 @@ SELECT dolt_commit('-Am','main_drop');
 SQL
 expect_merge_ok "table_both_delete" "$DB"
 
-
 DB="$TMPROOT/t4.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "t4"
 CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -156,7 +132,6 @@ SELECT dolt_commit('-Am','main_drop');
 SQL
 expect_merge_conflict "table_modify_vs_delete" "$DB"
 
-
 DB="$TMPROOT/t5.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "t5"
 CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -171,7 +146,6 @@ UPDATE t SET v='b' WHERE id=1;
 SELECT dolt_commit('-Am','main_update');
 SQL
 expect_merge_ok "table_both_modify_identical" "$DB"
-
 
 DB="$TMPROOT/t5b.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "t5b"
@@ -189,11 +163,7 @@ expect_merge_ok "table_both_add_different_tables" "$DB"
 
 echo ""
 
-
-
-
 echo "--- Columns ---"
-
 
 DB="$TMPROOT/c1.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "c1"
@@ -210,7 +180,6 @@ SELECT dolt_commit('-Am','main_add_col');
 SQL
 expect_merge_ok "col_both_add_identical" "$DB"
 
-
 DB="$TMPROOT/c2.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "c2"
 CREATE TABLE t(id INTEGER PRIMARY KEY);
@@ -225,7 +194,6 @@ ALTER TABLE t ADD COLUMN v INTEGER;
 SELECT dolt_commit('-Am','main_add_int');
 SQL
 expect_merge_conflict "col_both_add_different_type" "$DB"
-
 
 DB="$TMPROOT/c3.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "c3"
@@ -242,7 +210,6 @@ SELECT dolt_commit('-Am','main_drop');
 SQL
 expect_merge_ok "col_both_delete" "$DB"
 
-
 DB="$TMPROOT/c4.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "c4"
 CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT, w INT);
@@ -258,7 +225,6 @@ ALTER TABLE t ADD COLUMN v TEXT NOT NULL DEFAULT 'modified';
 SELECT dolt_commit('-Am','main_modify_v');
 SQL
 expect_merge_conflict "col_modify_vs_delete" "$DB"
-
 
 DB="$TMPROOT/c5.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "c5"
@@ -279,11 +245,7 @@ expect_eq "col_one_adds_default_filled" "0" "$W"
 
 echo ""
 
-
-
-
 echo "--- Foreign Keys ---"
-
 
 DB="$TMPROOT/fk1.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "fk1"
@@ -305,7 +267,6 @@ INSERT INTO child VALUES(1,1);
 SELECT dolt_commit('-Am','main_add_fk');
 SQL
 expect_merge_ok "fk_both_add_identical" "$DB"
-
 
 DB="$TMPROOT/fk2.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "fk2"
@@ -332,11 +293,7 @@ expect_merge_conflict "fk_both_add_different" "$DB"
 
 echo ""
 
-
-
-
 echo "--- Indexes ---"
-
 
 DB="$TMPROOT/ix1.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "ix1"
@@ -353,7 +310,6 @@ SELECT dolt_commit('-Am','main_add_idx');
 SQL
 expect_merge_ok "idx_both_add_identical" "$DB"
 
-
 DB="$TMPROOT/ix2.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "ix2"
 CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT, w INT);
@@ -368,7 +324,6 @@ CREATE INDEX idx_x ON t(w);
 SELECT dolt_commit('-Am','main_add_idx_w');
 SQL
 expect_merge_conflict "idx_both_add_different" "$DB"
-
 
 DB="$TMPROOT/ix3.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "ix3"
@@ -388,11 +343,7 @@ expect_merge_ok "idx_both_delete" "$DB"
 
 echo ""
 
-
-
-
 echo "--- Check Constraints ---"
-
 
 DB="$TMPROOT/ck1.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "ck1"
@@ -413,7 +364,6 @@ SELECT dolt_commit('-Am','main_add_check');
 SQL
 expect_merge_ok "check_both_add_identical" "$DB"
 
-
 DB="$TMPROOT/ck2.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "ck2"
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
@@ -433,11 +383,7 @@ SELECT dolt_commit('-Am','main_add_check_gt5');
 SQL
 expect_merge_conflict "check_both_add_different" "$DB"
 
-
-
-
 echo "--- Tables (additional) ---"
-
 
 DB="$TMPROOT/t6.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "t6"
@@ -453,10 +399,8 @@ ALTER TABLE t ADD COLUMN x TEXT DEFAULT '';
 SELECT dolt_commit('-Am','main_add_x');
 SQL
 expect_merge_ok "table_both_add_different_columns" "$DB"
-
 COLS=$(dl "$DB" "PRAGMA table_info(t);" "t6_cols" | wc -l | tr -d ' ')
 expect_eq "table_both_add_different_columns_col_count" "4" "$COLS"
-
 
 DB="$TMPROOT/t7.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "t7"
@@ -479,11 +423,7 @@ expect_merge_conflict "table_both_modify_same_col_differently" "$DB"
 
 echo ""
 
-
-
-
 echo "--- Columns (additional) ---"
-
 
 DB="$TMPROOT/c6.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "c6"
@@ -500,7 +440,6 @@ SELECT dolt_commit('-Am','main_add_v_nullable');
 SQL
 expect_merge_conflict "col_both_add_same_type_diff_constraints" "$DB"
 
-
 DB="$TMPROOT/c7.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "c7"
 CREATE TABLE t(id INTEGER PRIMARY KEY);
@@ -515,9 +454,6 @@ ALTER TABLE t ADD COLUMN v TEXT DEFAULT 'beta';
 SELECT dolt_commit('-Am','main_add_v_beta');
 SQL
 expect_merge_conflict "col_both_add_same_type_diff_default" "$DB"
-
-
-
 
 DB="$TMPROOT/c8.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "c8"
@@ -537,7 +473,6 @@ INSERT INTO t VALUES(1,'a');
 SELECT dolt_commit('-Am','main_add_notnull');
 SQL
 expect_merge_ok "col_both_modify_identical" "$DB"
-
 
 DB="$TMPROOT/c9.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "c9"
@@ -560,11 +495,7 @@ expect_merge_conflict "col_both_modify_differently" "$DB"
 
 echo ""
 
-
-
-
 echo "--- Foreign Keys (additional) ---"
-
 
 DB="$TMPROOT/fk3.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "fk3"
@@ -587,7 +518,6 @@ SELECT dolt_commit('-Am','main_drop_fk');
 SQL
 expect_merge_ok "fk_both_delete" "$DB"
 
-
 DB="$TMPROOT/fk4.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "fk4"
 CREATE TABLE parent(id INTEGER PRIMARY KEY);
@@ -609,7 +539,6 @@ SELECT dolt_commit('-Am','main_drop_fk');
 SQL
 expect_merge_conflict "fk_modify_vs_delete" "$DB"
 
-
 DB="$TMPROOT/fk5.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "fk5"
 CREATE TABLE parent(id INTEGER PRIMARY KEY);
@@ -630,7 +559,6 @@ INSERT INTO child VALUES(1,1);
 SELECT dolt_commit('-Am','main_add_cascade');
 SQL
 expect_merge_ok "fk_both_modify_identical" "$DB"
-
 
 DB="$TMPROOT/fk6.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "fk6"
@@ -655,11 +583,7 @@ expect_merge_conflict "fk_both_modify_differently" "$DB"
 
 echo ""
 
-
-
-
 echo "--- Indexes (additional) ---"
-
 
 DB="$TMPROOT/ix4.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "ix4"
@@ -678,7 +602,6 @@ SELECT dolt_commit('-Am','main_drop_idx');
 SQL
 expect_merge_conflict "idx_modify_vs_delete" "$DB"
 
-
 DB="$TMPROOT/ix5.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "ix5"
 CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT, w INT);
@@ -696,7 +619,6 @@ CREATE INDEX idx_v ON t(v, w);
 SELECT dolt_commit('-Am','main_expand_idx');
 SQL
 expect_merge_ok "idx_both_modify_identical" "$DB"
-
 
 DB="$TMPROOT/ix6.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "ix6"
@@ -718,11 +640,7 @@ expect_merge_conflict "idx_both_modify_differently" "$DB"
 
 echo ""
 
-
-
-
 echo "--- Check Constraints (additional) ---"
-
 
 DB="$TMPROOT/ck3.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "ck3"
@@ -743,7 +661,6 @@ SELECT dolt_commit('-Am','main_drop_check');
 SQL
 expect_merge_ok "check_both_delete" "$DB"
 
-
 DB="$TMPROOT/ck4.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "ck4"
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT CHECK(v > 0));
@@ -763,7 +680,6 @@ SELECT dolt_commit('-Am','main_drop_check');
 SQL
 expect_merge_conflict "check_modify_vs_delete" "$DB"
 
-
 DB="$TMPROOT/ck5.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "ck5"
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT CHECK(v > 0));
@@ -782,7 +698,6 @@ INSERT INTO t VALUES(1,10);
 SELECT dolt_commit('-Am','main_tighten');
 SQL
 expect_merge_ok "check_both_modify_identical" "$DB"
-
 
 DB="$TMPROOT/ck6.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "ck6"

--- a/test/vc_oracle_schema_merge_test.sh
+++ b/test/vc_oracle_schema_merge_test.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
-#
-# Schema merge oracle — test every scenario from the Dolt spec:
-# https://docs.dolthub.com/concepts/dolt/git/conflicts#schema
-#
-# Categories: Tables, Columns, Foreign Keys, Indexes, Check Constraints.
-# Each case has two branches that diverge from a common ancestor and
-# merge. The test checks whether the merge auto-resolves, produces
-# a schema conflict error, or produces a data conflict.
-#
-# Usage: bash vc_oracle_schema_merge_test.sh [path/to/doltlite]
-#
+
+
+
+
+
+
+
+
+
+
+
 
 set -u
 
@@ -24,19 +24,19 @@ fail_name() {
   echo "  FAIL: $1"
 }
 
-# Run SQL against a db, capture stdout+stderr
+
 dl() {
   local db="$1" sql="$2" tag="$3"
   "$DOLTLITE" "$db" "$sql" 2>"$TMPROOT/$tag.err"
 }
 
-# Bulk setup via stdin
+
 dl_setup() {
   local db="$1" tag="$2"
   "$DOLTLITE" "$db" >"$TMPROOT/$tag.out" 2>"$TMPROOT/$tag.err"
 }
 
-# Returns 0 (true) if the command produced an error
+
 dl_errors() {
   local db="$1" sql="$2" tag="$3"
   "$DOLTLITE" "$db" "$sql" >"$TMPROOT/$tag.out" 2>"$TMPROOT/$tag.err"
@@ -53,7 +53,7 @@ expect_eq() {
   fi
 }
 
-# Expect merge succeeds (no error)
+
 expect_merge_ok() {
   local name="$1" db="$2"
   if dl_errors "$db" "SELECT dolt_merge('feat');" "$name"; then
@@ -64,7 +64,7 @@ expect_merge_ok() {
   fi
 }
 
-# Expect merge fails with schema conflict
+
 expect_merge_conflict() {
   local name="$1" db="$2"
   if dl_errors "$db" "SELECT dolt_merge('feat');" "$name"; then
@@ -75,7 +75,7 @@ expect_merge_conflict() {
   fi
 }
 
-# Helper: create a fresh db with a base table, commit, branch 'feat'
+
 setup_base() {
   local db="$1" tag="$2" schema="$3"
   rm -f "$db"
@@ -89,12 +89,12 @@ SQL
 echo "=== Schema Merge Oracle (Dolt spec) ==="
 echo ""
 
-# ════════════════════════════════════════════════════
-# TABLES
-# ════════════════════════════════════════════════════
+
+
+
 echo "--- Tables ---"
 
-# T1: Both add same table with identical schema → auto-resolve
+
 DB="$TMPROOT/t1.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "t1"
 CREATE TABLE anchor(id INTEGER PRIMARY KEY);
@@ -109,7 +109,7 @@ SELECT dolt_commit('-Am','main_add');
 SQL
 expect_merge_ok "table_both_add_identical" "$DB"
 
-# T2: Both add same table with different schema → conflict
+
 DB="$TMPROOT/t2.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "t2"
 CREATE TABLE anchor(id INTEGER PRIMARY KEY);
@@ -124,7 +124,7 @@ SELECT dolt_commit('-Am','main_add');
 SQL
 expect_merge_conflict "table_both_add_different" "$DB"
 
-# T3: Both delete same table → auto-resolve
+
 DB="$TMPROOT/t3.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "t3"
 CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -140,7 +140,7 @@ SELECT dolt_commit('-Am','main_drop');
 SQL
 expect_merge_ok "table_both_delete" "$DB"
 
-# T4: One modifies, one deletes → conflict
+
 DB="$TMPROOT/t4.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "t4"
 CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -156,7 +156,7 @@ SELECT dolt_commit('-Am','main_drop');
 SQL
 expect_merge_conflict "table_modify_vs_delete" "$DB"
 
-# T5: Both modify same table, identical result → auto-resolve
+
 DB="$TMPROOT/t5.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "t5"
 CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -172,7 +172,7 @@ SELECT dolt_commit('-Am','main_update');
 SQL
 expect_merge_ok "table_both_modify_identical" "$DB"
 
-# T5b: Each branch adds a different new table → auto-resolve
+
 DB="$TMPROOT/t5b.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "t5b"
 CREATE TABLE anchor(id INTEGER PRIMARY KEY);
@@ -189,12 +189,12 @@ expect_merge_ok "table_both_add_different_tables" "$DB"
 
 echo ""
 
-# ════════════════════════════════════════════════════
-# COLUMNS
-# ════════════════════════════════════════════════════
+
+
+
 echo "--- Columns ---"
 
-# C1: Both add column with same definition → auto-resolve
+
 DB="$TMPROOT/c1.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "c1"
 CREATE TABLE t(id INTEGER PRIMARY KEY);
@@ -210,7 +210,7 @@ SELECT dolt_commit('-Am','main_add_col');
 SQL
 expect_merge_ok "col_both_add_identical" "$DB"
 
-# C2: Both add column with different type → conflict
+
 DB="$TMPROOT/c2.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "c2"
 CREATE TABLE t(id INTEGER PRIMARY KEY);
@@ -226,7 +226,7 @@ SELECT dolt_commit('-Am','main_add_int');
 SQL
 expect_merge_conflict "col_both_add_different_type" "$DB"
 
-# C3: Both delete same column → auto-resolve
+
 DB="$TMPROOT/c3.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "c3"
 CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -242,7 +242,7 @@ SELECT dolt_commit('-Am','main_drop');
 SQL
 expect_merge_ok "col_both_delete" "$DB"
 
-# C4: One modifies, one deletes column → conflict
+
 DB="$TMPROOT/c4.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "c4"
 CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT, w INT);
@@ -259,7 +259,7 @@ SELECT dolt_commit('-Am','main_modify_v');
 SQL
 expect_merge_conflict "col_modify_vs_delete" "$DB"
 
-# C5: One side adds a column, other doesn't touch → auto-resolve
+
 DB="$TMPROOT/c5.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "c5"
 CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -279,12 +279,12 @@ expect_eq "col_one_adds_default_filled" "0" "$W"
 
 echo ""
 
-# ════════════════════════════════════════════════════
-# FOREIGN KEYS
-# ════════════════════════════════════════════════════
+
+
+
 echo "--- Foreign Keys ---"
 
-# FK1: Both add same FK with identical definition → auto-resolve
+
 DB="$TMPROOT/fk1.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "fk1"
 CREATE TABLE parent(id INTEGER PRIMARY KEY);
@@ -306,7 +306,7 @@ SELECT dolt_commit('-Am','main_add_fk');
 SQL
 expect_merge_ok "fk_both_add_identical" "$DB"
 
-# FK2: Both add FK with different definition → conflict
+
 DB="$TMPROOT/fk2.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "fk2"
 CREATE TABLE parent(id INTEGER PRIMARY KEY);
@@ -332,12 +332,12 @@ expect_merge_conflict "fk_both_add_different" "$DB"
 
 echo ""
 
-# ════════════════════════════════════════════════════
-# INDEXES
-# ════════════════════════════════════════════════════
+
+
+
 echo "--- Indexes ---"
 
-# IX1: Both add same index → auto-resolve
+
 DB="$TMPROOT/ix1.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "ix1"
 CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -353,7 +353,7 @@ SELECT dolt_commit('-Am','main_add_idx');
 SQL
 expect_merge_ok "idx_both_add_identical" "$DB"
 
-# IX2: Both add index with different definitions → conflict
+
 DB="$TMPROOT/ix2.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "ix2"
 CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT, w INT);
@@ -369,7 +369,7 @@ SELECT dolt_commit('-Am','main_add_idx_w');
 SQL
 expect_merge_conflict "idx_both_add_different" "$DB"
 
-# IX3: Both delete same index → auto-resolve
+
 DB="$TMPROOT/ix3.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "ix3"
 CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -388,12 +388,12 @@ expect_merge_ok "idx_both_delete" "$DB"
 
 echo ""
 
-# ════════════════════════════════════════════════════
-# CHECK CONSTRAINTS
-# ════════════════════════════════════════════════════
+
+
+
 echo "--- Check Constraints ---"
 
-# CK1: Both add same CHECK → auto-resolve
+
 DB="$TMPROOT/ck1.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "ck1"
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
@@ -413,7 +413,7 @@ SELECT dolt_commit('-Am','main_add_check');
 SQL
 expect_merge_ok "check_both_add_identical" "$DB"
 
-# CK2: Both add different CHECK → conflict
+
 DB="$TMPROOT/ck2.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "ck2"
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
@@ -433,12 +433,12 @@ SELECT dolt_commit('-Am','main_add_check_gt5');
 SQL
 expect_merge_conflict "check_both_add_different" "$DB"
 
-# ════════════════════════════════════════════════════
-# TABLES (additional)
-# ════════════════════════════════════════════════════
+
+
+
 echo "--- Tables (additional) ---"
 
-# T6: Both add different columns to same table → auto-resolve (different names merge cleanly)
+
 DB="$TMPROOT/t6.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "t6"
 CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -453,11 +453,11 @@ ALTER TABLE t ADD COLUMN x TEXT DEFAULT '';
 SELECT dolt_commit('-Am','main_add_x');
 SQL
 expect_merge_ok "table_both_add_different_columns" "$DB"
-# Verify both columns are present after merge
+
 COLS=$(dl "$DB" "PRAGMA table_info(t);" "t6_cols" | wc -l | tr -d ' ')
 expect_eq "table_both_add_different_columns_col_count" "4" "$COLS"
 
-# T7: Both modify same column differently → conflict
+
 DB="$TMPROOT/t7.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "t7"
 CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -479,12 +479,12 @@ expect_merge_conflict "table_both_modify_same_col_differently" "$DB"
 
 echo ""
 
-# ════════════════════════════════════════════════════
-# COLUMNS (additional)
-# ════════════════════════════════════════════════════
+
+
+
 echo "--- Columns (additional) ---"
 
-# C6: Both add column, same type, different constraints → conflict
+
 DB="$TMPROOT/c6.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "c6"
 CREATE TABLE t(id INTEGER PRIMARY KEY);
@@ -500,7 +500,7 @@ SELECT dolt_commit('-Am','main_add_v_nullable');
 SQL
 expect_merge_conflict "col_both_add_same_type_diff_constraints" "$DB"
 
-# C7: Both add column, same type+constraints, different default data → conflict
+
 DB="$TMPROOT/c7.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "c7"
 CREATE TABLE t(id INTEGER PRIMARY KEY);
@@ -516,9 +516,9 @@ SELECT dolt_commit('-Am','main_add_v_beta');
 SQL
 expect_merge_conflict "col_both_add_same_type_diff_default" "$DB"
 
-# C8: Both modify column identically → auto-resolve
-# (SQLite ALTER TABLE doesn't support ALTER COLUMN, so we simulate via
-# DROP TABLE + recreate with modified column. Both sides do the same change.)
+
+
+
 DB="$TMPROOT/c8.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "c8"
 CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -538,7 +538,7 @@ SELECT dolt_commit('-Am','main_add_notnull');
 SQL
 expect_merge_ok "col_both_modify_identical" "$DB"
 
-# C9: Both modify column differently → conflict
+
 DB="$TMPROOT/c9.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "c9"
 CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
@@ -560,12 +560,12 @@ expect_merge_conflict "col_both_modify_differently" "$DB"
 
 echo ""
 
-# ════════════════════════════════════════════════════
-# FOREIGN KEYS (additional)
-# ════════════════════════════════════════════════════
+
+
+
 echo "--- Foreign Keys (additional) ---"
 
-# FK3: Both delete same FK → auto-resolve
+
 DB="$TMPROOT/fk3.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "fk3"
 CREATE TABLE parent(id INTEGER PRIMARY KEY);
@@ -587,7 +587,7 @@ SELECT dolt_commit('-Am','main_drop_fk');
 SQL
 expect_merge_ok "fk_both_delete" "$DB"
 
-# FK4: One modifies FK, other deletes → conflict
+
 DB="$TMPROOT/fk4.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "fk4"
 CREATE TABLE parent(id INTEGER PRIMARY KEY);
@@ -609,7 +609,7 @@ SELECT dolt_commit('-Am','main_drop_fk');
 SQL
 expect_merge_conflict "fk_modify_vs_delete" "$DB"
 
-# FK5: Both modify FK identically → auto-resolve
+
 DB="$TMPROOT/fk5.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "fk5"
 CREATE TABLE parent(id INTEGER PRIMARY KEY);
@@ -631,7 +631,7 @@ SELECT dolt_commit('-Am','main_add_cascade');
 SQL
 expect_merge_ok "fk_both_modify_identical" "$DB"
 
-# FK6: Both modify FK differently → conflict
+
 DB="$TMPROOT/fk6.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "fk6"
 CREATE TABLE parent(id INTEGER PRIMARY KEY);
@@ -655,12 +655,12 @@ expect_merge_conflict "fk_both_modify_differently" "$DB"
 
 echo ""
 
-# ════════════════════════════════════════════════════
-# INDEXES (additional)
-# ════════════════════════════════════════════════════
+
+
+
 echo "--- Indexes (additional) ---"
 
-# IX4: One modifies index, other deletes → conflict
+
 DB="$TMPROOT/ix4.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "ix4"
 CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT, w INT);
@@ -678,7 +678,7 @@ SELECT dolt_commit('-Am','main_drop_idx');
 SQL
 expect_merge_conflict "idx_modify_vs_delete" "$DB"
 
-# IX5: Both modify index identically → auto-resolve
+
 DB="$TMPROOT/ix5.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "ix5"
 CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT, w INT);
@@ -697,7 +697,7 @@ SELECT dolt_commit('-Am','main_expand_idx');
 SQL
 expect_merge_ok "idx_both_modify_identical" "$DB"
 
-# IX6: Both modify index differently → conflict
+
 DB="$TMPROOT/ix6.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "ix6"
 CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT, w INT);
@@ -718,12 +718,12 @@ expect_merge_conflict "idx_both_modify_differently" "$DB"
 
 echo ""
 
-# ════════════════════════════════════════════════════
-# CHECK CONSTRAINTS (additional)
-# ════════════════════════════════════════════════════
+
+
+
 echo "--- Check Constraints (additional) ---"
 
-# CK3: Both delete same CHECK → auto-resolve
+
 DB="$TMPROOT/ck3.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "ck3"
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT CHECK(v > 0));
@@ -743,7 +743,7 @@ SELECT dolt_commit('-Am','main_drop_check');
 SQL
 expect_merge_ok "check_both_delete" "$DB"
 
-# CK4: One modifies CHECK, other deletes → conflict
+
 DB="$TMPROOT/ck4.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "ck4"
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT CHECK(v > 0));
@@ -763,7 +763,7 @@ SELECT dolt_commit('-Am','main_drop_check');
 SQL
 expect_merge_conflict "check_modify_vs_delete" "$DB"
 
-# CK5: Both modify CHECK identically → auto-resolve
+
 DB="$TMPROOT/ck5.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "ck5"
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT CHECK(v > 0));
@@ -783,7 +783,7 @@ SELECT dolt_commit('-Am','main_tighten');
 SQL
 expect_merge_ok "check_both_modify_identical" "$DB"
 
-# CK6: Both modify CHECK differently → conflict
+
 DB="$TMPROOT/ck6.db"; rm -f "$DB"
 cat <<'SQL' | dl_setup "$DB" "ck6"
 CREATE TABLE t(id INTEGER PRIMARY KEY, v INT CHECK(v > 0));

--- a/test/vc_oracle_schemas_test.sh
+++ b/test/vc_oracle_schemas_test.sh
@@ -1,41 +1,41 @@
 #!/bin/bash
-#
-# Version-control oracle test: dolt_schemas vtable + dolt_diff view
-# visibility.
-#
-# doltlite's dolt_schemas is a projection over sqlite_schema filtered
-# to type IN ('view','trigger'). Since sqlite_schema is already in the
-# branch-scoped catalog, views are version-controlled per branch for
-# free: committed views appear in the commit they were created,
-# uncommitted views show up as a WORKING dolt_schemas entry in
-# dolt_diff, and branch switches surface the right view set.
-#
-# This oracle compares against Dolt 1.86.0+ on:
-#
-#   1. SELECT type, name, fragment FROM dolt_schemas ORDER BY type, name
-#      — the live view set on the current branch. `extra` and
-#      `sql_mode` are NOT compared (doltlite emits NULL for both;
-#      Dolt uses them for MySQL-specific metadata).
-#
-#   2. SELECT table_name FROM dolt_diff — which commits touch
-#      dolt_schemas. Compared on (message, table_name, data_change,
-#      schema_change) via a LEFT JOIN with dolt_log so engine-
-#      specific commit hashes don't matter. Both engines now emit
-#      schema_change=1 on the FIRST view/trigger creation (the
-#      implicit creation of dolt_schemas) and schema_change=0 on
-#      subsequent view/trigger commits.
-#
-# Triggers: covered via dual-SQL helpers (oracle_schemas_dual /
-# oracle_diff_touches_schemas_dual) that accept separate setup
-# blocks per engine, since CREATE TRIGGER bodies diverge between
-# Dolt's MySQL-ish dialect (single-statement FOR EACH ROW) and
-# doltlite's SQLite dialect (BEGIN ... END;). The dual comparisons
-# project only (type, name) — not `fragment` — because each engine
-# stores its own dialect verbatim and the fragment text legitimately
-# differs. Schema-row identity is what matters for VC semantics.
-#
-# Usage: bash vc_oracle_schemas_test.sh [path/to/doltlite] [path/to/dolt]
-#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 set -u
 set -o pipefail
@@ -52,9 +52,9 @@ normalize() {
   tr -d '\r' | sort
 }
 
-# Oracle for dolt_schemas table contents after a setup script.
-# Runs identical SQL on both engines, projects type|name|fragment
-# rows, sorts, compares.
+
+
+
 oracle_schemas() {
   local name="$1" setup="$2"
   local dir="$TMPROOT/${name}_schemas"
@@ -94,11 +94,11 @@ oracle_schemas() {
   fi
 }
 
-# Oracle for which commits touch dolt_schemas in dolt_diff, joined
-# against dolt_log on commit_hash so we compare by commit MESSAGE
-# (stable across engines). IMPORTANT: doltlite's dolt_diff is
-# summary-only, so we query it directly and grep dolt_schemas rows out
-# in shell instead of relying on row-history surfaces.
+
+
+
+
+
 oracle_diff_touches_schemas() {
   local name="$1" setup="$2"
   local dir="$TMPROOT/${name}_diff"
@@ -141,14 +141,14 @@ oracle_diff_touches_schemas() {
   fi
 }
 
-# Dual-setup variant of oracle_schemas: each engine runs its own
-# setup SQL so trigger DDL can be written in the engine's native
-# dialect. The projection is (type, name) only — fragment is
-# intentionally omitted because each engine stores the CREATE
-# TRIGGER body verbatim in its own dialect and those byte-strings
-# legitimately differ. Schema-row identity is what matters for VC
-# semantics: does the trigger appear in dolt_schemas, with the
-# right name, on the right commit / branch.
+
+
+
+
+
+
+
+
 oracle_schemas_dual() {
   local name="$1" dl_setup="$2" dt_setup="$3"
   local dir="$TMPROOT/${name}_schemas_dual"
@@ -188,10 +188,10 @@ oracle_schemas_dual() {
   fi
 }
 
-# Dual-setup variant of oracle_diff_touches_schemas: same per-engine
-# setup model. Compared surface is identical — (table_name, message,
-# data_change, schema_change) — since that projection doesn't depend
-# on trigger body text.
+
+
+
+
 oracle_diff_touches_schemas_dual() {
   local name="$1" dl_setup="$2" dt_setup="$3"
   local dir="$TMPROOT/${name}_diff_dual"
@@ -281,8 +281,8 @@ CREATE VIEW pending AS SELECT * FROM t;
 
 echo "--- dolt_diff visibility of view-touching commits ---"
 
-# Adding a view in its own commit: dolt_diff should show dolt_schemas
-# touched and NOT show the underlying table 't' touched.
+
+
 oracle_diff_touches_schemas "view_only_commit" "
 $SEED
 CREATE VIEW high AS SELECT * FROM t WHERE v > 15;
@@ -290,14 +290,14 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'just_view');
 "
 
-# CREATE TABLE does NOT touch dolt_schemas in either engine.
+
 oracle_diff_touches_schemas "table_only_no_schemas_touch" "
 CREATE TABLE t(id INT PRIMARY KEY);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'just_table');
 "
 
-# Multiple commits, some touching views, some not.
+
 oracle_diff_touches_schemas "mixed_commits" "
 $SEED
 CREATE VIEW v1 AS SELECT * FROM t;
@@ -312,8 +312,8 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'view_commit_2');
 "
 
-# Combined commit: both a table change and a view change in one
-# commit. dolt_diff should surface both as separate rows.
+
+
 oracle_diff_touches_schemas "combined_table_and_view" "
 $SEED
 INSERT INTO t VALUES(3, 30);
@@ -322,19 +322,19 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'combined');
 "
 
-# ─── Triggers ────────────────────────────────────────────────────────
-#
-# Both engines expose triggers in dolt_schemas as (type='trigger',
-# name=<trigger name>). The CREATE TRIGGER body text legitimately
-# differs by dialect, so we compare on (type, name) only via
-# oracle_schemas_dual. Dolt's `dolt sql` stdin parser has trouble
-# with multi-statement trigger bodies wrapped in BEGIN/END, so
-# every trigger body in these scenarios is a SINGLE statement —
-# either "FOR EACH ROW <stmt>" on the Dolt side or
-# "BEGIN <stmt>; END" on the doltlite side.
-#
-# SEED_TRIG extends $SEED with a log table so trigger bodies have
-# somewhere to write. Same on both engines.
+
+
+
+
+
+
+
+
+
+
+
+
+
 SEED_TRIG="
 $SEED
 CREATE TABLE log(id INT, v INT);
@@ -396,7 +396,7 @@ $SEED_TRIG
 CREATE TRIGGER t_ai AFTER INSERT ON t FOR EACH ROW INSERT INTO log VALUES(new.id, new.v);
 "
 
-# Mixed: a trigger and a view together in dolt_schemas.
+
 oracle_schemas_dual "trigger_and_view" "
 $SEED_TRIG
 CREATE VIEW high AS SELECT * FROM t WHERE v > 15;
@@ -411,9 +411,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'add_view_and_trigger');
 "
 
-# Branch isolation: trigger created on a feature branch must not
-# appear in dolt_schemas on main after checkout. This is the core
-# version-control property of sqlite_schema being branch-scoped.
+
+
+
 oracle_schemas_dual "trigger_on_feature_branch_only" "
 $SEED_TRIG
 SELECT dolt_branch('feat');
@@ -432,11 +432,11 @@ SELECT dolt_commit('-m', 'add_trigger_on_feat');
 SELECT dolt_checkout('main');
 "
 
-# Modify trigger (DROP + CREATE same name) inside a single commit.
-# The dolt_schemas projection is (type, name), so the end state is
-# identical to one_trigger — but the path through it exercises an
-# intra-commit delete-then-add on a schema row, which is a distinct
-# code path in the catalog diff machinery.
+
+
+
+
+
 oracle_schemas_dual "modify_trigger_single_commit" "
 $SEED_TRIG
 CREATE TRIGGER t_ai AFTER INSERT ON t BEGIN INSERT INTO log VALUES(1, new.v); END;
@@ -459,8 +459,8 @@ SELECT dolt_commit('-m', 'replaced_trigger');
 
 echo "--- dolt_diff visibility of trigger-touching commits ---"
 
-# Adding a trigger in its own commit: dolt_diff should show
-# dolt_schemas touched and NOT show the underlying table 't'.
+
+
 oracle_diff_touches_schemas_dual "trigger_only_commit" "
 $SEED_TRIG
 CREATE TRIGGER t_ai AFTER INSERT ON t BEGIN INSERT INTO log VALUES(new.id, new.v); END;
@@ -473,7 +473,7 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'just_trigger');
 "
 
-# Multiple commits, some touching triggers, some not.
+
 oracle_diff_touches_schemas_dual "mixed_trigger_commits" "
 $SEED_TRIG
 CREATE TRIGGER t1 AFTER INSERT ON t BEGIN INSERT INTO log VALUES(new.id, new.v); END;
@@ -500,10 +500,10 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'trigger_commit_2');
 "
 
-# Combined commit: both a table data change and a trigger schema
-# change in one commit. Mirrors the existing combined_table_and_view
-# scenario from the view section. dolt_diff should surface the
-# dolt_schemas row on the same commit as the table mutation.
+
+
+
+
 oracle_diff_touches_schemas_dual "combined_table_and_trigger" "
 $SEED_TRIG
 INSERT INTO t VALUES(3, 30);

--- a/test/vc_oracle_schemas_test.sh
+++ b/test/vc_oracle_schemas_test.sh
@@ -1,42 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 set -u
 set -o pipefail
 
@@ -51,9 +14,6 @@ source "$(dirname "$0")/lib/vc_oracle_common.sh"
 normalize() {
   tr -d '\r' | sort
 }
-
-
-
 
 oracle_schemas() {
   local name="$1" setup="$2"
@@ -93,11 +53,6 @@ oracle_schemas() {
     echo "    dolt:";     echo "$dt_out" | sed 's/^/      /'
   fi
 }
-
-
-
-
-
 
 oracle_diff_touches_schemas() {
   local name="$1" setup="$2"
@@ -141,14 +96,6 @@ oracle_diff_touches_schemas() {
   fi
 }
 
-
-
-
-
-
-
-
-
 oracle_schemas_dual() {
   local name="$1" dl_setup="$2" dt_setup="$3"
   local dir="$TMPROOT/${name}_schemas_dual"
@@ -187,10 +134,6 @@ oracle_schemas_dual() {
     echo "    dolt:";     echo "$dt_out" | sed 's/^/      /'
   fi
 }
-
-
-
-
 
 oracle_diff_touches_schemas_dual() {
   local name="$1" dl_setup="$2" dt_setup="$3"
@@ -281,8 +224,6 @@ CREATE VIEW pending AS SELECT * FROM t;
 
 echo "--- dolt_diff visibility of view-touching commits ---"
 
-
-
 oracle_diff_touches_schemas "view_only_commit" "
 $SEED
 CREATE VIEW high AS SELECT * FROM t WHERE v > 15;
@@ -290,13 +231,11 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'just_view');
 "
 
-
 oracle_diff_touches_schemas "table_only_no_schemas_touch" "
 CREATE TABLE t(id INT PRIMARY KEY);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'just_table');
 "
-
 
 oracle_diff_touches_schemas "mixed_commits" "
 $SEED
@@ -312,8 +251,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'view_commit_2');
 "
 
-
-
 oracle_diff_touches_schemas "combined_table_and_view" "
 $SEED
 INSERT INTO t VALUES(3, 30);
@@ -321,19 +258,6 @@ CREATE VIEW high AS SELECT * FROM t WHERE v > 15;
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'combined');
 "
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 SEED_TRIG="
 $SEED
@@ -396,7 +320,6 @@ $SEED_TRIG
 CREATE TRIGGER t_ai AFTER INSERT ON t FOR EACH ROW INSERT INTO log VALUES(new.id, new.v);
 "
 
-
 oracle_schemas_dual "trigger_and_view" "
 $SEED_TRIG
 CREATE VIEW high AS SELECT * FROM t WHERE v > 15;
@@ -410,9 +333,6 @@ CREATE TRIGGER t_ai AFTER INSERT ON t FOR EACH ROW INSERT INTO log VALUES(new.id
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'add_view_and_trigger');
 "
-
-
-
 
 oracle_schemas_dual "trigger_on_feature_branch_only" "
 $SEED_TRIG
@@ -431,11 +351,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'add_trigger_on_feat');
 SELECT dolt_checkout('main');
 "
-
-
-
-
-
 
 oracle_schemas_dual "modify_trigger_single_commit" "
 $SEED_TRIG
@@ -459,8 +374,6 @@ SELECT dolt_commit('-m', 'replaced_trigger');
 
 echo "--- dolt_diff visibility of trigger-touching commits ---"
 
-
-
 oracle_diff_touches_schemas_dual "trigger_only_commit" "
 $SEED_TRIG
 CREATE TRIGGER t_ai AFTER INSERT ON t BEGIN INSERT INTO log VALUES(new.id, new.v); END;
@@ -472,7 +385,6 @@ CREATE TRIGGER t_ai AFTER INSERT ON t FOR EACH ROW INSERT INTO log VALUES(new.id
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'just_trigger');
 "
-
 
 oracle_diff_touches_schemas_dual "mixed_trigger_commits" "
 $SEED_TRIG
@@ -499,10 +411,6 @@ CREATE TRIGGER t2 AFTER DELETE ON t FOR EACH ROW INSERT INTO log VALUES(old.id, 
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'trigger_commit_2');
 "
-
-
-
-
 
 oracle_diff_touches_schemas_dual "combined_table_and_trigger" "
 $SEED_TRIG

--- a/test/vc_oracle_state_transitions_test.sh
+++ b/test/vc_oracle_state_transitions_test.sh
@@ -1,34 +1,34 @@
 #!/bin/bash
-#
-# Version-control oracle test: HEAD / staged / working state transitions
-#
-# Doltlite has three stages for table state — HEAD (committed),
-# staged (what dolt_commit will commit), and working (live database
-# state) — and the forward path (modify → add → commit) is well
-# covered by other oracles. This file targets the REVERSE and
-# SIDE-STEP paths where things tend to subtly diverge: dolt_reset
-# moving rows between stages, dolt_checkout swapping branches with
-# uncommitted changes, table-level reset undoing only some changes,
-# and the interactions between concurrent staged and working
-# modifications to the same table.
-#
-# Each scenario builds up a specific (HEAD, staged, working) state
-# and then runs a state-changing operation. The oracle compares
-# the resulting state across THREE surfaces:
-#
-#   1. dolt_log    — what HEAD points to
-#   2. dolt_status — what's staged vs unstaged
-#   3. SELECT * FROM t — actual working-set table contents
-#
-# Comparing all three is essential here. The status alone could
-# show "no changes" while the working table actually contains
-# divergent data; the log alone could show the right HEAD while
-# the working set is silently wrong; and the table contents alone
-# could match while the staged catalog is in a wrong state that
-# would corrupt the next commit.
-#
-# Usage: bash vc_oracle_state_transitions_test.sh [path/to/doltlite] [path/to/dolt]
-#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 set -u
 set -o pipefail
@@ -66,18 +66,18 @@ normalize_table() {
     | sort
 }
 
-# Each scenario provides setup SQL and the name of the table whose
-# contents should be compared (some scenarios use multiple tables;
-# they pass a comma-separated list which becomes a UNION ALL).
+
+
+
 oracle() {
   local name="$1" setup="$2" tables="${3:-t}"
   local dir="$TMPROOT/$name"
   mkdir -p "$dir/dl" "$dir/dt"
 
-  # Build the table-content query as a UNION ALL across the named
-  # tables, prefixing each row with the table name so the harness
-  # can sort across tables consistently. Schema is assumed
-  # (id, v) — every scenario in this file uses that shape.
+
+
+
+
   local table_query=""
   IFS=',' read -ra tarr <<< "$tables"
   for tn in "${tarr[@]}"; do
@@ -125,7 +125,7 @@ oracle() {
   ) > "$dir/dt.status.raw"
   dt_status=$(tail -n +2 "$dir/dt.status.raw" | tr -d '"' | normalize_status)
 
-  # Build a Dolt-syntax table query (concat instead of ||).
+
   local dolt_table_query=""
   for tn in "${tarr[@]}"; do
     local part="SELECT concat('T', char(9), '$tn', char(9), coalesce(id,''), char(9), coalesce(v,'')) FROM $tn"
@@ -143,10 +143,10 @@ oracle() {
   ) > "$dir/dt.table.raw"
   dt_table=$(tail -n +2 "$dir/dt.table.raw" | tr -d '"' | normalize_table)
 
-  # Empty-on-both-sides safeguard. Every scenario in this file
-  # commits at least once and queries at least one table, so an
-  # empty log AND empty table on both sides means the harness
-  # query errored and the test is meaningless.
+
+
+
+
   if [ -z "$dl_log" ] && [ -z "$dt_log" ] && [ -z "$dl_table" ] && [ -z "$dt_table" ]; then
     fail=$((fail+1))
     FAILED_NAMES="$FAILED_NAMES $name"
@@ -186,10 +186,10 @@ SELECT dolt_commit('-m', 'c1');
 
 echo "--- reset moving things between stages ---"
 
-# Stage one change, modify ANOTHER thing in working only, then
-# reset (no args). The staged change should move back to working,
-# joining the existing unstaged change. Both should appear as
-# unstaged after the reset.
+
+
+
+
 oracle "reset_unstages_while_working_has_separate_diff" "
 $SEED
 INSERT INTO t VALUES (3, 30);
@@ -198,9 +198,9 @@ INSERT INTO t VALUES (4, 40);
 SELECT dolt_reset();
 "
 
-# Stage a row, then DELETE it from working. After --hard reset,
-# both the staged add and the working delete should be gone, and
-# the table should be back to HEAD's contents.
+
+
+
 oracle "hard_reset_undoes_stage_then_working_delete" "
 $SEED
 INSERT INTO t VALUES (3, 30);
@@ -209,11 +209,11 @@ DELETE FROM t WHERE id = 3;
 SELECT dolt_reset('--hard');
 "
 
-# Stage a modification, then make a SECOND modification to the
-# same row in working. After plain reset (mixed), staged is
-# cleared but working keeps both modifications visible (since
-# the second one was never committed and -mixed leaves working
-# alone). The visible row v should reflect the second change.
+
+
+
+
+
 oracle "mixed_reset_preserves_subsequent_working_change" "
 $SEED
 UPDATE t SET v = 100 WHERE id = 1;
@@ -222,9 +222,9 @@ UPDATE t SET v = 200 WHERE id = 1;
 SELECT dolt_reset();
 "
 
-# Same setup as above but --hard. Now BOTH the staged
-# modification AND the second working modification should be
-# wiped, and id=1 should be back to HEAD's value of 10.
+
+
+
 oracle "hard_reset_wipes_both_staged_and_working" "
 $SEED
 UPDATE t SET v = 100 WHERE id = 1;
@@ -233,9 +233,9 @@ UPDATE t SET v = 200 WHERE id = 1;
 SELECT dolt_reset('--hard');
 "
 
-# Stage a row addition, then reset that ONE table by name. The
-# staged add for that specific table should move back to working;
-# any other staged work should remain staged.
+
+
+
 oracle "table_reset_unstages_only_named_table" "
 CREATE TABLE a(id INTEGER PRIMARY KEY, v INT);
 CREATE TABLE b(id INTEGER PRIMARY KEY, v INT);
@@ -249,9 +249,9 @@ SELECT dolt_add('-A');
 SELECT dolt_reset('a');
 " "a,b"
 
-# Reset to a previous commit with --mixed. HEAD moves back, the
-# diff between c2 and c1 becomes UNSTAGED working changes, and
-# nothing is staged.
+
+
+
 oracle "mixed_reset_to_prev_commit_moves_diff_to_working" "
 $SEED
 INSERT INTO t VALUES (3, 30);
@@ -260,8 +260,8 @@ SELECT dolt_commit('-m', 'c2');
 SELECT dolt_reset('HEAD~1');
 "
 
-# Reset to a previous commit with --hard. HEAD moves back, the
-# diff is GONE entirely from working — table back to c1's content.
+
+
 oracle "hard_reset_to_prev_commit_drops_diff_entirely" "
 $SEED
 INSERT INTO t VALUES (3, 30);
@@ -272,9 +272,9 @@ SELECT dolt_reset('--hard', 'HEAD~1');
 
 echo "--- checkout moving things between stages ---"
 
-# Checkout to another branch with a CLEAN working set. Working
-# should swap to that branch's HEAD; staged should also reflect
-# that branch's HEAD.
+
+
+
 oracle "checkout_branch_clean_swaps_working" "
 $SEED
 SELECT dolt_branch('feature');
@@ -285,14 +285,14 @@ SELECT dolt_commit('-m', 'feat1');
 SELECT dolt_checkout('main');
 "
 
-# Working set is per-BRANCH in the Dolt server model (different
-# from git's session-tied behavior). When the user makes a
-# working-only change on main and checks out feature, the
-# change STAYS on main and is not visible on feature. Round-tripping
-# back to main restores the change. The harness uses two
-# separate `dolt sql` invocations to defeat single-session
-# carry-over so the comparison reflects the persistent
-# per-branch model.
+
+
+
+
+
+
+
+
 oracle "checkout_branch_per_branch_working_set" "
 $SEED
 SELECT dolt_branch('feature');
@@ -301,10 +301,10 @@ SELECT dolt_checkout('feature');
 SELECT dolt_checkout('main');
 "
 
-# checkout -b creates the new branch from current HEAD and
-# switches to it. Under the per-branch model, the new branch
-# starts with HEAD's working set — uncommitted main changes
-# are NOT inherited by the new branch.
+
+
+
+
 oracle "checkout_b_starts_from_head_not_working" "
 $SEED
 SELECT dolt_branch('feature');
@@ -314,9 +314,9 @@ SELECT dolt_checkout('-b', 'feature2');
 SELECT dolt_checkout('main');
 "
 
-# Checkout a single TABLE from HEAD. Working changes to that
-# table are reverted, working changes to other tables are
-# preserved.
+
+
+
 oracle "checkout_table_reverts_only_named_table" "
 CREATE TABLE a(id INTEGER PRIMARY KEY, v INT);
 CREATE TABLE b(id INTEGER PRIMARY KEY, v INT);
@@ -329,9 +329,9 @@ UPDATE b SET v = 999 WHERE id = 1;
 SELECT dolt_checkout('a');
 " "a,b"
 
-# Checkout a table that was both modified in working AND staged.
-# Both the staged modification and the working modification for
-# that table should be reverted.
+
+
+
 oracle "checkout_table_clears_both_staged_and_working" "
 $SEED
 UPDATE t SET v = 100 WHERE id = 1;
@@ -342,9 +342,9 @@ SELECT dolt_checkout('t');
 
 echo "--- full cycle ---"
 
-# Full forward-then-reverse cycle: commit something, reset --soft
-# back, the diff is now staged, commit again. Should produce a
-# new commit with the same content but a different message.
+
+
+
 oracle "soft_reset_uncommit_then_recommit" "
 $SEED
 INSERT INTO t VALUES (3, 30);
@@ -354,8 +354,8 @@ SELECT dolt_reset('--soft', 'HEAD~1');
 SELECT dolt_commit('-m', 'c2-recommitted');
 "
 
-# Commit, then mixed reset, then re-stage and re-commit with a
-# new message. The diff was unstaged in the middle.
+
+
 oracle "mixed_reset_uncommit_then_readd_recommit" "
 $SEED
 INSERT INTO t VALUES (3, 30);
@@ -366,9 +366,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c2-take-two');
 "
 
-# Cycle through branches: create feature, modify, switch back to
-# main, modify differently, switch to feature, switch to main.
-# Each switch should restore the right working set.
+
+
+
 oracle "branch_round_trip_preserves_each_side" "
 $SEED
 SELECT dolt_branch('feature');
@@ -386,8 +386,8 @@ SELECT dolt_checkout('main');
 
 echo "--- edge cases ---"
 
-# Stage a deletion of a tracked table (the whole table). After
-# reset, the deletion is undone and the table is back.
+
+
 oracle "reset_undoes_staged_table_deletion" "
 $SEED
 DROP TABLE t;
@@ -395,8 +395,8 @@ SELECT dolt_add('-A');
 SELECT dolt_reset('--hard');
 "
 
-# Working has a brand-new table; mixed reset shouldn't touch it
-# (the new table is untracked, like an unstaged file in git).
+
+
 oracle "mixed_reset_does_not_touch_untracked_new_table" "
 $SEED
 CREATE TABLE u(id INTEGER PRIMARY KEY, v INT);
@@ -404,10 +404,10 @@ INSERT INTO u VALUES (1, 99);
 SELECT dolt_reset();
 " "t,u"
 
-# Hard reset DOES wipe new untracked tables (matches git --hard
-# semantics: anything in working goes away).
-# UPDATE: actually git --hard does NOT remove untracked files;
-# you need --hard plus -x or git clean. Let's see what Dolt does.
+
+
+
+
 oracle "hard_reset_with_untracked_new_table" "
 $SEED
 CREATE TABLE u(id INTEGER PRIMARY KEY, v INT);
@@ -415,9 +415,9 @@ INSERT INTO u VALUES (1, 99);
 SELECT dolt_reset('--hard');
 " "t,u"
 
-# Add a table, commit, then reset --hard to BEFORE the add. The
-# table should be gone from working entirely (it was tracked,
-# now it's not even in HEAD).
+
+
+
 oracle "hard_reset_drops_table_added_after_target" "
 $SEED
 CREATE TABLE u(id INTEGER PRIMARY KEY, v INT);

--- a/test/vc_oracle_state_transitions_test.sh
+++ b/test/vc_oracle_state_transitions_test.sh
@@ -1,35 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 set -u
 set -o pipefail
 
@@ -66,17 +36,10 @@ normalize_table() {
     | sort
 }
 
-
-
-
 oracle() {
   local name="$1" setup="$2" tables="${3:-t}"
   local dir="$TMPROOT/$name"
   mkdir -p "$dir/dl" "$dir/dt"
-
-
-
-
 
   local table_query=""
   IFS=',' read -ra tarr <<< "$tables"
@@ -125,7 +88,6 @@ oracle() {
   ) > "$dir/dt.status.raw"
   dt_status=$(tail -n +2 "$dir/dt.status.raw" | tr -d '"' | normalize_status)
 
-
   local dolt_table_query=""
   for tn in "${tarr[@]}"; do
     local part="SELECT concat('T', char(9), '$tn', char(9), coalesce(id,''), char(9), coalesce(v,'')) FROM $tn"
@@ -142,10 +104,6 @@ oracle() {
     "$DOLT" sql -r csv -q "$dolt_table_query;" 2>>"$dir/dt.t.err"
   ) > "$dir/dt.table.raw"
   dt_table=$(tail -n +2 "$dir/dt.table.raw" | tr -d '"' | normalize_table)
-
-
-
-
 
   if [ -z "$dl_log" ] && [ -z "$dt_log" ] && [ -z "$dl_table" ] && [ -z "$dt_table" ]; then
     fail=$((fail+1))
@@ -186,10 +144,6 @@ SELECT dolt_commit('-m', 'c1');
 
 echo "--- reset moving things between stages ---"
 
-
-
-
-
 oracle "reset_unstages_while_working_has_separate_diff" "
 $SEED
 INSERT INTO t VALUES (3, 30);
@@ -197,9 +151,6 @@ SELECT dolt_add('-A');
 INSERT INTO t VALUES (4, 40);
 SELECT dolt_reset();
 "
-
-
-
 
 oracle "hard_reset_undoes_stage_then_working_delete" "
 $SEED
@@ -209,11 +160,6 @@ DELETE FROM t WHERE id = 3;
 SELECT dolt_reset('--hard');
 "
 
-
-
-
-
-
 oracle "mixed_reset_preserves_subsequent_working_change" "
 $SEED
 UPDATE t SET v = 100 WHERE id = 1;
@@ -222,9 +168,6 @@ UPDATE t SET v = 200 WHERE id = 1;
 SELECT dolt_reset();
 "
 
-
-
-
 oracle "hard_reset_wipes_both_staged_and_working" "
 $SEED
 UPDATE t SET v = 100 WHERE id = 1;
@@ -232,9 +175,6 @@ SELECT dolt_add('-A');
 UPDATE t SET v = 200 WHERE id = 1;
 SELECT dolt_reset('--hard');
 "
-
-
-
 
 oracle "table_reset_unstages_only_named_table" "
 CREATE TABLE a(id INTEGER PRIMARY KEY, v INT);
@@ -249,9 +189,6 @@ SELECT dolt_add('-A');
 SELECT dolt_reset('a');
 " "a,b"
 
-
-
-
 oracle "mixed_reset_to_prev_commit_moves_diff_to_working" "
 $SEED
 INSERT INTO t VALUES (3, 30);
@@ -259,8 +196,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c2');
 SELECT dolt_reset('HEAD~1');
 "
-
-
 
 oracle "hard_reset_to_prev_commit_drops_diff_entirely" "
 $SEED
@@ -272,9 +207,6 @@ SELECT dolt_reset('--hard', 'HEAD~1');
 
 echo "--- checkout moving things between stages ---"
 
-
-
-
 oracle "checkout_branch_clean_swaps_working" "
 $SEED
 SELECT dolt_branch('feature');
@@ -285,14 +217,6 @@ SELECT dolt_commit('-m', 'feat1');
 SELECT dolt_checkout('main');
 "
 
-
-
-
-
-
-
-
-
 oracle "checkout_branch_per_branch_working_set" "
 $SEED
 SELECT dolt_branch('feature');
@@ -300,10 +224,6 @@ INSERT INTO t VALUES (3, 30);
 SELECT dolt_checkout('feature');
 SELECT dolt_checkout('main');
 "
-
-
-
-
 
 oracle "checkout_b_starts_from_head_not_working" "
 $SEED
@@ -313,9 +233,6 @@ SELECT dolt_checkout('feature');
 SELECT dolt_checkout('-b', 'feature2');
 SELECT dolt_checkout('main');
 "
-
-
-
 
 oracle "checkout_table_reverts_only_named_table" "
 CREATE TABLE a(id INTEGER PRIMARY KEY, v INT);
@@ -329,9 +246,6 @@ UPDATE b SET v = 999 WHERE id = 1;
 SELECT dolt_checkout('a');
 " "a,b"
 
-
-
-
 oracle "checkout_table_clears_both_staged_and_working" "
 $SEED
 UPDATE t SET v = 100 WHERE id = 1;
@@ -342,9 +256,6 @@ SELECT dolt_checkout('t');
 
 echo "--- full cycle ---"
 
-
-
-
 oracle "soft_reset_uncommit_then_recommit" "
 $SEED
 INSERT INTO t VALUES (3, 30);
@@ -353,8 +264,6 @@ SELECT dolt_commit('-m', 'c2');
 SELECT dolt_reset('--soft', 'HEAD~1');
 SELECT dolt_commit('-m', 'c2-recommitted');
 "
-
-
 
 oracle "mixed_reset_uncommit_then_readd_recommit" "
 $SEED
@@ -365,9 +274,6 @@ SELECT dolt_reset('HEAD~1');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c2-take-two');
 "
-
-
-
 
 oracle "branch_round_trip_preserves_each_side" "
 $SEED
@@ -386,16 +292,12 @@ SELECT dolt_checkout('main');
 
 echo "--- edge cases ---"
 
-
-
 oracle "reset_undoes_staged_table_deletion" "
 $SEED
 DROP TABLE t;
 SELECT dolt_add('-A');
 SELECT dolt_reset('--hard');
 "
-
-
 
 oracle "mixed_reset_does_not_touch_untracked_new_table" "
 $SEED
@@ -404,19 +306,12 @@ INSERT INTO u VALUES (1, 99);
 SELECT dolt_reset();
 " "t,u"
 
-
-
-
-
 oracle "hard_reset_with_untracked_new_table" "
 $SEED
 CREATE TABLE u(id INTEGER PRIMARY KEY, v INT);
 INSERT INTO u VALUES (1, 99);
 SELECT dolt_reset('--hard');
 " "t,u"
-
-
-
 
 oracle "hard_reset_drops_table_added_after_target" "
 $SEED

--- a/test/vc_oracle_status_test.sh
+++ b/test/vc_oracle_status_test.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
-#
-# Version-control oracle test: dolt_status
-#
-# Runs identical working-set scenarios against doltlite and Dolt, then
-# compares the normalized `dolt_status` output. Catches divergence in how
-# each engine classifies new/modified/deleted/renamed tables, staged vs
-# unstaged, and mixed states.
-#
-# Usage: bash vc_oracle_status_test.sh [path/to/doltlite] [path/to/dolt]
-#
+
+
+
+
+
+
+
+
+
+
 
 set -u
 set -o pipefail
@@ -21,19 +21,19 @@ pass=0; fail=0
 FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
-# Strip CRLF only; status rows are already in sort order.
+
 normalize() {
   tr -d '\r'
 }
 
-# Run a scenario. $1=name, $2=setup SQL in doltlite syntax.
-# The harness rewrites `SELECT dolt_*(...)` -> `CALL dolt_*(...)` for Dolt.
+
+
 oracle() {
   local name="$1" setup="$2"
   local dir="$TMPROOT/$name"
   mkdir -p "$dir/dl" "$dir/dt"
 
-  # doltlite side: single tab-separated column, no csv quoting.
+
   local dl_out
   dl_out=$(printf "%s\n.headers off\n.mode list\n.separator '\t'\nSELECT table_name || char(9) || staged || char(9) || status FROM dolt_status ORDER BY table_name, staged, status;\n" "$setup" \
            | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \

--- a/test/vc_oracle_status_test.sh
+++ b/test/vc_oracle_status_test.sh
@@ -1,15 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
-
-
 set -u
 set -o pipefail
 
@@ -21,18 +11,14 @@ pass=0; fail=0
 FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
-
 normalize() {
   tr -d '\r'
 }
-
-
 
 oracle() {
   local name="$1" setup="$2"
   local dir="$TMPROOT/$name"
   mkdir -p "$dir/dl" "$dir/dt"
-
 
   local dl_out
   dl_out=$(printf "%s\n.headers off\n.mode list\n.separator '\t'\nSELECT table_name || char(9) || staged || char(9) || status FROM dolt_status ORDER BY table_name, staged, status;\n" "$setup" \

--- a/test/vc_oracle_tags_test.sh
+++ b/test/vc_oracle_tags_test.sh
@@ -1,21 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 set -u
 set -o pipefail
 

--- a/test/vc_oracle_tags_test.sh
+++ b/test/vc_oracle_tags_test.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
-#
-# Version-control oracle test: dolt_tags
-#
-# Runs identical tag-management scenarios against doltlite and Dolt and
-# compares the normalized dolt_tags output. Catches divergence in how each
-# engine reports tag listings, the per-tag tagger metadata and message,
-# and which commit a tag points at.
-#
-# Columns compared: tag_name, tag_hash (normalized), message. The
-# tagger/email/date columns are excluded because their values come from
-# process state and legitimately differ across the two engines unless
-# every scenario passes --author overrides; the message and pointed-at
-# commit are the load-bearing semantic axes.
-#
-# Usage: bash vc_oracle_tags_test.sh [path/to/doltlite] [path/to/dolt]
-#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 set -u
 set -o pipefail

--- a/test/vc_oracle_triggers_test.sh
+++ b/test/vc_oracle_triggers_test.sh
@@ -1,19 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 set -u
 set -o pipefail
 
@@ -28,13 +14,6 @@ source "$(dirname "$0")/lib/vc_oracle_common.sh"
 normalize() {
   tr -d '\r' | grep -v '^$' | sort
 }
-
-
-
-
-
-
-
 
 oracle_triggers_dual() {
   local name="$1" dl_setup="$2" dt_setup="$3" query="$4"
@@ -80,9 +59,6 @@ oracle_triggers_dual() {
 echo "=== Triggers + VC Oracle Tests ==="
 echo ""
 
-
-
-
 echo "--- AFTER INSERT one side ---"
 
 oracle_triggers_dual "after_insert_trigger_fires_on_feat_inserts" "
@@ -114,9 +90,6 @@ SELECT dolt_commit('-m','feat with trigger and inserts');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM log ORDER BY id;"
-
-
-
 
 echo "--- trigger survives merge and fires post-merge ---"
 
@@ -152,9 +125,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main post-merge insert');
 " "SELECT id, v FROM log ORDER BY id;"
 
-
-
-
 echo "--- AFTER UPDATE trigger ---"
 
 oracle_triggers_dual "after_update_trigger_logs_old_and_new" "
@@ -185,9 +155,6 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, diff FROM log ORDER BY id;"
 
-
-
-
 echo "--- AFTER DELETE trigger ---"
 
 oracle_triggers_dual "after_delete_trigger_logs_removed_rows" "
@@ -217,9 +184,6 @@ SELECT dolt_commit('-m','feat deletes + trigger');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM log ORDER BY id;"
-
-
-
 
 echo "--- trigger + independent main DML ---"
 
@@ -263,9 +227,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main post');
 " "SELECT id FROM log ORDER BY id;"
 
-
-
-
 echo "--- trigger dropped on feat ---"
 
 oracle_triggers_dual "trigger_drop_on_feat_main_inserts_no_log_entries" "
@@ -302,9 +263,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main post');
 " "SELECT count(*) FROM log;"
 
-
-
-
 echo "--- trigger + cherry-pick ---"
 
 oracle_triggers_dual "cherry_pick_of_trigger_creation_commit" "
@@ -339,9 +297,6 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main post');
 " "SELECT id FROM log;"
 
-
-
-
 echo "--- DELETE trigger on multi-row delete + merge ---"
 
 oracle_triggers_dual "delete_trigger_counts_rows_removed" "
@@ -371,9 +326,6 @@ SELECT dolt_commit('-m','feat deletes grp=1');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) FROM log;"
-
-
-
 
 echo "--- two triggers on same table ---"
 
@@ -408,9 +360,6 @@ SELECT dolt_commit('-m','feat');
 SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, kind FROM log ORDER BY id;"
-
-
-
 
 echo "--- trigger persists across commit/reopen-like sequence ---"
 
@@ -449,9 +398,6 @@ INSERT INTO t VALUES(4,'after_merge2');
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m','more inserts');
 " "SELECT id FROM log ORDER BY id;"
-
-
-
 
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="

--- a/test/vc_oracle_triggers_test.sh
+++ b/test/vc_oracle_triggers_test.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
-#
-# Triggers + version control oracle tests (doltlite vs Dolt).
-#
-# SQLite triggers use BEGIN…END; bodies. MySQL (Dolt) uses single-
-# statement "FOR EACH ROW <stmt>" bodies. The syntaxes are mutually
-# exclusive, so a single SQL string can't run on both engines.
-#
-# The oracle_triggers_dual helper below takes separate doltlite and
-# Dolt setup scripts and compares the final state of a shared query.
-# Each test pair is written so the *semantics* are identical; only
-# the trigger body syntax differs.
-#
-# Usage: bash vc_oracle_triggers_test.sh [path/to/doltlite] [path/to/dolt]
-#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 set -u
 set -o pipefail
@@ -29,13 +29,13 @@ normalize() {
   tr -d '\r' | grep -v '^$' | sort
 }
 
-# oracle_triggers_dual NAME DOLTLITE_SETUP DOLT_SETUP QUERY
-#   DOLTLITE_SETUP: SQLite-style setup (triggers use BEGIN…END;)
-#   DOLT_SETUP:     MySQL-style setup (triggers use FOR EACH ROW <stmt>)
-#                   vc_oracle_translate_for_dolt still rewrites the
-#                   SELECT dolt_XXX(…) calls to CALL dolt_XXX(…) on
-#                   the Dolt side.
-#   QUERY:          identical on both engines (no trigger DDL in here).
+
+
+
+
+
+
+
 oracle_triggers_dual() {
   local name="$1" dl_setup="$2" dt_setup="$3" query="$4"
   local dir="$TMPROOT/$name"
@@ -80,9 +80,9 @@ oracle_triggers_dual() {
 echo "=== Triggers + VC Oracle Tests ==="
 echo ""
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 1: AFTER INSERT trigger, one-sided, merged
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- AFTER INSERT one side ---"
 
 oracle_triggers_dual "after_insert_trigger_fires_on_feat_inserts" "
@@ -115,9 +115,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM log ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 2: Trigger created on feat, fires when main inserts after merge
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- trigger survives merge and fires post-merge ---"
 
 oracle_triggers_dual "trigger_on_feat_fires_on_main_after_merge" "
@@ -152,9 +152,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main post-merge insert');
 " "SELECT id, v FROM log ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 3: AFTER UPDATE trigger
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- AFTER UPDATE trigger ---"
 
 oracle_triggers_dual "after_update_trigger_logs_old_and_new" "
@@ -185,9 +185,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, diff FROM log ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 4: AFTER DELETE trigger
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- AFTER DELETE trigger ---"
 
 oracle_triggers_dual "after_delete_trigger_logs_removed_rows" "
@@ -218,9 +218,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id FROM log ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 5: Trigger + independent main-side DML merged
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- trigger + independent main DML ---"
 
 oracle_triggers_dual "trigger_on_feat_main_inserts_independently" "
@@ -263,9 +263,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main post');
 " "SELECT id FROM log ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 6: Trigger dropped on feat, merged
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- trigger dropped on feat ---"
 
 oracle_triggers_dual "trigger_drop_on_feat_main_inserts_no_log_entries" "
@@ -302,9 +302,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main post');
 " "SELECT count(*) FROM log;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 7: Trigger + cherry-pick
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- trigger + cherry-pick ---"
 
 oracle_triggers_dual "cherry_pick_of_trigger_creation_commit" "
@@ -339,9 +339,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','main post');
 " "SELECT id FROM log;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 8: Trigger fires during a DELETE cascade-like chain
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- DELETE trigger on multi-row delete + merge ---"
 
 oracle_triggers_dual "delete_trigger_counts_rows_removed" "
@@ -372,9 +372,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT count(*) FROM log;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 9: Two triggers on same table
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- two triggers on same table ---"
 
 oracle_triggers_dual "insert_and_delete_triggers_both_log" "
@@ -409,9 +409,9 @@ SELECT dolt_checkout('main');
 SELECT dolt_merge('feat');
 " "SELECT id, kind FROM log ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Section 10: Trigger fires across reopen (persists)
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo "--- trigger persists across commit/reopen-like sequence ---"
 
 oracle_triggers_dual "trigger_still_active_after_merge_reset_flow" "
@@ -450,9 +450,9 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m','more inserts');
 " "SELECT id FROM log ORDER BY id;"
 
-# ═══════════════════════════════════════════════════════════════════
-# Results
-# ═══════════════════════════════════════════════════════════════════
+
+
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then

--- a/test/vc_oracle_txn_commit_test.sh
+++ b/test/vc_oracle_txn_commit_test.sh
@@ -1,14 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
-
 set -u
 DOLTLITE="${1:?usage: $0 <doltlite> [dolt]}"
 DOLT="${2:-}"
@@ -34,7 +25,6 @@ dolt_query() {
 }
 
 echo "=== Transaction + dolt_commit Oracle Tests ==="
-
 
 echo ""
 echo "--- BEGIN + dolt_commit + ROLLBACK ---"
@@ -82,7 +72,6 @@ else
   echo "    expected 2, got $DL_A"
 fi
 
-
 echo ""
 echo "--- SAVEPOINT + dolt_commit + ROLLBACK TO ---"
 
@@ -129,7 +118,6 @@ else
   echo "    expected 2, got $DL_B"
 fi
 
-
 echo ""
 echo "--- No transaction + dolt_commit (baseline) ---"
 
@@ -150,7 +138,6 @@ else
   fail_name "no_txn_commit_works"
   echo "    expected 2, got $DL_C"
 fi
-
 
 echo ""
 echo "--- BEGIN + multiple inserts + dolt_commit + ROLLBACK ---"
@@ -175,7 +162,6 @@ else
   fail_name "begin_multi_insert_commit_rollback"
   echo "    expected 3, got $DL_D"
 fi
-
 
 echo ""
 echo "--- Nested savepoints + dolt_commit ---"
@@ -202,7 +188,6 @@ else
   echo "    expected 2, got $DL_E"
 fi
 
-
 echo ""
 echo "--- dolt_commit without open txn ---"
 
@@ -225,7 +210,6 @@ else
   echo "    expected 2, got $DL_F"
 fi
 
-
 echo ""
 echo "--- Reopen after BEGIN + dolt_commit (persistence) ---"
 
@@ -239,7 +223,6 @@ SELECT dolt_commit('-A','-m','c1');
 SQL
 )" >/dev/null
 
-
 DL_G=$(dl_query "$DB" "SELECT count(*) FROM t;")
 
 if [ "$DL_G" = "1" ]; then
@@ -248,7 +231,6 @@ else
   fail_name "reopen_after_begin_commit_persists"
   echo "    expected 1, got $DL_G"
 fi
-
 
 echo ""
 echo "--- BEGIN + bad dolt_commit option ---"
@@ -294,7 +276,6 @@ else
   fail_name "begin_bad_commit_option_rolls_back_on_reopen"
   echo "    expected 1, got $DL_H"
 fi
-
 
 echo ""
 echo "--- Nested savepoint + bad dolt_commit option ---"

--- a/test/vc_oracle_txn_commit_test.sh
+++ b/test/vc_oracle_txn_commit_test.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
-#
-# Oracle tests: SQL transaction interaction with dolt_commit.
-#
-# Verifies that dolt_commit() implicitly commits any open SQL
-# transaction, matching Dolt's behavior. After dolt_commit(),
-# ROLLBACK is a no-op and all pending DML is durable.
-#
-# Usage: bash test/vc_oracle_txn_commit_test.sh <doltlite> [dolt]
-#
+
+
+
+
+
+
+
+
+
 
 set -u
 DOLTLITE="${1:?usage: $0 <doltlite> [dolt]}"
@@ -35,7 +35,7 @@ dolt_query() {
 
 echo "=== Transaction + dolt_commit Oracle Tests ==="
 
-# ── Test A: BEGIN + dolt_commit + ROLLBACK ──────────────────
+
 echo ""
 echo "--- BEGIN + dolt_commit + ROLLBACK ---"
 
@@ -82,7 +82,7 @@ else
   echo "    expected 2, got $DL_A"
 fi
 
-# ── Test B: SAVEPOINT + dolt_commit + ROLLBACK TO ──────────
+
 echo ""
 echo "--- SAVEPOINT + dolt_commit + ROLLBACK TO ---"
 
@@ -129,7 +129,7 @@ else
   echo "    expected 2, got $DL_B"
 fi
 
-# ── Test C: No transaction + dolt_commit (baseline) ────────
+
 echo ""
 echo "--- No transaction + dolt_commit (baseline) ---"
 
@@ -151,7 +151,7 @@ else
   echo "    expected 2, got $DL_C"
 fi
 
-# ── Test D: BEGIN + multiple inserts + dolt_commit + ROLLBACK ──
+
 echo ""
 echo "--- BEGIN + multiple inserts + dolt_commit + ROLLBACK ---"
 
@@ -176,7 +176,7 @@ else
   echo "    expected 3, got $DL_D"
 fi
 
-# ── Test E: Nested savepoints + dolt_commit ────────────────
+
 echo ""
 echo "--- Nested savepoints + dolt_commit ---"
 
@@ -202,7 +202,7 @@ else
   echo "    expected 2, got $DL_E"
 fi
 
-# ── Test F: dolt_commit without open txn is fine ───────────
+
 echo ""
 echo "--- dolt_commit without open txn ---"
 
@@ -225,7 +225,7 @@ else
   echo "    expected 2, got $DL_F"
 fi
 
-# ── Test G: Reopen after BEGIN + dolt_commit + crash ───────
+
 echo ""
 echo "--- Reopen after BEGIN + dolt_commit (persistence) ---"
 
@@ -239,7 +239,7 @@ SELECT dolt_commit('-A','-m','c1');
 SQL
 )" >/dev/null
 
-# Reopen — the committed row must be there
+
 DL_G=$(dl_query "$DB" "SELECT count(*) FROM t;")
 
 if [ "$DL_G" = "1" ]; then
@@ -249,7 +249,7 @@ else
   echo "    expected 1, got $DL_G"
 fi
 
-# ── Test H: BEGIN + bad dolt_commit option should not persist txn ──
+
 echo ""
 echo "--- BEGIN + bad dolt_commit option ---"
 
@@ -295,7 +295,7 @@ else
   echo "    expected 1, got $DL_H"
 fi
 
-# ── Test I: Nested savepoint + bad dolt_commit option ───────
+
 echo ""
 echo "--- Nested savepoint + bad dolt_commit option ---"
 

--- a/test/vc_oracle_version_test.sh
+++ b/test/vc_oracle_version_test.sh
@@ -1,38 +1,38 @@
 #!/bin/bash
-#
-# Version-control oracle test: dolt_version
-#
-# dolt_version() is a 0-arg scalar that returns the build's version
-# string. It's useful for:
-#
-#   - Peer negotiation in the decentralized use case — a client can
-#     check the server's version before attempting format-sensitive
-#     operations (clone, push, fetch).
-#   - Debugging / bug reports: paste the output of SELECT dolt_version()
-#     in an issue and we know exactly which build produced it.
-#   - Schema migrations that behave differently per engine version.
-#
-# The interesting surface is small:
-#
-#   1. Zero args only. One arg or more must error, matching Dolt
-#      which does the same ("function 'dolt_version' expected 0
-#      arguments").
-#
-#   2. Deterministic: two invocations in the same session and
-#      across re-opens return the same string.
-#
-#   3. Non-empty, no whitespace, plausible version shape. We
-#      don't assert an exact format because doltlite uses
-#      `git describe` output (e.g. v0.7.3-29-g61abf71) while
-#      Dolt uses semver (1.83.5), and both are valid. The shape
-#      check is that the string matches [A-Za-z0-9.+-]+ — any
-#      reasonable version identifier lands in that alphabet.
-#
-#   4. Dolt conformance: both engines respect the same argcount
-#      contract (0 args passes, 1+ errors).
-#
-# Usage: bash vc_oracle_version_test.sh [path/to/doltlite] [path/to/dolt]
-#
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 set -u
 
@@ -43,9 +43,9 @@ trap "rm -rf $TMPROOT" EXIT
 pass=0; fail=0
 FAILED_NAMES=""
 
-# Run a single SQL statement against a fresh doltlite db and return
-# the one-column scalar result, stripped of any shell/commit noise
-# by tail -1.
+
+
+
 dl_scalar() {
   local name="$1" sql="$2"
   local db="$TMPROOT/$name.db"
@@ -53,8 +53,8 @@ dl_scalar() {
   "$DOLTLITE" "$db" "$sql" 2>"$TMPROOT/$name.err"
 }
 
-# Run a single SQL statement against a fresh Dolt repo and return
-# the scalar result (column 1 of the first non-header row).
+
+
 dolt_scalar() {
   local name="$1" sql="$2"
   local dir="$TMPROOT/${name}_dt"
@@ -68,8 +68,8 @@ dolt_scalar() {
   )
 }
 
-# Run a statement that should error. Returns 0 if doltlite printed
-# any "error"/"Error"/"ERROR" token, 1 otherwise.
+
+
 dl_errored() {
   local name="$1" sql="$2"
   local db="$TMPROOT/${name}_err.db"
@@ -78,7 +78,7 @@ dl_errored() {
   grep -qiE 'error|Error' "$TMPROOT/${name}.out" "$TMPROOT/${name}.err" 2>/dev/null
 }
 
-# Like dl_errored but for Dolt.
+
 dolt_errored() {
   local name="$1" sql="$2"
   local dir="$TMPROOT/${name}_dt_err"
@@ -144,7 +144,7 @@ expect_true() {
 echo "=== Version Control Oracle Tests: dolt_version ==="
 echo ""
 
-# ── 1. Basic invocation ───────────────────────────────────
+
 echo "--- 1. Returns a non-empty version string ---"
 
 V=$(dl_scalar "basic" "SELECT dolt_version();")
@@ -153,7 +153,7 @@ expect_shape    "dolt_version_plausible_shape" "$V"
 
 echo ""
 
-# ── 2. Determinism across calls ───────────────────────────
+
 echo "--- 2. Deterministic across same-session calls ---"
 
 V1=$(dl_scalar "det_a" "SELECT dolt_version();")
@@ -168,7 +168,7 @@ expect_equal "dolt_version_stable_across_reopen" "$V3" "$V4"
 
 echo ""
 
-# ── 3. Argcount contract ──────────────────────────────────
+
 echo "--- 3. Rejects non-zero argcount ---"
 
 if dl_errored "one_arg"   "SELECT dolt_version('x');"; then
@@ -187,7 +187,7 @@ fi
 
 echo ""
 
-# ── 4. Works inside a transaction and alongside DML ───────
+
 echo "--- 4. Callable mid-transaction ---"
 
 DB="$TMPROOT/mid_txn.db"
@@ -199,7 +199,7 @@ expect_equal    "dolt_version_same_in_txn"     "$V_MID" "$V"
 
 echo ""
 
-# ── 5. Dolt conformance ───────────────────────────────────
+
 echo "--- 5. Dolt conformance ---"
 
 DT_V=$(dolt_scalar "dt_basic" "SELECT DOLT_VERSION();")

--- a/test/vc_oracle_version_test.sh
+++ b/test/vc_oracle_version_test.sh
@@ -1,39 +1,5 @@
 #!/bin/bash
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 set -u
 
 DOLTLITE="${1:-./doltlite}"
@@ -43,17 +9,12 @@ trap "rm -rf $TMPROOT" EXIT
 pass=0; fail=0
 FAILED_NAMES=""
 
-
-
-
 dl_scalar() {
   local name="$1" sql="$2"
   local db="$TMPROOT/$name.db"
   rm -f "$db"
   "$DOLTLITE" "$db" "$sql" 2>"$TMPROOT/$name.err"
 }
-
-
 
 dolt_scalar() {
   local name="$1" sql="$2"
@@ -68,8 +29,6 @@ dolt_scalar() {
   )
 }
 
-
-
 dl_errored() {
   local name="$1" sql="$2"
   local db="$TMPROOT/${name}_err.db"
@@ -77,7 +36,6 @@ dl_errored() {
   "$DOLTLITE" "$db" "$sql" >"$TMPROOT/${name}.out" 2>"$TMPROOT/${name}.err"
   grep -qiE 'error|Error' "$TMPROOT/${name}.out" "$TMPROOT/${name}.err" 2>/dev/null
 }
-
 
 dolt_errored() {
   local name="$1" sql="$2"
@@ -144,7 +102,6 @@ expect_true() {
 echo "=== Version Control Oracle Tests: dolt_version ==="
 echo ""
 
-
 echo "--- 1. Returns a non-empty version string ---"
 
 V=$(dl_scalar "basic" "SELECT dolt_version();")
@@ -152,7 +109,6 @@ expect_nonempty "dolt_version_returns_nonempty" "$V"
 expect_shape    "dolt_version_plausible_shape" "$V"
 
 echo ""
-
 
 echo "--- 2. Deterministic across same-session calls ---"
 
@@ -167,7 +123,6 @@ V4=$("$DOLTLITE" "$DB" "SELECT dolt_version();" 2>>"$TMPROOT/session.err")
 expect_equal "dolt_version_stable_across_reopen" "$V3" "$V4"
 
 echo ""
-
 
 echo "--- 3. Rejects non-zero argcount ---"
 
@@ -187,7 +142,6 @@ fi
 
 echo ""
 
-
 echo "--- 4. Callable mid-transaction ---"
 
 DB="$TMPROOT/mid_txn.db"
@@ -198,7 +152,6 @@ expect_nonempty "dolt_version_mid_transaction" "$V_MID"
 expect_equal    "dolt_version_same_in_txn"     "$V_MID" "$V"
 
 echo ""
-
 
 echo "--- 5. Dolt conformance ---"
 


### PR DESCRIPTION
## Summary
- strip comments from Doltlite-specific source and tests
- restore only high-value comments for non-obvious storage, savepoint, pager shim, chunking, and fast-merge invariants
- leave tests largely as executable specs without explanatory prose

## Validation
- git diff --check
- make doltlite doltlite_regression_test_c
- ./doltlite_regression_test_c gc_rewrite_failure
- bash -n over modified shell tests