### PR TITLE
Fix use-after-free of stale pager-shim file handle (#1208)

### DIFF
--- a/src/pager_shim.c
+++ b/src/pager_shim.c
@@ -176,7 +176,12 @@ static sqlite3_file *shimPagerFile(Pager *p){
   ** chunk store's file handle via csReloadFromDisk or gcRewriteFile. */
   if( s->pStore ){
     sqlite3_file *pCurrent = chunkFileGetHandle(&((ChunkStore*)s->pStore)->file);
-    if( pCurrent ) return pCurrent;
+    /* The store owns the handle and may have closed it without reopening — e.g.
+    ** a csRollbackFailedAppend reopen that failed under OOM leaves it NULL. Do
+    ** NOT fall back to s->pFd here: it is the stale snapshot from shim creation
+    ** and may point at the handle the store just freed (use-after-free). Return
+    ** the inert dummy so file ops fail cleanly until the store reopens. */
+    return pCurrent ? pCurrent : pagerShimDummyFile();
   }
   return s->pFd;
 }


### PR DESCRIPTION
## Summary
A real heap-use-after-free in the pager shim, from the #1208 ASan triage.

`shimPagerFile()` resolves a chunk-store-bound shim's file handle through the store (`chunkFileGetHandle`) so callers see the **current** `cs->file.pFile` rather than the snapshot captured at shim creation (`s->pFd`) — important because GC / reload / failed-append rollback can replace the store's handle. But when the store had **closed its handle without reopening** — e.g. `csRollbackFailedAppend()` closes `cs->file.pFile` and its reopen fails under OOM, leaving it NULL — the function fell back to `return s->pFd`. `s->pFd` points at the very handle the store just freed via `csCloseFile()`, so a later op (a PRAGMA `sqlite3_file_control` in the repro) dereferenced freed memory:

```
heap-use-after-free in sqlite3OsFileControl
  freed by: csCloseFile <- csCommitToFile <- chunkStoreCommit <- prollyBtreeRollback
```

## Fix
For store-bound shims, `s->pFd` is never authoritative (that's the whole reason this resolves through the store). Return the inert dummy file object when the store's handle is NULL, so file ops are safe no-ops until the store reopens lazily — instead of dereferencing the freed `s->pFd`.

## Scope
- Removes the UAF (ASan fail-before / pass-after: heap-use-after-free → none). This affects **any** path where the store closes+reopens its handle and a `file_control` follows, not just the fault tests.
- Surfaced by `dbpagefault`/`walfault`; both still hit **separate** shm-error / virtual-table fault-injection issues before their summary, so they remain ungated (tracked in #1208). This is a **latent fix** — no test gated, evidence is the ASan transition.
- Regression-clean: vacuum/insert/fkey2/sort5/savepoint/update all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)