### PR TITLE
perf(sortkey): fast path single binary mem keys

### DIFF
--- a/src/sortkey.c
+++ b/src/sortkey.c
@@ -525,15 +525,77 @@ static int sortKeyEncodeMemArray(
   return pOut ? outPos : (int)outSize;
 }
 
+static int sortKeyFromSingleBinaryMemFast(
+  Mem *aMem,
+  int nMem,
+  int nKeyField,
+  const KeyInfo *pKeyInfo,
+  u8 **ppBuf,
+  int *pnAlloc,
+  int *pnOut
+){
+  Mem *pMem;
+  int flags;
+  u8 tag;
+  int nSize;
+  int nAlloc;
+  u8 *pOut;
+
+  if( !aMem || nMem!=1 || nKeyField!=0 ) return SQLITE_NOTFOUND;
+
+  pMem = &aMem[0];
+  flags = pMem->flags;
+  if( flags & MEM_Zero ) return SQLITE_NOTFOUND;
+  if( pMem->n < 0 || (pMem->n > 0 && pMem->z==0) ) return SQLITE_CORRUPT;
+
+  if( flags & MEM_Str ){
+    if( collFromKeyInfo(pKeyInfo, 0)!=SORTKEY_COLL_BINARY ){
+      return SQLITE_NOTFOUND;
+    }
+    tag = SORTKEY_TEXT;
+  }else if( flags & MEM_Blob ){
+    tag = SORTKEY_BLOB;
+  }else{
+    return SQLITE_NOTFOUND;
+  }
+
+  if( pMem->n>0 && memchr(pMem->z, 0, (size_t)pMem->n)!=0 ){
+    return SQLITE_NOTFOUND;
+  }
+  if( pMem->n > INT_MAX - 3 ) return SQLITE_TOOBIG;
+
+  nSize = pMem->n + 3;
+  nAlloc = nSize < 64 ? 64 : nSize;
+  if( *pnAlloc < nAlloc ){
+    u8 *pNew = (u8*)sqlite3_realloc64(*ppBuf, (sqlite3_uint64)nAlloc);
+    if( !pNew ) return SQLITE_NOMEM;
+    *ppBuf = pNew;
+    *pnAlloc = nAlloc;
+  }
+
+  pOut = *ppBuf;
+  pOut[0] = tag;
+  if( pMem->n>0 ) memcpy(pOut + 1, pMem->z, (size_t)pMem->n);
+  pOut[1 + pMem->n] = 0x00;
+  pOut[2 + pMem->n] = 0x00;
+  *pnOut = nSize;
+  return SQLITE_OK;
+}
+
 int sortKeyFromMemPrefixCollBuffer(
   Mem *aMem, int nMem, int nKeyField, const KeyInfo *pKeyInfo,
   u8 **ppBuf, int *pnAlloc, int *pnOut
 ){
   int nSize;
   int nAlloc;
+  int rc;
 
   *pnOut = 0;
   if( !aMem || nMem<=0 ) return SQLITE_NOTFOUND;
+
+  rc = sortKeyFromSingleBinaryMemFast(
+      aMem, nMem, nKeyField, pKeyInfo, ppBuf, pnAlloc, pnOut);
+  if( rc!=SQLITE_NOTFOUND ) return rc;
 
   nSize = sortKeyEncodeMemArray(aMem, nMem, nKeyField, pKeyInfo, 0);
   if( nSize == -3 ) return SQLITE_NOTFOUND;

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -2326,6 +2326,13 @@ static void run_sortkey_mem_matches_record(void){
   int nMemAlloc = 0;
   int nMemPrefixAlloc = 0;
   int rc;
+  Mem fastMem;
+  u8 *pFastKey = 0;
+  int nFastKey = 0;
+  int nFastAlloc = 0;
+  static const u8 aFastExpected[] = {
+    SORTKEY_TEXT, 'a', 'b', 'c', 0x00, 0x00
+  };
 
   printf("=== Sortkey Mem Matches Record Test ===\n\n");
 
@@ -2359,10 +2366,23 @@ static void run_sortkey_mem_matches_record(void){
         nMemPrefix==nRecordPrefix
         && memcmp(pMemPrefix, pRecordPrefix, nRecordPrefix)==0);
 
+  memset(&fastMem, 0, sizeof(fastMem));
+  fastMem.flags = MEM_Str;
+  fastMem.z = "abc";
+  fastMem.n = 3;
+  rc = sortKeyFromMemPrefixCollBuffer(&fastMem, 1, 0, 0,
+                                      &pFastKey, &nFastAlloc, &nFastKey);
+  check("sortkey_mem_single_binary_text_fast_ok", rc==SQLITE_OK);
+  check("sortkey_mem_single_binary_text_fast_output",
+        nFastKey==(int)sizeof(aFastExpected)
+        && memcmp(pFastKey, aFastExpected, sizeof(aFastExpected))==0);
+  check("sortkey_mem_single_binary_text_fast_alloc", nFastAlloc==64);
+
   sqlite3_free(pRecordKey);
   sqlite3_free(pMemKey);
   sqlite3_free(pRecordPrefix);
   sqlite3_free(pMemPrefix);
+  sqlite3_free(pFastKey);
 }
 
 static void run_reload_refs_transactional(void){


### PR DESCRIPTION
## Summary
- add a Mem-array sort-key fast path for single-field BINARY TEXT/BLOB keys without embedded zero bytes
- reuse the same compact encoding already used by the record-level single-field fast path
- extend the sortkey Mem/record regression test to cover the single binary text path

## Benchmark target
- Latest merged PR checked: #948 (`perf(prolly): skip mutmap sort for append-ordered edits`)
- Highest non-ignored sysbench multiplier: `oltp_insert`
- Key type: `TEXT PRIMARY KEY`
- Mode: in-memory
- Autocommit: false
- PR row: SQLite 16,504 us, Doltlite 25,929 us, 1.57x

## Local comparison
- Focused `oltp_insert` TEXT PK shape, 1000-row setup, 5000 inserts: baseline median 13,987 us; candidate median 13,822 us
- Longer 50k-insert version of same workload: baseline median 147,323 us; candidate median 144,989 us

## Tests
- `make doltlite libdoltlite.a -j8`
- `cc -O2 -I. -o /tmp/bench_timer_doltlite_textpk_insert_memfast test/sysbench_timer.c libdoltlite.a -lz -lm -lpthread`
- `/tmp/doltlite_regression_test_c_memfast sortkey_mem_matches_record`
- `/tmp/doltlite_regression_test_c_memfast sortkey_numeric_text_roundtrip`
- `/tmp/doltlite_regression_test_c_memfast sortkey_numeric_blob_roundtrip`
- `/tmp/doltlite_regression_test_c_memfast sortkey_buffer_exact_size`
