### PR TITLE
cleanup(prolly): unify subtree row-count into prollySubtreeCount

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -3581,53 +3581,6 @@ static int pushSavepoint(Btree *pBtree, int bStatement){
   return SQLITE_OK;
 }
 
-static int countSubtreeRows(
-  ChunkStore *pStore,
-  ProllyCache *pCache,
-  const ProllyHash *pHash,
-  i64 *pCount
-){
-  ProllyCacheEntry *pEntry = 0;
-  u8 *pData = 0;
-  int nData = 0;
-  int rc = SQLITE_OK;
-  int i;
-  i64 sum = 0;
-
-  pEntry = prollyCacheGet(pCache, pHash);
-  if( !pEntry ){
-    rc = chunkStoreGet(pStore, pHash, &pData, &nData);
-    if( rc!=SQLITE_OK ) return rc;
-    pEntry = prollyCachePut(pCache, pHash, pData, nData, &rc);
-    sqlite3_free(pData);
-    if( !pEntry ) return rc;
-  }
-
-  if( pEntry->node.level==0 ){
-    sum = (i64)pEntry->node.nItems;
-  }else if( prollyNodeHasSubtreeCounts(&pEntry->node) ){
-    for(i=0; i<(int)pEntry->node.nItems; i++){
-      sum += (i64)prollyNodeChildSubtreeCount(&pEntry->node, i);
-    }
-  }else{
-    for(i=0; i<(int)pEntry->node.nItems; i++){
-      ProllyHash childHash;
-      i64 childCount = 0;
-      prollyNodeChildHash(&pEntry->node, i, &childHash);
-      rc = countSubtreeRows(pStore, pCache, &childHash, &childCount);
-      if( rc!=SQLITE_OK ){
-        prollyCacheRelease(pCache, pEntry);
-        return rc;
-      }
-      sum += childCount;
-    }
-  }
-
-  prollyCacheRelease(pCache, pEntry);
-  *pCount = sum;
-  return SQLITE_OK;
-}
-
 static int countTreeEntries(Btree *pBtree, Pgno iTable, i64 *pCount){
   int rc;
   struct TableEntry *pTE;
@@ -3639,8 +3592,11 @@ static int countTreeEntries(Btree *pBtree, Pgno iTable, i64 *pCount){
     return SQLITE_OK;
   }
 
-  *pCount = 0;
-  rc = countSubtreeRows(&pBt->store, &pBt->cache, &pTE->root, pCount);
+  {
+    u64 cnt = 0;
+    rc = prollySubtreeCount(&pBt->store, &pBt->cache, &pTE->root, &cnt);
+    *pCount = (i64)cnt;
+  }
   return rc;
 }
 
@@ -3667,11 +3623,11 @@ static int countCursorLeftSiblings(
       n += (i64)prollyNodeChildSubtreeCount(&pEntry->node, i);
     }else{
       ProllyHash childHash;
-      i64 nChild = 0;
+      u64 nChild = 0;
       prollyNodeChildHash(&pEntry->node, i, &childHash);
-      rc = countSubtreeRows(pStore, pCache, &childHash, &nChild);
+      rc = prollySubtreeCount(pStore, pCache, &childHash, &nChild);
       if( rc!=SQLITE_OK ) return rc;
-      n += nChild;
+      n += (i64)nChild;
     }
   }
 

--- a/src/prolly_cursor.c
+++ b/src/prolly_cursor.c
@@ -5,6 +5,49 @@
 #include <string.h>
 #include <assert.h>
 
