### PR TITLE
cleanup: remove dead code and dedup trivial helpers (tier 1+2)

### DIFF
--- a/src/chunk_wal.c
+++ b/src/chunk_wal.c
@@ -264,9 +264,9 @@ int csReplayWal(ChunkStore *cs){
           break;
         }
 
-        cs->index.nChunks = (int)CS_READ_U32(m + 28);
+        cs->index.nChunks = (int)CS_READ_U32(m + CS_MANIFEST_CHUNK_COUNT_OFF);
 
-        memcpy(cs->refs.refsHash.data, m + 104, PROLLY_HASH_SIZE);
+        memcpy(cs->refs.refsHash.data, m + CS_MANIFEST_REFS_HASH_OFF, PROLLY_HASH_SIZE);
       }
       pos = recPos + 1 + CHUNK_MANIFEST_SIZE;
       nRootedPending = cs->staging.nPending;

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -71,7 +71,6 @@ extern int doltliteTagRegister(sqlite3 *db);
 extern int doltliteGcRegister(sqlite3 *db);
 extern int doltliteRegisterDiffTables(sqlite3 *db);
 extern int doltliteAncestorRegister(sqlite3 *db);
-extern int doltliteAtRegister(sqlite3 *db);
 extern int doltliteRegisterAtTables(sqlite3 *db);
 extern int doltliteRegisterHistoryTables(sqlite3 *db);
 extern int doltliteRegisterBlameTables(sqlite3 *db);
