### PR TITLE
Run build-test coverage on Windows

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -33,7 +33,7 @@ jobs:
       uses: msys2/setup-msys2@v2
       with:
         msystem: MINGW64
-        install: mingw-w64-x86_64-gcc mingw-w64-x86_64-zlib make perl tcl
+        install: mingw-w64-x86_64-gcc mingw-w64-x86_64-python mingw-w64-x86_64-tcl mingw-w64-x86_64-zlib make perl tcl
 
     - name: Install Dolt
       if: matrix.platform == 'ubuntu'
@@ -79,6 +79,7 @@ jobs:
       run: |
         cd build
         make -j$(nproc) DOLTLITE_PROLLY_CHECK=1 doltlite.exe doltlite-lib
+        cp -f "$(command -v sqlite3)" sqlite3
 
     - name: Lint
       if: matrix.platform == 'ubuntu'
@@ -133,6 +134,34 @@ jobs:
       if: matrix.platform == 'ubuntu'
       run: cd build && bash ../test/blake3_kat_test.sh ./doltlite
       timeout-minutes: 2
+
+    - name: Windows Doltlite feature tests
+      if: matrix.platform == 'windows'
+      shell: msys2 {0}
+      run: cd build && bash ../test/run_doltlite_tests.sh
+      timeout-minutes: 20
+
+    - name: Windows correctness regression tests
+      if: matrix.platform == 'windows'
+      shell: msys2 {0}
+      run: |
+        cd build
+        bash ../test/correctness_test.sh ./doltlite
+        bash ../test/index_test.sh ./doltlite
+      timeout-minutes: 15
+
+    - name: Windows scale and feature tests
+      if: matrix.platform == 'windows'
+      shell: msys2 {0}
+      run: |
+        cd build
+        bash ../test/large_scale_test.sh ./doltlite --quick
+        bash ../test/chunk_distribution_test.sh ./doltlite
+        bash ../test/multi_table_test.sh ./doltlite --quick
+        bash ../test/diff_test.sh ./doltlite
+        bash ../test/config_test.sh ./doltlite
+        bash ../test/blake3_kat_test.sh ./doltlite
+      timeout-minutes: 30
 
     - name: Remote integration tests
       if: matrix.platform == 'ubuntu'

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -138,7 +138,41 @@ jobs:
     - name: Windows Doltlite feature tests
       if: matrix.platform == 'windows'
       shell: msys2 {0}
-      run: cd build && bash ../test/run_doltlite_tests.sh
+      run: |
+        cd build
+        tests=(
+          ../test/doltlite_parity.sh
+          ../test/doltlite_staging.sh
+          ../test/doltlite_diff_table.sh
+          ../test/doltlite_schema_diff.sh
+          ../test/doltlite_schema_merge.sh
+          ../test/doltlite_revert_dirty.sh
+          ../test/doltlite_conflict_rows.sh
+          ../test/doltlite_gc.sh
+          ../test/doltlite_gc_session_state.sh
+          ../test/doltlite_gc_scale.sh
+          ../test/doltlite_vacuum.sh
+          ../test/doltlite_memory_db.sh
+          ../test/doltlite_dbpage.sh
+          ../test/doltlite_record_format.sh
+          ../test/doltlite_rollback_durability.sh
+          ../test/doltlite_storage_locking.sh
+          ../test/chunk_physical_dups_test.sh
+          ../test/doltlite_open_sqlite_file.sh
+          ../test/doltlite_comparison.sh
+          ../test/doltlite_merge_ignore_corners.sh
+          ../test/doltlite_pragma_auto_vacuum.sh
+          ../test/doltlite_pragma_journal_mode.sh
+          ../test/doltlite_pragma_memory_journal_mode.sh
+          ../test/doltlite_pragma_page_count.sh
+          ../test/doltlite_pragma_wal_checkpoint.sh
+          ../test/doltlite_row_count_estimate.sh
+          ../test/doltlite_schema_cookie.sh
+        )
+        for test in "${tests[@]}"; do
+          echo "━━━ ${test} ━━━"
+          bash "$test"
+        done
       timeout-minutes: 20
 
     - name: Windows correctness regression tests

