### PR TITLE
Rename inherited-testfixture job to sqlite-regression; raise timeout to 300s; re-gate securedel2

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -485,8 +485,8 @@ jobs:
           tkt-7bbfb7d442 tkt-4dd95f6943 tkt-2d1a5c67d \
           tkt-f3e5abed55
 
-  inherited-testfixture:
-    name: inherited-testfixture
+  sqlite-regression:
+    name: sqlite-regression
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
@@ -519,10 +519,10 @@ jobs:
     # files (multi-threaded thread*, crash/fault-injection walcrash*/
     # writecrash/wal*fault) are intentionally excluded — same rationale as
     # the crash.test exclusion above; they flake run-to-run.
-    - name: SQLite inherited tests
+    - name: SQLite regression tests
       run: |
         cd build
-        bash ../test/run_testfixture.sh "Inherited tests" 90 \
+        bash ../test/run_testfixture.sh "SQLite regression" 300 \
           8_3_names aggerror aggfault alterauth alterauth2 alterdropcol alterdropcol2 altertab3 alterlegacy altermalloc3 autoindex1 \
           index5 limit2 notnull \
           alterqf altertab2 altertrig amatch1 analyze3 analyze4 analyze5 analyze6 \
@@ -609,5 +609,5 @@ jobs:
           altermalloc2 closure01 fpconv1 fts3an fts3snippet fuzzer2 indexfault joinD json106 \
           mallocA mmap4 percentile savepoint4 sort3 sort4 sortfault speed1p speed2 speed4 \
           stmt tempfault vacuummem wherefault \
-          dbpage pagesize securedel reservebytes shrink format4 stat \
+          dbpage pagesize securedel securedel2 reservebytes shrink format4 stat \
           io sync sync2 multiplex4

--- a/test/known_testfixture_crashes.txt
+++ b/test/known_testfixture_crashes.txt
@@ -78,11 +78,3 @@ memdb1        # sqlite3_serialize/deserialize page-image API unsupported on prol
 createtab     # PRAGMA auto_vacuum errors (intentional) -> failed prepare -> stale stmt var -> UAF
 incrcorrupt   # PRAGMA auto_vacuum/incremental_vacuum errors (intentional) -> stale stmt var -> UAF
 
-# securedel2 exercises secure_delete over large data with repeated freed-space
-# byte scans. It completes (4 known divergences) in a plain build, but under the
-# CI DOLTLITE_PROLLY_CHECK build every prolly mutation is validated, so it runs
-# past the per-file timeout and never prints a summary line. secure_delete is an
-# intentional no-op on the chunk store anyway (no page freelist to zero; GC
-# reclaims old chunks), so its divergences carry no real-bug risk. Documented as
-# a timeout rather than gated.
-securedel2    # times out under DOLTLITE_PROLLY_CHECK (secure_delete byte-scan over large data); secure_delete is an intentional no-op

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1556,6 +1556,14 @@ securedel securedel-1.7  # secure_delete pragma no-op: no page freelist to zero
 securedel securedel-1.8  # secure_delete pragma no-op: no page freelist to zero
 securedel securedel-2.1  # secure_delete pragma no-op: no page freelist to zero
 
+# securedel2 — freed space is not zeroed in place (content-addressed store; GC
+# reclaims old chunks), so the freed-byte scans find old data. Not applicable to
+# the chunk store.
+securedel2 securedel2-1.4.1  # freed space not zeroed in place (content-addressed; GC reclaims)
+securedel2 securedel2-1.4.3  # freed space not zeroed in place (content-addressed; GC reclaims)
+securedel2 securedel2-1.5.2  # freed space not zeroed in place (content-addressed; GC reclaims)
+securedel2 securedel2-1.6.2  # freed space not zeroed in place (content-addressed; GC reclaims)
+
 # reclaims old chunks), so the freed-byte scans find old data. Not applicable to
 # the chunk store.
 


### PR DESCRIPTION
## Summary
- **Rename** the `inherited-testfixture` job (+ its step/label) to **`sqlite-regression`** — a clearer name for the full SQLite regression suite run against doltlite.
- **Raise the per-file timeout** in `run_testfixture.sh` from **90s → 300s**. Under the `DOLTLITE_PROLLY_CHECK` build, validation-heavy files can exceed 90s on a loaded runner and get misreported as crashes ("did not produce summary line"). It's a per-file cap, so fast files are unaffected.
- **Re-gate `securedel2`**: it completes in ~67s locally but timed out at ~90s in CI, so it had been crash-listed. With 300s it gates normally — restored its 4 recorded divergences and removed it from `known_testfixture_crashes.txt`.

## ⚠️ Action needed: branch protection
The job name changed `inherited-testfixture` → `sqlite-regression`. If `inherited-testfixture` is a **required status check** in branch protection, it must be updated to `sqlite-regression`, otherwise the old check will sit "expected" forever and the new one won't be required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)