### PR TITLE
Dedup catalog header parse in chunk walk

### DIFF
--- a/src/doltlite_chunk_walk.c
+++ b/src/doltlite_chunk_walk.c
@@ -10,23 +10,6 @@
 
 #include <string.h>
 
-static int parseCurrentCatalogHeader(
-  const u8 *data,
-  int nData,
-  int *pVersion,
-  int *pnTables,
-  const u8 **ppEntries
-){
-  const u8 *q;
-  if( nData < CAT_HEADER_SIZE_V3 ) return 0;
-  if( data[0] != CATALOG_FORMAT_V3 && data[0] != CATALOG_FORMAT_V4 ) return 0;
-  if( pVersion ) *pVersion = data[0];
-  q = data + CAT_HEADER_SIZE_V3 - 4;
-  *pnTables = (int)(q[0] | (q[1]<<8) | (q[2]<<16) | (q[3]<<24));
-  *ppEntries = data + CAT_HEADER_SIZE_V3;
-  return 1;
-}
-
 DoltliteChunkType doltliteClassifyChunk(const u8 *data, int nData){
   u32 m;
 
@@ -47,7 +30,7 @@ DoltliteChunkType doltliteClassifyChunk(const u8 *data, int nData){
 
   {
     int nTables; const u8 *pEntries; int iFormat;
-    if( parseCurrentCatalogHeader(data, nData, &iFormat, &nTables, &pEntries) ){
+    if( catalogParseHeaderEx(data, nData, &iFormat, &nTables, &pEntries) ){
       return CHUNK_CATALOG;
     }
   }
@@ -122,7 +105,7 @@ static int enumerateCatalogChildren(
   int i;
   int rc = SQLITE_OK;
 
-  if( !parseCurrentCatalogHeader(data, nData, &iFormat, &nTables, &p) ) return SQLITE_CORRUPT;
+  if( !catalogParseHeaderEx(data, nData, &iFormat, &nTables, &p) ) return SQLITE_CORRUPT;
   if( nTables < 0 || nTables >= 10000 ) return SQLITE_CORRUPT;
   for(i=0; i<nTables && rc==SQLITE_OK; i++){
     ProllyHash tableRoot;


### PR DESCRIPTION
Seventh PR from the dead/duplicate-code sweep.

`doltlite_chunk_walk.c` carried a private `parseCurrentCatalogHeader` that was byte-for-byte identical to `catalogParseHeaderEx` in `chunk_store.h` (already `#include`d). Dropped the copy and pointed both call sites at the shared helper — removes a second parser of the same on-disk catalog-header format (format-drift risk).

Note: the `CS_WAL_TAG_*` macro duplication this sweep also flagged was already resolved by a separate merged PR. The `chunk_staging` hash-table ensure/search pairs and the `doltlite_gc` three-source iteration were left alone — the staging pair differs by scan direction and the gc bodies differ per phase, so neither is a clean mechanical dedup.

1 file, −16 lines. Builds clean; `doltlite_regression_test_c` 108738/108738, all 13 gating C tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)