### PR TITLE
Feature-gap sweep wave 2: gate 38 files, 108 entries (#1208)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -155,14 +155,21 @@ jobs:
       if: matrix.platform == 'ubuntu'
       run: |
         cd build
-        make DOLTLITE_PROLLY_CHECK=1 doltlite
-        make DOLTLITE_PROLLY_CHECK=1 doltlite-lib
+        set -o pipefail
+        {
+          make DOLTLITE_PROLLY_CHECK=1 doltlite
+          make DOLTLITE_PROLLY_CHECK=1 doltlite-lib
+          # doltlite_parity.sh compares against the package-built stock
+          # SQLite CLI instead of whatever sqlite3 the runner image provides.
+          make DOLTLITE_PROLLY=0 sqlite3
+          # Stock SQLite lib for concurrent_branch_test
+          make libsqlite3.a USE_AMALGAMATION=0
+        } 2>&1 | tee build.log
         DOLTLITE_CHECK_AMALGAMATION=0 bash ../test/assert_doltlite_artifacts.sh .
-        # doltlite_parity.sh compares against the package-built stock
-        # SQLite CLI instead of whatever sqlite3 the runner image provides.
-        make DOLTLITE_PROLLY=0 sqlite3
-        # Stock SQLite lib for concurrent_branch_test
-        make libsqlite3.a USE_AMALGAMATION=0
+        if grep -E "warning:" build.log; then
+          echo "::error::compiler warnings in the build (see above); the build must be warning-free"
+          exit 1
+        fi
 
     - name: Build Windows
       if: matrix.platform == 'windows'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -235,6 +235,10 @@ jobs:
           8_3_names aggerror aggfault alter3 alter4 altercol altercons altercons2 alterauth alterauth2 alterdropcol alterdropcol2 altertab3 alterlegacy altermalloc3 autoindex1 \
           index5 limit2 notnull \
           corrupt5 corruptM rollback2 rollbackfault \
+          autovacuum2 backup5 bigfile busy corrupt7 corruptA corruptD corruptG corruptH corruptJ \
+          incrblob3 incrblobfault journal1 lock lock2 lock3 lock7 mallocD mallocF mallocK \
+          memdb memjournal mmapcorrupt mmapwarm oserror pager3 rdonly shared7 sharedlock unixexcl \
+          vacuum4 vacuum6 wal64k wal9 walprotocol2 walrestart walseh1 walshared \
           savepoint7 \
           tkt3871 tkt3121 vtab2 vtab4 vtabH vtab_err vtabdrop \
           attach2 attach3 autoindex3 autoindex5 pragma6 rowvalue9 skipscan1 skipscan2 \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -214,7 +214,12 @@ jobs:
     - name: Build testfixture
       run: |
         cd build
-        make DOLTLITE_PROLLY_CHECK=1 testfixture
+        set -o pipefail
+        make DOLTLITE_PROLLY_CHECK=1 testfixture 2>&1 | tee build.log
+        if grep -E "warning:" build.log; then
+          echo "::error::compiler warnings in the build (see above); the build must be warning-free"
+          exit 1
+        fi
 
     # Inherited upstream SQLite .test files that pass clean (or only with
     # already-recorded divergences) against doltlite. Swept and gated under

--- a/ext/blake3/blake3.c
+++ b/ext/blake3/blake3.c
@@ -1,3 +1,8 @@
+#if defined(__GNUC__)
+/* Vendored blake3 uses C99 mid-block declarations; keep its style. */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeclaration-after-statement"
+#endif
 /* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR CC0-1.0
 **
 ** Vendored verbatim from https://github.com/BLAKE3-team/BLAKE3 (1.8.5).
@@ -439,3 +444,6 @@ void blake3_hasher_reset(blake3_hasher *self) {
   chunk_state_reset(&self->chunk, self->key, 0);
   self->cv_stack_len = 0;
 }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif

--- a/ext/blake3/blake3_dispatch.c
+++ b/ext/blake3/blake3_dispatch.c
@@ -1,3 +1,8 @@
+#if defined(__GNUC__)
+/* Vendored blake3 uses C99 mid-block declarations; keep its style. */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeclaration-after-statement"
+#endif
 /* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR CC0-1.0
 **
 ** Vendored verbatim from https://github.com/BLAKE3-team/BLAKE3 (1.8.5).
@@ -341,3 +346,6 @@ size_t blake3_simd_degree(void) {
 #endif
   return 1;
 }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif

--- a/ext/blake3/blake3_impl.h
+++ b/ext/blake3/blake3_impl.h
@@ -31,6 +31,10 @@ enum blake3_flags {
 
 // This C implementation tries to support recent versions of GCC, Clang, and
 // MSVC.
+#ifdef INLINE
+/* tcl.h defines an empty INLINE; blake3 needs its own. */
+#undef INLINE
+#endif
 #if defined(_MSC_VER)
 #define INLINE static __forceinline
 #else

--- a/ext/blake3/blake3_portable.c
+++ b/ext/blake3/blake3_portable.c
@@ -1,3 +1,8 @@
+#if defined(__GNUC__)
+/* Vendored blake3 uses C99 mid-block declarations; keep its style. */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeclaration-after-statement"
+#endif
 /* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception OR CC0-1.0
 **
 ** Vendored verbatim from https://github.com/BLAKE3-team/BLAKE3 (1.8.5).
@@ -160,3 +165,6 @@ void blake3_hash_many_portable(const uint8_t *const *inputs, size_t num_inputs,
     out = &out[BLAKE3_OUT_LEN];
   }
 }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif

--- a/src/btmutex.c
+++ b/src/btmutex.c
@@ -189,7 +189,7 @@ static void SQLITE_NOINLINE btreeEnterAll(sqlite3 *db){
   Btree *p;
   assert( sqlite3_mutex_held(db->mutex) );
   for(i=0; i<db->nDb; i++){
-    p = db->aDb[i].pBt;
+    p = (void*)db->aDb[i].pBt;
     if( p && p->sharable ){
       sqlite3BtreeEnter(p);
       skipOk = 0;
@@ -205,7 +205,7 @@ static void SQLITE_NOINLINE btreeLeaveAll(sqlite3 *db){
   Btree *p;
   assert( sqlite3_mutex_held(db->mutex) );
   for(i=0; i<db->nDb; i++){
-    p = db->aDb[i].pBt;
+    p = (void*)db->aDb[i].pBt;
     if( p ) sqlite3BtreeLeave(p);
   }
 }
@@ -227,7 +227,7 @@ int sqlite3BtreeHoldsAllMutexes(sqlite3 *db){
   }
   for(i=0; i<db->nDb; i++){
     Btree *p;
-    p = db->aDb[i].pBt;
+    p = (void*)db->aDb[i].pBt;
     if( p && p->sharable &&
          (p->wantToLock==0 || !sqlite3_mutex_held(p->pBt->mutex)) ){
       return 0;
@@ -280,7 +280,7 @@ void sqlite3BtreeEnter(Btree *p){
 void sqlite3BtreeEnterAll(sqlite3 *db){
   int i;
   for(i=0; i<db->nDb; i++){
-    Btree *p = db->aDb[i].pBt;
+    Btree *p = (void*)db->aDb[i].pBt;
     if( p ){
       p->pBt->db = p->db;
     }

--- a/src/btree.c
+++ b/src/btree.c
@@ -2636,7 +2636,7 @@ int sqlite3BtreeOpen(
                  && sqlite3PagerVfs(pBt->pPager)==pVfs ){
           int iDb;
           for(iDb=db->nDb-1; iDb>=0; iDb--){
-            Btree *pExisting = db->aDb[iDb].pBt;
+            Btree *pExisting = (void*)db->aDb[iDb].pBt;
             if( pExisting && pExisting->pBt==pBt ){
               sqlite3_mutex_leave(mutexShared);
               sqlite3_mutex_leave(mutexOpen);
@@ -2774,7 +2774,7 @@ int sqlite3BtreeOpen(
     int i;
     Btree *pSib;
     for(i=0; i<db->nDb; i++){
-      if( (pSib = db->aDb[i].pBt)!=0 && pSib->sharable ){
+      if( (pSib = (void*)db->aDb[i].pBt)!=0 && pSib->sharable ){
         while( pSib->pPrev ){ pSib = pSib->pPrev; }
         if( (uptr)p->pBt<(uptr)pSib->pBt ){
           p->pNext = pSib;
@@ -4246,7 +4246,7 @@ static int autoVacuumCommit(Btree *p){
     if( db->xAutovacPages ){
       int iDb;
       for(iDb=0; ALWAYS(iDb<db->nDb); iDb++){
-        if( db->aDb[iDb].pBt==p ) break;
+        if( (void*)db->aDb[iDb].pBt==(void*)p ) break;
       }
       nVac = db->xAutovacPages(
         db->pAutovacPagesArg,

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1937,3 +1937,115 @@ vtab_err vtab_err-3-oom-transient.438  # fault-point shift
 # UNIQUE itself is enforced).
 vtabdrop vtabdrop-2.2  # no sqlite_autoindex row in sqlite_master enumeration
 vtabdrop vtabdrop-2.3  # no sqlite_autoindex row in sqlite_master enumeration
+
+# -- feature-gap sweep wave 2 (#1208): 38 completing files, every failing
+# assertion reproduced and its mechanism verified (rejection message, header
+# offset, sidecar absence, snapshot-concurrency contract, or fault shift).
+autovacuum2 autovacuum2-1.0  # auto_vacuum pragma rejected; freelist/page metrics + cascade
+autovacuum2 autovacuum2-1.1  # auto_vacuum pragma rejected; freelist/page metrics + cascade
+autovacuum2 autovacuum2-1.3  # auto_vacuum pragma rejected; freelist/page metrics + cascade
+autovacuum2 autovacuum2-1.4  # auto_vacuum pragma rejected; freelist/page metrics + cascade
+autovacuum2 autovacuum2-1.20  # auto_vacuum pragma rejected; freelist/page metrics + cascade
+backup5 backup5-1.3  # backup proceeds without the destination-in-use refusal; result verified correct
+backup5 backup5-1.4  # backup proceeds without the destination-in-use refusal; result verified correct
+bigfile bigfile-1.2  # fake_big_file + stock header poke at offset 28 corrupts the checksummed store
+busy busy-2.1  # snapshot concurrency: reader does not block the commit, busy handler never fires
+busy busy-2.2  # snapshot concurrency: reader does not block the commit, busy handler never fires
+busy busy-3.5  # snapshot concurrency: reader does not block the commit, busy handler never fires
+busy busy-3.7  # snapshot concurrency: reader does not block the commit, busy handler never fires
+corrupt7 corrupt7-1.1  # stock-page corruption injection: offsets land outside chunk-store structures
+corrupt7 corrupt7-1.2  # stock-page corruption injection: offsets land outside chunk-store structures
+corrupt7 corrupt7-2.1  # stock-page corruption injection: offsets land outside chunk-store structures
+corrupt7 corrupt7-2.2  # stock-page corruption injection: offsets land outside chunk-store structures
+corruptA corruptA-2.1  # stock header corruption at offsets the chunk store does not use
+corruptA corruptA-2.2  # stock header corruption at offsets the chunk store does not use
+corruptA corruptA-2.3  # stock header corruption at offsets the chunk store does not use
+corruptA corruptA-2.4  # stock header corruption at offsets the chunk store does not use
+corruptD corruptD-1.1.1  # stock cell-pointer corruption not applicable to chunk store
+corruptD corruptD-1.1.2  # stock cell-pointer corruption not applicable to chunk store
+corruptG corruptG-1.2  # stock header corruption: store rejects differently or misses the offset
+corruptG corruptG-1.3  # stock header corruption: store rejects differently or misses the offset
+corruptG corruptG-1.4  # stock header corruption: store rejects differently or misses the offset
+corruptG corruptG-2.1  # stock header corruption: store rejects differently or misses the offset
+corruptH corruptH-1.3  # stock-page corruption injection; offset misses + harness footgun cascade
+corruptH corruptH-2.2  # stock-page corruption injection; offset misses + harness footgun cascade
+corruptH corruptH-2.3  # stock-page corruption injection; offset misses + harness footgun cascade
+corruptH corruptH-3.3  # stock-page corruption injection; offset misses + harness footgun cascade
+corruptJ corruptJ-1.2  # stock-page corruption injection; hexio dump reads chunk-store bytes
+corruptJ corruptJ-2.2  # stock-page corruption injection; hexio dump reads chunk-store bytes
+corruptJ corruptJ-2.2b  # stock-page corruption injection; hexio dump reads chunk-store bytes
+incrblob3 incrblob3-7.2  # stock schema-cookie poke at offsets 40/24 corrupts the checksummed store
+incrblobfault incrblobfault-3-ioerr-persistent.2  # IO-fault point shift under fault injection
+incrblobfault incrblobfault-3-ioerr-persistent.3  # IO-fault point shift under fault injection
+incrblobfault incrblobfault-3-ioerr-transient.2  # IO-fault point shift under fault injection
+incrblobfault incrblobfault-3-ioerr-transient.3  # IO-fault point shift under fault injection
+journal1 journal1-1.2  # copies test.db-journal: no rollback-journal sidecar
+lock lock-2.3.2  # locking model: snapshot reads proceed; lock_status reports doltlite states; journal_mode cascade
+lock lock-2.4.2  # locking model: snapshot reads proceed; lock_status reports doltlite states; journal_mode cascade
+lock lock-7.2  # locking model: snapshot reads proceed; lock_status reports doltlite states; journal_mode cascade
+lock lock-7.3  # locking model: snapshot reads proceed; lock_status reports doltlite states; journal_mode cascade
+lock2 lock2-1.5  # locking model: schema read not blocked by writer; commit-state cascade
+lock2 lock2-1.7  # locking model: schema read not blocked by writer; commit-state cascade
+lock2 lock2-1.8  # locking model: schema read not blocked by writer; commit-state cascade
+lock3 lock3-4.1  # locking model: read proceeds where stock blocks
+lock7 lock7-1.6  # PRAGMA lock_status reports doltlite locking model
+mallocD mallocD-4.transient.98  # OOM fault-point shift under fault injection
+mallocD mallocD-4.transient.101  # OOM fault-point shift under fault injection
+mallocD mallocD-4.transient.111  # OOM fault-point shift under fault injection
+mallocD mallocD-4.transient.420  # OOM fault-point shift under fault injection
+mallocD mallocD-4.persistent.420  # OOM fault-point shift under fault injection
+mallocF malloeF-3.transient.36  # OOM fault-point shift under fault injection
+mallocF malloeF-3.transient.37  # OOM fault-point shift under fault injection
+mallocF malloeF-3.transient.38  # OOM fault-point shift under fault injection
+mallocF malloeF-3.transient.39  # OOM fault-point shift under fault injection
+mallocK mallocK-6.0  # custom collation utf16_aligned explicitly rejected
+memdb memdb-6.12  # rowid on composite-PK (WITHOUT ROWID) table; auto_vacuum rejected
+memdb memdb-9.1  # rowid on composite-PK (WITHOUT ROWID) table; auto_vacuum rejected
+memjournal memjournal-1.0  # journal_mode pragma rejected + cascade
+memjournal memjournal-1.1  # journal_mode pragma rejected + cascade
+memjournal memjournal-1.2  # journal_mode pragma rejected + cascade
+mmapcorrupt mmapcorrupt-2.1  # mmap stock-page corruption: offset misses chunk-store structures
+mmapwarm mmapwarm-1.0  # PRAGMA page_count: chunk store has no SQLite page count
+oserror oserror-1.2.1  # open-path differs: lock-file opened first; no -wal to unlink
+oserror oserror-1.3.1  # open-path differs: lock-file opened first; no -wal to unlink
+oserror oserror-1.3.2  # open-path differs: lock-file opened first; no -wal to unlink
+oserror oserror-2.1.1  # open-path differs: lock-file opened first; no -wal to unlink
+oserror oserror-2.1.2  # open-path differs: lock-file opened first; no -wal to unlink
+pager3 pager3-1.1.1  # journal-file existence probes; journal_mode rejected
+pager3 pager3-1.4.2  # journal-file existence probes; journal_mode rejected
+pager3 pager3-1.5.2  # journal-file existence probes; journal_mode rejected
+rdonly rdonly-1.2  # stock write-version header byte poke (offset 18) has no doltlite meaning; cascade
+rdonly rdonly-1.3.1  # stock write-version header byte poke (offset 18) has no doltlite meaning; cascade
+rdonly rdonly-1.4  # stock write-version header byte poke (offset 18) has no doltlite meaning; cascade
+rdonly rdonly-1.5  # stock write-version header byte poke (offset 18) has no doltlite meaning; cascade
+rdonly rdonly-1.6  # stock write-version header byte poke (offset 18) has no doltlite meaning; cascade
+shared7 shared7-1.1  # shared-cache ATTACH restrictions not applicable
+shared7 shared7-1.2  # shared-cache ATTACH restrictions not applicable
+shared7 shared7-1.3  # shared-cache ATTACH restrictions not applicable
+shared7 shared7-1.4  # shared-cache ATTACH restrictions not applicable
+sharedlock sharedlock-2.4  # shared-cache table lock not raised; snapshot read proceeds
+unixexcl unixexcl-1.1.4.multiproc  # multiproc locking model; wal_checkpoint frame counters zero (no-op checkpoint); data assertions pass
+unixexcl unixexcl-3.1.1.multiproc  # multiproc locking model; wal_checkpoint frame counters zero (no-op checkpoint); data assertions pass
+unixexcl unixexcl-3.2.3  # multiproc locking model; wal_checkpoint frame counters zero (no-op checkpoint); data assertions pass
+unixexcl unixexcl-3.2.7  # multiproc locking model; wal_checkpoint frame counters zero (no-op checkpoint); data assertions pass
+vacuum4 vacuum4-1.1  # auto_vacuum pragma rejected + cascade
+vacuum6 vacuum6-4.1.2.1  # auto_vacuum pragma rejected + cascade
+vacuum6 vacuum6-4.1.4.1  # auto_vacuum pragma rejected + cascade
+vacuum6 vacuum6-4.1.6.1  # auto_vacuum pragma rejected + cascade
+wal64k wal64k-1.1  # reads test.db-shm: no shm sidecar
+wal64k wal64k-1.2  # reads test.db-shm: no shm sidecar
+wal9 wal9-1.3  # file-size metric + missing -wal/-shm sidecars
+wal9 wal9-1.4  # file-size metric + missing -wal/-shm sidecars
+wal9 wal9-1.5  # file-size metric + missing -wal/-shm sidecars
+wal9 wal9-1.6  # file-size metric + missing -wal/-shm sidecars
+walprotocol2 walprotocol2-2.2  # WAL locking protocol: busy not raised; txn-state cascade
+walprotocol2 walprotocol2-2.3  # WAL locking protocol: busy not raised; txn-state cascade
+walprotocol2 walprotocol2-2.4  # WAL locking protocol: busy not raised; txn-state cascade
+walprotocol2 walprotocol2-2.5  # WAL locking protocol: busy not raised; txn-state cascade
+walrestart walrestart-1.0  # wal_checkpoint frame counters zero (no-op checkpoint)
+walrestart walrestart-1.1  # wal_checkpoint frame counters zero (no-op checkpoint)
+walrestart walrestart-1.2  # wal_checkpoint frame counters zero (no-op checkpoint)
+walrestart walrestart-1.4  # wal_checkpoint frame counters zero (no-op checkpoint)
+walseh1 walseh1-6-seh.1  # wal_checkpoint mode explicitly rejected under fault injection
+walshared walshared-1.2  # shared-cache WAL table locks not raised; snapshot reads proceed
+walshared walshared-1.3  # shared-cache WAL table locks not raised; snapshot reads proceed


### PR DESCRIPTION
Second wave of the feature-gap classification: the 38 completing files with 1–5 failures each. Every assertion reproduced; every mechanism verified in the test source, the engine's own error message, or by checking the surrounding data assertions — no analogy-to-precedent classifications (per the #1298 lesson, and Tim's "are you absolutely sure?" — the answer required clearing four red-flag shapes first):

- **`rdonly`'s accepted write**: traces to `hexio_write test.db 18 03` — the stock *write-version header byte*. The "readonly" state is stock-format semantics with no doltlite meaning; not a readonly-enforcement miss.
- **`busy-2.2`'s empty result**: the busy-handler args list (never invoked because the commit isn't blocked), not lost data — doltlite's snapshot model lets readers and committers coexist, and the data assertions around it pass.
- **`backup5`**: backup proceeds without stock's destination-in-use refusal, and tests 1.5–1.7 prove the resulting backup is *correct* and the open destination statement errors properly.
- **`unixexcl-3.2.x`/`walrestart`**: `wal_checkpoint` frame counters (zeros under the no-op checkpoint) with the snapshot-read data assertions passing.

Classes: explicit pragma/collation rejections + cascades; snapshot-concurrency contract (lock/busy/shared*/walprotocol2/walshared); stock raw-format pokes (corrupt7/A/D/G/H/J, bigfile, incrblob3, mmapcorrupt, rdonly); missing sidecars (journal1, wal64k, wal9); checkpoint counters; OOM/IO fault shifts (mallocD/F/K, incrblobfault); metrics (mmapwarm); #1176 rowid (memdb).

Harness: **all 38 gate OK, 108 entries, none unused.** (Entry names use the file's exact spellings, including upstream's `malloeF-*` typo.)

Wave 3 remaining: ~57 mid/high-count completers, 19 slow-probe files, `readonly`'s dir assumptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)