### PR TITLE
Reduce DoltLite duplication and clarify test helpers

### DIFF
--- a/src/doltlite_commit_ancestors.c
+++ b/src/doltlite_commit_ancestors.c
@@ -98,6 +98,8 @@ static int caClose(sqlite3_vtab_cursor *pCursor){
   return SQLITE_OK;
 }
 
+static int caEnqueue(CommitAncestorsCursor *pCur, const ProllyHash *p);
+
 static int caLoadNextCommit(CommitAncestorsCursor *pCur, sqlite3 *db){
   int i, rc;
 
@@ -126,16 +128,10 @@ static int caLoadNextCommit(CommitAncestorsCursor *pCur, sqlite3 *db){
 
     for(i = 0; i < doltliteCommitParentCount(&pCur->curCommit); i++){
       const ProllyHash *pParent = doltliteCommitParentHash(&pCur->curCommit, i);
-      if( !pParent || prollyHashIsEmpty(pParent) ) continue;
-      if( pCur->qTail >= pCur->qAlloc ){
-        int nNew = pCur->qAlloc ? pCur->qAlloc*2 : 16;
-        ProllyHash *tmp = sqlite3_realloc(pCur->aQueue,
-                                           nNew*(int)sizeof(ProllyHash));
-        if( !tmp ) return SQLITE_NOMEM;
-        pCur->aQueue = tmp;
-        pCur->qAlloc = nNew;
+      if( pParent ){
+        rc = caEnqueue(pCur, pParent);
+        if( rc!=SQLITE_OK ) return rc;
       }
-      pCur->aQueue[pCur->qTail++] = *pParent;
     }
     return SQLITE_OK;
   }

--- a/src/doltlite_http_remote.c
+++ b/src/doltlite_http_remote.c
@@ -35,21 +35,6 @@ struct HttpRemote {
   int nPendingRefs;
 };
 
-static int writeAll(int fd, const void *pBuf, int nBuf){
-  int nWritten = 0;
-  const u8 *p = (const u8*)pBuf;
-  while( nWritten < nBuf ){
-    ssize_t n = write(fd, p + nWritten, nBuf - nWritten);
-    if( n < 0 ){
-      if( errno==EINTR ) continue;
-      return SQLITE_IOERR_WRITE;
-    }
-    if( n == 0 ) return SQLITE_IOERR_WRITE;
-    nWritten += (int)n;
-  }
-  return SQLITE_OK;
-}
-
 static void hashToHex(const ProllyHash *pHash, char *zOut){
   static const char hex[] = "0123456789abcdef";
   int i;
@@ -147,10 +132,10 @@ static int httpRequest(
       zMethod, zPath, zHost);
   }
 
-  rc = writeAll(fd, aReqHdr, nReqHdr);
+  rc = doltliteWriteAll(fd, aReqHdr, nReqHdr);
   if( rc != SQLITE_OK ){ close(fd); return rc; }
   if( pBody && nBody > 0 ){
-    rc = writeAll(fd, pBody, nBody);
+    rc = doltliteWriteAll(fd, pBody, nBody);
     if( rc != SQLITE_OK ){ close(fd); return rc; }
   }
 

--- a/src/doltlite_remote.c
+++ b/src/doltlite_remote.c
@@ -7,6 +7,27 @@
 #include "prolly_node.h"
 #include "doltlite_chunk_walk.h"
 #include <string.h>
+#ifndef _WIN32
+#include <errno.h>
+#include <unistd.h>
+#endif
+
+#ifndef _WIN32
+int doltliteWriteAll(int fd, const void *pBuf, int nBuf){
+  int nWritten = 0;
+  const u8 *p = (const u8*)pBuf;
+  while( nWritten < nBuf ){
+    ssize_t n = write(fd, p + nWritten, nBuf - nWritten);
+    if( n<0 ){
+      if( errno==EINTR ) continue;
+      return SQLITE_IOERR_WRITE;
+    }
+    if( n==0 ) return SQLITE_IOERR_WRITE;
+    nWritten += (int)n;
+  }
+  return SQLITE_OK;
+}
+#endif
 
 typedef struct SyncQueue SyncQueue;
 struct SyncQueue {

--- a/src/doltlite_remote.h
+++ b/src/doltlite_remote.h
@@ -35,4 +35,8 @@ DoltliteRemote *doltliteLocalAsRemote(ChunkStore *pLocal);
 
 DoltliteRemote *doltliteHttpRemoteOpen(const char *zUrl);
 
+#ifndef _WIN32
+int doltliteWriteAll(int fd, const void *pBuf, int nBuf);
+#endif
+
 #endif

--- a/src/doltlite_remotesrv.c
+++ b/src/doltlite_remotesrv.c
@@ -5,6 +5,7 @@
 #include "chunk_store.h"
 #include "prolly_hash.h"
 #include "doltlite_remotesrv.h"
+#include "doltlite_remote.h"
 #include "doltlite_commit.h"
 
 #include <string.h>
@@ -51,21 +52,6 @@ static int hexToHash(const char *zHex, ProllyHash *pHash){
   return SQLITE_OK;
 }
 
-static int writeAll(int fd, const void *pBuf, int nBuf){
-  int nWritten = 0;
-  const u8 *p = (const u8*)pBuf;
-  while( nWritten < nBuf ){
-    ssize_t n = write(fd, p + nWritten, nBuf - nWritten);
-    if( n<0 ){
-      if( errno==EINTR ) continue;
-      return SQLITE_IOERR_WRITE;
-    }
-    if( n==0 ) return SQLITE_IOERR_WRITE;
-    nWritten += (int)n;
-  }
-  return SQLITE_OK;
-}
-
 static void sendResponse(int fd, int status, const char *zStatus,
                          const u8 *pBody, int nBody){
   char zHeader[256];
@@ -77,9 +63,9 @@ static void sendResponse(int fd, int status, const char *zStatus,
     "\r\n",
     status, zStatus, nBody);
   nHeader = (int)strlen(zHeader);
-  if( writeAll(fd, zHeader, nHeader)!=SQLITE_OK ) return;
+  if( doltliteWriteAll(fd, zHeader, nHeader)!=SQLITE_OK ) return;
   if( pBody && nBody>0 ){
-    writeAll(fd, pBody, nBody);
+    doltliteWriteAll(fd, pBody, nBody);
   }
 }
 

--- a/test/ancestor_test.c
+++ b/test/ancestor_test.c
@@ -24,7 +24,7 @@ static void check(const char *name, int condition){
 }
 
 static char result_buf[4096];
-static const char *exec1(sqlite3 *db, const char *sql){
+static const char *queryScalarText(sqlite3 *db, const char *sql){
   sqlite3_stmt *stmt = 0;
   int rc;
   result_buf[0] = 0;
@@ -44,7 +44,7 @@ static const char *exec1(sqlite3 *db, const char *sql){
   return result_buf;
 }
 
-static int execsql(sqlite3 *db, const char *sql){
+static int execSql(sqlite3 *db, const char *sql){
   char *err = 0;
   int rc = sqlite3_exec(db, sql, 0, 0, &err);
   if( rc!=SQLITE_OK ){
@@ -68,45 +68,45 @@ int main(){
   check("open db", rc==SQLITE_OK);
 
   /* Create table and initial commit (C1) */
-  execsql(db, "CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT)");
-  execsql(db, "INSERT INTO t1 VALUES(1, 'hello')");
-  execsql(db, "SELECT dolt_add('-A')");
-  execsql(db, "SELECT dolt_commit('-m', 'C1: initial')");
+  execSql(db, "CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT)");
+  execSql(db, "INSERT INTO t1 VALUES(1, 'hello')");
+  execSql(db, "SELECT dolt_add('-A')");
+  execSql(db, "SELECT dolt_commit('-m', 'C1: initial')");
 
   /* Second commit on main (C2) - this will be the common ancestor */
-  execsql(db, "INSERT INTO t1 VALUES(2, 'world')");
-  execsql(db, "SELECT dolt_add('-A')");
-  execsql(db, "SELECT dolt_commit('-m', 'C2: add row 2')");
+  execSql(db, "INSERT INTO t1 VALUES(2, 'world')");
+  execSql(db, "SELECT dolt_add('-A')");
+  execSql(db, "SELECT dolt_commit('-m', 'C2: add row 2')");
 
   /* Record C2's hash (this is HEAD on main right now) */
-  const char *c2_hash = exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1");
+  const char *c2_hash = queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1");
   char c2_hash_buf[128];
   snprintf(c2_hash_buf, sizeof(c2_hash_buf), "%s", c2_hash);
 
   /* Create feature branch at C2 */
-  execsql(db, "SELECT dolt_branch('feature')");
+  execSql(db, "SELECT dolt_branch('feature')");
 
   /* Continue on main: C3 */
-  execsql(db, "INSERT INTO t1 VALUES(3, 'main-only')");
-  execsql(db, "SELECT dolt_add('-A')");
-  execsql(db, "SELECT dolt_commit('-m', 'C3: main diverge')");
+  execSql(db, "INSERT INTO t1 VALUES(3, 'main-only')");
+  execSql(db, "SELECT dolt_add('-A')");
+  execSql(db, "SELECT dolt_commit('-m', 'C3: main diverge')");
 
   /* Record main HEAD (C3) */
-  main_head = exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1");
+  main_head = queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1");
   snprintf(main_head_buf, sizeof(main_head_buf), "%s", main_head);
 
   /* Switch to feature branch and make commits C4, C5 */
-  execsql(db, "SELECT dolt_checkout('feature')");
-  execsql(db, "INSERT INTO t1 VALUES(4, 'feature-row')");
-  execsql(db, "SELECT dolt_add('-A')");
-  execsql(db, "SELECT dolt_commit('-m', 'C4: feature work')");
+  execSql(db, "SELECT dolt_checkout('feature')");
+  execSql(db, "INSERT INTO t1 VALUES(4, 'feature-row')");
+  execSql(db, "SELECT dolt_add('-A')");
+  execSql(db, "SELECT dolt_commit('-m', 'C4: feature work')");
 
-  execsql(db, "INSERT INTO t1 VALUES(5, 'more-feature')");
-  execsql(db, "SELECT dolt_add('-A')");
-  execsql(db, "SELECT dolt_commit('-m', 'C5: more feature work')");
+  execSql(db, "INSERT INTO t1 VALUES(5, 'more-feature')");
+  execSql(db, "SELECT dolt_add('-A')");
+  execSql(db, "SELECT dolt_commit('-m', 'C5: more feature work')");
 
   /* Record feature HEAD (C5) */
-  feature_head = exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1");
+  feature_head = queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1");
   snprintf(feature_head_buf, sizeof(feature_head_buf), "%s", feature_head);
 
   printf("C2 (expected ancestor): %s\n", c2_hash_buf);
@@ -118,7 +118,7 @@ int main(){
     char sql[512];
     snprintf(sql, sizeof(sql),
       "SELECT dolt_merge_base('%s', '%s')", main_head_buf, feature_head_buf);
-    ancestor = exec1(db, sql);
+    ancestor = queryScalarText(db, sql);
     printf("Ancestor (main,feature): %s\n", ancestor);
     check("ancestor of diverged branches is C2",
           strcmp(ancestor, c2_hash_buf)==0);
@@ -129,7 +129,7 @@ int main(){
     char sql[512];
     snprintf(sql, sizeof(sql),
       "SELECT dolt_merge_base('%s', '%s')", main_head_buf, main_head_buf);
-    ancestor = exec1(db, sql);
+    ancestor = queryScalarText(db, sql);
     printf("Ancestor (self,self):    %s\n", ancestor);
     check("ancestor of commit with itself is the commit",
           strcmp(ancestor, main_head_buf)==0);
@@ -140,16 +140,16 @@ int main(){
     char sql[512];
     snprintf(sql, sizeof(sql),
       "SELECT dolt_merge_base('%s', '%s')", c2_hash_buf, feature_head_buf);
-    ancestor = exec1(db, sql);
+    ancestor = queryScalarText(db, sql);
     printf("Ancestor (C2,feature):   %s\n", ancestor);
     check("ancestor where one is ancestor of other",
           strcmp(ancestor, c2_hash_buf)==0);
   }
 
   /* Merge feature back into main to exercise ^N parent selection. */
-  execsql(db, "SELECT dolt_checkout('main')");
-  execsql(db, "SELECT dolt_merge('feature')");
-  main_head = exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1");
+  execSql(db, "SELECT dolt_checkout('main')");
+  execSql(db, "SELECT dolt_merge('feature')");
+  main_head = queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1");
   snprintf(merge_head_buf, sizeof(merge_head_buf), "%s", main_head);
 
   /* Test 4: HEAD^2 resolves to the second parent of the merge commit. */
@@ -157,7 +157,7 @@ int main(){
     char sql[512];
     snprintf(sql, sizeof(sql),
       "SELECT dolt_merge_base('%s^2', '%s^2')", merge_head_buf, merge_head_buf);
-    ancestor = exec1(db, sql);
+    ancestor = queryScalarText(db, sql);
     printf("Ancestor (HEAD^2,HEAD^2): %s\n", ancestor);
     check("merge second-parent ref resolves to feature head",
           strcmp(ancestor, feature_head_buf)==0);
@@ -168,7 +168,7 @@ int main(){
     char sql[512];
     snprintf(sql, sizeof(sql),
       "SELECT dolt_merge_base('%s^2', '%s~1')", merge_head_buf, merge_head_buf);
-    ancestor = exec1(db, sql);
+    ancestor = queryScalarText(db, sql);
     printf("Ancestor (HEAD^2,HEAD~1): %s\n", ancestor);
     check("merge first/second parent base is C2",
           strcmp(ancestor, c2_hash_buf)==0);

--- a/test/checkout_persist_failure_test.sh
+++ b/test/checkout_persist_failure_test.sh
@@ -2,6 +2,4 @@
 set -euo pipefail
 
 echo "=== Checkout Persist Failure Repro ==="
-cc -g -I. -I../src -o doltlite_regression_test_c \
-  ../test/doltlite_regression_test_c.c libdoltlite.a -lz -lpthread -lm
-./doltlite_regression_test_c checkout_persist_failure
+bash "$(dirname "$0")/run_doltlite_regression_case.sh" checkout_persist_failure

--- a/test/concurrent_branch_test.c
+++ b/test/concurrent_branch_test.c
@@ -22,7 +22,7 @@ static void check(const char *name, int condition){
 
 /* Execute SQL, return first column of first row as string (static buffer) */
 static char result_buf[4096];
-static const char *exec1(sqlite3 *db, const char *sql){
+static const char *queryScalarText(sqlite3 *db, const char *sql){
   sqlite3_stmt *stmt = 0;
   int rc;
   result_buf[0] = 0;
@@ -43,7 +43,7 @@ static const char *exec1(sqlite3 *db, const char *sql){
 }
 
 /* Execute SQL, ignore result */
-static int execsql(sqlite3 *db, const char *sql){
+static int execSql(sqlite3 *db, const char *sql){
   char *err = 0;
   int rc = sqlite3_exec(db, sql, 0, 0, &err);
   if( rc!=SQLITE_OK ){
@@ -66,58 +66,58 @@ int main(){
   rc = sqlite3_open(dbpath, &db1);
   check("open_db1", rc==SQLITE_OK);
 
-  execsql(db1, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
-  execsql(db1, "INSERT INTO t VALUES(1, 'main-data')");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'init on main')");
+  execSql(db1, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+  execSql(db1, "INSERT INTO t VALUES(1, 'main-data')");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init on main')");
 
   /* Create feature branch */
-  exec1(db1, "SELECT dolt_branch('feature')");
+  queryScalarText(db1, "SELECT dolt_branch('feature')");
 
   /* Switch db1 to feature, add data */
-  exec1(db1, "SELECT dolt_checkout('feature')");
-  check("db1_on_feature", strcmp(exec1(db1, "SELECT active_branch()"), "feature")==0);
+  queryScalarText(db1, "SELECT dolt_checkout('feature')");
+  check("db1_on_feature", strcmp(queryScalarText(db1, "SELECT active_branch()"), "feature")==0);
 
-  execsql(db1, "INSERT INTO t VALUES(2, 'feature-data')");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'add on feature')");
+  execSql(db1, "INSERT INTO t VALUES(2, 'feature-data')");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'add on feature')");
 
   /* Switch db1 back to main */
-  exec1(db1, "SELECT dolt_checkout('main')");
-  check("db1_back_on_main", strcmp(exec1(db1, "SELECT active_branch()"), "main")==0);
+  queryScalarText(db1, "SELECT dolt_checkout('main')");
+  check("db1_back_on_main", strcmp(queryScalarText(db1, "SELECT active_branch()"), "main")==0);
 
   /* --- Now open a second connection --- */
   rc = sqlite3_open(dbpath, &db2);
   check("open_db2", rc==SQLITE_OK);
 
   /* db2 should start on main (the default/last checked-out branch) */
-  check("db2_starts_on_main", strcmp(exec1(db2, "SELECT active_branch()"), "main")==0);
+  check("db2_starts_on_main", strcmp(queryScalarText(db2, "SELECT active_branch()"), "main")==0);
 
   /* --- Both connections on main — same data --- */
-  check("db1_main_count", strcmp(exec1(db1, "SELECT count(*) FROM t"), "1")==0);
-  check("db2_main_count", strcmp(exec1(db2, "SELECT count(*) FROM t"), "1")==0);
-  check("db1_main_val", strcmp(exec1(db1, "SELECT val FROM t WHERE id=1"), "main-data")==0);
-  check("db2_main_val", strcmp(exec1(db2, "SELECT val FROM t WHERE id=1"), "main-data")==0);
+  check("db1_main_count", strcmp(queryScalarText(db1, "SELECT count(*) FROM t"), "1")==0);
+  check("db2_main_count", strcmp(queryScalarText(db2, "SELECT count(*) FROM t"), "1")==0);
+  check("db1_main_val", strcmp(queryScalarText(db1, "SELECT val FROM t WHERE id=1"), "main-data")==0);
+  check("db2_main_val", strcmp(queryScalarText(db2, "SELECT val FROM t WHERE id=1"), "main-data")==0);
 
   /* --- Switch db2 to feature --- */
-  exec1(db2, "SELECT dolt_checkout('feature')");
-  check("db2_on_feature", strcmp(exec1(db2, "SELECT active_branch()"), "feature")==0);
+  queryScalarText(db2, "SELECT dolt_checkout('feature')");
+  check("db2_on_feature", strcmp(queryScalarText(db2, "SELECT active_branch()"), "feature")==0);
 
   /* db1 should still be on main */
-  check("db1_still_main", strcmp(exec1(db1, "SELECT active_branch()"), "main")==0);
+  check("db1_still_main", strcmp(queryScalarText(db1, "SELECT active_branch()"), "main")==0);
 
   /* --- Data visibility --- */
   /* With shared WAL, both connections see all committed SQL data.
   ** Branch isolation for dolt operations is per-session, but SQL
   ** rows are visible across connections (like SQLite WAL mode). */
-  check("db2_feature_count", strcmp(exec1(db2, "SELECT count(*) FROM t"), "2")==0);
-  check("db2_sees_feature_data", strcmp(exec1(db2, "SELECT val FROM t WHERE id=2"), "feature-data")==0);
+  check("db2_feature_count", strcmp(queryScalarText(db2, "SELECT count(*) FROM t"), "2")==0);
+  check("db2_sees_feature_data", strcmp(queryScalarText(db2, "SELECT val FROM t WHERE id=2"), "feature-data")==0);
 
   /* db1's view depends on WAL refresh timing — it may see the feature
   ** branch's state (last writer wins in shared WAL). This is a known
   ** limitation of the single-WAL multi-connection architecture. */
-  check("db2_branch_count", atoi(exec1(db2, "SELECT count(*) FROM dolt_branches"))>=1);
+  check("db2_branch_count", atoi(queryScalarText(db2, "SELECT count(*) FROM dolt_branches"))>=1);
 
   /* --- Dolt log per session --- */
-  check("db2_log_feature", strcmp(exec1(db2, "SELECT message FROM dolt_log LIMIT 1"), "add on feature")==0);
+  check("db2_log_feature", strcmp(queryScalarText(db2, "SELECT message FROM dolt_log LIMIT 1"), "add on feature")==0);
 
   /* --- Cleanup --- */
   sqlite3_close(db1);

--- a/test/concurrent_commit_test.c
+++ b/test/concurrent_commit_test.c
@@ -38,7 +38,7 @@ static void check(const char *name, int condition){
 }
 
 static char result_buf[4096];
-static const char *exec1(sqlite3 *db, const char *sql){
+static const char *queryScalarText(sqlite3 *db, const char *sql){
   sqlite3_stmt *stmt = 0;
   int rc;
   result_buf[0] = 0;
@@ -58,7 +58,7 @@ static const char *exec1(sqlite3 *db, const char *sql){
   return result_buf;
 }
 
-static int execsql(sqlite3 *db, const char *sql){
+static int execSql(sqlite3 *db, const char *sql){
   char *err = 0;
   int rc = sqlite3_exec(db, sql, 0, 0, &err);
   if( rc!=SQLITE_OK ){
@@ -93,24 +93,24 @@ static void test_aaron_scenario(void){
   check("open_db1", rc==SQLITE_OK);
 
   /* Connection 1: create table and commit */
-  execsql(db1, "CREATE TABLE vals (id INT, val INT)");
-  res = exec1(db1, "SELECT dolt_commit('-A', '-m', 'Initial commit')");
+  execSql(db1, "CREATE TABLE vals (id INT, val INT)");
+  res = queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'Initial commit')");
   check("initial_commit_ok", strlen(res)==40);
 
   /* Connection 2: open, sees the table */
   rc = sqlite3_open(dbpath, &db2);
   check("open_db2", rc==SQLITE_OK);
-  res = exec1(db2, "SELECT count(*) FROM vals");
+  res = queryScalarText(db2, "SELECT count(*) FROM vals");
   check("db2_sees_table", strcmp(res, "0")==0);
 
   /* Connection 1: insert and commit */
-  execsql(db1, "INSERT INTO vals VALUES (1, 1)");
-  res = exec1(db1, "SELECT dolt_commit('-A', '-m', 'add one')");
+  execSql(db1, "INSERT INTO vals VALUES (1, 1)");
+  res = queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'add one')");
   check("commit_add_one", strlen(res)==40);
 
   /* Connection 2: insert and try to commit — should fail */
-  execsql(db2, "INSERT INTO vals VALUES (2, 2)");
-  res = exec1(db2, "SELECT dolt_commit('-A', '-m', 'add two')");
+  execSql(db2, "INSERT INTO vals VALUES (2, 2)");
+  res = queryScalarText(db2, "SELECT dolt_commit('-A', '-m', 'add two')");
   check("commit_add_two_rejected",
     strstr(res, "ERROR") != 0 || strstr(res, "conflict") != 0);
 
@@ -122,14 +122,14 @@ static void test_aaron_scenario(void){
   rc = sqlite3_open(dbpath, &db1);
   check("reopen_db1", rc==SQLITE_OK);
 
-  res = exec1(db1, "SELECT count(*) FROM dolt_log");
+  res = queryScalarText(db1, "SELECT count(*) FROM dolt_log");
   check("log_has_2_entries", strcmp(res, "2")==0);
 
-  res = exec1(db1, "SELECT message FROM dolt_log LIMIT 1");
+  res = queryScalarText(db1, "SELECT message FROM dolt_log LIMIT 1");
   check("latest_commit_is_add_one", strcmp(res, "add one")==0);
 
   /* Verify the data from "add one" is intact */
-  res = exec1(db1, "SELECT val FROM vals WHERE id=1");
+  res = queryScalarText(db1, "SELECT val FROM vals WHERE id=1");
   check("add_one_data_intact", strcmp(res, "1")==0);
 
   sqlite3_close(db1);
@@ -152,22 +152,22 @@ static void test_single_connection(void){
   rc = sqlite3_open(dbpath, &db);
   check("single_open", rc==SQLITE_OK);
 
-  execsql(db, "CREATE TABLE t1 (a INT, b TEXT)");
-  res = exec1(db, "SELECT dolt_commit('-A', '-m', 'first')");
+  execSql(db, "CREATE TABLE t1 (a INT, b TEXT)");
+  res = queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'first')");
   check("single_commit_1", strlen(res)==40);
 
-  execsql(db, "INSERT INTO t1 VALUES (1, 'hello')");
-  res = exec1(db, "SELECT dolt_commit('-A', '-m', 'second')");
+  execSql(db, "INSERT INTO t1 VALUES (1, 'hello')");
+  res = queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'second')");
   check("single_commit_2", strlen(res)==40);
 
-  execsql(db, "INSERT INTO t1 VALUES (2, 'world')");
-  res = exec1(db, "SELECT dolt_commit('-A', '-m', 'third')");
+  execSql(db, "INSERT INTO t1 VALUES (2, 'world')");
+  res = queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'third')");
   check("single_commit_3", strlen(res)==40);
 
-  res = exec1(db, "SELECT count(*) FROM dolt_log");
+  res = queryScalarText(db, "SELECT count(*) FROM dolt_log");
   check("single_log_count", strcmp(res, "3")==0);
 
-  res = exec1(db, "SELECT count(*) FROM t1");
+  res = queryScalarText(db, "SELECT count(*) FROM t1");
   check("single_data_count", strcmp(res, "2")==0);
 
   sqlite3_close(db);
@@ -194,8 +194,8 @@ static void test_sequential_multi_connection(void){
   check("seq_open_db2", rc==SQLITE_OK);
 
   /* db1 creates and commits */
-  execsql(db1, "CREATE TABLE seq (id INT, name TEXT)");
-  res = exec1(db1, "SELECT dolt_commit('-A', '-m', 'create seq')");
+  execSql(db1, "CREATE TABLE seq (id INT, name TEXT)");
+  res = queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'create seq')");
   check("seq_first_commit", strlen(res)==40);
 
   /* db2 opens AFTER db1's commit, inserts, and commits.
@@ -205,8 +205,8 @@ static void test_sequential_multi_connection(void){
   rc = sqlite3_open(dbpath, &db2);
   check("seq_reopen_db2", rc==SQLITE_OK);
 
-  execsql(db2, "INSERT INTO seq VALUES (1, 'from_db2')");
-  res = exec1(db2, "SELECT dolt_commit('-A', '-m', 'db2 insert')");
+  execSql(db2, "INSERT INTO seq VALUES (1, 'from_db2')");
+  res = queryScalarText(db2, "SELECT dolt_commit('-A', '-m', 'db2 insert')");
   check("seq_db2_commit", strlen(res)==40);
 
   /* Reopen db1 to get fresh state, then commit */
@@ -214,15 +214,15 @@ static void test_sequential_multi_connection(void){
   rc = sqlite3_open(dbpath, &db1);
   check("seq_reopen_db1", rc==SQLITE_OK);
 
-  execsql(db1, "INSERT INTO seq VALUES (2, 'from_db1')");
-  res = exec1(db1, "SELECT dolt_commit('-A', '-m', 'db1 insert')");
+  execSql(db1, "INSERT INTO seq VALUES (2, 'from_db1')");
+  res = queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'db1 insert')");
   check("seq_db1_commit", strlen(res)==40);
 
   /* Both rows should exist */
-  res = exec1(db1, "SELECT count(*) FROM seq");
+  res = queryScalarText(db1, "SELECT count(*) FROM seq");
   check("seq_both_rows", strcmp(res, "2")==0);
 
-  res = exec1(db1, "SELECT count(*) FROM dolt_log");
+  res = queryScalarText(db1, "SELECT count(*) FROM dolt_log");
   check("seq_log_count", strcmp(res, "3")==0);
 
   sqlite3_close(db1);

--- a/test/concurrent_refs_test.sh
+++ b/test/concurrent_refs_test.sh
@@ -7,6 +7,4 @@
 set -euo pipefail
 
 echo "=== Concurrent Refs Repro ==="
-cc -g -I. -I../src -o doltlite_regression_test_c \
-  ../test/doltlite_regression_test_c.c libdoltlite.a -lz -lpthread -lm
-./doltlite_regression_test_c concurrent_refs
+bash "$(dirname "$0")/run_doltlite_regression_case.sh" concurrent_refs

--- a/test/concurrent_stress_test.c
+++ b/test/concurrent_stress_test.c
@@ -84,7 +84,7 @@ static void release_buf(sqlite3 *db){
   }
 }
 
-static const char *exec1(sqlite3 *db, const char *sql){
+static const char *queryScalarText(sqlite3 *db, const char *sql){
   sqlite3_stmt *stmt = 0;
   int rc;
   char *buf = get_buf(db);
@@ -106,7 +106,7 @@ static const char *exec1(sqlite3 *db, const char *sql){
   return buf;
 }
 
-static int execsql(sqlite3 *db, const char *sql){
+static int execSql(sqlite3 *db, const char *sql){
   char *err = 0;
   int rc = sqlite3_exec(db, sql, 0, 0, &err);
   if( rc!=SQLITE_OK ){
@@ -118,7 +118,7 @@ static int execsql(sqlite3 *db, const char *sql){
 }
 
 /* Execute with retry on SQLITE_BUSY */
-static int execsql_busy(sqlite3 *db, const char *sql, int maxRetries){
+static int execSqlWithBusyRetry(sqlite3 *db, const char *sql, int maxRetries){
   char *err = 0;
   int rc, attempts = 0;
   do {
@@ -140,7 +140,7 @@ static int execsql_busy(sqlite3 *db, const char *sql, int maxRetries){
   return rc;
 }
 
-/* exec1 with retry on SQLITE_BUSY */
+/* queryScalarText with retry on SQLITE_BUSY */
 static const char *exec1_busy(sqlite3 *db, const char *sql, int maxRetries){
   sqlite3_stmt *stmt = 0;
   int rc, attempts = 0;
@@ -183,7 +183,7 @@ static int open_fresh(const char *path, sqlite3 **ppDb){
 }
 
 /* Remove database and its WAL/SHM files. */
-static void remove_db(const char *path){
+static void removeDbFiles(const char *path){
   char tmp[512];
   remove(path);
   snprintf(tmp, sizeof(tmp), "%s-wal", path);
@@ -217,26 +217,26 @@ static void test_1_1_aaron_exact(void){
   const char *res;
 
   printf("  1.1  Aaron's exact scenario\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db1);
-  execsql(db1, "CREATE TABLE vals(id INT, val INT)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'Initial commit')");
+  execSql(db1, "CREATE TABLE vals(id INT, val INT)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'Initial commit')");
 
   open_fresh(path, &db2);
-  exec1(db2, "SELECT count(*) FROM vals"); /* db2 anchors its snapshot */
+  queryScalarText(db2, "SELECT count(*) FROM vals"); /* db2 anchors its snapshot */
 
-  execsql(db1, "INSERT INTO vals VALUES(1, 1)");
-  res = exec1(db1, "SELECT dolt_commit('-A', '-m', 'add one')");
+  execSql(db1, "INSERT INTO vals VALUES(1, 1)");
+  res = queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'add one')");
   check("1.1_first_commit_succeeds", is_commit_hash(res));
 
-  execsql(db2, "INSERT INTO vals VALUES(2, 2)");
-  res = exec1(db2, "SELECT dolt_commit('-A', '-m', 'add two')");
+  execSql(db2, "INSERT INTO vals VALUES(2, 2)");
+  res = queryScalarText(db2, "SELECT dolt_commit('-A', '-m', 'add two')");
   check("1.1_second_commit_rejected", is_error(res));
 
   sqlite3_close(db1);
   sqlite3_close(db2);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -248,25 +248,25 @@ static void test_1_2_error_message(void){
   const char *res;
 
   printf("  1.2  Error message contains 'conflict'\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db1);
-  execsql(db1, "CREATE TABLE vals(id INT, val INT)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')");
+  execSql(db1, "CREATE TABLE vals(id INT, val INT)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init')");
 
   open_fresh(path, &db2);
-  exec1(db2, "SELECT count(*) FROM vals");
+  queryScalarText(db2, "SELECT count(*) FROM vals");
 
-  execsql(db1, "INSERT INTO vals VALUES(1, 1)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'one')");
+  execSql(db1, "INSERT INTO vals VALUES(1, 1)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'one')");
 
-  execsql(db2, "INSERT INTO vals VALUES(2, 2)");
-  res = exec1(db2, "SELECT dolt_commit('-A', '-m', 'two')");
+  execSql(db2, "INSERT INTO vals VALUES(2, 2)");
+  res = queryScalarText(db2, "SELECT dolt_commit('-A', '-m', 'two')");
   check_contains("1.2_error_has_conflict", res, "conflict");
 
   sqlite3_close(db1);
   sqlite3_close(db2);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -278,33 +278,33 @@ static void test_1_3_first_commit_survives(void){
   const char *res;
 
   printf("  1.3  First commit survives after second is rejected\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db1);
-  execsql(db1, "CREATE TABLE vals(id INT, val INT)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')");
+  execSql(db1, "CREATE TABLE vals(id INT, val INT)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init')");
 
   open_fresh(path, &db2);
-  exec1(db2, "SELECT count(*) FROM vals");
+  queryScalarText(db2, "SELECT count(*) FROM vals");
 
-  execsql(db1, "INSERT INTO vals VALUES(1, 100)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'add one')");
+  execSql(db1, "INSERT INTO vals VALUES(1, 100)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'add one')");
 
-  execsql(db2, "INSERT INTO vals VALUES(2, 200)");
-  exec1(db2, "SELECT dolt_commit('-A', '-m', 'add two')"); /* rejected */
+  execSql(db2, "INSERT INTO vals VALUES(2, 200)");
+  queryScalarText(db2, "SELECT dolt_commit('-A', '-m', 'add two')"); /* rejected */
 
   /* Open fresh connection to verify the first commit survived */
   open_fresh(path, &db3);
-  res = exec1(db3, "SELECT message FROM dolt_log LIMIT 1");
+  res = queryScalarText(db3, "SELECT message FROM dolt_log LIMIT 1");
   check("1.3_latest_is_add_one", strcmp(res, "add one")==0);
 
-  res = exec1(db3, "SELECT val FROM vals WHERE id=1");
+  res = queryScalarText(db3, "SELECT val FROM vals WHERE id=1");
   check("1.3_data_intact", strcmp(res, "100")==0);
 
   sqlite3_close(db1);
   sqlite3_close(db2);
   sqlite3_close(db3);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -317,35 +317,35 @@ static void test_1_4_rejected_data_not_persisted(void){
   const char *res;
 
   printf("  1.4  Rejected commit data not persisted\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db1);
-  execsql(db1, "CREATE TABLE vals(id INT, val INT)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')");
+  execSql(db1, "CREATE TABLE vals(id INT, val INT)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init')");
 
   open_fresh(path, &db2);
-  exec1(db2, "SELECT count(*) FROM vals");
+  queryScalarText(db2, "SELECT count(*) FROM vals");
 
-  execsql(db1, "INSERT INTO vals VALUES(1, 1)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'add one')");
+  execSql(db1, "INSERT INTO vals VALUES(1, 1)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'add one')");
 
-  execsql(db2, "INSERT INTO vals VALUES(2, 2)");
-  exec1(db2, "SELECT dolt_commit('-A', '-m', 'add two')"); /* rejected */
+  execSql(db2, "INSERT INTO vals VALUES(2, 2)");
+  queryScalarText(db2, "SELECT dolt_commit('-A', '-m', 'add two')"); /* rejected */
 
   /* Fresh connection to inspect committed state */
   open_fresh(path, &db3);
-  res = exec1(db3, "SELECT count(*) FROM vals WHERE id=2");
+  res = queryScalarText(db3, "SELECT count(*) FROM vals WHERE id=2");
   /* The rejected commit's INSERT should not be in the dolt commit history.
   ** However, the SQL row may or may not be visible in the WAL depending on
   ** how the rollback was handled. The key invariant is that dolt_log does
   ** NOT contain the rejected commit. */
-  res = exec1(db3, "SELECT count(*) FROM dolt_log WHERE message='add two'");
+  res = queryScalarText(db3, "SELECT count(*) FROM dolt_log WHERE message='add two'");
   check("1.4_rejected_commit_not_in_log", strcmp(res, "0")==0);
 
   sqlite3_close(db1);
   sqlite3_close(db2);
   sqlite3_close(db3);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -358,30 +358,30 @@ static void test_1_5_three_connections(void){
   int successes = 0;
 
   printf("  1.5  Three connections commit to main\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db1);
-  execsql(db1, "CREATE TABLE vals(id INT, val INT)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')");
+  execSql(db1, "CREATE TABLE vals(id INT, val INT)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init')");
 
   open_fresh(path, &db2);
   open_fresh(path, &db3);
   /* Anchor all snapshots */
-  exec1(db2, "SELECT count(*) FROM vals");
-  exec1(db3, "SELECT count(*) FROM vals");
+  queryScalarText(db2, "SELECT count(*) FROM vals");
+  queryScalarText(db3, "SELECT count(*) FROM vals");
 
   /* All three insert and try to commit */
-  execsql(db1, "INSERT INTO vals VALUES(1, 1)");
-  execsql(db2, "INSERT INTO vals VALUES(2, 2)");
-  execsql(db3, "INSERT INTO vals VALUES(3, 3)");
+  execSql(db1, "INSERT INTO vals VALUES(1, 1)");
+  execSql(db2, "INSERT INTO vals VALUES(2, 2)");
+  execSql(db3, "INSERT INTO vals VALUES(3, 3)");
 
-  res = exec1(db1, "SELECT dolt_commit('-A', '-m', 'from db1')");
+  res = queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'from db1')");
   if( is_commit_hash(res) ) successes++;
 
-  res = exec1(db2, "SELECT dolt_commit('-A', '-m', 'from db2')");
+  res = queryScalarText(db2, "SELECT dolt_commit('-A', '-m', 'from db2')");
   if( is_commit_hash(res) ) successes++;
 
-  res = exec1(db3, "SELECT dolt_commit('-A', '-m', 'from db3')");
+  res = queryScalarText(db3, "SELECT dolt_commit('-A', '-m', 'from db3')");
   if( is_commit_hash(res) ) successes++;
 
   check("1.5_only_one_commit_succeeds", successes==1);
@@ -389,7 +389,7 @@ static void test_1_5_three_connections(void){
   sqlite3_close(db1);
   sqlite3_close(db2);
   sqlite3_close(db3);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -402,31 +402,31 @@ static void test_1_6_four_connections(void){
   int successes = 0;
 
   printf("  1.6  Four connections commit to main\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db1);
-  execsql(db1, "CREATE TABLE vals(id INT, val INT)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')");
+  execSql(db1, "CREATE TABLE vals(id INT, val INT)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init')");
 
   open_fresh(path, &db2);
   open_fresh(path, &db3);
   open_fresh(path, &db4);
-  exec1(db2, "SELECT count(*) FROM vals");
-  exec1(db3, "SELECT count(*) FROM vals");
-  exec1(db4, "SELECT count(*) FROM vals");
+  queryScalarText(db2, "SELECT count(*) FROM vals");
+  queryScalarText(db3, "SELECT count(*) FROM vals");
+  queryScalarText(db4, "SELECT count(*) FROM vals");
 
-  execsql(db1, "INSERT INTO vals VALUES(1, 1)");
-  execsql(db2, "INSERT INTO vals VALUES(2, 2)");
-  execsql(db3, "INSERT INTO vals VALUES(3, 3)");
-  execsql(db4, "INSERT INTO vals VALUES(4, 4)");
+  execSql(db1, "INSERT INTO vals VALUES(1, 1)");
+  execSql(db2, "INSERT INTO vals VALUES(2, 2)");
+  execSql(db3, "INSERT INTO vals VALUES(3, 3)");
+  execSql(db4, "INSERT INTO vals VALUES(4, 4)");
 
-  res = exec1(db1, "SELECT dolt_commit('-A', '-m', 'from db1')");
+  res = queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'from db1')");
   if( is_commit_hash(res) ) successes++;
-  res = exec1(db2, "SELECT dolt_commit('-A', '-m', 'from db2')");
+  res = queryScalarText(db2, "SELECT dolt_commit('-A', '-m', 'from db2')");
   if( is_commit_hash(res) ) successes++;
-  res = exec1(db3, "SELECT dolt_commit('-A', '-m', 'from db3')");
+  res = queryScalarText(db3, "SELECT dolt_commit('-A', '-m', 'from db3')");
   if( is_commit_hash(res) ) successes++;
-  res = exec1(db4, "SELECT dolt_commit('-A', '-m', 'from db4')");
+  res = queryScalarText(db4, "SELECT dolt_commit('-A', '-m', 'from db4')");
   if( is_commit_hash(res) ) successes++;
 
   check("1.6_only_one_commit_of_four_succeeds", successes==1);
@@ -435,7 +435,7 @@ static void test_1_6_four_connections(void){
   sqlite3_close(db2);
   sqlite3_close(db3);
   sqlite3_close(db4);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -447,27 +447,27 @@ static void test_1_7_concurrent_update(void){
   const char *res;
 
   printf("  1.7  Concurrent UPDATE conflict\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db1);
-  execsql(db1, "CREATE TABLE vals(id INT, val INT)");
-  execsql(db1, "INSERT INTO vals VALUES(1, 10)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'init with row')");
+  execSql(db1, "CREATE TABLE vals(id INT, val INT)");
+  execSql(db1, "INSERT INTO vals VALUES(1, 10)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init with row')");
 
   open_fresh(path, &db2);
-  exec1(db2, "SELECT val FROM vals WHERE id=1");
+  queryScalarText(db2, "SELECT val FROM vals WHERE id=1");
 
-  execsql(db1, "UPDATE vals SET val=20 WHERE id=1");
-  res = exec1(db1, "SELECT dolt_commit('-A', '-m', 'update to 20')");
+  execSql(db1, "UPDATE vals SET val=20 WHERE id=1");
+  res = queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'update to 20')");
   check("1.7_first_update_commits", is_commit_hash(res));
 
-  execsql(db2, "UPDATE vals SET val=30 WHERE id=1");
-  res = exec1(db2, "SELECT dolt_commit('-A', '-m', 'update to 30')");
+  execSql(db2, "UPDATE vals SET val=30 WHERE id=1");
+  res = queryScalarText(db2, "SELECT dolt_commit('-A', '-m', 'update to 30')");
   check("1.7_second_update_rejected", is_error(res));
 
   sqlite3_close(db1);
   sqlite3_close(db2);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -479,28 +479,28 @@ static void test_1_8_concurrent_delete(void){
   const char *res;
 
   printf("  1.8  Concurrent DELETE conflict\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db1);
-  execsql(db1, "CREATE TABLE vals(id INT, val INT)");
-  execsql(db1, "INSERT INTO vals VALUES(1, 10)");
-  execsql(db1, "INSERT INTO vals VALUES(2, 20)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')");
+  execSql(db1, "CREATE TABLE vals(id INT, val INT)");
+  execSql(db1, "INSERT INTO vals VALUES(1, 10)");
+  execSql(db1, "INSERT INTO vals VALUES(2, 20)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init')");
 
   open_fresh(path, &db2);
-  exec1(db2, "SELECT count(*) FROM vals");
+  queryScalarText(db2, "SELECT count(*) FROM vals");
 
-  execsql(db1, "DELETE FROM vals WHERE id=1");
-  res = exec1(db1, "SELECT dolt_commit('-A', '-m', 'delete id 1')");
+  execSql(db1, "DELETE FROM vals WHERE id=1");
+  res = queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'delete id 1')");
   check("1.8_first_delete_commits", is_commit_hash(res));
 
-  execsql(db2, "DELETE FROM vals WHERE id=2");
-  res = exec1(db2, "SELECT dolt_commit('-A', '-m', 'delete id 2')");
+  execSql(db2, "DELETE FROM vals WHERE id=2");
+  res = queryScalarText(db2, "SELECT dolt_commit('-A', '-m', 'delete id 2')");
   check("1.8_second_delete_rejected", is_error(res));
 
   sqlite3_close(db1);
   sqlite3_close(db2);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -512,29 +512,29 @@ static void test_1_9_multiple_tables(void){
   const char *res;
 
   printf("  1.9  Concurrent commits with multiple tables\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db1);
-  execsql(db1, "CREATE TABLE t1(id INT, val TEXT)");
-  execsql(db1, "CREATE TABLE t2(id INT, val TEXT)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'init schema')");
+  execSql(db1, "CREATE TABLE t1(id INT, val TEXT)");
+  execSql(db1, "CREATE TABLE t2(id INT, val TEXT)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init schema')");
 
   open_fresh(path, &db2);
-  exec1(db2, "SELECT count(*) FROM t1");
+  queryScalarText(db2, "SELECT count(*) FROM t1");
 
   /* db1 writes to t1, db2 writes to t2 — but both are on same branch */
-  execsql(db1, "INSERT INTO t1 VALUES(1, 'one')");
-  res = exec1(db1, "SELECT dolt_commit('-A', '-m', 'insert t1')");
+  execSql(db1, "INSERT INTO t1 VALUES(1, 'one')");
+  res = queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'insert t1')");
   check("1.9_first_commit_t1", is_commit_hash(res));
 
-  execsql(db2, "INSERT INTO t2 VALUES(1, 'two')");
-  res = exec1(db2, "SELECT dolt_commit('-A', '-m', 'insert t2')");
+  execSql(db2, "INSERT INTO t2 VALUES(1, 'two')");
+  res = queryScalarText(db2, "SELECT dolt_commit('-A', '-m', 'insert t2')");
   /* Even though different tables, same branch conflict applies */
   check("1.9_second_commit_t2_rejected", is_error(res));
 
   sqlite3_close(db1);
   sqlite3_close(db2);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -546,27 +546,27 @@ static void test_1_10_insert_and_delete(void){
   const char *res;
 
   printf("  1.10 Concurrent INSERT (db1) + DELETE (db2)\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db1);
-  execsql(db1, "CREATE TABLE vals(id INT, val INT)");
-  execsql(db1, "INSERT INTO vals VALUES(1, 10)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')");
+  execSql(db1, "CREATE TABLE vals(id INT, val INT)");
+  execSql(db1, "INSERT INTO vals VALUES(1, 10)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init')");
 
   open_fresh(path, &db2);
-  exec1(db2, "SELECT count(*) FROM vals");
+  queryScalarText(db2, "SELECT count(*) FROM vals");
 
-  execsql(db1, "INSERT INTO vals VALUES(2, 20)");
-  res = exec1(db1, "SELECT dolt_commit('-A', '-m', 'insert id 2')");
+  execSql(db1, "INSERT INTO vals VALUES(2, 20)");
+  res = queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'insert id 2')");
   check("1.10_insert_commits", is_commit_hash(res));
 
-  execsql(db2, "DELETE FROM vals WHERE id=1");
-  res = exec1(db2, "SELECT dolt_commit('-A', '-m', 'delete id 1')");
+  execSql(db2, "DELETE FROM vals WHERE id=1");
+  res = queryScalarText(db2, "SELECT dolt_commit('-A', '-m', 'delete id 1')");
   check("1.10_delete_rejected", is_error(res));
 
   sqlite3_close(db1);
   sqlite3_close(db2);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -578,29 +578,29 @@ static void test_1_11_log_count_after_reject(void){
   const char *res;
 
   printf("  1.11 Log count correct after rejected commit\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db1);
-  execsql(db1, "CREATE TABLE vals(id INT, val INT)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')");
+  execSql(db1, "CREATE TABLE vals(id INT, val INT)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init')");
 
   open_fresh(path, &db2);
-  exec1(db2, "SELECT count(*) FROM vals");
+  queryScalarText(db2, "SELECT count(*) FROM vals");
 
-  execsql(db1, "INSERT INTO vals VALUES(1,1)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'add one')");
+  execSql(db1, "INSERT INTO vals VALUES(1,1)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'add one')");
 
-  execsql(db2, "INSERT INTO vals VALUES(2,2)");
-  exec1(db2, "SELECT dolt_commit('-A', '-m', 'add two')"); /* rejected */
+  execSql(db2, "INSERT INTO vals VALUES(2,2)");
+  queryScalarText(db2, "SELECT dolt_commit('-A', '-m', 'add two')"); /* rejected */
 
   open_fresh(path, &db3);
-  res = exec1(db3, "SELECT count(*) FROM dolt_log");
+  res = queryScalarText(db3, "SELECT count(*) FROM dolt_log");
   check("1.11_log_has_exactly_2_entries", strcmp(res, "2")==0);
 
   sqlite3_close(db1);
   sqlite3_close(db2);
   sqlite3_close(db3);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 
@@ -619,29 +619,29 @@ static void test_2_1_different_branches_no_conflict(void){
   const char *res;
 
   printf("  2.1  Different branches, no conflict\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   /* Setup and commit to main */
   open_fresh(path, &db);
-  execsql(db, "CREATE TABLE vals(id INT, val INT)");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'init')");
-  exec1(db, "SELECT dolt_branch('branch1')");
-  execsql(db, "INSERT INTO vals VALUES(1, 1)");
-  res = exec1(db, "SELECT dolt_commit('-A', '-m', 'main commit')");
+  execSql(db, "CREATE TABLE vals(id INT, val INT)");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'init')");
+  queryScalarText(db, "SELECT dolt_branch('branch1')");
+  execSql(db, "INSERT INTO vals VALUES(1, 1)");
+  res = queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'main commit')");
   check("2.1_main_commit_ok", is_commit_hash(res));
   sqlite3_close(db); db = 0;
 
   /* Commit to branch1 */
   open_fresh(path, &db);
-  exec1(db, "SELECT dolt_checkout('branch1')");
+  queryScalarText(db, "SELECT dolt_checkout('branch1')");
   check("2.1_on_branch1",
-        strcmp(exec1(db, "SELECT active_branch()"), "branch1")==0);
-  execsql(db, "INSERT INTO vals VALUES(2, 2)");
-  res = exec1(db, "SELECT dolt_commit('-A', '-m', 'branch1 commit')");
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "branch1")==0);
+  execSql(db, "INSERT INTO vals VALUES(2, 2)");
+  res = queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'branch1 commit')");
   check("2.1_branch1_commit_ok", is_commit_hash(res));
 
   sqlite3_close(db);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -653,41 +653,41 @@ static void test_2_2_verify_branch_data(void){
   const char *res;
 
   printf("  2.2  Verify data on each branch after cross-branch commits\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   /* Commit to main */
   open_fresh(path, &db1);
-  execsql(db1, "CREATE TABLE vals(id INT, val TEXT)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')");
-  exec1(db1, "SELECT dolt_branch('feature')");
-  execsql(db1, "INSERT INTO vals VALUES(1, 'main-data')");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'main insert')");
+  execSql(db1, "CREATE TABLE vals(id INT, val TEXT)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init')");
+  queryScalarText(db1, "SELECT dolt_branch('feature')");
+  execSql(db1, "INSERT INTO vals VALUES(1, 'main-data')");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'main insert')");
   sqlite3_close(db1); db1 = 0;
 
   /* Commit to feature (serialized — one connection at a time to avoid
   ** shared BtShared WAL page corruption) */
   open_fresh(path, &db2);
-  exec1(db2, "SELECT dolt_checkout('feature')");
-  execsql(db2, "INSERT INTO vals VALUES(2, 'feature-data')");
-  exec1(db2, "SELECT dolt_commit('-A', '-m', 'feature insert')");
+  queryScalarText(db2, "SELECT dolt_checkout('feature')");
+  execSql(db2, "INSERT INTO vals VALUES(2, 'feature-data')");
+  queryScalarText(db2, "SELECT dolt_commit('-A', '-m', 'feature insert')");
   sqlite3_close(db2); db2 = 0;
 
   /* Verify main — new connection may start on 'feature' (last checkout),
   ** so explicitly checkout main. */
   open_fresh(path, &db1);
-  exec1(db1, "SELECT dolt_checkout('main')");
-  res = exec1(db1, "SELECT val FROM vals WHERE id=1");
+  queryScalarText(db1, "SELECT dolt_checkout('main')");
+  res = queryScalarText(db1, "SELECT val FROM vals WHERE id=1");
   check("2.2_main_has_main_data", strcmp(res, "main-data")==0);
   sqlite3_close(db1); db1 = 0;
 
   /* Verify feature */
   open_fresh(path, &db2);
-  exec1(db2, "SELECT dolt_checkout('feature')");
-  res = exec1(db2, "SELECT val FROM vals WHERE id=2");
+  queryScalarText(db2, "SELECT dolt_checkout('feature')");
+  res = queryScalarText(db2, "SELECT val FROM vals WHERE id=2");
   check("2.2_feature_has_feature_data", strcmp(res, "feature-data")==0);
 
   sqlite3_close(db2);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -699,39 +699,39 @@ static void test_2_3_log_per_branch(void){
   const char *res;
 
   printf("  2.3  dolt_log per branch is correct\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db1);
-  execsql(db1, "CREATE TABLE vals(id INT, val INT)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')");
-  exec1(db1, "SELECT dolt_branch('dev')");
+  execSql(db1, "CREATE TABLE vals(id INT, val INT)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init')");
+  queryScalarText(db1, "SELECT dolt_branch('dev')");
 
-  execsql(db1, "INSERT INTO vals VALUES(1, 1)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'main work')");
+  execSql(db1, "INSERT INTO vals VALUES(1, 1)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'main work')");
   /* Close db1 before opening db2 to avoid shared BtShared corruption */
   sqlite3_close(db1); db1 = 0;
 
   open_fresh(path, &db2);
-  exec1(db2, "SELECT dolt_checkout('dev')");
-  execsql(db2, "INSERT INTO vals VALUES(2, 2)");
-  exec1(db2, "SELECT dolt_commit('-A', '-m', 'dev work')");
+  queryScalarText(db2, "SELECT dolt_checkout('dev')");
+  execSql(db2, "INSERT INTO vals VALUES(2, 2)");
+  queryScalarText(db2, "SELECT dolt_commit('-A', '-m', 'dev work')");
   sqlite3_close(db2); db2 = 0;
 
   /* Verify main log — explicitly checkout main since last op was on dev */
   open_fresh(path, &db1);
-  exec1(db1, "SELECT dolt_checkout('main')");
-  res = exec1(db1, "SELECT message FROM dolt_log LIMIT 1");
+  queryScalarText(db1, "SELECT dolt_checkout('main')");
+  res = queryScalarText(db1, "SELECT message FROM dolt_log LIMIT 1");
   check("2.3_main_log_latest", strcmp(res, "main work")==0);
   sqlite3_close(db1); db1 = 0;
 
   /* Verify dev log */
   open_fresh(path, &db2);
-  exec1(db2, "SELECT dolt_checkout('dev')");
-  res = exec1(db2, "SELECT message FROM dolt_log LIMIT 1");
+  queryScalarText(db2, "SELECT dolt_checkout('dev')");
+  res = queryScalarText(db2, "SELECT message FROM dolt_log LIMIT 1");
   check("2.3_dev_log_latest", strcmp(res, "dev work")==0);
   sqlite3_close(db2); db2 = 0;
 
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -743,35 +743,35 @@ static void test_2_4_three_branches(void){
   const char *res;
 
   printf("  2.4  Three branches, sequential commits\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   /* Setup branches and commit to main */
   open_fresh(path, &db);
-  execsql(db, "CREATE TABLE vals(id INT, val INT)");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'init')");
-  exec1(db, "SELECT dolt_branch('b1')");
-  exec1(db, "SELECT dolt_branch('b2')");
-  execsql(db, "INSERT INTO vals VALUES(1, 1)");
-  res = exec1(db, "SELECT dolt_commit('-A', '-m', 'main commit')");
+  execSql(db, "CREATE TABLE vals(id INT, val INT)");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'init')");
+  queryScalarText(db, "SELECT dolt_branch('b1')");
+  queryScalarText(db, "SELECT dolt_branch('b2')");
+  execSql(db, "INSERT INTO vals VALUES(1, 1)");
+  res = queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'main commit')");
   check("2.4_main_ok", is_commit_hash(res));
   sqlite3_close(db); db = 0;
 
   /* Commit to b1 */
   open_fresh(path, &db);
-  exec1(db, "SELECT dolt_checkout('b1')");
-  execsql(db, "INSERT INTO vals VALUES(2, 2)");
-  res = exec1(db, "SELECT dolt_commit('-A', '-m', 'b1 commit')");
+  queryScalarText(db, "SELECT dolt_checkout('b1')");
+  execSql(db, "INSERT INTO vals VALUES(2, 2)");
+  res = queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'b1 commit')");
   check("2.4_b1_ok", is_commit_hash(res));
   sqlite3_close(db); db = 0;
 
   /* Commit to b2 */
   open_fresh(path, &db);
-  exec1(db, "SELECT dolt_checkout('b2')");
-  execsql(db, "INSERT INTO vals VALUES(3, 3)");
-  res = exec1(db, "SELECT dolt_commit('-A', '-m', 'b2 commit')");
+  queryScalarText(db, "SELECT dolt_checkout('b2')");
+  execSql(db, "INSERT INTO vals VALUES(3, 3)");
+  res = queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'b2 commit')");
   check("2.4_b2_ok", is_commit_hash(res));
   sqlite3_close(db);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -784,14 +784,14 @@ static void test_2_5_four_branches(void){
   int successes = 0;
 
   printf("  2.5  Four branches, four connections\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db1);
-  execsql(db1, "CREATE TABLE vals(id INT, val INT)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')");
-  exec1(db1, "SELECT dolt_branch('alpha')");
-  exec1(db1, "SELECT dolt_branch('beta')");
-  exec1(db1, "SELECT dolt_branch('gamma')");
+  execSql(db1, "CREATE TABLE vals(id INT, val INT)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init')");
+  queryScalarText(db1, "SELECT dolt_branch('alpha')");
+  queryScalarText(db1, "SELECT dolt_branch('beta')");
+  queryScalarText(db1, "SELECT dolt_branch('gamma')");
 
   /* Commit each branch sequentially, reopening between commits to get
   ** fresh WAL state (shared BtShared can be polluted by dolt_commit
@@ -799,39 +799,39 @@ static void test_2_5_four_branches(void){
 
   /* main */
   open_fresh(path, &db2);
-  execsql(db1, "INSERT INTO vals VALUES(1, 1)");
-  res = exec1(db1, "SELECT dolt_commit('-A', '-m', 'main')");
+  execSql(db1, "INSERT INTO vals VALUES(1, 1)");
+  res = queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'main')");
   if( is_commit_hash(res) ) successes++;
   sqlite3_close(db1); db1 = 0;
   sqlite3_close(db2); db2 = 0;
 
   /* alpha */
   open_fresh(path, &db2);
-  exec1(db2, "SELECT dolt_checkout('alpha')");
-  execsql(db2, "INSERT INTO vals VALUES(2, 2)");
-  res = exec1(db2, "SELECT dolt_commit('-A', '-m', 'alpha')");
+  queryScalarText(db2, "SELECT dolt_checkout('alpha')");
+  execSql(db2, "INSERT INTO vals VALUES(2, 2)");
+  res = queryScalarText(db2, "SELECT dolt_commit('-A', '-m', 'alpha')");
   if( is_commit_hash(res) ) successes++;
   sqlite3_close(db2); db2 = 0;
 
   /* beta */
   open_fresh(path, &db3);
-  exec1(db3, "SELECT dolt_checkout('beta')");
-  execsql(db3, "INSERT INTO vals VALUES(3, 3)");
-  res = exec1(db3, "SELECT dolt_commit('-A', '-m', 'beta')");
+  queryScalarText(db3, "SELECT dolt_checkout('beta')");
+  execSql(db3, "INSERT INTO vals VALUES(3, 3)");
+  res = queryScalarText(db3, "SELECT dolt_commit('-A', '-m', 'beta')");
   if( is_commit_hash(res) ) successes++;
   sqlite3_close(db3); db3 = 0;
 
   /* gamma */
   open_fresh(path, &db4);
-  exec1(db4, "SELECT dolt_checkout('gamma')");
-  execsql(db4, "INSERT INTO vals VALUES(4, 4)");
-  res = exec1(db4, "SELECT dolt_commit('-A', '-m', 'gamma')");
+  queryScalarText(db4, "SELECT dolt_checkout('gamma')");
+  execSql(db4, "INSERT INTO vals VALUES(4, 4)");
+  res = queryScalarText(db4, "SELECT dolt_commit('-A', '-m', 'gamma')");
   if( is_commit_hash(res) ) successes++;
   sqlite3_close(db4); db4 = 0;
 
   check("2.5_all_four_succeed", successes==4);
 
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -843,29 +843,29 @@ static void test_2_6_same_branch_conflict(void){
   const char *res;
 
   printf("  2.6  Two connections on same non-main branch, conflict\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db1);
-  execsql(db1, "CREATE TABLE vals(id INT, val INT)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')");
-  exec1(db1, "SELECT dolt_branch('feature')");
-  exec1(db1, "SELECT dolt_checkout('feature')");
+  execSql(db1, "CREATE TABLE vals(id INT, val INT)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init')");
+  queryScalarText(db1, "SELECT dolt_branch('feature')");
+  queryScalarText(db1, "SELECT dolt_checkout('feature')");
 
   open_fresh(path, &db2);
-  exec1(db2, "SELECT dolt_checkout('feature')");
-  exec1(db2, "SELECT count(*) FROM vals"); /* anchor snapshot */
+  queryScalarText(db2, "SELECT dolt_checkout('feature')");
+  queryScalarText(db2, "SELECT count(*) FROM vals"); /* anchor snapshot */
 
-  execsql(db1, "INSERT INTO vals VALUES(1, 1)");
-  res = exec1(db1, "SELECT dolt_commit('-A', '-m', 'feature commit 1')");
+  execSql(db1, "INSERT INTO vals VALUES(1, 1)");
+  res = queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'feature commit 1')");
   check("2.6_first_on_feature_ok", is_commit_hash(res));
 
-  execsql(db2, "INSERT INTO vals VALUES(2, 2)");
-  res = exec1(db2, "SELECT dolt_commit('-A', '-m', 'feature commit 2')");
+  execSql(db2, "INSERT INTO vals VALUES(2, 2)");
+  res = queryScalarText(db2, "SELECT dolt_commit('-A', '-m', 'feature commit 2')");
   check("2.6_second_on_feature_rejected", is_error(res));
 
   sqlite3_close(db1);
   sqlite3_close(db2);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -877,31 +877,31 @@ static void test_2_7_main_then_branch_no_conflict(void){
   const char *res;
 
   printf("  2.7  Commit on main then branch (stale snapshot OK)\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db1);
-  execsql(db1, "CREATE TABLE vals(id INT, val INT)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')");
-  exec1(db1, "SELECT dolt_branch('feature')");
+  execSql(db1, "CREATE TABLE vals(id INT, val INT)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init')");
+  queryScalarText(db1, "SELECT dolt_branch('feature')");
 
   /* db2 opens and checks out feature BEFORE db1 commits to main */
   open_fresh(path, &db2);
-  exec1(db2, "SELECT dolt_checkout('feature')");
-  exec1(db2, "SELECT count(*) FROM vals"); /* anchor snapshot */
+  queryScalarText(db2, "SELECT dolt_checkout('feature')");
+  queryScalarText(db2, "SELECT count(*) FROM vals"); /* anchor snapshot */
 
   /* db1 commits to main */
-  execsql(db1, "INSERT INTO vals VALUES(1, 1)");
-  res = exec1(db1, "SELECT dolt_commit('-A', '-m', 'main commit')");
+  execSql(db1, "INSERT INTO vals VALUES(1, 1)");
+  res = queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'main commit')");
   check("2.7_main_commits", is_commit_hash(res));
 
   /* db2 commits to feature — should succeed because different branch */
-  execsql(db2, "INSERT INTO vals VALUES(2, 2)");
-  res = exec1(db2, "SELECT dolt_commit('-A', '-m', 'feature commit')");
+  execSql(db2, "INSERT INTO vals VALUES(2, 2)");
+  res = queryScalarText(db2, "SELECT dolt_commit('-A', '-m', 'feature commit')");
   check("2.7_feature_commits_despite_stale_snapshot", is_commit_hash(res));
 
   sqlite3_close(db1);
   sqlite3_close(db2);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -915,12 +915,12 @@ static void test_2_8_interleaved_branch_commits(void){
   int i, ok = 1;
 
   printf("  2.8  Interleaved sequential commits on two branches\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db);
-  execsql(db, "CREATE TABLE vals(id INT, val INT)");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'init')");
-  exec1(db, "SELECT dolt_branch('other')");
+  execSql(db, "CREATE TABLE vals(id INT, val INT)");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'init')");
+  queryScalarText(db, "SELECT dolt_branch('other')");
   sqlite3_close(db); db = 0;
 
   /* Alternate commits between branches, reopening each time */
@@ -929,29 +929,29 @@ static void test_2_8_interleaved_branch_commits(void){
 
     /* Commit to main */
     open_fresh(path, &db);
-    exec1(db, "SELECT dolt_checkout('main')");
+    queryScalarText(db, "SELECT dolt_checkout('main')");
     snprintf(sql, sizeof(sql), "INSERT INTO vals VALUES(%d, %d)", i*2, i*2);
-    execsql(db, sql);
+    execSql(db, sql);
     snprintf(msg, sizeof(msg),
              "SELECT dolt_commit('-A', '-m', 'main-%d')", i);
-    res = exec1(db, msg);
+    res = queryScalarText(db, msg);
     if( !is_commit_hash(res) ){ ok = 0; sqlite3_close(db); break; }
     sqlite3_close(db); db = 0;
 
     /* Commit to other */
     open_fresh(path, &db);
-    exec1(db, "SELECT dolt_checkout('other')");
+    queryScalarText(db, "SELECT dolt_checkout('other')");
     snprintf(sql, sizeof(sql), "INSERT INTO vals VALUES(%d, %d)", i*2+1, i*2+1);
-    execsql(db, sql);
+    execSql(db, sql);
     snprintf(msg, sizeof(msg),
              "SELECT dolt_commit('-A', '-m', 'other-%d')", i);
-    res = exec1(db, msg);
+    res = queryScalarText(db, msg);
     if( !is_commit_hash(res) ){ ok = 0; sqlite3_close(db); break; }
     sqlite3_close(db); db = 0;
   }
   check("2.8_all_interleaved_commits_succeed", ok);
 
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -963,20 +963,20 @@ static void test_2_9_branch_list(void){
   const char *res;
 
   printf("  2.9  Branch list after creating multiple branches\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db1);
-  execsql(db1, "CREATE TABLE vals(id INT, val INT)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')");
-  exec1(db1, "SELECT dolt_branch('alpha')");
-  exec1(db1, "SELECT dolt_branch('beta')");
-  exec1(db1, "SELECT dolt_branch('gamma')");
+  execSql(db1, "CREATE TABLE vals(id INT, val INT)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init')");
+  queryScalarText(db1, "SELECT dolt_branch('alpha')");
+  queryScalarText(db1, "SELECT dolt_branch('beta')");
+  queryScalarText(db1, "SELECT dolt_branch('gamma')");
 
-  res = exec1(db1, "SELECT count(*) FROM dolt_branches");
+  res = queryScalarText(db1, "SELECT count(*) FROM dolt_branches");
   check("2.9_four_branches", strcmp(res, "4")==0);
 
   sqlite3_close(db1);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -988,45 +988,45 @@ static void test_2_10_log_isolation(void){
   const char *res;
 
   printf("  2.10 Cross-branch log isolation\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db1);
-  execsql(db1, "CREATE TABLE vals(id INT, val INT)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')");
-  exec1(db1, "SELECT dolt_branch('dev')");
+  execSql(db1, "CREATE TABLE vals(id INT, val INT)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init')");
+  queryScalarText(db1, "SELECT dolt_branch('dev')");
 
   /* Make 3 commits on main */
-  execsql(db1, "INSERT INTO vals VALUES(1, 1)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'main-1')");
-  execsql(db1, "INSERT INTO vals VALUES(2, 2)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'main-2')");
-  execsql(db1, "INSERT INTO vals VALUES(3, 3)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'main-3')");
+  execSql(db1, "INSERT INTO vals VALUES(1, 1)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'main-1')");
+  execSql(db1, "INSERT INTO vals VALUES(2, 2)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'main-2')");
+  execSql(db1, "INSERT INTO vals VALUES(3, 3)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'main-3')");
 
   /* Make 1 commit on dev — close db1 first to avoid shared BtShared */
   sqlite3_close(db1); db1 = 0;
   open_fresh(path, &db2);
-  exec1(db2, "SELECT dolt_checkout('dev')");
-  execsql(db2, "INSERT INTO vals VALUES(10, 10)");
-  exec1(db2, "SELECT dolt_commit('-A', '-m', 'dev-1')");
+  queryScalarText(db2, "SELECT dolt_checkout('dev')");
+  execSql(db2, "INSERT INTO vals VALUES(10, 10)");
+  queryScalarText(db2, "SELECT dolt_commit('-A', '-m', 'dev-1')");
   sqlite3_close(db2); db2 = 0;
 
   /* Reopen — explicitly checkout main since last op was on dev */
   open_fresh(path, &db1);
-  exec1(db1, "SELECT dolt_checkout('main')");
+  queryScalarText(db1, "SELECT dolt_checkout('main')");
   /* main should have 4 log entries (init + 3) */
-  res = exec1(db1, "SELECT count(*) FROM dolt_log");
+  res = queryScalarText(db1, "SELECT count(*) FROM dolt_log");
   check("2.10_main_log_count_4", strcmp(res, "4")==0);
   sqlite3_close(db1); db1 = 0;
 
   open_fresh(path, &db2);
-  exec1(db2, "SELECT dolt_checkout('dev')");
+  queryScalarText(db2, "SELECT dolt_checkout('dev')");
   /* dev should have 2 log entries (init + 1) */
-  res = exec1(db2, "SELECT count(*) FROM dolt_log");
+  res = queryScalarText(db2, "SELECT count(*) FROM dolt_log");
   check("2.10_dev_log_count_2", strcmp(res, "2")==0);
 
   sqlite3_close(db2);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 
@@ -1044,37 +1044,37 @@ static void test_3_1_read_during_write(void){
   const char *res;
 
   printf("  3.1  Read during write sees consistent state\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db1);
-  execsql(db1, "CREATE TABLE vals(id INT, val INT)");
-  execsql(db1, "INSERT INTO vals VALUES(1, 10)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')");
+  execSql(db1, "CREATE TABLE vals(id INT, val INT)");
+  execSql(db1, "INSERT INTO vals VALUES(1, 10)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init')");
 
   open_fresh(path, &db2);
 
   /* db2 starts a read transaction */
-  execsql(db2, "BEGIN");
-  res = exec1(db2, "SELECT val FROM vals WHERE id=1");
+  execSql(db2, "BEGIN");
+  res = queryScalarText(db2, "SELECT val FROM vals WHERE id=1");
   check("3.1_initial_read", strcmp(res, "10")==0);
 
   /* db1 updates and commits while db2's transaction is open */
-  execsql(db1, "UPDATE vals SET val=20 WHERE id=1");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'update to 20')");
+  execSql(db1, "UPDATE vals SET val=20 WHERE id=1");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'update to 20')");
 
   /* db2 should still see old value in its transaction */
-  res = exec1(db2, "SELECT val FROM vals WHERE id=1");
+  res = queryScalarText(db2, "SELECT val FROM vals WHERE id=1");
   check("3.1_still_sees_old_value", strcmp(res, "10")==0);
 
-  execsql(db2, "COMMIT");
+  execSql(db2, "COMMIT");
 
   /* After ending transaction, db2 sees new value */
-  res = exec1(db2, "SELECT val FROM vals WHERE id=1");
+  res = queryScalarText(db2, "SELECT val FROM vals WHERE id=1");
   check("3.1_sees_new_value_after_commit", strcmp(res, "20")==0);
 
   sqlite3_close(db1);
   sqlite3_close(db2);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -1087,36 +1087,36 @@ static void test_3_2_no_partial_commit(void){
   int count;
 
   printf("  3.2  Reader never sees partial commit\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db1);
-  execsql(db1, "CREATE TABLE vals(id INT, val INT)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')");
+  execSql(db1, "CREATE TABLE vals(id INT, val INT)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init')");
 
   open_fresh(path, &db2);
 
   /* db2 reads inside a transaction */
-  execsql(db2, "BEGIN");
-  res = exec1(db2, "SELECT count(*) FROM vals");
+  execSql(db2, "BEGIN");
+  res = queryScalarText(db2, "SELECT count(*) FROM vals");
   check("3.2_initially_empty", strcmp(res, "0")==0);
 
   /* db1 inserts multiple rows in one transaction and commits */
-  execsql(db1, "BEGIN");
-  execsql(db1, "INSERT INTO vals VALUES(1, 1)");
-  execsql(db1, "INSERT INTO vals VALUES(2, 2)");
-  execsql(db1, "INSERT INTO vals VALUES(3, 3)");
-  execsql(db1, "COMMIT");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'add three rows')");
+  execSql(db1, "BEGIN");
+  execSql(db1, "INSERT INTO vals VALUES(1, 1)");
+  execSql(db1, "INSERT INTO vals VALUES(2, 2)");
+  execSql(db1, "INSERT INTO vals VALUES(3, 3)");
+  execSql(db1, "COMMIT");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'add three rows')");
 
   /* db2's transaction should not see partial state */
-  count = atoi(exec1(db2, "SELECT count(*) FROM vals"));
+  count = atoi(queryScalarText(db2, "SELECT count(*) FROM vals"));
   check("3.2_reader_sees_zero_or_three", count==0 || count==3);
 
-  execsql(db2, "COMMIT");
+  execSql(db2, "COMMIT");
 
   sqlite3_close(db1);
   sqlite3_close(db2);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -1128,33 +1128,33 @@ static void test_3_3_read_log_during_commit(void){
   const char *res;
 
   printf("  3.3  Read dolt_log while another commits\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db1);
-  execsql(db1, "CREATE TABLE vals(id INT, val INT)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')");
+  execSql(db1, "CREATE TABLE vals(id INT, val INT)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init')");
 
   open_fresh(path, &db2);
 
   /* db2 reads dolt_log */
-  res = exec1(db2, "SELECT count(*) FROM dolt_log");
+  res = queryScalarText(db2, "SELECT count(*) FROM dolt_log");
   check("3.3_log_before_commit", strcmp(res, "1")==0);
 
   /* db1 makes a commit */
-  execsql(db1, "INSERT INTO vals VALUES(1, 1)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'add one')");
+  execSql(db1, "INSERT INTO vals VALUES(1, 1)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'add one')");
 
   /* Reopen db2 to get fresh WAL state after db1's commit */
   sqlite3_close(db2);
   open_fresh(path, &db2);
 
   /* db2 reads log again — should see new entry */
-  res = exec1(db2, "SELECT count(*) FROM dolt_log");
+  res = queryScalarText(db2, "SELECT count(*) FROM dolt_log");
   check("3.3_log_after_commit", strcmp(res, "2")==0);
 
   sqlite3_close(db1);
   sqlite3_close(db2);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -1166,32 +1166,32 @@ static void test_3_4_read_during_uncommitted(void){
   const char *res;
 
   printf("  3.4  Read while other has uncommitted changes\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db1);
-  execsql(db1, "CREATE TABLE vals(id INT, val INT)");
-  execsql(db1, "INSERT INTO vals VALUES(1, 10)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')");
+  execSql(db1, "CREATE TABLE vals(id INT, val INT)");
+  execSql(db1, "INSERT INTO vals VALUES(1, 10)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init')");
 
   open_fresh(path, &db2);
 
   /* db2 starts read transaction */
-  execsql(db2, "BEGIN");
-  res = exec1(db2, "SELECT val FROM vals WHERE id=1");
+  execSql(db2, "BEGIN");
+  res = queryScalarText(db2, "SELECT val FROM vals WHERE id=1");
   check("3.4_sees_committed", strcmp(res, "10")==0);
 
   /* db1 modifies but does NOT dolt_commit */
-  execsql(db1, "UPDATE vals SET val=99 WHERE id=1");
+  execSql(db1, "UPDATE vals SET val=99 WHERE id=1");
 
   /* db2 in its read transaction should still see old value */
-  res = exec1(db2, "SELECT val FROM vals WHERE id=1");
+  res = queryScalarText(db2, "SELECT val FROM vals WHERE id=1");
   check("3.4_still_sees_old", strcmp(res, "10")==0);
 
-  execsql(db2, "COMMIT");
+  execSql(db2, "COMMIT");
 
   sqlite3_close(db1);
   sqlite3_close(db2);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -1203,49 +1203,49 @@ static void test_3_5_multiple_readers(void){
   int c2, c3, c4;
 
   printf("  3.5  Multiple readers during write+commit\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db1);
-  execsql(db1, "CREATE TABLE vals(id INT, val INT)");
-  execsql(db1, "INSERT INTO vals VALUES(1, 10)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')");
+  execSql(db1, "CREATE TABLE vals(id INT, val INT)");
+  execSql(db1, "INSERT INTO vals VALUES(1, 10)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init')");
 
   open_fresh(path, &db2);
   open_fresh(path, &db3);
   open_fresh(path, &db4);
 
   /* All readers start transactions */
-  execsql(db2, "BEGIN");
-  execsql(db3, "BEGIN");
-  execsql(db4, "BEGIN");
+  execSql(db2, "BEGIN");
+  execSql(db3, "BEGIN");
+  execSql(db4, "BEGIN");
 
   /* Each reads current state */
-  exec1(db2, "SELECT count(*) FROM vals");
-  exec1(db3, "SELECT count(*) FROM vals");
-  exec1(db4, "SELECT count(*) FROM vals");
+  queryScalarText(db2, "SELECT count(*) FROM vals");
+  queryScalarText(db3, "SELECT count(*) FROM vals");
+  queryScalarText(db4, "SELECT count(*) FROM vals");
 
   /* Writer adds rows and commits */
-  execsql(db1, "INSERT INTO vals VALUES(2, 20)");
-  execsql(db1, "INSERT INTO vals VALUES(3, 30)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'add two rows')");
+  execSql(db1, "INSERT INTO vals VALUES(2, 20)");
+  execSql(db1, "INSERT INTO vals VALUES(3, 30)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'add two rows')");
 
   /* All readers should still see count=1 (snapshot isolation) */
-  c2 = atoi(exec1(db2, "SELECT count(*) FROM vals"));
-  c3 = atoi(exec1(db3, "SELECT count(*) FROM vals"));
-  c4 = atoi(exec1(db4, "SELECT count(*) FROM vals"));
+  c2 = atoi(queryScalarText(db2, "SELECT count(*) FROM vals"));
+  c3 = atoi(queryScalarText(db3, "SELECT count(*) FROM vals"));
+  c4 = atoi(queryScalarText(db4, "SELECT count(*) FROM vals"));
   check("3.5_reader2_snapshot", c2==1);
   check("3.5_reader3_snapshot", c3==1);
   check("3.5_reader4_snapshot", c4==1);
 
-  execsql(db2, "COMMIT");
-  execsql(db3, "COMMIT");
-  execsql(db4, "COMMIT");
+  execSql(db2, "COMMIT");
+  execSql(db3, "COMMIT");
+  execSql(db4, "COMMIT");
 
   sqlite3_close(db1);
   sqlite3_close(db2);
   sqlite3_close(db3);
   sqlite3_close(db4);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -1257,24 +1257,24 @@ static void test_3_6_read_status_concurrent(void){
   const char *res;
 
   printf("  3.6  Read dolt_status while other has staged changes\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db1);
-  execsql(db1, "CREATE TABLE vals(id INT, val INT)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')");
+  execSql(db1, "CREATE TABLE vals(id INT, val INT)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init')");
 
   /* db1 inserts but does not commit */
-  execsql(db1, "INSERT INTO vals VALUES(1, 1)");
+  execSql(db1, "INSERT INTO vals VALUES(1, 1)");
 
   /* db2 reads status */
   open_fresh(path, &db2);
-  res = exec1(db2, "SELECT count(*) FROM dolt_status");
+  res = queryScalarText(db2, "SELECT count(*) FROM dolt_status");
   /* Should see some status entries (the uncommitted change) */
   check("3.6_status_visible", atoi(res) >= 0); /* non-crash is the key */
 
   sqlite3_close(db1);
   sqlite3_close(db2);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -1285,25 +1285,25 @@ static void test_3_7_concurrent_active_branch(void){
   const char *path = "/tmp/stress_3_7.db";
 
   printf("  3.7  Read active_branch from multiple connections\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db1);
-  execsql(db1, "CREATE TABLE vals(id INT, val INT)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')");
-  exec1(db1, "SELECT dolt_branch('feature')");
+  execSql(db1, "CREATE TABLE vals(id INT, val INT)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init')");
+  queryScalarText(db1, "SELECT dolt_branch('feature')");
 
   open_fresh(path, &db2);
   open_fresh(path, &db3);
-  exec1(db2, "SELECT dolt_checkout('feature')");
+  queryScalarText(db2, "SELECT dolt_checkout('feature')");
 
-  check("3.7_db1_main", strcmp(exec1(db1, "SELECT active_branch()"), "main")==0);
-  check("3.7_db2_feature", strcmp(exec1(db2, "SELECT active_branch()"), "feature")==0);
-  check("3.7_db3_main", strcmp(exec1(db3, "SELECT active_branch()"), "main")==0);
+  check("3.7_db1_main", strcmp(queryScalarText(db1, "SELECT active_branch()"), "main")==0);
+  check("3.7_db2_feature", strcmp(queryScalarText(db2, "SELECT active_branch()"), "feature")==0);
+  check("3.7_db3_main", strcmp(queryScalarText(db3, "SELECT active_branch()"), "main")==0);
 
   sqlite3_close(db1);
   sqlite3_close(db2);
   sqlite3_close(db3);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -1315,35 +1315,35 @@ static void test_3_8_cross_branch_read_write(void){
   const char *res;
 
   printf("  3.8  Reader on branch while writer commits on different branch\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db1);
-  execsql(db1, "CREATE TABLE vals(id INT, val INT)");
-  execsql(db1, "INSERT INTO vals VALUES(1, 10)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')");
-  exec1(db1, "SELECT dolt_branch('feature')");
+  execSql(db1, "CREATE TABLE vals(id INT, val INT)");
+  execSql(db1, "INSERT INTO vals VALUES(1, 10)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init')");
+  queryScalarText(db1, "SELECT dolt_branch('feature')");
 
   open_fresh(path, &db2);
-  exec1(db2, "SELECT dolt_checkout('feature')");
+  queryScalarText(db2, "SELECT dolt_checkout('feature')");
 
   /* db2 reads on feature */
-  execsql(db2, "BEGIN");
-  res = exec1(db2, "SELECT val FROM vals WHERE id=1");
+  execSql(db2, "BEGIN");
+  res = queryScalarText(db2, "SELECT val FROM vals WHERE id=1");
   check("3.8_feature_reads_init", strcmp(res, "10")==0);
 
   /* db1 commits on main */
-  execsql(db1, "UPDATE vals SET val=99 WHERE id=1");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'main update')");
+  execSql(db1, "UPDATE vals SET val=99 WHERE id=1");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'main update')");
 
   /* db2 should still see 10 on feature */
-  res = exec1(db2, "SELECT val FROM vals WHERE id=1");
+  res = queryScalarText(db2, "SELECT val FROM vals WHERE id=1");
   check("3.8_feature_still_sees_10", strcmp(res, "10")==0);
 
-  execsql(db2, "COMMIT");
+  execSql(db2, "COMMIT");
 
   sqlite3_close(db1);
   sqlite3_close(db2);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -1355,25 +1355,25 @@ static void test_3_9_read_branches_during_create(void){
   int count;
 
   printf("  3.9  Read dolt_branches while branches are created\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db1);
-  execsql(db1, "CREATE TABLE vals(id INT, val INT)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')");
+  execSql(db1, "CREATE TABLE vals(id INT, val INT)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init')");
 
   open_fresh(path, &db2);
-  count = atoi(exec1(db2, "SELECT count(*) FROM dolt_branches"));
+  count = atoi(queryScalarText(db2, "SELECT count(*) FROM dolt_branches"));
   check("3.9_initially_1_branch", count==1);
 
-  exec1(db1, "SELECT dolt_branch('b1')");
-  exec1(db1, "SELECT dolt_branch('b2')");
+  queryScalarText(db1, "SELECT dolt_branch('b1')");
+  queryScalarText(db1, "SELECT dolt_branch('b2')");
 
-  count = atoi(exec1(db2, "SELECT count(*) FROM dolt_branches"));
+  count = atoi(queryScalarText(db2, "SELECT count(*) FROM dolt_branches"));
   check("3.9_sees_new_branches", count==3);
 
   sqlite3_close(db1);
   sqlite3_close(db2);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -1386,11 +1386,11 @@ static void test_3_10_read_commit_read_cycle(void){
   int i, ok = 1;
 
   printf("  3.10 Repeated read-commit-read cycle\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db1);
-  execsql(db1, "CREATE TABLE vals(id INT, val INT)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')");
+  execSql(db1, "CREATE TABLE vals(id INT, val INT)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init')");
 
   open_fresh(path, &db2);
 
@@ -1399,17 +1399,17 @@ static void test_3_10_read_commit_read_cycle(void){
     int count_before, count_after;
 
     /* db2 reads count */
-    count_before = atoi(exec1(db2, "SELECT count(*) FROM vals"));
+    count_before = atoi(queryScalarText(db2, "SELECT count(*) FROM vals"));
 
     /* db1 inserts and commits */
     snprintf(sql, sizeof(sql), "INSERT INTO vals VALUES(%d, %d)", i, i*10);
-    execsql_busy(db1, sql, 50);
+    execSqlWithBusyRetry(db1, sql, 50);
     snprintf(msg, sizeof(msg),
              "SELECT dolt_commit('-A', '-m', 'add %d')", i);
     exec1_busy(db1, msg, 50);
 
     /* db2 reads count again */
-    count_after = atoi(exec1(db2, "SELECT count(*) FROM vals"));
+    count_after = atoi(queryScalarText(db2, "SELECT count(*) FROM vals"));
     if( count_after != count_before + 1 ){ ok = 0; }
   }
 
@@ -1417,7 +1417,7 @@ static void test_3_10_read_commit_read_cycle(void){
 
   sqlite3_close(db1);
   sqlite3_close(db2);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 
@@ -1437,20 +1437,20 @@ static void test_4_1_multi_branch_sequential(void){
   int i, j, ok = 1;
 
   printf("  4.1  4 connections x 10 commits on different branches\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &dbs[0]);
-  execsql(dbs[0], "CREATE TABLE vals(id INT, val INT)");
-  exec1(dbs[0], "SELECT dolt_commit('-A', '-m', 'init')");
-  exec1(dbs[0], "SELECT dolt_branch('b1')");
-  exec1(dbs[0], "SELECT dolt_branch('b2')");
-  exec1(dbs[0], "SELECT dolt_branch('b3')");
+  execSql(dbs[0], "CREATE TABLE vals(id INT, val INT)");
+  queryScalarText(dbs[0], "SELECT dolt_commit('-A', '-m', 'init')");
+  queryScalarText(dbs[0], "SELECT dolt_branch('b1')");
+  queryScalarText(dbs[0], "SELECT dolt_branch('b2')");
+  queryScalarText(dbs[0], "SELECT dolt_branch('b3')");
 
   for(i=1; i<4; i++){
     char sql[256];
     open_fresh(path, &dbs[i]);
     snprintf(sql, sizeof(sql), "SELECT dolt_checkout('%s')", branches[i]);
-    exec1(dbs[i], sql);
+    queryScalarText(dbs[i], sql);
   }
 
   for(j=0; j<10; j++){
@@ -1458,7 +1458,7 @@ static void test_4_1_multi_branch_sequential(void){
       char sql[256], msg[256];
       int id = i*100 + j;
       snprintf(sql, sizeof(sql), "INSERT INTO vals VALUES(%d, %d)", id, id);
-      execsql_busy(dbs[i], sql, 50);
+      execSqlWithBusyRetry(dbs[i], sql, 50);
       snprintf(msg, sizeof(msg),
                "SELECT dolt_commit('-A', '-m', '%s-commit-%d')", branches[i], j);
       res = exec1_busy(dbs[i], msg, 50);
@@ -1468,7 +1468,7 @@ static void test_4_1_multi_branch_sequential(void){
   check("4.1_all_40_commits_succeed", ok);
 
   for(i=0; i<4; i++) sqlite3_close(dbs[i]);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -1482,21 +1482,21 @@ static void test_4_2_rapid_alternating_writes(void){
   int i, ok = 1;
 
   printf("  4.2  Rapid alternating writes (serial)\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db);
-  execsql(db, "CREATE TABLE vals(id INT, val INT)");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'init')");
+  execSql(db, "CREATE TABLE vals(id INT, val INT)");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'init')");
   sqlite3_close(db);
 
   for(i=0; i<20; i++){
     char sql[256], msg[256];
     open_fresh(path, &db);
     snprintf(sql, sizeof(sql), "INSERT INTO vals VALUES(%d, %d)", i, i);
-    execsql(db, sql);
+    execSql(db, sql);
     snprintf(msg, sizeof(msg),
              "SELECT dolt_commit('-A', '-m', 'commit-%d')", i);
-    res = exec1(db, msg);
+    res = queryScalarText(db, msg);
     if( !is_commit_hash(res) ){ ok = 0; }
     sqlite3_close(db);
   }
@@ -1504,10 +1504,10 @@ static void test_4_2_rapid_alternating_writes(void){
 
   /* Verify final state */
   open_fresh(path, &db);
-  res = exec1(db, "SELECT count(*) FROM vals");
+  res = queryScalarText(db, "SELECT count(*) FROM vals");
   check("4.2_all_20_rows_present", strcmp(res, "20")==0);
   sqlite3_close(db);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -1520,37 +1520,37 @@ static void test_4_3_uncommitted_then_other_commits(void){
   const char *res;
 
   printf("  4.3  Uncommitted DML, other commits, then first commits\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db1);
-  execsql(db1, "CREATE TABLE vals(id INT, val INT)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')");
+  execSql(db1, "CREATE TABLE vals(id INT, val INT)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init')");
 
   open_fresh(path, &db2);
 
   /* db1 inserts but does NOT commit yet */
-  execsql(db1, "INSERT INTO vals VALUES(1, 1)");
+  execSql(db1, "INSERT INTO vals VALUES(1, 1)");
 
   /* db2 inserts and commits */
-  execsql_busy(db2, "INSERT INTO vals VALUES(2, 2)", 50);
+  execSqlWithBusyRetry(db2, "INSERT INTO vals VALUES(2, 2)", 50);
   res = exec1_busy(db2, "SELECT dolt_commit('-A', '-m', 'db2 first')", 50);
   check("4.3_db2_commits_ok", is_commit_hash(res));
 
   /* db1 now tries to commit — should conflict because its snapshot
   ** predates db2's commit */
-  res = exec1(db1, "SELECT dolt_commit('-A', '-m', 'db1 after')");
+  res = queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'db1 after')");
   check("4.3_db1_conflicts", is_error(res));
 
   /* db1 reopens and can commit fresh */
   sqlite3_close(db1);
   open_fresh(path, &db1);
-  execsql(db1, "INSERT INTO vals VALUES(1, 1)");
-  res = exec1(db1, "SELECT dolt_commit('-A', '-m', 'db1 retry')");
+  execSql(db1, "INSERT INTO vals VALUES(1, 1)");
+  res = queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'db1 retry')");
   check("4.3_db1_retry_succeeds", is_commit_hash(res));
 
   sqlite3_close(db1);
   sqlite3_close(db2);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -1563,28 +1563,28 @@ static void test_4_4_checkout_during_write(void){
   const char *res;
 
   printf("  4.4  Checkout while another is writing\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db1);
-  execsql(db1, "CREATE TABLE vals(id INT, val INT)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')");
-  exec1(db1, "SELECT dolt_branch('feature')");
+  execSql(db1, "CREATE TABLE vals(id INT, val INT)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init')");
+  queryScalarText(db1, "SELECT dolt_branch('feature')");
 
   /* db2 checks out feature BEFORE db1 starts writing — avoids
   ** shared BtShared pollution from db1's uncommitted WAL writes. */
   open_fresh(path, &db2);
-  res = exec1(db2, "SELECT dolt_checkout('feature')");
+  res = queryScalarText(db2, "SELECT dolt_checkout('feature')");
   check("4.4_checkout_succeeds", !is_error(res));
-  check("4.4_on_feature", strcmp(exec1(db2, "SELECT active_branch()"), "feature")==0);
+  check("4.4_on_feature", strcmp(queryScalarText(db2, "SELECT active_branch()"), "feature")==0);
 
   /* Now db1 starts writing and commits on main */
-  execsql_busy(db1, "INSERT INTO vals VALUES(1, 1)", 50);
+  execSqlWithBusyRetry(db1, "INSERT INTO vals VALUES(1, 1)", 50);
   res = exec1_busy(db1, "SELECT dolt_commit('-A', '-m', 'main commit')", 50);
   check("4.4_main_commit_ok", is_commit_hash(res));
 
   sqlite3_close(db1);
   sqlite3_close(db2);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -1597,21 +1597,21 @@ static void test_4_5_alternating_connections(void){
   int i, ok = 1;
 
   printf("  4.5  Alternating connections, sequential commits\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db);
-  execsql(db, "CREATE TABLE vals(id INT, val INT)");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'init')");
+  execSql(db, "CREATE TABLE vals(id INT, val INT)");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'init')");
   sqlite3_close(db);
 
   for(i=0; i<10; i++){
     char sql[256], msg[256];
     open_fresh(path, &db);
     snprintf(sql, sizeof(sql), "INSERT INTO vals VALUES(%d, %d)", i, i);
-    execsql(db, sql);
+    execSql(db, sql);
     snprintf(msg, sizeof(msg),
              "SELECT dolt_commit('-A', '-m', 'step-%d')", i);
-    res = exec1(db, msg);
+    res = queryScalarText(db, msg);
     if( !is_commit_hash(res) ) ok = 0;
     sqlite3_close(db);
   }
@@ -1619,10 +1619,10 @@ static void test_4_5_alternating_connections(void){
   check("4.5_10_alternating_commits_ok", ok);
 
   open_fresh(path, &db);
-  res = exec1(db, "SELECT count(*) FROM dolt_log");
+  res = queryScalarText(db, "SELECT count(*) FROM dolt_log");
   check("4.5_log_has_11_entries", strcmp(res, "11")==0);
   sqlite3_close(db);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -1635,42 +1635,42 @@ static void test_4_6_conflict_recovery(void){
   const char *res;
 
   printf("  4.6  Conflict then recovery\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db1);
-  execsql(db1, "CREATE TABLE vals(id INT, val INT)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')");
+  execSql(db1, "CREATE TABLE vals(id INT, val INT)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init')");
 
   open_fresh(path, &db2);
-  exec1(db2, "SELECT count(*) FROM vals");
+  queryScalarText(db2, "SELECT count(*) FROM vals");
 
   /* Create conflict */
-  execsql(db1, "INSERT INTO vals VALUES(1, 1)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'first')");
+  execSql(db1, "INSERT INTO vals VALUES(1, 1)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'first')");
 
-  execsql(db2, "INSERT INTO vals VALUES(2, 2)");
-  res = exec1(db2, "SELECT dolt_commit('-A', '-m', 'second')");
+  execSql(db2, "INSERT INTO vals VALUES(2, 2)");
+  res = queryScalarText(db2, "SELECT dolt_commit('-A', '-m', 'second')");
   check("4.6_conflict_detected", is_error(res));
 
   /* db2 can recover by closing all connections and reopening */
   sqlite3_close(db1); db1 = 0;
   sqlite3_close(db2); db2 = 0;
   open_fresh(path, &db2);
-  execsql(db2, "INSERT INTO vals VALUES(20, 20)");
-  res = exec1(db2, "SELECT dolt_commit('-A', '-m', 'recovered')");
+  execSql(db2, "INSERT INTO vals VALUES(20, 20)");
+  res = queryScalarText(db2, "SELECT dolt_commit('-A', '-m', 'recovered')");
   check("4.6_recovery_commit_ok", is_commit_hash(res));
 
   /* Verify recovery commit is in the log */
-  res = exec1(db2, "SELECT message FROM dolt_log LIMIT 1");
+  res = queryScalarText(db2, "SELECT message FROM dolt_log LIMIT 1");
   check("4.6_recovery_in_log", strcmp(res, "recovered")==0);
 
   /* Verify at least the committed rows exist (WAL artifacts from rejected
   ** commit may or may not persist — the key is dolt_log correctness) */
-  res = exec1(db2, "SELECT count(*) FROM dolt_log");
+  res = queryScalarText(db2, "SELECT count(*) FROM dolt_log");
   check("4.6_log_has_3_entries", strcmp(res, "3")==0);
 
   sqlite3_close(db2);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -1683,11 +1683,11 @@ static void test_4_7_repeated_conflict_recovery(void){
   int i, conflicts = 0;
 
   printf("  4.7  Multiple conflict-recovery cycles\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db1);
-  execsql(db1, "CREATE TABLE vals(id INT, val INT)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')");
+  execSql(db1, "CREATE TABLE vals(id INT, val INT)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init')");
 
   for(i=0; i<5; i++){
     char sql1[256], sql2[256], msg1[256], msg2[256];
@@ -1697,20 +1697,20 @@ static void test_4_7_repeated_conflict_recovery(void){
     if(db2){ sqlite3_close(db2); db2=0; }
     open_fresh(path, &db1);
     open_fresh(path, &db2);
-    exec1(db2, "SELECT count(*) FROM vals"); /* anchor snapshot */
+    queryScalarText(db2, "SELECT count(*) FROM vals"); /* anchor snapshot */
 
     snprintf(sql1, sizeof(sql1), "INSERT INTO vals VALUES(%d, %d)", i*2, i*2);
     snprintf(sql2, sizeof(sql2), "INSERT INTO vals VALUES(%d, %d)", i*2+1, i*2+1);
 
-    execsql(db1, sql1);
+    execSql(db1, sql1);
     snprintf(msg1, sizeof(msg1),
              "SELECT dolt_commit('-A', '-m', 'cycle-%d-a')", i);
-    exec1(db1, msg1);
+    queryScalarText(db1, msg1);
 
-    execsql(db2, sql2);
+    execSql(db2, sql2);
     snprintf(msg2, sizeof(msg2),
              "SELECT dolt_commit('-A', '-m', 'cycle-%d-b')", i);
-    res = exec1(db2, msg2);
+    res = queryScalarText(db2, msg2);
     if( is_error(res) ) conflicts++;
   }
   check("4.7_all_5_cycles_produce_conflict", conflicts==5);
@@ -1722,10 +1722,10 @@ static void test_4_7_repeated_conflict_recovery(void){
   if(db2) sqlite3_close(db2);
   open_fresh(path, &db3);
   /* init + 5 successful commits = 6 log entries */
-  res = exec1(db3, "SELECT count(*) FROM dolt_log");
+  res = queryScalarText(db3, "SELECT count(*) FROM dolt_log");
   check("4.7_6_log_entries_from_successful_commits", strcmp(res, "6")==0);
   sqlite3_close(db3);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -1738,40 +1738,40 @@ static void test_4_8_large_batch_with_reader(void){
   int i;
 
   printf("  4.8  Large batch insert with concurrent reader\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db1);
-  execsql(db1, "CREATE TABLE vals(id INT, val INT)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')");
+  execSql(db1, "CREATE TABLE vals(id INT, val INT)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init')");
 
   open_fresh(path, &db2);
-  execsql(db2, "BEGIN");
-  exec1(db2, "SELECT count(*) FROM vals"); /* anchor at 0 rows */
+  execSql(db2, "BEGIN");
+  queryScalarText(db2, "SELECT count(*) FROM vals"); /* anchor at 0 rows */
 
   /* db1 inserts 100 rows */
-  execsql(db1, "BEGIN");
+  execSql(db1, "BEGIN");
   for(i=0; i<100; i++){
     char sql[256];
     snprintf(sql, sizeof(sql), "INSERT INTO vals VALUES(%d, %d)", i, i*10);
-    execsql(db1, sql);
+    execSql(db1, sql);
   }
-  execsql(db1, "COMMIT");
-  res = exec1(db1, "SELECT dolt_commit('-A', '-m', 'batch insert')");
+  execSql(db1, "COMMIT");
+  res = queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'batch insert')");
   check("4.8_batch_commit_ok", is_commit_hash(res));
 
   /* db2 should still see 0 rows in its snapshot */
-  res = exec1(db2, "SELECT count(*) FROM vals");
+  res = queryScalarText(db2, "SELECT count(*) FROM vals");
   check("4.8_reader_sees_0_in_snapshot", strcmp(res, "0")==0);
 
-  execsql(db2, "COMMIT");
+  execSql(db2, "COMMIT");
 
   /* After ending transaction, db2 sees 100 rows */
-  res = exec1(db2, "SELECT count(*) FROM vals");
+  res = queryScalarText(db2, "SELECT count(*) FROM vals");
   check("4.8_reader_sees_100_after_tx", strcmp(res, "100")==0);
 
   sqlite3_close(db1);
   sqlite3_close(db2);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -1785,11 +1785,11 @@ static void test_4_9_write_contention(void){
   int i;
 
   printf("  4.9  Write contention with busy retry\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db1);
-  execsql(db1, "CREATE TABLE vals(id INT, val INT)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')");
+  execSql(db1, "CREATE TABLE vals(id INT, val INT)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init')");
 
   open_fresh(path, &db2);
   open_fresh(path, &db3);
@@ -1799,7 +1799,7 @@ static void test_4_9_write_contention(void){
     char sql[256];
     sqlite3 *dbs[] = {db1, db2, db3};
     snprintf(sql, sizeof(sql), "INSERT INTO vals VALUES(%d, %d)", i, i);
-    execsql_busy(dbs[i%3], sql, 50);
+    execSqlWithBusyRetry(dbs[i%3], sql, 50);
   }
 
   /* db1 commits — captures all writes from shared WAL */
@@ -1809,7 +1809,7 @@ static void test_4_9_write_contention(void){
   sqlite3_close(db1);
   sqlite3_close(db2);
   sqlite3_close(db3);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -1822,21 +1822,21 @@ static void test_4_10_commit_reopen_cycle(void){
   int i, ok = 1;
 
   printf("  4.10 Commit-reopen cycle 20 times\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db);
-  execsql(db, "CREATE TABLE vals(id INT PRIMARY KEY, val INT)");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'init')");
+  execSql(db, "CREATE TABLE vals(id INT PRIMARY KEY, val INT)");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'init')");
   sqlite3_close(db);
 
   for(i=0; i<20; i++){
     char sql[256], msg[256];
     open_fresh(path, &db);
     snprintf(sql, sizeof(sql), "INSERT INTO vals VALUES(%d, %d)", i, i*10);
-    execsql(db, sql);
+    execSql(db, sql);
     snprintf(msg, sizeof(msg),
              "SELECT dolt_commit('-A', '-m', 'cycle %d')", i);
-    res = exec1(db, msg);
+    res = queryScalarText(db, msg);
     if( !is_commit_hash(res) ) ok = 0;
     sqlite3_close(db);
     db = 0;
@@ -1844,12 +1844,12 @@ static void test_4_10_commit_reopen_cycle(void){
   check("4.10_all_20_cycles_ok", ok);
 
   open_fresh(path, &db);
-  res = exec1(db, "SELECT count(*) FROM vals");
+  res = queryScalarText(db, "SELECT count(*) FROM vals");
   check("4.10_20_rows_present", strcmp(res, "20")==0);
-  res = exec1(db, "SELECT count(*) FROM dolt_log");
+  res = queryScalarText(db, "SELECT count(*) FROM dolt_log");
   check("4.10_21_log_entries", strcmp(res, "21")==0);
   sqlite3_close(db);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -1862,42 +1862,42 @@ static void test_4_11_branch_log_divergence(void){
   int i;
 
   printf("  4.11 Branch log divergence\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db);
-  execsql(db, "CREATE TABLE vals(id INT, val INT)");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'init')");
-  exec1(db, "SELECT dolt_branch('dev')");
+  execSql(db, "CREATE TABLE vals(id INT, val INT)");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'init')");
+  queryScalarText(db, "SELECT dolt_branch('dev')");
 
   /* 5 commits on main */
   for(i=0; i<5; i++){
     char sql[256], msg[256];
     snprintf(sql, sizeof(sql), "INSERT INTO vals VALUES(%d, %d)", i, i);
-    execsql(db, sql);
+    execSql(db, sql);
     snprintf(msg, sizeof(msg), "SELECT dolt_commit('-A', '-m', 'main-%d')", i);
-    exec1(db, msg);
+    queryScalarText(db, msg);
   }
 
   /* Switch to dev — 3 commits */
-  exec1(db, "SELECT dolt_checkout('dev')");
+  queryScalarText(db, "SELECT dolt_checkout('dev')");
   for(i=100; i<103; i++){
     char sql[256], msg[256];
     snprintf(sql, sizeof(sql), "INSERT INTO vals VALUES(%d, %d)", i, i);
-    execsql(db, sql);
+    execSql(db, sql);
     snprintf(msg, sizeof(msg), "SELECT dolt_commit('-A', '-m', 'dev-%d')", i-100);
-    exec1(db, msg);
+    queryScalarText(db, msg);
   }
 
-  res = exec1(db, "SELECT count(*) FROM dolt_log");
+  res = queryScalarText(db, "SELECT count(*) FROM dolt_log");
   check("4.11_dev_log_has_4", strcmp(res, "4")==0); /* init + 3 */
 
   /* Switch back to main */
-  exec1(db, "SELECT dolt_checkout('main')");
-  res = exec1(db, "SELECT count(*) FROM dolt_log");
+  queryScalarText(db, "SELECT dolt_checkout('main')");
+  res = queryScalarText(db, "SELECT count(*) FROM dolt_log");
   check("4.11_main_log_has_6", strcmp(res, "6")==0); /* init + 5 */
 
   sqlite3_close(db);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 
@@ -1915,22 +1915,22 @@ static void test_5_1_first_commit_race(void){
   int successes = 0;
 
   printf("  5.1  First commit ever from two connections\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db1);
   open_fresh(path, &db2);
 
-  execsql(db1, "CREATE TABLE t1(id INT, val INT)");
+  execSql(db1, "CREATE TABLE t1(id INT, val INT)");
   /* db2 may or may not see the table via WAL depending on timing */
 
-  res1 = exec1(db1, "SELECT dolt_commit('-A', '-m', 'first from db1')");
+  res1 = queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'first from db1')");
   if( is_commit_hash(res1) ) successes++;
 
   /* db2 tries to make a commit too — it may succeed if it sees a
   ** consistent state, or fail with conflict. Either is acceptable,
   ** the key invariant is no crash and no silent data loss. */
-  execsql_busy(db2, "CREATE TABLE IF NOT EXISTS t2(id INT, val INT)", 50);
-  res2 = exec1(db2, "SELECT dolt_commit('-A', '-m', 'first from db2')");
+  execSqlWithBusyRetry(db2, "CREATE TABLE IF NOT EXISTS t2(id INT, val INT)", 50);
+  res2 = queryScalarText(db2, "SELECT dolt_commit('-A', '-m', 'first from db2')");
   if( is_commit_hash(res2) ) successes++;
 
   check("5.1_at_least_one_succeeds", successes >= 1);
@@ -1938,7 +1938,7 @@ static void test_5_1_first_commit_race(void){
 
   sqlite3_close(db1);
   sqlite3_close(db2);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -1950,29 +1950,29 @@ static void test_5_2_empty_commit_during_insert(void){
   const char *res;
 
   printf("  5.2  Empty table commit while other inserts\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db1);
-  execsql(db1, "CREATE TABLE vals(id INT, val INT)");
-  execsql(db1, "INSERT INTO vals VALUES(1, 10)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')");
+  execSql(db1, "CREATE TABLE vals(id INT, val INT)");
+  execSql(db1, "INSERT INTO vals VALUES(1, 10)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init')");
 
   open_fresh(path, &db2);
-  exec1(db2, "SELECT count(*) FROM vals");
+  queryScalarText(db2, "SELECT count(*) FROM vals");
 
   /* db1 makes a commit that changes nothing in the table but adds a new one */
-  execsql(db1, "CREATE TABLE empty_t(x INT)");
-  res = exec1(db1, "SELECT dolt_commit('-A', '-m', 'add empty table')");
+  execSql(db1, "CREATE TABLE empty_t(x INT)");
+  res = queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'add empty table')");
   check("5.2_empty_table_commit_ok", is_commit_hash(res));
 
   /* db2 inserts into vals and tries to commit — stale snapshot */
-  execsql(db2, "INSERT INTO vals VALUES(2, 20)");
-  res = exec1(db2, "SELECT dolt_commit('-A', '-m', 'insert after')");
+  execSql(db2, "INSERT INTO vals VALUES(2, 20)");
+  res = queryScalarText(db2, "SELECT dolt_commit('-A', '-m', 'insert after')");
   check("5.2_stale_snapshot_rejected", is_error(res));
 
   sqlite3_close(db1);
   sqlite3_close(db2);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -1984,32 +1984,32 @@ static void test_5_3_schema_change_during_read(void){
   const char *res;
 
   printf("  5.3  Schema change while another reads\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db1);
-  execsql(db1, "CREATE TABLE t1(id INT, val INT)");
-  execsql(db1, "INSERT INTO t1 VALUES(1, 10)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')");
+  execSql(db1, "CREATE TABLE t1(id INT, val INT)");
+  execSql(db1, "INSERT INTO t1 VALUES(1, 10)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init')");
 
   open_fresh(path, &db2);
-  execsql(db2, "BEGIN");
-  res = exec1(db2, "SELECT val FROM t1 WHERE id=1");
+  execSql(db2, "BEGIN");
+  res = queryScalarText(db2, "SELECT val FROM t1 WHERE id=1");
   check("5.3_reader_sees_data", strcmp(res, "10")==0);
 
   /* db1 creates a new table and commits */
-  execsql_busy(db1, "CREATE TABLE t2(a INT, b TEXT)", 50);
+  execSqlWithBusyRetry(db1, "CREATE TABLE t2(a INT, b TEXT)", 50);
   res = exec1_busy(db1, "SELECT dolt_commit('-A', '-m', 'add t2')", 50);
   check("5.3_schema_commit_ok", is_commit_hash(res));
 
   /* db2 should still be able to read t1 in its snapshot */
-  res = exec1(db2, "SELECT val FROM t1 WHERE id=1");
+  res = queryScalarText(db2, "SELECT val FROM t1 WHERE id=1");
   check("5.3_reader_still_ok", strcmp(res, "10")==0);
 
-  execsql(db2, "COMMIT");
+  execSql(db2, "COMMIT");
 
   sqlite3_close(db1);
   sqlite3_close(db2);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -2021,32 +2021,32 @@ static void test_5_4_reset_during_read(void){
   const char *res;
 
   printf("  5.4  dolt_reset --hard while another reads\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db1);
-  execsql(db1, "CREATE TABLE vals(id INT, val INT)");
-  execsql(db1, "INSERT INTO vals VALUES(1, 10)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')");
+  execSql(db1, "CREATE TABLE vals(id INT, val INT)");
+  execSql(db1, "INSERT INTO vals VALUES(1, 10)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init')");
 
   /* db1 has uncommitted changes */
-  execsql(db1, "INSERT INTO vals VALUES(2, 20)");
+  execSql(db1, "INSERT INTO vals VALUES(2, 20)");
 
   /* db2 reads */
   open_fresh(path, &db2);
-  execsql(db2, "BEGIN");
-  res = exec1(db2, "SELECT count(*) FROM vals");
+  execSql(db2, "BEGIN");
+  res = queryScalarText(db2, "SELECT count(*) FROM vals");
   /* db2 sees either 1 or 2 depending on WAL timing — both are acceptable */
   check("5.4_reader_sees_data", atoi(res) >= 1);
 
   /* db1 resets hard */
-  res = exec1(db1, "SELECT dolt_reset('--hard')");
+  res = queryScalarText(db1, "SELECT dolt_reset('--hard')");
   check("5.4_reset_doesnt_crash", !is_error(res) || 1); /* either OK or error, no crash */
 
-  execsql(db2, "COMMIT");
+  execSql(db2, "COMMIT");
 
   sqlite3_close(db1);
   sqlite3_close(db2);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -2058,19 +2058,19 @@ static void test_5_5_empty_diff_commit(void){
   const char *res;
 
   printf("  5.5  Commit with empty diff\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db);
-  execsql(db, "CREATE TABLE vals(id INT, val INT)");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'init')");
+  execSql(db, "CREATE TABLE vals(id INT, val INT)");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'init')");
 
   /* Try to commit with no changes — may succeed with empty commit
   ** or fail with "nothing to commit". Either is acceptable. */
-  res = exec1(db, "SELECT dolt_commit('-A', '-m', 'empty commit')");
+  res = queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'empty commit')");
   check("5.5_empty_commit_no_crash", 1); /* no crash is the invariant */
 
   sqlite3_close(db);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -2084,19 +2084,19 @@ static void test_5_6_long_commit_message(void){
   const char *res;
 
   printf("  5.6  Very long commit message\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db);
-  execsql(db, "CREATE TABLE vals(id INT, val INT)");
+  execSql(db, "CREATE TABLE vals(id INT, val INT)");
   /* Create a message with 2000 'x' characters */
   memset(msg, 'x', 2000);
   msg[2000] = 0;
   snprintf(sql, sizeof(sql), "SELECT dolt_commit('-A', '-m', '%s')", msg);
-  res = exec1(db, sql);
+  res = queryScalarText(db, sql);
   check("5.6_long_message_commit_ok", is_commit_hash(res));
 
   sqlite3_close(db);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -2108,26 +2108,26 @@ static void test_5_7_late_connection(void){
   const char *res;
 
   printf("  5.7  Late connection sees committed state\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db1);
-  execsql(db1, "CREATE TABLE vals(id INT, val INT)");
-  execsql(db1, "INSERT INTO vals VALUES(1, 10)");
-  execsql(db1, "INSERT INTO vals VALUES(2, 20)");
-  execsql(db1, "INSERT INTO vals VALUES(3, 30)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'three rows')");
+  execSql(db1, "CREATE TABLE vals(id INT, val INT)");
+  execSql(db1, "INSERT INTO vals VALUES(1, 10)");
+  execSql(db1, "INSERT INTO vals VALUES(2, 20)");
+  execSql(db1, "INSERT INTO vals VALUES(3, 30)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'three rows')");
   sqlite3_close(db1);
 
   /* New connection opened after all commits */
   open_fresh(path, &db2);
-  res = exec1(db2, "SELECT count(*) FROM vals");
+  res = queryScalarText(db2, "SELECT count(*) FROM vals");
   check("5.7_late_sees_all_rows", strcmp(res, "3")==0);
 
-  res = exec1(db2, "SELECT count(*) FROM dolt_log");
+  res = queryScalarText(db2, "SELECT count(*) FROM dolt_log");
   check("5.7_late_sees_log", strcmp(res, "1")==0);
 
   sqlite3_close(db2);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -2140,34 +2140,34 @@ static void test_5_8_close_after_commit(void){
   int i;
 
   printf("  5.8  Close immediately after commit, reopen and verify\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db1);
-  execsql(db1, "CREATE TABLE vals(id INT, val INT)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')");
+  execSql(db1, "CREATE TABLE vals(id INT, val INT)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init')");
   sqlite3_close(db1);
 
   for(i=0; i<5; i++){
     char sql[256], msg[256];
     open_fresh(path, &db1);
     snprintf(sql, sizeof(sql), "INSERT INTO vals VALUES(%d, %d)", i, i);
-    execsql(db1, sql);
+    execSql(db1, sql);
     snprintf(msg, sizeof(msg),
              "SELECT dolt_commit('-A', '-m', 'row %d')", i);
-    exec1(db1, msg);
+    queryScalarText(db1, msg);
     sqlite3_close(db1);
     db1 = 0;
   }
 
   open_fresh(path, &db2);
-  res = exec1(db2, "SELECT count(*) FROM vals");
+  res = queryScalarText(db2, "SELECT count(*) FROM vals");
   check("5.8_all_rows_persisted", strcmp(res, "5")==0);
 
-  res = exec1(db2, "SELECT count(*) FROM dolt_log");
+  res = queryScalarText(db2, "SELECT count(*) FROM dolt_log");
   check("5.8_all_commits_in_log", strcmp(res, "6")==0);
 
   sqlite3_close(db2);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -2179,32 +2179,32 @@ static void test_5_9_multi_table_conflict(void){
   const char *res;
 
   printf("  5.9  Multi-table single commit, conflict detected\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db1);
-  execsql(db1, "CREATE TABLE t1(a INT)");
-  execsql(db1, "CREATE TABLE t2(b INT)");
-  execsql(db1, "CREATE TABLE t3(c INT)");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')");
+  execSql(db1, "CREATE TABLE t1(a INT)");
+  execSql(db1, "CREATE TABLE t2(b INT)");
+  execSql(db1, "CREATE TABLE t3(c INT)");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init')");
 
   open_fresh(path, &db2);
-  exec1(db2, "SELECT count(*) FROM t1");
+  queryScalarText(db2, "SELECT count(*) FROM t1");
 
   /* db1 writes to all 3 tables and commits */
-  execsql(db1, "INSERT INTO t1 VALUES(1)");
-  execsql(db1, "INSERT INTO t2 VALUES(2)");
-  execsql(db1, "INSERT INTO t3 VALUES(3)");
-  res = exec1(db1, "SELECT dolt_commit('-A', '-m', 'multi table')");
+  execSql(db1, "INSERT INTO t1 VALUES(1)");
+  execSql(db1, "INSERT INTO t2 VALUES(2)");
+  execSql(db1, "INSERT INTO t3 VALUES(3)");
+  res = queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'multi table')");
   check("5.9_multi_table_commit_ok", is_commit_hash(res));
 
   /* db2 writes to t1 only — should still conflict (branch HEAD changed) */
-  execsql(db2, "INSERT INTO t1 VALUES(10)");
-  res = exec1(db2, "SELECT dolt_commit('-A', '-m', 'conflict')");
+  execSql(db2, "INSERT INTO t1 VALUES(10)");
+  res = queryScalarText(db2, "SELECT dolt_commit('-A', '-m', 'conflict')");
   check("5.9_conflict_despite_single_table_write", is_error(res));
 
   sqlite3_close(db1);
   sqlite3_close(db2);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -2216,53 +2216,53 @@ static void test_5_10_integrity_after_conflict(void){
   const char *res;
 
   printf("  5.10 Integrity check after conflict\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db1);
-  execsql(db1, "CREATE TABLE vals(id INT PRIMARY KEY, val TEXT)");
-  execsql(db1, "INSERT INTO vals VALUES(1, 'alpha')");
-  execsql(db1, "INSERT INTO vals VALUES(2, 'beta')");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')");
+  execSql(db1, "CREATE TABLE vals(id INT PRIMARY KEY, val TEXT)");
+  execSql(db1, "INSERT INTO vals VALUES(1, 'alpha')");
+  execSql(db1, "INSERT INTO vals VALUES(2, 'beta')");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init')");
 
   open_fresh(path, &db2);
-  exec1(db2, "SELECT count(*) FROM vals");
+  queryScalarText(db2, "SELECT count(*) FROM vals");
 
   /* Cause a conflict */
-  execsql(db1, "INSERT INTO vals VALUES(3, 'gamma')");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'add gamma')");
+  execSql(db1, "INSERT INTO vals VALUES(3, 'gamma')");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'add gamma')");
 
-  execsql(db2, "INSERT INTO vals VALUES(4, 'delta')");
-  exec1(db2, "SELECT dolt_commit('-A', '-m', 'add delta')"); /* rejected */
+  execSql(db2, "INSERT INTO vals VALUES(4, 'delta')");
+  queryScalarText(db2, "SELECT dolt_commit('-A', '-m', 'add delta')"); /* rejected */
 
   sqlite3_close(db1);
   sqlite3_close(db2);
 
   /* Reopen and run integrity check */
   open_fresh(path, &db3);
-  res = exec1(db3, "PRAGMA integrity_check");
+  res = queryScalarText(db3, "PRAGMA integrity_check");
   check("5.10_integrity_check_ok", strcmp(res, "ok")==0);
 
   /* Verify committed data: the SQL table may contain WAL artifacts from
   ** the rejected commit (a known limitation of shared BtShared), but the
   ** dolt version history must be correct. */
-  res = exec1(db3, "SELECT count(*) FROM vals");
+  res = queryScalarText(db3, "SELECT count(*) FROM vals");
   /* Should have at least 3 rows (alpha, beta, gamma). May have 4 if the
   ** rejected commit's INSERT lingered in the WAL. */
   check("5.10_correct_row_count_at_least_3", atoi(res) >= 3);
 
-  res = exec1(db3, "SELECT val FROM vals WHERE id=3");
+  res = queryScalarText(db3, "SELECT val FROM vals WHERE id=3");
   check("5.10_gamma_exists", strcmp(res, "gamma")==0);
 
   /* The critical invariant: delta must NOT be in the dolt log */
-  res = exec1(db3, "SELECT count(*) FROM dolt_log WHERE message='add delta'");
+  res = queryScalarText(db3, "SELECT count(*) FROM dolt_log WHERE message='add delta'");
   check("5.10_delta_not_committed", strcmp(res, "0")==0);
 
   /* Only 2 dolt commits: init + add gamma */
-  res = exec1(db3, "SELECT count(*) FROM dolt_log");
+  res = queryScalarText(db3, "SELECT count(*) FROM dolt_log");
   check("5.10_exactly_2_log_entries", strcmp(res, "2")==0);
 
   sqlite3_close(db3);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -2275,11 +2275,11 @@ static void test_5_11_back_to_back_conflicts(void){
   int round, conflicts = 0;
 
   printf("  5.11 Back-to-back conflicts (3 rounds)\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &setup);
-  execsql(setup, "CREATE TABLE vals(id INT, val INT)");
-  exec1(setup, "SELECT dolt_commit('-A', '-m', 'init')");
+  execSql(setup, "CREATE TABLE vals(id INT, val INT)");
+  queryScalarText(setup, "SELECT dolt_commit('-A', '-m', 'init')");
   sqlite3_close(setup);
 
   for(round=0; round<3; round++){
@@ -2287,21 +2287,21 @@ static void test_5_11_back_to_back_conflicts(void){
 
     open_fresh(path, &db1);
     open_fresh(path, &db2);
-    exec1(db2, "SELECT count(*) FROM vals"); /* anchor */
+    queryScalarText(db2, "SELECT count(*) FROM vals"); /* anchor */
 
     snprintf(sql1, sizeof(sql1), "INSERT INTO vals VALUES(%d, %d)", round*10, round*10);
     snprintf(sql2, sizeof(sql2), "INSERT INTO vals VALUES(%d, %d)", round*10+1, round*10+1);
 
-    execsql(db1, sql1);
+    execSql(db1, sql1);
     snprintf(msg1, sizeof(msg1),
              "SELECT dolt_commit('-A', '-m', 'r%d-first')", round);
-    res = exec1(db1, msg1);
+    res = queryScalarText(db1, msg1);
     check("5.11_first_commits", is_commit_hash(res));
 
-    execsql(db2, sql2);
+    execSql(db2, sql2);
     snprintf(msg2, sizeof(msg2),
              "SELECT dolt_commit('-A', '-m', 'r%d-second')", round);
-    res = exec1(db2, msg2);
+    res = queryScalarText(db2, msg2);
     if( is_error(res) ) conflicts++;
 
     sqlite3_close(db1); db1 = 0;
@@ -2309,7 +2309,7 @@ static void test_5_11_back_to_back_conflicts(void){
   }
   check("5.11_all_3_rounds_conflicted", conflicts==3);
 
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 /*
@@ -2322,57 +2322,57 @@ static void test_5_12_comprehensive_integrity(void){
   const char *res;
 
   printf("  5.12 Comprehensive integrity after mixed operations\n");
-  remove_db(path);
+  removeDbFiles(path);
 
   open_fresh(path, &db);
-  execsql(db, "CREATE TABLE vals(id INT PRIMARY KEY, val TEXT)");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'init')");
+  execSql(db, "CREATE TABLE vals(id INT PRIMARY KEY, val TEXT)");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'init')");
 
   /* Insert 5 rows */
-  execsql(db, "INSERT INTO vals VALUES(1, 'one')");
-  execsql(db, "INSERT INTO vals VALUES(2, 'two')");
-  execsql(db, "INSERT INTO vals VALUES(3, 'three')");
-  execsql(db, "INSERT INTO vals VALUES(4, 'four')");
-  execsql(db, "INSERT INTO vals VALUES(5, 'five')");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'add 5 rows')");
+  execSql(db, "INSERT INTO vals VALUES(1, 'one')");
+  execSql(db, "INSERT INTO vals VALUES(2, 'two')");
+  execSql(db, "INSERT INTO vals VALUES(3, 'three')");
+  execSql(db, "INSERT INTO vals VALUES(4, 'four')");
+  execSql(db, "INSERT INTO vals VALUES(5, 'five')");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'add 5 rows')");
 
   /* Update some */
-  execsql(db, "UPDATE vals SET val='ONE' WHERE id=1");
-  execsql(db, "UPDATE vals SET val='THREE' WHERE id=3");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'update 2 rows')");
+  execSql(db, "UPDATE vals SET val='ONE' WHERE id=1");
+  execSql(db, "UPDATE vals SET val='THREE' WHERE id=3");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'update 2 rows')");
 
   /* Delete one */
-  execsql(db, "DELETE FROM vals WHERE id=4");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'delete id 4')");
+  execSql(db, "DELETE FROM vals WHERE id=4");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'delete id 4')");
 
   /* Verify state */
-  res = exec1(db, "SELECT count(*) FROM vals");
+  res = queryScalarText(db, "SELECT count(*) FROM vals");
   check("5.12_4_rows_remaining", strcmp(res, "4")==0);
 
-  res = exec1(db, "SELECT val FROM vals WHERE id=1");
+  res = queryScalarText(db, "SELECT val FROM vals WHERE id=1");
   check("5.12_id1_updated", strcmp(res, "ONE")==0);
 
-  res = exec1(db, "SELECT val FROM vals WHERE id=2");
+  res = queryScalarText(db, "SELECT val FROM vals WHERE id=2");
   check("5.12_id2_unchanged", strcmp(res, "two")==0);
 
-  res = exec1(db, "SELECT count(*) FROM dolt_log");
+  res = queryScalarText(db, "SELECT count(*) FROM dolt_log");
   check("5.12_4_log_entries", strcmp(res, "4")==0);
 
   /* Close, reopen, re-verify (persistence check) */
   sqlite3_close(db);
   open_fresh(path, &db);
 
-  res = exec1(db, "SELECT count(*) FROM vals");
+  res = queryScalarText(db, "SELECT count(*) FROM vals");
   check("5.12_persisted_4_rows", strcmp(res, "4")==0);
 
-  res = exec1(db, "SELECT val FROM vals WHERE id=3");
+  res = queryScalarText(db, "SELECT val FROM vals WHERE id=3");
   check("5.12_persisted_update", strcmp(res, "THREE")==0);
 
-  res = exec1(db, "PRAGMA integrity_check");
+  res = queryScalarText(db, "PRAGMA integrity_check");
   check("5.12_final_integrity_ok", strcmp(res, "ok")==0);
 
   sqlite3_close(db);
-  remove_db(path);
+  removeDbFiles(path);
 }
 
 

--- a/test/concurrent_write_test.c
+++ b/test/concurrent_write_test.c
@@ -32,7 +32,7 @@ static void check(const char *name, int condition){
 
 /* Execute SQL, return first column of first row as string (static buffer) */
 static char result_buf[4096];
-static const char *exec1(sqlite3 *db, const char *sql){
+static const char *queryScalarText(sqlite3 *db, const char *sql){
   sqlite3_stmt *stmt = 0;
   int rc;
   result_buf[0] = 0;
@@ -53,7 +53,7 @@ static const char *exec1(sqlite3 *db, const char *sql){
 }
 
 /* Execute SQL, ignore result */
-static int execsql(sqlite3 *db, const char *sql){
+static int execSql(sqlite3 *db, const char *sql){
   char *err = 0;
   int rc = sqlite3_exec(db, sql, 0, 0, &err);
   if( rc!=SQLITE_OK ){
@@ -64,7 +64,7 @@ static int execsql(sqlite3 *db, const char *sql){
 }
 
 /* Execute SQL with retry on SQLITE_BUSY */
-static int execsql_busy(sqlite3 *db, const char *sql, int maxRetries){
+static int execSqlWithBusyRetry(sqlite3 *db, const char *sql, int maxRetries){
   char *err = 0;
   int rc;
   int attempts = 0;
@@ -86,7 +86,7 @@ static int execsql_busy(sqlite3 *db, const char *sql, int maxRetries){
   return rc;
 }
 
-/* exec1 with retry on SQLITE_BUSY */
+/* queryScalarText with retry on SQLITE_BUSY */
 static const char *exec1_busy(sqlite3 *db, const char *sql, int maxRetries){
   sqlite3_stmt *stmt = 0;
   int rc;
@@ -144,87 +144,87 @@ int main(){
   sqlite3_busy_timeout(db4, 5000);
 
   /* --- All connections should be on main --- */
-  check("db1_on_main", strcmp(exec1(db1, "SELECT active_branch()"), "main")==0);
-  check("db2_on_main", strcmp(exec1(db2, "SELECT active_branch()"), "main")==0);
-  check("db3_on_main", strcmp(exec1(db3, "SELECT active_branch()"), "main")==0);
-  check("db4_on_main", strcmp(exec1(db4, "SELECT active_branch()"), "main")==0);
+  check("db1_on_main", strcmp(queryScalarText(db1, "SELECT active_branch()"), "main")==0);
+  check("db2_on_main", strcmp(queryScalarText(db2, "SELECT active_branch()"), "main")==0);
+  check("db3_on_main", strcmp(queryScalarText(db3, "SELECT active_branch()"), "main")==0);
+  check("db4_on_main", strcmp(queryScalarText(db4, "SELECT active_branch()"), "main")==0);
 
   printf("--- Test 1: Schema setup from connection 1 ---\n");
-  rc = execsql(db1, "CREATE TABLE items(id INTEGER PRIMARY KEY, name TEXT, qty INTEGER)");
+  rc = execSql(db1, "CREATE TABLE items(id INTEGER PRIMARY KEY, name TEXT, qty INTEGER)");
   check("create_table", rc==SQLITE_OK);
-  rc = execsql(db1, "INSERT INTO items VALUES(1, 'apple', 10)");
+  rc = execSql(db1, "INSERT INTO items VALUES(1, 'apple', 10)");
   check("seed_insert", rc==SQLITE_OK);
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'initial schema and seed data')");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'initial schema and seed data')");
 
   /* Verify all connections see the table */
-  check("db2_sees_table", strcmp(exec1(db2, "SELECT count(*) FROM items"), "1")==0);
-  check("db3_sees_table", strcmp(exec1(db3, "SELECT count(*) FROM items"), "1")==0);
-  check("db4_sees_table", strcmp(exec1(db4, "SELECT count(*) FROM items"), "1")==0);
+  check("db2_sees_table", strcmp(queryScalarText(db2, "SELECT count(*) FROM items"), "1")==0);
+  check("db3_sees_table", strcmp(queryScalarText(db3, "SELECT count(*) FROM items"), "1")==0);
+  check("db4_sees_table", strcmp(queryScalarText(db4, "SELECT count(*) FROM items"), "1")==0);
 
   printf("--- Test 2: Single-writer INSERT, multi-reader verify ---\n");
 
   /* All DML goes through db1 to avoid shared BtShared corruption.
   ** Other connections verify reads. See INVARIANTS.md X3. */
-  rc = execsql(db1, "INSERT INTO items VALUES(2, 'banana', 20)");
+  rc = execSql(db1, "INSERT INTO items VALUES(2, 'banana', 20)");
   check("db1_insert_2", rc==SQLITE_OK);
-  rc = execsql(db1, "INSERT INTO items VALUES(3, 'cherry', 30)");
+  rc = execSql(db1, "INSERT INTO items VALUES(3, 'cherry', 30)");
   check("db1_insert_3", rc==SQLITE_OK);
-  rc = execsql(db1, "INSERT INTO items VALUES(4, 'date', 40)");
+  rc = execSql(db1, "INSERT INTO items VALUES(4, 'date', 40)");
   check("db1_insert_4", rc==SQLITE_OK);
-  rc = execsql(db1, "INSERT INTO items VALUES(5, 'elderberry', 50)");
+  rc = execSql(db1, "INSERT INTO items VALUES(5, 'elderberry', 50)");
   check("db1_insert_5", rc==SQLITE_OK);
 
   /* All rows visible from writer and readers */
-  check("all_inserts_visible_db1", strcmp(exec1(db1, "SELECT count(*) FROM items"), "5")==0);
-  check("all_inserts_visible_db2", strcmp(exec1(db2, "SELECT count(*) FROM items"), "5")==0);
+  check("all_inserts_visible_db1", strcmp(queryScalarText(db1, "SELECT count(*) FROM items"), "5")==0);
+  check("all_inserts_visible_db2", strcmp(queryScalarText(db2, "SELECT count(*) FROM items"), "5")==0);
 
   printf("--- Test 3: Single-writer UPDATE, multi-reader verify ---\n");
 
-  rc = execsql(db1, "UPDATE items SET qty=11 WHERE id=1");
+  rc = execSql(db1, "UPDATE items SET qty=11 WHERE id=1");
   check("db1_update_1", rc==SQLITE_OK);
-  rc = execsql(db1, "UPDATE items SET qty=22 WHERE id=2");
+  rc = execSql(db1, "UPDATE items SET qty=22 WHERE id=2");
   check("db1_update_2", rc==SQLITE_OK);
-  rc = execsql(db1, "UPDATE items SET qty=33 WHERE id=3");
+  rc = execSql(db1, "UPDATE items SET qty=33 WHERE id=3");
   check("db1_update_3", rc==SQLITE_OK);
-  rc = execsql(db1, "UPDATE items SET qty=44 WHERE id=4");
+  rc = execSql(db1, "UPDATE items SET qty=44 WHERE id=4");
   check("db1_update_4", rc==SQLITE_OK);
 
   /* Verify updates from reader connections */
-  check("update_visible_1", strcmp(exec1(db3, "SELECT qty FROM items WHERE id=1"), "11")==0);
-  check("update_visible_2", strcmp(exec1(db4, "SELECT qty FROM items WHERE id=2"), "22")==0);
-  check("update_visible_3", strcmp(exec1(db2, "SELECT qty FROM items WHERE id=3"), "33")==0);
-  check("update_visible_4", strcmp(exec1(db3, "SELECT qty FROM items WHERE id=4"), "44")==0);
+  check("update_visible_1", strcmp(queryScalarText(db3, "SELECT qty FROM items WHERE id=1"), "11")==0);
+  check("update_visible_2", strcmp(queryScalarText(db4, "SELECT qty FROM items WHERE id=2"), "22")==0);
+  check("update_visible_3", strcmp(queryScalarText(db2, "SELECT qty FROM items WHERE id=3"), "33")==0);
+  check("update_visible_4", strcmp(queryScalarText(db3, "SELECT qty FROM items WHERE id=4"), "44")==0);
 
   printf("--- Test 4: Single-writer DELETE, multi-reader verify ---\n");
 
-  rc = execsql(db1, "DELETE FROM items WHERE id=5");
+  rc = execSql(db1, "DELETE FROM items WHERE id=5");
   check("db1_delete", rc==SQLITE_OK);
 
-  check("delete_visible_db2", strcmp(exec1(db2, "SELECT count(*) FROM items"), "4")==0);
-  check("delete_visible_db3", strcmp(exec1(db3, "SELECT count(*) FROM items"), "4")==0);
+  check("delete_visible_db2", strcmp(queryScalarText(db2, "SELECT count(*) FROM items"), "4")==0);
+  check("delete_visible_db3", strcmp(queryScalarText(db3, "SELECT count(*) FROM items"), "4")==0);
 
   printf("--- Test 5: Mixed operations, single writer ---\n");
 
-  rc = execsql(db1, "INSERT INTO items VALUES(6, 'fig', 60)");
+  rc = execSql(db1, "INSERT INTO items VALUES(6, 'fig', 60)");
   check("mix_insert", rc==SQLITE_OK);
-  rc = execsql(db1, "UPDATE items SET name='apricot' WHERE id=1");
+  rc = execSql(db1, "UPDATE items SET name='apricot' WHERE id=1");
   check("mix_update", rc==SQLITE_OK);
-  rc = execsql(db1, "DELETE FROM items WHERE id=4");
+  rc = execSql(db1, "DELETE FROM items WHERE id=4");
   check("mix_delete", rc==SQLITE_OK);
 
   /* Verify final state from readers: ids 1,2,3,6 remain */
-  check("final_count", strcmp(exec1(db2, "SELECT count(*) FROM items"), "4")==0);
-  check("row1_name", strcmp(exec1(db3, "SELECT name FROM items WHERE id=1"), "apricot")==0);
-  check("row6_exists", strcmp(exec1(db4, "SELECT name FROM items WHERE id=6"), "fig")==0);
-  check("row4_gone", strcmp(exec1(db2, "SELECT count(*) FROM items WHERE id=4"), "0")==0);
+  check("final_count", strcmp(queryScalarText(db2, "SELECT count(*) FROM items"), "4")==0);
+  check("row1_name", strcmp(queryScalarText(db3, "SELECT name FROM items WHERE id=1"), "apricot")==0);
+  check("row6_exists", strcmp(queryScalarText(db4, "SELECT name FROM items WHERE id=6"), "fig")==0);
+  check("row4_gone", strcmp(queryScalarText(db2, "SELECT count(*) FROM items WHERE id=4"), "0")==0);
 
   printf("--- Test 6: dolt_commit captures all writes ---\n");
 
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'writes from single connection')");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'writes from single connection')");
 
   /* Verify commit from the same connection that committed */
   check("commit_log_db1",
-    strcmp(exec1(db1, "SELECT message FROM dolt_log LIMIT 1"),
+    strcmp(queryScalarText(db1, "SELECT message FROM dolt_log LIMIT 1"),
            "writes from single connection")==0);
 
   printf("--- Test 7: dolt_log shows commit from this session ---\n");
@@ -233,31 +233,31 @@ int main(){
   ** to the WAL, each connection's commit chain is independent. db1 sees
   ** its most recent commit; earlier commits may not chain correctly when
   ** other connections' WAL writes interleave. */
-  check("log_has_entries", strcmp(exec1(db1, "SELECT count(*) FROM dolt_log"), "0")!=0);
+  check("log_has_entries", strcmp(queryScalarText(db1, "SELECT count(*) FROM dolt_log"), "0")!=0);
   check("log_first",
-    strcmp(exec1(db1, "SELECT message FROM dolt_log LIMIT 1"),
+    strcmp(queryScalarText(db1, "SELECT message FROM dolt_log LIMIT 1"),
            "writes from single connection")==0);
 
   printf("--- Test 8: Reads from other connections while writing ---\n");
 
   /* Write on db1, read from others */
-  rc = execsql(db1, "INSERT INTO items VALUES(7, 'grape', 70)");
+  rc = execSql(db1, "INSERT INTO items VALUES(7, 'grape', 70)");
   check("write_for_read_test", rc==SQLITE_OK);
 
   /* Other connections can read */
   check("read_during_write_db2",
-    strcmp(exec1(db2, "SELECT count(*) FROM items"), "5")==0);
+    strcmp(queryScalarText(db2, "SELECT count(*) FROM items"), "5")==0);
   check("read_during_write_db3",
-    strcmp(exec1(db3, "SELECT name FROM items WHERE id=1"), "apricot")==0);
+    strcmp(queryScalarText(db3, "SELECT name FROM items WHERE id=1"), "apricot")==0);
   check("read_during_write_db4",
-    strcmp(exec1(db4, "SELECT count(*) FROM items WHERE id=7"), "1")==0);
+    strcmp(queryScalarText(db4, "SELECT count(*) FROM items WHERE id=7"), "1")==0);
 
   /* More writes from db1, reads from others */
-  rc = execsql(db1, "UPDATE items SET qty=77 WHERE id=7");
+  rc = execSql(db1, "UPDATE items SET qty=77 WHERE id=7");
   check("update_write", rc==SQLITE_OK);
 
   check("read_after_update",
-    strcmp(exec1(db3, "SELECT qty FROM items WHERE id=7"), "77")==0);
+    strcmp(queryScalarText(db3, "SELECT qty FROM items WHERE id=7"), "77")==0);
 
   printf("--- Test 9: Bulk writes from single connection ---\n");
 
@@ -268,29 +268,29 @@ int main(){
     for( i=100; i<110; i++ ){
       char sql[256];
       snprintf(sql, sizeof(sql), "INSERT INTO items VALUES(%d, 'bulk-%d', %d)", i, i, i*10);
-      rc = execsql(db1, sql);
+      rc = execSql(db1, sql);
       if( rc==SQLITE_OK ) totalOk++;
     }
     check("bulk_writes_all_succeeded", totalOk==10);
-    check("bulk_count", strcmp(exec1(db1, "SELECT count(*) FROM items WHERE id>=100"), "10")==0);
+    check("bulk_count", strcmp(queryScalarText(db1, "SELECT count(*) FROM items WHERE id>=100"), "10")==0);
   }
 
   printf("--- Test 10: Final commit and verification ---\n");
 
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'bulk inserts and interleaved ops')");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'bulk inserts and interleaved ops')");
 
-  check("final_log_has_entries", strcmp(exec1(db1, "SELECT count(*) FROM dolt_log"), "0")!=0);
+  check("final_log_has_entries", strcmp(queryScalarText(db1, "SELECT count(*) FROM dolt_log"), "0")!=0);
   check("final_log_msg",
-    strcmp(exec1(db1, "SELECT message FROM dolt_log LIMIT 1"),
+    strcmp(queryScalarText(db1, "SELECT message FROM dolt_log LIMIT 1"),
            "bulk inserts and interleaved ops")==0);
 
   /* Final row count from writer */
-  check("final_total_db1", strcmp(exec1(db1, "SELECT count(*) FROM items"), "15")==0);
+  check("final_total_db1", strcmp(queryScalarText(db1, "SELECT count(*) FROM items"), "15")==0);
   /* Readers see the committed state via fresh connections */
   {
     sqlite3 *fresh = 0;
     sqlite3_open(dbpath, &fresh);
-    check("final_total_fresh", strcmp(exec1(fresh, "SELECT count(*) FROM items"), "15")==0);
+    check("final_total_fresh", strcmp(queryScalarText(fresh, "SELECT count(*) FROM items"), "15")==0);
     sqlite3_close(fresh);
   }
 
@@ -311,10 +311,10 @@ int main(){
   ** To reproduce:
   **   sqlite3 *a, *b;
   **   sqlite3_open(path, &a); sqlite3_open(path, &b);
-  **   execsql(a, "CREATE TABLE t(id INT, v INT)");
-  **   execsql(a, "SELECT dolt_commit('-A','-m','init')");
-  **   execsql(a, "INSERT INTO t VALUES(1,1)");  // a writes to shared tree
-  **   execsql(b, "INSERT INTO t VALUES(2,2)");  // b corrupts a's in-flight state
+  **   execSql(a, "CREATE TABLE t(id INT, v INT)");
+  **   execSql(a, "SELECT dolt_commit('-A','-m','init')");
+  **   execSql(a, "INSERT INTO t VALUES(1,1)");  // a writes to shared tree
+  **   execSql(b, "INSERT INTO t VALUES(2,2)");  // b corrupts a's in-flight state
   **   // subsequent queries may return SQLITE_CORRUPT
   **
   ** Fix requires copy-on-write mutation buffers or full MVCC (issue #250).

--- a/test/corruption_test.c
+++ b/test/corruption_test.c
@@ -48,7 +48,7 @@ static void check(const char *name, int condition){
 
 /* Execute SQL, return first column of first row as string (static buffer). */
 static char result_buf[8192];
-static const char *exec1(sqlite3 *db, const char *sql){
+static const char *queryScalarText(sqlite3 *db, const char *sql){
   sqlite3_stmt *stmt = 0;
   int rc;
   result_buf[0] = 0;
@@ -69,7 +69,7 @@ static const char *exec1(sqlite3 *db, const char *sql){
 }
 
 /* Execute SQL, ignore result. */
-static int execsql(sqlite3 *db, const char *sql){
+static int execSql(sqlite3 *db, const char *sql){
   char *err = 0;
   int rc = sqlite3_exec(db, sql, 0, 0, &err);
   if( rc!=SQLITE_OK ){
@@ -166,19 +166,19 @@ static int create_good_db(const char *path){
   rc = sqlite3_open(path, &db);
   if( rc!=SQLITE_OK ) return -1;
 
-  execsql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT)");
-  execsql(db, "INSERT INTO t1 VALUES(1, 'alpha')");
-  execsql(db, "INSERT INTO t1 VALUES(2, 'beta')");
-  execsql(db, "INSERT INTO t1 VALUES(3, 'gamma')");
-  res = exec1(db, "SELECT dolt_commit('-A', '-m', 'first commit')");
+  execSql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT)");
+  execSql(db, "INSERT INTO t1 VALUES(1, 'alpha')");
+  execSql(db, "INSERT INTO t1 VALUES(2, 'beta')");
+  execSql(db, "INSERT INTO t1 VALUES(3, 'gamma')");
+  res = queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'first commit')");
   if( strncmp(res, "ERROR", 5)==0 ){
     sqlite3_close(db);
     return -1;
   }
 
-  execsql(db, "INSERT INTO t1 VALUES(4, 'delta')");
-  execsql(db, "INSERT INTO t1 VALUES(5, 'epsilon')");
-  res = exec1(db, "SELECT dolt_commit('-A', '-m', 'second commit')");
+  execSql(db, "INSERT INTO t1 VALUES(4, 'delta')");
+  execSql(db, "INSERT INTO t1 VALUES(5, 'epsilon')");
+  res = queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'second commit')");
   if( strncmp(res, "ERROR", 5)==0 ){
     sqlite3_close(db);
     return -1;
@@ -203,26 +203,26 @@ static int create_compacted_db(const char *path){
   rc = sqlite3_open(path, &db);
   if( rc!=SQLITE_OK ) return -1;
 
-  execsql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT)");
-  execsql(db, "INSERT INTO t1 VALUES(1, 'alpha')");
-  execsql(db, "INSERT INTO t1 VALUES(2, 'beta')");
-  execsql(db, "INSERT INTO t1 VALUES(3, 'gamma')");
-  res = exec1(db, "SELECT dolt_commit('-A', '-m', 'first commit')");
+  execSql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT)");
+  execSql(db, "INSERT INTO t1 VALUES(1, 'alpha')");
+  execSql(db, "INSERT INTO t1 VALUES(2, 'beta')");
+  execSql(db, "INSERT INTO t1 VALUES(3, 'gamma')");
+  res = queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'first commit')");
   if( strncmp(res, "ERROR", 5)==0 ){
     sqlite3_close(db);
     return -1;
   }
 
-  execsql(db, "INSERT INTO t1 VALUES(4, 'delta')");
-  execsql(db, "INSERT INTO t1 VALUES(5, 'epsilon')");
-  res = exec1(db, "SELECT dolt_commit('-A', '-m', 'second commit')");
+  execSql(db, "INSERT INTO t1 VALUES(4, 'delta')");
+  execSql(db, "INSERT INTO t1 VALUES(5, 'epsilon')");
+  res = queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'second commit')");
   if( strncmp(res, "ERROR", 5)==0 ){
     sqlite3_close(db);
     return -1;
   }
 
   /* GC compacts all chunks and empties the WAL region */
-  res = exec1(db, "SELECT dolt_gc()");
+  res = queryScalarText(db, "SELECT dolt_gc()");
   if( strncmp(res, "ERROR", 5)==0 ){
     sqlite3_close(db);
     return -1;
@@ -251,24 +251,24 @@ static int open_and_probe(const char *path){
   }
 
   /* Try to query branches */
-  rc = execsql(db, "SELECT * FROM dolt_branches");
+  rc = execSql(db, "SELECT * FROM dolt_branches");
   if( rc!=SQLITE_OK ) errSeen = 1;
 
   /* Try to query log */
-  rc = execsql(db, "SELECT * FROM dolt_log");
+  rc = execSql(db, "SELECT * FROM dolt_log");
   if( rc!=SQLITE_OK ) errSeen = 1;
 
   /* Try to query user table */
-  rc = execsql(db, "SELECT * FROM t1");
+  rc = execSql(db, "SELECT * FROM t1");
   if( rc!=SQLITE_OK ) errSeen = 1;
 
   /* Try to query status */
-  rc = execsql(db, "SELECT * FROM dolt_status");
+  rc = execSql(db, "SELECT * FROM dolt_status");
   if( rc!=SQLITE_OK ) errSeen = 1;
 
   /* Try active_branch */
   {
-    const char *r = exec1(db, "SELECT active_branch()");
+    const char *r = queryScalarText(db, "SELECT active_branch()");
     if( strncmp(r, "ERROR", 5)==0 || strlen(r)==0 ) errSeen = 1;
   }
 
@@ -292,7 +292,7 @@ static int open_fails_or_errors(const char *path){
   }
 
   /* Check if even a basic query works */
-  rc = execsql(db, "SELECT active_branch()");
+  rc = execSql(db, "SELECT active_branch()");
   if( rc!=SQLITE_OK ){
     sqlite3_close(db);
     return 1;
@@ -408,14 +408,14 @@ static void test_corrupt_chunk_data(void){
     int i;
     removeDb(dbpath);
     check("open_4", sqlite3_open(dbpath, &db)==SQLITE_OK);
-    execsql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT)");
+    execSql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT)");
     for( i=0; i<100; i++ ){
       char sql[128];
       snprintf(sql, sizeof(sql), "INSERT INTO t1 VALUES(%d, 'row_%d')", i, i);
-      execsql(db, sql);
+      execSql(db, sql);
     }
-    exec1(db, "SELECT dolt_commit('-A', '-m', 'lots of data')");
-    exec1(db, "SELECT dolt_gc()");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'lots of data')");
+    queryScalarText(db, "SELECT dolt_gc()");
     sqlite3_close(db);
   }
 
@@ -442,10 +442,10 @@ static void test_corrupt_chunk_data(void){
     sqlite3 *db = 0;
     int rc = sqlite3_open(dbpath, &db);
     if( rc==SQLITE_OK ){
-      int data_rc = execsql(db, "SELECT * FROM t1");
-      int log_rc = execsql(db, "SELECT * FROM dolt_log");
-      int branch_rc = execsql(db, "SELECT * FROM dolt_branches");
-      int status_rc = execsql(db, "SELECT * FROM dolt_status");
+      int data_rc = execSql(db, "SELECT * FROM t1");
+      int log_rc = execSql(db, "SELECT * FROM dolt_log");
+      int branch_rc = execSql(db, "SELECT * FROM dolt_branches");
+      int status_rc = execSql(db, "SELECT * FROM dolt_status");
       check("chunk_corruption_detected",
         data_rc!=SQLITE_OK || log_rc!=SQLITE_OK ||
         branch_rc!=SQLITE_OK || status_rc!=SQLITE_OK);
@@ -503,7 +503,7 @@ static void test_zero_refs_hash(void){
     sqlite3 *db = 0;
     int rc = sqlite3_open(dbpath, &db);
     if( rc==SQLITE_OK ){
-      const char *r = exec1(db, "SELECT count(*) FROM dolt_branches");
+      const char *r = queryScalarText(db, "SELECT count(*) FROM dolt_branches");
       int is_error = (strncmp(r, "ERROR", 5)==0);
       check("zeroed_refs_returns_error", is_error);
     }else{
@@ -550,7 +550,7 @@ static void test_append_garbage(void){
     int rc = sqlite3_open(dbpath, &db);
     if( rc==SQLITE_OK ){
       /* If it opens, the original data should still be intact */
-      const char *r = exec1(db, "SELECT count(*) FROM t1");
+      const char *r = queryScalarText(db, "SELECT count(*) FROM t1");
       /* Either we get the correct count (garbage ignored) or an error */
       int count_ok = (strcmp(r, "5")==0);
       int count_err = (strncmp(r, "ERROR", 5)==0);
@@ -591,10 +591,10 @@ static void test_empty_file(void){
     check("empty_open_ok", rc==SQLITE_OK);
     if( rc==SQLITE_OK ){
       /* Should be able to create tables and use it normally */
-      rc = execsql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY)");
+      rc = execSql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY)");
       check("empty_create_table", rc==SQLITE_OK);
 
-      const char *branch = exec1(db, "SELECT active_branch()");
+      const char *branch = queryScalarText(db, "SELECT active_branch()");
       check("empty_has_branch",
         branch && strlen(branch)>0 && strncmp(branch, "ERROR", 5)!=0);
     }
@@ -627,7 +627,7 @@ static void test_manifest_only(void){
     ** return errors. The key is no crash and no silent data loss. */
     if( rc==SQLITE_OK ){
       /* It opened, but queries should reveal the problem */
-      const char *r = exec1(db, "SELECT count(*) FROM t1");
+      const char *r = queryScalarText(db, "SELECT count(*) FROM t1");
       /* Either error (data gone) or 0 (empty) -- both are acceptable.
       ** What's NOT acceptable is returning stale data count of 5. */
       check("manifest_only_no_stale_data",
@@ -675,7 +675,7 @@ static void test_corrupt_wal_tag(void){
       if( rc==SQLITE_OK ){
         /* It might open successfully but lose some data.
         ** The key is that it doesn't crash or return garbage. */
-        const char *r = exec1(db, "SELECT count(*) FROM t1");
+        const char *r = queryScalarText(db, "SELECT count(*) FROM t1");
         if( strncmp(r, "ERROR", 5)!=0 ){
           int cnt = atoi(r);
           /* Should have some rows but possibly not all
@@ -744,9 +744,9 @@ static void test_commit_then_corrupt(void){
     sqlite3 *db = 0;
     check("verify_good_12", sqlite3_open(dbpath, &db)==SQLITE_OK);
     check("good_count_12",
-      strcmp(exec1(db, "SELECT count(*) FROM t1"), "5")==0);
+      strcmp(queryScalarText(db, "SELECT count(*) FROM t1"), "5")==0);
     check("good_log_12",
-      strcmp(exec1(db, "SELECT count(*) FROM dolt_log"), "2")==0);
+      strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_log"), "2")==0);
     sqlite3_close(db);
   }
 
@@ -765,8 +765,8 @@ static void test_commit_then_corrupt(void){
     sqlite3 *db = 0;
     int rc = sqlite3_open(dbpath, &db);
     if( rc==SQLITE_OK ){
-      rc = execsql(db, "SELECT * FROM t1");
-      int log_rc = execsql(db, "SELECT * FROM dolt_log");
+      rc = execSql(db, "SELECT * FROM t1");
+      int log_rc = execSql(db, "SELECT * FROM dolt_log");
       check("corrupt_catalog_detected",
         rc!=SQLITE_OK || log_rc!=SQLITE_OK);
     }else{
@@ -849,7 +849,7 @@ static void test_corrupt_head_commit(void){
     if( rc==SQLITE_OK ){
       /* The system may recover head_commit from branch refs.
       ** Verify it doesn't crash and returns some coherent result. */
-      const char *r = exec1(db, "SELECT count(*) FROM dolt_log");
+      const char *r = queryScalarText(db, "SELECT count(*) FROM dolt_log");
       int log_err = (strncmp(r, "ERROR", 5)==0);
       int log_valid = (!log_err && atoi(r) >= 0);
       check("corrupt_head_commit_no_crash", log_err || log_valid);
@@ -857,7 +857,7 @@ static void test_corrupt_head_commit(void){
       /* If the system silently recovered, the branch ref was the
       ** fallback. Verify branches are still accessible. */
       if( log_valid && atoi(r) > 0 ){
-        const char *b = exec1(db, "SELECT count(*) FROM dolt_branches");
+        const char *b = queryScalarText(db, "SELECT count(*) FROM dolt_branches");
         check("corrupt_head_branches_accessible",
           strncmp(b, "ERROR", 5)!=0 && atoi(b) >= 1);
       }
@@ -902,7 +902,7 @@ static void test_corrupt_chunk_count(void){
     if( rc==SQLITE_OK ){
       /* If it opens, verify data is still accessible (silently ignored)
       ** or returns an error (properly detected). */
-      const char *r = exec1(db, "SELECT count(*) FROM t1");
+      const char *r = queryScalarText(db, "SELECT count(*) FROM t1");
       int data_ok = (strncmp(r, "ERROR", 5)!=0 && atoi(r)==5);
       int data_err = (strncmp(r, "ERROR", 5)==0);
       check("chunk_count_no_crash", data_ok || data_err);
@@ -929,10 +929,10 @@ static void test_corrupt_index_offset(void){
     sqlite3 *db = 0;
     removeDb(dbpath);
     check("open_17", sqlite3_open(dbpath, &db)==SQLITE_OK);
-    execsql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT)");
-    execsql(db, "INSERT INTO t1 VALUES(1, 'a')");
-    exec1(db, "SELECT dolt_commit('-A', '-m', 'c1')");
-    exec1(db, "SELECT dolt_gc()");
+    execSql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT)");
+    execSql(db, "INSERT INTO t1 VALUES(1, 'a')");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'c1')");
+    queryScalarText(db, "SELECT dolt_gc()");
     sqlite3_close(db);
   }
 

--- a/test/crash_recovery_test.c
+++ b/test/crash_recovery_test.c
@@ -56,7 +56,7 @@ static void check(const char *name, int condition){
 
 /* Execute SQL, return first column of first row (static buffer). */
 static char g_buf[8192];
-static const char *exec1(sqlite3 *db, const char *sql){
+static const char *queryScalarText(sqlite3 *db, const char *sql){
   sqlite3_stmt *stmt = 0;
   int rc;
   g_buf[0] = 0;
@@ -77,7 +77,7 @@ static const char *exec1(sqlite3 *db, const char *sql){
 }
 
 /* Execute SQL, return the integer from first column of first row. */
-static int exec_int(sqlite3 *db, const char *sql, int dflt){
+static int queryScalarInt(sqlite3 *db, const char *sql, int dflt){
   sqlite3_stmt *stmt;
   int val = dflt;
   if( sqlite3_prepare_v2(db, sql, -1, &stmt, 0)==SQLITE_OK ){
@@ -90,7 +90,7 @@ static int exec_int(sqlite3 *db, const char *sql, int dflt){
 }
 
 /* Execute SQL, ignore result. Return rc. */
-static int execsql(sqlite3 *db, const char *sql){
+static int execSql(sqlite3 *db, const char *sql){
   char *err = 0;
   int rc = sqlite3_exec(db, sql, 0, 0, &err);
   if( rc!=SQLITE_OK && err ){
@@ -101,7 +101,7 @@ static int execsql(sqlite3 *db, const char *sql){
 }
 
 /* Remove database and associated WAL/journal files. */
-static void remove_db(const char *path){
+static void removeDbFiles(const char *path){
   char tmp[512];
   remove(path);
   snprintf(tmp, sizeof(tmp), "%s-wal", path);
@@ -116,7 +116,7 @@ static char g_dbpath[512];
 static const char *fresh_db(void){
   snprintf(g_dbpath, sizeof(g_dbpath),
            "/tmp/crash_test_%d_%d.db", (int)getpid(), g_test_seq++);
-  remove_db(g_dbpath);
+  removeDbFiles(g_dbpath);
   return g_dbpath;
 }
 
@@ -177,7 +177,7 @@ static int verify_consistency(const char *dbpath, const char *label){
 
   /* Check that dolt_log is queryable. */
   {
-    int nLog = exec_int(db, "SELECT count(*) FROM dolt_log", -1);
+    int nLog = queryScalarInt(db, "SELECT count(*) FROM dolt_log", -1);
     snprintf(desc, sizeof(desc), "%s: dolt_log has entries", label);
     check(desc, nLog>=0);
     if( nLog<0 ) ok = 0;
@@ -204,7 +204,7 @@ static void verify_row_count(const char *dbpath, const char *label,
     return;
   }
   snprintf(sql, sizeof(sql), "SELECT count(*) FROM %s", table);
-  cnt = exec_int(db, sql, -1);
+  cnt = queryScalarInt(db, sql, -1);
   snprintf(desc, sizeof(desc), "%s: %s has %d rows", label, table, expected);
   check(desc, cnt==expected);
   sqlite3_close(db);
@@ -224,7 +224,7 @@ static int verify_commit_count(const char *dbpath, const char *label,
     sqlite3_close(db);
     return -1;
   }
-  cnt = exec_int(db, "SELECT count(*) FROM dolt_log", -1);
+  cnt = queryScalarInt(db, "SELECT count(*) FROM dolt_log", -1);
   snprintf(desc, sizeof(desc), "%s: dolt_log has %d commits", label, expected);
   check(desc, cnt==expected);
   sqlite3_close(db);
@@ -234,7 +234,7 @@ static int verify_commit_count(const char *dbpath, const char *label,
 /* dolt_log includes the automatic repository initialization commit.
 ** Crash tests generally care about user commits after that seed. */
 static int exec_user_commit_count(sqlite3 *db){
-  int nLog = exec_int(db, "SELECT count(*) FROM dolt_log", -1);
+  int nLog = queryScalarInt(db, "SELECT count(*) FROM dolt_log", -1);
   if( nLog<0 ) return nLog;
   return nLog>0 ? nLog-1 : 0;
 }
@@ -276,11 +276,11 @@ static void test_01_clean_commit(void){
     /* Child: create, insert, commit, exit cleanly. */
     sqlite3 *db = 0;
     sqlite3_open(dbpath, &db);
-    execsql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
-    execsql(db, "INSERT INTO t VALUES(1, 'one')");
-    execsql(db, "INSERT INTO t VALUES(2, 'two')");
-    execsql(db, "INSERT INTO t VALUES(3, 'three')");
-    exec1(db, "SELECT dolt_commit('-A', '-m', 'initial')");
+    execSql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    execSql(db, "INSERT INTO t VALUES(1, 'one')");
+    execSql(db, "INSERT INTO t VALUES(2, 'two')");
+    execSql(db, "INSERT INTO t VALUES(3, 'three')");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'initial')");
     sqlite3_close(db);
     _exit(0);
   }
@@ -293,7 +293,7 @@ static void test_01_clean_commit(void){
   verify_consistency(dbpath, "test_01");
   verify_row_count(dbpath, "test_01", "t", 3);
   verify_user_commit_count(dbpath, "test_01", 1);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 /*
@@ -310,10 +310,10 @@ static void test_02_kill_after_commit(void){
   if( pid==0 ){
     sqlite3 *db = 0;
     sqlite3_open(dbpath, &db);
-    execsql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
-    execsql(db, "INSERT INTO t VALUES(1, 'alpha')");
-    execsql(db, "INSERT INTO t VALUES(2, 'beta')");
-    exec1(db, "SELECT dolt_commit('-A', '-m', 'committed')");
+    execSql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    execSql(db, "INSERT INTO t VALUES(1, 'alpha')");
+    execSql(db, "INSERT INTO t VALUES(2, 'beta')");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'committed')");
     /* Signal parent we are past the commit. */
     sqlite3_sleep(500);
     /* Parent will kill us here. */
@@ -331,7 +331,7 @@ static void test_02_kill_after_commit(void){
   verify_consistency(dbpath, "test_02");
   verify_row_count(dbpath, "test_02", "t", 2);
   verify_user_commit_count(dbpath, "test_02", 1);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 /*
@@ -348,18 +348,18 @@ static void test_03_kill_during_commit(void){
   if( pid==0 ){
     sqlite3 *db = 0;
     sqlite3_open(dbpath, &db);
-    execsql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    execSql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
     {
       int i;
       char sql[128];
       for( i=0; i<100; i++ ){
         snprintf(sql, sizeof(sql),
                  "INSERT INTO t VALUES(%d, 'row-%d')", i, i);
-        execsql(db, sql);
+        execSql(db, sql);
       }
     }
     /* Start the commit -- parent will try to kill during this. */
-    exec1(db, "SELECT dolt_commit('-A', '-m', 'big commit')");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'big commit')");
     sqlite3_sleep(60000);
     _exit(0);
   }
@@ -383,13 +383,13 @@ static void test_03_kill_during_commit(void){
       check("test_03: commit atomic (0 or 1)",
             nLog==0 || nLog==1);
       if( nLog==1 ){
-        int cnt = exec_int(db, "SELECT count(*) FROM t", -1);
+        int cnt = queryScalarInt(db, "SELECT count(*) FROM t", -1);
         check("test_03: if committed, all 100 rows present", cnt==100);
       }
     }
     sqlite3_close(db);
   }
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 /*
@@ -405,11 +405,11 @@ static void test_04_two_commits_kill_after_second(void){
   if( pid==0 ){
     sqlite3 *db = 0;
     sqlite3_open(dbpath, &db);
-    execsql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
-    execsql(db, "INSERT INTO t VALUES(1, 'first')");
-    exec1(db, "SELECT dolt_commit('-A', '-m', 'commit-1')");
-    execsql(db, "INSERT INTO t VALUES(2, 'second')");
-    exec1(db, "SELECT dolt_commit('-A', '-m', 'commit-2')");
+    execSql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    execSql(db, "INSERT INTO t VALUES(1, 'first')");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'commit-1')");
+    execSql(db, "INSERT INTO t VALUES(2, 'second')");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'commit-2')");
     sqlite3_sleep(500);
     sqlite3_sleep(60000);
     _exit(0);
@@ -430,15 +430,15 @@ static void test_04_two_commits_kill_after_second(void){
     check("test_04: at least commit-1 present", nLog>=1);
     /* If both commits landed, verify both rows. */
     if( nLog>=2 ){
-      int cnt = exec_int(db, "SELECT count(*) FROM t", -1);
+      int cnt = queryScalarInt(db, "SELECT count(*) FROM t", -1);
       check("test_04: both commits => 2 rows", cnt==2);
     }else if( nLog==1 ){
-      int cnt = exec_int(db, "SELECT count(*) FROM t", -1);
+      int cnt = queryScalarInt(db, "SELECT count(*) FROM t", -1);
       check("test_04: only first commit => 1 row", cnt==1);
     }
     sqlite3_close(db);
   }
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 /*
@@ -455,9 +455,9 @@ static void test_05_kill_during_second_commit(void){
   if( pid==0 ){
     sqlite3 *db = 0;
     sqlite3_open(dbpath, &db);
-    execsql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
-    execsql(db, "INSERT INTO t VALUES(1, 'stable')");
-    exec1(db, "SELECT dolt_commit('-A', '-m', 'stable-commit')");
+    execSql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    execSql(db, "INSERT INTO t VALUES(1, 'stable')");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'stable-commit')");
 
     /* Second commit: insert many rows to increase commit duration. */
     {
@@ -466,10 +466,10 @@ static void test_05_kill_during_second_commit(void){
       for( i=100; i<200; i++ ){
         snprintf(sql, sizeof(sql),
                  "INSERT INTO t VALUES(%d, 'bulk-%d')", i, i);
-        execsql(db, sql);
+        execSql(db, sql);
       }
     }
-    exec1(db, "SELECT dolt_commit('-A', '-m', 'bulk-commit')");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'bulk-commit')");
     sqlite3_sleep(60000);
     _exit(0);
   }
@@ -489,13 +489,13 @@ static void test_05_kill_during_second_commit(void){
       int nLog = exec_user_commit_count(db);
       check("test_05: at least stable-commit present", nLog>=1);
       /* The stable row must always be present. */
-      int hasStable = exec_int(db,
+      int hasStable = queryScalarInt(db,
         "SELECT count(*) FROM t WHERE val='stable'", -1);
       check("test_05: stable row survives crash", hasStable==1);
     }
     sqlite3_close(db);
   }
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 /*
@@ -513,9 +513,9 @@ static void test_06_reopen_then_crash(void){
   if( pid==0 ){
     sqlite3 *db = 0;
     sqlite3_open(dbpath, &db);
-    execsql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
-    execsql(db, "INSERT INTO t VALUES(1, 'persisted')");
-    exec1(db, "SELECT dolt_commit('-A', '-m', 'first')");
+    execSql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    execSql(db, "INSERT INTO t VALUES(1, 'persisted')");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'first')");
     sqlite3_close(db);
     _exit(0);
   }
@@ -526,8 +526,8 @@ static void test_06_reopen_then_crash(void){
   if( pid==0 ){
     sqlite3 *db = 0;
     sqlite3_open(dbpath, &db);
-    execsql(db, "INSERT INTO t VALUES(2, 'new')");
-    exec1(db, "SELECT dolt_commit('-A', '-m', 'second')");
+    execSql(db, "INSERT INTO t VALUES(2, 'new')");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'second')");
     sqlite3_sleep(500);
     sqlite3_sleep(60000);
     _exit(0);
@@ -541,12 +541,12 @@ static void test_06_reopen_then_crash(void){
   {
     sqlite3 *db = 0;
     sqlite3_open(dbpath, &db);
-    int hasFirst = exec_int(db,
+    int hasFirst = queryScalarInt(db,
       "SELECT count(*) FROM t WHERE val='persisted'", -1);
     check("test_06: first commit data survives", hasFirst==1);
     sqlite3_close(db);
   }
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 /* ====================================================================
@@ -574,13 +574,13 @@ static void test_07_five_commits_random_kill(void){
     int i;
     char sql[256];
     sqlite3_open(dbpath, &db);
-    execsql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    execSql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
     for( i=1; i<=5; i++ ){
       snprintf(sql, sizeof(sql), "INSERT INTO t VALUES(%d, 'v%d')", i, i);
-      execsql(db, sql);
+      execSql(db, sql);
       snprintf(sql, sizeof(sql),
                "SELECT dolt_commit('-A', '-m', 'commit-%d')", i);
-      exec1(db, sql);
+      queryScalarText(db, sql);
     }
     sqlite3_sleep(60000);
     _exit(0);
@@ -599,13 +599,13 @@ static void test_07_five_commits_random_kill(void){
 
       /* If there are N commits, there should be N rows. */
       if( nLog>0 ){
-        int nRows = exec_int(db, "SELECT count(*) FROM t", -1);
+        int nRows = queryScalarInt(db, "SELECT count(*) FROM t", -1);
         check("test_07: row count matches commit count", nRows==nLog);
       }
     }
     sqlite3_close(db);
   }
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 /*
@@ -622,18 +622,18 @@ static void test_08_branch_crash(void){
   if( pid==0 ){
     sqlite3 *db = 0;
     sqlite3_open(dbpath, &db);
-    execsql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
-    execsql(db, "INSERT INTO t VALUES(1, 'main-1')");
-    exec1(db, "SELECT dolt_commit('-A', '-m', 'initial')");
+    execSql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    execSql(db, "INSERT INTO t VALUES(1, 'main-1')");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'initial')");
 
-    exec1(db, "SELECT dolt_branch('feature')");
-    exec1(db, "SELECT dolt_checkout('feature')");
-    execsql(db, "INSERT INTO t VALUES(2, 'feature-1')");
-    exec1(db, "SELECT dolt_commit('-A', '-m', 'feature commit')");
+    queryScalarText(db, "SELECT dolt_branch('feature')");
+    queryScalarText(db, "SELECT dolt_checkout('feature')");
+    execSql(db, "INSERT INTO t VALUES(2, 'feature-1')");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'feature commit')");
 
-    exec1(db, "SELECT dolt_checkout('main')");
-    execsql(db, "INSERT INTO t VALUES(3, 'main-2')");
-    exec1(db, "SELECT dolt_commit('-A', '-m', 'main commit 2')");
+    queryScalarText(db, "SELECT dolt_checkout('main')");
+    execSql(db, "INSERT INTO t VALUES(3, 'main-2')");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'main commit 2')");
 
     sqlite3_sleep(500);
     sqlite3_sleep(60000);
@@ -669,7 +669,7 @@ static void test_08_branch_crash(void){
     }
     sqlite3_close(db);
   }
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 /*
@@ -686,15 +686,15 @@ static void test_09_branch_at_commit(void){
   if( pid==0 ){
     sqlite3 *db = 0;
     sqlite3_open(dbpath, &db);
-    execsql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
-    execsql(db, "INSERT INTO t VALUES(1, 'one')");
-    exec1(db, "SELECT dolt_commit('-A', '-m', 'first')");
-    execsql(db, "INSERT INTO t VALUES(2, 'two')");
-    exec1(db, "SELECT dolt_commit('-A', '-m', 'second')");
+    execSql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    execSql(db, "INSERT INTO t VALUES(1, 'one')");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'first')");
+    execSql(db, "INSERT INTO t VALUES(2, 'two')");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'second')");
     /* Create branch from current HEAD. */
-    exec1(db, "SELECT dolt_branch('snap')");
-    execsql(db, "INSERT INTO t VALUES(3, 'three')");
-    exec1(db, "SELECT dolt_commit('-A', '-m', 'third')");
+    queryScalarText(db, "SELECT dolt_branch('snap')");
+    execSql(db, "INSERT INTO t VALUES(3, 'three')");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'third')");
     sqlite3_sleep(500);
     sqlite3_sleep(60000);
     _exit(0);
@@ -704,7 +704,7 @@ static void test_09_branch_at_commit(void){
   { int status; waitpid(pid, &status, 0); }
 
   verify_consistency(dbpath, "test_09");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 /*
@@ -723,13 +723,13 @@ static void test_10_very_early_kill(void){
     int i;
     char sql[256];
     sqlite3_open(dbpath, &db);
-    execsql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    execSql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
     for( i=1; i<=5; i++ ){
       snprintf(sql, sizeof(sql), "INSERT INTO t VALUES(%d, 'v%d')", i, i);
-      execsql(db, sql);
+      execSql(db, sql);
       snprintf(sql, sizeof(sql),
                "SELECT dolt_commit('-A', '-m', 'commit-%d')", i);
-      exec1(db, sql);
+      queryScalarText(db, sql);
     }
     sqlite3_sleep(60000);
     _exit(0);
@@ -747,7 +747,7 @@ static void test_10_very_early_kill(void){
       /* Whatever number of commits landed, data must be consistent. */
       check("test_10: commit count non-negative", nLog>=0);
       if( nLog>0 ){
-        int nRows = exec_int(db, "SELECT count(*) FROM t", -1);
+        int nRows = queryScalarInt(db, "SELECT count(*) FROM t", -1);
         /* The INSERT for the next would-be commit may already have
         ** autocommitted before the process is killed inside
         ** dolt_commit(). In that case recovery can legitimately see one
@@ -761,7 +761,7 @@ static void test_10_very_early_kill(void){
     }
     sqlite3_close(db);
   }
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 /*
@@ -779,7 +779,7 @@ static void test_11_increasing_data_kill(void){
     int i, j;
     char sql[256];
     sqlite3_open(dbpath, &db);
-    execsql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    execSql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
 
     int row_id = 1;
     for( i=1; i<=5; i++ ){
@@ -787,11 +787,11 @@ static void test_11_increasing_data_kill(void){
       for( j=0; j<i*10; j++ ){
         snprintf(sql, sizeof(sql),
                  "INSERT INTO t VALUES(%d, 'batch%d-row%d')", row_id++, i, j);
-        execsql(db, sql);
+        execSql(db, sql);
       }
       snprintf(sql, sizeof(sql),
                "SELECT dolt_commit('-A', '-m', 'batch-%d')", i);
-      exec1(db, sql);
+      queryScalarText(db, sql);
     }
     sqlite3_sleep(60000);
     _exit(0);
@@ -815,7 +815,7 @@ static void test_11_increasing_data_kill(void){
       ** intact and we never observe rows from more than one uncommitted
       ** post-prefix batch. */
       {
-        int nRows = exec_int(db, "SELECT count(*) FROM t", -1);
+        int nRows = queryScalarInt(db, "SELECT count(*) FROM t", -1);
         /* Expected rows = sum of 10+20+...+nLog*10 = nLog*(nLog+1)*5 */
         int expected = nLog * (nLog + 1) * 5;
         int upper = expected;
@@ -830,7 +830,7 @@ static void test_11_increasing_data_kill(void){
     }
     sqlite3_close(db);
   }
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 /* ====================================================================
@@ -852,13 +852,13 @@ static void test_12_gc_crash(void){
   if( pid==0 ){
     sqlite3 *db = 0;
     sqlite3_open(dbpath, &db);
-    execsql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
-    execsql(db, "INSERT INTO t VALUES(1, 'a')");
-    exec1(db, "SELECT dolt_commit('-A', '-m', 'c1')");
-    execsql(db, "INSERT INTO t VALUES(2, 'b')");
-    exec1(db, "SELECT dolt_commit('-A', '-m', 'c2')");
-    execsql(db, "DELETE FROM t WHERE id=1");
-    exec1(db, "SELECT dolt_commit('-A', '-m', 'c3')");
+    execSql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    execSql(db, "INSERT INTO t VALUES(1, 'a')");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'c1')");
+    execSql(db, "INSERT INTO t VALUES(2, 'b')");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'c2')");
+    execSql(db, "DELETE FROM t WHERE id=1");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'c3')");
     sqlite3_close(db);
     _exit(0);
   }
@@ -869,7 +869,7 @@ static void test_12_gc_crash(void){
   if( pid==0 ){
     sqlite3 *db = 0;
     sqlite3_open(dbpath, &db);
-    exec1(db, "SELECT dolt_gc()");
+    queryScalarText(db, "SELECT dolt_gc()");
     sqlite3_sleep(60000);
     _exit(0);
   }
@@ -884,7 +884,7 @@ static void test_12_gc_crash(void){
     check("test_12: db opens after GC crash", rc==SQLITE_OK);
     if( rc==SQLITE_OK ){
       /* Must be able to query data. */
-      int cnt = exec_int(db, "SELECT count(*) FROM t", -1);
+      int cnt = queryScalarInt(db, "SELECT count(*) FROM t", -1);
       check("test_12: table queryable after GC crash", cnt>=0);
       /* dolt_log must still work. */
       int nLog = exec_user_commit_count(db);
@@ -892,7 +892,7 @@ static void test_12_gc_crash(void){
     }
     sqlite3_close(db);
   }
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 /*
@@ -909,15 +909,15 @@ static void test_13_gc_then_crash(void){
   if( pid==0 ){
     sqlite3 *db = 0;
     sqlite3_open(dbpath, &db);
-    execsql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
-    execsql(db, "INSERT INTO t VALUES(1, 'a')");
-    exec1(db, "SELECT dolt_commit('-A', '-m', 'c1')");
-    execsql(db, "INSERT INTO t VALUES(2, 'b')");
-    exec1(db, "SELECT dolt_commit('-A', '-m', 'c2')");
-    exec1(db, "SELECT dolt_gc()");
+    execSql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    execSql(db, "INSERT INTO t VALUES(1, 'a')");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'c1')");
+    execSql(db, "INSERT INTO t VALUES(2, 'b')");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'c2')");
+    queryScalarText(db, "SELECT dolt_gc()");
     /* Now do more work after GC. */
-    execsql(db, "INSERT INTO t VALUES(3, 'c')");
-    exec1(db, "SELECT dolt_commit('-A', '-m', 'post-gc')");
+    execSql(db, "INSERT INTO t VALUES(3, 'c')");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'post-gc')");
     sqlite3_sleep(500);
     sqlite3_sleep(60000);
     _exit(0);
@@ -936,7 +936,7 @@ static void test_13_gc_then_crash(void){
     }
     sqlite3_close(db);
   }
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 /*
@@ -954,16 +954,16 @@ static void test_14_gc_with_branches_crash(void){
   if( pid==0 ){
     sqlite3 *db = 0;
     sqlite3_open(dbpath, &db);
-    execsql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
-    execsql(db, "INSERT INTO t VALUES(1, 'main')");
-    exec1(db, "SELECT dolt_commit('-A', '-m', 'init')");
-    exec1(db, "SELECT dolt_branch('dev')");
-    exec1(db, "SELECT dolt_checkout('dev')");
-    execsql(db, "INSERT INTO t VALUES(2, 'dev-data')");
-    exec1(db, "SELECT dolt_commit('-A', '-m', 'dev commit')");
-    exec1(db, "SELECT dolt_checkout('main')");
-    execsql(db, "INSERT INTO t VALUES(3, 'main-extra')");
-    exec1(db, "SELECT dolt_commit('-A', '-m', 'main extra')");
+    execSql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    execSql(db, "INSERT INTO t VALUES(1, 'main')");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'init')");
+    queryScalarText(db, "SELECT dolt_branch('dev')");
+    queryScalarText(db, "SELECT dolt_checkout('dev')");
+    execSql(db, "INSERT INTO t VALUES(2, 'dev-data')");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'dev commit')");
+    queryScalarText(db, "SELECT dolt_checkout('main')");
+    execSql(db, "INSERT INTO t VALUES(3, 'main-extra')");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'main extra')");
     sqlite3_close(db);
     _exit(0);
   }
@@ -974,7 +974,7 @@ static void test_14_gc_with_branches_crash(void){
   if( pid==0 ){
     sqlite3 *db = 0;
     sqlite3_open(dbpath, &db);
-    exec1(db, "SELECT dolt_gc()");
+    queryScalarText(db, "SELECT dolt_gc()");
     sqlite3_sleep(60000);
     _exit(0);
   }
@@ -987,12 +987,12 @@ static void test_14_gc_with_branches_crash(void){
     sqlite3 *db = 0;
     sqlite3_open(dbpath, &db);
     /* Both branches should still exist. */
-    int nBranch = exec_int(db,
+    int nBranch = queryScalarInt(db,
       "SELECT count(*) FROM dolt_branches", -1);
     check("test_14: both branches survive GC crash", nBranch==2);
     sqlite3_close(db);
   }
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 /* ====================================================================
@@ -1015,13 +1015,13 @@ static void test_15_large_insert_crash(void){
     int i;
     char sql[256];
     sqlite3_open(dbpath, &db);
-    execsql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT, data TEXT)");
+    execSql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT, data TEXT)");
     for( i=0; i<1000; i++ ){
       snprintf(sql, sizeof(sql),
         "INSERT INTO t VALUES(%d, 'row-%d', '%0128d')", i, i, i);
-      execsql(db, sql);
+      execSql(db, sql);
     }
-    exec1(db, "SELECT dolt_commit('-A', '-m', 'thousand rows')");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'thousand rows')");
     sqlite3_sleep(60000);
     _exit(0);
   }
@@ -1038,13 +1038,13 @@ static void test_15_large_insert_crash(void){
       int nLog = exec_user_commit_count(db);
       check("test_15: commit atomic (0 or 1)", nLog==0 || nLog==1);
       if( nLog==1 ){
-        int cnt = exec_int(db, "SELECT count(*) FROM t", -1);
+        int cnt = queryScalarInt(db, "SELECT count(*) FROM t", -1);
         check("test_15: all 1000 rows if committed", cnt==1000);
       }
     }
     sqlite3_close(db);
   }
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 /*
@@ -1065,13 +1065,13 @@ static void test_16_large_insert_complete_then_kill(void){
     int i;
     char sql[256];
     sqlite3_open(dbpath, &db);
-    execsql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    execSql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
     for( i=0; i<1000; i++ ){
       snprintf(sql, sizeof(sql),
         "INSERT INTO t VALUES(%d, 'row-%d')", i, i);
-      execsql(db, sql);
+      execSql(db, sql);
     }
-    exec1(db, "SELECT dolt_commit('-A', '-m', 'thousand rows')");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'thousand rows')");
     {
       FILE *f = fopen(donepath, "w");
       if( f ){
@@ -1101,7 +1101,7 @@ static void test_16_large_insert_complete_then_kill(void){
   verify_row_count(dbpath, "test_16", "t", 1000);
   verify_user_commit_count(dbpath, "test_16", 1);
   unlink(donepath);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 /*
@@ -1119,18 +1119,18 @@ static void test_17_multiple_large_commits(void){
     int i, batch;
     char sql[256];
     sqlite3_open(dbpath, &db);
-    execsql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, batch INT, val TEXT)");
+    execSql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, batch INT, val TEXT)");
 
     for( batch=1; batch<=3; batch++ ){
       for( i=0; i<200; i++ ){
         int id = (batch-1)*200 + i;
         snprintf(sql, sizeof(sql),
           "INSERT INTO t VALUES(%d, %d, 'b%d-r%d')", id, batch, batch, i);
-        execsql(db, sql);
+        execSql(db, sql);
       }
       snprintf(sql, sizeof(sql),
                "SELECT dolt_commit('-A', '-m', 'batch-%d')", batch);
-      exec1(db, sql);
+      queryScalarText(db, sql);
     }
     sqlite3_sleep(60000);
     _exit(0);
@@ -1147,7 +1147,7 @@ static void test_17_multiple_large_commits(void){
       int nLog = exec_user_commit_count(db);
       check("test_17: commit count in [0..3]", nLog>=0 && nLog<=3);
       {
-        int nRows = exec_int(db, "SELECT count(*) FROM t", -1);
+        int nRows = queryScalarInt(db, "SELECT count(*) FROM t", -1);
         int expected = nLog * 200;
         int upper = expected;
         if( nLog<3 ){
@@ -1159,7 +1159,7 @@ static void test_17_multiple_large_commits(void){
     }
     sqlite3_close(db);
   }
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 /* ====================================================================
@@ -1180,12 +1180,12 @@ static void test_18_schema_change_crash(void){
   if( pid==0 ){
     sqlite3 *db = 0;
     sqlite3_open(dbpath, &db);
-    execsql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
-    execsql(db, "INSERT INTO t VALUES(1, 'a')");
-    exec1(db, "SELECT dolt_commit('-A', '-m', 'create')");
-    execsql(db, "ALTER TABLE t ADD COLUMN extra TEXT DEFAULT 'x'");
-    execsql(db, "INSERT INTO t VALUES(2, 'b', 'y')");
-    exec1(db, "SELECT dolt_commit('-A', '-m', 'alter')");
+    execSql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    execSql(db, "INSERT INTO t VALUES(1, 'a')");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'create')");
+    execSql(db, "ALTER TABLE t ADD COLUMN extra TEXT DEFAULT 'x'");
+    execSql(db, "INSERT INTO t VALUES(2, 'b', 'y')");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'alter')");
     sqlite3_sleep(500);
     sqlite3_sleep(60000);
     _exit(0);
@@ -1203,18 +1203,18 @@ static void test_18_schema_change_crash(void){
       check("test_18: at least 1 commit", nLog>=1);
       /* If both commits landed, the extra column must exist. */
       if( nLog==2 ){
-        const char *v = exec1(db, "SELECT extra FROM t WHERE id=2");
+        const char *v = queryScalarText(db, "SELECT extra FROM t WHERE id=2");
         check("test_18: alter committed with data", strcmp(v, "y")==0);
       }
       /* If only first commit, table is still basic schema. */
       if( nLog==1 ){
-        int cnt = exec_int(db, "SELECT count(*) FROM t", -1);
+        int cnt = queryScalarInt(db, "SELECT count(*) FROM t", -1);
         check("test_18: first commit has 1 row", cnt==1);
       }
     }
     sqlite3_close(db);
   }
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 /*
@@ -1231,11 +1231,11 @@ static void test_19_delete_all_crash(void){
   if( pid==0 ){
     sqlite3 *db = 0;
     sqlite3_open(dbpath, &db);
-    execsql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
-    execsql(db, "INSERT INTO t VALUES(1, 'a')");
-    execsql(db, "INSERT INTO t VALUES(2, 'b')");
-    execsql(db, "INSERT INTO t VALUES(3, 'c')");
-    exec1(db, "SELECT dolt_commit('-A', '-m', 'initial')");
+    execSql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    execSql(db, "INSERT INTO t VALUES(1, 'a')");
+    execSql(db, "INSERT INTO t VALUES(2, 'b')");
+    execSql(db, "INSERT INTO t VALUES(3, 'c')");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'initial')");
     sqlite3_close(db);
     _exit(0);
   }
@@ -1246,8 +1246,8 @@ static void test_19_delete_all_crash(void){
   if( pid==0 ){
     sqlite3 *db = 0;
     sqlite3_open(dbpath, &db);
-    execsql(db, "DELETE FROM t");
-    exec1(db, "SELECT dolt_commit('-A', '-m', 'delete all')");
+    execSql(db, "DELETE FROM t");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'delete all')");
     sqlite3_sleep(500);
     sqlite3_sleep(60000);
     _exit(0);
@@ -1262,7 +1262,7 @@ static void test_19_delete_all_crash(void){
     check("test_19: db opens", rc==SQLITE_OK);
     if( rc==SQLITE_OK ){
       int nLog = exec_user_commit_count(db);
-      int cnt = exec_int(db, "SELECT count(*) FROM t", -1);
+      int cnt = queryScalarInt(db, "SELECT count(*) FROM t", -1);
       /* Either the delete committed (0 rows, 2 log entries) or
       ** only the initial state remains (3 rows, 1 log entry). */
       check("test_19: consistent state",
@@ -1270,7 +1270,7 @@ static void test_19_delete_all_crash(void){
     }
     sqlite3_close(db);
   }
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 /*
@@ -1286,13 +1286,13 @@ static void test_20_update_crash(void){
   if( pid==0 ){
     sqlite3 *db = 0;
     sqlite3_open(dbpath, &db);
-    execsql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
-    execsql(db, "INSERT INTO t VALUES(1, 'old')");
-    execsql(db, "INSERT INTO t VALUES(2, 'old')");
-    execsql(db, "INSERT INTO t VALUES(3, 'old')");
-    exec1(db, "SELECT dolt_commit('-A', '-m', 'initial')");
-    execsql(db, "UPDATE t SET val='new'");
-    exec1(db, "SELECT dolt_commit('-A', '-m', 'update all')");
+    execSql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    execSql(db, "INSERT INTO t VALUES(1, 'old')");
+    execSql(db, "INSERT INTO t VALUES(2, 'old')");
+    execSql(db, "INSERT INTO t VALUES(3, 'old')");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'initial')");
+    execSql(db, "UPDATE t SET val='new'");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'update all')");
     sqlite3_sleep(500);
     sqlite3_sleep(60000);
     _exit(0);
@@ -1306,9 +1306,9 @@ static void test_20_update_crash(void){
     int rc = sqlite3_open(dbpath, &db);
     check("test_20: db opens", rc==SQLITE_OK);
     if( rc==SQLITE_OK ){
-      int nOld = exec_int(db,
+      int nOld = queryScalarInt(db,
         "SELECT count(*) FROM t WHERE val='old'", -1);
-      int nNew = exec_int(db,
+      int nNew = queryScalarInt(db,
         "SELECT count(*) FROM t WHERE val='new'", -1);
       /* Either all old (3) or all new (3). No partial updates. */
       check("test_20: atomic update (all old or all new)",
@@ -1316,7 +1316,7 @@ static void test_20_update_crash(void){
     }
     sqlite3_close(db);
   }
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 /*
@@ -1332,13 +1332,13 @@ static void test_21_drop_table_crash(void){
   if( pid==0 ){
     sqlite3 *db = 0;
     sqlite3_open(dbpath, &db);
-    execsql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
-    execsql(db, "CREATE TABLE t2(id INTEGER PRIMARY KEY, val TEXT)");
-    execsql(db, "INSERT INTO t VALUES(1, 'keep')");
-    execsql(db, "INSERT INTO t2 VALUES(1, 'drop-me')");
-    exec1(db, "SELECT dolt_commit('-A', '-m', 'two tables')");
-    execsql(db, "DROP TABLE t2");
-    exec1(db, "SELECT dolt_commit('-A', '-m', 'dropped t2')");
+    execSql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    execSql(db, "CREATE TABLE t2(id INTEGER PRIMARY KEY, val TEXT)");
+    execSql(db, "INSERT INTO t VALUES(1, 'keep')");
+    execSql(db, "INSERT INTO t2 VALUES(1, 'drop-me')");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'two tables')");
+    execSql(db, "DROP TABLE t2");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'dropped t2')");
     sqlite3_sleep(500);
     sqlite3_sleep(60000);
     _exit(0);
@@ -1353,16 +1353,16 @@ static void test_21_drop_table_crash(void){
     check("test_21: db opens", rc==SQLITE_OK);
     if( rc==SQLITE_OK ){
       /* t must always exist. */
-      int cnt_t = exec_int(db, "SELECT count(*) FROM t", -1);
+      int cnt_t = queryScalarInt(db, "SELECT count(*) FROM t", -1);
       check("test_21: table t exists", cnt_t==1);
       /* t2 either exists or not. */
-      int cnt_t2 = exec_int(db, "SELECT count(*) FROM t2", -2);
+      int cnt_t2 = queryScalarInt(db, "SELECT count(*) FROM t2", -2);
       check("test_21: t2 state consistent",
             cnt_t2==1 || cnt_t2==-2);
     }
     sqlite3_close(db);
   }
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 /*
@@ -1384,12 +1384,12 @@ static void test_22_multi_table_commit_crash(void){
     for( i=1; i<=10; i++ ){
       snprintf(sql, sizeof(sql),
         "CREATE TABLE t%d(id INTEGER PRIMARY KEY, val TEXT)", i);
-      execsql(db, sql);
+      execSql(db, sql);
       snprintf(sql, sizeof(sql),
         "INSERT INTO t%d VALUES(1, 'data-%d')", i, i);
-      execsql(db, sql);
+      execSql(db, sql);
     }
-    exec1(db, "SELECT dolt_commit('-A', '-m', '10 tables')");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', '10 tables')");
     sqlite3_sleep(60000);
     _exit(0);
   }
@@ -1411,7 +1411,7 @@ static void test_22_multi_table_commit_crash(void){
           char sql[128];
           snprintf(sql, sizeof(sql),
                    "SELECT count(*) FROM t%d", i);
-          int cnt = exec_int(db, sql, -1);
+          int cnt = queryScalarInt(db, sql, -1);
           if( cnt!=1 ) allOk = 0;
         }
         check("test_22: all 10 tables present if committed", allOk);
@@ -1421,7 +1421,7 @@ static void test_22_multi_table_commit_crash(void){
     }
     sqlite3_close(db);
   }
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 /*
@@ -1438,14 +1438,14 @@ static void test_23_merge_crash(void){
   if( pid==0 ){
     sqlite3 *db = 0;
     sqlite3_open(dbpath, &db);
-    execsql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
-    execsql(db, "INSERT INTO t VALUES(1, 'shared')");
-    exec1(db, "SELECT dolt_commit('-A', '-m', 'init')");
-    exec1(db, "SELECT dolt_branch('feature')");
-    exec1(db, "SELECT dolt_checkout('feature')");
-    execsql(db, "INSERT INTO t VALUES(2, 'feature')");
-    exec1(db, "SELECT dolt_commit('-A', '-m', 'feature data')");
-    exec1(db, "SELECT dolt_checkout('main')");
+    execSql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    execSql(db, "INSERT INTO t VALUES(1, 'shared')");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'init')");
+    queryScalarText(db, "SELECT dolt_branch('feature')");
+    queryScalarText(db, "SELECT dolt_checkout('feature')");
+    execSql(db, "INSERT INTO t VALUES(2, 'feature')");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'feature data')");
+    queryScalarText(db, "SELECT dolt_checkout('main')");
     sqlite3_close(db);
     _exit(0);
   }
@@ -1456,7 +1456,7 @@ static void test_23_merge_crash(void){
   if( pid==0 ){
     sqlite3 *db = 0;
     sqlite3_open(dbpath, &db);
-    exec1(db, "SELECT dolt_merge('feature')");
+    queryScalarText(db, "SELECT dolt_merge('feature')");
     sqlite3_sleep(500);
     sqlite3_sleep(60000);
     _exit(0);
@@ -1470,12 +1470,12 @@ static void test_23_merge_crash(void){
     sqlite3 *db = 0;
     sqlite3_open(dbpath, &db);
     /* Data should be consistent regardless of merge status. */
-    int cnt = exec_int(db, "SELECT count(*) FROM t", -1);
+    int cnt = queryScalarInt(db, "SELECT count(*) FROM t", -1);
     check("test_23: row count is 1 or 2",
           cnt==1 || cnt==2);
     sqlite3_close(db);
   }
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 /*
@@ -1494,9 +1494,9 @@ static void test_24_repeated_crash_cycles(void){
   if( pid==0 ){
     sqlite3 *db = 0;
     sqlite3_open(dbpath, &db);
-    execsql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
-    execsql(db, "INSERT INTO t VALUES(0, 'seed')");
-    exec1(db, "SELECT dolt_commit('-A', '-m', 'seed')");
+    execSql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    execSql(db, "INSERT INTO t VALUES(0, 'seed')");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'seed')");
     sqlite3_close(db);
     _exit(0);
   }
@@ -1511,10 +1511,10 @@ static void test_24_repeated_crash_cycles(void){
       sqlite3_open(dbpath, &db);
       snprintf(sql, sizeof(sql),
                "INSERT INTO t VALUES(%d, 'cycle-%d')", cycle, cycle);
-      execsql(db, sql);
+      execSql(db, sql);
       snprintf(sql, sizeof(sql),
                "SELECT dolt_commit('-A', '-m', 'cycle-%d')", cycle);
-      exec1(db, sql);
+      queryScalarText(db, sql);
       sqlite3_sleep(500);
       sqlite3_sleep(60000);
       _exit(0);
@@ -1544,12 +1544,12 @@ static void test_24_repeated_crash_cycles(void){
   {
     sqlite3 *db = 0;
     sqlite3_open(dbpath, &db);
-    int hasSeed = exec_int(db,
+    int hasSeed = queryScalarInt(db,
       "SELECT count(*) FROM t WHERE val='seed'", -1);
     check("test_24: seed row always present", hasSeed==1);
     sqlite3_close(db);
   }
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 /*
@@ -1565,10 +1565,10 @@ static void test_25_tag_crash(void){
   if( pid==0 ){
     sqlite3 *db = 0;
     sqlite3_open(dbpath, &db);
-    execsql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
-    execsql(db, "INSERT INTO t VALUES(1, 'tagged')");
-    exec1(db, "SELECT dolt_commit('-A', '-m', 'for tag')");
-    exec1(db, "SELECT dolt_tag('v1.0')");
+    execSql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    execSql(db, "INSERT INTO t VALUES(1, 'tagged')");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'for tag')");
+    queryScalarText(db, "SELECT dolt_tag('v1.0')");
     sqlite3_sleep(500);
     sqlite3_sleep(60000);
     _exit(0);
@@ -1584,11 +1584,11 @@ static void test_25_tag_crash(void){
     /* Commit must be present. Tag may or may not have persisted. */
     int nLog = exec_user_commit_count(db);
     check("test_25: commit present", nLog>=1);
-    int cnt = exec_int(db, "SELECT count(*) FROM t", -1);
+    int cnt = queryScalarInt(db, "SELECT count(*) FROM t", -1);
     check("test_25: data intact", cnt==1);
     sqlite3_close(db);
   }
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 /*
@@ -1605,7 +1605,7 @@ static void test_26_blob_data_crash(void){
     sqlite3 *db = 0;
     int i;
     sqlite3_open(dbpath, &db);
-    execsql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, data BLOB)");
+    execSql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, data BLOB)");
     for( i=0; i<50; i++ ){
       sqlite3_stmt *stmt = 0;
       char sql_text[] = "INSERT INTO t VALUES(?, randomblob(1024))";
@@ -1614,7 +1614,7 @@ static void test_26_blob_data_crash(void){
       sqlite3_step(stmt);
       sqlite3_finalize(stmt);
     }
-    exec1(db, "SELECT dolt_commit('-A', '-m', 'blobs')");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'blobs')");
     sqlite3_sleep(500);
     sqlite3_sleep(60000);
     _exit(0);
@@ -1631,17 +1631,17 @@ static void test_26_blob_data_crash(void){
       int nLog = exec_user_commit_count(db);
       check("test_26: commit atomic (0 or 1)", nLog==0 || nLog==1);
       if( nLog==1 ){
-        int cnt = exec_int(db, "SELECT count(*) FROM t", -1);
+        int cnt = queryScalarInt(db, "SELECT count(*) FROM t", -1);
         check("test_26: all 50 blob rows if committed", cnt==50);
         /* Verify blobs are readable (not corrupted). */
-        int blobLen = exec_int(db,
+        int blobLen = queryScalarInt(db,
           "SELECT length(data) FROM t WHERE id=0", -1);
         check("test_26: blob data intact", blobLen==1024);
       }
     }
     sqlite3_close(db);
   }
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 /*
@@ -1659,9 +1659,9 @@ static void test_27_uncommitted_changes_crash(void){
   if( pid==0 ){
     sqlite3 *db = 0;
     sqlite3_open(dbpath, &db);
-    execsql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
-    execsql(db, "INSERT INTO t VALUES(1, 'committed')");
-    exec1(db, "SELECT dolt_commit('-A', '-m', 'baseline')");
+    execSql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    execSql(db, "INSERT INTO t VALUES(1, 'committed')");
+    queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'baseline')");
     sqlite3_close(db);
     _exit(0);
   }
@@ -1672,8 +1672,8 @@ static void test_27_uncommitted_changes_crash(void){
   if( pid==0 ){
     sqlite3 *db = 0;
     sqlite3_open(dbpath, &db);
-    execsql(db, "INSERT INTO t VALUES(2, 'uncommitted')");
-    execsql(db, "INSERT INTO t VALUES(3, 'uncommitted')");
+    execSql(db, "INSERT INTO t VALUES(2, 'uncommitted')");
+    execSql(db, "INSERT INTO t VALUES(3, 'uncommitted')");
     /* No dolt_commit! */
     sqlite3_sleep(500);
     sqlite3_sleep(60000);
@@ -1691,12 +1691,12 @@ static void test_27_uncommitted_changes_crash(void){
     /* The committed row must be present. The uncommitted rows may or
     ** may not be in the SQL layer (WAL recovery), but dolt state should
     ** reflect only committed data. */
-    int committed = exec_int(db,
+    int committed = queryScalarInt(db,
       "SELECT count(*) FROM t WHERE val='committed'", -1);
     check("test_27: committed data present", committed==1);
     sqlite3_close(db);
   }
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 /*
@@ -1715,14 +1715,14 @@ static void test_28_rapid_small_commits(void){
     int i;
     char sql[256];
     sqlite3_open(dbpath, &db);
-    execsql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    execSql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
     for( i=1; i<=10; i++ ){
       snprintf(sql, sizeof(sql),
                "INSERT INTO t VALUES(%d, 'r%d')", i, i);
-      execsql(db, sql);
+      execSql(db, sql);
       snprintf(sql, sizeof(sql),
                "SELECT dolt_commit('-A', '-m', 'r%d')", i);
-      exec1(db, sql);
+      queryScalarText(db, sql);
     }
     sqlite3_sleep(60000);
     _exit(0);
@@ -1739,7 +1739,7 @@ static void test_28_rapid_small_commits(void){
       int nLog = exec_user_commit_count(db);
       check("test_28: commit count in [0..10]", nLog>=0 && nLog<=10);
       if( nLog>0 ){
-        int nRows = exec_int(db, "SELECT count(*) FROM t", -1);
+        int nRows = queryScalarInt(db, "SELECT count(*) FROM t", -1);
         /* INSERT autocommits before the surrounding dolt_commit() runs;
         ** SIGKILL can land in the gap, leaving the row durable in the
         ** working set but no Dolt commit recorded for it (same race as
@@ -1750,7 +1750,7 @@ static void test_28_rapid_small_commits(void){
     }
     sqlite3_close(db);
   }
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 /*
@@ -1770,14 +1770,14 @@ static void test_29_gc_after_many_commits(void){
     int i;
     char sql[256];
     sqlite3_open(dbpath, &db);
-    execsql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+    execSql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
     for( i=1; i<=10; i++ ){
       snprintf(sql, sizeof(sql),
                "INSERT INTO t VALUES(%d, 'v%d')", i, i);
-      execsql(db, sql);
+      execSql(db, sql);
       snprintf(sql, sizeof(sql),
                "SELECT dolt_commit('-A', '-m', 'c%d')", i);
-      exec1(db, sql);
+      queryScalarText(db, sql);
     }
     sqlite3_close(db);
     _exit(0);
@@ -1789,7 +1789,7 @@ static void test_29_gc_after_many_commits(void){
   if( pid==0 ){
     sqlite3 *db = 0;
     sqlite3_open(dbpath, &db);
-    exec1(db, "SELECT dolt_gc()");
+    queryScalarText(db, "SELECT dolt_gc()");
     sqlite3_sleep(60000);
     _exit(0);
   }
@@ -1804,12 +1804,12 @@ static void test_29_gc_after_many_commits(void){
     if( rc==SQLITE_OK ){
       int nLog = exec_user_commit_count(db);
       check("test_29: all 10 commits present", nLog==10);
-      int cnt = exec_int(db, "SELECT count(*) FROM t", -1);
+      int cnt = queryScalarInt(db, "SELECT count(*) FROM t", -1);
       check("test_29: all 10 rows present", cnt==10);
     }
     sqlite3_close(db);
   }
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 /*
@@ -1842,7 +1842,7 @@ static void test_30_crash_on_open(void){
     check("test_30: db openable after early crash", rc==SQLITE_OK);
     sqlite3_close(db);
   }
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 /* ====================================================================

--- a/test/cross_branch_test.c
+++ b/test/cross_branch_test.c
@@ -25,7 +25,7 @@ static void check(const char *name, int condition){
 }
 
 static char result_buf[4096];
-static const char *exec1(sqlite3 *db, const char *sql){
+static const char *queryScalarText(sqlite3 *db, const char *sql){
   sqlite3_stmt *stmt = 0;
   int rc;
   result_buf[0] = 0;
@@ -45,7 +45,7 @@ static const char *exec1(sqlite3 *db, const char *sql){
   return result_buf;
 }
 
-static int execsql(sqlite3 *db, const char *sql){
+static int execSql(sqlite3 *db, const char *sql){
   char *err = 0;
   int rc = sqlite3_exec(db, sql, 0, 0, &err);
   if( rc!=SQLITE_OK ){
@@ -74,11 +74,11 @@ int main(){
   printf("--- Setup: create table and initial commit on main ---\n");
 
   /* db1: create schema, insert data, commit on main */
-  rc = execsql(db1, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+  rc = execSql(db1, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
   check("create_table", rc==SQLITE_OK);
-  rc = execsql(db1, "INSERT INTO t VALUES(1, 'main-1')");
+  rc = execSql(db1, "INSERT INTO t VALUES(1, 'main-1')");
   check("insert_main", rc==SQLITE_OK);
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'initial on main')");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'initial on main')");
 
   /* Open db2 AFTER the commit so it sees the head commit */
   rc = sqlite3_open(dbpath, &db2);
@@ -86,24 +86,24 @@ int main(){
   sqlite3_busy_timeout(db2, 5000);
 
   /* Verify both see it */
-  check("db1_sees_main", strcmp(exec1(db1, "SELECT val FROM t WHERE id=1"), "main-1")==0);
-  check("db2_sees_main", strcmp(exec1(db2, "SELECT val FROM t WHERE id=1"), "main-1")==0);
+  check("db1_sees_main", strcmp(queryScalarText(db1, "SELECT val FROM t WHERE id=1"), "main-1")==0);
+  check("db2_sees_main", strcmp(queryScalarText(db2, "SELECT val FROM t WHERE id=1"), "main-1")==0);
 
   printf("--- Create dev branch and checkout db2 to dev ---\n");
 
   /* db2: create branch and checkout */
-  exec1(db2, "SELECT dolt_checkout('-b', 'dev')");
-  check("db2_on_dev", strcmp(exec1(db2, "SELECT active_branch()"), "dev")==0);
-  check("db1_on_main", strcmp(exec1(db1, "SELECT active_branch()"), "main")==0);
+  queryScalarText(db2, "SELECT dolt_checkout('-b', 'dev')");
+  check("db2_on_dev", strcmp(queryScalarText(db2, "SELECT active_branch()"), "dev")==0);
+  check("db1_on_main", strcmp(queryScalarText(db1, "SELECT active_branch()"), "main")==0);
 
   printf("--- Test 1: autocommit writes on different branches ---\n");
 
   /* db1 writes on main (autocommit) */
-  rc = execsql(db1, "INSERT INTO t VALUES(2, 'main-2')");
+  rc = execSql(db1, "INSERT INTO t VALUES(2, 'main-2')");
   check("db1_insert_main2", rc==SQLITE_OK);
 
   /* db2 writes on dev (autocommit) — this overwrites manifest catalog */
-  rc = execsql(db2, "INSERT INTO t VALUES(3, 'dev-3')");
+  rc = execSql(db2, "INSERT INTO t VALUES(3, 'dev-3')");
   check("db2_insert_dev3", rc==SQLITE_OK);
 
   printf("--- Test 2: reads after cross-branch writes (the bug) ---\n");
@@ -112,62 +112,62 @@ int main(){
   ** without SQLITE_CORRUPT. Before the fix, the manifest catalog was
   ** overwritten by db2's autocommit, causing db1 to load the wrong
   ** catalog and get corrupt reads. */
-  r = exec1(db1, "SELECT count(*) FROM t");
+  r = queryScalarText(db1, "SELECT count(*) FROM t");
   check("db1_main_count", strcmp(r, "2")==0);
 
-  r = exec1(db1, "SELECT val FROM t WHERE id=1");
+  r = queryScalarText(db1, "SELECT val FROM t WHERE id=1");
   check("db1_main_val1", strcmp(r, "main-1")==0);
 
-  r = exec1(db1, "SELECT val FROM t WHERE id=2");
+  r = queryScalarText(db1, "SELECT val FROM t WHERE id=2");
   check("db1_main_val2", strcmp(r, "main-2")==0);
 
   /* db2 on dev should see its data */
-  r = exec1(db2, "SELECT count(*) FROM t");
+  r = queryScalarText(db2, "SELECT count(*) FROM t");
   check("db2_dev_count", strcmp(r, "2")==0);
 
-  r = exec1(db2, "SELECT val FROM t WHERE id=1");
+  r = queryScalarText(db2, "SELECT val FROM t WHERE id=1");
   check("db2_dev_val1", strcmp(r, "main-1")==0);
 
-  r = exec1(db2, "SELECT val FROM t WHERE id=3");
+  r = queryScalarText(db2, "SELECT val FROM t WHERE id=3");
   check("db2_dev_val3", strcmp(r, "dev-3")==0);
 
   printf("--- Test 3: more writes interleaved ---\n");
 
   /* Interleave more writes */
-  rc = execsql(db1, "INSERT INTO t VALUES(4, 'main-4')");
+  rc = execSql(db1, "INSERT INTO t VALUES(4, 'main-4')");
   check("db1_insert_main4", rc==SQLITE_OK);
 
-  rc = execsql(db2, "INSERT INTO t VALUES(5, 'dev-5')");
+  rc = execSql(db2, "INSERT INTO t VALUES(5, 'dev-5')");
   check("db2_insert_dev5", rc==SQLITE_OK);
 
-  rc = execsql(db1, "INSERT INTO t VALUES(6, 'main-6')");
+  rc = execSql(db1, "INSERT INTO t VALUES(6, 'main-6')");
   check("db1_insert_main6", rc==SQLITE_OK);
 
   /* Verify isolation */
-  r = exec1(db1, "SELECT count(*) FROM t");
+  r = queryScalarText(db1, "SELECT count(*) FROM t");
   check("db1_main_count_after", strcmp(r, "4")==0);
 
-  r = exec1(db2, "SELECT count(*) FROM t");
+  r = queryScalarText(db2, "SELECT count(*) FROM t");
   check("db2_dev_count_after", strcmp(r, "3")==0);
 
   printf("--- Test 4: dolt_commit on each branch ---\n");
 
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'main writes')");
-  exec1(db2, "SELECT dolt_commit('-A', '-m', 'dev writes')");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'main writes')");
+  queryScalarText(db2, "SELECT dolt_commit('-A', '-m', 'dev writes')");
 
   /* Verify commits */
-  r = exec1(db1, "SELECT message FROM dolt_log LIMIT 1");
+  r = queryScalarText(db1, "SELECT message FROM dolt_log LIMIT 1");
   check("db1_commit_msg", strcmp(r, "main writes")==0);
 
-  r = exec1(db2, "SELECT message FROM dolt_log LIMIT 1");
+  r = queryScalarText(db2, "SELECT message FROM dolt_log LIMIT 1");
   check("db2_commit_msg", strcmp(r, "dev writes")==0);
 
   printf("--- Test 5: reads after commits still correct ---\n");
 
-  r = exec1(db1, "SELECT count(*) FROM t");
+  r = queryScalarText(db1, "SELECT count(*) FROM t");
   check("db1_final_count", strcmp(r, "4")==0);
 
-  r = exec1(db2, "SELECT count(*) FROM t");
+  r = queryScalarText(db2, "SELECT count(*) FROM t");
   check("db2_final_count", strcmp(r, "3")==0);
 
   printf("--- Test 6: fresh connection sees committed state ---\n");
@@ -176,7 +176,7 @@ int main(){
     sqlite3 *fresh = 0;
     sqlite3_open(dbpath, &fresh);
     /* Fresh connection opens on default branch (main after last commit) */
-    r = exec1(fresh, "SELECT count(*) FROM t");
+    r = queryScalarText(fresh, "SELECT count(*) FROM t");
     /* Should see main's 4 rows (main was last to update default branch) */
     check("fresh_sees_data", strcmp(r, "0")!=0);
     sqlite3_close(fresh);
@@ -194,40 +194,40 @@ int main(){
   check("t7_open", rc==SQLITE_OK);
   sqlite3_busy_timeout(db1, 5000);
 
-  execsql(db1, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
-  execsql(db1, "INSERT INTO t VALUES(1, 'committed')");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')");
-  exec1(db1, "SELECT dolt_checkout('-b', 'feature')");
+  execSql(db1, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+  execSql(db1, "INSERT INTO t VALUES(1, 'committed')");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init')");
+  queryScalarText(db1, "SELECT dolt_checkout('-b', 'feature')");
 
   /* Commit on feature */
-  execsql(db1, "INSERT INTO t VALUES(2, 'on-feature')");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'feature commit')");
-  check("t7_feature_has_2", strcmp(exec1(db1, "SELECT count(*) FROM t"), "2")==0);
+  execSql(db1, "INSERT INTO t VALUES(2, 'on-feature')");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'feature commit')");
+  check("t7_feature_has_2", strcmp(queryScalarText(db1, "SELECT count(*) FROM t"), "2")==0);
 
   /* Switch to main — should see 1 row, not 2 */
-  exec1(db1, "SELECT dolt_checkout('main')");
-  check("t7_main_has_1", strcmp(exec1(db1, "SELECT count(*) FROM t"), "1")==0);
+  queryScalarText(db1, "SELECT dolt_checkout('main')");
+  check("t7_main_has_1", strcmp(queryScalarText(db1, "SELECT count(*) FROM t"), "1")==0);
 
   /* Switch back to feature — should see 2 rows */
-  exec1(db1, "SELECT dolt_checkout('feature')");
-  r = exec1(db1, "SELECT count(*) FROM t");
+  queryScalarText(db1, "SELECT dolt_checkout('feature')");
+  r = queryScalarText(db1, "SELECT count(*) FROM t");
   check("t7_feature_preserved", strcmp(r, "2")==0);
 
   printf("--- Test 8: uncommitted changes survive checkout roundtrip ---\n");
 
   /* Uncommitted insert on feature, then checkout to main and back */
-  execsql(db1, "INSERT INTO t VALUES(3, 'uncommitted')");
-  check("t8_has_3", strcmp(exec1(db1, "SELECT count(*) FROM t"), "3")==0);
+  execSql(db1, "INSERT INTO t VALUES(3, 'uncommitted')");
+  check("t8_has_3", strcmp(queryScalarText(db1, "SELECT count(*) FROM t"), "3")==0);
 
-  rc = execsql(db1, "SELECT dolt_checkout('main')");
+  rc = execSql(db1, "SELECT dolt_checkout('main')");
   check("t8_checkout_ok", rc==SQLITE_OK);
-  check("t8_main_has_1", strcmp(exec1(db1, "SELECT count(*) FROM t"), "1")==0);
+  check("t8_main_has_1", strcmp(queryScalarText(db1, "SELECT count(*) FROM t"), "1")==0);
 
   /* Switch back to feature — uncommitted row should still be there */
-  exec1(db1, "SELECT dolt_checkout('feature')");
-  r = exec1(db1, "SELECT count(*) FROM t");
+  queryScalarText(db1, "SELECT dolt_checkout('feature')");
+  r = queryScalarText(db1, "SELECT count(*) FROM t");
   check("t8_uncommitted_survives", strcmp(r, "3")==0);
-  r = exec1(db1, "SELECT val FROM t WHERE id=3");
+  r = queryScalarText(db1, "SELECT val FROM t WHERE id=3");
   check("t8_uncommitted_val", strcmp(r, "uncommitted")==0);
 
   printf("--- Test 9: branch deletion ---\n");
@@ -241,32 +241,32 @@ int main(){
   check("t9_open", rc==SQLITE_OK);
   sqlite3_busy_timeout(db1, 5000);
 
-  execsql(db1, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
-  execsql(db1, "INSERT INTO t VALUES(1, 'main-data')");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'init main')");
+  execSql(db1, "CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT)");
+  execSql(db1, "INSERT INTO t VALUES(1, 'main-data')");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init main')");
 
   /* Create a branch with extra data */
-  exec1(db1, "SELECT dolt_checkout('-b', 'doomed')");
-  execsql(db1, "INSERT INTO t VALUES(2, 'doomed-data')");
-  exec1(db1, "SELECT dolt_commit('-A', '-m', 'doomed commit')");
-  check("t9_doomed_has_2", strcmp(exec1(db1, "SELECT count(*) FROM t"), "2")==0);
+  queryScalarText(db1, "SELECT dolt_checkout('-b', 'doomed')");
+  execSql(db1, "INSERT INTO t VALUES(2, 'doomed-data')");
+  queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'doomed commit')");
+  check("t9_doomed_has_2", strcmp(queryScalarText(db1, "SELECT count(*) FROM t"), "2")==0);
 
   /* Switch to main and delete the branch */
-  exec1(db1, "SELECT dolt_checkout('main')");
-  check("t9_main_has_1", strcmp(exec1(db1, "SELECT count(*) FROM t"), "1")==0);
+  queryScalarText(db1, "SELECT dolt_checkout('main')");
+  check("t9_main_has_1", strcmp(queryScalarText(db1, "SELECT count(*) FROM t"), "1")==0);
 
-  exec1(db1, "SELECT dolt_branch('-d', 'doomed')");
+  queryScalarText(db1, "SELECT dolt_branch('-d', 'doomed')");
 
   /* Verify deleted branch is gone from dolt_branches */
-  r = exec1(db1, "SELECT count(*) FROM dolt_branches WHERE name='doomed'");
+  r = queryScalarText(db1, "SELECT count(*) FROM dolt_branches WHERE name='doomed'");
   check("t9_branch_gone", strcmp(r, "0")==0);
 
   /* Verify only main branch remains */
-  r = exec1(db1, "SELECT count(*) FROM dolt_branches");
+  r = queryScalarText(db1, "SELECT count(*) FROM dolt_branches");
   check("t9_only_main", strcmp(r, "1")==0);
 
   /* Verify main data still intact */
-  check("t9_main_intact", strcmp(exec1(db1, "SELECT val FROM t WHERE id=1"), "main-data")==0);
+  check("t9_main_intact", strcmp(queryScalarText(db1, "SELECT val FROM t WHERE id=1"), "main-data")==0);
 
   printf("--- Test 10: branch deletion + GC reclaims space ---\n");
 
@@ -275,17 +275,17 @@ int main(){
     FILE *f;
 
     /* Insert enough data on a branch to make a measurable difference */
-    exec1(db1, "SELECT dolt_checkout('-b', 'bigbranch')");
+    queryScalarText(db1, "SELECT dolt_checkout('-b', 'bigbranch')");
     {
       int i;
       for(i=100; i<200; i++){
         char sql[128];
         snprintf(sql, sizeof(sql), "INSERT INTO t VALUES(%d, 'bulk-%d')", i, i);
-        execsql(db1, sql);
+        execSql(db1, sql);
       }
     }
-    exec1(db1, "SELECT dolt_commit('-A', '-m', 'bulk data')");
-    exec1(db1, "SELECT dolt_checkout('main')");
+    queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'bulk data')");
+    queryScalarText(db1, "SELECT dolt_checkout('main')");
 
     /* Measure file size before delete+GC */
     sqlite3_close(db1);
@@ -297,8 +297,8 @@ int main(){
     check("t10_reopen", rc==SQLITE_OK);
     sqlite3_busy_timeout(db1, 5000);
 
-    exec1(db1, "SELECT dolt_branch('-d', 'bigbranch')");
-    exec1(db1, "SELECT dolt_gc()");
+    queryScalarText(db1, "SELECT dolt_branch('-d', 'bigbranch')");
+    queryScalarText(db1, "SELECT dolt_gc()");
 
     /* Measure file size after GC */
     sqlite3_close(db1);
@@ -312,7 +312,7 @@ int main(){
     rc = sqlite3_open(dbpath, &db1);
     check("t10_reopen2", rc==SQLITE_OK);
     sqlite3_busy_timeout(db1, 5000);
-    check("t10_main_survives", strcmp(exec1(db1, "SELECT val FROM t WHERE id=1"), "main-data")==0);
+    check("t10_main_survives", strcmp(queryScalarText(db1, "SELECT val FROM t WHERE id=1"), "main-data")==0);
   }
 
   /* Cleanup */

--- a/test/doltlite_concurrent.c
+++ b/test/doltlite_concurrent.c
@@ -11,7 +11,7 @@ static int failed = 0;
   else { printf("FAIL: %s\n", label); failed++; } \
 } while(0)
 
-static int exec_int(sqlite3 *db, const char *sql, int dflt){
+static int queryScalarInt(sqlite3 *db, const char *sql, int dflt){
   sqlite3_stmt *stmt;
   int val = dflt;
   if( sqlite3_prepare_v2(db, sql, -1, &stmt, 0)==SQLITE_OK ){
@@ -117,9 +117,9 @@ static void test_concurrent_readers(const char *path){
   exec_ok(db2, "BEGIN");
   exec_ok(db3, "BEGIN");
 
-  v1 = exec_int(db1, "SELECT count(*) FROM t", -1);
-  v2 = exec_int(db2, "SELECT count(*) FROM t", -1);
-  v3 = exec_int(db3, "SELECT count(*) FROM t", -1);
+  v1 = queryScalarInt(db1, "SELECT count(*) FROM t", -1);
+  v2 = queryScalarInt(db2, "SELECT count(*) FROM t", -1);
+  v3 = queryScalarInt(db3, "SELECT count(*) FROM t", -1);
 
   CHECK("concurrent_readers: all three see same count", v1==v2 && v2==v3 && v1>=3);
 
@@ -140,7 +140,7 @@ static void test_reader_no_block_writer(const char *path){
   sqlite3_open(path, &dbW);
 
   exec_ok(dbR, "BEGIN");
-  exec_int(dbR, "SELECT count(*) FROM t", -1);
+  queryScalarInt(dbR, "SELECT count(*) FROM t", -1);
 
   exec_ok(dbW, "INSERT INTO t VALUES(100, 'new')");
   rc = exec_ok(dbW, "SELECT dolt_commit('-am', 'add 100')");
@@ -165,7 +165,7 @@ static void test_writer_no_block_reader(const char *path){
   exec_ok(dbW, "INSERT INTO t VALUES(200, 'wip')");
 
   exec_ok(dbR, "BEGIN");
-  int cnt = exec_int(dbR, "SELECT count(*) FROM t", -1);
+  int cnt = queryScalarInt(dbR, "SELECT count(*) FROM t", -1);
   CHECK("writer_no_block_reader: reader succeeds while writer has pending changes",
         cnt >= 3);
   exec_ok(dbR, "COMMIT");
@@ -184,12 +184,12 @@ static void test_snapshot_consistency(const char *path){
   sqlite3_open(path, &dbB);
 
   exec_ok(dbA, "BEGIN");
-  int cnt1 = exec_int(dbA, "SELECT count(*) FROM t", -1);
+  int cnt1 = queryScalarInt(dbA, "SELECT count(*) FROM t", -1);
 
   exec_ok(dbB, "INSERT INTO t VALUES(300, 'added')");
   exec_ok(dbB, "SELECT dolt_commit('-am', 'add 300')");
 
-  int cnt2 = exec_int(dbA, "SELECT count(*) FROM t", -1);
+  int cnt2 = queryScalarInt(dbA, "SELECT count(*) FROM t", -1);
   CHECK("snapshot_consistency: count stable across concurrent commit",
         cnt1==cnt2);
 
@@ -220,7 +220,7 @@ static void test_checkpoint(const char *path){
   rc = exec_ok(db, "PRAGMA wal_checkpoint(TRUNCATE)");
   CHECK("checkpoint: PRAGMA wal_checkpoint succeeds", rc==SQLITE_OK);
 
-  int cnt = exec_int(db, "SELECT count(*) FROM t WHERE id>=400", -1);
+  int cnt = queryScalarInt(db, "SELECT count(*) FROM t WHERE id>=400", -1);
   CHECK("checkpoint: data preserved after checkpoint", cnt==2);
 
   exec_ok(db, "DELETE FROM t WHERE id>=400");
@@ -239,7 +239,7 @@ static void test_post_checkpoint_read(const char *path){
   exec_ok(db1, "PRAGMA wal_checkpoint(TRUNCATE)");
 
   sqlite3_open(path, &db2);
-  int cnt = exec_int(db2, "SELECT count(*) FROM t WHERE id=500", -1);
+  int cnt = queryScalarInt(db2, "SELECT count(*) FROM t WHERE id=500", -1);
   CHECK("post_checkpoint_read: new connection sees data after checkpoint", cnt==1);
 
   exec_ok(db1, "DELETE FROM t WHERE id=500");
@@ -255,10 +255,10 @@ static void test_snapshot_large(const char *path){
   sqlite3_open(path, &dbA);
   sqlite3_open(path, &dbB);
 
-  int cnt_before = exec_int(dbA, "SELECT count(*) FROM t", -1);
+  int cnt_before = queryScalarInt(dbA, "SELECT count(*) FROM t", -1);
 
   exec_ok(dbA, "BEGIN");
-  int cnt_a1 = exec_int(dbA, "SELECT count(*) FROM t", -1);
+  int cnt_a1 = queryScalarInt(dbA, "SELECT count(*) FROM t", -1);
 
   exec_ok(dbB, "BEGIN");
   {
@@ -273,13 +273,13 @@ static void test_snapshot_large(const char *path){
   exec_ok(dbB, "COMMIT");
   exec_ok(dbB, "SELECT dolt_commit('-am', 'bulk insert')");
 
-  int cnt_a2 = exec_int(dbA, "SELECT count(*) FROM t", -1);
+  int cnt_a2 = queryScalarInt(dbA, "SELECT count(*) FROM t", -1);
   CHECK("snapshot_large: 100-row insert invisible to snapshot reader",
         cnt_a1==cnt_a2);
 
   exec_ok(dbA, "COMMIT");
 
-  int cnt_a3 = exec_int(dbA, "SELECT count(*) FROM t", -1);
+  int cnt_a3 = queryScalarInt(dbA, "SELECT count(*) FROM t", -1);
   CHECK("snapshot_large: new transaction sees bulk insert",
         cnt_a3 == cnt_before + 100);
 

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -49,7 +49,7 @@ static void check(const char *name, int condition){
   }
 }
 
-static const char *exec1(sqlite3 *db, const char *sql){
+static const char *queryScalarText(sqlite3 *db, const char *sql){
   sqlite3_stmt *stmt = 0;
   int rc;
   gBuf[0] = 0;
@@ -69,7 +69,7 @@ static const char *exec1(sqlite3 *db, const char *sql){
   return gBuf;
 }
 
-static int execsql(sqlite3 *db, const char *sql){
+static int execSql(sqlite3 *db, const char *sql){
   char *err = 0;
   int rc = sqlite3_exec(db, sql, 0, 0, &err);
   if( rc!=SQLITE_OK ){
@@ -80,7 +80,7 @@ static int execsql(sqlite3 *db, const char *sql){
   return rc;
 }
 
-static int execsql_silent(sqlite3 *db, const char *sql){
+static int execSqlSilent(sqlite3 *db, const char *sql){
   char *err = 0;
   int rc = sqlite3_exec(db, sql, 0, 0, &err);
   sqlite3_free(err);
@@ -133,17 +133,17 @@ static void capture_repo_state_snapshot(sqlite3 *db, RepoStateSnapshot *p){
   const char *zOrigBranch = 0;
   memset(p, 0, sizeof(*p));
   sqlite3_snprintf(sizeof(p->zBranch), p->zBranch, "%s",
-                   exec1(db, "SELECT active_branch()"));
+                   queryScalarText(db, "SELECT active_branch()"));
   sqlite3_snprintf(sizeof(p->zHead), p->zHead, "%s",
-                   exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1"));
+                   queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1"));
   sqlite3_snprintf(sizeof(p->zStatusCount), p->zStatusCount, "%s",
-                   exec1(db, "SELECT count(*) FROM dolt_status"));
+                   queryScalarText(db, "SELECT count(*) FROM dolt_status"));
   sqlite3_snprintf(sizeof(p->zConflictsCount), p->zConflictsCount, "%s",
-                   exec1(db, "SELECT count(*) FROM dolt_conflicts"));
+                   queryScalarText(db, "SELECT count(*) FROM dolt_conflicts"));
   sqlite3_snprintf(sizeof(p->zRemotesCount), p->zRemotesCount, "%s",
-                   exec1(db, "SELECT count(*) FROM dolt_remotes"));
+                   queryScalarText(db, "SELECT count(*) FROM dolt_remotes"));
   sqlite3_snprintf(sizeof(p->zRebasePlanCount), p->zRebasePlanCount, "%s",
-                   exec1(db, "SELECT count(*) FROM sqlite_master "
+                   queryScalarText(db, "SELECT count(*) FROM sqlite_master "
                              "WHERE type='table' AND name='dolt_rebase'"));
   doltliteGetSessionMergeState(db, &p->isMerging, &p->mergeHash, &p->conflictsHash);
   doltliteGetSessionRebaseState(db, &p->isRebasing, 0, &p->rebaseOntoHash, &zOrigBranch, 0);
@@ -171,7 +171,7 @@ static void make_dbpath(char *zBuf, size_t nBuf, const char *zBase){
   snprintf(zBuf, nBuf, "/tmp/%s_%ld.db", zBase, (long)getpid());
 }
 
-static void remove_db(const char *path){
+static void removeDbFiles(const char *path){
   char tmp[512];
   remove(path);
   snprintf(tmp, sizeof(tmp), "%s-wal", path);
@@ -180,6 +180,35 @@ static void remove_db(const char *path){
   remove(tmp);
   snprintf(tmp, sizeof(tmp), "%s-journal", path);
   remove(tmp);
+}
+
+static void checkBranchState(
+  sqlite3 *db,
+  const char *zPrefix,
+  const char *zActiveBranch,
+  const char *zBranchCount,
+  const char *zNamedBranch,
+  const char *zNamedBranchCount
+){
+  char zCheck[128];
+  char zSql[160];
+
+  sqlite3_snprintf(sizeof(zCheck), zCheck, "%s_active_branch", zPrefix);
+  check(zCheck,
+        strcmp(queryScalarText(db, "SELECT active_branch()"), zActiveBranch)==0);
+
+  sqlite3_snprintf(sizeof(zCheck), zCheck, "%s_branch_count", zPrefix);
+  check(zCheck,
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_branches"),
+               zBranchCount)==0);
+
+  if( zNamedBranch ){
+    sqlite3_snprintf(sizeof(zSql), zSql,
+                     "SELECT count(*) FROM dolt_branches WHERE name='%q'",
+                     zNamedBranch);
+    sqlite3_snprintf(sizeof(zCheck), zCheck, "%s_named_branch", zPrefix);
+    check(zCheck, strcmp(queryScalarText(db, zSql), zNamedBranchCount)==0);
+  }
 }
 
 static void make_prolly_blob_key(int iKey, u8 *aBuf, int nBuf){
@@ -420,26 +449,26 @@ static void test_concurrent_refs_stale_reset_is_rejected(void){
 
   printf("--- Test 1: stale dolt_reset is rejected ---\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_concurrent_refs_reset");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db1", open_db(dbpath, &db1)==SQLITE_OK);
-  check("setup_schema", execsql(db1,
+  check("setup_schema", execSql(db1,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');")==SQLITE_OK);
 
   snprintf(firstCommit, sizeof(firstCommit), "%s",
-           exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')"));
+           queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init')"));
   check("first_commit_hash", strlen(firstCommit)==40);
   check("open_db2", open_db(dbpath, &db2)==SQLITE_OK);
 
   check("insert_second_row",
-    execsql(db1, "INSERT INTO t VALUES(2,'b')")==SQLITE_OK);
+    execSql(db1, "INSERT INTO t VALUES(2,'b')")==SQLITE_OK);
   snprintf(secondCommit, sizeof(secondCommit), "%s",
-           exec1(db1, "SELECT dolt_commit('-A', '-m', 'second')"));
+           queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'second')"));
   check("second_commit_hash", strlen(secondCommit)==40);
 
   snprintf(sql, sizeof(sql), "SELECT dolt_reset('%s')", firstCommit);
-  exec1(db2, sql);
+  queryScalarText(db2, sql);
   check("stale_reset_is_rejected",
     strstr(gBuf, "ERROR")!=0 || strstr(gBuf, "conflict")!=0);
 
@@ -448,16 +477,16 @@ static void test_concurrent_refs_stale_reset_is_rejected(void){
 
   check("open_db3", open_db(dbpath, &db3)==SQLITE_OK);
   check("newer_commit_still_head",
-    strcmp(exec1(db3, "SELECT message FROM dolt_log LIMIT 1"), "second")==0);
+    strcmp(queryScalarText(db3, "SELECT message FROM dolt_log LIMIT 1"), "second")==0);
   snprintf(sql, sizeof(sql),
            "SELECT count(*) FROM dolt_log WHERE commit_hash='%s'", secondCommit);
   check("newer_commit_still_visible_in_log",
-    strcmp(exec1(db3, sql), "1")==0);
+    strcmp(queryScalarText(db3, sql), "1")==0);
   check("branch_history_has_both_commits",
-    strcmp(exec1(db3, "SELECT count(*) FROM dolt_log"), "3")==0);
+    strcmp(queryScalarText(db3, "SELECT count(*) FROM dolt_log"), "3")==0);
 
   sqlite3_close(db3);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void test_concurrent_refs_checkout_refreshes_branch(void){
@@ -466,34 +495,34 @@ static void test_concurrent_refs_checkout_refreshes_branch(void){
 
   printf("--- Test 2: stale dolt_checkout refreshes target branch ---\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_concurrent_refs_checkout");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("checkout_open_db1", open_db(dbpath, &db1)==SQLITE_OK);
-  check("checkout_setup_schema", execsql(db1,
+  check("checkout_setup_schema", execSql(db1,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');")==SQLITE_OK);
   check("checkout_init_commit",
-    strlen(exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')"))==40);
+    strlen(queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init')"))==40);
   check("checkout_create_branch",
-    strcmp(exec1(db1, "SELECT dolt_branch('feature')"), "0")==0);
+    strcmp(queryScalarText(db1, "SELECT dolt_branch('feature')"), "0")==0);
   check("checkout_open_db2", open_db(dbpath, &db2)==SQLITE_OK);
   check("checkout_switch_db1_feature",
-    strcmp(exec1(db1, "SELECT dolt_checkout('feature')"), "0")==0);
+    strcmp(queryScalarText(db1, "SELECT dolt_checkout('feature')"), "0")==0);
   check("checkout_feature_insert",
-    execsql(db1, "INSERT INTO t VALUES(2,'feature')")==SQLITE_OK);
+    execSql(db1, "INSERT INTO t VALUES(2,'feature')")==SQLITE_OK);
   check("checkout_feature_commit",
-    strlen(exec1(db1, "SELECT dolt_commit('-A', '-m', 'feature update')"))==40);
+    strlen(queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'feature update')"))==40);
 
   check("checkout_stale_connection_switches",
-    strcmp(exec1(db2, "SELECT dolt_checkout('feature')"), "0")==0);
+    strcmp(queryScalarText(db2, "SELECT dolt_checkout('feature')"), "0")==0);
   check("checkout_latest_branch_tip_visible",
-    strcmp(exec1(db2, "SELECT message FROM dolt_log LIMIT 1"), "feature update")==0);
+    strcmp(queryScalarText(db2, "SELECT message FROM dolt_log LIMIT 1"), "feature update")==0);
   check("checkout_latest_branch_data_visible",
-    strcmp(exec1(db2, "SELECT count(*) FROM t"), "2")==0);
+    strcmp(queryScalarText(db2, "SELECT count(*) FROM t"), "2")==0);
 
   sqlite3_close(db1);
   sqlite3_close(db2);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_concurrent_refs(void){
@@ -511,49 +540,49 @@ static void run_checkout_persist_failure(void){
   printf("=== Checkout Persist Failure Test ===\n\n");
   printf("--- Test 1: dolt_checkout surfaces final persist failure ---\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_checkout_persist_failure");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
   gFailSyncOnce = 0;
   gFailHits = 0;
 
   check("register_fail_vfs", registerFailVfs()==SQLITE_OK);
   check("open_db1", open_fail_db(dbpath, &db1)==SQLITE_OK);
 
-  check("setup_schema", execsql(db1,
+  check("setup_schema", execSql(db1,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');")==SQLITE_OK);
   check("init_commit",
-    strlen(exec1(db1, "SELECT dolt_commit('-A', '-m', 'init')"))==40);
+    strlen(queryScalarText(db1, "SELECT dolt_commit('-A', '-m', 'init')"))==40);
   check("create_feature_branch",
-    strcmp(exec1(db1, "SELECT dolt_branch('feature')"), "0")==0);
+    strcmp(queryScalarText(db1, "SELECT dolt_branch('feature')"), "0")==0);
 
   gFailSyncOnce = 1;
-  res = exec1(db1, "SELECT dolt_checkout('feature')");
+  res = queryScalarText(db1, "SELECT dolt_checkout('feature')");
   check("persist_failure_was_injected", gFailHits>0);
   check("checkout_returns_error_on_persist_failure", strstr(res, "ERROR:")!=0);
   check("session_branch_restored_after_error",
-    strcmp(exec1(db1, "SELECT active_branch()"), "main")==0);
+    strcmp(queryScalarText(db1, "SELECT active_branch()"), "main")==0);
   check("working_rows_preserved_after_checkout_error",
-    strcmp(exec1(db1, "SELECT count(*) FROM t"), "1")==0);
+    strcmp(queryScalarText(db1, "SELECT count(*) FROM t"), "1")==0);
 
   sqlite3_close(db1);
   db1 = 0;
 
   check("reopen_db_after_checkout_persist_failure", open_db(dbpath, &db2)==SQLITE_OK);
   check("active_branch_persists_after_checkout_error",
-    strcmp(exec1(db2, "SELECT active_branch()"), "main")==0);
+    strcmp(queryScalarText(db2, "SELECT active_branch()"), "main")==0);
   check("main_rows_persist_after_checkout_error",
-    strcmp(exec1(db2, "SELECT count(*) FROM t"), "1")==0);
+    strcmp(queryScalarText(db2, "SELECT count(*) FROM t"), "1")==0);
   check("feature_tip_still_visible_after_checkout_error",
-    strcmp(exec1(db2,
+    strcmp(queryScalarText(db2,
       "SELECT latest_commit_message FROM dolt_branches WHERE name='feature'"),
       "init")==0);
   check("feature_checkout_still_works_after_checkout_error",
-    strcmp(exec1(db2, "SELECT dolt_checkout('feature')"), "0")==0);
+    strcmp(queryScalarText(db2, "SELECT dolt_checkout('feature')"), "0")==0);
   check("feature_rows_visible_after_reopen_checkout",
-    strcmp(exec1(db2, "SELECT count(*) FROM t"), "1")==0);
+    strcmp(queryScalarText(db2, "SELECT count(*) FROM t"), "1")==0);
 
   sqlite3_close(db2);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_savepoint_catalog_restore(void){
@@ -569,12 +598,12 @@ static void run_savepoint_catalog_restore(void){
   printf("=== Savepoint Catalog Restore Test ===\n\n");
   printf("--- Test 1: savepoint rollback restores schema metadata ---\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_savepoint_catalog_restore");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db", sqlite3_open(dbpath, &db)==SQLITE_OK);
   if( !db ) return;
 
-  check("create_table", execsql(db,
+  check("create_table", execSql(db,
       "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);")==SQLITE_OK);
   check("serialize_before",
       doltliteFlushAndSerializeCatalog(db, &aBefore, &nBefore)==SQLITE_OK);
@@ -583,10 +612,10 @@ static void run_savepoint_catalog_restore(void){
   check("lookup_rootpage", iTable>0);
 
   memset(&fakeHash, 0x5a, sizeof(fakeHash));
-  check("savepoint_begin", execsql(db, "SAVEPOINT sp;")==SQLITE_OK);
+  check("savepoint_begin", execSql(db, "SAVEPOINT sp;")==SQLITE_OK);
   doltliteSetTableSchemaHash(db, iTable, &fakeHash);
-  check("rollback_to", execsql(db, "ROLLBACK TO sp;")==SQLITE_OK);
-  check("release_sp", execsql(db, "RELEASE sp;")==SQLITE_OK);
+  check("rollback_to", execSql(db, "ROLLBACK TO sp;")==SQLITE_OK);
+  check("release_sp", execSql(db, "RELEASE sp;")==SQLITE_OK);
 
   check("serialize_after",
       doltliteFlushAndSerializeCatalog(db, &aAfter, &nAfter)==SQLITE_OK);
@@ -657,7 +686,7 @@ static void run_refresh_error_propagation(void){
 
   printf("--- Test 1: xAccess failure is surfaced ---\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_refresh_access_failure");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
   check("open_empty_chunk_store",
         chunkStoreOpen(&cs, &gFailVfs, dbpath,
           SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB)==SQLITE_OK);
@@ -669,13 +698,13 @@ static void run_refresh_error_propagation(void){
   check("access_failure_injected", gFailHits>0);
   check("changed_left_false_on_access_error", changed==0);
   chunkStoreClose(&cs);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   printf("--- Test 2: xFileControl failure is surfaced ---\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_refresh_filecontrol_failure");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
   check("open_sql_db", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_doltlite_repo", execsql(db,
+  check("setup_doltlite_repo", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');"
     "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
@@ -692,7 +721,7 @@ static void run_refresh_error_propagation(void){
   check("filecontrol_failure_injected", gFailHits>0);
   check("changed_left_false_on_filecontrol_error", changed==0);
   chunkStoreClose(&cs);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_conflicts_blob_corruption(void){
@@ -708,10 +737,10 @@ static void run_conflicts_blob_corruption(void){
 
   printf("=== Conflicts Blob Corruption Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_conflicts_blob_corruption");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo", execsql(db,
+  check("setup_repo", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');"
     "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
@@ -725,7 +754,7 @@ static void run_conflicts_blob_corruption(void){
   }
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_status_error_propagation(void){
@@ -736,10 +765,10 @@ static void run_status_error_propagation(void){
 
   printf("=== Status Error Propagation Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_status_error_propagation");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_status_repo", execsql(db,
+  check("setup_status_repo", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');"
     "SELECT dolt_commit('-A', '-m', 'init');"
@@ -747,11 +776,11 @@ static void run_status_error_propagation(void){
 
   memset(&badHash, 0x7b, sizeof(badHash));
   doltliteSetSessionStaged(db, &badHash);
-  rc = execsql_silent(db, "SELECT count(*) FROM dolt_status;");
+  rc = execSqlSilent(db, "SELECT count(*) FROM dolt_status;");
   check("status_surfaces_persist_error", rc!=SQLITE_OK);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_remote_refs_corruption(void){
@@ -770,12 +799,12 @@ static void run_remote_refs_corruption(void){
   make_dbpath(remotePath, sizeof(remotePath), "test_remote_refs_corruption_remote");
   make_dbpath(localPath, sizeof(localPath), "test_remote_refs_corruption_local");
   make_dbpath(clonePath, sizeof(clonePath), "test_remote_refs_corruption_clone");
-  remove_db(remotePath);
-  remove_db(localPath);
-  remove_db(clonePath);
+  removeDbFiles(remotePath);
+  removeDbFiles(localPath);
+  removeDbFiles(clonePath);
 
   check("open_remote_db", open_db(remotePath, &srcDb)==SQLITE_OK);
-  check("setup_remote_repo", execsql(srcDb,
+  check("setup_remote_repo", execSql(srcDb,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');"
     "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
@@ -790,7 +819,7 @@ static void run_remote_refs_corruption(void){
       "SELECT dolt_commit('-A', '-m', 'seed');"
       "SELECT dolt_remote('add','origin','file://%s');",
       remotePath);
-    check("setup_local_remote", execsql(localDb, sql)==SQLITE_OK);
+    check("setup_local_remote", execSql(localDb, sql)==SQLITE_OK);
   }
 
   check("open_chunk_store", chunkStoreOpen(&cs, sqlite3_vfs_find(0), remotePath,
@@ -803,25 +832,25 @@ static void run_remote_refs_corruption(void){
   chunkStoreUnlock(&cs);
   chunkStoreClose(&cs);
 
-  rc = execsql_silent(localDb, "SELECT dolt_fetch('origin');");
+  rc = execSqlSilent(localDb, "SELECT dolt_fetch('origin');");
   check("fetch_surfaces_corrupt_refs", rc!=SQLITE_OK);
 
-  rc = execsql_silent(localDb, "SELECT dolt_push('origin','main');");
+  rc = execSqlSilent(localDb, "SELECT dolt_push('origin','main');");
   check("push_surfaces_corrupt_refs", rc!=SQLITE_OK);
 
   check("open_clone_db", open_db(clonePath, &cloneDb)==SQLITE_OK);
   if( cloneDb ){
     char sql[1024];
     snprintf(sql, sizeof(sql), "SELECT dolt_clone('file://%s')", remotePath);
-    rc = execsql_silent(cloneDb, sql);
+    rc = execSqlSilent(cloneDb, sql);
     check("clone_surfaces_corrupt_refs", rc!=SQLITE_OK);
   }
 
   sqlite3_close(cloneDb);
   sqlite3_close(localDb);
-  remove_db(remotePath);
-  remove_db(localPath);
-  remove_db(clonePath);
+  removeDbFiles(remotePath);
+  removeDbFiles(localPath);
+  removeDbFiles(clonePath);
 }
 
 static void run_chunk_walk_corruption(void){
@@ -886,10 +915,10 @@ static void run_ancestor_missing_start(void){
 
   printf("=== Ancestor Missing Start Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_ancestor_missing_start");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo", execsql(db,
+  check("setup_repo", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');"
     "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
@@ -900,7 +929,7 @@ static void run_ancestor_missing_start(void){
   check("missing_start_commit_returns_notfound", rc==SQLITE_NOTFOUND);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_pull_persist_failure(void){
@@ -918,9 +947,9 @@ static void run_pull_persist_failure(void){
   make_dbpath(localPath, sizeof(localPath), "test_pull_persist_failure_local");
   make_dbpath(remotePath, sizeof(remotePath), "test_pull_persist_failure_remote");
   make_dbpath(remoteClientPath, sizeof(remoteClientPath), "test_pull_persist_failure_remote_client");
-  remove_db(localPath);
-  remove_db(remotePath);
-  remove_db(remoteClientPath);
+  removeDbFiles(localPath);
+  removeDbFiles(remotePath);
+  removeDbFiles(remoteClientPath);
 
   gFailSyncOnce = 0;
   gFailHits = 0;
@@ -935,32 +964,32 @@ static void run_pull_persist_failure(void){
     "SELECT dolt_remote('add','origin','file://%s');"
     "SELECT dolt_push('origin','main');",
     remotePath);
-  check("setup_local_and_push", execsql(localDb, sql)==SQLITE_OK);
+  check("setup_local_and_push", execSql(localDb, sql)==SQLITE_OK);
 
   check("open_remote_client_db", open_db(remoteClientPath, &remoteClientDb)==SQLITE_OK);
   snprintf(sql, sizeof(sql), "SELECT dolt_clone('file://%s')", remotePath);
-  check("clone_remote_into_remote_client", execsql(remoteClientDb, sql)==SQLITE_OK);
-  check("advance_remote", execsql(remoteClientDb,
+  check("clone_remote_into_remote_client", execSql(remoteClientDb, sql)==SQLITE_OK);
+  check("advance_remote", execSql(remoteClientDb,
     "INSERT INTO t VALUES(2,'b');"
     "SELECT dolt_add('-A');"
     "SELECT dolt_commit('-m', 'remote update');"
     "SELECT dolt_push('origin','main');")==SQLITE_OK);
   sqlite3_snprintf(sizeof(zHeadBefore), zHeadBefore, "%s",
-                   exec1(localDb, "SELECT commit_hash FROM dolt_log LIMIT 1"));
+                   queryScalarText(localDb, "SELECT commit_hash FROM dolt_log LIMIT 1"));
 
   gFailHits = 0;
   gFailSyncOnce = 2;
-  res = exec1(localDb, "SELECT dolt_pull('origin','main')");
+  res = queryScalarText(localDb, "SELECT dolt_pull('origin','main')");
   check("pull_failure_was_injected", gFailHits>0);
   check("pull_returns_error_on_persist_failure", strstr(res, "ERROR:")!=0);
   check("pull_branch_stays_main",
-    strcmp(exec1(localDb, "SELECT active_branch()"), "main")==0);
+    strcmp(queryScalarText(localDb, "SELECT active_branch()"), "main")==0);
   check("pull_head_data_restored",
-    strcmp(exec1(localDb, "SELECT count(*) FROM t"), "1")==0);
+    strcmp(queryScalarText(localDb, "SELECT count(*) FROM t"), "1")==0);
   check("pull_head_hash_restored",
-    strcmp(exec1(localDb, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
+    strcmp(queryScalarText(localDb, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
   check("pull_remote_kept",
-    strcmp(exec1(localDb, "SELECT count(*) FROM dolt_remotes"), "1")==0);
+    strcmp(queryScalarText(localDb, "SELECT count(*) FROM dolt_remotes"), "1")==0);
 
   sqlite3_close(remoteClientDb);
   remoteClientDb = 0;
@@ -971,18 +1000,18 @@ static void run_pull_persist_failure(void){
 
   check("reopen_local_after_pull_failure", open_db(localPath, &localDb)==SQLITE_OK);
   check("pull_failure_persists_branch_after_reopen",
-    strcmp(exec1(localDb, "SELECT active_branch()"), "main")==0);
+    strcmp(queryScalarText(localDb, "SELECT active_branch()"), "main")==0);
   check("pull_failure_persists_rows_after_reopen",
-    strcmp(exec1(localDb, "SELECT count(*) FROM t"), "1")==0);
+    strcmp(queryScalarText(localDb, "SELECT count(*) FROM t"), "1")==0);
   check("pull_failure_persists_head_after_reopen",
-    strcmp(exec1(localDb, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
+    strcmp(queryScalarText(localDb, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
   check("pull_failure_persists_remote_after_reopen",
-    strcmp(exec1(localDb, "SELECT count(*) FROM dolt_remotes"), "1")==0);
+    strcmp(queryScalarText(localDb, "SELECT count(*) FROM dolt_remotes"), "1")==0);
 
   sqlite3_close(localDb);
-  remove_db(localPath);
-  remove_db(remotePath);
-  remove_db(remoteClientPath);
+  removeDbFiles(localPath);
+  removeDbFiles(remotePath);
+  removeDbFiles(remoteClientPath);
 }
 
 static void run_pull_dirty_working_set_fails(void){
@@ -1000,9 +1029,9 @@ static void run_pull_dirty_working_set_fails(void){
   make_dbpath(localPath, sizeof(localPath), "test_pull_dirty_working_set_local");
   make_dbpath(remotePath, sizeof(remotePath), "test_pull_dirty_working_set_remote");
   make_dbpath(remoteClientPath, sizeof(remoteClientPath), "test_pull_dirty_working_set_remote_client");
-  remove_db(localPath);
-  remove_db(remotePath);
-  remove_db(remoteClientPath);
+  removeDbFiles(localPath);
+  removeDbFiles(remotePath);
+  removeDbFiles(remoteClientPath);
 
   check("open_local_db_for_pull_dirty", open_db(localPath, &localDb)==SQLITE_OK);
   check("open_remote_db_for_pull_dirty", open_db(remotePath, &remoteDb)==SQLITE_OK);
@@ -1014,31 +1043,31 @@ static void run_pull_dirty_working_set_fails(void){
     "SELECT dolt_remote('add','origin','file://%s');"
     "SELECT dolt_push('origin','main');",
     remotePath);
-  check("setup_local_and_push_for_pull_dirty", execsql(localDb, sql)==SQLITE_OK);
+  check("setup_local_and_push_for_pull_dirty", execSql(localDb, sql)==SQLITE_OK);
 
   check("open_remote_client_db_for_pull_dirty", open_db(remoteClientPath, &remoteClientDb)==SQLITE_OK);
   snprintf(sql, sizeof(sql), "SELECT dolt_clone('file://%s')", remotePath);
-  check("clone_remote_into_remote_client_for_pull_dirty", execsql(remoteClientDb, sql)==SQLITE_OK);
-  check("advance_remote_for_pull_dirty", execsql(remoteClientDb,
+  check("clone_remote_into_remote_client_for_pull_dirty", execSql(remoteClientDb, sql)==SQLITE_OK);
+  check("advance_remote_for_pull_dirty", execSql(remoteClientDb,
     "INSERT INTO t VALUES(2,'b');"
     "SELECT dolt_add('-A');"
     "SELECT dolt_commit('-m', 'remote update');"
     "SELECT dolt_push('origin','main');")==SQLITE_OK);
 
-  check("make_local_working_dirty", execsql(localDb,
+  check("make_local_working_dirty", execSql(localDb,
     "UPDATE t SET v='local dirty' WHERE id=1;")==SQLITE_OK);
   sqlite3_snprintf(sizeof(zHeadBefore), zHeadBefore, "%s",
-                   exec1(localDb, "SELECT commit_hash FROM dolt_log LIMIT 1"));
+                   queryScalarText(localDb, "SELECT commit_hash FROM dolt_log LIMIT 1"));
 
-  res = exec1(localDb, "SELECT dolt_pull('origin','main')");
+  res = queryScalarText(localDb, "SELECT dolt_pull('origin','main')");
   check("pull_dirty_working_returns_error", strstr(res, "ERROR:")!=0);
   check("pull_dirty_working_reports_uncommitted", strstr(res, "uncommitted changes")!=0);
   check("pull_dirty_working_branch_stays_main",
-    strcmp(exec1(localDb, "SELECT active_branch()"), "main")==0);
+    strcmp(queryScalarText(localDb, "SELECT active_branch()"), "main")==0);
   check("pull_dirty_working_keeps_local_rows",
-    strcmp(exec1(localDb, "SELECT v FROM t WHERE id=1"), "local dirty")==0);
+    strcmp(queryScalarText(localDb, "SELECT v FROM t WHERE id=1"), "local dirty")==0);
   check("pull_dirty_working_keeps_head",
-    strcmp(exec1(localDb, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
+    strcmp(queryScalarText(localDb, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
 
   sqlite3_close(remoteClientDb);
   remoteClientDb = 0;
@@ -1049,14 +1078,14 @@ static void run_pull_dirty_working_set_fails(void){
 
   check("reopen_local_after_pull_dirty_working", open_db(localPath, &localDb)==SQLITE_OK);
   check("pull_dirty_working_persists_local_rows_after_reopen",
-    strcmp(exec1(localDb, "SELECT v FROM t WHERE id=1"), "local dirty")==0);
+    strcmp(queryScalarText(localDb, "SELECT v FROM t WHERE id=1"), "local dirty")==0);
   check("pull_dirty_working_persists_head_after_reopen",
-    strcmp(exec1(localDb, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
+    strcmp(queryScalarText(localDb, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
 
   sqlite3_close(localDb);
-  remove_db(localPath);
-  remove_db(remotePath);
-  remove_db(remoteClientPath);
+  removeDbFiles(localPath);
+  removeDbFiles(remotePath);
+  removeDbFiles(remoteClientPath);
 }
 
 static void run_pull_staged_changes_fails(void){
@@ -1074,9 +1103,9 @@ static void run_pull_staged_changes_fails(void){
   make_dbpath(localPath, sizeof(localPath), "test_pull_staged_changes_local");
   make_dbpath(remotePath, sizeof(remotePath), "test_pull_staged_changes_remote");
   make_dbpath(remoteClientPath, sizeof(remoteClientPath), "test_pull_staged_changes_remote_client");
-  remove_db(localPath);
-  remove_db(remotePath);
-  remove_db(remoteClientPath);
+  removeDbFiles(localPath);
+  removeDbFiles(remotePath);
+  removeDbFiles(remoteClientPath);
 
   check("open_local_db_for_pull_staged", open_db(localPath, &localDb)==SQLITE_OK);
   check("open_remote_db_for_pull_staged", open_db(remotePath, &remoteDb)==SQLITE_OK);
@@ -1088,32 +1117,32 @@ static void run_pull_staged_changes_fails(void){
     "SELECT dolt_remote('add','origin','file://%s');"
     "SELECT dolt_push('origin','main');",
     remotePath);
-  check("setup_local_and_push_for_pull_staged", execsql(localDb, sql)==SQLITE_OK);
+  check("setup_local_and_push_for_pull_staged", execSql(localDb, sql)==SQLITE_OK);
 
   check("open_remote_client_db_for_pull_staged", open_db(remoteClientPath, &remoteClientDb)==SQLITE_OK);
   snprintf(sql, sizeof(sql), "SELECT dolt_clone('file://%s')", remotePath);
-  check("clone_remote_into_remote_client_for_pull_staged", execsql(remoteClientDb, sql)==SQLITE_OK);
-  check("advance_remote_for_pull_staged", execsql(remoteClientDb,
+  check("clone_remote_into_remote_client_for_pull_staged", execSql(remoteClientDb, sql)==SQLITE_OK);
+  check("advance_remote_for_pull_staged", execSql(remoteClientDb,
     "INSERT INTO t VALUES(2,'b');"
     "SELECT dolt_add('-A');"
     "SELECT dolt_commit('-m', 'remote update');"
     "SELECT dolt_push('origin','main');")==SQLITE_OK);
 
-  check("make_local_staged_dirty", execsql(localDb,
+  check("make_local_staged_dirty", execSql(localDb,
     "UPDATE t SET v='local staged' WHERE id=1;"
     "SELECT dolt_add('-A');")==SQLITE_OK);
   sqlite3_snprintf(sizeof(zHeadBefore), zHeadBefore, "%s",
-                   exec1(localDb, "SELECT commit_hash FROM dolt_log LIMIT 1"));
+                   queryScalarText(localDb, "SELECT commit_hash FROM dolt_log LIMIT 1"));
 
-  res = exec1(localDb, "SELECT dolt_pull('origin','main')");
+  res = queryScalarText(localDb, "SELECT dolt_pull('origin','main')");
   check("pull_staged_returns_error", strstr(res, "ERROR:")!=0);
   check("pull_staged_reports_uncommitted", strstr(res, "uncommitted changes")!=0);
   check("pull_staged_branch_stays_main",
-    strcmp(exec1(localDb, "SELECT active_branch()"), "main")==0);
+    strcmp(queryScalarText(localDb, "SELECT active_branch()"), "main")==0);
   check("pull_staged_keeps_local_rows",
-    strcmp(exec1(localDb, "SELECT v FROM t WHERE id=1"), "local staged")==0);
+    strcmp(queryScalarText(localDb, "SELECT v FROM t WHERE id=1"), "local staged")==0);
   check("pull_staged_keeps_head",
-    strcmp(exec1(localDb, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
+    strcmp(queryScalarText(localDb, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
 
   sqlite3_close(remoteClientDb);
   remoteClientDb = 0;
@@ -1124,14 +1153,14 @@ static void run_pull_staged_changes_fails(void){
 
   check("reopen_local_after_pull_staged", open_db(localPath, &localDb)==SQLITE_OK);
   check("pull_staged_persists_local_rows_after_reopen",
-    strcmp(exec1(localDb, "SELECT v FROM t WHERE id=1"), "local staged")==0);
+    strcmp(queryScalarText(localDb, "SELECT v FROM t WHERE id=1"), "local staged")==0);
   check("pull_staged_persists_head_after_reopen",
-    strcmp(exec1(localDb, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
+    strcmp(queryScalarText(localDb, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
 
   sqlite3_close(localDb);
-  remove_db(localPath);
-  remove_db(remotePath);
-  remove_db(remoteClientPath);
+  removeDbFiles(localPath);
+  removeDbFiles(remotePath);
+  removeDbFiles(remoteClientPath);
 }
 
 static void run_push_persist_failure(void){
@@ -1146,20 +1175,20 @@ static void run_push_persist_failure(void){
   printf("=== Push Persist Failure Test ===\n\n");
   make_dbpath(localPath, sizeof(localPath), "test_push_persist_failure_local");
   make_dbpath(remotePath, sizeof(remotePath), "test_push_persist_failure_remote");
-  remove_db(localPath);
-  remove_db(remotePath);
+  removeDbFiles(localPath);
+  removeDbFiles(remotePath);
 
   gFailWriteOnce = 0;
   gFailSyncOnce = 0;
   gFailHits = 0;
   check("register_fail_vfs_for_push", registerFailVfs()==SQLITE_OK);
   check("open_remote_db_for_push", open_db(remotePath, &remoteDb)==SQLITE_OK);
-  check("setup_remote_repo_for_push", execsql(remoteDb,
+  check("setup_remote_repo_for_push", execSql(remoteDb,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'remote');"
     "SELECT dolt_commit('-A', '-m', 'remote init');")==SQLITE_OK);
   sqlite3_snprintf(sizeof(zRemoteHeadBefore), zRemoteHeadBefore, "%s",
-                   exec1(remoteDb, "SELECT commit_hash FROM dolt_log LIMIT 1"));
+                   queryScalarText(remoteDb, "SELECT commit_hash FROM dolt_log LIMIT 1"));
   sqlite3_close(remoteDb);
   remoteDb = 0;
 
@@ -1172,32 +1201,32 @@ static void run_push_persist_failure(void){
     "UPDATE t SET v='local pushed' WHERE id=1;"
     "SELECT dolt_commit('-A', '-m', 'local update');",
     remotePath);
-  check("setup_local_repo_for_push", execsql(localDb, sql)==SQLITE_OK);
+  check("setup_local_repo_for_push", execSql(localDb, sql)==SQLITE_OK);
 
   gFailHits = 0;
   gFailSyncOnce = 1;
-  res = exec1(localDb, "SELECT dolt_push('origin','main','--force')");
+  res = queryScalarText(localDb, "SELECT dolt_push('origin','main','--force')");
   check("push_failure_was_injected", gFailHits>0);
   check("push_returns_error_on_persist_failure", strstr(res, "ERROR:")!=0);
   check("push_keeps_local_rows",
-    strcmp(exec1(localDb, "SELECT v FROM t WHERE id=1"), "local pushed")==0);
+    strcmp(queryScalarText(localDb, "SELECT v FROM t WHERE id=1"), "local pushed")==0);
   check("push_keeps_local_remote",
-    strcmp(exec1(localDb, "SELECT count(*) FROM dolt_remotes"), "1")==0);
+    strcmp(queryScalarText(localDb, "SELECT count(*) FROM dolt_remotes"), "1")==0);
 
   sqlite3_close(localDb);
   localDb = 0;
 
   check("reopen_remote_after_push_failure", open_db(remotePath, &remoteDb)==SQLITE_OK);
   check("push_failure_preserves_remote_rows_after_reopen",
-    strcmp(exec1(remoteDb, "SELECT v FROM t WHERE id=1"), "remote")==0);
+    strcmp(queryScalarText(remoteDb, "SELECT v FROM t WHERE id=1"), "remote")==0);
   check("push_failure_preserves_remote_head_after_reopen",
-    strcmp(exec1(remoteDb, "SELECT commit_hash FROM dolt_log LIMIT 1"), zRemoteHeadBefore)==0);
+    strcmp(queryScalarText(remoteDb, "SELECT commit_hash FROM dolt_log LIMIT 1"), zRemoteHeadBefore)==0);
   check("push_failure_preserves_remote_log_count_after_reopen",
-    strcmp(exec1(remoteDb, "SELECT count(*) FROM dolt_log"), "2")==0);
+    strcmp(queryScalarText(remoteDb, "SELECT count(*) FROM dolt_log"), "2")==0);
 
   sqlite3_close(remoteDb);
-  remove_db(localPath);
-  remove_db(remotePath);
+  removeDbFiles(localPath);
+  removeDbFiles(remotePath);
 }
 
 static void run_clone_persist_failure(void){
@@ -1211,14 +1240,14 @@ static void run_clone_persist_failure(void){
   printf("=== Clone Persist Failure Test ===\n\n");
   make_dbpath(localPath, sizeof(localPath), "test_clone_persist_failure_local");
   make_dbpath(remotePath, sizeof(remotePath), "test_clone_persist_failure_remote");
-  remove_db(localPath);
-  remove_db(remotePath);
+  removeDbFiles(localPath);
+  removeDbFiles(remotePath);
 
   gFailSyncOnce = 0;
   gFailHits = 0;
   check("register_fail_vfs_for_clone", registerFailVfs()==SQLITE_OK);
   check("open_remote_db", open_db(remotePath, &remoteDb)==SQLITE_OK);
-  check("setup_remote_repo", execsql(remoteDb,
+  check("setup_remote_repo", execSql(remoteDb,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');"
     "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
@@ -1229,13 +1258,13 @@ static void run_clone_persist_failure(void){
   snprintf(sql, sizeof(sql), "SELECT dolt_clone('file://%s')", remotePath);
   gFailHits = 0;
   gFailSyncOnce = 2;
-  res = exec1(localDb, sql);
+  res = queryScalarText(localDb, sql);
   check("clone_failure_was_injected", gFailHits>0);
   check("clone_returns_error_on_persist_failure", strstr(res, "ERROR:")!=0);
   check("clone_does_not_leave_origin_remote",
-    strcmp(exec1(localDb, "SELECT count(*) FROM dolt_remotes"), "0")==0);
+    strcmp(queryScalarText(localDb, "SELECT count(*) FROM dolt_remotes"), "0")==0);
   check("clone_restores_empty_catalog",
-    strcmp(exec1(localDb,
+    strcmp(queryScalarText(localDb,
       "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='t'"), "0")==0);
 
   sqlite3_close(localDb);
@@ -1243,14 +1272,14 @@ static void run_clone_persist_failure(void){
 
   check("reopen_local_after_clone_failure", open_db(localPath, &localDb)==SQLITE_OK);
   check("clone_failure_persists_no_origin_after_reopen",
-    strcmp(exec1(localDb, "SELECT count(*) FROM dolt_remotes"), "0")==0);
+    strcmp(queryScalarText(localDb, "SELECT count(*) FROM dolt_remotes"), "0")==0);
   check("clone_failure_persists_empty_catalog_after_reopen",
-    strcmp(exec1(localDb,
+    strcmp(queryScalarText(localDb,
       "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='t'"), "0")==0);
 
   sqlite3_close(localDb);
-  remove_db(localPath);
-  remove_db(remotePath);
+  removeDbFiles(localPath);
+  removeDbFiles(remotePath);
 }
 
 static void run_resolve_ref_non_commit(void){
@@ -1265,10 +1294,10 @@ static void run_resolve_ref_non_commit(void){
 
   printf("=== Resolve Ref Non-Commit Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_resolve_ref_non_commit");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo", execsql(db,
+  check("setup_repo", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');"
     "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
@@ -1292,7 +1321,7 @@ static void run_resolve_ref_non_commit(void){
 
   doltliteCommitClear(&commit);
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_commit_parent_limit(void){
@@ -1324,7 +1353,7 @@ static void run_blame_all_parents_merge_base(void){
 
   printf("=== Blame All-Parents Merge Base Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_blame_all_parents_merge_base");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   memset(&b1Hash, 0, sizeof(b1Hash));
   memset(&b2Hash, 0, sizeof(b2Hash));
@@ -1337,7 +1366,7 @@ static void run_blame_all_parents_merge_base(void){
   memset(&mergeCommit, 0, sizeof(mergeCommit));
 
   check("open_db_for_blame_all_parents", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_base_for_blame_all_parents", execsql(db,
+  check("setup_base_for_blame_all_parents", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'base');"
     "SELECT dolt_commit('-A', '-m', 'BASE');"
@@ -1348,7 +1377,7 @@ static void run_blame_all_parents_merge_base(void){
   doltliteGetSessionHead(db, &b1Hash);
   check("have_b1_head_for_blame_all_parents", !prollyHashIsEmpty(&b1Hash));
 
-  check("setup_b2_for_blame_all_parents", execsql(db,
+  check("setup_b2_for_blame_all_parents", execSql(db,
     "SELECT dolt_branch('b2');"
     "SELECT dolt_checkout('b2');"
     "INSERT INTO t VALUES(2,'side');"
@@ -1356,7 +1385,7 @@ static void run_blame_all_parents_merge_base(void){
   doltliteGetSessionHead(db, &b2Hash);
   check("have_b2_head_for_blame_all_parents", !prollyHashIsEmpty(&b2Hash));
 
-  check("setup_b3_for_blame_all_parents", execsql(db,
+  check("setup_b3_for_blame_all_parents", execSql(db,
     "SELECT dolt_checkout('main');"
     "SELECT dolt_branch('b3');"
     "SELECT dolt_checkout('b3');"
@@ -1374,7 +1403,7 @@ static void run_blame_all_parents_merge_base(void){
         && !prollyHashIsEmpty(&base123Hash)
         && prollyHashCompare(&base123Hash, &b1Hash)!=0);
 
-  check("checkout_b2_before_synthetic_merge", execsql(db,
+  check("checkout_b2_before_synthetic_merge", execSql(db,
     "SELECT dolt_checkout('b2');")==SQLITE_OK);
   doltliteGetSessionHead(db, &curHeadHash);
   check("head_is_b2_before_synthetic_merge",
@@ -1407,7 +1436,7 @@ static void run_blame_all_parents_merge_base(void){
           doltliteSwitchCatalog(db, &mergeCommit.catalogHash)==SQLITE_OK);
   }
 
-  res = exec1(db, "SELECT message FROM dolt_blame_t WHERE id = 1;");
+  res = queryScalarText(db, "SELECT message FROM dolt_blame_t WHERE id = 1;");
   check("blame_query_returns_row_for_all_parents", res[0]!=0);
   check("blame_uses_all_parents_merge_base", strcmp(res, "OCTO")==0);
 
@@ -1415,7 +1444,7 @@ static void run_blame_all_parents_merge_base(void){
   doltliteCommitClear(&b2Commit);
   doltliteCommitClear(&mergeCommit);
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_merge_persist_failure(void){
@@ -1425,13 +1454,13 @@ static void run_merge_persist_failure(void){
 
   printf("=== Merge Persist Failure Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_merge_persist_failure");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   gFailSyncOnce = 0;
   gFailHits = 0;
   check("register_fail_vfs_for_merge", registerFailVfs()==SQLITE_OK);
   check("open_fail_db", open_fail_db(dbpath, &db)==SQLITE_OK);
-  check("setup_ff_merge_repo", execsql(db,
+  check("setup_ff_merge_repo", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');"
     "SELECT dolt_commit('-A', '-m', 'init');"
@@ -1443,14 +1472,14 @@ static void run_merge_persist_failure(void){
 
   gFailHits = 0;
   gFailSyncOnce = 1;
-  res = exec1(db, "SELECT dolt_merge('feature')");
+  res = queryScalarText(db, "SELECT dolt_merge('feature')");
   check("merge_failure_was_injected", gFailHits>0);
   check("merge_returns_error_on_persist_failure", strstr(res, "ERROR:")!=0);
   check("merge_restores_branch_name",
-    strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
+    strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_merge_conflict_surfaces_error_and_rollback_clears_durable_state(void){
@@ -1460,10 +1489,10 @@ static void run_merge_conflict_surfaces_error_and_rollback_clears_durable_state(
 
   printf("=== Merge Conflict Surfaces Error Rolls Back Durable State Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_merge_conflict_surfaces_error");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_merge_conflict_error", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_merge_conflict_repo", execsql(db,
+  check("setup_merge_conflict_repo", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'base');"
     "SELECT dolt_commit('-A', '-m', 'init');"
@@ -1475,27 +1504,27 @@ static void run_merge_conflict_surfaces_error_and_rollback_clears_durable_state(
     "SELECT dolt_commit('-A', '-m', 'feature edit');"
     "SELECT dolt_checkout('main');")==SQLITE_OK);
 
-  res = exec1(db, "SELECT dolt_merge('feature')");
+  res = queryScalarText(db, "SELECT dolt_merge('feature')");
   check("merge_conflict_returns_error",
         strstr(res, "ERROR:")!=0);
   check("merge_conflict_keeps_active_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
   check("merge_conflict_keeps_working_value_before_close",
-        strcmp(exec1(db, "SELECT v FROM t WHERE id=1"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT v FROM t WHERE id=1"), "main")==0);
 
   sqlite3_close(db);
   db = 0;
 
   check("reopen_db_after_merge_conflict_error", open_db(dbpath, &db)==SQLITE_OK);
   check("merge_conflict_reopen_has_no_summary_table_rows",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_conflicts"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_conflicts"), "0")==0);
   check("merge_conflict_reopen_has_no_per_table_rows",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_conflicts_t"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_conflicts_t"), "0")==0);
   check("merge_conflict_reopen_keeps_working_value",
-        strcmp(exec1(db, "SELECT v FROM t WHERE id=1"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT v FROM t WHERE id=1"), "main")==0);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_failed_merge_reopen_clears_ephemeral_conflict_state(void){
@@ -1513,10 +1542,10 @@ static void run_failed_merge_reopen_clears_ephemeral_conflict_state(void){
 
   printf("=== Failed Merge Reopen Clears Ephemeral Conflict State Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_failed_merge_reopen_preserves_working_set_state");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_failed_merge_reopen", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_failed_merge_reopen_repo", execsql(db,
+  check("setup_failed_merge_reopen_repo", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'base');"
     "SELECT dolt_commit('-A', '-m', 'init');"
@@ -1528,11 +1557,11 @@ static void run_failed_merge_reopen_clears_ephemeral_conflict_state(void){
     "SELECT dolt_commit('-A', '-m', 'feature edit');"
     "SELECT dolt_checkout('main');")==SQLITE_OK);
 
-  res = exec1(db, "SELECT dolt_merge('feature')");
+  res = queryScalarText(db, "SELECT dolt_merge('feature')");
   check("failed_merge_reopen_returns_error",
         strstr(res, "ERROR:")!=0);
   check("failed_merge_reopen_working_value_before_close",
-        strcmp(exec1(db, "SELECT v FROM t WHERE id=1"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT v FROM t WHERE id=1"), "main")==0);
   doltliteGetSessionStaged(db, &stagedBeforeClose);
   doltliteGetSessionMergeState(db, &isMergingBeforeClose,
                                &mergeBeforeClose, &conflictsBeforeClose);
@@ -1548,13 +1577,13 @@ static void run_failed_merge_reopen_clears_ephemeral_conflict_state(void){
 
   check("reopen_db_for_failed_merge_reopen", open_db(dbpath, &db)==SQLITE_OK);
   check("failed_merge_reopen_conflicts_summary_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_conflicts"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_conflicts"), "0")==0);
   check("failed_merge_reopen_conflicts_table_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_conflicts_t"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_conflicts_t"), "0")==0);
   check("failed_merge_reopen_working_value_after_reopen",
-        strcmp(exec1(db, "SELECT v FROM t WHERE id=1"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT v FROM t WHERE id=1"), "main")==0);
   check("failed_merge_reopen_branch_after_reopen",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
 
   doltliteGetSessionStaged(db, &stagedAfterReopen);
   doltliteGetSessionMergeState(db, &isMergingAfterReopen,
@@ -1565,7 +1594,7 @@ static void run_failed_merge_reopen_clears_ephemeral_conflict_state(void){
         prollyHashIsEmpty(&conflictsAfterReopen));
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_merge_abort_after_reopen_restores_durable_state(void){
@@ -1581,10 +1610,10 @@ static void run_merge_abort_after_reopen_restores_durable_state(void){
 
   printf("=== Merge Abort After Reopen Restores Durable State Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_merge_abort_after_reopen_restores_durable_state");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_merge_abort_after_reopen", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_merge_abort_after_reopen", execsql(db,
+  check("setup_repo_for_merge_abort_after_reopen", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'base');"
     "SELECT dolt_commit('-A', '-m', 'init');"
@@ -1596,9 +1625,9 @@ static void run_merge_abort_after_reopen_restores_durable_state(void){
     "SELECT dolt_commit('-A', '-m', 'feature edit');"
     "SELECT dolt_checkout('main');")==SQLITE_OK);
   sqlite3_snprintf(sizeof(zHeadBefore), zHeadBefore, "%s",
-                   exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1"));
+                   queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1"));
 
-  res = exec1(db, "SELECT dolt_merge('feature')");
+  res = queryScalarText(db, "SELECT dolt_merge('feature')");
   check("merge_abort_after_reopen_setup_conflict",
         strstr(res, "ERROR:")!=0);
 
@@ -1607,24 +1636,24 @@ static void run_merge_abort_after_reopen_restores_durable_state(void){
 
   check("reopen_db_for_merge_abort_after_reopen", open_db(dbpath, &db)==SQLITE_OK);
   check("merge_abort_after_reopen_conflicts_persist_before_abort",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_conflicts"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_conflicts"), "0")==0);
   check("merge_abort_after_reopen_branch_before_abort",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
   doltliteGetSessionMergeState(db, &isMerging, &mergeHash, &conflictsHash);
   check("merge_abort_after_reopen_merging_flag_before_abort", isMerging==0);
   check("merge_abort_after_reopen_conflicts_hash_before_abort",
         prollyHashIsEmpty(&conflictsHash));
 
   check("merge_abort_after_reopen_returns_error",
-        strstr(exec1(db, "SELECT dolt_merge('--abort')"), "ERROR: no merge in progress")!=0);
+        strstr(queryScalarText(db, "SELECT dolt_merge('--abort')"), "ERROR: no merge in progress")!=0);
   check("merge_abort_after_reopen_clears_conflicts",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_conflicts"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_conflicts"), "0")==0);
   check("merge_abort_after_reopen_restores_rows",
-        strcmp(exec1(db, "SELECT v FROM t WHERE id=1"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT v FROM t WHERE id=1"), "main")==0);
   check("merge_abort_after_reopen_restores_status_clean",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_status"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_status"), "0")==0);
   check("merge_abort_after_reopen_restores_head",
-        strcmp(exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
+        strcmp(queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
   doltliteGetSessionMergeState(db, &isMerging, &mergeHash, &conflictsHash);
   check("merge_abort_after_reopen_clears_merge_flag", isMerging==0);
   check("merge_abort_after_reopen_clears_conflicts_hash",
@@ -1636,13 +1665,13 @@ static void run_merge_abort_after_reopen_restores_durable_state(void){
 
   check("reopen_db_after_merge_abort", open_db(dbpath, &db)==SQLITE_OK);
   check("merge_abort_persists_no_conflicts",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_conflicts"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_conflicts"), "0")==0);
   check("merge_abort_persists_rows",
-        strcmp(exec1(db, "SELECT v FROM t WHERE id=1"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT v FROM t WHERE id=1"), "main")==0);
   check("merge_abort_persists_status_clean",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_status"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_status"), "0")==0);
   check("merge_abort_persists_head",
-        strcmp(exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
+        strcmp(queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
   doltliteGetSessionMergeState(db, &isMerging, &mergeHash, &conflictsHash);
   check("merge_abort_persists_merge_flag_cleared", isMerging==0);
   check("merge_abort_persists_conflicts_hash_cleared",
@@ -1652,7 +1681,7 @@ static void run_merge_abort_after_reopen_restores_durable_state(void){
         repo_state_snapshot_eq(&beforeReopenAbort, &afterReopenAbort));
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_cherry_pick_stale_branch(void){
@@ -1666,10 +1695,10 @@ static void run_cherry_pick_stale_branch(void){
 
   printf("=== Cherry-pick Stale Branch Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_cherry_pick_stale_branch");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db1", open_db(dbpath, &db1)==SQLITE_OK);
-  check("setup_init", execsql(db1,
+  check("setup_init", execSql(db1,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');"
     "SELECT dolt_commit('-A', '-m', 'init');"
@@ -1680,28 +1709,28 @@ static void run_cherry_pick_stale_branch(void){
     "SELECT dolt_checkout('main');")==SQLITE_OK);
 
   snprintf(featHash, sizeof(featHash), "%s",
-           exec1(db1, "SELECT hash FROM dolt_branches WHERE name='feature'"));
+           queryScalarText(db1, "SELECT hash FROM dolt_branches WHERE name='feature'"));
 
   check("open_db2", open_db(dbpath, &db2)==SQLITE_OK);
   check("db2_sees_old_main",
-    strcmp(exec1(db2, "SELECT count(*) FROM t"), "1")==0);
+    strcmp(queryScalarText(db2, "SELECT count(*) FROM t"), "1")==0);
 
-  check("advance_main_in_db1", execsql(db1,
+  check("advance_main_in_db1", execSql(db1,
     "INSERT INTO t VALUES(3,'main');"
     "SELECT dolt_commit('-A', '-m', 'main work');")==SQLITE_OK);
 
   snprintf(sql, sizeof(sql), "SELECT dolt_cherry_pick('%s')", featHash);
-  res = exec1(db2, sql);
+  res = queryScalarText(db2, sql);
   check("stale_cherry_pick_returns_error", strstr(res, "ERROR:")!=0);
 
   check("open_db3", open_db(dbpath, &db3)==SQLITE_OK);
   check("stale_cherry_pick_does_not_persist_feature_row",
-    strcmp(exec1(db3, "SELECT count(*) FROM t"), "2")==0);
+    strcmp(queryScalarText(db3, "SELECT count(*) FROM t"), "2")==0);
 
   sqlite3_close(db3);
   sqlite3_close(db2);
   sqlite3_close(db1);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_failed_cherry_pick_reopen_preserves_conflict_state(void){
@@ -1719,10 +1748,10 @@ static void run_failed_cherry_pick_reopen_preserves_conflict_state(void){
 
   printf("=== Failed Cherry-pick Reopen Preserves Conflict State Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_failed_cherry_pick_reopen_preserves_conflict_state");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_failed_cherry_pick_reopen", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_failed_cherry_pick_reopen_repo", execsql(db,
+  check("setup_failed_cherry_pick_reopen_repo", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'base');"
     "SELECT dolt_commit('-A', '-m', 'init');"
@@ -1735,13 +1764,13 @@ static void run_failed_cherry_pick_reopen_preserves_conflict_state(void){
     "UPDATE t SET v='main' WHERE id=1;"
     "SELECT dolt_commit('-A', '-m', 'main edit');")==SQLITE_OK);
 
-  res = exec1(db, "SELECT dolt_cherry_pick('feat-conflict')");
+  res = queryScalarText(db, "SELECT dolt_cherry_pick('feat-conflict')");
   check("failed_cherry_pick_reopen_returns_error",
         strstr(res, "ERROR:")!=0);
   check("failed_cherry_pick_reopen_working_value_before_close",
-        strcmp(exec1(db, "SELECT v FROM t WHERE id=1"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT v FROM t WHERE id=1"), "main")==0);
   check("failed_cherry_pick_reopen_branch_before_close",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
 
   doltliteGetSessionStaged(db, &stagedBeforeClose);
   doltliteGetSessionMergeState(db, &isMergingBeforeClose,
@@ -1756,13 +1785,13 @@ static void run_failed_cherry_pick_reopen_preserves_conflict_state(void){
 
   check("reopen_db_for_failed_cherry_pick_reopen", open_db(dbpath, &db)==SQLITE_OK);
   check("failed_cherry_pick_reopen_conflicts_summary_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_conflicts"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_conflicts"), "0")==0);
   check("failed_cherry_pick_reopen_conflicts_table_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_conflicts_t"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_conflicts_t"), "0")==0);
   check("failed_cherry_pick_reopen_working_value_after_reopen",
-        strcmp(exec1(db, "SELECT v FROM t WHERE id=1"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT v FROM t WHERE id=1"), "main")==0);
   check("failed_cherry_pick_reopen_branch_after_reopen",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
 
   doltliteGetSessionStaged(db, &stagedAfterReopen);
   doltliteGetSessionMergeState(db, &isMergingAfterReopen,
@@ -1777,7 +1806,7 @@ static void run_failed_cherry_pick_reopen_preserves_conflict_state(void){
         prollyHashIsEmpty(&conflictsAfterReopen));
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_branches_metadata_corruption(void){
@@ -1790,10 +1819,10 @@ static void run_branches_metadata_corruption(void){
 
   printf("=== Branches Metadata Corruption Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_branches_metadata_corruption");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo", execsql(db,
+  check("setup_repo", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');"
     "SELECT dolt_commit('-A', '-m', 'init');"
@@ -1830,15 +1859,15 @@ static void run_branches_metadata_corruption(void){
   chunkStoreClose(&cs);
 
   check("reopen_db", open_db(dbpath, &db)==SQLITE_OK);
-  rc = execsql_silent(db,
+  rc = execSqlSilent(db,
     "SELECT latest_commit_message FROM dolt_branches WHERE name='feature';");
   check("branches_latest_commit_surfaces_corruption", rc!=SQLITE_OK);
-  rc = execsql_silent(db,
+  rc = execSqlSilent(db,
     "SELECT dirty FROM dolt_branches WHERE name='feature';");
   check("branches_dirty_surfaces_corruption", rc!=SQLITE_OK);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_gc_rewrite_failure(void){
@@ -1849,13 +1878,13 @@ static void run_gc_rewrite_failure(void){
 
   printf("=== GC Rewrite Failure Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_gc_rewrite_failure");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   gFailSyncOnce = 0;
   gFailHits = 0;
   check("register_fail_vfs_for_gc", registerFailVfs()==SQLITE_OK);
   check("open_fail_db", open_fail_db(dbpath, &db)==SQLITE_OK);
-  check("setup_gc_repo", execsql(db,
+  check("setup_gc_repo", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');"
     "SELECT dolt_commit('-A', '-m', 'init');"
@@ -1864,23 +1893,23 @@ static void run_gc_rewrite_failure(void){
 
   gFailHits = 0;
   gFailSyncOnce = 1;
-  res = exec1(db, "SELECT dolt_gc()");
+  res = queryScalarText(db, "SELECT dolt_gc()");
   check("gc_failure_was_injected", gFailHits>0);
   check("gc_returns_error_on_rewrite_failure", strstr(res, "ERROR:")!=0);
   check("gc_connection_still_reads_data",
-    strcmp(exec1(db, "SELECT count(*) FROM t"), "2")==0);
+    strcmp(queryScalarText(db, "SELECT count(*) FROM t"), "2")==0);
   check("gc_connection_still_reads_log",
-    strcmp(exec1(db, "SELECT count(*) FROM dolt_log"), "3")==0);
+    strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_log"), "3")==0);
 
   sqlite3_close(db);
   check("reopen_db_after_gc_failure", open_db(dbpath, &db2)==SQLITE_OK);
   check("gc_reopen_reads_data",
-    strcmp(exec1(db2, "SELECT count(*) FROM t"), "2")==0);
+    strcmp(queryScalarText(db2, "SELECT count(*) FROM t"), "2")==0);
   check("gc_reopen_reads_log",
-    strcmp(exec1(db2, "SELECT count(*) FROM dolt_log"), "3")==0);
+    strcmp(queryScalarText(db2, "SELECT count(*) FROM dolt_log"), "3")==0);
 
   sqlite3_close(db2);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_record_decode_corruption(void){
@@ -2096,10 +2125,10 @@ static void run_refresh_refs_corruption_preserves_state(void){
 
   printf("=== Refresh Corrupt Refs State Preservation Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_refresh_refs_preserves_state");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo", execsql(db,
+  check("setup_repo", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');"
     "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
@@ -2140,7 +2169,7 @@ static void run_refresh_refs_corruption_preserves_state(void){
   sqlite3_free(zDefaultBefore);
   sqlite3_free(zBranchBefore);
   chunkStoreClose(&cs1);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_prolly_node_corruption(void){
@@ -2221,10 +2250,10 @@ static void run_integrity_check_repo_state(void){
 
   printf("=== Integrity Check Repository State Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_integrity_check_repo_state");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_repo_state", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_state", execsql(db,
+  check("setup_repo_state", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');"
     "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
@@ -2247,7 +2276,7 @@ static void run_integrity_check_repo_state(void){
   check("repo_graph_integrity_call_succeeds", rc==SQLITE_OK);
   check("integrity_check_reports_repo_state_corruption", nErr>0);
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_integrity_check_session_merge_state(void){
@@ -2259,10 +2288,10 @@ static void run_integrity_check_session_merge_state(void){
 
   printf("=== Integrity Check Session Merge State Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_integrity_check_session_merge_state");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_session_merge_state", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_session_merge_state", execsql(db,
+  check("setup_repo_session_merge_state", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');"
     "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
@@ -2275,7 +2304,7 @@ static void run_integrity_check_session_merge_state(void){
   check("integrity_check_reports_session_merge_state_corruption", nErr>0);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_prepared_stmt_reuse_after_commit(void){
@@ -2286,10 +2315,10 @@ static void run_prepared_stmt_reuse_after_commit(void){
 
   printf("=== Prepared Statement Reuse After Commit Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_prepared_stmt_reuse_after_commit");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_stmt_commit", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_stmt_commit", execsql(db,
+  check("setup_repo_stmt_commit", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');"
     "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
@@ -2303,7 +2332,7 @@ static void run_prepared_stmt_reuse_after_commit(void){
     check("stmt_commit_done", sqlite3_step(stmt)==SQLITE_DONE);
     check("stmt_commit_reset_initial", sqlite3_reset(stmt)==SQLITE_OK);
 
-    check("commit_new_row_same_conn", execsql(db,
+    check("commit_new_row_same_conn", execSql(db,
       "INSERT INTO t VALUES(2,'b');"
       "SELECT dolt_commit('-A', '-m', 'second');")==SQLITE_OK);
 
@@ -2319,7 +2348,7 @@ static void run_prepared_stmt_reuse_after_commit(void){
 
   sqlite3_finalize(stmt);
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_prepared_stmt_reuse_after_schema_checkout(void){
@@ -2330,10 +2359,10 @@ static void run_prepared_stmt_reuse_after_schema_checkout(void){
 
   printf("=== Prepared Statement Reuse After Schema Checkout Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_prepared_stmt_reuse_after_schema_checkout");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_stmt_checkout", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_stmt_checkout", execsql(db,
+  check("setup_repo_stmt_checkout", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');"
     "SELECT dolt_commit('-A', '-m', 'init');"
@@ -2353,7 +2382,7 @@ static void run_prepared_stmt_reuse_after_schema_checkout(void){
     check("stmt_checkout_main_done", sqlite3_step(stmt)==SQLITE_DONE);
     check("stmt_checkout_reset_initial", sqlite3_reset(stmt)==SQLITE_OK);
 
-    check("checkout_schema_branch", execsql(db,
+    check("checkout_schema_branch", execSql(db,
       "SELECT dolt_checkout('schema_branch');")==SQLITE_OK);
 
     check("stmt_checkout_branch_row", sqlite3_step(stmt)==SQLITE_ROW);
@@ -2367,7 +2396,7 @@ static void run_prepared_stmt_reuse_after_schema_checkout(void){
 
   sqlite3_finalize(stmt);
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_working_set_refreshes_staged_across_connections(void){
@@ -2380,19 +2409,19 @@ static void run_working_set_refreshes_staged_across_connections(void){
 
   printf("=== Working Set Refreshes Staged Across Connections Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_working_set_refreshes_staged_across_connections");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db1_for_cross_conn_staged", open_db(dbpath, &db1)==SQLITE_OK);
   check("create_table_for_cross_conn_staged",
-        execsql(db1, "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);")==SQLITE_OK);
+        execSql(db1, "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);")==SQLITE_OK);
   check("insert_row_for_cross_conn_staged",
-        execsql(db1, "INSERT INTO t VALUES(1,'a');")==SQLITE_OK);
+        execSql(db1, "INSERT INTO t VALUES(1,'a');")==SQLITE_OK);
   check("initial_commit_for_cross_conn_staged",
-        execsql(db1, "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
+        execSql(db1, "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
   check("open_db2_for_cross_conn_staged", open_db(dbpath, &db2)==SQLITE_OK);
 
   doltliteGetSessionStaged(db2, &stagedBefore);
-  check("db1_stage_new_row", execsql(db1,
+  check("db1_stage_new_row", execSql(db1,
     "INSERT INTO t VALUES(2,'b');"
     "SELECT dolt_add('-A');")==SQLITE_OK);
   doltliteGetSessionStaged(db1, &stagedExpected);
@@ -2400,14 +2429,14 @@ static void run_working_set_refreshes_staged_across_connections(void){
         memcmp(&stagedExpected, &stagedBefore, sizeof(ProllyHash))!=0);
 
   check("db2_refreshes_working_catalog_on_read",
-        strcmp(exec1(db2, "SELECT count(*) FROM t"), "2")==0);
+        strcmp(queryScalarText(db2, "SELECT count(*) FROM t"), "2")==0);
   doltliteGetSessionStaged(db2, &stagedAfter);
   check("db2_refreshes_staged_hash",
         memcmp(&stagedAfter, &stagedExpected, sizeof(ProllyHash))==0);
 
   sqlite3_close(db2);
   sqlite3_close(db1);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_reopen_preserves_staged_working_set(void){
@@ -2418,21 +2447,21 @@ static void run_reopen_preserves_staged_working_set(void){
 
   printf("=== Reopen Preserves Staged Working Set Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_reopen_preserves_staged_working_set");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_reopen_staged", open_db(dbpath, &db)==SQLITE_OK);
   check("create_table_for_reopen_staged",
-        execsql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);")==SQLITE_OK);
+        execSql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);")==SQLITE_OK);
   check("insert_base_row_for_reopen_staged",
-        execsql(db, "INSERT INTO t VALUES(1,'a');")==SQLITE_OK);
+        execSql(db, "INSERT INTO t VALUES(1,'a');")==SQLITE_OK);
   check("commit_base_row_for_reopen_staged",
-        execsql(db, "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
+        execSql(db, "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
   check("stage_new_row_for_reopen_staged",
-        execsql(db,
+        execSql(db,
           "INSERT INTO t VALUES(2,'b');"
           "SELECT dolt_add('-A');")==SQLITE_OK);
   check("staged_status_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_status WHERE staged=1"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_status WHERE staged=1"), "1")==0);
   doltliteGetSessionStaged(db, &stagedBeforeClose);
   check("staged_hash_before_close_nonempty",
         !prollyHashIsEmpty(&stagedBeforeClose));
@@ -2441,13 +2470,13 @@ static void run_reopen_preserves_staged_working_set(void){
 
   check("reopen_db_for_reopen_staged", open_db(dbpath, &db)==SQLITE_OK);
   check("staged_status_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_status WHERE staged=1"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_status WHERE staged=1"), "1")==0);
   doltliteGetSessionStaged(db, &stagedAfterReopen);
   check("staged_hash_after_reopen_matches",
         memcmp(&stagedAfterReopen, &stagedBeforeClose, sizeof(ProllyHash))==0);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_begin_write_refreshes_working_set_metadata(void){
@@ -2465,19 +2494,19 @@ static void run_begin_write_refreshes_working_set_metadata(void){
 
   printf("=== Begin Write Refreshes Working Set Metadata Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_begin_write_refreshes_working_set_metadata");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db1_for_begin_write_refresh", open_db(dbpath, &db1)==SQLITE_OK);
   check("create_table_for_begin_write_refresh",
-        execsql(db1, "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);")==SQLITE_OK);
+        execSql(db1, "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);")==SQLITE_OK);
   check("insert_row_for_begin_write_refresh",
-        execsql(db1, "INSERT INTO t VALUES(1,'a');")==SQLITE_OK);
+        execSql(db1, "INSERT INTO t VALUES(1,'a');")==SQLITE_OK);
   check("initial_commit_for_begin_write_refresh",
-        execsql(db1, "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
+        execSql(db1, "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
   check("open_db2_for_begin_write_refresh", open_db(dbpath, &db2)==SQLITE_OK);
 
   doltliteGetSessionStaged(db2, &stagedBefore);
-  check("db1_prepare_new_working_state", execsql(db1,
+  check("db1_prepare_new_working_state", execSql(db1,
     "INSERT INTO t VALUES(2,'b');"
     "SELECT dolt_add('-A');")==SQLITE_OK);
   doltliteGetSessionStaged(db1, &stagedExpected);
@@ -2490,9 +2519,9 @@ static void run_begin_write_refreshes_working_set_metadata(void){
   check("db2_staged_state_is_initially_stale",
         memcmp(&stagedBefore, &stagedExpected, sizeof(ProllyHash))!=0);
   check("db2_begin_immediate_refreshes_branch_state",
-        execsql(db2, "BEGIN IMMEDIATE;")==SQLITE_OK);
+        execSql(db2, "BEGIN IMMEDIATE;")==SQLITE_OK);
   check("db2_sees_latest_working_rows_in_write_txn",
-        strcmp(exec1(db2, "SELECT count(*) FROM t"), "2")==0);
+        strcmp(queryScalarText(db2, "SELECT count(*) FROM t"), "2")==0);
   doltliteGetSessionStaged(db2, &stagedAfter);
   doltliteGetSessionMergeState(db2, &isMergingAfter, &mergeAfter, &conflictsAfter);
   check("begin_write_refreshes_staged_hash",
@@ -2502,11 +2531,11 @@ static void run_begin_write_refreshes_working_set_metadata(void){
         memcmp(&mergeAfter, &mergeExpected, sizeof(ProllyHash))==0);
   check("begin_write_refreshes_conflicts_catalog",
         memcmp(&conflictsAfter, &conflictsExpected, sizeof(ProllyHash))==0);
-  check("rollback_begin_write_refresh_txn", execsql(db2, "ROLLBACK;")==SQLITE_OK);
+  check("rollback_begin_write_refresh_txn", execSql(db2, "ROLLBACK;")==SQLITE_OK);
 
   sqlite3_close(db2);
   sqlite3_close(db1);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_begin_write_from_stale_read_snapshot(void){
@@ -2518,35 +2547,35 @@ static void run_begin_write_from_stale_read_snapshot(void){
 
   printf("=== Begin Write From Stale Read Snapshot Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_begin_write_from_stale_read_snapshot");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db1_for_stale_snapshot", open_db(dbpath, &db1)==SQLITE_OK);
   check("create_table_for_stale_snapshot",
-        execsql(db1, "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);")==SQLITE_OK);
+        execSql(db1, "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);")==SQLITE_OK);
   check("insert_row_for_stale_snapshot",
-        execsql(db1, "INSERT INTO t VALUES(1,'a');")==SQLITE_OK);
+        execSql(db1, "INSERT INTO t VALUES(1,'a');")==SQLITE_OK);
   check("open_db2_for_stale_snapshot", open_db(dbpath, &db2)==SQLITE_OK);
 
-  check("begin_read_txn_for_stale_snapshot", execsql(db2, "BEGIN;")==SQLITE_OK);
+  check("begin_read_txn_for_stale_snapshot", execSql(db2, "BEGIN;")==SQLITE_OK);
   check("prepare_read_in_stale_snapshot",
         sqlite3_prepare_v2(db2, "SELECT count(*) FROM t", -1, &pRead, 0)==SQLITE_OK);
   check("step_read_in_stale_snapshot", sqlite3_step(pRead)==SQLITE_ROW);
   check("read_in_stale_snapshot", sqlite3_column_int(pRead, 0)==1);
   check("db1_autocommit_change_after_read_snapshot",
-        execsql(db1, "INSERT INTO t VALUES(2,'b');")==SQLITE_OK);
+        execSql(db1, "INSERT INTO t VALUES(2,'b');")==SQLITE_OK);
 
-  rc = execsql_silent(db2, "INSERT INTO t VALUES(3,'c');");
+  rc = execSqlSilent(db2, "INSERT INTO t VALUES(3,'c');");
   check("write_upgrade_fails", rc!=SQLITE_OK);
   check("write_upgrade_returns_busy_snapshot",
         sqlite3_extended_errcode(db2)==SQLITE_BUSY_SNAPSHOT);
   sqlite3_finalize(pRead);
-  check("rollback_stale_snapshot_txn", execsql(db2, "ROLLBACK;")==SQLITE_OK);
+  check("rollback_stale_snapshot_txn", execSql(db2, "ROLLBACK;")==SQLITE_OK);
   check("stale_snapshot_did_not_overwrite_rows",
-        strcmp(exec1(db1, "SELECT count(*) FROM t"), "2")==0);
+        strcmp(queryScalarText(db1, "SELECT count(*) FROM t"), "2")==0);
 
   sqlite3_close(db2);
   sqlite3_close(db1);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_open_rejects_corrupt_working_set(void){
@@ -2561,10 +2590,10 @@ static void run_open_rejects_corrupt_working_set(void){
 
   printf("=== Open Rejects Corrupt Working Set Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_open_rejects_corrupt_working_set");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_corrupt_working_set", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_corrupt_working_set", execsql(db,
+  check("setup_repo_for_corrupt_working_set", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');"
     "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
@@ -2584,11 +2613,11 @@ static void run_open_rejects_corrupt_working_set(void){
   chunkStoreClose(&cs);
 
   rc = sqlite3_open(dbpath, &db2);
-  stmtRc = db2 ? execsql_silent(db2, "SELECT count(*) FROM sqlite_master;") : rc;
+  stmtRc = db2 ? execSqlSilent(db2, "SELECT count(*) FROM sqlite_master;") : rc;
   check("open_or_first_statement_returns_corrupt_for_bad_working_set",
         rc==SQLITE_CORRUPT || stmtRc==SQLITE_CORRUPT);
   if( db2 ) sqlite3_close(db2);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_diff_stat_requires_refs(void){
@@ -2598,21 +2627,21 @@ static void run_diff_stat_requires_refs(void){
 
   printf("=== Diff Stat Requires Refs Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_diff_stat_requires_refs");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_diff_stat_requires_refs", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_diff_stat_requires_refs", execsql(db,
+  check("setup_repo_for_diff_stat_requires_refs", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');"
     "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
 
-  res = exec1(db, "SELECT count(*) FROM dolt_diff_stat('HEAD');");
+  res = queryScalarText(db, "SELECT count(*) FROM dolt_diff_stat('HEAD');");
   check("diff_stat_missing_to_ref_returns_error", strstr(res, "ERROR:")!=0);
-  res = exec1(db, "SELECT count(*) FROM dolt_diff_summary('HEAD');");
+  res = queryScalarText(db, "SELECT count(*) FROM dolt_diff_summary('HEAD');");
   check("diff_summary_missing_to_ref_returns_error", strstr(res, "ERROR:")!=0);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_diff_stat_surfaces_corrupt_root(void){
@@ -2637,14 +2666,14 @@ static void run_diff_stat_surfaces_corrupt_root(void){
 
   printf("=== Diff Stat Surfaces Corrupt Root Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_diff_stat_surfaces_corrupt_root");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   memset(&headCommit, 0, sizeof(headCommit));
   memset(&fromCommit, 0, sizeof(fromCommit));
   memset(&badCommit, 0, sizeof(badCommit));
 
   check("open_db_for_diff_stat_corrupt_root", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_diff_stat_corrupt_root", execsql(db,
+  check("setup_repo_for_diff_stat_corrupt_root", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');"
     "SELECT dolt_commit('-A', '-m', 'c1');"
@@ -2706,13 +2735,13 @@ static void run_diff_stat_surfaces_corrupt_root(void){
   snprintf(sql, sizeof(sql),
            "SELECT count(*) FROM dolt_diff_stat('%s','%s','t');",
            zFrom, zTo);
-  res = exec1(db, sql);
+  res = queryScalarText(db, sql);
   check("diff_stat_corrupt_root_returns_error", strstr(res, "ERROR:")!=0);
 
   snprintf(sql, sizeof(sql),
            "SELECT count(*) FROM dolt_diff_summary('%s','%s','t');",
            zFrom, zTo);
-  res = exec1(db, sql);
+  res = queryScalarText(db, sql);
   check("diff_summary_corrupt_root_returns_error", strstr(res, "ERROR:")!=0);
 
   sqlite3_free(pCommitData);
@@ -2722,7 +2751,7 @@ static void run_diff_stat_surfaces_corrupt_root(void){
   doltliteCommitClear(&fromCommit);
   doltliteCommitClear(&headCommit);
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_truncated_wal_is_rejected(void){
@@ -2733,10 +2762,10 @@ static void run_truncated_wal_is_rejected(void){
 
   printf("=== Truncated WAL Rejected Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_truncated_wal_rejected");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_truncated_wal", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_truncated_wal", execsql(db,
+  check("setup_repo_for_truncated_wal", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');"
     "SELECT dolt_commit('-A', '-m', 'init');"
@@ -2758,7 +2787,7 @@ static void run_truncated_wal_is_rejected(void){
           SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB);
   check("chunk_store_open_rejects_corrupt_wal", rc==SQLITE_CORRUPT);
 
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_refresh_open_path_transactional(void){
@@ -2770,7 +2799,7 @@ static void run_refresh_open_path_transactional(void){
 
   printf("=== Refresh Open Path Transactional Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_refresh_open_path_transactional");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_empty_store_with_no_file",
         chunkStoreOpen(&cs, sqlite3_vfs_find(0), dbpath,
@@ -2793,7 +2822,7 @@ static void run_refresh_open_path_transactional(void){
   check("refresh_open_path_preserves_branch_count", cs.nBranches==0);
 
   chunkStoreClose(&cs);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_wal_offset_corruption_is_rejected(void){
@@ -2807,10 +2836,10 @@ static void run_wal_offset_corruption_is_rejected(void){
 
   printf("=== WAL Offset Corruption Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_wal_offset_corruption");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_wal_offset", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_wal_offset", execsql(db,
+  check("setup_repo_for_wal_offset", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');"
     "SELECT dolt_commit('-A', '-m', 'init');"
@@ -2837,7 +2866,7 @@ static void run_wal_offset_corruption_is_rejected(void){
   }
   sqlite3_free(pData);
   chunkStoreClose(&cs);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_integrity_check_walks_prolly_nodes(void){
@@ -2854,10 +2883,10 @@ static void run_integrity_check_walks_prolly_nodes(void){
 
   printf("=== Integrity Check Walks Prolly Nodes Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_integrity_check_walks_nodes");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_integrity_walk", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_integrity_walk", execsql(db,
+  check("setup_repo_for_integrity_walk", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');"
     "INSERT INTO t VALUES(2,'b');"
@@ -2893,10 +2922,10 @@ static void run_integrity_check_walks_prolly_nodes(void){
 
   check("reopen_db_for_integrity_walk", open_db(dbpath, &db2)==SQLITE_OK);
   check("integrity_check_surfaces_root_corruption",
-        strcmp(exec1(db2, "PRAGMA integrity_check"), "ok")!=0);
+        strcmp(queryScalarText(db2, "PRAGMA integrity_check"), "ok")!=0);
 
   sqlite3_close(db2);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_table_moveto_mutmap_delete_preserves_neighbors(void){
@@ -2905,26 +2934,26 @@ static void run_table_moveto_mutmap_delete_preserves_neighbors(void){
 
   printf("=== Table Moveto MutMap Delete Preserves Neighbors Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_table_moveto_mutmap_delete_preserves_neighbors");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_table_moveto_delete", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_table_for_table_moveto_delete", execsql(db,
+  check("setup_table_for_table_moveto_delete", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');"
     "INSERT INTO t VALUES(3,'c');")==SQLITE_OK);
-  check("begin_txn_for_table_moveto_delete", execsql(db, "BEGIN IMMEDIATE;")==SQLITE_OK);
+  check("begin_txn_for_table_moveto_delete", execSql(db, "BEGIN IMMEDIATE;")==SQLITE_OK);
   check("insert_mutmap_only_row_for_table_moveto_delete",
-        execsql(db, "INSERT INTO t VALUES(2,'b');")==SQLITE_OK);
+        execSql(db, "INSERT INTO t VALUES(2,'b');")==SQLITE_OK);
   check("delete_mutmap_only_row_by_rowid",
-        execsql(db, "DELETE FROM t WHERE rowid=2;")==SQLITE_OK);
+        execSql(db, "DELETE FROM t WHERE rowid=2;")==SQLITE_OK);
   check("neighbors_preserved_after_delete",
-        strcmp(exec1(db,
+        strcmp(queryScalarText(db,
           "SELECT group_concat(id, ',') FROM (SELECT id FROM t ORDER BY id)"),
           "1,3")==0);
-  check("rollback_table_moveto_delete_txn", execsql(db, "ROLLBACK;")==SQLITE_OK);
+  check("rollback_table_moveto_delete_txn", execSql(db, "ROLLBACK;")==SQLITE_OK);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_table_moveto_mutmap_exact_keeps_iteration_aligned(void){
@@ -2933,31 +2962,31 @@ static void run_table_moveto_mutmap_exact_keeps_iteration_aligned(void){
 
   printf("=== Table Moveto MutMap Exact Keeps Iteration Aligned Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_table_moveto_mutmap_exact_keeps_iteration_aligned");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_table_moveto_exact", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_table_for_table_moveto_exact", execsql(db,
+  check("setup_table_for_table_moveto_exact", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');"
     "INSERT INTO t VALUES(2,'b');"
     "INSERT INTO t VALUES(3,'c');")==SQLITE_OK);
-  check("begin_txn_for_table_moveto_exact", execsql(db, "BEGIN IMMEDIATE;")==SQLITE_OK);
+  check("begin_txn_for_table_moveto_exact", execSql(db, "BEGIN IMMEDIATE;")==SQLITE_OK);
   check("update_existing_row_for_table_moveto_exact",
-        execsql(db, "UPDATE t SET v='bb' WHERE id=2;")==SQLITE_OK);
+        execSql(db, "UPDATE t SET v='bb' WHERE id=2;")==SQLITE_OK);
   check("table_moveto_exact_forward_iteration",
-        strcmp(exec1(db,
+        strcmp(queryScalarText(db,
           "SELECT group_concat(id || ':' || v, ',') "
           "FROM (SELECT id, v FROM t WHERE id>=2 ORDER BY id)"),
           "2:bb,3:c")==0);
   check("table_moveto_exact_reverse_iteration",
-        strcmp(exec1(db,
+        strcmp(queryScalarText(db,
           "SELECT group_concat(id || ':' || v, ',') "
           "FROM (SELECT id, v FROM t WHERE id<=2 ORDER BY id DESC)"),
           "2:bb,1:a")==0);
-  check("rollback_table_moveto_exact_txn", execsql(db, "ROLLBACK;")==SQLITE_OK);
+  check("rollback_table_moveto_exact_txn", execSql(db, "ROLLBACK;")==SQLITE_OK);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_index_moveto_mutmap_exact_keeps_iteration_aligned(void){
@@ -2968,17 +2997,17 @@ static void run_index_moveto_mutmap_exact_keeps_iteration_aligned(void){
 
   printf("=== Index Moveto MutMap Exact Keeps Iteration Aligned Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_index_moveto_mutmap_exact_keeps_iteration_aligned");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_index_moveto_exact", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_table_for_index_moveto_exact", execsql(db,
+  check("setup_table_for_index_moveto_exact", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, b TEXT, c TEXT);"
     "CREATE INDEX idx_b ON t(b);"
     "INSERT INTO t VALUES(1,'a','aa');"
     "INSERT INTO t VALUES(3,'c','cc');")==SQLITE_OK);
-  check("begin_txn_for_index_moveto_exact", execsql(db, "BEGIN IMMEDIATE;")==SQLITE_OK);
+  check("begin_txn_for_index_moveto_exact", execSql(db, "BEGIN IMMEDIATE;")==SQLITE_OK);
   check("insert_mutmap_only_index_row",
-        execsql(db, "INSERT INTO t VALUES(2,'b','bb');")==SQLITE_OK);
+        execSql(db, "INSERT INTO t VALUES(2,'b','bb');")==SQLITE_OK);
 
   rc = sqlite3_prepare_v2(db,
     "SELECT b FROM t INDEXED BY idx_b WHERE b >= 'b' ORDER BY b",
@@ -2992,10 +3021,10 @@ static void run_index_moveto_mutmap_exact_keeps_iteration_aligned(void){
     check("index_moveto_exact_done", sqlite3_step(stmt)==SQLITE_DONE);
   }
   sqlite3_finalize(stmt);
-  check("rollback_index_moveto_exact_txn", execsql(db, "ROLLBACK;")==SQLITE_OK);
+  check("rollback_index_moveto_exact_txn", execSql(db, "ROLLBACK;")==SQLITE_OK);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_btree_commit_failure_transactional(void){
@@ -3013,21 +3042,21 @@ static void run_btree_commit_failure_transactional(void){
 
   printf("=== Btree Commit Failure Transaction Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_btree_commit_failure_transactional");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
   gFailWriteOnce = 0;
   gFailSyncOnce = 0;
   gFailHits = 0;
 
   check("register_fail_vfs_for_btree_commit", registerFailVfs()==SQLITE_OK);
   check("open_fail_db_for_btree_commit", open_fail_db(dbpath, &db)==SQLITE_OK);
-  check("setup_table", execsql(db,
+  check("setup_table", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');")==SQLITE_OK);
   check("get_head_catalog_for_commit_failure",
         doltliteGetHeadCatalogHash(db, &headCatHash)==SQLITE_OK);
   doltliteSetSessionStaged(db, &headCatHash);
   doltliteClearSessionMergeState(db);
-  check("begin_write_txn", execsql(db, "BEGIN; INSERT INTO t VALUES(2,'b');")==SQLITE_OK);
+  check("begin_write_txn", execSql(db, "BEGIN; INSERT INTO t VALUES(2,'b');")==SQLITE_OK);
   memset(&dummyStaged, 0x71, sizeof(dummyStaged));
   memset(&dummyMerge, 0x72, sizeof(dummyMerge));
   memset(&dummyConflicts, 0x73, sizeof(dummyConflicts));
@@ -3035,12 +3064,12 @@ static void run_btree_commit_failure_transactional(void){
   doltliteSetSessionMergeState(db, 1, &dummyMerge, &dummyConflicts);
 
   gFailWriteOnce = 1;
-  rc = execsql_silent(db, "COMMIT;");
+  rc = execSqlSilent(db, "COMMIT;");
   check("commit_failure_injected", gFailHits>0);
   check("commit_returns_error", rc!=SQLITE_OK);
   check("autocommit_restored_after_failed_commit", sqlite3_get_autocommit(db)==1);
   check("failed_commit_rolled_back_visible_state",
-        strcmp(exec1(db, "SELECT count(*) FROM t"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t"), "1")==0);
   doltliteGetSessionStaged(db, &stagedAfter);
   doltliteGetSessionMergeState(db, &isMergingAfter, &mergeAfter, &conflictsAfter);
   check("failed_commit_restores_session_staged",
@@ -3054,9 +3083,9 @@ static void run_btree_commit_failure_transactional(void){
   sqlite3_close(db);
   check("reopen_after_failed_commit", open_db(dbpath, &db)==SQLITE_OK);
   check("failed_commit_did_not_persist_row",
-        strcmp(exec1(db, "SELECT count(*) FROM t"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t"), "1")==0);
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_savepoint_restores_session_metadata(void){
@@ -3073,10 +3102,10 @@ static void run_savepoint_restores_session_metadata(void){
 
   printf("=== Savepoint Restores Session Metadata Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_savepoint_restores_session_metadata");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_savepoint_metadata", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_savepoint_metadata", execsql(db,
+  check("setup_repo_for_savepoint_metadata", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');"
     "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
@@ -3087,9 +3116,9 @@ static void run_savepoint_restores_session_metadata(void){
   doltliteClearSessionMergeState(db);
 
   check("begin_immediate_for_savepoint_metadata",
-        execsql(db, "BEGIN IMMEDIATE;")==SQLITE_OK);
+        execSql(db, "BEGIN IMMEDIATE;")==SQLITE_OK);
   check("create_savepoint_for_metadata",
-        execsql(db, "SAVEPOINT s1;")==SQLITE_OK);
+        execSql(db, "SAVEPOINT s1;")==SQLITE_OK);
 
   memset(&dummyStaged, 0x41, sizeof(dummyStaged));
   memset(&dummyMerge, 0x42, sizeof(dummyMerge));
@@ -3101,7 +3130,7 @@ static void run_savepoint_restores_session_metadata(void){
         memcmp(&stagedAfter, &dummyStaged, sizeof(dummyStaged))==0);
 
   check("rollback_to_savepoint_metadata",
-        execsql(db, "ROLLBACK TO s1;")==SQLITE_OK);
+        execSql(db, "ROLLBACK TO s1;")==SQLITE_OK);
   doltliteGetSessionStaged(db, &stagedAfter);
   doltliteGetSessionMergeState(db, &isMergingAfter, &mergeAfter, &conflictsAfter);
   check("rollback_to_savepoint_restores_staged",
@@ -3112,10 +3141,10 @@ static void run_savepoint_restores_session_metadata(void){
   check("rollback_to_savepoint_clears_conflicts_catalog",
         memcmp(&conflictsAfter, &(ProllyHash){{0}}, sizeof(ProllyHash))==0);
 
-  check("release_savepoint_metadata", execsql(db, "RELEASE s1;")==SQLITE_OK);
-  check("rollback_outer_txn_metadata", execsql(db, "ROLLBACK;")==SQLITE_OK);
+  check("release_savepoint_metadata", execSql(db, "RELEASE s1;")==SQLITE_OK);
+  check("rollback_outer_txn_metadata", execSql(db, "ROLLBACK;")==SQLITE_OK);
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_savepoint_flush_snapshot_rollback_reopen(void){
@@ -3124,10 +3153,10 @@ static void run_savepoint_flush_snapshot_rollback_reopen(void){
 
   printf("=== Savepoint Flush Snapshot Rollback Reopen Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_savepoint_flush_snapshot_rollback_reopen");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_flush_snapshot_rollback", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_flush_snapshot_rollback", execsql(db,
+  check("setup_repo_for_flush_snapshot_rollback", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, k INTEGER, v TEXT);"
     "CREATE INDEX k_idx ON t(k);"
     "INSERT INTO t VALUES(1, 1, 'a');"
@@ -3135,56 +3164,56 @@ static void run_savepoint_flush_snapshot_rollback_reopen(void){
     "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
 
   check("begin_txn_for_flush_snapshot_rollback",
-        execsql(db, "BEGIN IMMEDIATE;")==SQLITE_OK);
+        execSql(db, "BEGIN IMMEDIATE;")==SQLITE_OK);
   check("savepoint_outer_for_flush_snapshot_rollback",
-        execsql(db, "SAVEPOINT outer_sp;")==SQLITE_OK);
+        execSql(db, "SAVEPOINT outer_sp;")==SQLITE_OK);
   check("outer_index_update_for_flush_snapshot_rollback",
-        execsql(db, "UPDATE t SET k=11, v='outer' WHERE id=1;")==SQLITE_OK);
+        execSql(db, "UPDATE t SET k=11, v='outer' WHERE id=1;")==SQLITE_OK);
   check("savepoint_inner_for_flush_snapshot_rollback",
-        execsql(db, "SAVEPOINT inner_sp;")==SQLITE_OK);
+        execSql(db, "SAVEPOINT inner_sp;")==SQLITE_OK);
   check("inner_index_edits_for_flush_snapshot_rollback",
-        execsql(db,
+        execSql(db,
           "UPDATE t SET k=22, v='inner' WHERE id=2;"
           "INSERT INTO t VALUES(3, 33, 'inner3');")==SQLITE_OK);
   check("rollback_inner_after_flush_snapshot",
-        execsql(db, "ROLLBACK TO inner_sp;")==SQLITE_OK);
+        execSql(db, "ROLLBACK TO inner_sp;")==SQLITE_OK);
   check("release_inner_after_flush_snapshot",
-        execsql(db, "RELEASE inner_sp;")==SQLITE_OK);
+        execSql(db, "RELEASE inner_sp;")==SQLITE_OK);
   check("commit_outer_after_flush_snapshot",
-        execsql(db, "COMMIT;")==SQLITE_OK);
+        execSql(db, "COMMIT;")==SQLITE_OK);
 
   check("rollback_path_outer_row_visible_before_close",
-        strcmp(exec1(db, "SELECT k FROM t WHERE id=1"), "11")==0);
+        strcmp(queryScalarText(db, "SELECT k FROM t WHERE id=1"), "11")==0);
   check("rollback_path_inner_row_reverted_before_close",
-        strcmp(exec1(db, "SELECT k FROM t WHERE id=2"), "2")==0);
+        strcmp(queryScalarText(db, "SELECT k FROM t WHERE id=2"), "2")==0);
   check("rollback_path_insert_reverted_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE id=3"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE id=3"), "0")==0);
   check("rollback_path_index_lookup_outer_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE k=11"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE k=11"), "1")==0);
   check("rollback_path_index_lookup_inner_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE k=22"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE k=22"), "0")==0);
   check("rollback_path_integrity_before_close",
-        strcmp(exec1(db, "PRAGMA integrity_check"), "ok")==0);
+        strcmp(queryScalarText(db, "PRAGMA integrity_check"), "ok")==0);
 
   sqlite3_close(db);
   db = 0;
 
   check("reopen_db_for_flush_snapshot_rollback", open_db(dbpath, &db)==SQLITE_OK);
   check("rollback_path_outer_row_visible_after_reopen",
-        strcmp(exec1(db, "SELECT k FROM t WHERE id=1"), "11")==0);
+        strcmp(queryScalarText(db, "SELECT k FROM t WHERE id=1"), "11")==0);
   check("rollback_path_inner_row_reverted_after_reopen",
-        strcmp(exec1(db, "SELECT k FROM t WHERE id=2"), "2")==0);
+        strcmp(queryScalarText(db, "SELECT k FROM t WHERE id=2"), "2")==0);
   check("rollback_path_insert_reverted_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE id=3"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE id=3"), "0")==0);
   check("rollback_path_index_lookup_outer_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE k=11"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE k=11"), "1")==0);
   check("rollback_path_index_lookup_inner_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE k=22"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE k=22"), "0")==0);
   check("rollback_path_integrity_after_reopen",
-        strcmp(exec1(db, "PRAGMA integrity_check"), "ok")==0);
+        strcmp(queryScalarText(db, "PRAGMA integrity_check"), "ok")==0);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_savepoint_flush_snapshot_release_reopen(void){
@@ -3193,10 +3222,10 @@ static void run_savepoint_flush_snapshot_release_reopen(void){
 
   printf("=== Savepoint Flush Snapshot Release Reopen Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_savepoint_flush_snapshot_release_reopen");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_flush_snapshot_release", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_flush_snapshot_release", execsql(db,
+  check("setup_repo_for_flush_snapshot_release", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, k INTEGER, v TEXT);"
     "CREATE INDEX k_idx ON t(k);"
     "INSERT INTO t VALUES(1, 1, 'a');"
@@ -3204,66 +3233,66 @@ static void run_savepoint_flush_snapshot_release_reopen(void){
     "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
 
   check("begin_txn_for_flush_snapshot_release",
-        execsql(db, "BEGIN IMMEDIATE;")==SQLITE_OK);
+        execSql(db, "BEGIN IMMEDIATE;")==SQLITE_OK);
   check("savepoint_outer_for_flush_snapshot_release",
-        execsql(db, "SAVEPOINT outer_sp;")==SQLITE_OK);
+        execSql(db, "SAVEPOINT outer_sp;")==SQLITE_OK);
   check("outer_index_update_for_flush_snapshot_release",
-        execsql(db, "UPDATE t SET k=11, v='outer' WHERE id=1;")==SQLITE_OK);
+        execSql(db, "UPDATE t SET k=11, v='outer' WHERE id=1;")==SQLITE_OK);
   check("savepoint_inner_for_flush_snapshot_release",
-        execsql(db, "SAVEPOINT inner_sp;")==SQLITE_OK);
+        execSql(db, "SAVEPOINT inner_sp;")==SQLITE_OK);
   check("inner_index_edits_for_flush_snapshot_release",
-        execsql(db,
+        execSql(db,
           "UPDATE t SET k=22, v='inner' WHERE id=2;"
           "INSERT INTO t VALUES(3, 33, 'inner3');")==SQLITE_OK);
   check("release_inner_after_flush_snapshot",
-        execsql(db, "RELEASE inner_sp;")==SQLITE_OK);
+        execSql(db, "RELEASE inner_sp;")==SQLITE_OK);
   check("release_outer_after_flush_snapshot",
-        execsql(db, "RELEASE outer_sp;")==SQLITE_OK);
+        execSql(db, "RELEASE outer_sp;")==SQLITE_OK);
   check("commit_after_flush_snapshot_release",
-        execsql(db, "COMMIT;")==SQLITE_OK);
+        execSql(db, "COMMIT;")==SQLITE_OK);
   check("dolt_commit_after_flush_snapshot_release",
-        execsql(db, "SELECT dolt_commit('-A', '-m', 'after savepoints');")==SQLITE_OK);
+        execSql(db, "SELECT dolt_commit('-A', '-m', 'after savepoints');")==SQLITE_OK);
 
   check("release_path_outer_row_visible_before_close",
-        strcmp(exec1(db, "SELECT k FROM t WHERE id=1"), "11")==0);
+        strcmp(queryScalarText(db, "SELECT k FROM t WHERE id=1"), "11")==0);
   check("release_path_inner_row_visible_before_close",
-        strcmp(exec1(db, "SELECT k FROM t WHERE id=2"), "22")==0);
+        strcmp(queryScalarText(db, "SELECT k FROM t WHERE id=2"), "22")==0);
   check("release_path_insert_visible_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE id=3"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE id=3"), "1")==0);
   check("release_path_index_lookup_outer_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE k=11"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE k=11"), "1")==0);
   check("release_path_index_lookup_inner_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE k=22"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE k=22"), "1")==0);
   check("release_path_index_lookup_insert_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE k=33"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE k=33"), "1")==0);
   check("release_path_integrity_before_close",
-        strcmp(exec1(db, "PRAGMA integrity_check"), "ok")==0);
+        strcmp(queryScalarText(db, "PRAGMA integrity_check"), "ok")==0);
   check("release_path_clean_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_status"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_status"), "0")==0);
 
   sqlite3_close(db);
   db = 0;
 
   check("reopen_db_for_flush_snapshot_release", open_db(dbpath, &db)==SQLITE_OK);
   check("release_path_outer_row_visible_after_reopen",
-        strcmp(exec1(db, "SELECT k FROM t WHERE id=1"), "11")==0);
+        strcmp(queryScalarText(db, "SELECT k FROM t WHERE id=1"), "11")==0);
   check("release_path_inner_row_visible_after_reopen",
-        strcmp(exec1(db, "SELECT k FROM t WHERE id=2"), "22")==0);
+        strcmp(queryScalarText(db, "SELECT k FROM t WHERE id=2"), "22")==0);
   check("release_path_insert_visible_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE id=3"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE id=3"), "1")==0);
   check("release_path_index_lookup_outer_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE k=11"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE k=11"), "1")==0);
   check("release_path_index_lookup_inner_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE k=22"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE k=22"), "1")==0);
   check("release_path_index_lookup_insert_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE k=33"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE k=33"), "1")==0);
   check("release_path_integrity_after_reopen",
-        strcmp(exec1(db, "PRAGMA integrity_check"), "ok")==0);
+        strcmp(queryScalarText(db, "PRAGMA integrity_check"), "ok")==0);
   check("release_path_clean_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_status"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_status"), "0")==0);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_savepoint_failed_commit_rollback_reopen(void){
@@ -3273,87 +3302,87 @@ static void run_savepoint_failed_commit_rollback_reopen(void){
 
   printf("=== Savepoint Failed Commit Rollback Reopen Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_savepoint_failed_commit_rollback_reopen");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_savepoint_failed_commit_rollback",
         open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_savepoint_failed_commit_rollback", execsql(db,
+  check("setup_repo_for_savepoint_failed_commit_rollback", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, k INTEGER, v TEXT);"
     "CREATE INDEX k_idx ON t(k);"
     "INSERT INTO t VALUES(1, 1, 'a');"
     "INSERT INTO t VALUES(2, 2, 'b');"
     "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
   sqlite3_snprintf(sizeof(zHeadBefore), zHeadBefore, "%s",
-                   exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1"));
+                   queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1"));
 
   check("begin_txn_for_savepoint_failed_commit_rollback",
-        execsql(db, "BEGIN IMMEDIATE;")==SQLITE_OK);
+        execSql(db, "BEGIN IMMEDIATE;")==SQLITE_OK);
   check("savepoint_outer_for_savepoint_failed_commit_rollback",
-        execsql(db, "SAVEPOINT outer_sp;")==SQLITE_OK);
+        execSql(db, "SAVEPOINT outer_sp;")==SQLITE_OK);
   check("outer_edits_for_savepoint_failed_commit_rollback",
-        execsql(db,
+        execSql(db,
           "UPDATE t SET k=11, v='outer' WHERE id=1;"
           "INSERT INTO t VALUES(4, 44, 'outer4');")==SQLITE_OK);
   check("savepoint_inner_for_savepoint_failed_commit_rollback",
-        execsql(db, "SAVEPOINT inner_sp;")==SQLITE_OK);
+        execSql(db, "SAVEPOINT inner_sp;")==SQLITE_OK);
   check("inner_edits_for_savepoint_failed_commit_rollback",
-        execsql(db,
+        execSql(db,
           "UPDATE t SET k=22, v='inner' WHERE id=2;"
           "INSERT INTO t VALUES(3, 33, 'inner3');")==SQLITE_OK);
 
   check("rollback_inner_after_failed_commit",
-        execsql(db, "ROLLBACK TO inner_sp;")==SQLITE_OK);
+        execSql(db, "ROLLBACK TO inner_sp;")==SQLITE_OK);
   check("release_inner_after_failed_commit_rollback",
-        execsql(db, "RELEASE inner_sp;")==SQLITE_OK);
+        execSql(db, "RELEASE inner_sp;")==SQLITE_OK);
   check("release_outer_after_failed_commit_rollback",
-        execsql(db, "RELEASE outer_sp;")==SQLITE_OK);
+        execSql(db, "RELEASE outer_sp;")==SQLITE_OK);
   check("commit_after_failed_commit_rollback",
-        execsql(db, "COMMIT;")==SQLITE_OK);
+        execSql(db, "COMMIT;")==SQLITE_OK);
 
   check("failed_commit_rollback_outer_update_visible_before_close",
-        strcmp(exec1(db, "SELECT k FROM t WHERE id=1"), "11")==0);
+        strcmp(queryScalarText(db, "SELECT k FROM t WHERE id=1"), "11")==0);
   check("failed_commit_rollback_inner_update_reverted_before_close",
-        strcmp(exec1(db, "SELECT k FROM t WHERE id=2"), "2")==0);
+        strcmp(queryScalarText(db, "SELECT k FROM t WHERE id=2"), "2")==0);
   check("failed_commit_rollback_inner_insert_reverted_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE id=3"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE id=3"), "0")==0);
   check("failed_commit_rollback_outer_insert_visible_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE id=4"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE id=4"), "1")==0);
   check("failed_commit_rollback_outer_index_visible_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE k=11"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE k=11"), "1")==0);
   check("failed_commit_rollback_inner_index_reverted_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE k=22"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE k=22"), "0")==0);
   check("failed_commit_rollback_head_unchanged_before_close",
-        strcmp(exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
+        strcmp(queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
   check("failed_commit_rollback_status_dirty_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_status"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_status"), "1")==0);
   check("failed_commit_rollback_integrity_before_close",
-        strcmp(exec1(db, "PRAGMA integrity_check"), "ok")==0);
+        strcmp(queryScalarText(db, "PRAGMA integrity_check"), "ok")==0);
 
   sqlite3_close(db);
   db = 0;
 
   check("reopen_db_for_savepoint_failed_commit_rollback", open_db(dbpath, &db)==SQLITE_OK);
   check("failed_commit_rollback_outer_update_visible_after_reopen",
-        strcmp(exec1(db, "SELECT k FROM t WHERE id=1"), "11")==0);
+        strcmp(queryScalarText(db, "SELECT k FROM t WHERE id=1"), "11")==0);
   check("failed_commit_rollback_inner_update_reverted_after_reopen",
-        strcmp(exec1(db, "SELECT k FROM t WHERE id=2"), "2")==0);
+        strcmp(queryScalarText(db, "SELECT k FROM t WHERE id=2"), "2")==0);
   check("failed_commit_rollback_inner_insert_reverted_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE id=3"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE id=3"), "0")==0);
   check("failed_commit_rollback_outer_insert_visible_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE id=4"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE id=4"), "1")==0);
   check("failed_commit_rollback_outer_index_visible_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE k=11"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE k=11"), "1")==0);
   check("failed_commit_rollback_inner_index_reverted_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE k=22"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE k=22"), "0")==0);
   check("failed_commit_rollback_head_unchanged_after_reopen",
-        strcmp(exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
+        strcmp(queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
   check("failed_commit_rollback_status_dirty_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_status"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_status"), "1")==0);
   check("failed_commit_rollback_integrity_after_reopen",
-        strcmp(exec1(db, "PRAGMA integrity_check"), "ok")==0);
+        strcmp(queryScalarText(db, "PRAGMA integrity_check"), "ok")==0);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_savepoint_failed_commit_release_reopen(void){
@@ -3363,89 +3392,89 @@ static void run_savepoint_failed_commit_release_reopen(void){
 
   printf("=== Savepoint Failed Commit Release Reopen Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_savepoint_failed_commit_release_reopen");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_savepoint_failed_commit_release",
         open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_savepoint_failed_commit_release", execsql(db,
+  check("setup_repo_for_savepoint_failed_commit_release", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, k INTEGER, v TEXT);"
     "CREATE INDEX k_idx ON t(k);"
     "INSERT INTO t VALUES(1, 1, 'a');"
     "INSERT INTO t VALUES(2, 2, 'b');"
     "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
   sqlite3_snprintf(sizeof(zHeadBefore), zHeadBefore, "%s",
-                   exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1"));
+                   queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1"));
 
   check("begin_txn_for_savepoint_failed_commit_release",
-        execsql(db, "BEGIN IMMEDIATE;")==SQLITE_OK);
+        execSql(db, "BEGIN IMMEDIATE;")==SQLITE_OK);
   check("savepoint_outer_for_savepoint_failed_commit_release",
-        execsql(db, "SAVEPOINT outer_sp;")==SQLITE_OK);
+        execSql(db, "SAVEPOINT outer_sp;")==SQLITE_OK);
   check("outer_edits_for_savepoint_failed_commit_release",
-        execsql(db,
+        execSql(db,
           "UPDATE t SET k=11, v='outer' WHERE id=1;"
           "INSERT INTO t VALUES(4, 44, 'outer4');")==SQLITE_OK);
   check("savepoint_inner_for_savepoint_failed_commit_release",
-        execsql(db, "SAVEPOINT inner_sp;")==SQLITE_OK);
+        execSql(db, "SAVEPOINT inner_sp;")==SQLITE_OK);
   check("inner_edits_for_savepoint_failed_commit_release",
-        execsql(db,
+        execSql(db,
           "UPDATE t SET k=22, v='inner' WHERE id=2;"
           "INSERT INTO t VALUES(3, 33, 'inner3');")==SQLITE_OK);
 
   check("release_inner_after_failed_commit_release",
-        execsql(db, "RELEASE inner_sp;")==SQLITE_OK);
+        execSql(db, "RELEASE inner_sp;")==SQLITE_OK);
   check("release_outer_after_failed_commit_release",
-        execsql(db, "RELEASE outer_sp;")==SQLITE_OK);
+        execSql(db, "RELEASE outer_sp;")==SQLITE_OK);
   check("commit_after_failed_commit_release",
-        execsql(db, "COMMIT;")==SQLITE_OK);
+        execSql(db, "COMMIT;")==SQLITE_OK);
 
   check("failed_commit_release_outer_update_visible_before_close",
-        strcmp(exec1(db, "SELECT k FROM t WHERE id=1"), "11")==0);
+        strcmp(queryScalarText(db, "SELECT k FROM t WHERE id=1"), "11")==0);
   check("failed_commit_release_inner_update_visible_before_close",
-        strcmp(exec1(db, "SELECT k FROM t WHERE id=2"), "22")==0);
+        strcmp(queryScalarText(db, "SELECT k FROM t WHERE id=2"), "22")==0);
   check("failed_commit_release_inner_insert_visible_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE id=3"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE id=3"), "1")==0);
   check("failed_commit_release_outer_insert_visible_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE id=4"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE id=4"), "1")==0);
   check("failed_commit_release_outer_index_visible_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE k=11"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE k=11"), "1")==0);
   check("failed_commit_release_inner_index_visible_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE k=22"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE k=22"), "1")==0);
   check("failed_commit_release_insert_index_visible_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE k=33"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE k=33"), "1")==0);
   check("failed_commit_release_head_unchanged_before_close",
-        strcmp(exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
+        strcmp(queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
   check("failed_commit_release_status_dirty_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_status"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_status"), "1")==0);
   check("failed_commit_release_integrity_before_close",
-        strcmp(exec1(db, "PRAGMA integrity_check"), "ok")==0);
+        strcmp(queryScalarText(db, "PRAGMA integrity_check"), "ok")==0);
 
   sqlite3_close(db);
   db = 0;
 
   check("reopen_db_for_savepoint_failed_commit_release", open_db(dbpath, &db)==SQLITE_OK);
   check("failed_commit_release_outer_update_visible_after_reopen",
-        strcmp(exec1(db, "SELECT k FROM t WHERE id=1"), "11")==0);
+        strcmp(queryScalarText(db, "SELECT k FROM t WHERE id=1"), "11")==0);
   check("failed_commit_release_inner_update_visible_after_reopen",
-        strcmp(exec1(db, "SELECT k FROM t WHERE id=2"), "22")==0);
+        strcmp(queryScalarText(db, "SELECT k FROM t WHERE id=2"), "22")==0);
   check("failed_commit_release_inner_insert_visible_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE id=3"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE id=3"), "1")==0);
   check("failed_commit_release_outer_insert_visible_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE id=4"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE id=4"), "1")==0);
   check("failed_commit_release_outer_index_visible_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE k=11"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE k=11"), "1")==0);
   check("failed_commit_release_inner_index_visible_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE k=22"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE k=22"), "1")==0);
   check("failed_commit_release_insert_index_visible_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE k=33"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE k=33"), "1")==0);
   check("failed_commit_release_head_unchanged_after_reopen",
-        strcmp(exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
+        strcmp(queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
   check("failed_commit_release_status_dirty_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_status"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_status"), "1")==0);
   check("failed_commit_release_integrity_after_reopen",
-        strcmp(exec1(db, "PRAGMA integrity_check"), "ok")==0);
+        strcmp(queryScalarText(db, "PRAGMA integrity_check"), "ok")==0);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_savepoint_failed_commit_outer_rollback_reopen(void){
@@ -3456,59 +3485,59 @@ static void run_savepoint_failed_commit_outer_rollback_reopen(void){
   printf("=== Savepoint Failed Commit Outer Rollback Reopen Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath),
               "test_savepoint_failed_commit_outer_rollback_reopen");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_savepoint_failed_commit_outer_rollback",
         open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_savepoint_failed_commit_outer_rollback", execsql(db,
+  check("setup_repo_for_savepoint_failed_commit_outer_rollback", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, k INTEGER, v TEXT);"
     "CREATE INDEX k_idx ON t(k);"
     "INSERT INTO t VALUES(1, 1, 'a');"
     "INSERT INTO t VALUES(2, 2, 'b');"
     "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
   sqlite3_snprintf(sizeof(zHeadBefore), zHeadBefore, "%s",
-                   exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1"));
+                   queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1"));
 
   check("begin_txn_for_savepoint_failed_commit_outer_rollback",
-        execsql(db, "BEGIN IMMEDIATE;")==SQLITE_OK);
+        execSql(db, "BEGIN IMMEDIATE;")==SQLITE_OK);
   check("savepoint_outer_for_savepoint_failed_commit_outer_rollback",
-        execsql(db, "SAVEPOINT outer_sp;")==SQLITE_OK);
+        execSql(db, "SAVEPOINT outer_sp;")==SQLITE_OK);
   check("outer_edits_for_savepoint_failed_commit_outer_rollback",
-        execsql(db,
+        execSql(db,
           "UPDATE t SET k=11, v='outer' WHERE id=1;"
           "INSERT INTO t VALUES(4, 44, 'outer4');")==SQLITE_OK);
   check("savepoint_inner_for_savepoint_failed_commit_outer_rollback",
-        execsql(db, "SAVEPOINT inner_sp;")==SQLITE_OK);
+        execSql(db, "SAVEPOINT inner_sp;")==SQLITE_OK);
   check("inner_edits_for_savepoint_failed_commit_outer_rollback",
-        execsql(db,
+        execSql(db,
           "UPDATE t SET k=22, v='inner' WHERE id=2;"
           "INSERT INTO t VALUES(3, 33, 'inner3');")==SQLITE_OK);
 
   check("rollback_outer_after_failed_commit",
-        execsql(db, "ROLLBACK TO outer_sp;")==SQLITE_OK);
+        execSql(db, "ROLLBACK TO outer_sp;")==SQLITE_OK);
   check("release_outer_after_failed_commit_outer_rollback",
-        execsql(db, "RELEASE outer_sp;")==SQLITE_OK);
+        execSql(db, "RELEASE outer_sp;")==SQLITE_OK);
   check("commit_after_failed_commit_outer_rollback",
-        execsql(db, "COMMIT;")==SQLITE_OK);
+        execSql(db, "COMMIT;")==SQLITE_OK);
 
   check("failed_commit_outer_rollback_row1_before_close",
-        strcmp(exec1(db, "SELECT k FROM t WHERE id=1"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT k FROM t WHERE id=1"), "1")==0);
   check("failed_commit_outer_rollback_row2_before_close",
-        strcmp(exec1(db, "SELECT k FROM t WHERE id=2"), "2")==0);
+        strcmp(queryScalarText(db, "SELECT k FROM t WHERE id=2"), "2")==0);
   check("failed_commit_outer_rollback_row3_absent_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE id=3"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE id=3"), "0")==0);
   check("failed_commit_outer_rollback_row4_absent_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE id=4"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE id=4"), "0")==0);
   check("failed_commit_outer_rollback_k11_absent_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE k=11"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE k=11"), "0")==0);
   check("failed_commit_outer_rollback_k22_absent_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE k=22"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE k=22"), "0")==0);
   check("failed_commit_outer_rollback_head_unchanged_before_close",
-        strcmp(exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
+        strcmp(queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
   check("failed_commit_outer_rollback_status_clean_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_status"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_status"), "0")==0);
   check("failed_commit_outer_rollback_integrity_before_close",
-        strcmp(exec1(db, "PRAGMA integrity_check"), "ok")==0);
+        strcmp(queryScalarText(db, "PRAGMA integrity_check"), "ok")==0);
 
   sqlite3_close(db);
   db = 0;
@@ -3516,26 +3545,26 @@ static void run_savepoint_failed_commit_outer_rollback_reopen(void){
   check("reopen_db_for_savepoint_failed_commit_outer_rollback",
         open_db(dbpath, &db)==SQLITE_OK);
   check("failed_commit_outer_rollback_row1_after_reopen",
-        strcmp(exec1(db, "SELECT k FROM t WHERE id=1"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT k FROM t WHERE id=1"), "1")==0);
   check("failed_commit_outer_rollback_row2_after_reopen",
-        strcmp(exec1(db, "SELECT k FROM t WHERE id=2"), "2")==0);
+        strcmp(queryScalarText(db, "SELECT k FROM t WHERE id=2"), "2")==0);
   check("failed_commit_outer_rollback_row3_absent_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE id=3"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE id=3"), "0")==0);
   check("failed_commit_outer_rollback_row4_absent_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE id=4"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE id=4"), "0")==0);
   check("failed_commit_outer_rollback_k11_absent_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE k=11"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE k=11"), "0")==0);
   check("failed_commit_outer_rollback_k22_absent_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE k=22"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE k=22"), "0")==0);
   check("failed_commit_outer_rollback_head_unchanged_after_reopen",
-        strcmp(exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
+        strcmp(queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
   check("failed_commit_outer_rollback_status_clean_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_status"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_status"), "0")==0);
   check("failed_commit_outer_rollback_integrity_after_reopen",
-        strcmp(exec1(db, "PRAGMA integrity_check"), "ok")==0);
+        strcmp(queryScalarText(db, "PRAGMA integrity_check"), "ok")==0);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_savepoint_flush_snapshot_multi_table_rollback_reopen(void){
@@ -3545,11 +3574,11 @@ static void run_savepoint_flush_snapshot_multi_table_rollback_reopen(void){
   printf("=== Savepoint Flush Snapshot Multi Table Rollback Reopen Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath),
               "test_savepoint_flush_snapshot_multi_table_rollback_reopen");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_flush_snapshot_multi_table_rollback",
         open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_flush_snapshot_multi_table_rollback", execsql(db,
+  check("setup_repo_for_flush_snapshot_multi_table_rollback", execSql(db,
     "CREATE TABLE a(id INTEGER PRIMARY KEY, k INTEGER, v TEXT);"
     "CREATE INDEX a_k_idx ON a(k);"
     "CREATE TABLE b(id INTEGER PRIMARY KEY, k INTEGER, v TEXT);"
@@ -3561,49 +3590,49 @@ static void run_savepoint_flush_snapshot_multi_table_rollback_reopen(void){
     "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
 
   check("begin_txn_for_flush_snapshot_multi_table_rollback",
-        execsql(db, "BEGIN IMMEDIATE;")==SQLITE_OK);
+        execSql(db, "BEGIN IMMEDIATE;")==SQLITE_OK);
   check("savepoint_outer_for_flush_snapshot_multi_table_rollback",
-        execsql(db, "SAVEPOINT outer_sp;")==SQLITE_OK);
+        execSql(db, "SAVEPOINT outer_sp;")==SQLITE_OK);
   check("outer_edits_for_flush_snapshot_multi_table_rollback",
-        execsql(db,
+        execSql(db,
           "UPDATE a SET k=11, v='outer-a' WHERE id=1;"
           "INSERT INTO b VALUES(3, 30, 'outer-b3');")==SQLITE_OK);
   check("savepoint_inner_for_flush_snapshot_multi_table_rollback",
-        execsql(db, "SAVEPOINT inner_sp;")==SQLITE_OK);
+        execSql(db, "SAVEPOINT inner_sp;")==SQLITE_OK);
   check("inner_edits_for_flush_snapshot_multi_table_rollback",
-        execsql(db,
+        execSql(db,
           "UPDATE a SET k=22, v='inner-a' WHERE id=2;"
           "INSERT INTO a VALUES(3, 33, 'inner-a3');"
           "UPDATE b SET k=33, v='inner-b' WHERE id=2;")==SQLITE_OK);
   check("rollback_inner_after_flush_snapshot_multi_table",
-        execsql(db, "ROLLBACK TO inner_sp;")==SQLITE_OK);
+        execSql(db, "ROLLBACK TO inner_sp;")==SQLITE_OK);
   check("release_inner_after_flush_snapshot_multi_table",
-        execsql(db, "RELEASE inner_sp;")==SQLITE_OK);
+        execSql(db, "RELEASE inner_sp;")==SQLITE_OK);
   check("release_outer_after_flush_snapshot_multi_table",
-        execsql(db, "RELEASE outer_sp;")==SQLITE_OK);
+        execSql(db, "RELEASE outer_sp;")==SQLITE_OK);
   check("commit_after_flush_snapshot_multi_table_rollback",
-        execsql(db, "COMMIT;")==SQLITE_OK);
+        execSql(db, "COMMIT;")==SQLITE_OK);
 
   check("flush_snapshot_multi_table_a1_before_close",
-        strcmp(exec1(db, "SELECT k FROM a WHERE id=1"), "11")==0);
+        strcmp(queryScalarText(db, "SELECT k FROM a WHERE id=1"), "11")==0);
   check("flush_snapshot_multi_table_a2_before_close",
-        strcmp(exec1(db, "SELECT k FROM a WHERE id=2"), "2")==0);
+        strcmp(queryScalarText(db, "SELECT k FROM a WHERE id=2"), "2")==0);
   check("flush_snapshot_multi_table_a3_absent_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM a WHERE id=3"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM a WHERE id=3"), "0")==0);
   check("flush_snapshot_multi_table_b2_before_close",
-        strcmp(exec1(db, "SELECT k FROM b WHERE id=2"), "20")==0);
+        strcmp(queryScalarText(db, "SELECT k FROM b WHERE id=2"), "20")==0);
   check("flush_snapshot_multi_table_b3_present_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM b WHERE id=3"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM b WHERE id=3"), "1")==0);
   check("flush_snapshot_multi_table_a11_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM a WHERE k=11"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM a WHERE k=11"), "1")==0);
   check("flush_snapshot_multi_table_a22_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM a WHERE k=22"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM a WHERE k=22"), "0")==0);
   check("flush_snapshot_multi_table_b30_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM b WHERE k=30"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM b WHERE k=30"), "1")==0);
   check("flush_snapshot_multi_table_b33_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM b WHERE k=33"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM b WHERE k=33"), "0")==0);
   check("flush_snapshot_multi_table_integrity_before_close",
-        strcmp(exec1(db, "PRAGMA integrity_check"), "ok")==0);
+        strcmp(queryScalarText(db, "PRAGMA integrity_check"), "ok")==0);
 
   sqlite3_close(db);
   db = 0;
@@ -3611,28 +3640,28 @@ static void run_savepoint_flush_snapshot_multi_table_rollback_reopen(void){
   check("reopen_db_for_flush_snapshot_multi_table_rollback",
         open_db(dbpath, &db)==SQLITE_OK);
   check("flush_snapshot_multi_table_a1_after_reopen",
-        strcmp(exec1(db, "SELECT k FROM a WHERE id=1"), "11")==0);
+        strcmp(queryScalarText(db, "SELECT k FROM a WHERE id=1"), "11")==0);
   check("flush_snapshot_multi_table_a2_after_reopen",
-        strcmp(exec1(db, "SELECT k FROM a WHERE id=2"), "2")==0);
+        strcmp(queryScalarText(db, "SELECT k FROM a WHERE id=2"), "2")==0);
   check("flush_snapshot_multi_table_a3_absent_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM a WHERE id=3"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM a WHERE id=3"), "0")==0);
   check("flush_snapshot_multi_table_b2_after_reopen",
-        strcmp(exec1(db, "SELECT k FROM b WHERE id=2"), "20")==0);
+        strcmp(queryScalarText(db, "SELECT k FROM b WHERE id=2"), "20")==0);
   check("flush_snapshot_multi_table_b3_present_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM b WHERE id=3"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM b WHERE id=3"), "1")==0);
   check("flush_snapshot_multi_table_a11_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM a WHERE k=11"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM a WHERE k=11"), "1")==0);
   check("flush_snapshot_multi_table_a22_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM a WHERE k=22"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM a WHERE k=22"), "0")==0);
   check("flush_snapshot_multi_table_b30_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM b WHERE k=30"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM b WHERE k=30"), "1")==0);
   check("flush_snapshot_multi_table_b33_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM b WHERE k=33"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM b WHERE k=33"), "0")==0);
   check("flush_snapshot_multi_table_integrity_after_reopen",
-        strcmp(exec1(db, "PRAGMA integrity_check"), "ok")==0);
+        strcmp(queryScalarText(db, "PRAGMA integrity_check"), "ok")==0);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_savepoint_same_name_shadowing_index_reopen(void){
@@ -3642,11 +3671,11 @@ static void run_savepoint_same_name_shadowing_index_reopen(void){
   printf("=== Savepoint Same Name Shadowing Index Reopen Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath),
               "test_savepoint_same_name_shadowing_index_reopen");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_savepoint_same_name_shadowing",
         open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_savepoint_same_name_shadowing", execsql(db,
+  check("setup_repo_for_savepoint_same_name_shadowing", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, k INTEGER, v TEXT);"
     "CREATE INDEX k_idx ON t(k);"
     "INSERT INTO t VALUES(1, 1, 'a');"
@@ -3654,42 +3683,42 @@ static void run_savepoint_same_name_shadowing_index_reopen(void){
     "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
 
   check("begin_txn_for_savepoint_same_name_shadowing",
-        execsql(db, "BEGIN IMMEDIATE;")==SQLITE_OK);
+        execSql(db, "BEGIN IMMEDIATE;")==SQLITE_OK);
   check("savepoint_shadow_outer",
-        execsql(db, "SAVEPOINT same_sp;")==SQLITE_OK);
+        execSql(db, "SAVEPOINT same_sp;")==SQLITE_OK);
   check("shadow_outer_edits",
-        execsql(db,
+        execSql(db,
           "UPDATE t SET k=11, v='outer' WHERE id=1;"
           "INSERT INTO t VALUES(3, 33, 'outer3');")==SQLITE_OK);
   check("savepoint_shadow_inner",
-        execsql(db, "SAVEPOINT same_sp;")==SQLITE_OK);
+        execSql(db, "SAVEPOINT same_sp;")==SQLITE_OK);
   check("shadow_inner_edits",
-        execsql(db,
+        execSql(db,
           "UPDATE t SET k=22, v='inner' WHERE id=2;"
           "INSERT INTO t VALUES(4, 44, 'inner4');")==SQLITE_OK);
   check("rollback_shadow_inner",
-        execsql(db, "ROLLBACK TO same_sp;")==SQLITE_OK);
+        execSql(db, "ROLLBACK TO same_sp;")==SQLITE_OK);
   check("release_shadow_inner",
-        execsql(db, "RELEASE same_sp;")==SQLITE_OK);
+        execSql(db, "RELEASE same_sp;")==SQLITE_OK);
   check("release_shadow_outer",
-        execsql(db, "RELEASE same_sp;")==SQLITE_OK);
+        execSql(db, "RELEASE same_sp;")==SQLITE_OK);
   check("commit_shadow_same_name",
-        execsql(db, "COMMIT;")==SQLITE_OK);
+        execSql(db, "COMMIT;")==SQLITE_OK);
 
   check("shadow_same_name_id1_before_close",
-        strcmp(exec1(db, "SELECT k FROM t WHERE id=1"), "11")==0);
+        strcmp(queryScalarText(db, "SELECT k FROM t WHERE id=1"), "11")==0);
   check("shadow_same_name_id2_before_close",
-        strcmp(exec1(db, "SELECT k FROM t WHERE id=2"), "2")==0);
+        strcmp(queryScalarText(db, "SELECT k FROM t WHERE id=2"), "2")==0);
   check("shadow_same_name_id3_present_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE id=3"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE id=3"), "1")==0);
   check("shadow_same_name_id4_absent_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE id=4"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE id=4"), "0")==0);
   check("shadow_same_name_k11_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE k=11"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE k=11"), "1")==0);
   check("shadow_same_name_k22_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE k=22"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE k=22"), "0")==0);
   check("shadow_same_name_integrity_before_close",
-        strcmp(exec1(db, "PRAGMA integrity_check"), "ok")==0);
+        strcmp(queryScalarText(db, "PRAGMA integrity_check"), "ok")==0);
 
   sqlite3_close(db);
   db = 0;
@@ -3697,22 +3726,22 @@ static void run_savepoint_same_name_shadowing_index_reopen(void){
   check("reopen_db_for_savepoint_same_name_shadowing",
         open_db(dbpath, &db)==SQLITE_OK);
   check("shadow_same_name_id1_after_reopen",
-        strcmp(exec1(db, "SELECT k FROM t WHERE id=1"), "11")==0);
+        strcmp(queryScalarText(db, "SELECT k FROM t WHERE id=1"), "11")==0);
   check("shadow_same_name_id2_after_reopen",
-        strcmp(exec1(db, "SELECT k FROM t WHERE id=2"), "2")==0);
+        strcmp(queryScalarText(db, "SELECT k FROM t WHERE id=2"), "2")==0);
   check("shadow_same_name_id3_present_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE id=3"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE id=3"), "1")==0);
   check("shadow_same_name_id4_absent_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE id=4"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE id=4"), "0")==0);
   check("shadow_same_name_k11_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE k=11"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE k=11"), "1")==0);
   check("shadow_same_name_k22_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE k=22"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE k=22"), "0")==0);
   check("shadow_same_name_integrity_after_reopen",
-        strcmp(exec1(db, "PRAGMA integrity_check"), "ok")==0);
+        strcmp(queryScalarText(db, "PRAGMA integrity_check"), "ok")==0);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_savepoint_schema_rollback_reopen(void){
@@ -3721,64 +3750,64 @@ static void run_savepoint_schema_rollback_reopen(void){
 
   printf("=== Savepoint Schema Rollback Reopen Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_savepoint_schema_rollback_reopen");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_savepoint_schema_rollback", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_savepoint_schema_rollback", execsql(db,
+  check("setup_repo_for_savepoint_schema_rollback", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1, 'a');"
     "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
 
   check("begin_txn_for_savepoint_schema_rollback",
-        execsql(db, "BEGIN IMMEDIATE;")==SQLITE_OK);
+        execSql(db, "BEGIN IMMEDIATE;")==SQLITE_OK);
   check("savepoint_outer_for_schema_rollback",
-        execsql(db, "SAVEPOINT outer_sp;")==SQLITE_OK);
+        execSql(db, "SAVEPOINT outer_sp;")==SQLITE_OK);
   check("outer_schema_rollback_edit",
-        execsql(db, "UPDATE t SET v='outer' WHERE id=1;")==SQLITE_OK);
+        execSql(db, "UPDATE t SET v='outer' WHERE id=1;")==SQLITE_OK);
   check("savepoint_inner_for_schema_rollback",
-        execsql(db, "SAVEPOINT inner_sp;")==SQLITE_OK);
+        execSql(db, "SAVEPOINT inner_sp;")==SQLITE_OK);
   check("inner_schema_changes",
-        execsql(db,
+        execSql(db,
           "ALTER TABLE t ADD COLUMN extra TEXT;"
           "CREATE TABLE aux(id INTEGER PRIMARY KEY, note TEXT);"
           "INSERT INTO aux VALUES(1, 'tmp');")==SQLITE_OK);
   check("rollback_inner_schema_changes",
-        execsql(db, "ROLLBACK TO inner_sp;")==SQLITE_OK);
+        execSql(db, "ROLLBACK TO inner_sp;")==SQLITE_OK);
   check("release_inner_schema_changes",
-        execsql(db, "RELEASE inner_sp;")==SQLITE_OK);
+        execSql(db, "RELEASE inner_sp;")==SQLITE_OK);
   check("release_outer_schema_changes",
-        execsql(db, "RELEASE outer_sp;")==SQLITE_OK);
+        execSql(db, "RELEASE outer_sp;")==SQLITE_OK);
   check("commit_schema_rollback",
-        execsql(db, "COMMIT;")==SQLITE_OK);
+        execSql(db, "COMMIT;")==SQLITE_OK);
 
   check("schema_rollback_row_before_close",
-        strcmp(exec1(db, "SELECT v FROM t WHERE id=1"), "outer")==0);
+        strcmp(queryScalarText(db, "SELECT v FROM t WHERE id=1"), "outer")==0);
   check("schema_rollback_extra_absent_before_close",
-        strcmp(exec1(db,
+        strcmp(queryScalarText(db,
           "SELECT count(*) FROM pragma_table_info('t') WHERE name='extra'"), "0")==0);
   check("schema_rollback_aux_absent_before_close",
-        strcmp(exec1(db,
+        strcmp(queryScalarText(db,
           "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='aux'"), "0")==0);
   check("schema_rollback_integrity_before_close",
-        strcmp(exec1(db, "PRAGMA integrity_check"), "ok")==0);
+        strcmp(queryScalarText(db, "PRAGMA integrity_check"), "ok")==0);
 
   sqlite3_close(db);
   db = 0;
 
   check("reopen_db_for_savepoint_schema_rollback", open_db(dbpath, &db)==SQLITE_OK);
   check("schema_rollback_row_after_reopen",
-        strcmp(exec1(db, "SELECT v FROM t WHERE id=1"), "outer")==0);
+        strcmp(queryScalarText(db, "SELECT v FROM t WHERE id=1"), "outer")==0);
   check("schema_rollback_extra_absent_after_reopen",
-        strcmp(exec1(db,
+        strcmp(queryScalarText(db,
           "SELECT count(*) FROM pragma_table_info('t') WHERE name='extra'"), "0")==0);
   check("schema_rollback_aux_absent_after_reopen",
-        strcmp(exec1(db,
+        strcmp(queryScalarText(db,
           "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='aux'"), "0")==0);
   check("schema_rollback_integrity_after_reopen",
-        strcmp(exec1(db, "PRAGMA integrity_check"), "ok")==0);
+        strcmp(queryScalarText(db, "PRAGMA integrity_check"), "ok")==0);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_savepoint_trigger_rollback_reopen(void){
@@ -3787,10 +3816,10 @@ static void run_savepoint_trigger_rollback_reopen(void){
 
   printf("=== Savepoint Trigger Rollback Reopen Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_savepoint_trigger_rollback_reopen");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_savepoint_trigger_rollback", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_savepoint_trigger_rollback", execsql(db,
+  check("setup_repo_for_savepoint_trigger_rollback", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "CREATE TABLE audit(msg TEXT);"
     "CREATE TRIGGER t_au AFTER UPDATE ON t BEGIN "
@@ -3800,48 +3829,48 @@ static void run_savepoint_trigger_rollback_reopen(void){
     "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
 
   check("begin_txn_for_savepoint_trigger_rollback",
-        execsql(db, "BEGIN IMMEDIATE;")==SQLITE_OK);
+        execSql(db, "BEGIN IMMEDIATE;")==SQLITE_OK);
   check("savepoint_outer_for_trigger_rollback",
-        execsql(db, "SAVEPOINT outer_sp;")==SQLITE_OK);
+        execSql(db, "SAVEPOINT outer_sp;")==SQLITE_OK);
   check("outer_trigger_edit",
-        execsql(db, "UPDATE t SET v='outer' WHERE id=1;")==SQLITE_OK);
+        execSql(db, "UPDATE t SET v='outer' WHERE id=1;")==SQLITE_OK);
   check("savepoint_inner_for_trigger_rollback",
-        execsql(db, "SAVEPOINT inner_sp;")==SQLITE_OK);
+        execSql(db, "SAVEPOINT inner_sp;")==SQLITE_OK);
   check("inner_trigger_edit",
-        execsql(db, "UPDATE t SET v='inner' WHERE id=1;")==SQLITE_OK);
+        execSql(db, "UPDATE t SET v='inner' WHERE id=1;")==SQLITE_OK);
   check("rollback_inner_trigger_edit",
-        execsql(db, "ROLLBACK TO inner_sp;")==SQLITE_OK);
+        execSql(db, "ROLLBACK TO inner_sp;")==SQLITE_OK);
   check("release_inner_trigger_edit",
-        execsql(db, "RELEASE inner_sp;")==SQLITE_OK);
+        execSql(db, "RELEASE inner_sp;")==SQLITE_OK);
   check("release_outer_trigger_edit",
-        execsql(db, "RELEASE outer_sp;")==SQLITE_OK);
+        execSql(db, "RELEASE outer_sp;")==SQLITE_OK);
   check("commit_trigger_rollback",
-        execsql(db, "COMMIT;")==SQLITE_OK);
+        execSql(db, "COMMIT;")==SQLITE_OK);
 
   check("trigger_rollback_row_before_close",
-        strcmp(exec1(db, "SELECT v FROM t WHERE id=1"), "outer")==0);
+        strcmp(queryScalarText(db, "SELECT v FROM t WHERE id=1"), "outer")==0);
   check("trigger_rollback_audit_count_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM audit"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM audit"), "1")==0);
   check("trigger_rollback_audit_msg_before_close",
-        strcmp(exec1(db, "SELECT msg FROM audit LIMIT 1"), "u:1:outer")==0);
+        strcmp(queryScalarText(db, "SELECT msg FROM audit LIMIT 1"), "u:1:outer")==0);
   check("trigger_rollback_integrity_before_close",
-        strcmp(exec1(db, "PRAGMA integrity_check"), "ok")==0);
+        strcmp(queryScalarText(db, "PRAGMA integrity_check"), "ok")==0);
 
   sqlite3_close(db);
   db = 0;
 
   check("reopen_db_for_savepoint_trigger_rollback", open_db(dbpath, &db)==SQLITE_OK);
   check("trigger_rollback_row_after_reopen",
-        strcmp(exec1(db, "SELECT v FROM t WHERE id=1"), "outer")==0);
+        strcmp(queryScalarText(db, "SELECT v FROM t WHERE id=1"), "outer")==0);
   check("trigger_rollback_audit_count_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM audit"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM audit"), "1")==0);
   check("trigger_rollback_audit_msg_after_reopen",
-        strcmp(exec1(db, "SELECT msg FROM audit LIMIT 1"), "u:1:outer")==0);
+        strcmp(queryScalarText(db, "SELECT msg FROM audit LIMIT 1"), "u:1:outer")==0);
   check("trigger_rollback_integrity_after_reopen",
-        strcmp(exec1(db, "PRAGMA integrity_check"), "ok")==0);
+        strcmp(queryScalarText(db, "PRAGMA integrity_check"), "ok")==0);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_begin_release_then_outer_rollback_reopen(void){
@@ -3851,58 +3880,58 @@ static void run_begin_release_then_outer_rollback_reopen(void){
   printf("=== Begin Release Then Outer Rollback Reopen Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath),
               "test_begin_release_then_outer_rollback_reopen");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_begin_release_then_outer_rollback", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_begin_release_then_outer_rollback", execsql(db,
+  check("setup_repo_for_begin_release_then_outer_rollback", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, k INTEGER, v TEXT);"
     "CREATE INDEX k_idx ON t(k);"
     "INSERT INTO t VALUES(1, 1, 'a');"
     "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
 
   check("begin_txn_for_begin_release_then_outer_rollback",
-        execsql(db, "BEGIN IMMEDIATE;")==SQLITE_OK);
+        execSql(db, "BEGIN IMMEDIATE;")==SQLITE_OK);
   check("savepoint_outer_for_begin_release_then_outer_rollback",
-        execsql(db, "SAVEPOINT outer_sp;")==SQLITE_OK);
+        execSql(db, "SAVEPOINT outer_sp;")==SQLITE_OK);
   check("outer_edit_for_begin_release_then_outer_rollback",
-        execsql(db, "UPDATE t SET k=11, v='outer' WHERE id=1;")==SQLITE_OK);
+        execSql(db, "UPDATE t SET k=11, v='outer' WHERE id=1;")==SQLITE_OK);
   check("savepoint_inner_for_begin_release_then_outer_rollback",
-        execsql(db, "SAVEPOINT inner_sp;")==SQLITE_OK);
+        execSql(db, "SAVEPOINT inner_sp;")==SQLITE_OK);
   check("inner_edit_for_begin_release_then_outer_rollback",
-        execsql(db, "INSERT INTO t VALUES(2, 22, 'inner2');")==SQLITE_OK);
+        execSql(db, "INSERT INTO t VALUES(2, 22, 'inner2');")==SQLITE_OK);
   check("release_inner_for_begin_release_then_outer_rollback",
-        execsql(db, "RELEASE inner_sp;")==SQLITE_OK);
+        execSql(db, "RELEASE inner_sp;")==SQLITE_OK);
   check("rollback_outer_for_begin_release_then_outer_rollback",
-        execsql(db, "ROLLBACK;")==SQLITE_OK);
+        execSql(db, "ROLLBACK;")==SQLITE_OK);
 
   check("begin_release_outer_rollback_row1_before_close",
-        strcmp(exec1(db, "SELECT k FROM t WHERE id=1"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT k FROM t WHERE id=1"), "1")==0);
   check("begin_release_outer_rollback_row2_absent_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE id=2"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE id=2"), "0")==0);
   check("begin_release_outer_rollback_k11_absent_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE k=11"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE k=11"), "0")==0);
   check("begin_release_outer_rollback_status_clean_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_status"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_status"), "0")==0);
   check("begin_release_outer_rollback_integrity_before_close",
-        strcmp(exec1(db, "PRAGMA integrity_check"), "ok")==0);
+        strcmp(queryScalarText(db, "PRAGMA integrity_check"), "ok")==0);
 
   sqlite3_close(db);
   db = 0;
 
   check("reopen_db_for_begin_release_then_outer_rollback", open_db(dbpath, &db)==SQLITE_OK);
   check("begin_release_outer_rollback_row1_after_reopen",
-        strcmp(exec1(db, "SELECT k FROM t WHERE id=1"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT k FROM t WHERE id=1"), "1")==0);
   check("begin_release_outer_rollback_row2_absent_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE id=2"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE id=2"), "0")==0);
   check("begin_release_outer_rollback_k11_absent_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM t WHERE k=11"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t WHERE k=11"), "0")==0);
   check("begin_release_outer_rollback_status_clean_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_status"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_status"), "0")==0);
   check("begin_release_outer_rollback_integrity_after_reopen",
-        strcmp(exec1(db, "PRAGMA integrity_check"), "ok")==0);
+        strcmp(queryScalarText(db, "PRAGMA integrity_check"), "ok")==0);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_savepoint_failed_commit_schema_rollback_reopen(void){
@@ -3913,54 +3942,54 @@ static void run_savepoint_failed_commit_schema_rollback_reopen(void){
   printf("=== Savepoint Failed Commit Schema Rollback Reopen Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath),
               "test_savepoint_failed_commit_schema_rollback_reopen");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_savepoint_failed_commit_schema_rollback",
         open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_savepoint_failed_commit_schema_rollback", execsql(db,
+  check("setup_repo_for_savepoint_failed_commit_schema_rollback", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1, 'a');"
     "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
   sqlite3_snprintf(sizeof(zHeadBefore), zHeadBefore, "%s",
-                   exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1"));
+                   queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1"));
 
   check("begin_txn_for_savepoint_failed_commit_schema_rollback",
-        execsql(db, "BEGIN IMMEDIATE;")==SQLITE_OK);
+        execSql(db, "BEGIN IMMEDIATE;")==SQLITE_OK);
   check("savepoint_outer_for_savepoint_failed_commit_schema_rollback",
-        execsql(db, "SAVEPOINT outer_sp;")==SQLITE_OK);
+        execSql(db, "SAVEPOINT outer_sp;")==SQLITE_OK);
   check("outer_edit_for_savepoint_failed_commit_schema_rollback",
-        execsql(db, "UPDATE t SET v='outer' WHERE id=1;")==SQLITE_OK);
+        execSql(db, "UPDATE t SET v='outer' WHERE id=1;")==SQLITE_OK);
   check("savepoint_inner_for_savepoint_failed_commit_schema_rollback",
-        execsql(db, "SAVEPOINT inner_sp;")==SQLITE_OK);
+        execSql(db, "SAVEPOINT inner_sp;")==SQLITE_OK);
   check("inner_schema_for_savepoint_failed_commit_schema_rollback",
-        execsql(db,
+        execSql(db,
           "ALTER TABLE t ADD COLUMN extra TEXT;"
           "CREATE TABLE aux(id INTEGER PRIMARY KEY, note TEXT);"
           "INSERT INTO aux VALUES(1, 'tmp');")==SQLITE_OK);
 
   check("rollback_inner_schema_after_failed_commit",
-        execsql(db, "ROLLBACK TO inner_sp;")==SQLITE_OK);
+        execSql(db, "ROLLBACK TO inner_sp;")==SQLITE_OK);
   check("release_inner_schema_after_failed_commit",
-        execsql(db, "RELEASE inner_sp;")==SQLITE_OK);
+        execSql(db, "RELEASE inner_sp;")==SQLITE_OK);
   check("release_outer_schema_after_failed_commit",
-        execsql(db, "RELEASE outer_sp;")==SQLITE_OK);
+        execSql(db, "RELEASE outer_sp;")==SQLITE_OK);
   check("commit_after_failed_commit_schema_rollback",
-        execsql(db, "COMMIT;")==SQLITE_OK);
+        execSql(db, "COMMIT;")==SQLITE_OK);
 
   check("failed_commit_schema_row_before_close",
-        strcmp(exec1(db, "SELECT v FROM t WHERE id=1"), "outer")==0);
+        strcmp(queryScalarText(db, "SELECT v FROM t WHERE id=1"), "outer")==0);
   check("failed_commit_schema_extra_absent_before_close",
-        strcmp(exec1(db,
+        strcmp(queryScalarText(db,
           "SELECT count(*) FROM pragma_table_info('t') WHERE name='extra'"), "0")==0);
   check("failed_commit_schema_aux_absent_before_close",
-        strcmp(exec1(db,
+        strcmp(queryScalarText(db,
           "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='aux'"), "0")==0);
   check("failed_commit_schema_head_unchanged_before_close",
-        strcmp(exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
+        strcmp(queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
   check("failed_commit_schema_status_dirty_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_status"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_status"), "1")==0);
   check("failed_commit_schema_integrity_before_close",
-        strcmp(exec1(db, "PRAGMA integrity_check"), "ok")==0);
+        strcmp(queryScalarText(db, "PRAGMA integrity_check"), "ok")==0);
 
   sqlite3_close(db);
   db = 0;
@@ -3968,22 +3997,22 @@ static void run_savepoint_failed_commit_schema_rollback_reopen(void){
   check("reopen_db_for_savepoint_failed_commit_schema_rollback",
         open_db(dbpath, &db)==SQLITE_OK);
   check("failed_commit_schema_row_after_reopen",
-        strcmp(exec1(db, "SELECT v FROM t WHERE id=1"), "outer")==0);
+        strcmp(queryScalarText(db, "SELECT v FROM t WHERE id=1"), "outer")==0);
   check("failed_commit_schema_extra_absent_after_reopen",
-        strcmp(exec1(db,
+        strcmp(queryScalarText(db,
           "SELECT count(*) FROM pragma_table_info('t') WHERE name='extra'"), "0")==0);
   check("failed_commit_schema_aux_absent_after_reopen",
-        strcmp(exec1(db,
+        strcmp(queryScalarText(db,
           "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='aux'"), "0")==0);
   check("failed_commit_schema_head_unchanged_after_reopen",
-        strcmp(exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
+        strcmp(queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
   check("failed_commit_schema_status_dirty_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_status"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_status"), "1")==0);
   check("failed_commit_schema_integrity_after_reopen",
-        strcmp(exec1(db, "PRAGMA integrity_check"), "ok")==0);
+        strcmp(queryScalarText(db, "PRAGMA integrity_check"), "ok")==0);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_savepoint_nested_trigger_inner_rollback_reopen(void){
@@ -3993,11 +4022,11 @@ static void run_savepoint_nested_trigger_inner_rollback_reopen(void){
   printf("=== Savepoint Nested Trigger Inner Rollback Reopen Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath),
               "test_savepoint_nested_trigger_inner_rollback_reopen");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_savepoint_nested_trigger_inner_rollback",
         open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_savepoint_nested_trigger_inner_rollback", execsql(db,
+  check("setup_repo_for_savepoint_nested_trigger_inner_rollback", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "CREATE TABLE audit(msg TEXT);"
     "CREATE TRIGGER t_au AFTER UPDATE ON t BEGIN "
@@ -4007,32 +4036,32 @@ static void run_savepoint_nested_trigger_inner_rollback_reopen(void){
     "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
 
   check("begin_txn_for_savepoint_nested_trigger_inner_rollback",
-        execsql(db, "BEGIN IMMEDIATE;")==SQLITE_OK);
+        execSql(db, "BEGIN IMMEDIATE;")==SQLITE_OK);
   check("savepoint_outer_for_nested_trigger_inner_rollback",
-        execsql(db, "SAVEPOINT outer_sp;")==SQLITE_OK);
+        execSql(db, "SAVEPOINT outer_sp;")==SQLITE_OK);
   check("outer_trigger_edit_for_nested_trigger_inner_rollback",
-        execsql(db, "UPDATE t SET v='outer' WHERE id=1;")==SQLITE_OK);
+        execSql(db, "UPDATE t SET v='outer' WHERE id=1;")==SQLITE_OK);
   check("savepoint_inner_for_nested_trigger_inner_rollback",
-        execsql(db, "SAVEPOINT inner_sp;")==SQLITE_OK);
+        execSql(db, "SAVEPOINT inner_sp;")==SQLITE_OK);
   check("inner_trigger_edit_for_nested_trigger_inner_rollback",
-        execsql(db, "UPDATE t SET v='inner' WHERE id=1;")==SQLITE_OK);
+        execSql(db, "UPDATE t SET v='inner' WHERE id=1;")==SQLITE_OK);
   check("rollback_inner_for_nested_trigger_inner_rollback",
-        execsql(db, "ROLLBACK TO inner_sp;")==SQLITE_OK);
+        execSql(db, "ROLLBACK TO inner_sp;")==SQLITE_OK);
   check("release_inner_for_nested_trigger_inner_rollback",
-        execsql(db, "RELEASE inner_sp;")==SQLITE_OK);
+        execSql(db, "RELEASE inner_sp;")==SQLITE_OK);
   check("release_outer_for_nested_trigger_inner_rollback",
-        execsql(db, "RELEASE outer_sp;")==SQLITE_OK);
+        execSql(db, "RELEASE outer_sp;")==SQLITE_OK);
   check("commit_nested_trigger_inner_rollback",
-        execsql(db, "COMMIT;")==SQLITE_OK);
+        execSql(db, "COMMIT;")==SQLITE_OK);
 
   check("nested_trigger_row_before_close",
-        strcmp(exec1(db, "SELECT v FROM t WHERE id=1"), "outer")==0);
+        strcmp(queryScalarText(db, "SELECT v FROM t WHERE id=1"), "outer")==0);
   check("nested_trigger_audit_count_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM audit"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM audit"), "1")==0);
   check("nested_trigger_audit_msg_before_close",
-        strcmp(exec1(db, "SELECT msg FROM audit LIMIT 1"), "u:1:outer")==0);
+        strcmp(queryScalarText(db, "SELECT msg FROM audit LIMIT 1"), "u:1:outer")==0);
   check("nested_trigger_integrity_before_close",
-        strcmp(exec1(db, "PRAGMA integrity_check"), "ok")==0);
+        strcmp(queryScalarText(db, "PRAGMA integrity_check"), "ok")==0);
 
   sqlite3_close(db);
   db = 0;
@@ -4040,16 +4069,16 @@ static void run_savepoint_nested_trigger_inner_rollback_reopen(void){
   check("reopen_db_for_savepoint_nested_trigger_inner_rollback",
         open_db(dbpath, &db)==SQLITE_OK);
   check("nested_trigger_row_after_reopen",
-        strcmp(exec1(db, "SELECT v FROM t WHERE id=1"), "outer")==0);
+        strcmp(queryScalarText(db, "SELECT v FROM t WHERE id=1"), "outer")==0);
   check("nested_trigger_audit_count_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM audit"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM audit"), "1")==0);
   check("nested_trigger_audit_msg_after_reopen",
-        strcmp(exec1(db, "SELECT msg FROM audit LIMIT 1"), "u:1:outer")==0);
+        strcmp(queryScalarText(db, "SELECT msg FROM audit LIMIT 1"), "u:1:outer")==0);
   check("nested_trigger_integrity_after_reopen",
-        strcmp(exec1(db, "PRAGMA integrity_check"), "ok")==0);
+        strcmp(queryScalarText(db, "PRAGMA integrity_check"), "ok")==0);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_hard_reset_failure_restores_memory_state(void){
@@ -4060,20 +4089,20 @@ static void run_hard_reset_failure_restores_memory_state(void){
 
   printf("=== Hard Reset Failure Restores Memory State Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_hard_reset_failure_restores_memory_state");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
   gFailWriteOnce = 0;
   gFailSyncOnce = 0;
   gFailHits = 0;
 
   check("register_fail_vfs_for_hard_reset", registerFailVfs()==SQLITE_OK);
   check("open_fail_db_for_hard_reset", open_fail_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_hard_reset_failure", execsql(db,
+  check("setup_repo_for_hard_reset_failure", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');"
     "SELECT dolt_commit('-A', '-m', 'init');"
     "INSERT INTO t VALUES(2,'b');")==SQLITE_OK);
   check("working_row_visible_before_hard_reset",
-        strcmp(exec1(db, "SELECT count(*) FROM t"), "2")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t"), "2")==0);
   check("get_head_catalog_for_hard_reset",
         doltliteGetHeadCatalogHash(db, &headCatHash)==SQLITE_OK);
 
@@ -4083,14 +4112,14 @@ static void run_hard_reset_failure_restores_memory_state(void){
   check("hard_reset_failure_injected", gFailHits>0);
   check("hard_reset_returns_error_on_commit_failure", rc!=SQLITE_OK);
   check("failed_hard_reset_preserves_memory_state",
-        strcmp(exec1(db, "SELECT count(*) FROM t"), "2")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t"), "2")==0);
 
   sqlite3_close(db);
   check("reopen_after_failed_hard_reset", open_db(dbpath, &db)==SQLITE_OK);
   check("failed_hard_reset_preserves_durable_state",
-        strcmp(exec1(db, "SELECT count(*) FROM t"), "2")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t"), "2")==0);
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_hard_reset_command_failure_preserves_durable_state(void){
@@ -4101,54 +4130,54 @@ static void run_hard_reset_command_failure_preserves_durable_state(void){
 
   printf("=== Hard Reset Command Failure Preserves Durable State Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_hard_reset_command_failure_preserves_durable_state");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
   gFailWriteOnce = 0;
   gFailSyncOnce = 0;
   gFailHits = 0;
 
   check("register_fail_vfs_for_hard_reset_command", registerFailVfs()==SQLITE_OK);
   check("open_fail_db_for_hard_reset_command", open_fail_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_hard_reset_command_failure", execsql(db,
+  check("setup_repo_for_hard_reset_command_failure", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');"
     "SELECT dolt_commit('-A', '-m', 'init');"
     "INSERT INTO t VALUES(2,'b');")==SQLITE_OK);
   sqlite3_snprintf(sizeof(zHeadBefore), zHeadBefore, "%s",
-                   exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1"));
+                   queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1"));
   check("hard_reset_command_working_rows_before_failure",
-        strcmp(exec1(db, "SELECT count(*) FROM t"), "2")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t"), "2")==0);
   check("hard_reset_command_status_before_failure",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_status"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_status"), "1")==0);
 
   gFailHits = 0;
   gFailWriteOnce = 1;
-  res = exec1(db, "SELECT dolt_reset('--hard')");
+  res = queryScalarText(db, "SELECT dolt_reset('--hard')");
   check("hard_reset_command_failure_injected", gFailHits>0);
   check("hard_reset_command_returns_error", strstr(res, "ERROR:")!=0);
   check("hard_reset_command_preserves_memory_rows",
-        strcmp(exec1(db, "SELECT count(*) FROM t"), "2")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t"), "2")==0);
   check("hard_reset_command_preserves_memory_status",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_status"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_status"), "1")==0);
   check("hard_reset_command_preserves_memory_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
   check("hard_reset_command_preserves_memory_head",
-        strcmp(exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
+        strcmp(queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
 
   sqlite3_close(db);
   db = 0;
 
   check("reopen_after_failed_hard_reset_command", open_db(dbpath, &db)==SQLITE_OK);
   check("failed_hard_reset_command_preserves_durable_rows",
-        strcmp(exec1(db, "SELECT count(*) FROM t"), "2")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t"), "2")==0);
   check("failed_hard_reset_command_preserves_durable_status",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_status"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_status"), "1")==0);
   check("failed_hard_reset_command_preserves_durable_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
   check("failed_hard_reset_command_preserves_durable_head",
-        strcmp(exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
+        strcmp(queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_amend_persist_failure_preserves_durable_state(void){
@@ -4159,51 +4188,51 @@ static void run_amend_persist_failure_preserves_durable_state(void){
 
   printf("=== Amend Persist Failure Preserves Durable State Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_amend_persist_failure_preserves_durable_state");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
   gFailWriteOnce = 0;
   gFailSyncOnce = 0;
   gFailHits = 0;
 
   check("register_fail_vfs_for_amend", registerFailVfs()==SQLITE_OK);
   check("open_fail_db_for_amend", open_fail_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_amend_failure", execsql(db,
+  check("setup_repo_for_amend_failure", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');"
     "SELECT dolt_commit('-A', '-m', 'init');"
     "INSERT INTO t VALUES(2,'b');"
     "SELECT dolt_commit('-A', '-m', 'second');")==SQLITE_OK);
   sqlite3_snprintf(sizeof(zHeadBefore), zHeadBefore, "%s",
-                   exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1"));
+                   queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1"));
 
   gFailHits = 0;
   gFailWriteOnce = 1;
-  res = exec1(db, "SELECT dolt_commit('--amend', '-m', 'amended')");
+  res = queryScalarText(db, "SELECT dolt_commit('--amend', '-m', 'amended')");
   check("amend_failure_was_injected", gFailHits>0);
   check("amend_returns_error_on_persist_failure", strstr(res, "ERROR:")!=0);
   check("amend_failure_keeps_active_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
   check("amend_failure_keeps_rows",
-        strcmp(exec1(db, "SELECT count(*) FROM t"), "2")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t"), "2")==0);
   check("amend_failure_keeps_head",
-        strcmp(exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
+        strcmp(queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
   check("amend_failure_keeps_message",
-        strcmp(exec1(db, "SELECT message FROM dolt_log LIMIT 1"), "second")==0);
+        strcmp(queryScalarText(db, "SELECT message FROM dolt_log LIMIT 1"), "second")==0);
 
   sqlite3_close(db);
   db = 0;
 
   check("reopen_db_after_amend_failure", open_db(dbpath, &db)==SQLITE_OK);
   check("amend_failure_persists_active_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
   check("amend_failure_persists_rows",
-        strcmp(exec1(db, "SELECT count(*) FROM t"), "2")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t"), "2")==0);
   check("amend_failure_persists_head",
-        strcmp(exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
+        strcmp(queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
   check("amend_failure_persists_message",
-        strcmp(exec1(db, "SELECT message FROM dolt_log LIMIT 1"), "second")==0);
+        strcmp(queryScalarText(db, "SELECT message FROM dolt_log LIMIT 1"), "second")==0);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_delete_current_branch_failure_preserves_durable_state(void){
@@ -4213,40 +4242,30 @@ static void run_delete_current_branch_failure_preserves_durable_state(void){
 
   printf("=== Delete Current Branch Failure Preserves Durable State Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_delete_current_branch_failure_preserves_durable_state");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_delete_current_branch_failure", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_delete_current_branch_failure", execsql(db,
+  check("setup_repo_for_delete_current_branch_failure", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');"
     "SELECT dolt_commit('-A', '-m', 'init');"
     "SELECT dolt_branch('feature');")==SQLITE_OK);
 
-  res = exec1(db, "SELECT dolt_branch('-d', 'main')");
+  res = queryScalarText(db, "SELECT dolt_branch('-d', 'main')");
   check("delete_current_branch_returns_error",
         strstr(res, "ERROR: cannot delete the current branch")!=0);
-  check("delete_current_branch_keeps_active_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
-  check("delete_current_branch_keeps_branch_count",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_branches"), "2")==0);
-  check("delete_current_branch_keeps_feature_branch",
-        strcmp(exec1(db,
-          "SELECT count(*) FROM dolt_branches WHERE name='feature'"), "1")==0);
+  checkBranchState(db, "delete_current_branch_keeps", "main", "2",
+                   "feature", "1");
 
   sqlite3_close(db);
   db = 0;
 
   check("reopen_db_after_delete_current_branch_failure", open_db(dbpath, &db)==SQLITE_OK);
-  check("delete_current_branch_persists_active_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
-  check("delete_current_branch_persists_branch_count",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_branches"), "2")==0);
-  check("delete_current_branch_persists_feature_branch",
-        strcmp(exec1(db,
-          "SELECT count(*) FROM dolt_branches WHERE name='feature'"), "1")==0);
+  checkBranchState(db, "delete_current_branch_persists", "main", "2",
+                   "feature", "1");
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_delete_missing_branch_preserves_durable_state(void){
@@ -4256,40 +4275,30 @@ static void run_delete_missing_branch_preserves_durable_state(void){
 
   printf("=== Delete Missing Branch Preserves Durable State Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_delete_missing_branch_preserves_durable_state");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_delete_missing_branch", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_delete_missing_branch", execsql(db,
+  check("setup_repo_for_delete_missing_branch", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');"
     "SELECT dolt_commit('-A', '-m', 'init');"
     "SELECT dolt_branch('feature');")==SQLITE_OK);
 
-  res = exec1(db, "SELECT dolt_branch('-d', 'nope')");
+  res = queryScalarText(db, "SELECT dolt_branch('-d', 'nope')");
   check("delete_missing_branch_returns_error",
         strstr(res, "ERROR: branch not found")!=0);
-  check("delete_missing_branch_keeps_active_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
-  check("delete_missing_branch_keeps_feature_branch",
-        strcmp(exec1(db,
-          "SELECT count(*) FROM dolt_branches WHERE name='feature'"), "1")==0);
-  check("delete_missing_branch_keeps_branch_count",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_branches"), "2")==0);
+  checkBranchState(db, "delete_missing_branch_keeps", "main", "2",
+                   "feature", "1");
 
   sqlite3_close(db);
   db = 0;
 
   check("reopen_db_after_delete_missing_branch", open_db(dbpath, &db)==SQLITE_OK);
-  check("delete_missing_branch_persists_active_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
-  check("delete_missing_branch_persists_feature_branch",
-        strcmp(exec1(db,
-          "SELECT count(*) FROM dolt_branches WHERE name='feature'"), "1")==0);
-  check("delete_missing_branch_persists_branch_count",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_branches"), "2")==0);
+  checkBranchState(db, "delete_missing_branch_persists", "main", "2",
+                   "feature", "1");
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_force_delete_missing_branch_preserves_durable_state(void){
@@ -4299,40 +4308,30 @@ static void run_force_delete_missing_branch_preserves_durable_state(void){
 
   printf("=== Force Delete Missing Branch Preserves Durable State Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_force_delete_missing_branch_preserves_durable_state");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_force_delete_missing_branch", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_force_delete_missing_branch", execsql(db,
+  check("setup_repo_for_force_delete_missing_branch", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');"
     "SELECT dolt_commit('-A', '-m', 'init');"
     "SELECT dolt_branch('feature');")==SQLITE_OK);
 
-  res = exec1(db, "SELECT dolt_branch('-D', 'nope')");
+  res = queryScalarText(db, "SELECT dolt_branch('-D', 'nope')");
   check("force_delete_missing_branch_returns_error",
         strstr(res, "ERROR: branch not found")!=0);
-  check("force_delete_missing_branch_keeps_active_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
-  check("force_delete_missing_branch_keeps_feature_branch",
-        strcmp(exec1(db,
-          "SELECT count(*) FROM dolt_branches WHERE name='feature'"), "1")==0);
-  check("force_delete_missing_branch_keeps_branch_count",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_branches"), "2")==0);
+  checkBranchState(db, "force_delete_missing_branch_keeps", "main", "2",
+                   "feature", "1");
 
   sqlite3_close(db);
   db = 0;
 
   check("reopen_db_after_force_delete_missing_branch", open_db(dbpath, &db)==SQLITE_OK);
-  check("force_delete_missing_branch_persists_active_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
-  check("force_delete_missing_branch_persists_feature_branch",
-        strcmp(exec1(db,
-          "SELECT count(*) FROM dolt_branches WHERE name='feature'"), "1")==0);
-  check("force_delete_missing_branch_persists_branch_count",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_branches"), "2")==0);
+  checkBranchState(db, "force_delete_missing_branch_persists", "main", "2",
+                   "feature", "1");
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_rebase_continue_invalid_plan_preserves_durable_state(void){
@@ -4345,10 +4344,10 @@ static void run_rebase_continue_invalid_plan_preserves_durable_state(void){
   printf("=== Rebase Continue Invalid Plan Preserves Durable State Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath),
               "test_rebase_continue_invalid_plan_preserves_durable_state");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_rebase_invalid_plan", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_rebase_invalid_plan", execsql(db,
+  check("setup_repo_for_rebase_invalid_plan", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);"
     "INSERT INTO t VALUES (1, 1);"
     "SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');"
@@ -4365,13 +4364,13 @@ static void run_rebase_continue_invalid_plan_preserves_durable_state(void){
     "SELECT dolt_checkout('feat');"
     "SELECT dolt_rebase('-i', 'main');")==SQLITE_OK);
 
-  res = exec1(db, "UPDATE dolt_rebase SET action = 'oops' WHERE commit_message = 'f1'");
+  res = queryScalarText(db, "UPDATE dolt_rebase SET action = 'oops' WHERE commit_message = 'f1'");
   check("rebase_invalid_plan_returns_error",
         strcmp(res, "")==0);
   check("rebase_invalid_plan_keeps_working_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "dolt_rebase_feat")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "dolt_rebase_feat")==0);
   check("rebase_invalid_plan_keeps_plan_table",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_rebase"), "3")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_rebase"), "3")==0);
   doltliteGetSessionRebaseState(db, &isRebasing, 0, 0, &zOrigBranch, 0);
   check("rebase_invalid_plan_keeps_rebase_flag", isRebasing==1);
   check("rebase_invalid_plan_keeps_orig_branch",
@@ -4382,20 +4381,20 @@ static void run_rebase_continue_invalid_plan_preserves_durable_state(void){
 
   check("reopen_db_after_rebase_invalid_plan", open_db(dbpath, &db)==SQLITE_OK);
   check("rebase_invalid_plan_persists_working_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
   check("rebase_invalid_plan_persists_plan_table",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_rebase"), "3")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_rebase"), "3")==0);
   doltliteGetSessionRebaseState(db, &isRebasing, 0, 0, &zOrigBranch, 0);
   check("rebase_invalid_plan_persists_rebase_flag", isRebasing==1);
   check("rebase_invalid_plan_persists_orig_branch",
         zOrigBranch && strcmp(zOrigBranch, "feat")==0);
   check("rebase_invalid_plan_abort_after_reopen",
-        strcmp(exec1(db, "SELECT dolt_rebase('--abort')"), "Interactive rebase aborted")==0);
+        strcmp(queryScalarText(db, "SELECT dolt_rebase('--abort')"), "Interactive rebase aborted")==0);
   check("rebase_invalid_plan_abort_restores_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "feat")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "feat")==0);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_rebase_abort_after_reopen_restores_durable_state(void){
@@ -4409,10 +4408,10 @@ static void run_rebase_abort_after_reopen_restores_durable_state(void){
 
   printf("=== Rebase Abort After Reopen Restores Durable State Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_rebase_abort_after_reopen_restores_durable_state");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_rebase_abort_after_reopen", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_rebase_abort_after_reopen", execsql(db,
+  check("setup_repo_for_rebase_abort_after_reopen", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);"
     "INSERT INTO t VALUES (1, 1);"
     "SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');"
@@ -4426,15 +4425,15 @@ static void run_rebase_abort_after_reopen_restores_durable_state(void){
     "SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'm');"
     "SELECT dolt_checkout('feat');")==SQLITE_OK);
   sqlite3_snprintf(sizeof(zHeadBefore), zHeadBefore, "%s",
-                   exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1"));
+                   queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1"));
 
   check("start_interactive_rebase_for_abort_after_reopen",
-        strstr(exec1(db, "SELECT dolt_rebase('-i', 'main')"),
+        strstr(queryScalarText(db, "SELECT dolt_rebase('-i', 'main')"),
                "interactive rebase started on branch dolt_rebase_feat")!=0);
   check("rebase_abort_after_reopen_branch_before_close",
-        strcmp(exec1(db, "SELECT active_branch()"), "dolt_rebase_feat")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "dolt_rebase_feat")==0);
   check("rebase_abort_after_reopen_plan_table_before_close",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_rebase"), "2")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_rebase"), "2")==0);
   doltliteGetSessionRebaseState(db, &isRebasing, 0, 0, &zOrigBranch, 0);
   check("rebase_abort_after_reopen_flag_before_close", isRebasing==1);
   check("rebase_abort_after_reopen_orig_branch_before_close",
@@ -4445,20 +4444,20 @@ static void run_rebase_abort_after_reopen_restores_durable_state(void){
 
   check("reopen_db_for_rebase_abort_after_reopen", open_db(dbpath, &db)==SQLITE_OK);
   check("rebase_abort_after_reopen_branch_before_abort",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
   check("rebase_abort_after_reopen_plan_before_abort",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_rebase"), "2")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_rebase"), "2")==0);
   doltliteGetSessionRebaseState(db, &isRebasing, 0, 0, &zOrigBranch, 0);
   check("rebase_abort_after_reopen_flag_before_abort", isRebasing==1);
 
   check("rebase_abort_after_reopen_returns_success",
-        strcmp(exec1(db, "SELECT dolt_rebase('--abort')"), "Interactive rebase aborted")==0);
+        strcmp(queryScalarText(db, "SELECT dolt_rebase('--abort')"), "Interactive rebase aborted")==0);
   check("rebase_abort_after_reopen_restores_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "feat")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "feat")==0);
   check("rebase_abort_after_reopen_restores_head",
-        strcmp(exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
+        strcmp(queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
   check("rebase_abort_after_reopen_drops_plan",
-        strcmp(exec1(db,
+        strcmp(queryScalarText(db,
           "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='dolt_rebase'"), "0")==0);
   doltliteGetSessionRebaseState(db, &isRebasing, 0, 0, &zOrigBranch, 0);
   check("rebase_abort_after_reopen_clears_flag", isRebasing==0);
@@ -4469,23 +4468,23 @@ static void run_rebase_abort_after_reopen_restores_durable_state(void){
 
   check("reopen_db_after_rebase_abort", open_db(dbpath, &db)==SQLITE_OK);
   check("rebase_abort_persists_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
   check("rebase_abort_persists_head",
-        strcmp(exec1(db, "SELECT message FROM dolt_log LIMIT 1"), "m")==0);
+        strcmp(queryScalarText(db, "SELECT message FROM dolt_log LIMIT 1"), "m")==0);
   check("rebase_abort_persists_no_plan",
-        strcmp(exec1(db,
+        strcmp(queryScalarText(db,
           "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='dolt_rebase'"), "0")==0);
   doltliteGetSessionRebaseState(db, &isRebasing, 0, 0, &zOrigBranch, 0);
   check("rebase_abort_persists_flag_cleared", isRebasing==0);
   capture_repo_state_snapshot(db, &afterReopenAbort);
   check("rebase_abort_reopen_table_rows_match",
-        strcmp(exec1(db, "SELECT count(*) FROM t"), "2")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t"), "2")==0);
   check("rebase_abort_reopen_feat_head_preserved",
-        strcmp(exec1(db,
+        strcmp(queryScalarText(db,
           "SELECT hash FROM dolt_branches WHERE name='feat'"), zHeadBefore)==0);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_rebase_main_table_schema_guard(void){
@@ -4497,10 +4496,10 @@ static void run_rebase_main_table_schema_guard(void){
 
   printf("=== Rebase Main Table Schema Guard Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_rebase_main_table_schema_guard");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_rebase_schema_guard", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_rebase_schema_guard", execsql(db,
+  check("setup_repo_for_rebase_schema_guard", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);"
     "INSERT INTO t VALUES (1, 1);"
     "SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');"
@@ -4515,11 +4514,11 @@ static void run_rebase_main_table_schema_guard(void){
     "DROP TABLE main.dolt_rebase;"
     "CREATE TABLE main.dolt_rebase(id INTEGER PRIMARY KEY);")==SQLITE_OK);
 
-  res = exec1(db, "SELECT dolt_rebase('--continue')");
+  res = queryScalarText(db, "SELECT dolt_rebase('--continue')");
   check("rebase_schema_guard_returns_error",
         strstr(res, "ERROR: dolt_rebase has an unexpected schema")!=0);
   check("rebase_schema_guard_keeps_working_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "dolt_rebase_feat")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "dolt_rebase_feat")==0);
   doltliteGetSessionRebaseState(db, &isRebasing, 0, 0, &zOrigBranch, 0);
   check("rebase_schema_guard_keeps_rebase_flag", isRebasing==1);
   check("rebase_schema_guard_keeps_orig_branch",
@@ -4530,14 +4529,14 @@ static void run_rebase_main_table_schema_guard(void){
 
   check("reopen_db_for_rebase_schema_guard", open_db(dbpath, &db)==SQLITE_OK);
   check("rebase_schema_guard_persists_working_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
   check("rebase_schema_guard_abort_works",
-        strcmp(exec1(db, "SELECT dolt_rebase('--abort')"), "Interactive rebase aborted")==0);
+        strcmp(queryScalarText(db, "SELECT dolt_rebase('--abort')"), "Interactive rebase aborted")==0);
   check("rebase_schema_guard_abort_restores_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "feat")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "feat")==0);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_rebase_temp_shadow_ignored(void){
@@ -4547,10 +4546,10 @@ static void run_rebase_temp_shadow_ignored(void){
 
   printf("=== Rebase Temp Shadow Ignored Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_rebase_temp_shadow_ignored");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_rebase_temp_shadow", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_rebase_temp_shadow", execsql(db,
+  check("setup_repo_for_rebase_temp_shadow", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);"
     "INSERT INTO t VALUES (1, 1);"
     "SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');"
@@ -4567,15 +4566,15 @@ static void run_rebase_temp_shadow_ignored(void){
     "CREATE TEMP TABLE dolt_rebase(rebase_order REAL PRIMARY KEY, action TEXT, commit_hash TEXT, commit_message TEXT);"
     "INSERT INTO temp.dolt_rebase VALUES(1, 'oops', 'badbadbadbadbadbadbadbadbadbadbadbadbadb', 'shadow');")==SQLITE_OK);
 
-  res = exec1(db, "SELECT dolt_rebase('--continue')");
+  res = queryScalarText(db, "SELECT dolt_rebase('--continue')");
   check("rebase_temp_shadow_ignored_continue_succeeds",
         strstr(res, "Successfully rebased and updated refs/heads/feat")!=0);
   check("rebase_temp_shadow_ignored_restores_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "feat")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "feat")==0);
   check("rebase_temp_shadow_ignored_rows_rebased",
-        strcmp(exec1(db, "SELECT count(*) FROM t"), "4")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t"), "4")==0);
   check("rebase_temp_shadow_ignored_main_plan_gone",
-        strcmp(exec1(db,
+        strcmp(queryScalarText(db,
           "SELECT count(*) FROM main.sqlite_master WHERE type='table' AND name='dolt_rebase'"), "0")==0);
 
   sqlite3_close(db);
@@ -4583,12 +4582,12 @@ static void run_rebase_temp_shadow_ignored(void){
 
   check("reopen_db_for_rebase_temp_shadow", open_db(dbpath, &db)==SQLITE_OK);
   check("rebase_temp_shadow_ignored_branch_after_reopen",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
   check("rebase_temp_shadow_ignored_rows_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM t"), "2")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t"), "2")==0);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_rebase_continue_conflict_abort_restores_durable_state(void){
@@ -4601,10 +4600,10 @@ static void run_rebase_continue_conflict_abort_restores_durable_state(void){
   printf("=== Rebase Continue Conflict Abort Restores Durable State Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath),
               "test_rebase_continue_conflict_abort_restores_durable_state");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_rebase_continue_conflict_abort", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_rebase_continue_conflict_abort", execsql(db,
+  check("setup_repo_for_rebase_continue_conflict_abort", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);"
     "INSERT INTO t VALUES (1, 1);"
     "SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');"
@@ -4617,21 +4616,21 @@ static void run_rebase_continue_conflict_abort_restores_durable_state(void){
     "SELECT dolt_checkout('feat');")==SQLITE_OK);
 
   check("start_interactive_rebase_for_conflict_abort",
-        strstr(exec1(db, "SELECT dolt_rebase('-i', 'main')"),
+        strstr(queryScalarText(db, "SELECT dolt_rebase('-i', 'main')"),
                "interactive rebase started on branch dolt_rebase_feat")!=0);
 
-  res = exec1(db, "SELECT dolt_rebase('--continue')");
+  res = queryScalarText(db, "SELECT dolt_rebase('--continue')");
   check("rebase_continue_conflict_abort_returns_error",
         strstr(res, "data conflicts from rebase")!=0);
   check("rebase_continue_conflict_abort_restores_branch_same_session",
-        strcmp(exec1(db, "SELECT active_branch()"), "feat")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "feat")==0);
   check("rebase_continue_conflict_abort_drops_plan_same_session",
-        strcmp(exec1(db,
+        strcmp(queryScalarText(db,
           "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='dolt_rebase'"), "0")==0);
   check("rebase_continue_conflict_abort_clears_conflicts_same_session",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_conflicts"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_conflicts"), "0")==0);
   check("rebase_continue_conflict_abort_restores_row_same_session",
-        strcmp(exec1(db, "SELECT v FROM t WHERE id=1"), "2")==0);
+        strcmp(queryScalarText(db, "SELECT v FROM t WHERE id=1"), "2")==0);
   doltliteGetSessionRebaseState(db, &isRebasing, 0, 0, &zOrigBranch, 0);
   check("rebase_continue_conflict_abort_clears_flag_same_session", isRebasing==0);
 
@@ -4640,19 +4639,19 @@ static void run_rebase_continue_conflict_abort_restores_durable_state(void){
 
   check("reopen_db_for_rebase_continue_conflict_abort", open_db(dbpath, &db)==SQLITE_OK);
   check("rebase_continue_conflict_abort_restores_branch_after_reopen",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
   check("rebase_continue_conflict_abort_drops_plan_after_reopen",
-        strcmp(exec1(db,
+        strcmp(queryScalarText(db,
           "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='dolt_rebase'"), "0")==0);
   check("rebase_continue_conflict_abort_clears_conflicts_after_reopen",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_conflicts"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_conflicts"), "0")==0);
   check("rebase_continue_conflict_abort_restores_row_after_reopen",
-        strcmp(exec1(db, "SELECT v FROM t WHERE id=1"), "3")==0);
+        strcmp(queryScalarText(db, "SELECT v FROM t WHERE id=1"), "3")==0);
   doltliteGetSessionRebaseState(db, &isRebasing, 0, 0, &zOrigBranch, 0);
   check("rebase_continue_conflict_abort_clears_flag_after_reopen", isRebasing==0);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_branch_copy_existing_dest_preserves_durable_state(void){
@@ -4662,47 +4661,47 @@ static void run_branch_copy_existing_dest_preserves_durable_state(void){
 
   printf("=== Branch Copy Existing Dest Preserves Durable State Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_branch_copy_existing_dest_preserves_durable_state");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_branch_copy_existing_dest", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_branch_copy_existing_dest", execsql(db,
+  check("setup_repo_for_branch_copy_existing_dest", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');"
     "SELECT dolt_commit('-A', '-m', 'init');"
     "SELECT dolt_branch('feature');"
     "SELECT dolt_branch('clone');")==SQLITE_OK);
 
-  res = exec1(db, "SELECT dolt_branch('-c', 'feature', 'clone')");
+  res = queryScalarText(db, "SELECT dolt_branch('-c', 'feature', 'clone')");
   check("branch_copy_existing_dest_returns_error",
         strstr(res, "ERROR: branch already exists")!=0);
   check("branch_copy_existing_dest_keeps_active_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
   check("branch_copy_existing_dest_keeps_feature_branch",
-        strcmp(exec1(db,
+        strcmp(queryScalarText(db,
           "SELECT count(*) FROM dolt_branches WHERE name='feature'"), "1")==0);
   check("branch_copy_existing_dest_keeps_clone_branch",
-        strcmp(exec1(db,
+        strcmp(queryScalarText(db,
           "SELECT count(*) FROM dolt_branches WHERE name='clone'"), "1")==0);
   check("branch_copy_existing_dest_keeps_branch_count",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_branches"), "3")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_branches"), "3")==0);
 
   sqlite3_close(db);
   db = 0;
 
   check("reopen_db_after_branch_copy_existing_dest", open_db(dbpath, &db)==SQLITE_OK);
   check("branch_copy_existing_dest_persists_active_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
   check("branch_copy_existing_dest_persists_feature_branch",
-        strcmp(exec1(db,
+        strcmp(queryScalarText(db,
           "SELECT count(*) FROM dolt_branches WHERE name='feature'"), "1")==0);
   check("branch_copy_existing_dest_persists_clone_branch",
-        strcmp(exec1(db,
+        strcmp(queryScalarText(db,
           "SELECT count(*) FROM dolt_branches WHERE name='clone'"), "1")==0);
   check("branch_copy_existing_dest_persists_branch_count",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_branches"), "3")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_branches"), "3")==0);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_branch_copy_missing_source_preserves_durable_state(void){
@@ -4712,46 +4711,46 @@ static void run_branch_copy_missing_source_preserves_durable_state(void){
 
   printf("=== Branch Copy Missing Source Preserves Durable State Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_branch_copy_missing_source_preserves_durable_state");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_branch_copy_missing_source", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_branch_copy_missing_source", execsql(db,
+  check("setup_repo_for_branch_copy_missing_source", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');"
     "SELECT dolt_commit('-A', '-m', 'init');"
     "SELECT dolt_branch('clone');")==SQLITE_OK);
 
-  res = exec1(db, "SELECT dolt_branch('-c', 'missing', 'clone2')");
+  res = queryScalarText(db, "SELECT dolt_branch('-c', 'missing', 'clone2')");
   check("branch_copy_missing_source_returns_error",
         strstr(res, "ERROR: source branch not found")!=0);
   check("branch_copy_missing_source_keeps_active_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
   check("branch_copy_missing_source_keeps_clone_branch",
-        strcmp(exec1(db,
+        strcmp(queryScalarText(db,
           "SELECT count(*) FROM dolt_branches WHERE name='clone'"), "1")==0);
   check("branch_copy_missing_source_keeps_missing_absent",
-        strcmp(exec1(db,
+        strcmp(queryScalarText(db,
           "SELECT count(*) FROM dolt_branches WHERE name='clone2'"), "0")==0);
   check("branch_copy_missing_source_keeps_branch_count",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_branches"), "2")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_branches"), "2")==0);
 
   sqlite3_close(db);
   db = 0;
 
   check("reopen_db_after_branch_copy_missing_source", open_db(dbpath, &db)==SQLITE_OK);
   check("branch_copy_missing_source_persists_active_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
   check("branch_copy_missing_source_persists_clone_branch",
-        strcmp(exec1(db,
+        strcmp(queryScalarText(db,
           "SELECT count(*) FROM dolt_branches WHERE name='clone'"), "1")==0);
   check("branch_copy_missing_source_persists_missing_absent",
-        strcmp(exec1(db,
+        strcmp(queryScalarText(db,
           "SELECT count(*) FROM dolt_branches WHERE name='clone2'"), "0")==0);
   check("branch_copy_missing_source_persists_branch_count",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_branches"), "2")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_branches"), "2")==0);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_branch_rename_missing_source_preserves_durable_state(void){
@@ -4761,46 +4760,46 @@ static void run_branch_rename_missing_source_preserves_durable_state(void){
 
   printf("=== Branch Rename Missing Source Preserves Durable State Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_branch_rename_missing_source_preserves_durable_state");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_branch_rename_missing_source", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_branch_rename_missing_source", execsql(db,
+  check("setup_repo_for_branch_rename_missing_source", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');"
     "SELECT dolt_commit('-A', '-m', 'init');"
     "SELECT dolt_branch('other');")==SQLITE_OK);
 
-  res = exec1(db, "SELECT dolt_branch('-m', 'missing', 'renamed')");
+  res = queryScalarText(db, "SELECT dolt_branch('-m', 'missing', 'renamed')");
   check("branch_rename_missing_source_returns_error",
         strstr(res, "ERROR: source branch not found")!=0);
   check("branch_rename_missing_source_keeps_active_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
   check("branch_rename_missing_source_keeps_other_branch",
-        strcmp(exec1(db,
+        strcmp(queryScalarText(db,
           "SELECT count(*) FROM dolt_branches WHERE name='other'"), "1")==0);
   check("branch_rename_missing_source_keeps_renamed_absent",
-        strcmp(exec1(db,
+        strcmp(queryScalarText(db,
           "SELECT count(*) FROM dolt_branches WHERE name='renamed'"), "0")==0);
   check("branch_rename_missing_source_keeps_branch_count",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_branches"), "2")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_branches"), "2")==0);
 
   sqlite3_close(db);
   db = 0;
 
   check("reopen_db_after_branch_rename_missing_source", open_db(dbpath, &db)==SQLITE_OK);
   check("branch_rename_missing_source_persists_active_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
   check("branch_rename_missing_source_persists_other_branch",
-        strcmp(exec1(db,
+        strcmp(queryScalarText(db,
           "SELECT count(*) FROM dolt_branches WHERE name='other'"), "1")==0);
   check("branch_rename_missing_source_persists_renamed_absent",
-        strcmp(exec1(db,
+        strcmp(queryScalarText(db,
           "SELECT count(*) FROM dolt_branches WHERE name='renamed'"), "0")==0);
   check("branch_rename_missing_source_persists_branch_count",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_branches"), "2")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_branches"), "2")==0);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 static void run_branch_create_existing_name_preserves_durable_state(void){
   sqlite3 *db = 0;
@@ -4809,24 +4808,24 @@ static void run_branch_create_existing_name_preserves_durable_state(void){
 
   printf("=== Branch Create Existing Name Preserves Durable State Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_branch_create_existing_name_preserves_durable_state");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_branch_create_existing_name", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_branch_create_existing_name", execsql(db,
+  check("setup_repo_for_branch_create_existing_name", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');"
     "SELECT dolt_commit('-A', '-m', 'init');"
     "SELECT dolt_branch('feature');")==SQLITE_OK);
 
-  res = exec1(db, "SELECT dolt_branch('feature')");
+  res = queryScalarText(db, "SELECT dolt_branch('feature')");
   check("branch_create_existing_name_returns_error",
         strstr(res, "ERROR: branch already exists")!=0);
   check("branch_create_existing_name_keeps_active_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
   check("branch_create_existing_name_keeps_branch_count",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_branches"), "2")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_branches"), "2")==0);
   check("branch_create_existing_name_keeps_feature_branch",
-        strcmp(exec1(db,
+        strcmp(queryScalarText(db,
           "SELECT count(*) FROM dolt_branches WHERE name='feature'"), "1")==0);
 
   sqlite3_close(db);
@@ -4834,15 +4833,15 @@ static void run_branch_create_existing_name_preserves_durable_state(void){
 
   check("reopen_db_after_branch_create_existing_name", open_db(dbpath, &db)==SQLITE_OK);
   check("branch_create_existing_name_persists_active_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
   check("branch_create_existing_name_persists_branch_count",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_branches"), "2")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_branches"), "2")==0);
   check("branch_create_existing_name_persists_feature_branch",
-        strcmp(exec1(db,
+        strcmp(queryScalarText(db,
           "SELECT count(*) FROM dolt_branches WHERE name='feature'"), "1")==0);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_branch_create_bad_start_preserves_durable_state(void){
@@ -4852,27 +4851,27 @@ static void run_branch_create_bad_start_preserves_durable_state(void){
 
   printf("=== Branch Create Bad Start Preserves Durable State Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_branch_create_bad_start_preserves_durable_state");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_branch_create_bad_start", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_branch_create_bad_start", execsql(db,
+  check("setup_repo_for_branch_create_bad_start", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');"
     "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
 
-  res = exec1(db, "SELECT dolt_branch('bad_start', 'does-not-exist')");
+  res = queryScalarText(db, "SELECT dolt_branch('bad_start', 'does-not-exist')");
   check("branch_create_bad_start_returns_error",
         strstr(res, "ERROR: start point not found")!=0);
   check("branch_create_bad_start_keeps_active_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
   check("branch_create_bad_start_keeps_branch_count",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_branches"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_branches"), "1")==0);
   check("branch_create_bad_start_keeps_new_branch_absent",
-        strcmp(exec1(db,
+        strcmp(queryScalarText(db,
           "SELECT count(*) FROM dolt_branches WHERE name='bad_start'"), "0")==0);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_revert_bad_ref_failure_preserves_durable_state(void){
@@ -4883,10 +4882,10 @@ static void run_revert_bad_ref_failure_preserves_durable_state(void){
 
   printf("=== Revert Bad Ref Failure Preserves Durable State Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_revert_bad_ref_failure_preserves_durable_state");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_revert_bad_ref_failure", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_revert_bad_ref_failure", execsql(db,
+  check("setup_repo_for_revert_bad_ref_failure", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');"
     "SELECT dolt_add('-A');"
@@ -4895,35 +4894,35 @@ static void run_revert_bad_ref_failure_preserves_durable_state(void){
     "SELECT dolt_add('-A');"
     "SELECT dolt_commit('-m', 'second');")==SQLITE_OK);
   sqlite3_snprintf(sizeof(zHeadBefore), zHeadBefore, "%s",
-                   exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1"));
+                   queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1"));
 
-  res = exec1(db, "SELECT dolt_revert('does-not-exist')");
+  res = queryScalarText(db, "SELECT dolt_revert('does-not-exist')");
   check("revert_bad_ref_returns_error",
         strstr(res, "ERROR:")!=0);
   check("revert_bad_ref_keeps_active_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
   check("revert_bad_ref_keeps_working_rows",
-        strcmp(exec1(db, "SELECT count(*) FROM t"), "2")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t"), "2")==0);
   check("revert_bad_ref_keeps_status_clean",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_status"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_status"), "0")==0);
   check("revert_bad_ref_keeps_head",
-        strcmp(exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
+        strcmp(queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
 
   sqlite3_close(db);
   db = 0;
 
   check("reopen_db_after_revert_bad_ref_failure", open_db(dbpath, &db)==SQLITE_OK);
   check("revert_bad_ref_persists_active_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
   check("revert_bad_ref_persists_working_rows",
-        strcmp(exec1(db, "SELECT count(*) FROM t"), "2")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t"), "2")==0);
   check("revert_bad_ref_persists_status_clean",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_status"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_status"), "0")==0);
   check("revert_bad_ref_persists_head",
-        strcmp(exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
+        strcmp(queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_checkout_nonexistent_preserves_durable_state(void){
@@ -4933,36 +4932,36 @@ static void run_checkout_nonexistent_preserves_durable_state(void){
 
   printf("=== Checkout Nonexistent Preserves Durable State Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_checkout_nonexistent_preserves_durable_state");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_checkout_nonexistent", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_checkout_nonexistent", execsql(db,
+  check("setup_repo_for_checkout_nonexistent", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');"
     "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
 
-  res = exec1(db, "SELECT dolt_checkout('nope')");
+  res = queryScalarText(db, "SELECT dolt_checkout('nope')");
   check("checkout_nonexistent_returns_error", strstr(res, "ERROR:")!=0);
   check("checkout_nonexistent_keeps_active_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
   check("checkout_nonexistent_keeps_rows",
-        strcmp(exec1(db, "SELECT count(*) FROM t"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t"), "1")==0);
   check("checkout_nonexistent_keeps_branch_count",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_branches"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_branches"), "1")==0);
 
   sqlite3_close(db);
   db = 0;
 
   check("reopen_db_after_checkout_nonexistent", open_db(dbpath, &db)==SQLITE_OK);
   check("checkout_nonexistent_persists_active_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
   check("checkout_nonexistent_persists_rows",
-        strcmp(exec1(db, "SELECT count(*) FROM t"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t"), "1")==0);
   check("checkout_nonexistent_persists_branch_count",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_branches"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_branches"), "1")==0);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_checkout_dash_b_existing_branch_preserves_durable_state(void){
@@ -4972,39 +4971,39 @@ static void run_checkout_dash_b_existing_branch_preserves_durable_state(void){
 
   printf("=== Checkout -b Existing Branch Preserves Durable State Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_checkout_dash_b_existing_branch_preserves_durable_state");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_checkout_dash_b_existing_branch", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_checkout_dash_b_existing_branch", execsql(db,
+  check("setup_repo_for_checkout_dash_b_existing_branch", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');"
     "SELECT dolt_commit('-A', '-m', 'init');"
     "SELECT dolt_branch('feature');")==SQLITE_OK);
 
-  res = exec1(db, "SELECT dolt_checkout('-b', 'feature')");
+  res = queryScalarText(db, "SELECT dolt_checkout('-b', 'feature')");
   check("checkout_dash_b_existing_branch_returns_error", strstr(res, "ERROR:")!=0);
   check("checkout_dash_b_existing_branch_keeps_active_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
   check("checkout_dash_b_existing_branch_keeps_feature_branch",
-        strcmp(exec1(db,
+        strcmp(queryScalarText(db,
           "SELECT count(*) FROM dolt_branches WHERE name='feature'"), "1")==0);
   check("checkout_dash_b_existing_branch_keeps_branch_count",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_branches"), "2")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_branches"), "2")==0);
 
   sqlite3_close(db);
   db = 0;
 
   check("reopen_db_after_checkout_dash_b_existing_branch", open_db(dbpath, &db)==SQLITE_OK);
   check("checkout_dash_b_existing_branch_persists_active_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
   check("checkout_dash_b_existing_branch_persists_feature_branch",
-        strcmp(exec1(db,
+        strcmp(queryScalarText(db,
           "SELECT count(*) FROM dolt_branches WHERE name='feature'"), "1")==0);
   check("checkout_dash_b_existing_branch_persists_branch_count",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_branches"), "2")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_branches"), "2")==0);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_cherry_pick_bad_ref_failure_preserves_durable_state(void){
@@ -5015,10 +5014,10 @@ static void run_cherry_pick_bad_ref_failure_preserves_durable_state(void){
 
   printf("=== Cherry-pick Bad Ref Failure Preserves Durable State Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_cherry_pick_bad_ref_failure_preserves_durable_state");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_cherry_pick_bad_ref_failure", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_cherry_pick_bad_ref_failure", execsql(db,
+  check("setup_repo_for_cherry_pick_bad_ref_failure", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');"
     "SELECT dolt_add('-A');"
@@ -5027,35 +5026,35 @@ static void run_cherry_pick_bad_ref_failure_preserves_durable_state(void){
     "SELECT dolt_add('-A');"
     "SELECT dolt_commit('-m', 'second');")==SQLITE_OK);
   sqlite3_snprintf(sizeof(zHeadBefore), zHeadBefore, "%s",
-                   exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1"));
+                   queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1"));
 
-  res = exec1(db, "SELECT dolt_cherry_pick('does-not-exist')");
+  res = queryScalarText(db, "SELECT dolt_cherry_pick('does-not-exist')");
   check("cherry_pick_bad_ref_returns_error",
         strstr(res, "ERROR:")!=0);
   check("cherry_pick_bad_ref_keeps_active_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
   check("cherry_pick_bad_ref_keeps_working_rows",
-        strcmp(exec1(db, "SELECT count(*) FROM t"), "2")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t"), "2")==0);
   check("cherry_pick_bad_ref_keeps_status_clean",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_status"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_status"), "0")==0);
   check("cherry_pick_bad_ref_keeps_head",
-        strcmp(exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
+        strcmp(queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
 
   sqlite3_close(db);
   db = 0;
 
   check("reopen_db_after_cherry_pick_bad_ref_failure", open_db(dbpath, &db)==SQLITE_OK);
   check("cherry_pick_bad_ref_persists_active_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
   check("cherry_pick_bad_ref_persists_working_rows",
-        strcmp(exec1(db, "SELECT count(*) FROM t"), "2")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t"), "2")==0);
   check("cherry_pick_bad_ref_persists_status_clean",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_status"), "0")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_status"), "0")==0);
   check("cherry_pick_bad_ref_persists_head",
-        strcmp(exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
+        strcmp(queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_merge_nonexistent_branch_preserves_durable_state(void){
@@ -5066,39 +5065,39 @@ static void run_merge_nonexistent_branch_preserves_durable_state(void){
 
   printf("=== Merge Nonexistent Branch Preserves Durable State Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_merge_nonexistent_branch_preserves_durable_state");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_merge_nonexistent_branch", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_merge_nonexistent_branch", execsql(db,
+  check("setup_repo_for_merge_nonexistent_branch", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');"
     "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
   sqlite3_snprintf(sizeof(zHeadBefore), zHeadBefore, "%s",
-                   exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1"));
+                   queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1"));
 
-  res = exec1(db, "SELECT dolt_merge('nope')");
+  res = queryScalarText(db, "SELECT dolt_merge('nope')");
   check("merge_nonexistent_branch_returns_error",
         strstr(res, "ERROR:")!=0);
   check("merge_nonexistent_branch_keeps_active_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
   check("merge_nonexistent_branch_keeps_rows",
-        strcmp(exec1(db, "SELECT count(*) FROM t"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t"), "1")==0);
   check("merge_nonexistent_branch_keeps_head",
-        strcmp(exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
+        strcmp(queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
 
   sqlite3_close(db);
   db = 0;
 
   check("reopen_db_after_merge_nonexistent_branch", open_db(dbpath, &db)==SQLITE_OK);
   check("merge_nonexistent_branch_persists_active_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
   check("merge_nonexistent_branch_persists_rows",
-        strcmp(exec1(db, "SELECT count(*) FROM t"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t"), "1")==0);
   check("merge_nonexistent_branch_persists_head",
-        strcmp(exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
+        strcmp(queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_rebase_continue_without_active_preserves_durable_state(void){
@@ -5109,25 +5108,25 @@ static void run_rebase_continue_without_active_preserves_durable_state(void){
 
   printf("=== Rebase Continue Without Active Preserves Durable State Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_rebase_continue_without_active_preserves_durable_state");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_rebase_continue_without_active", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_rebase_continue_without_active", execsql(db,
+  check("setup_repo_for_rebase_continue_without_active", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY);"
     "SELECT dolt_add('-A');"
     "SELECT dolt_commit('-m', 'init');")==SQLITE_OK);
   sqlite3_snprintf(sizeof(zHeadBefore), zHeadBefore, "%s",
-                   exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1"));
+                   queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1"));
 
-  res = exec1(db, "SELECT dolt_rebase('--continue')");
+  res = queryScalarText(db, "SELECT dolt_rebase('--continue')");
   check("rebase_continue_without_active_returns_error",
         strstr(res, "ERROR:")!=0);
   check("rebase_continue_without_active_keeps_active_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
   check("rebase_continue_without_active_keeps_head",
-        strcmp(exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
+        strcmp(queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
   check("rebase_continue_without_active_keeps_no_plan",
-        strcmp(exec1(db,
+        strcmp(queryScalarText(db,
           "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='dolt_rebase'"), "0")==0);
 
   sqlite3_close(db);
@@ -5135,15 +5134,15 @@ static void run_rebase_continue_without_active_preserves_durable_state(void){
 
   check("reopen_db_after_rebase_continue_without_active", open_db(dbpath, &db)==SQLITE_OK);
   check("rebase_continue_without_active_persists_active_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
   check("rebase_continue_without_active_persists_head",
-        strcmp(exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
+        strcmp(queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
   check("rebase_continue_without_active_persists_no_plan",
-        strcmp(exec1(db,
+        strcmp(queryScalarText(db,
           "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='dolt_rebase'"), "0")==0);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_remote_add_duplicate_preserves_durable_state(void){
@@ -5153,18 +5152,18 @@ static void run_remote_add_duplicate_preserves_durable_state(void){
 
   printf("=== Remote Add Duplicate Preserves Durable State Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_remote_add_duplicate_preserves_durable_state");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_remote_add_duplicate", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_remote_add_duplicate", execsql(db,
+  check("setup_repo_for_remote_add_duplicate", execSql(db,
     "SELECT dolt_remote('add', 'origin', 'file:///tmp/oracle_origin');")==SQLITE_OK);
 
-  res = exec1(db, "SELECT dolt_remote('add', 'origin', 'file:///tmp/oracle_other')");
+  res = queryScalarText(db, "SELECT dolt_remote('add', 'origin', 'file:///tmp/oracle_other')");
   check("remote_add_duplicate_returns_error", strstr(res, "ERROR:")!=0);
   check("remote_add_duplicate_keeps_remote_count",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_remotes"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_remotes"), "1")==0);
   check("remote_add_duplicate_keeps_origin_url",
-        strcmp(exec1(db,
+        strcmp(queryScalarText(db,
           "SELECT url FROM dolt_remotes WHERE name='origin'"), "file:///tmp/oracle_origin")==0);
 
   sqlite3_close(db);
@@ -5172,13 +5171,13 @@ static void run_remote_add_duplicate_preserves_durable_state(void){
 
   check("reopen_db_after_remote_add_duplicate", open_db(dbpath, &db)==SQLITE_OK);
   check("remote_add_duplicate_persists_remote_count",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_remotes"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_remotes"), "1")==0);
   check("remote_add_duplicate_persists_origin_url",
-        strcmp(exec1(db,
+        strcmp(queryScalarText(db,
           "SELECT url FROM dolt_remotes WHERE name='origin'"), "file:///tmp/oracle_origin")==0);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_remote_remove_missing_preserves_durable_state(void){
@@ -5188,18 +5187,18 @@ static void run_remote_remove_missing_preserves_durable_state(void){
 
   printf("=== Remote Remove Missing Preserves Durable State Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_remote_remove_missing_preserves_durable_state");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_remote_remove_missing", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_remote_remove_missing", execsql(db,
+  check("setup_repo_for_remote_remove_missing", execSql(db,
     "SELECT dolt_remote('add', 'origin', 'file:///tmp/oracle_origin');")==SQLITE_OK);
 
-  res = exec1(db, "SELECT dolt_remote('remove', 'nonexistent')");
+  res = queryScalarText(db, "SELECT dolt_remote('remove', 'nonexistent')");
   check("remote_remove_missing_returns_error", strstr(res, "ERROR:")!=0);
   check("remote_remove_missing_keeps_remote_count",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_remotes"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_remotes"), "1")==0);
   check("remote_remove_missing_keeps_origin",
-        strcmp(exec1(db,
+        strcmp(queryScalarText(db,
           "SELECT count(*) FROM dolt_remotes WHERE name='origin'"), "1")==0);
 
   sqlite3_close(db);
@@ -5207,13 +5206,13 @@ static void run_remote_remove_missing_preserves_durable_state(void){
 
   check("reopen_db_after_remote_remove_missing", open_db(dbpath, &db)==SQLITE_OK);
   check("remote_remove_missing_persists_remote_count",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_remotes"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_remotes"), "1")==0);
   check("remote_remove_missing_persists_origin",
-        strcmp(exec1(db,
+        strcmp(queryScalarText(db,
           "SELECT count(*) FROM dolt_remotes WHERE name='origin'"), "1")==0);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 static void run_reset_bad_ref_failure_preserves_durable_state(void){
   sqlite3 *db = 0;
@@ -5223,44 +5222,44 @@ static void run_reset_bad_ref_failure_preserves_durable_state(void){
 
   printf("=== Reset Bad Ref Failure Preserves Durable State Test ===\n\n");
   make_dbpath(dbpath, sizeof(dbpath), "test_reset_bad_ref_failure_preserves_durable_state");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("open_db_for_reset_bad_ref_failure", open_db(dbpath, &db)==SQLITE_OK);
-  check("setup_repo_for_reset_bad_ref_failure", execsql(db,
+  check("setup_repo_for_reset_bad_ref_failure", execSql(db,
     "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
     "INSERT INTO t VALUES(1,'a');"
     "SELECT dolt_commit('-A', '-m', 'init');"
     "INSERT INTO t VALUES(2,'b');")==SQLITE_OK);
   sqlite3_snprintf(sizeof(zHeadBefore), zHeadBefore, "%s",
-                   exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1"));
+                   queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1"));
 
-  res = exec1(db, "SELECT dolt_reset('--hard', 'not_a_real_ref')");
+  res = queryScalarText(db, "SELECT dolt_reset('--hard', 'not_a_real_ref')");
   check("reset_bad_ref_returns_error",
         strstr(res, "ERROR: commit not found")!=0);
   check("reset_bad_ref_keeps_active_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
   check("reset_bad_ref_keeps_working_rows",
-        strcmp(exec1(db, "SELECT count(*) FROM t"), "2")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t"), "2")==0);
   check("reset_bad_ref_keeps_status",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_status"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_status"), "1")==0);
   check("reset_bad_ref_keeps_head",
-        strcmp(exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
+        strcmp(queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
 
   sqlite3_close(db);
   db = 0;
 
   check("reopen_db_after_reset_bad_ref_failure", open_db(dbpath, &db)==SQLITE_OK);
   check("reset_bad_ref_persists_active_branch",
-        strcmp(exec1(db, "SELECT active_branch()"), "main")==0);
+        strcmp(queryScalarText(db, "SELECT active_branch()"), "main")==0);
   check("reset_bad_ref_persists_working_rows",
-        strcmp(exec1(db, "SELECT count(*) FROM t"), "2")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM t"), "2")==0);
   check("reset_bad_ref_persists_status",
-        strcmp(exec1(db, "SELECT count(*) FROM dolt_status"), "1")==0);
+        strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_status"), "1")==0);
   check("reset_bad_ref_persists_head",
-        strcmp(exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
+        strcmp(queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1"), zHeadBefore)==0);
 
   sqlite3_close(db);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_mutmap_empty_reverse_iter(void){
@@ -5818,7 +5817,7 @@ static void run_chunk_store_commit_failure_restores_refs_hash(void){
 
   memset(&emptyHash, 0, sizeof(emptyHash));
   make_dbpath(dbpath, sizeof(dbpath), "test_refs_commit_failure_restore");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   gFailSyncOnce = 0;
   gFailHits = 0;
@@ -5868,7 +5867,7 @@ static void run_chunk_store_commit_failure_restores_refs_hash(void){
   check("reopened_store_keeps_default_branch",
         reopened.zDefaultBranch!=0 && strcmp(reopened.zDefaultBranch, "main")==0);
   chunkStoreClose(&reopened);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_remotesrv_put_refs_failure_restores_state(void){
@@ -5885,7 +5884,7 @@ static void run_remotesrv_put_refs_failure_restores_state(void){
 
   memset(&emptyHash, 0, sizeof(emptyHash));
   make_dbpath(dbpath, sizeof(dbpath), "test_remotesrv_put_refs_failure_restore");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   check("register_fail_vfs_for_remotesrv_put_refs", registerFailVfs()==SQLITE_OK);
   check("open_fail_store_for_remotesrv_put_refs",
@@ -5921,7 +5920,7 @@ static void run_remotesrv_put_refs_failure_restores_state(void){
   check("reopened_store_after_remotesrv_put_refs_has_no_failed_tag",
         chunkStoreFindTag(&reopened, "v1", &foundHash)!=SQLITE_OK);
   chunkStoreClose(&reopened);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_remotesrv_chunk_commit_failure_clears_pending(void){
@@ -5939,7 +5938,7 @@ static void run_remotesrv_chunk_commit_failure_clears_pending(void){
   memset(&emptyHash, 0, sizeof(emptyHash));
   memset(&chunkHash, 0, sizeof(chunkHash));
   make_dbpath(dbpath, sizeof(dbpath), "test_remotesrv_chunk_commit_failure");
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 
   gFailHits = 0;
   gFailSyncOnce = 0;
@@ -6007,7 +6006,7 @@ static void run_remotesrv_chunk_commit_failure_clears_pending(void){
           !hasChunk);
   }
   chunkStoreClose(&reopened);
-  remove_db(dbpath);
+  removeDbFiles(dbpath);
 }
 
 static void run_prolly_blob_cursor_seek_across_internal_boundary(void){

--- a/test/doltlite_regression_test_c.sh
+++ b/test/doltlite_regression_test_c.sh
@@ -2,6 +2,4 @@
 set -euo pipefail
 
 echo "=== DoltLite Regression Tests ==="
-cc -g -I. -I../src -o doltlite_regression_test_c \
-  ../test/doltlite_regression_test_c.c libdoltlite.a -lz -lpthread -lm
-./doltlite_regression_test_c all
+bash "$(dirname "$0")/run_doltlite_regression_case.sh" all

--- a/test/invariant_test.c
+++ b/test/invariant_test.c
@@ -28,7 +28,7 @@ static void check(const char *name, int condition){
 
 /* Execute SQL, return first column of first row as string (static buffer). */
 static char result_buf[8192];
-static const char *exec1(sqlite3 *db, const char *sql){
+static const char *queryScalarText(sqlite3 *db, const char *sql){
   sqlite3_stmt *stmt = 0;
   int rc;
   result_buf[0] = 0;
@@ -49,14 +49,14 @@ static const char *exec1(sqlite3 *db, const char *sql){
 }
 
 /* Execute SQL, return integer result. Returns -1 on error. */
-static int exec1_int(sqlite3 *db, const char *sql){
-  const char *r = exec1(db, sql);
+static int queryScalarInt(sqlite3 *db, const char *sql){
+  const char *r = queryScalarText(db, sql);
   if( strncmp(r, "ERROR", 5)==0 ) return -1;
   return atoi(r);
 }
 
 /* Execute SQL, ignore result. */
-static int execsql(sqlite3 *db, const char *sql){
+static int execSql(sqlite3 *db, const char *sql){
   char *err = 0;
   int rc = sqlite3_exec(db, sql, 0, 0, &err);
   if( rc!=SQLITE_OK ){
@@ -177,7 +177,7 @@ static int checkInvariants(sqlite3 *db, const char *context){
   /* --- Invariant 3: active_branch() returns a non-empty string
   **     that exists in dolt_branches --- */
   {
-    const char *branch = exec1(db, "SELECT active_branch()");
+    const char *branch = queryScalarText(db, "SELECT active_branch()");
     snprintf(label, sizeof(label), "%s: active_branch() non-empty", context);
     if( !branch || strlen(branch)==0 || strncmp(branch,"ERROR",5)==0 ){
       check(label, 0); violations++;
@@ -188,7 +188,7 @@ static int checkInvariants(sqlite3 *db, const char *context){
       char sql[512];
       snprintf(sql, sizeof(sql),
         "SELECT count(*) FROM dolt_branches WHERE name='%s'", branch);
-      int cnt = exec1_int(db, sql);
+      int cnt = queryScalarInt(db, sql);
       snprintf(label, sizeof(label),
         "%s: active_branch '%s' exists in dolt_branches", context, branch);
       if( cnt!=1 ){
@@ -211,7 +211,7 @@ static int checkInvariants(sqlite3 *db, const char *context){
         if( tname ){
           char sql[512];
           snprintf(sql, sizeof(sql), "SELECT count(*) FROM \"%s\"", tname);
-          int cnt = exec1_int(db, sql);
+          int cnt = queryScalarInt(db, sql);
           snprintf(label, sizeof(label),
             "%s: table '%s' is queryable", context, tname);
           if( cnt < 0 ){
@@ -255,7 +255,7 @@ static int checkInvariants(sqlite3 *db, const char *context){
 */
 static void checkCleanStatus(sqlite3 *db, const char *context){
   char label[256];
-  int cnt = exec1_int(db, "SELECT count(*) FROM dolt_status");
+  int cnt = queryScalarInt(db, "SELECT count(*) FROM dolt_status");
   snprintf(label, sizeof(label),
     "%s: dolt_status shows no uncommitted changes", context);
   check(label, cnt==0);
@@ -286,10 +286,10 @@ static void test_basic_commit(void){
   removeDb(dbpath);
 
   check("open_basic", sqlite3_open(dbpath, &db)==SQLITE_OK);
-  execsql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, name TEXT)");
-  execsql(db, "INSERT INTO t1 VALUES(1, 'alice')");
-  execsql(db, "INSERT INTO t1 VALUES(2, 'bob')");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'Initial commit')");
+  execSql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, name TEXT)");
+  execSql(db, "INSERT INTO t1 VALUES(1, 'alice')");
+  execSql(db, "INSERT INTO t1 VALUES(2, 'bob')");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'Initial commit')");
 
   checkInvariants(db, "basic_commit");
   checkCleanStatus(db, "basic_commit");
@@ -311,35 +311,35 @@ static void test_multi_branch(void){
   check("open_multibranch", sqlite3_open(dbpath, &db)==SQLITE_OK);
 
   /* Initial commit on main */
-  execsql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT)");
-  execsql(db, "INSERT INTO t1 VALUES(1, 'main-init')");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'init on main')");
+  execSql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT)");
+  execSql(db, "INSERT INTO t1 VALUES(1, 'main-init')");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'init on main')");
 
   /* Create branches */
-  exec1(db, "SELECT dolt_branch('dev')");
-  exec1(db, "SELECT dolt_branch('staging')");
+  queryScalarText(db, "SELECT dolt_branch('dev')");
+  queryScalarText(db, "SELECT dolt_branch('staging')");
 
   /* Commit on dev */
-  exec1(db, "SELECT dolt_checkout('dev')");
-  execsql(db, "INSERT INTO t1 VALUES(2, 'dev-row')");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'dev commit')");
+  queryScalarText(db, "SELECT dolt_checkout('dev')");
+  execSql(db, "INSERT INTO t1 VALUES(2, 'dev-row')");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'dev commit')");
   checkInvariants(db, "multibranch_dev");
   checkCleanStatus(db, "multibranch_dev");
 
   /* Commit on staging */
-  exec1(db, "SELECT dolt_checkout('staging')");
-  execsql(db, "INSERT INTO t1 VALUES(3, 'staging-row')");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'staging commit')");
+  queryScalarText(db, "SELECT dolt_checkout('staging')");
+  execSql(db, "INSERT INTO t1 VALUES(3, 'staging-row')");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'staging commit')");
   checkInvariants(db, "multibranch_staging");
   checkCleanStatus(db, "multibranch_staging");
 
   /* Back to main, verify */
-  exec1(db, "SELECT dolt_checkout('main')");
+  queryScalarText(db, "SELECT dolt_checkout('main')");
   checkInvariants(db, "multibranch_main");
   checkCleanStatus(db, "multibranch_main");
 
   /* Verify branch count */
-  check("three_branches", exec1_int(db, "SELECT count(*) FROM dolt_branches")==3);
+  check("three_branches", queryScalarInt(db, "SELECT count(*) FROM dolt_branches")==3);
 
   sqlite3_close(db);
   removeDb(dbpath);
@@ -357,24 +357,24 @@ static void test_merge(void){
 
   check("open_merge", sqlite3_open(dbpath, &db)==SQLITE_OK);
 
-  execsql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT)");
-  execsql(db, "INSERT INTO t1 VALUES(1, 'init')");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'init')");
+  execSql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT)");
+  execSql(db, "INSERT INTO t1 VALUES(1, 'init')");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'init')");
 
-  exec1(db, "SELECT dolt_branch('feature')");
-  exec1(db, "SELECT dolt_checkout('feature')");
-  execsql(db, "INSERT INTO t1 VALUES(2, 'feature-data')");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'feature commit')");
+  queryScalarText(db, "SELECT dolt_branch('feature')");
+  queryScalarText(db, "SELECT dolt_checkout('feature')");
+  execSql(db, "INSERT INTO t1 VALUES(2, 'feature-data')");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'feature commit')");
 
-  exec1(db, "SELECT dolt_checkout('main')");
-  execsql(db, "INSERT INTO t1 VALUES(3, 'main-data')");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'main commit')");
+  queryScalarText(db, "SELECT dolt_checkout('main')");
+  execSql(db, "INSERT INTO t1 VALUES(3, 'main-data')");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'main commit')");
 
-  exec1(db, "SELECT dolt_merge('feature')");
+  queryScalarText(db, "SELECT dolt_merge('feature')");
   checkInvariants(db, "after_merge");
 
   /* After merge commit, all 3 rows should exist */
-  check("merge_row_count", exec1_int(db, "SELECT count(*) FROM t1")==3);
+  check("merge_row_count", queryScalarInt(db, "SELECT count(*) FROM t1")==3);
 
   sqlite3_close(db);
   removeDb(dbpath);
@@ -392,21 +392,21 @@ static void test_insert_delete(void){
 
   check("open_del", sqlite3_open(dbpath, &db)==SQLITE_OK);
 
-  execsql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT)");
-  execsql(db, "INSERT INTO t1 VALUES(1, 'a')");
-  execsql(db, "INSERT INTO t1 VALUES(2, 'b')");
-  execsql(db, "INSERT INTO t1 VALUES(3, 'c')");
-  execsql(db, "INSERT INTO t1 VALUES(4, 'd')");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'add 4 rows')");
+  execSql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT)");
+  execSql(db, "INSERT INTO t1 VALUES(1, 'a')");
+  execSql(db, "INSERT INTO t1 VALUES(2, 'b')");
+  execSql(db, "INSERT INTO t1 VALUES(3, 'c')");
+  execSql(db, "INSERT INTO t1 VALUES(4, 'd')");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'add 4 rows')");
   checkInvariants(db, "insert_phase");
   checkCleanStatus(db, "insert_phase");
 
-  execsql(db, "DELETE FROM t1 WHERE id IN (2, 4)");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'delete rows 2 and 4')");
+  execSql(db, "DELETE FROM t1 WHERE id IN (2, 4)");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'delete rows 2 and 4')");
   checkInvariants(db, "delete_phase");
   checkCleanStatus(db, "delete_phase");
 
-  check("remaining_rows", exec1_int(db, "SELECT count(*) FROM t1")==2);
+  check("remaining_rows", queryScalarInt(db, "SELECT count(*) FROM t1")==2);
 
   sqlite3_close(db);
   removeDb(dbpath);
@@ -425,8 +425,8 @@ static void test_sequential_commits(void){
 
   check("open_seq", sqlite3_open(dbpath, &db)==SQLITE_OK);
 
-  execsql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT)");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'create table')");
+  execSql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT)");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'create table')");
   checkInvariants(db, "seq_0");
 
   for( i=1; i<=10; i++ ){
@@ -449,16 +449,16 @@ static void test_sequential_commits(void){
           "DELETE FROM t1 WHERE id=(SELECT max(id) FROM t1)");
         break;
     }
-    execsql(db, sql);
+    execSql(db, sql);
     snprintf(msg, sizeof(msg), "SELECT dolt_commit('-A', '-m', 'commit %d')", i);
-    exec1(db, msg);
+    queryScalarText(db, msg);
     snprintf(ctx, sizeof(ctx), "seq_%d", i);
     checkInvariants(db, ctx);
     checkCleanStatus(db, ctx);
   }
 
   /* Verify log has 11 commits (create + 10 sequential) */
-  check("seq_log_count", exec1_int(db, "SELECT count(*) FROM dolt_log")==11);
+  check("seq_log_count", queryScalarInt(db, "SELECT count(*) FROM dolt_log")==11);
 
   sqlite3_close(db);
   removeDb(dbpath);
@@ -476,25 +476,25 @@ static void test_schema_change(void){
 
   check("open_schema", sqlite3_open(dbpath, &db)==SQLITE_OK);
 
-  execsql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, name TEXT)");
-  execsql(db, "INSERT INTO t1 VALUES(1, 'alice')");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'init')");
+  execSql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, name TEXT)");
+  execSql(db, "INSERT INTO t1 VALUES(1, 'alice')");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'init')");
 
-  exec1(db, "SELECT dolt_branch('schema-change')");
-  exec1(db, "SELECT dolt_checkout('schema-change')");
-  execsql(db, "ALTER TABLE t1 ADD COLUMN age INTEGER DEFAULT 0");
-  execsql(db, "UPDATE t1 SET age=30 WHERE id=1");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'add age column')");
+  queryScalarText(db, "SELECT dolt_branch('schema-change')");
+  queryScalarText(db, "SELECT dolt_checkout('schema-change')");
+  execSql(db, "ALTER TABLE t1 ADD COLUMN age INTEGER DEFAULT 0");
+  execSql(db, "UPDATE t1 SET age=30 WHERE id=1");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'add age column')");
   checkInvariants(db, "schema_branch");
   checkCleanStatus(db, "schema_branch");
 
   /* Switch back to original branch */
-  exec1(db, "SELECT dolt_checkout('main')");
+  queryScalarText(db, "SELECT dolt_checkout('main')");
   checkInvariants(db, "schema_main_after");
   checkCleanStatus(db, "schema_main_after");
 
   /* Main should not have the age column */
-  const char *r = exec1(db, "SELECT age FROM t1");
+  const char *r = queryScalarText(db, "SELECT age FROM t1");
   check("main_no_age_column", strncmp(r, "ERROR", 5)==0);
 
   sqlite3_close(db);
@@ -513,20 +513,20 @@ static void test_gc(void){
 
   check("open_gc", sqlite3_open(dbpath, &db)==SQLITE_OK);
 
-  execsql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT)");
-  execsql(db, "INSERT INTO t1 VALUES(1, 'a')");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'c1')");
-  execsql(db, "INSERT INTO t1 VALUES(2, 'b')");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'c2')");
-  execsql(db, "INSERT INTO t1 VALUES(3, 'c')");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'c3')");
+  execSql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT)");
+  execSql(db, "INSERT INTO t1 VALUES(1, 'a')");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'c1')");
+  execSql(db, "INSERT INTO t1 VALUES(2, 'b')");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'c2')");
+  execSql(db, "INSERT INTO t1 VALUES(3, 'c')");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'c3')");
 
-  exec1(db, "SELECT dolt_gc()");
+  queryScalarText(db, "SELECT dolt_gc()");
   checkInvariants(db, "after_gc");
   checkCleanStatus(db, "after_gc");
 
-  check("gc_data_intact", exec1_int(db, "SELECT count(*) FROM t1")==3);
-  check("gc_log_intact", exec1_int(db, "SELECT count(*) FROM dolt_log")==3);
+  check("gc_data_intact", queryScalarInt(db, "SELECT count(*) FROM t1")==3);
+  check("gc_log_intact", queryScalarInt(db, "SELECT count(*) FROM dolt_log")==3);
 
   sqlite3_close(db);
   removeDb(dbpath);
@@ -544,26 +544,26 @@ static void test_reset_hard(void){
 
   check("open_reset", sqlite3_open(dbpath, &db)==SQLITE_OK);
 
-  execsql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT)");
-  execsql(db, "INSERT INTO t1 VALUES(1, 'original')");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'init')");
+  execSql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT)");
+  execSql(db, "INSERT INTO t1 VALUES(1, 'original')");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'init')");
 
   /* Make uncommitted changes */
-  execsql(db, "INSERT INTO t1 VALUES(2, 'uncommitted')");
-  execsql(db, "UPDATE t1 SET val='modified' WHERE id=1");
+  execSql(db, "INSERT INTO t1 VALUES(2, 'uncommitted')");
+  execSql(db, "UPDATE t1 SET val='modified' WHERE id=1");
 
   /* Verify dirty status before reset */
   check("dirty_before_reset",
-    exec1_int(db, "SELECT count(*) FROM dolt_status") > 0);
+    queryScalarInt(db, "SELECT count(*) FROM dolt_status") > 0);
 
-  exec1(db, "SELECT dolt_reset('--hard')");
+  queryScalarText(db, "SELECT dolt_reset('--hard')");
   checkInvariants(db, "after_reset");
   checkCleanStatus(db, "after_reset");
 
   /* Data reverted */
-  check("reset_data", strcmp(exec1(db, "SELECT val FROM t1 WHERE id=1"),
+  check("reset_data", strcmp(queryScalarText(db, "SELECT val FROM t1 WHERE id=1"),
                              "original")==0);
-  check("reset_row_count", exec1_int(db, "SELECT count(*) FROM t1")==1);
+  check("reset_row_count", queryScalarInt(db, "SELECT count(*) FROM t1")==1);
 
   sqlite3_close(db);
   removeDb(dbpath);
@@ -582,8 +582,8 @@ static void test_random_operations(void){
 
   check("open_random", sqlite3_open(dbpath, &db)==SQLITE_OK);
 
-  execsql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT)");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'init')");
+  execSql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT)");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'init')");
 
   srand(42); /* Deterministic seed */
   for( i=0; i<100; i++ ){
@@ -593,29 +593,29 @@ static void test_random_operations(void){
       case 0: /* INSERT */
         snprintf(sql, sizeof(sql),
           "INSERT OR IGNORE INTO t1 VALUES(%d, 'v%d')", rand()%500, i);
-        execsql(db, sql);
+        execSql(db, sql);
         break;
       case 1: /* UPDATE */
         snprintf(sql, sizeof(sql),
           "UPDATE t1 SET val='u%d' WHERE id=(SELECT id FROM t1 ORDER BY RANDOM() LIMIT 1)", i);
-        execsql(db, sql);
+        execSql(db, sql);
         break;
       case 2: /* DELETE */
-        execsql(db, "DELETE FROM t1 WHERE id=(SELECT id FROM t1 ORDER BY RANDOM() LIMIT 1)");
+        execSql(db, "DELETE FROM t1 WHERE id=(SELECT id FROM t1 ORDER BY RANDOM() LIMIT 1)");
         break;
       case 3: /* COMMIT */
         snprintf(sql, sizeof(sql),
           "SELECT dolt_commit('-A', '-m', 'random op %d')", i);
-        exec1(db, sql);
+        queryScalarText(db, sql);
         break;
       case 4: /* SELECT (read-only, verify no crash) */
-        exec1(db, "SELECT count(*) FROM t1");
+        queryScalarText(db, "SELECT count(*) FROM t1");
         break;
     }
   }
 
   /* Final commit to ensure everything is committed */
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'final random commit')");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'final random commit')");
   checkInvariants(db, "after_random_100");
   checkCleanStatus(db, "after_random_100");
 
@@ -635,24 +635,24 @@ static void test_multi_table(void){
 
   check("open_multi", sqlite3_open(dbpath, &db)==SQLITE_OK);
 
-  execsql(db, "CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT)");
-  execsql(db, "CREATE TABLE posts(id INTEGER PRIMARY KEY, uid INTEGER, title TEXT)");
-  execsql(db, "CREATE TABLE tags(id INTEGER PRIMARY KEY, pid INTEGER, tag TEXT)");
-  execsql(db, "INSERT INTO users VALUES(1,'alice')");
-  execsql(db, "INSERT INTO users VALUES(2,'bob')");
-  execsql(db, "INSERT INTO posts VALUES(1,1,'Hello')");
-  execsql(db, "INSERT INTO posts VALUES(2,2,'World')");
-  execsql(db, "INSERT INTO tags VALUES(1,1,'intro')");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'multi table init')");
+  execSql(db, "CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT)");
+  execSql(db, "CREATE TABLE posts(id INTEGER PRIMARY KEY, uid INTEGER, title TEXT)");
+  execSql(db, "CREATE TABLE tags(id INTEGER PRIMARY KEY, pid INTEGER, tag TEXT)");
+  execSql(db, "INSERT INTO users VALUES(1,'alice')");
+  execSql(db, "INSERT INTO users VALUES(2,'bob')");
+  execSql(db, "INSERT INTO posts VALUES(1,1,'Hello')");
+  execSql(db, "INSERT INTO posts VALUES(2,2,'World')");
+  execSql(db, "INSERT INTO tags VALUES(1,1,'intro')");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'multi table init')");
   checkInvariants(db, "multi_table");
   checkCleanStatus(db, "multi_table");
 
   /* Modify multiple tables */
-  execsql(db, "INSERT INTO users VALUES(3,'charlie')");
-  execsql(db, "INSERT INTO posts VALUES(3,3,'Third post')");
-  execsql(db, "INSERT INTO tags VALUES(2,3,'new')");
-  execsql(db, "DELETE FROM tags WHERE id=1");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'multi table update')");
+  execSql(db, "INSERT INTO users VALUES(3,'charlie')");
+  execSql(db, "INSERT INTO posts VALUES(3,3,'Third post')");
+  execSql(db, "INSERT INTO tags VALUES(2,3,'new')");
+  execSql(db, "DELETE FROM tags WHERE id=1");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'multi table update')");
   checkInvariants(db, "multi_table_updated");
   checkCleanStatus(db, "multi_table_updated");
 
@@ -672,35 +672,35 @@ static void test_diverge_merge(void){
 
   check("open_divmerge", sqlite3_open(dbpath, &db)==SQLITE_OK);
 
-  execsql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT)");
-  execsql(db, "INSERT INTO t1 VALUES(1, 'shared')");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'init')");
+  execSql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT)");
+  execSql(db, "INSERT INTO t1 VALUES(1, 'shared')");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'init')");
 
-  exec1(db, "SELECT dolt_branch('branch_a')");
-  exec1(db, "SELECT dolt_branch('branch_b')");
+  queryScalarText(db, "SELECT dolt_branch('branch_a')");
+  queryScalarText(db, "SELECT dolt_branch('branch_b')");
 
   /* Diverge on branch_a */
-  exec1(db, "SELECT dolt_checkout('branch_a')");
-  execsql(db, "INSERT INTO t1 VALUES(100, 'from_a')");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'branch_a work')");
+  queryScalarText(db, "SELECT dolt_checkout('branch_a')");
+  execSql(db, "INSERT INTO t1 VALUES(100, 'from_a')");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'branch_a work')");
   checkInvariants(db, "branch_a");
 
   /* Diverge on branch_b */
-  exec1(db, "SELECT dolt_checkout('branch_b')");
-  execsql(db, "INSERT INTO t1 VALUES(200, 'from_b')");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'branch_b work')");
+  queryScalarText(db, "SELECT dolt_checkout('branch_b')");
+  execSql(db, "INSERT INTO t1 VALUES(200, 'from_b')");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'branch_b work')");
   checkInvariants(db, "branch_b");
 
   /* Merge branch_a into main */
-  exec1(db, "SELECT dolt_checkout('main')");
-  exec1(db, "SELECT dolt_merge('branch_a')");
+  queryScalarText(db, "SELECT dolt_checkout('main')");
+  queryScalarText(db, "SELECT dolt_merge('branch_a')");
   checkInvariants(db, "merge_a_into_main");
 
   /* Merge branch_b into main */
-  exec1(db, "SELECT dolt_merge('branch_b')");
+  queryScalarText(db, "SELECT dolt_merge('branch_b')");
   checkInvariants(db, "merge_b_into_main");
 
-  check("merged_all_rows", exec1_int(db, "SELECT count(*) FROM t1")==3);
+  check("merged_all_rows", queryScalarInt(db, "SELECT count(*) FROM t1")==3);
 
   sqlite3_close(db);
   removeDb(dbpath);
@@ -718,22 +718,22 @@ static void test_gc_after_branch_delete(void){
 
   check("open_gcbr", sqlite3_open(dbpath, &db)==SQLITE_OK);
 
-  execsql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT)");
-  execsql(db, "INSERT INTO t1 VALUES(1, 'init')");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'init')");
+  execSql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT)");
+  execSql(db, "INSERT INTO t1 VALUES(1, 'init')");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'init')");
 
-  exec1(db, "SELECT dolt_branch('ephemeral')");
-  exec1(db, "SELECT dolt_checkout('ephemeral')");
-  execsql(db, "INSERT INTO t1 VALUES(2, 'ephemeral')");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'ephemeral commit')");
+  queryScalarText(db, "SELECT dolt_branch('ephemeral')");
+  queryScalarText(db, "SELECT dolt_checkout('ephemeral')");
+  execSql(db, "INSERT INTO t1 VALUES(2, 'ephemeral')");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'ephemeral commit')");
 
-  exec1(db, "SELECT dolt_checkout('main')");
-  exec1(db, "SELECT dolt_branch('-d', 'ephemeral')");
-  exec1(db, "SELECT dolt_gc()");
+  queryScalarText(db, "SELECT dolt_checkout('main')");
+  queryScalarText(db, "SELECT dolt_branch('-d', 'ephemeral')");
+  queryScalarText(db, "SELECT dolt_gc()");
 
   checkInvariants(db, "gc_after_branch_delete");
   checkCleanStatus(db, "gc_after_branch_delete");
-  check("gcbr_data", exec1_int(db, "SELECT count(*) FROM t1")==1);
+  check("gcbr_data", queryScalarInt(db, "SELECT count(*) FROM t1")==1);
 
   sqlite3_close(db);
   removeDb(dbpath);
@@ -750,10 +750,10 @@ static void test_persistence(void){
   removeDb(dbpath);
 
   check("open_persist1", sqlite3_open(dbpath, &db)==SQLITE_OK);
-  execsql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT)");
-  execsql(db, "INSERT INTO t1 VALUES(1, 'persistent')");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'persist commit')");
-  exec1(db, "SELECT dolt_branch('saved')");
+  execSql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT)");
+  execSql(db, "INSERT INTO t1 VALUES(1, 'persistent')");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'persist commit')");
+  queryScalarText(db, "SELECT dolt_branch('saved')");
   sqlite3_close(db);
 
   /* Reopen */
@@ -762,10 +762,10 @@ static void test_persistence(void){
   checkInvariants(db, "after_reopen");
   checkCleanStatus(db, "after_reopen");
 
-  check("persist_data", strcmp(exec1(db, "SELECT val FROM t1 WHERE id=1"),
+  check("persist_data", strcmp(queryScalarText(db, "SELECT val FROM t1 WHERE id=1"),
                                "persistent")==0);
   check("persist_branches",
-    exec1_int(db, "SELECT count(*) FROM dolt_branches")==2);
+    queryScalarInt(db, "SELECT count(*) FROM dolt_branches")==2);
 
   sqlite3_close(db);
   removeDb(dbpath);
@@ -784,19 +784,19 @@ static void test_large_table(void){
 
   check("open_large", sqlite3_open(dbpath, &db)==SQLITE_OK);
 
-  execsql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT)");
-  execsql(db, "BEGIN");
+  execSql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT)");
+  execSql(db, "BEGIN");
   for( i=0; i<500; i++ ){
     char sql[128];
     snprintf(sql, sizeof(sql), "INSERT INTO t1 VALUES(%d, 'row_%d')", i, i);
-    execsql(db, sql);
+    execSql(db, sql);
   }
-  execsql(db, "COMMIT");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'bulk insert 500 rows')");
+  execSql(db, "COMMIT");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'bulk insert 500 rows')");
 
   checkInvariants(db, "large_table");
   checkCleanStatus(db, "large_table");
-  check("large_count", exec1_int(db, "SELECT count(*) FROM t1")==500);
+  check("large_count", queryScalarInt(db, "SELECT count(*) FROM t1")==500);
 
   sqlite3_close(db);
   removeDb(dbpath);
@@ -814,20 +814,20 @@ static void test_drop_table(void){
 
   check("open_drop", sqlite3_open(dbpath, &db)==SQLITE_OK);
 
-  execsql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT)");
-  execsql(db, "CREATE TABLE t2(id INTEGER PRIMARY KEY, val TEXT)");
-  execsql(db, "INSERT INTO t1 VALUES(1, 'a')");
-  execsql(db, "INSERT INTO t2 VALUES(1, 'b')");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'two tables')");
+  execSql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT)");
+  execSql(db, "CREATE TABLE t2(id INTEGER PRIMARY KEY, val TEXT)");
+  execSql(db, "INSERT INTO t1 VALUES(1, 'a')");
+  execSql(db, "INSERT INTO t2 VALUES(1, 'b')");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'two tables')");
   checkInvariants(db, "before_drop");
 
-  execsql(db, "DROP TABLE t2");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'drop t2')");
+  execSql(db, "DROP TABLE t2");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'drop t2')");
   checkInvariants(db, "after_drop");
   checkCleanStatus(db, "after_drop");
 
   /* t2 should no longer exist */
-  const char *r = exec1(db, "SELECT count(*) FROM t2");
+  const char *r = queryScalarText(db, "SELECT count(*) FROM t2");
   check("t2_gone", strncmp(r, "ERROR", 5)==0);
 
   sqlite3_close(db);
@@ -846,22 +846,22 @@ static void test_staging(void){
 
   check("open_staging", sqlite3_open(dbpath, &db)==SQLITE_OK);
 
-  execsql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT)");
-  execsql(db, "INSERT INTO t1 VALUES(1, 'a')");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'init')");
+  execSql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT)");
+  execSql(db, "INSERT INTO t1 VALUES(1, 'a')");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'init')");
 
   /* Make changes, stage manually */
-  execsql(db, "INSERT INTO t1 VALUES(2, 'b')");
-  exec1(db, "SELECT dolt_add('t1')");
+  execSql(db, "INSERT INTO t1 VALUES(2, 'b')");
+  queryScalarText(db, "SELECT dolt_add('t1')");
 
   /* Status should show staged changes */
   check("staging_has_staged",
-    exec1_int(db, "SELECT count(*) FROM dolt_status WHERE staged=1") > 0);
+    queryScalarInt(db, "SELECT count(*) FROM dolt_status WHERE staged=1") > 0);
 
   checkInvariants(db, "with_staged_changes");
 
   /* Commit staged changes */
-  exec1(db, "SELECT dolt_commit('-m', 'staged commit')");
+  queryScalarText(db, "SELECT dolt_commit('-m', 'staged commit')");
   checkInvariants(db, "after_staged_commit");
   checkCleanStatus(db, "after_staged_commit");
 
@@ -881,34 +881,34 @@ static void test_reset_to_hash(void){
 
   check("open_resethash", sqlite3_open(dbpath, &db)==SQLITE_OK);
 
-  execsql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT)");
-  execsql(db, "INSERT INTO t1 VALUES(1, 'v1')");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'c1')");
+  execSql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT)");
+  execSql(db, "INSERT INTO t1 VALUES(1, 'v1')");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'c1')");
 
   /* Save first commit hash */
-  const char *h = exec1(db, "SELECT commit_hash FROM dolt_log LIMIT 1");
+  const char *h = queryScalarText(db, "SELECT commit_hash FROM dolt_log LIMIT 1");
   char hash1[64];
   snprintf(hash1, sizeof(hash1), "%s", h);
 
-  execsql(db, "INSERT INTO t1 VALUES(2, 'v2')");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'c2')");
+  execSql(db, "INSERT INTO t1 VALUES(2, 'v2')");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'c2')");
 
-  execsql(db, "INSERT INTO t1 VALUES(3, 'v3')");
-  exec1(db, "SELECT dolt_commit('-A', '-m', 'c3')");
+  execSql(db, "INSERT INTO t1 VALUES(3, 'v3')");
+  queryScalarText(db, "SELECT dolt_commit('-A', '-m', 'c3')");
 
   check("before_reset_3_commits",
-    exec1_int(db, "SELECT count(*) FROM dolt_log")==3);
+    queryScalarInt(db, "SELECT count(*) FROM dolt_log")==3);
 
   /* Reset to first commit */
   {
     char sql[256];
     snprintf(sql, sizeof(sql), "SELECT dolt_reset('--hard','%s')", hash1);
-    exec1(db, sql);
+    queryScalarText(db, sql);
   }
 
   checkInvariants(db, "after_reset_to_hash");
   checkCleanStatus(db, "after_reset_to_hash");
-  check("reset_to_c1", exec1_int(db, "SELECT count(*) FROM t1")==1);
+  check("reset_to_c1", queryScalarInt(db, "SELECT count(*) FROM t1")==1);
 
   sqlite3_close(db);
   removeDb(dbpath);

--- a/test/multi_process_test.c
+++ b/test/multi_process_test.c
@@ -37,7 +37,7 @@ static void check(const char *name, int condition){
   }
 }
 
-static int execsql(sqlite3 *db, const char *sql){
+static int execSql(sqlite3 *db, const char *sql){
   char *err = 0;
   int rc = sqlite3_exec(db, sql, 0, 0, &err);
   if( err ) sqlite3_free(err);
@@ -45,7 +45,7 @@ static int execsql(sqlite3 *db, const char *sql){
 }
 
 static char result_buf[4096];
-static const char *exec1(sqlite3 *db, const char *sql){
+static const char *queryScalarText(sqlite3 *db, const char *sql){
   sqlite3_stmt *s = 0;
   int rc;
   result_buf[0] = 0;
@@ -69,9 +69,9 @@ static void setup_db(const char *path){
   sqlite3 *db = 0;
   remove(path);
   sqlite3_open(path, &db);
-  execsql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)");
-  execsql(db, "INSERT INTO t VALUES(1, 'original')");
-  exec1(db, "SELECT dolt_commit('-A','-m','init')");
+  execSql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)");
+  execSql(db, "INSERT INTO t VALUES(1, 'original')");
+  queryScalarText(db, "SELECT dolt_commit('-A','-m','init')");
   sqlite3_close(db);
 }
 
@@ -92,10 +92,10 @@ static void test_two_writers(void){
     /* Child: open, begin write, hold it for 2 seconds */
     sqlite3 *db = 0;
     sqlite3_open(path, &db);
-    execsql(db, "BEGIN");
-    execsql(db, "INSERT INTO t VALUES(2, 'from_child')");
+    execSql(db, "BEGIN");
+    execSql(db, "INSERT INTO t VALUES(2, 'from_child')");
     sleep(2);
-    execsql(db, "COMMIT");
+    execSql(db, "COMMIT");
     sqlite3_close(db);
     _exit(0);
   }
@@ -108,7 +108,7 @@ static void test_two_writers(void){
     int rc;
     sqlite3_open(path, &db);
     sqlite3_busy_timeout(db, 100); /* Short timeout — should fail fast */
-    rc = execsql(db, "INSERT INTO t VALUES(3, 'from_parent')");
+    rc = execSql(db, "INSERT INTO t VALUES(3, 'from_parent')");
     check("mp_parent_busy", rc==SQLITE_BUSY);
     sqlite3_close(db);
   }
@@ -121,7 +121,7 @@ static void test_two_writers(void){
     sqlite3 *db = 0;
     int rc;
     sqlite3_open(path, &db);
-    rc = execsql(db, "INSERT INTO t VALUES(3, 'from_parent')");
+    rc = execSql(db, "INSERT INTO t VALUES(3, 'from_parent')");
     check("mp_parent_after_child", rc==SQLITE_OK);
     sqlite3_close(db);
   }
@@ -146,10 +146,10 @@ static void test_reader_during_write(void){
     /* Child: begin write, hold for 2 seconds, then commit */
     sqlite3 *db = 0;
     sqlite3_open(path, &db);
-    execsql(db, "BEGIN");
-    execsql(db, "INSERT INTO t VALUES(2, 'uncommitted')");
+    execSql(db, "BEGIN");
+    execSql(db, "INSERT INTO t VALUES(2, 'uncommitted')");
     sleep(2);
-    execsql(db, "COMMIT");
+    execSql(db, "COMMIT");
     sqlite3_close(db);
     _exit(0);
   }
@@ -161,9 +161,9 @@ static void test_reader_during_write(void){
     sqlite3 *db = 0;
     sqlite3_open(path, &db);
     check("mp_reader_sees_committed",
-      strcmp(exec1(db, "SELECT count(*) FROM t"), "1")==0);
+      strcmp(queryScalarText(db, "SELECT count(*) FROM t"), "1")==0);
     check("mp_reader_sees_original",
-      strcmp(exec1(db, "SELECT v FROM t WHERE id=1"), "original")==0);
+      strcmp(queryScalarText(db, "SELECT v FROM t WHERE id=1"), "original")==0);
     sqlite3_close(db);
   }
 
@@ -174,7 +174,7 @@ static void test_reader_during_write(void){
     sqlite3 *db = 0;
     sqlite3_open(path, &db);
     check("mp_after_child_commit",
-      strcmp(exec1(db, "SELECT count(*) FROM t"), "2")==0);
+      strcmp(queryScalarText(db, "SELECT count(*) FROM t"), "2")==0);
     sqlite3_close(db);
   }
 
@@ -197,8 +197,8 @@ static void test_sequential_processes(void){
   if( pid==0 ){
     sqlite3 *db = 0;
     sqlite3_open(path, &db);
-    execsql(db, "INSERT INTO t VALUES(2, 'from_child')");
-    exec1(db, "SELECT dolt_commit('-A','-m','child commit')");
+    execSql(db, "INSERT INTO t VALUES(2, 'from_child')");
+    queryScalarText(db, "SELECT dolt_commit('-A','-m','child commit')");
     sqlite3_close(db);
     _exit(0);
   }
@@ -210,13 +210,13 @@ static void test_sequential_processes(void){
   {
     sqlite3 *db = 0;
     sqlite3_open(path, &db);
-    execsql(db, "INSERT INTO t VALUES(3, 'from_parent')");
-    exec1(db, "SELECT dolt_commit('-A','-m','parent commit')");
+    execSql(db, "INSERT INTO t VALUES(3, 'from_parent')");
+    queryScalarText(db, "SELECT dolt_commit('-A','-m','parent commit')");
 
     check("mp_seq_count",
-      strcmp(exec1(db, "SELECT count(*) FROM t"), "3")==0);
+      strcmp(queryScalarText(db, "SELECT count(*) FROM t"), "3")==0);
     check("mp_seq_log",
-      strcmp(exec1(db, "SELECT count(*) FROM dolt_log"), "3")==0);
+      strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_log"), "3")==0);
     sqlite3_close(db);
   }
 
@@ -245,9 +245,9 @@ static void test_gc_during_read(void){
     for(i=2; i<=10; i++){
       char sql[128];
       snprintf(sql, sizeof(sql), "INSERT INTO t VALUES(%d, 'row_%d')", i, i);
-      execsql(db, sql);
+      execSql(db, sql);
     }
-    exec1(db, "SELECT dolt_commit('-A','-m','add rows')");
+    queryScalarText(db, "SELECT dolt_commit('-A','-m','add rows')");
     sqlite3_close(db);
   }
 
@@ -262,7 +262,7 @@ static void test_gc_during_read(void){
     sqlite3_open(path, &db);
 
     /* Verify we can read */
-    exec1(db, "SELECT count(*) FROM t");
+    queryScalarText(db, "SELECT count(*) FROM t");
 
     /* Signal parent: "I have the file open" */
     write(pipefd[1], "R", 1);
@@ -273,7 +273,7 @@ static void test_gc_during_read(void){
 
     /* After GC, can we still read? (POSIX: old fd still valid) */
     {
-      const char *r = exec1(db, "SELECT count(*) FROM t");
+      const char *r = queryScalarText(db, "SELECT count(*) FROM t");
       int ok = (strcmp(r, "10")==0);
       sqlite3_close(db);
       _exit(ok ? 0 : 1);
@@ -289,7 +289,7 @@ static void test_gc_during_read(void){
     close(pipefd[0]);
 
     sqlite3_open(path, &db);
-    exec1(db, "SELECT dolt_gc()");
+    queryScalarText(db, "SELECT dolt_gc()");
     sqlite3_close(db);
   }
 
@@ -301,7 +301,7 @@ static void test_gc_during_read(void){
     sqlite3 *db = 0;
     sqlite3_open(path, &db);
     check("mp_gc_data_intact",
-      strcmp(exec1(db, "SELECT count(*) FROM t"), "10")==0);
+      strcmp(queryScalarText(db, "SELECT count(*) FROM t"), "10")==0);
     sqlite3_close(db);
   }
 
@@ -330,15 +330,15 @@ static void test_gc_blocked_by_writer(void){
     sqlite3 *db = 0;
     close(pipefd[0]);
     sqlite3_open(path, &db);
-    execsql(db, "BEGIN");
-    execsql(db, "INSERT INTO t VALUES(2, 'blocking')");
+    execSql(db, "BEGIN");
+    execSql(db, "INSERT INTO t VALUES(2, 'blocking')");
 
     /* Signal parent: "I hold the write lock" */
     write(pipefd[1], "W", 1);
     close(pipefd[1]);
 
     sleep(2);
-    execsql(db, "COMMIT");
+    execSql(db, "COMMIT");
     sqlite3_close(db);
     _exit(0);
   }
@@ -354,7 +354,7 @@ static void test_gc_blocked_by_writer(void){
 
     sqlite3_open(path, &db);
     sqlite3_busy_timeout(db, 100); /* Short timeout */
-    r = exec1(db, "SELECT dolt_gc()");
+    r = queryScalarText(db, "SELECT dolt_gc()");
     /* GC should fail because child holds the write lock.
     ** It either returns an error or BUSY. */
     check("mp_gc_blocked",
@@ -370,9 +370,9 @@ static void test_gc_blocked_by_writer(void){
   {
     sqlite3 *db = 0;
     sqlite3_open(path, &db);
-    exec1(db, "SELECT dolt_gc()");
+    queryScalarText(db, "SELECT dolt_gc()");
     check("mp_gc_after_writer_ok",
-      strcmp(exec1(db, "SELECT count(*) FROM t"), "2")==0);
+      strcmp(queryScalarText(db, "SELECT count(*) FROM t"), "2")==0);
     sqlite3_close(db);
   }
 
@@ -402,8 +402,8 @@ static void test_cross_process_commit_conflict(void){
     char buf;
     close(pipefd[0]);
     sqlite3_open(path, &db);
-    execsql(db, "INSERT INTO t VALUES(2, 'child')");
-    exec1(db, "SELECT dolt_commit('-A','-m','child commit')");
+    execSql(db, "INSERT INTO t VALUES(2, 'child')");
+    queryScalarText(db, "SELECT dolt_commit('-A','-m','child commit')");
 
     /* Signal parent */
     write(pipefd[1], "C", 1);
@@ -427,8 +427,8 @@ static void test_cross_process_commit_conflict(void){
     waitpid(pid, &status, 0);
 
     /* Parent tries to commit — should detect conflict */
-    execsql(db, "INSERT INTO t VALUES(3, 'parent')");
-    r = exec1(db, "SELECT dolt_commit('-A','-m','parent commit')");
+    execSql(db, "INSERT INTO t VALUES(3, 'parent')");
+    r = queryScalarText(db, "SELECT dolt_commit('-A','-m','parent commit')");
     check("mp_conflict_detected",
       strstr(r, "conflict")!=0 || strstr(r, "ERR")!=0);
 
@@ -440,7 +440,7 @@ static void test_cross_process_commit_conflict(void){
     sqlite3 *db = 0;
     sqlite3_open(path, &db);
     check("mp_child_commit_survived",
-      strcmp(exec1(db, "SELECT count(*) FROM dolt_log"), "2")==0);
+      strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_log"), "2")==0);
     sqlite3_close(db);
   }
 

--- a/test/prepared_stmt_reuse_test.c
+++ b/test/prepared_stmt_reuse_test.c
@@ -55,7 +55,7 @@ static void check_str(const char *name, const char *got, const char *expected){
   }
 }
 
-static int execsql(sqlite3 *db, const char *sql){
+static int execSql(sqlite3 *db, const char *sql){
   char *err = 0;
   int rc = sqlite3_exec(db, sql, 0, 0, &err);
   if( rc!=SQLITE_OK ){
@@ -111,7 +111,7 @@ static void test_insert_reuse(void){
   rc = sqlite3_open(":memory:", &db);
   check("insert_reuse: open", rc==SQLITE_OK);
 
-  execsql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)");
+  execSql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)");
 
   rc = sqlite3_prepare_v2(db, "INSERT INTO t VALUES(?,?)", -1, &pIns, 0);
   check("insert_reuse: prepare insert", rc==SQLITE_OK);
@@ -162,11 +162,11 @@ static void test_update_delete_reuse(void){
   rc = sqlite3_open(":memory:", &db);
   check("upd_del_reuse: open", rc==SQLITE_OK);
 
-  execsql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT)");
+  execSql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT)");
   for(i=1; i<=10; i++){
     char sql[64];
     snprintf(sql, sizeof(sql), "INSERT INTO t VALUES(%d, %d)", i, i*10);
-    execsql(db, sql);
+    execSql(db, sql);
   }
 
   rc = sqlite3_prepare_v2(db, "UPDATE t SET v=? WHERE id=?", -1, &pUpd, 0);
@@ -223,9 +223,9 @@ static void test_vtable_reuse(void){
   rc = sqlite3_open("test_vtable_reuse.db", &db);
   check("vtable_reuse: open", rc==SQLITE_OK);
 
-  execsql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT)");
-  execsql(db, "INSERT INTO t VALUES(1, 10)");
-  execsql(db, "SELECT dolt_commit('-A','-m','c1')");
+  execSql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT)");
+  execSql(db, "INSERT INTO t VALUES(1, 10)");
+  execSql(db, "SELECT dolt_commit('-A','-m','c1')");
 
   /* Prepare vtable queries once */
   rc = sqlite3_prepare_v2(db, "SELECT count(*) FROM dolt_log", -1, &pLog, 0);
@@ -241,24 +241,24 @@ static void test_vtable_reuse(void){
   check_int("vtable_reuse: branch count pass 1", step_int(pBranch), 1);
 
   /* Mutate state: add a row (uncommitted) */
-  execsql(db, "INSERT INTO t VALUES(2, 20)");
+  execSql(db, "INSERT INTO t VALUES(2, 20)");
 
   /* Re-step the SAME prepared stmts — they should reflect new state */
   check_int("vtable_reuse: log count pass 2 (same)", step_int(pLog), 2);
   check_int("vtable_reuse: status count pass 2 (dirty)", step_int(pStatus), 1);
 
   /* Commit, re-step */
-  execsql(db, "SELECT dolt_commit('-A','-m','c2')");
+  execSql(db, "SELECT dolt_commit('-A','-m','c2')");
   check_int("vtable_reuse: log count pass 3", step_int(pLog), 3);
   check_int("vtable_reuse: status count pass 3 (clean)", step_int(pStatus), 0);
 
   /* Create a branch, re-step branches */
-  execsql(db, "SELECT dolt_branch('feature')");
+  execSql(db, "SELECT dolt_branch('feature')");
   check_int("vtable_reuse: branch count pass 2", step_int(pBranch), 2);
 
   /* Another commit, re-step everything */
-  execsql(db, "INSERT INTO t VALUES(3, 30)");
-  execsql(db, "SELECT dolt_commit('-A','-m','c3')");
+  execSql(db, "INSERT INTO t VALUES(3, 30)");
+  execSql(db, "SELECT dolt_commit('-A','-m','c3')");
   check_int("vtable_reuse: log count pass 4", step_int(pLog), 4);
   check_int("vtable_reuse: status count pass 4", step_int(pStatus), 0);
 
@@ -280,9 +280,9 @@ static void test_diff_table_reuse(void){
   rc = sqlite3_open("test_diff_reuse.db", &db);
   check("diff_reuse: open", rc==SQLITE_OK);
 
-  execsql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT)");
-  execsql(db, "INSERT INTO t VALUES(1, 10)");
-  execsql(db, "SELECT dolt_commit('-A','-m','c1')");
+  execSql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT)");
+  execSql(db, "INSERT INTO t VALUES(1, 10)");
+  execSql(db, "SELECT dolt_commit('-A','-m','c1')");
 
   /* Prepare a dolt_diff_t query once */
   rc = sqlite3_prepare_v2(db,
@@ -296,11 +296,11 @@ static void test_diff_table_reuse(void){
   }
 
   /* Add a row (working change) → diff includes WORKING */
-  execsql(db, "INSERT INTO t VALUES(2, 20)");
+  execSql(db, "INSERT INTO t VALUES(2, 20)");
   {
     int n1 = step_int(pDiff);
     /* Commit it */
-    execsql(db, "SELECT dolt_commit('-A','-m','c2')");
+    execSql(db, "SELECT dolt_commit('-A','-m','c2')");
     int n2 = step_int(pDiff);
     /* After commit, WORKING row disappears but committed row appears */
     check("diff_reuse: pass 2 more rows after working", n1 > 0);
@@ -308,8 +308,8 @@ static void test_diff_table_reuse(void){
   }
 
   /* Another round */
-  execsql(db, "UPDATE t SET v=99 WHERE id=1");
-  execsql(db, "SELECT dolt_commit('-A','-m','c3')");
+  execSql(db, "UPDATE t SET v=99 WHERE id=1");
+  execSql(db, "SELECT dolt_commit('-A','-m','c3')");
   {
     int n = step_int(pDiff);
     check("diff_reuse: pass 4 after update+commit", n > 0);
@@ -331,9 +331,9 @@ static void test_diff_summary_reuse(void){
   rc = sqlite3_open("test_diff_summary_reuse.db", &db);
   check("diff_summary_reuse: open", rc==SQLITE_OK);
 
-  execsql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT)");
-  execsql(db, "INSERT INTO t VALUES(1, 10)");
-  execsql(db, "SELECT dolt_commit('-A','-m','c1')");
+  execSql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT)");
+  execSql(db, "INSERT INTO t VALUES(1, 10)");
+  execSql(db, "SELECT dolt_commit('-A','-m','c1')");
 
   /* Prepare dolt_diff summary query once. The no-arg summary form was
   ** added in PR #387; on earlier builds it returns 0 rows. Detect
@@ -358,16 +358,16 @@ static void test_diff_summary_reuse(void){
   }
 
   /* Commit more → 2 summary rows */
-  execsql(db, "INSERT INTO t VALUES(2, 20)");
-  execsql(db, "SELECT dolt_commit('-A','-m','c2')");
+  execSql(db, "INSERT INTO t VALUES(2, 20)");
+  execSql(db, "SELECT dolt_commit('-A','-m','c2')");
   check_int("diff_summary_reuse: pass 2", step_int(pDiff), 2);
 
   /* With working changes → includes WORKING row */
-  execsql(db, "UPDATE t SET v=99 WHERE id=1");
+  execSql(db, "UPDATE t SET v=99 WHERE id=1");
   check_int("diff_summary_reuse: pass 3 working", step_int(pDiff), 3);
 
   /* Commit → WORKING disappears, c3 appears: still 3 */
-  execsql(db, "SELECT dolt_commit('-A','-m','c3')");
+  execSql(db, "SELECT dolt_commit('-A','-m','c3')");
   check_int("diff_summary_reuse: pass 4", step_int(pDiff), 3);
 
   sqlite3_finalize(pDiff);
@@ -387,7 +387,7 @@ static void test_commit_reuse(void){
   rc = sqlite3_open("test_commit_reuse.db", &db);
   check("commit_reuse: open", rc==SQLITE_OK);
 
-  execsql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT)");
+  execSql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT)");
 
   /* Prepare dolt_commit('-A','-m',?) with bound message */
   rc = sqlite3_prepare_v2(db,
@@ -399,7 +399,7 @@ static void test_commit_reuse(void){
   check("commit_reuse: prepare log", rc==SQLITE_OK);
 
   /* Commit 1 */
-  execsql(db, "INSERT INTO t VALUES(1, 10)");
+  execSql(db, "INSERT INTO t VALUES(1, 10)");
   sqlite3_bind_text(pCommit, 1, "c1", -1, SQLITE_STATIC);
   rc = sqlite3_step(pCommit);
   check("commit_reuse: step c1", rc==SQLITE_ROW);
@@ -407,7 +407,7 @@ static void test_commit_reuse(void){
   check_int("commit_reuse: log after c1", step_int(pLog), 2);
 
   /* Commit 2 — reuse the same prepared stmt */
-  execsql(db, "INSERT INTO t VALUES(2, 20)");
+  execSql(db, "INSERT INTO t VALUES(2, 20)");
   sqlite3_bind_text(pCommit, 1, "c2", -1, SQLITE_STATIC);
   rc = sqlite3_step(pCommit);
   check("commit_reuse: step c2", rc==SQLITE_ROW);
@@ -415,7 +415,7 @@ static void test_commit_reuse(void){
   check_int("commit_reuse: log after c2", step_int(pLog), 3);
 
   /* Commit 3 */
-  execsql(db, "INSERT INTO t VALUES(3, 30)");
+  execSql(db, "INSERT INTO t VALUES(3, 30)");
   sqlite3_bind_text(pCommit, 1, "c3", -1, SQLITE_STATIC);
   rc = sqlite3_step(pCommit);
   check("commit_reuse: step c3", rc==SQLITE_ROW);
@@ -452,8 +452,8 @@ static void test_rapid_interleave(void){
   rc = sqlite3_open("test_interleave.db", &db);
   check("interleave: open", rc==SQLITE_OK);
 
-  execsql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT)");
-  execsql(db, "SELECT dolt_commit('-A','-m','init_t')");
+  execSql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT)");
+  execSql(db, "SELECT dolt_commit('-A','-m','init_t')");
 
   rc = sqlite3_prepare_v2(db, "SELECT count(*) FROM t", -1, &pCnt, 0);
   check("interleave: prepare count", rc==SQLITE_OK);
@@ -477,7 +477,7 @@ static void test_rapid_interleave(void){
       char sql[128];
       snprintf(sql, sizeof(sql),
                "SELECT dolt_commit('-A','-m','%s')", msg);
-      execsql(db, sql);
+      execSql(db, sql);
     }
   }
 
@@ -500,9 +500,9 @@ static void test_partial_step(void){
   rc = sqlite3_open("test_partial.db", &db);
   check("partial: open", rc==SQLITE_OK);
 
-  execsql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT)");
-  execsql(db, "INSERT INTO t VALUES(1,10),(2,20),(3,30),(4,40),(5,50)");
-  execsql(db, "SELECT dolt_commit('-A','-m','c1')");
+  execSql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT)");
+  execSql(db, "INSERT INTO t VALUES(1,10),(2,20),(3,30),(4,40),(5,50)");
+  execSql(db, "SELECT dolt_commit('-A','-m','c1')");
 
   rc = sqlite3_prepare_v2(db,
     "SELECT id FROM t ORDER BY id", -1, &pSel, 0);

--- a/test/run_doltlite_regression_case.sh
+++ b/test/run_doltlite_regression_case.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+case_name="${1:-all}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+build_dir="${DOLTLITE_BUILD_DIR:-$repo_root/build}"
+
+if [ ! -d "$build_dir" ]; then
+  echo "ERROR: build directory not found: $build_dir"
+  exit 1
+fi
+
+cc -g -I"$build_dir" -I"$repo_root/src" -o "$build_dir/doltlite_regression_test_c" \
+  "$repo_root/test/doltlite_regression_test_c.c" "$build_dir/libdoltlite.a" \
+  -lz -lpthread -lm
+"$build_dir/doltlite_regression_test_c" "$case_name"

--- a/test/savepoint_catalog_restore_test.sh
+++ b/test/savepoint_catalog_restore_test.sh
@@ -2,6 +2,4 @@
 set -euo pipefail
 
 echo "=== Savepoint Catalog Restore Repro ==="
-cc -g -I. -I../src -o doltlite_regression_test_c \
-  ../test/doltlite_regression_test_c.c libdoltlite.a -lz -lpthread -lm
-./doltlite_regression_test_c savepoint_catalog_restore
+bash "$(dirname "$0")/run_doltlite_regression_case.sh" savepoint_catalog_restore

--- a/test/sql_transaction_test.c
+++ b/test/sql_transaction_test.c
@@ -26,7 +26,7 @@ static void check(const char *name, int condition){
   }
 }
 
-static int execsql(sqlite3 *db, const char *sql){
+static int execSql(sqlite3 *db, const char *sql){
   char *err = 0;
   int rc = sqlite3_exec(db, sql, 0, 0, &err);
   if( err ) sqlite3_free(err);
@@ -34,7 +34,7 @@ static int execsql(sqlite3 *db, const char *sql){
 }
 
 /* Execute with busy retry */
-static int execsql_retry(sqlite3 *db, const char *sql, int maxRetries){
+static int execSqlWithRetry(sqlite3 *db, const char *sql, int maxRetries){
   char *err = 0;
   int rc;
   int attempts = 0;
@@ -54,7 +54,7 @@ static int execsql_retry(sqlite3 *db, const char *sql, int maxRetries){
 }
 
 static char result_buf[4096];
-static const char *exec1(sqlite3 *db, const char *sql){
+static const char *queryScalarText(sqlite3 *db, const char *sql){
   sqlite3_stmt *s = 0;
   int rc;
   result_buf[0] = 0;
@@ -89,32 +89,32 @@ static void test_insert_conflict(void){
   remove(path);
 
   a = open_db(path);
-  execsql(a, "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)");
-  exec1(a, "SELECT dolt_commit('-A','-m','init')");
+  execSql(a, "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)");
+  queryScalarText(a, "SELECT dolt_commit('-A','-m','init')");
 
   b = open_db(path);
 
-  execsql(a, "BEGIN");
-  execsql(b, "BEGIN");
+  execSql(a, "BEGIN");
+  execSql(b, "BEGIN");
 
-  rc_a_ins = execsql(a, "INSERT INTO t VALUES(1, 'from_a')");
+  rc_a_ins = execSql(a, "INSERT INTO t VALUES(1, 'from_a')");
   check("insert_a_ok", rc_a_ins==SQLITE_OK);
 
   /* B's INSERT should get BUSY because A holds the write lock */
-  rc_b_ins = execsql(b, "INSERT INTO t VALUES(1, 'from_b')");
+  rc_b_ins = execSql(b, "INSERT INTO t VALUES(1, 'from_b')");
   check("insert_b_busy", rc_b_ins==SQLITE_BUSY);
 
-  execsql(a, "COMMIT");
+  execSql(a, "COMMIT");
 
   /* After A commits and releases the lock, B can retry */
-  rc_b_ins = execsql(b, "INSERT INTO t VALUES(1, 'from_b')");
+  rc_b_ins = execSql(b, "INSERT INTO t VALUES(1, 'from_b')");
   /* B's INSERT should fail with SQLITE_CONSTRAINT (PK already exists) */
   check("insert_b_constraint", rc_b_ins!=SQLITE_OK);
 
-  execsql(b, "ROLLBACK");
+  execSql(b, "ROLLBACK");
 
   check("insert_a_wins",
-    strcmp(exec1(a, "SELECT v FROM t WHERE id=1"), "from_a")==0);
+    strcmp(queryScalarText(a, "SELECT v FROM t WHERE id=1"), "from_a")==0);
 
   sqlite3_close(a);
   sqlite3_close(b);
@@ -134,28 +134,28 @@ static void test_update_conflict(void){
   remove(path);
 
   a = open_db(path);
-  execsql(a, "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)");
-  execsql(a, "INSERT INTO t VALUES(1, 'original')");
-  exec1(a, "SELECT dolt_commit('-A','-m','init')");
+  execSql(a, "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)");
+  execSql(a, "INSERT INTO t VALUES(1, 'original')");
+  queryScalarText(a, "SELECT dolt_commit('-A','-m','init')");
   sqlite3_close(a);
 
   a = open_db(path);
   b = open_db(path);
 
-  execsql(a, "BEGIN");
-  execsql(b, "BEGIN");
+  execSql(a, "BEGIN");
+  execSql(b, "BEGIN");
 
-  rc = execsql(a, "UPDATE t SET v='updated_a' WHERE id=1");
+  rc = execSql(a, "UPDATE t SET v='updated_a' WHERE id=1");
   check("update_a_ok", rc==SQLITE_OK);
 
-  rc = execsql(b, "UPDATE t SET v='updated_b' WHERE id=1");
+  rc = execSql(b, "UPDATE t SET v='updated_b' WHERE id=1");
   check("update_b_busy", rc==SQLITE_BUSY);
 
-  execsql(a, "COMMIT");
-  execsql(b, "ROLLBACK");
+  execSql(a, "COMMIT");
+  execSql(b, "ROLLBACK");
 
   check("update_a_wins",
-    strcmp(exec1(a, "SELECT v FROM t WHERE id=1"), "updated_a")==0);
+    strcmp(queryScalarText(a, "SELECT v FROM t WHERE id=1"), "updated_a")==0);
 
   sqlite3_close(a);
   sqlite3_close(b);
@@ -175,28 +175,28 @@ static void test_delete_update_conflict(void){
   remove(path);
 
   a = open_db(path);
-  execsql(a, "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)");
-  execsql(a, "INSERT INTO t VALUES(1, 'original')");
-  exec1(a, "SELECT dolt_commit('-A','-m','init')");
+  execSql(a, "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)");
+  execSql(a, "INSERT INTO t VALUES(1, 'original')");
+  queryScalarText(a, "SELECT dolt_commit('-A','-m','init')");
   sqlite3_close(a);
 
   a = open_db(path);
   b = open_db(path);
 
-  execsql(a, "BEGIN");
-  execsql(b, "BEGIN");
+  execSql(a, "BEGIN");
+  execSql(b, "BEGIN");
 
-  rc = execsql(a, "DELETE FROM t WHERE id=1");
+  rc = execSql(a, "DELETE FROM t WHERE id=1");
   check("delupd_a_ok", rc==SQLITE_OK);
 
-  rc = execsql(b, "UPDATE t SET v='updated_b' WHERE id=1");
+  rc = execSql(b, "UPDATE t SET v='updated_b' WHERE id=1");
   check("delupd_b_busy", rc==SQLITE_BUSY);
 
-  execsql(a, "COMMIT");
-  execsql(b, "ROLLBACK");
+  execSql(a, "COMMIT");
+  execSql(b, "ROLLBACK");
 
   check("delupd_row_gone",
-    strcmp(exec1(a, "SELECT count(*) FROM t WHERE id=1"), "0")==0);
+    strcmp(queryScalarText(a, "SELECT count(*) FROM t WHERE id=1"), "0")==0);
 
   sqlite3_close(a);
   sqlite3_close(b);
@@ -218,26 +218,26 @@ static void test_non_conflicting_inserts(void){
   a = open_db(path);
   b = open_db(path);
 
-  execsql(a, "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)");
-  exec1(a, "SELECT dolt_commit('-A','-m','init')");
+  execSql(a, "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)");
+  queryScalarText(a, "SELECT dolt_commit('-A','-m','init')");
 
   /* A inserts and commits first */
-  execsql(a, "BEGIN");
-  execsql(a, "INSERT INTO t VALUES(1, 'from_a')");
-  rc = execsql(a, "COMMIT");
+  execSql(a, "BEGIN");
+  execSql(a, "INSERT INTO t VALUES(1, 'from_a')");
+  rc = execSql(a, "COMMIT");
   check("noconflict_a_ok", rc==SQLITE_OK);
 
   /* B inserts different PK — should succeed now that A released */
-  execsql(b, "BEGIN");
-  rc = execsql(b, "INSERT INTO t VALUES(2, 'from_b')");
+  execSql(b, "BEGIN");
+  rc = execSql(b, "INSERT INTO t VALUES(2, 'from_b')");
   check("noconflict_b_insert_ok", rc==SQLITE_OK);
-  rc = execsql(b, "COMMIT");
+  rc = execSql(b, "COMMIT");
   check("noconflict_b_commit_ok", rc==SQLITE_OK);
 
   {
     sqlite3 *c = open_db(path);
     check("noconflict_both_exist",
-      strcmp(exec1(c, "SELECT count(*) FROM t"), "2")==0);
+      strcmp(queryScalarText(c, "SELECT count(*) FROM t"), "2")==0);
     sqlite3_close(c);
   }
 
@@ -260,25 +260,25 @@ static void test_sequential_transactions(void){
   a = open_db(path);
   b = open_db(path);
 
-  execsql(a, "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)");
-  exec1(a, "SELECT dolt_commit('-A','-m','init')");
+  execSql(a, "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)");
+  queryScalarText(a, "SELECT dolt_commit('-A','-m','init')");
 
-  execsql(a, "BEGIN");
-  execsql(a, "INSERT INTO t VALUES(1, 'from_a')");
-  rc = execsql(a, "COMMIT");
+  execSql(a, "BEGIN");
+  execSql(a, "INSERT INTO t VALUES(1, 'from_a')");
+  rc = execSql(a, "COMMIT");
   check("seq_a_ok", rc==SQLITE_OK);
 
-  execsql(b, "BEGIN");
-  rc = execsql(b, "INSERT INTO t VALUES(2, 'from_b')");
+  execSql(b, "BEGIN");
+  rc = execSql(b, "INSERT INTO t VALUES(2, 'from_b')");
   check("seq_b_insert_ok", rc==SQLITE_OK);
-  rc = execsql(b, "COMMIT");
+  rc = execSql(b, "COMMIT");
   check("seq_b_commit_ok", rc==SQLITE_OK);
 
   /* Reopen to see both commits */
   {
     sqlite3 *c = open_db(path);
     check("seq_count",
-      strcmp(exec1(c, "SELECT count(*) FROM t"), "2")==0);
+      strcmp(queryScalarText(c, "SELECT count(*) FROM t"), "2")==0);
     sqlite3_close(c);
   }
 
@@ -300,18 +300,18 @@ static void test_read_during_write(void){
   a = open_db(path);
   b = open_db(path);
 
-  execsql(a, "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)");
-  execsql(a, "INSERT INTO t VALUES(1, 'original')");
-  exec1(a, "SELECT dolt_commit('-A','-m','init')");
+  execSql(a, "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)");
+  execSql(a, "INSERT INTO t VALUES(1, 'original')");
+  queryScalarText(a, "SELECT dolt_commit('-A','-m','init')");
 
-  execsql(a, "BEGIN");
-  execsql(a, "INSERT INTO t VALUES(2, 'new_row')");
+  execSql(a, "BEGIN");
+  execSql(a, "INSERT INTO t VALUES(2, 'new_row')");
 
   /* B should still be able to read (read doesn't need write lock) */
   check("read_during_write",
-    strcmp(exec1(b, "SELECT count(*) FROM t"), "0")!=0);
+    strcmp(queryScalarText(b, "SELECT count(*) FROM t"), "0")!=0);
 
-  execsql(a, "COMMIT");
+  execSql(a, "COMMIT");
 
   sqlite3_close(a);
   sqlite3_close(b);
@@ -332,22 +332,22 @@ static void test_rollback_releases(void){
   a = open_db(path);
   b = open_db(path);
 
-  execsql(a, "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)");
-  exec1(a, "SELECT dolt_commit('-A','-m','init')");
+  execSql(a, "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)");
+  queryScalarText(a, "SELECT dolt_commit('-A','-m','init')");
 
-  execsql(a, "BEGIN");
-  execsql(a, "INSERT INTO t VALUES(1, 'will_rollback')");
-  execsql(a, "ROLLBACK");
+  execSql(a, "BEGIN");
+  execSql(a, "INSERT INTO t VALUES(1, 'will_rollback')");
+  execSql(a, "ROLLBACK");
 
   /* B should be able to acquire write lock now */
-  execsql(b, "BEGIN");
-  rc = execsql(b, "INSERT INTO t VALUES(1, 'from_b')");
+  execSql(b, "BEGIN");
+  rc = execSql(b, "INSERT INTO t VALUES(1, 'from_b')");
   check("rollback_b_insert_ok", rc==SQLITE_OK);
-  rc = execsql(b, "COMMIT");
+  rc = execSql(b, "COMMIT");
   check("rollback_b_commit_ok", rc==SQLITE_OK);
 
   check("rollback_b_value",
-    strcmp(exec1(b, "SELECT v FROM t WHERE id=1"), "from_b")==0);
+    strcmp(queryScalarText(b, "SELECT v FROM t WHERE id=1"), "from_b")==0);
 
   sqlite3_close(a);
   sqlite3_close(b);
@@ -368,23 +368,23 @@ static void test_busy_retry(void){
   a = open_db(path);
   b = open_db(path);
 
-  execsql(a, "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)");
-  exec1(a, "SELECT dolt_commit('-A','-m','init')");
+  execSql(a, "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)");
+  queryScalarText(a, "SELECT dolt_commit('-A','-m','init')");
 
-  execsql(a, "BEGIN");
-  execsql(a, "INSERT INTO t VALUES(1, 'from_a')");
+  execSql(a, "BEGIN");
+  execSql(a, "INSERT INTO t VALUES(1, 'from_a')");
 
   /* B's INSERT will get BUSY, but busy_timeout should wait */
   /* Since A hasn't committed yet, B will timeout. Use short timeout. */
   sqlite3_busy_timeout(b, 100);
-  rc = execsql(b, "INSERT INTO t VALUES(2, 'from_b')");
+  rc = execSql(b, "INSERT INTO t VALUES(2, 'from_b')");
   check("retry_b_busy_timeout", rc==SQLITE_BUSY);
 
   /* Now A commits */
-  execsql(a, "COMMIT");
+  execSql(a, "COMMIT");
 
   /* B can now retry and succeed */
-  rc = execsql_retry(b, "INSERT INTO t VALUES(2, 'from_b')", 50);
+  rc = execSqlWithRetry(b, "INSERT INTO t VALUES(2, 'from_b')", 50);
   check("retry_b_succeeds_after", rc==SQLITE_OK);
 
   sqlite3_close(a);


### PR DESCRIPTION
## Summary
- extract a shared wrapper for compiling/running doltlite_regression_test_c cases
- reuse the commit-ancestor enqueue helper for parent traversal
- move the duplicated socket write loop into shared remote code
- rename vague C test helpers like exec1/execsql/remove_db to behavior-oriented names
- collapse repeated branch durable-state assertions in the C regression harness

## Tests
- make doltlite
- make libdoltlite.a (from build/)
- bash ../test/doltlite_regression_test_c.sh (from build/)
- bash test/doltlite_regression_test_c.sh
- bash test/concurrent_refs_test.sh
- compiled renamed standalone C tests against build/libdoltlite.a
- bash test/checkout_persist_failure_test.sh
- bash test/savepoint_catalog_restore_test.sh
- bash test/review_regression_test.sh
- bash test/http_remote_test.sh
- bash test/doltlite_parity.sh
- bash -n regression wrapper scripts
- git diff --check