### PR TITLE
Remove unused sort key wrappers

### DIFF
--- a/src/sortkey.c
+++ b/src/sortkey.c
@@ -319,10 +319,6 @@ static int sortKeyEncode(const u8 *pRec, int nRec, u8 *pOut, int nMaxFields,
   return pOut ? outPos : (int)outSize;
 }
 
-int sortKeySize(const u8 *pRec, int nRec){
-  return sortKeyEncode(pRec, nRec, NULL, 0, NULL);
-}
-
 int sortKeyFromRecord(const u8 *pRec, int nRec, u8 **ppOut, int *pnOut){
   return sortKeyFromRecordPrefix(pRec, nRec, 0, ppOut, pnOut);
 }
@@ -641,16 +637,6 @@ int sortKeyFromInt64(i64 v, u8 *pOut, int *pnOut){
   writeIntBE(aData, v, (int)nData);
   *pnOut = encodeNumeric(pOut, serialType, aData, nData);
   return SQLITE_OK;
-}
-
-int sortKeyFromInt64Buffer(i64 v, u8 **ppBuf, int *pnAlloc, int *pnOut){
-  if( *pnAlloc < 64 ){
-    u8 *pNew = (u8*)sqlite3_realloc64(*ppBuf, 64);
-    if( !pNew ) return SQLITE_NOMEM;
-    *ppBuf = pNew;
-    *pnAlloc = 64;
-  }
-  return sortKeyFromInt64(v, *ppBuf, pnOut);
 }
 
 static void intSerialType(i64 v, u32 *pType, u32 *pLen){

--- a/src/sortkey.h
+++ b/src/sortkey.h
@@ -27,7 +27,6 @@ int sortKeyFromMemPrefixCollBuffer(
 );
 
 int sortKeyFromInt64(i64 v, u8 *pOut, int *pnOut);
-int sortKeyFromInt64Buffer(i64 v, u8 **ppBuf, int *pnAlloc, int *pnOut);
 
 static inline int sortKeyInt64FitsExact(i64 v){
   return v>=-9007199254740992LL && v<=9007199254740992LL;
@@ -48,8 +47,6 @@ static inline void sortKeyWriteExactInt64(i64 v, u8 *pOut){
     pOut[1+i] = (u8)(x >> (56 - i*8));
   }
 }
-
-int sortKeySize(const u8 *pRec, int nRec);
 
 int recordFromSortKey(const u8 *pSortKey, int nSortKey, u8 **ppOut, int *pnOut);
 int recordFromSortKeyBuffer(


### PR DESCRIPTION
## Summary
- remove unused sortKeySize wrapper
- remove unused sortKeyFromInt64Buffer wrapper
- keep the underlying sort-key encoding functions used by prolly indexes

## Tests
- make doltlite
- bash test/doltlite_diff.sh ./doltlite
- bash test/doltlite_diff_table.sh ./doltlite
- bash test/vc_oracle_diff_stat_test.sh ./doltlite