### PR TITLE
Fix dangling lock-file zPath in chunk store graph lock (#1249)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -523,7 +523,7 @@ jobs:
       run: |
         cd build
         bash ../test/run_testfixture.sh "Inherited tests" 90 \
-          8_3_names aggerror aggfault alterauth alterauth2 alterdropcol alterdropcol2 alterlegacy altermalloc3 \
+          8_3_names aggerror aggfault alterauth alterauth2 alterdropcol alterdropcol2 alterlegacy altermalloc3 autoindex1 \
           alterqf altertab2 altertrig amatch1 analyze3 analyze4 analyze5 analyze6 \
           analyze7 analyze8 analyze9 analyzeC analyzeD analyzeE analyzeF analyzeG \
           analyzer1 atof1 atof2 atomic atomic2 attach4 auth2 auth3 \

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -28,7 +28,7 @@ static char *csLockPath(const char *path){
 }
 
 static int csFileLock(sqlite3_vfs *pVfs, const char *path,
-                      sqlite3_file **ppFile){
+                      sqlite3_file **ppFile, char **pzName){
   char *zRaw = csLockPath(path);
   char *zLock = 0;
   sqlite3_file *pFile = 0;
@@ -37,6 +37,7 @@ static int csFileLock(sqlite3_vfs *pVfs, const char *path,
   int rc;
 
   *ppFile = 0;
+  *pzName = 0;
   if( !zRaw ) return SQLITE_NOMEM;
   /* Opened with SQLITE_OPEN_MAIN_DB, so the name must carry the VFS's
   ** double-nul terminator (csLockPath returns a singly-terminated string). */
@@ -44,27 +45,38 @@ static int csFileLock(sqlite3_vfs *pVfs, const char *path,
   sqlite3_free(zRaw);
   if( rc!=SQLITE_OK ) return rc;
   rc = sqlite3OsOpenMalloc(pVfs, zLock, &pFile, flags, 0);
-  sqlite3_free(zLock);
-  if( rc!=SQLITE_OK ) return rc;
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(zLock);
+    return rc;
+  }
   rc = sqlite3OsLock(pFile, SQLITE_LOCK_EXCLUSIVE);
   if( rc!=SQLITE_OK ){
     sqlite3OsCloseFree(pFile);
+    sqlite3_free(zLock);
     return rc;
   }
   *ppFile = pFile;
+  /* The unix VFS aliases unixFile.zPath to this buffer (it does not copy),
+  ** and SQLite's xOpen contract requires the name to stay valid until close.
+  ** Hand ownership to the caller, which frees it via csFileUnlock. */
+  *pzName = zLock;
   return SQLITE_OK;
 }
 
-static void csFileUnlock(sqlite3_file *pFile){
+static void csFileUnlock(sqlite3_file *pFile, char **pzName){
   if( pFile ){
     sqlite3OsUnlock(pFile, SQLITE_LOCK_NONE);
     sqlite3OsCloseFree(pFile);
   }
+  if( pzName ){
+    sqlite3_free(*pzName);
+    *pzName = 0;
+  }
 }
 
 static int csFileLockNB(sqlite3_vfs *pVfs, const char *path,
-                        sqlite3_file **ppFile){
-  return csFileLock(pVfs, path, ppFile);
+                        sqlite3_file **ppFile, char **pzName){
+  return csFileLock(pVfs, path, ppFile, pzName);
 }
 
 typedef sqlite3_file *CsFileLock;
@@ -301,6 +313,7 @@ int chunkStoreOpen(
   }
   cs->file.pVfs = pVfs;
   CS_GRAPH_LOCK(cs) = CS_FILE_LOCK_INIT;
+  cs->pGraphLockName = 0;
   cs->pLockMutex = sqlite3_mutex_alloc(SQLITE_MUTEX_RECURSIVE);
   cs->lockDepth = 0;
 
@@ -1061,6 +1074,7 @@ static int csCommitToFile(ChunkStore *cs){
   i64 origFileSize = 0;
   i64 writeOff = 0;
   CsFileLock lockFd = CS_FILE_LOCK_INIT;
+  char *lockName = 0;
   int hadFile = (cs->file.pFile != 0);
   int lockHeld = csFileLockHeld(CS_GRAPH_LOCK(cs));
   i64 newWalSize = cs->wal.nWalData;
@@ -1082,7 +1096,7 @@ static int csCommitToFile(ChunkStore *cs){
   if( lockHeld ){
     lockFd = CS_FILE_LOCK_INIT;
   }else{
-    rc = csFileLock(cs->file.pVfs, cs->file.zFilename, &lockFd);
+    rc = csFileLock(cs->file.pVfs, cs->file.zFilename, &lockFd, &lockName);
     if( rc!=SQLITE_OK ) return rc;
   }
 
@@ -1304,7 +1318,7 @@ static int csCommitToFile(ChunkStore *cs){
   cs->file.iFileSize = writeOff;
 
 commit_done:
-  csFileUnlock(lockFd);
+  csFileUnlock(lockFd, &lockName);
 
   if( rc != SQLITE_OK ){
     if( cs->file.pFile && writeOff > origFileSize ){
@@ -1454,14 +1468,14 @@ int chunkStoreLockAndRefreshChanged(ChunkStore *cs, int *pChanged){
     if( cs->pLockMutex ) sqlite3_mutex_leave(cs->pLockMutex);
     return SQLITE_ERROR;
   }
-  rc = csFileLockNB(cs->file.pVfs, cs->file.zFilename, &CS_GRAPH_LOCK(cs));
+  rc = csFileLockNB(cs->file.pVfs, cs->file.zFilename, &CS_GRAPH_LOCK(cs), &cs->pGraphLockName);
   if( rc!=SQLITE_OK ){
     if( cs->pLockMutex ) sqlite3_mutex_leave(cs->pLockMutex);
     return rc;
   }
   rc = chunkStoreRefreshIfChanged(cs, &changed);
   if( rc!=SQLITE_OK ){
-    csFileUnlock(CS_GRAPH_LOCK(cs));
+    csFileUnlock(CS_GRAPH_LOCK(cs), &cs->pGraphLockName);
     CS_GRAPH_LOCK(cs) = CS_FILE_LOCK_INIT;
     if( cs->pLockMutex ) sqlite3_mutex_leave(cs->pLockMutex);
     return rc;
@@ -1479,12 +1493,12 @@ void chunkStoreUnlock(ChunkStore *cs){
   if( cs->lockDepth > 0 ){
     cs->lockDepth--;
     if( cs->lockDepth == 0 && csFileLockHeld(CS_GRAPH_LOCK(cs)) ){
-      csFileUnlock(CS_GRAPH_LOCK(cs));
+      csFileUnlock(CS_GRAPH_LOCK(cs), &cs->pGraphLockName);
       CS_GRAPH_LOCK(cs) = CS_FILE_LOCK_INIT;
     }
     if( cs->pLockMutex ) sqlite3_mutex_leave(cs->pLockMutex);
   }else if( csFileLockHeld(CS_GRAPH_LOCK(cs)) ){
-    csFileUnlock(CS_GRAPH_LOCK(cs));
+    csFileUnlock(CS_GRAPH_LOCK(cs), &cs->pGraphLockName);
     CS_GRAPH_LOCK(cs) = CS_FILE_LOCK_INIT;
   }
 }

--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -133,6 +133,7 @@ struct ChunkStore {
   u8 isMemory;
   u8 snapshotPinned;
   sqlite3_file *pGraphLockFile;
+  char *pGraphLockName;        /* owned name kept alive for pGraphLockFile (xOpen contract) */
   sqlite3_mutex *pLockMutex;
   int lockDepth;
 };


### PR DESCRIPTION
## Summary
#1249: `autoindex1-113` captured spurious `SQLITE_WARNING {file renamed while open: …}` entries — including a garbage filename `æﮑÔuÆî-lock` — instead of just the expected automatic-index warning. The garbage bytes were the tell: a **dangling pointer / use-after-free read**.

## Root cause
`csFileLock` (`chunk_store.c`) opens the chunk-store graph-lock file via `sqlite3OsOpenMalloc(pVfs, zLock, …)` with `SQLITE_OPEN_MAIN_DB`, then **freed `zLock` immediately**. But the unix VFS aliases the filename — it does not copy it:
```c
/* os_unix.c */
pNew->zPath = zFilename;   /* pointer, not a copy */
```
and SQLite's xOpen contract requires the name to remain valid for the file's lifetime. So `pFile->zPath` dangled. At close, `unixClose → verifyDbFile` ran `osStat(pFile->zPath)`; the garbage path failed to stat, so `fileHasMoved()` returned true and logged `file renamed while open: <freed buffer>`. The freed block was variously uninitialized (`æﮑÔ…-lock`) or reused by a table-name allocation (`t1`/`t2`).

## Fix
Keep the lock-file name alive for the file's lifetime:
- `csFileLock`/`csFileLockNB` hand the owned name back to the caller.
- `csFileUnlock` frees it after closing the file.
- Stored in `ChunkStore.pGraphLockName` for the persistent graph lock; a local for the transient commit lock.

## Verification
- `autoindex1` now passes **0 of 40** (was 1 error with the garbage warnings) — fail-before/pass-after.
- **ASan-clean** on autoindex1.
- No regression vs freshly-built master on lock-heavy suites: `savepoint` 48=48, `trans` 19=19, `fkey2` 7=7.
- Gate `autoindex1.test` in the `inherited-testfixture` job.

Closes #1249.

🤖 Generated with [Claude Code](https://claude.com/claude-code)