### PR TITLE
Record UTF-16 encoding divergences; gate enc2 enc3 like3 numcast (#1208)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -442,7 +442,7 @@ jobs:
       run: |
         cd build
         bash ../test/run_testfixture.sh "Large tests" 180 \
-          func e_expr printf date randexpr1 enc4 \
+          func e_expr printf date randexpr1 enc4 enc2 enc3 like3 numcast \
           boundary1 boundary2 boundary3 select9
 
     - name: SQLite crash recovery tests

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1415,3 +1415,74 @@ misc1 misc1-14.2b  # no rollback-journal file: doltlite has no -journal
 # content"). Generated-column behavior itself is correct (the other 174 tests pass).
 gencol1 gencol1-15.10  # db deserialize (page-image API) unsupported (#1225)
 gencol1 gencol1-15.20  # db deserialize (page-image API) unsupported (#1225)
+
+# enc2 — UTF-16 encoding tests (#1164). DoltLite is locked to UTF-8: it ignores
+# PRAGMA encoding=utf16le/be and reports UTF-8, so tests that read back the
+# connection encoding (directly, via a custom collation/function result, or a
+# CAST of UTF-16 bytes) diverge. The collation/function/row data itself is
+# correct. A few are unordered SELECTs returning PK-order not insertion order
+# (rowid-order class); the multiset is identical.
+enc2 enc2-1.3  # unordered SELECT: PK-order vs insertion order (multiset equal)
+enc2 enc2-1.7  # unordered SELECT: PK-order vs insertion order (multiset equal)
+enc2 enc2-1.8  # unordered SELECT: PK-order vs insertion order (multiset equal)
+enc2 enc2-2.3  # unordered SELECT: PK-order vs insertion order (multiset equal)
+enc2 enc2-2.7  # unordered SELECT: PK-order vs insertion order (multiset equal)
+enc2 enc2-2.8  # unordered SELECT: PK-order vs insertion order (multiset equal)
+enc2 enc2-3.3  # unordered SELECT: PK-order vs insertion order (multiset equal)
+enc2 enc2-3.7  # unordered SELECT: PK-order vs insertion order (multiset equal)
+enc2 enc2-3.8  # unordered SELECT: PK-order vs insertion order (multiset equal)
+enc2 enc2-2.0.1  # reports UTF-8: doltlite ignores non-UTF-8 encodings (#1164)
+enc2 enc2-2.0.2  # reports UTF-8: doltlite ignores non-UTF-8 encodings (#1164)
+enc2 enc2-2.0.3  # reports UTF-8: doltlite ignores non-UTF-8 encodings (#1164)
+enc2 enc2-2.0.4  # reports UTF-8: doltlite ignores non-UTF-8 encodings (#1164)
+enc2 enc2-2.10  # reports UTF-8: doltlite ignores non-UTF-8 encodings (#1164)
+enc2 enc2-3.0.1  # reports UTF-8: doltlite ignores non-UTF-8 encodings (#1164)
+enc2 enc2-3.0.2  # reports UTF-8: doltlite ignores non-UTF-8 encodings (#1164)
+enc2 enc2-3.0.3  # reports UTF-8: doltlite ignores non-UTF-8 encodings (#1164)
+enc2 enc2-3.0.4  # reports UTF-8: doltlite ignores non-UTF-8 encodings (#1164)
+enc2 enc2-3.10  # reports UTF-8: doltlite ignores non-UTF-8 encodings (#1164)
+enc2 enc2-4.3  # reports UTF-8: doltlite ignores non-UTF-8 encodings (#1164)
+enc2 enc2-5.5  # reports UTF-8: doltlite ignores non-UTF-8 encodings (#1164)
+enc2 enc2-5.6  # reports UTF-8: doltlite ignores non-UTF-8 encodings (#1164)
+enc2 enc2-5.9  # reports UTF-8: doltlite ignores non-UTF-8 encodings (#1164)
+enc2 enc2-5.10  # reports UTF-8: doltlite ignores non-UTF-8 encodings (#1164)
+enc2 enc2-5.13  # reports UTF-8: doltlite ignores non-UTF-8 encodings (#1164)
+enc2 enc2-6.4  # reports UTF-8: doltlite ignores non-UTF-8 encodings (#1164)
+enc2 enc2-6.8  # reports UTF-8: doltlite ignores non-UTF-8 encodings (#1164)
+enc2 enc2-7.2  # reports UTF-8: doltlite ignores non-UTF-8 encodings (#1164)
+enc2 enc2-9.2  # reports UTF-8: doltlite ignores non-UTF-8 encodings (#1164)
+enc2 enc2-9.4  # reports UTF-8: doltlite ignores non-UTF-8 encodings (#1164)
+enc2 enc2-9.5  # reports UTF-8: doltlite ignores non-UTF-8 encodings (#1164)
+
+# enc3 — UTF-16 encoding (#1164). PRAGMA encoding ignored (UTF-8); 2.2/2.3 CAST a
+# UTF-16le byte blob to text: stock reads UTF-16 ('abcde'), doltlite reads UTF-8
+# (NUL-truncated). Stored bytes intact; encoding-only.
+enc3 enc3-1.1  # doltlite ignores non-UTF-8 encodings (#1164)
+enc3 enc3-2.1  # doltlite ignores non-UTF-8 encodings (#1164)
+enc3 enc3-2.2  # doltlite ignores non-UTF-8 encodings (#1164)
+enc3 enc3-2.3  # doltlite ignores non-UTF-8 encodings (#1164)
+enc3 enc3-3.2  # doltlite ignores non-UTF-8 encodings (#1164)
+
+# like3 — the like3-8.* subtests assert the connection encoding is UTF-16le/be
+# after PRAGMA encoding; doltlite reports UTF-8 (#1164). LIKE behavior is correct.
+like3 like3-8.utf16le.1.2  # doltlite ignores non-UTF-8 encodings (#1164)
+like3 like3-8.utf16le.2.2  # doltlite ignores non-UTF-8 encodings (#1164)
+like3 like3-8.utf16le.3.2  # doltlite ignores non-UTF-8 encodings (#1164)
+like3 like3-8.utf16le.4.2  # doltlite ignores non-UTF-8 encodings (#1164)
+like3 like3-8.utf16le.5.2  # doltlite ignores non-UTF-8 encodings (#1164)
+like3 like3-8.utf16le.6.2  # doltlite ignores non-UTF-8 encodings (#1164)
+like3 like3-8.utf16le.7.2  # doltlite ignores non-UTF-8 encodings (#1164)
+like3 like3-8.utf16le.8.2  # doltlite ignores non-UTF-8 encodings (#1164)
+like3 like3-8.utf16be.1.2  # doltlite ignores non-UTF-8 encodings (#1164)
+like3 like3-8.utf16be.2.2  # doltlite ignores non-UTF-8 encodings (#1164)
+like3 like3-8.utf16be.3.2  # doltlite ignores non-UTF-8 encodings (#1164)
+like3 like3-8.utf16be.4.2  # doltlite ignores non-UTF-8 encodings (#1164)
+like3 like3-8.utf16be.5.2  # doltlite ignores non-UTF-8 encodings (#1164)
+like3 like3-8.utf16be.6.2  # doltlite ignores non-UTF-8 encodings (#1164)
+like3 like3-8.utf16be.7.2  # doltlite ignores non-UTF-8 encodings (#1164)
+like3 like3-8.utf16be.8.2  # doltlite ignores non-UTF-8 encodings (#1164)
+
+# numcast — numcast-utf16{le,be}.0 assert the connection encoding; doltlite reports
+# utf8 (#1164). The numeric CAST behavior is correct.
+numcast numcast-utf16le.0  # doltlite ignores non-UTF-8 encodings (#1164)
+numcast numcast-utf16be.0  # doltlite ignores non-UTF-8 encodings (#1164)


### PR DESCRIPTION
## Summary
The `enc2`/`enc3`/`like3`/`numcast` divergences from the #1208 sweep are all the intentional **UTF-16 limitation (#1164)**: DoltLite is locked to UTF-8, ignores `PRAGMA encoding=utf16le/be`, and reports UTF-8. Every divergent subtest was reproduced against stock and falls into:

- **Encoding (#1164)** — the result includes the connection encoding (directly via `PRAGMA encoding`, or embedded in a custom collation result `enc2-5.x`, custom function result `enc2-6.x`, `sqlite_master`/`complete16` `enc2-9.x`, or a CAST of a UTF-16 byte blob `enc3-2.2/2.3`). The collation/function/numeric-cast/LIKE behavior and stored bytes are **correct**; only the encoding label/interpretation differs.
- **rowid-order** (`enc2-1.3/1.7/1.8/2.3/2.7/2.8/3.3/3.7/3.8`) — unordered `SELECT * FROM t1` returns PK-order instead of insertion order; the multiset is identical.

54 subtests recorded (enc2 31, enc3 5, like3 16, numcast 2), matching each file's exact failure set. Gate the four files. No code change. Part of #1208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)