### PR TITLE
Gate fts4aa: matchinfo deferral divergence is the synthetic page size

### DIFF
--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -5272,3 +5272,4 @@ pagerfault3 pagerfault3-1-ioerr-transient.19  # VACUUM=dolt_gc reports phase-pre
 pagerfault3 pagerfault3-1-ioerr-transient.20  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
 pagerfault3 pagerfault3-1-ioerr-transient.21  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
 pagerfault3 pagerfault3-1-ioerr-transient.22  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
+fts4aa fts4aa-1.9  # FTS4 deferral heuristic reads the synthetic 4096 page size; stock at page_size=4096 returns identical values

--- a/test/regression-buckets/ddl-schema.txt
+++ b/test/regression-buckets/ddl-schema.txt
@@ -120,6 +120,7 @@ fts3snippet2
 fts3sort
 fts3tok1
 fts3varint
+fts4aa
 fts4docid
 fts4incr
 fts4intck1
@@ -325,6 +326,7 @@ upsert5
 view
 view2
 view3
+vtab_alter
 vtab2
 vtab3
 vtab4
@@ -337,6 +339,8 @@ vtabA
 vtabB
 vtabC
 vtabD
+vtabdistinct
+vtabdrop
 vtabE
 vtabF
 vtabH
@@ -344,7 +348,4 @@ vtabI
 vtabJ
 vtabK
 vtabL
-vtab_alter
-vtabdistinct
-vtabdrop
 vtabrhs1


### PR DESCRIPTION
Closes #1244.

`fts4aa-1.9` expects FTS4 to **defer** the common token `in` and emit estimated matchinfo stats (`2 1 1`); doltlite computes real counts (`2 2 1`). Triaged per the issue's both-directions protocol — this is provably the synthetic-pragma class, not an FTS bug:

| configuration | result |
|---|---|
| doltlite prolly (synthetic page_size 4096) | `2 2 1` |
| doltlite **orig engine**, stock file at real page_size **1024** | `2 1 1` (expected) |
| doltlite orig engine, stock file at real page_size **4096** | `2 2 1` |

Same FTS code in all three — the deferral decision is a cost heuristic over `PRAGMA page_size` (`fts3EvalSelectDeferred` counts doclist overflow pages relative to it, and segment nodes are sized to `pgsz-35`). Testfixture builds pin stock dbs to 1024 via `SQLITE_DEFAULT_PAGE_SIZE`; prolly reports its synthetic constant 4096, so nothing overflows and nothing defers. Row content is identical; matchinfo deferred estimates are documented heuristics ("we assume that very common tokens occur exactly once in each column of each row").

Considered making the synthetic page size follow `SQLITE_DEFAULT_PAGE_SIZE` instead: rejected, since test builds would then exercise different FTS segment-node sizing (989-byte nodes) than release builds (4061), which is worse than one heuristic divergence.

`fts4aa` joins the ddl-schema bucket (with the other fts4 files), strict gate: `OK: fts4aa (53 tests, 1 known divergences)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)