### PR TITLE
ci: gate fkey_malloc with recorded rowid divergences (#1208)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -538,7 +538,7 @@ jobs:
           decimal delete3 delete4 e_blobbytes e_droptrigger e_dropview e_resolve emptytable \
           eqp eqp2 errofst1 eval exec exists existsexpr existsexpr2 \
           expr2 exprfault expridx1 filectrl filter1 filter2 filterfault fkey3 \
-          fkey4 fkey6 fkey7 fkey8 fordelete fts-9fd058691 fts3aa fts3ab fts3ac \
+          fkey4 fkey6 fkey7 fkey8 fkey_malloc fordelete fts-9fd058691 fts3aa fts3ab fts3ac \
           fts3ad fts3ae fts3af fts3ag fts3ah fts3aj fts3ak fts3al \
           fts3am fts3atoken fts3atoken2 fts3auto fts3aux1 fts3aux2 fts3b fts3c \
           fts3comp1 fts3corrupt fts3corrupt3 fts3corrupt5 fts3corrupt6 fts3d fts3defer fts3drop \

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1158,3 +1158,20 @@ fordelete fordelete-1.1  # sqlite_autoindex naming: "t1" vs "sqlite_autoindex_t1
 fordelete fordelete-1.2  # sqlite_autoindex naming
 fordelete fordelete-1.3  # sqlite_autoindex naming
 fordelete fordelete-1.4  # sqlite_autoindex naming
+
+# fkey_malloc — DELETE ... WHERE rowid uses the rowid column, which doltlite's
+# WITHOUT-ROWID tables don't expose, so these assertions diverge ("no such
+# column: rowid" / different affected-row count). Recovered into the gate after
+# the OOM crashes (#1212/#1216) were fixed; fault-iteration numbers are
+# deterministic on the CI build.
+fkey_malloc fkey_malloc-6.transient.33   # DELETE WHERE rowid: no such column rowid
+fkey_malloc fkey_malloc-6.transient.34   # DELETE WHERE rowid
+fkey_malloc fkey_malloc-6.transient.35   # DELETE WHERE rowid
+fkey_malloc fkey_malloc-6.transient.69   # DELETE WHERE rowid
+fkey_malloc fkey_malloc-6.persistent.69  # DELETE WHERE rowid
+fkey_malloc fkey_malloc-7.transient.200  # DELETE FROM t1 WHERE rowid>1: WITHOUT-ROWID row set differs
+fkey_malloc fkey_malloc-7.transient.201  # rowid-range DELETE
+fkey_malloc fkey_malloc-7.transient.202  # rowid-range DELETE
+fkey_malloc fkey_malloc-7.transient.523  # rowid-range DELETE
+fkey_malloc fkey_malloc-7.transient.524  # rowid-range DELETE
+fkey_malloc fkey_malloc-7.transient.525  # rowid-range DELETE


### PR DESCRIPTION
## Summary
Cleans up and gates **fkey_malloc** now that its OOM crashes are fixed (#1212/#1216).

fkey_malloc reaches its summary with 11 failures — **all the intentional WITHOUT-ROWID divergence**: sections 6 and 7 use `DELETE ... WHERE rowid` / `WHERE rowid>1`, and doltlite's WITHOUT-ROWID tables don't expose a `rowid` column (`no such column: rowid`, or a different affected-row set). Recorded the 11 entries and added fkey_malloc to the `inherited-testfixture` gate.

The fault-iteration subtest numbers (`6.transient.33`, …) are **deterministic on the CI build** — verified identical across repeated runs — so the strict gate won't flake.

Validated: `OK: fkey_malloc (5415 tests, 11 known divergences)`.

## rtree is NOT gated here — it's blocked by a real bug
rtree aborts **before its summary** with an uncaught `Error: undersize RTree blobs in "t1_node"`. That's `rtreecheck` (rtree.c) finding the `t1_node` shadow blob's `length(data) < 448` (the `iNodeSize` floor) — i.e. doltlite stores/returns the rtree node blob undersized. That's a doltlite **rtree-storage bug**, not a divergence, so it can't be divergence-gated. Tracked in #1208 for a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)