### PR TITLE
Fix nested statement transaction wrongly rolling back the parent (#1285)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -293,7 +293,7 @@ jobs:
           tkt2391 tkt2450 tkt2640 tkt2643 tkt2767 tkt2817 tkt2822 tkt2832 \
           tkt2927 tkt2942 tkt3093 tkt3201 tkt3292 tkt3298 tkt3334 tkt3346 \
           tkt3357 tkt3419 tkt3442 tkt3461 tkt3493 tkt3508 tkt3522 tkt3527 \
-          tkt3541 tkt3554 tkt3581 tkt35xx tkt3630 tkt3731 tkt3757 tkt3773 \
+          tkt3541 tkt3554 tkt3581 tkt35xx tkt3630 tkt3718 tkt3731 tkt3757 tkt3773 \
           tkt3791 tkt3793 tkt3824 tkt3832 tkt3838 tkt3841 tkt3879 tkt3911 \
           tkt3922 tkt3929 tkt3935 tkt3992 tkt3997 tokenize tpch01 trace2 \
           trace3 trans3 transitive1 trigger3 trigger4 trigger5 trigger6 trigger8 \

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -5526,8 +5526,21 @@ static int rollbackAllSavepoints(Btree *p, BtShared *pBt){
 
 static int rollbackNamedSavepoint(Btree *p, BtShared *pBt, int iSavepoint){
   struct SavepointTableState *pState = &p->aSavepointTables[iSavepoint];
+  BtCursor *pC;
   int j;
-  int rc = rollbackMutMapsToSavepoint(p, iSavepoint + 1, iSavepoint);
+  int rc;
+
+  /* Save every cursor's position before unwinding the savepoint, mirroring
+  ** stock sqlite3BtreeSavepoint's saveAllCursors() call. A statement-savepoint
+  ** rollback (a nested statement that failed) must leave the *parent*
+  ** statement's cursors usable so the outer statement can continue. Hard-
+  ** faulting all cursors here aborts the parent and discards rows it already
+  ** inserted (tkt3718). Saved cursors become CURSOR_REQUIRESEEK and re-seek the
+  ** restored tree on next access. */
+  rc = saveAllCursors(p, pBt, 0, 0);
+  if( rc!=SQLITE_OK ) return rc;
+
+  rc = rollbackMutMapsToSavepoint(p, iSavepoint + 1, iSavepoint);
   if( rc!=SQLITE_OK ) return rc;
   if( pState->aTables ){
     rc = restoreTablesFromSavepoint(p, pState);
@@ -5539,7 +5552,19 @@ static int rollbackNamedSavepoint(Btree *p, BtShared *pBt, int iSavepoint){
     freeSavepointTables(&p->aSavepointTables[j]);
   }
   p->nSavepoint = iSavepoint;
-  invalidateCursors(pBt, 0, SQLITE_ABORT);
+
+  /* The rollback may have freed or replaced pending-edit maps; detach every
+  ** cursor's now-stale map alias. Saved cursors re-seek; a cursor that could
+  ** not be saved (already invalid/faulted) is left as-is. */
+  for(pC=pBt->pCursor; pC; pC=pC->pNext){
+    if( pC->pBtree!=p ) continue;
+    pC->pMutMap = 0;
+    pC->mmActive = 0;
+    pC->mmPhysActive = 0;
+    pC->deferredTreeSeek = 0;
+    pC->mmIdx = -1;
+    pC->mmPhysIdx = -1;
+  }
   invalidateSchema(p);
   return SQLITE_OK;
 }


### PR DESCRIPTION
## Problem

When a UDF runs nested SQL inside a parent `INSERT` (the tkt3718 pattern — `INSERT INTO t2 SELECT a+5, sql(a==3, 'INSERT INTO t2 ...') FROM t1`), the nested statement opens its own statement transaction. Rolling that nested statement back — because it failed, or as the inner level of committed nesting — wrongly rolled back the **parent** statement too, silently dropping rows the parent had already inserted.

## Root cause

`rollbackNamedSavepoint` (the statement-savepoint ROLLBACK path) ended with `invalidateCursors(pBt, 0, SQLITE_ABORT)`, which hard-faults **every** cursor on the btree — including the parent statement's still-live write cursor. When the parent resumed, its faulted cursor returned `SQLITE_ABORT`, the parent halted, and its own statement transaction rolled back.

An env-gated trace of `tkt3718-2.2` showed it precisely: after the nested rollback correctly kept the parent's level-1 rows, a second `ROLLBACK iSp=0` (the parent's own statement halt, triggered by the faulted cursor) wiped rows 6,7,8 → `query aborted`.

Stock `sqlite3BtreeSavepoint` calls `saveAllCursors()` *before* a savepoint rollback so the outer statement's cursors survive as re-seekable and are never hard-faulted.

## Fix

In `rollbackNamedSavepoint`: save all cursors (→ `CURSOR_REQUIRESEEK`) before unwinding the savepoint, then detach their now-stale pending-map aliases (the rollback may have freed/replaced those maps) instead of faulting them. Saved cursors re-seek the restored tree on next access and the outer statement continues — matching stock SQLite.

## Verification

- **tkt3718: 7 → 0** failures (all 41 subtests pass) — fail-before/pass-after proven on a CI-faithful `DOLTLITE_PROLLY_CHECK=1` build
- **No regressions** vs master: savepoint 48, trans 19, trans2 29, trigger1 4, fkey2 7, conflict 0 — all unchanged; **savepoint7 improved 2 → 1**
- **ASan clean** (0 hits) across tkt3718 + savepoint families — no use-after-free from the saved cursors
- tkt3718 added to the `sqlite-regression` gate

Closes #1285.

🤖 Generated with [Claude Code](https://claude.com/claude-code)