### PR TITLE
fix: bounds checks, allocation overflow, and pOurVal leak in conflict vtables

### DIFF
--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -171,7 +171,7 @@ static int loadAllConflicts(
     int nl, nc;
     if( p+2 > data+nData ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
     nl = p[0]|(p[1]<<8); p+=2;
-    if( nl<0 || p+nl > data+nData ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
+    if( nl<0 || (size_t)nl > (size_t)(data+nData - p) ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
     aTables[i].zName = sqlite3_malloc(nl+1);
     if( !aTables[i].zName ){ rc = SQLITE_NOMEM; goto conflicts_cleanup; }
     memcpy(aTables[i].zName, p, nl); aTables[i].zName[nl]=0;
@@ -179,17 +179,23 @@ static int loadAllConflicts(
     if( p+4 > data+nData ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
     nc = p[0]|(p[1]<<8)|(p[2]<<16)|(p[3]<<24); p+=4;
     if( nc<0 ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
+    /* Validate that nc*sizeof(struct ConflictRow) fits within remaining bytes
+    ** (each row carries at least 4+8+4+4+4 = 24 header bytes), and use
+    ** sqlite3_malloc64 to avoid 32-bit multiplication overflow. */
+    if( (sqlite3_uint64)nc > (sqlite3_uint64)(data+nData - p) ){
+      rc = SQLITE_CORRUPT; goto conflicts_cleanup;
+    }
     aTables[i].nConflicts = nc;
-    aTables[i].aRows = sqlite3_malloc(nc * (int)sizeof(struct ConflictRow));
+    aTables[i].aRows = sqlite3_malloc64((sqlite3_uint64)nc * sizeof(struct ConflictRow));
     if( !aTables[i].aRows ){ rc = SQLITE_NOMEM; goto conflicts_cleanup; }
-    memset(aTables[i].aRows, 0, nc * (int)sizeof(struct ConflictRow));
+    memset(aTables[i].aRows, 0, (sqlite3_uint64)nc * sizeof(struct ConflictRow));
 
     for(j=0; j<nc; j++){
       struct ConflictRow *cr = &aTables[i].aRows[j];
       int kvl, bvl, ovl, tvl;
       if( p+4 > data+nData ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
       kvl = p[0]|(p[1]<<8)|(p[2]<<16)|(p[3]<<24); p+=4;
-      if( kvl<0 || p+kvl > data+nData ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
+      if( kvl<0 || (size_t)kvl > (size_t)(data+nData - p) ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
       if(kvl>0){
         cr->pKey = sqlite3_malloc(kvl);
         if( !cr->pKey ){ rc = SQLITE_NOMEM; goto conflicts_cleanup; }
@@ -203,7 +209,7 @@ static int loadAllConflicts(
       p+=8;
       if( p+4 > data+nData ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
       bvl = p[0]|(p[1]<<8)|(p[2]<<16)|(p[3]<<24); p+=4;
-      if( bvl<0 || p+bvl > data+nData ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
+      if( bvl<0 || (size_t)bvl > (size_t)(data+nData - p) ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
       if(bvl>0){
         cr->pBaseVal = sqlite3_malloc(bvl);
         if( !cr->pBaseVal ){ rc = SQLITE_NOMEM; goto conflicts_cleanup; }
@@ -213,7 +219,7 @@ static int loadAllConflicts(
       p += bvl;
       if( p+4 > data+nData ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
       ovl = p[0]|(p[1]<<8)|(p[2]<<16)|(p[3]<<24); p+=4;
-      if( ovl<0 || p+ovl > data+nData ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
+      if( ovl<0 || (size_t)ovl > (size_t)(data+nData - p) ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
       if(ovl>0){
         cr->pOurVal = sqlite3_malloc(ovl);
         if( !cr->pOurVal ){ rc = SQLITE_NOMEM; goto conflicts_cleanup; }
@@ -223,7 +229,7 @@ static int loadAllConflicts(
       p += ovl;
       if( p+4 > data+nData ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
       tvl = p[0]|(p[1]<<8)|(p[2]<<16)|(p[3]<<24); p+=4;
-      if( tvl<0 || p+tvl > data+nData ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
+      if( tvl<0 || (size_t)tvl > (size_t)(data+nData - p) ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
       if(tvl>0){
         cr->pTheirVal = sqlite3_malloc(tvl);
         if( !cr->pTheirVal ){ rc = SQLITE_NOMEM; goto conflicts_cleanup; }

--- a/src/doltlite_constraint_violations.c
+++ b/src/doltlite_constraint_violations.c
@@ -221,7 +221,7 @@ static int loadAllViolations(
     int nl, nr;
     if( p+2 > data+nData ){ rc = SQLITE_CORRUPT; goto fail; }
     nl = p[0] | (p[1]<<8); p += 2;
-    if( nl<0 || p+nl > data+nData ){ rc = SQLITE_CORRUPT; goto fail; }
+    if( nl<0 || (size_t)nl > (size_t)(data+nData - p) ){ rc = SQLITE_CORRUPT; goto fail; }
     aTables[i].zName = sqlite3_malloc(nl+1);
     if( !aTables[i].zName ){ rc = SQLITE_NOMEM; goto fail; }
     memcpy(aTables[i].zName, p, nl); aTables[i].zName[nl] = 0;
@@ -229,10 +229,16 @@ static int loadAllViolations(
     if( p+4 > data+nData ){ rc = SQLITE_CORRUPT; goto fail; }
     nr = p[0]|(p[1]<<8)|(p[2]<<16)|(p[3]<<24); p+=4;
     if( nr<0 ){ rc = SQLITE_CORRUPT; goto fail; }
+    /* Validate that nr rows can possibly fit in remaining bytes (each row
+    ** carries at least 1+4+8+4+4 = 21 header bytes), and use
+    ** sqlite3_malloc64 to avoid 32-bit multiplication overflow. */
+    if( (sqlite3_uint64)nr > (sqlite3_uint64)(data+nData - p) ){
+      rc = SQLITE_CORRUPT; goto fail;
+    }
     aTables[i].nRows = nr;
-    aTables[i].aRows = sqlite3_malloc(nr ? nr * (int)sizeof(ConstraintViolationRow) : 1);
+    aTables[i].aRows = sqlite3_malloc64(nr ? (sqlite3_uint64)nr * sizeof(ConstraintViolationRow) : 1);
     if( !aTables[i].aRows ){ rc = SQLITE_NOMEM; goto fail; }
-    memset(aTables[i].aRows, 0, nr ? nr * (int)sizeof(ConstraintViolationRow) : 1);
+    memset(aTables[i].aRows, 0, nr ? (sqlite3_uint64)nr * sizeof(ConstraintViolationRow) : 1);
 
     for(j=0; j<nr; j++){
       ConstraintViolationRow *r = &aTables[i].aRows[j];
@@ -241,7 +247,7 @@ static int loadAllViolations(
       r->violationType = *p++;
       if( p+4 > data+nData ){ rc = SQLITE_CORRUPT; goto fail; }
       kvl = p[0]|(p[1]<<8)|(p[2]<<16)|(p[3]<<24); p+=4;
-      if( kvl<0 || p+kvl > data+nData ){ rc = SQLITE_CORRUPT; goto fail; }
+      if( kvl<0 || (size_t)kvl > (size_t)(data+nData - p) ){ rc = SQLITE_CORRUPT; goto fail; }
       if( kvl>0 ){
         rc = dupBytes(p, kvl, &r->pKey);
         if( rc!=SQLITE_OK ) goto fail;
@@ -255,7 +261,7 @@ static int loadAllViolations(
       p += 8;
       if( p+4 > data+nData ){ rc = SQLITE_CORRUPT; goto fail; }
       vvl = p[0]|(p[1]<<8)|(p[2]<<16)|(p[3]<<24); p+=4;
-      if( vvl<0 || p+vvl > data+nData ){ rc = SQLITE_CORRUPT; goto fail; }
+      if( vvl<0 || (size_t)vvl > (size_t)(data+nData - p) ){ rc = SQLITE_CORRUPT; goto fail; }
       if( vvl>0 ){
         rc = dupBytes(p, vvl, &r->pVal);
         if( rc!=SQLITE_OK ) goto fail;
@@ -264,7 +270,7 @@ static int loadAllViolations(
       p += vvl;
       if( p+4 > data+nData ){ rc = SQLITE_CORRUPT; goto fail; }
       nil_ = p[0]|(p[1]<<8)|(p[2]<<16)|(p[3]<<24); p+=4;
-      if( nil_<0 || p+nil_ > data+nData ){ rc = SQLITE_CORRUPT; goto fail; }
+      if( nil_<0 || (size_t)nil_ > (size_t)(data+nData - p) ){ rc = SQLITE_CORRUPT; goto fail; }
       if( nil_>0 ){
         r->zInfo = sqlite3_malloc(nil_+1);
         if( !r->zInfo ){ rc = SQLITE_NOMEM; goto fail; }

--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -1169,6 +1169,7 @@ static void freeConflictRows(struct ConflictRow *aRows, int nRows){
   for(i=0; i<nRows; i++){
     sqlite3_free(aRows[i].pKey);
     sqlite3_free(aRows[i].pBaseVal);
+    sqlite3_free(aRows[i].pOurVal);
     sqlite3_free(aRows[i].pTheirVal);
   }
   sqlite3_free(aRows);


### PR DESCRIPTION
## Summary

Three related issues in the conflict/constraint-violation vtable deserialization paths.

- **B1 (critical) — pointer-overflow bypasses bounds checks.** The pattern `if (p + kvl > data + nData)` is UB in C when an attacker-controlled `kvl` (parsed from chunk data) is near `INT_MAX`: `p + kvl` overflows past the end and the check can pass on the wrong side, leading to OOB `memcpy` reads. Rewrote 9 sites as bytes-remaining arithmetic on unsigned types: 5 in `src/doltlite_conflicts.c` (lines 174, 192, 206, 216, 226) and 4 in `src/doltlite_constraint_violations.c` (lines 224, 244, 258, 267). Each site still rejects negative values explicitly before the unsigned compare.
- **B2 (high) — integer overflow in row-array allocation.** `sqlite3_malloc(nc * (int)sizeof(struct ConflictRow))` with attacker-controlled `nc` could wrap to a small int, undersize the allocation, and OOB-write in the populate loop. Switched to `sqlite3_malloc64((sqlite3_uint64)nc * sizeof(...))` and added a row-count sanity check against remaining bytes (each row carries a fixed-byte header, so `nc > remaining` is corrupt). Applied in `src/doltlite_conflicts.c:183` and `src/doltlite_constraint_violations.c:233`.
- **B3 (medium) — `freeConflictRows` leaked `pOurVal`.** Added `sqlite3_free(aRows[i].pOurVal)` to match `freeRowMergeCtx` in `src/doltlite_merge.c`.

No semantics change for well-formed chunks; only malformed/adversarial input is now rejected instead of being interpreted unsafely.

## Test plan

- [x] `make doltlite` — clean compile, no warnings
- [ ] CI conflict/constraint-violation vtable suites still pass (no semantics change for well-formed data)
- [ ] No new tests this round; test gaps tracked separately

Generated with [Claude Code](https://claude.com/claude-code)