### PR TITLE
Fix chunkStoreOpen leak and two UAFs found by ASan-running the C corpus

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -321,7 +321,10 @@ int chunkStoreOpen(
    || strcmp(zFilename, ":memory:")==0 ){
     cs->isMemory = 1;
     cs->file.zFilename = sqlite3_mprintf(":memory:");
-    if( cs->file.zFilename==0 ) return SQLITE_NOMEM;
+    if( cs->file.zFilename==0 ){
+      chunkStoreClose(cs);
+      return SQLITE_NOMEM;
+    }
     cs->index.nChunks = 0;
     cs->index.iIndexOffset = 0;
     cs->index.nIndexSize = 0;
@@ -331,12 +334,14 @@ int chunkStoreOpen(
   }
 
   rc = csCanonicalFilename(pVfs, zFilename, &cs->file.zFilename);
-  if( rc!=SQLITE_OK ) return rc;
+  if( rc!=SQLITE_OK ){
+    chunkStoreClose(cs);
+    return rc;
+  }
 
   rc = sqlite3OsAccess(pVfs, cs->file.zFilename, SQLITE_ACCESS_EXISTS, &exists);
   if( rc != SQLITE_OK ){
-    sqlite3_free(cs->file.zFilename);
-    cs->file.zFilename = 0;
+    chunkStoreClose(cs);
     return rc;
   }
 
@@ -344,8 +349,7 @@ int chunkStoreOpen(
     i64 mainSize = 0;
     rc = csFileSizeByName(pVfs, cs->file.zFilename, &mainSize);
     if( rc!=SQLITE_OK ){
-      sqlite3_free(cs->file.zFilename);
-      cs->file.zFilename = 0;
+      chunkStoreClose(cs);
       return rc;
     }
     if( mainSize==0 ){
@@ -366,15 +370,13 @@ int chunkStoreOpen(
     rc = csOpenFile(pVfs, cs->file.zFilename, &cs->file.pFile, openFlags, &outFlags);
     if( rc != SQLITE_OK ){
       if( wantReadOnly ){
-        sqlite3_free(cs->file.zFilename);
-        cs->file.zFilename = 0;
+        chunkStoreClose(cs);
         return rc;
       }
       openFlags = SQLITE_OPEN_READONLY | SQLITE_OPEN_MAIN_DB;
       rc = csOpenFile(pVfs, cs->file.zFilename, &cs->file.pFile, openFlags, 0);
       if( rc != SQLITE_OK ){
-        sqlite3_free(cs->file.zFilename);
-        cs->file.zFilename = 0;
+        chunkStoreClose(cs);
         return rc;
       }
       cs->readOnly = 1;
@@ -387,28 +389,19 @@ int chunkStoreOpen(
 
     rc = csReadManifest(cs);
     if( rc != SQLITE_OK ){
-      csCloseFile(cs->file.pFile);
-      cs->file.pFile = 0;
-      sqlite3_free(cs->file.zFilename);
-      cs->file.zFilename = 0;
+      chunkStoreClose(cs);
       return rc;
     }
 
     rc = csReadIndex(cs);
     if( rc != SQLITE_OK ){
-      csCloseFile(cs->file.pFile);
-      cs->file.pFile = 0;
-      sqlite3_free(cs->file.zFilename);
-      cs->file.zFilename = 0;
+      chunkStoreClose(cs);
       return rc;
     }
 
     rc = csReplayWal(cs);
     if( rc != SQLITE_OK ){
-      csCloseFile(cs->file.pFile);
-      cs->file.pFile = 0;
-      sqlite3_free(cs->file.zFilename);
-      cs->file.zFilename = 0;
+      chunkStoreClose(cs);
       return rc;
     }
 
@@ -436,8 +429,7 @@ int chunkStoreOpen(
     }
   }else{
     if( !(flags & SQLITE_OPEN_CREATE) ){
-      sqlite3_free(cs->file.zFilename);
-      cs->file.zFilename = 0;
+      chunkStoreClose(cs);
       return SQLITE_CANTOPEN;
     }
     cs->index.nChunks = 0;

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -240,15 +240,19 @@ void doltliteUpdateSchemaHashes(sqlite3 *db){
   const char *zName;
   while( (zName = doltliteNextTableForSchema(db, &idx, &iTable)) != 0 ){
     sqlite3_stmt *pStmt = 0;
-    char *zSql = sqlite3_mprintf(
-      "SELECT sql FROM sqlite_master WHERE type='table' AND tbl_name='%q'", zName);
+    /* zName points into the catalog, and stepping the query below can
+    ** begin a transaction that reloads it (cherry-pick refresh). */
+    char *zNameCopy = sqlite3_mprintf("%s", zName);
+    char *zSql = zNameCopy ? sqlite3_mprintf(
+      "SELECT sql FROM sqlite_master WHERE type='table' AND tbl_name='%q'",
+      zNameCopy) : 0;
     if( zSql ){
       if( sqlite3_prepare_v2(db, zSql, -1, &pStmt, 0)==SQLITE_OK ){
         if( sqlite3_step(pStmt)==SQLITE_ROW ){
           const char *zCreate = (const char*)sqlite3_column_text(pStmt, 0);
           if( zCreate ){
             ProllyHash h;
-            char *zCanon = doltliteCanonicalizeSchemaSql(zCreate, zName);
+            char *zCanon = doltliteCanonicalizeSchemaSql(zCreate, zNameCopy);
             if( zCanon ){
               prollyHashCompute(zCanon, (int)strlen(zCanon), &h);
               sqlite3_free(zCanon);
@@ -260,6 +264,7 @@ void doltliteUpdateSchemaHashes(sqlite3 *db){
       }
       sqlite3_free(zSql);
     }
+    sqlite3_free(zNameCopy);
   }
 
   {
@@ -905,7 +910,6 @@ static struct TableEntry *addFindEntryByName(
 
 typedef struct AddNameSlot AddNameSlot;
 struct AddNameSlot {
-  const char *zName;
   int iEntry;
 };
 
@@ -947,14 +951,13 @@ static int addNameIndexInit(
     u32 slot;
     if( !aEntry[i].zName ) continue;
     slot = addNameHash(aEntry[i].zName) & (u32)(nSlot - 1);
-    while( pIdx->aSlot[slot].zName ){
-      if( strcmp(pIdx->aSlot[slot].zName, aEntry[i].zName)==0 ){
+    while( pIdx->aSlot[slot].iEntry ){
+      if( strcmp(aEntry[pIdx->aSlot[slot].iEntry - 1].zName, aEntry[i].zName)==0 ){
         break;
       }
       slot = (slot + 1) & (u32)(nSlot - 1);
     }
-    if( !pIdx->aSlot[slot].zName ){
-      pIdx->aSlot[slot].zName = aEntry[i].zName;
+    if( !pIdx->aSlot[slot].iEntry ){
       pIdx->aSlot[slot].iEntry = i + 1;
     }
   }
@@ -976,8 +979,11 @@ static struct TableEntry *addNameIndexFind(
   slot = addNameHash(zName) & (u32)(pIdx->nSlot - 1);
   for(i=0; i<pIdx->nSlot; i++){
     AddNameSlot *pSlot = &pIdx->aSlot[slot];
-    if( !pSlot->zName ) return 0;
-    if( strcmp(pSlot->zName, zName)==0 ){
+    /* Compare through aEntry, not a cached pointer: the caller replaces
+    ** entry names while the index is live (dolt_commit -A), and a cached
+    ** pointer dangled after the old name was freed. */
+    if( !pSlot->iEntry ) return 0;
+    if( strcmp(pIdx->aEntry[pSlot->iEntry - 1].zName, zName)==0 ){
       return &pIdx->aEntry[pSlot->iEntry - 1];
     }
     slot = (slot + 1) & (u32)(pIdx->nSlot - 1);

--- a/src/doltlite_merge_constraints.c
+++ b/src/doltlite_merge_constraints.c
@@ -1109,6 +1109,7 @@ int doltliteDetectMergeUniqueViolations(
   }
   if( rc == SQLITE_DONE ) rc = SQLITE_OK;
   sqlite3_finalize(pTbls);
+  if( haveAnc ) doltliteFreeCatalog(aAnc, nAnc);
   return rc;
 }
 

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -1255,8 +1255,10 @@ static void init_v3_catalog_blob(u8 *aCat, int nCat, u16 nName){
   aCat[1] = 1;
   aCat[5] = 2;
   aCat[9] = BTREE_INTKEY;
-  aCat[50] = (u8)nName;
-  aCat[51] = (u8)(nName >> 8);
+  if( nCat>51 ){
+    aCat[50] = (u8)nName;
+    aCat[51] = (u8)(nName >> 8);
+  }
   if( nName>0 && nCat>52 ){
     aCat[52] = 't';
   }
@@ -3728,6 +3730,7 @@ static void run_integrity_check_walks_prolly_nodes(void){
         strcmp(queryScalarText(db2, "PRAGMA integrity_check"), "ok")!=0);
 
   sqlite3_close(db2);
+  doltliteFreeCatalog(aTables, nTables);
   removeDbFiles(dbpath);
 }
 


### PR DESCRIPTION
Closes #1325.

The filed leak: `chunkStoreOpen`'s eight early-error returns freed the filename by hand but never the lock mutex (56 bytes per failed open, e.g. opening a corrupted store), and the later ones also leaked whatever the manifest/index/WAL reads had attached. All now use `chunkStoreClose`, which is NULL-safe on a partial store and was already the cleanup for the later error paths.

Validating that under ASan meant running the full C regression corpus sanitized for the first time (CI's sanitizer job skips it). That surfaced and this PR also fixes:

- **UAF in `dolt_commit -A`**: the staged-table name index caches raw `zName` pointers while the alignment loop frees/replaces those names; a later hash-probe strcmp'd freed memory. The index now derives names through `aEntry[iEntry-1]`.
- **UAF in `doltliteUpdateSchemaHashes`**: `zName` points into the catalog and stepping its own `sqlite_master` query can begin a transaction that reloads the catalog (cherry-pick refresh path), freeing the name mid-loop. Copied for the loop body.
- **Ancestor-catalog leak** in `doltliteDetectMergeUniqueViolations` (freed only on the early prepare failure, never on the main exit), plus two harness bugs: a stack overflow in `init_v3_catalog_blob` (wrote the name-length field into a buffer deliberately truncated before it) and a never-freed catalog in the integrity-walk test.

## Verification

- Leak repro (open a corrupted store): 56-byte leak before, ASan-clean after; `incrblob3.test` ASan-clean
- Both UAFs reproduce deterministically in the existing corpus under ASan (`run_commit_am_many_tables`, `run_cherry_pick_stale_branch`) and are gone after
- Full corpus under ASan + `DOLTLITE_PROLLY_CHECK`: **309,781 / 309,781 pass**
- Remaining exit-time residue (~4.6KB / 21 allocations: one savepoint-snapshot engine leak plus small harness allocations in corruption tests) is inventoried in a follow-up issue rather than stretched into this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)