### PR TITLE
fix(refs): composed ancestor specs + deterministic LCA tiebreak

### DIFF
--- a/src/doltlite_ancestor.c
+++ b/src/doltlite_ancestor.c
@@ -299,21 +299,12 @@ int doltliteFindAncestor(
 
   {
     int iBest = -1;
-    i64 bestTs = 0;
-    DoltliteCommit commit;
     for(i=0; i<nCommon; i++){
       if( aRedundant[i] ) continue;
-      memset(&commit, 0, sizeof(commit));
-      rc = loadCommitByHash(db, &aCommon[i], &commit);
-      if( rc!=SQLITE_OK ) goto done;
       if( iBest<0
-       || commit.timestamp > bestTs
-       || (commit.timestamp == bestTs
-           && prollyHashCompare(&aCommon[i], &aCommon[iBest])<0) ){
+       || prollyHashCompare(&aCommon[i], &aCommon[iBest])<0 ){
         iBest = i;
-        bestTs = commit.timestamp;
       }
-      doltliteCommitClear(&commit);
     }
     if( iBest<0 ){
       rc = SQLITE_NOTFOUND;

--- a/src/doltlite_ref.c
+++ b/src/doltlite_ref.c
@@ -134,11 +134,10 @@ static int doltliteSelectParent(
 
 int doltliteResolveRef(sqlite3 *db, const char *zRef, ProllyHash *pCommit){
   ChunkStore *cs = doltliteGetChunkStore(db);
-  int len, j, n_back, parent_sel, rc;
+  int len, j, n, rc;
   int suffix_pos = -1;
   char suffix_op = 0;
   char *base_buf = 0;
-  const char *base;
 
   if( !zRef || !cs ) return SQLITE_ERROR;
 
@@ -157,45 +156,37 @@ int doltliteResolveRef(sqlite3 *db, const char *zRef, ProllyHash *pCommit){
     }
   }
 
-  n_back = 0;
-  parent_sel = 0;
-  base = zRef;
-  if( suffix_pos>=0 ){
-    if( suffix_pos==len-1 ){
-      if( suffix_op=='~' ){
-        n_back = 1;
-      }else{
-        parent_sel = 1;
-      }
-    }else{
-      int n = atoi(zRef + suffix_pos + 1);
-      if( n<=0 ) n = 0;
-      if( suffix_op=='~' ){
-        n_back = n;
-      }else{
-        parent_sel = n;
-      }
-    }
-    if( n_back>0 || parent_sel>0 ){
-      if( suffix_pos==0 ){
-        base = "HEAD";
-      }else{
-        base_buf = sqlite3_malloc(suffix_pos + 1);
-        if( !base_buf ) return SQLITE_NOMEM;
-        memcpy(base_buf, zRef, suffix_pos);
-        base_buf[suffix_pos] = '\0';
-        base = base_buf;
-      }
-    }
+  if( suffix_pos<0 ){
+    return doltliteResolveBaseRef(db, zRef, pCommit);
   }
 
-  rc = doltliteResolveBaseRef(db, base, pCommit);
-  if( rc==SQLITE_OK && n_back>0 ){
-    rc = doltliteWalkFirstParent(db, pCommit, n_back);
-  }else if( rc==SQLITE_OK && parent_sel>0 ){
-    rc = doltliteSelectParent(db, pCommit, parent_sel-1);
+  if( suffix_pos==len-1 ){
+    n = 1;
+  }else{
+    n = atoi(zRef + suffix_pos + 1);
+    if( n<0 ) return SQLITE_ERROR;
+    if( n==0 && suffix_op=='^' ) return SQLITE_ERROR;
   }
-  if( base_buf ) sqlite3_free(base_buf);
+
+  if( suffix_pos==0 ){
+    rc = doltliteResolveBaseRef(db, "HEAD", pCommit);
+  }else{
+    base_buf = sqlite3_malloc(suffix_pos + 1);
+    if( !base_buf ) return SQLITE_NOMEM;
+    memcpy(base_buf, zRef, suffix_pos);
+    base_buf[suffix_pos] = '\0';
+    rc = doltliteResolveRef(db, base_buf, pCommit);
+    sqlite3_free(base_buf);
+  }
+
+  if( rc!=SQLITE_OK ) return rc;
+
+  if( suffix_op=='~' ){
+    rc = doltliteWalkFirstParent(db, pCommit, n);
+  }else{
+    rc = doltliteSelectParent(db, pCommit, n-1);
+  }
+  if( rc==SQLITE_NOTFOUND ) rc = SQLITE_ERROR;
   return rc;
 }
 

--- a/test/vc_oracle_ancestor_spec_test.sh
+++ b/test/vc_oracle_ancestor_spec_test.sh
@@ -1,0 +1,311 @@
+#!/bin/bash
+
+set -u
+set -o pipefail
+
+DOLTLITE="${1:-./doltlite}"
+DOLT="${2:-dolt}"
+TMPROOT=$(mktemp -d)
+trap "rm -rf $TMPROOT" EXIT
+pass=0; fail=0
+FAILED_NAMES=""
+source "$(dirname "$0")/lib/vc_oracle_common.sh"
+
+run_dl_query() {
+  local db="$1" query="$2" out="$3" err="$4"
+  printf "%s\n" "$query" | "$DOLTLITE" "$db" >"$out" 2>"$err"
+}
+
+run_dt_query() {
+  local repo="$1" query="$2" out="$3" err="$4"
+  (
+    cd "$repo" || exit 1
+    "$DOLT" sql -q "$query" >"$out" 2>"$err"
+  )
+}
+
+dolt_repo_setup() {
+  local repo="$1" sql="$2"
+  mkdir -p "$repo"
+  (
+    cd "$repo" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    printf "%s\n" "$sql" | "$DOLT" sql >/dev/null 2>"$repo/.setup.err"
+  )
+}
+
+oracle_ok_and_in_set() {
+  local name="$1" setup="$2" ref="$3" valid_set="$4"
+  local dir="$TMPROOT/$name"
+  mkdir -p "$dir/dl"
+
+  local dl_query="SELECT dolt_hashof('$ref');"
+  run_dl_query "$dir/dl/db" "$(printf '%s\n%s\n' "$setup" "$dl_query")" "$dir/dl.out" "$dir/dl.err"
+  local dl_rc=$?
+
+  local dolt_setup
+  dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
+  dolt_repo_setup "$dir/dt" "$dolt_setup"
+  run_dt_query "$dir/dt" "$dl_query" "$dir/dt.out" "$dir/dt.err"
+  local dt_rc=$?
+
+  local dl_hash
+  dl_hash=$(tail -n 1 "$dir/dl.out" | tr -d '\r')
+  local dt_hash
+  dt_hash=$(grep -oE '[0-9a-z]{32,64}' "$dir/dt.out" | tail -n 1)
+
+  if [ "$dl_rc" -ne 0 ] || [ "$dt_rc" -ne 0 ]; then
+    fail=$((fail+1)); FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name (expected both to succeed; dl_rc=$dl_rc dt_rc=$dt_rc)"
+    return
+  fi
+  local dl_ok=0 dt_ok=0
+  for cand in $valid_set; do
+    [ "$dl_hash" = "$cand" ] && dl_ok=1
+    [ "$dt_hash" = "$cand" ] && dt_ok=1
+  done
+  if [ "$dl_ok" = 1 ] && [ "$dt_ok" = 1 ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1)); FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name (hashes not in valid set: $valid_set)"
+    echo "    doltlite: $dl_hash"
+    echo "    dolt:     $dt_hash"
+  fi
+}
+
+oracle_both_error() {
+  local name="$1" setup="$2" ref="$3"
+  local dir="$TMPROOT/${name}_err"
+  mkdir -p "$dir/dl"
+
+  local dl_query="SELECT dolt_hashof('$ref');"
+  run_dl_query "$dir/dl/db" "$(printf '%s\n%s\n' "$setup" "$dl_query")" "$dir/dl.out" "$dir/dl.err"
+  local dl_rc=$?
+
+  local dolt_setup
+  dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
+  dolt_repo_setup "$dir/dt" "$dolt_setup"
+  run_dt_query "$dir/dt" "$dl_query" "$dir/dt.out" "$dir/dt.err"
+  local dt_rc=$?
+
+  if [ "$dl_rc" -ne 0 ] && [ "$dt_rc" -ne 0 ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1)); FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name (expected both to error; dl_rc=$dl_rc dt_rc=$dt_rc)"
+    echo "    doltlite stderr: $(cat "$dir/dl.err" 2>/dev/null)"
+    echo "    dolt stderr:     $(cat "$dir/dt.err" 2>/dev/null)"
+  fi
+}
+
+oracle_both_ok() {
+  local name="$1" setup="$2" ref="$3"
+  local dir="$TMPROOT/${name}_ok"
+  mkdir -p "$dir/dl"
+
+  local dl_query="SELECT dolt_hashof('$ref');"
+  run_dl_query "$dir/dl/db" "$(printf '%s\n%s\n' "$setup" "$dl_query")" "$dir/dl.out" "$dir/dl.err"
+  local dl_rc=$?
+
+  local dolt_setup
+  dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
+  dolt_repo_setup "$dir/dt" "$dolt_setup"
+  run_dt_query "$dir/dt" "$dl_query" "$dir/dt.out" "$dir/dt.err"
+  local dt_rc=$?
+
+  local dl_hash
+  dl_hash=$(tail -n 1 "$dir/dl.out" | tr -d '\r')
+  local dt_hash
+  dt_hash=$(grep -oE '[0-9a-z]{32,64}' "$dir/dt.out" | tail -n 1)
+
+  if [ "$dl_rc" -eq 0 ] && [ "$dt_rc" -eq 0 ] && [ -n "$dl_hash" ] && [ -n "$dt_hash" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1)); FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name (expected both to succeed with non-empty hashes)"
+    echo "    dl_rc=$dl_rc dt_rc=$dt_rc"
+    echo "    doltlite hash: |$dl_hash|"
+    echo "    dolt hash:     |$dt_hash|"
+  fi
+}
+
+echo "=== Version Control Oracle Tests: ancestor spec (F4 LCA + F9 composed refs) ==="
+echo ""
+
+echo "--- F9: composed ref expressions (HEAD, ~, ^, ~N, ^N, composed) ---"
+
+MERGED="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+SELECT dolt_checkout('-b', 'feat');
+INSERT INTO t VALUES (10, 100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feat_c1');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'main_c2');
+SELECT dolt_merge('feat');
+"
+
+oracle_both_ok "head"           "$MERGED" "HEAD"
+oracle_both_ok "main"           "$MERGED" "main"
+oracle_both_ok "head_tilde"     "$MERGED" "HEAD~"
+oracle_both_ok "head_caret"     "$MERGED" "HEAD^"
+oracle_both_ok "head_tilde_1"   "$MERGED" "HEAD~1"
+oracle_both_ok "head_caret_1"   "$MERGED" "HEAD^1"
+oracle_both_ok "head_caret_2"   "$MERGED" "HEAD^2"
+oracle_both_ok "head_double_tilde" "$MERGED" "HEAD~~"
+oracle_both_ok "head_double_caret" "$MERGED" "HEAD^^"
+oracle_both_ok "head_caret2_tilde1" "$MERGED" "HEAD^2~1"
+oracle_both_ok "head_tilde_0"       "$MERGED" "HEAD~0"
+
+oracle_both_error "head_caret_0"   "$MERGED" "HEAD^0"
+oracle_both_error "head_tilde3_caret2" "$MERGED" "HEAD~3^2"
+oracle_both_error "head_tilde1_caret2" "$MERGED" "HEAD~1^2"
+oracle_both_error "nonmerge_branch_caret2" "$MERGED" "feat^2"
+
+echo ""
+echo "--- F4: LCA must be deterministic on criss-cross merge ---"
+
+CRISS_CROSS_FWD="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'base', '--date', '2020-01-01T00:00:00');
+SELECT dolt_branch('A');
+SELECT dolt_branch('B');
+SELECT dolt_checkout('A');
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'a1', '--date', '2030-01-01T00:00:00');
+SELECT dolt_checkout('B');
+INSERT INTO t VALUES (3, 30);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'b1', '--date', '2020-06-01T00:00:00');
+SELECT dolt_branch('C', 'A');
+SELECT dolt_branch('D', 'B');
+SELECT dolt_checkout('C');
+SELECT dolt_merge('B');
+SELECT dolt_checkout('D');
+SELECT dolt_merge('A');
+SELECT dolt_checkout('C');
+"
+
+CRISS_CROSS_REV="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'base', '--date', '2020-01-01T00:00:00');
+SELECT dolt_branch('A');
+SELECT dolt_branch('B');
+SELECT dolt_checkout('A');
+INSERT INTO t VALUES (2, 20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'a1', '--date', '2020-06-01T00:00:00');
+SELECT dolt_checkout('B');
+INSERT INTO t VALUES (3, 30);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'b1', '--date', '2030-01-01T00:00:00');
+SELECT dolt_branch('C', 'A');
+SELECT dolt_branch('D', 'B');
+SELECT dolt_checkout('C');
+SELECT dolt_merge('B');
+SELECT dolt_checkout('D');
+SELECT dolt_merge('A');
+SELECT dolt_checkout('C');
+"
+
+lca_query_dl="SELECT CASE
+  WHEN dolt_merge_base('C', 'D') = dolt_hashof('A') THEN 'LCA|a1'
+  WHEN dolt_merge_base('C', 'D') = dolt_hashof('B') THEN 'LCA|b1'
+  ELSE 'LCA|OTHER'
+END;"
+
+lca_query_dt="SELECT CASE
+  WHEN dolt_merge_base('C', 'D') = dolt_hashof('A') THEN CONCAT('LCA', '|', 'a1')
+  WHEN dolt_merge_base('C', 'D') = dolt_hashof('B') THEN CONCAT('LCA', '|', 'b1')
+  ELSE CONCAT('LCA', '|', 'OTHER')
+END;"
+
+run_lca_doltlite() {
+  local setup="$1" db="$2" out="$3" err="$4"
+  printf "%s\n.headers off\n.mode list\n%s\n" "$setup" "$lca_query_dl" \
+    | "$DOLTLITE" "$db" >"$out" 2>"$err"
+}
+
+assert_deterministic_lca() {
+  local name="$1" setup="$2"
+  local dl_runs=3
+  local prev=""
+  local i
+  for ((i=1; i<=dl_runs; i++)); do
+    local db="$TMPROOT/${name}_dl_${i}.db"
+    local out="$TMPROOT/${name}_dl_${i}.out"
+    local err="$TMPROOT/${name}_dl_${i}.err"
+    rm -f "$db"
+    run_lca_doltlite "$setup" "$db" "$out" "$err"
+    local cur
+    cur=$(grep '^LCA|' "$out" | head -n 1 | sed 's/^LCA|//')
+    if [ -z "$cur" ]; then
+      fail=$((fail+1)); FAILED_NAMES="$FAILED_NAMES ${name}_run${i}"
+      echo "  FAIL: ${name}_run${i} (no LCA line)"
+      echo "    output: $(cat "$out")"
+      return
+    fi
+    if [ "$cur" != "a1" ] && [ "$cur" != "b1" ]; then
+      fail=$((fail+1)); FAILED_NAMES="$FAILED_NAMES ${name}_run${i}"
+      echo "  FAIL: ${name}_run${i} (LCA not in {a1,b1}): $cur"
+      return
+    fi
+    if [ -n "$prev" ] && [ "$cur" != "$prev" ]; then
+      fail=$((fail+1)); FAILED_NAMES="$FAILED_NAMES ${name}_determinism"
+      echo "  FAIL: ${name} (LCA differs across runs: run1=$prev runN=$cur)"
+      return
+    fi
+    prev="$cur"
+  done
+  pass=$((pass+1))
+}
+
+assert_dolt_in_set() {
+  local name="$1" setup="$2"
+  local dolt_setup
+  dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
+  local repo="$TMPROOT/${name}_dt"
+  dolt_repo_setup "$repo" "$dolt_setup"
+  local out="$TMPROOT/${name}_dt.out"
+  local err="$TMPROOT/${name}_dt.err"
+  (cd "$repo" && "$DOLT" sql -q "$lca_query_dt") >"$out" 2>"$err"
+  local rc=$?
+  local got
+  got=$(grep -oE 'LCA\|[a-zA-Z0-9_]+' "$out" | head -n 1 | sed 's/^LCA|//')
+  if [ "$rc" -ne 0 ]; then
+    fail=$((fail+1)); FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name (dolt query failed rc=$rc)"
+    echo "    stderr: $(cat "$err")"
+    return
+  fi
+  if [ "$got" = "a1" ] || [ "$got" = "b1" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1)); FAILED_NAMES="$FAILED_NAMES $name"
+    echo "  FAIL: $name (dolt LCA not in {a1,b1}): |$got|"
+    echo "    output: $(cat "$out")"
+  fi
+}
+
+assert_deterministic_lca "criss_cross_fwd_dl_determinism" "$CRISS_CROSS_FWD"
+assert_deterministic_lca "criss_cross_rev_dl_determinism" "$CRISS_CROSS_REV"
+assert_dolt_in_set       "criss_cross_fwd_dt_in_set"     "$CRISS_CROSS_FWD"
+assert_dolt_in_set       "criss_cross_rev_dt_in_set"     "$CRISS_CROSS_REV"
+
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+if [ $fail -gt 0 ]; then
+  echo "Failed:$FAILED_NAMES"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Tier 4 review items F4 and F9 from the 2026-05-14 deep review.

