### PR TITLE
Make DoltLite backups safer

### DIFF
--- a/src/pager_shim.c
+++ b/src/pager_shim.c
@@ -12,6 +12,7 @@ int sqlite3_opentemp_count = 0;
 
 BtShared *SQLITE_WSD sqlite3SharedCacheList = 0;
 
+#include <stdio.h>
 #include <string.h>
 
 #define SHIM(p) ((PagerShim*)(p))
@@ -821,6 +822,38 @@ void enable_simulated_io_errors(void){
 
 ChunkStore *doltliteGetChunkStore(sqlite3 *db);
 
+static int doltliteBackupSameFile(
+  sqlite3_vfs *pSrcVfs,
+  const char *zSrcFile,
+  sqlite3_vfs *pDestVfs,
+  const char *zDestFile
+){
+  char *zSrcFull = 0;
+  char *zDestFull = 0;
+  int nSrc;
+  int nDest;
+  int same = strcmp(zSrcFile, zDestFile)==0;
+
+  if( pSrcVfs!=pDestVfs ) return same;
+  nSrc = pSrcVfs->mxPathname + 1;
+  nDest = pDestVfs->mxPathname + 1;
+  zSrcFull = sqlite3_malloc(nSrc);
+  zDestFull = sqlite3_malloc(nDest);
+  if( !zSrcFull || !zDestFull ) goto backup_same_file_done;
+  if( sqlite3OsFullPathname(pSrcVfs, zSrcFile, nSrc, zSrcFull)!=SQLITE_OK ){
+    goto backup_same_file_done;
+  }
+  if( sqlite3OsFullPathname(pDestVfs, zDestFile, nDest, zDestFull)!=SQLITE_OK ){
+    goto backup_same_file_done;
+  }
+  same = strcmp(zSrcFull, zDestFull)==0;
+
+backup_same_file_done:
+  sqlite3_free(zSrcFull);
+  sqlite3_free(zDestFull);
+  return same;
+}
+
 typedef struct DoltliteBackup DoltliteBackup;
 struct DoltliteBackup {
   sqlite3 *pSrcDb;
@@ -828,7 +861,9 @@ struct DoltliteBackup {
   char *zSrcFile;
   char *zDestFile;
   sqlite3_vfs *pVfs;
+  sqlite3_vfs *pDestVfs;
   int done;
+  int rc;
 };
 
 sqlite3_backup *sqlite3_backup_init(sqlite3 *pDest, const char *zDestDb,
@@ -850,9 +885,26 @@ sqlite3_backup *sqlite3_backup_init(sqlite3 *pDest, const char *zDestDb,
 
   srcCs = doltliteGetChunkStore(pSrc);
   destCs = doltliteGetChunkStore(pDest);
-  if( !srcCs || !chunkFileGetFilename(&srcCs->file) ) return 0;
-  if( srcCs->isMemory ) return 0;
-  if( !destCs || !chunkFileGetFilename(&destCs->file) ) return 0;
+  if( !srcCs || !chunkFileGetFilename(&srcCs->file) ){
+    sqlite3ErrorWithMsg(pDest, SQLITE_ERROR, "source database is not backed by a file");
+    return 0;
+  }
+  if( srcCs->isMemory ){
+    sqlite3ErrorWithMsg(pDest, SQLITE_ERROR, "cannot backup in-memory doltlite database");
+    return 0;
+  }
+  if( !destCs || !chunkFileGetFilename(&destCs->file) ){
+    sqlite3ErrorWithMsg(pDest, SQLITE_ERROR, "destination database is not backed by a file");
+    return 0;
+  }
+  if( doltliteBackupSameFile(chunkFileGetVfs(&srcCs->file),
+                             chunkFileGetFilename(&srcCs->file),
+                             chunkFileGetVfs(&destCs->file),
+                             chunkFileGetFilename(&destCs->file)) ){
+    sqlite3ErrorWithMsg(pDest, SQLITE_ERROR,
+                        "source and destination are the same database");
+    return 0;
+  }
 
   p = (DoltliteBackup*)sqlite3_malloc(sizeof(DoltliteBackup));
   if( !p ) return 0;
@@ -861,6 +913,7 @@ sqlite3_backup *sqlite3_backup_init(sqlite3 *pDest, const char *zDestDb,
   p->pSrcDb = pSrc;
   p->pDestDb = pDest;
   p->pVfs = chunkFileGetVfs(&srcCs->file);
+  p->pDestVfs = chunkFileGetVfs(&destCs->file);
   p->zSrcFile = sqlite3_mprintf("%s", chunkFileGetFilename(&srcCs->file));
   p->zDestFile = sqlite3_mprintf("%s", chunkFileGetFilename(&destCs->file));
   if( !p->zSrcFile || !p->zDestFile ){
@@ -875,46 +928,76 @@ sqlite3_backup *sqlite3_backup_init(sqlite3 *pDest, const char *zDestDb,
 
 int sqlite3_backup_step(sqlite3_backup *pBackup, int nPage){
   DoltliteBackup *p = (DoltliteBackup*)pBackup;
+  ChunkStore *srcCs;
+  ChunkStore *destCs;
   sqlite3_file *pSrc = 0;
-  sqlite3_file *pDest = 0;
+  sqlite3_file *pTmp = 0;
+  char *zTmpFile = 0;
   i64 fileSize = 0;
   int rc;
   int openFlags;
+  int srcLocked = 0;
+  int destLocked = 0;
   (void)nPage;
 
   if( !p ) return SQLITE_DONE;
   if( p->done ) return SQLITE_DONE;
+  if( p->rc!=SQLITE_OK ) return p->rc;
+
+  srcCs = doltliteGetChunkStore(p->pSrcDb);
+  destCs = doltliteGetChunkStore(p->pDestDb);
+  if( !srcCs || !destCs ){
+    p->rc = SQLITE_ERROR;
+    return p->rc;
+  }
+
+  rc = chunkStoreLockAndRefresh(srcCs);
+  if( rc!=SQLITE_OK ){
+    if( rc!=SQLITE_BUSY && rc!=SQLITE_LOCKED ) p->rc = rc;
+    return rc;
+  }
+  srcLocked = 1;
+
+  rc = chunkStoreLockAndRefresh(destCs);
+  if( rc!=SQLITE_OK ){
+    if( rc!=SQLITE_BUSY && rc!=SQLITE_LOCKED ) p->rc = rc;
+    goto backup_step_done;
+  }
+  destLocked = 1;
 
   openFlags = SQLITE_OPEN_READONLY | SQLITE_OPEN_MAIN_DB;
   rc = sqlite3OsOpenMalloc(p->pVfs, p->zSrcFile, &pSrc, openFlags, 0);
-  if( rc != SQLITE_OK ) return rc;
+  if( rc != SQLITE_OK ) goto backup_step_done;
 
   rc = sqlite3OsFileSize(pSrc, &fileSize);
   if( rc != SQLITE_OK ){
-    sqlite3OsCloseFree(pSrc);
-    return rc;
+    goto backup_step_done;
   }
 
-  openFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB;
-  rc = sqlite3OsOpenMalloc(p->pVfs, p->zDestFile, &pDest, openFlags, 0);
-  if( rc != SQLITE_OK ){
-    sqlite3OsCloseFree(pSrc);
-    return rc;
+  zTmpFile = sqlite3_mprintf("%s-backup-%p", p->zDestFile, (void*)p);
+  if( !zTmpFile ){
+    rc = SQLITE_NOMEM;
+    goto backup_step_done;
   }
+  (void)sqlite3OsDelete(p->pDestVfs, zTmpFile, 0);
+
+  openFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_EXCLUSIVE
+            | SQLITE_OPEN_MAIN_DB;
+  rc = sqlite3OsOpenMalloc(p->pDestVfs, zTmpFile, &pTmp, openFlags, 0);
+  if( rc != SQLITE_OK ) goto backup_step_done;
 
   {
     u8 *buf = (u8*)sqlite3_malloc(65536);
     i64 off = 0;
     if( !buf ){
-      sqlite3OsCloseFree(pSrc);
-      sqlite3OsCloseFree(pDest);
-      return SQLITE_NOMEM;
+      rc = SQLITE_NOMEM;
+      goto backup_step_done;
     }
     while( off < fileSize ){
       int toRead = (fileSize - off) > 65536 ? 65536 : (int)(fileSize - off);
       rc = sqlite3OsRead(pSrc, buf, toRead, off);
       if( rc != SQLITE_OK ) break;
-      rc = sqlite3OsWrite(pDest, buf, toRead, off);
+      rc = sqlite3OsWrite(pTmp, buf, toRead, off);
       if( rc != SQLITE_OK ) break;
       off += toRead;
     }
@@ -922,26 +1005,59 @@ int sqlite3_backup_step(sqlite3_backup *pBackup, int nPage){
   }
 
   if( rc == SQLITE_OK ){
-    rc = sqlite3OsSync(pDest, SQLITE_SYNC_NORMAL);
+    rc = sqlite3OsTruncate(pTmp, fileSize);
+  }
+  if( rc == SQLITE_OK ){
+    rc = sqlite3OsSync(pTmp, SQLITE_SYNC_NORMAL);
+  }
+  if( pTmp ){
+    sqlite3OsClose(pTmp);
+    sqlite3_free(pTmp);
+    pTmp = 0;
+  }
+  if( rc == SQLITE_OK && rename(zTmpFile, p->zDestFile)!=0 ){
+    rc = SQLITE_IOERR_WRITE;
   }
 
-  sqlite3OsCloseFree(pSrc);
-  sqlite3OsCloseFree(pDest);
+backup_step_done:
+  if( pSrc ) sqlite3OsCloseFree(pSrc);
+  if( pTmp ) sqlite3OsCloseFree(pTmp);
+  if( zTmpFile ){
+    if( rc!=SQLITE_OK ) (void)sqlite3OsDelete(p->pDestVfs, zTmpFile, 0);
+    sqlite3_free(zTmpFile);
+  }
+
+  if( destLocked ){
+    chunkStoreUnlock(destCs);
+    destLocked = 0;
+  }
+
+  if( rc == SQLITE_OK ){
+    destCs->file.iFileSize = -1;
+    destCs->hasMovedChecked = 0;
+    rc = chunkStoreLockAndRefresh(destCs);
+    if( rc==SQLITE_OK ) chunkStoreUnlock(destCs);
+  }
+
+  if( srcLocked ) chunkStoreUnlock(srcCs);
 
   if( rc == SQLITE_OK ){
     p->done = 1;
     return SQLITE_DONE;
   }
+  if( rc!=SQLITE_BUSY && rc!=SQLITE_LOCKED ) p->rc = rc;
   return rc;
 }
 
 int sqlite3_backup_finish(sqlite3_backup *pBackup){
   DoltliteBackup *p = (DoltliteBackup*)pBackup;
+  int rc;
   if( !p ) return SQLITE_OK;
+  rc = p->rc;
   sqlite3_free(p->zSrcFile);
   sqlite3_free(p->zDestFile);
   sqlite3_free(p);
-  return SQLITE_OK;
+  return rc==SQLITE_DONE ? SQLITE_OK : rc;
 }
 
 int sqlite3_backup_remaining(sqlite3_backup *pBackup){

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <sys/stat.h>
 #include "sqlite3.h"
 #include "prolly_hash.h"
 #include "chunk_store.h"
@@ -96,6 +97,26 @@ static int open_db(const char *path, sqlite3 **ppDb){
   return rc;
 }
 
+static sqlite3_int64 file_size_or_negative(const char *path){
+  struct stat st;
+  if( stat(path, &st)!=0 ) return -1;
+  return (sqlite3_int64)st.st_size;
+}
+
+static int backup_db(sqlite3 *src, sqlite3 *dest){
+  sqlite3_backup *pBackup;
+  int rc;
+  int rcFinish;
+
+  pBackup = sqlite3_backup_init(dest, "main", src, "main");
+  if( pBackup==0 ) return sqlite3_errcode(dest);
+
+  rc = sqlite3_backup_step(pBackup, -1);
+  rcFinish = sqlite3_backup_finish(pBackup);
+  if( rc==SQLITE_DONE ) rc = rcFinish;
+  return rc;
+}
+
 static int custom_collation_cmp(
   void *pCtx,
   int nA,
@@ -154,6 +175,94 @@ static void run_create_collation_unsupported(void){
   check("builtin_collation_still_works",
         strcmp(queryScalarText(db, "SELECT 'a'='A' COLLATE NOCASE"), "1")==0);
   sqlite3_close(db);
+}
+
+static void make_dbpath(char *zBuf, size_t nBuf, const char *zBase);
+static void removeDbFiles(const char *path);
+
+static void run_backup_safety(void){
+  sqlite3 *srcBig = 0;
+  sqlite3 *srcSmall = 0;
+  sqlite3 *dest = 0;
+  sqlite3 *sameA = 0;
+  sqlite3 *sameB = 0;
+  sqlite3_backup *pBackup;
+  char zBig[512];
+  char zSmall[512];
+  char zDest[512];
+  char zSame[512];
+  sqlite3_int64 nSmall;
+  sqlite3_int64 nDest;
+  int rc;
+
+  make_dbpath(zBig, sizeof(zBig), "backup_safety_big");
+  make_dbpath(zSmall, sizeof(zSmall), "backup_safety_small");
+  make_dbpath(zDest, sizeof(zDest), "backup_safety_dest");
+  make_dbpath(zSame, sizeof(zSame), "backup_safety_same");
+  removeDbFiles(zBig);
+  removeDbFiles(zSmall);
+  removeDbFiles(zDest);
+  removeDbFiles(zSame);
+
+  check("backup_safety_open_big", open_db(zBig, &srcBig)==SQLITE_OK);
+  check("backup_safety_open_dest", open_db(zDest, &dest)==SQLITE_OK);
+  if( srcBig==0 || dest==0 ) goto backup_safety_done;
+
+  rc = execSql(srcBig,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "WITH RECURSIVE c(x) AS (VALUES(1) UNION ALL SELECT x+1 FROM c WHERE x<1200) "
+    "INSERT INTO t SELECT x, printf('big-%04d', x) FROM c;");
+  check("backup_safety_seed_big", rc==SQLITE_OK);
+  check("backup_safety_copy_big", backup_db(srcBig, dest)==SQLITE_OK);
+  check("backup_safety_dest_big_visible",
+        strcmp(queryScalarText(dest, "SELECT count(*) FROM t"), "1200")==0);
+
+  sqlite3_close(srcBig);
+  sqlite3_close(dest);
+  srcBig = 0;
+  dest = 0;
+
+  check("backup_safety_open_small", open_db(zSmall, &srcSmall)==SQLITE_OK);
+  check("backup_safety_reopen_dest", open_db(zDest, &dest)==SQLITE_OK);
+  if( srcSmall==0 || dest==0 ) goto backup_safety_done;
+
+  rc = execSql(srcSmall,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1, 'small');");
+  check("backup_safety_seed_small", rc==SQLITE_OK);
+  nSmall = file_size_or_negative(zSmall);
+  check("backup_safety_small_has_size", nSmall > 0);
+
+  check("backup_safety_copy_small", backup_db(srcSmall, dest)==SQLITE_OK);
+  nDest = file_size_or_negative(zDest);
+  check("backup_safety_dest_truncated", nDest==nSmall);
+  check("backup_safety_dest_handle_refreshed",
+        strcmp(queryScalarText(dest, "SELECT count(*) FROM t"), "1")==0);
+  check("backup_safety_dest_value_refreshed",
+        strcmp(queryScalarText(dest, "SELECT v FROM t WHERE id=1"), "small")==0);
+
+  check("backup_safety_open_same_a", open_db(zSame, &sameA)==SQLITE_OK);
+  check("backup_safety_open_same_b", open_db(zSame, &sameB)==SQLITE_OK);
+  if( sameA && sameB ){
+    check("backup_safety_same_seed",
+          execSql(sameA, "CREATE TABLE s(x); INSERT INTO s VALUES(1);")==SQLITE_OK);
+    pBackup = sqlite3_backup_init(sameB, "main", sameA, "main");
+    check("backup_safety_same_file_rejected", pBackup==0);
+    check("backup_safety_same_file_message",
+          strstr(sqlite3_errmsg(sameB), "same database")!=0);
+    if( pBackup ) sqlite3_backup_finish(pBackup);
+  }
+
+backup_safety_done:
+  if( sameA ) sqlite3_close(sameA);
+  if( sameB ) sqlite3_close(sameB);
+  if( srcBig ) sqlite3_close(srcBig);
+  if( srcSmall ) sqlite3_close(srcSmall);
+  if( dest ) sqlite3_close(dest);
+  removeDbFiles(zBig);
+  removeDbFiles(zSmall);
+  removeDbFiles(zDest);
+  removeDbFiles(zSame);
 }
 
 static int stmt_column_text_equals(sqlite3_stmt *stmt, int iCol, const char *zExpect){
@@ -6989,6 +7098,7 @@ static void run_prolly_diff_leaf_surfaces_record_corruption(void){
 }
 
 static const RegressionCase aCases[] = {
+  { "backup_safety", "Backup Safety Test", run_backup_safety },
   { "create_collation_unsupported", "Create Collation Unsupported Test", run_create_collation_unsupported },
   { "concurrent_refs", "Concurrent Refs Test", run_concurrent_refs },
   { "checkout_persist_failure", "Checkout Persist Failure Test", run_checkout_persist_failure },

--- a/test/vc_ref_mutation_stress_test.c
+++ b/test/vc_ref_mutation_stress_test.c
@@ -294,9 +294,11 @@ static void verifyFinalState(const char *path){
   sqlite3 *db = 0;
   int rc;
   int count = 0;
+  char mainPath[320];
   char msg[256];
 
-  rc = sqlite3_open(path, &db);
+  sqlite3_snprintf(sizeof(mainPath), mainPath, "%s@main", path);
+  rc = sqlite3_open(mainPath, &db);
   check("verify_open", rc==SQLITE_OK);
   sqlite3_busy_timeout(db, 5000);
 

--- a/test/vc_ref_mutation_stress_test.c
+++ b/test/vc_ref_mutation_stress_test.c
@@ -294,15 +294,13 @@ static void verifyFinalState(const char *path){
   sqlite3 *db = 0;
   int rc;
   int count = 0;
-  char mainPath[320];
   char msg[256];
 
-  sqlite3_snprintf(sizeof(mainPath), mainPath, "%s@main", path);
-  rc = sqlite3_open(mainPath, &db);
+  rc = sqlite3_open(path, &db);
   check("verify_open", rc==SQLITE_OK);
   sqlite3_busy_timeout(db, 5000);
 
-  rc = execSqlWithRetry(db, "SELECT dolt_checkout('main')");
+  rc = execSqlWithRetry(db, "SELECT dolt_connect_branch('main')");
   check("verify_checkout_main", rc==SQLITE_OK);
   rc = queryIntWithRetry(db, "SELECT count(*) FROM ref_rows", &count);
   check("verify_all_rows_merged",


### PR DESCRIPTION
## Summary
- hold source and destination chunk-store locks while running DoltLite backup copies
- copy into a temporary sidecar file and rename it into place only after successful write/truncate/sync
- reject same-file source/destination backups using canonical VFS paths
- refresh the destination chunk-store after replacement so the open destination handle sees the backup contents
- add regression coverage for truncation, destination refresh, and same-file rejection

## Tests
- `make -C build libdoltlite.a`
- `bash test/run_doltlite_regression_case.sh backup_safety`
- `bash test/run_doltlite_regression_case.sh create_collation_unsupported`
- `make -C build doltlite`
- CLI `.backup` smoke test returned `2|ab`