### PR TITLE
refactor(chunk-store): Phase 5b — move csCloseFile body to chunk_file.c

### DIFF
--- a/src/chunk_file.c
+++ b/src/chunk_file.c
@@ -32,4 +32,10 @@ void chunkFileSetSize(ChunkFile *cf, i64 nSize){
   cf->iFileSize = nSize;
 }
 
+void csCloseFile(sqlite3_file *pFile){
+  if( pFile ){
+    sqlite3OsCloseFree(pFile);
+  }
+}
+
 #endif

--- a/src/chunk_file.h
+++ b/src/chunk_file.h
@@ -23,4 +23,6 @@ i64 chunkFileGetSize(const ChunkFile *cf);
 void chunkFileSetHandle(ChunkFile *cf, sqlite3_file *pFile);
 void chunkFileSetSize(ChunkFile *cf, i64 nSize);
 
+void csCloseFile(sqlite3_file *pFile);
+
 #endif

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -118,7 +118,6 @@
 
 static int csOpenFile(sqlite3_vfs *pVfs, const char *zPath,
                       sqlite3_file **ppFile, int flags);
-static void csCloseFile(sqlite3_file *pFile);
 static int csRollbackFailedAppend(ChunkStore *cs, i64 origFileSize);
 static int csRestoreCommittedRefsState(ChunkStore *cs);
 static int csReadManifest(ChunkStore *cs);
@@ -429,12 +428,6 @@ static int csOpenFile(
   int outFlags = 0;
   rc = sqlite3OsOpenMalloc(pVfs, zPath, ppFile, flags, &outFlags);
   return rc;
-}
-
-static void csCloseFile(sqlite3_file *pFile){
-  if( pFile ){
-    sqlite3OsCloseFree(pFile);
-  }
 }
 
 static int csRollbackFailedAppend(ChunkStore *cs, i64 origFileSize){


### PR DESCRIPTION
## Summary
- Moves `csCloseFile` from `chunk_store.c` into `chunk_file.c`, with its declaration now in `chunk_file.h`.
- `csOpenFile` stays static in `chunk_store.c` — only one caller, which is also in `chunk_store.c`.
- Completes the file-handle subsystem extraction begun in #881. The previously-extracted `chunk_file.c` held only accessor scaffolding; this PR moves the first real body in.

Diff: `chunk_file.c` +6, `chunk_file.h` +2, `chunk_store.c` -7.

## Test plan
- [x] `make doltlite-lib` + `make doltlite` clean rebuild
- [x] `make lint` — layering check passes
- [x] Smoke: `CREATE TABLE` + `dolt_commit` + reopen + `SELECT count(*) FROM dolt_log` = 2
- [x] `truncated_wal_rejected` (6/6)
- [x] `wal_offset_corruption` (5/5)
- [x] `reload_refs_transactional` (13/13)
- [x] `refresh_refs_corruption_preserves_state` (13/13)
- [ ] CI passes