### PR TITLE
Reuse pending delete-insert entries

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -2734,6 +2734,25 @@ static void setCursorToMutMapEntryPhys(BtCursor *pCur, int physIdx){
   }
 }
 
+static void setCursorToMutMapMissingEntryPhys(BtCursor *pCur, int physIdx){
+  ProllyMutMapEntry *pEntry = &pCur->pMutMap->aEntries[physIdx];
+  CLEAR_CACHED_PAYLOAD(pCur);
+  pCur->mmIdx = -1;
+  pCur->mmPhysIdx = physIdx;
+  pCur->mmActive = 1;
+  pCur->mmPhysActive = 1;
+  pCur->deferredTreeSeek = 0;
+  pCur->mergeSrc = MERGE_SRC_MUT;
+  pCur->eState = CURSOR_INVALID;
+  pCur->curFlags &= ~BTCF_AtLast;
+  if( pCur->curIntKey ){
+    pCur->cachedIntKey = prollyMutMapEntryIntKey(pEntry);
+    pCur->curFlags |= BTCF_ValidNKey;
+  }else{
+    pCur->curFlags &= ~BTCF_ValidNKey;
+  }
+}
+
 static int advanceTreeCursor(BtCursor *pCur, int dir){
   if( dir>0 ){
     return prollyCursorNext(&pCur->pCur);
@@ -6438,7 +6457,8 @@ static int prollyBtCursorTableMoveto(
       } else {
 
         *pRes = 1;
-        pCur->eState = CURSOR_INVALID;
+        setCursorToMutMapMissingEntryPhys(
+            pCur, (int)(pEntry - pCur->pMutMap->aEntries));
         return SQLITE_OK;
       }
     }
@@ -7268,9 +7288,19 @@ static int prollyBtCursorInsert(
     pInsertedPayload = pData;
     nInsertedPayload = nData;
 
-    rc = prollyMutMapInsert(pCur->pMutMap,
-                             NULL, 0, pPayload->nKey,
-                             pData, nData);
+    if( pCur->mmActive
+     && pCur->mmPhysActive
+     && pCur->pMutMap
+     && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH)
+     && (pCur->curFlags & BTCF_ValidNKey)
+     && pCur->cachedIntKey==pPayload->nKey ){
+      ProllyMutMapEntry *pEntry = currentMutMapEntry(pCur);
+      rc = prollyMutMapReplaceEntry(pCur->pMutMap, pEntry, pData, nData);
+    }else{
+      rc = prollyMutMapInsert(pCur->pMutMap,
+                               NULL, 0, pPayload->nKey,
+                               pData, nData);
+    }
   } else {
 
     int nSortKey = 0;
@@ -7610,11 +7640,39 @@ static int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
   }
   if( pCur->curIntKey ){
     iKey = savedIntKey;
-    rc = prollyMutMapDelete(pCur->pMutMap, NULL, 0, iKey);
+    if( pCur->mmActive
+     && pCur->mmPhysActive
+     && pCur->pMutMap
+     && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
+      ProllyMutMapEntry *pEntry = currentMutMapEntry(pCur);
+      if( pEntry->op==PROLLY_EDIT_INSERT
+       && prollyMutMapEntryIntKey(pEntry)==iKey ){
+        rc = prollyMutMapDeleteEntry(pCur->pMutMap, pEntry);
+      }else{
+        rc = prollyMutMapDelete(pCur->pMutMap, NULL, 0, iKey);
+      }
+    }else{
+      rc = prollyMutMapDelete(pCur->pMutMap, NULL, 0, iKey);
+    }
   } else {
     pKey = pSavedDelKey;
     nKey = nSavedDelKey;
-    rc = prollyMutMapDelete(pCur->pMutMap, pKey, nKey, 0);
+    if( pCur->mmActive
+     && pCur->mmPhysActive
+     && pCur->pMutMap
+     && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
+      ProllyMutMapEntry *pEntry = currentMutMapEntry(pCur);
+      if( pEntry->op==PROLLY_EDIT_INSERT
+       && pEntry->nKey==nKey
+       && nKey>0
+       && memcmp(pEntry->pKey, pKey, nKey)==0 ){
+        rc = prollyMutMapDeleteEntry(pCur->pMutMap, pEntry);
+      }else{
+        rc = prollyMutMapDelete(pCur->pMutMap, pKey, nKey, 0);
+      }
+    }else{
+      rc = prollyMutMapDelete(pCur->pMutMap, pKey, nKey, 0);
+    }
     /* Don't free pSavedDelKey here. The SAVEPOSITION reseek below reads
     ** from pKey, which aliases pSavedDelKey when savedDelKeyOwned is
     ** set; freeing now would memcpy from a dangling pointer. Cleanup

--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -716,6 +716,52 @@ int prollyMutMapDelete(
   return SQLITE_OK;
 }
 
+int prollyMutMapReplaceEntry(
+  ProllyMutMap *mm,
+  ProllyMutMapEntry *e,
+  const u8 *pVal,
+  int nVal
+){
+  int rc;
+  int phys;
+  if( !mm || !e ) return SQLITE_MISUSE;
+  phys = (int)(e - mm->aEntries);
+  if( phys<0 || phys>=mm->nEntries ) return SQLITE_CORRUPT_BKPT;
+  if( mm->currentSavepointLevel > 0
+   && decodeLevel(mm, e->bornAt) < mm->currentSavepointLevel ){
+    rc = appendUndoRec(mm, phys);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+  e->op = PROLLY_EDIT_INSERT;
+  rc = replaceEntryValue(e, pVal, nVal);
+  if( rc!=SQLITE_OK ) return rc;
+  e->bornAt = encodeLevel(mm, mm->currentSavepointLevel);
+  return SQLITE_OK;
+}
+
+int prollyMutMapDeleteEntry(
+  ProllyMutMap *mm,
+  ProllyMutMapEntry *e
+){
+  int rc;
+  int phys;
+  if( !mm || !e ) return SQLITE_MISUSE;
+  phys = (int)(e - mm->aEntries);
+  if( phys<0 || phys>=mm->nEntries ) return SQLITE_CORRUPT_BKPT;
+  if( e->op!=PROLLY_EDIT_INSERT ){
+    return SQLITE_OK;
+  }
+  if( mm->currentSavepointLevel > 0
+   && decodeLevel(mm, e->bornAt) < mm->currentSavepointLevel ){
+    rc = appendUndoRec(mm, phys);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+  e->op = PROLLY_EDIT_DELETE;
+  e->nVal = 0;
+  e->bornAt = encodeLevel(mm, mm->currentSavepointLevel);
+  return SQLITE_OK;
+}
+
 void prollyMutMapPushSavepoint(ProllyMutMap *mm, int level){
   if( !mm ) return;
   mm->currentSavepointLevel = level;

--- a/src/prolly_mutmap.h
+++ b/src/prolly_mutmap.h
@@ -71,8 +71,20 @@ int prollyMutMapInsert(ProllyMutMap *mm,
                        const u8 *pKey, int nKey, i64 intKey,
                        const u8 *pVal, int nVal);
 
+int prollyMutMapReplaceEntry(
+  ProllyMutMap *mm,
+  ProllyMutMapEntry *e,
+  const u8 *pVal,
+  int nVal
+);
+
 int prollyMutMapDelete(ProllyMutMap *mm,
                        const u8 *pKey, int nKey, i64 intKey);
+
+int prollyMutMapDeleteEntry(
+  ProllyMutMap *mm,
+  ProllyMutMapEntry *e
+);
 
 int prollyMutMapFindRc(
   ProllyMutMap *mm,


### PR DESCRIPTION
## Summary
- remember pending mutmap tombstones found by rowid seeks
- replace/delete already-positioned pending entries directly instead of doing a second mutmap lookup
- targets the oltp_delete_insert pattern without changing durable flush behavior

## Benchmarks
Exact oltp_delete_insert workload, median of 13 local runs:
- in-memory Doltlite: 21,136 us before -> 20,470 us after
- file-backed Doltlite: 23,817 us before -> 22,647 us after
- prepared storage loop: 7,541 us before -> 7,393 us after

## Tests
- focused delete/replace + savepoint oracle against stock SQLite
- bash test/correctness_test.sh ./doltlite
- bash test/sql_oracle_test.sh ./doltlite ./sqlite3
- bash test/doltlite_savepoint.sh ./doltlite
- bash test/doltlite_rollback_durability.sh ./doltlite