### PR TITLE
cleanup: dedup remote/gc/diff/hashof/ref helpers (tier 3+4)

### DIFF
--- a/src/chunk_index.c
+++ b/src/chunk_index.c
@@ -301,7 +301,7 @@ int csReadIndex(ChunkStore *cs){
   return SQLITE_OK;
 }
 
-static int csIndexEntryCmp(const void *a, const void *b){
+int csIndexEntryCmp(const void *a, const void *b){
   const ChunkIndexEntry *ea = (const ChunkIndexEntry *)a;
   const ChunkIndexEntry *eb = (const ChunkIndexEntry *)b;
   return prollyHashCompare(&ea->hash, &eb->hash);

--- a/src/chunk_index.h
+++ b/src/chunk_index.h
@@ -46,6 +46,7 @@ void chunkIndexReplaceEntries(ChunkIndex *idx, ChunkIndexEntry *aNew, int nNew);
 struct ChunkStore;
 int csReadIndex(struct ChunkStore *cs);
 int csSearchIndex(const ChunkIndexEntry *aIdx, int nIdx, const ProllyHash *pHash);
+int csIndexEntryCmp(const void *a, const void *b);
 int csMergeIndex(struct ChunkStore *cs, ChunkIndexEntry **ppMerged, int *pnMerged);
 void csReleaseIndexBuf(ChunkIndexEntry *aIndex, void *mmapBase, i64 mmapSize);
 

--- a/src/doltlite_diff.c
+++ b/src/doltlite_diff.c
@@ -427,13 +427,10 @@ static int diffConnect(sqlite3 *db, void *pAux, int argc,
   DoltliteDiffVtab *pVtab;
   int rc;
   (void)pAux; (void)argc; (void)argv; (void)pzErr;
-  rc = sqlite3_declare_vtab(db, diffSchema);
+  rc = doltliteVtabConnectSimple(db, diffSchema, sizeof(*pVtab), ppVtab);
   if( rc!=SQLITE_OK ) return rc;
-  pVtab = sqlite3_malloc(sizeof(*pVtab));
-  if( !pVtab ) return SQLITE_NOMEM;
-  memset(pVtab, 0, sizeof(*pVtab));
+  pVtab = (DoltliteDiffVtab*)*ppVtab;
   pVtab->db = db;
-  *ppVtab = &pVtab->base;
   return SQLITE_OK;
 }
 

--- a/src/doltlite_diff_stat.c
+++ b/src/doltlite_diff_stat.c
@@ -499,13 +499,10 @@ static int dstConnect(sqlite3 *db, void *pAux, int argc,
     const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){
   DstVtab *v; int rc;
   (void)pAux; (void)argc; (void)argv; (void)pzErr;
-  rc = sqlite3_declare_vtab(db, dstSchema);
+  rc = doltliteVtabConnectSimple(db, dstSchema, sizeof(*v), ppVtab);
   if( rc!=SQLITE_OK ) return rc;
-  v = sqlite3_malloc(sizeof(*v));
-  if( !v ) return SQLITE_NOMEM;
-  memset(v, 0, sizeof(*v));
+  v = (DstVtab*)*ppVtab;
   v->db = db;
-  *ppVtab = &v->base;
   return SQLITE_OK;
 }
 
@@ -792,13 +789,10 @@ static int dssConnect(sqlite3 *db, void *pAux, int argc,
     const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){
   DssVtab *v; int rc;
   (void)pAux; (void)argc; (void)argv; (void)pzErr;
-  rc = sqlite3_declare_vtab(db, dssSchema);
+  rc = doltliteVtabConnectSimple(db, dssSchema, sizeof(*v), ppVtab);
   if( rc!=SQLITE_OK ) return rc;
-  v = sqlite3_malloc(sizeof(*v));
-  if( !v ) return SQLITE_NOMEM;
-  memset(v, 0, sizeof(*v));
+  v = (DssVtab*)*ppVtab;
   v->db = db;
-  *ppVtab = &v->base;
   return SQLITE_OK;
 }
 

--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -220,10 +220,7 @@ static int gcAppendMarkedChunk(
     *pnBufAlloc = (int)newAlloc;
   }
 
-  (*ppBuf)[*pnBuf]   = (u8)(nChunkData);
-  (*ppBuf)[*pnBuf+1] = (u8)(nChunkData>>8);
-  (*ppBuf)[*pnBuf+2] = (u8)(nChunkData>>16);
-  (*ppBuf)[*pnBuf+3] = (u8)(nChunkData>>24);
+  CS_WRITE_U32(*ppBuf + *pnBuf, nChunkData);
 
   memcpy(&aNewIndex[*pnNewIndex].hash, pHash, sizeof(ProllyHash));
   aNewIndex[*pnNewIndex].offset = dataOffset + *pnBuf;
@@ -245,7 +242,7 @@ static int gcBuildCompactedData(
   ChunkIndexEntry **ppNewIndex,
   int *pnNewIndex
 ){
-  int i, j;
+  int i;
   int kept = 0;
   ChunkIndexEntry *aNewIndex = 0;
   int nNewIndex = 0;
@@ -319,15 +316,7 @@ static int gcBuildCompactedData(
     }
   }
 
-  for(i=1; i<nNewIndex; i++){
-    ChunkIndexEntry tmp = aNewIndex[i];
-    j = i-1;
-    while( j>=0 && memcmp(aNewIndex[j].hash.data, tmp.hash.data, PROLLY_HASH_SIZE)>0 ){
-      aNewIndex[j+1] = aNewIndex[j];
-      j--;
-    }
-    aNewIndex[j+1] = tmp;
-  }
+  qsort(aNewIndex, nNewIndex, sizeof(aNewIndex[0]), csIndexEntryCmp);
 
   *ppNewData = buf;
   *pnNewData = nBuf;
@@ -471,19 +460,9 @@ static int gcRewriteFile(
     u8 *p = indexBuf + i * CHUNK_INDEX_ENTRY_SIZE;
     memcpy(p, pNewIndex[i].hash.data, PROLLY_HASH_SIZE);
     p += PROLLY_HASH_SIZE;
-    {
-      i64 off = pNewIndex[i].offset;
-      p[0] = (u8)off; p[1] = (u8)(off>>8);
-      p[2] = (u8)(off>>16); p[3] = (u8)(off>>24);
-      p[4] = (u8)(off>>32); p[5] = (u8)(off>>40);
-      p[6] = (u8)(off>>48); p[7] = (u8)(off>>56);
-    }
+    CS_WRITE_I64(p, pNewIndex[i].offset);
     p += 8;
-    {
-      u32 sz = (u32)pNewIndex[i].size;
-      p[0] = (u8)sz; p[1] = (u8)(sz>>8);
-      p[2] = (u8)(sz>>16); p[3] = (u8)(sz>>24);
-    }
+    CS_WRITE_U32(p, (u32)pNewIndex[i].size);
   }
 
   manifestCs = *cs;

--- a/src/doltlite_hashof.c
+++ b/src/doltlite_hashof.c
@@ -532,6 +532,55 @@ static int hashofDbInCatalog(
   return SQLITE_OK;
 }
 
+/* Resolve a ref-spec argument to its commit's catalog hash. On NULL/empty input
+** or any resolve/load failure it sets the SQL result (null or an error prefixed
+** with zFn) and returns 1, meaning the caller should return immediately. On
+** success returns 0 with *pCatHash set. */
+static int hashofResolveRefCatalog(
+  sqlite3_context *ctx,
+  sqlite3 *db,
+  sqlite3_value *pRefArg,
+  const char *zFn,
+  ProllyHash *pCatHash
+){
+  const char *zRef;
+  ProllyHash commitHash;
+  DoltliteCommit commit;
+  char zErr[64];
+  int rc;
+
+  if( sqlite3_value_type(pRefArg)==SQLITE_NULL ){
+    sqlite3_result_null(ctx);
+    return 1;
+  }
+  zRef = (const char*)sqlite3_value_text(pRefArg);
+  if( !zRef ){
+    sqlite3_result_null(ctx);
+    return 1;
+  }
+  rc = doltliteResolveRef(db, zRef, &commitHash);
+  if( rc==SQLITE_NOTFOUND ){
+    sqlite3_snprintf(sizeof(zErr), zErr, "%s: invalid ref spec", zFn);
+    sqlite3_result_error(ctx, zErr, -1);
+    return 1;
+  }
+  if( rc!=SQLITE_OK ){
+    sqlite3_snprintf(sizeof(zErr), zErr, "%s: invalid ancestor spec", zFn);
+    sqlite3_result_error(ctx, zErr, -1);
+    return 1;
+  }
+  memset(&commit, 0, sizeof(commit));
+  rc = doltliteLoadCommit(db, &commitHash, &commit);
+  if( rc!=SQLITE_OK ){
+    sqlite3_snprintf(sizeof(zErr), zErr, "%s: commit load failed", zFn);
+    sqlite3_result_error(ctx, zErr, -1);
+    return 1;
+  }
+  *pCatHash = commit.catalogHash;
+  doltliteCommitClear(&commit);
+  return 0;
+}
+
 static void doltliteHashofTableFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3 *db;
   const char *zTable;
@@ -556,40 +605,12 @@ static void doltliteHashofTableFunc(sqlite3_context *ctx, int argc, sqlite3_valu
 
   if( argc==1 ){
     rc = doltliteFlushCatalogToHash(db, &catHash);
+    if( rc!=SQLITE_OK ){
+      sqlite3_result_error(ctx, "dolt_hashof_table: catalog flush failed", -1);
+      return;
+    }
   }else{
-    const char *zRef;
-    ProllyHash commitHash;
-    DoltliteCommit commit;
-    if( sqlite3_value_type(argv[1])==SQLITE_NULL ){
-      sqlite3_result_null(ctx);
-      return;
-    }
-    zRef = (const char*)sqlite3_value_text(argv[1]);
-    if( !zRef ){
-      sqlite3_result_null(ctx);
-      return;
-    }
-    rc = doltliteResolveRef(db, zRef, &commitHash);
-    if( rc==SQLITE_NOTFOUND ){
-      sqlite3_result_error(ctx, "dolt_hashof_table: invalid ref spec", -1);
-      return;
-    }
-    if( rc!=SQLITE_OK ){
-      sqlite3_result_error(ctx, "dolt_hashof_table: invalid ancestor spec", -1);
-      return;
-    }
-    memset(&commit, 0, sizeof(commit));
-    rc = doltliteLoadCommit(db, &commitHash, &commit);
-    if( rc!=SQLITE_OK ){
-      sqlite3_result_error(ctx, "dolt_hashof_table: commit load failed", -1);
-      return;
-    }
-    catHash = commit.catalogHash;
-    doltliteCommitClear(&commit);
-  }
-  if( rc!=SQLITE_OK ){
-    sqlite3_result_error(ctx, "dolt_hashof_table: catalog flush failed", -1);
-    return;
+    if( hashofResolveRefCatalog(ctx, db, argv[1], "dolt_hashof_table", &catHash) ) return;
   }
 
   rc = hashofTableInCatalog(db, &catHash, zTable, hex);
@@ -623,35 +644,7 @@ static void doltliteHashofDbFunc(sqlite3_context *ctx, int argc, sqlite3_value *
       return;
     }
   }else{
-    const char *zRef;
-    ProllyHash commitHash;
-    DoltliteCommit commit;
-    if( sqlite3_value_type(argv[0])==SQLITE_NULL ){
-      sqlite3_result_null(ctx);
-      return;
-    }
-    zRef = (const char*)sqlite3_value_text(argv[0]);
-    if( !zRef ){
-      sqlite3_result_null(ctx);
-      return;
-    }
-    rc = doltliteResolveRef(db, zRef, &commitHash);
-    if( rc==SQLITE_NOTFOUND ){
-      sqlite3_result_error(ctx, "dolt_hashof_db: invalid ref spec", -1);
-      return;
-    }
-    if( rc!=SQLITE_OK ){
-      sqlite3_result_error(ctx, "dolt_hashof_db: invalid ancestor spec", -1);
-      return;
-    }
-    memset(&commit, 0, sizeof(commit));
-    rc = doltliteLoadCommit(db, &commitHash, &commit);
-    if( rc!=SQLITE_OK ){
-      sqlite3_result_error(ctx, "dolt_hashof_db: commit load failed", -1);
-      return;
-    }
-    catHash = commit.catalogHash;
-    doltliteCommitClear(&commit);
+    if( hashofResolveRefCatalog(ctx, db, argv[0], "dolt_hashof_db", &catHash) ) return;
   }
 
   rc = hashofDbInCatalog(db, &catHash, hex);
@@ -689,35 +682,7 @@ static void doltliteHashofCatalogFunc(sqlite3_context *ctx, int argc, sqlite3_va
       }
     }
   }else{
-    const char *zRef;
-    ProllyHash commitHash;
-    DoltliteCommit commit;
-    if( sqlite3_value_type(argv[0])==SQLITE_NULL ){
-      sqlite3_result_null(ctx);
-      return;
-    }
-    zRef = (const char*)sqlite3_value_text(argv[0]);
-    if( !zRef ){
-      sqlite3_result_null(ctx);
-      return;
-    }
-    rc = doltliteResolveRef(db, zRef, &commitHash);
-    if( rc==SQLITE_NOTFOUND ){
-      sqlite3_result_error(ctx, "dolt_hashof_catalog: invalid ref spec", -1);
-      return;
-    }
-    if( rc!=SQLITE_OK ){
-      sqlite3_result_error(ctx, "dolt_hashof_catalog: invalid ancestor spec", -1);
-      return;
-    }
-    memset(&commit, 0, sizeof(commit));
-    rc = doltliteLoadCommit(db, &commitHash, &commit);
-    if( rc!=SQLITE_OK ){
-      sqlite3_result_error(ctx, "dolt_hashof_catalog: commit load failed", -1);
-      return;
-    }
-    catHash = commit.catalogHash;
-    doltliteCommitClear(&commit);
+    if( hashofResolveRefCatalog(ctx, db, argv[0], "dolt_hashof_catalog", &catHash) ) return;
   }
 
   doltliteHashToHex(&catHash, hex);

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -190,6 +190,24 @@ static SQLITE_INLINE int doltliteVtabOpenCursor(
   return SQLITE_OK;
 }
 
