### PR TITLE
Optimize autocommit int primary key appends

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -803,6 +803,33 @@ int chunkStoreSerializeRefs(ChunkStore *cs){
   int sz = 0;
   ProllyHash refsHash;
 
+  if( cs->refs.nBranches==1
+   && cs->refs.nTags==0
+   && cs->refs.nRemotes==0
+   && cs->refs.nTracking==0
+   && (!cs->refs.zDefaultBranch || strcmp(cs->refs.zDefaultBranch, "main")==0)
+   && strcmp(cs->refs.aBranches[0].zName, "main")==0 ){
+    u8 aBuf[73];
+    u8 *p = aBuf;
+    *p++ = 6;
+    CS_WRITE_U32(p,4); p+=4;
+    memcpy(p, "main", 4); p+=4;
+    CS_WRITE_U32(p,1); p+=4;
+    CS_WRITE_U32(p,4); p+=4;
+    memcpy(p, "main", 4); p+=4;
+    memcpy(p, cs->refs.aBranches[0].commitHash.data, PROLLY_HASH_SIZE);
+    p += PROLLY_HASH_SIZE;
+    memcpy(p, cs->refs.aBranches[0].workingSetHash.data, PROLLY_HASH_SIZE);
+    p += PROLLY_HASH_SIZE;
+    CS_WRITE_U32(p,0); p+=4;
+    CS_WRITE_U32(p,0); p+=4;
+    CS_WRITE_U32(p,0); p+=4;
+    assert( p==aBuf+sizeof(aBuf) );
+    rc = chunkStorePut(cs, aBuf, (int)sizeof(aBuf), &refsHash);
+    if( rc==SQLITE_OK ) memcpy(&cs->refs.refsHash, &refsHash, sizeof(ProllyHash));
+    return rc;
+  }
+
   rc = csSerializeRefsBlob(cs, &buf, &sz);
   if( rc!=SQLITE_OK ) return rc;
   rc = chunkStorePut(cs, buf, sz, &refsHash);

--- a/src/prolly_mutate.c
+++ b/src/prolly_mutate.c
@@ -3,6 +3,7 @@
 
 #include "prolly_mutate.h"
 #include "prolly_check.h"
+#include "prolly_xxhash.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -357,6 +358,338 @@ streaming_cleanup:
   return rc;
 }
 
