### PR TITLE
Avoid ordered inserts for lazy mutmaps

### DIFF
--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -541,7 +541,7 @@ int prollyMutMapInsert(
     if( rc!=SQLITE_OK ){
       return rc;
     }
-    if( mm->keepSorted || !mm->orderDirty ){
+    if( mm->keepSorted ){
       insertOrderEntry(mm, idx, phys);
     }else{
       mm->aOrder[phys] = phys;
@@ -613,7 +613,7 @@ int prollyMutMapDelete(
     if( rc!=SQLITE_OK ){
       return rc;
     }
-    if( mm->keepSorted || !mm->orderDirty ){
+    if( mm->keepSorted ){
       insertOrderEntry(mm, idx, phys);
     }else{
       mm->aOrder[phys] = phys;


### PR DESCRIPTION
## Target

Checked the latest merged doltlite PR, #908. In the sysbench comments, ignoring `index_join_scan`, the highest multiplier was:

- Key type: classic `INTEGER PRIMARY KEY` / rowid table
- Mode: in-memory
- Autocommit: no
- Benchmark: `oltp_update_index`
- PR comment: SQLite `32,791 us`, Doltlite `55,388 us`, `1.69x`

## Change

Lazy mutmaps were still maintaining sorted order after a seek had materialized order once. That means a write-heavy transaction could fall back into `insertOrderEntry()` and pay an ordered-array `memmove` on every later random insert/delete.

For lazy mutmaps, this PR always appends new edits and marks the order dirty. Ordered readers still call `ensureOrder()` when they actually need sorted traversal. `keepSorted` maps keep the old behavior.

## Local comparison

Clean `origin/master` before this change, full classic sysbench, `BENCH_RUNS=7`:

| Mode | Benchmark | SQLite us | Doltlite us | Ratio |
| --- | --- | ---: | ---: | ---: |
| In-memory | `oltp_update_index` | 17,697 | 28,525 | 1.61 |
| File-backed | `oltp_update_index` | 21,160 | 34,223 | 1.62 |
| File-backed autocommit | `oltp_update_index_ac` | 17,217 | 34,378 | 2.00 |

This branch, full classic sysbench, `BENCH_RUNS=7`:

| Mode | Benchmark | SQLite us | Doltlite us | Ratio |
| --- | --- | ---: | ---: | ---: |
| In-memory | `oltp_update_index` | 18,140 | 28,908 | 1.59 |
| File-backed | `oltp_update_index` | 20,615 | 31,495 | 1.53 |
| File-backed autocommit | `oltp_update_index_ac` | 19,436 | 34,321 | 1.77 |

A higher-run wrapped pass showed the in-memory Doltlite median at `29,311 us` on this branch. In a separate clean `origin/master` worktree, the same wrapped pass produced a Doltlite median of `31,968 us` for `oltp_update_index`.

The targeted longer in-memory indexed-update workload, using the same table/index/update shape with 200k updates to expose the O(n) behavior, improved from `2.30s` on clean `origin/master` to `0.50s` on this branch.

The full local sysbench comparison still exits non-zero due unrelated autocommit ceilings (`oltp_index_scan`, `oltp_update_non_index_ac`, `types_delete_insert_ac`, and `ac_writes` average).

## Validation

- `make doltlite`
- `DOLTLITE_BUILD_DIR=. bash test/doltlite_regression_test_c.sh` (`108631 passed, 0 failed`)
- `git diff --check`
