### PR TITLE
Dedup conflicts/constraint-violation array removal helpers

### DIFF
--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -35,36 +35,19 @@ static void freeConflictRow(struct ConflictRow *pRow){
 static void removeConflictRow(ConflictTableInfo *pTable, int iRow){
   if( !pTable || iRow<0 || iRow>=pTable->nConflicts ) return;
   freeConflictRow(&pTable->aRows[iRow]);
-  if( iRow < pTable->nConflicts - 1 ){
-    memmove(&pTable->aRows[iRow], &pTable->aRows[iRow+1],
-            (pTable->nConflicts - iRow - 1) * sizeof(struct ConflictRow));
-  }
-  pTable->nConflicts--;
-  if( pTable->aRows ){
-    memset(&pTable->aRows[pTable->nConflicts], 0, sizeof(struct ConflictRow));
-  }
+  doltliteArrayRemoveAt(pTable->aRows, &pTable->nConflicts, iRow,
+                        (int)sizeof(struct ConflictRow));
 }
 
 static void removeConflictTable(ConflictTableInfo *aTables, int *pnTables, int iTable){
-  int nTables;
-  if( !aTables || !pnTables ) return;
-  nTables = *pnTables;
-  if( iTable<0 || iTable>=nTables ) return;
+  int j;
+  if( !aTables || !pnTables || iTable<0 || iTable>=*pnTables ) return;
   sqlite3_free(aTables[iTable].zName);
-  {
-    int j;
-    for(j=0; j<aTables[iTable].nConflicts; j++){
-      freeConflictRow(&aTables[iTable].aRows[j]);
-    }
+  for(j=0; j<aTables[iTable].nConflicts; j++){
+    freeConflictRow(&aTables[iTable].aRows[j]);
   }
   sqlite3_free(aTables[iTable].aRows);
-  memset(&aTables[iTable], 0, sizeof(aTables[iTable]));
-  if( iTable < nTables - 1 ){
-    memmove(&aTables[iTable], &aTables[iTable+1],
-            (nTables - iTable - 1) * sizeof(ConflictTableInfo));
-  }
-  (*pnTables)--;
-  memset(&aTables[*pnTables], 0, sizeof(aTables[*pnTables]));
+  doltliteArrayRemoveAt(aTables, pnTables, iTable, (int)sizeof(ConflictTableInfo));
 }
 
 #define DOLTLITE_CONFLICTS_MAGIC0 'D'

--- a/src/doltlite_constraint_violations.c
+++ b/src/doltlite_constraint_violations.c
@@ -45,36 +45,19 @@ static void freeViolationTables(ConstraintViolationTable *a, int n){
 static void removeViolationRow(ConstraintViolationTable *pTable, int iRow){
   if( !pTable || iRow<0 || iRow>=pTable->nRows ) return;
   freeViolationRow(&pTable->aRows[iRow]);
-  if( iRow < pTable->nRows - 1 ){
-    memmove(&pTable->aRows[iRow], &pTable->aRows[iRow+1],
-            (pTable->nRows - iRow - 1) * sizeof(ConstraintViolationRow));
-  }
-  pTable->nRows--;
-  if( pTable->aRows ){
-    memset(&pTable->aRows[pTable->nRows], 0, sizeof(ConstraintViolationRow));
-  }
+  doltliteArrayRemoveAt(pTable->aRows, &pTable->nRows, iRow,
+                        (int)sizeof(ConstraintViolationRow));
 }
 
 static void removeViolationTable(ConstraintViolationTable *a, int *pn, int iTable){
-  int n;
-  if( !a || !pn ) return;
-  n = *pn;
-  if( iTable<0 || iTable>=n ) return;
+  int j;
+  if( !a || !pn || iTable<0 || iTable>=*pn ) return;
   sqlite3_free(a[iTable].zName);
-  {
-    int j;
-    for(j=0; j<a[iTable].nRows; j++){
-      freeViolationRow(&a[iTable].aRows[j]);
-    }
+  for(j=0; j<a[iTable].nRows; j++){
+    freeViolationRow(&a[iTable].aRows[j]);
   }
   sqlite3_free(a[iTable].aRows);
-  memset(&a[iTable], 0, sizeof(a[iTable]));
-  if( iTable < n - 1 ){
-    memmove(&a[iTable], &a[iTable+1],
-            (n - iTable - 1) * sizeof(ConstraintViolationTable));
-  }
-  (*pn)--;
-  memset(&a[*pn], 0, sizeof(a[*pn]));
+  doltliteArrayRemoveAt(a, pn, iTable, (int)sizeof(ConstraintViolationTable));
 }
 
 static ConstraintViolationTable *findOrCreateViolationTable(

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -52,6 +52,22 @@ static SQLITE_INLINE u64 doltliteFnv1aSep(u64 h){
   return h * DOLTLITE_FNV1A_PRIME;
 }
 
+/* Remove element iElem from a packed array of *pn elements of elemSize bytes:
+** shift the tail down, decrement *pn, and zero the freed slot. The caller must
+** release any memory the element owns first. */
+static SQLITE_INLINE void doltliteArrayRemoveAt(void *aBase, int *pn,
+                                                int iElem, int elemSize){
+  unsigned char *a = (unsigned char*)aBase;
+  int n = *pn;
+  if( !a || iElem<0 || iElem>=n ) return;
+  if( iElem < n-1 ){
+    memmove(a + (size_t)iElem*elemSize, a + (size_t)(iElem+1)*elemSize,
+            (size_t)(n-iElem-1)*elemSize);
+  }
+  *pn = n-1;
+  memset(a + (size_t)(n-1)*elemSize, 0, elemSize);
+}
+
 struct TableEntry {
   Pgno iTable;
   ProllyHash root;


### PR DESCRIPTION
Follow-on to #1101 (which landed the FNV-hash dedup). This is the array-removal-helper dedup that was pushed to that branch just after it merged, so it didn't make it in — re-homed here on a fresh branch off master.

`removeConflictRow/Table` and `removeViolationRow/Table` were four structurally identical functions: free the element's owned memory, then compact the packed array (memmove tail down, decrement count, zero freed slot). Only the struct type and count-field name differed.

Factor the compaction into `doltliteArrayRemoveAt(aBase, *pn, iElem, elemSize)` in `doltlite_internal.h`; each remover keeps its type-specific frees and calls the shared helper. Behavior-preserving.

3 files, +30/−48. Builds clean; `doltlite_regression_test_c` 309770/0, all 13 gating C tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)