### PR TITLE
test(memory_db): lock in :memory: routing semantics (non-bug)

### DIFF
--- a/test/doltlite_memory_db.sh
+++ b/test/doltlite_memory_db.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+DOLTLITE=./doltlite
+PASS=0; FAIL=0; ERRORS=""
+run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
+run_test_lastline() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1 | tail -1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
+run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if echo "$r"|grep -qE "$p"; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  pattern: $p\n  got:     $r"; fi; }
+
+echo "=== DoltLite :memory: routing tests ==="
+echo ""
+
+run_test "memory_engine_is_prolly" "SELECT doltlite_engine();" "prolly" ":memory:"
+
+run_test_lastline "memory_supports_dolt_commit" \
+  "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'); SELECT dolt_commit('-A','-m','init'); SELECT count(*) FROM dolt_log WHERE message='init';" \
+  "1" ":memory:"
+
+run_test_lastline "memory_supports_dolt_branch" \
+  "SELECT dolt_branch('feat'); SELECT count(*) FROM dolt_branches WHERE name IN ('main','feat');" \
+  "2" ":memory:"
+
+run_test_lastline "memory_supports_dolt_checkout_isolates_branches" \
+  "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'); SELECT dolt_commit('-A','-m','init'); SELECT dolt_branch('feat'); SELECT dolt_checkout('feat'); INSERT INTO t VALUES(2,'b'); SELECT dolt_commit('-A','-m','feat-row'); SELECT dolt_checkout('main'); SELECT count(*) FROM t;" \
+  "1" ":memory:"
+
+# Independent :memory: opens don't share state.
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY); INSERT INTO t VALUES(99);" | $DOLTLITE :memory: > /dev/null 2>&1
+R=$(echo "SELECT count(*) FROM t;" | $DOLTLITE :memory: 2>&1)
+if echo "$R" | grep -q "no such table"; then
+  PASS=$((PASS+1))
+else
+  FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: memory_opens_are_independent\n  expected: 'no such table'\n  got:      $R"
+fi
+
+# :memory: doesn't write to disk. Run in scratch dir, verify empty.
+SCRATCH=/tmp/test_memory_no_disk_$$
+mkdir -p $SCRATCH
+ORIG=$PWD
+cd $SCRATCH
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'); SELECT dolt_commit('-A','-m','init');" \
+  | $ORIG/doltlite :memory: > /dev/null 2>&1
+ARTIFACTS=$(ls -A $SCRATCH 2>&1)
+cd $ORIG
+if [ -z "$ARTIFACTS" ]; then
+  PASS=$((PASS+1))
+else
+  FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: memory_creates_no_disk_artifacts\n  expected: empty scratch dir\n  got:      $ARTIFACTS"
+fi
+rm -rf $SCRATCH
+
+# ATTACH ':memory:' as a secondary DB: standard SQLite semantics on
+# the attached schema; main keeps its doltlite engine.
+run_test_lastline "attached_memory_table_independent" \
+  "ATTACH ':memory:' AS aux; CREATE TABLE aux.t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO aux.t VALUES(1,'a'); SELECT count(*) FROM aux.t;" \
+  "1" ":memory:"
+
+run_test_lastline "main_and_attached_isolated" \
+  "ATTACH ':memory:' AS aux; CREATE TABLE main.t(id INTEGER); INSERT INTO main.t VALUES(1); SELECT count(*) FROM aux.sqlite_master WHERE name='t';" \
+  "0" ":memory:"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
+if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi

--- a/test/run_doltlite_tests.sh
+++ b/test/run_doltlite_tests.sh
@@ -50,6 +50,7 @@ TESTS=(
   # Storage and persistence
   doltlite_persistence.sh
   doltlite_branding.sh
+  doltlite_memory_db.sh
   doltlite_gc.sh
   doltlite_structural.sh
   chunk_physical_dups_test.sh


### PR DESCRIPTION
## Summary

The deep review flagged \`:memory:\` routing as P2 (\":memory: silently becomes chunk-store backed; inherits P1's rollback-writes bug\"). On inspection, this is **intentional design, not a bug**:

- A main-DB \`:memory:\` open routes to doltlite's own in-memory chunk store (\`isMemory=1\` flag, \`csCommitToMemory\` commit path) so VC features (\`dolt_log\`, \`dolt_commit\`, \`dolt_branch\`, \`dolt_checkout\`) work on in-memory databases.
- The \"inherits P1\" concern is mooted: \`csCommitToMemory\` is RAM-only, no disk I/O involved.
- ATTACH'd \`:memory:\` correctly routes to stock SQLite (per the existing \`db->aDb[0].pBt!=0\` guard at \`prolly_btree.c:3461\`), giving normal scratch-table semantics on attached schemas.

But the contract wasn't oracle-covered. Lock it in.

## New tests in \`doltlite_memory_db.sh\`

| Test | What it asserts |
|---|---|
| \`memory_engine_is_prolly\` | \`SELECT doltlite_engine()\` returns \"prolly\" |
| \`memory_supports_dolt_commit\` | Commit + log scan works |
| \`memory_supports_dolt_branch\` | \`dolt_branch\` creates branches in \`dolt_branches\` |
| \`memory_supports_dolt_checkout_isolates_branches\` | Checkout switches branches and their data is isolated |
| \`memory_opens_are_independent\` | Two separate \`:memory:\` opens don't share state |
| \`memory_creates_no_disk_artifacts\` | Running \`:memory:\` in an empty cwd leaves it empty |
| \`attached_memory_table_independent\` | ATTACH'd \`:memory:\` works as a standalone SQLite store |
| \`main_and_attached_isolated\` | Main and attached \`:memory:\` schemas don't bleed |

## Test plan

- [x] \`doltlite_memory_db.sh\` directly: 8/8
- [x] \`run_doltlite_tests.sh\` umbrella: 42/42 (added one new suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)