### PR TITLE
Share dynamic schema column builder

### DIFF
--- a/src/doltlite_at.c
+++ b/src/doltlite_at.c
@@ -14,17 +14,13 @@
 #include <time.h>
 
 static char *atBuildSchema(DoltliteColInfo *ci){
-  int i;
   sqlite3_str *pStr = sqlite3_str_new(0);
   char *z;
   if( !pStr ) return 0;
   sqlite3_str_appendall(pStr, "CREATE TABLE x(");
-  for(i=0; i<ci->nCol; i++){
-    if( i>0 ) sqlite3_str_appendall(pStr, ", ");
-    if( doltliteAppendQuotedIdent(pStr, ci->azName[i])!=SQLITE_OK ){
-      sqlite3_str_reset(pStr);
-      return 0;
-    }
+  if( doltliteAppendQuotedColumnList(pStr, ci->azName, ci->nCol, 0, 0)!=SQLITE_OK ){
+    sqlite3_str_reset(pStr);
+    return 0;
   }
   sqlite3_str_appendall(pStr, ", commit_ref TEXT HIDDEN)");
   z = sqlite3_str_finish(pStr);

--- a/src/doltlite_blame.c
+++ b/src/doltlite_blame.c
@@ -169,15 +169,11 @@ static void blameFreePkColumns(char **azNames, int *aColIdx, int nCols){
 static char *blameBuildSchema(BlameVtab *v){
   sqlite3_str *pStr = sqlite3_str_new(0);
   char *z;
-  int i;
   if( !pStr ) return 0;
   sqlite3_str_appendall(pStr, "CREATE TABLE x(");
-  for(i=0; i<v->nPkCols; i++){
-    if( i>0 ) sqlite3_str_appendall(pStr, ", ");
-    if( doltliteAppendQuotedIdent(pStr, v->azPkNames[i])!=SQLITE_OK ){
-      sqlite3_str_reset(pStr);
-      return 0;
-    }
+  if( doltliteAppendQuotedColumnList(pStr, v->azPkNames, v->nPkCols, 0, 0)!=SQLITE_OK ){
+    sqlite3_str_reset(pStr);
+    return 0;
   }
   if( v->nPkCols>0 ) sqlite3_str_appendall(pStr, ", ");
   sqlite3_str_appendall(pStr,

--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -371,22 +371,31 @@ struct CfRowCur {
 
 static char *cfrBuildSchema(const DoltliteColInfo *ci){
   sqlite3_str *pStr = sqlite3_str_new(0);
-  int i;
   char *z;
   if( !pStr ) return 0;
   sqlite3_str_appendall(pStr, "CREATE TABLE x(from_root_ish TEXT");
 
-  for(i=0; i<ci->nCol; i++){
-    sqlite3_str_appendf(pStr, ", \"base_%w\"", ci->azName[i]);
-  }
+  if( ci->nCol>0 ){
+    sqlite3_str_appendall(pStr, ", ");
+    if( doltliteAppendQuotedColumnList(pStr, ci->azName, ci->nCol, "base_", ", ")!=SQLITE_OK ){
+      sqlite3_str_reset(pStr);
+      return 0;
+    }
 
-  for(i=0; i<ci->nCol; i++){
-    sqlite3_str_appendf(pStr, ", \"our_%w\"", ci->azName[i]);
+    sqlite3_str_appendall(pStr, ", ");
+    if( doltliteAppendQuotedColumnList(pStr, ci->azName, ci->nCol, "our_", ", ")!=SQLITE_OK ){
+      sqlite3_str_reset(pStr);
+      return 0;
+    }
   }
   sqlite3_str_appendall(pStr, ", our_diff_type TEXT");
 
-  for(i=0; i<ci->nCol; i++){
-    sqlite3_str_appendf(pStr, ", \"their_%w\"", ci->azName[i]);
+  if( ci->nCol>0 ){
+    sqlite3_str_appendall(pStr, ", ");
+    if( doltliteAppendQuotedColumnList(pStr, ci->azName, ci->nCol, "their_", ", ")!=SQLITE_OK ){
+      sqlite3_str_reset(pStr);
+      return 0;
+    }
   }
   sqlite3_str_appendall(pStr, ", their_diff_type TEXT");
   sqlite3_str_appendall(pStr, ", dolt_conflict_id TEXT");

--- a/src/doltlite_constraint_violations.c
+++ b/src/doltlite_constraint_violations.c
@@ -479,11 +479,15 @@ struct CvRowCur {
 
 static char *cvrBuildSchema(const DoltliteColInfo *ci){
   sqlite3_str *pStr = sqlite3_str_new(0);
-  int i;
   char *z;
+  if( !pStr ) return 0;
   sqlite3_str_appendall(pStr, "CREATE TABLE x(violation_type TEXT");
-  for(i=0; i<ci->nCol; i++){
-    sqlite3_str_appendf(pStr, ", \"%w\"", ci->azName[i]);
+  if( ci->nCol>0 ){
+    sqlite3_str_appendall(pStr, ", ");
+    if( doltliteAppendQuotedColumnList(pStr, ci->azName, ci->nCol, 0, 0)!=SQLITE_OK ){
+      sqlite3_str_reset(pStr);
+      return 0;
+    }
   }
   sqlite3_str_appendall(pStr, ", violation_info TEXT)");
   z = sqlite3_str_finish(pStr);

--- a/src/doltlite_history.c
+++ b/src/doltlite_history.c
@@ -15,17 +15,13 @@
 #include <time.h>
 
 static char *htBuildSchema(DoltliteColInfo *ci){
-  int i;
   sqlite3_str *pStr = sqlite3_str_new(0);
   char *z;
   if( !pStr ) return 0;
   sqlite3_str_appendall(pStr, "CREATE TABLE x(");
-  for(i=0; i<ci->nCol; i++){
-    if( i>0 ) sqlite3_str_appendall(pStr, ", ");
-    if( doltliteAppendQuotedIdent(pStr, ci->azName[i])!=SQLITE_OK ){
-      sqlite3_str_reset(pStr);
-      return 0;
-    }
+  if( doltliteAppendQuotedColumnList(pStr, ci->azName, ci->nCol, 0, 0)!=SQLITE_OK ){
+    sqlite3_str_reset(pStr);
+    return 0;
   }
   sqlite3_str_appendall(pStr, ", commit_hash TEXT, committer TEXT, commit_date TEXT)");
   z = sqlite3_str_finish(pStr);

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -141,6 +141,23 @@ static SQLITE_INLINE int doltliteVtabOpenCursor(
   return SQLITE_OK;
 }
 
+static SQLITE_INLINE int doltliteAppendQuotedColumnList(
+  sqlite3_str *pStr,
+  char *const *azName,
+  int nName,
+  const char *zPrefix,
+  const char *zSep
+){
+  int i;
+  if( !zPrefix ) zPrefix = "";
+  if( !zSep ) zSep = ", ";
+  for(i=0; i<nName; i++){
+    if( i>0 ) sqlite3_str_appendall(pStr, zSep);
+    sqlite3_str_appendf(pStr, "\"%s%w\"", zPrefix, azName[i]);
+  }
+  return sqlite3_str_errcode(pStr);
+}
+
 static SQLITE_INLINE int doltliteFindTableRootByName(
   struct TableEntry *a, int n, const char *zName,
   ProllyHash *pRoot, u8 *pFlags


### PR DESCRIPTION
## Summary
- add a shared helper for appending quoted dynamic virtual-table column lists
- use it in dolt_at, dolt_history, dolt_blame, dolt_conflicts, and dolt_constraint_violations schema builders
- preserve module-specific schema prefixes/suffixes while removing repeated quoted-column loops

## Tests
- make doltlite
- bash test/doltlite_at.sh ./doltlite
- bash test/doltlite_history.sh ./doltlite
- bash test/doltlite_conflicts.sh ./doltlite
- bash test/doltlite_conflict_rows.sh ./doltlite
- bash test/vc_oracle_fk_merge_test.sh ./doltlite
- bash test/vc_oracle_blame_test.sh ./doltlite
- bash test/doltlite_schema_diff.sh ./doltlite
- bash test/doltlite_diff_table.sh ./doltlite