### PR TITLE
Optimize exact composite primary key seeks

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -6768,7 +6768,7 @@ static int prollyBtCursorIndexMoveto(
        && seekRes==0
        && pCur->pCur.eState==PROLLY_CURSOR_VALID
        && pCur->pKeyInfo
-       && pIdxKey->nField >= pCur->pKeyInfo->nAllField ){
+       && (exactMutMapKey || pIdxKey->nField >= pCur->pKeyInfo->nAllField) ){
         int isDeleted = 0;
         if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
           ProllyMutMapEntry *mmE = 0;


### PR DESCRIPTION
## Summary
- identify the highest multiplier from PR #1036 as composite PK file-backed autocommit writes: oltp_update_index_ac and oltp_delete_insert_ac tied at 4.73x
- skip the leaf scan for exact WITHOUT ROWID table primary-key seeks when the encoded sort key already matched the tree
- keep the pending-delete check before returning the tree hit

## Local benchmark notes
Focused 100K-row composite autocommit harness, DoltLite-only 21 runs on local Mac:
- baseline oltp_update_index_ac median 41,706 us, trimmed median 39,928 us
- branch oltp_update_index_ac median 43,064 us, trimmed median 41,423 us
- baseline oltp_delete_insert_ac median 58,642 us, trimmed median 55,993 us
- branch oltp_delete_insert_ac median 37,533 us, trimmed median 36,729 us

Local runs had large scheduler outliers; delete/insert showed the clear win among the tied worst metrics.

## Tests
- make -j8 doltlite doltlite-lib
- BENCH_ROWS=200 BENCH_RUNS=1 BENCH_MAX_MULTIPLIER=1000 BENCH_AVG_MAX_MULTIPLIER=1000 ./test/sysbench_compare_compositepk.sh
- make -j8 invariant_test corruption_test c-tests && ./invariant_test && ./corruption_test && test/run_c_tests.sh .