### PR TITLE
Harden catalog and zeroblob bounds checks

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -2128,7 +2128,9 @@ static int deserializeCatalog(Btree *pBtree, const u8 *data, int nData){
     u8 flags;
     struct TableEntry *pTE;
     int nLen;
-    if( q+4+1+PROLLY_HASH_SIZE > data+nData ) return SQLITE_CORRUPT;
+    if( q+4+1+PROLLY_HASH_SIZE+PROLLY_HASH_SIZE > data+nData ){
+      return SQLITE_CORRUPT;
+    }
     iTable = (Pgno)(q[0] | (q[1]<<8) | (q[2]<<16) | (q[3]<<24));
     q += 4;
     flags = *q++;
@@ -2136,10 +2138,8 @@ static int deserializeCatalog(Btree *pBtree, const u8 *data, int nData){
     if( !pTE ) return SQLITE_NOMEM;
     memcpy(pTE->root.data, q, PROLLY_HASH_SIZE);
     q += PROLLY_HASH_SIZE;
-    if( q + PROLLY_HASH_SIZE <= data+nData ){
-      memcpy(pTE->schemaHash.data, q, PROLLY_HASH_SIZE);
-      q += PROLLY_HASH_SIZE;
-    }
+    memcpy(pTE->schemaHash.data, q, PROLLY_HASH_SIZE);
+    q += PROLLY_HASH_SIZE;
     if( iFormat==CATALOG_FORMAT_V4 ){
       int nType, nName, nTbl;
       const u8 *pType, *pName, *pTbl;
@@ -2158,9 +2158,11 @@ static int deserializeCatalog(Btree *pBtree, const u8 *data, int nData){
         memcpy(pTE->zName, pName, nName);
         pTE->zName[nName] = 0;
       }
-    }else if( q+2 <= data+nData ){
+    }else{
+      if( q+2 > data+nData ) return SQLITE_CORRUPT;
       nLen = q[0] | (q[1]<<8); q += 2;
-      if( nLen>0 && q+nLen<=data+nData ){
+      if( q+nLen > data+nData ) return SQLITE_CORRUPT;
+      if( nLen>0 ){
         pTE->zName = sqlite3_malloc(nLen+1);
         if( pTE->zName ){
           memcpy(pTE->zName, q, nLen);
@@ -2168,10 +2170,12 @@ static int deserializeCatalog(Btree *pBtree, const u8 *data, int nData){
         }else{
           return SQLITE_NOMEM;
         }
-        q += nLen;
       }
+      q += nLen;
     }
   }
+
+  if( q!=data+nData ) return SQLITE_CORRUPT;
 
   {
     Pgno maxPage = 0;
@@ -6195,10 +6199,15 @@ static int prollyBtCursorInsert(
   if( pCur->curIntKey ){
     const u8 *pData = (const u8*)pPayload->pData;
     int nData = pPayload->nData;
-    int nTotal = nData + pPayload->nZero;
+    i64 nTotal64 = (i64)nData + (i64)pPayload->nZero;
+    int nTotal;
     u8 *pBuf = 0;
 
-    if( pPayload->nZero > 0 && nTotal > nData ){
+    if( nData<0 || pPayload->nZero<0 || nTotal64 > 0x7fffffff ){
+      return SQLITE_TOOBIG;
+    }
+    nTotal = (int)nTotal64;
+    if( pPayload->nZero > 0 ){
       pBuf = sqlite3_malloc(nTotal);
       if( !pBuf ) return SQLITE_NOMEM;
       if( nData > 0 ){

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -949,6 +949,63 @@ static void run_chunk_walk_corruption(void){
   }
 }
 
+static void init_v3_catalog_blob(u8 *aCat, int nCat, u16 nName){
+  memset(aCat, 0, nCat);
+  aCat[0] = CATALOG_FORMAT_V3;
+  aCat[1] = 1;
+  aCat[5] = 2;
+  aCat[9] = BTREE_INTKEY;
+  aCat[50] = (u8)nName;
+  aCat[51] = (u8)(nName >> 8);
+  if( nName>0 && nCat>52 ){
+    aCat[52] = 't';
+  }
+}
+
+static void run_catalog_deserialize_corruption(void){
+  sqlite3 *db = 0;
+  ChunkStore *cs;
+  ProllyHash h;
+  struct TableEntry *aTables = 0;
+  int nTables = 0;
+  int rc;
+  u8 truncatedNameCat[52];
+  u8 trailingCat[54];
+  u8 missingNameLenCat[50];
+
+  printf("=== Catalog Deserialize Corruption Test ===\n\n");
+
+  check("open_memory_db_for_catalog_corruption", open_db(":memory:", &db)==SQLITE_OK);
+  cs = doltliteGetChunkStore(db);
+  check("get_chunk_store_for_catalog_corruption", cs!=0);
+
+  init_v3_catalog_blob(truncatedNameCat, (int)sizeof(truncatedNameCat), 1);
+  check("put_truncated_name_catalog",
+        chunkStorePut(cs, truncatedNameCat, (int)sizeof(truncatedNameCat), &h)==SQLITE_OK);
+  rc = doltliteLoadCatalog(db, &h, &aTables, &nTables, 0);
+  check("truncated_name_catalog_rejected", rc==SQLITE_CORRUPT);
+  doltliteFreeCatalog(aTables, nTables);
+  aTables = 0; nTables = 0;
+
+  init_v3_catalog_blob(trailingCat, (int)sizeof(trailingCat), 1);
+  trailingCat[53] = 0xAA;
+  check("put_trailing_catalog",
+        chunkStorePut(cs, trailingCat, (int)sizeof(trailingCat), &h)==SQLITE_OK);
+  rc = doltliteLoadCatalog(db, &h, &aTables, &nTables, 0);
+  check("trailing_catalog_rejected", rc==SQLITE_CORRUPT);
+  doltliteFreeCatalog(aTables, nTables);
+  aTables = 0; nTables = 0;
+
+  init_v3_catalog_blob(missingNameLenCat, (int)sizeof(missingNameLenCat), 0);
+  check("put_missing_name_len_catalog",
+        chunkStorePut(cs, missingNameLenCat, (int)sizeof(missingNameLenCat), &h)==SQLITE_OK);
+  rc = doltliteLoadCatalog(db, &h, &aTables, &nTables, 0);
+  check("missing_name_len_catalog_rejected", rc==SQLITE_CORRUPT);
+  doltliteFreeCatalog(aTables, nTables);
+
+  sqlite3_close(db);
+}
+
 static void run_ancestor_missing_start(void){
   sqlite3 *db = 0;
   char dbpath[256];
@@ -6673,6 +6730,7 @@ static const RegressionCase aCases[] = {
   { "status_many_table_renames", "Status Many Table Renames Test", run_status_many_table_renames },
   { "remote_refs_corruption", "Remote Refs Corruption Test", run_remote_refs_corruption },
   { "chunk_walk_corruption", "Chunk Walk Corruption Test", run_chunk_walk_corruption },
+  { "catalog_deserialize_corruption", "Catalog Deserialize Corruption Test", run_catalog_deserialize_corruption },
   { "ancestor_missing_start", "Ancestor Missing Start Test", run_ancestor_missing_start },
   { "pull_persist_failure", "Pull Persist Failure Test", run_pull_persist_failure },
   { "push_persist_failure", "Push Persist Failure Test", run_push_persist_failure },


### PR DESCRIPTION
## Summary
- reject malformed catalog entries with missing schema hash, truncated v3 name payloads, or trailing bytes
- add catalog deserialization corruption coverage
- guard rowid-table zeroblob expansion against signed int overflow before allocation

## Tests
- make doltlite
- make doltlite-lib && DOLTLITE_BUILD_DIR=. bash test/run_doltlite_regression_case.sh catalog_deserialize_corruption
- bash test/doltlite_unicode_blob.sh
- bash test/oracle_large_blobs_test.sh ./doltlite ./sqlite3
- ./doltlite :memory: "CREATE TABLE t(id INTEGER PRIMARY KEY, b BLOB); INSERT INTO t VALUES(1, zeroblob(16)); SELECT length(b) FROM t;"
- ./doltlite :memory: "CREATE TABLE t(id INTEGER PRIMARY KEY, b BLOB); INSERT INTO t VALUES(1, zeroblob(2147483648));"