### PR TITLE
Fix spurious 'malformed database schema' from empty master-root records under OOM (#1231)

### DIFF
--- a/src/prepare.c
+++ b/src/prepare.c
@@ -109,6 +109,17 @@ int sqlite3InitCallback(void *pInit, int argc, char **argv, char **NotUsed){
     return 1;
   }
 
+#ifdef DOLTLITE_PROLLY
+  /* doltlite's prolly master root can retain an all-NULL placeholder record
+  ** after a schema write is interrupted by OOM (the same empty records #1224
+  ** drops when rebuilding the root; they persist until the next rebuild). Such
+  ** a row carries no schema object -- skip it rather than reporting the
+  ** database as malformed. A genuinely corrupt row never presents as all-NULL. */
+  if( argv[0]==0 && argv[1]==0 && argv[3]==0 && argv[4]==0 ){
+    return 0;
+  }
+#endif
+
   assert( iDb>=0 && iDb<db->nDb );
   if( argv[3]==0 ){
     corruptSchema(pData, argv, 0);


### PR DESCRIPTION
## Summary
Fixes #1231 — FTS schema reload reported `malformed database schema (?)` under OOM.

## Root cause
doltlite's prolly master root can retain an **all-NULL placeholder record** after a schema write is interrupted by OOM — the same empty records #1224 drops when *rebuilding* the root, but they persist until the next rebuild and are returned by the generic `SELECT * FROM sqlite_master` schema read. `sqlite3InitCallback` then reported the database as malformed, where the correct behavior under transient OOM is to ignore the empty placeholder. (Confirmed by instrumenting `corruptSchema`: the failing row is `type=NULL name=NULL rootpage=NULL sql=NULL`, with `mallocFailed=0`.)

## Fix
Under `DOLTLITE_PROLLY`, `sqlite3InitCallback` skips a row whose type/name/rootpage/sql are all NULL — it carries no schema object, and a genuinely corrupt row never presents as entirely NULL. This is the read-side complement to #1224's rebuild-side drop.

## Testing
- fts3malloc `malformed database schema` count: **0** (was the failing `(?)` assertions).
- **No regression**: schema/schema2/3/4 and fts3aa/fts3ab all 0 errors; fts4aa/select1/alter/trigger1/attach behave **identically to master** (verified by building master and diffing — attach aborts pre-summary on both; alter=5, trigger1=4 unchanged).

## Not fully gating fts3malloc
Past this fix, fts3malloc exposes a **separate, deeper** FTS-vtable consistency issue under OOM (`no such table: ft` / `vtable constructor failed`), filed as #1253. So fts3malloc is not added to a CI gate list here; this PR fixes the malformed-schema-read bug (which is general — it affects any OOM-interrupted schema write, not just FTS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)