### PR TITLE
refactor: extract ChunkFile from ChunkStore (decomposition phase 5)

### DIFF
--- a/main.mk
+++ b/main.mk
@@ -575,7 +575,7 @@ else
 endif
 
 PROLLY_OBJS = prolly_hash.o prolly_xxhash.o blake3.o blake3_portable.o blake3_dispatch.o $(BLAKE3_SIMD_OBJS) prolly_hashset.o prolly_node.o prolly_cache.o \
-              chunk_store.o chunk_wal.o chunk_refs.o chunk_index.o chunk_staging.o prolly_cursor.o prolly_mutmap.o prolly_chunker.o \
+              chunk_store.o chunk_wal.o chunk_refs.o chunk_index.o chunk_staging.o chunk_file.o prolly_cursor.o prolly_mutmap.o prolly_chunker.o \
               prolly_mutate.o prolly_diff.o prolly_three_way_diff.o prolly_three_way_merge.o prolly_btree.o pager_shim.o sortkey.o \
               doltlite.o doltlite_commit.o doltlite_ref.o doltlite_log.o doltlite_commit_ancestors.o doltlite_status.o \
               doltlite_diff.o doltlite_diff_table.o doltlite_branch.o doltlite_tag.o doltlite_ancestor.o doltlite_merge.o doltlite_schema_merge.o doltlite_conflicts.o \
@@ -1394,6 +1394,9 @@ chunk_index.o:	$(TOP)/src/chunk_index.c $(DEPS_OBJ_COMMON)
 
 chunk_staging.o:	$(TOP)/src/chunk_staging.c $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/chunk_staging.c
+
+chunk_file.o:	$(TOP)/src/chunk_file.c $(DEPS_OBJ_COMMON)
+	$(T.cc.sqlite) -c $(TOP)/src/chunk_file.c
 
 prolly_cursor.o:	$(TOP)/src/prolly_cursor.c $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/prolly_cursor.c

--- a/src/chunk_file.c
+++ b/src/chunk_file.c
@@ -1,0 +1,35 @@
+
+#ifdef DOLTLITE_PROLLY
+
+#include "chunk_file.h"
+#include <string.h>
+
+void chunkFileInit(ChunkFile *cf){
+  memset(cf, 0, sizeof(*cf));
+}
+
+const char *chunkFileGetFilename(const ChunkFile *cf){
+  return cf->zFilename;
+}
+
+sqlite3_vfs *chunkFileGetVfs(const ChunkFile *cf){
+  return cf->pVfs;
+}
+
+sqlite3_file *chunkFileGetHandle(const ChunkFile *cf){
+  return cf->pFile;
+}
+
+i64 chunkFileGetSize(const ChunkFile *cf){
+  return cf->iFileSize;
+}
+
+void chunkFileSetHandle(ChunkFile *cf, sqlite3_file *pFile){
+  cf->pFile = pFile;
+}
+
+void chunkFileSetSize(ChunkFile *cf, i64 nSize){
+  cf->iFileSize = nSize;
+}
+
+#endif

