### PR TITLE
ci(bench): tighten sysbench ceilings; split autocommit-writes

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -17,8 +17,6 @@ jobs:
 
     env:
       BENCH_RUNS: 5
-      BENCH_MAX_MULTIPLIER: 6
-      BENCH_AVG_MAX_MULTIPLIER: 5
 
     steps:
     - uses: actions/checkout@v4
@@ -141,8 +139,6 @@ jobs:
 
     env:
       BENCH_RUNS: 5
-      BENCH_MAX_MULTIPLIER: 6
-      BENCH_AVG_MAX_MULTIPLIER: 5
 
     steps:
     - uses: actions/checkout@v4

--- a/test/sysbench_compare.sh
+++ b/test/sysbench_compare.sh
@@ -15,8 +15,10 @@ SQLITE_AUTOCOMMIT_PRAGMAS=${SQLITE_AUTOCOMMIT_PRAGMAS:-"PRAGMA journal_mode=WAL;
 ROWS=${BENCH_ROWS:-100000}
 SEED=42
 TMPDIR=$(mktemp -d)
-BENCH_MAX_MULTIPLIER=${BENCH_MAX_MULTIPLIER:-6}
-BENCH_AVG_MAX_MULTIPLIER=${BENCH_AVG_MAX_MULTIPLIER:-5}
+BENCH_MAX_MULTIPLIER=${BENCH_MAX_MULTIPLIER:-2.5}
+BENCH_AVG_MAX_MULTIPLIER=${BENCH_AVG_MAX_MULTIPLIER:-2}
+BENCH_AC_WRITE_MAX_MULTIPLIER=${BENCH_AC_WRITE_MAX_MULTIPLIER:-5}
+BENCH_AC_WRITE_AVG_MAX_MULTIPLIER=${BENCH_AC_WRITE_AVG_MAX_MULTIPLIER:-5}
 BENCH_SECTION_MODE=${BENCH_SECTION_MODE:-full}
 
 cleanup() { rm -rf "$TMPDIR"; }
@@ -642,15 +644,15 @@ PYEOF
 }
 
 echo ""
-echo "### Performance Ceiling Check (${BENCH_MAX_MULTIPLIER}x individual, ${BENCH_AVG_MAX_MULTIPLIER}x average)"
+echo "### Performance Ceiling Check (${BENCH_MAX_MULTIPLIER}x individual, ${BENCH_AVG_MAX_MULTIPLIER}x average; autocommit writes: ${BENCH_AC_WRITE_MAX_MULTIPLIER}x / ${BENCH_AC_WRITE_AVG_MAX_MULTIPLIER}x)"
 echo ""
 
 ceiling_ok=0
 if [ "$BENCH_SECTION_MODE" = "autocommit" ]; then
   check_ceiling "ac_reads" "$READ_TESTS" "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
-  check_ceiling "ac_writes" "$WRITE_TESTS_AC" "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
+  check_ceiling "ac_writes" "$WRITE_TESTS_AC" "$BENCH_AC_WRITE_MAX_MULTIPLIER" || ceiling_ok=1
   check_average_ceiling "ac_reads" "$READ_TESTS" "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
-  check_average_ceiling "ac_writes" "$WRITE_TESTS_AC" "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
+  check_average_ceiling "ac_writes" "$WRITE_TESTS_AC" "$BENCH_AC_WRITE_AVG_MAX_MULTIPLIER" || ceiling_ok=1
 else
   check_ceiling "mem_reads" "$READ_TESTS" "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
   check_ceiling "mem_writes" "$WRITE_TESTS" "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
@@ -662,9 +664,9 @@ else
   check_average_ceiling "file_writes" "$WRITE_TESTS" "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
   if [ "$BENCH_SECTION_MODE" = "full" ]; then
     check_ceiling "ac_reads" "$READ_TESTS" "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
-    check_ceiling "ac_writes" "$WRITE_TESTS_AC" "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
+    check_ceiling "ac_writes" "$WRITE_TESTS_AC" "$BENCH_AC_WRITE_MAX_MULTIPLIER" || ceiling_ok=1
     check_average_ceiling "ac_reads" "$READ_TESTS" "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
-    check_average_ceiling "ac_writes" "$WRITE_TESTS_AC" "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
+    check_average_ceiling "ac_writes" "$WRITE_TESTS_AC" "$BENCH_AC_WRITE_AVG_MAX_MULTIPLIER" || ceiling_ok=1
   fi
 fi
 

