### PR TITLE
Fix indexed lookups and UNIQUE enforcement for zeroblob values

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -230,7 +230,7 @@ jobs:
           8_3_names aggerror aggfault alter3 alter4 altercol altercons altercons2 alterauth alterauth2 alterdropcol alterdropcol2 altertab3 alterlegacy altermalloc3 autoindex1 \
           index5 limit2 notnull \
           attach2 attach3 autoindex3 autoindex5 pragma6 rowvalue9 skipscan1 skipscan2 \
-          temptable temptable2 windowC windowE without_rowid7 \
+          temptable temptable2 windowC windowE without_rowid7 zeroblob \
           alterqf altertab2 altertrig amatch1 analyze3 analyze4 analyze5 analyze6 \
           analyze7 analyze8 analyze9 analyzeC analyzeD analyzeE analyzeF analyzeG \
           analyzer1 atof1 atof2 atomic atomic2 attach4 auth2 auth3 \

--- a/src/sortkey.c
+++ b/src/sortkey.c
@@ -463,7 +463,14 @@ static int sortKeyMemSerialType(Mem *pMem, u32 *pSerialType, u32 *pLen){
   }
   if( flags & (MEM_Str|MEM_Blob) ){
     if( flags & MEM_Zero ){
-      return SQLITE_NOTFOUND;
+      /* A zeroblob's tail exists only as u.nZero. Bailing (SQLITE_NOTFOUND)
+      ** let an indexed probe build a key that misses the stored entry, so
+      ** WHERE b=zeroblob(N) found nothing through an index (zeroblob-2.2) —
+      ** the MEM_IntReal lesson again. Expand to the literal bytes; on OOM
+      ** mallocFailed is set and the statement aborts. */
+      if( sqlite3VdbeMemExpandBlob(pMem)!=SQLITE_OK ){
+        return SQLITE_NOMEM;
+      }
     }
     if( pMem->n < 0 || (pMem->n > 0 && pMem->z==0) ){
       return SQLITE_CORRUPT;
@@ -493,11 +500,13 @@ static int sortKeyEncodeMemArray(
     u32 serialType;
     u32 fieldLen;
     u8 aNum[8];
-    const u8 *pField = (const u8*)pMem->z;
+    const u8 *pField;
     int coll;
     int rc = sortKeyMemSerialType(pMem, &serialType, &fieldLen);
     if( rc==SQLITE_NOTFOUND ) return -3;
     if( rc!=SQLITE_OK ) return -1;
+    /* After the serial-type call: zeroblob expansion reallocates pMem->z. */
+    pField = (const u8*)pMem->z;
 
     if( serialType <= 6 || serialType==8 || serialType==9 ){
       writeIntBE(aNum, pMem->u.i, (int)fieldLen);

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1866,3 +1866,10 @@ attach3 attach3-11.1  # cascade: aux name still attached after 11.0
 temptable2 temptable2-8.1  # PRAGMA page_count: chunk store has no SQLite page count
 temptable2 temptable2-8.3  # sqlite3_backup_init: page-image backup unsupported on prolly
 temptable2 temptable2-8.6  # sqlite3_backup_init: page-image backup unsupported on prolly
+# zeroblob-1.1.x — internal instrumentation: sqlite3_max_blobsize tracks the
+# largest blob allocation (prolly record encoding materializes the zeroblob,
+# stock keeps it lazy) and the memory-highwater bound assumes that laziness.
+# Value semantics are correct (indexed/unindexed lookups, UNIQUE, BLOB
+# round-trip all match stock).
+zeroblob zeroblob-1.1.1  # sqlite3_max_blobsize allocation metric (zeroblob materialized)
+zeroblob zeroblob-1.1.2  # memory-highwater bound assumes lazy zeroblob


### PR DESCRIPTION
Found in the #1208 sweep (zeroblob-2.2): comparisons against `zeroblob(N)` matched on an unindexed scan but **returned nothing through an index** — and, it turns out, `UNIQUE` on a blob column **accepted duplicate zeroblobs**.

## Cause
`sortKeyMemSerialType` (src/sortkey.c) returned `SQLITE_NOTFOUND` for `MEM_Zero` — a zeroblob (real bytes + a lazy zero tail in `u.nZero`) never produced a native index sort key, so the indexed probe/conflict check missed the stored entry. The exact `MEM_IntReal` shape from the REAL-UNIQUE bug: a special Mem flavor the key encoder forgot.

## Fix
Expand the zeroblob to its literal bytes (`sqlite3VdbeMemExpandBlob`, stock's own pattern) before computing the serial type; OOM sets `mallocFailed` and aborts the statement. The caller's `pField` now reads `pMem->z` *after* the call (expansion reallocates it). The single-mem fast path keeps its bail — its NOTFOUND falls back to the general encoder, and an expanded zeroblob has embedded NULs which that path already rejects.

## Verification
- `WHERE b=zeroblob(10000)` via index → row found (was empty); zeroblob equals literal `x'00000000'` through an index; `INSERT` of a duplicate zeroblob into a UNIQUE column now raises the constraint (was silently accepted).
- `zeroblob.test` 3 → 2 failures; the remaining two are internal allocation-metric instrumentation (`sqlite3_max_blobsize` / memory-highwater assume stock's lazy zeroblob) — recorded and **zeroblob gated**.
- No regressions: index 9, where 9, insert 1, conflict/unique/unique2/types/blob/boundary2/in4/tkt3718 all match master; incrblob2 33=33 (pre-existing family); ASan clean.

Part of #1208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)