### PR TITLE
Lazily cache non-int cursor payloads

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -5423,8 +5423,6 @@ static int prollyBtCursorNext(BtCursor *pCur, int flags){
         pCur->eState = CURSOR_VALID;
         if( pCur->curIntKey ){
           cacheCurrentTreePayloadIfIntKey(pCur);
-        }else{
-          cacheCurrentTreeStoredPayloadNonIntKey(pCur);
         }
       } else {
         pCur->eState = CURSOR_INVALID;
@@ -5488,8 +5486,6 @@ static int prollyBtCursorNext(BtCursor *pCur, int flags){
           pCur->eState = CURSOR_VALID;
           if( pCur->curIntKey ){
             cacheCurrentTreePayloadIfIntKey(pCur);
-          }else{
-            cacheCurrentTreeStoredPayloadNonIntKey(pCur);
           }
         } else {
           pCur->eState = CURSOR_INVALID;
@@ -6216,6 +6212,9 @@ static void getCursorPayload(BtCursor *pCur, const u8 **ppData, int *pnData){
     const u8 *pVal; int nVal;
     cursorCurrentTreeValue(pCur, &pVal, &nVal);
     if( nVal > 0 ){
+      pCur->pCachedPayload = (u8*)pVal;
+      pCur->nCachedPayload = nVal;
+      pCur->cachedPayloadOwned = 0;
       *ppData = pVal;
       *pnData = nVal;
     }else{


### PR DESCRIPTION
## Target

Latest merged PR inspected: #903 (`Reuse cached seek key for aux index deletes`). The largest multiplier in its sysbench comments is BLOB PK / In-Memory / Reads / `covering_index_scan`: SQLite 7,654 us vs Doltlite 14,916 us, `1.95x`. This is not file-backed and is not autocommit.

## Change

`covering_index_scan` for non-int primary keys advances cursors without reading payload columns. Previously every `Next` eagerly cached the current non-int-key tree payload anyway. This change leaves tree-owned payloads lazy and records the tree pointer only when `getCursorPayload()` is actually called.

## Validation

- `make libdoltlite.a`
- `DOLTLITE_BUILD_DIR=. bash test/doltlite_regression_test_c.sh` -> 108631 passed, 0 failed
- `BENCH_RUNS=5 BENCH_ROWS=1000 bash test/sysbench_compare_blobpk.sh` target metric: BLOB PK / In-Memory / Reads / `covering_index_scan` = SQLite 4,299 us vs Doltlite 7,704 us, `1.79x` (down from #903 comment `1.95x`)

Note: the full local BLOB-PK script still failed on unrelated autocommit write variance (`oltp_update_non_index_ac`, `oltp_delete_insert_ac`, `types_delete_insert_ac`), outside the target metric/path.