### PR TITLE
Fix count_changes over-count for OR-by-union DELETE; gate where7 (#1293)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -310,7 +310,7 @@ jobs:
           whereN window4 window5 window7 window8 window9 windowA windowB \
           windowD windowerr windowfault windowpushd with1 with2 with3 with4 with5 \
           with6 withM without_rowid2 without_rowid3 without_rowid4 without_rowid5 without_rowid6 \
-          update2 where4 whereD whereF whereG whereL window6 zeroblobfault zipfile \
+          update2 where4 whereD whereF whereG whereL where7 window6 zeroblobfault zipfile \
           zipfile2 zipfilefault \
           altermalloc2 closure01 fpconv1 fts3an fts3snippet fuzzer2 indexfault joinD json106 \
           mallocA mmap4 percentile savepoint4 sort3 sort4 sortfault speed1p speed2 speed4 \

--- a/src/delete.c
+++ b/src/delete.c
@@ -549,8 +549,18 @@ void sqlite3DeleteFrom(
       sqlite3VdbeAddOp1(v, OP_FinishSeek, iTabCur);
     }
  
-    /* Keep track of the number of rows to be deleted */
-    if( memCnt ){
+    /* Keep track of the number of rows to be deleted.
+    **
+    ** For the one-pass paths the row is deleted inline here in the WHERE loop,
+    ** so count it here. For the two-pass path (ONEPASS_OFF) the WHERE loop only
+    ** collects keys: under DoltLite's OR handling the same row is visited once
+    ** per OR term (bComplex is forced for any OR WHERE — see
+    ** doltliteExprContainsOr above — so the inline ONEPASS_MULTI delete that
+    ** stock SQLite uses, which removes a row before the next term re-finds it,
+    ** is unavailable). Counting here would count duplicates; the actual delete
+    ** loop iterates the de-duplicated keys (OP_RowSetRead / the ephemeral
+    ** index), so for ONEPASS_OFF we count there instead. */
+    if( memCnt && eOnePass!=ONEPASS_OFF ){
       sqlite3VdbeAddOp2(v, OP_AddImm, memCnt, 1);
     }
  
@@ -641,8 +651,15 @@ void sqlite3DeleteFrom(
       addrLoop = sqlite3VdbeAddOp3(v, OP_RowSetRead, iRowSet, 0, iKey);
       VdbeCoverage(v);
       assert( nKey==1 );
-    } 
- 
+    }
+
+    /* Count the row here for the two-pass path: this loop iterates the
+    ** de-duplicated keys collected above, so each row is counted exactly once
+    ** (the WHERE-loop count was suppressed for ONEPASS_OFF). */
+    if( memCnt && eOnePass==ONEPASS_OFF ){
+      sqlite3VdbeAddOp2(v, OP_AddImm, memCnt, 1);
+    }
+
     /* Delete the row */
 #ifndef SQLITE_OMIT_VIRTUALTABLE
     if( IsVirtual(pTab) ){


### PR DESCRIPTION
Closes #1293.

## Bug
With `PRAGMA count_changes=ON`, an index-driven OR `DELETE` over-counted when a row matched more than one OR term:
- `DELETE … WHERE a<2 OR a<3` → reported **3** (should be 2)
- `… a<2 OR a<3 OR a<4` → reported **6** = 3+2+1 (once per matching term)

Rows were deleted correctly and `changes()`/`total_changes()` were right — only the legacy `count_changes` value was wrong.

## Cause
doltlite forces the **two-pass** delete path for any OR WHERE (`doltliteExprContainsOr` → `bComplex`), because it can't delete inline during a prolly OR-by-union scan the way stock's `ONEPASS_MULTI` does (stock deletes a row during the first term's scan so the second term never re-finds it). In the two-pass path the WHERE loop only collects keys and visits a row **once per OR term**, but the change-count register (`memCnt`) was incremented there — counting the duplicates. The actual delete loop iterates the **de-duplicated** keys (`OP_RowSetRead` / ephemeral index), so `db->nChange` was already correct.

Verified against stock via `EXPLAIN`: stock uses `ONEPASS_MULTI` (inline delete, count in the scan subroutine — correct); doltlite uses `ONEPASS_OFF` (count in the scan subroutine — over-counts).

## Fix
For `ONEPASS_OFF`, increment the count register once per **unique key in the delete loop** instead of in the WHERE loop. The one-pass paths still count inline (unchanged).

## Verification
- All count_changes cases correct now: overlap→2, triple→3, disjoint→1, IPK→2, WITHOUT ROWID→2, simple→2, UPDATE→2.
- **where7-1.1.1** returns to passing (`where7`: 1→0); **delete/delete2/delete3/delete4/trigger1/trigger2/fkey2/where/conflict/in4/update all match master exactly** — no regression.
- ASan clean across where7/delete/delete2/in4.
- Gates **where7** (2027 tests, 0 divergences), which #1294 left ungated pending this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)