### PR TITLE
perf(prolly): skip mutmap sort for append-ordered edits

### DIFF
--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -438,6 +438,15 @@ static int ensureOrder(ProllyMutMap *mm){
     }
     return SQLITE_OK;
   }
+  if( mm->appendSorted ){
+    for(i=0; i<mm->nEntries; i++){
+      mm->aOrder[i] = i;
+      mm->aPos[i] = i;
+    }
+    mm->orderDirty = 0;
+    mm->posDirty = 0;
+    return SQLITE_OK;
+  }
   rc = mutmapSortOrder(mm);
   if( rc!=SQLITE_OK ) return rc;
   for(i=0; i<mm->nEntries; i++){
@@ -522,8 +531,21 @@ int prollyMutMapInitMode(ProllyMutMap *mm, u8 isIntKey, u8 keepSorted){
   memset(mm, 0, sizeof(*mm));
   mm->isIntKey = isIntKey;
   mm->keepSorted = keepSorted;
+  mm->appendSorted = 1;
   mm->orderDirty = keepSorted ? 0 : 1;
   return SQLITE_OK;
+}
+
+static void updateAppendSorted(ProllyMutMap *mm, int phys){
+  ProllyMutMapEntry *pPrev;
+  ProllyMutMapEntry *pNew;
+  if( mm->keepSorted || !mm->appendSorted || phys<=0 ) return;
+  pPrev = &mm->aEntries[phys - 1];
+  pNew = &mm->aEntries[phys];
+  if( compareEntries(pPrev->pKey, pPrev->nKey,
+                     pNew->pKey, pNew->nKey) > 0 ){
+    mm->appendSorted = 0;
+  }
 }
 
 static int appendUndoRec(ProllyMutMap *mm, int idx){
@@ -606,6 +628,7 @@ int prollyMutMapInsert(
     if( rc!=SQLITE_OK ){
       return rc;
     }
+    updateAppendSorted(mm, phys);
     if( mm->keepSorted || (!mm->orderDirty && mm->preferSorted) ){
       insertOrderEntry(mm, idx, phys);
     }else{
@@ -675,6 +698,7 @@ int prollyMutMapDelete(
     if( rc!=SQLITE_OK ){
       return rc;
     }
+    updateAppendSorted(mm, phys);
     if( mm->keepSorted || (!mm->orderDirty && mm->preferSorted) ){
       insertOrderEntry(mm, idx, phys);
     }else{
@@ -757,6 +781,7 @@ int prollyMutMapRollbackToSavepoint(ProllyMutMap *mm, int level){
         mm->nEntries = newN;
         mm->orderDirty = 1;
         mm->posDirty = 1;
+        mm->appendSorted = 0;
       }
       for(j=0; j<mm->nUndo; j++){
         mm->aUndo[j].entryIdx = aMap[mm->aUndo[j].entryIdx];
@@ -925,6 +950,7 @@ void prollyMutMapClear(ProllyMutMap *mm){
   mm->orderDirty = 0;
   mm->preferSorted = 0;
   mm->posDirty = 0;
+  mm->appendSorted = 1;
   mm->generation++;
   if( mm->aHash && mm->nHashAlloc>0 ){
     memset(mm->aHash, 0, mm->nHashAlloc * sizeof(int));
@@ -969,6 +995,7 @@ int prollyMutMapClone(ProllyMutMap **out, const ProllyMutMap *src){
   dst->orderDirty = src->orderDirty;
   dst->preferSorted = src->preferSorted;
   dst->posDirty = src->posDirty;
+  dst->appendSorted = src->appendSorted;
   dst->levelBase = src->levelBase;
   dst->currentSavepointLevel = src->currentSavepointLevel;
   dst->generation = src->generation;

--- a/src/prolly_mutmap.h
+++ b/src/prolly_mutmap.h
@@ -42,6 +42,7 @@ struct ProllyMutMap {
   /* Set after ordered access so mixed read/write maps keep their order. */
   u8 preferSorted;
   u8 posDirty;
+  u8 appendSorted;
   int nEntries;
   int nAlloc;
   int levelBase;

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -5789,6 +5789,47 @@ static void run_mutmap_delete_reinsert_reuses_entry(void){
   }
 }
 
+static void run_mutmap_append_sorted_order(void){
+  ProllyMutMap mm;
+  ProllyMutMapIter it;
+  static const u8 aVal[] = { 1 };
+  static const u8 aKey1[] = { 'a', 'a' };
+  static const u8 aKey2[] = { 'b', 'b' };
+  static const u8 aKey3[] = { 'c', 'c' };
+  static const u8 aKey0[] = { '0', '0' };
+
+  printf("=== MutMap Append Sorted Order Test ===\n\n");
+  check("mutmap_append_sorted_init",
+        prollyMutMapInitMode(&mm, 0, 0)==SQLITE_OK);
+  check("mutmap_append_sorted_insert_1",
+        prollyMutMapInsert(&mm, aKey1, sizeof(aKey1), 0,
+                           aVal, sizeof(aVal))==SQLITE_OK);
+  check("mutmap_append_sorted_insert_2",
+        prollyMutMapInsert(&mm, aKey2, sizeof(aKey2), 0,
+                           aVal, sizeof(aVal))==SQLITE_OK);
+  check("mutmap_append_sorted_insert_3",
+        prollyMutMapInsert(&mm, aKey3, sizeof(aKey3), 0,
+                           aVal, sizeof(aVal))==SQLITE_OK);
+  check("mutmap_append_sorted_flag_stays_set", mm.appendSorted);
+  prollyMutMapIterFirst(&it, &mm);
+  check("mutmap_append_sorted_iter_first",
+        prollyMutMapIterValid(&it)
+     && memcmp(prollyMutMapIterEntry(&it)->pKey, aKey1, sizeof(aKey1))==0);
+  check("mutmap_append_sorted_order_clean", !mm.orderDirty);
+  prollyMutMapFree(&mm);
+
+  check("mutmap_append_unsorted_init",
+        prollyMutMapInitMode(&mm, 0, 0)==SQLITE_OK);
+  check("mutmap_append_unsorted_insert_1",
+        prollyMutMapInsert(&mm, aKey2, sizeof(aKey2), 0,
+                           aVal, sizeof(aVal))==SQLITE_OK);
+  check("mutmap_append_unsorted_insert_2",
+        prollyMutMapInsert(&mm, aKey0, sizeof(aKey0), 0,
+                           aVal, sizeof(aVal))==SQLITE_OK);
+  check("mutmap_append_unsorted_flag_clears", !mm.appendSorted);
+  prollyMutMapFree(&mm);
+}
+
 typedef struct MutMapModelEntry MutMapModelEntry;
 struct MutMapModelEntry {
   i64 key;
@@ -6972,6 +7013,7 @@ static const RegressionCase aCases[] = {
   { "reset_bad_ref_failure_preserves_durable_state", "Reset Bad Ref Failure Preserves Durable State Test", run_reset_bad_ref_failure_preserves_durable_state },
   { "mutmap_empty_reverse_iter", "MutMap Empty Reverse Iterator Test", run_mutmap_empty_reverse_iter },
   { "mutmap_delete_reinsert_reuses_entry", "MutMap Delete Reinsert Reuses Entry Test", run_mutmap_delete_reinsert_reuses_entry },
+  { "mutmap_append_sorted_order", "MutMap Append Sorted Order Test", run_mutmap_append_sorted_order },
   { "mutmap_resolve_sorted_pos", "MutMap ResolveSortedPos Test", run_mutmap_resolve_sorted_pos },
   { "mutmap_differential_randomized", "MutMap Differential Randomized Test", run_mutmap_differential_randomized },
   { "prolly_mutate_skip_subtree_order", "Prolly Mutate Skipped Subtree Order Test", run_prolly_mutate_preserves_order_across_skipped_subtrees },


### PR DESCRIPTION
## Summary
- track whether lazy mutmap edits are appended in key order
- when append order is already sorted, materialize `aOrder` directly instead of sorting before iteration
- add a focused mutmap regression case for the append-sorted fast path and out-of-order fallback

## Benchmark target
- Latest merged PR checked: #945 (`perf(prolly): defer statement savepoint snapshots`)
- Highest non-ignored sysbench multiplier: `oltp_insert`
- Key type: `TEXT PRIMARY KEY`
- Mode: in-memory
- Autocommit: false
- PR row: SQLite 16,182 us, Doltlite 25,586 us, 1.58x

## Local comparison
- Focused `oltp_insert` TEXT PK shape, 1000-row setup, 5000 inserts: baseline median 14,998 us; candidate median 13,953 us
- Longer 50k-insert version of same workload: baseline median 151,333 us; candidate median 145,850 us

## Tests
- `make doltlite libdoltlite.a -j8`
- `cc -O2 -I. -o /tmp/bench_timer_doltlite_textpk_insert_appendsorted test/sysbench_timer.c libdoltlite.a -lz -lm -lpthread`
- `/tmp/doltlite_regression_test_c_appendsorted mutmap_append_sorted_order`
- `/tmp/doltlite_regression_test_c_appendsorted mutmap_differential_randomized`
- `/tmp/doltlite_regression_test_c_appendsorted mutmap_resolve_sorted_pos`
- `/tmp/doltlite_regression_test_c_appendsorted mutmap_delete_reinsert_reuses_entry`
- `/tmp/doltlite_regression_test_c_appendsorted savepoint_flush_snapshot_rollback_reopen`
