### PR TITLE
refactor: extract RefsTable from ChunkStore (decomposition phase 2a)

### DIFF
--- a/main.mk
+++ b/main.mk
@@ -575,7 +575,7 @@ else
 endif
 
 PROLLY_OBJS = prolly_hash.o prolly_xxhash.o blake3.o blake3_portable.o blake3_dispatch.o $(BLAKE3_SIMD_OBJS) prolly_hashset.o prolly_node.o prolly_cache.o \
-              chunk_store.o chunk_wal.o prolly_cursor.o prolly_mutmap.o prolly_chunker.o \
+              chunk_store.o chunk_wal.o chunk_refs.o prolly_cursor.o prolly_mutmap.o prolly_chunker.o \
               prolly_mutate.o prolly_diff.o prolly_three_way_diff.o prolly_three_way_merge.o prolly_btree.o pager_shim.o sortkey.o \
               doltlite.o doltlite_commit.o doltlite_ref.o doltlite_log.o doltlite_commit_ancestors.o doltlite_status.o \
               doltlite_diff.o doltlite_diff_table.o doltlite_branch.o doltlite_tag.o doltlite_ancestor.o doltlite_merge.o doltlite_schema_merge.o doltlite_conflicts.o \
@@ -1385,6 +1385,9 @@ chunk_store.o:	$(TOP)/src/chunk_store.c $(DEPS_OBJ_COMMON)
 chunk_wal.o:	$(TOP)/src/chunk_wal.c $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/chunk_wal.c
 
+
+chunk_refs.o:	$(TOP)/src/chunk_refs.c $(DEPS_OBJ_COMMON)
+	$(T.cc.sqlite) -c $(TOP)/src/chunk_refs.c
 prolly_cursor.o:	$(TOP)/src/prolly_cursor.c $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/prolly_cursor.c
 

--- a/src/chunk_refs.c
+++ b/src/chunk_refs.c
@@ -1,0 +1,67 @@
+
+#ifdef DOLTLITE_PROLLY
+
+#include "chunk_refs.h"
+#include <string.h>
+
+void refsTableInit(RefsTable *rt){
+  memset(rt, 0, sizeof(*rt));
+}
+
+void refsTableReset(RefsTable *rt){
+  memset(rt, 0, sizeof(*rt));
+}
+
+void refsTableGetBranches(const RefsTable *rt, int *pn, const BranchRef **par){
+  *pn = rt->nBranches;
+  *par = rt->aBranches;
+}
+
+void refsTableGetTags(const RefsTable *rt, int *pn, const TagRef **par){
+  *pn = rt->nTags;
+  *par = rt->aTags;
+}
+
+void refsTableGetRemotes(const RefsTable *rt, int *pn, const RemoteRef **par){
+  *pn = rt->nRemotes;
+  *par = rt->aRemotes;
+}
+
+void refsTableGetTracking(const RefsTable *rt, int *pn, const TrackingBranch **par){
+  *pn = rt->nTracking;
+  *par = rt->aTracking;
+}
+
+const char *refsTableGetDefaultBranchName(const RefsTable *rt){
+  return rt->zDefaultBranch;
+}
+
+const ProllyHash *refsTableGetHash(const RefsTable *rt){
+  return &rt->refsHash;
+}
+
+const ProllyHash *refsTableGetCommittedHash(const RefsTable *rt){
+  return &rt->committedRefsHash;
+}
+
+int refsTableBranchCount(const RefsTable *rt){
+  return rt->nBranches;
+}
+
+int refsTableTagCount(const RefsTable *rt){
+  return rt->nTags;
+}
+
+int refsTableRemoteCount(const RefsTable *rt){
+  return rt->nRemotes;
+}
+
+int refsTableTrackingCount(const RefsTable *rt){
+  return rt->nTracking;
+}
+
+void refsTableSetHash(RefsTable *rt, const ProllyHash *h){
+  memcpy(&rt->refsHash, h, sizeof(ProllyHash));
+}
+
+#endif

