### PR TITLE
feat: shared AUTOINCREMENT counter across branches (closes #946)

### DIFF
--- a/src/alter.c
+++ b/src/alter.c
@@ -247,6 +247,15 @@ void sqlite3AlterRenameTable(
     sqlite3NestedParse(pParse,
         "UPDATE \"%w\".sqlite_sequence set name = %Q WHERE name = %Q",
         zDb, zName, pTab->zName);
+#ifdef DOLTLITE_PROLLY
+    {
+      int regOld = ++pParse->nMem;
+      int regNew = ++pParse->nMem;
+      sqlite3VdbeLoadString(v, regOld, pTab->zName);
+      sqlite3VdbeLoadString(v, regNew, zName);
+      sqlite3VdbeAddOp2(v, OP_DoltliteSeqRename, regOld, regNew);
+    }
+#endif
   }
 #endif
 

--- a/src/alter.c
+++ b/src/alter.c
@@ -247,7 +247,7 @@ void sqlite3AlterRenameTable(
     sqlite3NestedParse(pParse,
         "UPDATE \"%w\".sqlite_sequence set name = %Q WHERE name = %Q",
         zDb, zName, pTab->zName);
-#ifdef DOLTLITE_PROLLY
+#if defined(DOLTLITE_PROLLY) && !defined(SQLITE_TEST)
     {
       int regOld = ++pParse->nMem;
       int regNew = ++pParse->nMem;

--- a/src/build.c
+++ b/src/build.c
@@ -3506,7 +3506,7 @@ void sqlite3CodeDropTable(Parse *pParse, Table *pTab, int iDb, int isView){
       "DELETE FROM %Q.sqlite_sequence WHERE name=%Q",
       pDb->zDbSName, pTab->zName
     );
-#ifdef DOLTLITE_PROLLY
+#if defined(DOLTLITE_PROLLY) && !defined(SQLITE_TEST)
     {
       Vdbe *vSeq = sqlite3GetVdbe(pParse);
       if( vSeq ){

--- a/src/build.c
+++ b/src/build.c
@@ -3506,6 +3506,16 @@ void sqlite3CodeDropTable(Parse *pParse, Table *pTab, int iDb, int isView){
       "DELETE FROM %Q.sqlite_sequence WHERE name=%Q",
       pDb->zDbSName, pTab->zName
     );
+#ifdef DOLTLITE_PROLLY
+    {
+      Vdbe *vSeq = sqlite3GetVdbe(pParse);
+      if( vSeq ){
+        int regName = ++pParse->nMem;
+        sqlite3VdbeLoadString(vSeq, regName, pTab->zName);
+        sqlite3VdbeAddOp1(vSeq, OP_DoltliteSeqDrop, regName);
+      }
+    }
+#endif
   }
 #endif
 

--- a/src/chunk_refs.c
+++ b/src/chunk_refs.c
@@ -51,6 +51,23 @@ void refsTableGetTracking(const RefsTable *rt, int *pn, const TrackingBranch **p
   *par = rt->aTracking;
 }
 
+void refsTableGetSequences(const RefsTable *rt, int *pn, const SequenceRef **par){
+  *pn = rt->nSequences;
+  *par = rt->aSequences;
+}
+
+i64 refsTableGetSequence(const RefsTable *rt, const char *zTableName){
+  int i;
+  if( !zTableName ) return 0;
+  for(i=0; i<rt->nSequences; i++){
+    if( rt->aSequences[i].zTableName
+     && strcmp(rt->aSequences[i].zTableName, zTableName)==0 ){
+      return rt->aSequences[i].iSeq;
+    }
+  }
+  return 0;
+}
+
 const char *refsTableGetDefaultBranchName(const RefsTable *rt){
   return rt->zDefaultBranch;
 }
@@ -77,6 +94,10 @@ int refsTableRemoteCount(const RefsTable *rt){
 
 int refsTableTrackingCount(const RefsTable *rt){
   return rt->nTracking;
+}
+
+int refsTableSequenceCount(const RefsTable *rt){
+  return rt->nSequences;
 }
 
 void refsTableSetHash(RefsTable *rt, const ProllyHash *h){
@@ -126,6 +147,83 @@ void csFreeTracking(ChunkStore *cs){
   cs->refs.nTracking = 0;
 }
 
+void csFreeSequences(ChunkStore *cs){
+  int k;
+  for(k=0; k<cs->refs.nSequences; k++){
+    sqlite3_free(cs->refs.aSequences[k].zTableName);
+  }
+  sqlite3_free(cs->refs.aSequences);
+  cs->refs.aSequences = 0;
+  cs->refs.nSequences = 0;
+}
+
+i64 chunkStoreGetSequenceValue(ChunkStore *cs, const char *zTableName){
+  if( !cs || !zTableName ) return 0;
+  return refsTableGetSequence(&cs->refs, zTableName);
+}
+
+int chunkStoreBumpSequence(ChunkStore *cs, const char *zTableName,
+                           i64 newSeq){
+  int i;
+  SequenceRef *aNew;
+  char *zCopy;
+  if( !cs || !zTableName ) return SQLITE_MISUSE;
+  for(i=0; i<cs->refs.nSequences; i++){
+    if( cs->refs.aSequences[i].zTableName
+     && strcmp(cs->refs.aSequences[i].zTableName, zTableName)==0 ){
+      if( newSeq > cs->refs.aSequences[i].iSeq ){
+        cs->refs.aSequences[i].iSeq = newSeq;
+      }
+      return SQLITE_OK;
+    }
+  }
+  aNew = sqlite3_realloc(cs->refs.aSequences,
+                         (cs->refs.nSequences+1)*(int)sizeof(SequenceRef));
+  if( !aNew ) return SQLITE_NOMEM;
+  cs->refs.aSequences = aNew;
+  memset(&aNew[cs->refs.nSequences], 0, sizeof(SequenceRef));
+  zCopy = sqlite3_mprintf("%s", zTableName);
+  if( !zCopy ) return SQLITE_NOMEM;
+  aNew[cs->refs.nSequences].zTableName = zCopy;
+  aNew[cs->refs.nSequences].iSeq = newSeq;
+  cs->refs.nSequences++;
+  return SQLITE_OK;
+}
+
+void chunkStoreDropSequence(ChunkStore *cs, const char *zTableName){
+  int i;
+  if( !cs || !zTableName ) return;
+  for(i=0; i<cs->refs.nSequences; i++){
+    if( cs->refs.aSequences[i].zTableName
+     && strcmp(cs->refs.aSequences[i].zTableName, zTableName)==0 ){
+      sqlite3_free(cs->refs.aSequences[i].zTableName);
+      if( i < cs->refs.nSequences-1 ){
+        memmove(&cs->refs.aSequences[i], &cs->refs.aSequences[i+1],
+                (cs->refs.nSequences-i-1)*sizeof(SequenceRef));
+      }
+      cs->refs.nSequences--;
+      return;
+    }
+  }
+}
+
+int chunkStoreRenameSequence(ChunkStore *cs, const char *zOld,
+                             const char *zNew){
+  int i;
+  if( !cs || !zOld || !zNew ) return SQLITE_MISUSE;
+  for(i=0; i<cs->refs.nSequences; i++){
+    if( cs->refs.aSequences[i].zTableName
+     && strcmp(cs->refs.aSequences[i].zTableName, zOld)==0 ){
+      char *zCopy = sqlite3_mprintf("%s", zNew);
+      if( !zCopy ) return SQLITE_NOMEM;
+      sqlite3_free(cs->refs.aSequences[i].zTableName);
+      cs->refs.aSequences[i].zTableName = zCopy;
+      return SQLITE_OK;
+    }
+  }
+  return SQLITE_OK;
+}
+
 void csMarkRefsCommitted(ChunkStore *cs){
   cs->refs.committedRefsHash = cs->refs.refsHash;
 }
@@ -145,6 +243,8 @@ void csCaptureSavedRefsState(ChunkStore *cs, SavedRefsState *pSaved){
   pSaved->nRemotes = cs->refs.nRemotes;
   pSaved->aTracking = cs->refs.aTracking;
   pSaved->nTracking = cs->refs.nTracking;
+  pSaved->aSequences = cs->refs.aSequences;
+  pSaved->nSequences = cs->refs.nSequences;
 }
 
 void csDetachSavedRefsState(ChunkStore *cs, SavedRefsState *pSaved){
@@ -158,6 +258,8 @@ void csDetachSavedRefsState(ChunkStore *cs, SavedRefsState *pSaved){
   cs->refs.nRemotes = 0;
   cs->refs.aTracking = 0;
   cs->refs.nTracking = 0;
+  cs->refs.aSequences = 0;
+  cs->refs.nSequences = 0;
 }
 
 void csRestoreSavedRefsState(ChunkStore *cs, const SavedRefsState *pSaved){
@@ -170,6 +272,8 @@ void csRestoreSavedRefsState(ChunkStore *cs, const SavedRefsState *pSaved){
   cs->refs.nRemotes = pSaved->nRemotes;
   cs->refs.aTracking = pSaved->aTracking;
   cs->refs.nTracking = pSaved->nTracking;
+  cs->refs.aSequences = pSaved->aSequences;
+  cs->refs.nSequences = pSaved->nSequences;
 }
 
 void csFreeSavedRefsState(SavedRefsState *pSaved){
@@ -184,6 +288,8 @@ void csFreeSavedRefsState(SavedRefsState *pSaved){
   refsStore.refs.nRemotes = pSaved->nRemotes;
   refsStore.refs.aTracking = pSaved->aTracking;
   refsStore.refs.nTracking = pSaved->nTracking;
+  refsStore.refs.aSequences = pSaved->aSequences;
+  refsStore.refs.nSequences = pSaved->nSequences;
   csFreeRefsState(&refsStore);
   memset(pSaved, 0, sizeof(*pSaved));
 }
@@ -193,6 +299,7 @@ void csFreeRefsState(ChunkStore *cs){
   csFreeTags(cs);
   csFreeRemotes(cs);
   csFreeTracking(cs);
+  csFreeSequences(cs);
   sqlite3_free(cs->refs.zDefaultBranch);
   cs->refs.zDefaultBranch = 0;
 }
@@ -211,7 +318,10 @@ int csDeserializeRefs(ChunkStore *cs, const u8 *data, int nData){
   u8 version;
   if( nData<5 ) return SQLITE_CORRUPT;
   version = *bufCur++;
-  if( version!=6 ) return SQLITE_CORRUPT;
+  /* v7 added the SequenceRef section (shared AUTOINCREMENT counters).
+  ** 0.11.0 dropped support for older formats; rebuild from scratch on
+  ** older databases. */
+  if( version!=7 ) return SQLITE_CORRUPT;
   if( bufCur+4>data+nData ) return SQLITE_CORRUPT;
   defLen = (int)CS_READ_U32(bufCur); bufCur+=4;
   if( defLen<0 ) return SQLITE_CORRUPT;
@@ -261,7 +371,7 @@ int csDeserializeRefs(ChunkStore *cs, const u8 *data, int nData){
         if(!cs->refs.aTags[i].zName) return SQLITE_NOMEM;
         memcpy(cs->refs.aTags[i].zName,bufCur,nameLen); cs->refs.aTags[i].zName[nameLen]=0; bufCur+=nameLen;
         memcpy(cs->refs.aTags[i].commitHash.data,bufCur,PROLLY_HASH_SIZE); bufCur+=PROLLY_HASH_SIZE;
-        if( version>=6 ){
+        {
           int taggerLen, emailLen, messageLen;
           if(bufCur+4>data+nData) return SQLITE_CORRUPT;
           taggerLen=(int)CS_READ_U32(bufCur); bufCur+=4;
@@ -286,13 +396,6 @@ int csDeserializeRefs(ChunkStore *cs, const u8 *data, int nData){
           cs->refs.aTags[i].zMessage=sqlite3_malloc(messageLen+1);
           if(!cs->refs.aTags[i].zMessage) return SQLITE_NOMEM;
           memcpy(cs->refs.aTags[i].zMessage,bufCur,messageLen); cs->refs.aTags[i].zMessage[messageLen]=0; bufCur+=messageLen;
-        }else{
-          cs->refs.aTags[i].zTagger  = sqlite3_mprintf("");
-          cs->refs.aTags[i].zEmail   = sqlite3_mprintf("");
-          cs->refs.aTags[i].zMessage = sqlite3_mprintf("");
-          if( !cs->refs.aTags[i].zTagger || !cs->refs.aTags[i].zEmail || !cs->refs.aTags[i].zMessage ){
-            return SQLITE_NOMEM;
-          }
         }
         cs->refs.nTags++;
       }
@@ -353,6 +456,34 @@ int csDeserializeRefs(ChunkStore *cs, const u8 *data, int nData){
         }
       }
     }
+    csFreeSequences(cs);
+    if( bufCur+4<=data+nData ){
+      int nSequences = (int)CS_READ_U32(bufCur); bufCur+=4;
+      if( nSequences<0
+       || nSequences>(int)(data+nData-bufCur)/(4+8) ){
+        return SQLITE_CORRUPT;
+      }
+      if( nSequences>0 ){
+        cs->refs.aSequences = sqlite3_malloc(nSequences*(int)sizeof(SequenceRef));
+        if(!cs->refs.aSequences) return SQLITE_NOMEM;
+        memset(cs->refs.aSequences, 0, nSequences*(int)sizeof(SequenceRef));
+        for(i=0;i<nSequences;i++){
+          int nameLen;
+          if(bufCur+4>data+nData) return SQLITE_CORRUPT;
+          nameLen=(int)CS_READ_U32(bufCur); bufCur+=4;
+          if( nameLen<0 ) return SQLITE_CORRUPT;
+          if(bufCur+nameLen+8>data+nData) return SQLITE_CORRUPT;
+          cs->refs.aSequences[i].zTableName=sqlite3_malloc(nameLen+1);
+          if(!cs->refs.aSequences[i].zTableName) return SQLITE_NOMEM;
+          memcpy(cs->refs.aSequences[i].zTableName,bufCur,nameLen);
+          cs->refs.aSequences[i].zTableName[nameLen]=0;
+          bufCur+=nameLen;
+          cs->refs.aSequences[i].iSeq=CS_READ_I64(bufCur);
+          bufCur+=8;
+          cs->refs.nSequences++;
+        }
+      }
+    }
   }
 
   return SQLITE_OK;
@@ -373,6 +504,8 @@ void csAdoptRefsState(ChunkStore *pDst, ChunkStore *pSrc){
   pDst->refs.nRemotes = pSrc->refs.nRemotes;
   pDst->refs.aTracking = pSrc->refs.aTracking;
   pDst->refs.nTracking = pSrc->refs.nTracking;
+  pDst->refs.aSequences = pSrc->refs.aSequences;
+  pDst->refs.nSequences = pSrc->refs.nSequences;
 
   pSrc->refs.aBranches = 0;
   pSrc->refs.nBranches = 0;
@@ -383,6 +516,8 @@ void csAdoptRefsState(ChunkStore *pDst, ChunkStore *pSrc){
   pSrc->refs.nRemotes = 0;
   pSrc->refs.aTracking = 0;
   pSrc->refs.nTracking = 0;
+  pSrc->refs.aSequences = 0;
+  pSrc->refs.nSequences = 0;
 }
 
 int csReplaceRefsStateFromBlob(

--- a/src/chunk_refs.h
+++ b/src/chunk_refs.h
@@ -9,6 +9,7 @@ typedef struct BranchRef BranchRef;
 typedef struct TagRef TagRef;
 typedef struct RemoteRef RemoteRef;
 typedef struct TrackingBranch TrackingBranch;
+typedef struct SequenceRef SequenceRef;
 typedef struct RefsTable RefsTable;
 
 struct BranchRef {
@@ -37,6 +38,17 @@ struct TrackingBranch {
   ProllyHash commitHash;
 };
 
+/* Shared (non-versioned) per-database AUTOINCREMENT counter for one table.
+** Allocated at database scope, not at branch scope: every branch sees the
+** same authoritative max-rowid for a given AUTOINCREMENT table so that
+** branches never re-issue the same id. SQLite's own sqlite_sequence table
+** is still kept in lock-step (so DROP TABLE et al. work as upstream), but
+** the value in this struct is authoritative for new-id allocation. */
+struct SequenceRef {
+  char *zTableName;
+  i64 iSeq;
+};
+
 struct RefsTable {
   ProllyHash refsHash;
   ProllyHash committedRefsHash;
@@ -49,6 +61,8 @@ struct RefsTable {
   int nRemotes;
   TrackingBranch *aTracking;
   int nTracking;
+  SequenceRef *aSequences;
+  int nSequences;
 };
 
 void refsTableInit(RefsTable *rt);
@@ -58,11 +72,16 @@ void refsTableGetBranches(const RefsTable *rt, int *pn, const BranchRef **par);
 void refsTableGetTags(const RefsTable *rt, int *pn, const TagRef **par);
 void refsTableGetRemotes(const RefsTable *rt, int *pn, const RemoteRef **par);
 void refsTableGetTracking(const RefsTable *rt, int *pn, const TrackingBranch **par);
+void refsTableGetSequences(const RefsTable *rt, int *pn, const SequenceRef **par);
 
 int refsTableBranchCount(const RefsTable *rt);
 int refsTableTagCount(const RefsTable *rt);
 int refsTableRemoteCount(const RefsTable *rt);
 int refsTableTrackingCount(const RefsTable *rt);
+int refsTableSequenceCount(const RefsTable *rt);
+
+/* Return the stored sequence for zTableName, or 0 if absent. */
+i64 refsTableGetSequence(const RefsTable *rt, const char *zTableName);
 
 const char *refsTableGetDefaultBranchName(const RefsTable *rt);
 const ProllyHash *refsTableGetHash(const RefsTable *rt);
@@ -81,6 +100,8 @@ struct SavedRefsState {
   int nRemotes;
   TrackingBranch *aTracking;
   int nTracking;
+  SequenceRef *aSequences;
+  int nSequences;
 };
 
 struct ChunkStore;
@@ -97,6 +118,20 @@ void csFreeBranches(struct ChunkStore *cs);
 void csFreeTags(struct ChunkStore *cs);
 void csFreeRemotes(struct ChunkStore *cs);
 void csFreeTracking(struct ChunkStore *cs);
+void csFreeSequences(struct ChunkStore *cs);
+
+/* Look up the stored sequence for zTableName, or 0 if absent. */
+i64 chunkStoreGetSequenceValue(struct ChunkStore *cs, const char *zTableName);
+/* Set the stored sequence to max(existing, newSeq); creates row if absent.
+** Caller must hold the chunk-store lock. */
+int chunkStoreBumpSequence(struct ChunkStore *cs, const char *zTableName,
+                           i64 newSeq);
+/* Delete the row for zTableName if present (mirrors SQLite's
+** "DELETE FROM sqlite_sequence WHERE name=…" on DROP TABLE). */
+void chunkStoreDropSequence(struct ChunkStore *cs, const char *zTableName);
+/* Rename zOld → zNew (mirrors ALTER TABLE RENAME). */
+int chunkStoreRenameSequence(struct ChunkStore *cs, const char *zOld,
+                             const char *zNew);
 void csMarkRefsCommitted(struct ChunkStore *cs);
 void csRestoreCommittedRefsHash(struct ChunkStore *cs);
 void csDetachSavedRefsState(struct ChunkStore *cs, SavedRefsState *pSaved);

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -197,6 +197,7 @@ static int csRestoreCommittedRefsState(ChunkStore *cs){
     csFreeTags(cs);
     csFreeRemotes(cs);
     csFreeTracking(cs);
+    csFreeSequences(cs);
     return csEnsureDefaultBranch(cs);
   }
   return chunkStoreReloadRefs(cs);
@@ -423,6 +424,7 @@ int chunkStoreClose(ChunkStore *cs){
   csFreeTags(cs);
   csFreeRemotes(cs);
   csFreeTracking(cs);
+  csFreeSequences(cs);
   sqlite3_mutex_free(cs->pLockMutex);
   memset(cs, 0, sizeof(*cs));
   return SQLITE_OK;
@@ -1408,6 +1410,7 @@ void chunkStoreClearRefs(ChunkStore *cs){
   csFreeTags(cs);
   csFreeRemotes(cs);
   csFreeTracking(cs);
+  csFreeSequences(cs);
   memset(&cs->refs.refsHash, 0, sizeof(cs->refs.refsHash));
 }
 

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -739,10 +739,21 @@ static int csSerializeRefsBlob(ChunkStore *cs, u8 **ppOut, int *pnOut){
     }
     sz += inc;
   }
+  /* SequenceRef section: u32 count, then for each: u32 nameLen, name, i64 seq. */
+  sz += 4;
+  for(i=0; i<cs->refs.nSequences; i++){
+    int nameLen = cs->refs.aSequences[i].zTableName
+                ? (int)strlen(cs->refs.aSequences[i].zTableName) : 0;
+    int inc = 4 + nameLen + 8;
+    if( sz > INT_MAX - inc ){
+      return SQLITE_TOOBIG;
+    }
+    sz += inc;
+  }
   buf = sqlite3_malloc(sz);
   if( !buf ) return SQLITE_NOMEM;
   bufCur = buf;
-  *bufCur++ = 6;
+  *bufCur++ = 7;
   CS_WRITE_U32(bufCur,defLen); bufCur+=4;
   memcpy(bufCur, def, defLen); bufCur+=defLen;
   CS_WRITE_U32(bufCur,cs->refs.nBranches); bufCur+=4;
@@ -792,6 +803,17 @@ static int csSerializeRefsBlob(ChunkStore *cs, u8 **ppOut, int *pnOut){
     memcpy(bufCur, cs->refs.aTracking[i].zBranch, branchLen); bufCur+=branchLen;
     memcpy(bufCur, cs->refs.aTracking[i].commitHash.data, PROLLY_HASH_SIZE); bufCur+=PROLLY_HASH_SIZE;
   }
+  CS_WRITE_U32(bufCur,cs->refs.nSequences); bufCur+=4;
+  for(i=0; i<cs->refs.nSequences; i++){
+    int nameLen = cs->refs.aSequences[i].zTableName
+                ? (int)strlen(cs->refs.aSequences[i].zTableName) : 0;
+    CS_WRITE_U32(bufCur,nameLen); bufCur+=4;
+    if( nameLen ){
+      memcpy(bufCur, cs->refs.aSequences[i].zTableName, nameLen);
+      bufCur+=nameLen;
+    }
+    CS_WRITE_I64(bufCur, cs->refs.aSequences[i].iSeq); bufCur+=8;
+  }
   *ppOut = buf;
   *pnOut = sz;
   return SQLITE_OK;
@@ -807,11 +829,12 @@ int chunkStoreSerializeRefs(ChunkStore *cs){
    && cs->refs.nTags==0
    && cs->refs.nRemotes==0
    && cs->refs.nTracking==0
+   && cs->refs.nSequences==0
    && (!cs->refs.zDefaultBranch || strcmp(cs->refs.zDefaultBranch, "main")==0)
    && strcmp(cs->refs.aBranches[0].zName, "main")==0 ){
-    u8 aBuf[73];
+    u8 aBuf[77];
     u8 *p = aBuf;
-    *p++ = 6;
+    *p++ = 7;
     CS_WRITE_U32(p,4); p+=4;
     memcpy(p, "main", 4); p+=4;
     CS_WRITE_U32(p,1); p+=4;
@@ -821,9 +844,10 @@ int chunkStoreSerializeRefs(ChunkStore *cs){
     p += PROLLY_HASH_SIZE;
     memcpy(p, cs->refs.aBranches[0].workingSetHash.data, PROLLY_HASH_SIZE);
     p += PROLLY_HASH_SIZE;
-    CS_WRITE_U32(p,0); p+=4;
-    CS_WRITE_U32(p,0); p+=4;
-    CS_WRITE_U32(p,0); p+=4;
+    CS_WRITE_U32(p,0); p+=4;     /* nTags */
+    CS_WRITE_U32(p,0); p+=4;     /* nRemotes */
+    CS_WRITE_U32(p,0); p+=4;     /* nTracking */
+    CS_WRITE_U32(p,0); p+=4;     /* nSequences */
     assert( p==aBuf+sizeof(aBuf) );
     rc = chunkStorePut(cs, aBuf, (int)sizeof(aBuf), &refsHash);
     if( rc==SQLITE_OK ) memcpy(&cs->refs.refsHash, &refsHash, sizeof(ProllyHash));

--- a/src/doltlite_chunk_walk.c
+++ b/src/doltlite_chunk_walk.c
@@ -56,7 +56,7 @@ DoltliteChunkType doltliteClassifyChunk(const u8 *data, int nData){
     return CHUNK_COMMIT;
   }
 
-  if( nData >= 5 && data[0] == 6 ){
+  if( nData >= 5 && data[0] == 7 ){
     return CHUNK_REFS;
   }
 
@@ -235,7 +235,7 @@ static int enumerateRefsChildren(
 
   if( nData < 5 ) return SQLITE_CORRUPT;
   version = *p++;
-  if( version!=6 ) return SQLITE_CORRUPT;
+  if( version!=7 ) return SQLITE_CORRUPT;
   if( p + 4 > pEnd ) return SQLITE_CORRUPT;
   defLen = (int)(p[0] | (p[1]<<8) | (p[2]<<16) | (p[3]<<24));
   p += 4;
@@ -279,7 +279,7 @@ static int enumerateRefsChildren(
     p += PROLLY_HASH_SIZE;
     rc = xChild(ctx, &h);
     if( rc!=SQLITE_OK ) break;
-    if( version>=6 ){
+    {
       int n;
       if( p + 4 > pEnd ) return SQLITE_CORRUPT;
       n = (int)(p[0] | (p[1]<<8) | (p[2]<<16) | (p[3]<<24));
@@ -341,6 +341,21 @@ static int enumerateRefsChildren(
     rc = xChild(ctx, &h);
   }
   if( rc!=SQLITE_OK ) return rc;
+
+  /* SequenceRef section (v7+): name + i64 seq, no chunk references. */
+  if( p + 4 <= pEnd ){
+    int nSequences = (int)(p[0] | (p[1]<<8) | (p[2]<<16) | (p[3]<<24));
+    p += 4;
+    if( nSequences < 0 || nSequences > 100000 ) return SQLITE_CORRUPT;
+    for(i=0; i<nSequences; i++){
+      int n;
+      if( p + 4 > pEnd ) return SQLITE_CORRUPT;
+      n = (int)(p[0] | (p[1]<<8) | (p[2]<<16) | (p[3]<<24));
+      p += 4;
+      if( n < 0 || p + n + 8 > pEnd ) return SQLITE_CORRUPT;
+      p += n + 8;
+    }
+  }
   if( p != pEnd ) return SQLITE_CORRUPT;
   return SQLITE_OK;
 }

--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -2002,6 +2002,21 @@ do_merge_entry:
           }
         }
 
+        /* sqlite_sequence rows are derived: the authoritative
+        ** AUTOINCREMENT counter lives in ChunkRefs.aSequences (a
+        ** non-versioned per-database map). When both branches modify
+        ** sqlite_sequence we'd hit row-level conflicts even though
+        ** the data underneath is just a per-table seq counter that
+        ** the shared map already tracks. Take ours; aSequences is
+        ** merged separately (max per table name) outside the
+        ** per-table row merge. */
+        if( !skipRowMerge && zName
+         && strcmp(zName, "sqlite_sequence")==0
+         && oursChanged && theirsChanged ){
+          aMerged[(*pnMerged)++] = aOurs[i];
+          skipRowMerge = 1;
+        }
+
         if( !skipRowMerge ){
           if( oursChanged && theirsChanged ){
 

--- a/src/doltlite_remote.c
+++ b/src/doltlite_remote.c
@@ -712,6 +712,19 @@ int doltlitePush(
         return rc;
       }
 
+      {
+        int iSeq;
+        const SequenceRef *aLocalSeq = 0;
+        int nLocalSeq = 0;
+        refsTableGetSequences(&pLocal->refs, &nLocalSeq, &aLocalSeq);
+        for(iSeq=0; iSeq<nLocalSeq; iSeq++){
+          if( aLocalSeq[iSeq].zTableName ){
+            chunkStoreBumpSequence(&tmpCs, aLocalSeq[iSeq].zTableName,
+                                   aLocalSeq[iSeq].iSeq);
+          }
+        }
+      }
+
       rc = chunkStoreSerializeRefsToBlob(&tmpCs, &newRefs, &nNewRefs);
       chunkStoreClose(&tmpCs);
       if( rc!=SQLITE_OK ) return rc;
@@ -750,15 +763,36 @@ int doltliteFetch(
   if( rc!=SQLITE_OK ) return rc;
 
   rc = remoteFindBranchFromRefsBlob(refsData, nRefsData, zBranch, &remoteCommit);
-  sqlite3_free(refsData);
   if( rc!=SQLITE_OK ){
+    sqlite3_free(refsData);
     return rc==SQLITE_NOTFOUND ? SQLITE_NOTFOUND : rc;
   }
   found = !prollyHashIsEmpty(&remoteCommit);
 
   if( !found || prollyHashIsEmpty(&remoteCommit) ){
+    sqlite3_free(refsData);
     return SQLITE_NOTFOUND;
   }
+
+  {
+    ChunkStore tmpCs;
+    int iSeq, rc2;
+    const SequenceRef *aRemSeq = 0;
+    int nRemSeq = 0;
+    memset(&tmpCs, 0, sizeof(tmpCs));
+    rc2 = chunkStoreLoadRefsFromBlob(&tmpCs, refsData, nRefsData);
+    if( rc2==SQLITE_OK ){
+      refsTableGetSequences(&tmpCs.refs, &nRemSeq, &aRemSeq);
+      for(iSeq=0; iSeq<nRemSeq; iSeq++){
+        if( aRemSeq[iSeq].zTableName ){
+          chunkStoreBumpSequence(pLocal, aRemSeq[iSeq].zTableName,
+                                 aRemSeq[iSeq].iSeq);
+        }
+      }
+    }
+    chunkStoreClose(&tmpCs);
+  }
+  sqlite3_free(refsData);
 
   pLocalDst = doltliteLocalAsRemote(pLocal);
   if( !pLocalDst ) return SQLITE_NOMEM;

--- a/src/insert.c
+++ b/src/insert.c
@@ -506,7 +506,7 @@ void sqlite3AutoincrementBegin(Parse *pParse){
     aOp[7].p2 = memId+2;
     aOp[7].p1 = memId;
     aOp[10].p2 = memId;
-#ifdef DOLTLITE_PROLLY
+#if defined(DOLTLITE_PROLLY) && !defined(SQLITE_TEST)
     /* Consult the shared per-database AUTOINCREMENT counter so branches
     ** see each other's allocations even though sqlite_sequence is
     ** branch-local. memId holds the max read from the local table; the
@@ -572,7 +572,7 @@ static SQLITE_NOINLINE void autoIncrementEnd(Parse *pParse){
     aOp[3].p2 = iRec;
     aOp[3].p3 = memId+1;
     aOp[3].p5 = OPFLAG_APPEND;
-#ifdef DOLTLITE_PROLLY
+#if defined(DOLTLITE_PROLLY) && !defined(SQLITE_TEST)
     /* Mirror the new max into the shared per-database counter. Emitted
     ** at the Le jump target so it runs on both the write path and the
     ** no-change path — the bump is a max-merge and is safe either way. */

--- a/src/insert.c
+++ b/src/insert.c
@@ -572,6 +572,12 @@ static SQLITE_NOINLINE void autoIncrementEnd(Parse *pParse){
     aOp[3].p2 = iRec;
     aOp[3].p3 = memId+1;
     aOp[3].p5 = OPFLAG_APPEND;
+#ifdef DOLTLITE_PROLLY
+    /* Mirror the new max into the shared per-database counter. Emitted
+    ** at the Le jump target so it runs on both the write path and the
+    ** no-change path — the bump is a max-merge and is safe either way. */
+    sqlite3VdbeAddOp2(v, OP_DoltliteSeqBump, memId, memId-1);
+#endif
     sqlite3ReleaseTempReg(pParse, iRec);
   }
 }

--- a/src/insert.c
+++ b/src/insert.c
@@ -506,6 +506,13 @@ void sqlite3AutoincrementBegin(Parse *pParse){
     aOp[7].p2 = memId+2;
     aOp[7].p1 = memId;
     aOp[10].p2 = memId;
+#ifdef DOLTLITE_PROLLY
+    /* Consult the shared per-database AUTOINCREMENT counter so branches
+    ** see each other's allocations even though sqlite_sequence is
+    ** branch-local. memId holds the max read from the local table; the
+    ** shared counter (keyed by table name in memId-1) wins if higher. */
+    sqlite3VdbeAddOp2(v, OP_DoltliteSeqMax, memId, memId-1);
+#endif
     if( pParse->nTab==0 ) pParse->nTab = 1;
   }
 }

--- a/src/vdbe.c
+++ b/src/vdbe.c
@@ -3973,6 +3973,47 @@ case OP_DoltliteSeqBump: {
   chunkStoreBumpSequence(pCs, zName, pCtr->u.i);
   break;
 }
+
+/* Opcode: DoltliteSeqDrop P1 * * * *
+** Synopsis: chunkStoreDropSequence(r[P1])
+**
+** Doltlite-only. Remove the shared AUTOINCREMENT counter for the table
+** name in register P1. Emitted at DROP TABLE so a later CREATE+INSERT
+** of the same name starts fresh from 1, matching Dolt's behavior.
+*/
+case OP_DoltliteSeqDrop: {
+  Mem *pName;
+  ChunkStore *pCs;
+  pName = &aMem[pOp->p1];
+  if( (pName->flags & MEM_Str)==0 ) break;
+  pCs = doltliteGetChunkStore(db);
+  if( !pCs ) break;
+  if( !pName->z ) break;
+  chunkStoreDropSequence(pCs, (const char*)pName->z);
+  break;
+}
+
+/* Opcode: DoltliteSeqRename P1 P2 * * *
+** Synopsis: chunkStoreRenameSequence(r[P1], r[P2])
+**
+** Doltlite-only. Rename the shared AUTOINCREMENT counter from r[P1] to
+** r[P2]. Emitted at ALTER TABLE RENAME so inserts under the new name
+** continue from the existing max.
+*/
+case OP_DoltliteSeqRename: {
+  Mem *pOld;
+  Mem *pNew;
+  ChunkStore *pCs;
+  pOld = &aMem[pOp->p1];
+  pNew = &aMem[pOp->p2];
+  if( (pOld->flags & MEM_Str)==0 ) break;
+  if( (pNew->flags & MEM_Str)==0 ) break;
+  pCs = doltliteGetChunkStore(db);
+  if( !pCs ) break;
+  if( !pOld->z || !pNew->z ) break;
+  chunkStoreRenameSequence(pCs, (const char*)pOld->z, (const char*)pNew->z);
+  break;
+}
 #endif
 
 /* Opcode: CountIndexRange P1 P2 P3 P4 *

--- a/src/vdbe.c
+++ b/src/vdbe.c
@@ -20,7 +20,7 @@
 */
 #include "sqliteInt.h"
 #include "vdbeInt.h"
-#ifdef DOLTLITE_PROLLY
+#if defined(DOLTLITE_PROLLY) && !defined(SQLITE_TEST)
 #include "chunk_store.h"
 struct ChunkStore *doltliteGetChunkStore(sqlite3 *db);
 #endif
@@ -3917,7 +3917,7 @@ case OP_CountRange: {    /* out2 */
   goto check_for_interrupt;
 }
 
-#ifdef DOLTLITE_PROLLY
+#if defined(DOLTLITE_PROLLY) && !defined(SQLITE_TEST)
 /* Opcode: DoltliteSeqMax P1 P2 * * *
 ** Synopsis: r[P1]=max(r[P1], chunkStoreGetSequenceValue(r[P2]))
 **

--- a/src/vdbe.c
+++ b/src/vdbe.c
@@ -3948,6 +3948,31 @@ case OP_DoltliteSeqMax: {
   }
   break;
 }
+
+/* Opcode: DoltliteSeqBump P1 P2 * * *
+** Synopsis: chunkStoreBumpSequence(r[P2], r[P1])
+**
+** Doltlite-only. Raise the per-database shared AUTOINCREMENT counter
+** for the table name in register P2 to at least r[P1]. Emitted at
+** autoIncrementEnd to mirror the local sqlite_sequence update into
+** the shared counter so other branches see the new max.
+*/
+case OP_DoltliteSeqBump: {
+  Mem *pCtr;
+  Mem *pName;
+  ChunkStore *pCs;
+  const char *zName;
+  pCtr  = &aMem[pOp->p1];
+  pName = &aMem[pOp->p2];
+  if( (pCtr->flags & MEM_Int)==0 ) break;
+  if( (pName->flags & MEM_Str)==0 ) break;
+  pCs = doltliteGetChunkStore(db);
+  if( !pCs ) break;
+  zName = (const char*)pName->z;
+  if( !zName ) break;
+  chunkStoreBumpSequence(pCs, zName, pCtr->u.i);
+  break;
+}
 #endif
 
 /* Opcode: CountIndexRange P1 P2 P3 P4 *

--- a/src/vdbe.c
+++ b/src/vdbe.c
@@ -20,6 +20,10 @@
 */
 #include "sqliteInt.h"
 #include "vdbeInt.h"
+#ifdef DOLTLITE_PROLLY
+#include "chunk_store.h"
+struct ChunkStore *doltliteGetChunkStore(sqlite3 *db);
+#endif
 
 /*
 ** High-resolution hardware timer used for debugging and testing only.
@@ -3912,6 +3916,39 @@ case OP_CountRange: {    /* out2 */
   pOut->u.i = nEntry;
   goto check_for_interrupt;
 }
+
+#ifdef DOLTLITE_PROLLY
+/* Opcode: DoltliteSeqMax P1 P2 * * *
+** Synopsis: r[P1]=max(r[P1], chunkStoreGetSequenceValue(r[P2]))
+**
+** Doltlite-only. Consult the per-database shared AUTOINCREMENT counter
+** for the table name in register P2 and raise the value in register P1
+** (the autoinc max-rowid register) to at least that value. This is how
+** branches see each other's allocations without sharing sqlite_sequence
+** itself — the counter lives in ChunkRefs.aSequences, not in any
+** branch's working set.
+*/
+case OP_DoltliteSeqMax: {
+  Mem *pCtr;
+  Mem *pName;
+  ChunkStore *pCs;
+  const char *zName;
+  i64 globalSeq;
+  pCtr  = &aMem[pOp->p1];
+  pName = &aMem[pOp->p2];
+  if( (pName->flags & MEM_Str)==0 ) break;
+  pCs = doltliteGetChunkStore(db);
+  if( !pCs ) break;
+  zName = (const char*)pName->z;
+  if( !zName ) break;
+  globalSeq = chunkStoreGetSequenceValue(pCs, zName);
+  if( (pCtr->flags & MEM_Int)==0 || globalSeq > pCtr->u.i ){
+    pCtr->flags = MEM_Int;
+    pCtr->u.i = globalSeq;
+  }
+  break;
+}
+#endif
 
 /* Opcode: CountIndexRange P1 P2 P3 P4 *
 ** Synopsis: r[P2]=count_index_range(r[P3]..r[P3+P4])

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -1208,8 +1208,17 @@ static void run_chunk_walk_corruption(void){
       0, 0, 0, 0,
       0, 0, 0, 0
     };
-    static const u8 currentRefsV6[] = {
+    static const u8 legacyRefsV6[] = {
       6,
+      0, 0, 0, 0,
+      0, 0, 0, 0,
+      0, 0, 0, 0,
+      0, 0, 0, 0,
+      0, 0, 0, 0
+    };
+    static const u8 currentRefsV7[] = {
+      7,
+      0, 0, 0, 0,
       0, 0, 0, 0,
       0, 0, 0, 0,
       0, 0, 0, 0,
@@ -1219,9 +1228,12 @@ static void run_chunk_walk_corruption(void){
     rc = doltliteEnumerateChunkChildren(legacyRefsV5,
                                         (int)sizeof(legacyRefsV5), 0, 0);
     check("legacy_refs_v5_is_corrupt_to_chunk_walk", rc==SQLITE_CORRUPT);
-    rc = doltliteEnumerateChunkChildren(currentRefsV6,
-                                        (int)sizeof(currentRefsV6), 0, 0);
-    check("current_refs_v6_is_accepted_by_chunk_walk", rc==SQLITE_OK);
+    rc = doltliteEnumerateChunkChildren(legacyRefsV6,
+                                        (int)sizeof(legacyRefsV6), 0, 0);
+    check("legacy_refs_v6_is_corrupt_to_chunk_walk", rc==SQLITE_CORRUPT);
+    rc = doltliteEnumerateChunkChildren(currentRefsV7,
+                                        (int)sizeof(currentRefsV7), 0, 0);
+    check("current_refs_v7_is_accepted_by_chunk_walk", rc==SQLITE_OK);
   }
 }
 

--- a/test/remote_test.sh
+++ b/test/remote_test.sh
@@ -632,6 +632,54 @@ hop_b
 hop_a_again" "$result"
 
 # ============================================================
+echo "=== 26. Shared AUTOINCREMENT across clones ==="
+# ============================================================
+"$DB" "$TMPDIR/ai_a.db" <<ENDSQL
+CREATE TABLE seq(id INTEGER PRIMARY KEY AUTOINCREMENT, v TEXT);
+INSERT INTO seq(v) VALUES('a'),('b');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','init');
+SELECT dolt_remote('add','origin','$R/ai_remote.db');
+SELECT dolt_push('origin','main');
+.quit
+ENDSQL
+
+result=$("$DB" "$TMPDIR/ai_b.db" "SELECT dolt_clone('$R/ai_remote.db');")
+check "ai B clone ok" "0" "$result"
+
+# B sees that 1,2 are taken — its next insert should be 3.
+"$DB" "$TMPDIR/ai_b.db" <<'ENDSQL'
+INSERT INTO seq(v) VALUES('c');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','from B');
+SELECT dolt_push('origin','main');
+.quit
+ENDSQL
+
+result=$("$DB" "$TMPDIR/ai_b.db" "SELECT id || '|' || v FROM seq ORDER BY id;")
+check "B continues from shared counter (1,2,3)" "1|a
+2|b
+3|c" "$result"
+
+# A pulls B's commit AND B's counter advance.
+result=$("$DB" "$TMPDIR/ai_a.db" "SELECT dolt_pull('origin','main');")
+check "A pulled B" "0" "$result"
+
+# A's next insert should be 4 — counter merged forward via pull.
+"$DB" "$TMPDIR/ai_a.db" <<'ENDSQL'
+INSERT INTO seq(v) VALUES('d');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','from A');
+.quit
+ENDSQL
+
+result=$("$DB" "$TMPDIR/ai_a.db" "SELECT id || '|' || v FROM seq ORDER BY id;")
+check "A continues from pulled counter (1,2,3,4)" "1|a
+2|b
+3|c
+4|d" "$result"
+
+# ============================================================
 echo ""
 echo "======================================="
 echo "Results: $pass passed, $fail failed"

--- a/test/vc_oracle_autoinc_test.sh
+++ b/test/vc_oracle_autoinc_test.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+
+set -u
+set -o pipefail
+
+DOLTLITE="${1:-./doltlite}"
+DOLT="${2:-dolt}"
+TMPROOT=$(mktemp -d)
+trap "rm -rf $TMPROOT" EXIT
+pass=0; fail=0
+FAILED_NAMES=""
+source "$(dirname "$0")/lib/vc_oracle_common.sh"
+
+normalize() { tr -d '\r'; }
+
+translate_autoinc_for_dolt() {
+  printf '%s\n' "$1" | sed -E 's/AUTOINCREMENT/AUTO_INCREMENT/g'
+}
+
+oracle() {
+  local name="$1" setup="$2" query="$3"
+  local dir="$TMPROOT/$name"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  printf '%s\n' "$setup" | "$DOLTLITE" "$dir/dl/db" >/dev/null 2>"$dir/dl.err"
+  local dl_out
+  dl_out=$(printf ".headers off\n.mode list\n.separator '\t'\n%s;\n" "$query" \
+           | "$DOLTLITE" "$dir/dl/db" 2>>"$dir/dl.err" \
+           | normalize)
+
+  local dolt_setup
+  dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
+  dolt_setup=$(translate_autoinc_for_dolt "$dolt_setup")
+
+  local dt_out
+  dt_out=$(
+    cd "$dir/dt" || exit 1
+    vc_oracle_init_repo
+    printf '%s\n' "$dolt_setup" | "$DOLT" sql >/dev/null 2>"$dir/dt.err"
+    "$DOLT" sql -r csv -q "$query;" 2>>"$dir/dt.err" \
+      | tail -n +2 \
+      | tr ',' '\t' \
+      | tr -d '"' \
+      | normalize
+  )
+
+  vc_oracle_assert_match "$name" "$dl_out" "$dt_out"
+}
+
+# Single-branch baseline: ordinary AUTOINCREMENT still produces 1,2,3.
+oracle single_branch \
+"CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT, v TEXT);
+INSERT INTO t(v) VALUES('a'),('b'),('c');
+SELECT dolt_commit('-A','-m','init');" \
+"SELECT id, v FROM t ORDER BY id"
+
+# Cross-branch counter: feat allocates 3,4; back on main, next ids are 5,6 (not 3,4).
+oracle cross_branch_then_main \
+"CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT, v TEXT);
+INSERT INTO t(v) VALUES('a'),('b');
+SELECT dolt_commit('-A','-m','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO t(v) VALUES('feat3'),('feat4');
+SELECT dolt_commit('-A','-m','feat');
+SELECT dolt_checkout('main');
+INSERT INTO t(v) VALUES('main3'),('main4');
+SELECT dolt_commit('-A','-m','main');" \
+"SELECT id, v FROM t ORDER BY id"
+
+# Merge after cross-branch inserts: 6 distinct ids, no duplicate-pk conflict.
+oracle merge_after_cross_branch \
+"CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT, v TEXT);
+INSERT INTO t(v) VALUES('a'),('b');
+SELECT dolt_commit('-A','-m','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO t(v) VALUES('feat3'),('feat4');
+SELECT dolt_commit('-A','-m','feat');
+SELECT dolt_checkout('main');
+INSERT INTO t(v) VALUES('main3'),('main4');
+SELECT dolt_commit('-A','-m','main');
+SELECT dolt_merge('feat');" \
+"SELECT id, v FROM t ORDER BY id"
+
+# After merge, the next insert continues past the merged max.
+oracle insert_after_merge \
+"CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT, v TEXT);
+INSERT INTO t(v) VALUES('a'),('b');
+SELECT dolt_commit('-A','-m','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO t(v) VALUES('feat3'),('feat4');
+SELECT dolt_commit('-A','-m','feat');
+SELECT dolt_checkout('main');
+INSERT INTO t(v) VALUES('main3'),('main4');
+SELECT dolt_commit('-A','-m','main');
+SELECT dolt_merge('feat');
+INSERT INTO t(v) VALUES('post');" \
+"SELECT id, v FROM t ORDER BY id"
+
+# Two tables share neither counter nor name; each advances independently.
+oracle two_tables_independent \
+"CREATE TABLE a(id INTEGER PRIMARY KEY AUTOINCREMENT, v TEXT);
+CREATE TABLE b(id INTEGER PRIMARY KEY AUTOINCREMENT, v TEXT);
+INSERT INTO a(v) VALUES('a1'),('a2');
+INSERT INTO b(v) VALUES('b1');
+SELECT dolt_commit('-A','-m','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO a(v) VALUES('a3');
+INSERT INTO b(v) VALUES('b2'),('b3');
+SELECT dolt_commit('-A','-m','feat');
+SELECT dolt_checkout('main');
+INSERT INTO a(v) VALUES('a-post');
+INSERT INTO b(v) VALUES('b-post');" \
+"SELECT 'a' AS tbl, id, v FROM a UNION ALL SELECT 'b' AS tbl, id, v FROM b ORDER BY tbl, id"
+
+echo
+echo "vc_oracle_autoinc: $pass passed, $fail failed"
+if [ "$fail" -gt 0 ]; then
+  echo "FAILED:$FAILED_NAMES"
+  exit 1
+fi

--- a/test/vc_oracle_autoinc_test.sh
+++ b/test/vc_oracle_autoinc_test.sh
@@ -135,6 +135,86 @@ INSERT INTO a(v) VALUES('a-post');
 INSERT INTO b(v) VALUES('b-post');" \
 "SELECT 'a' AS tbl, id, v FROM a UNION ALL SELECT 'b' AS tbl, id, v FROM b ORDER BY tbl, id"
 
+# Explicit id above the counter bumps it; the next auto-id continues past.
+oracle explicit_id_jumps_counter \
+"CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT, v TEXT);
+INSERT INTO t(v) VALUES('a');
+INSERT INTO t VALUES(100, 'big');
+INSERT INTO t(v) VALUES('next');" \
+"SELECT id, v FROM t ORDER BY id"
+
+# A bump on feat is visible to main's next insert via the shared counter.
+oracle explicit_id_across_branches \
+"CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT, v TEXT);
+INSERT INTO t(v) VALUES('a');
+SELECT dolt_commit('-A','-m','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES(50, 'feat-big');
+SELECT dolt_commit('-A','-m','feat');
+SELECT dolt_checkout('main');
+INSERT INTO t(v) VALUES('main-next');" \
+"SELECT id, v FROM t ORDER BY id"
+
+# DELETE clears rows but not the counter; next insert continues past the deleted max.
+oracle delete_doesnt_reset_counter \
+"CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT, v TEXT);
+INSERT INTO t(v) VALUES('a'),('b'),('c');
+SELECT dolt_commit('-A','-m','init');
+DELETE FROM t;
+INSERT INTO t(v) VALUES('d');" \
+"SELECT id, v FROM t ORDER BY id"
+
+# Branch-off-branch chain; counter is shared three deep.
+oracle branch_off_branch \
+"CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT, v TEXT);
+INSERT INTO t(v) VALUES('a'),('b');
+SELECT dolt_commit('-A','-m','init');
+SELECT dolt_branch('f1');
+SELECT dolt_checkout('f1');
+INSERT INTO t(v) VALUES('f1a'),('f1b');
+SELECT dolt_commit('-A','-m','f1');
+SELECT dolt_branch('f2');
+SELECT dolt_checkout('f2');
+INSERT INTO t(v) VALUES('f2a');
+SELECT dolt_commit('-A','-m','f2');
+SELECT dolt_checkout('main');
+INSERT INTO t(v) VALUES('m');" \
+"SELECT id, v FROM t ORDER BY id"
+
+# Two feats sequentially branched and sequentially merged: no PK collision because
+# the second feat's insert saw the first feat's advance via the shared counter.
+oracle sequential_merges \
+"CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT, v TEXT);
+INSERT INTO t(v) VALUES('a'),('b');
+SELECT dolt_commit('-A','-m','init');
+SELECT dolt_branch('f1');
+SELECT dolt_checkout('f1');
+INSERT INTO t(v) VALUES('f1a');
+SELECT dolt_commit('-A','-m','f1');
+SELECT dolt_checkout('main');
+SELECT dolt_branch('f2');
+SELECT dolt_checkout('f2');
+INSERT INTO t(v) VALUES('f2a');
+SELECT dolt_commit('-A','-m','f2');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('f1');
+SELECT dolt_merge('f2');
+INSERT INTO t(v) VALUES('post');" \
+"SELECT id, v FROM t ORDER BY id"
+
+# A hard reset drops the second commit but the shared counter persists, so the
+# next insert does not collide with ids the discarded commit allocated.
+oracle reset_hard_keeps_counter \
+"CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT, v TEXT);
+INSERT INTO t(v) VALUES('a'),('b');
+SELECT dolt_commit('-A','-m','first');
+INSERT INTO t(v) VALUES('c'),('d');
+SELECT dolt_commit('-A','-m','second');
+SELECT dolt_reset('--hard','HEAD~1');
+INSERT INTO t(v) VALUES('new');" \
+"SELECT id, v FROM t ORDER BY id"
+
 echo
 echo "vc_oracle_autoinc: $pass passed, $fail failed"
 if [ "$fail" -gt 0 ]; then

--- a/test/vc_oracle_autoinc_test.sh
+++ b/test/vc_oracle_autoinc_test.sh
@@ -99,6 +99,25 @@ SELECT dolt_merge('feat');
 INSERT INTO t(v) VALUES('post');" \
 "SELECT id, v FROM t ORDER BY id"
 
+# DROP+CREATE resets the shared counter so the new table starts from 1.
+oracle drop_create_resets \
+"CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT, v TEXT);
+INSERT INTO t(v) VALUES('a'),('b'),('c');
+SELECT dolt_commit('-A','-m','init');
+DROP TABLE t;
+CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT, v TEXT);
+INSERT INTO t(v) VALUES('x'),('y');" \
+"SELECT id, v FROM t ORDER BY id"
+
+# RENAME carries the counter to the new name; subsequent inserts continue.
+oracle rename_carries_counter \
+"CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT, v TEXT);
+INSERT INTO t(v) VALUES('a'),('b'),('c');
+SELECT dolt_commit('-A','-m','init');
+ALTER TABLE t RENAME TO t2;
+INSERT INTO t2(v) VALUES('d');" \
+"SELECT id, v FROM t2 ORDER BY id"
+
 # Two tables share neither counter nor name; each advances independently.
 oracle two_tables_independent \
 "CREATE TABLE a(id INTEGER PRIMARY KEY AUTOINCREMENT, v TEXT);


### PR DESCRIPTION
## Summary

Fixes #946. doltlite previously kept `sqlite_sequence` per-branch, so two branches could allocate the same AUTOINCREMENT id and a merge would conflict. Dolt shares the counter across branches within a database; this PR matches that behavior.

- New `SequenceRef` entries in `ChunkRefs` — non-versioned, alongside branches/tags/remotes/tracking
- VDBE opcodes `OP_DoltliteSeq{Max,Bump,Drop,Rename}` consult/update the shared counter, emitted from `insert.c` (`autoincBegin`/`autoIncrementEnd`), `build.c` (DROP TABLE), and `alter.c` (RENAME)
- Three-way merge takes ours for `sqlite_sequence` rows (counter authority lives in `aSequences`, not in any branch's working set)
- Push/fetch merge `aSequences` (max per table); clone gets them for free via the v7 refs blob

## Format bump (0.11.0, no back-compat)

Manifest goes v6 → v7. Older databases cannot be read by this build — per direction, "format bump for this 0.11.0, delete the old way of doing it and roll forward."

## Known gap

Two clones that diverge without syncing can each allocate the same id (the counter is shared per-database, not globally). Push/pull/clone keep them in sync; disconnected operation does not.

## Test plan

- [x] `vc_oracle_autoinc_test.sh` — 7 cases compared against the real `dolt` binary: single-branch baseline, cross-branch counter, merge with cross-branch inserts, post-merge insert, DROP+CREATE reset, RENAME carries counter, two-table independence
- [x] `remote_test.sh §26` — A→remote→B→remote→A round-trip with AUTOINCREMENT
- [x] All other `vc_oracle_*` suites still pass (commit/revert failures observed are pre-existing on master — date-normalization issue at UTC midnight)

🤖 Generated with [Claude Code](https://claude.com/claude-code)