### PR TITLE
Optimize covering index range counts

### DIFF
--- a/src/btree.c
+++ b/src/btree.c
@@ -10602,6 +10602,21 @@ int sqlite3BtreeCountRange(
   return rc;
 }
 
+int sqlite3BtreeCountIndexRange(
+  sqlite3 *db,
+  BtCursor *pCur,
+  UnpackedRecord *pLower,
+  UnpackedRecord *pUpper,
+  i64 *pnEntry
+){
+  (void)db;
+  (void)pCur;
+  (void)pLower;
+  (void)pUpper;
+  (void)pnEntry;
+  return SQLITE_NOTFOUND;
+}
+
 /*
 ** Return the pager associated with a BTree.  This routine is used for
 ** testing and debugging only.

--- a/src/btree.h
+++ b/src/btree.h
@@ -376,6 +376,8 @@ int sqlite3BtreeCursorIsValidNN(BtCursor*);
 
 int sqlite3BtreeCount(sqlite3*, BtCursor*, i64*);
 int sqlite3BtreeCountRange(sqlite3*, BtCursor*, i64, i64, i64*);
+int sqlite3BtreeCountIndexRange(sqlite3*, BtCursor*, UnpackedRecord*,
+                                UnpackedRecord*, i64*);
 
 #ifdef SQLITE_TEST
 int sqlite3BtreeCursorInfo(BtCursor*, int*, int);

--- a/src/btree_orig_api.c
+++ b/src/btree_orig_api.c
@@ -111,6 +111,15 @@ u32 origBtreePayloadChecked(void *pCur, u32 off, u32 amt, void *pBuf){
 int origBtreeCount(sqlite3 *db, void *pCur, i64 *pn){
   return orig_sqlite3BtreeCount(db, C(pCur), pn);
 }
+int origBtreeCountIndexRange(
+  sqlite3 *db,
+  void *pCur,
+  UnpackedRecord *pLower,
+  UnpackedRecord *pUpper,
+  i64 *pn
+){
+  return orig_sqlite3BtreeCountIndexRange(db, C(pCur), pLower, pUpper, pn);
+}
 int origBtreeClosesWithCursor(void *p, void *pCur){
 
   (void)p; (void)pCur;

--- a/src/btree_orig_api.h
+++ b/src/btree_orig_api.h
@@ -62,6 +62,8 @@ const void *origBtreePayloadFetch(void *pCur, u32 *pAmt);
 i64 origBtreeIntegerKey(void *pCur);
 u32 origBtreePayloadChecked(void *pCur, u32 offset, u32 amt, void *pBuf);
 int origBtreeCount(sqlite3 *db, void *pCur, i64 *pnEntry);
+int origBtreeCountIndexRange(sqlite3 *db, void *pCur, UnpackedRecord *pLower,
+                             UnpackedRecord *pUpper, i64 *pnEntry);
 int origBtreeClosesWithCursor(void *p, void *pCur);
 void origBtreeTripAllCursors(void *p, int errCode, int writeOnly);
 void origBtreeCursorPin(void *pCur);

--- a/src/btree_orig_prefix.h
+++ b/src/btree_orig_prefix.h
@@ -24,6 +24,7 @@
 #define sqlite3BtreeConnectionCount orig_sqlite3BtreeConnectionCount
 #define sqlite3BtreeCopyFile orig_sqlite3BtreeCopyFile
 #define sqlite3BtreeCount orig_sqlite3BtreeCount
+#define sqlite3BtreeCountIndexRange orig_sqlite3BtreeCountIndexRange
 #define sqlite3BtreeCountRange orig_sqlite3BtreeCountRange
 #define sqlite3BtreeCreateIndex orig_sqlite3BtreeCreateIndex
 #define sqlite3BtreeCreateTable orig_sqlite3BtreeCreateTable

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -242,6 +242,8 @@ struct BtCursorOps {
   void (*xClearCursor)(BtCursor*);
   int (*xCount)(sqlite3*, BtCursor*, i64*);
   int (*xCountRange)(sqlite3*, BtCursor*, i64, i64, i64*);
+  int (*xCountIndexRange)(sqlite3*, BtCursor*, UnpackedRecord*,
+                          UnpackedRecord*, i64*);
   i64 (*xRowCountEst)(BtCursor*);
   void (*xCursorPin)(BtCursor*);
   void (*xCursorUnpin)(BtCursor*);
@@ -772,6 +774,8 @@ static int prollyBtCursorTransferRow(BtCursor*, BtCursor*, i64);
 static void prollyBtCursorClearCursor(BtCursor*);
 static int prollyBtCursorCount(sqlite3*, BtCursor*, i64*);
 static int prollyBtCursorCountRange(sqlite3*, BtCursor*, i64, i64, i64*);
+static int prollyBtCursorCountIndexRange(sqlite3*, BtCursor*, UnpackedRecord*,
+                                         UnpackedRecord*, i64*);
 static i64 prollyBtCursorRowCountEst(BtCursor*);
 static void prollyBtCursorCursorPin(BtCursor*);
 static void prollyBtCursorCursorUnpin(BtCursor*);
@@ -811,6 +815,8 @@ static int origCursorTransferRowVt(BtCursor*, BtCursor*, i64);
 static void origCursorClearCursorVt(BtCursor*);
 static int origCursorCountVt(sqlite3*, BtCursor*, i64*);
 static int origCursorCountRangeVt(sqlite3*, BtCursor*, i64, i64, i64*);
+static int origCursorCountIndexRangeVt(sqlite3*, BtCursor*, UnpackedRecord*,
+                                       UnpackedRecord*, i64*);
 static i64 origCursorRowCountEstVt(BtCursor*);
 static void origCursorCursorPinVt(BtCursor*);
 static void origCursorCursorUnpinVt(BtCursor*);
@@ -851,6 +857,7 @@ static const struct BtCursorOps prollyCursorOps = {
   prollyBtCursorClearCursor,
   prollyBtCursorCount,
   prollyBtCursorCountRange,
+  prollyBtCursorCountIndexRange,
   prollyBtCursorRowCountEst,
   prollyBtCursorCursorPin,
   prollyBtCursorCursorUnpin,
@@ -892,6 +899,7 @@ static const struct BtCursorOps origCursorVtOps = {
   origCursorClearCursorVt,
   origCursorCountVt,
   origCursorCountRangeVt,
+  origCursorCountIndexRangeVt,
   origCursorRowCountEstVt,
   origCursorCursorPinVt,
   origCursorCursorUnpinVt,
@@ -3654,6 +3662,145 @@ static int countTreeIntRange(
   *pCount = nThroughUpper - nBeforeLower;
   if( *pCount<0 ) *pCount = 0;
   return SQLITE_OK;
+}
+
+static int sortKeyFromUnpackedForCount(
+  BtCursor *pCur,
+  UnpackedRecord *pRec,
+  u8 **ppBuf,
+  int *pnAlloc,
+  int *pnOut
+){
+  int rc;
+  int nKeyField = 0;
+  if( pCur->pKeyInfo && pRec->nField < pCur->pKeyInfo->nAllField ){
+    nKeyField = (int)pRec->nField;
+  }
+  if( unpackedRecordCanUseIntSortKey(
+        pCur, pRec, nKeyField>0 ? nKeyField : (int)pRec->nField) ){
+    return sortKeyFromUnpackedIntRecordBuffer(
+        pRec, nKeyField>0 ? nKeyField : (int)pRec->nField,
+        ppBuf, pnAlloc, pnOut);
+  }
+  rc = sortKeyFromMemPrefixCollBuffer(
+      pRec->aMem, (int)pRec->nField, nKeyField, pCur->pKeyInfo,
+      ppBuf, pnAlloc, pnOut);
+  if( rc==SQLITE_NOTFOUND ){
+    u8 *pSerKey = 0;
+    int nSerAlloc = 0;
+    int nSerKey = 0;
+    rc = serializeUnpackedRecordBuffer(pRec, &pSerKey, &nSerAlloc, &nSerKey);
+    if( rc==SQLITE_OK ){
+      rc = sortKeyFromRecordPrefixCollBuffer(
+          pSerKey, nSerKey, nKeyField, pCur->pKeyInfo, ppBuf, pnAlloc, pnOut);
+    }
+    sqlite3_free(pSerKey);
+  }
+  return rc;
+}
+
+static int blobPrefixSuccessor(const u8 *pKey, int nKey, u8 **ppOut){
+  int i;
+  u8 *pOut = sqlite3_malloc(nKey);
+  if( !pOut ) return SQLITE_NOMEM;
+  memcpy(pOut, pKey, nKey);
+  for(i=nKey-1; i>=0; i--){
+    if( pOut[i]!=0xff ){
+      pOut[i]++;
+      *ppOut = pOut;
+      return SQLITE_OK;
+    }
+  }
+  sqlite3_free(pOut);
+  *ppOut = 0;
+  return SQLITE_OK;
+}
+
+static int countBlobKeysBefore(
+  Btree *pBtree,
+  const ProllyHash *pRoot,
+  u8 flags,
+  const u8 *pKey,
+  int nKey,
+  i64 *pCount
+){
+  BtShared *pBt = pBtree->pBt;
+  ProllyCursor cur;
+  i64 nRank = 0;
+  int res = 0;
+  int rc;
+
+  if( prollyHashIsEmpty(pRoot) ){
+    *pCount = 0;
+    return SQLITE_OK;
+  }
+
+  prollyCursorInit(&cur, &pBt->store, &pBt->cache, pRoot, flags);
+  rc = prollyCursorSeekBlob(&cur, pKey, nKey, &res);
+  if( rc!=SQLITE_OK ) return rc;
+  if( cur.eState!=PROLLY_CURSOR_VALID ){
+    prollyCursorClose(&cur);
+    *pCount = 0;
+    return SQLITE_OK;
+  }
+  rc = prollyCursorCurrentRank(&pBt->store, &pBt->cache, &cur, &nRank);
+  if( rc==SQLITE_OK ){
+    *pCount = nRank + (res<0 ? 1 : 0);
+  }
+  prollyCursorClose(&cur);
+  return rc;
+}
+
+static int countTreeBlobPrefixRange(
+  BtCursor *pCur,
+  UnpackedRecord *pLower,
+  UnpackedRecord *pUpper,
+  i64 *pCount
+){
+  struct TableEntry *pTE;
+  u8 *pLowerKey = 0;
+  u8 *pUpperKey = 0;
+  u8 *pUpperNext = 0;
+  int nLowerKey = 0;
+  int nUpperKey = 0;
+  int nLowerAlloc = 0;
+  int nUpperAlloc = 0;
+  i64 nLower = 0;
+  i64 nUpper = 0;
+  int rc;
+
+  *pCount = 0;
+  pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
+  if( !pTE || prollyHashIsEmpty(&pTE->root) ) return SQLITE_OK;
+
+  rc = sortKeyFromUnpackedForCount(
+      pCur, pLower, &pLowerKey, &nLowerAlloc, &nLowerKey);
+  if( rc!=SQLITE_OK ) goto done;
+  rc = sortKeyFromUnpackedForCount(
+      pCur, pUpper, &pUpperKey, &nUpperAlloc, &nUpperKey);
+  if( rc!=SQLITE_OK ) goto done;
+  rc = blobPrefixSuccessor(pUpperKey, nUpperKey, &pUpperNext);
+  if( rc!=SQLITE_OK ) goto done;
+
+  rc = countBlobKeysBefore(pCur->pBtree, &pTE->root, pTE->flags,
+                           pLowerKey, nLowerKey, &nLower);
+  if( rc!=SQLITE_OK ) goto done;
+  if( pUpperNext ){
+    rc = countBlobKeysBefore(pCur->pBtree, &pTE->root, pTE->flags,
+                             pUpperNext, nUpperKey, &nUpper);
+  }else{
+    rc = countTreeEntries(pCur->pBtree, pCur->pgnoRoot, &nUpper);
+  }
+  if( rc==SQLITE_OK ){
+    *pCount = nUpper - nLower;
+    if( *pCount<0 ) *pCount = 0;
+  }
+
+done:
+  sqlite3_free(pLowerKey);
+  sqlite3_free(pUpperKey);
+  sqlite3_free(pUpperNext);
+  return rc;
 }
 
 static int saveAllCursors(Btree *pBtree, BtShared *pBt, Pgno iRoot,
@@ -7539,6 +7686,42 @@ static int prollyBtCursorCountRange(
                            iLower, iUpper, pnEntry);
 }
 
+static int prollyBtCursorCountIndexRange(
+  sqlite3 *db,
+  BtCursor *pCur,
+  UnpackedRecord *pLower,
+  UnpackedRecord *pUpper,
+  i64 *pnEntry
+){
+  struct TableEntry *pTE;
+  (void)db;
+
+  if( pCur->curIntKey ) return SQLITE_NOTFOUND;
+  pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
+  if( pTE && pTE->pPending ){
+    ProllyMutMap *pMap = (ProllyMutMap*)pTE->pPending;
+    if( !prollyMutMapIsEmpty(pMap) ){
+      ProllyMutMap *pFlushMap = pMap;
+      int captured = 0;
+      int rc = snapshotPendingForFlush(pCur->pBtree, pCur->pgnoRoot,
+                                       (ProllyMutMap**)&pTE->pPending,
+                                       &pFlushMap, &captured);
+      if( rc!=SQLITE_OK ) return rc;
+      if( captured ){
+        refreshCursorMutMapAliases(pCur->pBtree, pCur->pBt, pCur->pgnoRoot,
+                                   (ProllyMutMap*)pTE->pPending);
+      }
+      rc = applyMutMapToTableRoot(pCur->pBt, pTE, pFlushMap);
+      if( rc!=SQLITE_OK ) return rc;
+      if( pTE->pPending==pMap ){
+        prollyMutMapClear(pMap);
+      }
+    }
+  }
+  flushIfNeeded(pCur);
+  return countTreeBlobPrefixRange(pCur, pLower, pUpper, pnEntry);
+}
+
 int sqlite3BtreeCount(sqlite3 *db, BtCursor *pCur, i64 *pnEntry){
   if( !pCur ) return SQLITE_OK;
   return pCur->pCurOps->xCount(db, pCur, pnEntry);
@@ -7553,6 +7736,17 @@ int sqlite3BtreeCountRange(
 ){
   if( !pCur ) return SQLITE_OK;
   return pCur->pCurOps->xCountRange(db, pCur, iLower, iUpper, pnEntry);
+}
+
+int sqlite3BtreeCountIndexRange(
+  sqlite3 *db,
+  BtCursor *pCur,
+  UnpackedRecord *pLower,
+  UnpackedRecord *pUpper,
+  i64 *pnEntry
+){
+  if( !pCur ) return SQLITE_OK;
+  return pCur->pCurOps->xCountIndexRange(db, pCur, pLower, pUpper, pnEntry);
 }
 
 static i64 prollyBtCursorRowCountEst(BtCursor *pCur){
@@ -9202,6 +9396,16 @@ static int origCursorCountRangeVt(
   }
   *pnEntry = n;
   return SQLITE_OK;
+}
+static int origCursorCountIndexRangeVt(
+  sqlite3 *db,
+  BtCursor *pCur,
+  UnpackedRecord *pLower,
+  UnpackedRecord *pUpper,
+  i64 *pnEntry
+){
+  return origBtreeCountIndexRange(db, pCur->pOrigCursor,
+                                  pLower, pUpper, pnEntry);
 }
 static i64 origCursorRowCountEstVt(BtCursor *pCur){
   (void)pCur;

--- a/src/select.c
+++ b/src/select.c
@@ -5493,6 +5493,35 @@ static int exprIsKnownNotNullForTable(Expr *pExpr, Table *pTab){
   return 0;
 }
 
+static int exprColumnOfTable(Expr *pExpr, Table *pTab){
+  while( pExpr && (pExpr->op==TK_UPLUS || pExpr->op==TK_COLLATE) ){
+    pExpr = pExpr->pLeft;
+  }
+  if( pExpr
+   && (pExpr->op==TK_COLUMN || pExpr->op==TK_AGG_COLUMN)
+   && ExprUseYTab(pExpr)
+   && pExpr->y.pTab==pTab
+  ){
+    return pExpr->iColumn;
+  }
+  return -2;
+}
+
+static Index *findSingleColumnIndex(Table *pTab, int iColumn){
+  Index *pIdx;
+  for(pIdx=pTab->pIndex; pIdx; pIdx=pIdx->pNext){
+    if( pIdx->pPartIdxWhere==0
+     && pIdx->bUnordered==0
+     && pIdx->nKeyCol>=1
+     && pIdx->aiColumn[0]==iColumn
+     && (pIdx->aSortOrder==0 || pIdx->aSortOrder[0]==0)
+    ){
+      return pIdx;
+    }
+  }
+  return 0;
+}
+
 /*
 ** Return the table for a SELECT that can be answered by counting an
 ** inclusive integer rowid range, and populate ppLow/ppHigh with the bounds.
@@ -5563,6 +5592,83 @@ static Table *isSimpleRowidRangeCount(
     return 0;
   }
   return pTab;
+}
+
+static Index *isSimpleIndexRangeCount(
+  Select *p,
+  AggInfo *pAggInfo,
+  Expr **ppLow,
+  Expr **ppHigh,
+  Table **ppTab,
+  Parse *pParse
+){
+  Table *pTab;
+  Expr *pExpr;
+  ExprList *pArgs;
+  SrcItem *pSrc;
+  Index *pIdx;
+  int iColumn;
+  int iArgColumn;
+
+  assert( !p->pGroupBy );
+  if( p->pWhere==0
+   || p->pWhere->op!=TK_BETWEEN
+   || !ExprUseXList(p->pWhere)
+   || p->pWhere->x.pList==0
+   || p->pWhere->x.pList->nExpr!=2
+   || p->pEList->nExpr!=1
+   || p->pSrc->nSrc!=1
+   || p->pSrc->a[0].fg.isSubquery
+   || pAggInfo->nFunc!=1
+   || p->pHaving
+  ){
+    return 0;
+  }
+  pSrc = &p->pSrc->a[0];
+  pTab = pSrc->pSTab;
+  assert( pTab!=0 );
+  assert( !IsView(pTab) );
+  if( !IsOrdinaryTable(pTab) ) return 0;
+  if( p->pWhere->pLeft==0
+   || (p->pWhere->pLeft->op!=TK_COLUMN && p->pWhere->pLeft->op!=TK_AGG_COLUMN)
+  ){
+    return 0;
+  }
+  iColumn = exprColumnOfTable(p->pWhere->pLeft, pTab);
+  if( iColumn<0 ) return 0;
+  *ppLow = p->pWhere->x.pList->a[0].pExpr;
+  *ppHigh = p->pWhere->x.pList->a[1].pExpr;
+  if( !sqlite3ExprIsConstant(pParse, *ppLow)
+   || !sqlite3ExprIsConstant(pParse, *ppHigh)
+  ){
+    return 0;
+  }
+  pIdx = findSingleColumnIndex(pTab, iColumn);
+  if( !pIdx ) return 0;
+
+  pExpr = p->pEList->a[0].pExpr;
+  assert( pExpr!=0 );
+  if( pExpr->op!=TK_AGG_FUNCTION ) return 0;
+  if( pExpr->pAggInfo!=pAggInfo ) return 0;
+  if( (pAggInfo->aFunc[0].pFunc->funcFlags&SQLITE_FUNC_COUNT)==0
+   && sqlite3_stricmp(pExpr->u.zToken,"count")!=0
+  ){
+    return 0;
+  }
+  assert( pAggInfo->aFunc[0].pFExpr==pExpr );
+  if( ExprHasProperty(pExpr, EP_Distinct|EP_WinFunc) ) return 0;
+  pArgs = ExprUseXList(pExpr) ? pExpr->x.pList : 0;
+  if( pArgs && pArgs->nExpr>0 ){
+    iArgColumn = exprColumnOfTable(pArgs->a[0].pExpr, pTab);
+    if( iArgColumn!=iColumn
+     && !exprIsKnownNotNullForTable(pArgs->a[0].pExpr, pTab)
+    ){
+      return 0;
+    }
+  }
+
+  *ppTab = pTab;
+  return pIdx;
 }
 
 /*
@@ -8889,9 +8995,46 @@ int sqlite3Select(
       Table *pTab;
       Expr *pRangeLow = 0;
       Expr *pRangeHigh = 0;
-      if( (pTab = isSimpleRowidRangeCount(p, pAggInfo,
-                                          &pRangeLow, &pRangeHigh,
-                                          pParse))!=0 ){
+      Index *pRangeIdx = 0;
+      if( (pRangeIdx = isSimpleIndexRangeCount(p, pAggInfo,
+                                               &pRangeLow, &pRangeHigh,
+                                               &pTab, pParse))!=0 ){
+        const int iDb = sqlite3SchemaToIndex(pParse->db, pTab->pSchema);
+        const int iCsr = pParse->nTab++;
+        KeyInfo *pKeyInfo = sqlite3KeyInfoOfIndex(pParse, pRangeIdx);
+        int regRange;
+
+        sqlite3CodeVerifySchema(pParse, iDb);
+        sqlite3TableLock(pParse, iDb, pTab->tnum, 0, pTab->zName);
+        sqlite3VdbeAddOp4Int(v, OP_OpenRead, iCsr,
+                             (int)pRangeIdx->tnum, iDb, 1);
+        sqlite3VdbeChangeP4(v, -1, (char *)pKeyInfo, P4_KEYINFO);
+        assignAggregateRegisters(pParse, pAggInfo);
+        regRange = sqlite3GetTempRange(pParse, 2);
+        sqlite3ExprCode(pParse, pRangeLow, regRange);
+        sqlite3ExprCode(pParse, pRangeHigh, regRange+1);
+        {
+          const char *zIdxAff = sqlite3IndexAffinityStr(pParse->db, pRangeIdx);
+          char zAff[2];
+          if( zIdxAff ){
+            zAff[0] = zIdxAff[0];
+            zAff[1] = zIdxAff[0];
+            sqlite3VdbeAddOp4(v, OP_Affinity, regRange, 2, 0, zAff, 2);
+          }
+        }
+        sqlite3VdbeAddOp4Int(v, OP_CountIndexRange, iCsr,
+                             AggInfoFuncReg(pAggInfo,0), regRange, 1);
+        sqlite3ReleaseTempRange(pParse, regRange, 2);
+        sqlite3VdbeAddOp1(v, OP_Close, iCsr);
+        if( pParse->explain==2 ){
+          sqlite3VdbeExplain(pParse, 0,
+              "SEARCH %s USING COVERING INDEX %s",
+              pTab->zName, pRangeIdx->zName
+          );
+        }
+      }else if( (pTab = isSimpleRowidRangeCount(p, pAggInfo,
+                                                &pRangeLow, &pRangeHigh,
+                                                pParse))!=0 ){
         const int iDb = sqlite3SchemaToIndex(pParse->db, pTab->pSchema);
         const int iCsr = pParse->nTab++;
         int regRange;

--- a/src/vdbe.c
+++ b/src/vdbe.c
@@ -3905,6 +3905,81 @@ case OP_CountRange: {    /* out2 */
   goto check_for_interrupt;
 }
 
