### PR TITLE
Optimize small integer sorter comparisons

### DIFF
--- a/src/vdbesort.c
+++ b/src/vdbesort.c
@@ -906,16 +906,29 @@ static int vdbeSorterCompareInt(
   const int s2 = p2[1];                 /* Right hand serial type */
   const u8 * const v1 = &p1[ p1[0] ];   /* Pointer to value 1 */
   const u8 * const v2 = &p2[ p2[0] ];   /* Pointer to value 2 */
+  static const u8 aLen[] = {0, 1, 2, 3, 4, 6, 8, 0, 0, 0 };
   int res;                              /* Return value */
+  u8 n;
+  int i;
 
   assert( (s1>0 && s1<7) || s1==8 || s1==9 );
   assert( (s2>0 && s2<7) || s2==8 || s2==9 );
 
   if( s1==s2 ){
+    if( s1==1 ){
+      const int i1 = (signed char)v1[0];
+      const int i2 = (signed char)v2[0];
+      res = i1 - i2;
+      goto compare_int_done;
+    }else if( s1==2 ){
+      const int i1 = (i16)(((u16)v1[0]<<8) | v1[1]);
+      const int i2 = (i16)(((u16)v2[0]<<8) | v2[1]);
+      res = i1 - i2;
+      goto compare_int_done;
+    }
+
     /* The two values have the same sign. Compare using memcmp(). */
-    static const u8 aLen[] = {0, 1, 2, 3, 4, 6, 8, 0, 0, 0 };
-    const u8 n = aLen[s1];
-    int i;
+    n = aLen[s1];
     res = 0;
     for(i=0; i<n; i++){
       if( (res = v1[i] - v2[i])!=0 ){
@@ -944,6 +957,7 @@ static int vdbeSorterCompareInt(
     }
   }
 
+compare_int_done:
   assert( pTask->pSorter->pKeyInfo->aSortFlags!=0 );
   if( res==0 ){
     if( pTask->pSorter->pKeyInfo->nKeyField>1 ){


### PR DESCRIPTION
## Summary
- add fast paths for 1-byte and 2-byte integer serial types in the VDBE sorter integer comparator
- improves GROUP BY / ORDER BY workloads that sort small integer keys, including the classic INTKEY groupby_scan benchmark

## Local benchmark
Baseline before this change, BENCH_RUNS=3 wrapped:
- file-backed groupby_scan: 23,873 us
- in-memory groupby_scan: 22,361 us

After this change, BENCH_RUNS=5 wrapped with CI-style stock SQLite build:
- file-backed groupby_scan: 22,932 us
- in-memory groupby_scan: 21,544 us

Long isolated groupby_scan workload:
- before/profile run: 1,270,440 us
- after: ~1,057,717 us median-ish over 3 runs

## Validation
- make -j10 doltlite doltlite-lib
- make DOLTLITE_PROLLY=0 sqlite3 sqlite3.o
- cc timers for doltlite and stock SQLite
- BENCH_RUNS=5 BENCH_SECTION_MODE=wrapped bash test/sysbench_compare.sh
- focused ORDER BY / GROUP BY signed small-integer SQL check
- git diff --check

Note: make testfixture is blocked locally by missing tommath (ld: library 'tommath' not found).