### PR TITLE
Fix fts3 OOM schema placeholder cleanup

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -3306,6 +3306,7 @@ static int captureSavepointCatalogSnapshot(
 
   pState->aCatalogSnapshot = aSnapshot;
   pState->bCatalogSnapshot = 1;
+  pState->nTables = n;
   return SQLITE_OK;
 }
 
@@ -3362,6 +3363,14 @@ static int captureSavepointTables(
   u8 *catData = 0;
   int nCatData = 0;
   if( pState->bTablesCaptured ) return SQLITE_OK;
+  if( pState->aCatalogSnapshot ){
+    for(k=0; k<pState->nTables; k++){
+      sqlite3_free(pState->aCatalogSnapshot[k].zName);
+    }
+    sqlite3_free(pState->aCatalogSnapshot);
+    pState->aCatalogSnapshot = 0;
+    pState->bCatalogSnapshot = 0;
+  }
   memset(&pState->catalogHash, 0, sizeof(pState->catalogHash));
   if( bStatement ){
     rc = captureSavepointCatalogSnapshot(pBtree, pState);
@@ -3373,17 +3382,30 @@ static int captureSavepointTables(
     sqlite3_free(catData);
     if( rc!=SQLITE_OK ) return rc;
   }
-  pState->bTablesCaptured = 1;
-  if( pBtree->cat.n<=0 ) return SQLITE_OK;
+  if( pBtree->cat.n<=0 ){
+    pState->bTablesCaptured = 1;
+    return SQLITE_OK;
+  }
   pState->aTables = sqlite3_malloc(
       pBtree->cat.n * (int)sizeof(SavepointTableEntry));
-  if( !pState->aTables ) return SQLITE_NOMEM;
+  if( !pState->aTables ){
+    if( pState->aCatalogSnapshot ){
+      for(k=0; k<pBtree->cat.n; k++){
+        sqlite3_free(pState->aCatalogSnapshot[k].zName);
+      }
+      sqlite3_free(pState->aCatalogSnapshot);
+      pState->aCatalogSnapshot = 0;
+      pState->bCatalogSnapshot = 0;
+    }
+    return SQLITE_NOMEM;
+  }
   for(k=0; k<pBtree->cat.n; k++){
     pState->aTables[k].iTable = pBtree->cat.a[k].iTable;
     pState->aTables[k].pendingFlushSeekEdits =
         pBtree->cat.a[k].pendingFlushSeekEdits;
   }
   pState->nTables = pBtree->cat.n;
+  pState->bTablesCaptured = 1;
   return SQLITE_OK;
 }
 
@@ -8005,6 +8027,7 @@ static int prollyBtCursorInsert(
   if( pCur->pgnoRoot==1 ){
     rc = ensureStatementSavepointsCaptured(pCur->pBtree);
     if( rc!=SQLITE_OK ) return rc;
+    pCur->pBtree->bMasterRootChangedTxn = 1;
   }
 
   rc = saveAllCursors(pCur->pBtree, pCur->pBt, pCur->pgnoRoot, pCur);
@@ -8191,9 +8214,6 @@ static int prollyBtCursorInsert(
     if( rc==SQLITE_OK ) pCur->eState = CURSOR_VALID;
   }
 
-  if( rc==SQLITE_OK && pCur->pgnoRoot==1 ){
-    pCur->pBtree->bMasterRootChangedTxn = 1;
-  }
   return rc;
 }
 
@@ -8412,6 +8432,7 @@ static int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
   if( pCur->pgnoRoot==1 ){
     rc = ensureStatementSavepointsCaptured(pCur->pBtree);
     if( rc!=SQLITE_OK ) goto delete_cleanup;
+    pCur->pBtree->bMasterRootChangedTxn = 1;
   }
 
   rc = saveAllCursors(pCur->pBtree, pCur->pBt, pCur->pgnoRoot, pCur);
@@ -8529,9 +8550,6 @@ static int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
   rc = SQLITE_OK;
 
 delete_cleanup:
-  if( rc==SQLITE_OK && pCur->pgnoRoot==1 && hasSavedKey ){
-    pCur->pBtree->bMasterRootChangedTxn = 1;
-  }
   if( savedDelKeyOwned ) sqlite3_free(pSavedDelKey);
   return rc;
 }

--- a/test/doltlite_fts3_oom.test
+++ b/test/doltlite_fts3_oom.test
@@ -164,5 +164,40 @@ do_test doltlite_fts3_oom-3.2 {
        [expr {!$q2 && $cksum1 eq $cksum2}]
 } {1 0 1}
 
+do_test doltlite_fts3_oom-3.3 {
+  forcedelete test3.db
+  sqlite3 db3 test3.db
+  sqlite3_db_config_lookaside db3 0 0 0
+
+  db3 eval "SELECT * FROM sqlite_master" V break
+  set cksumsql "SELECT md5sum([join [concat rowid $V(*)] ,]) FROM sqlite_master"
+  set cksum1 [db3 one $cksumsql]
+
+  set bad ok
+  for {set iFail 1} {$iFail<=59 && $bad=="ok"} {incr iFail} {
+    sqlite3_memdebug_fail $iFail -repeat 100000
+    set res [catchsql {
+      CREATE VIRTUAL TABLE ft_oom USING fts3(a, b)
+    } db3]
+    set nFail [sqlite3_memdebug_fail -1 -benigncnt nBenign]
+    set q2 [catch {db3 one $cksumsql} cksum2]
+    set schema [catchsql {
+      SELECT rowid,type,name,tbl_name,rootpage,sql
+        FROM sqlite_master ORDER BY rowid
+    } db3]
+    if {$res!="1 {out of memory}"
+     || $nFail<=0
+     || $q2
+     || $cksum1 ne $cksum2
+     || $schema!="0 {}"
+    } {
+      set bad [list $iFail $res $nFail $q2 $cksum1 $cksum2 $schema]
+    }
+  }
+  catch {db3 close}
+  forcedelete test3.db
+  set bad
+} {ok}
+
 sqlite3_memdebug_fail -1
 finish_test


### PR DESCRIPTION
## Summary
- hide degenerate all-NULL sqlite_master placeholder rows from schema cursors
- mark master-root changes before schema flushes so OOM rollback sees the changed root
- avoid marking statement savepoint table capture complete until table snapshots are allocated
- add a targeted FTS3 OOM regression for the former fts3_malloc-1.1 persistent allocation failure prefix

## Tests
- LIBRARY_PATH=/opt/homebrew/lib make -C build-master-fts3oom-ci doltlite testfixture
- ./testfixture ../test/doltlite_fts3_oom.test
- focused fts3_malloc-1.1 repro through persistent attempts 1-64