### PR TITLE
Gate where4/whereD/whereG/whereL; file where7 count bug #1293 (#1208)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -310,7 +310,7 @@ jobs:
           whereN window4 window5 window7 window8 window9 windowA windowB \
           windowD windowerr windowfault windowpushd with1 with2 with3 with4 with5 \
           with6 withM without_rowid2 without_rowid3 without_rowid4 without_rowid5 without_rowid6 \
-          update2 whereF window6 zeroblobfault zipfile \
+          update2 where4 whereD whereF whereG whereL window6 zeroblobfault zipfile \
           zipfile2 zipfilefault \
           altermalloc2 closure01 fpconv1 fts3an fts3snippet fuzzer2 indexfault joinD json106 \
           mallocA mmap4 percentile savepoint4 sort3 sort4 sortfault speed1p speed2 speed4 \

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1722,3 +1722,32 @@ tkt3810 tkt3810-4  # orphan temp-trigger dropped with its table (catalog cascade
 # intentionally unsupported on doltlite-format databases.
 tkt3761 tkt3761-1.1  # auto_vacuum unsupported
 tkt3762 tkt3762-1.1  # auto_vacuum unsupported
+
+# where4 / whereD / whereG / whereL — query-planner and storage-model
+# divergences; in every case the result rows are correct, only a plan metric,
+# plan shape, or rowid availability differs:
+#   * where4-5.2/5.3: `SELECT rowid FROM t4` where t4 has a composite PRIMARY
+#     KEY. DoltLite stores composite/non-integer-PK tables WITHOUT ROWID
+#     (#1176), so `rowid` is not a column -> "no such column: rowid" (same
+#     class as without_rowid1-7.x).
+#   * whereD-3.4.*: assert sqlite_search_count (internal btree-step metric).
+#     The query results match; only the step count differs under prolly.
+#   * whereG-3.*: EXPLAIN QUERY PLAN shape. DoltLite's planner satisfies the
+#     `b.b1=?` lookup via the PRIMARY KEY rather than secondary index b_1 — a
+#     valid equivalent plan; the query returns the same rows.
+#   * whereL-110/120/121/122: EXPLAIN QUERY PLAN shape (constant-propagation
+#     join order); plan text differs, results are equivalent.
+where4 where4-5.2   # SELECT rowid on composite-PK (WITHOUT ROWID) table: no such column rowid
+where4 where4-5.3   # SELECT rowid on composite-PK (WITHOUT ROWID) table: no such column rowid
+whereD whereD-3.4.1  # sqlite_search_count plan metric; rows match
+whereD whereD-3.4.2  # sqlite_search_count plan metric; rows match
+whereD whereD-3.4.3  # sqlite_search_count plan metric; rows match
+whereD whereD-3.4.4  # sqlite_search_count plan metric; rows match
+whereG whereG-3.1    # EQP: PRIMARY KEY lookup vs secondary index b_1 (equivalent plan)
+whereG whereG-3.2    # EQP: PRIMARY KEY lookup vs secondary index b_1 (equivalent plan)
+whereG whereG-3.3    # EQP: PRIMARY KEY lookup vs secondary index b_1 (equivalent plan)
+whereG whereG-3.4    # EQP: PRIMARY KEY lookup vs secondary index b_1 (equivalent plan)
+whereL whereL-110    # EQP plan shape; results equivalent
+whereL whereL-120    # EQP plan shape; results equivalent
+whereL whereL-121    # EQP plan shape; results equivalent
+whereL whereL-122    # EQP plan shape; results equivalent


### PR DESCRIPTION
Continues the #1208 triage with the `where*` family. Gates four files whose failures are all intentional query-planner / storage-model divergences — results always correct, each assertion individually reproduced:

- **where4** (2) — `where4-5.2/5.3` do `SELECT rowid FROM t4` where `t4` has a composite PRIMARY KEY; doltlite stores composite-PK tables WITHOUT ROWID (#1176), so `rowid` isn't a column → `no such column: rowid`.
- **whereD** (4) — `whereD-3.4.*` assert `sqlite_search_count` (internal btree-step metric); rows match.
- **whereG** (4) — `whereG-3.*` EXPLAIN QUERY PLAN: doltlite satisfies the `b.b1=?` lookup via PRIMARY KEY instead of secondary index `b_1` (equivalent plan, same rows).
- **whereL** (4) — `whereL-110/120/121/122` EQP plan shape (constant-propagation join order).

Harness: `OK` for all four, no unused entries.

### `where7` deliberately NOT gated — real bug filed as #1293

`where7-1.1.1` (the only failure in 2027 tests) is a genuine wrong-result divergence: with `PRAGMA count_changes=ON`, an index-driven OR-by-union `DELETE` over-counts when a row matches multiple OR terms (`a<2 OR a<3` reports 3 vs 2; `a<2 OR a<3 OR a<4` reports 6 vs 3 = once per term-visit). Rows are deleted correctly and `changes()`/`total_changes()` are right — only the legacy `count_changes` value is wrong. Per the triage rule, a real bug gets fixed, not gated, so `where7` stays ungated pending #1293.

🤖 Generated with [Claude Code](https://claude.com/claude-code)