### PR TITLE
Fix all build warnings

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -155,14 +155,21 @@ jobs:
       if: matrix.platform == 'ubuntu'
       run: |
         cd build
-        make DOLTLITE_PROLLY_CHECK=1 doltlite
-        make DOLTLITE_PROLLY_CHECK=1 doltlite-lib
+        set -o pipefail
+        {
+          make DOLTLITE_PROLLY_CHECK=1 doltlite
+          make DOLTLITE_PROLLY_CHECK=1 doltlite-lib
+          # doltlite_parity.sh compares against the package-built stock
+          # SQLite CLI instead of whatever sqlite3 the runner image provides.
+          make DOLTLITE_PROLLY=0 sqlite3
+          # Stock SQLite lib for concurrent_branch_test
+          make libsqlite3.a USE_AMALGAMATION=0
+        } 2>&1 | tee build.log
         DOLTLITE_CHECK_AMALGAMATION=0 bash ../test/assert_doltlite_artifacts.sh .
-        # doltlite_parity.sh compares against the package-built stock
-        # SQLite CLI instead of whatever sqlite3 the runner image provides.
-        make DOLTLITE_PROLLY=0 sqlite3
-        # Stock SQLite lib for concurrent_branch_test
-        make libsqlite3.a USE_AMALGAMATION=0
+        if grep -E "warning:" build.log; then
+          echo "::error::compiler warnings in the build (see above); the build must be warning-free"
+          exit 1
+        fi
 
     - name: Build Windows
       if: matrix.platform == 'windows'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -214,7 +214,12 @@ jobs:
     - name: Build testfixture
       run: |
         cd build
-        make DOLTLITE_PROLLY_CHECK=1 testfixture
+        set -o pipefail
+        make DOLTLITE_PROLLY_CHECK=1 testfixture 2>&1 | tee build.log
+        if grep -E "warning:" build.log; then
+          echo "::error::compiler warnings in the build (see above); the build must be warning-free"
+          exit 1
+        fi
 
     # Inherited upstream SQLite .test files that pass clean (or only with
     # already-recorded divergences) against doltlite. Swept and gated under

--- a/ext/blake3/blake3.c
+++ b/ext/blake3/blake3.c
@@ -1,3 +1,8 @@
+#if defined(__GNUC__)
+/* Vendored blake3 uses C99 mid-block declarations; keep its style. */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeclaration-after-statement"
+#endif
 /* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR CC0-1.0
 **
 ** Vendored verbatim from https://github.com/BLAKE3-team/BLAKE3 (1.8.5).
@@ -439,3 +444,6 @@ void blake3_hasher_reset(blake3_hasher *self) {
   chunk_state_reset(&self->chunk, self->key, 0);
   self->cv_stack_len = 0;
 }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif

--- a/ext/blake3/blake3_dispatch.c
+++ b/ext/blake3/blake3_dispatch.c
@@ -1,3 +1,8 @@
+#if defined(__GNUC__)
+/* Vendored blake3 uses C99 mid-block declarations; keep its style. */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeclaration-after-statement"
+#endif
 /* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR CC0-1.0
 **
 ** Vendored verbatim from https://github.com/BLAKE3-team/BLAKE3 (1.8.5).
@@ -341,3 +346,6 @@ size_t blake3_simd_degree(void) {
 #endif
   return 1;
 }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif

--- a/ext/blake3/blake3_impl.h
+++ b/ext/blake3/blake3_impl.h
@@ -31,6 +31,10 @@ enum blake3_flags {
 
 // This C implementation tries to support recent versions of GCC, Clang, and
 // MSVC.
+#ifdef INLINE
+/* tcl.h defines an empty INLINE; blake3 needs its own. */
+#undef INLINE
+#endif
 #if defined(_MSC_VER)
 #define INLINE static __forceinline
 #else

