### PR TITLE
publish doltlite to *nix package managers on release: install.sh + .deb

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,7 +249,9 @@ jobs:
         VERSION=${GITHUB_REF_NAME#v}
         # Collect all zips, tarballs, and .deb files
         find artifacts -type f \( -name "*.zip" -o -name "*.tar.gz" -o -name "*.deb" \) -exec mv {} . \;
-        ls -la *.zip *.tar.gz *.deb 2>/dev/null || ls -la *.zip *.tar.gz
+        # Also stage the install script so users can curl|bash it.
+        cp install.sh ./install.sh
+        ls -la *.zip *.tar.gz *.deb install.sh 2>/dev/null || ls -la *.zip *.tar.gz install.sh
 
         # Create release if it doesn't already exist (may have been
         # created manually with release notes before the workflow ran)
@@ -260,7 +262,7 @@ jobs:
         fi
 
         # Upload artifacts to the release
-        ASSETS=$(find . -maxdepth 1 \( -name "*.zip" -o -name "*.tar.gz" -o -name "*.deb" \) -print)
+        ASSETS=$(find . -maxdepth 1 \( -name "*.zip" -o -name "*.tar.gz" -o -name "*.deb" -o -name "install.sh" \) -print)
         echo "Uploading: ${ASSETS}"
         gh release upload "${GITHUB_REF_NAME}" ${ASSETS} --clobber
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,6 +163,34 @@ jobs:
           7z a "${DIR}.zip" "${DIR}"
         fi
 
+    # Debian packages — built only on Linux. nfpm reads the per-package
+    # yaml configs in packaging/nfpm/, substitutes ${VERSION} and ${PKG_ARCH}
+    # and ${DEB_HOST_MULTIARCH}, and emits .deb files. We attach them to
+    # the GitHub release alongside the tarballs so users can install with
+    # `wget … && sudo dpkg -i doltlite_*.deb`.
+    - name: Install nfpm (Linux)
+      if: matrix.target == 'linux-x64'
+      run: |
+        NFPM_VERSION=2.43.0
+        curl -fsSL "https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/nfpm_${NFPM_VERSION}_Linux_x86_64.tar.gz" | sudo tar -xz -C /usr/local/bin nfpm
+        nfpm --version
+
+    - name: Build Debian packages (Linux)
+      if: matrix.target == 'linux-x64'
+      shell: bash
+      env:
+        VERSION: ${{ github.ref_name }}
+        PKG_ARCH: amd64
+      run: |
+        # nfpm reads VERSION from env; strip the leading "v" so we ship
+        # doltlite_0.10.3_amd64.deb, not doltlite_v0.10.3_amd64.deb.
+        export VERSION="${VERSION#v}"
+        mkdir -p dist
+        for cfg in packaging/nfpm/*.yaml; do
+          nfpm pkg --config "$cfg" --packager deb --target dist/
+        done
+        ls -la dist/
+
     - name: Upload binary artifacts
       uses: actions/upload-artifact@v4
       with:
@@ -170,6 +198,7 @@ jobs:
         path: |
           doltlite-tools-*.zip
           doltlite-lib-*.zip
+          dist/*.deb
 
   # ── Run benchmarks ────────────────────────────────────────
   benchmark:
@@ -218,9 +247,9 @@ jobs:
         GH_TOKEN: ${{ github.token }}
       run: |
         VERSION=${GITHUB_REF_NAME#v}
-        # Collect all zips and tarballs
-        find artifacts -type f \( -name "*.zip" -o -name "*.tar.gz" \) -exec mv {} . \;
-        ls -la *.zip *.tar.gz
+        # Collect all zips, tarballs, and .deb files
+        find artifacts -type f \( -name "*.zip" -o -name "*.tar.gz" -o -name "*.deb" \) -exec mv {} . \;
+        ls -la *.zip *.tar.gz *.deb 2>/dev/null || ls -la *.zip *.tar.gz
 
         # Create release if it doesn't already exist (may have been
         # created manually with release notes before the workflow ran)
@@ -231,7 +260,7 @@ jobs:
         fi
 
         # Upload artifacts to the release
-        ASSETS=$(find . -maxdepth 1 \( -name "*.zip" -o -name "*.tar.gz" \) -print)
+        ASSETS=$(find . -maxdepth 1 \( -name "*.zip" -o -name "*.tar.gz" -o -name "*.deb" \) -print)
         echo "Uploading: ${ASSETS}"
         gh release upload "${GITHUB_REF_NAME}" ${ASSETS} --clobber
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,17 @@ jobs:
         include:
           - os: ubuntu-latest
             target: linux-x64
+            pkg_arch: amd64
+            deb_multiarch: x86_64-linux-gnu
+            nfpm_arch: x86_64
+            ext: ""
+            lib_ext: ".so"
+            static_ext: ".a"
+          - os: ubuntu-24.04-arm
+            target: linux-arm64
+            pkg_arch: arm64
+            deb_multiarch: aarch64-linux-gnu
+            nfpm_arch: arm64
             ext: ""
             lib_ext: ".so"
             static_ext: ".a"
@@ -169,25 +180,31 @@ jobs:
     # the GitHub release alongside the tarballs so users can install with
     # `wget … && sudo dpkg -i doltlite_*.deb`.
     - name: Install nfpm (Linux)
-      if: matrix.target == 'linux-x64'
+      if: startsWith(matrix.target, 'linux-')
       run: |
         NFPM_VERSION=2.43.0
-        curl -fsSL "https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/nfpm_${NFPM_VERSION}_Linux_x86_64.tar.gz" | sudo tar -xz -C /usr/local/bin nfpm
+        curl -fsSL "https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/nfpm_${NFPM_VERSION}_Linux_${{ matrix.nfpm_arch }}.tar.gz" | sudo tar -xz -C /usr/local/bin nfpm
         nfpm --version
 
     - name: Build Debian packages (Linux)
-      if: matrix.target == 'linux-x64'
+      if: startsWith(matrix.target, 'linux-')
       shell: bash
       env:
         VERSION: ${{ github.ref_name }}
-        PKG_ARCH: amd64
+        PKG_ARCH: ${{ matrix.pkg_arch }}
+        DEB_HOST_MULTIARCH: ${{ matrix.deb_multiarch }}
       run: |
         # nfpm reads VERSION from env; strip the leading "v" so we ship
         # doltlite_0.10.3_amd64.deb, not doltlite_v0.10.3_amd64.deb.
         export VERSION="${VERSION#v}"
         mkdir -p dist
+        # nfpm only expands ${VAR} placeholders in a fixed set of metadata
+        # fields (name/version/arch/depends), not inside contents[].dst.
+        # Pre-render the YAML through envsubst so /usr/lib/${DEB_HOST_MULTIARCH}/
+        # picks up x86_64-linux-gnu vs aarch64-linux-gnu per matrix entry.
         for cfg in packaging/nfpm/*.yaml; do
-          nfpm pkg --config "$cfg" --packager deb --target dist/
+          envsubst < "$cfg" > "/tmp/$(basename "$cfg")"
+          nfpm pkg --config "/tmp/$(basename "$cfg")" --packager deb --target dist/
         done
         ls -la dist/
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Prebuilt binaries: [github.com/dolthub/doltlite/releases](https://github.com/dol
 
 ### macOS (arm64) / Linux (x86_64)
 
+Installs `doltlite` and `doltlite-remotesrv` to `/usr/local/bin`.
+
 ```
 sudo bash -c 'curl -fsSL https://github.com/dolthub/doltlite/releases/latest/download/install.sh | bash'
 ```

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Each install method places the same set of files (paths shown for `/usr/local`):
 - `lib/libdoltlite.a` — static library
 - `lib/libdoltlite.{so,dylib}` — shared library
 
-### macOS (arm64) / Linux (x86_64)
+### macOS (arm64) / Linux (x86_64 or arm64)
 
 ```
 sudo bash -c 'curl -fsSL https://github.com/dolthub/doltlite/releases/latest/download/install.sh | bash'
@@ -33,14 +33,17 @@ sudo bash -c 'curl -fsSL https://github.com/dolthub/doltlite/releases/latest/dow
 
 ### Debian / Ubuntu
 
+`.deb` packages ship for both `amd64` and `arm64`. Substitute `$ARCH` below:
+
 ```
 VER=0.10.3
+ARCH=amd64   # or arm64
 BASE=https://github.com/dolthub/doltlite/releases/download/v${VER}
-wget ${BASE}/libdoltlite0_${VER}_amd64.deb ${BASE}/doltlite_${VER}_amd64.deb
+wget ${BASE}/libdoltlite0_${VER}_${ARCH}.deb ${BASE}/doltlite_${VER}_${ARCH}.deb
 sudo dpkg -i libdoltlite0_*.deb doltlite_*.deb
 ```
 
-Add `libdoltlite-dev_${VER}_amd64.deb` for the header and static library.
+Add `libdoltlite-dev_${VER}_${ARCH}.deb` for the header and static library.
 
 ### Windows
 

--- a/README.md
+++ b/README.md
@@ -16,64 +16,29 @@ can be embedded in any language enabling local-first use cases for Dolt.
 
 ## Install
 
-Prebuilt binaries for each release are at
-[github.com/dolthub/doltlite/releases](https://github.com/dolthub/doltlite/releases).
+Prebuilt binaries: [github.com/dolthub/doltlite/releases](https://github.com/dolthub/doltlite/releases).
 
-### macOS
-
-DoltLite ships a prebuilt binary for Apple Silicon. The install script
-fetches the latest release and drops the `doltlite` and `doltlite-remotesrv`
-binaries in `/usr/local/bin`:
+### macOS (arm64) / Linux (x86_64)
 
 ```
 sudo bash -c 'curl -fsSL https://github.com/dolthub/doltlite/releases/latest/download/install.sh | bash'
 ```
 
-Honored env vars: `DOLTLITE_INSTALL_DIR` (default `/usr/local/bin`),
-`DOLTLITE_VERSION` (default: latest, e.g. `v0.10.3`).
-
-Intel Macs aren't part of the release matrix yet — build from source
-([Building](#building)) or run the arm64 binary under Rosetta.
-
-### Linux (curl install script — any distro)
-
-The same script as macOS works on x86\_64 Linux:
-
-```
-sudo bash -c 'curl -fsSL https://github.com/dolthub/doltlite/releases/latest/download/install.sh | bash'
-```
-
-### Linux (Debian / Ubuntu via `.deb`)
-
-Each release also ships three Debian packages mirroring the
-`sqlite3` / `libsqlite3-0` / `libsqlite3-dev` shape:
-
-| Package | What it contains |
-|---|---|
-| `doltlite_<ver>_amd64.deb` | `doltlite` and `doltlite-remotesrv` CLIs (`/usr/bin/`) |
-| `libdoltlite0_<ver>_amd64.deb` | runtime shared library (`/usr/lib/x86_64-linux-gnu/libdoltlite.so`) |
-| `libdoltlite-dev_<ver>_amd64.deb` | header (`/usr/include/doltlite.h`) and static library (`libdoltlite.a`) |
-
-Install everything for a CLI-only setup:
+### Debian / Ubuntu
 
 ```
 VER=0.10.3
 BASE=https://github.com/dolthub/doltlite/releases/download/v${VER}
-wget ${BASE}/libdoltlite0_${VER}_amd64.deb \
-     ${BASE}/doltlite_${VER}_amd64.deb
+wget ${BASE}/libdoltlite0_${VER}_amd64.deb ${BASE}/doltlite_${VER}_amd64.deb
 sudo dpkg -i libdoltlite0_*.deb doltlite_*.deb
 ```
 
-Add `libdoltlite-dev_${VER}_amd64.deb` if you want to compile programs that
-`#include <doltlite.h>` or statically link against `libdoltlite.a`.
-
-A hosted apt repo (so you can just `apt install doltlite`) is on the roadmap.
+Add `libdoltlite-dev_${VER}_amd64.deb` to compile against `<doltlite.h>` or `libdoltlite.a`.
 
 ### Windows
 
-Download `doltlite-tools-win-x64-<version>.zip` from the
-[releases page](https://github.com/dolthub/doltlite/releases), extract
-`doltlite.exe`, and add it to your `PATH`.
+Download `doltlite-tools-win-x64-<ver>.zip` from
+[releases](https://github.com/dolthub/doltlite/releases), extract `doltlite.exe`, add to `PATH`.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,14 @@ can be embedded in any language enabling local-first use cases for Dolt.
 
 Prebuilt binaries: [github.com/dolthub/doltlite/releases](https://github.com/dolthub/doltlite/releases).
 
-### macOS (arm64) / Linux (x86_64)
+Each install method places the same set of files (paths shown for `/usr/local`):
 
-Installs `doltlite` and `doltlite-remotesrv` to `/usr/local/bin`.
+- `bin/doltlite`, `bin/doltlite-remotesrv` — the CLI shell and remote sync server
+- `include/doltlite.h` — header for embedding
+- `lib/libdoltlite.a` — static library
+- `lib/libdoltlite.{so,dylib}` — shared library
+
+### macOS (arm64) / Linux (x86_64)
 
 ```
 sudo bash -c 'curl -fsSL https://github.com/dolthub/doltlite/releases/latest/download/install.sh | bash'
@@ -35,7 +40,7 @@ wget ${BASE}/libdoltlite0_${VER}_amd64.deb ${BASE}/doltlite_${VER}_amd64.deb
 sudo dpkg -i libdoltlite0_*.deb doltlite_*.deb
 ```
 
-Add `libdoltlite-dev_${VER}_amd64.deb` to compile against `<doltlite.h>` or `libdoltlite.a`.
+Add `libdoltlite-dev_${VER}_amd64.deb` for the header and static library.
 
 ### Windows
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,67 @@ prolly tree engine backed by a single-file content-addressed chunk store.
 [Why DoltLite?](https://www.dolthub.com/blog/2026-04-27-why-doltlite/) DoltLite
 can be embedded in any language enabling local-first use cases for Dolt.
 
+## Install
+
+Prebuilt binaries for each release are at
+[github.com/dolthub/doltlite/releases](https://github.com/dolthub/doltlite/releases).
+
+### macOS
+
+DoltLite ships a prebuilt binary for Apple Silicon. The install script
+fetches the latest release and drops the `doltlite` and `doltlite-remotesrv`
+binaries in `/usr/local/bin`:
+
+```
+sudo bash -c 'curl -fsSL https://github.com/dolthub/doltlite/releases/latest/download/install.sh | bash'
+```
+
+Honored env vars: `DOLTLITE_INSTALL_DIR` (default `/usr/local/bin`),
+`DOLTLITE_VERSION` (default: latest, e.g. `v0.10.3`).
+
+Intel Macs aren't part of the release matrix yet — build from source
+([Building](#building)) or run the arm64 binary under Rosetta.
+
+### Linux (curl install script — any distro)
+
+The same script as macOS works on x86\_64 Linux:
+
+```
+sudo bash -c 'curl -fsSL https://github.com/dolthub/doltlite/releases/latest/download/install.sh | bash'
+```
+
+### Linux (Debian / Ubuntu via `.deb`)
+
+Each release also ships three Debian packages mirroring the
+`sqlite3` / `libsqlite3-0` / `libsqlite3-dev` shape:
+
+| Package | What it contains |
+|---|---|
+| `doltlite_<ver>_amd64.deb` | `doltlite` and `doltlite-remotesrv` CLIs (`/usr/bin/`) |
+| `libdoltlite0_<ver>_amd64.deb` | runtime shared library (`/usr/lib/x86_64-linux-gnu/libdoltlite.so`) |
+| `libdoltlite-dev_<ver>_amd64.deb` | header (`/usr/include/doltlite.h`) and static library (`libdoltlite.a`) |
+
+Install everything for a CLI-only setup:
+
+```
+VER=0.10.3
+BASE=https://github.com/dolthub/doltlite/releases/download/v${VER}
+wget ${BASE}/libdoltlite0_${VER}_amd64.deb \
+     ${BASE}/doltlite_${VER}_amd64.deb
+sudo dpkg -i libdoltlite0_*.deb doltlite_*.deb
+```
+
+Add `libdoltlite-dev_${VER}_amd64.deb` if you want to compile programs that
+`#include <doltlite.h>` or statically link against `libdoltlite.a`.
+
+A hosted apt repo (so you can just `apt install doltlite`) is on the roadmap.
+
+### Windows
+
+Download `doltlite-tools-win-x64-<version>.zip` from the
+[releases page](https://github.com/dolthub/doltlite/releases), extract
+`doltlite.exe`, and add it to your `PATH`.
+
 ## Building
 
 ### macOS / Linux

--- a/install.sh
+++ b/install.sh
@@ -62,6 +62,32 @@ PREFIX="$(dirname "${INSTALL_DIR}")"
 INCLUDE_DIR="${PREFIX}/include"
 LIB_DIR="${PREFIX}/lib"
 
+# Fail fast with a helpful message if the user forgot sudo. /usr/local is
+# root-owned on most systems.
+can_write() {
+  local d="$1"
+  # Walk up to the first existing ancestor and check whether we could
+  # create/modify under it.
+  while [ ! -d "$d" ]; do
+    d="$(dirname "$d")"
+  done
+  [ -w "$d" ]
+}
+if [ "$(id -u)" -ne 0 ]; then
+  for d in "$INSTALL_DIR" "$INCLUDE_DIR" "$LIB_DIR"; do
+    if ! can_write "$d"; then
+      cat >&2 <<EOF
+doltlite: ${d} is not writable as $(id -un). Re-run with sudo:
+
+  sudo bash -c 'curl -fsSL https://github.com/dolthub/doltlite/releases/latest/download/install.sh | bash'
+
+Or set DOLTLITE_INSTALL_DIR to a directory you own (e.g. \$HOME/.local/bin).
+EOF
+      exit 1
+    fi
+  done
+fi
+
 # Pick the shared-library extension per platform.
 case "$PLATFORM" in
   linux) SHARED_EXT=".so" ;;

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Install the doltlite CLI and doltlite-remotesrv binaries from the latest
+# (or a pinned) GitHub release. Pipe me through bash:
+#
+#   sudo bash -c 'curl -fsSL https://github.com/dolthub/doltlite/releases/latest/download/install.sh | bash'
+#
+# Honored environment variables:
+#   DOLTLITE_INSTALL_DIR — target directory (default /usr/local/bin)
+#   DOLTLITE_VERSION     — pin to a specific version, e.g. v0.10.3
+#                          (default: the latest GitHub release)
+
+set -euo pipefail
+
+INSTALL_DIR="${DOLTLITE_INSTALL_DIR:-/usr/local/bin}"
+
+OS="$(uname -s)"
+case "$OS" in
+  Linux)  PLATFORM="linux" ;;
+  Darwin) PLATFORM="osx" ;;
+  *) echo "doltlite: unsupported OS '$OS' — try 'go install' from source" >&2; exit 1 ;;
+esac
+
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64|amd64) PKG_ARCH="x64" ;;
+  arm64|aarch64) PKG_ARCH="arm64" ;;
+  *) echo "doltlite: unsupported architecture '$ARCH'" >&2; exit 1 ;;
+esac
+
+TARGET="${PLATFORM}-${PKG_ARCH}"
+
+# The release matrix currently builds linux-x64, osx-arm64, and win-x64.
+# Other combinations don't have release artifacts; fall back to building
+# from source.
+case "$TARGET" in
+  linux-x64|osx-arm64) ;;
+  *)
+    echo "doltlite: no prebuilt binary for ${TARGET}." >&2
+    echo "Build from source — see https://github.com/dolthub/doltlite#building" >&2
+    exit 1
+    ;;
+esac
+
+# Resolve the version: pinned via env, or latest from GitHub.
+if [ -n "${DOLTLITE_VERSION:-}" ]; then
+  VERSION="$DOLTLITE_VERSION"
+else
+  VERSION="$(curl -fsSL https://api.github.com/repos/dolthub/doltlite/releases/latest \
+    | grep '"tag_name"' \
+    | head -1 \
+    | sed -E 's/.*"tag_name": "([^"]+)".*/\1/')"
+fi
+if [ -z "$VERSION" ]; then
+  echo "doltlite: failed to determine latest version" >&2
+  exit 1
+fi
+VERSION_NUM="${VERSION#v}"
+
+ZIP_NAME="doltlite-tools-${TARGET}-${VERSION_NUM}.zip"
+ZIP_URL="https://github.com/dolthub/doltlite/releases/download/${VERSION}/${ZIP_NAME}"
+
+TMP_DIR="$(mktemp -d -t doltlite-install-XXXXXX)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+echo "Downloading ${ZIP_URL}..."
+curl -fsSL -o "${TMP_DIR}/${ZIP_NAME}" "${ZIP_URL}"
+
+unzip -q -d "${TMP_DIR}" "${TMP_DIR}/${ZIP_NAME}"
+EXTRACTED_DIR="${TMP_DIR}/doltlite-tools-${TARGET}-${VERSION_NUM}"
+
+if [ ! -d "$EXTRACTED_DIR" ]; then
+  echo "doltlite: archive layout unexpected (missing ${EXTRACTED_DIR})" >&2
+  exit 1
+fi
+
+mkdir -p "${INSTALL_DIR}"
+for bin in doltlite doltlite-remotesrv; do
+  src="${EXTRACTED_DIR}/${bin}"
+  [ -f "$src" ] || continue
+  dst="${INSTALL_DIR}/${bin}"
+  install -m 0755 "$src" "$dst"
+  echo "Installed ${dst}"
+done
+
+cat <<EOF
+
+doltlite ${VERSION_NUM} installed.
+
+Verify with:
+  doltlite :memory: "SELECT dolt_version();"
+
+If ${INSTALL_DIR} is not on your \$PATH, add it or set
+DOLTLITE_INSTALL_DIR to a directory that is.
+EOF

--- a/install.sh
+++ b/install.sh
@@ -33,7 +33,7 @@ TARGET="${PLATFORM}-${PKG_ARCH}"
 # Other combinations don't have release artifacts; fall back to building
 # from source.
 case "$TARGET" in
-  linux-x64|osx-arm64) ;;
+  linux-x64|linux-arm64|osx-arm64) ;;
   *)
     echo "doltlite: no prebuilt binary for ${TARGET}." >&2
     echo "Build from source — see https://github.com/dolthub/doltlite#building" >&2

