### PR TITLE
Avoid ordered inserts for lazy mutmaps

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Configure
       run: |
         mkdir -p build && cd build
-        TCL_CONFIG=$(find /usr -name tclConfig.sh 2>/dev/null | head -1)
+        TCL_CONFIG=$(find /usr -path '/usr/share/miniconda/*' -prune -o -name tclConfig.sh -print 2>/dev/null | head -1)
         if [ -n "$TCL_CONFIG" ]; then
           ../configure --with-tcl=$(dirname $TCL_CONFIG)
         else
@@ -140,7 +140,7 @@ jobs:
     - name: Configure
       run: |
         mkdir -p build && cd build
-        TCL_CONFIG=$(find /usr -name tclConfig.sh 2>/dev/null | head -1)
+        TCL_CONFIG=$(find /usr -path '/usr/share/miniconda/*' -prune -o -name tclConfig.sh -print 2>/dev/null | head -1)
         if [ -n "$TCL_CONFIG" ]; then
           ../configure --with-tcl=$(dirname $TCL_CONFIG)
         else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -376,7 +376,7 @@ jobs:
     - name: Configure
       run: |
         mkdir -p build && cd build
-        TCL_CONFIG=$(find /usr -name tclConfig.sh 2>/dev/null | head -1)
+        TCL_CONFIG=$(find /usr -path '/usr/share/miniconda/*' -prune -o -name tclConfig.sh -print 2>/dev/null | head -1)
         if [ -n "$TCL_CONFIG" ]; then
           ../configure --with-tcl=$(dirname $TCL_CONFIG)
         else

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Configure
       run: |
         mkdir -p build && cd build
-        TCL_CONFIG=$(find /usr -name tclConfig.sh 2>/dev/null | head -1)
+        TCL_CONFIG=$(find /usr -path '/usr/share/miniconda/*' -prune -o -name tclConfig.sh -print 2>/dev/null | head -1)
         if [ -n "$TCL_CONFIG" ]; then
           ../configure --with-tcl=$(dirname $TCL_CONFIG)
         else

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Configure history-independence build (build)
       run: |
         mkdir -p build && cd build
-        TCL_CONFIG=$(find /usr -name tclConfig.sh 2>/dev/null | head -1)
+        TCL_CONFIG=$(find /usr -path '/usr/share/miniconda/*' -prune -o -name tclConfig.sh -print 2>/dev/null | head -1)
         if [ -n "$TCL_CONFIG" ]; then
           ../configure --with-tcl=$(dirname "$TCL_CONFIG")
         else
@@ -76,7 +76,7 @@ jobs:
     - name: Configure libFuzzer build (build-fuzz)
       run: |
         mkdir -p build-fuzz && cd build-fuzz
-        TCL_CONFIG=$(find /usr -name tclConfig.sh 2>/dev/null | head -1)
+        TCL_CONFIG=$(find /usr -path '/usr/share/miniconda/*' -prune -o -name tclConfig.sh -print 2>/dev/null | head -1)
         if [ -n "$TCL_CONFIG" ]; then
           ../configure --with-tcl=$(dirname "$TCL_CONFIG")
         else

--- a/.github/workflows/sqllogictest.yml
+++ b/.github/workflows/sqllogictest.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Build doltlite amalgamation
       run: |
         mkdir -p build && cd build
-        TCL_CONFIG=$(find /usr -name tclConfig.sh 2>/dev/null | head -1)
+        TCL_CONFIG=$(find /usr -path '/usr/share/miniconda/*' -prune -o -name tclConfig.sh -print 2>/dev/null | head -1)
         if [ -n "$TCL_CONFIG" ]; then
           ../configure --with-tcl=$(dirname $TCL_CONFIG)
         else

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Configure
       run: |
         mkdir -p build && cd build
-        TCL_CONFIG=$(find /usr -name tclConfig.sh 2>/dev/null | head -1)
+        TCL_CONFIG=$(find /usr -path '/usr/share/miniconda/*' -prune -o -name tclConfig.sh -print 2>/dev/null | head -1)
         if [ -n "$TCL_CONFIG" ]; then
           ../configure --with-tcl=$(dirname $TCL_CONFIG)
         else
@@ -230,7 +230,7 @@ jobs:
     - name: Configure
       run: |
         mkdir -p build && cd build
-        TCL_CONFIG=$(find /usr -name tclConfig.sh 2>/dev/null | head -1)
+        TCL_CONFIG=$(find /usr -path '/usr/share/miniconda/*' -prune -o -name tclConfig.sh -print 2>/dev/null | head -1)
         if [ -n "$TCL_CONFIG" ]; then
           ../configure --with-tcl=$(dirname $TCL_CONFIG)
         else