+/* Declare a fixed-schema vtab and allocate its zeroed instance. The caller
+** owns any per-vtab fields (e.g. ->db) after this returns SQLITE_OK. */
+static SQLITE_INLINE int doltliteVtabConnectSimple(
+  sqlite3 *db,
+  const char *zSchema,
+  int nByte,
+  sqlite3_vtab **ppVtab
+){
+  sqlite3_vtab *pVtab;
+  int rc = sqlite3_declare_vtab(db, zSchema);
+  if( rc!=SQLITE_OK ) return rc;
+  pVtab = sqlite3_malloc(nByte);
+  if( !pVtab ) return SQLITE_NOMEM;
+  memset(pVtab, 0, nByte);
+  *ppVtab = pVtab;
+  return SQLITE_OK;
+}
+
 static SQLITE_INLINE int doltliteAppendQuotedColumnList(
   sqlite3_str *pStr,
   char *const *azName,

--- a/src/doltlite_ref.c
+++ b/src/doltlite_ref.c
@@ -86,30 +86,6 @@ static int doltliteResolveBaseRef(
   return SQLITE_NOTFOUND;
 }
 
-static int doltliteWalkFirstParent(
-  sqlite3 *db,
-  ProllyHash *pCommit,
-  int n
-){
-  int i;
-  for(i=0; i<n; i++){
-    DoltliteCommit commit;
-    const ProllyHash *pParent;
-    int rc;
-    memset(&commit, 0, sizeof(commit));
-    rc = doltliteLoadCommit(db, pCommit, &commit);
-    if( rc!=SQLITE_OK ) return rc;
-    pParent = doltliteCommitParentHash(&commit, 0);
-    if( !pParent ){
-      doltliteCommitClear(&commit);
-      return SQLITE_NOTFOUND;
-    }
-    memcpy(pCommit, pParent, sizeof(ProllyHash));
-    doltliteCommitClear(&commit);
-  }
-  return SQLITE_OK;
-}
-
 static int doltliteSelectParent(
   sqlite3 *db,
   ProllyHash *pCommit,
@@ -129,6 +105,19 @@ static int doltliteSelectParent(
   }
   memcpy(pCommit, pParent, sizeof(ProllyHash));
   doltliteCommitClear(&commit);
+  return SQLITE_OK;
+}
+
+static int doltliteWalkFirstParent(
+  sqlite3 *db,
+  ProllyHash *pCommit,
+  int n
+){
+  int i;
+  for(i=0; i<n; i++){
+    int rc = doltliteSelectParent(db, pCommit, 0);
+    if( rc!=SQLITE_OK ) return rc;
+  }
   return SQLITE_OK;
 }
 

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -98,6 +98,24 @@ static int remoteSqlOpenNamedRemote(
   return SQLITE_OK;
 }
 
+/* Report the NOTFOUND/CANTOPEN result of remoteSqlOpenNamedRemote and return 1
+** if rc was such an open failure (caller should return); 0 otherwise. Pass the
+** saved txn state to clear it (pull path), or 0 when there is none. */
+static int remoteSqlReportOpenError(
+  sqlite3_context *ctx,
+  sqlite3 *db,
+  int rc,
+  DoltliteTxnState *pSaved
+){
+  if( rc!=SQLITE_NOTFOUND && rc!=SQLITE_CANTOPEN ) return 0;
+  (void)doltliteVcSealSavepointError(db);
+  if( pSaved ) doltliteTxnStateClear(pSaved);
+  sqlite3_result_error(ctx,
+    rc==SQLITE_NOTFOUND ? "remote not found"
+      : "failed to open remote (URL must start with file:// or http://)", -1);
+  return 1;
+}
+
 static int remoteSqlLoadCommit(
   ChunkStore *cs,
   const ProllyHash *pCommitHash,
@@ -271,16 +289,7 @@ static void doltPushFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   }
 
   rc = remoteSqlOpenNamedRemote(cs, zRemoteName, &zUrl, &pRemote);
-  if( rc==SQLITE_NOTFOUND ){
-    (void)doltliteVcSealSavepointError(db);
-    sqlite3_result_error(ctx, "remote not found", -1);
-    return;
-  }
-  if( rc==SQLITE_CANTOPEN ){
-    (void)doltliteVcSealSavepointError(db);
-    sqlite3_result_error(ctx, "failed to open remote (URL must start with file://)", -1);
-    return;
-  }
+  if( remoteSqlReportOpenError(ctx, db, rc, 0) ) return;
 
   rc = doltlitePush(cs, pRemote, zBranch, bForce);
   pRemote->xClose(pRemote);
@@ -385,16 +394,7 @@ static void doltFetchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   }
 
   rc = remoteSqlOpenNamedRemote(cs, zRemoteName, &zUrl, &pRemote);
