### PR TITLE
Cache table root classification

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -126,6 +126,8 @@ struct TableEntry {
   ProllyHash schemaHash;
   u8 flags;
   u8 pendingFlushSeekEdits;
+  u8 tableRootKnown;
+  u8 isTableRoot;
   char *zName;
   ProllyMutMap *pPending;
 };
@@ -151,6 +153,8 @@ struct SavepointCatalogEntry {
   ProllyHash schemaHash;
   u8 flags;
   u8 pendingFlushSeekEdits;
+  u8 tableRootKnown;
+  u8 isTableRoot;
   char *zName;
 };
 
@@ -2351,7 +2355,9 @@ static int deserializeCatalog(Btree *pBtree, const u8 *data, int nData){
       pName = q; q += nName;
       pTbl = q; q += nTbl;
       (void)pTbl;
+      pTE->tableRootKnown = 1;
       if( nType==5 && memcmp(pType, "table", 5)==0 && nName>0 ){
+        pTE->isTableRoot = 1;
         pTE->zName = sqlite3_malloc(nName+1);
         if( !pTE->zName ) return SQLITE_NOMEM;
         memcpy(pTE->zName, pName, nName);
@@ -2935,10 +2941,13 @@ static int saveCursorPosition(BtCursor *pCur){
 
 static int tableEntryIsTableRoot(Btree *pBtree, struct TableEntry *pTE){
   if( !pTE || pTE->iTable<=1 ) return 0;
+  if( pTE->tableRootKnown ) return pTE->isTableRoot ? 1 : 0;
   if( !pTE->zName && pBtree && pBtree->db ){
     pTE->zName = doltliteResolveTableNumber(pBtree->db, pTE->iTable);
   }
-  return pTE->zName!=0;
+  pTE->isTableRoot = pTE->zName!=0;
+  pTE->tableRootKnown = 1;
+  return pTE->isTableRoot ? 1 : 0;
 }
 
 static int restoreCursorPosition(BtCursor *pCur, int *pDifferentRow){
@@ -3054,6 +3063,8 @@ static int captureSavepointCatalogSnapshot(
     pDst->schemaHash = pSrc->schemaHash;
     pDst->flags = pSrc->flags;
     pDst->pendingFlushSeekEdits = pSrc->pendingFlushSeekEdits;
+    pDst->tableRootKnown = pSrc->tableRootKnown;
+    pDst->isTableRoot = pSrc->isTableRoot;
     if( pSrc->zName ){
       pDst->zName = sqlite3_mprintf("%s", pSrc->zName);
       if( !pDst->zName ){
@@ -3491,6 +3502,8 @@ static int restoreTablesFromSavepoint(
           pDst->schemaHash = pSrc->schemaHash;
           pDst->flags = pSrc->flags;
           pDst->pendingFlushSeekEdits = pSrc->pendingFlushSeekEdits;
+          pDst->tableRootKnown = pSrc->tableRootKnown;
+          pDst->isTableRoot = pSrc->isTableRoot;
           if( pSrc->zName ){
             pDst->zName = sqlite3_mprintf("%s", pSrc->zName);
             if( !pDst->zName ){

--- a/test/sql_oracle_test.sh
+++ b/test/sql_oracle_test.sh
@@ -6917,6 +6917,27 @@ SELECT * FROM t;
 "
 
 # ════════════════════════════════════════════════════════════════════
+# Category 122: BLOBKEY table root classification cache
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "--- Category 122: BLOBKEY table root classification cache ---"
+
+# Doltlite stores ordinary non-INTEGER primary-key tables as BLOBKEY
+# table roots. Secondary indexes are BLOBKEY roots too, so the cursor
+# layer has to distinguish table roots from index roots when splitting
+# table keys from payload records. This exercises a newly-created table
+# and secondary index in the same connection, before any catalog reload
+# can pre-classify the roots.
+oracle "cat122_blobkey_table_update_with_secondary_index" "
+CREATE TABLE t(a TEXT PRIMARY KEY, b INT, c TEXT);
+CREATE INDEX tb ON t(b);
+INSERT INTO t VALUES('x',1,'one'),('y',2,'two');
+UPDATE t SET b=3 WHERE a='x';
+SELECT a,b,c FROM t ORDER BY a;
+SELECT a FROM t WHERE b=3;
+"
+
+# ════════════════════════════════════════════════════════════════════
 echo ""
 echo "================================"
 echo "Results: $pass passed, $fail failed"


### PR DESCRIPTION
## Summary
- cache BLOBKEY table-root classification on catalog entries
- preserve the cache through savepoint catalog snapshots
- add oracle coverage for BLOBKEY table updates with a secondary index

## Benchmark
Focused `oltp_update_index` exact workload, 10k rows / 10k indexed updates, median local runs:
- in-memory Doltlite: 26,179 us -> 24,952 us
- file-backed Doltlite: 29,011 us -> 26,811 us

## Tests
- `./test/sql_oracle_test.sh` (557 passed, 0 failed)
- `git diff --check`
