### PR TITLE
fix(btree): savepoint-aware TRUNCATE; expand oracle coverage

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -2665,8 +2665,7 @@ static int flushPendingForTable(
   pTE->pendingFlushSeekEdits = 0;
   return SQLITE_OK;
 }
-static int syncSavepoints(BtCursor *pCur){
-  Btree *pBtree = pCur->pBtree;
+static int syncBtreeSavepoints(Btree *pBtree){
   sqlite3 *db = pBtree ? pBtree->db : 0;
   if( db ){
     int target = db->nSavepoint + db->nStatement;
@@ -2676,6 +2675,9 @@ static int syncSavepoints(BtCursor *pCur){
     }
   }
   return SQLITE_OK;
+}
+static int syncSavepoints(BtCursor *pCur){
+  return syncBtreeSavepoints(pCur->pBtree);
 }
 
 /* Pending edit maps are shared by every cursor on the same table. When a flush
@@ -5153,14 +5155,33 @@ static int prollyBtreeClearTable(Btree *p, int iTable, i64 *pnChange){
   invalidateCursors(pBt, (Pgno)iTable, SQLITE_ABORT);
   /* TRUNCATE: discard any pending mutations for this table. Without this,
   ** merging the now-empty tree with stale pending inserts would resurrect
-  ** rows the caller asked to remove. Cursor aliases must be cleared in the
-  ** same step because invalidateCursors leaves pCur->pMutMap untouched. */
+  ** rows the caller asked to remove. Inside a savepoint that captured
+  ** this table, hand the dirty map to the savepoint (via the same path
+  ** flushPendingForTable uses) so ROLLBACK TO can restore pre-savepoint
+  ** pending edits. Outside any savepoint, free the map outright. Either
+  ** way the cursor aliases must be updated since invalidateCursors
+  ** leaves pCur->pMutMap untouched. */
+  {
+    int rc = syncBtreeSavepoints(p);
+    if( rc!=SQLITE_OK ) return rc;
+  }
   if( pTE->pPending ){
     ProllyMutMap *pMap = (ProllyMutMap*)pTE->pPending;
-    prollyMutMapFree(pMap);
-    sqlite3_free(pMap);
-    pTE->pPending = 0;
-    refreshCursorMutMapAliases(p, pBt, (Pgno)iTable, 0);
+    ProllyMutMap *pFlushMap = pMap;
+    int captured = 0;
+    int rc = snapshotPendingForFlush(p, (Pgno)iTable,
+                                     (ProllyMutMap**)&pTE->pPending,
+                                     &pFlushMap, &captured);
+    if( rc!=SQLITE_OK ) return rc;
+    if( captured ){
+      refreshCursorMutMapAliases(p, pBt, (Pgno)iTable,
+                                 (ProllyMutMap*)pTE->pPending);
+    }else{
+      prollyMutMapFree(pMap);
+      sqlite3_free(pMap);
+      pTE->pPending = 0;
+      refreshCursorMutMapAliases(p, pBt, (Pgno)iTable, 0);
+    }
   }
   memset(&pTE->root, 0, sizeof(ProllyHash));
 

--- a/test/sql_oracle_test.sh
+++ b/test/sql_oracle_test.sh
@@ -1927,6 +1927,109 @@ COMMIT;
 SELECT count(*) FROM t;
 "
 
+# 16u. Truncate then DROP TABLE in the same transaction. Exercises
+# both the ClearTable and DropTable mutmap paths back-to-back. Pre-fix
+# the pending insert leaked into the empty tree before the drop.
+oracle "cat16_truncate_then_drop" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+BEGIN;
+INSERT INTO t VALUES (1,'a');
+DELETE FROM t;
+DROP TABLE t;
+SELECT name FROM sqlite_master WHERE type='table';
+COMMIT;
+SELECT name FROM sqlite_master WHERE type='table';
+"
+
+# 16v. Mixed pending insert/delete then truncate. With both operations
+# in the mutmap, the cleared state must drop both regardless of order.
+oracle "cat16_truncate_with_mixed_pending" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1,'a'),(2,'b'),(3,'c');
+BEGIN;
+DELETE FROM t WHERE id=2;
+INSERT INTO t VALUES (4,'d'),(5,'e');
+DELETE FROM t;
+SELECT count(*) FROM t;
+COMMIT;
+SELECT count(*) FROM t;
+"
+
+# 16w. Multiple truncates in the same transaction. Each one must
+# leave the mutmap in a clean state for the next round.
+oracle "cat16_truncate_multiple_times" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+BEGIN;
+INSERT INTO t VALUES (1,'a');
+DELETE FROM t;
+INSERT INTO t VALUES (2,'b');
+DELETE FROM t;
+INSERT INTO t VALUES (3,'c');
+DELETE FROM t;
+INSERT INTO t VALUES (99,'final');
+SELECT id, v FROM t;
+COMMIT;
+SELECT id, v FROM t;
+"
+
+# 16x. Truncate at the inner level of nested savepoints, then
+# release the outer. Stock SQLite preserves the inner-cleared state.
+oracle "cat16_truncate_nested_savepoint_release" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1,'a'),(2,'b');
+SAVEPOINT s1;
+INSERT INTO t VALUES (3,'c');
+SAVEPOINT s2;
+DELETE FROM t;
+INSERT INTO t VALUES (10,'x');
+RELEASE s2;
+RELEASE s1;
+SELECT id, v FROM t ORDER BY id;
+"
+
+# 16y. Truncate at inner savepoint, rollback the inner, keep the
+# outer. The inner clear is undone; outer's mutations are kept.
+oracle "cat16_truncate_nested_savepoint_inner_rollback" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1,'a'),(2,'b');
+SAVEPOINT s1;
+INSERT INTO t VALUES (3,'c');
+SAVEPOINT s2;
+DELETE FROM t;
+ROLLBACK TO s2;
+RELEASE s2;
+RELEASE s1;
+SELECT id, v FROM t ORDER BY id;
+"
+
+# 16z. Truncate then PRAGMA integrity_check inside the same
+# transaction. Catches any in-memory state that disagrees with the
+# materialized tree (the bug class that motivated this category).
+oracle "cat16_truncate_then_integrity_check" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+CREATE INDEX t_v ON t(v);
+BEGIN;
+INSERT INTO t VALUES (1,'a'),(2,'b');
+DELETE FROM t;
+PRAGMA integrity_check;
+COMMIT;
+PRAGMA integrity_check;
+"
+
+# 16aa. Truncate then re-INSERT via INSERT OR REPLACE with the same
+# PK as one that was pending pre-truncate. Pre-fix the UPSERT could
+# have hit a phantom row from the stale mutmap.
+oracle "cat16_truncate_then_insert_or_replace" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+BEGIN;
+INSERT INTO t VALUES (1,'pending');
+DELETE FROM t;
+INSERT OR REPLACE INTO t VALUES (1,'after');
+SELECT id, v FROM t;
+COMMIT;
+SELECT id, v FROM t;
+"
+
 # ════════════════════════════════════════════════════════════════════
 # Category 17: Partial indexes
 # ════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Recovers orphaned work that was on branch `fix/truncate-clear-pending-mutmap` after PR #975 merged. The follow-up commit was pushed to the branch but never PR'd. Found during a stale-branch cleanup sweep.

