### PR TITLE
Enforce SQLITE_OPEN_READONLY / mode=ro at chunk-store open (#1275)

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -354,10 +354,22 @@ int chunkStoreOpen(
   }
 
   if( exists ){
-    int openFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB;
+    /* Honor a caller-requested read-only open (SQLITE_OPEN_READONLY, e.g. the
+    ** sqlite3_open_v2 READONLY flag or a file:...?mode=ro URI). Without this we
+    ** always opened read-write and only fell back to read-only when the OS
+    ** denied write access, so a read-only connection on a writable file
+    ** silently accepted writes (#1275). */
+    int wantReadOnly = (flags & SQLITE_OPEN_READONLY)!=0;
+    int openFlags = (wantReadOnly ? SQLITE_OPEN_READONLY : SQLITE_OPEN_READWRITE)
+                  | SQLITE_OPEN_MAIN_DB;
     int outFlags = 0;
     rc = csOpenFile(pVfs, cs->file.zFilename, &cs->file.pFile, openFlags, &outFlags);
     if( rc != SQLITE_OK ){
+      if( wantReadOnly ){
+        sqlite3_free(cs->file.zFilename);
+        cs->file.zFilename = 0;
+        return rc;
+      }
       openFlags = SQLITE_OPEN_READONLY | SQLITE_OPEN_MAIN_DB;
       rc = csOpenFile(pVfs, cs->file.zFilename, &cs->file.pFile, openFlags, 0);
       if( rc != SQLITE_OK ){
@@ -366,11 +378,10 @@ int chunkStoreOpen(
         return rc;
       }
       cs->readOnly = 1;
-    }else if( outFlags & SQLITE_OPEN_READONLY ){
-      /* The VFS opened a read-only file: a read-write open silently downgrades
-      ** to read-only and returns OK with READONLY in the out-flags. Mark the
-      ** store read-only so writes fail with SQLITE_READONLY rather than later
-      ** hitting a failed write-lock and reporting SQLITE_BUSY. */
+    }else if( wantReadOnly || (outFlags & SQLITE_OPEN_READONLY) ){
+      /* Either the caller asked for read-only, or a read-write open silently
+      ** downgraded to read-only (VFS returned READONLY in the out-flags). Mark
+      ** the store read-only so writes fail with SQLITE_READONLY. */
       cs->readOnly = 1;
     }
 


### PR DESCRIPTION
## Summary
A connection opened read-only — via the `SQLITE_OPEN_READONLY` flag or a `file:…?mode=ro` URI — **silently accepted writes** instead of failing with `attempt to write a readonly database`. Read-only is a common safety boundary (read replicas, untrusted query paths), so this defeated the guarantee.

## Root cause
`chunkStoreOpen` always opened the file `SQLITE_OPEN_READWRITE` and only marked the store read-only when the OS *denied* write access (file permissions). It ignored the caller's requested `SQLITE_OPEN_READONLY` flag, so on a writable file a read-only connection got a read-write store → `cs->readOnly` stayed 0 → `BTS_READ_ONLY` was never set → `prollyBtreeBeginTrans` never returned `SQLITE_READONLY`. The enforcement chain already existed; it was just never armed.

## Fix
When the caller requests read-only (`flags & SQLITE_OPEN_READONLY`), open the file read-only and set `cs->readOnly`. Read-write opens keep the existing downgrade-on-OS-denial fallback.

## Verification
- fail-before / pass-after: a `-readonly` / `mode=ro` write now errors `attempt to write a readonly database` (was silently accepted); `e_uri` 22→21, `uri` 43→41.
- Read-only reads still work; normal read-write unaffected; read-only open of a missing file still fails `unable to open database file`.
- No regression vs freshly-built master: readonly 2=2, rdonly 5=5, attach2 24=24, insert 1=1, select1 1=1, trans 19=19, savepoint 48=48, exclusive2 12=12.
- ASan-clean.

(`e_uri`/`uri` are not gated here — they retain other divergences: shared-cache locking, `sqlite3_uri_parameter` exposure, filename canonicalization.)

Closes #1275.

🤖 Generated with [Claude Code](https://claude.com/claude-code)