### PR TITLE
chore(lint): extend chunk-layer rule to cover all chunk_*.{c,h}

### DIFF
--- a/test/lint_layers.sh
+++ b/test/lint_layers.sh
@@ -32,11 +32,11 @@ for f in "$SRCDIR"/prolly_*.c; do
   done < <(grep -n 'sqlite3_prepare_v2\|sqlite3_step\|sqlite3_exec' "$f" | grep -v ':[[:space:]]*/\*\|:[[:space:]]*\*\*\|:[[:space:]]*\*[[:space:]]')
 done
 
-# --- Rule 3: chunk_store.* must not include prolly_btree or doltlite headers ---
-for f in "$SRCDIR"/chunk_store.c "$SRCDIR"/chunk_store.h; do
+# --- Rule 3: chunk_*.* must not include prolly_btree or doltlite headers ---
+for f in "$SRCDIR"/chunk_*.c "$SRCDIR"/chunk_*.h; do
   [ -f "$f" ] || continue
   while IFS= read -r line; do
-    lint "$f:$line — chunk_store must not depend on prolly_btree or doltlite"
+    lint "$f:$line — chunk_* layer must not depend on prolly_btree or doltlite"
   done < <(grep -n '#include.*"prolly_btree\|#include.*"doltlite_' "$f")
 done
 


### PR DESCRIPTION
## Summary

After the 5-phase ChunkStore decomposition, the `chunk_*` layer now spans `chunk_store`, `chunk_wal`, `chunk_refs`, `chunk_index`, `chunk_staging`, and `chunk_file`. `test/lint_layers.sh` Rule 3 only checked `chunk_store.{c,h}` — so a new `chunk_*.c` that mistakenly `#include`'d `doltlite_internal.h` (or any other `doltlite_*.h` / `prolly_btree*.h`) would slip through the lint.

This PR globs the rule over all `chunk_*.{c,h}` files so the layering constraint applies to every file in the layer. Existing files already comply (they only `#include` `sqliteInt.h`, `prolly_hash.h`, and each other), so `make lint` continues to pass.

## Diff

```diff
-# --- Rule 3: chunk_store.* must not include prolly_btree or doltlite headers ---
-for f in "$SRCDIR"/chunk_store.c "$SRCDIR"/chunk_store.h; do
+# --- Rule 3: chunk_*.* must not include prolly_btree or doltlite headers ---
+for f in "$SRCDIR"/chunk_*.c "$SRCDIR"/chunk_*.h; do
   [ -f "$f" ] || continue
   while IFS= read -r line; do
-    lint "$f:$line — chunk_store must not depend on prolly_btree or doltlite"
+    lint "$f:$line — chunk_* layer must not depend on prolly_btree or doltlite"
   done < <(grep -n '#include.*"prolly_btree\|#include.*"doltlite_' "$f")
 done
```

## Test plan

- [x] `make lint` passes with the updated rule (all 12 current `chunk_*.{c,h}` files in src already comply)
- [x] Verified glob expands to: `chunk_file.{c,h}`, `chunk_index.{c,h}`, `chunk_refs.{c,h}`, `chunk_staging.{c,h}`, `chunk_store.{c,h}`, `chunk_wal.{c,h}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)