### PR TITLE
Stabilize autocommit write benchmark medians

### DIFF
--- a/test/sysbench_compare.sh
+++ b/test/sysbench_compare.sh
@@ -19,6 +19,7 @@ BENCH_MAX_MULTIPLIER=${BENCH_MAX_MULTIPLIER:-2.5}
 BENCH_AVG_MAX_MULTIPLIER=${BENCH_AVG_MAX_MULTIPLIER:-2}
 BENCH_AC_WRITE_MAX_MULTIPLIER=${BENCH_AC_WRITE_MAX_MULTIPLIER:-6}
 BENCH_AC_WRITE_AVG_MAX_MULTIPLIER=${BENCH_AC_WRITE_AVG_MAX_MULTIPLIER:-5}
+BENCH_AC_WRITE_RUNS=${BENCH_AC_WRITE_RUNS:-9}
 BENCH_SECTION_MODE=${BENCH_SECTION_MODE:-full}
 
 cleanup() { rm -rf "$TMPDIR"; }
@@ -413,7 +414,19 @@ else:
 
 bench_runs_for_test() {
   # BENCH_RUNS=1 for fast local iteration; default 5 for stable median.
-  echo "${BENCH_RUNS:-5}"
+  case "$1" in
+    *_ac) echo "$BENCH_AC_WRITE_RUNS" ;;
+    *) echo "${BENCH_RUNS:-5}" ;;
+  esac
+}
+
+bench_runs_summary() {
+  local base_runs="${BENCH_RUNS:-5}"
+  if [ "$BENCH_AC_WRITE_RUNS" = "$base_runs" ]; then
+    echo "median of ${base_runs} invocations per test"
+  else
+    echo "median of ${base_runs} invocations per test; autocommit writes use ${BENCH_AC_WRITE_RUNS}"
+  fi
 }
 
 median_us() {
@@ -584,7 +597,7 @@ case "$BENCH_SECTION_MODE" in
 esac
 
 echo ""
-echo "_${ROWS} rows, median of $(bench_runs_for_test summary) invocations per test, workload-only timing via host monotonic clock when available._"
+echo "_${ROWS} rows, $(bench_runs_summary), workload-only timing via host monotonic clock when available._"
 
 # ============================================================
 # Enforce performance ceiling (exit 1 if any test exceeds limit)

--- a/test/sysbench_compare_blobpk.sh
+++ b/test/sysbench_compare_blobpk.sh
@@ -26,6 +26,7 @@ BENCH_MAX_MULTIPLIER=${BENCH_MAX_MULTIPLIER:-2.5}
 BENCH_AVG_MAX_MULTIPLIER=${BENCH_AVG_MAX_MULTIPLIER:-2}
 BENCH_AC_WRITE_MAX_MULTIPLIER=${BENCH_AC_WRITE_MAX_MULTIPLIER:-6}
 BENCH_AC_WRITE_AVG_MAX_MULTIPLIER=${BENCH_AC_WRITE_AVG_MAX_MULTIPLIER:-5}
+BENCH_AC_WRITE_RUNS=${BENCH_AC_WRITE_RUNS:-9}
 SEED=42
 TMPDIR=$(mktemp -d)
 
@@ -431,9 +432,22 @@ else:
 bench_runs_for_test() {
   # BENCH_RUNS=1 for fast local iteration; default 5 for non-INTKEY
   # suites — each non-INTKEY write on doltlite goes through a per-
-  # statement flush path, so 11 runs blow the CI budget. Median of 5
-  # is still stable enough for tracking ratios across PRs.
-  echo "${BENCH_RUNS:-5}"
+  # statement flush path, so most tests keep the normal median-of-5
+  # budget. The autocommit writes are noisier in CI, so they get a
+  # wider median window.
+  case "$1" in
+    *_ac) echo "$BENCH_AC_WRITE_RUNS" ;;
+    *) echo "${BENCH_RUNS:-5}" ;;
+  esac
+}
+
+bench_runs_summary() {
+  local base_runs="${BENCH_RUNS:-5}"
+  if [ "$BENCH_AC_WRITE_RUNS" = "$base_runs" ]; then
+    echo "median of ${base_runs} invocations per test"
+  else
+    echo "median of ${base_runs} invocations per test; autocommit writes use ${BENCH_AC_WRITE_RUNS}"
+  fi
 }
 
 median_us() {
@@ -555,7 +569,7 @@ echo ""
 SQLITE_BENCH_PRAGMAS="$SQLITE_AUTOCOMMIT_PRAGMAS" run_section "ac_writes" "$WRITE_TESTS_AC" "$TMPDIR/bench_file" "$TMPDIR/bench_file"
 
 echo ""
-echo "_${ROWS} rows, median of $(bench_runs_for_test summary) invocations per test, workload-only timing via host monotonic clock when available._"
+echo "_${ROWS} rows, $(bench_runs_summary), workload-only timing via host monotonic clock when available._"
 
 # ============================================================
 # Enforce performance ceiling — gates the same shape sysbench_compare.sh

--- a/test/sysbench_compare_compositepk.sh
+++ b/test/sysbench_compare_compositepk.sh
@@ -29,6 +29,7 @@ BENCH_MAX_MULTIPLIER=${BENCH_MAX_MULTIPLIER:-2.5}
 BENCH_AVG_MAX_MULTIPLIER=${BENCH_AVG_MAX_MULTIPLIER:-2}
 BENCH_AC_WRITE_MAX_MULTIPLIER=${BENCH_AC_WRITE_MAX_MULTIPLIER:-6}
 BENCH_AC_WRITE_AVG_MAX_MULTIPLIER=${BENCH_AC_WRITE_AVG_MAX_MULTIPLIER:-5}
+BENCH_AC_WRITE_RUNS=${BENCH_AC_WRITE_RUNS:-9}
 SEED=42
 TMPDIR=$(mktemp -d)
 
@@ -451,9 +452,22 @@ else:
 bench_runs_for_test() {
   # BENCH_RUNS=1 for fast local iteration; default 5 for non-INTKEY
   # suites — each non-INTKEY write on doltlite goes through a per-
-  # statement flush path, so 11 runs blow the CI budget. Median of 5
-  # is still stable enough for tracking ratios across PRs.
-  echo "${BENCH_RUNS:-5}"
+  # statement flush path, so most tests keep the normal median-of-5
+  # budget. The autocommit writes are noisier in CI, so they get a
+  # wider median window.
+  case "$1" in
+    *_ac) echo "$BENCH_AC_WRITE_RUNS" ;;
+    *) echo "${BENCH_RUNS:-5}" ;;
+  esac
+}
+
+bench_runs_summary() {
+  local base_runs="${BENCH_RUNS:-5}"
+  if [ "$BENCH_AC_WRITE_RUNS" = "$base_runs" ]; then
+    echo "median of ${base_runs} invocations per test"
+  else
+    echo "median of ${base_runs} invocations per test; autocommit writes use ${BENCH_AC_WRITE_RUNS}"
+  fi
 }
 
 median_us() {
@@ -575,7 +589,7 @@ echo ""
 SQLITE_BENCH_PRAGMAS="$SQLITE_AUTOCOMMIT_PRAGMAS" run_section "ac_writes" "$WRITE_TESTS_AC" "$TMPDIR/bench_file" "$TMPDIR/bench_file"
 
 echo ""
-echo "_${ROWS} rows, median of $(bench_runs_for_test summary) invocations per test, workload-only timing via host monotonic clock when available._"
+echo "_${ROWS} rows, $(bench_runs_summary), workload-only timing via host monotonic clock when available._"
 
 # ============================================================
 # Enforce performance ceiling — gates the same shape sysbench_compare.sh

--- a/test/sysbench_compare_textpk.sh
+++ b/test/sysbench_compare_textpk.sh
@@ -25,6 +25,7 @@ BENCH_MAX_MULTIPLIER=${BENCH_MAX_MULTIPLIER:-2.5}
 BENCH_AVG_MAX_MULTIPLIER=${BENCH_AVG_MAX_MULTIPLIER:-2}
 BENCH_AC_WRITE_MAX_MULTIPLIER=${BENCH_AC_WRITE_MAX_MULTIPLIER:-6}
 BENCH_AC_WRITE_AVG_MAX_MULTIPLIER=${BENCH_AC_WRITE_AVG_MAX_MULTIPLIER:-5}
+BENCH_AC_WRITE_RUNS=${BENCH_AC_WRITE_RUNS:-9}
 SEED=42
 TMPDIR=$(mktemp -d)
 
@@ -431,9 +432,21 @@ else:
 bench_runs_for_test() {
   # BENCH_RUNS=1 for fast local iteration; default 5 for the TEXT PK
   # suite — each non-INTKEY write on doltlite goes through a per-statement
-  # mutmap flush, so 11 runs blow the CI budget. Median of 5 is still
-  # stable enough for tracking ratios across PRs.
-  echo "${BENCH_RUNS:-5}"
+  # mutmap flush, so most tests keep the normal median-of-5 budget. The
+  # autocommit writes are noisier in CI, so they get a wider median window.
+  case "$1" in
+    *_ac) echo "$BENCH_AC_WRITE_RUNS" ;;
+    *) echo "${BENCH_RUNS:-5}" ;;
+  esac
+}
+
+bench_runs_summary() {
+  local base_runs="${BENCH_RUNS:-5}"
+  if [ "$BENCH_AC_WRITE_RUNS" = "$base_runs" ]; then
+    echo "median of ${base_runs} invocations per test"
+  else
+    echo "median of ${base_runs} invocations per test; autocommit writes use ${BENCH_AC_WRITE_RUNS}"
+  fi
 }
 
 median_us() {
@@ -555,7 +568,7 @@ echo ""
 SQLITE_BENCH_PRAGMAS="$SQLITE_AUTOCOMMIT_PRAGMAS" run_section "ac_writes" "$WRITE_TESTS_AC" "$TMPDIR/bench_file" "$TMPDIR/bench_file"
 
 echo ""
-echo "_${ROWS} rows, median of $(bench_runs_for_test summary) invocations per test, workload-only timing via host monotonic clock when available._"
+echo "_${ROWS} rows, $(bench_runs_summary), workload-only timing via host monotonic clock when available._"
 
 # ============================================================
 # Enforce performance ceiling — gates the same shape sysbench_compare.sh


### PR DESCRIPTION
## Summary
- add BENCH_AC_WRITE_RUNS for autocommit write workloads, defaulting to 9 samples
- keep all other benchmark workloads at the existing BENCH_RUNS default of 5 samples
- update benchmark footers so reports show the wider autocommit-write median window

## Why
Autocommit write rows are much noisier in CI than the rest of the benchmark suite. The PR #1055 comments show isolated autocommit write rows jumping above the ceiling while section averages stay around the expected range. Increasing the median window only for those workloads reduces outlier sensitivity without making the whole suite substantially slower.

## Testing
- bash -n test/sysbench_compare.sh test/sysbench_compare_textpk.sh test/sysbench_compare_compositepk.sh test/sysbench_compare_blobpk.sh
- BENCH_ROWS=100 BENCH_SECTION_MODE=autocommit BENCH_RUNS=1 BENCH_AC_WRITE_RUNS=3 DOLTLITE=./doltlite SQLITE3=./sqlite3 bash test/sysbench_compare.sh