### PR TITLE
Optimize count over non-null columns for Doltlite

### DIFF
--- a/src/select.c
+++ b/src/select.c
@@ -6780,6 +6780,22 @@ static void finalizeAggFunctions(Parse *pParse, AggInfo *pAggInfo){
   }
 }
 
+#ifdef DOLTLITE_PROLLY
+static int aggregateArgCanBeNull(const Expr *pExpr){
+  if( pExpr->op==TK_AGG_COLUMN && pExpr->y.pTab!=0 ){
+    return ExprHasProperty(pExpr, EP_CanBeNull)
+#ifdef SQLITE_ALLOW_ROWID_IN_VIEW
+        || (pExpr->iColumn==XN_ROWID && IsView(pExpr->y.pTab))
+#endif
+        || (pExpr->iColumn>=0
+            && pExpr->y.pTab->aCol!=0
+            && ALWAYS(pExpr->iColumn<pExpr->y.pTab->nCol)
+            && pExpr->y.pTab->aCol[pExpr->iColumn].notNull==0);
+  }
+  return sqlite3ExprCanBeNull(pExpr);
+}
+#endif
+
 /*
 ** Generate code that will update the accumulator memory cells for an
 ** aggregate based on the current cursor position.
@@ -6894,7 +6910,19 @@ static void updateAccumulator(
       nArg = pList->nExpr;
       regAgg = sqlite3GetTempRange(pParse, nArg);
       regDistinct = regAgg;
+#ifdef DOLTLITE_PROLLY
+      if( nArg==1
+       && sqlite3StrICmp(pF->pFunc->zName, "count")==0
+       && pF->iDistinct<0
+       && 0==aggregateArgCanBeNull(pList->a[0].pExpr)
+      ){
+        sqlite3VdbeAddOp2(v, OP_Integer, 1, regAgg);
+      }else{
+        sqlite3ExprCodeExprList(pParse, pList, regAgg, 0, SQLITE_ECEL_DUP);
+      }
+#else
       sqlite3ExprCodeExprList(pParse, pList, regAgg, 0, SQLITE_ECEL_DUP);
+#endif
     }else{
       nArg = 0;
       regAgg = 0;

--- a/test/sql_oracle_test.sh
+++ b/test/sql_oracle_test.sh
@@ -6474,6 +6474,17 @@ SELECT min(score), max(score), sum(score) FROM t WHERE active = 1;
 PRAGMA integrity_check;
 "
 
+oracle "cat120_count_not_null_column" "
+CREATE TABLE t(k INTEGER NOT NULL, v INTEGER);
+INSERT INTO t VALUES (1,NULL),(2,7),(3,NULL);
+SELECT count(k), count(*), count(v) FROM t;
+CREATE TABLE a(k INTEGER NOT NULL);
+CREATE TABLE b(k INTEGER NOT NULL);
+INSERT INTO a VALUES(1),(2),(3);
+INSERT INTO b VALUES(1),(3);
+SELECT count(b.k), count(*) FROM a LEFT JOIN b USING(k);
+"
+
 # ════════════════════════════════════════════════════════════════════
 echo ""
 echo "================================"


### PR DESCRIPTION
## Summary
- avoid decoding aggregate arguments for Doltlite count(non_null_column) by emitting count(1)
- preserve nullable-column and outer-join count semantics
- add oracle coverage for count() over NOT NULL columns and left joins

## Testing
- bash test/sql_oracle_test.sh ./doltlite ./sqlite3
- local amplified BLOB PK benchmark: covering_index_scan ~1.74x, index_join_scan ~1.83x vs SQLite
- BENCH_RUNS=5 BLOB PK read metrics stayed below 2x; global 2x ceiling still blocked by autocommit write metrics