### PR TITLE
Fix DDL from a callback aborting the in-flight outer statement (#1299)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -284,12 +284,12 @@ jobs:
           tkt-2ea2425d34 tkt-31338dca7e tkt-313723c356 tkt-385a5b56b9 tkt-38cb5df375 tkt-3998683a16 tkt-3fe897352e tkt-4a03edc4c8 \
           tkt-4c86b126f2 tkt-4dd95f6943 tkt-4ef7e3cfca tkt-54844eea3f tkt-6bfb98dfc0 tkt-752e1646fc tkt-78e04e52ea tkt-7a31705a7e6 \
           tkt-7bbfb7d442 tkt-80ba201079 tkt-80e031a00f tkt-8454a207b9 tkt-868145d012 tkt-8c63ff0ec tkt-91e2e8ba6f tkt-99378177930f87bd \
-          tkt-9a8b09f8e6 tkt-9f2eb3abac tkt-a7b7803e tkt-a7debbe0 tkt-a8a0d2996a tkt-b1d3a2e531 tkt-b351d95f9 tkt-b75a9ca6b0 \
-          tkt-ba7cbfaedc tkt-bd484a090c tkt-bdc6bbbb38 tkt-c48d99d690 tkt-cbd054fa6b tkt-d11f09d36e tkt-d635236375 tkt-d82e3f3721 \
+          tkt-9a8b09f8e6 tkt-9f2eb3abac tkt-a7b7803e tkt-a7debbe0 tkt-a8a0d2996a tkt-b1d3a2e531 tkt-b351d95f9 tkt-b72787b1 tkt-b75a9ca6b0 \
+          tkt-ba7cbfaedc tkt-bd484a090c tkt-bdc6bbbb38 tkt-c48d99d690 tkt-c694113d5 tkt-cbd054fa6b tkt-d11f09d36e tkt-d635236375 tkt-d82e3f3721 \
           tkt-f3e5abed55 tkt-f67b41381a tkt-f777251dc7a tkt-f7b4edec tkt-f973c7ac31 tkt-fa7bf5ec tkt-fc7bd6358f tkt1435 \
           tkt1443 tkt1444 tkt1449 tkt1473 tkt1501 tkt1514 tkt1536 tkt1537 \
           e_select2 tkt-5ee23731f tkt2820 tkt3424 \
-          tkt1512 tkt1567 tkt2332 tkt2409 tkt2854 tkt2920 tkt3457 tkt3761 tkt3762 tkt3810 tkt4018 \
+          tkt1512 tkt1567 tkt2332 tkt2409 tkt2854 tkt2920 tkt3080 tkt3457 tkt3761 tkt3762 tkt3810 tkt4018 \
           tkt1644 tkt1873 tkt2141 tkt2192 tkt2213 tkt2251 tkt2285 tkt2339 \
           tkt2391 tkt2450 tkt2640 tkt2643 tkt2767 tkt2817 tkt2822 tkt2832 \
           tkt2927 tkt2942 tkt3093 tkt3201 tkt3292 tkt3298 tkt3334 tkt3346 \

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -3049,7 +3049,11 @@ static int saveCursorPosition(BtCursor *pCur){
 
   CLEAR_CACHED_PAYLOAD(pCur);
 
-  if( !prollyCursorIsValid(&pCur->pCur) ){
+  /* A map-sourced row's key comes from the mutmap below; the tree cursor may
+  ** legitimately be unpositioned (all rows still pending). */
+  if( !prollyCursorIsValid(&pCur->pCur)
+   && !(pCur->mmActive
+        && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH)) ){
     if( pCur->curIntKey && (pCur->curFlags & BTCF_ValidNKey) ){
 
       pCur->nKey = pCur->cachedIntKey;
@@ -5259,6 +5263,7 @@ static int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
       p->committedConstraintViolationsHash = p->constraintViolationsHash;
       btreeMarkWorkingStateChanged(p);
       if( bReloadSchema ){
+        BtCursor *pC;
         rc = buildRuntimeMasterRoot(p, &runtimeMasterRoot);
         if( rc!=SQLITE_OK ){
           sqlite3_free(catData);
@@ -5266,7 +5271,31 @@ static int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
           pBt->store.snapshotPinned = 0;
           return rc;
         }
-        invalidateCursors(pBt, 0, SQLITE_ABORT);
+        /* A statement can still be mid-scan here (a callback ran DDL in
+        ** autocommit — tkt3080). Save this handle's cursors so it survives
+        ** the catalog reload; fault only what can't be saved. The reload
+        ** frees the pending maps, so detach aliases either way. */
+        for(pC = pBt->pCursor; pC; pC = pC->pNext){
+          if( pC->pBtree==p ){
+            if( (pC->eState==CURSOR_VALID || pC->eState==CURSOR_SKIPNEXT)
+             && saveCursorPosition(pC)!=SQLITE_OK ){
+              pC->eState = CURSOR_FAULT;
+              pC->skipNext = SQLITE_ABORT;
+              prollyCursorReleaseAll(&pC->pCur);
+            }
+            pC->pMutMap = 0;
+            pC->mmActive = 0;
+            pC->mmPhysActive = 0;
+            pC->deferredTreeSeek = 0;
+            pC->mmIdx = -1;
+            pC->mmPhysIdx = -1;
+          }else{
+            pC->eState = CURSOR_FAULT;
+            pC->skipNext = SQLITE_ABORT;
+            pC->mmActive = 0;
+            prollyCursorReleaseAll(&pC->pCur);
+          }
+        }
         rc = deserializeCatalog(p, catData, nCatData);
         if( rc!=SQLITE_OK ){
           sqlite3_free(catData);
@@ -5278,9 +5307,20 @@ static int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
           struct TableEntry *pMaster = findTable(p, 1);
           if( pMaster ) pMaster->root = runtimeMasterRoot;
         }
+        /* A saved cursor whose table vanished in the reload would re-seek a
+        ** stale root; fault it. */
+        for(pC = pBt->pCursor; pC; pC = pC->pNext){
+          if( pC->pBtree==p && pC->eState==CURSOR_REQUIRESEEK
+           && findTable(p, pC->pgnoRoot)==0 ){
+            pC->eState = CURSOR_FAULT;
+            pC->skipNext = SQLITE_ABORT;
+          }
+        }
         invalidateSchema(p);
         if( p->db ){
-          sqlite3ExpirePreparedStatements(p->db, 0);
+          /* Advisory expiry: hard expiry (iCode 0) makes OP_OpenRead abort a
+          ** statement still running across this commit (tkt-c694113d5). */
+          sqlite3ExpirePreparedStatements(p->db, 1);
           sqlite3ResetAllSchemasOfConnection(p->db);
         }
       }
@@ -8103,6 +8143,16 @@ static int flushIfNeeded(BtCursor *pCur){
     }
   }
 
+  /* Save the initiating cursor too — it can belong to a statement that is
+  ** still running (a callback issued COMMIT, capi3-11.4); dropping it to
+  ** INVALID below ended that scan. Before flushMutMap: a map-sourced row's
+  ** key is read out of the map being flushed. */
+  if( !pCur->isPinned
+   && (pCur->eState==CURSOR_VALID || pCur->eState==CURSOR_SKIPNEXT) ){
+    rc = saveCursorPosition(pCur);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+
   rc = flushMutMap(pCur);
   if( rc!=SQLITE_OK ) return rc;
 
@@ -8112,6 +8162,10 @@ static int flushIfNeeded(BtCursor *pCur){
     prollyCursorInit(&pCur->pCur, &pCur->pBt->store, &pCur->pBt->cache,
                      &pTE->root, pTE->flags);
   }
+  /* The flush emptied the map; a saved cursor restoring with a stale
+  ** mmActive/mmIdx would consult it at a dead index. */
+  refreshCursorMutMapAliases(pCur->pBtree, pCur->pBt, pCur->pgnoRoot,
+                             pTE ? (ProllyMutMap*)pTE->pPending : 0);
   /* A cursor saved by saveAllCursors (e.g. another statement scanning this
   ** table while we flush a DELETE/UPDATE) keeps its REQUIRESEEK state: it has a
   ** saved key and must reseek against the new root on next access. Clobbering it

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -127,7 +127,6 @@ triggerC triggerC-2.1.2
 triggerC triggerC-2.1.3
 triggerC triggerC-2.1.4
 triggerC triggerC-2.1.6
-triggerC triggerC-12.2  # DROP TRIGGER mid-scan aborts the cursor rather than crashing
 
 # ── window1 ──
 window1 window1-10.7  # rowid-order vs PK-order on unordered SELECT

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1144,11 +1144,12 @@ capi3 capi3-4.4    # same (utf16 errmsg)
 capi3 capi3-8.3    # writable_schema sqlite_master corruption undetected: prolly catalog isn't the raw sqlite_master row store
 capi3 capi3-8.5    # same: injected bogus sqlite_master row doesn't malform the prolly catalog
 capi3 capi3-11.3.4 # PRAGMA lock_status reports doltlite's locking model ("main unlocked" vs "main shared")
-capi3 capi3-11.5   # finalize after COMMIT-during-active-read: SQLITE_ABORT vs SQLITE_ERROR
-# capi3-11.10/11.11 (step after ROLLBACK-during-active-read) now pass: the read
-# cursor survives a writeOnly ROLLBACK and re-seeks instead of faulting (#1240).
-capi3 capi3-11.12  # same: SQLITE_ERROR vs SQLITE_ROW
-capi3 capi3-11.13  # finalize of the faulted statement: SQLITE_ERROR vs SQLITE_OK
+# capi3-11.4/11.5 (step/finalize after COMMIT-during-active-read) now pass: the
+# scan survives the commit flush and re-seeks. capi3-11.10/11.11 (step after
+# ROLLBACK-during-active-read) pass since the read cursor survives a writeOnly
+# ROLLBACK.
+capi3 capi3-11.12  # step after ROLLBACK-during-active-read: SQLITE_ERROR vs SQLITE_ROW
+capi3 capi3-11.13  # finalize of that statement: SQLITE_SCHEMA vs SQLITE_OK
 
 # default — writable_schema edit to a column DEFAULT is not honored. The test
 # does PRAGMA writable_schema=ON; UPDATE sqlite_master SET sql='...DEFAULT(:xyz)'


### PR DESCRIPTION
Closes #1299. Running DDL from a UDF or row callback (`tkt3080`, `tkt-b72787b1`, `tkt-c694113d5`) aborted the still-running outer SELECT, where stock lets it finish. Three causes, all on the schema-changing autocommit path:

1. **Commit faulted every cursor.** `prollyBtreeCommitPhaseTwo` hard-faulted all cursors with `SQLITE_ABORT` before the catalog reload. Now saves this handle's cursors (re-seekable against the reloaded catalog) and faults only what can't be saved or whose table vanished in the reload; other handles' cursors fault as before.

2. **Hard statement expiry.** The same path called `sqlite3ExpirePreparedStatements(db, 0)`; hard expiry makes `OP_OpenRead` return `SQLITE_ABORT_ROLLBACK` for any running statement that re-opens a cursor — e.g. a `NOT EXISTS` subquery, once per outer row. Switched to advisory expiry (`iCode 1`), stock's schema-change semantics: running statements finish, then re-prepare.

3. **Pre-existing row loss, hidden on master.** `flushIfNeeded` dropped the *initiating* cursor to `CURSOR_INVALID`, so a SELECT resumed after a callback-issued `COMMIT` silently lost its remaining rows — on master today, `sqlite3_step` after a mid-scan COMMIT returns `SQLITE_DONE` with rows still in the table (masked because the blunt abort in (1) usually killed the statement first; capi3-11.4 exposed it once (1)/(2) stopped the aborts). Fixed by saving the initiating cursor before the flush, teaching `saveCursorPosition` to save map-sourced rows whose tree cursor is unpositioned, and resetting stale mutmap iterator state post-flush.

## Verification
- Minimal repro (CREATE INDEX in a row callback) returns all rows; `DROP TABLE` of a scanned table now correctly errors "database table is locked" (stock parity).
- **tkt3080 / tkt-b72787b1 / tkt-c694113d5 → 0 failures, gated.**
- **capi3 improves 10 → 9** known divergences: 11.4 *and* 11.5 now pass (entries removed; stale 11.13 reason corrected to `SQLITE_SCHEMA`). Mid-scan-COMMIT resume verified for table-created-in-txn, rows-pending-in-txn, and pre-existing-data shapes.
- No regressions: 38-suite sweep byte-identical to master (savepoint 48, trans 19/29, fkey2 7, trigger1 4, tkt3718 0, schema* 0, …); gate harness OK on all touched files; shell suites match master; ASan clean (capi3, tkt trio, tkt3718, savepoint, trans2, schema).

🤖 Generated with [Claude Code](https://claude.com/claude-code)