### PR TITLE
Fix FTS3 OOM schema rollback

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -576,6 +576,17 @@ static SQLITE_INLINE void cacheCurrentTreePayloadIfIntKey(BtCursor *pCur){
   }
 }
 
+static int isDegenerateSchemaPayload(const u8 *pVal, int nVal){
+  return nVal==6
+      && pVal
+      && pVal[0]==6
+      && pVal[1]==0
+      && pVal[2]==0
+      && pVal[3]==0
+      && pVal[4]==0
+      && pVal[5]==0;
+}
+
 static int cursorOnDegenerateSchemaRow(BtCursor *pCur, int *pIsDegenerate){
   const u8 *pVal;
   int nVal;
@@ -590,14 +601,7 @@ static int cursorOnDegenerateSchemaRow(BtCursor *pCur, int *pIsDegenerate){
     return SQLITE_OK;
   }
   if( pCur->pBtree->bFilterSchemaPlaceholders
-   && nVal==6
-   && pVal[0]==6
-   && pVal[1]==0
-   && pVal[2]==0
-   && pVal[3]==0
-   && pVal[4]==0
-   && pVal[5]==0
-  ){
+   && isDegenerateSchemaPayload(pVal, nVal) ){
     *pIsDegenerate = 1;
   }
   return SQLITE_OK;
@@ -5505,6 +5509,10 @@ static int restoreFromCommitted(Btree *p){
 static int prollyBtreeRollback(Btree *p, int tripCode, int writeOnly){
   BtShared *pBt = p->pBt;
   int rc = SQLITE_OK;
+  int bAutocommitOomRollback = writeOnly
+      && p->db
+      && p->db->autoCommit
+      && p->db->mallocFailed;
 
   if( pBt->inCatalogSerialize ) return SQLITE_OK;
 
@@ -5559,7 +5567,12 @@ static int prollyBtreeRollback(Btree *p, int tripCode, int writeOnly){
     }
     resetConnectionSchema(p);
     chunkStoreRollback(&pBt->store);
-    {
+    if( bAutocommitOomRollback ){
+      p->bFilterSchemaPlaceholders = 1;
+    }
+    /* Autocommit OOM rollback restores in-memory state only. Persisting the
+    ** restored catalog here can make a failed DDL attempt the new baseline. */
+    if( !bAutocommitOomRollback ){
       u8 *catData = 0;
       int nCatData = 0;
       ProllyHash catHash;
@@ -5742,7 +5755,7 @@ static int rollbackNamedSavepoint(Btree *p, BtShared *pBt, int iSavepoint){
 
   rc = rollbackMutMapsToSavepoint(p, iSavepoint + 1, iSavepoint);
   if( rc!=SQLITE_OK ) return rc;
-  if( pState->aTables ){
+  if( pState->bTablesCaptured ){
     rc = restoreTablesFromSavepoint(p, pState);
     if( rc!=SQLITE_OK ) return rc;
   }

--- a/test/doltlite_fts3_oom.test
+++ b/test/doltlite_fts3_oom.test
@@ -199,5 +199,56 @@ do_test doltlite_fts3_oom-3.3 {
   set bad
 } {ok}
 
+do_test doltlite_fts3_oom-3.4 {
+  forcedelete test4.db
+  sqlite3 db4 test4.db
+  sqlite3_db_config_lookaside db4 0 0 0
+
+  db4 eval "SELECT * FROM sqlite_master" V break
+  set cksumsql "SELECT md5sum([join [concat rowid $V(*)] ,]) FROM sqlite_master"
+  set cksum1 [db4 one $cksumsql]
+
+  set bad ok
+  set created 0
+  for {set iFail 1} {$iFail<=100 && $bad=="ok"} {incr iFail} {
+    sqlite3_memdebug_fail $iFail -repeat 100000
+    set res [catchsql {
+      CREATE VIRTUAL TABLE ft1 USING fts3(a, b)
+    } db4]
+    set nFail [sqlite3_memdebug_fail -1 -benigncnt nBenign]
+    set q2 [catch {db4 one $cksumsql} cksum2]
+    set schema [catchsql {
+      SELECT rowid,type,name,tbl_name,rootpage,sql
+        FROM sqlite_master ORDER BY rowid
+    } db4]
+    if {$nFail==0} {
+      if {$res!="0 {}"} {
+        set bad [list $iFail $res $nFail]
+      }
+      set created 1
+      break
+    }
+    if {$res!="1 {out of memory}"
+     || $q2
+     || $cksum1 ne $cksum2
+     || $schema!="0 {}"
+    } {
+      set bad [list $iFail $res $nFail $q2 $cksum1 $cksum2 $schema]
+    }
+  }
+  if {$bad=="ok" && !$created} {
+    set res [catchsql {
+      CREATE VIRTUAL TABLE ft1 USING fts3(a, b)
+    } db4]
+    if {$res!="0 {}"} {
+      set bad [list final $res]
+    }
+  }
+  set drop [catchsql {DROP TABLE ft1} db4]
+  catch {db4 close}
+  forcedelete test4.db
+  list $bad $drop
+} {ok {0 {}}}
+
 sqlite3_memdebug_fail -1
 finish_test


### PR DESCRIPTION
## Summary
- avoid persisting restored catalog state during write-only rollback, which could make a failed DDL attempt the new in-memory baseline
- enable filtering of SQLite's transient all-NULL schema placeholder only after OOM rollback
- add a focused FTS3 OOM regression covering repeated failed CREATE VIRTUAL TABLE attempts followed by a successful create/drop on the same connection

## Tests
- `./testfixture ../test/doltlite_fts3_oom.test`
- `./testfixture ../test/fts3malloc.test` (now reaches section 5; remaining failures: `fts3_malloc-2.1.transient.100000.18`, `fts3_malloc-4.2`)
- `./test/vc_oracle_blame_test.sh ./build-master-fts3oom-ci/doltlite dolt`
- `DOLTLITE=./build-master-fts3oom-ci/doltlite bash test/doltlite_gc_scale.sh`