### PR TITLE
Dedup remote open-remote path; fix stale violations comment

### DIFF
--- a/src/doltlite_constraint_violations.c
+++ b/src/doltlite_constraint_violations.c
@@ -229,9 +229,9 @@ static int loadAllViolations(
     if( p+4 > data+nData ){ rc = SQLITE_CORRUPT; goto fail; }
     nr = p[0]|(p[1]<<8)|(p[2]<<16)|(p[3]<<24); p+=4;
     if( nr<0 ){ rc = SQLITE_CORRUPT; goto fail; }
-    /* Validate that nr rows can possibly fit in remaining bytes (each row
-    ** carries at least 1+4+8+4+4 = 21 header bytes), and use
-    ** sqlite3_malloc64 to avoid 32-bit multiplication overflow. */
+    /* Reject impossible counts up front: every row needs at least one byte, so
+    ** nr can't exceed the bytes remaining. sqlite3_malloc64 below avoids 32-bit
+    ** overflow on the row-array allocation. */
     if( (sqlite3_uint64)nr > (sqlite3_uint64)(data+nData - p) ){
       rc = SQLITE_CORRUPT; goto fail;
     }

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -346,15 +346,13 @@ static void doltPushFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     }
   }
 
-  rc = chunkStoreFindRemote(cs, zRemoteName, &zUrl);
-  if( rc!=SQLITE_OK || !zUrl ){
+  rc = remoteSqlOpenNamedRemote(cs, zRemoteName, &zUrl, &pRemote);
+  if( rc==SQLITE_NOTFOUND ){
     (void)doltliteVcSealSavepointError(db);
     sqlite3_result_error(ctx, "remote not found", -1);
     return;
   }
-
-  pRemote = openRemoteByUrl(chunkFileGetVfs(&cs->file), zUrl);
-  if( !pRemote ){
+  if( rc==SQLITE_CANTOPEN ){
     (void)doltliteVcSealSavepointError(db);
     sqlite3_result_error(ctx, "failed to open remote (URL must start with file://)", -1);
     return;
@@ -468,15 +466,13 @@ static void doltFetchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     return;
   }
 
-  rc = chunkStoreFindRemote(cs, zRemoteName, &zUrl);
-  if( rc!=SQLITE_OK || !zUrl ){
+  rc = remoteSqlOpenNamedRemote(cs, zRemoteName, &zUrl, &pRemote);
+  if( rc==SQLITE_NOTFOUND ){
     (void)doltliteVcSealSavepointError(db);
     sqlite3_result_error(ctx, "remote not found", -1);
     return;
   }
-
-  pRemote = openRemoteByUrl(chunkFileGetVfs(&cs->file), zUrl);
-  if( !pRemote ){
+  if( rc==SQLITE_CANTOPEN ){
     (void)doltliteVcSealSavepointError(db);
     sqlite3_result_error(ctx, "failed to open remote (URL must start with file://)", -1);
     return;


### PR DESCRIPTION
Fourth PR from the dead/duplicate-code sweep. Independent of #1081/#1084/#1085 (disjoint files).

- **remote_sql** — `doltPushFunc` and `doltFetchFunc` inlined `chunkStoreFindRemote` + `openRemoteByUrl` with identical "remote not found" / "failed to open remote" messages; both now reuse the existing `remoteSqlOpenNamedRemote` helper (already used by `doltPullFunc`).
- **constraint_violations** — the deserialize row-count bounds-check comment claimed each row carries "21 header bytes," but the guard only rejects `nr > remaining bytes` (a ≥1-byte-per-row bound). Reworded to describe what the code actually does.

Skipped (intentionally): the refs-persist triplet (cross-file 2-line bodies) and the `fsSetRefsIf`/`localSetRefsIf` expected-hash prologue (a 3-line idiom in otherwise-different functions) — below the bar for a helper. The `sendXxx` server wrappers are left as-is (readability).

2 files, small diff. Builds clean; `doltlite_regression_test_c` 108738/108738, all 13 gating C tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)