### PR TITLE
Enable jrnlmode fixture for TransferRow crash coverage

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -554,7 +554,7 @@ jobs:
           indexexpr3 init insert2 insert3 insert4 insert5 insertfault instr \
           instrfault intreal ioerr5 ioerr6 istrue join2 join3 join4 \
           join6 join7 join8 join9 joinA joinC joinE joinF \
-          joinH joinI json107 json108 json109 json501 json502 jsonb01 \
+          joinH joinI jrnlmode json107 json108 json109 json501 json502 jsonb01 \
           keyword1 lastinsert laststmtchanges literal literal2 loadext loadext2 lock6 \
           lookaside malloc4 malloc5 malloc7 malloc8 malloc9 mallocB mallocE \
           mallocJ mallocL mallocM manydb mem5 memsubsys2 merge1 minmax4 misc2 \

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1236,3 +1236,85 @@ interrupt2 interrupt2-2.0     # scan continues past interrupt (extra rows)
 interrupt2 interrupt2-2.1     # interrupt not honored mid-scan
 interrupt2 interrupt2-3.1.2   # interrupt not honored mid-scan
 interrupt2 interrupt2-4.1     # interrupt not honored mid-scan
+
+# jrnlmode — DoltLite-format databases do not expose SQLite's rollback-journal
+# mode switching semantics; PRAGMA journal_mode either remains fixed or returns
+# "journal_mode is not configurable on doltlite-format databases". The xfer
+# crash from #1226 is fixed on current master; enabling the whole file keeps
+# jrnlmode-5.11 covered while documenting the remaining feature divergence.
+jrnlmode jrnlmode-1.0  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-1.1  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-1.2  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-1.4a  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-1.4b  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-1.5  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-1.6  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-1.7  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-1.7.1  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-1.7.2  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-1.8  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-1.9  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-1.10  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-1.11  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-1.12  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-1.13  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-1.14  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-1.15  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-1.16  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-1.99  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-2.1  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-2.2  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-2.3  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-2.4  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-2.5  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-3.2  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-4.1  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-4.2  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-4.3  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-4.4  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-5.1  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-5.3  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-5.4.1  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-5.4.2  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-5.5  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-5.6  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-5.7  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-5.8  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-5.10  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-5.11  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-5.12  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-5.13  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-5.14  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-5.15  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-5.16  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-5.17  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-5.18  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-5.19  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-5.20  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-5.21  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-5.22  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-6.1  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-6.2  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-6.3  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-6.4  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-6.5  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-6.7  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-6.9  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-7.1  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-7.2  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-8.5  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-8.6  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-8.7  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-8.8  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-8.13  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-8.14  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-8.15  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-8.16  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-8.17  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-8.21  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-8.23  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-8.24  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-8.28  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-8.30  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-9.1  # journal_mode unsupported on doltlite-format databases
+jrnlmode jrnlmode-9.2  # journal_mode unsupported on doltlite-format databases


### PR DESCRIPTION
## Summary
- enable the upstream `jrnlmode` Tcl fixture in the inherited-testfixture CI job
- document the 76 residual `jrnlmode` divergences caused by DoltLite-format databases not supporting SQLite rollback-journal mode switching
- recover `jrnlmode-5.11` into CI coverage for #1226

Closes #1226.

## Testing
- Docker Linux ARM64: direct `./testfixture ../test/jrnlmode.test` reaches summary with no crash (`76 errors out of 98 tests`)
- Docker Linux ARM64: `bash ../test/run_testfixture.sh "check" 120 jrnlmode` -> `OK: jrnlmode (98 tests, 76 known divergences)`

## Notes
Current master already contains the mutmap-aware `prollyBtCursorTransferRow()` source-row read, so the original ASan NULL-node deref no longer reproduces. This PR adds the missing CI guard requested by the issue and records the remaining intentional journal-mode behavior differences.