### PR TITLE
Fix cross-backend TransferRow SEGV; gate interrupt/vacuum5/autoinc (#1208)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -479,7 +479,7 @@ jobs:
           schema schema2 schema3 schema4 \
           shared shared2 shared3 \
           speed1 substr table tempdb \
-          vacuum vacuum2 \
+          vacuum vacuum2 vacuum5 autoinc interrupt \
           tkt-38cb5df375 tkt-9a8b09f8e6 tkt-99378177930f87bd \
           tkt-80e031a00f tkt-80ba201079 tkt-31338dca7e \
           tkt-7bbfb7d442 tkt-4dd95f6943 tkt-2d1a5c67d \

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -8271,7 +8271,41 @@ int sqlite3BtreeTripAllCursors(Btree *p, int errCode, int writeOnly){
   }
   return SQLITE_OK;
 }
+/* Backend-agnostic row transfer for when pSrc and pDest use different cursor
+** backends (e.g. VACUUM copying a prolly table into a stock-btree temp db).
+** Each backend's xTransferRow fast path assumes the other cursor is the same
+** type and reaches into pOrigCursor / pCur directly, which is a NULL deref
+** across backends. Copy via the public payload accessors instead. */
+static int btreeGenericTransferRow(BtCursor *pDest, BtCursor *pSrc, i64 iKey){
+  int rc;
+  BtreePayload x;
+  u32 nPayload;
+  u8 *pBuf;
+
+  nPayload = sqlite3BtreePayloadSize(pSrc);
+  pBuf = (u8*)sqlite3_malloc(nPayload>0 ? (int)nPayload : 1);
+  if( pBuf==0 ) return SQLITE_NOMEM;
+  rc = sqlite3BtreePayload(pSrc, 0, nPayload, pBuf);
+  if( rc!=SQLITE_OK ){ sqlite3_free(pBuf); return rc; }
+
+  memset(&x, 0, sizeof(x));
+  if( pDest->curIntKey ){
+    x.nKey = iKey;
+    x.pData = pBuf;
+    x.nData = (int)nPayload;
+  }else{
+    x.pKey = pBuf;
+    x.nKey = (int)nPayload;
+  }
+  rc = sqlite3BtreeInsert(pDest, &x, 0, 0);
+  sqlite3_free(pBuf);
+  return rc;
+}
+
 int sqlite3BtreeTransferRow(BtCursor *pDest, BtCursor *pSrc, i64 iKey){
+  if( pDest->pCurOps != pSrc->pCurOps ){
+    return btreeGenericTransferRow(pDest, pSrc, iKey);
+  }
   return pDest->pCurOps->xTransferRow(pDest, pSrc, iKey);
 }
 

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1175,3 +1175,20 @@ fkey_malloc fkey_malloc-7.transient.202  # rowid-range DELETE
 fkey_malloc fkey_malloc-7.transient.523  # rowid-range DELETE
 fkey_malloc fkey_malloc-7.transient.524  # rowid-range DELETE
 fkey_malloc fkey_malloc-7.transient.525  # rowid-range DELETE
+# vacuum5 — VACUUM file-size / page-count metrics; doltlite has no SQLite page
+# format so the byte/page counts differ (the data is correct). Recovered into
+# the gate once the cross-backend TransferRow SEGV was fixed.
+vacuum5 vacuum5-1.3.2  # VACUUM page-count/size metric
+vacuum5 vacuum5-1.3.3  # VACUUM size metric
+vacuum5 vacuum5-1.3.4  # VACUUM size metric
+vacuum5 vacuum5-3.2    # VACUUM size metric
+
+# autoinc — sqlite_master enumeration order, and writable_schema corruption of
+# sqlite_sequence not detected as malformed (prolly catalog isn't the raw
+# sqlite_master row store). AUTOINCREMENT itself works.
+autoinc autoinc-1.6   # sqlite_master enumeration order (t1 vs sqlite_sequence)
+autoinc autoinc-12.1  # writable_schema sqlite_sequence corruption undetected
+autoinc autoinc-12.2  # writable_schema corruption undetected
+autoinc autoinc-12.3  # writable_schema corruption undetected
+autoinc autoinc-12.4  # writable_schema corruption undetected
+autoinc autoinc-12.5  # writable_schema corruption undetected


### PR DESCRIPTION
## Summary
Fresh CRASH-ASAN file group from the #1208 triage — a real **NULL-deref SEGV** in the cross-backend row-transfer path.

`sqlite3BtreeTransferRow(pDest, pSrc)` dispatched on **pDest's** cursor backend only. Each backend's `xTransferRow` fast path assumes `pSrc` is the same backend and reaches into `pSrc->pOrigCursor` (stock path) or `pSrc->pCur` (prolly path) directly. When the two cursors use **different backends** — VACUUM copying a prolly user table into a stock-btree temp db, or INSERT...SELECT across backends — `orig_sqlite3BtreeTransferRow` ran `getCellInfo()` on a prolly source with no stock page → **SEGV** (`getCellInfo`, addr 0x46).

## Fix
Add `btreeGenericTransferRow`: when the cursor backends differ, copy the row via the public payload accessors (`sqlite3BtreePayloadSize`/`Payload` → buffer → `sqlite3BtreeInsert`) instead of the same-backend fast path. Same-backend transfers keep the fast path.

## Impact (4 SEGVs fixed)
- **interrupt** → passes, **gated** (1828 tests).
- **vacuum5** (VACUUM size/page-count metrics) and **autoinc** (sqlite_master order + `writable_schema` sqlite_sequence corruption undetected) → now reach summary with intentional divergences, recorded and **gated**.
- **interrupt2** → SEGV gone, but still fails because doltlite **doesn't honor `sqlite3_interrupt` during prolly scans** — a real *limitation*, not a divergence, so **not gated** (tracked in #1208; masking it would hide a real gap).
- **jrnlmode**, **shared9** → still crash on a separate issue (#1208).

## Validation
CI-faithful (`DOLTLITE_PROLLY_CHECK=1`): interrupt/vacuum5/autoinc gate green; **no regression** across vacuum/trans/insert/fkey2/sort5/update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)