### PR TITLE
fix(merge,remote): two Tier-4 corners from the deep review (F3 + F7)

### DIFF
--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -621,6 +621,7 @@ static int canFastMerge(
 ){
   Table *pTab;
   FKey *pFK;
+  int i;
 
   if( !schemaUnchangedBothSides ) return 0;
   if( !zName || !db ) return 0;
@@ -630,6 +631,12 @@ static int canFastMerge(
 
   if( pTab->pIndex ) return 0;
   if( pTab->pCheck && pTab->pCheck->nExpr>0 ) return 0;
+
+  for(i=0; i<pTab->nCol; i++){
+    Column *pCol = &pTab->aCol[i];
+    if( (pCol->colFlags & COLFLAG_PRIMKEY)!=0 ) continue;
+    if( pCol->notNull!=OE_None ) return 0;
+  }
 
   for(pFK=pTab->u.tab.pFKey; pFK; pFK=pFK->pNextFrom){
     if( pFK->aAction[0]!=OE_None || pFK->aAction[1]!=OE_None ) return 0;

--- a/src/doltlite_remote.c
+++ b/src/doltlite_remote.c
@@ -247,11 +247,6 @@ int doltliteSyncChunks(
       }
 
       rc = pSrc->xGetChunk(pSrc, &aBatch[i], &data, &nData);
-      if( rc==SQLITE_NOTFOUND ){
-
-        rc = SQLITE_OK;
-        continue;
-      }
       if( rc!=SQLITE_OK ) break;
 
       rc = pDst->xPutChunk(pDst, &aBatch[i], data, nData);

--- a/src/doltlite_status.c
+++ b/src/doltlite_status.c
@@ -447,30 +447,6 @@ static int compareCatalogs(
         && prollyHashCompare(&pFrom->schemaHash, &aTo[i].schemaHash)!=0;
       rc = SQLITE_OK;
       if( bRootChanged || bSchemaChanged ){
-        if( staged==0 ){
-          int ignored = 0;
-          char *zIgnErr = 0;
-          int irc = doltliteCheckIgnore(db, zName, &ignored, &zIgnErr);
-          if( irc==SQLITE_CONSTRAINT ){
-            if( pCur->base.pVtab->zErrMsg ){
-              sqlite3_free(pCur->base.pVtab->zErrMsg);
-            }
-            pCur->base.pVtab->zErrMsg = zIgnErr;
-            sqlite3_free(zName);
-            rc = SQLITE_ERROR;
-            goto compare_done;
-          }
-          if( irc!=SQLITE_OK ){
-            sqlite3_free(zIgnErr);
-            sqlite3_free(zName);
-            rc = irc;
-            goto compare_done;
-          }
-          if( ignored ){
-            sqlite3_free(zName);
-            continue;
-          }
-        }
         rc = addRow(pCur, zName, staged, "modified");
       }
     }

--- a/src/doltlite_status.c
+++ b/src/doltlite_status.c
@@ -447,6 +447,30 @@ static int compareCatalogs(
         && prollyHashCompare(&pFrom->schemaHash, &aTo[i].schemaHash)!=0;
       rc = SQLITE_OK;
       if( bRootChanged || bSchemaChanged ){
+        if( staged==0 ){
+          int ignored = 0;
+          char *zIgnErr = 0;
+          int irc = doltliteCheckIgnore(db, zName, &ignored, &zIgnErr);
+          if( irc==SQLITE_CONSTRAINT ){
+            if( pCur->base.pVtab->zErrMsg ){
+              sqlite3_free(pCur->base.pVtab->zErrMsg);
+            }
+            pCur->base.pVtab->zErrMsg = zIgnErr;
+            sqlite3_free(zName);
+            rc = SQLITE_ERROR;
+            goto compare_done;
+          }
+          if( irc!=SQLITE_OK ){
+            sqlite3_free(zIgnErr);
+            sqlite3_free(zName);
+            rc = irc;
+            goto compare_done;
+          }
+          if( ignored ){
+            sqlite3_free(zName);
+            continue;
+          }
+        }
         rc = addRow(pCur, zName, staged, "modified");
       }
     }

--- a/test/doltlite_merge_ignore_corners.sh
+++ b/test/doltlite_merge_ignore_corners.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# Merge / ignore corner cases from the deep review (Tier 4):
+#
+# F3 - canFastMerge skipped NOT NULL guard. Fast path could land
+#      NULL values into NOT NULL columns silently. Now bails on
+#      any non-PK column with NOT NULL.
+# F7 - doltliteSyncChunks swallowed SQLITE_NOTFOUND from
+#      pSrc->xGetChunk during push, masking missing local chunks.
+#      Now propagates the error. (Push code path; exercised
+#      indirectly via remote tests; pinned by smoke here only.)
+# F8 - Ignore semantics applied only to new tables; modifications
+#      to ignored tables were unconditionally reported in
+#      dolt_status. Now also consulted in the modified branch.
+
+DOLTLITE=./doltlite
+PASS=0; FAIL=0; ERRORS=""
+
+run_test_eq() {
+  local n="$1" got="$2" want="$3"
+  if [ "$got" = "$want" ]; then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1))
+    ERRORS="$ERRORS\nFAIL: $n\n  expected: $want\n  got:      $got"
+  fi
+}
+
+run_test_match() {
+  local n="$1" got="$2" pat="$3"
+  if echo "$got" | grep -qE "$pat"; then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1))
+    ERRORS="$ERRORS\nFAIL: $n\n  pattern: $pat\n  got:     $got"
+  fi
+}
+
+db_rm() { rm -f "$1" "${1}-wal"; }
+
+echo "=== Merge / ignore corner cases (F3 / F7 / F8) ==="
+echo ""
+
+# ----------------------------------------------------------------
+# F3 - NOT NULL is now part of canFastMerge's bail-out set.
+# Build a table with a NOT NULL column, fork two branches that
+# both modify rows, then merge. Without the fix the fast-merge
+# might silently write NULL; with the fix the slow-merge path
+# runs and constraint violations surface as conflicts.
+# ----------------------------------------------------------------
+DB=/tmp/test_t4_nn_$$.db; db_rm "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, label TEXT NOT NULL, v INTEGER);
+INSERT INTO t VALUES(1, 'a', 10);
+INSERT INTO t VALUES(2, 'b', 20);
+SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+# Branch divergent updates. Both branches change different rows.
+echo "SELECT dolt_branch('feat');
+UPDATE t SET v=11 WHERE id=1;
+SELECT dolt_commit('-A','-m','main_change');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+echo "SELECT dolt_checkout('feat');
+UPDATE t SET v=22 WHERE id=2;
+SELECT dolt_commit('-A','-m','feat_change');
+SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+# Merge: should succeed (no conflict — different rows changed).
+# The merge MUST go through the slow path now (since t has a
+# NOT NULL column). End state: both updates visible.
+run_test_match "f3_merge_with_notnull_succeeds" \
+  "$($DOLTLITE "$DB" "SELECT dolt_merge('feat');" 2>&1)" "^[0-9a-f]{40}$"
+run_test_eq "f3_main_change_visible" \
+  "$($DOLTLITE "$DB" "SELECT v FROM t WHERE id=1;" 2>&1)" "11"
+run_test_eq "f3_feat_change_visible" \
+  "$($DOLTLITE "$DB" "SELECT v FROM t WHERE id=2;" 2>&1)" "22"
+db_rm "$DB"
+
+# ----------------------------------------------------------------
+# F8 - Ignore on modified tables. Mark a table as ignored, modify
+# a row, run dolt_status; the row change should NOT appear.
+# Pinning by user-facing dolt_status output.
+# ----------------------------------------------------------------
+DB=/tmp/test_t4_ign_$$.db; db_rm "$DB"
+echo "CREATE TABLE keep_me(id INTEGER PRIMARY KEY, v TEXT);
+CREATE TABLE temp_log(id INTEGER PRIMARY KEY, msg TEXT);
+CREATE TABLE dolt_ignore(pattern TEXT NOT NULL, ignored TINYINT NOT NULL, PRIMARY KEY(pattern));
+INSERT INTO keep_me VALUES(1,'first');
+INSERT INTO temp_log VALUES(1,'noise');
+INSERT INTO dolt_ignore VALUES('temp_log', 1);
+SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+# Modify the ignored table.
+echo "INSERT INTO temp_log VALUES(2,'more noise');
+UPDATE temp_log SET msg='changed' WHERE id=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+# dolt_status should NOT list temp_log among modified tables.
+out=$($DOLTLITE "$DB" "SELECT table_name FROM dolt_status;" 2>&1)
+if echo "$out" | grep -q "temp_log"; then
+  FAIL=$((FAIL+1))
+  ERRORS="$ERRORS\nFAIL: f8_modified_ignored_not_reported\n  got rows: $out"
+else
+  PASS=$((PASS+1))
+fi
+
+# Sanity: modifying a non-ignored table should still appear.
+echo "INSERT INTO keep_me VALUES(2,'second');" | $DOLTLITE "$DB" > /dev/null 2>&1
+run_test_match "f8_modified_tracked_table_reported" \
+  "$($DOLTLITE "$DB" "SELECT table_name FROM dolt_status;" 2>&1)" \
+  "keep_me"
+
+db_rm "$DB"
+
+echo ""
+if [ $FAIL -gt 0 ]; then
+  printf "$ERRORS\n"
+  echo "RESULTS: $PASS passed, $FAIL failed"
+  exit 1
+fi
+echo "RESULTS: $PASS passed, $FAIL failed"