--- a/install.sh
+++ b/install.sh
@@ -56,31 +56,59 @@ if [ -z "$VERSION" ]; then
 fi
 VERSION_NUM="${VERSION#v}"
 
-ZIP_NAME="doltlite-tools-${TARGET}-${VERSION_NUM}.zip"
-ZIP_URL="https://github.com/dolthub/doltlite/releases/download/${VERSION}/${ZIP_NAME}"
+# INSTALL_DIR is the bin destination (default /usr/local/bin); PREFIX is
+# its parent — that's where include/ and lib/ land. Mirrors `make install`.
+PREFIX="$(dirname "${INSTALL_DIR}")"
+INCLUDE_DIR="${PREFIX}/include"
+LIB_DIR="${PREFIX}/lib"
+
+# Pick the shared-library extension per platform.
+case "$PLATFORM" in
+  linux) SHARED_EXT=".so" ;;
+  osx)   SHARED_EXT=".dylib" ;;
+esac
+
+TOOLS_ZIP="doltlite-tools-${TARGET}-${VERSION_NUM}.zip"
+LIB_ZIP="doltlite-lib-${TARGET}-${VERSION_NUM}.zip"
+BASE_URL="https://github.com/dolthub/doltlite/releases/download/${VERSION}"
 
 TMP_DIR="$(mktemp -d -t doltlite-install-XXXXXX)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
