### PR TITLE
Preserve stock SQLite primary key schemas

### DIFF
--- a/src/btree.h
+++ b/src/btree.h
@@ -268,6 +268,7 @@ int sqlite3BtreeProllyCachedIndexKeyCompare(
   UnpackedRecord *pUnKey,
   int *pRes
 );
+int sqlite3BtreeUsesOrig(Btree*);
 #endif
 int sqlite3BtreeCursorHasMoved(BtCursor*);
 int sqlite3BtreeCursorRestore(BtCursor*, int*);

--- a/src/build.c
+++ b/src/build.c
@@ -2740,6 +2740,8 @@ void sqlite3EndTable(
   **   - Views: no storage.
   **   - Internal sqlite_* tables: created by sqlite for AUTOINCREMENT
   **     bookkeeping etc. and don't have user PKs.
+  **   - Stock SQLite btrees: their on-disk rowid table layout must be
+  **     replayed exactly.
   **
   ** Runs during sqlite_master replay (db->init.busy) as well as
   ** user-issued CREATE TABLE, because the stored CREATE TABLE statement
@@ -2749,6 +2751,9 @@ void sqlite3EndTable(
   ** doltlite refuses to open databases written by older binaries that
   ** don't enforce this storage model. */
   if( iDb!=1
+#if defined(DOLTLITE_PROLLY) && !defined(SQLITE_TEST)
+   && !sqlite3BtreeUsesOrig(db->aDb[iDb].pBt)
+#endif
    && pParse->eParseMode!=PARSE_MODE_DECLARE_VTAB
    && IsOrdinaryTable(p)
    && sqlite3StrNICmp(p->zName, "sqlite_", 7)!=0

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -1403,7 +1403,7 @@ static void doltliteAddFunc(
   int opRc = SQLITE_OK;
 
   if( !cs ){
-    sqlite3_result_error(context, "no database open", -1);
+    sqlite3_result_error(context, doltliteVcUnavailableMessage(db), -1);
     goto add_cleanup;
   }
   if( argc==0 ){
@@ -1480,7 +1480,7 @@ static void doltliteCommitFunc(
   int i;
 
   if( !cs ){
-    sqlite3_result_error(context, "no database open", -1);
+    sqlite3_result_error(context, doltliteVcUnavailableMessage(db), -1);
     return;
   }
 
@@ -2376,7 +2376,7 @@ static void doltliteResetFunc(
   int bSucceeded = 0;
 
   if( !cs ){
-    sqlite3_result_error(context, "no database open", -1);
+    sqlite3_result_error(context, doltliteVcUnavailableMessage(db), -1);
     goto reset_cleanup;
   }
 
@@ -2660,7 +2660,7 @@ static void doltliteMergeFunc(
   memset(&ancCommit, 0, sizeof(ancCommit));
   memset(&savedState, 0, sizeof(savedState));
 
-  if( !cs ){ sqlite3_result_error(context, "no database", -1); return; }
+  if( !cs ){ sqlite3_result_error(context, doltliteVcUnavailableMessage(db), -1); return; }
   if( argc<1 ){ sqlite3_result_error(context, "usage: dolt_merge('branch')", -1); return; }
 
   for(i=0; i<argc; i++){

--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -304,7 +304,7 @@ static void doltBranchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
   int hadSavepoint = db->pSavepoint!=0;
   int i, rc;
 
-  if( !cs ){ branchError(ctx, hadSavepoint, "no database"); return; }
+  if( !cs ){ branchError(ctx, hadSavepoint, doltliteVcUnavailableMessage(db)); return; }
   if( argc<1 ){ branchError(ctx, hadSavepoint, "dolt_branch requires arguments"); return; }
 
   for(i=0; i<argc; i++){
@@ -748,7 +748,7 @@ static void doltConnectBranchFunc(
   (void)argc;
   memset(&m, 0, sizeof(m));
   if( !cs ){
-    sqlite3_result_error(ctx, "no database open", -1);
+    sqlite3_result_error(ctx, doltliteVcUnavailableMessage(db), -1);
     return;
   }
   zBranch = (const char*)sqlite3_value_text(argv[0]);
@@ -1103,7 +1103,7 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
   int hadExplicitTxn = !db->autoCommit;
   int rc;
 
-  if( !cs ){ (void)doltliteVcSealSavepointError(db); sqlite3_result_error(ctx, "no database", -1); return; }
+  if( !cs ){ (void)doltliteVcSealSavepointError(db); sqlite3_result_error(ctx, doltliteVcUnavailableMessage(db), -1); return; }
   if( argc<1 ){ (void)doltliteVcSealSavepointError(db); sqlite3_result_error(ctx, "branch name required", -1); return; }
   zBranch = (const char*)sqlite3_value_text(argv[0]);
   if( !zBranch ){ (void)doltliteVcSealSavepointError(db); sqlite3_result_error(ctx, "branch name required", -1); return; }

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -182,6 +182,7 @@ static SQLITE_INLINE int doltliteFindTableRootByName(
 
 ChunkStore *doltliteGetChunkStore(sqlite3 *db);
 BtShared *doltliteGetBtShared(sqlite3 *db);
+int doltliteIsStockSqliteDb(sqlite3 *db);
 void doltliteInvalidateWorkingState(sqlite3 *db);
 ProllyCache *doltliteGetCache(sqlite3 *db);
 int doltliteLoadCatalog(sqlite3 *db, const ProllyHash *catHash,
@@ -369,6 +370,13 @@ static SQLITE_INLINE int doltliteAppendQuotedIdent(sqlite3_str *pStr,
                                                    const char *zName){
   sqlite3_str_appendf(pStr, "\"%w\"", zName ? zName : "");
   return sqlite3_str_errcode(pStr);
+}
+
+static SQLITE_INLINE const char *doltliteVcUnavailableMessage(sqlite3 *db){
+  if( doltliteIsStockSqliteDb(db) ){
+    return "dolt version-control features are not available on stock SQLite databases";
+  }
+  return "no database open";
 }
 
 static SQLITE_INLINE int doltliteGrowArrayImpl(

--- a/src/doltlite_log.c
+++ b/src/doltlite_log.c
@@ -185,7 +185,14 @@ static int doltliteLogFilter(
   }
 
   cs = doltliteGetChunkStore(pVtab->db);
-  if( !cs ) return SQLITE_OK;
+  if( !cs ){
+    if( doltliteIsStockSqliteDb(pVtab->db) ){
+      pCursor->pVtab->zErrMsg = sqlite3_mprintf("%s",
+          doltliteVcUnavailableMessage(pVtab->db));
+      return pCursor->pVtab->zErrMsg ? SQLITE_ERROR : SQLITE_NOMEM;
+    }
+    return SQLITE_OK;
+  }
 
   if( useStart ){
     head = startHash;

--- a/src/doltlite_status.c
+++ b/src/doltlite_status.c
@@ -528,7 +528,14 @@ static int statusFilter(sqlite3_vtab_cursor *pCursor,
 
   statusFreeRows(pCur);
   pCur->iRow = 0;
-  if( !cs ) return SQLITE_OK;
+  if( !cs ){
+    if( doltliteIsStockSqliteDb(db) ){
+      pCursor->pVtab->zErrMsg = sqlite3_mprintf("%s",
+          doltliteVcUnavailableMessage(db));
+      return pCursor->pVtab->zErrMsg ? SQLITE_ERROR : SQLITE_NOMEM;
+    }
+    return SQLITE_OK;
+  }
 
   rc = doltliteGetHeadCatalogHash(db, &headCatHash);
   if( rc != SQLITE_OK ) goto status_done;

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -4128,6 +4128,10 @@ int sqlite3BtreeOpen(
   return SQLITE_OK;
 }
 
+int sqlite3BtreeUsesOrig(Btree *p){
+  return p && p->pOps==&origBtreeVtOps;
+}
+
 static int prollyBtreeClose(Btree *p){
   BtShared *pBt;
 

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -8453,6 +8453,7 @@ static void doltiteEngineFunc(
 ChunkStore *doltliteGetChunkStore(sqlite3 *db){
   if( db && db->nDb>0 && db->aDb[0].pBt ){
     Btree *pBt = db->aDb[0].pBt;
+    if( sqlite3BtreeUsesOrig(pBt) ) return 0;
     return &pBt->pBt->store;
   }
   return 0;
@@ -8460,9 +8461,15 @@ ChunkStore *doltliteGetChunkStore(sqlite3 *db){
 
 BtShared *doltliteGetBtShared(sqlite3 *db){
   if( db && db->nDb>0 && db->aDb[0].pBt ){
+    if( sqlite3BtreeUsesOrig(db->aDb[0].pBt) ) return 0;
     return db->aDb[0].pBt->pBt;
   }
   return 0;
+}
+
+int doltliteIsStockSqliteDb(sqlite3 *db){
+  return db && db->nDb>0 && db->aDb[0].pBt
+      && sqlite3BtreeUsesOrig(db->aDb[0].pBt);
 }
 
 void doltliteInvalidateWorkingState(sqlite3 *db){

--- a/test/doltlite_open_sqlite_file.sh
+++ b/test/doltlite_open_sqlite_file.sh
@@ -18,6 +18,7 @@ TMP=$(mktemp -d)
 trap "rm -rf $TMP" EXIT
 PASS=0; FAIL=0; SKIP=0
 ERRORS=""
+VC_UNAVAILABLE="dolt version-control features are not available on stock SQLite databases"
 
 want_eq() {
   local name="$1" got="$2" want="$3"
@@ -41,6 +42,11 @@ sq_last() { printf '%s\n' "$1" | $SQLITE3 "$2" 2>&1 | tail -1; }
 dl_last() { printf '%s\n' "$1" | $DOLTLITE "$2" 2>&1 | tail -1; }
 # Run SQL on doltlite, return all output.
 dl_all()  { printf '%s\n' "$1" | $DOLTLITE "$2" 2>&1; }
+
+want_vc_unavailable() {
+  local name="$1" sql="$2" db="$3"
+  want_eq "$name" "$(dl_all "$sql" "$db" | grep -c "$VC_UNAVAILABLE")" "1"
+}
 
 # Seed a stock SQLite file at $1 with $2 (the schema/data SQL).
 seed_stock() {
@@ -92,6 +98,34 @@ want_eq "R6_non_integer_pk_reads_payload_columns" \
   "$(dl_last "SELECT group_concat(username||':'||email||':'||balance||':'||status, ',') FROM accounts ORDER BY username;" "$DB")" \
   "alice:alice@example.com:100:active,bob:bob@example.com:250:frozen,carol:carol@example.com:50:active"
 
+want_eq "R7_non_integer_pk_payload_predicate" \
+  "$(dl_last "SELECT username FROM accounts WHERE balance >= 200 AND status='frozen';" "$DB")" \
+  "bob"
+
+want_eq "R8_text_pk_rowid_still_available" \
+  "$(dl_last "SELECT count(*) FROM accounts WHERE rowid IS NOT NULL;" "$DB")" \
+  "3"
+
+want_eq "R9_text_pk_column_types_preserved" \
+  "$(dl_last "SELECT group_concat(typeof(email)||':'||typeof(balance)||':'||typeof(status), ',') FROM (SELECT * FROM accounts ORDER BY username);" "$DB")" \
+  "text:integer:text,text:integer:text,text:integer:text"
+
+DB=$TMP/r10.db
+seed_stock "$DB" "CREATE TABLE orders(region TEXT NOT NULL, order_id INTEGER NOT NULL, item TEXT, qty INTEGER, PRIMARY KEY(region, order_id)); INSERT INTO orders VALUES('east',1,'pen',2),('east',2,'pad',3),('west',1,'bag',4);"
+want_eq "R10_composite_pk_reads_payload_columns" \
+  "$(dl_last "SELECT group_concat(region||':'||order_id||':'||item||':'||qty, ',') FROM (SELECT * FROM orders ORDER BY region, order_id);" "$DB")" \
+  "east:1:pen:2,east:2:pad:3,west:1:bag:4"
+
+want_eq "R11_composite_pk_rowid_still_available" \
+  "$(dl_last "SELECT count(*) FROM orders WHERE rowid IS NOT NULL;" "$DB")" \
+  "3"
+
+DB=$TMP/r12.db
+seed_stock "$DB" "CREATE TABLE blobs(k BLOB NOT NULL PRIMARY KEY, label TEXT, n INTEGER); INSERT INTO blobs VALUES(x'01','one',1),(x'0203','two-three',23);"
+want_eq "R12_blob_pk_reads_payload_columns" \
+  "$(dl_last "SELECT group_concat(hex(k)||':'||label||':'||n, ',') FROM (SELECT * FROM blobs ORDER BY k);" "$DB")" \
+  "01:one:1,0203:two-three:23"
+
 # ============================================================
 # Autocommit writes
 # ============================================================
@@ -111,6 +145,22 @@ want_eq "W3_autocommit_delete" \
 
 want_eq "W4_bulk_insert" \
   "$(dl_last "INSERT INTO t SELECT n+10, hex(n) FROM (WITH RECURSIVE seq(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM seq WHERE n<50) SELECT n FROM seq); SELECT count(*) FROM t WHERE id>10;" "$DB")" "50"
+
+DB=$TMP/w5.db
+seed_stock "$DB" "CREATE TABLE accounts(username TEXT NOT NULL PRIMARY KEY, email TEXT, balance INTEGER, status TEXT); INSERT INTO accounts VALUES('alice','alice@example.com',100,'active'),('bob','bob@example.com',250,'frozen');"
+want_eq "W5_text_pk_insert_update_delete_payload" \
+  "$(dl_last "INSERT INTO accounts VALUES('carol','carol@example.com',50,'active'); UPDATE accounts SET balance=balance+5, status='active' WHERE username='bob'; DELETE FROM accounts WHERE username='alice'; SELECT group_concat(username||':'||email||':'||balance||':'||status, ',') FROM (SELECT * FROM accounts ORDER BY username);" "$DB")" \
+  "bob:bob@example.com:255:active,carol:carol@example.com:50:active"
+
+want_eq "W6_text_pk_writes_visible_to_stock" \
+  "$(sq_last "SELECT group_concat(username||':'||balance, ',') FROM (SELECT * FROM accounts ORDER BY username);" "$DB")" \
+  "bob:255,carol:50"
+
+DB=$TMP/w7.db
+seed_stock "$DB" "CREATE TABLE orders(region TEXT NOT NULL, order_id INTEGER NOT NULL, item TEXT, qty INTEGER, PRIMARY KEY(region, order_id)); INSERT INTO orders VALUES('east',1,'pen',2);"
+want_eq "W7_composite_pk_insert_update_payload" \
+  "$(dl_last "INSERT INTO orders VALUES('west',1,'bag',4); UPDATE orders SET qty=5 WHERE region='east' AND order_id=1; SELECT group_concat(region||':'||order_id||':'||item||':'||qty, ',') FROM (SELECT * FROM orders ORDER BY region, order_id);" "$DB")" \
+  "east:1:pen:5,west:1:bag:4"
 
 # ============================================================
 # DDL
@@ -150,6 +200,16 @@ seed_stock "$DB" "CREATE TABLE u(id INTEGER PRIMARY KEY, v TEXT); CREATE INDEX i
 want_eq "D7_reindex_populated_table" \
   "$(dl_last "REINDEX; SELECT id FROM u WHERE v='b';" "$DB")" "2"
 
+DB=$TMP/d8.db
+seed_stock "$DB" "CREATE TABLE existing(id INTEGER PRIMARY KEY);"
+want_eq "D8_create_text_pk_table_on_stock_file_keeps_rowid" \
+  "$(dl_last "CREATE TABLE created(k TEXT NOT NULL PRIMARY KEY, v TEXT, n INTEGER); INSERT INTO created VALUES('a','alpha',1),('b','beta',2); SELECT count(*)||':'||group_concat(k||':'||v||':'||n, ',') FROM (SELECT * FROM created WHERE rowid IS NOT NULL ORDER BY k);" "$DB")" \
+  "2:a:alpha:1,b:beta:2"
+
+want_eq "D9_created_text_pk_table_readable_by_stock" \
+  "$(sq_last "SELECT group_concat(k||':'||v||':'||n, ',') FROM (SELECT * FROM created ORDER BY k);" "$DB")" \
+  "a:alpha:1,b:beta:2"
+
 # ============================================================
 # Constraints (declared at table-create time)
 # ============================================================
@@ -170,6 +230,16 @@ DB=$TMP/c3.db
 seed_stock "$DB" "PRAGMA foreign_keys=1; CREATE TABLE p(id INTEGER PRIMARY KEY); CREATE TABLE c(id INTEGER PRIMARY KEY, pid INTEGER, FOREIGN KEY(pid) REFERENCES p(id)); INSERT INTO p VALUES(1); INSERT INTO c VALUES(1,1);"
 want_eq "C3_fk_constraint_enforced" \
   "$(dl_all "PRAGMA foreign_keys=1; INSERT INTO c VALUES(2,99);" "$DB" | grep -ci 'foreign key')" "1"
+
+DB=$TMP/c4.db
+seed_stock "$DB" "CREATE TABLE accounts(username TEXT NOT NULL PRIMARY KEY, email TEXT); INSERT INTO accounts VALUES('alice','alice@example.com');"
+want_eq "C4_text_pk_uniqueness_enforced" \
+  "$(dl_all "INSERT INTO accounts VALUES('alice','dup@example.com');" "$DB" | grep -ci 'unique')" "1"
+
+DB=$TMP/c5.db
+seed_stock "$DB" "CREATE TABLE orders(region TEXT NOT NULL, order_id INTEGER NOT NULL, item TEXT, PRIMARY KEY(region, order_id)); INSERT INTO orders VALUES('east',1,'pen');"
+want_eq "C5_composite_pk_uniqueness_enforced" \
+  "$(dl_all "INSERT INTO orders VALUES('east',1,'pad');" "$DB" | grep -ci 'unique')" "1"
 
 # ============================================================
 # Transactions
@@ -210,10 +280,29 @@ seed_stock "$DB" "CREATE TABLE t(id INTEGER PRIMARY KEY);"
 want_eq "V1_doltlite_engine_reports_orig" \
   "$(dl_last "SELECT doltlite_engine();" "$DB")" "orig"
 
-# dolt_log on a stock-format file: should pass through with no rows
-# rather than erroring or crashing.
-want_eq "V2_dolt_log_empty_on_stock_format" \
-  "$(dl_last "SELECT count(*) FROM dolt_log;" "$DB")" "0"
+want_vc_unavailable "V2_dolt_add_unavailable_on_stock_format" \
+  "SELECT dolt_add('-A');" "$DB"
+
+want_vc_unavailable "V3_dolt_commit_unavailable_on_stock_format" \
+  "SELECT dolt_commit('-m','stock');" "$DB"
+
+want_vc_unavailable "V4_dolt_branch_unavailable_on_stock_format" \
+  "SELECT dolt_branch('feat');" "$DB"
+
+want_vc_unavailable "V5_dolt_checkout_unavailable_on_stock_format" \
+  "SELECT dolt_checkout('feat');" "$DB"
+
+want_vc_unavailable "V6_dolt_merge_unavailable_on_stock_format" \
+  "SELECT dolt_merge('feat');" "$DB"
+
+want_vc_unavailable "V7_dolt_reset_unavailable_on_stock_format" \
+  "SELECT dolt_reset('--hard');" "$DB"
+
+want_vc_unavailable "V8_dolt_log_unavailable_on_stock_format" \
+  "SELECT count(*) FROM dolt_log;" "$DB"
+
+want_vc_unavailable "V9_dolt_status_unavailable_on_stock_format" \
+  "SELECT count(*) FROM dolt_status;" "$DB"
 
 # ============================================================
 # Durability across reopen

--- a/test/doltlite_open_sqlite_file.sh
+++ b/test/doltlite_open_sqlite_file.sh
@@ -86,6 +86,12 @@ want_eq "R4_select_via_pre_existing_index" \
 want_eq "R5_sqlite_master_visible" \
   "$(dl_last "SELECT count(*) FROM sqlite_master WHERE type='index' AND name='idx_v';" "$DB")" "1"
 
+DB=$TMP/r6.db
+seed_stock "$DB" "CREATE TABLE accounts(username VARCHAR NOT NULL PRIMARY KEY, email TEXT, balance INTEGER, status TEXT); INSERT INTO accounts VALUES('alice','alice@example.com',100,'active'),('bob','bob@example.com',250,'frozen'),('carol','carol@example.com',50,'active');"
+want_eq "R6_non_integer_pk_reads_payload_columns" \
+  "$(dl_last "SELECT group_concat(username||':'||email||':'||balance||':'||status, ',') FROM accounts ORDER BY username;" "$DB")" \
+  "alice:alice@example.com:100:active,bob:bob@example.com:250:frozen,carol:carol@example.com:50:active"
+
 # ============================================================
 # Autocommit writes
 # ============================================================


### PR DESCRIPTION
## Summary
- skip DoltLite non-integer-PK schema conversion for databases routed to the stock SQLite btree engine
- expose a small btree helper for detecting the orig-btree route
- add a regression for opening a stock SQLite file with a TEXT primary key and payload columns

Fixes https://github.com/dolthub/doltlite/issues/1099

## Tests
- make doltlite
- bash test/doltlite_open_sqlite_file.sh ./doltlite
- bash test/doltlite_attach_sqlite.sh ./doltlite
- bash test/oracle_without_rowid_test.sh ./doltlite ./sqlite3
- direct issue repro against a stock-created accounts.db