### PR TITLE
add a homebrew-core-ready formula for doltlite

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ Each install method places the same set of files (paths shown for `/usr/local`):
 - `lib/libdoltlite.a` — static library
 - `lib/libdoltlite.{so,dylib}` — shared library
 
+### Homebrew (macOS / Linux)
+
+```
+brew install doltlite
+```
+
 ### macOS (arm64) / Linux (x86_64 or arm64)
 
 ```

--- a/packaging/homebrew/doltlite.rb
+++ b/packaging/homebrew/doltlite.rb
@@ -1,0 +1,36 @@
+# Homebrew formula for doltlite. Intended for submission to
+# Homebrew/homebrew-core — once accepted, `brew install doltlite` works
+# everywhere without a tap. Subsequent version bumps are opened
+# automatically by Homebrew's `BrewTestBot` because of the livecheck
+# block below (same pattern dolt uses).
+class Doltlite < Formula
+  desc "SQLite fork with Git-style version control via prolly trees"
+  homepage "https://github.com/dolthub/doltlite"
+  url "https://github.com/dolthub/doltlite/releases/download/v0.10.4/doltlite-autoconf-0.10.4.tar.gz"
+  sha256 "8a3244473e5a84664dda3e45ccd949691dd108a5efe05da0966948ac61fca7d8"
+  license "Apache-2.0"
+  head "https://github.com/dolthub/doltlite.git", branch: "master"
+
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
+  depends_on "zlib"
+
+  def install
+    mkdir "build" do
+      system "../configure"
+      system "make", "doltlite", "doltlite-remotesrv", "doltlite-lib"
+      bin.install "doltlite", "doltlite-remotesrv"
+      include.install "sqlite3.h" => "doltlite.h"
+      lib.install "libdoltlite.a"
+      lib.install OS.mac? ? "libdoltlite.dylib" : "libdoltlite.so"
+    end
+  end
+
+  test do
+    output = shell_output("#{bin}/doltlite :memory: 'SELECT dolt_version();'")
+    assert_match(/v?\d+\.\d+\.\d+/, output)
+  end
+end


### PR DESCRIPTION
## Summary

Adds `packaging/homebrew/doltlite.rb` — a complete, submittable Homebrew formula. **The plan is to land this in `Homebrew/homebrew-core` directly, same place dolt and sqlite live**, not a per-vendor tap. After acceptance, the install reduces to:

```
brew install doltlite
```

## Why homebrew-core, not a custom tap

The earlier version of this PR set up a `dolthub/homebrew-tap` with a release-workflow job that bumped the formula on every tag. Looked at how dolt actually distributes:

```
$ brew info --json=v2 dolt | jq '.formulae[0].tap'
"homebrew/core"
```

— so dolt is in `Homebrew/homebrew-core` directly, no tap. Same story for sqlite. The tap dance would have added infrastructure (new repo, PAT secret, custom workflow) for a UX strictly worse than the upstream path. Notability is fine for homebrew-core too — doltlite has 90 stars and a published blog post, clear of their 30-star threshold.

After acceptance, version bumps are handled by Homebrew's `BrewTestBot`: the formula's `livecheck` block (`strategy :github_latest`) tells it to watch this repo's releases and open update PRs to homebrew-core automatically. **No workflow code on our side**, no token to manage.

## What's in this PR

- **`packaging/homebrew/doltlite.rb`** — formula pinned to v0.10.4 (latest release at PR time) with the real `sha256` of `doltlite-autoconf-0.10.4.tar.gz`. Builds doltlite + doltlite-remotesrv + libdoltlite from source in a `build/` subdir, installs the same five-file layout that `install.sh` and the `.deb` packages produce:
  - `bin/doltlite`, `bin/doltlite-remotesrv`
  - `include/doltlite.h`
  - `lib/libdoltlite.a` + `lib/libdoltlite.{dylib,so}`
- **`test do`** block exercises `doltlite :memory: 'SELECT dolt_version()'`.
- **`livecheck`** block so future bumps are automated.
- **README** — `Homebrew (macOS / Linux)` subsection now reads `brew install doltlite` (works post-acceptance).

## Next step (manual, outside this PR)

Open a PR against [Homebrew/homebrew-core](https://github.com/Homebrew/homebrew-core) adding `Formula/d/doltlite.rb` with the same content as `packaging/homebrew/doltlite.rb` here. Per their [adding-new-formulae](https://docs.brew.sh/Adding-Software-to-Homebrew) docs:

```
brew create https://github.com/dolthub/doltlite/releases/download/v0.10.4/doltlite-autoconf-0.10.4.tar.gz
# replace generated formula with packaging/homebrew/doltlite.rb
brew audit --strict --new doltlite
brew install --build-from-source doltlite
brew test doltlite
# Then open a PR to Homebrew/homebrew-core
```

## Test plan

- [x] `brew style packaging/homebrew/doltlite.rb` (local) — passes
- [x] Manually rendered + ran `brew install --build-from-source` against the formula in a sandboxed prefix — installed the five files, `doltlite :memory: 'SELECT dolt_version()'` returns `v0.10.4`.
- [ ] Submit to homebrew-core; run their CI (`brew audit --strict --new`, `brew test`) once they pick up the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)