### PR TITLE
cleanup(chunk): unify refs-state shallow-copy via REFS_OWNED macros

### DIFF
--- a/src/chunk_refs.c
+++ b/src/chunk_refs.c
@@ -200,62 +200,22 @@ void csRestoreCommittedRefsHash(ChunkStore *cs){
 
 void csCaptureSavedRefsState(ChunkStore *cs, SavedRefsState *pSaved){
   memset(pSaved, 0, sizeof(*pSaved));
-  pSaved->zDefaultBranch = cs->refs.zDefaultBranch;
-  pSaved->aBranches = cs->refs.aBranches;
-  pSaved->nBranches = cs->refs.nBranches;
-  pSaved->aTags = cs->refs.aTags;
-  pSaved->nTags = cs->refs.nTags;
-  pSaved->aRemotes = cs->refs.aRemotes;
-  pSaved->nRemotes = cs->refs.nRemotes;
-  pSaved->aTracking = cs->refs.aTracking;
-  pSaved->nTracking = cs->refs.nTracking;
-  pSaved->aSequences = cs->refs.aSequences;
-  pSaved->nSequences = cs->refs.nSequences;
+  REFS_OWNED_COPY(*pSaved, cs->refs);
 }
 
 void csDetachSavedRefsState(ChunkStore *cs, SavedRefsState *pSaved){
   csCaptureSavedRefsState(cs, pSaved);
-  cs->refs.zDefaultBranch = 0;
-  cs->refs.aBranches = 0;
-  cs->refs.nBranches = 0;
-  cs->refs.aTags = 0;
-  cs->refs.nTags = 0;
-  cs->refs.aRemotes = 0;
-  cs->refs.nRemotes = 0;
-  cs->refs.aTracking = 0;
-  cs->refs.nTracking = 0;
-  cs->refs.aSequences = 0;
-  cs->refs.nSequences = 0;
+  REFS_OWNED_CLEAR(cs->refs);
 }
 
 void csRestoreSavedRefsState(ChunkStore *cs, const SavedRefsState *pSaved){
-  cs->refs.zDefaultBranch = pSaved->zDefaultBranch;
-  cs->refs.aBranches = pSaved->aBranches;
-  cs->refs.nBranches = pSaved->nBranches;
-  cs->refs.aTags = pSaved->aTags;
-  cs->refs.nTags = pSaved->nTags;
-  cs->refs.aRemotes = pSaved->aRemotes;
-  cs->refs.nRemotes = pSaved->nRemotes;
-  cs->refs.aTracking = pSaved->aTracking;
-  cs->refs.nTracking = pSaved->nTracking;
-  cs->refs.aSequences = pSaved->aSequences;
-  cs->refs.nSequences = pSaved->nSequences;
+  REFS_OWNED_COPY(cs->refs, *pSaved);
 }
 
 void csFreeSavedRefsState(SavedRefsState *pSaved){
   ChunkStore refsStore;
   memset(&refsStore, 0, sizeof(refsStore));
-  refsStore.refs.zDefaultBranch = pSaved->zDefaultBranch;
-  refsStore.refs.aBranches = pSaved->aBranches;
-  refsStore.refs.nBranches = pSaved->nBranches;
-  refsStore.refs.aTags = pSaved->aTags;
-  refsStore.refs.nTags = pSaved->nTags;
-  refsStore.refs.aRemotes = pSaved->aRemotes;
-  refsStore.refs.nRemotes = pSaved->nRemotes;
-  refsStore.refs.aTracking = pSaved->aTracking;
-  refsStore.refs.nTracking = pSaved->nTracking;
-  refsStore.refs.aSequences = pSaved->aSequences;
-  refsStore.refs.nSequences = pSaved->nSequences;
+  REFS_OWNED_COPY(refsStore.refs, *pSaved);
   csFreeRefsState(&refsStore);
   memset(pSaved, 0, sizeof(*pSaved));
 }
@@ -461,29 +421,8 @@ int csDeserializeRefsIntoTemp(ChunkStore *pTmp, const u8 *data, int nData){
 }
 
 void csAdoptRefsState(ChunkStore *pDst, ChunkStore *pSrc){
-  pDst->refs.aBranches = pSrc->refs.aBranches;
-  pDst->refs.nBranches = pSrc->refs.nBranches;
-  pDst->refs.zDefaultBranch = pSrc->refs.zDefaultBranch;
-  pDst->refs.aTags = pSrc->refs.aTags;
-  pDst->refs.nTags = pSrc->refs.nTags;
-  pDst->refs.aRemotes = pSrc->refs.aRemotes;
-  pDst->refs.nRemotes = pSrc->refs.nRemotes;
-  pDst->refs.aTracking = pSrc->refs.aTracking;
-  pDst->refs.nTracking = pSrc->refs.nTracking;
-  pDst->refs.aSequences = pSrc->refs.aSequences;
-  pDst->refs.nSequences = pSrc->refs.nSequences;
-
-  pSrc->refs.aBranches = 0;
-  pSrc->refs.nBranches = 0;
-  pSrc->refs.zDefaultBranch = 0;
-  pSrc->refs.aTags = 0;
-  pSrc->refs.nTags = 0;
-  pSrc->refs.aRemotes = 0;
-  pSrc->refs.nRemotes = 0;
-  pSrc->refs.aTracking = 0;
-  pSrc->refs.nTracking = 0;
-  pSrc->refs.aSequences = 0;
-  pSrc->refs.nSequences = 0;
+  REFS_OWNED_COPY(pDst->refs, pSrc->refs);
+  REFS_OWNED_CLEAR(pSrc->refs);
 }
 
 int csReplaceRefsStateFromBlob(

--- a/src/chunk_refs.h
+++ b/src/chunk_refs.h
@@ -99,6 +99,34 @@ struct SavedRefsState {
   int nSequences;
 };
 
+#define REFS_OWNED_COPY(D, S) do {           \
+  (D).zDefaultBranch = (S).zDefaultBranch;   \
+  (D).aBranches      = (S).aBranches;        \
+  (D).nBranches      = (S).nBranches;        \
+  (D).aTags          = (S).aTags;            \
+  (D).nTags          = (S).nTags;            \
+  (D).aRemotes       = (S).aRemotes;         \
+  (D).nRemotes       = (S).nRemotes;         \
+  (D).aTracking      = (S).aTracking;        \
+  (D).nTracking      = (S).nTracking;        \
+  (D).aSequences     = (S).aSequences;       \
+  (D).nSequences     = (S).nSequences;       \
+} while(0)
+
+#define REFS_OWNED_CLEAR(D) do {             \
+  (D).zDefaultBranch = 0;                    \
+  (D).aBranches      = 0;                    \
+  (D).nBranches      = 0;                    \
+  (D).aTags          = 0;                    \
+  (D).nTags          = 0;                    \
+  (D).aRemotes       = 0;                    \
+  (D).nRemotes       = 0;                    \
+  (D).aTracking      = 0;                    \
+  (D).nTracking      = 0;                    \
+  (D).aSequences     = 0;                    \
+  (D).nSequences     = 0;                    \
+} while(0)
+
 struct ChunkStore;
 void csCaptureSavedRefsState(struct ChunkStore *cs, SavedRefsState *pSaved);
 void csRestoreSavedRefsState(struct ChunkStore *cs, const SavedRefsState *pSaved);

