### PR TITLE
Preserve rollback fault code in rollbackCommittedState (#1307)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -229,6 +229,7 @@ jobs:
         bash ../test/run_testfixture.sh "SQLite regression" 300 \
           8_3_names aggerror aggfault alter3 alter4 altercol altercons altercons2 alterauth alterauth2 alterdropcol alterdropcol2 altertab3 alterlegacy altermalloc3 autoindex1 \
           index5 limit2 notnull \
+          savepoint7 \
           attach2 attach3 autoindex3 autoindex5 pragma6 rowvalue9 skipscan1 skipscan2 \
           temptable temptable2 windowC windowE without_rowid7 zeroblob \
           alterqf altertab2 altertrig amatch1 analyze3 analyze4 analyze5 analyze6 \

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -5633,9 +5633,20 @@ int sqlite3BtreeBeginStmt(Btree *p, int iStatement){
 }
 
 static int rollbackCommittedState(Btree *p, BtShared *pBt){
+  BtCursor *pC;
   int rc = restoreFromCommitted(p);
   if( rc!=SQLITE_OK ) return rc;
-  invalidateCursors(pBt, 0, SQLITE_ABORT);
+  /* Like invalidateCursors, but keep the code of an existing fault:
+  ** OP_Savepoint's cursor trip already stamped SQLITE_ABORT_ROLLBACK and
+  ** clobbering it to SQLITE_ABORT misreported the abort (savepoint7-2.2). */
+  for(pC=pBt->pCursor; pC; pC=pC->pNext){
+    if( pC->eState!=CURSOR_FAULT ){
+      pC->eState = CURSOR_FAULT;
+      pC->skipNext = SQLITE_ABORT;
+    }
+    pC->mmActive = 0;
+    prollyCursorReleaseAll(&pC->pCur);
+  }
   resetConnectionSchema(p);
   return SQLITE_OK;
 }


### PR DESCRIPTION
Closes #1307.

`ROLLBACK TO` of a savepoint that included DDL routes through `rollbackCommittedState` when the btree's lazily-pushed savepoint depth is shallower than the requested level. That path re-faulted every cursor with plain `SQLITE_ABORT`, clobbering the `SQLITE_ABORT_ROLLBACK` that `OP_Savepoint`'s cursor trip had already stamped — so the aborted outer statement reported `query aborted` instead of stock's `abort due to ROLLBACK` (savepoint7-2.2; traced by instrumenting the trip and the fault return: trip stamps 516, the next step reads 4).

Fix: keep an existing fault's code in `rollbackCommittedState`; the fault/detach/release behavior is otherwise identical.

- **savepoint7 → 0 failures, gated** (`OK: savepoint7 (12 tests)`).
- No regressions: savepoint 46, savepoint2/4/5 0, trans 19, trans2 29, fkey2 7, tkt3718 0, misc8 0, capi3 8, in4 0, where 6 — all master-identical (where/capi3 reflect #1298's merged fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)