### PR TITLE
Cache diff stat column mapping

### DIFF
--- a/src/doltlite_diff_stat.c
+++ b/src/doltlite_diff_stat.c
@@ -186,11 +186,58 @@ static int dsFieldValuesEqual(
   return memcmp(pA+aOff, pB+bOff, aLen)==0;
 }
 
+typedef struct DsColMap DsColMap;
+struct DsColMap {
+  int *aToFrom;
+  u8 *aFromMatched;
+  int nTo;
+  int nFrom;
+};
+
+static void dsFreeColMap(DsColMap *pMap){
+  sqlite3_free(pMap->aToFrom);
+  sqlite3_free(pMap->aFromMatched);
+  memset(pMap, 0, sizeof(*pMap));
+}
+
+static int dsBuildColMap(
+  char **azFromCols, int nFromCols,
+  char **azToCols, int nToCols,
+  DsColMap *pMap
+){
+  int i, j;
+  memset(pMap, 0, sizeof(*pMap));
+  pMap->nTo = nToCols;
+  pMap->nFrom = nFromCols;
+  if( nToCols>0 ){
+    pMap->aToFrom = sqlite3_malloc(nToCols * (int)sizeof(int));
+    if( !pMap->aToFrom ) return SQLITE_NOMEM;
+  }
+  if( nFromCols>0 ){
+    pMap->aFromMatched = sqlite3_malloc(nFromCols * (int)sizeof(u8));
+    if( !pMap->aFromMatched ){
+      dsFreeColMap(pMap);
+      return SQLITE_NOMEM;
+    }
+    memset(pMap->aFromMatched, 0, nFromCols * (int)sizeof(u8));
+  }
+  for(i=0; i<nToCols; i++){
+    pMap->aToFrom[i] = -1;
+    for(j=0; j<nFromCols; j++){
+      if( strcmp(azFromCols[j], azToCols[i])==0 ){
+        pMap->aToFrom[i] = j;
+        pMap->aFromMatched[j] = 1;
+        break;
+      }
+    }
+  }
+  return SQLITE_OK;
+}
+
 static int dsCountChangedCells(
   const u8 *pFromRec, int nFromRec,
   const u8 *pToRec,   int nToRec,
-  char **azFromCols,  int nFromCols,
-  char **azToCols,    int nToCols
+  const DsColMap *pColMap
 ){
   DoltliteRecordInfo fromRi, toRi;
   int i, changed = 0;
@@ -198,12 +245,9 @@ static int dsCountChangedCells(
   doltliteParseRecord(pFromRec, nFromRec, &fromRi);
   doltliteParseRecord(pToRec,   nToRec,   &toRi);
 
-  for(i=0; i<nToCols; i++){
-    int fromIdx;
-    for(fromIdx=0; fromIdx<nFromCols; fromIdx++){
-      if( strcmp(azFromCols[fromIdx], azToCols[i])==0 ) break;
-    }
-    if( fromIdx>=nFromCols ){
+  for(i=0; i<pColMap->nTo; i++){
+    int fromIdx = pColMap->aToFrom ? pColMap->aToFrom[i] : -1;
+    if( fromIdx<0 ){
 
       if( i<toRi.nField && toRi.aType[i]!=0 ) changed++;
       continue;
@@ -216,12 +260,8 @@ static int dsCountChangedCells(
     }
   }
 
-  for(i=0; i<nFromCols; i++){
-    int toIdx;
-    for(toIdx=0; toIdx<nToCols; toIdx++){
-      if( strcmp(azToCols[toIdx], azFromCols[i])==0 ) break;
-    }
-    if( toIdx<nToCols ) continue;
+  for(i=0; i<pColMap->nFrom; i++){
+    if( pColMap->aFromMatched && pColMap->aFromMatched[i] ) continue;
     if( i>=fromRi.nField ) continue;
     if( fromRi.aType[i]!=0 ) changed++;
   }
@@ -298,12 +338,14 @@ static int dsComputeTableStats(
   char *zFromSql = 0, *zToSql = 0;
   char **azFromCols = 0, **azToCols = 0;
   int nFromCols = 0, nToCols = 0;
+  DsColMap colMap;
   i64 oldCount = 0, newCount = 0;
   i64 rowsMod = 0, rowsAdd = 0, rowsDel = 0;
   i64 cellsMod = 0, cellsAdd = 0, cellsDel = 0;
   int rc;
 
   memset(pOut, 0, sizeof(*pOut));
+  memset(&colMap, 0, sizeof(colMap));
 
   rc = doltliteLoadCatalog(db, pFromCatHash, &aFrom, &nFromCat, 0);
   if( rc!=SQLITE_OK ) return rc;
@@ -352,6 +394,11 @@ static int dsComputeTableStats(
     hasFrom && hasTo &&
     strcmp(zFromSql ? zFromSql : "", zToSql ? zToSql : "")!=0;
 
+  if( hasFrom && hasTo ){
+    rc = dsBuildColMap(azFromCols, nFromCols, azToCols, nToCols, &colMap);
+    if( rc!=SQLITE_OK ) goto done;
+  }
+
   if( hasFrom ){
     rc = dsCountRows(db, &fromRoot, fromFlags, &oldCount);
     if( rc!=SQLITE_OK ) goto done;
@@ -388,7 +435,7 @@ static int dsComputeTableStats(
           int changed = dsCountChangedCells(
               pChange->pOldVal, pChange->nOldVal,
               pChange->pNewVal, pChange->nNewVal,
-              azFromCols, nFromCols, azToCols, nToCols);
+              &colMap);
           if( changed>0 ){
             rowsMod++;
             cellsMod += changed;
@@ -451,6 +498,7 @@ done:
   sqlite3_free(zToSql);
   dsFreeColNames(azFromCols, nFromCols);
   dsFreeColNames(azToCols, nToCols);
+  dsFreeColMap(&colMap);
   return rc;
 }
 

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -2687,6 +2687,54 @@ static void run_diff_stat_requires_refs(void){
   removeDbFiles(dbpath);
 }
 
+static void run_diff_stat_wide_modified_rows(void){
+  sqlite3 *db = 0;
+  char dbpath[256];
+  char sql[4096];
+  int i;
+
+  printf("=== Diff Stat Wide Modified Rows Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_diff_stat_wide_modified_rows");
+  removeDbFiles(dbpath);
+
+  check("open_db_for_diff_stat_wide_modified_rows",
+        open_db(dbpath, &db)==SQLITE_OK);
+
+  sqlite3_snprintf(sizeof(sql), sql,
+      "CREATE TABLE t(id INTEGER PRIMARY KEY");
+  for(i=1; i<=32; i++){
+    sqlite3_snprintf(sizeof(sql) - strlen(sql), sql + strlen(sql),
+        ", c%03d INT", i);
+  }
+  sqlite3_snprintf(sizeof(sql) - strlen(sql), sql + strlen(sql), ");");
+  check("create_wide_table_for_diff_stat", execSql(db, sql)==SQLITE_OK);
+
+  check("begin_wide_rows_for_diff_stat", execSql(db, "BEGIN;")==SQLITE_OK);
+  for(i=1; i<=80; i++){
+    sqlite3_snprintf(sizeof(sql), sql, "INSERT INTO t(id) VALUES(%d);", i);
+    check("insert_wide_row_for_diff_stat", execSql(db, sql)==SQLITE_OK);
+  }
+  check("commit_wide_base_for_diff_stat", execSql(db,
+    "COMMIT;"
+    "SELECT dolt_commit('-A', '-m', 'base');")==SQLITE_OK);
+
+  check("update_wide_rows_for_diff_stat", execSql(db,
+    "UPDATE t SET c016=id, c032=id*2;"
+    "SELECT dolt_commit('-A', '-m', 'wide update');")==SQLITE_OK);
+
+  check("diff_stat_wide_rows_modified",
+        strcmp(queryScalarText(db,
+          "SELECT rows_modified FROM dolt_diff_stat('HEAD~1','HEAD','t');"),
+          "80")==0);
+  check("diff_stat_wide_cells_modified",
+        strcmp(queryScalarText(db,
+          "SELECT cells_modified FROM dolt_diff_stat('HEAD~1','HEAD','t');"),
+          "160")==0);
+
+  sqlite3_close(db);
+  removeDbFiles(dbpath);
+}
+
 static void run_diff_stat_surfaces_corrupt_root(void){
   sqlite3 *db = 0;
   ChunkStore *cs = 0;
@@ -6477,6 +6525,7 @@ static const RegressionCase aCases[] = {
   { "begin_write_from_stale_read_snapshot", "Begin Write From Stale Read Snapshot Test", run_begin_write_from_stale_read_snapshot },
   { "open_rejects_corrupt_working_set", "Open Rejects Corrupt Working Set Test", run_open_rejects_corrupt_working_set },
   { "diff_stat_requires_refs", "Diff Stat Requires Refs Test", run_diff_stat_requires_refs },
+  { "diff_stat_wide_modified_rows", "Diff Stat Wide Modified Rows Test", run_diff_stat_wide_modified_rows },
   { "diff_stat_surfaces_corrupt_root", "Diff Stat Surfaces Corrupt Root Test", run_diff_stat_surfaces_corrupt_root },
   { "table_moveto_mutmap_delete_preserves_neighbors", "Table Moveto MutMap Delete Preserves Neighbors Test", run_table_moveto_mutmap_delete_preserves_neighbors },
   { "table_moveto_mutmap_exact_keeps_iteration_aligned", "Table Moveto MutMap Exact Keeps Iteration Aligned Test", run_table_moveto_mutmap_exact_keeps_iteration_aligned },


### PR DESCRIPTION
## Summary
- build the from/to column-name mapping once per table in dolt_diff_stat
- reuse the mapping for every modified row instead of scanning column names per row
- add a wide-table modified-row regression guard

## Tests
- make doltlite libdoltlite.a
- cc -g -I. -Isrc -o doltlite_regression_test_c test/doltlite_regression_test_c.c libdoltlite.a -lz -lpthread -lm && ./doltlite_regression_test_c diff_stat_wide_modified_rows
- bash test/vc_oracle_diff_stat_test.sh
- bash test/vc_oracle_diff_multi_pk_test.sh
- bash test/doltlite_diff.sh
- bash test/review_regression_test.sh
- bash test/doltlite_parity.sh