### PR TITLE
Re-triage testfixture crash backlog: harden getDbPointer, enable interrupt2, document divergences, file bug issues (#1208)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -479,7 +479,7 @@ jobs:
           schema schema2 schema3 schema4 \
           shared shared2 shared3 shared9 \
           speed1 substr table tempdb \
-          vacuum vacuum2 vacuum5 autoinc interrupt \
+          vacuum vacuum2 vacuum5 autoinc interrupt interrupt2 \
           tkt-38cb5df375 tkt-9a8b09f8e6 tkt-99378177930f87bd \
           tkt-80e031a00f tkt-80ba201079 tkt-31338dca7e \
           tkt-7bbfb7d442 tkt-4dd95f6943 tkt-2d1a5c67d \

--- a/src/test1.c
+++ b/src/test1.c
@@ -117,6 +117,16 @@ int getDbPointer(Tcl_Interp *interp, const char *zA, sqlite3 **ppDb){
     *ppDb = p->db;
   }else{
     *ppDb = (sqlite3*)sqlite3TestTextToPtr(zA);
+#ifdef DOLTLITE_PROLLY
+    /* doltlite validates the chunk-store manifest at open time, so a file with
+    ** deliberately-corrupted header bytes (set_file_format, shm permissions)
+    ** fails sqlite3_open and the Tcl connection command is never created. A
+    ** later "sqlite3_errcode db" then reaches this branch with a bare command
+    ** name, which sqlite3TestTextToPtr parses as a sub-page bogus pointer
+    ** (e.g. "db" -> 0xdb). Treat any NULL-page value as NULL so the error APIs
+    ** return cleanly rather than dereferencing a wild pointer. */
+    if( (uptr)(*ppDb) < 4096 ) *ppDb = 0;
+#endif
   }
   return TCL_OK;
 }

--- a/test/known_testfixture_crashes.txt
+++ b/test/known_testfixture_crashes.txt
@@ -32,3 +32,14 @@
 crash8        # crash-recovery simulation; incompatible with prolly format / times out
 fuzz3         # raw byte-corruption fuzz mutates test.db offsets; prolly storage aborts after restore/checksum
 shared        # shared-cache semantics unsupported under doltlite; setup aborts
+
+# Raw-format/WAL divergences whose failed open cascades into an uncaught Tcl
+# error before the summary line. doltlite validates the chunk-store manifest at
+# open time, so these files' deliberately-corrupted-header / readonly-shm setups
+# (set_file_format, file attributes -permissions) fail sqlite3_open and never
+# create the Tcl connection command; later "db ..." references then raise an
+# uncaught {invalid command name "db"} that aborts the script. The wild-pointer
+# SEGV these used to take inside getDbPointer (parsing "db" as the pointer 0xdb)
+# is fixed in test1.c; the underlying open-time divergence is intentional.
+alter2        # set_file_format corrupts the prolly manifest; eager open fails, db command never created
+walro         # readonly_shm + readonly *-shm perms; doltlite has no WAL shm, open fails, db command never created

--- a/test/known_testfixture_crashes.txt
+++ b/test/known_testfixture_crashes.txt
@@ -43,3 +43,17 @@ shared        # shared-cache semantics unsupported under doltlite; setup aborts
 # is fixed in test1.c; the underlying open-time divergence is intentional.
 alter2        # set_file_format corrupts the prolly manifest; eager open fails, db command never created
 walro         # readonly_shm + readonly *-shm perms; doltlite has no WAL shm, open fails, db command never created
+nan           # raw hexio_write of NaN bit patterns into the manifest; eager open fails, db command never created (same footgun as alter2)
+
+# WAL / shm feature divergences. doltlite has no rollback-journal or WAL *-shm
+# sidecar, so these files' journal-mode / shm-fault setups abort before the
+# summary line (uncaught "no such file"/shm errors, or a test-VFS lock UAF in
+# tvfsLock during WAL-checkpoint teardown). Feature gaps, not prolly bugs.
+dbpagefault   # shm-fault injection; doltlite has no *-shm, setup aborts pre-summary
+walfault      # WAL-frame fault injection; no WAL, aborts pre-summary
+e_walckpt     # WAL checkpoint semantics; reaches summary then UAFs in test_vfs tvfsLock teardown
+
+# rtree virtual table: after DROP+CREATE the %_node shadow table reload reads an
+# empty/undersized blob (vtable schema-reload visibility), accumulating into a
+# hang. History-dependent; not per-test gateable. Tracked in #1119.
+rtree         # rtree vtable schema-reload visibility; times out

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1201,3 +1201,21 @@ shared9 shared9-2.1  # shared-cache locking-model divergence
 shared9 shared9-3.4  # "database is locked" not surfaced (shared-cache model)
 shared9 shared9-3.5  # shared-cache locking-model divergence
 shared9 shared9-3.6  # shared-cache locking-model divergence
