### PR TITLE
Don't wedge a writable chunk store read-only on a failed reload reopen

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -1519,6 +1519,16 @@ static int csReloadFromDisk(ChunkStore *cs){
                           SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB);
   if( rc!=SQLITE_OK ) return rc;
 
+  /* chunkStoreOpen falls back to a read-only handle when the read-write open
+  ** fails transiently (e.g. an OOM-faulted open). Adopting that would wedge a
+  ** writable store read-only and make every later commit return
+  ** SQLITE_READONLY. Don't downgrade: fail so the caller retries (which
+  ** reopens read-write) and leave the current writable store untouched. */
+  if( tmp.readOnly && !cs->readOnly ){
+    chunkStoreClose(&tmp);
+    return SQLITE_BUSY;
+  }
+
   csCaptureReloadState(cs, &saved);
   csAdoptOpenedStoreState(cs, &tmp);
 


### PR DESCRIPTION
Spun out of the #1094 investigation as an independent latent bug.

`csReloadFromDisk` reopens the store via `chunkStoreOpen`, which **falls back to a read-only handle** when the read-write open fails transiently (an OOM-faulted open, or resource pressure during a `HAS_MOVED`/GC-triggered reload). The reload then *adopted* that read-only store, silently downgrading a writable connection — every subsequent commit returns `SQLITE_READONLY` and stops persisting.

Fix: if the reopen downgrades a writable store to read-only (`tmp.readOnly && !cs->readOnly`), fail the reload with `SQLITE_BUSY` (retryable — the retry reopens read-write) and leave the current writable store untouched, instead of adopting the read-only handle.

**Latent fix** — the wedge requires a transient read-write reopen failure mid-reload, which no existing test injects, so there's no fail-before case. Verified no regression:
- `doltlite_regression_test_c` 309770/0
- all 13 gating C tests pass
- `oom_dolt_fault_test` clean (this is also what surfaced the wedge while prototyping the #1094 fix, where a forced reload made it reproducible)

Context: #1094

🤖 Generated with [Claude Code](https://claude.com/claude-code)