### PR TITLE
Deduplicate DoltLite state shell tests

### DIFF
--- a/test/doltlite_diff.sh
+++ b/test/doltlite_diff.sh
@@ -1,22 +1,5 @@
 #!/bin/bash
-DOLTLITE=./doltlite
-PASS=0
-FAIL=0
-ERRORS=""
-
-run_test() {
-  local name="$1" sql="$2" expected="$3" db="$4"
-  local result=$(echo "$sql" | perl -e 'alarm(10); exec @ARGV' $DOLTLITE "$db" 2>&1)
-  if [ "$result" = "$expected" ]; then PASS=$((PASS+1))
-  else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $name\n  expected: $expected\n  got:      $result"; fi
-}
-
-run_test_match() {
-  local name="$1" sql="$2" pattern="$3" db="$4"
-  local result=$(echo "$sql" | perl -e 'alarm(10); exec @ARGV' $DOLTLITE "$db" 2>&1)
-  if echo "$result" | grep -qE "$pattern"; then PASS=$((PASS+1))
-  else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $name\n  pattern: $pattern\n  got:     $result"; fi
-}
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
 
 echo "=== Doltlite Diff Tests ==="
 echo ""
@@ -254,6 +237,4 @@ run_test "diff_stat_real_pos_neg_zero_no_diff" \
 
 rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17"
 
-echo ""
-echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
-if [ $FAIL -gt 0 ]; then echo -e "$ERRORS"; exit 1; fi
+dltest_finish

--- a/test/doltlite_gc_session_state.sh
+++ b/test/doltlite_gc_session_state.sh
@@ -4,30 +4,8 @@
 # state, constraint-violations catalog). gcMarkReachable seeds these from
 # every attached doltlite Btree on the calling connection.
 
-DOLTLITE=./doltlite
-PASS=0; FAIL=0; ERRORS=""
-
-run_test() {
-  local n="$1" s="$2" e="$3" d="$4"
-  local r=$(echo "$s" | perl -e 'alarm(15);exec @ARGV' $DOLTLITE "$d" 2>&1)
-  if [ "$r" = "$e" ]; then
-    PASS=$((PASS+1))
-  else
-    FAIL=$((FAIL+1))
-    ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"
-  fi
-}
-
-run_test_match() {
-  local n="$1" s="$2" p="$3" d="$4"
-  local r=$(echo "$s" | perl -e 'alarm(15);exec @ARGV' $DOLTLITE "$d" 2>&1)
-  if echo "$r" | grep -qE "$p"; then
-    PASS=$((PASS+1))
-  else
-    FAIL=$((FAIL+1))
-    ERRORS="$ERRORS\nFAIL: $n\n  pattern: $p\n  got:     $r"
-  fi
-}
+DLTEST_TIMEOUT=15
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
 
 db_rm() { rm -f "$1" "${1}-wal"; }
 
@@ -137,10 +115,4 @@ run_test_match "cv_table_c" "SELECT count(*) FROM c;" "[0-9]+" "$DB"
 
 db_rm "$DB"
 
-echo ""
-if [ $FAIL -gt 0 ]; then
-  printf "$ERRORS\n"
-  echo "RESULTS: $PASS passed, $FAIL failed"
-  exit 1
-fi
-echo "RESULTS: $PASS passed, $FAIL failed"
+dltest_finish

--- a/test/doltlite_staging.sh
+++ b/test/doltlite_staging.sh
@@ -1,38 +1,5 @@
 #!/bin/bash
-DOLTLITE=./doltlite
-PASS=0
-FAIL=0
-ERRORS=""
-
-run_test() {
-  local name="$1"
-  local sql="$2"
-  local expected="$3"
-  local db="$4"
-  local result
-  result=$(echo "$sql" | perl -e 'alarm(10); exec @ARGV' $DOLTLITE "$db" 2>&1)
-  if [ "$result" = "$expected" ]; then
-    PASS=$((PASS+1))
-  else
-    FAIL=$((FAIL+1))
-    ERRORS="$ERRORS\nFAIL: $name\n  expected: $expected\n  got:      $result"
-  fi
-}
-
-run_test_match() {
-  local name="$1"
-  local sql="$2"
-  local pattern="$3"
-  local db="$4"
-  local result
-  result=$(echo "$sql" | perl -e 'alarm(10); exec @ARGV' $DOLTLITE "$db" 2>&1)
-  if echo "$result" | grep -qE "$pattern"; then
-    PASS=$((PASS+1))
-  else
-    FAIL=$((FAIL+1))
-    ERRORS="$ERRORS\nFAIL: $name\n  pattern: $pattern\n  got:     $result"
-  fi
-}
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
 
 echo "=== Doltlite Staging Workflow Tests ==="
 echo ""
@@ -217,9 +184,4 @@ run_test "status_clean_composite_pk_schema" \
 
 rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB6B" "$DB7" "$DB8" "$DB9"
 
-echo ""
-echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
-if [ $FAIL -gt 0 ]; then
-  echo -e "$ERRORS"
-  exit 1
-fi
+dltest_finish

--- a/test/doltlite_working_set.sh
+++ b/test/doltlite_working_set.sh
@@ -1,18 +1,6 @@
 #!/bin/bash
 DOLTLITE=${DOLTLITE:-./doltlite}
-PASS=0; FAIL=0; ERRORS=""
-run_test() {
-  local n="$1" s="$2" e="$3" d="$4"
-  local r=$(echo "$s" | perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1)
-  if [ "$r" = "$e" ]; then PASS=$((PASS+1))
-  else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  expected: $e\n  got:      $r"; fi
-}
-run_test_match() {
-  local n="$1" s="$2" p="$3" d="$4"
-  local r=$(echo "$s" | perl -e 'alarm(10);exec @ARGV' $DOLTLITE "$d" 2>&1)
-  if echo "$r" | grep -qE "$p"; then PASS=$((PASS+1))
-  else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: $n\n  pattern: $p\n  got:     $r"; fi
-}
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
 
 echo "=== Per-Branch WorkingSet Tests ==="
 echo ""
@@ -190,7 +178,4 @@ run_test "multi_b2_new_row" \
 
 rm -f "$DB"
 
-echo ""
-echo "Results: $PASS passed, $FAIL failed out of $((PASS+FAIL)) tests"
-if [ -n "$ERRORS" ]; then echo -e "$ERRORS"; fi
-if [ $FAIL -gt 0 ]; then exit 1; fi
+dltest_finish


### PR DESCRIPTION
## Summary
- migrate four DoltLite state-oriented shell test harnesses onto test/lib/doltlite_test_common.sh
- preserve the gc session test timeout with DLTEST_TIMEOUT
- leave script-specific setup and assertions unchanged

Migrated scripts:
- test/doltlite_diff.sh
- test/doltlite_gc_session_state.sh
- test/doltlite_staging.sh
- test/doltlite_working_set.sh

## Tests
- bash -n test/doltlite_diff.sh test/doltlite_staging.sh test/doltlite_working_set.sh test/doltlite_gc_session_state.sh
- (cd build && bash ../test/doltlite_diff.sh)
- (cd build && bash ../test/doltlite_staging.sh)
- (cd build && bash ../test/doltlite_working_set.sh)
- (cd build && bash ../test/doltlite_gc_session_state.sh)
- make lint