### PR TITLE
fix: dlReadVarint signals short input via return-0 sentinel

### DIFF
--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -191,13 +191,22 @@ static int parseRecordFields(const u8 *pRec, int nRec,
   if(!pRec || nRec<1) { *ppFields=0; *pnFields=0; return 0; }
   pPos = pRec; pEnd = pRec + nRec;
   hdrBytes = dlReadVarint(pPos, pEnd, &hdrSize);
+  if(hdrBytes<=0){ *ppFields=0; *pnFields=0; return -1; }
   pPos += hdrBytes;
+  if((u64)hdrBytes > hdrSize || hdrSize > (u64)nRec){
+    *ppFields=0; *pnFields=0; return -1;
+  }
   pHdrEnd = pRec + (int)hdrSize;
   bodyOff = (int)hdrSize;
 
   while(pPos < pHdrEnd && pPos < pEnd){
     u64 st; int stBytes, sz;
     stBytes = dlReadVarint(pPos, pHdrEnd, &st);
+    if(stBytes<=0){
+      sqlite3_free(aFields);
+      *ppFields=0; *pnFields=0;
+      return -1;
+    }
     pPos += stBytes;
     sz = dlSerialTypeLen(st);
 

--- a/src/doltlite_schema_merge.c
+++ b/src/doltlite_schema_merge.c
@@ -95,12 +95,15 @@ int migrateDiffCb(void *pArg, const ProllyDiffChange *pChange){
     int hdrBytes, off;
 
     hdrBytes = dlReadVarint(hp, hpEnd, &hdrSize);
+    if( hdrBytes<=0 ) return SQLITE_CORRUPT;
+    if( (u64)hdrBytes > hdrSize || hdrSize > (u64)nVal ) return SQLITE_CORRUPT;
     hp += hdrBytes;
     off = (int)hdrSize;
 
     while( hp < pVal+hdrSize && hp < hpEnd && nFields<64 ){
       u64 st;
       int stBytes = dlReadVarint(hp, pVal+hdrSize, &st);
+      if( stBytes<=0 ) return SQLITE_CORRUPT;
       hp += stBytes;
       aType[nFields] = (int)st;
       aOffset[nFields] = off;

--- a/src/prolly_record.h
+++ b/src/prolly_record.h
@@ -4,6 +4,12 @@
 
 #include "sqliteInt.h"
 
+/*
+** Read a SQLite-style varint from p (bounded by pEnd) into *pVal.
+** Returns the number of bytes consumed, or 0 on short input.
+** A return of 0 is the sentinel for "truncated"; callers MUST check
+** this to distinguish a parse failure from a legitimate single-byte 0.
+*/
 static inline int dlReadVarint(const u8 *p, const u8 *pEnd, u64 *pVal){
   u64 v;
   int i;
@@ -15,6 +21,10 @@ static inline int dlReadVarint(const u8 *p, const u8 *pEnd, u64 *pVal){
     v = (v << 7) | (p[i] & 0x7f);
     if( !(p[i] & 0x80) ){ *pVal = v; return i + 1; }
   }
+  /* Either we exhausted 9 bytes without termination (valid) or we ran
+  ** off pEnd before finding a terminating byte. The latter is short
+  ** input; signal it with the 0 sentinel. */
+  if( i < 9 ){ *pVal = 0; return 0; }
   *pVal = v;
   return i;
 }


### PR DESCRIPTION
## Summary
- `dlReadVarint` previously returned 1 byte consumed with `*pVal=0` on truncated input — indistinguishable from a legit single-byte 0. Truncated records would parse "successfully" with `hdrSize=0` and the parser would read past the buffer.
- Made `dlReadVarint` return `0` as a sentinel for short input (both at start `p >= pEnd` and when the varint doesn't terminate before `pEnd`).
- Each caller now checks the return and aborts with `SQLITE_CORRUPT` (or surrounding equivalent) on short input.

## Files changed
- `src/prolly_record.h` — return-0 sentinel for both short-start and run-off cases; updated docstring.
- `src/doltlite_merge.c` — `parseRecordFields` now returns `-1` on parse failure (existing callers already handle `<0`).
- `src/doltlite_schema_merge.c` — `migrateDiffCb` now returns `SQLITE_CORRUPT` on parse failure.
- `src/doltlite_record.c` — no caller changes needed; existing `<=0` checks already catch the sentinel.

## Test plan
- [x] `make doltlite` clean compile, no warnings touching the changed code.
- [x] Smoke test: `./doltlite :memory: "SELECT 1;"` works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)