### PR TITLE
Assert DoltLite build artifacts use prolly engine

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -158,6 +158,7 @@ jobs:
         make DOLTLITE_PROLLY_CHECK=1 doltlite
         make DOLTLITE_PROLLY_CHECK=1 doltlite-lib
         make DOLTLITE_PROLLY_CHECK=1 testfixture
+        DOLTLITE_CHECK_AMALGAMATION=0 bash ../test/assert_doltlite_artifacts.sh .
         # doltlite_parity.sh compares against the package-built stock
         # SQLite CLI instead of whatever sqlite3 the runner image provides.
         make DOLTLITE_PROLLY=0 sqlite3
@@ -170,6 +171,7 @@ jobs:
       run: |
         cd build
         make -j$(nproc) DOLTLITE_PROLLY_CHECK=1 doltlite.exe doltlite-lib
+        DOLTLITE_CHECK_AMALGAMATION=0 DOLTLITE_CHECK_SHARED=0 bash ../test/assert_doltlite_artifacts.sh .
         cp -f "$(command -v sqlite3)" sqlite3
 
     - name: Lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,8 @@ jobs:
         source "$EMSDK/emsdk_env.sh"
         ./configure
         make sqlite3.c sqlite3.h sqlite3ext.h
+        DOLTLITE_CHECK_CLI=0 DOLTLITE_CHECK_STATIC=0 DOLTLITE_CHECK_SHARED=0 \
+          bash test/assert_doltlite_artifacts.sh .
         make -C ext/wasm dist
         # With DOLTLITE_PROLLY=1 (the default), mksqlite3c.tcl --doltlite weaves
         # the prolly storage engine and the version-control layer into sqlite3.c,
@@ -225,6 +227,7 @@ jobs:
         cp src/doltlite_remotesrv.h "${DIR}/doltlite_remotesrv.h" 2>/dev/null || true
         cp build/libdoltlite${{ matrix.static_ext }} "${DIR}/" 2>/dev/null || true
         cp build/libdoltlite${{ matrix.lib_ext }} "${DIR}/" 2>/dev/null || true
+        cp -P build/libdoltlite.so.0 "${DIR}/" 2>/dev/null || true
         if command -v zip >/dev/null 2>&1; then
           zip -r "${DIR}.zip" "${DIR}"
         else
@@ -344,9 +347,15 @@ jobs:
         # On workflow_dispatch (no tag), just assert the call returns
         # *something* non-empty rather than asserting an exact value.
         VERSION_OUT=$(doltlite :memory: 'SELECT dolt_version();')
+        ENGINE_OUT=$(doltlite :memory: 'SELECT doltlite_engine();')
         echo "dolt_version() => ${VERSION_OUT}"
+        echo "doltlite_engine() => ${ENGINE_OUT}"
         if [ -z "${VERSION_OUT}" ]; then
           echo "dolt_version() returned empty"
+          exit 1
+        fi
+        if [ "${ENGINE_OUT}" != "prolly" ]; then
+          echo "doltlite_engine() returned ${ENGINE_OUT}, expected prolly"
           exit 1
         fi
         if [ "${GITHUB_EVENT_NAME}" = "push" ] && [ -n "${GITHUB_REF_NAME}" ]; then
@@ -365,6 +374,23 @@ jobs:
         # is mis-linked or a virtual table is missing, this fails fast.
         doltlite :memory: 'SELECT 1;'
         doltlite :memory: 'CREATE TABLE t(x INT); INSERT INTO t VALUES (1),(2); SELECT count(*) FROM t;'
+        cat >/tmp/doltlite-installed-probe.c <<'EOF'
+        #include <doltlite.h>
+        #include <stdio.h>
+        int main(void){
+          sqlite3 *db = 0;
+          sqlite3_stmt *st = 0;
+          if( sqlite3_open(":memory:", &db)!=SQLITE_OK ) return 1;
+          if( sqlite3_prepare_v2(db, "SELECT doltlite_engine()", -1, &st, 0)!=SQLITE_OK ) return 2;
+          if( sqlite3_step(st)!=SQLITE_ROW ) return 3;
+          printf("%s\n", sqlite3_column_text(st, 0));
+          sqlite3_finalize(st);
+          sqlite3_close(db);
+          return 0;
+        }
+        EOF
+        cc /tmp/doltlite-installed-probe.c -ldoltlite -lz -lpthread -lm -o /tmp/doltlite-installed-probe
+        test "$(/tmp/doltlite-installed-probe)" = "prolly"
 
   # ── Run benchmarks ────────────────────────────────────────
   benchmark:

