### PR TITLE
Gate tkt-3a77c9714e; finish tkt-* triage, file DDL-abort bug #1299 (#1208)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -280,7 +280,7 @@ jobs:
           sort2 sort5 sorterref speed4p spellfix spellfix2 spellfix3 spellfix4 sqldiff1 \
           sqllog starschema1 stmtrand stmtvtab1 strict1 subquery2 subselect subtype1 \
           swarmvtab2 swarmvtab3 swarmvtabfault symlink2 tabfunc01 tableapi tableopts tempdb2 \
-          temptable3 temptrigger timediff1 tkt-02a8e81d44 tkt-18458b1a tkt-26ff0c2d1e tkt-2a5629202f tkt-2d1a5c67d \
+          temptable3 temptrigger timediff1 tkt-02a8e81d44 tkt-18458b1a tkt-26ff0c2d1e tkt-2a5629202f tkt-2d1a5c67d tkt-3a77c9714e \
           tkt-2ea2425d34 tkt-31338dca7e tkt-313723c356 tkt-385a5b56b9 tkt-38cb5df375 tkt-3998683a16 tkt-3fe897352e tkt-4a03edc4c8 \
           tkt-4c86b126f2 tkt-4dd95f6943 tkt-4ef7e3cfca tkt-54844eea3f tkt-6bfb98dfc0 tkt-752e1646fc tkt-78e04e52ea tkt-7a31705a7e6 \
           tkt-7bbfb7d442 tkt-80ba201079 tkt-80e031a00f tkt-8454a207b9 tkt-868145d012 tkt-8c63ff0ec tkt-91e2e8ba6f tkt-99378177930f87bd \

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1821,3 +1821,12 @@ whereL whereL-110    # EQP plan shape; results equivalent
 whereL whereL-120    # EQP plan shape; results equivalent
 whereL whereL-121    # EQP plan shape; results equivalent
 whereL whereL-122    # EQP plan shape; results equivalent
+
+# tkt-3a77c9714e-3.0 — `CREATE TABLE t1(i INT PRIMARY KEY, a, b)` then
+# `INSERT INTO t1 VALUES(NULL,...)`. Stock treats `INT PRIMARY KEY` (not the
+# `INTEGER PRIMARY KEY` rowid alias) as an ordinary PK on a rowid table, where
+# a NULL PK is allowed. DoltLite stores non-INTEGER / composite PK tables
+# WITHOUT ROWID (#1176), so the PK is NOT NULL and the NULL insert is rejected
+# with "NOT NULL constraint failed: t1.i". Same storage-model class as
+# without_rowid1-7.x and where4-5.2.
+tkt-3a77c9714e tkt-3a77c9714e-3.0  # INT PRIMARY KEY stored WITHOUT ROWID (#1176); NULL PK rejected


### PR DESCRIPTION
Completes triage of the remaining `tkt-*` cluster.

### Gated
- **tkt-3a77c9714e** (`3.0`) — `INSERT NULL` into an `INT PRIMARY KEY` column. Stock allows a NULL PK on a rowid table; doltlite stores non-`INTEGER` PK tables WITHOUT ROWID (#1176) so the PK is NOT NULL and the insert is rejected (`NOT NULL constraint failed: t1.i`). Same storage-model class as `without_rowid1` / `where4-5.2`. `OK: tkt-3a77c9714e (6 tests, 1 known divergences)`.

### Filed as a bug — #1299 (left ungated)
- **tkt3080**, **tkt-b72787b1**, **tkt-c694113d5** all fail on one root cause: running DDL (`CREATE TABLE`/`CREATE INDEX`) inside a callback **aborts the in-flight outer SELECT** where stock lets it finish. Minimal repro: a `CREATE INDEX` in a row callback drops the remaining rows with `query aborted`. Same family as #1285 (over-aggressive cursor invalidation) but on the schema-change path. A real correctness bug → fix, not gate.

### Deferred
- **tkt3871**, **tkt3121** — `echo` virtual-table test module ("SQL logic error"); grouping with a vtab-focused pass (vtab1/vtab2/vtabH/…).
- **tkt2686** — disk-full fault injection; hangs at test 6.x. Slow/fault-injection bucket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)