### PR TITLE
Document date raw-page divergences

### DIFF
--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -482,6 +482,10 @@ capi2 capi2-6.5
 check check-4.9
 collate4 collate4-2.1.2  # sqlite_search_count plan metric; rows match
 collate4 collate4-3.4    # full-file cascade after unsupported custom-collation index DDL
+# date-14 writes raw IEEE754 bytes directly into SQLite page offsets with
+# hexio_write, then verifies date/time behavior through that mutated record.
+# DoltLite's prolly storage has no SQLite page layout at those offsets, so
+# this is a raw storage-format divergence rather than a date/time bug.
 date date-14.1
 date date-14.2.0
 date date-14.2.1


### PR DESCRIPTION
## Summary
- keep the `date-14.*` cases in the testfixture divergence allow-list
- add a local comment explaining these tests mutate raw SQLite page bytes via `hexio_write`, which is not meaningful for DoltLite prolly storage

## Tests
- `bash ../test/run_testfixture.sh "date-14 divergence comment" 120 date`