### PR TITLE
fix(btree): xCursor returns CORRUPT on stale iTable instead of synthesizing

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -5289,17 +5289,37 @@ static int prollyBtreeCursor(
 
   pTE = findTable(p, iTable);
   if( !pTE ){
-    u8 flags = pKeyInfo ? BTREE_BLOBKEY : BTREE_INTKEY;
+    /* Two shapes land here:
+    **
+    **  (a) iTable < iNextTable — the iTable was previously allocated
+    **      and is gone from the catalog. Almost always indicates a
+    **      stale SQLite schema cache referring to a table that doltlite
+    **      has dropped (DROP TABLE, branch switch, dolt_reset). Stock
+    **      SQLite would return SQLITE_CORRUPT_PGNO from xCursor under
+    **      similar conditions; matching that behavior is much safer
+    **      than synthesizing a phantom entry that subsequent inserts
+    **      then write into and persist on commit.
+    **
+    **  (b) iTable >= iNextTable — the iTable has never been allocated
+    **      in this catalog. The merge / catalog-rebuild paths use this
+    **      shape to materialize tables they're importing from another
+    **      branch, opening read cursors before doltlite's catalog has
+    **      formally registered them. Synthesize for these. */
     if( iTable < p->cat.iNextTable ){
-      sqlite3_log(SQLITE_NOTICE,
+      sqlite3_log(SQLITE_CORRUPT,
         "doltlite: cursor open on iTable=%u not in catalog "
-        "(iNextTable=%u); synthesizing %s entry from pKeyInfo. "
-        "May indicate stale schema cache.",
+        "(iNextTable=%u, %s requested); rejecting as CORRUPT. "
+        "Likely cause: stale schema cache after a branch switch, "
+        "DROP, or concurrent catalog rewrite.",
         (unsigned)iTable, (unsigned)p->cat.iNextTable,
         pKeyInfo ? "BLOBKEY" : "INTKEY");
+      return SQLITE_CORRUPT_PGNO(iTable);
     }
-    pTE = addTable(p, iTable, flags);
-    if( !pTE ) return SQLITE_NOMEM;
+    {
+      u8 flags = pKeyInfo ? BTREE_BLOBKEY : BTREE_INTKEY;
+      pTE = addTable(p, iTable, flags);
+      if( !pTE ) return SQLITE_NOMEM;
+    }
   }
 
   pCur->curIntKey = (pTE->flags & BTREE_INTKEY) ? 1 : 0;


### PR DESCRIPTION
## Summary

`prollyBtreeCursor` used to handle every missing-catalog-entry case identically: synthesize a fresh `TableEntry` with flags guessed from `pKeyInfo`, log a `NOTICE` for the "stale schema" subcase, and continue. Writes through that phantom cursor went into the synthesized `pTE->pPending` and persisted through commit, silently injecting an empty table into the on-disk catalog. The existing log comment even named the failure mode: *"May indicate stale schema cache."*

## Two shapes land at the missing-entry branch

| shape | meaning | safe? |
|-------|---------|-------|
| `iTable < iNextTable` | iTable was previously allocated, now gone from catalog. Stale SQLite `Schema` cache after `DROP TABLE`, branch switch, `dolt_reset`. | No — stock SQLite returns `SQLITE_CORRUPT_PGNO` from xCursor in analogous conditions |
| `iTable >= iNextTable` | iTable has never been allocated in this catalog. The merge / catalog-rebuild paths open read cursors here to materialize tables imported from another branch before `doltliteBtreeCreateTable` formally registers them. | Yes — load-bearing for merge |

## Fix

Split the cases:

- `iTable < iNextTable` → log + `return SQLITE_CORRUPT_PGNO(iTable)`.
- `iTable >= iNextTable` → keep the synthesis path (no behavior change).

Confirmed empirically: the only path that exercises shape (b) in the test suite is `dolt_merge` — `fk_tables_plus_check_*` and friends. Initial naive attempt that rejected both shapes broke those tests; the split keeps them green.

## Test plan

Verified under `-fsanitize=address,undefined -fno-sanitize-recover=all`:

- [x] `test/sql_oracle_test.sh` — 548/548
- [x] `test/doltlite_commit.sh` — 44/44
- [x] `test/doltlite_branch.sh` — 60/60
- [x] `test/doltlite_merge.sh` — 91/91 (the test that originally broke)
- [x] `test/doltlite_conflicts.sh` — 40/40
- [x] `test/oracle_savepoints_test.sh` — 43/43
- [x] `test/oracle_foreign_keys_test.sh` — 45/45
- [x] `test/oracle_upsert_test.sh` — 35/35
- [x] `test/oracle_without_rowid_test.sh` — 39/39
- [x] `test/oracle_triggers_test.sh` — 27/27
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)