### PR TITLE
Reduce small chunk lookup overhead

### DIFF
--- a/src/chunk_staging.c
+++ b/src/chunk_staging.c
@@ -9,6 +9,8 @@
 #define CS_INIT_WRITEBUF_SIZE 4096
 #define CS_PEND_HT_INIT_BITS 12
 #define CS_PEND_HT_MAX_LOAD  4
+#define CS_PEND_HT_MIN_COUNT 16
+#define CS_RECENT_HT_MIN_COUNT 64
 
 void chunkStagingInit(ChunkStaging *st){
   memset(st, 0, sizeof(*st));
@@ -134,6 +136,15 @@ int csSearchPending(ChunkStore *cs, const ProllyHash *pHash, int *pIdx){
   int i; u32 b; int rc;
   *pIdx = -1;
   if( cs->staging.nPending==0 ) return SQLITE_OK;
+  if( cs->staging.nPending < CS_PEND_HT_MIN_COUNT ){
+    for(i=0; i<cs->staging.nPending; i++){
+      if( prollyHashCompare(&cs->staging.aPending[i].hash, pHash)==0 ){
+        *pIdx = i;
+        return SQLITE_OK;
+      }
+    }
+    return SQLITE_OK;
+  }
   rc = csPendHTEnsure(cs);
   if( rc!=SQLITE_OK ){
 
@@ -197,6 +208,15 @@ int csSearchRecent(ChunkStore *cs, const ProllyHash *pHash, int *pIdx){
   int i; u32 b; int rc;
   *pIdx = -1;
   if( cs->staging.nRecent==0 ) return SQLITE_OK;
+  if( cs->staging.nRecent < CS_RECENT_HT_MIN_COUNT ){
+    for(i=cs->staging.nRecent-1; i>=0; i--){
+      if( prollyHashCompare(&cs->staging.aRecent[i].hash, pHash)==0 ){
+        *pIdx = i;
+        return SQLITE_OK;
+      }
+    }
+    return SQLITE_OK;
+  }
   rc = csRecentHTEnsure(cs);
   if( rc!=SQLITE_OK ){
     for(i=cs->staging.nRecent-1; i>=0; i--){

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -977,14 +977,12 @@ int chunkStorePut(
   if( pHash ) memcpy(pHash, &h, sizeof(ProllyHash));
 
   {
-    u8 *pExisting = 0;
-    int nExisting = 0;
-    int getRc = chunkStoreGet(cs, &h, &pExisting, &nExisting);
-    if( getRc == SQLITE_OK ){
-      sqlite3_free(pExisting);
+    int bHas = 0;
+    int hasRc = chunkStoreHas(cs, &h, &bHas);
+    if( hasRc==SQLITE_OK && bHas ){
       return SQLITE_OK;
     }
-    sqlite3_free(pExisting);
+    if( hasRc!=SQLITE_OK ) return hasRc;
   }
 
   rc = csGrowPending(cs);


### PR DESCRIPTION
## Summary
- avoid building pending chunk hash tables for tiny staged sets
- use linear scans for very small recent chunk sets before allocating the recent hash table
- use chunkStoreHas() in chunkStorePut() so duplicate-content checks do not materialize payloads

## Validation
- make -j8 doltlite libdoltlite.a
- ./doltlite_regression_test_c all
- BENCH_RUNS=5 BENCH_SECTION_MODE=autocommit ... test/sysbench_compare.sh

## Local benchmark note
The autocommit write average improved from the earlier local 3-run baseline around 1.85x to 1.79x in the 5-run patched sweep. This machine is fsync-bound, so the useful part of this change is reducing per-commit malloc/hash-table work in the small chunk sets these write benchmarks produce.