### PR TITLE
ci: move int-key autocommit sysbench back to benchmark job

### DIFF
--- a/.github/workflows/benchmark-extra.yml
+++ b/.github/workflows/benchmark-extra.yml
@@ -1,10 +1,9 @@
 name: Benchmark Extra
 
 # Companion to Benchmark. Runs three non-INTKEY sysbench variants
-# (TEXT PK, BLOB PK, composite PK) plus the autocommit suite. Each
-# non-INTKEY variant is gated on both individual ratios and section
-# average ratios. The current ceilings leave room for runner noise while
-# still catching broad regressions.
+# (TEXT PK, BLOB PK, composite PK). Each is gated on both individual
+# ratios and section average ratios. The current ceilings leave room
+# for runner noise while still catching broad regressions.
 # BENCH_RUNS=5 across the job — each non-INTKEY write is a per-
 # statement flush, so the default 11 runs blows the 15-minute budget.
 
@@ -69,16 +68,13 @@ jobs:
         blobpk_rc=$?
         bash ../test/sysbench_compare_compositepk.sh > /tmp/bench_compositepk.md
         compositepk_rc=$?
-        BENCH_SECTION_MODE=autocommit \
-          bash ../test/sysbench_compare.sh           > /tmp/bench_autocommit.md
-        ac_rc=$?
         set -e
         cat /tmp/bench_textpk.md /tmp/bench_blobpk.md \
-            /tmp/bench_compositepk.md /tmp/bench_autocommit.md \
+            /tmp/bench_compositepk.md \
             > /tmp/bench_extra_results.md
         cat /tmp/bench_extra_results.md
         bench_rc=0
-        for rc in "$textpk_rc" "$blobpk_rc" "$compositepk_rc" "$ac_rc"; do
+        for rc in "$textpk_rc" "$blobpk_rc" "$compositepk_rc"; do
           if [ "$rc" != "0" ]; then bench_rc=$rc; fi
         done
         echo "bench_rc=$bench_rc" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -52,7 +52,7 @@ jobs:
         # the rc and propagate it after the PR-comment step has run, so
         # results are still visible on a failing run.
         set +e
-        BENCH_SECTION_MODE=wrapped bash ../test/sysbench_compare.sh > /tmp/bench_results.md
+        BENCH_SECTION_MODE=full bash ../test/sysbench_compare.sh > /tmp/bench_results.md
         bench_rc=$?
         set -e
         cat /tmp/bench_results.md

--- a/test/sysbench_compare.sh
+++ b/test/sysbench_compare.sh
@@ -550,8 +550,6 @@ case "$BENCH_SECTION_MODE" in
   autocommit)
     echo "## Sysbench-Style Benchmark (autocommit): Doltlite vs SQLite"
     echo ""
-    echo "_Moved out of the classic benchmark job so per-commit costs report separately._"
-    echo ""
     echo "### File-Backed (autocommit)"
     echo ""
     echo "_Each statement runs as its own transaction — exposes per-commit_"


### PR DESCRIPTION
## Summary

- `benchmark.yml` ran \`BENCH_SECTION_MODE=wrapped\` (in-memory + file-backed INT-key only).
- `benchmark-extra.yml` ran the three non-INTKEY variants (textpk, blobpk, compositepk) PLUS a separate autocommit run for INT keys.

This PR moves the INT-key autocommit section back into the classic benchmark job:

- `benchmark.yml`: \`BENCH_SECTION_MODE=wrapped\` → \`BENCH_SECTION_MODE=full\`. The \`full\` mode already covers everything \`wrapped\` did plus the ac_reads / ac_writes sections.
- `benchmark-extra.yml`: drop the autocommit invocation; keep textpk / blobpk / compositepk.
- `test/sysbench_compare.sh`: remove the stale "Moved out of the classic benchmark job" note from the \`autocommit\` case (the mode itself stays for local use).

## Test plan

- [ ] Both benchmark jobs run on CI
- [ ] benchmark.yml output now includes the "File-Backed (autocommit)" sections
- [ ] benchmark-extra.yml output no longer contains the autocommit sections; runtime should drop a few minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)