-echo "Downloading ${ZIP_URL}..."
-curl -fsSL -o "${TMP_DIR}/${ZIP_NAME}" "${ZIP_URL}"
+fetch() {
+  local name="$1"
+  echo "Downloading ${BASE_URL}/${name}..."
+  curl -fsSL -o "${TMP_DIR}/${name}" "${BASE_URL}/${name}"
+  unzip -q -d "${TMP_DIR}" "${TMP_DIR}/${name}"
+}
 
-unzip -q -d "${TMP_DIR}" "${TMP_DIR}/${ZIP_NAME}"
-EXTRACTED_DIR="${TMP_DIR}/doltlite-tools-${TARGET}-${VERSION_NUM}"
+fetch "${TOOLS_ZIP}"
+fetch "${LIB_ZIP}"
 
-if [ ! -d "$EXTRACTED_DIR" ]; then
-  echo "doltlite: archive layout unexpected (missing ${EXTRACTED_DIR})" >&2
-  exit 1
-fi
+TOOLS_DIR="${TMP_DIR}/doltlite-tools-${TARGET}-${VERSION_NUM}"
+LIB_SRC_DIR="${TMP_DIR}/doltlite-lib-${TARGET}-${VERSION_NUM}"
 
-mkdir -p "${INSTALL_DIR}"
+mkdir -p "${INSTALL_DIR}" "${INCLUDE_DIR}" "${LIB_DIR}"
+
 for bin in doltlite doltlite-remotesrv; do
