### PR TITLE
Scale sysbench fixtures to 100k rows

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,10 +13,10 @@ permissions:
 jobs:
   int-keys:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     env:
-      BENCH_RUNS: 21
+      BENCH_RUNS: 5
 
     steps:
     - uses: actions/checkout@v4
@@ -112,20 +112,35 @@ jobs:
           exit "$rc"
         fi
 
-  # Runs three non-INTKEY sysbench variants (TEXT PK, BLOB PK, composite
-  # PK). Each is gated on both individual ratios and section average
-  # ratios. Individual ceiling is 1.8x after recent write-path perf work
-  # brought the slowest variants comfortably below the previous gates.
-  # BENCH_RUNS=13 (vs int-keys' 21) because each non-INTKEY write is a
-  # per-statement flush and runs slower per iteration.
-  text-blob-comp-keys:
+  # Runs non-INTKEY sysbench variants as separate matrix jobs. At 100k rows
+  # each suite is large enough that running all three serially risks hitting
+  # the job timeout before benchmark results can be posted.
+  non-int-keys:
+    name: ${{ matrix.suite.name }}-keys
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        suite:
+          - name: textpk
+            script: sysbench_compare_textpk.sh
+            output: /tmp/bench_textpk.md
+            marker: '<!-- benchmark:textpk -->'
+          - name: blobpk
+            script: sysbench_compare_blobpk.sh
+            output: /tmp/bench_blobpk.md
+            marker: '<!-- benchmark:blobpk -->'
+          - name: compositepk
+            script: sysbench_compare_compositepk.sh
+            output: /tmp/bench_compositepk.md
+            marker: '<!-- benchmark:compositepk -->'
 
     env:
-      BENCH_RUNS: 13
-      BENCH_MAX_MULTIPLIER: 1.8
-      BENCH_AVG_MAX_MULTIPLIER: 1.5
+      BENCH_RUNS: 5
+      BENCH_MAX_MULTIPLIER: 5
+      BENCH_AVG_MAX_MULTIPLIER: 5
 
     steps:
     - uses: actions/checkout@v4
@@ -154,29 +169,17 @@ jobs:
         make DOLTLITE_PROLLY=0 sqlite3 sqlite3.o
         cc -O2 -I. -I../src -o bench_timer_sqlite ../test/sysbench_timer.c sqlite3.o -lpthread -lz -lm
 
-    - name: Run benchmarks
+    - name: Run benchmark
       id: bench
       run: |
         cd build
-        # Each script enforces the configured individual and average
-        # ceilings; capture rc per script and merge so a single ceiling
-        # break fails the job after the PR-comment step has run.
+        # The script enforces the configured individual and average ceilings;
+        # capture rc separately so results are still posted on a failure.
         set +e
-        bash ../test/sysbench_compare_textpk.sh      > /tmp/bench_textpk.md
-        textpk_rc=$?
-        bash ../test/sysbench_compare_blobpk.sh      > /tmp/bench_blobpk.md
-        blobpk_rc=$?
-        bash ../test/sysbench_compare_compositepk.sh > /tmp/bench_compositepk.md
-        compositepk_rc=$?
+        bash ../test/${{ matrix.suite.script }} > "${{ matrix.suite.output }}"
+        bench_rc=$?
         set -e
-        cat /tmp/bench_textpk.md /tmp/bench_blobpk.md \
-            /tmp/bench_compositepk.md \
-            > /tmp/bench_extra_results.md
-        cat /tmp/bench_extra_results.md
-        bench_rc=0
-        for rc in "$textpk_rc" "$blobpk_rc" "$compositepk_rc"; do
-          if [ "$rc" != "0" ]; then bench_rc=$rc; fi
-        done
+        cat "${{ matrix.suite.output }}"
         echo "bench_rc=$bench_rc" >> "$GITHUB_OUTPUT"
 
     - name: Comment PR with results
