### PR TITLE
Fix rollback use-after-free; recover capi3 into the gated testfixture suite

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -5288,17 +5288,28 @@ static int prollyBtreeRollback(Btree *p, int tripCode, int writeOnly){
   if( p->inTrans==TRANS_WRITE ){
     assert( pBt->store.isMemory || pBt->store.graphLockFd >= 0 );
     assert( pBt->store.isMemory || pBt->store.lockDepth > 0 );
+    /* Cursor pending-edit maps alias the catalog's per-table pPending maps,
+    ** which restoreFromCommitted() is about to free. Clear and detach the
+    ** aliases first; touching them after the catalog is freed is a UAF. */
+    {
+      BtCursor *pC;
+      for(pC = pBt->pCursor; pC; pC = pC->pNext){
+        if( pC->pBtree==p && pC->pMutMap ){
+          prollyMutMapClear(pC->pMutMap);
+          pC->pMutMap = 0;
+          pC->mmActive = 0;
+          pC->mmPhysActive = 0;
+          pC->deferredTreeSeek = 0;
+          pC->mmIdx = -1;
+          pC->mmPhysIdx = -1;
+        }
+      }
+    }
     rc = restoreFromCommitted(p);
     if( rc!=SQLITE_OK ){
       chunkStoreUnlock(&pBt->store);
       pBt->store.snapshotPinned = 0;
       return rc;
-    }
-    {
-      BtCursor *pC;
-      for(pC = pBt->pCursor; pC; pC = pC->pNext){
-        if( pC->pBtree==p && pC->pMutMap ) prollyMutMapClear(pC->pMutMap);
-      }
     }
     invalidateCursors(pBt, 0, tripCode ? tripCode : SQLITE_ABORT);
     invalidateSchema(p);

--- a/src/test_config.c
+++ b/src/test_config.c
@@ -41,6 +41,12 @@
 ** procedures use this to determine when tests should be omitted.
 */
 static void set_options(Tcl_Interp *interp){
+#ifdef DOLTLITE_PROLLY
+  Tcl_SetVar2(interp, "sqlite_options", "doltlite", "1", TCL_GLOBAL_ONLY);
+#else
+  Tcl_SetVar2(interp, "sqlite_options", "doltlite", "0", TCL_GLOBAL_ONLY);
+#endif
+
 #if HAVE_MALLOC_USABLE_SIZE
   Tcl_SetVar2(interp, "sqlite_options", "malloc_usable_size", "1",
               TCL_GLOBAL_ONLY);

--- a/test/capi3.test
+++ b/test/capi3.test
@@ -716,6 +716,10 @@ proc get_file_format {{fname test.db}} {
   return [hexio_get_int [hexio_read $fname 44 4]]
 }
 
+# doltlite stores offsets 40/44 inside its checksummed manifest, so the raw
+# file-format poke below corrupts the manifest and is rejected at open() rather
+# than surfacing "unsupported file format" lazily. No prolly equivalent exists.
+ifcapable {!doltlite} {
 if {![sqlite3 -has-codec]} {
   # Test what happens when the library encounters a newer file format.
   do_test capi3-7.1 {
@@ -728,6 +732,7 @@ if {![sqlite3 -has-codec]} {
     }
   } {1 {unsupported file format}}
   db close
+}
 }
 
 if {![sqlite3 -has-codec]} {

--- a/test/known_testfixture_crashes.txt
+++ b/test/known_testfixture_crashes.txt
@@ -13,14 +13,21 @@
 # OBJECT build too (USE_AMALGAMATION=0), i.e. they are pre-existing doltlite
 # issues, investigated and tracked in issue #1119:
 #
-#   capi3 / fkey2 abort on raw stock on-disk-format tests (set_file_format/hexio),
+#   fkey2 aborts on raw stock on-disk-format tests (set_file_format/hexio),
 #   which doltlite's prolly format has no equivalent for — a format divergence
 #   rather than a bug.
 #
 # Cross-db (ATTACHed) writes now work (a freshly attached db gets its default
 # branch created on first persist), so e_createtable, e_update, and alter
 # complete and moved to the divergence file.
-capi3    # aborts on set_file_format (raw stock page format; doltlite uses prolly)
+#
+# capi3 was here too. Its raw file-format block (capi3-7.x) pokes the sqlite
+# page header, which lands inside prolly's checksummed manifest; it is now
+# gated out with `ifcapable {!doltlite}`. Running past that abort exposed a
+# use-after-free in prollyBtreeRollback (cursor pending-map aliases were
+# cleared after restoreFromCommitted had already freed them), now fixed. capi3
+# reaches its summary line; its remaining C-API divergences are recorded in
+# the divergence file.
 # Additional crash/timeout files from the full capture (issue #1119):
 crash8        # crash-recovery simulation; incompatible with prolly format / times out
 fuzz3         # raw byte-corruption fuzz mutates test.db offsets; prolly storage aborts after restore/checksum

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1137,3 +1137,20 @@ vacuum2 vacuum2-4.2
 vacuum2 vacuum2-4.4
 vacuum2 vacuum2-4.5
 vacuum2 vacuum2-4.7
+
+# capi3 — C-API behaviors that diverge from stock sqlite at the error-code,
+# open-timing, locking, and catalog level (not row data). Recovered into the
+# gated suite after the capi3-7.x raw file-format block was gated out and the
+# prollyBtreeRollback use-after-free was fixed.
+capi3 capi3-3.3    # bogus-path open: doltlite defers the open error (SQLITE_OK) vs stock SQLITE_CANTOPEN
+capi3 capi3-3.4    # same: errmsg "not an error" vs "unable to open database file"
+capi3 capi3-4.3    # bogus-path open16: deferred open error vs SQLITE_CANTOPEN
+capi3 capi3-4.4    # same (utf16 errmsg)
+capi3 capi3-8.3    # writable_schema sqlite_master corruption undetected: prolly catalog isn't the raw sqlite_master row store
+capi3 capi3-8.5    # same: injected bogus sqlite_master row doesn't malform the prolly catalog
+capi3 capi3-11.3.4 # PRAGMA lock_status reports doltlite's locking model ("main unlocked" vs "main shared")
+capi3 capi3-11.5   # finalize after COMMIT-during-active-read: SQLITE_ABORT vs SQLITE_ERROR
+capi3 capi3-11.10  # step after ROLLBACK-during-active-read: cursor faulted (SQLITE_ERROR) vs stock auto-reset+rerun (SQLITE_ROW)
+capi3 capi3-11.11  # same statement, next step: SQLITE_ERROR vs SQLITE_DONE
+capi3 capi3-11.12  # same: SQLITE_ERROR vs SQLITE_ROW
+capi3 capi3-11.13  # finalize of the faulted statement: SQLITE_ERROR vs SQLITE_OK


### PR DESCRIPTION
## Summary
`capi3` was on `known_testfixture_crashes.txt` (whole-file skip). Triaging that skip recovered the file into the CI-gated suite **and uncovered a real heap-use-after-free** that the skip had been masking.

### Root cause of the skip
`capi3-7.x` pokes the sqlite page header at offsets 40/44 (`set_file_format`). Those bytes land inside doltlite's checksummed manifest, so doltlite rejects the corrupted file at `open()`. `sqlite3 db test.db` therefore throws, `db` is never created, and the top-level `db close` aborts the whole file before its summary line — which the harness counts as a crash.

### The masked bug (heap-use-after-free)
Once `capi3-7.x` is gated out and the file runs on, `capi3-11.9.2` (`ROLLBACK` with a live read cursor) trips a UAF under ASan:

```
ERROR: AddressSanitizer: heap-use-after-free in prollyMutMapClear
  prollyBtreeRollback -> prollyMutMapClear   (reads freed map)
freed by: prollyBtreeRollback -> restoreFromCommitted -> deserializeCatalog
          -> btreeFreeCatalogTables -> catFree
```

Cursor `pMutMap` pointers alias the catalog's per-table `pPending` maps. `restoreFromCommitted()` frees those maps, but the cursor aliases were cleared **afterward**. Fix: clear + detach the cursor aliases **before** `restoreFromCommitted()` frees the catalog.

## Changes
- **`src/prolly_btree.c`** — fix the UAF: clear/detach cursor pending-map aliases before the catalog is freed in `prollyBtreeRollback`.
- **`src/test_config.c`** — add a `doltlite` `ifcapable` token (gated by `#ifdef DOLTLITE_PROLLY`) so upstream `.test` files can fence off behavior with no prolly equivalent instead of silently forking.
- **`test/capi3.test`** — gate the raw file-format block (`capi3-7.x`) with `ifcapable {!doltlite}`.
- **`known_testfixture_crashes.txt`** — remove `capi3`, with a note on the resolution.
- **`known_testfixture_divergences.txt`** — record the 12 remaining C-API / open-timing / locking / catalog divergences, each with a reason.

## Result
- `capi3` goes from a whole-file crash-skip (0 gated tests) to **247 tests: 235 pass, 12 known divergences**, `run_testfixture.sh` exit 0.
- Verified under the ASan testfixture build. The gated rollback/transaction tests (`trans`, `savepoint`, `savepoint2/4`, `rollback`, `capi2`) still pass with the fix; the fix was confirmed against a clean master baseline (no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)