### PR TITLE
fix(dbpage): register on calling handle, reject pgno>1 explicitly

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -4873,7 +4873,9 @@ void doltliteRegister(sqlite3 *db){
   }
 
   {
+    extern int doltliteDbpageRegister(sqlite3*);
     extern int doltliteDbpageInstallAutoExt(void);
+    doltliteDbpageRegister(db);
     doltliteDbpageInstallAutoExt();
   }
   doltliteMaybeSeedRepo(db);

--- a/src/doltlite_dbpage.c
+++ b/src/doltlite_dbpage.c
@@ -174,7 +174,6 @@ static int dbpageFilter(sqlite3_vtab_cursor *pCursor,
     int idxNum, const char *idxStr, int argc, sqlite3_value **argv){
   DbpageCursor *pCur = (DbpageCursor*)pCursor;
   DbpageVtab *pVtab = (DbpageVtab*)pCursor->pVtab;
-  int wantPage1 = 1;
   int iArg = 0;
   (void)idxStr; (void)argc;
 
@@ -183,17 +182,21 @@ static int dbpageFilter(sqlite3_vtab_cursor *pCursor,
 
   if( idxNum & 1 ){
     sqlite3_int64 pgno = sqlite3_value_int64(argv[iArg++]);
-    wantPage1 = (pgno==1);
+    if( pgno!=1 ){
+      sqlite3_free(pVtab->base.zErrMsg);
+      pVtab->base.zErrMsg = sqlite3_mprintf(
+        "doltlite: sqlite_dbpage only supports pgno=1 "
+        "(content-addressed chunk store has no page layout)");
+      return SQLITE_ERROR;
+    }
   }
 
   if( idxNum & 2 ){
     iArg++;
   }
 
-  if( wantPage1 ){
-    synthesizeHeader(pVtab->db, pCur->aPage);
-    pCur->hasRow = 1;
-  }
+  synthesizeHeader(pVtab->db, pCur->aPage);
+  pCur->hasRow = 1;
   return SQLITE_OK;
 }
 

--- a/test/doltlite_dbpage.sh
+++ b/test/doltlite_dbpage.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Verify sqlite_dbpage divergence contract: pgno=1 returns the
+# synthesized header on the calling handle (no reopen needed);
+# pgno>1 errors with a clear message rather than returning EOF.
+
+DOLTLITE=./doltlite
+PASS=0; FAIL=0; ERRORS=""
+
+run_test() {
+  local n="$1" s="$2" e="$3" d="$4"
+  local r=$(printf '%s\n' "$s" | $DOLTLITE "$d" 2>&1)
+  if [ "$r" = "$e" ]; then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1))
+    ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"
+  fi
+}
+
+run_test_match() {
+  local n="$1" s="$2" p="$3" d="$4"
+  local r=$(printf '%s\n' "$s" | $DOLTLITE "$d" 2>&1)
+  if echo "$r" | grep -qE "$p"; then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1))
+    ERRORS="$ERRORS\nFAIL: $n\n  pattern: $p\n  got:     $r"
+  fi
+}
+
+db_rm() { rm -f "$1" "${1}-wal"; }
+
+echo "=== sqlite_dbpage divergence contract ==="
+echo ""
+
+DB=/tmp/test_dbpage_$$.db; db_rm "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a'),(2,'b');
+SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+# Page 1 available on the calling handle (no reopen). This is the P9
+# registration plumbing fix — sqlite_dbpage used to be installed only
+# as an auto-extension that fires on *future* opens.
+run_test "page1_size" "SELECT length(data) FROM sqlite_dbpage WHERE pgno=1;" "4096" "$DB"
+
+# Page 1 magic header.
+run_test "page1_magic" "SELECT substr(cast(data AS TEXT), 1, 15) FROM sqlite_dbpage WHERE pgno=1;" "SQLite format 3" "$DB"
+
+# Page count > 1 errors with a clear message.
+run_test_match "page2_rejected" "SELECT length(data) FROM sqlite_dbpage WHERE pgno=2;" \
+  "doltlite: sqlite_dbpage only supports pgno=1" "$DB"
+
+run_test_match "page99_rejected" "SELECT length(data) FROM sqlite_dbpage WHERE pgno=99;" \
+  "doltlite: sqlite_dbpage only supports pgno=1" "$DB"
+
+# Full scan (no pgno predicate) returns only page 1 — same as today.
+run_test "full_scan_count" "SELECT count(*) FROM sqlite_dbpage;" "1" "$DB"
+
+db_rm "$DB"
+
+echo ""
+if [ $FAIL -gt 0 ]; then
+  printf "$ERRORS\n"
+  echo "RESULTS: $PASS passed, $FAIL failed"
+  exit 1
+fi
+echo "RESULTS: $PASS passed, $FAIL failed"

--- a/test/run_doltlite_tests.sh
+++ b/test/run_doltlite_tests.sh
@@ -72,6 +72,7 @@ TESTS=(
 
   # Additional tests
   doltlite_attach_sqlite.sh
+  doltlite_dbpage.sh
   doltlite_open_sqlite_file.sh
   doltlite_behavior.sh
   doltlite_branch_edge.sh


### PR DESCRIPTION
## Summary
Closes deep-review **P9** ('\`sqlite_dbpage\` not registered on the calling handle') and tightens **P8** by replacing the silent EOF-for-deeper-pages behavior with a clear error.

### P9 — registration plumbing
\`doltliteRegister\` called only \`doltliteDbpageInstallAutoExt()\` (which registers an auto-extension that fires on **future** opens). The connection inside \`doltliteRegister\` itself did not get \`sqlite_dbpage\`. So \`./doltlite db.db 'SELECT * FROM sqlite_dbpage WHERE pgno=1;'\` returned \"no such table\" on the first invocation and only worked after a reopen.

Now \`doltliteRegister\` also calls \`doltliteDbpageRegister(db)\` directly. Two-line change.

### P8 — fail-loud on unsupported pages
Doltlite has no page layout (content-addressed chunk store). The pre-existing module synthesizes a believable page-1 header from session/catalog state, but for \`pgno > 1\` it silently returned EOF. That looks indistinguishable from \"database really has one page\" to tools like \`sqlite3_analyzer\` — they'd produce misleading reports.

Now \`pgno != 1\` returns \`SQLITE_ERROR\` with:

\`\`\`
doltlite: sqlite_dbpage only supports pgno=1
(content-addressed chunk store has no page layout)
\`\`\`

Full scans (no \`pgno\` predicate) still return the single page-1 row — unchanged.

The deeper P8 design question (\"what should \`sqlite_dbpage\` actually expose?\") is tracked in **#947** for whoever picks it up.

## Test plan
- [x] \`bash test/doltlite_dbpage.sh\` — 5/5 (new test pins the contract)
- [x] \`bash test/run_doltlite_tests.sh\` — 43/44 (the 1 failure, \`doltlite_regression_test_c.sh::mutmap_delete_reinsert_keeps_value_buffer\`, is a **pre-existing master regression** from #942 unrelated to this PR)

## Note on master test failure
While running the suite I noticed \`mutmap_delete_reinsert_keeps_value_buffer\` fails on a clean master checkout too. Filing a separate issue/PR; not blocking this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)