### PR TITLE
Avoid redundant mutmap iterator ordering checks

### DIFF
--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -964,7 +964,6 @@ int prollyMutMapIterValid(ProllyMutMapIter *it){
 }
 
 ProllyMutMapEntry *prollyMutMapIterEntry(ProllyMutMapIter *it){
-  ensureOrder(it->pMap);
   return entryAtOrder(it->pMap, it->idx);
 }
 


### PR DESCRIPTION
## Summary
- avoid re-running mutmap order validation for every iterator entry access
- iterator positioning APIs already establish ordering before iteration
- reduces hot-loop work in prolly mutation flushes, especially random secondary-index inserts

## Benchmark
Target: next autocommit benchmark after bulk insert, `oltp_insert_ac`.

Local file-backed autocommit timings are noisy due to fsync outliers:
- master `oltp_insert_ac` median: 35,913 us
- patched `oltp_insert_ac` median: 30,931 us on first pass; repeat was noisy at 40,071 us

CPU-side `:memory:` signal for the same SQL shape:
- master median: 9,049 us
- patched median: 8,815 us

`oltp_bulk_insert_ac` was already faster than SQLite locally and did not need a separate change.

## Tests
- `bash test/correctness_test.sh ./doltlite`
- `bash test/sql_oracle_test.sh ./doltlite ./sqlite3`
- `bash test/doltlite_savepoint.sh ./doltlite`
