### PR TITLE
Optimize binary text sorter comparisons

### DIFF
--- a/src/vdbesort.c
+++ b/src/vdbesort.c
@@ -844,7 +844,10 @@ static int vdbeSorterCompareText(
       goto text_compare_slow;
     }
     if( n1>0 && n2>0 && (res = (int)v1[0] - (int)v2[0])==0 ){
-      res = memcmp(v1+1, v2+1, MIN(n1, n2)-1);
+      int nCmp = MIN(n1, n2);
+      if( nCmp>1 && (res = (int)v1[1] - (int)v2[1])==0 ){
+        res = nCmp>2 ? memcmp(v1+2, v2+2, nCmp-2) : 0;
+      }
     }else if( n1==0 || n2==0 ){
       res = 0;
     }


### PR DESCRIPTION
## Summary
- Targeted the highest non-`index_join_scan` multiplier in the latest merged PR (#929) sysbench comment.
- Metric: `oltp_order_range`, classic INTEGER primary key, file-backed autocommit reads, `1.63x`.
- Optimizes the one-column BINARY text sorter comparator by checking the second byte before falling back to `memcmp`, avoiding most library calls for random text comparisons while preserving normal bytewise ordering.

## Local benchmark
Clean master build from `97c8fa94b` vs this branch, using the same generated classic INTEGER-key file-backed `oltp_order_range` workload.

- Master: 31 runs, median `3478 us`, avg `3543.9 us`
- Branch batch 1: 31 runs, median `3405 us`, avg `3491.9 us`
- Branch batch 2: 31 runs, median `3409 us`, avg `3460.4 us`
- Branch combined: 62 runs, median `3409 us`, avg `3476.2 us`

## Validation
- `make libdoltlite.a doltlite`
- focused ORDER BY parity check against `/usr/bin/sqlite3` for empty strings, equal prefixes, DESC, and embedded NULs
- `make lint`
