### PR TITLE
fix(btree): assert graph lock held on rollback writeback paths

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -4792,6 +4792,8 @@ static int prollyBtreeRollback(Btree *p, int tripCode, int writeOnly){
   (void)writeOnly;
 
   if( p->inTrans==TRANS_WRITE ){
+    assert( pBt->store.isMemory || pBt->store.graphLockFd >= 0 );
+    assert( pBt->store.isMemory || pBt->store.lockDepth > 0 );
     rc = restoreFromCommitted(p);
     if( rc!=SQLITE_OK ){
       chunkStoreUnlock(&pBt->store);
@@ -4914,6 +4916,9 @@ static int persistRolledBackSessionState(Btree *p, BtShared *pBt){
   ProllyHash catHash;
   const char *zBr = p->zBranch ? p->zBranch : "main";
   int rc;
+
+  assert( pBt->store.isMemory || pBt->store.graphLockFd >= 0 );
+  assert( pBt->store.isMemory || pBt->store.lockDepth > 0 );
 
   rc = serializeCatalog(p, &catData, &nCatData);
   if( rc==SQLITE_OK ){


### PR DESCRIPTION
## Summary

`prollyBtreeRollback` writes the post-`restoreFromCommitted` catalog and working-set blob to disk when the in-memory state diverges from on-disk (gated by `bMatchesDisk`). `persistRolledBackSessionState` (used by named-savepoint rollback) does the same unconditionally. Both assume the chunk-store graph lock is held — without it, two writers on the same branch could race and one would clobber the other's on-disk working set.

Today the lock is acquired in `prollyBtreeBeginTrans` and held through the entire write transaction; `chunkStoreCommit` only acquires/releases when `graphLockFd<0`, so mid-txn `dolt_commit` and friends don't drop it. The locking discipline is intact — but the disk-write blocks have no on-path check that any future refactor would have to honor.

## Fix

Asserts at the entry to each write block:

```c
assert( pBt->store.isMemory || pBt->store.graphLockFd >= 0 );
assert( pBt->store.isMemory || pBt->store.lockDepth > 0 );
```

`NDEBUG` release builds elide these. The `asan-ubsan` CI lane builds without `NDEBUG` (Sanitizers workflow `CFLAGS`) so the asserts are live there — any future regression that reaches the disk-write block without holding the lock surfaces in CI rather than as a silent clobber.

## Context

This is the smaller-than-the-report part of Critical #7 from the deep code review. The original report claimed:

- "Rollback writes to disk via `chunkStorePut`+`chunkStoreCommit`" — true, but by design for doltlite's session-level VC state.
- "Violates SQLite's `xRollback`-side-effect-free contract" — true at the SQLite level, accepted trade-off for doltlite.
- "Bumps `iWorkingStateVersion` mid-rollback" — **false**; verified by grep, that field is only bumped by the shared-WS refresh and `prollyBtreeCommitPhaseTwo`.

There's no live bug here — the lock is held continuously through the write transaction. Defensive tripwire only.

## Test plan

Built with `-fsanitize=address,undefined -fno-sanitize-recover=all` (asserts live):

- [x] `test/oracle_savepoints_test.sh` — 43/43
- [x] `test/doltlite_commit.sh` — 44/44
- [x] `test/doltlite_branch.sh` — 60/60
- [x] `test/doltlite_merge.sh` — 91/91
- [x] `test/sql_oracle_test.sh` — 548/548
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)