### PR TITLE
Gate joinB (clean, 0/513) — #1208

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -553,7 +553,7 @@ jobs:
           index4 index6 index7 index8 index9 indexA indexexpr1 indexexpr2 \
           indexexpr3 init insert2 insert3 insert4 insert5 insertfault instr \
           instrfault intreal ioerr5 ioerr6 istrue join2 join3 join4 join5 \
-          join6 join7 join8 join9 joinA joinC joinE joinF \
+          join6 join7 join8 join9 joinA joinB joinC joinE joinF \
           joinH joinI jrnlmode json107 json108 json109 json501 json502 jsonb01 \
           keyword1 lastinsert laststmtchanges literal literal2 loadext loadext2 lock6 \
           lookaside malloc4 malloc5 malloc7 malloc8 malloc9 mallocB mallocE \


### PR DESCRIPTION
Part of #1208 per-file testfixture gating (verify-each-individually).

`joinB` passes **0 errors out of 513 tests** in both builds:
- `build-ci` (DOLTLITE_PROLLY_CHECK=1, CI-faithful)
- `build-asan-tf` (ASan) — ASan-clean, no heap errors

No divergences to record; gating the file as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)