+
+# interrupt2 — sqlite3_interrupt() is not honored during prolly table scans:
+# cursor step loops don't poll db->u1.isInterrupted, so a running statement
+# never returns SQLITE_INTERRUPT (got "not interrupted" / extra rows scanned).
+# Feature gap tracked in #1228; the file does not crash and the other 16 tests
+# give real coverage.
+interrupt2 interrupt2-1.5.1   # interrupt not honored mid-scan
+interrupt2 interrupt2-1.5.3   # interrupt not honored mid-scan
+interrupt2 interrupt2-1.10.1  # interrupt not honored mid-scan
+interrupt2 interrupt2-1.10.3  # interrupt not honored mid-scan
+interrupt2 interrupt2-1.15.1  # interrupt not honored mid-scan
+interrupt2 interrupt2-1.15.3  # interrupt not honored mid-scan
+interrupt2 interrupt2-1.20.1  # interrupt not honored mid-scan
+interrupt2 interrupt2-1.20.3  # interrupt not honored mid-scan
+interrupt2 interrupt2-2.0     # scan continues past interrupt (extra rows)
+interrupt2 interrupt2-2.1     # interrupt not honored mid-scan
+interrupt2 interrupt2-3.1.2   # interrupt not honored mid-scan
+interrupt2 interrupt2-4.1     # interrupt not honored mid-scan


### PR DESCRIPTION
## Summary

Re-triages the remaining ASan testfixture crash backlog for #1208, separating **genuine doltlite memory bugs** from **intentional divergences / harness footguns**, and unblocking the runnable ones.

### Harness hardening (the footgun behind several "crashes")
`getDbPointer` parsed a bare connection name as a raw pointer when the Tcl command didn't exist (`sqlite3TestTextToPtr("db")` → `0xdb`). Under doltlite this fires whenever an open fails (the connection command is never created) and a later test references it by name → wild-pointer deref in `sqlite3SafetyCheckSickOrOk` → SEGV. Now gated under `DOLTLITE_PROLLY` to reject sub-page values, turning the SEGV into a clean error for *any* failed-open-then-reference-by-name test.

### Enabled in CI (real coverage)
- **`interrupt2`** — no crash; 12/28 diverge solely because `sqlite3_interrupt` isn't honored during prolly scans. Divergences recorded; file enabled (16 tests now give coverage). Feature gap tracked in **#1228**.

### Documented as intentional (crash list)
- `alter2`, `walro`, `nan` — raw-format footgun (corrupt-header / readonly-shm / NaN `hexio_write` → eager open fails → no `db` command).
- `dbpagefault`, `walfault`, `e_walckpt` — WAL/shm feature divergences (no journal / `*-shm` sidecar).
- `rtree` — vtable schema-reload visibility hang.

### Genuine doltlite memory bugs → filed for farm-out
| Issue | Bug |
|---|---|
| #1222 | `catFind` NULL-catalog deref under OOM (windowfault, notnullfault) |
| #1223 | `sqlite3VdbeExec` NULL deref under OOM (cffault, malloc) |
| #1224 | `buildRuntimeMasterRoot` NULL deref under OOM in commit (fts3malloc) |
| #1225 | `sqlite3_serialize` NULL deref on memdb (memdb1) |
| #1226 | `prollyBtCursorTransferRow` NULL node via `prollyCursorValue` (jrnlmode) |
| #1227 | zombie-close UAF: `sqlite3_close` frees prolly state used by open stmts (createtab, incrcorrupt) |

## Testing
- `build-asan-tf` (ASan) testfixture rebuilds clean.
- `alter2`/`walro`/`nan`: SEGV → clean abort (no DEADLYSIGNAL).
- `interrupt2`: reaches summary, exactly the 12 recorded divergences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)