### PR TITLE
Resolve symlinked DoltLite database paths

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -134,6 +134,40 @@ static int csOpenFile(
   return rc;
 }
 
+static int csCanonicalFilename(
+  sqlite3_vfs *pVfs,
+  const char *zFilename,
+  char **pzOut
+){
+  int nPath;
+  int rc;
+  char *zFull;
+  int n;
+
+  *pzOut = 0;
+  assert( pVfs!=0 );
+
+  nPath = pVfs->mxPathname + 1;
+  zFull = (char*)sqlite3_malloc(nPath);
+  if( !zFull ) return SQLITE_NOMEM;
+
+  rc = sqlite3OsFullPathname(pVfs, zFilename, nPath, zFull);
+  if( rc==SQLITE_OK_SYMLINK ){
+    *pzOut = zFull;
+    return SQLITE_OK;
+  }
+  sqlite3_free(zFull);
+  if( rc!=SQLITE_OK ){
+    return rc;
+  }
+
+  n = (int)strlen(zFilename);
+  *pzOut = (char*)sqlite3_malloc(n + 1);
+  if( !*pzOut ) return SQLITE_NOMEM;
+  memcpy(*pzOut, zFilename, n + 1);
+  return SQLITE_OK;
+}
+
 static int csRollbackFailedAppend(ChunkStore *cs, i64 origFileSize){
   sqlite3_int64 sizeNow = -1;
   int rc = SQLITE_OK;
@@ -257,9 +291,12 @@ int chunkStoreOpen(
 ){
   int rc;
   int exists = 0;
-  int n;
 
   memset(cs, 0, sizeof(*cs));
+  if( !pVfs ){
+    pVfs = sqlite3_vfs_find(0);
+    if( !pVfs ) return SQLITE_CANTOPEN;
+  }
   cs->file.pVfs = pVfs;
   CS_GRAPH_LOCK(cs) = CS_FILE_LOCK_INIT;
   cs->pLockMutex = sqlite3_mutex_alloc(SQLITE_MUTEX_RECURSIVE);
@@ -278,10 +315,8 @@ int chunkStoreOpen(
     return SQLITE_OK;
   }
 
-  n = (int)strlen(zFilename);
-  cs->file.zFilename = (char *)sqlite3_malloc(n + 1);
-  if( cs->file.zFilename == 0 ) return SQLITE_NOMEM;
-  memcpy(cs->file.zFilename, zFilename, n + 1);
+  rc = csCanonicalFilename(pVfs, zFilename, &cs->file.zFilename);
+  if( rc!=SQLITE_OK ) return rc;
 
   rc = sqlite3OsAccess(pVfs, cs->file.zFilename, SQLITE_ACCESS_EXISTS, &exists);
   if( rc != SQLITE_OK ){

--- a/test/doltlite_persistence.sh
+++ b/test/doltlite_persistence.sh
@@ -25,6 +25,25 @@ else FAIL=$((FAIL+1)); ERRORS="$ERRORS\nFAIL: single_file\n  expected: 1 file\n 
 rm -f "$DB"
 
 echo ""
+echo "--- Symlink path persistence ---"
+
+BASE=/tmp/test_persist_symlink_$$; rm -rf "$BASE"; mkdir -p "$BASE/real" "$BASE/link"
+DB="$BASE/real/test.db"
+LINK="$BASE/link/test.db"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'via-real');
+SELECT dolt_commit('-A','-m','init');" | $DOLTLITE "$DB" > /dev/null 2>&1
+ln -s ../real/test.db "$LINK"
+
+run_test "symlink_read_count" "SELECT count(*) FROM t;" "1" "$LINK"
+run_test "symlink_read_log" "SELECT count(*) FROM dolt_log;" "2" "$LINK"
+run_test_lastline "symlink_write_commit" "INSERT INTO t VALUES(2,'via-link'); SELECT dolt_commit('-A','-m','link write'); SELECT count(*) FROM t;" "2" "$LINK"
+run_test "symlink_real_path_sees_write" "SELECT v FROM t WHERE id=2;" "via-link" "$DB"
+run_test_match "symlink_real_path_sees_commit" "SELECT message FROM dolt_log LIMIT 1;" "link write" "$DB"
+
+rm -rf "$BASE"
+
+echo ""
 echo "--- Multiple commits ---"
 
 DB=/tmp/test_persist_multi_$$.db; rm -f "$DB"


### PR DESCRIPTION
## Summary
- canonicalize chunk-store filenames through the active VFS before opening
- allow SQLITE_OK_SYMLINK from xFullPathname so symlinked database paths resolve to their backing file
- add persistence coverage for reading and writing a DoltLite database through a symlink

Fixes #1114

## Tests
- make doltlite
- bash test/doltlite_persistence.sh