### PR TITLE
ci: run CI on pull requests only, not master pushes

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,8 +1,6 @@
 name: Benchmark
 
 on:
-  push:
-    branches: [master]
   pull_request:
 
 permissions:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,8 +1,6 @@
 name: Build-Test
 
 on:
-  push:
-    branches: [master]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,8 +1,6 @@
 name: Sanitizers
 
 on:
-  push:
-    branches: [master]
   pull_request:
 
 jobs:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,8 +1,6 @@
 name: Smoke
 
 on:
-  push:
-    branches: [master]
   pull_request:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,6 @@
 name: Test Suite
 
 on:
-  push:
-    branches: [master]
   pull_request:
 
 jobs:


### PR DESCRIPTION
## What

CI suites run on **open PRs only**, not again on the master commit a merge creates (redundant — the PR already gated it).

- Changed: `benchmark`, `build-test`, `sanitizers`, `smoke`, `test` — each now `pull_request` only (`build-test` keeps `workflow_dispatch`).
- Unchanged: `release.yml` triggers on `v*` tag pushes (releases still build/publish), and `sqlite-upstream-drift.yml` stays scheduled.

This PR exercises the new triggers — suites run here, and won't re-run on master after it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)