### PR TITLE
Fix pending index range seeks

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -6561,7 +6561,20 @@ static int findMatchingMutMapEntry(
     }
     cmpLen = pEntry->nKey < nSortKey ? pEntry->nKey : nSortKey;
     prefixCmp = memcmp(pEntry->pKey, pSortKey, cmpLen);
-    if( prefixCmp>0 || (prefixCmp==0 && pEntry->nKey < nSortKey) ){
+    if( prefixCmp>0 && pIdxKey->default_rc<0 ){
+      if( pEntry->op==PROLLY_EDIT_INSERT ){
+        pMatch = pEntry;
+        cmp = 1;
+      }else{
+        lo++;
+        continue;
+      }
+      break;
+    }
+    if( prefixCmp>0 ){
+      break;
+    }
+    if( prefixCmp==0 && pEntry->nKey < nSortKey ){
       break;
     }
     if( nRec==0 ){
@@ -6897,20 +6910,35 @@ static int prollyBtCursorIndexMoveto(
     }
     }
 
-      if( mutFound && (!treeFound || treeCmp!=0) ){
-      if( mutFromCursorMap ){
-        setCursorToMutMapEntryPhys(
-            pCur, (int)(mutE - pCur->pMutMap->aEntries));
-      }else{
-        rc = cacheCursorPayloadCopy(pCur, mutKey, mutNKey);
-        if( rc!=SQLITE_OK ){
-          return rc;
+    if( mutFound ){
+      int useMut = !treeFound;
+      if( treeFound ){
+        const u8 *pTreeKey = 0;
+        int nTreeKey = 0;
+        int nCmp;
+        int cmp;
+        prollyCursorKey(&pCur->pCur, &pTreeKey, &nTreeKey);
+        nCmp = nTreeKey < mutE->nKey ? nTreeKey : mutE->nKey;
+        cmp = memcmp(pTreeKey, mutE->pKey, nCmp);
+        if( cmp>0 || (cmp==0 && nTreeKey>mutE->nKey) ){
+          useMut = 1;
         }
-        pCur->eState = CURSOR_VALID;
       }
-      *pRes = mutCmp;
-      pIdxKey->eqSeen = 1;
-      return SQLITE_OK;
+      if( useMut ){
+        if( mutFromCursorMap ){
+          setCursorToMutMapEntryPhys(
+              pCur, (int)(mutE - pCur->pMutMap->aEntries));
+        }else{
+          rc = cacheCursorPayloadCopy(pCur, mutKey, mutNKey);
+          if( rc!=SQLITE_OK ){
+            return rc;
+          }
+          pCur->eState = CURSOR_VALID;
+        }
+        *pRes = mutCmp;
+        pIdxKey->eqSeen = 1;
+        return SQLITE_OK;
+      }
     }
     if( treeFound ){
       *pRes = treeCmp;

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -866,8 +866,6 @@ selectA selectA-3.8
 selectA selectA-3.80
 selectA selectA-3.81
 selectA selectA-3.9
-trans trans-6.26
-trans trans-6.36
 trans trans-9.10.5-2112
 trans trans-9.12.5-2544
 trans trans-9.14.5-3089


### PR DESCRIPTION
Fixes #1126.

Summary:
- Teach pending mutmap index seeks to return the first pending insert greater than a partial lower-bound key.

- Remove trans-6.26 and trans-6.36 from known testfixture divergences now that the existing tests pass.
Verification:
- LIBRARY_PATH=/opt/homebrew/lib make testfixture USE_AMALGAMATION=0
- ./testfixture test/trans.test (trans-6.26 and trans-6.36 pass; 19 existing trans-9.* fullfsync divergences still fail)

- bash ../test/run_testfixture.sh trans-1126 120 trans from tf-run: OK, 310 passing tests and 19 known divergences
- make lint




