### PR TITLE
Optimize prefix index seek comparison

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -5750,10 +5750,8 @@ static int prollyBtCursorIndexMoveto(
     u8 *pSortKey = 0;
     int nSortKey = 0;
     int nSeekKeyField = 0;
-    if( pCur->pKeyInfo
-     && pCur->pKeyInfo->nKeyField < pCur->pKeyInfo->nAllField
-     && pIdxKey->nField < pCur->pKeyInfo->nAllField ){
-      nSeekKeyField = (int)pCur->pKeyInfo->nKeyField;
+    if( pCur->pKeyInfo && pIdxKey->nField < pCur->pKeyInfo->nAllField ){
+      nSeekKeyField = (int)pIdxKey->nField;
     }
     rc = serializeUnpackedRecordBuffer(
         pIdxKey, &pCur->pSeekRecord, &pCur->nSeekRecordAlloc, &nSerKey);
@@ -5836,17 +5834,22 @@ static int prollyBtCursorIndexMoveto(
                   if( mmE && mmE->op==PROLLY_EDIT_DELETE ) isDeleted = 1;
                 }
                 if( !isDeleted ){
-                  const u8 *pVal2; int nVal2;
-                  prollyNodeValue(&pLeaf->node, i, &pVal2, &nVal2);
-                  if( nVal2==0 ){
-                    rc = recordFromSortKeyBuffer(
-                        pSK, nSK, &pRecBuf, &nRecBufAlloc, &nVal2);
-                    if( rc!=SQLITE_OK ) break;
-                    pVal2 = pRecBuf;
-                  }
-                  pIdxKey->eqSeen = 0;
                   bestIdx = i;
-                  bestCmp = sqlite3VdbeRecordCompare(nVal2, pVal2, pIdxKey);
+                  if( nSeekKeyField>0 ){
+                    pIdxKey->eqSeen = 0;
+                    bestCmp = 1;
+                  }else{
+                    const u8 *pVal2; int nVal2;
+                    prollyNodeValue(&pLeaf->node, i, &pVal2, &nVal2);
+                    if( nVal2==0 ){
+                      rc = recordFromSortKeyBuffer(
+                          pSK, nSK, &pRecBuf, &nRecBufAlloc, &nVal2);
+                      if( rc!=SQLITE_OK ) break;
+                      pVal2 = pRecBuf;
+                    }
+                    pIdxKey->eqSeen = 0;
+                    bestCmp = sqlite3VdbeRecordCompare(nVal2, pVal2, pIdxKey);
+                  }
                 }
               }
               break;


### PR DESCRIPTION
## Summary
- use the actual seek field count for prefix index seeks instead of relying on `KeyInfo.nKeyField < nAllField`
- cover ordinary rowid secondary indexes where `KeyInfo.nKeyField == nAllField` but the seek key is still a shorter prefix
- when sort-key bytes already prove the current entry is greater than the prefix seek key, avoid reconstructing a SQLite record just to compare it
- cache the encoded seek prefix from `IndexMoveto` and let `IdxGT`/`IdxGE` compare against it directly for `BTREE_SEEK_EQ` cursors, avoiding lazy payload reconstruction in the join-scan inner loop without affecting ordinary BETWEEN/range scans

## Benchmark signal
- PR CI before cached `BTREE_SEEK_EQ` compare: classic in-memory `index_join_scan` was `3,300 us`, `1.74x`
- local classic int PK after cached compare, `BENCH_RUNS=3 BENCH_SECTION_MODE=wrapped BENCH_ROWS=10000`: in-memory `index_join_scan` was `1,844 us`, `1.41x`; `covering_index_scan` stayed normal at `1.67x`
- local companion one-run checks for in-memory `index_join_scan`: text `1.42x`, blob `1.49x`, composite `1.43x`

## Tests
- `make libdoltlite.a`
- `make doltlite`
- `DOLTLITE_BUILD_DIR=. bash test/doltlite_regression_test_c.sh`
- `BENCH_RUNS=3 BENCH_SECTION_MODE=wrapped BENCH_ROWS=10000 BENCH_MAX_MULTIPLIER=99 BENCH_AVG_MAX_MULTIPLIER=99 bash test/sysbench_compare.sh`
- `BENCH_RUNS=1 BENCH_SECTION_MODE=wrapped BENCH_ROWS=10000 BENCH_MAX_MULTIPLIER=99 BENCH_AVG_MAX_MULTIPLIER=99 bash test/sysbench_compare_textpk.sh`
- `BENCH_RUNS=1 BENCH_SECTION_MODE=wrapped BENCH_ROWS=10000 BENCH_MAX_MULTIPLIER=99 BENCH_AVG_MAX_MULTIPLIER=99 bash test/sysbench_compare_blobpk.sh`
- `BENCH_RUNS=1 BENCH_SECTION_MODE=wrapped BENCH_ROWS=10000 BENCH_MAX_MULTIPLIER=99 BENCH_AVG_MAX_MULTIPLIER=99 bash test/sysbench_compare_compositepk.sh`
- `git diff --check`