### PR TITLE
cleanup: drop unused parameters from three static helpers

### DIFF
--- a/src/doltlite_blame.c
+++ b/src/doltlite_blame.c
@@ -414,7 +414,6 @@ static int blameCompareAgainstRef(
   sqlite3 *db,
   BlameCursor *pCur,
   const char *zTableName,
-  const ProllyHash *pCurRoot,
   u8 curFlags,
   const ProllyHash *pRefCatHash,
   const ProllyHash *pCommitHash,
@@ -431,8 +430,6 @@ static int blameCompareAgainstRef(
   int canScanRef = 0;
   int rc = SQLITE_OK;
   int i;
-
-  (void)pCurRoot;
 
   if( pRefCatHash && !prollyHashIsEmpty(pRefCatHash) ){
     rc = blameLoadTableRoot(db, pRefCatHash, zTableName, &refRoot, &refFlags);
@@ -575,7 +572,7 @@ static int blameWalk(
         rc = doltliteLoadCommit(db, &baseHash, &baseCommit);
         if( rc==SQLITE_OK ){
           rc = blameCompareAgainstRef(db, pCur, zTableName,
-                                      &curTableRoot, curFlags,
+                                      curFlags,
                                       &baseCommit.catalogHash,
                                       &walk, &commit);
           doltliteCommitClear(&baseCommit);
@@ -586,7 +583,7 @@ static int blameWalk(
         }
       }else if( haveCurTable ){
         rc = blameCompareAgainstRef(db, pCur, zTableName,
-                                    &curTableRoot, curFlags,
+                                    curFlags,
                                     0, &walk, &commit);
         if( rc!=SQLITE_OK ){
           doltliteCommitClear(&commit);
@@ -601,7 +598,7 @@ static int blameWalk(
         rc = doltliteLoadCommit(db, pParent, &parentCommit);
         if( rc==SQLITE_OK ){
           rc = blameCompareAgainstRef(db, pCur, zTableName,
-                                      &curTableRoot, curFlags,
+                                      curFlags,
                                       &parentCommit.catalogHash,
                                       &walk, &commit);
           doltliteCommitClear(&parentCommit);
@@ -612,7 +609,7 @@ static int blameWalk(
         }
       }else if( haveCurTable ){
         rc = blameCompareAgainstRef(db, pCur, zTableName,
-                                    &curTableRoot, curFlags,
+                                    curFlags,
                                     0, &walk, &commit);
         if( rc!=SQLITE_OK ){
           doltliteCommitClear(&commit);

--- a/src/doltlite_diff.c
+++ b/src/doltlite_diff.c
@@ -272,7 +272,6 @@ done:
 }
 
 static int computeCommitBatch(DoltliteDiffCursor *pCur, sqlite3 *db,
-                              const ProllyHash *pCommitHash,
                               const DoltliteCommit *pCommit,
                               const char *zCommitHex){
   struct TableEntry *aChild = 0, *aParent = 0;
@@ -280,7 +279,6 @@ static int computeCommitBatch(DoltliteDiffCursor *pCur, sqlite3 *db,
   int rc, i;
   const ProllyHash *pParentHash = doltliteCommitParentHash(pCommit, 0);
   int hasParent = (pParentHash && !prollyHashIsEmpty(pParentHash));
-  (void)pCommitHash;
 
   rc = doltliteLoadCatalog(db, &pCommit->catalogHash, &aChild, &nChild, 0);
   if( rc!=SQLITE_OK ) return rc;
@@ -382,7 +380,7 @@ static int diffAdvance(DoltliteDiffCursor *pCur, sqlite3 *db){
     if( rc!=SQLITE_OK ) return rc;
 
     doltliteHashToHex(&cur, zHex);
-    rc = computeCommitBatch(pCur, db, &cur, &commit, zHex);
+    rc = computeCommitBatch(pCur, db, &commit, zHex);
     if( rc!=SQLITE_OK ){
       doltliteCommitClear(&commit);
       return rc;

--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -865,8 +865,7 @@ static int openNextPairIter(DiffTblCursor *pCur, sqlite3 *db){
   }
 }
 
-static int advanceToNextRow(DiffTblCursor *pCur, sqlite3 *db,
-                            const char *zTableName){
+static int advanceToNextRow(DiffTblCursor *pCur, sqlite3 *db){
   int rc;
 
   pCur->hasRow = 0;
@@ -916,7 +915,6 @@ static int advanceToNextRow(DiffTblCursor *pCur, sqlite3 *db,
 
     rc = openNextPairIter(pCur, db);
     if( rc!=SQLITE_OK ) return rc;
-    (void)zTableName;
   }
 }
 
@@ -1088,13 +1086,13 @@ static int dtFilter(sqlite3_vtab_cursor *cur,
     return SQLITE_OK;
   }
 
-  return advanceToNextRow(c, db, pVtab->zTableName);
+  return advanceToNextRow(c, db);
 }
 
 static int dtNext(sqlite3_vtab_cursor *cur){
   DiffTblCursor *c = (DiffTblCursor*)cur;
   DiffTblVtab *pVtab = (DiffTblVtab*)cur->pVtab;
-  return advanceToNextRow(c, pVtab->db, pVtab->zTableName);
+  return advanceToNextRow(c, pVtab->db);
 }
 
 static int dtEof(sqlite3_vtab_cursor *cur){


### PR DESCRIPTION
Item #8 from the dead/duplicate-code cleanup sweep.

Three `static` helpers each carried a parameter that was only ever void-cast and never read. Drops the dead parameters and updates all callers.

| File | Helper | Dropped param | Callers fixed |
|------|--------|---------------|---------------|
| `doltlite_diff_table.c` | `advanceToNextRow` | `const char *zTableName` | `dtFilter`, `dtNext` |
| `doltlite_diff.c` | `computeCommitBatch` | `const ProllyHash *pCommitHash` | `diffAdvance` |
| `doltlite_blame.c` | `blameCompareAgainstRef` | `const ProllyHash *pCurRoot` | 4 call sites in `blameWalk` |

No behavior change. Surviving locals (`curTableRoot`, `cur`) remain in use at other sites, so nothing is orphaned.

## Verification
- Clean compile, zero warnings.
- `make c-tests` → 13/13 gating suites pass.
- Full doltlite regression suite (rebuilt `libdoltlite.a` with these changes) → 309,770 / 309,770 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)