### PR TITLE
cleanup: drop stale Windows-only dead stubs (remotesrv, http_remote)

### DIFF
--- a/src/doltlite_http_remote.c
+++ b/src/doltlite_http_remote.c
@@ -12,7 +12,6 @@
 
 #ifdef _WIN32
 
-void doltliteRegisterHttpRemote(sqlite3 *db){ (void)db; }
 DoltliteRemote *doltliteHttpRemoteOpen(const char *zUrl){ (void)zUrl; return 0; }
 #else
 #include <sys/socket.h>

--- a/src/doltlite_remotesrv.c
+++ b/src/doltlite_remotesrv.c
@@ -13,10 +13,6 @@
 
 #ifdef _WIN32
 
-DoltliteServer *doltliteServerCreate(const char *z, int p, char **e){
-  (void)z;(void)p; if(e) *e=sqlite3_mprintf("remotesrv not available on Windows"); return 0;
-}
-void doltliteServerDestroy(DoltliteServer *s){ (void)s; }
 int doltliteServerPort(DoltliteServer *s){ (void)s; return 0; }
 #else
 #include <sys/socket.h>


### PR DESCRIPTION
## Summary
Removes three dead Windows-only stub definitions found in the post-#1054 dead-code re-scan (task #6 of the cleanup list):

- `doltliteServerCreate` / `doltliteServerDestroy` (`doltlite_remotesrv.c`) — stub an API that was renamed to `doltliteServe` / `doltliteServeAsync` / `doltliteServerStop`. They have no header declaration and zero callers on any platform.
- `doltliteRegisterHttpRemote` (`doltlite_http_remote.c`) — no header declaration, zero callers anywhere.

**Kept** the Windows stubs for `doltliteServerPort` and `doltliteHttpRemoteOpen`: both back live, header-declared API symbols. `doltliteHttpRemoteOpen` is in fact required on Windows — `doltlite_remote_sql.c:102` calls it and that TU is in the lib build. `doltlite-remotesrv` is not built on Windows, so no Windows link depends on the removed stubs.

## Test plan
- [x] `make libdoltlite.a` — both edited TUs compile clean, no warnings
- [x] `make c-tests` + `bash test/run_c_tests.sh .` — 13/13 gating tests pass
- [ ] Windows CI build (`doltlite.exe` + `doltlite-lib`) — validates the `_WIN32` branch still compiles; can't be run locally on macOS

Note: the deletions live inside `#ifdef _WIN32`, so the local macOS build exercises only the preprocessor/structure, not the Windows code path. Windows CI on this PR is the real validation for the touched branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)