--- a/src/chunk_wal.c
+++ b/src/chunk_wal.c
@@ -99,17 +99,7 @@ void csAdoptOpenedStoreState(ChunkStore *pDst, ChunkStore *pSrc){
   pDst->index.aIndexMmapBase = pSrc->index.aIndexMmapBase;
   pDst->index.aIndexMmapSize = pSrc->index.aIndexMmapSize;
   pDst->wal.nWalData = pSrc->wal.nWalData;
-  pDst->refs.aBranches = pSrc->refs.aBranches;
-  pDst->refs.nBranches = pSrc->refs.nBranches;
-  pDst->refs.zDefaultBranch = pSrc->refs.zDefaultBranch;
-  pDst->refs.aTags = pSrc->refs.aTags;
-  pDst->refs.nTags = pSrc->refs.nTags;
-  pDst->refs.aRemotes = pSrc->refs.aRemotes;
-  pDst->refs.nRemotes = pSrc->refs.nRemotes;
-  pDst->refs.aTracking = pSrc->refs.aTracking;
-  pDst->refs.nTracking = pSrc->refs.nTracking;
-  pDst->refs.aSequences = pSrc->refs.aSequences;
-  pDst->refs.nSequences = pSrc->refs.nSequences;
+  REFS_OWNED_COPY(pDst->refs, pSrc->refs);
 
   pSrc->file.pFile = 0;
   pSrc->index.aIndex = 0;
@@ -117,17 +107,7 @@ void csAdoptOpenedStoreState(ChunkStore *pDst, ChunkStore *pSrc){
   pSrc->index.aIndexMmapBase = 0;
   pSrc->index.aIndexMmapSize = 0;
   pSrc->wal.nWalData = 0;
-  pSrc->refs.aBranches = 0;
-  pSrc->refs.nBranches = 0;
-  pSrc->refs.zDefaultBranch = 0;
-  pSrc->refs.aTags = 0;
-  pSrc->refs.nTags = 0;
-  pSrc->refs.aRemotes = 0;
-  pSrc->refs.nRemotes = 0;
-  pSrc->refs.aTracking = 0;
-  pSrc->refs.nTracking = 0;
-  pSrc->refs.aSequences = 0;
-  pSrc->refs.nSequences = 0;
+  REFS_OWNED_CLEAR(pSrc->refs);
 }
 
 void csFreeReloadState(ChunkStoreReloadState *pSaved){


### PR DESCRIPTION
Item #14 from the dead/duplicate-code cleanup sweep.

The 11 "owned" `RefsTable` fields — `zDefaultBranch` plus the branches/tags/remotes/tracking/sequences (pointer + count) pairs — were hand-copied or hand-cleared field-by-field in **six** places:

| Function | File |
|----------|------|
| `csCaptureSavedRefsState` | chunk_refs.c |
| `csDetachSavedRefsState` | chunk_refs.c |
| `csRestoreSavedRefsState` | chunk_refs.c |
| `csFreeSavedRefsState` | chunk_refs.c |
| `csAdoptRefsState` | chunk_refs.c |
| `csAdoptOpenedStoreState` | chunk_wal.c |

**This is the exact pattern behind the bug fixed in #1055**, where one copy forgot `aSequences`/`nSequences`. Adds `REFS_OWNED_COPY` / `REFS_OWNED_CLEAR` macros in `chunk_refs.h` (both files already include it via `chunk_store.h`) so the field list lives in one place — a future ref field is added once and flows to every copy site, making that bug class structurally impossible.

`RefsTable` and `SavedRefsState` share identical field names for the owned set, so the same macros work across both container types. Net −53 lines.

## Verification
- Clean compile, zero warnings.
- `make c-tests` → 13/13 gating suites pass.
- Full doltlite regression suite → 309,770 / 309,770 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)