### PR TITLE
ci: wire 8 orphan C tests into the test suite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,6 +127,16 @@ jobs:
           libdoltlite.a -lz -lpthread -lm
         ./prepared_stmt_reuse_test
 
+    # Wires the 8 previously-orphan C tests (concurrent_stress_test,
+    # invariant_test, corruption_test, cross_branch_test,
+    # multi_process_test, ancestor_test, three_way_diff_test,
+    # sql_transaction_test) into CI. The runner script splits them into
+    # GATING (must pass) and EXPECTED_FAIL (preexisting failures still
+    # surfaced but not blocking until the underlying bugs are fixed).
+    - name: Orphan C tests
+      run: cd build && make c-tests
+      timeout-minutes: 15
+
     - name: Python integration test
       run: cd build && LD_PRELOAD=./libdoltlite.so python3 ../examples/quickstart.py
 

--- a/main.mk
+++ b/main.mk
@@ -2562,6 +2562,74 @@ crash_recovery_test_sqlite_test$(T.exe): $(T.tcl.env.sh) has_tclsh85 $(TOP)/test
 		-lz -lpthread -lm
 
 #
+# Doltlite orphan C tests
+#
+# These adversarial C tests live under test/ but were historically not built
+# or run by any CI job. They link directly against libdoltlite.a and call into
+# the SQLite C API. Several of them surface real bugs on master; see
+# test/run_c_tests.sh for the gating-vs-non-blocking split.
+#
+# All of these share a simple compile recipe: link against the static
+# libdoltlite.a, with -lz/-lpthread/-lm.
+#
+DOLTLITE_C_TESTS = \
+	ancestor_test$(T.exe) \
+	sql_transaction_test$(T.exe) \
+	cross_branch_test$(T.exe) \
+	multi_process_test$(T.exe) \
+	invariant_test$(T.exe) \
+	corruption_test$(T.exe) \
+	concurrent_stress_test$(T.exe) \
+	three_way_diff_test$(T.exe)
+
+ancestor_test$(T.exe): $(TOP)/test/ancestor_test.c libdoltlite$(T.lib)
+	$(T.link) -I. -I$(TOP)/src -o $@ $(TOP)/test/ancestor_test.c \
+		libdoltlite$(T.lib) -lz -lpthread -lm
+
+sql_transaction_test$(T.exe): $(TOP)/test/sql_transaction_test.c libdoltlite$(T.lib)
+	$(T.link) -I. -I$(TOP)/src -o $@ $(TOP)/test/sql_transaction_test.c \
+		libdoltlite$(T.lib) -lz -lpthread -lm
+
+cross_branch_test$(T.exe): $(TOP)/test/cross_branch_test.c libdoltlite$(T.lib)
+	$(T.link) -I. -I$(TOP)/src -o $@ $(TOP)/test/cross_branch_test.c \
+		libdoltlite$(T.lib) -lz -lpthread -lm
+
+multi_process_test$(T.exe): $(TOP)/test/multi_process_test.c libdoltlite$(T.lib)
+	$(T.link) -I. -I$(TOP)/src -o $@ $(TOP)/test/multi_process_test.c \
+		libdoltlite$(T.lib) -lz -lpthread -lm
+
+invariant_test$(T.exe): $(TOP)/test/invariant_test.c libdoltlite$(T.lib)
+	$(T.link) -I. -I$(TOP)/src -o $@ $(TOP)/test/invariant_test.c \
+		libdoltlite$(T.lib) -lz -lpthread -lm
+
+corruption_test$(T.exe): $(TOP)/test/corruption_test.c libdoltlite$(T.lib)
+	$(T.link) -I. -I$(TOP)/src -o $@ $(TOP)/test/corruption_test.c \
+		libdoltlite$(T.lib) -lz -lpthread -lm
+
+concurrent_stress_test$(T.exe): $(TOP)/test/concurrent_stress_test.c libdoltlite$(T.lib)
+	$(T.link) -I. -I$(TOP)/src -o $@ $(TOP)/test/concurrent_stress_test.c \
+		libdoltlite$(T.lib) -lz -lpthread -lm
+
+# three_way_diff_test pokes prolly internals directly; needs sqliteInt.h
+# (-I. brings in sqlite_cfg.h, -I$(TOP)/src brings in sqliteInt.h and the
+# prolly_*.h headers) and the LIBOBJS0 objects (not the static archive, since
+# the test references prolly_* symbols that the linker may otherwise drop).
+three_way_diff_test$(T.exe): $(TOP)/test/three_way_diff_test.c $(LIBOBJS0)
+	$(T.link) -I. -I$(TOP)/src -DDOLTLITE_PROLLY=1 -D_HAVE_SQLITE_CONFIG_H \
+		-o $@ $(TOP)/test/three_way_diff_test.c $(LIBOBJS0) \
+		-lz -lpthread -lm
+
+doltlite-c-tests-build: $(DOLTLITE_C_TESTS)
+
+# Run all orphan C tests via the gating-aware runner script. The script
+# decides which failures gate CI and which are reported but tolerated
+# (because the failure was preexisting at the time the test was wired in).
+# To make a tolerated test gating, move it out of the EXPECTED_FAIL set in
+# test/run_c_tests.sh after fixing the underlying bug.
+c-tests: doltlite-c-tests-build
+	bash $(TOP)/test/run_c_tests.sh .
+
+#
 # libdoltlite: static and shared libraries with prolly tree engine.
 # These use the non-amalgamation objects (LIBOBJS0) which include the
 # Dolt version control functions, unlike libsqlite3 which uses the

