### PR TITLE
Optimize literal contains LIKE scans

### DIFF
--- a/src/func.c
+++ b/src/func.c
@@ -704,6 +704,83 @@ static const struct compareInfo likeInfoAlt = { '%', '_',   0, 0 };
 #define SQLITE_NOMATCH           1
 #define SQLITE_NOWILDCARDMATCH   2
 
+#ifdef DOLTLITE_PROLLY
+/*
+** Fast path for LIKE patterns of the form '%literal%'.  This is a common
+** table-scan predicate and is equivalent to searching for the literal byte
+** sequence when there are no inner wildcards or ESCAPE characters.  The
+** built-in LIKE implementation only folds ASCII case, so this path does the
+** same and leaves all other patterns to patternCompare().
+**
+** Return 0 or 1 if the fast path applies, or -1 if the caller should use the
+** generic matcher.
+*/
+static int likeContainsLiteralFast(
+  const u8 *zPat, int nPat,
+  const u8 *zStr, int nStr,
+  const struct compareInfo *pInfo,
+  u32 escape
+){
+  int i, j;
+  int nLit;
+  const u8 *zLit;
+  assert( zPat!=0 && zStr!=0 );
+  if( escape!=0
+   || pInfo->matchAll!='%'
+   || pInfo->matchOne!='_'
+   || pInfo->matchSet!=0
+   || nPat<2
+   || zPat[0]!='%'
+   || zPat[nPat-1]!='%'
+  ){
+    return -1;
+  }
+  zLit = zPat + 1;
+  nLit = nPat - 2;
+  for(i=0; i<nLit; i++){
+    if( zLit[i]==0 || zLit[i]=='%' || zLit[i]=='_' ){
+      return -1;
+    }
+  }
+  if( memchr(zStr, 0, nStr)!=0 ){
+    return -1;
+  }
+  if( nLit==0 ) return 1;
+  if( nLit>nStr ) return 0;
+
+  if( pInfo->noCase ){
+    char zStop[3];
+    if( zLit[0]>=0x80 ) return -1;
+    zStop[0] = sqlite3Toupper(zLit[0]);
+    zStop[1] = sqlite3Tolower(zLit[0]);
+    zStop[2] = 0;
+    i = 0;
+    while( i<=nStr-nLit ){
+      i += (int)strcspn((const char*)zStr+i, zStop);
+      if( i>nStr-nLit ) break;
+      for(j=0; j<nLit; j++){
+        u8 a = zStr[i+j];
+        u8 b = zLit[j];
+        if( a<0x80 ) a = sqlite3Tolower(a);
+        if( b<0x80 ) b = sqlite3Tolower(b);
+        if( a!=b ) break;
+      }
+      if( j==nLit ) return 1;
+      i++;
+    }
+  }else{
+    u8 first = zLit[0];
+    for(i=0; i<=nStr-nLit; i++){
+      const void *p = memchr(zStr+i, first, (size_t)(nStr-nLit-i+1));
+      if( p==0 ) break;
+      i = (int)((const u8*)p - zStr);
+      if( memcmp(zStr+i, zLit, (size_t)nLit)==0 ) return 1;
+    }
+  }
+  return 0;
+}
+#endif
+
 /*
 ** Compare two UTF-8 strings for equality where the first string is
 ** a GLOB or LIKE expression.  Return values:
@@ -981,6 +1058,16 @@ static void likeFunc(
   if( zA && zB ){
 #ifdef SQLITE_TEST
     sqlite3_like_count++;
+#endif
+#ifdef DOLTLITE_PROLLY
+    {
+      int bFast = likeContainsLiteralFast(zB, nPat, zA,
+          sqlite3_value_bytes(argv[1]), pInfo, escape);
+      if( bFast>=0 ){
+        sqlite3_result_int(context, bFast);
+        return;
+      }
+    }
 #endif
     sqlite3_result_int(context,
                       patternCompare(zB, zA, pInfo, escape)==SQLITE_MATCH);

--- a/test/sql_oracle_test.sh
+++ b/test/sql_oracle_test.sh
@@ -2780,6 +2780,24 @@ INSERT INTO t VALUES(1,'a%b'),(2,'a_b'),(3,'axb'),(4,'a%bc');
 SELECT path FROM t WHERE path LIKE 'a!%b%' ESCAPE '!' ORDER BY path;
 "
 
+# 27f. LIKE contains literal and fallback cases
+oracle "cat27_like_contains_literal" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES
+  (1,'abc'),(2,'xabcx'),(3,'ABC'),(4,'xabcy'),(5,'ab'),
+  (6,'a_c'),(7,'a%c'),(8,'za!bc'),(9,'éabc'),(10,'éABC'),
+  (11,''),(12,char(97,0,98,99));
+SELECT id FROM t WHERE v LIKE '%abc%' ORDER BY id;
+SELECT count(*) FROM t WHERE v LIKE '%ABC%';
+PRAGMA case_sensitive_like=ON;
+SELECT id FROM t WHERE v LIKE '%ABC%' ORDER BY id;
+SELECT id FROM t WHERE v LIKE '%a_c%' ORDER BY id;
+SELECT id FROM t WHERE v LIKE '%a!_c%' ESCAPE '!' ORDER BY id;
+SELECT id FROM t WHERE v LIKE '%a!%c%' ESCAPE '!' ORDER BY id;
+SELECT count(*) FROM t WHERE v LIKE '%%';
+SELECT count(*) FROM t WHERE v LIKE '%' || char(0) || '%';
+"
+
 # ════════════════════════════════════════════════════════════════════
 # Category 28: ALTER TABLE with indexes
 # ════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- add a Doltlite build fast path for LIKE patterns of the form `%literal%`
- keep escaped patterns, inner wildcards, embedded NUL cases, and non-applicable forms on the existing generic matcher
- add oracle coverage for contains-literal LIKE and fallback cases

## Benchmark
Focused `table_scan` benchmark, 10k rows, median of 11:
- before: SQLite 121,631 us, Doltlite 142,258 us, 1.17x
- after: SQLite 123,118 us, Doltlite 137,278 us, 1.11x

Wrapped sysbench, median of 9:
- in-memory `table_scan`: SQLite 120,889 us, Doltlite 134,865 us, 1.12x
- file-backed `table_scan`: SQLite 123,130 us, Doltlite 138,393 us, 1.12x

## Tests
- `bash test/sql_oracle_test.sh ./doltlite ./sqlite3` -> 556 passed, 0 failed
- `BENCH_RUNS=9 BENCH_SECTION_MODE=wrapped bash test/sysbench_compare.sh` -> all tests within ceilings