--- a/src/chunk_refs.h
+++ b/src/chunk_refs.h
@@ -1,0 +1,73 @@
+
+#ifndef DOLTLITE_CHUNK_REFS_H
+#define DOLTLITE_CHUNK_REFS_H
+
+#include "sqliteInt.h"
+#include "prolly_hash.h"
+
+typedef struct BranchRef BranchRef;
+typedef struct TagRef TagRef;
+typedef struct RemoteRef RemoteRef;
+typedef struct TrackingBranch TrackingBranch;
+typedef struct RefsTable RefsTable;
+
+struct BranchRef {
+  char *zName;
+  ProllyHash commitHash;
+  ProllyHash workingSetHash;
+};
+
+struct TagRef {
+  char *zName;
+  ProllyHash commitHash;
+  char *zTagger;
+  char *zEmail;
+  i64 timestamp;
+  char *zMessage;
+};
+
+struct RemoteRef {
+  char *zName;
+  char *zUrl;
+};
+
+struct TrackingBranch {
+  char *zRemote;
+  char *zBranch;
+  ProllyHash commitHash;
+};
+
+struct RefsTable {
+  ProllyHash refsHash;
+  ProllyHash committedRefsHash;
+  BranchRef *aBranches;
+  int nBranches;
+  char *zDefaultBranch;
+  TagRef *aTags;
+  int nTags;
+  RemoteRef *aRemotes;
+  int nRemotes;
+  TrackingBranch *aTracking;
+  int nTracking;
+};
+
+void refsTableInit(RefsTable *rt);
+void refsTableReset(RefsTable *rt);
+
+void refsTableGetBranches(const RefsTable *rt, int *pn, const BranchRef **par);
+void refsTableGetTags(const RefsTable *rt, int *pn, const TagRef **par);
+void refsTableGetRemotes(const RefsTable *rt, int *pn, const RemoteRef **par);
+void refsTableGetTracking(const RefsTable *rt, int *pn, const TrackingBranch **par);
+
+int refsTableBranchCount(const RefsTable *rt);
+int refsTableTagCount(const RefsTable *rt);
+int refsTableRemoteCount(const RefsTable *rt);
+int refsTableTrackingCount(const RefsTable *rt);
+
+const char *refsTableGetDefaultBranchName(const RefsTable *rt);
+const ProllyHash *refsTableGetHash(const RefsTable *rt);
+const ProllyHash *refsTableGetCommittedHash(const RefsTable *rt);
+
+void refsTableSetHash(RefsTable *rt, const ProllyHash *h);
+
+#endif

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -302,102 +302,102 @@ static void csReleaseIndexBuf(ChunkIndexEntry *aIndex,
 
 static void csFreeBranches(ChunkStore *cs){
   int k;
-  for(k=0; k<cs->nBranches; k++) sqlite3_free(cs->aBranches[k].zName);
-  sqlite3_free(cs->aBranches);
-  cs->aBranches = 0;
-  cs->nBranches = 0;
+  for(k=0; k<cs->refs.nBranches; k++) sqlite3_free(cs->refs.aBranches[k].zName);
+  sqlite3_free(cs->refs.aBranches);
+  cs->refs.aBranches = 0;
+  cs->refs.nBranches = 0;
 }
 static void csFreeTags(ChunkStore *cs){
   int k;
-  for(k=0; k<cs->nTags; k++){
-    sqlite3_free(cs->aTags[k].zName);
-    sqlite3_free(cs->aTags[k].zTagger);
-    sqlite3_free(cs->aTags[k].zEmail);
-    sqlite3_free(cs->aTags[k].zMessage);
+  for(k=0; k<cs->refs.nTags; k++){
+    sqlite3_free(cs->refs.aTags[k].zName);
+    sqlite3_free(cs->refs.aTags[k].zTagger);
+    sqlite3_free(cs->refs.aTags[k].zEmail);
+    sqlite3_free(cs->refs.aTags[k].zMessage);
   }
-  sqlite3_free(cs->aTags);
-  cs->aTags = 0;
-  cs->nTags = 0;
+  sqlite3_free(cs->refs.aTags);
+  cs->refs.aTags = 0;
+  cs->refs.nTags = 0;
 }
 static void csFreeRemotes(ChunkStore *cs){
   int k;
-  for(k=0; k<cs->nRemotes; k++){
-    sqlite3_free(cs->aRemotes[k].zName);
-    sqlite3_free(cs->aRemotes[k].zUrl);
+  for(k=0; k<cs->refs.nRemotes; k++){
+    sqlite3_free(cs->refs.aRemotes[k].zName);
+    sqlite3_free(cs->refs.aRemotes[k].zUrl);
   }
-  sqlite3_free(cs->aRemotes);
-  cs->aRemotes = 0;
-  cs->nRemotes = 0;
+  sqlite3_free(cs->refs.aRemotes);
+  cs->refs.aRemotes = 0;
+  cs->refs.nRemotes = 0;
 }
 static void csFreeTracking(ChunkStore *cs){
   int k;
-  for(k=0; k<cs->nTracking; k++){
-    sqlite3_free(cs->aTracking[k].zRemote);
-    sqlite3_free(cs->aTracking[k].zBranch);
+  for(k=0; k<cs->refs.nTracking; k++){
+    sqlite3_free(cs->refs.aTracking[k].zRemote);
+    sqlite3_free(cs->refs.aTracking[k].zBranch);
   }
-  sqlite3_free(cs->aTracking);
-  cs->aTracking = 0;
-  cs->nTracking = 0;
+  sqlite3_free(cs->refs.aTracking);
+  cs->refs.aTracking = 0;
+  cs->refs.nTracking = 0;
 }
 
 static void csMarkRefsCommitted(ChunkStore *cs){
-  cs->committedRefsHash = cs->refsHash;
+  cs->refs.committedRefsHash = cs->refs.refsHash;
 }
 
 static void csRestoreCommittedRefsHash(ChunkStore *cs){
-  cs->refsHash = cs->committedRefsHash;
+  cs->refs.refsHash = cs->refs.committedRefsHash;
 }
 
 static void csCaptureSavedRefsState(ChunkStore *cs, SavedRefsState *pSaved){
   memset(pSaved, 0, sizeof(*pSaved));
-  pSaved->zDefaultBranch = cs->zDefaultBranch;
-  pSaved->aBranches = cs->aBranches;
-  pSaved->nBranches = cs->nBranches;
-  pSaved->aTags = cs->aTags;
-  pSaved->nTags = cs->nTags;
-  pSaved->aRemotes = cs->aRemotes;
-  pSaved->nRemotes = cs->nRemotes;
-  pSaved->aTracking = cs->aTracking;
-  pSaved->nTracking = cs->nTracking;
+  pSaved->zDefaultBranch = cs->refs.zDefaultBranch;
+  pSaved->aBranches = cs->refs.aBranches;
+  pSaved->nBranches = cs->refs.nBranches;
+  pSaved->aTags = cs->refs.aTags;
+  pSaved->nTags = cs->refs.nTags;
+  pSaved->aRemotes = cs->refs.aRemotes;
+  pSaved->nRemotes = cs->refs.nRemotes;
+  pSaved->aTracking = cs->refs.aTracking;
+  pSaved->nTracking = cs->refs.nTracking;
 }
 
 static void csDetachSavedRefsState(ChunkStore *cs, SavedRefsState *pSaved){
   csCaptureSavedRefsState(cs, pSaved);
-  cs->zDefaultBranch = 0;
-  cs->aBranches = 0;
-  cs->nBranches = 0;
-  cs->aTags = 0;
-  cs->nTags = 0;
-  cs->aRemotes = 0;
-  cs->nRemotes = 0;
-  cs->aTracking = 0;
-  cs->nTracking = 0;
+  cs->refs.zDefaultBranch = 0;
+  cs->refs.aBranches = 0;
+  cs->refs.nBranches = 0;
+  cs->refs.aTags = 0;
+  cs->refs.nTags = 0;
+  cs->refs.aRemotes = 0;
+  cs->refs.nRemotes = 0;
+  cs->refs.aTracking = 0;
+  cs->refs.nTracking = 0;
 }
 
 static void csRestoreSavedRefsState(ChunkStore *cs, const SavedRefsState *pSaved){
-  cs->zDefaultBranch = pSaved->zDefaultBranch;
-  cs->aBranches = pSaved->aBranches;
-  cs->nBranches = pSaved->nBranches;
-  cs->aTags = pSaved->aTags;
-  cs->nTags = pSaved->nTags;
-  cs->aRemotes = pSaved->aRemotes;
-  cs->nRemotes = pSaved->nRemotes;
-  cs->aTracking = pSaved->aTracking;
-  cs->nTracking = pSaved->nTracking;
+  cs->refs.zDefaultBranch = pSaved->zDefaultBranch;
+  cs->refs.aBranches = pSaved->aBranches;
+  cs->refs.nBranches = pSaved->nBranches;
+  cs->refs.aTags = pSaved->aTags;
+  cs->refs.nTags = pSaved->nTags;
+  cs->refs.aRemotes = pSaved->aRemotes;
+  cs->refs.nRemotes = pSaved->nRemotes;
+  cs->refs.aTracking = pSaved->aTracking;
+  cs->refs.nTracking = pSaved->nTracking;
 }
 
 static void csFreeSavedRefsState(SavedRefsState *pSaved){
   ChunkStore refsStore;
   memset(&refsStore, 0, sizeof(refsStore));
-  refsStore.zDefaultBranch = pSaved->zDefaultBranch;
-  refsStore.aBranches = pSaved->aBranches;
-  refsStore.nBranches = pSaved->nBranches;
-  refsStore.aTags = pSaved->aTags;
-  refsStore.nTags = pSaved->nTags;
-  refsStore.aRemotes = pSaved->aRemotes;
-  refsStore.nRemotes = pSaved->nRemotes;
-  refsStore.aTracking = pSaved->aTracking;
-  refsStore.nTracking = pSaved->nTracking;
+  refsStore.refs.zDefaultBranch = pSaved->zDefaultBranch;
+  refsStore.refs.aBranches = pSaved->aBranches;
+  refsStore.refs.nBranches = pSaved->nBranches;
+  refsStore.refs.aTags = pSaved->aTags;
+  refsStore.refs.nTags = pSaved->nTags;
+  refsStore.refs.aRemotes = pSaved->aRemotes;
+  refsStore.refs.nRemotes = pSaved->nRemotes;
+  refsStore.refs.aTracking = pSaved->aTracking;
+  refsStore.refs.nTracking = pSaved->nTracking;
   csFreeRefsState(&refsStore);
   memset(pSaved, 0, sizeof(*pSaved));
 }
@@ -462,8 +462,8 @@ static void csAdoptOpenedStoreState(ChunkStore *pDst, ChunkStore *pSrc){
 
   pDst->pFile = pSrc->pFile;
   pDst->readOnly = pSrc->readOnly;
-  pDst->refsHash = pSrc->refsHash;
-  pDst->committedRefsHash = pSrc->committedRefsHash;
+  pDst->refs.refsHash = pSrc->refs.refsHash;
+  pDst->refs.committedRefsHash = pSrc->refs.committedRefsHash;
   pDst->nChunks = pSrc->nChunks;
   pDst->iIndexOffset = pSrc->iIndexOffset;
   pDst->nIndexSize = pSrc->nIndexSize;
@@ -474,15 +474,15 @@ static void csAdoptOpenedStoreState(ChunkStore *pDst, ChunkStore *pSrc){
   pDst->aIndexMmapBase = pSrc->aIndexMmapBase;
   pDst->aIndexMmapSize = pSrc->aIndexMmapSize;
   pDst->wal.nWalData = pSrc->wal.nWalData;
-  pDst->aBranches = pSrc->aBranches;
-  pDst->nBranches = pSrc->nBranches;
-  pDst->zDefaultBranch = pSrc->zDefaultBranch;
-  pDst->aTags = pSrc->aTags;
-  pDst->nTags = pSrc->nTags;
-  pDst->aRemotes = pSrc->aRemotes;
-  pDst->nRemotes = pSrc->nRemotes;
-  pDst->aTracking = pSrc->aTracking;
-  pDst->nTracking = pSrc->nTracking;
+  pDst->refs.aBranches = pSrc->refs.aBranches;
+  pDst->refs.nBranches = pSrc->refs.nBranches;
+  pDst->refs.zDefaultBranch = pSrc->refs.zDefaultBranch;
+  pDst->refs.aTags = pSrc->refs.aTags;
+  pDst->refs.nTags = pSrc->refs.nTags;
+  pDst->refs.aRemotes = pSrc->refs.aRemotes;
+  pDst->refs.nRemotes = pSrc->refs.nRemotes;
+  pDst->refs.aTracking = pSrc->refs.aTracking;
+  pDst->refs.nTracking = pSrc->refs.nTracking;
 
   pSrc->pFile = 0;
   pSrc->aIndex = 0;
@@ -490,15 +490,15 @@ static void csAdoptOpenedStoreState(ChunkStore *pDst, ChunkStore *pSrc){
   pSrc->aIndexMmapBase = 0;
   pSrc->aIndexMmapSize = 0;
   pSrc->wal.nWalData = 0;
-  pSrc->aBranches = 0;
-  pSrc->nBranches = 0;
-  pSrc->zDefaultBranch = 0;
-  pSrc->aTags = 0;
-  pSrc->nTags = 0;
-  pSrc->aRemotes = 0;
-  pSrc->nRemotes = 0;
-  pSrc->aTracking = 0;
-  pSrc->nTracking = 0;
+  pSrc->refs.aBranches = 0;
+  pSrc->refs.nBranches = 0;
+  pSrc->refs.zDefaultBranch = 0;
+  pSrc->refs.aTags = 0;
+  pSrc->refs.nTags = 0;
+  pSrc->refs.aRemotes = 0;
+  pSrc->refs.nRemotes = 0;
+  pSrc->refs.aTracking = 0;
+  pSrc->refs.nTracking = 0;
 }
 
 static void csFreeReloadState(ChunkStoreReloadState *pSaved){
@@ -513,14 +513,14 @@ static void csFreeRefsState(ChunkStore *cs){
   csFreeTags(cs);
   csFreeRemotes(cs);
   csFreeTracking(cs);
-  sqlite3_free(cs->zDefaultBranch);
-  cs->zDefaultBranch = 0;
+  sqlite3_free(cs->refs.zDefaultBranch);
+  cs->refs.zDefaultBranch = 0;
 }
 
 static int csEnsureDefaultBranch(ChunkStore *cs){
-  if( !cs->zDefaultBranch ){
-    cs->zDefaultBranch = sqlite3_mprintf("main");
-    if( !cs->zDefaultBranch ) return SQLITE_NOMEM;
+  if( !cs->refs.zDefaultBranch ){
+    cs->refs.zDefaultBranch = sqlite3_mprintf("main");
+    if( !cs->refs.zDefaultBranch ) return SQLITE_NOMEM;
   }
   return SQLITE_OK;
 }
@@ -580,7 +580,7 @@ static int csRollbackFailedAppend(ChunkStore *cs, i64 origFileSize){
 
 static int csRestoreCommittedRefsState(ChunkStore *cs){
   csRestoreCommittedRefsHash(cs);
-  if( prollyHashIsEmpty(&cs->committedRefsHash) ){
+  if( prollyHashIsEmpty(&cs->refs.committedRefsHash) ){
     csFreeBranches(cs);
     csFreeTags(cs);
     csFreeRemotes(cs);
@@ -593,14 +593,14 @@ static int csRestoreCommittedRefsState(ChunkStore *cs){
 static int csReloadFromDiskPreservingLocalRefs(ChunkStore *cs){
   int rc;
   int preserveRefs = cs->nPending > 0
-                  && prollyHashCompare(&cs->refsHash,
-                                       &cs->committedRefsHash)!=0;
+                  && prollyHashCompare(&cs->refs.refsHash,
+                                       &cs->refs.committedRefsHash)!=0;
   ProllyHash savedRefsHash;
   SavedRefsState savedRefs;
 
   memset(&savedRefs, 0, sizeof(savedRefs));
   if( preserveRefs ){
-    savedRefsHash = cs->refsHash;
+    savedRefsHash = cs->refs.refsHash;
     csDetachSavedRefsState(cs, &savedRefs);
   }
 
@@ -611,7 +611,7 @@ static int csReloadFromDiskPreservingLocalRefs(ChunkStore *cs){
       csFreeRefsState(cs);
     }
     csRestoreSavedRefsState(cs, &savedRefs);
-    cs->refsHash = savedRefsHash;
+    cs->refs.refsHash = savedRefsHash;
   }
   return rc;
 }
@@ -819,7 +819,7 @@ void csSerializeManifest(const ChunkStore *cs, u8 *aBuf){
   CS_WRITE_U32(aBuf + 40, (u32)cs->nIndexSize);
 
   CS_WRITE_I64(aBuf + 84, cs->wal.iWalOffset);
-  memcpy(aBuf + 104, cs->refsHash.data, PROLLY_HASH_SIZE);
+  memcpy(aBuf + 104, cs->refs.refsHash.data, PROLLY_HASH_SIZE);
 }
 
 static int csDeserializeIndexEntry(const u8 *aBuf, ChunkIndexEntry *e){
@@ -856,7 +856,7 @@ static int csReadManifest(ChunkStore *cs){
   cs->nIndexSize = (i64)CS_READ_U32(aBuf + 40);
 
   cs->wal.iWalOffset = CS_READ_I64(aBuf + 84);
-  memcpy(cs->refsHash.data, aBuf + 104, PROLLY_HASH_SIZE);
+  memcpy(cs->refs.refsHash.data, aBuf + 104, PROLLY_HASH_SIZE);
 
   return SQLITE_OK;
 }
@@ -1032,8 +1032,8 @@ static int csReplayWal(ChunkStore *cs){
   }
   if( walSize <= 0 ){
     if( cs->nIndex==0 && cs->nChunks==0
-     && !prollyHashIsEmpty(&cs->refsHash) ){
-      memset(cs->refsHash.data, 0, PROLLY_HASH_SIZE);
+     && !prollyHashIsEmpty(&cs->refs.refsHash) ){
+      memset(cs->refs.refsHash.data, 0, PROLLY_HASH_SIZE);
     }
     return SQLITE_OK;
   }
@@ -1097,7 +1097,7 @@ static int csReplayWal(ChunkStore *cs){
 
         cs->nChunks = (int)CS_READ_U32(m + 28);
 
-        memcpy(cs->refsHash.data, m + 104, PROLLY_HASH_SIZE);
+        memcpy(cs->refs.refsHash.data, m + 104, PROLLY_HASH_SIZE);
       }
       pos += CHUNK_MANIFEST_SIZE;
       nRootedPending = cs->nPending;
@@ -1113,7 +1113,7 @@ static int csReplayWal(ChunkStore *cs){
 
   if( nRootRecordsSeen == 0
    && nPendingBefore == 0 && cs->nIndex == 0 ){
-    memset(cs->refsHash.data, 0, PROLLY_HASH_SIZE);
+    memset(cs->refs.refsHash.data, 0, PROLLY_HASH_SIZE);
     cs->nChunks = 0;
   }
 
@@ -1130,10 +1130,10 @@ static int csReplayWal(ChunkStore *cs){
     csPendHTClear(cs);
   }
 
-  if( !prollyHashIsEmpty(&cs->refsHash) ){
+  if( !prollyHashIsEmpty(&cs->refs.refsHash) ){
     u8 *refsData = 0;
     int nRefsData = 0;
-    int rc2 = chunkStoreGet(cs, &cs->refsHash, &refsData, &nRefsData);
+    int rc2 = chunkStoreGet(cs, &cs->refs.refsHash, &refsData, &nRefsData);
     if( rc2==SQLITE_OK && refsData ){
       rc2 = csReplaceRefsStateFromBlob(&tmpRefs, refsData, nRefsData, 0);
       sqlite3_free(refsData);
@@ -1352,14 +1352,14 @@ int chunkStoreOpen(
       return rc;
     }
 
-    if( prollyHashIsEmpty(&cs->refsHash) && cs->nIndexSize>0 ){
+    if( prollyHashIsEmpty(&cs->refs.refsHash) && cs->nIndexSize>0 ){
       chunkStoreClose(cs);
       return SQLITE_CORRUPT;
     }
 
-    if( !prollyHashIsEmpty(&cs->refsHash) ){
+    if( !prollyHashIsEmpty(&cs->refs.refsHash) ){
       u8 *refsData = 0; int nRefsData = 0;
-      rc = chunkStoreGet(cs, &cs->refsHash, &refsData, &nRefsData);
+      rc = chunkStoreGet(cs, &cs->refs.refsHash, &refsData, &nRefsData);
       if( rc==SQLITE_OK ){
         rc = csDeserializeRefs(cs, refsData, nRefsData);
         sqlite3_free(refsData);
@@ -1409,7 +1409,7 @@ int chunkStoreClose(ChunkStore *cs){
   csPendHTClear(cs);
   csRecentHTClear(cs);
   sqlite3_free(cs->pWriteBuf);
-  sqlite3_free(cs->zDefaultBranch);
+  sqlite3_free(cs->refs.zDefaultBranch);
   csFreeBranches(cs);
   csFreeTags(cs);
   csFreeRemotes(cs);
@@ -1419,22 +1419,22 @@ int chunkStoreClose(ChunkStore *cs){
 }
 
 const char *chunkStoreGetDefaultBranch(ChunkStore *cs){
-  return cs->zDefaultBranch ? cs->zDefaultBranch : "main";
+  return cs->refs.zDefaultBranch ? cs->refs.zDefaultBranch : "main";
 }
 
 int chunkStoreSetDefaultBranch(ChunkStore *cs, const char *zName){
   char *zCopy = sqlite3_mprintf("%s", zName);
   if( !zCopy ) return SQLITE_NOMEM;
-  sqlite3_free(cs->zDefaultBranch);
-  cs->zDefaultBranch = zCopy;
+  sqlite3_free(cs->refs.zDefaultBranch);
+  cs->refs.zDefaultBranch = zCopy;
   return SQLITE_OK;
 }
 
 int chunkStoreFindBranch(ChunkStore *cs, const char *zName, ProllyHash *pCommit){
   int i;
-  for(i=0; i<cs->nBranches; i++){
-    if( strcmp(cs->aBranches[i].zName, zName)==0 ){
-      if( pCommit ) memcpy(pCommit, &cs->aBranches[i].commitHash, sizeof(ProllyHash));
+  for(i=0; i<cs->refs.nBranches; i++){
+    if( strcmp(cs->refs.aBranches[i].zName, zName)==0 ){
+      if( pCommit ) memcpy(pCommit, &cs->refs.aBranches[i].commitHash, sizeof(ProllyHash));
       return SQLITE_OK;
     }
   }
@@ -1444,22 +1444,22 @@ int chunkStoreFindBranch(ChunkStore *cs, const char *zName, ProllyHash *pCommit)
 int chunkStoreAddBranch(ChunkStore *cs, const char *zName, const ProllyHash *pCommit){
   struct BranchRef *aNew;
   if( chunkStoreFindBranch(cs, zName, 0)==SQLITE_OK ) return SQLITE_ERROR;
-  aNew = sqlite3_realloc(cs->aBranches, (cs->nBranches+1)*(int)sizeof(struct BranchRef));
+  aNew = sqlite3_realloc(cs->refs.aBranches, (cs->refs.nBranches+1)*(int)sizeof(struct BranchRef));
   if( !aNew ) return SQLITE_NOMEM;
-  cs->aBranches = aNew;
-  memset(&aNew[cs->nBranches], 0, sizeof(struct BranchRef));
-  aNew[cs->nBranches].zName = sqlite3_mprintf("%s", zName);
-  if( !aNew[cs->nBranches].zName ) return SQLITE_NOMEM;
-  memcpy(&aNew[cs->nBranches].commitHash, pCommit, sizeof(ProllyHash));
-  cs->nBranches++;
+  cs->refs.aBranches = aNew;
+  memset(&aNew[cs->refs.nBranches], 0, sizeof(struct BranchRef));
+  aNew[cs->refs.nBranches].zName = sqlite3_mprintf("%s", zName);
+  if( !aNew[cs->refs.nBranches].zName ) return SQLITE_NOMEM;
+  memcpy(&aNew[cs->refs.nBranches].commitHash, pCommit, sizeof(ProllyHash));
+  cs->refs.nBranches++;
   return SQLITE_OK;
 }
 
 int chunkStoreUpdateBranch(ChunkStore *cs, const char *zName, const ProllyHash *pCommit){
   int i;
-  for(i=0; i<cs->nBranches; i++){
-    if( strcmp(cs->aBranches[i].zName, zName)==0 ){
-      memcpy(&cs->aBranches[i].commitHash, pCommit, sizeof(ProllyHash));
+  for(i=0; i<cs->refs.nBranches; i++){
+    if( strcmp(cs->refs.aBranches[i].zName, zName)==0 ){
+      memcpy(&cs->refs.aBranches[i].commitHash, pCommit, sizeof(ProllyHash));
       return SQLITE_OK;
     }
   }
@@ -1468,11 +1468,11 @@ int chunkStoreUpdateBranch(ChunkStore *cs, const char *zName, const ProllyHash *
 
 int chunkStoreDeleteBranch(ChunkStore *cs, const char *zName){
   int i;
-  for(i=0; i<cs->nBranches; i++){
-    if( strcmp(cs->aBranches[i].zName, zName)==0 ){
-      sqlite3_free(cs->aBranches[i].zName);
-      cs->aBranches[i] = cs->aBranches[cs->nBranches-1];
-      cs->nBranches--;
+  for(i=0; i<cs->refs.nBranches; i++){
+    if( strcmp(cs->refs.aBranches[i].zName, zName)==0 ){
+      sqlite3_free(cs->refs.aBranches[i].zName);
+      cs->refs.aBranches[i] = cs->refs.aBranches[cs->refs.nBranches-1];
+      cs->refs.nBranches--;
       return SQLITE_OK;
     }
   }
@@ -1481,9 +1481,9 @@ int chunkStoreDeleteBranch(ChunkStore *cs, const char *zName){
 
 int chunkStoreGetBranchWorkingSet(ChunkStore *cs, const char *zBranch, ProllyHash *pHash){
   int i;
-  for(i=0; i<cs->nBranches; i++){
-    if( strcmp(cs->aBranches[i].zName, zBranch)==0 ){
-      memcpy(pHash, &cs->aBranches[i].workingSetHash, sizeof(ProllyHash));
+  for(i=0; i<cs->refs.nBranches; i++){
+    if( strcmp(cs->refs.aBranches[i].zName, zBranch)==0 ){
+      memcpy(pHash, &cs->refs.aBranches[i].workingSetHash, sizeof(ProllyHash));
       return SQLITE_OK;
     }
   }
@@ -1493,9 +1493,9 @@ int chunkStoreGetBranchWorkingSet(ChunkStore *cs, const char *zBranch, ProllyHas
 
 int chunkStoreSetBranchWorkingSet(ChunkStore *cs, const char *zBranch, const ProllyHash *pHash){
   int i;
-  for(i=0; i<cs->nBranches; i++){
-    if( strcmp(cs->aBranches[i].zName, zBranch)==0 ){
-      memcpy(&cs->aBranches[i].workingSetHash, pHash, sizeof(ProllyHash));
+  for(i=0; i<cs->refs.nBranches; i++){
+    if( strcmp(cs->refs.aBranches[i].zName, zBranch)==0 ){
+      memcpy(&cs->refs.aBranches[i].workingSetHash, pHash, sizeof(ProllyHash));
       return SQLITE_OK;
     }
   }
@@ -1504,9 +1504,9 @@ int chunkStoreSetBranchWorkingSet(ChunkStore *cs, const char *zBranch, const Pro
 
 int chunkStoreFindTag(ChunkStore *cs, const char *zName, ProllyHash *pCommit){
   int i;
-  for(i=0; i<cs->nTags; i++){
-    if( strcmp(cs->aTags[i].zName, zName)==0 ){
-      if( pCommit ) memcpy(pCommit, &cs->aTags[i].commitHash, sizeof(ProllyHash));
+  for(i=0; i<cs->refs.nTags; i++){
+    if( strcmp(cs->refs.aTags[i].zName, zName)==0 ){
+      if( pCommit ) memcpy(pCommit, &cs->refs.aTags[i].commitHash, sizeof(ProllyHash));
       return SQLITE_OK;
     }
   }
@@ -1528,36 +1528,36 @@ int chunkStoreAddTagFull(
 ){
   struct TagRef *aNew;
   if( chunkStoreFindTag(cs, zName, 0)==SQLITE_OK ) return SQLITE_ERROR;
-  aNew = sqlite3_realloc(cs->aTags, (cs->nTags+1)*(int)sizeof(struct TagRef));
+  aNew = sqlite3_realloc(cs->refs.aTags, (cs->refs.nTags+1)*(int)sizeof(struct TagRef));
   if( !aNew ) return SQLITE_NOMEM;
-  cs->aTags = aNew;
-  memset(&aNew[cs->nTags], 0, sizeof(struct TagRef));
-  aNew[cs->nTags].zName = sqlite3_mprintf("%s", zName);
-  if( !aNew[cs->nTags].zName ) return SQLITE_NOMEM;
-  memcpy(&aNew[cs->nTags].commitHash, pCommit, sizeof(ProllyHash));
-  aNew[cs->nTags].zTagger  = sqlite3_mprintf("%s", zTagger  ? zTagger  : "");
-  aNew[cs->nTags].zEmail   = sqlite3_mprintf("%s", zEmail   ? zEmail   : "");
-  aNew[cs->nTags].zMessage = sqlite3_mprintf("%s", zMessage ? zMessage : "");
-  if( !aNew[cs->nTags].zTagger || !aNew[cs->nTags].zEmail || !aNew[cs->nTags].zMessage ){
-    sqlite3_free(aNew[cs->nTags].zName);
-    sqlite3_free(aNew[cs->nTags].zTagger);
-    sqlite3_free(aNew[cs->nTags].zEmail);
-    sqlite3_free(aNew[cs->nTags].zMessage);
-    memset(&aNew[cs->nTags], 0, sizeof(struct TagRef));
+  cs->refs.aTags = aNew;
+  memset(&aNew[cs->refs.nTags], 0, sizeof(struct TagRef));
+  aNew[cs->refs.nTags].zName = sqlite3_mprintf("%s", zName);
+  if( !aNew[cs->refs.nTags].zName ) return SQLITE_NOMEM;
+  memcpy(&aNew[cs->refs.nTags].commitHash, pCommit, sizeof(ProllyHash));
+  aNew[cs->refs.nTags].zTagger  = sqlite3_mprintf("%s", zTagger  ? zTagger  : "");
+  aNew[cs->refs.nTags].zEmail   = sqlite3_mprintf("%s", zEmail   ? zEmail   : "");
+  aNew[cs->refs.nTags].zMessage = sqlite3_mprintf("%s", zMessage ? zMessage : "");
+  if( !aNew[cs->refs.nTags].zTagger || !aNew[cs->refs.nTags].zEmail || !aNew[cs->refs.nTags].zMessage ){
+    sqlite3_free(aNew[cs->refs.nTags].zName);
+    sqlite3_free(aNew[cs->refs.nTags].zTagger);
+    sqlite3_free(aNew[cs->refs.nTags].zEmail);
+    sqlite3_free(aNew[cs->refs.nTags].zMessage);
+    memset(&aNew[cs->refs.nTags], 0, sizeof(struct TagRef));
     return SQLITE_NOMEM;
   }
-  aNew[cs->nTags].timestamp = timestamp;
-  cs->nTags++;
+  aNew[cs->refs.nTags].timestamp = timestamp;
+  cs->refs.nTags++;
   return SQLITE_OK;
 }
 
 int chunkStoreDeleteTag(ChunkStore *cs, const char *zName){
   int i;
-  for(i=0; i<cs->nTags; i++){
-    if( strcmp(cs->aTags[i].zName, zName)==0 ){
-      sqlite3_free(cs->aTags[i].zName);
-      cs->aTags[i] = cs->aTags[cs->nTags-1];
-      cs->nTags--;
+  for(i=0; i<cs->refs.nTags; i++){
+    if( strcmp(cs->refs.aTags[i].zName, zName)==0 ){
+      sqlite3_free(cs->refs.aTags[i].zName);
+      cs->refs.aTags[i] = cs->refs.aTags[cs->refs.nTags-1];
+      cs->refs.nTags--;
       return SQLITE_OK;
     }
   }
@@ -1566,9 +1566,9 @@ int chunkStoreDeleteTag(ChunkStore *cs, const char *zName){
 
 int chunkStoreFindRemote(ChunkStore *cs, const char *zName, const char **pzUrl){
   int i;
-  for(i=0; i<cs->nRemotes; i++){
-    if( strcmp(cs->aRemotes[i].zName, zName)==0 ){
-      if( pzUrl ) *pzUrl = cs->aRemotes[i].zUrl;
+  for(i=0; i<cs->refs.nRemotes; i++){
+    if( strcmp(cs->refs.aRemotes[i].zName, zName)==0 ){
+      if( pzUrl ) *pzUrl = cs->refs.aRemotes[i].zUrl;
       return SQLITE_OK;
     }
   }
@@ -1578,35 +1578,35 @@ int chunkStoreFindRemote(ChunkStore *cs, const char *zName, const char **pzUrl){
 int chunkStoreAddRemote(ChunkStore *cs, const char *zName, const char *zUrl){
   struct RemoteRef *aNew;
   if( chunkStoreFindRemote(cs, zName, 0)==SQLITE_OK ) return SQLITE_ERROR;
-  aNew = sqlite3_realloc(cs->aRemotes, (cs->nRemotes+1)*(int)sizeof(struct RemoteRef));
+  aNew = sqlite3_realloc(cs->refs.aRemotes, (cs->refs.nRemotes+1)*(int)sizeof(struct RemoteRef));
   if( !aNew ) return SQLITE_NOMEM;
-  cs->aRemotes = aNew;
-  aNew[cs->nRemotes].zName = sqlite3_mprintf("%s", zName);
-  if( !aNew[cs->nRemotes].zName ) return SQLITE_NOMEM;
-  aNew[cs->nRemotes].zUrl = sqlite3_mprintf("%s", zUrl);
-  if( !aNew[cs->nRemotes].zUrl ){
-    sqlite3_free(aNew[cs->nRemotes].zName);
+  cs->refs.aRemotes = aNew;
+  aNew[cs->refs.nRemotes].zName = sqlite3_mprintf("%s", zName);
+  if( !aNew[cs->refs.nRemotes].zName ) return SQLITE_NOMEM;
+  aNew[cs->refs.nRemotes].zUrl = sqlite3_mprintf("%s", zUrl);
+  if( !aNew[cs->refs.nRemotes].zUrl ){
+    sqlite3_free(aNew[cs->refs.nRemotes].zName);
     return SQLITE_NOMEM;
   }
-  cs->nRemotes++;
+  cs->refs.nRemotes++;
   return SQLITE_OK;
 }
 
 int chunkStoreDeleteRemote(ChunkStore *cs, const char *zName){
   int i, j;
-  for(i=0; i<cs->nRemotes; i++){
-    if( strcmp(cs->aRemotes[i].zName, zName)==0 ){
-      sqlite3_free(cs->aRemotes[i].zName);
-      sqlite3_free(cs->aRemotes[i].zUrl);
-      cs->aRemotes[i] = cs->aRemotes[cs->nRemotes-1];
-      cs->nRemotes--;
+  for(i=0; i<cs->refs.nRemotes; i++){
+    if( strcmp(cs->refs.aRemotes[i].zName, zName)==0 ){
+      sqlite3_free(cs->refs.aRemotes[i].zName);
+      sqlite3_free(cs->refs.aRemotes[i].zUrl);
+      cs->refs.aRemotes[i] = cs->refs.aRemotes[cs->refs.nRemotes-1];
+      cs->refs.nRemotes--;
 
-      for(j=cs->nTracking-1; j>=0; j--){
-        if( strcmp(cs->aTracking[j].zRemote, zName)==0 ){
-          sqlite3_free(cs->aTracking[j].zRemote);
-          sqlite3_free(cs->aTracking[j].zBranch);
-          cs->aTracking[j] = cs->aTracking[cs->nTracking-1];
-          cs->nTracking--;
+      for(j=cs->refs.nTracking-1; j>=0; j--){
+        if( strcmp(cs->refs.aTracking[j].zRemote, zName)==0 ){
+          sqlite3_free(cs->refs.aTracking[j].zRemote);
+          sqlite3_free(cs->refs.aTracking[j].zBranch);
+          cs->refs.aTracking[j] = cs->refs.aTracking[cs->refs.nTracking-1];
+          cs->refs.nTracking--;
         }
       }
       return SQLITE_OK;
@@ -1618,10 +1618,10 @@ int chunkStoreDeleteRemote(ChunkStore *cs, const char *zName){
 int chunkStoreFindTracking(ChunkStore *cs, const char *zRemote,
                            const char *zBranch, ProllyHash *pCommit){
   int i;
-  for(i=0; i<cs->nTracking; i++){
-    if( strcmp(cs->aTracking[i].zRemote, zRemote)==0
-     && strcmp(cs->aTracking[i].zBranch, zBranch)==0 ){
-      if( pCommit ) memcpy(pCommit, &cs->aTracking[i].commitHash, sizeof(ProllyHash));
+  for(i=0; i<cs->refs.nTracking; i++){
+    if( strcmp(cs->refs.aTracking[i].zRemote, zRemote)==0
+     && strcmp(cs->refs.aTracking[i].zBranch, zBranch)==0 ){
+      if( pCommit ) memcpy(pCommit, &cs->refs.aTracking[i].commitHash, sizeof(ProllyHash));
       return SQLITE_OK;
     }
   }
@@ -1631,28 +1631,28 @@ int chunkStoreFindTracking(ChunkStore *cs, const char *zRemote,
 int chunkStoreUpdateTracking(ChunkStore *cs, const char *zRemote,
                              const char *zBranch, const ProllyHash *pCommit){
   int i;
-  for(i=0; i<cs->nTracking; i++){
-    if( strcmp(cs->aTracking[i].zRemote, zRemote)==0
-     && strcmp(cs->aTracking[i].zBranch, zBranch)==0 ){
-      memcpy(&cs->aTracking[i].commitHash, pCommit, sizeof(ProllyHash));
+  for(i=0; i<cs->refs.nTracking; i++){
+    if( strcmp(cs->refs.aTracking[i].zRemote, zRemote)==0
+     && strcmp(cs->refs.aTracking[i].zBranch, zBranch)==0 ){
+      memcpy(&cs->refs.aTracking[i].commitHash, pCommit, sizeof(ProllyHash));
       return SQLITE_OK;
     }
   }
 
   {
     struct TrackingBranch *aNew;
-    aNew = sqlite3_realloc(cs->aTracking, (cs->nTracking+1)*(int)sizeof(struct TrackingBranch));
+    aNew = sqlite3_realloc(cs->refs.aTracking, (cs->refs.nTracking+1)*(int)sizeof(struct TrackingBranch));
     if( !aNew ) return SQLITE_NOMEM;
-    cs->aTracking = aNew;
-    aNew[cs->nTracking].zRemote = sqlite3_mprintf("%s", zRemote);
-    if( !aNew[cs->nTracking].zRemote ) return SQLITE_NOMEM;
-    aNew[cs->nTracking].zBranch = sqlite3_mprintf("%s", zBranch);
-    if( !aNew[cs->nTracking].zBranch ){
-      sqlite3_free(aNew[cs->nTracking].zRemote);
+    cs->refs.aTracking = aNew;
+    aNew[cs->refs.nTracking].zRemote = sqlite3_mprintf("%s", zRemote);
+    if( !aNew[cs->refs.nTracking].zRemote ) return SQLITE_NOMEM;
+    aNew[cs->refs.nTracking].zBranch = sqlite3_mprintf("%s", zBranch);
+    if( !aNew[cs->refs.nTracking].zBranch ){
+      sqlite3_free(aNew[cs->refs.nTracking].zRemote);
       return SQLITE_NOMEM;
     }
-    memcpy(&aNew[cs->nTracking].commitHash, pCommit, sizeof(ProllyHash));
-    cs->nTracking++;
+    memcpy(&aNew[cs->refs.nTracking].commitHash, pCommit, sizeof(ProllyHash));
+    cs->refs.nTracking++;
   }
   return SQLITE_OK;
 }
@@ -1660,13 +1660,13 @@ int chunkStoreUpdateTracking(ChunkStore *cs, const char *zRemote,
 int chunkStoreDeleteTracking(ChunkStore *cs, const char *zRemote,
                              const char *zBranch){
   int i;
-  for(i=0; i<cs->nTracking; i++){
-    if( strcmp(cs->aTracking[i].zRemote, zRemote)==0
-     && strcmp(cs->aTracking[i].zBranch, zBranch)==0 ){
-      sqlite3_free(cs->aTracking[i].zRemote);
-      sqlite3_free(cs->aTracking[i].zBranch);
-      cs->aTracking[i] = cs->aTracking[cs->nTracking-1];
-      cs->nTracking--;
+  for(i=0; i<cs->refs.nTracking; i++){
+    if( strcmp(cs->refs.aTracking[i].zRemote, zRemote)==0
+     && strcmp(cs->refs.aTracking[i].zBranch, zBranch)==0 ){
+      sqlite3_free(cs->refs.aTracking[i].zRemote);
+      sqlite3_free(cs->refs.aTracking[i].zBranch);
+      cs->refs.aTracking[i] = cs->refs.aTracking[cs->refs.nTracking-1];
+      cs->refs.nTracking--;
       return SQLITE_OK;
     }
   }
@@ -1685,7 +1685,7 @@ int chunkStoreHasMany(ChunkStore *cs, const ProllyHash *aHash, int nHash, u8 *aR
 }
 
 static int csSerializeRefsBlob(ChunkStore *cs, u8 **ppOut, int *pnOut){
-  const char *def = cs->zDefaultBranch ? cs->zDefaultBranch : "main";
+  const char *def = cs->refs.zDefaultBranch ? cs->refs.zDefaultBranch : "main";
   int defLen = (int)strlen(def);
   int sz = 1 + 4 + defLen + 4 + 4 + 4 + 4;
   int i;
@@ -1694,18 +1694,18 @@ static int csSerializeRefsBlob(ChunkStore *cs, u8 **ppOut, int *pnOut){
   *ppOut = 0;
   *pnOut = 0;
 
-  for(i=0; i<cs->nBranches; i++){
-    int inc = 4 + (int)strlen(cs->aBranches[i].zName) + PROLLY_HASH_SIZE*2;
+  for(i=0; i<cs->refs.nBranches; i++){
+    int inc = 4 + (int)strlen(cs->refs.aBranches[i].zName) + PROLLY_HASH_SIZE*2;
     if( sz > INT_MAX - inc ){
       return SQLITE_TOOBIG;
     }
     sz += inc;
   }
-  for(i=0; i<cs->nTags; i++){
-    int taggerLen  = cs->aTags[i].zTagger  ? (int)strlen(cs->aTags[i].zTagger)  : 0;
-    int emailLen   = cs->aTags[i].zEmail   ? (int)strlen(cs->aTags[i].zEmail)   : 0;
-    int messageLen = cs->aTags[i].zMessage ? (int)strlen(cs->aTags[i].zMessage) : 0;
-    int inc = 4 + (int)strlen(cs->aTags[i].zName) + PROLLY_HASH_SIZE
+  for(i=0; i<cs->refs.nTags; i++){
+    int taggerLen  = cs->refs.aTags[i].zTagger  ? (int)strlen(cs->refs.aTags[i].zTagger)  : 0;
+    int emailLen   = cs->refs.aTags[i].zEmail   ? (int)strlen(cs->refs.aTags[i].zEmail)   : 0;
+    int messageLen = cs->refs.aTags[i].zMessage ? (int)strlen(cs->refs.aTags[i].zMessage) : 0;
+    int inc = 4 + (int)strlen(cs->refs.aTags[i].zName) + PROLLY_HASH_SIZE
             + 4 + taggerLen
             + 4 + emailLen
             + 8
@@ -1715,15 +1715,15 @@ static int csSerializeRefsBlob(ChunkStore *cs, u8 **ppOut, int *pnOut){
     }
     sz += inc;
   }
-  for(i=0; i<cs->nRemotes; i++){
-    int inc = 4 + (int)strlen(cs->aRemotes[i].zName) + 4 + (int)strlen(cs->aRemotes[i].zUrl);
+  for(i=0; i<cs->refs.nRemotes; i++){
+    int inc = 4 + (int)strlen(cs->refs.aRemotes[i].zName) + 4 + (int)strlen(cs->refs.aRemotes[i].zUrl);
     if( sz > INT_MAX - inc ){
       return SQLITE_TOOBIG;
     }
     sz += inc;
   }
-  for(i=0; i<cs->nTracking; i++){
-    int inc = 4 + (int)strlen(cs->aTracking[i].zRemote) + 4 + (int)strlen(cs->aTracking[i].zBranch) + PROLLY_HASH_SIZE;
+  for(i=0; i<cs->refs.nTracking; i++){
+    int inc = 4 + (int)strlen(cs->refs.aTracking[i].zRemote) + 4 + (int)strlen(cs->refs.aTracking[i].zBranch) + PROLLY_HASH_SIZE;
     if( sz > INT_MAX - inc ){
       return SQLITE_TOOBIG;
     }
@@ -1735,52 +1735,52 @@ static int csSerializeRefsBlob(ChunkStore *cs, u8 **ppOut, int *pnOut){
   *bufCur++ = 6;
   CS_WRITE_U32(bufCur,defLen); bufCur+=4;
   memcpy(bufCur, def, defLen); bufCur+=defLen;
-  CS_WRITE_U32(bufCur,cs->nBranches); bufCur+=4;
-  for(i=0; i<cs->nBranches; i++){
-    int nameLen = (int)strlen(cs->aBranches[i].zName);
+  CS_WRITE_U32(bufCur,cs->refs.nBranches); bufCur+=4;
+  for(i=0; i<cs->refs.nBranches; i++){
+    int nameLen = (int)strlen(cs->refs.aBranches[i].zName);
     CS_WRITE_U32(bufCur,nameLen); bufCur+=4;
-    memcpy(bufCur, cs->aBranches[i].zName, nameLen); bufCur+=nameLen;
-    memcpy(bufCur, cs->aBranches[i].commitHash.data, PROLLY_HASH_SIZE); bufCur+=PROLLY_HASH_SIZE;
-    memcpy(bufCur, cs->aBranches[i].workingSetHash.data, PROLLY_HASH_SIZE); bufCur+=PROLLY_HASH_SIZE;
+    memcpy(bufCur, cs->refs.aBranches[i].zName, nameLen); bufCur+=nameLen;
+    memcpy(bufCur, cs->refs.aBranches[i].commitHash.data, PROLLY_HASH_SIZE); bufCur+=PROLLY_HASH_SIZE;
+    memcpy(bufCur, cs->refs.aBranches[i].workingSetHash.data, PROLLY_HASH_SIZE); bufCur+=PROLLY_HASH_SIZE;
   }
-  CS_WRITE_U32(bufCur,cs->nTags); bufCur+=4;
-  for(i=0; i<cs->nTags; i++){
-    int nameLen    = (int)strlen(cs->aTags[i].zName);
-    int taggerLen  = cs->aTags[i].zTagger  ? (int)strlen(cs->aTags[i].zTagger)  : 0;
-    int emailLen   = cs->aTags[i].zEmail   ? (int)strlen(cs->aTags[i].zEmail)   : 0;
-    int messageLen = cs->aTags[i].zMessage ? (int)strlen(cs->aTags[i].zMessage) : 0;
+  CS_WRITE_U32(bufCur,cs->refs.nTags); bufCur+=4;
+  for(i=0; i<cs->refs.nTags; i++){
+    int nameLen    = (int)strlen(cs->refs.aTags[i].zName);
+    int taggerLen  = cs->refs.aTags[i].zTagger  ? (int)strlen(cs->refs.aTags[i].zTagger)  : 0;
+    int emailLen   = cs->refs.aTags[i].zEmail   ? (int)strlen(cs->refs.aTags[i].zEmail)   : 0;
+    int messageLen = cs->refs.aTags[i].zMessage ? (int)strlen(cs->refs.aTags[i].zMessage) : 0;
     CS_WRITE_U32(bufCur,nameLen); bufCur+=4;
-    memcpy(bufCur, cs->aTags[i].zName, nameLen); bufCur+=nameLen;
-    memcpy(bufCur, cs->aTags[i].commitHash.data, PROLLY_HASH_SIZE); bufCur+=PROLLY_HASH_SIZE;
+    memcpy(bufCur, cs->refs.aTags[i].zName, nameLen); bufCur+=nameLen;
+    memcpy(bufCur, cs->refs.aTags[i].commitHash.data, PROLLY_HASH_SIZE); bufCur+=PROLLY_HASH_SIZE;
     CS_WRITE_U32(bufCur,taggerLen); bufCur+=4;
-    if( taggerLen ) memcpy(bufCur, cs->aTags[i].zTagger, taggerLen);
+    if( taggerLen ) memcpy(bufCur, cs->refs.aTags[i].zTagger, taggerLen);
     bufCur+=taggerLen;
     CS_WRITE_U32(bufCur,emailLen); bufCur+=4;
-    if( emailLen ) memcpy(bufCur, cs->aTags[i].zEmail, emailLen);
+    if( emailLen ) memcpy(bufCur, cs->refs.aTags[i].zEmail, emailLen);
     bufCur+=emailLen;
-    CS_WRITE_I64(bufCur,cs->aTags[i].timestamp); bufCur+=8;
+    CS_WRITE_I64(bufCur,cs->refs.aTags[i].timestamp); bufCur+=8;
     CS_WRITE_U32(bufCur,messageLen); bufCur+=4;
-    if( messageLen ) memcpy(bufCur, cs->aTags[i].zMessage, messageLen);
+    if( messageLen ) memcpy(bufCur, cs->refs.aTags[i].zMessage, messageLen);
     bufCur+=messageLen;
   }
-  CS_WRITE_U32(bufCur,cs->nRemotes); bufCur+=4;
-  for(i=0; i<cs->nRemotes; i++){
-    int nameLen = (int)strlen(cs->aRemotes[i].zName);
-    int urlLen = (int)strlen(cs->aRemotes[i].zUrl);
+  CS_WRITE_U32(bufCur,cs->refs.nRemotes); bufCur+=4;
+  for(i=0; i<cs->refs.nRemotes; i++){
+    int nameLen = (int)strlen(cs->refs.aRemotes[i].zName);
+    int urlLen = (int)strlen(cs->refs.aRemotes[i].zUrl);
     CS_WRITE_U32(bufCur,nameLen); bufCur+=4;
-    memcpy(bufCur, cs->aRemotes[i].zName, nameLen); bufCur+=nameLen;
+    memcpy(bufCur, cs->refs.aRemotes[i].zName, nameLen); bufCur+=nameLen;
     CS_WRITE_U32(bufCur,urlLen); bufCur+=4;
-    memcpy(bufCur, cs->aRemotes[i].zUrl, urlLen); bufCur+=urlLen;
+    memcpy(bufCur, cs->refs.aRemotes[i].zUrl, urlLen); bufCur+=urlLen;
   }
-  CS_WRITE_U32(bufCur,cs->nTracking); bufCur+=4;
-  for(i=0; i<cs->nTracking; i++){
-    int remoteLen = (int)strlen(cs->aTracking[i].zRemote);
-    int branchLen = (int)strlen(cs->aTracking[i].zBranch);
+  CS_WRITE_U32(bufCur,cs->refs.nTracking); bufCur+=4;
+  for(i=0; i<cs->refs.nTracking; i++){
+    int remoteLen = (int)strlen(cs->refs.aTracking[i].zRemote);
+    int branchLen = (int)strlen(cs->refs.aTracking[i].zBranch);
     CS_WRITE_U32(bufCur,remoteLen); bufCur+=4;
-    memcpy(bufCur, cs->aTracking[i].zRemote, remoteLen); bufCur+=remoteLen;
+    memcpy(bufCur, cs->refs.aTracking[i].zRemote, remoteLen); bufCur+=remoteLen;
     CS_WRITE_U32(bufCur,branchLen); bufCur+=4;
-    memcpy(bufCur, cs->aTracking[i].zBranch, branchLen); bufCur+=branchLen;
-    memcpy(bufCur, cs->aTracking[i].commitHash.data, PROLLY_HASH_SIZE); bufCur+=PROLLY_HASH_SIZE;
+    memcpy(bufCur, cs->refs.aTracking[i].zBranch, branchLen); bufCur+=branchLen;
+    memcpy(bufCur, cs->refs.aTracking[i].commitHash.data, PROLLY_HASH_SIZE); bufCur+=PROLLY_HASH_SIZE;
   }
   *ppOut = buf;
   *pnOut = sz;
@@ -1797,7 +1797,7 @@ int chunkStoreSerializeRefs(ChunkStore *cs){
   if( rc!=SQLITE_OK ) return rc;
   rc = chunkStorePut(cs, buf, sz, &refsHash);
   sqlite3_free(buf);
-  if( rc==SQLITE_OK ) memcpy(&cs->refsHash, &refsHash, sizeof(ProllyHash));
+  if( rc==SQLITE_OK ) memcpy(&cs->refs.refsHash, &refsHash, sizeof(ProllyHash));
   return rc;
 }
 
@@ -1811,29 +1811,29 @@ static int csDeserializeRefs(ChunkStore *cs, const u8 *data, int nData){
   if( bufCur+4>data+nData ) return SQLITE_CORRUPT;
   defLen = (int)CS_READ_U32(bufCur); bufCur+=4;
   if( bufCur+defLen>data+nData ) return SQLITE_CORRUPT;
-  sqlite3_free(cs->zDefaultBranch);
-  cs->zDefaultBranch = sqlite3_malloc(defLen+1);
-  if(!cs->zDefaultBranch) return SQLITE_NOMEM;
-  memcpy(cs->zDefaultBranch, bufCur, defLen); cs->zDefaultBranch[defLen]=0; bufCur+=defLen;
+  sqlite3_free(cs->refs.zDefaultBranch);
+  cs->refs.zDefaultBranch = sqlite3_malloc(defLen+1);
+  if(!cs->refs.zDefaultBranch) return SQLITE_NOMEM;
+  memcpy(cs->refs.zDefaultBranch, bufCur, defLen); cs->refs.zDefaultBranch[defLen]=0; bufCur+=defLen;
   if( bufCur+4>data+nData ) return SQLITE_CORRUPT;
   nBranches = (int)CS_READ_U32(bufCur); bufCur+=4;
   csFreeBranches(cs);
   if( nBranches>0 ){
-    cs->aBranches = sqlite3_malloc(nBranches*(int)sizeof(struct BranchRef));
-    if(!cs->aBranches) return SQLITE_NOMEM;
+    cs->refs.aBranches = sqlite3_malloc(nBranches*(int)sizeof(struct BranchRef));
+    if(!cs->refs.aBranches) return SQLITE_NOMEM;
     for(i=0;i<nBranches;i++){
       int nameLen; if(bufCur+4>data+nData) return SQLITE_CORRUPT;
       nameLen=(int)CS_READ_U32(bufCur); bufCur+=4;
       if(bufCur+nameLen+PROLLY_HASH_SIZE>data+nData) return SQLITE_CORRUPT;
-      memset(&cs->aBranches[i], 0, sizeof(struct BranchRef));
-      cs->aBranches[i].zName=sqlite3_malloc(nameLen+1);
-      if(!cs->aBranches[i].zName) return SQLITE_NOMEM;
-      memcpy(cs->aBranches[i].zName,bufCur,nameLen); cs->aBranches[i].zName[nameLen]=0; bufCur+=nameLen;
-      memcpy(cs->aBranches[i].commitHash.data,bufCur,PROLLY_HASH_SIZE); bufCur+=PROLLY_HASH_SIZE;
+      memset(&cs->refs.aBranches[i], 0, sizeof(struct BranchRef));
+      cs->refs.aBranches[i].zName=sqlite3_malloc(nameLen+1);
+      if(!cs->refs.aBranches[i].zName) return SQLITE_NOMEM;
+      memcpy(cs->refs.aBranches[i].zName,bufCur,nameLen); cs->refs.aBranches[i].zName[nameLen]=0; bufCur+=nameLen;
+      memcpy(cs->refs.aBranches[i].commitHash.data,bufCur,PROLLY_HASH_SIZE); bufCur+=PROLLY_HASH_SIZE;
       if( bufCur+PROLLY_HASH_SIZE<=data+nData ){
-        memcpy(cs->aBranches[i].workingSetHash.data,bufCur,PROLLY_HASH_SIZE); bufCur+=PROLLY_HASH_SIZE;
+        memcpy(cs->refs.aBranches[i].workingSetHash.data,bufCur,PROLLY_HASH_SIZE); bufCur+=PROLLY_HASH_SIZE;
       }
-      cs->nBranches++;
+      cs->refs.nBranches++;
     }
   }
 
@@ -1841,48 +1841,48 @@ static int csDeserializeRefs(ChunkStore *cs, const u8 *data, int nData){
   if( bufCur+4<=data+nData ){
     nTags = (int)CS_READ_U32(bufCur); bufCur+=4;
     if( nTags>0 ){
-      cs->aTags = sqlite3_malloc(nTags*(int)sizeof(struct TagRef));
-      if(!cs->aTags) return SQLITE_NOMEM;
-      memset(cs->aTags, 0, nTags*(int)sizeof(struct TagRef));
+      cs->refs.aTags = sqlite3_malloc(nTags*(int)sizeof(struct TagRef));
+      if(!cs->refs.aTags) return SQLITE_NOMEM;
+      memset(cs->refs.aTags, 0, nTags*(int)sizeof(struct TagRef));
       for(i=0;i<nTags;i++){
         int nameLen; if(bufCur+4>data+nData) return SQLITE_CORRUPT;
         nameLen=(int)CS_READ_U32(bufCur); bufCur+=4;
         if(bufCur+nameLen+PROLLY_HASH_SIZE>data+nData) return SQLITE_CORRUPT;
-        cs->aTags[i].zName=sqlite3_malloc(nameLen+1);
-        if(!cs->aTags[i].zName) return SQLITE_NOMEM;
-        memcpy(cs->aTags[i].zName,bufCur,nameLen); cs->aTags[i].zName[nameLen]=0; bufCur+=nameLen;
-        memcpy(cs->aTags[i].commitHash.data,bufCur,PROLLY_HASH_SIZE); bufCur+=PROLLY_HASH_SIZE;
+        cs->refs.aTags[i].zName=sqlite3_malloc(nameLen+1);
+        if(!cs->refs.aTags[i].zName) return SQLITE_NOMEM;
+        memcpy(cs->refs.aTags[i].zName,bufCur,nameLen); cs->refs.aTags[i].zName[nameLen]=0; bufCur+=nameLen;
+        memcpy(cs->refs.aTags[i].commitHash.data,bufCur,PROLLY_HASH_SIZE); bufCur+=PROLLY_HASH_SIZE;
         if( version>=6 ){
           int taggerLen, emailLen, messageLen;
           if(bufCur+4>data+nData) return SQLITE_CORRUPT;
           taggerLen=(int)CS_READ_U32(bufCur); bufCur+=4;
           if(bufCur+taggerLen>data+nData) return SQLITE_CORRUPT;
-          cs->aTags[i].zTagger=sqlite3_malloc(taggerLen+1);
-          if(!cs->aTags[i].zTagger) return SQLITE_NOMEM;
-          memcpy(cs->aTags[i].zTagger,bufCur,taggerLen); cs->aTags[i].zTagger[taggerLen]=0; bufCur+=taggerLen;
+          cs->refs.aTags[i].zTagger=sqlite3_malloc(taggerLen+1);
+          if(!cs->refs.aTags[i].zTagger) return SQLITE_NOMEM;
+          memcpy(cs->refs.aTags[i].zTagger,bufCur,taggerLen); cs->refs.aTags[i].zTagger[taggerLen]=0; bufCur+=taggerLen;
           if(bufCur+4>data+nData) return SQLITE_CORRUPT;
           emailLen=(int)CS_READ_U32(bufCur); bufCur+=4;
           if(bufCur+emailLen>data+nData) return SQLITE_CORRUPT;
-          cs->aTags[i].zEmail=sqlite3_malloc(emailLen+1);
-          if(!cs->aTags[i].zEmail) return SQLITE_NOMEM;
-          memcpy(cs->aTags[i].zEmail,bufCur,emailLen); cs->aTags[i].zEmail[emailLen]=0; bufCur+=emailLen;
+          cs->refs.aTags[i].zEmail=sqlite3_malloc(emailLen+1);
+          if(!cs->refs.aTags[i].zEmail) return SQLITE_NOMEM;
+          memcpy(cs->refs.aTags[i].zEmail,bufCur,emailLen); cs->refs.aTags[i].zEmail[emailLen]=0; bufCur+=emailLen;
           if(bufCur+8>data+nData) return SQLITE_CORRUPT;
-          cs->aTags[i].timestamp=CS_READ_I64(bufCur); bufCur+=8;
+          cs->refs.aTags[i].timestamp=CS_READ_I64(bufCur); bufCur+=8;
           if(bufCur+4>data+nData) return SQLITE_CORRUPT;
           messageLen=(int)CS_READ_U32(bufCur); bufCur+=4;
           if(bufCur+messageLen>data+nData) return SQLITE_CORRUPT;
-          cs->aTags[i].zMessage=sqlite3_malloc(messageLen+1);
-          if(!cs->aTags[i].zMessage) return SQLITE_NOMEM;
-          memcpy(cs->aTags[i].zMessage,bufCur,messageLen); cs->aTags[i].zMessage[messageLen]=0; bufCur+=messageLen;
+          cs->refs.aTags[i].zMessage=sqlite3_malloc(messageLen+1);
+          if(!cs->refs.aTags[i].zMessage) return SQLITE_NOMEM;
+          memcpy(cs->refs.aTags[i].zMessage,bufCur,messageLen); cs->refs.aTags[i].zMessage[messageLen]=0; bufCur+=messageLen;
         }else{
-          cs->aTags[i].zTagger  = sqlite3_mprintf("");
-          cs->aTags[i].zEmail   = sqlite3_mprintf("");
-          cs->aTags[i].zMessage = sqlite3_mprintf("");
-          if( !cs->aTags[i].zTagger || !cs->aTags[i].zEmail || !cs->aTags[i].zMessage ){
+          cs->refs.aTags[i].zTagger  = sqlite3_mprintf("");
+          cs->refs.aTags[i].zEmail   = sqlite3_mprintf("");
+          cs->refs.aTags[i].zMessage = sqlite3_mprintf("");
+          if( !cs->refs.aTags[i].zTagger || !cs->refs.aTags[i].zEmail || !cs->refs.aTags[i].zMessage ){
             return SQLITE_NOMEM;
           }
         }
-        cs->nTags++;
+        cs->refs.nTags++;
       }
     }
   }
@@ -1892,46 +1892,46 @@ static int csDeserializeRefs(ChunkStore *cs, const u8 *data, int nData){
   if( bufCur+4<=data+nData ){
     int nRemotes = (int)CS_READ_U32(bufCur); bufCur+=4;
     if( nRemotes>0 ){
-      cs->aRemotes = sqlite3_malloc(nRemotes*(int)sizeof(struct RemoteRef));
-      if(!cs->aRemotes) return SQLITE_NOMEM;
-      memset(cs->aRemotes, 0, nRemotes*(int)sizeof(struct RemoteRef));
+      cs->refs.aRemotes = sqlite3_malloc(nRemotes*(int)sizeof(struct RemoteRef));
+      if(!cs->refs.aRemotes) return SQLITE_NOMEM;
+      memset(cs->refs.aRemotes, 0, nRemotes*(int)sizeof(struct RemoteRef));
       for(i=0;i<nRemotes;i++){
         int nameLen, urlLen;
         if(bufCur+4>data+nData) return SQLITE_CORRUPT;
         nameLen=(int)CS_READ_U32(bufCur); bufCur+=4;
         if(bufCur+nameLen+4>data+nData) return SQLITE_CORRUPT;
-        cs->aRemotes[i].zName=sqlite3_malloc(nameLen+1);
-        if(!cs->aRemotes[i].zName) return SQLITE_NOMEM;
-        memcpy(cs->aRemotes[i].zName,bufCur,nameLen); cs->aRemotes[i].zName[nameLen]=0; bufCur+=nameLen;
+        cs->refs.aRemotes[i].zName=sqlite3_malloc(nameLen+1);
+        if(!cs->refs.aRemotes[i].zName) return SQLITE_NOMEM;
+        memcpy(cs->refs.aRemotes[i].zName,bufCur,nameLen); cs->refs.aRemotes[i].zName[nameLen]=0; bufCur+=nameLen;
         urlLen=(int)CS_READ_U32(bufCur); bufCur+=4;
         if(bufCur+urlLen>data+nData) return SQLITE_CORRUPT;
-        cs->aRemotes[i].zUrl=sqlite3_malloc(urlLen+1);
-        if(!cs->aRemotes[i].zUrl) return SQLITE_NOMEM;
-        memcpy(cs->aRemotes[i].zUrl,bufCur,urlLen); cs->aRemotes[i].zUrl[urlLen]=0; bufCur+=urlLen;
-        cs->nRemotes++;
+        cs->refs.aRemotes[i].zUrl=sqlite3_malloc(urlLen+1);
+        if(!cs->refs.aRemotes[i].zUrl) return SQLITE_NOMEM;
+        memcpy(cs->refs.aRemotes[i].zUrl,bufCur,urlLen); cs->refs.aRemotes[i].zUrl[urlLen]=0; bufCur+=urlLen;
+        cs->refs.nRemotes++;
       }
     }
     if( bufCur+4<=data+nData ){
       int nTracking = (int)CS_READ_U32(bufCur); bufCur+=4;
       if( nTracking>0 ){
-        cs->aTracking = sqlite3_malloc(nTracking*(int)sizeof(struct TrackingBranch));
-        if(!cs->aTracking) return SQLITE_NOMEM;
-        memset(cs->aTracking, 0, nTracking*(int)sizeof(struct TrackingBranch));
+        cs->refs.aTracking = sqlite3_malloc(nTracking*(int)sizeof(struct TrackingBranch));
+        if(!cs->refs.aTracking) return SQLITE_NOMEM;
+        memset(cs->refs.aTracking, 0, nTracking*(int)sizeof(struct TrackingBranch));
         for(i=0;i<nTracking;i++){
           int remoteLen, branchLen;
           if(bufCur+4>data+nData) return SQLITE_CORRUPT;
           remoteLen=(int)CS_READ_U32(bufCur); bufCur+=4;
           if(bufCur+remoteLen+4>data+nData) return SQLITE_CORRUPT;
-          cs->aTracking[i].zRemote=sqlite3_malloc(remoteLen+1);
-          if(!cs->aTracking[i].zRemote) return SQLITE_NOMEM;
-          memcpy(cs->aTracking[i].zRemote,bufCur,remoteLen); cs->aTracking[i].zRemote[remoteLen]=0; bufCur+=remoteLen;
+          cs->refs.aTracking[i].zRemote=sqlite3_malloc(remoteLen+1);
+          if(!cs->refs.aTracking[i].zRemote) return SQLITE_NOMEM;
+          memcpy(cs->refs.aTracking[i].zRemote,bufCur,remoteLen); cs->refs.aTracking[i].zRemote[remoteLen]=0; bufCur+=remoteLen;
           branchLen=(int)CS_READ_U32(bufCur); bufCur+=4;
           if(bufCur+branchLen+PROLLY_HASH_SIZE>data+nData) return SQLITE_CORRUPT;
-          cs->aTracking[i].zBranch=sqlite3_malloc(branchLen+1);
-          if(!cs->aTracking[i].zBranch) return SQLITE_NOMEM;
-          memcpy(cs->aTracking[i].zBranch,bufCur,branchLen); cs->aTracking[i].zBranch[branchLen]=0; bufCur+=branchLen;
-          memcpy(cs->aTracking[i].commitHash.data,bufCur,PROLLY_HASH_SIZE); bufCur+=PROLLY_HASH_SIZE;
-          cs->nTracking++;
+          cs->refs.aTracking[i].zBranch=sqlite3_malloc(branchLen+1);
+          if(!cs->refs.aTracking[i].zBranch) return SQLITE_NOMEM;
+          memcpy(cs->refs.aTracking[i].zBranch,bufCur,branchLen); cs->refs.aTracking[i].zBranch[branchLen]=0; bufCur+=branchLen;
+          memcpy(cs->refs.aTracking[i].commitHash.data,bufCur,PROLLY_HASH_SIZE); bufCur+=PROLLY_HASH_SIZE;
+          cs->refs.nTracking++;
         }
       }
     }
@@ -1946,25 +1946,25 @@ static int csDeserializeRefsIntoTemp(ChunkStore *pTmp, const u8 *data, int nData
 }
 
 static void csAdoptRefsState(ChunkStore *pDst, ChunkStore *pSrc){
-  pDst->aBranches = pSrc->aBranches;
-  pDst->nBranches = pSrc->nBranches;
-  pDst->zDefaultBranch = pSrc->zDefaultBranch;
-  pDst->aTags = pSrc->aTags;
-  pDst->nTags = pSrc->nTags;
-  pDst->aRemotes = pSrc->aRemotes;
-  pDst->nRemotes = pSrc->nRemotes;
-  pDst->aTracking = pSrc->aTracking;
-  pDst->nTracking = pSrc->nTracking;
+  pDst->refs.aBranches = pSrc->refs.aBranches;
+  pDst->refs.nBranches = pSrc->refs.nBranches;
+  pDst->refs.zDefaultBranch = pSrc->refs.zDefaultBranch;
+  pDst->refs.aTags = pSrc->refs.aTags;
+  pDst->refs.nTags = pSrc->refs.nTags;
+  pDst->refs.aRemotes = pSrc->refs.aRemotes;
+  pDst->refs.nRemotes = pSrc->refs.nRemotes;
+  pDst->refs.aTracking = pSrc->refs.aTracking;
+  pDst->refs.nTracking = pSrc->refs.nTracking;
 
-  pSrc->aBranches = 0;
-  pSrc->nBranches = 0;
-  pSrc->zDefaultBranch = 0;
-  pSrc->aTags = 0;
-  pSrc->nTags = 0;
-  pSrc->aRemotes = 0;
-  pSrc->nRemotes = 0;
-  pSrc->aTracking = 0;
-  pSrc->nTracking = 0;
+  pSrc->refs.aBranches = 0;
+  pSrc->refs.nBranches = 0;
+  pSrc->refs.zDefaultBranch = 0;
+  pSrc->refs.aTags = 0;
+  pSrc->refs.nTags = 0;
+  pSrc->refs.aRemotes = 0;
+  pSrc->refs.nRemotes = 0;
+  pSrc->refs.aTracking = 0;
+  pSrc->refs.nTracking = 0;
 }
 
 static int csReplaceRefsStateFromBlob(
@@ -2473,24 +2473,24 @@ int chunkStoreCommit(ChunkStore *cs){
   if( cs->isMemory ) return csCommitToMemory(cs);
   if( cs->graphLockFd < 0 && cs->zFilename ){
     preserveRefs = cs->nPending > 0
-                && prollyHashCompare(&cs->refsHash,
-                                     &cs->committedRefsHash)!=0;
+                && prollyHashCompare(&cs->refs.refsHash,
+                                     &cs->refs.committedRefsHash)!=0;
     if( preserveRefs ){
-      savedRefsHash = cs->refsHash;
+      savedRefsHash = cs->refs.refsHash;
       csDetachSavedRefsState(cs, &savedRefs);
     }
     rc = chunkStoreLockAndRefresh(cs);
     if( rc!=SQLITE_OK ){
       if( preserveRefs ){
         csRestoreSavedRefsState(cs, &savedRefs);
-        cs->refsHash = savedRefsHash;
+        cs->refs.refsHash = savedRefsHash;
       }
       return rc;
     }
     if( preserveRefs ){
       csFreeRefsState(cs);
       csRestoreSavedRefsState(cs, &savedRefs);
-      cs->refsHash = savedRefsHash;
+      cs->refs.refsHash = savedRefsHash;
     }
     acquiredLock = 1;
   }
@@ -2512,7 +2512,7 @@ void chunkStoreRollback(ChunkStore *cs){
 }
 
 int chunkStoreIsEmpty(ChunkStore *cs){
-  return cs->nBranches == 0 && prollyHashIsEmpty(&cs->refsHash);
+  return cs->refs.nBranches == 0 && prollyHashIsEmpty(&cs->refs.refsHash);
 }
 
 void chunkStoreClearRefs(ChunkStore *cs){
@@ -2520,7 +2520,7 @@ void chunkStoreClearRefs(ChunkStore *cs){
   csFreeTags(cs);
   csFreeRemotes(cs);
   csFreeTracking(cs);
-  memset(&cs->refsHash, 0, sizeof(cs->refsHash));
+  memset(&cs->refs.refsHash, 0, sizeof(cs->refs.refsHash));
 }
 
 int chunkStoreReloadRefs(ChunkStore *cs){
@@ -2528,9 +2528,9 @@ int chunkStoreReloadRefs(ChunkStore *cs){
   int nRefsData = 0;
   int rc;
 
-  if( prollyHashIsEmpty(&cs->refsHash) ) return SQLITE_OK;
+  if( prollyHashIsEmpty(&cs->refs.refsHash) ) return SQLITE_OK;
 
-  rc = chunkStoreGet(cs, &cs->refsHash, &refsData, &nRefsData);
+  rc = chunkStoreGet(cs, &cs->refs.refsHash, &refsData, &nRefsData);
   if( rc!=SQLITE_OK ) return rc;
 
   rc = csReplaceRefsStateFromBlob(cs, refsData, nRefsData, 0);

--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -6,6 +6,7 @@
 #include "sqliteInt.h"
 #include "prolly_hash.h"
 #include "chunk_wal.h"
+#include "chunk_refs.h"
 
 #define CHUNK_STORE_MAGIC 0x444C5443
 #define CHUNK_STORE_VERSION 11
@@ -108,39 +109,7 @@ struct ChunkStore {
   char *zFilename;
   sqlite3_file *pFile;
   sqlite3_vfs *pVfs;
-  ProllyHash refsHash;
-  ProllyHash committedRefsHash;
-
-  struct BranchRef {
-    char *zName;
-    ProllyHash commitHash;
-    ProllyHash workingSetHash;
-  } *aBranches;
-  int nBranches;
-  char *zDefaultBranch;
-
-  struct TagRef {
-    char *zName;
-    ProllyHash commitHash;
-    char *zTagger;
-    char *zEmail;
-    i64 timestamp;
-    char *zMessage;
-  } *aTags;
-  int nTags;
-
-  struct RemoteRef {
-    char *zName;
-    char *zUrl;
-  } *aRemotes;
-  int nRemotes;
-
-  struct TrackingBranch {
-    char *zRemote;
-    char *zBranch;
-    ProllyHash commitHash;
-  } *aTracking;
-  int nTracking;
+  RefsTable refs;
 
   int nChunks;
   i64 iIndexOffset;

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -114,7 +114,7 @@ static int doltliteSaveTxnState(sqlite3 *db, DoltliteTxnState *p){
   memset(p, 0, sizeof(*p));
   if( !cs ) return SQLITE_ERROR;
 
-  memcpy(&p->refsHash, &cs->refsHash, sizeof(ProllyHash));
+  memcpy(&p->refsHash, refsTableGetHash(&cs->refs), sizeof(ProllyHash));
 
   p->zSessionBranch = sqlite3_mprintf("%s", doltliteGetSessionBranch(db));
   if( !p->zSessionBranch ){
@@ -142,7 +142,7 @@ static int doltliteRestoreTxnState(sqlite3 *db, DoltliteTxnState *p){
 
   if( !cs ) return SQLITE_ERROR;
 
-  memcpy(&cs->refsHash, &p->refsHash, sizeof(ProllyHash));
+  refsTableSetHash(&cs->refs, &p->refsHash);
   if( prollyHashIsEmpty(&p->refsHash) ){
     chunkStoreClearRefs(cs);
   }else{
@@ -576,7 +576,7 @@ static int doltliteAdvanceBranch(
   rc = doltliteSaveTxnState(db, &saved);
   if( rc!=SQLITE_OK ) return rc;
 
-  if( cs->nBranches==0 ){
+  if( refsTableBranchCount(&cs->refs)==0 ){
     rc = chunkStoreAddBranch(cs, branch, pNewHead);
     if( rc==SQLITE_OK ){
       rc = chunkStoreSetDefaultBranch(cs, branch);
@@ -4812,7 +4812,7 @@ static void doltliteMaybeSeedRepo(sqlite3 *db){
   int rc;
 
   if( !cs ) return;
-  if( cs->nBranches > 0 ) return;
+  if( refsTableBranchCount(&cs->refs) > 0 ) return;
   if( sqlite3_db_readonly(db, "main")==1 ) return;
 
   memset(&emptyParent, 0, sizeof(emptyParent));

--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -1360,13 +1360,13 @@ static int brNext(sqlite3_vtab_cursor *c){ ((BrCur*)c)->iRow++; return SQLITE_OK
 static int brEof(sqlite3_vtab_cursor *c){
   BrVtab *v = (BrVtab*)c->pVtab;
   ChunkStore *cs = doltliteGetChunkStore(v->db);
-  return !cs || ((BrCur*)c)->iRow >= cs->nBranches;
+  return !cs || ((BrCur*)c)->iRow >= refsTableBranchCount(&cs->refs);
 }
 
 static int brIsDirty(
   sqlite3 *db,
   ChunkStore *cs,
-  struct BranchRef *br,
+  const BranchRef *br,
   int *pDirty
 ){
   ProllyHash stagedCat;
@@ -1413,9 +1413,12 @@ static int brIsDirty(
 static int brColumn(sqlite3_vtab_cursor *c, sqlite3_context *ctx, int col){
   BrVtab *v = (BrVtab*)c->pVtab;
   ChunkStore *cs = doltliteGetChunkStore(v->db);
-  struct BranchRef *br;
+  const BranchRef *br;
+  int nBr;
+  const BranchRef *aBr;
   if(!cs) return SQLITE_OK;
-  br = &cs->aBranches[((BrCur*)c)->iRow];
+  refsTableGetBranches(&cs->refs, &nBr, &aBr);
+  br = &aBr[((BrCur*)c)->iRow];
 
   switch(col){
     case 0:

--- a/src/doltlite_commit_ancestors.c
+++ b/src/doltlite_commit_ancestors.c
@@ -191,13 +191,21 @@ static int caFilter(
   rc = caEnqueue(pCur, &head);
   if( rc!=SQLITE_OK ) return rc;
 
-  for( i = 0; i < cs->nBranches; i++ ){
-    rc = caEnqueue(pCur, &cs->aBranches[i].commitHash);
-    if( rc!=SQLITE_OK ) return rc;
+  {
+    int nBr; const BranchRef *aBr;
+    refsTableGetBranches(&cs->refs, &nBr, &aBr);
+    for( i = 0; i < nBr; i++ ){
+      rc = caEnqueue(pCur, &aBr[i].commitHash);
+      if( rc!=SQLITE_OK ) return rc;
+    }
   }
-  for( i = 0; i < cs->nTags; i++ ){
-    rc = caEnqueue(pCur, &cs->aTags[i].commitHash);
-    if( rc!=SQLITE_OK ) return rc;
+  {
+    int nTg; const TagRef *aTg;
+    refsTableGetTags(&cs->refs, &nTg, &aTg);
+    for( i = 0; i < nTg; i++ ){
+      rc = caEnqueue(pCur, &aTg[i].commitHash);
+      if( rc!=SQLITE_OK ) return rc;
+    }
   }
 
   if( pCur->qTail == 0 ) return SQLITE_OK;

--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -78,15 +78,23 @@ static int gcMarkReachable(
   rc = gcQueueInit(&queue);
   if( rc!=SQLITE_OK ) return rc;
 
-  rc = gcQueuePush(&queue, &cs->refsHash);
+  rc = gcQueuePush(&queue, refsTableGetHash(&cs->refs));
 
-  for(i=0; rc==SQLITE_OK && i<cs->nBranches; i++){
-    rc = gcQueuePush(&queue, &cs->aBranches[i].commitHash);
-    if( rc==SQLITE_OK ) rc = gcQueuePush(&queue, &cs->aBranches[i].workingSetHash);
+  {
+    int nBr; const BranchRef *aBr;
+    refsTableGetBranches(&cs->refs, &nBr, &aBr);
+    for(i=0; rc==SQLITE_OK && i<nBr; i++){
+      rc = gcQueuePush(&queue, &aBr[i].commitHash);
+      if( rc==SQLITE_OK ) rc = gcQueuePush(&queue, &aBr[i].workingSetHash);
+    }
   }
 
-  for(i=0; rc==SQLITE_OK && i<cs->nTags; i++){
-    rc = gcQueuePush(&queue, &cs->aTags[i].commitHash);
+  {
+    int nTg; const TagRef *aTg;
+    refsTableGetTags(&cs->refs, &nTg, &aTg);
+    for(i=0; rc==SQLITE_OK && i<nTg; i++){
+      rc = gcQueuePush(&queue, &aTg[i].commitHash);
+    }
   }
   if( rc!=SQLITE_OK ){
     gcQueueFree(&queue);

--- a/src/doltlite_remote.c
+++ b/src/doltlite_remote.c
@@ -105,23 +105,29 @@ static int remoteCollectRootsFromRefsBlob(
   rc = remoteLoadRefsView(pData, nData, &refsView);
   if( rc!=SQLITE_OK ) return rc;
 
-  nAlloc = refsView.nBranches + refsView.nTags + 1;
-  if( nAlloc>0 ){
-    aRoots = sqlite3_malloc(nAlloc * (int)sizeof(ProllyHash));
-    if( !aRoots ){
-      chunkStoreClose(&refsView);
-      return SQLITE_NOMEM;
+  {
+    int nBr, nTg;
+    const BranchRef *aBr;
+    const TagRef *aTg;
+    refsTableGetBranches(&refsView.refs, &nBr, &aBr);
+    refsTableGetTags(&refsView.refs, &nTg, &aTg);
+    nAlloc = nBr + nTg + 1;
+    if( nAlloc>0 ){
+      aRoots = sqlite3_malloc(nAlloc * (int)sizeof(ProllyHash));
+      if( !aRoots ){
+        chunkStoreClose(&refsView);
+        return SQLITE_NOMEM;
+      }
     }
-  }
-
-  for(i=0; i<refsView.nBranches; i++){
-    if( !prollyHashIsEmpty(&refsView.aBranches[i].commitHash) ){
-      aRoots[nRoots++] = refsView.aBranches[i].commitHash;
+    for(i=0; i<nBr; i++){
+      if( !prollyHashIsEmpty(&aBr[i].commitHash) ){
+        aRoots[nRoots++] = aBr[i].commitHash;
+      }
     }
-  }
-  for(i=0; i<refsView.nTags; i++){
-    if( !prollyHashIsEmpty(&refsView.aTags[i].commitHash) ){
-      aRoots[nRoots++] = refsView.aTags[i].commitHash;
+    for(i=0; i<nTg; i++){
+      if( !prollyHashIsEmpty(&aTg[i].commitHash) ){
+        aRoots[nRoots++] = aTg[i].commitHash;
+      }
     }
   }
 
@@ -301,10 +307,10 @@ static int fsGetRefs(DoltliteRemote *pRemote, u8 **ppData, int *pnData){
   FsRemote *p = (FsRemote*)pRemote;
   *ppData = 0;
   *pnData = 0;
-  if( prollyHashIsEmpty(&p->store.refsHash) ){
+  if( prollyHashIsEmpty(refsTableGetHash(&p->store.refs)) ){
     return SQLITE_NOTFOUND;
   }
-  return chunkStoreGet(&p->store, &p->store.refsHash, ppData, pnData);
+  return chunkStoreGet(&p->store, refsTableGetHash(&p->store.refs), ppData, pnData);
 }
 
 static int fsSetRefs(DoltliteRemote *pRemote, const u8 *pData, int nData){
@@ -313,12 +319,12 @@ static int fsSetRefs(DoltliteRemote *pRemote, const u8 *pData, int nData){
   ProllyHash refsHash;
   int rc = chunkStorePut(&p->store, pData, nData, &refsHash);
   if( rc==SQLITE_OK ){
-    memcpy(&oldRefsHash, &p->store.refsHash, sizeof(ProllyHash));
-    memcpy(&p->store.refsHash, &refsHash, sizeof(ProllyHash));
+    memcpy(&oldRefsHash, refsTableGetHash(&p->store.refs), sizeof(ProllyHash));
+    refsTableSetHash(&p->store.refs, &refsHash);
 
     rc = chunkStoreReloadRefs(&p->store);
     if( rc!=SQLITE_OK ){
-      memcpy(&p->store.refsHash, &oldRefsHash, sizeof(ProllyHash));
+      refsTableSetHash(&p->store.refs, &oldRefsHash);
       if( !prollyHashIsEmpty(&oldRefsHash) ){
         int restoreRc = chunkStoreReloadRefs(&p->store);
         if( restoreRc!=SQLITE_OK ) return restoreRc;
@@ -408,10 +414,10 @@ static int localGetRefs(DoltliteRemote *pRemote, u8 **ppData, int *pnData){
   LocalAsRemote *p = (LocalAsRemote*)pRemote;
   *ppData = 0;
   *pnData = 0;
-  if( prollyHashIsEmpty(&p->pStore->refsHash) ){
+  if( prollyHashIsEmpty(refsTableGetHash(&p->pStore->refs)) ){
     return SQLITE_NOTFOUND;
   }
-  return chunkStoreGet(p->pStore, &p->pStore->refsHash, ppData, pnData);
+  return chunkStoreGet(p->pStore, refsTableGetHash(&p->pStore->refs), ppData, pnData);
 }
 
 static int localSetRefs(DoltliteRemote *pRemote, const u8 *pData, int nData){
@@ -419,7 +425,7 @@ static int localSetRefs(DoltliteRemote *pRemote, const u8 *pData, int nData){
   ProllyHash refsHash;
   int rc = chunkStorePut(p->pStore, pData, nData, &refsHash);
   if( rc==SQLITE_OK ){
-    memcpy(&p->pStore->refsHash, &refsHash, sizeof(ProllyHash));
+    refsTableSetHash(&p->pStore->refs, &refsHash);
   }
   return rc;
 }
@@ -708,7 +714,7 @@ int doltliteClone(ChunkStore *pLocal, DoltliteRemote *pRemote){
   ProllyHash oldRefsHash;
   int rc;
 
-  memcpy(&oldRefsHash, &pLocal->refsHash, sizeof(ProllyHash));
+  memcpy(&oldRefsHash, refsTableGetHash(&pLocal->refs), sizeof(ProllyHash));
 
   rc = pRemote->xGetRefs(pRemote, &refsData, &nRefsData);
   if( rc!=SQLITE_OK ) return rc;
@@ -748,7 +754,7 @@ int doltliteClone(ChunkStore *pLocal, DoltliteRemote *pRemote){
     ProllyHash refsHash;
     rc = chunkStorePut(pLocal, refsData, nRefsData, &refsHash);
     if( rc==SQLITE_OK ){
-      memcpy(&pLocal->refsHash, &refsHash, sizeof(ProllyHash));
+      refsTableSetHash(&pLocal->refs, &refsHash);
     }
   }
   sqlite3_free(refsData);
@@ -756,13 +762,13 @@ int doltliteClone(ChunkStore *pLocal, DoltliteRemote *pRemote){
 
   rc = chunkStoreCommit(pLocal);
   if( rc!=SQLITE_OK ){
-    memcpy(&pLocal->refsHash, &oldRefsHash, sizeof(ProllyHash));
+    refsTableSetHash(&pLocal->refs, &oldRefsHash);
     return rc;
   }
 
   rc = chunkStoreReloadRefs(pLocal);
   if( rc!=SQLITE_OK ){
-    memcpy(&pLocal->refsHash, &oldRefsHash, sizeof(ProllyHash));
+    refsTableSetHash(&pLocal->refs, &oldRefsHash);
     if( !prollyHashIsEmpty(&oldRefsHash) ){
       int restoreRc = chunkStoreReloadRefs(pLocal);
       if( restoreRc!=SQLITE_OK ) return restoreRc;

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -39,7 +39,7 @@ static int remoteSqlStateSave(sqlite3 *db, ChunkStore *cs, RemoteSqlState *p){
 
   memset(p, 0, sizeof(*p));
 
-  memcpy(&p->refsHash, &cs->refsHash, sizeof(ProllyHash));
+  memcpy(&p->refsHash, refsTableGetHash(&cs->refs), sizeof(ProllyHash));
 
   p->zSessionBranch = sqlite3_mprintf("%s", doltliteGetSessionBranch(db));
   if( !p->zSessionBranch ){
@@ -62,7 +62,7 @@ static int remoteSqlStateSave(sqlite3 *db, ChunkStore *cs, RemoteSqlState *p){
 static int remoteSqlStateRestore(sqlite3 *db, ChunkStore *cs, RemoteSqlState *p){
   int rc;
 
-  memcpy(&cs->refsHash, &p->refsHash, sizeof(ProllyHash));
+  refsTableSetHash(&cs->refs, &p->refsHash);
   if( prollyHashIsEmpty(&p->refsHash) ){
     chunkStoreClearRefs(cs);
   }else{
@@ -397,26 +397,30 @@ static int parseRemoteBranchNames(
     chunkStoreClose(&refsView);
     return rc;
   }
-  if( refsView.nBranches > nRefsData / 44 ){
-    chunkStoreClose(&refsView);
-    return SQLITE_CORRUPT;
-  }
-
-  if( refsView.nBranches>0 ){
-    azNames = sqlite3_malloc(refsView.nBranches * sizeof(char*));
-    if( !azNames ){
+  {
+    int nBr;
+    const BranchRef *aBr;
+    refsTableGetBranches(&refsView.refs, &nBr, &aBr);
+    if( nBr > nRefsData / 44 ){
       chunkStoreClose(&refsView);
-      return SQLITE_NOMEM;
+      return SQLITE_CORRUPT;
     }
-    memset(azNames, 0, refsView.nBranches * sizeof(char*));
-    for(i=0; i<refsView.nBranches; i++){
-      azNames[nNames] = sqlite3_mprintf("%s", refsView.aBranches[i].zName);
-      if( !azNames[nNames] ){
-        freeNameList(azNames, nNames);
+    if( nBr>0 ){
+      azNames = sqlite3_malloc(nBr * sizeof(char*));
+      if( !azNames ){
         chunkStoreClose(&refsView);
         return SQLITE_NOMEM;
       }
-      nNames++;
+      memset(azNames, 0, nBr * sizeof(char*));
+      for(i=0; i<nBr; i++){
+        azNames[nNames] = sqlite3_mprintf("%s", aBr[i].zName);
+        if( !azNames[nNames] ){
+          freeNameList(azNames, nNames);
+          chunkStoreClose(&refsView);
+          return SQLITE_NOMEM;
+        }
+        nNames++;
+      }
     }
   }
   chunkStoreClose(&refsView);
@@ -704,10 +708,13 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
 
   if( !chunkStoreIsEmpty(cs) ){
     int virgin = 0;
-    if( cs->nBranches==1 ){
+    int nBr;
+    const BranchRef *aBr;
+    refsTableGetBranches(&cs->refs, &nBr, &aBr);
+    if( nBr==1 ){
       DoltliteCommit c;
       memset(&c, 0, sizeof(c));
-      if( doltliteLoadCommit(db, &cs->aBranches[0].commitHash, &c)==SQLITE_OK
+      if( doltliteLoadCommit(db, &aBr[0].commitHash, &c)==SQLITE_OK
        && doltliteCommitParentCount(&c)==0 ){
         virgin = 1;
       }
@@ -756,7 +763,7 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   {
     u8 *refsData = 0; int nRefsData = 0;
     ProllyHash refsHash;
-    memcpy(&refsHash, &cs->refsHash, sizeof(ProllyHash));
+    memcpy(&refsHash, refsTableGetHash(&cs->refs), sizeof(ProllyHash));
     if( !prollyHashIsEmpty(&refsHash) ){
       rc = chunkStoreGet(cs, &refsHash, &refsData, &nRefsData);
       (void)refsData;
@@ -767,9 +774,12 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   {
     const char *zDefault = chunkStoreGetDefaultBranch(cs);
     ProllyHash branchCommit;
+    int nBr;
+    const BranchRef *aBr;
+    refsTableGetBranches(&cs->refs, &nBr, &aBr);
 
-    if( !zDefault && cs->nBranches > 0 ){
-      zDefault = cs->aBranches[0].zName;
+    if( !zDefault && nBr > 0 ){
+      zDefault = aBr[0].zName;
     }
 
     if( zDefault ){
@@ -841,14 +851,17 @@ static int remNext(sqlite3_vtab_cursor *c){ ((RemCur*)c)->iRow++; return SQLITE_
 static int remEof(sqlite3_vtab_cursor *c){
   RemVtab *v = (RemVtab*)c->pVtab;
   ChunkStore *cs = doltliteGetChunkStore(v->db);
-  return !cs || ((RemCur*)c)->iRow >= cs->nRemotes;
+  return !cs || ((RemCur*)c)->iRow >= refsTableRemoteCount(&cs->refs);
 }
 static int remColumn(sqlite3_vtab_cursor *c, sqlite3_context *ctx, int col){
   RemVtab *v = (RemVtab*)c->pVtab;
   ChunkStore *cs = doltliteGetChunkStore(v->db);
-  struct RemoteRef *rem;
+  const RemoteRef *rem;
+  int nRm;
+  const RemoteRef *aRm;
   if(!cs) return SQLITE_OK;
-  rem = &cs->aRemotes[((RemCur*)c)->iRow];
+  refsTableGetRemotes(&cs->refs, &nRm, &aRm);
+  rem = &aRm[((RemCur*)c)->iRow];
   switch(col){
     case 0:
       sqlite3_result_text(ctx, rem->zName, -1, SQLITE_TRANSIENT);

--- a/src/doltlite_remotesrv.c
+++ b/src/doltlite_remotesrv.c
@@ -389,12 +389,12 @@ static void handleGetRefs(ChunkStore *pStore, int fd){
   int nData = 0;
   int rc;
 
-  if( prollyHashIsEmpty(&pStore->refsHash) ){
+  if( prollyHashIsEmpty(refsTableGetHash(&pStore->refs)) ){
     sendNotFound(fd);
     return;
   }
 
-  rc = chunkStoreGet(pStore, &pStore->refsHash, &pData, &nData);
+  rc = chunkStoreGet(pStore, refsTableGetHash(&pStore->refs), &pData, &nData);
   if( rc==SQLITE_NOTFOUND ){
     sendNotFound(fd);
     return;
@@ -422,7 +422,7 @@ static int remoteSrvApplyRefs(ChunkStore *pStore, const u8 *pBody, int nBody){
   if( nBody<=0 ) return SQLITE_ERROR;
   rc = chunkStorePut(pStore, pBody, nBody, &hash);
   if( rc==SQLITE_OK ){
-    pStore->refsHash = hash;
+    refsTableSetHash(&pStore->refs, &hash);
     rc = chunkStoreReloadRefs(pStore);
   }
   if( rc!=SQLITE_OK ){

--- a/src/doltlite_tag.c
+++ b/src/doltlite_tag.c
@@ -250,14 +250,17 @@ static int tagNext(sqlite3_vtab_cursor *pCursor){
 static int tagEof(sqlite3_vtab_cursor *pCursor){
   TagVtab *pVtab = (TagVtab*)pCursor->pVtab;
   ChunkStore *cs = doltliteGetChunkStore(pVtab->db);
-  return !cs || ((TagCur*)pCursor)->iRow >= cs->nTags;
+  return !cs || ((TagCur*)pCursor)->iRow >= refsTableTagCount(&cs->refs);
 }
 static int tagColumn(sqlite3_vtab_cursor *pCursor, sqlite3_context *ctx, int col){
   TagVtab *pVtab = (TagVtab*)pCursor->pVtab;
   ChunkStore *cs = doltliteGetChunkStore(pVtab->db);
-  struct TagRef *t;
+  const TagRef *t;
+  int nTg;
+  const TagRef *aTg;
   if( !cs ) return SQLITE_OK;
-  t = &cs->aTags[((TagCur*)pCursor)->iRow];
+  refsTableGetTags(&cs->refs, &nTg, &aTg);
+  t = &aTg[((TagCur*)pCursor)->iRow];
   switch(col){
     case 0:
       sqlite3_result_text(ctx, t->zName, -1, SQLITE_TRANSIENT);

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -6823,18 +6823,30 @@ int doltliteCheckRepoGraphIntegrity(Btree *p, int mxErr, int *pnErr){
   rc = prollyHashSetInit(&ctx.seen, 256);
   if( rc!=SQLITE_OK ) return rc;
 
-  rc = integrityCheckChunkGraph(&ctx, &pBt->store.refsHash);
-  for(i=0; rc==SQLITE_OK && i<pBt->store.nBranches; i++){
-    rc = integrityCheckChunkGraph(&ctx, &pBt->store.aBranches[i].commitHash);
-    if( rc==SQLITE_OK ){
-      rc = integrityCheckChunkGraph(&ctx, &pBt->store.aBranches[i].workingSetHash);
+  rc = integrityCheckChunkGraph(&ctx, refsTableGetHash(&pBt->store.refs));
+  {
+    int nBr; const BranchRef *aBr;
+    refsTableGetBranches(&pBt->store.refs, &nBr, &aBr);
+    for(i=0; rc==SQLITE_OK && i<nBr; i++){
+      rc = integrityCheckChunkGraph(&ctx, &aBr[i].commitHash);
+      if( rc==SQLITE_OK ){
+        rc = integrityCheckChunkGraph(&ctx, &aBr[i].workingSetHash);
+      }
     }
   }
-  for(i=0; rc==SQLITE_OK && i<pBt->store.nTags; i++){
-    rc = integrityCheckChunkGraph(&ctx, &pBt->store.aTags[i].commitHash);
+  {
+    int nTg; const TagRef *aTg;
+    refsTableGetTags(&pBt->store.refs, &nTg, &aTg);
+    for(i=0; rc==SQLITE_OK && i<nTg; i++){
+      rc = integrityCheckChunkGraph(&ctx, &aTg[i].commitHash);
+    }
   }
-  for(i=0; rc==SQLITE_OK && i<pBt->store.nTracking; i++){
-    rc = integrityCheckChunkGraph(&ctx, &pBt->store.aTracking[i].commitHash);
+  {
+    int nTk; const TrackingBranch *aTk;
+    refsTableGetTracking(&pBt->store.refs, &nTk, &aTk);
+    for(i=0; rc==SQLITE_OK && i<nTk; i++){
+      rc = integrityCheckChunkGraph(&ctx, &aTk[i].commitHash);
+    }
   }
   if( rc==SQLITE_OK && p->isMerging ){
     rc = integrityCheckChunkGraph(&ctx, &p->mergeCommitHash);

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -644,22 +644,22 @@ static void run_refs_blob_corruption(void){
 
   check("set_default_branch",
         chunkStoreSetDefaultBranch(&cs, "main")==SQLITE_OK);
-  cs.aBranches = sqlite3_malloc(sizeof(*cs.aBranches));
-  check("alloc_branch_ref", cs.aBranches!=0);
-  if( cs.aBranches ){
-    memset(cs.aBranches, 0, sizeof(*cs.aBranches));
-    cs.nBranches = 1;
-    cs.aBranches[0].zName = sqlite3_mprintf("main");
-    check("alloc_branch_name", cs.aBranches[0].zName!=0);
+  cs.refs.aBranches = sqlite3_malloc(sizeof(*cs.refs.aBranches));
+  check("alloc_branch_ref", cs.refs.aBranches!=0);
+  if( cs.refs.aBranches ){
+    memset(cs.refs.aBranches, 0, sizeof(*cs.refs.aBranches));
+    cs.refs.nBranches = 1;
+    cs.refs.aBranches[0].zName = sqlite3_mprintf("main");
+    check("alloc_branch_name", cs.refs.aBranches[0].zName!=0);
   }
 
-  cs.aTags = sqlite3_malloc(sizeof(*cs.aTags));
-  check("alloc_tag_ref", cs.aTags!=0);
-  if( cs.aTags ){
-    memset(cs.aTags, 0, sizeof(*cs.aTags));
-    cs.nTags = 1;
-    cs.aTags[0].zName = sqlite3_mprintf("v1");
-    check("alloc_tag_name", cs.aTags[0].zName!=0);
+  cs.refs.aTags = sqlite3_malloc(sizeof(*cs.refs.aTags));
+  check("alloc_tag_ref", cs.refs.aTags!=0);
+  if( cs.refs.aTags ){
+    memset(cs.refs.aTags, 0, sizeof(*cs.refs.aTags));
+    cs.refs.nTags = 1;
+    cs.refs.aTags[0].zName = sqlite3_mprintf("v1");
+    check("alloc_tag_name", cs.refs.aTags[0].zName!=0);
   }
 
   check("serialize_refs_blob",
@@ -871,7 +871,7 @@ static void run_remote_refs_corruption(void){
   check("lock_remote_store", chunkStoreLockAndRefresh(&cs)==SQLITE_OK);
   check("put_bad_remote_refs",
         chunkStorePut(&cs, badBlob, (int)sizeof(badBlob), &badRefsHash)==SQLITE_OK);
-  memcpy(&cs.refsHash, &badRefsHash, sizeof(ProllyHash));
+  memcpy(&cs.refs.refsHash, &badRefsHash, sizeof(ProllyHash));
   check("commit_bad_remote_refs", chunkStoreCommit(&cs)==SQLITE_OK);
   chunkStoreUnlock(&cs);
   chunkStoreClose(&cs);
@@ -1990,8 +1990,8 @@ static void run_branches_metadata_corruption(void){
   check("lock_store", chunkStoreLockAndRefresh(&cs)==SQLITE_OK);
   {
     int i;
-    for(i=0; i<cs.nBranches; i++){
-      if( cs.aBranches[i].zName && strcmp(cs.aBranches[i].zName, "feature")==0 ){
+    for(i=0; i<cs.refs.nBranches; i++){
+      if( cs.refs.aBranches[i].zName && strcmp(cs.refs.aBranches[i].zName, "feature")==0 ){
         iFeature = i;
         break;
       }
@@ -1999,8 +1999,8 @@ static void run_branches_metadata_corruption(void){
   }
   check("have_feature_branch", iFeature >= 0);
   if( iFeature >= 0 ){
-    memcpy(&cs.aBranches[iFeature].commitHash, &badHash, sizeof(ProllyHash));
-    memcpy(&cs.aBranches[iFeature].workingSetHash, &badHash, sizeof(ProllyHash));
+    memcpy(&cs.refs.aBranches[iFeature].commitHash, &badHash, sizeof(ProllyHash));
+    memcpy(&cs.refs.aBranches[iFeature].workingSetHash, &badHash, sizeof(ProllyHash));
   }
   check("serialize_corrupt_branch_refs", chunkStoreSerializeRefs(&cs)==SQLITE_OK);
   check("commit_corrupt_branch_refs", chunkStoreCommit(&cs)==SQLITE_OK);
@@ -2266,10 +2266,10 @@ static void run_reload_refs_transactional(void){
         chunkStoreAddBranch(&cs, "main", &emptyHash)==SQLITE_OK);
   check("serialize_good_refs",
         chunkStoreSerializeRefs(&cs)==SQLITE_OK);
-  nBranchesBefore = cs.nBranches;
-  zDefaultBefore = sqlite3_mprintf("%s", cs.zDefaultBranch ? cs.zDefaultBranch : "");
-  zBranchBefore = (cs.aBranches && cs.nBranches>0 && cs.aBranches[0].zName)
-                ? sqlite3_mprintf("%s", cs.aBranches[0].zName)
+  nBranchesBefore = cs.refs.nBranches;
+  zDefaultBefore = sqlite3_mprintf("%s", cs.refs.zDefaultBranch ? cs.refs.zDefaultBranch : "");
+  zBranchBefore = (cs.refs.aBranches && cs.refs.nBranches>0 && cs.refs.aBranches[0].zName)
+                ? sqlite3_mprintf("%s", cs.refs.aBranches[0].zName)
                 : sqlite3_mprintf("");
 
   check("load_bad_refs_blob_as_chunk",
@@ -2278,23 +2278,23 @@ static void run_reload_refs_transactional(void){
   rc = chunkStoreLoadRefsFromBlob(&cs, badBlob, (int)sizeof(badBlob));
   check("load_refs_blob_returns_corrupt", rc==SQLITE_CORRUPT);
   check("load_refs_blob_preserves_default_branch",
-        cs.zDefaultBranch && strcmp(cs.zDefaultBranch, zDefaultBefore)==0);
-  check("load_refs_blob_preserves_branch_count", cs.nBranches==nBranchesBefore);
+        cs.refs.zDefaultBranch && strcmp(cs.refs.zDefaultBranch, zDefaultBefore)==0);
+  check("load_refs_blob_preserves_branch_count", cs.refs.nBranches==nBranchesBefore);
   check("load_refs_blob_preserves_branch_name",
         nBranchesBefore==0 ||
-        (cs.aBranches && cs.aBranches[0].zName
-         && strcmp(cs.aBranches[0].zName, zBranchBefore)==0));
+        (cs.refs.aBranches && cs.refs.aBranches[0].zName
+         && strcmp(cs.refs.aBranches[0].zName, zBranchBefore)==0));
 
-  memcpy(&cs.refsHash, &badHash, sizeof(badHash));
+  memcpy(&cs.refs.refsHash, &badHash, sizeof(badHash));
   rc = chunkStoreReloadRefs(&cs);
   check("reload_refs_returns_corrupt", rc==SQLITE_CORRUPT);
   check("reload_refs_preserves_default_branch",
-        cs.zDefaultBranch && strcmp(cs.zDefaultBranch, zDefaultBefore)==0);
-  check("reload_refs_preserves_branch_count", cs.nBranches==nBranchesBefore);
+        cs.refs.zDefaultBranch && strcmp(cs.refs.zDefaultBranch, zDefaultBefore)==0);
+  check("reload_refs_preserves_branch_count", cs.refs.nBranches==nBranchesBefore);
   check("reload_refs_preserves_branch_name",
         nBranchesBefore==0 ||
-        (cs.aBranches && cs.aBranches[0].zName
-         && strcmp(cs.aBranches[0].zName, zBranchBefore)==0));
+        (cs.refs.aBranches && cs.refs.aBranches[0].zName
+         && strcmp(cs.refs.aBranches[0].zName, zBranchBefore)==0));
 
   sqlite3_free(zDefaultBefore);
   sqlite3_free(zBranchBefore);
@@ -2329,11 +2329,11 @@ static void run_refresh_refs_corruption_preserves_state(void){
 
   check("open_store_1", chunkStoreOpen(&cs1, sqlite3_vfs_find(0), dbpath,
         SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB)==SQLITE_OK);
-  refsHashBefore = cs1.refsHash;
-  nBranchesBefore = cs1.nBranches;
-  zDefaultBefore = sqlite3_mprintf("%s", cs1.zDefaultBranch ? cs1.zDefaultBranch : "");
-  zBranchBefore = (cs1.aBranches && cs1.nBranches>0 && cs1.aBranches[0].zName)
-                ? sqlite3_mprintf("%s", cs1.aBranches[0].zName)
+  refsHashBefore = cs1.refs.refsHash;
+  nBranchesBefore = cs1.refs.nBranches;
+  zDefaultBefore = sqlite3_mprintf("%s", cs1.refs.zDefaultBranch ? cs1.refs.zDefaultBranch : "");
+  zBranchBefore = (cs1.refs.aBranches && cs1.refs.nBranches>0 && cs1.refs.aBranches[0].zName)
+                ? sqlite3_mprintf("%s", cs1.refs.aBranches[0].zName)
                 : sqlite3_mprintf("");
 
   check("open_store_2", chunkStoreOpen(&cs2, sqlite3_vfs_find(0), dbpath,
@@ -2341,7 +2341,7 @@ static void run_refresh_refs_corruption_preserves_state(void){
   check("lock_store_2", chunkStoreLockAndRefresh(&cs2)==SQLITE_OK);
   check("put_bad_refs_chunk",
         chunkStorePut(&cs2, badBlob, (int)sizeof(badBlob), &badHash)==SQLITE_OK);
-  memcpy(&cs2.refsHash, &badHash, sizeof(badHash));
+  memcpy(&cs2.refs.refsHash, &badHash, sizeof(badHash));
   check("commit_bad_refs_hash", chunkStoreCommit(&cs2)==SQLITE_OK);
   chunkStoreUnlock(&cs2);
   chunkStoreClose(&cs2);
@@ -2350,14 +2350,14 @@ static void run_refresh_refs_corruption_preserves_state(void){
   check("refresh_returns_error_for_corrupt_refs", rc==SQLITE_CORRUPT);
   check("refresh_does_not_mark_changed", changed==0);
   check("refresh_preserves_default_branch",
-        cs1.zDefaultBranch && strcmp(cs1.zDefaultBranch, zDefaultBefore)==0);
-  check("refresh_preserves_branch_count", cs1.nBranches==nBranchesBefore);
+        cs1.refs.zDefaultBranch && strcmp(cs1.refs.zDefaultBranch, zDefaultBefore)==0);
+  check("refresh_preserves_branch_count", cs1.refs.nBranches==nBranchesBefore);
   check("refresh_preserves_branch_name",
         nBranchesBefore==0 ||
-        (cs1.aBranches && cs1.aBranches[0].zName
-         && strcmp(cs1.aBranches[0].zName, zBranchBefore)==0));
+        (cs1.refs.aBranches && cs1.refs.aBranches[0].zName
+         && strcmp(cs1.refs.aBranches[0].zName, zBranchBefore)==0));
   check("refresh_preserves_refs_hash",
-        memcmp(&cs1.refsHash, &refsHashBefore, sizeof(ProllyHash))==0);
+        memcmp(&cs1.refs.refsHash, &refsHashBefore, sizeof(ProllyHash))==0);
   sqlite3_free(zDefaultBefore);
   sqlite3_free(zBranchBefore);
   chunkStoreClose(&cs1);
@@ -3097,8 +3097,8 @@ static void run_refresh_open_path_transactional(void){
   rc = chunkStoreRefreshIfChanged(&cs, &changed);
   check("refresh_open_path_returns_error", rc!=SQLITE_OK);
   check("refresh_open_path_does_not_mark_changed", changed==0);
-  check("refresh_open_path_preserves_empty_refs", prollyHashIsEmpty(&cs.refsHash));
-  check("refresh_open_path_preserves_branch_count", cs.nBranches==0);
+  check("refresh_open_path_preserves_empty_refs", prollyHashIsEmpty(&cs.refs.refsHash));
+  check("refresh_open_path_preserves_branch_count", cs.refs.nBranches==0);
 
   chunkStoreClose(&cs);
   removeDbFiles(dbpath);
@@ -6064,18 +6064,18 @@ static void run_chunk_store_rollback_restores_refs_hash(void){
         chunkStoreSerializeRefs(&cs)==SQLITE_OK);
   check("commit_initial_refs_for_refs_rollback",
         chunkStoreCommit(&cs)==SQLITE_OK);
-  refsHashBefore = cs.refsHash;
+  refsHashBefore = cs.refs.refsHash;
 
   check("add_tag_before_rollback",
         chunkStoreAddTag(&cs, "v1", &emptyHash)==SQLITE_OK);
   check("serialize_updated_refs_before_rollback",
         chunkStoreSerializeRefs(&cs)==SQLITE_OK);
   check("refs_hash_changed_before_rollback",
-        memcmp(&cs.refsHash, &refsHashBefore, sizeof(ProllyHash))!=0);
+        memcmp(&cs.refs.refsHash, &refsHashBefore, sizeof(ProllyHash))!=0);
 
   chunkStoreRollback(&cs);
   check("refs_hash_restored_on_rollback",
-        memcmp(&cs.refsHash, &refsHashBefore, sizeof(ProllyHash))==0);
+        memcmp(&cs.refs.refsHash, &refsHashBefore, sizeof(ProllyHash))==0);
   check("reload_refs_after_rollback", chunkStoreReloadRefs(&cs)==SQLITE_OK);
   check("tag_absent_after_reload_rollback",
         chunkStoreFindTag(&cs, "v1", &foundHash)!=SQLITE_OK);
@@ -6112,14 +6112,14 @@ static void run_chunk_store_commit_failure_restores_refs_hash(void){
         chunkStoreSerializeRefs(&cs)==SQLITE_OK);
   check("commit_initial_refs_for_refs_commit_failure",
         chunkStoreCommit(&cs)==SQLITE_OK);
-  refsHashBefore = cs.refsHash;
+  refsHashBefore = cs.refs.refsHash;
 
   check("add_tag_for_refs_commit_failure",
         chunkStoreAddTag(&cs, "v1", &emptyHash)==SQLITE_OK);
   check("serialize_updated_refs_for_refs_commit_failure",
         chunkStoreSerializeRefs(&cs)==SQLITE_OK);
   check("refs_hash_changed_for_refs_commit_failure",
-        memcmp(&cs.refsHash, &refsHashBefore, sizeof(ProllyHash))!=0);
+        memcmp(&cs.refs.refsHash, &refsHashBefore, sizeof(ProllyHash))!=0);
 
   gFailHits = 0;
   gFailSyncOnce = 1;
@@ -6127,7 +6127,7 @@ static void run_chunk_store_commit_failure_restores_refs_hash(void){
   check("commit_failure_injected_for_refs_commit_failure", gFailHits>0);
   check("commit_failure_surfaces_for_refs_commit_failure", rc!=SQLITE_OK);
   check("refs_hash_restored_on_commit_failure",
-        memcmp(&cs.refsHash, &refsHashBefore, sizeof(ProllyHash))==0);
+        memcmp(&cs.refs.refsHash, &refsHashBefore, sizeof(ProllyHash))==0);
   check("in_memory_tag_absent_after_commit_failure",
         chunkStoreFindTag(&cs, "v1", &foundHash)!=SQLITE_OK);
 
@@ -6144,7 +6144,7 @@ static void run_chunk_store_commit_failure_restores_refs_hash(void){
   check("reopened_store_has_no_failed_tag",
         chunkStoreFindTag(&reopened, "v1", &foundHash)!=SQLITE_OK);
   check("reopened_store_keeps_default_branch",
-        reopened.zDefaultBranch!=0 && strcmp(reopened.zDefaultBranch, "main")==0);
+        reopened.refs.zDefaultBranch!=0 && strcmp(reopened.refs.zDefaultBranch, "main")==0);
   chunkStoreClose(&reopened);
   removeDbFiles(dbpath);
 }
@@ -6177,14 +6177,14 @@ static void run_remotesrv_put_refs_failure_restores_state(void){
         chunkStoreSerializeRefs(&cs)==SQLITE_OK);
   check("commit_initial_refs_for_remotesrv_put_refs",
         chunkStoreCommit(&cs)==SQLITE_OK);
-  refsHashBefore = cs.refsHash;
+  refsHashBefore = cs.refs.refsHash;
 
   rc = doltliteRemoteSrvApplyRefsForTest(&cs, aBadRefs, (int)sizeof(aBadRefs));
   check("remotesrv_put_refs_reload_failure_surfaces", rc!=SQLITE_OK);
   check("remotesrv_put_refs_restores_refs_hash",
-        memcmp(&cs.refsHash, &refsHashBefore, sizeof(ProllyHash))==0);
+        memcmp(&cs.refs.refsHash, &refsHashBefore, sizeof(ProllyHash))==0);
   check("remotesrv_put_refs_keeps_default_branch",
-        cs.zDefaultBranch!=0 && strcmp(cs.zDefaultBranch, "main")==0);
+        cs.refs.zDefaultBranch!=0 && strcmp(cs.refs.zDefaultBranch, "main")==0);
   check("remotesrv_put_refs_keeps_main_branch",
         chunkStoreFindBranch(&cs, "main", &foundHash)==SQLITE_OK);
   check("remotesrv_put_refs_does_not_leave_failed_tag",


### PR DESCRIPTION
Second slice of the ChunkStore decomposition plan, following PR #873 (WalState).

## What this PR does

- **New `src/chunk_refs.{h,c}`** with `RefsTable` struct (branches, tags, remotes, tracking, refsHash, committedRefsHash, zDefaultBranch) and an accessor API:
  - `refsTableGetBranches/Tags/Remotes/Tracking(rt, &n, &arr)` — const array + count via output params (the iteration style you chose).
  - `refsTableBranchCount/TagCount/RemoteCount/TrackingCount` — for sites that only need the count.
  - `refsTableGetHash/SetHash/GetCommittedHash` — refsHash access.
  - `refsTableGetDefaultBranchName`.
- **ChunkStore embeds `RefsTable refs;`** — replaces 4 ref-array fields + counts + zDefaultBranch + 2 ProllyHashes.
- **chunk_store.c** (chunk_* internal) renames ~150 sites from `cs->aBranches` etc. to `cs->refs.aBranches`. Mechanical.
- **9 external files migrated to accessors**: doltlite_branch.c, doltlite_tag.c, doltlite_remote.c, doltlite_remote_sql.c, doltlite_remotesrv.c, doltlite.c, doltlite_commit_ancestors.c, doltlite_gc.c, prolly_btree.c. Iteration becomes:
  ```c
  int nBr; const BranchRef *aBr;
  refsTableGetBranches(&cs->refs, &nBr, &aBr);
  for (i = 0; i < nBr; i++) { ... aBr[i].zName ... }
  ```
  refsHash read/write goes through `refsTableGetHash` / `refsTableSetHash`.

## What's deliberately NOT here

- **Phase 2b: function-body moves.** The ~20 `chunkStoreAddBranch` / `chunkStoreFindTag` / `chunkStoreSerializeRefs` / ... function bodies and their static helpers (csFreeBranches, csDeserializeRefs, csCaptureSavedRefsState, etc.) still live in chunk_store.c. They use `cs->refs.*` now, so they work fine. Moving them is a pure code-organization step that doubles the diff — split out to keep this PR reviewable at ~930 lines.
- **No on-disk format change.** CHUNK_STORE_VERSION stays 11.

## Test plan

- [x] `make doltlite-lib` + `make doltlite` build clean
- [x] Smoke: `CREATE TABLE + dolt_commit + dolt_log` returns commit hash + log count
- [x] `make lint` passes (test/lint_layers.sh — chunk_refs.h is in the chunk_* layer)
- [ ] Full CI on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)