### PR TITLE
Add Intel Mac (osx-x64) release build (#1290)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,6 +141,14 @@ jobs:
             ext: ""
             lib_ext: ".dylib"
             static_ext: ".a"
+          # macos-13 is the last Intel (x86_64) GitHub-hosted runner;
+          # macos-14+/macos-latest are Apple Silicon (arm64). Build the Intel
+          # Mac artifact here so x86_64 macOS users get a prebuilt binary.
+          - os: macos-13
+            target: osx-x64
+            ext: ""
+            lib_ext: ".dylib"
+            static_ext: ".a"
           - os: windows-latest
             target: win-x64
             ext: ".exe"

--- a/install.sh
+++ b/install.sh
@@ -29,11 +29,11 @@ esac
 
 TARGET="${PLATFORM}-${PKG_ARCH}"
 
-# The release matrix currently builds linux-x64, osx-arm64, and win-x64.
-# Other combinations don't have release artifacts; fall back to building
-# from source.
+# The release matrix builds linux-x64, linux-arm64, osx-arm64, osx-x64, and
+# win-x64. Other combinations don't have release artifacts; fall back to
+# building from source.
 case "$TARGET" in
-  linux-x64|linux-arm64|osx-arm64) ;;
+  linux-x64|linux-arm64|osx-arm64|osx-x64) ;;
   *)
     echo "doltlite: no prebuilt binary for ${TARGET}." >&2
     echo "Build from source — see https://github.com/dolthub/doltlite#building" >&2


### PR DESCRIPTION
Closes #1290 — Intel Mac build was absent from releases.

The release `build` matrix shipped `osx-arm64` but no Intel artifact, because GitHub's `macos-latest`/`macos-14+` runners are Apple Silicon. This adds a matrix entry on **`macos-13`** (the last Intel x86_64 GitHub-hosted runner), producing `doltlite-tools-osx-x64-*.zip` and `doltlite-lib-osx-x64-*.zip`.

- All existing macOS steps (brew zlib, configure+make, ad-hoc codesign, package tools/libs) key off `runner.os == 'macOS'`, so they apply unchanged — only the architecture differs.
- `install.sh` already computes `TARGET=osx-x64` from `uname`, but its allowlist rejected it; added `osx-x64` so Intel Macs download the prebuilt binary instead of falling back to a source build.

Validation: triggering a `workflow_dispatch` run of the release workflow on this branch, which builds every platform artifact (including the new `osx-x64`) but skips release creation (`release` job is gated `if: github.event_name != 'workflow_dispatch'`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)