### PR TITLE
Honor writeOnly in prollyBtreeRollback: read cursors survive ROLLBACK (#1240)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -559,7 +559,7 @@ jobs:
           lookaside malloc4 malloc5 malloc7 malloc8 malloc9 mallocB mallocE \
           mallocJ mallocL mallocM manydb mem5 memsubsys2 merge1 minmax4 misc2 \
           rowvaluefault \
-          misc3 misc6 misuse mmap2 mmapfault multiplex3 mutex2 normalize \
+          misc3 misc6 misc8 misuse mmap2 mmapfault multiplex3 mutex2 normalize \
           notify1 notify2 notify3 notnull2 notnullfault nulls1 numindex1 offset1 orderby5 \
           orderby6 orderby7 orderby8 orderby9 orderbyA orderbyB ovfl pageropt \
           parser1 pcache pragma5 pragmafault prefixes progress ptrchng pushdown \

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -5316,23 +5316,43 @@ static int restoreFromCommitted(Btree *p){
 static int prollyBtreeRollback(Btree *p, int tripCode, int writeOnly){
   BtShared *pBt = p->pBt;
   int rc = SQLITE_OK;
-  (void)writeOnly;
 
   if( pBt->inCatalogSerialize ) return SQLITE_OK;
 
   if( p->inTrans==TRANS_WRITE ){
     assert( pBt->store.isMemory || pBt->store.pGraphLockFile!=0 );
     assert( pBt->store.isMemory || pBt->store.lockDepth > 0 );
-    /* Cursor pending-edit maps alias the catalog's per-table pPending maps,
-    ** which restoreFromCommitted() (via catFree) frees. Detach the aliases so
-    ** nothing dereferences them afterwards. We only null them here — do NOT
-    ** clear the maps: catFree owns that, and a prior savepoint rollback may
-    ** already have freed the map this cursor points at, so clearing it would
-    ** be a use-after-free. ensureMutMap re-aliases from the catalog on reuse. */
+    /* Trip cursors for the rollback. A read-only cursor survives a writeOnly
+    ** rollback (schema unchanged): save its position so it re-seeks the
+    ** restored tree on next access, matching stock sqlite3BtreeTripAllCursors.
+    ** Otherwise a ROLLBACK issued mid-SELECT (e.g. from a user function) would
+    ** wrongly abort the read with SQLITE_ABORT_ROLLBACK (misc8-1.4). Write
+    ** cursors, and every cursor when the rollback changes the schema, are
+    ** faulted.
+    **
+    ** Either way detach the cursor's pending-edit map alias before
+    ** restoreFromCommitted() (via catFree) frees it. Detach AFTER
+    ** saveCursorPosition(), which copies out the key it needs first. We only
+    ** null the alias — catFree owns the map, and a prior savepoint rollback may
+    ** already have freed the one this cursor points at, so clearing it would be
+    ** a use-after-free (the #1207/#1213 fix). ensureMutMap re-aliases on reuse. */
     {
       BtCursor *pC;
+      int tc = tripCode ? tripCode : SQLITE_ABORT;
       for(pC = pBt->pCursor; pC; pC = pC->pNext){
-        if( pC->pBtree==p && pC->pMutMap ){
+        if( pC->pBtree!=p ) continue;
+        if( writeOnly
+         && (pC->curFlags & BTCF_WriteFlag)==0
+         && (pC->eState==CURSOR_VALID || pC->eState==CURSOR_SKIPNEXT)
+         && saveCursorPosition(pC)==SQLITE_OK ){
+          /* read cursor saved -> CURSOR_REQUIRESEEK; survives the rollback */
+        }else{
+          pC->eState = CURSOR_FAULT;
+          pC->skipNext = tc;
+          pC->mmActive = 0;
+          prollyCursorReleaseAll(&pC->pCur);
+        }
+        if( pC->pMutMap ){
           pC->pMutMap = 0;
           pC->mmActive = 0;
           pC->mmPhysActive = 0;
@@ -5348,7 +5368,6 @@ static int prollyBtreeRollback(Btree *p, int tripCode, int writeOnly){
       pBt->store.snapshotPinned = 0;
       return rc;
     }
-    invalidateCursors(pBt, 0, tripCode ? tripCode : SQLITE_ABORT);
     invalidateSchema(p);
     chunkStoreRollback(&pBt->store);
     {

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1145,8 +1145,8 @@ capi3 capi3-8.3    # writable_schema sqlite_master corruption undetected: prolly
 capi3 capi3-8.5    # same: injected bogus sqlite_master row doesn't malform the prolly catalog
 capi3 capi3-11.3.4 # PRAGMA lock_status reports doltlite's locking model ("main unlocked" vs "main shared")
 capi3 capi3-11.5   # finalize after COMMIT-during-active-read: SQLITE_ABORT vs SQLITE_ERROR
-capi3 capi3-11.10  # step after ROLLBACK-during-active-read: cursor faulted (SQLITE_ERROR) vs stock auto-reset+rerun (SQLITE_ROW)
-capi3 capi3-11.11  # same statement, next step: SQLITE_ERROR vs SQLITE_DONE
+# capi3-11.10/11.11 (step after ROLLBACK-during-active-read) now pass: the read
+# cursor survives a writeOnly ROLLBACK and re-seeks instead of faulting (#1240).
 capi3 capi3-11.12  # same: SQLITE_ERROR vs SQLITE_ROW
 capi3 capi3-11.13  # finalize of the faulted statement: SQLITE_ERROR vs SQLITE_OK
 


### PR DESCRIPTION
## Summary
Fixes #1240 — `misc8-1.4` got `abort due to ROLLBACK` where stock returns the query result.

## Root cause
`prollyBtreeRollback` had `(void)writeOnly;` — it **ignored** the `writeOnly` argument and faulted **every** cursor (`invalidateCursors`) on any `TRANS_WRITE` rollback. Stock SQLite's `sqlite3BtreeTripAllCursors` only faults *write* cursors when `writeOnly` is set (rollback didn't change the schema) and **saves read-only cursors** so an in-flight `SELECT` re-seeks the restored tree and continues.

So a `ROLLBACK` issued mid-`SELECT` (misc8-1.4 runs it from a user function via `coalesce(b, eval('ROLLBACK; SELECT ''bam'''))`) wrongly aborted the read. misc8-1.7, which also runs `CREATE TABLE` in the txn, still aborts correctly because the schema change forces `writeOnly=0`.

## Fix
In the rollback's cursor loop, for a `writeOnly` rollback, `saveCursorPosition()` each read-only cursor (`BTCF_WriteFlag` unset) → `CURSOR_REQUIRESEEK`, and fault only write cursors; a schema-changing rollback still faults all. The save runs before the mutmap alias detach and `restoreFromCommitted()`, preserving the #1207/#1213 ordering (saveCursorPosition copies out the key first, then the alias is nulled).

## Testing (fail-before/pass-after + regression)
- `misc8`: **1 → 0** errors; gated in CI. (misc8-1.4 passes; misc8-1.7 still aborts as expected.)
- **No regressions** — every transaction-heavy file's error count is **identical to master** (verified by building master and diffing): savepoint 48=48, trans 19=19, trans2 29=29, conflict/conflict2 0, fkey1 1, fkey2 7, trigger1 4, trigger2 0, delete 6, insert 1, update 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)