### PR TITLE
Reuse pending row update entries

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -7255,9 +7255,25 @@ static int prollyBtCursorInsert(
     pInsertedPayload = pData;
     nInsertedPayload = nData;
 
-    rc = prollyMutMapInsert(pCur->pMutMap,
-                             NULL, 0, pPayload->nKey,
-                             pData, nData);
+    if( pCur->mmActive
+     && pCur->mmPhysActive
+     && pCur->pMutMap
+     && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH)
+     && (pCur->curFlags & BTCF_ValidNKey)
+     && pCur->cachedIntKey==pPayload->nKey ){
+      ProllyMutMapEntry *pEntry = currentMutMapEntry(pCur);
+      if( pEntry->op==PROLLY_EDIT_INSERT ){
+        rc = prollyMutMapReplaceEntry(pCur->pMutMap, pEntry, pData, nData);
+      }else{
+        rc = prollyMutMapInsert(pCur->pMutMap,
+                                 NULL, 0, pPayload->nKey,
+                                 pData, nData);
+      }
+    }else{
+      rc = prollyMutMapInsert(pCur->pMutMap,
+                               NULL, 0, pPayload->nKey,
+                               pData, nData);
+    }
   } else {
 
     int nSortKey = 0;

--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -646,6 +646,29 @@ int prollyMutMapInsert(
   return SQLITE_OK;
 }
 
+int prollyMutMapReplaceEntry(
+  ProllyMutMap *mm,
+  ProllyMutMapEntry *e,
+  const u8 *pVal,
+  int nVal
+){
+  int rc;
+  int phys;
+  if( !mm || !e ) return SQLITE_MISUSE;
+  phys = (int)(e - mm->aEntries);
+  if( phys<0 || phys>=mm->nEntries ) return SQLITE_CORRUPT_BKPT;
+  if( mm->currentSavepointLevel > 0
+   && decodeLevel(mm, e->bornAt) < mm->currentSavepointLevel ){
+    rc = appendUndoRec(mm, phys);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+  e->op = PROLLY_EDIT_INSERT;
+  rc = replaceEntryValue(e, pVal, nVal);
+  if( rc!=SQLITE_OK ) return rc;
+  e->bornAt = encodeLevel(mm, mm->currentSavepointLevel);
+  return SQLITE_OK;
+}
+
 int prollyMutMapDelete(
   ProllyMutMap *mm,
   const u8 *pKey, int nKey, i64 intKey

--- a/src/prolly_mutmap.h
+++ b/src/prolly_mutmap.h
@@ -71,6 +71,13 @@ int prollyMutMapInsert(ProllyMutMap *mm,
                        const u8 *pKey, int nKey, i64 intKey,
                        const u8 *pVal, int nVal);
 
+int prollyMutMapReplaceEntry(
+  ProllyMutMap *mm,
+  ProllyMutMapEntry *e,
+  const u8 *pVal,
+  int nVal
+);
+
 int prollyMutMapDelete(ProllyMutMap *mm,
                        const u8 *pKey, int nKey, i64 intKey);
 


### PR DESCRIPTION
## Summary
- add a mutmap helper to replace the value for an already-positioned pending entry
- use it for int-key table updates when the cursor is already on the same pending row
- keep tombstones and unexpected cursor states on the existing insert path

## Benchmarks
- Prepared 10k random non-index updates, in-memory: Doltlite median 9,360 us before -> 7,634 us after locally
- Exact script-level sysbench timer remains parse/noise limited locally: in-memory median 16,675 us before -> 16,761 us after; file-backed timings were noisy on this machine

## Tests
- repeated update + savepoint rollback oracle check against stock SQLite
- bash test/sql_oracle_test.sh ./doltlite ./sqlite3
- bash test/correctness_test.sh ./doltlite