### PR TITLE
fix(pragma): reject journal_mode change on doltlite-format

### DIFF
--- a/src/btree.c
+++ b/src/btree.c
@@ -3195,6 +3195,11 @@ int sqlite3BtreeSecureDelete(Btree *p, int newFlag){
 ** is disabled. The default value for the auto-vacuum property is
 ** determined by the SQLITE_DEFAULT_AUTOVACUUM macro.
 */
+int sqlite3BtreeIsDoltliteFormat(Btree *p){
+  (void)p;
+  return 0;
+}
+
 int sqlite3BtreeSetAutoVacuum(Btree *p, int autoVacuum){
 #ifdef SQLITE_OMIT_AUTOVACUUM
   return SQLITE_READONLY;

--- a/src/btree.h
+++ b/src/btree.h
@@ -78,6 +78,7 @@ int sqlite3BtreeGetRequestedReserve(Btree*);
 int sqlite3BtreeGetReserveNoMutex(Btree *p);
 int sqlite3BtreeSetAutoVacuum(Btree *, int);
 int sqlite3BtreeGetAutoVacuum(Btree *);
+int sqlite3BtreeIsDoltliteFormat(Btree *);
 int sqlite3BtreeBeginTrans(Btree*,int,int*);
 int sqlite3BtreeCommitPhaseOne(Btree*, const char*);
 int sqlite3BtreeCommitPhaseTwo(Btree*, int);

--- a/src/btree_orig_prefix.h
+++ b/src/btree_orig_prefix.h
@@ -62,6 +62,7 @@
 #define sqlite3BtreeIncrVacuum orig_sqlite3BtreeIncrVacuum
 #define sqlite3BtreeIndexMoveto orig_sqlite3BtreeIndexMoveto
 #define sqlite3BtreeInsert orig_sqlite3BtreeInsert
+#define sqlite3BtreeIsDoltliteFormat orig_sqlite3BtreeIsDoltliteFormat
 #define sqlite3BtreeIntegerKey orig_sqlite3BtreeIntegerKey
 #define sqlite3BtreeIntegrityCheck orig_sqlite3BtreeIntegrityCheck
 #define sqlite3BtreeIsEmpty orig_sqlite3BtreeIsEmpty

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -3936,6 +3936,10 @@ int sqlite3BtreeGetReserveNoMutex(Btree *p){
   return p->pOps->xGetReserveNoMutex(p);
 }
 
+int sqlite3BtreeIsDoltliteFormat(Btree *p){
+  return p && p->pOps==&prollyBtreeOps;
+}
+
 static int prollyBtreeSetAutoVacuum(Btree *p, int autoVacuum){
   (void)p;
   if( autoVacuum==BTREE_AUTOVACUUM_NONE ) return SQLITE_OK;

--- a/src/vdbe.c
+++ b/src/vdbe.c
@@ -8187,6 +8187,13 @@ case OP_JournalMode: {    /* out2 */
   assert( sqlite3BtreeHoldsMutex(pBt) );
   if( !sqlite3PagerOkToChangeJournalMode(pPager) ) eNew = eOld;
 
+  if( eNew!=eOld && sqlite3BtreeIsDoltliteFormat(pBt) ){
+    rc = SQLITE_ERROR;
+    sqlite3VdbeError(p,
+      "journal_mode is not configurable on doltlite-format databases");
+    goto abort_due_to_error;
+  }
+
 #ifndef SQLITE_OMIT_WAL
   zFilename = sqlite3PagerFilename(pPager, 1);
 

--- a/src/vdbe.c
+++ b/src/vdbe.c
@@ -8187,12 +8187,14 @@ case OP_JournalMode: {    /* out2 */
   assert( sqlite3BtreeHoldsMutex(pBt) );
   if( !sqlite3PagerOkToChangeJournalMode(pPager) ) eNew = eOld;
 
+#ifdef DOLTLITE_PROLLY
   if( eNew!=eOld && sqlite3BtreeIsDoltliteFormat(pBt) ){
     rc = SQLITE_ERROR;
     sqlite3VdbeError(p,
       "journal_mode is not configurable on doltlite-format databases");
     goto abort_due_to_error;
   }
+#endif
 
 #ifndef SQLITE_OMIT_WAL
   zFilename = sqlite3PagerFilename(pPager, 1);

--- a/test/doltlite_pragma_journal_mode.sh
+++ b/test/doltlite_pragma_journal_mode.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# P7 (journal_mode slice). Doltlite has no SQLite-style journal;
+# the chunk store has its own append-only WAL that's an implementation
+# detail of the prolly btree. `PRAGMA journal_mode = X` used to be
+# cosmetic — the value was recorded but did nothing. Reads always
+# returned WAL.
+#
+# Contract after this PR:
+#
+#   - PRAGMA journal_mode;            -> reads back WAL.
+#   - PRAGMA journal_mode = WAL;      -> idempotent OK (already WAL).
+#   - PRAGMA journal_mode = X;        -> error for X in
+#                                        {DELETE,TRUNCATE,PERSIST,MEMORY},
+#                                        on doltlite-format DBs.
+#   - PRAGMA journal_mode = OFF;      -> coerced to QUERY by SQLite's
+#                                        defensive-mode handler before
+#                                        our check; reads back WAL.
+#   - Stock-SQLite-format DBs:          unchanged; upstream semantics.
+
+DOLTLITE=./doltlite
+SQLITE3=$(command -v sqlite3 2>/dev/null || echo /usr/bin/sqlite3)
+PASS=0; FAIL=0; ERRORS=""
+
+run_test() {
+  local n="$1" got="$2" want="$3"
+  if [ "$got" = "$want" ]; then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1))
+    ERRORS="$ERRORS\nFAIL: $n\n  expected: $want\n  got:      $got"
+  fi
+}
+
+run_test_match() {
+  local n="$1" got="$2" pat="$3"
+  if echo "$got" | grep -qE "$pat"; then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1))
+    ERRORS="$ERRORS\nFAIL: $n\n  pattern: $pat\n  got:     $got"
+  fi
+}
+
+db_rm() { rm -f "$1" "${1}-wal"; }
+
+echo "=== PRAGMA journal_mode (doltlite-format) ==="
+echo ""
+
+DB=/tmp/test_jm_dl_$$.db; db_rm "$DB"
+$DOLTLITE "$DB" "CREATE TABLE t(id INTEGER PRIMARY KEY);" > /dev/null 2>&1
+
+run_test "jm_dl_read" \
+  "$($DOLTLITE "$DB" "PRAGMA journal_mode;" 2>&1)" "wal"
+
+# Idempotent: already WAL.
+run_test "jm_dl_set_wal" \
+  "$($DOLTLITE "$DB" "PRAGMA journal_mode = WAL;" 2>&1)" "wal"
+
+# Real mode change attempts: error.
+for mode in DELETE TRUNCATE PERSIST MEMORY; do
+  out=$($DOLTLITE "$DB" "PRAGMA journal_mode = $mode;" 2>&1)
+  run_test_match "jm_dl_set_${mode}_rejected" "$out" \
+    "journal_mode is not configurable on doltlite-format"
+done
+
+# OFF is coerced to QUERY by SQLite's defensive-mode handling
+# before the prolly check runs. Returns the current mode.
+out=$($DOLTLITE "$DB" "PRAGMA journal_mode = OFF;" 2>&1)
+run_test "jm_dl_set_off_defensive" "$out" "wal"
+
+db_rm "$DB"
+
+if [ -x "$SQLITE3" ]; then
+  echo ""
+  echo "--- stock-SQLite file via orig route ---"
+
+  DB=/tmp/test_jm_stock_$$.db; db_rm "$DB"
+  $SQLITE3 "$DB" "CREATE TABLE t(id INTEGER PRIMARY KEY);" > /dev/null 2>&1
+
+  # Stock SQLite delete-mode database. Doltlite routes through
+  # the orig engine; the upstream journal_mode behavior applies.
+  run_test "jm_stock_read" \
+    "$($DOLTLITE "$DB" "PRAGMA journal_mode;" 2>&1)" "delete"
+
+  # Stock allows mode change via the upstream path; the doltlite
+  # error must not leak into this code path.
+  out=$($DOLTLITE "$DB" "PRAGMA journal_mode = DELETE;" 2>&1)
+  if echo "$out" | grep -qi "doltlite-format"; then
+    FAIL=$((FAIL+1))
+    ERRORS="$ERRORS\nFAIL: jm_stock_no_doltlite_msg_leaked\n  got: $out"
+  else
+    PASS=$((PASS+1))
+  fi
+
+  db_rm "$DB"
+fi
+
+echo ""
+if [ $FAIL -gt 0 ]; then
+  printf "$ERRORS\n"
+  echo "RESULTS: $PASS passed, $FAIL failed"
+  exit 1
+fi
+echo "RESULTS: $PASS passed, $FAIL failed"

--- a/test/run_doltlite_tests.sh
+++ b/test/run_doltlite_tests.sh
@@ -80,6 +80,7 @@ TESTS=(
   doltlite_open_sqlite_file.sh
   doltlite_comparison.sh
   doltlite_pragma_auto_vacuum.sh
+  doltlite_pragma_journal_mode.sh
   doltlite_record_format.sh
   doltlite_schema_cookie.sh
   doltlite_snapshot_isolation.sh


### PR DESCRIPTION
## Summary
Second slice of deep-review **P7**, mirroring the auto_vacuum reject landed in #964.

Doltlite reports WAL as its journal mode because that's the closest upstream analogue for "the chunk store has its own append-only WAL for recovery". The SQLite-level journal mode is not configurable — there is no SQLite journal to switch into a different mode. Prior behavior: \`PRAGMA journal_mode = X\` for any X silently recorded the value and reads returned WAL anyway. Misleading.

## Behavior change

On **doltlite-format** databases:

| PRAGMA | Before | After |
|---|---|---|
| \`journal_mode;\` (read) | wal | wal (unchanged) |
| \`journal_mode = WAL;\` | wal | wal (idempotent OK, unchanged) |
| \`journal_mode = DELETE\|TRUNCATE\|PERSIST\|MEMORY;\` | **silently OK** ← bug | error: "journal_mode is not configurable on doltlite-format databases" |
| \`journal_mode = OFF;\` | wal | wal (SQLite's defensive-mode handler coerces OFF→QUERY before the prolly check runs) |

On **stock-SQLite-format** databases via the orig route the upstream journal_mode behavior is preserved. The doltlite error message does not leak: \`sqlite3BtreeIsDoltliteFormat(pBt)\` returns 0 when pBt is routed to the renamed-orig engine.

## Implementation
- New helper \`sqlite3BtreeIsDoltliteFormat(Btree*)\` in \`prolly_btree.c\` returns 1 when \`pBt->pOps == &prollyBtreeOps\`. Declared in \`btree.h\` next to the other Btree accessors.
- \`OP_JournalMode\` (\`vdbe.c\`) checks after the standard QUERY and OkToChange normalization: if \`eNew != eOld\` AND \`sqlite3BtreeIsDoltliteFormat(pBt)\`, emit the doltlite-specific error via \`sqlite3VdbeError\` and abort.

## Compatibility
Same trade-off as #964 — upstream sqlite testfixture cases that \`PRAGMA journal_mode = X\` (X != WAL) on a doltlite-created database will fail. Those tests are an intentional divergence; failures get added to \`test/known_testfixture_divergences.txt\` once CI surfaces the specific test labels.

## Test plan
- [x] \`bash test/doltlite_pragma_journal_mode.sh\` — 9/9 (new): doltlite-format reject for DELETE/TRUNCATE/PERSIST/MEMORY; idempotent set=WAL; stock-format passthrough; doltlite error doesn't leak into orig route
- [x] \`bash test/run_doltlite_tests.sh\` — 58/58 suites
- [ ] CI testfixture — pending; will follow up with divergence-list updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)