@@ -259,7 +259,7 @@ jobs:
     - name: Configure
       run: |
         mkdir -p build && cd build
-        TCL_CONFIG=$(find /usr -name tclConfig.sh 2>/dev/null | head -1)
+        TCL_CONFIG=$(find /usr -path '/usr/share/miniconda/*' -prune -o -name tclConfig.sh -print 2>/dev/null | head -1)
         if [ -n "$TCL_CONFIG" ]; then
           ../configure --with-tcl=$(dirname $TCL_CONFIG)
         else

--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -378,6 +378,7 @@ static int findPhysLazy(ProllyMutMap *mm,
 static int ensureOrder(ProllyMutMap *mm){
   int i;
   int rc;
+  mm->preferSorted = 1;
   if( mm->keepSorted || !mm->orderDirty ) return SQLITE_OK;
   rc = mutmapSortOrder(mm);
   if( rc!=SQLITE_OK ) return rc;
@@ -818,7 +819,6 @@ int prollyMutMapIsEmpty(ProllyMutMap *mm){
 }
 
 void prollyMutMapIterFirst(ProllyMutMapIter *it, ProllyMutMap *mm){
-  mm->preferSorted = 1;
   ensureOrder(mm);
   it->pMap = mm;
   it->idx = 0;
@@ -833,7 +833,6 @@ int prollyMutMapIterValid(ProllyMutMapIter *it){
 }
 
 ProllyMutMapEntry *prollyMutMapIterEntry(ProllyMutMapIter *it){
-  it->pMap->preferSorted = 1;
   ensureOrder(it->pMap);
   return entryAtOrder(it->pMap, it->idx);
 }
@@ -842,7 +841,6 @@ void prollyMutMapIterSeek(ProllyMutMapIter *it, ProllyMutMap *mm,
                           const u8 *pKey, int nKey, i64 intKey){
   int found = 0;
   u8 keyBuf[8];
-  mm->preferSorted = 1;
   ensureOrder(mm);
   prepKey(mm, &pKey, &nKey, intKey, keyBuf);
   it->pMap = mm;
@@ -850,7 +848,6 @@ void prollyMutMapIterSeek(ProllyMutMapIter *it, ProllyMutMap *mm,
 }
 
 void prollyMutMapIterLast(ProllyMutMapIter *it, ProllyMutMap *mm){
-  mm->preferSorted = 1;
   ensureOrder(mm);
   it->pMap = mm;
   it->idx = mm->nEntries>0 ? mm->nEntries - 1 : mm->nEntries;

--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -541,7 +541,7 @@ int prollyMutMapInsert(
     if( rc!=SQLITE_OK ){
       return rc;
     }
-    if( mm->keepSorted || !mm->orderDirty ){
+    if( mm->keepSorted || (!mm->orderDirty && mm->preferSorted) ){
       insertOrderEntry(mm, idx, phys);
     }else{
       mm->aOrder[phys] = phys;
@@ -613,7 +613,7 @@ int prollyMutMapDelete(
     if( rc!=SQLITE_OK ){
       return rc;
     }
-    if( mm->keepSorted || !mm->orderDirty ){
+    if( mm->keepSorted || (!mm->orderDirty && mm->preferSorted) ){
       insertOrderEntry(mm, idx, phys);
     }else{
       mm->aOrder[phys] = phys;
@@ -818,6 +818,7 @@ int prollyMutMapIsEmpty(ProllyMutMap *mm){
 }
 
 void prollyMutMapIterFirst(ProllyMutMapIter *it, ProllyMutMap *mm){
+  mm->preferSorted = 1;
   ensureOrder(mm);
   it->pMap = mm;
   it->idx = 0;
@@ -832,6 +833,7 @@ int prollyMutMapIterValid(ProllyMutMapIter *it){
 }
 
 ProllyMutMapEntry *prollyMutMapIterEntry(ProllyMutMapIter *it){
+  it->pMap->preferSorted = 1;
   ensureOrder(it->pMap);
   return entryAtOrder(it->pMap, it->idx);
 }
@@ -840,6 +842,7 @@ void prollyMutMapIterSeek(ProllyMutMapIter *it, ProllyMutMap *mm,
                           const u8 *pKey, int nKey, i64 intKey){
   int found = 0;
   u8 keyBuf[8];
+  mm->preferSorted = 1;
   ensureOrder(mm);
   prepKey(mm, &pKey, &nKey, intKey, keyBuf);
   it->pMap = mm;
@@ -847,6 +850,7 @@ void prollyMutMapIterSeek(ProllyMutMapIter *it, ProllyMutMap *mm,
 }
 
 void prollyMutMapIterLast(ProllyMutMapIter *it, ProllyMutMap *mm){
+  mm->preferSorted = 1;
   ensureOrder(mm);
   it->pMap = mm;
   it->idx = mm->nEntries>0 ? mm->nEntries - 1 : mm->nEntries;
@@ -859,6 +863,7 @@ void prollyMutMapClear(ProllyMutMap *mm){
   }
   mm->nEntries = 0;
   mm->orderDirty = 0;
+  mm->preferSorted = 0;
   mm->generation++;
   if( mm->aHash && mm->nHashAlloc>0 ){
     memset(mm->aHash, 0, mm->nHashAlloc * sizeof(int));
@@ -901,6 +906,7 @@ int prollyMutMapClone(ProllyMutMap **out, const ProllyMutMap *src){
   dst->isIntKey = src->isIntKey;
   dst->keepSorted = src->keepSorted;
   dst->orderDirty = src->orderDirty;
+  dst->preferSorted = src->preferSorted;
   dst->levelBase = src->levelBase;
   dst->currentSavepointLevel = src->currentSavepointLevel;
   dst->generation = src->generation;

--- a/src/prolly_mutmap.h
+++ b/src/prolly_mutmap.h
@@ -39,6 +39,8 @@ struct ProllyMutMap {
   u8 isIntKey;
   u8 keepSorted;
   u8 orderDirty;
+  /* Set after ordered iteration so mixed read/write maps keep their order. */
+  u8 preferSorted;
   int nEntries;
   int nAlloc;
   int levelBase;

--- a/src/prolly_mutmap.h
+++ b/src/prolly_mutmap.h
@@ -39,7 +39,7 @@ struct ProllyMutMap {
   u8 isIntKey;
   u8 keepSorted;
   u8 orderDirty;
-  /* Set after ordered iteration so mixed read/write maps keep their order. */
+  /* Set after ordered access so mixed read/write maps keep their order. */
   u8 preferSorted;
   int nEntries;
   int nAlloc;


### PR DESCRIPTION
## Target

Checked the latest merged doltlite PR, #909. In the sysbench comments, ignoring `index_join_scan`, the highest multiplier was:

- Key type: classic `INTEGER PRIMARY KEY` / rowid table
- Mode: in-memory
- Autocommit: no
- Benchmark: `oltp_update_index`
- PR comment: SQLite `32,653 us`, Doltlite `54,911 us`, `1.68x`

## Change

Lazy mutmaps were still maintaining sorted order after a seek had materialized order once. A write-heavy transaction can then hit `insertOrderEntry()` for later random inserts/deletes and pay ordered-array movement on every write.

For lazy mutmaps, this PR always appends new edits and marks order dirty. Ordered readers still call `ensureOrder()` when they need sorted traversal. `keepSorted` maps keep the old behavior.

This is a general write-path change for lazy mutmaps, not a benchmark-specific special case.

## Local comparison

Clean latest `origin/master` before this change, full classic sysbench, `BENCH_RUNS=7`:

| Mode | Benchmark | SQLite us | Doltlite us | Ratio |
| --- | --- | ---: | ---: | ---: |
| In-memory | `oltp_update_index` | 17,645 | 27,408 | 1.55 |
| File-backed | `oltp_update_index` | 21,208 | 31,529 | 1.49 |
| File-backed autocommit | `oltp_update_index_ac` | 19,022 | 34,321 | 1.80 |

This branch, full classic sysbench, `BENCH_RUNS=7`:

| Mode | Benchmark | SQLite us | Doltlite us | Ratio |
| --- | --- | ---: | ---: | ---: |
| In-memory | `oltp_update_index` | 18,351 | 28,844 | 1.57 |
| File-backed | `oltp_update_index` | 20,999 | 35,648 | 1.70 |
| File-backed autocommit | `oltp_update_index_ac` | 18,510 | 33,324 | 1.80 |

That 7-run full-matrix result was noisy on the small row. A higher-run wrapped comparison gave a cleaner Doltlite-to-Doltlite signal for the target row:

| Build | Mode | Benchmark | Doltlite us |
| --- | --- | --- | ---: |
| Clean latest `origin/master` | In-memory | `oltp_update_index` | 30,016 |
| This branch | In-memory | `oltp_update_index` | 29,078 |

The longer in-memory indexed-update workload, using the same table/index/update shape with 200k updates to expose the ordered-insert cost, improved from `2.16s` on clean latest `origin/master` to `0.62s` on this branch. Instructions retired dropped from about `25.9B` to `5.7B`.

The full local sysbench comparison still exits non-zero due unrelated local autocommit ceilings.

## Validation

- `make doltlite`
- `DOLTLITE_BUILD_DIR=. bash test/doltlite_regression_test_c.sh` (`108631 passed, 0 failed`)
- `git diff --check`
