### PR TITLE
test: dedup oracle case name cell_merge_8_cols_interleaved

### DIFF
--- a/test/vc_oracle_feature_interaction_test.sh
+++ b/test/vc_oracle_feature_interaction_test.sh
@@ -3613,7 +3613,7 @@ SELECT dolt_merge('main');
 
 echo "--- stress cell merge ---"
 
-oracle "cell_merge_8_cols_interleaved" "
+oracle "cell_merge_8_cols_interleaved_single_row" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, c1 TEXT, c2 TEXT, c3 TEXT, c4 TEXT, c5 TEXT, c6 TEXT, c7 TEXT, c8 TEXT);
 INSERT INTO t VALUES(1,'a','b','c','d','e','f','g','h');
 SELECT dolt_add('-A');


### PR DESCRIPTION
## Summary

Two oracle cases in `test/vc_oracle_feature_interaction_test.sh` shared the name `cell_merge_8_cols_interleaved` (at lines 1929 and 3616). The `oracle()` helper uses `$TMPROOT/$name` as the working dir, so the second run clobbered the first's artifacts and the pass/fail counters double-counted.

Both cases run the same 8-column interleaved cell-merge scenario; they differ only in the assertion query projection:
- First: `SELECT id, c1..c8 FROM t ORDER BY id;`
- Second: `SELECT c1..c8 FROM t WHERE id=1;`

Renamed the second case to `cell_merge_8_cols_interleaved_single_row` to reflect the single-row projection. Assertion semantics unchanged.

## Test plan

- [x] Built doltlite locally and ran `bash test/vc_oracle_feature_interaction_test.sh ./doltlite dolt` — both renamed cases pass independently
- [x] Confirmed the 2 unrelated pre-existing failures (`soft_reset_recommit_no_explicit_add`, `soft_reset_two_levels_recommit_no_add`) are not introduced by this change (they fail on master too)

Generated with [Claude Code](https://claude.com/claude-code)