--- a/test/sysbench_compare_blobpk.sh
+++ b/test/sysbench_compare_blobpk.sh
@@ -7,9 +7,11 @@
 # byte order matches integer order). Companion to the TEXT PK suite —
 # verifies the non-INTKEY perf work generalizes to binary keys.
 #
-# Ceiling enforced at BENCH_MAX_MULTIPLIER (default 6×) on individual
-# read/write ratios and BENCH_AVG_MAX_MULTIPLIER (default 5×) on
-# section averages.
+# Ceilings: BENCH_MAX_MULTIPLIER (default 2.5×) on individual
+# read/write ratios and BENCH_AVG_MAX_MULTIPLIER (default 2×) on
+# section averages. Autocommit writes are gated separately by
+# BENCH_AC_WRITE_MAX_MULTIPLIER / BENCH_AC_WRITE_AVG_MAX_MULTIPLIER
+# (default 5× each) since per-statement durability has wider variance.
 #
 set -e
 
@@ -19,8 +21,10 @@ BENCH_TIMER_SQLITE=${BENCH_TIMER_SQLITE:-./bench_timer_sqlite}
 BENCH_TIMER_DOLTLITE=${BENCH_TIMER_DOLTLITE:-./bench_timer_doltlite}
 SQLITE_AUTOCOMMIT_PRAGMAS=${SQLITE_AUTOCOMMIT_PRAGMAS:-"PRAGMA journal_mode=WAL; PRAGMA synchronous=FULL;"}
 ROWS=${BENCH_ROWS:-100000}
-BENCH_MAX_MULTIPLIER=${BENCH_MAX_MULTIPLIER:-6}
-BENCH_AVG_MAX_MULTIPLIER=${BENCH_AVG_MAX_MULTIPLIER:-5}
+BENCH_MAX_MULTIPLIER=${BENCH_MAX_MULTIPLIER:-2.5}
+BENCH_AVG_MAX_MULTIPLIER=${BENCH_AVG_MAX_MULTIPLIER:-2}
+BENCH_AC_WRITE_MAX_MULTIPLIER=${BENCH_AC_WRITE_MAX_MULTIPLIER:-5}
+BENCH_AC_WRITE_AVG_MAX_MULTIPLIER=${BENCH_AC_WRITE_AVG_MAX_MULTIPLIER:-5}
 SEED=42
 TMPDIR=$(mktemp -d)
 
@@ -509,7 +513,7 @@ echo "## Sysbench-Style Benchmark (BLOB PK): Doltlite vs SQLite"
 echo ""
 echo "_Companion to the classic Sysbench-Style Benchmark. Every workload here"
 echo "runs against tables with a 16-byte big-endian \`BLOB PRIMARY KEY\`._"
-echo "_Individual ratios gated at ${BENCH_MAX_MULTIPLIER}×; section averages gated at ${BENCH_AVG_MAX_MULTIPLIER}×._"
+echo "_Individual ratios gated at ${BENCH_MAX_MULTIPLIER}×; section averages gated at ${BENCH_AVG_MAX_MULTIPLIER}×. Autocommit writes use ${BENCH_AC_WRITE_MAX_MULTIPLIER}× / ${BENCH_AC_WRITE_AVG_MAX_MULTIPLIER}×._"
 echo ""
 echo "### In-Memory"
 echo ""
@@ -614,7 +618,7 @@ PYEOF
 }
 
 echo ""
-echo "### Performance Ceiling Check (${BENCH_MAX_MULTIPLIER}x individual, ${BENCH_AVG_MAX_MULTIPLIER}x average)"
+echo "### Performance Ceiling Check (${BENCH_MAX_MULTIPLIER}x individual, ${BENCH_AVG_MAX_MULTIPLIER}x average; autocommit writes: ${BENCH_AC_WRITE_MAX_MULTIPLIER}x / ${BENCH_AC_WRITE_AVG_MAX_MULTIPLIER}x)"
 echo ""
 
 ceiling_ok=0
@@ -623,13 +627,13 @@ check_ceiling "mem_writes"  "$WRITE_TESTS"    "$BENCH_MAX_MULTIPLIER" || ceiling
 check_ceiling "file_reads"  "$READ_TESTS"     "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
 check_ceiling "file_writes" "$WRITE_TESTS"    "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
 check_ceiling "ac_reads"    "$READ_TESTS"     "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
