### PR TITLE
Fast path single-int index seek keys

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -2348,6 +2348,24 @@ static int serializeUnpackedRecordBuffer(
   *pnOut = nTotal;
   return SQLITE_OK;
 }
+
+static int unpackedRecordCanUseSingleIntSortKey(
+  BtCursor *pCur,
+  UnpackedRecord *pRec
+){
+  KeyInfo *pKeyInfo = pCur->pKeyInfo;
+  CollSeq *pColl;
+  if( !pKeyInfo || !pRec || pRec->nField!=1 ) return 0;
+  if( !(pRec->aMem[0].flags & MEM_Int) ) return 0;
+  if( pKeyInfo->aSortFlags && (pKeyInfo->aSortFlags[0] & KEYINFO_ORDER_DESC) ){
+    return 0;
+  }
+  pColl = pKeyInfo->aColl[0];
+  if( pColl && pColl->zName && sqlite3StrICmp(pColl->zName, "BINARY")!=0 ){
+    return 0;
+  }
+  return 1;
+}
 static void clearMergeCursorState(BtCursor *pCur){
   pCur->mmIdx = -1;
   pCur->mmPhysIdx = -1;
@@ -5787,13 +5805,20 @@ static int prollyBtCursorIndexMoveto(
     if( pCur->pKeyInfo && pIdxKey->nField < pCur->pKeyInfo->nAllField ){
       nSeekKeyField = (int)pIdxKey->nField;
     }
-    rc = serializeUnpackedRecordBuffer(
-        pIdxKey, &pCur->pSeekRecord, &pCur->nSeekRecordAlloc, &nSerKey);
-    if( rc!=SQLITE_OK ) return rc;
-    pSerKey = pCur->pSeekRecord;
-    rc = sortKeyFromRecordPrefixCollBuffer(
-        pSerKey, nSerKey, nSeekKeyField, pCur->pKeyInfo,
-        &pCur->pSeekSortKey, &pCur->nSeekSortKeyAlloc, &nSortKey);
+    if( nSeekKeyField==1
+     && unpackedRecordCanUseSingleIntSortKey(pCur, pIdxKey) ){
+      rc = sortKeyFromInt64Buffer(
+          pIdxKey->aMem[0].u.i,
+          &pCur->pSeekSortKey, &pCur->nSeekSortKeyAlloc, &nSortKey);
+    }else{
+      rc = serializeUnpackedRecordBuffer(
+          pIdxKey, &pCur->pSeekRecord, &pCur->nSeekRecordAlloc, &nSerKey);
+      if( rc!=SQLITE_OK ) return rc;
+      pSerKey = pCur->pSeekRecord;
+      rc = sortKeyFromRecordPrefixCollBuffer(
+          pSerKey, nSerKey, nSeekKeyField, pCur->pKeyInfo,
+          &pCur->pSeekSortKey, &pCur->nSeekSortKeyAlloc, &nSortKey);
+    }
     if( rc!=SQLITE_OK ) return rc;
     pSortKey = pCur->pSeekSortKey;
     pCur->nSeekSortKey = nSortKey;

--- a/src/sortkey.c
+++ b/src/sortkey.c
@@ -49,6 +49,9 @@ static u8 serialTypeTag(u32 serialType){
 #define SORTKEY_COLL_NOCASE 1
 #define SORTKEY_COLL_RTRIM  2
 
+static void intSerialType(i64 v, u32 *pType, u32 *pLen);
+static void writeIntBE(u8 *p, i64 v, int nByte);
+
 static int collFromKeyInfo(const KeyInfo *pKeyInfo, int iCol){
   const CollSeq *pColl;
   if( !pKeyInfo ) return SORTKEY_COLL_BINARY;
@@ -364,6 +367,25 @@ int sortKeyFromRecordPrefixColl(
   *ppOut = 0;
   return sortKeyFromRecordPrefixCollBuffer(
       pRec, nRec, nKeyField, pKeyInfo, ppOut, &(int){0}, pnOut);
+}
+
+int sortKeyFromInt64Buffer(i64 v, u8 **ppBuf, int *pnAlloc, int *pnOut){
+  u8 aData[8];
+  u8 *pOut;
+  u32 serialType;
+  u32 nData;
+
+  intSerialType(v, &serialType, &nData);
+  writeIntBE(aData, v, (int)nData);
+  if( *pnAlloc < 64 ){
+    u8 *pNew = (u8*)sqlite3_realloc64(*ppBuf, 64);
+    if( !pNew ) return SQLITE_NOMEM;
+    *ppBuf = pNew;
+    *pnAlloc = 64;
+  }
+  pOut = *ppBuf;
+  *pnOut = encodeNumeric(pOut, serialType, aData, nData);
+  return SQLITE_OK;
 }
 
 static void intSerialType(i64 v, u32 *pType, u32 *pLen){

--- a/src/sortkey.h
+++ b/src/sortkey.h
@@ -21,6 +21,8 @@ int sortKeyFromRecordPrefixCollBuffer(const u8 *pRec, int nRec, int nKeyField,
                                  const KeyInfo *pKeyInfo,
                                  u8 **ppBuf, int *pnAlloc, int *pnOut);
 
+int sortKeyFromInt64Buffer(i64 v, u8 **ppBuf, int *pnAlloc, int *pnOut);
+
 int sortKeySize(const u8 *pRec, int nRec);
 
 int recordFromSortKey(const u8 *pSortKey, int nSortKey, u8 **ppOut, int *pnOut);


### PR DESCRIPTION
## Summary
- add a direct sort-key encoder for single int64 values
- use it for single-column integer prefix index seeks in prolly btree cursors
- avoid building a transient SQLite record and re-parsing it through the generic record-to-sort-key path for `k=?` joins

## Validation
- `git diff --check`
- `make libdoltlite.a`
- `cc -O2 -I. -I./src -o bench_timer_doltlite test/sysbench_timer.c libdoltlite.a -lpthread -lz -lm`
- `DOLTLITE_BUILD_DIR=. bash test/doltlite_regression_test_c.sh` -> 108622 passed, 0 failed
- `BENCH_RUNS=5 BENCH_SECTION_MODE=wrapped BENCH_ROWS=10000 bash test/sysbench_compare.sh` -> all tests within 2.0x individual / 1.6x average ceilings

## Benchmark Notes
Classic wrapped local run on this branch:
- in-memory `index_join`: SQLite 2,381 us, Doltlite 3,030 us, 1.27x
- in-memory `index_join_scan`: SQLite 1,291 us, Doltlite 1,721 us, 1.33x
- file-backed `index_join_scan`: SQLite 1,781 us, Doltlite 2,351 us, 1.32x

This is aimed at shaving stable overhead from the repeated `SeekGE k=?` path that drives `index_join_scan`.