### PR TITLE
fix(pragma): real page_count + reject wal_checkpoint mode args on doltlite-format

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -3903,7 +3903,16 @@ Pgno sqlite3BtreeMaxPageCount(Btree *p, Pgno mxPage){
 }
 
 static Pgno prollyBtreeLastPage(Btree *p){
-  return p->cat.iNextTable + 1000;
+  ChunkStore *cs;
+  i64 n;
+  if( !p || !p->pBt ) return 0;
+  cs = &p->pBt->store;
+  n = (i64)chunkIndexCount(&cs->index)
+    + (i64)chunkStagingPendingCount(&cs->staging)
+    + (i64)chunkStagingRecentCount(&cs->staging);
+  if( n < 0 ) n = 0;
+  if( n > (i64)0xfffffffe ) n = (i64)0xfffffffe;
+  return (Pgno)n;
 }
 Pgno sqlite3BtreeLastPage(Btree *p){
   return p->pOps->xLastPage(p);

--- a/src/vdbe.c
+++ b/src/vdbe.c
@@ -8133,6 +8133,21 @@ case OP_Checkpoint: {
        || pOp->p2==SQLITE_CHECKPOINT_TRUNCATE
        || pOp->p2==SQLITE_CHECKPOINT_NOOP
   );
+#ifdef DOLTLITE_PROLLY
+  if( pOp->p2!=SQLITE_CHECKPOINT_PASSIVE ){
+    int iDb;
+    for(iDb=0; iDb<db->nDb; iDb++){
+      if( (pOp->p1==iDb || pOp->p1==SQLITE_MAX_DB)
+       && sqlite3BtreeIsDoltliteFormat(db->aDb[iDb].pBt) ){
+        rc = SQLITE_ERROR;
+        sqlite3VdbeError(p,
+          "wal_checkpoint mode is not configurable on doltlite-format "
+          "databases; use the default (PASSIVE) form");
+        goto abort_due_to_error;
+      }
+    }
+  }
+#endif
   rc = sqlite3Checkpoint(db, pOp->p1, pOp->p2, &aRes[1], &aRes[2]);
   if( rc ){
     if( rc!=SQLITE_BUSY ) goto abort_due_to_error;

--- a/test/doltlite_pragma_page_count.sh
+++ b/test/doltlite_pragma_page_count.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+# P7 (page_count slice). Doltlite has no page concept at storage —
+# the file is a content-addressed chunk store. The legacy
+# `PRAGMA page_count` was hardcoded to `iNextTable + 1000`, which
+# is a function of how many user tables have been created (not the
+# database's actual storage footprint), plus a fixed offset.
+#
+# After this PR, `PRAGMA page_count` returns the total chunk count
+# (index + pending + recent) — the honest measure of "how many
+# chunks are in the store right now".
+#
+# Numbers are NOT directly comparable to stock SQLite's page_count
+# (chunks are variable size, content-addressed). They are a coarse
+# proxy for storage footprint.
+
+DOLTLITE=./doltlite
+PASS=0; FAIL=0; ERRORS=""
+
+run_test_int_ge() {
+  local n="$1" got="$2" floor="$3"
+  if [ -n "$got" ] && [ "$got" -ge "$floor" ] 2>/dev/null; then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1))
+    ERRORS="$ERRORS\nFAIL: $n\n  expected: >= $floor\n  got:      $got"
+  fi
+}
+
+run_test_int_in() {
+  local n="$1" got="$2" lo="$3" hi="$4"
+  if [ -n "$got" ] && [ "$got" -ge "$lo" ] 2>/dev/null && [ "$got" -le "$hi" ] 2>/dev/null; then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1))
+    ERRORS="$ERRORS\nFAIL: $n\n  expected: in [$lo, $hi]\n  got:      $got"
+  fi
+}
+
+run_test_grows() {
+  local n="$1" before="$2" after="$3"
+  if [ -n "$before" ] && [ -n "$after" ] && [ "$after" -gt "$before" ] 2>/dev/null; then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1))
+    ERRORS="$ERRORS\nFAIL: $n\n  before: $before, after: $after"
+  fi
+}
+
+db_rm() { rm -f "$1" "${1}-wal"; }
+
+echo "=== PRAGMA page_count (chunk count) ==="
+echo ""
+
+# Empty doltlite-format DB: at least a few bookkeeping chunks.
+DB=/tmp/test_pc_empty_$$.db; db_rm "$DB"
+$DOLTLITE "$DB" "SELECT 1;" > /dev/null 2>&1
+empty_pc=$($DOLTLITE "$DB" "PRAGMA page_count;" 2>&1 | tr -d '\n')
+run_test_int_in "pc_empty_db_small_positive" "$empty_pc" 1 100
+db_rm "$DB"
+
+# Database with one small table and one commit: grows.
+DB=/tmp/test_pc_small_$$.db; db_rm "$DB"
+$DOLTLITE "$DB" "SELECT 1;" > /dev/null 2>&1
+pre=$($DOLTLITE "$DB" "PRAGMA page_count;" 2>&1 | tr -d '\n')
+$DOLTLITE "$DB" "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a'),(2,'b'),(3,'c');
+SELECT dolt_commit('-A','-m','c1');" > /dev/null 2>&1
+post=$($DOLTLITE "$DB" "PRAGMA page_count;" 2>&1 | tr -d '\n')
+run_test_grows "pc_grows_with_data" "$pre" "$post"
+db_rm "$DB"
+
+# Large insert: chunk count grows further.
+DB=/tmp/test_pc_large_$$.db; db_rm "$DB"
+$DOLTLITE "$DB" "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_commit('-A','-m','seed');" > /dev/null 2>&1
+small=$($DOLTLITE "$DB" "PRAGMA page_count;" 2>&1 | tr -d '\n')
+
+{
+  echo "BEGIN;"
+  for i in $(seq 2 1000); do
+    echo "INSERT INTO t VALUES($i,'row_$i');"
+  done
+  echo "COMMIT;"
+  echo "SELECT dolt_commit('-A','-m','bulk');"
+} | $DOLTLITE "$DB" > /dev/null 2>&1
+
+big=$($DOLTLITE "$DB" "PRAGMA page_count;" 2>&1 | tr -d '\n')
+run_test_grows "pc_grows_with_bulk_insert" "$small" "$big"
+
+# Should be well below the legacy fabricated value of iNextTable+1000.
+# With one user table, the legacy value would have been ~1002; the
+# real chunk count is much smaller (low tens).
+run_test_int_in "pc_not_fabricated_value" "$big" 1 200
+db_rm "$DB"
+
+echo ""
+if [ $FAIL -gt 0 ]; then
+  printf "$ERRORS\n"
+  echo "RESULTS: $PASS passed, $FAIL failed"
+  exit 1
+fi
+echo "RESULTS: $PASS passed, $FAIL failed"

