### PR TITLE
Deduplicate multiline DoltLite shell tests

### DIFF
--- a/test/doltlite_deep_history.sh
+++ b/test/doltlite_deep_history.sh
@@ -1,20 +1,6 @@
 #!/bin/bash
-DOLTLITE=./doltlite
-PASS=0; FAIL=0; ERRORS=""
-
-run_test() {
-  local n="$1" s="$2" e="$3" d="$4"
-  local r=$(echo "$s" | perl -e 'alarm(30); exec @ARGV' $DOLTLITE "$d" 2>&1)
-  if [ "$r" = "$e" ]; then PASS=$((PASS+1))
-  else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi
-}
-
-run_test_match() {
-  local n="$1" s="$2" p="$3" d="$4"
-  local r=$(echo "$s" | perl -e 'alarm(30); exec @ARGV' $DOLTLITE "$d" 2>&1)
-  if echo "$r" | grep -qE "$p"; then PASS=$((PASS+1))
-  else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  pattern: $p\n  got:     $r"; fi
-}
+DLTEST_TIMEOUT=30
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
 
 echo "=== Doltlite Deep Commit History Stress Tests ==="
 echo ""
@@ -139,9 +125,4 @@ fi
 
 rm -f "$DB"
 
-echo ""
-echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
-if [ $FAIL -gt 0 ]; then
-  echo -e "$ERRORS"
-  exit 1
-fi
+dltest_finish

--- a/test/doltlite_diff_alter.sh
+++ b/test/doltlite_diff_alter.sh
@@ -1,22 +1,5 @@
 #!/bin/bash
-DOLTLITE=./doltlite
-PASS=0
-FAIL=0
-ERRORS=""
-
-run_test() {
-  local name="$1" sql="$2" expected="$3" db="$4"
-  local result=$(echo "$sql" | perl -e 'alarm(10); exec @ARGV' $DOLTLITE "$db" 2>&1)
-  if [ "$result" = "$expected" ]; then PASS=$((PASS+1))
-  else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $name\n  expected: $expected\n  got:      $result"; fi
-}
-
-run_test_match() {
-  local name="$1" sql="$2" pattern="$3" db="$4"
-  local result=$(echo "$sql" | perl -e 'alarm(10); exec @ARGV' $DOLTLITE "$db" 2>&1)
-  if echo "$result" | grep -qE "$pattern"; then PASS=$((PASS+1))
-  else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $name\n  pattern: $pattern\n  got:     $result"; fi
-}
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
 
 echo "=== Doltlite Diff Across ALTER TABLE Tests ==="
 echo ""
@@ -142,6 +125,4 @@ run_test_match "diff_after_merge_works" \
 
 rm -f "$DB1" "$DB2" "$DB3" "$DB4" "$DB5"
 
-echo ""
-echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
-if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi
+dltest_finish

--- a/test/doltlite_dolt_table_pushdown.sh
+++ b/test/doltlite_dolt_table_pushdown.sh
@@ -1,33 +1,9 @@
 #!/bin/bash
-DOLTLITE=./doltlite
-PASS=0; FAIL=0; ERRORS=""
+DLTEST_TIMEOUT=30
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
 
 echo "=== Doltlite dolt_* vtab constraint pushdown ==="
 echo ""
