### PR TITLE
Document collate4 custom collation divergences

### DIFF
--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -422,6 +422,12 @@ collate3 collate3-3.12
 collate3 collate3-3.13
 collate3 collate3-3.14
 collate3 collate3-4.6
+
+# collate4 defines a custom TEXT collation. DoltLite rejects indexes that
+# depend on custom collations because persisted prolly sort keys can only
+# support built-in BINARY, NOCASE, and RTRIM comparisons. These failures are
+# either direct rejection of those indexes or downstream plan/search-count
+# checks that assume the rejected index exists.
 collate4 collate4-1.1.0
 collate4 collate4-1.1.4
 collate4 collate4-1.1.5
@@ -475,8 +481,8 @@ attach attach-8.4
 capi2 capi2-6.5
 check check-4.9
 collate1 collate1-6.8
-collate4 collate4-2.1.2
-collate4 collate4-3.4
+collate4 collate4-2.1.2  # sqlite_search_count plan metric; rows match
+collate4 collate4-3.4    # full-file cascade after unsupported custom-collation index DDL
 date date-14.1
 date date-14.2.0
 date date-14.2.1


### PR DESCRIPTION
## Summary

- Annotate the `collate4` known-divergence block as custom-collation/index fallout.
- Mark `collate4-2.1.2` as a `sqlite_search_count` plan-metric divergence where rows match.
- Mark `collate4-3.4` as a full-file cascade after unsupported custom-collation index DDL; isolated `PRIMARY KEY COLLATE NOCASE` returns the correct UNIQUE error.

## Notes

I investigated #1172 as a potential residual NOCASE bug after #1155/#1159. The named assertions are mixed:

- `collate4-2.1.2`, `2.1.8`, and `4.4` are search-count/plan assertions, not wrong result rows.
- `collate4-2.1.5` and related entries depend on `CREATE INDEX ... COLLATE TEXT`, which DoltLite intentionally rejects because persisted prolly sort keys support only built-in `BINARY`, `NOCASE`, and `RTRIM` semantics.
- `collate4-3.4` only returns `database disk image is malformed` in the full `collate4.test` sequence after earlier unsupported custom-collation DDL failures. A focused testfixture repro and a shell repro both return `UNIQUE constraint failed` for the `PRIMARY KEY COLLATE NOCASE` update path.

So this PR classifies #1172 as an allowlist/documentation issue instead of forcing stock-SQLite custom-collation index behavior into DoltLite.

Resolves #1172.

## Tests

```sh
cd build
bash ../test/run_testfixture.sh "1172 collate4 annotation" 120 collate4
```
