### PR TITLE
test(rollback): lock in pure-SQL rollback byte-stability (P1 was not a bug)

### DIFF
--- a/test/doltlite_rollback_durability.sh
+++ b/test/doltlite_rollback_durability.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# Pure-SQL ROLLBACK must be byte-stable on disk: BEGIN, mutate, ROLLBACK,
+# close — the file is identical to its pre-BEGIN state. This locks in the
+# bMatchesDisk short-circuit in prollyBtreeRollback (chunk_store writes
+# are skipped when the in-memory state matches what's already on disk).
+#
+# Deliberately NOT covered here:
+# - VC commands inside a txn (dolt_checkout etc.) persist immediately by
+#   design and ROLLBACK cannot undo them.
+# - COMMITs that fail with constraint violations persist the violations
+#   catalog as a user-visible feature.
+DOLTLITE="${1:-./doltlite}"
+TMP=$(mktemp -d)
+trap "rm -rf $TMP" EXIT
+PASS=0; FAIL=0; ERRORS=""
+
+file_size() { stat -f %z "$1" 2>/dev/null || stat -c %s "$1"; }
+file_sha()  { shasum -a 256 "$1" | awk '{print $1}'; }
+
+stable_rollback() {
+  local name="$1" setup="$2" txn="$3"
+  local db="$TMP/${name}.db"
+  rm -f "$db"
+  if [ -n "$setup" ]; then
+    printf '%s\n' "$setup" | "$DOLTLITE" "$db" >/dev/null 2>&1
+  fi
+  local size_before sha_before size_after sha_after
+  size_before=$(file_size "$db")
+  sha_before=$(file_sha "$db")
+  printf '%s\n' "$txn" | "$DOLTLITE" "$db" >/dev/null 2>&1
+  size_after=$(file_size "$db")
+  sha_after=$(file_sha "$db")
+  if [ "$size_before" = "$size_after" ] && [ "$sha_before" = "$sha_after" ]; then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1))
+    ERRORS="$ERRORS\nFAIL: $name\n  expected: file unchanged (size=$size_before sha=${sha_before:0:8})\n  got:      size=$size_after sha=${sha_after:0:8} (delta=$((size_after-size_before)))"
+  fi
+}
+
+echo "=== ROLLBACK durability tests ==="
+echo ""
+
+SEED_T="CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'); SELECT dolt_commit('-A','-m','seed');"
+SEED_PLAIN="CREATE TABLE t(id INTEGER PRIMARY KEY); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','seed');"
+
+stable_rollback "empty_begin_rollback" \
+  "$SEED_PLAIN" "BEGIN; ROLLBACK;"
+
+stable_rollback "dml_insert_rollback" \
+  "$SEED_T" "BEGIN; INSERT INTO t VALUES(2,'b'); ROLLBACK;"
+
+stable_rollback "dml_update_rollback" \
+  "$SEED_T" "BEGIN; UPDATE t SET v='X' WHERE id=1; ROLLBACK;"
+
+stable_rollback "dml_delete_rollback" \
+  "$SEED_T" "BEGIN; DELETE FROM t WHERE id=1; ROLLBACK;"
+
+stable_rollback "ddl_create_rollback" \
+  "$SEED_PLAIN" "BEGIN; CREATE TABLE x(id INTEGER PRIMARY KEY); ROLLBACK;"
+
+stable_rollback "ddl_drop_rollback" \
+  "$SEED_T" "BEGIN; DROP TABLE t; ROLLBACK;"
+
+stable_rollback "ddl_alter_rollback" \
+  "$SEED_T" "BEGIN; ALTER TABLE t ADD COLUMN w INTEGER; ROLLBACK;"
+
+stable_rollback "ddl_dml_rollback" \
+  "$SEED_PLAIN" "BEGIN; CREATE TABLE x(id INTEGER PRIMARY KEY); INSERT INTO x VALUES(1); ROLLBACK;"
+
+stable_rollback "savepoint_rollback_outer_rollback" \
+  "$SEED_T" "BEGIN; INSERT INTO t VALUES(2,'b'); SAVEPOINT s1; INSERT INTO t VALUES(3,'c'); ROLLBACK TO s1; ROLLBACK;"
+
+stable_rollback "nested_savepoints_outer_rollback" \
+  "$SEED_T" "BEGIN; SAVEPOINT a; INSERT INTO t VALUES(2,'b'); SAVEPOINT b; INSERT INTO t VALUES(3,'c'); ROLLBACK TO a; ROLLBACK;"
+
+stable_rollback "release_savepoint_then_outer_rollback" \
+  "$SEED_T" "BEGIN; SAVEPOINT a; INSERT INTO t VALUES(2,'b'); RELEASE a; ROLLBACK;"
+
+stable_rollback "trigger_rollback" \
+  "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); CREATE TABLE log(id INTEGER PRIMARY KEY AUTOINCREMENT, msg TEXT); CREATE TRIGGER trg AFTER INSERT ON t BEGIN INSERT INTO log(msg) VALUES('inserted ' || NEW.id); END; SELECT dolt_commit('-A','-m','seed');" \
+  "BEGIN; INSERT INTO t VALUES(1,'a'); ROLLBACK;"
+
+stable_rollback "many_inserts_rollback" \
+  "$SEED_T" \
+  "BEGIN; INSERT INTO t SELECT n+10, hex(randomblob(8)) FROM (WITH RECURSIVE seq(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM seq WHERE n<100) SELECT n FROM seq); ROLLBACK;"
+
+stable_rollback "rollback_after_select_only_inside_txn" \
+  "$SEED_T" "BEGIN; SELECT count(*) FROM t; ROLLBACK;"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
+if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi

--- a/test/run_doltlite_tests.sh
+++ b/test/run_doltlite_tests.sh
@@ -54,6 +54,7 @@ TESTS=(
   doltlite_structural.sh
   chunk_physical_dups_test.sh
   doltlite_savepoint.sh
+  doltlite_rollback_durability.sh
   doltlite_schema_merge.sh
   doltlite_branch_gc_stress.sh
 


### PR DESCRIPTION
## Summary

The deep review flagged **P1** (\"ROLLBACK durably writes to the chunk store\") as a critical SQLite-parity hole at \`prolly_btree.c:4665+\`. Phase 0 probes against current master prove the simple cases the review described — \`BEGIN; DDL/DML; ROLLBACK\` — **do not grow the file**.

The \`bMatchesDisk\` short-circuit at line 4713-4717 correctly catches the common case: rollback restores in-memory state to match disk's, the would-be working-set hash matches what's already there, and the \`chunkStorePut\`/\`chunkStoreCommit\` branch is skipped.

## Probe results on master

| Scenario | Δ file size | Notes |
|---|---:|---|
| \`BEGIN; ROLLBACK;\` | 0 | ✓ |
| \`BEGIN; INSERT; ROLLBACK;\` | 0 | ✓ |
| \`BEGIN; CREATE TABLE; ROLLBACK;\` | 0 | ✓ |
| \`BEGIN; DDL+DML; ROLLBACK;\` | 0 | ✓ |
| Nested savepoints, outer rollback | 0 | ✓ |
| \`BEGIN; dolt_checkout('feat'); ROLLBACK;\` | +484 | VC-inside-txn (intentional — see below) |
| Failed COMMIT (UNIQUE violation) | +169 | constraint_violations catalog persisted (intentional) |

## Two scenarios that still write — both intentional

1. **VC commands inside a txn**: \`dolt_checkout\`, \`dolt_branch\`, etc. persist immediately by design. ROLLBACK can't un-persist them; the rollback path writes a corrected WS blob to keep disk consistent with the now-checked-out branch. Reworking this is a holistic VC-vs-SQL-txn semantics question, not a one-line fix.
2. **COMMIT failed with constraint violation**: persists the \`dolt_constraint_violations\` catalog so the user can query it. Feature, not bug.

## Mark P1 as not-a-bug, lock the contract in tests

\`doltlite_rollback_durability.sh\` runs 14 byte-stability checks: open DB, seed, snapshot (size + SHA-256), run BEGIN/.../ROLLBACK, close, re-snapshot, compare. Any regression in the \`bMatchesDisk\` short-circuit will surface as a hash mismatch.

Coverage: empty txn, INSERT/UPDATE/DELETE rolled back, CREATE/DROP/ALTER table rolled back, DDL+DML rolled back, nested savepoints + outer rollback, savepoint release inside outer rollback, triggers + rollback, 100-row INSERT rolled back, SELECT-only inside txn rolled back.

## Test plan

- [x] \`doltlite_rollback_durability.sh\` directly: 14/14
- [x] \`run_doltlite_tests.sh\` umbrella: 42/42 (added one new suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)