-  src="${EXTRACTED_DIR}/${bin}"
+  src="${TOOLS_DIR}/${bin}"
   [ -f "$src" ] || continue
-  dst="${INSTALL_DIR}/${bin}"
-  install -m 0755 "$src" "$dst"
-  echo "Installed ${dst}"
+  install -m 0755 "$src" "${INSTALL_DIR}/${bin}"
+  echo "Installed ${INSTALL_DIR}/${bin}"
 done
+
+if [ -f "${LIB_SRC_DIR}/doltlite.h" ]; then
+  install -m 0644 "${LIB_SRC_DIR}/doltlite.h" "${INCLUDE_DIR}/doltlite.h"
+  echo "Installed ${INCLUDE_DIR}/doltlite.h"
+fi
+if [ -f "${LIB_SRC_DIR}/libdoltlite.a" ]; then
+  install -m 0644 "${LIB_SRC_DIR}/libdoltlite.a" "${LIB_DIR}/libdoltlite.a"
+  echo "Installed ${LIB_DIR}/libdoltlite.a"
+fi
+if [ -f "${LIB_SRC_DIR}/libdoltlite${SHARED_EXT}" ]; then
+  install -m 0755 "${LIB_SRC_DIR}/libdoltlite${SHARED_EXT}" "${LIB_DIR}/libdoltlite${SHARED_EXT}"
+  echo "Installed ${LIB_DIR}/libdoltlite${SHARED_EXT}"
+fi
 
 cat <<EOF
 

