### PR TITLE
fix: collision-resistant rowid for dolt_conflicts/dolt_constraint_violations vtables

### DIFF
--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -526,17 +526,42 @@ static const char *cfrDiffType(const u8 *pBase, int nBase,
 }
 
 static sqlite3_int64 cfrConflictRowid(const struct ConflictRow *cr){
+  u64 h = 1469598103934665603ULL;
+  int i;
   if( cr->nKey>0 && cr->pKey ){
-    u64 h = 1469598103934665603ULL;
-    int i;
     for(i=0; i<cr->nKey; i++){
       h ^= (u64)cr->pKey[i];
       h *= 1099511628211ULL;
     }
-    if( h==0 ) h = 1;
-    return (sqlite3_int64)(h & 0x7fffffffffffffffULL);
   }
-  return (sqlite3_int64)cr->intKey;
+  {
+    u64 k = (u64)cr->intKey;
+    for(i=0; i<8; i++){
+      h ^= (k >> (i*8)) & 0xff;
+      h *= 1099511628211ULL;
+    }
+  }
+  if( cr->nBaseVal>0 && cr->pBaseVal ){
+    for(i=0; i<cr->nBaseVal; i++){
+      h ^= (u64)cr->pBaseVal[i];
+      h *= 1099511628211ULL;
+    }
+  }
+  h *= 1099511628211ULL;
+  if( cr->nOurVal>0 && cr->pOurVal ){
+    for(i=0; i<cr->nOurVal; i++){
+      h ^= (u64)cr->pOurVal[i];
+      h *= 1099511628211ULL;
+    }
+  }
+  h *= 1099511628211ULL;
+  if( cr->nTheirVal>0 && cr->pTheirVal ){
+    for(i=0; i<cr->nTheirVal; i++){
+      h ^= (u64)cr->pTheirVal[i];
+      h *= 1099511628211ULL;
+    }
+  }
+  return (sqlite3_int64)(h & 0x7fffffffffffffffULL);
 }
 
 static int cfrColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){

--- a/src/doltlite_constraint_violations.c
+++ b/src/doltlite_constraint_violations.c
@@ -643,20 +643,25 @@ static int cvrColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
 static sqlite3_int64 cvrViolationRowid(const ConstraintViolationRow *r){
   u64 h = 1469598103934665603ULL;
   int i;
-
   if( r->nKey>0 && r->pKey ){
     for(i=0; i<r->nKey; i++){
       h ^= (u64)r->pKey[i];
       h *= 1099511628211ULL;
     }
-  }else{
-    const u8 *p = (const u8*)&r->intKey;
-    for(i=0; i<(int)sizeof(r->intKey); i++){
-      h ^= (u64)p[i];
+  }
+  {
+    u64 k = (u64)r->intKey;
+    for(i=0; i<8; i++){
+      h ^= (k >> (i*8)) & 0xff;
       h *= 1099511628211ULL;
     }
   }
-
+  if( r->nVal>0 && r->pVal ){
+    for(i=0; i<r->nVal; i++){
+      h ^= (u64)r->pVal[i];
+      h *= 1099511628211ULL;
+    }
+  }
   h ^= (u64)r->violationType;
   h *= 1099511628211ULL;
   if( r->zInfo ){
@@ -665,8 +670,6 @@ static sqlite3_int64 cvrViolationRowid(const ConstraintViolationRow *r){
       h *= 1099511628211ULL;
     }
   }
-
-  if( h==0 ) h = 1;
   return (sqlite3_int64)(h & 0x7fffffffffffffffULL);
 }
 


### PR DESCRIPTION
## Summary
- The `cfrConflictRowid` / `cvrViolationRowid` helpers hashed only the prolly key and remapped the all-zero FNV result to `1`, so a real `h==1` row and an all-zero row (or any genuine collision) shared a rowid. `xUpdate`'s scan-by-hash then dropped the first match and silently kept the intended target.
- Now hash the full row content (key bytes + intKey + base/our/their values for conflicts; key bytes + intKey + value + violationType + zInfo for violations) and drop the `h==0 -> 1` sentinel. SQLite vtables permit a 0 rowid, so the masked 63-bit output is used as-is.
- Preserves the existing rowid contract: content-derived and stable across reloads, so bulk `DELETE FROM dolt_conflicts_<t>` still finds each row after intermediate compactions.

## Background
The fix sketch suggested switching to a position-based rowid (`iTable*1e9 + iRow`). I prototyped that path, but SQLite's bulk `DELETE FROM <vtab>` accumulates all rowids before any `xUpdate`, and `xUpdate` reloads from storage between calls. With shifting array indices, the second delete in a two-row bulk delete missed its target. A true positional scheme would require an on-disk row identifier (storage format bump). Strengthening the content hash addresses the practical collision/sentinel bug with no storage change.

## Test plan
- [x] `bash test/vc_oracle_conflicts_resolve_test.sh ./doltlite dolt` -> 28 / 28
- [x] `bash test/vc_oracle_conflicts_table_test.sh ./doltlite dolt` -> 13 / 13
- [x] `bash test/vc_oracle_conflicts_test.sh ./doltlite dolt` -> 9 / 9
- [x] `bash test/doltlite_conflicts.sh ./doltlite` -> 40 / 40
- [x] `bash test/doltlite_conflict_rows.sh ./doltlite` -> 29 / 29
- [x] `bash test/vc_oracle_fk_merge_test.sh ./doltlite dolt` -> 73 / 73 (constraint-violation path)

Generated with [Claude Code](https://claude.com/claude-code)