--- a/test/doltlite_pragma_wal_checkpoint.sh
+++ b/test/doltlite_pragma_wal_checkpoint.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# P7 (wal_checkpoint slice). The SQLite checkpoint mode arg
+# (PASSIVE / FULL / RESTART / TRUNCATE) describes blocking behavior
+# and post-checkpoint WAL state. Doltlite's GC is closest to
+# TRUNCATE — it blocks all readers and writers via the chunk-store
+# lock, sweeps unreachable chunks, and atomically rewrites the file
+# so the WAL section is compacted into the index.
+#
+# But aliasing TRUNCATE to GC silently is misleading: a user asking
+# for PASSIVE explicitly does not want a stop-the-world operation.
+# So this PR rejects every non-default mode and keeps the default
+# (PASSIVE) as the existing no-op.
+#
+# Contract after this PR (doltlite-format DBs):
+#   - PRAGMA wal_checkpoint;             -> default; current no-op,
+#                                            returns "0|0|0".
+#   - PRAGMA wal_checkpoint(PASSIVE);    -> same; explicit PASSIVE
+#                                            is allowed because it
+#                                            matches the default.
+#   - PRAGMA wal_checkpoint(FULL|RESTART|TRUNCATE|NOOP)
+#                                        -> ERROR: "use the default
+#                                            (PASSIVE) form".
+#   - Users who want a full sweep should call SELECT dolt_gc().
+#
+# Stock-SQLite-format DBs via the orig route keep upstream
+# semantics unchanged.
+
+DOLTLITE=./doltlite
+SQLITE3=$(command -v sqlite3 2>/dev/null || echo /usr/bin/sqlite3)
+PASS=0; FAIL=0; ERRORS=""
+
+run_test_match() {
+  local n="$1" got="$2" pat="$3"
+  if echo "$got" | grep -qE "$pat"; then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1))
+    ERRORS="$ERRORS\nFAIL: $n\n  pattern: $pat\n  got:     $got"
+  fi
+}
+
+run_test_eq() {
+  local n="$1" got="$2" want="$3"
+  if [ "$got" = "$want" ]; then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1))
+    ERRORS="$ERRORS\nFAIL: $n\n  expected: $want\n  got:      $got"
+  fi
+}
+
+db_rm() { rm -f "$1" "${1}-wal"; }
+
+echo "=== PRAGMA wal_checkpoint (doltlite-format) ==="
+echo ""
+
+DB=/tmp/test_wc_dl_$$.db; db_rm "$DB"
+$DOLTLITE "$DB" "CREATE TABLE t(id INTEGER PRIMARY KEY);" > /dev/null 2>&1
+
+# Default form is allowed.
+run_test_eq "wc_dl_default" \
+  "$($DOLTLITE "$DB" "PRAGMA wal_checkpoint;" 2>&1)" "0|0|0"
+
+# Explicit PASSIVE is allowed.
+run_test_eq "wc_dl_passive_explicit" \
+  "$($DOLTLITE "$DB" "PRAGMA wal_checkpoint(PASSIVE);" 2>&1)" "0|0|0"
+
+# Other modes reject.
+for mode in FULL RESTART TRUNCATE; do
+  out=$($DOLTLITE "$DB" "PRAGMA wal_checkpoint($mode);" 2>&1)
+  run_test_match "wc_dl_${mode}_rejected" "$out" \
+    "wal_checkpoint mode is not configurable on doltlite-format"
+done
+
+db_rm "$DB"
+
+if [ -x "$SQLITE3" ]; then
+  echo ""
+  echo "--- stock-SQLite file via orig route ---"
+
+  DB=/tmp/test_wc_stock_$$.db; db_rm "$DB"
+  $SQLITE3 "$DB" "CREATE TABLE t(id INTEGER PRIMARY KEY);" > /dev/null 2>&1
+
+  # Stock-format files reach the orig route; the doltlite check
+  # does not fire. PRAGMA wal_checkpoint(FULL) should not surface
+  # the doltlite-specific message.
+  out=$($DOLTLITE "$DB" "PRAGMA wal_checkpoint(FULL);" 2>&1)
+  if echo "$out" | grep -qi "doltlite-format"; then
+    FAIL=$((FAIL+1))
+    ERRORS="$ERRORS\nFAIL: wc_stock_no_doltlite_msg_leaked\n  got: $out"
+  else
+    PASS=$((PASS+1))
+  fi
+
+  db_rm "$DB"
+fi
+
+echo ""
+if [ $FAIL -gt 0 ]; then
+  printf "$ERRORS\n"
+  echo "RESULTS: $PASS passed, $FAIL failed"
+  exit 1
+fi
+echo "RESULTS: $PASS passed, $FAIL failed"

