### PR TITLE
Fix OP_OpenDup NOMEM swallow → catFind NULL-deref SEGV under OOM (#1222)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -560,7 +560,7 @@ jobs:
           mallocJ mallocL mallocM manydb mem5 memsubsys2 merge1 minmax4 misc2 \
           rowvaluefault \
           misc3 misc6 misuse mmap2 mmapfault multiplex3 mutex2 normalize \
-          notify1 notify2 notify3 notnull2 nulls1 numindex1 offset1 orderby5 \
+          notify1 notify2 notify3 notnull2 notnullfault nulls1 numindex1 offset1 orderby5 \
           orderby6 orderby7 orderby8 orderby9 orderbyA orderbyB ovfl pageropt \
           parser1 pcache pragma5 pragmafault prefixes progress ptrchng pushdown \
           qrf01 qrf02 qrf03 qrf05 qrf06 queryonly quickcheck quota-glob \
@@ -600,6 +600,6 @@ jobs:
           where6 where8 where9 whereA whereB whereC whereE whereH \
           whereI whereJ whereK wherelfault wherelimit wherelimit2 wherelimit3 whereM \
           whereN window4 window5 window7 window8 window9 windowA windowB \
-          windowD windowerr windowpushd with1 with2 with3 with4 with5 \
+          windowD windowerr windowfault windowpushd with1 with2 with3 with4 with5 \
           with6 withM without_rowid2 without_rowid3 without_rowid4 without_rowid6 zeroblobfault zipfile \
           zipfile2 zipfilefault

--- a/src/vdbe.c
+++ b/src/vdbe.c
@@ -4778,10 +4778,13 @@ case OP_OpenDup: {           /* ncycle */
   pOrig->noReuse = 1;
   rc = sqlite3BtreeCursor(pCx->ub.pBtx, pCx->pgnoRoot, BTREE_WRCSR,
                           pCx->pKeyInfo, pCx->uc.pCursor);
-  /* The sqlite3BtreeCursor() routine can only fail for the first cursor
-  ** opened for a database.  Since there is already an open cursor when this
-  ** opcode is run, the sqlite3BtreeCursor() cannot fail */
-  assert( rc==SQLITE_OK );
+  /* Stock SQLite asserts this open cannot fail: a second cursor on an
+  ** already-open btree needs no allocation. doltlite's cursor open DOES
+  ** allocate (catalog entry + prolly cursor state), so under OOM it can
+  ** return SQLITE_NOMEM. Propagate it instead of running on an unopened
+  ** cursor (left zeroed by sqlite3BtreeCursorZero), which a later
+  ** OP_NewRowid/OP_Last would dereference via the prolly cursor ops. */
+  if( rc ) goto abort_due_to_error;
   break;
 }
 


### PR DESCRIPTION
## Summary
Fixes #1222 — the `catFind` NULL-catalog-deref SEGV that `windowfault` and `notnullfault` hit under OOM fault injection.

## Root cause (gdb on the failing fault iteration)
`OP_OpenDup` duplicates an ephemeral cursor via `sqlite3BtreeCursor` and — like stock SQLite — assumed the open **cannot fail** ("a second cursor on an already-open btree needs no allocation"), guarding it only with `assert(rc==SQLITE_OK)`.

That invariant is **false under doltlite**: its cursor open allocates a catalog entry + prolly cursor state, so under OOM `sqlite3BtreeCursor` returns `SQLITE_NOMEM` (confirmed: `rc=7` at the OpenDup site). The assert is a no-op in release builds, so the NOMEM was **swallowed**, leaving the BtCursor zeroed by `sqlite3BtreeCursorZero` (`pBtree=0`, default `prollyCursorOps`). A later `OP_NewRowid`→`sqlite3BtreeLast`→`prollyBtCursorLast`→`refreshCursorRoot`→`catFind(&NULL->cat)` then dereferenced the NULL `pBtree` → SEGV at `0x38`.

## Fix
`OP_OpenDup` now checks `rc` and `goto abort_due_to_error`, like every other allocating cursor open — the OOM aborts the statement cleanly instead of running on an unopened cursor. Same invariant-mismatch class as #1218 (cross-backend TransferRow).

## Testing (ASan, fail-before/pass-after)
- Before: `windowfault`/`notnullfault` → `SEGV in catFind`.
- After: `windowfault` **0 errors out of 5627 tests**, `notnullfault` **0 errors out of 467 tests**, no `DEADLYSIGNAL`.
- No regression in normal `OP_OpenDup` (materialized-view self-joins): `window1`/`window2` show only pre-existing rowid-order divergences; `window2` clean.
- Both enabled in the `inherited-testfixture` CI gate (run ~1s each non-ASan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)