### PR TITLE
Dedup conflicts/constraint-violation wire codecs via byte cursors

### DIFF
--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -79,7 +79,8 @@ int doltliteSerializeConflicts(
 ){
   int sz = 4 + 2;
   int i, j, rc;
-  u8 *buf, *p;
+  u8 *buf;
+  DlByteWriter w;
 
   for(i=0; i<nTables; i++){
     int nl = aTables[i].zName ? (int)strlen(aTables[i].zName) : 0;
@@ -95,39 +96,28 @@ int doltliteSerializeConflicts(
 
   buf = sqlite3_malloc(sz);
   if( !buf ) return SQLITE_NOMEM;
-  p = buf;
+  w.p = buf;
 
-  p[0] = DOLTLITE_CONFLICTS_MAGIC0;
-  p[1] = DOLTLITE_CONFLICTS_MAGIC1;
-  p[2] = DOLTLITE_CONFLICTS_MAGIC2;
-  p[3] = DOLTLITE_CONFLICTS_VERSION;
-  p += 4;
-  p[0]=(u8)nTables; p[1]=(u8)(nTables>>8); p+=2;
+  dlWriteU8(&w, DOLTLITE_CONFLICTS_MAGIC0);
+  dlWriteU8(&w, DOLTLITE_CONFLICTS_MAGIC1);
+  dlWriteU8(&w, DOLTLITE_CONFLICTS_MAGIC2);
+  dlWriteU8(&w, DOLTLITE_CONFLICTS_VERSION);
+  dlWriteU16(&w, nTables);
   for(i=0; i<nTables; i++){
     int nl = aTables[i].zName ? (int)strlen(aTables[i].zName) : 0;
-    int nc = aTables[i].nConflicts;
-    p[0]=(u8)nl; p[1]=(u8)(nl>>8); p+=2;
-    if(nl>0) memcpy(p, aTables[i].zName, nl);
-    p += nl;
-    p[0]=(u8)nc; p[1]=(u8)(nc>>8); p[2]=(u8)(nc>>16); p[3]=(u8)(nc>>24); p+=4;
-    for(j=0; j<nc; j++){
+    dlWriteU16Name(&w, aTables[i].zName, nl);
+    dlWriteU32(&w, aTables[i].nConflicts);
+    for(j=0; j<aTables[i].nConflicts; j++){
       struct ConflictRow *cr = &aTables[i].aRows[j];
-      i64 k = cr->intKey;
-      { int n=cr->nKey; p[0]=(u8)n; p[1]=(u8)(n>>8); p[2]=(u8)(n>>16); p[3]=(u8)(n>>24); p+=4; }
-      if(cr->nKey>0){ memcpy(p, cr->pKey, cr->nKey); p+=cr->nKey; }
-      p[0]=(u8)k; p[1]=(u8)(k>>8); p[2]=(u8)(k>>16); p[3]=(u8)(k>>24);
-      p[4]=(u8)(k>>32); p[5]=(u8)(k>>40); p[6]=(u8)(k>>48); p[7]=(u8)(k>>56);
-      p+=8;
-      { int n=cr->nBaseVal; p[0]=(u8)n; p[1]=(u8)(n>>8); p[2]=(u8)(n>>16); p[3]=(u8)(n>>24); p+=4; }
-      if(cr->nBaseVal>0){ memcpy(p, cr->pBaseVal, cr->nBaseVal); p+=cr->nBaseVal; }
-      { int n=cr->nOurVal; p[0]=(u8)n; p[1]=(u8)(n>>8); p[2]=(u8)(n>>16); p[3]=(u8)(n>>24); p+=4; }
-      if(cr->nOurVal>0){ memcpy(p, cr->pOurVal, cr->nOurVal); p+=cr->nOurVal; }
-      { int n=cr->nTheirVal; p[0]=(u8)n; p[1]=(u8)(n>>8); p[2]=(u8)(n>>16); p[3]=(u8)(n>>24); p+=4; }
-      if(cr->nTheirVal>0){ memcpy(p, cr->pTheirVal, cr->nTheirVal); p+=cr->nTheirVal; }
+      dlWriteU32Blob(&w, cr->pKey, cr->nKey);
+      dlWriteI64(&w, cr->intKey);
+      dlWriteU32Blob(&w, cr->pBaseVal, cr->nBaseVal);
+      dlWriteU32Blob(&w, cr->pOurVal, cr->nOurVal);
+      dlWriteU32Blob(&w, cr->pTheirVal, cr->nTheirVal);
     }
   }
 
-  rc = chunkStorePut(cs, buf, (int)(p-buf), pHash);
+  rc = chunkStorePut(cs, buf, (int)(w.p-buf), pHash);
   sqlite3_free(buf);
   return rc;
 }
@@ -140,7 +130,7 @@ static int loadAllConflicts(
   ProllyHash hash;
   u8 *data = 0; int nData = 0;
   extern void doltliteGetSessionConflictsCatalog(sqlite3*, ProllyHash*);
-  const u8 *p;
+  DlByteReader r;
   int nTables, i, j, rc;
   ConflictTableInfo *aTables;
 
@@ -151,38 +141,29 @@ static int loadAllConflicts(
   if( rc!=SQLITE_OK ) return rc;
   if( nData<(4+2) ){ sqlite3_free(data); return SQLITE_CORRUPT; }
 
-  p = data;
-
-  if( p[0]!=DOLTLITE_CONFLICTS_MAGIC0
-   || p[1]!=DOLTLITE_CONFLICTS_MAGIC1
-   || p[2]!=DOLTLITE_CONFLICTS_MAGIC2
-   || p[3]!=DOLTLITE_CONFLICTS_VERSION ){
+  dlReaderInit(&r, data, nData);
+  if( dlReadU8(&r)!=DOLTLITE_CONFLICTS_MAGIC0
+   || dlReadU8(&r)!=DOLTLITE_CONFLICTS_MAGIC1
+   || dlReadU8(&r)!=DOLTLITE_CONFLICTS_MAGIC2
+   || dlReadU8(&r)!=DOLTLITE_CONFLICTS_VERSION ){
     sqlite3_free(data);
     return SQLITE_CORRUPT;
   }
-  p += 4;
-  nTables = p[0]|(p[1]<<8); p+=2;
+  nTables = dlReadU16(&r);
 
   aTables = sqlite3_malloc(nTables * (int)sizeof(ConflictTableInfo));
   if( !aTables ){ sqlite3_free(data); return SQLITE_NOMEM; }
   memset(aTables, 0, nTables * (int)sizeof(ConflictTableInfo));
 
   for(i=0; i<nTables; i++){
-    int nl, nc;
-    if( p+2 > data+nData ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
-    nl = p[0]|(p[1]<<8); p+=2;
-    if( nl<0 || (size_t)nl > (size_t)(data+nData - p) ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
-    aTables[i].zName = sqlite3_malloc(nl+1);
-    if( !aTables[i].zName ){ rc = SQLITE_NOMEM; goto conflicts_cleanup; }
-    memcpy(aTables[i].zName, p, nl); aTables[i].zName[nl]=0;
-    p += nl;
-    if( p+4 > data+nData ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
-    nc = p[0]|(p[1]<<8)|(p[2]<<16)|(p[3]<<24); p+=4;
-    if( nc<0 ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
-    /* Validate that nc*sizeof(struct ConflictRow) fits within remaining bytes
-    ** (each row carries at least 4+8+4+4+4 = 24 header bytes), and use
-    ** sqlite3_malloc64 to avoid 32-bit multiplication overflow. */
-    if( (sqlite3_uint64)nc > (sqlite3_uint64)(data+nData - p) ){
+    int nc;
+    rc = dlReadU16Name(&r, &aTables[i].zName);
+    if( rc!=SQLITE_OK ) goto conflicts_cleanup;
+    nc = dlReadU32(&r);
+    if( r.err || nc<0 ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
+    /* Reject impossible counts up front: each row needs at least one byte, so
+    ** nc can't exceed the bytes remaining. malloc64 avoids 32-bit overflow. */
+    if( (sqlite3_uint64)nc > (sqlite3_uint64)(r.end - r.p) ){
       rc = SQLITE_CORRUPT; goto conflicts_cleanup;
     }
     aTables[i].nConflicts = nc;
@@ -192,55 +173,19 @@ static int loadAllConflicts(
 
     for(j=0; j<nc; j++){
       struct ConflictRow *cr = &aTables[i].aRows[j];
-      int kvl, bvl, ovl, tvl;
-      if( p+4 > data+nData ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
-      kvl = p[0]|(p[1]<<8)|(p[2]<<16)|(p[3]<<24); p+=4;
-      if( kvl<0 || (size_t)kvl > (size_t)(data+nData - p) ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
-      if(kvl>0){
-        cr->pKey = sqlite3_malloc(kvl);
-        if( !cr->pKey ){ rc = SQLITE_NOMEM; goto conflicts_cleanup; }
-        memcpy(cr->pKey, p, kvl);
-        cr->nKey = kvl;
-      }
-      p += kvl;
-      if( p+8 > data+nData ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
-      cr->intKey = (i64)((u64)p[0] | ((u64)p[1]<<8) | ((u64)p[2]<<16) | ((u64)p[3]<<24) |
-                         ((u64)p[4]<<32) | ((u64)p[5]<<40) | ((u64)p[6]<<48) | ((u64)p[7]<<56));
-      p+=8;
-      if( p+4 > data+nData ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
-      bvl = p[0]|(p[1]<<8)|(p[2]<<16)|(p[3]<<24); p+=4;
-      if( bvl<0 || (size_t)bvl > (size_t)(data+nData - p) ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
-      if(bvl>0){
-        cr->pBaseVal = sqlite3_malloc(bvl);
-        if( !cr->pBaseVal ){ rc = SQLITE_NOMEM; goto conflicts_cleanup; }
-        memcpy(cr->pBaseVal, p, bvl);
-        cr->nBaseVal = bvl;
-      }
-      p += bvl;
-      if( p+4 > data+nData ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
-      ovl = p[0]|(p[1]<<8)|(p[2]<<16)|(p[3]<<24); p+=4;
-      if( ovl<0 || (size_t)ovl > (size_t)(data+nData - p) ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
-      if(ovl>0){
-        cr->pOurVal = sqlite3_malloc(ovl);
-        if( !cr->pOurVal ){ rc = SQLITE_NOMEM; goto conflicts_cleanup; }
-        memcpy(cr->pOurVal, p, ovl);
-        cr->nOurVal = ovl;
-      }
-      p += ovl;
-      if( p+4 > data+nData ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
-      tvl = p[0]|(p[1]<<8)|(p[2]<<16)|(p[3]<<24); p+=4;
-      if( tvl<0 || (size_t)tvl > (size_t)(data+nData - p) ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
-      if(tvl>0){
-        cr->pTheirVal = sqlite3_malloc(tvl);
-        if( !cr->pTheirVal ){ rc = SQLITE_NOMEM; goto conflicts_cleanup; }
-        memcpy(cr->pTheirVal, p, tvl);
-        cr->nTheirVal = tvl;
-      }
-      p += tvl;
+      rc = dlReadU32Blob(&r, &cr->pKey, &cr->nKey);
+      if( rc!=SQLITE_OK ) goto conflicts_cleanup;
+      cr->intKey = dlReadI64(&r);
+      rc = dlReadU32Blob(&r, &cr->pBaseVal, &cr->nBaseVal);
+      if( rc!=SQLITE_OK ) goto conflicts_cleanup;
+      rc = dlReadU32Blob(&r, &cr->pOurVal, &cr->nOurVal);
+      if( rc!=SQLITE_OK ) goto conflicts_cleanup;
+      rc = dlReadU32Blob(&r, &cr->pTheirVal, &cr->nTheirVal);
+      if( rc!=SQLITE_OK ) goto conflicts_cleanup;
     }
   }
 
-  if( p!=data+nData ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
+  if( r.err || r.p != r.end ){ rc = SQLITE_CORRUPT; goto conflicts_cleanup; }
 
   *ppTables = aTables;
   *pnTables = nTables;

--- a/src/doltlite_constraint_violations.c
+++ b/src/doltlite_constraint_violations.c
@@ -113,7 +113,8 @@ static int serializeViolations(
 ){
   int sz = 4 + 2;
   int i, j, rc;
-  u8 *buf, *p;
+  u8 *buf;
+  DlByteWriter w;
 
   for(i=0; i<nTables; i++){
     int nl = aTables[i].zName ? (int)strlen(aTables[i].zName) : 0;
@@ -131,51 +132,30 @@ static int serializeViolations(
 
   buf = sqlite3_malloc(sz);
   if( !buf ) return SQLITE_NOMEM;
-  p = buf;
+  w.p = buf;
 
-  p[0] = DCV_MAGIC0;
-  p[1] = DCV_MAGIC1;
-  p[2] = DCV_MAGIC2;
-  p[3] = DCV_VERSION;
-  p += 4;
-  p[0] = (u8)nTables; p[1] = (u8)(nTables>>8); p += 2;
+  dlWriteU8(&w, DCV_MAGIC0);
+  dlWriteU8(&w, DCV_MAGIC1);
+  dlWriteU8(&w, DCV_MAGIC2);
+  dlWriteU8(&w, DCV_VERSION);
+  dlWriteU16(&w, nTables);
 
   for(i=0; i<nTables; i++){
     int nl = aTables[i].zName ? (int)strlen(aTables[i].zName) : 0;
-    int nr = aTables[i].nRows;
-    p[0] = (u8)nl; p[1] = (u8)(nl>>8); p += 2;
-    if( nl>0 ){ memcpy(p, aTables[i].zName, nl); p += nl; }
-    p[0]=(u8)nr; p[1]=(u8)(nr>>8); p[2]=(u8)(nr>>16); p[3]=(u8)(nr>>24); p += 4;
-    for(j=0; j<nr; j++){
+    dlWriteU16Name(&w, aTables[i].zName, nl);
+    dlWriteU32(&w, aTables[i].nRows);
+    for(j=0; j<aTables[i].nRows; j++){
       ConstraintViolationRow *r = &aTables[i].aRows[j];
       int ni = r->zInfo ? (int)strlen(r->zInfo) : 0;
-
-      *p++ = (u8)r->violationType;
-
-      p[0]=(u8)r->nKey; p[1]=(u8)(r->nKey>>8);
-      p[2]=(u8)(r->nKey>>16); p[3]=(u8)(r->nKey>>24); p+=4;
-      if( r->nKey>0 ){ memcpy(p, r->pKey, r->nKey); p += r->nKey; }
-
-      {
-        u64 k = (u64)r->intKey;
-        p[0]=(u8)k;      p[1]=(u8)(k>>8);
-        p[2]=(u8)(k>>16); p[3]=(u8)(k>>24);
-        p[4]=(u8)(k>>32); p[5]=(u8)(k>>40);
-        p[6]=(u8)(k>>48); p[7]=(u8)(k>>56);
-        p += 8;
-      }
-
-      p[0]=(u8)r->nVal; p[1]=(u8)(r->nVal>>8);
-      p[2]=(u8)(r->nVal>>16); p[3]=(u8)(r->nVal>>24); p+=4;
-      if( r->nVal>0 ){ memcpy(p, r->pVal, r->nVal); p += r->nVal; }
-
-      p[0]=(u8)ni; p[1]=(u8)(ni>>8);
-      p[2]=(u8)(ni>>16); p[3]=(u8)(ni>>24); p+=4;
-      if( ni>0 ){ memcpy(p, r->zInfo, ni); p += ni; }
+      dlWriteU8(&w, (u8)r->violationType);
+      dlWriteU32Blob(&w, r->pKey, r->nKey);
+      dlWriteI64(&w, r->intKey);
+      dlWriteU32Blob(&w, r->pVal, r->nVal);
+      dlWriteU32Blob(&w, (const u8*)r->zInfo, ni);
     }
   }
 
-  rc = chunkStorePut(cs, buf, (int)(p-buf), pHash);
+  rc = chunkStorePut(cs, buf, (int)(w.p-buf), pHash);
   sqlite3_free(buf);
   return rc;
 }
@@ -187,7 +167,7 @@ static int loadAllViolations(
 ){
   ProllyHash hash;
   u8 *data = 0; int nData = 0;
-  const u8 *p;
+  DlByteReader rd;
   int nTables, i, j, rc;
   ConstraintViolationTable *aTables;
 
@@ -201,16 +181,15 @@ static int loadAllViolations(
   if( rc!=SQLITE_OK ) return rc;
   if( nData<(4+2) ){ sqlite3_free(data); return SQLITE_CORRUPT; }
 
-  p = data;
-  if( p[0]!=DCV_MAGIC0
-   || p[1]!=DCV_MAGIC1
-   || p[2]!=DCV_MAGIC2
-   || p[3]!=DCV_VERSION ){
+  dlReaderInit(&rd, data, nData);
+  if( dlReadU8(&rd)!=DCV_MAGIC0
+   || dlReadU8(&rd)!=DCV_MAGIC1
+   || dlReadU8(&rd)!=DCV_MAGIC2
+   || dlReadU8(&rd)!=DCV_VERSION ){
     sqlite3_free(data);
     return SQLITE_CORRUPT;
   }
-  p += 4;
-  nTables = p[0] | (p[1]<<8); p += 2;
+  nTables = dlReadU16(&rd);
   if( nTables<0 ){ sqlite3_free(data); return SQLITE_CORRUPT; }
 
   aTables = sqlite3_malloc(nTables ? nTables * (int)sizeof(*aTables) : 1);
@@ -218,21 +197,15 @@ static int loadAllViolations(
   memset(aTables, 0, nTables ? nTables * (int)sizeof(*aTables) : 1);
 
   for(i=0; i<nTables; i++){
-    int nl, nr;
-    if( p+2 > data+nData ){ rc = SQLITE_CORRUPT; goto fail; }
-    nl = p[0] | (p[1]<<8); p += 2;
-    if( nl<0 || (size_t)nl > (size_t)(data+nData - p) ){ rc = SQLITE_CORRUPT; goto fail; }
-    aTables[i].zName = sqlite3_malloc(nl+1);
-    if( !aTables[i].zName ){ rc = SQLITE_NOMEM; goto fail; }
-    memcpy(aTables[i].zName, p, nl); aTables[i].zName[nl] = 0;
-    p += nl;
-    if( p+4 > data+nData ){ rc = SQLITE_CORRUPT; goto fail; }
-    nr = p[0]|(p[1]<<8)|(p[2]<<16)|(p[3]<<24); p+=4;
-    if( nr<0 ){ rc = SQLITE_CORRUPT; goto fail; }
+    int nr;
+    rc = dlReadU16Name(&rd, &aTables[i].zName);
+    if( rc!=SQLITE_OK ) goto fail;
+    nr = dlReadU32(&rd);
+    if( rd.err || nr<0 ){ rc = SQLITE_CORRUPT; goto fail; }
     /* Reject impossible counts up front: every row needs at least one byte, so
     ** nr can't exceed the bytes remaining. sqlite3_malloc64 below avoids 32-bit
     ** overflow on the row-array allocation. */
-    if( (sqlite3_uint64)nr > (sqlite3_uint64)(data+nData - p) ){
+    if( (sqlite3_uint64)nr > (sqlite3_uint64)(rd.end - rd.p) ){
       rc = SQLITE_CORRUPT; goto fail;
     }
     aTables[i].nRows = nr;
@@ -242,46 +215,18 @@ static int loadAllViolations(
 
     for(j=0; j<nr; j++){
       ConstraintViolationRow *r = &aTables[i].aRows[j];
-      int kvl, vvl, nil_;
-      if( p+1 > data+nData ){ rc = SQLITE_CORRUPT; goto fail; }
-      r->violationType = *p++;
-      if( p+4 > data+nData ){ rc = SQLITE_CORRUPT; goto fail; }
-      kvl = p[0]|(p[1]<<8)|(p[2]<<16)|(p[3]<<24); p+=4;
-      if( kvl<0 || (size_t)kvl > (size_t)(data+nData - p) ){ rc = SQLITE_CORRUPT; goto fail; }
-      if( kvl>0 ){
-        rc = dupBytes(p, kvl, &r->pKey);
-        if( rc!=SQLITE_OK ) goto fail;
-        r->nKey = kvl;
-      }
-      p += kvl;
-      if( p+8 > data+nData ){ rc = SQLITE_CORRUPT; goto fail; }
-      r->intKey = (i64)((u64)p[0] | ((u64)p[1]<<8) | ((u64)p[2]<<16) |
-                        ((u64)p[3]<<24) | ((u64)p[4]<<32) | ((u64)p[5]<<40) |
-                        ((u64)p[6]<<48) | ((u64)p[7]<<56));
-      p += 8;
-      if( p+4 > data+nData ){ rc = SQLITE_CORRUPT; goto fail; }
-      vvl = p[0]|(p[1]<<8)|(p[2]<<16)|(p[3]<<24); p+=4;
-      if( vvl<0 || (size_t)vvl > (size_t)(data+nData - p) ){ rc = SQLITE_CORRUPT; goto fail; }
-      if( vvl>0 ){
-        rc = dupBytes(p, vvl, &r->pVal);
-        if( rc!=SQLITE_OK ) goto fail;
-        r->nVal = vvl;
-      }
-      p += vvl;
-      if( p+4 > data+nData ){ rc = SQLITE_CORRUPT; goto fail; }
-      nil_ = p[0]|(p[1]<<8)|(p[2]<<16)|(p[3]<<24); p+=4;
-      if( nil_<0 || (size_t)nil_ > (size_t)(data+nData - p) ){ rc = SQLITE_CORRUPT; goto fail; }
-      if( nil_>0 ){
-        r->zInfo = sqlite3_malloc(nil_+1);
-        if( !r->zInfo ){ rc = SQLITE_NOMEM; goto fail; }
-        memcpy(r->zInfo, p, nil_);
-        r->zInfo[nil_] = 0;
-        p += nil_;
-      }
+      r->violationType = dlReadU8(&rd);
+      rc = dlReadU32Blob(&rd, &r->pKey, &r->nKey);
+      if( rc!=SQLITE_OK ) goto fail;
+      r->intKey = dlReadI64(&rd);
+      rc = dlReadU32Blob(&rd, &r->pVal, &r->nVal);
+      if( rc!=SQLITE_OK ) goto fail;
+      rc = dlReadU32Str(&rd, &r->zInfo);
+      if( rc!=SQLITE_OK ) goto fail;
     }
   }
 
-  if( p != data+nData ){ rc = SQLITE_CORRUPT; goto fail; }
+  if( rd.err || rd.p != rd.end ){ rc = SQLITE_CORRUPT; goto fail; }
 
   *ppTables = aTables;
   *pnTables = nTables;

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -213,6 +213,105 @@ static SQLITE_INLINE int doltliteFindTableRootByName(
   return SQLITE_NOTFOUND;
 }
 
+/* Little-endian read/write cursors for the hand-rolled conflicts and
+** constraint-violation on-disk codecs. The reader is sticky: any short read
+** sets ->err and yields 0, so a group of fields can be read then checked once.
+** Blob/name/string readers also return SQLITE_CORRUPT (bad length) or
+** SQLITE_NOMEM directly. */
+typedef struct DlByteReader { const u8 *p; const u8 *end; int err; } DlByteReader;
+
+static SQLITE_INLINE void dlReaderInit(DlByteReader *r, const u8 *data, int n){
+  r->p = data; r->end = data + n; r->err = 0;
+}
+static SQLITE_INLINE u8 dlReadU8(DlByteReader *r){
+  if( r->err || r->p+1 > r->end ){ r->err = 1; return 0; }
+  return *r->p++;
+}
+static SQLITE_INLINE int dlReadU16(DlByteReader *r){
+  if( r->err || r->p+2 > r->end ){ r->err = 1; return 0; }
+  { int v = r->p[0] | (r->p[1]<<8); r->p += 2; return v; }
+}
+static SQLITE_INLINE int dlReadU32(DlByteReader *r){
+  if( r->err || r->p+4 > r->end ){ r->err = 1; return 0; }
+  { int v = r->p[0] | (r->p[1]<<8) | (r->p[2]<<16) | (r->p[3]<<24);
+    r->p += 4; return v; }
+}
+static SQLITE_INLINE i64 dlReadI64(DlByteReader *r){
+  if( r->err || r->p+8 > r->end ){ r->err = 1; return 0; }
+  { i64 v = (i64)((u64)r->p[0] | ((u64)r->p[1]<<8) | ((u64)r->p[2]<<16)
+                | ((u64)r->p[3]<<24) | ((u64)r->p[4]<<32) | ((u64)r->p[5]<<40)
+                | ((u64)r->p[6]<<48) | ((u64)r->p[7]<<56));
+    r->p += 8; return v; }
+}
+/* u32-length-prefixed raw value blob; empty -> (*pp=0,*pn=0). */
+static SQLITE_INLINE int dlReadU32Blob(DlByteReader *r, u8 **pp, int *pn){
+  int n = dlReadU32(r);
+  *pp = 0; *pn = 0;
+  if( r->err ) return SQLITE_CORRUPT;
+  if( n<0 || (size_t)n > (size_t)(r->end - r->p) ){ r->err = 1; return SQLITE_CORRUPT; }
+  if( n>0 ){
+    *pp = sqlite3_malloc(n);
+    if( !*pp ) return SQLITE_NOMEM;
+    memcpy(*pp, r->p, n);
+    *pn = n;
+  }
+  r->p += n;
+  return SQLITE_OK;
+}
+/* u16-length-prefixed name -> fresh nul-terminated string (empty -> ""). */
+static SQLITE_INLINE int dlReadU16Name(DlByteReader *r, char **pz){
+  int n = dlReadU16(r);
+  *pz = 0;
+  if( r->err ) return SQLITE_CORRUPT;
+  if( n<0 || (size_t)n > (size_t)(r->end - r->p) ){ r->err = 1; return SQLITE_CORRUPT; }
+  *pz = sqlite3_malloc(n+1);
+  if( !*pz ) return SQLITE_NOMEM;
+  memcpy(*pz, r->p, n);
+  (*pz)[n] = 0;
+  r->p += n;
+  return SQLITE_OK;
+}
+/* u32-length-prefixed string -> fresh nul-terminated string; empty -> NULL. */
+static SQLITE_INLINE int dlReadU32Str(DlByteReader *r, char **pz){
+  int n = dlReadU32(r);
+  *pz = 0;
+  if( r->err ) return SQLITE_CORRUPT;
+  if( n<0 || (size_t)n > (size_t)(r->end - r->p) ){ r->err = 1; return SQLITE_CORRUPT; }
+  if( n>0 ){
+    *pz = sqlite3_malloc(n+1);
+    if( !*pz ) return SQLITE_NOMEM;
+    memcpy(*pz, r->p, n);
+    (*pz)[n] = 0;
+    r->p += n;
+  }
+  return SQLITE_OK;
+}
+
+typedef struct DlByteWriter { u8 *p; } DlByteWriter;
+static SQLITE_INLINE void dlWriteU8(DlByteWriter *w, u8 v){ *w->p++ = v; }
+static SQLITE_INLINE void dlWriteU16(DlByteWriter *w, int v){
+  w->p[0]=(u8)v; w->p[1]=(u8)(v>>8); w->p+=2;
+}
+static SQLITE_INLINE void dlWriteU32(DlByteWriter *w, int v){
+  w->p[0]=(u8)v; w->p[1]=(u8)(v>>8); w->p[2]=(u8)(v>>16); w->p[3]=(u8)(v>>24);
+  w->p+=4;
+}
+static SQLITE_INLINE void dlWriteI64(DlByteWriter *w, i64 v){
+  u64 k = (u64)v; int i;
+  for(i=0; i<8; i++) w->p[i] = (u8)(k >> (i*8));
+  w->p += 8;
+}
+static SQLITE_INLINE void dlWriteU32Blob(DlByteWriter *w, const u8 *p, int n){
+  dlWriteU32(w, n);
+  if( n>0 ) memcpy(w->p, p, n);
+  w->p += n;
+}
+static SQLITE_INLINE void dlWriteU16Name(DlByteWriter *w, const char *z, int n){
+  dlWriteU16(w, n);
+  if( n>0 ) memcpy(w->p, z, n);
+  w->p += n;
+}
+
 ChunkStore *doltliteGetChunkStore(sqlite3 *db);
 BtShared *doltliteGetBtShared(sqlite3 *db);
 void doltliteInvalidateWorkingState(sqlite3 *db);


### PR DESCRIPTION
The last piece of the conflicts.c↔constraint_violations.c mirror. Both on-disk codecs hand-rolled the same little-endian framing — ~50 copies of the `p[0]=(u8)n; p[1]=(u8)(n>>8); …` write idiom and the `if(p+N>end) CORRUPT; v=p[0]|…` read+bounds-check idiom, plus identical length-prefixed-blob and table-frame logic.

Adds shared byte cursors in `doltlite_internal.h`:
- **write cursor** — `dlWriteU8/U16/U32/I64/U32Blob/U16Name`
- **sticky-error read cursor** — `dlReadU8/U16/U32/I64` + `dlReadU32Blob`/`dlReadU16Name`/`dlReadU32Str`, with the bounds/length checks centralized.

`serializeConflicts`/`loadAllConflicts` and `serializeViolations`/`loadAllViolations` now read declaratively; the per-row bodies stay file-specific (different field sets) but every byte-twiddle and bounds check becomes a primitive call. **Wire format is byte-for-byte unchanged.**

The win here is correctness as much as line count: the corruption bounds checks now live in one audited place rather than being re-hand-rolled per field (where an off-by-one is an overread).

Independent of the pending #1104 (removal-helper dedup) — disjoint regions. Builds clean; `doltlite_regression_test_c` 309770/0 (incl. `conflicts_blob_corruption`, `record_decode_corruption`, refs-corruption, integrity checks), all 13 gating C tests pass, full shell suite 66/67 (env-only `doltlite_parity.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)