### PR TITLE
Fix multi-writer DML state refresh

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -361,6 +361,19 @@ static void csCaptureSavedRefsState(ChunkStore *cs, SavedRefsState *pSaved){
   pSaved->nTracking = cs->nTracking;
 }
 
+static void csDetachSavedRefsState(ChunkStore *cs, SavedRefsState *pSaved){
+  csCaptureSavedRefsState(cs, pSaved);
+  cs->zDefaultBranch = 0;
+  cs->aBranches = 0;
+  cs->nBranches = 0;
+  cs->aTags = 0;
+  cs->nTags = 0;
+  cs->aRemotes = 0;
+  cs->nRemotes = 0;
+  cs->aTracking = 0;
+  cs->nTracking = 0;
+}
+
 static void csRestoreSavedRefsState(ChunkStore *cs, const SavedRefsState *pSaved){
   cs->zDefaultBranch = pSaved->zDefaultBranch;
   cs->aBranches = pSaved->aBranches;
@@ -575,6 +588,32 @@ static int csRestoreCommittedRefsState(ChunkStore *cs){
     return csEnsureDefaultBranch(cs);
   }
   return chunkStoreReloadRefs(cs);
+}
+
+static int csReloadFromDiskPreservingLocalRefs(ChunkStore *cs){
+  int rc;
+  int preserveRefs = cs->nPending > 0
+                  && prollyHashCompare(&cs->refsHash,
+                                       &cs->committedRefsHash)!=0;
+  ProllyHash savedRefsHash;
+  SavedRefsState savedRefs;
+
+  memset(&savedRefs, 0, sizeof(savedRefs));
+  if( preserveRefs ){
+    savedRefsHash = cs->refsHash;
+    csDetachSavedRefsState(cs, &savedRefs);
+  }
+
+  rc = csReloadFromDisk(cs);
+
+  if( preserveRefs ){
+    if( rc==SQLITE_OK ){
+      csFreeRefsState(cs);
+    }
+    csRestoreSavedRefsState(cs, &savedRefs);
+    cs->refsHash = savedRefsHash;
+  }
+  return rc;
 }
 
 static int csSearchIndex(
@@ -2143,7 +2182,7 @@ static int csCommitToFile(ChunkStore *cs){
     int rc2 = sqlite3OsFileControl(cs->pFile, SQLITE_FCNTL_HAS_MOVED,
                                    &bMoved);
     if( rc2==SQLITE_OK && bMoved ){
-      rc = csReloadFromDisk(cs);
+      rc = csReloadFromDiskPreservingLocalRefs(cs);
       if( rc != SQLITE_OK ) goto commit_done;
       fileSize = cs->iFileSize;
     }
@@ -2151,7 +2190,7 @@ static int csCommitToFile(ChunkStore *cs){
   }
 
   if( fileSize > cs->iFileSize && hadFile ){
-    rc = csReloadFromDisk(cs);
+    rc = csReloadFromDiskPreservingLocalRefs(cs);
     if( rc != SQLITE_OK ) goto commit_done;
     fileSize = cs->iFileSize;
   }
@@ -2392,12 +2431,34 @@ commit_done:
 int chunkStoreCommit(ChunkStore *cs){
   int rc;
   int acquiredLock = 0;
+  int preserveRefs = 0;
+  ProllyHash savedRefsHash;
+  SavedRefsState savedRefs;
+
+  memset(&savedRefs, 0, sizeof(savedRefs));
   if( cs->readOnly ) return SQLITE_READONLY;
   if( cs->isMemory ) return csCommitToMemory(cs);
-
   if( cs->graphLockFd < 0 && cs->zFilename ){
+    preserveRefs = cs->nPending > 0
+                && prollyHashCompare(&cs->refsHash,
+                                     &cs->committedRefsHash)!=0;
+    if( preserveRefs ){
+      savedRefsHash = cs->refsHash;
+      csDetachSavedRefsState(cs, &savedRefs);
+    }
     rc = chunkStoreLockAndRefresh(cs);
-    if( rc!=SQLITE_OK ) return rc;
+    if( rc!=SQLITE_OK ){
+      if( preserveRefs ){
+        csRestoreSavedRefsState(cs, &savedRefs);
+        cs->refsHash = savedRefsHash;
+      }
+      return rc;
+    }
+    if( preserveRefs ){
+      csFreeRefsState(cs);
+      csRestoreSavedRefsState(cs, &savedRefs);
+      cs->refsHash = savedRefsHash;
+    }
     acquiredLock = 1;
   }
   rc = csCommitToFile(cs);

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -159,6 +159,7 @@ struct BtShared {
   BtCursor *pCursor;
   u16 btsFlags;
   u32 pageSize;
+  u32 iWorkingStateVersion;
   int nRef;
 };
 
@@ -252,6 +253,7 @@ struct Btree {
   BtShared *pBt;
   u8 inTrans;
   u32 iBDataVersion;
+  u32 iLoadedWorkingStateVersion;
   Btree *pNext;
   u64 nSeek;
 
@@ -392,11 +394,11 @@ static inline void btreeFreeCatalogTables(Btree *p){
 static void invalidateCursors(BtShared *pBt, Pgno iTable, int errCode);
 static void invalidateSchema(Btree *pBtree);
 static int flushMutMap(BtCursor *pCur);
-static void refreshCursorMutMapAliases(BtShared *pBt, Pgno iTable,
-                                        ProllyMutMap *pNewMap);
+static void refreshCursorMutMapAliases(Btree *pBtree, BtShared *pBt,
+                                        Pgno iTable, ProllyMutMap *pNewMap);
 static void getCursorPayload(BtCursor *pCur, const u8 **ppData, int *pnData);
 static int flushIfNeeded(BtCursor *pCur);
-static int flushAllPending(BtShared *pBt, Pgno iTable);
+static int flushAllPending(Btree *pBtree, BtShared *pBt, Pgno iTable);
 static int applyMutMapToTableRoot(BtShared *pBt, struct TableEntry *pTE, ProllyMutMap *pMap);
 static int flushPendingForTable(Btree *pBtree, BtShared *pBt,
                                 struct TableEntry *pTE, int clearInPlace);
@@ -463,7 +465,7 @@ static SQLITE_INLINE int prollyCursorNextFastLeaf(ProllyCursor *pCur){
   }
   return prollyCursorNext(pCur);
 }
-static int flushDeferredEdits(BtShared *pBt);
+static int flushDeferredEdits(Btree *pBtree, BtShared *pBt);
 static int ensureMutMap(BtCursor *pCur);
 static int saveCursorPosition(BtCursor *pCur);
 static int restoreCursorPosition(BtCursor *pCur, int *pDifferentRow);
@@ -476,7 +478,8 @@ static int snapshotPendingForFlush(Btree *pBtree, Pgno iTable, ProllyMutMap **pp
 static int restoreFromCommitted(Btree *p);
 static void refreshCursorRoot(BtCursor *pCur);
 static int countTreeEntries(Btree *pBtree, Pgno iTable, i64 *pCount);
-static int saveAllCursors(BtShared *pBt, Pgno iRoot, BtCursor *pExcept);
+static int saveAllCursors(Btree *pBtree, BtShared *pBt, Pgno iRoot,
+                          BtCursor *pExcept);
 static int serializeCatalog(Btree *pBtree, u8 **ppOut, int *pnOut);
 static int deserializeCatalog(Btree *pBtree, const u8 *data, int nData);
 static int tableEntryIsTableRoot(Btree *pBtree, struct TableEntry *pTE);
@@ -2369,7 +2372,7 @@ static int flushMutMap(BtCursor *pCur){
                                &pFlushMap, &captured);
   if( rc!=SQLITE_OK ) return rc;
   if( captured ){
-    refreshCursorMutMapAliases(pCur->pBt, pCur->pgnoRoot,
+    refreshCursorMutMapAliases(pCur->pBtree, pCur->pBt, pCur->pgnoRoot,
                                (ProllyMutMap*)pTE->pPending);
   }
   rc = applyMutMapToTableRoot(pCur->pBt, pTE, pFlushMap);
@@ -2405,7 +2408,7 @@ static int flushPendingForTable(
                                &pFlushMap, &captured);
   if( rc!=SQLITE_OK ) return rc;
   if( captured ){
-    refreshCursorMutMapAliases(pBt, pTE->iTable,
+    refreshCursorMutMapAliases(pBtree, pBt, pTE->iTable,
                                (ProllyMutMap*)pTE->pPending);
   }
 
@@ -2419,7 +2422,7 @@ static int flushPendingForTable(
       prollyMutMapFree(pMap);
       sqlite3_free(pMap);
       pTE->pPending = 0;
-      refreshCursorMutMapAliases(pBt, pTE->iTable, 0);
+      refreshCursorMutMapAliases(pBtree, pBt, pTE->iTable, 0);
     }
   }
   pTE->pendingFlushSeekEdits = 0;
@@ -2440,11 +2443,11 @@ static int syncSavepoints(BtCursor *pCur){
 
 /* Pending edit maps are shared by every cursor on the same table. When a flush
 ** swaps the table map, every live cursor must drop iterator state into it. */
-static void refreshCursorMutMapAliases(BtShared *pBt, Pgno iTable,
-                                        ProllyMutMap *pNewMap){
+static void refreshCursorMutMapAliases(Btree *pBtree, BtShared *pBt,
+                                        Pgno iTable, ProllyMutMap *pNewMap){
   BtCursor *p;
   for(p = pBt->pCursor; p; p = p->pNext){
-    if( p->pgnoRoot==iTable ){
+    if( p->pBtree==pBtree && p->pgnoRoot==iTable ){
       p->pMutMap = pNewMap;
       p->mmActive = 0;
       p->mmPhysActive = 0;
@@ -2481,7 +2484,7 @@ static int ensureMutMap(BtCursor *pCur){
     pMap->currentSavepointLevel = pCur->pBtree->nSavepoint;
   }
   pTE->pPending = pMap;
-  refreshCursorMutMapAliases(pCur->pBt, pCur->pgnoRoot, pMap);
+  refreshCursorMutMapAliases(pCur->pBtree, pCur->pBt, pCur->pgnoRoot, pMap);
   return SQLITE_OK;
 }
 
@@ -3222,10 +3225,13 @@ static int countTreeEntries(Btree *pBtree, Pgno iTable, i64 *pCount){
   return SQLITE_OK;
 }
 
-static int saveAllCursors(BtShared *pBt, Pgno iRoot, BtCursor *pExcept){
+static int saveAllCursors(Btree *pBtree, BtShared *pBt, Pgno iRoot,
+                          BtCursor *pExcept){
   BtCursor *p;
   for(p=pBt->pCursor; p; p=p->pNext){
-    if( p!=pExcept && (iRoot==0 || p->pgnoRoot==iRoot) ){
+    if( p->pBtree==pBtree
+     && p!=pExcept
+     && (iRoot==0 || p->pgnoRoot==iRoot) ){
       if( p->eState==CURSOR_VALID || p->eState==CURSOR_SKIPNEXT ){
         int rc = saveCursorPosition(p);
         if( rc!=SQLITE_OK ) return rc;
@@ -3315,6 +3321,7 @@ int sqlite3BtreeOpen(
 
   pBt->db = db;
   pBt->pageSize = PROLLY_DEFAULT_PAGE_SIZE;
+  pBt->iWorkingStateVersion = 1;
   pBt->nRef = 1;
   p->inTransaction = TRANS_NONE;
   p->bSchemaChangedTxn = 0;
@@ -3454,6 +3461,7 @@ int sqlite3BtreeOpen(
   p->pOps = &prollyBtreeOps;
   p->inTrans = TRANS_NONE;
   p->iBDataVersion = 1;
+  p->iLoadedWorkingStateVersion = pBt->iWorkingStateVersion;
   p->nSeek = 0;
 
   {
@@ -3962,6 +3970,7 @@ static int btreeWriteWorkingState(
 static int btreeReloadBranchWorkingState(Btree *p, int bLoadCatalog){
   BtShared *pBt = p->pBt;
   ProllyHash catHash;
+  ProllyHash workingCommitHash;
   ProllyHash stagedCatalog;
   ProllyHash mergeCommitHash;
   ProllyHash conflictsCatalogHash;
@@ -3973,9 +3982,11 @@ static int btreeReloadBranchWorkingState(Btree *p, int bLoadCatalog){
   const char *zBr = p->zBranch ? p->zBranch : "main";
   u8 isMerging = 0;
   u8 isRebasing = 0;
+  int hadUserCatalog = p->cat.n > 1;
   int rc;
 
   memset(&catHash, 0, sizeof(catHash));
+  memset(&workingCommitHash, 0, sizeof(workingCommitHash));
   memset(&stagedCatalog, 0, sizeof(stagedCatalog));
   memset(&mergeCommitHash, 0, sizeof(mergeCommitHash));
   memset(&conflictsCatalogHash, 0, sizeof(conflictsCatalogHash));
@@ -3984,7 +3995,7 @@ static int btreeReloadBranchWorkingState(Btree *p, int bLoadCatalog){
   memset(&constraintViolationsHash, 0, sizeof(constraintViolationsHash));
 
   rc = btreeLoadWorkingSetBlob(
-      &pBt->store, zBr, &catHash, 0, &stagedCatalog, &isMerging,
+      &pBt->store, zBr, &catHash, &workingCommitHash, &stagedCatalog, &isMerging,
       &mergeCommitHash, &conflictsCatalogHash,
       &isRebasing, &preRebaseCat, &rebaseOnto, &zRebaseOrigBranch,
       &zRebaseReturnBranch,
@@ -3998,7 +4009,8 @@ static int btreeReloadBranchWorkingState(Btree *p, int bLoadCatalog){
     return rc;
   }
   if( prollyHashIsEmpty(&catHash) ){
-    rc = btreeLoadBranchHeadCatalog(&pBt->store, zBr, &catHash, 0);
+    rc = btreeLoadBranchHeadCatalog(&pBt->store, zBr, &catHash,
+                                    &workingCommitHash);
     if( rc==SQLITE_NOTFOUND ){
       rc = SQLITE_OK;
     }
@@ -4033,6 +4045,9 @@ static int btreeReloadBranchWorkingState(Btree *p, int bLoadCatalog){
       }
     }
   }
+  if( prollyHashIsEmpty(&p->headCommit) || !hadUserCatalog ){
+    p->headCommit = workingCommitHash;
+  }
 
   p->stagedCatalog = stagedCatalog;
   p->isMerging = isMerging;
@@ -4049,20 +4064,58 @@ static int btreeReloadBranchWorkingState(Btree *p, int bLoadCatalog){
   return SQLITE_OK;
 }
 
+static void btreeBumpDataVersion(Btree *p){
+  p->iBDataVersion++;
+  if( p->pBt->pPagerShim ){
+    p->pBt->pPagerShim->iDataVersion++;
+  }
+}
+
+static void btreeMarkWorkingStateChanged(Btree *p){
+  BtShared *pBt = p->pBt;
+  pBt->iWorkingStateVersion++;
+  if( pBt->iWorkingStateVersion==0 ){
+    pBt->iWorkingStateVersion = 1;
+  }
+  p->iLoadedWorkingStateVersion = pBt->iWorkingStateVersion;
+  btreeBumpDataVersion(p);
+}
+
+static int btreeRefreshSharedWorkingState(Btree *p){
+  BtShared *pBt = p->pBt;
+  int rc;
+  if( p->iLoadedWorkingStateVersion==pBt->iWorkingStateVersion ){
+    return SQLITE_OK;
+  }
+  rc = btreeReloadBranchWorkingState(p, 1);
+  if( rc!=SQLITE_OK ) return rc;
+  p->iLoadedWorkingStateVersion = pBt->iWorkingStateVersion;
+  btreeBumpDataVersion(p);
+  return SQLITE_OK;
+}
+
 static int btreeRefreshFromDisk(Btree *p){
   BtShared *pBt = p->pBt;
   int bChanged = 0;
-  int rc = chunkStoreRefreshIfChanged(&pBt->store, &bChanged);
+  u8 snapshotPinned = pBt->store.snapshotPinned;
+  int bAutocommitBoundary = p->inTrans==TRANS_NONE
+    && p->db && p->db->autoCommit && !p->db->pSavepoint;
+  int rc;
+
+  if( bAutocommitBoundary ){
+    pBt->store.snapshotPinned = 0;
+  }
+  rc = chunkStoreRefreshIfChanged(&pBt->store, &bChanged);
+  if( bAutocommitBoundary ){
+    pBt->store.snapshotPinned = snapshotPinned;
+  }
   if( rc!=SQLITE_OK ) return rc;
   if( !bChanged ) return SQLITE_OK;
 
   rc = btreeReloadBranchWorkingState(p, 1);
   if( rc!=SQLITE_OK ) return rc;
 
-  p->iBDataVersion++;
-  if( pBt->pPagerShim ){
-    pBt->pPagerShim->iDataVersion++;
-  }
+  btreeMarkWorkingStateChanged(p);
 
   return SQLITE_OK;
 }
@@ -4080,11 +4133,27 @@ static int prollyBtreeBeginTrans(Btree *p, int wrFlag, int *pSchemaVersion){
   }
 
   if( p->inTrans==TRANS_READ && !wrFlag ){
-    return SQLITE_OK;
+    if( p->db && p->db->autoCommit && !p->db->pSavepoint ){
+      p->inTrans = TRANS_NONE;
+      p->inTransaction = TRANS_NONE;
+      pBt->store.snapshotPinned = 0;
+    }else{
+      return SQLITE_OK;
+    }
+  }
+
+  if( p->inTrans==TRANS_READ
+   && wrFlag
+   && p->iLoadedWorkingStateVersion!=pBt->iWorkingStateVersion ){
+    return SQLITE_BUSY_SNAPSHOT;
   }
 
   rc = btreeRefreshFromDisk(p);
   if( rc!=SQLITE_OK ) return rc;
+  if( p->inTrans==TRANS_NONE ){
+    rc = btreeRefreshSharedWorkingState(p);
+    if( rc!=SQLITE_OK ) return rc;
+  }
   if( pSchemaVersion ){
     *pSchemaVersion = (int)p->aMeta[BTREE_SCHEMA_VERSION];
   }
@@ -4195,7 +4264,7 @@ static int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
   (void)bCleanup;
 
   if( p->inTrans==TRANS_WRITE ){
-    rc = flushAllPending(pBt, 0);
+    rc = flushAllPending(p, pBt, 0);
     if( rc!=SQLITE_OK ) return rc;
 
     {
@@ -4235,10 +4304,7 @@ static int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
       p->committedMergeCommitHash = p->mergeCommitHash;
       p->committedConflictsCatalogHash = p->conflictsCatalogHash;
       p->committedConstraintViolationsHash = p->constraintViolationsHash;
-      p->iBDataVersion++;
-      if( pBt->pPagerShim ){
-        pBt->pPagerShim->iDataVersion++;
-      }
+      btreeMarkWorkingStateChanged(p);
       if( bReloadSchema ){
         rc = buildRuntimeMasterRoot(p, &runtimeMasterRoot);
         if( rc!=SQLITE_OK ){
@@ -4286,7 +4352,7 @@ static int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
       {
         BtCursor *pC;
         for(pC = pBt->pCursor; pC; pC = pC->pNext){
-          if( pC->pMutMap ) prollyMutMapClear(pC->pMutMap);
+          if( pC->pBtree==p && pC->pMutMap ) prollyMutMapClear(pC->pMutMap);
         }
       }
       invalidateCursors(pBt, 0, rc);
@@ -4368,7 +4434,7 @@ static int prollyBtreeRollback(Btree *p, int tripCode, int writeOnly){
     {
       BtCursor *pC;
       for(pC = pBt->pCursor; pC; pC = pC->pNext){
-        if( pC->pMutMap ) prollyMutMapClear(pC->pMutMap);
+        if( pC->pBtree==p && pC->pMutMap ) prollyMutMapClear(pC->pMutMap);
       }
     }
     invalidateCursors(pBt, 0, tripCode ? tripCode : SQLITE_ABORT);
@@ -4773,8 +4839,20 @@ static int prollyBtreeCursor(
 ){
   BtShared *pBt = p->pBt;
   struct TableEntry *pTE;
+  int rc;
 
   assert( p->inTrans>=TRANS_READ );
+
+  if( p->db && p->db->autoCommit && !p->db->pSavepoint
+   && p->inTrans!=TRANS_WRITE ){
+    u8 oldSnapshotPinned = pBt->store.snapshotPinned;
+    pBt->store.snapshotPinned = 0;
+    rc = btreeRefreshFromDisk(p);
+    pBt->store.snapshotPinned = oldSnapshotPinned;
+    if( rc!=SQLITE_OK ) return rc;
+    rc = btreeRefreshSharedWorkingState(p);
+    if( rc!=SQLITE_OK ) return rc;
+  }
 
   memset(pCur, 0, sizeof(BtCursor));
   pCur->pBtree = p;
@@ -6023,7 +6101,7 @@ static int prollyBtCursorInsert(
   rc = syncSavepoints(pCur);
   if( rc!=SQLITE_OK ) return rc;
 
-  rc = saveAllCursors(pCur->pBt, pCur->pgnoRoot, pCur);
+  rc = saveAllCursors(pCur->pBtree, pCur->pBt, pCur->pgnoRoot, pCur);
   if( rc!=SQLITE_OK ) return rc;
 
   rc = ensureMutMap(pCur);
@@ -6172,7 +6250,9 @@ static int flushIfNeeded(BtCursor *pCur){
   {
     BtCursor *p;
     for(p = pCur->pBt->pCursor; p; p = p->pNext){
-      if( p!=pCur && p->pgnoRoot==pCur->pgnoRoot ){
+      if( p->pBtree==pCur->pBtree
+       && p!=pCur
+       && p->pgnoRoot==pCur->pgnoRoot ){
         if( !p->isPinned
          && (p->eState==CURSOR_VALID || p->eState==CURSOR_SKIPNEXT) ){
           p->isPinned = 1;
@@ -6200,27 +6280,26 @@ static int flushIfNeeded(BtCursor *pCur){
   return SQLITE_OK;
 }
 
-static int flushAllPending(BtShared *pBt, Pgno iTable){
+static int flushAllPending(Btree *pBtree, BtShared *pBt, Pgno iTable){
   BtCursor *p;
   int rc;
 
   for(p = pBt->pCursor; p; p = p->pNext){
-    if( iTable==0 || p->pgnoRoot==iTable ){
+    if( p->pBtree==pBtree && (iTable==0 || p->pgnoRoot==iTable) ){
       rc = flushIfNeeded(p);
       if( rc!=SQLITE_OK ) return rc;
     }
   }
 
-  rc = flushDeferredEdits(pBt);
+  rc = flushDeferredEdits(pBtree, pBt);
   if( rc!=SQLITE_OK ) return rc;
 
   return SQLITE_OK;
 }
 
-static int flushDeferredEdits(BtShared *pBt){
+static int flushDeferredEdits(Btree *pBtree, BtShared *pBt){
   int rc = SQLITE_OK;
-  if( pBt->db && pBt->db->nDb>0 && pBt->db->aDb[0].pBt ){
-    Btree *pBtree = pBt->db->aDb[0].pBt;
+  if( pBtree ){
     int i;
     for(i=0; i<pBtree->cat.n; i++){
       struct TableEntry *pTE = &pBtree->cat.a[i];
@@ -6341,7 +6420,7 @@ static int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
   rc = syncSavepoints(pCur);
   if( rc!=SQLITE_OK ){ sqlite3_free(pSavedDelKey); return rc; }
 
-  rc = saveAllCursors(pCur->pBt, pCur->pgnoRoot, pCur);
+  rc = saveAllCursors(pCur->pBtree, pCur->pBt, pCur->pgnoRoot, pCur);
   if( rc!=SQLITE_OK ){ sqlite3_free(pSavedDelKey); return rc; }
 
   rc = ensureMutMap(pCur);
@@ -6565,7 +6644,7 @@ static int prollyBtCursorCount(sqlite3 *db, BtCursor *pCur, i64 *pnEntry){
                                        &pFlushMap, &captured);
       if( rc!=SQLITE_OK ) return rc;
       if( captured ){
-        refreshCursorMutMapAliases(pCur->pBt, pCur->pgnoRoot,
+        refreshCursorMutMapAliases(pCur->pBtree, pCur->pBt, pCur->pgnoRoot,
                                    (ProllyMutMap*)pTE->pPending);
       }
       rc = applyMutMapToTableRoot(pCur->pBt, pTE, pFlushMap);
@@ -7177,13 +7256,15 @@ const char *doltliteNextTableForSchema(sqlite3 *db, int *pIdx, Pgno *piTable){
 
 int doltliteFlushAndSerializeCatalog(sqlite3 *db, u8 **ppOut, int *pnOut){
   BtShared *pBt = doltliteGetBtShared(db);
+  Btree *pBtree;
   int rc;
   if( !pBt ) return SQLITE_ERROR;
   if( !db || db->nDb<=0 || !db->aDb[0].pBt ) return SQLITE_ERROR;
-  rc = flushAllPending(pBt, 0);
+  pBtree = db->aDb[0].pBt;
+  rc = flushAllPending(pBtree, pBt, 0);
   if( rc!=SQLITE_OK ) return rc;
 
-  rc = flushDeferredEdits(pBt);
+  rc = flushDeferredEdits(pBtree, pBt);
   if( rc!=SQLITE_OK ) return rc;
 
   {

--- a/test/concurrent_write_test.c
+++ b/test/concurrent_write_test.c
@@ -1,16 +1,15 @@
 /*
-** Concurrent access tests for DoltLite (single-writer, multi-reader).
+** Concurrent access tests for DoltLite.
 **
-** These tests verify the concurrency model that DoltLite currently supports:
-** one connection does all DML writes, other connections can read.
+** These tests verify multi-connection DML and reader consistency:
+** multiple sqlite3 handles can write through the same in-process BtShared
+** without corrupting the shared prolly state, and readers see a consistent
+** view - either the state before or after a write, never a partial or corrupt
+** intermediate state.
 **
-**   READER CONSISTENCY: Readers see a consistent view — either the state
-**   before or after a write, never a partial or corrupt intermediate state.
-**
-**   KNOWN LIMITATION: Multiple in-process connections sharing a BtShared
-**   cannot safely do concurrent DML to the same tables. This corrupts the
-**   shared in-memory prolly tree (see issue #250). The multi-writer
-**   scenario is documented as SKIPPED at the end of this file.
+** Explicit overlapping write transactions still serialize through SQLite's
+** write lock. A second writer may get SQLITE_BUSY until the first transaction
+** commits or rolls back.
 */
 #include <stdio.h>
 #include <stdlib.h>
@@ -84,6 +83,91 @@ static int execSqlWithBusyRetry(sqlite3 *db, const char *sql, int maxRetries){
     }
   } while( attempts < maxRetries );
   return rc;
+}
+
+static void test_multi_writer_dml(void){
+  sqlite3 *a = 0, *b = 0, *fresh = 0;
+  const char *dbpath = "/tmp/test_multi_writer_dml.db";
+  const char *r;
+  int rc;
+
+  printf("--- Test 11: Multi-writer DML from different connections ---\n");
+
+  remove(dbpath); { char _w[256]; snprintf(_w,256,"%s-wal",dbpath); remove(_w); }
+
+  rc = sqlite3_open(dbpath, &a);
+  check("mw_open_a", rc==SQLITE_OK);
+  rc = sqlite3_open(dbpath, &b);
+  check("mw_open_b", rc==SQLITE_OK);
+  sqlite3_busy_timeout(a, 5000);
+  sqlite3_busy_timeout(b, 5000);
+
+  rc = execSql(a, "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT, qty INT)");
+  check("mw_create_table", rc==SQLITE_OK);
+  rc = execSql(a, "CREATE INDEX t_v_idx ON t(v)");
+  check("mw_create_index", rc==SQLITE_OK);
+  r = queryScalarText(a, "SELECT dolt_commit('-A','-m','mw init')");
+  check("mw_initial_commit", strlen(r)==40);
+
+  rc = execSql(a, "INSERT INTO t VALUES(1, 'from_a', 10)");
+  check("mw_a_insert_1", rc==SQLITE_OK);
+  rc = execSql(b, "INSERT INTO t VALUES(2, 'from_b', 20)");
+  check("mw_b_insert_2", rc==SQLITE_OK);
+  check("mw_count_after_two_writers",
+    strcmp(queryScalarText(a, "SELECT count(*) FROM t"), "2")==0);
+  check("mw_reader_sees_two",
+    strcmp(queryScalarText(b, "SELECT count(*) FROM t"), "2")==0);
+
+  rc = execSql(a, "UPDATE t SET qty=11 WHERE id=1");
+  check("mw_a_update", rc==SQLITE_OK);
+  rc = execSql(b, "UPDATE t SET qty=22 WHERE id=2");
+  check("mw_b_update", rc==SQLITE_OK);
+  check("mw_updates_visible",
+    strcmp(queryScalarText(a, "SELECT sum(qty) FROM t"), "33")==0);
+
+  rc = execSql(a, "DELETE FROM t WHERE id=1");
+  check("mw_a_delete", rc==SQLITE_OK);
+  rc = execSql(b, "INSERT INTO t VALUES(3, 'from_b_3', 30)");
+  check("mw_b_insert_3", rc==SQLITE_OK);
+  check("mw_delete_insert_count",
+    strcmp(queryScalarText(a, "SELECT count(*) FROM t"), "2")==0);
+  check("mw_index_lookup",
+    strcmp(queryScalarText(b, "SELECT id FROM t WHERE v='from_b_3'"), "3")==0);
+
+  rc = execSql(a, "INSERT INTO t VALUES(3, 'dup', 99)");
+  check("mw_duplicate_pk_rejected", rc!=SQLITE_OK);
+  check("mw_duplicate_did_not_corrupt",
+    strcmp(queryScalarText(b, "SELECT count(*) FROM t"), "2")==0);
+
+  execSql(a, "BEGIN");
+  rc = execSql(a, "INSERT INTO t VALUES(4, 'held_by_a', 40)");
+  check("mw_explicit_a_insert", rc==SQLITE_OK);
+  sqlite3_busy_timeout(b, 100);
+  rc = execSql(b, "INSERT INTO t VALUES(5, 'blocked_b', 50)");
+  check("mw_explicit_b_busy", rc==SQLITE_BUSY);
+  rc = execSql(a, "COMMIT");
+  check("mw_explicit_a_commit", rc==SQLITE_OK);
+  sqlite3_busy_timeout(b, 5000);
+  rc = execSql(b, "INSERT INTO t VALUES(5, 'blocked_b', 50)");
+  check("mw_explicit_b_retry_ok", rc==SQLITE_OK);
+
+  r = queryScalarText(b, "SELECT dolt_commit('-A','-m','mw mixed writes')");
+  check("mw_commit_mixed_writes", strlen(r)==40);
+
+  rc = sqlite3_open(dbpath, &fresh);
+  check("mw_open_fresh", rc==SQLITE_OK);
+  check("mw_fresh_count",
+    strcmp(queryScalarText(fresh, "SELECT count(*) FROM t"), "4")==0);
+  check("mw_fresh_sum",
+    strcmp(queryScalarText(fresh, "SELECT sum(qty) FROM t"), "142")==0);
+  check("mw_latest_commit",
+    strcmp(queryScalarText(fresh, "SELECT message FROM dolt_log LIMIT 1"),
+           "mw mixed writes")==0);
+
+  sqlite3_close(fresh);
+  sqlite3_close(a);
+  sqlite3_close(b);
+  remove(dbpath); { char _w[256]; snprintf(_w,256,"%s-wal",dbpath); remove(_w); }
 }
 
 /* queryScalarText with retry on SQLITE_BUSY */
@@ -301,25 +385,7 @@ int main(){
   sqlite3_close(db4);
   remove(dbpath); { char _w[256]; snprintf(_w,256,"%s-wal",dbpath); remove(_w); }
 
-  /* --- SKIPPED: Multi-writer DML (known broken, see issue #250) ---
-  **
-  ** The following scenario causes "database disk image is malformed" errors
-  ** because multiple in-process connections share a single BtShared and its
-  ** prolly tree state. Concurrent DML from different connections corrupts
-  ** the in-memory tree. This is documented in INVARIANTS.md X3.
-  **
-  ** To reproduce:
-  **   sqlite3 *a, *b;
-  **   sqlite3_open(path, &a); sqlite3_open(path, &b);
-  **   execSql(a, "CREATE TABLE t(id INT, v INT)");
-  **   execSql(a, "SELECT dolt_commit('-A','-m','init')");
-  **   execSql(a, "INSERT INTO t VALUES(1,1)");  // a writes to shared tree
-  **   execSql(b, "INSERT INTO t VALUES(2,2)");  // b corrupts a's in-flight state
-  **   // subsequent queries may return SQLITE_CORRUPT
-  **
-  ** Fix requires copy-on-write mutation buffers or full MVCC (issue #250).
-  */
-  printf("\nSKIPPED: Multi-writer DML from different connections (issue #250)\n");
+  test_multi_writer_dml();
 
   printf("\nResults: %d passed, %d failed out of %d tests\n", nPass, nFail, nPass+nFail);
   return nFail > 0 ? 1 : 0;


### PR DESCRIPTION
## Summary
- scope pending mutation maps and cursor saves to the owning Btree connection
- refresh stale autocommit working state between in-process writers
- preserve locally serialized refs across late chunk-store reloads before commit
- reload the session head from the working-set blob so dolt_commit does not report false conflicts
- replace the skipped multi-writer DML case with regression coverage for interleaved inserts, updates, deletes, indexes, PK conflicts, explicit lock serialization, commit, and fresh reopen

Fixes #824. The chunk-store/working-set hardening is also relevant to #830, and multi_process_test passes, but this PR does not add a dedicated #830 repro.

## Tests
- make libdoltlite.a
- gcc -g -O0 -I. -o concurrent_write_test test/concurrent_write_test.c libdoltlite.a -lz -lpthread -lm && ./concurrent_write_test
- gcc -g -O0 -I. -o sql_transaction_test test/sql_transaction_test.c libdoltlite.a -lz -lpthread -lm && ./sql_transaction_test
- gcc -g -O0 -I. -o multi_process_test test/multi_process_test.c libdoltlite.a -lz -lpthread -lm && ./multi_process_test
- git diff --check