-check_ceiling "ac_writes"   "$WRITE_TESTS_AC" "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
+check_ceiling "ac_writes"   "$WRITE_TESTS_AC" "$BENCH_AC_WRITE_MAX_MULTIPLIER" || ceiling_ok=1
 check_average_ceiling "mem_reads"   "$READ_TESTS"     "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
 check_average_ceiling "mem_writes"  "$WRITE_TESTS"    "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
 check_average_ceiling "file_reads"  "$READ_TESTS"     "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
 check_average_ceiling "file_writes" "$WRITE_TESTS"    "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
 check_average_ceiling "ac_reads"    "$READ_TESTS"     "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
-check_average_ceiling "ac_writes"   "$WRITE_TESTS_AC" "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
+check_average_ceiling "ac_writes"   "$WRITE_TESTS_AC" "$BENCH_AC_WRITE_AVG_MAX_MULTIPLIER" || ceiling_ok=1
 
 if [ "$ceiling_ok" = "0" ]; then
   echo "All tests within ceilings."

--- a/test/sysbench_compare_compositepk.sh
+++ b/test/sysbench_compare_compositepk.sh
@@ -10,9 +10,11 @@
 # Logical id i is split as (a, b) = (i // 10000, i %% 10000) so lex (a,b)
 # tuple ordering matches integer ordering for any R below 10**8.
 #
-# Ceiling enforced at BENCH_MAX_MULTIPLIER (default 6×) on individual
-# read/write ratios and BENCH_AVG_MAX_MULTIPLIER (default 5×) on
-# section averages.
+# Ceilings: BENCH_MAX_MULTIPLIER (default 2.5×) on individual
+# read/write ratios and BENCH_AVG_MAX_MULTIPLIER (default 2×) on
+# section averages. Autocommit writes are gated separately by
+# BENCH_AC_WRITE_MAX_MULTIPLIER / BENCH_AC_WRITE_AVG_MAX_MULTIPLIER
+# (default 5× each) since per-statement durability has wider variance.
 #
 set -e
 
@@ -22,8 +24,10 @@ BENCH_TIMER_SQLITE=${BENCH_TIMER_SQLITE:-./bench_timer_sqlite}
 BENCH_TIMER_DOLTLITE=${BENCH_TIMER_DOLTLITE:-./bench_timer_doltlite}
 SQLITE_AUTOCOMMIT_PRAGMAS=${SQLITE_AUTOCOMMIT_PRAGMAS:-"PRAGMA journal_mode=WAL; PRAGMA synchronous=FULL;"}
 ROWS=${BENCH_ROWS:-100000}
-BENCH_MAX_MULTIPLIER=${BENCH_MAX_MULTIPLIER:-6}
-BENCH_AVG_MAX_MULTIPLIER=${BENCH_AVG_MAX_MULTIPLIER:-5}
+BENCH_MAX_MULTIPLIER=${BENCH_MAX_MULTIPLIER:-2.5}
+BENCH_AVG_MAX_MULTIPLIER=${BENCH_AVG_MAX_MULTIPLIER:-2}
+BENCH_AC_WRITE_MAX_MULTIPLIER=${BENCH_AC_WRITE_MAX_MULTIPLIER:-5}
+BENCH_AC_WRITE_AVG_MAX_MULTIPLIER=${BENCH_AC_WRITE_AVG_MAX_MULTIPLIER:-5}
 SEED=42
 TMPDIR=$(mktemp -d)
 
@@ -529,7 +533,7 @@ echo "## Sysbench-Style Benchmark (composite PK): Doltlite vs SQLite"
 echo ""
 echo "_Companion to the classic Sysbench-Style Benchmark. Every workload here"
 echo "runs against tables with a 2-column INTEGER \`PRIMARY KEY(a, b) WITHOUT ROWID\`._"
-echo "_Individual ratios gated at ${BENCH_MAX_MULTIPLIER}×; section averages gated at ${BENCH_AVG_MAX_MULTIPLIER}×._"
+echo "_Individual ratios gated at ${BENCH_MAX_MULTIPLIER}×; section averages gated at ${BENCH_AVG_MAX_MULTIPLIER}×. Autocommit writes use ${BENCH_AC_WRITE_MAX_MULTIPLIER}× / ${BENCH_AC_WRITE_AVG_MAX_MULTIPLIER}×._"
 echo ""
 echo "### In-Memory"
 echo ""
@@ -634,7 +638,7 @@ PYEOF
 }
 
 echo ""
