### PR TITLE
fix(pragma): reject auto_vacuum=FULL/INCR and incremental_vacuum on doltlite-format

### DIFF
--- a/src/pragma.c
+++ b/src/pragma.c
@@ -814,6 +814,11 @@ void sqlite3Pragma(
       ** as an auto-vacuum capable db.
       */
       rc = sqlite3BtreeSetAutoVacuum(pBt, eAuto);
+      if( rc==SQLITE_ERROR ){
+        sqlite3ErrorMsg(pParse,
+          "auto_vacuum is not supported on doltlite-format databases");
+        goto pragma_out;
+      }
       if( rc==SQLITE_OK && (eAuto==1 || eAuto==2) ){
         /* When setting the auto_vacuum mode to either "full" or
         ** "incremental", write the value of meta[6] in the database

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -3937,8 +3937,9 @@ int sqlite3BtreeGetReserveNoMutex(Btree *p){
 }
 
 static int prollyBtreeSetAutoVacuum(Btree *p, int autoVacuum){
-  (void)p; (void)autoVacuum;
-  return SQLITE_OK;
+  (void)p;
+  if( autoVacuum==BTREE_AUTOVACUUM_NONE ) return SQLITE_OK;
+  return SQLITE_ERROR;
 }
 int sqlite3BtreeSetAutoVacuum(Btree *p, int autoVacuum){
   if( !p ) return SQLITE_OK;
@@ -3956,7 +3957,7 @@ int sqlite3BtreeGetAutoVacuum(Btree *p){
 
 static int prollyBtreeIncrVacuum(Btree *p){
   (void)p;
-  return SQLITE_DONE;
+  return SQLITE_ERROR;
 }
 int sqlite3BtreeIncrVacuum(Btree *p){
   if( !p ) return SQLITE_DONE;

--- a/test/doltlite_pragma_auto_vacuum.sh
+++ b/test/doltlite_pragma_auto_vacuum.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+# P7 (auto_vacuum slice). Doltlite has no page layout, no allocator,
+# and no concept of vacuum at the storage level. Stock SQLite's
+# `PRAGMA auto_vacuum = FULL|INCR` and `PRAGMA incremental_vacuum`
+# both presume a paged store with a free-page list. doltlite used
+# to silently no-op these, which made `auto_vacuum=1` appear to
+# succeed and lulled users into expecting space reclamation that
+# never happened.
+#
+# Contract after this PR:
+#
+#   - PRAGMA auto_vacuum;          -> reads back 0 (NONE) — read is
+#                                     a query of the catalog-level
+#                                     flag and is supported.
+#   - PRAGMA auto_vacuum = 0;      -> silently OK (it's already NONE).
+#   - PRAGMA auto_vacuum = 1|2;    -> ERROR with clear message naming
+#                                     doltlite-format incompatibility.
+#   - PRAGMA incremental_vacuum;   -> ERROR at runtime.
+#
+# Stock-SQLite-format files opened via the orig route keep the
+# upstream behavior (the prolly-route reject doesn't fire).
+
+DOLTLITE=./doltlite
+SQLITE3=$(command -v sqlite3 2>/dev/null || echo /usr/bin/sqlite3)
+PASS=0; FAIL=0; ERRORS=""
+
+run_test() {
+  local n="$1" got="$2" want="$3"
+  if [ "$got" = "$want" ]; then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1))
+    ERRORS="$ERRORS\nFAIL: $n\n  expected: $want\n  got:      $got"
+  fi
+}
+
+run_test_match() {
+  local n="$1" got="$2" pat="$3"
+  if echo "$got" | grep -qE "$pat"; then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1))
+    ERRORS="$ERRORS\nFAIL: $n\n  pattern: $pat\n  got:     $got"
+  fi
+}
+
+db_rm() { rm -f "$1" "${1}-wal"; }
+
+echo "=== PRAGMA auto_vacuum / incremental_vacuum (doltlite-format) ==="
+echo ""
+
+# Doltlite-format database (created by doltlite).
+DB=/tmp/test_av_dl_$$.db; db_rm "$DB"
+$DOLTLITE "$DB" "CREATE TABLE t(id INTEGER PRIMARY KEY);" > /dev/null 2>&1
+
+# Read is always supported, returns 0.
+run_test "av_dl_read" \
+  "$($DOLTLITE "$DB" "PRAGMA auto_vacuum;" 2>&1)" "0"
+
+# Set to NONE: silently OK.
+out=$($DOLTLITE "$DB" "PRAGMA auto_vacuum = 0;" 2>&1)
+run_test "av_dl_set_none_ok" "$out" ""
+
+# Set to FULL: clear error.
+out=$($DOLTLITE "$DB" "PRAGMA auto_vacuum = 1;" 2>&1)
+run_test_match "av_dl_set_full_rejected" "$out" "auto_vacuum is not supported"
+
+# Set to INCR: clear error.
+out=$($DOLTLITE "$DB" "PRAGMA auto_vacuum = 2;" 2>&1)
+run_test_match "av_dl_set_incr_rejected" "$out" "auto_vacuum is not supported"
+
+# Incremental vacuum: runtime error.
+out=$($DOLTLITE "$DB" "PRAGMA incremental_vacuum;" 2>&1)
+run_test_match "av_dl_incr_rejected" "$out" "error|SQL logic"
+
+db_rm "$DB"
+
+# Stock-SQLite-format database (created by stock sqlite3 binary).
+# Doltlite routes this through the orig engine; the upstream
+# auto_vacuum / incremental_vacuum semantics apply.
+if [ -x "$SQLITE3" ]; then
+  echo ""
+  echo "--- stock-SQLite file via orig route ---"
+
+  DB=/tmp/test_av_stock_$$.db; db_rm "$DB"
+  $SQLITE3 "$DB" "PRAGMA auto_vacuum = 1; CREATE TABLE t(id INTEGER PRIMARY KEY);" > /dev/null 2>&1
+
+  # On a stock file, doltlite's PRAGMA path delegates to stock SQLite.
+  # Reading should return 1 (since the file was created with FULL).
+  run_test "av_stock_read" \
+    "$($DOLTLITE "$DB" "PRAGMA auto_vacuum;" 2>&1)" "1"
+
+  # Stock SQLite returns SQLITE_READONLY for changing the mode
+  # of an existing page-size-fixed db. doltlite shouldn't surface
+  # that as the doltlite-specific error.
+  out=$($DOLTLITE "$DB" "PRAGMA auto_vacuum = 0;" 2>&1)
+  if echo "$out" | grep -qi "auto_vacuum is not supported"; then
+    FAIL=$((FAIL+1))
+    ERRORS="$ERRORS\nFAIL: av_stock_no_doltlite_msg_leaked\n  doltlite error msg leaked into stock-format route\n  got: $out"
+  else
+    PASS=$((PASS+1))
+  fi
+
+  db_rm "$DB"
+fi
+
+echo ""
+if [ $FAIL -gt 0 ]; then
+  printf "$ERRORS\n"
+  echo "RESULTS: $PASS passed, $FAIL failed"
+  exit 1
+fi
+echo "RESULTS: $PASS passed, $FAIL failed"

--- a/test/doltlite_snapshot_isolation.sh
+++ b/test/doltlite_snapshot_isolation.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+# P6 — Snapshot isolation contract for read transactions.
+#
+# The deep review described `BEGIN; SELECT; SELECT;` in autocommit
+# as "not repeatable-read" via the drop-to-TRANS_NONE branch in
+# prollyBtreeBeginTrans. Empirically the behavior is correct:
+#
+#   - Pure autocommit (no BEGIN): each statement is its own
+#     transaction. Two SELECTs in autocommit between which another
+#     connection commits an UPDATE see DIFFERENT values. That's
+#     expected SQL autocommit semantics.
+#
+#   - Explicit BEGIN: db->autoCommit is set to 0 by the BEGIN
+#     statement, so the drop-to-NONE branch does not fire on
+#     subsequent SELECTs. The read snapshot is preserved until
+#     COMMIT / ROLLBACK.
+#
+# The branch fires correctly only in the cases where it should
+# (a fresh statement in autocommit mode that found a stale
+# TRANS_READ from prepare-time schema parsing).
+#
+# This test pins the contract so a future refactor doesn't
+# accidentally make BEGIN-bracketed reads non-repeatable, or make
+# autocommit reads spuriously repeatable.
+
+DOLTLITE=./doltlite
+PASS=0; FAIL=0; ERRORS=""
+
+run_test() {
+  local n="$1" got="$2" want="$3"
+  if [ "$got" = "$want" ]; then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1))
+    ERRORS="$ERRORS\nFAIL: $n\n  expected: $want\n  got:      $got"
+  fi
+}
+
+db_rm() { rm -f "$1" "${1}-wal"; }
+
+echo "=== Snapshot isolation contract (P6) ==="
+echo ""
+
+# ----------------------------------------------------------------
+# Contract 1: BEGIN ... COMMIT is repeatable-read across SELECTs
+# within the same connection, even when another connection
+# writes between them.
+# ----------------------------------------------------------------
+DB=/tmp/test_p6_repeat_$$.db; db_rm "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT); INSERT INTO t VALUES(1,10);" \
+  | $DOLTLITE "$DB" > /dev/null 2>&1
+
+OUTFILE=/tmp/test_p6_conn1_$$.out
+(
+  echo "BEGIN;"
+  echo "SELECT 'first:'||v FROM t WHERE id=1;"
+  sleep 2
+  echo "SELECT 'second:'||v FROM t WHERE id=1;"
+  echo "COMMIT;"
+) | $DOLTLITE "$DB" > "$OUTFILE" 2>&1 &
+PID=$!
+
+sleep 0.3
+# Another connection updates the value mid-flight.
+echo "UPDATE t SET v=99 WHERE id=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
+wait $PID
+
+first=$(grep '^first:' "$OUTFILE" | head -1)
+second=$(grep '^second:' "$OUTFILE" | head -1)
+
+run_test "begin_repeatable_first_select" "$first" "first:10"
+run_test "begin_repeatable_second_select" "$second" "second:10"
+# After the BEGIN-bracketed conn commits and we re-read, we
+# should see the value from conn2's update.
+post=$($DOLTLITE "$DB" "SELECT 'post:'||v FROM t WHERE id=1;" 2>/dev/null)
+run_test "begin_repeatable_post_visible" "$post" "post:99"
+rm -f "$OUTFILE"
+db_rm "$DB"
+
+# ----------------------------------------------------------------
+# Contract 2: Pure autocommit (no BEGIN) does NOT carry the
+# snapshot across statements.
+# ----------------------------------------------------------------
+DB=/tmp/test_p6_auto_$$.db; db_rm "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT); INSERT INTO t VALUES(1,10);" \
+  | $DOLTLITE "$DB" > /dev/null 2>&1
+
+OUTFILE=/tmp/test_p6_auto_conn1_$$.out
+(
+  echo "SELECT 'first:'||v FROM t WHERE id=1;"
+  sleep 1
+  echo "SELECT 'second:'||v FROM t WHERE id=1;"
+) | $DOLTLITE "$DB" > "$OUTFILE" 2>&1 &
+PID=$!
+
+sleep 0.3
+echo "UPDATE t SET v=42 WHERE id=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
+wait $PID
+
+first=$(grep '^first:' "$OUTFILE" | head -1)
+second=$(grep '^second:' "$OUTFILE" | head -1)
+run_test "autocommit_first_select" "$first" "first:10"
+run_test "autocommit_second_sees_update" "$second" "second:42"
+rm -f "$OUTFILE"
+db_rm "$DB"
+
+# ----------------------------------------------------------------
+# Contract 3: Multi-statement consistency inside a single
+# compound query (sub-selects). All sub-selects in one statement
+# must see the same snapshot.
+# ----------------------------------------------------------------
+DB=/tmp/test_p6_subq_$$.db; db_rm "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1,10),(2,20),(3,30);" \
+  | $DOLTLITE "$DB" > /dev/null 2>&1
+
+out=$($DOLTLITE "$DB" "SELECT
+  (SELECT v FROM t WHERE id=1) || ':' ||
+  (SELECT v FROM t WHERE id=2) || ':' ||
+  (SELECT sum(v) FROM t);" 2>&1)
+run_test "compound_query_consistent" "$out" "10:20:60"
+db_rm "$DB"
+
+# ----------------------------------------------------------------
+# Contract 4: ROLLBACK rolls back to the read-time snapshot —
+# the read transaction is not implicitly upgraded by mid-txn
+# reads.
+# ----------------------------------------------------------------
+DB=/tmp/test_p6_rollback_$$.db; db_rm "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v INT); INSERT INTO t VALUES(1,10);
+SELECT dolt_commit('-A','-m','c1');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+out=$(echo "BEGIN;
+SELECT v FROM t WHERE id=1;
+UPDATE t SET v=99 WHERE id=1;
+SELECT v FROM t WHERE id=1;
+ROLLBACK;
+SELECT v FROM t WHERE id=1;" | $DOLTLITE "$DB" 2>&1 | tr '\n' '|')
+run_test "rollback_to_pre_update" "$out" "10|99|10|"
+db_rm "$DB"
+
+echo ""
+if [ $FAIL -gt 0 ]; then
+  printf "$ERRORS\n"
+  echo "RESULTS: $PASS passed, $FAIL failed"
+  exit 1
+fi
+echo "RESULTS: $PASS passed, $FAIL failed"

--- a/test/run_doltlite_tests.sh
+++ b/test/run_doltlite_tests.sh
@@ -81,6 +81,7 @@ TESTS=(
   doltlite_comparison.sh
   doltlite_record_format.sh
   doltlite_schema_cookie.sh
+  doltlite_snapshot_isolation.sh
   doltlite_storage_locking.sh
   doltlite_unknown_table_cursor.sh
   doltlite_behavior.sh

--- a/test/run_doltlite_tests.sh
+++ b/test/run_doltlite_tests.sh
@@ -79,6 +79,7 @@ TESTS=(
   doltlite_arm_correctness.sh
   doltlite_open_sqlite_file.sh
   doltlite_comparison.sh
+  doltlite_pragma_auto_vacuum.sh
   doltlite_record_format.sh
   doltlite_schema_cookie.sh
   doltlite_snapshot_isolation.sh


### PR DESCRIPTION
## Summary
First slice of deep-review **P7**. Doltlite has no page layout, no allocator, and no concept of vacuum at the storage level. The PRAGMAs that operate on those things used to silently no-op, which let \`auto_vacuum=1\` appear to succeed and lulled users into expecting space reclamation that never happened.

## Behavior change

On **doltlite-format** databases:
| PRAGMA | Before | After |
|---|---|---|
| \`auto_vacuum;\` (read) | 0 | 0 (unchanged) |
| \`auto_vacuum = 0;\` | silently OK | silently OK (unchanged — already NONE) |
| \`auto_vacuum = 1\|2;\` | **silently OK** ← bug | error: "auto_vacuum is not supported on doltlite-format databases" |
| \`incremental_vacuum;\` | silently OK | runtime error |

On **stock-SQLite-format** databases opened via doltlite (orig route), the upstream semantics are preserved unchanged. The doltlite-specific error surfaces only when \`prollyBtreeSetAutoVacuum\` returns \`SQLITE_ERROR\`; the orig route's stock function returns whatever it would normally return (e.g. \`SQLITE_READONLY\` on a page-size-fixed db) and the pragma handler treats that exactly as upstream.

## Compatibility

Upstream sqlite testfixture cases that \`PRAGMA auto_vacuum=N\` on a doltlite-created database will fail. Those tests assume the rowid-paged storage model — a hard incompatibility with doltlite's prolly btree, not a bug. Failures will be added to \`test/known_testfixture_divergences.txt\` once CI surfaces the specific test labels.

## Test plan
- [x] \`bash test/doltlite_pragma_auto_vacuum.sh\` — 7/7 (new): doltlite-format reject; stock-format passthrough; orig-route doesn't leak the doltlite error message
- [x] \`bash test/run_doltlite_tests.sh\` — 57/57 suites
- [ ] CI testfixture — pending; will follow up with divergence-list updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)