### PR TITLE
Fix TransferRow SEGV on mutmap-resident source rows; gate shared9 (#1208)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -477,7 +477,7 @@ jobs:
           orderby1 orderby2 orderby3 orderby4 \
           pragma pragma2 printf2 \
           schema schema2 schema3 schema4 \
-          shared shared2 shared3 \
+          shared shared2 shared3 shared9 \
           speed1 substr table tempdb \
           vacuum vacuum2 vacuum5 autoinc interrupt \
           tkt-38cb5df375 tkt-9a8b09f8e6 tkt-99378177930f87bd \

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -8177,24 +8177,33 @@ int sqlite3BtreeDelete(BtCursor *pCur, u8 flags){
 
 static int prollyBtCursorTransferRow(BtCursor *pDest, BtCursor *pSrc, i64 iKey){
   int rc;
-  const u8 *pVal;
-  int nVal;
   BtreePayload payload;
 
   assert( pSrc->eState==CURSOR_VALID );
 
-  prollyCursorValue(&pSrc->pCur, &pVal, &nVal);
-
   memset(&payload, 0, sizeof(payload));
 
   if( pDest->curIntKey ){
+    /* Read the source value through getCursorPayload (mutmap-aware): a row that
+    ** lives in the source's pending mutmap has no tree node, so a bare
+    ** prollyCursorValue() on pSrc->pCur NULL-derefs in prollyNodeValue. */
+    const u8 *pVal;
+    int nVal;
+    getCursorPayload(pSrc, &pVal, &nVal);
     payload.nKey = iKey;
     payload.pData = pVal;
     payload.nData = nVal;
   } else {
     const u8 *pKey;
     int nKey;
-    prollyCursorKey(&pSrc->pCur, &pKey, &nKey);
+    if( pSrc->mmActive
+     && (pSrc->mergeSrc==MERGE_SRC_MUT || pSrc->mergeSrc==MERGE_SRC_BOTH) ){
+      ProllyMutMapEntry *pEntry = currentMutMapEntry(pSrc);
+      pKey = pEntry->pKey;
+      nKey = pEntry->nKey;
+    }else{
+      prollyCursorKey(&pSrc->pCur, &pKey, &nKey);
+    }
     payload.pKey = pKey;
     payload.nKey = nKey;
   }

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1192,3 +1192,12 @@ autoinc autoinc-12.2  # writable_schema corruption undetected
 autoinc autoinc-12.3  # writable_schema corruption undetected
 autoinc autoinc-12.4  # writable_schema corruption undetected
 autoinc autoinc-12.5  # writable_schema corruption undetected
+
+# shared9 — shared-cache locking model differs (doltlite doesn't surface the
+# "database is locked" shared-cache contention these assertions expect). Same
+# intentional locking-model category as the other shared* entries. Recovered
+# into the gate once the mutmap-source TransferRow SEGV was fixed.
+shared9 shared9-2.1  # shared-cache locking-model divergence
+shared9 shared9-3.4  # "database is locked" not surfaced (shared-cache model)
+shared9 shared9-3.5  # shared-cache locking-model divergence
+shared9 shared9-3.6  # shared-cache locking-model divergence


### PR DESCRIPTION
## Summary
Another CRASH-ASAN SEGV from #1208, in the same-backend prolly row-transfer path.

`prollyBtCursorTransferRow` read the source row via `prollyCursorValue(&pSrc->pCur)` / `prollyCursorKey(&pSrc->pCur)` — the **tree cursor only**. When the source row lives in the source cursor's **pending mutmap** (an uncommitted edit not yet flushed to the tree), `pSrc->pCur` is on no tree node, so `prollyNodeValue` NULL-deref'd:

```
SEGV in prollyNodeValue <- prollyCursorValue <- prollyBtCursorTransferRow <- sqlite3BtreeTransferRow
```

This is the same-backend prolly→prolly transfer (INSERT...SELECT etc.); #1218 only covered the cross-backend case.

## Fix
Read the source through the **mutmap-aware** accessors — `getCursorPayload()` for the value (table dest) and `currentMutMapEntry()`'s key when `pSrc->mmActive` for the index-key dest — mirroring how the cursor exposes its current row elsewhere.

## Impact
Fixes the SEGV in **jrnlmode** and **shared9**.
- **shared9** → reaches summary; its 4 failures are the intentional shared-cache locking-model divergence (`database is locked` not surfaced) — recorded and **gated**.
- **jrnlmode** → SEGV fixed but **ungated**: 76/98 assertions diverge because doltlite reports `journal_mode` as `wal` for every mode (no SQLite journal), a wholesale feature divergence like the other WAL/journal tests, not clean per-assertion divergences. Tracked in #1208.

## Validation
No regression: `interrupt`/`vacuum5`/`autoinc` (the #1218 TransferRow gates) plus `vacuum`/`insert`/`fkey2`/`sort5`/`update` all pass. shared9 gates green (20 tests, 4 known divergences).

🤖 Generated with [Claude Code](https://claude.com/claude-code)