### PR TITLE
Remove dead code: unused fns, stale decls, no-op logic

### DIFF
--- a/src/chunk_refs.c
+++ b/src/chunk_refs.c
@@ -42,16 +42,8 @@ i64 refsTableGetSequence(const RefsTable *rt, const char *zTableName){
   return 0;
 }
 
-const char *refsTableGetDefaultBranchName(const RefsTable *rt){
-  return rt->zDefaultBranch;
-}
-
 const ProllyHash *refsTableGetHash(const RefsTable *rt){
   return &rt->refsHash;
-}
-
-const ProllyHash *refsTableGetCommittedHash(const RefsTable *rt){
-  return &rt->committedRefsHash;
 }
 
 int refsTableBranchCount(const RefsTable *rt){

--- a/src/chunk_refs.h
+++ b/src/chunk_refs.h
@@ -78,9 +78,7 @@ int refsTableRemoteCount(const RefsTable *rt);
 /* Return the stored sequence for zTableName, or 0 if absent. */
 i64 refsTableGetSequence(const RefsTable *rt, const char *zTableName);
 
-const char *refsTableGetDefaultBranchName(const RefsTable *rt);
 const ProllyHash *refsTableGetHash(const RefsTable *rt);
-const ProllyHash *refsTableGetCommittedHash(const RefsTable *rt);
 
 void refsTableSetHash(RefsTable *rt, const ProllyHash *h);
 

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -929,7 +929,6 @@ int chunkStoreGet(
     }
   }
 
-verify:
   {
     ProllyHash h;
     prollyHashCompute(*ppData, *pnData, &h);

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -85,8 +85,6 @@ extern int doltliteFindAncestor(sqlite3 *db, const ProllyHash *h1,
 extern const char *doltliteNextTableForSchema(sqlite3 *db, int *pIdx, Pgno *piTable);
 extern void doltliteSetTableSchemaHash(sqlite3 *db, Pgno iTable, const ProllyHash *pH);
 
-int doltliteFlushCatalogToHash(sqlite3 *db, ProllyHash *pHash);
-
 int doltliteMaterializeDefaultColumns(sqlite3 *db);
 
 typedef struct DoltliteTxnState DoltliteTxnState;

--- a/src/doltlite_ancestor.c
+++ b/src/doltlite_ancestor.c
@@ -350,9 +350,6 @@ done:
   return rc;
 }
 
-extern int chunkStoreFindBranch(ChunkStore *cs, const char *zName, ProllyHash *pCommit);
-extern int chunkStoreFindTag(ChunkStore *cs, const char *zName, ProllyHash *pCommit);
-
 static void doltMergeBaseFunc(
   sqlite3_context *ctx,
   int argc,

--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -1185,17 +1185,14 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
 
   if( argc>1 && !isCreateAndSwitch ){
     ProllyHash sourceRef;
-    int bHasSourceRef = 0;
     rc = doltliteResolveRef(db, zBranch, &sourceRef);
     if( rc==SQLITE_OK ){
-      bHasSourceRef = 1;
       rc = doltliteCheckoutTables(db, zBranch, argv, 1, argc-1);
     }else{
       rc = doltliteCheckoutTables(db, 0, argv, 0, argc);
     }
     if( rc==SQLITE_NOTFOUND ){
-      const char *zMissing = bHasSourceRef ? zBranch : zBranch;
-      char *zErr = sqlite3_mprintf("no such branch or table: %s", zMissing);
+      char *zErr = sqlite3_mprintf("no such branch or table: %s", zBranch);
       (void)doltliteVcSealSavepointError(db);
       sqlite3_result_error(ctx, zErr ? zErr : "no such branch or table", -1);
       sqlite3_free(zErr);

--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -2532,7 +2532,6 @@ int doltliteMergeCatalogs(
   Pgno iNextAnc = 2, iNextOurs = 2, iNextTheirs = 2;
   struct TableEntry *aMerged = 0;
   int nMerged = 0;
-  int nMergedAlloc = 0;
   Pgno iNextMerged;
   int rc;
   int totalConflicts = 0;
@@ -2544,7 +2543,6 @@ int doltliteMergeCatalogs(
 
   MergeConflictTable *aConflictTables = 0;
   int nConflictTables = 0;
-  (void)nMergedAlloc;
 
   rc = loadMergeCatalogs(db, ancestor, ours, theirs,
                          &aAnc, &nAnc, &iNextAnc,


### PR DESCRIPTION
First PR from a codebase-wide dead/duplicate-code sweep. This one is pure dead-code removal — all verified unreferenced before deletion.

- `refsTableGetDefaultBranchName` / `refsTableGetCommittedHash` — defined + declared but never called anywhere.
- `chunk_store.c` — unused `verify:` label (nothing `goto`s it).
- `doltlite_ancestor.c` — dead `extern` decls of `chunkStoreFindBranch`/`FindTag` (never referenced in the file).
- `doltlite_branch.c` — no-op `bHasSourceRef ? zBranch : zBranch` ternary + the now-unused `bHasSourceRef`.
- `doltlite_merge.c` — write-only `nMergedAlloc` and its `(void)` suppression.
- `doltlite.c` — redundant local re-decl of `doltliteFlushCatalogToHash` (already in `doltlite_internal.h`).

7 files, +1/-22. Builds clean; `make c-tests` passes (0 gating failures / 13 binaries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)