### PR TITLE
fix(storage): hash-verify WAL chunks on replay; serialize cs lock via mutex

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -285,6 +285,8 @@ int chunkStoreOpen(
   memset(cs, 0, sizeof(*cs));
   cs->file.pVfs = pVfs;
   cs->graphLockFd = -1;
+  cs->pLockMutex = sqlite3_mutex_alloc(SQLITE_MUTEX_RECURSIVE);
+  cs->lockDepth = 0;
 
   if( zFilename==0 || zFilename[0]=='\0'
    || strcmp(zFilename, ":memory:")==0 ){
@@ -421,6 +423,7 @@ int chunkStoreClose(ChunkStore *cs){
   csFreeTags(cs);
   csFreeRemotes(cs);
   csFreeTracking(cs);
+  sqlite3_mutex_free(cs->pLockMutex);
   memset(cs, 0, sizeof(*cs));
   return SQLITE_OK;
 }
@@ -1370,19 +1373,31 @@ int chunkStoreLockAndRefreshChanged(ChunkStore *cs, int *pChanged){
   int rc;
   if( pChanged ) *pChanged = 0;
   if( cs->isMemory ) return SQLITE_OK;
-  if( cs->graphLockFd >= 0 ) return SQLITE_OK;
-  if( !cs->file.zFilename ) return SQLITE_ERROR;
+  if( cs->pLockMutex && sqlite3_mutex_try(cs->pLockMutex)!=SQLITE_OK ){
+    return SQLITE_BUSY;
+  }
+  if( cs->lockDepth > 0 ){
+    cs->lockDepth++;
+    return SQLITE_OK;
+  }
+  if( !cs->file.zFilename ){
+    if( cs->pLockMutex ) sqlite3_mutex_leave(cs->pLockMutex);
+    return SQLITE_ERROR;
+  }
   if( csFileLockNB(cs->file.zFilename, &cs->graphLockFd) != 0 ){
+    if( cs->pLockMutex ) sqlite3_mutex_leave(cs->pLockMutex);
     return SQLITE_BUSY;
   }
   rc = chunkStoreRefreshIfChanged(cs, &changed);
   if( rc!=SQLITE_OK ){
     csFileUnlock(cs->graphLockFd);
     cs->graphLockFd = -1;
-  }else if( pChanged ){
-    *pChanged = changed;
+    if( cs->pLockMutex ) sqlite3_mutex_leave(cs->pLockMutex);
+    return rc;
   }
-  return rc;
+  cs->lockDepth = 1;
+  if( pChanged ) *pChanged = changed;
+  return SQLITE_OK;
 }
 
 int chunkStoreLockAndRefresh(ChunkStore *cs){
@@ -1390,7 +1405,14 @@ int chunkStoreLockAndRefresh(ChunkStore *cs){
 }
 
 void chunkStoreUnlock(ChunkStore *cs){
-  if( cs->graphLockFd >= 0 ){
+  if( cs->lockDepth > 0 ){
+    cs->lockDepth--;
+    if( cs->lockDepth == 0 && cs->graphLockFd >= 0 ){
+      csFileUnlock(cs->graphLockFd);
+      cs->graphLockFd = -1;
+    }
+    if( cs->pLockMutex ) sqlite3_mutex_leave(cs->pLockMutex);
+  }else if( cs->graphLockFd >= 0 ){
     csFileUnlock(cs->graphLockFd);
     cs->graphLockFd = -1;
   }

--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -100,6 +100,8 @@ struct ChunkStore {
   u8 snapshotPinned;
   u8 hasMovedChecked;
   int graphLockFd;
+  sqlite3_mutex *pLockMutex;
+  int lockDepth;
 };
 
 int chunkStoreOpen(ChunkStore *cs, sqlite3_vfs *pVfs,

--- a/src/chunk_wal.c
+++ b/src/chunk_wal.c
@@ -5,6 +5,7 @@
 #include "chunk_store.h"
 #include "chunk_staging.h"
 #include "chunk_file.h"
+#include "../ext/blake3/blake3.h"
 #include <string.h>
 
 #define CS_READ_U32(p) (             \
@@ -215,6 +216,34 @@ int csReplayWal(ChunkStore *cs){
         break;
       }
 
+      {
+        blake3_hasher hasher;
+        ProllyHash bodyHash;
+        u8 chunkBuf[65536];
+        u32 nRemaining = len;
+        i64 readOff = cs->wal.iWalOffset + pos;
+        int hashMismatch = 0;
+        blake3_hasher_init(&hasher);
+        while( nRemaining > 0 ){
+          u32 toRead = nRemaining > sizeof(chunkBuf)
+                     ? (u32)sizeof(chunkBuf) : nRemaining;
+          rc = sqlite3OsRead(cs->file.pFile, chunkBuf, (int)toRead, readOff);
+          if( rc != SQLITE_OK ) goto replay_error;
+          blake3_hasher_update(&hasher, chunkBuf, (size_t)toRead);
+          readOff += toRead;
+          nRemaining -= toRead;
+        }
+        blake3_hasher_finalize(&hasher, bodyHash.data, PROLLY_HASH_SIZE);
+        if( prollyHashCompare(&bodyHash, &hash) != 0 ) hashMismatch = 1;
+        if( hashMismatch ){
+          sqlite3_log(SQLITE_NOTICE,
+            "doltlite: WAL chunk body hash mismatch at offset %lld (declared len=%u); "
+            "skipping (will surface as missing chunk on read)",
+            (long long)(cs->wal.iWalOffset + pos - 24 - 1), (unsigned)len);
+          pos += len;
+          continue;
+        }
+      }
       {
         int existing = csSearchIndex(cs->index.aIndex, cs->index.nIndex, &hash);
         ChunkIndexEntry *e = 0;

--- a/test/doltlite_storage_locking.sh
+++ b/test/doltlite_storage_locking.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+# Cover deep-review S6 + S10.
+#
+# S6 — WAL replay accepts chunk bodies without re-hashing. Torn or
+#      bitflipped writes were silently indexed; subsequent reads
+#      returned SQLITE_CORRUPT but the bad chunk lived in the index.
+#      Now WAL replay re-hashes each chunk body and skips on
+#      mismatch; the missing chunk surfaces at first read.
+#
+# S10 — Intra-process chunk-store lock used flock + a graphLockFd
+#       short-circuit. Under shared cache (two connections sharing
+#       BtShared → one ChunkStore) and across threads, the second
+#       caller saw "lock already held" and proceeded without real
+#       exclusion. The fix wraps the lock in a recursive sqlite3
+#       mutex: nested calls from the same thread succeed (existing
+#       commit-cycle nesting), concurrent callers from a different
+#       thread get SQLITE_BUSY.
+
+DOLTLITE=./doltlite
+PASS=0; FAIL=0; ERRORS=""
+
+run_test() {
+  local n="$1" s="$2" e="$3" d="$4"
+  local r=$(printf '%s\n' "$s" | $DOLTLITE "$d" 2>&1)
+  if [ "$r" = "$e" ]; then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1))
+    ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"
+  fi
+}
+
+run_test_match() {
+  local n="$1" s="$2" p="$3" d="$4"
+  local r=$(printf '%s\n' "$s" | $DOLTLITE "$d" 2>&1)
+  if echo "$r" | grep -qE "$p"; then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1))
+    ERRORS="$ERRORS\nFAIL: $n\n  pattern: $p\n  got:     $r"
+  fi
+}
+
+db_rm() { rm -f "$1" "${1}-wal"; }
+
+echo "=== Storage locking + WAL replay verify (S6 + S10) ==="
+echo ""
+
+# ----------------------------------------------------------------
+# S10 — Nested locking still works. A commit cycle internally
+# acquires the chunk-store lock, then csCommitToFile (re-entered
+# via chunkStoreCommit) sees graphLockFd already held and skips
+# re-acquiring. With the mutex now in place, depth-tracking must
+# preserve that pattern.
+# ----------------------------------------------------------------
+DB=/tmp/test_lock_nested_$$.db; db_rm "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a'),(2,'b'),(3,'c');
+SELECT dolt_commit('-A','-m','c1');" | $DOLTLITE "$DB" > /dev/null 2>&1
+run_test "s10_commit_with_nested_lock" \
+  "SELECT count(*) FROM t;" "3" "$DB"
+db_rm "$DB"
+
+# GC takes the lock; multiple sequential GCs on the same connection
+# must each be able to acquire/release cleanly.
+DB=/tmp/test_lock_seq_gc_$$.db; db_rm "$DB"
+{
+  echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+  for i in $(seq 1 10); do
+    echo "INSERT INTO t VALUES($i, 'row_$i');"
+    echo "SELECT dolt_commit('-A','-m','c$i');"
+  done
+} | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test_match "s10_first_gc" "SELECT dolt_gc();" "chunks" "$DB"
+run_test_match "s10_second_gc" "SELECT dolt_gc();" "chunks" "$DB"
+run_test_match "s10_third_gc" "SELECT dolt_gc();" "chunks" "$DB"
+run_test "s10_data_after_three_gcs" "SELECT count(*) FROM t;" "10" "$DB"
+
+db_rm "$DB"
+
+# ----------------------------------------------------------------
+# S6 — Corrupt a chunk body that lives in the WAL portion of the
+# file. WAL replay must detect the hash mismatch, skip the chunk,
+# and surface the missing chunk via integrity_check.
+#
+# This complements the regression-bank test
+# `integrity_check_surfaces_root_corruption`, which exercises the
+# same scenario but with a chunk whose offset sign at corruption
+# time may land in either WAL or indexed area depending on commit
+# state.
+# ----------------------------------------------------------------
+DB=/tmp/test_s6_wal_$$.db; db_rm "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'); SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+# Open the file and flip a byte in the middle. Without knowing the
+# exact layout we can't guarantee we hit the WAL portion, but we
+# can verify the reopen path doesn't crash and surfaces *some*
+# error when corruption is severe.
+file_size=$(stat -f%z "$DB" 2>/dev/null || stat -c%s "$DB" 2>/dev/null)
+mid=$((file_size / 2))
+# Flip a byte well past the file header (manifest is 168 bytes).
+perl -e '
+  my ($f, $off) = @ARGV;
+  open my $fh, "+<:raw", $f or die $!;
+  seek $fh, $off, 0;
+  my $b;
+  read $fh, $b, 1;
+  my $flipped = chr(ord($b) ^ 0xff);
+  seek $fh, $off, 0;
+  print $fh $flipped;
+  close $fh;
+' "$DB" "$mid"
+
+# Open and try to read. Behavior is "either: data is still readable
+# because the corruption hit padding / unrelated bytes; or: surface
+# an error". The key requirement is no crash.
+out=$($DOLTLITE "$DB" "SELECT v FROM t WHERE id=1;" 2>&1)
+exit_rc=$?
+# Exit must be 0 or a SQLite error code, never SIGSEGV / SIGBUS.
+if [ "$exit_rc" -ge 128 ]; then
+  FAIL=$((FAIL+1))
+  ERRORS="$ERRORS\nFAIL: s6_post_corruption_no_crash\n  exit=$exit_rc (signal)"
+else
+  PASS=$((PASS+1))
+fi
+db_rm "$DB"
+
+# ----------------------------------------------------------------
+# S6 — Healthy database round-trip still works (regression guard
+# for the streaming-hash code path in WAL replay).
+# ----------------------------------------------------------------
+DB=/tmp/test_s6_healthy_$$.db; db_rm "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a'),(2,'b'),(3,'c');
+SELECT dolt_commit('-A','-m','c1');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+# Reopen and verify all rows still come back.
+run_test "s6_healthy_reopen_count" "SELECT count(*) FROM t;" "3" "$DB"
+run_test "s6_healthy_reopen_value" "SELECT v FROM t WHERE id=2;" "b" "$DB"
+
+db_rm "$DB"
+
+echo ""
+if [ $FAIL -gt 0 ]; then
+  printf "$ERRORS\n"
+  echo "RESULTS: $PASS passed, $FAIL failed"
+  exit 1
+fi
+echo "RESULTS: $PASS passed, $FAIL failed"

--- a/test/run_doltlite_tests.sh
+++ b/test/run_doltlite_tests.sh
@@ -79,6 +79,7 @@ TESTS=(
   doltlite_open_sqlite_file.sh
   doltlite_record_format.sh
   doltlite_schema_cookie.sh
+  doltlite_storage_locking.sh
   doltlite_behavior.sh
   doltlite_branch_edge.sh
   doltlite_diff_alter.sh


### PR DESCRIPTION
## Summary
Closes the last two Tier 0 storage-correctness items from the deep review. After this, Tier 0 is complete.

### S6 — WAL replay hash verify (data-loss class)
WAL replay used to record chunk headers (hash + length) into the index without ever reading the body. A torn or bitflipped write between commit and crash was silently indexed, then surfaced later as \`SQLITE_CORRUPT\` on read — or, before #930's dedup-verify landed, could mask good data on a subsequent same-hash put.

WAL replay now re-hashes each chunk body via a **streaming** blake3 hasher (64 KiB read buffer — no large allocations even for ~2 GiB chunks). On mismatch the chunk is skipped: \`pos\` advances past the body so the rest of the WAL (including the root manifest) still gets replayed. The catalog reference to the missing chunk then surfaces as \`SQLITE_NOTFOUND\` at first read, which \`integrityCheckChunkGraph\` already translates into an integrity-check error.

The earlier abandoned S6 attempt broke \`integrity_check_surfaces_root_corruption\` because it \`break\`'d out at the first mismatch — the root manifest never got read, the catalog stayed empty, and integrity_check returned "ok" on a deliberately-corrupted DB. The skip-and-continue shape preserves the test's intent.

### S10 — Intra-process chunk-store lock
\`chunkStoreLockAndRefreshChanged\` used \`flock(2)\` for inter-process exclusion plus an early-return on \`graphLockFd >= 0\` for intra-process re-entry. Under shared cache (two connections sharing one ChunkStore), the second caller saw "lock already held" and proceeded without real exclusion. Under multi-threaded shared cache that's a clean race.

Added a \`sqlite3_mutex\` (\`SQLITE_MUTEX_RECURSIVE\`) and an explicit \`lockDepth\` to \`ChunkStore\`. Same-thread nested calls still work (recursive mutex + depth-tracking knows when to acquire/release the flock). A different-thread concurrent acquire returns \`SQLITE_BUSY\`, and the existing busy-handler retry loop at \`prollyBtreeBeginTrans:4485\` takes care of waiting.

## Test plan
- [x] \`bash test/run_doltlite_tests.sh\` — 52/52 suites
- [x] \`bash test/doltlite_storage_locking.sh\` — 8/8 (new)
- [x] \`bash test/review_regression_test.sh\` Guard 22 (sparse >2 GiB DB) — green; the streaming buffer means even very large chunks replay without the prior allocator ceiling
- [x] \`bash test/doltlite_regression_test_c.sh::integrity_check_surfaces_root_corruption\` — green; the skip-and-continue shape preserves the existing integrity contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)