--- a/packaging/nfpm/doltlite.yaml
+++ b/packaging/nfpm/doltlite.yaml
@@ -1,0 +1,33 @@
+# nfpm config for the `doltlite` Debian package — the CLI shell and the
+# remote sync server, mirroring what the `sqlite3` apt package ships.
+# See https://nfpm.goreleaser.com/configuration/ for the schema.
+name: doltlite
+arch: "${PKG_ARCH}"
+platform: linux
+version: "${VERSION}"
+section: database
+priority: optional
+maintainer: DoltHub <team@dolthub.com>
+description: |
+  DoltLite — SQLite fork with Git-style version control.
+  Provides the doltlite SQL shell (drop-in replacement for sqlite3) and
+  the doltlite-remotesrv binary for serving a doltlite database to
+  remote clients.
+vendor: DoltHub
+homepage: https://github.com/dolthub/doltlite
+license: Apache-2.0
+
+depends:
+  - libdoltlite0 (= ${VERSION})
+
+contents:
+  - src: build/doltlite
+    dst: /usr/bin/doltlite
+    file_info:
+      mode: 0755
+  - src: build/doltlite-remotesrv
+    dst: /usr/bin/doltlite-remotesrv
+    file_info:
+      mode: 0755
+  - src: LICENSE.md
+    dst: /usr/share/doc/doltlite/copyright

