### PR TITLE
Fix OOM build-misorder tree corruption in prollyMutateFlush (#1208)

### DIFF
--- a/src/prolly_mutate.c
+++ b/src/prolly_mutate.c
@@ -1358,6 +1358,13 @@ int prollyMutateFlush(ProllyMutator *pMut){
     return SQLITE_OK;
   }
 
+  /* Materialize the edit sort order before any strategy iterates it. The
+  ** iterator helpers compute it lazily and discard an allocation failure; an
+  ** OOM there would leave a stale order and a strategy (e.g. buildFromEdits)
+  ** would emit keys out of order, corrupting the tree. Fail cleanly instead. */
+  rc = prollyMutMapEnsureOrder(pMut->pEdits);
+  if( rc!=SQLITE_OK ) return rc;
+
   if( prollyHashIsEmpty(&pMut->oldRoot) ){
     rc = buildFromEdits(pMut);
   }else{

--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -435,6 +435,14 @@ static int ensureOrder(ProllyMutMap *mm){
   return SQLITE_OK;
 }
 
+/* Materialize the sorted iteration order now, propagating an allocation
+** failure. The void iterator-init helpers call ensureOrder() internally and
+** discard its return code, so a caller that must not iterate a stale order
+** under OOM (e.g. a tree build) calls this first and bails on error. */
+int prollyMutMapEnsureOrder(ProllyMutMap *mm){
+  return ensureOrder(mm);
+}
+
 static int rankEntryWithoutOrder(ProllyMutMap *mm, int phys){
   ProllyMutMapEntry *target = &mm->aEntries[phys];
   int rank = 0;

--- a/src/prolly_mutmap.h
+++ b/src/prolly_mutmap.h
@@ -111,6 +111,12 @@ struct ProllyMutMapIter {
   int idx;
 };
 
+/* Compute the sorted iteration order up front, returning SQLITE_NOMEM on
+** allocation failure. IterFirst/IterLast/IterSeek compute it lazily and
+** discard the error, so callers that must not iterate a stale order on OOM
+** (e.g. a tree build) should call this first and bail on failure. */
+int prollyMutMapEnsureOrder(ProllyMutMap *mm);
+
 void prollyMutMapIterFirst(ProllyMutMapIter *it, ProllyMutMap *mm);
 
 void prollyMutMapIterNext(ProllyMutMapIter *it);


### PR DESCRIPTION
## Summary
Fourth bug from the #1208 ASan-crash triage — a real **OOM-induced tree-corruption** bug.

The mutmap iterator helpers (`prollyMutMapIterFirst`/`Last`/`Seek`) are `void` and call `ensureOrder()` internally but **discard its return code**. `ensureOrder()` allocates sort scratch, so under OOM it returns `SQLITE_NOMEM` and leaves `orderDirty` set with a **stale/unsorted** `aOrder`. The iterator then walks entries in the wrong order, and a flush strategy that builds a tree from that iteration (`buildFromEdits`, …) emits **keys out of order** → a leaf with non-ascending keys → corrupt prolly tree.

- With `PROLLY_CHECK`: aborts — `prolly tree invariant violated: keys not strictly ascending at level=0 [strat=buildFromEdits]`.
- Without it: the corrupt root is committed and later reads report `database disk image is malformed`.

## Fix
Expose `prollyMutMapEnsureOrder()` and call it once at the top of `prollyMutateFlush`, propagating `SQLITE_NOMEM` so a failed sort aborts the flush cleanly instead of building from a stale order. Every strategy then iterates a correct order, and the iterators' discarded rc becomes harmless. (3 files, ~20 lines.)

## Evidence & scope
- **Fail-before / pass-after** under `PROLLY_CHECK`: `rtree` aborted with the invariant violation before this change; **zero corruption** after (`corrupt=0`).
- **Regression-clean** (`DOLTLITE_PROLLY_CHECK=1`): `trans`, `fts3fault` (21,208), `fts3fault2` (21,398), `savepoint`, `fkey2`, `vacuum`, `insert`, `update` all pass.
- **Latent fix — no test gated yet.** The fault tests that exposed this (`rtree`, `rowvaluefault`, `mallocL`, `fkey_malloc`) still fail on a **separate** `database disk image is malformed` bug in the commit/chunk-store OOM path (next target, #1208). This change is a prerequisite correctness fix, not a test-enabler.

Follow-up noted in #1208: the cursor-read iterator paths (`IterSeek`/`IterLast` in prolly_btree.c) also discard `ensureOrder`'s rc — lower severity (wrong read under OOM, not corruption).

🤖 Generated with [Claude Code](https://claude.com/claude-code)