### PR TITLE
Optimize integer index join seeks

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -2540,10 +2540,16 @@ static int sortKeyFromUnpackedIntRecordBuffer(
     *pnAlloc = nAlloc;
   }
   for(i=0; i<nField; i++){
+    i64 v = pRec->aMem[i].u.i;
     int n = 0;
-    int rc = sortKeyFromInt64(pRec->aMem[i].u.i, *ppBuf + nOut, &n);
-    if( rc!=SQLITE_OK ) return rc;
-    nOut += n;
+    if( sortKeyInt64FitsExact(v) ){
+      sortKeyWriteExactInt64(v, *ppBuf + nOut);
+      nOut += 9;
+    }else{
+      int rc = sortKeyFromInt64(v, *ppBuf + nOut, &n);
+      if( rc!=SQLITE_OK ) return rc;
+      nOut += n;
+    }
   }
   *pnOut = nOut;
   return SQLITE_OK;

--- a/src/prolly_node.c
+++ b/src/prolly_node.c
@@ -198,14 +198,6 @@ static SQLITE_INLINE int prollyKeyComparePrefix(
   const u8 *pRight,
   int n
 ){
-  int i;
-  if( n<=32 ){
-    for(i=0; i<n; i++){
-      int c = (int)pLeft[i] - (int)pRight[i];
-      if( c ) return c;
-    }
-    return 0;
-  }
   return memcmp(pLeft, pRight, n);
 }
 

--- a/src/sortkey.c
+++ b/src/sortkey.c
@@ -631,20 +631,8 @@ int sortKeyFromInt64(i64 v, u8 *pOut, int *pnOut){
   u32 serialType;
   u32 nData;
 
-  if( v>=-9007199254740992LL && v<=9007199254740992LL ){
-    double d = (double)v;
-    u64 x;
-    int i;
-    pOut[0] = SORTKEY_NUM;
-    memcpy(&x, &d, 8);
-    if( x & ((u64)1 << 63) ){
-      x = ~x;
-    }else{
-      x ^= ((u64)1 << 63);
-    }
-    for(i=0; i<8; i++){
-      pOut[1+i] = (u8)(x >> (56 - i*8));
-    }
+  if( sortKeyInt64FitsExact(v) ){
+    sortKeyWriteExactInt64(v, pOut);
     *pnOut = 9;
     return SQLITE_OK;
   }

--- a/src/sortkey.h
+++ b/src/sortkey.h
@@ -3,6 +3,7 @@
 #define SQLITE_SORTKEY_H
 
 #include "sqliteInt.h"
+#include <string.h>
 
 #define SORTKEY_NULL    0x05
 #define SORTKEY_NUM     0x15
@@ -27,6 +28,26 @@ int sortKeyFromMemPrefixCollBuffer(
 
 int sortKeyFromInt64(i64 v, u8 *pOut, int *pnOut);
 int sortKeyFromInt64Buffer(i64 v, u8 **ppBuf, int *pnAlloc, int *pnOut);
+
+static inline int sortKeyInt64FitsExact(i64 v){
+  return v>=-9007199254740992LL && v<=9007199254740992LL;
+}
+
+static inline void sortKeyWriteExactInt64(i64 v, u8 *pOut){
+  double d = (double)v;
+  u64 x;
+  int i;
+  pOut[0] = SORTKEY_NUM;
+  memcpy(&x, &d, 8);
+  if( x & ((u64)1 << 63) ){
+    x = ~x;
+  }else{
+    x ^= ((u64)1 << 63);
+  }
+  for(i=0; i<8; i++){
+    pOut[1+i] = (u8)(x >> (56 - i*8));
+  }
+}
 
 int sortKeySize(const u8 *pRec, int nRec);
 


### PR DESCRIPTION
## Summary
- inline the exact-int sort-key encoding used by integer index seek keys
- use the shared exact-int encoder from sortkey.c and the integer-index seek path
- let prolly node binary searches use libc memcmp directly for byte-key prefix comparisons

## Benchmark
Latest master baseline, BENCH_RUNS=5 BENCH_SECTION_MODE=wrapped:
- In-memory index_join: 3,057 us
- File-backed index_join: 4,780 us
- File-backed index_join_scan: 2,402 us

This branch, BENCH_RUNS=7 BENCH_SECTION_MODE=wrapped:
- In-memory index_join: 3,101 us
- File-backed index_join: 4,878 us
- File-backed index_join_scan: 2,380 us
- All benchmark ceilings passed

Earlier BENCH_RUNS=5 run on this branch:
- In-memory index_join: 3,005 us
- File-backed index_join: 5,024 us
- File-backed index_join_scan: 2,397 us

The local wall-clock numbers are noisy, but the change removes general per-seek work from integer-index probes and does not specialize the sysbench SQL shape.

## Verification
- make -j10 doltlite doltlite-lib
- BENCH_RUNS=7 BENCH_SECTION_MODE=wrapped bash test/sysbench_compare.sh
- signed exact-int index seek/order smoke test through ./doltlite
- git diff --check