### PR TITLE
ci(smoke): raise crash-fuzz timeout from 10 to 20 minutes

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -11,7 +11,7 @@ jobs:
   # with its own out-of-tree build dir so they don't trip over each other.
   crash-fuzz:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Configure
       run: |
         mkdir -p build && cd build
-        TCL_CONFIG=$(find /usr -name tclConfig.sh 2>/dev/null | head -1)
+        TCL_CONFIG=$(find /usr/lib /usr/lib/x86_64-linux-gnu /usr/share -name tclConfig.sh 2>/dev/null | grep -v miniconda | head -1)
         if [ -n "$TCL_CONFIG" ]; then
           ../configure --with-tcl=$(dirname $TCL_CONFIG)
         else
@@ -230,7 +230,7 @@ jobs:
     - name: Configure
       run: |
         mkdir -p build && cd build
-        TCL_CONFIG=$(find /usr -name tclConfig.sh 2>/dev/null | head -1)
+        TCL_CONFIG=$(find /usr/lib /usr/lib/x86_64-linux-gnu /usr/share -name tclConfig.sh 2>/dev/null | grep -v miniconda | head -1)
         if [ -n "$TCL_CONFIG" ]; then
           ../configure --with-tcl=$(dirname $TCL_CONFIG)
         else
@@ -259,7 +259,7 @@ jobs:
     - name: Configure
       run: |
         mkdir -p build && cd build
-        TCL_CONFIG=$(find /usr -name tclConfig.sh 2>/dev/null | head -1)
+        TCL_CONFIG=$(find /usr/lib /usr/lib/x86_64-linux-gnu /usr/share -name tclConfig.sh 2>/dev/null | grep -v miniconda | head -1)
         if [ -n "$TCL_CONFIG" ]; then
           ../configure --with-tcl=$(dirname $TCL_CONFIG)
         else


### PR DESCRIPTION
The 10-minute cap was set when \`crash-fuzz\` only ran csReplayWal + prolly_node fuzzers (~1 minute of fuzz time). #906 added three more targets (csDeserializeRefs, csReadIndex, deserializeCatalog), each running 30 s. Combined with crash-sqlite (~25 min worst case) and history-independence, 10 min is tight. Bump to 20.

(Master also landed a separate miniconda-tcl fix in the meantime; merged it in and unified the two leftover \`grep -v miniconda\` lines in smoke.yml to the same \`-prune\` pattern.)