### PR TITLE
Fast-path catalog serialization for DML commits

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -314,6 +314,9 @@ struct Btree {
   ProllyHash committedMergeCommitHash;
   ProllyHash committedConflictsCatalogHash;
   ProllyHash committedConstraintViolationsHash;
+  ProllyHash catalogCacheHash;
+  u8 *pCatalogCache;
+  int nCatalogCache;
 
   char *zBranch;
   char *zAuthorName;
@@ -408,6 +411,24 @@ static inline void removeTable(Btree *p, Pgno iTable){
 }
 static inline void btreeFreeCatalogTables(Btree *p){
   catFree(&p->cat);
+}
+static void btreeClearCatalogCache(Btree *p){
+  sqlite3_free(p->pCatalogCache);
+  p->pCatalogCache = 0;
+  p->nCatalogCache = 0;
+  memset(&p->catalogCacheHash, 0, sizeof(p->catalogCacheHash));
+}
+static void btreeTakeCatalogCache(Btree *p, u8 **ppData, int nData,
+                                  const ProllyHash *pHash){
+  sqlite3_free(p->pCatalogCache);
+  p->pCatalogCache = *ppData;
+  *ppData = 0;
+  p->nCatalogCache = nData;
+  if( pHash ){
+    p->catalogCacheHash = *pHash;
+  }else{
+    memset(&p->catalogCacheHash, 0, sizeof(p->catalogCacheHash));
+  }
 }
 static void invalidateCursors(BtShared *pBt, Pgno iTable, int errCode);
 static void invalidateSchema(Btree *pBtree);
@@ -2048,7 +2069,111 @@ int doltliteSerializeCatalogEntriesWithFallbackSchema(
       aFallbackSchema, nFallbackSchema, ppOut, pnOut);
 }
 