+static void nodeAppendState(const ProllyNode *pNode,
+                            const u8 *pKey, int nKey,
+                            int nVal,
+                            int *pEndsAtBoundary,
+                            int *pWouldSplit){
+  int i;
+  int nBytes = 0;
+  int thisSize = nKey + nVal;
+  int endsAtBoundary = 0;
+  int wouldSplit = 0;
+
+  for(i=0; i<(int)pNode->nItems; i++){
+    const u8 *pK, *pV;
+    int nK, nV;
+    prollyNodeKey(pNode, i, &pK, &nK);
+    prollyNodeValue(pNode, i, &pV, &nV);
+    (void)pK; (void)pV;
+    nBytes += nK + nV;
+  }
+  if( pNode->nItems>0 && nBytes >= PROLLY_CHUNK_MAX ){
+    endsAtBoundary = 1;
+  }else if( pNode->nItems>0 && nBytes >= PROLLY_CHUNK_MIN ){
+    const u8 *pLastKey, *pLastVal;
+    int nLastKey, nLastVal;
+    u32 h;
+    prollyNodeKey(pNode, (int)pNode->nItems - 1, &pLastKey, &nLastKey);
+    prollyNodeValue(pNode, (int)pNode->nItems - 1, &pLastVal, &nLastVal);
+    (void)pLastVal;
+    h = prollyXXH32(pLastKey, nLastKey, (u32)pNode->level);
+    endsAtBoundary = prollyWeibullCheck((u32)nBytes,
+                                        (u32)(nLastKey + nLastVal), h);
+  }
+
+  nBytes += thisSize;
+  if( nBytes >= PROLLY_CHUNK_MAX ){
+    wouldSplit = 1;
+  }else if( nBytes >= PROLLY_CHUNK_MIN ){
+    u32 h = prollyXXH32(pKey, nKey, 0);
+    wouldSplit = prollyWeibullCheck((u32)nBytes, (u32)thisSize, h);
+  }
+
+  *pEndsAtBoundary = endsAtBoundary;
+  *pWouldSplit = wouldSplit;
+}
+
+static int appendWouldSplitNode(const ProllyNode *pNode,
+                                const u8 *pKey, int nKey,
+                                int nVal){
+  int i;
+  int nBytes = 0;
+  int thisSize = nKey + nVal;
+  for(i=0; i<(int)pNode->nItems; i++){
+    const u8 *pK, *pV;
+    int nK, nV;
+    prollyNodeKey(pNode, i, &pK, &nK);
+    prollyNodeValue(pNode, i, &pV, &nV);
+    (void)pK; (void)pV;
+    nBytes += nK + nV;
+  }
+  nBytes += thisSize;
+  if( nBytes >= PROLLY_CHUNK_MAX ) return 1;
+  if( nBytes >= PROLLY_CHUNK_MIN ){
+    u32 h = prollyXXH32(pKey, nKey, (u32)pNode->level);
+    return prollyWeibullCheck((u32)nBytes, (u32)thisSize, h);
+  }
+  return 0;
+}
+
+static int nodeEndsAtChunkBoundary(const ProllyNode *pNode){
+  const u8 *pKey, *pVal;
+  int nKey, nVal;
+  int nBytes = 0;
+  int i;
+
+  if( pNode->nItems==0 ) return 0;
+  for(i=0; i<(int)pNode->nItems; i++){
+    prollyNodeKey(pNode, i, &pKey, &nKey);
+    prollyNodeValue(pNode, i, &pVal, &nVal);
+    (void)pVal;
+    nBytes += nKey + nVal;
+  }
+  if( nBytes >= PROLLY_CHUNK_MAX ) return 1;
+  if( nBytes >= PROLLY_CHUNK_MIN ){
+    u32 h;
+    prollyNodeKey(pNode, (int)pNode->nItems - 1, &pKey, &nKey);
+    prollyNodeValue(pNode, (int)pNode->nItems - 1, &pVal, &nVal);
+    h = prollyXXH32(pKey, nKey, (u32)pNode->level);
+    return prollyWeibullCheck((u32)nBytes, (u32)(nKey + nVal), h);
+  }
+  return 0;
+}
+
+static int appendNodeEntryToBuilder(
+  ProllyNodeBuilder *pBuilder,
+  const ProllyNode *pNode,
+  int i,
+  u64 subtreeCount
+){
+  const u8 *pKey, *pVal;
+  int nKey, nVal;
+  prollyNodeKey(pNode, i, &pKey, &nKey);
+  prollyNodeValue(pNode, i, &pVal, &nVal);
+  if( pNode->level==0 ){
+    return prollyNodeBuilderAdd(pBuilder, pKey, nKey, pVal, nVal);
+  }
+  return prollyNodeBuilderAddWithCount(pBuilder, pKey, nKey, pVal, nVal,
+                                       subtreeCount);
+}
+
+static int writeBuilderNode(ChunkStore *pStore, ProllyNodeBuilder *pBuilder,
+                            ProllyHash *pHash){
+  u8 *pData = 0;
+  int nData = 0;
+  int rc = prollyNodeBuilderFinish(pBuilder, &pData, &nData);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = chunkStorePut(pStore, pData, nData, pHash);
+  sqlite3_free(pData);
+  return rc;
+}
+
+static int tryAppendSingleIntNoSplit(ProllyMutator *pMut){
+  ProllyMutMapEntry *pEdit;
+  ProllyCursor cur;
+  ProllyHash childHash;
+  const u8 *pNewKey;
+  int nNewKey;
+  i64 iNewKey;
+  int rc;
+  int res = 0;
+  int level;
+
+  if( !(pMut->flags & PROLLY_NODE_INTKEY) ) return SQLITE_NOTFOUND;
+  if( prollyHashIsEmpty(&pMut->oldRoot) ) return SQLITE_NOTFOUND;
+  if( prollyMutMapCount(pMut->pEdits)!=1 ) return SQLITE_NOTFOUND;
+
+  pEdit = &pMut->pEdits->aEntries[0];
+  if( pEdit->op!=PROLLY_EDIT_INSERT || pEdit->nKey!=8 ){
+    return SQLITE_NOTFOUND;
+  }
+
+  pNewKey = pEdit->pKey;
+  nNewKey = pEdit->nKey;
+  iNewKey = prollyMutMapEntryIntKey(pEdit);
+
+  prollyCursorInit(&cur, pMut->pStore, pMut->pCache, &pMut->oldRoot,
+                   pMut->flags);
+  rc = prollyCursorLast(&cur, &res);
+  if( rc!=SQLITE_OK ){
+    prollyCursorClose(&cur);
+    return rc;
+  }
+  if( res!=0 || cur.eState!=PROLLY_CURSOR_VALID ){
+    prollyCursorClose(&cur);
+    return SQLITE_NOTFOUND;
+  }
+  if( iNewKey <= prollyCursorIntKey(&cur) ){
+    prollyCursorClose(&cur);
+    return SQLITE_NOTFOUND;
+  }
+
+  level = cur.iLevel;
+  {
+    int leafEndsAtBoundary = 0;
+    int leafWouldSplit = 0;
+    nodeAppendState(&cur.aLevel[level].pEntry->node,
+                    pNewKey, nNewKey, pEdit->nVal,
+                    &leafEndsAtBoundary, &leafWouldSplit);
+    if( leafEndsAtBoundary ){
+      int j;
+      for(j=1; j<level; j++){
+        if( nodeEndsAtChunkBoundary(&cur.aLevel[j].pEntry->node) ){
+          prollyCursorClose(&cur);
+          return SQLITE_NOTFOUND;
+        }
+      }
+      {
+        ProllyNodeBuilder b;
+        prollyNodeBuilderInit(&b, 0, pMut->flags);
+        rc = prollyNodeBuilderAdd(&b, pNewKey, nNewKey,
+                                  pEdit->pVal, pEdit->nVal);
+        if( rc==SQLITE_OK ){
+          rc = writeBuilderNode(pMut->pStore, &b, &childHash);
+        }
+        prollyNodeBuilderFree(&b);
+        if( rc!=SQLITE_OK ){
+          prollyCursorClose(&cur);
+          return rc;
+        }
+      }
+      if( level==0 ){
+        ProllyNode *pLeaf = &cur.aLevel[level].pEntry->node;
+        ProllyNodeBuilder b;
+        const u8 *pOldKey;
+        int nOldKey;
+        prollyNodeKey(pLeaf, (int)pLeaf->nItems - 1, &pOldKey, &nOldKey);
+        prollyNodeBuilderInit(&b, 1, pMut->flags);
+        rc = prollyNodeBuilderAddWithCount(&b, pOldKey, nOldKey,
+            pMut->oldRoot.data, PROLLY_HASH_SIZE, (u64)pLeaf->nItems);
+        if( rc==SQLITE_OK ){
+          rc = prollyNodeBuilderAddWithCount(&b, pNewKey, nNewKey,
+              childHash.data, PROLLY_HASH_SIZE, 1);
+        }
+        if( rc!=SQLITE_OK ){
+          prollyNodeBuilderFree(&b);
+          prollyCursorClose(&cur);
+          return rc;
+        }
+        rc = writeBuilderNode(pMut->pStore, &b, &childHash);
+        prollyNodeBuilderFree(&b);
+        if( rc!=SQLITE_OK ){
+          prollyCursorClose(&cur);
+          return rc;
+        }
+        pMut->newRoot = childHash;
+        prollyCursorClose(&cur);
+        return SQLITE_OK;
+      }else{
+        ProllyNode *pParent = &cur.aLevel[level - 1].pEntry->node;
+        ProllyNodeBuilder b;
+        ProllyHash parentHash;
+        int i;
+        if( appendWouldSplitNode(pParent, pNewKey, nNewKey, PROLLY_HASH_SIZE) ){
+          prollyCursorClose(&cur);
+          return SQLITE_NOTFOUND;
+        }
+        prollyNodeBuilderInit(&b, (u8)pParent->level, pMut->flags);
+        for(i=0; i<(int)pParent->nItems; i++){
+          u64 cnt = 0;
+          rc = parentChildSubtreeCount(pMut->pStore, pMut->pCache,
+                                       pParent, i, &cnt);
+          if( rc==SQLITE_OK ){
+            rc = appendNodeEntryToBuilder(&b, pParent, i, cnt);
+          }
+          if( rc!=SQLITE_OK ){
+            prollyNodeBuilderFree(&b);
+            prollyCursorClose(&cur);
+            return rc;
+          }
+        }
+        rc = prollyNodeBuilderAddWithCount(&b, pNewKey, nNewKey,
+                                           childHash.data, PROLLY_HASH_SIZE, 1);
+        if( rc==SQLITE_OK ){
+          rc = writeBuilderNode(pMut->pStore, &b, &parentHash);
+        }
+        prollyNodeBuilderFree(&b);
+        if( rc!=SQLITE_OK ){
+          prollyCursorClose(&cur);
+          return rc;
+        }
+        childHash = parentHash;
+        level--;
+      }
+    }else{
+      if( leafWouldSplit ){
+        prollyCursorClose(&cur);
+        return SQLITE_NOTFOUND;
+      }
+      {
+        ProllyNode *pLeaf = &cur.aLevel[level].pEntry->node;
+        ProllyNodeBuilder b;
+        int i;
+        prollyNodeBuilderInit(&b, 0, pMut->flags);
+        for(i=0; i<(int)pLeaf->nItems; i++){
+          rc = appendNodeEntryToBuilder(&b, pLeaf, i, 0);
+          if( rc!=SQLITE_OK ){
+            prollyNodeBuilderFree(&b);
+            prollyCursorClose(&cur);
+            return rc;
+          }
+        }
+        rc = prollyNodeBuilderAdd(&b, pNewKey, nNewKey,
+                                  pEdit->pVal, pEdit->nVal);
+        if( rc==SQLITE_OK ){
+          rc = writeBuilderNode(pMut->pStore, &b, &childHash);
+        }
+        prollyNodeBuilderFree(&b);
+        if( rc!=SQLITE_OK ){
+          prollyCursorClose(&cur);
+          return rc;
+        }
+      }
+    }
+  }
+
+  while( level>0 ){
+    ProllyNode *pNode;
+    ProllyNodeBuilder b;
+    ProllyHash parentHash;
+    int idx;
+    int i;
+
+    level--;
+    pNode = &cur.aLevel[level].pEntry->node;
+    idx = cur.aLevel[level].idx;
+    prollyNodeBuilderInit(&b, (u8)pNode->level, pMut->flags);
+    for(i=0; i<(int)pNode->nItems; i++){
+      u64 cnt = 0;
+      if( i==idx ){
+        rc = parentChildSubtreeCount(pMut->pStore, pMut->pCache,
+                                     pNode, i, &cnt);
+        if( rc==SQLITE_OK ){
+          rc = prollyNodeBuilderAddWithCount(
+              &b, pNewKey, nNewKey, childHash.data, PROLLY_HASH_SIZE,
+              cnt + 1);
+        }
+      }else{
+        rc = parentChildSubtreeCount(pMut->pStore, pMut->pCache,
+                                     pNode, i, &cnt);
+        if( rc==SQLITE_OK ){
+          rc = appendNodeEntryToBuilder(&b, pNode, i, cnt);
+        }
+      }
+      if( rc!=SQLITE_OK ){
+        prollyNodeBuilderFree(&b);
+        prollyCursorClose(&cur);
+        return rc;
+      }
+    }
+    rc = writeBuilderNode(pMut->pStore, &b, &parentHash);
+    prollyNodeBuilderFree(&b);
+    if( rc!=SQLITE_OK ){
+      prollyCursorClose(&cur);
+      return rc;
+    }
+    childHash = parentHash;
+  }
+
+  pMut->newRoot = childHash;
+  prollyCursorClose(&cur);
+  return SQLITE_OK;
+}
+
 int prollyMutateFlush(ProllyMutator *pMut){
   int rc;
 
@@ -368,7 +701,10 @@ int prollyMutateFlush(ProllyMutator *pMut){
   if( prollyHashIsEmpty(&pMut->oldRoot) ){
     rc = buildFromEdits(pMut);
   }else{
-    rc = streamingMerge(pMut);
+    rc = tryAppendSingleIntNoSplit(pMut);
+    if( rc==SQLITE_NOTFOUND ){
+      rc = streamingMerge(pMut);
+    }
   }
 
 #ifdef DOLTLITE_PROLLY_CHECK

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -304,6 +304,73 @@ backup_safety_done:
   removeDbFiles(zSame);
 }
 
+static void run_integer_pk_autocommit_append_correctness(void){
+  sqlite3 *db = 0;
+  sqlite3_stmt *stmt = 0;
+  char dbpath[256];
+  int rc;
+  int i;
+  const int nRow = 1500;
+
+  make_dbpath(dbpath, sizeof(dbpath), "test_integer_pk_autocommit_append");
+  removeDbFiles(dbpath);
+
+  check("integer_pk_append_open", open_db(dbpath, &db)==SQLITE_OK);
+  if( db==0 ) goto integer_pk_append_done;
+
+  check("integer_pk_append_create",
+        execSql(db, "CREATE TABLE t(id INTEGER PRIMARY KEY, k INTEGER, v TEXT);")
+        ==SQLITE_OK);
+  rc = sqlite3_prepare_v2(db,
+      "INSERT INTO t VALUES(?1, ?2, ?3)", -1, &stmt, 0);
+  check("integer_pk_append_prepare", rc==SQLITE_OK);
+  for(i=1; rc==SQLITE_OK && i<=nRow; i++){
+    char zVal[32];
+    sqlite3_snprintf(sizeof(zVal), zVal, "v-%04d", i);
+    sqlite3_bind_int(stmt, 1, i);
+    sqlite3_bind_int(stmt, 2, i*2);
+    sqlite3_bind_text(stmt, 3, zVal, -1, SQLITE_TRANSIENT);
+    rc = sqlite3_step(stmt);
+    if( rc!=SQLITE_DONE ){
+      fprintf(stderr, "  insert failed at row %d: %s (rc=%d)\n",
+              i, sqlite3_errmsg(db), rc);
+      break;
+    }
+    rc = sqlite3_reset(stmt);
+    sqlite3_clear_bindings(stmt);
+  }
+  sqlite3_finalize(stmt);
+  stmt = 0;
+  check("integer_pk_append_inserts", rc==SQLITE_OK);
+
+  check("integer_pk_append_count_min_max_sum",
+        strcmp(queryScalarText(db,
+          "SELECT count(*) || ',' || min(id) || ',' || max(id) || ',' || sum(k) "
+          "FROM t"), "1500,1,1500,2251500")==0);
+  check("integer_pk_append_point_read",
+        strcmp(queryScalarText(db, "SELECT v FROM t WHERE id=1499"), "v-1499")==0);
+  check("integer_pk_append_integrity",
+        strcmp(queryScalarText(db, "PRAGMA integrity_check"), "ok")==0);
+
+  sqlite3_close(db);
+  db = 0;
+
+  check("integer_pk_append_reopen", open_db(dbpath, &db)==SQLITE_OK);
+  if( db ){
+    check("integer_pk_append_reopen_count",
+          strcmp(queryScalarText(db, "SELECT count(*) FROM t"), "1500")==0);
+    check("integer_pk_append_reopen_point_read",
+          strcmp(queryScalarText(db, "SELECT v FROM t WHERE id=1500"), "v-1500")==0);
+    check("integer_pk_append_reopen_integrity",
+          strcmp(queryScalarText(db, "PRAGMA integrity_check"), "ok")==0);
+  }
+
+integer_pk_append_done:
+  if( stmt ) sqlite3_finalize(stmt);
+  if( db ) sqlite3_close(db);
+  removeDbFiles(dbpath);
+}
+
 static int stmt_column_text_equals(sqlite3_stmt *stmt, int iCol, const char *zExpect){
   const unsigned char *z = sqlite3_column_text(stmt, iCol);
   if( !zExpect ) return z==0;
@@ -7269,6 +7336,7 @@ static void run_prolly_diff_leaf_surfaces_record_corruption(void){
 
 static const RegressionCase aCases[] = {
   { "backup_safety", "Backup Safety Test", run_backup_safety },
+  { "integer_pk_autocommit_append_correctness", "Integer PK Autocommit Append Correctness Test", run_integer_pk_autocommit_append_correctness },
   { "create_collation_unsupported", "Create Collation Unsupported Test", run_create_collation_unsupported },
   { "rowid_in_integer_literals_uses_rowset", "Rowid IN Integer Literals RowSet Test", run_rowid_in_integer_literals_uses_rowset },
   { "concurrent_refs", "Concurrent Refs Test", run_concurrent_refs },


### PR DESCRIPTION
## Summary
- add a fast path for single-row increasing INTEGER PRIMARY KEY appends that rewrites only the rightmost prolly path when chunk boundaries allow it
- handle the common closed-rightmost-leaf case by appending a new one-row leaf into the open parent path
- fast-path the common single-main-branch refs serialization shape
- add a file-backed autocommit append regression test that verifies same-session reads, reopen reads, and integrity_check

## Local results
- `make -j8 doltlite libdoltlite.a`
- `sh test/run_doltlite_regression_case.sh integer_pk_autocommit_append_correctness`
- `sh test/run_doltlite_regression_case.sh prolly_mutate_skip_subtree_order`
- `sh test/run_doltlite_regression_case.sh integrity_check_walks_nodes`
- 2000 separate CLI autocommit inserts + `PRAGMA integrity_check`

## Benchmark signal
With a timer rebuilt against this branch:
- long Doltlite-only bulk append median: ~486ms for the 5000-row autocommit SQL file
- 5-run autocommit section: `oltp_bulk_insert_ac` was 16,795us Doltlite vs 11,519us SQLite, 1.46x