--- a/test/run_doltlite_tests.sh
+++ b/test/run_doltlite_tests.sh
@@ -80,6 +80,7 @@ TESTS=(
   doltlite_open_sqlite_file.sh
   doltlite_comparison.sh
   doltlite_pragma_auto_vacuum.sh
+  doltlite_pragma_page_count.sh
   doltlite_record_format.sh
   doltlite_schema_cookie.sh
   doltlite_snapshot_isolation.sh

--- a/test/run_doltlite_tests.sh
+++ b/test/run_doltlite_tests.sh
@@ -82,6 +82,7 @@ TESTS=(
   doltlite_pragma_auto_vacuum.sh
   doltlite_pragma_journal_mode.sh
   doltlite_pragma_page_count.sh
+  doltlite_pragma_wal_checkpoint.sh
   doltlite_record_format.sh
   doltlite_schema_cookie.sh
   doltlite_snapshot_isolation.sh


### PR DESCRIPTION
## Summary
Two P7 slices in one PR (the merge of #965 brought in the shared \`sqlite3BtreeIsDoltliteFormat\` plumbing this branch needs for the wal_checkpoint check).

### page_count returns the real chunk count
\`prollyBtreeLastPage\` used to return \`p->cat.iNextTable + 1000\` — a fictional value derived from how many user tables existed plus a fixed offset. \`PRAGMA page_count\` consumed this via \`OP_Pagecount\`.

Now returns \`chunkIndexCount + chunkStagingPendingCount + chunkStagingRecentCount\` — the honest "how many chunks are in the store right now". Clamped to \`[0, 0xfffffffe]\` to fit \`Pgno\` (u32).

| Scenario | Before | After |
|---|---|---|
| Empty DB | ~1001 | ~4 |
| 1 table, 1 row, 1 commit | ~1003 | ~16 |
| 1 table, 1000 rows, 1 commit | ~1003 | ~29 |

### wal_checkpoint rejects non-default modes
SQLite's checkpoint mode arg describes blocking semantics and post-checkpoint WAL state. Doltlite's closest analog is TRUNCATE — GC stop-the-worlds via the chunk-store lock, sweeps unreachable chunks, and atomically rewrites the file with the WAL section compacted into the index.

Silently aliasing TRUNCATE to GC misleads — a caller asking for PASSIVE explicitly does not want a stop-the-world operation. So reject every non-default mode; keep the default (PASSIVE) as the existing no-op. Users who want a full sweep call \`dolt_gc()\`.

| Mode | Before | After |
|---|---|---|
| \`wal_checkpoint;\` (default = PASSIVE) | no-op, returns 0\|0\|0 | unchanged |
| \`wal_checkpoint(PASSIVE);\` | no-op | unchanged |
| \`wal_checkpoint(FULL\|RESTART\|TRUNCATE);\` | silently 0\|0\|0 | error |

Stock-SQLite-format DBs via the orig route keep upstream semantics unchanged for both fixes (the doltlite check is gated on \`sqlite3BtreeIsDoltliteFormat\`).

## Test plan
- [x] \`bash test/doltlite_pragma_page_count.sh\` — 4/4 (new): empty DB small positive; grows with inserts; stays below legacy fabricated ~1002
- [x] \`bash test/doltlite_pragma_wal_checkpoint.sh\` — 6/6 (new): doltlite-format default + explicit PASSIVE OK; FULL/RESTART/TRUNCATE reject; stock-format doesn't leak error message
- [x] \`bash test/run_doltlite_tests.sh\` — 60/60 suites
- [ ] CI testfixture — pending; will follow up with divergence-list updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)