### PR TITLE
fix(check): re-hash chunk content in prollyCheckTree

### DIFF
--- a/src/prolly_check.c
+++ b/src/prolly_check.c
@@ -38,6 +38,31 @@ static int checkSubtree(
     return rc;
   }
 
+  /* Re-derive the content hash and compare. chunkStoreGet's own verify
+  ** only covers the disk-read path; chunks served from the in-memory
+  ** pending or recent buffers return their cached bytes unverified.
+  ** The integrity walker is the last line of defense against an
+  ** in-process corruption (buffer overrun, stale alias, etc.) that
+  ** mutated the staging bytes between write and check, so re-hash
+  ** unconditionally here. */
+  {
+    ProllyHash computed;
+    prollyHashCompute(pData, nData, &computed);
+    if( prollyHashCompare(&computed, pHash) != 0 ){
+      *pzErr = sqlite3_mprintf(
+        "chunk content does not hash to its store key: "
+        "expected=%02x%02x%02x%02x%02x%02x%02x%02x "
+        "computed=%02x%02x%02x%02x%02x%02x%02x%02x nData=%d",
+        pHash->data[0], pHash->data[1], pHash->data[2], pHash->data[3],
+        pHash->data[4], pHash->data[5], pHash->data[6], pHash->data[7],
+        computed.data[0], computed.data[1], computed.data[2], computed.data[3],
+        computed.data[4], computed.data[5], computed.data[6], computed.data[7],
+        nData);
+      sqlite3_free(pData);
+      return SQLITE_CORRUPT;
+    }
+  }
+
   rc = prollyNodeParse(&node, pData, nData);
   if( rc!=SQLITE_OK ){
     *pzErr = sqlite3_mprintf(


### PR DESCRIPTION
## Summary

\`checkSubtree\` in \`prolly_check.c\` fetches each chunk via \`chunkStoreGet\`, parses it as a node, walks the tree, and validates structural invariants (level monotonicity, key order, parent/child boundary equality). It does **not** verify that the bytes it just received actually hash to the key it was looking up under.

\`chunkStoreGet\` has its own content-hash verify, but only on the disk-read path. Chunks served from the in-memory pending or recent staging buffers return cached bytes unverified (\`chunk_store.c\`, the \`verify:\` fall-through at line 926 is reached only after \`sqlite3OsRead\`, not after the in-memory copies). If anything between a successful \`chunkStorePut\` and a subsequent \`prollyCheckTree\` walks those bytes — buffer overrun in another module, stale alias, use-after-free that happens to land in a still-allocated staging slot — the integrity walker sees the corrupted data, parses it as a valid node, and passes.

Silent corruption inside an invariant-checking build is exactly the failure mode the check exists to prevent.

## Fix

After \`chunkStoreGet\` succeeds, recompute BLAKE3 of \`pData\` and compare to the requested \`pHash\`. Mismatch returns \`SQLITE_CORRUPT\` with a diagnostic showing both hashes and the chunk size. \`prollyMutateFlush\` then aborts as usual on \`SQLITE_CORRUPT\`.

This is compiled into test binaries only (\`-DDOLTLITE_PROLLY_CHECK=1\`); production releases never see it. One extra BLAKE3 per chunk visited — the walker is already O(N) over chunks, so the additional cost is a constant factor that's fine in a check-only build.

## Test plan

Built with \`DOLTLITE_PROLLY_CHECK=1\` (the check is gated on this flag — without it the file isn't compiled). Every mutmap flush walks the tree and verifies every chunk:

- [x] \`test/doltlite_commit.sh\` — 44/44
- [x] \`test/doltlite_branch.sh\` — 60/60
- [x] \`test/doltlite_merge.sh\` — 91/91
- [x] \`test/doltlite_conflicts.sh\` — 40/40
- [x] \`test/sql_oracle_test.sh\` — 548/548
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)