### PR TITLE
Fix DoltLite indexed OR deletes

### DIFF
--- a/src/delete.c
+++ b/src/delete.c
@@ -278,6 +278,15 @@ Expr *sqlite3LimitWhere(
 #endif /* defined(SQLITE_ENABLE_UPDATE_DELETE_LIMIT) */
        /*      && !defined(SQLITE_OMIT_SUBQUERY) */
 
+#ifdef DOLTLITE_PROLLY
+static int doltliteExprContainsOr(const Expr *pExpr){
+  if( pExpr==0 ) return 0;
+  if( pExpr->op==TK_OR ) return 1;
+  return doltliteExprContainsOr(pExpr->pLeft)
+      || doltliteExprContainsOr(pExpr->pRight);
+}
+#endif
+
 /*
 ** Generate code for a DELETE FROM statement.
 **
@@ -495,6 +504,12 @@ void sqlite3DeleteFrom(
   {
     u16 wcf = WHERE_ONEPASS_DESIRED|WHERE_DUPLICATES_OK;
     if( sNC.ncFlags & NC_Subquery ) bComplex = 1;
+#ifdef DOLTLITE_PROLLY
+    /* A one-pass multi-index OR DELETE can update prolly pending maps for
+    ** indexes that later OR arms are still scanning. Use the two-pass rowset
+    ** path so row discovery completes before table and index mutation. */
+    if( doltliteExprContainsOr(pWhere) ) bComplex = 1;
+#endif
     wcf |= (bComplex ? 0 : WHERE_ONEPASS_MULTIROW);
     if( HasRowid(pTab) ){
       /* For a rowid table, initialize the RowSet to an empty set */

--- a/test/doltlite_delete_or.sh
+++ b/test/doltlite_delete_or.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
+
+echo "=== DoltLite indexed OR DELETE tests ==="
+echo ""
+
+DB=/tmp/test_doltlite_delete_or_$$.db
+rm -f "$DB"
+trap 'rm -f "$DB"' EXIT
+
+setup_sql="
+CREATE TABLE tab1(
+  pk INTEGER PRIMARY KEY,
+  col0 INTEGER,
+  col1 FLOAT,
+  col2 TEXT,
+  col3 INTEGER,
+  col4 FLOAT,
+  col5 TEXT
+);
+CREATE INDEX idx_tab1_0 on tab1 (col0);
+CREATE INDEX idx_tab1_1 on tab1 (col1);
+CREATE INDEX idx_tab1_3 on tab1 (col3);
+CREATE INDEX idx_tab1_4 on tab1 (col4);
+INSERT INTO tab1 VALUES(0,23,80.49,'a',0,0.0,'a');
+INSERT INTO tab1 VALUES(1,35,93.54,'b',0,0.0,'b');
+INSERT INTO tab1 VALUES(2,56,89.33,'c',0,0.0,'c');
+INSERT INTO tab1 VALUES(3,90,94.9,'d',0,0.0,'d');
+INSERT INTO tab1 VALUES(4,76,32.25,'e',0,0.0,'e');
+INSERT INTO tab1 VALUES(5,48,43.98,'f',0,0.0,'f');
+INSERT INTO tab1 VALUES(6,98,95.92,'g',0,0.0,'g');
+INSERT INTO tab1 VALUES(7,37,86.74,'h',0,0.0,'h');
+INSERT INTO tab1 VALUES(8,62,76.58,'i',0,0.0,'i');
+INSERT INTO tab1 VALUES(9,12,81.67,'j',0,0.0,'j');
+"
+
+dltest_run_sql "$setup_sql" "$DB" >/dev/null
+
+plan=$(dltest_run_sql \
+  "EXPLAIN DELETE FROM tab1 WHERE col0 < 79 OR col1 > 38.84;" "$DB")
+if echo "$plan" | grep -q 'RowSetAdd' && echo "$plan" | grep -q 'RowSetRead'; then
+  dltest_pass
+else
+  dltest_fail "or_delete_uses_rowset" \
+    "  expected RowSetAdd and RowSetRead in EXPLAIN output\n  got:\n$plan"
+fi
+
+run_test_lastline "or_delete_removes_all_matches" "
+DELETE FROM tab1 WHERE col0 < 79 OR col1 > 38.84;
+SELECT count(*) FROM tab1;
+" "0" "$DB"
+
+dltest_finish

--- a/test/run_doltlite_tests.sh
+++ b/test/run_doltlite_tests.sh
@@ -63,6 +63,7 @@ TESTS=(
   chunk_physical_dups_test.sh
   doltlite_savepoint.sh
   doltlite_rollback_durability.sh
+  doltlite_delete_or.sh
   doltlite_schema_merge.sh
   doltlite_branch_gc_stress.sh
 


### PR DESCRIPTION
Fixes #1151.

## Summary
- force DoltLite DELETE statements with OR predicates onto SQLite's two-pass rowset delete path
- avoid mutating prolly table/index pending maps while later OR arms are still scanning indexes
- add a focused indexed OR DELETE regression and include it in the DoltLite shell suite

## Tests
- bash test/doltlite_delete_or.sh
- cd build && bash ../test/doltlite_delete_or.sh
- extracted 2,779-statement repro from index/delete/10/slt_good_0.test: COUNT|0
- rebuilt DoltLite amalgamation sqllogictest runner; index/delete/10/slt_good_0.test: 0 errors out of 10730
- rebuilt DoltLite amalgamation sqllogictest runner; all index/delete/{10,100,1000}/*.test: 0 errors
- make devtest: fails in existing debug-amalgamation build setup before TCL tests run (sqlite3BtreeSeekCount conflicts / sqlite3SchemaMutexHeld redefinition)
- bash test/run_doltlite_tests.sh: 65 passed, 2 failed out of 67 suites; failures were existing unrelated doltlite_persistence.sh symlink-path checks and doltlite_open_sqlite_file.sh stock-file behavior