### PR TITLE
Record schema error on db handle for expired legacy-prepare statements (#1268)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -537,7 +537,7 @@ jobs:
           conflict2 contrib01 corrupt3 cost countofview coveridxscan csv01 ctime \
           cursorhint cursorhint2 dataversion1 date2 date3 date4 date5 dbdata \
           cffault decimal default descidx3 delete3 delete4 e_blobbytes e_droptrigger e_dropview e_resolve emptytable \
-          eqp eqp2 errofst1 eval exec exists existsexpr existsexpr2 \
+          eqp eqp2 errmsg errofst1 eval exec exists existsexpr existsexpr2 \
           expr2 exprfault expridx1 filectrl filter1 filter2 filterfault fkey3 \
           fkey4 fkey6 fkey7 fkey8 fkey_malloc fordelete fts-9fd058691 fts3aa fts3ab fts3ac \
           fts3ad fts3ae fts3af fts3ag fts3ah fts3aj fts3ak fts3al \

--- a/src/vdbeapi.c
+++ b/src/vdbeapi.c
@@ -787,6 +787,17 @@ static int sqlite3Step(Vdbe *p){
           ** value.
           */
           rc = sqlite3VdbeTransferError(p);
+#ifdef DOLTLITE_PROLLY
+        }else{
+          /* Legacy sqlite3_prepare (v1): record the error on the db handle so
+          ** sqlite3_errcode()/sqlite3_errmsg() reflect it. DoltLite marks the
+          ** statement expired on a same-connection schema change, taking this
+          ** path; stock instead reaches the error through OP_Transaction's
+          ** cookie check (which sets db->errCode at end_of_step, skipped here
+          ** by the goto). Without this, errmsg() returns "not an error" even
+          ** though step returned SQLITE_ERROR (#1268). */
+          sqlite3Error(db, rc);
+#endif
         }
         goto end_of_step;
       }

--- a/src/vdbeaux.c
+++ b/src/vdbeaux.c
@@ -3618,6 +3618,15 @@ int sqlite3VdbeReset(Vdbe *p){
     }else{
       db->errCode = p->rc;
     }
+#ifdef DOLTLITE_PROLLY
+  }else if( p->expired && p->rc!=SQLITE_OK ){
+    /* An expired statement (a same-connection schema change occurred before it
+    ** ran) never advanced pc, so the transfer above is skipped. Record its rc
+    ** (e.g. SQLITE_SCHEMA) on the db handle so sqlite3_errcode()/errmsg()
+    ** reflect the schema error after finalize/reset rather than reporting the
+    ** stale code from a prior step (#1268). */
+    db->errCode = p->rc;
+#endif
   }
 
   /* Reset register contents and reclaim error message memory.


### PR DESCRIPTION
## Summary
On the legacy `sqlite3_prepare` (v1) path, when a same-connection schema change occurred before a prepared statement ran, `sqlite3_errcode()`/`sqlite3_errmsg()` reported **"not an error"** even though `step` returned `SQLITE_ERROR` and `finalize` returned `SQLITE_SCHEMA`. The codes were correct; the db handle's error state was never set (`errmsg-3.1.2`).

## Root cause
DoltLite marks the statement expired on the schema change, so:
- `sqlite3Step` takes the `p->expired` branch, which for non-SAVESQL (v1) does **not** transfer the error to the db handle (only v2/SAVESQL calls `sqlite3VdbeTransferError`); and
- `sqlite3VdbeReset` skips its error transfer because the expired statement never advanced `pc` (`if(p->pc>=0)`).

Stock instead reaches the error through `OP_Transaction`'s cookie check during execution, which records `db->errCode` at end_of_step.

## Fix (both gated under `DOLTLITE_PROLLY`)
- `sqlite3Step` expired branch: for the v1 case, `sqlite3Error(db, rc)` so step's `SQLITE_ERROR` is reflected by `errmsg` ("SQL logic error").
- `sqlite3VdbeReset`: when the statement is expired with a non-OK `rc` (pc<0, normal transfer skipped), record `p->rc` so finalize/reset report `SQLITE_SCHEMA` ("database schema has changed").

## Verification
- `errmsg` 1→0 (step `SQLITE_ERROR`/"SQL logic error"; finalize `SQLITE_SCHEMA`/"database schema has changed").
- No regression vs freshly-built master: schema/schema2/schema3 0=0, capi2 1=1, capi3 10=10, reindex 7=7, alter 5=5, trigger1 4=4.
- ASan-clean. Gate `errmsg`.

Closes #1268.

🤖 Generated with [Claude Code](https://claude.com/claude-code)