### PR TITLE
Record altertab3/index5/limit2/notnull divergences; gate the four files (#1245-#1248)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -523,7 +523,8 @@ jobs:
       run: |
         cd build
         bash ../test/run_testfixture.sh "Inherited tests" 90 \
-          8_3_names aggerror aggfault alterauth alterauth2 alterdropcol alterdropcol2 alterlegacy altermalloc3 autoindex1 \
+          8_3_names aggerror aggfault alterauth alterauth2 alterdropcol alterdropcol2 altertab3 alterlegacy altermalloc3 autoindex1 \
+          index5 limit2 notnull \
           alterqf altertab2 altertrig amatch1 analyze3 analyze4 analyze5 analyze6 \
           analyze7 analyze8 analyze9 analyzeC analyzeD analyzeE analyzeF analyzeG \
           analyzer1 atof1 atof2 atomic atomic2 attach4 auth2 auth3 \

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1336,3 +1336,33 @@ descidx3 descidx3-1.1  # hexio read of SQLite file-format version byte (chunk st
 # AUTOINCREMENT table round-trips the keyword through DROP COLUMN, never reuses
 # a deleted max rowid, and maintains sqlite_sequence. Raw-schema-edit divergence.
 alterdropcol alterdropcol-8.2  # AUTOINCREMENT injected via writable_schema UPDATE; structural catalog ignores raw sqlite_schema edits
+
+# altertab3 — altertab3-31.1 asserts `PRAGMA page_count` is unchanged across an
+# `ALTER TABLE DROP COLUMN` (stock's metadata-only drop). DoltLite stores a
+# chunk store, not SQLite pages, so page_count is not a stable per-table page
+# metric and differs. Raw page-format pragma; the drop itself is correct
+# (altertab3-31.2 reads the surviving column back as 5.0).
+altertab3 altertab3-31.1  # PRAGMA page_count across DROP COLUMN; chunk store has no SQLite page count
+
+# index5 — index5-1.3 records the on-disk page WRITE ORDER during CREATE INDEX
+# via a custom test VFS (forward/backward/non-contiguous page offsets) and
+# asserts a mostly-sequential pattern. DoltLite's chunk store writes
+# content-addressed chunks, not sequential btree pages, so the write-offset
+# pattern does not apply. Raw storage-layout divergence; the index is built
+# correctly (index5-1.2 passes).
+index5 index5-1.3  # page write-order via test VFS; chunk store is not page-sequential
+
+# limit2 — limit2-110.3 compares sqlite_search_count between an indexed and an
+# unindexed ORDER BY ... LIMIT, asserting the indexed plan scans <2% as many
+# rows. sqlite_search_count is an internal scan-count metric DoltLite's prolly
+# cursor does not increment the same way; the query RESULTS are correct
+# (limit2-110.1/110.2 pass). Internal-counter divergence.
+limit2 limit2-110.3  # sqlite_search_count scan-count metric; prolly cursor counts differently
+
+# notnull — notnull-6.5 (do_uses_op_next_test) checks whether the plan for
+# `SELECT * FROM t5 WHERE a IS ?` uses OP_Next, expecting yes for t5(a PRIMARY
+# KEY). DoltLite treats a non-integer PRIMARY KEY as WITHOUT ROWID (#1176), so
+# the PK is unique-and-NOT-NULL and the planner uses a single seek (no OP_Next),
+# matching t8 (explicit WITHOUT ROWID, expects 0). Verified row semantics are
+# correct; only the plan differs. WITHOUT-ROWID-PK plan divergence (#1176).
+notnull notnull-6.5  # plan uses a seek not OP_Next: non-integer PK is WITHOUT ROWID (#1176)


### PR DESCRIPTION
## Summary
The four "expected 1, got 0" divergences from the #1208 ungated-file sweep are all intentional. Each is the **sole** divergence in its file (108, 4, 25, 107 tests respectively), and I verified the real semantics are correct in every case.

| Issue | Subtest | What it actually asserts | Verdict |
|---|---|---|---|
| #1245 | `altertab3-31.1` | `PRAGMA page_count` unchanged across `ALTER TABLE DROP COLUMN` | page-format pragma — chunk store has no SQLite page count. Drop is correct (31.2 → `5.0`) |
| #1246 | `index5-1.3` | on-disk page **write order** during `CREATE INDEX` (custom test VFS) | raw storage layout — chunk store writes content-addressed chunks, not sequential pages. Index builds (1.2 passes) |
| #1247 | `limit2-110.3` | `sqlite_search_count` ratio between indexed/unindexed `ORDER BY … LIMIT` | internal scan-count metric — prolly cursor counts differently. Results correct (110.1/110.2 pass) |
| #1248 | `notnull-6.5` | plan for `t5(a PRIMARY KEY)` uses `OP_Next` (`do_uses_op_next_test`) | non-integer PK is WITHOUT ROWID (#1176) → unique/NOT NULL → planner seeks, no `OP_Next`; matches t8 |

### notnull-6.5 verified in both directions
`SELECT * FROM t5 WHERE a IS 2` → `2`; `WHERE a IS 9` → empty; all rows correct. doltlite rejects `INSERT INTO t5 VALUES(NULL)` with `NOT NULL constraint failed` because a non-integer PRIMARY KEY is treated as WITHOUT ROWID (#1176, an accepted design divergence). Because the PK is known unique-and-not-null, the planner uses a single seek instead of a scan — which is exactly why `OP_Next` is absent. It's a query-*plan* artifact, not a row-result bug.

## Change
- Record the four subtests in `known_testfixture_divergences.txt` with mechanism comments.
- Gate `altertab3`, `index5`, `limit2`, `notnull` in the `inherited-testfixture` job.

No code change. Closes #1245, closes #1246, closes #1247, closes #1248.

🤖 Generated with [Claude Code](https://claude.com/claude-code)