### PR TITLE
Fix oversized secondary index keys

### DIFF
--- a/src/prolly_chunker.c
+++ b/src/prolly_chunker.c
@@ -176,7 +176,10 @@ static int addToLevel(ProllyChunker *ch, int level,
   thisSize = PROLLY_NODE_ENTRY_BYTES(level, nKey, nVal);
   pLevel->nBytes += thisSize;
 
-  if( pLevel->nBytes >= PROLLY_CHUNK_MIN ){
+  /* A single entry may be larger than the target chunk size. It cannot be
+  ** split, and flushing it immediately would propagate the same oversized
+  ** separator key up every level until SQLITE_FULL. */
+  if( pLevel->nItems>1 && pLevel->nBytes >= PROLLY_CHUNK_MIN ){
     int atBoundary;
     if( pLevel->nBytes >= PROLLY_CHUNK_MAX ){
       atBoundary = 1;

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -746,7 +746,6 @@ date date-14.2.99
 enc enc-12.1  # doltlite-format ignores non-UTF-8 database encodings
 enc enc-12.3  # doltlite-format ignores non-UTF-8 database encodings
 enc enc-12.8  # doltlite-format ignores non-UTF-8 database encodings
-insert insert-15.1
 insert insert-5.4
 intpkey intpkey-3.2
 intpkey intpkey-3.6

--- a/test/oracle_large_blobs_test.sh
+++ b/test/oracle_large_blobs_test.sh
@@ -80,6 +80,29 @@ SELECT id, length(b) FROM t;
 "
 done
 
+# ─── BLOB values as secondary index keys ──────────────────────────
+echo "--- BLOB secondary index keys ---"
+
+oracle "large_blob_index_key" "
+CREATE TABLE t(id INT PRIMARY KEY, b BLOB);
+CREATE INDEX i1 ON t(b);
+INSERT INTO t VALUES(1, zeroblob(33000));
+INSERT INTO t VALUES(2, zeroblob(34000));
+INSERT INTO t VALUES(3, zeroblob(35000));
+SELECT id, length(b) FROM t INDEXED BY i1 ORDER BY b, id;
+"
+
+oracle "replace_select_large_blob_index_key" "
+CREATE TABLE t1(a INTEGER PRIMARY KEY, b BLOB);
+CREATE INDEX i1 ON t1(b);
+CREATE TABLE t2(a, b);
+INSERT INTO t2 VALUES(4, randomblob(31000));
+INSERT INTO t2 VALUES(4, randomblob(32000));
+INSERT INTO t2 VALUES(4, randomblob(33000));
+REPLACE INTO t1 SELECT a, b FROM t2;
+SELECT a, length(b) FROM t1;
+"
+
 # ─── TEXT round-trip at varying sizes ──────────────────────────────
 echo "--- TEXT length round-trip ---"
 


### PR DESCRIPTION
## Summary

- allow a single prolly entry to exceed the target chunk size without immediately flushing it up every tree level
- add oracle coverage for large BLOB values used as secondary index keys
- remove `insert insert-15.1` from the known testfixture divergence list

Fixes #1191.

## Details

`insert-15.1` failed because the secondary index key contained a ~33KB BLOB. The chunker flushed as soon as a level reached `PROLLY_CHUNK_MAX`; for a singleton oversized key, that propagated the same oversized separator key to the parent, then the grandparent, until it hit max depth and returned `SQLITE_FULL`.

A singleton oversized entry cannot be split, so the chunker now waits until a level has more than one entry before applying normal chunk-boundary flushing.

## Testing

```bash
LIBRARY_PATH=/opt/homebrew/lib make testfixture
bash ../test/run_testfixture.sh "insert audit after allow-list cleanup" 120 insert
bash ../test/oracle_large_blobs_test.sh ./doltlite ./sqlite3
bash test/doltlite_regression_test_c.sh
```
