### PR TITLE
chunk store: report SQLITE_READONLY (not SQLITE_BUSY) for a read-only file (#1175)

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -94,7 +94,7 @@
 #endif
 
 static int csOpenFile(sqlite3_vfs *pVfs, const char *zPath,
-                      sqlite3_file **ppFile, int flags);
+                      sqlite3_file **ppFile, int flags, int *pOutFlags);
 static int csRollbackFailedAppend(ChunkStore *cs, i64 origFileSize);
 static int csRestoreCommittedRefsState(ChunkStore *cs);
 static int csReadManifest(ChunkStore *cs);
@@ -126,11 +126,13 @@ static int csOpenFile(
   sqlite3_vfs *pVfs,
   const char *zPath,
   sqlite3_file **ppFile,
-  int flags
+  int flags,
+  int *pOutFlags
 ){
   int rc;
   int outFlags = 0;
   rc = sqlite3OsOpenMalloc(pVfs, zPath, ppFile, flags, &outFlags);
+  if( pOutFlags ) *pOutFlags = outFlags;
   return rc;
 }
 
@@ -186,7 +188,7 @@ static int csRollbackFailedAppend(ChunkStore *cs, i64 origFileSize){
   csCloseFile(cs->file.pFile);
   cs->file.pFile = 0;
   rc = csOpenFile(cs->file.pVfs, cs->file.zFilename, &cs->file.pFile,
-                  SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB);
+                  SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB, 0);
   if( rc!=SQLITE_OK ) return rc;
 
   rc = sqlite3OsTruncate(cs->file.pFile, origFileSize);
@@ -334,15 +336,22 @@ int chunkStoreOpen(
 
   if( exists ){
     int openFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB;
-    rc = csOpenFile(pVfs, cs->file.zFilename, &cs->file.pFile, openFlags);
+    int outFlags = 0;
+    rc = csOpenFile(pVfs, cs->file.zFilename, &cs->file.pFile, openFlags, &outFlags);
     if( rc != SQLITE_OK ){
       openFlags = SQLITE_OPEN_READONLY | SQLITE_OPEN_MAIN_DB;
-      rc = csOpenFile(pVfs, cs->file.zFilename, &cs->file.pFile, openFlags);
+      rc = csOpenFile(pVfs, cs->file.zFilename, &cs->file.pFile, openFlags, 0);
       if( rc != SQLITE_OK ){
         sqlite3_free(cs->file.zFilename);
         cs->file.zFilename = 0;
         return rc;
       }
+      cs->readOnly = 1;
+    }else if( outFlags & SQLITE_OPEN_READONLY ){
+      /* The VFS opened a read-only file: a read-write open silently downgrades
+      ** to read-only and returns OK with READONLY in the out-flags. Mark the
+      ** store read-only so writes fail with SQLITE_READONLY rather than later
+      ** hitting a failed write-lock and reporting SQLITE_BUSY. */
       cs->readOnly = 1;
     }
 
@@ -1060,7 +1069,7 @@ static int csCommitToFile(ChunkStore *cs){
   if( cs->file.pFile == 0 ){
     int openFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE
                   | SQLITE_OPEN_MAIN_DB;
-    rc = csOpenFile(cs->file.pVfs, cs->file.zFilename, &cs->file.pFile, openFlags);
+    rc = csOpenFile(cs->file.pVfs, cs->file.zFilename, &cs->file.pFile, openFlags, 0);
     if( rc != SQLITE_OK ) return SQLITE_CANTOPEN;
   }
 

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -734,9 +734,6 @@ date date-14.2.96
 date date-14.2.97
 date date-14.2.98
 date date-14.2.99
-delete delete-8.1
-delete delete-8.3
-delete delete-8.5
 delete delete-9.2
 delete delete-9.3
 enc enc-12.1  # doltlite-format ignores non-UTF-8 database encodings


### PR DESCRIPTION
## What

Writing to a read-only database file reported `database is locked` (`SQLITE_BUSY`) instead of `attempt to write a readonly database` (`SQLITE_READONLY`). The write was correctly refused (no data loss) — only the error code/message was wrong.

## Root cause

The unix VFS silently downgrades a read-write open of a read-only file to read-only and returns `SQLITE_OK` with `SQLITE_OPEN_READONLY` in the *out-flags*. `csOpenFile` discarded the out-flags, so `cs->readOnly` stayed `0`. The first write then reached the graph-lock acquisition, whose `open(O_RDWR)` failed on the read-only file and was reported as `SQLITE_BUSY` — never reaching `chunkStoreCommit`'s `cs->readOnly → SQLITE_READONLY` check.

## Fix

Expose the out-flags from `csOpenFile` and set `cs->readOnly` when the VFS downgraded the open to read-only. Writes then fail early with `SQLITE_READONLY`.

## Verification

```sql
-- on a chmod 444 database:
DELETE FROM t3;   -- before: "database is locked"   after: "attempt to write a readonly database"
SELECT * FROM t3; -- 123 (preserved, both)
```
- DELETE/INSERT/UPDATE on a read-only file all report `attempt to write a readonly database`; reads still work; a writable DB is unaffected.
- Full shell suite **72/72** + C regression pass.
- testfixture `delete.test` validated in a **non-root** container (root bypasses the read-only bit): `OK: delete (68 tests, 2 known divergences)` — `delete-8.1/8.3/8.5` now pass and are removed from the divergence list; the remaining two are the `delete-9.2/9.3` mid-scan cases (#1177).

Fixes #1175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)