--- a/src/chunk_file.h
+++ b/src/chunk_file.h
@@ -1,0 +1,26 @@
+
+#ifndef DOLTLITE_CHUNK_FILE_H
+#define DOLTLITE_CHUNK_FILE_H
+
+#include "sqliteInt.h"
+
+typedef struct ChunkFile ChunkFile;
+
+struct ChunkFile {
+  char *zFilename;
+  sqlite3_file *pFile;
+  sqlite3_vfs *pVfs;
+  i64 iFileSize;
+};
+
+void chunkFileInit(ChunkFile *cf);
+
+const char *chunkFileGetFilename(const ChunkFile *cf);
+sqlite3_vfs *chunkFileGetVfs(const ChunkFile *cf);
+sqlite3_file *chunkFileGetHandle(const ChunkFile *cf);
+i64 chunkFileGetSize(const ChunkFile *cf);
+
+void chunkFileSetHandle(ChunkFile *cf, sqlite3_file *pFile);
+void chunkFileSetSize(ChunkFile *cf, i64 nSize);
+
+#endif

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -421,7 +421,7 @@ static void csRestoreReplayState(ChunkStore *cs, const ChunkStoreReplayState *pS
 
 static void csCaptureReloadState(ChunkStore *cs, ChunkStoreReloadState *pSaved){
   memset(pSaved, 0, sizeof(*pSaved));
-  pSaved->pFile = cs->pFile;
+  pSaved->pFile = cs->file.pFile;
   pSaved->aIndex = cs->index.aIndex;
   pSaved->aIndexMmapBase = cs->index.aIndexMmapBase;
   pSaved->aIndexMmapSize = cs->index.aIndexMmapSize;
@@ -460,7 +460,7 @@ static void csAdoptOpenedStoreState(ChunkStore *pDst, ChunkStore *pSrc){
   pDst->staging.nRecentAlloc = 0;
   csRecentHTClear(pDst);
 
-  pDst->pFile = pSrc->pFile;
+  pDst->file.pFile = pSrc->file.pFile;
   pDst->readOnly = pSrc->readOnly;
   pDst->refs.refsHash = pSrc->refs.refsHash;
   pDst->refs.committedRefsHash = pSrc->refs.committedRefsHash;
@@ -468,7 +468,7 @@ static void csAdoptOpenedStoreState(ChunkStore *pDst, ChunkStore *pSrc){
   pDst->index.iIndexOffset = pSrc->index.iIndexOffset;
   pDst->index.nIndexSize = pSrc->index.nIndexSize;
   pDst->wal.iWalOffset = pSrc->wal.iWalOffset;
-  pDst->iFileSize = pSrc->iFileSize;
+  pDst->file.iFileSize = pSrc->file.iFileSize;
   pDst->index.aIndex = pSrc->index.aIndex;
   pDst->index.nIndex = pSrc->index.nIndex;
   pDst->index.aIndexMmapBase = pSrc->index.aIndexMmapBase;
@@ -484,7 +484,7 @@ static void csAdoptOpenedStoreState(ChunkStore *pDst, ChunkStore *pSrc){
   pDst->refs.aTracking = pSrc->refs.aTracking;
   pDst->refs.nTracking = pSrc->refs.nTracking;
 
-  pSrc->pFile = 0;
+  pSrc->file.pFile = 0;
   pSrc->index.aIndex = 0;
   pSrc->index.nIndex = 0;
   pSrc->index.aIndexMmapBase = 0;
@@ -550,29 +550,29 @@ static int csRollbackFailedAppend(ChunkStore *cs, i64 origFileSize){
   sqlite3_int64 sizeNow = -1;
   int rc = SQLITE_OK;
 
-  if( !cs->pFile ) return SQLITE_IOERR;
+  if( !cs->file.pFile ) return SQLITE_IOERR;
 
-  rc = sqlite3OsTruncate(cs->pFile, origFileSize);
+  rc = sqlite3OsTruncate(cs->file.pFile, origFileSize);
   if( rc==SQLITE_OK ){
-    rc = sqlite3OsFileSize(cs->pFile, &sizeNow);
+    rc = sqlite3OsFileSize(cs->file.pFile, &sizeNow);
   }
   if( rc==SQLITE_OK && sizeNow==origFileSize ){
-    (void)sqlite3OsSync(cs->pFile, SQLITE_SYNC_NORMAL);
+    (void)sqlite3OsSync(cs->file.pFile, SQLITE_SYNC_NORMAL);
     return SQLITE_OK;
   }
 
-  csCloseFile(cs->pFile);
-  cs->pFile = 0;
-  rc = csOpenFile(cs->pVfs, cs->zFilename, &cs->pFile,
+  csCloseFile(cs->file.pFile);
+  cs->file.pFile = 0;
+  rc = csOpenFile(cs->file.pVfs, cs->file.zFilename, &cs->file.pFile,
                   SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB);
   if( rc!=SQLITE_OK ) return rc;
 
-  rc = sqlite3OsTruncate(cs->pFile, origFileSize);
+  rc = sqlite3OsTruncate(cs->file.pFile, origFileSize);
   if( rc==SQLITE_OK ){
-    rc = sqlite3OsFileSize(cs->pFile, &sizeNow);
+    rc = sqlite3OsFileSize(cs->file.pFile, &sizeNow);
   }
   if( rc==SQLITE_OK && sizeNow==origFileSize ){
-    (void)sqlite3OsSync(cs->pFile, SQLITE_SYNC_NORMAL);
+    (void)sqlite3OsSync(cs->file.pFile, SQLITE_SYNC_NORMAL);
     return SQLITE_OK;
   }
   return rc==SQLITE_OK ? SQLITE_IOERR_TRUNCATE : rc;
@@ -836,7 +836,7 @@ static int csReadManifest(ChunkStore *cs){
   u32 magic, version;
   int rc;
 
-  rc = sqlite3OsRead(cs->pFile, aBuf, CHUNK_MANIFEST_SIZE, 0);
+  rc = sqlite3OsRead(cs->file.pFile, aBuf, CHUNK_MANIFEST_SIZE, 0);
   if( rc != SQLITE_OK ) return rc;
 
   magic = CS_READ_U32(aBuf + 0);
@@ -893,12 +893,12 @@ static int csReadIndex(ChunkStore *cs){
   if( cs->index.iIndexOffset < 0 || cs->index.nIndexSize < 0 ){
     return SQLITE_CORRUPT;
   }
-  if( cs->pFile ){
-    rc = sqlite3OsFileSize(cs->pFile, &fileSize);
+  if( cs->file.pFile ){
+    rc = sqlite3OsFileSize(cs->file.pFile, &fileSize);
     if( rc != SQLITE_OK ) return rc;
-  }else if( cs->zFilename ){
+  }else if( cs->file.zFilename ){
     struct stat st;
-    if( stat(cs->zFilename, &st) != 0 ) return SQLITE_IOERR;
+    if( stat(cs->file.zFilename, &st) != 0 ) return SQLITE_IOERR;
     fileSize = (i64)st.st_size;
   }
   if( fileSize > 0
@@ -907,8 +907,8 @@ static int csReadIndex(ChunkStore *cs){
     return SQLITE_CORRUPT;
   }
 
-  if( cs->zFilename
-   && csMapIndex(cs->zFilename, cs->index.iIndexOffset, cs->index.nIndexSize,
+  if( cs->file.zFilename
+   && csMapIndex(cs->file.zFilename, cs->index.iIndexOffset, cs->index.nIndexSize,
                   &pMapBase, &nMapSize, &pMapData) == SQLITE_OK ){
     cs->index.aIndex = (ChunkIndexEntry *)pMapData;
     cs->index.nIndex = nEntries;
@@ -933,7 +933,7 @@ static int csReadIndex(ChunkStore *cs){
     return SQLITE_NOMEM;
   }
 
-  rc = sqlite3OsRead(cs->pFile, aBuf, cs->index.nIndexSize, cs->index.iIndexOffset);
+  rc = sqlite3OsRead(cs->file.pFile, aBuf, cs->index.nIndexSize, cs->index.iIndexOffset);
   if( rc != SQLITE_OK ){
     sqlite3_free(aBuf);
     sqlite3_free(cs->index.aIndex);
@@ -1021,14 +1021,14 @@ static int csReplayWal(ChunkStore *cs){
 
   memset(&tmpRefs, 0, sizeof(tmpRefs));
 
-  if( cs->wal.iWalOffset <= 0 || !cs->pFile ) return SQLITE_OK;
+  if( cs->wal.iWalOffset <= 0 || !cs->file.pFile ) return SQLITE_OK;
 
   {
     i64 fileSize = 0;
-    int rc = sqlite3OsFileSize(cs->pFile, &fileSize);
+    int rc = sqlite3OsFileSize(cs->file.pFile, &fileSize);
     if( rc != SQLITE_OK ) return rc;
     walSize = fileSize - cs->wal.iWalOffset;
-    cs->iFileSize = fileSize;
+    cs->file.iFileSize = fileSize;
   }
   if( walSize <= 0 ){
     if( cs->index.nIndex==0 && cs->index.nChunks==0
@@ -1045,7 +1045,7 @@ static int csReplayWal(ChunkStore *cs){
   pos = 0;
   while( pos < walSize ){
     u8 tag = 0;
-    rc = sqlite3OsRead(cs->pFile, &tag, 1, cs->wal.iWalOffset + pos);
+    rc = sqlite3OsRead(cs->file.pFile, &tag, 1, cs->wal.iWalOffset + pos);
     if( rc != SQLITE_OK ) goto replay_error;
     pos++;
 
@@ -1056,7 +1056,7 @@ static int csReplayWal(ChunkStore *cs){
       if( pos + 20 + 4 > walSize ){
         break;
       }
-      rc = sqlite3OsRead(cs->pFile, aHdr, sizeof(aHdr), cs->wal.iWalOffset + pos);
+      rc = sqlite3OsRead(cs->file.pFile, aHdr, sizeof(aHdr), cs->wal.iWalOffset + pos);
       if( rc != SQLITE_OK ) goto replay_error;
       memcpy(&hash, aHdr, 20);
       len = CS_READ_U32(aHdr + 20);
@@ -1088,7 +1088,7 @@ static int csReplayWal(ChunkStore *cs){
       }
       {
         u32 magic;
-        rc = sqlite3OsRead(cs->pFile, m, sizeof(m), cs->wal.iWalOffset + pos);
+        rc = sqlite3OsRead(cs->file.pFile, m, sizeof(m), cs->wal.iWalOffset + pos);
         if( rc != SQLITE_OK ) goto replay_error;
         magic = CS_READ_U32(m);
         if( magic != CHUNK_STORE_MAGIC ){
@@ -1276,50 +1276,50 @@ int chunkStoreOpen(
   int n;
 
   memset(cs, 0, sizeof(*cs));
-  cs->pVfs = pVfs;
+  cs->file.pVfs = pVfs;
   cs->graphLockFd = -1;
 
   if( zFilename==0 || zFilename[0]=='\0'
    || strcmp(zFilename, ":memory:")==0 ){
     cs->isMemory = 1;
-    cs->zFilename = sqlite3_mprintf(":memory:");
-    if( cs->zFilename==0 ) return SQLITE_NOMEM;
+    cs->file.zFilename = sqlite3_mprintf(":memory:");
+    if( cs->file.zFilename==0 ) return SQLITE_NOMEM;
     cs->index.nChunks = 0;
     cs->index.iIndexOffset = 0;
     cs->index.nIndexSize = 0;
     cs->wal.iWalOffset = CHUNK_MANIFEST_SIZE;
-    cs->pFile = 0;
+    cs->file.pFile = 0;
     return SQLITE_OK;
   }
 
   n = (int)strlen(zFilename);
-  cs->zFilename = (char *)sqlite3_malloc(n + 1);
-  if( cs->zFilename == 0 ) return SQLITE_NOMEM;
-  memcpy(cs->zFilename, zFilename, n + 1);
+  cs->file.zFilename = (char *)sqlite3_malloc(n + 1);
+  if( cs->file.zFilename == 0 ) return SQLITE_NOMEM;
+  memcpy(cs->file.zFilename, zFilename, n + 1);
 
-  rc = sqlite3OsAccess(pVfs, cs->zFilename, SQLITE_ACCESS_EXISTS, &exists);
+  rc = sqlite3OsAccess(pVfs, cs->file.zFilename, SQLITE_ACCESS_EXISTS, &exists);
   if( rc != SQLITE_OK ){
-    sqlite3_free(cs->zFilename);
-    cs->zFilename = 0;
+    sqlite3_free(cs->file.zFilename);
+    cs->file.zFilename = 0;
     return rc;
   }
 
   if( exists ){
     struct stat mainStat;
-    if( stat(cs->zFilename, &mainStat)==0 && mainStat.st_size==0 ){
+    if( stat(cs->file.zFilename, &mainStat)==0 && mainStat.st_size==0 ){
       exists = 0;
     }
   }
 
   if( exists ){
     int openFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB;
-    rc = csOpenFile(pVfs, cs->zFilename, &cs->pFile, openFlags);
+    rc = csOpenFile(pVfs, cs->file.zFilename, &cs->file.pFile, openFlags);
     if( rc != SQLITE_OK ){
       openFlags = SQLITE_OPEN_READONLY | SQLITE_OPEN_MAIN_DB;
-      rc = csOpenFile(pVfs, cs->zFilename, &cs->pFile, openFlags);
+      rc = csOpenFile(pVfs, cs->file.zFilename, &cs->file.pFile, openFlags);
       if( rc != SQLITE_OK ){
-        sqlite3_free(cs->zFilename);
-        cs->zFilename = 0;
+        sqlite3_free(cs->file.zFilename);
+        cs->file.zFilename = 0;
         return rc;
       }
       cs->readOnly = 1;
@@ -1327,28 +1327,28 @@ int chunkStoreOpen(
 
     rc = csReadManifest(cs);
     if( rc != SQLITE_OK ){
-      csCloseFile(cs->pFile);
-      cs->pFile = 0;
-      sqlite3_free(cs->zFilename);
-      cs->zFilename = 0;
+      csCloseFile(cs->file.pFile);
+      cs->file.pFile = 0;
+      sqlite3_free(cs->file.zFilename);
+      cs->file.zFilename = 0;
       return rc;
     }
 
     rc = csReadIndex(cs);
     if( rc != SQLITE_OK ){
-      csCloseFile(cs->pFile);
-      cs->pFile = 0;
-      sqlite3_free(cs->zFilename);
-      cs->zFilename = 0;
+      csCloseFile(cs->file.pFile);
+      cs->file.pFile = 0;
+      sqlite3_free(cs->file.zFilename);
+      cs->file.zFilename = 0;
       return rc;
     }
 
     rc = csReplayWal(cs);
     if( rc != SQLITE_OK ){
-      csCloseFile(cs->pFile);
-      cs->pFile = 0;
-      sqlite3_free(cs->zFilename);
-      cs->zFilename = 0;
+      csCloseFile(cs->file.pFile);
+      cs->file.pFile = 0;
+      sqlite3_free(cs->file.zFilename);
+      cs->file.zFilename = 0;
       return rc;
     }
 
@@ -1376,8 +1376,8 @@ int chunkStoreOpen(
     }
   }else{
     if( !(flags & SQLITE_OPEN_CREATE) ){
-      sqlite3_free(cs->zFilename);
-      cs->zFilename = 0;
+      sqlite3_free(cs->file.zFilename);
+      cs->file.zFilename = 0;
       return SQLITE_CANTOPEN;
     }
     cs->index.nChunks = 0;
@@ -1385,8 +1385,8 @@ int chunkStoreOpen(
     cs->index.nIndexSize = 0;
 
     cs->wal.iWalOffset = CHUNK_MANIFEST_SIZE;
-    cs->iFileSize = 0;
-    cs->pFile = 0;
+    cs->file.iFileSize = 0;
+    cs->file.pFile = 0;
   }
 
   csMarkRefsCommitted(cs);
@@ -1395,11 +1395,11 @@ int chunkStoreOpen(
 
 int chunkStoreClose(ChunkStore *cs){
   chunkStoreUnlock(cs);
-  if( cs->pFile ){
-    csCloseFile(cs->pFile);
-    cs->pFile = 0;
+  if( cs->file.pFile ){
+    csCloseFile(cs->file.pFile);
+    cs->file.pFile = 0;
   }
-  sqlite3_free(cs->zFilename);
+  sqlite3_free(cs->file.zFilename);
   csReleaseIndexBuf(cs->index.aIndex, cs->index.aIndexMmapBase, cs->index.aIndexMmapSize);
   cs->index.aIndex = 0;
   cs->index.aIndexMmapBase = 0;
@@ -2056,7 +2056,7 @@ int chunkStoreGet(
       e = &cs->index.aIndex[idx];
     }
 
-    if( cs->pFile == 0 ){
+    if( cs->file.pFile == 0 ){
       if( cs->staging.pWriteBuf && e->offset >= 0
        && (e->offset + 4 + e->size) <= cs->staging.nWriteBuf ){
         u8 *pCopy = (u8 *)sqlite3_malloc(e->size);
@@ -2076,7 +2076,7 @@ int chunkStoreGet(
       u8 *pBuf;
       u32 storedLen;
 
-      rc = sqlite3OsRead(cs->pFile, lenBuf, 4, fileOff);
+      rc = sqlite3OsRead(cs->file.pFile, lenBuf, 4, fileOff);
       if( rc != SQLITE_OK ) return rc;
 
       storedLen = CS_READ_U32(lenBuf);
@@ -2087,7 +2087,7 @@ int chunkStoreGet(
       pBuf = (u8 *)sqlite3_malloc(sz);
       if( pBuf == 0 ) return SQLITE_NOMEM;
 
-      rc = sqlite3OsRead(cs->pFile, pBuf, sz, fileOff + 4);
+      rc = sqlite3OsRead(cs->file.pFile, pBuf, sz, fileOff + 4);
       if( rc != SQLITE_OK ){
         sqlite3_free(pBuf);
         return rc;
@@ -2182,7 +2182,7 @@ static int csCommitToFile(ChunkStore *cs){
   i64 origFileSize = 0;
   i64 writeOff = 0;
   int lockFd = -1;
-  int hadFile = (cs->pFile != 0);
+  int hadFile = (cs->file.pFile != 0);
   int lockHeld = (cs->graphLockFd >= 0);
   i64 newWalSize = cs->wal.nWalData;
   ChunkIndexEntry *aCommittedPending = 0;
@@ -2192,40 +2192,40 @@ static int csCommitToFile(ChunkStore *cs){
   int useRecent = 0;
   int crashWriteActive = csCrashWriteInjectionActive();
 
-  if( cs->pFile == 0 ){
+  if( cs->file.pFile == 0 ){
     int openFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE
                   | SQLITE_OPEN_MAIN_DB;
-    rc = csOpenFile(cs->pVfs, cs->zFilename, &cs->pFile, openFlags);
+    rc = csOpenFile(cs->file.pVfs, cs->file.zFilename, &cs->file.pFile, openFlags);
     if( rc != SQLITE_OK ) return SQLITE_CANTOPEN;
   }
 
   if( lockHeld ){
     lockFd = -1;
   }else{
-    if( csFileLock(cs->zFilename, &lockFd) != 0 ){
+    if( csFileLock(cs->file.zFilename, &lockFd) != 0 ){
       return SQLITE_BUSY;
     }
   }
 
-  rc = cs->pFile->pMethods->xFileSize(cs->pFile, &fileSize);
+  rc = cs->file.pFile->pMethods->xFileSize(cs->file.pFile, &fileSize);
   if( rc != SQLITE_OK ) goto commit_done;
 
   if( hadFile && !cs->hasMovedChecked ){
     int bMoved = 0;
-    int rc2 = sqlite3OsFileControl(cs->pFile, SQLITE_FCNTL_HAS_MOVED,
+    int rc2 = sqlite3OsFileControl(cs->file.pFile, SQLITE_FCNTL_HAS_MOVED,
                                    &bMoved);
     if( rc2==SQLITE_OK && bMoved ){
       rc = csReloadFromDiskPreservingLocalRefs(cs);
       if( rc != SQLITE_OK ) goto commit_done;
-      fileSize = cs->iFileSize;
+      fileSize = cs->file.iFileSize;
     }
     cs->hasMovedChecked = 1;
   }
 
-  if( fileSize > cs->iFileSize && hadFile ){
+  if( fileSize > cs->file.iFileSize && hadFile ){
     rc = csReloadFromDiskPreservingLocalRefs(cs);
     if( rc != SQLITE_OK ) goto commit_done;
-    fileSize = cs->iFileSize;
+    fileSize = cs->file.iFileSize;
   }
   origFileSize = fileSize;
 
@@ -2317,7 +2317,7 @@ static int csCommitToFile(ChunkStore *cs){
     cs->wal.iWalOffset = CHUNK_MANIFEST_SIZE;
     csSerializeManifest(cs, manifest);
     CRASH_CHECK_WRITE();
-    rc = sqlite3OsWrite(cs->pFile, manifest, CHUNK_MANIFEST_SIZE, 0);
+    rc = sqlite3OsWrite(cs->file.pFile, manifest, CHUNK_MANIFEST_SIZE, 0);
     if( rc != SQLITE_OK ) goto commit_done;
     fileSize = CHUNK_MANIFEST_SIZE;
   }
@@ -2356,7 +2356,7 @@ static int csCommitToFile(ChunkStore *cs){
         pOut += pe->size;
       }
       CRASH_CHECK_WRITE();
-      rc = sqlite3OsWrite(cs->pFile, pWalBatch, (int)walBytes, writeOff);
+      rc = sqlite3OsWrite(cs->file.pFile, pWalBatch, (int)walBytes, writeOff);
       if( pWalBatch != aSmallWalBatch ) sqlite3_free(pWalBatch);
       if( rc != SQLITE_OK ) goto commit_done;
       writeOff += walBytes;
@@ -2371,7 +2371,7 @@ static int csCommitToFile(ChunkStore *cs){
 
         bufOff = pe->offset + 4;
         CRASH_CHECK_WRITE();
-        rc = sqlite3OsWrite(cs->pFile, recHdr, 25, writeOff);
+        rc = sqlite3OsWrite(cs->file.pFile, recHdr, 25, writeOff);
         if( rc != SQLITE_OK ) goto commit_done;
         writeOff += 25;
 
@@ -2381,7 +2381,7 @@ static int csCommitToFile(ChunkStore *cs){
           while( remaining > 0 && rc==SQLITE_OK ){
             int toWrite = remaining > 65536 ? 65536 : remaining;
             CRASH_CHECK_WRITE();
-            rc = sqlite3OsWrite(cs->pFile, pSrc, toWrite, writeOff);
+            rc = sqlite3OsWrite(cs->file.pFile, pSrc, toWrite, writeOff);
             pSrc += toWrite;
             writeOff += toWrite;
             remaining -= toWrite;
@@ -2398,13 +2398,13 @@ static int csCommitToFile(ChunkStore *cs){
     rootRec[0] = CS_WAL_TAG_ROOT;
     csSerializeManifest(cs, rootRec + 1);
     CRASH_CHECK_WRITE();
-    rc = sqlite3OsWrite(cs->pFile, rootRec, sizeof(rootRec), writeOff);
+    rc = sqlite3OsWrite(cs->file.pFile, rootRec, sizeof(rootRec), writeOff);
     if( rc != SQLITE_OK ) goto commit_done;
     writeOff += sizeof(rootRec);
   }
 
   CRASH_CHECK_WRITE();
-  rc = sqlite3OsSync(cs->pFile, SQLITE_SYNC_NORMAL);
+  rc = sqlite3OsSync(cs->file.pFile, SQLITE_SYNC_NORMAL);
 
 #ifdef SQLITE_TEST
   }
@@ -2412,13 +2412,13 @@ static int csCommitToFile(ChunkStore *cs){
 #endif
   if( rc != SQLITE_OK ) goto commit_done;
 
-  cs->iFileSize = writeOff;
+  cs->file.iFileSize = writeOff;
 
 commit_done:
   csFileUnlock(lockFd);
 
   if( rc != SQLITE_OK ){
-    if( cs->pFile && writeOff > origFileSize ){
+    if( cs->file.pFile && writeOff > origFileSize ){
       (void)csRollbackFailedAppend(cs, origFileSize);
     }
     (void)csRestoreCommittedRefsState(cs);
@@ -2471,7 +2471,7 @@ int chunkStoreCommit(ChunkStore *cs){
   memset(&savedRefs, 0, sizeof(savedRefs));
   if( cs->readOnly ) return SQLITE_READONLY;
   if( cs->isMemory ) return csCommitToMemory(cs);
-  if( cs->graphLockFd < 0 && cs->zFilename ){
+  if( cs->graphLockFd < 0 && cs->file.zFilename ){
     preserveRefs = cs->staging.nPending > 0
                 && prollyHashCompare(&cs->refs.refsHash,
                                      &cs->refs.committedRefsHash)!=0;
@@ -2539,7 +2539,7 @@ int chunkStoreReloadRefs(ChunkStore *cs){
 }
 
 const char *chunkStoreFilename(ChunkStore *cs){
-  return cs->zFilename;
+  return cs->file.zFilename;
 }
 
 int chunkStoreLockAndRefresh(ChunkStore *cs){
@@ -2547,8 +2547,8 @@ int chunkStoreLockAndRefresh(ChunkStore *cs){
   int rc;
   if( cs->isMemory ) return SQLITE_OK;
   if( cs->graphLockFd >= 0 ) return SQLITE_OK;
-  if( !cs->zFilename ) return SQLITE_ERROR;
-  if( csFileLockNB(cs->zFilename, &cs->graphLockFd) != 0 ){
+  if( !cs->file.zFilename ) return SQLITE_ERROR;
+  if( csFileLockNB(cs->file.zFilename, &cs->graphLockFd) != 0 ){
     return SQLITE_BUSY;
   }
   rc = chunkStoreRefreshIfChanged(cs, &changed);
@@ -2573,14 +2573,14 @@ static int csDetectExternalChanges(ChunkStore *cs, int *pChanged){
   *pChanged = 0;
   if( cs->isMemory ) return SQLITE_OK;
 
-  if( cs->pFile==0 ){
+  if( cs->file.pFile==0 ){
     int exists = 0;
-    rc = sqlite3OsAccess(cs->pVfs, cs->zFilename,
+    rc = sqlite3OsAccess(cs->file.pVfs, cs->file.zFilename,
                          SQLITE_ACCESS_EXISTS, &exists);
     if( rc!=SQLITE_OK ) return rc;
     if( exists ){
       struct stat mainStat;
-      if( stat(cs->zFilename, &mainStat)==0 ){
+      if( stat(cs->file.zFilename, &mainStat)==0 ){
         if( mainStat.st_size > 0 ){
           *pChanged = 1;
         }
@@ -2592,7 +2592,7 @@ static int csDetectExternalChanges(ChunkStore *cs, int *pChanged){
   }
 
   if( !cs->hasMovedChecked ){
-    rc = sqlite3OsFileControl(cs->pFile, SQLITE_FCNTL_HAS_MOVED, &bMoved);
+    rc = sqlite3OsFileControl(cs->file.pFile, SQLITE_FCNTL_HAS_MOVED, &bMoved);
     if( rc!=SQLITE_OK ) return rc;
     if( bMoved ){
       *pChanged = 1;
@@ -2603,9 +2603,9 @@ static int csDetectExternalChanges(ChunkStore *cs, int *pChanged){
 
   {
     i64 fileSize = 0;
-    rc = sqlite3OsFileSize(cs->pFile, &fileSize);
+    rc = sqlite3OsFileSize(cs->file.pFile, &fileSize);
     if( rc!=SQLITE_OK ) return rc;
-    if( fileSize > cs->iFileSize ){
+    if( fileSize > cs->file.iFileSize ){
       *pChanged = 1;
     }
   }
@@ -2638,7 +2638,7 @@ int chunkStoreRefreshIfChanged(ChunkStore *cs, int *pChanged){
 static int csReloadFromDisk(ChunkStore *cs){
   ChunkStore tmp;
   ChunkStoreReloadState saved;
-  int rc = chunkStoreOpen(&tmp, cs->pVfs, cs->zFilename,
+  int rc = chunkStoreOpen(&tmp, cs->file.pVfs, cs->file.zFilename,
                           SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB);
   if( rc!=SQLITE_OK ) return rc;
 

--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -9,6 +9,7 @@
 #include "chunk_refs.h"
 #include "chunk_index.h"
 #include "chunk_staging.h"
+#include "chunk_file.h"
 
 #define CHUNK_STORE_MAGIC 0x444C5443
 #define CHUNK_STORE_VERSION 11
@@ -88,15 +89,10 @@ struct ConflictEntry {
 #endif
 
 struct ChunkStore {
-  char *zFilename;
-  sqlite3_file *pFile;
-  sqlite3_vfs *pVfs;
+  ChunkFile file;
   RefsTable refs;
-
   ChunkIndex index;
   WalState wal;
-  i64 iFileSize;
-
   ChunkStaging staging;
 
   u8 readOnly;

--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -335,8 +335,8 @@ static int gcRewriteFile(
 
   csSerializeManifest(&manifestCs, manifest);
 
-  if( cs->zFilename && strcmp(cs->zFilename, ":memory:")!=0 ){
-    char *zTmp = sqlite3_mprintf("%s-gc-tmp", cs->zFilename);
+  if( chunkFileGetFilename(&cs->file) && strcmp(chunkFileGetFilename(&cs->file), ":memory:")!=0 ){
+    char *zTmp = sqlite3_mprintf("%s-gc-tmp", chunkFileGetFilename(&cs->file));
     if( !zTmp ){
       sqlite3_free(indexBuf);
       return SQLITE_NOMEM;
@@ -348,9 +348,9 @@ static int gcRewriteFile(
                    | SQLITE_OPEN_MAIN_DB;
       i64 writeOff = 0;
 
-      cs->pVfs->xDelete(cs->pVfs, zTmp, 0);
+      chunkFileGetVfs(&cs->file)->xDelete(chunkFileGetVfs(&cs->file), zTmp, 0);
 
-      rc = sqlite3OsOpenMalloc(cs->pVfs, zTmp, &pTmpFile, tmpFlags, 0);
+      rc = sqlite3OsOpenMalloc(chunkFileGetVfs(&cs->file), zTmp, &pTmpFile, tmpFlags, 0);
       if( rc != SQLITE_OK ){
         sqlite3_free(zTmp); sqlite3_free(indexBuf);
         return SQLITE_CANTOPEN;
@@ -393,17 +393,17 @@ static int gcRewriteFile(
       sqlite3OsCloseFree(pTmpFile);
 
       if( rc==SQLITE_OK ){
-        sqlite3_file *pOldFile = cs->pFile;
+        sqlite3_file *pOldFile = chunkFileGetHandle(&cs->file);
         sqlite3_file *pNewFile = 0;
 
         GC_CRASH_CHECK();
-        if( rename(zTmp, cs->zFilename)!=0 ){
+        if( rename(zTmp, chunkFileGetFilename(&cs->file))!=0 ){
           rc = SQLITE_IOERR;
         }
 
 #if !defined(_WIN32) && !defined(WIN32)
         if( rc==SQLITE_OK ){
-          char *zDir = sqlite3_mprintf("%s", cs->zFilename);
+          char *zDir = sqlite3_mprintf("%s", chunkFileGetFilename(&cs->file));
           if( zDir ){
             int k = (int)strlen(zDir);
             while( k>0 && zDir[k-1]!='/' ) k--;
@@ -426,7 +426,7 @@ static int gcRewriteFile(
           int reopenAttempt;
           for(reopenAttempt=0; reopenAttempt<3; reopenAttempt++){
             pNewFile = 0;
-            rc = sqlite3OsOpenMalloc(cs->pVfs, cs->zFilename, &pNewFile,
+            rc = sqlite3OsOpenMalloc(chunkFileGetVfs(&cs->file), chunkFileGetFilename(&cs->file), &pNewFile,
                                      reopenFlags, 0);
             if( rc==SQLITE_OK ) break;
             if( pNewFile ){
@@ -437,14 +437,14 @@ static int gcRewriteFile(
         }
 
         if( rc==SQLITE_OK ){
-          cs->pFile = pNewFile;
+          chunkFileSetHandle(&cs->file, pNewFile);
           walStateSetDataSize(&cs->wal, 0);
           if( pOldFile ){
             sqlite3OsCloseFree(pOldFile);
           }
         }
       }else{
-        cs->pVfs->xDelete(cs->pVfs, zTmp, 0);
+        chunkFileGetVfs(&cs->file)->xDelete(chunkFileGetVfs(&cs->file), zTmp, 0);
       }
     }
     sqlite3_free(zTmp);
@@ -551,7 +551,7 @@ static void doltliteGcFunc(
     return;
   }
 
-  if( !cs->zFilename || strcmp(cs->zFilename, ":memory:")==0 ){
+  if( !chunkFileGetFilename(&cs->file) || strcmp(chunkFileGetFilename(&cs->file), ":memory:")==0 ){
     sqlite3_result_text(context, "0 chunks removed, 0 chunks kept (in-memory)", -1, SQLITE_TRANSIENT);
     return;
   }
@@ -603,7 +603,7 @@ int doltliteGcCompact(sqlite3 *db){
   int rc;
 
   if( !cs ) return SQLITE_OK;
-  if( !cs->zFilename || strcmp(cs->zFilename, ":memory:")==0 ){
+  if( !chunkFileGetFilename(&cs->file) || strcmp(chunkFileGetFilename(&cs->file), ":memory:")==0 ){
     return SQLITE_OK;
   }
 

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -154,7 +154,7 @@ static int remoteSqlOpenNamedRemote(
     return SQLITE_NOTFOUND;
   }
 
-  *ppRemote = openRemoteByUrl(cs->pVfs, *pzUrl);
+  *ppRemote = openRemoteByUrl(chunkFileGetVfs(&cs->file), *pzUrl);
   if( !*ppRemote ){
     return SQLITE_CANTOPEN;
   }
@@ -348,7 +348,7 @@ static void doltPushFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     return;
   }
 
-  pRemote = openRemoteByUrl(cs->pVfs, zUrl);
+  pRemote = openRemoteByUrl(chunkFileGetVfs(&cs->file), zUrl);
   if( !pRemote ){
     (void)doltliteVcSealSavepointError(db);
     sqlite3_result_error(ctx, "failed to open remote (URL must start with file://)", -1);
@@ -470,7 +470,7 @@ static void doltFetchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     return;
   }
 
-  pRemote = openRemoteByUrl(cs->pVfs, zUrl);
+  pRemote = openRemoteByUrl(chunkFileGetVfs(&cs->file), zUrl);
   if( !pRemote ){
     (void)doltliteVcSealSavepointError(db);
     sqlite3_result_error(ctx, "failed to open remote (URL must start with file://)", -1);
@@ -512,7 +512,7 @@ static void doltFetchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     pRemote = 0;
 
     for(i=0; i<nNames; i++){
-      DoltliteRemote *pBrRemote = openRemoteByUrl(cs->pVfs, zUrl);
+      DoltliteRemote *pBrRemote = openRemoteByUrl(chunkFileGetVfs(&cs->file), zUrl);
       if( !pBrRemote ){
         freeNameList(azNames, nNames);
         (void)doltliteVcSealSavepointError(db);
@@ -739,7 +739,7 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     chunkStoreClearRefs(cs);
   }
 
-  pRemote = openRemoteByUrl(cs->pVfs, zUrl);
+  pRemote = openRemoteByUrl(chunkFileGetVfs(&cs->file), zUrl);
   if( !pRemote ){
     remoteSqlRestoreAndReport(ctx, db, cs, &savedState, SQLITE_ERROR,
                               "failed to open remote (URL must start with file://)");

--- a/src/pager_shim.c
+++ b/src/pager_shim.c
@@ -174,7 +174,7 @@ static sqlite3_file *shimPagerFile(Pager *p){
   ** actor (concurrent connection, peer process, or gc) replaces the
   ** chunk store's file handle via csReloadFromDisk or gcRewriteFile. */
   if( s->pStore ){
-    sqlite3_file *pCurrent = ((ChunkStore*)s->pStore)->pFile;
+    sqlite3_file *pCurrent = chunkFileGetHandle(&((ChunkStore*)s->pStore)->file);
     if( pCurrent ) return pCurrent;
   }
   return s->pFd;
@@ -843,9 +843,9 @@ sqlite3_backup *sqlite3_backup_init(sqlite3 *pDest, const char *zDestDb,
 
   srcCs = doltliteGetChunkStore(pSrc);
   destCs = doltliteGetChunkStore(pDest);
-  if( !srcCs || !srcCs->zFilename ) return 0;
+  if( !srcCs || !chunkFileGetFilename(&srcCs->file) ) return 0;
   if( srcCs->isMemory ) return 0;
-  if( !destCs || !destCs->zFilename ) return 0;
+  if( !destCs || !chunkFileGetFilename(&destCs->file) ) return 0;
 
   p = (DoltliteBackup*)sqlite3_malloc(sizeof(DoltliteBackup));
   if( !p ) return 0;
@@ -853,9 +853,9 @@ sqlite3_backup *sqlite3_backup_init(sqlite3 *pDest, const char *zDestDb,
 
   p->pSrcDb = pSrc;
   p->pDestDb = pDest;
-  p->pVfs = srcCs->pVfs;
-  p->zSrcFile = sqlite3_mprintf("%s", srcCs->zFilename);
-  p->zDestFile = sqlite3_mprintf("%s", destCs->zFilename);
+  p->pVfs = chunkFileGetVfs(&srcCs->file);
+  p->zSrcFile = sqlite3_mprintf("%s", chunkFileGetFilename(&srcCs->file));
+  p->zDestFile = sqlite3_mprintf("%s", chunkFileGetFilename(&destCs->file));
   if( !p->zSrcFile || !p->zDestFile ){
     sqlite3_free(p->zSrcFile);
     sqlite3_free(p->zDestFile);

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -3341,7 +3341,7 @@ int sqlite3BtreeOpen(
     return rc;
   }
 
-  pBt->pPagerShim = pagerShimCreate(pVfs, zFilename, pBt->store.pFile);
+  pBt->pPagerShim = pagerShimCreate(pVfs, zFilename, chunkFileGetHandle(&pBt->store.file));
   if( !pBt->pPagerShim ){
     prollyCacheFree(&pBt->cache);
     chunkStoreClose(&pBt->store);

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -3115,7 +3115,7 @@ static void run_truncated_wal_is_rejected(void){
   if( walStateGetDataSize(&cs.wal) > 0 ){
     unsigned char badTag = 0xff;
     check("corrupt_first_wal_tag",
-          sqlite3OsWrite(cs.pFile, &badTag, 1, walStateGetOffset(&cs.wal))==SQLITE_OK);
+          sqlite3OsWrite(cs.file.pFile, &badTag, 1, walStateGetOffset(&cs.wal))==SQLITE_OK);
   }
   chunkStoreClose(&cs);
 
@@ -3140,7 +3140,7 @@ static void run_refresh_open_path_transactional(void){
   check("open_empty_store_with_no_file",
         chunkStoreOpen(&cs, sqlite3_vfs_find(0), dbpath,
           SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB)==SQLITE_OK);
-  check("store_starts_without_file", cs.pFile==0);
+  check("store_starts_without_file", cs.file.pFile==0);
 
   f = fopen(dbpath, "wb");
   check("create_corrupt_file", f!=0);
@@ -3196,7 +3196,7 @@ static void run_wal_offset_corruption_is_rejected(void){
   }
   check("have_wal_backed_index_entry", iWal >= 0);
   if( iWal >= 0 ){
-    cs.index.aIndex[iWal].offset = cs.iFileSize + 1024;
+    cs.index.aIndex[iWal].offset = cs.file.iFileSize + 1024;
     rc = chunkStoreGet(&cs, &cs.index.aIndex[iWal].hash, &pData, &nData);
     check("corrupt_wal_offset_returns_error", rc!=SQLITE_OK);
   }
@@ -3252,7 +3252,7 @@ static void run_integrity_check_walks_prolly_nodes(void){
   if( dataOff >= 0 ){
     unsigned char badByte = 0;
     check("corrupt_root_chunk_magic",
-          sqlite3OsWrite(cs.pFile, &badByte, 1, dataOff)==SQLITE_OK);
+          sqlite3OsWrite(cs.file.pFile, &badByte, 1, dataOff)==SQLITE_OK);
   }
   chunkStoreClose(&cs);
 


### PR DESCRIPTION
Final slice of the ChunkStore decomposition plan. After this, ChunkStore looks like:

\`\`\`c
struct ChunkStore {
  ChunkFile     file;      // pFile, pVfs, zFilename, iFileSize
  RefsTable     refs;
  ChunkIndex    index;
  WalState      wal;
  ChunkStaging  staging;
  u8 readOnly; isMemory; snapshotPinned; hasMovedChecked;
  int graphLockFd;
};
\`\`\`

**5 subsystems + 5 simple fields**. Down from ~30 fields in a god-struct when the decomposition started.

## What this PR does

- New \`src/chunk_file.{h,c}\` with \`ChunkFile\` struct + accessor API: \`chunkFileGetFilename / Vfs / Handle / Size\`, \`chunkFileSetHandle / Size\`.
- ChunkStore embeds \`ChunkFile file;\`. The 4 fields (zFilename, pFile, pVfs, iFileSize) collapse into 1.
- **chunk_store.c**: ~94 internal sites renamed via perl regex (\`cs->pFile\` → \`cs->file.pFile\` etc.).
- **4 external consumers migrated** to accessors:
  - \`doltlite_gc.c\` — 11 sites. The GC rename + handle-swap path uses \`chunkFileSetHandle\` for the post-rename install.
  - \`doltlite_remote_sql.c\` — 5 \`cs->pVfs\` reads (for openRemoteByUrl).
  - \`pager_shim.c\` — 6 sites: \`shimPagerFile\` fallback + \`doltliteBackupInit\` field reads.
  - \`prolly_btree.c\` — 1 site at the pager-shim wiring.
- \`test/doltlite_regression_test_c.c\` — 4 white-box sites migrated preemptively.
- \`graphLockFd\` and \`hasMovedChecked\` stay in ChunkStore per planning Q&A — they're more operational state than file identity.

## Test plan

- [x] \`make doltlite-lib\` + \`make doltlite\` clean
- [x] Smoke: CREATE TABLE + dolt_commit returns hash
- [x] \`make lint\` passes
- [x] \`wal_offset_corruption\` (5/5), \`truncated_wal_rejected\` (6/6) pass locally
- [ ] Full CI

## The decomposition arc

1. ✅ WalState (#873)
2. ✅ RefsTable (#875)
3. ✅ ChunkIndex (#877)
4. ✅ ChunkStaging (#880)
5. **ChunkFile (this PR)**

This closes the plan. Future tidiness work (moving static helpers like \`csReadIndex\`, \`csReplayWal\`, \`chunkStoreAddBranch\` from chunk_store.c into their respective subsystem .c files) can happen incrementally if/when motivated — the architecture doesn't require it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)