### PR TITLE
Migrate more DoltLite shell tests to shared harness

### DIFF
--- a/test/doltlite_branch.sh
+++ b/test/doltlite_branch.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
-DOLTLITE=./doltlite
-PASS=0; FAIL=0; ERRORS=""
-run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
-run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if echo "$r"|grep -qE "$p"; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  pattern: $p\n  got:     $r"; fi; }
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
 
 echo "=== Doltlite Branch Tests (Per-Session) ==="
 echo ""
@@ -171,6 +168,4 @@ run_test "branch_from_second_parent_ref_persists_across_reopen" "SELECT count(*)
 run_test "branch_from_second_parent_hash_persists_across_reopen" "SELECT count(*) FROM t;" "2" "$DB13/from_hash"
 
 rm -f "$DB" "$DB2" "$DB2B" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13"
-echo ""
-echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
-if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi
+dltest_finish

--- a/test/doltlite_branding.sh
+++ b/test/doltlite_branding.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
-DOLTLITE=./doltlite
-PASS=0; FAIL=0; ERRORS=""
-run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
-run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if echo "$r"|grep -qE "$p"; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  pattern: $p\n  got:     $r"; fi; }
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
 
 echo "=== DoltLite Branding Tests ==="
 echo ""
@@ -12,9 +9,9 @@ run_test "engine_func" "SELECT doltlite_engine();" "prolly" ":memory:"
 run_test_match "engine_old_gone" "SELECT doltite_engine();" "no such function" ":memory:"
 
 VER=$($DOLTLITE -version 2>&1)
-if echo "$VER" | grep -q "DoltLite"; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: version_flag\n  expected: DoltLite\n  got:      $VER"; fi
+if echo "$VER" | grep -q "DoltLite"; then dltest_pass; else dltest_fail "version_flag" "  expected: DoltLite\n  got:      $VER"; fi
 
-if echo "$VER" | grep -q "SQLite"; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: version_sqlite\n  expected: SQLite\n  got:      $VER"; fi
+if echo "$VER" | grep -q "SQLite"; then dltest_pass; else dltest_fail "version_sqlite" "  expected: SQLite\n  got:      $VER"; fi
 
 run_script() {
   if [ "$(uname)" = "Darwin" ]; then
@@ -29,17 +26,15 @@ BANNER=$(run_script $DOLTLITE :memory: <<'EOF' | head -5
 EOF
 )
 
-if echo "$BANNER" | grep -q "DoltLite"; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: banner\n  expected: DoltLite\n  got:      $BANNER"; fi
+if echo "$BANNER" | grep -q "DoltLite"; then dltest_pass; else dltest_fail "banner" "  expected: DoltLite\n  got:      $BANNER"; fi
 
-if echo "$BANNER" | grep -q "SQLite version"; then FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: no_sqlite_version\n  should not contain: SQLite version\n  got:      $BANNER"; else PASS=$((PASS+1)); fi
+if echo "$BANNER" | grep -q "SQLite version"; then dltest_fail "no_sqlite_version" "  should not contain: SQLite version\n  got:      $BANNER"; else dltest_pass; fi
 
 PROMPT=$(run_script $DOLTLITE :memory: <<'PEOF' | cat
 SELECT 1;
 .quit
 PEOF
 )
-if echo "$PROMPT" | grep -q "doltlite>"; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: prompt\n  expected: doltlite>\n  got:      $PROMPT"; fi
+if echo "$PROMPT" | grep -q "doltlite>"; then dltest_pass; else dltest_fail "prompt" "  expected: doltlite>\n  got:      $PROMPT"; fi
 
-echo ""
-echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
-if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi
+dltest_finish

--- a/test/doltlite_conflicts.sh
+++ b/test/doltlite_conflicts.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
-DOLTLITE=./doltlite
-PASS=0; FAIL=0; ERRORS=""
-run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
-run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if echo "$r"|grep -qE "$p"; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  pattern: $p\n  got:     $r"; fi; }
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
 
 echo "=== Doltlite Conflicts Tests ==="
 echo ""
@@ -175,6 +172,4 @@ run_test_match "theirs_delete_trigger_skipped" \
   "^TDT\\|0$" "$DB9"
 
 rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9"
-echo ""
-echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
-if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi
+dltest_finish

--- a/test/doltlite_diff_table.sh
+++ b/test/doltlite_diff_table.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
-DOLTLITE=./doltlite
-PASS=0; FAIL=0; ERRORS=""
-run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
-run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if echo "$r"|grep -qE "$p"; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  pattern: $p\n  got:     $r"; fi; }
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
 
 echo "=== Doltlite dolt_diff_<table> Audit Log Tests ==="
 echo ""
@@ -213,6 +210,4 @@ run_test_match "vals_mod_to" "SELECT typeof(to_v) FROM dolt_diff_t WHERE diff_ty
 
 rm -f "$DB"
 
-echo ""
-echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
-if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi
+dltest_finish

--- a/test/doltlite_log.sh
+++ b/test/doltlite_log.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
-DOLTLITE=./doltlite
-PASS=0; FAIL=0; ERRORS=""
-run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
 
 echo "=== Doltlite dolt_log Tests ==="
 echo ""
@@ -23,6 +21,4 @@ run_test "tag_does_not_change_log_count_after_reopen" "SELECT count(*) FROM dolt
 run_test "tag_does_not_change_log_top_message_after_reopen" "SELECT message FROM dolt_log LIMIT 1;" "c2" "$DB3"
 
 rm -f "$DB1" "$DB2" "$DB3"
-echo ""
-echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
-if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi
+dltest_finish

--- a/test/doltlite_memory_db.sh
+++ b/test/doltlite_memory_db.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
-DOLTLITE=./doltlite
-PASS=0; FAIL=0; ERRORS=""
-run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
-run_test_lastline() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1 | tail -1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
-run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if echo "$r"|grep -qE "$p"; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  pattern: $p\n  got:     $r"; fi; }
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
 
 echo "=== DoltLite :memory: routing tests ==="
 echo ""
@@ -26,9 +22,9 @@ run_test_lastline "memory_supports_dolt_checkout_isolates_branches" \
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY); INSERT INTO t VALUES(99);" | $DOLTLITE :memory: > /dev/null 2>&1
 R=$(echo "SELECT count(*) FROM t;" | $DOLTLITE :memory: 2>&1)
 if echo "$R" | grep -q "no such table"; then
