### PR TITLE
cleanup(prolly): unify serial-type int helpers in prolly_record.h

### DIFF
--- a/src/doltlite_record.c
+++ b/src/doltlite_record.c
@@ -6,17 +6,6 @@
 #include <string.h>
 #include <stdio.h>
 
-static i64 recReadInt(const u8 *p, int nBytes){
-  i64 v;
-  int i;
-
-  v = (p[0] & 0x80) ? -1 : 0;
-  for(i=0; i<nBytes; i++){
-    v = (v << 8) | p[i];
-  }
-  return v;
-}
-
 typedef struct RecBuf RecBuf;
 struct RecBuf {
   char *z;
@@ -93,11 +82,10 @@ char *doltliteDecodeRecord(const u8 *pData, int nData){
     }else if( st==9 ){
       rc = recBufAppend(&buf, "1", 1);
     }else if( st>=1 && st<=6 ){
-      static const int sizes[] = {0,1,2,3,4,6,8};
-      int nBytes = sizes[st];
+      int nBytes = dlSerialTypeLen((u64)st);
       char tmp[32];
       if( pBody + nBytes > pEnd ){ rc = SQLITE_CORRUPT; break; }
-      sqlite3_snprintf(sizeof(tmp), tmp, "%lld", recReadInt(pBody, nBytes));
+      sqlite3_snprintf(sizeof(tmp), tmp, "%lld", dlReadIntBytes(pBody, nBytes));
       rc = recBufAppend(&buf, tmp, -1);
       pBody += nBytes;
     }else if( st==7 ){
@@ -304,14 +292,9 @@ void doltliteResultField(
   if( st==8 ){ sqlite3_result_int(ctx, 0); return; }
   if( st==9 ){ sqlite3_result_int(ctx, 1); return; }
   if( st>=1 && st<=6 ){
-    static const int sizes[] = {0,1,2,3,4,6,8};
-    int nB = sizes[st];
+    int nB = dlSerialTypeLen((u64)st);
     if( off+nB <= nData ){
-      const u8 *q = pData + off;
-      i64 v = (q[0] & 0x80) ? -1 : 0;
-      int i;
-      for(i=0; i<nB; i++) v = (v<<8) | q[i];
-      sqlite3_result_int64(ctx, v);
+      sqlite3_result_int64(ctx, dlReadIntBytes(pData + off, nB));
     }else{
       sqlite3_result_null(ctx);
     }
@@ -390,14 +373,9 @@ int doltliteBindField(
   if( st==8 ) return sqlite3_bind_int(pStmt, iParam, 0);
   if( st==9 ) return sqlite3_bind_int(pStmt, iParam, 1);
   if( st>=1 && st<=6 ){
-    static const int sizes[] = {0,1,2,3,4,6,8};
-    int nB = sizes[st];
+    int nB = dlSerialTypeLen((u64)st);
     if( off+nB <= nData ){
-      const u8 *q = pData + off;
-      i64 v = (q[0] & 0x80) ? -1 : 0;
-      int i;
-      for(i=0; i<nB; i++) v = (v<<8) | q[i];
-      return sqlite3_bind_int64(pStmt, iParam, v);
+      return sqlite3_bind_int64(pStmt, iParam, dlReadIntBytes(pData + off, nB));
     }
     return sqlite3_bind_null(pStmt, iParam);
   }

--- a/src/prolly_diff.c
+++ b/src/prolly_diff.c
@@ -116,42 +116,6 @@ static int diffEmitModify(
   return xCallback(pCtx, &change);
 }
 
-static int diffSerialIsInt(int st){
-  return st>=1 && st<=9 && st!=7;
-}
-
-static i64 diffDecodeInt(int st, const u8 *p, int n){
-  static const int sizes[] = {0,1,2,3,4,6,8};
-  i64 v;
-  int i;
-  if( st==0 ) return 0;
-  if( st==8 ) return 0;
-  if( st==9 ) return 1;
-  if( st>=1 && st<=6 ){
-    int nB = sizes[st];
-    if( nB > n ) return 0;
-    v = (p[0] & 0x80) ? -1 : 0;
-    for(i=0; i<nB; i++) v = (v<<8) | p[i];
-    return v;
-  }
-  return 0;
-}
-
-static int diffSerialTypeSize(u64 st){
-  if( st==0 ) return 0;
-  if( st==1 ) return 1;
-  if( st==2 ) return 2;
-  if( st==3 ) return 3;
-  if( st==4 ) return 4;
-  if( st==5 ) return 6;
-  if( st==6 ) return 8;
-  if( st==7 ) return 8;
-  if( st==8 || st==9 ) return 0;
-  if( st>=12 && (st&1)==0 ) return (int)(st-12)/2;
-  if( st>=13 && (st&1)==1 ) return (int)(st-13)/2;
-  return 0;
-}
-
 static int diffRecordsEqualFieldwise(
   const u8 *pA, int nA,
   const u8 *pB, int nB,
@@ -179,18 +143,18 @@ static int diffRecordsEqualFieldwise(
     int szB;
 
     if( stA != stB ){
-      if( diffSerialIsInt(stA) && diffSerialIsInt(stB) ){
-        i64 vA = diffDecodeInt(stA, pA + aInfo.aOffset[i],
+      if( dlSerialIsInt(stA) && dlSerialIsInt(stB) ){
+        i64 vA = dlDecodeSerialInt(stA, pA + aInfo.aOffset[i],
                                 nA - aInfo.aOffset[i]);
-        i64 vB = diffDecodeInt(stB, pB + bInfo.aOffset[i],
+        i64 vB = dlDecodeSerialInt(stB, pB + bInfo.aOffset[i],
                                 nB - bInfo.aOffset[i]);
         if( vA != vB ) return SQLITE_OK;
         continue;
       }
       return SQLITE_OK;
     }
-    szA = diffSerialTypeSize((u64)stA);
-    szB = diffSerialTypeSize((u64)stB);
+    szA = dlSerialTypeLen((u64)stA);
+    szB = dlSerialTypeLen((u64)stB);
     if( szA != szB ) return SQLITE_OK;
     if( szA>0 && memcmp(pA + aInfo.aOffset[i], pB + bInfo.aOffset[i], szA)!=0 ){
       return SQLITE_OK;

--- a/src/prolly_record.h
+++ b/src/prolly_record.h
@@ -38,6 +38,27 @@ static inline int dlSerialTypeLen(u64 st){
   return 0;
 }
 
+static inline int dlSerialIsInt(int st){
+  return st>=1 && st<=9 && st!=7;
+}
+
+static inline i64 dlReadIntBytes(const u8 *p, int nBytes){
+  i64 v = (nBytes>0 && (p[0] & 0x80)) ? -1 : 0;
+  int i;
+  for(i=0; i<nBytes; i++) v = (v<<8) | p[i];
+  return v;
+}
+
+static inline i64 dlDecodeSerialInt(int st, const u8 *p, int n){
+  if( st==9 ) return 1;
+  if( st>=1 && st<=6 ){
+    int nB = dlSerialTypeLen((u64)st);
+    if( nB > n ) return 0;
+    return dlReadIntBytes(p, nB);
+  }
+  return 0;
+}
+
 #define DOLTLITE_MAX_RECORD_FIELDS SQLITE_MAX_COLUMN
 
 typedef struct DoltliteRecordInfo DoltliteRecordInfo;


### PR DESCRIPTION
Item #12 from the dead/duplicate-code cleanup sweep.

`prolly_record.h` already held the shared serial-type primitives (`dlSerialTypeLen`, `dlReadVarint`). This adds three siblings next to them and routes the scattered copies through them:

- `dlSerialIsInt(st)` — is this an integer serial type
- `dlReadIntBytes(p, nBytes)` — signed big-endian N-byte read
- `dlDecodeSerialInt(st, p, n)` — decode the integer value of a serial type

### Removed duplicates
| File | Dropped |
|------|---------|
| `prolly_diff.c` | `diffSerialIsInt`, `diffDecodeInt`, `diffSerialTypeSize` |
| `doltlite_record.c` | local `recReadInt` + three inline `{0,1,2,3,4,6,8}` decode loops (`doltliteDecodeRecord`, `doltliteResultField`, `doltliteBindField`) |

`diffSerialTypeSize` was a line-for-line equivalent of `dlSerialTypeLen` — the explicit even/odd split for text/blob types `(st-12)/2` vs `(st-13)/2` collapses to the same value under integer division, verified for representative serial types. Net −37 lines.

## Verification
- Clean compile, zero warnings.
- `make c-tests` → 13/13 gating suites pass.
- Full doltlite regression suite → 309,770 / 309,770 pass (this is the per-row decode/result/bind path, exercised throughout).

> Cut directly from `master` (not stacked on #1066/#1067, which are still open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)