**F4 — LCA tiebreak determinism**: `doltliteFindAncestor` picked the LCA with the newest timestamp (and hash as secondary). This biases towards recent commits and reads each candidate commit just to extract the timestamp. Drop the timestamp comparison entirely — pick the lowest hash, deterministic on identical input.

**F9 — Composed ancestor specs**: `doltliteResolveRef` only parsed one trailing `~N`/`^N` suffix, then passed everything before it to the literal-ref lookup. Composed forms like `HEAD^2~1`, `HEAD~~`, `HEAD^^` silently fell through to NULL. Rewrite it to recursively peel the rightmost suffix and resolve the remaining base. Probed against installed Dolt 2.0.3:

| ref expression | Dolt | doltlite before | doltlite after |
|---|---|---|---|
| `HEAD^2~1` | OK | NULL | OK |
| `HEAD~~` / `HEAD^^` | OK | NULL | OK |
| `HEAD~0` | OK (identity) | NULL | OK (identity) |
| `HEAD^0` | error | NULL | error |
| `HEAD~3^2` | error | NULL | error |
| `HEAD~1^2` | error | NULL | error |
| `feat^2` (non-merge) | error | NULL | error |

Behavior for plain bogus refs (`'not_a_branch'`) is unchanged — still returns NULL rather than Dolt's "invalid ref spec" error. That's a separate parity gap with broader call-site impact.

**Test**: new `test/vc_oracle_ancestor_spec_test.sh` exercises both fixes against installed Dolt — 19 assertions covering composed ref expressions, `~0`/`^0` edge cases, and deterministic LCA selection across repeated criss-cross builds. CI picks it up automatically via the `vc_oracle_*_test.sh` glob.

## Test plan
- [x] `make doltlite` (clean build, no new warnings)
- [x] `bash test/run_doltlite_tests.sh` — 61/61 doltlite suites pass
- [x] All `vc_oracle_*_test.sh` pass locally against installed Dolt 2.0.3
- [x] New `vc_oracle_ancestor_spec_test.sh` — 19 passed, 0 failed, stable over 10 stress runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)