### PR TITLE
fix(vc): tier-3 trio — fall-through annotation, real ±0.0 diff, force-current-branch guard

### DIFF
--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -494,6 +494,13 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
       }
       m.zName = zName;
       m.force = force;
+      if( force
+       && strcmp(zName, doltliteGetSessionBranch(db))==0
+       && chunkStoreFindBranch(cs, zName, 0)==SQLITE_OK ){
+        branchError(ctx, hadSavepoint,
+          "cannot force-update the current branch");
+        return;
+      }
       rc = doltliteMutateRefs(db, mutateBranchRef, &m);
       if( rc!=SQLITE_OK ){
         branchNamedResultError(ctx, hadSavepoint, rc,

--- a/src/doltlite_diff_stat.c
+++ b/src/doltlite_diff_stat.c
@@ -178,6 +178,18 @@ static int dsFieldValuesEqual(
       return ai==bi;
     }
   }
+  if( aType==7 && bType==7 ){
+    u64 ar = 0, br = 0;
+    double da, db;
+    int i;
+    if( aOff<0 || aOff+8>nA ) return 0;
+    if( bOff<0 || bOff+8>nB ) return 0;
+    for(i=0; i<8; i++) ar = (ar<<8) | pA[aOff+i];
+    for(i=0; i<8; i++) br = (br<<8) | pB[bOff+i];
+    memcpy(&da, &ar, 8);
+    memcpy(&db, &br, 8);
+    return da == db;
+  }
   if( aType != bType ) return 0;
   aLen = dlSerialTypeLen(aType);
   if( aLen<0 ) return 0;

--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -743,6 +743,19 @@ static int fieldValuesEqual(
     }
   }
 
+  if( aType==7 && bType==7 ){
+    u64 ar = 0, br = 0;
+    double da, db;
+    int i;
+    if( aOff<0 || aOff+8>nA ) return 0;
+    if( bOff<0 || bOff+8>nB ) return 0;
+    for(i=0; i<8; i++) ar = (ar<<8) | pA[aOff+i];
+    for(i=0; i<8; i++) br = (br<<8) | pB[bOff+i];
+    memcpy(&da, &ar, 8);
+    memcpy(&db, &br, 8);
+    return da == db;
+  }
+
   if( aType != bType ) return 0;
   aLen = dlSerialTypeLen(aType);
   if( aLen<0 ) return 0;

--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -562,6 +562,7 @@ static int rowMergeCallback(void *pCtx, const ThreeWayChange *pChange){
       }
 
     }
