### PR TITLE
fix: don't UAF azFrom on FK realloc failure

### DIFF
--- a/src/doltlite_merge_constraints.c
+++ b/src/doltlite_merge_constraints.c
@@ -1691,15 +1691,19 @@ int doltliteDetectMergeFkViolations(
 
       if( nCol >= nAlloc ){
         int nNew = nAlloc ? nAlloc*2 : 4;
-        char **azFromNew = sqlite3_realloc64(azFrom, (sqlite3_int64)nNew * sizeof(char*));
-        char **azToNew = sqlite3_realloc64(azTo, (sqlite3_int64)nNew * sizeof(char*));
-        if( !azFromNew || !azToNew ){
-          sqlite3_free(azFromNew);
-          sqlite3_free(azToNew);
+        char **azFromNew;
+        char **azToNew;
+        azFromNew = sqlite3_realloc64(azFrom, (sqlite3_int64)nNew * sizeof(char*));
+        if( !azFromNew ){
           rc = SQLITE_NOMEM;
           break;
         }
         azFrom = azFromNew;
+        azToNew = sqlite3_realloc64(azTo, (sqlite3_int64)nNew * sizeof(char*));
+        if( !azToNew ){
+          rc = SQLITE_NOMEM;
+          break;
+        }
         azTo = azToNew;
         nAlloc = nNew;
       }


### PR DESCRIPTION
## Summary

Fix a use-after-free in `findFkViolations` in `src/doltlite_merge_constraints.c`. When growing the `azFrom` / `azTo` column-list buffers, both reallocs were issued before either return value was checked. If `sqlite3_realloc64(azFrom, ...)` succeeded but `sqlite3_realloc64(azTo, ...)` failed, `azFrom` was left pointing to memory that `realloc` had already moved or freed; the subsequent `freeStringArray(azFrom, nCol)` cleanup at the bottom of the loop then walks freed memory (UAF, and in the moved-memory case, double-free of the new block via `sqlite3_free(azFromNew)`).

The fix is straightforward: realloc each buffer sequentially, and only assign the local pointer (`azFrom = azFromNew`) after that realloc succeeds. On failure, simply set `rc = SQLITE_NOMEM` and break; the original buffers (or the just-assigned new buffer) remain owned by `azFrom`/`azTo` and are freed correctly by the existing cleanup path.

Found in code review by two independent reviewers.

## Test plan

- [x] `make doltlite` builds cleanly with no new warnings
- [ ] Existing FK/unique-violation merge tests still pass (not run locally; covered by CI)