### PR TITLE
Fix cursor restore after deleting current row

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -3019,7 +3019,8 @@ static int restoreCursorPosition(BtCursor *pCur, int *pDifferentRow){
       pCur->eState = CURSOR_VALID;
       if( pDifferentRow ) *pDifferentRow = 0;
     } else if( pCur->pCur.eState==PROLLY_CURSOR_VALID ){
-      pCur->eState = CURSOR_VALID;
+      pCur->skipNext = res;
+      pCur->eState = CURSOR_SKIPNEXT;
       if( pDifferentRow ) *pDifferentRow = 1;
     } else {
       pCur->eState = CURSOR_INVALID;

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -744,7 +744,6 @@ delete delete-8.1
 delete delete-8.3
 delete delete-8.5
 delete delete-9.2
-delete delete-9.3
 enc enc-12.1  # doltlite-format ignores non-UTF-8 database encodings
 enc enc-12.3  # doltlite-format ignores non-UTF-8 database encodings
 enc enc-12.8  # doltlite-format ignores non-UTF-8 database encodings


### PR DESCRIPTION
## Summary
- preserve SQLite-style SKIPNEXT behavior when restoring a prolly cursor and the saved row was deleted
- leave the restored cursor on the successor so the next OP_Next does not skip it
- remove the now-fixed delete-9.3 known divergence

Fixes #1177

## Tests
- LIBRARY_PATH=/opt/homebrew/opt/libtommath/lib make testfixture
- bash ../test/run_testfixture.sh "1177 delete" 120 delete
- LIBRARY_PATH=/opt/homebrew/opt/libtommath/lib make doltlite

## Notes
- delete-9.2 still remains listed as a known divergence; this PR only fixes the deleted-current-row case from delete-9.3.