### PR TITLE
fix: case-insensitive branch comparisons

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -1416,7 +1416,7 @@ int chunkStoreSetDefaultBranch(ChunkStore *cs, const char *zName){
 int chunkStoreFindBranch(ChunkStore *cs, const char *zName, ProllyHash *pCommit){
   int i;
   for(i=0; i<cs->nBranches; i++){
-    if( strcmp(cs->aBranches[i].zName, zName)==0 ){
+    if( sqlite3_stricmp(cs->aBranches[i].zName, zName)==0 ){
       if( pCommit ) memcpy(pCommit, &cs->aBranches[i].commitHash, sizeof(ProllyHash));
       return SQLITE_OK;
     }
@@ -1441,7 +1441,7 @@ int chunkStoreAddBranch(ChunkStore *cs, const char *zName, const ProllyHash *pCo
 int chunkStoreUpdateBranch(ChunkStore *cs, const char *zName, const ProllyHash *pCommit){
   int i;
   for(i=0; i<cs->nBranches; i++){
-    if( strcmp(cs->aBranches[i].zName, zName)==0 ){
+    if( sqlite3_stricmp(cs->aBranches[i].zName, zName)==0 ){
       memcpy(&cs->aBranches[i].commitHash, pCommit, sizeof(ProllyHash));
       return SQLITE_OK;
     }
@@ -1452,7 +1452,7 @@ int chunkStoreUpdateBranch(ChunkStore *cs, const char *zName, const ProllyHash *
 int chunkStoreDeleteBranch(ChunkStore *cs, const char *zName){
   int i;
   for(i=0; i<cs->nBranches; i++){
-    if( strcmp(cs->aBranches[i].zName, zName)==0 ){
+    if( sqlite3_stricmp(cs->aBranches[i].zName, zName)==0 ){
       sqlite3_free(cs->aBranches[i].zName);
       cs->aBranches[i] = cs->aBranches[cs->nBranches-1];
       cs->nBranches--;
@@ -1465,7 +1465,7 @@ int chunkStoreDeleteBranch(ChunkStore *cs, const char *zName){
 int chunkStoreGetBranchWorkingSet(ChunkStore *cs, const char *zBranch, ProllyHash *pHash){
   int i;
   for(i=0; i<cs->nBranches; i++){
-    if( strcmp(cs->aBranches[i].zName, zBranch)==0 ){
+    if( sqlite3_stricmp(cs->aBranches[i].zName, zBranch)==0 ){
       memcpy(pHash, &cs->aBranches[i].workingSetHash, sizeof(ProllyHash));
       return SQLITE_OK;
     }
@@ -1477,7 +1477,7 @@ int chunkStoreGetBranchWorkingSet(ChunkStore *cs, const char *zBranch, ProllyHas
 int chunkStoreSetBranchWorkingSet(ChunkStore *cs, const char *zBranch, const ProllyHash *pHash){
   int i;
   for(i=0; i<cs->nBranches; i++){
-    if( strcmp(cs->aBranches[i].zName, zBranch)==0 ){
+    if( sqlite3_stricmp(cs->aBranches[i].zName, zBranch)==0 ){
       memcpy(&cs->aBranches[i].workingSetHash, pHash, sizeof(ProllyHash));
       return SQLITE_OK;
     }

--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -366,11 +366,11 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
       if( branchNameEmpty(aPositional[0]) ){
         branchError(ctx, hadSavepoint, "branch name required"); return;
       }
-      if( strcmp(aPositional[0], doltliteGetSessionBranch(db))==0 ){
+      if( sqlite3_stricmp(aPositional[0], doltliteGetSessionBranch(db))==0 ){
         branchError(ctx, hadSavepoint, "cannot delete the current branch");
         return;
       }
-      if( strcmp(aPositional[0], "main")==0 ){
+      if( sqlite3_stricmp(aPositional[0], "main")==0 ){
         branchError(ctx, hadSavepoint,
           "cannot delete branch 'main' (doltlite requires main to exist)");
         return;
@@ -444,12 +444,12 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
       memset(&m, 0, sizeof(m));
       m.zSrc = aPositional[0];
       m.zDest = aPositional[1];
-      if( strcmp(m.zSrc, "main")==0 ){
+      if( sqlite3_stricmp(m.zSrc, "main")==0 ){
         branchError(ctx, hadSavepoint,
           "cannot rename branch 'main' (doltlite requires main to exist)");
         return;
       }
-      renamingCurrent = strcmp(m.zSrc, doltliteGetSessionBranch(db))==0;
+      renamingCurrent = sqlite3_stricmp(m.zSrc, doltliteGetSessionBranch(db))==0;
       rc = doltliteMutateRefs(db, mutateBranchMove, &m);
       if( rc!=SQLITE_OK ){
         branchNamedResultError(ctx, hadSavepoint, rc,
@@ -1166,7 +1166,7 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
     isCreateAndSwitch = 1;
   }
 
-  if( strcmp(zBranch, doltliteGetSessionBranch(db))==0 && argc==1 ){
+  if( sqlite3_stricmp(zBranch, doltliteGetSessionBranch(db))==0 && argc==1 ){
     sqlite3_result_int(ctx, 0);
     return;
   }
@@ -1377,7 +1377,7 @@ static int brIsDirty(
 
   *pDirty = 0;
 
-  if( strcmp(br->zName, doltliteGetSessionBranch(db))==0 ){
+  if( sqlite3_stricmp(br->zName, doltliteGetSessionBranch(db))==0 ){
     *pDirty = doltliteHasUncommittedChanges(db) ? 1 : 0;
     return SQLITE_OK;
   }

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -630,7 +630,7 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     }
   }
 
-  if( strcmp(zBranch, doltliteGetSessionBranch(db))==0
+  if( sqlite3_stricmp(zBranch, doltliteGetSessionBranch(db))==0
    && doltliteHasUncommittedChanges(db) ){
     remoteSqlRestoreAndReport(ctx, db, cs, &savedState, SQLITE_ERROR,
                               "cannot pull with uncommitted changes");
@@ -644,7 +644,7 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     return;
   }
 
-  if( strcmp(zBranch, doltliteGetSessionBranch(db))==0 ){
+  if( sqlite3_stricmp(zBranch, doltliteGetSessionBranch(db))==0 ){
     rc = remoteSqlResetSessionToCommit(db, 0, &trackingCommit);
     if( rc!=SQLITE_OK ){
       remoteSqlRestoreAndReport(ctx, db, cs, &savedState, SQLITE_ERROR,


### PR DESCRIPTION
## Summary
- A user could bypass the \"cannot delete branch main\" guard by first creating branch \`MAIN\` (case-different from \`main\`), then deleting \`main\` as if it were a normal branch. Same gap let two branches differing only in case coexist, and \`chunkStoreSetDefaultBranch\` was never updated after a stray rename-by-case.
- Switch every branch-name comparison to \`sqlite3_stricmp\`: chunk_store branch find/add/update/delete/working-set, the literal \`\"main\"\` guards in \`dolt_branch -d\` / \`dolt_branch -m\`, the session-branch checks in \`doltlite_branch.c\` (delete-current, rename-current, checkout no-op, vtable dirty bit), and the two session-branch comparisons in \`doltlite_remote_sql.c\` that gate pull behavior.
- On-disk branch name storage is unchanged; only comparisons are case-insensitive.

## Behavior change
- \`SELECT dolt_branch('MAIN')\` now errors when \`main\` already exists (\"branch already exists\").
- \`SELECT dolt_branch('-D', 'MAIN')\` / \`'Main'\` now hit the \"cannot delete branch 'main'\" guard.
- Creating \`feature\` then \`FEATURE\` is rejected as a duplicate. Lookups (delete, copy, rename) accept any case.

## Divergence from Dolt
Upstream Dolt is case-sensitive for branch ops (verified with \`dolt 1.88.0\`: \`MAIN\` and \`main\` can coexist, you can delete \`main\` while \`MAIN\` is checked out). doltlite now diverges intentionally to match common git-like expectations and close the bypass; row-level branch semantics are unaffected.

## Test plan
- [x] \`./configure && make doltlite\` builds clean
- [x] \`bash test/vc_oracle_branch_test.sh ./doltlite\` -> 33 passed
- [x] \`bash test/vc_oracle_branches_test.sh ./doltlite\` -> 15 passed
- [x] \`bash test/vc_oracle_checkout_test.sh ./doltlite\` -> 50 passed
- [x] Manual: create \`MAIN\` while on \`main\` -> error; delete \`MAIN\`/\`Main\` -> guard hit; create \`FEATURE\` after \`feature\` -> error; delete \`feature\` via \`-D FEATURE\` -> succeeds

Generated with [Claude Code](https://claude.com/claude-code)