### PR TITLE
Gate 23 clean inherited testfixture files (#1208)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -602,4 +602,7 @@ jobs:
           whereN window4 window5 window7 window8 window9 windowA windowB \
           windowD windowerr windowfault windowpushd with1 with2 with3 with4 with5 \
           with6 withM without_rowid2 without_rowid3 without_rowid4 without_rowid6 zeroblobfault zipfile \
-          zipfile2 zipfilefault
+          zipfile2 zipfilefault \
+          altermalloc2 closure01 fpconv1 fts3an fts3snippet fuzzer2 indexfault joinD json106 \
+          mallocA mmap4 percentile savepoint4 sort3 sort4 sortfault speed1p speed2 speed4 \
+          stmt tempfault vacuummem wherefault


### PR DESCRIPTION
## Summary
Part of the #1208 broad triage. A classification sweep of the 416 ungated inherited testfixture files (1189 total − 765 gated − crash-listed) bucketed them as: **30 CLEAN**, 292 DIVERGE, 73 ABORT, 21 TIMEOUT, 0 CRASH.

This PR gates the **23 deterministic CLEAN files** (pass with 0 errors) in the `inherited-testfixture` job:
`altermalloc2 closure01 fpconv1 fts3an fts3snippet fuzzer2 indexfault joinD json106 mallocA mmap4 percentile savepoint4 sort3 sort4 sortfault speed1p speed2 speed4 stmt tempfault vacuummem wherefault`

Excluded from the 30 CLEAN: the 7 known-nondeterministic files (`thread002/004/2`, `walcrash4`, `walfault2`, `walrofault`, `writecrash`) that flake run-to-run.

The DIVERGE / ABORT / TIMEOUT buckets are tracked in follow-up issues (real-bug candidates filed individually; suspected-known divergences in a single careful-walkthrough issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)