### PR TITLE
docs: fix README version drift and macOS install footguns

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Each install method places the same set of files (paths shown for `/usr/local`):
 - `lib/libdoltlite.a` — static library
 - `lib/libdoltlite.{so,dylib}` — shared library
 
-### macOS (arm64) / Linux (x86_64 or arm64)
+### macOS (Apple Silicon) / Linux (x86_64 or arm64)
 
 ```
 sudo bash -c 'curl -fsSL https://github.com/dolthub/doltlite/releases/latest/download/install.sh | bash'
@@ -36,7 +36,7 @@ sudo bash -c 'curl -fsSL https://github.com/dolthub/doltlite/releases/latest/dow
 `.deb` packages ship for both `amd64` and `arm64`. Substitute `$ARCH` below:
 
 ```
-VER=0.10.3
+VER=$(curl -fsSL https://api.github.com/repos/dolthub/doltlite/releases/latest | jq -r .tag_name | sed 's/^v//')
 ARCH=amd64   # or arm64
 BASE=https://github.com/dolthub/doltlite/releases/download/v${VER}
 wget ${BASE}/libdoltlite0_${VER}_${ARCH}.deb ${BASE}/doltlite_${VER}_${ARCH}.deb
@@ -173,7 +173,12 @@ standard `sqlite3` module, zero code changes:
 
 ```bash
 cd build
+# Linux:
 LD_PRELOAD=./libdoltlite.so python3 ../examples/quickstart.py
+# macOS: Python's _sqlite3 is statically linked against the system SQLite,
+# so LD_PRELOAD / DYLD_INSERT_LIBRARIES won't redirect it. Load doltlite
+# explicitly via ctypes instead:
+#   python3 -c 'import ctypes; ctypes.CDLL("./libdoltlite.dylib"); import runpy; runpy.run_path("../examples/quickstart.py")'
 ```
 
 **Go** ([`examples/go/main.go`](examples/go/main.go)) — uses
@@ -682,7 +687,7 @@ have are sent.
 
 ```sql
 SELECT dolt_version();
--- "v0.7.4"
+-- e.g. "v0.10.6"
 ```
 
 Zero-arg scalar returning the build's version string (from


### PR DESCRIPTION
## Summary

Four user-facing drift fixes in the README:

- **D1**: `.deb` install example was pinned to `VER=0.10.3` (4 versions stale; current is v0.10.6). Replaced with a `latest`-resolver one-liner that matches `install.sh`'s `tag_name` lookup style.
- **D2**: `dolt_version()` example showed `-- "v0.7.4"` (14 versions stale). Replaced with `-- e.g. "v0.10.6"` so future drift is obvious.
- **D3**: README header said "macOS (arm64)" while `install.sh:36` only ships `osx-arm64` — clarified to "macOS (Apple Silicon)" so users with Intel Macs aren't misled.
- **D4**: Python quickstart only showed `LD_PRELOAD=./libdoltlite.so`, which silently does nothing on macOS because Python's `_sqlite3` is statically linked against the system SQLite. Added a `ctypes.CDLL` fallback alongside the Linux command.

No new sections, no restructuring — just the four drift points.

## Test plan

- [ ] CI green
- [ ] Visually verify the rendered README on the PR page
- [ ] (Optional) Run the new `VER=$(curl ...)` snippet on a Debian box to confirm `jq` is the right resolver dep

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

[Claude Code](https://claude.com/claude-code) generated.