### PR TITLE
Defer mutmap position rebuilds

### DIFF
--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -8,6 +8,7 @@
 
 #define MUTMAP_INIT_CAP 16
 #define MUTMAP_MIN_HASH 32
+#define MUTMAP_POS_UPDATE_LIMIT 64
 
 i64 prollyMutMapEntryIntKey(const ProllyMutMapEntry *e){
   const u8 *p = e->pKey;
@@ -379,13 +380,23 @@ static int ensureOrder(ProllyMutMap *mm){
   int i;
   int rc;
   mm->preferSorted = 1;
-  if( mm->keepSorted || !mm->orderDirty ) return SQLITE_OK;
+  if( mm->keepSorted ) return SQLITE_OK;
+  if( !mm->orderDirty ){
+    if( mm->posDirty ){
+      for(i=0; i<mm->nEntries; i++){
+        mm->aPos[mm->aOrder[i]] = i;
+      }
+      mm->posDirty = 0;
+    }
+    return SQLITE_OK;
+  }
   rc = mutmapSortOrder(mm);
   if( rc!=SQLITE_OK ) return rc;
   for(i=0; i<mm->nEntries; i++){
     mm->aPos[mm->aOrder[i]] = i;
   }
   mm->orderDirty = 0;
+  mm->posDirty = 0;
   return SQLITE_OK;
 }
 
@@ -439,14 +450,19 @@ static int ensureCapacity(ProllyMutMap *mm){
 }
 
 static void insertOrderEntry(ProllyMutMap *mm, int idx, int phys){
-  int i;
+  int shifted = mm->nEntries - idx;
   if( idx < mm->nEntries ){
     memmove(&mm->aOrder[idx+1], &mm->aOrder[idx],
             (mm->nEntries - idx) * sizeof(int));
   }
   mm->aOrder[idx] = phys;
-  for(i=idx; i<=mm->nEntries; i++){
-    mm->aPos[mm->aOrder[i]] = i;
+  if( !mm->isIntKey || shifted <= MUTMAP_POS_UPDATE_LIMIT ){
+    int i;
+    for(i=idx; i<=mm->nEntries; i++){
+      mm->aPos[mm->aOrder[i]] = i;
+    }
+  }else{
+    mm->posDirty = 1;
   }
 }
 
@@ -691,9 +707,11 @@ int prollyMutMapRollbackToSavepoint(ProllyMutMap *mm, int level){
         for(j=0; j<mm->nEntries; j++){
           mm->aPos[mm->aOrder[j]] = j;
         }
+        mm->posDirty = 0;
       }else{
         mm->nEntries = newN;
         mm->orderDirty = 1;
+        mm->posDirty = 1;
       }
       for(j=0; j<mm->nUndo; j++){
         mm->aUndo[j].entryIdx = aMap[mm->aUndo[j].entryIdx];
@@ -861,6 +879,7 @@ void prollyMutMapClear(ProllyMutMap *mm){
   mm->nEntries = 0;
   mm->orderDirty = 0;
   mm->preferSorted = 0;
+  mm->posDirty = 0;
   mm->generation++;
   if( mm->aHash && mm->nHashAlloc>0 ){
     memset(mm->aHash, 0, mm->nHashAlloc * sizeof(int));
@@ -904,6 +923,7 @@ int prollyMutMapClone(ProllyMutMap **out, const ProllyMutMap *src){
   dst->keepSorted = src->keepSorted;
   dst->orderDirty = src->orderDirty;
   dst->preferSorted = src->preferSorted;
+  dst->posDirty = src->posDirty;
   dst->levelBase = src->levelBase;
   dst->currentSavepointLevel = src->currentSavepointLevel;
   dst->generation = src->generation;

--- a/src/prolly_mutmap.h
+++ b/src/prolly_mutmap.h
@@ -41,6 +41,7 @@ struct ProllyMutMap {
   u8 orderDirty;
   /* Set after ordered access so mixed read/write maps keep their order. */
   u8 preferSorted;
+  u8 posDirty;
   int nEntries;
   int nAlloc;
   int levelBase;


### PR DESCRIPTION
## Summary
- Targeted latest merged PR #918 sysbench hotspot excluding index_join_scan: classic integer-PK oltp_read_write, In-Memory, Writes, wrapped transaction (not autocommit), 1.74x in the PR comment.
- Avoid eager aPos reverse-index maintenance on each ordered mutmap insert/delete.
- Mark positions dirty and rebuild lazily only when an ordered-position lookup needs them.

## Local benchmark
Clean origin/master direct in-memory oltp_read_write: median 45,288 us over 9 runs.
This branch direct in-memory oltp_read_write: median 44,534 us over 9 runs.

BENCH_RUNS=7 BENCH_SECTION_MODE=wrapped bash test/sysbench_compare.sh:
- In-Memory oltp_read_write: SQLite 30,204 us, Doltlite 44,862 us, 1.49x.
- File-Backed oltp_read_write: SQLite 34,459 us, Doltlite 50,292 us, 1.46x.
- All tests within 2.0x individual / 1.6x average ceilings.

## Tests
- make doltlite doltlite-lib
- DOLTLITE_BUILD_DIR=. bash test/run_doltlite_regression_case.sh mutmap_differential_randomized
- DOLTLITE_BUILD_DIR=. bash test/run_doltlite_regression_case.sh mutmap_resolve_sorted_pos
- DOLTLITE_BUILD_DIR=. bash test/doltlite_regression_test_c.sh
- git diff --check