-  if( rc==SQLITE_NOTFOUND ){
-    (void)doltliteVcSealSavepointError(db);
-    sqlite3_result_error(ctx, "remote not found", -1);
-    return;
-  }
-  if( rc==SQLITE_CANTOPEN ){
-    (void)doltliteVcSealSavepointError(db);
-    sqlite3_result_error(ctx, "failed to open remote (URL must start with file://)", -1);
-    return;
-  }
+  if( remoteSqlReportOpenError(ctx, db, rc, 0) ) return;
 
   if( argc>=2 && sqlite3_value_type(argv[1])!=SQLITE_NULL ){
 
@@ -435,7 +435,7 @@ static void doltFetchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
       if( !pBrRemote ){
         doltliteFreeStringArray(azNames, nNames);
         (void)doltliteVcSealSavepointError(db);
-        sqlite3_result_error(ctx, "failed to open remote (URL must start with file://)", -1);
+        sqlite3_result_error(ctx, "failed to open remote (URL must start with file:// or http://)", -1);
         return;
       }
       rc = doltliteFetch(cs, pBrRemote, zRemoteName, azNames[i]);
@@ -494,18 +494,7 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   }
 
   rc = remoteSqlOpenNamedRemote(cs, zRemoteName, &zUrl, &pRemote);
