### PR TITLE
cleanup: unify diff field-value comparator into doltlite_record

### DIFF
--- a/src/doltlite_diff_stat.c
+++ b/src/doltlite_diff_stat.c
@@ -140,64 +140,6 @@ static int dsCountRows(sqlite3 *db, const ProllyHash *pRoot, u8 flags,
   return SQLITE_OK;
 }
 
-static i64 dsReadInt(const u8 *p, int nBytes){
-  i64 v;
-  int i;
-  if( nBytes<=0 ) return 0;
-  v = (p[0] & 0x80) ? -1 : 0;
-  for(i=0; i<nBytes; i++) v = (v<<8) | p[i];
-  return v;
-}
-
-static int dsFieldValuesEqual(
-  int aType, const u8 *pA, int nA, int aOff,
-  int bType, const u8 *pB, int nB, int bOff
-){
-  i64 ai, bi;
-  int aLen, bLen;
-  if( aType==0 && bType==0 ) return 1;
-  if( aType==0 || bType==0 ) return 0;
-  {
-    int aIsInt = (aType>=1 && aType<=6) || aType==8 || aType==9;
-    int bIsInt = (bType>=1 && bType<=6) || bType==8 || bType==9;
-    if( aIsInt && bIsInt ){
-      if( aType==8 )      ai = 0;
-      else if( aType==9 ) ai = 1;
-      else{
-        aLen = dlSerialTypeLen(aType);
-        if( aOff<0 || aOff+aLen>nA ) return 0;
-        ai = dsReadInt(pA+aOff, aLen);
-      }
-      if( bType==8 )      bi = 0;
-      else if( bType==9 ) bi = 1;
-      else{
-        bLen = dlSerialTypeLen(bType);
-        if( bOff<0 || bOff+bLen>nB ) return 0;
-        bi = dsReadInt(pB+bOff, bLen);
-      }
-      return ai==bi;
-    }
-  }
-  if( aType==7 && bType==7 ){
-    u64 ar = 0, br = 0;
-    double da, db;
-    int i;
-    if( aOff<0 || aOff+8>nA ) return 0;
-    if( bOff<0 || bOff+8>nB ) return 0;
-    for(i=0; i<8; i++) ar = (ar<<8) | pA[aOff+i];
-    for(i=0; i<8; i++) br = (br<<8) | pB[bOff+i];
-    memcpy(&da, &ar, 8);
-    memcpy(&db, &br, 8);
-    return da == db;
-  }
-  if( aType != bType ) return 0;
-  aLen = dlSerialTypeLen(aType);
-  if( aLen<0 ) return 0;
-  if( aOff<0 || aOff+aLen>nA ) return 0;
-  if( bOff<0 || bOff+aLen>nB ) return 0;
-  return memcmp(pA+aOff, pB+bOff, aLen)==0;
-}
-
 typedef struct DsColMap DsColMap;
 struct DsColMap {
   int *aToFrom;
@@ -265,7 +207,7 @@ static int dsCountChangedCells(
       continue;
     }
     if( i>=toRi.nField || fromIdx>=fromRi.nField ) continue;
-    if( !dsFieldValuesEqual(
+    if( !doltliteFieldValuesEqual(
             fromRi.aType[fromIdx], pFromRec, nFromRec, fromRi.aOffset[fromIdx],
             toRi.aType[i],         pToRec,   nToRec,   toRi.aOffset[i]) ){
       changed++;

--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -701,68 +701,6 @@ cleanup:
   return rc;
 }
 
-static i64 sdReadInt(const u8 *p, int nBytes){
-  i64 v;
-  int i;
-  if( nBytes<=0 ) return 0;
-  v = (p[0] & 0x80) ? -1 : 0;
-  for(i=0; i<nBytes; i++) v = (v<<8) | p[i];
-  return v;
-}
-
-static int fieldValuesEqual(
-  int aType, const u8 *pA, int nA, int aOff,
-  int bType, const u8 *pB, int nB, int bOff
-){
-  i64 ai, bi;
-  int aLen, bLen;
-
-  if( aType==0 && bType==0 ) return 1;
-  if( aType==0 || bType==0 ) return 0;
-
-  {
-    int aIsInt = (aType>=1 && aType<=6) || aType==8 || aType==9;
-    int bIsInt = (bType>=1 && bType<=6) || bType==8 || bType==9;
-    if( aIsInt && bIsInt ){
-      if( aType==8 )      ai = 0;
-      else if( aType==9 ) ai = 1;
-      else{
-        aLen = dlSerialTypeLen(aType);
-        if( aOff<0 || aOff+aLen>nA ) return 0;
-        ai = sdReadInt(pA+aOff, aLen);
-      }
-      if( bType==8 )      bi = 0;
-      else if( bType==9 ) bi = 1;
-      else{
-        bLen = dlSerialTypeLen(bType);
-        if( bOff<0 || bOff+bLen>nB ) return 0;
-        bi = sdReadInt(pB+bOff, bLen);
-      }
-      return ai==bi;
-    }
-  }
-
-  if( aType==7 && bType==7 ){
-    u64 ar = 0, br = 0;
-    double da, db;
-    int i;
-    if( aOff<0 || aOff+8>nA ) return 0;
-    if( bOff<0 || bOff+8>nB ) return 0;
-    for(i=0; i<8; i++) ar = (ar<<8) | pA[aOff+i];
-    for(i=0; i<8; i++) br = (br<<8) | pB[bOff+i];
-    memcpy(&da, &ar, 8);
-    memcpy(&db, &br, 8);
-    return da == db;
-  }
-
-  if( aType != bType ) return 0;
-  aLen = dlSerialTypeLen(aType);
-  if( aLen<0 ) return 0;
-  if( aOff<0 || aOff+aLen>nA ) return 0;
-  if( bOff<0 || bOff+aLen>nB ) return 0;
-  return memcmp(pA+aOff, pB+bOff, aLen)==0;
-}
-
 static int changeIsSchemaOnly(
   const u8 *pFromRec, int nFromRec,
   const u8 *pToRec,   int nToRec,
@@ -797,7 +735,7 @@ static int changeIsSchemaOnly(
       if( toRi.aType[toRec]!=0 ) return 0;
       continue;
     }
-    if( !fieldValuesEqual(
+    if( !doltliteFieldValuesEqual(
             fromRi.aType[fromRec], pFromRec, nFromRec, fromRi.aOffset[fromRec],
             toRi.aType[toRec],     pToRec,   nToRec,   toRi.aOffset[toRec]) ){
       return 0;

--- a/src/doltlite_record.c
+++ b/src/doltlite_record.c
@@ -6,6 +6,59 @@
 #include <string.h>
 #include <stdio.h>
 
+int doltliteFieldValuesEqual(
+  int aType, const u8 *pA, int nA, int aOff,
+  int bType, const u8 *pB, int nB, int bOff
+){
+  i64 ai, bi;
+  int aLen, bLen;
+
+  if( aType==0 && bType==0 ) return 1;
+  if( aType==0 || bType==0 ) return 0;
+
+  {
+    int aIsInt = (aType>=1 && aType<=6) || aType==8 || aType==9;
+    int bIsInt = (bType>=1 && bType<=6) || bType==8 || bType==9;
+    if( aIsInt && bIsInt ){
+      if( aType==8 )      ai = 0;
+      else if( aType==9 ) ai = 1;
+      else{
+        aLen = dlSerialTypeLen(aType);
+        if( aOff<0 || aOff+aLen>nA ) return 0;
+        ai = dlReadIntBytes(pA+aOff, aLen);
+      }
+      if( bType==8 )      bi = 0;
+      else if( bType==9 ) bi = 1;
+      else{
+        bLen = dlSerialTypeLen(bType);
+        if( bOff<0 || bOff+bLen>nB ) return 0;
+        bi = dlReadIntBytes(pB+bOff, bLen);
+      }
+      return ai==bi;
+    }
+  }
+
+  if( aType==7 && bType==7 ){
+    u64 ar = 0, br = 0;
+    double da, db;
+    int i;
+    if( aOff<0 || aOff+8>nA ) return 0;
+    if( bOff<0 || bOff+8>nB ) return 0;
+    for(i=0; i<8; i++) ar = (ar<<8) | pA[aOff+i];
+    for(i=0; i<8; i++) br = (br<<8) | pB[bOff+i];
+    memcpy(&da, &ar, 8);
+    memcpy(&db, &br, 8);
+    return da == db;
+  }
+
+  if( aType != bType ) return 0;
+  aLen = dlSerialTypeLen(aType);
+  if( aLen<0 ) return 0;
+  if( aOff<0 || aOff+aLen>nA ) return 0;
+  if( bOff<0 || bOff+aLen>nB ) return 0;
+  return memcmp(pA+aOff, pB+bOff, aLen)==0;
+}
+
 typedef struct RecBuf RecBuf;
 struct RecBuf {
   char *z;

--- a/src/record_codec.h
+++ b/src/record_codec.h
@@ -57,4 +57,7 @@ int doltliteBindField(sqlite3_stmt *pStmt, int iParam,
                       const u8 *pData, int nData,
                       int serialType, int offset);
 
+int doltliteFieldValuesEqual(int aType, const u8 *pA, int nA, int aOff,
+                             int bType, const u8 *pB, int nB, int bOff);
+
 #endif


### PR DESCRIPTION
Item #16 from the dead/duplicate-code cleanup sweep.

`doltlite_diff_stat.c` and `doltlite_diff_table.c` each carried a byte-for-byte copy of a serial-type-aware field-equality comparator (`dsFieldValuesEqual` / `fieldValuesEqual`) plus an identical signed-int reader (`dsReadInt` / `sdReadInt`).

- Adds one `doltliteFieldValuesEqual()` in `doltlite_record.c`, declared in `record_codec.h` (both files already include it).
- The shared comparator reads ints via the existing `dlReadIntBytes` helper (added in #1068), so **both local readers are removed entirely** — no leftover duplication.
- Comparator logic, including every bounds check, is preserved verbatim.

Net −64 lines.

## Verification
- Clean compile, zero warnings.
- `make c-tests` → 13/13 gating suites pass.
- Full doltlite regression suite → 309,770 / 309,770 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)