### PR TITLE
Optimize write transaction begin refresh

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -4967,14 +4967,19 @@ static int prollyBtreeBeginTrans(Btree *p, int wrFlag, int *pSchemaVersion){
     return SQLITE_BUSY_SNAPSHOT;
   }
 
-  rc = btreeRefreshFromDisk(p);
-  if( rc!=SQLITE_OK ) return rc;
-  if( p->inTrans==TRANS_NONE ){
+  if( !wrFlag ){
+    rc = btreeRefreshFromDisk(p);
+    if( rc!=SQLITE_OK ) return rc;
+    if( p->inTrans==TRANS_NONE ){
+      rc = btreeRefreshSharedWorkingState(p);
+      if( rc!=SQLITE_OK ) return rc;
+    }
+    if( pSchemaVersion ){
+      *pSchemaVersion = (int)p->aMeta[BTREE_SCHEMA_VERSION];
+    }
+  }else if( p->inTrans==TRANS_NONE ){
     rc = btreeRefreshSharedWorkingState(p);
     if( rc!=SQLITE_OK ) return rc;
-  }
-  if( pSchemaVersion ){
-    *pSchemaVersion = (int)p->aMeta[BTREE_SCHEMA_VERSION];
   }
 
   if( wrFlag ){
@@ -5041,6 +5046,9 @@ static int prollyBtreeBeginTrans(Btree *p, int wrFlag, int *pSchemaVersion){
     }
   }
 
+  if( pSchemaVersion ){
+    *pSchemaVersion = (int)p->aMeta[BTREE_SCHEMA_VERSION];
+  }
   pBt->store.snapshotPinned = 1;
 
   return SQLITE_OK;


### PR DESCRIPTION
## Summary
- avoid the pre-lock disk refresh when beginning a write transaction
- keep the locked `chunkStoreLockAndRefreshChanged()` refresh/check as the authoritative write-path freshness check
- preserve the existing read transaction refresh path

## Notes
This removes duplicated external-change probing on autocommit writes. Local autocommit benchmark runs were noisy, so this is intentionally a narrow transaction-path cleanup rather than a claimed large benchmark win.

## Testing
- `make -j8 doltlite doltlite-lib`
- `make c-tests`
- `../test/run_c_tests.sh .`
  - C gating suite passed: 0 / 12 failures
