### PR TITLE
fix(btree): defer pSavedDelKey free past the SAVEPOSITION reseek

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -7064,30 +7064,18 @@ static int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
   }
 
   rc = syncSavepoints(pCur);
-  if( rc!=SQLITE_OK ){
-    if( savedDelKeyOwned ) sqlite3_free(pSavedDelKey);
-    return rc;
-  }
+  if( rc!=SQLITE_OK ) goto delete_cleanup;
 
   if( pCur->pgnoRoot==1 ){
     rc = ensureStatementSavepointsCaptured(pCur->pBtree);
-    if( rc!=SQLITE_OK ){
-      if( savedDelKeyOwned ) sqlite3_free(pSavedDelKey);
-      return rc;
-    }
+    if( rc!=SQLITE_OK ) goto delete_cleanup;
   }
 
   rc = saveAllCursors(pCur->pBtree, pCur->pBt, pCur->pgnoRoot, pCur);
-  if( rc!=SQLITE_OK ){
-    if( savedDelKeyOwned ) sqlite3_free(pSavedDelKey);
-    return rc;
-  }
+  if( rc!=SQLITE_OK ) goto delete_cleanup;
 
   rc = ensureMutMap(pCur);
-  if( rc!=SQLITE_OK ){
-    if( savedDelKeyOwned ) sqlite3_free(pSavedDelKey);
-    return rc;
-  }
+  if( rc!=SQLITE_OK ) goto delete_cleanup;
 
   /* If no key could be resolved from cursor state, treat the delete as
   ** a no-op. Falling through would call prollyMutMapDelete with iKey=0
@@ -7097,8 +7085,8 @@ static int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
   ** Delete on an invalid cursor in normal bytecode, but a future
   ** refactor or fuzz path could. */
   if( !hasSavedKey ){
-    if( savedDelKeyOwned ) sqlite3_free(pSavedDelKey);
-    return SQLITE_OK;
+    rc = SQLITE_OK;
+    goto delete_cleanup;
   }
   if( pCur->curIntKey ){
     iKey = savedIntKey;
@@ -7107,11 +7095,13 @@ static int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
     pKey = pSavedDelKey;
     nKey = nSavedDelKey;
     rc = prollyMutMapDelete(pCur->pMutMap, pKey, nKey, 0);
-    if( savedDelKeyOwned ) sqlite3_free(pSavedDelKey);
-    pSavedDelKey = 0;
+    /* Don't free pSavedDelKey here. The SAVEPOSITION reseek below reads
+    ** from pKey, which aliases pSavedDelKey when savedDelKeyOwned is
+    ** set; freeing now would memcpy from a dangling pointer. Cleanup
+    ** runs at delete_cleanup once the reseek (if any) has finished. */
   }
 
-  if( rc!=SQLITE_OK ) return rc;
+  if( rc!=SQLITE_OK ) goto delete_cleanup;
 
   {
     int canDefer = (pCur->pgnoRoot > 1);
@@ -7129,12 +7119,13 @@ static int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
       } else {
         pCur->eState = CURSOR_INVALID;
       }
-      return SQLITE_OK;
+      rc = SQLITE_OK;
+      goto delete_cleanup;
     }
   }
 
   rc = btreeDeleteImmediate(pCur);
-  if( rc!=SQLITE_OK ) return rc;
+  if( rc!=SQLITE_OK ) goto delete_cleanup;
 
   if( flags & BTREE_SAVEPOSITION ){
     int res = 0;
@@ -7164,7 +7155,11 @@ static int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
     pCur->eState = CURSOR_INVALID;
   }
 
