### PR TITLE
Reduce autocommit chunk-index merge spikes

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -151,6 +151,7 @@ static int csCrashWriteInjectionActive(void){
 #define CS_WAL_TAG_CHUNK  0x01
 #define CS_WAL_TAG_ROOT   0x02
 #define CS_RECENT_FAST_PATH_MAX 16384
+#define CS_WRITEBUF_RETAIN_MAX (64*1024)
 
 #if CHUNK_STORE_LE_PACKING
 typedef char chunk_index_entry_size_check[
@@ -1339,10 +1340,12 @@ commit_done:
   }
   sqlite3_free(aMergePending);
 
-  sqlite3_free(cs->staging.pWriteBuf);
-  cs->staging.pWriteBuf = 0;
   cs->staging.nWriteBuf = 0;
-  cs->staging.nWriteBufAlloc = 0;
+  if( cs->staging.nWriteBufAlloc > CS_WRITEBUF_RETAIN_MAX ){
+    sqlite3_free(cs->staging.pWriteBuf);
+    cs->staging.pWriteBuf = 0;
+    cs->staging.nWriteBufAlloc = 0;
+  }
   cs->staging.nPending = 0;
   csPendHTClear(cs);
   csMarkRefsCommitted(cs);

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -150,6 +150,7 @@ static int csCrashWriteInjectionActive(void){
 
 #define CS_WAL_TAG_CHUNK  0x01
 #define CS_WAL_TAG_ROOT   0x02
+#define CS_RECENT_FAST_PATH_MAX 16384
 
 #if CHUNK_STORE_LE_PACKING
 typedef char chunk_index_entry_size_check[
@@ -1146,7 +1147,9 @@ static int csCommitToFile(ChunkStore *cs){
     }
 
     useRecent = !crashWriteActive
-             && cs->staging.nPending <= 32 && cs->staging.nRecent + cs->staging.nPending <= 8192;
+             && cs->staging.nPending <= 32
+             && cs->staging.nRecent + cs->staging.nPending
+                  <= CS_RECENT_FAST_PATH_MAX;
     if( useRecent ){
       rc = csGrowRecent(cs, cs->staging.nPending);
       if( rc!=SQLITE_OK ) goto commit_done;


### PR DESCRIPTION
## Summary
- raise the chunk-store recent-entry fast path limit from 8192 to 16384
- retain small staging write buffers after successful file commits, capped at 64 KiB
- retain the initial pending chunk hash table across commit/rollback resets
- name the relevant thresholds as CS_RECENT_FAST_PATH_MAX and CS_WRITEBUF_RETAIN_MAX

## Why
Autocommit write workloads append small batches of chunks repeatedly. The chunk store keeps recent committed chunks out of the full sorted index as a latency fast path, but once recent + pending exceeded 8192 it fell back to a full chunk-index merge and reset recent entries. In the sysbench autocommit write shape, that can create a periodic latency spike in an otherwise stable run.

16384 is conservative: the current recent hash table starts at 4096 buckets with max load 4, so this doubles the merge cliff without crossing the next hash-table resize cliff.

The file commit path also freed the staging write buffer after every successful commit. Tiny autocommit writes then paid repeated allocate/free costs in the hot path. Retaining small buffers removes that allocator churn while still dropping buffers larger than 64 KiB after bigger commits.

Finally, if a statement produces enough chunks to build the pending dedup hash table, commit/rollback now reset the initial table in place instead of freeing it. Larger grown tables are still freed, so big transactions do not leave large allocations behind.

## Testing
- make doltlite
- git diff --check