### PR TITLE
cleanup(chunk): unify CS_READ/WRITE macros into chunk_store.h

### DIFF
--- a/src/chunk_index.c
+++ b/src/chunk_index.c
@@ -10,15 +10,6 @@
 #include <limits.h>
 #include <sys/stat.h>
 
-#define CS_READ_U32(p) ( \
-    (u32)((p)[0]) | ((u32)((p)[1])<<8) \
-  | ((u32)((p)[2])<<16) | ((u32)((p)[3])<<24))
-#define CS_READ_I64(p) ( \
-    (i64)((u64)(p)[0]) | ((i64)((u64)(p)[1])<<8) \
-  | ((i64)((u64)(p)[2])<<16) | ((i64)((u64)(p)[3])<<24) \
-  | ((i64)((u64)(p)[4])<<32) | ((i64)((u64)(p)[5])<<40) \
-  | ((i64)((u64)(p)[6])<<48) | ((i64)((u64)(p)[7])<<56))
-
 void chunkIndexGetEntries(const ChunkIndex *idx, int *pn, const ChunkIndexEntry **par){
   *pn = idx->nIndex;
   *par = idx->aIndex;

--- a/src/chunk_refs.c
+++ b/src/chunk_refs.c
@@ -5,24 +5,6 @@
 #include "chunk_store.h"
 #include <string.h>
 
-#define CS_READ_U32(p) (             \
-  (u32)(((const u8*)(p))[0])       | \
-  (u32)(((const u8*)(p))[1]) << 8  | \
-  (u32)(((const u8*)(p))[2]) << 16 | \
-  (u32)(((const u8*)(p))[3]) << 24   \
-)
-
-#define CS_READ_I64(p) (                  \
-  ((i64)(((const u8*)(p))[0]))       |    \
-  ((i64)(((const u8*)(p))[1]) << 8)  |    \
-  ((i64)(((const u8*)(p))[2]) << 16) |    \
-  ((i64)(((const u8*)(p))[3]) << 24) |    \
-  ((i64)(((const u8*)(p))[4]) << 32) |    \
-  ((i64)(((const u8*)(p))[5]) << 40) |    \
-  ((i64)(((const u8*)(p))[6]) << 48) |    \
-  ((i64)(((const u8*)(p))[7]) << 56)      \
-)
-
 void refsTableGetBranches(const RefsTable *rt, int *pn, const BranchRef **par){
   *pn = rt->nBranches;
   *par = rt->aBranches;

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -93,42 +93,6 @@
 # define CS_GRAPH_LOCK(cs) ((cs)->graphLockFd)
 #endif
 
-#define CS_READ_U32(p) (             \
-  (u32)(((const u8*)(p))[0])       | \
-  (u32)(((const u8*)(p))[1]) << 8  | \
-  (u32)(((const u8*)(p))[2]) << 16 | \
-  (u32)(((const u8*)(p))[3]) << 24   \
-)
-
-#define CS_WRITE_U32(p, v) do {      \
-  ((u8*)(p))[0] = (u8)((v));        \
-  ((u8*)(p))[1] = (u8)((v) >> 8);   \
-  ((u8*)(p))[2] = (u8)((v) >> 16);  \
-  ((u8*)(p))[3] = (u8)((v) >> 24);  \
-} while(0)
-
-#define CS_READ_I64(p) (                  \
-  (i64)((u64)(((const u8*)(p))[0])      ) | \
-  (i64)((u64)(((const u8*)(p))[1]) << 8 ) | \
-  (i64)((u64)(((const u8*)(p))[2]) << 16) | \
-  (i64)((u64)(((const u8*)(p))[3]) << 24) | \
-  (i64)((u64)(((const u8*)(p))[4]) << 32) | \
-  (i64)((u64)(((const u8*)(p))[5]) << 40) | \
-  (i64)((u64)(((const u8*)(p))[6]) << 48) | \
-  (i64)((u64)(((const u8*)(p))[7]) << 56)   \
-)
-
-#define CS_WRITE_I64(p, v) do {            \
-  ((u8*)(p))[0] = (u8)((u64)(v));         \
-  ((u8*)(p))[1] = (u8)((u64)(v) >> 8);    \
-  ((u8*)(p))[2] = (u8)((u64)(v) >> 16);   \
-  ((u8*)(p))[3] = (u8)((u64)(v) >> 24);   \
-  ((u8*)(p))[4] = (u8)((u64)(v) >> 32);   \
-  ((u8*)(p))[5] = (u8)((u64)(v) >> 40);   \
-  ((u8*)(p))[6] = (u8)((u64)(v) >> 48);   \
-  ((u8*)(p))[7] = (u8)((u64)(v) >> 56);   \
-} while(0)
-
 static int csOpenFile(sqlite3_vfs *pVfs, const char *zPath,
                       sqlite3_file **ppFile, int flags);
 static int csRollbackFailedAppend(ChunkStore *cs, i64 origFileSize);

