### PR TITLE
Support DoltLite shell test harness variants

### DIFF
--- a/test/doltlite_behavior.sh
+++ b/test/doltlite_behavior.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
-DOLTLITE=./doltlite
-PASS=0; FAIL=0; ERRORS=""
-run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
-run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1); if echo "$r"|grep -qiE "$p"; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  pattern: $p\n  got:     $r"; fi; }
+DLTEST_MATCH_FLAGS=i
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
 
 echo "=== Doltlite Behavior Tests ==="
 echo ""
@@ -353,6 +351,4 @@ run_test "at_commit_hash_count" \
 
 rm -f "$DB"
 
-echo ""
-echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
-if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi
+dltest_finish

--- a/test/doltlite_branch_gc_stress.sh
+++ b/test/doltlite_branch_gc_stress.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
-DOLTLITE=./doltlite
-PASS=0; FAIL=0; ERRORS=""
-run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(30);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
-run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(30);exec @ARGV' $DOLTLITE "$d" 2>&1); if echo "$r"|grep -qE "$p"; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  pattern: $p\n  got:     $r"; fi; }
+DLTEST_TIMEOUT=30
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
 
 file_size() {
   local s=0
@@ -248,6 +246,4 @@ run_test "recycle_reuse_after_gc" "SELECT count(*) FROM dolt_branches;" "2" "$DB
 
 db_rm "$DB"
 
-echo ""
-echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
-if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi
+dltest_finish

--- a/test/doltlite_gc.sh
+++ b/test/doltlite_gc.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
-DOLTLITE=./doltlite
-PASS=0; FAIL=0; ERRORS=""
-run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1 | tr -d '\r'); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
-run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1 | tr -d '\r'); if echo "$r"|grep -qE "$p"; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  pattern: $p\n  got:     $r"; fi; }
+DLTEST_STRIP_CR=1
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
 db_size() { local s=0; for f in "$1" "${1}-wal"; do [ -f "$f" ] && s=$((s + $(stat -f%z "$f" 2>/dev/null || stat -c%s "$f" 2>/dev/null))); done; echo $s; }
 db_rm() { rm -f "$1" "${1}-wal" "${1}-lock"; }
 
@@ -296,6 +294,4 @@ run_test_match "gc_taghist_diff" \
 
 db_rm "$DB"
 
-echo ""
-echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
-if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi
+dltest_finish

--- a/test/doltlite_unicode_blob.sh
+++ b/test/doltlite_unicode_blob.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
-DOLTLITE=./doltlite
-PASS=0; FAIL=0; ERRORS=""
-run_test() { local n="$1" s="$2" e="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(30);exec @ARGV' $DOLTLITE "$d" 2>&1); if [ "$r" = "$e" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi; }
-run_test_match() { local n="$1" s="$2" p="$3" d="$4"; local r=$(echo "$s"|perl -e 'alarm(30);exec @ARGV' $DOLTLITE "$d" 2>&1); if echo "$r"|grep -qE -- "$p"; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  pattern: $p\n  got:     $r"; fi; }
+DLTEST_TIMEOUT=30
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
 
 echo "=== Doltlite Unicode, Special Characters & Large BLOB Tests ==="
 echo ""
@@ -364,9 +362,4 @@ echo "SELECT dolt_commit('-A','-m','update reals');" | $DOLTLITE "$DB" > /dev/nu
 
 rm -f "$DB"
 
-echo ""
-echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
-if [ $FAIL -gt 0 ]; then
-  echo -e "$ERRORS"
-  exit 1
-fi
+dltest_finish

--- a/test/lib/doltlite_test_common.sh
+++ b/test/lib/doltlite_test_common.sh
@@ -5,11 +5,17 @@ PASS="${PASS:-0}"
 FAIL="${FAIL:-0}"
 ERRORS="${ERRORS:-}"
 DLTEST_TIMEOUT="${DLTEST_TIMEOUT:-10}"
+DLTEST_STRIP_CR="${DLTEST_STRIP_CR:-0}"
+DLTEST_MATCH_FLAGS="${DLTEST_MATCH_FLAGS:-}"
 
 dltest_run_sql() {
   local sql="$1"
   local db="$2"
-  echo "$sql" | perl -e "alarm($DLTEST_TIMEOUT);exec @ARGV" "$DOLTLITE" "$db" 2>&1
+  if [ "$DLTEST_STRIP_CR" = "1" ]; then
+    echo "$sql" | perl -e "alarm($DLTEST_TIMEOUT);exec @ARGV" "$DOLTLITE" "$db" 2>&1 | tr -d '\r'
+  else
+    echo "$sql" | perl -e "alarm($DLTEST_TIMEOUT);exec @ARGV" "$DOLTLITE" "$db" 2>&1
+  fi
 }
 
 dltest_pass() {
@@ -58,7 +64,7 @@ run_test_match() {
   local db="$4"
   local result
   result=$(dltest_run_sql "$sql" "$db")
-  if echo "$result" | grep -qE "$pattern"; then
+  if echo "$result" | grep -qE${DLTEST_MATCH_FLAGS} -- "$pattern"; then
     dltest_pass
   else
     dltest_fail "$name" "  pattern: $pattern\n  got:     $result"


### PR DESCRIPTION
## Summary
- add shared shell-test helper knobs for CR stripping, case-insensitive regex matches, timeout overrides, and safe grep patterns
- migrate doltlite_gc, doltlite_behavior, doltlite_branch_gc_stress, and doltlite_unicode_blob onto the shared helper
- remove duplicated runner/footer code from the migrated scripts

## Tests
- bash -n test/lib/doltlite_test_common.sh test/doltlite_gc.sh test/doltlite_behavior.sh test/doltlite_branch_gc_stress.sh test/doltlite_unicode_blob.sh
- (cd build && bash ../test/doltlite_gc.sh)
- (cd build && bash ../test/doltlite_behavior.sh)
- (cd build && bash ../test/doltlite_branch_gc_stress.sh)
- (cd build && bash ../test/doltlite_unicode_blob.sh)
- make lint