### PR TITLE
Record descidx3-1.1 as raw file-format divergence; gate descidx3 (#1242)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -535,7 +535,7 @@ jobs:
           collate5 collate6 collate7 collate8 collateA collateB colname columncount \
           conflict2 contrib01 corrupt3 cost countofview coveridxscan csv01 ctime \
           cursorhint cursorhint2 dataversion1 date2 date3 date4 date5 dbdata \
-          cffault decimal default delete3 delete4 e_blobbytes e_droptrigger e_dropview e_resolve emptytable \
+          cffault decimal default descidx3 delete3 delete4 e_blobbytes e_droptrigger e_dropview e_resolve emptytable \
           eqp eqp2 errofst1 eval exec exists existsexpr existsexpr2 \
           expr2 exprfault expridx1 filectrl filter1 filter2 filterfault fkey3 \
           fkey4 fkey6 fkey7 fkey8 fkey_malloc fordelete fts-9fd058691 fts3aa fts3ab fts3ac \

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1318,3 +1318,10 @@ jrnlmode jrnlmode-8.28  # journal_mode unsupported on doltlite-format databases
 jrnlmode jrnlmode-8.30  # journal_mode unsupported on doltlite-format databases
 jrnlmode jrnlmode-9.1  # journal_mode unsupported on doltlite-format databases
 jrnlmode jrnlmode-9.2  # journal_mode unsupported on doltlite-format databases
+
+# descidx3 — descidx3-1.1 reads the SQLite file-format version byte via
+# get_file_format (hexio_read test.db offset 44). DoltLite stores a chunk store,
+# not a SQLite file, so that offset is not the format field and reads 0 vs the
+# expected 4. Raw on-disk-format divergence; the descending-index behavior the
+# file actually exercises (descidx3-2.x..) is correct.
+descidx3 descidx3-1.1  # hexio read of SQLite file-format version byte (chunk store has no such field)


### PR DESCRIPTION
## Summary
#1242 (descidx3-1.1: "DESC index returns 0 rows, expected 4") is **not a DESC-index bug** — my candidate note misread the values. `descidx3-1.1` is:
```tcl
proc get_file_format {{fname test.db}} { return [hexio_get_int [hexio_read $fname 44 4]] }
...
do_test descidx3-1.1 { execsql {CREATE TABLE...; CREATE INDEX ... DESC ...}; get_file_format } {4}
```
The expected `4` is the **SQLite file-format version byte** (offset 44), not a row count. DoltLite stores a **chunk store**, not a SQLite file, so offset 44 isn't the format field and reads `0` — a raw on-disk-format divergence (same class as date/crash/pragma file-format tests).

The DESC index itself is **correct**: 14 of 15 descidx3 tests pass (descidx3-2.x exercises descending-index scans, NULL/blob ordering, etc.).

## Change
- Record `descidx3 descidx3-1.1` in `known_testfixture_divergences.txt`.
- Gate `descidx3.test` in the `inherited-testfixture` job (passes with the one recorded divergence).

No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)