### PR TITLE
Fix concurrent-merge lost update; keep rebase working

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -1511,6 +1511,24 @@ int chunkStoreRefreshIfChanged(ChunkStore *cs, int *pChanged){
   return SQLITE_OK;
 }
 
+int chunkStoreForceRefresh(ChunkStore *cs){
+  int rc;
+  int wasPinned;
+  if( cs->isMemory ) return SQLITE_OK;
+  /* Only the outermost lock holder reloads; a reentrant (inner) holder runs
+  ** under the outer scope's already-current view, so a multi-step VC op that
+  ** holds the lock across sub-operations keeps the in-memory state it builds. */
+  if( cs->lockDepth != 1 ) return SQLITE_OK;
+  /* Reload even under a pinned snapshot — the VC write needs the true on-disk
+  ** branch tips. Unpin around it (the heuristic refresh path suppresses reloads
+  ** while pinned), then restore the pin. */
+  wasPinned = cs->snapshotPinned;
+  cs->snapshotPinned = 0;
+  rc = csReloadFromDiskPreservingLocalRefs(cs);
+  cs->snapshotPinned = wasPinned;
+  return rc;
+}
+
 static int csReloadFromDisk(ChunkStore *cs){
   ChunkStore tmp;
   ChunkStoreReloadState saved;

--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -213,4 +213,10 @@ const char *chunkStoreFilename(ChunkStore *cs);
 
 int chunkStoreRefreshIfChanged(ChunkStore *cs, int *pChanged);
 
+/* Reload persisted refs from disk for a VC write op, bypassing the file-size/
+** HAS_MOVED change heuristic (which can miss a peer commit when the WAL is
+** reused, leaving a stale branch tip). Reloads only at the outermost lock
+** acquisition; caller holds the graph lock. */
+int chunkStoreForceRefresh(ChunkStore *cs);
+
 #endif

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -171,15 +171,14 @@ static int doltliteRefreshAndConfirmHead(
   rc = chunkStoreLockAndRefresh(cs);
   if( rc!=SQLITE_OK ) return rc;
 
-  if( cs->snapshotPinned ){
-    int changed = 0;
-    cs->snapshotPinned = 0;
-    rc = chunkStoreRefreshIfChanged(cs, &changed);
-    cs->snapshotPinned = 1;
-    if( rc!=SQLITE_OK ){
-      chunkStoreUnlock(cs);
-      return rc;
-    }
+  /* Reload persisted refs so this CAS compares against the true on-disk branch
+  ** tip. The lock-time change heuristic can miss a peer commit (WAL reuse
+  ** leaves the file size unchanged), and a stale tip would let a fast-forward
+  ** clobber the peer's advance. */
+  rc = chunkStoreForceRefresh(cs);
+  if( rc!=SQLITE_OK ){
+    chunkStoreUnlock(cs);
+    return rc;
   }
 
   zBranch = doltliteGetSessionBranch(db);
@@ -428,15 +427,15 @@ int doltliteMutateRefs(sqlite3 *db, DoltliteRefsMutation xMutate, void *pArg){
 
   rc = chunkStoreLockAndRefresh(cs);
   if( rc!=SQLITE_OK ) return rc;
-  if( cs->snapshotPinned ){
-    int changed = 0;
-    cs->snapshotPinned = 0;
-    rc = chunkStoreRefreshIfChanged(cs, &changed);
-    cs->snapshotPinned = 1;
-    if( rc!=SQLITE_OK ){
-      chunkStoreUnlock(cs);
-      return rc;
-    }
+
+  /* xMutate edits the in-memory refs and serializeRefs rewrites the whole refs
+  ** blob, so a stale view would drop a peer's concurrent ref change (e.g. a
+  ** branch delete clobbering main's just-merged advance). Reload persisted
+  ** refs first rather than trusting the lock-time change heuristic. */
+  rc = chunkStoreForceRefresh(cs);
+  if( rc!=SQLITE_OK ){
+    chunkStoreUnlock(cs);
+    return rc;
   }
 
   rc = xMutate(db, cs, pArg);

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -4486,6 +4486,13 @@ static void doltliteRebaseInteractiveStart(
     goto fail;
   }
   bWorkingBranchCreated = 1;
+  /* Persist the working branch now. The sub-ops below (checkout, plan table)
+  ** each reload persisted refs at their lock — the VC fresh-read that closes
+  ** the concurrency window — which would discard this still-in-memory branch.
+  ** Committing it makes the reload re-read it instead. */
+  rc = chunkStoreSerializeRefs(cs);
+  if( rc==SQLITE_OK ) rc = chunkStoreCommit(cs);
+  if( rc!=SQLITE_OK ) goto fail;
   rc = doltliteCheckoutBranchForRebase(db, zWorking);
   if( rc!=SQLITE_OK ) goto fail;
 

--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -449,6 +449,9 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
       m.zDest = aPositional[1];
       {
         const char *zDefault = chunkStoreGetDefaultBranch(cs);
+        /* Resolve "was the default?" before the mutate: doltliteMutateRefs
+        ** reloads persisted refs, freeing the buffer zDefault points into. */
+        int srcWasDefault = zDefault && strcmp(m.zSrc, zDefault)==0;
         renamingCurrent = strcmp(m.zSrc, doltliteGetSessionBranch(db))==0;
         rc = doltliteMutateRefs(db, mutateBranchMove, &m);
         if( rc!=SQLITE_OK ){
@@ -459,7 +462,7 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
         if( renamingCurrent ){
           doltliteSetSessionBranch(db, m.zDest);
         }
-        if( zDefault && strcmp(m.zSrc, zDefault)==0 ){
+        if( srcWasDefault ){
           chunkStoreSetDefaultBranch(cs, m.zDest);
           (void)chunkStoreSerializeRefs(cs);
           (void)chunkStoreCommit(cs);


### PR DESCRIPTION
Fixes the concurrent-merge lost-update from #1094 by reading fresh persisted refs at the VC write CAS, and adjusts rebase to work in that model. Two commits, as discussed.

### Commit 1 — read fresh persisted refs at the VC write CAS
Concurrent VC mutations could silently lose a committed row: the write-path CAS (`doltliteRefreshAndConfirmHead`) and refs rewrite (`doltliteMutateRefs`) trusted the in-memory refs, refreshed only by `csDetectExternalChanges`' file-size/`HAS_MOVED` heuristic — which misses a peer commit when the WAL is reused (file size unchanged). So the op compared/rewrote against a **stale branch tip** and a fast-forward (or branch-delete) clobbered the peer's advance.

`chunkStoreForceRefresh` reloads persisted refs unconditionally at the **outermost** lock acquisition; wired into the two VC write entry points. Fixes the lost update: `vc_ref_mutation_stress_test` **600/600** (was ~1/120).

### Commit 2 — keep rebase working under the new model
The fresh-read broke interactive rebase: it built the working-branch ref in memory and committed it late, but a sub-op's fresh-read discarded it (`dolt_rebase('-i')` → `NOTFOUND`, 33 cases). A VC op can't hold the graph lock across sub-ops to suppress the reload — the btree owns the lock per statement. So the working branch is now made **durable as soon as it's created**, and the reload re-reads it. Continue/abort already commit their ref edits via `doltliteMutateRefs`, so this fixes all rebase cases.

### Validation
- `vc_ref_mutation_stress_test` 600/600 (baseline ~1/120)
- `doltlite_regression_test_c all` 309,770/0 (rebase green)
- `make c-tests` 0/13 gating
- `oom_dolt_fault_test` 0 bugs

Builds on #1096 (the read-only-downgrade guard, needed because the forced reload re-exposes that OOM wedge). Closes #1094.

🤖 Generated with [Claude Code](https://claude.com/claude-code)