### PR TITLE
Share simple DoltLite vtab helpers

### DIFF
--- a/src/doltlite_at.c
+++ b/src/doltlite_at.c
@@ -162,9 +162,8 @@ static int atBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
 }
 
 static int atOpen(sqlite3_vtab *pVtab, sqlite3_vtab_cursor **pp){
-  AtCursor *c;(void)pVtab;
-  c=sqlite3_malloc(sizeof(*c)); if(!c) return SQLITE_NOMEM;
-  memset(c,0,sizeof(*c)); *pp=&c->base; return SQLITE_OK;
+  (void)pVtab;
+  return doltliteVtabOpenCursor(pp, sizeof(AtCursor));
 }
 
 static int atClose(sqlite3_vtab_cursor *cur){

--- a/src/doltlite_blame.c
+++ b/src/doltlite_blame.c
@@ -770,13 +770,8 @@ static int bmBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
 }
 
 static int bmOpen(sqlite3_vtab *pVtab, sqlite3_vtab_cursor **ppCursor){
-  BlameCursor *c;
   (void)pVtab;
-  c = sqlite3_malloc(sizeof(*c));
-  if( !c ) return SQLITE_NOMEM;
-  memset(c, 0, sizeof(*c));
-  *ppCursor = &c->base;
-  return SQLITE_OK;
+  return doltliteVtabOpenCursor(ppCursor, sizeof(BlameCursor));
 }
 
 static int bmClose(sqlite3_vtab_cursor *pCursor){

--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -1358,12 +1358,10 @@ static int brConnect(sqlite3 *db, void *pAux, int argc,
   *ppVtab = &p->base;
   return SQLITE_OK;
 }
-static int brDisconnect(sqlite3_vtab *v){ sqlite3_free(v); return SQLITE_OK; }
 static int brOpen(sqlite3_vtab *v, sqlite3_vtab_cursor **pp){
-  BrCur *c = sqlite3_malloc(sizeof(*c)); (void)v;
-  if(!c) return SQLITE_NOMEM; memset(c,0,sizeof(*c)); *pp=&c->base; return SQLITE_OK;
+  (void)v;
+  return doltliteVtabOpenCursor(pp, sizeof(BrCur));
 }
-static int brClose(sqlite3_vtab_cursor *c){ sqlite3_free(c); return SQLITE_OK; }
 static int brFilter(sqlite3_vtab_cursor *c, int n, const char *s, int a, sqlite3_value **v){
   (void)n;(void)s;(void)a;(void)v;
   ((BrCur*)c)->iRow = 0; return SQLITE_OK;
@@ -1497,8 +1495,8 @@ static int brBestIndex(sqlite3_vtab *v, sqlite3_index_info *p){
   (void)v; p->estimatedCost=10; p->estimatedRows=5; return SQLITE_OK;
 }
 static sqlite3_module brMod = {
-  0,0,brConnect,brBestIndex,brDisconnect,0,
-  brOpen,brClose,brFilter,brNext,brEof,brColumn,brRowid,
+  0,0,brConnect,brBestIndex,doltliteVtabDisconnect,0,
+  brOpen,doltliteVtabClose,brFilter,brNext,brEof,brColumn,brRowid,
   0,0,0,0,0,0,0,0,0,0,0,0
 };
 

--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -318,10 +318,9 @@ static int cfConnect(sqlite3 *db, void *pAux, int argc,
   v = sqlite3_malloc(sizeof(*v)); if(!v) return SQLITE_NOMEM;
   memset(v,0,sizeof(*v)); v->db=db; *ppVtab=&v->base; return SQLITE_OK;
 }
-static int cfDisconnect(sqlite3_vtab *v){ sqlite3_free(v); return SQLITE_OK; }
 static int cfOpen(sqlite3_vtab *v, sqlite3_vtab_cursor **pp){
-  ConflictsCur *c=sqlite3_malloc(sizeof(*c)); (void)v;
-  if(!c) return SQLITE_NOMEM; memset(c,0,sizeof(*c)); *pp=&c->base; return SQLITE_OK;
+  (void)v;
+  return doltliteVtabOpenCursor(pp, sizeof(ConflictsCur));
 }
 static int cfClose(sqlite3_vtab_cursor *cur){
   ConflictsCur *c=(ConflictsCur*)cur;
@@ -349,7 +348,7 @@ static int cfRowid(sqlite3_vtab_cursor *cur, sqlite3_int64 *r){ *r=((ConflictsCu
 static int cfBestIndex(sqlite3_vtab *v, sqlite3_index_info *p){ (void)v; p->estimatedCost=10; return SQLITE_OK; }
 
 static sqlite3_module conflictsModule = {
-  0,0,cfConnect,cfBestIndex,cfDisconnect,0,cfOpen,cfClose,cfFilter,cfNext,cfEof,
+  0,0,cfConnect,cfBestIndex,doltliteVtabDisconnect,0,cfOpen,cfClose,cfFilter,cfNext,cfEof,
   cfColumn,cfRowid,0,0,0,0,0,0,0,0,0,0,0,0
 };
 
@@ -459,12 +458,13 @@ static int cfrDisconnect(sqlite3_vtab *pVtab){
 }
 
 static int cfrOpen(sqlite3_vtab *pVtab, sqlite3_vtab_cursor **pp){
-  CfRowCur *c = sqlite3_malloc(sizeof(*c));
+  CfRowCur *c;
   (void)pVtab;
-  if(!c) return SQLITE_NOMEM;
-  memset(c,0,sizeof(*c));
+  if( doltliteVtabOpenCursor(pp, sizeof(CfRowCur))!=SQLITE_OK ){
+    return SQLITE_NOMEM;
+  }
+  c = (CfRowCur*)*pp;
   c->iTableIdx = -1;
-  *pp = &c->base;
   return SQLITE_OK;
 }
 

--- a/src/doltlite_constraint_violations.c
+++ b/src/doltlite_constraint_violations.c
@@ -406,14 +406,9 @@ static int cvsConnect(sqlite3 *db, void *pAux, int argc,
   *ppVtab = &v->base;
   return SQLITE_OK;
 }
-static int cvsDisconnect(sqlite3_vtab *v){ sqlite3_free(v); return SQLITE_OK; }
 static int cvsOpen(sqlite3_vtab *v, sqlite3_vtab_cursor **pp){
-  CvSumCur *c = sqlite3_malloc(sizeof(*c));
   (void)v;
-  if( !c ) return SQLITE_NOMEM;
-  memset(c, 0, sizeof(*c));
-  *pp = &c->base;
-  return SQLITE_OK;
+  return doltliteVtabOpenCursor(pp, sizeof(CvSumCur));
 }
 static int cvsClose(sqlite3_vtab_cursor *cur){
   CvSumCur *c = (CvSumCur*)cur;
@@ -460,7 +455,7 @@ static int cvsBestIndex(sqlite3_vtab *v, sqlite3_index_info *p){
 }
 
 static sqlite3_module cvSummaryModule = {
-  0, 0, cvsConnect, cvsBestIndex, cvsDisconnect, 0, cvsOpen, cvsClose,
+  0, 0, cvsConnect, cvsBestIndex, doltliteVtabDisconnect, 0, cvsOpen, cvsClose,
   cvsFilter, cvsNext, cvsEof, cvsColumn, cvsRowid,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 };
@@ -555,12 +550,13 @@ static int cvrDisconnect(sqlite3_vtab *pVtab){
 }
 
 static int cvrOpen(sqlite3_vtab *pVtab, sqlite3_vtab_cursor **pp){
-  CvRowCur *c = sqlite3_malloc(sizeof(*c));
+  CvRowCur *c;
   (void)pVtab;
-  if( !c ) return SQLITE_NOMEM;
-  memset(c, 0, sizeof(*c));
+  if( doltliteVtabOpenCursor(pp, sizeof(CvRowCur))!=SQLITE_OK ){
+    return SQLITE_NOMEM;
+  }
+  c = (CvRowCur*)*pp;
   c->iTableIdx = -1;
-  *pp = &c->base;
   return SQLITE_OK;
 }
 

--- a/src/doltlite_diff_stat.c
+++ b/src/doltlite_diff_stat.c
@@ -515,8 +515,6 @@ static int dstConnect(sqlite3 *db, void *pAux, int argc,
   return SQLITE_OK;
 }
 
-static int dstDisconnect(sqlite3_vtab *v){ sqlite3_free(v); return SQLITE_OK; }
-
 static int dstBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
   (void)pVtab;
   return doltliteBestIndexRefs(pInfo, DST_COL_FROM_REF, DST_COL_TO_REF,
@@ -524,12 +522,8 @@ static int dstBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
 }
 
 static int dstOpen(sqlite3_vtab *v, sqlite3_vtab_cursor **pp){
-  DstCursor *c; (void)v;
-  c = sqlite3_malloc(sizeof(*c));
-  if( !c ) return SQLITE_NOMEM;
-  memset(c, 0, sizeof(*c));
-  *pp = &c->base;
-  return SQLITE_OK;
+  (void)v;
+  return doltliteVtabOpenCursor(pp, sizeof(DstCursor));
 }
 
 static int dstClose(sqlite3_vtab_cursor *cur){
@@ -760,7 +754,7 @@ static int dstRowid(sqlite3_vtab_cursor *cur, sqlite3_int64 *r){
 }
 
 static sqlite3_module diffStatModule = {
-  0, 0, dstConnect, dstBestIndex, dstDisconnect, 0,
+  0, 0, dstConnect, dstBestIndex, doltliteVtabDisconnect, 0,
   dstOpen, dstClose, dstFilter, dstNext, dstEof,
   dstColumn, dstRowid,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
@@ -822,8 +816,6 @@ static int dssConnect(sqlite3 *db, void *pAux, int argc,
   return SQLITE_OK;
 }
 
-static int dssDisconnect(sqlite3_vtab *v){ sqlite3_free(v); return SQLITE_OK; }
-
 static int dssBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
   (void)pVtab;
   return doltliteBestIndexRefs(pInfo, DSS_COL_FROM_REF, DSS_COL_TO_REF,
@@ -831,12 +823,8 @@ static int dssBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
 }
 
 static int dssOpen(sqlite3_vtab *v, sqlite3_vtab_cursor **pp){
-  DssCursor *c; (void)v;
-  c = sqlite3_malloc(sizeof(*c));
-  if( !c ) return SQLITE_NOMEM;
-  memset(c, 0, sizeof(*c));
-  *pp = &c->base;
-  return SQLITE_OK;
+  (void)v;
+  return doltliteVtabOpenCursor(pp, sizeof(DssCursor));
 }
 
 static int dssClose(sqlite3_vtab_cursor *cur){
@@ -978,7 +966,7 @@ static int dssRowid(sqlite3_vtab_cursor *cur, sqlite3_int64 *r){
 }
 
 static sqlite3_module diffSummaryModule = {
-  0, 0, dssConnect, dssBestIndex, dssDisconnect, 0,
+  0, 0, dssConnect, dssBestIndex, doltliteVtabDisconnect, 0,
   dssOpen, dssClose, dssFilter, dssNext, dssEof,
   dssColumn, dssRowid,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0

--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -957,12 +957,8 @@ static int dtBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
 }
 
 static int dtOpen(sqlite3_vtab *pVtab, sqlite3_vtab_cursor **pp){
-  DiffTblCursor *c; (void)pVtab;
-  c = sqlite3_malloc(sizeof(*c));
-  if( !c ) return SQLITE_NOMEM;
-  memset(c, 0, sizeof(*c));
-  *pp = &c->base;
-  return SQLITE_OK;
+  (void)pVtab;
+  return doltliteVtabOpenCursor(pp, sizeof(DiffTblCursor));
 }
 
 static int dtClose(sqlite3_vtab_cursor *cur){

--- a/src/doltlite_history.c
+++ b/src/doltlite_history.c
@@ -387,9 +387,8 @@ static int htBestIndex(sqlite3_vtab *v, sqlite3_index_info *p){
 }
 
 static int htOpen(sqlite3_vtab *pVtab, sqlite3_vtab_cursor **pp){
-  HistCursor *c;(void)pVtab;
-  c=sqlite3_malloc(sizeof(*c)); if(!c) return SQLITE_NOMEM;
-  memset(c,0,sizeof(*c)); *pp=&c->base; return SQLITE_OK;
+  (void)pVtab;
+  return doltliteVtabOpenCursor(pp, sizeof(HistCursor));
 }
 
 static int htClose(sqlite3_vtab_cursor *cur){

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -106,6 +106,28 @@ static SQLITE_INLINE void doltliteResultTimestamp(sqlite3_context *ctx, i64 time
   }
 }
 
+static SQLITE_INLINE int doltliteVtabDisconnect(sqlite3_vtab *pVtab){
+  sqlite3_free(pVtab);
+  return SQLITE_OK;
+}
+
+static SQLITE_INLINE int doltliteVtabClose(sqlite3_vtab_cursor *pCur){
+  sqlite3_free(pCur);
+  return SQLITE_OK;
+}
+
+static SQLITE_INLINE int doltliteVtabOpenCursor(
+  sqlite3_vtab_cursor **ppCursor,
+  int nByte
+){
+  sqlite3_vtab_cursor *pCur;
+  pCur = sqlite3_malloc(nByte);
+  if( !pCur ) return SQLITE_NOMEM;
+  memset(pCur, 0, nByte);
+  *ppCursor = pCur;
+  return SQLITE_OK;
+}
+
 static SQLITE_INLINE int doltliteFindTableRootByName(
   struct TableEntry *a, int n, const char *zName,
   ProllyHash *pRoot, u8 *pFlags

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -843,12 +843,10 @@ static int remConnect(sqlite3 *db, void *pAux, int argc,
   *ppVtab = &p->base;
   return SQLITE_OK;
 }
-static int remDisconnect(sqlite3_vtab *v){ sqlite3_free(v); return SQLITE_OK; }
 static int remOpen(sqlite3_vtab *v, sqlite3_vtab_cursor **pp){
-  RemCur *c = sqlite3_malloc(sizeof(*c)); (void)v;
-  if(!c) return SQLITE_NOMEM; memset(c,0,sizeof(*c)); *pp=&c->base; return SQLITE_OK;
+  (void)v;
+  return doltliteVtabOpenCursor(pp, sizeof(RemCur));
 }
-static int remClose(sqlite3_vtab_cursor *c){ sqlite3_free(c); return SQLITE_OK; }
 static int remFilter(sqlite3_vtab_cursor *c, int n, const char *s, int a, sqlite3_value **v){
   (void)n;(void)s;(void)a;(void)v;
   ((RemCur*)c)->iRow = 0; return SQLITE_OK;
@@ -902,8 +900,8 @@ static int remBestIndex(sqlite3_vtab *v, sqlite3_index_info *p){
 }
 
 static sqlite3_module remotesModule = {
-  0,0,remConnect,remBestIndex,remDisconnect,0,
-  remOpen,remClose,remFilter,remNext,remEof,remColumn,remRowid,
+  0,0,remConnect,remBestIndex,doltliteVtabDisconnect,0,
+  remOpen,doltliteVtabClose,remFilter,remNext,remEof,remColumn,remRowid,
   0,0,0,0,0,0,0,0,0,0,0,0
 };
 

--- a/src/doltlite_schema_diff.c
+++ b/src/doltlite_schema_diff.c
@@ -423,20 +423,14 @@ static int sdConnect(sqlite3 *db, void *pAux, int argc,
   return SQLITE_OK;
 }
 
-static int sdDisconnect(sqlite3_vtab *v){ sqlite3_free(v); return SQLITE_OK; }
-
 static int sdBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
   (void)pVtab;
   return doltliteBestIndexRefs(pInfo, 4, 5, 6);
 }
 
 static int sdOpen(sqlite3_vtab *v, sqlite3_vtab_cursor **pp){
-  SdCursor *c; (void)v;
-  c = sqlite3_malloc(sizeof(*c));
-  if( !c ) return SQLITE_NOMEM;
-  memset(c, 0, sizeof(*c));
-  *pp = &c->base;
-  return SQLITE_OK;
+  (void)v;
+  return doltliteVtabOpenCursor(pp, sizeof(SdCursor));
 }
 
 static int sdClose(sqlite3_vtab_cursor *cur){
@@ -688,7 +682,7 @@ static int sdRowid(sqlite3_vtab_cursor *cur, sqlite3_int64 *r){
 }
 
 static sqlite3_module schemaDiffModule = {
-  0, 0, sdConnect, sdBestIndex, sdDisconnect, 0,
+  0, 0, sdConnect, sdBestIndex, doltliteVtabDisconnect, 0,
   sdOpen, sdClose, sdFilter, sdNext, sdEof,
   sdColumn, sdRowid,
   0,0,0,0,0,0,0,0,0,0,0,0


### PR DESCRIPTION
## Summary
- add shared helpers for simple DoltLite virtual-table disconnect, cursor close, and zeroed cursor allocation
- replace duplicate cursor allocation/free boilerplate across DoltLite-owned virtual tables
- leave module-specific close/disconnect paths intact where they release owned state

## Tests
- make doltlite
- bash test/doltlite_conflicts.sh ./doltlite
- bash test/doltlite_conflict_rows.sh ./doltlite
- bash test/vc_oracle_fk_merge_test.sh ./doltlite
- bash test/vc_oracle_remotes_test.sh ./doltlite
- bash test/doltlite_at.sh ./doltlite
- bash test/doltlite_advanced.sh ./doltlite
- bash test/doltlite_comparison.sh ./doltlite
- bash test/doltlite_history.sh ./doltlite
- bash test/doltlite_diff_table.sh ./doltlite
- bash test/doltlite_schema_diff.sh ./doltlite
- bash test/vc_oracle_blame_test.sh ./doltlite
- bash test/vc_oracle_diff_stat_test.sh ./doltlite