### PR TITLE
Save cursors on truncate so a concurrent scan survives whole-table DELETE

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -5653,14 +5653,21 @@ static int prollyBtreeClearTable(Btree *p, int iTable, i64 *pnChange){
     if( rc!=SQLITE_OK ) return rc;
   }
 
-  invalidateCursors(pBt, (Pgno)iTable, SQLITE_ABORT);
+  /* Save, don't abort, cursors on this table: the truncate optimization
+  ** (DELETE with no WHERE) can fire while another statement scans the table,
+  ** and that scan must restore against the now-empty tree and continue
+  ** rather than fail with SQLITE_ABORT. */
+  {
+    int rc = saveAllCursors(p, pBt, (Pgno)iTable, 0);
+    if( rc!=SQLITE_OK ) return rc;
+  }
   /* TRUNCATE: discard any pending mutations for this table. Without this,
   ** merging the now-empty tree with stale pending inserts would resurrect
   ** rows the caller asked to remove. Inside a savepoint that captured
   ** this table, hand the dirty map to the savepoint (via the same path
   ** flushPendingForTable uses) so ROLLBACK TO can restore pre-savepoint
   ** pending edits. Outside any savepoint, free the map outright. Either
-  ** way the cursor aliases must be updated since invalidateCursors
+  ** way the cursor aliases must be updated since saving the cursors
   ** leaves pCur->pMutMap untouched. */
   {
     int rc = syncBtreeSavepoints(p);

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -743,7 +743,6 @@ date date-14.2.96
 date date-14.2.97
 date date-14.2.98
 date date-14.2.99
-delete delete-9.2
 enc enc-12.1  # doltlite-format ignores non-UTF-8 database encodings
 enc enc-12.3  # doltlite-format ignores non-UTF-8 database encodings
 enc enc-12.8  # doltlite-format ignores non-UTF-8 database encodings


### PR DESCRIPTION
## Problem

A join scanning `t5, t6` that deletes the **entire** outer table mid-scan drops every remaining output row and returns `SQLITE_ABORT`:

```sql
-- scan: SELECT t5.rowid AS r, c, d FROM t5, t6 ORDER BY a
-- when r==2, run: DELETE FROM t5
```

| | result |
|---|---|
| stock | `1 a b \| 1 c d \| 2 a b \| {} c d` |
| doltlite (before) | `1 a b \| 1 c d \| 2 a b` then `SQLITE_ABORT` |

## Root cause

`DELETE FROM t5` with no `WHERE` uses the **truncate optimization** (`OP_Clear` → `prollyBtreeClearTable`). That path tripped all open cursors on the table with `invalidateCursors(..., SQLITE_ABORT)`. Stock SQLite's `sqlite3BtreeClearTable` instead **saves** those cursors (`saveAllCursors`), so an in-progress scan restores against the now-empty tree (reading NULLs for the deleted current row) and continues. The row-by-row delete path already saved cursors — which is why deleting a single row mid-scan (#1177) worked while truncate did not.

## Fix

Switch `ClearTable` from `invalidateCursors(SQLITE_ABORT)` to `saveAllCursors`, matching stock.

## Verification

- Standalone C repro now matches stock exactly; `del-current-row` (#1177) still works; wider inner table emits all trailing NULL rows then clean `SQLITE_DONE`.
- `delete.test` via testfixture: `delete-9.2` fixed, entry removed, gate green (`OK: delete (68 tests, 0 divergences)`), validated **non-root** (the `delete-8.x` readonly tests are a root-container artifact, not a regression).
- C regression: 309,770/309,770. `run_doltlite_tests.sh`: 72/72 suites.

Closes #1184. Sibling of #1165/#1177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)