### PR TITLE
Gate 4 clean files: e_select2 tkt-5ee23731f tkt2820 tkt3424 (#1208)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -288,6 +288,7 @@ jobs:
           tkt-ba7cbfaedc tkt-bd484a090c tkt-bdc6bbbb38 tkt-c48d99d690 tkt-cbd054fa6b tkt-d11f09d36e tkt-d635236375 tkt-d82e3f3721 \
           tkt-f3e5abed55 tkt-f67b41381a tkt-f777251dc7a tkt-f7b4edec tkt-f973c7ac31 tkt-fa7bf5ec tkt-fc7bd6358f tkt1435 \
           tkt1443 tkt1444 tkt1449 tkt1473 tkt1501 tkt1514 tkt1536 tkt1537 \
+          e_select2 tkt-5ee23731f tkt2820 tkt3424 \
           tkt1644 tkt1873 tkt2141 tkt2192 tkt2213 tkt2251 tkt2285 tkt2339 \
           tkt2391 tkt2450 tkt2640 tkt2643 tkt2767 tkt2817 tkt2822 tkt2832 \
           tkt2927 tkt2942 tkt3093 tkt3201 tkt3292 tkt3298 tkt3334 tkt3346 \


### PR DESCRIPTION
Four files that pass with zero divergences, each verified stable across 3 consecutive runs (no flake):
- `e_select2` 0/206
- `tkt-5ee23731f` 0/2
- `tkt2820` 0/17
- `tkt3424` 0/5

No divergence entries needed. Part of #1208.

(Caught during a ground-truth sweep whose unattended 120s-under-load readings were unreliable for slow files — these four were re-verified individually.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)