### PR TITLE
Correct the fts3malloc divergence classification

### DIFF
--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -5265,4 +5265,4 @@ pagerfault3 pagerfault3-1-ioerr-transient.20  # VACUUM=dolt_gc reports phase-pre
 pagerfault3 pagerfault3-1-ioerr-transient.21  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
 pagerfault3 pagerfault3-1-ioerr-transient.22  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
 fts4aa fts4aa-1.9  # FTS4 deferral heuristic reads the synthetic 4096 page size; stock at page_size=4096 returns identical values
-fts3malloc fts3_malloc-2.1.transient.100000.18  # transient OOM at one fault point silently skips a master row in count(*) — #1333
+fts3malloc fts3_malloc-2.1.transient.100000.18  # expected count bakes in a master row stock leaks from a faulted CREATE; doltlite's CREATE stays atomic (clean replay = 4 on both engines) — #1333


### PR DESCRIPTION
Closes #1333.

The lone gated fts3malloc divergence (`2.1.transient.100000.18`: `count(*) FROM sqlite_master` returns 4 where the test expects 5) turned out not to be a row skip. Proof chain:

| experiment | result |
|---|---|
| clean (unfaulted) replay of section 1 + 2.0, **prolly engine** | 4 rows |
| clean replay, **orig engine** (stock format) | 4 rows |
| full fts3malloc run on a stock-format db (orig engine) | identical `[0 4]` failure at the same fault point |
| same, on a **pre-#1330** build | `[0 1]` — the non-atomic wreckage that campaign fixed |
| isolated faulted-CREATE scans, both engines | no partial leaks; one complete-table leak at the same point on both |

So 4 is the correct count for a database where every faulted CREATE either fully succeeded or fully rolled back. Upstream's expected 5 bakes in a master row that stock **leaks from a faulted CREATE VIRTUAL TABLE** — the do_write_test harness tolerates it via its checksum-changed early return. The statement-journal coverage from #1330 plus the rollback fixes from #1334 live in shared code (compile-time, both engines), making the faulted CREATE atomic where stock's is not.

This PR just rewrites the divergence entry's reason to record that mechanism. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)