### PR TITLE
fix(prolly): lock S5/E8 invariants as explicit assertions (non-bugs)

### DIFF
--- a/src/prolly_chunker.c
+++ b/src/prolly_chunker.c
@@ -5,6 +5,8 @@
 #include "prolly_cursor.h"
 #include "prolly_xxhash.h"
 
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <assert.h>
 
@@ -240,6 +242,15 @@ int prollyChunkerFinish(ProllyChunker *ch){
     level++;
   }
 
+#ifdef DOLTLITE_PROLLY_CHECK
+  if( ch->nLevels > 0 ){
+    fprintf(stderr,
+            "doltlite: S5 invariant: prollyChunkerFinish has nLevels=%d "
+            "but every level is empty; would have returned empty root\n",
+            ch->nLevels);
+    abort();
+  }
+#endif
   memset(&ch->root, 0, sizeof(ProllyHash));
   return SQLITE_OK;
 }

--- a/src/prolly_mutate.c
+++ b/src/prolly_mutate.c
@@ -176,6 +176,15 @@ static int streamingMergeNode(
   int rc = SQLITE_OK;
   int i;
 
+#ifdef DOLTLITE_PROLLY_CHECK
+  if( pNode->level == 0 ){
+    fprintf(stderr,
+            "doltlite: E8 invariant: streamingMergeNode called on a "
+            "level-0 (leaf) node; expected internal\n");
+    abort();
+  }
+#endif
+
   for( i = 0; i < pNode->nItems; i++ ){
     const u8 *pBoundKey; int nBoundKey;
     const u8 *pChildVal; int nChildVal;
@@ -213,6 +222,16 @@ static int streamingMergeNode(
         if( !pChildEntry ) return rc;
       }
 
+#ifdef DOLTLITE_PROLLY_CHECK
+      if( pChildEntry->node.level != pNode->level - 1 ){
+        fprintf(stderr,
+                "doltlite: E8 invariant: parent level=%d but child level=%d "
+                "(expected %d)\n",
+                (int)pNode->level, (int)pChildEntry->node.level,
+                (int)pNode->level - 1);
+        abort();
+      }
+#endif
       if( pChildEntry->node.level == 0 ){
         rc = mergeLeaf(pMut, &pChildEntry->node, pChunker, pIter, childIsLast);
       }else{


### PR DESCRIPTION
## Summary

Deep review **S5** (prollyChunkerFinish returning an empty root when \`nLevels > 0\`) and **E8** (streamingMergeNode adding at a level inconsistent with the child's actual level) are theoretical concerns. On inspection, neither is reachable from the current public API:

- **S5** would require \`nLevels > 0\` with every level's \`nItems == 0\`. \`addToLevel\` bumps \`nLevels\` and adds atomically; an incremented \`nLevels\` without a populated level is only possible under partial-failure (OOM in \`prollyNodeBuilderAdd\`), where the caller bails before calling Finish.
- **E8** confused parent-level with child-level. \`streamingMergeNode\` calls \`prollyChunkerAddAtLevel(pChunker, pNode->level, ...)\`. The chunker level passed is the level of the PARENT being rebuilt; children at that level live one tier below. Passing \`pNode->level\` is correct.

But these invariants live in the heads of the original authors. Future refactors can break them silently — the existing prolly tree invariant check from #920 catches some shapes after the fact, but not the chunker's own internal state.

## Lock the invariants as explicit checks under \`DOLTLITE_PROLLY_CHECK\`

- **prollyChunkerFinish (S5)**: if execution falls past the loop with \`nLevels > 0\`, every level was empty when scanned. \`abort\` with a diagnostic naming S5.
- **streamingMergeNode (E8)**:
  - At entry: \`pNode->level > 0\` (must be internal).
  - After loading a child via cache or store: \`pChildEntry->node.level == pNode->level - 1\`.

Default builds: zero overhead (assertions compile out under \`NDEBUG\`). CI builds with \`DOLTLITE_PROLLY_CHECK=1\` and would surface any regression to either invariant loudly.

## Test plan

- [x] \`correctness_test.sh\`: 41/41
- [x] \`doltlite_regression_test_c.sh\`: 108637/108637
- [x] \`run_doltlite_tests.sh\` umbrella: 42/42

🤖 Generated with [Claude Code](https://claude.com/claude-code)