### PR TITLE
Cache decoded index rowids

### DIFF
--- a/src/vdbe.c
+++ b/src/vdbe.c
@@ -4885,6 +4885,7 @@ case OP_SeekGT: {       /* jump0, in3, group, ncycle */
 
   pC->deferredMoveto = 0;
   pC->cacheStatus = CACHE_STALE;
+  pC->idxRowidCacheValid = 0;
   if( pC->isTable ){
     u16 flags3, newType;
     /* The OPFLAG_SEEKEQ/BTREE_SEEK_EQ flag is only set on index cursors */
@@ -5266,6 +5267,7 @@ case OP_SeekScan: {          /* ncycle */
     }
     nStep--;
     pC->cacheStatus = CACHE_STALE;
+    pC->idxRowidCacheValid = 0;
     rc = sqlite3BtreeNext(pC->uc.pCursor, 0);
     if( rc ){
       if( rc==SQLITE_DONE ){
@@ -5500,6 +5502,7 @@ case OP_Found: {        /* jump, in3, ncycle */
   pC->nullRow = 1-alreadyExists;
   pC->deferredMoveto = 0;
   pC->cacheStatus = CACHE_STALE;
+  pC->idxRowidCacheValid = 0;
   if( pOp->opcode==OP_Found ){
     VdbeBranchTaken(alreadyExists!=0,2);
     if( alreadyExists ) goto jump_to_p2;
@@ -6300,6 +6303,7 @@ case OP_NullRow: {
   }
   pC->nullRow = 1;
   pC->cacheStatus = CACHE_STALE;
+  pC->idxRowidCacheValid = 0;
   if( pC->eCurType==CURTYPE_BTREE ){
     assert( pC->uc.pCursor!=0 );
     sqlite3BtreeClearCursor(pC->uc.pCursor);
@@ -6359,6 +6363,7 @@ case OP_Last: {              /* jump0, ncycle */
   pC->nullRow = (u8)res;
   pC->deferredMoveto = 0;
   pC->cacheStatus = CACHE_STALE;
+  pC->idxRowidCacheValid = 0;
   if( rc ) goto abort_due_to_error;
   if( pOp->p2>0 ){
     VdbeBranchTaken(res!=0,2);
@@ -6476,6 +6481,7 @@ case OP_Rewind: {        /* jump0, ncycle */
     rc = sqlite3BtreeFirst(pCrsr, &res);
     pC->deferredMoveto = 0;
     pC->cacheStatus = CACHE_STALE;
+    pC->idxRowidCacheValid = 0;
   }
   if( rc ) goto abort_due_to_error;
   pC->nullRow = (u8)res;
@@ -6606,6 +6612,7 @@ case OP_Next:          /* jump, ncycle */
 
 next_tail:
   pC->cacheStatus = CACHE_STALE;
+  pC->idxRowidCacheValid = 0;
   VdbeBranchTaken(rc==SQLITE_OK,2);
   if( rc==SQLITE_OK ){
     pC->nullRow = 0;
@@ -6752,6 +6759,7 @@ case OP_IdxDelete: {
         goto abort_due_to_error;
       }
       pC->cacheStatus = CACHE_STALE;
+      pC->idxRowidCacheValid = 0;
       pC->seekResult = 0;
       break;
     }
@@ -6767,6 +6775,7 @@ case OP_IdxDelete: {
   if( rc ) goto abort_due_to_error;
   assert( pC->deferredMoveto==0 );
   pC->cacheStatus = CACHE_STALE;
+  pC->idxRowidCacheValid = 0;
   pC->seekResult = 0;
   break;
 }
@@ -6825,9 +6834,15 @@ case OP_IdxRowid: {           /* out2, ncycle */
 
   if( !pC->nullRow ){
     rowid = 0;  /* Not needed.  Only used to silence a warning. */
-    rc = sqlite3VdbeIdxRowid(db, pC->uc.pCursor, &rowid);
-    if( rc!=SQLITE_OK ){
-      goto abort_due_to_error;
+    if( pC->idxRowidCacheValid ){
+      rowid = pC->idxRowidCache;
+    }else{
+      rc = sqlite3VdbeIdxRowid(db, pC->uc.pCursor, &rowid);
+      if( rc!=SQLITE_OK ){
+        goto abort_due_to_error;
+      }
+      pC->idxRowidCache = rowid;
+      pC->idxRowidCacheValid = 1;
     }
     if( pOp->opcode==OP_DeferredSeek ){
       assert( pOp->p3>=0 && pOp->p3<p->nCursor );

--- a/src/vdbeInt.h
+++ b/src/vdbeInt.h
@@ -108,6 +108,8 @@ struct VdbeCursor {
   /* seekResult does not distinguish between "no seeks have ever occurred
   ** on this cursor" and "the most recent seek was an exact match".
   ** For CURTYPE_PSEUDO, seekResult is the register holding the record */
+  u8 idxRowidCacheValid;  /* True if idxRowidCache is valid */
+  i64 idxRowidCache;      /* Rowid decoded from the current index entry */
 
   /* When a new VdbeCursor is allocated, only the fields above are zeroed.
   ** The fields that follow are uninitialized, and must be individually

--- a/src/vdbeaux.c
+++ b/src/vdbeaux.c
@@ -3830,6 +3830,7 @@ int SQLITE_NOINLINE sqlite3VdbeHandleMovedCursor(VdbeCursor *p){
   assert( sqlite3BtreeCursorHasMoved(p->uc.pCursor) );
   rc = sqlite3BtreeCursorRestore(p->uc.pCursor, &isDifferentRow);
   p->cacheStatus = CACHE_STALE;
+  p->idxRowidCacheValid = 0;
   if( isDifferentRow ) p->nullRow = 1;
   return rc;
 }


### PR DESCRIPTION
## Summary
- cache rowids decoded from the current index entry so DeferredSeek followed by IdxRowid does not decode the same rowid twice
- invalidate the cache whenever the VDBE cursor is repositioned or restored

## Benchmark
- Focused index-scan workload: 1,327,973 us -> 1,099,641 us
- File-backed sysbench oltp_index_scan median: 4,936 us -> 4,821 us

## Tests
- make -j$(sysctl -n hw.ncpu) doltlite doltlite-lib
- bash test/doltlite_parity.sh
- DOLTLITE_BUILD_DIR=. bash test/run_doltlite_regression_case.sh prolly_int_cursor_boundary
- DOLTLITE_BUILD_DIR=. bash test/run_doltlite_regression_case.sh prolly_blob_cursor_boundary
- DOLTLITE_BUILD_DIR=. bash test/run_doltlite_regression_case.sh prolly_int_cursor_seek_past_max
- DOLTLITE_BUILD_DIR=. bash test/run_doltlite_regression_case.sh prolly_blob_cursor_seek_past_max
- BENCH_RUNS=5 BENCH_SECTION_MODE=wrapped bash test/sysbench_compare.sh