### PR TITLE
Avoid lookup after int-key insert

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -6330,6 +6330,9 @@ static int prollyBtCursorInsert(
   int seekResult
 ){
   int rc;
+  const u8 *pInsertedPayload = 0;
+  int nInsertedPayload = 0;
+  u8 *pIntKeyBuf = 0;
   (void)seekResult;
 
   if( flags & BTREE_PREFORMAT ){
@@ -6353,27 +6356,27 @@ static int prollyBtCursorInsert(
     int nData = pPayload->nData;
     i64 nTotal64 = (i64)nData + (i64)pPayload->nZero;
     int nTotal;
-    u8 *pBuf = 0;
 
     if( nData<0 || pPayload->nZero<0 || nTotal64 > 0x7fffffff ){
       return SQLITE_TOOBIG;
     }
     nTotal = (int)nTotal64;
     if( pPayload->nZero > 0 ){
-      pBuf = sqlite3_malloc(nTotal);
-      if( !pBuf ) return SQLITE_NOMEM;
+      pIntKeyBuf = sqlite3_malloc(nTotal);
+      if( !pIntKeyBuf ) return SQLITE_NOMEM;
       if( nData > 0 ){
-        memcpy(pBuf, pData, nData);
+        memcpy(pIntKeyBuf, pData, nData);
       }
-      memset(pBuf + nData, 0, pPayload->nZero);
-      pData = pBuf;
+      memset(pIntKeyBuf + nData, 0, pPayload->nZero);
+      pData = pIntKeyBuf;
       nData = nTotal;
     }
+    pInsertedPayload = pData;
+    nInsertedPayload = nData;
 
     rc = prollyMutMapInsert(pCur->pMutMap,
                              NULL, 0, pPayload->nKey,
                              pData, nData);
-    sqlite3_free(pBuf);
   } else {
 
     int nSortKey = 0;
@@ -6407,7 +6410,10 @@ static int prollyBtCursorInsert(
     }
   }
 
-  if( rc!=SQLITE_OK ) return rc;
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(pIntKeyBuf);
+    return rc;
+  }
 
   {
     int canDefer = (pCur->pgnoRoot > 1);
@@ -6416,21 +6422,17 @@ static int prollyBtCursorInsert(
     }
     if( canDefer ){
       if( (flags & BTREE_SAVEPOSITION) && pCur->curIntKey ){
-        ProllyMutMapEntry *pEntry = 0;
-        rc = prollyMutMapFindRc(pCur->pMutMap, NULL, 0, pPayload->nKey, &pEntry);
-        if( rc!=SQLITE_OK ) return rc;
         pCur->eState = CURSOR_VALID;
         pCur->curFlags |= BTCF_ValidNKey;
         pCur->cachedIntKey = pPayload->nKey;
-        rc = cacheCursorPayloadCopy(
-            pCur,
-            (pEntry && pEntry->nVal > 0 && pEntry->pVal) ? pEntry->pVal : 0,
-            (pEntry && pEntry->nVal > 0 && pEntry->pVal) ? pEntry->nVal : 0);
+        rc = cacheCursorPayloadCopy(pCur, pInsertedPayload, nInsertedPayload);
+        sqlite3_free(pIntKeyBuf);
         if( rc!=SQLITE_OK ) return rc;
 
         pCur->mmActive = 0;
         pCur->flushSeekEdits = 0;
       } else if( (flags & BTREE_SAVEPOSITION) && !pCur->curIntKey ){
+        sqlite3_free(pIntKeyBuf);
         CLEAR_CACHED_PAYLOAD(pCur);
         if( prollyCursorIsValid(&pCur->pCur) ){
           int trc = prollyCursorNext(&pCur->pCur);
@@ -6447,6 +6449,7 @@ static int prollyBtCursorInsert(
         pCur->mmActive = 0;
         pCur->flushSeekEdits = 0;
       } else {
+        sqlite3_free(pIntKeyBuf);
         pCur->eState = CURSOR_INVALID;
         pCur->flushSeekEdits = 0;
       }
@@ -6454,6 +6457,7 @@ static int prollyBtCursorInsert(
     }
   }
 
+  sqlite3_free(pIntKeyBuf);
   rc = flushMutMap(pCur);
   if( rc!=SQLITE_OK ) return rc;
   {


### PR DESCRIPTION
## Target

Checked the latest merged doltlite PR, #906. In the sysbench section, ignoring `index_join_scan`, the highest multiplier was:

- Key type: classic `INTEGER PRIMARY KEY` / rowid table
- Mode: in-memory
- Autocommit: no
- Benchmark: `oltp_write_only`
- PR comment: SQLite `12,848 us`, Doltlite `21,815 us`, `1.70x`

## Change

Avoid a redundant mutmap lookup after int-key table inserts that request `BTREE_SAVEPOSITION`. The insert path already has the payload bytes that were written into the mutmap, so it can copy those bytes directly into the cursor payload cache instead of finding the just-inserted row again.

This applies generally to int-key table insert/update cursor preservation, not to a single benchmark shape.

## Local comparison

Clean `origin/master` before this change, `BENCH_RUNS=7`:

| Mode | Benchmark | SQLite us | Doltlite us | Ratio |
| --- | --- | ---: | ---: | ---: |
| In-memory | `oltp_write_only` | 7,513 | 11,936 | 1.59 |
| File-backed | `oltp_write_only` | 10,248 | 15,303 | 1.49 |
| File-backed autocommit | `oltp_write_only_ac` | 22,883 | 36,214 | 1.58 |

This branch, `BENCH_RUNS=7`:

| Mode | Benchmark | SQLite us | Doltlite us | Ratio |
| --- | --- | ---: | ---: | ---: |
| In-memory | `oltp_write_only` | 7,289 | 11,342 | 1.56 |
| File-backed | `oltp_write_only` | 10,172 | 15,534 | 1.53 |
| File-backed autocommit | `oltp_write_only_ac` | 26,612 | 33,931 | 1.28 |

The full local sysbench comparison still exits non-zero due unrelated autocommit ceilings (`oltp_index_scan`, `oltp_update_non_index_ac`, `types_delete_insert_ac`, and `ac_writes` average).

## Validation

- `make doltlite`
- `DOLTLITE_BUILD_DIR=. bash test/doltlite_regression_test_c.sh` (`108631 passed, 0 failed`)
- `git diff --check`
