### PR TITLE
Dedup merge constraint helpers

### DIFF
--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -131,19 +131,8 @@ int doltliteBuildIndexSortKey(
     for(i=0; i<nOutField; i++){
       int col = aFieldOrder[i];
       int st = (useIpk && col==iPKey) ? (int)ipkType : info.aType[col];
-      int flen;
+      int flen = st>0 ? dlSerialTypeLen((u64)st) : 0;
       hdrLen += sqlite3VarintLen(st);
-      if( st<=0 ){ flen = 0; }
-      else if( st==1 ){ flen = 1; }
-      else if( st==2 ){ flen = 2; }
-      else if( st==3 ){ flen = 3; }
-      else if( st==4 ){ flen = 4; }
-      else if( st==5 ){ flen = 6; }
-      else if( st==6 || st==7 ){ flen = 8; }
-      else if( st==8 || st==9 ){ flen = 0; }
-      else if( st>=12 && (st&1)==0 ){ flen = (st-12)/2; }
-      else if( st>=13 && (st&1)==1 ){ flen = (st-13)/2; }
-      else{ flen = 0; }
       bodyLen += flen;
     }
 
@@ -187,17 +176,7 @@ int doltliteBuildIndexSortKey(
         continue;
       }
       st = info.aType[col];
-      if( st<=0 ){ flen = 0; }
-      else if( st==1 ){ flen = 1; }
-      else if( st==2 ){ flen = 2; }
-      else if( st==3 ){ flen = 3; }
-      else if( st==4 ){ flen = 4; }
-      else if( st==5 ){ flen = 6; }
-      else if( st==6 || st==7 ){ flen = 8; }
-      else if( st==8 || st==9 ){ flen = 0; }
-      else if( st>=12 && (st&1)==0 ){ flen = (st-12)/2; }
-      else if( st>=13 && (st&1)==1 ){ flen = (st-13)/2; }
-      else{ flen = 0; }
+      flen = st>0 ? dlSerialTypeLen((u64)st) : 0;
       if( flen>0 ){
         memcpy(p, pRec + info.aOffset[col], flen);
         p += flen;

--- a/src/doltlite_merge_constraints.c
+++ b/src/doltlite_merge_constraints.c
@@ -305,6 +305,28 @@ static int loadMergePkInfo(sqlite3 *db, const char *zTable, MergePkInfo *pPk){
   return SQLITE_OK;
 }
 
+/* FK specs whose parent-side column is unnamed (azTo[i]==0) reference the
+** parent's primary key positionally; fill those slots from zParent's PK. */
+static int backfillParentPk(sqlite3 *db, const char *zParent,
+                            char **azTo, int nCol){
+  int i, needParentPk = 0;
+  MergePkInfo parentPk;
+  int rc;
+  for(i=0; i<nCol; i++) if( !azTo[i] ) needParentPk = 1;
+  if( !needParentPk ) return SQLITE_OK;
+  memset(&parentPk, 0, sizeof(parentPk));
+  rc = loadMergePkInfo(db, zParent, &parentPk);
+  if( rc == SQLITE_OK ){
+    for(i=0; i<nCol; i++){
+      if( !azTo[i] && i < parentPk.nPk ){
+        azTo[i] = sqlite3_mprintf("%s", parentPk.azPk[i]);
+      }
+    }
+  }
+  freeMergePkInfo(&parentPk);
+  return rc;
+}
+
 
 static u8 *buildRecordFromStmtCols(
   sqlite3_stmt *pStmt,
@@ -1588,22 +1610,8 @@ int doltliteDetectMergeFkViolations(
       const char *zToRaw = (const char*)sqlite3_column_text(pFk, 4);
 
       if( curId>=0 && id!=curId ){
-        int needParentPk = 0;
-        for(int i=0; i<nCol; i++) if( !azTo[i] ) needParentPk = 1;
-        if( needParentPk ){
-          MergePkInfo parentPk;
-          memset(&parentPk, 0, sizeof(parentPk));
-          rc = loadMergePkInfo(db, zParent, &parentPk);
-          if( rc == SQLITE_OK ){
-            for(int i=0; i<nCol; i++){
-              if( !azTo[i] && i < parentPk.nPk ){
-                azTo[i] = sqlite3_mprintf("%s", parentPk.azPk[i]);
-              }
-            }
-          }
-          freeMergePkInfo(&parentPk);
-          if( rc != SQLITE_OK ) break;
-        }
+        rc = backfillParentPk(db, zParent, azTo, nCol);
+        if( rc != SQLITE_OK ) break;
         rc = detectFkViolationsForSpec(db,
             haveAnc ? aAnc : 0, haveAnc ? nAnc : 0,
             zTable, hasRowid, &childPk, zParent, curId,
@@ -1652,21 +1660,7 @@ int doltliteDetectMergeFkViolations(
       rc = SQLITE_OK;
     }
     if( rc==SQLITE_OK && curId>=0 ){
-      int needParentPk = 0;
-      for(int i=0; i<nCol; i++) if( !azTo[i] ) needParentPk = 1;
-      if( needParentPk ){
-        MergePkInfo parentPk;
-        memset(&parentPk, 0, sizeof(parentPk));
-        rc = loadMergePkInfo(db, zParent, &parentPk);
-        if( rc == SQLITE_OK ){
-          for(int i=0; i<nCol; i++){
-            if( !azTo[i] && i < parentPk.nPk ){
-              azTo[i] = sqlite3_mprintf("%s", parentPk.azPk[i]);
-            }
-          }
-        }
-        freeMergePkInfo(&parentPk);
-      }
+      rc = backfillParentPk(db, zParent, azTo, nCol);
       if( rc==SQLITE_OK ){
         rc = detectFkViolationsForSpec(db,
             haveAnc ? aAnc : 0, haveAnc ? nAnc : 0,


### PR DESCRIPTION
Fifth PR from the dead/duplicate-code sweep. Behavior-preserving within-file dedup in the merge constraint code.

- **merge_constraints** — extract `backfillParentPk()`; the "fill null FK target columns from the parent table's primary key" block was duplicated between the per-id-boundary and trailing-flush paths of `doltliteDetectMergeFkViolations`.
- **merge** — replace the two copies of the 11-branch serial-type→field-length switch in `doltliteBuildIndexSortKey` with the existing `dlSerialTypeLen` helper (equal for all `st >= 0`; kept the `st<=0 ? 0` guard so the defensive non-positive case is byte-for-byte identical).

Deliberately **skipped** several items the scan flagged here, because they're not clean behavior-preserving dedups:
- The `doltlite.c` constraint-detection triple — `doltliteDetectPostMergeConstraintViolations` looks reusable but has a *different contract* than the two inline sites (it adds a `sqlite_master` short-circuit probe and discards `zDetectErrMsg`, while the inline sites surface the error message). Unifying would change behavior.
- The 4 `isRowPreExisting` guard sites — fetch the ancestor row differently (by-name vs by-key vs `hasRowid`-branched) with different cleanup; no uniform helper.
- `conflicts.c`↔`constraint_violations.c` FNV hash / row-removal / wire codec, and the `merge.c`↔`schema_merge.c` column-constraint classifier — cross-file, would need a new shared-header symbol for small bodies.

2 files. Builds clean; `doltlite_regression_test_c` 108738/108738, all 13 gating C tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)