### PR TITLE
Avoid extra allocation on read cache misses

### DIFF
--- a/src/prolly_cache.c
+++ b/src/prolly_cache.c
@@ -176,6 +176,63 @@ ProllyCacheEntry *prollyCachePut(
   return pEntry;
 }
 
+ProllyCacheEntry *prollyCachePutOwned(
+  ProllyCache *cache,
+  const ProllyHash *hash,
+  u8 *pData,
+  int nData,
+  int *pRc
+){
+  int iBucket;
+  ProllyCacheEntry *pEntry;
+  int rc;
+
+  if( pRc ) *pRc = SQLITE_OK;
+
+  pEntry = prollyCacheGet(cache, hash);
+  if( pEntry ){
+    sqlite3_free(pData);
+    return pEntry;
+  }
+
+  while( cache->nUsed>=cache->nCapacity ){
+    if( !cacheEvictOne(cache) ){
+
+      break;
+    }
+  }
+
+  pEntry = (ProllyCacheEntry *)sqlite3_malloc(sizeof(ProllyCacheEntry));
+  if( pEntry==0 ){
+    sqlite3_free(pData);
+    if( pRc ) *pRc = SQLITE_NOMEM;
+    return 0;
+  }
+  memset(pEntry, 0, sizeof(*pEntry));
+
+  memcpy(pEntry->hash.data, hash->data, PROLLY_HASH_SIZE);
+  pEntry->pData = pData;
+  pEntry->nData = nData;
+  pEntry->nRef = 1;
+
+  rc = prollyNodeParse(&pEntry->node, pData, nData);
+  if( rc!=SQLITE_OK ){
+    if( pRc ) *pRc = rc;
+    sqlite3_free(pData);
+    sqlite3_free(pEntry);
+    return 0;
+  }
+
+  iBucket = cacheHashBucket(cache, hash);
+  pEntry->pHashNext = cache->aBucket[iBucket];
+  cache->aBucket[iBucket] = pEntry;
+
+  lruInsertHead(cache, pEntry);
+
+  cache->nUsed++;
+  return pEntry;
+}
+
 void prollyCacheRelease(ProllyCache *cache, ProllyCacheEntry *entry){
   (void)cache;
   assert( entry->nRef>0 );

--- a/src/prolly_cache.h
+++ b/src/prolly_cache.h
@@ -38,6 +38,11 @@ ProllyCacheEntry *prollyCachePut(ProllyCache *cache,
                                   const u8 *pData, int nData,
                                   int *pRc);
 
+ProllyCacheEntry *prollyCachePutOwned(ProllyCache *cache,
+                                      const ProllyHash *hash,
+                                      u8 *pData, int nData,
+                                      int *pRc);
+
 void prollyCacheRelease(ProllyCache *cache, ProllyCacheEntry *entry);
 
 void prollyCacheFree(ProllyCache *cache);

--- a/src/prolly_cursor.c
+++ b/src/prolly_cursor.c
@@ -18,8 +18,7 @@ int prollySubtreeCount(ChunkStore *pStore, ProllyCache *pCache,
   if( !pEntry ){
     rc = chunkStoreGet(pStore, pHash, &pData, &nData);
     if( rc!=SQLITE_OK ) return rc;
-    pEntry = prollyCachePut(pCache, pHash, pData, nData, &rc);
-    sqlite3_free(pData);
+    pEntry = prollyCachePutOwned(pCache, pHash, pData, nData, &rc);
     if( !pEntry ) return rc;
   }
 
@@ -68,8 +67,7 @@ static int loadNode(ProllyCursor *cur, const ProllyHash *hash,
     return rc;
   }
 
-  pEntry = prollyCachePut(cur->pCache, hash, pData, nData, &rc);
-  sqlite3_free(pData);
+  pEntry = prollyCachePutOwned(cur->pCache, hash, pData, nData, &rc);
   if( pEntry==0 ){
     return rc;
   }

--- a/src/prolly_mutate.c
+++ b/src/prolly_mutate.c
@@ -231,8 +231,8 @@ static int streamingMergeNode(
       if( !pChildEntry ){
         rc = chunkStoreGet(pMut->pStore, &childHash, &pChildData, &nChildData);
         if( rc!=SQLITE_OK ) return rc;
-        pChildEntry = prollyCachePut(pCache, &childHash, pChildData, nChildData, &rc);
-        sqlite3_free(pChildData);
+        pChildEntry = prollyCachePutOwned(pCache, &childHash,
+                                          pChildData, nChildData, &rc);
         if( !pChildEntry ) return rc;
       }
 
@@ -1205,9 +1205,8 @@ static int validateReplaceBatchNode(
         rc = chunkStoreGet(pMut->pStore, &childHash,
                            &pChildData, &nChildData);
         if( rc!=SQLITE_OK ) return rc;
-        pChildEntry = prollyCachePut(pMut->pCache, &childHash,
-                                     pChildData, nChildData, &rc);
-        sqlite3_free(pChildData);
+        pChildEntry = prollyCachePutOwned(pMut->pCache, &childHash,
+                                          pChildData, nChildData, &rc);
         if( !pChildEntry ) return rc;
       }
       rc = validateReplaceBatchNode(pMut, &pChildEntry->node, pIter,
@@ -1278,9 +1277,8 @@ static int replaceBatchNodeNoRechunk(
           prollyNodeBuilderFree(&b);
           return rc;
         }
-        pChildEntry = prollyCachePut(pMut->pCache, &childHash,
-                                     pChildData, nChildData, &rc);
-        sqlite3_free(pChildData);
+        pChildEntry = prollyCachePutOwned(pMut->pCache, &childHash,
+                                          pChildData, nChildData, &rc);
         if( !pChildEntry ){
           prollyNodeBuilderFree(&b);
           return rc;


### PR DESCRIPTION
## Summary
- add prollyCachePutOwned for cache inserts that can take ownership of an already allocated node buffer
- use it on read-cache miss paths after chunkStoreGet
- read file-backed chunk length and payload with a single VFS read
- keep prollyCachePut unchanged for callers that need copy semantics

## Why
On a prolly-node cache miss, chunkStoreGet allocates a buffer for the chunk bytes. The read path then called prollyCachePut, which allocated a second buffer, copied the bytes, and freed the original. This removes that extra allocation/copy on the hot cache-miss path while keeping the cache entry ownership model unchanged.

chunkStoreGet also performed two VFS reads for file-backed chunks: one read for the stored length and one for the payload. Reading the record contiguously removes one syscall from cache-miss reads while preserving the stored-length and hash verification checks.

These changes are aimed more at reducing read latency variance from allocator and syscall churn than changing steady-state cached-read latency.

## Testing
- git diff --check