### PR TITLE
refactor: move index helper bodies into chunk_index.c (Phase 3b)

### DIFF
--- a/src/chunk_index.c
+++ b/src/chunk_index.c
@@ -1,8 +1,23 @@
 
 #ifdef DOLTLITE_PROLLY
 
+#include "chunk_store.h"
 #include "chunk_index.h"
+#include "prolly_hash.h"
 #include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <limits.h>
+#include <sys/stat.h>
+
+#define CS_READ_U32(p) ( \
+    (u32)((p)[0]) | ((u32)((p)[1])<<8) \
+  | ((u32)((p)[2])<<16) | ((u32)((p)[3])<<24))
+#define CS_READ_I64(p) ( \
+    (i64)((u64)(p)[0]) | ((i64)((u64)(p)[1])<<8) \
+  | ((i64)((u64)(p)[2])<<16) | ((i64)((u64)(p)[3])<<24) \
+  | ((i64)((u64)(p)[4])<<32) | ((i64)((u64)(p)[5])<<40) \
+  | ((i64)((u64)(p)[6])<<48) | ((i64)((u64)(p)[7])<<56))
 
 void chunkIndexInit(ChunkIndex *idx){
   memset(idx, 0, sizeof(*idx));
@@ -45,6 +60,331 @@ void chunkIndexReplaceEntries(ChunkIndex *idx, ChunkIndexEntry *aNew, int nNew){
   idx->nIndex = nNew;
   idx->aIndexMmapBase = 0;
   idx->aIndexMmapSize = 0;
+}
+
+#if CHUNK_STORE_LE_PACKING
+#  if defined(_WIN32)
+#    include <windows.h>
+static int csMapIndex(const char *zPath, i64 offset, i64 nBytes,
+                      void **ppMapBase, i64 *pnMapSize,
+                      const u8 **ppData){
+  HANDLE hFile = CreateFileA(zPath, GENERIC_READ, FILE_SHARE_READ,
+                              NULL, OPEN_EXISTING,
+                              FILE_ATTRIBUTE_NORMAL, NULL);
+  HANDLE hMap;
+  void *pMap;
+  SYSTEM_INFO si;
+  i64 alignOffset, alignPad, mapSize;
+
+  if( hFile==INVALID_HANDLE_VALUE ) return SQLITE_CANTOPEN;
+
+  GetSystemInfo(&si);
+  alignOffset = (offset / si.dwAllocationGranularity)
+              * si.dwAllocationGranularity;
+  alignPad = offset - alignOffset;
+  mapSize = nBytes + alignPad;
+
+  hMap = CreateFileMappingA(hFile, NULL, PAGE_READONLY, 0, 0, NULL);
+  CloseHandle(hFile);
+  if( hMap==NULL ) return SQLITE_IOERR;
+
+  pMap = MapViewOfFile(hMap, FILE_MAP_READ,
+                        (DWORD)(alignOffset >> 32),
+                        (DWORD)(alignOffset & 0xFFFFFFFF),
+                        (SIZE_T)mapSize);
+  CloseHandle(hMap);
+  if( pMap==NULL ) return SQLITE_IOERR;
+
+  *ppMapBase = pMap;
+  *pnMapSize = mapSize;
+  *ppData = (const u8 *)pMap + alignPad;
+  return SQLITE_OK;
+}
+
+static void csUnmapIndex(void *pMapBase, i64 nMapSize){
+  (void)nMapSize;
+  if( pMapBase ) UnmapViewOfFile(pMapBase);
+}
+#  else
+#    include <sys/mman.h>
+#    include <fcntl.h>
+#    include <unistd.h>
+static int csMapIndex(const char *zPath, i64 offset, i64 nBytes,
+                      void **ppMapBase, i64 *pnMapSize,
+                      const u8 **ppData){
+  int fd;
+  long pageSize;
+  i64 alignOffset, alignPad, mapSize;
+  void *pMap;
+
+  fd = open(zPath, O_RDONLY);
+  if( fd < 0 ) return SQLITE_CANTOPEN;
+
+  pageSize = sysconf(_SC_PAGESIZE);
+  if( pageSize <= 0 ) pageSize = 4096;
+
+  alignOffset = (offset / pageSize) * pageSize;
+  alignPad = offset - alignOffset;
+  mapSize = nBytes + alignPad;
+
+  pMap = mmap(NULL, (size_t)mapSize, PROT_READ, MAP_PRIVATE, fd,
+              (off_t)alignOffset);
+  close(fd);
+  if( pMap == MAP_FAILED ) return SQLITE_IOERR;
+
+  *ppMapBase = pMap;
+  *pnMapSize = mapSize;
+  *ppData = (const u8 *)pMap + alignPad;
+  return SQLITE_OK;
+}
+
+static void csUnmapIndex(void *pMapBase, i64 nMapSize){
+  if( pMapBase ) munmap(pMapBase, (size_t)nMapSize);
+}
+#  endif
+#else
+static int csMapIndex(const char *zPath, i64 offset, i64 nBytes,
+                      void **ppMapBase, i64 *pnMapSize,
+                      const u8 **ppData){
+  (void)zPath; (void)offset; (void)nBytes;
+  (void)ppMapBase; (void)pnMapSize; (void)ppData;
+  return SQLITE_NOTFOUND;
+}
+static void csUnmapIndex(void *pMapBase, i64 nMapSize){
+  (void)pMapBase; (void)nMapSize;
+}
+#endif
+
+void csReleaseIndexBuf(ChunkIndexEntry *aIndex,
+                       void *mmapBase, i64 mmapSize){
+  if( mmapBase ){
+    csUnmapIndex(mmapBase, mmapSize);
+  }else{
+    sqlite3_free(aIndex);
+  }
+}
+
+int csSearchIndex(
+  const ChunkIndexEntry *aIdx,
+  int nIdx,
+  const ProllyHash *pHash
+){
+  int lo = 0;
+  int hi = nIdx - 1;
+  while( lo <= hi ){
+    int mid = lo + (hi - lo) / 2;
+    int cmp = prollyHashCompare(&aIdx[mid].hash, pHash);
+    if( cmp == 0 ) return mid;
+    if( cmp < 0 ){
+      lo = mid + 1;
+    }else{
+      hi = mid - 1;
+    }
+  }
+  return -1;
+}
+
+static int csDeserializeIndexEntry(const u8 *aBuf, ChunkIndexEntry *e){
+  u32 sz = CS_READ_U32(aBuf + PROLLY_HASH_SIZE + 8);
+  if( sz > (u32)0x7fffffff ) return SQLITE_CORRUPT;
+  memcpy(e->hash.data, aBuf, PROLLY_HASH_SIZE);
+  e->offset = CS_READ_I64(aBuf + PROLLY_HASH_SIZE);
+  e->size = (int)sz;
+  return SQLITE_OK;
+}
+
+int csReadIndex(ChunkStore *cs){
+  int rc;
+  i64 nEntries64;
+  int nEntries;
+  u8 *aBuf;
+  int i;
+  void *pMapBase = 0;
+  i64 nMapSize = 0;
+  const u8 *pMapData = 0;
+  i64 fileSize = 0;
+
+  if( cs->index.nIndexSize == 0 || cs->index.nChunks == 0 ){
+    cs->index.nIndex = 0;
+    return SQLITE_OK;
+  }
+
+  nEntries64 = cs->index.nIndexSize / CHUNK_INDEX_ENTRY_SIZE;
+  if( nEntries64 * CHUNK_INDEX_ENTRY_SIZE != cs->index.nIndexSize ){
+    return SQLITE_CORRUPT;
+  }
+  if( nEntries64 > INT_MAX ){
+    return SQLITE_TOOBIG;
+  }
+  nEntries = (int)nEntries64;
+
+  if( cs->index.iIndexOffset < 0 || cs->index.nIndexSize < 0 ){
+    return SQLITE_CORRUPT;
+  }
+  if( cs->file.pFile ){
+    rc = sqlite3OsFileSize(cs->file.pFile, &fileSize);
+    if( rc != SQLITE_OK ) return rc;
+  }else if( cs->file.zFilename ){
+    struct stat st;
+    if( stat(cs->file.zFilename, &st) != 0 ) return SQLITE_IOERR;
+    fileSize = (i64)st.st_size;
+  }
+  if( fileSize > 0
+   && (cs->index.iIndexOffset > fileSize
+       || cs->index.nIndexSize > fileSize - cs->index.iIndexOffset) ){
+    return SQLITE_CORRUPT;
+  }
+
+  if( cs->file.zFilename
+   && csMapIndex(cs->file.zFilename, cs->index.iIndexOffset, cs->index.nIndexSize,
+                  &pMapBase, &nMapSize, &pMapData) == SQLITE_OK ){
+    cs->index.aIndex = (ChunkIndexEntry *)pMapData;
+    cs->index.nIndex = nEntries;
+    cs->index.aIndexMmapBase = pMapBase;
+    cs->index.aIndexMmapSize = nMapSize;
+    return SQLITE_OK;
+  }
+
+  cs->index.aIndex = (ChunkIndexEntry *)sqlite3_malloc(
+    nEntries * (int)sizeof(ChunkIndexEntry)
+  );
+  if( cs->index.aIndex == 0 ) return SQLITE_NOMEM;
+  cs->index.nIndex = nEntries;
+  cs->index.aIndexMmapBase = 0;
+  cs->index.aIndexMmapSize = 0;
+
+  aBuf = (u8 *)sqlite3_malloc64(cs->index.nIndexSize);
+  if( aBuf == 0 ){
+    sqlite3_free(cs->index.aIndex);
+    cs->index.aIndex = 0;
+    cs->index.nIndex = 0;
+    return SQLITE_NOMEM;
+  }
+
+  rc = sqlite3OsRead(cs->file.pFile, aBuf, cs->index.nIndexSize, cs->index.iIndexOffset);
+  if( rc != SQLITE_OK ){
+    sqlite3_free(aBuf);
+    sqlite3_free(cs->index.aIndex);
+    cs->index.aIndex = 0;
+    cs->index.nIndex = 0;
+    return rc;
+  }
+
+  for( i = 0; i < nEntries; i++ ){
+    rc = csDeserializeIndexEntry(aBuf + i * CHUNK_INDEX_ENTRY_SIZE,
+                                 &cs->index.aIndex[i]);
+    if( rc != SQLITE_OK ){
+      sqlite3_free(aBuf);
+      sqlite3_free(cs->index.aIndex);
+      cs->index.aIndex = 0;
+      cs->index.nIndex = 0;
+      return rc;
+    }
+  }
+
+  sqlite3_free(aBuf);
+  return SQLITE_OK;
+}
+
+static int csIndexEntryCmp(const void *a, const void *b){
+  const ChunkIndexEntry *ea = (const ChunkIndexEntry *)a;
+  const ChunkIndexEntry *eb = (const ChunkIndexEntry *)b;
+  return prollyHashCompare(&ea->hash, &eb->hash);
+}
+
+static int csIndexLowerBound(
+  const ChunkIndexEntry *aIndex,
+  int nIndex,
+  int lo,
+  const ProllyHash *pHash
+){
+  int hi = nIndex;
+  while( lo < hi ){
+    int mid = lo + ((hi - lo) >> 1);
+    if( prollyHashCompare(&aIndex[mid].hash, pHash) < 0 ){
+      lo = mid + 1;
+    }else{
+      hi = mid;
+    }
+  }
+  return lo;
+}
+
+int csMergeIndex(
+  ChunkStore *cs,
+  ChunkIndexEntry **ppMerged,
+  int *pnMerged
+){
+  int nTotal = cs->index.nIndex + cs->staging.nPending;
+  ChunkIndexEntry *aMerged;
+  int idxPos, pendPos, outPos;
+
+  *ppMerged = 0;
+  *pnMerged = 0;
+  if( nTotal == 0 ) return SQLITE_OK;
+
+  aMerged = (ChunkIndexEntry *)sqlite3_malloc(
+    nTotal * (int)sizeof(ChunkIndexEntry)
+  );
+  if( aMerged == 0 ) return SQLITE_NOMEM;
+
+  if( cs->staging.nPending > 1 ){
+    qsort(cs->staging.aPending, cs->staging.nPending, sizeof(ChunkIndexEntry),
+          csIndexEntryCmp);
+  }
+
+  if( cs->staging.nPending > 0 && cs->staging.nPending <= 32 ){
+    idxPos = 0;
+    outPos = 0;
+    for( pendPos = 0; pendPos < cs->staging.nPending; pendPos++ ){
+      ChunkIndexEntry *pPending = &cs->staging.aPending[pendPos];
+      int found;
+      int nCopy;
+      int pos = csIndexLowerBound(cs->index.aIndex, cs->index.nIndex, idxPos,
+                                  &pPending->hash);
+      nCopy = pos - idxPos;
+      if( nCopy > 0 ){
+        memcpy(&aMerged[outPos], &cs->index.aIndex[idxPos],
+               nCopy * sizeof(ChunkIndexEntry));
+        outPos += nCopy;
+      }
+      found = pos < cs->index.nIndex
+           && prollyHashCompare(&cs->index.aIndex[pos].hash, &pPending->hash)==0;
+      aMerged[outPos++] = *pPending;
+      idxPos = found ? pos + 1 : pos;
+    }
+    if( idxPos < cs->index.nIndex ){
+      int nCopy = cs->index.nIndex - idxPos;
+      memcpy(&aMerged[outPos], &cs->index.aIndex[idxPos],
+             nCopy * sizeof(ChunkIndexEntry));
+      outPos += nCopy;
+    }
+    *ppMerged = aMerged;
+    *pnMerged = outPos;
+    return SQLITE_OK;
+  }
+
+  idxPos = 0;
+  pendPos = 0;
+  outPos = 0;
+  while( idxPos < cs->index.nIndex && pendPos < cs->staging.nPending ){
+    int cmp = prollyHashCompare(&cs->index.aIndex[idxPos].hash, &cs->staging.aPending[pendPos].hash);
+    if( cmp < 0 ){
+      aMerged[outPos++] = cs->index.aIndex[idxPos++];
+    }else if( cmp > 0 ){
+      aMerged[outPos++] = cs->staging.aPending[pendPos++];
+    }else{
+
+      aMerged[outPos++] = cs->staging.aPending[pendPos++];
+      idxPos++;
+    }
+  }
+  while( idxPos < cs->index.nIndex ) aMerged[outPos++] = cs->index.aIndex[idxPos++];
+  while( pendPos < cs->staging.nPending ) aMerged[outPos++] = cs->staging.aPending[pendPos++];
+
+  *ppMerged = aMerged;
+  *pnMerged = outPos;
+  return SQLITE_OK;
 }
 
 #endif

--- a/src/chunk_index.h
+++ b/src/chunk_index.h
@@ -49,4 +49,10 @@ i64 chunkIndexSize(const ChunkIndex *idx);
 void chunkIndexSetMetadata(ChunkIndex *idx, int nChunks, i64 iOffset, i64 nSize);
 void chunkIndexReplaceEntries(ChunkIndex *idx, ChunkIndexEntry *aNew, int nNew);
 
+struct ChunkStore;
+int csReadIndex(struct ChunkStore *cs);
+int csSearchIndex(const ChunkIndexEntry *aIdx, int nIdx, const ProllyHash *pHash);
+int csMergeIndex(struct ChunkStore *cs, ChunkIndexEntry **ppMerged, int *pnMerged);
+void csReleaseIndexBuf(ChunkIndexEntry *aIndex, void *mmapBase, i64 mmapSize);
+
 #endif

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -122,16 +122,9 @@ static void csCloseFile(sqlite3_file *pFile);
 static int csRollbackFailedAppend(ChunkStore *cs, i64 origFileSize);
 static int csRestoreCommittedRefsState(ChunkStore *cs);
 static int csReadManifest(ChunkStore *cs);
-static int csReadIndex(ChunkStore *cs);
 static int csDeserializeRefs(ChunkStore *cs, const u8 *data, int nData);
-static int csSearchIndex(const ChunkIndexEntry *aIdx, int nIdx,
-                         const ProllyHash *pHash);
 static int csSearchPending(ChunkStore *cs, const ProllyHash *pHash, int *pIdx);
-static int csIndexEntryCmp(const void *a, const void *b);
 void csSerializeManifest(const ChunkStore *cs, u8 *aBuf);
-static int csDeserializeIndexEntry(const u8 *aBuf, ChunkIndexEntry *e);
-static int csMergeIndex(ChunkStore *cs, ChunkIndexEntry **ppMerged,
-                        int *pnMerged);
 static int csGrowPending(ChunkStore *cs);
 static int csGrowRecent(ChunkStore *cs, int nAdd);
 static int csGrowWriteBuf(ChunkStore *cs, int nNeeded);
@@ -197,108 +190,6 @@ typedef char chunk_index_entry_size_check[
   (sizeof(ChunkIndexEntry) == CHUNK_INDEX_ENTRY_SIZE) ? 1 : -1
 ];
 #endif
-
-#if CHUNK_STORE_LE_PACKING
-#  if defined(_WIN32)
-#    include <windows.h>
-static int csMapIndex(const char *zPath, i64 offset, i64 nBytes,
-                      void **ppMapBase, i64 *pnMapSize,
-                      const u8 **ppData){
-  HANDLE hFile = CreateFileA(zPath, GENERIC_READ, FILE_SHARE_READ,
-                              NULL, OPEN_EXISTING,
-                              FILE_ATTRIBUTE_NORMAL, NULL);
-  HANDLE hMap;
-  void *pMap;
-  SYSTEM_INFO si;
-  i64 alignOffset, alignPad, mapSize;
-
-  if( hFile==INVALID_HANDLE_VALUE ) return SQLITE_CANTOPEN;
-
-  GetSystemInfo(&si);
-  alignOffset = (offset / si.dwAllocationGranularity)
-              * si.dwAllocationGranularity;
-  alignPad = offset - alignOffset;
-  mapSize = nBytes + alignPad;
-
-  hMap = CreateFileMappingA(hFile, NULL, PAGE_READONLY, 0, 0, NULL);
-  CloseHandle(hFile);
-  if( hMap==NULL ) return SQLITE_IOERR;
-
-  pMap = MapViewOfFile(hMap, FILE_MAP_READ,
-                        (DWORD)(alignOffset >> 32),
-                        (DWORD)(alignOffset & 0xFFFFFFFF),
-                        (SIZE_T)mapSize);
-  CloseHandle(hMap);
-  if( pMap==NULL ) return SQLITE_IOERR;
-
-  *ppMapBase = pMap;
-  *pnMapSize = mapSize;
-  *ppData = (const u8 *)pMap + alignPad;
-  return SQLITE_OK;
-}
-
-static void csUnmapIndex(void *pMapBase, i64 nMapSize){
-  (void)nMapSize;
-  if( pMapBase ) UnmapViewOfFile(pMapBase);
-}
-#  else
-#    include <sys/mman.h>
-#    include <fcntl.h>
-#    include <unistd.h>
-static int csMapIndex(const char *zPath, i64 offset, i64 nBytes,
-                      void **ppMapBase, i64 *pnMapSize,
-                      const u8 **ppData){
-  int fd;
-  long pageSize;
-  i64 alignOffset, alignPad, mapSize;
-  void *pMap;
-
-  fd = open(zPath, O_RDONLY);
-  if( fd < 0 ) return SQLITE_CANTOPEN;
-
-  pageSize = sysconf(_SC_PAGESIZE);
-  if( pageSize <= 0 ) pageSize = 4096;
-
-  alignOffset = (offset / pageSize) * pageSize;
-  alignPad = offset - alignOffset;
-  mapSize = nBytes + alignPad;
-
-  pMap = mmap(NULL, (size_t)mapSize, PROT_READ, MAP_PRIVATE, fd,
-              (off_t)alignOffset);
-  close(fd);
-  if( pMap == MAP_FAILED ) return SQLITE_IOERR;
-
-  *ppMapBase = pMap;
-  *pnMapSize = mapSize;
-  *ppData = (const u8 *)pMap + alignPad;
-  return SQLITE_OK;
-}
-
-static void csUnmapIndex(void *pMapBase, i64 nMapSize){
-  if( pMapBase ) munmap(pMapBase, (size_t)nMapSize);
-}
-#  endif
-#else
-static int csMapIndex(const char *zPath, i64 offset, i64 nBytes,
-                      void **ppMapBase, i64 *pnMapSize,
-                      const u8 **ppData){
-  (void)zPath; (void)offset; (void)nBytes;
-  (void)ppMapBase; (void)pnMapSize; (void)ppData;
-  return SQLITE_NOTFOUND;
-}
-static void csUnmapIndex(void *pMapBase, i64 nMapSize){
-  (void)pMapBase; (void)nMapSize;
-}
-#endif
-
-static void csReleaseIndexBuf(ChunkIndexEntry *aIndex,
-                              void *mmapBase, i64 mmapSize){
-  if( mmapBase ){
-    csUnmapIndex(mmapBase, mmapSize);
-  }else{
-    sqlite3_free(aIndex);
-  }
-}
 
 static void csFreeBranches(ChunkStore *cs){
   int k;
@@ -616,26 +507,6 @@ static int csReloadFromDiskPreservingLocalRefs(ChunkStore *cs){
   return rc;
 }
 
-static int csSearchIndex(
-  const ChunkIndexEntry *aIdx,
-  int nIdx,
-  const ProllyHash *pHash
-){
-  int lo = 0;
-  int hi = nIdx - 1;
-  while( lo <= hi ){
-    int mid = lo + (hi - lo) / 2;
-    int cmp = prollyHashCompare(&aIdx[mid].hash, pHash);
-    if( cmp == 0 ) return mid;
-    if( cmp < 0 ){
-      lo = mid + 1;
-    }else{
-      hi = mid - 1;
-    }
-  }
-  return -1;
-}
-
 #define CS_PEND_HT_INIT_BITS 12
 #define CS_PEND_HT_MAX_LOAD  4
 
@@ -822,15 +693,6 @@ void csSerializeManifest(const ChunkStore *cs, u8 *aBuf){
   memcpy(aBuf + 104, cs->refs.refsHash.data, PROLLY_HASH_SIZE);
 }
 
-static int csDeserializeIndexEntry(const u8 *aBuf, ChunkIndexEntry *e){
-  u32 sz = CS_READ_U32(aBuf + PROLLY_HASH_SIZE + 8);
-  if( sz > (u32)0x7fffffff ) return SQLITE_CORRUPT;
-  memcpy(e->hash.data, aBuf, PROLLY_HASH_SIZE);
-  e->offset = CS_READ_I64(aBuf + PROLLY_HASH_SIZE);
-  e->size = (int)sz;
-  return SQLITE_OK;
-}
-
 static int csReadManifest(ChunkStore *cs){
   u8 aBuf[CHUNK_MANIFEST_SIZE];
   u32 magic, version;
@@ -858,103 +720,6 @@ static int csReadManifest(ChunkStore *cs){
   cs->wal.iWalOffset = CS_READ_I64(aBuf + 84);
   memcpy(cs->refs.refsHash.data, aBuf + 104, PROLLY_HASH_SIZE);
 
-  return SQLITE_OK;
-}
-
-static int csReadIndex(ChunkStore *cs){
-  int rc;
-  i64 nEntries64;
-  int nEntries;
-  u8 *aBuf;
-  int i;
-  void *pMapBase = 0;
-  i64 nMapSize = 0;
-  const u8 *pMapData = 0;
-  i64 fileSize = 0;
-
-  if( cs->index.nIndexSize == 0 || cs->index.nChunks == 0 ){
-    cs->index.nIndex = 0;
-    return SQLITE_OK;
-  }
-
-  nEntries64 = cs->index.nIndexSize / CHUNK_INDEX_ENTRY_SIZE;
-  if( nEntries64 * CHUNK_INDEX_ENTRY_SIZE != cs->index.nIndexSize ){
-    return SQLITE_CORRUPT;
-  }
-  if( nEntries64 > INT_MAX ){
-    return SQLITE_TOOBIG;
-  }
-  nEntries = (int)nEntries64;
-
-  /* Validate that iIndexOffset + nIndexSize lies within the file. mmap'ing
-  ** past EOF can return zero-filled or sparse pages on some platforms,
-  ** which causes csSearchIndex to read garbage and SIGBUS instead of
-  ** returning SQLITE_CORRUPT. See issue #827. */
-  if( cs->index.iIndexOffset < 0 || cs->index.nIndexSize < 0 ){
-    return SQLITE_CORRUPT;
-  }
-  if( cs->file.pFile ){
-    rc = sqlite3OsFileSize(cs->file.pFile, &fileSize);
-    if( rc != SQLITE_OK ) return rc;
-  }else if( cs->file.zFilename ){
-    struct stat st;
-    if( stat(cs->file.zFilename, &st) != 0 ) return SQLITE_IOERR;
-    fileSize = (i64)st.st_size;
-  }
-  if( fileSize > 0
-   && (cs->index.iIndexOffset > fileSize
-       || cs->index.nIndexSize > fileSize - cs->index.iIndexOffset) ){
-    return SQLITE_CORRUPT;
-  }
-
-  if( cs->file.zFilename
-   && csMapIndex(cs->file.zFilename, cs->index.iIndexOffset, cs->index.nIndexSize,
-                  &pMapBase, &nMapSize, &pMapData) == SQLITE_OK ){
-    cs->index.aIndex = (ChunkIndexEntry *)pMapData;
-    cs->index.nIndex = nEntries;
-    cs->index.aIndexMmapBase = pMapBase;
-    cs->index.aIndexMmapSize = nMapSize;
-    return SQLITE_OK;
-  }
-
-  cs->index.aIndex = (ChunkIndexEntry *)sqlite3_malloc(
-    nEntries * (int)sizeof(ChunkIndexEntry)
-  );
-  if( cs->index.aIndex == 0 ) return SQLITE_NOMEM;
-  cs->index.nIndex = nEntries;
-  cs->index.aIndexMmapBase = 0;
-  cs->index.aIndexMmapSize = 0;
-
-  aBuf = (u8 *)sqlite3_malloc64(cs->index.nIndexSize);
-  if( aBuf == 0 ){
-    sqlite3_free(cs->index.aIndex);
-    cs->index.aIndex = 0;
-    cs->index.nIndex = 0;
-    return SQLITE_NOMEM;
-  }
-
-  rc = sqlite3OsRead(cs->file.pFile, aBuf, cs->index.nIndexSize, cs->index.iIndexOffset);
-  if( rc != SQLITE_OK ){
-    sqlite3_free(aBuf);
-    sqlite3_free(cs->index.aIndex);
-    cs->index.aIndex = 0;
-    cs->index.nIndex = 0;
-    return rc;
-  }
-
-  for( i = 0; i < nEntries; i++ ){
-    rc = csDeserializeIndexEntry(aBuf + i * CHUNK_INDEX_ENTRY_SIZE,
-                                 &cs->index.aIndex[i]);
-    if( rc != SQLITE_OK ){
-      sqlite3_free(aBuf);
-      sqlite3_free(cs->index.aIndex);
-      cs->index.aIndex = 0;
-      cs->index.nIndex = 0;
-      return rc;
-    }
-  }
-
-  sqlite3_free(aBuf);
   return SQLITE_OK;
 }
 
@@ -1162,107 +927,6 @@ replay_error:
   if( haveTmpRefs ) csFreeRefsState(&tmpRefs);
   csRollbackReplayState(cs, &saved, nPendingBefore);
   return rc;
-}
-
-static int csIndexEntryCmp(const void *a, const void *b){
-  const ChunkIndexEntry *ea = (const ChunkIndexEntry *)a;
-  const ChunkIndexEntry *eb = (const ChunkIndexEntry *)b;
-  return prollyHashCompare(&ea->hash, &eb->hash);
-}
-
-static int csIndexLowerBound(
-  const ChunkIndexEntry *aIndex,
-  int nIndex,
-  int lo,
-  const ProllyHash *pHash
-){
-  int hi = nIndex;
-  while( lo < hi ){
-    int mid = lo + ((hi - lo) >> 1);
-    if( prollyHashCompare(&aIndex[mid].hash, pHash) < 0 ){
-      lo = mid + 1;
-    }else{
-      hi = mid;
-    }
-  }
-  return lo;
-}
-
-static int csMergeIndex(
-  ChunkStore *cs,
-  ChunkIndexEntry **ppMerged,
-  int *pnMerged
-){
-  int nTotal = cs->index.nIndex + cs->staging.nPending;
-  ChunkIndexEntry *aMerged;
-  int idxPos, pendPos, outPos;
-
-  *ppMerged = 0;
-  *pnMerged = 0;
-  if( nTotal == 0 ) return SQLITE_OK;
-
-  aMerged = (ChunkIndexEntry *)sqlite3_malloc(
-    nTotal * (int)sizeof(ChunkIndexEntry)
-  );
-  if( aMerged == 0 ) return SQLITE_NOMEM;
-
-  if( cs->staging.nPending > 1 ){
-    qsort(cs->staging.aPending, cs->staging.nPending, sizeof(ChunkIndexEntry),
-          csIndexEntryCmp);
-  }
-
-  if( cs->staging.nPending > 0 && cs->staging.nPending <= 32 ){
-    idxPos = 0;
-    outPos = 0;
-    for( pendPos = 0; pendPos < cs->staging.nPending; pendPos++ ){
-      ChunkIndexEntry *pPending = &cs->staging.aPending[pendPos];
-      int found;
-      int nCopy;
-      int pos = csIndexLowerBound(cs->index.aIndex, cs->index.nIndex, idxPos,
-                                  &pPending->hash);
-      nCopy = pos - idxPos;
-      if( nCopy > 0 ){
-        memcpy(&aMerged[outPos], &cs->index.aIndex[idxPos],
-               nCopy * sizeof(ChunkIndexEntry));
-        outPos += nCopy;
-      }
-      found = pos < cs->index.nIndex
-           && prollyHashCompare(&cs->index.aIndex[pos].hash, &pPending->hash)==0;
-      aMerged[outPos++] = *pPending;
-      idxPos = found ? pos + 1 : pos;
-    }
-    if( idxPos < cs->index.nIndex ){
-      int nCopy = cs->index.nIndex - idxPos;
-      memcpy(&aMerged[outPos], &cs->index.aIndex[idxPos],
-             nCopy * sizeof(ChunkIndexEntry));
-      outPos += nCopy;
-    }
-    *ppMerged = aMerged;
-    *pnMerged = outPos;
-    return SQLITE_OK;
-  }
-
-  idxPos = 0;
-  pendPos = 0;
-  outPos = 0;
-  while( idxPos < cs->index.nIndex && pendPos < cs->staging.nPending ){
-    int cmp = prollyHashCompare(&cs->index.aIndex[idxPos].hash, &cs->staging.aPending[pendPos].hash);
-    if( cmp < 0 ){
-      aMerged[outPos++] = cs->index.aIndex[idxPos++];
-    }else if( cmp > 0 ){
-      aMerged[outPos++] = cs->staging.aPending[pendPos++];
-    }else{
-
-      aMerged[outPos++] = cs->staging.aPending[pendPos++];
-      idxPos++;
-    }
-  }
-  while( idxPos < cs->index.nIndex ) aMerged[outPos++] = cs->index.aIndex[idxPos++];
-  while( pendPos < cs->staging.nPending ) aMerged[outPos++] = cs->staging.aPending[pendPos++];
-
-  *ppMerged = aMerged;
-  *pnMerged = outPos;
-  return SQLITE_OK;
 }
 
 int chunkStoreOpen(


### PR DESCRIPTION
Follow-up tidiness to the Phase 3 ChunkIndex extraction (PR #877). Moves the static helpers that operate on ChunkIndex state out of \`chunk_store.c\` and into \`chunk_index.c\` where the rest of the index code already lives.

## What moved

From \`chunk_store.c\` → \`chunk_index.c\`:

- \`csReadIndex\` — mmap-or-malloc-read + deserialize the durable index
- \`csSearchIndex\` — binary search by hash
- \`csMergeIndex\` — merge pending+index into a new sorted array
- \`csReleaseIndexBuf\` — unmap or free
- \`csDeserializeIndexEntry\`, \`csIndexEntryCmp\`, \`csIndexLowerBound\`
- \`csMapIndex\` (Windows / Unix mmap / NOTFOUND-stub variants), \`csUnmapIndex\` (3 variants)

## API split

The four functions chunk_store.c still calls (\`csReadIndex\`, \`csSearchIndex\`, \`csMergeIndex\`, \`csReleaseIndexBuf\`) become non-static and get forward declarations in \`chunk_index.h\`. The rest stay static-internal to chunk_index.c.

\`chunk_index.c\` now \`#include\`s \`chunk_store.h\` (the ChunkStore struct is needed by \`csReadIndex\` reading \`cs->file.*\` and \`csMergeIndex\` walking \`cs->staging.*\`). \`CS_READ_U32\` / \`CS_READ_I64\` byte-unpacking macros are duplicated locally rather than promoting them to a shared header.

## Test plan

- [x] \`make doltlite-lib && make doltlite\` clean
- [x] Smoke: CREATE TABLE + dolt_commit returns hash
- [x] \`make lint\` passes (lint_layers — chunk_index.c only depends on chunk_store.h and prolly_hash.h)
- [x] \`wal_offset_corruption\` (5/5), \`truncated_wal_rejected\` (6/6), \`memory_chunk_lookup_corruption\` (5/5) pass locally
- [ ] Full CI

## Scope

\`chunk_store.c\` is now ~336 lines smaller. This is the first of the deferred Phase-Xb function-body moves; the equivalent work for refs/staging/wal/file helpers can follow incrementally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)