+int prollySubtreeCount(ChunkStore *pStore, ProllyCache *pCache,
+                       const ProllyHash *pHash, u64 *pCount){
+  ProllyCacheEntry *pEntry = 0;
+  u8 *pData = 0;
+  int nData = 0;
+  int rc = SQLITE_OK;
+  int i;
+  u64 sum = 0;
+
+  pEntry = prollyCacheGet(pCache, pHash);
+  if( !pEntry ){
+    rc = chunkStoreGet(pStore, pHash, &pData, &nData);
+    if( rc!=SQLITE_OK ) return rc;
+    pEntry = prollyCachePut(pCache, pHash, pData, nData, &rc);
+    sqlite3_free(pData);
+    if( !pEntry ) return rc;
+  }
+
+  if( pEntry->node.level==0 ){
+    sum = (u64)pEntry->node.nItems;
+  }else if( prollyNodeHasSubtreeCounts(&pEntry->node) ){
+    for( i=0; i<(int)pEntry->node.nItems; i++ ){
+      sum += prollyNodeChildSubtreeCount(&pEntry->node, i);
+    }
+  }else{
+    for( i=0; i<(int)pEntry->node.nItems; i++ ){
+      ProllyHash childHash;
+      u64 childCount = 0;
+      prollyNodeChildHash(&pEntry->node, i, &childHash);
+      rc = prollySubtreeCount(pStore, pCache, &childHash, &childCount);
+      if( rc!=SQLITE_OK ){
+        prollyCacheRelease(pCache, pEntry);
+        return rc;
+      }
+      sum += childCount;
+    }
+  }
+
+  prollyCacheRelease(pCache, pEntry);
+  *pCount = sum;
+  return SQLITE_OK;
+}
+
 static int loadNode(ProllyCursor *cur, const ProllyHash *hash,
                     ProllyCacheEntry **ppEntry){
   ProllyCacheEntry *pEntry;

--- a/src/prolly_cursor.h
+++ b/src/prolly_cursor.h
@@ -62,4 +62,7 @@ void prollyCursorReleaseAll(ProllyCursor *cur);
 
 void prollyCursorClose(ProllyCursor *cur);
 
+int prollySubtreeCount(ChunkStore *pStore, ProllyCache *pCache,
+                       const ProllyHash *pHash, u64 *pCount);
+
 #endif

--- a/src/prolly_mutate.c
+++ b/src/prolly_mutate.c
@@ -10,53 +10,6 @@
 
 #define PROLLY_EST_ENTRIES_PER_LEAF 50
 
-static int subtreeCountByHash(
-  ChunkStore *pStore,
-  ProllyCache *pCache,
-  const ProllyHash *pHash,
-  u64 *pCount
-){
-  ProllyCacheEntry *pEntry = 0;
-  u8 *pData = 0;
-  int nData = 0;
-  int rc = SQLITE_OK;
-  int i;
-  u64 sum = 0;
-
-  pEntry = prollyCacheGet(pCache, pHash);
-  if( !pEntry ){
-    rc = chunkStoreGet(pStore, pHash, &pData, &nData);
-    if( rc!=SQLITE_OK ) return rc;
-    pEntry = prollyCachePut(pCache, pHash, pData, nData, &rc);
-    sqlite3_free(pData);
-    if( !pEntry ) return rc;
-  }
-
-  if( pEntry->node.level==0 ){
-    sum = (u64)pEntry->node.nItems;
-  }else if( prollyNodeHasSubtreeCounts(&pEntry->node) ){
-    for( i=0; i<(int)pEntry->node.nItems; i++ ){
-      sum += prollyNodeChildSubtreeCount(&pEntry->node, i);
-    }
-  }else{
-    for( i=0; i<(int)pEntry->node.nItems; i++ ){
-      ProllyHash childHash;
-      u64 childCount = 0;
-      prollyNodeChildHash(&pEntry->node, i, &childHash);
-      rc = subtreeCountByHash(pStore, pCache, &childHash, &childCount);
-      if( rc!=SQLITE_OK ){
-        prollyCacheRelease(pCache, pEntry);
-        return rc;
-      }
-      sum += childCount;
-    }
-  }
-
-  prollyCacheRelease(pCache, pEntry);
-  *pCount = sum;
-  return SQLITE_OK;
-}
-
 static int parentChildSubtreeCount(
   ChunkStore *pStore,
   ProllyCache *pCache,
@@ -70,7 +23,7 @@ static int parentChildSubtreeCount(
   }else{
     ProllyHash childHash;
     prollyNodeChildHash(pParent, i, &childHash);
-    return subtreeCountByHash(pStore, pCache, &childHash, pCount);
+    return prollySubtreeCount(pStore, pCache, &childHash, pCount);
   }
 }
 

--- a/src/prolly_three_way_merge.c
+++ b/src/prolly_three_way_merge.c
@@ -45,52 +45,6 @@ static int fmEmitChild(
   const ProllyHash *pTheirs
 );
 
-static int fmSubtreeCount(
-  FmCtx *fm,
-  const ProllyHash *pHash,
-  u64 *pCount
-){
-  ProllyCacheEntry *pEntry = 0;
-  u8 *pData = 0;
-  int nData = 0;
-  int rc = SQLITE_OK;
-  int i;
-  u64 sum = 0;
-
-  pEntry = prollyCacheGet(fm->pCache, pHash);
-  if( !pEntry ){
-    rc = chunkStoreGet(fm->pStore, pHash, &pData, &nData);
-    if( rc!=SQLITE_OK ) return rc;
-    pEntry = prollyCachePut(fm->pCache, pHash, pData, nData, &rc);
-    sqlite3_free(pData);
-    if( !pEntry ) return rc;
-  }
-
-  if( pEntry->node.level==0 ){
-    sum = (u64)pEntry->node.nItems;
-  }else if( prollyNodeHasSubtreeCounts(&pEntry->node) ){
-    for( i=0; i<(int)pEntry->node.nItems; i++ ){
-      sum += prollyNodeChildSubtreeCount(&pEntry->node, i);
-    }
-  }else{
-    for( i=0; i<(int)pEntry->node.nItems; i++ ){
-      ProllyHash childHash;
-      u64 childCount = 0;
-      prollyNodeChildHash(&pEntry->node, i, &childHash);
-      rc = fmSubtreeCount(fm, &childHash, &childCount);
-      if( rc!=SQLITE_OK ){
-        prollyCacheRelease(fm->pCache, pEntry);
-        return rc;
-      }
-      sum += childCount;
-    }
-  }
-
-  prollyCacheRelease(fm->pCache, pEntry);
-  *pCount = sum;
-  return SQLITE_OK;
-}
-
 static int fmEmitSubtreeRows(
   FmCtx *fm, ProllyChunker *pCh,
   const ProllyHash *pSubtreeRoot
@@ -493,7 +447,7 @@ static int fmEmitChild(
     ** this parent level; otherwise emit rows so the rebuilt tree stays sorted. */
     if( fmChunkerLevelsBelowEmpty(pCh, parentLevel) ){
       u64 spliceCount = 0;
-      rc = fmSubtreeCount(fm, pSplice, &spliceCount);
+      rc = prollySubtreeCount(fm->pStore, fm->pCache, pSplice, &spliceCount);
       if( rc != SQLITE_OK ) return rc;
       return prollyChunkerAddAtLevelWithCount(pCh, parentLevel,
                                               pBoundKey, nBoundKey,


### PR DESCRIPTION
Item #11 from the dead/duplicate-code cleanup sweep.

Three structurally identical recursive "count rows under this subtree hash" helpers existed:

| File | Old name | Accumulator | Store/cache passed as |
|------|----------|-------------|------------------------|
| `prolly_mutate.c` | `subtreeCountByHash` | `u64` | `(pStore, pCache)` |
| `prolly_three_way_merge.c` | `fmSubtreeCount` | `u64` | `FmCtx*` |
| `prolly_btree.c` | `countSubtreeRows` | `i64` | `(pStore, pCache)` |

Adds one `prollySubtreeCount(ChunkStore*, ProllyCache*, const ProllyHash*, u64*)` in `prolly_cursor.c`, declared in `prolly_cursor.h` (which already pulls in `chunk_store.h`, `prolly_cache.h`, `prolly_node.h` and is reached by all three callers). The three-way-merge caller passes `fm->pStore` / `fm->pCache`; the btree callers, which track counts as `i64`, bridge through a `u64` temporary and cast the result.

Behavior-preserving. Net −91 lines.

## Verification
- Clean compile, zero warnings.
- `make c-tests` → 13/13 gating suites pass.
- Full doltlite regression suite → 309,770 / 309,770 pass.

> Note: independent of #1066 (item #10), which is still open; this branch is cut directly from `master`, not stacked on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)