### PR TITLE
Optimize delete-insert edit pairs

### DIFF
--- a/src/prolly_mutate.c
+++ b/src/prolly_mutate.c
@@ -1057,6 +1057,62 @@ static int tryAppendSingleIntNoSplit(ProllyMutator *pMut){
   return SQLITE_OK;
 }
 
+static int tryDeleteInsertPairNoRechunk(ProllyMutator *pMut){
+  ProllyMutator one;
+  ProllyMutMap oneMap;
+  ProllyMutMapEntry *pDel = 0;
+  ProllyMutMapEntry *pIns = 0;
+  ProllyHash midRoot;
+  int i;
+  int rc;
+
+  if( prollyHashIsEmpty(&pMut->oldRoot) ) return SQLITE_NOTFOUND;
+  if( prollyMutMapCount(pMut->pEdits)!=2 ) return SQLITE_NOTFOUND;
+
+  for(i=0; i<2; i++){
+    ProllyMutMapEntry *pEntry = &pMut->pEdits->aEntries[i];
+    if( pEntry->op==PROLLY_EDIT_DELETE ){
+      if( pDel ) return SQLITE_NOTFOUND;
+      pDel = pEntry;
+    }else if( pEntry->op==PROLLY_EDIT_INSERT ){
+      if( pIns ) return SQLITE_NOTFOUND;
+      pIns = pEntry;
+    }else{
+      return SQLITE_NOTFOUND;
+    }
+  }
+  if( !pDel || !pIns ) return SQLITE_NOTFOUND;
+
+  memset(&oneMap, 0, sizeof(oneMap));
+  oneMap.isIntKey = pMut->pEdits->isIntKey;
+  oneMap.keepSorted = pMut->pEdits->keepSorted;
+  oneMap.aEntries = pDel;
+  oneMap.nEntries = 1;
+  oneMap.nAlloc = 1;
+
+  one = *pMut;
+  one.pEdits = &oneMap;
+  rc = tryDeleteSingleNoRechunk(&one);
+  if( rc!=SQLITE_OK ) return rc;
+  midRoot = one.newRoot;
+
+  memset(&oneMap, 0, sizeof(oneMap));
+  oneMap.isIntKey = pMut->pEdits->isIntKey;
+  oneMap.keepSorted = pMut->pEdits->keepSorted;
+  oneMap.aEntries = pIns;
+  oneMap.nEntries = 1;
+  oneMap.nAlloc = 1;
+
+  one = *pMut;
+  one.oldRoot = midRoot;
+  one.pEdits = &oneMap;
+  rc = tryInsertOrReplaceSingleNoRechunk(&one);
+  if( rc!=SQLITE_OK ) return rc;
+
+  pMut->newRoot = one.newRoot;
+  return SQLITE_OK;
+}
+
 int prollyMutateFlush(ProllyMutator *pMut){
   int rc;
 
@@ -1074,6 +1130,9 @@ int prollyMutateFlush(ProllyMutator *pMut){
     }
     if( rc==SQLITE_NOTFOUND ){
       rc = tryDeleteSingleNoRechunk(pMut);
+    }
+    if( rc==SQLITE_NOTFOUND ){
+      rc = tryDeleteInsertPairNoRechunk(pMut);
     }
     if( rc==SQLITE_NOTFOUND ){
       rc = streamingMerge(pMut);

--- a/test/invariant_test.c
+++ b/test/invariant_test.c
@@ -988,6 +988,33 @@ static void test_single_row_mutation_fast_path(void){
   check("single_mutation_blob_integrity",
     strcmp(queryScalarText(db, "PRAGMA integrity_check"), "ok")==0);
 
+  execSql(db, "CREATE TABLE ttext(id TEXT PRIMARY KEY, k INTEGER, val TEXT)");
+  execSql(db, "CREATE INDEX ttext_k ON ttext(k)");
+  execSql(db, "BEGIN");
+  for( i=1; i<=5000; i++ ){
+    char sql[256];
+    snprintf(sql, sizeof(sql),
+      "INSERT INTO ttext VALUES('%032x', %d, 'row_%d')", i, i, i);
+    execSql(db, sql);
+  }
+  execSql(db, "COMMIT");
+
+  execSql(db,
+    "UPDATE ttext SET k=8001 "
+    "WHERE id='000000000000000000000000000009c4'");
+  execSql(db,
+    "UPDATE ttext SET k=8002 "
+    "WHERE id='00000000000000000000000000000d05'");
+
+  check("single_mutation_text_index_count",
+    queryScalarInt(db, "SELECT count(*) FROM ttext")==5000);
+  check("single_mutation_text_index_old_gone",
+    queryScalarInt(db, "SELECT count(*) FROM ttext WHERE k IN (2500,3333)")==0);
+  check("single_mutation_text_index_new",
+    queryScalarInt(db, "SELECT count(*) FROM ttext WHERE k IN (8001,8002)")==2);
+  check("single_mutation_text_index_integrity",
+    strcmp(queryScalarText(db, "PRAGMA integrity_check"), "ok")==0);
+
   sqlite3_close(db);
   removeDb(dbpath);
 }


### PR DESCRIPTION
## Summary
- adds a no-rechunk fast path for two-edit delete+insert mutation batches
- reuses the existing single-delete and single-insert shape validation, falling back to streaming merge if either edit would rechunk
- adds invariant coverage for indexed TEXT primary-key updates

## Benchmark Target
Last merged PR checked: #1039 (`04d01572eb`, "Optimize variable-size single row replacements").

Highest sysbench multiplier in the generated comments:
- key type: `textpk`
- mode: file-backed
- autocommit: yes
- metric: `oltp_update_index_ac`
- multiplier: `4.90x` (`101,192us` Doltlite / `20,657us` SQLite)

Local DoltLite-only comparison on 100K-row TEXT PK targets, 15 runs each:

| Test | Baseline median | New median | Baseline trimmed median | New trimmed median |
| --- | ---: | ---: | ---: | ---: |
| `oltp_update_index_ac` | 543,674us | 53,082us | 467,639us | 52,995us |
| `oltp_update_non_index_ac` | 663,494us | 474,889us | 461,847us | 51,622us |
| `oltp_delete_insert_ac` | 143,247us | 45,061us | 92,042us | 43,336us |
| `oltp_write_only_ac` | 42,278us | 41,120us | 42,171us | 38,715us |

Local autocommit timings on this machine are noisy, but the target path shows a large before/after improvement under the same harness.

## Validation
- `BENCH_ROWS=200 BENCH_RUNS=1 BENCH_MAX_MULTIPLIER=1000 BENCH_AVG_MAX_MULTIPLIER=1000 ./test/sysbench_compare_textpk.sh`
- `make -j8 invariant_test corruption_test c-tests`
