### PR TITLE
Sync empty pending-map savepoint level to btree depth (fixes fkey2-2.70)

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -2913,7 +2913,18 @@ static int ensureMutMap(BtCursor *pCur){
   if( !pTE ) return SQLITE_INTERNAL;
 
   if( pTE->pPending ){
-    pCur->pMutMap = (ProllyMutMap*)pTE->pPending;
+    ProllyMutMap *pExisting = (ProllyMutMap*)pTE->pPending;
+    /* Keep an empty pending map's savepoint level in step with the btree's
+    ** current depth. A savepoint release can drop the depth without rewriting
+    ** a map that had no live entries to commit, leaving currentSavepointLevel
+    ** stale; a later edit would then be stamped at a released level and undone
+    ** by an unrelated statement's rollback. */
+    if( pCur->pBtree
+     && prollyMutMapIsEmpty(pExisting)
+     && pExisting->currentSavepointLevel != pCur->pBtree->nSavepoint ){
+      pExisting->currentSavepointLevel = pCur->pBtree->nSavepoint;
+    }
+    pCur->pMutMap = pExisting;
     return SQLITE_OK;
   }
 

--- a/test/known_testfixture_crashes.txt
+++ b/test/known_testfixture_crashes.txt
@@ -21,7 +21,6 @@
 # branch created on first persist), so e_createtable, e_update, and alter
 # complete and moved to the divergence file.
 capi3    # aborts on set_file_format (raw stock page format; doltlite uses prolly)
-fkey2    # aborts under fkey2-2.x (raw-format / pre-existing doltlite divergence)
 # Additional crash/timeout files from the full capture (issue #1119):
 crash8        # crash-recovery simulation; incompatible with prolly format / times out
 fuzz3         # raw byte-corruption fuzz mutates test.db offsets; prolly storage aborts after restore/checksum


### PR DESCRIPTION
## Problem

A pending mutmap caches `currentSavepointLevel` — the savepoint depth at which its edits are stamped. `pushSavepointOnMutMaps`/`releaseMutMapsToSavepoint` keep it in step as savepoints open/close, but a release can drop the btree depth **without rewriting a map that had no live entries to commit**, leaving its `currentSavepointLevel` **stale and higher than the real depth**.

A later edit on that (still-empty) map is then stamped at the released, higher level. In the `fkey2` deferred-FK sequence (section 2):
- `DELETE FROM node` (test 63) ran at real depth 0 but stamped its tombstones at the stale level 1.
- `INSERT INTO node SELECT ...` (test 67) hit a UNIQUE violation; rolling back its statement savepoint (level 1) **also wiped the DELETE-63 tombstones**, reverting `node` to its committed rows.
- So `INSERT INTO node VALUES(2,…)` (test 70) spuriously failed `UNIQUE`.

This was the logic bug uncovered by #1197 (confirmed not a memory bug — ASan-clean). Traced to: at DELETE-63 the mutmap had `currentSavepointLevel=1` while `nSavepoint=0` and the map was empty (`nEntries=0`).

## Fix

`ensureMutMap` resyncs an **empty** pending map's `currentSavepointLevel` to the btree's current `nSavepoint` before use. Empty ⇒ no live entries to mis-level, so the resync is safe in either direction.

## Verification

- `fkey2-2.70 / 2.71 / 2.72 / 2.75` → all **Ok**. `fkey2.test` now completes (1217 tests) instead of aborting, so it's **removed from `known_testfixture_crashes.txt`**. Its remaining `5.x`/`13.x` (FK+rowid) failures were already tracked as known divergences (no list change). Gate: `OK: fkey2 (1217 tests, 7 known divergences)`.
- **No regressions** across the broad testfixture set: savepoint, trigger1/2/3/A/B/C, delete, insert, conflict, conflict2, in/in2/in3, update, e_fkey, fkey1/3/4, with1/2, randexpr1.
- C regression: **309,781/309,781**. `run_doltlite_tests.sh`: 72/72.
- Regression coverage: `fkey2.test` (CI bidirectional gate) is fail-before/pass-after for this; the minimal trigger requires the full section-2 savepoint churn (no compact standalone repro — accumulated state).

Closes #1195

🤖 Generated with [Claude Code](https://claude.com/claude-code)