### PR TITLE
fix(btree): guard prollyBtCursorDelete against deleting rowid 0

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -7089,16 +7089,23 @@ static int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
     return rc;
   }
 
+  /* If no key could be resolved from cursor state, treat the delete as
+  ** a no-op. Falling through would call prollyMutMapDelete with iKey=0
+  ** (intkey) or an empty blob key, silently deleting rowid 0 or the
+  ** empty-blob row if either exists. Reachable today only via
+  ** CURSOR_INVALID without cached key — SQLite's VDBE doesn't issue
+  ** Delete on an invalid cursor in normal bytecode, but a future
+  ** refactor or fuzz path could. */
+  if( !hasSavedKey ){
+    if( savedDelKeyOwned ) sqlite3_free(pSavedDelKey);
+    return SQLITE_OK;
+  }
   if( pCur->curIntKey ){
-    if( hasSavedKey ){
-      iKey = savedIntKey;
-    }
+    iKey = savedIntKey;
     rc = prollyMutMapDelete(pCur->pMutMap, NULL, 0, iKey);
   } else {
-    if( hasSavedKey ){
-      pKey = pSavedDelKey;
-      nKey = nSavedDelKey;
-    }
+    pKey = pSavedDelKey;
+    nKey = nSavedDelKey;
     rc = prollyMutMapDelete(pCur->pMutMap, pKey, nKey, 0);
     if( savedDelKeyOwned ) sqlite3_free(pSavedDelKey);
     pSavedDelKey = 0;

--- a/test/sql_oracle_test.sh
+++ b/test/sql_oracle_test.sh
@@ -1830,6 +1830,68 @@ COMMIT;
 SELECT count(*) FROM t;
 "
 
+# 16m. Rowid 0 must not be deleted by accident. prollyBtCursorDelete
+# previously fell through with iKey=0 when hasSavedKey was false,
+# silently deleting rowid 0 if present. Today VDBE gates this with
+# successful seek so the path is walled off, but the SQL surface
+# needs to pin rowid-0 behavior in case a future change ever lets a
+# CURSOR_INVALID state reach Delete.
+oracle "cat16_rowid_zero_survives_seek_miss" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(0,'zero'),(1,'one'),(2,'two');
+DELETE FROM t WHERE rowid=999;
+SELECT id, v FROM t ORDER BY id;
+"
+
+# 16n. Rowid 0 + DELETE with always-false predicate. VDBE walks the
+# table and conditionally deletes; cursor goes invalid at end of scan.
+oracle "cat16_rowid_zero_survives_no_match_delete" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(0,'zero'),(1,'one'),(2,'two');
+DELETE FROM t WHERE v='nonexistent';
+SELECT id, v FROM t ORDER BY id;
+"
+
+# 16o. Rowid 0 + DELETE that empties the table. The cursor sweeps
+# through all rows. Verify rowid 0 is treated like every other rowid
+# and not double-deleted by a stray no-key Delete.
+oracle "cat16_rowid_zero_full_delete" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(0,'zero'),(1,'one'),(2,'two');
+DELETE FROM t WHERE id<10;
+SELECT count(*) FROM t;
+INSERT INTO t VALUES(0,'fresh-zero');
+SELECT * FROM t;
+"
+
+# 16p. Empty-key (zero-length blob) row on an index. Same shape as
+# rowid 0 for the blob path of prollyBtCursorDelete.
+oracle "cat16_empty_blob_key_survives" "
+CREATE TABLE t(k BLOB PRIMARY KEY, v TEXT) WITHOUT ROWID;
+INSERT INTO t VALUES (x'', 'empty-key'),(x'01','one'),(x'02','two');
+DELETE FROM t WHERE k=x'ff';
+SELECT hex(k), v FROM t ORDER BY k;
+"
+
+# 16q. INSERT OR REPLACE colliding with rowid 0. REPLACE goes
+# through cursor.delete with a known key — make sure the row at
+# rowid 0 is the one replaced and nothing else gets removed.
+oracle "cat16_rowid_zero_replace_no_collateral" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(0,'zero'),(1,'one'),(2,'two');
+INSERT OR REPLACE INTO t VALUES(0,'replaced');
+SELECT id, v FROM t ORDER BY id;
+"
+
+# 16r. UPDATE on rowid 0 — internally a delete+insert. Confirms the
+# UPDATE path doesn't accidentally trigger the no-key delete bug.
+oracle "cat16_rowid_zero_update_no_collateral" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(0,'zero'),(1,'one'),(2,'two');
+UPDATE t SET v='updated' WHERE id=0;
+SELECT id, v FROM t ORDER BY id;
+"
+
 # ════════════════════════════════════════════════════════════════════
 # Category 17: Partial indexes
 # ════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

`prollyBtCursorDelete` walks a cascade of fallbacks to resolve the key of the row to delete (mmActive entry → cachedIntKey → live prolly cursor → cached payload sortkey → cursor key). If every branch misses, `hasSavedKey` stays 0 and execution falls through to:

```c
if( pCur->curIntKey ){
  if( hasSavedKey ){ iKey = savedIntKey; }
  rc = prollyMutMapDelete(pCur->pMutMap, NULL, 0, iKey);  // iKey = 0
}
```

A `prollyMutMapDelete` with `iKey=0` silently deletes rowid 0 if it exists. The blob path has the same shape with `pKey=0, nKey=0`, deleting the empty-blob row.

## Reachability

**Today: not reachable from SQL.** I tried half a dozen shapes that should land an INVALID cursor at `OP_Delete`:

- `DELETE WHERE rowid=999` (seek-miss)
- `DELETE WHERE rowid IN (empty subquery)`
- `DELETE WHERE v='nonexistent'` (always-false predicate)
- `INSERT OR REPLACE` collisions with rowid 0
- `UPDATE WHERE rowid=0`

All preserved rowid 0 correctly. SQLite's VDBE gates `OP_Delete` on a successful prior seek; pending-flush invalidation sets `eState=CURSOR_FAULT` which returns `SQLITE_CORRUPT_BKPT` at the top of `prollyBtCursorDelete`.

So the original deep-review claim ("window opens after pending-flush invalidation between SeekRowid and Delete") doesn't actually hold against current code. But the latent fallthrough is a real corruption mode if anything upstream changes (VDBE refactor, fuzz, future C-API caller, FORDELETE cursor semantics).

## Fix

Convert the implicit fallthrough into an explicit `return SQLITE_OK` no-op when `hasSavedKey` is false. Worst case becomes "Delete did nothing" instead of "Delete clobbered rowid 0".

## Tests

6 tripwire cases in Category 16 pin the SQL-level behavior:

- `cat16_rowid_zero_survives_seek_miss` — rowid 0 survives DELETE with no match
- `cat16_rowid_zero_survives_no_match_delete` — same via predicate
- `cat16_rowid_zero_full_delete` — full sweep treats rowid 0 like every other rowid
- `cat16_empty_blob_key_survives` — empty-blob row survives no-match DELETE (blob path)
- `cat16_rowid_zero_replace_no_collateral` — INSERT OR REPLACE replaces only rowid 0
- `cat16_rowid_zero_update_no_collateral` — UPDATE on rowid 0 doesn't touch others

If any future change re-exposes the no-key Delete path, these tests diverge from stock SQLite and surface the regression.

## Test plan

- [x] Clean build, no new warnings
- [x] `test/sql_oracle_test.sh` — 546/546 (540 prior + 6 new)
- [x] `test/doltlite_commit.sh` — 44/44
- [x] `test/doltlite_branch.sh` — 60/60
- [x] `test/doltlite_merge.sh` — 91/91
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)