### PR TITLE
Optimize single-row prolly mutations

### DIFF
--- a/src/prolly_mutate.c
+++ b/src/prolly_mutate.c
@@ -465,6 +465,40 @@ static int nodeEndsAtChunkBoundary(const ProllyNode *pNode){
   return 0;
 }
 
+static int nodeHasSameChunkShape(const ProllyNode *pNode,
+                                 int requireFinalBoundary){
+  const u8 *pKey, *pVal;
+  int nKey, nVal;
+  int nBytes = 0;
+  int i;
+
+  if( pNode->nItems==0 ) return 0;
+  for(i=0; i<(int)pNode->nItems; i++){
+    int isBoundary = 0;
+    int thisSize;
+
+    prollyNodeKey(pNode, i, &pKey, &nKey);
+    prollyNodeValue(pNode, i, &pVal, &nVal);
+    (void)pVal;
+    thisSize = PROLLY_NODE_ENTRY_BYTES(pNode->level, nKey, nVal);
+    nBytes += thisSize;
+    if( nBytes >= PROLLY_CHUNK_MAX ){
+      isBoundary = 1;
+    }else if( nBytes >= PROLLY_CHUNK_MIN ){
+      u32 h = prollyXXH32(pKey, nKey, (u32)pNode->level);
+      isBoundary = prollyWeibullCheck((u32)nBytes, (u32)thisSize, h);
+    }
+
+    if( i<(int)pNode->nItems - 1 && isBoundary ){
+      return 0;
+    }
+    if( i==(int)pNode->nItems - 1 && requireFinalBoundary && !isBoundary ){
+      return 0;
+    }
+  }
+  return 1;
+}
+
 static int appendNodeEntryToBuilder(
   ProllyNodeBuilder *pBuilder,
   const ProllyNode *pNode,
@@ -491,6 +525,92 @@ static int writeBuilderNode(ChunkStore *pStore, ProllyNodeBuilder *pBuilder,
   rc = chunkStorePut(pStore, pData, nData, pHash);
   sqlite3_free(pData);
   return rc;
+}
+
+static int finishAndWriteBuilderNode(ChunkStore *pStore,
+                                     ProllyNodeBuilder *pBuilder,
+                                     int requireBoundary,
+                                     ProllyHash *pHash){
+  u8 *pData = 0;
+  int nData = 0;
+  int rc = prollyNodeBuilderFinish(pBuilder, &pData, &nData);
+  ProllyNode node;
+
+  if( rc!=SQLITE_OK ) return rc;
+  rc = prollyNodeParse(&node, pData, nData);
+  if( rc==SQLITE_OK && !nodeHasSameChunkShape(&node, requireBoundary) ){
+    rc = SQLITE_NOTFOUND;
+  }
+  if( rc==SQLITE_OK ){
+    rc = chunkStorePut(pStore, pData, nData, pHash);
+  }
+  sqlite3_free(pData);
+  return rc;
+}
+
+static int cursorLeafIsRightmost(ProllyCursor *pCur){
+  int i;
+  for(i=0; i<pCur->iLevel; i++){
+    ProllyNode *pNode = &pCur->aLevel[i].pEntry->node;
+    if( pCur->aLevel[i].idx != (int)pNode->nItems - 1 ){
+      return 0;
+    }
+  }
+  return 1;
+}
+
+static int rewriteAncestorSpine(
+  ProllyMutator *pMut,
+  ProllyCursor *pCur,
+  int level,
+  ProllyHash *pChildHash,
+  int countDelta
+){
+  int rc = SQLITE_OK;
+
+  while( level>0 ){
+    ProllyNode *pNode;
+    ProllyNodeBuilder b;
+    ProllyHash parentHash;
+    int idx;
+    int i;
+
+    level--;
+    pNode = &pCur->aLevel[level].pEntry->node;
+    idx = pCur->aLevel[level].idx;
+    prollyNodeBuilderInit(&b, (u8)pNode->level, pMut->flags);
+    for(i=0; i<(int)pNode->nItems; i++){
+      u64 cnt = 0;
+      rc = parentChildSubtreeCount(pMut->pStore, pMut->pCache,
+                                   pNode, i, &cnt);
+      if( rc==SQLITE_OK ){
+        if( i==idx ){
+          const u8 *pKey;
+          int nKey;
+          if( countDelta<0 && cnt==0 ){
+            rc = SQLITE_CORRUPT;
+          }else{
+            prollyNodeKey(pNode, i, &pKey, &nKey);
+            rc = prollyNodeBuilderAddWithCount(
+                &b, pKey, nKey, pChildHash->data, PROLLY_HASH_SIZE,
+                countDelta<0 ? cnt - 1 : cnt + 1);
+          }
+        }else{
+          rc = appendNodeEntryToBuilder(&b, pNode, i, cnt);
+        }
+      }
+      if( rc!=SQLITE_OK ){
+        prollyNodeBuilderFree(&b);
+        return rc;
+      }
+    }
+    rc = writeBuilderNode(pMut->pStore, &b, &parentHash);
+    prollyNodeBuilderFree(&b);
+    if( rc!=SQLITE_OK ) return rc;
+    *pChildHash = parentHash;
+  }
+
+  return SQLITE_OK;
 }
 
 /* Replace one existing row when node boundaries cannot change. */
@@ -612,6 +732,185 @@ static int tryReplaceSingleSameSize(ProllyMutator *pMut){
   pMut->newRoot = childHash;
   prollyCursorClose(&cur);
   return SQLITE_OK;
+}
+
+static int tryDeleteSingleNoRechunk(ProllyMutator *pMut){
+  ProllyMutMapEntry *pEdit;
+  ProllyCursor cur;
+  ProllyHash childHash;
+  i64 iKey;
+  int rc;
+  int res = 0;
+  int level;
+
+  if( prollyHashIsEmpty(&pMut->oldRoot) ) return SQLITE_NOTFOUND;
+  if( prollyMutMapCount(pMut->pEdits)!=1 ) return SQLITE_NOTFOUND;
+
+  pEdit = &pMut->pEdits->aEntries[0];
+  if( pEdit->op!=PROLLY_EDIT_DELETE ){
+    return SQLITE_NOTFOUND;
+  }
+  if( (pMut->flags & PROLLY_NODE_INTKEY) && pEdit->nKey!=8 ){
+    return SQLITE_NOTFOUND;
+  }
+
+  prollyCursorInit(&cur, pMut->pStore, pMut->pCache, &pMut->oldRoot,
+                   pMut->flags);
+  if( pMut->flags & PROLLY_NODE_INTKEY ){
+    iKey = prollyMutMapEntryIntKey(pEdit);
+    rc = prollyCursorSeekInt(&cur, iKey, &res);
+  }else{
+    rc = prollyCursorSeekBlob(&cur, pEdit->pKey, pEdit->nKey, &res);
+  }
+  if( rc!=SQLITE_OK ){
+    prollyCursorClose(&cur);
+    return rc;
+  }
+  if( res!=0 || cur.eState!=PROLLY_CURSOR_VALID ){
+    prollyCursorClose(&cur);
+    return SQLITE_NOTFOUND;
+  }
+
+  level = cur.iLevel;
+  {
+    ProllyNode *pLeaf = &cur.aLevel[level].pEntry->node;
+    int idx = cur.aLevel[level].idx;
+    ProllyNodeBuilder b;
+    int requireBoundary;
+    int i;
+
+    if( pLeaf->nItems<=1 || idx==(int)pLeaf->nItems - 1 ){
+      prollyCursorClose(&cur);
+      return SQLITE_NOTFOUND;
+    }
+
+    prollyNodeBuilderInit(&b, 0, pMut->flags);
+    for(i=0; i<(int)pLeaf->nItems; i++){
+      if( i==idx ) continue;
+      rc = appendNodeEntryToBuilder(&b, pLeaf, i, 0);
+      if( rc!=SQLITE_OK ){
+        prollyNodeBuilderFree(&b);
+        prollyCursorClose(&cur);
+        return rc;
+      }
+    }
+    requireBoundary = !cursorLeafIsRightmost(&cur);
+    rc = finishAndWriteBuilderNode(pMut->pStore, &b, requireBoundary,
+                                   &childHash);
+    prollyNodeBuilderFree(&b);
+    if( rc!=SQLITE_OK ){
+      prollyCursorClose(&cur);
+      return rc;
+    }
+  }
+
+  rc = rewriteAncestorSpine(pMut, &cur, level, &childHash, -1);
+  if( rc==SQLITE_OK ){
+    pMut->newRoot = childHash;
+  }
+  prollyCursorClose(&cur);
+  return rc;
+}
+
+static int tryInsertSingleNoRechunk(ProllyMutator *pMut){
+  ProllyMutMapEntry *pEdit;
+  ProllyCursor cur;
+  ProllyHash childHash;
+  i64 iKey = 0;
+  int rc;
+  int res = 0;
+  int level;
+
+  if( prollyHashIsEmpty(&pMut->oldRoot) ) return SQLITE_NOTFOUND;
+  if( prollyMutMapCount(pMut->pEdits)!=1 ) return SQLITE_NOTFOUND;
+
+  pEdit = &pMut->pEdits->aEntries[0];
+  if( pEdit->op!=PROLLY_EDIT_INSERT ){
+    return SQLITE_NOTFOUND;
+  }
+  if( (pMut->flags & PROLLY_NODE_INTKEY) && pEdit->nKey!=8 ){
+    return SQLITE_NOTFOUND;
+  }
+
+  prollyCursorInit(&cur, pMut->pStore, pMut->pCache, &pMut->oldRoot,
+                   pMut->flags);
+  if( pMut->flags & PROLLY_NODE_INTKEY ){
+    iKey = prollyMutMapEntryIntKey(pEdit);
+    rc = prollyCursorSeekInt(&cur, iKey, &res);
+  }else{
+    rc = prollyCursorSeekBlob(&cur, pEdit->pKey, pEdit->nKey, &res);
+  }
+  if( rc!=SQLITE_OK ){
+    prollyCursorClose(&cur);
+    return rc;
+  }
+  if( res==0 || cur.eState!=PROLLY_CURSOR_VALID ){
+    prollyCursorClose(&cur);
+    return SQLITE_NOTFOUND;
+  }
+
+  if( pMut->flags & PROLLY_NODE_INTKEY ){
+    if( iKey>=prollyCursorIntKey(&cur) ){
+      prollyCursorClose(&cur);
+      return SQLITE_NOTFOUND;
+    }
+  }else{
+    const u8 *pCurKey;
+    int nCurKey;
+    prollyCursorKey(&cur, &pCurKey, &nCurKey);
+    if( compareKeys(pEdit->pKey, pEdit->nKey, pCurKey, nCurKey)>=0 ){
+      prollyCursorClose(&cur);
+      return SQLITE_NOTFOUND;
+    }
+  }
+
+  level = cur.iLevel;
+  {
+    ProllyNode *pLeaf = &cur.aLevel[level].pEntry->node;
+    int idx = cur.aLevel[level].idx;
+    ProllyNodeBuilder b;
+    int requireBoundary;
+    int i;
+
+    if( idx<0 || idx>=(int)pLeaf->nItems ){
+      prollyCursorClose(&cur);
+      return SQLITE_NOTFOUND;
+    }
+
+    prollyNodeBuilderInit(&b, 0, pMut->flags);
+    for(i=0; i<(int)pLeaf->nItems; i++){
+      if( i==idx ){
+        rc = prollyNodeBuilderAdd(&b, pEdit->pKey, pEdit->nKey,
+                                  pEdit->pVal, pEdit->nVal);
+        if( rc!=SQLITE_OK ){
+          prollyNodeBuilderFree(&b);
+          prollyCursorClose(&cur);
+          return rc;
+        }
+      }
+      rc = appendNodeEntryToBuilder(&b, pLeaf, i, 0);
+      if( rc!=SQLITE_OK ){
+        prollyNodeBuilderFree(&b);
+        prollyCursorClose(&cur);
+        return rc;
+      }
+    }
+    requireBoundary = !cursorLeafIsRightmost(&cur);
+    rc = finishAndWriteBuilderNode(pMut->pStore, &b, requireBoundary,
+                                   &childHash);
+    prollyNodeBuilderFree(&b);
+    if( rc!=SQLITE_OK ){
+      prollyCursorClose(&cur);
+      return rc;
+    }
+  }
+
+  rc = rewriteAncestorSpine(pMut, &cur, level, &childHash, 1);
+  if( rc==SQLITE_OK ){
+    pMut->newRoot = childHash;
+  }
+  prollyCursorClose(&cur);
+  return rc;
 }
 
 static int tryAppendSingleIntNoSplit(ProllyMutator *pMut){
@@ -840,6 +1139,12 @@ int prollyMutateFlush(ProllyMutator *pMut){
     rc = tryReplaceSingleSameSize(pMut);
     if( rc==SQLITE_NOTFOUND ){
       rc = tryAppendSingleIntNoSplit(pMut);
+    }
+    if( rc==SQLITE_NOTFOUND ){
+      rc = tryDeleteSingleNoRechunk(pMut);
+    }
+    if( rc==SQLITE_NOTFOUND ){
+      rc = tryInsertSingleNoRechunk(pMut);
     }
     if( rc==SQLITE_NOTFOUND ){
       rc = streamingMerge(pMut);

--- a/test/invariant_test.c
+++ b/test/invariant_test.c
@@ -917,6 +917,52 @@ static void test_reset_to_hash(void){
   removeDb(dbpath);
 }
 
+/*
+** Test 18: Single-row delete/reinsert on a multi-level integer-key table.
+*/
+static void test_single_row_mutation_fast_path(void){
+  sqlite3 *db = 0;
+  const char *dbpath = "/tmp/test_inv_single_mutation.db";
+  int i;
+
+  printf("--- Test 18: Single-row mutation fast path shape ---\n");
+  removeDb(dbpath);
+
+  check("open_single_mutation", sqlite3_open(dbpath, &db)==SQLITE_OK);
+
+  execSql(db, "CREATE TABLE t1(id INTEGER PRIMARY KEY, val TEXT)");
+  execSql(db, "BEGIN");
+  for( i=1; i<=5000; i++ ){
+    char sql[128];
+    snprintf(sql, sizeof(sql), "INSERT INTO t1 VALUES(%d, 'row_%d')", i, i);
+    execSql(db, sql);
+  }
+  execSql(db, "COMMIT");
+
+  execSql(db, "DELETE FROM t1 WHERE id=2500");
+  execSql(db, "INSERT INTO t1 VALUES(2500, 'restored')");
+  execSql(db, "DELETE FROM t1 WHERE id=3333");
+  execSql(db, "INSERT INTO t1 VALUES(3333, 'again')");
+
+  check("single_mutation_count",
+    queryScalarInt(db, "SELECT count(*) FROM t1")==5000);
+  check("single_mutation_min",
+    queryScalarInt(db, "SELECT min(id) FROM t1")==1);
+  check("single_mutation_max",
+    queryScalarInt(db, "SELECT max(id) FROM t1")==5000);
+  check("single_mutation_value_2500",
+    strcmp(queryScalarText(db, "SELECT val FROM t1 WHERE id=2500"),
+           "restored")==0);
+  check("single_mutation_value_3333",
+    strcmp(queryScalarText(db, "SELECT val FROM t1 WHERE id=3333"),
+           "again")==0);
+  check("single_mutation_integrity",
+    strcmp(queryScalarText(db, "PRAGMA integrity_check"), "ok")==0);
+
+  sqlite3_close(db);
+  removeDb(dbpath);
+}
+
 /* ========================================================================
 ** Main
 ** ======================================================================== */
@@ -941,6 +987,7 @@ int main(void){
   test_drop_table();
   test_staging();
   test_reset_to_hash();
+  test_single_row_mutation_fast_path();
 
   printf("\n=== Results: %d passed, %d failed out of %d tests ===\n",
     nPass, nFail, nPass+nFail);

--- a/test/sysbench_compare_blobpk.sh
+++ b/test/sysbench_compare_blobpk.sh
@@ -57,9 +57,7 @@ def rstr(n):
 def hk(i):
     return f"X'{i.to_bytes(16, 'big').hex()}'"
 
-# Common schema + data — sbtest1 / sbtest2 use BLOB PRIMARY KEY here.
-# sbtest_types keeps INTEGER PK because that table tests value-type
-# coverage, not PK shape.
+# Common schema + data uses BLOB PRIMARY KEY here.
 def write_prepare(f):
     f.write("CREATE TABLE sbtest1(id BLOB PRIMARY KEY, k INTEGER NOT NULL DEFAULT 0, c TEXT NOT NULL DEFAULT '', pad TEXT NOT NULL DEFAULT '');\n")
     f.write("CREATE INDEX k_idx ON sbtest1(k);\n")
@@ -77,10 +75,10 @@ def write_prepare_join(f):
     f.write("COMMIT;\n")
 
 def write_prepare_types(f):
-    f.write("CREATE TABLE sbtest_types(id INTEGER PRIMARY KEY, ival INTEGER, rval REAL, tval TEXT);\n")
+    f.write("CREATE TABLE sbtest_types(id BLOB PRIMARY KEY, ival INTEGER, rval REAL, tval TEXT);\n")
     f.write("BEGIN;\n")
     for i in range(1, R+1):
-        f.write(f"INSERT INTO sbtest_types VALUES({i},{random.randint(-1000000,1000000)},{random.uniform(-1e6,1e6)},'{rstr(50)}');\n")
+        f.write(f"INSERT INTO sbtest_types VALUES({hk(i)},{random.randint(-1000000,1000000)},{random.uniform(-1e6,1e6)},'{rstr(50)}');\n")
     f.write("COMMIT;\n")
 
 # Each test file: prepare + ".print BENCH_START" + workload + ".print BENCH_END"
@@ -223,8 +221,8 @@ def w_types_delete_insert(f):
     f.write("BEGIN;\n")
     for _ in range(5000):
         id=rint(1,R)
-        f.write(f"DELETE FROM sbtest_types WHERE id={id};\n")
-        f.write(f"INSERT OR REPLACE INTO sbtest_types VALUES({id},{random.randint(-1000000,1000000)},{random.uniform(-1e6,1e6)},'{rstr(50)}');\n")
+        f.write(f"DELETE FROM sbtest_types WHERE id={hk(id)};\n")
+        f.write(f"INSERT OR REPLACE INTO sbtest_types VALUES({hk(id)},{random.randint(-1000000,1000000)},{random.uniform(-1e6,1e6)},'{rstr(50)}');\n")
     f.write("COMMIT;\n")
 
 def w_types_table_scan(f):
@@ -343,8 +341,8 @@ def w_types_delete_insert_autocommit(f):
     # 2 statements per iteration; halve the loop.
     for _ in range(AC // 2):
         id = rint(1, R)
-        f.write(f"DELETE FROM sbtest_types WHERE id={id};\n")
-        f.write(f"INSERT OR REPLACE INTO sbtest_types VALUES({id},{random.randint(-1000000,1000000)},{random.uniform(-1e6,1e6)},'{rstr(50)}');\n")
+        f.write(f"DELETE FROM sbtest_types WHERE id={hk(id)};\n")
+        f.write(f"INSERT OR REPLACE INTO sbtest_types VALUES({hk(id)},{random.randint(-1000000,1000000)},{random.uniform(-1e6,1e6)},'{rstr(50)}');\n")
 
 def w_read_write_autocommit(f):
     # The mix is ~16 statements per iteration (10 point selects, 3 ranges,

--- a/test/sysbench_compare_compositepk.sh
+++ b/test/sysbench_compare_compositepk.sh
@@ -74,9 +74,7 @@ def kbetween(s, e):
     ea, eb = parts(e)
     return f"(a,b) BETWEEN ({sa},{sb}) AND ({ea},{eb})"
 
-# Common schema + data — sbtest1 / sbtest2 use a 2-column composite PK.
-# sbtest_types keeps INTEGER PK because that table tests value-type
-# coverage, not PK shape.
+# Common schema + data uses a 2-column composite PK.
 def write_prepare(f):
     f.write("CREATE TABLE sbtest1(a INTEGER NOT NULL, b INTEGER NOT NULL, k INTEGER NOT NULL DEFAULT 0, c TEXT NOT NULL DEFAULT '', pad TEXT NOT NULL DEFAULT '', PRIMARY KEY(a,b)) WITHOUT ROWID;\n")
     f.write("CREATE INDEX k_idx ON sbtest1(k);\n")
@@ -94,10 +92,10 @@ def write_prepare_join(f):
     f.write("COMMIT;\n")
 
 def write_prepare_types(f):
-    f.write("CREATE TABLE sbtest_types(id INTEGER PRIMARY KEY, ival INTEGER, rval REAL, tval TEXT);\n")
+    f.write("CREATE TABLE sbtest_types(a INTEGER NOT NULL, b INTEGER NOT NULL, ival INTEGER, rval REAL, tval TEXT, PRIMARY KEY(a,b)) WITHOUT ROWID;\n")
     f.write("BEGIN;\n")
     for i in range(1, R+1):
-        f.write(f"INSERT INTO sbtest_types VALUES({i},{random.randint(-1000000,1000000)},{random.uniform(-1e6,1e6)},'{rstr(50)}');\n")
+        f.write(f"INSERT INTO sbtest_types VALUES({kvals(i)},{random.randint(-1000000,1000000)},{random.uniform(-1e6,1e6)},'{rstr(50)}');\n")
     f.write("COMMIT;\n")
 
 # Each test file: prepare + ".print BENCH_START" + workload + ".print BENCH_END"
@@ -243,8 +241,8 @@ def w_types_delete_insert(f):
     f.write("BEGIN;\n")
     for _ in range(5000):
         id=rint(1,R)
-        f.write(f"DELETE FROM sbtest_types WHERE id={id};\n")
-        f.write(f"INSERT OR REPLACE INTO sbtest_types VALUES({id},{random.randint(-1000000,1000000)},{random.uniform(-1e6,1e6)},'{rstr(50)}');\n")
+        f.write(f"DELETE FROM sbtest_types WHERE {kw(id)};\n")
+        f.write(f"INSERT OR REPLACE INTO sbtest_types VALUES({kvals(id)},{random.randint(-1000000,1000000)},{random.uniform(-1e6,1e6)},'{rstr(50)}');\n")
     f.write("COMMIT;\n")
 
 def w_types_table_scan(f):
@@ -363,8 +361,8 @@ def w_types_delete_insert_autocommit(f):
     # 2 statements per iteration; halve the loop.
     for _ in range(AC // 2):
         id = rint(1, R)
-        f.write(f"DELETE FROM sbtest_types WHERE id={id};\n")
-        f.write(f"INSERT OR REPLACE INTO sbtest_types VALUES({id},{random.randint(-1000000,1000000)},{random.uniform(-1e6,1e6)},'{rstr(50)}');\n")
+        f.write(f"DELETE FROM sbtest_types WHERE {kw(id)};\n")
+        f.write(f"INSERT OR REPLACE INTO sbtest_types VALUES({kvals(id)},{random.randint(-1000000,1000000)},{random.uniform(-1e6,1e6)},'{rstr(50)}');\n")
 
 def w_read_write_autocommit(f):
     # The mix is ~16 statements per iteration (10 point selects, 3 ranges,

--- a/test/sysbench_compare_textpk.sh
+++ b/test/sysbench_compare_textpk.sh
@@ -57,9 +57,7 @@ def rstr(n):
 def hk(i):
     return f"{i:032x}"
 
-# Common schema + data — sbtest1 / sbtest2 use TEXT PRIMARY KEY here.
-# sbtest_types keeps INTEGER PK because that table tests value-type
-# coverage, not PK shape.
+# Common schema + data uses TEXT PRIMARY KEY here.
 def write_prepare(f):
     f.write("CREATE TABLE sbtest1(id TEXT PRIMARY KEY, k INTEGER NOT NULL DEFAULT 0, c TEXT NOT NULL DEFAULT '', pad TEXT NOT NULL DEFAULT '');\n")
     f.write("CREATE INDEX k_idx ON sbtest1(k);\n")
@@ -77,10 +75,10 @@ def write_prepare_join(f):
     f.write("COMMIT;\n")
 
 def write_prepare_types(f):
-    f.write("CREATE TABLE sbtest_types(id INTEGER PRIMARY KEY, ival INTEGER, rval REAL, tval TEXT);\n")
+    f.write("CREATE TABLE sbtest_types(id TEXT PRIMARY KEY, ival INTEGER, rval REAL, tval TEXT);\n")
     f.write("BEGIN;\n")
     for i in range(1, R+1):
-        f.write(f"INSERT INTO sbtest_types VALUES({i},{random.randint(-1000000,1000000)},{random.uniform(-1e6,1e6)},'{rstr(50)}');\n")
+        f.write(f"INSERT INTO sbtest_types VALUES('{hk(i)}',{random.randint(-1000000,1000000)},{random.uniform(-1e6,1e6)},'{rstr(50)}');\n")
     f.write("COMMIT;\n")
 
 # Each test file: prepare + ".print BENCH_START" + workload + ".print BENCH_END"
@@ -223,8 +221,8 @@ def w_types_delete_insert(f):
     f.write("BEGIN;\n")
     for _ in range(5000):
         id=rint(1,R)
-        f.write(f"DELETE FROM sbtest_types WHERE id={id};\n")
-        f.write(f"INSERT OR REPLACE INTO sbtest_types VALUES({id},{random.randint(-1000000,1000000)},{random.uniform(-1e6,1e6)},'{rstr(50)}');\n")
+        f.write(f"DELETE FROM sbtest_types WHERE id='{hk(id)}';\n")
+        f.write(f"INSERT OR REPLACE INTO sbtest_types VALUES('{hk(id)}',{random.randint(-1000000,1000000)},{random.uniform(-1e6,1e6)},'{rstr(50)}');\n")
     f.write("COMMIT;\n")
 
 def w_types_table_scan(f):
@@ -343,8 +341,8 @@ def w_types_delete_insert_autocommit(f):
     # 2 statements per iteration; halve the loop.
     for _ in range(AC // 2):
         id = rint(1, R)
-        f.write(f"DELETE FROM sbtest_types WHERE id={id};\n")
-        f.write(f"INSERT OR REPLACE INTO sbtest_types VALUES({id},{random.randint(-1000000,1000000)},{random.uniform(-1e6,1e6)},'{rstr(50)}');\n")
+        f.write(f"DELETE FROM sbtest_types WHERE id='{hk(id)}';\n")
+        f.write(f"INSERT OR REPLACE INTO sbtest_types VALUES('{hk(id)}',{random.randint(-1000000,1000000)},{random.uniform(-1e6,1e6)},'{rstr(50)}');\n")
 
 def w_read_write_autocommit(f):
     # The mix is ~16 statements per iteration (10 point selects, 3 ranges,


### PR DESCRIPTION
## Summary
- add conservative fast paths for single-row prolly delete/insert mutations when leaf chunk boundaries and separator keys are preserved
- rebuild only the edited leaf plus ancestor spine instead of falling through to streaming merge
- add invariant coverage for delete/reinsert on a multi-level integer-key table
- fix non-int sysbench type benchmarks so `sbtest_types` uses each suite's actual key shape: composite, TEXT, or BLOB

## Benchmark target
Latest merged PR #1034 sysbench comment highest multiplier was in the compositepk suite, file-backed autocommit, `types_delete_insert_ac` at 5.05x. That exposed single-row delete/reinsert costs, and the benchmark now uses the composite PK shape it is supposed to measure.

Local targeted 100k-row timing before the benchmark schema correction, Doltlite only:
- baseline median: 257,222 us
- this branch median: 145,565 us

## Tests
- `make -j8 sqlite3.o libdoltlite.a`
- `make -j8 doltlite`
- `make -j8 invariant_test corruption_test && ./invariant_test && ./corruption_test`
- `make -j8 c-tests && test/run_c_tests.sh .`
- targeted 100k-row `types_delete_insert_ac` baseline/new timing with `test/sysbench_timer.c` helper
- `BENCH_ROWS=200 BENCH_RUNS=1 BENCH_MAX_MULTIPLIER=1000 BENCH_AVG_MAX_MULTIPLIER=1000 ./test/sysbench_compare_compositepk.sh`
- `BENCH_ROWS=200 BENCH_RUNS=1 BENCH_MAX_MULTIPLIER=1000 BENCH_AVG_MAX_MULTIPLIER=1000 ./test/sysbench_compare_textpk.sh`
- `BENCH_ROWS=200 BENCH_RUNS=1 BENCH_MAX_MULTIPLIER=1000 BENCH_AVG_MAX_MULTIPLIER=1000 ./test/sysbench_compare_blobpk.sh`