--- a/test/run_c_tests.sh
+++ b/test/run_c_tests.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+#
+# Runner for the 8 orphan C tests that were previously not wired into CI.
+#
+# Two categories:
+#
+#   GATING            - currently passes on master. A failure here breaks CI.
+#   EXPECTED_FAIL     - currently has preexisting failures or crashes on
+#                       master. Run anyway (because the whole point of wiring
+#                       these in is to surface bugs), but a nonzero exit
+#                       does NOT break CI. The exit status and pass/fail
+#                       counts are still printed so PRs can see them.
+#
+# When you fix the bug surfaced by a test in EXPECTED_FAIL, move it to GATING
+# in this file so future regressions break CI.
+#
+# Usage: run_c_tests.sh BUILD_DIR
+#   BUILD_DIR is where the test binaries live (typically the doltlite build
+#   directory, e.g. "build" or "build-test"). All test binaries are expected
+#   to already be built. Use `make c-tests` to build them.
+
+set -u
+
+BUILD_DIR="${1:-.}"
+cd "$BUILD_DIR" || { echo "Build dir $BUILD_DIR not found"; exit 2; }
+
+# Tests that pass cleanly on master at the time of wiring.
+GATING=(
+  ancestor_test
+)
+
+# Tests that have known preexisting failures or crashes on master. These are
+# run but their nonzero exit does not break CI. Each one has a follow-up
+# bug to track.
+#
+# Counts at time of wiring (master @ HEAD when this file was first added):
+#   sql_transaction_test    22 passed,  2 failed (no crash)
+#   invariant_test         838 passed,  3 failed (no crash)
+#   three_way_diff_test     74 passed, 39 failed (no crash)
+#   cross_branch_test        crashes after 4 reported fails (SIGSEGV)
+#   corruption_test          crashes after 4 reported fails (SIGABRT/139)
+#   multi_process_test       1 failure then exits nonzero
+#   concurrent_stress_test   SIGSEGV very early
+#
+# These represent real, latent bugs that the CI suite was previously
+# hiding. They should be triaged and fixed one at a time, after which
+# each test should be promoted into GATING.
+EXPECTED_FAIL=(
+  sql_transaction_test
+  invariant_test
+  three_way_diff_test
+  cross_branch_test
+  corruption_test
+  multi_process_test
+  concurrent_stress_test
+)
+
+run_one() {
+  local name="$1"
+  local kind="$2"   # "GATING" or "EXPECTED_FAIL"
+  local exe="./$name"
+
+  if [ ! -x "$exe" ]; then
+    echo "MISSING: $exe (not built)"
+    return 1
+  fi
+
+  echo "============================================================"
+  echo "[$kind] running $name"
+  echo "============================================================"
+  "$exe"
+  local ec=$?
+  echo "[$kind] $name exited with $ec"
+  return $ec
+}
+
+gating_failures=0
+expected_failures=0
+
+for t in "${GATING[@]}"; do
+  if ! run_one "$t" GATING; then
+    gating_failures=$((gating_failures + 1))
+  fi
+done
+
+for t in "${EXPECTED_FAIL[@]}"; do
+  if ! run_one "$t" EXPECTED_FAIL; then
+    expected_failures=$((expected_failures + 1))
+  fi
+done
+
+echo
+echo "============================================================"
+echo "Summary"
+echo "============================================================"
+echo "GATING failures        : $gating_failures / ${#GATING[@]}"
+echo "EXPECTED_FAIL failures : $expected_failures / ${#EXPECTED_FAIL[@]} (not gating)"
+
+if [ "$gating_failures" -ne 0 ]; then
+  echo "FAIL: $gating_failures gating tests failed"
+  exit 1
+fi
+
+echo "OK: all gating tests passed"
+exit 0


