### PR TITLE
Fix buildRuntimeMasterRoot NULL-type-row deref SEGV under OOM (#1224)

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -2263,6 +2263,30 @@ static int buildRuntimeMasterRoot(Btree *pBtree, ProllyHash *pMasterRoot){
     freeCatalogEntryMeta(aMeta, nMeta);
     return rc;
   }
+
+  /* Drop degenerate rows whose type field is NULL. loadSchemaCatalogRows()
+  ** returns a row for every master-root record, and schemaCatalogTextField()
+  ** hands back a NULL string for a record field stored as SQL NULL (serial
+  ** type 0). Such a row carries no table/index/view/trigger and would crash
+  ** the strcmp() classification below; schemaCatalogRowWanted() already
+  ** filters them on other read paths. They appear after an OOM-interrupted
+  ** schema build leaves empty records in the master root — skipping them here
+  ** also keeps them out of the rebuilt root, so the schema self-heals. */
+  {
+    int nKept = 0;
+    for(i=0; i<nRows; i++){
+      if( aRows[i].zType==0 ){
+        sqlite3_free(aRows[i].zName);
+        sqlite3_free(aRows[i].zTblName);
+        sqlite3_free(aRows[i].zSql);
+        continue;
+      }
+      if( nKept!=i ) aRows[nKept] = aRows[i];
+      nKept++;
+    }
+    nRows = nKept;
+  }
+
   if( nRows<=0 ){
     freeSchemaCatalogRows(aRows, nRows);
     freeCatalogEntryMeta(aMeta, nMeta);


### PR DESCRIPTION
## Summary
Fixes #1224 — the `buildRuntimeMasterRoot` SEGV during commit under OOM fault injection (`fts3malloc`).

## Root cause (gdb, non-perturbing)
`buildRuntimeMasterRoot` classifies each schema-catalog row via `strcmp(row.zType, "table"/"index")`. `zType` comes from `schemaCatalogTextField()`, which returns a **NULL** string for a record field stored as SQL NULL (serial type 0). `loadSchemaCatalogRows()` keeps such rows, so when the committed master root contained empty (all-NULL) records — left by an OOM-interrupted schema build — the unguarded `strcmp` dereferenced NULL → SEGV.

gdb confirmed: two all-NULL rows (`zType=zName=zTblName=zSql=NULL`), `mallocFailed=0` (the transient OOM had already recovered, so this is a genuine data condition, not an in-flight OOM).

## Fix
Filter NULL-`zType` rows after loading, matching the existing guard in `schemaCatalogRowWanted()`. This also keeps the empty records out of the rebuilt master root, so the schema self-heals on the next commit. No effect on normal databases (real schema rows always have a non-NULL type).

## Testing (ASan, fail-before/pass-after)
- Before: `fts3malloc` → `SEGV in strcmp ← buildRuntimeMasterRoot` (commit path).
- After: crash=0; runs well past the original crash point.
- No regression: `fts3aa`, `fts3ab`, `schema` clean; `select1` only its known divergence.

## Not gating fts3malloc yet
Past the fixed SEGV, `fts3malloc` hits a **separate** "malformed database schema under OOM" issue (filed as https://github.com/dolthub/doltlite/issues/1231) that prevents it reaching the summary line, so it is not added to a CI gate list here. Same shape as the #1215 fix (resolve one OOM crash, the fault test surfaces the next). The `buildRuntimeMasterRoot` fix stands on its own — it removes a NULL-deref on the commit path that any database under memory pressure could hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)