### PR TITLE
Fix VFS double-nul filename contract violation; gate sort5 (#1208)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -569,7 +569,7 @@ jobs:
           selectH session shared4 sharedB shell1 shell2 shell3 shell4 \
           shell5 shell6 shell7 shell8 shell9 shellA shellB skipscan3 \
           skipscan5 skipscan6 snapshot snapshot_fault snapshot_up snapshot2 snapshot3 snapshot4 \
-          sort2 sorterref speed4p spellfix spellfix2 spellfix3 spellfix4 sqldiff1 \
+          sort2 sort5 sorterref speed4p spellfix spellfix2 spellfix3 spellfix4 sqldiff1 \
           sqllog starschema1 stmtrand stmtvtab1 strict1 subquery2 subselect subtype1 \
           swarmvtab2 swarmvtab3 swarmvtabfault symlink2 tabfunc01 tableapi tableopts tempdb2 \
           temptable3 temptrigger timediff1 tkt-02a8e81d44 tkt-18458b1a tkt-26ff0c2d1e tkt-2a5629202f tkt-2d1a5c67d \

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -29,14 +29,20 @@ static char *csLockPath(const char *path){
 
 static int csFileLock(sqlite3_vfs *pVfs, const char *path,
                       sqlite3_file **ppFile){
-  char *zLock = csLockPath(path);
+  char *zRaw = csLockPath(path);
+  char *zLock = 0;
   sqlite3_file *pFile = 0;
   int flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE
             | SQLITE_OPEN_MAIN_DB;
   int rc;
 
   *ppFile = 0;
-  if( !zLock ) return SQLITE_NOMEM;
+  if( !zRaw ) return SQLITE_NOMEM;
+  /* Opened with SQLITE_OPEN_MAIN_DB, so the name must carry the VFS's
+  ** double-nul terminator (csLockPath returns a singly-terminated string). */
+  rc = chunkStoreDupFilenameDoubleNul(zRaw, &zLock);
+  sqlite3_free(zRaw);
+  if( rc!=SQLITE_OK ) return rc;
   rc = sqlite3OsOpenMalloc(pVfs, zLock, &pFile, flags, 0);
   sqlite3_free(zLock);
   if( rc!=SQLITE_OK ) return rc;
@@ -121,6 +127,19 @@ static int csFileSizeByName(sqlite3_vfs *pVfs, const char *zPath, i64 *pSize){
   return rc;
 }
 
+/* See chunk_store.h. Terminates with two nuls for the VFS xOpen() main-db
+** filename contract. */
+int chunkStoreDupFilenameDoubleNul(const char *z, char **pzOut){
+  int n = (int)strlen(z);
+  char *p = (char*)sqlite3_malloc(n + 2);
+  if( !p ) return SQLITE_NOMEM;
+  memcpy(p, z, n);
+  p[n] = '\0';
+  p[n + 1] = '\0';
+  *pzOut = p;
+  return SQLITE_OK;
+}
+
 static int csCanonicalFilename(
   sqlite3_vfs *pVfs,
   const char *zFilename,
@@ -129,7 +148,6 @@ static int csCanonicalFilename(
   int nPath;
   int rc;
   char *zFull;
-  int n;
 
   *pzOut = 0;
   assert( pVfs!=0 );
@@ -140,19 +158,16 @@ static int csCanonicalFilename(
 
   rc = sqlite3OsFullPathname(pVfs, zFilename, nPath, zFull);
   if( rc==SQLITE_OK_SYMLINK ){
-    *pzOut = zFull;
-    return SQLITE_OK;
+    rc = chunkStoreDupFilenameDoubleNul(zFull, pzOut);
+    sqlite3_free(zFull);
+    return rc;
   }
   sqlite3_free(zFull);
   if( rc!=SQLITE_OK ){
     return rc;
   }
 
-  n = (int)strlen(zFilename);
-  *pzOut = (char*)sqlite3_malloc(n + 1);
-  if( !*pzOut ) return SQLITE_NOMEM;
-  memcpy(*pzOut, zFilename, n + 1);
-  return SQLITE_OK;
+  return chunkStoreDupFilenameDoubleNul(zFilename, pzOut);
 }
 
 static int csRollbackFailedAppend(ChunkStore *cs, i64 origFileSize){

--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -215,4 +215,10 @@ int chunkStoreRefreshIfChanged(ChunkStore *cs, int *pChanged);
 ** acquisition; caller holds the graph lock. */
 int chunkStoreForceRefresh(ChunkStore *cs);
 
+/* Duplicate z into a fresh buffer terminated by TWO '\0' bytes, as required
+** for any filename handed to a VFS xOpen() with SQLITE_OPEN_MAIN_DB (the
+** empty URI-parameter terminator; sqlite3_uri_parameter and test VFSes scan
+** past the first nul). Returns SQLITE_OK or SQLITE_NOMEM. */
+int chunkStoreDupFilenameDoubleNul(const char *z, char **pzOut);
+
 #endif

--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -399,10 +399,19 @@ static int gcRewriteFile(
   csSerializeManifest(&manifestCs, manifest);
 
   if( chunkFileGetFilename(&cs->file) && strcmp(chunkFileGetFilename(&cs->file), ":memory:")!=0 ){
-    char *zTmp = sqlite3_mprintf("%s-gc-tmp", chunkFileGetFilename(&cs->file));
-    if( !zTmp ){
+    char *zRaw = sqlite3_mprintf("%s-gc-tmp", chunkFileGetFilename(&cs->file));
+    char *zTmp = 0;
+    if( !zRaw ){
       sqlite3_free(indexBuf);
       return SQLITE_NOMEM;
+    }
+    /* Opened with SQLITE_OPEN_MAIN_DB below, so the name needs the VFS's
+    ** double-nul terminator. */
+    rc = chunkStoreDupFilenameDoubleNul(zRaw, &zTmp);
+    sqlite3_free(zRaw);
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(indexBuf);
+      return rc;
     }
 
     {

--- a/src/pager_shim.c
+++ b/src/pager_shim.c
@@ -915,7 +915,14 @@ sqlite3_backup *sqlite3_backup_init(sqlite3 *pDest, const char *zDestDb,
   p->pDestDb = pDest;
   p->pVfs = chunkFileGetVfs(&srcCs->file);
   p->pDestVfs = chunkFileGetVfs(&destCs->file);
-  p->zSrcFile = sqlite3_mprintf("%s", chunkFileGetFilename(&srcCs->file));
+  /* zSrcFile is opened with SQLITE_OPEN_MAIN_DB below, so it needs the VFS's
+  ** double-nul terminator (a plain "%s" copy keeps only the first nul). */
+  p->zSrcFile = 0;
+  if( chunkStoreDupFilenameDoubleNul(chunkFileGetFilename(&srcCs->file),
+                                     &p->zSrcFile)!=SQLITE_OK ){
+    sqlite3_free(p);
+    return 0;
+  }
   p->zDestFile = sqlite3_mprintf("%s", chunkFileGetFilename(&destCs->file));
   if( !p->zSrcFile || !p->zDestFile ){
     sqlite3_free(p->zSrcFile);
@@ -975,10 +982,16 @@ int sqlite3_backup_step(sqlite3_backup *pBackup, int nPage){
     goto backup_step_done;
   }
 
-  zTmpFile = sqlite3_mprintf("%s-backup-%p", p->zDestFile, (void*)p);
-  if( !zTmpFile ){
-    rc = SQLITE_NOMEM;
-    goto backup_step_done;
+  {
+    /* Opened with SQLITE_OPEN_MAIN_DB below; needs the VFS double-nul name. */
+    char *zTmpRaw = sqlite3_mprintf("%s-backup-%p", p->zDestFile, (void*)p);
+    if( !zTmpRaw ){
+      rc = SQLITE_NOMEM;
+      goto backup_step_done;
+    }
+    rc = chunkStoreDupFilenameDoubleNul(zTmpRaw, &zTmpFile);
+    sqlite3_free(zTmpRaw);
+    if( rc!=SQLITE_OK ) goto backup_step_done;
   }
   (void)sqlite3OsDelete(p->pDestVfs, zTmpFile, 0);
 


### PR DESCRIPTION
## Summary
First fix from the ASan-crash triage in #1208. A filename passed to a VFS `xOpen()` with `SQLITE_OPEN_MAIN_DB` must be terminated by **two** `\0` bytes — `sqlite3_uri_parameter()` and test VFSes (`tvfsOpen`) scan the URI key/value list starting at `zName[strlen(zName)+1]`. doltlite allocated these names with a single nul (`sqlite3_malloc(n+1)`, `sqlite3_mprintf`, `"%s"` copies), so the scan read **past the heap buffer**.

ASan stack (pre-fix, `sort5`):
```
strlen → Tcl_NewStringObj → tvfsOpen (test_vfs.c:642)
  → sqlite3OsOpenMalloc → csFileLock → chunkStoreLockAndRefresh → chunkStoreCommit
```

## Fix
Added `chunkStoreDupFilenameDoubleNul()` and routed every doltlite site that opens a name with `SQLITE_OPEN_MAIN_DB` through it:
| Site | File |
|---|---|
| `csCanonicalFilename` (main chunk-store file) | chunk_store.c |
| `csFileLock` (graph lock file, via `csLockPath`) | chunk_store.c |
| `gcRewriteFile` (GC temp file) | doltlite_gc.c |
| backup source file + `-backup-%p` temp | pager_shim.c |

## Impact (from the 33-file ASan sweep)
- **`sort5`** (plain sort test; triggers GC via VACUUM) → now **CLEAN**, added to the `inherited-testfixture` gate.
- `uri`, `e_uri`, `mjournal` → no longer crash; now diverge on URI/journal-mode semantics (stay in #1208 backlog, not gated).
- The other 29 ASan crashes are unrelated root causes (separate follow-ups).

## Validation
Built CI-faithfully (`DOLTLITE_PROLLY_CHECK=1`) on master:
- `sort5` OK (16 tests) — fail-before (heap-buffer-overflow) / pass-after.
- No regression: `vacuum`, `vacuum2`, `savepoint`, `trans`, `fkey2` all OK (the commit/GC/lock/backup paths the change touches).
- `backup`/`backup2` remain CRASH/FAIL **exactly as before this change** (pre-existing, separate issues in #1208) — not regressed.

The `pager_shim` backup sites are a latent fix (same bug, no clean test currently exercises them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)