### PR TITLE
Fix ASan exit-leak residue; run the C corpus under ASan in CI

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -82,3 +82,23 @@ jobs:
 
     - name: Correctness regression tests
       run: cd build && bash ../test/correctness_test.sh ./doltlite
+
+    # The C regression corpus (~310k checks) under ASan/UBSan with leak
+    # detection — where the #1325/#1328 use-after-frees and leaks lived.
+    # Reuses the objects built above; only the archive and link are new.
+    # No stdbuf here: its LD_PRELOAD loads ahead of the ASan runtime and
+    # aborts the process. Buffered stdout is lost if LSan exits nonzero,
+    # but the sanitizer report itself goes to unbuffered stderr.
+    - name: C regression corpus (ASan/UBSan)
+      run: |
+        cd build
+        make \
+          CFLAGS="-O1 -g -fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=all" \
+          LDFLAGS="-fsanitize=address,undefined" \
+          libdoltlite.a
+        cc -O1 -g -fsanitize=address,undefined -fno-omit-frame-pointer -fno-sanitize-recover=all \
+          -I. -I../src \
+          -o doltlite_regression_test_c ../test/doltlite_regression_test_c.c \
+          libdoltlite.a -lz -lpthread -lm
+        ./doltlite_regression_test_c all
+

--- a/src/chunk_refs.c
+++ b/src/chunk_refs.c
@@ -255,12 +255,16 @@ int csDeserializeRefs(ChunkStore *cs, const u8 *data, int nData){
   if( nBranches>0 ){
     cs->refs.aBranches = sqlite3_malloc(nBranches*(int)sizeof(struct BranchRef));
     if(!cs->refs.aBranches) return SQLITE_NOMEM;
+    memset(cs->refs.aBranches, 0, nBranches*(int)sizeof(struct BranchRef));
+    /* Count the whole zeroed array up front (here and below): a parse
+    ** failure mid-entry must leave already-allocated fields visible to
+    ** csFreeBranches, or a truncated blob leaks them. */
+    cs->refs.nBranches = nBranches;
     for(i=0;i<nBranches;i++){
       int nameLen; if(bufCur+4>data+nData) return SQLITE_CORRUPT;
       nameLen=(int)CS_READ_U32(bufCur); bufCur+=4;
       if( nameLen<0 ) return SQLITE_CORRUPT;
       if(bufCur+nameLen+PROLLY_HASH_SIZE>data+nData) return SQLITE_CORRUPT;
-      memset(&cs->refs.aBranches[i], 0, sizeof(struct BranchRef));
       cs->refs.aBranches[i].zName=sqlite3_malloc(nameLen+1);
       if(!cs->refs.aBranches[i].zName) return SQLITE_NOMEM;
       memcpy(cs->refs.aBranches[i].zName,bufCur,nameLen); cs->refs.aBranches[i].zName[nameLen]=0; bufCur+=nameLen;
@@ -268,7 +272,6 @@ int csDeserializeRefs(ChunkStore *cs, const u8 *data, int nData){
       if( bufCur+PROLLY_HASH_SIZE<=data+nData ){
         memcpy(cs->refs.aBranches[i].workingSetHash.data,bufCur,PROLLY_HASH_SIZE); bufCur+=PROLLY_HASH_SIZE;
       }
-      cs->refs.nBranches++;
     }
   }
 
@@ -280,6 +283,7 @@ int csDeserializeRefs(ChunkStore *cs, const u8 *data, int nData){
       cs->refs.aTags = sqlite3_malloc(nTags*(int)sizeof(struct TagRef));
       if(!cs->refs.aTags) return SQLITE_NOMEM;
       memset(cs->refs.aTags, 0, nTags*(int)sizeof(struct TagRef));
+      cs->refs.nTags = nTags;
       for(i=0;i<nTags;i++){
         int nameLen; if(bufCur+4>data+nData) return SQLITE_CORRUPT;
         nameLen=(int)CS_READ_U32(bufCur); bufCur+=4;
@@ -315,7 +319,6 @@ int csDeserializeRefs(ChunkStore *cs, const u8 *data, int nData){
           if(!cs->refs.aTags[i].zMessage) return SQLITE_NOMEM;
           memcpy(cs->refs.aTags[i].zMessage,bufCur,messageLen); cs->refs.aTags[i].zMessage[messageLen]=0; bufCur+=messageLen;
         }
-        cs->refs.nTags++;
       }
     }
   }
@@ -329,6 +332,7 @@ int csDeserializeRefs(ChunkStore *cs, const u8 *data, int nData){
       cs->refs.aRemotes = sqlite3_malloc(nRemotes*(int)sizeof(struct RemoteRef));
       if(!cs->refs.aRemotes) return SQLITE_NOMEM;
       memset(cs->refs.aRemotes, 0, nRemotes*(int)sizeof(struct RemoteRef));
+      cs->refs.nRemotes = nRemotes;
       for(i=0;i<nRemotes;i++){
         int nameLen, urlLen;
         if(bufCur+4>data+nData) return SQLITE_CORRUPT;
@@ -344,7 +348,6 @@ int csDeserializeRefs(ChunkStore *cs, const u8 *data, int nData){
         cs->refs.aRemotes[i].zUrl=sqlite3_malloc(urlLen+1);
         if(!cs->refs.aRemotes[i].zUrl) return SQLITE_NOMEM;
         memcpy(cs->refs.aRemotes[i].zUrl,bufCur,urlLen); cs->refs.aRemotes[i].zUrl[urlLen]=0; bufCur+=urlLen;
-        cs->refs.nRemotes++;
       }
     }
     if( bufCur+4<=data+nData ){
@@ -354,6 +357,7 @@ int csDeserializeRefs(ChunkStore *cs, const u8 *data, int nData){
         cs->refs.aTracking = sqlite3_malloc(nTracking*(int)sizeof(struct TrackingBranch));
         if(!cs->refs.aTracking) return SQLITE_NOMEM;
         memset(cs->refs.aTracking, 0, nTracking*(int)sizeof(struct TrackingBranch));
+      cs->refs.nTracking = nTracking;
         for(i=0;i<nTracking;i++){
           int remoteLen, branchLen;
           if(bufCur+4>data+nData) return SQLITE_CORRUPT;
@@ -370,7 +374,6 @@ int csDeserializeRefs(ChunkStore *cs, const u8 *data, int nData){
           if(!cs->refs.aTracking[i].zBranch) return SQLITE_NOMEM;
           memcpy(cs->refs.aTracking[i].zBranch,bufCur,branchLen); cs->refs.aTracking[i].zBranch[branchLen]=0; bufCur+=branchLen;
           memcpy(cs->refs.aTracking[i].commitHash.data,bufCur,PROLLY_HASH_SIZE); bufCur+=PROLLY_HASH_SIZE;
-          cs->refs.nTracking++;
         }
       }
     }
@@ -385,6 +388,7 @@ int csDeserializeRefs(ChunkStore *cs, const u8 *data, int nData){
         cs->refs.aSequences = sqlite3_malloc(nSequences*(int)sizeof(SequenceRef));
         if(!cs->refs.aSequences) return SQLITE_NOMEM;
         memset(cs->refs.aSequences, 0, nSequences*(int)sizeof(SequenceRef));
+      cs->refs.nSequences = nSequences;
         for(i=0;i<nSequences;i++){
           int nameLen;
           if(bufCur+4>data+nData) return SQLITE_CORRUPT;
@@ -398,7 +402,6 @@ int csDeserializeRefs(ChunkStore *cs, const u8 *data, int nData){
           bufCur+=nameLen;
           cs->refs.aSequences[i].iSeq=CS_READ_I64(bufCur);
           bufCur+=8;
-          cs->refs.nSequences++;
         }
       }
     }

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -4120,13 +4120,17 @@ static int rebaseRestoreBranchState(sqlite3 *db, const char *zBranch){
   rc = doltliteLoadCommit(db, &headHash, &headCommit);
   if( rc!=SQLITE_OK ) return rc;
   rc = doltliteSwitchCatalog(db, &headCommit.catalogHash);
-  if( rc!=SQLITE_OK ) return rc;
+  if( rc!=SQLITE_OK ){
+    doltliteCommitClear(&headCommit);
+    return rc;
+  }
   doltliteSetSessionBranch(db, zBranch);
   doltliteSetSessionHead(db, &headHash);
   doltliteSetSessionStaged(db, &headCommit.catalogHash);
   doltliteClearSessionMergeState(db);
   memset(&emptyHash, 0, sizeof(emptyHash));
   doltliteSetSessionConstraintViolationsCatalog(db, &emptyHash);
+  doltliteCommitClear(&headCommit);
   return SQLITE_OK;
 }
 

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -5439,7 +5439,7 @@ static int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
       }
       p->inTrans = TRANS_NONE;
       p->inTransaction = TRANS_NONE;
-      p->nSavepoint = 0;
+      btreeDiscardAllSavepoints(p);
       p->bSchemaChangedTxn = 0;
       p->bMasterRootChangedTxn = 0;
 
@@ -5469,7 +5469,7 @@ static int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
       chunkStoreRollback(&pBt->store);
       p->inTrans = TRANS_NONE;
       p->inTransaction = TRANS_NONE;
-      p->nSavepoint = 0;
+      btreeDiscardAllSavepoints(p);
       p->bSchemaChangedTxn = 0;
       p->bMasterRootChangedTxn = 0;
       chunkStoreUnlock(&pBt->store);
@@ -5482,7 +5482,7 @@ static int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
   p->inTransaction = TRANS_NONE;
   p->bSchemaChangedTxn = 0;
   p->bMasterRootChangedTxn = 0;
-  p->nSavepoint = 0;
+  btreeDiscardAllSavepoints(p);
 
   chunkStoreUnlock(&pBt->store);
   pBt->store.snapshotPinned = 0;

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -3480,7 +3480,7 @@ static void run_diff_stat_surfaces_corrupt_root(void){
 
   sqlite3_free(pCommitData);
   sqlite3_free(pCatData);
-  sqlite3_free(aTables);
+  doltliteFreeCatalog(aTables, nTables);
   doltliteCommitClear(&badCommit);
   doltliteCommitClear(&fromCommit);
   doltliteCommitClear(&headCommit);


### PR DESCRIPTION
Closes #1328.

## Engine fixes

- **Savepoint states abandoned at commit** (the root of most of the residue): `prollyBtreeCommitPhaseTwo` reset `nSavepoint = 0` on all three exit paths without freeing the captured states — every table capture and pending-edit snapshot (and the mutmaps they own, which were all the "indirect" leaks) taken during a transaction leaked at COMMIT. Now uses `btreeDiscardAllSavepoints`, the same helper rollback uses.
- **`csDeserializeRefs` partial-parse leaks**: each branch/tag/remote/tracking/sequence entry was counted only after parsing completely, so a truncated blob left already-allocated names invisible to the `csFree*` helpers (the refs-blob-corruption leaks). Each array is now zeroed and counted in full up front; partial entries free cleanly.
- **`rebaseRestoreBranchState`** never cleared the loaded head commit (author/email/message strings).
- Harness: the diff-stat corruption test freed its catalog with a raw `sqlite3_free(aTables)`, leaking the entry names — now `doltliteFreeCatalog`.

## CI extension (as requested)

New step in the **existing asan-ubsan job** (per review): reuses that job's ASan+UBSan objects, links the corpus runner, and runs all ~310k checks with `detect_leaks=1` and `-fno-sanitize-recover=all`, failing on any report. This corpus had never run sanitized — it's where the #1325 use-after-frees and this issue's leaks lived. (The first draft as a separate job failed in CI because `stdbuf`'s LD_PRELOAD loads ahead of the ASan runtime; dropped — the sanitizer report goes to unbuffered stderr anyway.) Local validation of the exact CI recipe: 309,807/309,807 pass, zero findings, zero leaks.

## Verification

Full corpus under ASan: **309,807 / 309,807 pass, exit 0, zero leak reports** (was 21 allocations / ~4.6KB). One iteration caught my own first attempt double-freeing in the harness — the new CI job caught-by-construction exactly the class it exists for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
