### PR TITLE
Optimize sysbench read-write mutmap paths

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -2890,6 +2890,8 @@ static int saveCursorPosition(BtCursor *pCur){
     return SQLITE_OK;
   }
 
+  CLEAR_CACHED_PAYLOAD(pCur);
+
   if( !prollyCursorIsValid(&pCur->pCur) ){
     if( pCur->curIntKey && (pCur->curFlags & BTCF_ValidNKey) ){
 
@@ -7127,10 +7129,16 @@ static void getCursorPayload(BtCursor *pCur, const u8 **ppData, int *pnData){
     ProllyMutMapEntry *e = currentMutMapEntry(pCur);
     if( pCur->curIntKey ){
 
+      pCur->pCachedPayload = e->pVal;
+      pCur->nCachedPayload = e->nVal;
+      pCur->cachedPayloadOwned = 0;
       *ppData = e->pVal;
       *pnData = e->nVal;
     }else{
       if( e->nVal > 0 && e->pVal ){
+        pCur->pCachedPayload = e->pVal;
+        pCur->nCachedPayload = e->nVal;
+        pCur->cachedPayloadOwned = 0;
         *ppData = e->pVal;
         *pnData = e->nVal;
       }else{
@@ -7148,6 +7156,11 @@ static void getCursorPayload(BtCursor *pCur, const u8 **ppData, int *pnData){
 
   if( pCur->curIntKey ){
     cursorCurrentTreeValue(pCur, ppData, pnData);
+    if( *pnData > 0 ){
+      pCur->pCachedPayload = (u8*)*ppData;
+      pCur->nCachedPayload = *pnData;
+      pCur->cachedPayloadOwned = 0;
+    }
   }else{
 
     const u8 *pVal; int nVal;

--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -477,29 +477,26 @@ static int ensureCapacity(ProllyMutMap *mm){
     ProllyMutMapEntry *aNew;
     int *aOrderNew;
     int *aPosNew;
-    aNew = sqlite3_malloc(nNew * sizeof(ProllyMutMapEntry));
-    aOrderNew = sqlite3_malloc(nNew * sizeof(int));
-    aPosNew = sqlite3_malloc(nNew * sizeof(int));
-    if( !aNew || !aOrderNew || !aPosNew ){
-      sqlite3_free(aNew);
-      sqlite3_free(aOrderNew);
-      sqlite3_free(aPosNew);
+    aNew = sqlite3_realloc(mm->aEntries, nNew * sizeof(ProllyMutMapEntry));
+    if( !aNew ){
       return SQLITE_NOMEM;
     }
-    if( mm->nEntries > 0 ){
+    if( aNew != mm->aEntries && mm->nEntries > 0 ){
       int i;
-      memcpy(aNew, mm->aEntries, mm->nEntries * sizeof(ProllyMutMapEntry));
-      memcpy(aOrderNew, mm->aOrder, mm->nEntries * sizeof(int));
-      memcpy(aPosNew, mm->aPos, mm->nEntries * sizeof(int));
       for(i=0; i<mm->nEntries; i++){
         fixInlineKeyPtr(&aNew[i]);
       }
     }
-    sqlite3_free(mm->aEntries);
-    sqlite3_free(mm->aOrder);
-    sqlite3_free(mm->aPos);
     mm->aEntries = aNew;
+    aOrderNew = sqlite3_realloc(mm->aOrder, nNew * sizeof(int));
+    if( !aOrderNew ){
+      return SQLITE_NOMEM;
+    }
     mm->aOrder = aOrderNew;
+    aPosNew = sqlite3_realloc(mm->aPos, nNew * sizeof(int));
+    if( !aPosNew ){
+      return SQLITE_NOMEM;
+    }
     mm->aPos = aPosNew;
     mm->nAlloc = nNew;
   }


### PR DESCRIPTION
## Summary
- cache cursor payloads for mutmap entries and int-key tree rows during merged scans
- clear cached payloads before saving cursor positions so cached mutmap/tree pointers are not reused after reseek
- grow mutmap arrays with realloc and repair inline-key pointers when the entry array moves

## Benchmark
Local oltp_read_write A/B on this machine:
- master prepared median: 31.7 ms
- patch prepared median: 30.5 ms
- master script :memory: median: 43126 us
- patch script :memory: median: 41668 us
- master script file median: 44853 us
- patch script file median: 44183 us

## Tests
- bash test/correctness_test.sh ./doltlite
- bash test/sql_oracle_test.sh ./doltlite ./sqlite3
- bash test/doltlite_savepoint.sh ./doltlite
- bash test/doltlite_rollback_durability.sh ./doltlite
- ./oom_dolt_fault_test