### PR TITLE
docs: use doltlite.h in README and quickstart example

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,10 @@ make -C ext/wasm dist
 
 ## Using as a C Library
 
-Doltlite is designed as a drop-in replacement for SQLite. It uses the same
-`sqlite3.h` header and `sqlite3_*` API, so existing C programs work without
-code changes — just link against `libdoltlite` instead of `libsqlite3` to get
+Doltlite is designed as a drop-in replacement for SQLite. New code should
+include `doltlite.h` and call the `sqlite3_*` API; the build also installs
+`sqlite3.h` as a back-compat alias so existing C programs work without code
+changes — just link against `libdoltlite` instead of `libsqlite3` to get
 version control. The build produces `libdoltlite.a` (static) and
 `libdoltlite.dylib`/`.so` (shared) with the full prolly tree engine and all
 Dolt functions included.

--- a/examples/quickstart.c
+++ b/examples/quickstart.c
@@ -16,7 +16,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "sqlite3.h"
+#include "doltlite.h"
 
 /* Print a result set with column headers */
 static int callback(void *label, int argc, char **argv, char **azColName){


### PR DESCRIPTION
Follows #843 which installs all three headers (`sqlite3.h`, `doltlite.h`, `doltlite_remotesrv.h`) as aliases. Now that `doltlite.h` is reliably present after install, switching the README narrative + `examples/quickstart.c` to use it as the canonical include. The `sqlite3.h` alias stays installed so existing code keeps compiling unchanged.

- `README.md` "Using as a C Library" paragraph reworded to lead with `doltlite.h` and note `sqlite3.h` is the back-compat alias.
- `examples/quickstart.c` switched to `#include "doltlite.h"`; verified `cc -c` clean against the in-tree header.