### PR TITLE
Fix change count for whole-table DELETE over pending rows (#1263)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -472,7 +472,7 @@ jobs:
           aggnested aggorderby \
           affinity2 affinity3 \
           between distinct distinctagg \
-          e_createtable e_delete e_insert e_select e_update e_fkey \
+          e_createtable e_delete e_insert e_select e_update e_fkey e_changes e_totalchanges \
           func2 func3 hexlit icu intarray \
           orderby1 orderby2 orderby3 orderby4 \
           pragma pragma2 printf2 \

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -5726,19 +5726,32 @@ static int prollyBtreeClearTable(Btree *p, int iTable, i64 *pnChange){
     return SQLITE_OK;
   }
 
-  if( pnChange ){
-    int rc = countTreeEntries(p, (Pgno)iTable, pnChange);
-    if( rc!=SQLITE_OK ) return rc;
-  }
-
-  /* Save, don't abort, cursors on this table: the truncate optimization
-  ** (DELETE with no WHERE) can fire while another statement scans the table,
-  ** and that scan must restore against the now-empty tree and continue
-  ** rather than fail with SQLITE_ABORT. */
+  /* Save, don't abort, cursors on this table before mutating it: the truncate
+  ** optimization (DELETE with no WHERE) can fire while another statement scans
+  ** the table, and that scan must restore against the now-empty tree and
+  ** continue rather than fail with SQLITE_ABORT. */
   {
     int rc = saveAllCursors(p, pBt, (Pgno)iTable, 0);
     if( rc!=SQLITE_OK ) return rc;
   }
+  {
+    int rc = syncBtreeSavepoints(p);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+
+  if( pnChange ){
+    /* The change count must include rows that exist only as pending,
+    ** same-transaction mutations not yet in the committed root — e.g. a
+    ** whole-table DELETE inside a trigger that just populated the table.
+    ** Merge pending into the root first (mirroring the SELECT count(*) path,
+    ** flushPendingForTable + countTreeEntries) so the count is exact; the
+    ** truncate below then clears the merged root. */
+    int rc = flushPendingForTable(p, pBt, pTE, 1);
+    if( rc!=SQLITE_OK ) return rc;
+    rc = countTreeEntries(p, (Pgno)iTable, pnChange);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+
   /* TRUNCATE: discard any pending mutations for this table. Without this,
   ** merging the now-empty tree with stale pending inserts would resurrect
   ** rows the caller asked to remove. Inside a savepoint that captured
@@ -5746,11 +5759,8 @@ static int prollyBtreeClearTable(Btree *p, int iTable, i64 *pnChange){
   ** flushPendingForTable uses) so ROLLBACK TO can restore pre-savepoint
   ** pending edits. Outside any savepoint, free the map outright. Either
   ** way the cursor aliases must be updated since saving the cursors
-  ** leaves pCur->pMutMap untouched. */
-  {
-    int rc = syncBtreeSavepoints(p);
-    if( rc!=SQLITE_OK ) return rc;
-  }
+  ** leaves pCur->pMutMap untouched. (After a counted flush above the pending
+  ** map is already empty; this still releases it cleanly.) */
   if( pTE->pPending ){
     ProllyMutMap *pMap = (ProllyMutMap*)pTE->pPending;
     ProllyMutMap *pFlushMap = pMap;


### PR DESCRIPTION
## Summary
#1263 was filed as "sqlite3_changes()/total_changes() don't count prolly writes." Investigation showed that's **mostly not true** — `changes()` is correct for INSERT, UPDATE, and `DELETE … WHERE`. There is one genuine, narrow bug, fixed here.

## Root cause
`prollyBtreeClearTable` — the truncate optimization for `DELETE` with no `WHERE` (`OP_Clear`) — computed the cleared-row count with `countTreeEntries` on the **committed root only**, ignoring same-transaction pending mutations in the table's mutmap.

So a whole-table DELETE of rows inserted in the same statement-transaction reported **0** changes. At top level the prior INSERT had auto-committed (rows already in the root → count correct), so it only surfaced when uncommitted pending rows existed — e.g. a trigger that populates then clears a table:

```sql
CREATE TRIGGER … BEGIN
  INSERT INTO q3 VALUES(1),(2),(3),(4),(5);   -- changes()=5  ✓
  DELETE FROM q3;                              -- changes()=0  ✗  (should be 5)
END;
```

Surfaced as `e_changes-7.2/7.3` and `e_totalchanges`.

## Fix
Before counting, merge pending into the root with `flushPendingForTable` (the same flush + `countTreeEntries` the `SELECT count(*)` path uses), making the count exact; the truncate then clears the merged root. `saveAllCursors` and `syncBtreeSavepoints` are hoisted above the flush so cursors are saved and savepoints captured before the root is mutated (preserving truncate-during-scan and `ROLLBACK TO`). The no-count path (`pnChange==NULL`) is unchanged.

## Verification
- Fail-before / pass-after: `e_changes` 2→0, `e_totalchanges` 4→0.
- ASan-clean.
- No regression vs freshly-built master: `delete` 6=6, `trigger1` 4=4, `savepoint` 48=48, `trans` 19=19, `fkey2` 7=7.
- Gate `e_changes` and `e_totalchanges`.

## Not in scope
`changes.test` (66/67) is **not** this bug: it fails because `PRAGMA journal_mode=off` (intentionally unsupported on doltlite) aborts the setup `db eval` before `CREATE TABLE`, so the table never exists and later inserts no-op — a cascade of an intentional divergence, tracked separately in the #1208 sweep.

Closes #1263.

🤖 Generated with [Claude Code](https://claude.com/claude-code)