### PR TITLE
Treat schema root as empty, not corrupt, when absent from the catalog

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -5834,7 +5834,7 @@ static int prollyBtreeCursor(
     **      shape to materialize tables they're importing from another
     **      branch, opening read cursors before doltlite's catalog has
     **      formally registered them. Synthesize for these. */
-    if( iTable < p->cat.iNextTable ){
+    if( iTable!=1 && iTable < p->cat.iNextTable ){
       sqlite3_log(SQLITE_CORRUPT,
         "doltlite: cursor open on iTable=%u not in catalog "
         "(iNextTable=%u, %s requested); rejecting as CORRUPT. "
@@ -5844,6 +5844,8 @@ static int prollyBtreeCursor(
         pKeyInfo ? "BLOBKEY" : "INTKEY");
       return SQLITE_CORRUPT_PGNO(iTable);
     }
+    /* The schema root (page 1) is never a dropped user table; an absent
+    ** entry just means an empty schema, so synthesize rather than reject. */
     {
       u8 flags = pKeyInfo ? BTREE_BLOBKEY : BTREE_INTKEY;
       pTE = addTable(p, iTable, flags);

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -797,9 +797,6 @@ minmax3 minmax3-4.5
 minmax3 minmax3-4.6
 quote quote-2.5
 rowid rowid-4.5
-savepoint savepoint-10.1.1
-savepoint savepoint-10.1.2
-savepoint savepoint-10.1.3
 savepoint savepoint-10.2.1
 savepoint savepoint-10.2.10
 savepoint savepoint-10.2.11
@@ -815,15 +812,7 @@ savepoint savepoint-10.2.7
 savepoint savepoint-10.2.8
 savepoint savepoint-10.2.9
 savepoint savepoint-11.1
-savepoint savepoint-11.10
-savepoint savepoint-11.11
-savepoint savepoint-11.12
-savepoint savepoint-11.7
 savepoint savepoint-11.8
-savepoint savepoint-11.9
-savepoint savepoint-12.1
-savepoint savepoint-12.2
-savepoint savepoint-12.3
 savepoint savepoint-13.1
 savepoint savepoint-14.1.2
 savepoint savepoint-14.1.3


### PR DESCRIPTION
## Problem

A bare `SAVEPOINT` in autocommit mode on a **never-committed** database, with a `CREATE TABLE` inside it followed by `ROLLBACK TO`, leaves the connection reporting **"database disk image is malformed"** on the next read:

```sql
SAVEPOINT one;
CREATE TABLE t2(a,b);
ROLLBACK TO one;
SELECT count(*) FROM sqlite_master;   -- database disk image is malformed
```

`ROLLBACK TO` correctly restores the empty pre-savepoint catalog (no `sqlite_master` entry) but leaves `iNextTable` at 2. Re-parsing the schema then opens a cursor on the schema root (page 1), and `prollyBtreeCursor` rejected it as a dropped user table because `1 < iNextTable`.

## Fix

The schema root (page 1) is never a dropped user table — an absent entry just means an empty schema. Exempt page 1 from the corrupt-rejection path so it synthesizes an empty table, matching stock SQLite where page 1 is always valid.

## Verification

- Minimal repro (above) now returns `0`; subsequent DDL/DML works.
- `savepoint.test` via testfixture: **"database disk image is malformed" 26 → 0**, errors 59 → 48. Now-passing: `10.1.1`, `12.2`, `12.3`, `10.1.2/3`, `11.7/9/10/11/12`, `12.1`. Their 11 entries removed from `known_testfixture_divergences.txt`; bidirectional gate passes (`OK: savepoint (140 tests, 46 known divergences)`).
- Remaining savepoint divergences (`5.4.4`, `17.1`, `10.2.x`/`14.x`/`15.x`) are the intentional locking-model / attach-status cascade (reproduce correctly standalone).
- `run_doltlite_tests.sh`: 72/72 suites, 120/120 guards. C regression: 309,770/309,770 pass.

Closes #1182

🤖 Generated with [Claude Code](https://claude.com/claude-code)