### PR TITLE
cleanup: unify catalog serial-value codec into record_codec

### DIFF
--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -1501,59 +1501,6 @@ static Pgno remapSchemaRootpage(
   return iRootpage;
 }
 
-typedef struct MergeFieldValue MergeFieldValue;
-struct MergeFieldValue {
-  int eType;
-  i64 i;
-  const void *p;
-  int n;
-};
-
-static u32 mergeCatalogSerialType(const MergeFieldValue *pMem, u32 *pLen){
-  if( pMem->eType == SQLITE_NULL ){ *pLen = 0; return 0; }
-  if( pMem->eType == SQLITE_INTEGER ){
-    i64 v = pMem->i;
-    if( v==0 ){ *pLen = 0; return 8; }
-    if( v==1 ){ *pLen = 0; return 9; }
-    if( v>=-128 && v<=127 ){ *pLen = 1; return 1; }
-    if( v>=-32768 && v<=32767 ){ *pLen = 2; return 2; }
-    if( v>=-8388608 && v<=8388607 ){ *pLen = 3; return 3; }
-    if( v>=-2147483648LL && v<=2147483647LL ){ *pLen = 4; return 4; }
-    if( v>=-140737488355328LL && v<=140737488355327LL ){ *pLen = 6; return 5; }
-    *pLen = 8; return 6;
-  }
-  if( pMem->eType == SQLITE_TEXT ){
-    *pLen = (u32)pMem->n;
-    return (u32)(pMem->n * 2 + 13);
-  }
-  if( pMem->eType == SQLITE_BLOB ){
-    *pLen = (u32)pMem->n;
-    return (u32)(pMem->n * 2 + 12);
-  }
-  *pLen = 0;
-  return 0;
-}
-
-static void mergeCatalogSerialPut(u8 *pOut, const MergeFieldValue *pMem, u32 serialType){
-  switch( serialType ){
-    case 0:
-    case 8:
-    case 9:
-      return;
-    case 1: doltliteIpkWriteBE(pOut, pMem->i, 1); return;
-    case 2: doltliteIpkWriteBE(pOut, pMem->i, 2); return;
-    case 3: doltliteIpkWriteBE(pOut, pMem->i, 3); return;
-    case 4: doltliteIpkWriteBE(pOut, pMem->i, 4); return;
-    case 5: doltliteIpkWriteBE(pOut, pMem->i, 6); return;
-    case 6: doltliteIpkWriteBE(pOut, pMem->i, 8); return;
-    default:
-      if( serialType>=12 ){
-        memcpy(pOut, pMem->p, (size_t)pMem->n);
-      }
-      return;
-  }
-}
-
 static u8 *buildSchemaCatalogRecord(
   const char *zType,
   const char *zName,
@@ -1562,7 +1509,7 @@ static u8 *buildSchemaCatalogRecord(
   const char *zSql,
   int *pnOut
 ){
-  MergeFieldValue aMem[5];
+  DoltliteSerialValue aMem[5];
   u32 aType[5];
   u32 aLen[5];
   int i, hdrSize = 0, bodySize = 0, pos;
@@ -1586,7 +1533,7 @@ static u8 *buildSchemaCatalogRecord(
   }
 
   for(i=0; i<5; i++){
-    aType[i] = mergeCatalogSerialType(&aMem[i], &aLen[i]);
+    aType[i] = doltliteSerialTypeOf(&aMem[i], &aLen[i]);
     hdrSize += sqlite3VarintLen(aType[i]);
     bodySize += (int)aLen[i];
   }
@@ -1601,7 +1548,7 @@ static u8 *buildSchemaCatalogRecord(
   for(i=0; i<5; i++){
     pHdr += sqlite3PutVarint(pHdr, aType[i]);
     if( aLen[i]>0 ){
-      mergeCatalogSerialPut(pBody, &aMem[i], aType[i]);
+      doltliteSerialPut(pBody, &aMem[i], aType[i]);
       pBody += aLen[i];
     }
   }

--- a/src/doltlite_merge_constraints.c
+++ b/src/doltlite_merge_constraints.c
@@ -305,66 +305,6 @@ static int loadMergePkInfo(sqlite3 *db, const char *zTable, MergePkInfo *pPk){
   return SQLITE_OK;
 }
 
-typedef struct MergeFieldValue MergeFieldValue;
-struct MergeFieldValue {
-  int eType;
-  i64 i;
-  double r;
-  const void *p;
-  int n;
-};
-
-static u32 mergeSerialType(const MergeFieldValue *pMem, u32 *pLen){
-  if( pMem->eType == SQLITE_NULL ){ *pLen = 0; return 0; }
-  if( pMem->eType == SQLITE_INTEGER ){
-    i64 v = pMem->i;
-    if( v==0 ){ *pLen = 0; return 8; }
-    if( v==1 ){ *pLen = 0; return 9; }
-    if( v>=-128 && v<=127 ){ *pLen = 1; return 1; }
-    if( v>=-32768 && v<=32767 ){ *pLen = 2; return 2; }
-    if( v>=-8388608 && v<=8388607 ){ *pLen = 3; return 3; }
-    if( v>=-2147483648LL && v<=2147483647LL ){ *pLen = 4; return 4; }
-    if( v>=-140737488355328LL && v<=140737488355327LL ){ *pLen = 6; return 5; }
-    *pLen = 8; return 6;
-  }
-  if( pMem->eType == SQLITE_FLOAT ){ *pLen = 8; return 7; }
-  if( pMem->eType == SQLITE_TEXT ){
-    *pLen = (u32)pMem->n;
-    return (u32)(pMem->n * 2 + 13);
-  }
-  if( pMem->eType == SQLITE_BLOB ){
-    *pLen = (u32)pMem->n;
-    return (u32)(pMem->n * 2 + 12);
-  }
-  *pLen = 0;
-  return 0;
-}
-
-static void mergeSerialPut(u8 *pOut, const MergeFieldValue *pMem, u32 serialType){
-  switch( serialType ){
-    case 0:
-    case 8:
-    case 9:
-      return;
-    case 1: doltliteIpkWriteBE(pOut, pMem->i, 1); return;
-    case 2: doltliteIpkWriteBE(pOut, pMem->i, 2); return;
-    case 3: doltliteIpkWriteBE(pOut, pMem->i, 3); return;
-    case 4: doltliteIpkWriteBE(pOut, pMem->i, 4); return;
-    case 5: doltliteIpkWriteBE(pOut, pMem->i, 6); return;
-    case 6: doltliteIpkWriteBE(pOut, pMem->i, 8); return;
-    case 7: {
-      sqlite3_uint64 u;
-      memcpy(&u, &pMem->r, 8);
-      doltliteIpkWriteBE(pOut, (i64)u, 8);
-      return;
-    }
-    default:
-      if( serialType>=12 ){
-        memcpy(pOut, pMem->p, (size_t)pMem->n);
-      }
-      return;
-  }
-}
 
 static u8 *buildRecordFromStmtCols(
   sqlite3_stmt *pStmt,
@@ -372,7 +312,7 @@ static u8 *buildRecordFromStmtCols(
   int nField,
   int *pnOut
 ){
-  MergeFieldValue *aMem = 0;
+  DoltliteSerialValue *aMem = 0;
   u32 *aType = 0;
   u32 *aLen = 0;
   u8 *pOut = 0;
@@ -382,14 +322,14 @@ static u8 *buildRecordFromStmtCols(
   *pnOut = 0;
   if( nField<=0 ) return 0;
 
-  aMem = sqlite3_malloc64((sqlite3_int64)nField * sizeof(MergeFieldValue));
+  aMem = sqlite3_malloc64((sqlite3_int64)nField * sizeof(DoltliteSerialValue));
   aType = sqlite3_malloc64((sqlite3_int64)nField * sizeof(u32));
   aLen = sqlite3_malloc64((sqlite3_int64)nField * sizeof(u32));
   if( !aMem || !aType || !aLen ){
     sqlite3_free(aMem); sqlite3_free(aType); sqlite3_free(aLen);
     return 0;
   }
-  memset(aMem, 0, (size_t)nField * sizeof(MergeFieldValue));
+  memset(aMem, 0, (size_t)nField * sizeof(DoltliteSerialValue));
 
   for(i=0; i<nField; i++){
     int iCol = iStart + i;
@@ -414,7 +354,7 @@ static u8 *buildRecordFromStmtCols(
       default:
         break;
     }
-    aType[i] = mergeSerialType(&aMem[i], &aLen[i]);
+    aType[i] = doltliteSerialTypeOf(&aMem[i], &aLen[i]);
     hdrSize += sqlite3VarintLen(aType[i]);
     bodySize += (int)aLen[i];
   }
@@ -432,7 +372,7 @@ static u8 *buildRecordFromStmtCols(
   for(i=0; i<nField; i++){
     pHdr += sqlite3PutVarint(pHdr, aType[i]);
     if( aLen[i]>0 ){
-      mergeSerialPut(pBody, &aMem[i], aType[i]);
+      doltliteSerialPut(pBody, &aMem[i], aType[i]);
       pBody += aLen[i];
     }
   }

--- a/src/doltlite_record.c
+++ b/src/doltlite_record.c
@@ -6,6 +6,54 @@
 #include <string.h>
 #include <stdio.h>
 
+u32 doltliteSerialTypeOf(const DoltliteSerialValue *pVal, u32 *pLen){
+  if( pVal->eType == SQLITE_NULL ){ *pLen = 0; return 0; }
+  if( pVal->eType == SQLITE_INTEGER ){
+    i64 v = pVal->i;
+    if( v==0 ){ *pLen = 0; return 8; }
+    if( v==1 ){ *pLen = 0; return 9; }
+    if( v>=-128 && v<=127 ){ *pLen = 1; return 1; }
+    if( v>=-32768 && v<=32767 ){ *pLen = 2; return 2; }
+    if( v>=-8388608 && v<=8388607 ){ *pLen = 3; return 3; }
+    if( v>=-2147483648LL && v<=2147483647LL ){ *pLen = 4; return 4; }
+    if( v>=-140737488355328LL && v<=140737488355327LL ){ *pLen = 6; return 5; }
+    *pLen = 8; return 6;
+  }
+  if( pVal->eType == SQLITE_FLOAT ){ *pLen = 8; return 7; }
+  if( pVal->eType == SQLITE_TEXT ){
+    *pLen = (u32)pVal->n;
+    return (u32)(pVal->n * 2 + 13);
+  }
+  if( pVal->eType == SQLITE_BLOB ){
+    *pLen = (u32)pVal->n;
+    return (u32)(pVal->n * 2 + 12);
+  }
+  *pLen = 0;
+  return 0;
+}
+
+void doltliteSerialPut(u8 *pOut, const DoltliteSerialValue *pVal, u32 serialType){
+  i64 v;
+  int nByte, i;
+  if( serialType==0 || serialType==8 || serialType==9 ) return;
+  if( serialType==7 ){
+    sqlite3_uint64 u;
+    memcpy(&u, &pVal->r, 8);
+    v = (i64)u;
+    nByte = 8;
+  }else if( serialType>=1 && serialType<=6 ){
+    v = pVal->i;
+    nByte = dlSerialTypeLen(serialType);
+  }else{
+    if( serialType>=12 ) memcpy(pOut, pVal->p, (size_t)pVal->n);
+    return;
+  }
+  for(i=nByte-1; i>=0; i--){
+    pOut[i] = (u8)(v & 0xFF);
+    v >>= 8;
+  }
+}
+
 int doltliteFieldValuesEqual(
   int aType, const u8 *pA, int nA, int aOff,
   int bType, const u8 *pB, int nB, int bOff

--- a/src/record_codec.h
+++ b/src/record_codec.h
@@ -60,4 +60,19 @@ int doltliteBindField(sqlite3_stmt *pStmt, int iParam,
 int doltliteFieldValuesEqual(int aType, const u8 *pA, int nA, int aOff,
                              int bType, const u8 *pB, int nB, int bOff);
 
+/* A SQLite value to be encoded into a record. eType is one of the
+** SQLITE_* type codes; i/r/p+n carry the integer, real and text/blob
+** payloads respectively. */
+typedef struct DoltliteSerialValue DoltliteSerialValue;
+struct DoltliteSerialValue {
+  int eType;
+  i64 i;
+  double r;
+  const void *p;
+  int n;
+};
+
+u32 doltliteSerialTypeOf(const DoltliteSerialValue *pVal, u32 *pLen);
+void doltliteSerialPut(u8 *pOut, const DoltliteSerialValue *pVal, u32 serialType);
+
 #endif


### PR DESCRIPTION
Item #19 (last of the duplicate-code items) from the cleanup sweep.

`doltlite_merge.c` and `doltlite_merge_constraints.c` each carried a near-identical `MergeFieldValue` struct plus a value→serial-type encoder and a serial-put writer for building catalog / constraint-violation records. The constraints copy was a strict superset of the merge copy (it also handled `SQLITE_FLOAT`).

Adds a shared `DoltliteSerialValue` + `doltliteSerialTypeOf` / `doltliteSerialPut` to the record codec (declared in `record_codec.h`, defined in `doltlite_record.c`) using the float-capable superset, and routes both record builders through them. The put writer is self-contained — big-endian widths via the existing `dlSerialTypeLen` — so the codec gains no new dependency.

**Behavior-preserving:** `merge.c`'s catalog records only ever hold NULL/INT/TEXT, so the added FLOAT/BLOB handling is inert for it; constraints keeps its existing FLOAT path. Net −50 lines.

Leaves `prolly_btree.c`'s separate `SchemaFieldValue` codec (different struct, own BE writer, NULL/INT/TEXT-only) untouched as a possible follow-up.

## Verification
- Clean compile, zero warnings.
- `make c-tests` → 13/13 gating suites pass.
- Full regression suite → 309,770 / 309,770 pass.
- Schema/merge/conflict feature suites pass: `doltlite_schema_merge` (76), `doltlite_merge` (91), `vc_oracle_schema_merge_test` (37), `vc_oracle_merge_test` (48), `vc_oracle_conflicts_test` (9), `doltlite_conflicts` (40), `vc_oracle_schemas_test` (19), `doltlite_schema_diff` (49).

🤖 Generated with [Claude Code](https://claude.com/claude-code)