### PR TITLE
fix(cursor): defensive log for anomalous unknown-table synthesis (P5)

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -5255,6 +5255,14 @@ static int prollyBtreeCursor(
   pTE = findTable(p, iTable);
   if( !pTE ){
     u8 flags = pKeyInfo ? BTREE_BLOBKEY : BTREE_INTKEY;
+    if( iTable < p->cat.iNextTable ){
+      sqlite3_log(SQLITE_NOTICE,
+        "doltlite: cursor open on iTable=%u not in catalog "
+        "(iNextTable=%u); synthesizing %s entry from pKeyInfo. "
+        "May indicate stale schema cache.",
+        (unsigned)iTable, (unsigned)p->cat.iNextTable,
+        pKeyInfo ? "BLOBKEY" : "INTKEY");
+    }
     pTE = addTable(p, iTable, flags);
     if( !pTE ) return SQLITE_NOMEM;
   }

--- a/test/doltlite_unknown_table_cursor.sh
+++ b/test/doltlite_unknown_table_cursor.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+# P5 — Cursor opens on an iTable that isn't in the catalog used to
+# silently synthesize a TableEntry guessing the key class from
+# pKeyInfo (BLOBKEY if non-NULL, INTKEY else). The review flagged
+# this as a wrong-key-class hazard on schema-cache miss or ATTACH
+# race; in practice, with the P13 blake3 schema cookie ruling out
+# spurious cache-miss invalidation, the surviving exposure is
+# stale-prepared-statement races.
+#
+# The fix adds a defensive sqlite3_log notice when synthesis fires
+# AND iTable is below the catalog's iNextTable — the anomaly case
+# (the table should already be there). Normal paths
+# (merge/cherry-pick that introduce cross-branch tables with
+# iTable >= iNextTable) take the synthesis path without the log.
+#
+# This test pins:
+#   1. Normal usage doesn't trigger spurious "no such table" errors.
+#   2. Merge/cherry-pick across branches with new tables still work
+#      (these rely on the synthesis path).
+#   3. CREATE TABLE / DROP TABLE / re-CREATE keeps the catalog
+#      consistent.
+
+DOLTLITE=./doltlite
+PASS=0; FAIL=0; ERRORS=""
+
+run_test() {
+  local n="$1" s="$2" e="$3" d="$4"
+  local r=$(printf '%s\n' "$s" | $DOLTLITE "$d" 2>&1)
+  if [ "$r" = "$e" ]; then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1))
+    ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"
+  fi
+}
+
+run_test_match() {
+  local n="$1" s="$2" p="$3" d="$4"
+  local r=$(printf '%s\n' "$s" | $DOLTLITE "$d" 2>&1)
+  if echo "$r" | grep -qE "$p"; then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1))
+    ERRORS="$ERRORS\nFAIL: $n\n  pattern: $p\n  got:     $r"
+  fi
+}
+
+db_rm() { rm -f "$1" "${1}-wal"; }
+
+echo "=== P5 — unknown-table cursor synthesis ==="
+echo ""
+
+# ----------------------------------------------------------------
+# Normal CREATE TABLE / writes / reads — catalog is always
+# populated before cursors open. No anomaly.
+# ----------------------------------------------------------------
+DB=/tmp/test_p5_create_$$.db; db_rm "$DB"
+run_test "p5_create_insert_select" \
+  "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a'),(2,'b'),(3,'c');
+SELECT count(*) FROM t;" "3" "$DB"
+db_rm "$DB"
+
+# Mixed key classes: rowid table, integer PK alias, blob PK,
+# composite PK, WITHOUT ROWID. Each has different
+# (iTable, flags) tuples in the catalog.
+DB=/tmp/test_p5_mixed_$$.db; db_rm "$DB"
+echo "
+CREATE TABLE rt(id INTEGER PRIMARY KEY, v TEXT);
+CREATE TABLE bt(k BLOB PRIMARY KEY, v TEXT) WITHOUT ROWID;
+CREATE TABLE ct(a INTEGER, b INTEGER, v TEXT, PRIMARY KEY(a,b)) WITHOUT ROWID;
+CREATE INDEX idx_rt_v ON rt(v);
+CREATE INDEX idx_ct_v ON ct(v);
+INSERT INTO rt VALUES(1,'r1'),(2,'r2');
+INSERT INTO bt VALUES(x'01','b1');
+INSERT INTO ct VALUES(1,1,'c1'),(1,2,'c2');
+" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test "p5_rowid_table_count" "SELECT count(*) FROM rt;" "2" "$DB"
+run_test "p5_without_rowid_blob_pk" "SELECT v FROM bt WHERE k=x'01';" "b1" "$DB"
+run_test "p5_composite_pk" "SELECT v FROM ct WHERE a=1 AND b=2;" "c2" "$DB"
+run_test "p5_rowid_index_lookup" "SELECT id FROM rt WHERE v='r2';" "2" "$DB"
+db_rm "$DB"
+
+# ----------------------------------------------------------------
+# Merge with new tables on the incoming branch. The synthesis
+# path fires here when main opens cursors on feat-introduced
+# tables that have iTable >= main's iNextTable. The defensive
+# log filter (iTable < iNextTable) skips these — no warning,
+# no error.
+# ----------------------------------------------------------------
+DB=/tmp/test_p5_merge_$$.db; db_rm "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1,10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+echo "SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+CREATE TABLE p(id INTEGER PRIMARY KEY, u INT UNIQUE);
+CREATE TABLE c(id INTEGER PRIMARY KEY, u INT, FOREIGN KEY(u) REFERENCES p(u));
+INSERT INTO p VALUES(1,100);
+INSERT INTO c VALUES(1,100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat_add_fk_tables');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+echo "SELECT dolt_checkout('main');
+CREATE TABLE t_new(id INTEGER PRIMARY KEY, v INT CHECK(v > 0));
+INSERT INTO t_new SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t_new RENAME TO t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main_check');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test_match "p5_merge_introduces_new_tables" \
+  "SELECT dolt_merge('feat');" "^[0-9a-f]{40}$" "$DB"
+run_test "p5_merge_main_table_intact" "SELECT count(*) FROM t;" "1" "$DB"
+run_test "p5_merge_feat_table_p" "SELECT count(*) FROM p;" "1" "$DB"
+run_test "p5_merge_feat_table_c" "SELECT count(*) FROM c;" "1" "$DB"
+db_rm "$DB"
+
+# Cherry-pick has the same cross-branch table-introduction path.
+# Get the commit hash while still on feat.
+DB=/tmp/test_p5_cp_$$.db; db_rm "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1,10);
+SELECT dolt_commit('-A','-m','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+CREATE TABLE newtab(id INTEGER PRIMARY KEY, label TEXT);
+INSERT INTO newtab VALUES(1,'hello');
+SELECT dolt_commit('-A','-m','add_newtab');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+CP_HASH=$(echo "SELECT commit_hash FROM dolt_log WHERE message='add_newtab';" \
+  | $DOLTLITE "$DB/feat" 2>/dev/null | head -1)
+
+echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+if [ -n "$CP_HASH" ]; then
+  run_test_match "p5_cherry_pick_new_table" \
+    "SELECT dolt_cherry_pick('$CP_HASH');" \
+    "^[0-9a-f]{40}$" "$DB"
+  run_test "p5_cp_new_table_visible" "SELECT label FROM newtab WHERE id=1;" "hello" "$DB"
+else
+  FAIL=$((FAIL+1))
+  ERRORS="$ERRORS\nFAIL: p5_cherry_pick_setup (couldn't find commit hash)"
+fi
+db_rm "$DB"
+
+echo ""
+if [ $FAIL -gt 0 ]; then
+  printf "$ERRORS\n"
+  echo "RESULTS: $PASS passed, $FAIL failed"
+  exit 1
+fi
+echo "RESULTS: $PASS passed, $FAIL failed"

--- a/test/run_doltlite_tests.sh
+++ b/test/run_doltlite_tests.sh
@@ -82,6 +82,7 @@ TESTS=(
   doltlite_record_format.sh
   doltlite_schema_cookie.sh
   doltlite_storage_locking.sh
+  doltlite_unknown_table_cursor.sh
   doltlite_behavior.sh
   doltlite_branch_edge.sh
   doltlite_diff_alter.sh


### PR DESCRIPTION
## Summary
Closes deep-review **P5** with a scoped fix and an analysis note.

## Background
\`prollyBtreeCursor\` synthesizes a \`TableEntry\` when a cursor opens on an iTable not in the catalog, guessing key class from \`pKeyInfo\`: BLOBKEY if non-NULL, INTKEY else. The review flagged this as a wrong-key-class hazard on schema-cache miss or ATTACH race.

## Analysis
The synthesis path is **necessary** for cross-branch table introduction during merge and cherry-pick — tables created on the incoming branch have iTable values not yet in the current branch's catalog, and the merge/cherry-pick code relies on cursor open populating the catalog with the right flags. A strict reject breaks \`doltlite_merge.sh::fk_tables_plus_check_merge_hash\` and \`doltlite_cherry_pick.sh::cp_fk_tables_hash\`.

The wrong-key-class scenario the review described requires:
1. iTable previously existed in the on-disk catalog with class A.
2. The on-disk catalog has been updated to class B (e.g., a schema change that swapped rowid for WITHOUT ROWID).
3. A prepared statement on this connection still holds stale pKeyInfo from class A's shape.
4. The schema cookie didn't invalidate the prepared statement.

After **PR #950 (P13)** the schema cookie is blake3-truncated, so the cookie-collision rate is ~2^-32 against any adversary, vs the prior polynomial hash's predictable collisions on small structural mutations. The race in (4) is now vanishingly unlikely.

## Fix
When synthesis fires AND \`iTable < cat.iNextTable\` (the catalog once had — or could have had — an entry for this iTable, so its absence is anomalous), emit a \`sqlite3_log(SQLITE_NOTICE, ...)\` warning naming the iTable and the inferred key class. Operators get a signal if the residual race ever fires in the wild. For cross-branch cases (\`iTable >= iNextTable\`) the synthesis is the intended path and no log fires.

## Test plan
- [x] \`bash test/run_doltlite_tests.sh\` — 55/55 suites
- [x] \`bash test/doltlite_unknown_table_cursor.sh\` — 11/11 (new): mixed key classes round-trip, merge across new feat tables, cherry-pick introducing a new table

🤖 Generated with [Claude Code](https://claude.com/claude-code)