### PR TITLE
Avoid redundant locked commit file size check

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -1059,10 +1059,14 @@ static int csCommitToFile(ChunkStore *cs){
     }
   }
 
-  rc = cs->file.pFile->pMethods->xFileSize(cs->file.pFile, &fileSize);
-  if( rc != SQLITE_OK ) goto commit_done;
+  if( lockHeld && hadFile ){
+    fileSize = cs->file.iFileSize;
+  }else{
+    rc = cs->file.pFile->pMethods->xFileSize(cs->file.pFile, &fileSize);
+    if( rc != SQLITE_OK ) goto commit_done;
+  }
 
-  if( hadFile ){
+  if( hadFile && !lockHeld ){
     int bMoved = 0;
     int rc2 = sqlite3OsFileControl(cs->file.pFile, SQLITE_FCNTL_HAS_MOVED,
                                    &bMoved);

--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -497,6 +497,7 @@ static int gcRewriteFile(
 
         if( rc==SQLITE_OK ){
           chunkFileSetHandle(&cs->file, pNewFile);
+          chunkFileSetSize(&cs->file, CHUNK_MANIFEST_SIZE + nNewData + indexSize);
           walStateSetDataSize(&cs->wal, 0);
           if( pOldFile ){
             sqlite3OsCloseFree(pOldFile);


### PR DESCRIPTION
## Summary
- skip the duplicate file-size syscall in `csCommitToFile()` when the chunk store graph lock is already held
- keep the existing file-size/moved-file refresh path before acquiring the write lock
- update the cached chunk-file size after GC rewrites the file, so post-GC locked commits append at the correct offset

## Validation
- `make -j8 doltlite libdoltlite.a`
- `./doltlite_regression_test_c all`
- GC rewrite smoke: delete row, `SELECT dolt_gc()`, insert another row, reopen, `PRAGMA integrity_check`
- `BENCH_RUNS=5 BENCH_SECTION_MODE=autocommit ... test/sysbench_compare.sh`

## Benchmark note
Local autocommit timings are noisy and fsync-bound on this machine. This change removes one redundant file-size probe from each locked write commit while preserving the pre-commit external-change detection and fixing the GC cache case that made the earlier shortcut unsafe.