### PR TITLE
perf(cache): bump default prolly cache to 16384

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -112,7 +112,7 @@ int doltliteSerializeCatalogEntriesWithFallbackSchema(
   (pCur)->nSeekKeyField = 0; \
 }while(0)
 
-#define PROLLY_DEFAULT_CACHE_SIZE 1024
+#define PROLLY_DEFAULT_CACHE_SIZE 16384
 
 #define PROLLY_DEFAULT_PAGE_SIZE 4096
 


### PR DESCRIPTION
## Summary

- Default prolly cache size: **1024 → 16384** entries (`PROLLY_DEFAULT_CACHE_SIZE` in `prolly_btree.c`).
- One-line constant change. Cache is per database file (not per table/index), grows lazily, ceiling ~64 MB per DB.
- 100k-row sysbench DBs were thrashing the cache constantly (~2k leaves per tree, 4+ trees). At 16384 entries the working set fits and reads stop re-paying BLAKE3 verify on every miss.

## File-backed read multiplier vs SQLite (median of 5, 100k rows)

| Test                  | 1024  | 16384 |
|-----------------------|------:|------:|
| oltp_point_select     | 1.11x | 0.55x |
| oltp_range_select     | 2.30x | 0.82x |
| oltp_sum_range        | 2.17x | 0.75x |
| oltp_index_scan       | 1.57x | 0.81x |
| select_random_points  | 2.60x | 0.60x |
| select_random_ranges  | 1.61x | 0.76x |
| index_join_scan       | 2.54x | 1.15x |
| types_table_scan      | 1.96x | 0.92x |
| table_scan            | 2.17x | 0.97x |
| oltp_read_only        | 1.47x | 0.88x |
| **Average**           | **1.81x** | **0.86x** |

Doltlite is now **faster than SQLite on file-backed reads on average**. mem_reads and ac_reads also improved (1.65 → 1.18, 1.47 → ~1.02 respectively).

Even sequential scans (`table_scan`, `types_table_scan`) benefit — second-pass tree walks (sums, joins) no longer evict what the first pass cached.

## Test plan
- [x] Local `test/run_doltlite_tests.sh` — 67/67 suites pass
- [ ] CI sysbench benchmark confirms the perf delta on the runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)