-  if( rc==SQLITE_NOTFOUND ){
-    (void)doltliteVcSealSavepointError(db);
-    doltliteTxnStateClear(&savedState);
-    sqlite3_result_error(ctx, "remote not found", -1);
-    return;
-  }
-  if( rc==SQLITE_CANTOPEN ){
-    (void)doltliteVcSealSavepointError(db);
-    doltliteTxnStateClear(&savedState);
-    sqlite3_result_error(ctx, "failed to open remote (URL must start with file://)", -1);
-    return;
-  }
+  if( remoteSqlReportOpenError(ctx, db, rc, &savedState) ) return;
 
   rc = doltliteFetch(cs, pRemote, zRemoteName, zBranch);
   pRemote->xClose(pRemote);
@@ -661,7 +650,7 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   pRemote = openRemoteByUrl(chunkFileGetVfs(&cs->file), zUrl);
   if( !pRemote ){
     remoteSqlRestoreAndReport(ctx, db, cs, &savedState, SQLITE_ERROR,
-                              "failed to open remote (URL must start with file://)");
+                              "failed to open remote (URL must start with file:// or http://)");
     return;
   }
 

--- a/src/doltlite_schema_diff.c
+++ b/src/doltlite_schema_diff.c
@@ -413,13 +413,10 @@ static int sdConnect(sqlite3 *db, void *pAux, int argc,
     const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){
   SdVtab *v; int rc;
   (void)pAux; (void)argc; (void)argv; (void)pzErr;
-  rc = sqlite3_declare_vtab(db, sdSchema);
+  rc = doltliteVtabConnectSimple(db, sdSchema, sizeof(*v), ppVtab);
   if( rc!=SQLITE_OK ) return rc;
-  v = sqlite3_malloc(sizeof(*v));
-  if( !v ) return SQLITE_NOMEM;
-  memset(v, 0, sizeof(*v));
+  v = (SdVtab*)*ppVtab;
   v->db = db;
-  *ppVtab = &v->base;
   return SQLITE_OK;
 }
 


