### PR TITLE
Feature-gap sweep wave 1: gate 4 clean files, crash-list 38 (#1208)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -229,6 +229,7 @@ jobs:
         bash ../test/run_testfixture.sh "SQLite regression" 300 \
           8_3_names aggerror aggfault alter3 alter4 altercol altercons altercons2 alterauth alterauth2 alterdropcol alterdropcol2 altertab3 alterlegacy altermalloc3 autoindex1 \
           index5 limit2 notnull \
+          corrupt5 corruptM rollback2 rollbackfault \
           savepoint7 \
           tkt3871 tkt3121 vtab2 vtab4 vtabH vtab_err vtabdrop \
           attach2 attach3 autoindex3 autoindex5 pragma6 rowvalue9 skipscan1 skipscan2 \

--- a/test/known_testfixture_crashes.txt
+++ b/test/known_testfixture_crashes.txt
@@ -92,3 +92,46 @@ tkt-5d863f876e # journal_mode unsupported -> setup aborts -> cascade
 tkt-fc62af4523 # journal_mode unsupported -> setup aborts -> cascade
 savepoint6     # auto_vacuum unsupported -> uncaught setup error aborts pre-summary
 vtab1          # echo constructor over a PK (WITHOUT ROWID) table fails at vtab1-5.x; uncaught -> aborts pre-summary
+
+# ── feature-gap sweep wave 1 (#1208): files whose setup aborts pre-summary on
+# an intentional rejection or a stock-only artifact. Reasons captured from a
+# per-file non-root run.
+autovacuum       # auto_vacuum unsupported -> uncaught setup error
+corrupt2         # auto_vacuum unsupported -> uncaught setup error
+e_vacuum         # auto_vacuum unsupported -> uncaught setup error
+incrvacuum       # auto_vacuum unsupported -> uncaught setup error
+incrvacuum3      # auto_vacuum unsupported -> uncaught setup error
+incrvacuum_ioerr # auto_vacuum unsupported -> uncaught setup error
+ioerr4           # auto_vacuum unsupported -> uncaught setup error
+mallocC          # auto_vacuum unsupported -> uncaught setup error
+mmap1            # auto_vacuum unsupported -> uncaught setup error
+vacuum3          # auto_vacuum unsupported -> uncaught setup error
+pager2           # journal_mode not configurable -> uncaught setup error
+pagerfault       # journal_mode not configurable -> uncaught setup error
+pagerfault2      # journal_mode not configurable -> uncaught setup error
+wal6             # journal_mode not configurable -> uncaught setup error
+walnoshm         # journal_mode not configurable -> uncaught setup error
+wal              # reads test.db-wal: doltlite has no -wal sidecar
+wal2             # wal helper reads ::filename of the -wal sidecar
+walbak           # reads test.db-wal: no -wal sidecar
+walcksum         # copies test.db-wal: no -wal sidecar
+waloverwrite     # copies test.db-wal: no -wal sidecar
+walslow          # copies test.db-wal: no -wal sidecar
+walvfs           # reads test.db-wal: no -wal sidecar
+lock5            # copies test.db-journal: no rollback-journal sidecar
+rollback         # copies test.db-journal: no rollback-journal sidecar
+bigfile2         # corruption injection: chunk store reports malformed, file aborts
+corrupt          # corruption injection: chunk store reports malformed, file aborts
+corrupt4         # corruption injection: "file is not a database" aborts the file
+corruptC         # corruption-injection cascade: setup table never created
+corruptI         # corruption injection: chunk store reports malformed, file aborts
+multiplex2       # multiplex VFS on chunk store: disk I/O error aborts setup
+incrblob         # incrblob API on a PK (WITHOUT ROWID) table: "cannot open table without rowid"
+pager1           # journal/txn-model cascade: "cannot commit - no transaction is active"
+backup           # sqlite3_backup_init: page-image backup unsupported
+mallocAll        # failed open -> "db" command never created (test-harness footgun)
+walthread        # multi-threaded WAL stress: nondeterministic class (same as thread*)
+win32heap        # windows-only: silent platform return, no summary line
+win32lock        # windows-only: silent platform return, no summary line
+win32longpath    # windows-only: silent platform return, no summary line
+win32nolock      # windows-only: silent platform return, no summary line


### PR DESCRIPTION
First wave from the per-file classification of the feature-gap families (154 files, each run non-root in a clean working dir; reasons captured from actual output, not inferred).

### Gated clean (0 divergences)
`corrupt5`, `corruptM`, `rollback2`, `rollbackfault` — harness `OK` with no entries.

### Crash-listed (38, with captured reasons)
- **auto_vacuum rejections (10)**: autovacuum, corrupt2, e_vacuum, incrvacuum, incrvacuum3, incrvacuum_ioerr, ioerr4, mallocC, mmap1, vacuum3 — the intentional `auto_vacuum is not supported` error is uncaught at setup.
- **journal_mode rejections (5)**: pager2, pagerfault, pagerfault2, wal6, walnoshm.
- **missing sidecar files (9)**: wal, wal2, walbak, walcksum, waloverwrite, walslow, walvfs (no `-wal`), lock5, rollback (no `-journal`) — the tests copy/read stock's sidecar files, which doltlite doesn't produce.
- **corruption injection (5)**: bigfile2, corrupt, corruptI (chunk store reports malformed → file aborts), corrupt4 ("file is not a database"), corruptC (setup cascade).
- **singles**: incrblob (`cannot open table without rowid` — stock's own incrblob restriction hitting the #1176 surface), pager1 (txn-model cascade), backup (page-image backup API), mallocAll (failed-open → `db` command never created, known harness footgun), walthread (multi-threaded nondeterministic class, same as thread*), win32heap/win32lock/win32longpath/win32nolock (windows-only; silent return → no summary on unix).

### Held back for later waves
- `readonly`: 0 errors in a clean dir but fails 1.1/1.2 on leftover state — its directory assumptions need a look before gating.
- 19 timeout-or-silent files (corrupt9, dbstatus, e_walauto, ioerr2, lock4, malloc3, shmlock, wal3, walbig, walro2, walsetlk…) — need longer-probe classification (likely the #1283 slow bucket).
- ~95 completed files with 1–1000 recordable divergences — per-assertion capture in the next waves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)