+static int serializeCatalogPatchRoots(Btree *pBtree, u8 **ppOut, int *pnOut){
+  u8 *buf = 0;
+  const u8 *pEntries;
+  u8 *q;
+  int nData = 0;
+  int nTables = 0;
+  int iFormat = 0;
+  int i, nPatched = 0;
+  int rc;
+
+  if( pBtree->bSchemaChangedTxn
+   || prollyHashIsEmpty(&pBtree->committedCatalogHash) ){
+    return SQLITE_NOTFOUND;
+  }
+
+  if( pBtree->pCatalogCache
+   && pBtree->nCatalogCache>0
+   && prollyHashCompare(&pBtree->catalogCacheHash,
+                        &pBtree->committedCatalogHash)==0 ){
+    buf = sqlite3_malloc(pBtree->nCatalogCache);
+    if( !buf ) return SQLITE_NOMEM;
+    memcpy(buf, pBtree->pCatalogCache, pBtree->nCatalogCache);
+    nData = pBtree->nCatalogCache;
+  }else{
+    rc = chunkStoreGet(&pBtree->pBt->store, &pBtree->committedCatalogHash,
+                       &buf, &nData);
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(buf);
+      return rc;
+    }
+  }
+  if( !buf || !catalogParseHeaderEx(buf, nData, &iFormat, &nTables, &pEntries)
+   || nTables!=pBtree->cat.n ){
+    sqlite3_free(buf);
+    return SQLITE_NOTFOUND;
+  }
+
+  q = buf + (pEntries - (const u8*)buf);
+  for(i=0; i<nTables; i++){
+    Pgno iTable;
+    struct TableEntry *pTE;
+    int nSkip;
+
+    if( q + CAT_ENTRY_ITABLE_SIZE + CAT_ENTRY_FLAGS_SIZE
+        + PROLLY_HASH_SIZE + PROLLY_HASH_SIZE > buf + nData ){
+      sqlite3_free(buf);
+      return SQLITE_NOTFOUND;
+    }
+
+    iTable = (Pgno)(q[0] | (q[1]<<8) | (q[2]<<16) | (q[3]<<24));
+    pTE = findTable(pBtree, iTable);
+    if( !pTE ){
+      sqlite3_free(buf);
+      return SQLITE_NOTFOUND;
+    }
+
+    q += CAT_ENTRY_ITABLE_SIZE + CAT_ENTRY_FLAGS_SIZE;
+    /* The persisted sqlite_master root is canonicalized. DML does not change
+    ** it, and the in-memory root may be a runtime view after DDL. */
+    if( iTable!=1 ){
+      memcpy(q, pTE->root.data, PROLLY_HASH_SIZE);
+    }
+    q += PROLLY_HASH_SIZE + PROLLY_HASH_SIZE;
+    nPatched++;
+
+    if( iFormat==CATALOG_FORMAT_V4 ){
+      int nType, nName, nTbl;
+      if( q + 6 > buf + nData ){
+        sqlite3_free(buf);
+        return SQLITE_NOTFOUND;
+      }
+      nType = q[0] | (q[1]<<8);
+      nName = q[2] | (q[3]<<8);
+      nTbl = q[4] | (q[5]<<8);
+      q += 6;
+      nSkip = nType + nName + nTbl;
+    }else{
+      if( q + 2 > buf + nData ){
+        sqlite3_free(buf);
+        return SQLITE_NOTFOUND;
+      }
+      nSkip = q[0] | (q[1]<<8);
+      q += 2;
+    }
+    if( nSkip<0 || q + nSkip > buf + nData ){
+      sqlite3_free(buf);
+      return SQLITE_NOTFOUND;
+    }
+    q += nSkip;
+  }
+
+  if( q!=buf+nData || nPatched!=pBtree->cat.n ){
+    sqlite3_free(buf);
+    return SQLITE_NOTFOUND;
+  }
+
+  *ppOut = buf;
+  *pnOut = nData;
+  return SQLITE_OK;
+}
+
 static int serializeCatalog(Btree *pBtree, u8 **ppOut, int *pnOut){
+  int rc = serializeCatalogPatchRoots(pBtree, ppOut, pnOut);
+  if( rc==SQLITE_OK ) return SQLITE_OK;
+  if( rc!=SQLITE_NOTFOUND ) return rc;
   return doltliteSerializeCatalogEntriesForBtreeImpl(
       pBtree, pBtree->cat.a, pBtree->cat.n, 0, 0, ppOut, pnOut);
 }
@@ -4085,6 +4210,7 @@ static int prollyBtreeClose(Btree *p){
     p->pSchema = 0;
   }
   btreeFreeCatalogTables(p);
