### PR TITLE
Clean up dead and duplicated DoltLite code

### DIFF
--- a/src/chunk_file.c
+++ b/src/chunk_file.c
@@ -4,10 +4,6 @@
 #include "chunk_file.h"
 #include <string.h>
 
-void chunkFileInit(ChunkFile *cf){
-  memset(cf, 0, sizeof(*cf));
-}
-
 const char *chunkFileGetFilename(const ChunkFile *cf){
   return cf->zFilename;
 }
@@ -18,10 +14,6 @@ sqlite3_vfs *chunkFileGetVfs(const ChunkFile *cf){
 
 sqlite3_file *chunkFileGetHandle(const ChunkFile *cf){
   return cf->pFile;
-}
-
-i64 chunkFileGetSize(const ChunkFile *cf){
-  return cf->iFileSize;
 }
 
 void chunkFileSetHandle(ChunkFile *cf, sqlite3_file *pFile){

--- a/src/chunk_file.h
+++ b/src/chunk_file.h
@@ -13,12 +13,9 @@ struct ChunkFile {
   i64 iFileSize;
 };
 
-void chunkFileInit(ChunkFile *cf);
-
 const char *chunkFileGetFilename(const ChunkFile *cf);
 sqlite3_vfs *chunkFileGetVfs(const ChunkFile *cf);
 sqlite3_file *chunkFileGetHandle(const ChunkFile *cf);
-i64 chunkFileGetSize(const ChunkFile *cf);
 
 void chunkFileSetHandle(ChunkFile *cf, sqlite3_file *pFile);
 void chunkFileSetSize(ChunkFile *cf, i64 nSize);

--- a/src/chunk_index.c
+++ b/src/chunk_index.c
@@ -19,14 +19,6 @@
   | ((i64)((u64)(p)[4])<<32) | ((i64)((u64)(p)[5])<<40) \
   | ((i64)((u64)(p)[6])<<48) | ((i64)((u64)(p)[7])<<56))
 
-void chunkIndexInit(ChunkIndex *idx){
-  memset(idx, 0, sizeof(*idx));
-}
-
-void chunkIndexReset(ChunkIndex *idx){
-  memset(idx, 0, sizeof(*idx));
-}
-
 void chunkIndexGetEntries(const ChunkIndex *idx, int *pn, const ChunkIndexEntry **par){
   *pn = idx->nIndex;
   *par = idx->aIndex;
@@ -34,18 +26,6 @@ void chunkIndexGetEntries(const ChunkIndex *idx, int *pn, const ChunkIndexEntry 
 
 int chunkIndexCount(const ChunkIndex *idx){
   return idx->nIndex;
-}
-
-int chunkIndexNChunks(const ChunkIndex *idx){
-  return idx->nChunks;
-}
-
-i64 chunkIndexOffset(const ChunkIndex *idx){
-  return idx->iIndexOffset;
-}
-
-i64 chunkIndexSize(const ChunkIndex *idx){
-  return idx->nIndexSize;
 }
 
 void chunkIndexSetMetadata(ChunkIndex *idx, int nChunks, i64 iOffset, i64 nSize){

--- a/src/chunk_index.h
+++ b/src/chunk_index.h
@@ -37,14 +37,8 @@ struct ChunkIndex {
   i64 nIndexSize;
 };
 
-void chunkIndexInit(ChunkIndex *idx);
-void chunkIndexReset(ChunkIndex *idx);
-
 void chunkIndexGetEntries(const ChunkIndex *idx, int *pn, const ChunkIndexEntry **par);
 int chunkIndexCount(const ChunkIndex *idx);
-int chunkIndexNChunks(const ChunkIndex *idx);
-i64 chunkIndexOffset(const ChunkIndex *idx);
-i64 chunkIndexSize(const ChunkIndex *idx);
 
 void chunkIndexSetMetadata(ChunkIndex *idx, int nChunks, i64 iOffset, i64 nSize);
 void chunkIndexReplaceEntries(ChunkIndex *idx, ChunkIndexEntry *aNew, int nNew);

--- a/src/chunk_refs.c
+++ b/src/chunk_refs.c
@@ -23,14 +23,6 @@
   ((i64)(((const u8*)(p))[7]) << 56)      \
 )
 
-void refsTableInit(RefsTable *rt){
-  memset(rt, 0, sizeof(*rt));
-}
-
-void refsTableReset(RefsTable *rt){
-  memset(rt, 0, sizeof(*rt));
-}
-
 void refsTableGetBranches(const RefsTable *rt, int *pn, const BranchRef **par){
   *pn = rt->nBranches;
   *par = rt->aBranches;
@@ -90,14 +82,6 @@ int refsTableTagCount(const RefsTable *rt){
 
 int refsTableRemoteCount(const RefsTable *rt){
   return rt->nRemotes;
-}
-
-int refsTableTrackingCount(const RefsTable *rt){
-  return rt->nTracking;
-}
-
-int refsTableSequenceCount(const RefsTable *rt){
-  return rt->nSequences;
 }
 
 void refsTableSetHash(RefsTable *rt, const ProllyHash *h){

--- a/src/chunk_refs.h
+++ b/src/chunk_refs.h
@@ -65,9 +65,6 @@ struct RefsTable {
   int nSequences;
 };
 
-void refsTableInit(RefsTable *rt);
-void refsTableReset(RefsTable *rt);
-
 void refsTableGetBranches(const RefsTable *rt, int *pn, const BranchRef **par);
 void refsTableGetTags(const RefsTable *rt, int *pn, const TagRef **par);
 void refsTableGetRemotes(const RefsTable *rt, int *pn, const RemoteRef **par);
@@ -77,8 +74,6 @@ void refsTableGetSequences(const RefsTable *rt, int *pn, const SequenceRef **par
 int refsTableBranchCount(const RefsTable *rt);
 int refsTableTagCount(const RefsTable *rt);
 int refsTableRemoteCount(const RefsTable *rt);
-int refsTableTrackingCount(const RefsTable *rt);
-int refsTableSequenceCount(const RefsTable *rt);
 
 /* Return the stored sequence for zTableName, or 0 if absent. */
 i64 refsTableGetSequence(const RefsTable *rt, const char *zTableName);

--- a/src/chunk_staging.c
+++ b/src/chunk_staging.c
@@ -12,14 +12,6 @@
 #define CS_PEND_HT_MIN_COUNT 16
 #define CS_RECENT_HT_MIN_COUNT 64
 
-void chunkStagingInit(ChunkStaging *st){
-  memset(st, 0, sizeof(*st));
-}
-
-void chunkStagingReset(ChunkStaging *st){
-  memset(st, 0, sizeof(*st));
-}
-
 void chunkStagingGetPending(const ChunkStaging *st, int *pn, const ChunkIndexEntry **par){
   *pn = st->nPending;
   *par = st->aPending;

--- a/src/chunk_staging.h
+++ b/src/chunk_staging.h
@@ -30,9 +30,6 @@ struct ChunkStaging {
   i64 nCommittedWriteBuf;
 };
 
-void chunkStagingInit(ChunkStaging *st);
-void chunkStagingReset(ChunkStaging *st);
-
 void chunkStagingGetPending(const ChunkStaging *st, int *pn, const ChunkIndexEntry **par);
 void chunkStagingGetRecent(const ChunkStaging *st, int *pn, const ChunkIndexEntry **par);
 int chunkStagingPendingCount(const ChunkStaging *st);

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -135,7 +135,6 @@ static int csRollbackFailedAppend(ChunkStore *cs, i64 origFileSize);
 static int csRestoreCommittedRefsState(ChunkStore *cs);
 static int csReadManifest(ChunkStore *cs);
 void csSerializeManifest(const ChunkStore *cs, u8 *aBuf);
-static int csDeserializeIndexEntry(const u8 *aBuf, ChunkIndexEntry *e);
 
 static int csReloadFromDisk(ChunkStore *cs);
 static int csDetectExternalChanges(ChunkStore *cs, int *pChanged);
@@ -680,22 +679,6 @@ int chunkStoreUpdateTracking(ChunkStore *cs, const char *zRemote,
     cs->refs.nTracking++;
   }
   return SQLITE_OK;
-}
-
-int chunkStoreDeleteTracking(ChunkStore *cs, const char *zRemote,
-                             const char *zBranch){
-  int i;
-  for(i=0; i<cs->refs.nTracking; i++){
-    if( strcmp(cs->refs.aTracking[i].zRemote, zRemote)==0
-     && strcmp(cs->refs.aTracking[i].zBranch, zBranch)==0 ){
-      sqlite3_free(cs->refs.aTracking[i].zRemote);
-      sqlite3_free(cs->refs.aTracking[i].zBranch);
-      cs->refs.aTracking[i] = cs->refs.aTracking[cs->refs.nTracking-1];
-      cs->refs.nTracking--;
-      return SQLITE_OK;
-    }
-  }
-  return SQLITE_NOTFOUND;
 }
 
 int chunkStoreHasMany(ChunkStore *cs, const ProllyHash *aHash, int nHash, u8 *aResult){

--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -153,8 +153,6 @@ int chunkStoreUpdateTracking(ChunkStore *cs, const char *zRemote,
                              const char *zBranch, const ProllyHash *pCommit);
 int chunkStoreFindTracking(ChunkStore *cs, const char *zRemote,
                            const char *zBranch, ProllyHash *pCommit);
-int chunkStoreDeleteTracking(ChunkStore *cs, const char *zRemote,
-                             const char *zBranch);
 
 int chunkStoreLoadRefsFromBlob(ChunkStore *cs, const u8 *data, int nData);
 

--- a/src/chunk_wal.c
+++ b/src/chunk_wal.c
@@ -18,15 +18,6 @@
 #define CS_WAL_TAG_CHUNK  0x01
 #define CS_WAL_TAG_ROOT   0x02
 
-void walStateInit(WalState *w){
-  memset(w, 0, sizeof(*w));
-}
-
-void walStateReset(WalState *w){
-  w->iWalOffset = 0;
-  w->nWalData = 0;
-}
-
 i64 walStateGetOffset(const WalState *w){
   return w->iWalOffset;
 }

--- a/src/chunk_wal.h
+++ b/src/chunk_wal.h
@@ -31,9 +31,6 @@ struct ChunkStoreReloadState {
   SavedRefsState refs;
 };
 
-void walStateInit(WalState *w);
-void walStateReset(WalState *w);
-
 i64 walStateGetOffset(const WalState *w);
 i64 walStateGetDataSize(const WalState *w);
 

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -775,12 +775,6 @@ static int doltliteVcSealBranchStyleTxnMaybeKeepTopLevelSavepoint(sqlite3 *db){
   return doltliteVcSealBranchStyleTxn(db);
 }
 
-static int doltliteSetDefaultBranchRefs(sqlite3 *db, ChunkStore *cs, void *pArg){
-  const char *zBranch = (const char*)pArg;
-  UNUSED_PARAMETER(db);
-  return chunkStoreSetDefaultBranch(cs, zBranch);
-}
-
 static int rebaseRestoreReturnBranchWorkingState(
   sqlite3 *db,
   const char *zBranch
@@ -4135,14 +4129,6 @@ fail:
   sqlite3_finalize(pStmt);
   rebaseFreePlan(aPlan, nPlan);
   return rc;
-}
-
-static char *rebaseDeriveOrigBranchFromWorking(const char *zWorking){
-  static const char zPrefix[] = "dolt_rebase_";
-  int nPrefix = (int)strlen(zPrefix);
-  if( !zWorking ) return 0;
-  if( strncmp(zWorking, zPrefix, nPrefix)!=0 ) return 0;
-  return sqlite3_mprintf("%s", zWorking + nPrefix);
 }
 
 static char *rebaseBuildWorkingBranchName(const char *zOrigBranch){

--- a/src/doltlite_blame.c
+++ b/src/doltlite_blame.c
@@ -925,18 +925,8 @@ static int bmColumn(sqlite3_vtab_cursor *pCursor,
       else sqlite3_result_null(ctx);
       break;
     case 1: {
-      time_t t;
-      struct tm *tm;
       if( !r->blamed ){ sqlite3_result_null(ctx); break; }
-      t = (time_t)r->commitDate;
-      tm = gmtime(&t);
-      if( tm ){
-        char buf[32];
-        strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", tm);
-        sqlite3_result_text(ctx, buf, -1, SQLITE_TRANSIENT);
-      }else{
-        sqlite3_result_null(ctx);
-      }
+      doltliteResultTimestamp(ctx, r->commitDate);
       break;
     }
     case 2:

--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -75,7 +75,6 @@ static void branchNamedResultError(
 
 static int mutateBranchRef(sqlite3 *db, ChunkStore *cs, void *pArg){
   BranchMutationCtx *p = (BranchMutationCtx*)pArg;
-  int rc;
 
   if( p->isDelete ){
     (void)db;
@@ -1479,15 +1478,7 @@ static int brColumn(sqlite3_vtab_cursor *c, sqlite3_context *ctx, int col){
                             -1, SQLITE_TRANSIENT);
         break;
       case 4: {
-        time_t t = (time_t)cm.timestamp;
-        struct tm *tm = gmtime(&t);
-        if( tm ){
-          char buf[32];
-          strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", tm);
-          sqlite3_result_text(ctx, buf, -1, SQLITE_TRANSIENT);
-        }else{
-          sqlite3_result_null(ctx);
-        }
+        doltliteResultTimestamp(ctx, cm.timestamp);
         break;
       }
       case 5:

--- a/src/doltlite_diff.c
+++ b/src/doltlite_diff.c
@@ -660,15 +660,7 @@ static int diffColumn(sqlite3_vtab_cursor *pCursor,
       if( r->timestamp==0 && r->zCommitter==0 ){
         sqlite3_result_null(ctx);
       }else{
-        time_t t = (time_t)r->timestamp;
-        struct tm *tm = gmtime(&t);
-        if( tm ){
-          char buf[32];
-          strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", tm);
-          sqlite3_result_text(ctx, buf, -1, SQLITE_TRANSIENT);
-        }else{
-          sqlite3_result_null(ctx);
-        }
+        doltliteResultTimestamp(ctx, r->timestamp);
       }
       break;
     }

--- a/src/doltlite_diff_stat.c
+++ b/src/doltlite_diff_stat.c
@@ -576,33 +576,9 @@ static int dstConnect(sqlite3 *db, void *pAux, int argc,
 static int dstDisconnect(sqlite3_vtab *v){ sqlite3_free(v); return SQLITE_OK; }
 
 static int dstBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
-  int iFrom = -1, iTo = -1, iTbl = -1;
-  int i, argvIdx = 1;
   (void)pVtab;
-  for(i=0; i<pInfo->nConstraint; i++){
-    if( !pInfo->aConstraint[i].usable ) continue;
-    if( pInfo->aConstraint[i].op!=SQLITE_INDEX_CONSTRAINT_EQ ) continue;
-    switch( pInfo->aConstraint[i].iColumn ){
-      case DST_COL_FROM_REF: iFrom = i; break;
-      case DST_COL_TO_REF:   iTo   = i; break;
-      case DST_COL_TBL:      iTbl  = i; break;
-    }
-  }
-  if( iFrom>=0 ){
-    pInfo->aConstraintUsage[iFrom].argvIndex = argvIdx++;
-    pInfo->aConstraintUsage[iFrom].omit = 1;
-  }
-  if( iTo>=0 ){
-    pInfo->aConstraintUsage[iTo].argvIndex = argvIdx++;
-    pInfo->aConstraintUsage[iTo].omit = 1;
-  }
-  if( iTbl>=0 ){
-    pInfo->aConstraintUsage[iTbl].argvIndex = argvIdx++;
-    pInfo->aConstraintUsage[iTbl].omit = 1;
-  }
-  pInfo->idxNum = (iFrom>=0 ? 1 : 0) | (iTo>=0 ? 2 : 0) | (iTbl>=0 ? 4 : 0);
-  pInfo->estimatedCost = 1000.0;
-  return SQLITE_OK;
+  return doltliteBestIndexRefs(pInfo, DST_COL_FROM_REF, DST_COL_TO_REF,
+                               DST_COL_TBL);
 }
 
 static int dstOpen(sqlite3_vtab *v, sqlite3_vtab_cursor **pp){
@@ -907,33 +883,9 @@ static int dssConnect(sqlite3 *db, void *pAux, int argc,
 static int dssDisconnect(sqlite3_vtab *v){ sqlite3_free(v); return SQLITE_OK; }
 
 static int dssBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
-  int iFrom = -1, iTo = -1, iTbl = -1;
-  int i, argvIdx = 1;
   (void)pVtab;
-  for(i=0; i<pInfo->nConstraint; i++){
-    if( !pInfo->aConstraint[i].usable ) continue;
-    if( pInfo->aConstraint[i].op!=SQLITE_INDEX_CONSTRAINT_EQ ) continue;
-    switch( pInfo->aConstraint[i].iColumn ){
-      case DSS_COL_FROM_REF: iFrom = i; break;
-      case DSS_COL_TO_REF:   iTo   = i; break;
-      case DSS_COL_TBL:      iTbl  = i; break;
-    }
-  }
-  if( iFrom>=0 ){
-    pInfo->aConstraintUsage[iFrom].argvIndex = argvIdx++;
-    pInfo->aConstraintUsage[iFrom].omit = 1;
-  }
-  if( iTo>=0 ){
-    pInfo->aConstraintUsage[iTo].argvIndex = argvIdx++;
-    pInfo->aConstraintUsage[iTo].omit = 1;
-  }
-  if( iTbl>=0 ){
-    pInfo->aConstraintUsage[iTbl].argvIndex = argvIdx++;
-    pInfo->aConstraintUsage[iTbl].omit = 1;
-  }
-  pInfo->idxNum = (iFrom>=0 ? 1 : 0) | (iTo>=0 ? 2 : 0) | (iTbl>=0 ? 4 : 0);
-  pInfo->estimatedCost = 1000.0;
-  return SQLITE_OK;
+  return doltliteBestIndexRefs(pInfo, DSS_COL_FROM_REF, DSS_COL_TO_REF,
+                               DSS_COL_TBL);
 }
 
 static int dssOpen(sqlite3_vtab *v, sqlite3_vtab_cursor **pp){

--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -430,7 +430,6 @@ static int buildDiffPairs(DiffTblCursor *pCur, sqlite3 *db,
   int currInited = 0;
   ProllyHash curr;
   int rc = SQLITE_OK;
-  int i;
 
   if( !cs ) return SQLITE_OK;
   memset(&map, 0, sizeof(map));
@@ -837,7 +836,6 @@ static int openNextPairIter(DiffTblCursor *pCur, sqlite3 *db){
   {
     DiffPair *p;
     u8 flags;
-    int rc2;
     p = &pCur->aPairs[pCur->iPair++];
     flags = p->fromFlags ? p->fromFlags : p->toFlags;
     doltliteHashToHex(&p->fromHash, pCur->row.zFromCommit);

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -5,6 +5,7 @@
 #include "sqliteInt.h"
 #include "prolly_hash.h"
 #include "chunk_store.h"
+#include <time.h>
 
 typedef struct BtShared BtShared;
 typedef struct ProllyCache ProllyCache;
@@ -51,13 +52,58 @@ static SQLITE_INLINE struct TableEntry *doltliteFindTableByName(
   return 0;
 }
 
-static SQLITE_INLINE int tableEntryNameCmp(const void *a, const void *b){
-  const struct TableEntry *ea = (const struct TableEntry *)a;
-  const struct TableEntry *eb = (const struct TableEntry *)b;
-  if( !ea->zName && !eb->zName ) return 0;
-  if( !ea->zName ) return -1;
-  if( !eb->zName ) return 1;
-  return strcmp(ea->zName, eb->zName);
+static SQLITE_INLINE int doltliteBestIndexRefs(
+  sqlite3_index_info *pInfo,
+  int iFromCol,
+  int iToCol,
+  int iTableCol
+){
+  int i;
+  int iFrom = -1;
+  int iTo = -1;
+  int iTbl = -1;
+  int argvIdx = 1;
+
+  for(i=0; i<pInfo->nConstraint; i++){
+    if( !pInfo->aConstraint[i].usable ) continue;
+    if( pInfo->aConstraint[i].op!=SQLITE_INDEX_CONSTRAINT_EQ ) continue;
+    if( pInfo->aConstraint[i].iColumn==iFromCol ){
+      iFrom = i;
+    }else if( pInfo->aConstraint[i].iColumn==iToCol ){
+      iTo = i;
+    }else if( pInfo->aConstraint[i].iColumn==iTableCol ){
+      iTbl = i;
+    }
+  }
+
+  if( iFrom>=0 ){
+    pInfo->aConstraintUsage[iFrom].argvIndex = argvIdx++;
+    pInfo->aConstraintUsage[iFrom].omit = 1;
+  }
+  if( iTo>=0 ){
+    pInfo->aConstraintUsage[iTo].argvIndex = argvIdx++;
+    pInfo->aConstraintUsage[iTo].omit = 1;
+  }
+  if( iTbl>=0 ){
+    pInfo->aConstraintUsage[iTbl].argvIndex = argvIdx++;
+    pInfo->aConstraintUsage[iTbl].omit = 1;
+  }
+
+  pInfo->idxNum = (iFrom>=0 ? 1 : 0) | (iTo>=0 ? 2 : 0) | (iTbl>=0 ? 4 : 0);
+  pInfo->estimatedCost = 1000.0;
+  return SQLITE_OK;
+}
+
+static SQLITE_INLINE void doltliteResultTimestamp(sqlite3_context *ctx, i64 timestamp){
+  time_t t = (time_t)timestamp;
+  struct tm *tm = gmtime(&t);
+  if( tm ){
+    char buf[32];
+    strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", tm);
+    sqlite3_result_text(ctx, buf, -1, SQLITE_TRANSIENT);
+  }else{
+    sqlite3_result_null(ctx);
+  }
 }
 
 static SQLITE_INLINE int doltliteFindTableRootByName(

--- a/src/doltlite_log.c
+++ b/src/doltlite_log.c
@@ -238,15 +238,7 @@ static int doltliteLogColumn(
       break;
     case 3:
       {
-        time_t t = (time_t)c->timestamp;
-        struct tm *tm = gmtime(&t);
-        if( tm ){
-          char buf[32];
-          strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", tm);
-          sqlite3_result_text(ctx, buf, -1, SQLITE_TRANSIENT);
-        }else{
-          sqlite3_result_null(ctx);
-        }
+        doltliteResultTimestamp(ctx, c->timestamp);
       }
       break;
     case 4:

--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -1534,26 +1534,18 @@ static u32 mergeCatalogSerialType(const MergeFieldValue *pMem, u32 *pLen){
   return 0;
 }
 
-static void mergeCatalogWriteIntBe(u8 *pOut, i64 v, int nByte){
-  int i;
-  for(i=nByte-1; i>=0; i--){
-    pOut[i] = (u8)(v & 0xFF);
-    v >>= 8;
-  }
-}
-
 static void mergeCatalogSerialPut(u8 *pOut, const MergeFieldValue *pMem, u32 serialType){
   switch( serialType ){
     case 0:
     case 8:
     case 9:
       return;
-    case 1: mergeCatalogWriteIntBe(pOut, pMem->i, 1); return;
-    case 2: mergeCatalogWriteIntBe(pOut, pMem->i, 2); return;
-    case 3: mergeCatalogWriteIntBe(pOut, pMem->i, 3); return;
-    case 4: mergeCatalogWriteIntBe(pOut, pMem->i, 4); return;
-    case 5: mergeCatalogWriteIntBe(pOut, pMem->i, 6); return;
-    case 6: mergeCatalogWriteIntBe(pOut, pMem->i, 8); return;
+    case 1: doltliteIpkWriteBE(pOut, pMem->i, 1); return;
+    case 2: doltliteIpkWriteBE(pOut, pMem->i, 2); return;
+    case 3: doltliteIpkWriteBE(pOut, pMem->i, 3); return;
+    case 4: doltliteIpkWriteBE(pOut, pMem->i, 4); return;
+    case 5: doltliteIpkWriteBE(pOut, pMem->i, 6); return;
+    case 6: doltliteIpkWriteBE(pOut, pMem->i, 8); return;
     default:
       if( serialType>=12 ){
         memcpy(pOut, pMem->p, (size_t)pMem->n);

--- a/src/doltlite_merge_constraints.c
+++ b/src/doltlite_merge_constraints.c
@@ -340,30 +340,22 @@ static u32 mergeSerialType(const MergeFieldValue *pMem, u32 *pLen){
   return 0;
 }
 
-static void mergeWriteIntBe(u8 *pOut, i64 v, int nByte){
-  int i;
-  for(i=nByte-1; i>=0; i--){
-    pOut[i] = (u8)(v & 0xFF);
-    v >>= 8;
-  }
-}
-
 static void mergeSerialPut(u8 *pOut, const MergeFieldValue *pMem, u32 serialType){
   switch( serialType ){
     case 0:
     case 8:
     case 9:
       return;
-    case 1: mergeWriteIntBe(pOut, pMem->i, 1); return;
-    case 2: mergeWriteIntBe(pOut, pMem->i, 2); return;
-    case 3: mergeWriteIntBe(pOut, pMem->i, 3); return;
-    case 4: mergeWriteIntBe(pOut, pMem->i, 4); return;
-    case 5: mergeWriteIntBe(pOut, pMem->i, 6); return;
-    case 6: mergeWriteIntBe(pOut, pMem->i, 8); return;
+    case 1: doltliteIpkWriteBE(pOut, pMem->i, 1); return;
+    case 2: doltliteIpkWriteBE(pOut, pMem->i, 2); return;
+    case 3: doltliteIpkWriteBE(pOut, pMem->i, 3); return;
+    case 4: doltliteIpkWriteBE(pOut, pMem->i, 4); return;
+    case 5: doltliteIpkWriteBE(pOut, pMem->i, 6); return;
+    case 6: doltliteIpkWriteBE(pOut, pMem->i, 8); return;
     case 7: {
       sqlite3_uint64 u;
       memcpy(&u, &pMem->r, 8);
-      mergeWriteIntBe(pOut, (i64)u, 8);
+      doltliteIpkWriteBE(pOut, (i64)u, 8);
       return;
     }
     default:

--- a/src/doltlite_remotesrv.c
+++ b/src/doltlite_remotesrv.c
@@ -220,7 +220,6 @@ static int parsePath(
 ){
   const char *p = zPath;
   const char *dbStart;
-  const char *dbEnd;
   const char *epStart;
   int dbLen, epLen;
 

--- a/src/doltlite_schema_diff.c
+++ b/src/doltlite_schema_diff.c
@@ -426,36 +426,8 @@ static int sdConnect(sqlite3 *db, void *pAux, int argc,
 static int sdDisconnect(sqlite3_vtab *v){ sqlite3_free(v); return SQLITE_OK; }
 
 static int sdBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
-  int iFrom = -1, iTo = -1, iTbl = -1;
-  int i, argvIdx = 1;
   (void)pVtab;
-
-  for(i=0; i<pInfo->nConstraint; i++){
-    if( !pInfo->aConstraint[i].usable ) continue;
-    if( pInfo->aConstraint[i].op!=SQLITE_INDEX_CONSTRAINT_EQ ) continue;
-    switch( pInfo->aConstraint[i].iColumn ){
-      case 4: iFrom = i; break;
-      case 5: iTo   = i; break;
-      case 6: iTbl  = i; break;
-    }
-  }
-
-  if( iFrom>=0 ){
-    pInfo->aConstraintUsage[iFrom].argvIndex = argvIdx++;
-    pInfo->aConstraintUsage[iFrom].omit = 1;
-  }
-  if( iTo>=0 ){
-    pInfo->aConstraintUsage[iTo].argvIndex = argvIdx++;
-    pInfo->aConstraintUsage[iTo].omit = 1;
-  }
-  if( iTbl>=0 ){
-    pInfo->aConstraintUsage[iTbl].argvIndex = argvIdx++;
-    pInfo->aConstraintUsage[iTbl].omit = 1;
-  }
-
-  pInfo->idxNum = (iFrom>=0 ? 1 : 0) | (iTo>=0 ? 2 : 0) | (iTbl>=0 ? 4 : 0);
-  pInfo->estimatedCost = 1000.0;
-  return SQLITE_OK;
+  return doltliteBestIndexRefs(pInfo, 4, 5, 6);
 }
 
 static int sdOpen(sqlite3_vtab *v, sqlite3_vtab_cursor **pp){

--- a/src/doltlite_tag.c
+++ b/src/doltlite_tag.c
@@ -280,15 +280,7 @@ static int tagColumn(sqlite3_vtab_cursor *pCursor, sqlite3_context *ctx, int col
                           -1, SQLITE_TRANSIENT);
       break;
     case 4: {
-      time_t secs = (time_t)t->timestamp;
-      struct tm *tm = gmtime(&secs);
-      if( tm ){
-        char buf[32];
-        strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", tm);
-        sqlite3_result_text(ctx, buf, -1, SQLITE_TRANSIENT);
-      }else{
-        sqlite3_result_null(ctx);
-      }
+      doltliteResultTimestamp(ctx, t->timestamp);
       break;
     }
     case 5:

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -118,8 +118,6 @@ int doltliteSerializeCatalogEntriesWithFallbackSchema(
 
 #define PROLLY_MAX_RECORD_SIZE ((sqlite3_int64)(1024*1024*1024))
 
-static const ProllyHash emptyHash = {{0}};
-
 struct TableEntry {
   Pgno iTable;
   ProllyHash root;
@@ -543,7 +541,6 @@ static int serializeCatalog(Btree *pBtree, u8 **ppOut, int *pnOut);
 static int deserializeCatalog(Btree *pBtree, const u8 *data, int nData);
 static int tableEntryIsTableRoot(Btree *pBtree, struct TableEntry *pTE);
 static int btreeRefreshFromDisk(Btree *p);
-static int btreeReloadBranchWorkingState(Btree *p, int bLoadCatalog);
 static int btreeReadWorkingCatalog(ChunkStore *cs, const char *zBranch,
                                    ProllyHash *pCatHash,
                                    ProllyHash *pCommitHash);
@@ -1089,15 +1086,6 @@ struct CatalogSerializeEntry {
   const char *zTblName;
 };
 
-static int tableEntryNameCmp(const void *a, const void *b){
-  const struct TableEntry *ea = (const struct TableEntry *)a;
-  const struct TableEntry *eb = (const struct TableEntry *)b;
-  if( !ea->zName && !eb->zName ) return 0;
-  if( !ea->zName ) return -1;
-  if( !eb->zName ) return 1;
-  return strcmp(ea->zName, eb->zName);
-}
-
 static void freeCatalogEntryMeta(CatalogEntryMeta *aMeta, int nMeta){
   int i;
   for(i=0; i<nMeta; i++){
@@ -1130,23 +1118,6 @@ static const CatalogEntryMeta *findCatalogEntryMetaByPgno(
   int i;
   for(i=0; i<nMeta; i++){
     if( aMeta[i].iTable==iTable ) return &aMeta[i];
-  }
-  return 0;
-}
-
-static const CatalogEntryMeta *findCatalogEntryMetaByObject(
-  CatalogEntryMeta *aMeta,
-  int nMeta,
-  const char *zType,
-  const char *zName,
-  const char *zTblName
-){
-  int i;
-  for(i=0; i<nMeta; i++){
-    if( strcmp(aMeta[i].zType ? aMeta[i].zType : "", zType ? zType : "")!=0 ) continue;
-    if( strcmp(aMeta[i].zName ? aMeta[i].zName : "", zName ? zName : "")!=0 ) continue;
-    if( strcmp(aMeta[i].zTblName ? aMeta[i].zTblName : "", zTblName ? zTblName : "")!=0 ) continue;
-    return &aMeta[i];
   }
   return 0;
 }
@@ -2397,24 +2368,6 @@ static int deserializeCatalog(Btree *pBtree, const u8 *data, int nData){
     pBtree->aMeta[BTREE_LARGEST_ROOT_PAGE] = maxPage;
 
     pBtree->cat.iNextTable = maxCatalogTable + 1;
-  }
-
-  if( getenv("DOLTLITE_DEBUG_CAT") ){
-    fprintf(stderr, "deserializeCatalog: n=%d\n", pBtree->cat.n);
-    for(i=0; i<pBtree->cat.n; i++){
-      char zRoot[PROLLY_HASH_SIZE*2 + 1];
-      int k;
-      for(k=0; k<PROLLY_HASH_SIZE; k++){
-        static const char zHex[] = "0123456789abcdef";
-        zRoot[k*2] = zHex[(pBtree->cat.a[i].root.data[k] >> 4) & 0xF];
-        zRoot[k*2 + 1] = zHex[pBtree->cat.a[i].root.data[k] & 0xF];
-      }
-      zRoot[PROLLY_HASH_SIZE*2] = 0;
-      fprintf(stderr, "  cat[%d]: iTable=%u name=%s flags=%u root=%s\n",
-              i, (unsigned)pBtree->cat.a[i].iTable,
-              pBtree->cat.a[i].zName ? pBtree->cat.a[i].zName : "(null)",
-              (unsigned)pBtree->cat.a[i].flags, zRoot);
-    }
   }
 
   return SQLITE_OK;
@@ -3686,26 +3639,8 @@ static int countTreeEntries(Btree *pBtree, Pgno iTable, i64 *pCount){
     return SQLITE_OK;
   }
 
-  if( getenv("DOLTLITE_DEBUG_COUNT") && iTable==3 ){
-    char zRoot[PROLLY_HASH_SIZE*2 + 1];
-    int k;
-    static const char zHex[] = "0123456789abcdef";
-    for(k=0; k<PROLLY_HASH_SIZE; k++){
-      zRoot[k*2] = zHex[(pTE->root.data[k] >> 4) & 0xF];
-      zRoot[k*2 + 1] = zHex[pTE->root.data[k] & 0xF];
-    }
-    zRoot[PROLLY_HASH_SIZE*2] = 0;
-    fprintf(stderr, "countTreeEntries: branch=%s iTable=%u flags=%u root=%s\n",
-            pBtree->zBranch ? pBtree->zBranch : "(null)",
-            (unsigned)iTable, (unsigned)pTE->flags, zRoot);
-  }
-
   *pCount = 0;
   rc = countSubtreeRows(&pBt->store, &pBt->cache, &pTE->root, pCount);
-  if( getenv("DOLTLITE_DEBUG_COUNT") && iTable==3 ){
-    fprintf(stderr, "countTreeEntries: rc=%d count=%lld\n",
-            rc, (long long)*pCount);
-  }
   return rc;
 }
 
@@ -4870,10 +4805,6 @@ static int btreeReloadBranchWorkingStateInto(
   return SQLITE_OK;
 }
 
-static int btreeReloadBranchWorkingState(Btree *p, int bLoadCatalog){
-  return btreeReloadBranchWorkingStateInto(p, bLoadCatalog, 0);
-}
-
 static void btreeStoreCommittedFromCurrent(Btree *p, const ProllyHash *pCatHash){
   if( pCatHash ){
     p->committedCatalogHash = *pCatHash;
@@ -5078,7 +5009,6 @@ int sqlite3BtreeCommitPhaseOne(Btree *p, const char *zSuperJrnl){
 static int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
   BtShared *pBt = p->pBt;
   int rc = SQLITE_OK;
-  int rcRollback = SQLITE_OK;
   u8 *catData = 0;
   int nCatData = 0;
   ProllyHash catHash;
@@ -5777,7 +5707,6 @@ static int prollyBtreeCursor(
 ){
   BtShared *pBt = p->pBt;
   struct TableEntry *pTE;
-  int rc;
 
   assert( p->inTrans>=TRANS_READ );
 

--- a/src/prolly_chunker.c
+++ b/src/prolly_chunker.c
@@ -236,7 +236,6 @@ int prollyChunkerAdd(ProllyChunker *ch,
 int prollyChunkerFinish(ProllyChunker *ch){
   int rc;
   int level;
-  int maxLevel;
 
   if( ch->nLevels == 0 ){
     memset(&ch->root, 0, sizeof(ProllyHash));
@@ -291,12 +290,6 @@ int prollyChunkerFinish(ProllyChunker *ch){
 
 void prollyChunkerGetRoot(ProllyChunker *ch, ProllyHash *pRoot){
   memcpy(pRoot, &ch->root, sizeof(ProllyHash));
-}
-
-int prollyChunkerAddAtLevel(ProllyChunker *ch, int level,
-                            const u8 *pKey, int nKey,
-                            const u8 *pVal, int nVal){
-  return addToLevel(ch, level, pKey, nKey, pVal, nVal, 0);
 }
 
 int prollyChunkerAddAtLevelWithCount(ProllyChunker *ch, int level,

--- a/src/prolly_chunker.h
+++ b/src/prolly_chunker.h
@@ -47,10 +47,6 @@ void prollyChunkerGetRoot(ProllyChunker *ch, ProllyHash *pRoot);
 
 void prollyChunkerFree(ProllyChunker *ch);
 
-int prollyChunkerAddAtLevel(ProllyChunker *ch, int level,
-                            const u8 *pKey, int nKey,
-                            const u8 *pVal, int nVal);
-
 int prollyChunkerAddAtLevelWithCount(ProllyChunker *ch, int level,
                                      const u8 *pKey, int nKey,
                                      const u8 *pVal, int nVal,

--- a/src/prolly_mutate.c
+++ b/src/prolly_mutate.c
@@ -154,7 +154,6 @@ static int mergeLeaf(
 ){
   int rc = SQLITE_OK;
   int j;
-  u8 flags = pMut->flags;
   const u8 *pLastKey = 0;
   int nLastKey = 0;
 

--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -1159,32 +1159,4 @@ int prollyMutMapClone(ProllyMutMap **out, const ProllyMutMap *src){
   return SQLITE_OK;
 }
 
-/* Merge every entry in pSrc into pDst and clear pSrc. Both maps MUST
-** be in the same key mode (isIntKey). For int-keyed maps, each entry's
-** pKey contains its key already encoded big-endian via encodeIntKeyBE
-** (see prepKey above and prollyMutMapEntryIntKey), so passing pKey/nKey
-** with intKey=0 takes the "pre-encoded blob" branch of prepKey and the
-** byte sequence is used as-is — the right thing for matched modes. If
-** the modes don't match, however, an int-keyed pSrc's 8-byte encoded
-** bytes get treated as a blob key (or vice versa: a blob key gets
-** misread as an encoded int), silently corrupting pDst's sort order
-** and hash table. */
-int prollyMutMapMerge(ProllyMutMap *pDst, ProllyMutMap *pSrc){
-  int i, rc;
-  assert( pDst->isIntKey == pSrc->isIntKey );
-  if( pDst->isIntKey != pSrc->isIntKey ) return SQLITE_MISUSE;
-  for(i=0; i<pSrc->nEntries; i++){
-    ProllyMutMapEntry *e = &pSrc->aEntries[i];
-    if( e->op==PROLLY_EDIT_INSERT ){
-      rc = prollyMutMapInsert(pDst, e->pKey, e->nKey, 0,
-                               e->pVal, e->nVal);
-    }else{
-      rc = prollyMutMapDelete(pDst, e->pKey, e->nKey, 0);
-    }
-    if( rc!=SQLITE_OK ) return rc;
-  }
-  prollyMutMapClear(pSrc);
-  return SQLITE_OK;
-}
-
 #endif

--- a/src/prolly_mutmap.h
+++ b/src/prolly_mutmap.h
@@ -124,8 +124,6 @@ void prollyMutMapIterSeek(ProllyMutMapIter *it, ProllyMutMap *mm,
 
 void prollyMutMapIterLast(ProllyMutMapIter *it, ProllyMutMap *mm);
 
-int prollyMutMapMerge(ProllyMutMap *pDst, ProllyMutMap *pSrc);
-
 int prollyMutMapClone(ProllyMutMap **out, const ProllyMutMap *src);
 
 void prollyMutMapPushSavepoint(ProllyMutMap *mm, int level);


### PR DESCRIPTION
## Summary
- remove unused DoltLite internal wrappers, dead static helpers, stale locals, and redundant debug-only code paths
- extract shared vtab ref-constraint and timestamp rendering helpers
- reuse existing integer record writer helpers in merge serialization code

## Testing
- make doltlite
- clang first-party syntax/warning sweep with -Wunused-function -Wunused-variable -Wunused-value
- DOLTLITE=./doltlite bash test/doltlite_schema_diff.sh
- DOLTLITE=./doltlite bash test/doltlite_diff.sh
- DOLTLITE=./doltlite bash test/doltlite_log.sh
- DOLTLITE=./doltlite test/doltlite_tag.sh
- DOLTLITE=./doltlite bash test/doltlite_comparison.sh
- DOLTLITE=./doltlite bash test/doltlite_dolt_table_pushdown.sh
- DOLTLITE=./doltlite bash test/doltlite_merge.sh