### PR TITLE
Fast path single-int index bound compares

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -6121,12 +6121,6 @@ int sqlite3BtreeProllyCachedIndexKeyCompare(
   if( pCur->eState!=CURSOR_VALID || !pIdxKey || !pCur->pKeyInfo ){
     return SQLITE_NOTFOUND;
   }
-  if( !prollyBtCursorCursorHasHint(pCur, BTREE_SEEK_EQ) ){
-    return SQLITE_NOTFOUND;
-  }
-  if( pCur->nSeekSortKey<=0 || pCur->nSeekKeyField!=(int)pIdxKey->nField ){
-    return SQLITE_NOTFOUND;
-  }
 
   if( pCur->mmActive
    && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
@@ -6140,19 +6134,45 @@ int sqlite3BtreeProllyCachedIndexKeyCompare(
     return SQLITE_NOTFOUND;
   }
 
-  nCmp = nKey < pCur->nSeekSortKey ? nKey : pCur->nSeekSortKey;
-  cmp = memcmp(pKey, pCur->pSeekSortKey, nCmp);
-  if( cmp<0 ){
-    *pRes = -1;
-  }else if( cmp>0 ){
-    *pRes = 1;
-  }else if( nKey < pCur->nSeekSortKey ){
-    *pRes = -1;
-  }else{
-    pIdxKey->eqSeen = 1;
-    *pRes = pIdxKey->default_rc;
+  if( prollyBtCursorCursorHasHint(pCur, BTREE_SEEK_EQ)
+   && pCur->nSeekSortKey>0
+   && pCur->nSeekKeyField==(int)pIdxKey->nField ){
+    nCmp = nKey < pCur->nSeekSortKey ? nKey : pCur->nSeekSortKey;
+    cmp = memcmp(pKey, pCur->pSeekSortKey, nCmp);
+    if( cmp<0 ){
+      *pRes = -1;
+    }else if( cmp>0 ){
+      *pRes = 1;
+    }else if( nKey < pCur->nSeekSortKey ){
+      *pRes = -1;
+    }else{
+      pIdxKey->eqSeen = 1;
+      *pRes = pIdxKey->default_rc;
+    }
+    return SQLITE_OK;
   }
-  return SQLITE_OK;
+
+  if( unpackedRecordCanUseSingleIntSortKey(pCur, pIdxKey) ){
+    u8 aSortKey[18];
+    int nSortKey = 0;
+    int rc = sortKeyFromInt64(pIdxKey->aMem[0].u.i, aSortKey, &nSortKey);
+    if( rc!=SQLITE_OK ) return rc;
+    nCmp = nKey < nSortKey ? nKey : nSortKey;
+    cmp = memcmp(pKey, aSortKey, nCmp);
+    if( cmp<0 ){
+      *pRes = -1;
+    }else if( cmp>0 ){
+      *pRes = 1;
+    }else if( nKey < nSortKey ){
+      *pRes = -1;
+    }else{
+      pIdxKey->eqSeen = 1;
+      *pRes = pIdxKey->default_rc;
+    }
+    return SQLITE_OK;
+  }
+
+  return SQLITE_NOTFOUND;
 }
 
 static i64 prollyBtCursorIntegerKey(BtCursor *pCur){

--- a/src/sortkey.c
+++ b/src/sortkey.c
@@ -369,23 +369,25 @@ int sortKeyFromRecordPrefixColl(
       pRec, nRec, nKeyField, pKeyInfo, ppOut, &(int){0}, pnOut);
 }
 
-int sortKeyFromInt64Buffer(i64 v, u8 **ppBuf, int *pnAlloc, int *pnOut){
+int sortKeyFromInt64(i64 v, u8 *pOut, int *pnOut){
   u8 aData[8];
-  u8 *pOut;
   u32 serialType;
   u32 nData;
 
   intSerialType(v, &serialType, &nData);
   writeIntBE(aData, v, (int)nData);
+  *pnOut = encodeNumeric(pOut, serialType, aData, nData);
+  return SQLITE_OK;
+}
+
+int sortKeyFromInt64Buffer(i64 v, u8 **ppBuf, int *pnAlloc, int *pnOut){
   if( *pnAlloc < 64 ){
     u8 *pNew = (u8*)sqlite3_realloc64(*ppBuf, 64);
     if( !pNew ) return SQLITE_NOMEM;
     *ppBuf = pNew;
     *pnAlloc = 64;
   }
-  pOut = *ppBuf;
-  *pnOut = encodeNumeric(pOut, serialType, aData, nData);
-  return SQLITE_OK;
+  return sortKeyFromInt64(v, *ppBuf, pnOut);
 }
 
 static void intSerialType(i64 v, u32 *pType, u32 *pLen){

--- a/src/sortkey.h
+++ b/src/sortkey.h
@@ -21,6 +21,7 @@ int sortKeyFromRecordPrefixCollBuffer(const u8 *pRec, int nRec, int nKeyField,
                                  const KeyInfo *pKeyInfo,
                                  u8 **ppBuf, int *pnAlloc, int *pnOut);
 
+int sortKeyFromInt64(i64 v, u8 *pOut, int *pnOut);
 int sortKeyFromInt64Buffer(i64 v, u8 **ppBuf, int *pnAlloc, int *pnOut);
 
 int sortKeySize(const u8 *pRec, int nRec);


### PR DESCRIPTION
## Target

Latest merged PR inspected: #904 (`Lazily cache non-int cursor payloads`). The largest multiplier in its sysbench comments is BLOB PK / In-Memory / Reads / `covering_index_scan`: SQLite 7,642 us vs Doltlite 13,566 us, `1.78x`. This is not file-backed and is not autocommit.

## Change

The BLOB-PK `covering_index_scan` query uses the secondary `k` index and runs a tight `SeekGE` / `IdxGT` / `Next` loop. After #904, `Next` no longer eagerly materializes non-int payloads, but `IdxGT` still fell back to reading/comparing the index record for range bounds.

This PR extends the prolly index compare hook to handle single integer index bounds directly against the current prolly sort key, avoiding record payload work in that loop. It also exposes a stack-buffer `sortKeyFromInt64()` helper so this fast path does not allocate.

## Local comparison

Clean master binary built from `origin/master` in a separate worktree versus this branch binary, same generated BLOB-PK `covering_index_scan` SQL, `:memory:`, 15 alternating runs:

- master median: 9,024 us
- patched median: 5,984 us

Full BLOB-PK suite runs were noisy locally. The target metric from one clean-master full-suite baseline was 7,781 us; one patched full-suite run was 7,702 us, while another noisy run was 8,040 us. The controlled target-only run above is the comparison I trust for this path.

## Validation

- `make doltlite`
- `git diff --check`
- `DOLTLITE_BUILD_DIR=. bash test/doltlite_regression_test_c.sh` -> 108631 passed, 0 failed

Note: local full BLOB-PK suite still trips unrelated autocommit write ceilings in this environment.