### PR TITLE
Fix remote refs update races

### DIFF
--- a/src/doltlite_http_remote.c
+++ b/src/doltlite_http_remote.c
@@ -33,6 +33,8 @@ struct HttpRemote {
 
   u8 *pPendingRefs;
   int nPendingRefs;
+  ProllyHash expectedRefsHash;
+  u8 hasExpectedRefsHash;
 };
 
 static void hashToHex(const ProllyHash *pHash, char *zOut){
@@ -144,6 +146,11 @@ static int httpRequest(
       "Connection: close\r\n"
       "\r\n",
       zMethod, zPath, zHost);
+  }
+
+  if( nReqHdr < 0 || nReqHdr >= (int)sizeof(aReqHdr) ){
+    close(fd);
+    return SQLITE_TOOBIG;
   }
 
   rc = doltliteWriteAll(fd, aReqHdr, nReqHdr);
@@ -405,6 +412,7 @@ static int httpSetRefs(DoltliteRemote *pRemote, const u8 *pData, int nData){
   sqlite3_free(p->pPendingRefs);
   p->pPendingRefs = 0;
   p->nPendingRefs = 0;
+  p->hasExpectedRefsHash = 0;
 
   if( pData && nData > 0 ){
     p->pPendingRefs = sqlite3_malloc(nData);
@@ -412,6 +420,24 @@ static int httpSetRefs(DoltliteRemote *pRemote, const u8 *pData, int nData){
     memcpy(p->pPendingRefs, pData, nData);
     p->nPendingRefs = nData;
   }
+  return SQLITE_OK;
+}
+
+static int httpSetRefsIf(
+  DoltliteRemote *pRemote,
+  const ProllyHash *pExpectedRefsHash,
+  const u8 *pData,
+  int nData
+){
+  HttpRemote *p = (HttpRemote*)pRemote;
+  int rc = httpSetRefs(pRemote, pData, nData);
+  if( rc!=SQLITE_OK ) return rc;
+  if( pExpectedRefsHash ){
+    memcpy(&p->expectedRefsHash, pExpectedRefsHash, sizeof(ProllyHash));
+  }else{
+    memset(&p->expectedRefsHash, 0, sizeof(ProllyHash));
+  }
+  p->hasExpectedRefsHash = 1;
   return SQLITE_OK;
 }
 
@@ -438,15 +464,30 @@ static int httpCommit(DoltliteRemote *pRemote){
 
   if( p->pPendingRefs && p->nPendingRefs > 0 ){
     pResp = 0; nResp = 0; status = 0;
-    zPath = buildPath(p, "/refs");
+    zPath = buildPath(p, p->hasExpectedRefsHash ? "/refs-if" : "/refs");
     if( !zPath ) return SQLITE_NOMEM;
 
-    rc = httpRequest(p->zHost, p->port, "PUT", zPath,
-                     p->pPendingRefs, p->nPendingRefs,
-                     &status, &pResp, &nResp);
+    if( p->hasExpectedRefsHash ){
+      u8 *pReq = sqlite3_malloc(PROLLY_HASH_SIZE + p->nPendingRefs);
+      if( !pReq ){
+        sqlite3_free(zPath);
+        return SQLITE_NOMEM;
+      }
+      memcpy(pReq, p->expectedRefsHash.data, PROLLY_HASH_SIZE);
+      memcpy(pReq + PROLLY_HASH_SIZE, p->pPendingRefs, p->nPendingRefs);
+      rc = httpRequest(p->zHost, p->port, "PUT", zPath,
+                       pReq, PROLLY_HASH_SIZE + p->nPendingRefs,
+                       &status, &pResp, &nResp);
+      sqlite3_free(pReq);
+    }else{
+      rc = httpRequest(p->zHost, p->port, "PUT", zPath,
+                       p->pPendingRefs, p->nPendingRefs,
+                       &status, &pResp, &nResp);
+    }
     sqlite3_free(zPath);
     sqlite3_free(pResp);
     if( rc != SQLITE_OK ) return rc;
+    if( status == 409 ) return SQLITE_BUSY;
     if( status != 200 && status != 204 ) return SQLITE_ERROR;
   }
 
@@ -467,6 +508,7 @@ static int httpCommit(DoltliteRemote *pRemote){
   p->pUploadBuf = 0;
   p->nUploadBuf = 0;
   p->nUploadBufAlloc = 0;
+  p->hasExpectedRefsHash = 0;
 
   sqlite3_free(p->pPendingRefs);
   p->pPendingRefs = 0;
@@ -565,6 +607,7 @@ DoltliteRemote *doltliteHttpRemoteOpen(const char *zUrl){
   p->base.xHasChunks = httpHasChunks;
   p->base.xGetRefs = httpGetRefs;
   p->base.xSetRefs = httpSetRefs;
+  p->base.xSetRefsIf = httpSetRefsIf;
   p->base.xCommit = httpCommit;
   p->base.xClose = httpClose;
 

--- a/src/doltlite_remote.c
+++ b/src/doltlite_remote.c
@@ -274,6 +274,7 @@ typedef struct FsRemote FsRemote;
 struct FsRemote {
   DoltliteRemote base;
   ChunkStore store;
+  int lockedForCas;
 };
 
 static int fsGetChunk(DoltliteRemote *pRemote, const ProllyHash *pHash,
@@ -334,6 +335,36 @@ static int fsSetRefs(DoltliteRemote *pRemote, const u8 *pData, int nData){
   return rc;
 }
 
+static int fsSetRefsIf(
+  DoltliteRemote *pRemote,
+  const ProllyHash *pExpectedRefsHash,
+  const u8 *pData,
+  int nData
+){
+  FsRemote *p = (FsRemote*)pRemote;
+  ProllyHash expected;
+  int rc;
+  if( pExpectedRefsHash ){
+    memcpy(&expected, pExpectedRefsHash, sizeof(expected));
+  }else{
+    memset(&expected, 0, sizeof(expected));
+  }
+  rc = chunkStoreLockAndRefresh(&p->store);
+  if( rc!=SQLITE_OK ) return rc;
+  p->lockedForCas = 1;
+  if( prollyHashCompare(refsTableGetHash(&p->store.refs), &expected)!=0 ){
+    chunkStoreUnlock(&p->store);
+    p->lockedForCas = 0;
+    return SQLITE_BUSY;
+  }
+  rc = fsSetRefs(pRemote, pData, nData);
+  if( rc!=SQLITE_OK ){
+    chunkStoreUnlock(&p->store);
+    p->lockedForCas = 0;
+  }
+  return rc;
+}
+
 static int remoteStorePersistRefs(ChunkStore *pStore){
   int rc = chunkStoreSerializeRefs(pStore);
   if( rc==SQLITE_OK ) rc = chunkStoreCommit(pStore);
@@ -342,11 +373,17 @@ static int remoteStorePersistRefs(ChunkStore *pStore){
 
 static int fsCommit(DoltliteRemote *pRemote){
   FsRemote *p = (FsRemote*)pRemote;
-  return remoteStorePersistRefs(&p->store);
+  int rc = remoteStorePersistRefs(&p->store);
+  if( p->lockedForCas ){
+    chunkStoreUnlock(&p->store);
+    p->lockedForCas = 0;
+  }
+  return rc;
 }
 
 static void fsClose(DoltliteRemote *pRemote){
   FsRemote *p = (FsRemote*)pRemote;
+  if( p->lockedForCas ) chunkStoreUnlock(&p->store);
   chunkStoreClose(&p->store);
   sqlite3_free(p);
 }
@@ -365,6 +402,7 @@ DoltliteRemote *doltliteFsRemoteOpen(sqlite3_vfs *pVfs, const char *zPath){
   p->base.xHasChunks = fsHasChunks;
   p->base.xGetRefs = fsGetRefs;
   p->base.xSetRefs = fsSetRefs;
+  p->base.xSetRefsIf = fsSetRefsIf;
   p->base.xCommit = fsCommit;
   p->base.xClose = fsClose;
 
@@ -430,6 +468,25 @@ static int localSetRefs(DoltliteRemote *pRemote, const u8 *pData, int nData){
   return rc;
 }
 
+static int localSetRefsIf(
+  DoltliteRemote *pRemote,
+  const ProllyHash *pExpectedRefsHash,
+  const u8 *pData,
+  int nData
+){
+  LocalAsRemote *p = (LocalAsRemote*)pRemote;
+  ProllyHash expected;
+  if( pExpectedRefsHash ){
+    memcpy(&expected, pExpectedRefsHash, sizeof(expected));
+  }else{
+    memset(&expected, 0, sizeof(expected));
+  }
+  if( prollyHashCompare(refsTableGetHash(&p->pStore->refs), &expected)!=0 ){
+    return SQLITE_BUSY;
+  }
+  return localSetRefs(pRemote, pData, nData);
+}
+
 static int localCommit(DoltliteRemote *pRemote){
   LocalAsRemote *p = (LocalAsRemote*)pRemote;
   return chunkStoreCommit(p->pStore);
@@ -450,6 +507,7 @@ DoltliteRemote *doltliteLocalAsRemote(ChunkStore *pLocal){
   p->base.xHasChunks = localHasChunks;
   p->base.xGetRefs = localGetRefs;
   p->base.xSetRefs = localSetRefs;
+  p->base.xSetRefsIf = localSetRefsIf;
   p->base.xCommit = localCommit;
   p->base.xClose = localClose;
   p->pStore = pLocal;
@@ -546,9 +604,12 @@ int doltlitePush(
   ProllyHash localCommit;
   ProllyHash localCatalog;
   ProllyHash remoteCommit;
+  ProllyHash expectedRefsHash;
+  u8 *refsData = 0;
+  int nRefsData = 0;
   int rc;
-  int i;
 
+  memset(&expectedRefsHash, 0, sizeof(expectedRefsHash));
   rc = chunkStoreFindBranch(pLocal, zBranch, &localCommit);
   if( rc!=SQLITE_OK ){
     return SQLITE_ERROR;
@@ -557,10 +618,20 @@ int doltlitePush(
   rc = remoteLoadCommitCatalogHash(pLocal, &localCommit, &localCatalog);
   if( rc!=SQLITE_OK ) return rc;
 
+  rc = pRemote->xGetRefs(pRemote, &refsData, &nRefsData);
+  if( rc==SQLITE_OK && refsData ){
+    prollyHashCompute(refsData, nRefsData, &expectedRefsHash);
+  }else if( rc==SQLITE_NOTFOUND ){
+    refsData = 0;
+    nRefsData = 0;
+    rc = SQLITE_OK;
+  }
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(refsData);
+    return rc;
+  }
+
   if( !bForce ){
-    u8 *refsData = 0;
-    int nRefsData = 0;
-    rc = pRemote->xGetRefs(pRemote, &refsData, &nRefsData);
     if( rc==SQLITE_OK && refsData ){
       rc = remoteFindBranchFromRefsBlob(refsData, nRefsData, zBranch, &remoteCommit);
       if( rc==SQLITE_OK && !prollyHashIsEmpty(&remoteCommit)
@@ -571,17 +642,16 @@ int doltlitePush(
           return isAnc<0 ? SQLITE_NOMEM : SQLITE_ERROR;
         }
       }
-      sqlite3_free(refsData);
       if( rc==SQLITE_NOTFOUND ){
         rc = SQLITE_OK;
       }else if( rc!=SQLITE_OK ){
+        sqlite3_free(refsData);
         return rc;
       }
-    }else if( rc==SQLITE_NOTFOUND ){
-      rc = SQLITE_OK;
     }
-    if( rc!=SQLITE_OK ) return rc;
   }
+  sqlite3_free(refsData);
+  refsData = 0;
 
   {
     DoltliteRemote *pLocalSrc = doltliteLocalAsRemote(pLocal);
@@ -651,7 +721,11 @@ int doltlitePush(
       chunkStoreClose(&tmpCs);
       if( rc!=SQLITE_OK ) return rc;
 
-      rc = pRemote->xSetRefs(pRemote, newRefs, nNewRefs);
+      if( pRemote->xSetRefsIf ){
+        rc = pRemote->xSetRefsIf(pRemote, &expectedRefsHash, newRefs, nNewRefs);
+      }else{
+        rc = pRemote->xSetRefs(pRemote, newRefs, nNewRefs);
+      }
       sqlite3_free(newRefs);
       if( rc!=SQLITE_OK ) return rc;
     }

--- a/src/doltlite_remote.h
+++ b/src/doltlite_remote.h
@@ -10,6 +10,7 @@ struct DoltliteRemote {
   int (*xHasChunks)(DoltliteRemote*, const ProllyHash*, int nHash, u8 *aResult);
   int (*xGetRefs)(DoltliteRemote*, u8**, int*);
   int (*xSetRefs)(DoltliteRemote*, const u8*, int);
+  int (*xSetRefsIf)(DoltliteRemote*, const ProllyHash*, const u8*, int);
   int (*xCommit)(DoltliteRemote*);
   void (*xClose)(DoltliteRemote*);
 };

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -361,7 +361,8 @@ static void doltPushFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   if( rc!=SQLITE_OK ){
     (void)doltliteVcSealSavepointError(db);
     remoteSqlResultError(ctx, rc,
-      rc==SQLITE_ERROR ? "push failed (not a fast-forward?)" : 0);
+      rc==SQLITE_BUSY ? "push failed (remote refs changed)"
+      : rc==SQLITE_ERROR ? "push failed (not a fast-forward?)" : 0);
     return;
   }
   sqlite3_result_int(ctx, 0);

--- a/src/doltlite_remotesrv.c
+++ b/src/doltlite_remotesrv.c
@@ -92,6 +92,10 @@ static void sendPayloadTooLarge(int fd){
                (const u8*)"Payload Too Large", 17);
 }
 
+static void sendConflict(int fd){
+  sendResponse(fd, 409, "Conflict", (const u8*)"Conflict", 8);
+}
+
 static int remoteSrvCommitPending(ChunkStore *pStore){
   int rc = chunkStoreCommit(pStore);
   if( rc!=SQLITE_OK ){
@@ -295,6 +299,11 @@ static void handleHasChunks(ChunkStore *pStore, int fd,
     return;
   }
   memset(aResult, 0, nHashes);
+  if( !pStore ){
+    sendOk(fd, aResult, nHashes);
+    sqlite3_free(aResult);
+    return;
+  }
 
   rc = chunkStoreHasMany(pStore, (const ProllyHash*)pBody,
                          nHashes, aResult);
@@ -431,6 +440,26 @@ static int remoteSrvApplyRefs(ChunkStore *pStore, const u8 *pBody, int nBody){
   }
   return remoteSrvCommitPending(pStore);
 }
+
+static int remoteSrvApplyRefsIf(
+  ChunkStore *pStore,
+  const ProllyHash *pExpectedRefsHash,
+  const u8 *pBody,
+  int nBody
+){
+  int rc;
+  if( nBody<=0 ) return SQLITE_ERROR;
+  rc = chunkStoreLockAndRefresh(pStore);
+  if( rc!=SQLITE_OK ) return rc;
+  if( prollyHashCompare(refsTableGetHash(&pStore->refs), pExpectedRefsHash)!=0 ){
+    chunkStoreUnlock(pStore);
+    return SQLITE_BUSY;
+  }
+  rc = remoteSrvApplyRefs(pStore, pBody, nBody);
+  chunkStoreUnlock(pStore);
+  return rc;
+}
+
 static void handlePutRefs(ChunkStore *pStore, int fd,
                           const u8 *pBody, int nBody){
   int rc;
@@ -441,6 +470,32 @@ static void handlePutRefs(ChunkStore *pStore, int fd,
   }
 
   rc = remoteSrvApplyRefs(pStore, pBody, nBody);
+  if( rc!=SQLITE_OK ){
+    sendError(fd);
+    return;
+  }
+
+  sendOk(fd, 0, 0);
+}
+
+static void handlePutRefsIf(ChunkStore *pStore, int fd,
+                            const u8 *pBody, int nBody){
+  ProllyHash expectedRefsHash;
+  int rc;
+
+  if( nBody<=PROLLY_HASH_SIZE ){
+    sendBadRequest(fd);
+    return;
+  }
+  memcpy(expectedRefsHash.data, pBody, PROLLY_HASH_SIZE);
+
+  rc = remoteSrvApplyRefsIf(pStore, &expectedRefsHash,
+                            pBody + PROLLY_HASH_SIZE,
+                            nBody - PROLLY_HASH_SIZE);
+  if( rc==SQLITE_BUSY ){
+    sendConflict(fd);
+    return;
+  }
   if( rc!=SQLITE_OK ){
     sendError(fd);
     return;
@@ -482,6 +537,10 @@ static void handleRequest(DoltliteServer *pSrv, int fd){
   char zDbPath[1024];
   int rc;
   int flags;
+  int isReadOnlyEndpoint = 0;
+  int isHasChunksEndpoint = 0;
+  int exists = 0;
+  sqlite3_vfs *pVfs;
 
   rc = parseRequest(fd, zMethod, sizeof(zMethod),
                     zPath, sizeof(zPath), &pBody, &nBody);
@@ -507,9 +566,32 @@ static void handleRequest(DoltliteServer *pSrv, int fd){
   }
 
   sqlite3_snprintf(sizeof(zDbPath), zDbPath, "%s/%s", pSrv->zDir, zDbName);
-  flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB;
+  isHasChunksEndpoint = strcmp(zMethod, "POST")==0
+                     && strcmp(zEndpoint, "has-chunks")==0;
+  isReadOnlyEndpoint = strcmp(zMethod, "GET")==0 || isHasChunksEndpoint;
+  pVfs = sqlite3_vfs_find(0);
+  rc = pVfs->xAccess(pVfs, zDbPath, SQLITE_ACCESS_EXISTS, &exists);
+  if( rc!=SQLITE_OK ){
+    sendError(fd);
+    sqlite3_free(pBody);
+    return;
+  }
+  if( !exists && isHasChunksEndpoint ){
+    handleHasChunks(0, fd, pBody, nBody);
+    sqlite3_free(pBody);
+    return;
+  }
+  if( !exists && isReadOnlyEndpoint ){
+    sendNotFound(fd);
+    sqlite3_free(pBody);
+    return;
+  }
+
+  flags = isReadOnlyEndpoint
+        ? (SQLITE_OPEN_READONLY | SQLITE_OPEN_MAIN_DB)
+        : (SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB);
   memset(&store, 0, sizeof(store));
-  rc = chunkStoreOpen(&store, sqlite3_vfs_find(0), zDbPath, flags);
+  rc = chunkStoreOpen(&store, pVfs, zDbPath, flags);
   if( rc!=SQLITE_OK ){
     sendError(fd);
     sqlite3_free(pBody);
@@ -539,6 +621,8 @@ static void handleRequest(DoltliteServer *pSrv, int fd){
   }else if( strcmp(zMethod, "PUT")==0 ){
     if( strcmp(zEndpoint, "refs")==0 ){
       handlePutRefs(&store, fd, pBody, nBody);
+    }else if( strcmp(zEndpoint, "refs-if")==0 ){
+      handlePutRefsIf(&store, fd, pBody, nBody);
     }else{
       sendNotFound(fd);
     }

--- a/test/http_remote_test.sh
+++ b/test/http_remote_test.sh
@@ -59,6 +59,8 @@ cat > "$TMPDIR/http_test.c" << 'CEOF'
 #include <dlfcn.h>
 #include "sqlite3.h"
 #include "doltlite_remotesrv.h"
+#include "doltlite_remote.h"
+#include "prolly_hash.h"
 
 static int gShortWriteOnce = 0;
 
@@ -144,6 +146,11 @@ static int query_int(sqlite3 *db, const char *sql) {
   return val;
 }
 
+static int file_exists(const char *path) {
+  struct stat st;
+  return stat(path, &st) == 0;
+}
+
 static int raw_http_status(int port, const char *path) {
   int fd, n;
   struct sockaddr_in addr;
@@ -201,7 +208,7 @@ static int raw_http_status(int port, const char *path) {
   else { printf("  FAIL: %s\n    expected: |%s|\n    actual:   |%s|\n", desc, _e, _a); fail++; } \
 } while(0)
 
-#define HTTP_TEST_EXPECTED_ASSERTIONS 51
+#define HTTP_TEST_EXPECTED_ASSERTIONS 59
 
 int main(int argc, char **argv) {
   int pass = 0, fail = 0;
@@ -253,9 +260,17 @@ int main(int argc, char **argv) {
   CHECK("dot path returns 404", 404, raw_http_status(port, "/./root"));
 
   /* ============================================================
-   * 2c. Short-write transport handling
+   * 2c. Read-only requests do not create missing databases
    * ============================================================ */
-  printf("=== 2c. Short-write transport handling ===\n");
+  printf("=== 2c. Missing read does not create DB ===\n");
+  snprintf(path, sizeof(path), "%s/missing_read.db", srvdir);
+  CHECK("missing refs returns 404", 404, raw_http_status(port, "/missing_read.db/refs"));
+  CHECK("missing refs did not create file", 0, file_exists(path));
+
+  /* ============================================================
+   * 2d. Short-write transport handling
+   * ============================================================ */
+  printf("=== 2d. Short-write transport handling ===\n");
   enable_short_write_once();
   CHECK("server response survives short write", 200, raw_http_status(port, "/src.db/root"));
   sqlite3 *shortCloneDb;
@@ -266,6 +281,20 @@ int main(int argc, char **argv) {
   CHECK("client request survives short write", SQLITE_OK, run_sql(shortCloneDb, sql));
   CHECK("short-write clone has 3 users", 3, query_int(shortCloneDb, "SELECT count(*) FROM users"));
   sqlite3_close(shortCloneDb);
+
+  /* ============================================================
+   * 2e. Oversized HTTP request headers are rejected before write
+   * ============================================================ */
+  printf("=== 2e. Long HTTP URL rejected ===\n");
+  sqlite3 *longUrlDb;
+  char longName[1800];
+  memset(longName, 'a', sizeof(longName)-1);
+  longName[sizeof(longName)-1] = 0;
+  snprintf(path, sizeof(path), "%s/long_url.db", tmpdir);
+  sqlite3_open(path, &longUrlDb);
+  snprintf(sql, sizeof(sql), "SELECT dolt_clone('http://127.0.0.1:%d/%s')", port, longName);
+  CHECK("long URL clone errors", 1, run_sql_quiet(longUrlDb, sql) != SQLITE_OK);
+  sqlite3_close(longUrlDb);
 
   /* ============================================================
    * 3. Clone via HTTP - verify all data, branch, remote, history
@@ -303,6 +332,48 @@ int main(int argc, char **argv) {
     query_str(cloneDb, "SELECT commit_hash FROM dolt_log LIMIT 1"),
     query_str(verifyDb, "SELECT commit_hash FROM dolt_log LIMIT 1"));
   sqlite3_close(verifyDb);
+
+  /* ============================================================
+   * 4b. Stale conditional refs update is rejected
+   * ============================================================ */
+  printf("=== 4b. Stale refs update rejected ===\n");
+  {
+    char url[256];
+    u8 *oldRefs = 0;
+    int nOldRefs = 0;
+    ProllyHash oldRefsHash;
+    DoltliteRemote *staleRemote;
+    snprintf(path, sizeof(path), "%s/cas.db", srvdir);
+    sqlite3_open(path, &verifyDb);
+    run_sql(verifyDb, "CREATE TABLE cas_t(id INTEGER PRIMARY KEY, v TEXT)");
+    run_sql(verifyDb, "INSERT INTO cas_t VALUES(1,'base')");
+    run_sql(verifyDb, "SELECT dolt_add('-A')");
+    run_sql(verifyDb, "SELECT dolt_commit('-m','cas base')");
+    sqlite3_close(verifyDb);
+
+    snprintf(url, sizeof(url), "http://127.0.0.1:%d/cas.db", port);
+    staleRemote = doltliteHttpRemoteOpen(url);
+    CHECK("open stale remote", 1, staleRemote != 0);
+    CHECK("read stale refs", SQLITE_OK, staleRemote->xGetRefs(staleRemote, &oldRefs, &nOldRefs));
+    prollyHashCompute(oldRefs, nOldRefs, &oldRefsHash);
+
+    sqlite3_open(path, &verifyDb);
+    run_sql(verifyDb, "INSERT INTO cas_t VALUES(2,'server_only')");
+    run_sql(verifyDb, "SELECT dolt_add('-A')");
+    run_sql(verifyDb, "SELECT dolt_commit('-m','server-only advance')");
+    sqlite3_close(verifyDb);
+
+    CHECK("buffer stale refs-if", SQLITE_OK,
+      staleRemote->xSetRefsIf(staleRemote, &oldRefsHash, oldRefs, nOldRefs));
+    CHECK("stale refs-if commit rejected", SQLITE_BUSY, staleRemote->xCommit(staleRemote));
+    staleRemote->xClose(staleRemote);
+    sqlite3_free(oldRefs);
+
+    sqlite3_open(path, &verifyDb);
+    CHECK_STR("server head kept newer commit", "server-only advance",
+      query_str(verifyDb, "SELECT message FROM dolt_log LIMIT 1"));
+    sqlite3_close(verifyDb);
+  }
 
   /* ============================================================
    * 5. Fetch in original - tracking branch updated, local unchanged
@@ -665,7 +736,12 @@ CEOF
 # Build the test
 cd "$TMPDIR"
 BUILD_DIR="$(dirname "$DOLTLITE")"
-cc -g -O0 -I"$BUILD_DIR" -I"$BUILD_DIR/../src" \
+if [ -d "$BUILD_DIR/src" ]; then
+  SRC_DIR="$BUILD_DIR/src"
+else
+  SRC_DIR="$BUILD_DIR/../src"
+fi
+cc -g -O0 -I"$BUILD_DIR" -I"$SRC_DIR" \
   -DDOLTLITE_PROLLY=1 -D_HAVE_SQLITE_CONFIG_H -DBUILD_sqlite \
   -o http_test http_test.c \
   "$BUILD_DIR/libdoltlite.a" -lz -lpthread -lm 2>&1


### PR DESCRIPTION
## Summary
- add conditional refs updates for remote pushes so stale push state is rejected instead of overwriting newer refs
- make HTTP refs updates use a server-side compare-and-set endpoint
- prevent read-only HTTP remote requests from creating missing database files
- reject oversized HTTP request headers before writing past the client stack buffer

## Tests
- make doltlite doltlite-remotesrv
- make doltlite-lib
- ./test/http_remote_test.sh ./doltlite
- ./test/remote_test.sh ./doltlite
- ./test/vc_oracle_remotes_test.sh ./doltlite dolt
- git diff --check -- src/doltlite_remote.h src/doltlite_remote.c src/doltlite_http_remote.c src/doltlite_remotesrv.c src/doltlite_remote_sql.c test/http_remote_test.sh