### PR TITLE
Optimize blame parent row comparison

### DIFF
--- a/src/doltlite_blame.c
+++ b/src/doltlite_blame.c
@@ -284,6 +284,34 @@ static int blameSeekRowInTree(
   return SQLITE_OK;
 }
 
+static int blameBlobKeyCmp(
+  const u8 *pA, int nA,
+  const u8 *pB, int nB
+){
+  int n = (nA < nB) ? nA : nB;
+  int c = memcmp(pA, pB, n);
+  if( c ) return c;
+  return nA - nB;
+}
+
+static int blameCursorCompareRowKey(
+  ProllyCursor *pRefCur,
+  u8 flags,
+  const BlameRow *pRow
+){
+  if( flags & PROLLY_NODE_INTKEY ){
+    i64 refKey = prollyCursorIntKey(pRefCur);
+    if( refKey < pRow->intKey ) return -1;
+    if( refKey > pRow->intKey ) return 1;
+    return 0;
+  }else{
+    const u8 *pRefKey = 0;
+    int nRefKey = 0;
+    prollyCursorKey(pRefCur, &pRefKey, &nRefKey);
+    return blameBlobKeyCmp(pRefKey, nRefKey, pRow->pKey, pRow->nKey);
+  }
+}
+
 static int blameRowValueEqual(const u8 *pA, int nA, const u8 *pB, int nB){
   int isA = (pA && nA>0);
   int isB = (pB && nB>0);
@@ -353,10 +381,15 @@ static int blameCompareAgainstRef(
 ){
   ChunkStore *cs = doltliteGetChunkStore(db);
   ProllyCache *pCache = doltliteGetCache(db);
+  ProllyCursor refCur;
   ProllyHash refRoot;
   u8 refFlags = 0;
   int haveRef = 0;
-  int rc, i;
+  int refCurOpen = 0;
+  int refCurValid = 0;
+  int canScanRef = 0;
+  int rc = SQLITE_OK;
+  int i;
 
   (void)pCurRoot;
 
@@ -366,6 +399,18 @@ static int blameCompareAgainstRef(
     else if( rc!=SQLITE_NOTFOUND ) return rc;
   }
 
+  canScanRef = haveRef
+      && !prollyHashIsEmpty(&refRoot)
+      && ((refFlags & PROLLY_NODE_INTKEY)==(curFlags & PROLLY_NODE_INTKEY));
+  if( canScanRef ){
+    int res = 0;
+    prollyCursorInit(&refCur, cs, pCache, &refRoot, refFlags);
+    refCurOpen = 1;
+    rc = prollyCursorFirst(&refCur, &res);
+    if( rc!=SQLITE_OK ) goto blame_compare_done;
+    refCurValid = (res==0);
+  }
+
   for(i=0; i<pCur->nRows; i++){
     BlameRow *r = &pCur->aRows[i];
     const u8 *pRefVal = 0;
@@ -373,17 +418,35 @@ static int blameCompareAgainstRef(
     if( r->blamed ) continue;
 
     if( haveRef ){
-      rc = blameSeekRowInTree(cs, pCache, &refRoot, refFlags, r, &pRefVal, &nRefVal);
-      if( rc!=SQLITE_OK ) return rc;
+      if( canScanRef ){
+        int cmp = 1;
+        while( refCurValid ){
+          cmp = blameCursorCompareRowKey(&refCur, refFlags, r);
+          if( cmp>=0 ) break;
+          rc = prollyCursorNext(&refCur);
+          if( rc!=SQLITE_OK ) goto blame_compare_done;
+          refCurValid = prollyCursorIsValid(&refCur);
+        }
+        if( refCurValid && cmp==0 ){
+          prollyCursorValue(&refCur, &pRefVal, &nRefVal);
+        }
+      }else{
+        rc = blameSeekRowInTree(cs, pCache, &refRoot, refFlags, r,
+                                &pRefVal, &nRefVal);
+        if( rc!=SQLITE_OK ) goto blame_compare_done;
+      }
     }
 
     if( !blameRowValueEqual(r->pCurVal, r->nCurVal, pRefVal, nRefVal) ){
       rc = blameAssign(r, pCommitHash, pCommit);
-      if( rc!=SQLITE_OK ) return rc;
+      if( rc!=SQLITE_OK ) goto blame_compare_done;
       pCur->nUnresolved--;
     }
   }
-  return SQLITE_OK;
+
+blame_compare_done:
+  if( refCurOpen ) prollyCursorClose(&refCur);
+  return rc;
 }
 
 static int blameUnresolvedCount(BlameCursor *pCur){

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -1418,6 +1418,51 @@ static void run_blame_all_parents_merge_base(void){
   remove_db(dbpath);
 }
 
+static void run_blame_deep_history_scan(void){
+  sqlite3 *db = 0;
+  char dbpath[256];
+  char sql[256];
+  int i;
+
+  printf("=== Blame Deep History Scan Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_blame_deep_history_scan");
+  remove_db(dbpath);
+
+  check("open_db_for_blame_deep_history_scan", open_db(dbpath, &db)==SQLITE_OK);
+  check("create_table_for_blame_deep_history_scan", execsql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);"
+    "BEGIN;")==SQLITE_OK);
+  for(i=1; i<=100; i++){
+    sqlite3_snprintf(sizeof(sql), sql,
+      "INSERT INTO t VALUES(%d,0);", i);
+    check("insert_row_for_blame_deep_history_scan",
+          execsql(db, sql)==SQLITE_OK);
+  }
+  check("commit_initial_rows_for_blame_deep_history_scan", execsql(db,
+    "COMMIT;"
+    "SELECT dolt_commit('-A', '-m', 'init');")==SQLITE_OK);
+
+  for(i=1; i<=80; i++){
+    sqlite3_snprintf(sizeof(sql), sql,
+      "UPDATE t SET v=%d WHERE id=%d;"
+      "SELECT dolt_commit('-A', '-m', 'c%d');", i, i, i);
+    check("commit_update_for_blame_deep_history_scan",
+          execsql(db, sql)==SQLITE_OK);
+  }
+
+  check("blame_deep_history_row_count",
+        strcmp(exec1(db, "SELECT count(*) FROM dolt_blame_t;"), "100")==0);
+  check("blame_deep_history_updated_row",
+        strcmp(exec1(db, "SELECT message FROM dolt_blame_t WHERE id=80;"),
+               "c80")==0);
+  check("blame_deep_history_unchanged_row",
+        strcmp(exec1(db, "SELECT message FROM dolt_blame_t WHERE id=100;"),
+               "init")==0);
+
+  sqlite3_close(db);
+  remove_db(dbpath);
+}
+
 static void run_merge_persist_failure(void){
   sqlite3 *db = 0;
   char dbpath[256];
@@ -6447,6 +6492,7 @@ static const RegressionCase aCases[] = {
   { "resolve_ref_non_commit", "Resolve Ref Non-Commit Test", run_resolve_ref_non_commit },
   { "commit_parent_limit", "Commit Parent Limit Test", run_commit_parent_limit },
   { "blame_all_parents_merge_base", "Blame All-Parents Merge Base Test", run_blame_all_parents_merge_base },
+  { "blame_deep_history_scan", "Blame Deep History Scan Test", run_blame_deep_history_scan },
   { "merge_persist_failure", "Merge Persist Failure Test", run_merge_persist_failure },
   { "merge_conflict_surfaces_error", "Merge Conflict Surfaces Error Test", run_merge_conflict_surfaces_error_and_rollback_clears_durable_state },
   { "failed_merge_reopen_preserves_working_set_state", "Failed Merge Reopen Preserves Working Set State Test", run_failed_merge_reopen_clears_ephemeral_conflict_state },


### PR DESCRIPTION
## Summary
- compare `dolt_blame_<table>` rows against a parent table with one forward cursor scan per commit
- avoid repeated parent-tree seeks for each unresolved row when the key encoding is unchanged
- keep the old seek path as a fallback for schema/key-encoding changes
- add a deep-history blame regression guard

## Tests
- `make doltlite libdoltlite.a`
- `cc -g -I. -Isrc -o doltlite_regression_test_c test/doltlite_regression_test_c.c libdoltlite.a -lz -lpthread -lm && ./doltlite_regression_test_c blame_deep_history_scan`
- `bash test/vc_oracle_blame_test.sh`
- `bash test/vc_oracle_diff_multi_pk_test.sh`
- `bash test/review_regression_test.sh`
- `bash test/doltlite_parity.sh`