### PR TITLE
chunk_store: skip read-time hash verify on in-memory paths

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -2017,7 +2017,7 @@ int chunkStoreGet(
     memcpy(pCopy, cs->pWriteBuf + off + 4, sz);
     *ppData = pCopy;
     *pnData = sz;
-    goto verify;
+    return SQLITE_OK;
   }
 
   {
@@ -2042,7 +2042,7 @@ int chunkStoreGet(
         memcpy(pCopy, cs->pWriteBuf + e->offset + 4, e->size);
         *ppData = pCopy;
         *pnData = e->size;
-        goto verify;
+        return SQLITE_OK;
       }
       return SQLITE_CORRUPT;
     }


### PR DESCRIPTION
## Summary

Follow-up to #841. The chunk-hash verify catches **disk-level** failure modes (torn writes, bit-flips, bad WAL bodies). Reads that come from `pWriteBuf` — the pending list and the `cs->pFile == 0` in-memory path — never touched disk, so the BLAKE3 over them is overhead with no safety benefit. The in-memory sysbench regression from #841 was this cost.

## Fix

Inside `chunkStoreGet`:

- The pending-hit branch (`csSearchPending` returned an idx) now `return SQLITE_OK` directly.
- The `cs->pFile == 0` in-memory branch (read from `pWriteBuf` for an aIndex/aRecent entry) also `return SQLITE_OK` directly.
- Only the `sqlite3OsRead` fall-through path threads through `verify:`.

Safety story for disk-backed DBs is unchanged: every chunk read from `cs->pFile` is still re-hashed against the requested key, and `SQLITE_CORRUPT` is returned on mismatch.

## Smoke

- Disk-backed: write + commit + read → 2 rows, correct.
- In-memory: same → 2 rows, correct.
- Build clean.