### PR TITLE
Recover ordering, WITHOUT ROWID, collation & encoding coverage (#1313 3/4)

### DIFF
--- a/test/doltlite_recover_collation.test
+++ b/test/doltlite_recover_collation.test
@@ -1,0 +1,569 @@
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+# Recovers the intent of upstream collation assertions that doltlite's CI gates
+# as intentional divergences.  Doltlite's prolly-tree sort keys only support the
+# built-in BINARY, NOCASE, and RTRIM collations, so CREATE INDEX (and implicit
+# PK/UNIQUE indexes) that depend on a user-defined collation are rejected with
+# "doltlite does not support indexes with custom collation '<name>'".  Custom
+# collations remain fully usable in ORDER BY / WHERE / window frames.  These
+# tests re-assert: the exact rejection, that query SEMANTICS stay correct
+# without the rejected index (built-in BINARY stands in for the upstream
+# binary-equivalent custom TEXT collation), that built-in-collation indexes
+# still give sorted (nosort) scans, and that a database holding custom-collated
+# COLUMNS stays healthy across reopen without the collation registered (unlike
+# stock, where the custom-collated index makes integrity_check/REINDEX fail).
+#
+# covers: collate4 collate4-1.1.0 — table with NOCASE+custom-TEXT columns; NOCASE index accepted (1.1), custom-TEXT index rejected verbatim (1.2)
+# covers: collate4 collate4-1.1.4 — ORDER BY custom-TEXT column returns binary order via registered collation, sorter not index (1.4)
+# covers: collate4 collate4-1.1.5 — ORDER BY b COLLATE TEXT same result through explicit custom collate (1.5)
+# covers: collate4 collate4-1.1.8 — NOCASE PK iterates in case-insensitive order, nosort (1.8); NULL PK rejected is the doltlite divergence that gated the family (1.7)
+# covers: collate4 collate4-1.1.9 — ORDER BY a COLLATE NOCASE == PK order, nosort (1.8)
+# covers: collate4 collate4-1.1.10 — binary (upstream TEXT) order over NOCASE PK needs a sort, correct result (1.9)
+# covers: collate4 collate4-1.1.11 — column-level UNIQUE index drives ORDER BY, nosort (1.11)
+# covers: collate4 collate4-1.1.12 — ORDER BY b == unique-index collation order, nosort (1.11)
+# covers: collate4 collate4-1.1.13 — ORDER BY b under the other collation requires sort, correct (1.12)
+# covers: collate4 collate4-1.1.14 — table-constraint PRIMARY KEY on custom-TEXT column rejected verbatim (1.13); built-in equivalent created (1.14)
+# covers: collate4 collate4-1.1.15 — UNIQUE(a NOCASE) index orders ORDER BY a, nosort (1.15)
+# covers: collate4 collate4-1.1.16 — ORDER BY a COLLATE NOCASE same, nosort (1.15)
+# covers: collate4 collate4-1.1.17 — ORDER BY a COLLATE BINARY sorts, correct order (1.16)
+# covers: collate4 collate4-1.1.18 — PK(b) drives ORDER BY b, nosort (1.17)
+# covers: collate4 collate4-1.1.19 — ORDER BY b in PK collation, nosort (1.17)
+# covers: collate4 collate4-1.1.20 — ORDER BY b COLLATE NOCASE sorts, correct (1.18)
+# covers: collate4 collate4-1.1.21 — CREATE INDEX ... (a COLLATE TEXT) rejected verbatim (1.20)
+# covers: collate4 collate4-1.1.24 — binary-order query over NOCASE column stays correct without the rejected custom index (1.23)
+# covers: collate4 collate4-1.1.27 — index with explicit built-in COLLATE NOCASE accepted and drives ORDER BY, nosort (1.21, 1.22)
+# covers: collate4 collate4-1.1.30 — all section-1 tables drop cleanly after rejections (1.24)
+# covers: collate4 collate4-1.2.0 — two-column index covering a custom-TEXT column rejected verbatim (2.2)
+# covers: collate4 collate4-1.2.1 — (a, b COLLATE BINARY) index orders ORDER BY a, nosort (2.4)
+# covers: collate4 collate4-1.2.2 — ORDER BY a COLLATE nocase same, nosort (2.4)
+# covers: collate4 collate4-1.2.4 — ORDER BY a, b-second-column, nosort via two-column index (2.5)
+# covers: collate4 collate4-1.2.6 — ORDER BY a, b in index collation, nosort (2.5)
+# covers: collate4 collate4-1.2.14 — index (a COLLATE TEXT, b COLLATE NOCASE) rejected verbatim (2.6)
+# covers: collate4 collate4-1.2.17 — (a COLLATE BINARY, b COLLATE NOCASE) index orders ORDER BY a COLLATE BINARY, nosort (2.8)
+# covers: collate4 collate4-1.2.19 — both index columns order the query, nosort (2.9)
+# covers: collate4 collate4-1.2.21 — DESC scan of that index, nosort (2.10)
+# covers: collate4 collate4-1.2.24 — DESC over both columns, nosort (2.11)
+# covers: collate4 collate4-1.2.7 — composite PK containing custom-TEXT column rejected verbatim (2.12); NOCASE composite PK equivalent created (2.13)
+# covers: collate4 collate4-1.2.8 — composite NOCASE PK orders ORDER BY a, nosort (2.14)
+# covers: collate4 collate4-1.2.9 — ORDER BY a COLLATE nocase same, nosort (2.14)
+# covers: collate4 collate4-1.2.10 — ORDER BY a COLLATE BINARY sorts, correct (2.15)
+# covers: collate4 collate4-1.2.11 — ORDER BY a, b follows PK, nosort (2.16)
+# covers: collate4 collate4-1.2.12 — ORDER BY a, b COLLATE NOCASE breaks PK order, sorts, correct (2.17)
+# covers: collate4 collate4-1.2.13 — ORDER BY a, b in declared collations == PK order, nosort (2.16)
+# covers: collate4 collate4-1.2.25 — section-2 tables drop cleanly (2.18)
+# covers: collate4 collate4-2.1.4 — custom-TEXT index rejected (3.4); cross-collation WHERE a=b result stays correct without it (3.1)
+# covers: collate4 collate4-2.1.5 — WHERE b=a compares under left operand's custom TEXT collation: exact-case match only (3.3)
+# covers: collate4 collate4-2.1.7 — NOCASE index accepted; WHERE a=b and IN-subquery results unchanged by index (3.2, 3.6)
+# covers: collate4 collate4-2.1.8 — a IN ('z','a') matches case-insensitively (3.5)
+# covers: collate4 collate4-2.1.9 — after the custom-index rejection the IN query still returns the NOCASE-correct rows (3.4, 3.5)
+# covers: collate4 collate4-2.2.1b — NATURAL JOIN across nocase/custom-text columns returns all matches with no index (4.1); the (a,b,c) index the original built is rejected because b is custom-collated (4.2)
+# covers: collate4 collate4-2.2.2 — explicit (.. c COLLATE TEXT) index rejected (4.3); BINARY-override index accepted and join result unchanged (4.4)
+# covers: collate4 collate4-4.3 — min() over custom-TEXT column correct with the index rejected (5.1, 5.2)
+# covers: collate4 collate4-4.4 — max() over custom-TEXT column correct (5.1)
+# covers: collate4 collate4-4.5 — COLLATE NUMERIC index rejected verbatim; min/max still correct (5.3, 5.4)
+# covers: enc enc-11.1 — index on test_collate column rejected verbatim; table usable, collation-based equality still answers (6.1, 6.2)
+# covers: select9 select9-2.1.1 — CREATE INDEX ... e COLLATE REVERSE rejected verbatim (7.1); compound UNION ORDER BY 2 COLLATE reverse, 1 returns the exact upstream rows (7.3)
+# covers: select9 select9-2.X — the rejected index truly does not exist: DROP INDEX fails with no such index (7.2)
+# covers: select9 select9-3.1 — SELECT a ORDER BY 1 with no index sorts, full correct order (7.4)
+# covers: select9 select9-4.1 — same assertion as 3.1 upstream (7.4); index restores nosort ordered scan (7.5)
+# covers: window6 window6-3.1 — index named with keyword 'window' using custom collation rejected verbatim (8.1); ORDER BY x COLLATE window correct without it (8.2) and with a keyword-named BINARY index (8.3)
+# covers: windowE windowE-1.0 — CREATE INDEX t1b ON t1(b custom-collated) rejected verbatim (9.1); window RANGE frame over the custom collation works, upstream 1.2 result (9.2)
+# covers: windowE windowE-1.3 — after the collation proc flips, the frame result equals stock's verified no-index answer (9.3)
+# covers: collate1 collate1-6.7 — DELETE of a parent row referenced through a case-insensitive-collated PK fails with FOREIGN KEY constraint failed; built-in NOCASE stands in for the custom '"""' collation and the row is addressed by PK value, not rowid (10.1, 10.2, 10.3)
+# covers: collate3 collate3-1.6.1 — custom-collated column orders correctly while registered (11.1); index on it rejected verbatim instead of being created (11.2)
+# covers: collate3 collate3-1.6.3 — reopen without the collation: integrity_check is ok because no custom-collated index can exist (11.10)
+# covers: collate3 collate3-1.6.4 — REINDEX succeeds after reopen for the same reason (11.11)
+# covers: collate3 collate3-1.7.1 — CREATE INDEX (a COLLATE caseless) on a plain column rejected verbatim (11.3)
+# covers: collate3 collate3-1.7.3 — integrity_check ok without the collation registered (11.10)
+# covers: collate3 collate3-1.7.4 — REINDEX ok without the collation registered (11.11)
+# covers: collate3 collate3-3.0 — index rejected at creation (11.2), reopen still serves the data (11.4)
+# covers: collate3 collate3-3.1 — INSERT succeeds after reopen: no custom index forces a comparison (11.12)
+# covers: collate3 collate3-3.2 — UPDATE of the custom-collated column succeeds for the same reason (11.13); other columns too (11.14)
+# covers: collate3 collate3-3.4 — DELETE ... WHERE 1 succeeds: no collation-dependent comparison needed (11.15)
+# covers: collate3 collate3-3.5 — table data remains readable throughout (11.4, 11.16)
+# covers: collate3 collate3-3.8 — integrity_check stays ok where stock errored on the orphaned index (11.10)
+# covers: collate3 collate3-3.10 — ORDER BY 1 COLLATE caseless errors: no such collation sequence (11.6)
+# covers: collate3 collate3-3.11 — ORDER BY c1 errors identically through the column collation (11.5)
+# covers: collate3 collate3-3.12 — WHERE c1 = ... errors identically (11.7)
+# covers: collate3 collate3-3.13 — CREATE TABLE referencing the missing collation errors (11.8)
+# covers: collate3 collate3-3.14 — CREATE INDEX on the column errors with no such collation sequence (11.9)
+# covers: collate3 collate3-4.6 — explicit COLLATE-in-index form rejected before it can persist (11.3)
+# not-covered: (none)
+#
+# SUSPECTED BUG: "CREATE TABLE t(b UNIQUE COLLATE custom)" bypasses the
+# custom-collation index rejection.  sqlite3AddCollateType (src/build.c:1976)
+# retrofits the collation onto the already-created implicit UNIQUE index
+# without the DOLTLITE_PROLLY check that sqlite3CreateIndex applies
+# (src/build.c:4387).  The persisted index then uses the custom collation
+# (PRAGMA index_list shows it; ORDER BY b COLLATE custom scans it nosort), and
+# after reopen without the collation registered PRAGMA integrity_check fails
+# with "no such collation sequence" — exactly the state the rejection exists
+# to prevent.  This is why collate4-1.1.7's table (a PRIMARY KEY COLLATE
+# NOCASE, b UNIQUE COLLATE TEXT) is creatable here; tests below use built-in
+# collation equivalents instead of relying on the buggy path.
+
+proc cksort {sql} {
+  set ::sqlite_sort_count 0
+  set data [execsql $sql]
+  if {$::sqlite_sort_count} {set x sort} {set x nosort}
+  lappend data $x
+  return $data
+}
+
+db collate TEXT text_collate
+proc text_collate {a b} { return [string compare $a $b] }
+db collate NUMERIC numeric_collate
+proc numeric_collate {lhs rhs} {
+  if {$lhs == $rhs} {return 0}
+  return [expr ($lhs>$rhs)?1:-1]
+}
+
+#-------------------------------------------------------------------------
+# 1.* — collate4-1.1.*: ORDER BY with single-column indexes.
+#
+do_test doltlite_recover_collation-1.1 {
+  execsql {
+    CREATE TABLE c4t1(a COLLATE NOCASE, b COLLATE TEXT);
+    INSERT INTO c4t1 VALUES('b','b');
+    INSERT INTO c4t1 VALUES(NULL,NULL);
+    INSERT INTO c4t1 VALUES('A','A');
+    INSERT INTO c4t1 VALUES('C','C');
+    CREATE INDEX c4i1 ON c4t1(a);
+  }
+} {}
+do_test doltlite_recover_collation-1.2 {
+  catchsql { CREATE INDEX c4i2 ON c4t1(b) }
+} {1 {doltlite does not support indexes with custom collation 'TEXT'}}
+do_test doltlite_recover_collation-1.3 {
+  cksort { SELECT a FROM c4t1 ORDER BY a }
+} {{} A b C nosort}
+do_test doltlite_recover_collation-1.4 {
+  cksort { SELECT b FROM c4t1 ORDER BY b }
+} {{} A C b sort}
+do_test doltlite_recover_collation-1.5 {
+  cksort { SELECT b FROM c4t1 ORDER BY b COLLATE TEXT }
+} {{} A C b sort}
+
+do_test doltlite_recover_collation-1.6 {
+  execsql {
+    CREATE TABLE c4t2(a TEXT PRIMARY KEY COLLATE NOCASE);
+    INSERT INTO c4t2 VALUES('a');
+    INSERT INTO c4t2 VALUES('B');
+    INSERT INTO c4t2 VALUES('c');
+  }
+} {}
+do_test doltlite_recover_collation-1.7 {
+  catchsql { INSERT INTO c4t2 VALUES(NULL) }
+} {1 {NOT NULL constraint failed: c4t2.a}}
+do_test doltlite_recover_collation-1.8 {
+  cksort { SELECT a FROM c4t2 ORDER BY a }
+} {a B c nosort}
+do_test doltlite_recover_collation-1.9 {
+  cksort { SELECT a FROM c4t2 ORDER BY a COLLATE BINARY }
+} {B a c sort}
+
+do_test doltlite_recover_collation-1.10 {
+  execsql {
+    CREATE TABLE c4t2b(b TEXT UNIQUE);
+    INSERT INTO c4t2b VALUES('a');
+    INSERT INTO c4t2b VALUES('B');
+  }
+} {}
+do_test doltlite_recover_collation-1.11 {
+  cksort { SELECT b FROM c4t2b ORDER BY b }
+} {B a nosort}
+do_test doltlite_recover_collation-1.12 {
+  cksort { SELECT b FROM c4t2b ORDER BY b COLLATE NOCASE }
+} {a B sort}
+
+do_test doltlite_recover_collation-1.13 {
+  catchsql {
+    CREATE TABLE c4t3bad(b COLLATE TEXT, a COLLATE NOCASE, UNIQUE(a), PRIMARY KEY(b))
+  }
+} {1 {doltlite does not support indexes with custom collation 'TEXT'}}
+do_test doltlite_recover_collation-1.14 {
+  execsql {
+    CREATE TABLE c4t3(b TEXT, a COLLATE NOCASE, UNIQUE(a), PRIMARY KEY(b));
+    INSERT INTO c4t3 VALUES('a','a');
+    INSERT INTO c4t3 VALUES('B','B');
+  }
+} {}
+do_test doltlite_recover_collation-1.15 {
+  cksort { SELECT a FROM c4t3 ORDER BY a }
+} {a B nosort}
+do_test doltlite_recover_collation-1.16 {
+  cksort { SELECT a FROM c4t3 ORDER BY a COLLATE BINARY }
+} {B a sort}
+do_test doltlite_recover_collation-1.17 {
+  cksort { SELECT b FROM c4t3 ORDER BY b }
+} {B a nosort}
+do_test doltlite_recover_collation-1.18 {
+  cksort { SELECT b FROM c4t3 ORDER BY b COLLATE NOCASE }
+} {a B sort}
+
+do_test doltlite_recover_collation-1.19 {
+  execsql {
+    CREATE TABLE c4t4(a COLLATE NOCASE, b);
+    INSERT INTO c4t4 VALUES('b','b');
+    INSERT INTO c4t4 VALUES('A','A');
+    INSERT INTO c4t4 VALUES('C','C');
+  }
+} {}
+do_test doltlite_recover_collation-1.20 {
+  catchsql { CREATE INDEX c4i3 ON c4t4(a COLLATE TEXT) }
+} {1 {doltlite does not support indexes with custom collation 'TEXT'}}
+do_test doltlite_recover_collation-1.21 {
+  execsql { CREATE INDEX c4i4 ON c4t4(b COLLATE NOCASE) }
+} {}
+do_test doltlite_recover_collation-1.22 {
+  cksort { SELECT b FROM c4t4 ORDER BY b COLLATE NOCASE }
+} {A b C nosort}
+do_test doltlite_recover_collation-1.23 {
+  cksort { SELECT a FROM c4t4 ORDER BY a COLLATE BINARY }
+} {A C b sort}
+do_test doltlite_recover_collation-1.24 {
+  execsql {
+    DROP TABLE c4t1;
+    DROP TABLE c4t2;
+    DROP TABLE c4t2b;
+    DROP TABLE c4t3;
+    DROP TABLE c4t4;
+  }
+} {}
+
+#-------------------------------------------------------------------------
+# 2.* — collate4-1.2.*: ORDER BY with two-column indexes.
+#
+do_test doltlite_recover_collation-2.1 {
+  execsql {
+    CREATE TABLE u1(a COLLATE NOCASE, b COLLATE TEXT);
+    INSERT INTO u1 VALUES('b','b');
+    INSERT INTO u1 VALUES('A','A');
+    INSERT INTO u1 VALUES('C','C');
+  }
+} {}
+do_test doltlite_recover_collation-2.2 {
+  catchsql { CREATE INDEX u1bad ON u1(a, b) }
+} {1 {doltlite does not support indexes with custom collation 'TEXT'}}
+do_test doltlite_recover_collation-2.3 {
+  execsql { CREATE INDEX u1i ON u1(a, b COLLATE BINARY) }
+} {}
+do_test doltlite_recover_collation-2.4 {
+  cksort { SELECT a FROM u1 ORDER BY a }
+} {A b C nosort}
+do_test doltlite_recover_collation-2.5 {
+  cksort { SELECT a FROM u1 ORDER BY a, b COLLATE BINARY }
+} {A b C nosort}
+do_test doltlite_recover_collation-2.6 {
+  catchsql { CREATE INDEX u1bad2 ON u1(a COLLATE TEXT, b COLLATE NOCASE) }
+} {1 {doltlite does not support indexes with custom collation 'TEXT'}}
+do_test doltlite_recover_collation-2.7 {
+  execsql { CREATE INDEX u1i2 ON u1(a COLLATE BINARY, b COLLATE NOCASE) }
+} {}
+do_test doltlite_recover_collation-2.8 {
+  cksort { SELECT a FROM u1 ORDER BY a COLLATE BINARY }
+} {A C b nosort}
+do_test doltlite_recover_collation-2.9 {
+  cksort { SELECT a FROM u1 ORDER BY a COLLATE BINARY, b COLLATE NOCASE }
+} {A C b nosort}
+do_test doltlite_recover_collation-2.10 {
+  cksort { SELECT a FROM u1 ORDER BY a COLLATE BINARY DESC }
+} {b C A nosort}
+do_test doltlite_recover_collation-2.11 {
+  cksort { SELECT a FROM u1 ORDER BY a COLLATE BINARY DESC, b COLLATE NOCASE DESC }
+} {b C A nosort}
+do_test doltlite_recover_collation-2.12 {
+  catchsql {
+    CREATE TABLE u2bad(a COLLATE NOCASE, b COLLATE TEXT, PRIMARY KEY(a, b))
+  }
+} {1 {doltlite does not support indexes with custom collation 'TEXT'}}
+do_test doltlite_recover_collation-2.13 {
+  execsql {
+    CREATE TABLE u2(a COLLATE NOCASE, b, PRIMARY KEY(a, b));
+    INSERT INTO u2 VALUES('a','a');
+    INSERT INTO u2 VALUES('B','B');
+  }
+} {}
+do_test doltlite_recover_collation-2.14 {
+  cksort { SELECT a FROM u2 ORDER BY a }
+} {a B nosort}
+do_test doltlite_recover_collation-2.15 {
+  cksort { SELECT a FROM u2 ORDER BY a COLLATE BINARY }
+} {B a sort}
+do_test doltlite_recover_collation-2.16 {
+  cksort { SELECT a FROM u2 ORDER BY a, b }
+} {a B nosort}
+do_test doltlite_recover_collation-2.17 {
+  cksort { SELECT a FROM u2 ORDER BY a, b COLLATE NOCASE }
+} {a B sort}
+do_test doltlite_recover_collation-2.18 {
+  execsql {
+    DROP TABLE u1;
+    DROP TABLE u2;
+  }
+} {}
+
+#-------------------------------------------------------------------------
+# 3.* — collate4-2.1.*: WHERE clauses across differently-collated columns.
+#
+do_test doltlite_recover_collation-3.1 {
+  execsql {
+    CREATE TABLE w1(a COLLATE NOCASE);
+    CREATE TABLE w2(b COLLATE TEXT);
+    INSERT INTO w1 VALUES('a'),('A'),('b'),('B'),('c'),('C'),('d'),('D'),('e'),('D');
+    INSERT INTO w2 VALUES('A'),('Z');
+    SELECT * FROM w2, w1 WHERE a = b ORDER BY w1.a COLLATE BINARY;
+  }
+} {A A A a}
+do_test doltlite_recover_collation-3.2 {
+  execsql { CREATE INDEX w1i ON w1(a) }
+  execsql { SELECT * FROM w2, w1 WHERE a = b ORDER BY w1.a COLLATE BINARY }
+} {A A A a}
+do_test doltlite_recover_collation-3.3 {
+  execsql { SELECT * FROM w2, w1 WHERE b = a ORDER BY w1.a COLLATE BINARY }
+} {A A}
+do_test doltlite_recover_collation-3.4 {
+  catchsql { CREATE INDEX w1i2 ON w1(a COLLATE TEXT) }
+} {1 {doltlite does not support indexes with custom collation 'TEXT'}}
+do_test doltlite_recover_collation-3.5 {
+  execsql { SELECT a FROM w1 WHERE a IN ('z','a') ORDER BY a COLLATE BINARY }
+} {A a}
+do_test doltlite_recover_collation-3.6 {
+  execsql { SELECT a FROM w1 WHERE a IN (SELECT b FROM w2) ORDER BY a COLLATE BINARY }
+} {A a}
+
+#-------------------------------------------------------------------------
+# 4.* — collate4-2.2.*: NATURAL JOIN with mixed collations.
+#
+do_test doltlite_recover_collation-4.1 {
+  execsql {
+    CREATE TABLE j1(a COLLATE NOCASE, b COLLATE TEXT, c);
+    CREATE TABLE j2(a COLLATE NOCASE, b COLLATE TEXT, c COLLATE TEXT);
+    INSERT INTO j1 VALUES('0','0','0'),('0','0','1'),('0','1','0'),('0','1','1'),
+                         ('1','0','0'),('1','0','1'),('1','1','0'),('1','1','1');
+    INSERT INTO j2 SELECT * FROM j1;
+    SELECT * FROM j2 NATURAL JOIN j1 ORDER BY j1.a, j1.b, j1.c;
+  }
+} {0 0 0 0 0 1 0 1 0 0 1 1 1 0 0 1 0 1 1 1 0 1 1 1}
+do_test doltlite_recover_collation-4.2 {
+  catchsql { CREATE INDEX j1bad ON j1(a, b, c) }
+} {1 {doltlite does not support indexes with custom collation 'TEXT'}}
+do_test doltlite_recover_collation-4.3 {
+  catchsql { CREATE INDEX j1bad2 ON j1(a, b, c COLLATE TEXT) }
+} {1 {doltlite does not support indexes with custom collation 'TEXT'}}
+do_test doltlite_recover_collation-4.4 {
+  execsql { CREATE INDEX j1i ON j1(a, b COLLATE BINARY, c) }
+  execsql { SELECT * FROM j2 NATURAL JOIN j1 ORDER BY j1.a, j1.b, j1.c }
+} {0 0 0 0 0 1 0 1 0 0 1 1 1 0 0 1 0 1 1 1 0 1 1 1}
+
+#-------------------------------------------------------------------------
+# 5.* — collate4-4.*: min()/max() over a custom-collated column.
+#
+do_test doltlite_recover_collation-5.1 {
+  execsql {
+    CREATE TABLE mm(a COLLATE TEXT);
+    INSERT INTO mm VALUES('2'),('10'),('20'),('104');
+    SELECT min(a), max(a) FROM mm;
+  }
+} {10 20}
+do_test doltlite_recover_collation-5.2 {
+  catchsql { CREATE INDEX mmi ON mm(a) }
+} {1 {doltlite does not support indexes with custom collation 'TEXT'}}
+do_test doltlite_recover_collation-5.3 {
+  catchsql { CREATE INDEX mmi ON mm(a COLLATE NUMERIC) }
+} {1 {doltlite does not support indexes with custom collation 'NUMERIC'}}
+do_test doltlite_recover_collation-5.4 {
+  execsql { SELECT min(a), max(a) FROM mm }
+} {10 20}
+
+#-------------------------------------------------------------------------
+# 6.* — enc-11.1: index over a custom-collated text column with odd utf8.
+#
+db collate test_collate test_collate_cmp
+proc test_collate_cmp {a b} { return [string compare $a $b] }
+do_test doltlite_recover_collation-6.1 {
+  execsql {
+    CREATE TABLE ab(a COLLATE test_collate, b);
+    INSERT INTO ab VALUES(CAST (X'C388' AS TEXT), X'888800');
+    INSERT INTO ab VALUES(CAST (X'C0808080808080808080808080808080808080808080808080808080808080808080808080808080808080808080808080808080808388' AS TEXT), X'888800');
+  }
+  catchsql { CREATE INDEX ab_i ON ab(a, b) }
+} {1 {doltlite does not support indexes with custom collation 'test_collate'}}
+do_test doltlite_recover_collation-6.2 {
+  set cp200 "È"
+  execsql { SELECT count(*) FROM ab WHERE a = $::cp200 }
+} {1}
+
+#-------------------------------------------------------------------------
+# 7.* — select9: compound selects ordered by a custom collation.
+#
+db collate reverse reverse_cmp
+proc reverse_cmp {lhs rhs} { return [string compare $rhs $lhs] }
+do_test doltlite_recover_collation-7.1 {
+  execsql {
+    CREATE TABLE s1(a, b, c);
+    CREATE TABLE s2(d, e, f);
+    INSERT INTO s1 VALUES(1,'one','I'),(3,NULL,NULL),(5,'five','V'),(7,'seven','VII'),
+      (9,NULL,NULL),(2,'two','II'),(4,'four','IV'),(6,NULL,NULL),(8,'eight','VIII'),
+      (10,'ten','X');
+    INSERT INTO s2 VALUES(1,'two','IV'),(2,'four','VIII'),(3,NULL,NULL),(4,'eight','XVI'),
+      (5,'ten','XX'),(6,NULL,NULL),(7,'fourteen','XXVIII'),(8,'sixteen','XXXII'),
+      (9,NULL,NULL),(10,'twenty','XL');
+  }
+  catchsql { CREATE INDEX s2i ON s2(d DESC, e COLLATE REVERSE ASC) }
+} {1 {doltlite does not support indexes with custom collation 'REVERSE'}}
+do_test doltlite_recover_collation-7.2 {
+  catchsql { DROP INDEX s2i }
+} {1 {no such index: s2i}}
+do_test doltlite_recover_collation-7.3 {
+  execsql {
+    SELECT * FROM s1 WHERE a<5 UNION SELECT * FROM s2 WHERE d>=5
+    ORDER BY 2 COLLATE reverse, 1
+  }
+} {3 {} {} 6 {} {} 9 {} {} 2 two II 10 twenty XL 5 ten XX 8 sixteen XXXII 1 one I 7 fourteen XXVIII 4 four IV}
+do_test doltlite_recover_collation-7.4 {
+  cksort { SELECT a FROM s1 ORDER BY 1 }
+} {1 2 3 4 5 6 7 8 9 10 sort}
+do_test doltlite_recover_collation-7.5 {
+  execsql { CREATE INDEX s1i ON s1(a) }
+  cksort { SELECT a FROM s1 ORDER BY 1 }
+} {1 2 3 4 5 6 7 8 9 10 nosort}
+
+#-------------------------------------------------------------------------
+# 8.* — window6-3.1: 'window' keyword as object name + custom collation.
+#
+db collate window wincmp
+proc wincmp {a b} { string compare $b $a }
+do_test doltlite_recover_collation-8.1 {
+  execsql {
+    CREATE TABLE x1(x);
+    INSERT INTO x1 VALUES('bob'),('alice'),('cate');
+  }
+  catchsql { CREATE INDEX window ON x1(x COLLATE window) }
+} {1 {doltlite does not support indexes with custom collation 'window'}}
+do_test doltlite_recover_collation-8.2 {
+  execsql { SELECT * FROM x1 ORDER BY x COLLATE window }
+} {cate bob alice}
+do_test doltlite_recover_collation-8.3 {
+  execsql {
+    CREATE INDEX window ON x1(x);
+    SELECT * FROM x1 ORDER BY x COLLATE window;
+  }
+} {cate bob alice}
+
+#-------------------------------------------------------------------------
+# 9.* — windowE: RANGE window frames ordered by a custom collation.
+#
+db collate custom custom_cmp
+proc custom_cmp {a b} { return [string compare $a $b] }
+do_test doltlite_recover_collation-9.1 {
+  execsql {
+    CREATE TABLE wt1(a INTEGER PRIMARY KEY, b TEXT COLLATE custom);
+    INSERT INTO wt1 VALUES(1,'one'),(2,'two'),(3,'three'),(4,'four'),(5,'five'),(6,'six');
+  }
+  catchsql { CREATE INDEX wt1b ON wt1(b) }
+} {1 {doltlite does not support indexes with custom collation 'custom'}}
+do_test doltlite_recover_collation-9.2 {
+  execsql {
+    SELECT group_concat(a,',') OVER win FROM wt1
+    WINDOW win AS (ORDER BY b RANGE BETWEEN 1 PRECEDING AND 2 PRECEDING)
+  }
+} {5 4 1 6 3 2}
+proc custom_cmp {a b} { return [string compare $b $a] }
+do_test doltlite_recover_collation-9.3 {
+  db cache flush
+  execsql {
+    SELECT group_concat(a,',') OVER win FROM wt1
+    WINDOW win AS (ORDER BY b RANGE BETWEEN 1 PRECEDING AND 2 PRECEDING)
+  }
+} {2 3 6 1 4 5}
+
+#-------------------------------------------------------------------------
+# 10.* — collate1-6.7: FK enforcement through a case-insensitive parent PK.
+#
+do_test doltlite_recover_collation-10.1 {
+  execsql {
+    PRAGMA foreign_keys = ON;
+    CREATE TABLE p1(a TEXT PRIMARY KEY COLLATE NOCASE);
+    CREATE TABLE ch1(x, y REFERENCES p1);
+    INSERT INTO p1 VALUES('abc');
+    INSERT INTO ch1 VALUES(1, 'ABC');
+  }
+} {}
+do_test doltlite_recover_collation-10.2 {
+  catchsql { DELETE FROM p1 WHERE a = 'abc' }
+} {1 {FOREIGN KEY constraint failed}}
+do_test doltlite_recover_collation-10.3 {
+  execsql { SELECT * FROM p1 }
+} {abc}
+
+#-------------------------------------------------------------------------
+# 11.* — collate3: reopen without the custom collation registered.  Because
+# doltlite refuses to persist custom-collated indexes, the database stays
+# fully consistent: only statements that actually need the collation fail.
+#
+db close
+forcedelete test.db
+sqlite3 db test.db
+db collate caseless caseless_cmp
+proc caseless_cmp {a b} { string compare -nocase $a $b }
+do_test doltlite_recover_collation-11.1 {
+  execsql {
+    CREATE TABLE ct1(c1 COLLATE caseless, c2);
+    INSERT INTO ct1 VALUES('Abc2','y');
+    INSERT INTO ct1 VALUES('abc1','y');
+    INSERT INTO ct1 VALUES('aBc3','y');
+    SELECT c1 FROM ct1 ORDER BY c1;
+  }
+} {abc1 Abc2 aBc3}
+do_test doltlite_recover_collation-11.2 {
+  catchsql { CREATE INDEX cti1 ON ct1(c1) }
+} {1 {doltlite does not support indexes with custom collation 'caseless'}}
+do_test doltlite_recover_collation-11.3 {
+  execsql { CREATE TABLE ct2(a) }
+  catchsql { CREATE INDEX cti2 ON ct2(a COLLATE caseless) }
+} {1 {doltlite does not support indexes with custom collation 'caseless'}}
+do_test doltlite_recover_collation-11.4 {
+  db close
+  sqlite3 db test.db
+  execsql { SELECT count(*) FROM ct1 }
+} {3}
+do_test doltlite_recover_collation-11.5 {
+  catchsql { SELECT c1 FROM ct1 ORDER BY c1 }
+} {1 {no such collation sequence: caseless}}
+do_test doltlite_recover_collation-11.6 {
+  catchsql { SELECT c1 FROM ct1 ORDER BY 1 COLLATE caseless }
+} {1 {no such collation sequence: caseless}}
+do_test doltlite_recover_collation-11.7 {
+  catchsql { SELECT * FROM ct1 WHERE c1 = 'abc1' }
+} {1 {no such collation sequence: caseless}}
+do_test doltlite_recover_collation-11.8 {
+  catchsql { CREATE TABLE bad(c1 COLLATE caseless) }
+} {1 {no such collation sequence: caseless}}
+do_test doltlite_recover_collation-11.9 {
+  catchsql { CREATE INDEX cti3 ON ct1(c1) }
+} {1 {no such collation sequence: caseless}}
+do_test doltlite_recover_collation-11.10 {
+  catchsql { PRAGMA integrity_check }
+} {0 ok}
+do_test doltlite_recover_collation-11.11 {
+  catchsql { REINDEX }
+} {0 {}}
+do_test doltlite_recover_collation-11.12 {
+  catchsql { INSERT INTO ct1 VALUES('xxx','y') }
+} {0 {}}
+do_test doltlite_recover_collation-11.13 {
+  catchsql { UPDATE ct1 SET c1 = 'yyy' }
+} {0 {}}
+do_test doltlite_recover_collation-11.14 {
+  catchsql { UPDATE ct1 SET c2 = 'z' }
+} {0 {}}
+do_test doltlite_recover_collation-11.15 {
+  catchsql { DELETE FROM ct1 WHERE 1 }
+} {0 {}}
+do_test doltlite_recover_collation-11.16 {
+  execsql { SELECT count(*) FROM ct1 }
+} {0}
+
+finish_test

--- a/test/doltlite_recover_ordering.test
+++ b/test/doltlite_recover_ordering.test
@@ -1,0 +1,370 @@
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+# Recovers the intent of gated ordering/metric divergences through doltlite's
+# real surface: rowid/insertion-order assertions become PK-ordered (ORDER BY)
+# multiset assertions, and internal scan-counter assertions become EXPLAIN
+# QUERY PLAN assertions.
+#
+# covers: select1 select1-2.23 — aliased-aggregate misuse error still raised; NULL PKs of the original replaced with real PKs (doltlite PKs are NOT NULL)
+# covers: index index-11.1 — PK(b) point lookup returns the right row AND EQP proves SEARCH USING PRIMARY KEY (search_count metric replaced by plan assertion)
+# covers: index index-13.2 — t5 UNIQUE auto-indexes exist by name (ORDER BY name; PK has no separate index in doltlite), all undroppable, PK+UNIQUE still enforced
+# covers: index index-17.1 — sqlite_autoindex_t7_N naming convention asserted with ORDER BY name instead of rowid order; constraints enforced and undroppable
+# covers: collate4 collate4-1.1.7 — NOCASE PK accepts case-distinct rows, rejects NOCASE-equal dup and NULL PK; NOCASE vs BINARY ORDER BY both asserted (custom TEXT collation replaced by built-in BINARY)
+# covers: window1 window1-10.7 — same correlated window subquery with ORDER BY outer.emp added; same multiset of rows
+# covers: window1 window1-10.8 — same FILTER window subquery with ORDER BY outer.emp added; same multiset of rows
+# covers: e_select e_select-4.9.4 — GROUP BY boolean expression groups the same rows; group_concat asserted in doltlite's deterministic PK scan order, ordered by group
+# covers: shared shared-1.10.5 — closing a second connection mid-write-transaction rolls it back; survivor sees only committed rows (ORDER BY pk) and can still write
+# covers: cffault cffault-2.1-cantopen-persistent.1 — cacheflush mid-scan over pending UPDATE: scan sees updated rows in PK order, txn stays open, COMMIT durable across reopen
+# covers: cffault cffault-2.1-cantopen-transient.1 — same scenario (single deterministic cacheflush pass; fault-injection variants collapse to it)
+# covers: cffault cffault-2.1-full.1 — same scenario
+# covers: cffault cffault-2.1-ioerr-persistent.1 — same scenario
+# covers: cffault cffault-2.1-ioerr-transient.1 — same scenario
+# covers: cffault cffault-2.1-oom-persistent.31 — same scenario
+# covers: cffault cffault-2.1-oom-transient.28 — same scenario
+# covers: cffault cffault-2.1-oom-transient.31 — same scenario
+# covers: cffault cffault-2.1-shmerr-persistent.1 — same scenario
+# covers: cffault cffault-2.1-shmerr-transient.1 — same scenario
+# covers: cffault cffault-2.4-oom-transient.22 — cacheflush + db_release_memory + cacheflush over pending UPDATE: SELECT sees updated rows, ROLLBACK restores originals
+# covers: altercol altercol-11.1 — RENAME COLUMN rewrites table and index SQL; sqlite_master read with ORDER BY name instead of creation order (echo vtable dropped: module not built here, vtable surface is doltlite-intentional)
+# covers: limit2 limit2-110.3 — search_count ratio replaced by plan assertion: both ORDER BY b and ORDER BY +b forms return identical correct rows and EQP uses covering-index searches, never a full scan
+# not-covered: (none)
+
+#-------------------------------------------------------------------------
+# select1-2.23
+#
+do_test doltlite_recover_ordering-1.1 {
+  execsql {
+    CREATE TABLE tkt2526(a,b,c PRIMARY KEY);
+    INSERT INTO tkt2526 VALUES('x','y',1);
+    INSERT INTO tkt2526 VALUES('x','z',2);
+  }
+  catchsql {
+    SELECT count(a) AS cn FROM tkt2526 GROUP BY a HAVING cn<max(cn)
+  }
+} {1 {misuse of aliased aggregate cn}}
+do_test doltlite_recover_ordering-1.2 {
+  execsql {SELECT a, count(a) FROM tkt2526 GROUP BY a ORDER BY a}
+} {x 2}
+
+#-------------------------------------------------------------------------
+# index-11.1
+#
+do_test doltlite_recover_ordering-2.1 {
+  execsql {
+    CREATE TABLE t3(
+      a text,
+      b int,
+      c float,
+      PRIMARY KEY(b)
+    );
+  }
+  for {set i 1} {$i<=50} {incr i} {
+    execsql "INSERT INTO t3 VALUES('x${i}x',$i,0.$i)"
+  }
+  execsql {SELECT c FROM t3 WHERE b==10}
+} {0.1}
+do_test doltlite_recover_ordering-2.2 {
+  set res [list]
+  db eval {EXPLAIN QUERY PLAN SELECT c FROM t3 WHERE b==10} x {
+    lappend res [set x(detail)]
+  }
+  set res
+} {{SEARCH t3 USING PRIMARY KEY (b=?)}}
+
+#-------------------------------------------------------------------------
+# index-13.2
+#
+do_test doltlite_recover_ordering-3.1 {
+  execsql {
+   CREATE TABLE t5(
+      a int UNIQUE,
+      b float PRIMARY KEY,
+      c varchar(10),
+      UNIQUE(a,c)
+   );
+   INSERT INTO t5 VALUES(1,2,3);
+   SELECT * FROM t5;
+  }
+} {1 2.0 3}
+do_test doltlite_recover_ordering-3.2 {
+  execsql {
+    SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='t5'
+    ORDER BY name
+  }
+} {sqlite_autoindex_t5_1 sqlite_autoindex_t5_3}
+do_test doltlite_recover_ordering-3.3 {
+  catchsql {INSERT INTO t5 VALUES(2,2,4)}
+} {1 {UNIQUE constraint failed: t5.b}}
+do_test doltlite_recover_ordering-3.4 {
+  catchsql {INSERT INTO t5 VALUES(1,3,4)}
+} {1 {UNIQUE constraint failed: t5.a}}
+do_test doltlite_recover_ordering-3.5 {
+  catchsql {DROP INDEX 'sqlite_autoindex_t5_1'}
+} {1 {index associated with UNIQUE or PRIMARY KEY constraint cannot be dropped}}
+do_test doltlite_recover_ordering-3.6 {
+  catchsql {DROP INDEX 'sqlite_autoindex_t5_3'}
+} {1 {index associated with UNIQUE or PRIMARY KEY constraint cannot be dropped}}
+
+#-------------------------------------------------------------------------
+# index-17.1
+#
+do_test doltlite_recover_ordering-4.1 {
+  execsql {
+    CREATE TABLE t7(c, d UNIQUE, UNIQUE(c), PRIMARY KEY(c, d) );
+    SELECT name FROM sqlite_master WHERE tbl_name = 't7' AND type = 'index'
+    ORDER BY name;
+  }
+} {sqlite_autoindex_t7_1 sqlite_autoindex_t7_2}
+do_test doltlite_recover_ordering-4.2 {
+  execsql {INSERT INTO t7 VALUES(1, 2)}
+  list [catchsql {INSERT INTO t7 VALUES(1, 3)}] \
+       [catchsql {INSERT INTO t7 VALUES(2, 2)}]
+} {{1 {UNIQUE constraint failed: t7.c}} {1 {UNIQUE constraint failed: t7.d}}}
+do_test doltlite_recover_ordering-4.3 {
+  catchsql {DROP INDEX sqlite_autoindex_t7_1}
+} {1 {index associated with UNIQUE or PRIMARY KEY constraint cannot be dropped}}
+do_test doltlite_recover_ordering-4.4 {
+  catchsql {DROP INDEX sqlite_autoindex_t7_2}
+} {1 {index associated with UNIQUE or PRIMARY KEY constraint cannot be dropped}}
+
+#-------------------------------------------------------------------------
+# collate4-1.1.7
+#
+do_test doltlite_recover_ordering-5.1 {
+  execsql {
+    CREATE TABLE collate4t2(
+      a PRIMARY KEY COLLATE NOCASE,
+      b UNIQUE
+    );
+    INSERT INTO collate4t2 VALUES( 'a', 'a' );
+    INSERT INTO collate4t2 VALUES( 'B', 'B' );
+  }
+} {}
+do_test doltlite_recover_ordering-5.2 {
+  catchsql {INSERT INTO collate4t2 VALUES(NULL, NULL)}
+} {1 {NOT NULL constraint failed: collate4t2.a}}
+do_test doltlite_recover_ordering-5.3 {
+  catchsql {INSERT INTO collate4t2 VALUES('A', 'x')}
+} {1 {UNIQUE constraint failed: collate4t2.a}}
+do_test doltlite_recover_ordering-5.4 {
+  execsql {SELECT a FROM collate4t2 ORDER BY a}
+} {a B}
+do_test doltlite_recover_ordering-5.5 {
+  execsql {SELECT a FROM collate4t2 ORDER BY a COLLATE BINARY}
+} {B a}
+
+#-------------------------------------------------------------------------
+# window1-10.7 / window1-10.8
+#
+do_test doltlite_recover_ordering-6.1 {
+  execsql {
+    CREATE TABLE sales(emp TEXT PRIMARY KEY, region, total);
+    INSERT INTO sales VALUES
+        ('Alice',     'North', 34),
+        ('Frank',     'South', 22),
+        ('Charles',   'North', 45),
+        ('Darrell',   'South', 8),
+        ('Grant',     'South', 23),
+        ('Brad' ,     'North', 22),
+        ('Elizabeth', 'South', 99),
+        ('Horace',    'East',   1);
+  }
+  execsql {
+    SELECT emp, region, (
+      SELECT sum(total) OVER (
+        ORDER BY total RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+      ) || outer.emp FROM sales
+    ) FROM sales AS outer ORDER BY outer.emp;
+  }
+} {Alice North 254Alice Brad North 254Brad Charles North 254Charles Darrell South 254Darrell Elizabeth South 254Elizabeth Frank South 254Frank Grant South 254Grant Horace East 254Horace}
+do_test doltlite_recover_ordering-6.2 {
+  execsql {
+    SELECT emp, region, (
+      SELECT sum(total) FILTER (WHERE sales.emp!=outer.emp) OVER (
+        ORDER BY total RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+      ) FROM sales
+    ) FROM sales AS outer ORDER BY outer.emp;
+  }
+} {Alice North 220 Brad North 232 Charles North 209 Darrell South 246 Elizabeth South 155 Frank South 232 Grant South 231 Horace East 253}
+
+#-------------------------------------------------------------------------
+# e_select-4.9.4
+#
+do_test doltlite_recover_ordering-7.1 {
+  execsql {
+    CREATE TABLE b1(one PRIMARY KEY, two);
+    INSERT INTO b1 VALUES(1, 'o');
+    INSERT INTO b1 VALUES(4, 'f');
+    INSERT INTO b1 VALUES(3, 't');
+    INSERT INTO b1 VALUES(2, 't');
+    INSERT INTO b1 VALUES(5, 'f');
+    INSERT INTO b1 VALUES(7, 's');
+    INSERT INTO b1 VALUES(6, 's');
+  }
+  execsql {
+    SELECT (one==2 OR two=='o') AS g, count(*), sum(one)
+    FROM b1 GROUP BY g ORDER BY g
+  }
+} {0 5 25 1 2 3}
+do_test doltlite_recover_ordering-7.2 {
+  execsql {
+    SELECT (one==2 OR two=='o') AS g, group_concat(one)
+    FROM b1 GROUP BY g ORDER BY g
+  }
+} {0 3,4,5,6,7 1 1,2}
+
+#-------------------------------------------------------------------------
+# shared-1.10.5
+#
+do_test doltlite_recover_ordering-8.1 {
+  execsql {
+    CREATE TABLE de(d PRIMARY KEY, e);
+    INSERT INTO de VALUES('Ubon', 120000);
+    INSERT INTO de VALUES('Khon Kaen', 200000);
+  }
+  sqlite3 db2 test.db
+  execsql {
+    BEGIN;
+    INSERT INTO de VALUES('Pataya', 30000);
+  } db2
+  db2 close
+  execsql {SELECT * FROM de ORDER BY d}
+} {{Khon Kaen} 200000 Ubon 120000}
+do_test doltlite_recover_ordering-8.2 {
+  execsql {
+    INSERT INTO de VALUES('Chiang Mai', 100000);
+    SELECT d FROM de ORDER BY d;
+  }
+} {{Chiang Mai} {Khon Kaen} Ubon}
+
+#-------------------------------------------------------------------------
+# cffault-2.1-* : sqlite3_db_cacheflush during a scan of updated rows
+#
+do_test doltlite_recover_ordering-9.1 {
+  execsql {
+    CREATE TABLE cf1(a PRIMARY KEY, b, c);
+    CREATE INDEX cfi1 ON cf1(b);
+    INSERT INTO cf1 VALUES(1, 2,  zeroblob(600));
+    INSERT INTO cf1 VALUES(3, 4,  zeroblob(600));
+    INSERT INTO cf1 VALUES(5, 6,  zeroblob(600));
+    INSERT INTO cf1 VALUES(7, 8,  zeroblob(600));
+    INSERT INTO cf1 VALUES(9, 10, zeroblob(600));
+    BEGIN;
+    UPDATE cf1 SET b=b+1;
+  }
+  set result [list]
+  db eval { SELECT a, b FROM cf1 ORDER BY a } {
+    if {$a==5} { catch { sqlite3_db_cacheflush db } }
+    lappend result $a $b
+  }
+  set result
+} {1 3 3 5 5 7 7 9 9 11}
+do_test doltlite_recover_ordering-9.2 {
+  sqlite3_get_autocommit db
+} {0}
+do_test doltlite_recover_ordering-9.3 {
+  execsql {
+    INSERT INTO cf1 VALUES(11, 12, zeroblob(600));
+    COMMIT;
+  }
+  execsql {SELECT a, b FROM cf1 ORDER BY a}
+} {1 3 3 5 5 7 7 9 9 11 11 12}
+do_test doltlite_recover_ordering-9.4 {
+  db close
+  sqlite3 db test.db
+  execsql {SELECT a, b FROM cf1 ORDER BY a}
+} {1 3 3 5 5 7 7 9 9 11 11 12}
+do_test doltlite_recover_ordering-9.5 {
+  execsql {PRAGMA integrity_check}
+} {ok}
+
+#-------------------------------------------------------------------------
+# cffault-2.4-oom-transient.22 : cacheflush + release-memory + cacheflush
+#
+do_test doltlite_recover_ordering-10.1 {
+  execsql {
+    BEGIN;
+    UPDATE cf1 SET b=b-1;
+  }
+  catch { sqlite3_db_cacheflush db }
+  catch { sqlite3_db_release_memory db }
+  catch { sqlite3_db_cacheflush db }
+  execsql { SELECT a, b FROM cf1 ORDER BY a }
+} {1 2 3 4 5 6 7 8 9 10 11 11}
+do_test doltlite_recover_ordering-10.2 {
+  execsql {ROLLBACK}
+  execsql {SELECT a, b FROM cf1 ORDER BY a}
+} {1 3 3 5 5 7 7 9 9 11 11 12}
+do_test doltlite_recover_ordering-10.3 {
+  execsql {PRAGMA integrity_check}
+} {ok}
+
+#-------------------------------------------------------------------------
+# altercol-11.1
+#
+do_test doltlite_recover_ordering-11.1 {
+  execsql {
+    CREATE TABLE x1(a, b, c);
+    CREATE INDEX x1b ON x1(b);
+    CREATE TABLE x2(q);
+    INSERT INTO x1 VALUES(1, 2, 3);
+    ALTER TABLE x1 RENAME b TO bbb;
+  }
+  execsql {
+    SELECT sql FROM sqlite_master
+    WHERE name IN ('x1','x1b','x2') ORDER BY name
+  }
+} {{CREATE TABLE x1(a, bbb, c)} {CREATE INDEX x1b ON x1(bbb)} {CREATE TABLE x2(q)}}
+do_test doltlite_recover_ordering-11.2 {
+  execsql {SELECT bbb FROM x1 WHERE bbb=2 ORDER BY a}
+} {2}
+
+#-------------------------------------------------------------------------
+# limit2-110.3
+#
+do_test doltlite_recover_ordering-12.1 {
+  execsql {
+    CREATE TABLE lt1(a,b);
+    WITH RECURSIVE c(x) AS (VALUES(1) UNION ALL SELECT x+1 FROM c WHERE x<1000)
+      INSERT INTO lt1(a,b) SELECT 1, (x*17)%1000 + 1000 FROM c;
+    INSERT INTO lt1(a,b) VALUES(2,2),(3,1006),(4,4),(5,9999);
+    CREATE INDEX lt1ab ON lt1(a,b);
+    CREATE TABLE lt2(x,y);
+    INSERT INTO lt2(x,y) VALUES('a',1),('a',2),('a',3),('a',4);
+    INSERT INTO lt2(x,y) VALUES('b',1),('c',2),('d',3),('e',4);
+    CREATE INDEX lt2xy ON lt2(x,y);
+  }
+  execsql {
+    SELECT a, b, '|' FROM lt2, lt1
+    WHERE lt2.x='a' AND lt1.a=lt2.y ORDER BY lt1.b LIMIT 5
+  }
+} {2 2 | 4 4 | 1 1000 | 1 1001 | 1 1002 |}
+do_test doltlite_recover_ordering-12.2 {
+  execsql {
+    SELECT a, b, '|' FROM lt2, lt1
+    WHERE lt2.x='a' AND lt1.a=lt2.y ORDER BY +lt1.b LIMIT 5
+  }
+} {2 2 | 4 4 | 1 1000 | 1 1001 | 1 1002 |}
+do_test doltlite_recover_ordering-12.3 {
+  set res [list]
+  db eval {
+    EXPLAIN QUERY PLAN SELECT a, b, '|' FROM lt2, lt1
+    WHERE lt2.x='a' AND lt1.a=lt2.y ORDER BY lt1.b LIMIT 5
+  } x {
+    lappend res [set x(detail)]
+  }
+  set res
+} {{SEARCH lt2 USING COVERING INDEX lt2xy (x=?)} {SEARCH lt1 USING COVERING INDEX lt1ab (a=?)} {USE TEMP B-TREE FOR ORDER BY}}
+do_test doltlite_recover_ordering-12.4 {
+  set res [list]
+  db eval {
+    EXPLAIN QUERY PLAN SELECT a, b, '|' FROM lt2, lt1
+    WHERE lt2.x='a' AND lt1.a=lt2.y ORDER BY +lt1.b LIMIT 5
+  } x {
+    lappend res [set x(detail)]
+  }
+  set res
+} {{SEARCH lt2 USING COVERING INDEX lt2xy (x=?)} {SEARCH lt1 USING COVERING INDEX lt1ab (a=?)} {USE TEMP B-TREE FOR ORDER BY}}
+
+finish_test

--- a/test/doltlite_recover_utf16_errtext.test
+++ b/test/doltlite_recover_utf16_errtext.test
@@ -1,0 +1,217 @@
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+source $testdir/malloc_common.tcl
+
+# Recovers gated utf16-encoding and fault-error-text divergences (#1164, #1208).
+#
+# like3-8.*: the originals set PRAGMA encoding=UTF-16le/be and asserted the
+# connection reported that encoding, around a scenario storing invalid-UTF8
+# text (CAST X'FF..' AS TEXT) and matching it with LIKE pre/post index.
+# doltlite stores all text as UTF-8 and PRAGMA encoding reports UTF-8 (#1164).
+# Recovered intent: the utf16 pragma is accepted-but-ignored (reports UTF-8),
+# and the exact same invalid-UTF8 values round-trip byte-exactly through the
+# UTF-8 store across an index build and a close/reopen, with LIKE matching.
+#
+# numcast-utf16{le,be}.0: originals asserted the encoding report on a fresh
+# :memory: db; recovered as the UTF-8 report plus the full numeric CAST table
+# the original ran under that encoding (including non-ASCII strings).
+#
+# pagerfault3-1-ioerr-transient.*: original ran VACUUM under transient IO
+# fault injection expecting stock pager error text; doltlite's VACUUM runs
+# dolt_gc, which reports phase-prefixed error text (#1208). Recovered intent:
+# under each injected fault point, VACUUM either succeeds or fails with one of
+# doltlite's exact gc error messages, the data stays readable on the same
+# connection, integrity_check is ok, and a fault-free VACUUM then succeeds.
+#
+# covers: like3 like3-8.utf16le.1.2 — PRAGMA encoding='UTF-16le' then encoding reports UTF-8; X'FF' text scenario intact
+# covers: like3 like3-8.utf16le.2.2 — same UTF-8 report; X'FFBF' text scenario intact
+# covers: like3 like3-8.utf16le.3.2 — same UTF-8 report; X'FFBFBF' text scenario intact
+# covers: like3 like3-8.utf16le.4.2 — same UTF-8 report; X'FFBFBFBF' text scenario intact
+# covers: like3 like3-8.utf16le.5.2 — same UTF-8 report; 'abc'||X'FF' text scenario intact
+# covers: like3 like3-8.utf16le.6.2 — same UTF-8 report; 'def'||X'FFBF' text scenario intact
+# covers: like3 like3-8.utf16le.7.2 — same UTF-8 report; 'ghi'||X'FFBFBF' text scenario intact
+# covers: like3 like3-8.utf16le.8.2 — same UTF-8 report; 'jkl'||X'FFBFBFBF' text scenario intact
+# covers: like3 like3-8.utf16be.1.2 — PRAGMA encoding='UTF-16be' then encoding reports UTF-8; X'FF' text scenario intact
+# covers: like3 like3-8.utf16be.2.2 — same UTF-8 report; X'FFBF' text scenario intact
+# covers: like3 like3-8.utf16be.3.2 — same UTF-8 report; X'FFBFBF' text scenario intact
+# covers: like3 like3-8.utf16be.4.2 — same UTF-8 report; X'FFBFBFBF' text scenario intact
+# covers: like3 like3-8.utf16be.5.2 — same UTF-8 report; 'abc'||X'FF' text scenario intact
+# covers: like3 like3-8.utf16be.6.2 — same UTF-8 report; 'def'||X'FFBF' text scenario intact
+# covers: like3 like3-8.utf16be.7.2 — same UTF-8 report; 'ghi'||X'FFBFBF' text scenario intact
+# covers: like3 like3-8.utf16be.8.2 — same UTF-8 report; 'jkl'||X'FFBFBFBF' text scenario intact
+# covers: numcast numcast-utf16le.0 — fresh :memory: db, PRAGMA encoding='utf16le', report normalizes to utf8; full cast table re-run
+# covers: numcast numcast-utf16be.0 — fresh :memory: db, PRAGMA encoding='utf16be', report normalizes to utf8; full cast table re-run
+# covers: pagerfault3 pagerfault3-1-ioerr-transient.4 — fault point 4: VACUUM error in doltlite gc-message set; data+integrity preserved
+# covers: pagerfault3 pagerfault3-1-ioerr-transient.5 — fault point 5: same contract
+# covers: pagerfault3 pagerfault3-1-ioerr-transient.6 — fault point 6: same contract
+# covers: pagerfault3 pagerfault3-1-ioerr-transient.7 — fault point 7: same contract
+# covers: pagerfault3 pagerfault3-1-ioerr-transient.8 — fault point 8: same contract
+# covers: pagerfault3 pagerfault3-1-ioerr-transient.9 — fault point 9: same contract
+# covers: pagerfault3 pagerfault3-1-ioerr-transient.10 — fault point 10: same contract
+# covers: pagerfault3 pagerfault3-1-ioerr-transient.11 — fault point 11: same contract
+# covers: pagerfault3 pagerfault3-1-ioerr-transient.12 — fault point 12: same contract
+# covers: pagerfault3 pagerfault3-1-ioerr-transient.13 — fault point 13: same contract
+# covers: pagerfault3 pagerfault3-1-ioerr-transient.14 — fault point 14: same contract
+# covers: pagerfault3 pagerfault3-1-ioerr-transient.15 — fault point 15: same contract
+# covers: pagerfault3 pagerfault3-1-ioerr-transient.16 — fault point 16: same contract
+# covers: pagerfault3 pagerfault3-1-ioerr-transient.18 — fault point 18: same contract
+# covers: pagerfault3 pagerfault3-1-ioerr-transient.19 — fault point 19: same contract
+# covers: pagerfault3 pagerfault3-1-ioerr-transient.20 — fault point 20: same contract
+# covers: pagerfault3 pagerfault3-1-ioerr-transient.21 — fault point 21: same contract
+# covers: pagerfault3 pagerfault3-1-ioerr-transient.22 — fault point 22: same contract
+# not-covered: (none)
+
+#-------------------------------------------------------------------------
+# 1.* doltlite encoding pragma contract: utf16 forms are accepted but the
+# connection stays UTF-8; truly unknown names still error.
+#
+do_test doltlite_recover_utf16_errtext-1.1 {
+  execsql {PRAGMA encoding='UTF-16le'}
+  execsql {PRAGMA encoding}
+} {UTF-8}
+do_test doltlite_recover_utf16_errtext-1.2 {
+  execsql {PRAGMA encoding='UTF-16be'}
+  execsql {PRAGMA encoding}
+} {UTF-8}
+do_catchsql_test doltlite_recover_utf16_errtext-1.3 {
+  PRAGMA encoding='bogus'
+} {1 {unsupported encoding: bogus}}
+
+#-------------------------------------------------------------------------
+# 2.* numcast under attempted utf16 encodings (numcast-utf16{le,be}.0)
+#
+foreach enc {utf16le utf16be} {
+  do_test doltlite_recover_utf16_errtext-2.$enc.0 {
+    db close
+    sqlite3 db :memory:
+    db eval "PRAGMA encoding='$enc'"
+    set x [db eval {PRAGMA encoding}]
+    string map {- {}} [string tolower $x]
+  } {utf8}
+  foreach {idx str rval ival} {
+     1 12345.0       12345.0    12345
+     2 12345.0e0     12345.0    12345
+     3 -12345.0e0   -12345.0   -12345
+     4 -12345.25    -12345.25  -12345
+     5 { -12345.0}  -12345.0   -12345
+     6 { 876xyz}       876.0      876
+     7 { 456ķ89}       456.0      456
+     8 { Ġ 321.5}        0.0        0
+  } {
+    do_test doltlite_recover_utf16_errtext-2.$enc.$idx.1 {
+      db eval {SELECT CAST($str AS real)}
+    } $rval
+    do_test doltlite_recover_utf16_errtext-2.$enc.$idx.2 {
+      db eval {SELECT CAST($str AS integer)}
+    } $ival
+  }
+}
+
+#-------------------------------------------------------------------------
+# 3.* like3-8 recovery: invalid-UTF8 text under attempted utf16 encodings.
+# hexwant is the byte-exact UTF-8 image the value must keep across index
+# creation and a close/reopen of the persistent chunk store.
+#
+foreach enc {UTF-16le UTF-16be} {
+  foreach {tn expr hexwant} {
+    1 "CAST (X'FF' AS TEXT)"                FF
+    2 "CAST (X'FFBF' AS TEXT)"              FFBF
+    3 "CAST (X'FFBFBF' AS TEXT)"            FFBFBF
+    4 "CAST (X'FFBFBFBF' AS TEXT)"          FFBFBFBF
+    5 "'abc' || CAST (X'FF' AS TEXT)"       616263FF
+    6 "'def' || CAST (X'FFBF' AS TEXT)"     646566FFBF
+    7 "'ghi' || CAST (X'FFBFBF' AS TEXT)"   676869FFBFBF
+    8 "'jkl' || CAST (X'FFBFBFBF' AS TEXT)" 6A6B6CFFBFBFBF
+  } {
+    set base utf[string range $enc 4 end].$tn
+    reset_db
+    execsql "PRAGMA encoding = '$enc'"
+
+    do_test doltlite_recover_utf16_errtext-3.$base.1 {
+      execsql {PRAGMA encoding}
+    } {UTF-8}
+
+    do_test doltlite_recover_utf16_errtext-3.$base.2 {
+      execsql {CREATE TABLE t1(x)}
+      execsql "INSERT INTO t1 VALUES( $expr )"
+      execsql {SELECT typeof(x) FROM t1}
+    } {text}
+
+    do_test doltlite_recover_utf16_errtext-3.$base.3 {
+      execsql {SELECT rowid FROM t1 WHERE x LIKE (SELECT x||'%' FROM t1)}
+    } {1}
+
+    do_test doltlite_recover_utf16_errtext-3.$base.4 {
+      execsql {CREATE INDEX i1 ON t1(x)}
+      execsql {SELECT rowid FROM t1 WHERE x LIKE (SELECT x||'%' FROM t1)}
+    } {1}
+
+    do_test doltlite_recover_utf16_errtext-3.$base.5 {
+      db close
+      sqlite3 db test.db
+      execsql {SELECT hex(CAST(x AS BLOB)) FROM t1}
+    } $hexwant
+  }
+}
+
+#-------------------------------------------------------------------------
+# 4.* pagerfault3-1 recovery: VACUUM (= dolt_gc) under transient IO faults.
+# Each fault point must yield either success or one of doltlite's exact gc
+# error messages, leave the data readable and integrity ok, and a fault-free
+# VACUUM afterwards must succeed.
+#
+reset_db
+do_test doltlite_recover_utf16_errtext-4.0 {
+  execsql {
+    PRAGMA auto_vacuum = 0;
+    PRAGMA page_size = 2048;
+    CREATE TABLE t1(x);
+    INSERT INTO t1 VALUES(zeroblob(1200));
+  }
+  faultsim_save_and_close
+} {}
+
+set ::gc_errors_seen 0
+set ::gc_allowed [list \
+  {0 {}} \
+  {1 {failed to acquire lock for gc}} \
+  {1 {gc mark phase failed}} \
+  {1 {gc sweep phase failed}} \
+  {1 {disk I/O error}} \
+]
+
+for {set i 1} {$i<=25} {incr i} {
+  do_test doltlite_recover_utf16_errtext-4.$i {
+    faultsim_restore_and_reopen
+    set ::sqlite_io_error_persist 0
+    set ::sqlite_io_error_pending $i
+    set rc [catch {db eval {PRAGMA page_size = 1024; VACUUM;}} msg]
+    set ::sqlite_io_error_pending 0
+    set ::sqlite_io_error_hit 0
+    set ::sqlite_io_error_hardhit 0
+    set res [list $rc $msg]
+    if {[string match {1 {gc * phase failed}} $res]} { incr ::gc_errors_seen }
+    list \
+      [expr {[lsearch -exact $::gc_allowed $res]>=0 ? "allowed" : $res}] \
+      [execsql {SELECT count(*), length(x) FROM t1}] \
+      [execsql {PRAGMA integrity_check}]
+  } {allowed {1 1200} ok}
+}
+
+do_test doltlite_recover_utf16_errtext-4.26 {
+  expr {$::gc_errors_seen > 0}
+} {1}
+
+do_test doltlite_recover_utf16_errtext-4.27 {
+  faultsim_restore_and_reopen
+  execsql {
+    PRAGMA page_size = 1024;
+    VACUUM;
+  }
+  db close
+  sqlite3 db test.db
+  list [execsql {SELECT count(*), length(x) FROM t1}] \
+       [execsql {PRAGMA integrity_check}]
+} {{1 1200} ok}
+
+finish_test

--- a/test/doltlite_recover_withoutrowid.test
+++ b/test/doltlite_recover_withoutrowid.test
@@ -1,0 +1,1129 @@
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+# Recovers the intent of upstream assertions gated as WITHOUT-ROWID-surface
+# divergences (#1176 class): doltlite stores any non-INTEGER / composite-PK
+# table WITHOUT ROWID, so `rowid` is not a column, sqlite_autoindex_* rows are
+# not materialized, and the PK is implicitly NOT NULL. Each original is
+# re-asserted through the declared PK: uniqueness, PK-order iteration, point
+# lookups, UPDATE/DELETE by PK, FK actions, and plan shape via PRIMARY KEY.
+#
+# covers: fordelete fordelete-1.1 — DELETE WHERE pk=? on implicit-PK table deletes exactly that row (section 1)
+# covers: fordelete fordelete-1.2 — DELETE WHERE pk=? AND b=? deletes only on full match (section 1)
+# covers: fordelete fordelete-1.3 — DELETE WHERE pk>? range-delete by PK (section 1)
+# covers: fordelete fordelete-1.4 — point delete by key (rowid=? re-expressed as pk=?) (section 1)
+# covers: fkey_malloc fkey_malloc-6.transient.33 — self-ref FK INSERT/DELETE/UPDATE sequence by PK succeeds (section 2)
+# covers: fkey_malloc fkey_malloc-6.transient.34 — same scenario, DELETE leg (section 2)
+# covers: fkey_malloc fkey_malloc-6.transient.35 — same scenario, UPDATE SET DEFAULT leg (section 2)
+# covers: fkey_malloc fkey_malloc-6.transient.69 — final state {jkl jkl} after full sequence (section 2)
+# covers: fkey_malloc fkey_malloc-6.persistent.69 — same final-state assertion (section 2)
+# covers: fkey_malloc fkey_malloc-7.transient.200 — DROP child then parent with composite-PK FK succeeds (section 2)
+# covers: fkey_malloc fkey_malloc-7.transient.201 — same drop sequence (section 2)
+# covers: fkey_malloc fkey_malloc-7.transient.202 — same drop sequence (section 2)
+# covers: fkey_malloc fkey_malloc-7.transient.523 — same drop sequence (section 2)
+# covers: fkey_malloc fkey_malloc-7.transient.524 — same drop sequence (section 2)
+# covers: fkey_malloc fkey_malloc-7.transient.525 — same drop sequence + FK still enforced after (section 2)
+# covers: notnull notnull-6.5 — `a IS ?` on implicit-PK table: plan parity with explicit WITHOUT ROWID (no OP_Next), rows correct (section 3)
+# covers: update2 update2-2.3 — point UPDATE by PK on t3(a PRIMARY KEY,b,c) with secondary index (section 4)
+# covers: whereF whereF-4.0 — EQP for composite-PK t4 a=?,b=? lookup uses (a=? AND b=?) seek (section 5)
+# covers: without_rowid5 without_rowid5-1.1 — implicit-PK table behaves as WITHOUT ROWID: rowid/_rowid_/oid all rejected, data identical to explicit twin (section 6)
+# covers: without_rowid5 without_rowid5-5.5 — NULL into any composite-PK column rejected NOT NULL, like explicit WITHOUT ROWID (section 6)
+# covers: tkt1567 tkt1567-1.3 — bulk UPDATE of half the TEXT-PK rows inside txn succeeds (section 7)
+# covers: tkt1567 tkt1567-1.4 — colliding UPDATE fails UNIQUE, txn commits, integrity ok (section 7)
+# covers: where4 where4-5.2 — IN lists with NULL prune correctly on composite-PK table (section 8)
+# covers: where4 where4-5.3 — NULL in first IN list likewise (section 8)
+# covers: whereD whereD-3.4.1 — PK point lookup returns correct row (search-count metric dropped) (section 9)
+# covers: whereD whereD-3.4.2 — OR-of-AND with one subquery term, rows correct (section 9)
+# covers: whereD whereD-3.4.3 — commuted OR-of-AND, rows correct (section 9)
+# covers: whereD whereD-3.4.4 — both terms subqueries, rows correct (section 9)
+# covers: whereG whereG-3.1 — commuted b1=a1: plan identical across commutations, SEARCH b by PK (section 10)
+# covers: whereG whereG-3.2 — a1=b1 commutation same plan (section 10)
+# covers: whereG whereG-3.3 — a2=5 AND b1=a1 commutation same plan (section 10)
+# covers: whereG whereG-3.4 — a2=5 AND a1=b1 commutation same plan (section 10)
+# covers: whereL whereL-110 — constant propagation through view join: rows correct (section 11)
+# covers: whereL whereL-120 — t3.j=5 propagation: SEARCH lt1/lt2 then SCAN lt3, no sort (section 11)
+# covers: whereL whereL-121 — abs(5) propagates: plan identical to whereL-120 (section 11)
+# covers: whereL whereL-122 — coalesce(5,random()) not constant: plan differs, rows still equal (section 11)
+# covers: tkt-3a77c9714e tkt-3a77c9714e-3.0 — nested OR/IN flattening returns NULL row; doltlite NULL-PK rejection asserted as contract (section 12)
+# covers: without_rowid1 without_rowid1-7.1 — CHECK(rowid) on implicit-PK table fails CREATE with no such column: rowid (section 13)
+# covers: without_rowid1 without_rowid1-7.2 — cascade: t70a not created, INSERT errors no such table (section 13)
+# covers: rowvalue9 rowvalue9-1.0.1 — composite-PK a1 + a2 setup via explicit lbl column (section 14)
+# covers: rowvalue9 rowvalue9-1.0.2 — a2 affinity/typeof round-trip in rowid order (section 14)
+# covers: rowvalue9 rowvalue9-1.1.1 — scalar-subquery row-value lookup by (a,b) affinity (section 14)
+# covers: rowvalue9 rowvalue9-1.1.2 — (a,b)=(x,y) vector form same result (section 14)
+# covers: rowvalue9 rowvalue9-1.2.3 — join form a=x AND b=y (section 14)
+# covers: rowvalue9 rowvalue9-1.2.4 — join vector form (a,b)=(x,y) (section 14)
+# covers: rowvalue9 rowvalue9-1.3.1 — coalesce-wrapped comparison loses index affinity, all rows match (section 14)
+# covers: rowvalue9 rowvalue9-1.3.2 — vector coalesce form (section 14)
+# covers: rowvalue9 rowvalue9-1.4.1 — +x/+y unindexed comparison (section 14)
+# covers: rowvalue9 rowvalue9-1.4.2 — vector +x,+y form (section 14)
+# covers: rowvalue9 rowvalue9-1.5.1 — subquery with +x/+y (section 14)
+# covers: rowvalue9 rowvalue9-1.5.2 — subquery vector (a,b)=(+x,+y) (section 14)
+# covers: rowvalue9 rowvalue9-1.5.3 — subquery vector (+x,+y)=(a,b) (section 14)
+# covers: rowvalue9 rowvalue9-1.6.1 — (a,b) IN (SELECT x,y) row-value IN (section 14)
+# covers: rowvalue9 rowvalue9-1.6.2 — EXISTS row-value correlated form (section 14)
+# covers: without_rowid7 without_rowid7-2.4 — PRIMARY KEY(a COLLATE nocase, a) accepted; PK uniqueness uses both components (section 15)
+# covers: skipscan1 skipscan1-2.2eqp — skip-scan over composite PK: EQP shows PRIMARY KEY (ANY(a) AND b=?) (section 16)
+# covers: skipscan1 skipscan1-3.1 — order-distinct skip-scan DISTINCT rows correct (NULL PK re-expressed as distinct non-NULL keys) (section 16)
+# covers: skipscan1 skipscan1-3.2 — skip-scan DISTINCT plan: PK skip-scan + temp b-tree for DISTINCT (section 16)
+# covers: skipscan2 skipscan2-1.5eqp — height>=180 query rows correct under faked stats (plan choice may differ) (section 16)
+# covers: tkt3871 tkt3871-1.1 — 500-row TEXT-PK table built in txn, count correct (section 17)
+# covers: tkt3871 tkt3871-1.2 — a=1 OR a=2 returns both rows via index lookups (section 17)
+# covers: tkt3871 tkt3871-1.3 — OR optimization: plan uses two PK seeks, not a scan (section 17)
+# covers: tkt3871 tkt3871-1.4 — a=1 OR a=2 OR b=9 includes UNIQUE-index leg (section 17)
+# covers: tkt3871 tkt3871-1.5 — OR plan uses PK and UNIQUE index seeks, not a scan (section 17)
+# covers: tkt3121 vtabD-1.2 — join on PK column returns matching descr (echo layer dropped; same query over real tables) (section 18)
+# covers: vtab4 vtab4-1.2 — implicit-txn INSERT: vtab lifecycle xBegin/xSync/xCommit asserted via echo over rowid table; PK-table insert verified directly (section 19)
+# covers: vtab4 vtab4-1.3 — implicit-txn UPDATE on PK table applies fully (section 19)
+# covers: vtab4 vtab4-1.4 — implicit-txn DELETE empties PK table (section 19)
+# covers: vtab4 vtab4-2.1 — multi-INSERT inside BEGIN/COMMIT commits once, all rows present (section 19)
+# covers: vtab4 vtab4-2.2 — two-table txn: INSERT SELECT + DELETE commit atomically (section 19)
+# covers: vtab4 vtab4-2.3 — sreal contents after commit (section 19)
+# covers: vtab4 vtab4-2.4 — treal emptied after commit (section 19)
+# covers: vtab4 vtab4-2.5 — explicit ROLLBACK of two-table txn (section 19)
+# covers: vtab4 vtab4-2.6 — sreal restored after rollback (section 19)
+# covers: vtab4 vtab4-2.7 — treal restored after rollback (section 19)
+# covers: vtab4 vtab4-3.1 — failed commit (xSync fail via echo over rowid table) reports error; PK dup gives real UNIQUE message (section 19)
+# covers: vtab4 vtab4-3.2 — xSync failure triggers xRollback, data unchanged (section 19)
+# covers: vtab4 vtab4-3.3 — failed txn leaves both tables consistent (section 19)
+# covers: dbstatus2 dbstatus2-1.1 — PK-blob table survives reopen with correct sizes (cache-stat metric dropped) (section 20)
+# covers: dbstatus2 dbstatus2-1.2 — point lookup a=2 returns 600-byte blob (section 20)
+# covers: dbstatus2 dbstatus2-1.3 — repeated lookup stable (section 20)
+# covers: dbstatus2 dbstatus2-1.4 — repeated lookup stable (section 20)
+# covers: dbstatus2 dbstatus2-1.5 — repeated lookup stable (section 20)
+# covers: dbstatus2 dbstatus2-1.7 — blob content length readable (incrblob re-expressed as length(b)) (section 20)
+# covers: dbstatus2 dbstatus2-1.8 — read-after-reopen consistency (section 20)
+# covers: dbstatus2 dbstatus2-1.9 — read-after-reopen consistency (section 20)
+# covers: dbstatus2 dbstatus2-2.2 — INSERT row 4 persists (write-stat metric dropped) (section 20)
+# covers: dbstatus2 dbstatus2-2.3 — table count after insert (section 20)
+# covers: dbstatus2 dbstatus2-2.6 — journal-mode write path: insert row 5 persists (section 20)
+# covers: dbstatus2 dbstatus2-2.7 — insert row 5 verified (section 20)
+# covers: dbstatus2 dbstatus2-2.8 — post-insert state stable (section 20)
+# covers: dbstatus2 dbstatus2-3.2 — UPDATE all blobs to 1000 bytes (spill scenario) succeeds (section 20)
+# covers: dbstatus2 dbstatus2-3.3 — post-update lengths + integrity ok (section 20)
+# covers: index index-7.3 — implicit PK index enforces uniqueness on test1.f2 (autoindex name dropped) (section 21)
+# covers: index index-16.1 — c UNIQUE PRIMARY KEY: single constraint enforced, dup rejected (section 21)
+# covers: index index-16.2 — recreate same shape, still enforced (section 21)
+# covers: index index-16.3 — c PRIMARY KEY + UNIQUE(c): dup rejected once (section 21)
+# covers: index index-16.4 — UNIQUE(c,d)+PK(c,d): same-pair dup rejected, differing d allowed (section 21)
+# covers: index index-16.5 — UNIQUE(c)+PK(c,d): c alone enforced even with new d (section 21)
+# covers: fkey2 fkey2-5.2 — incrblob write to FK column rejected (rowid child table) (section 22)
+# covers: fkey2 fkey2-5.3 — incrblob -readonly on FK column allowed (section 22)
+# covers: fkey2 fkey2-5.4 — incrblob write allowed once foreign_keys=off (section 22)
+# covers: fkey2 fkey2-13.1.2.1 — REPLACE that would orphan child fails FK (PK-conflict form replaces rowid form) (section 23)
+# covers: fkey2 fkey2-13.1.2.3 — same REPLACE inside explicit txn fails FK (section 23)
+# covers: fkey2 fkey2-13.1.3 — REPLACE keeping referenced (b,c) succeeds, child intact (section 23)
+# covers: fkey2 fkey2-13.1.4 — repeat REPLACE of same content succeeds, child intact (section 23)
+# covers: e_createtable e_createtable-3.11.2 — lowered SQLITE_LIMIT_COLUMN rejects 501-column CREATE with its own table name (section 24)
+# covers: e_createtable e_createtable-4.4.1 — NULL into single-col PK rejected NOT NULL (doltlite contract); NULL-distinctness held by UNIQUE col (section 24)
+# covers: e_createtable e_createtable-4.4.2 — same, repeat insert (section 24)
+# covers: e_createtable e_createtable-4.4.3 — same, repeat insert (section 24)
+# covers: e_createtable e_createtable-4.4.4 — NULL into composite-PK x rejected (section 24)
+# covers: e_createtable e_createtable-4.4.5 — same class (section 24)
+# covers: e_createtable e_createtable-4.4.6 — same class (section 24)
+# covers: e_createtable e_createtable-4.4.7 — same class (section 24)
+# covers: e_createtable e_createtable-4.4.8 — NULL into composite-PK y rejected (section 24)
+# covers: e_createtable e_createtable-4.4.9 — same class (section 24)
+# covers: e_createtable e_createtable-4.4.10 — same class (section 24)
+# covers: e_createtable e_createtable-4.4.11 — same class (section 24)
+# covers: e_createtable e_createtable-4.4.12 — same class (section 24)
+# covers: e_createtable e_createtable-4.4.13 — NULL,NULL rejected on first PK col (section 24)
+# covers: e_createtable e_createtable-4.4.14 — same class (section 24)
+# covers: e_createtable e_createtable-4.5.1.1 — NULL-distinctness intent re-expressed: 3 NULLs coexist under UNIQUE, counted (section 24)
+# covers: e_createtable e_createtable-4.5.1.2 — PK columns hold zero NULLs (implicit NOT NULL) (section 24)
+# covers: e_createtable e_createtable-4.5.1.3 — same count contract (section 24)
+# covers: e_createtable e_createtable-4.5.1.4 — same count contract (section 24)
+# covers: e_createtable e_createtable-4.9.1 — TEXT PK enforced by unique index semantics: dup rejected (section 24)
+# covers: e_createtable e_createtable-4.9.4 — PK + UNIQUE both enforced independently (section 24)
+# covers: e_createtable e_createtable-4.9.5 — PK + UNIQUE(c,b) both enforced (section 24)
+# covers: e_createtable e_createtable-4.10.1 — PK lookup planned as SEARCH ... PRIMARY KEY (b=?) (section 24)
+# covers: e_createtable e_createtable-4.15.5.4 — ON CONFLICT REPLACE final rows asserted in PK order (section 24)
+# covers: e_createtable e_createtable-5.3.4 — composite integer PK is not a rowid alias: no rowid column at all (section 24)
+# covers: e_createtable e_createtable-5.3.5 — pk int + composite: same contract (section 24)
+# covers: e_createtable e_createtable-5.3.6 — pk int single: same contract (section 24)
+# covers: e_createtable e_createtable-5.3.7 — pk int primary key: same contract (section 24)
+# covers: e_createtable e_createtable-5.4.2.1 — INT pk not rowid alias (no rowid), integer affinity + unique (section 24)
+# covers: e_createtable e_createtable-5.4.2.2 — BIGINT pk same (section 24)
+# covers: e_createtable e_createtable-5.4.2.3 — SHORT INTEGER pk same (section 24)
+# covers: e_createtable e_createtable-5.4.2.4 — UNSIGNED INTEGER pk same (section 24)
+# covers: e_createtable e_createtable-5.4.3 — '2.0' coerced to integer 2 in all four INT-ish PKs (section 24)
+# covers: e_createtable e_createtable-5.6.1 — INTEGER PRIMARY KEY DESC is not a rowid alias; row round-trips by declared PK (section 24)
+# covers: e_fkey e_fkey-16.4 — nocase-collated parent key: DELETE parent by PK blocked by FK (section 25)
+# covers: e_fkey e_fkey-17.4 — NUMERIC-affinity parent: DELETE referenced row by PK blocked, unreferenced row deletable (section 25)
+# covers: e_fkey e_fkey-44.2 — ON DELETE SET NULL: delete parent by PK value (section 25)
+# covers: e_fkey e_fkey-44.3 — child key set NULL (section 25)
+# covers: e_fkey e_fkey-44.4 — ON UPDATE SET NULL: update parent PK by value (section 25)
+# covers: e_fkey e_fkey-44.5 — child key set NULL on update (section 25)
+# covers: e_fkey e_fkey-45.1 — SET DEFAULT setup without explicit rowids (section 25)
+# covers: e_fkey e_fkey-45.2 — delete parent; remaining parents in PK order (section 25)
+# covers: e_fkey e_fkey-45.3 — child reset to DEFAULT X'0000' (section 25)
+# covers: e_fkey e_fkey-45.4 — update parent PK; remaining parents in PK order (section 25)
+# covers: e_fkey e_fkey-45.5 — child reset to DEFAULT X'9999' (section 25)
+# covers: e_fkey e_fkey-51.2 — BEFORE-trigger/constraint/FK-action/AFTER-trigger ordering observed via child default (22) (section 25)
+# covers: e_fkey e_fkey-51.3 — negative-key variant orders differently, child default 23 distinguishes step order (section 25)
+# covers: e_fkey e_fkey-52.6 — ON UPDATE CASCADE fires only on distinct values; NULL into composite PK rejected as doltlite contract (section 25)
+# covers: e_fkey e_fkey-57.7 — explicit DELETE fires AFTER DELETE trigger (logged via old.a); DROP TABLE's implicit delete does not (section 25)
+# covers: e_fkey e_fkey-58.3 — DROP TABLE parent inside txn fails immediate FK, table intact (section 25)
+#
+# not-covered: (none)
+
+#-------------------------------------------------------------------------
+# 1: fordelete — DELETE forms on an implicit-PK (WITHOUT ROWID) table.
+do_execsql_test doltlite_recover_withoutrowid-1.1 {
+  CREATE TABLE fd1(a PRIMARY KEY, b);
+  INSERT INTO fd1 VALUES(1,'a'),(2,'b'),(3,'c'),(4,'d'),(5,'e'),(6,'f'),(7,'g'),(8,'h');
+  DELETE FROM fd1 WHERE a=2;
+  SELECT a FROM fd1 ORDER BY a;
+} {1 3 4 5 6 7 8}
+do_execsql_test doltlite_recover_withoutrowid-1.2 {
+  DELETE FROM fd1 WHERE a=3 AND b='c';
+  DELETE FROM fd1 WHERE a=4 AND b='zzz';
+  SELECT a FROM fd1 ORDER BY a;
+} {1 4 5 6 7 8}
+do_execsql_test doltlite_recover_withoutrowid-1.3 {
+  DELETE FROM fd1 WHERE a>5;
+  SELECT a, b FROM fd1 ORDER BY a;
+} {1 a 4 d 5 e}
+do_execsql_test doltlite_recover_withoutrowid-1.4 {
+  PRAGMA integrity_check;
+} {ok}
+
+#-------------------------------------------------------------------------
+# 2: fkey_malloc-6/7 — the gated DML re-expressed by PK instead of rowid.
+do_execsql_test doltlite_recover_withoutrowid-2.1 {
+  PRAGMA foreign_keys = 1;
+  CREATE TABLE fm1(
+    x PRIMARY KEY,
+    y REFERENCES fm1 ON DELETE RESTRICT ON UPDATE SET DEFAULT
+  );
+  INSERT INTO fm1 VALUES('abc', 'abc');
+  INSERT INTO fm1 VALUES('def', 'def');
+  INSERT INTO fm1 VALUES('ghi', 'ghi');
+  DELETE FROM fm1 WHERE x<>'abc';
+  UPDATE fm1 SET x='jkl', y='jkl';
+  SELECT * FROM fm1;
+} {jkl jkl}
+do_catchsql_test doltlite_recover_withoutrowid-2.2 {
+  INSERT INTO fm1 VALUES('mno', 'nope');
+} {1 {FOREIGN KEY constraint failed}}
+do_execsql_test doltlite_recover_withoutrowid-2.3 {
+  CREATE TABLE fmx(a, b, PRIMARY KEY(a, b));
+  CREATE TABLE fmy(c, d,
+    FOREIGN KEY(d, c) REFERENCES fmx DEFERRABLE INITIALLY DEFERRED
+  );
+  CREATE TABLE fmz(e, f, FOREIGN KEY(e, f) REFERENCES fmx);
+  DROP TABLE fmy;
+  DROP TABLE fmx;
+  SELECT name FROM sqlite_master WHERE name IN ('fmx','fmy','fmz') ORDER BY name;
+} {fmz}
+
+#-------------------------------------------------------------------------
+# 3: notnull-6.5 — implicit-PK `a IS ?` plans like explicit WITHOUT ROWID
+# (single seek, no OP_Next) and returns correct rows.
+do_test doltlite_recover_withoutrowid-3.1 {
+  execsql {
+    CREATE TABLE nn5(a PRIMARY KEY);
+    CREATE TABLE nn8(a PRIMARY KEY) WITHOUT ROWID;
+    INSERT INTO nn5 VALUES('x'),('y');
+    INSERT INTO nn8 VALUES('x'),('y');
+  }
+  set counts {}
+  foreach t {nn5 nn8} {
+    set n 0
+    db eval "EXPLAIN SELECT * FROM $t WHERE a IS ?" r {
+      if {$r(opcode)=="Next"} {incr n}
+    }
+    lappend counts $n
+  }
+  set counts
+} {0 0}
+do_execsql_test doltlite_recover_withoutrowid-3.2 {
+  SELECT * FROM nn5 WHERE a IS 'x';
+  SELECT * FROM nn8 WHERE a IS 'x';
+  SELECT count(*) FROM nn5 WHERE a IS NULL;
+} {x x 0}
+
+#-------------------------------------------------------------------------
+# 4: update2-2.3 — point UPDATE by PK on the implicit-PK table.
+do_execsql_test doltlite_recover_withoutrowid-4.1 {
+  CREATE TABLE u3(a PRIMARY KEY, b, c);
+  CREATE INDEX u3i ON u3(b);
+  UPDATE u3 SET c=1 WHERE a='nosuch';
+  INSERT INTO u3 VALUES('k1', 10, 0), ('k2', 20, 0);
+  UPDATE u3 SET c=1 WHERE a='k2';
+  SELECT a, c FROM u3 ORDER BY a;
+} {k1 0 k2 1}
+
+#-------------------------------------------------------------------------
+# 5: whereF-4.0 — composite-PK lookup plan.
+do_execsql_test doltlite_recover_withoutrowid-5.1 {
+  CREATE TABLE wf4(a,b,c,d,e, PRIMARY KEY(a,b,c));
+  CREATE INDEX wf4adc ON wf4(a,d,c);
+  CREATE UNIQUE INDEX wf4aebc ON wf4(a,e,b,c);
+  EXPLAIN QUERY PLAN SELECT d FROM wf4 WHERE a=? AND b=?;
+} {/a=. AND b=./}
+
+#-------------------------------------------------------------------------
+# 6: without_rowid5 — implicit-PK table is a WITHOUT ROWID table.
+do_execsql_test doltlite_recover_withoutrowid-6.1 {
+  CREATE TABLE wr1(a PRIMARY KEY,b,c);
+  CREATE TABLE wr1w(a PRIMARY KEY,b,c) WITHOUT ROWID;
+  INSERT INTO wr1 VALUES(1565,681,1148),(1429,1190,1619),(425,358,1306);
+  INSERT INTO wr1w SELECT a,b,c FROM wr1;
+  SELECT a,b,c FROM wr1 ORDER BY a;
+  SELECT a,b,c FROM wr1w ORDER BY a;
+} {425 358 1306 1429 1190 1619 1565 681 1148 425 358 1306 1429 1190 1619 1565 681 1148}
+do_catchsql_test doltlite_recover_withoutrowid-6.2 {
+  SELECT rowid FROM wr1;
+} {1 {no such column: rowid}}
+do_catchsql_test doltlite_recover_withoutrowid-6.3 {
+  SELECT _rowid_ FROM wr1;
+} {1 {no such column: _rowid_}}
+do_catchsql_test doltlite_recover_withoutrowid-6.4 {
+  SELECT oid FROM wr1;
+} {1 {no such column: oid}}
+do_execsql_test doltlite_recover_withoutrowid-6.5 {
+  CREATE TABLE wrnn(a, b, c, d, e, PRIMARY KEY(c,a,e));
+  INSERT INTO wrnn VALUES(1,2,3,4,5);
+} {}
+do_catchsql_test doltlite_recover_withoutrowid-6.6 {
+  INSERT INTO wrnn VALUES(NULL, 3,4,5,6);
+} {1 {NOT NULL constraint failed: wrnn.a}}
+do_catchsql_test doltlite_recover_withoutrowid-6.7 {
+  INSERT INTO wrnn VALUES(3,4,NULL,7,8);
+} {1 {NOT NULL constraint failed: wrnn.c}}
+do_catchsql_test doltlite_recover_withoutrowid-6.8 {
+  INSERT INTO wrnn VALUES(4,5,6,7,NULL);
+} {1 {NOT NULL constraint failed: wrnn.e}}
+do_execsql_test doltlite_recover_withoutrowid-6.9 {
+  SELECT count(*) FROM wrnn;
+} {1}
+
+#-------------------------------------------------------------------------
+# 7: tkt1567 — TEXT-PK bulk update inside txn; collision fails UNIQUE.
+do_test doltlite_recover_withoutrowid-7.1 {
+  execsql {CREATE TABLE k1(a TEXT PRIMARY KEY)}
+  set bigstr abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ
+  for {set i 0} {$i<100} {incr i} {
+    set x [format %5d [expr $i*2]]
+    execsql "INSERT INTO k1 VALUES('$x-$bigstr')"
+  }
+  execsql {
+    BEGIN;
+    UPDATE k1 SET a = a||'x' WHERE substr(a,5,1)='0' OR substr(a,5,1)='2';
+  }
+} {}
+do_catchsql_test doltlite_recover_withoutrowid-7.2 {
+  UPDATE k1 SET a = CASE WHEN a<'  100' THEN substr(a,1,10) ELSE '9999' END;
+} {1 {UNIQUE constraint failed: k1.a}}
+do_execsql_test doltlite_recover_withoutrowid-7.3 {
+  COMMIT;
+  SELECT count(*) FROM k1;
+} {100}
+do_execsql_test doltlite_recover_withoutrowid-7.4 {
+  PRAGMA integrity_check;
+} {ok}
+
+#-------------------------------------------------------------------------
+# 8: where4-5.2/5.3 — IN + NULL pruning on a composite-PK table.
+do_execsql_test doltlite_recover_withoutrowid-8.1 {
+  CREATE TABLE w4(x,y,z,PRIMARY KEY(x,y));
+  INSERT INTO w4 VALUES(1,1,11),(1,2,12),(1,3,13),(2,2,22);
+  SELECT x,y FROM w4 WHERE x IN (1,9,2,5) AND y IN (1,3,NULL,2) AND z!=13 ORDER BY x,y;
+} {1 1 1 2 2 2}
+do_execsql_test doltlite_recover_withoutrowid-8.2 {
+  SELECT x,y FROM w4 WHERE x IN (1,9,NULL,2) AND y IN (1,3,2) AND z!=13 ORDER BY x,y;
+} {1 1 1 2 2 2}
+
+#-------------------------------------------------------------------------
+# 9: whereD-3.4.* — OR-of-AND with subquery terms over implicit-PK lookup.
+do_execsql_test doltlite_recover_withoutrowid-9.1 {
+  CREATE TABLE d3(a, b, c);
+  CREATE UNIQUE INDEX di3 ON d3(a, b);
+  INSERT INTO d3 VALUES(1,'one','i'),(3,'three','iii'),(6,'six','vi'),
+                       (2,'two','ii'),(4,'four','iv'),(5,'five','v');
+  CREATE TABLE d4(x PRIMARY KEY, y);
+  INSERT INTO d4 VALUES('a','one'),('b','two');
+  SELECT y FROM d4 WHERE x='a';
+} {one}
+do_execsql_test doltlite_recover_withoutrowid-9.2 {
+  SELECT a, b FROM d3 WHERE
+        (a=1 AND b=(SELECT y FROM d4 WHERE x='a'))
+     OR (a=2 AND b='two') ORDER BY a;
+} {1 one 2 two}
+do_execsql_test doltlite_recover_withoutrowid-9.3 {
+  SELECT a, b FROM d3 WHERE
+        (a=2 AND b='two')
+     OR (a=1 AND b=(SELECT y FROM d4 WHERE x='a')) ORDER BY a;
+} {1 one 2 two}
+do_execsql_test doltlite_recover_withoutrowid-9.4 {
+  SELECT a, b FROM d3 WHERE
+        (a=2 AND b=(SELECT y FROM d4 WHERE x='b'))
+     OR (a=1 AND b=(SELECT y FROM d4 WHERE x='a')) ORDER BY a;
+} {1 one 2 two}
+
+#-------------------------------------------------------------------------
+# 10: whereG-3.* — commuting WHERE terms must not change the plan; the
+# b1 lookup is a PK seek in doltlite.
+proc wr_plan {sql} {
+  set res {}
+  db eval "EXPLAIN QUERY PLAN $sql" r {lappend res $r(detail)}
+  join $res {; }
+}
+do_execsql_test doltlite_recover_withoutrowid-10.1 {
+  CREATE TABLE ga(a1 PRIMARY KEY, a2);
+  CREATE TABLE gb(b1 PRIMARY KEY, b2);
+  INSERT INTO ga VALUES(10, 5), (11, 6);
+  INSERT INTO gb VALUES(10, 'ten'), (11, 'eleven');
+} {}
+do_test doltlite_recover_withoutrowid-10.2 {
+  set p1 [wr_plan {SELECT * FROM ga, gb WHERE b1=a1 AND a2=5}]
+  set p2 [wr_plan {SELECT * FROM ga, gb WHERE a1=b1 AND a2=5}]
+  set p3 [wr_plan {SELECT * FROM ga, gb WHERE a2=5 AND b1=a1}]
+  set p4 [wr_plan {SELECT * FROM ga, gb WHERE a2=5 AND a1=b1}]
+  list [expr {$p1 eq $p2}] [expr {$p1 eq $p3}] [expr {$p1 eq $p4}] \
+       [string match {*SEARCH gb USING PRIMARY KEY (b1=?)*} $p1]
+} {1 1 1 1}
+do_execsql_test doltlite_recover_withoutrowid-10.3 {
+  SELECT * FROM ga, gb WHERE a2=5 AND a1=b1;
+} {10 5 10 ten}
+
+#-------------------------------------------------------------------------
+# 11: whereL — constant propagation across implicit-PK joins.
+do_execsql_test doltlite_recover_withoutrowid-11.1 {
+  CREATE TABLE lt1(a INT PRIMARY KEY, b, c, d, e);
+  CREATE TABLE lt2(a INT PRIMARY KEY, f, g, h, i);
+  CREATE TABLE lt3(a INT PRIMARY KEY, j, k, l, m);
+  CREATE VIEW lv4 AS SELECT * FROM lt2 UNION ALL SELECT * FROM lt3;
+  INSERT INTO lt1 VALUES(5,'b','c','d','e');
+  INSERT INTO lt2 VALUES(5,'f','g','h','i');
+  INSERT INTO lt3 VALUES(9,5,'k','l','m');
+  SELECT * FROM lt1, lv4 WHERE lt1.a=5 AND lv4.a=lt1.a;
+} {5 b c d e 5 f g h i}
+do_test doltlite_recover_withoutrowid-11.2 {
+  set q120 {SELECT * FROM lt1, lt2, lt3
+            WHERE lt1.a=lt2.a AND lt2.a=lt3.j AND lt3.j=5 ORDER BY lt1.a}
+  set q121 {SELECT * FROM lt1, lt2, lt3
+            WHERE lt1.a=lt2.a AND lt2.a=lt3.j AND lt3.j=abs(5) ORDER BY lt1.a}
+  set q122 {SELECT * FROM lt1, lt2, lt3
+            WHERE lt1.a=lt2.a AND lt2.a=lt3.j AND lt3.j=coalesce(5,random()) ORDER BY lt1.a}
+  set p120 [wr_plan $q120]
+  set p121 [wr_plan $q121]
+  set p122 [wr_plan $q122]
+  list [expr {$p120 eq $p121}] [expr {$p120 eq $p122}] \
+       [string match {*SEARCH lt1 USING PRIMARY KEY (a=?)*} $p120] \
+       [expr {[execsql $q120] eq [execsql $q121]}] \
+       [expr {[execsql $q120] eq [execsql $q122]}]
+} {1 0 1 1 1}
+do_execsql_test doltlite_recover_withoutrowid-11.3 {
+  SELECT * FROM lt1, lt2, lt3
+   WHERE lt1.a=lt2.a AND lt2.a=lt3.j AND lt3.j=5 ORDER BY lt1.a;
+} {5 b c d e 5 f g h i 9 5 k l m}
+
+#-------------------------------------------------------------------------
+# 12: tkt-3a77c9714e-3.0 — nested OR/IN flattening over INT-PK table;
+# NULL PK rejected is the doltlite contract, query intent kept with i=1.
+do_catchsql_test doltlite_recover_withoutrowid-12.1 {
+  CREATE TABLE tk1(i INT PRIMARY KEY, a, b);
+  INSERT INTO tk1 VALUES(NULL,'one','i');
+} {1 {NOT NULL constraint failed: tk1.i}}
+do_execsql_test doltlite_recover_withoutrowid-12.2 {
+  INSERT INTO tk1 VALUES(1,'one','i');
+  CREATE INDEX tki1a ON tk1(a);
+  CREATE INDEX tki1b ON tk1(b);
+  SELECT (SELECT 1
+            FROM (SELECT 1 FROM tk1 WHERE a=1 OR b='i')
+           WHERE a='o'
+              OR b IN (SELECT a=('b' IN (SELECT 'a'))))
+    FROM tk1;
+} {{}}
+
+#-------------------------------------------------------------------------
+# 13: without_rowid1-7.* — CHECK(rowid) cannot resolve on an implicit
+# WITHOUT ROWID table (same as upstream's explicit WITHOUT ROWID case 7.3).
+do_catchsql_test doltlite_recover_withoutrowid-13.1 {
+  CREATE TABLE t70a(
+     a INT CHECK( rowid!=33 ),
+     b TEXT PRIMARY KEY
+  );
+} {1 {no such column: rowid}}
+do_catchsql_test doltlite_recover_withoutrowid-13.2 {
+  INSERT INTO t70a(a,b) VALUES(99,'hello');
+} {1 {no such table: t70a}}
+
+#-------------------------------------------------------------------------
+# 14: rowvalue9 section 1 — row-value affinity over a composite-PK table,
+# rowid labels re-expressed as an explicit lbl column.
+do_execsql_test doltlite_recover_withoutrowid-14.1 {
+  CREATE TABLE a1(lbl, c, b INTEGER, a TEXT, PRIMARY KEY(a, b));
+  INSERT INTO a1 (lbl, c, b, a) VALUES(3,  '0x03', 1, 1);
+  INSERT INTO a1 (lbl, c, b, a) VALUES(14, '0x0E', 2, 2);
+  INSERT INTO a1 (lbl, c, b, a) VALUES(15, '0x0F', 3, 3);
+  INSERT INTO a1 (lbl, c, b, a) VALUES(92, '0x5C', 4, 4);
+  CREATE TABLE a2(x BLOB, y BLOB);
+  INSERT INTO a2(x, y) VALUES(1, 1);
+  INSERT INTO a2(x, y) VALUES(2, '2');
+  INSERT INTO a2(x, y) VALUES('3', 3);
+  INSERT INTO a2(x, y) VALUES('4', '4');
+} {}
+do_execsql_test doltlite_recover_withoutrowid-14.2 {
+  SELECT x, typeof(x), y, typeof(y) FROM a2 ORDER BY rowid;
+} {1 integer 1 integer 2 integer 2 text 3 text 3 integer 4 text 4 text}
+do_execsql_test doltlite_recover_withoutrowid-14.3 {
+  SELECT (SELECT lbl FROM a1 WHERE a=x AND b=y) FROM a2 ORDER BY rowid;
+} {{} {} 15 92}
+do_execsql_test doltlite_recover_withoutrowid-14.4 {
+  SELECT (SELECT lbl FROM a1 WHERE (a, b) = (x, y)) FROM a2 ORDER BY rowid;
+} {{} {} 15 92}
+do_execsql_test doltlite_recover_withoutrowid-14.5 {
+  SELECT a1.lbl FROM a1, a2 WHERE a=x AND b=y ORDER BY 1;
+} {15 92}
+do_execsql_test doltlite_recover_withoutrowid-14.6 {
+  SELECT a1.lbl FROM a1, a2 WHERE (a, b) = (x, y) ORDER BY 1;
+} {15 92}
+do_execsql_test doltlite_recover_withoutrowid-14.7 {
+  SELECT a1.lbl FROM a1, a2
+   WHERE coalesce(NULL,x)=a AND coalesce(NULL,y)=b ORDER BY 1;
+} {3 14 15 92}
+do_execsql_test doltlite_recover_withoutrowid-14.8 {
+  SELECT a1.lbl FROM a1, a2
+   WHERE (coalesce(NULL,x), coalesce(NULL,y)) = (a, b) ORDER BY 1;
+} {3 14 15 92}
+do_execsql_test doltlite_recover_withoutrowid-14.9 {
+  SELECT a1.lbl FROM a1, a2 WHERE +x=a AND +y=b ORDER BY 1;
+} {3 14 15 92}
+do_execsql_test doltlite_recover_withoutrowid-14.10 {
+  SELECT a1.lbl FROM a1, a2 WHERE (+x, +y) = (a, b) ORDER BY 1;
+} {3 14 15 92}
+do_execsql_test doltlite_recover_withoutrowid-14.11 {
+  SELECT (SELECT lbl FROM a1 WHERE a=+x AND b=+y) FROM a2 ORDER BY rowid;
+} {3 14 15 92}
+do_execsql_test doltlite_recover_withoutrowid-14.12 {
+  SELECT (SELECT lbl FROM a1 WHERE (a, b) = (+x, +y)) FROM a2 ORDER BY rowid;
+} {3 14 15 92}
+do_execsql_test doltlite_recover_withoutrowid-14.13 {
+  SELECT (SELECT lbl FROM a1 WHERE (+x, +y) = (a, b)) FROM a2 ORDER BY rowid;
+} {3 14 15 92}
+do_execsql_test doltlite_recover_withoutrowid-14.14 {
+  SELECT a1.lbl FROM a1 WHERE (a, b) IN (SELECT x, y FROM a2) ORDER BY 1;
+} {15 92}
+do_execsql_test doltlite_recover_withoutrowid-14.15 {
+  SELECT a1.lbl FROM a1, a2 WHERE EXISTS (
+    SELECT 1 FROM a1 WHERE a=x AND b=y
+  ) ORDER BY 1;
+} {3 3 14 14 15 15 92 92}
+
+#-------------------------------------------------------------------------
+# 15: without_rowid7-2.4 — duplicate PK column with collation accepted;
+# uniqueness keyed on both components.
+do_execsql_test doltlite_recover_withoutrowid-15.1 {
+  CREATE TABLE wt3(a, b, PRIMARY KEY(a COLLATE nocase, a));
+  INSERT INTO wt3 VALUES('abc',1);
+  INSERT INTO wt3 VALUES('ABC',2);
+  SELECT a, b FROM wt3 ORDER BY b;
+} {abc 1 ABC 2}
+do_catchsql_test doltlite_recover_withoutrowid-15.2 {
+  INSERT INTO wt3 VALUES('abc',3);
+} {1 {UNIQUE constraint failed: wt3.a, wt3.a}}
+
+#-------------------------------------------------------------------------
+# 16: skipscan1 / skipscan2 — skip-scan over the composite PRIMARY KEY.
+do_execsql_test doltlite_recover_withoutrowid-16.1 {
+  CREATE TABLE sk2(a TEXT, b INT, c INT, d INT, PRIMARY KEY(a,b,c));
+  INSERT INTO sk2 VALUES('abc',345,7,8),('def',345,9,10),('ghi',346,11,12);
+  ANALYZE;
+  UPDATE sqlite_stat1 SET stat='10000 5000 2000 10' WHERE tbl='sk2';
+  ANALYZE sqlite_master;
+  SELECT a,b,c,d,'|' FROM sk2 WHERE d<>99 AND b=345 ORDER BY a;
+} {abc 345 7 8 | def 345 9 10 |}
+do_execsql_test doltlite_recover_withoutrowid-16.2 {
+  EXPLAIN QUERY PLAN
+  SELECT a,b,c,d,'|' FROM sk2 WHERE d<>99 AND b=345 ORDER BY a;
+} {/* PRIMARY KEY (ANY(a) AND b=?)*/}
+do_execsql_test doltlite_recover_withoutrowid-16.3 {
+  CREATE TABLE skt1 (c1, c2, c3, c4, PRIMARY KEY(c4, c3));
+  INSERT INTO skt1 VALUES(3,0,1,7);
+  INSERT INTO skt1 VALUES(0,4,1,8);
+  INSERT INTO skt1 VALUES(5,6,1,9);
+  INSERT INTO skt1 VALUES(0,4,1,10);
+  ANALYZE;
+  UPDATE sqlite_stat1 SET stat='18 18 6' WHERE tbl='skt1';
+  ANALYZE sqlite_master;
+  SELECT DISTINCT quote(c1), quote(c2), quote(c3), '|'
+    FROM skt1 WHERE skt1.c3 = 1 ORDER BY 1, 2;
+} {0 4 1 | 3 0 1 | 5 6 1 |}
+do_execsql_test doltlite_recover_withoutrowid-16.4 {
+  EXPLAIN QUERY PLAN
+  SELECT DISTINCT quote(c1), quote(c2), quote(c3), quote(c4), '|'
+    FROM skt1 WHERE skt1.c3 = 1;
+} {/* PRIMARY KEY (ANY(c4) AND c3=?)*/}
+do_execsql_test doltlite_recover_withoutrowid-16.5 {
+  CREATE TABLE people(
+    name TEXT PRIMARY KEY,
+    role TEXT NOT NULL,
+    height INT NOT NULL,
+    CHECK( role IN ('student','teacher') )
+  );
+  CREATE INDEX people_idx1 ON people(role, height);
+  INSERT INTO people VALUES('Alice','student',156),('Bob','student',161),
+   ('Cindy','student',155),('David','student',181),('Emily','teacher',158),
+   ('Fred','student',163),('Ginny','student',169),('Harold','student',172),
+   ('Imma','student',179),('Jack','student',181),('Karen','student',163),
+   ('Logan','student',177),('Megan','teacher',159),('Nathan','student',163),
+   ('Olivia','student',161),('Patrick','teacher',180),('Quiana','student',182),
+   ('Robert','student',159),('Sally','student',166),('Tom','student',171),
+   ('Ursula','student',170),('Vance','student',179),('Willma','student',175),
+   ('Xavier','teacher',185),('Yvonne','student',149),('Zach','student',170);
+  ANALYZE sqlite_master;
+  INSERT INTO sqlite_stat1 VALUES('people','people_idx1','1000000 250000 2000');
+  ANALYZE sqlite_master;
+  SELECT name FROM people WHERE height>=180 ORDER BY +name;
+} {David Jack Patrick Quiana Xavier}
+
+#-------------------------------------------------------------------------
+# 17: tkt3871 — OR optimization over TEXT PK + UNIQUE column.
+do_test doltlite_recover_withoutrowid-17.1 {
+  execsql {
+    BEGIN;
+    CREATE TABLE q1(a PRIMARY KEY, b UNIQUE);
+  }
+  for {set i 0} {$i < 500} {incr i} {
+    execsql { INSERT INTO q1 VALUES($i, $i*$i) }
+  }
+  execsql COMMIT
+  execsql { SELECT count(*) FROM q1 }
+} {500}
+do_execsql_test doltlite_recover_withoutrowid-17.2 {
+  SELECT * FROM q1 WHERE a = 1 OR a = 2 ORDER BY a;
+} {1 1 2 4}
+do_test doltlite_recover_withoutrowid-17.3 {
+  set p [wr_plan {SELECT * FROM q1 WHERE a = 1 OR a = 2}]
+  string match {*SCAN q1*} $p
+} {0}
+do_execsql_test doltlite_recover_withoutrowid-17.4 {
+  SELECT * FROM q1 WHERE a = 1 OR a = 2 OR b = 9 ORDER BY a;
+} {1 1 2 4 3 9}
+do_test doltlite_recover_withoutrowid-17.5 {
+  set p [wr_plan {SELECT * FROM q1 WHERE a = 1 OR a = 2 OR b = 9}]
+  string match {*SCAN q1*} $p
+} {0}
+
+#-------------------------------------------------------------------------
+# 18: tkt3121 vtabD-1.2 — join on the PK column.
+do_execsql_test doltlite_recover_withoutrowid-18.1 {
+  CREATE TABLE r1(field);
+  CREATE TABLE r2(col PRIMARY KEY, descr);
+  INSERT INTO r1 VALUES('abcd');
+  INSERT INTO r2 VALUES('abcd', 'A nice description');
+  INSERT INTO r2 VALUES('efgh', 'Another description');
+  SELECT r1.field AS Field, r2.descr AS Descr
+    FROM r1 INNER JOIN r2 ON r1.field = r2.col ORDER BY r1.field;
+} {abcd {A nice description}}
+
+#-------------------------------------------------------------------------
+# 19: vtab4 — transaction lifecycle. Row semantics on the PK table
+# directly; xBegin/xSync/xCommit/xRollback via echo over a rowid table.
+do_execsql_test doltlite_recover_withoutrowid-19.1 {
+  CREATE TABLE vreal(a PRIMARY KEY, b, c);
+  INSERT INTO vreal VALUES(1, 2, 3);
+  UPDATE vreal SET a = 2;
+  SELECT * FROM vreal;
+} {2 2 3}
+do_execsql_test doltlite_recover_withoutrowid-19.2 {
+  DELETE FROM vreal;
+  SELECT count(*) FROM vreal;
+} {0}
+do_execsql_test doltlite_recover_withoutrowid-19.3 {
+  BEGIN;
+  INSERT INTO vreal VALUES(1, 2, 3);
+  INSERT INTO vreal VALUES(4, 5, 6);
+  INSERT INTO vreal VALUES(7, 8, 9);
+  COMMIT;
+  SELECT * FROM vreal ORDER BY a;
+} {1 2 3 4 5 6 7 8 9}
+do_execsql_test doltlite_recover_withoutrowid-19.4 {
+  CREATE TABLE sreal(a, b, c UNIQUE);
+  BEGIN;
+  INSERT INTO sreal SELECT * FROM vreal;
+  DELETE FROM vreal;
+  COMMIT;
+  SELECT * FROM sreal ORDER BY a;
+  SELECT count(*) FROM vreal;
+} {1 2 3 4 5 6 7 8 9 0}
+do_execsql_test doltlite_recover_withoutrowid-19.5 {
+  BEGIN;
+  INSERT INTO vreal SELECT * FROM sreal;
+  DELETE FROM sreal;
+  ROLLBACK;
+  SELECT * FROM sreal ORDER BY a;
+  SELECT count(*) FROM vreal;
+} {1 2 3 4 5 6 7 8 9 0}
+do_catchsql_test doltlite_recover_withoutrowid-19.6 {
+  INSERT INTO sreal VALUES(10, 11, 3);
+} {1 {UNIQUE constraint failed: sreal.c}}
+do_test doltlite_recover_withoutrowid-19.7 {
+  register_echo_module [sqlite3_connection_pointer db]
+  execsql {
+    CREATE TABLE rreal(a INTEGER PRIMARY KEY, b, c);
+    CREATE VIRTUAL TABLE recho USING echo(rreal);
+  }
+  set ::echo_module [list]
+  execsql { INSERT INTO recho VALUES(1, 2, 3) }
+  string match {*xBegin echo(rreal) xSync echo(rreal) xCommit echo(rreal)} \
+      $::echo_module
+} {1}
+do_test doltlite_recover_withoutrowid-19.8 {
+  set ::echo_module [list]
+  set ::echo_module_sync_fail rreal
+  set res [catchsql { INSERT INTO recho VALUES(4, 5, 6) }]
+  unset ::echo_module_sync_fail
+  list $res [string match \
+      {*xBegin echo(rreal) xSync echo(rreal) xRollback echo(rreal)} \
+      $::echo_module]
+} {{1 {unknown error}} 1}
+do_execsql_test doltlite_recover_withoutrowid-19.9 {
+  SELECT * FROM rreal;
+} {1 2 3}
+
+#-------------------------------------------------------------------------
+# 20: dbstatus2 — the data scenario behind the cache-stat metrics:
+# PK-blob table, reopen, point lookups, inserts, spill-sized update.
+do_test doltlite_recover_withoutrowid-20.1 {
+  execsql {
+    CREATE TABLE bt1(a PRIMARY KEY, b);
+    INSERT INTO bt1 VALUES(1, zeroblob(600));
+    INSERT INTO bt1 VALUES(2, zeroblob(600));
+    INSERT INTO bt1 VALUES(3, zeroblob(600));
+  }
+  db close
+  sqlite3 db test.db
+  execsql { SELECT count(*) FROM bt1 }
+} {3}
+do_execsql_test doltlite_recover_withoutrowid-20.2 {
+  SELECT length(b) FROM bt1 WHERE a=2;
+} {600}
+do_execsql_test doltlite_recover_withoutrowid-20.3 {
+  SELECT length(b) FROM bt1 WHERE a=2;
+} {600}
+do_execsql_test doltlite_recover_withoutrowid-20.4 {
+  SELECT length(b) FROM bt1 WHERE a=1;
+} {600}
+do_execsql_test doltlite_recover_withoutrowid-20.5 {
+  INSERT INTO bt1 VALUES(4, zeroblob(600));
+  INSERT INTO bt1 VALUES(5, zeroblob(600));
+  SELECT a, length(b) FROM bt1 ORDER BY a;
+} {1 600 2 600 3 600 4 600 5 600}
+do_execsql_test doltlite_recover_withoutrowid-20.6 {
+  UPDATE bt1 SET b=zeroblob(1000);
+  SELECT a, length(b) FROM bt1 ORDER BY a;
+} {1 1000 2 1000 3 1000 4 1000 5 1000}
+do_execsql_test doltlite_recover_withoutrowid-20.7 {
+  PRAGMA integrity_check;
+} {ok}
+
+#-------------------------------------------------------------------------
+# 21: index — implicit PK/UNIQUE constraint enforcement (autoindex
+# bookkeeping rows are not materialized in doltlite).
+do_execsql_test doltlite_recover_withoutrowid-21.1 {
+  CREATE TABLE test1(f1 int, f2 int primary key);
+  INSERT INTO test1 VALUES(15, 32768), (16, 65536), (17, 131072);
+  SELECT f1 FROM test1 WHERE f2=65536;
+} {16}
+do_catchsql_test doltlite_recover_withoutrowid-21.2 {
+  INSERT INTO test1 VALUES(99, 65536);
+} {1 {UNIQUE constraint failed: test1.f2}}
+do_test doltlite_recover_withoutrowid-21.3 {
+  execsql {
+    CREATE TABLE t7(c UNIQUE PRIMARY KEY);
+    INSERT INTO t7 VALUES(1);
+  }
+  catchsql { INSERT INTO t7 VALUES(1) }
+} {1 {UNIQUE constraint failed: t7.c}}
+do_test doltlite_recover_withoutrowid-21.4 {
+  execsql {
+    DROP TABLE t7;
+    CREATE TABLE t7(c UNIQUE PRIMARY KEY);
+    INSERT INTO t7 VALUES(1);
+  }
+  catchsql { INSERT INTO t7 VALUES(1) }
+} {1 {UNIQUE constraint failed: t7.c}}
+do_test doltlite_recover_withoutrowid-21.5 {
+  execsql {
+    DROP TABLE t7;
+    CREATE TABLE t7(c PRIMARY KEY, UNIQUE(c));
+    INSERT INTO t7 VALUES(1);
+  }
+  catchsql { INSERT INTO t7 VALUES(1) }
+} {1 {UNIQUE constraint failed: t7.c}}
+do_test doltlite_recover_withoutrowid-21.6 {
+  execsql {
+    DROP TABLE t7;
+    CREATE TABLE t7(c, d, UNIQUE(c, d), PRIMARY KEY(c, d));
+    INSERT INTO t7 VALUES(1, 1);
+    INSERT INTO t7 VALUES(1, 2);
+  }
+  catchsql { INSERT INTO t7 VALUES(1, 1) }
+} {1 {UNIQUE constraint failed: t7.c, t7.d}}
+do_test doltlite_recover_withoutrowid-21.7 {
+  execsql {
+    DROP TABLE t7;
+    CREATE TABLE t7(c, d, UNIQUE(c), PRIMARY KEY(c, d));
+    INSERT INTO t7 VALUES(1, 1);
+  }
+  catchsql { INSERT INTO t7 VALUES(1, 2) }
+} {1 {UNIQUE constraint failed: t7.c}}
+
+#-------------------------------------------------------------------------
+# 22: fkey2-5.* — incrblob may not write an FK column while FKs are on
+# (child kept a rowid table so the incrblob API itself applies).
+do_test doltlite_recover_withoutrowid-22.1 {
+  execsql {
+    PRAGMA foreign_keys = 1;
+    CREATE TABLE fbp(a PRIMARY KEY, b);
+    CREATE TABLE fbc(id INTEGER PRIMARY KEY, b REFERENCES fbp(a));
+    INSERT INTO fbp VALUES('hello', 'world');
+    INSERT INTO fbc VALUES(1, 'hello');
+  }
+  set rc [catch { set fd [db incrblob fbc b 1] } msg]
+  list $rc $msg
+} {1 {cannot open foreign key column for writing}}
+do_test doltlite_recover_withoutrowid-22.2 {
+  set rc [catch { set fd [db incrblob -readonly fbc b 1] } msg]
+  close $fd
+  set rc
+} {0}
+do_test doltlite_recover_withoutrowid-22.3 {
+  execsql { PRAGMA foreign_keys = off }
+  set rc [catch { set fd [db incrblob fbc b 1] } msg]
+  close $fd
+  execsql { PRAGMA foreign_keys = on }
+  set rc
+} {0}
+
+#-------------------------------------------------------------------------
+# 23: fkey2-13.1.* — FK processing on REPLACE, conflicts taken on the
+# declared keys instead of an explicit rowid.
+do_execsql_test doltlite_recover_withoutrowid-23.1 {
+  CREATE TABLE pp(a UNIQUE, b, c, PRIMARY KEY(b, c));
+  CREATE TABLE cc(d, e, f UNIQUE, FOREIGN KEY(d, e) REFERENCES pp);
+  INSERT INTO pp VALUES(1, 2, 3);
+  INSERT INTO cc VALUES(2, 3, 1);
+} {}
+do_catchsql_test doltlite_recover_withoutrowid-23.2 {
+  REPLACE INTO pp VALUES(1, 4, 5);
+} {1 {FOREIGN KEY constraint failed}}
+do_execsql_test doltlite_recover_withoutrowid-23.3 {
+  SELECT * FROM pp;
+  SELECT * FROM cc;
+} {1 2 3 2 3 1}
+do_test doltlite_recover_withoutrowid-23.4 {
+  execsql BEGIN
+  catchsql { REPLACE INTO pp VALUES(1, 4, 5) }
+} {1 {FOREIGN KEY constraint failed}}
+do_execsql_test doltlite_recover_withoutrowid-23.5 {
+  COMMIT;
+  SELECT * FROM pp;
+  SELECT * FROM cc;
+} {1 2 3 2 3 1}
+do_execsql_test doltlite_recover_withoutrowid-23.6 {
+  REPLACE INTO pp VALUES(2, 2, 3);
+  SELECT * FROM pp;
+  SELECT * FROM cc;
+} {2 2 3 2 3 1}
+do_execsql_test doltlite_recover_withoutrowid-23.7 {
+  REPLACE INTO pp VALUES(2, 2, 3);
+  SELECT * FROM pp;
+  SELECT * FROM cc;
+} {2 2 3 2 3 1}
+
+#-------------------------------------------------------------------------
+# 24: e_createtable — column limit, PK NOT-NULL contract, NULL
+# distinctness via UNIQUE, constraint-as-index semantics, REPLACE order,
+# non-rowid-alias PK shapes.
+do_test doltlite_recover_withoutrowid-24.1 {
+  set cols500 {}
+  set cols501 {}
+  for {set i 0} {$i < 500} {incr i} { lappend cols500 "c$i" }
+  for {set i 0} {$i < 501} {incr i} { lappend cols501 "c$i" }
+  sqlite3_limit db SQLITE_LIMIT_COLUMN 500
+  set r1 [catchsql "CREATE TABLE ctok([join $cols500 ,])"]
+  set r2 [catchsql "CREATE TABLE ct11([join $cols501 ,])"]
+  sqlite3_limit db SQLITE_LIMIT_COLUMN 2000
+  list $r1 $r2
+} {{0 {}} {1 {too many columns on ct11}}}
+do_execsql_test doltlite_recover_withoutrowid-24.2 {
+  CREATE TABLE et1(x PRIMARY KEY, y);
+  CREATE TABLE et2(x, y, PRIMARY KEY(x, y));
+} {}
+do_catchsql_test doltlite_recover_withoutrowid-24.3 {
+  INSERT INTO et1 VALUES(NULL, 0);
+} {1 {NOT NULL constraint failed: et1.x}}
+do_catchsql_test doltlite_recover_withoutrowid-24.4 {
+  INSERT INTO et2 VALUES(NULL, 'zero');
+} {1 {NOT NULL constraint failed: et2.x}}
+do_catchsql_test doltlite_recover_withoutrowid-24.5 {
+  INSERT INTO et2 VALUES(0, NULL);
+} {1 {NOT NULL constraint failed: et2.y}}
+do_catchsql_test doltlite_recover_withoutrowid-24.6 {
+  INSERT INTO et2 VALUES(NULL, NULL);
+} {1 {NOT NULL constraint failed: et2.x}}
+do_execsql_test doltlite_recover_withoutrowid-24.7 {
+  CREATE TABLE etu(x UNIQUE, y);
+  INSERT INTO etu VALUES(NULL, 0);
+  INSERT INTO etu VALUES(NULL, 0);
+  INSERT INTO etu VALUES(NULL, 0);
+  SELECT count(*) FROM etu WHERE x IS NULL;
+} {3}
+do_execsql_test doltlite_recover_withoutrowid-24.8 {
+  SELECT count(*) FROM et1 WHERE x IS NULL;
+  SELECT count(*) FROM et2 WHERE x IS NULL;
+  SELECT count(*) FROM et2 WHERE y IS NULL;
+} {0 0 0}
+do_test doltlite_recover_withoutrowid-24.9 {
+  execsql {
+    CREATE TABLE ei1(a TEXT PRIMARY KEY, b);
+    INSERT INTO ei1 VALUES('k', 1);
+  }
+  catchsql { INSERT INTO ei1 VALUES('k', 2) }
+} {1 {UNIQUE constraint failed: ei1.a}}
+do_test doltlite_recover_withoutrowid-24.10 {
+  execsql {
+    CREATE TABLE ei4(a PRIMARY KEY, b TEXT UNIQUE);
+    INSERT INTO ei4 VALUES(1, 'x');
+  }
+  list [catchsql { INSERT INTO ei4 VALUES(1, 'y') }] \
+       [catchsql { INSERT INTO ei4 VALUES(2, 'x') }]
+} {{1 {UNIQUE constraint failed: ei4.a}} {1 {UNIQUE constraint failed: ei4.b}}}
+do_test doltlite_recover_withoutrowid-24.11 {
+  execsql {
+    CREATE TABLE ei5(a PRIMARY KEY, b, c, UNIQUE(c, b));
+    INSERT INTO ei5 VALUES(1, 'b', 'c');
+  }
+  list [catchsql { INSERT INTO ei5 VALUES(1, 'q', 'r') }] \
+       [catchsql { INSERT INTO ei5 VALUES(2, 'b', 'c') }]
+} {{1 {UNIQUE constraint failed: ei5.a}} {1 {UNIQUE constraint failed: ei5.c, ei5.b}}}
+do_execsql_test doltlite_recover_withoutrowid-24.12 {
+  CREATE TABLE eq1(a, b PRIMARY KEY);
+  INSERT INTO eq1 VALUES('x', 5);
+  EXPLAIN QUERY PLAN SELECT * FROM eq1 WHERE b = 5;
+} {/*SEARCH eq1 USING PRIMARY KEY (b=?)*/}
+do_execsql_test doltlite_recover_withoutrowid-24.13 {
+  SELECT * FROM eq1 WHERE b = 5;
+} {x 5}
+do_execsql_test doltlite_recover_withoutrowid-24.14 {
+  CREATE TABLE t1_re(a PRIMARY KEY ON CONFLICT REPLACE, b);
+  INSERT INTO t1_re VALUES(1, 'one');
+  INSERT INTO t1_re VALUES(2, 'two');
+  BEGIN;
+  INSERT INTO t1_re VALUES(3, 'three');
+  INSERT INTO t1_re SELECT ((a%2)*a+3), 'string' FROM t1_re;
+  SELECT * FROM t1_re ORDER BY a;
+} {1 one 2 two 3 string 4 string 6 string}
+do_test doltlite_recover_withoutrowid-24.15 {
+  set ac [sqlite3_get_autocommit db]
+  execsql COMMIT
+  set ac
+} {0}
+do_test doltlite_recover_withoutrowid-24.16 {
+  set res {}
+  foreach create {
+    {CREATE TABLE et5(pk integer, v integer, primary key(pk, v))}
+    {CREATE TABLE et5(pk int, v integer, primary key(pk, v))}
+    {CREATE TABLE et5(pk int, v integer, primary key(pk))}
+    {CREATE TABLE et5(pk int primary key, v integer)}
+  } {
+    catchsql { DROP TABLE et5 }
+    execsql $create
+    lappend res [catchsql { SELECT rowid FROM et5 }]
+  }
+  set res
+} [lrepeat 4 {1 {no such column: rowid}}]
+do_test doltlite_recover_withoutrowid-24.17 {
+  execsql {
+    CREATE TABLE et6(pk INT primary key);
+    CREATE TABLE et7(pk BIGINT primary key);
+    CREATE TABLE et8(pk SHORT INTEGER primary key);
+    CREATE TABLE et9(pk UNSIGNED INTEGER primary key);
+  }
+  list [catchsql {SELECT rowid FROM et6}] [catchsql {SELECT rowid FROM et7}] \
+       [catchsql {SELECT rowid FROM et8}] [catchsql {SELECT rowid FROM et9}]
+} [lrepeat 4 {1 {no such column: rowid}}]
+do_execsql_test doltlite_recover_withoutrowid-24.18 {
+  INSERT INTO et6 VALUES('2.0');
+  INSERT INTO et7 VALUES('2.0');
+  INSERT INTO et8 VALUES('2.0');
+  INSERT INTO et9 VALUES('2.0');
+  SELECT typeof(pk), pk FROM et6;
+  SELECT typeof(pk), pk FROM et7;
+  SELECT typeof(pk), pk FROM et8;
+  SELECT typeof(pk), pk FROM et9;
+} {integer 2 integer 2 integer 2 integer 2}
+do_catchsql_test doltlite_recover_withoutrowid-24.19 {
+  INSERT INTO et6 VALUES(2);
+} {1 {UNIQUE constraint failed: et6.pk}}
+do_test doltlite_recover_withoutrowid-24.20 {
+  execsql { CREATE TABLE etd(x INTEGER PRIMARY KEY DESC, y, z) }
+  list [catchsql { SELECT rowid FROM etd }] \
+       [execsql { INSERT INTO etd VALUES(5,1,2); SELECT x,y,z FROM etd }]
+} {{1 {no such column: rowid}} {5 1 2}}
+
+#-------------------------------------------------------------------------
+# 25: e_fkey — FK actions addressed by PK value instead of rowid.
+do_execsql_test doltlite_recover_withoutrowid-25.1 {
+  CREATE TABLE kt1(a COLLATE nocase PRIMARY KEY);
+  CREATE TABLE kt2(b REFERENCES kt1);
+  INSERT INTO kt1 VALUES('oNe');
+  INSERT INTO kt2 VALUES('one');
+  INSERT INTO kt2 VALUES('ONE');
+  UPDATE kt2 SET b = 'OnE';
+  UPDATE kt1 SET a = 'ONE';
+} {}
+do_catchsql_test doltlite_recover_withoutrowid-25.2 {
+  DELETE FROM kt1 WHERE a='one';
+} {1 {FOREIGN KEY constraint failed}}
+do_execsql_test doltlite_recover_withoutrowid-25.3 {
+  CREATE TABLE at1(a NUMERIC PRIMARY KEY);
+  CREATE TABLE at2(b TEXT REFERENCES at1);
+  INSERT INTO at1 VALUES(1);
+  INSERT INTO at1 VALUES(2);
+  INSERT INTO at1 VALUES('three');
+  INSERT INTO at2 VALUES('2.0');
+} {}
+do_catchsql_test doltlite_recover_withoutrowid-25.4 {
+  DELETE FROM at1 WHERE a=2;
+} {1 {FOREIGN KEY constraint failed}}
+do_execsql_test doltlite_recover_withoutrowid-25.5 {
+  DELETE FROM at1 WHERE a=1;
+  SELECT count(*) FROM at1;
+} {2}
+do_execsql_test doltlite_recover_withoutrowid-25.6 {
+  CREATE TABLE pA(x PRIMARY KEY);
+  CREATE TABLE cA(c REFERENCES pA ON DELETE SET NULL);
+  CREATE TABLE cB(c REFERENCES pA ON UPDATE SET NULL);
+  INSERT INTO pA VALUES(X'ABCD');
+  INSERT INTO pA VALUES(X'1234');
+  INSERT INTO cA VALUES(X'ABCD');
+  INSERT INTO cB VALUES(X'1234');
+  DELETE FROM pA WHERE x=X'ABCD';
+  SELECT quote(x) FROM pA;
+} {X'1234'}
+do_execsql_test doltlite_recover_withoutrowid-25.7 {
+  SELECT quote(c) FROM cA;
+} {NULL}
+do_execsql_test doltlite_recover_withoutrowid-25.8 {
+  UPDATE pA SET x = X'8765' WHERE x=X'1234';
+  SELECT quote(x) FROM pA;
+} {X'8765'}
+do_execsql_test doltlite_recover_withoutrowid-25.9 {
+  SELECT quote(c) FROM cB;
+} {NULL}
+do_execsql_test doltlite_recover_withoutrowid-25.10 {
+  CREATE TABLE pD(x PRIMARY KEY);
+  CREATE TABLE cD(c DEFAULT X'0000' REFERENCES pD ON DELETE SET DEFAULT);
+  CREATE TABLE cE(c DEFAULT X'9999' REFERENCES pD ON UPDATE SET DEFAULT);
+  INSERT INTO pD VALUES(X'0000');
+  INSERT INTO pD VALUES(X'9999');
+  INSERT INTO pD VALUES(X'ABCD');
+  INSERT INTO pD VALUES(X'1234');
+  INSERT INTO cD VALUES(X'ABCD');
+  INSERT INTO cE VALUES(X'1234');
+} {}
+do_execsql_test doltlite_recover_withoutrowid-25.11 {
+  DELETE FROM pD WHERE x=X'ABCD';
+  SELECT quote(x) FROM pD ORDER BY x;
+} {X'0000' X'1234' X'9999'}
+do_execsql_test doltlite_recover_withoutrowid-25.12 {
+  SELECT quote(c) FROM cD;
+} {X'0000'}
+do_execsql_test doltlite_recover_withoutrowid-25.13 {
+  UPDATE pD SET x = X'8765' WHERE x=X'1234';
+  SELECT quote(x) FROM pD ORDER BY x;
+} {X'0000' X'8765' X'9999'}
+do_execsql_test doltlite_recover_withoutrowid-25.14 {
+  SELECT quote(c) FROM cE;
+} {X'9999'}
+do_test doltlite_recover_withoutrowid-25.15 {
+  proc maxparent {args} { db one {SELECT max(x) FROM parent} }
+  db func maxparent maxparent
+  execsql {
+    CREATE TABLE parent(x PRIMARY KEY);
+    CREATE TRIGGER bu BEFORE UPDATE ON parent BEGIN
+      INSERT INTO parent VALUES(new.x-old.x);
+    END;
+    CREATE TABLE child(
+      a DEFAULT (maxparent()) REFERENCES parent ON UPDATE SET DEFAULT
+    );
+    CREATE TRIGGER au AFTER UPDATE ON parent BEGIN
+      INSERT INTO parent VALUES(new.x+old.x);
+    END;
+    INSERT INTO parent VALUES(1);
+    INSERT INTO child VALUES(1);
+    UPDATE parent SET x = 22;
+    SELECT x FROM parent ORDER BY x; SELECT 'xxx'; SELECT a FROM child;
+  }
+} {21 22 23 xxx 22}
+do_execsql_test doltlite_recover_withoutrowid-25.16 {
+  DELETE FROM child;
+  DELETE FROM parent;
+  INSERT INTO parent VALUES(-1);
+  INSERT INTO child VALUES(-1);
+  UPDATE parent SET x = 22;
+  SELECT x FROM parent ORDER BY x; SELECT 'xxx'; SELECT a FROM child;
+} {21 22 23 xxx 23}
+do_execsql_test doltlite_recover_withoutrowid-25.17 {
+  CREATE TABLE zeus(a INTEGER COLLATE NOCASE, b, PRIMARY KEY(a, b));
+  CREATE TABLE apollo(c, d, FOREIGN KEY(c, d) REFERENCES zeus ON UPDATE CASCADE);
+  INSERT INTO zeus VALUES('abc', 'xyz');
+  INSERT INTO apollo VALUES('ABC', 'xyz');
+  UPDATE zeus SET a = 'aBc';
+  SELECT * FROM apollo;
+} {ABC xyz}
+do_execsql_test doltlite_recover_withoutrowid-25.18 {
+  UPDATE zeus SET b = 'www';
+  SELECT typeof(c), c, typeof(d), d FROM apollo;
+} {text aBc text www}
+do_catchsql_test doltlite_recover_withoutrowid-25.19 {
+  UPDATE zeus SET b = NULL;
+} {1 {NOT NULL constraint failed: zeus.b}}
+do_execsql_test doltlite_recover_withoutrowid-25.20 {
+  CREATE TABLE p(a, b, PRIMARY KEY(a, b));
+  CREATE TABLE pc1(c, d, FOREIGN KEY(c, d) REFERENCES p ON DELETE SET NULL);
+  CREATE TABLE pc5(c, d, FOREIGN KEY(c, d) REFERENCES p ON DELETE NO ACTION);
+  CREATE TABLE log(msg);
+  CREATE TRIGGER tt AFTER DELETE ON p BEGIN
+    INSERT INTO log VALUES('delete ' || old.a);
+  END;
+  INSERT INTO p VALUES('a', 'b');
+  INSERT INTO pc1 VALUES('a', 'b');
+  BEGIN;
+  DROP TABLE p;
+  SELECT * FROM pc1;
+} {{} {}}
+do_execsql_test doltlite_recover_withoutrowid-25.21 {
+  SELECT * FROM log;
+} {}
+do_execsql_test doltlite_recover_withoutrowid-25.22 {
+  ROLLBACK;
+  BEGIN;
+  DELETE FROM p;
+  SELECT * FROM log;
+} {{delete a}}
+do_execsql_test doltlite_recover_withoutrowid-25.23 {
+  ROLLBACK;
+  DELETE FROM pc1;
+  INSERT INTO pc5 VALUES('a', 'b');
+} {}
+do_catchsql_test doltlite_recover_withoutrowid-25.24 {
+  BEGIN;
+  DROP TABLE p;
+} {1 {FOREIGN KEY constraint failed}}
+do_test doltlite_recover_withoutrowid-25.25 {
+  set res [execsql {
+    SELECT * FROM p;
+    SELECT * FROM pc5;
+  }]
+  catchsql ROLLBACK
+  set res
+} {a b a b}
+
+finish_test

--- a/test/regression-buckets/core-sql.txt
+++ b/test/regression-buckets/core-sql.txt
@@ -83,6 +83,10 @@ decimal
 distinct
 distinctagg
 doltlite_fts3_oom
+doltlite_recover_collation
+doltlite_recover_ordering
+doltlite_recover_utf16_errtext
+doltlite_recover_withoutrowid
 e_blobbytes
 e_expr
 e_resolve
@@ -308,10 +312,10 @@ skipscan3
 skipscan5
 skipscan6
 snapshot
+snapshot_up
 snapshot2
 snapshot3
 snapshot4
-snapshot_up
 sort
 sort2
 sort3
@@ -384,11 +388,11 @@ whereI
 whereJ
 whereK
 whereL
-whereM
-whereN
 wherelimit
 wherelimit2
 wherelimit3
+whereM
+whereN
 window1
 window2
 window3


### PR DESCRIPTION
Part of #1313. **422 assertions covering 289 gated entries.**

- WITHOUT ROWID rowid-references re-expressed through declared PKs (uniqueness, PK-order iteration, lookups, UPDATE/DELETE by PK).
- Unordered-result divergences asserted as ordered multisets; search_count-style metrics replaced by EXPLAIN QUERY PLAN index-usage checks with matching results.
- Custom-collation rejection pinned verbatim plus built-in-collation ordering equivalents; UTF-8 round-trips for the utf16 surface; error text asserted exactly.
- Gated in the **core-sql** bucket as zero-divergence files; adversarially verified as in PR 1/4.

Surfaced 1 suspected bug (UNIQUE COLLATE custom bypasses the index rejection via sqlite3AddCollateType) — filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)