### PR TITLE
Inline integer cursor rowid reads

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -450,6 +450,11 @@ static SQLITE_INLINE u64 cursorCurrentTreeKeyPrefixInt(BtCursor *pCur){
        | ((u64)p[6]<<8) | (u64)p[7];
 }
 
+static SQLITE_INLINE i64 cursorCurrentTreeIntKey(BtCursor *pCur){
+  u64 u = cursorCurrentTreeKeyPrefixInt(pCur);
+  return (i64)(u ^ ((u64)1 << 63));
+}
+
 static int cacheCursorPayloadReconstructed(
   BtCursor *pCur, const u8 *pSortKey, int nSortKey
 );
@@ -6579,11 +6584,12 @@ static i64 prollyBtCursorIntegerKey(BtCursor *pCur){
    && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
     return prollyMutMapEntryIntKey(currentMutMapEntry(pCur));
   }
-  if( !prollyCursorIsValid(&pCur->pCur)
+  if( pCur->pCur.eState!=PROLLY_CURSOR_VALID
    && (pCur->curFlags & BTCF_ValidNKey) ){
     return pCur->cachedIntKey;
   }
-  return prollyCursorIntKey(&pCur->pCur);
+  assert( pCur->pCur.eState==PROLLY_CURSOR_VALID );
+  return cursorCurrentTreeIntKey(pCur);
 }
 i64 sqlite3BtreeIntegerKey(BtCursor *pCur){
   return pCur->pCurOps->xIntegerKey(pCur);


### PR DESCRIPTION
## Summary
- inline the normal tree-backed integer key read in prollyBtCursorIntegerKey()
- avoid extra prolly cursor validity/key function calls on Rowid opcode range-bound checks

## Benchmark
- focused 400k SUM(k) range workload: 2,779,424 us -> 2,555,597 us median of 5
- wrapped sysbench file-backed oltp_sum_range: 8,237 us -> 8,251 us in this run; this short test was effectively flat/noisy while the longer focused workload showed the stable improvement
- wrapped sysbench file-backed averages stayed within ceilings

## Verification
- make -j$(sysctl -n hw.ncpu) doltlite doltlite-lib
- DOLTLITE_BUILD_DIR=. bash test/run_doltlite_regression_case.sh prolly_int_cursor_boundary
- DOLTLITE_BUILD_DIR=. bash test/run_doltlite_regression_case.sh prolly_int_cursor_seek_past_max
- DOLTLITE_BUILD_DIR=. bash test/run_doltlite_regression_case.sh prolly_blob_cursor_boundary
- DOLTLITE_BUILD_DIR=. bash test/run_doltlite_regression_case.sh prolly_blob_cursor_seek_past_max
- BENCH_RUNS=5 BENCH_SECTION_MODE=wrapped bash test/sysbench_compare.sh