### PR TITLE
perf: encode prolly sort keys from mem values

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -5832,13 +5832,19 @@ static int prollyBtCursorIndexMoveto(
           pIdxKey->aMem[0].u.i,
           &pCur->pSeekSortKey, &pCur->nSeekSortKeyAlloc, &nSortKey);
     }else{
-      rc = serializeUnpackedRecordBuffer(
-          pIdxKey, &pCur->pSeekRecord, &pCur->nSeekRecordAlloc, &nSerKey);
-      if( rc!=SQLITE_OK ) return rc;
-      pSerKey = pCur->pSeekRecord;
-      rc = sortKeyFromRecordPrefixCollBuffer(
-          pSerKey, nSerKey, nSeekKeyField, pCur->pKeyInfo,
+      rc = sortKeyFromMemPrefixCollBuffer(
+          pIdxKey->aMem, (int)pIdxKey->nField, nSeekKeyField,
+          pCur->pKeyInfo,
           &pCur->pSeekSortKey, &pCur->nSeekSortKeyAlloc, &nSortKey);
+      if( rc==SQLITE_NOTFOUND ){
+        rc = serializeUnpackedRecordBuffer(
+            pIdxKey, &pCur->pSeekRecord, &pCur->nSeekRecordAlloc, &nSerKey);
+        if( rc!=SQLITE_OK ) return rc;
+        pSerKey = pCur->pSeekRecord;
+        rc = sortKeyFromRecordPrefixCollBuffer(
+            pSerKey, nSerKey, nSeekKeyField, pCur->pKeyInfo,
+            &pCur->pSeekSortKey, &pCur->nSeekSortKeyAlloc, &nSortKey);
+      }
     }
     if( rc!=SQLITE_OK ) return rc;
     pSortKey = pCur->pSeekSortKey;
@@ -6413,11 +6419,22 @@ static int prollyBtCursorInsert(
         isIndex = (pTE && !tableEntryIsTableRoot(pCur->pBtree, pTE));
       }
     }
