### PR TITLE
fix(packaging): register ldconfig trigger for libdoltlite0 .deb

### DIFF
--- a/packaging/nfpm/libdoltlite0.yaml
+++ b/packaging/nfpm/libdoltlite0.yaml
@@ -32,3 +32,12 @@ contents:
       mode: 0644
   - src: LICENSE.md
     dst: /usr/share/doc/libdoltlite0/copyright
+
+# Standard Debian shared-library hook: dpkg runs ldconfig in postinst so
+# /etc/ld.so.cache picks up libdoltlite.so.0 right after install. Without
+# this, the package-smoke check sees libdoltlite not registered with
+# ldconfig — and so would every user who only does `dpkg -i`.
+deb:
+  triggers:
+    interest_noawait:
+      - ldconfig


### PR DESCRIPTION
v0.10.8's \`package-smoke-deb\` job caught it: after \`dpkg -i libdoltlite0_*.deb\`, \`ldconfig -p\` doesn't list libdoltlite, so \`dlopen(\"libdoltlite.so.0\")\` fails for Python ctypes / Node / anything respecting SONAME, and \`-ldoltlite\` loaders break.

Standard Debian library packages register interest in the \`ldconfig\` trigger; dpkg then runs \`ldconfig\` in postinst and \`/etc/ld.so.cache\` picks up the new SONAME. Add the equivalent nfpm declaration.

After this merges: delete and re-cut v0.10.8 (per your preference) so the published binaries are usable.