### PR TITLE
Handle OOM during prolly payload reconstruction

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -535,7 +535,7 @@ jobs:
           collate5 collate6 collate7 collate8 collateA collateB colname columncount \
           conflict2 contrib01 corrupt3 cost countofview coveridxscan csv01 ctime \
           cursorhint cursorhint2 dataversion1 date2 date3 date4 date5 dbdata \
-          decimal delete3 delete4 e_blobbytes e_droptrigger e_dropview e_resolve emptytable \
+          cffault decimal delete3 delete4 e_blobbytes e_droptrigger e_dropview e_resolve emptytable \
           eqp eqp2 errofst1 eval exec exists existsexpr existsexpr2 \
           expr2 exprfault expridx1 filectrl filter1 filter2 filterfault fkey3 \
           fkey4 fkey6 fkey7 fkey8 fkey_malloc fordelete fts-9fd058691 fts3aa fts3ab fts3ac \

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -465,7 +465,7 @@ static void invalidateSchema(Btree *pBtree);
 static int flushMutMap(BtCursor *pCur);
 static void refreshCursorMutMapAliases(Btree *pBtree, BtShared *pBt,
                                         Pgno iTable, ProllyMutMap *pNewMap);
-static void getCursorPayload(BtCursor *pCur, const u8 **ppData, int *pnData);
+static int getCursorPayload(BtCursor *pCur, const u8 **ppData, int *pnData);
 static int flushIfNeeded(BtCursor *pCur);
 static int flushAllPending(Btree *pBtree, BtShared *pBt, Pgno iTable);
 static int applyMutMapToTableRoot(BtShared *pBt, struct TableEntry *pTE, ProllyMutMap *pMap);
@@ -7471,12 +7471,32 @@ i64 sqlite3BtreeIntegerKey(BtCursor *pCur){
   return pCur->pCurOps->xIntegerKey(pCur);
 }
 
