### PR TITLE
Retain pending chunk hash table across autocommit

### DIFF
--- a/src/chunk_staging.c
+++ b/src/chunk_staging.c
@@ -57,6 +57,19 @@ void csPendHTClear(ChunkStore *cs){
   cs->staging.nPendingHTSize = 0;
 }
 
+void csPendHTReset(ChunkStore *cs){
+  int initSize = 1 << CS_PEND_HT_INIT_BITS;
+  if( cs->staging.nPendingHTSize > initSize ){
+    csPendHTClear(cs);
+    return;
+  }
+  if( cs->staging.aPendingHT ){
+    memset(cs->staging.aPendingHT, 0xff,
+           cs->staging.nPendingHTSize * sizeof(int));
+  }
+  cs->staging.nPendingHTBuilt = 0;
+}
+
 void csRecentHTClear(ChunkStore *cs){
   sqlite3_free(cs->staging.aRecentHT);
   sqlite3_free(cs->staging.aRecentHTNext);

--- a/src/chunk_staging.h
+++ b/src/chunk_staging.h
@@ -41,6 +41,7 @@ void chunkStagingResetAfterSweep(ChunkStaging *st);
 
 struct ChunkStore;
 void csPendHTClear(struct ChunkStore *cs);
+void csPendHTReset(struct ChunkStore *cs);
 void csRecentHTClear(struct ChunkStore *cs);
 int csGrowPending(struct ChunkStore *cs);
 int csGrowRecent(struct ChunkStore *cs, int nAdd);

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -1043,7 +1043,7 @@ static int csCommitToMemory(ChunkStore *cs){
     cs->index.aIndexMmapBase = 0;
     cs->index.aIndexMmapSize = 0;
     cs->staging.nPending = 0;
-    csPendHTClear(cs);
+    csPendHTReset(cs);
     cs->staging.nCommittedWriteBuf = cs->staging.nWriteBuf;
   }
   csMarkRefsCommitted(cs);
@@ -1347,7 +1347,7 @@ commit_done:
     cs->staging.nWriteBufAlloc = 0;
   }
   cs->staging.nPending = 0;
-  csPendHTClear(cs);
+  csPendHTReset(cs);
   csMarkRefsCommitted(cs);
 
   return SQLITE_OK;
@@ -1393,7 +1393,7 @@ int chunkStoreCommit(ChunkStore *cs){
 
 void chunkStoreRollback(ChunkStore *cs){
   cs->staging.nPending = 0;
-  csPendHTClear(cs);
+  csPendHTReset(cs);
   if( cs->isMemory ){
 
     cs->staging.nWriteBuf = cs->staging.nCommittedWriteBuf;


### PR DESCRIPTION
## Summary
- add csPendHTReset to clear pending chunk hash tables without freeing the initial allocation
- use the reset path after commit and rollback instead of freeing pending hash-table storage
- still free larger grown hash tables so large transactions do not leave big allocations behind

## Why
Autocommit write statements can produce enough chunks to build the pending dedup hash table. Before this change, every commit/rollback freed that table, so the next similar statement paid the allocation cost again. Resetting the initial table in place removes another small allocator source of latency variance in the same path as PR #1062.

## Testing
- make doltlite
- git diff --check