### PR TITLE
Skip absent seeks for empty append inserts

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -6390,6 +6390,7 @@ static int prollyBtCursorTableMoveto(
   int *pRes
 ){
   int rc;
+  int rootIsEmpty;
   (void)bias;
 
   assert( pCur->curIntKey );
@@ -6400,8 +6401,19 @@ static int prollyBtCursorTableMoveto(
   CLEAR_CACHED_PAYLOAD(pCur);
   CLEAR_CACHED_SEEK_KEY(pCur);
 
+  rootIsEmpty = prollyHashIsEmpty(&pCur->pCur.root);
   if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
     ProllyMutMapEntry *pEntry = 0;
+    if( rootIsEmpty
+     && pCur->pMutMap->isIntKey
+     && pCur->pMutMap->appendSorted
+     && intKey > prollyMutMapEntryIntKey(
+                  &pCur->pMutMap->aEntries[pCur->pMutMap->nEntries-1])
+    ){
+      *pRes = 1;
+      pCur->eState = CURSOR_INVALID;
+      return SQLITE_OK;
+    }
     rc = prollyMutMapFindRc(pCur->pMutMap, 0, 0, intKey, &pEntry);
     if( rc!=SQLITE_OK ) return rc;
     if( pEntry ){
@@ -6418,6 +6430,16 @@ static int prollyBtCursorTableMoveto(
       }
     }
 
+  }
+
+  if( rootIsEmpty ){
+    refreshCursorRoot(pCur);
+    rootIsEmpty = prollyHashIsEmpty(&pCur->pCur.root);
+  }
+  if( rootIsEmpty ){
+    *pRes = 1;
+    pCur->eState = CURSOR_INVALID;
+    return SQLITE_OK;
   }
 
   refreshCursorRoot(pCur);

--- a/test/sql_oracle_test.sh
+++ b/test/sql_oracle_test.sh
@@ -5550,6 +5550,21 @@ SELECT * FROM t ORDER BY id;
 SELECT count(*) FROM t;
 "
 
+# 88e. Sorted explicit rowid inserts with pending duplicates
+oracle "cat88_insert_sorted_explicit_rowid" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT);
+BEGIN;
+INSERT INTO t VALUES(1,'a');
+INSERT INTO t VALUES(2,'b');
+INSERT INTO t VALUES(3,'c');
+INSERT OR IGNORE INTO t VALUES(2,'dup');
+INSERT INTO t VALUES(5,'e');
+INSERT INTO t VALUES(4,'d');
+COMMIT;
+SELECT id, val FROM t ORDER BY id;
+SELECT count(*) FROM t;
+"
+
 # ════════════════════════════════════════════════════════════════════
 # Category 89: UPDATE with complex SET expressions
 # ════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- skip rowid absence seeks when an int-key cursor is inserting beyond append-sorted pending rows into an empty prolly tree
- refresh once before proving absence for the no-pending empty-root case
- add oracle coverage for sorted explicit rowid inserts, pending duplicate ignore, and out-of-order fallback

## Benchmark
Focused `oltp_bulk_insert`, median of 9:
- baseline: in-memory Doltlite 13,060 us, file-backed Doltlite 15,476 us
- after: in-memory Doltlite 12,712 us, file-backed Doltlite 14,712 us

Wrapped sysbench, median of 9:
- in-memory `oltp_bulk_insert`: SQLite 9,742 us, Doltlite 13,049 us, 1.34x
- file-backed `oltp_bulk_insert`: SQLite 11,215 us, Doltlite 14,944 us, 1.33x

## Tests
- `bash test/sql_oracle_test.sh ./doltlite ./sqlite3` -> 556 passed, 0 failed
- `BENCH_RUNS=9 BENCH_SECTION_MODE=wrapped bash test/sysbench_compare.sh` -> all tests within ceilings