### PR TITLE
refactor: extract WalState from ChunkStore (decomposition phase 1)

### DIFF
--- a/main.mk
+++ b/main.mk
@@ -575,7 +575,7 @@ else
 endif
 
 PROLLY_OBJS = prolly_hash.o prolly_xxhash.o blake3.o blake3_portable.o blake3_dispatch.o $(BLAKE3_SIMD_OBJS) prolly_hashset.o prolly_node.o prolly_cache.o \
-              chunk_store.o prolly_cursor.o prolly_mutmap.o prolly_chunker.o \
+              chunk_store.o chunk_wal.o prolly_cursor.o prolly_mutmap.o prolly_chunker.o \
               prolly_mutate.o prolly_diff.o prolly_three_way_diff.o prolly_three_way_merge.o prolly_btree.o pager_shim.o sortkey.o \
               doltlite.o doltlite_commit.o doltlite_ref.o doltlite_log.o doltlite_commit_ancestors.o doltlite_status.o \
               doltlite_diff.o doltlite_diff_table.o doltlite_branch.o doltlite_tag.o doltlite_ancestor.o doltlite_merge.o doltlite_schema_merge.o doltlite_conflicts.o \
@@ -1375,6 +1375,9 @@ prolly_cache.o:	$(TOP)/src/prolly_cache.c $(DEPS_OBJ_COMMON)
 
 chunk_store.o:	$(TOP)/src/chunk_store.c $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/chunk_store.c