@@ -188,26 +191,20 @@ jobs:
           // template-literal-unsafe chars in it) never has to round-trip
           // through YAML scalars or JS template-literal parsing.
           const fs = require('fs');
-          const body = fs.readFileSync('/tmp/bench_extra_results.md', 'utf8');
+          const body = fs.readFileSync('${{ matrix.suite.output }}', 'utf8');
 
           if (!context.issue.number) {
             console.log('No PR context (push event) — skipping comment');
             return;
           }
 
-          // Find existing benchmark-extra comment. Markers used to be
-          // textpk-only; now we look for any of the non-INTKEY markers.
+          const marker = '${{ matrix.suite.marker }}';
           const comments = await github.rest.issues.listComments({
             owner: context.repo.owner,
             repo: context.repo.repo,
             issue_number: context.issue.number,
           });
-          const botComment = comments.data.find(c =>
-            c.body.includes('<!-- benchmark:textpk -->') ||
-            c.body.includes('<!-- benchmark:blobpk -->') ||
-            c.body.includes('<!-- benchmark:compositepk -->') ||
-            c.body.includes('## Sysbench-Style Benchmark (TEXT PK): Doltlite vs SQLite')
-          );
+          const botComment = comments.data.find(c => c.body.includes(marker));
 
           if (botComment) {
             await github.rest.issues.updateComment({

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -395,7 +395,7 @@ jobs:
     - name: Run benchmarks
       run: |
         cd build
-        BENCH_RUNS=21 BENCH_SECTION_MODE=wrapped bash ../test/sysbench_compare.sh > /tmp/bench_classic.md
+        BENCH_RUNS=5 BENCH_SECTION_MODE=wrapped bash ../test/sysbench_compare.sh > /tmp/bench_classic.md
         sed -n '/### File-Backed/,/^_/p' /tmp/bench_classic.md > /tmp/bench_results.md
 
     - name: Upload benchmark results

--- a/test/sysbench_compare.sh
+++ b/test/sysbench_compare.sh
@@ -12,11 +12,11 @@ SQLITE3=${SQLITE3:-./sqlite3}
 BENCH_TIMER_SQLITE=${BENCH_TIMER_SQLITE:-./bench_timer_sqlite}
 BENCH_TIMER_DOLTLITE=${BENCH_TIMER_DOLTLITE:-./bench_timer_doltlite}
 SQLITE_AUTOCOMMIT_PRAGMAS=${SQLITE_AUTOCOMMIT_PRAGMAS:-"PRAGMA journal_mode=WAL; PRAGMA synchronous=FULL;"}
-ROWS=${BENCH_ROWS:-10000}
+ROWS=${BENCH_ROWS:-100000}
 SEED=42
 TMPDIR=$(mktemp -d)
-BENCH_MAX_MULTIPLIER=${BENCH_MAX_MULTIPLIER:-1.8}
-BENCH_AVG_MAX_MULTIPLIER=${BENCH_AVG_MAX_MULTIPLIER:-1.5}
+BENCH_MAX_MULTIPLIER=${BENCH_MAX_MULTIPLIER:-5}
+BENCH_AVG_MAX_MULTIPLIER=${BENCH_AVG_MAX_MULTIPLIER:-5}
 BENCH_SECTION_MODE=${BENCH_SECTION_MODE:-full}
 
 cleanup() { rm -rf "$TMPDIR"; }
@@ -60,14 +60,14 @@ def write_prepare_join(f):
     f.write("CREATE TABLE sbtest2(id INTEGER PRIMARY KEY, k INTEGER NOT NULL DEFAULT 0, c TEXT NOT NULL DEFAULT '', pad TEXT NOT NULL DEFAULT '');\n")
     f.write("CREATE INDEX k_idx2 ON sbtest2(k);\n")
     f.write("BEGIN;\n")
-    for i in range(1, min(R,1000)+1):
+    for i in range(1, R+1):
         f.write(f"INSERT INTO sbtest2 VALUES({i},{rint(1,R)},'{rstr(60)}','{rstr(30)}');\n")
     f.write("COMMIT;\n")
 
 def write_prepare_types(f):
     f.write("CREATE TABLE sbtest_types(id INTEGER PRIMARY KEY, ival INTEGER, rval REAL, tval TEXT);\n")
     f.write("BEGIN;\n")
-    for i in range(1, 1001):
+    for i in range(1, R+1):
         f.write(f"INSERT INTO sbtest_types VALUES({i},{random.randint(-1000000,1000000)},{random.uniform(-1e6,1e6)},'{rstr(50)}');\n")
     f.write("COMMIT;\n")
 
@@ -200,13 +200,13 @@ def w_index_join(f):
 
 def w_index_join_scan(f):
     for _ in range(100):
-        s=rint(1,min(R,950))
+        s=rint(1,max(R-50,1))
         f.write(f"SELECT count(*) FROM sbtest1 a JOIN sbtest2 b ON a.k=b.k WHERE b.id BETWEEN {s} AND {s+49};\n")
 
 def w_types_delete_insert(f):
     f.write("BEGIN;\n")
     for _ in range(5000):
-        id=rint(1,1000)
+        id=rint(1,R)
         f.write(f"DELETE FROM sbtest_types WHERE id={id};\n")
         f.write(f"INSERT OR REPLACE INTO sbtest_types VALUES({id},{random.randint(-1000000,1000000)},{random.uniform(-1e6,1e6)},'{rstr(50)}');\n")
     f.write("COMMIT;\n")
@@ -326,7 +326,7 @@ def w_write_only_autocommit(f):
 def w_types_delete_insert_autocommit(f):
     # 2 statements per iteration; halve the loop.
     for _ in range(AC // 2):
-        id = rint(1, 1000)
+        id = rint(1, R)
         f.write(f"DELETE FROM sbtest_types WHERE id={id};\n")
         f.write(f"INSERT OR REPLACE INTO sbtest_types VALUES({id},{random.randint(-1000000,1000000)},{random.uniform(-1e6,1e6)},'{rstr(50)}');\n")
 
@@ -410,8 +410,8 @@ else:
 }
 
 bench_runs_for_test() {
-  # BENCH_RUNS=1 for fast local iteration; default 11 for stable median.
-  echo "${BENCH_RUNS:-11}"
+  # BENCH_RUNS=1 for fast local iteration; default 5 for stable median.
+  echo "${BENCH_RUNS:-5}"
 }
 
 median_us() {

--- a/test/sysbench_compare_blobpk.sh
+++ b/test/sysbench_compare_blobpk.sh
@@ -7,13 +7,8 @@
 # byte order matches integer order). Companion to the TEXT PK suite —
 # verifies the non-INTKEY perf work generalizes to binary keys.
 #
-# Default row count (BENCH_ROWS) is smaller than the classic suite because
-# every doltlite write here goes through the per-statement non-INTKEY flush
-# path, and full-scale R blows the CI 15-minute budget in the prepare phase
-# alone.
-#
-# Ceiling enforced at BENCH_MAX_MULTIPLIER (default 1.8×) on individual
-# read/write ratios and BENCH_AVG_MAX_MULTIPLIER (default 1.5×) on
+# Ceiling enforced at BENCH_MAX_MULTIPLIER (default 5×) on individual
+# read/write ratios and BENCH_AVG_MAX_MULTIPLIER (default 5×) on
 # section averages.
 #
 set -e
@@ -23,9 +18,9 @@ SQLITE3=${SQLITE3:-./sqlite3}
 BENCH_TIMER_SQLITE=${BENCH_TIMER_SQLITE:-./bench_timer_sqlite}
 BENCH_TIMER_DOLTLITE=${BENCH_TIMER_DOLTLITE:-./bench_timer_doltlite}
 SQLITE_AUTOCOMMIT_PRAGMAS=${SQLITE_AUTOCOMMIT_PRAGMAS:-"PRAGMA journal_mode=WAL; PRAGMA synchronous=FULL;"}
-ROWS=${BENCH_ROWS:-1000}
-BENCH_MAX_MULTIPLIER=${BENCH_MAX_MULTIPLIER:-1.8}
-BENCH_AVG_MAX_MULTIPLIER=${BENCH_AVG_MAX_MULTIPLIER:-1.5}
+ROWS=${BENCH_ROWS:-100000}
+BENCH_MAX_MULTIPLIER=${BENCH_MAX_MULTIPLIER:-5}
+BENCH_AVG_MAX_MULTIPLIER=${BENCH_AVG_MAX_MULTIPLIER:-5}
 SEED=42
 TMPDIR=$(mktemp -d)
 
@@ -77,14 +72,14 @@ def write_prepare_join(f):
     f.write("CREATE TABLE sbtest2(id BLOB PRIMARY KEY, k INTEGER NOT NULL DEFAULT 0, c TEXT NOT NULL DEFAULT '', pad TEXT NOT NULL DEFAULT '');\n")
     f.write("CREATE INDEX k_idx2 ON sbtest2(k);\n")
     f.write("BEGIN;\n")
-    for i in range(1, min(R,1000)+1):
+    for i in range(1, R+1):
         f.write(f"INSERT INTO sbtest2 VALUES({hk(i)},{rint(1,R)},'{rstr(60)}','{rstr(30)}');\n")
     f.write("COMMIT;\n")
 
 def write_prepare_types(f):
     f.write("CREATE TABLE sbtest_types(id INTEGER PRIMARY KEY, ival INTEGER, rval REAL, tval TEXT);\n")
     f.write("BEGIN;\n")
-    for i in range(1, min(R,1000)+1):
+    for i in range(1, R+1):
         f.write(f"INSERT INTO sbtest_types VALUES({i},{random.randint(-1000000,1000000)},{random.uniform(-1e6,1e6)},'{rstr(50)}');\n")
     f.write("COMMIT;\n")
 
@@ -221,13 +216,13 @@ def w_index_join(f):
 
 def w_index_join_scan(f):
     for _ in range(100):
-        s=rint(1,min(R,950))
+        s=rint(1,max(R-50,1))
         f.write(f"SELECT count(*) FROM sbtest1 a JOIN sbtest2 b ON a.k=b.k WHERE b.id BETWEEN {hk(s)} AND {hk(s+49)};\n")
 
 def w_types_delete_insert(f):
     f.write("BEGIN;\n")
     for _ in range(5000):
-        id=rint(1,min(R,1000))
+        id=rint(1,R)
         f.write(f"DELETE FROM sbtest_types WHERE id={id};\n")
         f.write(f"INSERT OR REPLACE INTO sbtest_types VALUES({id},{random.randint(-1000000,1000000)},{random.uniform(-1e6,1e6)},'{rstr(50)}');\n")
     f.write("COMMIT;\n")
@@ -347,7 +342,7 @@ def w_write_only_autocommit(f):
 def w_types_delete_insert_autocommit(f):
     # 2 statements per iteration; halve the loop.
     for _ in range(AC // 2):
-        id = rint(1, min(R, 1000))
+        id = rint(1, R)
         f.write(f"DELETE FROM sbtest_types WHERE id={id};\n")
         f.write(f"INSERT OR REPLACE INTO sbtest_types VALUES({id},{random.randint(-1000000,1000000)},{random.uniform(-1e6,1e6)},'{rstr(50)}');\n")
 

--- a/test/sysbench_compare_compositepk.sh
+++ b/test/sysbench_compare_compositepk.sh
@@ -10,13 +10,8 @@
 # Logical id i is split as (a, b) = (i // 10000, i %% 10000) so lex (a,b)
 # tuple ordering matches integer ordering for any R below 10**8.
 #
-# Default row count (BENCH_ROWS) is smaller than the classic suite because
-# every doltlite write here goes through the per-statement non-INTKEY flush
-# path, and full-scale R blows the CI 15-minute budget in the prepare phase
-# alone.
-#
-# Ceiling enforced at BENCH_MAX_MULTIPLIER (default 1.8×) on individual
-# read/write ratios and BENCH_AVG_MAX_MULTIPLIER (default 1.5×) on
+# Ceiling enforced at BENCH_MAX_MULTIPLIER (default 5×) on individual
+# read/write ratios and BENCH_AVG_MAX_MULTIPLIER (default 5×) on
 # section averages.
 #
 set -e
@@ -26,9 +21,9 @@ SQLITE3=${SQLITE3:-./sqlite3}
 BENCH_TIMER_SQLITE=${BENCH_TIMER_SQLITE:-./bench_timer_sqlite}
 BENCH_TIMER_DOLTLITE=${BENCH_TIMER_DOLTLITE:-./bench_timer_doltlite}
 SQLITE_AUTOCOMMIT_PRAGMAS=${SQLITE_AUTOCOMMIT_PRAGMAS:-"PRAGMA journal_mode=WAL; PRAGMA synchronous=FULL;"}
-ROWS=${BENCH_ROWS:-1000}
-BENCH_MAX_MULTIPLIER=${BENCH_MAX_MULTIPLIER:-1.8}
-BENCH_AVG_MAX_MULTIPLIER=${BENCH_AVG_MAX_MULTIPLIER:-1.5}
+ROWS=${BENCH_ROWS:-100000}
+BENCH_MAX_MULTIPLIER=${BENCH_MAX_MULTIPLIER:-5}
+BENCH_AVG_MAX_MULTIPLIER=${BENCH_AVG_MAX_MULTIPLIER:-5}
 SEED=42
 TMPDIR=$(mktemp -d)
 
@@ -61,8 +56,7 @@ def rstr(n):
     return ''.join(random.choices(string.ascii_lowercase, k=n))
 
 # Split an integer i into (a, b) where (a, b) tuple-compares the same
-# as i. With B=10000, this works for any R < 10**8 (we never go past
-# the CI's BENCH_ROWS=1000 default).
+# as i. With B=10000, this works for any R < 10**8.
 B = 10000
 def parts(i):
     return (i // B, i % B)
@@ -95,14 +89,14 @@ def write_prepare_join(f):
     f.write("CREATE TABLE sbtest2(a INTEGER NOT NULL, b INTEGER NOT NULL, k INTEGER NOT NULL DEFAULT 0, c TEXT NOT NULL DEFAULT '', pad TEXT NOT NULL DEFAULT '', PRIMARY KEY(a,b)) WITHOUT ROWID;\n")
     f.write("CREATE INDEX k_idx2 ON sbtest2(k);\n")
     f.write("BEGIN;\n")
-    for i in range(1, min(R,1000)+1):
+    for i in range(1, R+1):
         f.write(f"INSERT INTO sbtest2 VALUES({kvals(i)},{rint(1,R)},'{rstr(60)}','{rstr(30)}');\n")
     f.write("COMMIT;\n")
 
 def write_prepare_types(f):
     f.write("CREATE TABLE sbtest_types(id INTEGER PRIMARY KEY, ival INTEGER, rval REAL, tval TEXT);\n")
     f.write("BEGIN;\n")
-    for i in range(1, min(R,1000)+1):
+    for i in range(1, R+1):
         f.write(f"INSERT INTO sbtest_types VALUES({i},{random.randint(-1000000,1000000)},{random.uniform(-1e6,1e6)},'{rstr(50)}');\n")
     f.write("COMMIT;\n")
 
@@ -241,14 +235,14 @@ def w_index_join(f):
 
 def w_index_join_scan(f):
     for _ in range(100):
-        s=rint(1,min(R,950))
+        s=rint(1,max(R-50,1))
         sa,sb=parts(s); ea,eb=parts(s+49)
         f.write(f"SELECT count(*) FROM sbtest1 a JOIN sbtest2 b ON a.k=b.k WHERE (b.a,b.b) BETWEEN ({sa},{sb}) AND ({ea},{eb});\n")
 
 def w_types_delete_insert(f):
     f.write("BEGIN;\n")
     for _ in range(5000):
-        id=rint(1,min(R,1000))
+        id=rint(1,R)
         f.write(f"DELETE FROM sbtest_types WHERE id={id};\n")
         f.write(f"INSERT OR REPLACE INTO sbtest_types VALUES({id},{random.randint(-1000000,1000000)},{random.uniform(-1e6,1e6)},'{rstr(50)}');\n")
     f.write("COMMIT;\n")
@@ -368,7 +362,7 @@ def w_write_only_autocommit(f):
 def w_types_delete_insert_autocommit(f):
     # 2 statements per iteration; halve the loop.
     for _ in range(AC // 2):
-        id = rint(1, min(R, 1000))
+        id = rint(1, R)
         f.write(f"DELETE FROM sbtest_types WHERE id={id};\n")
         f.write(f"INSERT OR REPLACE INTO sbtest_types VALUES({id},{random.randint(-1000000,1000000)},{random.uniform(-1e6,1e6)},'{rstr(50)}');\n")
 

--- a/test/sysbench_compare_textpk.sh
+++ b/test/sysbench_compare_textpk.sh
@@ -6,13 +6,8 @@
 # tables with a 32-char hex TEXT PRIMARY KEY (UUID-shaped). Surfaces the
 # non-INTKEY mutmap-flush cost; companion to issue #718's followup work.
 #
-# Default row count (BENCH_ROWS) is smaller than the classic suite because
-# every doltlite write here goes through the per-statement non-INTKEY flush
-# path, and full-scale R blows the CI 15-minute budget in the prepare phase
-# alone.
-#
-# Ceiling enforced at BENCH_MAX_MULTIPLIER (default 1.8×) on individual
-# read/write ratios and BENCH_AVG_MAX_MULTIPLIER (default 1.5×) on
+# Ceiling enforced at BENCH_MAX_MULTIPLIER (default 5×) on individual
+# read/write ratios and BENCH_AVG_MAX_MULTIPLIER (default 5×) on
 # section averages.
 #
 set -e
@@ -22,9 +17,9 @@ SQLITE3=${SQLITE3:-./sqlite3}
 BENCH_TIMER_SQLITE=${BENCH_TIMER_SQLITE:-./bench_timer_sqlite}
 BENCH_TIMER_DOLTLITE=${BENCH_TIMER_DOLTLITE:-./bench_timer_doltlite}
 SQLITE_AUTOCOMMIT_PRAGMAS=${SQLITE_AUTOCOMMIT_PRAGMAS:-"PRAGMA journal_mode=WAL; PRAGMA synchronous=FULL;"}
-ROWS=${BENCH_ROWS:-1000}
-BENCH_MAX_MULTIPLIER=${BENCH_MAX_MULTIPLIER:-1.8}
-BENCH_AVG_MAX_MULTIPLIER=${BENCH_AVG_MAX_MULTIPLIER:-1.5}
+ROWS=${BENCH_ROWS:-100000}
+BENCH_MAX_MULTIPLIER=${BENCH_MAX_MULTIPLIER:-5}
+BENCH_AVG_MAX_MULTIPLIER=${BENCH_AVG_MAX_MULTIPLIER:-5}
 SEED=42
 TMPDIR=$(mktemp -d)
 
@@ -77,14 +72,14 @@ def write_prepare_join(f):
     f.write("CREATE TABLE sbtest2(id TEXT PRIMARY KEY, k INTEGER NOT NULL DEFAULT 0, c TEXT NOT NULL DEFAULT '', pad TEXT NOT NULL DEFAULT '');\n")
     f.write("CREATE INDEX k_idx2 ON sbtest2(k);\n")
     f.write("BEGIN;\n")
-    for i in range(1, min(R,1000)+1):
+    for i in range(1, R+1):
         f.write(f"INSERT INTO sbtest2 VALUES('{hk(i)}',{rint(1,R)},'{rstr(60)}','{rstr(30)}');\n")
     f.write("COMMIT;\n")
 
 def write_prepare_types(f):
     f.write("CREATE TABLE sbtest_types(id INTEGER PRIMARY KEY, ival INTEGER, rval REAL, tval TEXT);\n")
     f.write("BEGIN;\n")
-    for i in range(1, min(R,1000)+1):
+    for i in range(1, R+1):
         f.write(f"INSERT INTO sbtest_types VALUES({i},{random.randint(-1000000,1000000)},{random.uniform(-1e6,1e6)},'{rstr(50)}');\n")
     f.write("COMMIT;\n")
 
@@ -221,13 +216,13 @@ def w_index_join(f):
 
 def w_index_join_scan(f):
     for _ in range(100):
-        s=rint(1,min(R,950))
+        s=rint(1,max(R-50,1))
         f.write(f"SELECT count(*) FROM sbtest1 a JOIN sbtest2 b ON a.k=b.k WHERE b.id BETWEEN '{hk(s)}' AND '{hk(s+49)}';\n")
 
 def w_types_delete_insert(f):
     f.write("BEGIN;\n")
     for _ in range(5000):
-        id=rint(1,min(R,1000))
+        id=rint(1,R)
         f.write(f"DELETE FROM sbtest_types WHERE id={id};\n")
         f.write(f"INSERT OR REPLACE INTO sbtest_types VALUES({id},{random.randint(-1000000,1000000)},{random.uniform(-1e6,1e6)},'{rstr(50)}');\n")
     f.write("COMMIT;\n")
@@ -347,7 +342,7 @@ def w_write_only_autocommit(f):
 def w_types_delete_insert_autocommit(f):
     # 2 statements per iteration; halve the loop.
     for _ in range(AC // 2):
-        id = rint(1, min(R, 1000))
+        id = rint(1, R)
         f.write(f"DELETE FROM sbtest_types WHERE id={id};\n")
         f.write(f"INSERT OR REPLACE INTO sbtest_types VALUES({id},{random.randint(-1000000,1000000)},{random.uniform(-1e6,1e6)},'{rstr(50)}');\n")
 


### PR DESCRIPTION
## Summary
- make the classic sysbench default row count 100,000
- make TEXT/BLOB/composite PK sysbench defaults match at 100,000 rows
- remove 1,000-row caps from join helper tables and `sbtest_types` fixtures so every benchmark table scales with `BENCH_ROWS`
- reduce benchmark CI samples to 5 for every suite while this is the baseline-before-optimization gate
- split text/blob/composite PK benchmarks into separate matrix jobs and separate PR comments
- set individual and section-average performance ceilings to 5x until the 100k-row path is optimized

## Local timing gauge
One-run, 100k-row probes on a beefy Mac:
- classic wrapped: ~75s
- text PK: ~122s
- blob PK: ~117s
- composite PK: ~112s

With 5 runs:
- int-key job should be materially below the old 21-run timeout pressure
- each non-int-key matrix job should run independently instead of serializing all three suites

## Tests
- `bash -n test/sysbench_compare.sh test/sysbench_compare_textpk.sh test/sysbench_compare_blobpk.sh test/sysbench_compare_compositepk.sh`
- smoke-generated all four scripts with `BENCH_ROWS=10`, `BENCH_RUNS=1`, dummy engines, and timers disabled
- parsed `.github/workflows/benchmark.yml` and `.github/workflows/release.yml` with Ruby YAML
- `git diff --check`
