### PR TITLE
Optimize rowid range count queries

### DIFF
--- a/src/btree.c
+++ b/src/btree.c
@@ -10556,6 +10556,52 @@ int sqlite3BtreeCount(sqlite3 *db, BtCursor *pCur, i64 *pnEntry){
   return rc;
 }
 
+int sqlite3BtreeCountRange(
+  sqlite3 *db,
+  BtCursor *pCur,
+  i64 iLower,
+  i64 iUpper,
+  i64 *pnEntry
+){
+  i64 nEntry = 0;
+  int rc;
+  int res = 0;
+
+  *pnEntry = 0;
+  if( iLower>iUpper ) return SQLITE_OK;
+
+  assert( pCur->curIntKey );
+  rc = sqlite3BtreeTableMoveto(pCur, iLower, 0, &res);
+  if( rc!=SQLITE_OK ) return rc;
+  while( !sqlite3BtreeEof(pCur)
+      && sqlite3BtreeIntegerKey(pCur)<iLower
+      && !AtomicLoad(&db->u1.isInterrupted)
+  ){
+    rc = sqlite3BtreeNext(pCur, 0);
+    if( rc!=SQLITE_OK ){
+      if( rc==SQLITE_DONE ){
+        rc = SQLITE_OK;
+      }
+      break;
+    }
+  }
+
+  while( !sqlite3BtreeEof(pCur) && !AtomicLoad(&db->u1.isInterrupted) ){
+    if( sqlite3BtreeIntegerKey(pCur)>iUpper ) break;
+    nEntry++;
+    rc = sqlite3BtreeNext(pCur, 0);
+    if( rc!=SQLITE_OK ){
+      if( rc==SQLITE_DONE ){
+        rc = SQLITE_OK;
+      }
+      break;
+    }
+  }
+
+  *pnEntry = nEntry;
+  return rc;
+}
+
 /*
 ** Return the pager associated with a BTree.  This routine is used for
 ** testing and debugging only.

--- a/src/btree.h
+++ b/src/btree.h
@@ -375,6 +375,7 @@ int sqlite3BtreeCursorIsValid(BtCursor*);
 int sqlite3BtreeCursorIsValidNN(BtCursor*);
 
 int sqlite3BtreeCount(sqlite3*, BtCursor*, i64*);
+int sqlite3BtreeCountRange(sqlite3*, BtCursor*, i64, i64, i64*);
 
 #ifdef SQLITE_TEST
 int sqlite3BtreeCursorInfo(BtCursor*, int*, int);

--- a/src/btree_orig_prefix.h
+++ b/src/btree_orig_prefix.h
@@ -24,6 +24,7 @@
 #define sqlite3BtreeConnectionCount orig_sqlite3BtreeConnectionCount
 #define sqlite3BtreeCopyFile orig_sqlite3BtreeCopyFile
 #define sqlite3BtreeCount orig_sqlite3BtreeCount
+#define sqlite3BtreeCountRange orig_sqlite3BtreeCountRange
 #define sqlite3BtreeCreateIndex orig_sqlite3BtreeCreateIndex
 #define sqlite3BtreeCreateTable orig_sqlite3BtreeCreateTable
 #define sqlite3BtreeCursor orig_sqlite3BtreeCursor

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -241,6 +241,7 @@ struct BtCursorOps {
   int (*xTransferRow)(BtCursor*, BtCursor*, i64);
   void (*xClearCursor)(BtCursor*);
   int (*xCount)(sqlite3*, BtCursor*, i64*);
+  int (*xCountRange)(sqlite3*, BtCursor*, i64, i64, i64*);
   i64 (*xRowCountEst)(BtCursor*);
   void (*xCursorPin)(BtCursor*);
   void (*xCursorUnpin)(BtCursor*);
@@ -770,6 +771,7 @@ static int prollyBtCursorDelete(BtCursor*, u8);
 static int prollyBtCursorTransferRow(BtCursor*, BtCursor*, i64);
 static void prollyBtCursorClearCursor(BtCursor*);
 static int prollyBtCursorCount(sqlite3*, BtCursor*, i64*);
+static int prollyBtCursorCountRange(sqlite3*, BtCursor*, i64, i64, i64*);
 static i64 prollyBtCursorRowCountEst(BtCursor*);
 static void prollyBtCursorCursorPin(BtCursor*);
 static void prollyBtCursorCursorUnpin(BtCursor*);
@@ -808,6 +810,7 @@ static int origCursorDeleteVt(BtCursor*, u8);
 static int origCursorTransferRowVt(BtCursor*, BtCursor*, i64);
 static void origCursorClearCursorVt(BtCursor*);
 static int origCursorCountVt(sqlite3*, BtCursor*, i64*);
+static int origCursorCountRangeVt(sqlite3*, BtCursor*, i64, i64, i64*);
 static i64 origCursorRowCountEstVt(BtCursor*);
 static void origCursorCursorPinVt(BtCursor*);
 static void origCursorCursorUnpinVt(BtCursor*);
@@ -847,6 +850,7 @@ static const struct BtCursorOps prollyCursorOps = {
   prollyBtCursorTransferRow,
   prollyBtCursorClearCursor,
   prollyBtCursorCount,
+  prollyBtCursorCountRange,
   prollyBtCursorRowCountEst,
   prollyBtCursorCursorPin,
   prollyBtCursorCursorUnpin,
@@ -887,6 +891,7 @@ static const struct BtCursorOps origCursorVtOps = {
   origCursorTransferRowVt,
   origCursorClearCursorVt,
   origCursorCountVt,
+  origCursorCountRangeVt,
   origCursorRowCountEstVt,
   origCursorCursorPinVt,
   origCursorCursorUnpinVt,
@@ -3518,6 +3523,137 @@ static int countTreeEntries(Btree *pBtree, Pgno iTable, i64 *pCount){
             rc, (long long)*pCount);
   }
   return rc;
+}
+
+static int countCursorLeftSiblings(
+  ChunkStore *pStore,
+  ProllyCache *pCache,
+  ProllyCursor *pCur,
+  int iLevel,
+  i64 *pCount
+){
+  ProllyCacheEntry *pEntry = pCur->aLevel[iLevel].pEntry;
+  int iChild = pCur->aLevel[iLevel].idx;
+  int i;
+  i64 n = 0;
+  int rc = SQLITE_OK;
+
+  if( !pEntry || pEntry->node.level==0 ){
+    *pCount = 0;
+    return SQLITE_OK;
+  }
+
+  for(i=0; i<iChild; i++){
+    if( prollyNodeHasSubtreeCounts(&pEntry->node) ){
+      n += (i64)prollyNodeChildSubtreeCount(&pEntry->node, i);
+    }else{
+      ProllyHash childHash;
+      i64 nChild = 0;
+      prollyNodeChildHash(&pEntry->node, i, &childHash);
+      rc = countSubtreeRows(pStore, pCache, &childHash, &nChild);
+      if( rc!=SQLITE_OK ) return rc;
+      n += nChild;
+    }
+  }
+
+  *pCount = n;
+  return SQLITE_OK;
+}
+
+static int prollyCursorCurrentRank(
+  ChunkStore *pStore,
+  ProllyCache *pCache,
+  ProllyCursor *pCur,
+  i64 *pRank
+){
+  ProllyCacheEntry *pLeaf;
+  i64 n = 0;
+  int i;
+  int rc;
+
+  if( pCur->eState!=PROLLY_CURSOR_VALID ){
+    *pRank = 0;
+    return SQLITE_OK;
+  }
+
+  for(i=0; i<pCur->iLevel; i++){
+    i64 nLeft = 0;
+    rc = countCursorLeftSiblings(pStore, pCache, pCur, i, &nLeft);
+    if( rc!=SQLITE_OK ) return rc;
+    n += nLeft;
+  }
+
+  pLeaf = pCur->aLevel[pCur->iLevel].pEntry;
+  if( !pLeaf || pLeaf->node.level!=0 ) return SQLITE_CORRUPT;
+  n += pCur->aLevel[pCur->iLevel].idx;
+  *pRank = n;
+  return SQLITE_OK;
+}
+
+static int countIntKeysUpTo(
+  Btree *pBtree,
+  const ProllyHash *pRoot,
+  u8 flags,
+  i64 intKey,
+  i64 *pCount
+){
+  BtShared *pBt = pBtree->pBt;
+  ProllyCursor cur;
+  i64 nRank = 0;
+  int res = 0;
+  int rc;
+
+  if( prollyHashIsEmpty(pRoot) ){
+    *pCount = 0;
+    return SQLITE_OK;
+  }
+
+  prollyCursorInit(&cur, &pBt->store, &pBt->cache, pRoot, flags);
+  rc = prollyCursorSeekInt(&cur, intKey, &res);
+  if( rc!=SQLITE_OK ) return rc;
+  if( cur.eState!=PROLLY_CURSOR_VALID ){
+    prollyCursorClose(&cur);
+    *pCount = 0;
+    return SQLITE_OK;
+  }
+  rc = prollyCursorCurrentRank(&pBt->store, &pBt->cache, &cur, &nRank);
+  if( rc==SQLITE_OK ){
+    *pCount = nRank + (res<=0 ? 1 : 0);
+  }
+  prollyCursorClose(&cur);
+  return rc;
+}
+
+static int countTreeIntRange(
+  Btree *pBtree,
+  Pgno iTable,
+  i64 iLower,
+  i64 iUpper,
+  i64 *pCount
+){
+  struct TableEntry *pTE;
+  i64 nBeforeLower = 0;
+  i64 nThroughUpper = 0;
+  int rc;
+
+  *pCount = 0;
+  if( iLower>iUpper ) return SQLITE_OK;
+  pTE = findTable(pBtree, iTable);
+  if( !pTE || prollyHashIsEmpty(&pTE->root) ) return SQLITE_OK;
+
+  if( iLower==SMALLEST_INT64 ){
+    nBeforeLower = 0;
+  }else{
+    rc = countIntKeysUpTo(pBtree, &pTE->root, pTE->flags,
+                          iLower-1, &nBeforeLower);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+  rc = countIntKeysUpTo(pBtree, &pTE->root, pTE->flags,
+                        iUpper, &nThroughUpper);
+  if( rc!=SQLITE_OK ) return rc;
+  *pCount = nThroughUpper - nBeforeLower;
+  if( *pCount<0 ) *pCount = 0;
+  return SQLITE_OK;
 }
 
 static int saveAllCursors(Btree *pBtree, BtShared *pBt, Pgno iRoot,
@@ -7366,9 +7502,57 @@ static int prollyBtCursorCount(sqlite3 *db, BtCursor *pCur, i64 *pnEntry){
   flushIfNeeded(pCur);
   return countTreeEntries(pCur->pBtree, pCur->pgnoRoot, pnEntry);
 }
+
+static int prollyBtCursorCountRange(
+  sqlite3 *db,
+  BtCursor *pCur,
+  i64 iLower,
+  i64 iUpper,
+  i64 *pnEntry
+){
+  struct TableEntry *pTE;
+  (void)db;
+
+  pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
+  if( pTE && pTE->pPending ){
+    ProllyMutMap *pMap = (ProllyMutMap*)pTE->pPending;
+    if( !prollyMutMapIsEmpty(pMap) ){
+      ProllyMutMap *pFlushMap = pMap;
+      int captured = 0;
+      int rc = snapshotPendingForFlush(pCur->pBtree, pCur->pgnoRoot,
+                                       (ProllyMutMap**)&pTE->pPending,
+                                       &pFlushMap, &captured);
+      if( rc!=SQLITE_OK ) return rc;
+      if( captured ){
+        refreshCursorMutMapAliases(pCur->pBtree, pCur->pBt, pCur->pgnoRoot,
+                                   (ProllyMutMap*)pTE->pPending);
+      }
+      rc = applyMutMapToTableRoot(pCur->pBt, pTE, pFlushMap);
+      if( rc!=SQLITE_OK ) return rc;
+      if( pTE->pPending==pMap ){
+        prollyMutMapClear(pMap);
+      }
+    }
+  }
+  flushIfNeeded(pCur);
+  return countTreeIntRange(pCur->pBtree, pCur->pgnoRoot,
+                           iLower, iUpper, pnEntry);
+}
+
 int sqlite3BtreeCount(sqlite3 *db, BtCursor *pCur, i64 *pnEntry){
   if( !pCur ) return SQLITE_OK;
   return pCur->pCurOps->xCount(db, pCur, pnEntry);
+}
+
+int sqlite3BtreeCountRange(
+  sqlite3 *db,
+  BtCursor *pCur,
+  i64 iLower,
+  i64 iUpper,
+  i64 *pnEntry
+){
+  if( !pCur ) return SQLITE_OK;
+  return pCur->pCurOps->xCountRange(db, pCur, iLower, iUpper, pnEntry);
 }
 
 static i64 prollyBtCursorRowCountEst(BtCursor *pCur){
@@ -8990,6 +9174,34 @@ static void origCursorClearCursorVt(BtCursor *pCur){
 }
 static int origCursorCountVt(sqlite3 *db, BtCursor *pCur, i64 *pnEntry){
   return origBtreeCount(db, pCur->pOrigCursor, pnEntry);
+}
+static int origCursorCountRangeVt(
+  sqlite3 *db,
+  BtCursor *pCur,
+  i64 iLower,
+  i64 iUpper,
+  i64 *pnEntry
+){
+  int rc;
+  int res = 0;
+  i64 n = 0;
+  (void)db;
+
+  *pnEntry = 0;
+  if( iLower>iUpper ) return SQLITE_OK;
+  rc = origBtreeTableMoveto(pCur->pOrigCursor, iLower, 0, &res);
+  if( rc!=SQLITE_OK ) return rc;
+  if( res!=0 && origBtreeEof(pCur->pOrigCursor) ){
+    return SQLITE_OK;
+  }
+  while( !origBtreeEof(pCur->pOrigCursor) ){
+    if( origBtreeIntegerKey(pCur->pOrigCursor)>iUpper ) break;
+    n++;
+    rc = origBtreeNext(pCur->pOrigCursor, 0);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+  *pnEntry = n;
+  return SQLITE_OK;
 }
 static i64 origCursorRowCountEstVt(BtCursor *pCur){
   (void)pCur;

--- a/src/select.c
+++ b/src/select.c
@@ -5461,6 +5461,110 @@ static Table *isSimpleCount(Select *p, AggInfo *pAggInfo){
   return pTab;
 }
 
+static int exprIsRowidOfTable(Expr *pExpr, Table *pTab){
+  while( pExpr && (pExpr->op==TK_UPLUS || pExpr->op==TK_COLLATE) ){
+    pExpr = pExpr->pLeft;
+  }
+  return pExpr
+      && pExpr->op==TK_COLUMN
+      && ExprUseYTab(pExpr)
+      && pExpr->y.pTab==pTab
+      && (pExpr->iColumn<0 || pExpr->iColumn==pTab->iPKey);
+}
+
+static int exprIsKnownNotNullForTable(Expr *pExpr, Table *pTab){
+  while( pExpr && (pExpr->op==TK_UPLUS || pExpr->op==TK_COLLATE) ){
+    pExpr = pExpr->pLeft;
+  }
+  if( !pExpr ) return 0;
+  if( !sqlite3ExprCanBeNull(pExpr) ) return 1;
+  if( (pExpr->op==TK_COLUMN || pExpr->op==TK_AGG_COLUMN)
+   && ExprUseYTab(pExpr)
+   && pExpr->y.pTab==pTab
+  ){
+    if( pExpr->iColumn<0 || pExpr->iColumn==pTab->iPKey ) return 1;
+    if( pExpr->iColumn>=0
+     && pExpr->iColumn<pTab->nCol
+     && pTab->aCol[pExpr->iColumn].notNull!=0
+    ){
+      return 1;
+    }
+  }
+  return 0;
+}
+
+/*
+** Return the table for a SELECT that can be answered by counting an
+** inclusive integer rowid range, and populate ppLow/ppHigh with the bounds.
+** This is deliberately narrower than SQLite's general WHERE handling:
+** non-integer bounds keep the normal row scan so rowid comparison affinity
+** remains exactly SQLite-compatible.
+*/
+static Table *isSimpleRowidRangeCount(
+  Select *p,
+  AggInfo *pAggInfo,
+  Expr **ppLow,
+  Expr **ppHigh,
+  Parse *pParse
+){
+  Table *pTab;
+  Expr *pExpr;
+  ExprList *pArgs;
+  SrcItem *pSrc;
+  int dummy;
+  int lowOk;
+  int highOk;
+
+  (void)pParse;
+  assert( !p->pGroupBy );
+  if( p->pWhere==0
+   || p->pWhere->op!=TK_BETWEEN
+   || !ExprUseXList(p->pWhere)
+   || p->pWhere->x.pList==0
+   || p->pWhere->x.pList->nExpr!=2
+   || p->pEList->nExpr!=1
+   || p->pSrc->nSrc!=1
+   || p->pSrc->a[0].fg.isSubquery
+   || pAggInfo->nFunc!=1
+   || p->pHaving
+  ){
+    return 0;
+  }
+  pSrc = &p->pSrc->a[0];
+  pTab = pSrc->pSTab;
+  assert( pTab!=0 );
+  assert( !IsView(pTab) );
+  if( !IsOrdinaryTable(pTab) || !HasRowid(pTab) ) return 0;
+  if( !exprIsRowidOfTable(p->pWhere->pLeft, pTab) ) return 0;
+  *ppLow = p->pWhere->x.pList->a[0].pExpr;
+  *ppHigh = p->pWhere->x.pList->a[1].pExpr;
+  lowOk = sqlite3ExprIsInteger(*ppLow, &dummy, 0);
+  highOk = sqlite3ExprIsInteger(*ppHigh, &dummy, 0);
+  if( !lowOk || !highOk ){
+    return 0;
+  }
+
+  pExpr = p->pEList->a[0].pExpr;
+  assert( pExpr!=0 );
+  if( pExpr->op!=TK_AGG_FUNCTION ) return 0;
+  if( pExpr->pAggInfo!=pAggInfo ) return 0;
+  if( (pAggInfo->aFunc[0].pFunc->funcFlags&SQLITE_FUNC_COUNT)==0
+   && sqlite3_stricmp(pExpr->u.zToken,"count")!=0
+  ){
+    return 0;
+  }
+  assert( pAggInfo->aFunc[0].pFExpr==pExpr );
+  if( ExprHasProperty(pExpr, EP_Distinct|EP_WinFunc) ) return 0;
+  pArgs = ExprUseXList(pExpr) ? pExpr->x.pList : 0;
+  if( pArgs
+   && pArgs->nExpr>0
+   && !exprIsKnownNotNullForTable(pArgs->a[0].pExpr, pTab)
+  ){
+    return 0;
+  }
+  return pTab;
+}
+
 /*
 ** If the source-list item passed as an argument was augmented with an
 ** INDEXED BY clause, then try to locate the specified index. If there
@@ -8783,7 +8887,33 @@ int sqlite3Select(
     else {
       /* Aggregate functions without GROUP BY. tag-select-0820 */
       Table *pTab;
