### PR TITLE
harden vtable rowid hash against length-shift collisions

### DIFF
--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -534,6 +534,7 @@ static sqlite3_int64 cfrConflictRowid(const struct ConflictRow *cr){
       h *= 1099511628211ULL;
     }
   }
+  h *= 1099511628211ULL;
   {
     u64 k = (u64)cr->intKey;
     for(i=0; i<8; i++){
@@ -541,6 +542,7 @@ static sqlite3_int64 cfrConflictRowid(const struct ConflictRow *cr){
       h *= 1099511628211ULL;
     }
   }
+  h *= 1099511628211ULL;
   if( cr->nBaseVal>0 && cr->pBaseVal ){
     for(i=0; i<cr->nBaseVal; i++){
       h ^= (u64)cr->pBaseVal[i];

--- a/src/doltlite_constraint_violations.c
+++ b/src/doltlite_constraint_violations.c
@@ -649,6 +649,7 @@ static sqlite3_int64 cvrViolationRowid(const ConstraintViolationRow *r){
       h *= 1099511628211ULL;
     }
   }
+  h *= 1099511628211ULL;
   {
     u64 k = (u64)r->intKey;
     for(i=0; i<8; i++){
@@ -656,13 +657,16 @@ static sqlite3_int64 cvrViolationRowid(const ConstraintViolationRow *r){
       h *= 1099511628211ULL;
     }
   }
+  h *= 1099511628211ULL;
   if( r->nVal>0 && r->pVal ){
     for(i=0; i<r->nVal; i++){
       h ^= (u64)r->pVal[i];
       h *= 1099511628211ULL;
     }
   }
+  h *= 1099511628211ULL;
   h ^= (u64)r->violationType;
+  h *= 1099511628211ULL;
   h *= 1099511628211ULL;
   if( r->zInfo ){
     for(i=0; r->zInfo[i]; i++){


### PR DESCRIPTION
## Summary

- Adds `h *= PRIME` separators between every adjacent section in both `cfrConflictRowid` and `cvrViolationRowid`. PR #861 had partial separators between `baseVal`/`ourVal`/`theirVal` in conflicts and none in violations; the `pKey`/`intKey`/firstValue boundary was unguarded in both.
- Eliminates the length-shift collision class: two rows whose fields shift bytes across the section boundary no longer produce identical FNV-1a byte streams.

Concrete example the previous code allowed (now blocked):

```
Row A: pKey=[A,B,C], intKey bytes [D..K], pVal=[L,M]
Row B: pKey=[A,B,C,D], intKey bytes [E..L], pVal=[M]
Both stream identically as: A,B,C,D,E,F,G,H,I,J,K,L,M
```

Same hash, different rows → `DELETE FROM dolt_conflicts_t WHERE rowid=?` could drop the wrong one (this was the same class of bug #861 fixed for the sentinel-aliasing case).

Practical risk on real keyed SQLite records was already negligible, but this closes the class entirely and keeps the two rowid functions structurally symmetric.

## Test plan

- [ ] Existing conflict/violation vtable tests still pass (rowids change values but remain stable across reloads within a session — that's all the existing tests assert)
- [ ] DELETE FROM dolt_conflicts_t / dolt_constraint_violations_t WHERE rowid=? still deletes exactly one row in the smoke tests
- [ ] No persisted use of rowid values across sessions (verified: rowids are recomputed from row content each open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)