### PR TITLE
Avoid eager secondary-index payload reconstruction

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -439,19 +439,13 @@ static SQLITE_INLINE void cacheCurrentTreePayloadIfIntKey(BtCursor *pCur){
   }
 }
 
-static void cacheCurrentTreePayloadNonIntKey(BtCursor *pCur){
+static void cacheCurrentTreeStoredPayloadNonIntKey(BtCursor *pCur){
   const u8 *pVal; int nVal;
   cursorCurrentTreeValue(pCur, &pVal, &nVal);
   if( nVal > 0 ){
     pCur->pCachedPayload = (u8*)pVal;
     pCur->nCachedPayload = nVal;
     pCur->cachedPayloadOwned = 0;
-    return;
-  }
-  {
-    const u8 *pKey; int nKey;
-    prollyCursorKey(&pCur->pCur, &pKey, &nKey);
-    (void)cacheCursorPayloadReconstructed(pCur, pKey, nKey);
   }
 }
 
@@ -5360,7 +5354,7 @@ static int prollyBtCursorNext(BtCursor *pCur, int flags){
         if( pCur->curIntKey ){
           cacheCurrentTreePayloadIfIntKey(pCur);
         }else{
-          cacheCurrentTreePayloadNonIntKey(pCur);
+          cacheCurrentTreeStoredPayloadNonIntKey(pCur);
         }
       } else {
         pCur->eState = CURSOR_INVALID;
@@ -5425,7 +5419,7 @@ static int prollyBtCursorNext(BtCursor *pCur, int flags){
           if( pCur->curIntKey ){
             cacheCurrentTreePayloadIfIntKey(pCur);
           }else{
-            cacheCurrentTreePayloadNonIntKey(pCur);
+            cacheCurrentTreeStoredPayloadNonIntKey(pCur);
           }
         } else {
           pCur->eState = CURSOR_INVALID;
@@ -5999,7 +5993,7 @@ static int prollyBtCursorIndexMoveto(
     if( treeFound ){
       *pRes = treeCmp;
       pCur->eState = CURSOR_VALID;
-      cacheCurrentTreePayloadNonIntKey(pCur);
+      cacheCurrentTreeStoredPayloadNonIntKey(pCur);
       return SQLITE_OK;
     }
   }
@@ -6013,7 +6007,7 @@ no_match:
     if( lastRes==0 ){
       pCur->eState = CURSOR_VALID;
       *pRes = -1;
-      cacheCurrentTreePayloadNonIntKey(pCur);
+      cacheCurrentTreeStoredPayloadNonIntKey(pCur);
     } else {
       pCur->eState = CURSOR_INVALID;
       *pRes = -1;


### PR DESCRIPTION
## Summary
- avoid reconstructing secondary-index payload records during cursor movement when the tree entry has no stored value
- keep eager caching for stored tree payloads and rely on the existing lazy payload reconstruction path when the VM actually requests payload
- use the actual seek field count for prefix index seeks, including ordinary rowid secondary indexes where `KeyInfo.nKeyField == nAllField` but the seek key is shorter
- avoid reconstructing a SQLite record when prefix sort-key comparison already proves the current index entry is greater than the seek prefix

## Benchmark signal
- PR CI before the second prefix fix: classic in-memory `index_join_scan` was `3,524 us`, `1.86x`; autocommit reads showed `1.96x`
- local classic int PK after the second prefix fix, `BENCH_RUNS=3 BENCH_SECTION_MODE=wrapped BENCH_ROWS=10000`: `index_join_scan` in-memory was `1,957 us`, `1.50x`
- local companion one-run checks for in-memory `index_join_scan`: text `1.41x`, blob `1.61x`, composite `1.44x`

## Tests
- `make libdoltlite.a`
- `make doltlite`
- `DOLTLITE_BUILD_DIR=. bash test/doltlite_regression_test_c.sh`
- `BENCH_RUNS=3 BENCH_SECTION_MODE=wrapped BENCH_ROWS=10000 BENCH_MAX_MULTIPLIER=99 BENCH_AVG_MAX_MULTIPLIER=99 bash test/sysbench_compare.sh`
- `BENCH_RUNS=1 BENCH_SECTION_MODE=wrapped BENCH_ROWS=10000 BENCH_MAX_MULTIPLIER=99 BENCH_AVG_MAX_MULTIPLIER=99 bash test/sysbench_compare_textpk.sh`
- `BENCH_RUNS=1 BENCH_SECTION_MODE=wrapped BENCH_ROWS=10000 BENCH_MAX_MULTIPLIER=99 BENCH_AVG_MAX_MULTIPLIER=99 bash test/sysbench_compare_blobpk.sh`
- `BENCH_RUNS=1 BENCH_SECTION_MODE=wrapped BENCH_ROWS=10000 BENCH_MAX_MULTIPLIER=99 BENCH_AVG_MAX_MULTIPLIER=99 bash test/sysbench_compare_compositepk.sh`
- `git diff --check`