### PR TITLE
Fix UPDATE REPLACE trigger cursor pin handling

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -2902,7 +2902,7 @@ static int saveCursorPosition(BtCursor *pCur){
     return SQLITE_OK;
   }
   if( pCur->isPinned ){
-    return SQLITE_OK;
+    return SQLITE_CONSTRAINT_PINNED;
   }
 
   CLEAR_CACHED_PAYLOAD(pCur);

--- a/test/doltlite_update_replace_trigger.sh
+++ b/test/doltlite_update_replace_trigger.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
+
+echo "=== DoltLite UPDATE REPLACE trigger tests ==="
+echo ""
+
+DB=/tmp/test_doltlite_update_replace_trigger_$$.db
+rm -f "$DB"
+trap 'rm -f "$DB"' EXIT
+
+setup_sql="
+CREATE TABLE t1(a UNIQUE ON CONFLICT REPLACE, b);
+INSERT INTO t1(a,b) VALUES(4,12),(9,13);
+CREATE INDEX i0 ON t1(b);
+CREATE TRIGGER tr0 DELETE ON t1 BEGIN
+  UPDATE t1 SET b = a;
+END;
+"
+
+dltest_run_sql "$setup_sql" "$DB" >/dev/null
+
+run_test_lastline "update_replace_trigger_initial_integrity" "
+PRAGMA integrity_check;
+" "ok" "$DB"
+
+out=$(dltest_run_sql "
+PRAGMA recursive_triggers = true;
+UPDATE t1 SET a=0;
+" "$DB" 2>&1)
+rc=$?
+if [ "$rc" -ne 0 ] && echo "$out" | grep -q "constraint failed"; then
+  dltest_pass
+else
+  dltest_fail "update_replace_trigger_constraint" \
+    "  expected constraint failed\n  rc=$rc\n  output:\n$out"
+fi
+
+run_test_lastline "update_replace_trigger_final_integrity" "
+PRAGMA integrity_check;
+" "ok" "$DB"
+
+run_test "update_replace_trigger_rows_unchanged" "
+SELECT rowid,a,b FROM t1 ORDER BY rowid;
+" "1|4|12
+2|9|13" "$DB"
+
+dltest_finish

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -948,8 +948,6 @@ trigger1 trigger1-6.5
 trigger1 trigger1-6.6
 trigger2 trigger2-2.11-before
 trigger2 trigger2-2.12-after
-update update-20.20
-update update-20.30
 where where-1.1.1
 where where-24-3.4
 where where-25.1

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -946,8 +946,6 @@ trigger1 trigger1-6.1
 trigger1 trigger1-6.2
 trigger1 trigger1-6.5
 trigger1 trigger1-6.6
-update update-20.20
-update update-20.30
 where where-1.1.1
 where where-24-3.4
 where where-25.1

--- a/test/run_doltlite_tests.sh
+++ b/test/run_doltlite_tests.sh
@@ -64,6 +64,7 @@ TESTS=(
   doltlite_savepoint.sh
   doltlite_rollback_durability.sh
   doltlite_delete_or.sh
+  doltlite_update_replace_trigger.sh
   doltlite_schema_merge.sh
   doltlite_branch_gc_stress.sh
 


### PR DESCRIPTION
## Summary

Fixes #1156.

DoltLite was allowing writes to proceed while another cursor on the same prolly table was pinned by `OP_CursorLock`. In SQLite, attempting to save a pinned cursor returns `SQLITE_CONSTRAINT_PINNED`, which aborts recursive-trigger REPLACE cases before stale outer UPDATE state can overwrite trigger-side index changes.

This aligns prolly cursor save behavior with SQLite by returning `SQLITE_CONSTRAINT_PINNED` for pinned cursors. The upstream `update-20` cases now pass and have been removed from the testfixture divergence list.

## Tests

- `make doltlite`
- `bash ../test/doltlite_update_replace_trigger.sh`
- direct SQL repro from #1156
- `LIBRARY_PATH=/opt/homebrew/opt/libtommath/lib make testfixture`
- `testfixture test/update.test`
- `bash ../test/run_testfixture.sh local 60 update`