### PR TITLE
Fix LEFT JOIN extra rows: invalidate orig cursor in origCursorClearCursorVt (#1238)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -552,7 +552,7 @@ jobs:
           having hidden hook hook2 ieee754 imposter1 incrblob4 index2 \
           index4 index6 index7 index8 index9 indexA indexexpr1 indexexpr2 \
           indexexpr3 init insert2 insert3 insert4 insert5 insertfault instr \
-          instrfault intreal ioerr5 ioerr6 istrue join2 join3 join4 \
+          instrfault intreal ioerr5 ioerr6 istrue join2 join3 join4 join5 \
           join6 join7 join8 join9 joinA joinC joinE joinF \
           joinH joinI jrnlmode json107 json108 json109 json501 json502 jsonb01 \
           keyword1 lastinsert laststmtchanges literal literal2 loadext loadext2 lock6 \

--- a/src/btree_orig_api.c
+++ b/src/btree_orig_api.c
@@ -71,6 +71,7 @@ int origBtreeCursor(void *p, Pgno iTable, int wrFlag,
   return orig_sqlite3BtreeCursor(B(p), iTable, wrFlag, pKeyInfo, C(pCur));
 }
 int origBtreeCloseCursor(void *pCur){ return orig_sqlite3BtreeCloseCursor(C(pCur)); }
+void origBtreeClearCursor(void *pCur){ orig_sqlite3BtreeClearCursor(C(pCur)); }
 int origBtreeCursorIsLastOnSingle(void *pCur){
   BtCursor *c = C(pCur);
   BtShared *pBt;

--- a/src/btree_orig_api.h
+++ b/src/btree_orig_api.h
@@ -45,6 +45,7 @@ Schema *origBtreeSchema(void *p, int nBytes, void(*xFree)(void*));
 int origBtreeCursor(void *p, Pgno iTable, int wrFlag,
                     struct KeyInfo *pKeyInfo, void *pCur);
 int origBtreeCloseCursor(void *pCur);
+void origBtreeClearCursor(void *pCur);
 int origBtreeCursorHasMoved(void *pCur);
 int origBtreeCursorRestore(void *pCur, int *pDifferentRow);
 int origBtreeFirst(void *pCur, int *pRes);

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -10318,8 +10318,12 @@ static int origCursorTransferRowVt(BtCursor *pDest, BtCursor *pSrc, i64 iKey){
   return origBtreeTransferRow(pDest->pOrigCursor, pSrc->pOrigCursor, iKey);
 }
 static void origCursorClearCursorVt(BtCursor *pCur){
-  (void)pCur;
-
+  /* Must invalidate the underlying stock cursor. OP_NullRow calls this to
+  ** null-extend a LEFT JOIN; if the orig (ephemeral/automatic-index) cursor
+  ** keeps its live position, the following OP_Next walks the index instead of
+  ** terminating, emitting spurious matched rows (join5-3.2: a NULL join key
+  ** that should match nothing returns extra rows). */
+  origBtreeClearCursor(pCur->pOrigCursor);
 }
 static int origCursorCountVt(sqlite3 *db, BtCursor *pCur, i64 *pnEntry){
   return origBtreeCount(db, pCur->pOrigCursor, pnEntry);


### PR DESCRIPTION
## Summary
Fixes #1238 — `join5-3.2` returned extra/duplicate rows from a LEFT JOIN.

## Root cause (gdb + pristine comparison)
`origCursorClearCursorVt` (the orig/ephemeral-backend `xClearCursor`) was a **no-op**:
```c
static void origCursorClearCursorVt(BtCursor *pCur){ (void)pCur; }
```
So `sqlite3BtreeClearCursor()` did nothing for an ephemeral / **automatic-index** (orig-backed) cursor. `OP_NullRow` calls `sqlite3BtreeClearCursor` to null-extend a LEFT JOIN; with the cursor left at its live btree position, the following `OP_Next` **walked the index** instead of terminating — emitting spurious matched rows whenever a LEFT JOIN used an automatic index with a NULL join key.

Confirmed via gdb: `OP_IsNull` correctly skips the seek (join key is NULL), but the null-extend's `NullRow → Next` then walks the autoindex. Pristine SQLite **3.45.1 returns 1 row with byte-for-byte identical bytecode**, so this is a runtime cursor-lifecycle bug in doltlite's orig-cursor wrapper — not a plan/codegen difference. It affects **both prolly and stock-mode** builds and **any** automatic-index LEFT JOIN with a NULL join key.

## Fix
Add `origBtreeClearCursor()` (wraps the renamed stock `orig_sqlite3BtreeClearCursor`) and call it from `origCursorClearCursorVt`, mirroring `prollyBtCursorClearCursor` which already invalidates (`eState=CURSOR_INVALID`).

## Testing (fail-before/pass-after)
- `join5-3.2`: 4 rows → **1 row** (correct).
- `join5.test`: **0 errors / 53 tests** — gated in CI.
- No regression: `join`/`join2`/`join3`/`join4` all 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)