### PR TITLE
Optimize text sorter comparisons

### DIFF
--- a/src/vdbesort.c
+++ b/src/vdbesort.c
@@ -820,6 +820,7 @@ static int vdbeSorterCompareText(
 
   int n1;
   int n2;
+  int len;
   int res;
 
   if( pKeyInfo->nKeyField==1
@@ -842,7 +843,11 @@ static int vdbeSorterCompareText(
     if( n1!=nKey1 - p1[0] || n2!=nKey2 - p2[0] ){
       goto text_compare_slow;
     }
-    res = memcmp(v1, v2, MIN(n1, n2));
+    if( n1>0 && n2>0 && (res = (int)v1[0] - (int)v2[0])==0 ){
+      res = memcmp(v1+1, v2+1, MIN(n1, n2)-1);
+    }else if( n1==0 || n2==0 ){
+      res = 0;
+    }
     if( res==0 ){
       res = n1 - n2;
     }
@@ -855,7 +860,12 @@ static int vdbeSorterCompareText(
 text_compare_slow:
   getVarint32NR(&p1[1], n1);
   getVarint32NR(&p2[1], n2);
-  res = memcmp(v1, v2, (MIN(n1, n2) - 13)/2);
+  len = (MIN(n1, n2) - 13)/2;
+  if( len>0 && (res = (int)v1[0] - (int)v2[0])==0 ){
+    res = memcmp(v1+1, v2+1, len-1);
+  }else if( len==0 ){
+    res = 0;
+  }
   if( res==0 ){
     res = n1 - n2;
   }


### PR DESCRIPTION
## Summary
- Target from latest merged PR #924 sysbench comments, excluding `index_join_scan`: classic INTEGER-key `oltp_order_range`, file-backed autocommit reads, 1.66x.
- Add a first-byte fast check to the one-field BINARY text sorter comparator before falling back to `memcmp()`.
- This is general for text ORDER BY/DISTINCT sorter workloads where text keys commonly differ early.

## Local benchmark
Exact classic `oltp_order_range` shape: 10K integer-PK rows, file-backed DB, fresh DB per sample, 31 samples.

- master median: 3719 us
- branch median: 3600 us
- delta: -3.2%

## Validation
- `make libdoltlite.a doltlite`
- `cc -O2 -I. -I./src -o bench_timer_doltlite test/sysbench_timer.c libdoltlite.a -lpthread -lz -lm`
- `make lint`
- focused ASC/DESC/DISTINCT text ORDER BY comparison against stock `/usr/bin/sqlite3`
