### PR TITLE
Deduplicate DoltLite shell test harnesses

### DIFF
--- a/test/doltlite_conflict_rows.sh
+++ b/test/doltlite_conflict_rows.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
-DOLTLITE=./doltlite
-PASS=0; FAIL=0; ERRORS=""
-run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
-run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if echo "$r"|grep -qE "$p"; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  pattern: $p\n  got:     $r"; fi; }
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
 
 echo "=== Doltlite Per-Row Conflict Resolution Tests ==="
 echo ""
@@ -141,6 +138,4 @@ run_test_match "compositepk_target_delete_keeps_other" "BEGIN; SELECT dolt_merge
 run_test_match "compositepk_full_delete_clears" "BEGIN; SELECT dolt_merge('hf'); DELETE FROM dolt_conflicts_t; SELECT 'CF|' || count(*) FROM dolt_conflicts; ROLLBACK;" "^CF\\|0$" "$DB"
 rm -f "$DB"
 
-echo ""
-echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
-if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi
+dltest_finish

--- a/test/doltlite_demo.sh
+++ b/test/doltlite_demo.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
-DOLTLITE=./doltlite
-PASS=0; FAIL=0; ERRORS=""
-run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
-run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if echo "$r"|grep -qE "$p"; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  pattern: $p\n  got:     $r"; fi; }
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
 
 echo "=== Doltlite Demo Test (Dolt Getting Started) ==="
 echo ""
@@ -118,6 +115,4 @@ run_test "persist_tags" "SELECT count(*) FROM dolt_tags;" "1" "$DB"
 
 rm -f "$DB"
 
-echo ""
-echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
-if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi
+dltest_finish

--- a/test/doltlite_e2e.sh
+++ b/test/doltlite_e2e.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
-DOLTLITE=./doltlite
-PASS=0; FAIL=0; ERRORS=""
-run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
-run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if echo "$r"|grep -qE "$p"; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  pattern: $p\n  got:     $r"; fi; }
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
 
 echo "=== Doltlite End-to-End Integration Tests ==="
 echo ""
@@ -130,6 +127,4 @@ run_test "e2e_persist_tags" "SELECT count(*) FROM dolt_tags;" "2" "$DB"
 run_test "e2e_persist_branches" "SELECT count(*) FROM dolt_branches;" "2" "$DB"
 
 rm -f "$DB"
-echo ""
-echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
-if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi
+dltest_finish

--- a/test/doltlite_persistence.sh
+++ b/test/doltlite_persistence.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
-DOLTLITE=./doltlite
-PASS=0; FAIL=0; ERRORS=""
-run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
-run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if echo "$r"|grep -qE "$p"; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  pattern: $p\n  got:     $r"; fi; }
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
 
 echo "=== Doltlite File Persistence Tests ==="
 echo ""
@@ -347,6 +344,4 @@ run_test "diverged_main_val" "SELECT v FROM t WHERE id=3;" "main_again" "$DB"
 
 rm -f "$DB"
 
-echo ""
-echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
-if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi
+dltest_finish

--- a/test/doltlite_tag.sh
+++ b/test/doltlite_tag.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
-DOLTLITE=./doltlite
-PASS=0; FAIL=0; ERRORS=""
-run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
-run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if echo "$r"|grep -qE "$p"; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  pattern: $p\n  got:     $r"; fi; }
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
 
 echo "=== Doltlite Tag Tests ==="
 echo ""
@@ -59,6 +56,4 @@ parenttilde
 v1.0" "$DB"
 
 rm -f "$DB" "$DB2"
-echo ""
-echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
-if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi
+dltest_finish

--- a/test/lib/doltlite_test_common.sh
+++ b/test/lib/doltlite_test_common.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+DOLTLITE="${DOLTLITE:-./doltlite}"
+PASS="${PASS:-0}"
+FAIL="${FAIL:-0}"
+ERRORS="${ERRORS:-}"
+DLTEST_TIMEOUT="${DLTEST_TIMEOUT:-10}"
+
+dltest_run_sql() {
+  local sql="$1"
+  local db="$2"
+  echo "$sql" | perl -e "alarm($DLTEST_TIMEOUT);exec @ARGV" "$DOLTLITE" "$db" 2>&1
+}
+
+dltest_pass() {
+  PASS=$((PASS+1))
+}
+
+dltest_fail() {
+  local name="$1"
+  local msg="$2"
+  FAIL=$((FAIL+1))
+  ERRORS="$ERRORS\nFAIL: $name\n$msg"
+}
+
+run_test() {
+  local name="$1"
+  local sql="$2"
+  local expected="$3"
+  local db="$4"
+  local result
+  result=$(dltest_run_sql "$sql" "$db")
+  if [ "$result" = "$expected" ]; then
+    dltest_pass
+  else
+    dltest_fail "$name" "  expected: $expected\n  got:      $result"
+  fi
+}
+
+run_test_lastline() {
+  local name="$1"
+  local sql="$2"
+  local expected="$3"
+  local db="$4"
+  local result
+  result=$(dltest_run_sql "$sql" "$db" | tail -1)
+  if [ "$result" = "$expected" ]; then
+    dltest_pass
+  else
+    dltest_fail "$name" "  expected: $expected\n  got:      $result"
+  fi
+}
+
+run_test_match() {
+  local name="$1"
+  local sql="$2"
+  local pattern="$3"
+  local db="$4"
+  local result
+  result=$(dltest_run_sql "$sql" "$db")
+  if echo "$result" | grep -qE "$pattern"; then
+    dltest_pass
+  else
+    dltest_fail "$name" "  pattern: $pattern\n  got:     $result"
+  fi
+}
+
+dltest_finish() {
+  echo ""
+  echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
+  if [ "$FAIL" -gt 0 ]; then
+    echo -e "$ERRORS"
+    exit 1
+  fi
+}


### PR DESCRIPTION
## Summary
- add a shared DoltLite shell-test helper on master
- migrate 12 DoltLite shell tests to use the shared helper
- preserve existing assertion output, timeout behavior, and result formatting

## Tests
- `bash -n test/lib/doltlite_test_common.sh test/doltlite_log.sh test/doltlite_branding.sh test/doltlite_memory_db.sh test/doltlite_branch.sh test/doltlite_conflicts.sh test/doltlite_diff_table.sh test/doltlite_schema_diff.sh test/doltlite_tag.sh test/doltlite_demo.sh test/doltlite_e2e.sh test/doltlite_persistence.sh test/doltlite_conflict_rows.sh`
- from `build/`:
  - `bash ../test/doltlite_log.sh`
  - `bash ../test/doltlite_branding.sh`
  - `bash ../test/doltlite_memory_db.sh`
  - `bash ../test/doltlite_branch.sh`
  - `bash ../test/doltlite_conflicts.sh`
  - `bash ../test/doltlite_diff_table.sh`
  - `bash ../test/doltlite_schema_diff.sh`
  - `bash ../test/doltlite_tag.sh`
  - `bash ../test/doltlite_demo.sh`
  - `bash ../test/doltlite_e2e.sh`
  - `bash ../test/doltlite_conflict_rows.sh`
  - `bash ../test/doltlite_persistence.sh`
- `make lint`