-      if( (pTab = isSimpleCount(p, pAggInfo))!=0 ){
+      Expr *pRangeLow = 0;
+      Expr *pRangeHigh = 0;
+      if( (pTab = isSimpleRowidRangeCount(p, pAggInfo,
+                                          &pRangeLow, &pRangeHigh,
+                                          pParse))!=0 ){
+        const int iDb = sqlite3SchemaToIndex(pParse->db, pTab->pSchema);
+        const int iCsr = pParse->nTab++;
+        int regRange;
+
+        sqlite3CodeVerifySchema(pParse, iDb);
+        sqlite3TableLock(pParse, iDb, pTab->tnum, 0, pTab->zName);
+        sqlite3VdbeAddOp4Int(v, OP_OpenRead, iCsr, (int)pTab->tnum, iDb, 1);
+        assignAggregateRegisters(pParse, pAggInfo);
+        regRange = sqlite3GetTempRange(pParse, 2);
+        sqlite3ExprCode(pParse, pRangeLow, regRange);
+        sqlite3ExprCode(pParse, pRangeHigh, regRange+1);
+        sqlite3VdbeAddOp3(v, OP_CountRange, iCsr,
+                          AggInfoFuncReg(pAggInfo,0), regRange);
+        sqlite3ReleaseTempRange(pParse, regRange, 2);
+        sqlite3VdbeAddOp1(v, OP_Close, iCsr);
+        if( pParse->explain==2 ){
+          sqlite3VdbeExplain(pParse, 0,
+              "SEARCH %s USING INTEGER PRIMARY KEY (rowid>? AND rowid<?)",
+              pTab->zName
+          );
+        }
+      }else if( (pTab = isSimpleCount(p, pAggInfo))!=0 ){
         /* tag-select-0821
         **
         ** If isSimpleCount() returns a pointer to a Table structure, then

--- a/src/vdbe.c
+++ b/src/vdbe.c
@@ -3869,6 +3869,42 @@ case OP_Count: {         /* out2 */
   goto check_for_interrupt;
 }
 
+/* Opcode: CountRange P1 P2 P3 * *
+** Synopsis: r[P2]=count_range(r[P3]..r[P3+1])
+**
+** Store in register P2 the number of entries in intkey table cursor P1 with
+** rowids between registers P3 and P3+1, inclusive. Both bound registers must
+** contain integer values.
+*/
+case OP_CountRange: {    /* out2 */
+  i64 nEntry;
+  i64 iLower;
+  i64 iUpper;
+  BtCursor *pCrsr;
+  Mem *pLower;
+  Mem *pUpper;
+
+  assert( p->apCsr[pOp->p1]->eCurType==CURTYPE_BTREE );
+  pCrsr = p->apCsr[pOp->p1]->uc.pCursor;
+  assert( pCrsr );
+  pLower = &aMem[pOp->p3];
+  pUpper = &aMem[pOp->p3+1];
+  applyNumericAffinity(pLower, 0);
+  applyNumericAffinity(pUpper, 0);
+  if( (pLower->flags & MEM_Int)==0 || (pUpper->flags & MEM_Int)==0 ){
+    sqlite3VdbeMemSetInt64(&aMem[pOp->p2], 0);
+    goto check_for_interrupt;
+  }
+  iLower = pLower->u.i;
+  iUpper = pUpper->u.i;
+  nEntry = 0;
+  rc = sqlite3BtreeCountRange(db, pCrsr, iLower, iUpper, &nEntry);
+  if( rc ) goto abort_due_to_error;
+  pOut = out2Prerelease(p, pOp);
+  pOut->u.i = nEntry;
+  goto check_for_interrupt;
+}
+
 /* Opcode: Savepoint P1 * * P4 *
 **
 ** Open, release or rollback the savepoint named by parameter P4, depending

--- a/test/doltlite_count_perf.sh
+++ b/test/doltlite_count_perf.sh
@@ -55,6 +55,20 @@ assert_count() {
   fi
 }
 
+assert_sql() {
+  local name="$1" db="$2" sql="$3" expected="$4"
+  local got
+  got=$(echo "$sql" | $DOLTLITE "$db" 2>&1)
+  if [ "$got" = "$expected" ]; then
+    PASS=$((PASS+1))
+    echo "  PASS: $name — result=$got"
+  else
+    FAIL=$((FAIL+1))
+    ERRORS="$ERRORS\nFAIL: $name expected=$expected got=$got"
+    echo "  FAIL: $name — expected=$expected got=$got"
+  fi
+}
+
 assert_bounded() {
   local name="$1" actual_us="$2" max_us="$3"
   if [ "$actual_us" -le "$max_us" ]; then
@@ -100,6 +114,12 @@ assert_count "count_1k"    "$DB_1K"   1000
 assert_count "count_10k"   "$DB_10K"  10000
 assert_count "count_100k"  "$DB_100K" 100000
 assert_count "count_1m"    "$DB_1M"   1000000
+assert_sql "count_not_null_rowid_range" "$DB_1K" \
+  "CREATE TABLE u(id INTEGER PRIMARY KEY, k INTEGER NOT NULL);
+   INSERT INTO u VALUES(1,1),(3,3),(7,7),(10,10);
+   SELECT count(k) FROM u WHERE id BETWEEN 2 AND 8;" 2
+assert_sql "count_rowid_range_empty" "$DB_1K" \
+  "SELECT count(*) FROM t WHERE id BETWEEN 2000 AND 2010;" 0
 
 echo ""
 echo "--- Performance ---"


### PR DESCRIPTION
## Summary
- add a CountRange VDBE opcode backed by prolly cursor rank/subtree counts
- emit it for simple COUNT(*) / COUNT(non-null column) queries over integer-literal rowid BETWEEN ranges
- add coverage for rowid range counts in the count perf test

## Benchmark
- focused select_random_ranges workload: ~274k-283k us before, ~226k-243k us after
- wrapped sysbench file-backed select_random_ranges: 4,404 us before, 4,105 us after

## Tests
- make -j$(sysctl -n hw.ncpu) doltlite doltlite-lib
- bash test/doltlite_count_perf.sh
- BENCH_SECTION_MODE=wrapped BENCH_ROWS=10000 bash test/sysbench_compare.sh