### PR TITLE
Avoid redundant read refresh on cursor open

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -5017,17 +5017,6 @@ static int prollyBtreeCursor(
 
   assert( p->inTrans>=TRANS_READ );
 
-  if( p->db && p->db->autoCommit && !p->db->pSavepoint
-   && p->inTrans!=TRANS_WRITE ){
-    u8 oldSnapshotPinned = pBt->store.snapshotPinned;
-    pBt->store.snapshotPinned = 0;
-    rc = btreeRefreshFromDisk(p);
-    pBt->store.snapshotPinned = oldSnapshotPinned;
-    if( rc!=SQLITE_OK ) return rc;
-    rc = btreeRefreshSharedWorkingState(p);
-    if( rc!=SQLITE_OK ) return rc;
-  }
-
   memset(pCur, 0, sizeof(BtCursor));
   pCur->pBtree = p;
   pCur->pBt = pBt;


### PR DESCRIPTION
## Summary
- target from last merged PR #917 sysbench comments: `oltp_index_scan`, classic integer primary key schema, file-backed autocommit reads, 1.75x (SQLite 3,873 us, Doltlite 6,769 us)
- remove the cursor-open refresh for read transactions; `prollyBtreeBeginTrans` already refreshes from disk and pins the read snapshot before cursors are opened
- avoids redundant file-size/external-change checks for read statements with multiple cursors, including index lookup plus table lookup

## Local benchmark
Targeted `oltp_index_scan` file-backed SQL, Doltlite-only median:
- clean `origin/master`: 5,573 us (11 runs)
- this branch: 4,867 us (11 runs)

Autocommit section, 7 runs, this branch:
- `oltp_index_scan`: SQLite 2,693 us, Doltlite 4,883 us, 1.81x
- local section exited nonzero due existing unrelated write rows over ceiling: `oltp_update_non_index_ac`, `types_delete_insert_ac`, and ac_writes average

## Tests
- `make doltlite doltlite-lib`
- `DOLTLITE_BUILD_DIR=. bash test/doltlite_regression_test_c.sh`
- `DOLTLITE=./doltlite bash test/doltlite_working_set.sh`
- `DOLTLITE=./doltlite bash test/doltlite_branch.sh`
- `BENCH_RUNS=7 BENCH_SECTION_MODE=autocommit bash test/sysbench_compare.sh` (expected local ceiling failures noted above)
- `git diff --check`