### PR TITLE
Triage tkt-* cluster: gate 11 intentional, crash-list 6 cascades (#1208)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -289,6 +289,7 @@ jobs:
           tkt-f3e5abed55 tkt-f67b41381a tkt-f777251dc7a tkt-f7b4edec tkt-f973c7ac31 tkt-fa7bf5ec tkt-fc7bd6358f tkt1435 \
           tkt1443 tkt1444 tkt1449 tkt1473 tkt1501 tkt1514 tkt1536 tkt1537 \
           e_select2 tkt-5ee23731f tkt2820 tkt3424 \
+          tkt1512 tkt1567 tkt2332 tkt2409 tkt2854 tkt2920 tkt3457 tkt3761 tkt3762 tkt3810 tkt4018 \
           tkt1644 tkt1873 tkt2141 tkt2192 tkt2213 tkt2251 tkt2285 tkt2339 \
           tkt2391 tkt2450 tkt2640 tkt2643 tkt2767 tkt2817 tkt2822 tkt2832 \
           tkt2927 tkt2942 tkt3093 tkt3201 tkt3292 tkt3298 tkt3334 tkt3346 \

--- a/test/known_testfixture_crashes.txt
+++ b/test/known_testfixture_crashes.txt
@@ -78,3 +78,15 @@ memdb1        # sqlite3_serialize/deserialize page-image API unsupported on prol
 createtab     # PRAGMA auto_vacuum errors (intentional) -> failed prepare -> stale stmt var -> UAF
 incrcorrupt   # PRAGMA auto_vacuum/incremental_vacuum errors (intentional) -> stale stmt var -> UAF
 
+# These tkt-* files set PRAGMA auto_vacuum or journal_mode in their setup, which
+# DoltLite intentionally rejects ("not supported on doltlite-format databases").
+# That aborts the setup before the schema is created, so every later subtest
+# fails with "no such table ..." -- a cascade of one intentional feature-gap, not
+# hundreds of independent divergences. Documented here rather than recording the
+# whole cascade in the divergence list.
+tkt1667        # auto_vacuum unsupported -> setup aborts -> cascade
+tkt-9d68c883   # auto_vacuum unsupported -> setup aborts -> cascade
+tkt-5e10420e8d # auto_vacuum unsupported -> setup aborts -> cascade
+tkt2565        # auto_vacuum unsupported -> setup aborts (pre-summary)
+tkt-5d863f876e # journal_mode unsupported -> setup aborts -> cascade
+tkt-fc62af4523 # journal_mode unsupported -> setup aborts -> cascade

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1659,3 +1659,66 @@ multiplex4 multiplex4-1.0  # multiplex VFS not used by doltlite
 multiplex4 multiplex4-1.2  # multiplex VFS not used by doltlite
 multiplex4 multiplex4-1.10  # multiplex VFS not used by doltlite
 multiplex4 multiplex4-1.11  # multiplex VFS not used by doltlite
+
+# tkt1567 — explicit rowid reference on a non-integer-PK (WITHOUT ROWID) table.
+tkt1567 tkt1567-1.3  # explicit rowid on a WITHOUT-ROWID table (#1176)
+tkt1567 tkt1567-1.4  # explicit rowid on a WITHOUT-ROWID table (#1176)
+
+# tkt1512 / tkt2920 — read page_size from the SQLite file header and simulate a
+# full disk; the chunk store is not a SQLite file and has no page-based size or
+# disk-full path. Raw page-format divergence.
+tkt1512 tkt1512-1.2  # raw page_size from SQLite file header
+tkt1512 tkt1512-1.3  # raw page_size from SQLite file header
+tkt1512 tkt1512-1.4  # raw page_size from SQLite file header
+tkt2920 tkt2920-1.1  # page_size / disk-full simulation; chunk store has neither
+tkt2920 tkt2920-1.3  # page_size / disk-full simulation; chunk store has neither
+tkt2920 tkt2920-1.5  # page_size / disk-full simulation; chunk store has neither
+tkt2920 tkt2920-1.9  # page_size / disk-full simulation; chunk store has neither
+
+# tkt2409 / tkt2854 / tkt4018 — depend on the SQLite SHARED/RESERVED locking and
+# rollback-journal model (table/schema locked, cross-process lock visibility).
+# DoltLite uses chunk-store locking, so the lock errors and cross-process states
+# differ. Locking-model divergence.
+tkt2409 tkt2409-2.2  # locking-model divergence
+tkt2409 tkt2409-2.3  # locking-model divergence
+tkt2854 tkt2854-1.3  # locking-model divergence
+tkt2854 tkt2854-1.7  # locking-model divergence
+tkt2854 tkt2854-1.8  # locking-model divergence
+tkt2854 tkt2854-1.9  # locking-model divergence
+tkt2854 tkt2854-1.10  # locking-model divergence
+tkt2854 tkt2854-1.11  # locking-model divergence
+tkt2854 tkt2854-1.12  # locking-model divergence
+tkt2854 tkt2854-1.13  # locking-model divergence
+tkt2854 tkt2854-1.14  # locking-model divergence
+tkt2854 tkt2854-1.16  # locking-model divergence
+tkt2854 tkt2854-1.20  # locking-model divergence
+tkt4018 tkt4018-1.3  # locking-model divergence (shared-lock / cross-process visibility)
+tkt4018 tkt4018-2.2  # locking-model divergence (shared-lock / cross-process visibility)
+
+# tkt3457 — backs up via the rollback journal file (test.db-journal); DoltLite has
+# no rollback journal. No -journal file to copy.
+tkt3457 tkt3457-1.1  # no rollback-journal file to back up
+tkt3457 tkt3457-1.2  # no rollback-journal file to back up
+tkt3457 tkt3457-1.3  # no rollback-journal file to back up
+tkt3457 tkt3457-1.4  # no rollback-journal file to back up
+tkt3457 tkt3457-1.5  # no rollback-journal file to back up
+
+# tkt2332 — unordered SELECT returns PK-order rows instead of rowid/insertion order;
+# the multiset is identical (random-data ordering test). rowid-order divergence.
+tkt2332 tkt2332-10000.3  # PK-order vs insertion order (multiset equal)
+tkt2332 tkt2332-10000.5  # PK-order vs insertion order (multiset equal)
+tkt2332 tkt2332-100000.3  # PK-order vs insertion order (multiset equal)
+tkt2332 tkt2332-100000.5  # PK-order vs insertion order (multiset equal)
+tkt2332 tkt2332-1000000.3  # PK-order vs insertion order (multiset equal)
+tkt2332 tkt2332-1000000.5  # PK-order vs insertion order (multiset equal)
+
+# tkt3810 — a TEMP TRIGGER whose base table is dropped becomes an orphan in stock
+# (still listed in temp.sqlite_master). DoltLite cascades the trigger drop with
+# the table, so the orphan is gone. Schema-catalog cascade divergence.
+tkt3810 tkt3810-3  # orphan temp-trigger dropped with its table (catalog cascade)
+tkt3810 tkt3810-4  # orphan temp-trigger dropped with its table (catalog cascade)
+
+# tkt3761 / tkt3762 — single PRAGMA auto_vacuum assertion; auto_vacuum is
+# intentionally unsupported on doltlite-format databases.
+tkt3761 tkt3761-1.1  # auto_vacuum unsupported
+tkt3762 tkt3762-1.1  # auto_vacuum unsupported

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1705,12 +1705,12 @@ tkt3457 tkt3457-1.5  # no rollback-journal file to back up
 
 # tkt2332 — unordered SELECT returns PK-order rows instead of rowid/insertion order;
 # the multiset is identical (random-data ordering test). rowid-order divergence.
-tkt2332 tkt2332-10000.3  # PK-order vs insertion order (multiset equal)
-tkt2332 tkt2332-10000.5  # PK-order vs insertion order (multiset equal)
-tkt2332 tkt2332-100000.3  # PK-order vs insertion order (multiset equal)
-tkt2332 tkt2332-100000.5  # PK-order vs insertion order (multiset equal)
-tkt2332 tkt2332-1000000.3  # PK-order vs insertion order (multiset equal)
-tkt2332 tkt2332-1000000.5  # PK-order vs insertion order (multiset equal)
+tkt2332 tkt2332.10000.3  # PK-order vs insertion order (multiset equal)
+tkt2332 tkt2332.10000.5  # PK-order vs insertion order (multiset equal)
+tkt2332 tkt2332.100000.3  # PK-order vs insertion order (multiset equal)
+tkt2332 tkt2332.100000.5  # PK-order vs insertion order (multiset equal)
+tkt2332 tkt2332.1000000.3  # PK-order vs insertion order (multiset equal)
+tkt2332 tkt2332.1000000.5  # PK-order vs insertion order (multiset equal)
 
 # tkt3810 — a TEMP TRIGGER whose base table is dropped becomes an orphan in stock
 # (still listed in temp.sqlite_master). DoltLite cascades the trigger drop with


### PR DESCRIPTION
## Summary
Per-subtest triage of the diverging `tkt-*` files (reproduced vs stock).

**Gated + recorded (intentional, 11 files):**
| File(s) | Class |
|---|---|
| tkt1567 | explicit rowid on a WITHOUT-ROWID table (#1176) |
| tkt1512, tkt2920 | raw `page_size` from file header / disk-full simulation |
| tkt2409, tkt2854, tkt4018 | SHARED/RESERVED locking + cross-process model |
| tkt3457 | no rollback-journal file to back up |
| tkt2332 | PK-order vs insertion order (multiset equal) |
| tkt3810 | orphan TEMP TRIGGER dropped with its table (catalog cascade) |
| tkt3761, tkt3762 | single `auto_vacuum` unsupported assertion |

**Crash-listed (auto_vacuum/journal_mode aborts setup → whole-file cascade):** tkt1667, tkt-9d68c883, tkt-5e10420e8d, tkt2565, tkt-5d863f876e, tkt-fc62af4523.

**Split out, not gated:**
- **#1285** — real bug: `tkt3718` nested statement transaction wrongly rolls back the parent INSERT (lost rows).
- **#1286** — candidates needing more triage: `tkt3080`/`tkt-b72787b1`/`tkt-c694113d5` (query-aborted under nested UDF SQL, maybe same root as #1285), `tkt3121`/`tkt3871` (echo vtab), `tkt-3a77c9714e` (NOT NULL).

No code change. Part of #1208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)