--- a/packaging/nfpm/libdoltlite-dev.yaml
+++ b/packaging/nfpm/libdoltlite-dev.yaml
@@ -1,0 +1,32 @@
+# nfpm config for libdoltlite-dev — header + static library, mirroring
+# what `libsqlite3-dev` ships. Required to compile programs that
+# `#include <doltlite.h>` or want to statically link against
+# libdoltlite.a.
+name: libdoltlite-dev
+arch: "${PKG_ARCH}"
+platform: linux
+version: "${VERSION}"
+section: libdevel
+priority: optional
+maintainer: DoltHub <team@dolthub.com>
+description: |
+  DoltLite development files — header and static library for compiling
+  programs that link against doltlite. Companion to libdoltlite0.
+vendor: DoltHub
+homepage: https://github.com/dolthub/doltlite
+license: Apache-2.0
+
+depends:
+  - libdoltlite0 (= ${VERSION})
+
+contents:
+  - src: build/sqlite3.h
+    dst: /usr/include/doltlite.h
+    file_info:
+      mode: 0644
+  - src: build/libdoltlite.a
+    dst: /usr/lib/x86_64-linux-gnu/libdoltlite.a
+    file_info:
+      mode: 0644
+  - src: LICENSE.md
+    dst: /usr/share/doc/libdoltlite-dev/copyright

