### PR TITLE
cleanup(prolly): unify blob-key comparator into prollyKeyCmp

### DIFF
--- a/src/prolly_diff.c
+++ b/src/prolly_diff.c
@@ -6,16 +6,6 @@
 
 #include <string.h>
 
-static int diffBlobKeyCmp(
-  const u8 *pA, int nA,
-  const u8 *pB, int nB
-){
-  int n = (nA < nB) ? nA : nB;
-  int c = memcmp(pA, pB, n);
-  if( c ) return c;
-  return nA - nB;
-}
-
 static void diffCompareKeys(
   ProllyCursor *pOld,
   ProllyCursor *pNew,
@@ -27,7 +17,7 @@ static void diffCompareKeys(
   (void)flags;
   prollyCursorKey(pOld, &pKeyOld, &nKeyOld);
   prollyCursorKey(pNew, &pKeyNew, &nKeyNew);
-  *pCmp = diffBlobKeyCmp(pKeyOld, nKeyOld, pKeyNew, nKeyNew);
+  *pCmp = prollyKeyCmp(pKeyOld, nKeyOld, pKeyNew, nKeyNew);
 }
 
 static void diffFillKey(
@@ -347,7 +337,7 @@ static int diffNodeKeyCmp(
   (void)flags;
   prollyNodeKey(pA, iA, &pKA, &nKA);
   prollyNodeKey(pB, iB, &pKB, &nKB);
-  return diffBlobKeyCmp(pKA, nKA, pKB, nKB);
+  return prollyKeyCmp(pKA, nKA, pKB, nKB);
 }
 
 static void diffEmitKey(ProllyDiffChange *ch, const ProllyNode *pN, int i, u8 flags){
@@ -371,7 +361,7 @@ static int diffLeaves(
       const u8 *pKA; int nKA; const u8 *pKB; int nKB;
       prollyNodeKey(pOld, i, &pKA, &nKA);
       prollyNodeKey(pNew, j, &pKB, &nKB);
-      cmp = diffBlobKeyCmp(pKA, nKA, pKB, nKB);
+      cmp = prollyKeyCmp(pKA, nKA, pKB, nKB);
     }
 
     if( cmp < 0 ){

--- a/src/prolly_mutate.c
+++ b/src/prolly_mutate.c
@@ -74,18 +74,6 @@ static int parentChildSubtreeCount(
   }
 }
 
-static int compareKeys(
-  const u8 *pKey1, int nKey1,
-  const u8 *pKey2, int nKey2
-){
-  int n = nKey1 < nKey2 ? nKey1 : nKey2;
-  int c = memcmp(pKey1, pKey2, n);
-  if( c != 0 ) return c;
-  if( nKey1 < nKey2 ) return -1;
-  if( nKey1 > nKey2 ) return 1;
-  return 0;
-}
-
 static int buildFromEdits(
   ProllyMutator *pMut
 ){
@@ -128,7 +116,7 @@ static int subtreeHasEdits(
   int cmp;
   if( !prollyMutMapIterValid(pIter) ) return 0;
   pEd = prollyMutMapIterEntry(pIter);
-  cmp = compareKeys(pEd->pKey, pEd->nKey, pBoundKey, nBoundKey);
+  cmp = prollyKeyCmp(pEd->pKey, pEd->nKey, pBoundKey, nBoundKey);
   return (cmp <= 0);
 }
 
@@ -181,7 +169,7 @@ static int mergeLeaf(
     }
 
     {
-      int pastLeaf = compareKeys(pEd->pKey, pEd->nKey, pLastKey, nLastKey);
+      int pastLeaf = prollyKeyCmp(pEd->pKey, pEd->nKey, pLastKey, nLastKey);
       if( pastLeaf > 0 ){
 
         const u8 *pVal; int nVal;
@@ -193,7 +181,7 @@ static int mergeLeaf(
       }
     }
 
-    cmp = compareKeys(pCurKey, nCurKey, pEd->pKey, pEd->nKey);
+    cmp = prollyKeyCmp(pCurKey, nCurKey, pEd->pKey, pEd->nKey);
     if( cmp < 0 ){
 
       const u8 *pVal; int nVal;
@@ -720,7 +708,7 @@ static int tryInsertOrReplaceSingleNoRechunk(ProllyMutator *pMut){
       const u8 *pCurKey;
       int nCurKey;
       prollyCursorKey(&cur, &pCurKey, &nCurKey);
-      if( compareKeys(pEdit->pKey, pEdit->nKey, pCurKey, nCurKey)>=0 ){
+      if( prollyKeyCmp(pEdit->pKey, pEdit->nKey, pCurKey, nCurKey)>=0 ){
         prollyCursorClose(&cur);
         return SQLITE_NOTFOUND;
       }
@@ -895,7 +883,7 @@ static int tryAppendSingleNoSplit(ProllyMutator *pMut){
     const u8 *pLastKey;
     int nLastKey;
     prollyCursorKey(&cur, &pLastKey, &nLastKey);
-    if( compareKeys(pNewKey, nNewKey, pLastKey, nLastKey)<=0 ){
+    if( prollyKeyCmp(pNewKey, nNewKey, pLastKey, nLastKey)<=0 ){
       prollyCursorClose(&cur);
       return SQLITE_NOTFOUND;
     }
@@ -1166,7 +1154,7 @@ static int replaceBatchLeafNoRechunk(
     prollyNodeValue(pLeaf, i, &pVal, &nVal);
     if( prollyMutMapIterValid(pIter) ){
       pEd = prollyMutMapIterEntry(pIter);
-      cmp = compareKeys(pEd->pKey, pEd->nKey, pCurKey, nCurKey);
+      cmp = prollyKeyCmp(pEd->pKey, pEd->nKey, pCurKey, nCurKey);
     }
     if( cmp<0 ){
       prollyNodeBuilderFree(&b);
@@ -1214,7 +1202,7 @@ static int validateReplaceBatchLeaf(
     prollyNodeKey(pLeaf, i, &pCurKey, &nCurKey);
     if( prollyMutMapIterValid(pIter) ){
       pEd = prollyMutMapIterEntry(pIter);
-      cmp = compareKeys(pEd->pKey, pEd->nKey, pCurKey, nCurKey);
+      cmp = prollyKeyCmp(pEd->pKey, pEd->nKey, pCurKey, nCurKey);
     }
     if( cmp<0 ){
       return SQLITE_NOTFOUND;
@@ -1414,7 +1402,7 @@ static int tryReplaceBatchNoRechunk(ProllyMutator *pMut){
     int nMaxKey;
     prollyNodeKey(pRootNode, (int)pRootNode->nItems - 1,
                   &pMaxKey, &nMaxKey);
-    if( compareKeys(pFirst->pKey, pFirst->nKey, pMaxKey, nMaxKey)>0 ){
+    if( prollyKeyCmp(pFirst->pKey, pFirst->nKey, pMaxKey, nMaxKey)>0 ){
       rc = SQLITE_NOTFOUND;
       goto replace_batch_cleanup;
     }

--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -45,17 +45,6 @@ static void prepKey(ProllyMutMap *mm,
   *pnKey = 8;
 }
 
-static int compareEntries(
-  const u8 *pKeyA, int nKeyA,
-  const u8 *pKeyB, int nKeyB
-){
-  int n = nKeyA < nKeyB ? nKeyA : nKeyB;
-  int c = memcmp(pKeyA, pKeyB, n);
-  if( c != 0 ) return c;
-  if( nKeyA < nKeyB ) return -1;
-  if( nKeyA > nKeyB ) return 1;
-  return 0;
-}
 
 static u64 keyPrefix64(const u8 *pKey, int nKey){
   u64 r = 0;
@@ -87,7 +76,7 @@ static int compareEntryToKey(
     return e->keyPrefix < keyPrefix ? -1 : 1;
   }
   if( mm->isIntKey ) return 0;
-  return compareEntries(e->pKey, e->nKey, pKey, nKey);
+  return prollyKeyCmp(e->pKey, e->nKey, pKey, nKey);
 }
 
 static u32 hashKey(const u8 *pKey, int nKey){
@@ -114,7 +103,7 @@ static int orderPairCmp(ProllyMutMap *mm, const OrderPair *a, const OrderPair *b
   if( mm->isIntKey ) return 0;
   ea = &mm->aEntries[a->phys];
   eb = &mm->aEntries[b->phys];
-  return compareEntries(ea->pKey, ea->nKey, eb->pKey, eb->nKey);
+  return prollyKeyCmp(ea->pKey, ea->nKey, eb->pKey, eb->nKey);
 }
 
 static void mutmapInsertionSort(ProllyMutMap *mm, OrderPair *a, int lo, int hi){
@@ -463,7 +452,7 @@ static int rankEntryWithoutOrder(ProllyMutMap *mm, int phys){
   int i;
   for(i=0; i<mm->nEntries; i++){
     if( i==phys ) continue;
-    if( compareEntries(mm->aEntries[i].pKey, mm->aEntries[i].nKey,
+    if( prollyKeyCmp(mm->aEntries[i].pKey, mm->aEntries[i].nKey,
                        target->pKey, target->nKey) < 0 ){
       rank++;
     }
@@ -539,7 +528,7 @@ static void updateAppendSorted(ProllyMutMap *mm, int phys){
   if( mm->keepSorted || !mm->appendSorted || phys<=0 ) return;
   pPrev = &mm->aEntries[phys - 1];
   pNew = &mm->aEntries[phys];
-  if( compareEntries(pPrev->pKey, pPrev->nKey,
+  if( prollyKeyCmp(pPrev->pKey, pPrev->nKey,
                      pNew->pKey, pNew->nKey) > 0 ){
     mm->appendSorted = 0;
   }

--- a/src/prolly_node.h
+++ b/src/prolly_node.h
@@ -16,6 +16,13 @@
 #define PROLLY_NODE_ENTRY_BYTES(level,nKey,nVal) \
   ((nKey) + (nVal) + 8 + ((level)>0 ? 8 : 0))
 
+static inline int prollyKeyCmp(const u8 *pA, int nA, const u8 *pB, int nB){
+  int n = nA < nB ? nA : nB;
+  int c = memcmp(pA, pB, n);
+  if( c ) return c;
+  return nA - nB;
+}
+
 typedef struct ProllyNode ProllyNode;
 /* Parsed view over immutable node bytes. Offsets in the node are little-endian
 ** on disk; accessors decode them instead of relying on host alignment.

--- a/src/prolly_three_way_diff.c
+++ b/src/prolly_three_way_diff.c
@@ -14,13 +14,8 @@ static int diffChangeKeyCmp(
   const ProllyDiffChange *pB,
   u8 flags
 ){
-  int n;
-  int c;
   (void)flags;
-  n = (pA->nKey < pB->nKey) ? pA->nKey : pB->nKey;
-  c = memcmp(pA->pKey, pB->pKey, n);
-  if( c ) return c;
-  return pA->nKey - pB->nKey;
+  return prollyKeyCmp(pA->pKey, pA->nKey, pB->pKey, pB->nKey);
 }
 
 static void fillKeyFromChange(ThreeWayChange *pOut,

--- a/src/prolly_three_way_merge.c
+++ b/src/prolly_three_way_merge.c
@@ -13,15 +13,6 @@
 ** fall back to the full row-wise merge path without treating it as an error. */
 #define FM_FALLBACK  SQLITE_DONE
 
-static int fmKeyCmp(const u8 *pA, int nA, const u8 *pB, int nB){
-  int n = nA < nB ? nA : nB;
-  int c = memcmp(pA, pB, n);
-  if( c ) return c;
-  if( nA < nB ) return -1;
-  if( nA > nB ) return 1;
-  return 0;
-}
-
 static int fmChunkerLevelsBelowEmpty(const ProllyChunker *pCh, int level){
   int i;
   for( i = 0; i < level && i < pCh->nLevels; i++ ){
@@ -444,8 +435,8 @@ static int fmWalkInterior(
     prollyNodeKey(pOursN, i, &pOK, &nOK);
     prollyNodeKey(pTheirsN, i, &pTK, &nTK);
 
-    if( fmKeyCmp(pAK, nAK, pOK, nOK) != 0
-     || fmKeyCmp(pAK, nAK, pTK, nTK) != 0 ){
+    if( prollyKeyCmp(pAK, nAK, pOK, nOK) != 0
+     || prollyKeyCmp(pAK, nAK, pTK, nTK) != 0 ){
       const u8 *pSeek = 0;
       int nSeek = 0;
       i64 iSeek = 0;


### PR DESCRIPTION
Item #10 from the dead/duplicate-code cleanup sweep.

Five copies of the same lexicographic key comparator (memcmp over the shorter length, then break ties by length) lived across the prolly layer:

| File | Old name | Now |
|------|----------|-----|
| `prolly_diff.c` | `diffBlobKeyCmp` | calls `prollyKeyCmp` |
| `prolly_mutate.c` | `compareKeys` | calls `prollyKeyCmp` |
| `prolly_three_way_merge.c` | `fmKeyCmp` | calls `prollyKeyCmp` |
| `prolly_mutmap.c` | `compareEntries` | calls `prollyKeyCmp` |
| `prolly_three_way_diff.c` | `diffChangeKeyCmp` (struct-based) | delegates body to `prollyKeyCmp` |

Adds one `static inline int prollyKeyCmp(const u8*, int, const u8*, int)` to `prolly_node.h`, which is transitively included by all five translation units.

The four raw copies split between `-1/0/1` and `(nA - nB)` return conventions; every call site uses only the **sign** of the result, so unifying onto a single comparator is behavior-preserving. Net −40 lines.

## Verification
- Clean compile, zero warnings.
- `make c-tests` → 13/13 gating suites pass.
- Full doltlite regression suite → 309,770 / 309,770 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)