### PR TITLE
Dedup prolly_* layer

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -7826,11 +7826,11 @@ struct Pager *sqlite3BtreePager(Btree *p){
   return p->pOps->xPager(p);
 }
 
-static int prollyBtCursorCount(sqlite3 *db, BtCursor *pCur, i64 *pnEntry){
-  struct TableEntry *pTE;
-  (void)db;
-
-  pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
+/* Drain any pending mutations for this cursor's table into the tree root so a
+** count walks committed data. Mirrors the snapshot/apply/clear sequence used
+** on the write path. */
+static int flushPendingForCount(BtCursor *pCur){
+  struct TableEntry *pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
   if( pTE && pTE->pPending ){
     ProllyMutMap *pMap = (ProllyMutMap*)pTE->pPending;
     if( !prollyMutMapIsEmpty(pMap) ){
@@ -7852,6 +7852,14 @@ static int prollyBtCursorCount(sqlite3 *db, BtCursor *pCur, i64 *pnEntry){
     }
   }
   flushIfNeeded(pCur);
+  return SQLITE_OK;
+}
+
+static int prollyBtCursorCount(sqlite3 *db, BtCursor *pCur, i64 *pnEntry){
+  int rc;
+  (void)db;
+  rc = flushPendingForCount(pCur);
+  if( rc!=SQLITE_OK ) return rc;
   return countTreeEntries(pCur->pBtree, pCur->pgnoRoot, pnEntry);
 }
 
@@ -7862,31 +7870,10 @@ static int prollyBtCursorCountRange(
   i64 iUpper,
   i64 *pnEntry
 ){
-  struct TableEntry *pTE;
+  int rc;
   (void)db;
-
-  pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
-  if( pTE && pTE->pPending ){
-    ProllyMutMap *pMap = (ProllyMutMap*)pTE->pPending;
-    if( !prollyMutMapIsEmpty(pMap) ){
-      ProllyMutMap *pFlushMap = pMap;
-      int captured = 0;
-      int rc = snapshotPendingForFlush(pCur->pBtree, pCur->pgnoRoot,
-                                       (ProllyMutMap**)&pTE->pPending,
-                                       &pFlushMap, &captured);
-      if( rc!=SQLITE_OK ) return rc;
-      if( captured ){
-        refreshCursorMutMapAliases(pCur->pBtree, pCur->pBt, pCur->pgnoRoot,
-                                   (ProllyMutMap*)pTE->pPending);
-      }
-      rc = applyMutMapToTableRoot(pCur->pBt, pTE, pFlushMap);
-      if( rc!=SQLITE_OK ) return rc;
-      if( pTE->pPending==pMap ){
-        prollyMutMapClear(pMap);
-      }
-    }
-  }
-  flushIfNeeded(pCur);
+  rc = flushPendingForCount(pCur);
+  if( rc!=SQLITE_OK ) return rc;
   return countTreeIntRange(pCur->pBtree, pCur->pgnoRoot,
                            iLower, iUpper, pnEntry);
 }
@@ -7898,32 +7885,11 @@ static int prollyBtCursorCountIndexRange(
   UnpackedRecord *pUpper,
   i64 *pnEntry
 ){
-  struct TableEntry *pTE;
+  int rc;
   (void)db;
-
   if( pCur->curIntKey ) return SQLITE_NOTFOUND;
-  pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
-  if( pTE && pTE->pPending ){
-    ProllyMutMap *pMap = (ProllyMutMap*)pTE->pPending;
-    if( !prollyMutMapIsEmpty(pMap) ){
-      ProllyMutMap *pFlushMap = pMap;
-      int captured = 0;
-      int rc = snapshotPendingForFlush(pCur->pBtree, pCur->pgnoRoot,
-                                       (ProllyMutMap**)&pTE->pPending,
-                                       &pFlushMap, &captured);
-      if( rc!=SQLITE_OK ) return rc;
-      if( captured ){
-        refreshCursorMutMapAliases(pCur->pBtree, pCur->pBt, pCur->pgnoRoot,
-                                   (ProllyMutMap*)pTE->pPending);
-      }
-      rc = applyMutMapToTableRoot(pCur->pBt, pTE, pFlushMap);
-      if( rc!=SQLITE_OK ) return rc;
-      if( pTE->pPending==pMap ){
-        prollyMutMapClear(pMap);
-      }
-    }
-  }
-  flushIfNeeded(pCur);
+  rc = flushPendingForCount(pCur);
+  if( rc!=SQLITE_OK ) return rc;
   return countTreeBlobPrefixRange(pCur, pLower, pUpper, pnEntry);
 }
 

--- a/src/prolly_cache.c
+++ b/src/prolly_cache.c
@@ -122,61 +122,22 @@ ProllyCacheEntry *prollyCachePut(
   int nData,
   int *pRc
 ){
-  int iBucket;
   ProllyCacheEntry *pEntry;
   u8 *pCopy;
-  int rc;
-
-  if( pRc ) *pRc = SQLITE_OK;
 
   pEntry = prollyCacheGet(cache, hash);
   if( pEntry ){
+    if( pRc ) *pRc = SQLITE_OK;
     return pEntry;
-  }
-
-  pEntry = 0;
-  if( cache->nUsed>=cache->nCapacity ){
-    pEntry = cacheEvictOne(cache);
-  }
-
-  if( pEntry==0 ){
-    pEntry = (ProllyCacheEntry *)sqlite3_malloc(sizeof(ProllyCacheEntry));
-    if( pEntry==0 ){
-      if( pRc ) *pRc = SQLITE_NOMEM;
-      return 0;
-    }
-    memset(pEntry, 0, sizeof(*pEntry));
   }
 
   pCopy = (u8 *)sqlite3_malloc(nData);
   if( pCopy==0 ){
     if( pRc ) *pRc = SQLITE_NOMEM;
-    sqlite3_free(pEntry);
     return 0;
   }
   memcpy(pCopy, pData, nData);
-
-  memcpy(pEntry->hash.data, hash->data, PROLLY_HASH_SIZE);
-  pEntry->pData = pCopy;
-  pEntry->nData = nData;
-  pEntry->nRef = 1;
-
-  rc = prollyNodeParse(&pEntry->node, pCopy, nData);
-  if( rc!=SQLITE_OK ){
-    if( pRc ) *pRc = rc;
-    sqlite3_free(pCopy);
-    sqlite3_free(pEntry);
-    return 0;
-  }
-
-  iBucket = cacheHashBucket(cache, hash);
-  pEntry->pHashNext = cache->aBucket[iBucket];
-  cache->aBucket[iBucket] = pEntry;
-
-  lruInsertHead(cache, pEntry);
-
-  cache->nUsed++;
-  return pEntry;
+  return prollyCachePutOwned(cache, hash, pCopy, nData, pRc);
 }
 
 ProllyCacheEntry *prollyCachePutOwned(

--- a/src/prolly_chunker.c
+++ b/src/prolly_chunker.c
@@ -49,31 +49,25 @@ static void builderLastKey(ProllyNodeBuilder *b,
   *pnKey = (int)(off1 - off0);
 }
 
+static void resetLevel(ProllyChunkerLevel *pLevel){
+  prollyNodeBuilderReset(&pLevel->builder);
+  pLevel->nItems = 0;
+  pLevel->nBytes = 0;
+  pLevel->subtreeCount = 0;
+}
+
 static int flushLevel(ProllyChunker *ch, int level){
   ProllyChunkerLevel *pLevel = &ch->aLevel[level];
-  u8 *pData = 0;
-  int nData = 0;
   ProllyHash hash;
   const u8 *pLastKey;
   int nLastKey;
   u64 flushedCount;
   int rc;
 
-  assert( pLevel->builder.nItems > 0 );
-
   builderLastKey(&pLevel->builder, &pLastKey, &nLastKey);
   flushedCount = pLevel->subtreeCount;
 
-  rc = prollyNodeBuilderFinish(&pLevel->builder, &pData, &nData);
-  if( rc!=SQLITE_OK ) return rc;
-
-  rc = chunkStorePut(ch->pStore, pData, nData, &hash);
-  if( rc==SQLITE_OK && ch->pCache ){
-    ProllyCacheEntry *pEntry;
-    pEntry = prollyCachePut(ch->pCache, &hash, pData, nData, &rc);
-    if( pEntry ) prollyCacheRelease(ch->pCache, pEntry);
-  }
-  sqlite3_free(pData);
+  rc = finishFlushLevel(ch, level, &hash);
   if( rc!=SQLITE_OK ) return rc;
 
   if( level + 1 >= PROLLY_CURSOR_MAX_DEPTH ){
@@ -86,11 +80,7 @@ static int flushLevel(ProllyChunker *ch, int level){
                   flushedCount);
   if( rc!=SQLITE_OK ) return rc;
 
-  prollyNodeBuilderReset(&pLevel->builder);
-  pLevel->nItems = 0;
-  pLevel->nBytes = 0;
-  pLevel->subtreeCount = 0;
-
+  resetLevel(pLevel);
   return SQLITE_OK;
 }
 
@@ -145,10 +135,7 @@ static int finishPropagateLevel(ProllyChunker *ch, int level){
                   hash.data, PROLLY_HASH_SIZE, flushedCount);
   if( rc!=SQLITE_OK ) return rc;
 
-  prollyNodeBuilderReset(&pLevel->builder);
-  pLevel->nItems = 0;
-  pLevel->nBytes = 0;
-  pLevel->subtreeCount = 0;
+  resetLevel(pLevel);
   return SQLITE_OK;
 }
 

--- a/src/prolly_diff.c
+++ b/src/prolly_diff.c
@@ -579,6 +579,26 @@ static void diffIterFreeCopies(ProllyDiffIter *pIter){
   pIter->nNewValCopy = 0;
 }
 
+/* Copy a cursor value into the iterator-owned buffer and point the change at
+** it. On OOM sets pIter->rc and returns SQLITE_NOMEM; nSrc==0 leaves an empty
+** (null) value. */
+static int diffSetChangeVal(
+  ProllyDiffIter *pIter,
+  u8 **ppCopy, int *pnCopy,
+  const u8 **ppOut, int *pnOut,
+  const u8 *pSrc, int nSrc
+){
+  if( nSrc > 0 ){
+    *ppCopy = sqlite3_malloc(nSrc);
+    if( !*ppCopy ){ pIter->rc = SQLITE_NOMEM; return SQLITE_NOMEM; }
+    memcpy(*ppCopy, pSrc, nSrc);
+    *pnCopy = nSrc;
+  }
+  *ppOut = *ppCopy;
+  *pnOut = *pnCopy;
+  return SQLITE_OK;
+}
+
 int prollyDiffIterOpen(
   ProllyDiffIter *pIter,
   ChunkStore *pStore,
@@ -666,14 +686,8 @@ int prollyDiffIterStep(ProllyDiffIter *pIter, ProllyDiffChange **ppChange){
         pIter->rc = diffIterCopyKey(pIter, pCh, pOld, pIter->flags);
         if( pIter->rc!=SQLITE_OK ) return pIter->rc;
         prollyCursorValue(pOld, &pVal, &nVal);
-        if( nVal > 0 ){
-          pIter->pOldValCopy = sqlite3_malloc(nVal);
-          if( !pIter->pOldValCopy ){ pIter->rc = SQLITE_NOMEM; return SQLITE_NOMEM; }
-          memcpy(pIter->pOldValCopy, pVal, nVal);
-          pIter->nOldValCopy = nVal;
-        }
-        pCh->pOldVal = pIter->pOldValCopy;
-        pCh->nOldVal = pIter->nOldValCopy;
+        if( diffSetChangeVal(pIter, &pIter->pOldValCopy, &pIter->nOldValCopy,
+                             &pCh->pOldVal, &pCh->nOldVal, pVal, nVal) ) return SQLITE_NOMEM;
         pIter->rc = prollyCursorNext(pOld);
         break;
       }else if( cmp > 0 ){
@@ -683,14 +697,8 @@ int prollyDiffIterStep(ProllyDiffIter *pIter, ProllyDiffChange **ppChange){
         pIter->rc = diffIterCopyKey(pIter, pCh, pNew, pIter->flags);
         if( pIter->rc!=SQLITE_OK ) return pIter->rc;
         prollyCursorValue(pNew, &pVal, &nVal);
-        if( nVal > 0 ){
-          pIter->pNewValCopy = sqlite3_malloc(nVal);
-          if( !pIter->pNewValCopy ){ pIter->rc = SQLITE_NOMEM; return SQLITE_NOMEM; }
-          memcpy(pIter->pNewValCopy, pVal, nVal);
-          pIter->nNewValCopy = nVal;
-        }
-        pCh->pNewVal = pIter->pNewValCopy;
-        pCh->nNewVal = pIter->nNewValCopy;
+        if( diffSetChangeVal(pIter, &pIter->pNewValCopy, &pIter->nNewValCopy,
+                             &pCh->pNewVal, &pCh->nNewVal, pVal, nVal) ) return SQLITE_NOMEM;
         pIter->rc = prollyCursorNext(pNew);
         break;
       }else{
@@ -710,22 +718,10 @@ int prollyDiffIterStep(ProllyDiffIter *pIter, ProllyDiffChange **ppChange){
           if( pIter->rc!=SQLITE_OK ) return pIter->rc;
           prollyCursorValue(pOld, &pOV, &nOV);
           prollyCursorValue(pNew, &pNV, &nNV);
-          if( nOV > 0 ){
-            pIter->pOldValCopy = sqlite3_malloc(nOV);
-            if( !pIter->pOldValCopy ){ pIter->rc = SQLITE_NOMEM; return SQLITE_NOMEM; }
-            memcpy(pIter->pOldValCopy, pOV, nOV);
-            pIter->nOldValCopy = nOV;
-          }
-          if( nNV > 0 ){
-            pIter->pNewValCopy = sqlite3_malloc(nNV);
-            if( !pIter->pNewValCopy ){ pIter->rc = SQLITE_NOMEM; return SQLITE_NOMEM; }
-            memcpy(pIter->pNewValCopy, pNV, nNV);
-            pIter->nNewValCopy = nNV;
-          }
-          pCh->pOldVal = pIter->pOldValCopy;
-          pCh->nOldVal = pIter->nOldValCopy;
-          pCh->pNewVal = pIter->pNewValCopy;
-          pCh->nNewVal = pIter->nNewValCopy;
+          if( diffSetChangeVal(pIter, &pIter->pOldValCopy, &pIter->nOldValCopy,
+                               &pCh->pOldVal, &pCh->nOldVal, pOV, nOV) ) return SQLITE_NOMEM;
+          if( diffSetChangeVal(pIter, &pIter->pNewValCopy, &pIter->nNewValCopy,
+                               &pCh->pNewVal, &pCh->nNewVal, pNV, nNV) ) return SQLITE_NOMEM;
           pIter->rc = prollyCursorNext(pOld);
           if( pIter->rc==SQLITE_OK ) pIter->rc = prollyCursorNext(pNew);
           break;
@@ -738,14 +734,8 @@ int prollyDiffIterStep(ProllyDiffIter *pIter, ProllyDiffChange **ppChange){
       pIter->rc = diffIterCopyKey(pIter, pCh, pOld, pIter->flags);
       if( pIter->rc!=SQLITE_OK ) return pIter->rc;
       prollyCursorValue(pOld, &pVal, &nVal);
-      if( nVal > 0 ){
-        pIter->pOldValCopy = sqlite3_malloc(nVal);
-        if( !pIter->pOldValCopy ){ pIter->rc = SQLITE_NOMEM; return SQLITE_NOMEM; }
-        memcpy(pIter->pOldValCopy, pVal, nVal);
-        pIter->nOldValCopy = nVal;
-      }
-      pCh->pOldVal = pIter->pOldValCopy;
-      pCh->nOldVal = pIter->nOldValCopy;
+      if( diffSetChangeVal(pIter, &pIter->pOldValCopy, &pIter->nOldValCopy,
+                           &pCh->pOldVal, &pCh->nOldVal, pVal, nVal) ) return SQLITE_NOMEM;
       pIter->rc = prollyCursorNext(pOld);
       break;
     }else{
@@ -755,14 +745,8 @@ int prollyDiffIterStep(ProllyDiffIter *pIter, ProllyDiffChange **ppChange){
       pIter->rc = diffIterCopyKey(pIter, pCh, pNew, pIter->flags);
       if( pIter->rc!=SQLITE_OK ) return pIter->rc;
       prollyCursorValue(pNew, &pVal, &nVal);
-      if( nVal > 0 ){
-        pIter->pNewValCopy = sqlite3_malloc(nVal);
-        if( !pIter->pNewValCopy ){ pIter->rc = SQLITE_NOMEM; return SQLITE_NOMEM; }
-        memcpy(pIter->pNewValCopy, pVal, nVal);
-        pIter->nNewValCopy = nVal;
-      }
-      pCh->pNewVal = pIter->pNewValCopy;
-      pCh->nNewVal = pIter->nNewValCopy;
+      if( diffSetChangeVal(pIter, &pIter->pNewValCopy, &pIter->nNewValCopy,
+                           &pCh->pNewVal, &pCh->nNewVal, pVal, nVal) ) return SQLITE_NOMEM;
       pIter->rc = prollyCursorNext(pNew);
       break;
     }

--- a/src/prolly_mutate.c
+++ b/src/prolly_mutate.c
@@ -312,100 +312,78 @@ streaming_cleanup:
   return rc;
 }
 
-static void nodeAppendState(const ProllyNode *pNode,
-                            const u8 *pKey, int nKey,
-                            int nVal,
-                            int *pEndsAtBoundary,
-                            int *pWouldSplit){
-  int i;
-  int nBytes = 0;
-  int thisSize = PROLLY_NODE_ENTRY_BYTES(pNode->level, nKey, nVal);
-  int endsAtBoundary = 0;
-  int wouldSplit = 0;
-
-  for(i=0; i<(int)pNode->nItems; i++){
-    const u8 *pK, *pV;
-    int nK, nV;
-    prollyNodeKey(pNode, i, &pK, &nK);
-    prollyNodeValue(pNode, i, &pV, &nV);
-    (void)pK; (void)pV;
-    nBytes += PROLLY_NODE_ENTRY_BYTES(pNode->level, nK, nV);
-  }
-  if( pNode->nItems>0 && nBytes >= PROLLY_CHUNK_MAX ){
-    endsAtBoundary = 1;
-  }else if( pNode->nItems>0 && nBytes >= PROLLY_CHUNK_MIN ){
-    const u8 *pLastKey, *pLastVal;
-    int nLastKey, nLastVal;
-    u32 h;
-    prollyNodeKey(pNode, (int)pNode->nItems - 1, &pLastKey, &nLastKey);
-    prollyNodeValue(pNode, (int)pNode->nItems - 1, &pLastVal, &nLastVal);
-    (void)pLastVal;
-    h = prollyXXH32(pLastKey, nLastKey, (u32)pNode->level);
-    endsAtBoundary = prollyWeibullCheck((u32)nBytes,
-                                        (u32)PROLLY_NODE_ENTRY_BYTES(
-                                          pNode->level, nLastKey, nLastVal),
-                                        h);
-  }
-
-  nBytes += thisSize;
-  if( nBytes >= PROLLY_CHUNK_MAX ){
-    wouldSplit = 1;
-  }else if( nBytes >= PROLLY_CHUNK_MIN ){
-    u32 h = prollyXXH32(pKey, nKey, 0);
-    wouldSplit = prollyWeibullCheck((u32)nBytes, (u32)thisSize, h);
-  }
-
-  *pEndsAtBoundary = endsAtBoundary;
-  *pWouldSplit = wouldSplit;
-}
-
-static int appendWouldSplitNode(const ProllyNode *pNode,
-                                const u8 *pKey, int nKey,
-                                int nVal){
-  int i;
-  int nBytes = 0;
-  int thisSize = PROLLY_NODE_ENTRY_BYTES(pNode->level, nKey, nVal);
-  for(i=0; i<(int)pNode->nItems; i++){
-    const u8 *pK, *pV;
-    int nK, nV;
-    prollyNodeKey(pNode, i, &pK, &nK);
-    prollyNodeValue(pNode, i, &pV, &nV);
-    (void)pK; (void)pV;
-    nBytes += PROLLY_NODE_ENTRY_BYTES(pNode->level, nK, nV);
-  }
-  nBytes += thisSize;
+/* Boundary predicate shared with the chunker (prolly_chunker.c addToLevel): an
+** entry of thisSize bytes whose key is pKey closes a chunk when the running
+** byte count reaches PROLLY_CHUNK_MAX, or PROLLY_CHUNK_MIN and the Weibull
+** roll fires. Seeded with the node level so leaves and internal nodes match
+** the shapes the chunker produces. */
+static int chunkBoundary(int nBytes, int thisSize,
+                         const u8 *pKey, int nKey, u8 level){
   if( nBytes >= PROLLY_CHUNK_MAX ) return 1;
   if( nBytes >= PROLLY_CHUNK_MIN ){
-    u32 h = prollyXXH32(pKey, nKey, (u32)pNode->level);
+    u32 h = prollyXXH32(pKey, nKey, (u32)level);
     return prollyWeibullCheck((u32)nBytes, (u32)thisSize, h);
   }
   return 0;
 }
 
+static int nodeTotalBytes(const ProllyNode *pNode){
+  int i;
+  int nBytes = 0;
+  for(i=0; i<(int)pNode->nItems; i++){
+    const u8 *pK, *pV;
+    int nK, nV;
+    prollyNodeKey(pNode, i, &pK, &nK);
+    prollyNodeValue(pNode, i, &pV, &nV);
+    (void)pK; (void)pV;
+    nBytes += PROLLY_NODE_ENTRY_BYTES(pNode->level, nK, nV);
+  }
+  return nBytes;
+}
+
+static void nodeAppendState(const ProllyNode *pNode,
+                            const u8 *pKey, int nKey,
+                            int nVal,
+                            int *pEndsAtBoundary,
+                            int *pWouldSplit){
+  int nBytes = nodeTotalBytes(pNode);
+  int thisSize = PROLLY_NODE_ENTRY_BYTES(pNode->level, nKey, nVal);
+
+  *pEndsAtBoundary = 0;
+  if( pNode->nItems>0 ){
+    const u8 *pLastKey, *pLastVal;
+    int nLastKey, nLastVal;
+    prollyNodeKey(pNode, (int)pNode->nItems - 1, &pLastKey, &nLastKey);
+    prollyNodeValue(pNode, (int)pNode->nItems - 1, &pLastVal, &nLastVal);
+    *pEndsAtBoundary = chunkBoundary(nBytes,
+        PROLLY_NODE_ENTRY_BYTES(pNode->level, nLastKey, nLastVal),
+        pLastKey, nLastKey, pNode->level);
+  }
+
+  *pWouldSplit = chunkBoundary(nBytes + thisSize, thisSize,
+                               pKey, nKey, pNode->level);
+}
+
+static int appendWouldSplitNode(const ProllyNode *pNode,
+                                const u8 *pKey, int nKey,
+                                int nVal){
+  int thisSize = PROLLY_NODE_ENTRY_BYTES(pNode->level, nKey, nVal);
+  int nBytes = nodeTotalBytes(pNode) + thisSize;
+  return chunkBoundary(nBytes, thisSize, pKey, nKey, pNode->level);
+}
+
 static int nodeEndsAtChunkBoundary(const ProllyNode *pNode){
   const u8 *pKey, *pVal;
   int nKey, nVal;
-  int nBytes = 0;
-  int i;
+  int nBytes;
 
   if( pNode->nItems==0 ) return 0;
-  for(i=0; i<(int)pNode->nItems; i++){
-    prollyNodeKey(pNode, i, &pKey, &nKey);
-    prollyNodeValue(pNode, i, &pVal, &nVal);
-    (void)pVal;
-    nBytes += PROLLY_NODE_ENTRY_BYTES(pNode->level, nKey, nVal);
-  }
-  if( nBytes >= PROLLY_CHUNK_MAX ) return 1;
-  if( nBytes >= PROLLY_CHUNK_MIN ){
-    u32 h;
-    prollyNodeKey(pNode, (int)pNode->nItems - 1, &pKey, &nKey);
-    prollyNodeValue(pNode, (int)pNode->nItems - 1, &pVal, &nVal);
-    h = prollyXXH32(pKey, nKey, (u32)pNode->level);
-    return prollyWeibullCheck((u32)nBytes,
-                              (u32)PROLLY_NODE_ENTRY_BYTES(pNode->level,
-                                                           nKey, nVal), h);
-  }
-  return 0;
+  nBytes = nodeTotalBytes(pNode);
+  prollyNodeKey(pNode, (int)pNode->nItems - 1, &pKey, &nKey);
+  prollyNodeValue(pNode, (int)pNode->nItems - 1, &pVal, &nVal);
+  return chunkBoundary(nBytes,
+                       PROLLY_NODE_ENTRY_BYTES(pNode->level, nKey, nVal),
+                       pKey, nKey, pNode->level);
 }
 
 static int nodeHasSameChunkShape(const ProllyNode *pNode,
@@ -417,7 +395,7 @@ static int nodeHasSameChunkShape(const ProllyNode *pNode,
 
   if( pNode->nItems==0 ) return 0;
   for(i=0; i<(int)pNode->nItems; i++){
-    int isBoundary = 0;
+    int isBoundary;
     int thisSize;
 
     prollyNodeKey(pNode, i, &pKey, &nKey);
@@ -425,12 +403,7 @@ static int nodeHasSameChunkShape(const ProllyNode *pNode,
     (void)pVal;
     thisSize = PROLLY_NODE_ENTRY_BYTES(pNode->level, nKey, nVal);
     nBytes += thisSize;
-    if( nBytes >= PROLLY_CHUNK_MAX ){
-      isBoundary = 1;
-    }else if( nBytes >= PROLLY_CHUNK_MIN ){
-      u32 h = prollyXXH32(pKey, nKey, (u32)pNode->level);
-      isBoundary = prollyWeibullCheck((u32)nBytes, (u32)thisSize, h);
-    }
+    isBoundary = chunkBoundary(nBytes, thisSize, pKey, nKey, pNode->level);
 
     if( i<(int)pNode->nItems - 1 && isBoundary ){
       return 0;

--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -12,24 +12,8 @@
 #define MUTMAP_RADIX_SORT_MIN 128
 
 i64 prollyMutMapEntryIntKey(const ProllyMutMapEntry *e){
-  const u8 *p = e->pKey;
-  u64 u;
-  if( e->nKey != 8 || p == 0 ) return 0;
-  u = ((u64)p[0]<<56) | ((u64)p[1]<<48) | ((u64)p[2]<<40) | ((u64)p[3]<<32)
-    | ((u64)p[4]<<24) | ((u64)p[5]<<16) | ((u64)p[6]<<8) | (u64)p[7];
-  return (i64)(u ^ ((u64)1 << 63));
-}
-
-static void encodeIntKeyBE(i64 v, u8 buf[8]){
-  u64 u = ((u64)v) ^ ((u64)1 << 63);
-  buf[0] = (u8)(u >> 56);
-  buf[1] = (u8)(u >> 48);
-  buf[2] = (u8)(u >> 40);
-  buf[3] = (u8)(u >> 32);
-  buf[4] = (u8)(u >> 24);
-  buf[5] = (u8)(u >> 16);
-  buf[6] = (u8)(u >> 8);
-  buf[7] = (u8)u;
+  if( e->nKey != 8 || e->pKey == 0 ) return 0;
+  return prollyDecodeIntKey(e->pKey);
 }
 
 static void prepKey(ProllyMutMap *mm,
@@ -40,7 +24,7 @@ static void prepKey(ProllyMutMap *mm,
     assert( intKey == 0 );
     return;
   }
-  encodeIntKeyBE(intKey, buf);
+  prollyEncodeIntKey(intKey, buf);
   *ppKey = buf;
   *pnKey = 8;
 }

--- a/src/prolly_node.c
+++ b/src/prolly_node.c
@@ -152,17 +152,17 @@ void prollyEncodeIntKey(i64 v, u8 buf[8]){
   buf[7] = (u8)u;
 }
 
+i64 prollyDecodeIntKey(const u8 *p){
+  u64 u = ((u64)p[0]<<56) | ((u64)p[1]<<48) | ((u64)p[2]<<40) | ((u64)p[3]<<32)
+        | ((u64)p[4]<<24) | ((u64)p[5]<<16) | ((u64)p[6]<<8) | (u64)p[7];
+  return (i64)(u ^ ((u64)1 << 63));
+}
+
 i64 prollyNodeIntKey(const ProllyNode *pNode, int i){
   u32 off;
-  const u8 *p;
-  u64 u;
   assert( i >= 0 && i < (int)pNode->nItems );
   off = PROLLY_GET_U32((const u8*)&pNode->aKeyOff[i]);
-  p = pNode->pKeyData + off;
-
-  u = ((u64)p[0]<<56) | ((u64)p[1]<<48) | ((u64)p[2]<<40) | ((u64)p[3]<<32)
-    | ((u64)p[4]<<24) | ((u64)p[5]<<16) | ((u64)p[6]<<8) | (u64)p[7];
-  return (i64)(u ^ ((u64)1 << 63));
+  return prollyDecodeIntKey(pNode->pKeyData + off);
 }
 
 void prollyNodeChildHash(const ProllyNode *pNode, int i, ProllyHash *pHash){

--- a/src/prolly_node.h
+++ b/src/prolly_node.h
@@ -62,6 +62,8 @@ int prollyNodeSearchInt(const ProllyNode *pNode, i64 intKey, int *pRes);
 
 void prollyEncodeIntKey(i64 v, u8 buf[8]);
 
+i64 prollyDecodeIntKey(const u8 *p);
+
 typedef struct ProllyNodeBuilder ProllyNodeBuilder;
 struct ProllyNodeBuilder {
   u8 level;

--- a/src/prolly_three_way_merge.c
+++ b/src/prolly_three_way_merge.c
@@ -120,6 +120,57 @@ static int fmResolveAndEmit(
   return SQLITE_OK;
 }
 
+typedef struct FmKey FmKey;
+struct FmKey {
+  const u8 *p;
+  int n;
+  i64 i;
+  int has;
+};
+
+static void fmKeyFromNode(u8 flags, const ProllyNode *pN, int idx, FmKey *pK){
+  pK->p = 0; pK->n = 0; pK->i = 0;
+  pK->has = idx < (int)pN->nItems;
+  if( pK->has ){
+    prollyNodeKey(pN, idx, &pK->p, &pK->n);
+    if( flags & PROLLY_NODE_INTKEY ) pK->i = prollyNodeIntKey(pN, idx);
+  }
+}
+
+static void fmKeyFromCursor(u8 flags, ProllyCursor *pC, FmKey *pK){
+  pK->p = 0; pK->n = 0; pK->i = 0;
+  pK->has = prollyCursorIsValid(pC);
+  if( pK->has ){
+    prollyCursorKey(pC, &pK->p, &pK->n);
+    if( flags & PROLLY_NODE_INTKEY ) pK->i = prollyCursorIntKey(pC);
+  }
+}
+
+/* Pick the smallest of the three present keys into *pMin, then reset each
+** input's .has to whether that side actually holds the min key (the rest of
+** the merge advances exactly the sides flagged here). */
+static void fmSelectMinKey(u8 flags, FmKey *pA, FmKey *pO, FmKey *pT, FmKey *pMin){
+  FmKey *aSide[3];
+  int minSide = -1;
+  int s;
+  aSide[0] = pA; aSide[1] = pO; aSide[2] = pT;
+  for( s = 0; s < 3; s++ ){
+    if( !aSide[s]->has ) continue;
+    if( minSide < 0
+     || prollyCompareKeys(flags, aSide[s]->p, aSide[s]->n, aSide[s]->i,
+                          aSide[minSide]->p, aSide[minSide]->n, aSide[minSide]->i) < 0 ){
+      minSide = s;
+    }
+  }
+  *pMin = *aSide[minSide];
+  for( s = 0; s < 3; s++ ){
+    if( aSide[s]->has ){
+      aSide[s]->has = prollyCompareKeys(flags, aSide[s]->p, aSide[s]->n, aSide[s]->i,
+                                        pMin->p, pMin->n, pMin->i) == 0;
+    }
+  }
+}
+
 static int fmMergeLeaves(
   FmCtx *fm, ProllyChunker *pCh,
   const ProllyNode *pAncN,
@@ -132,92 +183,28 @@ static int fmMergeLeaves(
   while( ai < (int)pAncN->nItems
       || oi < (int)pOursN->nItems
       || ti < (int)pTheirsN->nItems ){
-    const u8 *pAK = 0, *pOK = 0, *pTK = 0;
-    int nAK = 0, nOK = 0, nTK = 0;
+    FmKey ka, ko, kt, kmin;
     const u8 *pAV = 0, *pOV = 0, *pTV = 0;
     int nAV = 0, nOV = 0, nTV = 0;
-    i64 iAKey = 0, iOKey = 0, iTKey = 0;
-    int has_a = 0, has_o = 0, has_t = 0;
-    const u8 *pK = 0;
-    int nK = 0;
-    i64 iK = 0;
 
-    if( ai < (int)pAncN->nItems ){
-      prollyNodeKey(pAncN, ai, &pAK, &nAK);
-      if( fm->flags & PROLLY_NODE_INTKEY ) iAKey = prollyNodeIntKey(pAncN, ai);
-    }
-    if( oi < (int)pOursN->nItems ){
-      prollyNodeKey(pOursN, oi, &pOK, &nOK);
-      if( fm->flags & PROLLY_NODE_INTKEY ) iOKey = prollyNodeIntKey(pOursN, oi);
-    }
-    if( ti < (int)pTheirsN->nItems ){
-      prollyNodeKey(pTheirsN, ti, &pTK, &nTK);
-      if( fm->flags & PROLLY_NODE_INTKEY ) iTKey = prollyNodeIntKey(pTheirsN, ti);
-    }
+    fmKeyFromNode(fm->flags, pAncN, ai, &ka);
+    fmKeyFromNode(fm->flags, pOursN, oi, &ko);
+    fmKeyFromNode(fm->flags, pTheirsN, ti, &kt);
+    fmSelectMinKey(fm->flags, &ka, &ko, &kt, &kmin);
 
-    {
-      int hasAny[3];
-      int minSide = -1;
-      int s;
-      const u8 *pCK; int nCK; i64 iCK;
-      const u8 *pMK; int nMK; i64 iMK;
-      int cmp;
+    if( ka.has ) prollyNodeValue(pAncN, ai, &pAV, &nAV);
+    if( ko.has ) prollyNodeValue(pOursN, oi, &pOV, &nOV);
+    if( kt.has ) prollyNodeValue(pTheirsN, ti, &pTV, &nTV);
 
-      hasAny[0] = (ai < (int)pAncN->nItems);
-      hasAny[1] = (oi < (int)pOursN->nItems);
-      hasAny[2] = (ti < (int)pTheirsN->nItems);
-
-      for( s = 0; s < 3; s++ ){
-        if( !hasAny[s] ) continue;
-        if( minSide < 0 ){ minSide = s; continue; }
-        if( s == 0 ){ pCK = pAK; nCK = nAK; iCK = iAKey; }
-        else if( s == 1 ){ pCK = pOK; nCK = nOK; iCK = iOKey; }
-        else { pCK = pTK; nCK = nTK; iCK = iTKey; }
-        if( minSide == 0 ){ pMK = pAK; nMK = nAK; iMK = iAKey; }
-        else if( minSide == 1 ){ pMK = pOK; nMK = nOK; iMK = iOKey; }
-        else { pMK = pTK; nMK = nTK; iMK = iTKey; }
-        cmp = prollyCompareKeys(fm->flags,
-                                 pCK, nCK, iCK,
-                                 pMK, nMK, iMK);
-        if( cmp < 0 ) minSide = s;
-      }
-      if( minSide == 0 ){ pK = pAK; nK = nAK; iK = iAKey; }
-      else if( minSide == 1 ){ pK = pOK; nK = nOK; iK = iOKey; }
-      else { pK = pTK; nK = nTK; iK = iTKey; }
-
-      if( hasAny[0] ){
-        cmp = prollyCompareKeys(fm->flags,
-                                 pAK, nAK, iAKey,
-                                 pK, nK, iK);
-        has_a = (cmp == 0);
-      }
-      if( hasAny[1] ){
-        cmp = prollyCompareKeys(fm->flags,
-                                     pOK, nOK, iOKey,
-                                     pK, nK, iK);
-        has_o = (cmp == 0);
-      }
-      if( hasAny[2] ){
-        cmp = prollyCompareKeys(fm->flags,
-                                 pTK, nTK, iTKey,
-                                 pK, nK, iK);
-        has_t = (cmp == 0);
-      }
-    }
-
-    if( has_a ) prollyNodeValue(pAncN, ai, &pAV, &nAV);
-    if( has_o ) prollyNodeValue(pOursN, oi, &pOV, &nOV);
-    if( has_t ) prollyNodeValue(pTheirsN, ti, &pTV, &nTV);
-
-    rc = fmResolveAndEmit(pCh, pK, nK,
-                           has_a, pAV, nAV,
-                           has_o, pOV, nOV,
-                           has_t, pTV, nTV);
+    rc = fmResolveAndEmit(pCh, kmin.p, kmin.n,
+                           ka.has, pAV, nAV,
+                           ko.has, pOV, nOV,
+                           kt.has, pTV, nTV);
     if( rc != SQLITE_OK ) return rc;
 
-    if( has_a ) ai++;
-    if( has_o ) oi++;
-    if( has_t ) ti++;
+    if( ka.has ) ai++;
+    if( ko.has ) oi++;
+    if( kt.has ) ti++;
   }
 
   return SQLITE_OK;
@@ -232,78 +219,28 @@ static int fmCursorMerge(
   while( prollyCursorIsValid(pAncC)
       || prollyCursorIsValid(pOursC)
       || prollyCursorIsValid(pTheirsC) ){
-    int hasAny[3];
-    const u8 *pAK = 0, *pOK = 0, *pTK = 0;
-    int nAK = 0, nOK = 0, nTK = 0;
-    i64 iAKey = 0, iOKey = 0, iTKey = 0;
+    FmKey ka, ko, kt, kmin;
     const u8 *pAV = 0, *pOV = 0, *pTV = 0;
     int nAV = 0, nOV = 0, nTV = 0;
-    int has_a = 0, has_o = 0, has_t = 0;
-    const u8 *pK; int nK; i64 iK;
-    int minSide = -1;
-    int s, cmp;
-    const u8 *pCK; int nCK; i64 iCK;
-    const u8 *pMK; int nMK; i64 iMK;
 
-    hasAny[0] = prollyCursorIsValid(pAncC);
-    hasAny[1] = prollyCursorIsValid(pOursC);
-    hasAny[2] = prollyCursorIsValid(pTheirsC);
+    fmKeyFromCursor(fm->flags, pAncC, &ka);
+    fmKeyFromCursor(fm->flags, pOursC, &ko);
+    fmKeyFromCursor(fm->flags, pTheirsC, &kt);
+    fmSelectMinKey(fm->flags, &ka, &ko, &kt, &kmin);
 
-    if( hasAny[0] ){
-      prollyCursorKey(pAncC, &pAK, &nAK);
-      if( fm->flags & PROLLY_NODE_INTKEY ) iAKey = prollyCursorIntKey(pAncC);
-    }
-    if( hasAny[1] ){
-      prollyCursorKey(pOursC, &pOK, &nOK);
-      if( fm->flags & PROLLY_NODE_INTKEY ) iOKey = prollyCursorIntKey(pOursC);
-    }
-    if( hasAny[2] ){
-      prollyCursorKey(pTheirsC, &pTK, &nTK);
-      if( fm->flags & PROLLY_NODE_INTKEY ) iTKey = prollyCursorIntKey(pTheirsC);
-    }
+    if( ka.has ) prollyCursorValue(pAncC, &pAV, &nAV);
+    if( ko.has ) prollyCursorValue(pOursC, &pOV, &nOV);
+    if( kt.has ) prollyCursorValue(pTheirsC, &pTV, &nTV);
 
-    for( s = 0; s < 3; s++ ){
-      if( !hasAny[s] ) continue;
-      if( minSide < 0 ){ minSide = s; continue; }
-      if( s == 0 ){ pCK = pAK; nCK = nAK; iCK = iAKey; }
-      else if( s == 1 ){ pCK = pOK; nCK = nOK; iCK = iOKey; }
-      else { pCK = pTK; nCK = nTK; iCK = iTKey; }
-      if( minSide == 0 ){ pMK = pAK; nMK = nAK; iMK = iAKey; }
-      else if( minSide == 1 ){ pMK = pOK; nMK = nOK; iMK = iOKey; }
-      else { pMK = pTK; nMK = nTK; iMK = iTKey; }
-      cmp = prollyCompareKeys(fm->flags, pCK, nCK, iCK, pMK, nMK, iMK);
-      if( cmp < 0 ) minSide = s;
-    }
-    if( minSide == 0 ){ pK = pAK; nK = nAK; iK = iAKey; }
-    else if( minSide == 1 ){ pK = pOK; nK = nOK; iK = iOKey; }
-    else { pK = pTK; nK = nTK; iK = iTKey; }
-
-    if( hasAny[0] ){
-      cmp = prollyCompareKeys(fm->flags, pAK, nAK, iAKey, pK, nK, iK);
-      has_a = (cmp == 0);
-    }
-    if( hasAny[1] ){
-      cmp = prollyCompareKeys(fm->flags, pOK, nOK, iOKey, pK, nK, iK);
-      has_o = (cmp == 0);
-    }
-    if( hasAny[2] ){
-      cmp = prollyCompareKeys(fm->flags, pTK, nTK, iTKey, pK, nK, iK);
-      has_t = (cmp == 0);
-    }
-
-    if( has_a ) prollyCursorValue(pAncC, &pAV, &nAV);
-    if( has_o ) prollyCursorValue(pOursC, &pOV, &nOV);
-    if( has_t ) prollyCursorValue(pTheirsC, &pTV, &nTV);
-
-    rc = fmResolveAndEmit(pCh, pK, nK,
-                           has_a, pAV, nAV,
-                           has_o, pOV, nOV,
-                           has_t, pTV, nTV);
+    rc = fmResolveAndEmit(pCh, kmin.p, kmin.n,
+                           ka.has, pAV, nAV,
+                           ko.has, pOV, nOV,
+                           kt.has, pTV, nTV);
     if( rc != SQLITE_OK ) return rc;
 
-    if( has_a ){ rc = prollyCursorNext(pAncC); if( rc != SQLITE_OK ) return rc; }
-    if( has_o ){ rc = prollyCursorNext(pOursC); if( rc != SQLITE_OK ) return rc; }
-    if( has_t ){ rc = prollyCursorNext(pTheirsC); if( rc != SQLITE_OK ) return rc; }
+    if( ka.has ){ rc = prollyCursorNext(pAncC); if( rc != SQLITE_OK ) return rc; }
+    if( ko.has ){ rc = prollyCursorNext(pOursC); if( rc != SQLITE_OK ) return rc; }
+    if( kt.has ){ rc = prollyCursorNext(pTheirsC); if( rc != SQLITE_OK ) return rc; }
   }
 
   return SQLITE_OK;


### PR DESCRIPTION
Second PR from the codebase dead/duplicate-code sweep. Behavior-preserving consolidation of duplicated logic in the prolly tree engine. Independent of #1081 (disjoint files).

- **prolly_node / prolly_mutmap** — add `prollyDecodeIntKey`; mutmap reuses it + `prollyEncodeIntKey` instead of its own byte-identical big-endian int-key codec.
- **prolly_btree** — extract `flushPendingForCount()`; the pending-mutmap snapshot/apply/clear block was copy-pasted across all three count entry points.
- **prolly_three_way_merge** — factor `FmKey` + `fmSelectMinKey()`/`fmKeyFromNode()`/`fmKeyFromCursor()`; `fmMergeLeaves` and `fmCursorMerge` each carried ~50 lines of identical min-of-three key selection.
- **prolly_diff** — extract `diffSetChangeVal()` for the malloc/NOMEM/memcpy value-copy block repeated 6× in `prollyDiffIterStep`.
- **prolly_cache** — `prollyCachePut` copies then delegates to `prollyCachePutOwned` instead of duplicating the evict/parse/insert tail.
- **prolly_chunker** — `flushLevel` reuses `finishFlushLevel`; add `resetLevel()`.
- **prolly_mutate** — factor `chunkBoundary()`/`nodeTotalBytes()` shared by the four chunk-shape predicates. Also unifies the boundary hash seed on `pNode->level` (`nodeAppendState`'s would-split path previously hardcoded `0` — identical in effect since it only runs on leaves where `level==0`, but now consistent with its siblings and the chunker).

9 files, +201/−407. Builds clean; `invariant_test` 856/856, `doltlite_regression_test_c` 108738/108738, all 13 gating C tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)