### PR TITLE
Size sort-key buffers exactly

### DIFF
--- a/src/sortkey.c
+++ b/src/sortkey.c
@@ -2,6 +2,7 @@
 #ifdef DOLTLITE_PROLLY
 
 #include "sortkey.h"
+#include <limits.h>
 #include <string.h>
 
 static int skGetVarint32(const u8 *p, u32 *pVal){
@@ -66,7 +67,12 @@ static u32 collTextLen(int coll, const u8 *pData, u32 nData){
   return nData;
 }
 
-static int encodedFieldSize(u32 serialType, const u8 *pData, u32 nData, int coll){
+static sqlite3_int64 encodedFieldSize(
+  u32 serialType,
+  const u8 *pData,
+  u32 nData,
+  int coll
+){
   u8 tag = serialTypeTag(serialType);
   switch( tag ){
     case SORTKEY_NULL:
@@ -93,22 +99,22 @@ static int encodedFieldSize(u32 serialType, const u8 *pData, u32 nData, int coll
       return 9;
     case SORTKEY_TEXT: {
       u32 n = collTextLen(coll, pData, nData);
-      int extra = 0;
+      sqlite3_int64 extra = 0;
       u32 i;
       for(i = 0; i < n; i++){
         u8 b = pData[i];
         if( coll==SORTKEY_COLL_NOCASE && b >= 'A' && b <= 'Z' ) b += 32;
         if( b == 0x00 ) extra++;
       }
-      return 1 + (int)n + extra + 2;
+      return 1 + (sqlite3_int64)n + extra + 2;
     }
     case SORTKEY_BLOB: {
-      int extra = 0;
+      sqlite3_int64 extra = 0;
       u32 i;
       for(i = 0; i < nData; i++){
         if( pData[i] == 0x00 ) extra++;
       }
-      return 1 + (int)nData + extra + 2;
+      return 1 + (sqlite3_int64)nData + extra + 2;
     }
     default:
       return 1;
@@ -250,6 +256,7 @@ static int sortKeyEncode(const u8 *pRec, int nRec, u8 *pOut, int nMaxFields,
   u32 hdrOff;
   u32 dataOff;
   int outPos = 0;
+  sqlite3_int64 outSize = 0;
   int nField = 0;
 
   if( nRec <= 0 ) return -1;
@@ -269,7 +276,7 @@ static int sortKeyEncode(const u8 *pRec, int nRec, u8 *pOut, int nMaxFields,
     hdrOff += skGetVarint32(pRec + hdrOff, &serialType);
     fieldLen = serialTypeLen(serialType);
 
-    if( dataOff + fieldLen > (u32)nRec ) return -1;
+    if( fieldLen > (u32)nRec - dataOff ) return -1;
     pField = pRec + dataOff;
     coll = collFromKeyInfo(pKeyInfo, nField);
 
@@ -293,14 +300,19 @@ static int sortKeyEncode(const u8 *pRec, int nRec, u8 *pOut, int nMaxFields,
           break;
       }
     }else{
-      outPos += encodedFieldSize(serialType, pField, fieldLen, coll);
+      sqlite3_int64 nFieldSize =
+          encodedFieldSize(serialType, pField, fieldLen, coll);
+      if( nFieldSize > INT_MAX || outSize > INT_MAX - nFieldSize ){
+        return -2;
+      }
+      outSize += nFieldSize;
     }
 
     dataOff += fieldLen;
     nField++;
   }
 
-  return outPos;
+  return pOut ? outPos : (int)outSize;
 }
 
 int sortKeySize(const u8 *pRec, int nRec){
@@ -322,22 +334,25 @@ int sortKeyFromRecordPrefixCollBuffer(
   u8 **ppBuf, int *pnAlloc, int *pnOut
 ){
   int nSize;
-  int nEstimate;
+  int nAlloc;
 
   *pnOut = 0;
 
-  nEstimate = 9 * nRec + 16;
-  if( nEstimate < 64 ) nEstimate = 64;
+  nSize = sortKeyEncode(pRec, nRec, 0, nKeyField, pKeyInfo);
+  if( nSize == -2 ) return SQLITE_TOOBIG;
+  if( nSize < 0 ) return SQLITE_CORRUPT;
 
-  if( *pnAlloc < nEstimate ){
-    u8 *pNew = (u8*)sqlite3_realloc(*ppBuf, nEstimate);
+  nAlloc = nSize < 64 ? 64 : nSize;
+  if( *pnAlloc < nAlloc ){
+    u8 *pNew = (u8*)sqlite3_realloc64(*ppBuf, (sqlite3_uint64)nAlloc);
     if( !pNew ) return SQLITE_NOMEM;
     *ppBuf = pNew;
-    *pnAlloc = nEstimate;
+    *pnAlloc = nAlloc;
   }
 
-  nSize = sortKeyEncode(pRec, nRec, *ppBuf, nKeyField, pKeyInfo);
-  if( nSize < 0 ) return SQLITE_CORRUPT;
+  if( nSize != sortKeyEncode(pRec, nRec, *ppBuf, nKeyField, pKeyInfo) ){
+    return SQLITE_CORRUPT;
+  }
   *pnOut = nSize;
   return SQLITE_OK;
 }

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -2025,6 +2025,49 @@ static void run_sortkey_numeric_blob_roundtrip(void){
   }
 }
 
+static void run_sortkey_buffer_exact_size(void){
+  u8 record[73];
+  u8 *pSortKey = 0;
+  u8 *pRoundTrip = 0;
+  int nAlloc = 1;
+  int nSortKey = 0;
+  int nRoundTrip = 0;
+  int rc;
+  int i;
+
+  printf("=== Sortkey Buffer Exact Size Test ===\n\n");
+
+  record[0] = 0x03;
+  record[1] = 0x81;
+  record[2] = 0x18;
+  for(i=0; i<70; i++){
+    record[3+i] = (u8)('a' + (i % 26));
+  }
+  record[3+17] = 0x00;
+  record[3+53] = 0x00;
+
+  pSortKey = sqlite3_malloc64((sqlite3_uint64)nAlloc);
+  check("sortkey_buffer_initial_alloc_ok", pSortKey!=0);
+  if( !pSortKey ) return;
+
+  rc = sortKeyFromRecordPrefixCollBuffer(
+      record, (int)sizeof(record), 0, 0, &pSortKey, &nAlloc, &nSortKey);
+  check("sortkey_buffer_exact_size_encode_ok", rc==SQLITE_OK);
+  check("sortkey_buffer_exact_size_output", nSortKey==75);
+  check("sortkey_buffer_exact_size_allocation", nAlloc==75);
+
+  if( rc==SQLITE_OK ){
+    rc = recordFromSortKey(pSortKey, nSortKey, &pRoundTrip, &nRoundTrip);
+    check("sortkey_buffer_exact_size_decode_ok", rc==SQLITE_OK);
+    check("sortkey_buffer_exact_size_roundtrips",
+      nRoundTrip==(int)sizeof(record)
+      && memcmp(pRoundTrip, record, sizeof(record))==0);
+  }
+
+  sqlite3_free(pSortKey);
+  sqlite3_free(pRoundTrip);
+}
+
 static void run_reload_refs_transactional(void){
   ChunkStore cs;
   ProllyHash emptyHash;
@@ -6415,6 +6458,7 @@ static const RegressionCase aCases[] = {
   { "sortkey_two_numeric_roundtrip", "Sortkey Two Numeric Roundtrip Test", run_sortkey_two_numeric_roundtrip },
   { "sortkey_numeric_text_roundtrip", "Sortkey Numeric Text Roundtrip Test", run_sortkey_numeric_text_roundtrip },
   { "sortkey_numeric_blob_roundtrip", "Sortkey Numeric Blob Roundtrip Test", run_sortkey_numeric_blob_roundtrip },
+  { "sortkey_buffer_exact_size", "Sortkey Buffer Exact Size Test", run_sortkey_buffer_exact_size },
   { "reload_refs_transactional", "Reload Refs Transactional Test", run_reload_refs_transactional },
   { "refresh_refs_corruption_preserves_state", "Refresh Corrupt Refs State Preservation Test", run_refresh_refs_corruption_preserves_state },
   { "prolly_node_corruption", "Prolly Node Corruption Test", run_prolly_node_corruption },


### PR DESCRIPTION
## Summary
- compute the encoded sort-key size before reallocating reusable buffers
- keep sort-key size arithmetic in sqlite3_int64 and return SQLITE_TOOBIG before int overflow
- use sqlite3_realloc64 and add a C regression for exact buffer sizing with escaped blob keys

## Tests
- make doltlite
- make libdoltlite.a (from build/)
- cc -g -I. -I../src -o doltlite_regression_test_c ../test/doltlite_regression_test_c.c libdoltlite.a -lz -lpthread -lm && ./doltlite_regression_test_c sortkey_buffer_exact_size (from build/)
- bash ../test/doltlite_regression_test_c.sh (from build/)
- bash test/review_regression_test.sh
- bash test/doltlite_parity.sh