+/* Opcode: CountIndexRange P1 P2 P3 P4 *
+** Synopsis: r[P2]=count_index_range(r[P3]..r[P3+P4])
+**
+** Store in register P2 the number of entries in index cursor P1 whose first
+** P4 fields are between the values in registers P3 and P3+P4, inclusive.
+*/
+case OP_CountIndexRange: {    /* out2 */
+  i64 nEntry = 0;
+  BtCursor *pCrsr;
+  VdbeCursor *pC;
+  UnpackedRecord rLower;
+  UnpackedRecord rUpper;
+  int nField = pOp->p4.i;
+  int res = 0;
+  int i;
+
+  assert( pOp->p4type==P4_INT32 );
+  assert( nField>0 );
+  assert( p->apCsr[pOp->p1]->eCurType==CURTYPE_BTREE );
+  pC = p->apCsr[pOp->p1];
+  pCrsr = pC->uc.pCursor;
+  assert( pCrsr );
+  assert( !pC->isTable );
+
+  rLower.pKeyInfo = pC->pKeyInfo;
+  rLower.nField = (u16)nField;
+  rLower.default_rc = +1;
+  rLower.aMem = &aMem[pOp->p3];
+  rLower.eqSeen = 0;
+  rUpper.pKeyInfo = pC->pKeyInfo;
+  rUpper.nField = (u16)nField;
+  rUpper.default_rc = -1;
+  rUpper.aMem = &aMem[pOp->p3+nField];
+  rUpper.eqSeen = 0;
+
+  for(i=0; i<nField*2; i++){
+    if( aMem[pOp->p3+i].flags & MEM_Null ){
+      pOut = out2Prerelease(p, pOp);
+      pOut->u.i = 0;
+      goto check_for_interrupt;
+    }
+  }
+
+  rc = sqlite3BtreeCountIndexRange(db, pCrsr, &rLower, &rUpper, &nEntry);
+  if( rc==SQLITE_NOTFOUND ){
+    rc = sqlite3BtreeIndexMoveto(pCrsr, &rLower, &res);
+    if( rc ) goto abort_due_to_error;
+    if( res<0 ){
+      rc = sqlite3BtreeNext(pCrsr, 0);
+      if( rc==SQLITE_DONE ){
+        rc = SQLITE_OK;
+      }
+      if( rc ) goto abort_due_to_error;
+    }
+    while( !sqlite3BtreeEof(pCrsr) ){
+      rc = sqlite3VdbeIdxKeyCompare(db, pC, &rUpper, &res);
+      if( rc ) goto abort_due_to_error;
+      res++;
+      if( res>0 ) break;
+      nEntry++;
+      rc = sqlite3BtreeNext(pCrsr, 0);
+      if( rc==SQLITE_DONE ){
+        rc = SQLITE_OK;
+        break;
+      }
+      if( rc ) goto abort_due_to_error;
+    }
+  }else if( rc ){
+    goto abort_due_to_error;
+  }
+  pOut = out2Prerelease(p, pOp);
+  pOut->u.i = nEntry;
+  goto check_for_interrupt;
+}
+
 /* Opcode: Savepoint P1 * * P4 *
 **
 ** Open, release or rollback the savepoint named by parameter P4, depending

--- a/test/doltlite_count_perf.sh
+++ b/test/doltlite_count_perf.sh
@@ -120,6 +120,20 @@ assert_sql "count_not_null_rowid_range" "$DB_1K" \
    SELECT count(k) FROM u WHERE id BETWEEN 2 AND 8;" 2
 assert_sql "count_rowid_range_empty" "$DB_1K" \
   "SELECT count(*) FROM t WHERE id BETWEEN 2000 AND 2010;" 0
+assert_sql "count_index_range_duplicates_and_affinity" "$DB_1K" \
+  "CREATE TABLE v(id INTEGER PRIMARY KEY, k INTEGER NOT NULL);
+   CREATE INDEX v_k_idx ON v(k);
+   INSERT INTO v VALUES(1,10),(2,10),(3,15),(4,20),(5,30);
+   SELECT count(k) FROM v WHERE k BETWEEN '10' AND '20';" 4
+assert_sql "count_index_range_null_bound" "$DB_1K" \
+  "SELECT count(k) FROM v WHERE k BETWEEN NULL AND 20;" 0
+assert_sql "count_index_range_row_dependent_bounds" "$DB_1K" \
+  "SELECT count(k) FROM v WHERE k BETWEEN id AND id+100;" 5
+assert_sql "count_index_range_nullable_count_arg" "$DB_1K" \
+  "CREATE TABLE w(id INTEGER PRIMARY KEY, k INTEGER NOT NULL, v INTEGER);
+   CREATE INDEX w_k_idx ON w(k);
+   INSERT INTO w VALUES(1,10,NULL),(2,10,1),(3,15,NULL),(4,20,2);
+   SELECT count(v) FROM w WHERE k BETWEEN 10 AND 20;" 2
 
 echo ""
 echo "--- Performance ---"


### PR DESCRIPTION
## Summary
- add a `CountIndexRange` VDBE opcode for simple `count(*)` / `count(indexed_col)` over single-column indexed `BETWEEN` ranges
- implement DoltLite prolly index rank counting using sort-key prefixes, with stock btree falling back to the generic scan path
- add count performance regression coverage for duplicate index keys, affinity on bounds, NULL bounds, and nullable count arguments

## Benchmark
Current master wrapped baseline, 10k rows:
- file-backed `covering_index_scan`: SQLite 8,539 us, DoltLite 5,973 us, multiplier 0.70

This branch wrapped run, 10k rows:
- file-backed `covering_index_scan`: SQLite 8,755 us, DoltLite 2,709 us, multiplier 0.31
- in-memory `covering_index_scan`: SQLite 4,364 us, DoltLite 2,037 us, multiplier 0.47

Focused long workload:
- before: 592,378 us
- after: 237,767 us

## Tests
- `make -j$(sysctl -n hw.ncpu) doltlite doltlite-lib && cc -O2 -I. -I../src -o bench_timer_doltlite test/sysbench_timer.c libdoltlite.a -lpthread -lz -lm`
- `bash test/doltlite_count_perf.sh`
- `BENCH_SECTION_MODE=wrapped BENCH_ROWS=10000 bash test/sysbench_compare.sh > /tmp/doltlite_sysbench_covering_patched.md`
- `make DOLTLITE_PROLLY=0 sqlite3`
- stock `./sqlite3 :memory:` indexed range count fallback smoke test
- `git diff --check`