### PR DESCRIPTION
## Summary

Eight substantive C test files in `test/` (~7,000 lines of adversarial
coverage) were authored, compilable, and meaningful but **not wired into
any CI workflow**. Every PR has been merging without these running.

This PR closes that gap.

## Changes

- `main.mk`: adds a `make c-tests` target that builds the 8 binaries
  against `libdoltlite.a` (`three_way_diff_test` pokes prolly internals so
  it links against `$(LIBOBJS0)` instead) and runs them via a new
  `test/run_c_tests.sh` runner.
- `test/run_c_tests.sh`: gating-aware runner. Splits the 8 tests into
  `GATING` (must pass to keep CI green) and `EXPECTED_FAIL` (preexisting
  failures we are surfacing but not yet blocking on). When a bug is fixed,
  move its test from `EXPECTED_FAIL` to `GATING`.
- `.github/workflows/test.yml`: new `Orphan C tests` step that runs
  `make c-tests` inside the existing `build-and-test` job. 15-minute
  timeout.

## Test categorization on master

Verified locally on macOS at master HEAD. Numbers are the failure
counts the previously-orphan suite surfaces:

### GATING (1 test, must pass)
- `ancestor_test` -> 6 passed, 0 failed

### EXPECTED_FAIL (7 tests, surfaced bugs)
- `sql_transaction_test` -> 22 passed, 2 failed (`noconflict_both_exist`, `seq_count`)
- `invariant_test` -> 838 passed, 3 failed (`seq_log_count`, `gc_log_intact`, `before_reset_3_commits`)
- `three_way_diff_test` -> 74 passed, 39 failed (every basic diff scenario fails the `diff ok`/`1 change` assertions)
- `cross_branch_test` -> 4 failures then SIGSEGV
- `corruption_test` -> 4 failures then bus error
- `multi_process_test` -> 1 failure then SIGSEGV
- `concurrent_stress_test` -> SIGSEGV very early in the suite

These are real, latent bugs the suite was hiding. They should be
triaged and fixed one at a time. `three_way_diff_test` and
`concurrent_stress_test` in particular look like they were never run
in their current form against the current engine.

## Test plan

- [ ] CI green on the GATING test (`ancestor_test`)
- [ ] CI run shows EXPECTED_FAIL count of 7 in the `Orphan C tests` step output
- [ ] Follow-up: triage each EXPECTED_FAIL test, fix underlying bug, promote to GATING

Builds verified locally:
- All 8 binaries compile cleanly via `make c-tests` (warnings only, no errors)
- Runner script exits 0 because no GATING test failed
- EXPECTED_FAIL count printed as 7/7 as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)