### PR TITLE
Make sysbench workload seeds deterministic

### DIFF
--- a/test/sysbench_compare.sh
+++ b/test/sysbench_compare.sh
@@ -74,12 +74,18 @@ def write_prepare_types(f):
 # Each test file: prepare + ".print BENCH_START" + workload + ".print BENCH_END"
 # The runner times between START and END markers
 
+def stable_seed(name):
+    h = 0
+    for ch in name:
+        h = ((h * 131) + ord(ch)) % 10000
+    return $SEED + h
+
 def make_test(name, prepare_fn, workload_fn):
     random.seed($SEED)  # Reset for deterministic prepare
     with open(f'{d}/{name}.sql', 'w') as f:
         prepare_fn(f)
         f.write(".print BENCH_START\n")
-        random.seed($SEED + hash(name) % 10000)  # Unique workload seed
+        random.seed(stable_seed(name))  # Unique deterministic workload seed
         workload_fn(f)
         f.write(".print BENCH_END\n")
 

--- a/test/sysbench_compare_blobpk.sh
+++ b/test/sysbench_compare_blobpk.sh
@@ -91,12 +91,18 @@ def write_prepare_types(f):
 # Each test file: prepare + ".print BENCH_START" + workload + ".print BENCH_END"
 # The runner times between START and END markers
 
+def stable_seed(name):
+    h = 0
+    for ch in name:
+        h = ((h * 131) + ord(ch)) % 10000
+    return $SEED + h
+
 def make_test(name, prepare_fn, workload_fn):
     random.seed($SEED)  # Reset for deterministic prepare
     with open(f'{d}/{name}.sql', 'w') as f:
         prepare_fn(f)
         f.write(".print BENCH_START\n")
-        random.seed($SEED + hash(name) % 10000)  # Unique workload seed
+        random.seed(stable_seed(name))  # Unique deterministic workload seed
         workload_fn(f)
         f.write(".print BENCH_END\n")
 

--- a/test/sysbench_compare_compositepk.sh
+++ b/test/sysbench_compare_compositepk.sh
@@ -109,12 +109,18 @@ def write_prepare_types(f):
 # Each test file: prepare + ".print BENCH_START" + workload + ".print BENCH_END"
 # The runner times between START and END markers
 
+def stable_seed(name):
+    h = 0
+    for ch in name:
+        h = ((h * 131) + ord(ch)) % 10000
+    return $SEED + h
+
 def make_test(name, prepare_fn, workload_fn):
     random.seed($SEED)  # Reset for deterministic prepare
     with open(f'{d}/{name}.sql', 'w') as f:
         prepare_fn(f)
         f.write(".print BENCH_START\n")
-        random.seed($SEED + hash(name) % 10000)  # Unique workload seed
+        random.seed(stable_seed(name))  # Unique deterministic workload seed
         workload_fn(f)
         f.write(".print BENCH_END\n")
 

--- a/test/sysbench_compare_textpk.sh
+++ b/test/sysbench_compare_textpk.sh
@@ -91,12 +91,18 @@ def write_prepare_types(f):
 # Each test file: prepare + ".print BENCH_START" + workload + ".print BENCH_END"
 # The runner times between START and END markers
 
+def stable_seed(name):
+    h = 0
+    for ch in name:
+        h = ((h * 131) + ord(ch)) % 10000
+    return $SEED + h
+
 def make_test(name, prepare_fn, workload_fn):
     random.seed($SEED)  # Reset for deterministic prepare
     with open(f'{d}/{name}.sql', 'w') as f:
         prepare_fn(f)
         f.write(".print BENCH_START\n")
-        random.seed($SEED + hash(name) % 10000)  # Unique workload seed
+        random.seed(stable_seed(name))  # Unique deterministic workload seed
         workload_fn(f)
         f.write(".print BENCH_END\n")
 


### PR DESCRIPTION
## Summary
- replace Python's randomized hash(name) with a deterministic per-test seed in the sysbench benchmark generators
- apply the same fix to classic, TEXT PK, BLOB PK, and composite PK benchmark scripts

## Why
The benchmark SQL workload varied across workflow runs because Python salts hash() per process. That makes indexed-read trend comparisons noisy and can look like a code regression even when the generated SQL changed.

## Local investigation
- Compared current master against 30542ee1d with PYTHONHASHSEED=0 and BENCH_RUNS=3; in-memory indexed-read timings were essentially flat.
- GitHub benchmark history shows the large in-memory indexed-read regression came from #841 and was mostly removed by #851; recent apparent movement is within the noisy benchmark generator.

## Tests
- git diff --check -- test/sysbench_compare.sh test/sysbench_compare_textpk.sh test/sysbench_compare_blobpk.sh test/sysbench_compare_compositepk.sh
- BENCH_RUNS=1 BENCH_SECTION_MODE=wrapped BENCH_ROWS=1000 bash test/sysbench_compare.sh
- BENCH_RUNS=1 BENCH_ROWS=1000 BENCH_MAX_MULTIPLIER=100 BENCH_AVG_MAX_MULTIPLIER=100 bash test/sysbench_compare_textpk.sh
- BENCH_RUNS=1 BENCH_ROWS=1000 BENCH_MAX_MULTIPLIER=100 BENCH_AVG_MAX_MULTIPLIER=100 bash test/sysbench_compare_blobpk.sh
- BENCH_RUNS=1 BENCH_ROWS=1000 BENCH_MAX_MULTIPLIER=100 BENCH_AVG_MAX_MULTIPLIER=100 bash test/sysbench_compare_compositepk.sh