### PR TITLE
ci: add non-blocking .deb package smoke test to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,6 +235,88 @@ jobs:
           doltlite-lib-*.zip
           dist/*.deb
 
+  # ── Package smoke test (.deb) ─────────────────────────────
+  # Non-blocking sanity check: download the just-built linux-x64 .debs,
+  # `dpkg -i` them on a clean ubuntu-latest, and assert `doltlite` runs
+  # and `SELECT dolt_version()` reports the release tag. Catches the
+  # class of regression where the build succeeds but the package itself
+  # is broken (missing files, bad paths, undeclared deps, etc.) —
+  # exactly what ba3685707e ("make the autoconf release tarball
+  # actually build") would have caught earlier.
+  #
+  # Started as non-blocking on purpose: the `release` job below does NOT
+  # depend on this. Promote to a required check once it has demonstrated
+  # reliability across a few releases.
+  package-smoke-deb:
+    needs: build
+    runs-on: ubuntu-latest
+    # Only run when there are real artifacts to install — i.e., on a
+    # tag push (where the binaries-linux-x64 artifact will have been
+    # produced by `build`). Manual workflow_dispatch runs also produce
+    # artifacts, so allow those too.
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    steps:
+    - name: Download linux-x64 binary artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: binaries-linux-x64
+        path: artifacts
+
+    - name: Show downloaded artifacts
+      run: |
+        find artifacts -type f | sort
+        ls -la artifacts/dist/ 2>/dev/null || true
+
+    - name: Install .deb packages
+      run: |
+        # Install in dependency order: libdoltlite0 (runtime), then
+        # libdoltlite-dev (headers), then doltlite (CLI). Each depends
+        # on the previous via `Depends:` in the .deb metadata.
+        sudo dpkg -i artifacts/dist/libdoltlite0_*.deb
+        sudo dpkg -i artifacts/dist/libdoltlite-dev_*.deb
+        sudo dpkg -i artifacts/dist/doltlite_*.deb
+        # If any deps are missing, apt-get -f install would fix them;
+        # surface that as a failure instead so we notice.
+        dpkg -l | grep -E '^ii\s+(doltlite|libdoltlite)' || (echo "package not installed cleanly" && exit 1)
+
+    - name: Verify installed files
+      run: |
+        # Sanity: each .deb's payload lands where we expect. Catches
+        # paths drifting from the nfpm yaml without anyone noticing.
+        test -x /usr/bin/doltlite
+        test -x /usr/bin/doltlite-remotesrv
+        test -f /usr/include/doltlite.h
+        test -f /usr/include/sqlite3.h
+        ldconfig -p | grep -q libdoltlite || (echo "libdoltlite.so.0 not registered with ldconfig" && exit 1)
+
+    - name: Smoke test — doltlite CLI runs and reports version
+      run: |
+        # `SELECT dolt_version()` should match the tag we built from.
+        # On workflow_dispatch (no tag), just assert the call returns
+        # *something* non-empty rather than asserting an exact value.
+        VERSION_OUT=$(doltlite :memory: 'SELECT dolt_version();')
+        echo "dolt_version() => ${VERSION_OUT}"
+        if [ -z "${VERSION_OUT}" ]; then
+          echo "dolt_version() returned empty"
+          exit 1
+        fi
+        if [ "${GITHUB_EVENT_NAME}" = "push" ] && [ -n "${GITHUB_REF_NAME}" ]; then
+          EXPECTED="${GITHUB_REF_NAME#v}"
+          # dolt_version() may include extra qualifiers; substring match
+          # is enough to confirm the right binary is on PATH.
+          case "${VERSION_OUT}" in
+            *"${EXPECTED}"*) echo "version matches tag ${EXPECTED}" ;;
+            *) echo "version ${VERSION_OUT} does not contain tag ${EXPECTED}"; exit 1 ;;
+          esac
+        fi
+
+    - name: Smoke test — basic SQL works
+      run: |
+        # Trivial SQL plus a doltlite-specific call. If the shared lib
+        # is mis-linked or a virtual table is missing, this fails fast.
+        doltlite :memory: 'SELECT 1;'
+        doltlite :memory: 'CREATE TABLE t(x INT); INSERT INTO t VALUES (1),(2); SELECT count(*) FROM t;'
+
   # ── Run benchmarks ────────────────────────────────────────
   benchmark:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds a `package-smoke-deb` job to `.github/workflows/release.yml` that downloads the just-built linux-x64 `.deb` artifacts (`libdoltlite0`, `libdoltlite-dev`, `doltlite`), `dpkg -i`s them on a clean `ubuntu-latest`, and asserts the CLI actually runs.
- Smoke assertions: file layout (`/usr/bin/doltlite`, `/usr/include/doltlite.h`, `ldconfig` sees `libdoltlite.so.0`), `doltlite :memory: 'SELECT dolt_version();'` returns the release tag, and basic SQL (`SELECT 1;`, `CREATE TABLE`/`INSERT`/`count(*)`) executes.
- Covers the **.deb** install path (most common Linux distribution path; #843 already covers Homebrew via `test do`). Catches the regression class exemplified by `ba3685707e` ("make the autoconf release tarball actually build") — build succeeds but the package itself is broken.
- **Non-blocking by design**: the `release` job continues to depend only on `[source, build, benchmark]`. Promote to required once proven reliable over a few releases.

## Mechanics
- `needs: build` so it only runs after the `binaries-linux-x64` artifact exists.
- Gated `if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'` so it only runs when there are real artifacts (i.e., on tag pushes / manual dispatches), not on PRs that touch this file.

## Test plan
- [ ] On next tag push (`v*`), confirm `package-smoke-deb` runs after `build` and reports green.
- [ ] Manually trigger via `workflow_dispatch` on master to dry-run without cutting a release.
- [ ] Once stable across 2-3 releases, add to required checks and/or hoist to `needs:` of `release`.

Note: this PR itself will NOT trigger the smoke job — the workflow is `on: push: tags: ['v*']` / `workflow_dispatch`, not `pull_request`. That's intentional: the smoke job needs the build matrix's `.deb` artifacts, which only exist on release events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)