### PR TITLE
Optimize batched int key replacements

### DIFF
--- a/src/prolly_mutate.c
+++ b/src/prolly_mutate.c
@@ -155,6 +155,12 @@ static int mergeLeaf(
   int rc = SQLITE_OK;
   int j;
   u8 flags = pMut->flags;
+  const u8 *pLastKey = 0;
+  int nLastKey = 0;
+
+  if( pLeaf->nItems>0 ){
+    prollyNodeKey(pLeaf, pLeaf->nItems - 1, &pLastKey, &nLastKey);
+  }
 
   for( j = 0; j < pLeaf->nItems; ){
     int haveEdit = prollyMutMapIterValid(pIter);
@@ -176,10 +182,7 @@ static int mergeLeaf(
     }
 
     {
-      const u8 *pLastKey; int nLastKey;
-      int pastLeaf;
-      prollyNodeKey(pLeaf, pLeaf->nItems - 1, &pLastKey, &nLastKey);
-      pastLeaf = compareKeys(pEd->pKey, pEd->nKey, pLastKey, nLastKey);
+      int pastLeaf = compareKeys(pEd->pKey, pEd->nKey, pLastKey, nLastKey);
       if( pastLeaf > 0 ){
 
         const u8 *pVal; int nVal;
@@ -1127,6 +1130,315 @@ static int tryDeleteInsertPairNoRechunk(ProllyMutator *pMut){
   return SQLITE_OK;
 }
 
+static int mutmapHasOnlyInserts(ProllyMutMap *pMap){
+  int i;
+  if( prollyMutMapIsEmpty(pMap) ) return 0;
+  for(i=0; i<prollyMutMapCount(pMap); i++){
+    if( pMap->aEntries[i].op!=PROLLY_EDIT_INSERT ){
+      return 0;
+    }
+  }
+  return 1;
+}
+
+static int replaceBatchLeafNoRechunk(
+  ProllyMutator *pMut,
+  const ProllyNode *pLeaf,
+  ProllyMutMapIter *pIter,
+  int isLast,
+  ProllyHash *pHash,
+  int *pChanged
+){
+  ProllyNodeBuilder b;
+  int rc = SQLITE_OK;
+  int changed = 0;
+  int i;
+
+  prollyNodeBuilderInit(&b, 0, pMut->flags);
+  for(i=0; i<(int)pLeaf->nItems; i++){
+    const u8 *pCurKey;
+    const u8 *pVal;
+    int nCurKey;
+    int nVal;
+    ProllyMutMapEntry *pEd = 0;
+    int cmp = 1;
+
+    prollyNodeKey(pLeaf, i, &pCurKey, &nCurKey);
+    prollyNodeValue(pLeaf, i, &pVal, &nVal);
+    if( prollyMutMapIterValid(pIter) ){
+      pEd = prollyMutMapIterEntry(pIter);
+      cmp = compareKeys(pEd->pKey, pEd->nKey, pCurKey, nCurKey);
+    }
+    if( cmp<0 ){
+      prollyNodeBuilderFree(&b);
+      return SQLITE_NOTFOUND;
+    }else if( cmp==0 ){
+      rc = prollyNodeBuilderAdd(&b, pCurKey, nCurKey,
+                                pEd->pVal, pEd->nVal);
+      changed = 1;
+      prollyMutMapIterNext(pIter);
+    }else{
+      rc = prollyNodeBuilderAdd(&b, pCurKey, nCurKey, pVal, nVal);
+    }
+    if( rc!=SQLITE_OK ){
+      prollyNodeBuilderFree(&b);
+      return rc;
+    }
+  }
+
+  if( isLast && prollyMutMapIterValid(pIter) ){
+    prollyNodeBuilderFree(&b);
+    return SQLITE_NOTFOUND;
+  }
+
+  if( changed ){
+    rc = writeBuilderNode(pMut->pStore, &b, pHash);
+  }
+  prollyNodeBuilderFree(&b);
+  if( rc!=SQLITE_OK ) return rc;
+  *pChanged = changed;
+  return SQLITE_OK;
+}
+
+static int validateReplaceBatchLeaf(
+  const ProllyNode *pLeaf,
+  ProllyMutMapIter *pIter,
+  int isLast
+){
+  int i;
+  for(i=0; i<(int)pLeaf->nItems; i++){
+    const u8 *pCurKey;
+    int nCurKey;
+    ProllyMutMapEntry *pEd = 0;
+    int cmp = 1;
+
+    prollyNodeKey(pLeaf, i, &pCurKey, &nCurKey);
+    if( prollyMutMapIterValid(pIter) ){
+      pEd = prollyMutMapIterEntry(pIter);
+      cmp = compareKeys(pEd->pKey, pEd->nKey, pCurKey, nCurKey);
+    }
+    if( cmp<0 ){
+      return SQLITE_NOTFOUND;
+    }else if( cmp==0 ){
+      prollyMutMapIterNext(pIter);
+    }
+  }
+  if( isLast && prollyMutMapIterValid(pIter) ){
+    return SQLITE_NOTFOUND;
+  }
+  return SQLITE_OK;
+}
+
+static int validateReplaceBatchNode(
+  ProllyMutator *pMut,
+  const ProllyNode *pNode,
+  ProllyMutMapIter *pIter,
+  int isLast
+){
+  int rc = SQLITE_OK;
+  int i;
+
+  if( pNode->level==0 ){
+    return validateReplaceBatchLeaf(pNode, pIter, isLast);
+  }
+
+  for(i=0; i<(int)pNode->nItems; i++){
+    const u8 *pBoundKey;
+    const u8 *pChildVal;
+    int nBoundKey;
+    int nChildVal;
+    int childIsLast = isLast && (i==(int)pNode->nItems - 1);
+    int forceDescend = childIsLast && prollyMutMapIterValid(pIter);
+
+    prollyNodeKey(pNode, i, &pBoundKey, &nBoundKey);
+    prollyNodeValue(pNode, i, &pChildVal, &nChildVal);
+    if( nChildVal!=PROLLY_HASH_SIZE ) return SQLITE_CORRUPT;
+    if( forceDescend || subtreeHasEdits(pIter, pBoundKey, nBoundKey) ){
+      ProllyHash childHash;
+      ProllyCacheEntry *pChildEntry;
+      u8 *pChildData = 0;
+      int nChildData = 0;
+
+      memcpy(&childHash, pChildVal, PROLLY_HASH_SIZE);
+      pChildEntry = prollyCacheGet(pMut->pCache, &childHash);
+      if( !pChildEntry ){
+        rc = chunkStoreGet(pMut->pStore, &childHash,
+                           &pChildData, &nChildData);
+        if( rc!=SQLITE_OK ) return rc;
+        pChildEntry = prollyCachePut(pMut->pCache, &childHash,
+                                     pChildData, nChildData, &rc);
+        sqlite3_free(pChildData);
+        if( !pChildEntry ) return rc;
+      }
+      rc = validateReplaceBatchNode(pMut, &pChildEntry->node, pIter,
+                                    childIsLast);
+      prollyCacheRelease(pMut->pCache, pChildEntry);
+      if( rc!=SQLITE_OK ) return rc;
+    }
+  }
+  return SQLITE_OK;
+}
+
+static int replaceBatchNodeNoRechunk(
+  ProllyMutator *pMut,
+  const ProllyNode *pNode,
+  ProllyMutMapIter *pIter,
+  int isLast,
+  ProllyHash *pHash,
+  int *pChanged
+){
+  ProllyNodeBuilder b;
+  int rc = SQLITE_OK;
+  int changed = 0;
+  int i;
+
+  if( pNode->level==0 ){
+    return replaceBatchLeafNoRechunk(pMut, pNode, pIter, isLast,
+                                     pHash, pChanged);
+  }
+
+  prollyNodeBuilderInit(&b, pNode->level, pMut->flags);
+  for(i=0; i<(int)pNode->nItems; i++){
+    const u8 *pBoundKey;
+    const u8 *pChildVal;
+    int nBoundKey;
+    int nChildVal;
+    int childIsLast = isLast && (i==(int)pNode->nItems - 1);
+    int forceDescend = childIsLast && prollyMutMapIterValid(pIter);
+    ProllyHash childHash;
+    ProllyHash newChildHash;
+    u64 childCount = 0;
+    int childChanged = 0;
+
+    prollyNodeKey(pNode, i, &pBoundKey, &nBoundKey);
+    prollyNodeValue(pNode, i, &pChildVal, &nChildVal);
+    if( nChildVal!=PROLLY_HASH_SIZE ){
+      prollyNodeBuilderFree(&b);
+      return SQLITE_CORRUPT;
+    }
+    memcpy(&childHash, pChildVal, PROLLY_HASH_SIZE);
+    newChildHash = childHash;
+    rc = parentChildSubtreeCount(pMut->pStore, pMut->pCache,
+                                 pNode, i, &childCount);
+    if( rc!=SQLITE_OK ){
+      prollyNodeBuilderFree(&b);
+      return rc;
+    }
+
+    if( forceDescend || subtreeHasEdits(pIter, pBoundKey, nBoundKey) ){
+      ProllyCacheEntry *pChildEntry;
+      u8 *pChildData = 0;
+      int nChildData = 0;
+
+      pChildEntry = prollyCacheGet(pMut->pCache, &childHash);
+      if( !pChildEntry ){
+        rc = chunkStoreGet(pMut->pStore, &childHash,
+                           &pChildData, &nChildData);
+        if( rc!=SQLITE_OK ){
+          prollyNodeBuilderFree(&b);
+          return rc;
+        }
+        pChildEntry = prollyCachePut(pMut->pCache, &childHash,
+                                     pChildData, nChildData, &rc);
+        sqlite3_free(pChildData);
+        if( !pChildEntry ){
+          prollyNodeBuilderFree(&b);
+          return rc;
+        }
+      }
+      rc = replaceBatchNodeNoRechunk(pMut, &pChildEntry->node, pIter,
+                                     childIsLast, &newChildHash,
+                                     &childChanged);
+      prollyCacheRelease(pMut->pCache, pChildEntry);
+      if( rc!=SQLITE_OK ){
+        prollyNodeBuilderFree(&b);
+        return rc;
+      }
+      if( childChanged ) changed = 1;
+    }
+
+    rc = prollyNodeBuilderAddWithCount(
+        &b, pBoundKey, nBoundKey,
+        (childChanged ? newChildHash.data : childHash.data),
+        PROLLY_HASH_SIZE, childCount);
+    if( rc!=SQLITE_OK ){
+      prollyNodeBuilderFree(&b);
+      return rc;
+    }
+  }
+
+  if( changed ){
+    rc = writeBuilderNode(pMut->pStore, &b, pHash);
+  }
+  prollyNodeBuilderFree(&b);
+  if( rc!=SQLITE_OK ) return rc;
+  *pChanged = changed;
+  return SQLITE_OK;
+}
+
+static int tryReplaceBatchNoRechunk(ProllyMutator *pMut){
+  ProllyMutMapIter iter;
+  ProllyCacheEntry *pRootEntry = 0;
+  u8 *pRootData = 0;
+  int nRootData = 0;
+  ProllyNode rootNode;
+  ProllyNode *pRootNode = &rootNode;
+  ProllyHash newRoot;
+  int changed = 0;
+  int rc;
+
+  /* Conservative batch path for rowid-table updates: only existing INT keys
+  ** are replaced, so leaf boundaries, separator keys, and subtree counts are
+  ** unchanged. */
+  if( prollyHashIsEmpty(&pMut->oldRoot) ) return SQLITE_NOTFOUND;
+  if( !(pMut->flags & PROLLY_NODE_INTKEY) ) return SQLITE_NOTFOUND;
+  if( prollyMutMapCount(pMut->pEdits)<=1 ) return SQLITE_NOTFOUND;
+  if( !mutmapHasOnlyInserts(pMut->pEdits) ) return SQLITE_NOTFOUND;
+
+  pRootEntry = pMut->pCache ? prollyCacheGet(pMut->pCache, &pMut->oldRoot) : 0;
+  if( pRootEntry ){
+    pRootNode = &pRootEntry->node;
+  }else{
+    rc = chunkStoreGet(pMut->pStore, &pMut->oldRoot, &pRootData, &nRootData);
+    if( rc!=SQLITE_OK ) return rc;
+    rc = prollyNodeParse(&rootNode, pRootData, nRootData);
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(pRootData);
+      return rc;
+    }
+  }
+
+  prollyMutMapIterFirst(&iter, pMut->pEdits);
+  if( prollyMutMapIterValid(&iter) && pRootNode->nItems>0 ){
+    ProllyMutMapEntry *pFirst = prollyMutMapIterEntry(&iter);
+    const u8 *pMaxKey;
+    int nMaxKey;
+    prollyNodeKey(pRootNode, (int)pRootNode->nItems - 1,
+                  &pMaxKey, &nMaxKey);
+    if( compareKeys(pFirst->pKey, pFirst->nKey, pMaxKey, nMaxKey)>0 ){
+      rc = SQLITE_NOTFOUND;
+      goto replace_batch_cleanup;
+    }
+  }
+  rc = validateReplaceBatchNode(pMut, pRootNode, &iter, 1);
+  if( rc==SQLITE_OK && prollyMutMapIterValid(&iter) ){
+    rc = SQLITE_NOTFOUND;
+  }
+  if( rc==SQLITE_OK ){
+    prollyMutMapIterFirst(&iter, pMut->pEdits);
+    rc = replaceBatchNodeNoRechunk(pMut, pRootNode, &iter, 1,
+                                   &newRoot, &changed);
+  }
+  if( rc==SQLITE_OK ){
+    pMut->newRoot = changed ? newRoot : pMut->oldRoot;
+  }
+
+replace_batch_cleanup:
+  if( pRootEntry ) prollyCacheRelease(pMut->pCache, pRootEntry);
+  sqlite3_free(pRootData);
+  return rc;
+}
+
 int prollyMutateFlush(ProllyMutator *pMut){
   int rc;
 
@@ -1147,6 +1459,9 @@ int prollyMutateFlush(ProllyMutator *pMut){
     }
     if( rc==SQLITE_NOTFOUND ){
       rc = tryDeleteInsertPairNoRechunk(pMut);
+    }
+    if( rc==SQLITE_NOTFOUND ){
+      rc = tryReplaceBatchNoRechunk(pMut);
     }
     if( rc==SQLITE_NOTFOUND ){
       rc = streamingMerge(pMut);

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -6666,6 +6666,103 @@ static void run_prolly_mutate_appends_blob_key_to_right_edge(void){
   chunkStoreClose(&cs);
 }
 
+static void run_prolly_mutate_batches_existing_int_replacements(void){
+  ChunkStore cs;
+  ProllyCache cache;
+  ProllyChunker chunker;
+  ProllyMutMap mm;
+  ProllyMutator mut;
+  ProllyCursor cur;
+  ProllyHash rootHash, newRootHash;
+  ProllyNode rootNode;
+  u8 *pRootData = 0;
+  int nRootData = 0;
+  u8 aKey[8];
+  u8 aVal[32];
+  const u8 *pVal = 0;
+  int nVal = 0;
+  int rc;
+  int res = 99;
+  int i;
+  int nSeen = 0;
+  const int nItem = 100000;
+
+  printf("=== Prolly Mutate Batch Int Replacement Test ===\n\n");
+
+  check("open_memory_store_for_prolly_batch_replace",
+        chunkStoreOpen(&cs, sqlite3_vfs_find(0), ":memory:", 0)==SQLITE_OK);
+  check("init_cache_for_prolly_batch_replace",
+        prollyCacheInit(&cache, 64)==SQLITE_OK);
+  check("init_chunker_for_prolly_batch_replace",
+        prollyChunkerInit(&chunker, &cs, PROLLY_NODE_INTKEY)==SQLITE_OK);
+
+  for( i = 1; i <= nItem; i++ ){
+    prollyEncodeIntKey(i, aKey);
+    sqlite3_snprintf(sizeof(aVal), (char*)aVal, "row-%d", i);
+    check("add_key_to_chunker_for_prolly_batch_replace",
+          prollyChunkerAdd(&chunker, aKey, sizeof(aKey),
+                           aVal, (int)strlen((char*)aVal))==SQLITE_OK);
+  }
+  check("finish_chunker_for_prolly_batch_replace",
+        prollyChunkerFinish(&chunker)==SQLITE_OK);
+  prollyChunkerGetRoot(&chunker, &rootHash);
+  prollyChunkerFree(&chunker);
+
+  check("load_root_for_prolly_batch_replace",
+        chunkStoreGet(&cs, &rootHash, &pRootData, &nRootData)==SQLITE_OK);
+  check("parse_root_for_prolly_batch_replace",
+        prollyNodeParse(&rootNode, pRootData, nRootData)==SQLITE_OK);
+  check("root_is_multi_level_for_prolly_batch_replace", rootNode.level >= 2);
+  sqlite3_free(pRootData);
+
+  check("init_mutmap_for_prolly_batch_replace",
+        prollyMutMapInitMode(&mm, 1, 0)==SQLITE_OK);
+  for( i = 1000; i < 2000; i++ ){
+    sqlite3_snprintf(sizeof(aVal), (char*)aVal, "new-%d", i);
+    check("insert_replacement_for_prolly_batch_replace",
+          prollyMutMapInsert(&mm, 0, 0, i,
+                             aVal, (int)strlen((char*)aVal))==SQLITE_OK);
+  }
+
+  memset(&mut, 0, sizeof(mut));
+  mut.pStore = &cs;
+  mut.pCache = &cache;
+  mut.oldRoot = rootHash;
+  mut.pEdits = &mm;
+  mut.flags = PROLLY_NODE_INTKEY;
+  rc = prollyMutateFlush(&mut);
+  check("flush_batch_int_replacements", rc==SQLITE_OK);
+  newRootHash = mut.newRoot;
+  prollyMutMapFree(&mm);
+
+  prollyCursorInit(&cur, &cs, &cache, &newRootHash, PROLLY_NODE_INTKEY);
+  rc = prollyCursorSeekInt(&cur, 1500, &res);
+  check("seek_replaced_batch_int_key", rc==SQLITE_OK);
+  check("seek_replaced_batch_int_key_found",
+        res==0 && prollyCursorIsValid(&cur));
+  if( prollyCursorIsValid(&cur) ){
+    prollyCursorValue(&cur, &pVal, &nVal);
+    check("replaced_batch_int_value",
+          nVal==8 && memcmp(pVal, "new-1500", 8)==0);
+  }
+  prollyCursorClose(&cur);
+
+  prollyCursorInit(&cur, &cs, &cache, &newRootHash, PROLLY_NODE_INTKEY);
+  rc = prollyCursorFirst(&cur, &res);
+  check("cursor_first_after_batch_int_replace", rc==SQLITE_OK);
+  while( prollyCursorIsValid(&cur) ){
+    nSeen++;
+    rc = prollyCursorNext(&cur);
+    if( rc!=SQLITE_OK ) break;
+  }
+  check("batch_int_replace_count_unchanged", nSeen==nItem);
+  check("iterate_after_batch_int_replace_ok", rc==SQLITE_OK);
+
+  prollyCursorClose(&cur);
+  prollyCacheFree(&cache);
+  chunkStoreClose(&cs);
+}
+
 static void run_chunk_store_rollback_restores_refs_hash(void){
   ChunkStore cs;
   ProllyHash emptyHash;
@@ -7528,6 +7625,7 @@ static const RegressionCase aCases[] = {
   { "mutmap_differential_randomized", "MutMap Differential Randomized Test", run_mutmap_differential_randomized },
   { "prolly_mutate_skip_subtree_order", "Prolly Mutate Skipped Subtree Order Test", run_prolly_mutate_preserves_order_across_skipped_subtrees },
   { "prolly_mutate_blob_right_edge_append", "Prolly Mutate Blob Right Edge Append Test", run_prolly_mutate_appends_blob_key_to_right_edge },
+  { "prolly_mutate_batch_int_replace", "Prolly Mutate Batch Int Replacement Test", run_prolly_mutate_batches_existing_int_replacements },
   { "refs_hash_rollback_restore", "Chunk Store Rollback Restores Refs Hash Test", run_chunk_store_rollback_restores_refs_hash },
   { "refs_hash_commit_failure_restore", "Chunk Store Commit Failure Restores Refs Hash Test", run_chunk_store_commit_failure_restores_refs_hash },
   { "remotesrv_put_refs_failure_restore", "RemoteSrv Put Refs Failure Restores State Test", run_remotesrv_put_refs_failure_restores_state },


### PR DESCRIPTION
## Summary
- Targets the current in-memory `oltp_write_only` outlier from PR #1043 benchmark comments: classic INT keys, in-memory, non-autocommit, `oltp_write_only` at 2.25x SQLite.
- Adds a conservative batch replacement fast path for INT-key prolly trees.
- The fast path only fires when all pending edits are inserts over existing INT keys, so leaf boundaries, separator keys, and subtree counts stay unchanged.
- Adds direct regression coverage for 1,000 replacements in a multi-level INT-key tree.

## Local benchmark comparison
Custom 100K-row classic INT-key in-memory harness, 15 runs, clean master vs this branch:

- `oltp_write_only` median: `29,008us` -> `28,187us`
- `oltp_write_only` trimmed median: `28,924us` -> `28,181us`
- commit-only slice for the same workload: about `19,316us` -> `18,749us`

Nearby checks:
- `oltp_update_non_index` median: `37,987us` -> `37,174us`
- `oltp_delete_insert` median: `43,982us` -> `43,448us`
- `oltp_update_index` stayed essentially flat/noisy: `56,749us` -> `56,576us`

## Tests
- `DOLTLITE_BUILD_DIR=$PWD bash test/run_doltlite_regression_case.sh prolly_mutate_batch_int_replace`
- `BENCH_ROWS=200 BENCH_RUNS=1 BENCH_MAX_MULTIPLIER=1000 BENCH_AVG_MAX_MULTIPLIER=1000 bash test/sysbench_compare.sh`
- `make -j8 c-tests`
