### PR TITLE
Defer pending map ordering for write-heavy transactions

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -2368,7 +2368,7 @@ static SQLITE_INLINE ProllyMutMapEntry *orderedMutMapEntryAt(
   ProllyMutMap *pMap,
   int idx
 ){
-  if( pMap->keepSorted ){
+  if( pMap->keepSorted || !pMap->orderDirty ){
     return &pMap->aEntries[pMap->aOrder[idx]];
   }
   return prollyMutMapEntryAt(pMap, idx);
@@ -2511,7 +2511,6 @@ static void refreshCursorMutMapAliases(Btree *pBtree, BtShared *pBt,
 static int ensureMutMap(BtCursor *pCur){
   int rc;
   struct TableEntry *pTE;
-  int keepSorted;
   ProllyMutMap *pMap;
 
   pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
@@ -2524,8 +2523,7 @@ static int ensureMutMap(BtCursor *pCur){
 
   pMap = sqlite3_malloc(sizeof(ProllyMutMap));
   if( !pMap ) return SQLITE_NOMEM;
-  keepSorted = tableEntryIsTableRoot(pCur->pBtree, pTE);
-  rc = prollyMutMapInitMode(pMap, pCur->curIntKey, (u8)keepSorted);
+  rc = prollyMutMapInitMode(pMap, pCur->curIntKey, 0);
   if( rc!=SQLITE_OK ){
     sqlite3_free(pMap);
     return rc;

--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -437,6 +437,18 @@ static int ensureCapacity(ProllyMutMap *mm){
   return SQLITE_OK;
 }
 
+static void insertOrderEntry(ProllyMutMap *mm, int idx, int phys){
+  int i;
+  if( idx < mm->nEntries ){
+    memmove(&mm->aOrder[idx+1], &mm->aOrder[idx],
+            (mm->nEntries - idx) * sizeof(int));
+  }
+  mm->aOrder[idx] = phys;
+  for(i=idx; i<=mm->nEntries; i++){
+    mm->aPos[mm->aOrder[i]] = i;
+  }
+}
+
 int prollyMutMapInit(ProllyMutMap *mm, u8 isIntKey){
   return prollyMutMapInitMode(mm, isIntKey, 1);
 }
@@ -445,6 +457,7 @@ int prollyMutMapInitMode(ProllyMutMap *mm, u8 isIntKey, u8 keepSorted){
   memset(mm, 0, sizeof(*mm));
   mm->isIntKey = isIntKey;
   mm->keepSorted = keepSorted;
+  mm->orderDirty = keepSorted ? 0 : 1;
   return SQLITE_OK;
 }
 
@@ -486,7 +499,7 @@ int prollyMutMapInsert(
   u8 keyBuf[8];
   prepKey(mm, &pKey, &nKey, intKey, keyBuf);
 
-  if( mm->keepSorted ){
+  if( mm->keepSorted || !mm->orderDirty ){
     idx = bsearch_key(mm, pKey, nKey, &found);
     if( found ){
       phys = mm->aOrder[idx];
@@ -528,13 +541,8 @@ int prollyMutMapInsert(
     if( rc!=SQLITE_OK ){
       return rc;
     }
-    if( mm->keepSorted ){
-      if( idx < mm->nEntries ){
-        memmove(&mm->aOrder[idx+1], &mm->aOrder[idx],
-                (mm->nEntries - idx) * sizeof(int));
-      }
-      mm->aOrder[idx] = phys;
-      mm->aPos[phys] = idx;
+    if( mm->keepSorted || !mm->orderDirty ){
+      insertOrderEntry(mm, idx, phys);
     }else{
       mm->aOrder[phys] = phys;
       mm->aPos[phys] = phys;
@@ -558,7 +566,7 @@ int prollyMutMapDelete(
   u8 keyBuf[8];
   prepKey(mm, &pKey, &nKey, intKey, keyBuf);
 
-  if( mm->keepSorted ){
+  if( mm->keepSorted || !mm->orderDirty ){
     idx = bsearch_key(mm, pKey, nKey, &found);
     if( found ){
       phys = mm->aOrder[idx];
@@ -605,13 +613,8 @@ int prollyMutMapDelete(
     if( rc!=SQLITE_OK ){
       return rc;
     }
-    if( mm->keepSorted ){
-      if( idx < mm->nEntries ){
-        memmove(&mm->aOrder[idx+1], &mm->aOrder[idx],
-                (mm->nEntries - idx) * sizeof(int));
-      }
-      mm->aOrder[idx] = phys;
-      mm->aPos[phys] = idx;
+    if( mm->keepSorted || !mm->orderDirty ){
+      insertOrderEntry(mm, idx, phys);
     }else{
       mm->aOrder[phys] = phys;
       mm->aPos[phys] = phys;


### PR DESCRIPTION
## Summary
- defer pending-map ordering for point-write-heavy transactions
- keep ordered maps direct/indexed after the first ordered access, then maintain order incrementally
- avoid eager sorted-array maintenance for write-only workloads while preserving scan behavior

## Validation
- `git diff --check origin/master...HEAD`
- `make libdoltlite.a`
- `cc -O2 -I. -I./src -o bench_timer_doltlite test/sysbench_timer.c libdoltlite.a -lpthread -lz -lm`
- `DOLTLITE_BUILD_DIR=. bash test/doltlite_regression_test_c.sh` -> 108622 passed, 0 failed
- `BENCH_RUNS=3 BENCH_SECTION_MODE=wrapped BENCH_ROWS=10000 bash test/sysbench_compare.sh` -> all tests within 2.0x individual / 1.6x average ceilings

## Benchmark Notes
- in-memory `oltp_write_only`: SQLite 7,599 us, Doltlite 12,201 us, 1.61x
- file-backed `oltp_write_only`: SQLite 10,005 us, Doltlite 15,751 us, 1.57x
- file-backed write average: 1.39x

The local signal is modest and noisy, but this removes eager sorted-array maintenance from write-only pending table maps and keeps read-write scans from repeatedly forcing full lazy-map sorts.