### PR TITLE
Gate the echo-vtab cluster; crash-list vtab1 (#1208)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -229,6 +229,7 @@ jobs:
         bash ../test/run_testfixture.sh "SQLite regression" 300 \
           8_3_names aggerror aggfault alter3 alter4 altercol altercons altercons2 alterauth alterauth2 alterdropcol alterdropcol2 altertab3 alterlegacy altermalloc3 autoindex1 \
           index5 limit2 notnull \
+          tkt3871 tkt3121 vtab2 vtab4 vtabH vtab_err vtabdrop \
           attach2 attach3 autoindex3 autoindex5 pragma6 rowvalue9 skipscan1 skipscan2 \
           temptable temptable2 windowC windowE without_rowid7 zeroblob \
           alterqf altertab2 altertrig amatch1 analyze3 analyze4 analyze5 analyze6 \

--- a/test/known_testfixture_crashes.txt
+++ b/test/known_testfixture_crashes.txt
@@ -91,3 +91,4 @@ tkt2565        # auto_vacuum unsupported -> setup aborts (pre-summary)
 tkt-5d863f876e # journal_mode unsupported -> setup aborts -> cascade
 tkt-fc62af4523 # journal_mode unsupported -> setup aborts -> cascade
 savepoint6     # auto_vacuum unsupported -> uncaught setup error aborts pre-summary
+vtab1          # echo constructor over a PK (WITHOUT ROWID) table fails at vtab1-5.x; uncaught -> aborts pre-summary

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1873,3 +1873,64 @@ temptable2 temptable2-8.6  # sqlite3_backup_init: page-image backup unsupported 
 # round-trip all match stock).
 zeroblob zeroblob-1.1.1  # sqlite3_max_blobsize allocation metric (zeroblob materialized)
 zeroblob zeroblob-1.1.2  # memory-highwater bound assumes lazy zeroblob
+
+# echo-vtab cluster — the echo test module (src/test8.c) reads its backing
+# table via "SELECT rowid, * FROM <real-table>". Any echo vtab over a table
+# with a non-INTEGER PRIMARY KEY (stored WITHOUT ROWID, #1176 surface) fails
+# that internal query ("SQL logic error" / "vtable constructor failed"), and
+# the files' later assertions cascade off the poisoned setup. The vtab layer
+# itself is fine: echo over rowid tables passes throughout these files.
+tkt3871 tkt3871-1.1  # echo over PK table: internal SELECT rowid fails (WITHOUT ROWID)
+tkt3871 tkt3871-1.2  # cascade: echo vtab e unusable
+tkt3871 tkt3871-1.3  # cascade: echo vtab e unusable
+tkt3871 tkt3871-1.4  # cascade: echo vtab e unusable
+tkt3871 tkt3871-1.5  # cascade: echo vtab e unusable
+tkt3121 vtabD-1.2    # echo over r2(col PRIMARY KEY): internal SELECT rowid fails
+
+# vtab2-5.3 — UTF-16 + hex-encoded names: PRAGMA encoding ignored (#1164) so
+# the %C8/%C9 byte names decode differently and the "already exists" malformed
+# -schema reparse path never fires; the injected row reparses as a plain
+# missing module instead.
+vtab2 vtab2-5.3  # encoding-dependent corruption-injection error text (#1164)
+
+# vtab4 — treal(a PRIMARY KEY) is WITHOUT ROWID, so every echo read/write of
+# it hits the module's internal rowid query; 1.2's extra leading xConnect is
+# doltlite's post-DDL schema reload reconnecting the vtab. Everything after
+# 1.3 cascades (half-applied echo writes, empty callback logs, the real
+# UNIQUE message where stock saw "unknown error").
+vtab4 vtab4-1.2  # extra xConnect: schema reload reconnects the vtab
+vtab4 vtab4-1.3  # echo internal SELECT rowid fails (WITHOUT ROWID)
+vtab4 vtab4-1.4  # cascade
+vtab4 vtab4-2.1  # cascade
+vtab4 vtab4-2.2  # cascade
+vtab4 vtab4-2.3  # cascade
+vtab4 vtab4-2.4  # cascade
+vtab4 vtab4-2.5  # cascade
+vtab4 vtab4-2.6  # cascade
+vtab4 vtab4-2.7  # cascade
+vtab4 vtab4-3.1  # cascade: real UNIQUE message vs stock "unknown error"
+vtab4 vtab4-3.2  # cascade
+vtab4 vtab4-3.3  # cascade
+
+# vtabH-1.1 — extra leading xConnect (schema reload reconnects the vtab);
+# the xBestIndex/xFilter content matches stock.
+vtabH vtabH-1.1  # extra xConnect: schema reload reconnects the vtab
+
+# vtab_err — OOM fault injection over the echo module: doltlite's allocation
+# pattern shifts which fault points surface, so a handful of the 1927
+# injected runs settle differently. No leaks or crashes (file completes).
+vtab_err vtab_err-1.3.3              # OOM-recovery count differs under fault injection
+vtab_err vtab_err-2.transient.580    # fault-point shift
+vtab_err vtab_err-2.transient.714    # fault-point shift
+vtab_err vtab_err-2.transient.737    # fault-point shift
+vtab_err vtab_err-2.transient.738    # fault-point shift
+vtab_err vtab_err-2.persistent.737   # fault-point shift
+vtab_err vtab_err-2.persistent.738   # fault-point shift
+vtab_err vtab_err-3-oom-transient.437  # fault-point shift
+vtab_err vtab_err-3-oom-transient.438  # fault-point shift
+
+# vtabdrop-2.2/2.3 — sqlite_master enumeration omits the sqlite_autoindex_*
+# row for the fts shadow table's UNIQUE (the recorded no-autoindex-row class;
+# UNIQUE itself is enforced).
+vtabdrop vtabdrop-2.2  # no sqlite_autoindex row in sqlite_master enumeration
+vtabdrop vtabdrop-2.3  # no sqlite_autoindex row in sqlite_master enumeration


### PR DESCRIPTION
Completes the deferred echo-vtab family from the #1208 sweep (tkt3871/tkt3121 plus vtab1/vtab2/vtab4/vtabH/vtab_err/vtabdrop). One root mechanism, verified in the module source: **the echo test module reads its backing table via `SELECT rowid, * FROM <real-table>`** (src/test8.c:852), so any echo vtab over a non-INTEGER-PK table — which doltlite stores WITHOUT ROWID (#1176) — fails that internal query, and the rest of each file cascades off the poisoned setup. Echo over rowid tables passes throughout these same files, so the vtab layer itself is sound.

| File | Entries | Notes |
|---|---|---|
| tkt3871 | 5 | echo over `a PRIMARY KEY` table + cascades |
| tkt3121 | 1 | `vtabD-1.2`: echo over `col PRIMARY KEY` |
| vtab4 | 13 | same + cascades (half-applied echo writes, empty callback logs, real UNIQUE message vs stock "unknown error"); 1.2 = one extra leading `xConnect` from the post-DDL schema reload reconnecting the vtab |
| vtabH | 1 | extra leading `xConnect` only; xBestIndex/xFilter content matches |
| vtab2 | 1 | UTF-16 hex-name corruption injection; encoding ignored (#1164) so the malformed-schema path never fires |
| vtab_err | 9/1927 | OOM fault-point shifts; file completes, no crashes |
| vtabdrop | 2 | sqlite_master enumeration omits the `sqlite_autoindex` row (recorded class) |
| vtab1 | crash list | echo constructor over a PK table fails at vtab1-5.x, uncaught → aborts pre-summary |

Harness: all 7 gate OK (32 entries, none unused).

🤖 Generated with [Claude Code](https://claude.com/claude-code)