### PR TITLE
Fix sqlite3_serialize SEGV on prolly-backed db (#1225)

### DIFF
--- a/src/memdb.c
+++ b/src/memdb.c
@@ -789,6 +789,17 @@ unsigned char *sqlite3_serialize(
   }
   pBt = db->aDb[iDb].pBt;
   if( pBt==0 ) return 0;
+#ifdef DOLTLITE_PROLLY
+  /* doltlite stores prolly trees, not a stock page image. Its chunk-store
+  ** pager shim answers every sqlite3PagerGet() with SQLITE_OK and a NULL page,
+  ** so the page dump below would memcpy() from a NULL pointer. There is no page
+  ** image to serialize, so report the operation as unsupported (NULL) rather
+  ** than crashing or returning a zero-filled buffer. */
+  {
+    extern int pagerShimIsShim(const Pager*);
+    if( pagerShimIsShim(sqlite3BtreePager(pBt)) ) return 0;
+  }
+#endif
   szPage = sqlite3BtreeGetPageSize(pBt);
   zSql = sqlite3_mprintf("PRAGMA \"%w\".page_count", zSchema);
   rc = zSql ? sqlite3_prepare_v2(db, zSql, -1, &pStmt, 0) : SQLITE_NOMEM;

--- a/src/pager_shim.c
+++ b/src/pager_shim.c
@@ -463,6 +463,14 @@ static inline const PagerOps *getPagerOps(const Pager *p){
   return &origPagerOps;
 }
 
+/* True when pPager is doltlite's chunk-store pager shim rather than a real
+** SQLite pager. The shim only services the handful of pager calls the prolly
+** btree facade makes; it has no page image, so callers that need real pages
+** (e.g. sqlite3_serialize's page dump) must treat a shim as unsupported. */
+int pagerShimIsShim(const Pager *p){
+  return p && ((const PagerShim*)p)->magic == PAGER_SHIM_MAGIC;
+}
+
 PagerShim *pagerShimCreate(
   sqlite3_vfs *pVfs,
   const char *zFilename,

--- a/src/pager_shim.h
+++ b/src/pager_shim.h
@@ -37,6 +37,9 @@ void pagerShimDestroy(PagerShim *pShim);
 ** even when the underlying cs->pFile is replaced. */
 void pagerShimSetStore(PagerShim *pShim, struct ChunkStore *pStore);
 
+/* True when pPager is a chunk-store pager shim (vs a real SQLite pager). */
+int pagerShimIsShim(const Pager *pPager);
+
 sqlite3_file *sqlite3PagerFile(Pager*);
 
 const char *sqlite3PagerFilename(const Pager*, int);

--- a/test/known_testfixture_crashes.txt
+++ b/test/known_testfixture_crashes.txt
@@ -57,3 +57,10 @@ e_walckpt     # WAL checkpoint semantics; reaches summary then UAFs in test_vfs 
 # empty/undersized blob (vtable schema-reload visibility), accumulating into a
 # hang. History-dependent; not per-test gateable. Tracked in #1119.
 rtree         # rtree vtable schema-reload visibility; times out
+
+# memdb1 exercises the sqlite3_serialize()/sqlite3_deserialize() page-image API,
+# which is unsupported on prolly storage (no stock page image). sqlite3_serialize
+# now returns NULL cleanly instead of crashing (#1225), but the file then aborts
+# on the first `db deserialize` (line 52) before the summary. doltlite exports via
+# a VFS backup (sqlite3_js_db_export under DOLTLITE_PROLLY), not this API.
+memdb1        # sqlite3_serialize/deserialize page-image API unsupported on prolly storage


### PR DESCRIPTION
## Summary
Fixes #1225 — the `sqlite3_serialize` NULL-deref SEGV on an in-memory (prolly) db (memdb1).

## Root cause
`sqlite3_serialize()` page-dumps via `sqlite3PagerGet()` + `memcpy()` when the db isn't a stock memdb. doltlite's prolly databases have no stock page image — the chunk-store pager **shim** answers every `sqlite3PagerGet()` with `SQLITE_OK` and a **NULL** page, so `sqlite3PagerGetData()` returns NULL and the page-dump `memcpy()` read from address 0 → SEGV.

## Fix
Add `pagerShimIsShim()` and, under `DOLTLITE_PROLLY`, return NULL from `sqlite3_serialize()` when the db's pager is the shim. The page-image serialize is genuinely unsupported on prolly storage, so report it as unsupported (NULL) rather than crash or return a zero-filled buffer.

**doltlite's own export is unaffected:** `sqlite3_js_db_export` is gated under `DOLTLITE_PROLLY` (sqlite3-wasm.c:1397) to export via a VFS backup to a temp file and `return`s before the `sqlite3_serialize` fallback — so the wasm export-roundtrip path never touches this code.

## Testing (ASan, fail-before/pass-after)
- Before: `memdb1` → `SEGV (memcpy from NULL) ← sqlite3_serialize`.
- After: crash=0; `sqlite3_serialize` returns NULL cleanly.
- No regression to real serialize (file/ephemeral dbs use real pagers, not the shim).

## Not gating memdb1
memdb1 is a serialize/**deserialize** feature test; past the fixed serialize SEGV it aborts on the first `db deserialize` (line 52) — `sqlite3_deserialize` of a page image is equally unsupported on prolly storage. Documented on the crash list as a feature gap. The `sqlite3_serialize` fix stands on its own: it removes a public-API crash any caller could hit on a prolly db.

🤖 Generated with [Claude Code](https://claude.com/claude-code)