### PR TITLE
fix(btree): route SQLite-format probe through the VFS

### DIFF
--- a/src/btree_orig_api.c
+++ b/src/btree_orig_api.c
@@ -148,19 +148,37 @@ void origBtreeEnter(void *p){ orig_sqlite3BtreeEnter(B(p)); }
 void origBtreeLeave(void *p){ orig_sqlite3BtreeLeave(B(p)); }
 void *origBtreePager(void *p){ return orig_sqlite3BtreePager(B(p)); }
 
-int origBtreeIsSqliteFile(const char *zFilename){
-  FILE *f;
-  char buf[16];
-  if( !zFilename || zFilename[0]=='\0' || strcmp(zFilename,":memory:")==0 ){
+int origBtreeIsSqliteFile(sqlite3_vfs *pVfs, const char *zFilename){
+  sqlite3_file *pFile = 0;
+  int exists = 0;
+  int outFlags = 0;
+  int rc;
+  u8 buf[16];
+
+  if( !zFilename || zFilename[0]=='\0'
+   || strcmp(zFilename, ":memory:")==0 ){
     return 0;
   }
-  f = fopen(zFilename, "rb");
-  if( !f ) return 0;
-  if( fread(buf, 1, 16, f) < 16 ){
-    fclose(f);
+  if( !pVfs ){
+    pVfs = sqlite3_vfs_find(0);
+    if( !pVfs ) return 0;
+  }
+
+  rc = sqlite3OsAccess(pVfs, zFilename, SQLITE_ACCESS_EXISTS, &exists);
+  if( rc!=SQLITE_OK || !exists ) return 0;
+
+  rc = sqlite3OsOpenMalloc(pVfs, zFilename, &pFile,
+                           SQLITE_OPEN_READONLY | SQLITE_OPEN_MAIN_DB,
+                           &outFlags);
+  if( rc!=SQLITE_OK ){
+    if( pFile ) sqlite3OsCloseFree(pFile);
     return 0;
   }
-  fclose(f);
+
+  rc = sqlite3OsRead(pFile, buf, sizeof(buf), 0);
+  sqlite3OsCloseFree(pFile);
+  if( rc!=SQLITE_OK ) return 0;
+
   return memcmp(buf, "SQLite format 3\000", 16)==0;
 }
 

--- a/src/btree_orig_api.h
+++ b/src/btree_orig_api.h
@@ -85,6 +85,6 @@ int origBtreeIntegrityCheck(sqlite3 *db, void *p, Pgno *aRoot,
                             sqlite3_value *aCnt, int nRoot, int mxErr,
                             int *pnErr, char **pzOut);
 
-int origBtreeIsSqliteFile(const char *zFilename);
+int origBtreeIsSqliteFile(sqlite3_vfs *pVfs, const char *zFilename);
 
 #endif

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -3545,7 +3545,7 @@ int sqlite3BtreeOpen(
    || (strcmp(zFilename, ":memory:")==0 && db->aDb[0].pBt!=0)
    || (flags & BTREE_SINGLE)
    || (vfsFlags & SQLITE_OPEN_TEMP_DB)
-   || origBtreeIsSqliteFile(zFilename)
+   || origBtreeIsSqliteFile(pVfs, zFilename)
   ){
     p = sqlite3_malloc(sizeof(Btree));
     if( !p ) return SQLITE_NOMEM;


### PR DESCRIPTION
## Summary

`origBtreeIsSqliteFile` used stdio `fopen`/`fread`/`fclose` to read the first 16 bytes of `zFilename` and check the SQLite magic string. That bypasses the VFS, so any non-default VFS (encryption, in-memory, test fixtures, network) saw a path that `fopen` couldn't resolve and the probe returned `0` — `sqlite3BtreeOpen` then routed through the doltlite path even when the VFS would treat the file as stock SQLite.

This swaps the probe to use the VFS path: `sqlite3OsAccess` → `sqlite3OsOpenMalloc` → `sqlite3OsRead` → `sqlite3OsCloseFree`, threading the same `pVfs` that `sqlite3BtreeOpen` will hand to the eventual engine. Behavior on the default unix/win32 VFS is unchanged; custom VFSes now see consistent probe-vs-open results.

Found while doing a deep code review — the same VFS-bypass pattern shows up in two more places in `chunk_store.c` (`stat()` at line 317 and 1434). Those aren't fixed here; they can be a follow-up.

## Test plan

- [x] Clean build (no new warnings)
- [x] `test/doltlite_open_sqlite_file.sh` — 29/29 pass (drop-in-replacement contract preserved)
- [x] `test/doltlite_attach_sqlite.sh` — 13/13 pass (`ATTACH 'stock.db'` still works)
- [x] Smoke test on a fresh chunk-store DB — `CREATE TABLE` + `dolt_commit` + `dolt_branch` + `dolt_branches` work
- [ ] CI on the runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)