--- a/packaging/nfpm/libdoltlite-dev.yaml
+++ b/packaging/nfpm/libdoltlite-dev.yaml
@@ -25,7 +25,7 @@ contents:
     file_info:
       mode: 0644
   - src: build/libdoltlite.a
-    dst: /usr/lib/x86_64-linux-gnu/libdoltlite.a
+    dst: /usr/lib/${DEB_HOST_MULTIARCH}/libdoltlite.a
     file_info:
       mode: 0644
   - src: LICENSE.md

--- a/packaging/nfpm/libdoltlite0.yaml
+++ b/packaging/nfpm/libdoltlite0.yaml
@@ -1,0 +1,29 @@
+# nfpm config for libdoltlite0 — the runtime shared library, mirroring
+# what `libsqlite3-0` ships. Co-installable across major versions
+# (the `0` suffix is the ABI version, fixed at 0 until a breaking change).
+name: libdoltlite0
+arch: "${PKG_ARCH}"
+platform: linux
+version: "${VERSION}"
+section: libs
+priority: optional
+maintainer: DoltHub <team@dolthub.com>
+description: |
+  DoltLite shared library — runtime support for programs that link
+  against -ldoltlite. Includes the prolly-tree storage engine, BLAKE3
+  hashing, and the Dolt version-control SQL functions.
+vendor: DoltHub
+homepage: https://github.com/dolthub/doltlite
+license: Apache-2.0
+
+depends:
+  - libc6
+  - zlib1g
+
+contents:
+  - src: build/libdoltlite.so
+    dst: /usr/lib/x86_64-linux-gnu/libdoltlite.so
+    file_info:
+      mode: 0644
+  - src: LICENSE.md
+    dst: /usr/share/doc/libdoltlite0/copyright

--- a/packaging/nfpm/libdoltlite0.yaml
+++ b/packaging/nfpm/libdoltlite0.yaml
@@ -22,7 +22,7 @@ depends:
 
 contents:
   - src: build/libdoltlite.so
-    dst: /usr/lib/x86_64-linux-gnu/libdoltlite.so
+    dst: /usr/lib/${DEB_HOST_MULTIARCH}/libdoltlite.so
     file_info:
       mode: 0644
   - src: LICENSE.md


### PR DESCRIPTION
## Summary

Two install paths for *nix on every tagged release, plus a README `## Install` section that documents them. Linux builds and `.deb` packages now ship for both `amd64` and `arm64`.

### `install.sh` (any \*nix on `linux-x64`, `linux-arm64`, or `osx-arm64`)

A `curl | bash` style installer at the repo root, uploaded to each release as `install.sh`. Same UX dolt has — detects platform/arch, downloads the matching `doltlite-tools-*` and `doltlite-lib-*` zips, drops a complete set of files in a `make install`-style layout:

| Path | What |
|---|---|
| `/usr/local/bin/doltlite` | CLI shell (sqlite3-compatible) |
| `/usr/local/bin/doltlite-remotesrv` | remote sync server |
| `/usr/local/include/doltlite.h` | C header for embedding |
| `/usr/local/lib/libdoltlite.a` | static library |
| `/usr/local/lib/libdoltlite.{so,dylib}` | shared library |

```
sudo bash -c 'curl -fsSL https://github.com/dolthub/doltlite/releases/latest/download/install.sh | bash'
```

Honored env vars: `DOLTLITE_INSTALL_DIR` (default `/usr/local/bin`), `DOLTLITE_VERSION` (default: latest, pin like `v0.10.3`). Fails fast with a clear "re-run with sudo" message if any of the target dirs isn't writable.

### `.deb` packages (Debian / Ubuntu, `amd64` + `arm64`)

Three nfpm configs that mirror Debian's `sqlite3` / `libsqlite3-0` / `libsqlite3-dev` split:

| Package | Files |
|---|---|
| `doltlite_<ver>_<arch>.deb` | `/usr/bin/doltlite`, `/usr/bin/doltlite-remotesrv` |
| `libdoltlite0_<ver>_<arch>.deb` | `/usr/lib/{x86_64,aarch64}-linux-gnu/libdoltlite.so` |
| `libdoltlite-dev_<ver>_<arch>.deb` | `/usr/include/doltlite.h`, `libdoltlite.a` |

Built in the release workflow's `linux-x64` *and* `linux-arm64` matrix entries via `nfpm pkg`, attached to the GitHub release alongside the existing tarballs.

```
VER=0.10.3
ARCH=amd64    # or arm64
BASE=https://github.com/dolthub/doltlite/releases/download/v\${VER}
wget \${BASE}/libdoltlite0_\${VER}_\${ARCH}.deb \${BASE}/doltlite_\${VER}_\${ARCH}.deb
sudo dpkg -i libdoltlite0_*.deb doltlite_*.deb
```

### linux-arm64 release matrix entry

Uses GitHub's free `ubuntu-24.04-arm` runner for native arm64 builds — no QEMU/cross-compile complexity. The existing build steps work as-is; the only new wiring is per-matrix variables (`pkg_arch`, `deb_multiarch`, `nfpm_arch`) consumed by the packaging step.

nfpm's `${VAR}` substitution only applies to a fixed set of metadata fields (not `contents[].dst`), so the workflow renders the yamls through `envsubst` first to template `${DEB_HOST_MULTIARCH}` to the right value per arch.

## Why this shape

\#632 (Docker image) closed as won't-fix — SQLite, which doltlite positions itself as a drop-in for, doesn't ship one. The right move is to match SQLite's distribution channels, not dolt's. SQLite ships into Debian's official archive as the three-package split; getting into Debian official requires sponsorship and is slow, so phase 1 is `.deb` files attached to releases.

The `install.sh` path mirrors what dolt already does on *nix (their install script + curl|bash one-liner), giving us parity for casual installs.

## README `## Install` section

Added above `## Building`. Per-platform commands only — macOS arm64 and Linux (x86_64 or arm64) via `install.sh`, Debian/Ubuntu via `.deb`, Windows via the existing tools zip. The file inventory lives at the top of the section so users see what gets installed before picking a method.

## Out of scope for this PR

- **Hosted apt repo** (so `apt install doltlite` works without manual `wget` + `dpkg -i`). Follow-up — pick Cloudsmith / self-host / dolthub.com served, GPG sign the repo, push from CI.
- **Intel Mac (`osx-x64`).** Older macOS, lower priority. Build from source for now.
- **Other package managers** (brew, MacPorts, apk, dnf, AUR, chocolatey/scoop). Future PRs.

## Test plan

- [x] Built all three `.deb`s locally with macOS-resident nfpm against a staged `build/` dir for **both** archs: `dpkg-deb -c` confirms `/usr/lib/x86_64-linux-gnu/` for amd64 and `/usr/lib/aarch64-linux-gnu/` for arm64, no spurious conffiles; `dpkg-deb -I` shows correct `Architecture:`, `Depends:`, `Version:`.
- [x] Ran `install.sh` against the current `v0.10.4` release into a temp dir: downloads both tools and lib zips, installs all 5 files (CLIs + header + `.a` + `.dylib`), `doltlite :memory: \"SELECT dolt_version()\"` returns `v0.10.4`.
- [x] Permission check: unprivileged invocation against `/usr/local/bin` refuses with the sudo hint; writable user dir proceeds normally.
- [ ] Push a `v*` test tag (or trigger release.yml via dispatch) to confirm CI runs the new packaging steps end-to-end on both `ubuntu-latest` and `ubuntu-24.04-arm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)