### PR TITLE
CI: dedupe build-test ubuntu vs sqlite-regression (10 tkt-* files)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -479,8 +479,4 @@ jobs:
           schema schema2 schema3 schema4 \
           shared shared2 shared3 shared9 \
           speed1 substr table tempdb \
-          vacuum vacuum2 vacuum5 autoinc interrupt interrupt2 doltlite_fts3_oom \
-          tkt-38cb5df375 tkt-9a8b09f8e6 tkt-99378177930f87bd \
-          tkt-80e031a00f tkt-80ba201079 tkt-31338dca7e \
-          tkt-7bbfb7d442 tkt-4dd95f6943 tkt-2d1a5c67d \
-          tkt-f3e5abed55
+          vacuum vacuum2 vacuum5 autoinc interrupt interrupt2 doltlite_fts3_oom


### PR DESCRIPTION
The `ubuntu` job (build-test.yml) and `sqlite-regression` (test.yml) both run per-PR with the same testfixture harness and `DOLTLITE_PROLLY_CHECK=1`, and 10 tkt-* files appeared in both lists — pure duplicate coverage, introduced when the tkt-* cluster was gated into sqlite-regression while these 10 already sat in build-test's "Additional tests" tail.

Removed from build-test; `sqlite-regression` remains their canonical home (it's the inherited-corpus gate). Overlap between the two lists is now zero:

`tkt-2d1a5c67d tkt-31338dca7e tkt-38cb5df375 tkt-4dd95f6943 tkt-7bbfb7d442 tkt-80ba201079 tkt-80e031a00f tkt-99378177930f87bd tkt-9a8b09f8e6 tkt-f3e5abed55`

🤖 Generated with [Claude Code](https://claude.com/claude-code)