### PR TITLE
Ungate remaining C tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,9 @@ jobs:
         make doltlite
         make doltlite-lib
         make testfixture
+        # doltlite_parity.sh compares against the package-built stock
+        # SQLite CLI instead of whatever sqlite3 the runner image provides.
+        make DOLTLITE_PROLLY=0 sqlite3
         # Stock SQLite lib for concurrent_branch_test
         make libsqlite3.a USE_AMALGAMATION=0
 
@@ -127,12 +130,8 @@ jobs:
           libdoltlite.a -lz -lpthread -lm
         ./prepared_stmt_reuse_test
 
-    # Wires the previously-orphan C tests (invariant_test, corruption_test,
-    # cross_branch_test, multi_process_test, ancestor_test,
-    # three_way_diff_test, sql_transaction_test) into CI. The runner
-    # script splits them into GATING (must pass) and EXPECTED_FAIL
-    # (preexisting failures still surfaced but not blocking until the
-    # underlying bugs are fixed).
+    # Wires the previously-orphan C tests into CI. All tests in
+    # test/run_c_tests.sh are gating and must pass.
     - name: Orphan C tests
       run: cd build && make c-tests
       timeout-minutes: 15

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -1340,6 +1340,11 @@ int chunkStoreOpen(
       return rc;
     }
 
