### PR TITLE
Skip repeated append rowid seeks

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -126,6 +126,9 @@ struct TableEntry {
   ProllyHash schemaHash;
   u8 flags;
   u8 pendingFlushSeekEdits;
+  u8 appendSeekFloorValid;
+  i64 appendSeekFloor;
+  ProllyHash appendSeekRoot;
   char *zName;
   ProllyMutMap *pPending;
 };
@@ -6390,6 +6393,7 @@ static int prollyBtCursorTableMoveto(
   int *pRes
 ){
   int rc;
+  struct TableEntry *pTE;
   (void)bias;
 
   assert( pCur->curIntKey );
@@ -6400,8 +6404,22 @@ static int prollyBtCursorTableMoveto(
   CLEAR_CACHED_PAYLOAD(pCur);
   CLEAR_CACHED_SEEK_KEY(pCur);
 
+  pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
   if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
     ProllyMutMapEntry *pEntry = 0;
+    if( pTE
+     && pTE->appendSeekFloorValid
+     && prollyHashCompare(&pTE->root, &pTE->appendSeekRoot)==0
+     && pCur->pMutMap->isIntKey
+     && pCur->pMutMap->appendSorted
+     && intKey >= pTE->appendSeekFloor
+     && intKey > prollyMutMapEntryIntKey(
+                  &pCur->pMutMap->aEntries[pCur->pMutMap->nEntries-1])
+    ){
+      *pRes = 1;
+      pCur->eState = CURSOR_INVALID;
+      return SQLITE_OK;
+    }
     rc = prollyMutMapFindRc(pCur->pMutMap, 0, 0, intKey, &pEntry);
     if( rc!=SQLITE_OK ) return rc;
     if( pEntry ){
@@ -6431,6 +6449,18 @@ static int prollyBtCursorTableMoveto(
       CLEAR_CACHED_PAYLOAD(pCur);
       cacheCurrentTreePayloadIfIntKey(pCur);
     } else if( pCur->pCur.eState==PROLLY_CURSOR_VALID ){
+      if( *pRes<0 ){
+        if( pTE ){
+          if( !pTE->appendSeekFloorValid
+           || prollyHashCompare(&pTE->root, &pTE->appendSeekRoot)!=0
+           || intKey < pTE->appendSeekFloor
+          ){
+            pTE->appendSeekFloor = intKey;
+          }
+          pTE->appendSeekRoot = pTE->root;
+          pTE->appendSeekFloorValid = 1;
+        }
+      }
       pCur->eState = CURSOR_VALID;
       pCur->curFlags &= ~BTCF_ValidNKey;
       cacheCurrentTreePayloadIfIntKey(pCur);

--- a/test/sql_oracle_test.sh
+++ b/test/sql_oracle_test.sh
@@ -5550,6 +5550,21 @@ SELECT * FROM t ORDER BY id;
 SELECT count(*) FROM t;
 "
 
+# 88e. Append explicit rowids past existing max with pending duplicates
+oracle "cat88_insert_append_existing_rowid" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, val TEXT);
+INSERT INTO t VALUES(1,'a'),(2,'b'),(3,'c');
+BEGIN;
+INSERT INTO t VALUES(4,'d');
+INSERT INTO t VALUES(5,'e');
+INSERT OR IGNORE INTO t VALUES(4,'dup');
+INSERT INTO t VALUES(7,'g');
+INSERT INTO t VALUES(6,'f');
+COMMIT;
+SELECT id, val FROM t ORDER BY id;
+SELECT count(*) FROM t;
+"
+
 # ════════════════════════════════════════════════════════════════════
 # Category 89: UPDATE with complex SET expressions
 # ════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- cache the lowest rowid proven beyond the current table root max on the table entry
- use that proof to skip repeated absent tree seeks for later append-sorted pending int-key inserts
- guard the cache by the table root hash and pending-map append order
- add oracle coverage for appending explicit rowids past an existing max with pending duplicate and out-of-order fallback

## Benchmark
Focused `oltp_insert`, median of 9:
- baseline: in-memory Doltlite 10,321 us, file-backed Doltlite 11,676 us
- after: in-memory Doltlite 9,694 us, file-backed Doltlite 11,191 us

Wrapped sysbench, median of 9:
- in-memory `oltp_insert`: SQLite 7,779 us, Doltlite 9,969 us, 1.28x
- file-backed `oltp_insert`: SQLite 9,164 us, Doltlite 11,250 us, 1.23x

## Tests
- `bash test/sql_oracle_test.sh ./doltlite ./sqlite3` -> 556 passed, 0 failed
- `BENCH_RUNS=9 BENCH_SECTION_MODE=wrapped bash test/sysbench_compare.sh` -> all tests within ceilings