--- a/test/doltlite_merge_ignore_corners.sh
+++ b/test/doltlite_merge_ignore_corners.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Merge / ignore corner cases from the deep review (Tier 4):
+# Merge / push corner cases from the deep review (Tier 4):
 #
 # F3 - canFastMerge skipped NOT NULL guard. Fast path could land
 #      NULL values into NOT NULL columns silently. Now bails on
@@ -8,9 +8,11 @@
 #      pSrc->xGetChunk during push, masking missing local chunks.
 #      Now propagates the error. (Push code path; exercised
 #      indirectly via remote tests; pinned by smoke here only.)
-# F8 - Ignore semantics applied only to new tables; modifications
-#      to ignored tables were unconditionally reported in
-#      dolt_status. Now also consulted in the modified branch.
+#
+# F8 (also in the deep review's Tier 4) was investigated and
+# REJECTED — Dolt's behavior is "ignore only gates new tables;
+# tracked-table modifications still show in dolt_status". The
+# vc_oracle_ignore_test.sh oracle pins the parity. F8 stays as-is.
 
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
@@ -37,7 +39,7 @@ run_test_match() {
 
 db_rm() { rm -f "$1" "${1}-wal"; }
 
-echo "=== Merge / ignore corner cases (F3 / F7 / F8) ==="
+echo "=== Merge / push corner cases (F3 / F7) ==="
 echo ""
 
 # ----------------------------------------------------------------
@@ -63,7 +65,7 @@ UPDATE t SET v=22 WHERE id=2;
 SELECT dolt_commit('-A','-m','feat_change');
 SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
-# Merge: should succeed (no conflict — different rows changed).
+# Merge: should succeed (no conflict - different rows changed).
 # The merge MUST go through the slow path now (since t has a
 # NOT NULL column). End state: both updates visible.
 run_test_match "f3_merge_with_notnull_succeeds" \
@@ -72,41 +74,6 @@ run_test_eq "f3_main_change_visible" \
   "$($DOLTLITE "$DB" "SELECT v FROM t WHERE id=1;" 2>&1)" "11"
 run_test_eq "f3_feat_change_visible" \
   "$($DOLTLITE "$DB" "SELECT v FROM t WHERE id=2;" 2>&1)" "22"
-db_rm "$DB"
-
-# ----------------------------------------------------------------
-# F8 - Ignore on modified tables. Mark a table as ignored, modify
-# a row, run dolt_status; the row change should NOT appear.
-# Pinning by user-facing dolt_status output.
-# ----------------------------------------------------------------
-DB=/tmp/test_t4_ign_$$.db; db_rm "$DB"
-echo "CREATE TABLE keep_me(id INTEGER PRIMARY KEY, v TEXT);
-CREATE TABLE temp_log(id INTEGER PRIMARY KEY, msg TEXT);
-CREATE TABLE dolt_ignore(pattern TEXT NOT NULL, ignored TINYINT NOT NULL, PRIMARY KEY(pattern));
-INSERT INTO keep_me VALUES(1,'first');
-INSERT INTO temp_log VALUES(1,'noise');
-INSERT INTO dolt_ignore VALUES('temp_log', 1);
-SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
-
-# Modify the ignored table.
-echo "INSERT INTO temp_log VALUES(2,'more noise');
-UPDATE temp_log SET msg='changed' WHERE id=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
-
-# dolt_status should NOT list temp_log among modified tables.
-out=$($DOLTLITE "$DB" "SELECT table_name FROM dolt_status;" 2>&1)
-if echo "$out" | grep -q "temp_log"; then
-  FAIL=$((FAIL+1))
-  ERRORS="$ERRORS\nFAIL: f8_modified_ignored_not_reported\n  got rows: $out"
-else
-  PASS=$((PASS+1))
-fi
-
-# Sanity: modifying a non-ignored table should still appear.
-echo "INSERT INTO keep_me VALUES(2,'second');" | $DOLTLITE "$DB" > /dev/null 2>&1
-run_test_match "f8_modified_tracked_table_reported" \
-  "$($DOLTLITE "$DB" "SELECT table_name FROM dolt_status;" 2>&1)" \
-  "keep_me"
-
 db_rm "$DB"
 
 echo ""

--- a/test/run_doltlite_tests.sh
+++ b/test/run_doltlite_tests.sh
@@ -83,6 +83,7 @@ TESTS=(
   doltlite_pragma_journal_mode.sh
   doltlite_pragma_page_count.sh
   doltlite_pragma_wal_checkpoint.sh
+  doltlite_merge_ignore_corners.sh
   doltlite_record_format.sh
   doltlite_schema_cookie.sh
   doltlite_snapshot_isolation.sh


### PR DESCRIPTION
## Summary
Two Tier-4 corner fixes. F8 was investigated, found to break Dolt parity, and reverted in a follow-up commit.

### F3 — \`canFastMerge\` NOT NULL gate (\`src/doltlite_merge.c\`)
The fast-merge path bypassed constraint checks; the gate already rejected UNIQUE (via \`pTab->pIndex\`) and CHECK / FK with non-OE_None actions, but didn't check for NOT NULL columns. A fast-merge that produced a NULL in a NOT NULL non-PK column would land silently. Fixed: iterate \`pTab->aCol\`, bail if any non-PK column has \`notNull != OE_None\`.

### F7 — \`doltliteSyncChunks\` silent NOTFOUND on push (\`src/doltlite_remote.c\`)
During push, a \`SQLITE_NOTFOUND\` from \`pSrc->xGetChunk\` was treated as \`rc = SQLITE_OK; continue\`, masking missing local chunks — the push appeared to succeed while silently skipping unreachable referenced chunks. Now propagates the error.

### F8 — Investigated, rejected
\`vc_oracle_ignore_test.sh\` (against installed Dolt) confirms Dolt's actual behavior: \`dolt_ignore\` only suppresses NEW tables from status; once a table is tracked, modifications to it appear in \`dolt_status\` regardless of ignore pattern. The deep-review note described the existing code accurately but the implied fix (also consult for modifications) breaks parity. Two failing oracle cases caught it.

The doltlite_status.c change is reverted; the F8 row stays as-is in the catalog of "intentional, matches Dolt".

## Test plan
- [x] \`bash test/doltlite_merge_ignore_corners.sh\` — 3/3 (F3 only; F8 assertions removed)
- [x] \`bash test/vc_oracle_ignore_test.sh\` (vs installed Dolt) — 43/43
- [x] \`bash test/run_doltlite_tests.sh\` — 61/61 suites
- F7 isn't easily exercised from shell SQL (push needs a remote). Code review only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)