### PR TITLE
Fix integrity_check false failures: stale compare-key cache + GC of the runtime master root (#1306)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -229,6 +229,7 @@ jobs:
         bash ../test/run_testfixture.sh "SQLite regression" 300 \
           8_3_names aggerror aggfault alter3 alter4 altercol altercons altercons2 alterauth alterauth2 alterdropcol alterdropcol2 altertab3 alterlegacy altermalloc3 autoindex1 \
           index5 limit2 notnull \
+          without_rowid1 \
           alterqf altertab2 altertrig amatch1 analyze3 analyze4 analyze5 analyze6 \
           analyze7 analyze8 analyze9 analyzeC analyzeD analyzeE analyzeF analyzeG \
           analyzer1 atof1 atof2 atomic atomic2 attach4 auth2 auth3 \

--- a/src/pragma.c
+++ b/src/pragma.c
@@ -1891,6 +1891,11 @@ void sqlite3Pragma(
             char *zErr;
             a1 = sqlite3VdbeAddOp4Int(v, OP_IdxGT, iDataCur, 0,r2,pPk->nKeyCol);
             VdbeCoverage(v);
+#if defined(DOLTLITE_PROLLY)
+            /* r2 is reloaded from each row; the prolly compare-key cache
+            ** must not reuse the previous iteration's probe. */
+            sqlite3VdbeChangeP5(v, 1);
+#endif
             sqlite3VdbeAddOp1(v, OP_IsNull, r2); VdbeCoverage(v);
             zErr = sqlite3MPrintf(db,
                    "row not in PRIMARY KEY order for %s",

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -10255,6 +10255,15 @@ int doltliteSeedSessionHashes(
     if( rc==SQLITE_OK ) rc = xPush(pCtx, &pBt->preRebaseWorkingCat);
     if( rc==SQLITE_OK ) rc = xPush(pCtx, &pBt->rebaseOntoCommit);
     if( rc==SQLITE_OK ) rc = xPush(pCtx, &pBt->constraintViolationsHash);
+    /* The live catalog's roots: table 1 can be the runtime master-root view,
+    ** which is intentionally absent from the persisted catalog — without this
+    ** a GC collects it while the open session still reads through it. */
+    {
+      int k;
+      for(k=0; rc==SQLITE_OK && k<pBt->cat.n; k++){
+        rc = xPush(pCtx, &pBt->cat.a[k].root);
+      }
+    }
   }
   return rc;
 }

--- a/src/vdbe.c
+++ b/src/vdbe.c
@@ -7254,6 +7254,12 @@ case OP_IdxGE:  {       /* jump, ncycle */
     pCur = pC->uc.pCursor;
     assert( sqlite3BtreeCursorIsValid(pCur) );
 #if defined(DOLTLITE_PROLLY)
+    /* p5: the bound registers are rewritten between executions with no
+    ** intervening seek (integrity_check reloads them from each row), so the
+    ** cached compare key would be stale. */
+    if( pOp->p5 ){
+      sqlite3BtreeProllyClearCompareKey(pCur);
+    }
     rc = sqlite3BtreeProllyCachedIndexKeyCompare(pCur, &r, &res);
     if( rc==SQLITE_NOTFOUND ){
       rc = SQLITE_OK;

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -307,7 +307,6 @@ vacuum2 vacuum2-4.1   # post-VACUUM auto_vacuum mode change
 vacuum2 vacuum2-5.2   # "cannot VACUUM - SQL statements in progress" error path
 vacuum2 vacuum2-5.3   # error path
 vacuum2 vacuum2-5.4   # error path
-vacuum2 vacuum2-6.3   # post-VACUUM page count
 
 # ── crash7 ──
 # crash7 verifies crash recovery during VACUUM. Since VACUUM is a no-op
@@ -1117,9 +1116,7 @@ tkt-f3e5abed55 tkt-f3e5abed55-2.5
 vacuum vacuum-7.1
 vacuum vacuum-7.5
 vacuum2 vacuum2-2.1
-vacuum2 vacuum2-3.17
 vacuum2 vacuum2-3.3
-vacuum2 vacuum2-3.7
 vacuum2 vacuum2-4.2
 vacuum2 vacuum2-4.4
 vacuum2 vacuum2-4.5

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1830,3 +1830,10 @@ whereL whereL-122    # EQP plan shape; results equivalent
 # with "NOT NULL constraint failed: t1.i". Same storage-model class as
 # without_rowid1-7.x and where4-5.2.
 tkt-3a77c9714e tkt-3a77c9714e-3.0  # INT PRIMARY KEY stored WITHOUT ROWID (#1176); NULL PK rejected
+
+# without_rowid1-7.x — t70a(a INT CHECK(rowid!=33), b TEXT PRIMARY KEY): stock
+# keeps it a rowid table so the CHECK can reference rowid; doltlite stores
+# non-INTEGER-PK tables WITHOUT ROWID, where rowid is not a column. 7.1's
+# CREATE fails resolving the CHECK; 7.2 cascades (no such table).
+without_rowid1 without_rowid1-7.1  # CHECK(rowid) on implicit WITHOUT ROWID table
+without_rowid1 without_rowid1-7.2  # cascade: t70a was never created


### PR DESCRIPTION
Closes #1306. The `without_rowid1` integrity failures turned out to be **two unrelated bugs**, neither a storage corruption — queries on the affected tables were verified byte-identical to stock throughout.

## 1. Stale compare-key cache neutered/broke the order check (regression from the textpk optimization)
integrity_check's WITHOUT-ROWID order verification re-issues `OP_IdxGT` per row, reloading the bound registers from the previous row with **no intervening seek**. The compare-key cache revalidates only on `nField`, so every row compared against the *first* iteration's probe:
- a `INTEGER PRIMARY KEY DESC … WITHOUT ROWID` table failed `row not in PRIMARY KEY order` on perfectly ordered data (pre-optimization build returns `ok` — bisected), and
- the ASC order check **silently passed against a stale NULL probe** — i.e. it verified nothing.

Fix: the integrity codegen sets `p5` on that `OP_IdxGT`, and the opcode clears the cursor's compare cache when `p5` is set. Bounds that are loop-invariant (the optimization's target: range-scan bounds, set before the seek) keep the cache; `in4` stays at 0 and the textpk perf path is untouched.

## 2. dolt_gc collected the live runtime master root
`VACUUM` runs `dolt_gc()`, which retains refs-reachable chunks plus seeded session hashes — but `doltliteSeedSessionHashes` never seeded the **live catalog's table roots**. Table 1's root can be the synthesized runtime master-root view (intentionally absent from the persisted catalog), so a GC with real garbage collected it out from under the open session. integrity_check then reported a missing chunk — and any schema read through that root after cache eviction would have failed the same way, so this was a real post-GC hazard, not just cosmetic. (Explains the state-dependence: a fresh db has no garbage, so GC never rewrote the file.) Fix: seed every live catalog root into the retention set.

## Verification
- `without_rowid1` 5 → 2 failures; remaining `7.1/7.2` are the `CHECK(rowid)`-on-implicit-WITHOUT-ROWID surface (#1176), recorded — **file gated** (`OK: without_rowid1 (83 tests, 2 known divergences)`).
- DESC-PK + REINDEX and redundant-UNIQUE + VACUUM repros both return `ok`.
- No regressions: in4 0, where 9, where4 2, index 9, intpkey 3, fkey2 7, tkt3718 0, savepoint 48, trans2 29 — all master-identical.
- **GC shell suites all pass**: gc 51/51, gc-session-state 12/12, branch-gc-stress 35/35, gc-scale 12/12, vacuum 10/10, persistence 66/66 (GC still shrinks files — the extra retention is just the live roots).
- ASan clean (without_rowid1/7, vacuum4, index, fkey2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)