### PR TITLE
Support staging individual rows on indexed tables (#1276)

### DIFF
--- a/src/doltlite_workspace.c
+++ b/src/doltlite_workspace.c
@@ -394,14 +394,77 @@ static int wsPatchCatalogRoot(
   return rc;
 }
 
+/* Apply one row's index-entry transition to a single secondary index's root:
+** remove the entry for pSrc (the value leaving the staged tree) and add the
+** entry for pTgt (the value entering it). pSrc/pTgt are full row records (or
+** NULL when the row is absent on that side). Uses doltliteBuildIndexSortKey
+** to reconstruct the native secondary-index key, mirroring the merge path. */
+static int wsApplyRowToIndex(
+  ChunkStore *cs, ProllyCache *pCache,
+  struct TableEntry *idxEntry, Index *pIdx, int iPKey,
+  const u8 *pKey, int nKey, i64 intKey,
+  const u8 *pSrc, int nSrc, const u8 *pTgt, int nTgt
+){
+  ProllyHash root = idxEntry->root;
+  int rc = SQLITE_OK;
+  if( pSrc ){
+    u8 *pIK = 0; int nIK = 0;
+    ProllyHash next;
+    rc = doltliteBuildIndexSortKey(pSrc, nSrc, pIdx->aiColumn, pIdx->nKeyCol,
+                                   0, iPKey, intKey, pKey, nKey, &pIK, &nIK);
+    if( rc==SQLITE_OK ){
+      rc = prollyMutateDelete(cs, pCache, &root, idxEntry->flags,
+                              pIK, nIK, 0, &next);
+      sqlite3_free(pIK);
+      if( rc==SQLITE_OK ) root = next;
+    }
+    if( rc!=SQLITE_OK ) return rc;
+  }
+  if( pTgt ){
+    u8 *pIK = 0; int nIK = 0;
+    ProllyHash next;
+    rc = doltliteBuildIndexSortKey(pTgt, nTgt, pIdx->aiColumn, pIdx->nKeyCol,
+                                   0, iPKey, intKey, pKey, nKey, &pIK, &nIK);
+    if( rc==SQLITE_OK ){
+      rc = prollyMutateInsert(cs, pCache, &root, idxEntry->flags,
+                              pIK, nIK, 0, 0, 0, &next);
+      sqlite3_free(pIK);
+      if( rc==SQLITE_OK ) root = next;
+    }
+    if( rc!=SQLITE_OK ) return rc;
+  }
+  idxEntry->root = root;
+  return SQLITE_OK;
+}
+
 static int wsApplyRowToStaged(WorkspaceVtab *p, WorkspaceRow *r, int makeStaged){
   sqlite3 *db = p->db;
   ChunkStore *cs = doltliteGetChunkStore(db);
   ProllyCache *pCache = doltliteGetCache(db);
-  ProllyHash headHash, headCat, stagedCat, stagedRoot, headRoot, newRoot, newCat;
+  ProllyHash headHash, headCat, stagedCat, newRoot, newCat;
   DoltliteCommit headCommit;
-  u8 flags = r->flags;
+  struct TableEntry *aTables = 0;
+  int nTables = 0;
+  struct TableEntry *pData;
+  Table *pTab;
+  u8 *pCatBuf = 0;
+  int nCatBuf = 0;
   int rc;
+
+  /* The staged copy of this row moves between its HEAD value and its WORKING
+  ** value. For ADD the row is absent at HEAD; for DELETE it is absent in the
+  ** working set. Staging advances HEAD->WORKING; unstaging reverts
+  ** WORKING->HEAD. The data tree is keyed by primary key (set or delete the
+  ** target), while each secondary index must drop the source value's key and
+  ** add the target value's key (#1276). */
+  const u8 *pHeadVal = (r->diffType==PROLLY_DIFF_ADD)    ? 0 : r->pOldVal;
+  int        nHeadVal = (r->diffType==PROLLY_DIFF_ADD)    ? 0 : r->nOldVal;
+  const u8 *pWorkVal = (r->diffType==PROLLY_DIFF_DELETE) ? 0 : r->pNewVal;
+  int        nWorkVal = (r->diffType==PROLLY_DIFF_DELETE) ? 0 : r->nNewVal;
+  const u8 *pSrc = makeStaged ? pHeadVal : pWorkVal;
+  int        nSrc = makeStaged ? nHeadVal : nWorkVal;
+  const u8 *pTgt = makeStaged ? pWorkVal : pHeadVal;
+  int        nTgt = makeStaged ? nWorkVal : nHeadVal;
 
   if( !cs || !pCache ) return SQLITE_ERROR;
   memset(&headCommit, 0, sizeof(headCommit));
@@ -414,56 +477,52 @@ static int wsApplyRowToStaged(WorkspaceVtab *p, WorkspaceRow *r, int makeStaged)
 
   doltliteGetSessionStaged(db, &stagedCat);
   if( prollyHashIsEmpty(&stagedCat) ) stagedCat = headCat;
-  rc = wsLoadTableRoot(db, &stagedCat, p->zTableName, &stagedRoot, &flags, 0);
-  if( rc!=SQLITE_OK ) return rc;
 
-  if( makeStaged ){
-    if( r->diffType==PROLLY_DIFF_DELETE ){
-      rc = prollyMutateDelete(cs, pCache, &stagedRoot, flags,
-                              r->pKey, r->nKey, r->intKey, &newRoot);
-    }else{
-      rc = prollyMutateInsert(cs, pCache, &stagedRoot, flags,
-                              r->pKey, r->nKey, r->intKey,
-                              r->pNewVal, r->nNewVal, &newRoot);
-    }
-  }else{
-    u8 headFlags = flags;
-    rc = wsLoadTableRoot(db, &headCat, p->zTableName, &headRoot, &headFlags, 0);
-    if( rc!=SQLITE_OK ) return rc;
-    if( r->diffType==PROLLY_DIFF_ADD ){
-      rc = prollyMutateDelete(cs, pCache, &stagedRoot, flags,
-                              r->pKey, r->nKey, r->intKey, &newRoot);
-    }else{
-      rc = prollyMutateInsert(cs, pCache, &stagedRoot, flags,
-                              r->pKey, r->nKey, r->intKey,
-                              r->pOldVal, r->nOldVal, &newRoot);
-    }
-  }
+  /* Load the staged catalog once and patch the data root and every secondary
+  ** index root in place, then reserialize as a single new catalog. */
+  rc = doltliteLoadCatalog(db, &stagedCat, &aTables, &nTables, 0);
   if( rc!=SQLITE_OK ) return rc;
-  rc = wsPatchCatalogRoot(db, &stagedCat, p->zTableName, &newRoot, &newCat);
-  if( rc==SQLITE_OK ){
-    doltliteSetSessionStaged(db, &newCat);
+  pData = doltliteFindTableByName(aTables, nTables, p->zTableName);
+  if( !pData ){
+    doltliteFreeCatalog(aTables, nTables);
+    return SQLITE_NOTFOUND;
   }
+
+  if( pTgt ){
+    rc = prollyMutateInsert(cs, pCache, &pData->root, pData->flags,
+                            r->pKey, r->nKey, r->intKey, pTgt, nTgt, &newRoot);
+  }else{
+    rc = prollyMutateDelete(cs, pCache, &pData->root, pData->flags,
+                            r->pKey, r->nKey, r->intKey, &newRoot);
+  }
+  if( rc!=SQLITE_OK ){ doltliteFreeCatalog(aTables, nTables); return rc; }
+  pData->root = newRoot;
+
+  pTab = sqlite3FindTable(db, p->zTableName, "main");
+  if( pTab ){
+    Index *pIdx;
+    for(pIdx=pTab->pIndex; pIdx && rc==SQLITE_OK; pIdx=pIdx->pNext){
+      struct TableEntry *idxEntry;
+      /* For WITHOUT ROWID tables the PK is exposed as a pseudo-index whose
+      ** root is the table tree itself; it is not a separate secondary index. */
+      if( pIdx->idxType==SQLITE_IDXTYPE_PRIMARYKEY ) continue;
+      idxEntry = doltliteFindTableByNumber(aTables, nTables, pIdx->tnum);
+      if( !idxEntry ) continue;
+      rc = wsApplyRowToIndex(cs, pCache, idxEntry, pIdx, pTab->iPKey,
+                             r->pKey, r->nKey, r->intKey,
+                             pSrc, nSrc, pTgt, nTgt);
+    }
+  }
+  if( rc!=SQLITE_OK ){ doltliteFreeCatalog(aTables, nTables); return rc; }
+
+  rc = doltliteSerializeCatalogEntries(db, aTables, nTables, &pCatBuf, &nCatBuf);
+  if( rc==SQLITE_OK ) rc = chunkStorePut(cs, pCatBuf, nCatBuf, &newCat);
+  sqlite3_free(pCatBuf);
+  doltliteFreeCatalog(aTables, nTables);
+  if( rc==SQLITE_OK ) doltliteSetSessionStaged(db, &newCat);
   return rc;
 }
 
-static int wsTableHasSecondaryIndexes(sqlite3 *db, const char *zTable, int *pHas){
-  sqlite3_stmt *pStmt = 0;
-  char *zSql;
-  int rc;
-  *pHas = 0;
-  zSql = sqlite3_mprintf(
-      "SELECT 1 FROM sqlite_master "
-      "WHERE type='index' AND tbl_name='%q' AND sql IS NOT NULL LIMIT 1",
-      zTable);
-  if( !zSql ) return SQLITE_NOMEM;
-  rc = sqlite3_prepare_v2(db, zSql, -1, &pStmt, 0);
-  sqlite3_free(zSql);
-  if( rc!=SQLITE_OK ) return rc;
-  if( sqlite3_step(pStmt)==SQLITE_ROW ) *pHas = 1;
-  sqlite3_finalize(pStmt);
-  return SQLITE_OK;
-}
 
 static int wsUpdate(sqlite3_vtab *pBase, int argc, sqlite3_value **argv,
                     sqlite3_int64 *pRowid){
@@ -489,16 +548,6 @@ static int wsUpdate(sqlite3_vtab *pBase, int argc, sqlite3_value **argv,
   }
   newStaged = sqlite3_value_int(argv[2 + 1]) ? 1 : 0;
   if( newStaged==r->staged ) return SQLITE_OK;
-  {
-    int hasIndexes = 0;
-    int rc = wsTableHasSecondaryIndexes(p->db, p->zTableName, &hasIndexes);
-    if( rc!=SQLITE_OK ) return rc;
-    if( hasIndexes ){
-      pBase->zErrMsg = sqlite3_mprintf(
-          "staging individual workspace rows for indexed tables is not yet supported");
-      return SQLITE_CONSTRAINT;
-    }
-  }
   return wsApplyRowToStaged(p, r, newStaged);
 }
 

--- a/test/doltlite_workspace.sh
+++ b/test/doltlite_workspace.sh
@@ -39,15 +39,34 @@ SELECT dolt_commit('-A','-m','seed');
 UPDATE t SET v=2;
 " "$IDX_DB" >/dev/null
 
-if "$DOLTLITE" "$IDX_DB" "UPDATE dolt_workspace_t SET staged=TRUE;" >/tmp/doltlite_ws_idx.out 2>/tmp/doltlite_ws_idx.err; then
-  dltest_fail "workspace_indexed_table_rejected" "expected indexed table staging to fail"
-else
+# Staging individual rows on indexed tables is supported (#1276): the staged
+# secondary index must stay consistent with the staged data. Here row 1 is
+# modified v=1 -> v=2 in the working set; staging it must move the index entry
+# from v=1 to v=2.
+if "$DOLTLITE" "$IDX_DB" "UPDATE dolt_workspace_t SET staged=TRUE WHERE to_id=1;" \
+     >/tmp/doltlite_ws_idx.out 2>/tmp/doltlite_ws_idx.err; then
   dltest_pass
+else
+  dltest_fail "workspace_indexed_table_staged" "$(cat /tmp/doltlite_ws_idx.err)"
 fi
-if ! grep -q "indexed tables is not yet supported" /tmp/doltlite_ws_idx.err; then
-  dltest_fail "workspace_indexed_table_error_message" "$(cat /tmp/doltlite_ws_idx.err)"
-else
+
+# Commit the staged row and confirm the committed index is consistent with the
+# committed data: integrity_check passes, the index finds the new value (v=2)
+# and not the stale one (v=1).
+"$DOLTLITE" "$IDX_DB" "SELECT dolt_commit('-m','stage indexed row');" >/dev/null 2>&1
+idx_integ=$("$DOLTLITE" "$IDX_DB" "PRAGMA integrity_check;" 2>&1)
+if [ "$idx_integ" = "ok" ]; then
   dltest_pass
+else
+  dltest_fail "workspace_indexed_integrity_check" "$idx_integ"
+fi
+
+idx_new=$("$DOLTLITE" "$IDX_DB" "SELECT id FROM t WHERE v=2;" 2>&1)
+idx_old=$("$DOLTLITE" "$IDX_DB" "SELECT id FROM t WHERE v=1;" 2>&1)
+if [ "$idx_new" = "1" ] && [ -z "$idx_old" ]; then
+  dltest_pass
+else
+  dltest_fail "workspace_indexed_query" "new=[$idx_new] old=[$idx_old]"
 fi
 
 dltest_finish

--- a/test/doltlite_workspace.sh
+++ b/test/doltlite_workspace.sh
@@ -61,12 +61,49 @@ else
   dltest_fail "workspace_indexed_integrity_check" "$idx_integ"
 fi
 
+# Prove the secondary index exists and has not drifted from the data: the
+# index-served lookup (WHERE v=N, which EXPLAIN shows uses idx_t_v) must agree
+# with a forced full scan (+v=N defeats the index). New value found both ways,
+# old value gone both ways.
 idx_new=$("$DOLTLITE" "$IDX_DB" "SELECT id FROM t WHERE v=2;" 2>&1)
+scan_new=$("$DOLTLITE" "$IDX_DB" "SELECT id FROM t WHERE +v=2;" 2>&1)
 idx_old=$("$DOLTLITE" "$IDX_DB" "SELECT id FROM t WHERE v=1;" 2>&1)
-if [ "$idx_new" = "1" ] && [ -z "$idx_old" ]; then
+scan_old=$("$DOLTLITE" "$IDX_DB" "SELECT id FROM t WHERE +v=1;" 2>&1)
+if [ "$idx_new" = "1" ] && [ "$idx_new" = "$scan_new" ] \
+   && [ -z "$idx_old" ] && [ -z "$scan_old" ]; then
   dltest_pass
 else
-  dltest_fail "workspace_indexed_query" "new=[$idx_new] old=[$idx_old]"
+  dltest_fail "workspace_indexed_query" \
+    "idx_new=[$idx_new] scan_new=[$scan_new] idx_old=[$idx_old] scan_old=[$scan_old]"
+fi
+
+# NOCASE index (validated here rather than the vc oracle, since Dolt has no
+# NOCASE collation): staging a single row must build the same normalized
+# secondary-index key the native write path does, so integrity_check passes and
+# a case-insensitive index lookup finds it.
+NC_DB=/tmp/doltlite_workspace_nocase_$$.db
+rm -rf "$NC_DB"
+trap 'rm -rf "$DB"; rm -rf "$IDX_DB"; rm -rf "$NC_DB"' EXIT
+dltest_run_sql "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT COLLATE NOCASE);
+CREATE INDEX idx_t_v ON t(v);
+INSERT INTO t VALUES(1,'Abc'),(2,'Def');
+SELECT dolt_commit('-A','-m','seed');
+INSERT INTO t VALUES(3,'GHI');
+UPDATE dolt_workspace_t SET staged=TRUE WHERE to_id=3;
+SELECT dolt_commit('-m','stage nocase row');
+" "$NC_DB" >/dev/null
+nc_integ=$("$DOLTLITE" "$NC_DB" "PRAGMA integrity_check;" 2>&1)
+if [ "$nc_integ" = "ok" ]; then
+  dltest_pass
+else
+  dltest_fail "workspace_indexed_nocase_integrity" "$nc_integ"
+fi
+nc_ci=$("$DOLTLITE" "$NC_DB" "SELECT id FROM t WHERE v='ghi';" 2>&1)
+if [ "$nc_ci" = "3" ]; then
+  dltest_pass
+else
+  dltest_fail "workspace_indexed_nocase_query" "ci=[$nc_ci]"
 fi
 
 dltest_finish

--- a/test/vc_oracle_workspace_test.sh
+++ b/test/vc_oracle_workspace_test.sh
@@ -374,6 +374,125 @@ SELECT dolt_commit('-m','composite_delete_subset');
 SELECT CONCAT('R|WORKING_DIFF|', from_a, '|', from_b, '|', from_v, '|', diff_type)
   FROM dolt_diff_m('HEAD', 'WORKING') ORDER BY from_a,from_b;"
 
+# ---------------------------------------------------------------------------
+# Indexed-table single-row staging (#1276): the staged secondary index must
+# stay consistent with the staged data. Each test stages a subset of rows on a
+# table with a secondary index, commits, and checks the committed diff AND an
+# index-served query (point lookup / ORDER BY / range) against the Dolt oracle
+# -- a stale or wrong staged index would diverge from Dolt.
+# ---------------------------------------------------------------------------
+IDX="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT, confidence INT);
+CREATE INDEX iv ON t(v);
+INSERT INTO t VALUES(1,10,0),(2,20,0),(3,30,0),(4,40,0);
+SELECT dolt_commit('-A','-m','seed');
+"
+
+oracle "idx_stage_modified_one" "$IDX
+UPDATE t SET v=120 WHERE id=2;
+UPDATE dolt_workspace_t SET staged=TRUE WHERE to_id=2;
+SELECT dolt_commit('-m','mod2');
+" "SELECT CONCAT('R|C|', to_id, '|', to_v, '|', diff_type)
+  FROM dolt_diff_t('HEAD~1','HEAD') ORDER BY to_id;
+SELECT CONCAT('R|IDX|', id, '|', v) FROM t WHERE v=120 ORDER BY id;
+SELECT CONCAT('R|OLD|', id) FROM t WHERE v=20 ORDER BY id;"
+
+oracle "idx_stage_added_one" "$IDX
+INSERT INTO t VALUES(5,50,1),(6,60,-1);
+UPDATE dolt_workspace_t SET staged=TRUE WHERE to_id=5;
+SELECT dolt_commit('-m','add5');
+" "SELECT CONCAT('R|C|', to_id, '|', to_v, '|', diff_type)
+  FROM dolt_diff_t('HEAD~1','HEAD') ORDER BY to_id;
+SELECT CONCAT('R|IDX|', id, '|', v) FROM t WHERE v=50 ORDER BY id;"
+
+oracle "idx_stage_deleted_one" "$IDX
+DELETE FROM t WHERE id=3;
+UPDATE dolt_workspace_t SET staged=TRUE WHERE from_id=3;
+SELECT dolt_commit('-m','del3');
+" "SELECT CONCAT('R|C|', IFNULL(from_id,''), '|', diff_type)
+  FROM dolt_diff_t('HEAD~1','HEAD') ORDER BY from_id;
+SELECT CONCAT('R|IDX|', id) FROM t WHERE v=30 ORDER BY id;"
+
+oracle "idx_modify_indexed_col_moves_entry" "$IDX
+UPDATE t SET v=999 WHERE id=1;
+UPDATE dolt_workspace_t SET staged=TRUE WHERE to_id=1;
+SELECT dolt_commit('-m','mv1');
+DELETE FROM t WHERE id IN (2,3,4);
+" "SELECT CONCAT('R|NEW|', id, '|', v) FROM t WHERE v=999 ORDER BY id;
+SELECT CONCAT('R|GONE|', id) FROM t WHERE v=10 ORDER BY id;"
+
+oracle "idx_stage_subset_orderby_index" "$IDX
+UPDATE t SET v=v+1000 WHERE id IN (1,3);
+UPDATE dolt_workspace_t SET staged=TRUE WHERE to_id IN (1,3);
+SELECT dolt_commit('-m','subset');
+" "SELECT CONCAT('R|ORD|', id, '|', v) FROM t ORDER BY v, id;"
+
+oracle "idx_stage_then_unstage" "$IDX
+UPDATE t SET v=777 WHERE id=2;
+UPDATE dolt_workspace_t SET staged=TRUE WHERE to_id=2;
+UPDATE dolt_workspace_t SET staged=FALSE WHERE to_id=2;
+" "SELECT CONCAT('R|W|', staged, '|', diff_type, '|', to_id, '|', to_v)
+  FROM dolt_workspace_t ORDER BY to_id;
+SELECT CONCAT('R|IDX|', id, '|', v) FROM t WHERE v=777 ORDER BY id;"
+
+oracle "idx_unique_stage_insert" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, a TEXT, b TEXT);
+CREATE UNIQUE INDEX uab ON t(a,b);
+INSERT INTO t VALUES(1,'p','q'),(2,'r','s');
+SELECT dolt_commit('-A','-m','seed');
+INSERT INTO t VALUES(3,'x','y');
+UPDATE dolt_workspace_t SET staged=TRUE WHERE to_id=3;
+SELECT dolt_commit('-m','add3');
+" "SELECT CONCAT('R|C|', to_id, '|', to_a, '|', to_b)
+  FROM dolt_diff_t('HEAD~1','HEAD') ORDER BY to_id;
+SELECT CONCAT('R|IDX|', id) FROM t WHERE a='x' AND b='y';"
+
+oracle "idx_multicol_stage_modify" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, a TEXT, b TEXT);
+CREATE INDEX iab ON t(a,b);
+INSERT INTO t VALUES(1,'p','q'),(2,'r','s');
+SELECT dolt_commit('-A','-m','seed');
+UPDATE t SET b='Z' WHERE id=1;
+UPDATE dolt_workspace_t SET staged=TRUE WHERE to_id=1;
+SELECT dolt_commit('-m','mod1');
+DELETE FROM t WHERE id=2;
+" "SELECT CONCAT('R|NEW|', id, '|', b) FROM t WHERE a='p' AND b='Z' ORDER BY id;
+SELECT CONCAT('R|GONE|', id) FROM t WHERE a='p' AND b='q' ORDER BY id;"
+
+oracle "idx_ignore_present_stage_indexed" "
+INSERT INTO dolt_ignore VALUES('gen_%', 1);
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+CREATE INDEX iv ON t(v);
+INSERT INTO t VALUES(1,10),(2,20);
+SELECT dolt_commit('-A','-m','seed');
+CREATE TABLE gen_tmp(id INTEGER PRIMARY KEY, x INT);
+INSERT INTO gen_tmp VALUES(1,1);
+UPDATE t SET v=200 WHERE id=1;
+UPDATE dolt_workspace_t SET staged=TRUE WHERE to_id=1;
+SELECT dolt_commit('-m','stage t only');
+" "SELECT CONCAT('R|C|', to_id, '|', to_v) FROM dolt_diff_t('HEAD~1','HEAD') ORDER BY to_id;
+SELECT CONCAT('R|IDX|', id, '|', v) FROM t WHERE v=200 ORDER BY id;"
+
+oracle "idx_ignore_addall_skips_ignored_indexed" "
+INSERT INTO dolt_ignore VALUES('tmp_%', 1);
+CREATE TABLE keep(id INTEGER PRIMARY KEY, v INT);
+CREATE INDEX kv ON keep(v);
+CREATE TABLE tmp_idx(id INTEGER PRIMARY KEY, v INT);
+CREATE INDEX tv ON tmp_idx(v);
+INSERT INTO keep VALUES(1,10),(2,20);
+INSERT INTO tmp_idx VALUES(1,99);
+SELECT dolt_commit('-A','-m','seed');
+" "SELECT CONCAT('R|KEEP|', to_id, '|', to_v) FROM dolt_diff_keep('HEAD~1','HEAD') ORDER BY to_id;
+SELECT CONCAT('R|IDX|', id, '|', v) FROM keep WHERE v=20 ORDER BY id;"
+
+oracle "idx_range_query_after_stage" "$IDX
+UPDATE t SET v=15 WHERE id=1;
+UPDATE t SET v=25 WHERE id=2;
+UPDATE dolt_workspace_t SET staged=TRUE WHERE to_id IN (1,2);
+SELECT dolt_commit('-m','range');
+" "SELECT CONCAT('R|RNG|', id, '|', v) FROM t WHERE v BETWEEN 15 AND 30 ORDER BY v, id;"
+
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then


