### PR TITLE
chunk_store: verify chunk hash on read

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -1956,7 +1956,7 @@ int chunkStoreGet(
     memcpy(pCopy, cs->pWriteBuf + off + 4, sz);
     *ppData = pCopy;
     *pnData = sz;
-    return SQLITE_OK;
+    goto verify;
   }
 
   {
@@ -1981,7 +1981,7 @@ int chunkStoreGet(
         memcpy(pCopy, cs->pWriteBuf + e->offset + 4, e->size);
         *ppData = pCopy;
         *pnData = e->size;
-        return SQLITE_OK;
+        goto verify;
       }
       return SQLITE_CORRUPT;
     }
@@ -2015,6 +2015,17 @@ int chunkStoreGet(
     }
   }
 
+verify:
+  {
+    ProllyHash h;
+    prollyHashCompute(*ppData, *pnData, &h);
+    if( memcmp(&h, hash, sizeof(ProllyHash)) != 0 ){
+      sqlite3_free(*ppData);
+      *ppData = 0;
+      *pnData = 0;
+      return SQLITE_CORRUPT;
+    }
+  }
   return SQLITE_OK;
 }
 


### PR DESCRIPTION
## Summary

`chunkStoreGet` returned the indexed bytes for a requested hash without re-hashing them against the requested key. Torn writes, on-disk bit-flips, and WAL-replay entries whose body doesn't match the recorded header hash would silently be served as valid chunks.

This was the CRITICAL #5 finding from the 2026-05-12 code review.

## Fix

Single tail `verify:` block at the end of `chunkStoreGet`. All four read paths (pending, recent, in-memory `pWriteBuf`, on-disk) `goto verify` after setting `*ppData`/`*pnData`. The tail block re-hashes and compares against the requested key; mismatch frees the buffer and returns `SQLITE_CORRUPT`.

Cost: one BLAKE3 hash per chunk read (~10-50ns for typical leaves). Acceptable for the integrity guarantee.

## Notes

Adjacent gap: `csReplayWal` records chunk entries from a header read (hash + length) without ever reading the body. Bad bodies still land in the pending list. With this fix, the bad bytes get caught on the next `chunkStoreGet` — but eagerly verifying during WAL replay would catch them at recovery time. Worth a follow-up.