### PR TITLE
Dedup conflicts/constraint-violation helpers (FNV hash + array removal)

### DIFF
--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -535,43 +535,16 @@ static const char *cfrDiffType(const u8 *pBase, int nBase,
 }
 
 static sqlite3_int64 cfrConflictRowid(const struct ConflictRow *cr){
-  u64 h = 1469598103934665603ULL;
-  int i;
-  if( cr->nKey>0 && cr->pKey ){
-    for(i=0; i<cr->nKey; i++){
-      h ^= (u64)cr->pKey[i];
-      h *= 1099511628211ULL;
-    }
-  }
-  h *= 1099511628211ULL;
-  {
-    u64 k = (u64)cr->intKey;
-    for(i=0; i<8; i++){
-      h ^= (k >> (i*8)) & 0xff;
-      h *= 1099511628211ULL;
-    }
-  }
-  h *= 1099511628211ULL;
-  if( cr->nBaseVal>0 && cr->pBaseVal ){
-    for(i=0; i<cr->nBaseVal; i++){
-      h ^= (u64)cr->pBaseVal[i];
-      h *= 1099511628211ULL;
-    }
-  }
-  h *= 1099511628211ULL;
-  if( cr->nOurVal>0 && cr->pOurVal ){
-    for(i=0; i<cr->nOurVal; i++){
-      h ^= (u64)cr->pOurVal[i];
-      h *= 1099511628211ULL;
-    }
-  }
-  h *= 1099511628211ULL;
-  if( cr->nTheirVal>0 && cr->pTheirVal ){
-    for(i=0; i<cr->nTheirVal; i++){
-      h ^= (u64)cr->pTheirVal[i];
-      h *= 1099511628211ULL;
-    }
-  }
+  u64 h = DOLTLITE_FNV1A_OFFSET;
+  h = doltliteFnv1aBytes(h, cr->pKey, cr->nKey);
+  h = doltliteFnv1aSep(h);
+  h = doltliteFnv1aI64(h, cr->intKey);
+  h = doltliteFnv1aSep(h);
+  h = doltliteFnv1aBytes(h, cr->pBaseVal, cr->nBaseVal);
+  h = doltliteFnv1aSep(h);
+  h = doltliteFnv1aBytes(h, cr->pOurVal, cr->nOurVal);
+  h = doltliteFnv1aSep(h);
+  h = doltliteFnv1aBytes(h, cr->pTheirVal, cr->nTheirVal);
   return (sqlite3_int64)(h & 0x7fffffffffffffffULL);
 }
 

--- a/src/doltlite_constraint_violations.c
+++ b/src/doltlite_constraint_violations.c
@@ -641,39 +641,17 @@ static int cvrColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
 }
 
 static sqlite3_int64 cvrViolationRowid(const ConstraintViolationRow *r){
-  u64 h = 1469598103934665603ULL;
-  int i;
-  if( r->nKey>0 && r->pKey ){
-    for(i=0; i<r->nKey; i++){
-      h ^= (u64)r->pKey[i];
-      h *= 1099511628211ULL;
-    }
-  }
-  h *= 1099511628211ULL;
-  {
-    u64 k = (u64)r->intKey;
-    for(i=0; i<8; i++){
-      h ^= (k >> (i*8)) & 0xff;
-      h *= 1099511628211ULL;
-    }
-  }
-  h *= 1099511628211ULL;
-  if( r->nVal>0 && r->pVal ){
-    for(i=0; i<r->nVal; i++){
-      h ^= (u64)r->pVal[i];
-      h *= 1099511628211ULL;
-    }
-  }
-  h *= 1099511628211ULL;
+  u64 h = DOLTLITE_FNV1A_OFFSET;
+  h = doltliteFnv1aBytes(h, r->pKey, r->nKey);
+  h = doltliteFnv1aSep(h);
+  h = doltliteFnv1aI64(h, r->intKey);
+  h = doltliteFnv1aSep(h);
+  h = doltliteFnv1aBytes(h, r->pVal, r->nVal);
+  h = doltliteFnv1aSep(h);
   h ^= (u64)r->violationType;
-  h *= 1099511628211ULL;
-  h *= 1099511628211ULL;
-  if( r->zInfo ){
-    for(i=0; r->zInfo[i]; i++){
-      h ^= (u64)(u8)r->zInfo[i];
-      h *= 1099511628211ULL;
-    }
-  }
+  h *= DOLTLITE_FNV1A_PRIME;
+  h = doltliteFnv1aSep(h);
+  h = doltliteFnv1aStr(h, r->zInfo);
   return (sqlite3_int64)(h & 0x7fffffffffffffffULL);
 }
 

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -19,6 +19,39 @@ enum DoltliteVcTxnMode {
   DOLTLITE_VC_TXN_NESTED_SAVEPOINT = 2
 };
 
+/* FNV-1a row-fingerprint helpers shared by the conflicts and constraint-
+** violation vtab rowid functions: fold each field with doltliteFnv1aBytes/
+** I64/Str, calling doltliteFnv1aSep between fields. */
+#define DOLTLITE_FNV1A_OFFSET 1469598103934665603ULL
+#define DOLTLITE_FNV1A_PRIME  1099511628211ULL
+
+static SQLITE_INLINE u64 doltliteFnv1aBytes(u64 h, const u8 *p, int n){
+  int i;
+  if( p ){
+    for(i=0; i<n; i++){ h ^= (u64)p[i]; h *= DOLTLITE_FNV1A_PRIME; }
+  }
+  return h;
+}
+
+static SQLITE_INLINE u64 doltliteFnv1aI64(u64 h, i64 v){
+  u64 k = (u64)v;
+  int i;
+  for(i=0; i<8; i++){ h ^= (k >> (i*8)) & 0xff; h *= DOLTLITE_FNV1A_PRIME; }
+  return h;
+}
+
+static SQLITE_INLINE u64 doltliteFnv1aStr(u64 h, const char *z){
+  if( z ){
+    int i;
+    for(i=0; z[i]; i++){ h ^= (u64)(u8)z[i]; h *= DOLTLITE_FNV1A_PRIME; }
+  }
+  return h;
+}
+
+static SQLITE_INLINE u64 doltliteFnv1aSep(u64 h){
+  return h * DOLTLITE_FNV1A_PRIME;
+}
+
 struct TableEntry {
   Pgno iTable;
   ProllyHash root;


### PR DESCRIPTION
Picks up the cleanest pieces of the conflicts.c↔constraint_violations.c mirror deferred from the original sweep. Pure refactors, behavior-preserving.

### FNV-1a rowid hashing
`cfrConflictRowid` and `cvrViolationRowid` each hand-rolled the same FNV-1a row fingerprint (~40 lines of byte-fold + per-field separator, over different field sets). Factored into shared `SQLITE_INLINE` helpers in `doltlite_internal.h` (`doltliteFnv1aBytes`/`I64`/`Str`/`Sep` + offset/prime constants). Byte-for-byte identical hashes.

### Array removal helpers
`removeConflictRow/Table` and `removeViolationRow/Table` were four structurally identical array-compaction functions (differing only in struct type + count-field name). Factored the compaction into `doltliteArrayRemoveAt(aBase, *pn, iElem, elemSize)`; each remover keeps its type-specific frees and calls the shared helper.

Builds clean; `doltlite_regression_test_c` 309770/0, all 13 gating C tests pass, full shell suite 66/67 (only `doltlite_parity.sh`, env-only — needs a reference `./sqlite3`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)