### PR TITLE
fix(diff): scope cursor-walk fallback to the current subtree

### DIFF
--- a/src/prolly_diff.c
+++ b/src/prolly_diff.c
@@ -512,8 +512,15 @@ static int diffNodesOneLevel(
             sqlite3_free(pCO); sqlite3_free(pCN);
             rc = SQLITE_NOMEM;
           }else{
-            prollyCursorInit(pCO, pStore, pCache, pOldRoot, flags);
-            prollyCursorInit(pCN, pStore, pCache, pNewRoot, flags);
+            /* Walk only the current subtree, NOT the absolute root.
+            ** Using pOldRoot/pNewRoot would re-traverse regions
+            ** already queued on the driver's stack (sibling subtrees
+            ** of ancestors), causing duplicate ADD/DELETE/MODIFY
+            ** callbacks once those pairs get popped and processed.
+            ** Compare with the level-mismatch path at the bottom of
+            ** this function, which already passes pOldHash/pNewHash. */
+            prollyCursorInit(pCO, pStore, pCache, pOldHash, flags);
+            prollyCursorInit(pCN, pStore, pCache, pNewHash, flags);
 
             if( i > 0 && (flags & PROLLY_NODE_INTKEY) ){
               i64 seekKey = prollyNodeIntKey(&oldNode, i-1);


### PR DESCRIPTION
## Summary

\`diffNodesOneLevel\` walks two interior nodes in lockstep, pushing equal-bound child pairs onto the driver's stack and falling back to a cursor merge-walk when interior keys diverge. The fallback at \`prolly_diff.c:515\` initialized both cursors on \`pOldRoot\`/\`pNewRoot\` — the absolute tree roots, plumbed down from \`prollyDiff\` — then seeked them to the previous interior boundary key.

That's wrong when we're not at the top level. Starting cursors at the absolute root means the merge-walk visits every key from the seek point all the way to EOF of the entire tree. Sibling-of-ancestor subtrees with keys greater than the seek key get re-walked here AND again when their (already-pushed) stack pairs are later popped — producing duplicate ADD / DELETE / MODIFY callbacks.

## Trace

1. \`prollyDiff\` seeds the stack with \`(rootOld, rootNew)\` and pops it.
2. \`diffNodesOneLevel\` iterates root.children. Slots whose hashes differ but whose keys match get **pushed** onto the stack. A slot with diverging keys triggers the **fallback**, walks \`pOldRoot\` from that key to EOF (covers everything from that point onward), sets \`i=j=nItems\`, exits.
3. Earlier-pushed pairs are then popped. They cover the regions BEFORE the root-level fallback's seek key, so they don't overlap — good.
4. But when one of those subtree pairs has its own interior key divergence, its fallback also walks \`pOldRoot\` from its (smaller) seek key to EOF — which now includes the regions the root-level fallback already covered. **Double emission.**

## Fix

The level-mismatch path one screen down (\`prolly_diff.c:572\`) already passes \`pOldHash\`/\`pNewHash\` to \`diffCursorWalk\` for exactly this reason; the interior fallback was the only spot still using the absolute roots. Two-character fix: \`pOldRoot\`/\`pNewRoot\` → \`pOldHash\`/\`pNewHash\`.

## Test plan

- [x] \`test/doltlite_diff.sh\` — 36/36
- [x] \`test/doltlite_diff_table.sh\` — 39/39
- [x] \`test/doltlite_diff_alter.sh\` — 15/15
- [x] \`test/doltlite_merge.sh\` — 91/91
- [x] \`test/doltlite_conflicts.sh\` — 40/40
- [x] \`test/sql_oracle_test.sh\` — 548/548
- [x] Also passes under \`DOLTLITE_PROLLY_CHECK=1\` (every mutmap flush re-walks the tree and verifies invariants)
- [ ] CI

## Why existing tests didn't catch this

Existing diff tests work small datasets where the prolly tree is one level deep, so they don't actually hit the bug — explaining how it lay latent. A regression test that triggers it deterministically would need 5000+ row tables with structured cross-branch deletes that diverge interior boundaries at multiple levels; deferring that to a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)