### PR TITLE
Fast-path exact integer sort keys

### DIFF
--- a/src/sortkey.c
+++ b/src/sortkey.c
@@ -508,6 +508,24 @@ int sortKeyFromInt64(i64 v, u8 *pOut, int *pnOut){
   u32 serialType;
   u32 nData;
 
+  if( v>=-9007199254740992LL && v<=9007199254740992LL ){
+    double d = (double)v;
+    u64 x;
+    int i;
+    pOut[0] = SORTKEY_NUM;
+    memcpy(&x, &d, 8);
+    if( x & ((u64)1 << 63) ){
+      x = ~x;
+    }else{
+      x ^= ((u64)1 << 63);
+    }
+    for(i=0; i<8; i++){
+      pOut[1+i] = (u8)(x >> (56 - i*8));
+    }
+    *pnOut = 9;
+    return SQLITE_OK;
+  }
+
   intSerialType(v, &serialType, &nData);
   writeIntBE(aData, v, (int)nData);
   *pnOut = encodeNumeric(pOut, serialType, aData, nData);


### PR DESCRIPTION
## Summary
- target from last merged PR #916 sysbench comments: `oltp_update_index`, classic integer primary key, in-memory, wrapped transaction (not autocommit), 1.74x (SQLite 32,489 us, Doltlite 56,529 us)
- add a fast path in `sortKeyFromInt64` for int64 values exactly representable as IEEE doubles
- avoids the full SQLite serial-type encode/decode path for common integer index keys, including `k` and rowid in the target benchmark

## Local benchmark
Targeted `oltp_update_index` in-memory SQL, Doltlite-only median:
- clean `origin/master`: 27,514 us (11 runs)
- this branch: 26,669 us (11 runs)

Wrapped sysbench section, 7 runs, this branch:
- in-memory `oltp_update_index`: SQLite 18,094 us, Doltlite 27,523 us, 1.52x

## Tests
- `make doltlite doltlite-lib`
- `DOLTLITE_BUILD_DIR=. bash test/run_doltlite_regression_case.sh sortkey_two_numeric_roundtrip`
- `DOLTLITE_BUILD_DIR=. bash test/run_doltlite_regression_case.sh sortkey_mem_matches_record`
- `DOLTLITE_BUILD_DIR=. bash test/doltlite_regression_test_c.sh`
- `DOLTLITE=./doltlite bash test/doltlite_working_set.sh`
- `DOLTLITE=./doltlite bash test/doltlite_branch.sh`
- `BENCH_RUNS=7 BENCH_SECTION_MODE=wrapped bash test/sysbench_compare.sh`
- `git diff --check`