### PR TITLE
Record WITHOUT-ROWID/collation divergences; gate update2 whereF without_rowid5 window6 (#1208)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -602,7 +602,8 @@ jobs:
           whereI whereJ whereK wherelfault wherelimit wherelimit2 wherelimit3 whereM \
           whereN window4 window5 window7 window8 window9 windowA windowB \
           windowD windowerr windowfault windowpushd with1 with2 with3 with4 with5 \
-          with6 withM without_rowid2 without_rowid3 without_rowid4 without_rowid6 zeroblobfault zipfile \
+          with6 withM without_rowid2 without_rowid3 without_rowid4 without_rowid5 without_rowid6 \
+          update2 whereF window6 zeroblobfault zipfile \
           zipfile2 zipfilefault \
           altermalloc2 closure01 fpconv1 fts3an fts3snippet fuzzer2 indexfault joinD json106 \
           mallocA mmap4 percentile savepoint4 sort3 sort4 sortfault speed1p speed2 speed4 \

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1366,3 +1366,27 @@ limit2 limit2-110.3  # sqlite_search_count scan-count metric; prolly cursor coun
 # matching t8 (explicit WITHOUT ROWID, expects 0). Verified row semantics are
 # correct; only the plan differs. WITHOUT-ROWID-PK plan divergence (#1176).
 notnull notnull-6.5  # plan uses a seek not OP_Next: non-integer PK is WITHOUT ROWID (#1176)
+
+# update2 — update2-2.3 runs `UPDATE t3 SET c=1 WHERE rowid=?` on
+# t3(a PRIMARY KEY,b,c). DoltLite stores a non-integer PRIMARY KEY as WITHOUT
+# ROWID (#1176), so there is no rowid column → "no such column: rowid". The
+# non-rowid UPDATE (2.2, WHERE b=?) passes. WITHOUT-ROWID-PK divergence.
+update2 update2-2.3  # explicit rowid on a non-integer-PK (WITHOUT ROWID) table (#1176)
+
+# whereF — whereF-4.0 runs `EXPLAIN QUERY PLAN SELECT rowid FROM t4 ...` where
+# t4 has PRIMARY KEY(a,b,c) (composite → WITHOUT ROWID, #1176), so rowid does
+# not exist. WITHOUT-ROWID-PK divergence.
+whereF whereF-4.0  # explicit rowid on a composite-PK (WITHOUT ROWID) table (#1176)
+
+# without_rowid5 — the file contrasts a normal (rowid) table against a WITHOUT
+# ROWID one. -1.1 selects rowid/_rowid_/oid from t1(a PRIMARY KEY,b,c) expecting
+# the rowid alias to exist, but DoltLite stores a non-integer PK as WITHOUT ROWID
+# (#1176) → no rowid. -5.5 expects a NULL insert into the PK to succeed, but a
+# WITHOUT-ROWID PK is implicitly NOT NULL. Both are the #1176 surface.
+without_rowid5 without_rowid5-1.1  # rowid alias absent: non-integer PK is WITHOUT ROWID (#1176)
+without_rowid5 without_rowid5-5.5  # WITHOUT-ROWID PK is implicitly NOT NULL (#1176)
+
+# window6 — window6-3.1 creates an index using a user-defined collation
+# (`CREATE INDEX window ON x1(x COLLATE window)`). DoltLite does not support
+# indexes with a custom collation (same class as collate3/collate4). Feature gap.
+window6 window6-3.1  # index with user-defined collation unsupported


### PR DESCRIPTION
## Summary
A batch of 4 deeply-inspected, confirmed-intentional divergences from the #1208 sweep. Each `do_test` block was read and the class confirmed; in every file all other subtests pass.

| File | Subtest | What it does | Class |
|---|---|---|---|
| update2 | 2.3 | `UPDATE t3 SET c=1 WHERE rowid=?` on `t3(a PRIMARY KEY,b,c)` | non-integer PK → WITHOUT ROWID, no rowid (#1176). 2.2 (`WHERE b=?`) passes |
| whereF | 4.0 | `EXPLAIN QUERY PLAN SELECT rowid FROM t4`, `t4 … PRIMARY KEY(a,b,c)` | composite PK → WITHOUT ROWID (#1176) |
| without_rowid5 | 1.1 | `SELECT rowid,_rowid_,oid FROM t1(a PRIMARY KEY,b,c)` | non-integer PK → WITHOUT ROWID (#1176) |
| without_rowid5 | 5.5 | NULL insert into the PK column | WITHOUT-ROWID PK is implicitly NOT NULL (#1176) |
| window6 | 3.1 | `CREATE INDEX window ON x1(x COLLATE window)` | user-defined collation on index unsupported (collate3/4 class) |

These are the standard WITHOUT-ROWID-PK surface (DoltLite stores any non-integer/composite PRIMARY KEY as WITHOUT ROWID) and the custom-collation feature gap.

No code change. Gate `update2`, `whereF`, `without_rowid5`, `window6`. Part of #1208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)