### PR TITLE
fix(chunk-store): verify existing chunks on chunkStorePut dedup hit

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -941,20 +941,21 @@ int chunkStorePut(
   ProllyHash *pHash
 ){
   int rc;
-  int idx = -1;
   ProllyHash h;
 
   prollyHashCompute(pData, nData, &h);
   if( pHash ) memcpy(pHash, &h, sizeof(ProllyHash));
 
-  if( csSearchIndex(cs->index.aIndex, cs->index.nIndex, &h) >= 0 ) return SQLITE_OK;
-  rc = csSearchRecent(cs, &h, &idx);
-  if( rc!=SQLITE_OK ) return rc;
-  if( idx >= 0 ) return SQLITE_OK;
-  idx = -1;
-  rc = csSearchPending(cs, &h, &idx);
-  if( rc!=SQLITE_OK ) return rc;
-  if( idx >= 0 ) return SQLITE_OK;
+  {
+    u8 *pExisting = 0;
+    int nExisting = 0;
+    int getRc = chunkStoreGet(cs, &h, &pExisting, &nExisting);
+    if( getRc == SQLITE_OK ){
+      sqlite3_free(pExisting);
+      return SQLITE_OK;
+    }
+    sqlite3_free(pExisting);
+  }
 
   rc = csGrowPending(cs);
   if( rc != SQLITE_OK ) return rc;


### PR DESCRIPTION
## Summary

Builds on PR #841 (read-time chunkStoreGet hash verify). That PR made torn/bit-rotted chunks surface loudly as SQLITE_CORRUPT on read. But **chunkStorePut still deduplicated by hash alone** — if a write produced the same hash as an existing-but-corrupt chunk, the put silently returned OK without overwriting. A user observing CORRUPT and trying to recover by re-executing the original workload would have their good bytes dropped on the floor.

This was the latent half of the S6 finding from the deep review.

## Fix

Replace the three independent searches (index, recent, pending) in \`chunkStorePut\` with a single \`chunkStoreGet\` against the new content's hash. \`chunkStoreGet\` already does the searches **and** applies the read-time hash verify from #841. Three outcomes:

| chunkStoreGet rc | Meaning | Action |
|---|---|---|
| SQLITE_OK | Existing chunk present and readable | Skip the write (dedup) |
| SQLITE_NOTFOUND | No existing chunk | Write new bytes |
| SQLITE_CORRUPT | Existing chunk is torn | Write new bytes as fresh pending entry |

\`csMergeIndex\` at \`chunk_index.c:351\` already replaces matching index entries with newer pending entries on commit, so the corrupt on-disk entry naturally gets evicted by the good one.

## Performance

- **Hot path (no dedup hit):** same in-memory searches as before, NOTFOUND returns immediately. Zero extra I/O.
- **Dedup-hit path:** one extra read + hash. Cost of \"prove the existing chunk is actually usable.\"

## Relationship to #927

This replaces the abandoned S7 fsync-ordering approach from #927. The trade was:

| | Per-commit cost | Recovery story |
|---|---|---|
| #927 (S7 fsync) | 1 fsync per commit | Atomic commit durability |
| This PR (dedup-verify) | 0 extra in hot path | Re-execute-to-recover works |

For doltlite's move-fast posture, dedup-verify is the better trade.

## Test plan

- [x] \`correctness_test.sh\`: 41/41
- [x] \`doltlite_regression_test_c.sh\`: 108637/108637 (the existing \`prolly_diff_record_corruption\` and \`integrity_check_surfaces_root_corruption\` cases still pass — read-time verify behavior is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)