-    rc = sortKeyFromRecordPrefixCollBuffer(
-        (const u8*)pPayload->pKey, (int)pPayload->nKey,
-        isIndex ? 0 : (splitKey ? nKeyField : 0),
-        pCur->pKeyInfo,
-        &pCur->pSeekSortKey, &pCur->nSeekSortKeyAlloc, &nSortKey);
+    if( pPayload->aMem && pPayload->nMem > 0 ){
+      rc = sortKeyFromMemPrefixCollBuffer(
+          pPayload->aMem, (int)pPayload->nMem,
+          isIndex ? 0 : (splitKey ? nKeyField : 0),
+          pCur->pKeyInfo,
+          &pCur->pSeekSortKey, &pCur->nSeekSortKeyAlloc, &nSortKey);
+    }else{
+      rc = SQLITE_NOTFOUND;
+    }
+    if( rc==SQLITE_NOTFOUND ){
+      rc = sortKeyFromRecordPrefixCollBuffer(
+          (const u8*)pPayload->pKey, (int)pPayload->nKey,
+          isIndex ? 0 : (splitKey ? nKeyField : 0),
+          pCur->pKeyInfo,
+          &pCur->pSeekSortKey, &pCur->nSeekSortKeyAlloc, &nSortKey);
+    }
     if( rc==SQLITE_OK ){
       if( splitKey ){
         rc = prollyMutMapInsert(pCur->pMutMap,

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -6419,22 +6419,11 @@ static int prollyBtCursorInsert(
         isIndex = (pTE && !tableEntryIsTableRoot(pCur->pBtree, pTE));
       }
     }
-    if( pPayload->aMem && pPayload->nMem > 0 ){
-      rc = sortKeyFromMemPrefixCollBuffer(
-          pPayload->aMem, (int)pPayload->nMem,
-          isIndex ? 0 : (splitKey ? nKeyField : 0),
-          pCur->pKeyInfo,
-          &pCur->pSeekSortKey, &pCur->nSeekSortKeyAlloc, &nSortKey);
-    }else{
-      rc = SQLITE_NOTFOUND;
-    }
-    if( rc==SQLITE_NOTFOUND ){
-      rc = sortKeyFromRecordPrefixCollBuffer(
-          (const u8*)pPayload->pKey, (int)pPayload->nKey,
-          isIndex ? 0 : (splitKey ? nKeyField : 0),
-          pCur->pKeyInfo,
-          &pCur->pSeekSortKey, &pCur->nSeekSortKeyAlloc, &nSortKey);
-    }
+    rc = sortKeyFromRecordPrefixCollBuffer(
+        (const u8*)pPayload->pKey, (int)pPayload->nKey,
+        isIndex ? 0 : (splitKey ? nKeyField : 0),
+        pCur->pKeyInfo,
+        &pCur->pSeekSortKey, &pCur->nSeekSortKeyAlloc, &nSortKey);
     if( rc==SQLITE_OK ){
       if( splitKey ){
         rc = prollyMutMapInsert(pCur->pMutMap,

--- a/src/sortkey.c
+++ b/src/sortkey.c
@@ -2,6 +2,7 @@
 #ifdef DOLTLITE_PROLLY
 
 #include "sortkey.h"
+#include "vdbeInt.h"
 #include <limits.h>
 #include <string.h>
 
@@ -354,6 +355,139 @@ int sortKeyFromRecordPrefixCollBuffer(
   }
 
   if( nSize != sortKeyEncode(pRec, nRec, *ppBuf, nKeyField, pKeyInfo) ){
+    return SQLITE_CORRUPT;
+  }
+  *pnOut = nSize;
+  return SQLITE_OK;
+}
+
+static int sortKeyMemSerialType(Mem *pMem, u32 *pSerialType, u32 *pLen){
+  int flags = pMem->flags;
+  if( flags & MEM_Null ){
+    *pSerialType = 0;
+    *pLen = 0;
+    return SQLITE_OK;
+  }
+  if( flags & MEM_IntReal ){
+    return SQLITE_NOTFOUND;
+  }
+  if( flags & MEM_Int ){
+    intSerialType(pMem->u.i, pSerialType, pLen);
+    return SQLITE_OK;
+  }
+  if( flags & MEM_Real ){
+    *pSerialType = 7;
+    *pLen = 8;
+    return SQLITE_OK;
+  }
+  if( flags & (MEM_Str|MEM_Blob) ){
+    if( flags & MEM_Zero ){
+      return SQLITE_NOTFOUND;
+    }
+    if( pMem->n < 0 || (pMem->n > 0 && pMem->z==0) ){
+      return SQLITE_CORRUPT;
+    }
+    *pLen = (u32)pMem->n;
+    *pSerialType = (*pLen * 2) + 12 + ((flags & MEM_Str)!=0);
+    return SQLITE_OK;
+  }
+  return SQLITE_NOTFOUND;
+}
+
+static int sortKeyEncodeMemArray(
+  Mem *aMem,
+  int nMem,
+  int nKeyField,
+  const KeyInfo *pKeyInfo,
+  u8 *pOut
+){
+  int nField = nKeyField > 0 && nKeyField < nMem ? nKeyField : nMem;
+  sqlite3_int64 outSize = 0;
+  int outPos = 0;
+  int i;
+
+  if( nField < 0 ) return -1;
+  for(i = 0; i < nField; i++){
+    Mem *pMem = &aMem[i];
+    u32 serialType;
+    u32 fieldLen;
+    u8 aNum[8];
+    const u8 *pField = (const u8*)pMem->z;
+    int coll;
+    int rc = sortKeyMemSerialType(pMem, &serialType, &fieldLen);
+    if( rc==SQLITE_NOTFOUND ) return -3;
+    if( rc!=SQLITE_OK ) return -1;
+
+    if( serialType <= 6 || serialType==8 || serialType==9 ){
+      writeIntBE(aNum, pMem->u.i, (int)fieldLen);
+      pField = aNum;
+    }else if( serialType==7 ){
+      u64 v;
+      memcpy(&v, &pMem->u.r, 8);
+      aNum[0] = (u8)(v >> 56); aNum[1] = (u8)(v >> 48);
+      aNum[2] = (u8)(v >> 40); aNum[3] = (u8)(v >> 32);
+      aNum[4] = (u8)(v >> 24); aNum[5] = (u8)(v >> 16);
+      aNum[6] = (u8)(v >> 8);  aNum[7] = (u8)v;
+      pField = aNum;
+    }
+
+    coll = collFromKeyInfo(pKeyInfo, i);
+    if( pOut ){
+      u8 tag = serialTypeTag(serialType);
+      switch( tag ){
+        case SORTKEY_NULL:
+          pOut[outPos++] = SORTKEY_NULL;
+          break;
+        case SORTKEY_NUM:
+          outPos += encodeNumeric(pOut + outPos, serialType, pField, fieldLen);
+          break;
+        case SORTKEY_TEXT:
+          outPos += encodeText(pOut + outPos, pField, fieldLen, coll);
+          break;
+        case SORTKEY_BLOB:
+          outPos += encodeVarLen(pOut + outPos, tag, pField, fieldLen);
+          break;
+        default:
+          pOut[outPos++] = SORTKEY_NULL;
+          break;
+      }
+    }else{
+      sqlite3_int64 nFieldSize =
+          encodedFieldSize(serialType, pField, fieldLen, coll);
+      if( nFieldSize > INT_MAX || outSize > INT_MAX - nFieldSize ){
+        return -2;
+      }
+      outSize += nFieldSize;
+    }
+  }
+
+  return pOut ? outPos : (int)outSize;
+}
+
+int sortKeyFromMemPrefixCollBuffer(
+  Mem *aMem, int nMem, int nKeyField, const KeyInfo *pKeyInfo,
+  u8 **ppBuf, int *pnAlloc, int *pnOut
+){
+  int nSize;
+  int nAlloc;
+
+  *pnOut = 0;
+  if( !aMem || nMem<=0 ) return SQLITE_NOTFOUND;
+
+  nSize = sortKeyEncodeMemArray(aMem, nMem, nKeyField, pKeyInfo, 0);
+  if( nSize == -3 ) return SQLITE_NOTFOUND;
+  if( nSize == -2 ) return SQLITE_TOOBIG;
+  if( nSize < 0 ) return SQLITE_CORRUPT;
+
+  nAlloc = nSize < 64 ? 64 : nSize;
+  if( *pnAlloc < nAlloc ){
+    u8 *pNew = (u8*)sqlite3_realloc64(*ppBuf, (sqlite3_uint64)nAlloc);
+    if( !pNew ) return SQLITE_NOMEM;
+    *ppBuf = pNew;
+    *pnAlloc = nAlloc;
+  }
+
+  if( nSize != sortKeyEncodeMemArray(aMem, nMem, nKeyField, pKeyInfo, *ppBuf) ){
     return SQLITE_CORRUPT;
   }
   *pnOut = nSize;

--- a/src/sortkey.h
+++ b/src/sortkey.h
@@ -20,6 +20,10 @@ int sortKeyFromRecordPrefixColl(const u8 *pRec, int nRec, int nKeyField,
 int sortKeyFromRecordPrefixCollBuffer(const u8 *pRec, int nRec, int nKeyField,
                                  const KeyInfo *pKeyInfo,
                                  u8 **ppBuf, int *pnAlloc, int *pnOut);
+int sortKeyFromMemPrefixCollBuffer(
+  Mem *aMem, int nMem, int nKeyField, const KeyInfo *pKeyInfo,
+  u8 **ppBuf, int *pnAlloc, int *pnOut
+);
 
 int sortKeyFromInt64(i64 v, u8 *pOut, int *pnOut);
 int sortKeyFromInt64Buffer(i64 v, u8 **ppBuf, int *pnAlloc, int *pnOut);

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -17,6 +17,7 @@
 #include "prolly_mutate.h"
 #include "prolly_node.h"
 #include "prolly_mutmap.h"
+#include "vdbeInt.h"
 #include "sortkey.h"
 
 typedef unsigned char u8;
@@ -2301,6 +2302,67 @@ static void run_sortkey_buffer_exact_size(void){
 
   sqlite3_free(pSortKey);
   sqlite3_free(pRoundTrip);
+}
+
+static void run_sortkey_mem_matches_record(void){
+  static const u8 record[] = {
+    0x04,
+    0x01,
+    0x13,
+    0x12,
+    0x7b,
+    'a', 0x00, 'b',
+    0x01, 0x00, 0x03
+  };
+  Mem aMem[3];
+  u8 *pRecordKey = 0;
+  u8 *pMemKey = 0;
+  u8 *pRecordPrefix = 0;
+  u8 *pMemPrefix = 0;
+  int nRecordKey = 0;
+  int nMemKey = 0;
+  int nRecordPrefix = 0;
+  int nMemPrefix = 0;
+  int nMemAlloc = 0;
+  int nMemPrefixAlloc = 0;
+  int rc;
+
+  printf("=== Sortkey Mem Matches Record Test ===\n\n");
+
+  memset(aMem, 0, sizeof(aMem));
+  aMem[0].flags = MEM_Int;
+  aMem[0].u.i = 123;
+  aMem[1].flags = MEM_Str;
+  aMem[1].z = "a\000b";
+  aMem[1].n = 3;
+  aMem[2].flags = MEM_Blob;
+  aMem[2].z = "\001\000\003";
+  aMem[2].n = 3;
+
+  rc = sortKeyFromRecordPrefixColl(record, (int)sizeof(record), 0, 0,
+                                   &pRecordKey, &nRecordKey);
+  check("sortkey_mem_record_encode_ok", rc==SQLITE_OK);
+  rc = sortKeyFromMemPrefixCollBuffer(aMem, 3, 0, 0,
+                                      &pMemKey, &nMemAlloc, &nMemKey);
+  check("sortkey_mem_encode_ok", rc==SQLITE_OK);
+  check("sortkey_mem_matches_record",
+        nMemKey==nRecordKey && memcmp(pMemKey, pRecordKey, nRecordKey)==0);
+
+  rc = sortKeyFromRecordPrefixColl(record, (int)sizeof(record), 1, 0,
+                                   &pRecordPrefix, &nRecordPrefix);
+  check("sortkey_mem_record_prefix_encode_ok", rc==SQLITE_OK);
+  rc = sortKeyFromMemPrefixCollBuffer(aMem, 3, 1, 0,
+                                      &pMemPrefix, &nMemPrefixAlloc,
+                                      &nMemPrefix);
+  check("sortkey_mem_prefix_encode_ok", rc==SQLITE_OK);
+  check("sortkey_mem_prefix_matches_record",
+        nMemPrefix==nRecordPrefix
+        && memcmp(pMemPrefix, pRecordPrefix, nRecordPrefix)==0);
+
+  sqlite3_free(pRecordKey);
+  sqlite3_free(pMemKey);
+  sqlite3_free(pRecordPrefix);
+  sqlite3_free(pMemPrefix);
 }
 
 static void run_reload_refs_transactional(void){
@@ -6824,6 +6886,7 @@ static const RegressionCase aCases[] = {
   { "sortkey_numeric_text_roundtrip", "Sortkey Numeric Text Roundtrip Test", run_sortkey_numeric_text_roundtrip },
   { "sortkey_numeric_blob_roundtrip", "Sortkey Numeric Blob Roundtrip Test", run_sortkey_numeric_blob_roundtrip },
   { "sortkey_buffer_exact_size", "Sortkey Buffer Exact Size Test", run_sortkey_buffer_exact_size },
+  { "sortkey_mem_matches_record", "Sortkey Mem Matches Record Test", run_sortkey_mem_matches_record },
   { "reload_refs_transactional", "Reload Refs Transactional Test", run_reload_refs_transactional },
   { "refresh_refs_corruption_preserves_state", "Refresh Corrupt Refs State Preservation Test", run_refresh_refs_corruption_preserves_state },
   { "prolly_node_corruption", "Prolly Node Corruption Test", run_prolly_node_corruption },


### PR DESCRIPTION
## Summary
- add a direct sort-key encoder for decomposed SQLite Mem values
- use it for prolly index seeks, falling back to the existing record parser when needed
- keep insert paths on packed record parsing so unique index entries preserve trailing rowid fields
- add regression coverage that validates Mem-derived sort keys match record-derived sort keys

## Benchmark target
From the last merged doltlite PR's sysbench comment (#912), excluding index_join_scan, the highest multiplier was:
- metric: oltp_read_write
- key type: TEXT primary key
- mode: in-memory
- autocommit: false
- comment result: SQLite 59,186 us, Doltlite 104,406 us, 1.76x

## Local comparison
Clean master baseline, BENCH_RUNS=7, text PK in-memory non-autocommit:
- oltp_read_write: SQLite 32,801 us, Doltlite 55,521 us, 1.69x

This branch after narrowing the fast path, BENCH_RUNS=7, text PK in-memory non-autocommit:
- oltp_read_write: SQLite 33,265 us, Doltlite 53,946 us, 1.62x

Note: the local text PK compare script still exits nonzero on unrelated autocommit threshold rows, as it did on the clean baseline. A BENCH_RUNS=21 classic rerun did not reproduce CI's oltp_insert_ac failure locally; local oltp_insert_ac was 1.45x, though other local autocommit rows remained noisy.

## Verification
- make doltlite doltlite-lib
- cc -O2 -I. -I./src -o bench_timer_doltlite test/sysbench_timer.c libdoltlite.a -lpthread -lz -lm
- bash test/doltlite_index_prefix.sh
- bash test/doltlite_gc_scale.sh
- DOLTLITE_BUILD_DIR=. bash test/doltlite_regression_test_c.sh
- BENCH_RUNS=7 bash test/sysbench_compare_textpk.sh > /tmp/text_after_narrow.md (expected nonzero from unrelated autocommit ceilings)
- BENCH_RUNS=21 BENCH_SECTION_MODE=full bash test/sysbench_compare.sh > /tmp/classic_rerun_after_narrow.md (did not reproduce CI oltp_insert_ac; local unrelated/noisy rows still exceeded)
- git diff --check