### PR DESCRIPTION
Second batch from the dead/duplicate-code scan (follows #1106). Low-risk dedup plus one real message fix. No outright dead code in this set — these are unifications of repeated logic.

## Changes
- **`doltlite_remote_sql.c`** — collapse the three identical `NOTFOUND`/`CANTOPEN` open-remote error ladders (push/fetch/pull) into `remoteSqlReportOpenError`. Also fixes the stale `"URL must start with file://"` message — `http://` is accepted too, so it now reads `file:// or http://`.
- **`doltlite_gc.c`** — replace hand-rolled little-endian byte packing with the existing `CS_WRITE_U32`/`CS_WRITE_I64` macros (keeps GC writes in lock-step with the index/manifest readers), and swap the inline O(n²) insertion sort for `qsort` over the existing `csIndexEntryCmp` (now exported from `chunk_index.h`). `prollyHashCompare` is `memcmp` over `PROLLY_HASH_SIZE`, so the ordering is identical.
- **`doltlite_diff.c` / `doltlite_diff_stat.c` / `doltlite_schema_diff.c`** — route the four fixed-schema vtab `Connect` functions through a new `doltliteVtabConnectSimple` helper (declare + alloc + zero), alongside the existing `doltliteVtabOpenCursor`/`doltliteVtabDisconnect`.
- **`doltlite_hashof.c`** — extract `hashofResolveRefCatalog`, shared by the ref-spec arm of all three `dolt_hashof_*` functions (the per-function error prefix is passed in).
- **`doltlite_ref.c`** — express `doltliteWalkFirstParent` as a loop over `doltliteSelectParent` instead of a second copy of the load-parent body.

Net: −194 / +123 across 10 files.

## Verification
- Clean build, no warnings
- Smoke tests: `dolt_hashof_table/db/catalog` (0-arg, ref-arg, bad-ref error text), the new remote error message, GC compaction + reopen integrity
- `test/run_doltlite_tests.sh`: 67/67 suites pass
- C regression suite: 309770/309770 tests pass

Remaining scan items (cross-TU helpers + a few intentionally-deferred risky ones) are tracked for a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)