### PR TITLE
Document createtab/incrcorrupt UAF as intentional PRAGMA-divergence footgun (#1227)

### DIFF
--- a/test/known_testfixture_crashes.txt
+++ b/test/known_testfixture_crashes.txt
@@ -64,3 +64,16 @@ rtree         # rtree vtable schema-reload visibility; times out
 # on the first `db deserialize` (line 52) before the summary. doltlite exports via
 # a VFS backup (sqlite3_js_db_export under DOLTLITE_PROLLY), not this API.
 memdb1        # sqlite3_serialize/deserialize page-image API unsupported on prolly storage
+
+# createtab and incrcorrupt UAF on a freed sqlite3_stmt, but the root cause is
+# an intentional divergence, not a lifecycle bug. doltlite deliberately errors
+# on PRAGMA auto_vacuum / incremental_vacuum ("auto_vacuum is not supported on
+# doltlite-format databases"). That makes a sqlite3_prepare fail, so the test's
+# Tcl stmt variable is never reassigned and keeps a stale pointer to a statement
+# whose connection was already closed (freed via sqlite3LeaveMutexAndCloseZombie);
+# the next sqlite3_column_int / sqlite3_finalize on that freed pointer is the UAF.
+# It is undetectable defensively (a freed stmt pointer looks valid) and is a test
+# footgun exposed by the intentional PRAGMA divergence, like alter2/walro.
+# (createtab additionally diverges on read-cursor-abort-across-DDL; see triggerC-12.2.)
+createtab     # PRAGMA auto_vacuum errors (intentional) -> failed prepare -> stale stmt var -> UAF
+incrcorrupt   # PRAGMA auto_vacuum/incremental_vacuum errors (intentional) -> stale stmt var -> UAF


### PR DESCRIPTION
## Summary
#1227 was filed as a "zombie-close UAF," but triage showed it is **not a doltlite memory bug** — it is a test footgun downstream of an intentional divergence. Per decision, keep the intentional PRAGMA error and document the two files on the crash list (no code change).

## Root cause (gdb + stmt-pointer logging)
1. doltlite **deliberately errors** on `PRAGMA auto_vacuum` / `incremental_vacuum`: `auto_vacuum is not supported on doltlite-format databases`.
2. That makes a `sqlite3_prepare` fail (e.g. `createtab-1.1`'s `PRAGMA auto_vacuum=1` aborts the execsql so `t1` is never created → `1.3` `SELECT x FROM t1` → `no such table: t1`).
3. Because the prepare errored, the test's `set STMT [sqlite3_prepare ...]` never runs, so the Tcl `$STMT`/`$stmt` var keeps a **stale pointer** to a statement whose connection was already closed (freed via `sqlite3LeaveMutexAndCloseZombie` — the real but incidental freed-by stack).
4. The next `sqlite3_column_int` / `sqlite3_finalize` on that freed pointer → UAF.

It is **undetectable defensively** (a freed stmt pointer is indistinguishable from a valid one), and is the same footgun class as alter2/walro — a test continuing after an intentional-divergence error. (createtab additionally diverges on read-cursor-abort-across-DDL, the known triggerC-12.2 class.)

## Change
Document `createtab` and `incrcorrupt` on `test/known_testfixture_crashes.txt` as intentional PRAGMA-divergence footguns. Closes #1227.

🤖 Generated with [Claude Code](https://claude.com/claude-code)