### PR TITLE
chunk_store: fix replay/AddTag partial-failure cleanup

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -1010,8 +1010,6 @@ static int csReplayWal(ChunkStore *cs){
 
   memset(&tmpRefs, 0, sizeof(tmpRefs));
 
-  csCaptureReplayState(cs, &saved);
-
   if( cs->iWalOffset <= 0 || !cs->pFile ) return SQLITE_OK;
 
   {
@@ -1028,6 +1026,8 @@ static int csReplayWal(ChunkStore *cs){
     }
     return SQLITE_OK;
   }
+
+  csCaptureReplayState(cs, &saved);
 
   cs->nWalData = walSize;
 
@@ -1522,6 +1522,11 @@ int chunkStoreAddTagFull(
   aNew[cs->nTags].zEmail   = sqlite3_mprintf("%s", zEmail   ? zEmail   : "");
   aNew[cs->nTags].zMessage = sqlite3_mprintf("%s", zMessage ? zMessage : "");
   if( !aNew[cs->nTags].zTagger || !aNew[cs->nTags].zEmail || !aNew[cs->nTags].zMessage ){
+    sqlite3_free(aNew[cs->nTags].zName);
+    sqlite3_free(aNew[cs->nTags].zTagger);
+    sqlite3_free(aNew[cs->nTags].zEmail);
+    sqlite3_free(aNew[cs->nTags].zMessage);
+    memset(&aNew[cs->nTags], 0, sizeof(struct TagRef));
     return SQLITE_NOMEM;
   }
   aNew[cs->nTags].timestamp = timestamp;


### PR DESCRIPTION
## Summary
- `csReplayWal` captured replay state before three early-return paths (no WAL, fileSize error, empty WAL), leaving no path to release the saved `SavedRefsState` (zDefaultBranch + branch/tag/remote/tracking arrays) on those exits. Defer capture until after the early-exit checks so saved-state ownership is well-defined on every exit.
- `chunkStoreAddTagFull` bumped `cs->aTags` via `sqlite3_realloc` but on `sqlite3_mprintf` failure for `zTagger`/`zEmail`/`zMessage` returned `SQLITE_NOMEM` without freeing the partial fields, leaving slot `aTags[cs->nTags]` with mixed allocated/zero pointers and uninitialized state for the next AddTag. Free the partial fields and zero the slot, matching the `chunkStoreAddBranch` pattern.

## Test plan
- [x] `./configure && make doltlite` builds clean (no new warnings on `chunk_store.o`)
- [x] Diff is minimal and surgical (7 lines added, 2 lines removed)
- [ ] Existing CI exercises chunk store reload and tag creation paths

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>