### PR TITLE
packaging: install sqlite3.h and doltlite_remotesrv.h alongside doltlite.h

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,7 +181,9 @@ jobs:
         VERSION=${GITHUB_REF_NAME#v}
         DIR="doltlite-lib-${{ matrix.target }}-${VERSION}"
         mkdir -p "${DIR}"
+        cp build/sqlite3.h "${DIR}/sqlite3.h" 2>/dev/null || true
         cp build/sqlite3.h "${DIR}/doltlite.h" 2>/dev/null || true
+        cp src/doltlite_remotesrv.h "${DIR}/doltlite_remotesrv.h" 2>/dev/null || true
         cp build/libdoltlite${{ matrix.static_ext }} "${DIR}/" 2>/dev/null || true
         cp build/libdoltlite${{ matrix.lib_ext }} "${DIR}/" 2>/dev/null || true
         if command -v zip >/dev/null 2>&1; then

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Prebuilt binaries: [github.com/dolthub/doltlite/releases](https://github.com/dol
 Each install method places the same set of files (paths shown for `/usr/local`):
 
 - `bin/doltlite`, `bin/doltlite-remotesrv` — the CLI shell and remote sync server
-- `include/doltlite.h` — header for embedding
+- `include/sqlite3.h`, `include/doltlite.h` — embedding header (same content; either name works)
+- `include/doltlite_remotesrv.h` — in-process remote server API
 - `lib/libdoltlite.a` — static library
 - `lib/libdoltlite.{so,dylib}` — shared library
 

--- a/install.sh
+++ b/install.sh
@@ -123,10 +123,12 @@ for bin in doltlite doltlite-remotesrv; do
   echo "Installed ${INSTALL_DIR}/${bin}"
 done
 
-if [ -f "${LIB_SRC_DIR}/doltlite.h" ]; then
-  install -m 0644 "${LIB_SRC_DIR}/doltlite.h" "${INCLUDE_DIR}/doltlite.h"
-  echo "Installed ${INCLUDE_DIR}/doltlite.h"
-fi
+for hdr in sqlite3.h doltlite.h doltlite_remotesrv.h; do
+  if [ -f "${LIB_SRC_DIR}/${hdr}" ]; then
+    install -m 0644 "${LIB_SRC_DIR}/${hdr}" "${INCLUDE_DIR}/${hdr}"
+    echo "Installed ${INCLUDE_DIR}/${hdr}"
+  fi
+done
 if [ -f "${LIB_SRC_DIR}/libdoltlite.a" ]; then
   install -m 0644 "${LIB_SRC_DIR}/libdoltlite.a" "${LIB_DIR}/libdoltlite.a"
   echo "Installed ${LIB_DIR}/libdoltlite.a"

--- a/packaging/homebrew/doltlite.rb
+++ b/packaging/homebrew/doltlite.rb
@@ -16,7 +16,14 @@ class Doltlite < Formula
       system "../configure"
       system "make", "doltlite", "doltlite-remotesrv", "doltlite-lib"
       bin.install "doltlite", "doltlite-remotesrv"
+      # Ship sqlite3.h verbatim so existing C programs that
+      # `#include "sqlite3.h"` (including examples/quickstart.c) just
+      # work after install. doltlite.h is the same content under the
+      # project's preferred name. doltlite_remotesrv.h declares the
+      # in-process remote-server API (doltliteServeAsync et al.).
+      include.install "sqlite3.h"
       include.install "sqlite3.h" => "doltlite.h"
+      include.install "#{buildpath}/src/doltlite_remotesrv.h"
       lib.install "libdoltlite.a"
       lib.install OS.mac? ? "libdoltlite.dylib" : "libdoltlite.so"
     end
@@ -25,5 +32,19 @@ class Doltlite < Formula
   test do
     assert_match version.to_s,
                  shell_output("#{bin}/doltlite :memory: 'SELECT dolt_version();'")
+    (testpath/"hello.c").write <<~EOS
+      #include <stdio.h>
+      #include "sqlite3.h"
+      int main(void) {
+        sqlite3 *db;
+        if (sqlite3_open(":memory:", &db) != SQLITE_OK) return 1;
+        sqlite3_close(db);
+        printf("ok\\n");
+        return 0;
+      }
+    EOS
+    system ENV.cc, "hello.c", "-I#{include}", "-L#{lib}", "-ldoltlite",
+                   "-o", "hello"
+    assert_equal "ok", shell_output("./hello").chomp
   end
 end

--- a/packaging/nfpm/libdoltlite-dev.yaml
+++ b/packaging/nfpm/libdoltlite-dev.yaml
@@ -20,8 +20,20 @@ depends:
   - libdoltlite0 (= ${VERSION})
 
 contents:
+  # Ship sqlite3.h verbatim so existing C programs that
+  # `#include "sqlite3.h"` (including examples/quickstart.c) keep
+  # working after `apt install libdoltlite-dev`. doltlite.h is the
+  # same content under the project's preferred name.
+  - src: build/sqlite3.h
+    dst: /usr/include/sqlite3.h
+    file_info:
+      mode: 0644
   - src: build/sqlite3.h
     dst: /usr/include/doltlite.h
+    file_info:
+      mode: 0644
+  - src: src/doltlite_remotesrv.h
+    dst: /usr/include/doltlite_remotesrv.h
     file_info:
       mode: 0644
   - src: build/libdoltlite.a


### PR DESCRIPTION
## Summary

- The dev header shipped to date is `doltlite.h` (which is `sqlite3.h` verbatim under a different name), but the README C snippets and `examples/quickstart.c` do `#include "sqlite3.h"`. After `brew install doltlite` or `dpkg -i libdoltlite-dev.deb`, that include didn't resolve. Also, the in-process remote-server API (`doltlite_remotesrv.h` — `doltliteServeAsync` et al., referenced from README L692) wasn't shipped at all.
- Approach A (cheapest): install `sqlite3.h`, `doltlite.h` (same content), and `doltlite_remotesrv.h` on all three distribution channels (Homebrew, libdoltlite-dev .deb, release.yml lib zip + install.sh).
- No header content changes — just additional install paths and an aliasing copy.

## Test plan

- [x] Built `make doltlite-lib` locally; staged a fake install dir with the three headers and the dylib.
- [x] Compiled `examples/quickstart.c` (`#include "sqlite3.h"`) against the staged headers; ran end-to-end against an in-memory DB.
- [x] Compiled a tiny program using `#include "doltlite.h"` and `#include "doltlite_remotesrv.h"` against the staged headers; confirmed `doltliteServeAsync` is declared.
- [x] Extended Homebrew `test do` block: compiles + runs a sqlite3_open program against the installed headers and library to catch regressions of this exact gap.
- [ ] CI: confirm release.yml lib zip now contains `sqlite3.h`, `doltlite.h`, `doltlite_remotesrv.h` (will be visible on the next release).
- [ ] CI: confirm libdoltlite-dev .deb's contents include `/usr/include/sqlite3.h` and `/usr/include/doltlite_remotesrv.h` (next release).

## Notes

- Did not change any header contents — `doltlite.h` is still sqlite3.h verbatim. A future PR could make `doltlite.h` a thin wrapper that includes `sqlite3.h` and forward-declares doltlite-only public symbols (Approach B in the design discussion), but that's a separate cleanup.
- The doltlite-specific public-symbol surface that currently has no header declaration is small (zero non-`dolt_*-as-SQL-functions` symbols beyond what `doltlite_remotesrv.h` already declares); no new C symbols were uncovered during this review.