### PR TITLE
fix: plug CommitPhaseTwo unlock leak + tighten WAL replay corruption detection

### DIFF
--- a/src/chunk_wal.c
+++ b/src/chunk_wal.c
@@ -195,6 +195,10 @@ int csReplayWal(ChunkStore *cs){
       ProllyHash hash;
       u32 len;
       if( pos + 20 + 4 > walSize ){
+        sqlite3_log(SQLITE_NOTICE,
+          "doltlite: WAL chunk header truncated at offset %lld; "
+          "stopping replay at last commit boundary",
+          (long long)(cs->wal.iWalOffset + pos - 1));
         break;
       }
       rc = sqlite3OsRead(cs->file.pFile, aHdr, sizeof(aHdr), cs->wal.iWalOffset + pos);
@@ -204,6 +208,10 @@ int csReplayWal(ChunkStore *cs){
       pos += 24;
       if( pos < 0 || len > (u32)0x7fffffff
        || (u64)pos + len > (u64)walSize ){
+        sqlite3_log(SQLITE_NOTICE,
+          "doltlite: WAL chunk body truncated at offset %lld (declared len=%u); "
+          "stopping replay at last commit boundary",
+          (long long)(cs->wal.iWalOffset + pos - 24 - 1), (unsigned)len);
         break;
       }
 
@@ -225,6 +233,10 @@ int csReplayWal(ChunkStore *cs){
     } else if( tag == CS_WAL_TAG_ROOT ){
       u8 m[CHUNK_MANIFEST_SIZE];
       if( pos + CHUNK_MANIFEST_SIZE > walSize ){
+        sqlite3_log(SQLITE_NOTICE,
+          "doltlite: WAL root manifest truncated at offset %lld; "
+          "stopping replay at last commit boundary",
+          (long long)(cs->wal.iWalOffset + pos - 1));
         break;
       }
       {
@@ -233,6 +245,14 @@ int csReplayWal(ChunkStore *cs){
         if( rc != SQLITE_OK ) goto replay_error;
         magic = CS_READ_U32(m);
         if( magic != CHUNK_STORE_MAGIC ){
+          if( pos + CHUNK_MANIFEST_SIZE < walSize ){
+            rc = SQLITE_CORRUPT;
+            goto replay_error;
+          }
+          sqlite3_log(SQLITE_NOTICE,
+            "doltlite: WAL root manifest at tail offset %lld has bad magic; "
+            "stopping replay at last commit boundary",
+            (long long)(cs->wal.iWalOffset + pos - 1));
           break;
         }
 

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -4348,14 +4348,25 @@ static int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
 
   if( p->inTrans==TRANS_WRITE ){
     rc = flushAllPending(p, pBt, 0);
-    if( rc!=SQLITE_OK ) return rc;
+    if( rc!=SQLITE_OK ){
+      chunkStoreRollback(&pBt->store);
+      chunkStoreUnlock(&pBt->store);
+      pBt->store.snapshotPinned = 0;
+      return rc;
+    }
 
     {
       rc = serializeCatalog(p, &catData, &nCatData);
       if( rc==SQLITE_OK ){
         rc = chunkStorePut(&pBt->store, catData, nCatData, &catHash);
       }
-      if( rc!=SQLITE_OK ) return rc;
+      if( rc!=SQLITE_OK ){
+        sqlite3_free(catData);
+        chunkStoreRollback(&pBt->store);
+        chunkStoreUnlock(&pBt->store);
+        pBt->store.snapshotPinned = 0;
+        return rc;
+      }
 
       {
         const char *zBr = p->zBranch ? p->zBranch : "main";
@@ -4370,9 +4381,21 @@ static int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
                                       p->zRebaseOrigBranch,
                                       p->zRebaseReturnBranch,
                                       &p->constraintViolationsHash);
-        if( rc!=SQLITE_OK ) return rc;
+        if( rc!=SQLITE_OK ){
+          sqlite3_free(catData);
+          chunkStoreRollback(&pBt->store);
+          chunkStoreUnlock(&pBt->store);
+          pBt->store.snapshotPinned = 0;
+          return rc;
+        }
         rc = chunkStoreSerializeRefs(&pBt->store);
-        if( rc!=SQLITE_OK ) return rc;
+        if( rc!=SQLITE_OK ){
+          sqlite3_free(catData);
+          chunkStoreRollback(&pBt->store);
+          chunkStoreUnlock(&pBt->store);
+          pBt->store.snapshotPinned = 0;
+          return rc;
+        }
       }
     }
 

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -3205,6 +3205,75 @@ static void run_wal_offset_corruption_is_rejected(void){
   removeDbFiles(dbpath);
 }
 
+static void run_wal_mid_corruption_rejected(void){
+  sqlite3 *db = 0;
+  ChunkStore cs;
+  char dbpath[256];
+  i64 walOff = -1;
+  i64 walSize = -1;
+  i64 magicPos = -1;
+  u8 *walBuf = 0;
+  int rc;
+
+  printf("=== WAL Mid-Corruption Rejected Test ===\n\n");
+  make_dbpath(dbpath, sizeof(dbpath), "test_wal_mid_corruption_rejected");
+  removeDbFiles(dbpath);
+
+  check("open_db_for_wal_mid", open_db(dbpath, &db)==SQLITE_OK);
+  check("setup_repo_for_wal_mid", execSql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'a');"
+    "SELECT dolt_commit('-A', '-m', 'init');"
+    "INSERT INTO t VALUES(2,'b');"
+    "SELECT dolt_commit('-A', '-m', 'second');"
+    "INSERT INTO t VALUES(3,'c');"
+    "SELECT dolt_commit('-A', '-m', 'third');")==SQLITE_OK);
+  sqlite3_close(db);
+
+  check("open_store_for_wal_mid", chunkStoreOpen(&cs, sqlite3_vfs_find(0), dbpath,
+        SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB)==SQLITE_OK);
+  walOff = walStateGetOffset(&cs.wal);
+  walSize = walStateGetDataSize(&cs.wal);
+  check("have_wal_for_mid_corruption", walSize > 256);
+
+  if( walSize > 0 ){
+    walBuf = (u8 *)sqlite3_malloc((int)walSize);
+    check("alloc_wal_buf", walBuf != 0);
+    if( walBuf ){
+      check("read_wal_buf",
+            sqlite3OsRead(cs.file.pFile, walBuf, (int)walSize, walOff)==SQLITE_OK);
+      {
+        i64 p;
+        for(p=0; p+4 <= walSize; p++){
+          u32 v = (u32)walBuf[p]
+                | ((u32)walBuf[p+1]<<8)
+                | ((u32)walBuf[p+2]<<16)
+                | ((u32)walBuf[p+3]<<24);
+          if( v == CHUNK_STORE_MAGIC ){
+            magicPos = p;
+            break;
+          }
+        }
+      }
+      sqlite3_free(walBuf);
+    }
+  }
+  check("found_root_magic_in_wal", magicPos >= 0 && magicPos < walSize - 8);
+
+  if( magicPos >= 0 ){
+    u8 badMagic[4] = {0xde, 0xad, 0xbe, 0xef};
+    check("corrupt_root_magic",
+          sqlite3OsWrite(cs.file.pFile, badMagic, 4, walOff + magicPos)==SQLITE_OK);
+  }
+  chunkStoreClose(&cs);
+
+  rc = chunkStoreOpen(&cs, sqlite3_vfs_find(0), dbpath,
+          SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB);
+  check("chunk_store_open_rejects_mid_wal_corruption", rc==SQLITE_CORRUPT);
+
+  removeDbFiles(dbpath);
+}
+
 static void run_integrity_check_walks_prolly_nodes(void){
   sqlite3 *db = 0;
   sqlite3 *db2 = 0;
@@ -6761,6 +6830,7 @@ static const RegressionCase aCases[] = {
   { "truncated_wal_rejected", "Truncated WAL Rejected Test", run_truncated_wal_is_rejected },
   { "refresh_open_path_transactional", "Refresh Open Path Transactional Test", run_refresh_open_path_transactional },
   { "wal_offset_corruption", "WAL Offset Corruption Test", run_wal_offset_corruption_is_rejected },
+  { "wal_mid_corruption_rejected", "WAL Mid-Corruption Rejected Test", run_wal_mid_corruption_rejected },
   { "integrity_check_walks_nodes", "Integrity Check Walks Prolly Nodes Test", run_integrity_check_walks_prolly_nodes },
   { "memory_chunk_lookup_corruption", "Memory Chunk Lookup Corruption Test", run_memory_chunk_lookup_corruption },
   { "prolly_diff_record_corruption", "Prolly Diff Record Corruption Test", run_prolly_diff_record_corruption },


### PR DESCRIPTION
Closes review items 6 and 8.

## Summary

**Item 6 — \`prollyBtreeCommitPhaseTwo\` unlock paths.**
Four pre-commit early-return sites in the TRANS_WRITE branch were returning without releasing the chunk-store lock or clearing the snapshot pin, and three of them also leaked the serialized catalog buffer:
- \`flushAllPending\` failure
- \`serializeCatalog\` / \`chunkStorePut\` failure
- \`btreeStoreWorkingSetBlob\` failure
- \`chunkStoreSerializeRefs\` failure

Each path now does \`chunkStoreRollback\` + \`chunkStoreUnlock\` + \`snapshotPinned = 0\` (and frees \`catData\` where applicable), mirroring the post-commit failure cleanup.

**Item 8 — \`csReplayWal\` silent break on bad data.**
The replay loop previously broke silently when it hit any of:
- a truncated chunk header
- a truncated chunk body
- a truncated root manifest
- a root manifest with bad magic

Tail truncation is expected after a crash, but a bad-magic root manifest *with more WAL bytes after it* is real corruption, not tail truncation. New behavior:
- Truncated tail structures: log \`SQLITE_NOTICE\` and stop replay at the last commit boundary (no change in crash-recovery semantics).
- Bad-magic root manifest with trailing data: return \`SQLITE_CORRUPT\` instead of silently discarding the bytes after it.

Adds new regression test \`wal_mid_corruption_rejected\` (3-commit setup, locate \`CHUNK_STORE_MAGIC\` byte in WAL, overwrite it, verify next \`chunkStoreOpen\` returns \`SQLITE_CORRUPT\`).

## Test plan
- [x] \`make doltlite-lib\` + \`make doltlite\` clean rebuild
- [x] \`make lint\` — layering check passes
- [x] WAL regression tests (37/37 + 9/9 new):
  - \`truncated_wal_rejected\` (6/6)
  - \`wal_offset_corruption\` (5/5)
  - \`reload_refs_transactional\` (13/13)
  - \`refresh_refs_corruption_preserves_state\` (13/13)
  - \`wal_mid_corruption_rejected\` (9/9, new)
- [x] Full C regression suite: 108631/108631 pass
- [ ] CI passes