### PR TITLE
Cross-compile Intel Mac (osx-x64) on Apple Silicon runner (#1290)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,11 +141,17 @@ jobs:
             ext: ""
             lib_ext: ".dylib"
             static_ext: ".a"
-          # macos-13 is the last Intel (x86_64) GitHub-hosted runner;
-          # macos-14+/macos-latest are Apple Silicon (arm64). Build the Intel
-          # Mac artifact here so x86_64 macOS users get a prebuilt binary.
-          - os: macos-13
+          # Intel Mac (x86_64) artifact, cross-compiled on the Apple Silicon
+          # runner via `-arch x86_64`. We don't use a macos-13 Intel runner:
+          # those are scarce and queue unreliably, and a stuck osx-x64 leg
+          # blocks the whole release (the release job needs the full matrix).
+          # The build cleanly separates host tools (lemon/mkkeywordhash/jimsh,
+          # built with bare $(B.cc), stay native arm64 and runnable) from the
+          # target objects/link (take -arch x86_64 via CFLAGS/LDFLAGS), and the
+          # SDK's libz is universal so `-lz` resolves the x86_64 slice.
+          - os: macos-latest
             target: osx-x64
+            cross_arch: "-arch x86_64"
             ext: ""
             lib_ext: ".dylib"
             static_ext: ".a"
@@ -170,10 +176,26 @@ jobs:
 
     - name: Configure and build (Unix)
       if: runner.os != 'Windows'
+      env:
+        # Empty for native targets; "-arch x86_64" for the cross-compiled
+        # Intel Mac build (see the osx-x64 matrix entry).
+        CROSS_ARCH: ${{ matrix.cross_arch }}
       run: |
         mkdir -p build && cd build
         ../configure
-        make -j$(nproc 2>/dev/null || sysctl -n hw.ncpu) doltlite doltlite-remotesrv doltlite-lib
+        if [ -n "$CROSS_ARCH" ]; then
+          # Cross-compile the *target* compiler with the arch flag while pinning
+          # B.cc (build-host tools: lemon, mkkeywordhash, jimsh) to the native
+          # cc so they run on this arm64 runner. Overriding CC rather than
+          # CFLAGS preserves configure's -O2/-dynamic/-DNDEBUG flags, and the
+          # link inherits the arch via $(CC). The macOS SDK's libz is universal
+          # so -lz resolves the x86_64 slice.
+          make -j$(sysctl -n hw.ncpu) \
+            CC="cc $CROSS_ARCH" B.cc="cc" \
+            doltlite doltlite-remotesrv doltlite-lib
+        else
+          make -j$(nproc 2>/dev/null || sysctl -n hw.ncpu) doltlite doltlite-remotesrv doltlite-lib
+        fi
 
     - name: Build (Windows / MSYS2)
       if: runner.os == 'Windows'

--- a/main.mk
+++ b/main.mk
@@ -559,9 +559,13 @@ LIBOBJS0 = alter.o analyze.o attach.o auth.o \
 # architecture. We probe via $(CC) (not $(B.cc)) because the wasm
 # cross-compile path overrides only CC on the make command line, while
 # B.cc stays bound to the host's cc from the autoconf-generated
-# Makefile.
+# Makefile. Pass $(CFLAGS) into the probe too: an Apple-clang macOS
+# cross-build keeps CC but selects the target arch via `-arch x86_64`
+# in CFLAGS, and `cc -arch x86_64 -dumpmachine` reports the x86_64
+# triple — without the flag the probe would report the host's arm64
+# and wrongly pick blake3_neon.o.
 #
-BLAKE3_TARGET_TRIPLE := $(shell $(CC) -dumpmachine 2>/dev/null)
+BLAKE3_TARGET_TRIPLE := $(shell $(CC) $(CFLAGS) -dumpmachine 2>/dev/null)
 ifneq (,$(findstring wasm,$(BLAKE3_TARGET_TRIPLE))$(findstring emscripten,$(BLAKE3_TARGET_TRIPLE)))
   # emcc/wasm32: SIMD intrinsics need -msimd128, which we don't want
   # to require. Stick to portable; dispatch.c compiles down to direct


### PR DESCRIPTION
Follow-up to #1295. That built `osx-x64` on a `macos-13` Intel runner, but those runners are scarce and queue unreliably — and since the `release` upload job `needs` the full `build` matrix, a stuck `osx-x64` leg **blocks the entire release** (no artifacts publish for *any* platform, as just happened on the v0.11.11 run). Switch to cross-compiling on the `macos-latest` (arm64) runner.

### How

The build separates the build-host compiler (`$(B.cc)` — lemon, mkkeywordhash, jimsh) from the target compiler (`$(CC)`/`$(T.cc)`). For `osx-x64` we override `CC="cc -arch x86_64"` and pin `B.cc="cc"`:
- Host tools build native arm64 → run on the runner to generate sources.
- Target objects + final link are x86_64 (the link inherits `-arch` via `$(CC)`).
- Overriding `CC` (not `CFLAGS`) preserves configure's `-O2 -dynamic -DNDEBUG`.
- The macOS SDK's `libz` is universal, so `-lz` resolves the x86_64 slice.

`main.mk`: the BLAKE3 SIMD selection probed `$(CC) -dumpmachine`, which reports the compiler's *default* arch (arm64) and wrongly selected `blake3_neon.o`. Pass `$(CFLAGS)` into the probe so `-arch x86_64` is honored (`cc -arch x86_64 -dumpmachine` → `x86_64-apple-darwin`) and the x86_64 SSE/AVX objects are chosen. Native builds are unaffected (extra CFLAGS to `-dumpmachine` are ignored).

### Validation

Built locally on an Apple Silicon Mac:
```
make CC="cc -arch x86_64" B.cc="cc" doltlite doltlite-remotesrv doltlite-lib
```
- `doltlite`, `doltlite-remotesrv` → `Mach-O 64-bit executable x86_64`
- `libdoltlite.dylib` → `Mach-O 64-bit dynamically linked shared library x86_64`
- compile line `cc -arch x86_64 -DNDEBUG -dynamic -O2` (optimization preserved)
- the x86_64 binary runs (Rosetta): `SELECT doltlite_engine()` → `prolly`
- BLAKE3 objects: `blake3_sse2/sse41/avx2/avx512` (no `blake3_neon`)

Once merged I'll re-point the `v0.11.11` tag to rebuild the release reliably with the Intel binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)