### PR TITLE
Declare merge violation detectors in shared header

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -642,12 +642,6 @@ static int doltliteDetectPostMergeConstraintViolations(
   const ProllyHash *pAncCatHash,
   int *pnViolations
 ){
-  extern int doltliteDetectMergeFkViolations(
-      sqlite3*, const ProllyHash*, char**, int*);
-  extern int doltliteDetectMergeUniqueViolations(
-      sqlite3*, const ProllyHash*, char**, int*);
-  extern int doltliteDetectMergeCheckViolations(
-      sqlite3*, const ProllyHash*, char**, int*);
   int nViolations = 0;
   int nUnique = 0;
   int nCheck = 0;
@@ -2922,12 +2916,6 @@ static void doltliteMergeFunc(
     graphLocked = 0;
   }
   {
-    extern int doltliteDetectMergeFkViolations(
-        sqlite3*, const ProllyHash*, char**, int*);
-    extern int doltliteDetectMergeUniqueViolations(
-        sqlite3*, const ProllyHash*, char**, int*);
-    extern int doltliteDetectMergeCheckViolations(
-        sqlite3*, const ProllyHash*, char**, int*);
     int nViolations = 0;
     int nUnique = 0;
     int nCheck = 0;
@@ -3210,12 +3198,6 @@ static int applyMergedCatalogAndCommit(
   }
 
   {
-    extern int doltliteDetectMergeFkViolations(
-        sqlite3*, const ProllyHash*, char**, int*);
-    extern int doltliteDetectMergeUniqueViolations(
-        sqlite3*, const ProllyHash*, char**, int*);
-    extern int doltliteDetectMergeCheckViolations(
-        sqlite3*, const ProllyHash*, char**, int*);
     int nViolations = 0;
     int nUnique = 0;
     int nCheck = 0;

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -191,6 +191,15 @@ int doltliteGetHeadCatalogHash(sqlite3 *db, ProllyHash *pCatHash);
 int doltliteFlushAndSerializeCatalog(sqlite3 *db, u8 **ppOut, int *pnOut);
 int doltliteDeserializeCatalogForTest(sqlite3 *db, const u8 *data, int nData);
 int doltliteFlushCatalogToHash(sqlite3 *db, ProllyHash *pHash);
+
+/* Post-merge constraint detectors (defined in doltlite_merge_constraints.c). */
+int doltliteDetectMergeFkViolations(sqlite3 *db, const ProllyHash *pAncCatHash,
+                                    char **pzErrMsg, int *pnFound);
+int doltliteDetectMergeUniqueViolations(sqlite3 *db, const ProllyHash *pAncCatHash,
+                                        char **pzErrMsg, int *pnFound);
+int doltliteDetectMergeCheckViolations(sqlite3 *db, const ProllyHash *pAncCatHash,
+                                       char **pzErrMsg, int *pnFound);
+
 int doltliteGetWorkingTableState(sqlite3 *db, const char *zTable,
                                  ProllyHash *pRoot, u8 *pFlags,
                                  ProllyHash *pSchemaHash);


### PR DESCRIPTION
Eighth and final PR from the dead/duplicate-code sweep.

The three `doltliteDetectMerge{Fk,Unique,Check}Violations` prototypes were copy-pasted as block-scope `extern` declarations at three call sites in `doltlite.c`. Declared them once in `doltlite_internal.h` (which both `doltlite.c` and the defining TU `doltlite_merge_constraints.c` already include) and dropped the local externs.

This is the only clean item from the "collapse redundant wrappers" task. The others were intentionally left: `findTableEntry`/`findTableByName` in merge.c are legitimate local aliases used 9×/4× (inlining the canonical names would only add verbosity), and `doltliteAtRegister` mirrors the `doltliteXxxRegister` naming convention of the registration sequence.

2 files, +9/−18. Builds clean; `doltlite_regression_test_c` 108738/108738, all 13 gating C tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)