### PR TITLE
cleanup: shared cross-file helpers for catalog/constraint/ref logic

### DIFF
--- a/src/doltlite_at.c
+++ b/src/doltlite_at.c
@@ -208,30 +208,19 @@ static int atFilter(sqlite3_vtab_cursor *cur,
 
   {
     ProllyHash branchCommit;
+    ProllyHash effCatHash;
     int isBranch = (chunkStoreFindBranch(cs,zRef,&branchCommit)==SQLITE_OK
                     && !prollyHashIsEmpty(&branchCommit));
     if( isBranch ){
-      ProllyHash wsCatHash, wsCommitHash;
-      memset(&wsCatHash,0,sizeof(wsCatHash));
-      memset(&wsCommitHash,0,sizeof(wsCommitHash));
-      if( chunkStoreReadBranchWorkingCatalog(cs,zRef,&wsCatHash,&wsCommitHash)==SQLITE_OK
-       && !prollyHashIsEmpty(&wsCommitHash)
-       && memcmp(wsCommitHash.data,branchCommit.data,PROLLY_HASH_SIZE)==0
-       && memcmp(wsCatHash.data,commit.catalogHash.data,PROLLY_HASH_SIZE)!=0 ){
-
-        rc=doltliteLoadCatalog(db,&wsCatHash,&aTables,&nTables,0);
-        doltliteCommitClear(&commit);
-        if(rc!=SQLITE_OK) return rc;
-        goto at_find_root;
-      }
+      doltliteResolveBranchEffectiveCatalog(cs, zRef, &branchCommit,
+                                            &commit.catalogHash, &effCatHash);
+    }else{
+      memcpy(&effCatHash, &commit.catalogHash, sizeof(ProllyHash));
     }
+    rc=doltliteLoadCatalog(db,&effCatHash,&aTables,&nTables,0);
   }
-
-  rc=doltliteLoadCatalog(db,&commit.catalogHash,&aTables,&nTables,0);
   doltliteCommitClear(&commit);
   if(rc!=SQLITE_OK) return rc;
-
-at_find_root:
 
   rc=doltliteFindTableRootByName(aTables,nTables,v->zTableName,&tableRoot,&flags);
   doltliteFreeCatalog(aTables,nTables);

--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -549,22 +549,8 @@ static int checkoutLoadAndApply(
     doltliteCommitClear(&commit);
   }
 
-  {
-    ProllyHash wsCatHash, wsCommitHash;
-    memset(&wsCatHash, 0, sizeof(wsCatHash));
-    memset(&wsCommitHash, 0, sizeof(wsCommitHash));
-    if( chunkStoreReadBranchWorkingCatalog(cs, zBranch, &wsCatHash, &wsCommitHash)==SQLITE_OK
-     && !prollyHashIsEmpty(&wsCommitHash)
-     && memcmp(wsCommitHash.data, pCommitHash->data, PROLLY_HASH_SIZE)==0
-     && memcmp(wsCatHash.data, committedCatHash.data, PROLLY_HASH_SIZE)!=0 ){
-
-      memcpy(pCatHash, &wsCatHash, sizeof(ProllyHash));
-      rc = doltliteSwitchCatalog(db, pCatHash);
-      return rc;
-    }
-  }
-
-  memcpy(pCatHash, &committedCatHash, sizeof(ProllyHash));
+  doltliteResolveBranchEffectiveCatalog(cs, zBranch, pCommitHash,
+                                        &committedCatHash, pCatHash);
   rc = doltliteSwitchCatalog(db, pCatHash);
   return rc;
 }

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -6,6 +6,7 @@
 #include "prolly_hash.h"
 #include "chunk_store.h"
 #include <time.h>
+#include <ctype.h>
 
 typedef struct BtShared BtShared;
 typedef struct ProllyCache ProllyCache;
