### PR TITLE
Harden GC rewrite failure handling

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -169,3 +169,34 @@ jobs:
           leak-*
           timeout-*
         if-no-files-found: ignore
+
+  windows:
+    runs-on: windows-latest
+    timeout-minutes: 25
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Windows dependencies
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: MINGW64
+        install: mingw-w64-x86_64-gcc mingw-w64-x86_64-zlib make perl tcl
+
+    - name: Configure and build
+      shell: msys2 {0}
+      run: |
+        mkdir -p build && cd build
+        ../configure
+        make -j$(nproc) DOLTLITE_PROLLY_CHECK=1 doltlite.exe doltlite-lib
+
+    - name: GC smoke tests
+      shell: msys2 {0}
+      run: |
+        cd build
+        ./doltlite.exe /tmp/windows_smoke.db "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'); SELECT dolt_commit('-A','-m','c1'); SELECT dolt_gc(); SELECT count(*) FROM t;"
+        bash ../test/doltlite_gc.sh
+        bash ../test/doltlite_gc_session_state.sh
+        bash ../test/doltlite_pragma_page_count.sh
+        cd ..
+        bash test/run_doltlite_regression_case.sh gc_rewrite_failure

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -190,11 +190,23 @@ jobs:
         ../configure
         make -j$(nproc) DOLTLITE_PROLLY_CHECK=1 doltlite.exe doltlite-lib
 
+    - name: Basic SQL smoke tests
+      shell: msys2 {0}
+      run: |
+        cd build
+        rm -f /tmp/windows_smoke_basic.db /tmp/windows_smoke_basic.db-wal
+        test "$(./doltlite.exe :memory: "SELECT 1;")" = "1"
+        ./doltlite.exe /tmp/windows_smoke_basic.db "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'); SELECT count(*) FROM t;"
+        test "$(./doltlite.exe /tmp/windows_smoke_basic.db "SELECT v FROM t WHERE id=1;")" = "a"
+        ./doltlite.exe /tmp/windows_smoke_basic.db "SELECT dolt_commit('-A','-m','c1');"
+        test "$(./doltlite.exe /tmp/windows_smoke_basic.db "SELECT count(*) FROM dolt_log;")" = "2"
+
     - name: GC smoke tests
       shell: msys2 {0}
       run: |
         cd build
-        ./doltlite.exe /tmp/windows_smoke.db "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'); SELECT dolt_commit('-A','-m','c1'); SELECT dolt_gc(); SELECT count(*) FROM t;"
+        rm -f /tmp/windows_smoke_gc.db /tmp/windows_smoke_gc.db-wal
+        ./doltlite.exe /tmp/windows_smoke_gc.db "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'); SELECT dolt_commit('-A','-m','c1'); SELECT dolt_gc(); SELECT count(*) FROM t;"
         bash ../test/doltlite_gc.sh
         bash ../test/doltlite_gc_session_state.sh
         bash ../test/doltlite_pragma_page_count.sh

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -194,7 +194,7 @@ jobs:
       shell: msys2 {0}
       run: |
         cd build
-        rm -f /tmp/windows_smoke_basic.db /tmp/windows_smoke_basic.db-wal
+        rm -f /tmp/windows_smoke_basic.db /tmp/windows_smoke_basic.db-wal /tmp/windows_smoke_basic.db-lock
         test "$(./doltlite.exe :memory: "SELECT 1;")" = "1"
         ./doltlite.exe /tmp/windows_smoke_basic.db "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'); SELECT count(*) FROM t;"
         test "$(./doltlite.exe /tmp/windows_smoke_basic.db "SELECT v FROM t WHERE id=1;")" = "a"
@@ -205,7 +205,7 @@ jobs:
       shell: msys2 {0}
       run: |
         cd build
-        rm -f /tmp/windows_smoke_gc.db /tmp/windows_smoke_gc.db-wal
+        rm -f /tmp/windows_smoke_gc.db /tmp/windows_smoke_gc.db-wal /tmp/windows_smoke_gc.db-lock
         ./doltlite.exe /tmp/windows_smoke_gc.db "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'); SELECT dolt_commit('-A','-m','c1'); SELECT dolt_gc(); SELECT count(*) FROM t;"
         bash ../test/doltlite_gc.sh
         bash ../test/doltlite_gc_session_state.sh

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -210,5 +210,3 @@ jobs:
         bash ../test/doltlite_gc.sh
         bash ../test/doltlite_gc_session_state.sh
         bash ../test/doltlite_pragma_page_count.sh
-        cd ..
-        bash test/run_doltlite_regression_case.sh gc_rewrite_failure

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -220,7 +220,7 @@ jobs:
           tkt-7bbfb7d442 tkt-4dd95f6943 tkt-2d1a5c67d \
           tkt-f3e5abed55
 
-  windows-gc-smoke:
+  windows-smoke:
     runs-on: windows-latest
     timeout-minutes: 25
 
@@ -244,7 +244,6 @@ jobs:
       shell: msys2 {0}
       run: |
         cd build
-        cp doltlite.exe doltlite
         bash ../test/doltlite_gc.sh
         bash ../test/doltlite_gc_session_state.sh
         bash ../test/doltlite_pragma_page_count.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -220,6 +220,37 @@ jobs:
           tkt-7bbfb7d442 tkt-4dd95f6943 tkt-2d1a5c67d \
           tkt-f3e5abed55
 
+  windows-gc-smoke:
+    runs-on: windows-latest
+    timeout-minutes: 25
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Windows dependencies
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: MINGW64
+        install: mingw-w64-x86_64-gcc mingw-w64-x86_64-zlib make perl tcl
+
+    - name: Configure and build
+      shell: msys2 {0}
+      run: |
+        mkdir -p build && cd build
+        ../configure
+        make -j$(nproc) DOLTLITE_PROLLY_CHECK=1 doltlite.exe doltlite-lib
+
+    - name: GC smoke tests
+      shell: msys2 {0}
+      run: |
+        cd build
+        cp doltlite.exe doltlite
+        bash ../test/doltlite_gc.sh
+        bash ../test/doltlite_gc_session_state.sh
+        bash ../test/doltlite_pragma_page_count.sh
+        cd ..
+        bash test/run_doltlite_regression_case.sh gc_rewrite_failure
+
   concurrency-stress:
     runs-on: ubuntu-latest
     timeout-minutes: 25

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -220,36 +220,6 @@ jobs:
           tkt-7bbfb7d442 tkt-4dd95f6943 tkt-2d1a5c67d \
           tkt-f3e5abed55
 