-echo "### Performance Ceiling Check (${BENCH_MAX_MULTIPLIER}x individual, ${BENCH_AVG_MAX_MULTIPLIER}x average)"
+echo "### Performance Ceiling Check (${BENCH_MAX_MULTIPLIER}x individual, ${BENCH_AVG_MAX_MULTIPLIER}x average; autocommit writes: ${BENCH_AC_WRITE_MAX_MULTIPLIER}x / ${BENCH_AC_WRITE_AVG_MAX_MULTIPLIER}x)"
 echo ""
 
 ceiling_ok=0
@@ -643,13 +647,13 @@ check_ceiling "mem_writes"  "$WRITE_TESTS"    "$BENCH_MAX_MULTIPLIER" || ceiling
 check_ceiling "file_reads"  "$READ_TESTS"     "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
 check_ceiling "file_writes" "$WRITE_TESTS"    "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
 check_ceiling "ac_reads"    "$READ_TESTS"     "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
-check_ceiling "ac_writes"   "$WRITE_TESTS_AC" "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
+check_ceiling "ac_writes"   "$WRITE_TESTS_AC" "$BENCH_AC_WRITE_MAX_MULTIPLIER" || ceiling_ok=1
 check_average_ceiling "mem_reads"   "$READ_TESTS"     "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
 check_average_ceiling "mem_writes"  "$WRITE_TESTS"    "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
 check_average_ceiling "file_reads"  "$READ_TESTS"     "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
 check_average_ceiling "file_writes" "$WRITE_TESTS"    "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
 check_average_ceiling "ac_reads"    "$READ_TESTS"     "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
-check_average_ceiling "ac_writes"   "$WRITE_TESTS_AC" "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
+check_average_ceiling "ac_writes"   "$WRITE_TESTS_AC" "$BENCH_AC_WRITE_AVG_MAX_MULTIPLIER" || ceiling_ok=1
 
 if [ "$ceiling_ok" = "0" ]; then
   echo "All tests within ceilings."

--- a/test/sysbench_compare_textpk.sh
+++ b/test/sysbench_compare_textpk.sh
@@ -6,9 +6,11 @@
 # tables with a 32-char hex TEXT PRIMARY KEY (UUID-shaped). Surfaces the
 # non-INTKEY mutmap-flush cost; companion to issue #718's followup work.
 #
-# Ceiling enforced at BENCH_MAX_MULTIPLIER (default 6×) on individual
-# read/write ratios and BENCH_AVG_MAX_MULTIPLIER (default 5×) on
-# section averages.
+# Ceilings: BENCH_MAX_MULTIPLIER (default 2.5×) on individual
+# read/write ratios and BENCH_AVG_MAX_MULTIPLIER (default 2×) on
+# section averages. Autocommit writes are gated separately by
+# BENCH_AC_WRITE_MAX_MULTIPLIER / BENCH_AC_WRITE_AVG_MAX_MULTIPLIER
+# (default 5× each) since per-statement durability has wider variance.
 #
 set -e
 
@@ -18,8 +20,10 @@ BENCH_TIMER_SQLITE=${BENCH_TIMER_SQLITE:-./bench_timer_sqlite}
 BENCH_TIMER_DOLTLITE=${BENCH_TIMER_DOLTLITE:-./bench_timer_doltlite}
 SQLITE_AUTOCOMMIT_PRAGMAS=${SQLITE_AUTOCOMMIT_PRAGMAS:-"PRAGMA journal_mode=WAL; PRAGMA synchronous=FULL;"}
 ROWS=${BENCH_ROWS:-100000}
-BENCH_MAX_MULTIPLIER=${BENCH_MAX_MULTIPLIER:-6}
-BENCH_AVG_MAX_MULTIPLIER=${BENCH_AVG_MAX_MULTIPLIER:-5}
+BENCH_MAX_MULTIPLIER=${BENCH_MAX_MULTIPLIER:-2.5}
+BENCH_AVG_MAX_MULTIPLIER=${BENCH_AVG_MAX_MULTIPLIER:-2}
+BENCH_AC_WRITE_MAX_MULTIPLIER=${BENCH_AC_WRITE_MAX_MULTIPLIER:-5}
+BENCH_AC_WRITE_AVG_MAX_MULTIPLIER=${BENCH_AC_WRITE_AVG_MAX_MULTIPLIER:-5}
 SEED=42
 TMPDIR=$(mktemp -d)
 
