### PR TITLE
Preserve REQUIRESEEK cursors when flushing pending writes (#1165)

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -7635,7 +7635,13 @@ static int flushIfNeeded(BtCursor *pCur){
     prollyCursorInit(&pCur->pCur, &pCur->pBt->store, &pCur->pBt->cache,
                      &pTE->root, pTE->flags);
   }
-  pCur->eState = CURSOR_INVALID;
+  /* A cursor saved by saveAllCursors (e.g. another statement scanning this
+  ** table while we flush a DELETE/UPDATE) keeps its REQUIRESEEK state: it has a
+  ** saved key and must reseek against the new root on next access. Clobbering it
+  ** to INVALID here dropped the saved position, ending the other scan early. */
+  if( pCur->eState!=CURSOR_REQUIRESEEK ){
+    pCur->eState = CURSOR_INVALID;
+  }
   return SQLITE_OK;
 }
 

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -744,8 +744,6 @@ delete delete-8.3
 delete delete-8.5
 delete delete-9.2
 delete delete-9.3
-delete delete-9.4
-delete delete-9.5
 enc enc-12.1  # doltlite-format ignores non-UTF-8 database encodings
 enc enc-12.3  # doltlite-format ignores non-UTF-8 database encodings
 enc enc-12.8  # doltlite-format ignores non-UTF-8 database encodings
@@ -816,7 +814,6 @@ minmax3 minmax3-4.4
 minmax3 minmax3-4.5
 minmax3 minmax3-4.6
 quote quote-2.5
-rowid rowid-13.1
 rowid rowid-4.5
 savepoint savepoint-10.1.1
 savepoint savepoint-10.1.2


### PR DESCRIPTION
## What

A `DELETE`/`UPDATE` while another statement is scanning the same table corrupted the scan: rows after the mutation were dropped (the join cursor in testfixture `delete-9.x` returned NULL columns / truncated; a single-table scan ended early).

## Root cause

When a write flushes its pending mutmap, `flushIfNeeded()` runs per cursor: it re-inits the cursor against the new root, then **unconditionally** set `eState = CURSOR_INVALID`. But `saveAllCursors()` had just saved the *other* statement's scan cursor to `CURSOR_REQUIRESEEK` (with its key). Overwriting that with `INVALID` dropped the saved position, so the next `OP_Next` hit the `eState==CURSOR_INVALID → SQLITE_DONE` early-out and the scan ended.

Traced precisely: `saveAllCursors` → scan cursor `REQUIRESEEK (nKey=2)`, then `flushIfNeeded` → `INVALID`, then `OP_Next` → `DONE`.

## Fix

Keep a `REQUIRESEEK` cursor in that state in `flushIfNeeded` — it has a saved key and reseeks against the new root on next access. Only non-saved cursors become `INVALID`.

## Verification

Faithful C repro (mirrors `delete-9.4`: scan + mid-scan `DELETE` via a nested statement) — before: scan truncates / NULL columns; after: matches stock across single-table (delete passed/future row), indexed `ORDER BY`, and the two-table join.

```
two tables, del outer   doltlite: [1 a b][1 c d][2 a b][2 c d][3 a b][3 c d]   (== stock)
```

- Full shell suite **69/69** + C regression pass.
- testfixture A/B (fixed vs master, container): **zero** new failures; flips `delete-9.4`, `delete-9.5`, `rowid-13.1` to passing (removed from the divergence list). (`delete-9.2/9.3` — delete-current-row / whole-table mid-scan — remain divergent and listed.) Pre-existing `attach`/`delete-8.x` container artifacts are identical on master.

Fixes #1165.

🤖 Generated with [Claude Code](https://claude.com/claude-code)