### PR DESCRIPTION
## Summary
`dolt_workspace` single-row staging (`UPDATE dolt_workspace_<t> SET staged=…`) patched only the table's **data** root in the staged catalog and bailed with *"staging individual workspace rows for indexed tables is not yet supported"* when the table had a secondary index — otherwise the staged index would drift from the staged data.

This maintains the secondary indexes too, reusing the **merge path's** machinery (the "dolt→stock-sqlite layer reversal" that was the hard part already exists).

## Approach
Model the staged row as moving between its **HEAD** value (`pOldVal`, or absent for ADD) and its **WORKING** value (`pNewVal`, or absent for DELETE): staging advances HEAD→WORKING, unstaging reverts WORKING→HEAD. For each non-PK index, drop the **source** value's entry and add the **target** value's entry, rebuilding the native secondary-index key with `doltliteBuildIndexSortKey` (same reconstruction the three-way merge uses, including IPK-ghost handling). The staged catalog is loaded once and the data root plus every index root patched in place, then reserialized as one new catalog. Guard removed.

## Verification
- **Byte-identical to native writes**: `dolt_hashof_table` matches a plain `INSERT`/`UPDATE`/`DELETE`+commit across **ADD / MODIFY / DELETE × plain / UNIQUE / multi-column / NOCASE × IPK / non-IPK**. (NOCASE confirmed identical, so the BINARY-default keyinfo is correct here, matching the merge path.)
- `PRAGMA integrity_check` passes after staging+commit; the index finds the new value and not the stale one.
- ASan-clean on the new path.
- Updated the two `doltlite_workspace.sh` tests that asserted the old rejection to verify the new capability instead (now 5/5).

Closes #1276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)