### PR TITLE
Fix record-header over-read past prolly node buffers; gate fordelete (#1208)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -538,7 +538,7 @@ jobs:
           decimal delete3 delete4 e_blobbytes e_droptrigger e_dropview e_resolve emptytable \
           eqp eqp2 errofst1 eval exec exists existsexpr existsexpr2 \
           expr2 exprfault expridx1 filectrl filter1 filter2 filterfault fkey3 \
-          fkey4 fkey6 fkey7 fkey8 fts-9fd058691 fts3aa fts3ab fts3ac \
+          fkey4 fkey6 fkey7 fkey8 fordelete fts-9fd058691 fts3aa fts3ab fts3ac \
           fts3ad fts3ae fts3af fts3ag fts3ah fts3aj fts3ak fts3al \
           fts3am fts3atoken fts3atoken2 fts3auto fts3aux1 fts3aux2 fts3b fts3c \
           fts3comp1 fts3corrupt fts3corrupt3 fts3corrupt5 fts3corrupt6 fts3d fts3defer fts3drop \

--- a/src/prolly_cache.c
+++ b/src/prolly_cache.c
@@ -5,6 +5,11 @@
 #include <string.h>
 #include <assert.h>
 
+/* Trailing zero bytes appended to every cached node buffer so a reader
+** parsing the last cell's record header can safely over-read one serial-type
+** varint (max 9 bytes) past the payload, matching SQLite's page-buffer slack. */
+#define PROLLY_NODE_BUFFER_SLOP 8
+
 static int cacheHashBucket(const ProllyCache *cache, const ProllyHash *hash){
   u32 h;
   memcpy(&h, hash->data, sizeof(u32));
@@ -172,6 +177,23 @@ ProllyCacheEntry *prollyCachePutOwned(
       return 0;
     }
     memset(pEntry, 0, sizeof(*pEntry));
+  }
+
+  /* A reader parsing the last cell's record header (e.g. OP_Column) lets
+  ** GetVarint32 speculatively read up to 8 bytes past the cell's payload.
+  ** SQLite's page buffers carry that slack; prolly node buffers are exactly
+  ** sized, so grow the owned buffer with zeroed trailing slop to keep those
+  ** boundary over-reads in bounds. nData stays the logical size. */
+  {
+    u8 *pPadded = (u8*)sqlite3_realloc(pData, nData + PROLLY_NODE_BUFFER_SLOP);
+    if( pPadded==0 ){
+      sqlite3_free(pData);
+      sqlite3_free(pEntry);
+      if( pRc ) *pRc = SQLITE_NOMEM;
+      return 0;
+    }
+    pData = pPadded;
+    memset(pData + nData, 0, PROLLY_NODE_BUFFER_SLOP);
   }
 
   memcpy(pEntry->hash.data, hash->data, PROLLY_HASH_SIZE);

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1149,3 +1149,12 @@ capi3 capi3-11.10  # step after ROLLBACK-during-active-read: cursor faulted (SQL
 capi3 capi3-11.11  # same statement, next step: SQLITE_ERROR vs SQLITE_DONE
 capi3 capi3-11.12  # same: SQLITE_ERROR vs SQLITE_ROW
 capi3 capi3-11.13  # finalize of the faulted statement: SQLITE_ERROR vs SQLITE_OK
+
+# fordelete — doltlite doesn't materialize named sqlite_autoindex_* rows for
+# WITHOUT-ROWID/implicit unique indexes, so PRAGMA index_list reports just the
+# table; the FOR-DELETE behavior under test is otherwise correct. (Recovered
+# into the gate once the node-buffer over-read crash was fixed.)
+fordelete fordelete-1.1  # sqlite_autoindex naming: "t1" vs "sqlite_autoindex_t1_1 t1"
+fordelete fordelete-1.2  # sqlite_autoindex naming
+fordelete fordelete-1.3  # sqlite_autoindex naming
+fordelete fordelete-1.4  # sqlite_autoindex naming


### PR DESCRIPTION
## Summary
Third ASan-crash fix from the #1208 triage.

`OP_Column` (and similar) takes a **direct pointer** into a row payload and lets `sqlite3GetVarint32` **speculatively read a serial-type varint up to 8 bytes past** it while parsing the record header. SQLite's own page buffers carry that trailing slack; prolly cache node buffers are allocated **exactly `nData`**, so when a row is the **last cell** in its node, the header parse over-runs the buffer → heap-buffer-overflow (`sqlite3GetVarint` in `sqlite3VdbeExec`).

This reproduces on a **normal path** (`fordelete-3.1`), not just under OOM.

## Fix
Append `PROLLY_NODE_BUFFER_SLOP` (8) zeroed bytes to every cached node buffer in `prollyCachePutOwned` — the single choke point all cached nodes pass through (so the prolly node parse and all readers see the slack). `nData` stays the logical size; the slop only backstops boundary over-reads.

## Disambiguation (slop vs. corruption)
I verified this is the real fix and not masking a bug:
- **`fordelete`** → now passes; its 4 remaining failures are the **intentional** `sqlite_autoindex` naming divergence for WITHOUT-ROWID indexes (recorded), data is correct. **Gated.**
- **`rowvaluefault` / `mallocL` / `fkey_malloc` / `rtree`** → crash gone, but they now **fail visibly** with `database disk image is malformed` under OOM injection. That's a **separate, deeper OOM-error-path corruption bug** (same family as rtree's prolly-invariant violation) — **left in the #1208 backlog, NOT masked** (they remain red, not green-with-wrong-data).

## Validation
CI-faithful (`DOLTLITE_PROLLY_CHECK=1`): `fordelete` OK (20 tests, 4 known divergences); **no regression** across `select1`/`insert`/`update`/`where`/`join`/`index`/`intpkey`/`fkey2`/`vacuum`/`trans`/`savepoint`/`sort5`/`fts3fault`/`count`/`rowid`. (`asan-ubsan` CI confirms memory/leak; perf-ceiling jobs will show if the per-put `realloc` needs follow-up — if so, allocate slop at the node-buffer source.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)