### PR TITLE
fix(packaging): stop shipping /usr/include/sqlite3.h

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,7 +181,6 @@ jobs:
         VERSION=${GITHUB_REF_NAME#v}
         DIR="doltlite-lib-${{ matrix.target }}-${VERSION}"
         mkdir -p "${DIR}"
-        cp build/sqlite3.h "${DIR}/sqlite3.h" 2>/dev/null || true
         cp build/sqlite3.h "${DIR}/doltlite.h" 2>/dev/null || true
         cp src/doltlite_remotesrv.h "${DIR}/doltlite_remotesrv.h" 2>/dev/null || true
         cp build/libdoltlite${{ matrix.static_ext }} "${DIR}/" 2>/dev/null || true
@@ -286,7 +285,17 @@ jobs:
         test -x /usr/bin/doltlite
         test -x /usr/bin/doltlite-remotesrv
         test -f /usr/include/doltlite.h
-        test -f /usr/include/sqlite3.h
+        # We intentionally do NOT install /usr/include/sqlite3.h —
+        # that path is owned by libsqlite3-dev (pre-installed on
+        # ubuntu-latest) and shipping our copy there made `dpkg -i`
+        # fail. Guard against regression: if sqlite3.h exists, it
+        # must NOT be owned by libdoltlite-dev.
+        if [ -e /usr/include/sqlite3.h ] \
+           && dpkg -S /usr/include/sqlite3.h 2>/dev/null \
+              | grep -q '^libdoltlite-dev:'; then
+          echo "regression: libdoltlite-dev installs /usr/include/sqlite3.h"
+          exit 1
+        fi
         ldconfig -p | grep -q libdoltlite || (echo "libdoltlite.so.0 not registered with ldconfig" && exit 1)
 
     - name: Smoke test — doltlite CLI runs and reports version

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Prebuilt binaries: [github.com/dolthub/doltlite/releases](https://github.com/dol
 Each install method places the same set of files (paths shown for `/usr/local`):
 
 - `bin/doltlite`, `bin/doltlite-remotesrv` — the CLI shell and remote sync server
-- `include/sqlite3.h`, `include/doltlite.h` — embedding header (same content; either name works)
+- `include/doltlite.h` — embedding header (the SQLite C API, under our name; `#include <doltlite.h>`)
 - `include/doltlite_remotesrv.h` — in-process remote server API
 - `lib/libdoltlite.a` — static library
 - `lib/libdoltlite.{so,dylib}` — shared library
@@ -126,10 +126,11 @@ make -C ext/wasm dist
 
 ## Using as a C Library
 
-Doltlite is designed as a drop-in replacement for SQLite. It uses the same
-`sqlite3.h` header and `sqlite3_*` API, so existing C programs work without
-code changes — just link against `libdoltlite` instead of `libsqlite3` to get
-version control. The build produces `libdoltlite.a` (static) and
+Doltlite exposes the full SQLite C API (`sqlite3_open`, `sqlite3_exec`,
+`sqlite3_prepare_v2`, ...) through `doltlite.h`. Existing C programs port
+by changing `#include "sqlite3.h"` to `#include <doltlite.h>` and linking
+against `libdoltlite` instead of `libsqlite3` — no other source changes —
+to get version control. The build produces `libdoltlite.a` (static) and
 `libdoltlite.dylib`/`.so` (shared) with the full prolly tree engine and all
 Dolt functions included.
 

--- a/examples/quickstart.c
+++ b/examples/quickstart.c
@@ -16,7 +16,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "sqlite3.h"
+#include "doltlite.h"
 
 /* Print a result set with column headers */
 static int callback(void *label, int argc, char **argv, char **azColName){

--- a/main.mk
+++ b/main.mk
@@ -1249,6 +1249,12 @@ sqlite3.h: $(MAKE_SANITY_CHECK) $(TOP)/src/sqlite.h.in \
 		$(TOP)/VERSION $(B.tclsh)
 	$(B.tclsh) $(TOP)/tool/mksqlite3h.tcl $(TOP) -o sqlite3.h
 
+# doltlite.h is the same content as sqlite3.h under our preferred name.
+# Generated alongside the SQLite header so source builds and installed
+# packages expose the same include path (#include "doltlite.h").
+doltlite.h: sqlite3.h
+	cp sqlite3.h doltlite.h
+
 sqlite3.c:	.target_source sqlite3.h $(TOP)/tool/mksqlite3c.tcl src-verify$(B.exe) \
 		$(B.tclsh) $(EXTRA_SRC)
 	$(B.tclsh) $(TOP)/tool/mksqlite3c.tcl $(AMALGAMATION_GEN_FLAGS) $(EXTRA_SRC)
@@ -2664,7 +2670,7 @@ libdoltlite$(T.dll):	$(LIBOBJS0)
 	$(T.link.shared) -o $@ $(LIBOBJS0) $(LDFLAGS.libsqlite3) \
 		$(LDFLAGS.libdoltlite.os-specific) $(LDFLAGS.libdoltlite.soname)
 
-doltlite-lib: libdoltlite$(T.lib) libdoltlite$(T.dll)
+doltlite-lib: libdoltlite$(T.lib) libdoltlite$(T.dll) doltlite.h
 all: doltlite-lib
 
 #

--- a/packaging/homebrew/doltlite.rb
+++ b/packaging/homebrew/doltlite.rb
@@ -16,12 +16,12 @@ class Doltlite < Formula
       system "../configure"
       system "make", "doltlite", "doltlite-remotesrv", "doltlite-lib"
       bin.install "doltlite", "doltlite-remotesrv"
-      # Ship sqlite3.h verbatim so existing C programs that
-      # `#include "sqlite3.h"` (including examples/quickstart.c) just
-      # work after install. doltlite.h is the same content under the
-      # project's preferred name. doltlite_remotesrv.h declares the
+      # Install the embedding header as doltlite.h only. We do NOT
+      # ship sqlite3.h: spoofing the canonical SQLite header path
+      # collides with the system's sqlite3 packages on the same
+      # machine. doltlite.h is the same generated SQLite amalgamation
+      # header under our name. doltlite_remotesrv.h declares the
       # in-process remote-server API (doltliteServeAsync et al.).
-      include.install "sqlite3.h"
       include.install "sqlite3.h" => "doltlite.h"
       include.install "#{buildpath}/src/doltlite_remotesrv.h"
       lib.install "libdoltlite.a"
@@ -34,7 +34,7 @@ class Doltlite < Formula
                  shell_output("#{bin}/doltlite :memory: 'SELECT dolt_version();'")
     (testpath/"hello.c").write <<~EOS
       #include <stdio.h>
-      #include "sqlite3.h"
+      #include "doltlite.h"
       int main(void) {
         sqlite3 *db;
         if (sqlite3_open(":memory:", &db) != SQLITE_OK) return 1;

--- a/packaging/nfpm/libdoltlite-dev.yaml
+++ b/packaging/nfpm/libdoltlite-dev.yaml
@@ -20,14 +20,11 @@ depends:
   - libdoltlite0 (= ${VERSION})
 
 contents:
-  # Ship sqlite3.h verbatim so existing C programs that
-  # `#include "sqlite3.h"` (including examples/quickstart.c) keep
-  # working after `apt install libdoltlite-dev`. doltlite.h is the
-  # same content under the project's preferred name.
-  - src: build/sqlite3.h
-    dst: /usr/include/sqlite3.h
-    file_info:
-      mode: 0644
+  # Install the header as doltlite.h only. We deliberately do NOT ship
+  # /usr/include/sqlite3.h: it collides with libsqlite3-dev (extremely
+  # common as a transitive dep — Python dev headers, php, perl, etc.)
+  # and `dpkg -i` fails. Users `#include <doltlite.h>`; the file
+  # content is the same generated SQLite amalgamation header.
   - src: build/sqlite3.h
     dst: /usr/include/doltlite.h
     file_info:


### PR DESCRIPTION
## Summary

- `libdoltlite-dev` installed our `sqlite3.h` at `/usr/include/sqlite3.h`, owned by `libsqlite3-dev` (pre-installed on ubuntu-latest and a transitive dep of Python/PHP/Perl dev packages). `dpkg -i` fails with "trying to overwrite '/usr/include/sqlite3.h'". This was caught on v0.10.7 by the non-blocking smoke test from #854.
- Drop the spoof: install header as `/usr/include/doltlite.h` only. Same cleanup in Homebrew, the `doltlite-lib-*.zip` distribution, README, `examples/quickstart.c`. Internal build naming (`make sqlite3.c sqlite3.h`, autoconf tarball) unchanged.
- Smoke test now also has a regression guard: fails if `/usr/include/sqlite3.h` is ever owned by `libdoltlite-dev` again.

## Test plan

- [ ] CI: `package-smoke-deb` job passes (dpkg -i succeeds, doltlite.h present, smoke SQL works)
- [ ] CI: regression guard fires when re-adding `sqlite3.h` to `libdoltlite-dev.yaml` (sanity check by toggling locally if curious)
- [ ] On a fresh ubuntu with `libsqlite3-dev` already installed: `dpkg -i libdoltlite-dev_*.deb` succeeds
- [ ] On a system without `libsqlite3-dev`: same — `/usr/include/doltlite.h` only, no `/usr/include/sqlite3.h` from us
- [ ] Homebrew formula: `brew install --build-from-source` succeeds; the inline `hello.c` test compiles with `#include "doltlite.h"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)