### PR TITLE
Record VFS I/O-counter divergences; gate io sync sync2 multiplex4 (#1208)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -609,4 +609,5 @@ jobs:
           altermalloc2 closure01 fpconv1 fts3an fts3snippet fuzzer2 indexfault joinD json106 \
           mallocA mmap4 percentile savepoint4 sort3 sort4 sortfault speed1p speed2 speed4 \
           stmt tempfault vacuummem wherefault \
-          dbpage pagesize securedel reservebytes shrink format4 stat
+          dbpage pagesize securedel reservebytes shrink format4 stat \
+          io sync sync2 multiplex4

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1601,3 +1601,53 @@ stat stat-7.2  # dbstat vtable (per-page b-tree stats) empty; no SQLite pages
 stat stat-7.2.1  # dbstat vtable (per-page b-tree stats) empty; no SQLite pages
 stat stat-7.2.3  # dbstat vtable (per-page b-tree stats) empty; no SQLite pages
 stat stat-7.2.4  # dbstat vtable (per-page b-tree stats) empty; no SQLite pages
+# io — counts VFS write/sync operations and checks on-disk file size via a test
+# VFS. DoltLite's chunk store batches I/O differently and its file layout is not
+# SQLite-page-sized, so the operation counts and file sizes differ. I/O-model
+# divergence; data is correct.
+io io-1.1  # VFS I/O op-count / file-size; chunk store has a different I/O model
+io io-1.2  # VFS I/O op-count / file-size; chunk store has a different I/O model
+io io-1.3  # VFS I/O op-count / file-size; chunk store has a different I/O model
+io io-1.4  # VFS I/O op-count / file-size; chunk store has a different I/O model
+io io-1.5  # VFS I/O op-count / file-size; chunk store has a different I/O model
+io io-3.1  # VFS I/O op-count / file-size; chunk store has a different I/O model
+io io-3.2  # VFS I/O op-count / file-size; chunk store has a different I/O model
+io io-3.3  # VFS I/O op-count / file-size; chunk store has a different I/O model
+io io-4.1  # VFS I/O op-count / file-size; chunk store has a different I/O model
+io io-4.2.1  # VFS I/O op-count / file-size; chunk store has a different I/O model
+io io-4.2.2  # VFS I/O op-count / file-size; chunk store has a different I/O model
+io io-4.2.3  # VFS I/O op-count / file-size; chunk store has a different I/O model
+io io-4.3.1  # VFS I/O op-count / file-size; chunk store has a different I/O model
+io io-4.3.3  # VFS I/O op-count / file-size; chunk store has a different I/O model
+io io-4.3.4  # VFS I/O op-count / file-size; chunk store has a different I/O model
+io io-5.1  # VFS I/O op-count / file-size; chunk store has a different I/O model
+io io-5.2  # VFS I/O op-count / file-size; chunk store has a different I/O model
+io io-5.3  # VFS I/O op-count / file-size; chunk store has a different I/O model
+io io-5.4  # VFS I/O op-count / file-size; chunk store has a different I/O model
+io io-5.5  # VFS I/O op-count / file-size; chunk store has a different I/O model
+
+# sync — asserts the number of fsync calls (sqlite_sync_count). DoltLite syncs the
+# chunk store differently, so the count differs. Internal I/O-counter divergence.
+sync sync-1.1  # fsync count differs: chunk store I/O model
+sync sync-1.2  # fsync count differs: chunk store I/O model
+sync sync-1.3  # fsync count differs: chunk store I/O model
+sync sync-1.4  # fsync count differs: chunk store I/O model
+
+# sync2 — fsync-count variants (sqlite_sync_count under different journal/sync
+# settings). Same internal I/O-counter divergence as sync.
+sync2 sync2-1.1  # fsync count differs: chunk store I/O model
+sync2 sync2-1.2.3  # fsync count differs: chunk store I/O model
+sync2 sync2-1.3.3  # fsync count differs: chunk store I/O model
+sync2 sync2-1.4.3  # fsync count differs: chunk store I/O model
+sync2 sync2-1.6  # fsync count differs: chunk store I/O model
+sync2 sync2-1.8.3  # fsync count differs: chunk store I/O model
+sync2 sync2-1.9  # fsync count differs: chunk store I/O model
+sync2 sync2-1.10.3  # fsync count differs: chunk store I/O model
+
+# multiplex4 — the multiplex VFS splits a database across numbered files
+# (name.001, ...). DoltLite uses its own chunk store, not the multiplex VFS, so
+# only the single file exists and the multiplex pragma is off. VFS not applicable.
+multiplex4 multiplex4-1.0  # multiplex VFS not used by doltlite
+multiplex4 multiplex4-1.2  # multiplex VFS not used by doltlite
+multiplex4 multiplex4-1.10  # multiplex VFS not used by doltlite
+multiplex4 multiplex4-1.11  # multiplex VFS not used by doltlite


### PR DESCRIPTION
## Summary
4 files, 36 subtests — all VFS I/O-model divergences (each verified vs stock).

| File | n | Cause |
|---|--:|---|
| io | 20 | counts VFS write/sync ops and on-disk file size via a test VFS; doltlite batches I/O differently and the chunk-store file isn't SQLite-page-sized. Data is correct |
| sync | 4 | asserts the fsync count (`sqlite_sync_count`); chunk store syncs differently |
| sync2 | 8 | fsync-count variants under different journal/sync settings |
| multiplex4 | 4 | the multiplex VFS splits a db across `name.001/...`; doltlite uses its own chunk store (single file) |

No code change. Part of #1208.

(Note: `uri`/`e_uri` from the same area are held back for separate careful review — URI filename canonicalization and param handling, where a real "param not honored" bug could hide.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)