### PR TITLE
fix(vdbe): guard applyNumericAffinity in OP_CountRange against MEM_Int

### DIFF
--- a/src/vdbe.c
+++ b/src/vdbe.c
@@ -3889,8 +3889,16 @@ case OP_CountRange: {    /* out2 */
   assert( pCrsr );
   pLower = &aMem[pOp->p3];
   pUpper = &aMem[pOp->p3+1];
-  applyNumericAffinity(pLower, 0);
-  applyNumericAffinity(pUpper, 0);
+  /* applyNumericAffinity() requires the input to be MEM_Str (it asserts
+  ** so in debug builds and clobbers the union in release builds). Only
+  ** invoke it when the register is text-only, matching SQLite's own
+  ** guard used everywhere else. */
+  if( (pLower->flags & (MEM_Int|MEM_IntReal|MEM_Real|MEM_Str))==MEM_Str ){
+    applyNumericAffinity(pLower, 0);
+  }
+  if( (pUpper->flags & (MEM_Int|MEM_IntReal|MEM_Real|MEM_Str))==MEM_Str ){
+    applyNumericAffinity(pUpper, 0);
+  }
   if( (pLower->flags & MEM_Int)==0 || (pUpper->flags & MEM_Int)==0 ){
     sqlite3VdbeMemSetInt64(&aMem[pOp->p2], 0);
     goto check_for_interrupt;


### PR DESCRIPTION
## Summary

\`OP_CountRange\` (added in 369eae2530 \"Optimize rowid range counts\") unconditionally called \`applyNumericAffinity()\` on its lower- and upper-bound registers. That function's contract — asserted in debug builds and exploited by release-build optimizations — is that the input is \`MEM_Str\`. Calling it on an already-\`MEM_Int\` register is undefined behavior; on macOS post-fork+merge+GC the register state landed such that the unchecked call corrupted \`pLower->u.i\` from the literal lower bound to \`0\`, turning every \`SELECT count(*) FROM t WHERE id BETWEEN A AND B\` into \`count(id <= B)\` — which is only correct when \`A == 1\`.

## How it surfaced

\`test/multi_process_gc_test.c::test_gc_vs_merge\` ran fine on Linux CI but failed 10/10 on macOS with the perf commits applied:

| Query | Returned | Should be |
|---|---|---|
| \`count(*) WHERE id BETWEEN 1 AND 50\` | 50 ✓ | 50 |
| \`count(*) WHERE id BETWEEN 51 AND 70\` | **70** | 20 |
| \`count(*) WHERE id BETWEEN 71 AND 90\` | **90** | 20 |

Diagnostic trace inside \`OP_CountRange\`:

\`\`\`
BEFORE p1=1 p2=1 p3=2 lo.flags=0x4 lo.u.i=51 up.flags=0x4 up.u.i=70
AFTER                  lo.flags=0x4 lo.u.i=0  up.flags=0x4 up.u.i=70
\`\`\`

\`applyNumericAffinity()\` was the only call between BEFORE/AFTER. Compare to \`OP_Lt\` at \`vdbe.c:2407\` which correctly gates with:

\`\`\`c
if( (flags1 & (MEM_Int|MEM_IntReal|MEM_Real|MEM_Str))==MEM_Str ){
  applyNumericAffinity(pIn1,0);
}
\`\`\`

This PR applies the same gate to \`OP_CountRange\`.

## Test plan

- [x] \`make multi_process_gc_test\` passes 10/10 on macOS (was 0/10)
- [x] \`make c-tests\` — all 12 gating tests pass
- [x] One-line fix, no behavioral change for the well-typed text→int path

🤖 Generated with [Claude Code](https://claude.com/claude-code)