### PR TITLE
Reuse cached seek key for non-int deletes

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -6109,6 +6109,27 @@ int sqlite3BtreeIndexMoveto(
   return pCur->pCurOps->xIndexMoveto(pCur, pIdxKey, pRes);
 }
 
+static int cachedSeekKeyMatchesCurrent(BtCursor *pCur){
+  const u8 *pKey = 0;
+  int nKey = 0;
+
+  if( !pCur || pCur->curIntKey
+   || pCur->nSeekSortKey<=0 || pCur->nSeekKeyField!=0 ){
+    return 0;
+  }
+  if( pCur->mmActive
+   && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
+    ProllyMutMapEntry *e = currentMutMapEntry(pCur);
+    if( !e ) return 0;
+    pKey = e->pKey;
+    nKey = e->nKey;
+  }else if( prollyCursorIsValid(&pCur->pCur) ){
+    prollyCursorKey(&pCur->pCur, &pKey, &nKey);
+  }
+  return pKey && nKey==pCur->nSeekSortKey
+      && memcmp(pKey, pCur->pSeekSortKey, nKey)==0;
+}
+
 int sqlite3BtreeProllyCachedIndexKeyCompare(
   BtCursor *pCur,
   UnpackedRecord *pIdxKey,
@@ -6628,7 +6649,8 @@ static int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
         hasSavedKey = 1;
       }
     } else {
-      if( (flags & BTREE_AUXDELETE) && pCur->nSeekSortKey>0 ){
+      if( pCur->nSeekSortKey>0
+       && ((flags & BTREE_AUXDELETE) || cachedSeekKeyMatchesCurrent(pCur)) ){
         pSavedDelKey = pCur->pSeekSortKey;
         nSavedDelKey = pCur->nSeekSortKey;
         hasSavedKey = 1;


### PR DESCRIPTION
## Summary

- Latest merged PR checked: #907.
- Highest sysbench multiplier excluding `index_join_scan`: BLOB PK, In-Memory Writes, `oltp_delete_insert` at 1.71x in the PR comment (SQLite 28,510 us, Doltlite 48,883 us).
- Reuse the cursor's cached full seek sort key for non-integer-key deletes when it still matches the current cursor key.

This avoids reconstructing/copying the delete key after an exact seek, which is common for BLOB/TEXT/composite primary-key deletes. The match check keeps scan deletes from using a stale seek key.

## Local comparison

Clean latest master, `BENCH_RUNS=7 BENCH_ROWS=1000 bash test/sysbench_compare_blobpk.sh`:

- In-memory `oltp_delete_insert`: Doltlite 29,221 us, 1.81x
- File-backed `oltp_delete_insert`: Doltlite 30,246 us, 1.76x
- File-backed autocommit `oltp_delete_insert_ac`: Doltlite 33,810 us, 1.24x

This branch, same command:

- In-memory `oltp_delete_insert`: Doltlite 28,053 us, 1.73x
- File-backed `oltp_delete_insert`: Doltlite 28,407 us, 1.70x
- File-backed autocommit `oltp_delete_insert_ac`: Doltlite 35,920 us, 1.31x

The full blobpk benchmark still exits non-zero locally due to unrelated autocommit write ceilings (`oltp_update_non_index_ac`, `types_delete_insert_ac`, and ac_writes average).

## Validation

- `make doltlite`
- `DOLTLITE_BUILD_DIR=. bash test/doltlite_regression_test_c.sh` (`108631 passed, 0 failed`)
- `git diff --check`
