### PR TITLE
Fix false 'malformed' from OOM-swallowing payload reconstruction; gate rowvaluefault/mallocL (#1208)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -557,7 +557,8 @@ jobs:
           joinH joinI json107 json108 json109 json501 json502 jsonb01 \
           keyword1 lastinsert laststmtchanges literal literal2 loadext loadext2 lock6 \
           lookaside malloc4 malloc5 malloc7 malloc8 malloc9 mallocB mallocE \
-          mallocJ mallocM manydb mem5 memsubsys2 merge1 minmax4 misc2 \
+          mallocJ mallocL mallocM manydb mem5 memsubsys2 merge1 minmax4 misc2 \
+          rowvaluefault \
           misc3 misc6 misuse mmap2 mmapfault multiplex3 mutex2 normalize \
           notify1 notify2 notify3 notnull2 nulls1 numindex1 offset1 orderby5 \
           orderby6 orderby7 orderby8 orderby9 orderbyA orderbyB ovfl pageropt \

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -7497,10 +7497,18 @@ static void getCursorPayload(BtCursor *pCur, const u8 **ppData, int *pnData){
         *ppData = e->pVal;
         *pnData = e->nVal;
       }else{
-        if( cacheCursorPayloadReconstructed(pCur, e->pKey, e->nKey)==SQLITE_OK ){
+        int rcRecon = cacheCursorPayloadReconstructed(pCur, e->pKey, e->nKey);
+        if( rcRecon==SQLITE_OK ){
           *ppData = pCur->pCachedPayload;
           *pnData = pCur->nCachedPayload;
         }else{
+          /* Reconstruction failed under OOM. PayloadSize and PayloadFetch each
+          ** call this; if one fails and a later (transient-OOM) call succeeds,
+          ** OP_Column sees size 0 vs a non-empty row and reports a false
+          ** "malformed". Record the OOM so the read aborts as SQLITE_NOMEM. */
+          if( rcRecon==SQLITE_NOMEM && pCur->pBtree && pCur->pBtree->db ){
+            sqlite3OomFault(pCur->pBtree->db);
+          }
           *ppData = 0;
           *pnData = 0;
         }
@@ -7531,12 +7539,20 @@ static void getCursorPayload(BtCursor *pCur, const u8 **ppData, int *pnData){
     }else{
       const u8 *pKey; int nKey;
       prollyCursorKey(&pCur->pCur, &pKey, &nKey);
-      if( cacheCursorPayloadReconstructed(pCur, pKey, nKey)==SQLITE_OK ){
-        *ppData = pCur->pCachedPayload;
-        *pnData = pCur->nCachedPayload;
-      }else{
-        *ppData = pVal;
-        *pnData = 0;
+      {
+        int rcRecon = cacheCursorPayloadReconstructed(pCur, pKey, nKey);
+        if( rcRecon==SQLITE_OK ){
+          *ppData = pCur->pCachedPayload;
+          *pnData = pCur->nCachedPayload;
+        }else{
+          /* See note above: surface reconstruction OOM as SQLITE_NOMEM so a
+          ** size/fetch mismatch can't masquerade as a corrupt record. */
+          if( rcRecon==SQLITE_NOMEM && pCur->pBtree && pCur->pBtree->db ){
+            sqlite3OomFault(pCur->pBtree->db);
+          }
+          *ppData = pVal;
+          *pnData = 0;
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
The "database disk image is malformed under OOM" bug that gated rtree/rowvaluefault/mallocL/fkey_malloc — and it was a **false corruption**, not real data loss.

`OP_Column` calls `sqlite3BtreePayloadSize()` then `sqlite3BtreePayloadFetch()`; both route through `getCursorPayload()`, which for a value needing reconstruction calls `cacheCursorPayloadReconstructed()`. On failure it **silently set `*pnData = 0` and dropped the error**. Under **transient OOM**, the first call (PayloadSize) fails → size `0`, while the second (PayloadFetch, OOM recovered) returns the real non-empty row → `OP_Column` sees `header-size > payloadSize(0)` and reports `SQLITE_CORRUPT` — a fake "malformed" on a row that's actually intact.

## How it was found
Eight instrumentation cycles, progressively ruling out: the commit/durability path (append-only, crash-safe), dangling chunks (all chunkStoreGet corrupt sites silent), node-structure parse (clean at cache-put), and node-builder value truncation. The decisive trace at `op_column_corrupt` showed **`payloadSize=0` but `szRow=7`** — a size/fetch *mismatch*, not bad data.

## Fix
Record the reconstruction OOM via `sqlite3OomFault()` at both `getCursorPayload` failure sites. The read then aborts as `SQLITE_NOMEM` (`abort_due_to_error` converts the column path to NOMEM when `mallocFailed` is set) — the correct OOM outcome the fault tests expect — instead of fabricating corruption.

## Impact
- **rowvaluefault (210 tests)** and **mallocL (1852 tests)** now pass clean → **gated**.
- **rtree**: the #1215 sort-order corruption is gone (`corrupt=0`); a *separate* residual failure remains (tracked in #1208).
- **fkey_malloc**: "malformed" fixed; its remaining failures are the intentional WITHOUT-ROWID `no such column: rowid` divergence.

## Validation
CI-faithful (`DOLTLITE_PROLLY_CHECK=1`): rowvaluefault + mallocL OK; **no regression** across trans/fts3fault(21208)/savepoint/fkey2/vacuum/sort5/insert/update. (`asan-ubsan` confirms no memory issue.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)