### PR TITLE
fix(pragma): :memory: reports journal_mode=memory, not wal

### DIFF
--- a/src/pager_shim.c
+++ b/src/pager_shim.c
@@ -337,8 +337,10 @@ static int shimPagerWalSupported(Pager *p){
   (void)p; return 1;
 }
 static int shimPagerOpenWal(Pager *p, int *pisOpen){
-  SHIM(p)->journalMode = PAGER_JOURNALMODE_WAL;
-  if( pisOpen ) *pisOpen = 1;
+  if( !shimPagerIsMemdb(p) ){
+    SHIM(p)->journalMode = PAGER_JOURNALMODE_WAL;
+  }
+  if( pisOpen ) *pisOpen = (SHIM(p)->journalMode==PAGER_JOURNALMODE_WAL);
   return SQLITE_OK;
 }
 static int shimPagerCloseWal(Pager *p, sqlite3 *db){
@@ -498,7 +500,12 @@ PagerShim *pagerShimCreate(
   }
   pShim->pFd          = pFd;
   pShim->pVfs         = pVfs;
-  pShim->journalMode  = PAGER_JOURNALMODE_WAL;
+  if( pShim->zFilename[0]=='\0'
+   || strcmp(pShim->zFilename, ":memory:")==0 ){
+    pShim->journalMode = PAGER_JOURNALMODE_MEMORY;
+  }else{
+    pShim->journalMode = PAGER_JOURNALMODE_WAL;
+  }
   pShim->eLock        = 0;
   pShim->iDataVersion = 1;
 

--- a/test/doltlite_pragma_memory_journal_mode.sh
+++ b/test/doltlite_pragma_memory_journal_mode.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# P7 (final slice). PagerShim used to initialize journalMode to WAL
+# unconditionally and shimPagerOpenWal promoted to WAL on every
+# call. As a result, `PRAGMA journal_mode` on a `:memory:` database
+# reported "wal" even though there's no WAL file (and can't be one
+# for memdbs).
+#
+# After this PR:
+#   - File-backed doltlite DBs report "wal" (unchanged).
+#   - `:memory:` DBs report "memory" — matches stock SQLite.
+#   - Setting journal_mode = MEMORY on a memdb is idempotent OK.
+#   - Setting journal_mode = WAL on a memdb is rejected by SQLite's
+#     existing OP_JournalMode WAL-transition check (empty filename
+#     coerces eNew to eOld silently); the doltlite reject doesn't
+#     fire because eNew ends up equal to eOld.
+#
+# This closes out the P7 cluster.
+
+DOLTLITE=./doltlite
+PASS=0; FAIL=0; ERRORS=""
+
+run_test_eq() {
+  local n="$1" got="$2" want="$3"
+  if [ "$got" = "$want" ]; then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1))
+    ERRORS="$ERRORS\nFAIL: $n\n  expected: $want\n  got:      $got"
+  fi
+}
+
+db_rm() { rm -f "$1" "${1}-wal"; }
+
+echo "=== PRAGMA journal_mode on :memory: ==="
+echo ""
+
+# :memory: reports memory, not wal.
+run_test_eq "mem_journal_mode_is_memory" \
+  "$($DOLTLITE ":memory:" "PRAGMA journal_mode;" 2>&1)" "memory"
+
+# Idempotent set to current.
+run_test_eq "mem_set_memory_idempotent" \
+  "$($DOLTLITE ":memory:" "PRAGMA journal_mode = MEMORY;" 2>&1)" "memory"
+
+# File-backed DB still reports wal (regression guard).
+DB=/tmp/test_mwjm_file_$$.db; db_rm "$DB"
+$DOLTLITE "$DB" "CREATE TABLE t(id INTEGER PRIMARY KEY);" > /dev/null 2>&1
+run_test_eq "file_journal_mode_is_wal" \
+  "$($DOLTLITE "$DB" "PRAGMA journal_mode;" 2>&1)" "wal"
+db_rm "$DB"
+
+echo ""
+if [ $FAIL -gt 0 ]; then
+  printf "$ERRORS\n"
+  echo "RESULTS: $PASS passed, $FAIL failed"
+  exit 1
+fi
+echo "RESULTS: $PASS passed, $FAIL failed"

--- a/test/run_doltlite_tests.sh
+++ b/test/run_doltlite_tests.sh
@@ -81,6 +81,7 @@ TESTS=(
   doltlite_comparison.sh
   doltlite_pragma_auto_vacuum.sh
   doltlite_pragma_journal_mode.sh
+  doltlite_pragma_memory_journal_mode.sh
   doltlite_record_format.sh
   doltlite_schema_cookie.sh
   doltlite_snapshot_isolation.sh


### PR DESCRIPTION
## Summary
Final P7 slice. PagerShim used to initialize \`journalMode\` to \`PAGER_JOURNALMODE_WAL\` unconditionally, and \`shimPagerOpenWal\` promoted to WAL on every call. \`PRAGMA journal_mode\` on a \`:memory:\` database reported "wal" even though there's no WAL file and can't be one for memdbs.

## Behavior change

| DB | Before | After |
|---|---|---|
| File-backed doltlite | wal | wal (unchanged) |
| \`:memory:\` doltlite | wal | memory |

Empty-filename DBs (\`sqlite3_open("")\`) still take the upstream temp-file route and report whatever stock SQLite reports ("delete" by default).

## Implementation
- \`pagerShimCreate\` picks the initial mode based on filename: empty or \`:memory:\` → MEMORY; otherwise WAL.
- \`shimPagerOpenWal\` only promotes to WAL when not a memdb, matching stock SQLite's \`sqlite3PagerOpenWal\` which won't open WAL on a memdb either. \`pisOpen\` reflects the actual state.

The journal_mode reject from #965 still applies: trying to \`PRAGMA journal_mode = WAL\` on a memdb hits SQLite's existing WAL-transition check (empty filename + WAL is silently coerced to current mode before the doltlite reject sees a real change), so no error message.

## Test plan
- [x] \`bash test/doltlite_pragma_memory_journal_mode.sh\` — 3/3 (new): \`:memory:\` reports "memory"; idempotent set; file-backed DB still reports "wal"
- [x] \`bash test/run_doltlite_tests.sh\` — 59/59 suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)