### PR TITLE
Skip redundant autocommit working set reloads

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -1365,9 +1365,10 @@ const char *chunkStoreFilename(ChunkStore *cs){
   return cs->file.zFilename;
 }
 
-int chunkStoreLockAndRefresh(ChunkStore *cs){
+int chunkStoreLockAndRefreshChanged(ChunkStore *cs, int *pChanged){
   int changed = 0;
   int rc;
+  if( pChanged ) *pChanged = 0;
   if( cs->isMemory ) return SQLITE_OK;
   if( cs->graphLockFd >= 0 ) return SQLITE_OK;
   if( !cs->file.zFilename ) return SQLITE_ERROR;
@@ -1378,8 +1379,14 @@ int chunkStoreLockAndRefresh(ChunkStore *cs){
   if( rc!=SQLITE_OK ){
     csFileUnlock(cs->graphLockFd);
     cs->graphLockFd = -1;
+  }else if( pChanged ){
+    *pChanged = changed;
   }
   return rc;
+}
+
+int chunkStoreLockAndRefresh(ChunkStore *cs){
+  return chunkStoreLockAndRefreshChanged(cs, 0);
 }
 
 void chunkStoreUnlock(ChunkStore *cs){

--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -108,6 +108,7 @@ int chunkStoreOpen(ChunkStore *cs, sqlite3_vfs *pVfs,
 int chunkStoreClose(ChunkStore *cs);
 
 int chunkStoreLockAndRefresh(ChunkStore *cs);
+int chunkStoreLockAndRefreshChanged(ChunkStore *cs, int *pChanged);
 void chunkStoreUnlock(ChunkStore *cs);
 int chunkStoreHasExternalChanges(ChunkStore *cs, int *pChanged);
 

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -4300,6 +4300,17 @@ static int btreeReloadBranchWorkingState(Btree *p, int bLoadCatalog){
   return btreeReloadBranchWorkingStateInto(p, bLoadCatalog, 0);
 }
 
+static void btreeStoreCommittedFromCurrent(Btree *p, const ProllyHash *pCatHash){
+  if( pCatHash ){
+    p->committedCatalogHash = *pCatHash;
+  }
+  p->committedStagedCatalog = p->stagedCatalog;
+  p->committedIsMerging = p->isMerging;
+  p->committedMergeCommitHash = p->mergeCommitHash;
+  p->committedConflictsCatalogHash = p->conflictsCatalogHash;
+  p->committedConstraintViolationsHash = p->constraintViolationsHash;
+}
+
 static void btreeBumpDataVersion(Btree *p){
   p->iBDataVersion++;
   if( p->pBt->pPagerShim ){
@@ -4319,12 +4330,15 @@ static void btreeMarkWorkingStateChanged(Btree *p){
 
 static int btreeRefreshSharedWorkingState(Btree *p){
   BtShared *pBt = p->pBt;
+  ProllyHash loadedCatHash;
   int rc;
   if( p->iLoadedWorkingStateVersion==pBt->iWorkingStateVersion ){
     return SQLITE_OK;
   }
-  rc = btreeReloadBranchWorkingState(p, 1);
+  memset(&loadedCatHash, 0, sizeof(loadedCatHash));
+  rc = btreeReloadBranchWorkingStateInto(p, 1, &loadedCatHash);
   if( rc!=SQLITE_OK ) return rc;
+  btreeStoreCommittedFromCurrent(p, &loadedCatHash);
   p->iLoadedWorkingStateVersion = pBt->iWorkingStateVersion;
   btreeBumpDataVersion(p);
   return SQLITE_OK;
@@ -4336,6 +4350,7 @@ static int btreeRefreshFromDisk(Btree *p){
   u8 snapshotPinned = pBt->store.snapshotPinned;
   int bAutocommitBoundary = p->inTrans==TRANS_NONE
     && p->db && p->db->autoCommit && !p->db->pSavepoint;
+  ProllyHash loadedCatHash;
   int rc;
 
   if( bAutocommitBoundary ){
@@ -4348,9 +4363,11 @@ static int btreeRefreshFromDisk(Btree *p){
   if( rc!=SQLITE_OK ) return rc;
   if( !bChanged ) return SQLITE_OK;
 
-  rc = btreeReloadBranchWorkingState(p, 1);
+  memset(&loadedCatHash, 0, sizeof(loadedCatHash));
+  rc = btreeReloadBranchWorkingStateInto(p, 1, &loadedCatHash);
   if( rc!=SQLITE_OK ) return rc;
 
+  btreeStoreCommittedFromCurrent(p, &loadedCatHash);
   btreeMarkWorkingStateChanged(p);
 
   return SQLITE_OK;
@@ -4395,12 +4412,13 @@ static int prollyBtreeBeginTrans(Btree *p, int wrFlag, int *pSchemaVersion){
   }
 
   if( wrFlag ){
+    int bStoreChanged = 0;
     int nSavepointStart = p->nSavepoint;
     if( pBt->btsFlags & BTS_READ_ONLY ){
       return SQLITE_READONLY;
     }
 
-    rc = chunkStoreLockAndRefresh(&pBt->store);
+    rc = chunkStoreLockAndRefreshChanged(&pBt->store, &bStoreChanged);
     if( rc!=SQLITE_OK ) return rc;
 
     if( p->inTrans==TRANS_READ ){
@@ -4416,7 +4434,10 @@ static int prollyBtreeBeginTrans(Btree *p, int wrFlag, int *pSchemaVersion){
       }
     }
 
-    {
+    if( p->inTrans==TRANS_READ
+     || bStoreChanged
+     || p->iLoadedWorkingStateVersion!=pBt->iWorkingStateVersion
+     || (prollyHashIsEmpty(&p->committedCatalogHash) && p->cat.n>1) ){
       ProllyHash loadedCatHash;
       memset(&loadedCatHash, 0, sizeof(loadedCatHash));
       rc = btreeReloadBranchWorkingStateInto(p, 1, &loadedCatHash);
@@ -4424,13 +4445,9 @@ static int prollyBtreeBeginTrans(Btree *p, int wrFlag, int *pSchemaVersion){
         chunkStoreUnlock(&pBt->store);
         return rc;
       }
-      p->committedCatalogHash = loadedCatHash;
+      btreeStoreCommittedFromCurrent(p, &loadedCatHash);
     }
-    p->committedStagedCatalog = p->stagedCatalog;
-    p->committedIsMerging = p->isMerging;
-    p->committedMergeCommitHash = p->mergeCommitHash;
-    p->committedConflictsCatalogHash = p->conflictsCatalogHash;
-    p->committedConstraintViolationsHash = p->constraintViolationsHash;
+    btreeStoreCommittedFromCurrent(p, 0);
 
     if( p->db ){
       while( p->nSavepoint < p->db->nSavepoint ){


### PR DESCRIPTION
## Summary
- expose whether `chunkStoreLockAndRefresh` observed an on-disk change while taking the write lock
- skip the begin-write branch working-set reload when the locked refresh reports no external change and this handle is already on the current shared working-state version
- keep the reload for stale read upgrades, concurrent external changes, sibling-handle working-state changes, and the first write that still needs committed catalog state

## Local validation
- `make libdoltlite.a doltlite`
- `git diff --check`
- `./doltlite_regression_test_c refresh_open_path_transactional`
- `./doltlite_regression_test_c reload_refs_transactional`
- `./doltlite_regression_test_c begin_write_refreshes_working_set_metadata`
- `./doltlite_regression_test_c begin_write_from_stale_read_snapshot`
- custom two-connection autocommit visibility test: passed

## Local perf check
Compared clean `origin/master` at `4e62d6e04` to this branch with `BENCH_SECTION_MODE=autocommit BENCH_RUNS=9` using separate `sysbench_timer` binaries.

| benchmark | master us | branch us | branch/master |
|---|---:|---:|---:|
| oltp_bulk_insert_ac | 23,244 | 20,001 | 0.860 |
| oltp_insert_ac | 35,231 | 34,860 | 0.989 |
| oltp_update_index_ac | 36,394 | 36,909 | 1.014 |
| oltp_update_non_index_ac | 30,119 | 28,084 | 0.932 |
| oltp_delete_insert_ac | 38,702 | 37,053 | 0.957 |
| oltp_write_only_ac | 34,511 | 35,115 | 1.018 |
| types_delete_insert_ac | 26,726 | 25,690 | 0.961 |
| oltp_read_write_ac | 39,464 | 38,708 | 0.981 |

Aggregate local autocommit write time for these rows: `256,420 / 264,391 = 0.970`.
