### PR TITLE
ci: run CI on pull requests only, not master pushes

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,8 +1,6 @@
 name: Benchmark
 
 on:
-  push:
-    branches: [master]
   pull_request:
 
 permissions:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,8 +1,6 @@
 name: Build-Test
 
 on:
-  push:
-    branches: [master]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,8 +1,6 @@
 name: Sanitizers
 
 on:
-  push:
-    branches: [master]
   pull_request:
 
 jobs:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,8 +1,6 @@
 name: Smoke
 
 on:
-  push:
-    branches: [master]
   pull_request:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,6 @@
 name: Test Suite
 
 on:
-  push:
-    branches: [master]
   pull_request:
 
 jobs:


### PR DESCRIPTION
## What

Removes the `push: branches: [master]` trigger from the CI workflows so they run on **pull requests only**, not again on the post-merge master commit (redundant — the PR already gated it).

Changed: `benchmark`, `build-test`, `sanitizers`, `smoke`, `test` (each keeps `pull_request`; `build-test` keeps `workflow_dispatch`).

Unchanged: `release.yml` (still triggers on `v*` tags) and `sqlite-upstream-drift.yml` (scheduled).

This PR itself exercises the new triggers — the suites should run here on `pull_request` and not on master after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)