-  return SQLITE_OK;
+  rc = SQLITE_OK;
+
+delete_cleanup:
+  if( savedDelKeyOwned ) sqlite3_free(pSavedDelKey);
+  return rc;
 }
 int sqlite3BtreeDelete(BtCursor *pCur, u8 flags){
   if( !pCur ) return SQLITE_OK;

--- a/test/sql_oracle_test.sh
+++ b/test/sql_oracle_test.sh
@@ -1892,6 +1892,41 @@ UPDATE t SET v='updated' WHERE id=0;
 SELECT id, v FROM t ORDER BY id;
 "
 
+# 16s. BTREE_SAVEPOSITION reseek-after-delete shape against a
+# blob/WITHOUT-ROWID table with >65k pending mutations. The mutmap
+# drain threshold (PROLLY_MUTMAP_PENDING_FLUSH_LIMIT) forces canDefer
+# to 0 inside prollyBtCursorDelete, falling through to the
+# btreeDeleteImmediate + reseek path. The reseek aliased the freed
+# pSavedDelKey via local pKey when savedDelKeyOwned was set — a UAF
+# the goto-cleanup refactor in this PR closes. Even though the
+# free-then-read may return plausible bytes from a freshly-freed
+# allocator slot, ASAN would catch the read; this oracle pins the
+# correct behavior end-to-end.
+oracle "cat16_savepos_blob_pk_bulk_update" "
+CREATE TABLE t(k BLOB PRIMARY KEY, v TEXT) WITHOUT ROWID;
+CREATE INDEX t_v ON t(v);
+BEGIN;
+WITH RECURSIVE c(i) AS (VALUES(1) UNION ALL SELECT i+1 FROM c WHERE i<70000)
+  INSERT INTO t SELECT randomblob(32), printf('v%05d', i) FROM c;
+UPDATE t SET v = v || 'X' WHERE v < 'v00500';
+SELECT count(*) FROM t;
+SELECT count(*) FROM t WHERE v LIKE '%X';
+COMMIT;
+SELECT count(*) FROM t WHERE v LIKE '%X';
+"
+
+# 16t. Same shape but DELETE rather than UPDATE.
+oracle "cat16_savepos_blob_pk_bulk_delete" "
+CREATE TABLE t(k BLOB PRIMARY KEY, v TEXT) WITHOUT ROWID;
+BEGIN;
+WITH RECURSIVE c(i) AS (VALUES(1) UNION ALL SELECT i+1 FROM c WHERE i<70000)
+  INSERT INTO t SELECT randomblob(32), printf('v%05d', i) FROM c;
+DELETE FROM t WHERE v < 'v00500';
+SELECT count(*) FROM t;
+COMMIT;
+SELECT count(*) FROM t;
+"
+
 # ════════════════════════════════════════════════════════════════════
 # Category 17: Partial indexes
 # ════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

In `prollyBtCursorDelete`'s blob branch:

```c
} else {
  if( hasSavedKey ){
    pKey = pSavedDelKey;       // pKey ALIASES pSavedDelKey
    nKey = nSavedDelKey;
  }
  rc = prollyMutMapDelete(pCur->pMutMap, pKey, nKey, 0);
  if( savedDelKeyOwned ) sqlite3_free(pSavedDelKey);  // pKey now dangles
  pSavedDelKey = 0;
}
```

Later, after `btreeDeleteImmediate`, the SAVEPOSITION reseek does:

```c
} else if( pKey && nKey > 0 ){
  u8 *pReseek = sqlite3_malloc(nKey);
  if( pReseek ){
    memcpy(pReseek, pKey, nKey);   // read from freed allocation
    rc = prollyCursorSeekBlob(&pCur->pCur, pReseek, nKey, &res);
    ...
```

Use-after-free. ASAN catches it under the right workload, but sqlite3_malloc's reuse pattern often returns the freshly-freed bytes intact, so the SQL-level symptom is rare.

## Reachability

All of:
1. `canDefer == 0` — either `pCur->pgnoRoot == 1` (sqlite_master via writable_schema, which SQLite's parser blocks today) or `mutMapShouldDrain(pCur)` (≥65k pending entries)
2. Non-INTKEY table
3. `flags & BTREE_SAVEPOSITION` set by VDBE
4. `savedDelKeyOwned == 1` — key came from mmActive iteration or live prolly cursor (not the borrowed `pSeekSortKey` path)

Narrow but real. The fix is a refactor with no behavior change for working paths and removes a latent memory-safety bug.

## Fix

Consolidate the error/success exits to a single `delete_cleanup:` label and free `pSavedDelKey` once at function exit. `pSavedDelKey` now outlives the reseek; `pKey`'s alias is valid for the whole function body.

## Tests

Two new oracle cases:

- `cat16_savepos_blob_pk_bulk_update` — 70k inserts on `WITHOUT ROWID` BLOB-PK table, then `UPDATE` that triggers the drain+reseek path.
- `cat16_savepos_blob_pk_bulk_delete` — same shape, `DELETE` variant.

## Test plan

Verified clean under `-fsanitize=address,undefined -fno-sanitize-recover=all`:

- [x] `test/oracle_savepoints_test.sh` — 43/43
- [x] `test/oracle_foreign_keys_test.sh` — 45/45
- [x] `test/oracle_upsert_test.sh` — 35/35
- [x] `test/oracle_generated_columns_test.sh` — 37/37
- [x] `test/oracle_without_rowid_test.sh` — 39/39
- [x] `test/oracle_triggers_test.sh` — 27/27
- [x] `test/sql_oracle_test.sh` — 542/542 (540 prior + 2 new)
- [x] `test/doltlite_commit.sh` — 44/44
- [x] `test/doltlite_branch.sh` — 60/60
- [x] `test/doltlite_merge.sh` — 91/91
- [x] `test/doltlite_conflicts.sh` — 40/40
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)