### PR TITLE
chunk_store: verify chunk body hash during WAL replay

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -1016,6 +1016,19 @@ static int csReplayWal(ChunkStore *cs){
       }
 
       {
+        u8 *pBody = (u8 *)sqlite3_malloc((int)len);
+        ProllyHash bodyHash;
+        if( pBody == 0 ){ rc = SQLITE_NOMEM; goto replay_error; }
+        rc = sqlite3OsRead(cs->pFile, pBody, (int)len, cs->iWalOffset + pos);
+        if( rc != SQLITE_OK ){ sqlite3_free(pBody); goto replay_error; }
+        prollyHashCompute(pBody, (int)len, &bodyHash);
+        sqlite3_free(pBody);
+        if( memcmp(&bodyHash, &hash, sizeof(ProllyHash)) != 0 ){
+          break;
+        }
+      }
+
+      {
         int existing = csSearchIndex(cs->aIndex, cs->nIndex, &hash);
         ChunkIndexEntry *e = 0;
         if( existing < 0 ){


### PR DESCRIPTION
## Summary

Follow-up to #841. That PR added hash verification at read time in `chunkStoreGet`, catching torn writes / bit-flips / bad WAL-replay bodies when the chunk is first served. This PR catches them eagerly during WAL replay so a corrupted body is detected at DB open rather than at first read.

## Fix

In `csReplayWal`, after the existing torn-write bounds check and before the pending-entry add: read the body, BLAKE3-hash it, compare to the header's declared hash. On mismatch, `break` out of the replay loop — same fail-fast pattern the surrounding code uses for partial-write detection (`(u64)pos + len > walSize`). Earlier (verified) WAL entries are kept.

## Cost

One BLAKE3 over each WAL chunk body at DB open. The bodies were already going to be paged in eventually on first read; this just pulls the work forward. For DBs with many uncommitted WAL chunks at open this is measurable but bounded; for the steady-state case (small WAL) it's negligible.

## Smoke tested

Write + commit + uncommitted insert → reopen → reads return correct rows; the WAL-replay path now goes through the new verify and accepts the legitimate chunks.