### PR TITLE
Record alterdropcol-8.2 as raw-schema-edit divergence; gate alterdropcol (#1243)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -523,7 +523,7 @@ jobs:
       run: |
         cd build
         bash ../test/run_testfixture.sh "Inherited tests" 90 \
-          8_3_names aggerror aggfault alterauth alterauth2 alterdropcol2 alterlegacy altermalloc3 \
+          8_3_names aggerror aggfault alterauth alterauth2 alterdropcol alterdropcol2 alterlegacy altermalloc3 \
           alterqf altertab2 altertrig amatch1 analyze3 analyze4 analyze5 analyze6 \
           analyze7 analyze8 analyze9 analyzeC analyzeD analyzeE analyzeF analyzeG \
           analyzer1 atof1 atof2 atomic atomic2 attach4 auth2 auth3 \

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1325,3 +1325,14 @@ jrnlmode jrnlmode-9.2  # journal_mode unsupported on doltlite-format databases
 # expected 4. Raw on-disk-format divergence; the descending-index behavior the
 # file actually exercises (descidx3-2.x..) is correct.
 descidx3 descidx3-1.1  # hexio read of SQLite file-format version byte (chunk store has no such field)
+
+# alterdropcol — alterdropcol-8.2 expects AUTOINCREMENT in the regenerated DDL,
+# but test 8.0 injects AUTOINCREMENT via a raw `PRAGMA writable_schema=1;
+# UPDATE sqlite_schema SET sql='...AUTOINCREMENT...'` edit on a table that was
+# CREATEd without it. DoltLite regenerates DDL from its structural catalog and
+# ignores raw sqlite_schema text edits (same intentional class as #1241 /
+# capi3-8.3/8.5), so the catalog never recorded AUTOINCREMENT and the rewritten
+# DDL omits it. AUTOINCREMENT itself is fully honored: a normally-created
+# AUTOINCREMENT table round-trips the keyword through DROP COLUMN, never reuses
+# a deleted max rowid, and maintains sqlite_sequence. Raw-schema-edit divergence.
+alterdropcol alterdropcol-8.2  # AUTOINCREMENT injected via writable_schema UPDATE; structural catalog ignores raw sqlite_schema edits


### PR DESCRIPTION
## Summary
#1243 (alterdropcol-8.2: regenerated DDL drops AUTOINCREMENT) is **not an AUTOINCREMENT bug** — it's the writable_schema raw-edit class (same as #1241, capi3-8.3/8.5).

`alterdropcol-8.0` creates the table **without** AUTOINCREMENT, then injects it via a raw schema-text edit:
```sql
CREATE TABLE t1(a INTEGER PRIMARY KEY, b);
PRAGMA writable_schema = 1;
UPDATE sqlite_schema SET sql = 'CREATE TABLE t1(a INTEGER PRIMARY KEY AUTOINCREMENT, b)';
```
DoltLite regenerates DDL from its **structural catalog** and ignores raw `sqlite_schema` text edits, so the catalog never recorded AUTOINCREMENT. After `DROP COLUMN b`, the rewritten DDL is `CREATE TABLE t1(a INTEGER PRIMARY KEY)` — no AUTOINCREMENT, because it was never really there.

## AUTOINCREMENT is fully honored (verified directly)
Built `testfixture` and ran a normal AUTOINCREMENT table:
- `CREATE TABLE n(a INTEGER PRIMARY KEY AUTOINCREMENT, b)` → DDL round-trips **with** the keyword.
- Insert 3 rows, `DELETE FROM n WHERE a=3`, insert again → new row is **a=4**, not reusing 3 (the AUTOINCREMENT guarantee; plain INTEGER PK would reuse 3).
- `sqlite_sequence` shows `n 4`.
- `ALTER TABLE n DROP COLUMN b` → `CREATE TABLE n(a INTEGER PRIMARY KEY AUTOINCREMENT)` — keyword **preserved** through DROP COLUMN.

So DROP COLUMN preserves AUTOINCREMENT correctly; only the writable_schema-injected (non-catalog) AUTOINCREMENT is lost — by design.

## Change
- Record `alterdropcol alterdropcol-8.2` in `known_testfixture_divergences.txt` (102/103 pass).
- Gate `alterdropcol.test` in the `inherited-testfixture` job.

No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)