-  windows-smoke:
-    runs-on: windows-latest
-    timeout-minutes: 25
-
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Install Windows dependencies
-      uses: msys2/setup-msys2@v2
-      with:
-        msystem: MINGW64
-        install: mingw-w64-x86_64-gcc mingw-w64-x86_64-zlib make perl tcl
-
-    - name: Configure and build
-      shell: msys2 {0}
-      run: |
-        mkdir -p build && cd build
-        ../configure
-        make -j$(nproc) DOLTLITE_PROLLY_CHECK=1 doltlite.exe doltlite-lib
-
-    - name: GC smoke tests
-      shell: msys2 {0}
-      run: |
-        cd build
-        bash ../test/doltlite_gc.sh
-        bash ../test/doltlite_gc_session_state.sh
-        bash ../test/doltlite_pragma_page_count.sh
-        cd ..
-        bash test/run_doltlite_regression_case.sh gc_rewrite_failure
-
   concurrency-stress:
     runs-on: ubuntu-latest
     timeout-minutes: 25

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -13,50 +13,52 @@
 #include <sys/stat.h>
 
 #ifdef _WIN32
-# include <io.h>
-# include <windows.h>
-  static int csFileLock(const char *path, int *pFd){
-    int fd = _open(path, _O_BINARY | _O_RDWR | _O_CREAT, 0644);
-    if( fd < 0 ) return -1;
-    {
-      HANDLE h = (HANDLE)_get_osfhandle(fd);
-      OVERLAPPED ov = {0};
-      if( !LockFileEx(h, LOCKFILE_EXCLUSIVE_LOCK, 0, MAXDWORD, MAXDWORD, &ov) ){
-        _close(fd);
-        return -1;
-      }
+  static int csFileLockHeld(sqlite3_file *pFile){
+    return pFile!=0;
+  }
+  static char *csLockPath(const char *path){
+    return sqlite3_mprintf("%s-lock", path);
+  }
+  static int csFileLock(sqlite3_vfs *pVfs, const char *path,
+                        sqlite3_file **ppFile){
+    char *zLock = csLockPath(path);
+    sqlite3_file *pFile = 0;
+    int flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE
+              | SQLITE_OPEN_MAIN_DB;
+    int rc;
+
+    *ppFile = 0;
+    if( !zLock ) return -1;
+    rc = sqlite3OsOpenMalloc(pVfs, zLock, &pFile, flags, 0);
+    sqlite3_free(zLock);
+    if( rc!=SQLITE_OK ) return -1;
+    rc = sqlite3OsLock(pFile, SQLITE_LOCK_EXCLUSIVE);
+    if( rc!=SQLITE_OK ){
+      sqlite3OsCloseFree(pFile);
+      return -1;
     }
-    *pFd = fd;
+    *ppFile = pFile;
     return 0;
   }
-  static void csFileUnlock(int fd){
-    if( fd >= 0 ){
-      HANDLE h = (HANDLE)_get_osfhandle(fd);
-      OVERLAPPED ov = {0};
-      UnlockFileEx(h, 0, MAXDWORD, MAXDWORD, &ov);
-      _close(fd);
+  static void csFileUnlock(sqlite3_file *pFile){
+    if( pFile ){
+      sqlite3OsUnlock(pFile, SQLITE_LOCK_NONE);
+      sqlite3OsCloseFree(pFile);
     }
   }
-  static int csFileLockNB(const char *path, int *pFd){
-    int fd = _open(path, _O_BINARY | _O_RDWR | _O_CREAT, 0644);
-    if( fd < 0 ) return -1;
-    {
-      HANDLE h = (HANDLE)_get_osfhandle(fd);
-      OVERLAPPED ov = {0};
-      if( !LockFileEx(h, LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY,
-                       0, MAXDWORD, MAXDWORD, &ov) ){
-        _close(fd);
-        return -1;
-      }
-    }
-    *pFd = fd;
-    return 0;
+  static int csFileLockNB(sqlite3_vfs *pVfs, const char *path,
+                          sqlite3_file **ppFile){
+    return csFileLock(pVfs, path, ppFile);
   }
 #else
 # include <unistd.h>
 # include <sys/file.h>
-  static int csFileLock(const char *path, int *pFd){
+  static int csFileLockHeld(int fd){
+    return fd>=0;
+  }
+  static int csFileLock(sqlite3_vfs *pVfs, const char *path, int *pFd){
     int fd = open(path, O_RDWR | O_CREAT, 0644);
+    (void)pVfs;
     if( fd < 0 ) return -1;
     if( flock(fd, LOCK_EX) != 0 ){
       close(fd);
@@ -68,8 +70,9 @@
   static void csFileUnlock(int fd){
     if( fd >= 0 ) close(fd);
   }
-  static int csFileLockNB(const char *path, int *pFd){
+  static int csFileLockNB(sqlite3_vfs *pVfs, const char *path, int *pFd){
     int fd = open(path, O_RDWR | O_CREAT, 0644);
+    (void)pVfs;
     if( fd < 0 ) return -1;
     if( flock(fd, LOCK_EX | LOCK_NB) != 0 ){
       close(fd);
@@ -78,6 +81,16 @@
     *pFd = fd;
     return 0;
   }
+#endif
+
+#ifdef _WIN32
+  typedef sqlite3_file *CsFileLock;
+# define CS_FILE_LOCK_INIT 0
+# define CS_GRAPH_LOCK(cs) ((cs)->pGraphLockFile)
+#else
+  typedef int CsFileLock;
+# define CS_FILE_LOCK_INIT -1
+# define CS_GRAPH_LOCK(cs) ((cs)->graphLockFd)
 #endif
 
 #define CS_READ_U32(p) (             \
@@ -285,7 +298,7 @@ int chunkStoreOpen(
 
   memset(cs, 0, sizeof(*cs));
   cs->file.pVfs = pVfs;
-  cs->graphLockFd = -1;
+  CS_GRAPH_LOCK(cs) = CS_FILE_LOCK_INIT;
   cs->pLockMutex = sqlite3_mutex_alloc(SQLITE_MUTEX_RECURSIVE);
   cs->lockDepth = 0;
 
@@ -1058,9 +1071,9 @@ static int csCommitToFile(ChunkStore *cs){
   i64 fileSize = 0;
   i64 origFileSize = 0;
   i64 writeOff = 0;
-  int lockFd = -1;
+  CsFileLock lockFd = CS_FILE_LOCK_INIT;
   int hadFile = (cs->file.pFile != 0);
-  int lockHeld = (cs->graphLockFd >= 0);
+  int lockHeld = csFileLockHeld(CS_GRAPH_LOCK(cs));
   i64 newWalSize = cs->wal.nWalData;
   ChunkIndexEntry *aCommittedPending = 0;
   ChunkIndexEntry aSmallCommittedPending[32];
@@ -1078,9 +1091,9 @@ static int csCommitToFile(ChunkStore *cs){
   }
 
   if( lockHeld ){
-    lockFd = -1;
+    lockFd = CS_FILE_LOCK_INIT;
   }else{
-    if( csFileLock(cs->file.zFilename, &lockFd) != 0 ){
+    if( csFileLock(cs->file.pVfs, cs->file.zFilename, &lockFd) != 0 ){
       return SQLITE_BUSY;
     }
   }
@@ -1361,7 +1374,7 @@ int chunkStoreCommit(ChunkStore *cs){
   memset(&savedRefs, 0, sizeof(savedRefs));
   if( cs->readOnly ) return SQLITE_READONLY;
   if( cs->isMemory ) return csCommitToMemory(cs);
-  if( cs->graphLockFd < 0 && cs->file.zFilename ){
+  if( !csFileLockHeld(CS_GRAPH_LOCK(cs)) && cs->file.zFilename ){
     preserveRefs = cs->staging.nPending > 0
                 && prollyHashCompare(&cs->refs.refsHash,
                                      &cs->refs.committedRefsHash)!=0;
@@ -1449,14 +1462,14 @@ int chunkStoreLockAndRefreshChanged(ChunkStore *cs, int *pChanged){
     if( cs->pLockMutex ) sqlite3_mutex_leave(cs->pLockMutex);
     return SQLITE_ERROR;
   }
-  if( csFileLockNB(cs->file.zFilename, &cs->graphLockFd) != 0 ){
+  if( csFileLockNB(cs->file.pVfs, cs->file.zFilename, &CS_GRAPH_LOCK(cs)) != 0 ){
     if( cs->pLockMutex ) sqlite3_mutex_leave(cs->pLockMutex);
     return SQLITE_BUSY;
   }
   rc = chunkStoreRefreshIfChanged(cs, &changed);
   if( rc!=SQLITE_OK ){
-    csFileUnlock(cs->graphLockFd);
-    cs->graphLockFd = -1;
+    csFileUnlock(CS_GRAPH_LOCK(cs));
+    CS_GRAPH_LOCK(cs) = CS_FILE_LOCK_INIT;
     if( cs->pLockMutex ) sqlite3_mutex_leave(cs->pLockMutex);
     return rc;
   }
@@ -1472,32 +1485,15 @@ int chunkStoreLockAndRefresh(ChunkStore *cs){
 void chunkStoreUnlock(ChunkStore *cs){
   if( cs->lockDepth > 0 ){
     cs->lockDepth--;
-    if( cs->lockDepth == 0 && cs->graphLockFd >= 0 ){
-      csFileUnlock(cs->graphLockFd);
-      cs->graphLockFd = -1;
+    if( cs->lockDepth == 0 && csFileLockHeld(CS_GRAPH_LOCK(cs)) ){
+      csFileUnlock(CS_GRAPH_LOCK(cs));
+      CS_GRAPH_LOCK(cs) = CS_FILE_LOCK_INIT;
     }
     if( cs->pLockMutex ) sqlite3_mutex_leave(cs->pLockMutex);
-  }else if( cs->graphLockFd >= 0 ){
-    csFileUnlock(cs->graphLockFd);
-    cs->graphLockFd = -1;
+  }else if( csFileLockHeld(CS_GRAPH_LOCK(cs)) ){
+    csFileUnlock(CS_GRAPH_LOCK(cs));
+    CS_GRAPH_LOCK(cs) = CS_FILE_LOCK_INIT;
   }
-}
-
-int chunkStoreReleaseFileLock(ChunkStore *cs){
-  if( cs->graphLockFd >= 0 ){
-    csFileUnlock(cs->graphLockFd);
-    cs->graphLockFd = -1;
-  }
-  return SQLITE_OK;
-}
-
-int chunkStoreReacquireFileLock(ChunkStore *cs){
-  if( cs->isMemory || cs->graphLockFd >= 0 ) return SQLITE_OK;
-  if( !cs->file.zFilename ) return SQLITE_ERROR;
-  if( csFileLockNB(cs->file.zFilename, &cs->graphLockFd) != 0 ){
-    return SQLITE_BUSY;
-  }
-  return SQLITE_OK;
 }
 
 static int csDetectExternalChanges(ChunkStore *cs, int *pChanged){

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -1483,6 +1483,23 @@ void chunkStoreUnlock(ChunkStore *cs){
   }
 }
 
+int chunkStoreReleaseFileLock(ChunkStore *cs){
+  if( cs->graphLockFd >= 0 ){
+    csFileUnlock(cs->graphLockFd);
+    cs->graphLockFd = -1;
+  }
+  return SQLITE_OK;
+}
+
+int chunkStoreReacquireFileLock(ChunkStore *cs){
+  if( cs->isMemory || cs->graphLockFd >= 0 ) return SQLITE_OK;
+  if( !cs->file.zFilename ) return SQLITE_ERROR;
+  if( csFileLockNB(cs->file.zFilename, &cs->graphLockFd) != 0 ){
+    return SQLITE_BUSY;
+  }
+  return SQLITE_OK;
+}
+
 static int csDetectExternalChanges(ChunkStore *cs, int *pChanged){
   int bMoved = 0;
   int rc;

--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -112,6 +112,8 @@ int chunkStoreClose(ChunkStore *cs);
 int chunkStoreLockAndRefresh(ChunkStore *cs);
 int chunkStoreLockAndRefreshChanged(ChunkStore *cs, int *pChanged);
 void chunkStoreUnlock(ChunkStore *cs);
+int chunkStoreReleaseFileLock(ChunkStore *cs);
+int chunkStoreReacquireFileLock(ChunkStore *cs);
 int chunkStoreHasExternalChanges(ChunkStore *cs, int *pChanged);
 
 int chunkStoreWriteBranchWorkingCatalog(ChunkStore *cs, const char *zBranch,

--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -99,7 +99,11 @@ struct ChunkStore {
   u8 isMemory;
   u8 snapshotPinned;
   u8 hasMovedChecked;
+#ifdef _WIN32
+  sqlite3_file *pGraphLockFile;
+#else
   int graphLockFd;
+#endif
   sqlite3_mutex *pLockMutex;
   int lockDepth;
 };
@@ -112,8 +116,6 @@ int chunkStoreClose(ChunkStore *cs);
 int chunkStoreLockAndRefresh(ChunkStore *cs);
 int chunkStoreLockAndRefreshChanged(ChunkStore *cs, int *pChanged);
 void chunkStoreUnlock(ChunkStore *cs);
-int chunkStoreReleaseFileLock(ChunkStore *cs);
-int chunkStoreReacquireFileLock(ChunkStore *cs);
 int chunkStoreHasExternalChanges(ChunkStore *cs, int *pChanged);
 
 int chunkStoreWriteBranchWorkingCatalog(ChunkStore *cs, const char *zBranch,

--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -339,7 +339,8 @@ static int gcRewriteFile(
   const u8 *pNewData,
   int nNewData,
   const ChunkIndexEntry *pNewIndex,
-  int nNewIndex
+  int nNewIndex,
+  int *pReplaced
 ){
   int i;
   int indexSize = nNewIndex * CHUNK_INDEX_ENTRY_SIZE;
@@ -348,6 +349,8 @@ static int gcRewriteFile(
   u8 manifest[CHUNK_MANIFEST_SIZE];
   ChunkStore manifestCs;
   int rc = SQLITE_OK;
+
+  *pReplaced = 0;
 
 #ifdef SQLITE_TEST
   {
@@ -407,7 +410,7 @@ static int gcRewriteFile(
                    | SQLITE_OPEN_MAIN_DB;
       i64 writeOff = 0;
 
-      chunkFileGetVfs(&cs->file)->xDelete(chunkFileGetVfs(&cs->file), zTmp, 0);
+      sqlite3OsDelete(chunkFileGetVfs(&cs->file), zTmp, 0);
 
       rc = sqlite3OsOpenMalloc(chunkFileGetVfs(&cs->file), zTmp, &pTmpFile, tmpFlags, 0);
       if( rc != SQLITE_OK ){
@@ -449,15 +452,18 @@ static int gcRewriteFile(
         GC_CRASH_CHECK();
         rc = sqlite3OsSync(pTmpFile, SQLITE_SYNC_NORMAL);
       }
-      sqlite3OsCloseFree(pTmpFile);
-
       if( rc==SQLITE_OK ){
         sqlite3_file *pOldFile = chunkFileGetHandle(&cs->file);
         sqlite3_file *pNewFile = 0;
+        int dirSyncRc = SQLITE_OK;
 
         GC_CRASH_CHECK();
         if( rename(zTmp, chunkFileGetFilename(&cs->file))!=0 ){
           rc = SQLITE_IOERR;
+        }else{
+          *pReplaced = 1;
+          sqlite3OsCloseFree(pTmpFile);
+          pTmpFile = 0;
         }
 
 #if !defined(_WIN32) && !defined(WIN32)
@@ -471,14 +477,30 @@ static int gcRewriteFile(
               int dfd = open(zDir, O_RDONLY);
               if( dfd>=0 ){
                 GC_CRASH_CHECK();
-                fsync(dfd);
-                close(dfd);
+                if( fsync(dfd)!=0 ){
+                  dirSyncRc = SQLITE_IOERR_DIR_FSYNC;
+                }
+                if( close(dfd)!=0 && dirSyncRc==SQLITE_OK ){
+                  dirSyncRc = SQLITE_IOERR_DIR_FSYNC;
+                }
+              }else{
+                dirSyncRc = SQLITE_IOERR_DIR_FSYNC;
               }
             }
             sqlite3_free(zDir);
+          }else{
+            dirSyncRc = SQLITE_NOMEM;
           }
         }
 #endif
+
+        if( *pReplaced ){
+          if( pOldFile ){
+            sqlite3OsCloseFree(pOldFile);
+          }
+          chunkFileSetHandle(&cs->file, 0);
+          chunkFileSetSize(&cs->file, 0);
+        }
 
         if( rc==SQLITE_OK ){
           int reopenFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB;
@@ -499,12 +521,15 @@ static int gcRewriteFile(
           chunkFileSetHandle(&cs->file, pNewFile);
           chunkFileSetSize(&cs->file, CHUNK_MANIFEST_SIZE + nNewData + indexSize);
           walStateSetDataSize(&cs->wal, 0);
-          if( pOldFile ){
-            sqlite3OsCloseFree(pOldFile);
-          }
+          if( dirSyncRc!=SQLITE_OK ) rc = dirSyncRc;
+        }else if( pNewFile ){
+          sqlite3OsCloseFree(pNewFile);
         }
       }else{
-        chunkFileGetVfs(&cs->file)->xDelete(chunkFileGetVfs(&cs->file), zTmp, 0);
+        sqlite3OsDelete(chunkFileGetVfs(&cs->file), zTmp, 0);
+      }
+      if( !*pReplaced && pTmpFile ){
+        sqlite3OsCloseFree(pTmpFile);
       }
     }
     sqlite3_free(zTmp);
@@ -530,6 +555,7 @@ static int gcSweep(
   u8 *buf = 0;
   int nBuf = 0;
   int rc = SQLITE_OK;
+  int replaced = 0;
 
   {
     int nIdx; const ChunkIndexEntry *aIdx;
@@ -570,9 +596,9 @@ static int gcSweep(
   rc = gcBuildCompactedData(cs, marked, &buf, &nBuf, &aNewIndex, &nNewIndex);
   if( rc!=SQLITE_OK ) return rc;
 
-  rc = gcRewriteFile(cs, buf, nBuf, aNewIndex, nNewIndex);
+  rc = gcRewriteFile(cs, buf, nBuf, aNewIndex, nNewIndex, &replaced);
 
-  if( rc==SQLITE_OK ){
+  if( rc==SQLITE_OK || replaced ){
     int indexSize = nNewIndex * CHUNK_INDEX_ENTRY_SIZE;
     chunkIndexReplaceEntries(&cs->index, aNewIndex, nNewIndex);
     chunkIndexSetMetadata(&cs->index, nNewIndex,

--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -555,7 +555,6 @@ static int gcRewriteFile(
         sqlite3_file *pOldFile = chunkFileGetHandle(&cs->file);
         sqlite3_file *pNewFile = 0;
         int dirSyncRc = SQLITE_OK;
-        int releasedFileLock = 0;
 
 #if SQLITE_OS_WIN
         /* Windows will not reliably replace either an open source file or an
@@ -569,10 +568,6 @@ static int gcRewriteFile(
           chunkFileSetHandle(&cs->file, 0);
           chunkFileSetSize(&cs->file, 0);
         }
-        rc = chunkStoreReleaseFileLock(cs);
-        if( rc==SQLITE_OK ){
-          releasedFileLock = 1;
-        }
 #endif
 
         GC_CRASH_CHECK();
@@ -580,12 +575,6 @@ static int gcRewriteFile(
           rc = gcReplaceFile(chunkFileGetVfs(&cs->file), zTmp,
                              chunkFileGetFilename(&cs->file));
         }
-#if SQLITE_OS_WIN
-        if( releasedFileLock ){
-          int lockRc = chunkStoreReacquireFileLock(cs);
-          if( rc==SQLITE_OK && lockRc!=SQLITE_OK ) rc = lockRc;
-        }
-#endif
         if( rc!=SQLITE_OK ){
 #if SQLITE_OS_WIN
           if( chunkFileGetHandle(&cs->file)==0 ){

--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -336,37 +336,69 @@ static int gcBuildCompactedData(
   return SQLITE_OK;
 }
 
-static int gcReplaceFile(const char *zTmp, const char *zDest){
+static int gcReplaceFile(sqlite3_vfs *pVfs, const char *zTmp, const char *zDest){
 #if SQLITE_OS_WIN
+  char *zTmpFull = 0;
+  char *zDestFull = 0;
   WCHAR *zTmpW = 0;
   WCHAR *zDestW = 0;
   int rc = SQLITE_OK;
   int nTmp, nDest;
+  int nPath;
 
-  nTmp = MultiByteToWideChar(CP_UTF8, 0, zTmp, -1, 0, 0);
-  nDest = MultiByteToWideChar(CP_UTF8, 0, zDest, -1, 0, 0);
-  if( nTmp==0 || nDest==0 ) return SQLITE_IOERR;
+  nPath = pVfs ? pVfs->mxPathname : 0;
+  if( nPath<=0 ) return SQLITE_IOERR;
+
+  zTmpFull = sqlite3_malloc64((sqlite3_uint64)nPath);
+  zDestFull = sqlite3_malloc64((sqlite3_uint64)nPath);
+  if( zTmpFull==0 || zDestFull==0 ){
+    sqlite3_free(zTmpFull);
+    sqlite3_free(zDestFull);
+    return SQLITE_NOMEM;
+  }
+  rc = sqlite3OsFullPathname(pVfs, zTmp, nPath, zTmpFull);
+  if( rc==SQLITE_OK ){
+    rc = sqlite3OsFullPathname(pVfs, zDest, nPath, zDestFull);
+  }
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(zTmpFull);
+    sqlite3_free(zDestFull);
+    return rc;
+  }
+
+  nTmp = MultiByteToWideChar(CP_UTF8, 0, zTmpFull, -1, 0, 0);
+  nDest = MultiByteToWideChar(CP_UTF8, 0, zDestFull, -1, 0, 0);
+  if( nTmp==0 || nDest==0 ){
+    sqlite3_free(zTmpFull);
+    sqlite3_free(zDestFull);
+    return SQLITE_IOERR;
+  }
 
   zTmpW = sqlite3_malloc64((sqlite3_uint64)nTmp * sizeof(WCHAR));
   zDestW = sqlite3_malloc64((sqlite3_uint64)nDest * sizeof(WCHAR));
   if( zTmpW==0 || zDestW==0 ){
+    sqlite3_free(zTmpFull);
+    sqlite3_free(zDestFull);
     sqlite3_free(zTmpW);
     sqlite3_free(zDestW);
     return SQLITE_NOMEM;
   }
 
-  if( MultiByteToWideChar(CP_UTF8, 0, zTmp, -1, zTmpW, nTmp)==0
-   || MultiByteToWideChar(CP_UTF8, 0, zDest, -1, zDestW, nDest)==0
+  if( MultiByteToWideChar(CP_UTF8, 0, zTmpFull, -1, zTmpW, nTmp)==0
+   || MultiByteToWideChar(CP_UTF8, 0, zDestFull, -1, zDestW, nDest)==0
   ){
     rc = SQLITE_IOERR;
   }else if( !MoveFileExW(zTmpW, zDestW,
                          MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH) ){
     rc = SQLITE_IOERR;
   }
+  sqlite3_free(zTmpFull);
+  sqlite3_free(zDestFull);
   sqlite3_free(zTmpW);
   sqlite3_free(zDestW);
   return rc;
 #else
+  (void)pVfs;
   return rename(zTmp, zDest)==0 ? SQLITE_OK : SQLITE_IOERR;
 #endif
 }
@@ -535,7 +567,8 @@ static int gcRewriteFile(
 #endif
 
         GC_CRASH_CHECK();
-        rc = gcReplaceFile(zTmp, chunkFileGetFilename(&cs->file));
+        rc = gcReplaceFile(chunkFileGetVfs(&cs->file), zTmp,
+                           chunkFileGetFilename(&cs->file));
         if( rc!=SQLITE_OK ){
 #if SQLITE_OS_WIN
           if( chunkFileGetHandle(&cs->file)==0 ){

--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -555,6 +555,7 @@ static int gcRewriteFile(
         sqlite3_file *pOldFile = chunkFileGetHandle(&cs->file);
         sqlite3_file *pNewFile = 0;
         int dirSyncRc = SQLITE_OK;
+        int releasedFileLock = 0;
 
 #if SQLITE_OS_WIN
         /* Windows will not reliably replace either an open source file or an
@@ -568,11 +569,23 @@ static int gcRewriteFile(
           chunkFileSetHandle(&cs->file, 0);
           chunkFileSetSize(&cs->file, 0);
         }
+        rc = chunkStoreReleaseFileLock(cs);
+        if( rc==SQLITE_OK ){
+          releasedFileLock = 1;
+        }
 #endif
 
         GC_CRASH_CHECK();
-        rc = gcReplaceFile(chunkFileGetVfs(&cs->file), zTmp,
-                           chunkFileGetFilename(&cs->file));
+        if( rc==SQLITE_OK ){
+          rc = gcReplaceFile(chunkFileGetVfs(&cs->file), zTmp,
+                             chunkFileGetFilename(&cs->file));
+        }
+#if SQLITE_OS_WIN
+        if( releasedFileLock ){
+          int lockRc = chunkStoreReacquireFileLock(cs);
+          if( rc==SQLITE_OK && lockRc!=SQLITE_OK ) rc = lockRc;
+        }
+#endif
         if( rc!=SQLITE_OK ){
 #if SQLITE_OS_WIN
           if( chunkFileGetHandle(&cs->file)==0 ){

--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -545,6 +545,10 @@ static int gcRewriteFile(
 
       if( rc==SQLITE_OK ){
         GC_CRASH_CHECK();
+        rc = sqlite3OsTruncate(pTmpFile, writeOff);
+      }
+      if( rc==SQLITE_OK ){
+        GC_CRASH_CHECK();
         rc = sqlite3OsSync(pTmpFile, SQLITE_SYNC_NORMAL);
       }
       if( rc==SQLITE_OK ){

--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -11,7 +11,9 @@
 
 #include <string.h>
 #include <stdio.h>
-#if !defined(_WIN32) && !defined(WIN32)
+#if SQLITE_OS_WIN
+#include "os_win.h"
+#else
 #include <fcntl.h>
 #include <unistd.h>
 #endif
@@ -334,6 +336,67 @@ static int gcBuildCompactedData(
   return SQLITE_OK;
 }
 
+static int gcReplaceFile(const char *zTmp, const char *zDest){
+#if SQLITE_OS_WIN
+  WCHAR *zTmpW = 0;
+  WCHAR *zDestW = 0;
+  int rc = SQLITE_OK;
+  int nTmp, nDest;
+
+  nTmp = MultiByteToWideChar(CP_UTF8, 0, zTmp, -1, 0, 0);
+  nDest = MultiByteToWideChar(CP_UTF8, 0, zDest, -1, 0, 0);
+  if( nTmp==0 || nDest==0 ) return SQLITE_IOERR;
+
+  zTmpW = sqlite3_malloc64((sqlite3_uint64)nTmp * sizeof(WCHAR));
+  zDestW = sqlite3_malloc64((sqlite3_uint64)nDest * sizeof(WCHAR));
+  if( zTmpW==0 || zDestW==0 ){
+    sqlite3_free(zTmpW);
+    sqlite3_free(zDestW);
+    return SQLITE_NOMEM;
+  }
+
+  if( MultiByteToWideChar(CP_UTF8, 0, zTmp, -1, zTmpW, nTmp)==0
+   || MultiByteToWideChar(CP_UTF8, 0, zDest, -1, zDestW, nDest)==0
+  ){
+    rc = SQLITE_IOERR;
+  }else if( !MoveFileExW(zTmpW, zDestW,
+                         MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH) ){
+    rc = SQLITE_IOERR;
+  }
+  sqlite3_free(zTmpW);
+  sqlite3_free(zDestW);
+  return rc;
+#else
+  return rename(zTmp, zDest)==0 ? SQLITE_OK : SQLITE_IOERR;
+#endif
+}
+
+static int gcReopenChunkFile(ChunkStore *cs, sqlite3_file **ppFile){
+  int rc;
+  int flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB;
+  sqlite3_file *pFile = 0;
+  i64 fileSize = 0;
+
+  rc = sqlite3OsOpenMalloc(chunkFileGetVfs(&cs->file),
+                           chunkFileGetFilename(&cs->file), &pFile, flags, 0);
+  if( rc!=SQLITE_OK ){
+    if( pFile ) sqlite3OsCloseFree(pFile);
+    return rc;
+  }
+  rc = sqlite3OsFileSize(pFile, &fileSize);
+  if( rc!=SQLITE_OK ){
+    sqlite3OsCloseFree(pFile);
+    return rc;
+  }
+  if( ppFile ){
+    *ppFile = pFile;
+  }else{
+    chunkFileSetHandle(&cs->file, pFile);
+    chunkFileSetSize(&cs->file, fileSize);
+  }
+  return SQLITE_OK;
+}
+
 static int gcRewriteFile(
   ChunkStore *cs,
   const u8 *pNewData,
@@ -457,13 +520,36 @@ static int gcRewriteFile(
         sqlite3_file *pNewFile = 0;
         int dirSyncRc = SQLITE_OK;
 
+#if SQLITE_OS_WIN
+        /* Windows will not reliably replace either an open source file or an
+        ** open destination file. Close both before the atomic replace call,
+        ** and restore the destination handle if replacement fails. */
+        sqlite3OsCloseFree(pTmpFile);
+        pTmpFile = 0;
+        if( pOldFile ){
+          sqlite3OsCloseFree(pOldFile);
+          pOldFile = 0;
+          chunkFileSetHandle(&cs->file, 0);
+          chunkFileSetSize(&cs->file, 0);
+        }
+#endif
+
         GC_CRASH_CHECK();
-        if( rename(zTmp, chunkFileGetFilename(&cs->file))!=0 ){
-          rc = SQLITE_IOERR;
+        rc = gcReplaceFile(zTmp, chunkFileGetFilename(&cs->file));
+        if( rc!=SQLITE_OK ){
+#if SQLITE_OS_WIN
+          if( chunkFileGetHandle(&cs->file)==0 ){
+            int restoreRc = gcReopenChunkFile(cs, 0);
+            if( restoreRc!=SQLITE_OK ) rc = restoreRc;
+          }
+#endif
+          sqlite3OsDelete(chunkFileGetVfs(&cs->file), zTmp, 0);
         }else{
           *pReplaced = 1;
+#if !SQLITE_OS_WIN
           sqlite3OsCloseFree(pTmpFile);
           pTmpFile = 0;
+#endif
         }
 
 #if !defined(_WIN32) && !defined(WIN32)
@@ -503,12 +589,10 @@ static int gcRewriteFile(
         }
 
         if( rc==SQLITE_OK ){
-          int reopenFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB;
           int reopenAttempt;
           for(reopenAttempt=0; reopenAttempt<3; reopenAttempt++){
             pNewFile = 0;
-            rc = sqlite3OsOpenMalloc(chunkFileGetVfs(&cs->file), chunkFileGetFilename(&cs->file), &pNewFile,
-                                     reopenFlags, 0);
+            rc = gcReopenChunkFile(cs, &pNewFile);
             if( rc==SQLITE_OK ) break;
             if( pNewFile ){
               sqlite3OsCloseFree(pNewFile);

--- a/src/os_win.c
+++ b/src/os_win.c
@@ -2662,6 +2662,18 @@ static int winFileControl(sqlite3_file *id, int op, void *pArg){
       OSTRACE(("FCNTL file=%p, rc=SQLITE_OK\n", pFile->h));
       return SQLITE_OK;
     }
+    case SQLITE_FCNTL_HAS_MOVED: {
+      /*
+      ** Unlike unix, this VFS does not track inode/file-id state for an open
+      ** handle. Windows opens database files without FILE_SHARE_DELETE, so a
+      ** concurrent GC cannot atomically replace a chunk-store file while this
+      ** handle remains open. Report "not moved" instead of SQLITE_NOTFOUND so
+      ** callers may use this file-control as a portable change probe.
+      */
+      *(int*)pArg = 0;
+      OSTRACE(("FCNTL file=%p, rc=SQLITE_OK\n", pFile->h));
+      return SQLITE_OK;
+    }
     case SQLITE_FCNTL_WIN32_AV_RETRY: {
       int *a = (int*)pArg;
       if( a[0]>0 ){

--- a/test/doltlite_gc.sh
+++ b/test/doltlite_gc.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 DOLTLITE=./doltlite
 PASS=0; FAIL=0; ERRORS=""
-run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
-run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if echo "$r"|grep -qE "$p"; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  pattern: $p\n  got:     $r"; fi; }
+run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1 | tr -d '\r'); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
+run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1 | tr -d '\r'); if echo "$r"|grep -qE "$p"; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  pattern: $p\n  got:     $r"; fi; }
 db_size() { local s=0; for f in "$1" "${1}-wal"; do [ -f "$f" ] && s=$((s + $(stat -f%z "$f" 2>/dev/null || stat -c%s "$f" 2>/dev/null))); done; echo $s; }
-db_rm() { rm -f "$1" "${1}-wal"; }
+db_rm() { rm -f "$1" "${1}-wal" "${1}-lock"; }
 
 echo "=== Doltlite Garbage Collection Tests ==="
 echo ""
@@ -20,7 +20,7 @@ run_test_match "gc_clean" "SELECT dolt_gc();" "0 chunks removed" "$DB"
 run_test "gc_clean_data" "SELECT count(*) FROM t;" "1" "$DB"
 run_test "gc_clean_log" "SELECT count(*) FROM dolt_log;" "2" "$DB"
 
-nFiles=$(ls "$DB"* 2>/dev/null | wc -l | tr -d ' ')
+nFiles=$(ls "$DB"* 2>/dev/null | grep -v -- '-lock$' | wc -l | tr -d ' ')
 if [ "$nFiles" = "1" ]; then PASS=$((PASS+1))
 else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: gc_single_file\n  expected: 1 file\n  got:      $nFiles files"; fi
 
@@ -59,8 +59,9 @@ SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 echo "SELECT dolt_branch('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('feat');" | $DOLTLITE "$DB" > /dev/null 2>&1
-echo "INSERT INTO t VALUES(100,'feat_only');
-SELECT dolt_commit('-A','-m','feat commit');" | $DOLTLITE "$DB/feat" > /dev/null 2>&1
+echo "SELECT dolt_connect_branch('feat');
+INSERT INTO t VALUES(100,'feat_only');
+SELECT dolt_commit('-A','-m','feat commit');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 SIZE_WITH_BRANCH=$(db_size "$DB")
@@ -88,8 +89,9 @@ SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 echo "SELECT dolt_branch('dev');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('dev');" | $DOLTLITE "$DB" > /dev/null 2>&1
-echo "INSERT INTO t VALUES(2,'dev_data');
-SELECT dolt_commit('-A','-m','dev commit');" | $DOLTLITE "$DB/dev" > /dev/null 2>&1
+echo "SELECT dolt_connect_branch('dev');
+INSERT INTO t VALUES(2,'dev_data');
+SELECT dolt_commit('-A','-m','dev commit');" | $DOLTLITE "$DB" > /dev/null 2>&1
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 
 echo "SELECT dolt_tag('v1.0');" | $DOLTLITE "$DB" > /dev/null 2>&1
@@ -101,7 +103,8 @@ run_test "gc_preserve_branches" "SELECT count(*) FROM dolt_branches;" "2" "$DB"
 run_test "gc_preserve_tags" "SELECT count(*) FROM dolt_tags;" "1" "$DB"
 
 echo "SELECT dolt_checkout('dev');" | $DOLTLITE "$DB" > /dev/null 2>&1
-run_test "gc_preserve_dev" "SELECT count(*) FROM t;" "2" "$DB/dev"
+run_test "gc_preserve_dev" "SELECT dolt_connect_branch('dev'); SELECT count(*) FROM t;" "0
+2" "$DB"
 
 echo "SELECT dolt_checkout('main');" | $DOLTLITE "$DB" > /dev/null 2>&1
 run_test "gc_preserve_reopen_main" "SELECT count(*) FROM t;" "1" "$DB"

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -521,6 +521,7 @@ static int gFailSyncOnce = 0;
 static int gFailAccessOnce = 0;
 static int gFailHasMovedOnce = 0;
 static int gFailFileSizeOnce = 0;
+static int gFailOpenMainOnce = 0;
 static int gFailHits = 0;
 
 static int failAccess(sqlite3_vfs *pVfs, const char *zName, int flags, int *pResOut);
@@ -670,8 +671,15 @@ static int failOpen(sqlite3_vfs *pVfs, const char *zName, sqlite3_file *pFile,
   FailFile *p = (FailFile*)pFile;
   sqlite3_file *pReal = (sqlite3_file*)&p[1];
   int rc;
+  int nName = zName ? (int)strlen(zName) : 0;
+  int isGcTmp = nName>=7 && strcmp(zName+nName-7, "-gc-tmp")==0;
 
   memset(p, 0, sizeof(*p));
+  if( gFailOpenMainOnce>0 && !isGcTmp && (flags & SQLITE_OPEN_MAIN_DB)!=0 ){
+    gFailOpenMainOnce--;
+    gFailHits++;
+    return SQLITE_CANTOPEN;
+  }
   rc = gBaseVfs->xOpen(gBaseVfs, zName, pReal, flags, pOutFlags);
   if( rc!=SQLITE_OK ) return rc;
 
@@ -818,6 +826,7 @@ static void run_checkout_persist_failure(void){
   make_dbpath(dbpath, sizeof(dbpath), "test_checkout_persist_failure");
   removeDbFiles(dbpath);
   gFailSyncOnce = 0;
+  gFailOpenMainOnce = 0;
   gFailHits = 0;
 
   check("register_fail_vfs", registerFailVfs()==SQLITE_OK);
@@ -1951,6 +1960,7 @@ static void run_merge_persist_failure(void){
   removeDbFiles(dbpath);
 
   gFailSyncOnce = 0;
+  gFailOpenMainOnce = 0;
   gFailHits = 0;
   check("register_fail_vfs_for_merge", registerFailVfs()==SQLITE_OK);
   check("open_fail_db", open_fail_db(dbpath, &db)==SQLITE_OK);
@@ -2395,12 +2405,26 @@ static void run_gc_rewrite_failure(void){
   check("gc_connection_still_reads_log",
     strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_log"), "3")==0);
 
+  gFailHits = 0;
+  gFailOpenMainOnce = 3;
+  res = queryScalarText(db, "SELECT dolt_gc()");
+  check("gc_post_replace_open_failure_was_injected", gFailHits>0);
+  check("gc_post_replace_open_failure_returns_error", strstr(res, "ERROR:")!=0);
+  check("gc_post_replace_connection_can_continue",
+    execSql(db,
+      "INSERT INTO t VALUES(3,'c');"
+      "SELECT dolt_commit('-A', '-m', 'third');")==SQLITE_OK);
+  check("gc_post_replace_connection_reads_data",
+    strcmp(queryScalarText(db, "SELECT count(*) FROM t"), "3")==0);
+  check("gc_post_replace_connection_reads_log",
+    strcmp(queryScalarText(db, "SELECT count(*) FROM dolt_log"), "4")==0);
+
   sqlite3_close(db);
   check("reopen_db_after_gc_failure", open_db(dbpath, &db2)==SQLITE_OK);
   check("gc_reopen_reads_data",
-    strcmp(queryScalarText(db2, "SELECT count(*) FROM t"), "2")==0);
+    strcmp(queryScalarText(db2, "SELECT count(*) FROM t"), "3")==0);
   check("gc_reopen_reads_log",
-    strcmp(queryScalarText(db2, "SELECT count(*) FROM dolt_log"), "3")==0);
+    strcmp(queryScalarText(db2, "SELECT count(*) FROM dolt_log"), "4")==0);
 
   sqlite3_close(db2);
   removeDbFiles(dbpath);


### PR DESCRIPTION
## Summary
- close the old GC chunk-store file handle once live file replacement succeeds, preventing the connection from continuing on the pre-GC unlinked file
- adopt the compacted in-memory GC metadata whenever replacement has already happened, even if a later reopen or directory sync reports an error
- route temp cleanup through SQLite VFS helpers and surface directory fsync failures
- add regression coverage for post-replace reopen failure on the GC path

## Tests
- bash test/run_doltlite_regression_case.sh gc_rewrite_failure
- bash test/doltlite_gc.sh
- bash test/doltlite_gc_session_state.sh build/doltlite
- git diff --check