### PR TITLE
docs: document DoltliteVcTxnMode enum

### DIFF
--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -10,6 +10,21 @@ typedef struct BtShared BtShared;
 typedef struct ProllyCache ProllyCache;
 typedef struct SchemaEntry SchemaEntry;
 
+/* Classifies the SQLite transaction shape surrounding a VC operation
+** (merge, cherry-pick, revert, ...). doltliteVcTxnMode() returns one
+** of these based on db->autoCommit and db->pSavepoint, and the VC seal
+** / rollback paths branch on the result:
+**
+**   PLAIN            Inside an explicit BEGIN/COMMIT with no SAVEPOINT.
+**                    Conflicts and violations are surfaced in the
+**                    working set for the user to resolve, then commit.
+**   AUTOCOMMIT_LIKE  autoCommit is on, or a top-level SAVEPOINT is
+**                    acting as the outer txn boundary. VC ops persist
+**                    directly and failures hard-reset session state.
+**   NESTED_SAVEPOINT Inside BEGIN plus one or more nested SAVEPOINTs.
+**                    Failures roll back to the enclosing savepoint, so
+**                    error messages warn that violations are discarded.
+*/
 typedef enum DoltliteVcTxnMode DoltliteVcTxnMode;
 enum DoltliteVcTxnMode {
   DOLTLITE_VC_TXN_PLAIN = 0,


### PR DESCRIPTION
## Summary

Adds a block comment above the `DoltliteVcTxnMode` enum in `src/doltlite_internal.h` explaining when each of the three modes applies. The names alone (PLAIN / AUTOCOMMIT_LIKE / NESTED_SAVEPOINT) were opaque without reading `doltliteVcTxnMode()` and the VC seal / rollback callers.

What each mode means (per `doltliteVcTxnMode()` in `src/doltlite.c` and the switch arms in `doltliteVcCheckoutCommit` / merge / cherry-pick / revert paths):

- **PLAIN** -- Inside an explicit BEGIN/COMMIT with no SAVEPOINT. Conflicts and constraint violations are surfaced in the working set so the user can resolve them and `dolt_commit`.
- **AUTOCOMMIT_LIKE** -- `db->autoCommit` is on, or a top-level SAVEPOINT is acting as the outer txn boundary (`doltliteSavepointIsTopLevelTxn`). VC ops persist directly; failures hard-reset session state (`doltliteHardReset` + restored saved session bits).
- **NESTED_SAVEPOINT** -- Inside BEGIN plus one or more nested SAVEPOINTs. Failures roll back to the enclosing savepoint, which discards conflict / violation rows -- error messages in this arm explicitly tell users to re-run outside a savepoint to inspect them.

Header-only change, no semantic change. Comment is 15 lines, matches the existing SQLite-style `/* ... ** ... */` block-comment tone already used elsewhere in this header (e.g. the `MigrateDiffCtx` field comment).

## Test plan

- [x] `cd build && make doltlite-lib` builds clean (libdoltlite.a + libdoltlite.dylib link successfully)
- [x] No changes outside `src/doltlite_internal.h`

Generated with Claude Code