### PR TITLE
fix(gc): seed in-memory session hashes into mark queue

### DIFF
--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -67,7 +67,33 @@ static int gcChildCb(void *ctx, const ProllyHash *pHash){
   return gcQueuePush(q, pHash);
 }
 
+#ifdef DOLTLITE_PROLLY_CHECK
+typedef struct GcVerifyCtx GcVerifyCtx;
+struct GcVerifyCtx { ChunkStore *cs; int rc; };
+
+static int gcVerifyHashCb(void *ctx, const ProllyHash *pHash){
+  GcVerifyCtx *v = (GcVerifyCtx*)ctx;
+  u8 *data = 0; int nData = 0;
+  if( prollyHashIsEmpty(pHash) ) return SQLITE_OK;
+  v->rc = chunkStoreGet(v->cs, pHash, &data, &nData);
+  sqlite3_free(data);
+  if( v->rc!=SQLITE_OK ){
+    fprintf(stderr,
+            "doltlite: GC invariant: session hash unreachable after sweep\n");
+    abort();
+  }
+  return SQLITE_OK;
+}
+
+static void gcVerifySessionResolvable(sqlite3 *db, ChunkStore *cs){
+  GcVerifyCtx v;
+  v.cs = cs; v.rc = SQLITE_OK;
+  (void)doltliteSeedSessionHashes(db, cs, gcVerifyHashCb, &v);
+}
+#endif
+
 static int gcMarkReachable(
+  sqlite3 *db,
   ChunkStore *cs,
   ProllyHashSet *marked
 ){
@@ -103,6 +129,10 @@ static int gcMarkReachable(
     for(i=0; rc==SQLITE_OK && i<nPend; i++){
       rc = gcQueuePush(&queue, &aPend[i].hash);
     }
+  }
+
+  if( rc==SQLITE_OK ){
+    rc = doltliteSeedSessionHashes(db, cs, gcChildCb, &queue);
   }
 
   if( rc!=SQLITE_OK ){
@@ -603,7 +633,7 @@ static void doltliteGcFunc(
     return;
   }
 
-  rc = gcMarkReachable(cs, &marked);
+  rc = gcMarkReachable(db, cs, &marked);
   if( rc!=SQLITE_OK ){
     prollyHashSetFree(&marked);
     chunkStoreUnlock(cs);
@@ -613,6 +643,9 @@ static void doltliteGcFunc(
 
   rc = gcSweep(cs, &marked, &nKept, &nRemoved);
   prollyHashSetFree(&marked);
+#ifdef DOLTLITE_PROLLY_CHECK
+  if( rc==SQLITE_OK ) gcVerifySessionResolvable(db, cs);
+#endif
   chunkStoreUnlock(cs);
 
   if( rc!=SQLITE_OK ){
@@ -645,11 +678,14 @@ int doltliteGcCompact(sqlite3 *db){
     return rc;
   }
 
-  rc = gcMarkReachable(cs, &marked);
+  rc = gcMarkReachable(db, cs, &marked);
   if( rc==SQLITE_OK ){
     rc = gcSweep(cs, &marked, &nKept, &nRemoved);
   }
   prollyHashSetFree(&marked);
+#ifdef DOLTLITE_PROLLY_CHECK
+  if( rc==SQLITE_OK ) gcVerifySessionResolvable(db, cs);
+#endif
   chunkStoreUnlock(cs);
   return rc;
 }

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -148,6 +148,9 @@ void doltliteSetSessionConflictsCatalog(sqlite3 *db, const ProllyHash *pHash);
 void doltliteGetSessionConstraintViolationsCatalog(sqlite3 *db, ProllyHash *pHash);
 void doltliteSetSessionConstraintViolationsCatalog(sqlite3 *db, const ProllyHash *pHash);
 int doltliteSessionHasConstraintViolations(sqlite3 *db);
+int doltliteSeedSessionHashes(sqlite3 *db, ChunkStore *cs,
+                              int (*xPush)(void*, const ProllyHash*),
+                              void *pCtx);
 int doltliteGetSessionTableRoot(sqlite3 *db, Pgno iTable,
                                  ProllyHash *pRoot, u8 *pFlags);
 int doltliteSaveWorkingSet(sqlite3 *db);

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -8371,6 +8371,28 @@ int doltliteSessionHasConstraintViolations(sqlite3 *db){
   return !prollyHashIsEmpty(&db->aDb[0].pBt->constraintViolationsHash);
 }
 
+int doltliteSeedSessionHashes(
+  sqlite3 *db,
+  ChunkStore *cs,
+  int (*xPush)(void*, const ProllyHash*),
+  void *pCtx
+){
+  int i, rc = SQLITE_OK;
+  if( !db || !cs || !xPush ) return SQLITE_OK;
+  for(i=0; rc==SQLITE_OK && i<db->nDb; i++){
+    Btree *pBt = db->aDb[i].pBt;
+    if( !pBt || pBt->pOps!=&prollyBtreeOps || !pBt->pBt ) continue;
+    if( &pBt->pBt->store!=cs ) continue;
+    rc = xPush(pCtx, &pBt->stagedCatalog);
+    if( rc==SQLITE_OK ) rc = xPush(pCtx, &pBt->mergeCommitHash);
+    if( rc==SQLITE_OK ) rc = xPush(pCtx, &pBt->conflictsCatalogHash);
+    if( rc==SQLITE_OK ) rc = xPush(pCtx, &pBt->preRebaseWorkingCat);
+    if( rc==SQLITE_OK ) rc = xPush(pCtx, &pBt->rebaseOntoCommit);
+    if( rc==SQLITE_OK ) rc = xPush(pCtx, &pBt->constraintViolationsHash);
+  }
+  return rc;
+}
+
 int doltliteSaveWorkingSetWithHash(sqlite3 *db, const ProllyHash *pWorkingCatHash){
   ChunkStore *cs = doltliteGetChunkStore(db);
   Btree *pBtree;

--- a/test/doltlite_gc_session_state.sh
+++ b/test/doltlite_gc_session_state.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+# Verify dolt_gc / wal_checkpoint don't drop chunks reachable only via
+# in-memory session state (staged catalog, mid-merge conflicts, mid-rebase
+# state, constraint-violations catalog). gcMarkReachable seeds these from
+# every attached doltlite Btree on the calling connection.
+
+DOLTLITE=./doltlite
+PASS=0; FAIL=0; ERRORS=""
+
+run_test() {
+  local n="$1" s="$2" e="$3" d="$4"
+  local r=$(echo "$s" | perl -e 'alarm(15);exec @ARGV' $DOLTLITE "$d" 2>&1)
+  if [ "$r" = "$e" ]; then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1))
+    ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"
+  fi
+}
+
+run_test_match() {
+  local n="$1" s="$2" p="$3" d="$4"
+  local r=$(echo "$s" | perl -e 'alarm(15);exec @ARGV' $DOLTLITE "$d" 2>&1)
+  if echo "$r" | grep -qE "$p"; then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1))
+    ERRORS="$ERRORS\nFAIL: $n\n  pattern: $p\n  got:     $r"
+  fi
+}
+
+db_rm() { rm -f "$1" "${1}-wal"; }
+
+echo "=== Doltlite GC over session state ==="
+echo ""
+
+# ----------------------------------------------------------------
+# S1: staged-but-uncommitted survives GC
+# ----------------------------------------------------------------
+DB=/tmp/test_gc_session_staged_$$.db; db_rm "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_commit('-A','-m','c1');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+# Stage rows without committing, then GC, then commit. The staged catalog
+# hash must remain resolvable across the GC.
+echo "INSERT INTO t VALUES(2,'b'),(3,'c');
+SELECT dolt_add('-A');
+SELECT dolt_gc();
+SELECT dolt_commit('-m','c2');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test "staged_commit_count" "SELECT count(*) FROM t;" "3" "$DB"
+run_test "staged_commit_log"   "SELECT count(*) FROM dolt_log;" "3" "$DB"
+run_test "staged_commit_value" "SELECT v FROM t WHERE id=3;" "c" "$DB"
+
+# Reopen — chunks must still be on disk.
+run_test "staged_reopen_count" "SELECT count(*) FROM t;" "3" "$DB"
+
+db_rm "$DB"
+
+# ----------------------------------------------------------------
+# S2: mid-merge with conflicts — gc + abort
+# ----------------------------------------------------------------
+DB=/tmp/test_gc_session_merge_$$.db; db_rm "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_commit('-A','-m','init');
+SELECT dolt_branch('feat');
+UPDATE t SET v='main_branch' WHERE id=1;
+SELECT dolt_commit('-A','-m','main change');
+SELECT dolt_checkout('feat');
+UPDATE t SET v='feat_branch' WHERE id=1;
+SELECT dolt_commit('-A','-m','feat change');
+SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+# Trigger a conflicting merge, leave it unresolved, run GC, then abort.
+# Aborting must restore the head working state — which requires the
+# pre-merge catalog hash to still be on disk.
+echo "SELECT dolt_merge('feat');
+SELECT dolt_gc();
+SELECT dolt_merge('--abort');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test "merge_abort_count" "SELECT count(*) FROM t;" "1" "$DB"
+run_test "merge_abort_value" "SELECT v FROM t WHERE id=1;" "main_branch" "$DB"
+run_test "merge_abort_status_empty" "SELECT count(*) FROM dolt_status;" "0" "$DB"
+
+db_rm "$DB"
+
+# ----------------------------------------------------------------
+# S3: wal_checkpoint mid-staging (the shimPagerCheckpoint -> GC path)
+# ----------------------------------------------------------------
+DB=/tmp/test_gc_session_checkpoint_$$.db; db_rm "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+# `PRAGMA wal_checkpoint` routes through shimPagerCheckpoint -> doltliteGcCompact.
+# Run it between staging and commit; data must survive.
+echo "INSERT INTO t VALUES(2,'b'),(3,'c');
+SELECT dolt_add('-A');
+PRAGMA wal_checkpoint;
+SELECT dolt_commit('-m','c2');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test "ckpt_commit_count" "SELECT count(*) FROM t;" "3" "$DB"
+run_test "ckpt_commit_log"   "SELECT count(*) FROM dolt_log;" "3" "$DB"
+
+# Reopen.
+run_test "ckpt_reopen_count" "SELECT count(*) FROM t;" "3" "$DB"
+
+db_rm "$DB"
+
+# ----------------------------------------------------------------
+# S4: constraint-violations catalog survives GC
+# ----------------------------------------------------------------
+DB=/tmp/test_gc_session_cv_$$.db; db_rm "$DB"
+echo "CREATE TABLE p(id INTEGER PRIMARY KEY);
+CREATE TABLE c(id INTEGER PRIMARY KEY, pid INTEGER, FOREIGN KEY(pid) REFERENCES p(id));
+INSERT INTO p VALUES(1);
+INSERT INTO c VALUES(10, 1);
+SELECT dolt_commit('-A','-m','init');
+SELECT dolt_branch('feat');
+DELETE FROM p WHERE id=1;
+SELECT dolt_commit('-A','-m','main del');
+SELECT dolt_checkout('feat');
+INSERT INTO c VALUES(20, 1);
+SELECT dolt_commit('-A','-m','feat insert');
+SELECT dolt_checkout('main');
+PRAGMA foreign_keys=1;
+SELECT dolt_merge('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+# At this point a CV catalog should exist on the session. GC must preserve it.
+echo "SELECT dolt_gc();" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+# Whatever the CV outcome is, the rows that landed must still be readable.
+run_test_match "cv_table_p" "SELECT count(*) FROM p;" "[0-9]+" "$DB"
+run_test_match "cv_table_c" "SELECT count(*) FROM c;" "[0-9]+" "$DB"
+
+db_rm "$DB"
+
+echo ""
+if [ $FAIL -gt 0 ]; then
+  printf "$ERRORS\n"
+  echo "RESULTS: $PASS passed, $FAIL failed"
+  exit 1
+fi
+echo "RESULTS: $PASS passed, $FAIL failed"

--- a/test/run_doltlite_tests.sh
+++ b/test/run_doltlite_tests.sh
@@ -52,6 +52,7 @@ TESTS=(
   doltlite_branding.sh
   doltlite_memory_db.sh
   doltlite_gc.sh
+  doltlite_gc_session_state.sh
   doltlite_structural.sh
   chunk_physical_dups_test.sh
   doltlite_savepoint.sh


### PR DESCRIPTION
## Summary
Closes the remaining S3 gap from the deep-review S1–S4 cluster (commit c2adb3cbc9 already fixed S1, S2, and most of S3 via pending-chunk seeding and WS-version-aware walks; this PR plugs the last hole).

The previously open exposure was: a chunk already flushed to the index, reachable *only* via the in-memory per-Btree fields (\`stagedCatalog\`, \`mergeCommitHash\`, \`conflictsCatalogHash\`, \`preRebaseWorkingCat\`, \`rebaseOntoCommit\`, \`constraintViolationsHash\`) on a connection whose \`dolt_*\` op hadn't yet persisted the WS blob. An audit of every \`doltliteSetSession*\` call site (see commit message) found that all current paths either persist immediately or set values that are transitively reachable via a fresh branch tip, so this PR is structural defense rather than a live bug repair. Without it, any future setter without an accompanying persist would silently expose data loss across \`dolt_gc\` / \`PRAGMA wal_checkpoint\`.

## Changes
- \`gcMarkReachable\` now takes \`sqlite3*\` and seeds the queue with every non-empty session hash on every attached doltlite Btree on the calling connection (via \`doltliteSeedSessionHashes\` in \`prolly_btree.c\`).
- Under \`DOLTLITE_PROLLY_CHECK\`, after a successful \`gcSweep\`, every session hash on every attached Btree must still resolve via \`chunkStoreGet\`; abort otherwise. Catches any future regression that breaks transitive reachability.
- New \`test/doltlite_gc_session_state.sh\` exercises GC across mid-staging, mid-merge-with-conflicts, \`PRAGMA wal_checkpoint\` mid-stage, and FK-CV-catalog states. Wired into \`run_doltlite_tests.sh\`.

## Test plan
- [x] \`bash test/run_doltlite_tests.sh\` (default build) — 44/44 suites green
- [x] Same suite rebuilt with \`make DOLTLITE_PROLLY_CHECK=1 doltlite\` — 44/44 green, invariant doesn't fire on any path

🤖 Generated with [Claude Code](https://claude.com/claude-code)