### PR TITLE
Use attached schema when serializing catalogs

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -368,6 +368,7 @@ int doltliteMaterializeDefaultColumns(sqlite3 *db){
 int doltliteLoadLiveSchemaSql(
   sqlite3 *db,
   const char *zType,
+  const char *zDb,
   const char *zName,
   const char *zTblName,
   char **pzSql
@@ -381,15 +382,15 @@ int doltliteLoadLiveSchemaSql(
 
   if( zTblName && zTblName[0] ){
     zQuery = sqlite3_mprintf(
-      "SELECT sql FROM main.sqlite_master "
+      "SELECT sql FROM \"%w\".sqlite_master "
       "WHERE type=%Q AND name=%Q AND tbl_name=%Q",
-      zType, zName, zTblName
+      zDb ? zDb : "main", zType, zName, zTblName
     );
   }else{
     zQuery = sqlite3_mprintf(
-      "SELECT sql FROM main.sqlite_master "
+      "SELECT sql FROM \"%w\".sqlite_master "
       "WHERE type=%Q AND name=%Q",
-      zType, zName
+      zDb ? zDb : "main", zType, zName
     );
   }
   if( !zQuery ) return SQLITE_NOMEM;

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -541,7 +541,7 @@ int loadSchemaFromCatalog(sqlite3 *db, ChunkStore *cs, ProllyCache *pCache,
 SchemaEntry *findSchemaEntry(SchemaEntry *a, int n, const char *zName);
 void freeSchemaEntries(SchemaEntry *a, int n);
 char *doltliteCanonicalizeSchemaSql(const char *zSql, const char *zName);
-int doltliteLoadLiveSchemaSql(sqlite3 *db, const char *zType,
+int doltliteLoadLiveSchemaSql(sqlite3 *db, const char *zType, const char *zDb,
                               const char *zName, const char *zTblName,
                               char **pzSql);
 

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -42,6 +42,7 @@ static void registerDoltiteFunctions(sqlite3 *db);
 void doltliteGetSessionHead(sqlite3 *db, ProllyHash *pHead);
 char *doltliteCanonicalizeSchemaSql(const char *zSql, const char *zName);
 int doltliteLoadLiveSchemaSql(sqlite3 *db, const char *zType,
+                              const char *zDb,
                               const char *zName, const char *zTblName,
                               char **pzSql);
 int doltliteResolveTableName(sqlite3 *db, const char *zTable, Pgno *piTable);
@@ -423,6 +424,23 @@ static inline void removeTable(Btree *p, Pgno iTable){
 }
 static inline void btreeFreeCatalogTables(Btree *p){
   catFree(&p->cat);
+}
+
+static int btreeSchemaIndex(Btree *pBtree){
+  sqlite3 *db;
+  int i;
+  if( !pBtree || !(db = pBtree->db) ) return -1;
+  for(i=0; i<db->nDb; i++){
+    if( db->aDb[i].pBt==pBtree ) return i;
+  }
+  return -1;
+}
+
+static const char *btreeSchemaName(Btree *pBtree){
+  sqlite3 *db = pBtree ? pBtree->db : 0;
+  int iDb = btreeSchemaIndex(pBtree);
+  if( !db || iDb<0 || iDb>=db->nDb ) return "main";
+  return db->aDb[iDb].zDbSName ? db->aDb[iDb].zDbSName : "main";
 }
 static void btreeClearCatalogCache(Btree *p){
   sqlite3_free(p->pCatalogCache);
@@ -1171,7 +1189,13 @@ static int buildLiveCatalogEntryMeta(Btree *pBtree, CatalogEntryMeta **ppMeta, i
   HashElem *k;
   CatalogEntryMeta *aMeta = 0;
   int nMeta = 0, nAlloc = 0, rc = SQLITE_OK, i;
-  if( !pBtree || !(db = pBtree->db) || db->nDb<=0 || !(pSchema = db->aDb[0].pSchema) ){
+  if( !pBtree || !(db = pBtree->db) || db->nDb<=0 ){
+    *ppMeta = 0;
+    *pnMeta = 0;
+    return SQLITE_OK;
+  }
+  i = btreeSchemaIndex(pBtree);
+  if( i<0 || i>=db->nDb || !(pSchema = db->aDb[i].pSchema) ){
     *ppMeta = 0;
     *pnMeta = 0;
     return SQLITE_OK;
@@ -1614,6 +1638,7 @@ static void filterSchemaCatalogRows(
 
 static int appendMissingSchemaCatalogRows(
   sqlite3 *db,
+  const char *zDb,
   SchemaCatalogRow **paRows,
   int *pnRows,
   CatalogEntryMeta *aMeta,
@@ -1696,7 +1721,7 @@ static int appendMissingSchemaCatalogRows(
       sqlite3_free(aRows);
       return SQLITE_NOMEM;
     }
-    rc = doltliteLoadLiveSchemaSql(db, pRow->zType, pRow->zName,
+    rc = doltliteLoadLiveSchemaSql(db, pRow->zType, zDb, pRow->zName,
                                    pRow->zTblName, &pRow->zSql);
     if( rc!=SQLITE_OK ){
       freeSchemaCatalogRows(aRows, nRows+1);
@@ -1819,7 +1844,8 @@ static int doltliteSerializeCatalogEntriesForBtreeImpl(
     return rc;
   }
   filterSchemaCatalogRows(aRows, &nRows, aTables, nTables);
-  rc = appendMissingSchemaCatalogRows(db, &aRows, &nRows, aMeta, nMeta,
+  rc = appendMissingSchemaCatalogRows(db, btreeSchemaName(pBtree),
+                                      &aRows, &nRows, aMeta, nMeta,
                                       aTables, nTables);
   if( rc==SQLITE_OK ){
     rc = appendFallbackSchemaCatalogRows(&aRows, &nRows, aTables, nTables,
@@ -2195,7 +2221,8 @@ static int buildRuntimeMasterRoot(Btree *pBtree, ProllyHash *pMasterRoot){
     freeCatalogEntryMeta(aMeta, nMeta);
     return rc;
   }
-  rc = appendMissingSchemaCatalogRows(pBtree->db, &aRows, &nRows, aMeta, nMeta,
+  rc = appendMissingSchemaCatalogRows(pBtree->db, btreeSchemaName(pBtree),
+                                      &aRows, &nRows, aMeta, nMeta,
                                       pBtree->cat.a, pBtree->cat.n);
   if( rc!=SQLITE_OK ){
     freeCatalogEntryMeta(aMeta, nMeta);

--- a/test/known_testfixture_crashes.txt
+++ b/test/known_testfixture_crashes.txt
@@ -19,12 +19,8 @@
 #   rather than a bug.
 #
 # Cross-db (ATTACHed) writes now work (a freshly attached db gets its default
-# branch created on first persist), so e_createtable and e_update complete and
-# moved to the divergence file. alter gets much further but still stops before
-# the summary on attached-db ALTER TABLE RENAME, whose schema reload can't
-# resolve the renamed table ("malformed database schema (i3) - no such table:
-# aux.<t2>") — a separate attached-db reload bug.
-alter    # attached-db ALTER RENAME: schema reload can't resolve the renamed table
+# branch created on first persist), so e_createtable, e_update, and alter
+# complete and moved to the divergence file.
 capi3    # aborts on set_file_format (raw stock page format; doltlite uses prolly)
 fkey2    # aborts under fkey2-2.x (raw-format / pre-existing doltlite divergence)
 # Additional crash/timeout files from the full capture (issue #1119):

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -68,6 +68,7 @@ alter alter-1.2  # ALTER TABLE rowid-preservation semantics
 alter alter-1.5  # ALTER TABLE rowid-preservation semantics
 alter alter-1.6  # ALTER TABLE rowid-preservation semantics
 alter alter-1.7  # ALTER TABLE rowid-preservation semantics
+alter alter-6.6  # sqlite_master oid lookup after reopen; canonical schema row order
 
 # ── in ──
 in in-19.40  # IN clause path that hits NOT NULL via rowid lookup
@@ -173,14 +174,6 @@ e_createtable e_createtable-5.6.1
 # (reports a reload "index i1 already exists" where stock reports a different
 # error). The cross-db write itself now works; the reload bug is tracked
 # separately.
-e_update e_update-2.2.2
-e_update e_update-2.2.X
-e_update e_update-2.3.0
-e_update e_update-2.3.1
-e_update e_update-2.3.2
-e_update e_update-2.3.3
-e_update e_update-2.4.1
-e_update e_update-2.4.2
 
 # ── e_select ──
 e_select e_select-4.9.4  # rowid-order vs PK-order on unordered SELECT


### PR DESCRIPTION
## Summary
- resolve the schema name for the Btree being serialized instead of hardwiring catalog serialization to main
- load live schema SQL from the owning schema's sqlite_master, so aux commits do not persist main schema rows
- move alter from crash-listed to divergence-listed now that alter.test reaches its summary

Fixes #1137

## Testing
- LIBRARY_PATH=/opt/homebrew/lib make testfixture USE_AMALGAMATION=0
- ./testfixture test/alter.test (reaches summary; 5 known divergences)
- bash test/run_testfixture.sh via alter-run: OK: alter (123 tests, 5 known divergences)
- LIBRARY_PATH=/opt/homebrew/lib make testfixture
- make lint
- git diff --check