@@ -206,6 +207,46 @@ static SQLITE_INLINE int doltliteVtabConnectSimple(
   memset(pVtab, 0, nByte);
   *ppVtab = pVtab;
   return SQLITE_OK;
+}
+
+/* Effective catalog hash for a branch ref: the committed catalog unless the
+** branch has an uncommitted working-set catalog recorded against this exact
+** commit, in which case that working catalog wins. */
+static SQLITE_INLINE void doltliteResolveBranchEffectiveCatalog(
+  ChunkStore *cs,
+  const char *zBranch,
+  const ProllyHash *pBranchCommit,
+  const ProllyHash *pCommittedCatHash,
+  ProllyHash *pCatHash
+){
+  ProllyHash wsCatHash, wsCommitHash;
+  memset(&wsCatHash, 0, sizeof(wsCatHash));
+  memset(&wsCommitHash, 0, sizeof(wsCommitHash));
+  if( chunkStoreReadBranchWorkingCatalog(cs, zBranch, &wsCatHash, &wsCommitHash)==SQLITE_OK
+   && !prollyHashIsEmpty(&wsCommitHash)
+   && memcmp(wsCommitHash.data, pBranchCommit->data, PROLLY_HASH_SIZE)==0
+   && memcmp(wsCatHash.data, pCommittedCatHash->data, PROLLY_HASH_SIZE)!=0 ){
+    memcpy(pCatHash, &wsCatHash, sizeof(ProllyHash));
+  }else{
+    memcpy(pCatHash, pCommittedCatHash, sizeof(ProllyHash));
+  }
+}
+
+/* True if a trimmed CREATE TABLE body segment is a table-level constraint
+** (PRIMARY KEY / UNIQUE / CHECK / FOREIGN KEY / CONSTRAINT) rather than a
+** column definition. s/len delimit the already-trimmed segment. */
+static SQLITE_INLINE int doltliteSegmentIsTableConstraint(const char *s, int len){
+  if( len>=11 && sqlite3_strnicmp(s, "PRIMARY KEY", 11)==0
+      && (len==11 || !isalnum((unsigned char)s[11])) ) return 1;
+  if( len>=6 && sqlite3_strnicmp(s, "UNIQUE", 6)==0
+      && (len==6 || s[6]=='(' || isspace((unsigned char)s[6])) ) return 1;
+  if( len>=5 && sqlite3_strnicmp(s, "CHECK", 5)==0
+      && (len==5 || s[5]=='(' || isspace((unsigned char)s[5])) ) return 1;
+  if( len>=11 && sqlite3_strnicmp(s, "FOREIGN KEY", 11)==0
+      && (len==11 || !isalnum((unsigned char)s[11])) ) return 1;
+  if( len>=10 && sqlite3_strnicmp(s, "CONSTRAINT", 10)==0
+      && (len==10 || isspace((unsigned char)s[10])) ) return 1;
+  return 0;
 }
 
 static SQLITE_INLINE int doltliteAppendQuotedColumnList(

--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -902,27 +902,7 @@ static int parseColumns(
       len = (int)(e - s);
       if( len > 0 ){
 
-        int isConstraint = 0;
-        {
-          const char *t = s;
-
-          if( len>=11 && sqlite3_strnicmp(t, "PRIMARY KEY", 11)==0
-              && (len==11 || !isalnum((unsigned char)t[11])) ){
-            isConstraint = 1;
-          }else if( len>=6 && sqlite3_strnicmp(t, "UNIQUE", 6)==0
-              && (len==6 || t[6]=='(' || isspace((unsigned char)t[6])) ){
-            isConstraint = 1;
-          }else if( len>=5 && sqlite3_strnicmp(t, "CHECK", 5)==0
-              && (len==5 || t[5]=='(' || isspace((unsigned char)t[5])) ){
-            isConstraint = 1;
-          }else if( len>=11 && sqlite3_strnicmp(t, "FOREIGN KEY", 11)==0
-              && (len==11 || !isalnum((unsigned char)t[11])) ){
-            isConstraint = 1;
-          }else if( len>=10 && sqlite3_strnicmp(t, "CONSTRAINT", 10)==0
-              && (len==10 || isspace((unsigned char)t[10])) ){
-            isConstraint = 1;
-          }
-        }
+        int isConstraint = doltliteSegmentIsTableConstraint(s, len);
 
         if( !isConstraint ){
 

--- a/src/doltlite_schema_diff.c
+++ b/src/doltlite_schema_diff.c
@@ -437,6 +437,38 @@ static int sdClose(sqlite3_vtab_cursor *cur){
   return SQLITE_OK;
 }
 
+static int sdResolveOne(
+  sqlite3 *db,
+  sqlite3_vtab *pVtab,
+  const char *zRef,
+  const char *zWhich,
+  ProllyHash *pCatHash
+){
+  DoltliteCommit commit;
+  ProllyHash commitHash;
+  int rc;
+
+  rc = doltliteResolveRef(db, zRef, &commitHash);
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(pVtab->zErrMsg);
+    pVtab->zErrMsg = sqlite3_mprintf(
+      "dolt_schema_diff: %s '%s' could not be resolved", zWhich, zRef);
+    return SQLITE_ERROR;
+  }
+  memset(&commit, 0, sizeof(commit));
+  rc = doltliteLoadCommit(db, &commitHash, &commit);
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(pVtab->zErrMsg);
+    pVtab->zErrMsg = sqlite3_mprintf(
+      "dolt_schema_diff: %s '%s' resolved to a hash but the "
+      "commit could not be loaded", zWhich, zRef);
+    return SQLITE_ERROR;
+  }
+  memcpy(pCatHash, &commit.catalogHash, sizeof(ProllyHash));
+  doltliteCommitClear(&commit);
+  return SQLITE_OK;
+}
+
 static int sdResolveRefs(
   sqlite3 *db,
   sqlite3_vtab *pVtab,
@@ -445,8 +477,6 @@ static int sdResolveRefs(
   ProllyHash *pFromCatHash,
   ProllyHash *pToCatHash
 ){
-  DoltliteCommit commit;
-  ProllyHash commitHash;
   int rc;
 
   if( !zFromRef || !zToRef ){
@@ -457,45 +487,9 @@ static int sdResolveRefs(
     return SQLITE_ERROR;
   }
 
-  rc = doltliteResolveRef(db, zFromRef, &commitHash);
-  if( rc!=SQLITE_OK ){
-    sqlite3_free(pVtab->zErrMsg);
-    pVtab->zErrMsg = sqlite3_mprintf(
-      "dolt_schema_diff: from_ref '%s' could not be resolved", zFromRef);
-    return SQLITE_ERROR;
-  }
-  memset(&commit, 0, sizeof(commit));
-  rc = doltliteLoadCommit(db, &commitHash, &commit);
-  if( rc!=SQLITE_OK ){
-    sqlite3_free(pVtab->zErrMsg);
-    pVtab->zErrMsg = sqlite3_mprintf(
-      "dolt_schema_diff: from_ref '%s' resolved to a hash but the "
-      "commit could not be loaded", zFromRef);
-    return SQLITE_ERROR;
-  }
-  memcpy(pFromCatHash, &commit.catalogHash, sizeof(ProllyHash));
-  doltliteCommitClear(&commit);
-
-  rc = doltliteResolveRef(db, zToRef, &commitHash);
-  if( rc!=SQLITE_OK ){
-    sqlite3_free(pVtab->zErrMsg);
-    pVtab->zErrMsg = sqlite3_mprintf(
-      "dolt_schema_diff: to_ref '%s' could not be resolved", zToRef);
-    return SQLITE_ERROR;
-  }
-  memset(&commit, 0, sizeof(commit));
-  rc = doltliteLoadCommit(db, &commitHash, &commit);
-  if( rc!=SQLITE_OK ){
-    sqlite3_free(pVtab->zErrMsg);
-    pVtab->zErrMsg = sqlite3_mprintf(
-      "dolt_schema_diff: to_ref '%s' resolved to a hash but the "
-      "commit could not be loaded", zToRef);
-    return SQLITE_ERROR;
-  }
-  memcpy(pToCatHash, &commit.catalogHash, sizeof(ProllyHash));
-  doltliteCommitClear(&commit);
-
-  return SQLITE_OK;
+  rc = sdResolveOne(db, pVtab, zFromRef, "from_ref", pFromCatHash);
+  if( rc!=SQLITE_OK ) return rc;
+  return sdResolveOne(db, pVtab, zToRef, "to_ref", pToCatHash);
 }
 
 static int sdParseArgs(

--- a/src/doltlite_schema_merge.c
+++ b/src/doltlite_schema_merge.c
@@ -291,22 +291,7 @@ int migrateSchemaRowData(
               if( e > s ){
                 int segLen = (int)(e - s);
 
-                if( segLen>=11 && sqlite3_strnicmp(s, "PRIMARY KEY", 11)==0
-                    && (segLen==11 || !isalnum((unsigned char)s[11])) ){
-                  isConstraint = 1;
-                }else if( segLen>=6 && sqlite3_strnicmp(s, "UNIQUE", 6)==0
-                    && (segLen==6 || s[6]=='(' || isspace((unsigned char)s[6])) ){
-                  isConstraint = 1;
-                }else if( segLen>=5 && sqlite3_strnicmp(s, "CHECK", 5)==0
-                    && (segLen==5 || s[5]=='(' || isspace((unsigned char)s[5])) ){
-                  isConstraint = 1;
-                }else if( segLen>=11 && sqlite3_strnicmp(s, "FOREIGN KEY", 11)==0
-                    && (segLen==11 || !isalnum((unsigned char)s[11])) ){
-                  isConstraint = 1;
-                }else if( segLen>=10 && sqlite3_strnicmp(s, "CONSTRAINT", 10)==0
-                    && (segLen==10 || isspace((unsigned char)s[10])) ){
-                  isConstraint = 1;
-                }
+                isConstraint = doltliteSegmentIsTableConstraint(s, segLen);
 
                 if( !isConstraint ){
 


### PR DESCRIPTION
Third batch from the dead/duplicate-code scan (follows #1106, #1108). Extracts shared helpers for logic that was copy-pasted across translation units.

## Changes
- **`doltlite_internal.h`** — two new inline helpers (plus `#include <ctype.h>`):
  - `doltliteSegmentIsTableConstraint` — the 5-branch `PRIMARY KEY`/`UNIQUE`/`CHECK`/`FOREIGN KEY`/`CONSTRAINT` detector that was byte-identical in `doltlite_merge.c` and `doltlite_schema_merge.c`.
  - `doltliteResolveBranchEffectiveCatalog` — the "use the branch working-set catalog iff it's recorded against this exact commit, else the committed catalog" decision duplicated in `doltlite_at.c` and `doltlite_branch.c`.
- **`doltlite_merge.c` / `doltlite_schema_merge.c`** — use the shared constraint detector.
- **`doltlite_at.c` / `doltlite_branch.c`** — use the shared effective-catalog helper. `at.c` now picks the catalog hash once and does a single `doltliteLoadCatalog`, which lets the `goto at_find_root`/label go away.
- **`doltlite_schema_diff.c`** — `sdResolveRefs` contained the same ~17-line resolve-and-load block twice (from + to); factored into `sdResolveOne`. The per-ref/per-stage error messages are preserved verbatim via a `from_ref`/`to_ref` label.

Net: −103 / +78 across 6 files.

## Scope note
A few scan candidates were evaluated and deliberately left alone because unifying them would reduce readability or change behavior — details in commit history / `CLEANUP_TODO.md`: the conflicts/cv FNV1a hashers (only a tiny common prefix; a shared helper would return a leaky partial hash), the conflicts/cv remove/free lifecycle ladders (heterogeneous structs would force `void*` callbacks), the cross-file diff ref→catalog-hash unification (lossy vs `schema_diff`'s granular error messages), and the `remote_sql` seal+error ladder (mixed `result_error`/`result_error_code` styles — needs a deliberate broader pass).

## Verification
- Clean build, no warnings
- Smoke tests: `dolt_schema_diff` bad-ref messages, `dolt_at_*` reading a branch's uncommitted working-set catalog, a constraint-bearing merge
- `test/run_doltlite_tests.sh`: 67/67 suites pass
- C regression suite: 309770/309770 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)