### PR TITLE
fix(remote_sql): save/restore constraint-violations catalog in RemoteSqlState

### DIFF
--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -25,6 +25,7 @@ struct RemoteSqlState {
   ProllyHash sessionStaged;
   ProllyHash sessionMergeCommit;
   ProllyHash sessionConflictsCatalog;
+  ProllyHash sessionConstraintViolationsCatalog;
   ProllyHash sessionCatalogHash;
   u8 sessionIsMerging;
 };
@@ -51,6 +52,8 @@ static int remoteSqlStateSave(sqlite3 *db, ChunkStore *cs, RemoteSqlState *p){
   doltliteGetSessionMergeState(db, &p->sessionIsMerging,
                                &p->sessionMergeCommit,
                                &p->sessionConflictsCatalog);
+  doltliteGetSessionConstraintViolationsCatalog(
+      db, &p->sessionConstraintViolationsCatalog);
 
   rc = doltliteFlushCatalogToHash(db, &p->sessionCatalogHash);
   if( rc!=SQLITE_OK ){
@@ -79,6 +82,8 @@ static int remoteSqlStateRestore(sqlite3 *db, ChunkStore *cs, RemoteSqlState *p)
   doltliteSetSessionMergeState(db, p->sessionIsMerging,
                                &p->sessionMergeCommit,
                                &p->sessionConflictsCatalog);
+  doltliteSetSessionConstraintViolationsCatalog(
+      db, &p->sessionConstraintViolationsCatalog);
   return SQLITE_OK;
 }
 


### PR DESCRIPTION
## Summary
- `RemoteSqlState` (the revert-on-failure snapshot used by `dolt_pull` and `dolt_clone`) mirrored every session field that `DoltliteTxnState` saves **except** the constraint-violations catalog. This adds the field plus its Get-on-save / Set-on-restore so the two snapshot structs stay in parity.
- Found during the RemoteSqlState ↔ DoltliteTxnState divergence audit (companion to #1055).

## Why there's no regression test
This is **latent** hardening, not an observable bug fix:
- `dolt_pull` is fast-forward-only (rejects non-FF, so it never runs a merge → no constraint violations are produced).
- `dolt_clone` requires an empty/virgin database (no pre-existing violations).
- `remoteSqlStateRestore` runs **only** on failure, and every failure branch that could carry mutated CVs sits *before* the one CV-mutating step (`remoteSqlResetSessionToCommit` → hard reset). The single post-mutation failure window is `remoteSqlPersistRefs`, reachable only via white-box fault injection.

So no black-box test can fail on master today. Per our fail-before/pass-after test rule, latent fixes are documented as such rather than shipped with a test that passes both ways. The merge path that *does* mutate CVs is already covered through `DoltliteTxnState`.

## Test plan
- [x] `make libdoltlite.a` compiles clean with the change
- [x] `sql_transaction_test` 24/24 pass against the rebuilt library