### PR TITLE
perf(prolly): reuse mutmap value buffers after deletes

### DIFF
--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -651,10 +651,7 @@ int prollyMutMapDelete(
         if( rc!=SQLITE_OK ) return rc;
       }
       e->op = PROLLY_EDIT_DELETE;
-      sqlite3_free(e->pVal);
-      e->pVal = 0;
       e->nVal = 0;
-      e->nValAlloc = 0;
       e->bornAt = encodeLevel(mm, mm->currentSavepointLevel);
       return SQLITE_OK;
     }

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -5749,14 +5749,30 @@ static void run_mutmap_delete_reinsert_reuses_entry(void){
   for( mode = 0; mode < 2; mode++ ){
     ProllyMutMap mm;
     ProllyMutMapEntry *e = 0;
+    void *pFirstVal = 0;
+    int nFirstValAlloc = 0;
     int rc;
 
     check("mutmap_delete_reinsert_init",
           prollyMutMapInitMode(&mm, 1, (u8)mode)==SQLITE_OK);
     check("mutmap_delete_reinsert_insert",
           prollyMutMapInsert(&mm, 0, 0, 42, aFirst, sizeof(aFirst))==SQLITE_OK);
+    rc = prollyMutMapFindRc(&mm, 0, 0, 42, &e);
+    check("mutmap_delete_reinsert_find_first", rc==SQLITE_OK && e!=0);
+    if( e ){
+      pFirstVal = e->pVal;
+      nFirstValAlloc = e->nValAlloc;
+    }
     check("mutmap_delete_reinsert_delete",
           prollyMutMapDelete(&mm, 0, 0, 42)==SQLITE_OK);
+    rc = prollyMutMapFindRc(&mm, 0, 0, 42, &e);
+    check("mutmap_delete_reinsert_find_deleted", rc==SQLITE_OK && e!=0);
+    check("mutmap_delete_reinsert_keeps_value_buffer",
+          e!=0
+       && e->op==PROLLY_EDIT_DELETE
+       && e->nVal==0
+       && e->pVal==pFirstVal
+       && e->nValAlloc==nFirstValAlloc);
     check("mutmap_delete_reinsert_insert_again",
           prollyMutMapInsert(&mm, 0, 0, 42, aSecond, sizeof(aSecond))==SQLITE_OK);
 
@@ -5766,6 +5782,7 @@ static void run_mutmap_delete_reinsert_reuses_entry(void){
           e!=0
        && e->op==PROLLY_EDIT_INSERT
        && e->nVal==(int)sizeof(aSecond)
+       && e->pVal==pFirstVal
        && memcmp(e->pVal, aSecond, sizeof(aSecond))==0);
 
     prollyMutMapFree(&mm);


### PR DESCRIPTION
## Summary
- keep pending mutmap value allocations when an INSERT entry is converted to a DELETE tombstone
- let a later reinsert for the same key reuse that existing buffer instead of freeing and reallocating
- strengthen the mutmap delete/reinsert regression case to assert buffer reuse

## Benchmark target
- Latest merged PR checked: #941 (`ci: lower sysbench individual gate`)
- Highest non-ignored sysbench multiplier: `oltp_write_only`
- Key type: `INTEGER PRIMARY KEY`
- Mode: in-memory
- Autocommit: false
- PR row: SQLite 13,229 us, Doltlite 21,097 us, 1.59x

## Local comparison
- Focused `oltp_write_only` shape, 10k-row setup, 1000 write loops: baseline median 11,187 us; candidate median 11,089 us
- Longer 100k-loop version of same workload: baseline median 747,237 us; candidate median 723,164 us

## Tests
- `make doltlite libdoltlite.a -j8`
- `cc -O2 -I. -o /tmp/bench_timer_doltlite_intpk_wo_reuse test/sysbench_timer.c libdoltlite.a -lz -lm -lpthread`
- transaction rollback smoke test for delete + insert
- savepoint rollback smoke test for delete + insert
- `/tmp/doltlite_regression_test_c mutmap_delete_reinsert_reuses_entry`
- `/tmp/doltlite_regression_test_c mutmap_differential_randomized`
