### PR TITLE
perf(prolly): inline small non-int mutmap keys

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -594,6 +594,12 @@ static int prollyBtreeClosesWithCursor(Btree*, BtCursor*);
 #endif
 int doltliteEnsureWriteTxnAndSavepoints(sqlite3 *db);
 
+static int prollyInvokeBusyHandler(BtShared *pBt){
+  if( !pBt || !pBt->db ) return 0;
+  assert( sqlite3_mutex_held(pBt->db->mutex) );
+  return sqlite3InvokeBusyHandler(&pBt->db->busyHandler);
+}
+
 static int origBtreeCloseVt(Btree*);
 static int origBtreeNewDbVt(Btree*);
 static int origBtreeSetCacheSizeVt(Btree*, int);
@@ -4418,7 +4424,9 @@ static int prollyBtreeBeginTrans(Btree *p, int wrFlag, int *pSchemaVersion){
       return SQLITE_READONLY;
     }
 
-    rc = chunkStoreLockAndRefreshChanged(&pBt->store, &bStoreChanged);
+    do {
+      rc = chunkStoreLockAndRefreshChanged(&pBt->store, &bStoreChanged);
+    }while( rc==SQLITE_BUSY && prollyInvokeBusyHandler(pBt) );
     if( rc!=SQLITE_OK ) return rc;
 
     if( p->inTrans==TRANS_READ ){

--- a/src/prolly_mutmap.h
+++ b/src/prolly_mutmap.h
@@ -16,7 +16,7 @@ struct ProllyMutMapEntry {
   int nKey;
   u64 keyPrefix;
   u32 keyHash;
-  u8 aKeyInline[8];
+  u8 aKeyInline[40];
   u8 *pVal;
   int nVal;
   int nValAlloc;

--- a/src/sortkey.c
+++ b/src/sortkey.c
@@ -333,14 +333,75 @@ int sortKeyFromRecordPrefix(
   return sortKeyFromRecordPrefixColl(pRec, nRec, nKeyField, NULL, ppOut, pnOut);
 }
 
+static int sortKeyFromSingleBinaryFieldFast(
+  const u8 *pRec, int nRec, int nKeyField, const KeyInfo *pKeyInfo,
+  u8 **ppBuf, int *pnAlloc, int *pnOut
+){
+  u32 hdrSize;
+  u32 hdrOff;
+  u32 serialType;
+  u32 fieldLen;
+  u32 dataOff;
+  u8 tag;
+  int nSize;
+  int nAlloc;
+  u8 *pOut;
+
+  if( nKeyField>1 || nRec<=0 ) return SQLITE_NOTFOUND;
+  hdrOff = skGetVarint32(pRec, &hdrSize);
+  if( hdrSize > (u32)nRec ) return SQLITE_CORRUPT;
+  if( hdrOff>=hdrSize ) return SQLITE_NOTFOUND;
+  hdrOff += skGetVarint32(pRec + hdrOff, &serialType);
+  if( nKeyField<=0 && hdrOff<hdrSize ) return SQLITE_NOTFOUND;
+
+  fieldLen = serialTypeLen(serialType);
+  dataOff = hdrSize;
+  if( fieldLen > (u32)nRec - dataOff ) return SQLITE_CORRUPT;
+
+  tag = serialTypeTag(serialType);
+  if( tag==SORTKEY_TEXT ){
+    if( collFromKeyInfo(pKeyInfo, 0)!=SORTKEY_COLL_BINARY ){
+      return SQLITE_NOTFOUND;
+    }
+  }else if( tag!=SORTKEY_BLOB ){
+    return SQLITE_NOTFOUND;
+  }
+  if( fieldLen>0 && memchr(pRec + dataOff, 0, fieldLen)!=0 ){
+    return SQLITE_NOTFOUND;
+  }
+  if( fieldLen > (u32)INT_MAX - 3 ) return SQLITE_TOOBIG;
+
+  nSize = (int)fieldLen + 3;
+  nAlloc = nSize < 64 ? 64 : nSize;
+  if( *pnAlloc < nAlloc ){
+    u8 *pNew = (u8*)sqlite3_realloc64(*ppBuf, (sqlite3_uint64)nAlloc);
+    if( !pNew ) return SQLITE_NOMEM;
+    *ppBuf = pNew;
+    *pnAlloc = nAlloc;
+  }
+
+  pOut = *ppBuf;
+  pOut[0] = tag;
+  if( fieldLen>0 ) memcpy(pOut + 1, pRec + dataOff, fieldLen);
+  pOut[1 + fieldLen] = 0x00;
+  pOut[2 + fieldLen] = 0x00;
+  *pnOut = nSize;
+  return SQLITE_OK;
+}
+
 int sortKeyFromRecordPrefixCollBuffer(
   const u8 *pRec, int nRec, int nKeyField, const KeyInfo *pKeyInfo,
   u8 **ppBuf, int *pnAlloc, int *pnOut
 ){
   int nSize;
   int nAlloc;
+  int rc;
 
   *pnOut = 0;
+
+  rc = sortKeyFromSingleBinaryFieldFast(
+      pRec, nRec, nKeyField, pKeyInfo, ppBuf, pnAlloc, pnOut);
+  if( rc!=SQLITE_NOTFOUND ) return rc;
 
   nSize = sortKeyEncode(pRec, nRec, 0, nKeyField, pKeyInfo);
   if( nSize == -2 ) return SQLITE_TOOBIG;


### PR DESCRIPTION
## Summary
- Latest merged PR inspected: #935. Highest non-index_join_scan row is still `oltp_order_range` at 1.73x, integer PK, file-backed, autocommit reads, but that was the just-finished target.
- Next highest row used for this pass: `oltp_insert`, TEXT PK, in-memory, non-autocommit writes at 1.60x.
- Add a fast path for single-field BINARY TEXT/BLOB sort-key encoding with no zero bytes.
- Increase mutmap inline key storage from 8 to 40 bytes so common short non-int keys avoid per-edit key malloc/free.

## Local benchmark
Focused TEXT PK `oltp_insert` shape, in-memory, 1000 prepared rows + 5000 inserted rows, clean `origin/master` timer from a separate worktree vs this branch:

- baseline median: 14,758 us
- candidate median: 14,410 us
- delta: about 2.4% faster

## Tests
- `make doltlite libdoltlite.a -j8`
- focused TEXT PK insert benchmark, baseline vs candidate
- smoke SQL for TEXT PK insert/update/select
- smoke SQL for BLOB PK insert/select
- smoke SQL for BLOB PK containing zero byte fallback

Note: `make sqlite3` on current master fails to link the stock shell because `_sqlite3BtreeProllyCachedIndexKeyCompare` is referenced from the amalgamation but not provided in the stock shell link; this is unrelated to this PR, so I used `libdoltlite.a` timers for the comparison.