### PR TITLE
Cache newly chunked prolly nodes

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -1012,6 +1012,7 @@ static int csCommitToFile(ChunkStore *cs){
   int lockHeld = (cs->graphLockFd >= 0);
   i64 newWalSize = cs->wal.nWalData;
   ChunkIndexEntry *aCommittedPending = 0;
+  ChunkIndexEntry aSmallCommittedPending[32];
   ChunkIndexEntry *aMergePending = 0;
   ChunkIndexEntry *aMerged = 0;
   int nMerged = 0;
@@ -1074,12 +1075,17 @@ static int csCommitToFile(ChunkStore *cs){
     }
     newWalSize = cs->wal.nWalData + appendBytes;
 
-    aCommittedPending = (ChunkIndexEntry*)sqlite3_malloc(
-      cs->staging.nPending * (int)sizeof(ChunkIndexEntry)
-    );
-    if( !aCommittedPending ){
-      rc = SQLITE_NOMEM;
-      goto commit_done;
+    if( cs->staging.nPending <= (int)(sizeof(aSmallCommittedPending)
+                                    / sizeof(aSmallCommittedPending[0])) ){
+      aCommittedPending = aSmallCommittedPending;
+    }else{
+      aCommittedPending = (ChunkIndexEntry*)sqlite3_malloc(
+        cs->staging.nPending * (int)sizeof(ChunkIndexEntry)
+      );
+      if( !aCommittedPending ){
+        rc = SQLITE_NOMEM;
+        goto commit_done;
+      }
     }
 
     for( i = 0; i < cs->staging.nPending; i++ ){
@@ -1248,7 +1254,9 @@ commit_done:
       (void)csRollbackFailedAppend(cs, origFileSize);
     }
     (void)csRestoreCommittedRefsState(cs);
-    sqlite3_free(aCommittedPending);
+    if( aCommittedPending!=aSmallCommittedPending ){
+      sqlite3_free(aCommittedPending);
+    }
     sqlite3_free(aMergePending);
     sqlite3_free(aMerged);
     return rc;
@@ -1273,7 +1281,9 @@ commit_done:
   }else{
     sqlite3_free(aMerged);
   }
-  sqlite3_free(aCommittedPending);
+  if( aCommittedPending!=aSmallCommittedPending ){
+    sqlite3_free(aCommittedPending);
+  }
   sqlite3_free(aMergePending);
 
   sqlite3_free(cs->staging.pWriteBuf);

--- a/src/prolly_chunker.c
+++ b/src/prolly_chunker.c
@@ -68,6 +68,11 @@ static int flushLevel(ProllyChunker *ch, int level){
   if( rc!=SQLITE_OK ) return rc;
 
   rc = chunkStorePut(ch->pStore, pData, nData, &hash);
+  if( rc==SQLITE_OK && ch->pCache ){
+    ProllyCacheEntry *pEntry;
+    pEntry = prollyCachePut(ch->pCache, &hash, pData, nData, &rc);
+    if( pEntry ) prollyCacheRelease(ch->pCache, pEntry);
+  }
   sqlite3_free(pData);
   if( rc!=SQLITE_OK ) return rc;
 
@@ -102,6 +107,11 @@ static int finishFlushLevel(ProllyChunker *ch, int level,
   if( rc!=SQLITE_OK ) return rc;
 
   rc = chunkStorePut(ch->pStore, pData, nData, pHash);
+  if( rc==SQLITE_OK && ch->pCache ){
+    ProllyCacheEntry *pEntry;
+    pEntry = prollyCachePut(ch->pCache, pHash, pData, nData, &rc);
+    if( pEntry ) prollyCacheRelease(ch->pCache, pEntry);
+  }
   sqlite3_free(pData);
   if( rc!=SQLITE_OK ) return rc;
 
@@ -198,8 +208,14 @@ static int addToLevel(ProllyChunker *ch, int level,
 }
 
 int prollyChunkerInit(ProllyChunker *ch, ChunkStore *pStore, u8 flags){
+  return prollyChunkerInitWithCache(ch, pStore, 0, flags);
+}
+
+int prollyChunkerInitWithCache(ProllyChunker *ch, ChunkStore *pStore,
+                               ProllyCache *pCache, u8 flags){
   memset(ch, 0, sizeof(ProllyChunker));
   ch->pStore = pStore;
+  ch->pCache = pCache;
   ch->flags = flags;
   ch->nLevels = 0;
   memset(&ch->root, 0, sizeof(ProllyHash));

--- a/src/prolly_chunker.h
+++ b/src/prolly_chunker.h
@@ -6,6 +6,7 @@
 #include "prolly_hash.h"
 #include "prolly_node.h"
 #include "prolly_cursor.h"
+#include "prolly_cache.h"
 #include "chunk_store.h"
 
 /* Min/max bounds for content-defined chunks. The chunker may split after the
@@ -25,6 +26,7 @@ struct ProllyChunkerLevel {
 
 struct ProllyChunker {
   ChunkStore *pStore;
+  ProllyCache *pCache;
   u8 flags;
   int nLevels;
   ProllyChunkerLevel aLevel[PROLLY_CURSOR_MAX_DEPTH];
@@ -32,6 +34,8 @@ struct ProllyChunker {
 };
 
 int prollyChunkerInit(ProllyChunker *ch, ChunkStore *pStore, u8 flags);
+int prollyChunkerInitWithCache(ProllyChunker *ch, ChunkStore *pStore,
+                               ProllyCache *pCache, u8 flags);
 
 int prollyChunkerAdd(ProllyChunker *ch,
                      const u8 *pKey, int nKey,

--- a/src/prolly_mutate.c
+++ b/src/prolly_mutate.c
@@ -92,7 +92,8 @@ static int buildFromEdits(
   ProllyMutMapIter iter;
   int rc;
 
-  rc = prollyChunkerInit(&chunker, pMut->pStore, pMut->flags);
+  rc = prollyChunkerInitWithCache(&chunker, pMut->pStore, pMut->pCache,
+                                  pMut->flags);
   if( rc!=SQLITE_OK ) return rc;
 
   prollyMutMapIterFirst(&iter, pMut->pEdits);
@@ -322,27 +323,36 @@ static int streamingMerge(
   u8 *pRootData = 0;
   int nRootData = 0;
   ProllyNode rootNode;
+  ProllyNode *pRootNode = &rootNode;
+  ProllyCacheEntry *pRootEntry = 0;
   ProllyCache *pCache = pMut->pCache;
 
-  rc = chunkStoreGet(pMut->pStore, &pMut->oldRoot, &pRootData, &nRootData);
-  if( rc!=SQLITE_OK ) return rc;
-  rc = prollyNodeParse(&rootNode, pRootData, nRootData);
-  if( rc!=SQLITE_OK ){
-    sqlite3_free(pRootData);
-    return rc;
+  pRootEntry = pCache ? prollyCacheGet(pCache, &pMut->oldRoot) : 0;
+  if( pRootEntry ){
+    pRootNode = &pRootEntry->node;
+  }else{
+    rc = chunkStoreGet(pMut->pStore, &pMut->oldRoot, &pRootData, &nRootData);
+    if( rc!=SQLITE_OK ) return rc;
+    rc = prollyNodeParse(&rootNode, pRootData, nRootData);
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(pRootData);
+      return rc;
+    }
   }
 
   prollyMutMapIterFirst(&iter, pMut->pEdits);
-  rc = prollyChunkerInit(&chunker, pMut->pStore, pMut->flags);
+  rc = prollyChunkerInitWithCache(&chunker, pMut->pStore, pMut->pCache,
+                                  pMut->flags);
   if( rc!=SQLITE_OK ){
+    if( pRootEntry ) prollyCacheRelease(pCache, pRootEntry);
     sqlite3_free(pRootData);
     return rc;
   }
 
-  if( rootNode.level == 0 ){
-    rc = mergeLeaf(pMut, &rootNode, &chunker, &iter, 1);
+  if( pRootNode->level == 0 ){
+    rc = mergeLeaf(pMut, pRootNode, &chunker, &iter, 1);
   }else{
-    rc = streamingMergeNode(pMut, &rootNode, &chunker, &iter, 1);
+    rc = streamingMergeNode(pMut, pRootNode, &chunker, &iter, 1);
   }
   if( rc!=SQLITE_OK ) goto streaming_cleanup;
 
@@ -352,6 +362,7 @@ static int streamingMerge(
   }
 
 streaming_cleanup:
+  if( pRootEntry ) prollyCacheRelease(pCache, pRootEntry);
   prollyChunkerFree(&chunker);
   sqlite3_free(pRootData);
   return rc;


### PR DESCRIPTION
## Summary
- cache prolly nodes as they are emitted by the chunker
- pass the btree prolly cache through mutation flushes
- reuse cached roots during streaming merges to avoid hot chunk lookup/reparse work on repeated writes

## Benchmark
Isolated file-backed int-key `oltp_insert_ac` workload, 200 autocommit inserts:
- baseline median: `34,147us`
- patched median: `29,069us`
- median improvement: `14.9%`

Longer 5000-insert samples:
- baseline: `806ms`, `913ms`, `737ms`
- patched: `612ms`, `716ms`, `688ms`

## Tests
- `make -j8 doltlite libdoltlite.a`
- `./doltlite_regression_test_c all`
- manual indexed autocommit insert smoke tests with `PRAGMA integrity_check`