@@ -509,7 +513,7 @@ echo "## Sysbench-Style Benchmark (TEXT PK): Doltlite vs SQLite"
 echo ""
 echo "_Companion to the classic Sysbench-Style Benchmark. Every workload here"
 echo "runs against tables with a 32-char hex \`TEXT PRIMARY KEY\` (UUID-shaped)._"
-echo "_Individual ratios gated at ${BENCH_MAX_MULTIPLIER}×; section averages gated at ${BENCH_AVG_MAX_MULTIPLIER}×._"
+echo "_Individual ratios gated at ${BENCH_MAX_MULTIPLIER}×; section averages gated at ${BENCH_AVG_MAX_MULTIPLIER}×. Autocommit writes use ${BENCH_AC_WRITE_MAX_MULTIPLIER}× / ${BENCH_AC_WRITE_AVG_MAX_MULTIPLIER}×._"
 echo ""
 echo "### In-Memory"
 echo ""
@@ -614,7 +618,7 @@ PYEOF
 }
 
 echo ""
-echo "### Performance Ceiling Check (${BENCH_MAX_MULTIPLIER}x individual, ${BENCH_AVG_MAX_MULTIPLIER}x average)"
+echo "### Performance Ceiling Check (${BENCH_MAX_MULTIPLIER}x individual, ${BENCH_AVG_MAX_MULTIPLIER}x average; autocommit writes: ${BENCH_AC_WRITE_MAX_MULTIPLIER}x / ${BENCH_AC_WRITE_AVG_MAX_MULTIPLIER}x)"
 echo ""
 
 ceiling_ok=0
@@ -623,13 +627,13 @@ check_ceiling "mem_writes"  "$WRITE_TESTS"    "$BENCH_MAX_MULTIPLIER" || ceiling
 check_ceiling "file_reads"  "$READ_TESTS"     "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
 check_ceiling "file_writes" "$WRITE_TESTS"    "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
 check_ceiling "ac_reads"    "$READ_TESTS"     "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
-check_ceiling "ac_writes"   "$WRITE_TESTS_AC" "$BENCH_MAX_MULTIPLIER" || ceiling_ok=1
+check_ceiling "ac_writes"   "$WRITE_TESTS_AC" "$BENCH_AC_WRITE_MAX_MULTIPLIER" || ceiling_ok=1
 check_average_ceiling "mem_reads"   "$READ_TESTS"     "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
 check_average_ceiling "mem_writes"  "$WRITE_TESTS"    "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
 check_average_ceiling "file_reads"  "$READ_TESTS"     "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
 check_average_ceiling "file_writes" "$WRITE_TESTS"    "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
 check_average_ceiling "ac_reads"    "$READ_TESTS"     "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
-check_average_ceiling "ac_writes"   "$WRITE_TESTS_AC" "$BENCH_AVG_MAX_MULTIPLIER" || ceiling_ok=1
+check_average_ceiling "ac_writes"   "$WRITE_TESTS_AC" "$BENCH_AC_WRITE_AVG_MAX_MULTIPLIER" || ceiling_ok=1
 
 if [ "$ceiling_ok" = "0" ]; then
   echo "All tests within ceilings."


### PR DESCRIPTION
## Summary

- Tighten sysbench ceiling defaults from **6× individual / 5× section average → 2.5× / 2.0×** for all sections except autocommit writes.
- Add separate ceiling vars for autocommit writes: `BENCH_AC_WRITE_MAX_MULTIPLIER` / `BENCH_AC_WRITE_AVG_MAX_MULTIPLIER`, default **5× / 5×**.
- Drop the explicit `BENCH_MAX_MULTIPLIER=6` / `BENCH_AVG_MAX_MULTIPLIER=5` env overrides in `.github/workflows/benchmark.yml` so the new script defaults take effect.

## Why

With the prolly-cache bump (#1041) and the recent fast-path work, every read section sits well under 2× on master. Keeping 6×/5× would let a real regression land green. Autocommit writes stay on the wider gate because per-statement durability has real variance and is the next thing to attack — not something the ceiling-tightening should mask.

Same edit applied to all four sysbench scripts (int / text / blob / composite PK).

## Test plan
- [ ] `benchmark.yml` job is green on this branch (validates the new ceilings against current master perf)
- [ ] Confirm in the rendered ceiling line that autocommit writes show `5x / 5x` and everything else shows `2.5x / 2x`

🤖 Generated with [Claude Code](https://claude.com/claude-code)