### PR TITLE
Fix FTS3 malloc schema cleanup

### DIFF
--- a/src/prepare.c
+++ b/src/prepare.c
@@ -416,6 +416,14 @@ int sqlite3InitOne(sqlite3 *db, int iDb, char **pzErrMsg, u32 mFlags){
     pDb = &db->aDb[iDb];
   }else
   if( rc==SQLITE_OK || ((db->flags&SQLITE_NoSchemaError) && rc!=SQLITE_NOMEM)){
+#ifdef DOLTLITE_PROLLY
+    if( pDb->pBt
+     && sqlite3FindTable(db, zSchemaTabName, pDb->zDbSName)==0
+    ){
+      rc = SQLITE_SCHEMA;
+      goto initone_error_out;
+    }
+#endif
     /* Hack: If the SQLITE_NoSchemaError flag is set, then consider
     ** the schema loaded, even if errors (other than OOM) occurred. In
     ** this situation the current sqlite3_prepare() operation will fail,

--- a/src/prepare.c
+++ b/src/prepare.c
@@ -255,6 +255,14 @@ int sqlite3InitOne(sqlite3 *db, int iDb, char **pzErrMsg, u32 mFlags){
   initData.nInitRow = 0;
   initData.mxPage = 0;
   sqlite3InitCallback(&initData, 5, (char **)azArg, 0);
+#ifdef DOLTLITE_PROLLY
+  if( initData.rc==SQLITE_OK
+   && sqlite3FindTable(db, zSchemaTabName, db->aDb[iDb].zDbSName)==0
+  ){
+    sqlite3OomFault(db);
+    initData.rc = SQLITE_NOMEM_BKPT;
+  }
+#endif
   db->mDbFlags &= mask;
   if( initData.rc ){
     rc = initData.rc;

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -292,6 +292,8 @@ struct Btree {
 
   u8 inTransaction;
   u8 bSchemaChangedTxn;
+  u8 bMasterRootChangedTxn;
+  u8 bFilterSchemaPlaceholders;
 
   int nSavepoint;
   int nSavepointAlloc;
@@ -303,6 +305,8 @@ struct Btree {
     u8 bCatalogSnapshot;
     u8 bStatement;
     u8 bTablesCaptured;
+    u8 bSchemaChangedTxn;
+    u8 bMasterRootChangedTxn;
 
     SavepointPendingSnapshot *aPendingSnapshot;
     int nPendingSnapshot;
@@ -573,6 +577,18 @@ static int cursorOnDegenerateSchemaRow(BtCursor *pCur, int *pIsDegenerate){
   rc = getCursorPayload(pCur, &pVal, &nVal);
   if( rc!=SQLITE_OK ) return rc;
   if( !pVal || nVal<=0 ){
+    *pIsDegenerate = 1;
+    return SQLITE_OK;
+  }
+  if( pCur->pBtree->bFilterSchemaPlaceholders
+   && nVal==6
+   && pVal[0]==6
+   && pVal[1]==0
+   && pVal[2]==0
+   && pVal[3]==0
+   && pVal[4]==0
+   && pVal[5]==0
+  ){
     *pIsDegenerate = 1;
   }
   return SQLITE_OK;
@@ -1139,6 +1155,14 @@ static void catFree(Catalog *cat){
 static void invalidateSchema(Btree *pBtree){
   if( pBtree->pSchema && pBtree->xFreeSchema ){
     pBtree->xFreeSchema(pBtree->pSchema);
+  }
+}
+
+static void resetConnectionSchema(Btree *pBtree){
+  invalidateSchema(pBtree);
+  if( pBtree->db ){
+    sqlite3ExpirePreparedStatements(pBtree->db, 0);
+    sqlite3ResetAllSchemasOfConnection(pBtree->db);
   }
 }
 
@@ -2235,8 +2259,11 @@ static int serializeCatalogPatchRoots(Btree *pBtree, u8 **ppOut, int *pnOut){
 
     q += CAT_ENTRY_ITABLE_SIZE + CAT_ENTRY_FLAGS_SIZE;
     /* The persisted sqlite_master root is canonicalized. DML does not change
-    ** it, and the in-memory root may be a runtime view after DDL. */
-    if( iTable!=1 ){
+    ** it, and the in-memory root may be a runtime view after DDL. Virtual-table
+    ** DDL can update sqlite_master without tripping the normal schema-version
+    ** path, so patch the master root only when a page-1 write has survived
+    ** statement rollback in this transaction. */
+    if( iTable!=1 || pBtree->bMasterRootChangedTxn ){
       memcpy(q, pTE->root.data, PROLLY_HASH_SIZE);
     }
     q += PROLLY_HASH_SIZE + PROLLY_HASH_SIZE;
@@ -2432,6 +2459,8 @@ static int deserializeCatalog(Btree *pBtree, const u8 *data, int nData){
   const u8 *q = data;
   int nTables, i;
   int iFormat = 0;
+  Catalog catNew;
+  u32 aMetaNew[16];
 
   {
     const u8 *pEntries;
@@ -2441,8 +2470,10 @@ static int deserializeCatalog(Btree *pBtree, const u8 *data, int nData){
     q = pEntries;
   }
 
-  btreeFreeCatalogTables(pBtree);
-  initDefaultMeta(pBtree);
+  memset(&catNew, 0, sizeof(catNew));
+  memset(aMetaNew, 0, sizeof(aMetaNew));
+  aMetaNew[BTREE_FILE_FORMAT] = 4;
+  aMetaNew[BTREE_TEXT_ENCODING] = SQLITE_UTF8;
 
   {
     ProllyHash h;
@@ -2452,7 +2483,7 @@ static int deserializeCatalog(Btree *pBtree, const u8 *data, int nData){
                | ((u32)h.data[1] << 8)
                | ((u32)h.data[2] << 16)
                | ((u32)h.data[3] << 24);
-    pBtree->aMeta[BTREE_SCHEMA_VERSION] = schemaHash | 1;
+    aMetaNew[BTREE_SCHEMA_VERSION] = schemaHash | 1;
   }
 
   for(i=0; i<nTables; i++){
@@ -2461,13 +2492,17 @@ static int deserializeCatalog(Btree *pBtree, const u8 *data, int nData){
     struct TableEntry *pTE;
     int nLen;
     if( q+4+1+PROLLY_HASH_SIZE+PROLLY_HASH_SIZE > data+nData ){
+      catFree(&catNew);
       return SQLITE_CORRUPT;
     }
     iTable = (Pgno)(q[0] | (q[1]<<8) | (q[2]<<16) | (q[3]<<24));
     q += 4;
     flags = *q++;
-    pTE = addTable(pBtree, iTable, flags);
-    if( !pTE ) return SQLITE_NOMEM;
+    pTE = catAdd(&catNew, iTable, flags);
+    if( !pTE ){
+      catFree(&catNew);
+      return SQLITE_NOMEM;
+    }
     memcpy(pTE->root.data, q, PROLLY_HASH_SIZE);
     q += PROLLY_HASH_SIZE;
     memcpy(pTE->schemaHash.data, q, PROLLY_HASH_SIZE);
@@ -2475,11 +2510,17 @@ static int deserializeCatalog(Btree *pBtree, const u8 *data, int nData){
     if( iFormat==CATALOG_FORMAT_V4 ){
       int nType, nName, nTbl;
       const u8 *pType, *pName, *pTbl;
-      if( q+6 > data+nData ) return SQLITE_CORRUPT;
+      if( q+6 > data+nData ){
+        catFree(&catNew);
+        return SQLITE_CORRUPT;
+      }
       nType = q[0] | (q[1]<<8); q += 2;
       nName = q[0] | (q[1]<<8); q += 2;
       nTbl = q[0] | (q[1]<<8); q += 2;
-      if( q+nType+nName+nTbl > data+nData ) return SQLITE_CORRUPT;
+      if( q+nType+nName+nTbl > data+nData ){
+        catFree(&catNew);
+        return SQLITE_CORRUPT;
+      }
       pType = q; q += nType;
       pName = q; q += nName;
       pTbl = q; q += nTbl;
@@ -2488,20 +2529,30 @@ static int deserializeCatalog(Btree *pBtree, const u8 *data, int nData){
       if( nType==5 && memcmp(pType, "table", 5)==0 && nName>0 ){
         pTE->isTableRoot = 1;
         pTE->zName = sqlite3_malloc(nName+1);
-        if( !pTE->zName ) return SQLITE_NOMEM;
+        if( !pTE->zName ){
+          catFree(&catNew);
+          return SQLITE_NOMEM;
+        }
         memcpy(pTE->zName, pName, nName);
         pTE->zName[nName] = 0;
       }
     }else{
-      if( q+2 > data+nData ) return SQLITE_CORRUPT;
+      if( q+2 > data+nData ){
+        catFree(&catNew);
+        return SQLITE_CORRUPT;
+      }
       nLen = q[0] | (q[1]<<8); q += 2;
-      if( q+nLen > data+nData ) return SQLITE_CORRUPT;
+      if( q+nLen > data+nData ){
+        catFree(&catNew);
+        return SQLITE_CORRUPT;
+      }
       if( nLen>0 ){
         pTE->zName = sqlite3_malloc(nLen+1);
         if( pTE->zName ){
           memcpy(pTE->zName, q, nLen);
           pTE->zName[nLen] = 0;
         }else{
+          catFree(&catNew);
           return SQLITE_NOMEM;
         }
       }
@@ -2509,22 +2560,28 @@ static int deserializeCatalog(Btree *pBtree, const u8 *data, int nData){
     }
   }
 
-  if( q!=data+nData ) return SQLITE_CORRUPT;
+  if( q!=data+nData ){
+    catFree(&catNew);
+    return SQLITE_CORRUPT;
+  }
 
   {
     Pgno maxPage = 0;
     Pgno maxCatalogTable = 0;
-    for(i=0; i<pBtree->cat.n; i++){
-      if( pBtree->cat.a[i].iTable > maxCatalogTable ){
-        maxCatalogTable = pBtree->cat.a[i].iTable;
+    for(i=0; i<catNew.n; i++){
+      if( catNew.a[i].iTable > maxCatalogTable ){
+        maxCatalogTable = catNew.a[i].iTable;
       }
     }
     maxPage = maxCatalogTable;
-    pBtree->aMeta[BTREE_LARGEST_ROOT_PAGE] = maxPage;
+    aMetaNew[BTREE_LARGEST_ROOT_PAGE] = maxPage;
 
-    pBtree->cat.iNextTable = maxCatalogTable + 1;
+    catNew.iNextTable = maxCatalogTable + 1;
   }
 
+  btreeFreeCatalogTables(pBtree);
+  pBtree->cat = catNew;
+  memcpy(pBtree->aMeta, aMetaNew, sizeof(aMetaNew));
   return SQLITE_OK;
 }
 
@@ -3194,6 +3251,8 @@ static void freeSavepointTables(struct SavepointTableState *pState){
   memset(&pState->conflictsCatalogHash, 0, sizeof(pState->conflictsCatalogHash));
   memset(&pState->constraintViolationsHash, 0, sizeof(pState->constraintViolationsHash));
   pState->isRebasing = 0;
+  pState->bSchemaChangedTxn = 0;
+  pState->bMasterRootChangedTxn = 0;
   memset(&pState->preRebaseWorkingCat, 0, sizeof(pState->preRebaseWorkingCat));
   memset(&pState->rebaseOntoCommit, 0, sizeof(pState->rebaseOntoCommit));
 }
@@ -3761,6 +3820,8 @@ static int pushSavepoint(Btree *pBtree, int bStatement){
   pState->nPendingSnapshotAlloc = 0;
   pState->bStatement = (u8)bStatement;
   pState->bTablesCaptured = 0;
+  pState->bSchemaChangedTxn = pBtree->bSchemaChangedTxn;
+  pState->bMasterRootChangedTxn = pBtree->bMasterRootChangedTxn;
   pState->nTables = 0;
   pState->iLargestRootPage = 0;
   pState->isRebasing = 0;
@@ -4169,6 +4230,8 @@ int sqlite3BtreeOpen(
   pBt->nRef = 1;
   p->inTransaction = TRANS_NONE;
   p->bSchemaChangedTxn = 0;
+  p->bMasterRootChangedTxn = 0;
+  p->bFilterSchemaPlaceholders = 0;
 
   if( pBt->store.readOnly ){
     pBt->btsFlags |= BTS_READ_ONLY;
@@ -5271,16 +5334,13 @@ static int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
           struct TableEntry *pMaster = findTable(p, 1);
           if( pMaster ) pMaster->root = runtimeMasterRoot;
         }
-        invalidateSchema(p);
-        if( p->db ){
-          sqlite3ExpirePreparedStatements(p->db, 0);
-          sqlite3ResetAllSchemasOfConnection(p->db);
-        }
+        resetConnectionSchema(p);
       }
       p->inTrans = TRANS_NONE;
       p->inTransaction = TRANS_NONE;
       p->nSavepoint = 0;
       p->bSchemaChangedTxn = 0;
+      p->bMasterRootChangedTxn = 0;
 
       btreeTakeCatalogCache(p, &catData, nCatData, &catHash);
       sqlite3_free(catData);
@@ -5304,12 +5364,13 @@ static int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
         }
       }
       invalidateCursors(pBt, 0, rc);
-      invalidateSchema(p);
+      resetConnectionSchema(p);
       chunkStoreRollback(&pBt->store);
       p->inTrans = TRANS_NONE;
       p->inTransaction = TRANS_NONE;
       p->nSavepoint = 0;
       p->bSchemaChangedTxn = 0;
+      p->bMasterRootChangedTxn = 0;
       chunkStoreUnlock(&pBt->store);
       pBt->store.snapshotPinned = 0;
     }
@@ -5319,6 +5380,7 @@ static int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
   p->inTrans = TRANS_NONE;
   p->inTransaction = TRANS_NONE;
   p->bSchemaChangedTxn = 0;
+  p->bMasterRootChangedTxn = 0;
   p->nSavepoint = 0;
 
   chunkStoreUnlock(&pBt->store);
@@ -5364,6 +5426,15 @@ static int restoreFromCommitted(Btree *p){
   p->mergeCommitHash = p->committedMergeCommitHash;
   p->conflictsCatalogHash = p->committedConflictsCatalogHash;
   p->constraintViolationsHash = p->committedConstraintViolationsHash;
+  p->bFilterSchemaPlaceholders = 1;
+  {
+    ProllyHash runtimeMasterRoot;
+    struct TableEntry *pMaster;
+    int rc = buildRuntimeMasterRoot(p, &runtimeMasterRoot);
+    if( rc!=SQLITE_OK ) return rc;
+    pMaster = findTable(p, 1);
+    if( pMaster ) pMaster->root = runtimeMasterRoot;
+  }
   return SQLITE_OK;
 }
 
@@ -5422,7 +5493,7 @@ static int prollyBtreeRollback(Btree *p, int tripCode, int writeOnly){
       pBt->store.snapshotPinned = 0;
       return rc;
     }
-    invalidateSchema(p);
+    resetConnectionSchema(p);
     chunkStoreRollback(&pBt->store);
     {
       u8 *catData = 0;
@@ -5523,7 +5594,7 @@ static int rollbackCommittedState(Btree *p, BtShared *pBt){
   int rc = restoreFromCommitted(p);
   if( rc!=SQLITE_OK ) return rc;
   invalidateCursors(pBt, 0, SQLITE_ABORT);
-  invalidateSchema(p);
+  resetConnectionSchema(p);
   return SQLITE_OK;
 }
 
@@ -5601,12 +5672,13 @@ static int rollbackNamedSavepoint(Btree *p, BtShared *pBt, int iSavepoint){
     if( rc!=SQLITE_OK ) return rc;
   }
   restoreSavepointSessionState(p, pState);
+  p->bSchemaChangedTxn = pState->bSchemaChangedTxn;
+  p->bMasterRootChangedTxn = pState->bMasterRootChangedTxn;
   freeSavepointTables(pState);
   for(j=iSavepoint+1; j<p->nSavepoint; j++){
     freeSavepointTables(&p->aSavepointTables[j]);
   }
   p->nSavepoint = iSavepoint;
-
   /* The rollback may have freed or replaced pending-edit maps; detach every
   ** cursor's now-stale map alias. Saved cursors re-seek; a cursor that could
   ** not be saved (already invalid/faulted) is left as-is. */
@@ -5804,6 +5876,11 @@ static int prollyBtreeClearTable(Btree *p, int iTable, i64 *pnChange){
     if( pnChange ) *pnChange = 0;
     return SQLITE_OK;
   }
+  if( iTable==1 ){
+    if( pnChange ) *pnChange = 0;
+    p->bMasterRootChangedTxn = 0;
+    return SQLITE_OK;
+  }
 
   /* Save, don't abort, cursors on this table before mutating it: the truncate
   ** optimization (DELETE with no WHERE) can fire while another statement scans
@@ -5913,6 +5990,7 @@ static int prollyBtreeUpdateMeta(Btree *p, int idx, u32 value){
 
   if( idx==BTREE_SCHEMA_VERSION ){
     p->bSchemaChangedTxn = 1;
+    p->bMasterRootChangedTxn = 1;
     p->iBDataVersion++;
     if( pBt->pPagerShim ){
       pBt->pPagerShim->iDataVersion++;
@@ -5924,6 +6002,12 @@ static int prollyBtreeUpdateMeta(Btree *p, int idx, u32 value){
 int sqlite3BtreeUpdateMeta(Btree *p, int idx, u32 value){
   if( !p ) return SQLITE_OK;
   return p->pOps->xUpdateMeta(p, idx, value);
+}
+
+void sqlite3BtreeMarkMasterRootChanged(Btree *p){
+  if( p && p->pOps==&prollyBtreeOps ){
+    p->bMasterRootChangedTxn = 1;
+  }
 }
 
 static void *prollyBtreeSchema(Btree *p, int nBytes, void (*xFree)(void*)){
@@ -8044,6 +8128,9 @@ static int prollyBtCursorInsert(
     if( rc==SQLITE_OK ) pCur->eState = CURSOR_VALID;
   }
 
+  if( rc==SQLITE_OK && pCur->pgnoRoot==1 ){
+    pCur->pBtree->bMasterRootChangedTxn = 1;
+  }
   return rc;
 }
 
@@ -8365,6 +8452,9 @@ static int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
   rc = SQLITE_OK;
 
 delete_cleanup:
+  if( rc==SQLITE_OK && pCur->pgnoRoot==1 && hasSavedKey ){
+    pCur->pBtree->bMasterRootChangedTxn = 0;
+  }
   if( savedDelKeyOwned ) sqlite3_free(pSavedDelKey);
   return rc;
 }

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -2777,7 +2777,7 @@ static int sortKeyFromIntRecordLocal(
   int outPos = 0;
 
   *pnOut = 0;
-  if( nRec<=0 ) return SQLITE_NOTFOUND;
+  if( !pRec || nRec<=0 ) return SQLITE_NOTFOUND;
   hdrOff = prollyGetVarint32(pRec, &hdrSize);
   if( hdrSize > (u32)nRec ) return SQLITE_CORRUPT;
   dataOff = hdrSize;

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -5426,18 +5426,6 @@ static int restoreFromCommitted(Btree *p){
   p->mergeCommitHash = p->committedMergeCommitHash;
   p->conflictsCatalogHash = p->committedConflictsCatalogHash;
   p->constraintViolationsHash = p->committedConstraintViolationsHash;
-  {
-    ProllyHash runtimeMasterRoot;
-    struct TableEntry *pMaster;
-    u8 bOldFilter = p->bFilterSchemaPlaceholders;
-    int rc;
-    p->bFilterSchemaPlaceholders = 1;
-    rc = buildRuntimeMasterRoot(p, &runtimeMasterRoot);
-    p->bFilterSchemaPlaceholders = bOldFilter;
-    if( rc!=SQLITE_OK ) return rc;
-    pMaster = findTable(p, 1);
-    if( pMaster ) pMaster->root = runtimeMasterRoot;
-  }
   return SQLITE_OK;
 }
 

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -5426,11 +5426,14 @@ static int restoreFromCommitted(Btree *p){
   p->mergeCommitHash = p->committedMergeCommitHash;
   p->conflictsCatalogHash = p->committedConflictsCatalogHash;
   p->constraintViolationsHash = p->committedConstraintViolationsHash;
-  p->bFilterSchemaPlaceholders = 1;
   {
     ProllyHash runtimeMasterRoot;
     struct TableEntry *pMaster;
-    int rc = buildRuntimeMasterRoot(p, &runtimeMasterRoot);
+    u8 bOldFilter = p->bFilterSchemaPlaceholders;
+    int rc;
+    p->bFilterSchemaPlaceholders = 1;
+    rc = buildRuntimeMasterRoot(p, &runtimeMasterRoot);
+    p->bFilterSchemaPlaceholders = bOldFilter;
     if( rc!=SQLITE_OK ) return rc;
     pMaster = findTable(p, 1);
     if( pMaster ) pMaster->root = runtimeMasterRoot;
@@ -8453,7 +8456,7 @@ static int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
 
 delete_cleanup:
   if( rc==SQLITE_OK && pCur->pgnoRoot==1 && hasSavedKey ){
-    pCur->pBtree->bMasterRootChangedTxn = 0;
+    pCur->pBtree->bMasterRootChangedTxn = 1;
   }
   if( savedDelKeyOwned ) sqlite3_free(pSavedDelKey);
   return rc;

--- a/src/sortkey.c
+++ b/src/sortkey.c
@@ -274,7 +274,7 @@ static int sortKeyEncode(const u8 *pRec, int nRec, u8 *pOut, int nMaxFields,
   sqlite3_int64 outSize = 0;
   int nField = 0;
 
-  if( nRec <= 0 ) return -1;
+  if( !pRec || nRec <= 0 ) return -1;
 
   hdrOff = skGetVarint32(pRec, &hdrSize);
   if( hdrSize > (u32)nRec ) return -1;
@@ -358,7 +358,7 @@ static int sortKeyFromSingleBinaryFieldFast(
   int nAlloc;
   u8 *pOut;
 
-  if( nKeyField>1 || nRec<=0 ) return SQLITE_NOTFOUND;
+  if( !pRec || nKeyField>1 || nRec<=0 ) return SQLITE_NOTFOUND;
   if( descFromKeyInfo(pKeyInfo, 0) ) return SQLITE_NOTFOUND;
   hdrOff = skGetVarint32(pRec, &hdrSize);
   if( hdrSize > (u32)nRec ) return SQLITE_CORRUPT;
@@ -647,7 +647,7 @@ int sortKeyRecordNeedsPayload(const u8 *pRec, int nRec, int nKeyField){
   u32 hdrOff;
   int nField = 0;
 
-  if( nRec <= 0 ) return 0;
+  if( !pRec || nRec <= 0 ) return 0;
 
   hdrOff = skGetVarint32(pRec, &hdrSize);
   if( hdrSize > (u32)nRec ) return 0;

--- a/src/sqliteInt.h
+++ b/src/sqliteInt.h
@@ -5695,6 +5695,7 @@ int sqlite3ReadOnlyShadowTables(sqlite3 *db);
 int sqlite3VtabEponymousTableInit(Parse*,Module*);
 void sqlite3VtabEponymousTableClear(sqlite3*,Module*);
 void sqlite3VtabMakeWritable(Parse*,Table*);
+void sqlite3BtreeMarkMasterRootChanged(Btree*);
 void sqlite3VtabBeginParse(Parse*, Token*, Token*, Token*, int);
 void sqlite3VtabFinishParse(Parse*, Token*);
 void sqlite3VtabArgInit(Parse*);

--- a/src/sqliteInt.h
+++ b/src/sqliteInt.h
@@ -5695,7 +5695,9 @@ int sqlite3ReadOnlyShadowTables(sqlite3 *db);
 int sqlite3VtabEponymousTableInit(Parse*,Module*);
 void sqlite3VtabEponymousTableClear(sqlite3*,Module*);
 void sqlite3VtabMakeWritable(Parse*,Table*);
+#ifdef DOLTLITE_PROLLY
 void sqlite3BtreeMarkMasterRootChanged(Btree*);
+#endif
 void sqlite3VtabBeginParse(Parse*, Token*, Token*, Token*, int);
 void sqlite3VtabFinishParse(Parse*, Token*);
 void sqlite3VtabArgInit(Parse*);

--- a/src/vtab.c
+++ b/src/vtab.c
@@ -802,6 +802,11 @@ int sqlite3VtabCallCreate(sqlite3 *db, int iDb, const char *zTab, char **pzErr){
 #endif
     }
   }
+#ifdef DOLTLITE_PROLLY
+  else if( rc!=SQLITE_OK ){
+    sqlite3ResetOneSchema(db, iDb);
+  }
+#endif
 
   return rc;
 }

--- a/src/vtab.c
+++ b/src/vtab.c
@@ -804,6 +804,7 @@ int sqlite3VtabCallCreate(sqlite3 *db, int iDb, const char *zTab, char **pzErr){
   }
 #ifdef DOLTLITE_PROLLY
   else if( rc!=SQLITE_OK ){
+    sqlite3BtreeMarkMasterRootChanged(db->aDb[iDb].pBt);
     sqlite3ResetOneSchema(db, iDb);
   }
 #endif

--- a/src/vtab.c
+++ b/src/vtab.c
@@ -797,7 +797,9 @@ int sqlite3VtabCallCreate(sqlite3 *db, int iDb, const char *zTab, char **pzErr){
     rc = growVTrans(db);
     if( rc==SQLITE_OK ){
       addToVTrans(db, sqlite3GetVTable(db, pTab));
+#ifdef DOLTLITE_PROLLY
       sqlite3BtreeMarkMasterRootChanged(db->aDb[iDb].pBt);
+#endif
     }
   }
 
@@ -953,7 +955,9 @@ int sqlite3VtabCallDestroy(sqlite3 *db, int iDb, const char *zTab){
       p->pVtab = 0;
       pTab->u.vtab.p = 0;
       sqlite3VtabUnlock(p);
+#ifdef DOLTLITE_PROLLY
       sqlite3BtreeMarkMasterRootChanged(db->aDb[iDb].pBt);
+#endif
     }
     sqlite3DeleteTable(db, pTab);
   }

--- a/src/vtab.c
+++ b/src/vtab.c
@@ -797,6 +797,7 @@ int sqlite3VtabCallCreate(sqlite3 *db, int iDb, const char *zTab, char **pzErr){
     rc = growVTrans(db);
     if( rc==SQLITE_OK ){
       addToVTrans(db, sqlite3GetVTable(db, pTab));
+      sqlite3BtreeMarkMasterRootChanged(db->aDb[iDb].pBt);
     }
   }
 
@@ -952,6 +953,7 @@ int sqlite3VtabCallDestroy(sqlite3 *db, int iDb, const char *zTab){
       p->pVtab = 0;
       pTab->u.vtab.p = 0;
       sqlite3VtabUnlock(p);
+      sqlite3BtreeMarkMasterRootChanged(db->aDb[iDb].pBt);
     }
     sqlite3DeleteTable(db, pTab);
   }

--- a/test/doltlite_fts3_oom.test
+++ b/test/doltlite_fts3_oom.test
@@ -121,6 +121,27 @@ foreach {tn iFail sql okres} {
 }
 
 do_test doltlite_fts3_oom-3.1 {
+  set bad ok
+  for {set iFail 1} {$iFail<=340 && $bad=="ok"} {incr iFail} {
+    sqlite3_memdebug_fail $iFail -repeat 1
+    set res [catchsql {
+      CREATE VIRTUAL TABLE ft_bad USING fts3(a, b, tokenize unknown)
+    }]
+    sqlite3_memdebug_fail -1
+    set q [catch {db eval {SELECT name FROM sqlite_master ORDER BY name}} rows]
+    set rc [lindex $res 0]
+    set msg [lindex $res 1]
+    if {$q
+     || $rc!=1
+     || ($msg!="out of memory" && $msg!="unknown tokenizer: unknown")
+    } {
+      set bad [list $iFail $res $q $rows]
+    }
+  }
+  set bad
+} {ok}
+
+do_test doltlite_fts3_oom-3.2 {
   forcedelete test2.db
   sqlite3 db2 test2.db
   sqlite3_db_config_lookaside db2 0 0 0

--- a/test/doltlite_fts3_oom.test
+++ b/test/doltlite_fts3_oom.test
@@ -120,5 +120,28 @@ foreach {tn iFail sql okres} {
   } {1}
 }
 
+do_test doltlite_fts3_oom-3.1 {
+  forcedelete test2.db
+  sqlite3 db2 test2.db
+  sqlite3_db_config_lookaside db2 0 0 0
+
+  db2 eval "SELECT * FROM sqlite_master" V break
+  set cksumsql "SELECT md5sum([join [concat rowid $V(*)] ,]) FROM sqlite_master"
+  set cksum1 [db2 one $cksumsql]
+
+  sqlite3_memdebug_fail 74 -repeat 100000
+  set res [catchsql {
+    CREATE VIRTUAL TABLE ft_oom USING fts3(a, b)
+  } db2]
+  set nFail [sqlite3_memdebug_fail -1 -benigncnt nBenign]
+  set q2 [catch {db2 one $cksumsql} cksum2]
+  catch {db2 close}
+  forcedelete test2.db
+
+  list [expr {$res=="1 {out of memory}" && $nFail>0}] \
+       $q2 \
+       [expr {!$q2 && $cksum1 eq $cksum2}]
+} {1 0 1}
+
 sqlite3_memdebug_fail -1
 finish_test

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1192,15 +1192,9 @@ vacuum5 vacuum5-1.3.3  # VACUUM size metric
 vacuum5 vacuum5-1.3.4  # VACUUM size metric
 vacuum5 vacuum5-3.2    # VACUUM size metric
 
-# autoinc — sqlite_master enumeration order, and writable_schema corruption of
-# sqlite_sequence not detected as malformed (prolly catalog isn't the raw
-# sqlite_master row store). AUTOINCREMENT itself works.
+# autoinc — sqlite_master enumeration order differs. AUTOINCREMENT itself
+# works, including writable_schema sqlite_sequence corruption tests.
 autoinc autoinc-1.6   # sqlite_master enumeration order (t1 vs sqlite_sequence)
-autoinc autoinc-12.1  # writable_schema sqlite_sequence corruption undetected
-autoinc autoinc-12.2  # writable_schema corruption undetected
-autoinc autoinc-12.3  # writable_schema corruption undetected
-autoinc autoinc-12.4  # writable_schema corruption undetected
-autoinc autoinc-12.5  # writable_schema corruption undetected
 
 # shared9 — shared-cache locking model differs (doltlite doesn't surface the
 # "database is locked" shared-cache contention these assertions expect). Same

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1150,15 +1150,6 @@ capi3 capi3-11.5   # finalize after COMMIT-during-active-read: SQLITE_ABORT vs S
 capi3 capi3-11.12  # same: SQLITE_ERROR vs SQLITE_ROW
 capi3 capi3-11.13  # finalize of the faulted statement: SQLITE_ERROR vs SQLITE_OK
 
-# default — writable_schema edit to a column DEFAULT is not honored. The test
-# does PRAGMA writable_schema=ON; UPDATE sqlite_master SET sql='...DEFAULT(:xyz)'
-# to rewrite b's default to an (invalid) bind parameter; stock then yields NULL
-# on insert, doltlite keeps the original DEFAULT 99. doltlite's schema is the
-# structural catalog (regenerated), not the raw sqlite_master.sql text, so the
-# injected edit has no effect -- same intentional class as capi3-8.3/8.5. Normal
-# DEFAULT handling (default-1.x/2.x/3.x/4.0/4.2-4.x) is correct.
-default default-4.1  # writable_schema sqlite_master.sql DEFAULT edit not honored (structural catalog)
-
 # fordelete — doltlite doesn't materialize named sqlite_autoindex_* rows for
 # WITHOUT-ROWID/implicit unique indexes, so PRAGMA index_list reports just the
 # table; the FOR-DELETE behavior under test is otherwise correct. (Recovered
@@ -1326,17 +1317,6 @@ jrnlmode jrnlmode-9.2  # journal_mode unsupported on doltlite-format databases
 # file actually exercises (descidx3-2.x..) is correct.
 descidx3 descidx3-1.1  # hexio read of SQLite file-format version byte (chunk store has no such field)
 
-# alterdropcol — alterdropcol-8.2 expects AUTOINCREMENT in the regenerated DDL,
-# but test 8.0 injects AUTOINCREMENT via a raw `PRAGMA writable_schema=1;
-# UPDATE sqlite_schema SET sql='...AUTOINCREMENT...'` edit on a table that was
-# CREATEd without it. DoltLite regenerates DDL from its structural catalog and
-# ignores raw sqlite_schema text edits (same intentional class as #1241 /
-# capi3-8.3/8.5), so the catalog never recorded AUTOINCREMENT and the rewritten
-# DDL omits it. AUTOINCREMENT itself is fully honored: a normally-created
-# AUTOINCREMENT table round-trips the keyword through DROP COLUMN, never reuses
-# a deleted max rowid, and maintains sqlite_sequence. Raw-schema-edit divergence.
-alterdropcol alterdropcol-8.2  # AUTOINCREMENT injected via writable_schema UPDATE; structural catalog ignores raw sqlite_schema edits
-
 # alter3 / alter4 — two raw-format divergence classes, neither involving the
 # ALTER itself (the rewritten columns and data round-trip correctly):
 #   * PRAGMA [aux.]schema_version: DoltLite derives schema_version from the
@@ -1375,44 +1355,16 @@ altertab3 altertab3-31.1  # PRAGMA page_count across DROP COLUMN; chunk store ha
 #   * 11.1: order of rows returned from sqlite_schema. DoltLite returns catalog
 #     entries in its own order (virtual table e1 before base table x1); stock
 #     returns creation order. Unordered SELECT, multiset-equal.
-#   * 13.2.* and 14.1/14.2: tests 13.1.4-13.1.8 deliberately corrupt the schema
-#     via `PRAGMA writable_schema=ON; DELETE FROM sqlite_master WHERE
-#     name='x1i'`. DoltLite's index lives in its structural catalog, not in the
-#     sqlite_master text, so the raw DELETE removes the master row but not the
-#     catalog index — leaving an orphan that DoltLite reports as "malformed
-#     database schema (x1i) - orphan index" on the next schema op, where stock
-#     (whose schema IS sqlite_master) simply dropped it. Every later op in the
-#     same db (the trigger creates 13.2.*.1, the rename-column probes 14.1/14.2)
-#     hits the poisoned schema. writable_schema-corruption boundary; no
-#     reset_db until line 674.
 altercol altercol-11.1      # sqlite_schema row order (multiset equal)
-altercol altercol-13.2.1.1  # poisoned by 13.1.8 writable_schema DELETE (orphan index x1i)
-altercol altercol-13.2.1.2  # orphan index x1i after writable_schema DELETE (structural catalog desync)
-altercol altercol-13.2.2.1  # poisoned by 13.1.8 writable_schema DELETE (orphan index x1i)
-altercol altercol-13.2.2.2  # orphan index x1i after writable_schema DELETE (structural catalog desync)
-altercol altercol-13.2.3.1  # poisoned by 13.1.8 writable_schema DELETE (orphan index x1i)
-altercol altercol-13.2.3.2  # orphan index x1i after writable_schema DELETE (structural catalog desync)
-altercol altercol-13.2.4.1  # poisoned by 13.1.8 writable_schema DELETE (orphan index x1i)
-altercol altercol-13.2.4.2  # orphan index x1i after writable_schema DELETE (structural catalog desync)
-altercol altercol-14.1      # poisoned by 13.1.8 writable_schema DELETE (orphan index x1i)
-altercol altercol-14.2      # poisoned by 13.1.8 writable_schema DELETE (orphan index x1i)
 
 # altercons / altercons2 — DDL text divergences after ALTER, never wrong data:
 #   * altercons 3.7.2/3.8.2: DoltLite leaves a trailing space in the rewritten
 #     CREATE TABLE text after DROP COLUMN ("... PRIMARY KEY) " vs "...)").
 #   * altercons 6.4.1: DoltLite normalizes "CHECK (expr)" to "CHECK(expr)" in
 #     stored DDL.
-#   * altercons2 1.1.3/1.5.3/1.6.3: test 1.*.1 corrupts the schema with
-#     `PRAGMA writable_schema=1; UPDATE sqlite_schema SET sql=<partial>`.
-#     DoltLite regenerates DDL from its structural catalog and ignores the raw
-#     sqlite_schema text edit (same class as alterdropcol-8.2), so 1.*.3 reads
-#     back the original CREATE TABLE rather than the injected partial text.
 altercons altercons-3.7.2   # trailing space in rewritten DDL after DROP COLUMN
 altercons altercons-3.8.2   # trailing space in rewritten DDL after DROP COLUMN
 altercons altercons-6.4.1   # DDL normalizes "CHECK (" to "CHECK("
-altercons2 altercons2-1.1.3  # writable_schema raw sql edit ignored; structural catalog regenerates DDL
-altercons2 altercons2-1.5.3  # writable_schema raw sql edit ignored; structural catalog regenerates DDL
-altercons2 altercons2-1.6.3  # writable_schema raw sql edit ignored; structural catalog regenerates DDL
 
 # index5 — index5-1.3 records the on-disk page WRITE ORDER during CREATE INDEX
 # via a custom test VFS (forward/backward/non-contiguous page offsets) and

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -921,13 +921,6 @@ trigger1 trigger1-6.2
 trigger1 trigger1-6.5
 trigger1 trigger1-6.6
 where where-1.1.1  # sqlite_search_count metric; SELECT x,y,w WHERE w=10 returns 3|121|10 on both
-# where-25.* inject btree corruption via PRAGMA writable_schema (rewrite a rootpage
-# number) and expect "database disk image is malformed"/"corrupt database". doltlite's
-# CTLD/prolly format has no such btree page graph to corrupt; on an uncorrupted db the
-# 25.x row/upsert semantics match stock exactly.
-where where-25.1
-where where-25.2
-where where-25.5
 
 # --- Large/Additional/Crash-recovery divergences (full local capture via the
 # object testfixture; PR #1116 / issue #1119). Same classes: raw stock on-disk
@@ -1142,7 +1135,6 @@ capi3 capi3-3.4    # same: errmsg "not an error" vs "unable to open database fil
 capi3 capi3-4.3    # bogus-path open16: deferred open error vs SQLITE_CANTOPEN
 capi3 capi3-4.4    # same (utf16 errmsg)
 capi3 capi3-8.3    # writable_schema sqlite_master corruption undetected: prolly catalog isn't the raw sqlite_master row store
-capi3 capi3-8.5    # same: injected bogus sqlite_master row doesn't malform the prolly catalog
 capi3 capi3-11.3.4 # PRAGMA lock_status reports doltlite's locking model ("main unlocked" vs "main shared")
 capi3 capi3-11.5   # finalize after COMMIT-during-active-read: SQLITE_ABORT vs SQLITE_ERROR
 # capi3-11.10/11.11 (step after ROLLBACK-during-active-read) now pass: the read


### PR DESCRIPTION
## Summary
- preserve pending Doltlite catalog state across FTS3 OOM rollback paths
- keep the synthetic sqlite_master OOM guard at schema-table creation time only
- add a targeted Doltlite FTS3 OOM regression for post-failed-create sqlite_master readability

## Testing
- `./testfixture ../test/doltlite_fts3_oom.test`
- `./testfixture ../test/fts3malloc.test` now passes the old early `fts3_malloc-1.1` failure and reaches the next known failure at `fts3_malloc-1.5.transient.100000.319` (`no such table: main.sqlite_master`)
