### PR TITLE
Read chunk records with one VFS call

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -912,27 +912,26 @@ int chunkStoreGet(
     {
       i64 fileOff = e->offset;
       int sz = e->size;
-      u8 lenBuf[4];
       u8 *pBuf;
       u32 storedLen;
 
-      rc = sqlite3OsRead(cs->file.pFile, lenBuf, 4, fileOff);
-      if( rc != SQLITE_OK ) return rc;
-
-      storedLen = CS_READ_U32(lenBuf);
-      if( (int)storedLen != sz ){
-        return SQLITE_CORRUPT;
-      }
-
-      pBuf = (u8 *)sqlite3_malloc(sz);
+      if( sz > INT_MAX - 4 ) return SQLITE_TOOBIG;
+      pBuf = (u8 *)sqlite3_malloc(sz + 4);
       if( pBuf == 0 ) return SQLITE_NOMEM;
 
-      rc = sqlite3OsRead(cs->file.pFile, pBuf, sz, fileOff + 4);
+      rc = sqlite3OsRead(cs->file.pFile, pBuf, sz + 4, fileOff);
       if( rc != SQLITE_OK ){
         sqlite3_free(pBuf);
         return rc;
       }
 
+      storedLen = CS_READ_U32(pBuf);
+      if( (int)storedLen != sz ){
+        sqlite3_free(pBuf);
+        return SQLITE_CORRUPT;
+      }
+
+      memmove(pBuf, pBuf + 4, sz);
       *ppData = pBuf;
       *pnData = sz;
     }


### PR DESCRIPTION
## Summary
- read file-backed chunk length and payload with a single VFS read in chunkStoreGet
- preserve stored-length validation and hash verification

## Why
File-backed chunk reads previously made two VFS calls on every cache miss: one for the 4-byte stored length and one for the payload. Reading the record contiguously removes one syscall from the read-cache-miss path. This is aimed at reducing latency variance from syscall scheduling rather than changing cached-read steady state.

## Testing
- git diff --check