### PR TITLE
Route DoltLite storage file IO through SQLite VFS

### DIFF
--- a/main.mk
+++ b/main.mk
@@ -2647,6 +2647,7 @@ DOLTLITE_C_TESTS = \
 	corruption_test$(T.exe) \
 	three_way_diff_test$(T.exe) \
 	sequence_reload_test$(T.exe) \
+	chunk_store_fork_lock_test$(T.exe) \
 	oom_dolt_fault_test$(T.exe)
 
 ancestor_test$(T.exe): $(TOP)/test/ancestor_test.c libdoltlite$(T.lib)
@@ -2683,6 +2684,10 @@ multi_process_gc_test$(T.exe): $(TOP)/test/multi_process_gc_test.c libdoltlite$(
 
 sequence_reload_test$(T.exe): $(TOP)/test/sequence_reload_test.c libdoltlite$(T.lib)
 	$(T.link) -I. -I$(TOP)/src -o $@ $(TOP)/test/sequence_reload_test.c \
+		libdoltlite$(T.lib) -lz -lpthread -lm
+
+chunk_store_fork_lock_test$(T.exe): $(TOP)/test/chunk_store_fork_lock_test.c libdoltlite$(T.lib)
+	$(T.link) -I. -I$(TOP)/src -o $@ $(TOP)/test/chunk_store_fork_lock_test.c \
 		libdoltlite$(T.lib) -lz -lpthread -lm
 
 invariant_test$(T.exe): $(TOP)/test/invariant_test.c libdoltlite$(T.lib)

--- a/main.mk
+++ b/main.mk
@@ -307,6 +307,7 @@ all:	lint doltlite$(T.exe)
 
 lint:
 	@bash $(TOP)/test/lint_layers.sh $(TOP)/src
+	@bash $(TOP)/test/lint_no_raw_os_fileio.sh $(TOP)/src
 
 ########################################################################
 ########################################################################

--- a/src/chunk_index.c
+++ b/src/chunk_index.c
@@ -8,7 +8,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <limits.h>
-#include <sys/stat.h>
 
 void chunkIndexGetEntries(const ChunkIndex *idx, int *pn, const ChunkIndexEntry **par){
   *pn = idx->nIndex;
@@ -33,106 +32,11 @@ void chunkIndexReplaceEntries(ChunkIndex *idx, ChunkIndexEntry *aNew, int nNew){
   idx->aIndexMmapSize = 0;
 }
 
-#if CHUNK_STORE_LE_PACKING
-#  if defined(_WIN32)
-#    include <windows.h>
-static int csMapIndex(const char *zPath, i64 offset, i64 nBytes,
-                      void **ppMapBase, i64 *pnMapSize,
-                      const u8 **ppData){
-  HANDLE hFile = CreateFileA(zPath, GENERIC_READ, FILE_SHARE_READ,
-                              NULL, OPEN_EXISTING,
-                              FILE_ATTRIBUTE_NORMAL, NULL);
-  HANDLE hMap;
-  void *pMap;
-  SYSTEM_INFO si;
-  i64 alignOffset, alignPad, mapSize;
-
-  if( hFile==INVALID_HANDLE_VALUE ) return SQLITE_CANTOPEN;
-
-  GetSystemInfo(&si);
-  alignOffset = (offset / si.dwAllocationGranularity)
-              * si.dwAllocationGranularity;
-  alignPad = offset - alignOffset;
-  mapSize = nBytes + alignPad;
-
-  hMap = CreateFileMappingA(hFile, NULL, PAGE_READONLY, 0, 0, NULL);
-  CloseHandle(hFile);
-  if( hMap==NULL ) return SQLITE_IOERR;
-
-  pMap = MapViewOfFile(hMap, FILE_MAP_READ,
-                        (DWORD)(alignOffset >> 32),
-                        (DWORD)(alignOffset & 0xFFFFFFFF),
-                        (SIZE_T)mapSize);
-  CloseHandle(hMap);
-  if( pMap==NULL ) return SQLITE_IOERR;
-
-  *ppMapBase = pMap;
-  *pnMapSize = mapSize;
-  *ppData = (const u8 *)pMap + alignPad;
-  return SQLITE_OK;
-}
-
-static void csUnmapIndex(void *pMapBase, i64 nMapSize){
-  (void)nMapSize;
-  if( pMapBase ) UnmapViewOfFile(pMapBase);
-}
-#  else
-#    include <sys/mman.h>
-#    include <fcntl.h>
-#    include <unistd.h>
-static int csMapIndex(const char *zPath, i64 offset, i64 nBytes,
-                      void **ppMapBase, i64 *pnMapSize,
-                      const u8 **ppData){
-  int fd;
-  long pageSize;
-  i64 alignOffset, alignPad, mapSize;
-  void *pMap;
-
-  fd = open(zPath, O_RDONLY);
-  if( fd < 0 ) return SQLITE_CANTOPEN;
-
-  pageSize = sysconf(_SC_PAGESIZE);
-  if( pageSize <= 0 ) pageSize = 4096;
-
-  alignOffset = (offset / pageSize) * pageSize;
-  alignPad = offset - alignOffset;
-  mapSize = nBytes + alignPad;
-
-  pMap = mmap(NULL, (size_t)mapSize, PROT_READ, MAP_PRIVATE, fd,
-              (off_t)alignOffset);
-  close(fd);
-  if( pMap == MAP_FAILED ) return SQLITE_IOERR;
-
-  *ppMapBase = pMap;
-  *pnMapSize = mapSize;
-  *ppData = (const u8 *)pMap + alignPad;
-  return SQLITE_OK;
-}
-
-static void csUnmapIndex(void *pMapBase, i64 nMapSize){
-  if( pMapBase ) munmap(pMapBase, (size_t)nMapSize);
-}
-#  endif
-#else
-static int csMapIndex(const char *zPath, i64 offset, i64 nBytes,
-                      void **ppMapBase, i64 *pnMapSize,
-                      const u8 **ppData){
-  (void)zPath; (void)offset; (void)nBytes;
-  (void)ppMapBase; (void)pnMapSize; (void)ppData;
-  return SQLITE_NOTFOUND;
-}
-static void csUnmapIndex(void *pMapBase, i64 nMapSize){
-  (void)pMapBase; (void)nMapSize;
-}
-#endif
-
 void csReleaseIndexBuf(ChunkIndexEntry *aIndex,
                        void *mmapBase, i64 mmapSize){
-  if( mmapBase ){
-    csUnmapIndex(mmapBase, mmapSize);
-  }else{
-    sqlite3_free(aIndex);
-  }
+  (void)mmapBase;
+  (void)mmapSize;
+  sqlite3_free(aIndex);
 }
 
 int csSearchIndex(
@@ -191,9 +95,6 @@ int csReadIndex(ChunkStore *cs){
   int nEntries;
   u8 *aBuf;
   int i;
-  void *pMapBase = 0;
-  i64 nMapSize = 0;
-  const u8 *pMapData = 0;
   i64 fileSize = 0;
 
   if( cs->index.nIndexSize == 0 ){
@@ -211,7 +112,13 @@ int csReadIndex(ChunkStore *cs){
   if( nEntries64 > INT_MAX ){
     return SQLITE_TOOBIG;
   }
+  if( cs->index.nIndexSize > INT_MAX ){
+    return SQLITE_TOOBIG;
+  }
   nEntries = (int)nEntries64;
+  if( nEntries > INT_MAX/(int)sizeof(ChunkIndexEntry) ){
+    return SQLITE_TOOBIG;
+  }
   /* nChunks includes WAL chunks; only compacted entries are in this index. */
   if( nEntries > cs->index.nChunks ){
     return SQLITE_CORRUPT;
@@ -220,34 +127,13 @@ int csReadIndex(ChunkStore *cs){
   if( cs->index.iIndexOffset < 0 || cs->index.nIndexSize < 0 ){
     return SQLITE_CORRUPT;
   }
-  if( cs->file.pFile ){
-    rc = sqlite3OsFileSize(cs->file.pFile, &fileSize);
-    if( rc != SQLITE_OK ) return rc;
-  }else if( cs->file.zFilename ){
-    struct stat st;
-    if( stat(cs->file.zFilename, &st) != 0 ) return SQLITE_IOERR;
-    fileSize = (i64)st.st_size;
-  }
+  if( cs->file.pFile==0 ) return SQLITE_IOERR;
+  rc = sqlite3OsFileSize(cs->file.pFile, &fileSize);
+  if( rc != SQLITE_OK ) return rc;
   if( fileSize > 0
    && (cs->index.iIndexOffset > fileSize
        || cs->index.nIndexSize > fileSize - cs->index.iIndexOffset) ){
     return SQLITE_CORRUPT;
-  }
-
-  if( cs->file.zFilename
-   && csMapIndex(cs->file.zFilename, cs->index.iIndexOffset, cs->index.nIndexSize,
-                  &pMapBase, &nMapSize, &pMapData) == SQLITE_OK ){
-    rc = csValidateIndexEntries((const ChunkIndexEntry*)pMapData, nEntries,
-                                cs->index.iIndexOffset);
-    if( rc!=SQLITE_OK ){
-      csUnmapIndex(pMapBase, nMapSize);
-      return rc;
-    }
-    cs->index.aIndex = (ChunkIndexEntry *)pMapData;
-    cs->index.nIndex = nEntries;
-    cs->index.aIndexMmapBase = pMapBase;
-    cs->index.aIndexMmapSize = nMapSize;
-    return SQLITE_OK;
   }
 
   cs->index.aIndex = (ChunkIndexEntry *)sqlite3_malloc(

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -15,7 +15,16 @@ static int csFileLockHeld(sqlite3_file *pFile){
 }
 
 static char *csLockPath(const char *path){
-  return sqlite3_mprintf("%s-lock", path);
+  const char *zBase = strrchr(path, '/');
+  int nDir = 0;
+
+  if( zBase ){
+    nDir = (int)(zBase - path) + 1;
+    zBase++;
+  }else{
+    zBase = path;
+  }
+  return sqlite3_mprintf("%.*s.%s-lock", nDir, path, zBase);
 }
 
 static int csFileLock(sqlite3_vfs *pVfs, const char *path,

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -36,17 +36,17 @@ static int csFileLock(sqlite3_vfs *pVfs, const char *path,
   int rc;
 
   *ppFile = 0;
-  if( !zLock ) return -1;
+  if( !zLock ) return SQLITE_NOMEM;
   rc = sqlite3OsOpenMalloc(pVfs, zLock, &pFile, flags, 0);
   sqlite3_free(zLock);
-  if( rc!=SQLITE_OK ) return -1;
+  if( rc!=SQLITE_OK ) return rc;
   rc = sqlite3OsLock(pFile, SQLITE_LOCK_EXCLUSIVE);
   if( rc!=SQLITE_OK ){
     sqlite3OsCloseFree(pFile);
-    return -1;
+    return rc;
   }
   *ppFile = pFile;
-  return 0;
+  return SQLITE_OK;
 }
 
 static void csFileUnlock(sqlite3_file *pFile){
@@ -1061,15 +1061,14 @@ static int csCommitToFile(ChunkStore *cs){
     int openFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE
                   | SQLITE_OPEN_MAIN_DB;
     rc = csOpenFile(cs->file.pVfs, cs->file.zFilename, &cs->file.pFile, openFlags, 0);
-    if( rc != SQLITE_OK ) return SQLITE_CANTOPEN;
+    if( rc != SQLITE_OK ) return rc==SQLITE_NOMEM ? rc : SQLITE_CANTOPEN;
   }
 
   if( lockHeld ){
     lockFd = CS_FILE_LOCK_INIT;
   }else{
-    if( csFileLock(cs->file.pVfs, cs->file.zFilename, &lockFd) != 0 ){
-      return SQLITE_BUSY;
-    }
+    rc = csFileLock(cs->file.pVfs, cs->file.zFilename, &lockFd);
+    if( rc!=SQLITE_OK ) return rc;
   }
 
   if( lockHeld && hadFile ){
@@ -1440,9 +1439,10 @@ int chunkStoreLockAndRefreshChanged(ChunkStore *cs, int *pChanged){
     if( cs->pLockMutex ) sqlite3_mutex_leave(cs->pLockMutex);
     return SQLITE_ERROR;
   }
-  if( csFileLockNB(cs->file.pVfs, cs->file.zFilename, &CS_GRAPH_LOCK(cs)) != 0 ){
+  rc = csFileLockNB(cs->file.pVfs, cs->file.zFilename, &CS_GRAPH_LOCK(cs));
+  if( rc!=SQLITE_OK ){
     if( cs->pLockMutex ) sqlite3_mutex_leave(cs->pLockMutex);
-    return SQLITE_BUSY;
+    return rc;
   }
   rc = chunkStoreRefreshIfChanged(cs, &changed);
   if( rc!=SQLITE_OK ){

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -9,7 +9,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <limits.h>
-#include <sys/stat.h>
 
 static int csFileLockHeld(sqlite3_file *pFile){
   return pFile!=0;
@@ -97,6 +96,19 @@ static int csOpenFile(
   int outFlags = 0;
   rc = sqlite3OsOpenMalloc(pVfs, zPath, ppFile, flags, &outFlags);
   if( pOutFlags ) *pOutFlags = outFlags;
+  return rc;
+}
+
+static int csFileSizeByName(sqlite3_vfs *pVfs, const char *zPath, i64 *pSize){
+  sqlite3_file *pFile = 0;
+  int flags = SQLITE_OPEN_READONLY | SQLITE_OPEN_MAIN_DB;
+  int rc;
+
+  *pSize = 0;
+  rc = csOpenFile(pVfs, zPath, &pFile, flags, 0);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = sqlite3OsFileSize(pFile, pSize);
+  sqlite3OsCloseFree(pFile);
   return rc;
 }
 
@@ -292,8 +304,14 @@ int chunkStoreOpen(
   }
 
   if( exists ){
-    struct stat mainStat;
-    if( stat(cs->file.zFilename, &mainStat)==0 && mainStat.st_size==0 ){
+    i64 mainSize = 0;
+    rc = csFileSizeByName(pVfs, cs->file.zFilename, &mainSize);
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(cs->file.zFilename);
+      cs->file.zFilename = 0;
+      return rc;
+    }
+    if( mainSize==0 ){
       exists = 0;
     }
   }
@@ -1460,13 +1478,11 @@ static int csDetectExternalChanges(ChunkStore *cs, int *pChanged){
                          SQLITE_ACCESS_EXISTS, &exists);
     if( rc!=SQLITE_OK ) return rc;
     if( exists ){
-      struct stat mainStat;
-      if( stat(cs->file.zFilename, &mainStat)==0 ){
-        if( mainStat.st_size > 0 ){
-          *pChanged = 1;
-        }
-      }else{
-        return SQLITE_IOERR;
+      i64 mainSize = 0;
+      rc = csFileSizeByName(cs->file.pVfs, cs->file.zFilename, &mainSize);
+      if( rc!=SQLITE_OK ) return rc;
+      if( mainSize > 0 ){
+        *pChanged = 1;
       }
     }
     return SQLITE_OK;

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -9,89 +9,53 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <limits.h>
-#include <fcntl.h>
 #include <sys/stat.h>
 
-#ifdef _WIN32
-  static int csFileLockHeld(sqlite3_file *pFile){
-    return pFile!=0;
+static int csFileLockHeld(sqlite3_file *pFile){
+  return pFile!=0;
+}
+
+static char *csLockPath(const char *path){
+  return sqlite3_mprintf("%s-lock", path);
+}
+
+static int csFileLock(sqlite3_vfs *pVfs, const char *path,
+                      sqlite3_file **ppFile){
+  char *zLock = csLockPath(path);
+  sqlite3_file *pFile = 0;
+  int flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE
+            | SQLITE_OPEN_MAIN_DB;
+  int rc;
+
+  *ppFile = 0;
+  if( !zLock ) return -1;
+  rc = sqlite3OsOpenMalloc(pVfs, zLock, &pFile, flags, 0);
+  sqlite3_free(zLock);
+  if( rc!=SQLITE_OK ) return -1;
+  rc = sqlite3OsLock(pFile, SQLITE_LOCK_EXCLUSIVE);
+  if( rc!=SQLITE_OK ){
+    sqlite3OsCloseFree(pFile);
+    return -1;
   }
-  static char *csLockPath(const char *path){
-    return sqlite3_mprintf("%s-lock", path);
+  *ppFile = pFile;
+  return 0;
+}
+
+static void csFileUnlock(sqlite3_file *pFile){
+  if( pFile ){
+    sqlite3OsUnlock(pFile, SQLITE_LOCK_NONE);
+    sqlite3OsCloseFree(pFile);
   }
-  static int csFileLock(sqlite3_vfs *pVfs, const char *path,
+}
+
+static int csFileLockNB(sqlite3_vfs *pVfs, const char *path,
                         sqlite3_file **ppFile){
-    char *zLock = csLockPath(path);
-    sqlite3_file *pFile = 0;
-    int flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE
-              | SQLITE_OPEN_MAIN_DB;
-    int rc;
+  return csFileLock(pVfs, path, ppFile);
+}
 
-    *ppFile = 0;
-    if( !zLock ) return -1;
-    rc = sqlite3OsOpenMalloc(pVfs, zLock, &pFile, flags, 0);
-    sqlite3_free(zLock);
-    if( rc!=SQLITE_OK ) return -1;
-    rc = sqlite3OsLock(pFile, SQLITE_LOCK_EXCLUSIVE);
-    if( rc!=SQLITE_OK ){
-      sqlite3OsCloseFree(pFile);
-      return -1;
-    }
-    *ppFile = pFile;
-    return 0;
-  }
-  static void csFileUnlock(sqlite3_file *pFile){
-    if( pFile ){
-      sqlite3OsUnlock(pFile, SQLITE_LOCK_NONE);
-      sqlite3OsCloseFree(pFile);
-    }
-  }
-  static int csFileLockNB(sqlite3_vfs *pVfs, const char *path,
-                          sqlite3_file **ppFile){
-    return csFileLock(pVfs, path, ppFile);
-  }
-#else
-# include <unistd.h>
-# include <sys/file.h>
-  static int csFileLockHeld(int fd){
-    return fd>=0;
-  }
-  static int csFileLock(sqlite3_vfs *pVfs, const char *path, int *pFd){
-    int fd = open(path, O_RDWR | O_CREAT, 0644);
-    (void)pVfs;
-    if( fd < 0 ) return -1;
-    if( flock(fd, LOCK_EX) != 0 ){
-      close(fd);
-      return -1;
-    }
-    *pFd = fd;
-    return 0;
-  }
-  static void csFileUnlock(int fd){
-    if( fd >= 0 ) close(fd);
-  }
-  static int csFileLockNB(sqlite3_vfs *pVfs, const char *path, int *pFd){
-    int fd = open(path, O_RDWR | O_CREAT, 0644);
-    (void)pVfs;
-    if( fd < 0 ) return -1;
-    if( flock(fd, LOCK_EX | LOCK_NB) != 0 ){
-      close(fd);
-      return -1;
-    }
-    *pFd = fd;
-    return 0;
-  }
-#endif
-
-#ifdef _WIN32
-  typedef sqlite3_file *CsFileLock;
+typedef sqlite3_file *CsFileLock;
 # define CS_FILE_LOCK_INIT 0
 # define CS_GRAPH_LOCK(cs) ((cs)->pGraphLockFile)
-#else
-  typedef int CsFileLock;
-# define CS_FILE_LOCK_INIT -1
-# define CS_GRAPH_LOCK(cs) ((cs)->graphLockFd)
-#endif
 
 static int csOpenFile(sqlite3_vfs *pVfs, const char *zPath,
                       sqlite3_file **ppFile, int flags, int *pOutFlags);

--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -132,11 +132,7 @@ struct ChunkStore {
   u8 readOnly;
   u8 isMemory;
   u8 snapshotPinned;
-#ifdef _WIN32
   sqlite3_file *pGraphLockFile;
-#else
-  int graphLockFd;
-#endif
   sqlite3_mutex *pLockMutex;
   int lockDepth;
 };

--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -11,12 +11,6 @@
 
 #include <string.h>
 #include <stdio.h>
-#if SQLITE_OS_WIN
-#include "os_win.h"
-#else
-#include <fcntl.h>
-#include <unistd.h>
-#endif
 
 extern void csSerializeManifest(const ChunkStore *cs, u8 *aBuf);
 #include "doltlite_internal.h"
@@ -325,73 +319,6 @@ static int gcBuildCompactedData(
   return SQLITE_OK;
 }
 
-static int gcReplaceFile(sqlite3_vfs *pVfs, const char *zTmp, const char *zDest){
-#if SQLITE_OS_WIN
-  char *zTmpFull = 0;
-  char *zDestFull = 0;
-  WCHAR *zTmpW = 0;
-  WCHAR *zDestW = 0;
-  int rc = SQLITE_OK;
-  int nTmp, nDest;
-  int nPath;
-
-  nPath = pVfs ? pVfs->mxPathname : 0;
-  if( nPath<=0 ) return SQLITE_IOERR;
-
-  zTmpFull = sqlite3_malloc64((sqlite3_uint64)nPath);
-  zDestFull = sqlite3_malloc64((sqlite3_uint64)nPath);
-  if( zTmpFull==0 || zDestFull==0 ){
-    sqlite3_free(zTmpFull);
-    sqlite3_free(zDestFull);
-    return SQLITE_NOMEM;
-  }
-  rc = sqlite3OsFullPathname(pVfs, zTmp, nPath, zTmpFull);
-  if( rc==SQLITE_OK ){
-    rc = sqlite3OsFullPathname(pVfs, zDest, nPath, zDestFull);
-  }
-  if( rc!=SQLITE_OK ){
-    sqlite3_free(zTmpFull);
-    sqlite3_free(zDestFull);
-    return rc;
-  }
-
-  nTmp = MultiByteToWideChar(CP_UTF8, 0, zTmpFull, -1, 0, 0);
-  nDest = MultiByteToWideChar(CP_UTF8, 0, zDestFull, -1, 0, 0);
-  if( nTmp==0 || nDest==0 ){
-    sqlite3_free(zTmpFull);
-    sqlite3_free(zDestFull);
-    return SQLITE_IOERR;
-  }
-
-  zTmpW = sqlite3_malloc64((sqlite3_uint64)nTmp * sizeof(WCHAR));
-  zDestW = sqlite3_malloc64((sqlite3_uint64)nDest * sizeof(WCHAR));
-  if( zTmpW==0 || zDestW==0 ){
-    sqlite3_free(zTmpFull);
-    sqlite3_free(zDestFull);
-    sqlite3_free(zTmpW);
-    sqlite3_free(zDestW);
-    return SQLITE_NOMEM;
-  }
-
-  if( MultiByteToWideChar(CP_UTF8, 0, zTmpFull, -1, zTmpW, nTmp)==0
-   || MultiByteToWideChar(CP_UTF8, 0, zDestFull, -1, zDestW, nDest)==0
-  ){
-    rc = SQLITE_IOERR;
-  }else if( !MoveFileExW(zTmpW, zDestW,
-                         MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH) ){
-    rc = SQLITE_IOERR;
-  }
-  sqlite3_free(zTmpFull);
-  sqlite3_free(zDestFull);
-  sqlite3_free(zTmpW);
-  sqlite3_free(zDestW);
-  return rc;
-#else
-  (void)pVfs;
-  return rename(zTmp, zDest)==0 ? SQLITE_OK : SQLITE_IOERR;
-#endif
-}
-
 static int gcReopenChunkFile(ChunkStore *cs, sqlite3_file **ppFile){
   int rc;
   int flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB;
@@ -533,7 +460,6 @@ static int gcRewriteFile(
       if( rc==SQLITE_OK ){
         sqlite3_file *pOldFile = chunkFileGetHandle(&cs->file);
         sqlite3_file *pNewFile = 0;
-        int dirSyncRc = SQLITE_OK;
 
 #if SQLITE_OS_WIN
         /* Windows will not reliably replace either an open source file or an
@@ -551,8 +477,8 @@ static int gcRewriteFile(
 
         GC_CRASH_CHECK();
         if( rc==SQLITE_OK ){
-          rc = gcReplaceFile(chunkFileGetVfs(&cs->file), zTmp,
-                             chunkFileGetFilename(&cs->file));
+          rc = sqlite3OsReplaceFile(chunkFileGetVfs(&cs->file), zTmp,
+                                    chunkFileGetFilename(&cs->file));
         }
         if( rc!=SQLITE_OK ){
 #if SQLITE_OS_WIN
@@ -569,34 +495,6 @@ static int gcRewriteFile(
           pTmpFile = 0;
 #endif
         }
-
-#if !defined(_WIN32) && !defined(WIN32)
-        if( rc==SQLITE_OK ){
-          char *zDir = sqlite3_mprintf("%s", chunkFileGetFilename(&cs->file));
-          if( zDir ){
-            int k = (int)strlen(zDir);
-            while( k>0 && zDir[k-1]!='/' ) k--;
-            if( k>0 ) zDir[k-1] = 0; else{ zDir[0]='.'; zDir[1]=0; }
-            {
-              int dfd = open(zDir, O_RDONLY);
-              if( dfd>=0 ){
-                GC_CRASH_CHECK();
-                if( fsync(dfd)!=0 ){
-                  dirSyncRc = SQLITE_IOERR_DIR_FSYNC;
-                }
-                if( close(dfd)!=0 && dirSyncRc==SQLITE_OK ){
-                  dirSyncRc = SQLITE_IOERR_DIR_FSYNC;
-                }
-              }else{
-                dirSyncRc = SQLITE_IOERR_DIR_FSYNC;
-              }
-            }
-            sqlite3_free(zDir);
-          }else{
-            dirSyncRc = SQLITE_NOMEM;
-          }
-        }
-#endif
 
         if( *pReplaced ){
           if( pOldFile ){
@@ -623,7 +521,6 @@ static int gcRewriteFile(
           chunkFileSetHandle(&cs->file, pNewFile);
           chunkFileSetSize(&cs->file, CHUNK_MANIFEST_SIZE + nNewData + indexSize);
           walStateSetDataSize(&cs->wal, 0);
-          if( dirSyncRc!=SQLITE_OK ) rc = dirSyncRc;
         }else if( pNewFile ){
           sqlite3OsCloseFree(pNewFile);
         }

--- a/src/os.c
+++ b/src/os.c
@@ -16,7 +16,7 @@
 #include "sqliteInt.h"
 #if SQLITE_OS_WIN
 # include "os_win.h"
-#elif !defined(SQLITE_WASM)
+#elif !defined(SQLITE_WASM) && !defined(__EMSCRIPTEN__)
 # include <fcntl.h>
 # include <unistd.h>
 #endif
@@ -302,7 +302,7 @@ int sqlite3OsReplaceFile(sqlite3_vfs *pVfs, const char *zTmp, const char *zDest)
   sqlite3_free(zTmpW);
   sqlite3_free(zDestW);
   return rc;
-#elif defined(SQLITE_WASM)
+#elif defined(SQLITE_WASM) || defined(__EMSCRIPTEN__)
   sqlite3_file *pIn = 0;
   sqlite3_file *pOut = 0;
   u8 *aBuf = 0;

--- a/src/os.c
+++ b/src/os.c
@@ -14,6 +14,12 @@
 ** architectures.
 */
 #include "sqliteInt.h"
+#if SQLITE_OS_WIN
+# include "os_win.h"
+#else
+# include <fcntl.h>
+# include <unistd.h>
+#endif
 
 /*
 ** If we compile with the SQLITE_TEST macro set, then the following block
@@ -235,6 +241,115 @@ int sqlite3OsDelete(sqlite3_vfs *pVfs, const char *zPath, int dirSync){
   assert( dirSync==0 || dirSync==1 );
   return pVfs->xDelete!=0 ? pVfs->xDelete(pVfs, zPath, dirSync) : SQLITE_OK;
 }
+
+int sqlite3OsReplaceFile(sqlite3_vfs *pVfs, const char *zTmp, const char *zDest){
+#if SQLITE_OS_WIN
+  int nPath = pVfs->mxPathname + 1;
+  char *zTmpFull = 0;
+  char *zDestFull = 0;
+  WCHAR *zTmpW = 0;
+  WCHAR *zDestW = 0;
+  int nTmp, nDest;
+  int rc;
+
+  zTmpFull = sqlite3_malloc64((sqlite3_uint64)nPath);
+  zDestFull = sqlite3_malloc64((sqlite3_uint64)nPath);
+  if( zTmpFull==0 || zDestFull==0 ){
+    sqlite3_free(zTmpFull);
+    sqlite3_free(zDestFull);
+    return SQLITE_NOMEM;
+  }
+  rc = sqlite3OsFullPathname(pVfs, zTmp, nPath, zTmpFull);
+  if( rc==SQLITE_OK ){
+    rc = sqlite3OsFullPathname(pVfs, zDest, nPath, zDestFull);
+  }
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(zTmpFull);
+    sqlite3_free(zDestFull);
+    return rc;
+  }
+
+  nTmp = MultiByteToWideChar(CP_UTF8, 0, zTmpFull, -1, 0, 0);
+  nDest = MultiByteToWideChar(CP_UTF8, 0, zDestFull, -1, 0, 0);
+  if( nTmp==0 || nDest==0 ){
+    sqlite3_free(zTmpFull);
+    sqlite3_free(zDestFull);
+    return SQLITE_IOERR;
+  }
+
+  zTmpW = sqlite3_malloc64((sqlite3_uint64)nTmp * sizeof(WCHAR));
+  zDestW = sqlite3_malloc64((sqlite3_uint64)nDest * sizeof(WCHAR));
+  if( zTmpW==0 || zDestW==0 ){
+    sqlite3_free(zTmpFull);
+    sqlite3_free(zDestFull);
+    sqlite3_free(zTmpW);
+    sqlite3_free(zDestW);
+    return SQLITE_NOMEM;
+  }
+
+  if( MultiByteToWideChar(CP_UTF8, 0, zTmpFull, -1, zTmpW, nTmp)==0
+   || MultiByteToWideChar(CP_UTF8, 0, zDestFull, -1, zDestW, nDest)==0
+  ){
+    rc = SQLITE_IOERR;
+  }else if( !MoveFileExW(zTmpW, zDestW,
+                         MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH) ){
+    rc = SQLITE_IOERR;
+  }else{
+    rc = SQLITE_OK;
+  }
+  sqlite3_free(zTmpFull);
+  sqlite3_free(zDestFull);
+  sqlite3_free(zTmpW);
+  sqlite3_free(zDestW);
+  return rc;
+#else
+  int rc = SQLITE_OK;
+  char *zDestFull = 0;
+  int nPath = pVfs->mxPathname + 1;
+
+  zDestFull = sqlite3_malloc64((sqlite3_uint64)nPath);
+  if( zDestFull==0 ) return SQLITE_NOMEM;
+  rc = sqlite3OsFullPathname(pVfs, zDest, nPath, zDestFull);
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(zDestFull);
+    return rc;
+  }
+
+  if( rename(zTmp, zDest)!=0 ){
+    rc = SQLITE_IOERR;
+  }else{
+    char *zDir = sqlite3_mprintf("%s", zDestFull);
+    if( zDir==0 ){
+      rc = SQLITE_NOMEM;
+    }else{
+      int k = (int)strlen(zDir);
+      int dfd;
+      while( k>0 && zDir[k-1]!='/' ) k--;
+      if( k>0 ){
+        zDir[k-1] = 0;
+      }else{
+        zDir[0] = '.';
+        zDir[1] = 0;
+      }
+      dfd = open(zDir, O_RDONLY);
+      if( dfd>=0 ){
+        if( fsync(dfd)!=0 ){
+          rc = SQLITE_IOERR_DIR_FSYNC;
+        }
+        if( close(dfd)!=0 && rc==SQLITE_OK ){
+          rc = SQLITE_IOERR_DIR_FSYNC;
+        }
+      }else{
+        rc = SQLITE_IOERR_DIR_FSYNC;
+      }
+      sqlite3_free(zDir);
+    }
+  }
+  sqlite3_free(zDestFull);
+  return rc;
+#endif
+}
+
 int sqlite3OsAccess(
   sqlite3_vfs *pVfs,
   const char *zPath,

--- a/src/os.c
+++ b/src/os.c
@@ -16,7 +16,7 @@
 #include "sqliteInt.h"
 #if SQLITE_OS_WIN
 # include "os_win.h"
-#else
+#elif !defined(SQLITE_WASM)
 # include <fcntl.h>
 # include <unistd.h>
 #endif
@@ -301,6 +301,56 @@ int sqlite3OsReplaceFile(sqlite3_vfs *pVfs, const char *zTmp, const char *zDest)
   sqlite3_free(zDestFull);
   sqlite3_free(zTmpW);
   sqlite3_free(zDestW);
+  return rc;
+#elif defined(SQLITE_WASM)
+  sqlite3_file *pIn = 0;
+  sqlite3_file *pOut = 0;
+  u8 *aBuf = 0;
+  i64 nByte = 0;
+  i64 iOff = 0;
+  int rc;
+
+  rc = sqlite3OsOpenMalloc(pVfs, zTmp, &pIn,
+                           SQLITE_OPEN_READONLY | SQLITE_OPEN_MAIN_DB, 0);
+  if( rc!=SQLITE_OK ) goto wasm_replace_done;
+  rc = sqlite3OsFileSize(pIn, &nByte);
+  if( rc!=SQLITE_OK ) goto wasm_replace_done;
+
+  (void)sqlite3OsDelete(pVfs, zDest, 0);
+  rc = sqlite3OsOpenMalloc(pVfs, zDest, &pOut,
+                           SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE
+                         | SQLITE_OPEN_EXCLUSIVE | SQLITE_OPEN_MAIN_DB, 0);
+  if( rc!=SQLITE_OK ) goto wasm_replace_done;
+
+  aBuf = sqlite3_malloc(65536);
+  if( aBuf==0 ){
+    rc = SQLITE_NOMEM;
+    goto wasm_replace_done;
+  }
+  while( iOff<nByte ){
+    int nCopy = (nByte - iOff) > 65536 ? 65536 : (int)(nByte - iOff);
+    rc = sqlite3OsRead(pIn, aBuf, nCopy, iOff);
+    if( rc!=SQLITE_OK ) break;
+    rc = sqlite3OsWrite(pOut, aBuf, nCopy, iOff);
+    if( rc!=SQLITE_OK ) break;
+    iOff += nCopy;
+  }
+  if( rc==SQLITE_OK ){
+    rc = sqlite3OsTruncate(pOut, nByte);
+  }
+  if( rc==SQLITE_OK ){
+    rc = sqlite3OsSync(pOut, SQLITE_SYNC_NORMAL);
+  }
+
+wasm_replace_done:
+  sqlite3_free(aBuf);
+  if( pIn ) sqlite3OsCloseFree(pIn);
+  if( pOut ) sqlite3OsCloseFree(pOut);
+  if( rc==SQLITE_OK ){
+    (void)sqlite3OsDelete(pVfs, zTmp, 0);
+  }else{
+    (void)sqlite3OsDelete(pVfs, zDest, 0);
+  }
   return rc;
 #else
   int rc = SQLITE_OK;

--- a/src/os.h
+++ b/src/os.h
@@ -202,6 +202,7 @@ int sqlite3OsUnfetch(sqlite3_file *, i64, void *);
 */
 int sqlite3OsOpen(sqlite3_vfs *, const char *, sqlite3_file*, int, int *);
 int sqlite3OsDelete(sqlite3_vfs *, const char *, int);
+int sqlite3OsReplaceFile(sqlite3_vfs *, const char *, const char *);
 int sqlite3OsAccess(sqlite3_vfs *, const char *, int, int *pResOut);
 int sqlite3OsFullPathname(sqlite3_vfs *, const char *, int, char *);
 #ifndef SQLITE_OMIT_LOAD_EXTENSION

--- a/src/pager_shim.c
+++ b/src/pager_shim.c
@@ -1016,8 +1016,8 @@ int sqlite3_backup_step(sqlite3_backup *pBackup, int nPage){
     sqlite3_free(pTmp);
     pTmp = 0;
   }
-  if( rc == SQLITE_OK && rename(zTmpFile, p->zDestFile)!=0 ){
-    rc = SQLITE_IOERR_WRITE;
+  if( rc == SQLITE_OK ){
+    rc = sqlite3OsReplaceFile(p->pDestVfs, zTmpFile, p->zDestFile);
   }
 
 backup_step_done:

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -5286,7 +5286,7 @@ static int prollyBtreeRollback(Btree *p, int tripCode, int writeOnly){
   if( pBt->inCatalogSerialize ) return SQLITE_OK;
 
   if( p->inTrans==TRANS_WRITE ){
-    assert( pBt->store.isMemory || pBt->store.graphLockFd >= 0 );
+    assert( pBt->store.isMemory || pBt->store.pGraphLockFile!=0 );
     assert( pBt->store.isMemory || pBt->store.lockDepth > 0 );
     rc = restoreFromCommitted(p);
     if( rc!=SQLITE_OK ){
@@ -5413,7 +5413,7 @@ static int persistRolledBackSessionState(Btree *p, BtShared *pBt){
   const char *zBr = p->zBranch ? p->zBranch : "main";
   int rc;
 
-  assert( pBt->store.isMemory || pBt->store.graphLockFd >= 0 );
+  assert( pBt->store.isMemory || pBt->store.pGraphLockFile!=0 );
   assert( pBt->store.isMemory || pBt->store.lockDepth > 0 );
 
   rc = serializeCatalog(p, &catData, &nCatData);

--- a/test/chunk_store_fork_lock_test.c
+++ b/test/chunk_store_fork_lock_test.c
@@ -1,0 +1,138 @@
+/*
+** Chunk-store fork-lock regression test.
+**
+** Historically the Unix chunk-store graph lock used open()+flock(). BSD flock
+** state is associated with the open file description, so a child created by
+** fork() inherits a reference that keeps the parent's lock alive after the
+** parent closes its fd. This test holds the chunk-store lock, forks a sleeping
+** child, unlocks in the parent, then verifies that a second ChunkStore can
+** acquire the same lock before the child exits.
+*/
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "sqlite3.h"
+#include "chunk_store.h"
+
+#ifndef _WIN32
+# include <unistd.h>
+# include <sys/types.h>
+# include <sys/wait.h>
+#endif
+
+static int nPass = 0;
+static int nFail = 0;
+
+static void check(const char *name, int condition){
+  if( condition ){
+    nPass++;
+  }else{
+    nFail++;
+    fprintf(stderr, "FAIL: %s\n", name);
+  }
+}
+
+static void rm_db(const char *zPath){
+  char zBuf[512];
+  remove(zPath);
+  snprintf(zBuf, sizeof(zBuf), "%s-lock", zPath);
+  remove(zBuf);
+  snprintf(zBuf, sizeof(zBuf), "%s-wal", zPath);
+  remove(zBuf);
+}
+
+static int exec_sql(sqlite3 *db, const char *zSql){
+  char *zErr = 0;
+  int rc = sqlite3_exec(db, zSql, 0, 0, &zErr);
+  if( zErr ){
+    fprintf(stderr, "exec error: %s\n", zErr);
+    sqlite3_free(zErr);
+  }
+  return rc;
+}
+
+static int create_committed_db(const char *zPath){
+  sqlite3 *db = 0;
+  int rc;
+  rc = sqlite3_open(zPath, &db);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = exec_sql(db,
+    "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);"
+    "INSERT INTO t VALUES(1,'a');"
+    "SELECT dolt_commit('-A','-m','init');"
+  );
+  sqlite3_close(db);
+  return rc;
+}
+
+static void test_fork_child_does_not_keep_parent_lock(void){
+#ifdef _WIN32
+  check("fork_lock_test_skipped_on_windows", 1);
+#else
+  const char *zPath = "/tmp/test_chunk_store_fork_lock.db";
+  sqlite3_vfs *pVfs;
+  ChunkStore cs1, cs2;
+  pid_t pid;
+  int status = 0;
+  int rc;
+
+  printf("--- fork child does not keep released chunk-store lock ---\n");
+  rm_db(zPath);
+  rc = create_committed_db(zPath);
+  check("fork_lock_setup_db", rc==SQLITE_OK);
+  if( rc!=SQLITE_OK ) return;
+
+  pVfs = sqlite3_vfs_find(0);
+  check("fork_lock_has_vfs", pVfs!=0);
+  if( !pVfs ) return;
+
+  rc = chunkStoreOpen(&cs1, pVfs, zPath,
+    SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB);
+  check("fork_lock_open_cs1", rc==SQLITE_OK);
+  if( rc!=SQLITE_OK ) return;
+
+  rc = chunkStoreLockAndRefresh(&cs1);
+  check("fork_lock_acquire_parent", rc==SQLITE_OK);
+  if( rc!=SQLITE_OK ){
+    chunkStoreClose(&cs1);
+    return;
+  }
+
+  pid = fork();
+  check("fork_lock_fork_succeeded", pid>=0);
+  if( pid==0 ){
+    sleep(2);
+    _exit(0);
+  }
+  if( pid<0 ){
+    chunkStoreUnlock(&cs1);
+    chunkStoreClose(&cs1);
+    return;
+  }
+
+  chunkStoreUnlock(&cs1);
+  chunkStoreClose(&cs1);
+
+  rc = chunkStoreOpen(&cs2, pVfs, zPath,
+    SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB);
+  check("fork_lock_open_cs2", rc==SQLITE_OK);
+  if( rc==SQLITE_OK ){
+    rc = chunkStoreLockAndRefresh(&cs2);
+    check("fork_lock_reacquire_while_child_alive", rc==SQLITE_OK);
+    if( rc==SQLITE_OK ) chunkStoreUnlock(&cs2);
+    chunkStoreClose(&cs2);
+  }
+
+  waitpid(pid, &status, 0);
+  check("fork_lock_child_exit_ok", WIFEXITED(status) && WEXITSTATUS(status)==0);
+  rm_db(zPath);
+#endif
+}
+
+int main(void){
+  test_fork_child_does_not_keep_parent_lock();
+
+  printf("\n");
+  printf("chunk_store_fork_lock_test: %d passed, %d failed\n", nPass, nFail);
+  return nFail ? 1 : 0;
+}

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -673,9 +673,12 @@ static int failOpen(sqlite3_vfs *pVfs, const char *zName, sqlite3_file *pFile,
   int rc;
   int nName = zName ? (int)strlen(zName) : 0;
   int isGcTmp = nName>=7 && strcmp(zName+nName-7, "-gc-tmp")==0;
+  int isDoltLiteLock = nName>=5 && strcmp(zName+nName-5, "-lock")==0;
 
   memset(p, 0, sizeof(*p));
-  if( gFailOpenMainOnce>0 && !isGcTmp && (flags & SQLITE_OPEN_MAIN_DB)!=0 ){
+  if( gFailOpenMainOnce>0 && !isGcTmp && !isDoltLiteLock
+   && (flags & SQLITE_OPEN_MAIN_DB)!=0
+  ){
     gFailOpenMainOnce--;
     gFailHits++;
     return SQLITE_CANTOPEN;

--- a/test/fuzz_deserialize_refs.c
+++ b/test/fuzz_deserialize_refs.c
@@ -12,7 +12,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   if (size > (size_t)0x7fffffff) return 0;
 
   memset(&cs, 0, sizeof(cs));
-  cs.graphLockFd = -1;
+  cs.pGraphLockFile = 0;
 
   (void)csDeserializeRefs(&cs, data, (int)size);
 

--- a/test/fuzz_read_index.c
+++ b/test/fuzz_read_index.c
@@ -45,7 +45,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     cs.file.pFile = pFile;
     cs.file.zFilename = sqlite3_mprintf("%s", path);
     cs.file.pVfs = pVfs;
-    cs.graphLockFd = -1;
+    cs.pGraphLockFile = 0;
     cs.index.iIndexOffset = 0;
     cs.index.nIndexSize = (i64)size;
     cs.index.nChunks = 1;

--- a/test/fuzz_replaywal.c
+++ b/test/fuzz_replaywal.c
@@ -49,7 +49,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     cs.file.pFile = pFile;
     cs.file.zFilename = sqlite3_mprintf("%s", path);
     cs.file.pVfs = pVfs;
-    cs.graphLockFd = -1;
+    cs.pGraphLockFile = 0;
     cs.wal.iWalOffset = 1;
 
     (void)csReplayWal(&cs);

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1110,11 +1110,6 @@ shared3 shared3-3.1
 shared3 shared3-3.2
 shared3 shared3-3.3
 shared3 shared3-3.4
-# tempdb-2.2/2.3 assert sqlite_open_file_count (number of OS journal/subjournal
-# handles). doltlite opens no SQLite journal files. The statement-journal rollback
-# behavior the block exercises (UNIQUE violation rolls back, tables intact) matches stock.
-tempdb tempdb-2.2
-tempdb tempdb-2.3
 # tkt-2d1a5c67d-3.6: WAL-checkpoint/recovery test driven by ~99 open incrblob
 # handles + raw test.db-wal file copy; computed value ('xyz') matches stock.
 tkt-2d1a5c67d tkt-2d1a5c67d-3.6

--- a/test/lint_no_raw_os_fileio.sh
+++ b/test/lint_no_raw_os_fileio.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+#
+# DoltLite storage should route filesystem access through SQLite's VFS layer.
+# This lint keeps raw OS file calls out of DoltLite-owned production code.
+#
+# Allowlisted exceptions are either:
+#   - socket/pipe descriptors, not database files;
+#   - the os_kv.c VFS implementation itself;
+#   - atomic rename / directory fsync gaps not represented by sqlite3_vfs.
+
+set -u
+
+SRCDIR="${1:-src}"
+ROOT="$(cd "$SRCDIR/.." && pwd)"
+TMPFILE=$(mktemp)
+trap "rm -f $TMPFILE" EXIT
+
+cd "$ROOT" || exit 2
+shopt -s nullglob
+
+FILES=(
+  src/chunk_*.c src/chunk_*.h
+  src/prolly_*.c src/prolly_*.h
+  src/doltlite*.c src/doltlite*.h
+  src/sortkey.c src/sortkey.h
+  src/pager_shim.c
+  src/os_kv.c
+)
+
+CALL_RE='\b(open|close|read|write|pread|pwrite|lseek|stat|fstat|access|unlink|rename|mkdir|rmdir|remove|fopen|fclose|fread|fwrite|fflush|fsync|fdatasync|flock|fcntl|mmap|munmap)[[:space:]]*\('
+INCLUDE_RE='#[[:space:]]*include[[:space:]]*<((sys/)?stat|fcntl|unistd|sys/file|sys/mman|dirent)\.h>'
+
+raw_matches() {
+  rg -n "$CALL_RE" "${FILES[@]}" 2>/dev/null || true
+  rg -n "$INCLUDE_RE" "${FILES[@]}" 2>/dev/null || true
+}
+
+raw_matches \
+  | grep -Ev '^src/doltlite_remotesrv\.c:[0-9]+:.*\b(read|close)[[:space:]]*\(' \
+  | grep -Ev '^src/doltlite_http_remote\.c:[0-9]+:.*\b(read|close)[[:space:]]*\(' \
+  | grep -Ev '^src/doltlite_remote\.c:[0-9]+:.*\bwrite[[:space:]]*\(' \
+  | grep -Ev '^src/doltlite_gc\.c:[0-9]+:.*\b(rename|open|fsync|close)[[:space:]]*\(' \
+  | grep -Ev '^src/pager_shim\.c:[0-9]+:.*\brename[[:space:]]*\(' \
+  | grep -Ev '^src/os_kv\.c:[0-9]+:.*\b(fopen|fclose|fread|unlink|access|stat)[[:space:]]*\(' \
+  | grep -Ev '^src/(doltlite_remotesrv|doltlite_http_remote|doltlite_remote|doltlite_gc|os_kv)\.c:[0-9]+:#include <unistd\.h>' \
+  | grep -Ev '^src/doltlite_gc\.c:[0-9]+:#include <fcntl\.h>' \
+  | grep -Ev '^src/os_kv\.c:[0-9]+:#include <sys/stat\.h>' \
+  > "$TMPFILE"
+
+NFAIL=$(wc -l < "$TMPFILE" | tr -d ' ')
+if [ "$NFAIL" -eq 0 ]; then
+  echo "lint_no_raw_os_fileio: all checks passed"
+  exit 0
+fi
+
+echo "lint_no_raw_os_fileio: raw OS file IO found in DoltLite-owned code"
+cat "$TMPFILE" | sed 's/^/  /'
+echo ""
+echo "Use sqlite3_vfs/sqlite3Os* APIs for database-file access, or add a narrow"
+echo "allowlist entry with a comment explaining why the VFS cannot express it."
+exit 1

--- a/test/lint_no_raw_os_fileio.sh
+++ b/test/lint_no_raw_os_fileio.sh
@@ -3,10 +3,8 @@
 # DoltLite storage should route filesystem access through SQLite's VFS layer.
 # This lint keeps raw OS file calls out of DoltLite-owned production code.
 #
-# Allowlisted exceptions are either:
-#   - socket/pipe descriptors, not database files;
-#   - the os_kv.c VFS implementation itself;
-#   - atomic rename / directory fsync gaps not represented by sqlite3_vfs.
+# Allowlisted exceptions are either socket/pipe descriptors, not database
+# files, or the os_kv.c VFS implementation itself.
 
 set -u
 
@@ -39,11 +37,8 @@ raw_matches \
   | grep -Ev '^src/doltlite_remotesrv\.c:[0-9]+:.*\b(read|close)[[:space:]]*\(' \
   | grep -Ev '^src/doltlite_http_remote\.c:[0-9]+:.*\b(read|close)[[:space:]]*\(' \
   | grep -Ev '^src/doltlite_remote\.c:[0-9]+:.*\bwrite[[:space:]]*\(' \
-  | grep -Ev '^src/doltlite_gc\.c:[0-9]+:.*\b(rename|open|fsync|close)[[:space:]]*\(' \
-  | grep -Ev '^src/pager_shim\.c:[0-9]+:.*\brename[[:space:]]*\(' \
   | grep -Ev '^src/os_kv\.c:[0-9]+:.*\b(fopen|fclose|fread|unlink|access|stat)[[:space:]]*\(' \
-  | grep -Ev '^src/(doltlite_remotesrv|doltlite_http_remote|doltlite_remote|doltlite_gc|os_kv)\.c:[0-9]+:#include <unistd\.h>' \
-  | grep -Ev '^src/doltlite_gc\.c:[0-9]+:#include <fcntl\.h>' \
+  | grep -Ev '^src/(doltlite_remotesrv|doltlite_http_remote|doltlite_remote|os_kv)\.c:[0-9]+:#include <unistd\.h>' \
   | grep -Ev '^src/os_kv\.c:[0-9]+:#include <sys/stat\.h>' \
   > "$TMPFILE"
 

--- a/test/run_c_tests.sh
+++ b/test/run_c_tests.sh
@@ -27,6 +27,7 @@ GATING=(
   cross_branch_test
   corruption_test
   sequence_reload_test
+  chunk_store_fork_lock_test
 )
 
 run_one() {


### PR DESCRIPTION
## Summary
- replace the Unix-only `open()+flock()` chunk-store graph lock with SQLite VFS file locking
- keep the VFS lock sidecar out of the database filename glob while preserving cross-process lock rendezvous
- route chunk-store file probes and compacted-index reads through `sqlite3_vfs` / `sqlite3Os*` APIs instead of raw `stat()`, `open()`, `mmap()`, or Windows file mapping calls
- move atomic file replacement and directory fsync behavior behind a new internal `sqlite3OsReplaceFile()` OS-layer helper, then use it from DoltLite GC and backup paths
- add and wire a CI lint guard that rejects raw OS file IO in DoltLite-owned production storage code, with narrow exceptions for socket/pipe IO and `os_kv.c` as a VFS implementation
- add a deterministic fork regression test that verifies a child process does not keep a released parent chunk-store lock alive

Fixes #1205.

## Testing
- `make lint`
- `make doltlite chunk_store_fork_lock_test`
- `./chunk_store_fork_lock_test`
- `bash test/doltlite_storage_locking.sh`
- `bash test/doltlite_persistence.sh`
- `make c-tests`
- `clang -O1 -g -DDOLTLITE_PROLLY=1 -D_HAVE_SQLITE_CONFIG_H -I. -Isrc -c test/fuzz_replaywal.c -o /tmp/fuzz_replaywal_check.o`
