### PR TITLE
Fix GC verify invariant aborting on injected IO faults

### DIFF
--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -73,7 +73,9 @@ static int gcVerifyHashCb(void *ctx, const ProllyHash *pHash){
   if( prollyHashIsEmpty(pHash) ) return SQLITE_OK;
   v->rc = chunkStoreGet(v->cs, pHash, &data, &nData);
   sqlite3_free(data);
-  if( v->rc!=SQLITE_OK ){
+  /* Only NOTFOUND means the sweep collected a live hash. Other errors
+  ** (injected IO faults, OOM) leave the check inconclusive. */
+  if( v->rc==SQLITE_NOTFOUND ){
     fprintf(stderr,
             "doltlite: GC invariant: session hash unreachable after sweep\n");
     abort();

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -2541,33 +2541,6 @@ pager4 pager4-1.8  # rename-while-open not detected: writes continue to the open
 pager4 pager4-1.9  # rename-while-open not detected: writes continue to the open inode
 pager4 pager4-1.10  # rename-while-open not detected: writes continue to the open inode
 pager4 pager4-1.11  # rename-while-open not detected: writes continue to the open inode
-pagerfault3 quota-2.1.2  # gc sweep fails gracefully under injected IO errors
-pagerfault3 quota-2.1.3  # gc sweep fails gracefully under injected IO errors
-pagerfault3 quota-2.1.4  # gc sweep fails gracefully under injected IO errors
-pagerfault3 quota-2.1.5  # gc sweep fails gracefully under injected IO errors
-pagerfault3 quota-2.2.1  # gc sweep fails gracefully under injected IO errors
-pagerfault3 quota-2.2.2  # gc sweep fails gracefully under injected IO errors
-pagerfault3 quota-2.2.3  # gc sweep fails gracefully under injected IO errors
-pagerfault3 quota-2.4.2  # gc sweep fails gracefully under injected IO errors
-pagerfault3 quota-2.4.3  # gc sweep fails gracefully under injected IO errors
-pagerfault3 quota-2.4.4  # gc sweep fails gracefully under injected IO errors
-pagerfault3 quota-3.1.2  # gc sweep fails gracefully under injected IO errors
-pagerfault3 quota-3.1.4  # gc sweep fails gracefully under injected IO errors
-pagerfault3 quota-3.1.5  # gc sweep fails gracefully under injected IO errors
-pagerfault3 quota-3.2.1  # gc sweep fails gracefully under injected IO errors
-pagerfault3 quota-3.2.2  # gc sweep fails gracefully under injected IO errors
-pagerfault3 quota-3.2.3  # gc sweep fails gracefully under injected IO errors
-pagerfault3 quota-3.2.4  # gc sweep fails gracefully under injected IO errors
-pagerfault3 quota-3.2.5  # gc sweep fails gracefully under injected IO errors
-pagerfault3 quota-3.2.6  # gc sweep fails gracefully under injected IO errors
-pagerfault3 quota-3.2.7  # gc sweep fails gracefully under injected IO errors
-pagerfault3 quota-3.2.8  # gc sweep fails gracefully under injected IO errors
-pagerfault3 quota-3.2.9  # gc sweep fails gracefully under injected IO errors
-pagerfault3 quota-3.3.1  # gc sweep fails gracefully under injected IO errors
-pagerfault3 quota-4.4.6  # gc sweep fails gracefully under injected IO errors
-pagerfault3 quota-4.4.7  # gc sweep fails gracefully under injected IO errors
-pagerfault3 quota-5.3.prep  # gc sweep fails gracefully under injected IO errors
-pagerfault3 quota-5.4.1  # gc sweep fails gracefully under injected IO errors
 resetdb resetdb-100  # sqlite_dbpage writes rejected; page counts/journal-mode reporting differ
 resetdb resetdb-110  # sqlite_dbpage writes rejected; page counts/journal-mode reporting differ
 resetdb resetdb-200  # sqlite_dbpage writes rejected; page counts/journal-mode reporting differ
@@ -5285,3 +5258,23 @@ wal5 wal5-capi-5.2.17  # WAL checkpoint/frame counters zero; sidecar absent
 wal5 wal5-capi-5.2.18  # WAL checkpoint/frame counters zero; sidecar absent
 wal5 wal5-capi-5.2.19  # WAL checkpoint/frame counters zero; sidecar absent
 wal5 wal5-capi-5.2.21  # WAL checkpoint/frame counters zero; sidecar absent
+pagerfault3 pagerfault3-pre1  # synthetic chunk-format page_count
+pagerfault3 pagerfault3-pre2  # synthetic chunk-format page_count
+pagerfault3 pagerfault3-1-ioerr-transient.4  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
+pagerfault3 pagerfault3-1-ioerr-transient.5  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
+pagerfault3 pagerfault3-1-ioerr-transient.6  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
+pagerfault3 pagerfault3-1-ioerr-transient.7  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
+pagerfault3 pagerfault3-1-ioerr-transient.8  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
+pagerfault3 pagerfault3-1-ioerr-transient.9  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
+pagerfault3 pagerfault3-1-ioerr-transient.10  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
+pagerfault3 pagerfault3-1-ioerr-transient.11  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
+pagerfault3 pagerfault3-1-ioerr-transient.12  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
+pagerfault3 pagerfault3-1-ioerr-transient.13  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
+pagerfault3 pagerfault3-1-ioerr-transient.14  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
+pagerfault3 pagerfault3-1-ioerr-transient.15  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
+pagerfault3 pagerfault3-1-ioerr-transient.16  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
+pagerfault3 pagerfault3-1-ioerr-transient.18  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
+pagerfault3 pagerfault3-1-ioerr-transient.19  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
+pagerfault3 pagerfault3-1-ioerr-transient.20  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
+pagerfault3 pagerfault3-1-ioerr-transient.21  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
+pagerfault3 pagerfault3-1-ioerr-transient.22  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault

--- a/test/regression-buckets/fault-fuzz.txt
+++ b/test/regression-buckets/fault-fuzz.txt
@@ -14,11 +14,11 @@ fts3fault
 fts3fault2
 fts3tok_err
 fuzz
+fuzz_malloc
 fuzz-oss1
 fuzz2
 fuzz3
 fuzz4
-fuzz_malloc
 fuzzer1
 fuzzer2
 fuzzerfault
@@ -49,6 +49,7 @@ mallocM
 mmapfault
 notnullfault
 oserror
+pagerfault3
 pragmafault
 rollbackfault
 rowvaluefault


### PR DESCRIPTION
Closes #1320.

`pagerfault3` (IO faults injected during `VACUUM`, which is `dolt_gc` on doltlite) intermittently dumped core. The crash is the `DOLTLITE_PROLLY_CHECK` post-sweep invariant: it verifies every session hash is still reachable by **reading it back through the still-faulty VFS**, so an injected IO error during the verification read trips the same `abort()` as a genuinely collected hash.

## Fix

`gcVerifyHashCb` aborts only on `SQLITE_NOTFOUND` — the signature of a chunk actually removed by the sweep (the bug class this invariant exists to catch, cf. #1306). IO faults, OOM, and other read errors leave the check inconclusive instead of killing the process.

## pagerfault3: excluded → gated

With the abort gone, pagerfault3 completes with an identical failure set across runs, so it moves from excluded-as-nondeterministic to strict-gated in fault-fuzz (29 tests, 20 divergences):
- `pre1`/`pre2`: synthetic chunk-format `page_count` (known intentional class)
- `1-ioerr-transient.4-16,18-22`: `faultsim` flags `dolt_gc`'s phase-prefixed error text ("gc sweep phase failed") where stock reports plain `disk I/O error`

This also removes 27 orphaned `pagerfault3 quota-2.1.x` entries the list inherited from an earlier batch — those test names don't exist in pagerfault3.test and were never validated because the file wasn't gated; they'd have failed the strict gate on first contact.

## Verification

- Fail-before: unfixed build aborts with `GC invariant: session hash unreachable after sweep` + core dump mid-file
- Pass-after: two consecutive runs complete, byte-identical failure lists
- Strict gate on the rebased branch: `OK: pagerfault3 (29 tests, 20 known divergences)`
- GC shell suites green on the fixed build: `doltlite_gc.sh`, `doltlite_gc_session_state.sh`, `doltlite_branch_gc_stress.sh`, plus the CI gc smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)