--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -16,6 +16,42 @@
 #define CHUNK_MANIFEST_SIZE 168
 #define CHUNK_INDEX_ENTRY_SIZE 32
 
+#define CS_READ_U32(p) (             \
+  (u32)(((const u8*)(p))[0])       | \
+  (u32)(((const u8*)(p))[1]) << 8  | \
+  (u32)(((const u8*)(p))[2]) << 16 | \
+  (u32)(((const u8*)(p))[3]) << 24   \
+)
+
+#define CS_WRITE_U32(p, v) do {      \
+  ((u8*)(p))[0] = (u8)((v));        \
+  ((u8*)(p))[1] = (u8)((v) >> 8);   \
+  ((u8*)(p))[2] = (u8)((v) >> 16);  \
+  ((u8*)(p))[3] = (u8)((v) >> 24);  \
+} while(0)
+
+#define CS_READ_I64(p) (                  \
+  (i64)((u64)(((const u8*)(p))[0])      ) | \
+  (i64)((u64)(((const u8*)(p))[1]) << 8 ) | \
+  (i64)((u64)(((const u8*)(p))[2]) << 16) | \
+  (i64)((u64)(((const u8*)(p))[3]) << 24) | \
+  (i64)((u64)(((const u8*)(p))[4]) << 32) | \
+  (i64)((u64)(((const u8*)(p))[5]) << 40) | \
+  (i64)((u64)(((const u8*)(p))[6]) << 48) | \
+  (i64)((u64)(((const u8*)(p))[7]) << 56)   \
+)
+
+#define CS_WRITE_I64(p, v) do {            \
+  ((u8*)(p))[0] = (u8)((u64)(v));         \
+  ((u8*)(p))[1] = (u8)((u64)(v) >> 8);    \
+  ((u8*)(p))[2] = (u8)((u64)(v) >> 16);   \
+  ((u8*)(p))[3] = (u8)((u64)(v) >> 24);   \
+  ((u8*)(p))[4] = (u8)((u64)(v) >> 32);   \
+  ((u8*)(p))[5] = (u8)((u64)(v) >> 40);   \
+  ((u8*)(p))[6] = (u8)((u64)(v) >> 48);   \
+  ((u8*)(p))[7] = (u8)((u64)(v) >> 56);   \
+} while(0)
+
 #define WS_FORMAT_VERSION_V2 2
 #define WS_FORMAT_VERSION_V3 3
 #define WS_FORMAT_VERSION_V4 4

--- a/src/chunk_wal.c
+++ b/src/chunk_wal.c
@@ -8,13 +8,6 @@
 #include "../ext/blake3/blake3.h"
 #include <string.h>
 
-#define CS_READ_U32(p) (             \
-  (u32)(((const u8*)(p))[0])       | \
-  (u32)(((const u8*)(p))[1]) << 8  | \
-  (u32)(((const u8*)(p))[2]) << 16 | \
-  (u32)(((const u8*)(p))[3]) << 24   \
-)
-
 #define CS_WAL_TAG_CHUNK  0x01
 #define CS_WAL_TAG_ROOT   0x02
 


### PR DESCRIPTION
Item #9 from the dead/duplicate-code cleanup sweep.

The `CS_READ_U32` / `CS_READ_I64` / `CS_WRITE_U32` / `CS_WRITE_I64` byte-packing macros were duplicated across four files. Consolidates a single canonical definition into `chunk_store.h` (already `#include`d by all four) and drops the local copies.

| File | Before | After |
|------|--------|-------|
| `chunk_store.c` | defined all 4 | uses header |
| `chunk_index.c` | local U32 + I64 | uses header |
| `chunk_refs.c` | local U32 + I64 | uses header |
| `chunk_wal.c` | local U32 | uses header |

### Latent bug fixed
The `chunk_index.c` and `chunk_refs.c` copies of `CS_READ_I64` shifted a **signed** value — `((i64)byte) << 56` — which is undefined behavior when the high byte sets the sign bit. The canonical form (from `chunk_store.c`) shifts in **unsigned** `u64` first, then casts to `i64`. Mainstream compilers produce identical bits today, so there's no observable behavior change — this is a UB-removal + dedup, with no fail-before/pass-after test possible.

Net −34 lines.

## Verification
- Clean compile, zero warnings (no macro-redefinition warnings → confirms single source).
- `make c-tests` → 13/13 gating suites pass.
- Full doltlite regression suite → 309,770 / 309,770 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)