-  PASS=$((PASS+1))
+  dltest_pass
 else
-  FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: memory_opens_are_independent\n  expected: 'no such table'\n  got:      $R"
+  dltest_fail "memory_opens_are_independent" "  expected: 'no such table'\n  got:      $R"
 fi
 
 # :memory: doesn't write to disk. Run in scratch dir, verify empty.
@@ -41,9 +37,9 @@ echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1,'a'
 ARTIFACTS=$(ls -A $SCRATCH 2>&1)
 cd $ORIG
 if [ -z "$ARTIFACTS" ]; then
-  PASS=$((PASS+1))
+  dltest_pass
 else
-  FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: memory_creates_no_disk_artifacts\n  expected: empty scratch dir\n  got:      $ARTIFACTS"
+  dltest_fail "memory_creates_no_disk_artifacts" "  expected: empty scratch dir\n  got:      $ARTIFACTS"
 fi
 rm -rf $SCRATCH
 
@@ -57,6 +53,4 @@ run_test_lastline "main_and_attached_isolated" \
   "ATTACH ':memory:' AS aux; CREATE TABLE main.t(id INTEGER); INSERT INTO main.t VALUES(1); SELECT count(*) FROM aux.sqlite_master WHERE name='t';" \
   "0" ":memory:"
 
-echo ""
-echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
-if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi
+dltest_finish

--- a/test/doltlite_schema_diff.sh
+++ b/test/doltlite_schema_diff.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
-DOLTLITE=./doltlite
-PASS=0; FAIL=0; ERRORS=""
-run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
-run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if echo "$r"|grep -qE "$p"; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  pattern: $p\n  got:     $r"; fi; }
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
 
 echo "=== Doltlite Schema Diff Tests ==="
 echo ""
@@ -389,6 +386,4 @@ run_test_match "rebase_replay_u_to_stmt" \
 
 rm -f "$DB"
 
-echo ""
-echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
-if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi
+dltest_finish


### PR DESCRIPTION
## Summary
- migrate 7 additional DoltLite shell tests to the shared shell-test helper from #1109
- remove duplicate inline `run_test` / `run_test_match` definitions
- preserve existing result formatting and assertion behavior

## Tests
- `bash -n test/doltlite_log.sh test/doltlite_branding.sh test/doltlite_memory_db.sh test/doltlite_branch.sh test/doltlite_conflicts.sh test/doltlite_diff_table.sh test/doltlite_schema_diff.sh`
- from `build/`:
  - `bash ../test/doltlite_log.sh`
  - `bash ../test/doltlite_branding.sh`
  - `bash ../test/doltlite_memory_db.sh`
  - `bash ../test/doltlite_branch.sh`
  - `bash ../test/doltlite_conflicts.sh`
  - `bash ../test/doltlite_diff_table.sh`
  - `bash ../test/doltlite_schema_diff.sh`
- `make lint`