### PR TITLE
refactor: extract ChunkIndex from ChunkStore (decomposition phase 3)

### DIFF
--- a/main.mk
+++ b/main.mk
@@ -575,7 +575,7 @@ else
 endif
 
 PROLLY_OBJS = prolly_hash.o prolly_xxhash.o blake3.o blake3_portable.o blake3_dispatch.o $(BLAKE3_SIMD_OBJS) prolly_hashset.o prolly_node.o prolly_cache.o \
-              chunk_store.o chunk_wal.o chunk_refs.o prolly_cursor.o prolly_mutmap.o prolly_chunker.o \
+              chunk_store.o chunk_wal.o chunk_refs.o chunk_index.o prolly_cursor.o prolly_mutmap.o prolly_chunker.o \
               prolly_mutate.o prolly_diff.o prolly_three_way_diff.o prolly_three_way_merge.o prolly_btree.o pager_shim.o sortkey.o \
               doltlite.o doltlite_commit.o doltlite_ref.o doltlite_log.o doltlite_commit_ancestors.o doltlite_status.o \
               doltlite_diff.o doltlite_diff_table.o doltlite_branch.o doltlite_tag.o doltlite_ancestor.o doltlite_merge.o doltlite_schema_merge.o doltlite_conflicts.o \
@@ -1388,6 +1388,10 @@ chunk_wal.o:	$(TOP)/src/chunk_wal.c $(DEPS_OBJ_COMMON)
 
 chunk_refs.o:	$(TOP)/src/chunk_refs.c $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/chunk_refs.c
+
+chunk_index.o:	$(TOP)/src/chunk_index.c $(DEPS_OBJ_COMMON)
+	$(T.cc.sqlite) -c $(TOP)/src/chunk_index.c
+
 prolly_cursor.o:	$(TOP)/src/prolly_cursor.c $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/prolly_cursor.c
 

--- a/src/chunk_index.c
+++ b/src/chunk_index.c
@@ -1,0 +1,50 @@
+
+#ifdef DOLTLITE_PROLLY
+
+#include "chunk_index.h"
+#include <string.h>
+
+void chunkIndexInit(ChunkIndex *idx){
+  memset(idx, 0, sizeof(*idx));
+}
+
+void chunkIndexReset(ChunkIndex *idx){
+  memset(idx, 0, sizeof(*idx));
+}
+
+void chunkIndexGetEntries(const ChunkIndex *idx, int *pn, const ChunkIndexEntry **par){
+  *pn = idx->nIndex;
+  *par = idx->aIndex;
+}
+
+int chunkIndexCount(const ChunkIndex *idx){
+  return idx->nIndex;
+}
+
+int chunkIndexNChunks(const ChunkIndex *idx){
+  return idx->nChunks;
+}
+
+i64 chunkIndexOffset(const ChunkIndex *idx){
+  return idx->iIndexOffset;
+}
+
+i64 chunkIndexSize(const ChunkIndex *idx){
+  return idx->nIndexSize;
+}
+
+void chunkIndexSetMetadata(ChunkIndex *idx, int nChunks, i64 iOffset, i64 nSize){
+  idx->nChunks = nChunks;
+  idx->iIndexOffset = iOffset;
+  idx->nIndexSize = nSize;
+}
+
+void chunkIndexReplaceEntries(ChunkIndex *idx, ChunkIndexEntry *aNew, int nNew){
+  sqlite3_free(idx->aIndex);
+  idx->aIndex = aNew;
+  idx->nIndex = nNew;
+  idx->aIndexMmapBase = 0;
+  idx->aIndexMmapSize = 0;
+}
+
+#endif