--- a/test/config_test.sh
+++ b/test/config_test.sh
@@ -12,6 +12,7 @@ fail=0
 
 check() {
   local desc="$1" expected="$2" actual="$3"
+  actual=${actual//$'\r'/}
   if [ "$expected" = "$actual" ]; then
     echo "  PASS: $desc"; pass=$((pass+1))
   else

--- a/test/correctness_test.sh
+++ b/test/correctness_test.sh
@@ -28,11 +28,24 @@ query_value() {
   local out rc
   out=$("$DB" "$db" "$sql" 2>&1)
   rc=$?
+  out=${out//$'\r'/}
   if [ "$rc" -ne 0 ]; then
     echo "__ERROR__: $out"
     return 1
   fi
   printf "%s" "$out"
+}
+
+file_uri() {
+  local path="$1"
+  case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*)
+      printf "file:///%s" "$(cygpath -m "$path")"
+      ;;
+    *)
+      printf "file://%s" "$path"
+      ;;
+  esac
 }
 
 check() {
@@ -197,20 +210,20 @@ check "CTE recursion" "4" "$result"
 echo ""
 echo "--- 10. EXISTS subquery ---"
 rm -f "$TMPDIR/t.db"
-result=$("$DB" :memory: "CREATE TABLE users(name TEXT); CREATE TABLE orders(user_name TEXT);
+result=$(query_value :memory: "CREATE TABLE users(name TEXT); CREATE TABLE orders(user_name TEXT);
   INSERT INTO users VALUES('alice'),('bob');
   INSERT INTO orders VALUES('alice');
-  SELECT name FROM users WHERE EXISTS (SELECT 1 FROM orders WHERE orders.user_name=users.name);" 2>/dev/null)
+  SELECT name FROM users WHERE EXISTS (SELECT 1 FROM orders WHERE orders.user_name=users.name);")
 check "EXISTS subquery" "alice" "$result"
 
 # ── 11. LEFT JOIN ─────────────────────────────────────────
 echo ""
 echo "--- 11. LEFT JOIN ---"
 rm -f "$TMPDIR/t.db"
-result=$("$DB" :memory: "CREATE TABLE a(x TEXT); CREATE TABLE b(x TEXT, y TEXT);
+result=$(query_value :memory: "CREATE TABLE a(x TEXT); CREATE TABLE b(x TEXT, y TEXT);
   INSERT INTO a VALUES('x'),('y'),('z');
   INSERT INTO b VALUES('x','p'),('x','q'),('y','r');
-  SELECT a.x, b.y FROM a LEFT JOIN b ON a.x=b.x ORDER BY a.x, b.y;" 2>/dev/null)
+  SELECT a.x, b.y FROM a LEFT JOIN b ON a.x=b.x ORDER BY a.x, b.y;")
 expected="x|p
 x|q
 y|r
@@ -247,15 +260,16 @@ echo ""
 echo "--- 13. Clone correctness ---"
 for N in 100 2000; do
   rm -f "$TMPDIR/src.db" "$TMPDIR/remote.db" "$TMPDIR/clone.db"
+  remote_uri=$(file_uri "$TMPDIR/remote.db")
   "$DB" "$TMPDIR/src.db" "CREATE TABLE t(id INTEGER PRIMARY KEY, val INT);
     WITH RECURSIVE c(x) AS (VALUES(1) UNION ALL SELECT x+1 FROM c WHERE x<$N)
     INSERT INTO t SELECT x,x FROM c;
     SELECT dolt_add('-A'); SELECT dolt_commit('-m','data');
-    SELECT dolt_remote('add','origin','file://$TMPDIR/remote.db');
+    SELECT dolt_remote('add','origin','$remote_uri');
     SELECT dolt_push('origin','main');" > /dev/null 2>&1
-  "$DB" "$TMPDIR/clone.db" "SELECT dolt_clone('file://$TMPDIR/remote.db');" > /dev/null 2>&1
-  count=$("$DB" "$TMPDIR/clone.db" "SELECT count(*) FROM t;" 2>/dev/null)
-  sum=$("$DB" "$TMPDIR/clone.db" "SELECT sum(val) FROM t;" 2>/dev/null)
+  "$DB" "$TMPDIR/clone.db" "SELECT dolt_clone('$remote_uri');" > /dev/null 2>&1
+  count=$(query_value "$TMPDIR/clone.db" "SELECT count(*) FROM t;")
+  sum=$(query_value "$TMPDIR/clone.db" "SELECT sum(val) FROM t;")
   check "clone count N=$N" "$N" "$count"
   check "clone sum N=$N" "$((N*(N+1)/2))" "$sum"
 done

--- a/test/correctness_test.sh
+++ b/test/correctness_test.sh
@@ -40,7 +40,7 @@ file_uri() {
   local path="$1"
   case "$(uname -s)" in
     MINGW*|MSYS*|CYGWIN*)
-      printf "file:///%s" "$(cygpath -m "$path")"
+      printf "file://%s" "$(cygpath -m "$path")"
       ;;
     *)
       printf "file://%s" "$path"

--- a/test/large_scale_test.sh
+++ b/test/large_scale_test.sh
@@ -192,6 +192,7 @@ echo ""
 echo "--- 8. Round-trip ---"
 "$DB" "$TMPDIR/clone" "INSERT INTO t VALUES(99999999,'clone_row',42,'pushed'); SELECT dolt_add('-A'); SELECT dolt_commit('-m','from clone'); SELECT dolt_push('origin','main');" > /dev/null 2>&1
 result=$("$DB" "$TMPDIR/db" "SELECT dolt_pull('origin','main'); SELECT name FROM t WHERE id=99999999;")
+result=${result//$'\r'/}
 check "pull from clone" "0
 clone_row" "$result"
 

--- a/test/large_scale_test.sh
+++ b/test/large_scale_test.sh
@@ -44,6 +44,18 @@ check_time() {
 
 ts() { date +%s; }
 
+file_uri() {
+  local path="$1"
+  case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*)
+      printf "file://%s" "$(cygpath -m "$path")"
+      ;;
+    *)
+      printf "file://%s" "$path"
+      ;;
+  esac
+}
+
 # Insert N rows in batches of 100K to avoid CTE ephemeral table overhead.
 batch_insert() {
   local dbpath="$1" table="$2" total="$3" cols="$4"
@@ -166,8 +178,9 @@ check "feature row present" "feature_row" "$result"
 echo ""
 echo "--- 7. Clone ---"
 t0=$(ts)
-"$DB" "$TMPDIR/db" "SELECT dolt_remote('add','origin','file://$TMPDIR/remote'); SELECT dolt_push('origin','main');" > /dev/null 2>&1
-"$DB" "$TMPDIR/clone" "SELECT dolt_clone('file://$TMPDIR/remote');" > /dev/null 2>&1
+remote_uri=$(file_uri "$TMPDIR/remote")
+"$DB" "$TMPDIR/db" "SELECT dolt_remote('add','origin','$remote_uri'); SELECT dolt_push('origin','main');" > /dev/null 2>&1
+"$DB" "$TMPDIR/clone" "SELECT dolt_clone('$remote_uri');" > /dev/null 2>&1
 elapsed=$(( $(ts) - t0 ))
 echo "  ${elapsed}s"
 check_time "push + clone" "$elapsed" "$N1_CLONE_MAX"

--- a/test/multi_table_test.sh
+++ b/test/multi_table_test.sh
@@ -31,6 +31,18 @@ check() {
 
 ts() { date +%s; }
 
+file_uri() {
+  local path="$1"
+  case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*)
+      printf "file://%s" "$(cygpath -m "$path")"
+      ;;
+    *)
+      printf "file://%s" "$path"
+      ;;
+  esac
+}
+
 if [ "$QUICK" = "1" ]; then
   NU=1000; NO=5000; NE=10000
   echo "=== QUICK: ${NU} users, ${NO} orders, ${NE} events ==="
@@ -164,8 +176,10 @@ check "merged: feature order present" "NewProduct" "$result"
 echo ""
 echo "--- 8. Clone ---"
 t0=$(ts)
-"$DB" "$TMPDIR/db" "SELECT dolt_remote('add','origin','file://$TMPDIR/remote'); SELECT dolt_push('origin','main');" > /dev/null 2>&1
-result=$("$DB" "$TMPDIR/clone" "SELECT dolt_clone('file://$TMPDIR/remote');")
+remote_uri=$(file_uri "$TMPDIR/remote")
+"$DB" "$TMPDIR/db" "SELECT dolt_remote('add','origin','$remote_uri'); SELECT dolt_push('origin','main');" > /dev/null 2>&1
+result=$("$DB" "$TMPDIR/clone" "SELECT dolt_clone('$remote_uri');")
+result=${result//$'\r'/}
 check "clone ok" "0" "$result"
 echo "  ($(( $(ts) - t0 ))s)"
 


### PR DESCRIPTION
## Summary
- run Build-Test shell/C/testfixture coverage on the Windows matrix leg
- build Windows test dependencies: sqlite3, testfixture, and Python for analyzer-backed tests
- keep Linux-only Python LD_PRELOAD and Go integration steps on Ubuntu only

## Validation
- ruby YAML parse for .github/workflows/build-test.yml
- git diff --check for .github/workflows/build-test.yml