### PR TITLE
harden int arithmetic in allocation paths

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -129,7 +129,7 @@ static int csSearchIndex(const ChunkIndexEntry *aIdx, int nIdx,
 static int csSearchPending(ChunkStore *cs, const ProllyHash *pHash, int *pIdx);
 static int csIndexEntryCmp(const void *a, const void *b);
 void csSerializeManifest(const ChunkStore *cs, u8 *aBuf);
-static void csDeserializeIndexEntry(const u8 *aBuf, ChunkIndexEntry *e);
+static int csDeserializeIndexEntry(const u8 *aBuf, ChunkIndexEntry *e);
 static int csMergeIndex(ChunkStore *cs, ChunkIndexEntry **ppMerged,
                         int *pnMerged);
 static int csGrowPending(ChunkStore *cs);
@@ -822,10 +822,13 @@ void csSerializeManifest(const ChunkStore *cs, u8 *aBuf){
   memcpy(aBuf + 104, cs->refsHash.data, PROLLY_HASH_SIZE);
 }
 
-static void csDeserializeIndexEntry(const u8 *aBuf, ChunkIndexEntry *e){
+static int csDeserializeIndexEntry(const u8 *aBuf, ChunkIndexEntry *e){
+  u32 sz = CS_READ_U32(aBuf + PROLLY_HASH_SIZE + 8);
+  if( sz > (u32)0x7fffffff ) return SQLITE_CORRUPT;
   memcpy(e->hash.data, aBuf, PROLLY_HASH_SIZE);
   e->offset = CS_READ_I64(aBuf + PROLLY_HASH_SIZE);
-  e->size = (int)CS_READ_U32(aBuf + PROLLY_HASH_SIZE + 8);
+  e->size = (int)sz;
+  return SQLITE_OK;
 }
 
 static int csReadManifest(ChunkStore *cs){
@@ -940,7 +943,15 @@ static int csReadIndex(ChunkStore *cs){
   }
 
   for( i = 0; i < nEntries; i++ ){
-    csDeserializeIndexEntry(aBuf + i * CHUNK_INDEX_ENTRY_SIZE, &cs->aIndex[i]);
+    rc = csDeserializeIndexEntry(aBuf + i * CHUNK_INDEX_ENTRY_SIZE,
+                                 &cs->aIndex[i]);
+    if( rc != SQLITE_OK ){
+      sqlite3_free(aBuf);
+      sqlite3_free(cs->aIndex);
+      cs->aIndex = 0;
+      cs->nIndex = 0;
+      return rc;
+    }
   }
 
   sqlite3_free(aBuf);
@@ -1050,7 +1061,8 @@ static int csReplayWal(ChunkStore *cs){
       memcpy(&hash, aHdr, 20);
       len = CS_READ_U32(aHdr + 20);
       pos += 24;
-      if( pos < 0 || (u64)pos + len > (u64)walSize ){
+      if( pos < 0 || len > (u32)0x7fffffff
+       || (u64)pos + len > (u64)walSize ){
         break;
       }
 

--- a/src/doltlite_commit_ancestors.c
+++ b/src/doltlite_commit_ancestors.c
@@ -152,12 +152,14 @@ static int caNext(sqlite3_vtab_cursor *pCursor){
 static int caEnqueue(CommitAncestorsCursor *pCur, const ProllyHash *p){
   if( prollyHashIsEmpty(p) ) return SQLITE_OK;
   if( pCur->qTail >= pCur->qAlloc ){
-    int nNew = pCur->qAlloc ? pCur->qAlloc*2 : 16;
-    ProllyHash *tmp = sqlite3_realloc(pCur->aQueue,
-                                       nNew*(int)sizeof(ProllyHash));
+    i64 nNew = pCur->qAlloc ? (i64)pCur->qAlloc * 2 : (i64)16;
+    ProllyHash *tmp;
+    if( nNew > (i64)0x7fffffff/(i64)sizeof(ProllyHash) ) return SQLITE_NOMEM;
+    tmp = sqlite3_realloc(pCur->aQueue,
+                          (int)(nNew * (i64)sizeof(ProllyHash)));
     if( !tmp ) return SQLITE_NOMEM;
     pCur->aQueue = tmp;
-    pCur->qAlloc = nNew;
+    pCur->qAlloc = (int)nNew;
   }
   pCur->aQueue[pCur->qTail++] = *p;
   return SQLITE_OK;

--- a/src/doltlite_diff.c
+++ b/src/doltlite_diff.c
@@ -392,14 +392,20 @@ static int diffAdvance(DoltliteDiffCursor *pCur, sqlite3 *db){
       if( prollyHashSetContains(&pCur->visited, pParent) ) continue;
       if( prollyHashSetContains(&pCur->queued,  pParent) ) continue;
       if( pCur->qTail >= pCur->qAlloc ){
-        int nNew = pCur->qAlloc*2;
-        ProllyHash *tmp = sqlite3_realloc(pCur->aQueue,
-                                          nNew*(int)sizeof(ProllyHash));
+        i64 nNew = (i64)pCur->qAlloc * 2;
+        i64 nBytes;
+        ProllyHash *tmp;
+        if( nNew > (i64)0x7fffffff/(i64)sizeof(ProllyHash) ){
+          doltliteCommitClear(&commit);
+          return SQLITE_NOMEM;
+        }
+        nBytes = nNew * (i64)sizeof(ProllyHash);
+        tmp = sqlite3_realloc(pCur->aQueue, (int)nBytes);
         if( !tmp ){
           doltliteCommitClear(&commit);
           return SQLITE_NOMEM;
         }
-        pCur->aQueue = tmp; pCur->qAlloc = nNew;
+        pCur->aQueue = tmp; pCur->qAlloc = (int)nNew;
       }
       pCur->aQueue[pCur->qTail++] = *pParent;
       rc = prollyHashSetAdd(&pCur->queued, pParent);

--- a/src/doltlite_history.c
+++ b/src/doltlite_history.c
@@ -128,14 +128,19 @@ static int htOpenTableAtCommit(HistCursor *c, sqlite3 *db,
       if( prollyHashSetContains(&c->visited, pParent) ) continue;
       if( prollyHashSetContains(&c->queued, pParent) ) continue;
       if( c->qTail >= c->qAlloc ){
-        int nNew = c->qAlloc ? c->qAlloc*2 : 16;
-        ProllyHash *tmp = sqlite3_realloc(c->aQueue,
-                                           nNew*(int)sizeof(ProllyHash));
+        i64 nNew = c->qAlloc ? (i64)c->qAlloc * 2 : (i64)16;
+        ProllyHash *tmp;
+        if( nNew > (i64)0x7fffffff/(i64)sizeof(ProllyHash) ){
+          doltliteCommitClear(&commit);
+          return SQLITE_NOMEM;
+        }
+        tmp = sqlite3_realloc(c->aQueue,
+                              (int)(nNew * (i64)sizeof(ProllyHash)));
         if( !tmp ){
           doltliteCommitClear(&commit);
           return SQLITE_NOMEM;
         }
-        c->aQueue = tmp; c->qAlloc = nNew;
+        c->aQueue = tmp; c->qAlloc = (int)nNew;
       }
       c->aQueue[c->qTail++] = *pParent;
       rc = prollyHashSetAdd(&c->queued, pParent);

--- a/src/doltlite_log.c
+++ b/src/doltlite_log.c
@@ -122,12 +122,14 @@ static int logAdvance(DoltliteLogCursor *pCur, sqlite3 *db){
       const ProllyHash *pParent = doltliteCommitParentHash(&pCur->curCommit, i);
       if( !pParent || prollyHashIsEmpty(pParent) ) continue;
       if( pCur->qTail >= pCur->qAlloc ){
-        int nNew = pCur->qAlloc ? pCur->qAlloc*2 : 16;
-        ProllyHash *tmp = sqlite3_realloc(pCur->aQueue,
-                                           nNew*(int)sizeof(ProllyHash));
+        i64 nNew = pCur->qAlloc ? (i64)pCur->qAlloc * 2 : (i64)16;
+        ProllyHash *tmp;
+        if( nNew > (i64)0x7fffffff/(i64)sizeof(ProllyHash) ) return SQLITE_NOMEM;
+        tmp = sqlite3_realloc(pCur->aQueue,
+                              (int)(nNew * (i64)sizeof(ProllyHash)));
         if( !tmp ) return SQLITE_NOMEM;
         pCur->aQueue = tmp;
-        pCur->qAlloc = nNew;
+        pCur->qAlloc = (int)nNew;
       }
       pCur->aQueue[pCur->qTail++] = *pParent;
     }

--- a/src/doltlite_record.c
+++ b/src/doltlite_record.c
@@ -26,14 +26,25 @@ struct RecBuf {
 
 static int recBufAppend(RecBuf *b, const char *z, int n){
   char *zNew;
+  i64 nNeed;
   if( n<0 ) n = (int)strlen(z);
-  if( b->n + n + 1 > b->nAlloc ){
-    int nNew = b->nAlloc ? b->nAlloc*2 : 128;
-    while( nNew < b->n + n + 1 ) nNew *= 2;
-    zNew = sqlite3_realloc(b->z, nNew);
+  if( n<0 ) return SQLITE_NOMEM;
+  nNeed = (i64)b->n + (i64)n + 1;
+  if( nNeed > (i64)0x7fffffff ) return SQLITE_NOMEM;
+  if( nNeed > (i64)b->nAlloc ){
+    i64 nNew = b->nAlloc ? (i64)b->nAlloc * 2 : (i64)128;
+    while( nNew < nNeed ){
+      if( nNew > (i64)0x7fffffff/2 ){
+        nNew = (i64)0x7fffffff;
+        break;
+      }
+      nNew *= 2;
+    }
+    if( nNew < nNeed ) return SQLITE_NOMEM;
+    zNew = sqlite3_realloc(b->z, (int)nNew);
     if( !zNew ) return SQLITE_NOMEM;
     b->z = zNew;
-    b->nAlloc = nNew;
+    b->nAlloc = (int)nNew;
   }
   memcpy(b->z + b->n, z, n);
   b->n += n;

--- a/src/prolly_node.c
+++ b/src/prolly_node.c
@@ -262,49 +262,77 @@ void prollyNodeBuilderInit(ProllyNodeBuilder *b, u8 level, u8 flags){
 }
 
 static int builderGrowOffsets(ProllyNodeBuilder *b){
-  int nNeeded = b->nItems + 2;
-  if( nNeeded>b->nAlloc ){
-    int nNew = b->nAlloc ? b->nAlloc * 2 : PROLLY_BUILDER_INIT_CAP;
+  i64 nNeeded = (i64)b->nItems + 2;
+  if( nNeeded > (i64)0x7fffffff/(i64)sizeof(u32) ) return SQLITE_NOMEM;
+  if( nNeeded > (i64)b->nAlloc ){
+    i64 nNew = b->nAlloc ? (i64)b->nAlloc * 2 : (i64)PROLLY_BUILDER_INIT_CAP;
     u32 *aNew;
-    while( nNew<nNeeded ) nNew *= 2;
+    while( nNew < nNeeded ){
+      if( nNew > (i64)0x7fffffff/(i64)sizeof(u32)/2 ){
+        nNew = (i64)0x7fffffff/(i64)sizeof(u32);
+        break;
+      }
+      nNew *= 2;
+    }
+    if( nNew < nNeeded ) return SQLITE_NOMEM;
 
-    aNew = (u32*)sqlite3_realloc(b->aKeyOff, nNew * sizeof(u32));
+    aNew = (u32*)sqlite3_realloc(b->aKeyOff, (int)(nNew * (i64)sizeof(u32)));
     if( !aNew ) return SQLITE_NOMEM;
     b->aKeyOff = aNew;
 
-    aNew = (u32*)sqlite3_realloc(b->aValOff, nNew * sizeof(u32));
+    aNew = (u32*)sqlite3_realloc(b->aValOff, (int)(nNew * (i64)sizeof(u32)));
     if( !aNew ) return SQLITE_NOMEM;
     b->aValOff = aNew;
 
-    b->nAlloc = nNew;
+    b->nAlloc = (int)nNew;
   }
   return SQLITE_OK;
 }
 
 static int builderGrowKeyBuf(ProllyNodeBuilder *b, int nAdd){
-  int nNeeded = b->nKeyBytes + nAdd;
-  if( nNeeded>b->nKeyBufAlloc ){
-    int nNew = b->nKeyBufAlloc ? b->nKeyBufAlloc * 2 : PROLLY_BUILDER_INIT_BUF;
+  i64 nNeeded;
+  if( nAdd<0 ) return SQLITE_NOMEM;
+  nNeeded = (i64)b->nKeyBytes + (i64)nAdd;
+  if( nNeeded > (i64)0x7fffffff ) return SQLITE_NOMEM;
+  if( nNeeded > (i64)b->nKeyBufAlloc ){
+    i64 nNew = b->nKeyBufAlloc ? (i64)b->nKeyBufAlloc * 2 : (i64)PROLLY_BUILDER_INIT_BUF;
     u8 *pNew;
-    while( nNew<nNeeded ) nNew *= 2;
-    pNew = (u8*)sqlite3_realloc(b->pKeyBuf, nNew);
+    while( nNew < nNeeded ){
+      if( nNew > (i64)0x7fffffff/2 ){
+        nNew = (i64)0x7fffffff;
+        break;
+      }
+      nNew *= 2;
+    }
+    if( nNew < nNeeded ) return SQLITE_NOMEM;
+    pNew = (u8*)sqlite3_realloc(b->pKeyBuf, (int)nNew);
     if( !pNew ) return SQLITE_NOMEM;
     b->pKeyBuf = pNew;
-    b->nKeyBufAlloc = nNew;
+    b->nKeyBufAlloc = (int)nNew;
   }
   return SQLITE_OK;
 }
 
 static int builderGrowValBuf(ProllyNodeBuilder *b, int nAdd){
-  int nNeeded = b->nValBytes + nAdd;
-  if( nNeeded>b->nValBufAlloc ){
-    int nNew = b->nValBufAlloc ? b->nValBufAlloc * 2 : PROLLY_BUILDER_INIT_BUF;
+  i64 nNeeded;
+  if( nAdd<0 ) return SQLITE_NOMEM;
+  nNeeded = (i64)b->nValBytes + (i64)nAdd;
+  if( nNeeded > (i64)0x7fffffff ) return SQLITE_NOMEM;
+  if( nNeeded > (i64)b->nValBufAlloc ){
+    i64 nNew = b->nValBufAlloc ? (i64)b->nValBufAlloc * 2 : (i64)PROLLY_BUILDER_INIT_BUF;
     u8 *pNew;
-    while( nNew<nNeeded ) nNew *= 2;
-    pNew = (u8*)sqlite3_realloc(b->pValBuf, nNew);
+    while( nNew < nNeeded ){
+      if( nNew > (i64)0x7fffffff/2 ){
+        nNew = (i64)0x7fffffff;
+        break;
+      }
+      nNew *= 2;
+    }
+    if( nNew < nNeeded ) return SQLITE_NOMEM;
+    pNew = (u8*)sqlite3_realloc(b->pValBuf, (int)nNew);
     if( !pNew ) return SQLITE_NOMEM;
     b->pValBuf = pNew;
-    b->nValBufAlloc = nNew;
+    b->nValBufAlloc = (int)nNew;
   }
   return SQLITE_OK;
 }


### PR DESCRIPTION
## Summary

Six sites with the same shape as recent fixes #855/#857/#858: attacker-influenced input → `int` arithmetic for allocation sizing → no `INT_MAX` guard. Found via a targeted sweep after those three landed.

### u32 → int cast-narrow on disk-derived size fields

A crafted chunk-store manifest or WAL could set a `u32` size > INT_MAX, producing a negative `e->size` after the cast. Downstream allocations then truncated or wrote OOB.

- **`chunk_store.c csReplayWal`** — reject `len > INT_MAX` alongside the existing `pos + len > walSize` check before storing as `e->size`.
- **`chunk_store.c csDeserializeIndexEntry`** — function now returns `int`; caller (`csReadIndex`) propagates `SQLITE_CORRUPT` when the manifest claims an oversized chunk.

### Unbounded `nNew *= 2` doubling on commit-graph queues / record buffers / node builders

With ~107M accumulated entries (adversarial commit DAG, attacker-tuned record blob), `nNew` overflows `int` to negative or wraps small; `realloc(p, nNew * sizeof(T))` then either under-allocates or fails opaquely.

- **`doltlite_diff.c`, `doltlite_commit_ancestors.c`, `doltlite_history.c`, `doltlite_log.c`** — queue grow uses i64 doubling, checks `nNew * sizeof(ProllyHash)` against INT_MAX before realloc.
- **`doltlite_record.c recBufAppend`** — i64 sum, capped doubling.
- **`prolly_node.c builderGrowOffsets / KeyBuf / ValBuf`** — same template, accounting for `sizeof(u32)` in the offsets array.

### Fix template

```c
i64 nNew = nAlloc ? (i64)nAlloc * 2 : SEED;
while( nNew < (i64)nNeeded ){
  if( nNew > (i64)INT_MAX/2 ){ nNew = INT_MAX; break; }
  nNew *= 2;
}
if( nNew < (i64)nNeeded ) return SQLITE_NOMEM;
pNew = sqlite3_realloc(p, (int)nNew);
```

## Test plan

- [x] `make doltlite-lib && make doltlite` succeeds locally
- [x] Basic CREATE/INSERT/SELECT roundtrip works
- [x] dolt_commit + dolt_log exercise the touched commit-graph queue paths
- [ ] Full CI (oracle, sqllogictest, asan-ubsan) on master
- [ ] No behavioral change for non-adversarial workloads (the new bounds are all > INT_MAX, so legitimate allocations are untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)