### PR TITLE
Make OOM rollback unable to publish or dangle partial state

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -224,7 +224,35 @@ static int csRestoreCommittedRefsState(ChunkStore *cs){
     csFreeSequences(cs);
     return csEnsureDefaultBranch(cs);
   }
-  return chunkStoreReloadRefs(cs);
+  {
+    int rc = chunkStoreReloadRefs(cs);
+    if( rc!=SQLITE_OK ){
+      /* The reload allocates and can fail mid-OOM-rollback. Leaving the
+      ** uncommitted refs in place dangles pointers at chunks the rollback
+      ** is discarding; clear them without allocating and reload from
+      ** committedRefsHash at the next use instead. */
+      csFreeBranches(cs);
+      csFreeTags(cs);
+      csFreeRemotes(cs);
+      csFreeTracking(cs);
+      csFreeSequences(cs);
+      cs->bRefsStale = 1;
+      return rc;
+    }
+    cs->bRefsStale = 0;
+    return SQLITE_OK;
+  }
+}
+
+/* Repair a stale refs table (cleared by an OOM rollback) by reloading it
+** from the committed refs blob. Called before refs lookups that would
+** otherwise read an empty table as a valid empty database. */
+int chunkStoreEnsureRefsFresh(ChunkStore *cs){
+  int rc;
+  if( !cs->bRefsStale ) return SQLITE_OK;
+  rc = chunkStoreReloadRefs(cs);
+  if( rc==SQLITE_OK ) cs->bRefsStale = 0;
+  return rc;
 }
 
 static int csReloadFromDiskPreservingLocalRefs(ChunkStore *cs){

--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -125,6 +125,8 @@ typedef struct ChunkStore ChunkStore;
 struct ChunkStore {
   ChunkFile file;
   RefsTable refs;
+  u8 bRefsStale;          /* refs restore failed under OOM and was cleared;
+                          ** reload from refsHash before the next use */
   ChunkIndex index;
   WalState wal;
   ChunkStaging staging;
@@ -201,6 +203,7 @@ int chunkStorePut(ChunkStore *cs, const u8 *pData, int nData,
 int chunkStoreCommit(ChunkStore *cs);
 
 void chunkStoreRollback(ChunkStore *cs);
+int chunkStoreEnsureRefsFresh(ChunkStore *cs);
 
 int chunkStoreIsEmpty(ChunkStore *cs);
 

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -300,6 +300,9 @@ struct Btree {
   u8 bSchemaChangedTxn;
   u8 bMasterRootChangedTxn;
   u8 bFilterSchemaPlaceholders;
+  u8 bCatalogDropped;     /* OOM rollback dropped the catalog; reload before
+                          ** treating an empty committedCatalogHash as a
+                          ** fresh database */
 
   int nSavepoint;
   int nSavepointAlloc;
@@ -5155,6 +5158,7 @@ static int btreeRefreshSharedWorkingState(Btree *p){
   rc = btreeReloadBranchWorkingStateInto(p, 1, &loadedCatHash);
   if( rc!=SQLITE_OK ) return rc;
   btreeStoreCommittedFromCurrent(p, &loadedCatHash);
+  p->bCatalogDropped = 0;
   p->iLoadedWorkingStateVersion = pBt->iWorkingStateVersion;
   btreeBumpDataVersion(p);
   return SQLITE_OK;
@@ -5269,6 +5273,7 @@ static int prollyBtreeBeginTrans(Btree *p, int wrFlag, int *pSchemaVersion){
         return rc;
       }
       btreeStoreCommittedFromCurrent(p, &loadedCatHash);
+      p->bCatalogDropped = 0;
     }
     btreeStoreCommittedFromCurrent(p, 0);
 
@@ -5474,7 +5479,18 @@ static int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
       sqlite3_free(catData);
       rc2 = restoreFromCommitted(p);
       if( rc2!=SQLITE_OK ){
+        /* Same shape as the rollback path: the reload OOM'd, but the
+        ** transaction must end with the partial state discarded, or the
+        ** next statement's autocommit publishes it. */
+        btreeFreeCatalogTables(p);
+        memset(&p->committedCatalogHash, 0, sizeof(p->committedCatalogHash));
+        p->bCatalogDropped = 1;
+        p->iLoadedWorkingStateVersion = pBt->iWorkingStateVersion - 1;
+        resetConnectionSchema(p);
         chunkStoreRollback(&pBt->store);
+        p->inTrans = TRANS_NONE;
+        p->inTransaction = TRANS_NONE;
+        btreeDiscardAllSavepoints(p);
         chunkStoreUnlock(&pBt->store);
         pBt->store.snapshotPinned = 0;
         /* Preserve the original commit error; restore failure is secondary. */
@@ -5531,6 +5547,20 @@ int sqlite3BtreeCommit(Btree *p){
 
 static int restoreFromCommitted(Btree *p){
   if( prollyHashIsEmpty(&p->committedCatalogHash) ){
+    if( p->bCatalogDropped ){
+      /* A prior OOM rollback dropped the catalog. Installing the default
+      ** empty catalog here would let the persist-on-rollback path write an
+      ** empty working set over real tables. Reload the committed state
+      ** from the store instead; failure keeps the dropped state. */
+      ProllyHash loadedCatHash;
+      int rc;
+      memset(&loadedCatHash, 0, sizeof(loadedCatHash));
+      rc = btreeReloadBranchWorkingStateInto(p, 1, &loadedCatHash);
+      if( rc!=SQLITE_OK ) return rc;
+      btreeStoreCommittedFromCurrent(p, &loadedCatHash);
+      p->bCatalogDropped = 0;
+      return SQLITE_OK;
+    }
     btreeFreeCatalogTables(p);
     initDefaultMeta(p);
     p->cat.iNextTable = 2;
@@ -5683,12 +5713,21 @@ static int prollyBtreeRollback(Btree *p, int tripCode, int writeOnly){
     }
     rc = restoreFromCommitted(p);
     if( rc!=SQLITE_OK ){
-      if( bAutocommitOomRollback ){
-        p->inTrans = TRANS_NONE;
-        p->inTransaction = TRANS_NONE;
-        btreeDiscardAllSavepoints(p);
-        chunkStoreRollback(&pBt->store);
-      }
+      /* Reloading the committed catalog failed (OOM). The transaction must
+      ** still end with nothing dangling: chunkStoreRollback() is about to
+      ** discard staging, and the catalog may still point at staged chunks
+      ** (a DDL attempt repoints the sqlite_master root at one). Drop the
+      ** catalog without allocating and force the next BeginTrans to reload
+      ** the committed working state. */
+      btreeFreeCatalogTables(p);
+      memset(&p->committedCatalogHash, 0, sizeof(p->committedCatalogHash));
+      p->bCatalogDropped = 1;
+      p->iLoadedWorkingStateVersion = pBt->iWorkingStateVersion - 1;
+      resetConnectionSchema(p);
+      p->inTrans = TRANS_NONE;
+      p->inTransaction = TRANS_NONE;
+      btreeDiscardAllSavepoints(p);
+      chunkStoreRollback(&pBt->store);
       chunkStoreUnlock(&pBt->store);
       pBt->store.snapshotPinned = 0;
       return rc;
@@ -5700,7 +5739,7 @@ static int prollyBtreeRollback(Btree *p, int tripCode, int writeOnly){
     }
     /* Autocommit OOM rollback restores in-memory state only. Persisting the
     ** restored catalog here can make a failed DDL attempt the new baseline. */
-    if( !bAutocommitOomRollback ){
+    if( !bAutocommitOomRollback && !p->bCatalogDropped ){
       u8 *catData = 0;
       int nCatData = 0;
       ProllyHash catHash;
@@ -5804,7 +5843,19 @@ int doltliteBtreeCaptureStatement(void *pArg){
 static int rollbackCommittedState(Btree *p, BtShared *pBt){
   BtCursor *pC;
   int rc = restoreFromCommitted(p);
-  if( rc!=SQLITE_OK ) return rc;
+  if( rc!=SQLITE_OK ){
+    /* The reload OOM'd partway; the catalog may still point at staged
+    ** chunks the rollback is about to discard (a DDL attempt repointed
+    ** the sqlite_master root). Drop it without allocating and let the
+    ** next BeginTrans reload the committed working state. */
+    btreeFreeCatalogTables(p);
+    memset(&p->committedCatalogHash, 0, sizeof(p->committedCatalogHash));
+    p->bCatalogDropped = 1;
+    p->iLoadedWorkingStateVersion = pBt->iWorkingStateVersion - 1;
+    invalidateCursors(pBt, 0, SQLITE_ABORT);
+    resetConnectionSchema(p);
+    return rc;
+  }
   /* Like invalidateCursors, but keep the code of an existing fault:
   ** OP_Savepoint's cursor trip already stamped SQLITE_ABORT_ROLLBACK and
   ** clobbering it to SQLITE_ABORT misreported the abort (savepoint7-2.2). */

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -5046,6 +5046,8 @@ static int btreeReloadBranchWorkingStateInto(
   memset(&rebaseOnto, 0, sizeof(rebaseOnto));
   memset(&constraintViolationsHash, 0, sizeof(constraintViolationsHash));
 
+  rc = chunkStoreEnsureRefsFresh(&pBt->store);
+  if( rc!=SQLITE_OK ) return rc;
   rc = btreeLoadWorkingSetBlob(
       &pBt->store, zBr, &catHash, &workingCommitHash, &stagedCatalog, &isMerging,
       &mergeCommitHash, &conflictsCatalogHash,
@@ -5739,7 +5741,8 @@ static int prollyBtreeRollback(Btree *p, int tripCode, int writeOnly){
     }
     /* Autocommit OOM rollback restores in-memory state only. Persisting the
     ** restored catalog here can make a failed DDL attempt the new baseline. */
-    if( !bAutocommitOomRollback && !p->bCatalogDropped ){
+    if( !bAutocommitOomRollback && !p->bCatalogDropped
+     && !pBt->store.bRefsStale ){
       u8 *catData = 0;
       int nCatData = 0;
       ProllyHash catHash;

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -5265,3 +5265,4 @@ pagerfault3 pagerfault3-1-ioerr-transient.20  # VACUUM=dolt_gc reports phase-pre
 pagerfault3 pagerfault3-1-ioerr-transient.21  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
 pagerfault3 pagerfault3-1-ioerr-transient.22  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
 fts4aa fts4aa-1.9  # FTS4 deferral heuristic reads the synthetic 4096 page size; stock at page_size=4096 returns identical values
+fts3malloc fts3_malloc-2.1.transient.100000.18  # transient OOM at one fault point silently skips a master row in count(*) — #1333

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -4432,10 +4432,6 @@ memjournal2 memjournal2-1.2.299.3  # in-memory journal premise: journal_mode fix
 memjournal2 memjournal2-1.2.300.1  # in-memory journal premise: journal_mode fixed, sidecar absent
 memjournal2 memjournal2-1.2.300.2  # in-memory journal premise: journal_mode fixed, sidecar absent
 memjournal2 memjournal2-1.2.300.3  # in-memory journal premise: journal_mode fixed, sidecar absent
-shared_err shared_ioerr-1.36.cleanup.2  # shared-cache fault injection: locking model + fault-point shifts
-shared_err shared_ioerr-1.37.cleanup.2  # shared-cache fault injection: locking model + fault-point shifts
-shared_err shared_ioerr-1.38.cleanup.2  # shared-cache fault injection: locking model + fault-point shifts
-shared_err shared_ioerr-1.39.cleanup.2  # shared-cache fault injection: locking model + fault-point shifts
 shared_err shared_ioerr-2.122.cleanup.1  # shared-cache fault injection: locking model + fault-point shifts
 shared_err shared_ioerr-2.123.cleanup.1  # shared-cache fault injection: locking model + fault-point shifts
 shared_err shared_ioerr-2.124.cleanup.1  # shared-cache fault injection: locking model + fault-point shifts

--- a/test/regression-buckets/fault-fuzz.txt
+++ b/test/regression-buckets/fault-fuzz.txt
@@ -12,6 +12,7 @@ filterfault
 fkey_malloc
 fts3fault
 fts3fault2
+fts3malloc
 fts3tok_err
 fuzz
 fuzz_malloc


### PR DESCRIPTION
Fixes the two named failures in #1322 and the file abort that blocked `fts3malloc.test` from ever completing. Builds on #1330.

## Root cause

Stock SQLite's rollback is allocation-free by design (pager journal playback). doltlite's is not: `restoreFromCommitted()` reloads the committed catalog (allocates) and `chunkStoreRollback()` re-parsed the refs blob (allocates). Under persistent OOM the rollback itself fails, and three paths returned with the write transaction still open and in-memory state pointing at staged chunks the rollback discards:

1. **`prollyBtreeRollback`** — the next statement's autocommit then **durably committed the partial writes**. Traced fault-point-by-fault-point: `DELETE ... MATCH` under OOM deleted its first row via xUpdate, the failed rollback left the txn open, and the following SELECT committed it (fts3malloc-4.2's surviving rows; `malformed inverted index` from integrity_check; the 5.3.persistent.326 malformed-database failure).
2. **`prollyBtreeCommitPhaseTwo`'s failure branch** — same shape when the OOM lands inside the commit.
3. **`rollbackCommittedState`** — a faulted CREATE VIRTUAL TABLE repoints the sqlite_master root at a staged node; the dangling root then failed every subsequent read with SQLITE_NOTFOUND ("unknown operation"), aborting the whole file at `1.2.persistent.6x` (the blocker noted in #1330).

## Fixes

- All three failure paths now **drop the catalog without allocating** (frees only), clear the loaded-state markers, and force the next BeginTrans to reload the committed working state. The transaction always ends.
- **`bCatalogDropped`** distinguishes dropped-needs-reload from genuinely-fresh: without it, a later `restoreFromCommitted()` installed the default *empty* catalog as success and the persist-on-rollback path wrote an **empty working set over real tables** (the cascading empty-schema corruption).
- **Refs restore can no longer dangle or launder**: chunkStoreRollback's refs re-parse allocates and failed silently under OOM, leaving refs pointing at discarded staged chunks; the reload path then tolerated the resulting NOTFOUND as an empty database. Now the refs are cleared without allocating, marked stale, and reloaded from the committed blob at the next working-state load. This turned out to be the mechanism behind nearly all of the newly-reachable section 2-3 failures: **fts3malloc goes from 52 remaining failures to 1** (out of 15,149).

## Verification

- 900-point persistent-OOM fault scan of `DELETE ... MATCH`: master shows durable row loss + malformed FTS index from fault 269 onward; fixed build has **zero bad points** — every fault either fails cleanly with all rows intact or succeeds completely.
- `fts3malloc.test`: master aborts at `1.2.persistent.6x`; fixed build **runs to completion** with sections 1, 4, 5 fully passing — including the issue's two named failures (`4.2`, `5.3.persistent.326`).
- Newly reachable sections 2-3 expose 52 pre-existing transient-OOM error-laundering divergences (one fault point per SELECT test, self-healing, no durable damage) — tracked in #1333 with mechanism notes. fts3malloc stays ungated (fault-point sets are environment-sensitive, mallocH-class).
- Zero OOM-baseline drift: all rollback-path work is allocation-free (an earlier commit-time snapshot design consumed transient fault points and was scrapped — fault-point sets differ between runners and local, making per-commit allocations ungateable). Four shared_err cleanup divergences now pass and come off the list. Both buckets verified clean non-root locally.
- **fts3malloc is now gated** in the fault-fuzz bucket: 15,148/15,149 with one known divergence (2.1.transient.100000.18: count(*) returns 4 instead of 5 — a silent row skip under a single transient fault, tracked in #1333).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


