### PR TITLE
Record intentional divergences from #1264 triage; gate main misc1 misc5 gencol1

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -559,6 +559,7 @@ jobs:
           keyword1 lastinsert laststmtchanges literal literal2 loadext loadext2 lock6 \
           lookaside malloc4 malloc5 malloc7 malloc8 malloc9 mallocB mallocE \
           mallocJ mallocL mallocM manydb mem5 memsubsys2 merge1 minmax4 misc2 \
+          main misc1 misc5 gencol1 \
           rowvaluefault \
           misc3 misc6 misc8 misuse mmap2 mmapfault multiplex3 mutex2 normalize \
           notify1 notify2 notify3 notnull2 notnullfault nulls1 numindex1 offset1 orderby5 \

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1390,3 +1390,28 @@ without_rowid5 without_rowid5-5.5  # WITHOUT-ROWID PK is implicitly NOT NULL (#1
 # (`CREATE INDEX window ON x1(x COLLATE window)`). DoltLite does not support
 # indexes with a custom collation (same class as collate3/collate4). Feature gap.
 window6 window6-3.1  # index with user-defined collation unsupported
+
+# main — main-2.0 writes garbage ("hi!") to test.db then expects sqlite3_open to
+# SUCCEED (stock opens lazily, defers validation). DoltLite validates the chunk
+# store manifest eagerly at open, so a non-chunk-store file fails to open with a
+# disk I/O error. Eager-open-validation divergence.
+main main-2.0  # eager chunk-store validation at open; stock opens lazily
+
+# misc5 — misc5-4.1 writes "This is not really a database" to test.db then
+# expects "file is not a database" on first access. DoltLite's eager chunk-store
+# open reports "disk I/O error" for the unparseable file instead. Not-a-database
+# detection message differs (no SQLite header to inspect).
+misc5 misc5-4.1  # not-a-database open error message differs (chunk store, not a SQLite file)
+
+# misc1 — misc1-14.2b expects test.db-journal to exist during an open write
+# transaction. DoltLite uses a chunk store, not a rollback journal, so no
+# -journal file is ever created (file exists -> 0 vs expected 1). 14.1/14.2a
+# (journal absent) pass. Rollback-journal feature divergence.
+misc1 misc1-14.2b  # no rollback-journal file: doltlite has no -journal
+
+# gencol1 — gencol1-15.10/15.20 use `db deserialize [decode_hexdb ...]` to load a
+# raw SQLite page image. DoltLite does not support the page-image deserialize API
+# (prolly feature gap, #1225); the deserialize fails ("unable to set MEMDB
+# content"). Generated-column behavior itself is correct (the other 174 tests pass).
+gencol1 gencol1-15.10  # db deserialize (page-image API) unsupported (#1225)
+gencol1 gencol1-15.20  # db deserialize (page-image API) unsupported (#1225)


### PR DESCRIPTION
## Summary
Triaged the #1264 suspicious set by reproducing each against stock `sqlite3`. **Four are intentional** (one subtest each); the **two genuine bugs are split into their own issues** and not gated.

### Intentional (recorded + gated here)
| File | Subtest | Cause |
|---|---|---|
| main | 2.0 | writes garbage to test.db, expects open to **succeed** (stock lazy open); DoltLite validates the chunk-store manifest **eagerly** at open → disk I/O error |
| misc5 | 4.1 | garbage file → expects "file is not a database"; DoltLite's eager open reports "disk I/O error" (no SQLite header to inspect) |
| misc1 | 14.2b | expects `test.db-journal` to exist mid-transaction; DoltLite has no rollback journal (chunk store). 14.1/14.2a pass |
| gencol1 | 15.10/15.20 | `db deserialize` (page-image API) unsupported (#1225); generated-column behavior itself is correct (174 other tests pass) |

### Real bugs found in the same triage (NOT gated, filed separately)
- **#1267** — UPSERT `ON CONFLICT` on a non-INTEGER UNIQUE column inserts a duplicate and corrupts the index (serious / silent corruption).
- **#1268** — legacy `sqlite3_prepare` (v1) schema-recompile returns the correct error codes but a blank message (minor).

No code change. Closes #1264.

🤖 Generated with [Claude Code](https://claude.com/claude-code)