-static void getCursorPayload(BtCursor *pCur, const u8 **ppData, int *pnData){
+static int cursorPayloadFault(
+  BtCursor *pCur,
+  int rc,
+  const u8 **ppData,
+  int *pnData
+){
+  sqlite3 *db = pCur && pCur->pBtree ? pCur->pBtree->db : 0;
+  /* PayloadSize and PayloadFetch may both reconstruct payloads. Surface OOM
+  ** through db->mallocFailed so a size/fetch mismatch cannot masquerade as
+  ** a malformed record. */
+  if( rc==SQLITE_NOMEM && db ){
+    sqlite3OomFault(db);
+  }
+  *ppData = 0;
+  *pnData = 0;
+  return rc;
+}
+
+static int getCursorPayload(BtCursor *pCur, const u8 **ppData, int *pnData){
+  *ppData = 0;
+  *pnData = 0;
 
   if( pCur->pCachedPayload && pCur->nCachedPayload > 0 ){
     *ppData = pCur->pCachedPayload;
     *pnData = pCur->nCachedPayload;
-    return;
+    return SQLITE_OK;
   }
 
   if( pCur->mmActive
@@ -7497,24 +7517,16 @@ static void getCursorPayload(BtCursor *pCur, const u8 **ppData, int *pnData){
         *ppData = e->pVal;
         *pnData = e->nVal;
       }else{
-        int rcRecon = cacheCursorPayloadReconstructed(pCur, e->pKey, e->nKey);
-        if( rcRecon==SQLITE_OK ){
+        int rc = cacheCursorPayloadReconstructed(pCur, e->pKey, e->nKey);
+        if( rc==SQLITE_OK ){
           *ppData = pCur->pCachedPayload;
           *pnData = pCur->nCachedPayload;
         }else{
-          /* Reconstruction failed under OOM. PayloadSize and PayloadFetch each
-          ** call this; if one fails and a later (transient-OOM) call succeeds,
-          ** OP_Column sees size 0 vs a non-empty row and reports a false
-          ** "malformed". Record the OOM so the read aborts as SQLITE_NOMEM. */
-          if( rcRecon==SQLITE_NOMEM && pCur->pBtree && pCur->pBtree->db ){
-            sqlite3OomFault(pCur->pBtree->db);
-          }
-          *ppData = 0;
-          *pnData = 0;
+          return cursorPayloadFault(pCur, rc, ppData, pnData);
         }
       }
     }
-    return;
+    return SQLITE_OK;
   }
 
   if( pCur->curIntKey ){
@@ -7537,25 +7549,18 @@ static void getCursorPayload(BtCursor *pCur, const u8 **ppData, int *pnData){
       *ppData = pVal;
       *pnData = nVal;
     }else{
-      const u8 *pKey; int nKey;
+      const u8 *pKey; int nKey; int rc;
       prollyCursorKey(&pCur->pCur, &pKey, &nKey);
-      {
-        int rcRecon = cacheCursorPayloadReconstructed(pCur, pKey, nKey);
-        if( rcRecon==SQLITE_OK ){
-          *ppData = pCur->pCachedPayload;
-          *pnData = pCur->nCachedPayload;
-        }else{
-          /* See note above: surface reconstruction OOM as SQLITE_NOMEM so a
-          ** size/fetch mismatch can't masquerade as a corrupt record. */
-          if( rcRecon==SQLITE_NOMEM && pCur->pBtree && pCur->pBtree->db ){
-            sqlite3OomFault(pCur->pBtree->db);
-          }
-          *ppData = pVal;
-          *pnData = 0;
-        }
+      rc = cacheCursorPayloadReconstructed(pCur, pKey, nKey);
+      if( rc==SQLITE_OK ){
+        *ppData = pCur->pCachedPayload;
+        *pnData = pCur->nCachedPayload;
+      }else{
+        return cursorPayloadFault(pCur, rc, ppData, pnData);
       }
     }
   }
+  return SQLITE_OK;
 }
 
 static u32 prollyBtCursorPayloadSize(BtCursor *pCur){
@@ -7565,7 +7570,9 @@ static u32 prollyBtCursorPayloadSize(BtCursor *pCur){
   if( pCur->pCachedPayload && pCur->nCachedPayload > 0 ){
     return (u32)pCur->nCachedPayload;
   }
-  getCursorPayload(pCur, &pData, &nData);
+  if( getCursorPayload(pCur, &pData, &nData)!=SQLITE_OK ){
+    return 0;
+  }
   return (u32)nData;
 }
 u32 sqlite3BtreePayloadSize(BtCursor *pCur){
@@ -7578,9 +7585,13 @@ u32 sqlite3BtreePayloadSize(BtCursor *pCur){
 static int prollyBtCursorPayload(BtCursor *pCur, u32 offset, u32 amt, void *pBuf){
   const u8 *pData;
   int nData;
+  int rc;
 
   assert( pCur->eState==CURSOR_VALID );
-  getCursorPayload(pCur, &pData, &nData);
+  rc = getCursorPayload(pCur, &pData, &nData);
+  if( rc!=SQLITE_OK ){
+    return rc;
+  }
 
   if( (i64)offset + (i64)amt > (i64)nData ){
     return SQLITE_CORRUPT_BKPT;
@@ -7603,7 +7614,10 @@ static const void *prollyBtCursorPayloadFetch(BtCursor *pCur, u32 *pAmt){
     if( pAmt ) *pAmt = (u32)pCur->nCachedPayload;
     return (const void*)pCur->pCachedPayload;
   }
-  getCursorPayload(pCur, &pData, &nData);
+  if( getCursorPayload(pCur, &pData, &nData)!=SQLITE_OK ){
+    if( pAmt ) *pAmt = 0;
+    return 0;
+  }
 
   if( pAmt ) *pAmt = (u32)nData;
   return (const void*)pData;
@@ -8189,7 +8203,10 @@ static int prollyBtCursorTransferRow(BtCursor *pDest, BtCursor *pSrc, i64 iKey){
     ** prollyCursorValue() on pSrc->pCur NULL-derefs in prollyNodeValue. */
     const u8 *pVal;
     int nVal;
-    getCursorPayload(pSrc, &pVal, &nVal);
+    rc = getCursorPayload(pSrc, &pVal, &nVal);
+    if( rc!=SQLITE_OK ){
+      return rc;
+    }
     payload.nKey = iKey;
     payload.pData = pVal;
     payload.nData = nVal;
@@ -8795,12 +8812,16 @@ int sqlite3BtreeCheckpoint(Btree *p, int eMode, int *pnLog, int *pnCkpt){
 static int prollyBtCursorPayloadChecked(BtCursor *pCur, u32 offset, u32 amt, void *pBuf){
   const u8 *pVal;
   int nVal;
+  int rc;
 
   if( pCur->eState!=CURSOR_VALID ){
     return SQLITE_ABORT;
   }
 
-  getCursorPayload(pCur, &pVal, &nVal);
+  rc = getCursorPayload(pCur, &pVal, &nVal);
+  if( rc!=SQLITE_OK ){
+    return rc;
+  }
 
   if( (i64)offset + (i64)amt > (i64)nVal ){
     return SQLITE_CORRUPT_BKPT;

--- a/src/vdbe.c
+++ b/src/vdbe.c
@@ -3103,6 +3103,10 @@ op_column_restart:
       assert( sqlite3BtreeCursorIsValid(pCrsr) );
       pC->payloadSize = sqlite3BtreePayloadSize(pCrsr);
       pC->aRow = sqlite3BtreePayloadFetch(pCrsr, &pC->szRow);
+      if( pC->aRow==0 ){
+        if( db->mallocFailed ) goto no_mem;
+        goto op_column_corrupt;
+      }
       assert( pC->szRow<=pC->payloadSize );
       assert( pC->szRow<=65536 );  /* Maximum page size is 64KiB */
     }

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1175,6 +1175,23 @@ fkey_malloc fkey_malloc-7.transient.202  # rowid-range DELETE
 fkey_malloc fkey_malloc-7.transient.523  # rowid-range DELETE
 fkey_malloc fkey_malloc-7.transient.524  # rowid-range DELETE
 fkey_malloc fkey_malloc-7.transient.525  # rowid-range DELETE
+
+# cffault — sqlite3_db_cacheflush fault tests scan updated rows without an
+# ORDER BY. SQLite observes rowid/insertion order; DoltLite observes user-PK
+# order from prolly storage, so the injected-fault iteration sees a different
+# row order/visible row set. Recovered into the gate once #1223 stopped OOM
+# payload reconstruction from returning a NULL payload pointer.
+cffault cffault-2.1-cantopen-persistent.1  # cacheflush fault during unordered scan
+cffault cffault-2.1-cantopen-transient.1   # cacheflush fault during unordered scan
+cffault cffault-2.1-full.1                 # cacheflush fault during unordered scan
+cffault cffault-2.1-ioerr-persistent.1     # cacheflush fault during unordered scan
+cffault cffault-2.1-ioerr-transient.1      # cacheflush fault during unordered scan
+cffault cffault-2.1-oom-persistent.31      # cacheflush fault during unordered scan
+cffault cffault-2.1-oom-transient.28       # cacheflush fault during unordered scan
+cffault cffault-2.1-oom-transient.31       # cacheflush fault during unordered scan
+cffault cffault-2.1-shmerr-persistent.1    # cacheflush fault during unordered scan
+cffault cffault-2.1-shmerr-transient.1     # cacheflush fault during unordered scan
+cffault cffault-2.4-oom-transient.22       # cacheflush/release-memory unordered scan
 # vacuum5 — VACUUM file-size / page-count metrics; doltlite has no SQLite page
 # format so the byte/page counts differ (the data is correct). Recovered into
 # the gate once the cross-backend TransferRow SEGV was fixed.


### PR DESCRIPTION
## Summary
- propagate payload reconstruction failures from prolly cursors instead of returning a null payload as if it were valid
- mark reconstruction OOM on the sqlite connection so OP_Column exits through SQLITE_NOMEM
- guard OP_Column against null payload fetches before reading the record header
- enable the upstream `cffault` Tcl fixture in `inherited-testfixture` and document its 11 residual DoltLite divergences

Fixes #1223.

## Testing
- `LIBRARY_PATH=/opt/homebrew/lib CPATH=/opt/homebrew/include make testfixture`
- Docker Linux ARM64: `bash ../test/run_testfixture.sh "check" 120 cffault` -> `OK: cffault (211 tests, 11 known divergences)`
- full `cffault.test`: original trigger `cffault-1.2-oom-persistent.23... Ok`; full file now reaches summary
- scratch `malloc.test` extraction with `do_malloc_test 4 -start 650 -end 650`: `malloc-malloc-4.persistent.650... Ok`

## Notes
The issue also listed the whole `malloc` fixture. I measured it with `--maxerror=10000`; it still hits the 10,000-failure cap before completing (`10000 errors out of 22813 tests`, last failures in `malloc-13`). That is too large/incomplete for this exact-divergence CI gate, so this PR does not add `malloc` to `inherited-testfixture`.