### PR TITLE
Fix savepoint-path rollback use-after-free; gate fts3fault/fts3fault2 (#1208)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -542,6 +542,7 @@ jobs:
           fts3ad fts3ae fts3af fts3ag fts3ah fts3aj fts3ak fts3al \
           fts3am fts3atoken fts3atoken2 fts3auto fts3aux1 fts3aux2 fts3b fts3c \
           fts3comp1 fts3corrupt fts3corrupt3 fts3corrupt5 fts3corrupt6 fts3d fts3defer fts3drop \
+          fts3fault fts3fault2 \
           fts3dropmod fts3e fts3expr fts3expr2 fts3expr3 fts3expr4 fts3expr5 fts3f \
           fts3first fts3integrity fts3join fts3matchinfo fts3matchinfo2 fts3misc fts3near fts3offsets \
           fts3prefix fts3prefix2 fts3query fts3rank fts3snippet2 fts3sort fts3tok_err fts3tok1 \

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -5289,13 +5289,15 @@ static int prollyBtreeRollback(Btree *p, int tripCode, int writeOnly){
     assert( pBt->store.isMemory || pBt->store.pGraphLockFile!=0 );
     assert( pBt->store.isMemory || pBt->store.lockDepth > 0 );
     /* Cursor pending-edit maps alias the catalog's per-table pPending maps,
-    ** which restoreFromCommitted() is about to free. Clear and detach the
-    ** aliases first; touching them after the catalog is freed is a UAF. */
+    ** which restoreFromCommitted() (via catFree) frees. Detach the aliases so
+    ** nothing dereferences them afterwards. We only null them here — do NOT
+    ** clear the maps: catFree owns that, and a prior savepoint rollback may
+    ** already have freed the map this cursor points at, so clearing it would
+    ** be a use-after-free. ensureMutMap re-aliases from the catalog on reuse. */
     {
       BtCursor *pC;
       for(pC = pBt->pCursor; pC; pC = pC->pNext){
         if( pC->pBtree==p && pC->pMutMap ){
-          prollyMutMapClear(pC->pMutMap);
           pC->pMutMap = 0;
           pC->mmActive = 0;
           pC->mmPhysActive = 0;


### PR DESCRIPTION
## Summary
Second ASan-crash fix from the #1208 triage — a cousin of #1207 (the rollback UAF).

On a failed statement under OOM injection, `sqlite3VdbeHalt` does two things in order:
1. **Closes the statement savepoint** — `prollyBtreeSavepoint` → `rollbackMutMapsToSavepoint` **frees/swaps** a table's pending mutmap. (On the OOM error path it returns before the `invalidateCursors` that would normally run.)
2. **Runs a full `ROLLBACK`** — `prollyBtreeRollback`'s clear loop called `prollyMutMapClear()` on each cursor's `pMutMap` alias.

But step 1 already freed the map that alias points at → **heap-use-after-free** in `prollyMutMapClear` via `prollyBtreeRollback`.

## Fix
That `prollyMutMapClear()` call was **redundant**: `restoreFromCommitted()` frees every catalog `pPending` map via `catFree()` regardless. The loop only needs to **detach** the cursor aliases (null them) so nothing dereferences a map that `catFree` owns — and that a prior savepoint rollback may already have freed. One line removed; the detach stays.

## Impact (from the 33-file ASan sweep)
- **`fts3fault`** (21,103 tests) and **`fts3fault2`** (21,298 tests) → now pass clean; **added to the gate** (42K+ assertions, ~10s each).
- `rtree` no longer hits this UAF but aborts on a **separate, deeper bug** — `prolly tree invariant violated: keys not strictly ascending` under `rtree3` OOM-transient injection — left in the #1208 backlog.

## Validation
- ASan: the 3 targets go from CRASH → no-crash (fail-before/pass-after).
- CI-faithful (`DOLTLITE_PROLLY_CHECK=1`): `fts3fault`/`fts3fault2` OK via `run_testfixture.sh`; **no regression** across `savepoint`/`savepoint2`/`savepoint4`/`trans`/`fkey2`/`vacuum`/`sort5`. (CI's `asan-ubsan` job with leak detection will confirm no leak from dropping the redundant clear.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)