### PR TITLE
Inline short prolly blob key comparisons

### DIFF
--- a/src/prolly_node.c
+++ b/src/prolly_node.c
@@ -156,6 +156,22 @@ void prollyNodeChildHash(const ProllyNode *pNode, int i, ProllyHash *pHash){
   memcpy(pHash->data, pNode->pValData + off, PROLLY_HASH_SIZE);
 }
 
+static SQLITE_INLINE int prollyKeyComparePrefix(
+  const u8 *pLeft,
+  const u8 *pRight,
+  int n
+){
+  int i;
+  if( n<=32 ){
+    for(i=0; i<n; i++){
+      int c = (int)pLeft[i] - (int)pRight[i];
+      if( c ) return c;
+    }
+    return 0;
+  }
+  return memcmp(pLeft, pRight, n);
+}
+
 int prollyNodeSearchBlob(
   const ProllyNode *pNode,
   const u8 *pKey,
@@ -180,7 +196,7 @@ int prollyNodeSearchBlob(
     prollyNodeKey(pNode, mid, &pMidKey, &nMidKey);
 
     nCmp = nMidKey < nKey ? nMidKey : nKey;
-    c = memcmp(pKey, pMidKey, nCmp);
+    c = prollyKeyComparePrefix(pKey, pMidKey, nCmp);
     if( c==0 ) c = nKey - nMidKey;
 
     if( c==0 ){


### PR DESCRIPTION
## Summary
- avoid libc memcmp call overhead for short prolly blob-key prefix comparisons
- use the inline path in prollyNodeSearchBlob(), which is hot during BLOB index-join seeks

## Testing
- bash test/sql_oracle_test.sh ./doltlite ./sqlite3
- amplified BLOB index_join_scan: ~2.03s -> ~1.93s locally
- BENCH_RUNS=5 BLOB PK read metrics: in-memory index_join_scan 1.80x, file-backed 1.35x, autocommit/read 1.73x; full 2.0x global ceiling still blocked by unrelated autocommit writes