### PR TITLE
make the autoconf release tarball actually build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,10 +36,26 @@ jobs:
     - name: Package autoconf source
       run: |
         VERSION=${GITHUB_REF_NAME#v}
+        # All files the autosetup-driven configure + make pipeline needs to
+        # build doltlite, doltlite-remotesrv, and libdoltlite from a clean
+        # extracted tarball with no git history. Validated by running
+        # `./configure && make doltlite doltlite-remotesrv doltlite-lib`
+        # against a tarball with exactly this file list.
+        #
+        # Stamp DOLTLITE_VERSION into a sidecar file so main.mk's
+        # `$(shell git describe ...)` fallback doesn't end up as "dev"
+        # when the tarball is extracted outside git.
+        echo "v${VERSION}" > .dolt_release_version
         tar czf doltlite-autoconf-${VERSION}.tar.gz \
           --transform "s,^,doltlite-autoconf-${VERSION}/," \
-          configure Makefile.in main.mk src/ ext/ \
-          sqlite3.c sqlite3.h
+          configure Makefile.in Makefile.linux-generic Makefile.msc main.mk \
+          auto.def VERSION manifest manifest.tags manifest.uuid \
+          pragma.h magic.txt lempar.c \
+          sqlite3.pc.in sqlite.pc.in \
+          src/ ext/ tool/ autosetup/ autoconf/ \
+          sqlite3.c sqlite3.h sqlite3ext.h sqlite3session.h \
+          .dolt_release_version
+        rm .dolt_release_version
 
     - name: Package wasm distribution
       run: |

--- a/main.mk
+++ b/main.mk
@@ -588,7 +588,7 @@ PROLLY_OBJS = prolly_hash.o prolly_xxhash.o blake3.o blake3_portable.o blake3_di
               doltlite_http_remote.o doltlite_remotesrv.o
 
 DOLTLITE_PROLLY ?= 1
-DOLTLITE_VERSION ?= $(shell git describe --tags --always 2>/dev/null || echo "dev")
+DOLTLITE_VERSION ?= $(shell cat $(TOP)/.dolt_release_version 2>/dev/null || git describe --tags --always 2>/dev/null || echo "dev")
 ifeq ($(DOLTLITE_PROLLY),1)
   # Replace btree.o/pager.o/wal.o/btmutex.o/backup.o with prolly engine
   LIBOBJS0 := $(filter-out btree.o pager.o wal.o btmutex.o backup.o,$(LIBOBJS0))


### PR DESCRIPTION
## Summary

The release workflow's autoconf source tarball was missing a bunch of files that the autosetup-driven `./configure && make` pipeline needs. Extracting it and running `./configure` gave:

```
../configure: 1: ../autosetup/autosetup-find-tclsh: not found
```

Discovered while submitting [Homebrew/homebrew-core#282089](https://github.com/Homebrew/homebrew-core/pull/282089) (doltlite formula) — their Linux CI does `brew install --build-from-source` against this tarball and failed.

## What was missing

The old "Package autoconf source" step packed only `configure Makefile.in main.mk src/ ext/ sqlite3.c sqlite3.h`. The autosetup-driven configure also needs:

- `autosetup/` (the autosetup helper scripts — `autosetup-find-tclsh`, etc.)
- `auto.def` (the autosetup project definition)
- `VERSION` (read by auto.def)
- `manifest`, `manifest.tags`, `manifest.uuid` (fossil-style source identification)
- `pragma.h`, `magic.txt`, `lempar.c` (referenced by main.mk)
- `sqlite3.pc.in`, `sqlite.pc.in` (pkg-config templates that configure renders)
- `tool/` (build helpers main.mk shells out to)
- `autoconf/` (autoconf-style alternative build path)
- `sqlite3ext.h`, `sqlite3session.h` (public headers)
- `Makefile.linux-generic`, `Makefile.msc` (per-platform Makefile alternatives)

Validated by building a tarball with exactly the new file list, extracting it, and running `./configure && make doltlite doltlite-remotesrv doltlite-lib` — all three targets build cleanly, `doltlite :memory: 'SELECT dolt_version()'` works.

## Version stamping for out-of-tree builds

`main.mk` had:

```make
DOLTLITE_VERSION ?= $(shell git describe --tags --always 2>/dev/null || echo "dev")
```

Outside a git checkout (Homebrew, distro packagers, anyone extracting the tarball) this fell back to "dev" — meaning `SELECT dolt_version();` returns "dev" not "v0.10.6". The release workflow now writes a `.dolt_release_version` sidecar file into the tarball, and `main.mk` reads it before falling back to git describe.

Source-tree builds and prebuilt-binary CI builds are unaffected (no sidecar, falls through to git describe).

## Why nobody noticed before

The prebuilt binary builds in `release.yml`'s `build` job run *inside the git checkout*, so they always had every file + a working git history. The autoconf tarball was only consumed by `doltlite-node`'s `scripts/download.js`, which doesn't run `./configure` at all — it just extracts source files and feeds them to `build-amalgamation.js`. The Homebrew submission was the first consumer that exercised the full `./configure && make install` path on the tarball.

## Test plan

- [x] Locally built a tarball with the new file list, extracted it, ran `./configure && make doltlite doltlite-remotesrv doltlite-lib` — all targets built, `./doltlite :memory: 'SELECT dolt_version();'` returns the stamped version
- [ ] After merge, push a `v0.10.6` tag; verify the new release's `doltlite-autoconf-0.10.6.tar.gz` builds clean when extracted outside the repo
- [ ] Update [Homebrew/homebrew-core#282089](https://github.com/Homebrew/homebrew-core/pull/282089) to point at v0.10.6 and re-run their CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)