### PR TITLE
Gate exprfault2 (clean, 0/27979) — #1208

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -242,7 +242,7 @@ jobs:
           cursorhint cursorhint2 dataversion1 date2 date3 date4 date5 dbdata \
           cffault decimal default descidx3 delete3 delete4 e_blobbytes e_droptrigger e_dropview e_resolve emptytable \
           eqp eqp2 errmsg errofst1 eval exec exists existsexpr existsexpr2 \
-          expr2 exprfault expridx1 filectrl filter1 filter2 filterfault fkey3 \
+          expr2 exprfault exprfault2 expridx1 filectrl filter1 filter2 filterfault fkey3 \
           fkey4 fkey6 fkey7 fkey8 fkey_malloc fordelete fts-9fd058691 fts3aa fts3ab fts3ac \
           fts3ad fts3ae fts3af fts3ag fts3ah fts3aj fts3ak fts3al \
           fts3am fts3atoken fts3atoken2 fts3auto fts3aux1 fts3aux2 fts3b fts3c \


### PR DESCRIPTION
`exprfault2` passes all 27979 expression fault-injection assertions with no divergences (authoritative check: no `!Failures` line; fault injection is deterministic so it's stable).

Follow-up to #1282, which merged before this file got added to the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)