### PR TITLE
Fix GC schema rootpage metadata

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -2387,14 +2387,16 @@ static int deserializeCatalog(Btree *pBtree, const u8 *data, int nData){
 
   {
     Pgno maxPage = 0;
+    Pgno maxCatalogTable = 0;
     for(i=0; i<pBtree->cat.n; i++){
-      if( pBtree->cat.a[i].iTable > maxPage ){
-        maxPage = pBtree->cat.a[i].iTable;
+      if( pBtree->cat.a[i].iTable > maxCatalogTable ){
+        maxCatalogTable = pBtree->cat.a[i].iTable;
       }
     }
+    maxPage = maxCatalogTable;
     pBtree->aMeta[BTREE_LARGEST_ROOT_PAGE] = maxPage;
 
-    pBtree->cat.iNextTable = maxPage + 1;
+    pBtree->cat.iNextTable = maxCatalogTable + 1;
   }
 
   if( getenv("DOLTLITE_DEBUG_CAT") ){
@@ -4379,6 +4381,12 @@ static Pgno prollyBtreeLastPage(Btree *p){
     + (i64)chunkStagingRecentCount(&cs->staging);
   if( n < 0 ) n = 0;
   if( n > (i64)0xfffffffe ) n = (i64)0xfffffffe;
+  /* SQLite uses LastPage as an upper bound when validating schema rootpages.
+  ** Doltlite's physical page count is a chunk count, which GC can reduce
+  ** below stable sqlite_master rootpage numbers. */
+  if( p->aMeta[BTREE_LARGEST_ROOT_PAGE]>(Pgno)n ){
+    n = p->aMeta[BTREE_LARGEST_ROOT_PAGE];
+  }
   return (Pgno)n;
 }
 Pgno sqlite3BtreeLastPage(Btree *p){

--- a/test/doltlite_gc.sh
+++ b/test/doltlite_gc.sh
@@ -229,6 +229,35 @@ run_test "gc_tables_reopen_b" "SELECT count(*) FROM b;" "2" "$DB"
 
 db_rm "$DB"
 
+DB=/tmp/test_gc_schema_rootpages_$$.db; db_rm "$DB"
+echo "PRAGMA foreign_keys=ON;
+CREATE TABLE a(
+  id TEXT PRIMARY KEY,
+  x TEXT NOT NULL
+);
+CREATE TABLE b(
+  id TEXT PRIMARY KEY,
+  a_id TEXT NOT NULL REFERENCES a(id),
+  y TEXT NOT NULL
+);
+CREATE TABLE c(
+  a_id TEXT NOT NULL REFERENCES a(id),
+  b_id TEXT NOT NULL REFERENCES b(id),
+  y TEXT NOT NULL,
+  z INTEGER NOT NULL CHECK(z >= 0),
+  PRIMARY KEY(a_id,b_id)
+) WITHOUT ROWID;
+CREATE INDEX idx_b_a ON b(a_id);
+CREATE INDEX idx_c_y ON c(y);
+SELECT dolt_gc();" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test "gc_schema_rootpage_reopen" \
+  "SELECT count(*) FROM sqlite_master WHERE name='idx_c_y';" "1" "$DB"
+run_test_match "gc_schema_rootpage_second_gc" \
+  "SELECT dolt_gc();" "chunks" "$DB"
+
+db_rm "$DB"
+
 DB=/tmp/test_gc_idem_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');

--- a/test/doltlite_pragma_page_count.sh
+++ b/test/doltlite_pragma_page_count.sh
@@ -5,9 +5,10 @@
 # is a function of how many user tables have been created (not the
 # database's actual storage footprint), plus a fixed offset.
 #
-# After this PR, `PRAGMA page_count` returns the total chunk count
-# (index + pending + recent) — the honest measure of "how many
-# chunks are in the store right now".
+# `PRAGMA page_count` returns the total chunk count (index + pending
+# + recent), clamped high enough to cover SQLite-visible schema rootpages.
+# This keeps it an honest storage-footprint proxy while preserving the
+# invariant SQLite's schema loader expects: rootpage <= last page.
 #
 # Numbers are NOT directly comparable to stock SQLite's page_count
 # (chunks are variable size, content-addressed). They are a coarse
@@ -92,6 +93,36 @@ run_test_grows "pc_grows_with_bulk_insert" "$small" "$big"
 # With one user table, the legacy value would have been ~1002; the
 # real chunk count is much smaller (low tens).
 run_test_int_in "pc_not_fabricated_value" "$big" 1 200
+db_rm "$DB"
+
+# GC can compact the physical chunk count below stable sqlite_master rootpage
+# numbers. Fresh opens still need page_count/LastPage to cover those rootpages,
+# otherwise SQLite rejects the schema as malformed during initialization.
+DB=/tmp/test_pc_gc_rootpages_$$.db; db_rm "$DB"
+$DOLTLITE "$DB" "PRAGMA foreign_keys=ON;
+CREATE TABLE a(
+  id TEXT PRIMARY KEY,
+  x TEXT NOT NULL
+);
+CREATE TABLE b(
+  id TEXT PRIMARY KEY,
+  a_id TEXT NOT NULL REFERENCES a(id),
+  y TEXT NOT NULL
+);
+CREATE TABLE c(
+  a_id TEXT NOT NULL REFERENCES a(id),
+  b_id TEXT NOT NULL REFERENCES b(id),
+  y TEXT NOT NULL,
+  z INTEGER NOT NULL CHECK(z >= 0),
+  PRIMARY KEY(a_id,b_id)
+) WITHOUT ROWID;
+CREATE INDEX idx_b_a ON b(a_id);
+CREATE INDEX idx_c_y ON c(y);
+SELECT dolt_gc();" > /dev/null 2>&1
+
+pc=$($DOLTLITE "$DB" "PRAGMA page_count;" 2>&1 | tr -d '\n')
+max_root=$($DOLTLITE "$DB" "SELECT max(rootpage) FROM sqlite_master;" 2>&1 | tr -d '\n')
+run_test_int_ge "pc_gc_covers_schema_rootpages" "$pc" "$max_root"
 db_rm "$DB"
 
 echo ""


### PR DESCRIPTION
Fixes #1040.

## Summary
- restore BTREE_LARGEST_ROOT_PAGE high enough for canonical sqlite_master rootpages after catalog deserialize
- add GC regression coverage for fresh reopen after GC with secondary indexes, FKs, and WITHOUT ROWID schema

## Tests
- make -j8 doltlite doltlite-lib
- bash test/doltlite_gc.sh