+  btreeClearCatalogCache(p);
   if( p->aSavepointTables ){
     int i;
     for(i=0; i<p->nSavepoint; i++){
@@ -4997,6 +5123,7 @@ static int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
       p->nSavepoint = 0;
       p->bSchemaChangedTxn = 0;
 
+      btreeTakeCatalogCache(p, &catData, nCatData, &catHash);
       sqlite3_free(catData);
       chunkStoreUnlock(&pBt->store);
       pBt->store.snapshotPinned = 0;

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -2171,11 +2171,15 @@ static int serializeCatalogPatchRoots(Btree *pBtree, u8 **ppOut, int *pnOut){
 }
 
 static int serializeCatalog(Btree *pBtree, u8 **ppOut, int *pnOut){
+  return doltliteSerializeCatalogEntriesForBtreeImpl(
+      pBtree, pBtree->cat.a, pBtree->cat.n, 0, 0, ppOut, pnOut);
+}
+
+static int serializeCatalogForCommit(Btree *pBtree, u8 **ppOut, int *pnOut){
   int rc = serializeCatalogPatchRoots(pBtree, ppOut, pnOut);
   if( rc==SQLITE_OK ) return SQLITE_OK;
   if( rc!=SQLITE_NOTFOUND ) return rc;
-  return doltliteSerializeCatalogEntriesForBtreeImpl(
-      pBtree, pBtree->cat.a, pBtree->cat.n, 0, 0, ppOut, pnOut);
+  return serializeCatalog(pBtree, ppOut, pnOut);
 }
 
 static int buildRuntimeMasterRoot(Btree *pBtree, ProllyHash *pMasterRoot){
@@ -5037,7 +5041,7 @@ static int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
     }
 
     {
-      rc = serializeCatalog(p, &catData, &nCatData);
+      rc = serializeCatalogForCommit(p, &catData, &nCatData);
       if( rc==SQLITE_OK ){
         rc = chunkStorePut(&pBt->store, catData, nCatData, &catHash);
       }

--- a/test/sql_oracle_test.sh
+++ b/test/sql_oracle_test.sh
@@ -23,12 +23,17 @@ normalize_oracle_output() {
 
 oracle() {
   local name="$1" sql="$2"
+  oracle_with_flags "$name" "$sql" ""
+}
+
+oracle_with_flags() {
+  local name="$1" sql="$2" flags="$3"
   local dl="$TMPDIR/dl_${name}.db" sq="$TMPDIR/sq_${name}.db"
   local out_dl out_sq norm_dl norm_sq rc_dl rc_sq
   rm -f "$dl" "$sq"
-  out_dl=$(echo "$sql" | "$DOLTLITE" "$dl" 2>&1)
+  out_dl=$(echo "$sql" | "$DOLTLITE" $flags "$dl" 2>&1)
   rc_dl=$?
-  out_sq=$(echo "$sql" | "$SQLITE3" "$sq" 2>&1)
+  out_sq=$(echo "$sql" | "$SQLITE3" $flags "$sq" 2>&1)
   rc_sq=$?
   norm_dl=$(printf '%s\n' "$out_dl" | normalize_oracle_output)
   norm_sq=$(printf '%s\n' "$out_sq" | normalize_oracle_output)
@@ -42,6 +47,10 @@ oracle() {
     echo "    sqlite3 rc:  $rc_sq"
     echo "    sqlite3:  $(echo "$out_sq" | head -3)"
   fi
+}
+
+oracle_unsafe() {
+  oracle_with_flags "$1" "$2" "--unsafe-testing"
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -6837,7 +6846,7 @@ DROP TABLE sqlite_master;
 # different (working) path. Verify behavior matches stock SQLite.
 # This is a sanity check, not a tripwire — but it confirms the
 # only currently-reachable iTable=1 mutation path is correct.
-oracle "cat121_writable_schema_delete_master" "
+oracle_unsafe "cat121_writable_schema_delete_master" "
 CREATE TABLE keep(x INT);
 INSERT INTO keep VALUES(1);
 PRAGMA writable_schema = 1;
@@ -6864,7 +6873,7 @@ SELECT name FROM aux.sqlite_master WHERE type='table';
 # 121e. PRAGMA integrity_check after writable_schema operations.
 # If iTable==1 ever leaks pending state, integrity_check is one of
 # the first signals.
-oracle "cat121_integrity_after_writable_schema" "
+oracle_unsafe "cat121_integrity_after_writable_schema" "
 CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES (1,'a'),(2,'b');
 PRAGMA writable_schema = 1;


### PR DESCRIPTION
## Summary
- reuse the previous serialized catalog for no-schema-change commits
- patch only user table/index root hashes instead of rebuilding sqlite_master metadata
- cache the last persisted catalog bytes per connection for repeated autocommit writes

## Validation
- make -j8 doltlite doltlite_regression_test_c && ./doltlite_regression_test_c all
- make -j8 sql_transaction_test corruption_test && ./sql_transaction_test && ./corruption_test
- manual DDL/indexed DML/reopen/integrity_check smoke
- BENCH_SECTION_MODE=autocommit BENCH_RUNS=3 SQLITE3=/usr/bin/sqlite3 bash test/sysbench_compare.sh (still fails local autocommit ceiling, but oltp_insert_ac improved in local runs)