--- a/ext/blake3/blake3_portable.c
+++ b/ext/blake3/blake3_portable.c
@@ -1,3 +1,8 @@
+#if defined(__GNUC__)
+/* Vendored blake3 uses C99 mid-block declarations; keep its style. */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeclaration-after-statement"
+#endif
 /* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR CC0-1.0
 **
 ** Vendored verbatim from https://github.com/BLAKE3-team/BLAKE3 (1.8.5).
@@ -160,3 +165,6 @@ void blake3_hash_many_portable(const uint8_t *const *inputs, size_t num_inputs,
     out = &out[BLAKE3_OUT_LEN];
   }
 }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif

--- a/src/btmutex.c
+++ b/src/btmutex.c
@@ -189,7 +189,7 @@ static void SQLITE_NOINLINE btreeEnterAll(sqlite3 *db){
   Btree *p;
   assert( sqlite3_mutex_held(db->mutex) );
   for(i=0; i<db->nDb; i++){
-    p = db->aDb[i].pBt;
+    p = (void*)db->aDb[i].pBt;
     if( p && p->sharable ){
       sqlite3BtreeEnter(p);
       skipOk = 0;
@@ -205,7 +205,7 @@ static void SQLITE_NOINLINE btreeLeaveAll(sqlite3 *db){
   Btree *p;
   assert( sqlite3_mutex_held(db->mutex) );
   for(i=0; i<db->nDb; i++){
-    p = db->aDb[i].pBt;
+    p = (void*)db->aDb[i].pBt;
     if( p ) sqlite3BtreeLeave(p);
   }
 }
@@ -227,7 +227,7 @@ int sqlite3BtreeHoldsAllMutexes(sqlite3 *db){
   }
   for(i=0; i<db->nDb; i++){
     Btree *p;
-    p = db->aDb[i].pBt;
+    p = (void*)db->aDb[i].pBt;
     if( p && p->sharable &&
          (p->wantToLock==0 || !sqlite3_mutex_held(p->pBt->mutex)) ){
       return 0;
@@ -280,7 +280,7 @@ void sqlite3BtreeEnter(Btree *p){
 void sqlite3BtreeEnterAll(sqlite3 *db){
   int i;
   for(i=0; i<db->nDb; i++){
-    Btree *p = db->aDb[i].pBt;
+    Btree *p = (void*)db->aDb[i].pBt;
     if( p ){
       p->pBt->db = p->db;
     }

--- a/src/btree.c
+++ b/src/btree.c
@@ -2636,7 +2636,7 @@ int sqlite3BtreeOpen(
                  && sqlite3PagerVfs(pBt->pPager)==pVfs ){
           int iDb;
           for(iDb=db->nDb-1; iDb>=0; iDb--){
-            Btree *pExisting = db->aDb[iDb].pBt;
+            Btree *pExisting = (void*)db->aDb[iDb].pBt;
             if( pExisting && pExisting->pBt==pBt ){
               sqlite3_mutex_leave(mutexShared);
               sqlite3_mutex_leave(mutexOpen);
@@ -2774,7 +2774,7 @@ int sqlite3BtreeOpen(
     int i;
     Btree *pSib;
     for(i=0; i<db->nDb; i++){
-      if( (pSib = db->aDb[i].pBt)!=0 && pSib->sharable ){
+      if( (pSib = (void*)db->aDb[i].pBt)!=0 && pSib->sharable ){
         while( pSib->pPrev ){ pSib = pSib->pPrev; }
         if( (uptr)p->pBt<(uptr)pSib->pBt ){
           p->pNext = pSib;
@@ -4246,7 +4246,7 @@ static int autoVacuumCommit(Btree *p){
     if( db->xAutovacPages ){
       int iDb;
       for(iDb=0; ALWAYS(iDb<db->nDb); iDb++){
-        if( db->aDb[iDb].pBt==p ) break;
+        if( (void*)db->aDb[iDb].pBt==(void*)p ) break;
       }
       nVac = db->xAutovacPages(
         db->pAutovacPagesArg,


### PR DESCRIPTION
Master's build emitted 21 warnings; all three build modes (amalgamation testfixture, object `doltlite`, stock-mode `sqlite3`) now compile with **zero**.

| Class | Count | Fix |
|---|---|---|
| `"INLINE" redefined` | 1 | `tcl.h` defines an empty `INLINE`; the testfixture amalgamation includes it before vendored blake3, whose definition then redefines it. `#undef` first — blake3's definition was already the one in effect, so no behavior change. |
| `declaration-after-statement` | 15 | Vendored blake3's C99 mid-block declarations under sqlite's C89 flags. The object build already suppressed this via `BLAKE3_CFLAGS`; the amalgamation didn't. Push/pop the diagnostic around the two vendored `.c` files rather than restyling third-party code. |
| `orig_Btree` pointer mismatches | 5 | Stock `btree.c`/`btmutex.c` compiled under the `orig_` rename read `db->aDb[i].pBt`, which holds the doltlite `Btree`. Bridged through `(void*)` so both rename modes compile silently. |

Verified: zero warnings in all three modes; select1/index/where/blob/fkey2/tkt3718 match master; `dolt_commit`/`dolt_hashof_table` smoke produces the expected hashes (blake3 untouched functionally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)