+    if( prollyHashIsEmpty(&cs->refsHash) && cs->nIndexSize>0 ){
+      chunkStoreClose(cs);
+      return SQLITE_CORRUPT;
+    }
+
     if( !prollyHashIsEmpty(&cs->refsHash) ){
       u8 *refsData = 0; int nRefsData = 0;
       rc = chunkStoreGet(cs, &cs->refsHash, &refsData, &nRefsData);

--- a/test/corruption_test.c
+++ b/test/corruption_test.c
@@ -9,9 +9,8 @@
 ** DoltLite file format (from chunk_store.h):
 **   [Manifest header: 168 bytes at offset 0]
 **     magic(4) + version(4) + root_hash(20) + chunk_count(4) +
-**     index_offset(8) + index_size(4) + catalog_hash(20) +
-**     head_commit(20) + wal_offset(8) + reserved(12) + refs_hash(20) +
-**     reserved(64)
+**     index_offset(8) + index_size(4) + reserved(40) +
+**     wal_offset(8) + reserved(12) + refs_hash(20) + reserved(44)
 **   [Compacted chunk data: offset 168 to iWalOffset]
 **     length(4) + data(length), with sorted index
 **   [WAL region: iWalOffset to EOF]
@@ -710,8 +709,8 @@ static void test_wrong_file_size_in_manifest(void){
 
   /* The wal_offset field is at offset:
   **   magic(4) + version(4) + root_hash(20) + chunk_count(4) +
-  **   index_offset(8) + index_size(4) + catalog_hash(20) +
-  **   head_commit(20) + wal_offset(8) = offset 84
+  **   index_offset(8) + index_size(4) + reserved(40) +
+  **   wal_offset(8) = offset 84
   ** wal_offset is an i64 at offset 84
   **
   ** Set it to a wildly wrong value */
@@ -727,67 +726,13 @@ static void test_wrong_file_size_in_manifest(void){
 }
 
 /*
-** Test 12: Create compacted database, verify it works, corrupt the
-** catalog hash, then reopen. Verify error reporting.
-**
-** After GC, the manifest catalog_hash is authoritative.
-*/
-static void test_commit_then_corrupt(void){
-  const char *dbpath = "/tmp/test_corr_reopen.db";
-
-  printf("--- Test 12: Commit, GC, corrupt catalog, reopen ---\n");
-
-  check("create_compacted_12", create_compacted_db(dbpath)==0);
-
-  /* Verify it works before corruption */
-  {
-    sqlite3 *db = 0;
-    check("verify_good_12", sqlite3_open(dbpath, &db)==SQLITE_OK);
-    check("good_count_12",
-      strcmp(queryScalarText(db, "SELECT count(*) FROM t1"), "5")==0);
-    /* doltlite's dolt_log includes the auto-generated "Initialize data
-    ** repository" commit, so: genesis + first commit + second commit = 3. */
-    check("good_log_12",
-      strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_log"), "3")==0);
-    sqlite3_close(db);
-  }
-
-  /* Corrupt the catalog hash at offset 44 (20 bytes).
-  ** After GC, no WAL root records exist to override this. */
-  {
-    unsigned char bad_hash[20];
-    memset(bad_hash, 0xAB, sizeof(bad_hash));
-    check("corrupt_12",
-      corrupt_bytes(dbpath, 44, bad_hash, sizeof(bad_hash))==0);
-  }
-
-  /* Reopen -- the corrupted catalog hash should cause errors when
-  ** trying to look up tables */
-  {
-    sqlite3 *db = 0;
-    int rc = sqlite3_open(dbpath, &db);
-    if( rc==SQLITE_OK ){
-      rc = execSql(db, "SELECT * FROM t1");
-      int log_rc = execSql(db, "SELECT * FROM dolt_log");
-      check("corrupt_catalog_detected",
-        rc!=SQLITE_OK || log_rc!=SQLITE_OK);
-    }else{
-      check("corrupt_catalog_detected", 1);
-    }
-    if( db ) sqlite3_close(db);
-  }
-
-  removeDb(dbpath);
-}
-
-/*
-** Test 13: Corrupt magic number.
+** Test 12: Corrupt magic number.
 ** Should fail to open as DoltLite.
 */
 static void test_corrupt_magic(void){
   const char *dbpath = "/tmp/test_corr_magic.db";
 
-  printf("--- Test 13: Corrupt magic number ---\n");
+  printf("--- Test 12: Corrupt magic number ---\n");
 
   check("create_good_13", create_good_db(dbpath)==0);
 
@@ -803,12 +748,12 @@ static void test_corrupt_magic(void){
 }
 
 /*
-** Test 14: Corrupt version number to unsupported version.
+** Test 13: Corrupt version number to unsupported version.
 */
 static void test_corrupt_version(void){
   const char *dbpath = "/tmp/test_corr_version.db";
 
-  printf("--- Test 14: Corrupt version number ---\n");
+  printf("--- Test 13: Corrupt version number ---\n");
 
   check("create_good_14", create_good_db(dbpath)==0);
 
@@ -824,8 +769,7 @@ static void test_corrupt_version(void){
 }
 
 /*
-** Test 15: Corrupt the head_commit hash in a compacted DB.
-** After GC, the manifest is authoritative.
+** Test 14: Corrupt the reserved former head_commit bytes in a compacted DB.
 **
 ** NOTE: The system recovers head_commit from the active branch's commit
 ** hash in refs, so manifest head_commit corruption is tolerated. This test
@@ -835,7 +779,7 @@ static void test_corrupt_version(void){
 static void test_corrupt_head_commit(void){
   const char *dbpath = "/tmp/test_corr_head.db";
 
-  printf("--- Test 15: Corrupt head_commit hash (compacted) ---\n");
+  printf("--- Test 14: Corrupt former head_commit bytes (compacted) ---\n");
 
   check("create_compacted_15", create_compacted_db(dbpath)==0);
 
@@ -873,7 +817,7 @@ static void test_corrupt_head_commit(void){
 }
 
 /*
-** Test 16: Corrupt the chunk_count field in a compacted DB.
+** Test 15: Corrupt the chunk_count field in a compacted DB.
 ** After GC, chunk_count should govern how many index entries to read.
 **
 ** NOTE: The system currently derives the actual index entry count from
@@ -885,7 +829,7 @@ static void test_corrupt_head_commit(void){
 static void test_corrupt_chunk_count(void){
   const char *dbpath = "/tmp/test_corr_chunkcount.db";
 
-  printf("--- Test 16: Corrupt chunk_count field (compacted) ---\n");
+  printf("--- Test 15: Corrupt chunk_count field (compacted) ---\n");
 
   check("create_compacted_16", create_compacted_db(dbpath)==0);
 
@@ -919,12 +863,12 @@ static void test_corrupt_chunk_count(void){
 }
 
 /*
-** Test 17: Corrupt index_offset to point past end of file.
+** Test 16: Corrupt index_offset to point past end of file.
 */
 static void test_corrupt_index_offset(void){
   const char *dbpath = "/tmp/test_corr_idxoff.db";
 
-  printf("--- Test 17: Corrupt index_offset ---\n");
+  printf("--- Test 16: Corrupt index_offset ---\n");
 
   /* Create and GC */
   {
@@ -967,7 +911,6 @@ int main(void){
   test_manifest_only();
   test_corrupt_wal_tag();
   test_wrong_file_size_in_manifest();
-  test_commit_then_corrupt();
   test_corrupt_magic();
   test_corrupt_version();
   test_corrupt_head_commit();

--- a/test/doltlite_parity.sh
+++ b/test/doltlite_parity.sh
@@ -1,43 +1,24 @@
 #!/bin/bash
 DOLTLITE=./doltlite
-SQLITE3=$(command -v sqlite3 2>/dev/null || echo /usr/bin/sqlite3)
-PASS=0; FAIL=0; SKIP=0; ERRORS=""
+SQLITE3=./sqlite3
+PASS=0; FAIL=0; ERRORS=""
 
 if [ ! -x "$DOLTLITE" ]; then
   echo "ERROR: $DOLTLITE not found or not executable"
   exit 1
 fi
 
-if ! command -v "$SQLITE3" >/dev/null 2>&1; then
-  echo "ERROR: system sqlite3 not found in PATH"
+if [ ! -x "$SQLITE3" ]; then
+  echo "ERROR: $SQLITE3 not found or not executable"
   exit 1
 fi
 
 SQLITE_VERSION=$("$SQLITE3" :memory: "SELECT sqlite_version();" 2>/dev/null)
-SQLITE_MAJOR=$(echo "$SQLITE_VERSION" | cut -d. -f1)
-SQLITE_MINOR=$(echo "$SQLITE_VERSION" | cut -d. -f2)
 
 echo "=== DoltLite SQLite Parity Tests ==="
 echo "DoltLite:       $DOLTLITE"
-echo "System sqlite3: $SQLITE3 (version $SQLITE_VERSION)"
+echo "Package sqlite3: $SQLITE3 (version $SQLITE_VERSION)"
 echo ""
-
-HAS_WINDOW=0
-HAS_JSON=0
-HAS_UPSERT=0
-HAS_CTE=0
-
-if [ "$SQLITE_MAJOR" -gt 3 ] || { [ "$SQLITE_MAJOR" -eq 3 ] && [ "$SQLITE_MINOR" -ge 25 ]; }; then
-  HAS_WINDOW=1
-fi
-if [ "$SQLITE_MAJOR" -gt 3 ] || { [ "$SQLITE_MAJOR" -eq 3 ] && [ "$SQLITE_MINOR" -ge 9 ]; }; then
-  if echo "SELECT json_array(1,2,3);" | "$SQLITE3" :memory: >/dev/null 2>&1; then
-    HAS_JSON=1
-  fi
-fi
-if [ "$SQLITE_MAJOR" -gt 3 ] || { [ "$SQLITE_MAJOR" -eq 3 ] && [ "$SQLITE_MINOR" -ge 9 ]; }; then
-  HAS_CTE=1
-fi
 
 run_parity() {
   local name="$1"
@@ -53,13 +34,6 @@ run_parity() {
     FAIL=$((FAIL+1))
     ERRORS="$ERRORS\nFAIL: $name\n  --- doltlite ---\n$out_dl\n  --- sqlite3 ---\n$out_sq\n"
   fi
-}
-
-skip_test() {
-  local name="$1"
-  local reason="$2"
-  SKIP=$((SKIP+1))
-  echo "  SKIP: $name ($reason)"
 }
 
 echo "--- Basic CRUD ---"
@@ -275,8 +249,7 @@ SELECT id, val FROM t t1 WHERE val = (SELECT MAX(val) FROM t t2 WHERE t2.grp=t1.
 
 echo "--- Window functions ---"
 
-if [ "$HAS_WINDOW" -eq 1 ]; then
-  run_parity "row_number" "
+run_parity "row_number" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, grp TEXT, val INTEGER);
 INSERT INTO t VALUES(1,'a',10);
 INSERT INTO t VALUES(2,'a',20);
@@ -285,7 +258,7 @@ INSERT INTO t VALUES(4,'b',40);
 SELECT id, grp, ROW_NUMBER() OVER (PARTITION BY grp ORDER BY val) AS rn FROM t ORDER BY id;
 "
 
-  run_parity "rank_dense_rank" "
+run_parity "rank_dense_rank" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, val INTEGER);
 INSERT INTO t VALUES(1,10);
 INSERT INTO t VALUES(2,20);
@@ -294,7 +267,7 @@ INSERT INTO t VALUES(4,30);
 SELECT id, val, RANK() OVER (ORDER BY val) AS rnk, DENSE_RANK() OVER (ORDER BY val) AS drnk FROM t ORDER BY id;
 "
 
-  run_parity "lead_lag" "
+run_parity "lead_lag" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, val INTEGER);
 INSERT INTO t VALUES(1,10);
 INSERT INTO t VALUES(2,20);
@@ -303,7 +276,7 @@ INSERT INTO t VALUES(4,40);
 SELECT id, val, LAG(val,1) OVER (ORDER BY id) AS prev, LEAD(val,1) OVER (ORDER BY id) AS next FROM t ORDER BY id;
 "
 
-  run_parity "sum_over" "
+run_parity "sum_over" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, val INTEGER);
 INSERT INTO t VALUES(1,10);
 INSERT INTO t VALUES(2,20);
@@ -311,7 +284,7 @@ INSERT INTO t VALUES(3,30);
 SELECT id, val, SUM(val) OVER (ORDER BY id) AS running FROM t ORDER BY id;
 "
 
-  run_parity "ntile" "
+run_parity "ntile" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, val INTEGER);
 INSERT INTO t VALUES(1,10);
 INSERT INTO t VALUES(2,20);
@@ -319,9 +292,6 @@ INSERT INTO t VALUES(3,30);
 INSERT INTO t VALUES(4,40);
 SELECT id, NTILE(2) OVER (ORDER BY id) AS tile FROM t ORDER BY id;
 "
-else
-  skip_test "window_functions" "sqlite3 $SQLITE_VERSION < 3.25"
-fi
 
 echo "--- NULL handling ---"
 
@@ -527,31 +497,30 @@ SELECT julianday('2024-03-15') - julianday('2024-03-01');
 
 echo "--- JSON functions ---"
 
-if [ "$HAS_JSON" -eq 1 ]; then
-  run_parity "json_array" "
+run_parity "json_array" "
 SELECT json_array(1,2,'three',NULL);
 "
 
-  run_parity "json_object" "
+run_parity "json_object" "
 SELECT json_object('a',1,'b','two');
 "
 
-  run_parity "json_extract" "
+run_parity "json_extract" "
 SELECT json_extract('{\"a\":1,\"b\":[2,3]}', '\$.a');
 SELECT json_extract('{\"a\":1,\"b\":[2,3]}', '\$.b[0]');
 "
 
-  run_parity "json_type" "
+run_parity "json_type" "
 SELECT json_type('{\"a\":1}', '\$.a');
 SELECT json_type('{\"a\":\"hello\"}', '\$.a');
 "
 
-  run_parity "json_valid" "
+run_parity "json_valid" "
 SELECT json_valid('{\"a\":1}');
 SELECT json_valid('not json');
 "
 
-  run_parity "json_group_array" "
+run_parity "json_group_array" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');
 INSERT INTO t VALUES(2,'b');
@@ -559,15 +528,12 @@ INSERT INTO t VALUES(3,'c');
 SELECT json_group_array(v) FROM t ORDER BY id;
 "
 
-  run_parity "json_group_object" "
+run_parity "json_group_object" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, k TEXT, v INTEGER);
 INSERT INTO t VALUES(1,'x',10);
 INSERT INTO t VALUES(2,'y',20);
 SELECT json_group_object(k,v) FROM t ORDER BY id;
 "
-else
-  skip_test "json_functions" "sqlite3 $SQLITE_VERSION lacks JSON support"
-fi
 
 echo "--- Set operations ---"
 
@@ -619,13 +585,12 @@ SELECT v FROM a EXCEPT SELECT v FROM b ORDER BY v;
 
 echo "--- CTEs ---"
 
-if [ "$HAS_CTE" -eq 1 ]; then
-  run_parity "simple_cte" "
+run_parity "simple_cte" "
 WITH nums AS (SELECT 1 AS n UNION ALL SELECT 2 UNION ALL SELECT 3)
 SELECT * FROM nums ORDER BY n;
 "
 
-  run_parity "recursive_cte" "
+run_parity "recursive_cte" "
 WITH RECURSIVE cnt(x) AS (
   SELECT 1
   UNION ALL
@@ -634,7 +599,7 @@ WITH RECURSIVE cnt(x) AS (
 SELECT x FROM cnt;
 "
 
-  run_parity "cte_with_table" "
+run_parity "cte_with_table" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, parent_id INTEGER, name TEXT);
 INSERT INTO t VALUES(1,NULL,'root');
 INSERT INTO t VALUES(2,1,'a');
@@ -648,15 +613,12 @@ WITH RECURSIVE tree(id, name, depth) AS (
 SELECT id, name, depth FROM tree ORDER BY id;
 "
 
-  run_parity "multiple_ctes" "
+run_parity "multiple_ctes" "
 WITH
   a AS (SELECT 1 AS x UNION ALL SELECT 2),
   b AS (SELECT x*10 AS y FROM a)
 SELECT * FROM b ORDER BY y;
 "
-else
-  skip_test "cte" "sqlite3 $SQLITE_VERSION < 3.9"
-fi
 
 echo "--- CAST ---"
 
@@ -985,7 +947,7 @@ SELECT pk FROM parent ORDER BY pk;
 
 echo ""
 echo "======================================="
-echo "Results: $PASS passed, $FAIL failed, $SKIP skipped out of $((PASS+FAIL+SKIP)) tests"
+echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
 echo "======================================="
 if [ $FAIL -gt 0 ]; then
   echo ""

--- a/test/oom_dolt_fault_test.c
+++ b/test/oom_dolt_fault_test.c
@@ -12,9 +12,7 @@
 ** checks on allocation results). The harness intentionally does NOT
 ** fix them; it only detects them. Followups go in the PR body.
 **
-** This is wired into c-tests via test/run_c_tests.sh. Placement (GATING
-** vs EXPECTED_FAIL) depends on observed behavior on master at wire-in
-** time. See test/run_c_tests.sh for the convention.
+** This is wired into c-tests via test/run_c_tests.sh.
 */
 #include <stdio.h>
 #include <string.h>

--- a/test/run_c_tests.sh
+++ b/test/run_c_tests.sh
@@ -1,18 +1,6 @@
 #!/usr/bin/env bash
 #
-# Runner for the 8 orphan C tests that were previously not wired into CI.
-#
-# Two categories:
-#
-#   GATING            - currently passes on master. A failure here breaks CI.
-#   EXPECTED_FAIL     - currently has preexisting failures or crashes on
-#                       master. Run anyway (because the whole point of wiring
-#                       these in is to surface bugs), but a nonzero exit
-#                       does NOT break CI. The exit status and pass/fail
-#                       counts are still printed so PRs can see them.
-#
-# When you fix the bug surfaced by a test in EXPECTED_FAIL, move it to GATING
-# in this file so future regressions break CI.
+# Runner for the orphan C tests that are wired into CI.
 #
 # Usage: run_c_tests.sh BUILD_DIR
 #   BUILD_DIR is where the test binaries live (typically the doltlite build
@@ -32,27 +20,13 @@ GATING=(
   three_way_diff_test
   multi_process_test
   oom_dolt_fault_test
-)
-
-# Tests that have known preexisting failures or crashes on master. These are
-# run but their nonzero exit does not break CI. Each one has a follow-up
-# bug to track.
-#
-# Counts at time of wiring (master @ HEAD when this file was first added):
-#   cross_branch_test        crashes after 4 reported fails (SIGSEGV)
-#   corruption_test          crashes after 4 reported fails (SIGABRT/139)
-#
-# These represent real, latent bugs that the CI suite was previously
-# hiding. They should be triaged and fixed one at a time, after which
-# each test should be promoted into GATING.
-EXPECTED_FAIL=(
   cross_branch_test
   corruption_test
 )
 
 run_one() {
   local name="$1"
-  local kind="$2"   # "GATING" or "EXPECTED_FAIL"
+  local kind="$2"
   local exe="./$name"
 
   if [ ! -x "$exe" ]; then
@@ -70,17 +44,10 @@ run_one() {
 }
 
 gating_failures=0
-expected_failures=0
 
 for t in "${GATING[@]}"; do
   if ! run_one "$t" GATING; then
     gating_failures=$((gating_failures + 1))
-  fi
-done
-
-for t in "${EXPECTED_FAIL[@]}"; do
-  if ! run_one "$t" EXPECTED_FAIL; then
-    expected_failures=$((expected_failures + 1))
   fi
 done
 
@@ -89,7 +56,6 @@ echo "============================================================"
 echo "Summary"
 echo "============================================================"
 echo "GATING failures        : $gating_failures / ${#GATING[@]}"
-echo "EXPECTED_FAIL failures : $expected_failures / ${#EXPECTED_FAIL[@]} (not gating)"
 
 if [ "$gating_failures" -ne 0 ]; then
   echo "FAIL: $gating_failures gating tests failed"


### PR DESCRIPTION
## Summary
- promote cross_branch_test and corruption_test into the gating C test set
- detect corrupted compacted stores with an empty refs hash instead of reopening as a fresh repository
- remove a stale corruption assertion for the old catalog_hash manifest field

## Verification
- make c-tests