### PR TITLE
Share DoltLite string array cleanup

### DIFF
--- a/src/doltlite_blame.c
+++ b/src/doltlite_blame.c
@@ -158,11 +158,7 @@ static int blameLoadPkColumns(
 }
 
 static void blameFreePkColumns(char **azNames, int *aColIdx, int nCols){
-  int i;
-  if( azNames ){
-    for(i=0; i<nCols; i++) sqlite3_free(azNames[i]);
-    sqlite3_free(azNames);
-  }
+  doltliteFreeStringArray(azNames, nCols);
   sqlite3_free(aColIdx);
 }
 

--- a/src/doltlite_diff_stat.c
+++ b/src/doltlite_diff_stat.c
@@ -111,12 +111,6 @@ static int dsLoadCreateSql(
   return SQLITE_OK;
 }
 
-static void dsFreeColNames(char **az, int n){
-  int i;
-  for(i=0; i<n; i++) sqlite3_free(az[i]);
-  sqlite3_free(az);
-}
-
 static int dsCountRows(sqlite3 *db, const ProllyHash *pRoot, u8 flags,
                        i64 *pnRow){
   ChunkStore *cs = doltliteGetChunkStore(db);
@@ -450,8 +444,8 @@ static int dsComputeTableStats(
 done:
   sqlite3_free(zFromSql);
   sqlite3_free(zToSql);
-  dsFreeColNames(azFromCols, nFromCols);
-  dsFreeColNames(azToCols, nToCols);
+  doltliteFreeStringArray(azFromCols, nFromCols);
+  doltliteFreeStringArray(azToCols, nToCols);
   dsFreeColMap(&colMap);
   return rc;
 }
@@ -621,9 +615,7 @@ struct DsFilterCtx {
 };
 
 static void dsFilterCtxClear(DsFilterCtx *pCtx){
-  int i;
-  for(i=0; i<pCtx->nNames; i++) sqlite3_free(pCtx->azNames[i]);
-  sqlite3_free(pCtx->azNames);
+  doltliteFreeStringArray(pCtx->azNames, pCtx->nNames);
   memset(pCtx, 0, sizeof(*pCtx));
 }
 

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -158,6 +158,13 @@ static SQLITE_INLINE int doltliteAppendQuotedColumnList(
   return sqlite3_str_errcode(pStr);
 }
 
+static SQLITE_INLINE void doltliteFreeStringArray(char **az, int n){
+  int i;
+  if( !az ) return;
+  for(i=0; i<n; i++) sqlite3_free(az[i]);
+  sqlite3_free(az);
+}
+
 static SQLITE_INLINE int doltliteFindTableRootByName(
   struct TableEntry *a, int n, const char *zName,
   ProllyHash *pRoot, u8 *pFlags

--- a/src/doltlite_merge_constraints.c
+++ b/src/doltlite_merge_constraints.c
@@ -158,12 +158,6 @@ static int fkRefreshAppendName(char ***pazNames, int *pnNames, const char *zName
   return SQLITE_OK;
 }
 
-static void fkRefreshFreeNames(char **azNames, int nNames){
-  int i;
-  for(i=0; i<nNames; i++) sqlite3_free(azNames[i]);
-  sqlite3_free(azNames);
-}
-
 static int fkRefreshCandidateTables(sqlite3 *db, int *pChanged){
   sqlite3_stmt *pStmt = 0;
   char **azNames = 0;
@@ -181,13 +175,13 @@ static int fkRefreshCandidateTables(sqlite3 *db, int *pChanged){
     if( rc==SQLITE_OK ) rc = fkRefreshAppendName(&azNames, &nNames, zParent);
     if( rc!=SQLITE_OK ){
       sqlite3_finalize(pStmt);
-      fkRefreshFreeNames(azNames, nNames);
+      doltliteFreeStringArray(azNames, nNames);
       return rc;
     }
   }
   sqlite3_finalize(pStmt);
   if( stepRc!=SQLITE_DONE ){
-    fkRefreshFreeNames(azNames, nNames);
+    doltliteFreeStringArray(azNames, nNames);
     return stepRc;
   }
 
@@ -198,17 +192,17 @@ static int fkRefreshCandidateTables(sqlite3 *db, int *pChanged){
     }
     zSql = sqlite3_mprintf("REINDEX \"%w\"", azNames[i]);
     if( !zSql ){
-      fkRefreshFreeNames(azNames, nNames);
+      doltliteFreeStringArray(azNames, nNames);
       return SQLITE_NOMEM;
     }
     rc = sqlite3_exec(db, zSql, 0, 0, 0);
     sqlite3_free(zSql);
     if( rc!=SQLITE_OK ){
-      fkRefreshFreeNames(azNames, nNames);
+      doltliteFreeStringArray(azNames, nNames);
       return rc;
     }
   }
-  fkRefreshFreeNames(azNames, nNames);
+  doltliteFreeStringArray(azNames, nNames);
   if( pChanged ) *pChanged = (nNames>0);
   return SQLITE_OK;
 }
@@ -221,10 +215,8 @@ struct MergePkInfo {
 };
 
 static void freeMergePkInfo(MergePkInfo *pPk){
-  int i;
   if( !pPk ) return;
-  for(i=0; i<pPk->nPk; i++) sqlite3_free(pPk->azPk[i]);
-  sqlite3_free(pPk->azPk);
+  doltliteFreeStringArray(pPk->azPk, pPk->nPk);
   sqlite3_free(pPk->zPkCols);
   memset(pPk, 0, sizeof(*pPk));
 }
@@ -278,8 +270,7 @@ static int loadMergePkInfo(sqlite3 *db, const char *zTable, MergePkInfo *pPk){
   }
   sqlite3_finalize(pStmt);
   if( rc!=SQLITE_DONE && rc!=SQLITE_OK ){
-    for(i=0; i<nPk; i++) sqlite3_free(azPk[i]);
-    sqlite3_free(azPk);
+    doltliteFreeStringArray(azPk, nPk);
     return rc;
   }
 
@@ -287,8 +278,7 @@ static int loadMergePkInfo(sqlite3 *db, const char *zTable, MergePkInfo *pPk){
   for(i=0; i<nPk; i++){
     if( !azPk[i] ){
       sqlite3_free(sqlite3_str_finish(pCols));
-      for(i=0; i<nPk; i++) sqlite3_free(azPk[i]);
-      sqlite3_free(azPk);
+      doltliteFreeStringArray(azPk, nPk);
       return SQLITE_CORRUPT;
     }
     if( i>0 ) sqlite3_str_appendall(pCols, ", ");
@@ -1360,13 +1350,6 @@ int doltliteDetectMergeCheckViolations(
   return rc;
 }
 
-static void freeStringArray(char **az, int n){
-  int i;
-  if( !az ) return;
-  for(i=0; i<n; i++) sqlite3_free(az[i]);
-  sqlite3_free(az);
-}
-
 static int detectFkViolationsForSpec(
   sqlite3 *db,
   struct TableEntry *aAnc, int nAnc,
@@ -1608,8 +1591,8 @@ int doltliteDetectMergeFkViolations(
             haveAnc ? aAnc : 0, haveAnc ? nAnc : 0,
             zTable, hasRowid, &childPk, zParent, curId,
             azFrom, azTo, nCol, &nFound);
-        freeStringArray(azFrom, nCol);
-        freeStringArray(azTo, nCol);
+        doltliteFreeStringArray(azFrom, nCol);
+        doltliteFreeStringArray(azTo, nCol);
         azFrom = 0; azTo = 0; nCol = 0; nAlloc = 0;
         sqlite3_free(zParent); zParent = 0;
         if( rc != SQLITE_OK ) break;
@@ -1675,8 +1658,8 @@ int doltliteDetectMergeFkViolations(
       }
     }
 
-    freeStringArray(azFrom, nCol);
-    freeStringArray(azTo, nCol);
+    doltliteFreeStringArray(azFrom, nCol);
+    doltliteFreeStringArray(azTo, nCol);
     sqlite3_free(zParent);
     sqlite3_finalize(pFk);
     freeMergePkInfo(&childPk);

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -144,8 +144,6 @@ static int remoteSqlResetSessionToCommit(
   return rc;
 }
 
-static void freeNameList(char **azNames, int nNames);
-
 static void doltRemoteFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
   ChunkStore *cs = doltliteGetChunkStore(db);
@@ -351,7 +349,7 @@ static int parseRemoteBranchNames(
       for(i=0; i<nBr; i++){
         azNames[nNames] = sqlite3_mprintf("%s", aBr[i].zName);
         if( !azNames[nNames] ){
-          freeNameList(azNames, nNames);
+          doltliteFreeStringArray(azNames, nNames);
           chunkStoreClose(&refsView);
           return SQLITE_NOMEM;
         }
@@ -363,12 +361,6 @@ static int parseRemoteBranchNames(
   *pazNames = azNames;
   *pnNames = nNames;
   return SQLITE_OK;
-}
-
-static void freeNameList(char **azNames, int nNames){
-  int i;
-  for(i=0; i<nNames; i++) sqlite3_free(azNames[i]);
-  sqlite3_free(azNames);
 }
 
 static void doltFetchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
@@ -447,7 +439,7 @@ static void doltFetchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     for(i=0; i<nNames; i++){
       DoltliteRemote *pBrRemote = openRemoteByUrl(chunkFileGetVfs(&cs->file), zUrl);
       if( !pBrRemote ){
-        freeNameList(azNames, nNames);
+        doltliteFreeStringArray(azNames, nNames);
         (void)doltliteVcSealSavepointError(db);
         sqlite3_result_error(ctx, "failed to open remote (URL must start with file://)", -1);
         return;
@@ -455,13 +447,13 @@ static void doltFetchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
       rc = doltliteFetch(cs, pBrRemote, zRemoteName, azNames[i]);
       pBrRemote->xClose(pBrRemote);
       if( rc!=SQLITE_OK ){
-        freeNameList(azNames, nNames);
+        doltliteFreeStringArray(azNames, nNames);
         (void)doltliteVcSealSavepointError(db);
         remoteSqlResultError(ctx, rc, "fetch failed");
         return;
       }
     }
-    freeNameList(azNames, nNames);
+    doltliteFreeStringArray(azNames, nNames);
   }
 
   if( pRemote ) pRemote->xClose(pRemote);


### PR DESCRIPTION
## Summary
- add a shared helper for freeing SQLite-allocated string arrays
- replace local string-list cleanup helpers in remote SQL, merge constraints, diff stat, and blame code
- keep higher-level cleanup helpers where they also clear companion state

## Tests
- make doltlite
- bash test/vc_oracle_remotes_test.sh ./doltlite
- bash test/vc_oracle_diff_stat_test.sh ./doltlite
- bash test/vc_oracle_blame_test.sh ./doltlite
- bash test/vc_oracle_fk_merge_test.sh ./doltlite
- bash test/doltlite_conflicts.sh ./doltlite