### PR TITLE
Dedup diff/blame/history

### DIFF
--- a/src/doltlite_diff.c
+++ b/src/doltlite_diff.c
@@ -196,11 +196,64 @@ static int batchAppend(DoltliteDiffCursor *pCur,
   return SQLITE_OK;
 }
 
+/* Diff child against parent catalogs, emitting one batch row per changed table
+** (plus the dolt_schemas view/trigger special case and reverse scan for
+** drops). zHex/pCommit label the rows: "WORKING"+null for the working set, the
+** commit hex+commit for a committed diff. */
+static int diffCatalogPair(
+  DoltliteDiffCursor *pCur, sqlite3 *db,
+  struct TableEntry *aChild, int nChild,
+  struct TableEntry *aParent, int nParent,
+  const char *zHex, const DoltliteCommit *pCommit
+){
+  int rc = SQLITE_OK, i;
+  for(i=0; i<nChild; i++){
+    struct TableEntry *e = &aChild[i];
+    struct TableEntry *p;
+    u8 dataChange, schemaChange;
+    if( !e->zName ){
+      ProllyHash emptyRoot;
+      const ProllyHash *pOldRoot;
+      struct TableEntry *pOldMaster;
+      memset(&emptyRoot, 0, sizeof(emptyRoot));
+      pOldMaster = doltliteFindTableByNumber(aParent, nParent, 1);
+      pOldRoot = pOldMaster ? &pOldMaster->root : &emptyRoot;
+      if( schemaHasViewOrTriggerDiff(db, pOldRoot, &e->root, e->flags) ){
+        u8 schemaChangeFlag =
+          schemaHasAnyViewOrTrigger(db, pOldRoot, e->flags) ? 0 : 1;
+        rc = batchAppend(pCur, zHex, "dolt_schemas", pCommit,
+                         1, schemaChangeFlag);
+        if( rc!=SQLITE_OK ) return rc;
+      }
+      continue;
+    }
+    p = doltliteFindTableByName(aParent, nParent, e->zName);
+    if( !p ){
+      dataChange = 1;
+      schemaChange = 1;
+    }else{
+      dataChange   = (prollyHashCompare(&e->root, &p->root) != 0) ? 1 : 0;
+      schemaChange = (prollyHashCompare(&e->schemaHash, &p->schemaHash) != 0) ? 1 : 0;
+      if( !dataChange && !schemaChange ) continue;
+    }
+    rc = batchAppend(pCur, zHex, e->zName, pCommit, dataChange, schemaChange);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+  for(i=0; i<nParent; i++){
+    struct TableEntry *p = &aParent[i];
+    if( !p->zName ) continue;
+    if( doltliteFindTableByName(aChild, nChild, p->zName) ) continue;
+    rc = batchAppend(pCur, zHex, p->zName, pCommit, 1, 1);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+  return rc;
+}
+
 static int computeWorkingBatch(DoltliteDiffCursor *pCur, sqlite3 *db){
   ProllyHash headCat, workCat;
   struct TableEntry *aHead = 0, *aWork = 0;
   int nHead = 0, nWork = 0;
-  int rc, i;
+  int rc;
   static const char zWorkingHex[] = "WORKING";
   char zHexBuf[PROLLY_HASH_SIZE*2+1];
 
@@ -225,47 +278,8 @@ static int computeWorkingBatch(DoltliteDiffCursor *pCur, sqlite3 *db){
   memset(zHexBuf, 0, sizeof(zHexBuf));
   memcpy(zHexBuf, zWorkingHex, sizeof(zWorkingHex));
 
-  for(i=0; i<nWork; i++){
-    struct TableEntry *e = &aWork[i];
-    struct TableEntry *p;
-    u8 dataChange, schemaChange;
-    if( !e->zName ){
-      ProllyHash emptyRoot;
-      const ProllyHash *pOldRoot;
-      struct TableEntry *pOldMaster;
-      memset(&emptyRoot, 0, sizeof(emptyRoot));
-      pOldMaster = doltliteFindTableByNumber(aHead, nHead, 1);
-      pOldRoot = pOldMaster ? &pOldMaster->root : &emptyRoot;
-      if( schemaHasViewOrTriggerDiff(db, pOldRoot, &e->root, e->flags) ){
-        u8 schemaChangeFlag =
-          schemaHasAnyViewOrTrigger(db, pOldRoot, e->flags) ? 0 : 1;
-        rc = batchAppend(pCur, zHexBuf, "dolt_schemas", 0,
-                         1, schemaChangeFlag);
-        if( rc!=SQLITE_OK ) goto done;
-      }
-      continue;
-    }
-    p = doltliteFindTableByName(aHead, nHead, e->zName);
-    if( !p ){
-      dataChange = 1;
-      schemaChange = 1;
-    }else{
-      dataChange   = (prollyHashCompare(&e->root, &p->root) != 0) ? 1 : 0;
-      schemaChange = (prollyHashCompare(&e->schemaHash, &p->schemaHash) != 0) ? 1 : 0;
-      if( !dataChange && !schemaChange ) continue;
-    }
-    rc = batchAppend(pCur, zHexBuf, e->zName, 0, dataChange, schemaChange);
-    if( rc!=SQLITE_OK ) goto done;
-  }
-  for(i=0; i<nHead; i++){
-    struct TableEntry *p = &aHead[i];
-    if( !p->zName ) continue;
-    if( doltliteFindTableByName(aWork, nWork, p->zName) ) continue;
-    rc = batchAppend(pCur, zHexBuf, p->zName, 0, 1, 1);
-    if( rc!=SQLITE_OK ) goto done;
-  }
+  rc = diffCatalogPair(pCur, db, aWork, nWork, aHead, nHead, zHexBuf, 0);
 
-done:
   doltliteFreeCatalog(aHead, nHead);
   doltliteFreeCatalog(aWork, nWork);
   return rc;
@@ -276,7 +290,7 @@ static int computeCommitBatch(DoltliteDiffCursor *pCur, sqlite3 *db,
                               const char *zCommitHex){
   struct TableEntry *aChild = 0, *aParent = 0;
   int nChild = 0, nParent = 0;
-  int rc, i;
+  int rc;
   const ProllyHash *pParentHash = doltliteCommitParentHash(pCommit, 0);
   int hasParent = (pParentHash && !prollyHashIsEmpty(pParentHash));
 
@@ -297,49 +311,9 @@ static int computeCommitBatch(DoltliteDiffCursor *pCur, sqlite3 *db,
     }
   }
 
-  for(i=0; i<nChild; i++){
-    struct TableEntry *e = &aChild[i];
-    struct TableEntry *p;
-    u8 dataChange, schemaChange;
-    if( !e->zName ){
-      ProllyHash emptyRoot;
-      const ProllyHash *pOldRoot;
-      struct TableEntry *pOldMaster;
-      memset(&emptyRoot, 0, sizeof(emptyRoot));
-      pOldMaster = doltliteFindTableByNumber(aParent, nParent, 1);
-      pOldRoot = pOldMaster ? &pOldMaster->root : &emptyRoot;
-      if( schemaHasViewOrTriggerDiff(db, pOldRoot, &e->root, e->flags) ){
-        u8 schemaChangeFlag =
-          schemaHasAnyViewOrTrigger(db, pOldRoot, e->flags) ? 0 : 1;
-        rc = batchAppend(pCur, zCommitHex, "dolt_schemas", pCommit,
-                         1, schemaChangeFlag);
-        if( rc!=SQLITE_OK ) goto done;
-      }
-      continue;
-    }
-    p = doltliteFindTableByName(aParent, nParent, e->zName);
-    if( !p ){
-      dataChange = 1;
-      schemaChange = 1;
-    }else{
-      dataChange   = (prollyHashCompare(&e->root, &p->root) != 0) ? 1 : 0;
-      schemaChange = (prollyHashCompare(&e->schemaHash, &p->schemaHash) != 0) ? 1 : 0;
-      if( !dataChange && !schemaChange ) continue;
-    }
-    rc = batchAppend(pCur, zCommitHex, e->zName, pCommit,
-                     dataChange, schemaChange);
-    if( rc!=SQLITE_OK ) goto done;
-  }
+  rc = diffCatalogPair(pCur, db, aChild, nChild, aParent, nParent,
+                       zCommitHex, pCommit);
 
-  for(i=0; i<nParent; i++){
-    struct TableEntry *p = &aParent[i];
-    if( !p->zName ) continue;
-    if( doltliteFindTableByName(aChild, nChild, p->zName) ) continue;
-    rc = batchAppend(pCur, zCommitHex, p->zName, pCommit, 1, 1);
-    if( rc!=SQLITE_OK ) goto done;
-  }
-
-done:
   doltliteFreeCatalog(aChild, nChild);
   doltliteFreeCatalog(aParent, nParent);
   return rc;

--- a/src/doltlite_diff_stat.c
+++ b/src/doltlite_diff_stat.c
@@ -549,6 +549,31 @@ static int dstAppend(DstCursor *c, const DsStatRow *r){
   return SQLITE_OK;
 }
 
+static int dsAppendTableNames(
+  struct TableEntry *aCat, int nCat,
+  char ***paz, int *pn, int *pAlloc
+){
+  int i, j;
+  for(i=0; i<nCat; i++){
+    const char *zName = aCat[i].zName;
+    int dup = 0;
+    if( !zName || aCat[i].iTable==1 ) continue;
+    for(j=0; j<*pn; j++){ if( strcmp((*paz)[j], zName)==0 ){ dup=1; break; } }
+    if( dup ) continue;
+    if( *pn>=*pAlloc ){
+      int newAlloc = *pAlloc ? *pAlloc*2 : 8;
+      char **aNew = sqlite3_realloc(*paz, newAlloc*(int)sizeof(char*));
+      if( !aNew ) return SQLITE_NOMEM;
+      *paz = aNew;
+      *pAlloc = newAlloc;
+    }
+    (*paz)[*pn] = sqlite3_mprintf("%s", zName);
+    if( !(*paz)[*pn] ) return SQLITE_NOMEM;
+    (*pn)++;
+  }
+  return SQLITE_OK;
+}
+
 static int dsCollectTableNames(
   sqlite3 *db,
   const ProllyHash *pFromCat,
@@ -559,7 +584,7 @@ static int dsCollectTableNames(
   int nFrom = 0, nTo = 0;
   char **az = 0;
   int n = 0, alloc = 0;
-  int rc, i, j;
+  int rc, j;
 
   *pazOut = 0;
   *pnOut = 0;
@@ -572,40 +597,9 @@ static int dsCollectTableNames(
     return rc;
   }
 
-  for(i=0; i<nFrom; i++){
-    const char *zName = aFrom[i].zName;
-    int dup = 0;
-    if( !zName || aFrom[i].iTable==1 ) continue;
-    for(j=0; j<n; j++){ if( strcmp(az[j], zName)==0 ){ dup=1; break; } }
-    if( dup ) continue;
-    if( n>=alloc ){
-      int newAlloc = alloc ? alloc*2 : 8;
-      char **aNew = sqlite3_realloc(az, newAlloc*(int)sizeof(char*));
-      if( !aNew ){ rc = SQLITE_NOMEM; goto fail; }
-      az = aNew;
-      alloc = newAlloc;
-    }
-    az[n] = sqlite3_mprintf("%s", zName);
-    if( !az[n] ){ rc = SQLITE_NOMEM; goto fail; }
-    n++;
-  }
-  for(i=0; i<nTo; i++){
-    const char *zName = aTo[i].zName;
-    int dup = 0;
-    if( !zName || aTo[i].iTable==1 ) continue;
-    for(j=0; j<n; j++){ if( strcmp(az[j], zName)==0 ){ dup=1; break; } }
-    if( dup ) continue;
-    if( n>=alloc ){
-      int newAlloc = alloc ? alloc*2 : 8;
-      char **aNew = sqlite3_realloc(az, newAlloc*(int)sizeof(char*));
-      if( !aNew ){ rc = SQLITE_NOMEM; goto fail; }
-      az = aNew;
-      alloc = newAlloc;
-    }
-    az[n] = sqlite3_mprintf("%s", zName);
-    if( !az[n] ){ rc = SQLITE_NOMEM; goto fail; }
-    n++;
-  }
+  rc = dsAppendTableNames(aFrom, nFrom, &az, &n, &alloc);
+  if( rc==SQLITE_OK ) rc = dsAppendTableNames(aTo, nTo, &az, &n, &alloc);
+  if( rc!=SQLITE_OK ) goto fail;
 
   doltliteFreeCatalog(aFrom, nFrom);
   doltliteFreeCatalog(aTo, nTo);

--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -1051,16 +1051,7 @@ static int dtColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
 
     sqlite3_result_text(ctx, r->zToCommit, -1, SQLITE_TRANSIENT);
   }else if( nCols > 0 && col == nCols+1 ){
-
-    time_t t = (time_t)r->toDate;
-    struct tm *tm = gmtime(&t);
-    if(tm){
-      char b[32];
-      strftime(b, sizeof(b), "%Y-%m-%d %H:%M:%S", tm);
-      sqlite3_result_text(ctx, b, -1, SQLITE_TRANSIENT);
-    }else{
-      sqlite3_result_null(ctx);
-    }
+    doltliteResultTimestamp(ctx, r->toDate);
   }else if( nCols > 0 && col < 2*nCols+2 ){
     int colIdx = col - nCols - 2;
     doltliteResultUserCol(ctx, &pVtab->cols, r->pOldVal, r->nOldVal,
@@ -1069,16 +1060,7 @@ static int dtColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
 
     sqlite3_result_text(ctx, r->zFromCommit, -1, SQLITE_TRANSIENT);
   }else if( nCols > 0 && col == 2*nCols+3 ){
-
-    time_t t = (time_t)r->fromDate;
-    struct tm *tm = gmtime(&t);
-    if(tm){
-      char b[32];
-      strftime(b, sizeof(b), "%Y-%m-%d %H:%M:%S", tm);
-      sqlite3_result_text(ctx, b, -1, SQLITE_TRANSIENT);
-    }else{
-      sqlite3_result_null(ctx);
-    }
+    doltliteResultTimestamp(ctx, r->fromDate);
   }else if( nCols > 0 && col == 2*nCols+4 ){
     switch( r->diffType ){
       case PROLLY_DIFF_ADD:    sqlite3_result_text(ctx,"added",-1,SQLITE_STATIC); break;

--- a/src/doltlite_history.c
+++ b/src/doltlite_history.c
@@ -511,10 +511,7 @@ static int htColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
         sqlite3_result_text(ctx,c->zCommitter,-1,SQLITE_TRANSIENT);
         break;
       case 2:
-        {time_t t=(time_t)c->commitDate;struct tm *tm=gmtime(&t);
-          if(tm){char b[32];strftime(b,sizeof(b),"%Y-%m-%d %H:%M:%S",tm);
-            sqlite3_result_text(ctx,b,-1,SQLITE_TRANSIENT);
-          }else sqlite3_result_null(ctx);}
+        doltliteResultTimestamp(ctx, c->commitDate);
         break;
     }
   }


### PR DESCRIPTION
Third PR from the dead/duplicate-code sweep. Behavior-preserving dedup in the diff vtables. Independent of #1081/#1084 (disjoint files).

- **diff_table, history** — replace three inline `gmtime`/`strftime` blocks with the existing `doltliteResultTimestamp()` helper (identical `%Y-%m-%d %H:%M:%S` format).
- **diff_stat** — extract `dsAppendTableNames()`; `dsCollectTableNames` had the dedup/grow/copy loop pasted once for the from-catalog and once for the to-catalog.
- **diff** — extract `diffCatalogPair()`; `computeWorkingBatch` and `computeCommitBatch` shared the same child-vs-parent catalog walk (the `dolt_schemas` view/trigger special case plus the reverse drop scan); only catalog loading and the row label differ.

Skipped (intentionally): the `dsLoadColNames`/`loadColInfoAtCatalog` temp-db scaffold and `dsCountChangedCells`/`changeIsSchemaOnly` field-compare — cross-file with divergent return conventions and outputs; the shared part is too small to justify a new shared-header symbol.

4 files, +90/−143. Builds clean; `doltlite_regression_test_c` 108738/108738, all 13 gating C tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)