### PR TITLE
ci(bench): raise iteration counts to reduce variance

### DIFF
--- a/.github/workflows/benchmark-extra.yml
+++ b/.github/workflows/benchmark-extra.yml
@@ -4,8 +4,9 @@ name: Benchmark Extra
 # (TEXT PK, BLOB PK, composite PK). Each is gated on both individual
 # ratios and section average ratios. The individual ceiling matches
 # the classic benchmark job.
-# BENCH_RUNS=5 across the job — each non-INTKEY write is a per-
-# statement flush, so the default 11 runs blows the 15-minute budget.
+# BENCH_RUNS=9 across the job — each non-INTKEY write is a per-
+# statement flush, so we keep it below the 15-run value used by
+# the classic Benchmark job to stay within the 25-minute budget.
 
 on:
   push:
@@ -18,7 +19,7 @@ permissions:
   pull-requests: write
 
 env:
-  BENCH_RUNS: 5
+  BENCH_RUNS: 9
   BENCH_MAX_MULTIPLIER: 2.0
   BENCH_AVG_MAX_MULTIPLIER: 1.6
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -10,10 +10,13 @@ permissions:
   issues: write
   pull-requests: write
 
+env:
+  BENCH_RUNS: 15
+
 jobs:
   benchmark:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -366,7 +366,7 @@ jobs:
   # ── Run benchmarks ────────────────────────────────────────
   benchmark:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
     - uses: actions/checkout@v4
 
@@ -395,7 +395,7 @@ jobs:
     - name: Run benchmarks
       run: |
         cd build
-        BENCH_SECTION_MODE=wrapped bash ../test/sysbench_compare.sh > /tmp/bench_classic.md
+        BENCH_RUNS=15 BENCH_SECTION_MODE=wrapped bash ../test/sysbench_compare.sh > /tmp/bench_classic.md
         sed -n '/### File-Backed/,/^_/p' /tmp/bench_classic.md > /tmp/bench_results.md
 
     - name: Upload benchmark results


### PR DESCRIPTION
## Summary
- **Benchmark** (PR + master): \`BENCH_RUNS\` 11 → 15, timeout 15 → 20 min.
- **Benchmark Extra** (PR + master): \`BENCH_RUNS\` 5 → 9, timeout stays at 25 min.
- **Release benchmark**: \`BENCH_RUNS\` 11 → 15, timeout 15 → 20 min.

More runs → median ratio used by the gates is less sensitive to a single noisy iteration. Extra stays below normal because each non-INTKEY write does a per-statement flush.

## Test plan
- [ ] Benchmark job completes within new 20-min budget
- [ ] Benchmark Extra job completes within existing 25-min budget at 9 runs
- [ ] Release benchmark job completes within new 20-min budget