### PR TITLE
test: FK action coverage for merge constraint oracle

### DIFF
--- a/test/vc_oracle_fk_merge_test.sh
+++ b/test/vc_oracle_fk_merge_test.sh
@@ -292,6 +292,304 @@ ROLLBACK;" \
   "0|1|1:9:main1,2:9:feat2"
 echo ""
 
+# Helper for cases where the merge MUST succeed (no rollback) and the
+# resulting state must match an expected string. Setup must commit the
+# pre-merge state on both branches; this helper performs the merge as a
+# separate statement so we can detect spurious errors. The state query
+# should produce a single line ending in 'OK' on success and 'BAD' on
+# unexpected state — matches the style of run_rollback_case.
+#
+# Setup scripts that need cascading FK behavior must start with
+# 'PRAGMA foreign_keys=1;' since SQLite/doltlite has FK enforcement OFF
+# by default. Dolt has FK enforcement ON by default and does not accept
+# the PRAGMA, so these are doltlite-only oracle cases (the matching Dolt
+# behavior was verified manually during test authoring).
+run_clean_merge_case() {
+  local name="$1" setup_sql="$2" state_query="$3"
+  local db="$TMPROOT/$name.db"
+  rm -f "$db"
+
+  printf '%s\n' "$setup_sql" | dl_setup "$db" "$name"
+
+  local merge_err
+  merge_err=$("$DOLTLITE" "$db" "SELECT dolt_merge('feat');" 2>"$TMPROOT/${name}_merge.err" > "$TMPROOT/${name}_merge.out"; cat "$TMPROOT/${name}_merge.err")
+  if [ -n "$merge_err" ]; then
+    fail_name "${name}_merge_succeeds"
+    echo "    unexpected merge error: $merge_err"
+    return
+  else
+    pass_name "${name}_merge_succeeds"
+  fi
+
+  local conflicts
+  conflicts=$(dl "$db" "SELECT count(*) FROM dolt_conflicts;" "${name}_conflicts")
+  expect_eq "${name}_no_conflicts" "0" "$conflicts"
+
+  local violations
+  violations=$(dl "$db" "SELECT count(*) FROM dolt_constraint_violations;" "${name}_violations")
+  expect_eq "${name}_no_violations" "0" "$violations"
+
+  local state
+  state=$(dl "$db" "$state_query" "${name}_state")
+  expect_eq "${name}_state_ok" "OK" "$state"
+}
+
+echo "--- I. ON DELETE CASCADE: parent dropped on main, unrelated feat insert ---"
+run_clean_merge_case \
+  "fk_action_cascade_clean" \
+"PRAGMA foreign_keys=1;
+CREATE TABLE parent(pk INTEGER PRIMARY KEY);
+CREATE TABLE child(pk INTEGER PRIMARY KEY, pv INT, FOREIGN KEY(pv) REFERENCES parent(pk) ON DELETE CASCADE);
+INSERT INTO parent VALUES (1),(2),(3);
+INSERT INTO child VALUES (100,1),(101,1),(200,2);
+SELECT dolt_commit('-Am','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO parent VALUES (4);
+INSERT INTO child VALUES (400,4);
+SELECT dolt_commit('-Am','feat_add_unrelated');
+SELECT dolt_checkout('main');
+DELETE FROM parent WHERE pk=1;
+SELECT dolt_commit('-Am','main_drop_parent');" \
+  "SELECT CASE
+      WHEN (SELECT group_concat(pk || ':' || pv, ',')
+              FROM (SELECT pk,pv FROM child ORDER BY pk))='200:2,400:4'
+       AND (SELECT count(*) FROM parent)=3
+      THEN 'OK' ELSE 'BAD' END;"
+echo ""
+
+echo "--- J. ON DELETE CASCADE: orphan from feat side surfaces violation ---"
+run_rollback_case \
+  "fk_action_cascade_orphan" \
+"PRAGMA foreign_keys=1;
+CREATE TABLE parent(pk INTEGER PRIMARY KEY);
+CREATE TABLE child(pk INTEGER PRIMARY KEY, pv INT, FOREIGN KEY(pv) REFERENCES parent(pk) ON DELETE CASCADE);
+INSERT INTO parent VALUES (1),(2);
+INSERT INTO child VALUES (100,1),(200,2);
+SELECT dolt_commit('-Am','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO child VALUES (300,1);
+SELECT dolt_commit('-Am','feat_add_child_of_p1');
+SELECT dolt_checkout('main');
+DELETE FROM parent WHERE pk=1;
+SELECT dolt_commit('-Am','main_drop_p1');" \
+  "SELECT CASE
+      WHEN (SELECT count(*) FROM parent)=1
+       AND (SELECT count(*) FROM child WHERE pv=1)=0
+       AND (SELECT count(*) FROM child WHERE pk=200)=1
+      THEN 'OK' ELSE 'BAD' END;"
+echo ""
+
+echo "--- K. ON DELETE SET NULL: orphan from main side NULLed, feat add merges ---"
+run_clean_merge_case \
+  "fk_action_set_null_clean" \
+"PRAGMA foreign_keys=1;
+CREATE TABLE parent(pk INTEGER PRIMARY KEY);
+CREATE TABLE child(pk INTEGER PRIMARY KEY, pv INT, FOREIGN KEY(pv) REFERENCES parent(pk) ON DELETE SET NULL);
+INSERT INTO parent VALUES (1),(2);
+INSERT INTO child VALUES (100,1),(200,2);
+SELECT dolt_commit('-Am','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO child VALUES (300,2);
+SELECT dolt_commit('-Am','feat_add_child');
+SELECT dolt_checkout('main');
+DELETE FROM parent WHERE pk=1;
+SELECT dolt_commit('-Am','main_drop_p1');" \
+  "SELECT CASE
+      WHEN (SELECT group_concat(pk || ':' || ifnull(pv,'NULL'), ',')
+              FROM (SELECT pk,pv FROM child ORDER BY pk))='100:NULL,200:2,300:2'
+      THEN 'OK' ELSE 'BAD' END;"
+echo ""
+
+echo "--- L. ON UPDATE CASCADE: parent key updated, propagates through merge ---"
+run_clean_merge_case \
+  "fk_action_update_cascade_clean" \
+"PRAGMA foreign_keys=1;
+CREATE TABLE parent(pk INTEGER PRIMARY KEY);
+CREATE TABLE child(pk INTEGER PRIMARY KEY, pv INT, FOREIGN KEY(pv) REFERENCES parent(pk) ON UPDATE CASCADE);
+INSERT INTO parent VALUES (1),(2);
+INSERT INTO child VALUES (100,1),(200,2);
+SELECT dolt_commit('-Am','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO child VALUES (300,2);
+SELECT dolt_commit('-Am','feat_add_child');
+SELECT dolt_checkout('main');
+UPDATE parent SET pk=10 WHERE pk=1;
+SELECT dolt_commit('-Am','main_renumber');" \
+  "SELECT CASE
+      WHEN (SELECT group_concat(pk || ':' || pv, ',')
+              FROM (SELECT pk,pv FROM child ORDER BY pk))='100:10,200:2,300:2'
+       AND (SELECT group_concat(pk, ',')
+              FROM (SELECT pk FROM parent ORDER BY pk))='2,10'
+      THEN 'OK' ELSE 'BAD' END;"
+echo ""
+
+echo "--- M. Explicit ON DELETE NO ACTION: orphan from feat side rolls back ---"
+run_rollback_case \
+  "fk_action_no_action_explicit" \
+"PRAGMA foreign_keys=1;
+CREATE TABLE parent(pk INTEGER PRIMARY KEY);
+CREATE TABLE child(pk INTEGER PRIMARY KEY, pv INT, FOREIGN KEY(pv) REFERENCES parent(pk) ON DELETE NO ACTION);
+INSERT INTO parent VALUES (1),(2);
+INSERT INTO child VALUES (200,2);
+SELECT dolt_commit('-Am','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO child VALUES (300,1);
+SELECT dolt_commit('-Am','feat_add_child_p1');
+SELECT dolt_checkout('main');
+DELETE FROM parent WHERE pk=1;
+SELECT dolt_commit('-Am','main_drop_p1');" \
+  "SELECT CASE
+      WHEN (SELECT count(*) FROM parent)=1
+       AND (SELECT count(*) FROM child)=1
+       AND (SELECT count(*) FROM child WHERE pk=300)=0
+      THEN 'OK' ELSE 'BAD' END;"
+echo ""
+
+echo "--- N. Both sides delete same parent with CASCADE: convergent merge ---"
+run_clean_merge_case \
+  "fk_action_convergent_delete" \
+"PRAGMA foreign_keys=1;
+CREATE TABLE parent(pk INTEGER PRIMARY KEY);
+CREATE TABLE child(pk INTEGER PRIMARY KEY, pv INT, FOREIGN KEY(pv) REFERENCES parent(pk) ON DELETE CASCADE);
+INSERT INTO parent VALUES (1),(2);
+INSERT INTO child VALUES (100,1),(200,2);
+SELECT dolt_commit('-Am','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+DELETE FROM parent WHERE pk=1;
+SELECT dolt_commit('-Am','feat_drop_p1');
+SELECT dolt_checkout('main');
+DELETE FROM parent WHERE pk=1;
+SELECT dolt_commit('-Am','main_drop_p1');" \
+  "SELECT CASE
+      WHEN (SELECT group_concat(pk, ',')
+              FROM (SELECT pk FROM parent ORDER BY pk))='2'
+       AND (SELECT group_concat(pk || ':' || pv, ',')
+              FROM (SELECT pk,pv FROM child ORDER BY pk))='200:2'
+      THEN 'OK' ELSE 'BAD' END;"
+echo ""
+
+echo "--- O. Multi-column FK with ON DELETE CASCADE: clean merge ---"
+run_clean_merge_case \
+  "fk_action_multicolumn_cascade" \
+"PRAGMA foreign_keys=1;
+CREATE TABLE parent(a INT, b INT, PRIMARY KEY(a,b));
+CREATE TABLE child(pk INTEGER PRIMARY KEY, ca INT, cb INT, FOREIGN KEY(ca,cb) REFERENCES parent(a,b) ON DELETE CASCADE);
+INSERT INTO parent VALUES (1,1),(2,2);
+INSERT INTO child VALUES (100,1,1),(200,2,2);
+SELECT dolt_commit('-Am','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO child VALUES (300,2,2);
+SELECT dolt_commit('-Am','feat_add_child');
+SELECT dolt_checkout('main');
+DELETE FROM parent WHERE a=1 AND b=1;
+SELECT dolt_commit('-Am','main_drop_p11');" \
+  "SELECT CASE
+      WHEN (SELECT group_concat(pk || ':' || ca || ':' || cb, ',')
+              FROM (SELECT pk,ca,cb FROM child ORDER BY pk))='200:2:2,300:2:2'
+       AND (SELECT count(*) FROM parent)=1
+      THEN 'OK' ELSE 'BAD' END;"
+echo ""
+
+echo "--- P. Multi-column FK with ON DELETE SET NULL: NULL both columns ---"
+run_clean_merge_case \
+  "fk_action_multicolumn_set_null" \
+"PRAGMA foreign_keys=1;
+CREATE TABLE parent(a INT, b INT, PRIMARY KEY(a,b));
+CREATE TABLE child(pk INTEGER PRIMARY KEY, ca INT, cb INT, FOREIGN KEY(ca,cb) REFERENCES parent(a,b) ON DELETE SET NULL);
+INSERT INTO parent VALUES (1,1),(2,2);
+INSERT INTO child VALUES (100,1,1),(200,2,2);
+SELECT dolt_commit('-Am','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO child VALUES (300,2,2);
+SELECT dolt_commit('-Am','feat_add_child');
+SELECT dolt_checkout('main');
+DELETE FROM parent WHERE a=1 AND b=1;
+SELECT dolt_commit('-Am','main_drop_p11');" \
+  "SELECT CASE
+      WHEN (SELECT group_concat(pk || ':' || ifnull(ca,'NULL') || ':' || ifnull(cb,'NULL'), ',')
+              FROM (SELECT pk,ca,cb FROM child ORDER BY pk))='100:NULL:NULL,200:2:2,300:2:2'
+      THEN 'OK' ELSE 'BAD' END;"
+echo ""
+
+echo "--- Q. Parent deleted on feat (not main) with CASCADE: clean merge ---"
+run_clean_merge_case \
+  "fk_action_cascade_feat_side" \
+"PRAGMA foreign_keys=1;
+CREATE TABLE parent(pk INTEGER PRIMARY KEY);
+CREATE TABLE child(pk INTEGER PRIMARY KEY, pv INT, FOREIGN KEY(pv) REFERENCES parent(pk) ON DELETE CASCADE);
+INSERT INTO parent VALUES (1),(2),(3);
+INSERT INTO child VALUES (100,1),(200,2),(300,3);
+SELECT dolt_commit('-Am','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+DELETE FROM parent WHERE pk=2;
+SELECT dolt_commit('-Am','feat_drop_p2');
+SELECT dolt_checkout('main');
+INSERT INTO parent VALUES (4);
+INSERT INTO child VALUES (400,4);
+SELECT dolt_commit('-Am','main_add_unrelated');" \
+  "SELECT CASE
+      WHEN (SELECT group_concat(pk || ':' || pv, ',')
+              FROM (SELECT pk,pv FROM child ORDER BY pk))='100:1,300:3,400:4'
+       AND (SELECT group_concat(pk, ',')
+              FROM (SELECT pk FROM parent ORDER BY pk))='1,3,4'
+      THEN 'OK' ELSE 'BAD' END;"
+echo ""
+
+echo "--- R. ON UPDATE CASCADE + ON DELETE CASCADE: divergent edits surface conflict/violation and roll back ---"
+run_rollback_case \
+  "fk_action_update_divergent" \
+"PRAGMA foreign_keys=1;
+CREATE TABLE parent(pk INTEGER PRIMARY KEY);
+CREATE TABLE child(pk INTEGER PRIMARY KEY, pv INT, FOREIGN KEY(pv) REFERENCES parent(pk) ON UPDATE CASCADE ON DELETE CASCADE);
+INSERT INTO parent VALUES (1),(2);
+INSERT INTO child VALUES (100,1),(200,2);
+SELECT dolt_commit('-Am','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+UPDATE child SET pv=2 WHERE pk=100;
+SELECT dolt_commit('-Am','feat_repoint_child');
+SELECT dolt_checkout('main');
+UPDATE parent SET pk=10 WHERE pk=1;
+SELECT dolt_commit('-Am','main_renumber_p1');" \
+  "SELECT CASE
+      WHEN (SELECT group_concat(pk, ',')
+              FROM (SELECT pk FROM parent ORDER BY pk))='2,10'
+       AND (SELECT group_concat(pk || ':' || pv, ',')
+              FROM (SELECT pk,pv FROM child ORDER BY pk))='100:10,200:2'
+      THEN 'OK' ELSE 'BAD' END;"
+echo ""
+
+echo "--- S. ON DELETE SET DEFAULT (doltlite-only; dolt rejects the syntax, dolthub/dolt#11041) ---"
+run_clean_merge_case \
+  "fk_action_set_default" \
+"PRAGMA foreign_keys=1;
+CREATE TABLE parent(pk INTEGER PRIMARY KEY);
+CREATE TABLE child(pk INTEGER PRIMARY KEY, pv INT DEFAULT 99, FOREIGN KEY(pv) REFERENCES parent(pk) ON DELETE SET DEFAULT);
+INSERT INTO parent VALUES (1),(2),(99);
+INSERT INTO child VALUES (100,1),(200,2);
+SELECT dolt_commit('-Am','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO child VALUES (300,2);
+SELECT dolt_commit('-Am','feat_add_child');
+SELECT dolt_checkout('main');
+DELETE FROM parent WHERE pk=1;
+SELECT dolt_commit('-Am','main_drop_p1');" \
+  "SELECT CASE
+      WHEN (SELECT group_concat(pk || ':' || pv, ',')
+              FROM (SELECT pk,pv FROM child ORDER BY pk))='100:99,200:2,300:2'
+      THEN 'OK' ELSE 'BAD' END;"
+echo ""
+
 echo "======================================="
 echo "Results: $pass passed, $fail failed"
 echo "======================================="


### PR DESCRIPTION
## Summary

- Adds 11 oracle cases to `test/vc_oracle_fk_merge_test.sh` covering cross-branch merges with `ON DELETE CASCADE` / `SET NULL` / `SET DEFAULT` / `NO ACTION` and `ON UPDATE CASCADE`, including multi-column FK and convergent deletes.
- Closes a HIGH-severity coverage gap: prior FK merge cases used implicit `NO ACTION` only. Cascading FK actions are a notorious bug surface — this path recently had a UAF (#813) and other latent issues flagged in review.
- Introduces `run_clean_merge_case` for cases where the merge MUST succeed; existing `run_rollback_case` handles violation paths.

## New cases

| Case | Action | Outcome |
| --- | --- | --- |
| I `fk_action_cascade_clean` | `ON DELETE CASCADE` | clean merge, cascade applied on main |
| J `fk_action_cascade_orphan` | `ON DELETE CASCADE` | feat-side child of deleted parent rolls back |
| K `fk_action_set_null_clean` | `ON DELETE SET NULL` | clean merge, orphan FK -> NULL |
| L `fk_action_update_cascade_clean` | `ON UPDATE CASCADE` | clean merge, child key renumbered |
| M `fk_action_no_action_explicit` | `ON DELETE NO ACTION` | explicit clause, orphan rolls back |
| N `fk_action_convergent_delete` | `ON DELETE CASCADE` | both sides delete same parent — converges |
| O `fk_action_multicolumn_cascade` | multi-col `ON DELETE CASCADE` | clean merge |
| P `fk_action_multicolumn_set_null` | multi-col `ON DELETE SET NULL` | both FK cols -> NULL |
| Q `fk_action_cascade_feat_side` | `ON DELETE CASCADE` on feat | varies which side cascades |
| R `fk_action_update_divergent` | `ON UPDATE CASCADE` + `ON DELETE CASCADE` | both sides edit incompatibly — rolls back |
| S `fk_action_set_default` | `ON DELETE SET DEFAULT` | doltlite-only (see Caveats) |

73 assertions total (29 prior + 44 new), all pass.

## Caveats

- SQLite/doltlite has FK enforcement off by default; new cases prepend `PRAGMA foreign_keys=1;`.
- Dolt rejects `ON DELETE SET DEFAULT` (`"SET DEFAULT" is not supported`) at parse time; case S is doltlite-only and the parity gap is filed as dolthub/dolt#11041. MySQL also rejects SET DEFAULT so this may be intentional; flagged so the divergence is tracked.

## Test plan

- [x] `make doltlite` builds clean
- [x] `bash test/vc_oracle_fk_merge_test.sh ./doltlite dolt` -> 73 passed, 0 failed
- [x] Each new clean-merge case manually verified against `dolt sql -c` (cases I, K, L, N, O, P, Q produce identical post-merge state; case S is doltlite-only by design)
- [x] Each new rollback case (J, M, R) verified to error on `dolt_merge` and restore pre-merge state in both engines

🤖 Generated with [Claude Code](https://claude.com/claude-code)