### PR TITLE
Handle unsupported encoding pragmas

### DIFF
--- a/src/pragma.c
+++ b/src/pragma.c
@@ -2279,6 +2279,12 @@ void sqlite3Pragma(
         for(pEnc=&encnames[0]; pEnc->zName; pEnc++){
           if( 0==sqlite3StrICmp(zRight, pEnc->zName) ){
             u8 enc = pEnc->enc ? pEnc->enc : SQLITE_UTF16NATIVE;
+#ifdef DOLTLITE_PROLLY
+            if( enc!=SQLITE_UTF8 ){
+              /* Doltlite-format databases store SQL text as UTF-8. */
+              break;
+            }
+#endif
             SCHEMA_ENC(db) = enc;
             sqlite3SetTextEncoding(db, enc);
             break;

--- a/test/doltlite_pragma_encoding.sh
+++ b/test/doltlite_pragma_encoding.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Doltlite's prolly storage stores SQL text in UTF-8. Ignore unsupported
+# database encodings instead of allowing SQLite's UTF-16 setup path to fail
+# later while initializing the schema.
+
+source "$(dirname "$0")/lib/doltlite_test_common.sh"
+
+db_rm() {
+  rm -rf "$1" "${1}-wal"
+}
+
+echo "=== PRAGMA encoding (doltlite-format) ==="
+echo ""
+
+DB=/tmp/test_encoding_dl_$$.db; db_rm "$DB"
+
+run_test "encoding_default_utf8" \
+  "PRAGMA encoding;" \
+  "UTF-8" \
+  "$DB"
+
+run_test "encoding_utf8_ok" \
+  "PRAGMA encoding='UTF-8'; CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1, 'abc'); SELECT v FROM t;" \
+  "abc" \
+  "$DB"
+
+db_rm "$DB"
+
+run_test "encoding_utf16le_ignored" \
+  "PRAGMA encoding='UTF-16le';" \
+  "" \
+  "$DB"
+
+run_test "encoding_after_ignored_still_utf8" \
+  "PRAGMA encoding;" \
+  "UTF-8" \
+  "$DB"
+
+run_test "encoding_after_ignored_can_create" \
+  "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t VALUES(1, 'abc'); PRAGMA encoding; SELECT v FROM t;" \
+  "UTF-8
+abc" \
+  "$DB"
+
+db_rm "$DB"
+
+dltest_finish

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -746,9 +746,9 @@ delete delete-9.2
 delete delete-9.3
 delete delete-9.4
 delete delete-9.5
-enc enc-12.1
-enc enc-12.3
-enc enc-12.8
+enc enc-12.1  # doltlite-format ignores non-UTF-8 database encodings
+enc enc-12.3  # doltlite-format ignores non-UTF-8 database encodings
+enc enc-12.8  # doltlite-format ignores non-UTF-8 database encodings
 insert insert-15.1
 insert insert-5.4
 intpkey intpkey-3.2
@@ -1083,27 +1083,27 @@ crash6 crash6-3.8.3
 crash6 crash6-3.9.2
 crash6 crash6-3.9.3
 distinct distinct-2.6.1
-e_expr e_expr-27.4.4
-e_expr e_expr-27.4.5
-e_expr e_expr-27.4.6
-e_expr e_expr-27.4.7
-e_expr e_expr-27.4.8
-e_expr e_expr-27.4.9
-e_expr e_expr-28.1.3
-e_expr e_expr-28.1.4
-e_expr e_expr-29.1.5
-e_expr e_expr-29.1.6
-e_expr e_expr-29.1.7
-e_expr e_expr-29.1.8
-e_expr e_expr-30.1.5
-e_expr e_expr-30.1.6
-e_expr e_expr-30.1.7
-e_expr e_expr-30.1.8
-e_expr e_expr-33.1.1
-e_expr e_expr-33.1.3
-e_expr e_expr-33.1.4
-enc4 enc4-2.1
-enc4 enc4-3.1
+e_expr e_expr-27.4.4  # doltlite-format ignores non-UTF-8 database encodings
+e_expr e_expr-27.4.5  # doltlite-format ignores non-UTF-8 database encodings
+e_expr e_expr-27.4.6  # doltlite-format ignores non-UTF-8 database encodings
+e_expr e_expr-27.4.7  # doltlite-format ignores non-UTF-8 database encodings
+e_expr e_expr-27.4.8  # doltlite-format ignores non-UTF-8 database encodings
+e_expr e_expr-27.4.9  # doltlite-format ignores non-UTF-8 database encodings
+e_expr e_expr-28.1.3  # doltlite-format ignores non-UTF-8 database encodings
+e_expr e_expr-28.1.4  # doltlite-format ignores non-UTF-8 database encodings
+e_expr e_expr-29.1.5  # doltlite-format ignores non-UTF-8 database encodings
+e_expr e_expr-29.1.6  # doltlite-format ignores non-UTF-8 database encodings
+e_expr e_expr-29.1.7  # doltlite-format ignores non-UTF-8 database encodings
+e_expr e_expr-29.1.8  # doltlite-format ignores non-UTF-8 database encodings
+e_expr e_expr-30.1.5  # doltlite-format ignores non-UTF-8 database encodings
+e_expr e_expr-30.1.6  # doltlite-format ignores non-UTF-8 database encodings
+e_expr e_expr-30.1.7  # doltlite-format ignores non-UTF-8 database encodings
+e_expr e_expr-30.1.8  # doltlite-format ignores non-UTF-8 database encodings
+e_expr e_expr-33.1.1  # doltlite-format ignores non-UTF-8 database encodings
+e_expr e_expr-33.1.3  # doltlite-format ignores non-UTF-8 database encodings
+e_expr e_expr-33.1.4  # doltlite-format ignores non-UTF-8 database encodings
+enc4 enc4-2.1  # doltlite-format ignores non-UTF-8 database encodings
+enc4 enc4-3.1  # doltlite-format ignores non-UTF-8 database encodings
 pragma2 pragma2-1.3
 pragma2 pragma2-1.4
 pragma2 pragma2-2.5

--- a/test/run_doltlite_tests.sh
+++ b/test/run_doltlite_tests.sh
@@ -87,6 +87,7 @@ TESTS=(
   doltlite_open_sqlite_file.sh
   doltlite_comparison.sh
   doltlite_pragma_auto_vacuum.sh
+  doltlite_pragma_encoding.sh
   doltlite_pragma_journal_mode.sh
   doltlite_pragma_memory_journal_mode.sh
   doltlite_pragma_page_count.sh


### PR DESCRIPTION
## Summary
- keep DoltLite-format databases locked to UTF-8 when PRAGMA encoding requests UTF-16
- add a DoltLite shell regression covering ignored UTF-16 encoding requests and successful table creation afterward
- annotate the encoding-related testfixture divergences as UTF-8-only format behavior

Fixes #1164

## Tests
- make doltlite
- bash ../test/doltlite_pragma_encoding.sh
- LIBRARY_PATH=/opt/homebrew/opt/libtommath/lib make testfixture
- bash ../test/run_testfixture.sh "encoding 1164" 120 enc enc4 e_expr
- git diff --check