### PR TITLE
Cache non-int cursor payload after next

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -5423,6 +5423,8 @@ static int prollyBtCursorNext(BtCursor *pCur, int flags){
         pCur->eState = CURSOR_VALID;
         if( pCur->curIntKey ){
           cacheCurrentTreePayloadIfIntKey(pCur);
+        }else{
+          cacheCurrentTreeStoredPayloadNonIntKey(pCur);
         }
       } else {
         pCur->eState = CURSOR_INVALID;
@@ -5486,6 +5488,8 @@ static int prollyBtCursorNext(BtCursor *pCur, int flags){
           pCur->eState = CURSOR_VALID;
           if( pCur->curIntKey ){
             cacheCurrentTreePayloadIfIntKey(pCur);
+          }else{
+            cacheCurrentTreeStoredPayloadNonIntKey(pCur);
           }
         } else {
           pCur->eState = CURSOR_INVALID;


### PR DESCRIPTION
## Summary

- The latest merged PR comment I checked was #905. The highest sysbench multiplier was in `benchmark:textpk`: `index_join_scan` under `TEXT PRIMARY KEY`, File-Backed (autocommit) Reads. The comment showed SQLite 1,960 us vs Doltlite 3,525 us, or 1.80x.
- Cache the stored payload pointer when a non-integer-key cursor advances to the next tree row.
- This avoids redoing the leaf value lookup when the next opcode reads a column from that row, which is the common shape for text/blob/composite primary-key range scans and join scans.

## Local comparison

Clean `origin/master` vs this branch, `BENCH_RUNS=7 BENCH_ROWS=1000 bash test/sysbench_compare_textpk.sh`:

- File-backed `index_join_scan`: 1,986 us -> 1,959 us
- File-backed autocommit `index_join_scan`: 2,052 us -> 2,076 us locally, which is within the local noise I saw on this benchmark
- Isolated target-only Doltlite comparison against a clean master worktree, 15 samples, same generated `TEXT PK` `index_join_scan` workload: median 19,008 us -> 18,976 us

The full textpk benchmark still exits non-zero locally because unrelated autocommit write metrics exceed the current ceiling (`oltp_update_non_index_ac`, `types_delete_insert_ac`, and ac_writes average).

## Validation

- `make doltlite`
- `DOLTLITE_BUILD_DIR=. bash test/doltlite_regression_test_c.sh` (`108631 passed, 0 failed`)
- `git diff --check`
