### PR TITLE
Optimize same-size blob-key replacements

### DIFF
--- a/src/prolly_mutate.c
+++ b/src/prolly_mutate.c
@@ -489,8 +489,8 @@ static int writeBuilderNode(ChunkStore *pStore, ProllyNodeBuilder *pBuilder,
   return rc;
 }
 
-/* Replace one existing int-key row when node boundaries cannot change. */
-static int tryReplaceSingleIntSameSize(ProllyMutator *pMut){
+/* Replace one existing row when node boundaries cannot change. */
+static int tryReplaceSingleSameSize(ProllyMutator *pMut){
   ProllyMutMapEntry *pEdit;
   ProllyCursor cur;
   ProllyHash childHash;
@@ -499,19 +499,25 @@ static int tryReplaceSingleIntSameSize(ProllyMutator *pMut){
   int res = 0;
   int level;
 
-  if( !(pMut->flags & PROLLY_NODE_INTKEY) ) return SQLITE_NOTFOUND;
   if( prollyHashIsEmpty(&pMut->oldRoot) ) return SQLITE_NOTFOUND;
   if( prollyMutMapCount(pMut->pEdits)!=1 ) return SQLITE_NOTFOUND;
 
   pEdit = &pMut->pEdits->aEntries[0];
-  if( pEdit->op!=PROLLY_EDIT_INSERT || pEdit->nKey!=8 ){
+  if( pEdit->op!=PROLLY_EDIT_INSERT ){
+    return SQLITE_NOTFOUND;
+  }
+  if( (pMut->flags & PROLLY_NODE_INTKEY) && pEdit->nKey!=8 ){
     return SQLITE_NOTFOUND;
   }
 
-  iKey = prollyMutMapEntryIntKey(pEdit);
   prollyCursorInit(&cur, pMut->pStore, pMut->pCache, &pMut->oldRoot,
                    pMut->flags);
-  rc = prollyCursorSeekInt(&cur, iKey, &res);
+  if( pMut->flags & PROLLY_NODE_INTKEY ){
+    iKey = prollyMutMapEntryIntKey(pEdit);
+    rc = prollyCursorSeekInt(&cur, iKey, &res);
+  }else{
+    rc = prollyCursorSeekBlob(&cur, pEdit->pKey, pEdit->nKey, &res);
+  }
   if( rc!=SQLITE_OK ){
     prollyCursorClose(&cur);
     return rc;
@@ -827,7 +833,7 @@ int prollyMutateFlush(ProllyMutator *pMut){
   if( prollyHashIsEmpty(&pMut->oldRoot) ){
     rc = buildFromEdits(pMut);
   }else{
-    rc = tryReplaceSingleIntSameSize(pMut);
+    rc = tryReplaceSingleSameSize(pMut);
     if( rc==SQLITE_NOTFOUND ){
       rc = tryAppendSingleIntNoSplit(pMut);
     }


### PR DESCRIPTION
## Summary
- extend the existing same-size single-row replacement fast path to blob-key trees
- avoid falling back to streaming merge when a blob-key update replaces an existing row without changing encoded value size

## Benchmarks
Target from PR #1029 comments: blobpk-keys `oltp_update_index_ac`, which reported Doltlite at 5.03x SQLite.

Local 100k-row file-backed benchmark:
- SQLite median: 9,839 us
- Doltlite before: 42,465 us
- Doltlite after: 38,529 us median over 21 patched runs

Local 100k-row memory benchmark:
- Doltlite before: 16,994 us
- Doltlite after: 15,976 us

## Tests
- `bash test/correctness_test.sh ./doltlite`
- focused blob primary-key indexed update with `PRAGMA integrity_check`
- `bash test/doltlite_savepoint.sh ./doltlite`
- `bash test/doltlite_rollback_durability.sh ./doltlite`