### PR TITLE
Fix sqllogictest "memory leak after connection close" on the whole corpus

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -5029,12 +5029,6 @@ void doltliteRegister(sqlite3 *db){
     if( doltliteConstraintViolationsRegister(db)!=SQLITE_OK ) return;
   }
 
-  {
-    extern int doltliteDbpageRegister(sqlite3*);
-    extern int doltliteDbpageInstallAutoExt(void);
-    doltliteDbpageRegister(db);
-    doltliteDbpageInstallAutoExt();
-  }
   doltliteMaybeSeedRepo(db);
 }
 

--- a/src/doltlite_dbpage.c
+++ b/src/doltlite_dbpage.c
@@ -247,17 +247,4 @@ int doltliteDbpageRegister(sqlite3 *db){
   return sqlite3_create_module(db, "sqlite_dbpage", &doltliteDbpageModule, 0);
 }
 
-static int doltliteDbpageExtInit(
-  sqlite3 *db,
-  char **pzErrMsg,
-  const sqlite3_api_routines *pApi
-){
-  (void)pzErrMsg; (void)pApi;
-  return doltliteDbpageRegister(db);
-}
-
-int doltliteDbpageInstallAutoExt(void){
-  return sqlite3_auto_extension((void(*)(void))doltliteDbpageExtInit);
-}
-
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -50,6 +50,9 @@ int sqlite3StmtVtabInit(sqlite3*);
 #ifdef SQLITE_EXTRA_AUTOEXT
 int SQLITE_EXTRA_AUTOEXT(sqlite3*);
 #endif
+#if defined(DOLTLITE_PROLLY) && defined(SQLITE_ENABLE_DBPAGE_VTAB)
+int doltliteDbpageRegister(sqlite3*);
+#endif
 /*
 ** An array of pointers to extension initializer functions for
 ** built-in extensions.
@@ -68,7 +71,13 @@ static int (*const sqlite3BuiltinExtensions[])(sqlite3*) = {
   sqlite3RtreeInit,
 #endif
 #ifdef SQLITE_ENABLE_DBPAGE_VTAB
+#ifdef DOLTLITE_PROLLY
+  /* doltlite ships its own sqlite_dbpage; register it here so it wins
+  ** without a process-global auto-extension that outlives sqlite3_close. */
+  doltliteDbpageRegister,
+#else
   sqlite3DbpageRegister,
+#endif
 #endif
 #ifdef SQLITE_ENABLE_DBSTAT_VTAB
   sqlite3DbstatRegister,


### PR DESCRIPTION
## What

doltlite ships its own divergent `sqlite_dbpage` virtual table (it only exposes page 1). To make it override the built-in `SQLITE_ENABLE_DBPAGE_VTAB` module on every connection, it was installed via `sqlite3_auto_extension()`.

The auto-extension list is a **process-global** array allocated through sqlite3's *counted* allocator and released only at `sqlite3_shutdown()`. So after `sqlite3_close()`, `sqlite3_memory_used()` stays nonzero (16 bytes — one pointer slot, established on the first open, never growing).

The official sqllogictest sqlite3 driver checks `sqlite3_memory_used()==0` after closing each connection and reports `memory leak after connection close` / `disconnection from database failed` when it isn't. That single check fired on **essentially every file** in the corpus — it's the lone "doltlite: 1 error" seen across `evidence/*`, `select1`, `select5`, and every `random/*` file.

## Fix

Replace the built-in `sqlite_dbpage` entry in `sqlite3BuiltinExtensions[]` with doltlite's `doltliteDbpageRegister` under `DOLTLITE_PROLLY`. It runs at the same point the stock module would, on every connection (including the calling handle), so doltlite's table wins **without any persistent global**. The now-redundant early direct registration in `doltliteRegister()` and the auto-extension shim are removed.

## Verification

- **Fail-before / pass-after:** a minimal open → use → close loop reports `sqlite3_memory_used()==16` after each cycle on master, and `==0` after this change (matching stock).
- `sqlite_dbpage` still works on the calling handle (page 1 returns the 4096-byte synthesized header; `pgno>1` still errors) — `doltlite_dbpage.sh` passes 5/5.
- Full shell suite: **67/67 suites pass**.
- C correctness regression: **309,770/309,770 pass**.

Triage of #1118; this removes the dominant sqllogictest divergence bucket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)