-
-run_test() {
-  local n="$1" sql="$2" expected="$3" db="$4"
-  local r
-  r=$(echo "$sql" | perl -e 'alarm(30);exec @ARGV' $DOLTLITE "$db" 2>&1)
-  if [ "$r" = "$expected" ]; then
-    PASS=$((PASS+1))
-  else
-    FAIL=$((FAIL+1))
-    ERRORS="$ERRORS\nFAIL: $n\n  expected: $expected\n  got:      $r"
-  fi
-}
-
-run_test_match() {
-  local n="$1" sql="$2" pat="$3" db="$4"
-  local r
-  r=$(echo "$sql" | perl -e 'alarm(30);exec @ARGV' $DOLTLITE "$db" 2>&1)
-  if echo "$r" | grep -qE "$pat"; then
-    PASS=$((PASS+1))
-  else
-    FAIL=$((FAIL+1))
-    ERRORS="$ERRORS\nFAIL: $n\n  pattern: $pat\n  got:     $r"
-  fi
-}
 
 time_ms() {
   local start end
@@ -185,9 +161,4 @@ run_test "nonint_history_filter_correct" \
 
 rm -f "$DB2"
 
-echo ""
-echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
-if [ $FAIL -gt 0 ]; then
-  echo -e "$ERRORS"
-  exit 1
-fi
+dltest_finish

--- a/test/doltlite_gc_scale.sh
+++ b/test/doltlite_gc_scale.sh
@@ -1,13 +1,6 @@
 #!/bin/bash
-DOLTLITE=./doltlite
-PASS=0; FAIL=0; ERRORS=""
-
-run_test() {
-  local n="$1" s="$2" e="$3" d="$4"
-  local r=$(echo "$s" | perl -e 'alarm(60);exec @ARGV' $DOLTLITE "$d" 2>&1)
-  if [ "$r" = "$e" ]; then PASS=$((PASS+1))
-  else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi
-}
+DLTEST_TIMEOUT=60
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
 
 echo "=== GC Tests at Scale ==="
 echo ""
@@ -130,10 +123,4 @@ fi
 
 rm -f "$DB1" "$DB2" "$DB3" "$DB4"
 
-echo ""
-echo "Results: $PASS passed, $FAIL failed"
-if [ $FAIL -gt 0 ]; then
-  echo -e "$ERRORS"
-  exit 1
-fi
-echo "All tests passed!"
+dltest_finish

--- a/test/doltlite_index_prefix.sh
+++ b/test/doltlite_index_prefix.sh
@@ -1,13 +1,6 @@
 #!/bin/bash
-DOLTLITE=./doltlite
-PASS=0; FAIL=0; ERRORS=""
-
-run_test() {
-  local n="$1" s="$2" e="$3" d="$4"
-  local r=$(echo "$s" | perl -e 'alarm(60);exec @ARGV' $DOLTLITE "$d" 2>&1)
-  if [ "$r" = "$e" ]; then PASS=$((PASS+1))
-  else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi
-}
+DLTEST_TIMEOUT=60
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
 
 echo "=== Index Tests at Scale ==="
 echo ""
@@ -248,10 +241,4 @@ run_test "mixed_10k_2prefix" \
 
 rm -f "$DB1" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7"
 
-echo ""
-echo "Results: $PASS passed, $FAIL failed"
-if [ $FAIL -gt 0 ]; then
-  echo -e "$ERRORS"
-  exit 1
-fi
-echo "All tests passed!"
+dltest_finish

--- a/test/doltlite_reset.sh
+++ b/test/doltlite_reset.sh
@@ -1,19 +1,5 @@
 #!/bin/bash
-DOLTLITE=./doltlite
-PASS=0; FAIL=0; ERRORS=""
-
-run_test() {
-  local name="$1" sql="$2" expected="$3" db="$4"
-  local result=$(echo "$sql" | perl -e 'alarm(10); exec @ARGV' $DOLTLITE "$db" 2>&1)
-  if [ "$result" = "$expected" ]; then PASS=$((PASS+1))
-  else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $name\n  expected: $expected\n  got:      $result"; fi
-}
-run_test_match() {
-  local name="$1" sql="$2" pattern="$3" db="$4"
-  local result=$(echo "$sql" | perl -e 'alarm(10); exec @ARGV' $DOLTLITE "$db" 2>&1)
-  if echo "$result" | grep -qE "$pattern"; then PASS=$((PASS+1))
-  else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $name\n  pattern: $pattern\n  got:     $result"; fi
-}
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
 
 echo "=== Doltlite Reset Tests ==="
 echo ""
@@ -252,6 +238,4 @@ run_test "path_reset_recreated_table_keeps_live_row" \
 
 rm -f "$DB" "$DB2" "$DB3" "$DB3B" "$DB3C" "$DB4" "$DB5" "$DB5B" "$DB5C" "$DB5C.hash" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10"
 
-echo ""
-echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
-if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi
+dltest_finish

--- a/test/doltlite_revert_dirty.sh
+++ b/test/doltlite_revert_dirty.sh
@@ -1,28 +1,5 @@
 #!/bin/bash
-DOLTLITE=./doltlite
-PASS=0; FAIL=0; ERRORS=""
-
-run_test() {
-  local n="$1" s="$2" e="$3" d="$4"
-  local r=$(echo "$s" | perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1)
-  if [ "$r" = "$e" ]; then
-    PASS=$((PASS+1))
-  else
-    FAIL=$((FAIL+1))
-    ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"
-  fi
-}
-
-run_test_match() {
-  local n="$1" s="$2" p="$3" d="$4"
-  local r=$(echo "$s" | perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1)
-  if echo "$r" | grep -qE "$p"; then
-    PASS=$((PASS+1))
-  else
-    FAIL=$((FAIL+1))
-    ERRORS="$ERRORS\nFAIL: $n\n  pattern: $p\n  got:     $r"
-  fi
-}
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
 
 db_rm() { rm -f "$1" "${1}-wal"; }
 
@@ -117,6 +94,4 @@ run_test "rv_clean_t_reverted" "SELECT count(*) FROM t;" "0" "$DB"
 
 db_rm "$DB"
 
-echo ""
-echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
-if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi
+dltest_finish


### PR DESCRIPTION
## Summary
- migrate seven multiline DoltLite shell test harnesses onto test/lib/doltlite_test_common.sh
- preserve timeout-specific behavior with DLTEST_TIMEOUT where needed
- keep script-specific helpers and custom assertions unchanged

Migrated scripts:
- test/doltlite_deep_history.sh
- test/doltlite_gc_scale.sh
- test/doltlite_dolt_table_pushdown.sh
- test/doltlite_diff_alter.sh
- test/doltlite_index_prefix.sh
- test/doltlite_reset.sh
- test/doltlite_revert_dirty.sh

Note: test/doltlite_rebase.sh was checked but left out because it currently fails one behavioral assertion on master, independent of this mechanical cleanup.

## Tests
- bash -n test/doltlite_deep_history.sh test/doltlite_gc_scale.sh test/doltlite_dolt_table_pushdown.sh test/doltlite_diff_alter.sh test/doltlite_index_prefix.sh test/doltlite_reset.sh test/doltlite_revert_dirty.sh
- (cd build && bash ../test/doltlite_deep_history.sh)
- (cd build && bash ../test/doltlite_gc_scale.sh)
- (cd build && bash ../test/doltlite_dolt_table_pushdown.sh)
- (cd build && bash ../test/doltlite_diff_alter.sh)
- (cd build && bash ../test/doltlite_index_prefix.sh)
- (cd build && bash ../test/doltlite_reset.sh)
- (cd build && bash ../test/doltlite_revert_dirty.sh)
- make lint