### PR TITLE
Fix ATTACHed-DDL stack overflow and mid-scan DROP TRIGGER use-after-free

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -181,6 +181,7 @@ struct BtShared {
   u32 pageSize;
   u32 iWorkingStateVersion;
   int nRef;
+  u8 inCatalogSerialize;
 };
 
 struct BtreeOps {
@@ -4980,6 +4981,11 @@ static int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
   ProllyHash catHash;
   (void)bCleanup;
 
+  /* Catalog serialization runs a SELECT whose finalize re-enters
+  ** commit/rollback; that nested call is read-only, so no-op it instead of
+  ** recursing into a stack overflow. */
+  if( pBt->inCatalogSerialize ) return SQLITE_OK;
+
   if( p->inTrans==TRANS_WRITE ){
     rc = flushAllPending(p, pBt, 0);
     if( rc!=SQLITE_OK ){
@@ -4990,7 +4996,9 @@ static int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
     }
 
     {
+      pBt->inCatalogSerialize = 1;
       rc = serializeCatalogForCommit(p, &catData, &nCatData);
+      pBt->inCatalogSerialize = 0;
       if( rc==SQLITE_OK ){
         rc = chunkStorePut(&pBt->store, catData, nCatData, &catHash);
       }
@@ -5165,6 +5173,8 @@ static int prollyBtreeRollback(Btree *p, int tripCode, int writeOnly){
   int rc = SQLITE_OK;
   (void)writeOnly;
 
+  if( pBt->inCatalogSerialize ) return SQLITE_OK;
+
   if( p->inTrans==TRANS_WRITE ){
     assert( pBt->store.isMemory || pBt->store.graphLockFd >= 0 );
     assert( pBt->store.isMemory || pBt->store.lockDepth > 0 );
@@ -5193,7 +5203,9 @@ static int prollyBtreeRollback(Btree *p, int tripCode, int writeOnly){
       int bMatchesDisk = 0;
       const char *zBr = p->zBranch ? p->zBranch : "main";
 
+      pBt->inCatalogSerialize = 1;
       rc = serializeCatalog(p, &catData, &nCatData);
+      pBt->inCatalogSerialize = 0;
       if( rc!=SQLITE_OK ){
         chunkStoreUnlock(&pBt->store);
         pBt->store.snapshotPinned = 0;
@@ -6107,6 +6119,12 @@ static int prollyBtCursorNext(BtCursor *pCur, int flags){
     return SQLITE_DONE;
   }
 
+  /* Faulted mid-scan: cached nodes are already released, so return the stored
+  ** error instead of advancing into freed memory. */
+  if( pCur->eState==CURSOR_FAULT ){
+    return pCur->skipNext;
+  }
+
   if( pCur->eState==CURSOR_REQUIRESEEK ){
     rc = restoreCursorPosition(pCur, 0);
     if( rc!=SQLITE_OK ) return rc;
@@ -6224,6 +6242,10 @@ static int prollyBtCursorPrevious(BtCursor *pCur, int flags){
 
   if( pCur->eState==CURSOR_INVALID ){
     return SQLITE_DONE;
+  }
+
+  if( pCur->eState==CURSOR_FAULT ){
+    return pCur->skipNext;
   }
 
   if( pCur->eState==CURSOR_REQUIRESEEK ){

--- a/test/known_testfixture_crashes.txt
+++ b/test/known_testfixture_crashes.txt
@@ -14,12 +14,15 @@
 # reproduce in the OBJECT build too (USE_AMALGAMATION=0), i.e. they are
 # pre-existing doltlite issues, investigated and tracked in issue #1119:
 #
-#   alter / triggerC are genuine robustness BUGS (SIGSEGV) — they should error
-#   cleanly, not crash. capi3 / fkey2 abort on raw stock on-disk-format tests
-#   (set_file_format/hexio), which doltlite's prolly format has no equivalent
-#   for — a format divergence rather than a bug.
-alter    # SIGSEGV (stack overflow): cross-db DDL on an ATTACHed db -> issue #1120
-triggerC # SIGSEGV: DROP TRIGGER during an active SELECT cursor -> issue #1121
+#   capi3 / fkey2 abort on raw stock on-disk-format tests (set_file_format/hexio),
+#   which doltlite's prolly format has no equivalent for — a format divergence
+#   rather than a bug.
+#
+# triggerC's use-after-free is fixed and it now produces a summary (its
+# divergences are in the divergence file). alter's stack overflow is fixed; it
+# no longer crashes but still stops before the summary on unsupported cross-db
+# (ATTACHed) DDL, which returns SQLITE_NOTFOUND / "unknown operation".
+alter    # cross-db (ATTACHed) DDL is unsupported and errors out before the summary
 capi3    # aborts on set_file_format (raw stock page format; doltlite uses prolly)
 fkey2    # aborts under fkey2-2.x (raw-format / pre-existing doltlite divergence)
 # Additional crash/timeout files from the full capture (issue #1119):

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -126,6 +126,7 @@ triggerC triggerC-2.1.2
 triggerC triggerC-2.1.3
 triggerC triggerC-2.1.4
 triggerC triggerC-2.1.6
+triggerC triggerC-12.2  # DROP TRIGGER mid-scan aborts the cursor rather than crashing
 
 # ── window1 ──
 window1 window1-10.7  # rowid-order vs PK-order on unordered SELECT


### PR DESCRIPTION
Closes #1120
Closes #1121

Fixes the two crashes filed as #1120 and #1121. Both are pre-existing doltlite bugs, surfaced once core-tests ran against real doltlite (PR #1116), and both reproduce in the object build (`USE_AMALGAMATION=0`).

## #1120 — stack overflow on DDL against an ATTACHed db

`CREATE TABLE aux.t(...)` after `ATTACH` recursed until the stack guard page faulted (`___chkstk_darwin`). The cycle:

```
prollyBtreeCommitPhaseTwo → serializeCatalog → appendMissingSchemaCatalogRows
  → doltliteLoadLiveSchemaSql (runs a SELECT) → sqlite3_finalize
  → sqlite3VdbeHalt → vdbeCommit / sqlite3RollbackAll → (re-enter commit/rollback) ↺
```

Catalog serialization runs a `SELECT` whose `finalize` re-enters commit **and** rollback while the write transaction is still open. Both `prollyBtreeCommitPhaseTwo` and `prollyBtreeRollback` serialize the catalog, so the recursion alternated between them. Fix: a `BtShared.inCatalogSerialize` guard set around both serialize calls and checked at the top of both — the nested, read-only commit/rollback no-ops.

## #1121 — use-after-free on DROP TRIGGER during an open SELECT

`DROP TRIGGER` from inside a `SELECT` row loop crashed in `prollyCursorNextFastLeaf` reading a freed `ProllyCacheEntry`. The schema change calls `invalidateCursors`, which trips open cursors to `CURSOR_FAULT` and releases their cached nodes — but `prollyBtCursorNext`/`Previous` only handled `REQUIRESEEK` and fell through to dereference the freed entry. Fix: return the stored fault code for `CURSOR_FAULT`, matching stock SQLite (which handles it in `restoreCursorPosition`). The scan now aborts cleanly (`SQLITE_ABORT`) rather than crashing — the abort-not-crash outcome the issue asks for.

## Tests / CI list reconciliation
- `triggerC` now runs to completion → removed from the crash list; `triggerC-12.2` recorded as a divergence (clean abort vs stock's continue).
- `alter`'s stack overflow is gone, but it still stops before the summary on unsupported cross-db (ATTACHed) DDL (returns `SQLITE_NOTFOUND`); it stays crash-listed with an updated reason. Improving that error message is remaining #1119 triage.

Verified locally (object build):
- `triggerC` / `alter` no longer SIGSEGV; harness reports `OK: triggerC` and `CRASH (expected): alter`.
- `test/run_doltlite_tests.sh`: 67 suites / 120 tests, 0 failed.
- `test/doltlite_regression_test_c.sh`: 309,770 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)