### PR TITLE
Fast path exact full index seeks

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -6010,7 +6010,30 @@ static int prollyBtCursorIndexMoveto(
       }
     }
 
-    rc = prollyCursorSeekBlob(&pCur->pCur, pSortKey, nSortKey, &(int){0});
+    {
+      int seekRes = 0;
+      rc = prollyCursorSeekBlob(&pCur->pCur, pSortKey, nSortKey, &seekRes);
+      if( rc==SQLITE_OK
+       && seekRes==0
+       && pCur->pCur.eState==PROLLY_CURSOR_VALID
+       && pCur->pKeyInfo
+       && pIdxKey->nField >= pCur->pKeyInfo->nAllField ){
+        int isDeleted = 0;
+        if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
+          ProllyMutMapEntry *mmE = 0;
+          rc = prollyMutMapFindRc(pCur->pMutMap, pSortKey, nSortKey, 0, &mmE);
+          if( rc!=SQLITE_OK ) return rc;
+          if( mmE && mmE->op==PROLLY_EDIT_DELETE ) isDeleted = 1;
+        }
+        if( !isDeleted ){
+          *pRes = 0;
+          pIdxKey->eqSeen = 1;
+          pCur->eState = CURSOR_VALID;
+          cacheCurrentTreeStoredPayloadNonIntKey(pCur);
+          return SQLITE_OK;
+        }
+      }
+    }
     if( rc==SQLITE_OK && pCur->pCur.eState==PROLLY_CURSOR_VALID ){
       int iLevel = pCur->pCur.iLevel;
       ProllyCacheEntry *pLeaf = pCur->pCur.aLevel[iLevel].pEntry;


### PR DESCRIPTION
## Summary
- Target from latest merged PR #928 sysbench comments, excluding `index_join_scan`: classic INTEGER-key `oltp_update_index_ac`, file-backed autocommit writes, 1.75x.
- Add a btree-layer fast path for exact full-key index seeks after a prolly seek returns an exact match.
- This avoids leaf scanning and record comparison for full index-key probes, while still honoring pending deletes in the cursor mutmap.

## Local benchmark
Exact classic `oltp_update_index_ac` shape: 10K integer-PK rows, secondary `k_idx`, 200 autocommitted indexed-column updates, file-backed DB, fresh DB per sample, 31 samples.

- master median: 36596 us
- branch median: 34912 us
- delta: -4.6%

## Validation
- `make libdoltlite.a doltlite`
- `cc -O2 -I. -I./src -o bench_timer_doltlite test/sysbench_timer.c libdoltlite.a -lpthread -lz -lm`
- `make lint`
- focused indexed-update output comparison against stock `/usr/bin/sqlite3`
- `bash ./test/index_test.sh ./doltlite`
