### PR TITLE
fix: schema merge handles their-side ADD rows correctly

### DIFF
--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -210,6 +210,16 @@ struct MigrateDiffCtx {
   int *aiColIdx;
   char **azColNames;
   int nCols;
+  /* For PROLLY_DIFF_ADD: their-side row doesn't exist in the merged
+  ** working set yet (row-merge was skipped due to schema actions), so
+  ** UPDATE...WHERE rowid=? matches zero rows. pIns is an INSERT statement
+  ** that materializes the full row from their-side record bytes. azAllCols
+  ** / aiAllColIdx describe every column in their schema (record-field
+  ** index), in declared order, so we can bind values from the their-side
+  ** record into the INSERT. */
+  sqlite3_stmt *pIns;
+  int *aiAllColIdx;
+  int nAllCols;
 };
 
 char *extractColNameFromDef(const char *zDef);

--- a/src/doltlite_schema_merge.c
+++ b/src/doltlite_schema_merge.c
@@ -81,12 +81,23 @@ int migrateDiffCb(void *pArg, const ProllyDiffChange *pChange){
   int aType[64], aOffset[64];
   int nFields = 0;
   int sj, bindIdx;
+  sqlite3_stmt *pStmt;
+  int bIsAdd;
 
   if( pChange->type == PROLLY_DIFF_DELETE ) return SQLITE_OK;
 
   pVal = pChange->pNewVal;
   nVal = pChange->nNewVal;
   if( !pVal || nVal<=0 ) return SQLITE_OK;
+
+  /* PROLLY_DIFF_ADD: their branch inserted a new row that doesn't exist
+  ** in the merged working set (row-merge was skipped because of schema
+  ** actions). UPDATE WHERE rowid=? would match zero rows, leaving the
+  ** new column NULL. Use the INSERT statement so the row materializes
+  ** with all their-side column values. */
+  bIsAdd = (pChange->type == PROLLY_DIFF_ADD);
+  pStmt = bIsAdd ? ctx->pIns : ctx->pUpd;
+  if( !pStmt ) return SQLITE_OK;
 
   {
     const u8 *hp = pVal;
@@ -109,26 +120,47 @@ int migrateDiffCb(void *pArg, const ProllyDiffChange *pChange){
     }
   }
 
-  sqlite3_reset(ctx->pUpd);
+  sqlite3_reset(pStmt);
   bindIdx = 1;
-  for(sj=0; sj<ctx->nCols; sj++){
-    if( ctx->aiColIdx[sj]<0 || !ctx->azColNames[sj] ) continue;
-    if( ctx->aiColIdx[sj] < nFields ){
-      int brc = doltliteBindField(ctx->pUpd, bindIdx, pVal, nVal,
-                                  aType[ctx->aiColIdx[sj]],
-                                  aOffset[ctx->aiColIdx[sj]]);
+  if( bIsAdd ){
+    /* Bind rowid first, then every column from their schema in declared
+    ** order. The INSERT statement was built to match this binding order:
+    ** INSERT INTO "t"(rowid, "c1", "c2", ...) VALUES(?,?,?,...). */
+    int brc = sqlite3_bind_int64(pStmt, bindIdx++, pChange->intKey);
+    if( brc!=SQLITE_OK ) return brc;
+    for(sj=0; sj<ctx->nAllCols; sj++){
+      int rec = ctx->aiAllColIdx[sj];
+      if( rec>=0 && rec<nFields ){
+        brc = doltliteBindField(pStmt, bindIdx, pVal, nVal,
+                                aType[rec], aOffset[rec]);
+      }else{
+        brc = sqlite3_bind_null(pStmt, bindIdx);
+      }
       if( brc!=SQLITE_OK ) return brc;
-    }else{
-      int brc = sqlite3_bind_null(ctx->pUpd, bindIdx);
+      bindIdx++;
+    }
+  }else{
+    for(sj=0; sj<ctx->nCols; sj++){
+      if( ctx->aiColIdx[sj]<0 || !ctx->azColNames[sj] ) continue;
+      if( ctx->aiColIdx[sj] < nFields ){
+        int brc = doltliteBindField(pStmt, bindIdx, pVal, nVal,
+                                    aType[ctx->aiColIdx[sj]],
+                                    aOffset[ctx->aiColIdx[sj]]);
+        if( brc!=SQLITE_OK ) return brc;
+      }else{
+        int brc = sqlite3_bind_null(pStmt, bindIdx);
+        if( brc!=SQLITE_OK ) return brc;
+      }
+      bindIdx++;
+    }
+    {
+      int brc = sqlite3_bind_int64(pStmt, bindIdx, pChange->intKey);
       if( brc!=SQLITE_OK ) return brc;
     }
-    bindIdx++;
   }
+
   {
-    int brc = sqlite3_bind_int64(ctx->pUpd, bindIdx, pChange->intKey);
-    int src;
-    if( brc!=SQLITE_OK ) return brc;
-    src = sqlite3_step(ctx->pUpd);
+    int src = sqlite3_step(pStmt);
     if( src!=SQLITE_DONE ) return src;
   }
 
@@ -179,6 +211,10 @@ int migrateSchemaRowData(
     char **azColNames = 0;
     int *aiColIdx = 0;
     int nCols = 0;
+    char **azAllColNames = 0;
+    int *aiAllColIdx = 0;
+    int nAllCols = 0;
+    int nAllColsAlloc = 0;
     int sj;
 
     if( pAct->nAddColumns<=0 ) continue;
@@ -287,10 +323,32 @@ int migrateSchemaRowData(
                       aiColIdx[sj] = colOrdinal;
                     }
                   }
-                  sqlite3_free(zColName);
-                  if( rc!=SQLITE_OK ){
-                    goto next_action;
+
+                  /* Record every their-side column (in declared order)
+                  ** so we can build a full INSERT for PROLLY_DIFF_ADD
+                  ** rows that don't exist in the merged working set yet. */
+                  if( nAllCols >= nAllColsAlloc ){
+                    int nNew = nAllColsAlloc ? nAllColsAlloc*2 : 8;
+                    char **azNew = sqlite3_realloc(azAllColNames,
+                                                    nNew*(int)sizeof(char*));
+                    int *aiNew = sqlite3_realloc(aiAllColIdx,
+                                                  nNew*(int)sizeof(int));
+                    if( !azNew || !aiNew ){
+                      if( azNew ) azAllColNames = azNew;
+                      if( aiNew ) aiAllColIdx = aiNew;
+                      sqlite3_free(zColName);
+                      rc = SQLITE_NOMEM;
+                      goto next_action;
+                    }
+                    azAllColNames = azNew;
+                    aiAllColIdx = aiNew;
+                    nAllColsAlloc = nNew;
                   }
+                  /* Ownership of zColName transfers to azAllColNames. */
+                  azAllColNames[nAllCols] = zColName;
+                  aiAllColIdx[nAllCols] = colOrdinal;
+                  nAllCols++;
+
                   colOrdinal++;
                 }
               }
@@ -320,6 +378,7 @@ int migrateSchemaRowData(
         char *zSet = 0;
         int paramIdx = 1;
         sqlite3_stmt *pUpd = 0;
+        sqlite3_stmt *pIns = 0;
 
         for(sj=0; sj<nCols; sj++){
           if( aiColIdx[sj]<0 || !azColNames[sj] ) continue;
@@ -348,6 +407,49 @@ int migrateSchemaRowData(
         sqlite3_free(zUpdate);
         if( rc!=SQLITE_OK ) goto next_action;
 
+        /* Build the INSERT used for PROLLY_DIFF_ADD rows. Bindings are:
+        ** ?1=rowid, ?2..?N+1 = every column of their schema in declared
+        ** order. The callback fills NULL for any record-field index
+        ** that's missing from the their-side record bytes. */
+        if( nAllCols>0 ){
+          char *zCols = 0;
+          char *zVals = 0;
+          int p;
+          for(sj=0; sj<nAllCols; sj++){
+            char *zNewC = zCols
+              ? sqlite3_mprintf("%s, \"%w\"", zCols, azAllColNames[sj])
+              : sqlite3_mprintf("\"%w\"", azAllColNames[sj]);
+            sqlite3_free(zCols);
+            zCols = zNewC;
+            if( !zCols ){ rc = SQLITE_NOMEM; sqlite3_free(zVals); break; }
+          }
+          for(p=0; p<nAllCols && rc==SQLITE_OK; p++){
+            char *zNewV = zVals
+              ? sqlite3_mprintf("%s, ?%d", zVals, p+2)
+              : sqlite3_mprintf("?%d", p+2);
+            sqlite3_free(zVals);
+            zVals = zNewV;
+            if( !zVals ){ rc = SQLITE_NOMEM; break; }
+          }
+          if( rc==SQLITE_OK ){
+            char *zInsert = sqlite3_mprintf(
+                "INSERT INTO \"%w\"(rowid, %s) VALUES(?1, %s)",
+                pAct->zTableName, zCols, zVals);
+            if( !zInsert ){
+              rc = SQLITE_NOMEM;
+            }else{
+              rc = sqlite3_prepare_v2(db, zInsert, -1, &pIns, 0);
+              sqlite3_free(zInsert);
+            }
+          }
+          sqlite3_free(zCols);
+          sqlite3_free(zVals);
+          if( rc!=SQLITE_OK ){
+            sqlite3_finalize(pUpd);
+            goto next_action;
+          }
+        }
+
         {
           struct TableEntry *ancTE;
           ProllyHash ancRoot;
@@ -365,12 +467,16 @@ int migrateSchemaRowData(
           diffCtx.aiColIdx = aiColIdx;
           diffCtx.azColNames = azColNames;
           diffCtx.nCols = nCols;
+          diffCtx.pIns = pIns;
+          diffCtx.aiAllColIdx = aiAllColIdx;
+          diffCtx.nAllCols = nAllCols;
 
           rc = prollyDiff(cs, pCache, &ancRoot, &theirTE->root,
                           theirTE->flags, migrateDiffCb, &diffCtx);
         }
 
         sqlite3_finalize(pUpd);
+        sqlite3_finalize(pIns);
       }
     }
 
@@ -381,6 +487,11 @@ next_action:
       sqlite3_free(azColNames);
     }
     sqlite3_free(aiColIdx);
+    if( azAllColNames ){
+      for(sj=0; sj<nAllCols; sj++) sqlite3_free(azAllColNames[sj]);
+      sqlite3_free(azAllColNames);
+    }
+    sqlite3_free(aiAllColIdx);
 
     if( rc!=SQLITE_OK ) break;
   }


### PR DESCRIPTION
## Summary

\`migrateDiffCb\` in \`src/doltlite_schema_merge.c\` was treating
\`PROLLY_DIFF_ADD\` and \`PROLLY_DIFF_MODIFY\` identically — both as
\`UPDATE WHERE rowid=?N\`. For ADDs, that's a row their branch inserted
that doesn't exist in the merged working set yet, so the UPDATE matches
zero rows and the new column ends up NULL after merge.

This triggers specifically when both sides change the schema, where
\`mergeCatalogPass1\` takes the schema-action path (skipping row-merge
to defer to \`migrateSchemaRowData\`) and uses only our-side rows for
the merged tree. \`PROLLY_DIFF_MODIFY\` rows are present (our side kept
them), so UPDATE works; \`PROLLY_DIFF_ADD\` rows exist only on their
side and need to be materialized.

### Fix

\`migrateSchemaRowData\` now parses the full their-side column list (not
just the added columns) and prepares an additional \`INSERT\` statement
bound to \`rowid\` + every their-side column in declared order.
\`migrateDiffCb\` dispatches by change type:

- \`PROLLY_DIFF_ADD\` -> INSERT (materializes the full row with their
  values, columns from our-side schema not present in theirs default
  to NULL/DEFAULT)
- \`PROLLY_DIFF_MODIFY\` -> existing UPDATE (back-fill the new columns
  on rows already present)
- \`PROLLY_DIFF_DELETE\` -> still skipped (separate scope)

## Test plan

- [x] \`make doltlite\` builds clean (no warnings)
- [x] \`test/vc_oracle_schema_merge_test.sh\` -- 37/37 PASS
- [x] \`test/doltlite_schema_merge.sh\` -- 76/76 PASS
- [x] \`test/doltlite_merge.sh\` -- 91/91 PASS
- [x] \`test/vc_oracle_merge_test.sh\` -- 48/48 PASS
- [x] \`test/vc_oracle_merge_base_test.sh\` -- 23/23 PASS
- [x] \`test/oracle_schema_change_cherry_pick_revert_test.sh\` -- 23/23 PASS
- [x] Manual repro: feat adds col w + inserts rows (2,'b',10),(3,'c',20);
      main adds col x; merge feat into main. Before fix: rows 2/3 have
      w=NULL. After fix: w=10/20.

\xf0\x9f\xa4\x96 Generated with [Claude Code](https://claude.com/claude-code)