### PR TITLE
Add workspace tables for partial row staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,8 @@ gcc -o myapp myapp.c -I/path/to/build -L/path/to/build -ldoltlite -lpthread -lz
 The API is the standard [SQLite C API](https://sqlite.org/cintro.html) —
 `sqlite3_open`, `sqlite3_exec`, `sqlite3_prepare_v2`, etc. Dolt features are
 called as SQL functions (`dolt_commit`, `dolt_branch`, `dolt_merge`, ...) and
-virtual tables (`dolt_log`, `dolt_diff_<table>`, `dolt_history_<table>`, ...).
+virtual tables (`dolt_log`, `dolt_diff_<table>`, `dolt_workspace_<table>`,
+`dolt_history_<table>`, ...).
 
 ### Quickstart Examples
 
@@ -280,6 +281,26 @@ SELECT * FROM dolt_status;
 -- users      | 1      | modified
 -- orders     | 0      | new table
 ```
+
+#### Workspace Tables
+
+`dolt_workspace_<table>` exposes row-level working/staged changes and lets
+you stage or unstage individual edits by updating `staged`:
+
+```sql
+SELECT id, staged, diff_type, to_id, to_rating, to_confidence,
+       from_rating, from_confidence
+  FROM dolt_workspace_ratings;
+
+UPDATE dolt_workspace_ratings
+   SET staged = TRUE
+ WHERE to_confidence > from_confidence;
+
+SELECT dolt_commit('-m', 'accept higher-confidence edits');
+```
+
+`DELETE FROM dolt_workspace_<table>` and row-level staging on tables with
+secondary indexes are not implemented yet.
 
 #### Ignoring Tables (`dolt_ignore`)
 
@@ -911,6 +932,7 @@ bash ../test/run_doltlite_tests.sh
 bash ../test/doltlite_parity.sh          # SQLite compatibility (119 tests)
 bash ../test/doltlite_commit.sh          # Commits and log
 bash ../test/doltlite_staging.sh         # Add, status, staging
+bash ../test/doltlite_workspace.sh       # Workspace tables and partial row staging
 bash ../test/doltlite_branch.sh          # Branching and checkout
 bash ../test/doltlite_merge.sh           # Three-way merge
 bash ../test/doltlite_attach_sqlite.sh   # ATTACH standard SQLite databases
@@ -919,12 +941,14 @@ bash ../test/doltlite_attach_sqlite.sh   # ATTACH standard SQLite databases
 ### Differential Oracle Tests
 
 Doltlite ships a suite of differential oracle tests that run the same SQL
-through doltlite and stock sqlite3 and compare results byte-for-byte. Each
+through doltlite and stock sqlite3, or through doltlite and Dolt for
+version-control behavior, and compare results byte-for-byte. Each
 script is focused on a SQL feature surface — savepoints, foreign keys,
 UPSERT, generated columns, WITHOUT ROWID, large BLOBs at chunk boundaries,
 ATTACH cross-engine queries, TEMP tables, triggers, dot-commands, FTS5 —
-and scenarios are written to hit storage-layer edge cases. The oracles
-drove most of the correctness fixes in recent releases.
+workspace staging, and version-control operations — and scenarios are written
+to hit storage-layer edge cases. The oracles drove most of the correctness
+fixes in recent releases.
 
 ```bash
 cd build
@@ -939,6 +963,7 @@ bash ../test/oracle_attach_test.sh ./doltlite ./sqlite3
 bash ../test/oracle_temp_tables_test.sh ./doltlite ./sqlite3
 bash ../test/oracle_triggers_test.sh ./doltlite ./sqlite3
 bash ../test/oracle_fts5_test.sh ./doltlite ./sqlite3
+bash ../test/vc_oracle_workspace_test.sh ./doltlite dolt
 ```
 
 A separate CI job builds the same suite with

--- a/main.mk
+++ b/main.mk
@@ -579,7 +579,7 @@ PROLLY_OBJS = prolly_hash.o prolly_xxhash.o blake3.o blake3_portable.o blake3_di
               chunk_store.o chunk_wal.o chunk_refs.o chunk_index.o chunk_staging.o chunk_file.o prolly_cursor.o prolly_mutmap.o prolly_chunker.o \
               prolly_mutate.o prolly_check.o prolly_diff.o prolly_three_way_diff.o prolly_three_way_merge.o prolly_btree.o pager_shim.o sortkey.o \
               doltlite.o doltlite_commit.o doltlite_ref.o doltlite_log.o doltlite_commit_ancestors.o doltlite_status.o \
-              doltlite_diff.o doltlite_diff_table.o doltlite_branch.o doltlite_tag.o doltlite_ancestor.o doltlite_merge.o doltlite_schema_merge.o doltlite_conflicts.o \
+              doltlite_diff.o doltlite_diff_table.o doltlite_workspace.o doltlite_branch.o doltlite_tag.o doltlite_ancestor.o doltlite_merge.o doltlite_schema_merge.o doltlite_conflicts.o \
               doltlite_gc.o doltlite_chunk_walk.o doltlite_history.o doltlite_at.o doltlite_blame.o doltlite_schema_diff.o doltlite_schemas.o doltlite_diff_stat.o doltlite_record.o \
               doltlite_ignore.o doltlite_hashof.o \
               doltlite_constraint_violations.o \
@@ -619,7 +619,7 @@ ifeq ($(DOLTLITE_PROLLY),1)
     $(TOP)/src/chunk_staging.c $(TOP)/src/chunk_file.c \
     $(TOP)/src/doltlite.c $(TOP)/src/doltlite_commit.c $(TOP)/src/doltlite_ref.c \
     $(TOP)/src/doltlite_log.c $(TOP)/src/doltlite_commit_ancestors.c \
-    $(TOP)/src/doltlite_status.c $(TOP)/src/doltlite_diff.c $(TOP)/src/doltlite_diff_table.c \
+    $(TOP)/src/doltlite_status.c $(TOP)/src/doltlite_diff.c $(TOP)/src/doltlite_diff_table.c $(TOP)/src/doltlite_workspace.c \
     $(TOP)/src/doltlite_branch.c $(TOP)/src/doltlite_tag.c $(TOP)/src/doltlite_ancestor.c \
     $(TOP)/src/doltlite_merge.c $(TOP)/src/doltlite_schema_merge.c \
     $(TOP)/src/doltlite_conflicts.c $(TOP)/src/doltlite_gc.c $(TOP)/src/doltlite_chunk_walk.c \
@@ -1528,6 +1528,9 @@ doltlite_chunk_walk.o:	$(TOP)/src/doltlite_chunk_walk.c $(DEPS_OBJ_COMMON)
 
 doltlite_diff_table.o:	$(TOP)/src/doltlite_diff_table.c $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/doltlite_diff_table.c
+
+doltlite_workspace.o:	$(TOP)/src/doltlite_workspace.c $(DEPS_OBJ_COMMON)
+	$(T.cc.sqlite) -c $(TOP)/src/doltlite_workspace.c
 
 doltlite_history.o:	$(TOP)/src/doltlite_history.c $(DEPS_OBJ_COMMON)
 	$(T.cc.sqlite) -c $(TOP)/src/doltlite_history.c

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -70,6 +70,7 @@ extern int doltliteRegisterConflictTables(sqlite3 *db);
 extern int doltliteTagRegister(sqlite3 *db);
 extern int doltliteGcRegister(sqlite3 *db);
 extern int doltliteRegisterDiffTables(sqlite3 *db);
+extern int doltliteRegisterWorkspaceTables(sqlite3 *db);
 extern int doltliteAncestorRegister(sqlite3 *db);
 extern int doltliteRegisterAtTables(sqlite3 *db);
 extern int doltliteRegisterHistoryTables(sqlite3 *db);
@@ -2021,6 +2022,11 @@ static void doltliteCommitFunc(
   doltliteHashToHex(&commitHash, hexBuf);
 
   rc = doltliteRegisterDiffTables(db);
+  if( rc!=SQLITE_OK ){
+    sqlite3_result_error_code(context, rc);
+    return;
+  }
+  rc = doltliteRegisterWorkspaceTables(db);
   if( rc!=SQLITE_OK ){
     sqlite3_result_error_code(context, rc);
     return;
@@ -5012,6 +5018,7 @@ void doltliteRegister(sqlite3 *db){
   if( doltliteConflictsRegister(db)!=SQLITE_OK ) return;
   if( doltliteGcRegister(db)!=SQLITE_OK ) return;
   if( doltliteRegisterDiffTables(db)!=SQLITE_OK ) return;
+  if( doltliteRegisterWorkspaceTables(db)!=SQLITE_OK ) return;
   if( doltliteAncestorRegister(db)!=SQLITE_OK ) return;
   if( doltliteRegisterAtTables(db)!=SQLITE_OK ) return;
   if( doltliteRegisterHistoryTables(db)!=SQLITE_OK ) return;

--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -558,11 +558,14 @@ static int checkoutLoadAndApply(
 static int refreshBranchScopedTables(sqlite3 *db){
   int rc;
   extern int doltliteRegisterDiffTables(sqlite3 *db);
+  extern int doltliteRegisterWorkspaceTables(sqlite3 *db);
   extern int doltliteRegisterHistoryTables(sqlite3 *db);
   extern int doltliteRegisterAtTables(sqlite3 *db);
   extern int doltliteRegisterBlameTables(sqlite3 *db);
 
   rc = doltliteRegisterDiffTables(db);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = doltliteRegisterWorkspaceTables(db);
   if( rc!=SQLITE_OK ) return rc;
   rc = doltliteRegisterHistoryTables(db);
   if( rc!=SQLITE_OK ) return rc;

--- a/src/doltlite_workspace.c
+++ b/src/doltlite_workspace.c
@@ -1,0 +1,515 @@
+
+#ifdef DOLTLITE_PROLLY
+
+#include "sqliteInt.h"
+#include "prolly_hash.h"
+#include "prolly_diff.h"
+#include "prolly_mutate.h"
+#include "prolly_cache.h"
+#include "chunk_store.h"
+#include "doltlite_commit.h"
+#include "doltlite_record.h"
+#include "doltlite_internal.h"
+
+#include <string.h>
+
+typedef struct WorkspaceRow WorkspaceRow;
+struct WorkspaceRow {
+  i64 rowid;
+  int staged;
+  u8 diffType;
+  u8 flags;
+  u8 *pKey; int nKey; i64 intKey;
+  u8 *pOldVal; int nOldVal;
+  u8 *pNewVal; int nNewVal;
+};
+
+typedef struct WorkspaceVtab WorkspaceVtab;
+struct WorkspaceVtab {
+  sqlite3_vtab base;
+  sqlite3 *db;
+  char *zTableName;
+  DoltliteColInfo cols;
+  WorkspaceRow *aCache;
+  int nCache;
+};
+
+typedef struct WorkspaceCursor WorkspaceCursor;
+struct WorkspaceCursor {
+  sqlite3_vtab_cursor base;
+  int iRow;
+};
+
+static void wsFreeRows(WorkspaceRow *aRow, int nRow){
+  int i;
+  for(i=0; i<nRow; i++){
+    sqlite3_free(aRow[i].pKey);
+    sqlite3_free(aRow[i].pOldVal);
+    sqlite3_free(aRow[i].pNewVal);
+  }
+  sqlite3_free(aRow);
+}
+
+static void wsClearCache(WorkspaceVtab *p){
+  wsFreeRows(p->aCache, p->nCache);
+  p->aCache = 0;
+  p->nCache = 0;
+}
+
+static char *wsBuildSchema(DoltliteColInfo *ci){
+  sqlite3_str *pStr = sqlite3_str_new(0);
+  char *z;
+  int i;
+  if( !pStr ) return 0;
+  sqlite3_str_appendall(pStr, "CREATE TABLE x(id INTEGER, staged INTEGER, diff_type TEXT");
+  for(i=0; i<ci->nCol; i++){
+    char *z = sqlite3_mprintf("to_%s", ci->azName[i] ? ci->azName[i] : "");
+    if( !z ){ sqlite3_str_reset(pStr); return 0; }
+    sqlite3_str_appendall(pStr, ", ");
+    if( doltliteAppendQuotedIdent(pStr, z)!=SQLITE_OK ){
+      sqlite3_free(z);
+      sqlite3_str_reset(pStr);
+      return 0;
+    }
+    sqlite3_free(z);
+  }
+  for(i=0; i<ci->nCol; i++){
+    char *z = sqlite3_mprintf("from_%s", ci->azName[i] ? ci->azName[i] : "");
+    if( !z ){ sqlite3_str_reset(pStr); return 0; }
+    sqlite3_str_appendall(pStr, ", ");
+    if( doltliteAppendQuotedIdent(pStr, z)!=SQLITE_OK ){
+      sqlite3_free(z);
+      sqlite3_str_reset(pStr);
+      return 0;
+    }
+    sqlite3_free(z);
+  }
+  sqlite3_str_appendall(pStr, ")");
+  z = sqlite3_str_finish(pStr);
+  return z;
+}
+
+static int wsLoadTableRoot(
+  sqlite3 *db,
+  const ProllyHash *pCatHash,
+  const char *zTableName,
+  ProllyHash *pRoot,
+  u8 *pFlags,
+  ProllyHash *pSchemaHash
+){
+  struct TableEntry *aTables = 0;
+  int nTables = 0;
+  struct TableEntry *pEntry;
+  int rc;
+
+  memset(pRoot, 0, sizeof(*pRoot));
+  if( pFlags ) *pFlags = 0;
+  if( pSchemaHash ) memset(pSchemaHash, 0, sizeof(*pSchemaHash));
+  rc = doltliteLoadCatalog(db, pCatHash, &aTables, &nTables, 0);
+  if( rc!=SQLITE_OK ) return rc;
+  pEntry = doltliteFindTableByName(aTables, nTables, zTableName);
+  if( pEntry ){
+    memcpy(pRoot, &pEntry->root, sizeof(*pRoot));
+    if( pFlags ) *pFlags = pEntry->flags;
+    if( pSchemaHash ) memcpy(pSchemaHash, &pEntry->schemaHash, sizeof(*pSchemaHash));
+  }
+  doltliteFreeCatalog(aTables, nTables);
+  return SQLITE_OK;
+}
+
+static int wsAppendRow(
+  WorkspaceVtab *pVtab,
+  int staged,
+  u8 flags,
+  const ProllyDiffChange *pChange
+){
+  WorkspaceRow *aNew;
+  WorkspaceRow *r;
+  aNew = sqlite3_realloc(pVtab->aCache,
+                         (pVtab->nCache+1)*(int)sizeof(WorkspaceRow));
+  if( !aNew ) return SQLITE_NOMEM;
+  pVtab->aCache = aNew;
+  r = &pVtab->aCache[pVtab->nCache];
+  memset(r, 0, sizeof(*r));
+  r->rowid = pVtab->nCache + 1;
+  r->staged = staged;
+  r->diffType = pChange->type;
+  r->flags = flags;
+  r->intKey = pChange->intKey;
+  if( pChange->nKey>0 ){
+    r->pKey = sqlite3_malloc(pChange->nKey);
+    if( !r->pKey ) return SQLITE_NOMEM;
+    memcpy(r->pKey, pChange->pKey, pChange->nKey);
+    r->nKey = pChange->nKey;
+  }
+  if( pChange->nOldVal>0 ){
+    r->pOldVal = sqlite3_malloc(pChange->nOldVal);
+    if( !r->pOldVal ) return SQLITE_NOMEM;
+    memcpy(r->pOldVal, pChange->pOldVal, pChange->nOldVal);
+    r->nOldVal = pChange->nOldVal;
+  }
+  if( pChange->nNewVal>0 ){
+    r->pNewVal = sqlite3_malloc(pChange->nNewVal);
+    if( !r->pNewVal ) return SQLITE_NOMEM;
+    memcpy(r->pNewVal, pChange->pNewVal, pChange->nNewVal);
+    r->nNewVal = pChange->nNewVal;
+  }
+  pVtab->nCache++;
+  return SQLITE_OK;
+}
+
+static int wsDiffPair(
+  WorkspaceVtab *pVtab,
+  const ProllyHash *pFromRoot,
+  const ProllyHash *pToRoot,
+  u8 flags,
+  int staged
+){
+  ChunkStore *cs = doltliteGetChunkStore(pVtab->db);
+  ProllyCache *pCache = doltliteGetCache(pVtab->db);
+  ProllyDiffIter iter;
+  ProllyDiffChange *pChange = 0;
+  int rc;
+  if( !cs || !pCache ) return SQLITE_OK;
+  if( prollyHashCompare(pFromRoot, pToRoot)==0 ) return SQLITE_OK;
+  rc = prollyDiffIterOpen(&iter, cs, pCache, pFromRoot, pToRoot, flags);
+  if( rc!=SQLITE_OK ) return rc;
+  while( (rc = prollyDiffIterStep(&iter, &pChange))==SQLITE_ROW && pChange ){
+    rc = wsAppendRow(pVtab, staged, flags, pChange);
+    if( rc!=SQLITE_OK ) break;
+  }
+  prollyDiffIterClose(&iter);
+  if( rc==SQLITE_DONE ) rc = SQLITE_OK;
+  return rc;
+}
+
+static int wsLoadRows(WorkspaceVtab *pVtab){
+  sqlite3 *db = pVtab->db;
+  ProllyHash headHash, headCat, stagedCat, workingCat;
+  ProllyHash headRoot, stagedRoot, workingRoot;
+  ProllyHash schemaHash;
+  DoltliteCommit headCommit;
+  u8 headFlags = 0, stagedFlags = 0, workingFlags = 0;
+  int rc;
+
+  wsClearCache(pVtab);
+  memset(&headCommit, 0, sizeof(headCommit));
+  memset(&headCat, 0, sizeof(headCat));
+  memset(&stagedCat, 0, sizeof(stagedCat));
+  memset(&workingCat, 0, sizeof(workingCat));
+
+  doltliteGetSessionHead(db, &headHash);
+  if( prollyHashIsEmpty(&headHash) ) return SQLITE_OK;
+  rc = doltliteLoadCommit(db, &headHash, &headCommit);
+  if( rc!=SQLITE_OK ) return rc;
+  headCat = headCommit.catalogHash;
+  doltliteCommitClear(&headCommit);
+
+  doltliteGetSessionStaged(db, &stagedCat);
+  if( prollyHashIsEmpty(&stagedCat) ) stagedCat = headCat;
+  rc = doltliteFlushCatalogToHash(db, &workingCat);
+  if( rc!=SQLITE_OK ) return rc;
+
+  rc = wsLoadTableRoot(db, &headCat, pVtab->zTableName,
+                       &headRoot, &headFlags, &schemaHash);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = wsLoadTableRoot(db, &stagedCat, pVtab->zTableName,
+                       &stagedRoot, &stagedFlags, &schemaHash);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = wsLoadTableRoot(db, &workingCat, pVtab->zTableName,
+                       &workingRoot, &workingFlags, &schemaHash);
+  if( rc!=SQLITE_OK ) return rc;
+
+  if( !stagedFlags ) stagedFlags = headFlags ? headFlags : workingFlags;
+  if( !workingFlags ) workingFlags = stagedFlags ? stagedFlags : headFlags;
+  rc = wsDiffPair(pVtab, &headRoot, &stagedRoot, stagedFlags, 1);
+  if( rc==SQLITE_OK ){
+    rc = wsDiffPair(pVtab, &stagedRoot, &workingRoot, workingFlags, 0);
+  }
+  return rc;
+}
+
+static int wsConnect(sqlite3 *db, void *pAux, int argc,
+    const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){
+  WorkspaceVtab *pVtab;
+  const char *zModName;
+  char *zSchema;
+  int rc;
+  (void)pAux;
+
+  pVtab = sqlite3_malloc(sizeof(*pVtab));
+  if( !pVtab ) return SQLITE_NOMEM;
+  memset(pVtab, 0, sizeof(*pVtab));
+  pVtab->db = db;
+  zModName = argv[0];
+  if( zModName && strncmp(zModName, "dolt_workspace_", 15)==0 ){
+    pVtab->zTableName = sqlite3_mprintf("%s", zModName + 15);
+  }else if( argc>3 ){
+    pVtab->zTableName = sqlite3_mprintf("%s", argv[3]);
+  }else{
+    pVtab->zTableName = sqlite3_mprintf("");
+  }
+  rc = doltliteLoadUserTableColumns(db, pVtab->zTableName, &pVtab->cols, pzErr);
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(pVtab->zTableName);
+    sqlite3_free(pVtab);
+    return rc;
+  }
+  zSchema = wsBuildSchema(&pVtab->cols);
+  if( !zSchema ){
+    doltliteFreeColInfo(&pVtab->cols);
+    sqlite3_free(pVtab->zTableName);
+    sqlite3_free(pVtab);
+    return SQLITE_NOMEM;
+  }
+  rc = sqlite3_declare_vtab(db, zSchema);
+  sqlite3_free(zSchema);
+  if( rc!=SQLITE_OK ){
+    doltliteFreeColInfo(&pVtab->cols);
+    sqlite3_free(pVtab->zTableName);
+    sqlite3_free(pVtab);
+    return rc;
+  }
+  *ppVtab = &pVtab->base;
+  return SQLITE_OK;
+}
+
+static int wsDisconnect(sqlite3_vtab *pBase){
+  WorkspaceVtab *p = (WorkspaceVtab*)pBase;
+  wsClearCache(p);
+  doltliteFreeColInfo(&p->cols);
+  sqlite3_free(p->zTableName);
+  sqlite3_free(p);
+  return SQLITE_OK;
+}
+
+static int wsBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
+  (void)pVtab;
+  pInfo->estimatedCost = 1000.0;
+  return SQLITE_OK;
+}
+
+static int wsOpen(sqlite3_vtab *pVtab, sqlite3_vtab_cursor **pp){
+  (void)pVtab;
+  return doltliteVtabOpenCursor(pp, sizeof(WorkspaceCursor));
+}
+
+static int wsClose(sqlite3_vtab_cursor *cur){
+  sqlite3_free(cur);
+  return SQLITE_OK;
+}
+
+static int wsFilter(sqlite3_vtab_cursor *cur,
+    int idxNum, const char *idxStr, int argc, sqlite3_value **argv){
+  WorkspaceCursor *c = (WorkspaceCursor*)cur;
+  WorkspaceVtab *p = (WorkspaceVtab*)cur->pVtab;
+  (void)idxNum; (void)idxStr; (void)argc; (void)argv;
+  c->iRow = 0;
+  return wsLoadRows(p);
+}
+
+static int wsNext(sqlite3_vtab_cursor *cur){
+  ((WorkspaceCursor*)cur)->iRow++;
+  return SQLITE_OK;
+}
+
+static int wsEof(sqlite3_vtab_cursor *cur){
+  WorkspaceCursor *c = (WorkspaceCursor*)cur;
+  WorkspaceVtab *p = (WorkspaceVtab*)cur->pVtab;
+  return c->iRow >= p->nCache;
+}
+
+static int wsColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
+  WorkspaceCursor *c = (WorkspaceCursor*)cur;
+  WorkspaceVtab *p = (WorkspaceVtab*)cur->pVtab;
+  WorkspaceRow *r = &p->aCache[c->iRow];
+  int nCols = p->cols.nCol;
+  if( col==0 ){
+    sqlite3_result_int64(ctx, r->rowid);
+  }else if( col==1 ){
+    sqlite3_result_int(ctx, r->staged);
+  }else if( col==2 ){
+    switch( r->diffType ){
+      case PROLLY_DIFF_ADD:    sqlite3_result_text(ctx,"added",-1,SQLITE_STATIC); break;
+      case PROLLY_DIFF_DELETE: sqlite3_result_text(ctx,"removed",-1,SQLITE_STATIC); break;
+      case PROLLY_DIFF_MODIFY: sqlite3_result_text(ctx,"modified",-1,SQLITE_STATIC); break;
+      default: sqlite3_result_null(ctx); break;
+    }
+  }else if( col>=3 && col<3+nCols ){
+    doltliteResultUserCol(ctx, &p->cols, r->pNewVal, r->nNewVal,
+                          r->intKey, col-3);
+  }else if( col>=3+nCols && col<3+2*nCols ){
+    doltliteResultUserCol(ctx, &p->cols, r->pOldVal, r->nOldVal,
+                          r->intKey, col-3-nCols);
+  }else{
+    sqlite3_result_null(ctx);
+  }
+  return SQLITE_OK;
+}
+
+static int wsRowid(sqlite3_vtab_cursor *cur, sqlite3_int64 *pRowid){
+  WorkspaceCursor *c = (WorkspaceCursor*)cur;
+  WorkspaceVtab *p = (WorkspaceVtab*)cur->pVtab;
+  *pRowid = p->aCache[c->iRow].rowid;
+  return SQLITE_OK;
+}
+
+static WorkspaceRow *wsFindCachedRow(WorkspaceVtab *p, i64 rowid){
+  int i;
+  for(i=0; i<p->nCache; i++){
+    if( p->aCache[i].rowid==rowid ) return &p->aCache[i];
+  }
+  return 0;
+}
+
+static int wsPatchCatalogRoot(
+  sqlite3 *db,
+  const ProllyHash *pCatHash,
+  const char *zTableName,
+  const ProllyHash *pNewRoot,
+  ProllyHash *pNewCatHash
+){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  struct TableEntry *aTables = 0;
+  int nTables = 0;
+  struct TableEntry *pEntry;
+  u8 *pData = 0;
+  int nData = 0;
+  int rc;
+  if( !cs ) return SQLITE_ERROR;
+  rc = doltliteLoadCatalog(db, pCatHash, &aTables, &nTables, 0);
+  if( rc!=SQLITE_OK ) return rc;
+  pEntry = doltliteFindTableByName(aTables, nTables, zTableName);
+  if( !pEntry ){
+    doltliteFreeCatalog(aTables, nTables);
+    return SQLITE_NOTFOUND;
+  }
+  pEntry->root = *pNewRoot;
+  rc = doltliteSerializeCatalogEntries(db, aTables, nTables, &pData, &nData);
+  if( rc==SQLITE_OK ){
+    rc = chunkStorePut(cs, pData, nData, pNewCatHash);
+  }
+  sqlite3_free(pData);
+  doltliteFreeCatalog(aTables, nTables);
+  return rc;
+}
+
+static int wsApplyRowToStaged(WorkspaceVtab *p, WorkspaceRow *r, int makeStaged){
+  sqlite3 *db = p->db;
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  ProllyCache *pCache = doltliteGetCache(db);
+  ProllyHash headHash, headCat, stagedCat, stagedRoot, headRoot, newRoot, newCat;
+  DoltliteCommit headCommit;
+  u8 flags = r->flags;
+  int rc;
+
+  if( !cs || !pCache ) return SQLITE_ERROR;
+  memset(&headCommit, 0, sizeof(headCommit));
+  doltliteGetSessionHead(db, &headHash);
+  if( prollyHashIsEmpty(&headHash) ) return SQLITE_ERROR;
+  rc = doltliteLoadCommit(db, &headHash, &headCommit);
+  if( rc!=SQLITE_OK ) return rc;
+  headCat = headCommit.catalogHash;
+  doltliteCommitClear(&headCommit);
+
+  doltliteGetSessionStaged(db, &stagedCat);
+  if( prollyHashIsEmpty(&stagedCat) ) stagedCat = headCat;
+  rc = wsLoadTableRoot(db, &stagedCat, p->zTableName, &stagedRoot, &flags, 0);
+  if( rc!=SQLITE_OK ) return rc;
+
+  if( makeStaged ){
+    if( r->diffType==PROLLY_DIFF_DELETE ){
+      rc = prollyMutateDelete(cs, pCache, &stagedRoot, flags,
+                              r->pKey, r->nKey, r->intKey, &newRoot);
+    }else{
+      rc = prollyMutateInsert(cs, pCache, &stagedRoot, flags,
+                              r->pKey, r->nKey, r->intKey,
+                              r->pNewVal, r->nNewVal, &newRoot);
+    }
+  }else{
+    u8 headFlags = flags;
+    rc = wsLoadTableRoot(db, &headCat, p->zTableName, &headRoot, &headFlags, 0);
+    if( rc!=SQLITE_OK ) return rc;
+    if( r->diffType==PROLLY_DIFF_ADD ){
+      rc = prollyMutateDelete(cs, pCache, &stagedRoot, flags,
+                              r->pKey, r->nKey, r->intKey, &newRoot);
+    }else{
+      rc = prollyMutateInsert(cs, pCache, &stagedRoot, flags,
+                              r->pKey, r->nKey, r->intKey,
+                              r->pOldVal, r->nOldVal, &newRoot);
+    }
+  }
+  if( rc!=SQLITE_OK ) return rc;
+  rc = wsPatchCatalogRoot(db, &stagedCat, p->zTableName, &newRoot, &newCat);
+  if( rc==SQLITE_OK ){
+    doltliteSetSessionStaged(db, &newCat);
+  }
+  return rc;
+}
+
+static int wsTableHasSecondaryIndexes(sqlite3 *db, const char *zTable, int *pHas){
+  sqlite3_stmt *pStmt = 0;
+  char *zSql;
+  int rc;
+  *pHas = 0;
+  zSql = sqlite3_mprintf(
+      "SELECT 1 FROM sqlite_master "
+      "WHERE type='index' AND tbl_name='%q' AND sql IS NOT NULL LIMIT 1",
+      zTable);
+  if( !zSql ) return SQLITE_NOMEM;
+  rc = sqlite3_prepare_v2(db, zSql, -1, &pStmt, 0);
+  sqlite3_free(zSql);
+  if( rc!=SQLITE_OK ) return rc;
+  if( sqlite3_step(pStmt)==SQLITE_ROW ) *pHas = 1;
+  sqlite3_finalize(pStmt);
+  return SQLITE_OK;
+}
+
+static int wsUpdate(sqlite3_vtab *pBase, int argc, sqlite3_value **argv,
+                    sqlite3_int64 *pRowid){
+  WorkspaceVtab *p = (WorkspaceVtab*)pBase;
+  WorkspaceRow *r;
+  int newStaged;
+  (void)pRowid;
+  if( argc==1 ){
+    pBase->zErrMsg = sqlite3_mprintf(
+        "DELETE from dolt_workspace_%s is not yet supported", p->zTableName);
+    return SQLITE_CONSTRAINT;
+  }
+  if( sqlite3_value_type(argv[0])==SQLITE_NULL ){
+    pBase->zErrMsg = sqlite3_mprintf(
+        "INSERT into dolt_workspace_%s is not supported", p->zTableName);
+    return SQLITE_CONSTRAINT;
+  }
+  if( argc < 2 + 3 + p->cols.nCol*2 ) return SQLITE_MISUSE;
+  r = wsFindCachedRow(p, sqlite3_value_int64(argv[0]));
+  if( !r ){
+    pBase->zErrMsg = sqlite3_mprintf("workspace row is no longer available");
+    return SQLITE_ABORT;
+  }
+  newStaged = sqlite3_value_int(argv[2 + 1]) ? 1 : 0;
+  if( newStaged==r->staged ) return SQLITE_OK;
+  {
+    int hasIndexes = 0;
+    int rc = wsTableHasSecondaryIndexes(p->db, p->zTableName, &hasIndexes);
+    if( rc!=SQLITE_OK ) return rc;
+    if( hasIndexes ){
+      pBase->zErrMsg = sqlite3_mprintf(
+          "staging individual workspace rows for indexed tables is not yet supported");
+      return SQLITE_CONSTRAINT;
+    }
+  }
+  return wsApplyRowToStaged(p, r, newStaged);
+}
+
+static sqlite3_module workspaceModule = {
+  0, wsConnect, wsConnect, wsBestIndex, wsDisconnect, wsDisconnect,
+  wsOpen, wsClose, wsFilter, wsNext, wsEof, wsColumn, wsRowid,
+  wsUpdate,0,0,0,0,0,0,0,0,0,0,0
+};
+
+int doltliteRegisterWorkspaceTables(sqlite3 *db){
+  return doltliteForEachUserTable(db, "dolt_workspace_", &workspaceModule);
+}
+
+#endif

--- a/test/doltlite_rollback_durability.sh
+++ b/test/doltlite_rollback_durability.sh
@@ -14,7 +14,12 @@ TMP=$(mktemp -d)
 trap "rm -rf $TMP" EXIT
 PASS=0; FAIL=0; ERRORS=""
 
-file_size() { stat -f %z "$1" 2>/dev/null || stat -c %s "$1"; }
+file_size() {
+  case "$(uname -s)" in
+    Darwin|FreeBSD) stat -f %z "$1" ;;
+    *) stat -c %s "$1" ;;
+  esac
+}
 file_sha()  { shasum -a 256 "$1" | awk '{print $1}'; }
 
 stable_rollback() {

--- a/test/doltlite_workspace.sh
+++ b/test/doltlite_workspace.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "$0")/lib/doltlite_test_common.sh"
+
+DB=/tmp/doltlite_workspace_$$.db
+rm -rf "$DB"
+trap 'rm -rf "$DB"' EXIT
+
+dltest_run_sql "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT, confidence INT);
+INSERT INTO t VALUES(1,10,0),(2,20,0),(3,30,0);
+SELECT dolt_commit('-A','-m','seed');
+UPDATE t SET v=v+100, confidence=CASE id WHEN 1 THEN 1 WHEN 2 THEN -1 ELSE 2 END;
+UPDATE dolt_workspace_t SET staged=TRUE WHERE to_confidence > from_confidence;
+SELECT dolt_commit('-m','partial');
+" "$DB" >/dev/null
+
+run_test "workspace_partial_commit_keeps_unstaged_diff" \
+  "SELECT to_id || '|' || to_v || '|' || from_v || '|' || diff_type
+     FROM dolt_diff_t('HEAD', 'WORKING')
+    ORDER BY to_id;" \
+  "2|120|20|modified" "$DB"
+
+run_test "workspace_partial_commit_visible_rows" \
+  "SELECT id || '|' || v || '|' || confidence FROM t ORDER BY id;" \
+  $'1|110|1\n2|120|-1\n3|130|2' "$DB"
+
+IDX_DB=/tmp/doltlite_workspace_index_$$.db
+rm -rf "$IDX_DB"
+trap 'rm -rf "$DB"; rm -rf "$IDX_DB"' EXIT
+
+dltest_run_sql "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+CREATE INDEX idx_t_v ON t(v);
+INSERT INTO t VALUES(1,1);
+SELECT dolt_commit('-A','-m','seed');
+UPDATE t SET v=2;
+" "$IDX_DB" >/dev/null
+
+if "$DOLTLITE" "$IDX_DB" "UPDATE dolt_workspace_t SET staged=TRUE;" >/tmp/doltlite_ws_idx.out 2>/tmp/doltlite_ws_idx.err; then
+  dltest_fail "workspace_indexed_table_rejected" "expected indexed table staging to fail"
+else
+  dltest_pass
+fi
+if ! grep -q "indexed tables is not yet supported" /tmp/doltlite_ws_idx.err; then
+  dltest_fail "workspace_indexed_table_error_message" "$(cat /tmp/doltlite_ws_idx.err)"
+else
+  dltest_pass
+fi
+
+dltest_finish

--- a/test/run_doltlite_tests.sh
+++ b/test/run_doltlite_tests.sh
@@ -31,6 +31,7 @@ TESTS=(
   # Versioning features
   doltlite_commit.sh
   doltlite_staging.sh
+  doltlite_workspace.sh
   doltlite_diff.sh
   doltlite_reset.sh
   doltlite_branch.sh

--- a/test/vc_oracle_workspace_test.sh
+++ b/test/vc_oracle_workspace_test.sh
@@ -1,0 +1,382 @@
+#!/bin/bash
+
+set -u
+set -o pipefail
+
+DOLTLITE="${1:-./doltlite}"
+DOLT="${2:-dolt}"
+TMPROOT=$(mktemp -d)
+trap "rm -rf $TMPROOT" EXIT
+pass=0; fail=0
+FAILED_NAMES=""
+source "$(dirname "$0")/lib/vc_oracle_common.sh"
+
+translate_for_dolt() {
+  sed -E '
+    s/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g
+    s/"dolt_diff_([^"]+)"\(([^)]*)\)/dolt_diff(\2, "\1")/g
+    s/`dolt_diff_([^`]+)`\(([^)]*)\)/dolt_diff(\2, '"'"'\1'"'"')/g
+    s/dolt_diff_([a-zA-Z0-9_]+)\(([^)]*)\)/dolt_diff(\2, "\1")/g
+  '
+}
+
+oracle() {
+  local name="$1" setup="$2" query="$3" allow_empty="${4:-}"
+  local dir="$TMPROOT/$name"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_out
+  dl_out=$(printf "%s\n.headers off\n.mode list\n%s\n" "$setup" "$query" \
+           | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
+           | tr -d '\r' \
+           | grep '^R|' | sort)
+
+  local dolt_setup dolt_query
+  dolt_setup=$(echo "$setup" | translate_for_dolt)
+  dolt_query=$(echo "$query" | translate_for_dolt)
+
+  (
+    cd "$dir/dt" || exit 1
+    vc_oracle_init_repo
+    {
+      echo "$dolt_setup"
+      echo "$dolt_query"
+    } | "$DOLT" sql -c -r csv 2>"$dir/dt.err"
+  ) > "$dir/dt.raw"
+
+  local dt_out
+  dt_out=$(tr -d '"\r' < "$dir/dt.raw" | grep '^R|' | sort)
+
+  if [ "$allow_empty" = "EXPECT_EMPTY" ]; then
+    vc_oracle_assert_match_allow_empty "$name" "$dl_out" "$dt_out"
+  else
+    vc_oracle_assert_match "$name" "$dl_out" "$dt_out"
+  fi
+}
+
+echo "=== Version Control Oracle Tests: dolt_workspace tables ==="
+echo ""
+
+BASE="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT, confidence INT);
+INSERT INTO t VALUES(1,10,0),(2,20,0),(3,30,0),(4,40,0);
+SELECT dolt_commit('-A','-m','seed');
+"
+
+oracle "workspace_read_modified_rows" "$BASE
+UPDATE t SET v=v+100, confidence=id-3;
+" "SELECT CONCAT('R|', staged, '|', diff_type, '|', to_id, '|', to_v, '|', from_v)
+       FROM dolt_workspace_t
+      ORDER BY to_id;"
+
+oracle "workspace_clean_table_empty" "$BASE" \
+  "SELECT CONCAT('R|', staged, '|', diff_type, '|', to_id)
+     FROM dolt_workspace_t
+    ORDER BY to_id;" \
+  "EXPECT_EMPTY"
+
+oracle "workspace_read_added_rows" "$BASE
+INSERT INTO t VALUES(5,50,1),(6,60,-1);
+" "SELECT CONCAT('R|', staged, '|', diff_type, '|', to_id, '|', to_v, '|', to_confidence)
+       FROM dolt_workspace_t
+      ORDER BY to_id;"
+
+oracle "workspace_read_removed_rows" "$BASE
+DELETE FROM t WHERE id IN (1,3);
+" "SELECT CONCAT('R|', staged, '|', diff_type, '|', IFNULL(from_id,''), '|', IFNULL(from_v,''))
+       FROM dolt_workspace_t
+      ORDER BY from_id;"
+
+oracle "workspace_read_mixed_diff_types" "$BASE
+UPDATE t SET v=200 WHERE id=2;
+DELETE FROM t WHERE id=3;
+INSERT INTO t VALUES(5,50,1);
+" "SELECT CONCAT('R|', diff_type, '|', IFNULL(to_id,''), '|', IFNULL(from_id,''), '|', IFNULL(to_v,''), '|', IFNULL(from_v,''))
+       FROM dolt_workspace_t
+      ORDER BY diff_type, IFNULL(to_id, from_id);"
+
+oracle "stage_positive_confidence_only" "$BASE
+UPDATE t SET v=v+100, confidence=id-3;
+UPDATE dolt_workspace_t SET staged=TRUE WHERE to_confidence > from_confidence;
+SELECT dolt_commit('-m','partial');
+" "SELECT CONCAT('R|COMMITTED|', to_id, '|', to_v, '|', from_v, '|', diff_type)
+  FROM dolt_diff_t('HEAD~1', 'HEAD') ORDER BY to_id;
+SELECT CONCAT('R|WORKING_DIFF|', to_id, '|', to_v, '|', from_v, '|', diff_type)
+  FROM dolt_diff_t('HEAD', 'WORKING') ORDER BY to_id;"
+
+oracle "stage_even_ids_only" "$BASE
+UPDATE t SET v=v+100;
+UPDATE dolt_workspace_t SET staged=TRUE WHERE to_id % 2 = 0;
+SELECT dolt_commit('-m','even_ids');
+" "SELECT CONCAT('R|COMMITTED|', to_id, '|', to_v, '|', from_v, '|', diff_type)
+  FROM dolt_diff_t('HEAD~1', 'HEAD') ORDER BY to_id;
+SELECT CONCAT('R|WORKING_DIFF|', to_id, '|', to_v, '|', from_v, '|', diff_type)
+  FROM dolt_diff_t('HEAD', 'WORKING') ORDER BY to_id;"
+
+oracle "stage_by_from_value" "$BASE
+UPDATE t SET v=v+100;
+UPDATE dolt_workspace_t SET staged=TRUE WHERE from_v >= 30;
+SELECT dolt_commit('-m','from_value');
+" "SELECT CONCAT('R|COMMITTED|', to_id, '|', to_v, '|', from_v, '|', diff_type)
+  FROM dolt_diff_t('HEAD~1', 'HEAD') ORDER BY to_id;
+SELECT CONCAT('R|WORKING_DIFF|', to_id, '|', to_v, '|', from_v, '|', diff_type)
+  FROM dolt_diff_t('HEAD', 'WORKING') ORDER BY to_id;"
+
+oracle "stage_all_workspace_rows" "$BASE
+UPDATE t SET v=v+100;
+UPDATE dolt_workspace_t SET staged=TRUE;
+SELECT dolt_commit('-m','all_workspace');
+" "SELECT CONCAT('R|COMMITTED|', to_id, '|', to_v, '|', from_v, '|', diff_type)
+  FROM dolt_diff_t('HEAD~1', 'HEAD') ORDER BY to_id;
+SELECT CONCAT('R|WORKING_DIFF|', to_id, '|', to_v, '|', from_v, '|', diff_type)
+  FROM dolt_diff_t('HEAD', 'WORKING') ORDER BY to_id;" \
+  "EXPECT_EMPTY"
+
+oracle "stage_modified_only_from_mixed_changes" "$BASE
+UPDATE t SET v=200 WHERE id=2;
+DELETE FROM t WHERE id=3;
+INSERT INTO t VALUES(5,50,1);
+UPDATE dolt_workspace_t SET staged=TRUE WHERE diff_type='modified';
+SELECT dolt_commit('-m','modified_only');
+" "SELECT CONCAT('R|COMMITTED|', to_id, '|', to_v, '|', from_v, '|', diff_type)
+  FROM dolt_diff_t('HEAD~1', 'HEAD') ORDER BY to_id;
+SELECT CONCAT('R|WORKING_DIFF|', diff_type, '|', IFNULL(to_id,''), '|', IFNULL(from_id,''))
+  FROM dolt_diff_t('HEAD', 'WORKING') ORDER BY diff_type, IFNULL(to_id, from_id);"
+
+oracle "stage_specific_insert" "$BASE
+INSERT INTO t VALUES(5,50,1),(6,60,-1);
+UPDATE dolt_workspace_t SET staged=TRUE WHERE diff_type='added' AND to_confidence > 0;
+SELECT dolt_commit('-m','insert_one');
+" "SELECT CONCAT('R|COMMITTED|', to_id, '|', to_v, '|', diff_type)
+  FROM dolt_diff_t('HEAD~1', 'HEAD') ORDER BY to_id;
+SELECT CONCAT('R|WORKING_DIFF|', to_id, '|', to_v, '|', diff_type)
+  FROM dolt_diff_t('HEAD', 'WORKING') ORDER BY to_id;"
+
+oracle "stage_multiple_inserts_by_id_range" "$BASE
+INSERT INTO t VALUES(5,50,1),(6,60,1),(7,70,1);
+UPDATE dolt_workspace_t SET staged=TRUE WHERE diff_type='added' AND to_id BETWEEN 5 AND 6;
+SELECT dolt_commit('-m','insert_range');
+" "SELECT CONCAT('R|COMMITTED|', to_id, '|', to_v, '|', diff_type)
+  FROM dolt_diff_t('HEAD~1', 'HEAD') ORDER BY to_id;
+SELECT CONCAT('R|WORKING_DIFF|', to_id, '|', to_v, '|', diff_type)
+  FROM dolt_diff_t('HEAD', 'WORKING') ORDER BY to_id;"
+
+oracle "stage_insert_then_unstage_one" "$BASE
+INSERT INTO t VALUES(5,50,1),(6,60,1);
+UPDATE dolt_workspace_t SET staged=TRUE WHERE diff_type='added';
+UPDATE dolt_workspace_t SET staged=FALSE WHERE to_id=6;
+SELECT dolt_commit('-m','insert_unstage_one');
+" "SELECT CONCAT('R|COMMITTED|', to_id, '|', to_v, '|', diff_type)
+  FROM dolt_diff_t('HEAD~1', 'HEAD') ORDER BY to_id;
+SELECT CONCAT('R|WORKING_DIFF|', to_id, '|', to_v, '|', diff_type)
+  FROM dolt_diff_t('HEAD', 'WORKING') ORDER BY to_id;"
+
+oracle "stage_specific_delete" "$BASE
+DELETE FROM t WHERE id IN (1,2);
+UPDATE dolt_workspace_t SET staged=TRUE WHERE diff_type='removed' AND from_id=1;
+SELECT dolt_commit('-m','delete_one');
+" "SELECT CONCAT('R|COMMITTED|', from_id, '|', from_v, '|', diff_type)
+  FROM dolt_diff_t('HEAD~1', 'HEAD') ORDER BY from_id;
+SELECT CONCAT('R|WORKING_DIFF|', from_id, '|', from_v, '|', diff_type)
+  FROM dolt_diff_t('HEAD', 'WORKING') ORDER BY from_id;"
+
+oracle "stage_multiple_deletes_by_predicate" "$BASE
+DELETE FROM t WHERE id IN (1,2,4);
+UPDATE dolt_workspace_t SET staged=TRUE WHERE diff_type='removed' AND from_v <= 20;
+SELECT dolt_commit('-m','delete_predicate');
+" "SELECT CONCAT('R|COMMITTED|', from_id, '|', from_v, '|', diff_type)
+  FROM dolt_diff_t('HEAD~1', 'HEAD') ORDER BY from_id;
+SELECT CONCAT('R|WORKING_DIFF|', from_id, '|', from_v, '|', diff_type)
+  FROM dolt_diff_t('HEAD', 'WORKING') ORDER BY from_id;"
+
+oracle "stage_delete_then_unstage_one" "$BASE
+DELETE FROM t WHERE id IN (1,2,3);
+UPDATE dolt_workspace_t SET staged=TRUE WHERE diff_type='removed';
+UPDATE dolt_workspace_t SET staged=FALSE WHERE from_id=2;
+SELECT dolt_commit('-m','delete_unstage_one');
+" "SELECT CONCAT('R|COMMITTED|', from_id, '|', from_v, '|', diff_type)
+  FROM dolt_diff_t('HEAD~1', 'HEAD') ORDER BY from_id;
+SELECT CONCAT('R|WORKING_DIFF|', from_id, '|', from_v, '|', diff_type)
+  FROM dolt_diff_t('HEAD', 'WORKING') ORDER BY from_id;"
+
+oracle "unstage_one_modified_row" "$BASE
+UPDATE t SET v=v+100;
+UPDATE dolt_workspace_t SET staged=TRUE WHERE to_id IN (1,2,3);
+UPDATE dolt_workspace_t SET staged=FALSE WHERE to_id=2;
+SELECT dolt_commit('-m','partial_unstage');
+" "SELECT CONCAT('R|COMMITTED|', to_id, '|', to_v, '|', from_v, '|', diff_type)
+  FROM dolt_diff_t('HEAD~1', 'HEAD') ORDER BY to_id;
+SELECT CONCAT('R|WORKING_DIFF|', to_id, '|', to_v, '|', from_v, '|', diff_type)
+  FROM dolt_diff_t('HEAD', 'WORKING') ORDER BY to_id;"
+
+oracle "unstage_all_after_stage_all" "$BASE
+UPDATE t SET v=v+100;
+UPDATE dolt_workspace_t SET staged=TRUE;
+UPDATE dolt_workspace_t SET staged=FALSE;
+" "SELECT CONCAT('R|', staged, '|', diff_type, '|', to_id, '|', to_v, '|', from_v)
+       FROM dolt_workspace_t
+      ORDER BY to_id;"
+
+oracle "restage_after_unstage" "$BASE
+UPDATE t SET v=v+100;
+UPDATE dolt_workspace_t SET staged=TRUE WHERE to_id IN (1,2);
+UPDATE dolt_workspace_t SET staged=FALSE WHERE to_id=1;
+UPDATE dolt_workspace_t SET staged=TRUE WHERE to_id=1;
+SELECT dolt_commit('-m','restage');
+" "SELECT CONCAT('R|COMMITTED|', to_id, '|', to_v, '|', from_v, '|', diff_type)
+  FROM dolt_diff_t('HEAD~1', 'HEAD') ORDER BY to_id;
+SELECT CONCAT('R|WORKING_DIFF|', to_id, '|', to_v, '|', from_v, '|', diff_type)
+  FROM dolt_diff_t('HEAD', 'WORKING') ORDER BY to_id;"
+
+oracle "workspace_status_before_commit" "$BASE
+UPDATE t SET v=v+100;
+UPDATE dolt_workspace_t SET staged=TRUE WHERE to_id IN (1,3);
+" "SELECT CONCAT('R|WS|', staged, '|', to_id, '|', to_v, '|', from_v)
+       FROM dolt_workspace_t
+      ORDER BY staged DESC, to_id;
+SELECT CONCAT('R|STATUS|', table_name, '|', staged, '|', status)
+       FROM dolt_status
+      ORDER BY staged, table_name;"
+
+oracle "workspace_after_partial_commit_shows_remaining" "$BASE
+UPDATE t SET v=v+100;
+UPDATE dolt_workspace_t SET staged=TRUE WHERE to_id=1;
+SELECT dolt_commit('-m','one');
+" "SELECT CONCAT('R|WS|', staged, '|', to_id, '|', to_v, '|', from_v)
+       FROM dolt_workspace_t
+      ORDER BY to_id;"
+
+oracle "second_round_partial_commit" "$BASE
+UPDATE t SET v=v+100;
+UPDATE dolt_workspace_t SET staged=TRUE WHERE to_id IN (1,2);
+SELECT dolt_commit('-m','round1');
+UPDATE t SET v=v+1000 WHERE id IN (2,3,4);
+UPDATE dolt_workspace_t SET staged=TRUE WHERE to_id IN (2,4);
+SELECT dolt_commit('-m','round2');
+" "SELECT CONCAT('R|COMMITTED|', to_id, '|', to_v, '|', from_v, '|', diff_type)
+  FROM dolt_diff_t('HEAD~1', 'HEAD') ORDER BY to_id;
+SELECT CONCAT('R|WORKING_DIFF|', to_id, '|', to_v, '|', from_v, '|', diff_type)
+  FROM dolt_diff_t('HEAD', 'WORKING') ORDER BY to_id;"
+
+oracle "working_advances_past_staged_row" "$BASE
+UPDATE t SET v=100 WHERE id=1;
+UPDATE dolt_workspace_t SET staged=TRUE WHERE to_id=1;
+UPDATE t SET v=200 WHERE id=1;
+" "SELECT CONCAT('R|WS|', staged, '|', to_id, '|', to_v, '|', from_v)
+       FROM dolt_workspace_t
+      ORDER BY staged DESC, to_id;"
+
+oracle "commit_staged_when_working_advances" "$BASE
+UPDATE t SET v=100 WHERE id=1;
+UPDATE dolt_workspace_t SET staged=TRUE WHERE to_id=1;
+UPDATE t SET v=200 WHERE id=1;
+SELECT dolt_commit('-m','staged_old_value');
+" "SELECT CONCAT('R|COMMITTED|', to_id, '|', to_v, '|', from_v, '|', diff_type)
+  FROM dolt_diff_t('HEAD~1', 'HEAD') ORDER BY to_id;
+SELECT CONCAT('R|WORKING_DIFF|', to_id, '|', to_v, '|', from_v, '|', diff_type)
+  FROM dolt_diff_t('HEAD', 'WORKING') ORDER BY to_id;"
+
+oracle "multi_table_isolation_stage_t_only" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+CREATE TABLE u(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1,10),(2,20);
+INSERT INTO u VALUES(1,100),(2,200);
+SELECT dolt_commit('-A','-m','seed');
+UPDATE t SET v=v+1;
+UPDATE u SET v=v+1;
+UPDATE dolt_workspace_t SET staged=TRUE WHERE to_id=1;
+SELECT dolt_commit('-m','stage_t_one');
+" "SELECT CONCAT('R|T_COMMITTED|', to_id, '|', to_v, '|', from_v, '|', diff_type)
+  FROM dolt_diff_t('HEAD~1', 'HEAD') ORDER BY to_id;
+SELECT CONCAT('R|T_WORKING|', to_id, '|', to_v, '|', from_v, '|', diff_type)
+  FROM dolt_diff_t('HEAD', 'WORKING') ORDER BY to_id;
+SELECT CONCAT('R|U_WORKING|', to_id, '|', to_v, '|', from_v, '|', diff_type)
+  FROM dolt_diff_u('HEAD', 'WORKING') ORDER BY to_id;"
+
+oracle "multi_table_stage_each_table" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+CREATE TABLE u(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1,10),(2,20);
+INSERT INTO u VALUES(1,100),(2,200);
+SELECT dolt_commit('-A','-m','seed');
+UPDATE t SET v=v+1;
+UPDATE u SET v=v+1;
+UPDATE dolt_workspace_t SET staged=TRUE WHERE to_id=2;
+UPDATE dolt_workspace_u SET staged=TRUE WHERE to_id=1;
+SELECT dolt_commit('-m','stage_each');
+" "SELECT CONCAT('R|T_COMMITTED|', to_id, '|', to_v, '|', from_v, '|', diff_type)
+  FROM dolt_diff_t('HEAD~1', 'HEAD') ORDER BY to_id;
+SELECT CONCAT('R|U_COMMITTED|', to_id, '|', to_v, '|', from_v, '|', diff_type)
+  FROM dolt_diff_u('HEAD~1', 'HEAD') ORDER BY to_id;
+SELECT CONCAT('R|T_WORKING|', to_id, '|', to_v, '|', from_v, '|', diff_type)
+  FROM dolt_diff_t('HEAD', 'WORKING') ORDER BY to_id;
+SELECT CONCAT('R|U_WORKING|', to_id, '|', to_v, '|', from_v, '|', diff_type)
+  FROM dolt_diff_u('HEAD', 'WORKING') ORDER BY to_id;"
+
+oracle "text_and_null_values" "
+CREATE TABLE s(id INTEGER PRIMARY KEY, v TEXT, note TEXT);
+INSERT INTO s VALUES(1,'a',NULL),(2,'b','old'),(3,'c',NULL);
+SELECT dolt_commit('-A','-m','seed');
+UPDATE s SET v=upper(v), note=CASE id WHEN 1 THEN 'new' WHEN 2 THEN NULL ELSE 'keep' END;
+UPDATE dolt_workspace_s SET staged=TRUE WHERE from_note IS NULL AND to_note IS NOT NULL;
+SELECT dolt_commit('-m','text_null');
+" "SELECT CONCAT('R|COMMITTED|', to_id, '|', to_v, '|', IFNULL(to_note,'NULL'), '|', IFNULL(from_note,'NULL'), '|', diff_type)
+  FROM dolt_diff_s('HEAD~1', 'HEAD') ORDER BY to_id;
+SELECT CONCAT('R|WORKING_DIFF|', to_id, '|', to_v, '|', IFNULL(to_note,'NULL'), '|', IFNULL(from_note,'NULL'), '|', diff_type)
+  FROM dolt_diff_s('HEAD', 'WORKING') ORDER BY to_id;"
+
+oracle "quoted_table_and_column_names" "
+CREATE TABLE \`odd table\`(id INTEGER PRIMARY KEY, \`select\` INT, \`two words\` TEXT);
+INSERT INTO \`odd table\` VALUES(1,10,'a'),(2,20,'b');
+SELECT dolt_commit('-A','-m','seed');
+UPDATE \`odd table\` SET \`select\`=\`select\`+100, \`two words\`=upper(\`two words\`);
+UPDATE \`dolt_workspace_odd table\` SET staged=TRUE WHERE to_id=2;
+SELECT dolt_commit('-m','quoted');
+" "SELECT CONCAT('R|COMMITTED|', to_id, '|', to_select, '|', from_select, '|', diff_type)
+  FROM \`dolt_diff_odd table\`('HEAD~1', 'HEAD') ORDER BY to_id;
+SELECT CONCAT('R|WORKING_DIFF|', to_id, '|', to_select, '|', from_select, '|', diff_type)
+  FROM \`dolt_diff_odd table\`('HEAD', 'WORKING') ORDER BY to_id;"
+
+oracle "composite_pk_stage_subset" "
+CREATE TABLE m(a INT, b INT, v TEXT, score INT, PRIMARY KEY(a,b));
+INSERT INTO m VALUES(1,1,'one',0),(1,2,'two',0),(2,1,'three',0);
+SELECT dolt_commit('-A','-m','seed');
+UPDATE m SET v=upper(v), score=a+b;
+UPDATE dolt_workspace_m SET staged=TRUE WHERE to_score >= 3;
+SELECT dolt_commit('-m','partial_composite');
+" "SELECT CONCAT('R|COMMITTED|', to_a, '|', to_b, '|', to_v, '|', from_v, '|', diff_type)
+  FROM dolt_diff_m('HEAD~1', 'HEAD') ORDER BY to_a,to_b;
+SELECT CONCAT('R|WORKING_DIFF|', to_a, '|', to_b, '|', to_v, '|', from_v, '|', diff_type)
+  FROM dolt_diff_m('HEAD', 'WORKING') ORDER BY to_a,to_b;"
+
+oracle "composite_pk_stage_insert_and_update" "
+CREATE TABLE m(a INT, b INT, v TEXT, score INT, PRIMARY KEY(a,b));
+INSERT INTO m VALUES(1,1,'one',0),(1,2,'two',0);
+SELECT dolt_commit('-A','-m','seed');
+UPDATE m SET v='ONE', score=10 WHERE a=1 AND b=1;
+INSERT INTO m VALUES(2,1,'three',3),(2,2,'four',4);
+UPDATE dolt_workspace_m SET staged=TRUE WHERE to_a=2 OR to_score=10;
+SELECT dolt_commit('-m','composite_insert_update');
+" "SELECT CONCAT('R|COMMITTED|', diff_type, '|', IFNULL(to_a,''), '|', IFNULL(to_b,''), '|', IFNULL(from_a,''), '|', IFNULL(from_b,''))
+  FROM dolt_diff_m('HEAD~1', 'HEAD') ORDER BY diff_type, IFNULL(to_a,from_a), IFNULL(to_b,from_b);
+SELECT CONCAT('R|WORKING_DIFF|', diff_type, '|', IFNULL(to_a,''), '|', IFNULL(to_b,''), '|', IFNULL(from_a,''), '|', IFNULL(from_b,''))
+  FROM dolt_diff_m('HEAD', 'WORKING') ORDER BY diff_type, IFNULL(to_a,from_a), IFNULL(to_b,from_b);"
+
+oracle "composite_pk_delete_subset" "
+CREATE TABLE m(a INT, b INT, v TEXT, PRIMARY KEY(a,b));
+INSERT INTO m VALUES(1,1,'one'),(1,2,'two'),(2,1,'three');
+SELECT dolt_commit('-A','-m','seed');
+DELETE FROM m WHERE a=1 OR b=1;
+UPDATE dolt_workspace_m SET staged=TRUE WHERE from_a=1 AND from_b=2;
+SELECT dolt_commit('-m','composite_delete_subset');
+" "SELECT CONCAT('R|COMMITTED|', from_a, '|', from_b, '|', from_v, '|', diff_type)
+  FROM dolt_diff_m('HEAD~1', 'HEAD') ORDER BY from_a,from_b;
+SELECT CONCAT('R|WORKING_DIFF|', from_a, '|', from_b, '|', from_v, '|', diff_type)
+  FROM dolt_diff_m('HEAD', 'WORKING') ORDER BY from_a,from_b;"
+
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+if [ $fail -gt 0 ]; then
+  echo "Failed:$FAILED_NAMES"
+  exit 1
+fi

--- a/tool/mksqlite3c.tcl
+++ b/tool/mksqlite3c.tcl
@@ -569,6 +569,7 @@ proc emit_doltlite_engine_block {} {
     prolly_btree.c pager_shim.c sortkey.c
     doltlite.c doltlite_commit.c doltlite_ref.c doltlite_log.c
     doltlite_commit_ancestors.c doltlite_status.c doltlite_diff.c doltlite_diff_table.c
+    doltlite_workspace.c
     doltlite_branch.c doltlite_tag.c doltlite_ancestor.c doltlite_merge.c
     doltlite_schema_merge.c doltlite_conflicts.c doltlite_gc.c doltlite_chunk_walk.c
     doltlite_history.c doltlite_at.c doltlite_blame.c doltlite_schema_diff.c


### PR DESCRIPTION
## Summary
- add per-table `dolt_workspace_<table>` virtual tables for reading workspace diffs
- support updating the `staged` column to stage/unstage individual row edits
- register workspace tables on startup, commit refresh, and branch refresh paths
- wire the new source into normal and amalgamation builds

## Notes
- row-level staging currently rejects tables with secondary indexes instead of writing stale staged index roots
- workspace `DELETE`/revert behavior is not implemented in this first slice

## Tests
- `test/vc_oracle_workspace_test.sh ./doltlite dolt` (31/31)
- `test/doltlite_workspace.sh` (4/4)
- `test/vc_oracle_add_test.sh ./doltlite dolt` (27/27)
- `make sqlite3.c`
- `make sqlite3`