+
+chunk_wal.o:	$(TOP)/src/chunk_wal.c $(DEPS_OBJ_COMMON)
+	$(T.cc.sqlite) -c $(TOP)/src/chunk_wal.c
 
 prolly_cursor.o:	$(TOP)/src/prolly_cursor.c $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/prolly_cursor.c

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -467,13 +467,13 @@ static void csAdoptOpenedStoreState(ChunkStore *pDst, ChunkStore *pSrc){
   pDst->nChunks = pSrc->nChunks;
   pDst->iIndexOffset = pSrc->iIndexOffset;
   pDst->nIndexSize = pSrc->nIndexSize;
-  pDst->iWalOffset = pSrc->iWalOffset;
+  pDst->wal.iWalOffset = pSrc->wal.iWalOffset;
   pDst->iFileSize = pSrc->iFileSize;
   pDst->aIndex = pSrc->aIndex;
   pDst->nIndex = pSrc->nIndex;
   pDst->aIndexMmapBase = pSrc->aIndexMmapBase;
   pDst->aIndexMmapSize = pSrc->aIndexMmapSize;
-  pDst->nWalData = pSrc->nWalData;
+  pDst->wal.nWalData = pSrc->wal.nWalData;
   pDst->aBranches = pSrc->aBranches;
   pDst->nBranches = pSrc->nBranches;
   pDst->zDefaultBranch = pSrc->zDefaultBranch;
@@ -489,7 +489,7 @@ static void csAdoptOpenedStoreState(ChunkStore *pDst, ChunkStore *pSrc){
   pSrc->nIndex = 0;
   pSrc->aIndexMmapBase = 0;
   pSrc->aIndexMmapSize = 0;
-  pSrc->nWalData = 0;
+  pSrc->wal.nWalData = 0;
   pSrc->aBranches = 0;
   pSrc->nBranches = 0;
   pSrc->zDefaultBranch = 0;
@@ -818,7 +818,7 @@ void csSerializeManifest(const ChunkStore *cs, u8 *aBuf){
   CS_WRITE_I64(aBuf + 32, cs->iIndexOffset);
   CS_WRITE_U32(aBuf + 40, (u32)cs->nIndexSize);
 
-  CS_WRITE_I64(aBuf + 84, cs->iWalOffset);
+  CS_WRITE_I64(aBuf + 84, cs->wal.iWalOffset);
   memcpy(aBuf + 104, cs->refsHash.data, PROLLY_HASH_SIZE);
 }
 
@@ -855,7 +855,7 @@ static int csReadManifest(ChunkStore *cs){
   cs->iIndexOffset = CS_READ_I64(aBuf + 32);
   cs->nIndexSize = (i64)CS_READ_U32(aBuf + 40);
 
-  cs->iWalOffset = CS_READ_I64(aBuf + 84);
+  cs->wal.iWalOffset = CS_READ_I64(aBuf + 84);
   memcpy(cs->refsHash.data, aBuf + 104, PROLLY_HASH_SIZE);
 
   return SQLITE_OK;
@@ -1021,13 +1021,13 @@ static int csReplayWal(ChunkStore *cs){
 
   memset(&tmpRefs, 0, sizeof(tmpRefs));
 
-  if( cs->iWalOffset <= 0 || !cs->pFile ) return SQLITE_OK;
+  if( cs->wal.iWalOffset <= 0 || !cs->pFile ) return SQLITE_OK;
 
   {
     i64 fileSize = 0;
     int rc = sqlite3OsFileSize(cs->pFile, &fileSize);
     if( rc != SQLITE_OK ) return rc;
-    walSize = fileSize - cs->iWalOffset;
+    walSize = fileSize - cs->wal.iWalOffset;
     cs->iFileSize = fileSize;
   }
   if( walSize <= 0 ){
@@ -1040,12 +1040,12 @@ static int csReplayWal(ChunkStore *cs){
 
   csCaptureReplayState(cs, &saved);
 
-  cs->nWalData = walSize;
+  cs->wal.nWalData = walSize;
 
   pos = 0;
   while( pos < walSize ){
     u8 tag = 0;
-    rc = sqlite3OsRead(cs->pFile, &tag, 1, cs->iWalOffset + pos);
+    rc = sqlite3OsRead(cs->pFile, &tag, 1, cs->wal.iWalOffset + pos);
     if( rc != SQLITE_OK ) goto replay_error;
     pos++;
 
@@ -1056,7 +1056,7 @@ static int csReplayWal(ChunkStore *cs){
       if( pos + 20 + 4 > walSize ){
         break;
       }
-      rc = sqlite3OsRead(cs->pFile, aHdr, sizeof(aHdr), cs->iWalOffset + pos);
+      rc = sqlite3OsRead(cs->pFile, aHdr, sizeof(aHdr), cs->wal.iWalOffset + pos);
       if( rc != SQLITE_OK ) goto replay_error;
       memcpy(&hash, aHdr, 20);
       len = CS_READ_U32(aHdr + 20);
@@ -1074,7 +1074,7 @@ static int csReplayWal(ChunkStore *cs){
           if( rc != SQLITE_OK ) goto replay_error;
           e = &cs->aPending[cs->nPending];
           memcpy(&e->hash, &hash, sizeof(ProllyHash));
-          e->offset = cs->iWalOffset + (i64)(pos - 4);
+          e->offset = cs->wal.iWalOffset + (i64)(pos - 4);
           e->size = (int)len;
           cs->nPending++;
         }
@@ -1088,7 +1088,7 @@ static int csReplayWal(ChunkStore *cs){
       }
       {
         u32 magic;
-        rc = sqlite3OsRead(cs->pFile, m, sizeof(m), cs->iWalOffset + pos);
+        rc = sqlite3OsRead(cs->pFile, m, sizeof(m), cs->wal.iWalOffset + pos);
         if( rc != SQLITE_OK ) goto replay_error;
         magic = CS_READ_U32(m);
         if( magic != CHUNK_STORE_MAGIC ){
@@ -1287,7 +1287,7 @@ int chunkStoreOpen(
     cs->nChunks = 0;
     cs->iIndexOffset = 0;
     cs->nIndexSize = 0;
-    cs->iWalOffset = CHUNK_MANIFEST_SIZE;
+    cs->wal.iWalOffset = CHUNK_MANIFEST_SIZE;
     cs->pFile = 0;
     return SQLITE_OK;
   }
@@ -1384,7 +1384,7 @@ int chunkStoreOpen(
     cs->iIndexOffset = 0;
     cs->nIndexSize = 0;
 
-    cs->iWalOffset = CHUNK_MANIFEST_SIZE;
+    cs->wal.iWalOffset = CHUNK_MANIFEST_SIZE;
     cs->iFileSize = 0;
     cs->pFile = 0;
   }
@@ -2184,7 +2184,7 @@ static int csCommitToFile(ChunkStore *cs){
   int lockFd = -1;
   int hadFile = (cs->pFile != 0);
   int lockHeld = (cs->graphLockFd >= 0);
-  i64 newWalSize = cs->nWalData;
+  i64 newWalSize = cs->wal.nWalData;
   ChunkIndexEntry *aCommittedPending = 0;
   ChunkIndexEntry *aMergePending = 0;
   ChunkIndexEntry *aMerged = 0;
@@ -2242,11 +2242,11 @@ static int csCommitToFile(ChunkStore *cs){
       }
       appendBytes += recBytes;
     }
-    if( cs->nWalData > LARGEST_INT64 - appendBytes ){
+    if( cs->wal.nWalData > LARGEST_INT64 - appendBytes ){
       rc = SQLITE_TOOBIG;
       goto commit_done;
     }
-    newWalSize = cs->nWalData + appendBytes;
+    newWalSize = cs->wal.nWalData + appendBytes;
 
     aCommittedPending = (ChunkIndexEntry*)sqlite3_malloc(
       cs->nPending * (int)sizeof(ChunkIndexEntry)
@@ -2314,7 +2314,7 @@ static int csCommitToFile(ChunkStore *cs){
 
   if( fileSize == 0 ){
     u8 manifest[CHUNK_MANIFEST_SIZE];
-    cs->iWalOffset = CHUNK_MANIFEST_SIZE;
+    cs->wal.iWalOffset = CHUNK_MANIFEST_SIZE;
     csSerializeManifest(cs, manifest);
     CRASH_CHECK_WRITE();
     rc = sqlite3OsWrite(cs->pFile, manifest, CHUNK_MANIFEST_SIZE, 0);
@@ -2443,7 +2443,7 @@ commit_done:
       cs->nRecent = 0;
       csRecentHTClear(cs);
     }
-    cs->nWalData = newWalSize;
+    cs->wal.nWalData = newWalSize;
   }else{
     sqlite3_free(aMerged);
   }

--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -5,6 +5,7 @@
 
 #include "sqliteInt.h"
 #include "prolly_hash.h"
+#include "chunk_wal.h"
 
 #define CHUNK_STORE_MAGIC 0x444C5443
 #define CHUNK_STORE_VERSION 11
@@ -144,7 +145,7 @@ struct ChunkStore {
   int nChunks;
   i64 iIndexOffset;
   i64 nIndexSize;
-  i64 iWalOffset;
+  WalState wal;
   i64 iFileSize;
 
   /* aIndex is the durable sorted manifest. Small commits append into aRecent
@@ -181,8 +182,6 @@ struct ChunkStore {
   u8 hasMovedChecked;
   int graphLockFd;
   i64 nCommittedWriteBuf;
-
-  i64 nWalData;
 };
 
 int chunkStoreOpen(ChunkStore *cs, sqlite3_vfs *pVfs,

--- a/src/chunk_wal.c
+++ b/src/chunk_wal.c
@@ -1,0 +1,32 @@
+
+#ifdef DOLTLITE_PROLLY
+
+#include "chunk_wal.h"
+#include <string.h>
+
+void walStateInit(WalState *w){
+  memset(w, 0, sizeof(*w));
+}
+
+void walStateReset(WalState *w){
+  w->iWalOffset = 0;
+  w->nWalData = 0;
+}
+
+i64 walStateGetOffset(const WalState *w){
+  return w->iWalOffset;
+}
+
+i64 walStateGetDataSize(const WalState *w){
+  return w->nWalData;
+}
+
+void walStateSetOffset(WalState *w, i64 iOffset){
+  w->iWalOffset = iOffset;
+}
+
+void walStateSetDataSize(WalState *w, i64 nData){
+  w->nWalData = nData;
+}
+
+#endif

--- a/src/chunk_wal.h
+++ b/src/chunk_wal.h
@@ -1,0 +1,23 @@
+
+#ifndef DOLTLITE_CHUNK_WAL_H
+#define DOLTLITE_CHUNK_WAL_H
+
+#include "sqliteInt.h"
+
+typedef struct WalState WalState;
+
+struct WalState {
+  i64 iWalOffset;
+  i64 nWalData;
+};
+
+void walStateInit(WalState *w);
+void walStateReset(WalState *w);
+
+i64 walStateGetOffset(const WalState *w);
+i64 walStateGetDataSize(const WalState *w);
+
+void walStateSetOffset(WalState *w, i64 iOffset);
+void walStateSetDataSize(WalState *w, i64 nData);
+
+#endif

--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -309,7 +309,7 @@ static int gcRewriteFile(
   manifestCs.nChunks = nNewIndex;
   manifestCs.iIndexOffset = indexOffset;
   manifestCs.nIndexSize = indexSize;
-  manifestCs.iWalOffset = indexOffset + indexSize;
+  walStateSetOffset(&manifestCs.wal, indexOffset + indexSize);
 
   csSerializeManifest(&manifestCs, manifest);
 
@@ -416,7 +416,7 @@ static int gcRewriteFile(
 
         if( rc==SQLITE_OK ){
           cs->pFile = pNewFile;
-          cs->nWalData = 0;
+          walStateSetDataSize(&cs->wal, 0);
           if( pOldFile ){
             sqlite3OsCloseFree(pOldFile);
           }
@@ -486,7 +486,7 @@ static int gcSweep(
     cs->nChunks = nNewIndex;
     cs->iIndexOffset = CHUNK_MANIFEST_SIZE + nBuf;
     cs->nIndexSize = indexSize;
-    cs->iWalOffset = CHUNK_MANIFEST_SIZE + nBuf + indexSize;
+    walStateSetOffset(&cs->wal, CHUNK_MANIFEST_SIZE + nBuf + indexSize);
     aNewIndex = 0;
 
     cs->nPending = 0;

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -3054,11 +3054,11 @@ static void run_truncated_wal_is_rejected(void){
 
   check("open_store_for_wal_tag_corruption", chunkStoreOpen(&cs, sqlite3_vfs_find(0), dbpath,
         SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB)==SQLITE_OK);
-  check("have_wal_region", cs.nWalData > 0);
-  if( cs.nWalData > 0 ){
+  check("have_wal_region", walStateGetDataSize(&cs.wal) > 0);
+  if( walStateGetDataSize(&cs.wal) > 0 ){
     unsigned char badTag = 0xff;
     check("corrupt_first_wal_tag",
-          sqlite3OsWrite(cs.pFile, &badTag, 1, cs.iWalOffset)==SQLITE_OK);
+          sqlite3OsWrite(cs.pFile, &badTag, 1, walStateGetOffset(&cs.wal))==SQLITE_OK);
   }
   chunkStoreClose(&cs);
 
@@ -3131,7 +3131,7 @@ static void run_wal_offset_corruption_is_rejected(void){
   {
     int i;
     for(i=0; i<cs.nIndex; i++){
-      if( cs.aIndex[i].offset >= cs.iWalOffset ){
+      if( cs.aIndex[i].offset >= walStateGetOffset(&cs.wal) ){
         iWal = i;
         break;
       }
@@ -3183,7 +3183,7 @@ static void run_integrity_check_walks_prolly_nodes(void){
     for(i=0; i<cs.nIndex; i++){
       if( prollyHashCompare(&cs.aIndex[i].hash, &pTable->root)==0 ){
         if( cs.aIndex[i].offset < 0 ){
-          dataOff = cs.iWalOffset + (-(cs.aIndex[i].offset + 1));
+          dataOff = walStateGetOffset(&cs.wal) + (-(cs.aIndex[i].offset + 1));
         }else{
           dataOff = cs.aIndex[i].offset + 4;
         }


### PR DESCRIPTION
First slice of the ChunkStore decomposition plan. Validates the accessor-API methodology with the smallest blast radius (1 external consumer: doltlite_gc.c).

## What this PR does

- New `src/chunk_wal.{h,c}` with `WalState` struct (iWalOffset + nWalData) and accessor API (walStateGet/Set Offset/DataSize, walStateInit/Reset).
- `ChunkStore` embeds `WalState wal;` instead of the two raw i64 fields. `chunk_store.h` includes `chunk_wal.h`.
- `chunk_store.c` (internal to the chunk_* layer) accesses `cs->wal.iWalOffset` directly. 19 mechanical renames.
- `doltlite_gc.c` (external consumer) migrated to the accessor API. 3 sites.

## What's deliberately NOT in this PR

- **No on-disk format change.** CHUNK_STORE_VERSION stays at 11. The refactor is purely an in-memory shape change.
- **No nav comment in chunk_store.c.** Project convention is zero inline comments in doltlite src/.
- **No byte-diff make target.** Will follow in a separate PR once the methodology has landed.
- **WAL replay logic stays in chunk_store.c.** csReplayWal reaches into ChunkStore's index/refs state; moving it now would either require a cross-subsystem callback shape (over-engineered) or direct field reaching (defeats the point). It will move naturally when ChunkIndex is also extracted in a later phase.

## Test plan

- [x] `make doltlite-lib` and `make doltlite` build clean
- [x] Smoke: `doltlite :memory: "CREATE TABLE t(x); INSERT INTO t VALUES (1); SELECT dolt_commit('-A','-m','x');"` returns a hash
- [x] `make lint` passes (test/lint_layers.sh — no layer violations)
- [ ] Full CI on the PR

## Plan it's part of

Per the decomposition plan agreed on earlier:
1. **WalState (this PR)**
2. RefsTable — 7 external consumers, biggest mechanical scope
3. ChunkIndex — touches mmap lifecycle
4. ChunkStaging — pending + recent + write buffer
5. Cleanup — coordinator-thin ChunkStore

Each phase: full accessor migration, strict byte-identical on-disk format, no public API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)