### PR TITLE
Fix UNIQUE/UPSERT conflict detection for integer-valued reals (#1267)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -593,7 +593,7 @@ jobs:
           trace3 trans3 transitive1 trigger3 trigger4 trigger5 trigger6 trigger8 \
           trigger9 triggerD triggerF triggerG triggerupfrom types3 unhex unionall2 \
           unionallfault unionvtab unionvtabfault unique unique2 unordered upfrom1 upfrom2 \
-          upfrom3 upfrom4 upfromfault upsert2 upsert3 upsert4 upsert5 uri2 \
+          upfrom3 upfrom4 upfromfault upsert1 upsert2 upsert3 upsert4 upsert5 uri2 \
           values valuesfault varint view2 view3 vtab_alter vtab3 vtab5 \
           vtab6 vtab7 vtab8 vtab9 vtabA vtabB vtabC vtabD \
           vtabdistinct vtabE vtabF vtabI vtabJ vtabK vtabL vtabrhs1 \

--- a/src/sortkey.c
+++ b/src/sortkey.c
@@ -442,7 +442,15 @@ static int sortKeyMemSerialType(Mem *pMem, u32 *pSerialType, u32 *pLen){
     return SQLITE_OK;
   }
   if( flags & MEM_IntReal ){
-    return SQLITE_NOTFOUND;
+    /* An integer-valued real (e.g. an integer coerced into a REAL column by
+    ** affinity): the value lives in u.i. Encode it via its integer serial
+    ** type — encodeNumeric normalizes integer serial types to the same IEEE
+    ** bytes as serialType 7, so this produces a key identical to a true real
+    ** of the same magnitude. Bailing here (SQLITE_NOTFOUND) instead let two
+    ** identical integer-valued reals build mismatched index keys, so UNIQUE
+    ** conflicts went undetected and duplicates were stored (#1267). */
+    intSerialType(pMem->u.i, pSerialType, pLen);
+    return SQLITE_OK;
   }
   if( flags & MEM_Int ){
     intSerialType(pMem->u.i, pSerialType, pLen);


### PR DESCRIPTION
## Summary
A UNIQUE constraint — and UPSERT `ON CONFLICT` — on a REAL column was **not enforced** when the value was an *integer-valued real* (e.g. inserting `1`, or `1.0`, into a REAL column, where affinity yields a `MEM_IntReal`). Duplicates were silently stored and the unique index corrupted; UPSERT inserted a duplicate instead of updating in place. Silent data corruption.

```sql
CREATE TABLE t(c0 REAL UNIQUE, c1);
INSERT INTO t VALUES(1,2);
INSERT INTO t VALUES(1,3);   -- stock: UNIQUE constraint failed; doltlite (before): 2 rows
```

## Root cause
`sortKeyMemSerialType` (`src/sortkey.c`) returned `SQLITE_NOTFOUND` for `MEM_IntReal`. So the index sort key couldn't be built for an integer-valued real and fell back to a path whose key didn't match the stored entry — the conflict probe never matched. A true fractional real (`2.5`, plain `MEM_Real`) and a plain integer both encoded fine, which is exactly why **only integer-valued reals** were affected.

## Fix
Encode `MEM_IntReal` via its integer value (`intSerialType(u.i)`), like `MEM_Int`. `encodeNumeric` normalizes integer serial types to the same IEEE-double bytes as `serialType 7`, so an integer-valued real now produces a key **identical** to a true real of the same magnitude — conflicts are detected.

## Verification
- fail-before / pass-after: `upsert1` 1→0; direct repros (REAL UNIQUE dup int/`1.0` now raise UNIQUE; `upsert1-800` matches stock `1.0|1.0`, `2.0|1`; distinct reals still allowed — no false collisions).
- No regression vs freshly-built master: index 9=9, where 9=9, cast 0=0, affinity2 0=0, conflict 0=0, insert 1=1, minmax 1=1, rowid 1=1, boundary2 (3022) 0=0.
- ASan-clean across all.
- Gate `upsert1`.

Closes #1267.

🤖 Generated with [Claude Code](https://claude.com/claude-code)