### PR TITLE
Fix prolly table-root range seek using PK-key prefix (LEFT of ORDER BY non-PK) (#1239)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -428,7 +428,7 @@ jobs:
           trans where expr attach \
           coalesce conflict cse date join subquery view \
           between cast check limit null quote rowid sort types \
-          types2 in in2 in3 in4 in5 in6 like like2 \
+          types2 in in2 in3 in4 in5 in6 in7 like like2 \
           minmax minmax2 minmax3 select5 select6 select7 \
           selectA selectB distinctagg enc count capi2 capi3 \
           collate1 collate2 collate3 collate4 \

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -6940,6 +6940,19 @@ static int prollyBtCursorIndexMoveto(
     if( pCur->pKeyInfo && pIdxKey->nField < pCur->pKeyInfo->nAllField ){
       nSeekKeyField = (int)pIdxKey->nField;
     }
+    /* A table-root (WITHOUT ROWID / PK) tree is keyed by the PK columns only;
+    ** the non-PK columns live in the row value. A range seek (default_rc!=0)
+    ** whose probe extends past the PK — e.g. a SeekGE that appends a sentinel
+    ** field for ORDER BY positioning — must seek on the PK prefix. Otherwise
+    ** the longer probe sort key sorts past the shorter tree keys and lands
+    ** beyond the target row, so the move-to scan starts too late and returns
+    ** the wrong (or no) row (in7-2.1: IN(...) ORDER BY <non-PK> NULLS LAST). */
+    if( pCur->isTableRoot && pCur->pKeyInfo
+     && pIdxKey->default_rc != 0
+     && pIdxKey->nField > pCur->pKeyInfo->nKeyField
+     && (nSeekKeyField==0 || nSeekKeyField > pCur->pKeyInfo->nKeyField) ){
+      nSeekKeyField = pCur->pKeyInfo->nKeyField;
+    }
     if( unpackedRecordCanUseIntSortKey(
             pCur, pIdxKey,
             nSeekKeyField>0 ? nSeekKeyField : (int)pIdxKey->nField) ){


### PR DESCRIPTION
## Summary
Fixes #1239 — `SELECT b FROM t1(a PK,b) WHERE a IN (1,2,3) ORDER BY b NULLS LAST` returned `(3,three),(3,three)` instead of `(1,one),(3,three),(2,NULL)`.

## Root cause
A WITHOUT ROWID / PK table is stored in prolly **keyed by the PK columns only**; non-PK columns live in the row value (stock SQLite keys the whole row). A range seek (`default_rc != 0`) whose probe extends past the PK — e.g. a `SeekGE` that appends a sentinel field for `ORDER BY` positioning (`a='1', b=NULL`, nField=2) — built a sort key **longer** than the tree's 1-field PK keys. `memcmp` then sorted the longer probe **past** the shorter tree entries, so `prollyCursorSeekBlob` landed beyond the target row and the move-to scan started too late → wrong row returned (and repeated).

Confirmed via instrumentation: the working `nField=1` seek uses the prefix path and lands correctly; the failing `nField=2` seek used the full-key path (`nSeekKeyField=0`). Pristine SQLite 3.45.1 emits **byte-identical bytecode** and is correct — so it's a prolly seek bug, both build modes.

## Fix
In `prollyBtCursorIndexMoveto`, for a **table-root range seek** whose probe exceeds `nKeyField`, seek on the **PK-key prefix** (`nKeyField`), matching the tree's key structure. Gated to `default_rc != 0` (range seeks only) so exact seeks / uniqueness checks are untouched. The existing move-to fallback loop already refines via the row value.

## Testing (fail-before/pass-after + regression)
- `in7-2.1`: wrong rows → correct; **`in7.test` 0/27**, gated in CI.
- **No regressions**: `join`/`join2`–`join5`, `orderby1`–`4`, `in2`/`4`/`5`/`6`, `where2`, `index2`/`4`, `select5` all 0 errors; and every other file's divergence count is **identical to master** (descidx2 27=27, in3 5=5, index 9=9, where 9=9, without_rowid1 4=4, minmax/fkey1/select1 unchanged) — verified by building master and diffing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)