### PR TITLE
Restore created-then-dropped tables on ROLLBACK TO a savepoint

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -3541,6 +3541,27 @@ static int restoreTablesFromSavepoint(
       }
       pBtree->cat.a[idx].pendingFlushSeekEdits =
           pState->aTables[k].pendingFlushSeekEdits;
+      if( apPending[k]==0 ){
+        /* A table dropped after this savepoint has no live mutmap, and
+        ** rollbackMutMapsToSavepoint only visits the current catalog so it
+        ** never saw it. Recover its pre-drop edits from the savepoint pending
+        ** snapshot so rows created before the drop survive ROLLBACK TO. */
+        int iThis = (int)(pState - pBtree->aSavepointTables);
+        int iSp = -1, iSnap = -1;
+        ProllyMutMap *pSnap = findPendingSnapshot(
+            pBtree, iThis, pState->aTables[k].iTable, &iSp, &iSnap);
+        if( pSnap ){
+          pBtree->aSavepointTables[iSp].aPendingSnapshot[iSnap].pPending = 0;
+          rc = prollyMutMapRollbackToSavepoint(pSnap, iThis + 1);
+          if( rc!=SQLITE_OK ){
+            prollyMutMapFree(pSnap);
+            sqlite3_free(pSnap);
+            sqlite3_free(apPending);
+            return rc;
+          }
+          apPending[k] = pSnap;
+        }
+      }
       pBtree->cat.a[idx].pPending = apPending[k];
     }
   }
@@ -5502,6 +5523,27 @@ static int prollyBtreeDropTable(Btree *p, int iTable, int *piMoved){
   }
 
   invalidateCursors(pBt, (Pgno)iTable, SQLITE_ABORT);
+
+  /* Hand the dropped table's pending edits to any open savepoint that captured
+  ** it (the path flushPendingForTable/clearTable use), so ROLLBACK TO can
+  ** restore a table created and dropped within the same transaction. Otherwise
+  ** catRemove frees the map outright and the pre-drop rows are lost. */
+  {
+    int rc = syncBtreeSavepoints(p);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+  {
+    struct TableEntry *pTE = findTable(p, (Pgno)iTable);
+    if( pTE && pTE->pPending ){
+      ProllyMutMap *pFlushMap = 0;
+      int captured = 0;
+      int rc = snapshotPendingForFlush(p, (Pgno)iTable,
+                                       (ProllyMutMap**)&pTE->pPending,
+                                       &pFlushMap, &captured);
+      if( rc!=SQLITE_OK ) return rc;
+    }
+  }
+
   /* Clear any cursor aliases of the dropped table's pending mutmap before
   ** catRemove frees it; otherwise rollback (prollyBtreeRollback) would
   ** later iterate live cursors and dereference a freed map. */

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -807,7 +807,6 @@ savepoint savepoint-17.1
 savepoint savepoint-3.2
 savepoint savepoint-3.3
 savepoint savepoint-3.4
-savepoint savepoint-4.4
 savepoint savepoint-5.4.3
 savepoint savepoint-5.4.4
 savepoint savepoint-6.1


### PR DESCRIPTION
Investigated #1125. The `savepoint.test` divergences are mostly **intended**, but the investigation surfaced one **real bug**, fixed here.

## Real bug fixed: savepoint-4.4
A table created within a transaction and `DROP`ped after a `SAVEPOINT` was not restored by `ROLLBACK TO` — its rows came back empty:
```sql
BEGIN;
  CREATE TABLE t3(g,h); INSERT INTO t3 VALUES('I','II');
  SAVEPOINT one;
  DROP TABLE t3;
ROLLBACK TO one;
SELECT * FROM t3;   -- expected: I II   got (before): <empty>
```
Two gaps:
1. `prollyBtreeDropTable` freed the table's pending mutmap (`catRemove`) without handing it to any open savepoint, so the pre-drop rows were lost. (The flush and `clearTable`/`DELETE` paths already snapshot via `snapshotPendingForFlush`; `DROP` didn't.)
2. Even when preserved, `restoreTablesFromSavepoint` only sourced pending maps from the **current** catalog — where the dropped table is absent — so the snapshot was never reapplied on restore.

Fix mirrors the flush/clear path: snapshot the dropped table's pending mutmap into open savepoints before freeing, and on restore recover a re-added table's edits from the savepoint pending snapshot (rolled back to the savepoint level).

Confirmed: `DROP` now matches `DELETE`/`INSERT` across a savepoint; removed the now-passing `savepoint-4.4` divergence entry.

## Confirmed intended (not fixed — by design)
- **lock_status** (savepoint-3.2/3.3/3.4, 10.x): `PRAGMA lock_status` reports `unlocked` where stock reports `reserved`. doltlite locks its chunk store, not the SQLite file via the `unlocked→reserved→…` state machine (`pager_shim.c` doesn't implement `SQLITE_FCNTL_LOCKSTATE`). It's a `SQLITE_TEST`-only debug pragma.
- **"database is locked"** (savepoint-5.4.x, 14.x, 15.x): all multi-connection (`db2` / `do_multiclient_test`). doltlite allows concurrent reader+writer (snapshot isolation) where SQLite serializes via file locks; the adjacent data-correctness subtests pass, confirming isolation is correct. The `no such savepoint` errors are cascades from that.

## Verification
- savepoint-4.4 + minimal repros (DROP-only, DROP+re-CREATE, pre-existing table) all return the correct rows.
- No regressions: doltlite shell suite 67/67, C regression 309,770/0, and `savepoint2`/`trans`/`trigger1`/`fkey1`/`fkey3` error counts unchanged vs their allow-listed counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)