--- a/src/chunk_index.h
+++ b/src/chunk_index.h
@@ -1,0 +1,52 @@
+
+#ifndef DOLTLITE_CHUNK_INDEX_H
+#define DOLTLITE_CHUNK_INDEX_H
+
+#include "sqliteInt.h"
+#include "prolly_hash.h"
+
+typedef struct ChunkIndexEntry ChunkIndexEntry;
+typedef struct ChunkIndex ChunkIndex;
+
+#if defined(__GNUC__) || defined(__clang__)
+#  define DOLTLITE_PACKED __attribute__((__packed__))
+#elif defined(_MSC_VER)
+#  define DOLTLITE_PACKED
+#  pragma pack(push, 1)
+#else
+#  define DOLTLITE_PACKED
+#endif
+
+struct DOLTLITE_PACKED ChunkIndexEntry {
+  ProllyHash hash;
+  i64 offset;
+  int size;
+};
+
+#if defined(_MSC_VER)
+#  pragma pack(pop)
+#endif
+
+struct ChunkIndex {
+  ChunkIndexEntry *aIndex;
+  int nIndex;
+  void *aIndexMmapBase;
+  i64 aIndexMmapSize;
+  int nChunks;
+  i64 iIndexOffset;
+  i64 nIndexSize;
+};
+
+void chunkIndexInit(ChunkIndex *idx);
+void chunkIndexReset(ChunkIndex *idx);
+
+void chunkIndexGetEntries(const ChunkIndex *idx, int *pn, const ChunkIndexEntry **par);
+int chunkIndexCount(const ChunkIndex *idx);
+int chunkIndexNChunks(const ChunkIndex *idx);
+i64 chunkIndexOffset(const ChunkIndex *idx);
+i64 chunkIndexSize(const ChunkIndex *idx);
+
+void chunkIndexSetMetadata(ChunkIndex *idx, int nChunks, i64 iOffset, i64 nSize);
+void chunkIndexReplaceEntries(ChunkIndex *idx, ChunkIndexEntry *aNew, int nNew);
+
+#endif

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -404,27 +404,27 @@ static void csFreeSavedRefsState(SavedRefsState *pSaved){
 
 static void csCaptureReplayState(ChunkStore *cs, ChunkStoreReplayState *pSaved){
   memset(pSaved, 0, sizeof(*pSaved));
-  pSaved->aIndex = cs->aIndex;
-  pSaved->nIndex = cs->nIndex;
-  pSaved->aIndexMmapBase = cs->aIndexMmapBase;
-  pSaved->aIndexMmapSize = cs->aIndexMmapSize;
+  pSaved->aIndex = cs->index.aIndex;
+  pSaved->nIndex = cs->index.nIndex;
+  pSaved->aIndexMmapBase = cs->index.aIndexMmapBase;
+  pSaved->aIndexMmapSize = cs->index.aIndexMmapSize;
   csCaptureSavedRefsState(cs, &pSaved->refs);
 }
 
 static void csRestoreReplayState(ChunkStore *cs, const ChunkStoreReplayState *pSaved){
-  cs->aIndex = pSaved->aIndex;
-  cs->nIndex = pSaved->nIndex;
-  cs->aIndexMmapBase = pSaved->aIndexMmapBase;
-  cs->aIndexMmapSize = pSaved->aIndexMmapSize;
+  cs->index.aIndex = pSaved->aIndex;
+  cs->index.nIndex = pSaved->nIndex;
+  cs->index.aIndexMmapBase = pSaved->aIndexMmapBase;
+  cs->index.aIndexMmapSize = pSaved->aIndexMmapSize;
   csRestoreSavedRefsState(cs, &pSaved->refs);
 }
 
 static void csCaptureReloadState(ChunkStore *cs, ChunkStoreReloadState *pSaved){
   memset(pSaved, 0, sizeof(*pSaved));
   pSaved->pFile = cs->pFile;
-  pSaved->aIndex = cs->aIndex;
-  pSaved->aIndexMmapBase = cs->aIndexMmapBase;
-  pSaved->aIndexMmapSize = cs->aIndexMmapSize;
+  pSaved->aIndex = cs->index.aIndex;
+  pSaved->aIndexMmapBase = cs->index.aIndexMmapBase;
+  pSaved->aIndexMmapSize = cs->index.aIndexMmapSize;
   csCaptureSavedRefsState(cs, &pSaved->refs);
 }
 
@@ -432,7 +432,7 @@ static void csReleaseReplayState(
   ChunkStore *cs,
   ChunkStoreReplayState *pSaved
 ){
-  if( cs->aIndex!=pSaved->aIndex ){
+  if( cs->index.aIndex!=pSaved->aIndex ){
     csReleaseIndexBuf(pSaved->aIndex, pSaved->aIndexMmapBase,
                        pSaved->aIndexMmapSize);
   }
@@ -445,8 +445,8 @@ static void csRollbackReplayState(
   ChunkStoreReplayState *pSaved,
   int nPendingBefore
 ){
-  if( cs->aIndex!=pSaved->aIndex ){
-    csReleaseIndexBuf(cs->aIndex, cs->aIndexMmapBase, cs->aIndexMmapSize);
+  if( cs->index.aIndex!=pSaved->aIndex ){
+    csReleaseIndexBuf(cs->index.aIndex, cs->index.aIndexMmapBase, cs->index.aIndexMmapSize);
   }
   csRestoreReplayState(cs, pSaved);
   cs->nPending = nPendingBefore;
@@ -464,15 +464,15 @@ static void csAdoptOpenedStoreState(ChunkStore *pDst, ChunkStore *pSrc){
   pDst->readOnly = pSrc->readOnly;
   pDst->refs.refsHash = pSrc->refs.refsHash;
   pDst->refs.committedRefsHash = pSrc->refs.committedRefsHash;
-  pDst->nChunks = pSrc->nChunks;
-  pDst->iIndexOffset = pSrc->iIndexOffset;
-  pDst->nIndexSize = pSrc->nIndexSize;
+  pDst->index.nChunks = pSrc->index.nChunks;
+  pDst->index.iIndexOffset = pSrc->index.iIndexOffset;
+  pDst->index.nIndexSize = pSrc->index.nIndexSize;
   pDst->wal.iWalOffset = pSrc->wal.iWalOffset;
   pDst->iFileSize = pSrc->iFileSize;
-  pDst->aIndex = pSrc->aIndex;
-  pDst->nIndex = pSrc->nIndex;
-  pDst->aIndexMmapBase = pSrc->aIndexMmapBase;
-  pDst->aIndexMmapSize = pSrc->aIndexMmapSize;
+  pDst->index.aIndex = pSrc->index.aIndex;
+  pDst->index.nIndex = pSrc->index.nIndex;
+  pDst->index.aIndexMmapBase = pSrc->index.aIndexMmapBase;
+  pDst->index.aIndexMmapSize = pSrc->index.aIndexMmapSize;
   pDst->wal.nWalData = pSrc->wal.nWalData;
   pDst->refs.aBranches = pSrc->refs.aBranches;
   pDst->refs.nBranches = pSrc->refs.nBranches;
@@ -485,10 +485,10 @@ static void csAdoptOpenedStoreState(ChunkStore *pDst, ChunkStore *pSrc){
   pDst->refs.nTracking = pSrc->refs.nTracking;
 
   pSrc->pFile = 0;
-  pSrc->aIndex = 0;
-  pSrc->nIndex = 0;
-  pSrc->aIndexMmapBase = 0;
-  pSrc->aIndexMmapSize = 0;
+  pSrc->index.aIndex = 0;
+  pSrc->index.nIndex = 0;
+  pSrc->index.aIndexMmapBase = 0;
+  pSrc->index.aIndexMmapSize = 0;
   pSrc->wal.nWalData = 0;
   pSrc->refs.aBranches = 0;
   pSrc->refs.nBranches = 0;
@@ -814,9 +814,9 @@ void csSerializeManifest(const ChunkStore *cs, u8 *aBuf){
   CS_WRITE_U32(aBuf + 0, CHUNK_STORE_MAGIC);
   CS_WRITE_U32(aBuf + 4, CHUNK_STORE_VERSION);
 
-  CS_WRITE_U32(aBuf + 28, (u32)cs->nChunks);
-  CS_WRITE_I64(aBuf + 32, cs->iIndexOffset);
-  CS_WRITE_U32(aBuf + 40, (u32)cs->nIndexSize);
+  CS_WRITE_U32(aBuf + 28, (u32)cs->index.nChunks);
+  CS_WRITE_I64(aBuf + 32, cs->index.iIndexOffset);
+  CS_WRITE_U32(aBuf + 40, (u32)cs->index.nIndexSize);
 
   CS_WRITE_I64(aBuf + 84, cs->wal.iWalOffset);
   memcpy(aBuf + 104, cs->refs.refsHash.data, PROLLY_HASH_SIZE);
@@ -851,9 +851,9 @@ static int csReadManifest(ChunkStore *cs){
     return SQLITE_NOTADB;
   }
 
-  cs->nChunks = (int)CS_READ_U32(aBuf + 28);
-  cs->iIndexOffset = CS_READ_I64(aBuf + 32);
-  cs->nIndexSize = (i64)CS_READ_U32(aBuf + 40);
+  cs->index.nChunks = (int)CS_READ_U32(aBuf + 28);
+  cs->index.iIndexOffset = CS_READ_I64(aBuf + 32);
+  cs->index.nIndexSize = (i64)CS_READ_U32(aBuf + 40);
 
   cs->wal.iWalOffset = CS_READ_I64(aBuf + 84);
   memcpy(cs->refs.refsHash.data, aBuf + 104, PROLLY_HASH_SIZE);
@@ -872,13 +872,13 @@ static int csReadIndex(ChunkStore *cs){
   const u8 *pMapData = 0;
   i64 fileSize = 0;
 
-  if( cs->nIndexSize == 0 || cs->nChunks == 0 ){
-    cs->nIndex = 0;
+  if( cs->index.nIndexSize == 0 || cs->index.nChunks == 0 ){
+    cs->index.nIndex = 0;
     return SQLITE_OK;
   }
 
-  nEntries64 = cs->nIndexSize / CHUNK_INDEX_ENTRY_SIZE;
-  if( nEntries64 * CHUNK_INDEX_ENTRY_SIZE != cs->nIndexSize ){
+  nEntries64 = cs->index.nIndexSize / CHUNK_INDEX_ENTRY_SIZE;
+  if( nEntries64 * CHUNK_INDEX_ENTRY_SIZE != cs->index.nIndexSize ){
     return SQLITE_CORRUPT;
   }
   if( nEntries64 > INT_MAX ){
@@ -890,7 +890,7 @@ static int csReadIndex(ChunkStore *cs){
   ** past EOF can return zero-filled or sparse pages on some platforms,
   ** which causes csSearchIndex to read garbage and SIGBUS instead of
   ** returning SQLITE_CORRUPT. See issue #827. */
-  if( cs->iIndexOffset < 0 || cs->nIndexSize < 0 ){
+  if( cs->index.iIndexOffset < 0 || cs->index.nIndexSize < 0 ){
     return SQLITE_CORRUPT;
   }
   if( cs->pFile ){
@@ -902,54 +902,54 @@ static int csReadIndex(ChunkStore *cs){
     fileSize = (i64)st.st_size;
   }
   if( fileSize > 0
-   && (cs->iIndexOffset > fileSize
-       || cs->nIndexSize > fileSize - cs->iIndexOffset) ){
+   && (cs->index.iIndexOffset > fileSize
+       || cs->index.nIndexSize > fileSize - cs->index.iIndexOffset) ){
     return SQLITE_CORRUPT;
   }
 
   if( cs->zFilename
-   && csMapIndex(cs->zFilename, cs->iIndexOffset, cs->nIndexSize,
+   && csMapIndex(cs->zFilename, cs->index.iIndexOffset, cs->index.nIndexSize,
                   &pMapBase, &nMapSize, &pMapData) == SQLITE_OK ){
-    cs->aIndex = (ChunkIndexEntry *)pMapData;
-    cs->nIndex = nEntries;
-    cs->aIndexMmapBase = pMapBase;
-    cs->aIndexMmapSize = nMapSize;
+    cs->index.aIndex = (ChunkIndexEntry *)pMapData;
+    cs->index.nIndex = nEntries;
+    cs->index.aIndexMmapBase = pMapBase;
+    cs->index.aIndexMmapSize = nMapSize;
     return SQLITE_OK;
   }
 
-  cs->aIndex = (ChunkIndexEntry *)sqlite3_malloc(
+  cs->index.aIndex = (ChunkIndexEntry *)sqlite3_malloc(
     nEntries * (int)sizeof(ChunkIndexEntry)
   );
-  if( cs->aIndex == 0 ) return SQLITE_NOMEM;
-  cs->nIndex = nEntries;
-  cs->aIndexMmapBase = 0;
-  cs->aIndexMmapSize = 0;
+  if( cs->index.aIndex == 0 ) return SQLITE_NOMEM;
+  cs->index.nIndex = nEntries;
+  cs->index.aIndexMmapBase = 0;
+  cs->index.aIndexMmapSize = 0;
 
-  aBuf = (u8 *)sqlite3_malloc64(cs->nIndexSize);
+  aBuf = (u8 *)sqlite3_malloc64(cs->index.nIndexSize);
   if( aBuf == 0 ){
-    sqlite3_free(cs->aIndex);
-    cs->aIndex = 0;
-    cs->nIndex = 0;
+    sqlite3_free(cs->index.aIndex);
+    cs->index.aIndex = 0;
+    cs->index.nIndex = 0;
     return SQLITE_NOMEM;
   }
 
-  rc = sqlite3OsRead(cs->pFile, aBuf, cs->nIndexSize, cs->iIndexOffset);
+  rc = sqlite3OsRead(cs->pFile, aBuf, cs->index.nIndexSize, cs->index.iIndexOffset);
   if( rc != SQLITE_OK ){
     sqlite3_free(aBuf);
-    sqlite3_free(cs->aIndex);
-    cs->aIndex = 0;
-    cs->nIndex = 0;
+    sqlite3_free(cs->index.aIndex);
+    cs->index.aIndex = 0;
+    cs->index.nIndex = 0;
     return rc;
   }
 
   for( i = 0; i < nEntries; i++ ){
     rc = csDeserializeIndexEntry(aBuf + i * CHUNK_INDEX_ENTRY_SIZE,
-                                 &cs->aIndex[i]);
+                                 &cs->index.aIndex[i]);
     if( rc != SQLITE_OK ){
       sqlite3_free(aBuf);
-      sqlite3_free(cs->aIndex);
-      cs->aIndex = 0;
-      cs->nIndex = 0;
+      sqlite3_free(cs->index.aIndex);
+      cs->index.aIndex = 0;
+      cs->index.nIndex = 0;
       return rc;
     }
   }
@@ -1031,7 +1031,7 @@ static int csReplayWal(ChunkStore *cs){
     cs->iFileSize = fileSize;
   }
   if( walSize <= 0 ){
-    if( cs->nIndex==0 && cs->nChunks==0
+    if( cs->index.nIndex==0 && cs->index.nChunks==0
      && !prollyHashIsEmpty(&cs->refs.refsHash) ){
       memset(cs->refs.refsHash.data, 0, PROLLY_HASH_SIZE);
     }
@@ -1067,7 +1067,7 @@ static int csReplayWal(ChunkStore *cs){
       }
 
       {
-        int existing = csSearchIndex(cs->aIndex, cs->nIndex, &hash);
+        int existing = csSearchIndex(cs->index.aIndex, cs->index.nIndex, &hash);
         ChunkIndexEntry *e = 0;
         if( existing < 0 ){
           rc = csGrowPending(cs);
@@ -1095,7 +1095,7 @@ static int csReplayWal(ChunkStore *cs){
           break;
         }
 
-        cs->nChunks = (int)CS_READ_U32(m + 28);
+        cs->index.nChunks = (int)CS_READ_U32(m + 28);
 
         memcpy(cs->refs.refsHash.data, m + 104, PROLLY_HASH_SIZE);
       }
@@ -1112,9 +1112,9 @@ static int csReplayWal(ChunkStore *cs){
   cs->nPending = nRootedPending;
 
   if( nRootRecordsSeen == 0
-   && nPendingBefore == 0 && cs->nIndex == 0 ){
+   && nPendingBefore == 0 && cs->index.nIndex == 0 ){
     memset(cs->refs.refsHash.data, 0, PROLLY_HASH_SIZE);
-    cs->nChunks = 0;
+    cs->index.nChunks = 0;
   }
 
   if( cs->nPending > 0 ){
@@ -1122,10 +1122,10 @@ static int csReplayWal(ChunkStore *cs){
     int nMerged = 0;
     rc = csMergeIndex(cs, &aMerged, &nMerged);
     if( rc != SQLITE_OK ) goto replay_error;
-    cs->aIndex = aMerged;
-    cs->nIndex = nMerged;
-    cs->aIndexMmapBase = 0;
-    cs->aIndexMmapSize = 0;
+    cs->index.aIndex = aMerged;
+    cs->index.nIndex = nMerged;
+    cs->index.aIndexMmapBase = 0;
+    cs->index.aIndexMmapSize = 0;
     cs->nPending = 0;
     csPendHTClear(cs);
   }
@@ -1193,7 +1193,7 @@ static int csMergeIndex(
   ChunkIndexEntry **ppMerged,
   int *pnMerged
 ){
-  int nTotal = cs->nIndex + cs->nPending;
+  int nTotal = cs->index.nIndex + cs->nPending;
   ChunkIndexEntry *aMerged;
   int idxPos, pendPos, outPos;
 
@@ -1218,22 +1218,22 @@ static int csMergeIndex(
       ChunkIndexEntry *pPending = &cs->aPending[pendPos];
       int found;
       int nCopy;
-      int pos = csIndexLowerBound(cs->aIndex, cs->nIndex, idxPos,
+      int pos = csIndexLowerBound(cs->index.aIndex, cs->index.nIndex, idxPos,
                                   &pPending->hash);
       nCopy = pos - idxPos;
       if( nCopy > 0 ){
-        memcpy(&aMerged[outPos], &cs->aIndex[idxPos],
+        memcpy(&aMerged[outPos], &cs->index.aIndex[idxPos],
                nCopy * sizeof(ChunkIndexEntry));
         outPos += nCopy;
       }
-      found = pos < cs->nIndex
-           && prollyHashCompare(&cs->aIndex[pos].hash, &pPending->hash)==0;
+      found = pos < cs->index.nIndex
+           && prollyHashCompare(&cs->index.aIndex[pos].hash, &pPending->hash)==0;
       aMerged[outPos++] = *pPending;
       idxPos = found ? pos + 1 : pos;
     }
-    if( idxPos < cs->nIndex ){
-      int nCopy = cs->nIndex - idxPos;
-      memcpy(&aMerged[outPos], &cs->aIndex[idxPos],
+    if( idxPos < cs->index.nIndex ){
+      int nCopy = cs->index.nIndex - idxPos;
+      memcpy(&aMerged[outPos], &cs->index.aIndex[idxPos],
              nCopy * sizeof(ChunkIndexEntry));
       outPos += nCopy;
     }
@@ -1245,10 +1245,10 @@ static int csMergeIndex(
   idxPos = 0;
   pendPos = 0;
   outPos = 0;
-  while( idxPos < cs->nIndex && pendPos < cs->nPending ){
-    int cmp = prollyHashCompare(&cs->aIndex[idxPos].hash, &cs->aPending[pendPos].hash);
+  while( idxPos < cs->index.nIndex && pendPos < cs->nPending ){
+    int cmp = prollyHashCompare(&cs->index.aIndex[idxPos].hash, &cs->aPending[pendPos].hash);
     if( cmp < 0 ){
-      aMerged[outPos++] = cs->aIndex[idxPos++];
+      aMerged[outPos++] = cs->index.aIndex[idxPos++];
     }else if( cmp > 0 ){
       aMerged[outPos++] = cs->aPending[pendPos++];
     }else{
@@ -1257,7 +1257,7 @@ static int csMergeIndex(
       idxPos++;
     }
   }
-  while( idxPos < cs->nIndex ) aMerged[outPos++] = cs->aIndex[idxPos++];
+  while( idxPos < cs->index.nIndex ) aMerged[outPos++] = cs->index.aIndex[idxPos++];
   while( pendPos < cs->nPending ) aMerged[outPos++] = cs->aPending[pendPos++];
 
   *ppMerged = aMerged;
@@ -1284,9 +1284,9 @@ int chunkStoreOpen(
     cs->isMemory = 1;
     cs->zFilename = sqlite3_mprintf(":memory:");
     if( cs->zFilename==0 ) return SQLITE_NOMEM;
-    cs->nChunks = 0;
-    cs->iIndexOffset = 0;
-    cs->nIndexSize = 0;
+    cs->index.nChunks = 0;
+    cs->index.iIndexOffset = 0;
+    cs->index.nIndexSize = 0;
     cs->wal.iWalOffset = CHUNK_MANIFEST_SIZE;
     cs->pFile = 0;
     return SQLITE_OK;
@@ -1352,7 +1352,7 @@ int chunkStoreOpen(
       return rc;
     }
 
-    if( prollyHashIsEmpty(&cs->refs.refsHash) && cs->nIndexSize>0 ){
+    if( prollyHashIsEmpty(&cs->refs.refsHash) && cs->index.nIndexSize>0 ){
       chunkStoreClose(cs);
       return SQLITE_CORRUPT;
     }
@@ -1380,9 +1380,9 @@ int chunkStoreOpen(
       cs->zFilename = 0;
       return SQLITE_CANTOPEN;
     }
-    cs->nChunks = 0;
-    cs->iIndexOffset = 0;
-    cs->nIndexSize = 0;
+    cs->index.nChunks = 0;
+    cs->index.iIndexOffset = 0;
+    cs->index.nIndexSize = 0;
 
     cs->wal.iWalOffset = CHUNK_MANIFEST_SIZE;
     cs->iFileSize = 0;
@@ -1400,10 +1400,10 @@ int chunkStoreClose(ChunkStore *cs){
     cs->pFile = 0;
   }
   sqlite3_free(cs->zFilename);
-  csReleaseIndexBuf(cs->aIndex, cs->aIndexMmapBase, cs->aIndexMmapSize);
-  cs->aIndex = 0;
-  cs->aIndexMmapBase = 0;
-  cs->aIndexMmapSize = 0;
+  csReleaseIndexBuf(cs->index.aIndex, cs->index.aIndexMmapBase, cs->index.aIndexMmapSize);
+  cs->index.aIndex = 0;
+  cs->index.aIndexMmapBase = 0;
+  cs->index.aIndexMmapSize = 0;
   sqlite3_free(cs->aPending);
   sqlite3_free(cs->aRecent);
   csPendHTClear(cs);
@@ -1999,7 +1999,7 @@ int chunkStoreHas(ChunkStore *cs, const ProllyHash *hash, int *pHas){
   int idx = -1;
   int rc;
   *pHas = 0;
-  if( csSearchIndex(cs->aIndex, cs->nIndex, hash) >= 0 ){
+  if( csSearchIndex(cs->index.aIndex, cs->index.nIndex, hash) >= 0 ){
     *pHas = 1;
     return SQLITE_OK;
   }
@@ -2049,11 +2049,11 @@ int chunkStoreGet(
     if( idx >= 0 ){
       e = &cs->aRecent[idx];
     }else{
-      idx = csSearchIndex(cs->aIndex, cs->nIndex, hash);
+      idx = csSearchIndex(cs->index.aIndex, cs->index.nIndex, hash);
       if( idx < 0 ){
         return SQLITE_NOTFOUND;
       }
-      e = &cs->aIndex[idx];
+      e = &cs->index.aIndex[idx];
     }
 
     if( cs->pFile == 0 ){
@@ -2125,7 +2125,7 @@ int chunkStorePut(
   prollyHashCompute(pData, nData, &h);
   if( pHash ) memcpy(pHash, &h, sizeof(ProllyHash));
 
-  if( csSearchIndex(cs->aIndex, cs->nIndex, &h) >= 0 ) return SQLITE_OK;
+  if( csSearchIndex(cs->index.aIndex, cs->index.nIndex, &h) >= 0 ) return SQLITE_OK;
   rc = csSearchRecent(cs, &h, &idx);
   if( rc!=SQLITE_OK ) return rc;
   if( idx >= 0 ) return SQLITE_OK;
@@ -2162,11 +2162,11 @@ static int csCommitToMemory(ChunkStore *cs){
     int nMem = 0;
     int rc = csMergeIndex(cs, &aMem, &nMem);
     if( rc!=SQLITE_OK ) return rc;
-    csReleaseIndexBuf(cs->aIndex, cs->aIndexMmapBase, cs->aIndexMmapSize);
-    cs->aIndex = aMem;
-    cs->nIndex = nMem;
-    cs->aIndexMmapBase = 0;
-    cs->aIndexMmapSize = 0;
+    csReleaseIndexBuf(cs->index.aIndex, cs->index.aIndexMmapBase, cs->index.aIndexMmapSize);
+    cs->index.aIndex = aMem;
+    cs->index.nIndex = nMem;
+    cs->index.aIndexMmapBase = 0;
+    cs->index.aIndexMmapSize = 0;
     cs->nPending = 0;
     csPendHTClear(cs);
     cs->nCommittedWriteBuf = cs->nWriteBuf;
@@ -2435,11 +2435,11 @@ commit_done:
       cs->nRecent += cs->nPending;
       sqlite3_free(aMerged);
     }else{
-      csReleaseIndexBuf(cs->aIndex, cs->aIndexMmapBase, cs->aIndexMmapSize);
-      cs->aIndex = aMerged;
-      cs->nIndex = nMerged;
-      cs->aIndexMmapBase = 0;
-      cs->aIndexMmapSize = 0;
+      csReleaseIndexBuf(cs->index.aIndex, cs->index.aIndexMmapBase, cs->index.aIndexMmapSize);
+      cs->index.aIndex = aMerged;
+      cs->index.nIndex = nMerged;
+      cs->index.aIndexMmapBase = 0;
+      cs->index.aIndexMmapSize = 0;
       cs->nRecent = 0;
       csRecentHTClear(cs);
     }

--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -7,6 +7,7 @@
 #include "prolly_hash.h"
 #include "chunk_wal.h"
 #include "chunk_refs.h"
+#include "chunk_index.h"
 
 #define CHUNK_STORE_MAGIC 0x444C5443
 #define CHUNK_STORE_VERSION 11
@@ -68,7 +69,6 @@ static SQLITE_INLINE int catalogParseHeader(
 }
 
 typedef struct ChunkStore ChunkStore;
-typedef struct ChunkIndexEntry ChunkIndexEntry;
 typedef struct ConflictEntry ConflictEntry;
 
 struct ConflictEntry {
@@ -79,25 +79,6 @@ struct ConflictEntry {
   u8 *pTheirVal;
   int nTheirVal;
 };
-
-#if defined(__GNUC__) || defined(__clang__)
-#  define DOLTLITE_PACKED __attribute__((__packed__))
-#elif defined(_MSC_VER)
-#  define DOLTLITE_PACKED
-#  pragma pack(push, 1)
-#else
-#  define DOLTLITE_PACKED
-#endif
-
-struct DOLTLITE_PACKED ChunkIndexEntry {
-  ProllyHash hash;
-  i64 offset;
-  int size;
-};
-
-#if defined(_MSC_VER)
-#  pragma pack(pop)
-#endif
 
 #if defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 #  define CHUNK_STORE_LE_PACKING 1
@@ -111,19 +92,9 @@ struct ChunkStore {
   sqlite3_vfs *pVfs;
   RefsTable refs;
 
-  int nChunks;
-  i64 iIndexOffset;
-  i64 nIndexSize;
+  ChunkIndex index;
   WalState wal;
   i64 iFileSize;
-
-  /* aIndex is the durable sorted manifest. Small commits append into aRecent
-  ** first so readers can find new chunks without rewriting the manifest. */
-  ChunkIndexEntry *aIndex;
-  int nIndex;
-
-  void *aIndexMmapBase;
-  i64 aIndexMmapSize;
 
   ChunkIndexEntry *aPending;
   int nPending;

--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -213,8 +213,12 @@ static int gcBuildCompactedData(
   i64 dataOffset = CHUNK_MANIFEST_SIZE;
   int rc = SQLITE_OK;
 
-  for(i=0; i<cs->nIndex; i++){
-    if( prollyHashSetContains(marked, &cs->aIndex[i].hash) ) kept++;
+  {
+    int nIdx; const ChunkIndexEntry *aIdx;
+    chunkIndexGetEntries(&cs->index, &nIdx, &aIdx);
+    for(i=0; i<nIdx; i++){
+      if( prollyHashSetContains(marked, &aIdx[i].hash) ) kept++;
+    }
   }
   for(i=0; i<cs->nRecent; i++){
     if( prollyHashSetContains(marked, &cs->aRecent[i].hash) ) kept++;
@@ -223,13 +227,17 @@ static int gcBuildCompactedData(
   aNewIndex = sqlite3_malloc((kept ? kept : 1) * (int)sizeof(ChunkIndexEntry));
   if( !aNewIndex ) return SQLITE_NOMEM;
 
-  for(i=0; i<cs->nIndex; i++){
-    rc = gcAppendMarkedChunk(cs, &cs->aIndex[i].hash, marked, &buf, &nBuf,
-                             &nBufAlloc, dataOffset, aNewIndex, &nNewIndex);
-    if( rc!=SQLITE_OK ){
-      sqlite3_free(aNewIndex);
-      sqlite3_free(buf);
-      return rc;
+  {
+    int nIdx; const ChunkIndexEntry *aIdx;
+    chunkIndexGetEntries(&cs->index, &nIdx, &aIdx);
+    for(i=0; i<nIdx; i++){
+      rc = gcAppendMarkedChunk(cs, &aIdx[i].hash, marked, &buf, &nBuf,
+                               &nBufAlloc, dataOffset, aNewIndex, &nNewIndex);
+      if( rc!=SQLITE_OK ){
+        sqlite3_free(aNewIndex);
+        sqlite3_free(buf);
+        return rc;
+      }
     }
   }
   for(i=0; i<cs->nRecent; i++){
@@ -314,9 +322,7 @@ static int gcRewriteFile(
   }
 
   manifestCs = *cs;
-  manifestCs.nChunks = nNewIndex;
-  manifestCs.iIndexOffset = indexOffset;
-  manifestCs.nIndexSize = indexSize;
+  chunkIndexSetMetadata(&manifestCs.index, nNewIndex, indexOffset, indexSize);
   walStateSetOffset(&manifestCs.wal, indexOffset + indexSize);
 
   csSerializeManifest(&manifestCs, manifest);
@@ -457,11 +463,15 @@ static int gcSweep(
   int nBuf = 0;
   int rc = SQLITE_OK;
 
-  for(i=0; i<cs->nIndex; i++){
-    if( prollyHashSetContains(marked, &cs->aIndex[i].hash) ){
-      kept++;
-    }else{
-      removed++;
+  {
+    int nIdx; const ChunkIndexEntry *aIdx;
+    chunkIndexGetEntries(&cs->index, &nIdx, &aIdx);
+    for(i=0; i<nIdx; i++){
+      if( prollyHashSetContains(marked, &aIdx[i].hash) ){
+        kept++;
+      }else{
+        removed++;
+      }
     }
   }
   for(i=0; i<cs->nPending; i++){
@@ -488,12 +498,9 @@ static int gcSweep(
 
   if( rc==SQLITE_OK ){
     int indexSize = nNewIndex * CHUNK_INDEX_ENTRY_SIZE;
-    sqlite3_free(cs->aIndex);
-    cs->aIndex = aNewIndex;
-    cs->nIndex = nNewIndex;
-    cs->nChunks = nNewIndex;
-    cs->iIndexOffset = CHUNK_MANIFEST_SIZE + nBuf;
-    cs->nIndexSize = indexSize;
+    chunkIndexReplaceEntries(&cs->index, aNewIndex, nNewIndex);
+    chunkIndexSetMetadata(&cs->index, nNewIndex,
+                          CHUNK_MANIFEST_SIZE + nBuf, indexSize);
     walStateSetOffset(&cs->wal, CHUNK_MANIFEST_SIZE + nBuf + indexSize);
     aNewIndex = 0;
 
@@ -553,7 +560,7 @@ static void doltliteGcFunc(
     return;
   }
 
-  rc = prollyHashSetInit(&marked, cs->nIndex > 64 ? cs->nIndex : 64);
+  rc = prollyHashSetInit(&marked, chunkIndexCount(&cs->index) > 64 ? chunkIndexCount(&cs->index) : 64);
   if( rc!=SQLITE_OK ){
     chunkStoreUnlock(cs);
     sqlite3_result_error(context, "out of memory", -1);
@@ -596,7 +603,7 @@ int doltliteGcCompact(sqlite3 *db){
   rc = chunkStoreLockAndRefresh(cs);
   if( rc!=SQLITE_OK ) return rc;
 
-  rc = prollyHashSetInit(&marked, cs->nIndex > 64 ? cs->nIndex : 64);
+  rc = prollyHashSetInit(&marked, chunkIndexCount(&cs->index) > 64 ? chunkIndexCount(&cs->index) : 64);
   if( rc!=SQLITE_OK ){
     chunkStoreUnlock(cs);
     return rc;

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -2410,9 +2410,9 @@ static void run_memory_chunk_lookup_corruption(void){
         chunkStorePut(&cs, payload, (int)sizeof(payload), &h)==SQLITE_OK);
   check("commit_mem_store_lookup",
         chunkStoreCommit(&cs)==SQLITE_OK);
-  check("have_committed_index_entry", cs.nIndex > 0);
-  if( cs.nIndex > 0 ){
-    cs.aIndex[0].offset = cs.nWriteBuf + 100;
+  check("have_committed_index_entry", cs.index.nIndex > 0);
+  if( cs.index.nIndex > 0 ){
+    cs.index.aIndex[0].offset = cs.nWriteBuf + 100;
   }
   rc = chunkStoreGet(&cs, &h, &pOut, &nOut);
   check("memory_lookup_corruption_returns_corrupt", rc==SQLITE_CORRUPT);
@@ -3130,8 +3130,8 @@ static void run_wal_offset_corruption_is_rejected(void){
         SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB)==SQLITE_OK);
   {
     int i;
-    for(i=0; i<cs.nIndex; i++){
-      if( cs.aIndex[i].offset >= walStateGetOffset(&cs.wal) ){
+    for(i=0; i<cs.index.nIndex; i++){
+      if( cs.index.aIndex[i].offset >= walStateGetOffset(&cs.wal) ){
         iWal = i;
         break;
       }
@@ -3139,8 +3139,8 @@ static void run_wal_offset_corruption_is_rejected(void){
   }
   check("have_wal_backed_index_entry", iWal >= 0);
   if( iWal >= 0 ){
-    cs.aIndex[iWal].offset = cs.iFileSize + 1024;
-    rc = chunkStoreGet(&cs, &cs.aIndex[iWal].hash, &pData, &nData);
+    cs.index.aIndex[iWal].offset = cs.iFileSize + 1024;
+    rc = chunkStoreGet(&cs, &cs.index.aIndex[iWal].hash, &pData, &nData);
     check("corrupt_wal_offset_returns_error", rc!=SQLITE_OK);
   }
   sqlite3_free(pData);
@@ -3180,12 +3180,12 @@ static void run_integrity_check_walks_prolly_nodes(void){
         SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB)==SQLITE_OK);
   if( pTable ){
     int i;
-    for(i=0; i<cs.nIndex; i++){
-      if( prollyHashCompare(&cs.aIndex[i].hash, &pTable->root)==0 ){
-        if( cs.aIndex[i].offset < 0 ){
-          dataOff = walStateGetOffset(&cs.wal) + (-(cs.aIndex[i].offset + 1));
+    for(i=0; i<cs.index.nIndex; i++){
+      if( prollyHashCompare(&cs.index.aIndex[i].hash, &pTable->root)==0 ){
+        if( cs.index.aIndex[i].offset < 0 ){
+          dataOff = walStateGetOffset(&cs.wal) + (-(cs.index.aIndex[i].offset + 1));
         }else{
-          dataOff = cs.aIndex[i].offset + 4;
+          dataOff = cs.index.aIndex[i].offset + 4;
         }
         break;
       }


### PR DESCRIPTION
Third slice of the ChunkStore decomposition plan, following PR #873 (WalState) and PR #875 (RefsTable).

## What this PR does

- **New `src/chunk_index.{h,c}`** with `ChunkIndex` struct (the index entries, mmap state, and on-disk footprint metadata) and an accessor API:
  - `chunkIndexGetEntries(idx, &n, &arr)` — const array iteration (same shape as refs accessors).
  - `chunkIndexCount / NChunks / Offset / Size` — read scalars.
  - `chunkIndexSetMetadata(idx, nChunks, iOffset, nSize)` — set the three on-disk-footprint fields atomically (used by GC's temp manifest construction).
  - `chunkIndexReplaceEntries(idx, aNew, nNew)` — frees old array and takes ownership of new (used by GC's swap).
- **ChunkStore embeds `ChunkIndex index;`** — 7 fields consolidated. `ChunkIndexEntry` (the packed struct) lives in chunk_index.h now; chunk_store.h includes it.
- **chunk_store.c** (chunk_* internal): ~100 sites renamed mechanically.
- **doltlite_gc.c** (sole external consumer, 14 sites) migrated to accessors:
  - Iteration uses `int nIdx; const ChunkIndexEntry *aIdx; chunkIndexGetEntries(...)` blocks.
  - The GC bulk swap (5 lines of direct field mutation) becomes one `chunkIndexReplaceEntries` + one `chunkIndexSetMetadata`.
  - The GC temp-manifest construction (3 lines of direct field mutation on a local ChunkStore copy) becomes one `chunkIndexSetMetadata`.
- **test/doltlite_regression_test_c.c**: preemptively migrated the 13 white-box-test sites.

## Story of the debugging detour

While verifying I hit a confusing failure on `have_wal_backed_index_entry` — `iWalOffset=0`, `nChunks=garbage`. After ~30 minutes of investigation it turned out to be **stale build artifacts**: `make doltlite-lib` wasn't recompiling `chunk_store.c` for some dependency reason. After `rm build/chunk_store.o build/libdoltlite.a && make`, everything passed. No real regression. The Makefile dependencies might be worth tightening, but that's outside this PR's scope.

## Test plan

- [x] `make doltlite-lib` + `make doltlite` clean
- [x] Smoke: CREATE TABLE + dolt_commit returns commit hash
- [x] `wal_offset_corruption`, `truncated_wal_rejected`, `reload_refs_transactional` regression tests pass locally
- [x] `make lint` passes (test/lint_layers.sh)
- [ ] Full CI

## What's NOT here

- No on-disk format change. CHUNK_STORE_VERSION stays 11.
- The static helpers in chunk_store.c that operate on the index (csReadIndex, csSearchIndex, csMergeIndex, csDeserializeIndexEntry, csMapIndex/Unmap) stay in chunk_store.c for now. Same pattern as Phase 2a — moving function bodies is a follow-up tidiness step.

## Plan it's part of

1. ✅ WalState (#873)
2. ✅ RefsTable (#875)
3. **ChunkIndex (this PR)**
4. ChunkStaging — pending + recent + write buffer
5. Cleanup — coordinator-thin ChunkStore

🤖 Generated with [Claude Code](https://claude.com/claude-code)