## What it fixes

PR #975 made `prollyBtreeClearTable` free `pTE->pPending` outright on TRUNCATE — fixed the "deleted rows resurrected" bug but introduced a narrower regression: when TRUNCATE runs inside a savepoint that captured outer-savepoint pending mutations, those undo records are lost on ROLLBACK TO the inner savepoint.

Repro:
```sql
CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
INSERT INTO t VALUES (1,'a'),(2,'b');
SAVEPOINT s1;
  INSERT INTO t VALUES (3,'c');          -- pending @ s1
  SAVEPOINT s2;
    DELETE FROM t;                       -- earlier fix lost (3,'c')
  ROLLBACK TO s2;
RELEASE s1;
SELECT * FROM t;                         -- stock SQLite: 1,2,3
                                         -- pre-fix: 1,2 (regression)
```

Fix uses the same `snapshotPendingForFlush` helper that `flushPendingForTable` uses, handing the dirty mutmap to the outermost capturing savepoint frame before clearing. `ROLLBACK TO` then restores via the existing `rollbackMutMapsToSavepoint` path. Outside any savepoint, the free-outright fast path is unchanged.

Also: `xClearTable` is reached without the cursor-level `syncSavepoints` hook that Insert/Delete fire, so `pBtree->nSavepoint` could lag behind `db->nSavepoint`. Pulled the body of `syncSavepoints(BtCursor*)` into a new `syncBtreeSavepoints(Btree*)` that the cleartable path calls explicitly.

## Test coverage

7 new oracle cases in `test/sql_oracle_test.sh` (Category 16, letters 16u–16aa — renumbered from the original 16m–16s to avoid colliding with master's already-merged 16m–16t rowid-zero tests):

- `cat16_truncate_then_drop`
- `cat16_truncate_with_mixed_pending`
- `cat16_truncate_multiple_times`
- `cat16_truncate_nested_savepoint_release`
- `cat16_truncate_nested_savepoint_inner_rollback`
- `cat16_truncate_then_integrity_check`
- `cat16_truncate_then_insert_or_replace`

All pass against stock SQLite with the fix; on master without it, the savepoint-aware case fails.

## Test plan
- [x] `doltlite_merge.sh` — 91/91 pass
- [x] `doltlite_savepoint.sh` — 128/128 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)