--- a/main.mk
+++ b/main.mk
@@ -2750,6 +2750,7 @@ LDFLAGS.libdoltlite.soname = $(if $(filter .so,$(T.dll)),-Wl$(libdoltlite.comma)
 libdoltlite$(T.dll):	$(LIBOBJS0)
 	$(T.link.shared) -o $@ $(LIBOBJS0) $(LDFLAGS.libsqlite3) \
 		$(LDFLAGS.libdoltlite.os-specific) $(LDFLAGS.libdoltlite.soname)
+	$(if $(filter .so,$(T.dll)),ln -sf libdoltlite$(T.dll) libdoltlite$(T.dll).0)
 
 doltlite-lib: libdoltlite$(T.lib) libdoltlite$(T.dll) doltlite.h
 all: doltlite-lib

--- a/test/assert_doltlite_artifacts.sh
+++ b/test/assert_doltlite_artifacts.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+build_dir="${1:-.}"
+cd "$build_dir"
+
+cc_bin="${CC:-cc}"
+want="prolly"
+probe_cflags=(-w)
+probe_libs=(-lz -lpthread -lm)
+case "$(uname -s)" in
+  Linux*) probe_libs+=(-ldl) ;;
+esac
+
+check_value() {
+  label="$1"
+  got="$2"
+  if [ "$got" != "$want" ]; then
+    echo "$label: expected doltlite_engine() => $want, got: $got" >&2
+    exit 1
+  fi
+  echo "$label: doltlite_engine() => $got"
+}
+
+probe_dir="$(mktemp -d "${TMPDIR:-/tmp}/doltlite-artifact-probe.XXXXXX")"
+probe_c="$probe_dir/probe.c"
+trap 'rm -rf "$probe_dir"' EXIT
+
+cat >"$probe_c" <<'EOF'
+#include "sqlite3.h"
+#include <stdio.h>
+
+int main(void){
+  sqlite3 *db = 0;
+  sqlite3_stmt *st = 0;
+  int rc = sqlite3_open(":memory:", &db);
+  if( rc!=SQLITE_OK ){
+    fprintf(stderr, "sqlite3_open: %s\n", db ? sqlite3_errmsg(db) : "no db");
+    return 1;
+  }
+  rc = sqlite3_prepare_v2(db, "SELECT doltlite_engine()", -1, &st, 0);
+  if( rc!=SQLITE_OK ){
+    fprintf(stderr, "prepare: %s\n", sqlite3_errmsg(db));
+    sqlite3_close(db);
+    return 2;
+  }
+  rc = sqlite3_step(st);
+  if( rc!=SQLITE_ROW ){
+    fprintf(stderr, "step: rc=%d\n", rc);
+    sqlite3_finalize(st);
+    sqlite3_close(db);
+    return 3;
+  }
+  printf("%s\n", sqlite3_column_text(st, 0));
+  sqlite3_finalize(st);
+  sqlite3_close(db);
+  return 0;
+}
+EOF
+
+if [ "${DOLTLITE_CHECK_CLI:-1}" != 0 ]; then
+  if [ -x ./doltlite ]; then
+    check_value "doltlite CLI" "$(./doltlite :memory: 'SELECT doltlite_engine();')"
+  elif [ -x ./doltlite.exe ]; then
+    check_value "doltlite CLI" "$(./doltlite.exe :memory: 'SELECT doltlite_engine();')"
+  else
+    echo "doltlite CLI: skipped, binary not found" >&2
+  fi
+fi
+
+if [ "${DOLTLITE_CHECK_STATIC:-1}" != 0 ] && [ -f ./libdoltlite.a ]; then
+  "$cc_bin" "${probe_cflags[@]}" -I. "$probe_c" ./libdoltlite.a "${probe_libs[@]}" -o "$probe_dir/static"
+  check_value "libdoltlite.a" "$("$probe_dir/static")"
+fi
+
+if [ "${DOLTLITE_CHECK_SHARED:-1}" != 0 ]; then
+  if [ -f ./libdoltlite.so ] || [ -f ./libdoltlite.dylib ]; then
+    if [ "$(uname -s)" = "Linux" ] && [ ! -e ./libdoltlite.so.0 ]; then
+      echo "libdoltlite shared: missing libdoltlite.so.0 for Linux SONAME" >&2
+      exit 1
+    fi
+    "$cc_bin" "${probe_cflags[@]}" -I. "$probe_c" -L. -ldoltlite "${probe_libs[@]}" -o "$probe_dir/shared"
+    case "$(uname -s)" in
+      Darwin) got="$(DYLD_LIBRARY_PATH="$PWD${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}" "$probe_dir/shared")" ;;
+      *) got="$(LD_LIBRARY_PATH="$PWD${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" "$probe_dir/shared")" ;;
+    esac
+    check_value "libdoltlite shared" "$got"
+  fi
+fi
+
+if [ "${DOLTLITE_CHECK_AMALGAMATION:-1}" != 0 ] && [ -f ./sqlite3.c ]; then
+  if ! grep -q 'Begin file prolly_btree.c' sqlite3.c; then
+    echo "sqlite3.c: missing prolly_btree.c marker; this looks like stock SQLite" >&2
+    exit 1
+  fi
+  "$cc_bin" "${probe_cflags[@]}" -I. "$probe_c" ./sqlite3.c "${probe_libs[@]}" -o "$probe_dir/amalgamation"
+  check_value "sqlite3.c amalgamation" "$("$probe_dir/amalgamation")"
+fi


### PR DESCRIPTION
Summary:
- add a reusable artifact probe that fails unless doltlite_engine() returns prolly
- run it for native CLI/static/shared library builds before the intentionally stock sqlite3 oracle build
- run it for the release amalgamation and installed Debian CLI/library smoke path

Audit result:
- clean origin/master build produced real DoltLite for doltlite, libdoltlite.a, libdoltlite.dylib, and generated sqlite3.c
- local dirty builds can still reuse a previously generated DoltLite sqlite3.c when asking for a stock sqlite3 oracle, so this PR focuses the guard on shipped DoltLite artifacts and runs before stock-oracle generation

Verification:
- clean out-of-tree build from origin/master: configure && make doltlite doltlite-remotesrv doltlite-lib sqlite3.c sqlite3.h
- DOLTLITE_CHECK_AMALGAMATION=0 bash test/assert_doltlite_artifacts.sh /tmp/doltlite-ship-audit-build
- DOLTLITE_CHECK_CLI=0 DOLTLITE_CHECK_STATIC=0 DOLTLITE_CHECK_SHARED=0 bash test/assert_doltlite_artifacts.sh /tmp/doltlite-ship-audit-build
- ruby YAML parse for .github/workflows/build-test.yml and .github/workflows/release.yml
- bash -n test/assert_doltlite_artifacts.sh
- git diff --check