### PR TITLE
Optimize blob key right-edge appends

### DIFF
--- a/src/prolly_mutate.c
+++ b/src/prolly_mutate.c
@@ -845,7 +845,7 @@ static int tryDeleteSingleNoRechunk(ProllyMutator *pMut){
   return rc;
 }
 
-static int tryAppendSingleIntNoSplit(ProllyMutator *pMut){
+static int tryAppendSingleNoSplit(ProllyMutator *pMut){
   ProllyMutMapEntry *pEdit;
   ProllyCursor cur;
   ProllyHash childHash;
@@ -856,18 +856,22 @@ static int tryAppendSingleIntNoSplit(ProllyMutator *pMut){
   int res = 0;
   int level;
 
-  if( !(pMut->flags & PROLLY_NODE_INTKEY) ) return SQLITE_NOTFOUND;
   if( prollyHashIsEmpty(&pMut->oldRoot) ) return SQLITE_NOTFOUND;
   if( prollyMutMapCount(pMut->pEdits)!=1 ) return SQLITE_NOTFOUND;
 
   pEdit = &pMut->pEdits->aEntries[0];
-  if( pEdit->op!=PROLLY_EDIT_INSERT || pEdit->nKey!=8 ){
+  if( pEdit->op!=PROLLY_EDIT_INSERT ){
+    return SQLITE_NOTFOUND;
+  }
+  if( (pMut->flags & PROLLY_NODE_INTKEY) && pEdit->nKey!=8 ){
     return SQLITE_NOTFOUND;
   }
 
   pNewKey = pEdit->pKey;
   nNewKey = pEdit->nKey;
-  iNewKey = prollyMutMapEntryIntKey(pEdit);
+  if( pMut->flags & PROLLY_NODE_INTKEY ){
+    iNewKey = prollyMutMapEntryIntKey(pEdit);
+  }
 
   prollyCursorInit(&cur, pMut->pStore, pMut->pCache, &pMut->oldRoot,
                    pMut->flags);
@@ -880,9 +884,19 @@ static int tryAppendSingleIntNoSplit(ProllyMutator *pMut){
     prollyCursorClose(&cur);
     return SQLITE_NOTFOUND;
   }
-  if( iNewKey <= prollyCursorIntKey(&cur) ){
-    prollyCursorClose(&cur);
-    return SQLITE_NOTFOUND;
+  if( pMut->flags & PROLLY_NODE_INTKEY ){
+    if( iNewKey <= prollyCursorIntKey(&cur) ){
+      prollyCursorClose(&cur);
+      return SQLITE_NOTFOUND;
+    }
+  }else{
+    const u8 *pLastKey;
+    int nLastKey;
+    prollyCursorKey(&cur, &pLastKey, &nLastKey);
+    if( compareKeys(pNewKey, nNewKey, pLastKey, nLastKey)<=0 ){
+      prollyCursorClose(&cur);
+      return SQLITE_NOTFOUND;
+    }
   }
 
   level = cur.iLevel;
@@ -1126,7 +1140,7 @@ int prollyMutateFlush(ProllyMutator *pMut){
   }else{
     rc = tryInsertOrReplaceSingleNoRechunk(pMut);
     if( rc==SQLITE_NOTFOUND ){
-      rc = tryAppendSingleIntNoSplit(pMut);
+      rc = tryAppendSingleNoSplit(pMut);
     }
     if( rc==SQLITE_NOTFOUND ){
       rc = tryDeleteSingleNoRechunk(pMut);

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -6600,6 +6600,72 @@ static void run_prolly_mutate_preserves_order_across_skipped_subtrees(void){
   chunkStoreClose(&cs);
 }
 
+static void run_prolly_mutate_appends_blob_key_to_right_edge(void){
+  ChunkStore cs;
+  ProllyCache cache;
+  ProllyChunker chunker;
+  ProllyCursor cur;
+  ProllyHash rootHash, newRootHash;
+  ProllyNode rootNode;
+  u8 *pRootData = 0;
+  int nRootData = 0;
+  u8 aKey[33];
+  const u8 *pKey = 0;
+  int nKey = 0;
+  int rc;
+  int res = 99;
+  int i;
+  const int nItem = 100000;
+  u8 aVal[256];
+
+  printf("=== Prolly Mutate Blob Right Edge Append Test ===\n\n");
+  memset(aVal, 'v', sizeof(aVal));
+
+  check("open_memory_store_for_prolly_blob_append",
+        chunkStoreOpen(&cs, sqlite3_vfs_find(0), ":memory:", 0)==SQLITE_OK);
+  check("init_cache_for_prolly_blob_append",
+        prollyCacheInit(&cache, 64)==SQLITE_OK);
+  check("init_chunker_for_prolly_blob_append",
+        prollyChunkerInit(&chunker, &cs, PROLLY_NODE_BLOBKEY)==SQLITE_OK);
+
+  for( i = 0; i < nItem; i++ ){
+    make_prolly_blob_key(i, aKey, sizeof(aKey));
+    check("add_key_to_chunker_for_prolly_blob_append",
+          prollyChunkerAdd(&chunker, aKey, 32, aVal, sizeof(aVal))==SQLITE_OK);
+  }
+  check("finish_chunker_for_prolly_blob_append",
+        prollyChunkerFinish(&chunker)==SQLITE_OK);
+  prollyChunkerGetRoot(&chunker, &rootHash);
+  prollyChunkerFree(&chunker);
+
+  check("load_root_for_prolly_blob_append",
+        chunkStoreGet(&cs, &rootHash, &pRootData, &nRootData)==SQLITE_OK);
+  check("parse_root_for_prolly_blob_append",
+        prollyNodeParse(&rootNode, pRootData, nRootData)==SQLITE_OK);
+  check("root_is_multi_level_for_prolly_blob_append", rootNode.level >= 2);
+  sqlite3_free(pRootData);
+
+  make_prolly_blob_key(nItem, aKey, sizeof(aKey));
+  rc = prollyMutateInsert(&cs, &cache, &rootHash, PROLLY_NODE_BLOBKEY,
+                          aKey, 32, 0, aVal, sizeof(aVal), &newRootHash);
+  check("append_blob_key_to_multi_level_tree", rc==SQLITE_OK);
+
+  prollyCursorInit(&cur, &cs, &cache, &newRootHash, PROLLY_NODE_BLOBKEY);
+  rc = prollyCursorLast(&cur, &res);
+  check("cursor_last_after_blob_append", rc==SQLITE_OK);
+  check("cursor_last_after_blob_append_valid",
+        res==0 && prollyCursorIsValid(&cur));
+  if( prollyCursorIsValid(&cur) ){
+    prollyCursorKey(&cur, &pKey, &nKey);
+    check("last_key_after_blob_append_is_new_key",
+          nKey==32 && memcmp(pKey, aKey, 32)==0);
+  }
+
+  prollyCursorClose(&cur);
+  prollyCacheFree(&cache);
+  chunkStoreClose(&cs);
+}
+
 static void run_chunk_store_rollback_restores_refs_hash(void){
   ChunkStore cs;
   ProllyHash emptyHash;
@@ -7461,6 +7527,7 @@ static const RegressionCase aCases[] = {
   { "mutmap_resolve_sorted_pos", "MutMap ResolveSortedPos Test", run_mutmap_resolve_sorted_pos },
   { "mutmap_differential_randomized", "MutMap Differential Randomized Test", run_mutmap_differential_randomized },
   { "prolly_mutate_skip_subtree_order", "Prolly Mutate Skipped Subtree Order Test", run_prolly_mutate_preserves_order_across_skipped_subtrees },
+  { "prolly_mutate_blob_right_edge_append", "Prolly Mutate Blob Right Edge Append Test", run_prolly_mutate_appends_blob_key_to_right_edge },
   { "refs_hash_rollback_restore", "Chunk Store Rollback Restores Refs Hash Test", run_chunk_store_rollback_restores_refs_hash },
   { "refs_hash_commit_failure_restore", "Chunk Store Commit Failure Restores Refs Hash Test", run_chunk_store_commit_failure_restores_refs_hash },
   { "remotesrv_put_refs_failure_restore", "RemoteSrv Put Refs Failure Restores State Test", run_remotesrv_put_refs_failure_restores_state },


### PR DESCRIPTION
## Summary
- Latest merged benchmark source: PR #1042 (`perf/text-update-index-ac`).
- Highest multiplier in the generated sysbench comments: `blobpk`, file-backed, autocommit, `oltp_write_only_ac` at 4.33x SQLite (`24,353us` SQLite vs `105,409us` DoltLite).
- While tracing that family locally, the direct `oltp_write_only_ac` path was already mostly using local replace/delete/pair fast paths; the remaining streaming fallbacks are boundary-sensitive and need a separate, higher-risk tree-shape change.
- This PR takes the safe win found in the same blobpk file-backed autocommit write family: generalize the right-edge append fast path from INT keys to BLOB/TEXT sort keys when the append proves it will not split/rechunk.

## Local benchmark comparison
Custom 100K-row blobpk file-backed autocommit harness, 15 runs, comparing clean master worktree to this branch:

- `oltp_insert_ac` trimmed median: `182,602us` -> `33,972us`
- `oltp_insert_ac` median: `683,804us` -> `35,768us`
- `oltp_update_index_ac` trimmed median: `58,508us` -> `42,454us`
- `oltp_write_only_ac` focused 30-run median stayed flat/noisy: `38,980us` -> `39,798us`

## Tests
- `DOLTLITE_BUILD_DIR=$PWD bash test/run_doltlite_regression_case.sh prolly_mutate_blob_right_edge_append`
- `BENCH_ROWS=200 BENCH_RUNS=1 BENCH_MAX_MULTIPLIER=1000 BENCH_AVG_MAX_MULTIPLIER=1000 ./test/sysbench_compare_blobpk.sh`
- `make -j8 c-tests`
