### PR TITLE
Optimize variable-size single row replacements

### DIFF
--- a/src/prolly_mutate.c
+++ b/src/prolly_mutate.c
@@ -663,13 +663,11 @@ static int tryInsertOrReplaceSingleNoRechunk(ProllyMutator *pMut){
     const u8 *pOldVal;
     int nOldVal;
     ProllyNodeBuilder b;
+    int sameSize;
     int i;
 
     prollyNodeValue(pLeaf, idx, &pOldVal, &nOldVal);
-    if( nOldVal!=pEdit->nVal ){
-      prollyCursorClose(&cur);
-      return SQLITE_NOTFOUND;
-    }
+    sameSize = (nOldVal==pEdit->nVal);
 
     prollyNodeBuilderInit(&b, 0, pMut->flags);
     for(i=0; i<(int)pLeaf->nItems; i++){
@@ -685,7 +683,13 @@ static int tryInsertOrReplaceSingleNoRechunk(ProllyMutator *pMut){
         return rc;
       }
     }
-    rc = writeBuilderNode(pMut->pStore, &b, &childHash);
+    if( sameSize ){
+      rc = writeBuilderNode(pMut->pStore, &b, &childHash);
+    }else{
+      rc = finishAndWriteBuilderNode(pMut->pStore, &b,
+                                     !cursorLeafIsRightmost(&cur),
+                                     &childHash);
+    }
     prollyNodeBuilderFree(&b);
     if( rc!=SQLITE_OK ){
       prollyCursorClose(&cur);

--- a/test/invariant_test.c
+++ b/test/invariant_test.c
@@ -959,6 +959,35 @@ static void test_single_row_mutation_fast_path(void){
   check("single_mutation_integrity",
     strcmp(queryScalarText(db, "PRAGMA integrity_check"), "ok")==0);
 
+  execSql(db, "CREATE TABLE tblob(id BLOB PRIMARY KEY, val TEXT, pad TEXT)");
+  execSql(db, "BEGIN");
+  for( i=1; i<=5000; i++ ){
+    char sql[256];
+    snprintf(sql, sizeof(sql),
+      "INSERT INTO tblob VALUES(x'%032x', 'row_%d', 'pad')", i, i);
+    execSql(db, sql);
+  }
+  execSql(db, "COMMIT");
+
+  execSql(db,
+    "UPDATE tblob SET val='short' WHERE id=x'000000000000000000000000000009c4'");
+  execSql(db,
+    "UPDATE tblob SET val='this replacement is intentionally longer' "
+    "WHERE id=x'00000000000000000000000000000d05'");
+
+  check("single_mutation_blob_count",
+    queryScalarInt(db, "SELECT count(*) FROM tblob")==5000);
+  check("single_mutation_blob_short",
+    strcmp(queryScalarText(db,
+      "SELECT val FROM tblob WHERE id=x'000000000000000000000000000009c4'"),
+      "short")==0);
+  check("single_mutation_blob_long",
+    strcmp(queryScalarText(db,
+      "SELECT val FROM tblob WHERE id=x'00000000000000000000000000000d05'"),
+      "this replacement is intentionally longer")==0);
+  check("single_mutation_blob_integrity",
+    strcmp(queryScalarText(db, "PRAGMA integrity_check"), "ok")==0);
+
   sqlite3_close(db);
   removeDb(dbpath);
 }


### PR DESCRIPTION
## Summary
- expands the single-row prolly replacement fast path to handle value-size changes when the rebuilt leaf proves its chunk-boundary shape is unchanged
- keeps the existing same-size path unchanged and falls back to streaming merge when shape validation fails
- adds invariant coverage for variable-size replacements on a BLOB primary-key table

## Benchmark Target
Last merged PR checked: #1038 (`558c46ffc1`, "Optimize exact composite primary key seeks").

Highest sysbench multiplier in the generated comments:
- key type: `blobpk`
- mode: file-backed
- autocommit: yes
- metric: `oltp_delete_insert_ac`
- multiplier: `5.03x` (`88,459us` Doltlite / `17,578us` SQLite)

Local DoltLite-only comparison on 100K-row BLOB PK targets, 30 runs each:

| Test | Baseline median | New median | Baseline trimmed median | New trimmed median |
| --- | ---: | ---: | ---: | ---: |
| `oltp_delete_insert_ac` | 135,623us | 60,493us | 96,981us | 55,614us |
| `oltp_update_index_ac` | 167,301us | 76,659us | 126,243us | 51,405us |
| `oltp_insert_ac` | 41,581us | 40,805us | 41,180us | 39,631us |

Local runs are noisy on this machine, but the before/after was run from clean `origin/master` and this branch using the same harness.

## Validation
- `BENCH_ROWS=200 BENCH_RUNS=1 BENCH_MAX_MULTIPLIER=1000 BENCH_AVG_MAX_MULTIPLIER=1000 ./test/sysbench_compare_blobpk.sh`
- `make -j8 invariant_test corruption_test c-tests`
- `./invariant_test`
- `test/run_c_tests.sh .`
