### PR TITLE
fix(btree): free pending mutmap on DROP TABLE and clear cursor aliases

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -965,6 +965,12 @@ static void catRemove(Catalog *cat, Pgno iTable){
   for(i=0; i<cat->n; i++){
     if( cat->a[i].iTable==iTable ){
       sqlite3_free(cat->a[i].zName);
+      if( cat->a[i].pPending ){
+        ProllyMutMap *pMap = (ProllyMutMap*)cat->a[i].pPending;
+        prollyMutMapFree(pMap);
+        sqlite3_free(pMap);
+        cat->a[i].pPending = 0;
+      }
       if( i<cat->n-1 ){
         memmove(&cat->a[i], &cat->a[i+1],
                 (cat->n-i-1)*(int)sizeof(struct TableEntry));
@@ -5098,6 +5104,10 @@ static int prollyBtreeDropTable(Btree *p, int iTable, int *piMoved){
   }
 
   invalidateCursors(pBt, (Pgno)iTable, SQLITE_ABORT);
+  /* Clear any cursor aliases of the dropped table's pending mutmap before
+  ** catRemove frees it; otherwise rollback (prollyBtreeRollback) would
+  ** later iterate live cursors and dereference a freed map. */
+  refreshCursorMutMapAliases(p, pBt, (Pgno)iTable, 0);
   removeTable(p, (Pgno)iTable);
 
   if( piMoved ) *piMoved = 0;


### PR DESCRIPTION
## Summary

`catRemove()` shifted/decremented the catalog array but only freed `TableEntry.zName`, never `TableEntry.pPending`. The `ProllyMutMap` allocated for the dropped table's pending edits was orphaned — a leak per `DROP TABLE` that survived for the lifetime of the connection.

Freeing `pPending` inside `catRemove` plugs the leak, but on its own it would introduce a use-after-free: any cursor that called `ensureMutMap` on the dropped table is holding `pCur->pMutMap = (the now-freed map)`. `prollyBtreeRollback` iterates every cursor at lines 4716 and 4798 and calls `prollyMutMapClear(pC->pMutMap)` regardless of cursor `eState`, so the next rollback would deref freed memory.

Two paired changes:

- **`catRemove`** (`prolly_btree.c:963`): also free `pPending`. Mirrors the pattern `catFree` already uses for whole-catalog teardown.
- **`prollyBtreeDropTable`** (`prolly_btree.c:5079`): after `invalidateCursors` but before `removeTable`, call `refreshCursorMutMapAliases(..., iTable, 0)` to null out cursor `pMutMap` fields for the dropped table. This is the same helper that's already used after a successful flush (line 2653).

Found while doing a deep code review of `prolly_btree.c`. This is Critical #2 in the review — a confirmed leak today, plus a latent use-after-free that any naive "just free pPending" fix would expose.

## Test plan

- [x] Clean build
- [x] `test/doltlite_commit.sh` — 44/44 pass
- [x] `test/doltlite_branch.sh` — 60/60 pass
- [x] `test/doltlite_merge.sh` — 91/91 pass
- [x] Smoke test: \`CREATE TABLE t; INSERT; BEGIN; INSERT; DROP TABLE t; ROLLBACK\` → table back with original rows; subsequent \`DROP\` works
- [x] Stress: 500-row INSERT inside savepoint then DROP + ROLLBACK; unrelated table data intact, schema empty of the dropped table
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)