### PR TITLE
Fix trigger visibility across pending non-intkey writes

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -7398,6 +7398,9 @@ static int prollyBtCursorInsert(
   const u8 *pInsertedPayload = 0;
   int nInsertedPayload = 0;
   u8 *pIntKeyBuf = 0;
+  u8 aLocalSortKey[128];
+  const u8 *pSortKey = 0;
+  int nSortKey = 0;
   (void)seekResult;
 
   if( flags & BTREE_PREFORMAT ){
@@ -7465,12 +7468,9 @@ static int prollyBtCursorInsert(
     }
   } else {
 
-    int nSortKey = 0;
     int nKeyField = 0;
     int splitKey = 0;
     int isIndex = 0;
-    u8 aLocalSortKey[128];
-    const u8 *pSortKey = 0;
     if( pCur->pKeyInfo
      && pCur->pKeyInfo->nKeyField < pCur->pKeyInfo->nAllField ){
       nKeyField = (int)pCur->pKeyInfo->nKeyField;
@@ -7529,21 +7529,28 @@ static int prollyBtCursorInsert(
         pCur->mmActive = 0;
         pCur->flushSeekEdits = 0;
       } else if( (flags & BTREE_SAVEPOSITION) && !pCur->curIntKey ){
+        ProllyMutMapEntry *pEntry = 0;
         sqlite3_free(pIntKeyBuf);
         CLEAR_CACHED_PAYLOAD(pCur);
         if( prollyCursorIsValid(&pCur->pCur) ){
           int trc = prollyCursorNext(&pCur->pCur);
-          if( trc==SQLITE_OK
-           && pCur->pCur.eState==PROLLY_CURSOR_VALID ){
-            pCur->eState = CURSOR_SKIPNEXT;
-            pCur->skipNext = 1;
-          } else {
-            pCur->eState = CURSOR_INVALID;
-          }
-        } else {
-          pCur->eState = CURSOR_INVALID;
+          if( trc!=SQLITE_OK ) return trc;
         }
-        pCur->mmActive = 0;
+        rc = prollyMutMapFindRc(pCur->pMutMap, pSortKey, nSortKey, 0, &pEntry);
+        if( rc!=SQLITE_OK ) return rc;
+        if( pEntry ){
+          pCur->mmIdx = prollyMutMapOrderIndexFromEntry(pCur->pMutMap, pEntry);
+          pCur->mmPhysIdx = -1;
+          pCur->mmActive = 1;
+          pCur->mmPhysActive = 0;
+          pCur->mergeSrc = MERGE_SRC_MUT;
+          pCur->eState = CURSOR_VALID;
+        }else{
+          pCur->mmActive = 0;
+          pCur->eState = pCur->pCur.eState==PROLLY_CURSOR_VALID
+                       ? CURSOR_SKIPNEXT : CURSOR_INVALID;
+          pCur->skipNext = pCur->eState==CURSOR_SKIPNEXT ? 1 : 0;
+        }
         pCur->flushSeekEdits = 0;
       } else {
         sqlite3_free(pIntKeyBuf);

--- a/test/doltlite_trigger_visibility.sh
+++ b/test/doltlite_trigger_visibility.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
+
+echo "=== DoltLite trigger visibility tests ==="
+echo ""
+
+DB=/tmp/test_doltlite_trigger_visibility_$$.db
+rm -f "$DB"
+trap 'rm -f "$DB"' EXIT
+
+run_test "before_delete_trigger_updates_prior_insert" "
+CREATE TABLE tbl(a PRIMARY KEY, b, c);
+CREATE TABLE log(a, b, c);
+INSERT INTO tbl VALUES(1, 2, 3);
+INSERT INTO log VALUES(1, 2, 3);
+INSERT INTO log VALUES(10, 20, 30);
+CREATE TRIGGER the_trigger BEFORE DELETE ON tbl BEGIN
+  INSERT INTO tbl VALUES(500, '' * 10, 700);
+  UPDATE tbl SET c = old.c;
+  DELETE FROM log;
+END;
+DELETE FROM tbl WHERE a = 1;
+SELECT * FROM tbl;
+SELECT * FROM log;
+" "500|0|3" "$DB"
+
+run_test_lastline "before_delete_trigger_integrity" "
+PRAGMA integrity_check;
+" "ok" "$DB"
+
+rm -f "$DB"
+
+run_test "after_insert_trigger_updates_prior_insert" "
+CREATE TABLE tbl(a PRIMARY KEY, b, c);
+CREATE TABLE log(a, b, c);
+INSERT INTO log VALUES(1, 2, 3);
+INSERT INTO log VALUES(10, 20, 30);
+CREATE TRIGGER the_trigger AFTER INSERT ON tbl BEGIN
+  INSERT INTO tbl VALUES(500, new.b * 10, 700);
+  UPDATE tbl SET c = '';
+  DELETE FROM log;
+END;
+INSERT INTO tbl VALUES(1, 2, 3);
+SELECT * FROM tbl;
+SELECT * FROM log;
+" "1|2|
+500|20|" "$DB"
+
+run_test_lastline "after_insert_trigger_integrity" "
+PRAGMA integrity_check;
+" "ok" "$DB"
+
+dltest_finish

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -946,8 +946,6 @@ trigger1 trigger1-6.1
 trigger1 trigger1-6.2
 trigger1 trigger1-6.5
 trigger1 trigger1-6.6
-trigger2 trigger2-2.11-before
-trigger2 trigger2-2.12-after
 update update-20.20
 update update-20.30
 where where-1.1.1

--- a/test/run_doltlite_tests.sh
+++ b/test/run_doltlite_tests.sh
@@ -64,6 +64,7 @@ TESTS=(
   doltlite_savepoint.sh
   doltlite_rollback_durability.sh
   doltlite_delete_or.sh
+  doltlite_trigger_visibility.sh
   doltlite_schema_merge.sh
   doltlite_branch_gc_stress.sh
 


### PR DESCRIPTION
## Summary
- preserve the pending mut-map entry as the active cursor position after non-intkey `BTREE_SAVEPOSITION` writes
- add DoltLite trigger visibility regressions for rows inserted earlier in the same trigger program
- remove the now-fixed `trigger2` divergence entries

Fixes #1157

## Tests
- `make doltlite`
- `bash ../test/doltlite_trigger_visibility.sh`
- `./testfixture ../test/trigger2.test` from a clean temp directory
- `bash ../test/run_testfixture.sh local 60 trigger2` from a clean build-shaped temp directory
