### PR TITLE
harden remaining int-overflow sites + add grow-array helper

### DIFF
--- a/src/doltlite_blame.c
+++ b/src/doltlite_blame.c
@@ -211,13 +211,8 @@ static int blameCollectLiveRows(
     int nKey = 0, nVal = 0;
     BlameRow *r;
 
-    if( pCur->nRows >= pCur->nAlloc ){
-      int nNew = pCur->nAlloc ? pCur->nAlloc*2 : 64;
-      BlameRow *aNew = sqlite3_realloc(pCur->aRows, nNew*(int)sizeof(BlameRow));
-      if( !aNew ){ prollyCursorClose(&cur); return SQLITE_NOMEM; }
-      pCur->aRows = aNew;
-      pCur->nAlloc = nNew;
-    }
+    rc = DOLTLITE_GROW_ARRAY(&pCur->aRows, &pCur->nAlloc, pCur->nRows + 1, 64);
+    if( rc!=SQLITE_OK ){ prollyCursorClose(&cur); return rc; }
     r = &pCur->aRows[pCur->nRows];
     memset(r, 0, sizeof(*r));
 

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -234,4 +234,29 @@ static SQLITE_INLINE int doltliteAppendQuotedIdent(sqlite3_str *pStr,
   return sqlite3_str_errcode(pStr);
 }
 
+static SQLITE_INLINE int doltliteGrowArrayImpl(
+  void **ppArr, int *pnAlloc, int nNeeded, int elemSize, int seed
+){
+  i64 nNew;
+  void *pNew;
+  if( nNeeded <= *pnAlloc ) return SQLITE_OK;
+  if( elemSize <= 0 || nNeeded < 0 || seed <= 0 ) return SQLITE_NOMEM;
+  nNew = *pnAlloc>0 ? (i64)*pnAlloc * 2 : (i64)seed;
+  while( nNew < (i64)nNeeded ){
+    if( nNew > (i64)0x7fffffff/2 ){ nNew = (i64)0x7fffffff; break; }
+    nNew *= 2;
+  }
+  if( nNew < (i64)nNeeded ) return SQLITE_NOMEM;
+  if( nNew > (i64)0x7fffffff/(i64)elemSize ) return SQLITE_NOMEM;
+  pNew = sqlite3_realloc(*ppArr, (int)(nNew * (i64)elemSize));
+  if( !pNew ) return SQLITE_NOMEM;
+  *ppArr = pNew;
+  *pnAlloc = (int)nNew;
+  return SQLITE_OK;
+}
+
+#define DOLTLITE_GROW_ARRAY(ppArr, pnAlloc, nNeeded, seed) \
+  doltliteGrowArrayImpl((void**)(ppArr), (pnAlloc), (nNeeded), \
+                        (int)sizeof(**(ppArr)), (seed))
+
 #endif

--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -216,15 +216,10 @@ static int parseRecordFields(const u8 *pRec, int nRec,
       return -1;
     }
 
-    if(nFields >= nAlloc){
-      RecField *aNew;
-      nAlloc = nAlloc ? nAlloc*2 : 16;
-      aNew = sqlite3_realloc(aFields, nAlloc*(int)sizeof(RecField));
-      if(!aNew){
-        sqlite3_free(aFields);
-        return -1;
-      }
-      aFields = aNew;
+    if( DOLTLITE_GROW_ARRAY(&aFields, &nAlloc, nFields+1, 16)!=SQLITE_OK ){
+      sqlite3_free(aFields);
+      *ppFields=0; *pnFields=0;
+      return -1;
     }
     aFields[nFields].st = st;
     aFields[nFields].off = (int)bodyOff;
@@ -569,14 +564,9 @@ static int rowMergeCallback(void *pCtx, const ThreeWayChange *pChange){
     }
     case THREE_WAY_CONFLICT_DM: {
 
-      struct ConflictRow *aNew;
-      if( ctx->nConflicts >= ctx->nConflictsAlloc ){
-        int nNew = ctx->nConflictsAlloc ? ctx->nConflictsAlloc*2 : 16;
-        aNew = sqlite3_realloc(ctx->aConflicts, nNew*(int)sizeof(struct ConflictRow));
-        if( !aNew ) return SQLITE_NOMEM;
-        ctx->aConflicts = aNew;
-        ctx->nConflictsAlloc = nNew;
-      }
+      rc = DOLTLITE_GROW_ARRAY(&ctx->aConflicts, &ctx->nConflictsAlloc,
+                                ctx->nConflicts + 1, 16);
+      if( rc!=SQLITE_OK ) return rc;
       {
         struct ConflictRow *cr = &ctx->aConflicts[ctx->nConflicts];
         memset(cr, 0, sizeof(*cr));
@@ -953,21 +943,15 @@ static int parseColumns(
               return SQLITE_CORRUPT;
             }
 
-            if( nCols >= nAlloc ){
-              int nNew = nAlloc ? nAlloc*2 : 8;
-              ParsedColumn *aNew = sqlite3_realloc(aCols, nNew*(int)sizeof(ParsedColumn));
-              if( !aNew ){
-                sqlite3_free(zName);
-                sqlite3_free(zTrimmed);
-                { int ci; for(ci=0;ci<nCols;ci++){
-                  sqlite3_free(aCols[ci].zName);
-                  sqlite3_free(aCols[ci].zDef);
-                }}
-                sqlite3_free(aCols);
-                return SQLITE_NOMEM;
-              }
-              aCols = aNew;
-              nAlloc = nNew;
+            if( DOLTLITE_GROW_ARRAY(&aCols, &nAlloc, nCols+1, 8)!=SQLITE_OK ){
+              sqlite3_free(zName);
+              sqlite3_free(zTrimmed);
+              { int ci; for(ci=0;ci<nCols;ci++){
+                sqlite3_free(aCols[ci].zName);
+                sqlite3_free(aCols[ci].zDef);
+              }}
+              sqlite3_free(aCols);
+              return SQLITE_NOMEM;
             }
             aCols[nCols].zName = zName;
             aCols[nCols].zDef = zTrimmed;
@@ -1055,13 +1039,8 @@ static int trySchemaColumnMerge(
 
       }else{
 
-        if( nAdd >= nAddAlloc ){
-          int nNew = nAddAlloc ? nAddAlloc*2 : 4;
-          char **azNew = sqlite3_realloc(azAdd, nNew*(int)sizeof(char*));
-          if( !azNew ){ rc = SQLITE_NOMEM; goto schema_merge_cleanup; }
-          azAdd = azNew;
-          nAddAlloc = nNew;
-        }
+        rc = DOLTLITE_GROW_ARRAY(&azAdd, &nAddAlloc, nAdd+1, 4);
+        if( rc!=SQLITE_OK ) goto schema_merge_cleanup;
         azAdd[nAdd] = sqlite3_mprintf("%s", aTheirs[i].zDef);
         nAdd++;
       }

--- a/src/doltlite_remote.c
+++ b/src/doltlite_remote.c
@@ -3,6 +3,7 @@
 
 #include "doltlite_remote.h"
 #include "doltlite_commit.h"
+#include "doltlite_internal.h"
 #include "prolly_hashset.h"
 #include "prolly_node.h"
 #include "doltlite_chunk_walk.h"
@@ -52,14 +53,10 @@ static void syncQueueFree(SyncQueue *q){
 }
 
 static int syncQueuePush(SyncQueue *q, const ProllyHash *h){
+  int rc;
   if( prollyHashIsEmpty(h) ) return SQLITE_OK;
-  if( q->nItems >= q->nAlloc ){
-    int newAlloc = q->nAlloc * 2;
-    ProllyHash *aNew = sqlite3_realloc(q->aItems, newAlloc * sizeof(ProllyHash));
-    if( !aNew ) return SQLITE_NOMEM;
-    q->aItems = aNew;
-    q->nAlloc = newAlloc;
-  }
+  rc = DOLTLITE_GROW_ARRAY(&q->aItems, &q->nAlloc, q->nItems + 1, 16);
+  if( rc!=SQLITE_OK ) return rc;
   memcpy(&q->aItems[q->nItems], h, sizeof(ProllyHash));
   q->nItems++;
   return SQLITE_OK;

--- a/src/doltlite_schema_merge.c
+++ b/src/doltlite_schema_merge.c
@@ -331,11 +331,26 @@ int migrateSchemaRowData(
                   ** so we can build a full INSERT for PROLLY_DIFF_ADD
                   ** rows that don't exist in the merged working set yet. */
                   if( nAllCols >= nAllColsAlloc ){
-                    int nNew = nAllColsAlloc ? nAllColsAlloc*2 : 8;
-                    char **azNew = sqlite3_realloc(azAllColNames,
-                                                    nNew*(int)sizeof(char*));
-                    int *aiNew = sqlite3_realloc(aiAllColIdx,
-                                                  nNew*(int)sizeof(int));
+                    i64 nNew = nAllColsAlloc ? (i64)nAllColsAlloc * 2 : 8;
+                    char **azNew;
+                    int *aiNew;
+                    while( nNew < (i64)(nAllCols + 1) ){
+                      if( nNew > (i64)0x7fffffff/2 ){
+                        nNew = (i64)0x7fffffff; break;
+                      }
+                      nNew *= 2;
+                    }
+                    if( nNew < (i64)(nAllCols + 1)
+                     || nNew > (i64)0x7fffffff/(i64)sizeof(char*)
+                     || nNew > (i64)0x7fffffff/(i64)sizeof(int) ){
+                      sqlite3_free(zColName);
+                      rc = SQLITE_NOMEM;
+                      goto next_action;
+                    }
+                    azNew = sqlite3_realloc(azAllColNames,
+                                            (int)(nNew * (i64)sizeof(char*)));
+                    aiNew = sqlite3_realloc(aiAllColIdx,
+                                             (int)(nNew * (i64)sizeof(int)));
                     if( !azNew || !aiNew ){
                       if( azNew ) azAllColNames = azNew;
                       if( aiNew ) aiAllColIdx = aiNew;
@@ -345,7 +360,7 @@ int migrateSchemaRowData(
                     }
                     azAllColNames = azNew;
                     aiAllColIdx = aiNew;
-                    nAllColsAlloc = nNew;
+                    nAllColsAlloc = (int)nNew;
                   }
                   /* Ownership of zColName transfers to azAllColNames. */
                   azAllColNames[nAllCols] = zColName;

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -895,12 +895,13 @@ static struct TableEntry *catAdd(Catalog *cat, Pgno iTable, u8 flags){
   }
 
   if( cat->n>=cat->nAlloc ){
-    int nNew = cat->nAlloc ? cat->nAlloc*2 : 16;
+    i64 nNew = cat->nAlloc ? (i64)cat->nAlloc * 2 : (i64)16;
     struct TableEntry *aNew;
-    aNew = sqlite3_realloc(cat->a, nNew*(int)sizeof(struct TableEntry));
+    if( nNew > (i64)0x7fffffff/(i64)sizeof(struct TableEntry) ) return 0;
+    aNew = sqlite3_realloc(cat->a, (int)(nNew * (i64)sizeof(struct TableEntry)));
     if( !aNew ) return 0;
     cat->a = aNew;
-    cat->nAlloc = nNew;
+    cat->nAlloc = (int)nNew;
   }
 
   {
@@ -1082,12 +1083,15 @@ static int addCatalogEntryMeta(
   CatalogEntryMeta *pNew;
   if( findCatalogEntryMetaByPgno(aMeta, *pnMeta, iTable) ) return SQLITE_OK;
   if( *pnMeta>=*pnAlloc ){
-    int nNew = *pnAlloc ? *pnAlloc*2 : 16;
-    pNew = sqlite3_realloc(aMeta, nNew*(int)sizeof(CatalogEntryMeta));
+    i64 nNew = *pnAlloc ? (i64)*pnAlloc * 2 : (i64)16;
+    if( nNew > (i64)0x7fffffff/(i64)sizeof(CatalogEntryMeta) ){
+      return SQLITE_NOMEM;
+    }
+    pNew = sqlite3_realloc(aMeta, (int)(nNew * (i64)sizeof(CatalogEntryMeta)));
     if( !pNew ) return SQLITE_NOMEM;
     aMeta = pNew;
     *paMeta = aMeta;
-    *pnAlloc = nNew;
+    *pnAlloc = (int)nNew;
   }
   memset(&aMeta[*pnMeta], 0, sizeof(CatalogEntryMeta));
   aMeta[*pnMeta].iTable = iTable;
@@ -1452,15 +1456,22 @@ static int loadSchemaCatalogRows(
         sqlite3_free(zType); sqlite3_free(zName); sqlite3_free(zTblName); break;
       }
       if( nRows>=nAlloc ){
-        int nNew = nAlloc ? nAlloc*2 : 16;
-        SchemaCatalogRow *aNew = sqlite3_realloc(aRows, nNew*(int)sizeof(SchemaCatalogRow));
+        i64 nNew = nAlloc ? (i64)nAlloc * 2 : (i64)16;
+        SchemaCatalogRow *aNew;
+        if( nNew > (i64)0x7fffffff/(i64)sizeof(SchemaCatalogRow) ){
+          sqlite3_free(zType); sqlite3_free(zName); sqlite3_free(zTblName); sqlite3_free(zSql);
+          rc = SQLITE_NOMEM;
+          break;
+        }
+        aNew = sqlite3_realloc(aRows,
+                               (int)(nNew * (i64)sizeof(SchemaCatalogRow)));
         if( !aNew ){
           sqlite3_free(zType); sqlite3_free(zName); sqlite3_free(zTblName); sqlite3_free(zSql);
           rc = SQLITE_NOMEM;
           break;
         }
         aRows = aNew;
-        nAlloc = nNew;
+        nAlloc = (int)nNew;
       }
       memset(&aRows[nRows], 0, sizeof(SchemaCatalogRow));
       aRows[nRows].iRowid = prollyCursorIntKey(&cur);
@@ -1583,14 +1594,20 @@ static int appendMissingSchemaCatalogRows(
     }
     if( !wanted ) continue;
     if( nRows>=nAlloc ){
-      int nNew = nAlloc ? nAlloc*2 : 16;
-      SchemaCatalogRow *aNew = sqlite3_realloc(aRows, nNew*(int)sizeof(SchemaCatalogRow));
+      i64 nNew = nAlloc ? (i64)nAlloc * 2 : (i64)16;
+      SchemaCatalogRow *aNew;
+      if( nNew > (i64)0x7fffffff/(i64)sizeof(SchemaCatalogRow) ){
+        freeSchemaCatalogRows(aRows, nRows);
+        return SQLITE_NOMEM;
+      }
+      aNew = sqlite3_realloc(aRows,
+                             (int)(nNew * (i64)sizeof(SchemaCatalogRow)));
       if( !aNew ){
         freeSchemaCatalogRows(aRows, nRows);
         return SQLITE_NOMEM;
       }
       aRows = aNew;
-      nAlloc = nNew;
+      nAlloc = (int)nNew;
     }
     pRow = &aRows[nRows];
     memset(pRow, 0, sizeof(*pRow));
@@ -1659,14 +1676,20 @@ static int appendFallbackSchemaCatalogRows(
     }
     if( !pSe ) continue;
     if( nRows>=nAlloc ){
-      int nNew = nAlloc ? nAlloc*2 : 16;
-      SchemaCatalogRow *aNew = sqlite3_realloc(aRows, nNew*(int)sizeof(SchemaCatalogRow));
+      i64 nNew = nAlloc ? (i64)nAlloc * 2 : (i64)16;
+      SchemaCatalogRow *aNew;
+      if( nNew > (i64)0x7fffffff/(i64)sizeof(SchemaCatalogRow) ){
+        freeSchemaCatalogRows(aRows, nRows);
+        return SQLITE_NOMEM;
+      }
+      aNew = sqlite3_realloc(aRows,
+                             (int)(nNew * (i64)sizeof(SchemaCatalogRow)));
       if( !aNew ){
         freeSchemaCatalogRows(aRows, nRows);
         return SQLITE_NOMEM;
       }
       aRows = aNew;
-      nAlloc = nNew;
+      nAlloc = (int)nNew;
     }
     pRow = &aRows[nRows];
     memset(pRow, 0, sizeof(*pRow));
@@ -2826,12 +2849,17 @@ static int appendPendingSnapshot(
   ProllyMutMap *pPending
 ){
   if( pState->nPendingSnapshot >= pState->nPendingSnapshotAlloc ){
-    int nNew = pState->nPendingSnapshotAlloc ? pState->nPendingSnapshotAlloc * 2 : 4;
-    SavepointPendingSnapshot *aNew = sqlite3_realloc(
-        pState->aPendingSnapshot, nNew * (int)sizeof(SavepointPendingSnapshot));
+    i64 nNew = pState->nPendingSnapshotAlloc
+                 ? (i64)pState->nPendingSnapshotAlloc * 2 : (i64)4;
+    SavepointPendingSnapshot *aNew;
+    if( nNew > (i64)0x7fffffff/(i64)sizeof(SavepointPendingSnapshot) ){
+      return SQLITE_NOMEM;
+    }
+    aNew = sqlite3_realloc(pState->aPendingSnapshot,
+        (int)(nNew * (i64)sizeof(SavepointPendingSnapshot)));
     if( !aNew ) return SQLITE_NOMEM;
     pState->aPendingSnapshot = aNew;
-    pState->nPendingSnapshotAlloc = nNew;
+    pState->nPendingSnapshotAlloc = (int)nNew;
   }
   pState->aPendingSnapshot[pState->nPendingSnapshot].iTable = iTable;
   pState->aPendingSnapshot[pState->nPendingSnapshot].pPending = pPending;
@@ -3132,12 +3160,17 @@ static int pushSavepoint(Btree *pBtree, int bStatement){
   struct SavepointTableState *pState;
 
   if( pBtree->nSavepoint>=pBtree->nSavepointAlloc ){
-    int nNew = pBtree->nSavepointAlloc ? pBtree->nSavepointAlloc*2 : 8;
+    i64 nNew = pBtree->nSavepointAlloc
+                 ? (i64)pBtree->nSavepointAlloc * 2 : (i64)8;
     struct SavepointTableState *aNewT;
-    aNewT = sqlite3_realloc(pBtree->aSavepointTables, nNew*(int)sizeof(struct SavepointTableState));
+    if( nNew > (i64)0x7fffffff/(i64)sizeof(struct SavepointTableState) ){
+      return SQLITE_NOMEM;
+    }
+    aNewT = sqlite3_realloc(pBtree->aSavepointTables,
+        (int)(nNew * (i64)sizeof(struct SavepointTableState)));
     if( !aNewT ) return SQLITE_NOMEM;
     pBtree->aSavepointTables = aNewT;
-    pBtree->nSavepointAlloc = nNew;
+    pBtree->nSavepointAlloc = (int)nNew;
   }
 
   pState = &pBtree->aSavepointTables[pBtree->nSavepoint];

--- a/src/prolly_diff.c
+++ b/src/prolly_diff.c
@@ -3,7 +3,6 @@
 
 #include "prolly_diff.h"
 #include "prolly_record.h"
-#include "doltlite_internal.h"
 
 #include <string.h>
 
@@ -467,8 +466,19 @@ static int diffNodesOneLevel(
 
       if( cmp==0 ){
 
-        rc = DOLTLITE_GROW_ARRAY(ppStack, pnStackAlloc, *pnStack + 2, 32);
-        if( rc!=SQLITE_OK ) break;
+        if( *pnStack + 2 > *pnStackAlloc ){
+          i64 nNew = *pnStackAlloc ? (i64)*pnStackAlloc * 2 : (i64)32;
+          ProllyHash *pNew;
+          if( nNew > (i64)0x7fffffff/(i64)sizeof(ProllyHash) ){
+            rc = SQLITE_NOMEM;
+            break;
+          }
+          pNew = sqlite3_realloc(*ppStack,
+                                 (int)(nNew * (i64)sizeof(ProllyHash)));
+          if( !pNew ){ rc = SQLITE_NOMEM; break; }
+          *ppStack = pNew;
+          *pnStackAlloc = (int)nNew;
+        }
         (*ppStack)[(*pnStack)++] = oldChild;
         (*ppStack)[(*pnStack)++] = newChild;
         i++; j++;

--- a/src/prolly_diff.c
+++ b/src/prolly_diff.c
@@ -3,6 +3,7 @@
 
 #include "prolly_diff.h"
 #include "prolly_record.h"
+#include "doltlite_internal.h"
 
 #include <string.h>
 
@@ -466,14 +467,8 @@ static int diffNodesOneLevel(
 
       if( cmp==0 ){
 
-        if( *pnStack + 2 > *pnStackAlloc ){
-          int nNew = *pnStackAlloc ? *pnStackAlloc * 2 : 32;
-          ProllyHash *pNew = sqlite3_realloc(*ppStack,
-                                             nNew * (int)sizeof(ProllyHash));
-          if( !pNew ){ rc = SQLITE_NOMEM; break; }
-          *ppStack = pNew;
-          *pnStackAlloc = nNew;
-        }
+        rc = DOLTLITE_GROW_ARRAY(ppStack, pnStackAlloc, *pnStack + 2, 32);
+        if( rc!=SQLITE_OK ) break;
         (*ppStack)[(*pnStack)++] = oldChild;
         (*ppStack)[(*pnStack)++] = newChild;
         i++; j++;


### PR DESCRIPTION
## Summary

Follow-up to #869. A second sweep found **13 more sites** matching the same class: `int nNew = nAlloc*2; realloc(p, nNew*sizeof(T))` with no INT_MAX guard, attacker-influenced input.

Adds a `DOLTLITE_GROW_ARRAY` helper macro + static inline impl in \`doltlite_internal.h\`:

\`\`\`c
#define DOLTLITE_GROW_ARRAY(ppArr, pnAlloc, nNeeded, seed) \\
  doltliteGrowArrayImpl((void**)(ppArr), (pnAlloc), (nNeeded), \\
                        (int)sizeof(**(ppArr)), (seed))
\`\`\`

Sites migrated to the macro (cleanest match):
- \`doltlite_blame.c\` blameCollectLiveRows
- \`doltlite_remote.c\` syncQueuePush — **also fixes a separate \"first push\" bug**: \`nAlloc=0 \-> newAlloc = 0*2 = 0 \-> realloc(NULL, 0)\` was undefined behavior
- \`doltlite_merge.c\` parseRecordFields, mergeConflictRowsCB, column-parse, azAdd
- \`prolly_diff.c\` diffIterTriplets stack

Sites where the macro doesn't fit get the same i64+bound template inlined:
- \`doltlite_schema_merge.c\` azAllColNames + aiAllColIdx (paired arrays sharing one alloc counter)
- \`prolly_btree.c\` 7 sites — file locally redefines \`TableEntry\`/\`SchemaEntry\`, so including \`doltlite_internal.h\` triggers redef errors. Untangling those defs is out of scope here.

PR #869's already-fixed sites are not touched; a follow-up after both PRs land can migrate them to use \`DOLTLITE_GROW_ARRAY\` for consistency.

## Test plan

- [x] \`make doltlite-lib && make doltlite\` clean
- [x] Smoke: dolt_commit + dolt_log roundtrip works
- [ ] CI: full suite + sanitizers + oracle on PR
- [ ] No on-disk format change (these are all in-memory allocation paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)