### PR TITLE
fix(mutmap): assert key-mode match in prollyMutMapMerge

### DIFF
--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -1117,8 +1117,20 @@ int prollyMutMapClone(ProllyMutMap **out, const ProllyMutMap *src){
   return SQLITE_OK;
 }
 
+/* Merge every entry in pSrc into pDst and clear pSrc. Both maps MUST
+** be in the same key mode (isIntKey). For int-keyed maps, each entry's
+** pKey contains its key already encoded big-endian via encodeIntKeyBE
+** (see prepKey above and prollyMutMapEntryIntKey), so passing pKey/nKey
+** with intKey=0 takes the "pre-encoded blob" branch of prepKey and the
+** byte sequence is used as-is — the right thing for matched modes. If
+** the modes don't match, however, an int-keyed pSrc's 8-byte encoded
+** bytes get treated as a blob key (or vice versa: a blob key gets
+** misread as an encoded int), silently corrupting pDst's sort order
+** and hash table. */
 int prollyMutMapMerge(ProllyMutMap *pDst, ProllyMutMap *pSrc){
   int i, rc;
+  assert( pDst->isIntKey == pSrc->isIntKey );
+  if( pDst->isIntKey != pSrc->isIntKey ) return SQLITE_MISUSE;
   for(i=0; i<pSrc->nEntries; i++){
     ProllyMutMapEntry *e = &pSrc->aEntries[i];
     if( e->op==PROLLY_EDIT_INSERT ){


### PR DESCRIPTION
## Summary

\`prollyMutMapMerge\` walks pSrc's entries and re-inserts each into pDst, passing \`intKey=0\` unconditionally. That works when both maps are in the same key mode:

- **blob-keyed**: \`prepKey\` is a no-op (\`mm->isIntKey\` is false); the entry's \`pKey\`/\`nKey\` is used verbatim.
- **int-keyed**: \`prepKey\` sees \`pKey != 0\` / \`nKey > 0\` and takes the "pre-encoded blob" branch — entries store their key as the 8-byte big-endian \`encodeIntKeyBE\` output (see \`prollyMutMapEntryIntKey\` for the reverse direction). \`intKey=0\` satisfies \`prepKey\`'s internal assert.

But if \`pDst->isIntKey != pSrc->isIntKey\`:

- **blob → int**: pSrc's arbitrary-length blob bytes get treated as a pre-encoded intKey, taking the prepKey shortcut and entering pDst with wrong sort order.
- **int → blob**: pSrc's 8-byte encoded intKey gets stored as a blob key that no other entry in pDst can ever match by content, breaking merge semantics.

Either direction: silent corruption of pDst's order/hash; no diagnostic.

## Reachability

\`prollyMutMapMerge\` has **no callers in the tree today**. Purely latent — exists in the API surface but isn't wired up. This fix prevents any future caller from triggering the bug without first verifying the key-mode invariant.

## Fix

Add the invariant explicitly: \`assert(pDst->isIntKey == pSrc->isIntKey)\` for debug/ASAN catch, plus a \`return SQLITE_MISUSE\` for production diagnostic. Doc comment names the contract above the function.

## Test plan

Tests unchanged (dead-code function, no behavior change for live paths):

- [x] \`test/sql_oracle_test.sh\` — 548/548
- [x] \`test/doltlite_commit.sh\` — 44/44
- [x] \`test/doltlite_branch.sh\` — 60/60
- [x] \`test/doltlite_merge.sh\` — 91/91
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)