+    deliberate_fall_through
     case THREE_WAY_CONFLICT_DM: {
 
       rc = DOLTLITE_GROW_ARRAY(&ctx->aConflicts, &ctx->nConflictsAlloc,

--- a/test/doltlite_branch_edge.sh
+++ b/test/doltlite_branch_edge.sh
@@ -445,6 +445,52 @@ run_test "gc_empty_db_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 db_rm "$DB"
 
 echo ""
+echo "--- Category 7: Force-update of currently-checked-out branch ---"
+
+DB=/tmp/test_bedge_force_curr_$$.db; db_rm "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'c1');
+SELECT dolt_commit('-A','-m','c1');
+INSERT INTO t VALUES(2,'c2');
+SELECT dolt_commit('-A','-m','c2');
+INSERT INTO t VALUES(3,'c3');
+SELECT dolt_commit('-A','-m','c3');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test_match "force_current_branch_rejected" \
+  "SELECT dolt_branch('-f','main','HEAD~2');" \
+  "cannot force-update the current branch" "$DB"
+
+run_test "force_current_branch_no_state_change" \
+  "SELECT count(*) FROM t;" \
+  "3" "$DB"
+
+run_test "force_current_branch_log_intact" \
+  "SELECT count(*) FROM dolt_log;" \
+  "4" "$DB"
+
+echo "SELECT dolt_branch('other');
+SELECT dolt_checkout('other');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test "force_other_branch_allowed" \
+  "SELECT dolt_checkout('other'); SELECT dolt_branch('-f','main','HEAD~2'); SELECT dolt_checkout('main'); SELECT count(*) FROM dolt_log;" \
+  "0
+0
+0
+2" "$DB"
+
+db_rm "$DB"
+
+DB=/tmp/test_bedge_force_nonexist_$$.db; db_rm "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY);
+SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test_match "force_create_new_branch_allowed" \
+  "SELECT dolt_branch('-f','brand_new');" \
+  "^$|0" "$DB"
+
+db_rm "$DB"
+
+echo ""
 
 echo "=== Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests ==="
 if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi

--- a/test/doltlite_diff.sh
+++ b/test/doltlite_diff.sh
@@ -211,7 +211,48 @@ run_test "diff_summary_revert_schema_only_row" \
   "SELECT table_name || '|' || data_change || '|' || schema_change FROM dolt_diff WHERE message='main_check';" \
   "t|0|1" "$DB13"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13"
+DB14=/tmp/test_diff14_$$.db; rm -f "$DB14"
+echo "CREATE TABLE r(id INTEGER PRIMARY KEY, v REAL);
+INSERT INTO r VALUES(1, 3.14);
+SELECT dolt_commit('-A','-m','c1');
+UPDATE r SET v = 3.14 WHERE id=1;" | $DOLTLITE "$DB14" > /dev/null 2>&1
+
+run_test "diff_real_same_value_no_diff" \
+  "SELECT count(*) FROM dolt_diff_r WHERE to_commit='WORKING';" \
+  "0" "$DB14"
+
+DB15=/tmp/test_diff15_$$.db; rm -f "$DB15"
+echo "CREATE TABLE r(id INTEGER PRIMARY KEY, v REAL);
+INSERT INTO r VALUES(1, 0.0);
+SELECT dolt_commit('-A','-m','c1');
+UPDATE r SET v = -0.0 WHERE id=1;" | $DOLTLITE "$DB15" > /dev/null 2>&1
+
+run_test "diff_real_pos_neg_zero_no_diff" \
+  "SELECT count(*) FROM dolt_diff_r WHERE to_commit='WORKING';" \
+  "0" "$DB15"
+
+DB16=/tmp/test_diff16_$$.db; rm -f "$DB16"
+echo "CREATE TABLE r(id INTEGER PRIMARY KEY, v REAL);
+INSERT INTO r VALUES(1, 1.5);
+SELECT dolt_commit('-A','-m','c1');
+UPDATE r SET v = 2.5 WHERE id=1;" | $DOLTLITE "$DB16" > /dev/null 2>&1
+
+run_test "diff_real_distinct_values_modified" \
+  "SELECT count(*) FROM dolt_diff_r WHERE to_commit='WORKING' AND diff_type='modified';" \
+  "1" "$DB16"
+
+DB17=/tmp/test_diff17_$$.db; rm -f "$DB17"
+echo "CREATE TABLE r(id INTEGER PRIMARY KEY, v REAL);
+INSERT INTO r VALUES(1, 0.0);
+SELECT dolt_commit('-A','-m','c1');
+UPDATE r SET v = -0.0 WHERE id=1;
+SELECT dolt_commit('-A','-m','c2');" | $DOLTLITE "$DB17" > /dev/null 2>&1
+
+run_test "diff_stat_real_pos_neg_zero_no_diff" \
+  "SELECT rows_modified FROM dolt_diff_stat('HEAD~1', 'HEAD', 'r');" \
+  "0" "$DB17"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17"
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"


### PR DESCRIPTION
## Summary

Three small VC fixes bundled in one PR, from the deep-review pass on tier-3/critical items #12, #14, and #15. Each is small and independently correct; bundling because they share the "VC behavior gap" theme.

### 1. `doltlite_merge.c` — annotate intentional fall-through (originally finding #12)
`rowMergeCallback` falls through from `CONFLICT_MM` to `CONFLICT_DM` when `tryCellMerge` can't auto-merge a row. The fall-through is correct today, but unannotated — a future maintainer adding an obvious-looking `break` at the end of the CONFLICT_MM block would silently drop modify/modify conflicts that couldn't be auto-merged.

Added `deliberate_fall_through` (SQLite's `__attribute__((fallthrough))` macro) to make the intent explicit and satisfy `-Wimplicit-fallthrough` if that warning is ever enabled.

### 2. `doltlite_diff_table.c` / `doltlite_diff_stat.c` — REAL ±0.0 false positive (originally finding #14)
`fieldValuesEqual` (and the verbatim copy `dsFieldValuesEqual`) compared REAL serial type 7 values with `memcmp`. Under IEEE 754, +0.0 and -0.0 are equal but have different bit patterns — so `dolt_diff` and `dolt_diff_stat` would mark `0.0` → `-0.0` as a modified row.

Fix: when both fields are serial type 7, decode the 8 bytes big-endian to `double` and compare with `==`. IEEE handles +0.0 == -0.0 correctly; NaN can't reach storage (SQLite rejects NaN at insert).

### 3. `doltlite_branch.c` — force-update current branch guard (originally finding #15)
`dolt_branch -f main HEAD~3` while checked out on `main` silently rewrote the current branch and dropped commits. `MODE_DELETE` already had this guard (line 369); `MODE_CREATE` with `force` did not.

Matches Git's behavior:
```
$ git branch -f main HEAD~3
fatal: cannot force update the branch 'main' checked out at '...'
```

Force-create of a non-existent branch and force-update of a non-current branch continue to work as before.

## Test plan
- [x] `bash test/doltlite_diff.sh` — 40 pass (4 new cases)
- [x] `bash test/doltlite_branch_edge.sh` — 76 pass (5 new cases)
- [x] `bash test/doltlite_merge.sh` — 91 pass
- [x] `bash test/doltlite_conflicts.sh` — 40 pass
- [x] `bash test/doltlite_branch.sh` — 60 pass
- [x] `bash test/vc_oracle_diff_test.sh` — 54 pass
- [x] `bash test/vc_oracle_diff_stat_test.sh` — 49 pass
- [x] `bash test/vc_oracle_branch_test.sh` — 33 pass
- [x] `bash test/vc_oracle_merge_test.sh` — 48 pass
- [x] `bash test/vc_oracle_active_branch_test.sh` — 4 pass
- [x] `bash test/doltlite_diff_table.sh` — 39 pass
- [x] `bash test/doltlite_diff_alter.sh` — 15 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)