### PR TITLE
Record default-4.1 as intentional writable_schema divergence; gate default (#1241)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -535,7 +535,7 @@ jobs:
           collate5 collate6 collate7 collate8 collateA collateB colname columncount \
           conflict2 contrib01 corrupt3 cost countofview coveridxscan csv01 ctime \
           cursorhint cursorhint2 dataversion1 date2 date3 date4 date5 dbdata \
-          cffault decimal delete3 delete4 e_blobbytes e_droptrigger e_dropview e_resolve emptytable \
+          cffault decimal default delete3 delete4 e_blobbytes e_droptrigger e_dropview e_resolve emptytable \
           eqp eqp2 errofst1 eval exec exists existsexpr existsexpr2 \
           expr2 exprfault expridx1 filectrl filter1 filter2 filterfault fkey3 \
           fkey4 fkey6 fkey7 fkey8 fkey_malloc fordelete fts-9fd058691 fts3aa fts3ab fts3ac \

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1150,6 +1150,15 @@ capi3 capi3-11.5   # finalize after COMMIT-during-active-read: SQLITE_ABORT vs S
 capi3 capi3-11.12  # same: SQLITE_ERROR vs SQLITE_ROW
 capi3 capi3-11.13  # finalize of the faulted statement: SQLITE_ERROR vs SQLITE_OK
 
+# default — writable_schema edit to a column DEFAULT is not honored. The test
+# does PRAGMA writable_schema=ON; UPDATE sqlite_master SET sql='...DEFAULT(:xyz)'
+# to rewrite b's default to an (invalid) bind parameter; stock then yields NULL
+# on insert, doltlite keeps the original DEFAULT 99. doltlite's schema is the
+# structural catalog (regenerated), not the raw sqlite_master.sql text, so the
+# injected edit has no effect -- same intentional class as capi3-8.3/8.5. Normal
+# DEFAULT handling (default-1.x/2.x/3.x/4.0/4.2-4.x) is correct.
+default default-4.1  # writable_schema sqlite_master.sql DEFAULT edit not honored (structural catalog)
+
 # fordelete — doltlite doesn't materialize named sqlite_autoindex_* rows for
 # WITHOUT-ROWID/implicit unique indexes, so PRAGMA index_list reports just the
 # table; the FOR-DELETE behavior under test is otherwise correct. (Recovered


### PR DESCRIPTION
## Summary
#1241 (default-4.1: column DEFAULT returns `'99'` instead of `NULL`) is **not a doltlite bug** — it's an intentional writable_schema/schema-regeneration divergence. Closes #1241 by recording it and gating default.test.

## Root cause
default-4.0/4.1 deliberately corrupts the schema:
```sql
sqlite3_db_config db DEFENSIVE 0
CREATE TABLE t1(a TEXT, b TEXT DEFAULT(99));
PRAGMA writable_schema=ON;
UPDATE sqlite_master SET sql='CREATE TABLE t1(a TEXT, b TEXT DEFAULT(:xyz))';
-- reopen, then INSERT t1(a); SELECT quote(b)
```
Stock 3.45.1 (DEFENSIVE off) honors the rewritten `sqlite_master.sql` → default `:xyz` (unbound) → **NULL**. doltlite's schema is the **structural catalog** (regenerated), not the raw `sqlite_master.sql` text, so the injected edit has no effect and the original **`DEFAULT 99`** is kept (`'99'`). Same intentional class as the already-recorded **capi3-8.3/8.5** (writable_schema corruption not honored).

Verified doltlite's *real* DEFAULT handling is correct: the other 15 `default.test` cases (1.x/2.x/3.x normal defaults, 4.2-4.4 non-constant-default rejection) all pass.

## Change
- Record `default default-4.1` in `known_testfixture_divergences.txt` with the reason.
- Gate `default.test` in the `inherited-testfixture` job (now passes with the one recorded divergence).

No code change — doltlite's structural-schema behavior here is by design and arguably safer (it ignores raw schema corruption).

🤖 Generated with [Claude Code](https://claude.com/claude-code)