### PR TITLE
Optimize diff table commit traversal map

### DIFF
--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -134,6 +134,7 @@ static void closeDiffIter(DiffTblCursor *pCur){
 }
 
 typedef struct CmTblInfo CmTblInfo;
+typedef struct CmTblMap CmTblMap;
 struct CmTblInfo {
   ProllyHash key;
   ProllyHash tblRoot;
@@ -144,34 +145,106 @@ struct CmTblInfo {
   char       zHexName[PROLLY_HASH_SIZE*2+1];
 };
 
-static int mapFind(const CmTblInfo *aMap, int nMap, const ProllyHash *pKey){
-  int i;
-  for(i=0; i<nMap; i++){
-    if( prollyHashCompare(&aMap[i].key, pKey)==0 ) return i;
-  }
-  return -1;
+struct CmTblMap {
+  CmTblInfo *aEntry;
+  int nEntry;
+  int nAlloc;
+  int *aSlot;
+  int nSlot;
+};
+
+static u32 cmHashSlot(const ProllyHash *pKey, int nSlot){
+  u32 h;
+  memcpy(&h, pKey->data, sizeof(h));
+  return h & (u32)(nSlot - 1);
 }
 
-static int mapPut(CmTblInfo **paMap, int *pnMap, const ProllyHash *pKey,
-                  const ProllyHash *pTblRoot,
-                  const ProllyHash *pCatHash,
-                  const ProllyHash *pSchemaHash,
-                  u8 flags,
-                  const char *zHexName, i64 date){
-  int idx = mapFind(*paMap, *pnMap, pKey);
+static void cmMapFree(CmTblMap *pMap){
+  sqlite3_free(pMap->aEntry);
+  sqlite3_free(pMap->aSlot);
+  memset(pMap, 0, sizeof(*pMap));
+}
+
+static int cmMapRebuild(CmTblMap *pMap, int nSlot){
+  int i;
+  int *aSlot;
+  aSlot = sqlite3_malloc(nSlot * (int)sizeof(int));
+  if( !aSlot ) return SQLITE_NOMEM;
+  memset(aSlot, 0, nSlot * (int)sizeof(int));
+
+  for(i=0; i<pMap->nEntry; i++){
+    u32 slot = cmHashSlot(&pMap->aEntry[i].key, nSlot);
+    while( aSlot[slot]!=0 ){
+      slot = (slot + 1) & (u32)(nSlot - 1);
+    }
+    aSlot[slot] = i + 1;
+  }
+
+  sqlite3_free(pMap->aSlot);
+  pMap->aSlot = aSlot;
+  pMap->nSlot = nSlot;
+  return SQLITE_OK;
+}
+
+static int cmMapEnsureSlots(CmTblMap *pMap){
+  int nSlot;
+  if( pMap->nSlot>0 && (pMap->nEntry + 1)*2 <= pMap->nSlot ){
+    return SQLITE_OK;
+  }
+  nSlot = pMap->nSlot ? pMap->nSlot*2 : 16;
+  while( nSlot < (pMap->nEntry + 1)*2 ) nSlot *= 2;
+  return cmMapRebuild(pMap, nSlot);
+}
+
+static CmTblInfo *cmMapFind(CmTblMap *pMap, const ProllyHash *pKey){
+  u32 slot;
+  int i;
+  if( pMap->nSlot==0 ) return 0;
+  slot = cmHashSlot(pKey, pMap->nSlot);
+  for(i=0; i<pMap->nSlot; i++){
+    int idx = pMap->aSlot[slot];
+    if( idx==0 ) return 0;
+    if( prollyHashCompare(&pMap->aEntry[idx-1].key, pKey)==0 ){
+      return &pMap->aEntry[idx-1];
+    }
+    slot = (slot + 1) & (u32)(pMap->nSlot - 1);
+  }
+  return 0;
+}
+
+static int cmMapPut(CmTblMap *pMap, const ProllyHash *pKey,
+                    const ProllyHash *pTblRoot,
+                    const ProllyHash *pCatHash,
+                    const ProllyHash *pSchemaHash,
+                    u8 flags,
+                    const char *zHexName, i64 date){
   CmTblInfo *e;
-  if( idx<0 ){
-    CmTblInfo *aNew = sqlite3_realloc(*paMap,
-                          (*pnMap+1)*(int)sizeof(CmTblInfo));
-    if( !aNew ) return SQLITE_NOMEM;
-    *paMap = aNew;
-    e = &aNew[*pnMap];
+  int rc;
+
+  e = cmMapFind(pMap, pKey);
+  if( !e ){
+    u32 slot;
+    rc = cmMapEnsureSlots(pMap);
+    if( rc!=SQLITE_OK ) return rc;
+    if( pMap->nEntry >= pMap->nAlloc ){
+      int nNew = pMap->nAlloc ? pMap->nAlloc*2 : 16;
+      CmTblInfo *aNew = sqlite3_realloc(pMap->aEntry,
+                            nNew*(int)sizeof(CmTblInfo));
+      if( !aNew ) return SQLITE_NOMEM;
+      pMap->aEntry = aNew;
+      pMap->nAlloc = nNew;
+    }
+    e = &pMap->aEntry[pMap->nEntry];
     memset(e, 0, sizeof(*e));
     e->key = *pKey;
-    (*pnMap)++;
-  }else{
-    e = &(*paMap)[idx];
+    slot = cmHashSlot(pKey, pMap->nSlot);
+    while( pMap->aSlot[slot]!=0 ){
+      slot = (slot + 1) & (u32)(pMap->nSlot - 1);
+    }
+    pMap->aSlot[slot] = pMap->nEntry + 1;
+    pMap->nEntry++;
   }
+
   e->tblRoot = *pTblRoot;
   e->catHash = *pCatHash;
   e->schemaHash = *pSchemaHash;
@@ -261,8 +334,7 @@ static int seedWorkingChildInfo(
   sqlite3 *db,
   const ProllyHash *pHeadHash,
   const char *zTableName,
-  CmTblInfo **paMap,
-  int *pnMap
+  CmTblMap *pMap
 ){
   ProllyHash workingCat;
   ProllyHash workingTblRoot;
@@ -282,8 +354,8 @@ static int seedWorkingChildInfo(
   rc = loadTblRootAtCommit(db, &workingCat, zTableName, &workingTblRoot,
                            &workingFlags, &workingSchemaHash);
   if( rc!=SQLITE_OK ) return rc;
-  return mapPut(paMap, pnMap, pHeadHash, &workingTblRoot, &workingCat,
-                &workingSchemaHash, workingFlags, zWorking, 0);
+  return cmMapPut(pMap, pHeadHash, &workingTblRoot, &workingCat,
+                  &workingSchemaHash, workingFlags, zWorking, 0);
 }
 
 static int appendCurrentDiffPair(
@@ -293,18 +365,15 @@ static int appendCurrentDiffPair(
   const ProllyHash *pCurTblRoot,
   const ProllyHash *pCurSchemaHash,
   u8 curFlags,
-  CmTblInfo *aMap,
-  int nMap
+  CmTblMap *pMap
 ){
   CmTblInfo *pInfo;
-  int idx;
   int rootsDiffer;
   int schemasDiffer;
   u8 fromFlags;
 
-  idx = mapFind(aMap, nMap, pCurr);
-  if( idx<0 ) return SQLITE_OK;
-  pInfo = &aMap[idx];
+  pInfo = cmMapFind(pMap, pCurr);
+  if( !pInfo ) return SQLITE_OK;
   rootsDiffer = prollyHashCompare(&pInfo->tblRoot, pCurTblRoot)!=0;
   schemasDiffer = prollyHashCompare(&pInfo->schemaHash, pCurSchemaHash)!=0;
   if( !rootsDiffer && !schemasDiffer ) return SQLITE_OK;
@@ -318,8 +387,7 @@ static int appendCurrentDiffPair(
 }
 
 static int registerCommitParents(
-  CmTblInfo **paMap,
-  int *pnMap,
+  CmTblMap *pMap,
   ProllyHashSet *pSeen,
   ProllyHash **paStack,
   int *pnStack,
@@ -337,8 +405,8 @@ static int registerCommitParents(
   for(i=0; i<doltliteCommitParentCount(pCommit); i++){
     pParent = doltliteCommitParentHash(pCommit, i);
     if( !pParent ) continue;
-    rc = mapPut(paMap, pnMap, pParent, pCurTblRoot, &pCommit->catalogHash,
-                pCurSchemaHash, curFlags, zCurHex, pCommit->timestamp);
+    rc = cmMapPut(pMap, pParent, pCurTblRoot, &pCommit->catalogHash,
+                  pCurSchemaHash, curFlags, zCurHex, pCommit->timestamp);
     if( rc!=SQLITE_OK ) return rc;
   }
   for(i=0; i<doltliteCommitParentCount(pCommit); i++){
@@ -354,8 +422,7 @@ static int buildDiffPairs(DiffTblCursor *pCur, sqlite3 *db,
                           const char *zTableName){
   ChunkStore *cs = doltliteGetChunkStore(db);
   ProllyHash headHash;
-  CmTblInfo *aMap = 0;
-  int nMap = 0;
+  CmTblMap map;
   ProllyHash *aStack = 0;
   int nStack = 0, nStackAlloc = 0;
   ProllyHashSet seen;
@@ -366,10 +433,11 @@ static int buildDiffPairs(DiffTblCursor *pCur, sqlite3 *db,
   int i;
 
   if( !cs ) return SQLITE_OK;
+  memset(&map, 0, sizeof(map));
 
   doltliteGetSessionHead(db, &headHash);
   if( prollyHashIsEmpty(&headHash) ) return SQLITE_OK;
-  rc = seedWorkingChildInfo(db, &headHash, zTableName, &aMap, &nMap);
+  rc = seedWorkingChildInfo(db, &headHash, zTableName, &map);
   if( rc!=SQLITE_OK ) goto walk_done;
 
   rc = prollyHashSetInit(&seen, 64);
@@ -405,10 +473,9 @@ static int buildDiffPairs(DiffTblCursor *pCur, sqlite3 *db,
 
     doltliteHashToHex(&curr, curHex);
     rc = appendCurrentDiffPair(pCur, &curr, &commit, &curTblRoot,
-                               &curSchemaHash, curFlags, aMap, nMap);
+                               &curSchemaHash, curFlags, &map);
     if( rc==SQLITE_OK ){
-      rc = registerCommitParents(&aMap, &nMap, &seen,
-                                 &aStack, &nStack, &nStackAlloc,
+      rc = registerCommitParents(&map, &seen, &aStack, &nStack, &nStackAlloc,
                                  &commit, &curTblRoot,
                                  &curSchemaHash, curFlags, curHex);
     }
@@ -424,7 +491,7 @@ static int buildDiffPairs(DiffTblCursor *pCur, sqlite3 *db,
   }
 
 walk_done:
-  sqlite3_free(aMap);
+  cmMapFree(&map);
   sqlite3_free(aStack);
   if( seenInit ) prollyHashSetFree(&seen);
   return rc;

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -2615,6 +2615,45 @@ static void run_diff_stat_requires_refs(void){
   remove_db(dbpath);
 }
 
+static void run_diff_table_deep_history_map(void){
+  sqlite3 *db = 0;
+  char dbpath[256];
+  char sql[256];
+  int i;
+
+  printf("=== Diff Table Deep History Map Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_diff_table_deep_history_map");
+  remove_db(dbpath);
+
+  check("open_db_for_diff_table_deep_history_map",
+        open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_diff_table_deep_history_map", execsql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);"
+    "INSERT INTO t VALUES(1,0);"
+    "SELECT dolt_commit('-A', '-m', 'c0');")==SQLITE_OK);
+
+  for(i=1; i<=80; i++){
+    sqlite3_snprintf(sizeof(sql), sql,
+      "UPDATE t SET v=%d WHERE id=1;"
+      "SELECT dolt_commit('-A', '-m', 'c%d');", i, i);
+    check("diff_table_deep_history_commit", execsql(db, sql)==SQLITE_OK);
+  }
+
+  check("diff_table_deep_history_count",
+        strcmp(exec1(db,
+          "SELECT count(*) FROM dolt_diff_t WHERE diff_type='modified';"),
+          "80")==0);
+  check("diff_table_deep_history_latest_value",
+        strcmp(exec1(db,
+          "SELECT to_v FROM dolt_diff_t "
+          "WHERE to_commit=(SELECT commit_hash FROM dolt_log "
+          "                 WHERE message='c80');"),
+          "80")==0);
+
+  sqlite3_close(db);
+  remove_db(dbpath);
+}
+
 static void run_diff_stat_surfaces_corrupt_root(void){
   sqlite3 *db = 0;
   ChunkStore *cs = 0;
@@ -6434,6 +6473,7 @@ static const RegressionCase aCases[] = {
   { "begin_write_from_stale_read_snapshot", "Begin Write From Stale Read Snapshot Test", run_begin_write_from_stale_read_snapshot },
   { "open_rejects_corrupt_working_set", "Open Rejects Corrupt Working Set Test", run_open_rejects_corrupt_working_set },
   { "diff_stat_requires_refs", "Diff Stat Requires Refs Test", run_diff_stat_requires_refs },
+  { "diff_table_deep_history_map", "Diff Table Deep History Map Test", run_diff_table_deep_history_map },
   { "diff_stat_surfaces_corrupt_root", "Diff Stat Surfaces Corrupt Root Test", run_diff_stat_surfaces_corrupt_root },
   { "table_moveto_mutmap_delete_preserves_neighbors", "Table Moveto MutMap Delete Preserves Neighbors Test", run_table_moveto_mutmap_delete_preserves_neighbors },
   { "table_moveto_mutmap_exact_keeps_iteration_aligned", "Table Moveto MutMap Exact Keeps Iteration Aligned Test", run_table_moveto_mutmap_exact_keeps_iteration_aligned },


### PR DESCRIPTION
## Summary
- replace the linear commit-child lookup in `dolt_diff_<table>` history traversal with an open-addressed hash map
- keep diff pair behavior unchanged while making map lookup/update expected O(1) instead of linear in commit count
- add a deep-history `dolt_diff_t` regression guard

## Tests
- `make doltlite libdoltlite.a`
- `cc -g -I. -Isrc -o doltlite_regression_test_c test/doltlite_regression_test_c.c libdoltlite.a -lz -lpthread -lm && ./doltlite_regression_test_c diff_table_deep_history_map`
- `bash test/doltlite_diff_table.sh`
- `bash test/review_regression_test.sh`
- `bash test/doltlite_parity.sh`