### PR TITLE
packaging: add SONAME and versioned filename to libdoltlite shared lib

### DIFF
--- a/main.mk
+++ b/main.mk
@@ -2567,14 +2567,30 @@ crash_recovery_test_sqlite_test$(T.exe): $(T.tcl.env.sh) has_tclsh85 $(TOP)/test
 # Dolt version control functions, unlike libsqlite3 which uses the
 # amalgamation.
 #
+# The shared library is named libdoltlite0 in the Debian package to
+# signal ABI version 0. To make that meaningful (and to let future
+# libdoltlite1 co-install with libdoltlite0), we set a SONAME of
+# libdoltlite.so.0 at link time on Linux. On Darwin we set the
+# install_name to libdoltlite.dylib via the inherited (substituted)
+# os-specific LDFLAGS from libsqlite3; we keep that as-is rather than
+# baking in a versioned dylib name because Homebrew (the only macOS
+# distribution channel) re-links anyway and an unversioned dylib is
+# what the formula expects.
+#
 libdoltlite$(T.lib):	$(LIBOBJS0)
 	$(AR) $(AR.flags) $@ $(LIBOBJS0)
 
 LDFLAGS.libdoltlite.os-specific = $(subst $(libsqlite3.DLL),libdoltlite$(T.dll),$(LDFLAGS.libsqlite3.os-specific))
+# On Linux (T.dll==.so), force a SONAME of libdoltlite.so.0 regardless
+# of how --soname=... was passed to libsqlite3, so that dlopen of
+# "libdoltlite.so.0" and ld of "-ldoltlite" both find the same file.
+# Empty on Darwin (T.dll==.dylib) and on Windows-side builds.
+libdoltlite.comma := ,
+LDFLAGS.libdoltlite.soname = $(if $(filter .so,$(T.dll)),-Wl$(libdoltlite.comma)-soname$(libdoltlite.comma)libdoltlite.so.0,)
 
 libdoltlite$(T.dll):	$(LIBOBJS0)
 	$(T.link.shared) -o $@ $(LIBOBJS0) $(LDFLAGS.libsqlite3) \
-		$(LDFLAGS.libdoltlite.os-specific)
+		$(LDFLAGS.libdoltlite.os-specific) $(LDFLAGS.libdoltlite.soname)
 
 doltlite-lib: libdoltlite$(T.lib) libdoltlite$(T.dll)
 all: doltlite-lib

--- a/packaging/nfpm/libdoltlite-dev.yaml
+++ b/packaging/nfpm/libdoltlite-dev.yaml
@@ -28,5 +28,12 @@ contents:
     dst: /usr/lib/${DEB_HOST_MULTIARCH}/libdoltlite.a
     file_info:
       mode: 0644
+  # Unversioned symlink lives in the -dev package, pointing at the
+  # SONAME-matched file shipped by libdoltlite0. This is the standard
+  # Debian split: the linker name (libfoo.so) is dev-only; the SONAME
+  # name (libfoo.so.N) is in the runtime package.
+  - src: libdoltlite.so.0
+    dst: /usr/lib/${DEB_HOST_MULTIARCH}/libdoltlite.so
+    type: symlink
   - src: LICENSE.md
     dst: /usr/share/doc/libdoltlite-dev/copyright

--- a/packaging/nfpm/libdoltlite0.yaml
+++ b/packaging/nfpm/libdoltlite0.yaml
@@ -21,8 +21,13 @@ depends:
   - zlib1g
 
 contents:
+  # The runtime file ships under its SONAME-matching name so that
+  # dlopen("libdoltlite.so.0") (Python ctypes, Node's process.dlopen,
+  # anything respecting SONAME) finds it. The unversioned symlink
+  # libdoltlite.so lives in libdoltlite-dev, mirroring how libsqlite3-0
+  # and libsqlite3-dev partition the files in Debian.
   - src: build/libdoltlite.so
-    dst: /usr/lib/${DEB_HOST_MULTIARCH}/libdoltlite.so
+    dst: /usr/lib/${DEB_HOST_MULTIARCH}/libdoltlite.so.0
     file_info:
       mode: 0644
   - src: LICENSE.md


### PR DESCRIPTION
## Summary

- The `.deb` was named `libdoltlite0` to signal ABI version 0, but the shared library was built without `-Wl,-soname` so `dlopen(\"libdoltlite.so.0\")` (Python `ctypes.CDLL`, Node `process.dlopen`, anything respecting SONAME) would fail, and a future `libdoltlite1` could not co-install.
- Pass `-Wl,-soname,libdoltlite.so.0` on Linux. macOS already had the right `-install_name` flag wired via the existing `$(subst ...)` on `LDFLAGS.libsqlite3.os-specific`, so no change was needed there.
- Update nfpm config: `libdoltlite0` now ships `libdoltlite.so.0` (the SONAME-matched runtime file) and `libdoltlite-dev` ships a `libdoltlite.so -> libdoltlite.so.0` symlink. This mirrors how Debian splits `libsqlite3-0` and `libsqlite3-dev`.

## Verify

Built locally in a fresh Debian Bookworm container (`debian:bookworm` on arm64):

```
$ readelf -d build/libdoltlite.so | grep -i soname
 0x000000000000000e (SONAME)             Library soname: [libdoltlite.so.0]
```

`dpkg -c` on the resulting `.deb`s:

```
libdoltlite0:
-rw-r--r-- ./usr/lib/aarch64-linux-gnu/libdoltlite.so.0

libdoltlite-dev:
-rw-r--r-- ./usr/lib/aarch64-linux-gnu/libdoltlite.a
l--------- ./usr/lib/aarch64-linux-gnu/libdoltlite.so -> libdoltlite.so.0
-rw-r--r-- ./usr/include/doltlite.h
```

macOS build (`make libdoltlite.dylib`) still succeeds; `otool -D libdoltlite.dylib` shows `/usr/local/lib/libdoltlite.dylib` (unchanged from before).

## Test plan

- [x] `make libdoltlite.dylib` succeeds on macOS (Darwin 24).
- [x] `make libdoltlite.so libdoltlite.a` succeeds in `debian:bookworm` container.
- [x] `readelf -d build/libdoltlite.so | grep SONAME` shows `libdoltlite.so.0`.
- [x] `nfpm pkg --packager deb` builds both `libdoltlite0_*.deb` and `libdoltlite-dev_*.deb`.
- [x] `dpkg -c` confirms `libdoltlite.so.0` as the real file and `libdoltlite.so` as a dev-package symlink.
- [ ] Manual: in CI/release, verify `python3 -c \"import ctypes; ctypes.CDLL('libdoltlite.so.0')\"` works on a host with the `.deb` installed (this PR doesn't change CI; release.yml's existing nfpm step will pick up the new yaml).

## Notes

- The package name `libdoltlite0` is unchanged. Only the file/symlink layout inside the `.deb` changes.
- This is a targeted change to the libdoltlite link command; the libsqlite3 link command is unchanged (libsqlite3 has its own soname mechanism gated behind `--soname=` and historically used `none` for this project).
- macOS install_name fix was already working via the existing `$(subst ...)` line; the diff only documents that intent with a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)