@@ -84,8 +83,6 @@ extern int doltliteFindAncestor(sqlite3 *db, const ProllyHash *h1,
 
 extern const char *doltliteNextTableForSchema(sqlite3 *db, int *pIdx, Pgno *piTable);
 extern void doltliteSetTableSchemaHash(sqlite3 *db, Pgno iTable, const ProllyHash *pH);
-
-int doltliteMaterializeDefaultColumns(sqlite3 *db);
 
 void doltliteTxnStateClear(DoltliteTxnState *p){
   sqlite3_free(p->zSessionBranch);
@@ -1900,7 +1897,6 @@ static void doltliteCommitFunc(
   {
     ProllyHash parentHash;
     char *zParsedName = 0, *zParsedEmail = 0;
-    char *zTrimmedMessage = 0;
     doltliteGetSessionHead(db, &parentHash);
 
     if( amend ){
@@ -1971,7 +1967,6 @@ static void doltliteCommitFunc(
 
     rc = doltliteCreateAndStoreCommitWithTime(db, &parentHash, &catalogHash,
         zMessage, zParsedName, zParsedEmail, 0, 0, explicitTimestamp, &commitHash);
-    sqlite3_free(zTrimmedMessage);
     sqlite3_free(zParsedName);
     sqlite3_free(zParsedEmail);
     if( rc!=SQLITE_OK ){
@@ -3145,11 +3140,13 @@ static int applyMergedCatalogAndCommit(
   char *zMergeErr = 0;
   int graphLocked = 0;
   int bPreferOurMaster;
+  const char *zOpLabel;
   int rc;
 
   memset(&savedState, 0, sizeof(savedState));
   if( hexBuf ) hexBuf[0] = '\0';
   bPreferOurMaster = (sqlite3_strnicmp(zMessage, "Revert", 6)==0);
+  zOpLabel = bPreferOurMaster ? "Revert" : "Cherry-pick";
 
   rc = doltliteEnsureWriteTxnAndSavepoints(db);
   if( rc!=SQLITE_OK ) return rc;
@@ -3247,9 +3244,7 @@ static int applyMergedCatalogAndCommit(
           "constraint violations, transaction rolled back.", -1);
         break;
       case DOLTLITE_VC_TXN_PLAIN:
-        rc = doltliteReportConstraintViolations(db, context,
-                                 sqlite3_strnicmp(zMessage, "Revert", 6)==0
-                                   ? "Revert" : "Cherry-pick");
+        rc = doltliteReportConstraintViolations(db, context, zOpLabel);
         if( rc!=SQLITE_OK ) goto apply_rollback;
         rc = doltliteVcSealActiveSavepoints(db);
         if( rc!=SQLITE_OK ) goto apply_rollback;
@@ -3283,9 +3278,7 @@ static int applyMergedCatalogAndCommit(
       if( rc!=SQLITE_OK ) return rc;
       return SQLITE_OK;
     case DOLTLITE_VC_TXN_PLAIN:
-      rc = doltliteReportConflicts(db, context, *pnConflicts,
-                                   sqlite3_strnicmp(zMessage, "Revert", 6)==0
-                                     ? "Revert" : "Cherry-pick");
+      rc = doltliteReportConflicts(db, context, *pnConflicts, zOpLabel);
       if( rc!=SQLITE_OK ) goto apply_rollback;
       rc = doltliteVcSealActiveSavepoints(db);
       if( rc!=SQLITE_OK ) goto apply_rollback;
@@ -3298,8 +3291,7 @@ static int applyMergedCatalogAndCommit(
         char msg[256];
         sqlite3_snprintf(sizeof(msg), msg,
           "%s has %d conflict(s). Resolve and then commit with dolt_commit.",
-          sqlite3_strnicmp(zMessage, "Revert", 6)==0 ? "Revert" : "Cherry-pick",
-          *pnConflicts);
+          zOpLabel, *pnConflicts);
         sqlite3_result_error(context, msg, -1);
       }
       return SQLITE_OK;
@@ -5020,7 +5012,7 @@ void doltliteRegister(sqlite3 *db){
   if( doltliteGcRegister(db)!=SQLITE_OK ) return;
   if( doltliteRegisterDiffTables(db)!=SQLITE_OK ) return;
   if( doltliteAncestorRegister(db)!=SQLITE_OK ) return;
-  if( doltliteAtRegister(db)!=SQLITE_OK ) return;
+  if( doltliteRegisterAtTables(db)!=SQLITE_OK ) return;
   if( doltliteRegisterHistoryTables(db)!=SQLITE_OK ) return;
   if( doltliteRegisterBlameTables(db)!=SQLITE_OK ) return;
   if( doltliteSchemaDiffRegister(db)!=SQLITE_OK ) return;

--- a/src/doltlite_at.c
+++ b/src/doltlite_at.c
@@ -313,8 +313,4 @@ int doltliteRegisterAtTables(sqlite3 *db){
   return doltliteForEachUserTable(db, "dolt_at_", &atModule);
 }
 
-int doltliteAtRegister(sqlite3 *db){
-  return doltliteRegisterAtTables(db);
-}
-
 #endif

--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -1379,7 +1379,7 @@ static int brColumn(sqlite3_vtab_cursor *c, sqlite3_context *ctx, int col){
       sqlite3_result_text(ctx, br->zName, -1, SQLITE_TRANSIENT);
       return SQLITE_OK;
     case 1: {
-      char h[41];
+      char h[PROLLY_HASH_SIZE*2+1];
       doltliteHashToHex(&br->commitHash, h);
       sqlite3_result_text(ctx, h, -1, SQLITE_TRANSIENT);
       return SQLITE_OK;

--- a/src/doltlite_commit_ancestors.c
+++ b/src/doltlite_commit_ancestors.c
@@ -23,7 +23,6 @@ struct CommitAncestorsCursor {
   int qHead, qTail, qAlloc;
   ProllyHashSet visited;
   int visitedInit;
-  ProllyHash curHash;
   char zCurHex[PROLLY_HASH_SIZE*2+1];
   DoltliteCommit curCommit;
   int curParents;
@@ -119,7 +118,6 @@ static int caLoadNextCommit(CommitAncestorsCursor *pCur, sqlite3 *db){
     rc = doltliteLoadCommit(db, &cur, &pCur->curCommit);
     if( rc!=SQLITE_OK ) return rc;
 
-    pCur->curHash = cur;
     doltliteHashToHex(&cur, pCur->zCurHex);
     pCur->hasRow = 1;
     pCur->curParents = doltliteCommitParentCount(&pCur->curCommit);

--- a/src/doltlite_log.c
+++ b/src/doltlite_log.c
@@ -26,7 +26,6 @@ struct DoltliteLogCursor {
   int qHead, qTail, qAlloc;
   ProllyHashSet visited;
   int visitedInit;
-  ProllyHash curHash;
   char zHex[PROLLY_HASH_SIZE*2+1];
   DoltliteCommit curCommit;
   int hasRow;
@@ -124,7 +123,6 @@ static int logAdvance(DoltliteLogCursor *pCur, sqlite3 *db){
       return rc;
     }
 
-    pCur->curHash = cur;
     doltliteHashToHex(&cur, pCur->zHex);
     pCur->hasRow = 1;
 

--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -21,14 +21,6 @@ typedef struct ConflictTableInfo ConflictTableInfo;
 extern int doltliteSerializeConflicts(ChunkStore *cs, ConflictTableInfo *aTables,
                                        int nTables, ProllyHash *pHash);
 
-static struct TableEntry *findTableEntry(
-  struct TableEntry *aEntries,
-  int nEntries,
-  Pgno iTable
-){
-  return doltliteFindTableByNumber(aEntries, nEntries, iTable);
-}
-
 typedef struct MergeIndexInfo MergeIndexInfo;
 struct MergeIndexInfo {
   Pgno iTable;
@@ -807,14 +799,6 @@ merge_err:
   return rc;
 }
 
-static struct TableEntry *findTableByName(
-  struct TableEntry *aEntries,
-  int nEntries,
-  const char *zName
-){
-  return doltliteFindTableByName(aEntries, nEntries, zName);
-}
-
 typedef struct ParsedColumn ParsedColumn;
 struct ParsedColumn {
   char *zName;
@@ -1359,7 +1343,7 @@ static struct TableEntry *findCatalogEntryBySchemaObject(
     if( strcmp(aSchema[i].zType ? aSchema[i].zType : "", zType ? zType : "")!=0 ) continue;
     if( strcmp(aSchema[i].zName ? aSchema[i].zName : "", zName ? zName : "")!=0 ) continue;
     if( strcmp(aSchema[i].zTblName ? aSchema[i].zTblName : "", zTblName ? zTblName : "")!=0 ) continue;
-    return findTableEntry(aCat, nCat, aSchema[i].iRootpage);
+    return doltliteFindTableByNumber(aCat, nCat, aSchema[i].iRootpage);
   }
   return 0;
 }
@@ -1929,13 +1913,13 @@ static int mergeCatalogPass1(
             pOurSe->zType, pOurSe->zName, pOurSe->zTblName);
         goto do_merge_entry;
       }
-      ancEntry = findTableEntry(aAnc, nAnc, aOurs[i].iTable);
-      theirsEntry = findTableEntry(aTheirs, nTheirs, aOurs[i].iTable);
+      ancEntry = doltliteFindTableByNumber(aAnc, nAnc, aOurs[i].iTable);
+      theirsEntry = doltliteFindTableByNumber(aTheirs, nTheirs, aOurs[i].iTable);
       goto do_merge_entry;
     }
 
-    ancEntry = findTableByName(aAnc, nAnc, zName);
-    theirsEntry = findTableByName(aTheirs, nTheirs, zName);
+    ancEntry = doltliteFindTableByName(aAnc, nAnc, zName);
+    theirsEntry = doltliteFindTableByName(aTheirs, nTheirs, zName);
 
 do_merge_entry:
 
@@ -2072,7 +2056,7 @@ do_merge_entry:
                       if( pIdx->idxType==SQLITE_IDXTYPE_PRIMARYKEY ){
                         continue;
                       }
-                      oursIdx = findTableEntry(aOurs, nOurs, pIdx->tnum);
+                      oursIdx = doltliteFindTableByNumber(aOurs, nOurs, pIdx->tnum);
                       if( oursIdx ){
                         MergeIndexInfo *mi = &aIdxInfo[nIdxInfo];
                         mi->iTable = pIdx->tnum;
@@ -2176,8 +2160,8 @@ post_merge_table_rows:;
   }
 
   if( iTable1Idx >= 0 ){
-    struct TableEntry *ancEntry = findTableEntry(aAnc, nAnc, 1);
-    struct TableEntry *theirsEntry = findTableEntry(aTheirs, nTheirs, 1);
+    struct TableEntry *ancEntry = doltliteFindTableByNumber(aAnc, nAnc, 1);
+    struct TableEntry *theirsEntry = doltliteFindTableByNumber(aTheirs, nTheirs, 1);
     int hasSchemaActions = (ppSchemaActions && pnSchemaActions && *pnSchemaActions > 0);
     int bPreferOurMasterHere = bPreferOurMaster
         && replayDropsDisjointSchemaObject(aAncSchema, nAncSchema,
@@ -2349,7 +2333,7 @@ static int mergeCatalogPass2(
         continue;
       }
 
-      if( !findTableEntry(aOurs, nOurs, aTheirs[i].iTable) ){
+      if( !doltliteFindTableByNumber(aOurs, nOurs, aTheirs[i].iTable) ){
         struct TableEntry newEntry = aTheirs[i];
         int j, conflict = 0;
         Pgno oldPg = newEntry.iTable;
@@ -2377,8 +2361,8 @@ static int mergeCatalogPass2(
         if( newEntry.iTable >= *piNextMerged ) *piNextMerged = newEntry.iTable + 1;
         aMerged[(*pnMerged)++] = newEntry;
       }else if( bDisjointSchemaChanges ){
-        struct TableEntry *oursIdx = findTableEntry(aOurs, nOurs, aTheirs[i].iTable);
-        struct TableEntry *ancIdx = findTableEntry(aAnc, nAnc, aTheirs[i].iTable);
+        struct TableEntry *oursIdx = doltliteFindTableByNumber(aOurs, nOurs, aTheirs[i].iTable);
+        struct TableEntry *ancIdx = doltliteFindTableByNumber(aAnc, nAnc, aTheirs[i].iTable);
         if( oursIdx && !ancIdx
          && (prollyHashCompare(&oursIdx->root, &aTheirs[i].root)!=0
              || prollyHashCompare(&oursIdx->schemaHash, &aTheirs[i].schemaHash)!=0) ){
@@ -2401,11 +2385,11 @@ static int mergeCatalogPass2(
       continue;
     }
 
-    oursEntry = findTableByName(aOurs, nOurs, zName);
+    oursEntry = doltliteFindTableByName(aOurs, nOurs, zName);
     if( oursEntry ) continue;
 
     {
-      struct TableEntry *ancEntry = findTableByName(aAnc, nAnc, zName);
+      struct TableEntry *ancEntry = doltliteFindTableByName(aAnc, nAnc, zName);
       if( !ancEntry ){
 
         struct TableEntry newEntry = aTheirs[i];

--- a/src/doltlite_remote.c
+++ b/src/doltlite_remote.c
@@ -369,15 +369,9 @@ static int fsSetRefsIf(
   return rc;
 }
 
-static int remoteStorePersistRefs(ChunkStore *pStore){
-  int rc = chunkStoreSerializeRefs(pStore);
-  if( rc==SQLITE_OK ) rc = chunkStoreCommit(pStore);
-  return rc;
-}
-
 static int fsCommit(DoltliteRemote *pRemote){
   FsRemote *p = (FsRemote*)pRemote;
-  int rc = remoteStorePersistRefs(&p->store);
+  int rc = doltliteRemotePersistRefs(&p->store);
   if( p->lockedForCas ){
     chunkStoreUnlock(&p->store);
     p->lockedForCas = 0;
@@ -779,7 +773,7 @@ int doltliteFetch(
   rc = chunkStoreUpdateTracking(pLocal, zRemoteName, zBranch, &remoteCommit);
   if( rc!=SQLITE_OK ) return rc;
 
-  return remoteStorePersistRefs(pLocal);
+  return doltliteRemotePersistRefs(pLocal);
 }
 
 int doltliteClone(ChunkStore *pLocal, DoltliteRemote *pRemote){

--- a/src/doltlite_remote.h
+++ b/src/doltlite_remote.h
@@ -15,6 +15,12 @@ struct DoltliteRemote {
   void (*xClose)(DoltliteRemote*);
 };
 
+static inline int doltliteRemotePersistRefs(ChunkStore *cs){
+  int rc = chunkStoreSerializeRefs(cs);
+  if( rc==SQLITE_OK ) rc = chunkStoreCommit(cs);
+  return rc;
+}
+
 int doltliteSyncChunks(
   DoltliteRemote *pSrc,
   DoltliteRemote *pDst,

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -98,12 +98,6 @@ static int remoteSqlOpenNamedRemote(
   return SQLITE_OK;
 }
 
-static int remoteSqlPersistRefs(ChunkStore *cs){
-  int rc = chunkStoreSerializeRefs(cs);
-  if( rc==SQLITE_OK ) rc = chunkStoreCommit(cs);
-  return rc;
-}
-
 static int remoteSqlLoadCommit(
   ChunkStore *cs,
   const ProllyHash *pCommitHash,
@@ -583,7 +577,7 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     }
   }
 
-  rc = remoteSqlPersistRefs(cs);
+  rc = doltliteRemotePersistRefs(cs);
   if( rc!=SQLITE_OK ){
     remoteSqlRestoreAndReport(ctx, db, cs, &savedState, rc, 0);
     return;
@@ -687,17 +681,6 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   }
 
   {
-    u8 *refsData = 0; int nRefsData = 0;
-    ProllyHash refsHash;
-    memcpy(&refsHash, refsTableGetHash(&cs->refs), sizeof(ProllyHash));
-    if( !prollyHashIsEmpty(&refsHash) ){
-      rc = chunkStoreGet(cs, &refsHash, &refsData, &nRefsData);
-      (void)refsData;
-      sqlite3_free(refsData);
-    }
-  }
-
-  {
     const char *zDefault = chunkStoreGetDefaultBranch(cs);
     ProllyHash branchCommit;
     int nBr;
@@ -731,7 +714,7 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     }
   }
 
-  rc = remoteSqlPersistRefs(cs);
+  rc = doltliteRemotePersistRefs(cs);
   if( rc!=SQLITE_OK ){
     remoteSqlRestoreAndReport(ctx, db, cs, &savedState, rc, 0);
     return;


### PR DESCRIPTION
First batch from a deep dead/duplicate-code scan of the doltlite-specific sources (~31k lines across `src/doltlite*.c` and `src/chunk_*.c`). This PR is the low-risk, high-confidence tier: dead-code deletes and trivial dedup. The scan also confirmed the comment bar is already met — nothing to strip.

## Dead code removed
- `doltlite.c` — unused `zTrimmedMessage` var; redundant `doltliteMaterializeDefaultColumns` forward prototype (definition precedes its only call)
- `doltlite_remote_sql.c` — dead `refsData` fetch block in `doltCloneFunc` (fetched, `(void)`-cast, freed, never used)
- `doltlite_commit_ancestors.c`, `doltlite_log.c` — write-only `curHash` cursor field (the hex form is what's emitted)

## Dedup / cleanup
- `doltlite.c` — compute the Revert/Cherry-pick op label once, reuse at 3 sites
- `doltlite_merge.c` — drop `findTableEntry`/`findTableByName` pass-through wrappers; call `doltliteFindTableBy{Number,Name}` directly
- `doltlite_remote.{c,h}`, `doltlite_remote_sql.c` — unify the two byte-identical `persistRefs` helpers into a `doltliteRemotePersistRefs` inline
- `chunk_wal.c` — replace bare manifest offsets `28`/`104` with `CS_MANIFEST_CHUNK_COUNT_OFF`/`CS_MANIFEST_REFS_HASH_OFF` (keeps WAL replay in lock-step with the manifest layout)
- `doltlite_at.c` — drop redundant `doltliteAtRegister` pass-through, call `doltliteRegisterAtTables` directly
- `doltlite_branch.c` — replace magic `char h[41]` with `PROLLY_HASH_SIZE*2+1`

Net: −81 / +32 across 10 files.

## Deliberately skipped
Unifying `checkoutLoadLiveTableSql`/`statusLoadLiveTableSql` — they look like duplicates but have divergent NULL-`sql` semantics tied to their callers (branch normalizes to `""` for a schema diff; status keeps NULL for a rename matcher). Unifying would need a flag or risk a subtle regression for ~20 lines.

## Verification
- Clean build, no warnings
- `test/run_doltlite_tests.sh`: 67/67 suites pass
- C regression suite: 309770/309770 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)