### PR TITLE
Recover locking-contract & explicit-rejection coverage (#1313 4/4)

### DIFF
--- a/test/doltlite_recover_locking_1.test
+++ b/test/doltlite_recover_locking_1.test
@@ -1,0 +1,676 @@
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+# Recovered-intent coverage for gated divergences (shard locking_1).
+# All scenarios run on uniquely-named db files (rloc1*.db) so concurrent
+# harness runs sharing build-ci cannot interfere with this file's state.
+#
+# covers: enc2 enc2-1.3 — SELECT * multiset asserted with ORDER BY a; bare SELECT * iterates in PK order
+# covers: enc2 enc2-1.7 — rows with c>3 are exactly {four five}, asserted via ORDER BY c
+# covers: enc2 enc2-1.8 — second c>3 row retrievable with correct text (ORDER BY c result)
+# covers: enc2 enc2-2.3 — same dbcontents scenario after PRAGMA encoding=UTF16le (ignored; identical UTF-8 behavior)
+# covers: enc2 enc2-2.7 — c>3 multiset unchanged after UTF16le pragma
+# covers: enc2 enc2-2.8 — c>3 multiset unchanged after UTF16le pragma
+# covers: enc2 enc2-3.3 — same scenario after PRAGMA encoding=UTF16be (ignored)
+# covers: enc2 enc2-3.7 — c>3 multiset unchanged after UTF16be pragma
+# covers: enc2 enc2-3.8 — c>3 multiset unchanged after UTF16be pragma
+# covers: enc2 enc2-2.0.1 — doltlite reports UTF-8 after PRAGMA encoding=UTF16le on fresh db
+# covers: enc2 enc2-2.0.2 — PRAGMA encoding=UTF8 leaves report at UTF-8
+# covers: enc2 enc2-2.0.3 — PRAGMA encoding=UTF16le ignored, reports UTF-8
+# covers: enc2 enc2-2.0.4 — PRAGMA encoding=UTF16be ignored, reports UTF-8
+# covers: enc2 enc2-2.10 — encoding still reports UTF-8 after data ops on the "UTF-16le" db
+# covers: enc2 enc2-3.0.1 — UTF16be variant of 2.0.1 (single UTF-8-locked contract)
+# covers: enc2 enc2-3.0.2 — UTF16be variant of 2.0.2
+# covers: enc2 enc2-3.0.3 — UTF16be variant of 2.0.3
+# covers: enc2 enc2-3.0.4 — UTF16be variant of 2.0.4
+# covers: enc2 enc2-3.10 — UTF16be variant of 2.10
+# covers: enc2 enc2-4.3 — ATTACH of another doltlite db always succeeds: every doltlite db is UTF-8 so no encoding mismatch is possible
+# covers: enc2 enc2-5.5 — best-match collation in (always-)UTF-8 db chosen and sorts correctly
+# covers: enc2 enc2-5.6 — UTF-16BE-only collation still selected and sorts correctly
+# covers: enc2 enc2-5.9 — all-encodings collation: UTF-8 version chosen, sort correct
+# covers: enc2 enc2-5.10 — UTF-16LE-only collation still selected and sorts correctly
+# covers: enc2 enc2-5.13 — collation-needed callback registers collation; sort correct
+# covers: enc2 enc2-6.4 — best-match user function is the UTF-8 version in a doltlite db; result text correct
+# covers: enc2 enc2-6.8 — UTF-16BE-only user function still callable with correct result
+# covers: enc2 enc2-7.2 — fresh db opened "as UTF-16" reports UTF-8; schema visible to second handle
+# covers: enc2 enc2-9.2 — PRAGMA encoding=UTF-16le on empty db: reports UTF-8
+# covers: enc2 enc2-9.4 — table creatable after UTF-16le pragma; encoding stays UTF-8
+# covers: enc2 enc2-9.5 — encoding report stable (UTF-8) across reopen; unicode data round-trips
+# covers: windowC 2.0 — group_concat window over blob value after PRAGMA encoding=UTF16le: no crash, deterministic UTF-8 bytes
+# covers: windowC 2.1 — same after PRAGMA encoding=UTF16be: identical result (encoding pragma is a no-op)
+# covers: shared6 shared6-1.1.2 — sqlite3_enable_shared_cache(1) reports 0: shared-cache is permanently disabled in doltlite
+# covers: shared2 shared2-3.2 — same shared-cache-disabled contract
+# covers: shared6 shared6-1.2.1 — db2 reads committed snapshot while db holds BEGIN EXCLUSIVE
+# covers: shared6 shared6-1.3.3 — db2 reads committed snapshot while db has an open write txn
+# covers: shared6 shared6-1.3.4 — db2 write during db's open write txn fails {database is locked}
+# covers: shared6 shared6-1.3.5 — db2 write during db's open write txn fails; reads still proceed
+# covers: shared6 shared6-1.4.2 — db2 read proceeds while db's txn includes a CREATE TABLE (schema write)
+# covers: shared6 shared6-1.4.3 — with read_uncommitted=1, db2 sees only committed rows; db2 write during db read-only txn succeeds
+# covers: shared6 shared6-2.2 — second connection reads committed data while first has open write txn
+# covers: shared6 shared6-2.3 — reader connections always see last-committed state
+# covers: shared6 shared6-2.4 — after COMMIT every connection sees the new rows
+# covers: shared6 shared6-3.2 — write from second connection during first's open scan proceeds; scan keeps its snapshot
+# covers: shared6 shared6-3.3 — BEGIN EXCLUSIVE succeeds while another connection holds an active read statement; same-connection DROP mid-scan errors {database table is locked}
+# covers: shared6 shared6-3.4 — db2 SELECT proceeds while db holds BEGIN EXCLUSIVE
+# covers: shared6 shared6-3.5 — COMMIT of the exclusive txn succeeds
+# covers: shared6 shared6-3.6 — BEGIN EXCLUSIVE while other connection is in an open read txn succeeds
+# covers: shared6 shared6-3.7 — with both connections in BEGIN, the writer's INSERT succeeds
+# covers: shared6 shared6-3.8 — both txns commit; both connections converge on the same rows
+# covers: shared6 shared6-3.10 — a third connection can BEGIN;ROLLBACK; then read normally
+# covers: tkt2854 tkt2854-1.3 — BEGIN EXCLUSIVE while another connection holds an open read txn succeeds (chunk-store writers don't block on readers)
+# covers: tkt2854 tkt2854-1.7 — prepared statements on db2 stay usable across db's exclusive txn
+# covers: tkt2854 tkt2854-1.8 — db2 BEGIN EXCLUSIVE during db's exclusive txn fails {database is locked}
+# covers: tkt2854 tkt2854-1.9 — db2 BEGIN IMMEDIATE during db's exclusive txn fails {database is locked}
+# covers: tkt2854 tkt2854-1.10 — db2 plain BEGIN during db's exclusive txn succeeds (deferred, touches nothing)
+# covers: tkt2854 tkt2854-1.11 — db2 prepared SELECT steps fine during db's exclusive txn (snapshot read)
+# covers: tkt2854 tkt2854-1.12 — db2 BEGIN EXCLUSIVE blocked with doltlite's lock error
+# covers: tkt2854 tkt2854-1.13 — db2 BEGIN IMMEDIATE blocked with doltlite's lock error
+# covers: tkt2854 tkt2854-1.14 — plain BEGIN + read + COMMIT all succeed under the other connection's exclusive lock
+# covers: tkt2854 tkt2854-1.16 — independent connection reads committed snapshot during exclusive txn
+# covers: tkt2854 tkt2854-1.20 — BEGIN EXCLUSIVE fails {database is locked} when another connection holds a write txn on an attached db; both connections recover
+# covers: tkt2409 tkt2409-2.2 — write txn + COMMIT succeed while another connection holds an active read statement
+# covers: tkt2409 tkt2409-2.3 — after releasing the read statement, both connections consistent and integrity_check ok
+# covers: shared2 shared2-1.1 — DELETE of all rows from another connection mid-scan: scan completes its snapshot; delete commits
+# covers: exclusive exclusive-2.5 — locking_mode=exclusive does not lock out a second connection's writes
+# covers: exclusive exclusive-2.6 — second connection's txn commits while first is in locking_mode=exclusive
+# covers: exclusive exclusive-2.7 — no stuck COMMIT: txns complete normally
+# covers: exclusive exclusive-2.8 — ROLLBACK of second connection's txn restores its snapshot
+# covers: exclusive exclusive-2.9 — first connection's writes don't lock out the second's reads
+# covers: exclusive exclusive-2.10 — switching locking_mode does not strand locks; reads proceed
+# covers: exclusive exclusive-2.11 — after locking_mode=normal both connections converge
+# covers: exclusive exclusive-3.1 — txn boundary: BEGIN;DELETE;COMMIT durable across reopen (journal-file states have no doltlite analog)
+# covers: exclusive exclusive-3.2 — committed state intact after reopen
+# covers: exclusive exclusive-3.5 — BEGIN;UPDATE;ROLLBACK restores prior rows
+# covers: exclusive exclusive-5.5 — multi-statement txn with UNIQUE indexes commits correct rows (statement-journal analog)
+# covers: exclusive exclusive-6.2 — uncommitted txn rows are invisible to a newly opened connection
+# covers: exclusive exclusive-6.3 — new connection sees exactly the committed prefix
+# covers: exclusive exclusive-7.1 — locking_mode/journal_mode pragma dance: exclusive wal normal 0, then journal_mode=DELETE rejected with exact message; db stays usable
+# covers: exclusive2 exclusive2-1.2 — committed change by db2 immediately visible to db (no stale page cache to fool)
+# covers: exclusive2 exclusive2-1.6 — every committed txn changes visible content (signature changes)
+# covers: exclusive2 exclusive2-1.9 — no stale-cache serving: db re-reads current committed state
+# covers: exclusive2 exclusive2-2.2 — under locking_mode=exclusive, db still sees db2's committed update
+# covers: exclusive2 exclusive2-2.8 — reads after lock-mode flips return correct data, integrity_check ok (never serves stale/corrupt cache)
+# covers: exclusive2 exclusive2-3.0 — content hash advances on commit (change-counter analog)
+# covers: exclusive2 exclusive2-3.1 — content hash changes after first INSERT
+# covers: exclusive2 exclusive2-3.2 — content hash changes after second INSERT
+# covers: exclusive2 exclusive2-3.3 — hash changes under locking_mode=exclusive too
+# covers: exclusive2 exclusive2-3.4 — hash stable across a pure read (no-op does not change content)
+# covers: exclusive2 exclusive2-3.5 — hash stable across locking_mode flip without writes
+# covers: exclusive2 exclusive2-3.6 — hash changes again on next INSERT after mode flip
+# covers: capi3 capi3-3.3 — bogus-path open: doltlite defers the error; handle reports SQLITE_OK
+# covers: capi3 capi3-3.4 — errmsg on the deferred handle is "not an error"; first real use fails "unable to open database file"
+# covers: capi3 capi3-4.3 — same deferred-open contract (utf16 open path shares it; doltlite is UTF-8-only)
+# covers: capi3 capi3-4.4 — same deferred errmsg contract
+# covers: capi3 capi3-8.3 — writable_schema INSERT INTO sqlite_master cannot corrupt the prolly catalog: reopen works, schema usable, integrity ok
+# covers: capi3 capi3-11.3.4 — PRAGMA lock_status reports doltlite's model: main unlocked after COMMIT during active read
+# covers: capi3 capi3-11.12 — step after DONE (post writeOnly-ROLLBACK stmt) returns SQLITE_ERROR; data via fresh query correct
+# covers: capi3 capi3-11.13 — finalize of that statement returns SQLITE_SCHEMA; connection unaffected
+# covers: select2 select2-3.3 — after DROP INDEX the plan is a full SCAN (EQP) instead of index search; result identical
+#
+# not-covered: (none)
+
+db close
+forcedelete rloc1.db rloc1b.db rloc1e.db
+sqlite3 db rloc1.db
+set DB [sqlite3_connection_pointer db]
+
+#-------------------------------------------------------------------
+# 1.* enc2 unordered-SELECT class: PK-order iteration, multiset equal.
+#
+do_test doltlite_recover_locking_1-1.1 {
+  execsql {
+    CREATE TABLE t1(a PRIMARY KEY, b, c);
+    INSERT INTO t1 VALUES('one', 'I', 1);
+    INSERT INTO t1 VALUES('two', 'II', 2);
+    INSERT INTO t1 VALUES('three','III',3);
+    INSERT INTO t1 VALUES('four','IV',4);
+    INSERT INTO t1 VALUES('five','V',5);
+    SELECT * FROM t1 ORDER BY a;
+  }
+} {five V 5 four IV 4 one I 1 three III 3 two II 2}
+do_test doltlite_recover_locking_1-1.2 {
+  execsql {SELECT * FROM t1}
+} [execsql {SELECT * FROM t1 ORDER BY a}]
+do_test doltlite_recover_locking_1-1.3 {
+  execsql {SELECT a FROM t1 WHERE c>3 ORDER BY c}
+} {four five}
+do_test doltlite_recover_locking_1-1.4 {
+  execsql {
+    PRAGMA encoding=UTF16le;
+    SELECT a FROM t1 WHERE c>3 ORDER BY c;
+  }
+} {four five}
+do_test doltlite_recover_locking_1-1.5 {
+  execsql {
+    PRAGMA encoding=UTF16be;
+    SELECT * FROM t1 WHERE a='four';
+  }
+} {four IV 4}
+
+#-------------------------------------------------------------------
+# 2.* enc2 reports-UTF-8 class: encoding locked to UTF-8 everywhere.
+#
+do_test doltlite_recover_locking_1-2.1 {
+  execsql {PRAGMA encoding}
+} {UTF-8}
+do_test doltlite_recover_locking_1-2.2 {
+  execsql {PRAGMA encoding=UTF8; PRAGMA encoding;}
+} {UTF-8}
+do_test doltlite_recover_locking_1-2.3 {
+  execsql {PRAGMA encoding=UTF16le; PRAGMA encoding;}
+} {UTF-8}
+do_test doltlite_recover_locking_1-2.4 {
+  execsql {PRAGMA encoding=UTF16be; PRAGMA encoding;}
+} {UTF-8}
+do_test doltlite_recover_locking_1-2.5 {
+  sqlite3 dbe rloc1e.db
+  dbe eval {
+    PRAGMA encoding='UTF-16le';
+    PRAGMA encoding;
+  }
+} {UTF-8}
+do_test doltlite_recover_locking_1-2.6 {
+  dbe eval {
+    CREATE TABLE zz(t);
+    INSERT INTO zz VALUES(char(8364,233,20013));
+    PRAGMA encoding;
+  }
+} {UTF-8}
+do_test doltlite_recover_locking_1-2.7 {
+  dbe close
+  sqlite3 dbe rloc1e.db
+  dbe eval {
+    SELECT unicode(t), unicode(substr(t,2,1)), unicode(substr(t,3,1)), length(t) FROM zz;
+    PRAGMA encoding;
+  }
+} {8364 233 20013 3 UTF-8}
+do_test doltlite_recover_locking_1-2.8 {
+  # second handle sees the schema created above; encoding agrees
+  sqlite3 dbe2 rloc1e.db
+  set res [dbe2 eval {SELECT name FROM sqlite_master ORDER BY name; PRAGMA encoding;}]
+  dbe2 close
+  dbe close
+  set res
+} {zz UTF-8}
+
+#-------------------------------------------------------------------
+# 3.* enc2-4.3: ATTACH always compatible (all doltlite dbs are UTF-8).
+#
+do_test doltlite_recover_locking_1-3.1 {
+  sqlite3 dbx rloc1b.db
+  dbx eval {CREATE TABLE abc(a,b,c); INSERT INTO abc VALUES(1,2,3);}
+  dbx close
+  execsql {
+    ATTACH 'rloc1b.db' AS aux;
+    SELECT * FROM aux.abc;
+  }
+} {1 2 3}
+do_test doltlite_recover_locking_1-3.2 {
+  execsql {DETACH aux}
+} {}
+
+#-------------------------------------------------------------------
+# 4.* enc2-5.x: collation selection in the UTF-8-locked db.
+#
+set ::values [list one two three four five]
+set ::test_collate_enc INVALID
+proc test_collate {enc lhs rhs} {
+  set ::test_collate_enc $enc
+  set l [lsearch -exact $::values $lhs]
+  set r [lsearch -exact $::values $rhs]
+  return [expr $l - $r]
+}
+do_test doltlite_recover_locking_1-4.0 {
+  execsql {
+    CREATE TABLE t5(a);
+    INSERT INTO t5 VALUES('one');
+    INSERT INTO t5 VALUES('two');
+    INSERT INTO t5 VALUES('five');
+    INSERT INTO t5 VALUES('three');
+    INSERT INTO t5 VALUES('four');
+  }
+} {}
+do_test doltlite_recover_locking_1-4.1 {
+  add_test_collate $DB 1 1 1
+  set res [execsql {SELECT * FROM t5 ORDER BY 1 COLLATE test_collate}]
+  lappend res $::test_collate_enc
+} {one two three four five UTF-8}
+do_test doltlite_recover_locking_1-4.2 {
+  add_test_collate $DB 0 1 0
+  set res [execsql {SELECT a FROM t5 ORDER BY 1 COLLATE test_collate}]
+  lappend res $::test_collate_enc
+} {one two three four five UTF-16LE}
+do_test doltlite_recover_locking_1-4.3 {
+  add_test_collate $DB 0 0 1
+  set res [execsql {SELECT a AS aa FROM t5 ORDER BY 1 COLLATE test_collate}]
+  lappend res $::test_collate_enc
+} {one two three four five UTF-16BE}
+do_test doltlite_recover_locking_1-4.4 {
+  add_test_collate $DB 0 0 0
+  add_test_collate_needed $DB
+  set res [execsql {SELECT a FROM t5 ORDER BY a COLLATE test_collate}]
+  lappend res $::test_collate_enc
+} {one two three four five UTF-8}
+
+#-------------------------------------------------------------------
+# 5.* enc2-6.x: user-function encoding selection.
+#
+proc test_function {enc arg} { return "$enc $arg" }
+do_test doltlite_recover_locking_1-5.1 {
+  add_test_function $DB 1 1 1
+  execsql {SELECT test_function('sqlite')}
+} {{UTF-8 sqlite}}
+db close
+sqlite3 db rloc1.db
+set DB [sqlite3_connection_pointer db]
+do_test doltlite_recover_locking_1-5.2 {
+  add_test_function $DB 0 1 0
+  execsql {SELECT test_function('sqlite')}
+} {{UTF-16LE sqlite}}
+db close
+sqlite3 db rloc1.db
+set DB [sqlite3_connection_pointer db]
+do_test doltlite_recover_locking_1-5.3 {
+  add_test_function $DB 0 0 1
+  execsql {SELECT test_function('sqlite')}
+} {{UTF-16BE sqlite}}
+
+#-------------------------------------------------------------------
+# 6.* windowC-2.x: blob group_concat window query is crash-free and
+# yields the same UTF-8 bytes whatever encoding was requested.
+#
+do_test doltlite_recover_locking_1-6.1 {
+  execsql {
+    PRAGMA encoding=UTF16le;
+    WITH separator(x) AS (VALUES(',a,'),(',bc,')),
+         value(y) AS (VALUES(1),(x'5585d09013455178cd11ce4a'))
+    SELECT hex(group_concat(y,x) OVER (ORDER BY x ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING))
+    FROM separator, value;
+  }
+} {{} 31 5585D09013455178CD11CE4A 31}
+do_test doltlite_recover_locking_1-6.2 {
+  execsql {
+    PRAGMA encoding=UTF16be;
+    WITH separator(x) AS (VALUES(',a,'),(',bc,')),
+         value(y) AS (VALUES(1),(x'5585d09013455178cd11ce4a'))
+    SELECT hex(group_concat(y,x) OVER (ORDER BY x ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING))
+    FROM separator, value;
+  }
+} {{} 31 5585D09013455178CD11CE4A 31}
+
+#-------------------------------------------------------------------
+# 7.* shared-cache / locking model: doltlite's concurrency contract.
+#
+do_test doltlite_recover_locking_1-7.1 {
+  list [sqlite3_enable_shared_cache 1] [sqlite3_enable_shared_cache]
+} {0 0}
+do_test doltlite_recover_locking_1-7.2 {
+  execsql {CREATE TABLE c1(a PRIMARY KEY, b); INSERT INTO c1 VALUES(1,2);}
+  sqlite3 db2 rloc1.db
+  db2 eval {SELECT * FROM c1}
+} {1 2}
+do_test doltlite_recover_locking_1-7.3 {
+  # db has an open write txn (data + schema writes): db2 reads the snapshot
+  execsql {BEGIN; INSERT INTO c1 VALUES(3,4); CREATE TABLE c2(x);}
+  db2 eval {SELECT * FROM c1 ORDER BY a}
+} {1 2}
+do_test doltlite_recover_locking_1-7.4 {
+  # ... but db2 cannot write while db's write txn is open
+  catchsql {INSERT INTO c1 VALUES(5,6)} db2
+} {1 {database is locked}}
+do_test doltlite_recover_locking_1-7.5 {
+  execsql {COMMIT}
+  list [execsql {SELECT * FROM c1 ORDER BY a}] [db2 eval {SELECT * FROM c1 ORDER BY a}]
+} {{1 2 3 4} {1 2 3 4}}
+do_test doltlite_recover_locking_1-7.6 {
+  # exclusive txn: db2 reads proceed, db2 writes are locked out
+  execsql {BEGIN EXCLUSIVE}
+  list [db2 eval {SELECT * FROM c1 ORDER BY a}] [catchsql {INSERT INTO c1 VALUES(7,8)} db2]
+} {{1 2 3 4} {1 {database is locked}}}
+do_test doltlite_recover_locking_1-7.7 {
+  list [catchsql {BEGIN EXCLUSIVE} db2] [catchsql {BEGIN IMMEDIATE} db2]
+} {{1 {database is locked}} {1 {database is locked}}}
+do_test doltlite_recover_locking_1-7.8 {
+  # plain BEGIN touches nothing: it, reads, and COMMIT all succeed
+  db2 eval {BEGIN; SELECT count(*) FROM c1; COMMIT;}
+} {2}
+do_test doltlite_recover_locking_1-7.9 {
+  execsql {INSERT INTO c1 VALUES(7,8); COMMIT;}
+  db2 eval {SELECT * FROM c1 ORDER BY a}
+} {1 2 3 4 7 8}
+do_test doltlite_recover_locking_1-7.10 {
+  # BEGIN EXCLUSIVE while db2 holds an active read statement: succeeds,
+  # the write commits, and db2's statement keeps working on its snapshot.
+  set ::S1 [sqlite3_prepare db2 "SELECT a FROM c1 ORDER BY a" -1 TAIL]
+  list [sqlite3_step $::S1] [catchsql {BEGIN EXCLUSIVE}] \
+       [catchsql {INSERT INTO c1 VALUES(9,10)}] [catchsql {COMMIT}]
+} {SQLITE_ROW {0 {}} {0 {}} {0 {}}}
+do_test doltlite_recover_locking_1-7.11 {
+  set res {}
+  while {[sqlite3_step $::S1] eq "SQLITE_ROW"} {
+    lappend res [sqlite3_column_text $::S1 0]
+  }
+  lappend res [sqlite3_finalize $::S1]
+} {3 7 SQLITE_OK}
+do_test doltlite_recover_locking_1-7.12 {
+  # after releasing the read statement both connections are consistent
+  list [db2 eval {SELECT count(*) FROM c1}] [execsql {SELECT count(*) FROM c1}] \
+       [execsql {PRAGMA integrity_check}] [db2 eval {PRAGMA integrity_check}]
+} {4 4 ok ok}
+do_test doltlite_recover_locking_1-7.13 {
+  # BEGIN EXCLUSIVE while db2 is inside an open read txn: succeeds
+  db2 eval {BEGIN; SELECT count(*) FROM c1;}
+  set res [list [catchsql {BEGIN EXCLUSIVE}] [catchsql {COMMIT}]]
+  db2 eval {COMMIT}
+  set res
+} {{0 {}} {0 {}}}
+do_test doltlite_recover_locking_1-7.14 {
+  # db2 write while db holds a read-only txn: succeeds (writers don't
+  # block on readers); db's snapshot is stable until COMMIT
+  execsql {BEGIN; SELECT count(*) FROM c1;}
+  set w [catchsql {INSERT INTO c1 VALUES(11,12)} db2]
+  set during [execsql {SELECT count(*) FROM c1}]
+  execsql {COMMIT}
+  list $w $during [execsql {SELECT count(*) FROM c1}]
+} {{0 {}} 4 5}
+do_test doltlite_recover_locking_1-7.15 {
+  # both connections in BEGIN, reader active: writer's INSERT succeeds
+  db2 eval {BEGIN; SELECT count(*) FROM c1;}
+  execsql {BEGIN}
+  set w [catchsql {INSERT INTO c1 VALUES(13,14)}]
+  execsql {COMMIT}
+  set in2 [db2 eval {SELECT count(*) FROM c1}]
+  db2 eval {COMMIT}
+  list $w $in2 [db2 eval {SELECT count(*) FROM c1}]
+} {{0 {}} 5 6}
+do_test doltlite_recover_locking_1-7.16 {
+  # third connection: BEGIN;ROLLBACK then normal reads
+  sqlite3 db3 rloc1.db
+  set res [db3 eval {BEGIN; ROLLBACK; SELECT count(*) FROM c1;}]
+  db3 close
+  set res
+} {6}
+do_test doltlite_recover_locking_1-7.17 {
+  # insert from db2 mid-scan: write proceeds, scan keeps its snapshot
+  set got {}
+  db eval {SELECT a FROM c1 ORDER BY a} {
+    lappend got $a
+    if {$a==1} {
+      lappend got [catch {db2 eval {INSERT INTO c1 VALUES(0,0)}}]
+    }
+  }
+  set got
+} {1 0 3 7 9 11 13}
+do_test doltlite_recover_locking_1-7.18 {
+  # DELETE of every row from db2 mid-scan: scan completes its snapshot
+  set n 0
+  set w {}
+  db eval {SELECT a FROM c1 ORDER BY a} {
+    incr n
+    if {$n==2} { set w [catch {db2 eval {DELETE FROM c1}}] }
+  }
+  list $n $w [execsql {SELECT count(*) FROM c1}]
+} {7 0 0}
+do_test doltlite_recover_locking_1-7.19 {
+  # DROP TABLE from the same connection mid-scan is refused
+  execsql {INSERT INTO c1 VALUES(1,2),(2,3),(3,4)}
+  set got {}
+  db eval {SELECT a FROM c1 ORDER BY a} {
+    if {$a==1} {
+      lappend got [catch {db eval {DROP TABLE c1}} msg] $msg
+    }
+  }
+  set got
+} {1 {database table is locked}}
+do_test doltlite_recover_locking_1-7.20 {
+  # read_uncommitted is accepted; reads still see only committed rows
+  db2 eval {PRAGMA read_uncommitted=1}
+  execsql {BEGIN; INSERT INTO c1 VALUES(4,5);}
+  set res [db2 eval {SELECT count(*) FROM c1}]
+  execsql {COMMIT}
+  list $res [db2 eval {SELECT count(*) FROM c1}]
+} {3 4}
+do_test doltlite_recover_locking_1-7.21 {
+  # write txn on an ATTACHed db held by another connection blocks
+  # BEGIN EXCLUSIVE; everything recovers after that txn commits
+  sqlite3 db4 rloc1b.db
+  execsql {ATTACH 'rloc1b.db' AS aux}
+  db4 eval {BEGIN IMMEDIATE; INSERT INTO abc VALUES(4,5,6);}
+  set r1 [catchsql {BEGIN EXCLUSIVE}]
+  db4 eval {COMMIT}
+  db4 close
+  set r2 [execsql {SELECT count(*) FROM aux.abc}]
+  set r3 [catchsql {INSERT INTO aux.abc VALUES(7,8,9)}]
+  list $r1 $r2 $r3 [execsql {SELECT count(*) FROM aux.abc}]
+} {{1 {database is locked}} 2 {0 {}} 3}
+do_test doltlite_recover_locking_1-7.22 {
+  execsql {DETACH aux}
+  db2 close
+} {}
+
+#-------------------------------------------------------------------
+# 8.* exclusive: locking_mode=exclusive holds no locks in doltlite.
+#
+do_test doltlite_recover_locking_1-8.1 {
+  execsql {
+    DELETE FROM c1;
+    INSERT INTO c1 VALUES(1,2),(4,5),(7,8);
+    PRAGMA locking_mode=exclusive;
+  }
+} {exclusive}
+do_test doltlite_recover_locking_1-8.2 {
+  # db (exclusive mode) has read the db; db2 can still read AND write
+  execsql {SELECT count(*) FROM c1}
+  sqlite3 db2 rloc1.db
+  db2 eval {INSERT INTO c1 VALUES(10,11); SELECT count(*) FROM c1;}
+} {4}
+do_test doltlite_recover_locking_1-8.3 {
+  # db sees db2's commit immediately (no lock, no stale cache)
+  execsql {SELECT count(*) FROM c1}
+} {4}
+do_test doltlite_recover_locking_1-8.4 {
+  # db2 rollback restores its snapshot
+  db2 eval {BEGIN; INSERT INTO c1 VALUES(13,14); ROLLBACK; SELECT count(*) FROM c1;}
+} {4}
+do_test doltlite_recover_locking_1-8.5 {
+  # db writes while in exclusive mode; db2 reads proceed
+  execsql {INSERT INTO c1 VALUES(16,17)}
+  db2 eval {SELECT count(*) FROM c1}
+} {5}
+do_test doltlite_recover_locking_1-8.6 {
+  execsql {PRAGMA locking_mode=normal}
+  list [execsql {SELECT count(*) FROM c1}] [db2 eval {SELECT count(*) FROM c1}]
+} {5 5}
+do_test doltlite_recover_locking_1-8.7 {
+  # txn boundaries durable across reopen (journal truncation analog)
+  execsql {
+    PRAGMA locking_mode=exclusive;
+    BEGIN;
+    DELETE FROM c1;
+    COMMIT;
+    INSERT INTO c1 VALUES('A','B');
+  }
+  db2 close
+  db close
+  sqlite3 db rloc1.db
+  set DB [sqlite3_connection_pointer db]
+  execsql {SELECT * FROM c1}
+} {A B}
+do_test doltlite_recover_locking_1-8.8 {
+  execsql {
+    BEGIN;
+    UPDATE c1 SET a=1, b=2;
+    ROLLBACK;
+    SELECT * FROM c1;
+  }
+} {A B}
+do_test doltlite_recover_locking_1-8.9 {
+  # multi-statement txn over UNIQUE columns: statement-journal analog
+  execsql {
+    CREATE TABLE abc2(a UNIQUE, b UNIQUE, c UNIQUE);
+    PRAGMA locking_mode=exclusive;
+    BEGIN;
+    INSERT INTO abc2 VALUES(1,2,3);
+    INSERT INTO abc2 SELECT a+1, b+1, c+1 FROM abc2;
+  }
+  set conflict [catchsql {INSERT INTO abc2 SELECT a, b, c FROM abc2}]
+  execsql {COMMIT}
+  list $conflict [execsql {SELECT * FROM abc2 ORDER BY a}] \
+       [execsql {PRAGMA locking_mode=normal}]
+} {{1 {UNIQUE constraint failed: abc2.c}} {1 2 3 2 3 4} normal}
+do_test doltlite_recover_locking_1-8.10 {
+  # uncommitted rows invisible to a newly opened connection
+  execsql {BEGIN; INSERT INTO abc2 VALUES(10,11,12);}
+  sqlite3 db2 rloc1.db
+  set res [db2 eval {SELECT count(*) FROM abc2}]
+  execsql {ROLLBACK}
+  list $res [db2 eval {SELECT count(*) FROM abc2}] [execsql {SELECT count(*) FROM abc2}]
+} {2 2 2}
+do_test doltlite_recover_locking_1-8.11 {
+  db2 close
+  execsql {
+    PRAGMA locking_mode = EXCLUSIVE;
+    PRAGMA journal_mode = WAL;
+    PRAGMA locking_mode = NORMAL;
+    PRAGMA user_version;
+  }
+} {exclusive wal normal 0}
+do_test doltlite_recover_locking_1-8.12 {
+  catchsql {PRAGMA journal_mode = DELETE}
+} {1 {journal_mode is not configurable on doltlite-format databases}}
+do_test doltlite_recover_locking_1-8.13 {
+  # the rejection leaves the db fully usable and is stable across reopen
+  db close
+  sqlite3 db rloc1.db
+  set DB [sqlite3_connection_pointer db]
+  list [catchsql {PRAGMA journal_mode = DELETE}] \
+       [execsql {INSERT INTO abc2 VALUES(7,8,9); SELECT count(*) FROM abc2;}] \
+       [execsql {PRAGMA integrity_check}]
+} {{1 {journal_mode is not configurable on doltlite-format databases}} 3 ok}
+
+#-------------------------------------------------------------------
+# 9.* exclusive2: no page cache to go stale; content hash is the
+# change-counter analog.
+#
+do_test doltlite_recover_locking_1-9.1 {
+  execsql {CREATE TABLE x1(a PRIMARY KEY, b)}
+  execsql {INSERT INTO x1 VALUES(1,'one'),(2,'two')}
+  sqlite3 db2 rloc1.db
+  set sig1 [execsql {SELECT count(*), group_concat(b) FROM (SELECT b FROM x1 ORDER BY a)}]
+  db2 eval {UPDATE x1 SET b='TWO' WHERE a=2}
+  set sig2 [execsql {SELECT count(*), group_concat(b) FROM (SELECT b FROM x1 ORDER BY a)}]
+  list $sig1 $sig2
+} {{2 one,two} {2 one,TWO}}
+do_test doltlite_recover_locking_1-9.2 {
+  # same freshness under locking_mode=exclusive
+  execsql {PRAGMA locking_mode=exclusive; SELECT count(*) FROM x1;}
+  db2 eval {UPDATE x1 SET b='II' WHERE a=2}
+  set res [execsql {SELECT b FROM x1 WHERE a=2}]
+  execsql {PRAGMA locking_mode=normal}
+  list $res [execsql {PRAGMA integrity_check}]
+} {II ok}
+do_test doltlite_recover_locking_1-9.3 {
+  set h0 [execsql {SELECT dolt_hashof_table('x1')}]
+  execsql {INSERT INTO x1 VALUES(3,'three')}
+  set h1 [execsql {SELECT dolt_hashof_table('x1')}]
+  execsql {INSERT INTO x1 VALUES(4,'four')}
+  set h2 [execsql {SELECT dolt_hashof_table('x1')}]
+  execsql {PRAGMA locking_mode=exclusive}
+  execsql {INSERT INTO x1 VALUES(5,'five')}
+  set h3 [execsql {SELECT dolt_hashof_table('x1')}]
+  execsql {SELECT count(*) FROM x1}
+  set h4 [execsql {SELECT dolt_hashof_table('x1')}]
+  execsql {PRAGMA locking_mode=normal}
+  set h5 [execsql {SELECT dolt_hashof_table('x1')}]
+  execsql {INSERT INTO x1 VALUES(6,'six')}
+  set h6 [execsql {SELECT dolt_hashof_table('x1')}]
+  list [expr {$h0 ne $h1}] [expr {$h1 ne $h2}] [expr {$h2 ne $h3}] \
+       [expr {$h3 eq $h4}] [expr {$h4 eq $h5}] [expr {$h5 ne $h6}]
+} {1 1 1 1 1 1}
+do_test doltlite_recover_locking_1-9.4 {
+  db2 close
+} {}
+
+#-------------------------------------------------------------------
+# 10.* capi3: deferred bogus-path open, catalog robustness,
+# lock_status, stmt lifecycle after rollback-during-read.
+#
+do_test doltlite_recover_locking_1-10.1 {
+  set dbh [sqlite3_open /bogus/path/rloc1.db {}]
+  list [sqlite3_errcode $dbh] [sqlite3_errmsg $dbh]
+} {SQLITE_OK {not an error}}
+do_test doltlite_recover_locking_1-10.2 {
+  sqlite3_close $dbh
+  sqlite3 dbb /bogus/path/rloc1.db
+  set rc [catch {dbb eval {CREATE TABLE z(a)}} msg]
+  dbb close
+  list $rc $msg
+} {1 {unable to open database file}}
+do_test doltlite_recover_locking_1-10.3 {
+  # writable_schema garbage row cannot corrupt the prolly catalog
+  sqlite3_db_config db DEFENSIVE 0
+  set r1 [catchsql {
+    PRAGMA writable_schema=ON;
+    INSERT INTO sqlite_master VALUES(NULL,NULL,NULL,NULL,NULL);
+  }]
+  catchsql {PRAGMA writable_schema=OFF}
+  db close
+  set r2 [catch {sqlite3 db rloc1.db}]
+  set DB [sqlite3_connection_pointer db]
+  list $r1 $r2 [execsql {SELECT count(*) FROM x1}] \
+       [execsql {CREATE TABLE post(a); INSERT INTO post VALUES(1); SELECT * FROM post;}] \
+       [execsql {PRAGMA integrity_check}]
+} {{0 {}} 0 6 1 ok}
+do_test doltlite_recover_locking_1-10.4 {
+  # COMMIT during an active read succeeds; lock_status shows main unlocked
+  execsql {
+    CREATE TABLE t2(a);
+    INSERT INTO t2 VALUES(1);
+    INSERT INTO t2 VALUES(2);
+    BEGIN;
+    INSERT INTO t2 VALUES(3);
+  }
+  set ::STMT [sqlite3_prepare $DB "SELECT a FROM t2 ORDER BY a" -1 TAIL]
+  sqlite3_step $::STMT
+  catchsql {ROLLBACK}
+  lrange [execsql {PRAGMA lock_status}] 0 1
+} {main unlocked}
+do_test doltlite_recover_locking_1-10.5 {
+  # the read cursor survives the writeOnly ROLLBACK and finishes its scan
+  list [sqlite3_step $::STMT] [sqlite3_step $::STMT] [sqlite3_step $::STMT]
+} {SQLITE_ROW SQLITE_ROW SQLITE_DONE}
+do_test doltlite_recover_locking_1-10.6 {
+  # step after DONE: doltlite reports SQLITE_ERROR (no silent auto-reset)
+  sqlite3_step $::STMT
+} {SQLITE_ERROR}
+do_test doltlite_recover_locking_1-10.7 {
+  sqlite3_finalize $::STMT
+} {SQLITE_SCHEMA}
+do_test doltlite_recover_locking_1-10.8 {
+  # connection unaffected; committed data correct (the 3 was rolled back)
+  execsql {SELECT a FROM t2 ORDER BY a}
+} {1 2}
+
+#-------------------------------------------------------------------
+# 11.* select2-3.3: DROP INDEX forces a full scan; results identical.
+#
+do_test doltlite_recover_locking_1-11.1 {
+  execsql {
+    CREATE TABLE tbl2(f1 int PRIMARY KEY, f2 int);
+    INSERT INTO tbl2 VALUES(1,10),(2,20),(3,30);
+    CREATE INDEX idx1 ON tbl2(f2);
+  }
+  set eqp [execsql {EXPLAIN QUERY PLAN SELECT f1 FROM tbl2 WHERE f2=20}]
+  list [regexp {SEARCH tbl2 USING COVERING INDEX idx1} $eqp] \
+       [execsql {SELECT f1 FROM tbl2 WHERE f2=20}]
+} {1 2}
+do_test doltlite_recover_locking_1-11.2 {
+  execsql {DROP INDEX idx1}
+  set eqp [execsql {EXPLAIN QUERY PLAN SELECT f1 FROM tbl2 WHERE f2=20}]
+  list [regexp {SCAN tbl2} $eqp] [execsql {SELECT f1 FROM tbl2 WHERE f2=20}]
+} {1 2}
+
+db close
+forcedelete rloc1.db rloc1b.db rloc1e.db
+sqlite3 db test.db
+finish_test

--- a/test/doltlite_recover_locking_2.test
+++ b/test/doltlite_recover_locking_2.test
@@ -1,0 +1,680 @@
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+# Recovers the intent of gated locking-model divergences (shard locking_2).
+# Stock asserted rollback-journal/shared-cache lock states and "database is
+# locked" errors. doltlite's chunk-store contract instead: concurrent
+# connections read AND write; readers hold statement/transaction snapshots;
+# PRAGMA lock_status always reads unlocked; pager metrics read 0.
+#
+# covers: attach2 attach2-2.4 — encoding mismatch unfirable: PRAGMA encoding pinned UTF-8, utf16 set is a no-op, ATTACH always succeeds and text round-trips (1.1-1.3)
+# covers: attach2 attach2-4.2.1 — lock_status during read txn reads unlocked (2.7)
+# covers: attach2 attach2-4.3.1 — lock_status while 2nd conn reads stays unlocked (2.2-2.5, 2.7)
+# covers: attach2 attach2-4.4 — 2nd-conn write during 1st conn read txn succeeds (2.6)
+# covers: attach2 attach2-4.4.1 — lock_status after concurrent write reads unlocked (2.7)
+# covers: attach2 attach2-4.5.1 — lock_status with 2nd-conn open write txn on attached db reads unlocked (2.10)
+# covers: attach2 attach2-4.5.2 — same, writer side reads unlocked not reserved (2.10)
+# covers: attach2 attach2-4.6.1.1 — read of attached db another conn is writing allowed; lock_status unlocked (2.9, 2.10)
+# covers: attach2 attach2-4.6.1.2 — writer's lock_status stays unlocked during reads (2.10)
+# covers: attach2 attach2-4.6.2.1 — write against attached db another conn is writing errors "database is locked" (chunk-store write lock), lock_status still unlocked (2.10, 2.11)
+# covers: attach2 attach2-4.6.2.2 — same, writer side state unchanged (2.10, 2.11)
+# covers: attach2 attach2-4.7.1 — lock states unchanged while 2nd conn write txn open (2.10, 2.17)
+# covers: attach2 attach2-4.7.2 — same, 2nd conn side (2.17)
+# covers: attach2 attach2-4.8 — 2nd conn reads main db inside its txn: own writes + committed rows visible (2.13)
+# covers: attach2 attach2-4.8.1 — lock_status unlocked while write txn open (2.10) and after commits (2.17)
+# covers: attach2 attach2-4.8.2 — same, 2nd conn (2.17)
+# covers: attach2 attach2-4.9.1 — 1st conn write while 2nd conn write txn open errors "database is locked"; lock_status never surfaces it (2.14)
+# covers: attach2 attach2-4.9.2 — same, 2nd conn state (2.17)
+# covers: attach2 attach2-4.10 — 2nd conn COMMIT while 1st conn read txn open succeeds, not "database is locked" (2.15)
+# covers: attach2 attach2-4.10.1 — lock_status after that commit unlocked (2.17)
+# covers: attach2 attach2-4.10.2 — no pending state surfaced (2.17)
+# covers: attach2 attach2-4.11.2 — after 1st conn commit no residual reserved/pending state (2.16, 2.17)
+# covers: attach2 attach2-4.12 — both commits land; final lock_status unlocked on both conns (2.16, 2.17)
+# covers: attach2 attach2-4.15 — after the conflict both conns write again and converge on identical contents (2.18-2.22)
+# covers: savepoint savepoint-3.2 — savepoint write holds no pager lock: lock_status unlocked after INSERT (3.1)
+# covers: savepoint savepoint-3.3 — ROLLBACK TO keeps txn open, lock_status unlocked, write undone (3.2)
+# covers: savepoint savepoint-3.4 — re-insert after rollback works, lock_status unlocked (3.3); RELEASE ends txn (3.4, 3.5)
+# covers: savepoint savepoint-5.4.3 — RELEASE succeeds while 2nd conn holds read txn (4.2, 4.3)
+# covers: savepoint savepoint-5.4.4 — after release: reader snapshot intact, then sees committed rows (4.4-4.6)
+# covers: savepoint savepoint-14.1.2 — RELEASE while reader open succeeds instead of "database is locked" (5.2)
+# covers: savepoint savepoint-14.1.3 — savepoint really gone after release: ROLLBACK TO errors (5.3)
+# covers: savepoint savepoint-14.1.4 — reader commits and sees released rows (5.4)
+# covers: savepoint savepoint-14.1.5 — second round: savepoint+insert with reader open works (5.5)
+# covers: savepoint savepoint-14.1.6 — ROLLBACK TO + more inserts + RELEASE all complete (5.5)
+# covers: savepoint savepoint-14.2.2 — same contract, second multiclient permutation collapses to same scenario (5.2-5.5)
+# covers: savepoint savepoint-14.2.3 — see 5.3
+# covers: savepoint savepoint-14.2.4 — see 5.4-5.5
+# covers: savepoint savepoint-14.2.5 — see 5.5
+# covers: savepoint savepoint-14.2.6 — index build on 2nd conn + integrity_check ok after savepoint traffic (5.6)
+# covers: savepoint savepoint-15.1.2 — COMMIT under locking_mode=EXCLUSIVE with reader open succeeds (6.2, 6.3)
+# covers: savepoint savepoint-15.1.3 — rollback-free recovery: reader snapshot then convergence (6.4, 6.5)
+# covers: savepoint savepoint-15.2.2 — same contract, second permutation (6.2-6.5)
+# covers: savepoint savepoint-15.2.3 — locking_mode back to NORMAL, writes work, integrity ok (6.6, 6.7)
+# covers: savepoint savepoint-17.1 — schema-cache rollback scenario verbatim, no upstream lock-state pollution (7.1, 7.2)
+# SUSPECTED BUG (separate, not asserted here): after another connection
+# commits a data write (INSERT, or CREATE INDEX on a populated table), a txn
+# doing CREATE TABLE; INSERT; SAVEPOINT; ROLLBACK TO loses the pre-savepoint
+# row (SELECT returns empty; should return it). Repro:
+#   conn2: CREATE TABLE w(x); INSERT INTO w VALUES(1);
+#   conn1: BEGIN; CREATE TABLE tc(a,b); INSERT INTO tc VALUES(1,2);
+#          SAVEPOINT one; INSERT INTO tc VALUES(3,4); ROLLBACK TO one;
+#          SELECT * FROM tc;  -- returns {} instead of {1 2}
+# Pure cross-connection CREATE TABLE (no row writes) does not trigger it.
+# Section 7 therefore runs before any second-connection writes.
+# covers: pragma2 pragma2-1.3 — DROP works; freelist_count reads 0 (no freelist pages in prolly) (8.1, 8.2)
+# covers: pragma2 pragma2-1.4 — main.freelist_count reads 0 (8.3)
+# covers: pragma2 pragma2-2.5 — DELETE on attached db works; aux freelist_count reads 0 (8.4)
+# covers: pragma2 pragma2-3.1 — freelist_count on all schemas reads 0 (8.5)
+# covers: pragma2 pragma2-3.2 — writing freelist_count is a no-op (8.6)
+# covers: pragma2 pragma2-3.3 — writing aux freelist_count is a no-op (8.7)
+# covers: pragma2 pragma2-4.1 — cache_size echoes set value; cache_spill reads 0 (8.8)
+# covers: pragma2 pragma2-4.4 — UPDATE in txn takes no pager lock (lock_status unlocked, vs stock exclusive); rows correct after rollback (8.9)
+# covers: pragma2 pragma2-4.5.1 — cache_spill=OFF accepted, reads 0; data unaffected (8.10)
+# covers: pragma2 pragma2-4.5.2 — cache_spill=100000 accepted, reads 0 (8.11)
+# covers: pragma2 pragma2-4.5.3 — cache_spill=25 accepted, reads 0, no exclusive lock possible (8.12)
+# covers: pragma2 pragma2-4.5.4 — cache_spill(-25) accepted, reads 0 (8.13)
+# covers: pragma2 pragma2-4.6 — txn UPDATE on attached db: lock_status unlocked on all schemas, commit works (8.15)
+# covers: pragma2 pragma2-4.8 — cache_spill=ON accepted, reads 0; no exclusive lock state (8.14)
+# covers: pragma2 pragma2-5.1 — fresh db: page_size+cache_size+cache_spill=YES accepted, cache_spill reads 0 (8.16)
+# covers: pragma2 pragma2-5.3 — cache_spill(-51) accepted, reads 0 (8.16)
+# covers: memdb2 memdb2-1.1.1 — two-connection shared-db scenario recast on doltlite's shared surface (a db file); memdb VFS statements are unsupported (9.1)
+# covers: memdb2 memdb2-1.1.2 — reader opens txn, sees initial rows (9.1)
+# covers: memdb2 memdb2-1.1.3 — writer opens txn + insert while reader open (9.2)
+# covers: memdb2 memdb2-1.1.4 — writer COMMIT succeeds instead of "database is locked" (9.3)
+# covers: memdb2 memdb2-1.1.5 — reader keeps snapshot until END (9.4)
+# covers: memdb2 memdb2-1.1.6 — no deferred-commit dance needed; commit already landed (9.3)
+# covers: memdb2 memdb2-1.1.7 — reader sees all rows after closing its txn (9.5)
+# covers: memdb2 memdb2-1.2.1 — same scenario; the tn=2 permutation only varied the memdb URI spelling (9.1)
+# covers: memdb2 memdb2-1.2.2 — see 9.1
+# covers: memdb2 memdb2-1.2.3 — see 9.2
+# covers: memdb2 memdb2-1.2.4 — see 9.3
+# covers: memdb2 memdb2-1.2.5 — see 9.4
+# covers: memdb2 memdb2-1.2.6 — see 9.3
+# covers: memdb2 memdb2-1.2.7 — see 9.5
+# covers: nolock nolock-1.0 — xLock counts inapplicable; contract: default open writes+reads correctly (10.1, 10.2)
+# covers: nolock nolock-1.1 — nolock=0 open behaves identically (10.3)
+# covers: nolock nolock-1.2 — nolock=1 open: create/insert/select work (10.1)
+# covers: nolock nolock-1.3 — readonly open reads correctly (10.3)
+# covers: nolock nolock-2.2 — second connection reads same data (10.4)
+# covers: nolock nolock-2.12 — immutable=0-equivalent plain reopen reads (10.2, 10.4)
+# covers: nolock nolock-2.22 — immutable=1 open reads correctly (10.5)
+# covers: nolock nolock-2.32 — immutable=1 + readonly reads correctly (10.5)
+# covers: nolock nolock-3.2 — IOCAP_IMMUTABLE class: immutable read path returns correct data (10.5)
+# covers: nolock nolock-3.12 — immutable + readonly read path (10.5)
+# covers: nolock nolock-4.1 — journal_mode=WAL request under nolock: db usable, rows durable (10.6)
+# covers: nolock nolock-4.3 — WAL-requested db reopened with nolock=1 reads fine (doltlite has no WAL-shm gate) (10.6)
+# covers: shared8 shared8-0.0 — shared-cache premise replaced: multiple connections to one db share committed schema (11.1)
+# covers: shared8 shared8-1.3 — 2nd conn sees schema (table+view) created by 1st (11.1)
+# covers: shared8 shared8-1.4 — closing 1st conn does not invalidate 2nd conn's schema (11.2)
+# covers: shared8 shared8-1.5 — 3rd conn opens and reads view (11.3)
+# covers: shared8 shared8-1.6 — 2nd conn still works alongside 3rd (11.4)
+# covers: shared8 shared8-1.7 — closing 2nd conn leaves 3rd working (11.5)
+# covers: shared9 shared9-2.1 — custom-collation index rejected with doltlite's exact error; column collation accepted (12.1)
+# covers: shared9 shared9-3.4 — COMMIT with 2nd-conn read txn open succeeds instead of "database is locked" (12.5)
+# covers: shared9 shared9-3.5 — no busy-handler cross-fire possible: commit completes, reader snapshot intact (12.6)
+# covers: shared9 shared9-3.6 — after reader closes txn both conns converge (12.7); no dangling collation use-after-close (12.2)
+# covers: tkt4018 tkt4018-1.3 — 2nd-conn write while 1st holds read txn succeeds; 1st conn snapshot excludes it (13.1, 13.2)
+# covers: tkt4018 tkt4018-2.2 — BEGIN; SELECT ORDER BY sees all committed rows; readonly conn write rejected (13.3-13.5)
+# covers: shared shared-1.7.2 — open scan unaffected by concurrent delete of sibling table; full contents returned (14.1-14.3)
+# covers: capi2 capi2-6.5 — 2nd-conn INSERT into table mid-scan succeeds; running statement keeps its snapshot (14.1, 14.3)
+#
+# not-covered: (none)
+
+db close
+foreach f {rlk2.db rlk2b.db rlk2p.db rlk2q.db rlk2n.db rlk2w.db rlk2s.db rlk2t.db} {
+  forcedelete $f
+  forcedelete .${f}-lock
+}
+sqlite3 db rlk2.db
+
+#-------------------------------------------------------------------------
+# 1.* attach2-2.4: UTF-8 only, ATTACH encoding mismatch cannot exist.
+#
+do_execsql_test doltlite_recover_locking_2-1.1 {
+  PRAGMA encoding;
+} {UTF-8}
+do_execsql_test doltlite_recover_locking_2-1.2 {
+  PRAGMA encoding='UTF-16le';
+  PRAGMA encoding;
+} {UTF-8}
+do_test doltlite_recover_locking_2-1.3 {
+  sqlite3 dbe rlk2b.db
+  dbe eval {
+    PRAGMA encoding='utf16';
+    CREATE TABLE tt(x);
+    INSERT INTO tt VALUES('text2');
+    CREATE TABLE t1f(a,b);
+  }
+  dbe close
+  list [catchsql {ATTACH 'rlk2b.db' AS file2}] [catchsql {SELECT x FROM file2.tt}]
+} {{0 {}} {0 text2}}
+
+#-------------------------------------------------------------------------
+# 7.* savepoint-17.1: schema rollback leaves a clean schema cache. Runs
+# before any second-connection writes (see SUSPECTED BUG above).
+#
+do_execsql_test doltlite_recover_locking_2-7.1 {
+  BEGIN;
+    CREATE TABLE t6(a, b);
+    INSERT INTO t6 VALUES(1, 2);
+    SAVEPOINT one;
+      INSERT INTO t6 VALUES(3, 4);
+    ROLLBACK TO one;
+    SELECT * FROM t6;
+  ROLLBACK;
+} {1 2}
+do_execsql_test doltlite_recover_locking_2-7.2 {
+  CREATE TABLE t6(a, b);
+  SELECT count(*) FROM t6;
+} {0}
+
+#-------------------------------------------------------------------------
+# 2.* attach2-4: two connections + attached db; everything stays unlocked
+# and concurrent writes succeed.
+#
+do_execsql_test doltlite_recover_locking_2-2.1 {
+  CREATE TABLE t1(a,b);
+  SELECT count(*) FROM t1;
+} {0}
+do_test doltlite_recover_locking_2-2.2 {
+  execsql {PRAGMA lock_status}
+} {main unlocked temp closed file2 unlocked}
+do_test doltlite_recover_locking_2-2.3 {
+  sqlite3 db2 rlk2.db
+  db2 eval {ATTACH 'rlk2b.db' AS file2}
+  execsql {PRAGMA lock_status} db2
+} {main unlocked temp closed file2 unlocked}
+do_test doltlite_recover_locking_2-2.4 {
+  execsql {BEGIN; SELECT * FROM t1;}
+} {}
+do_test doltlite_recover_locking_2-2.5 {
+  execsql {SELECT * FROM t1} db2
+} {}
+do_test doltlite_recover_locking_2-2.6 {
+  catchsql {INSERT INTO t1 VALUES(1,2)} db2
+} {0 {}}
+do_test doltlite_recover_locking_2-2.7 {
+  execsql {PRAGMA lock_status}
+} {main unlocked temp closed file2 unlocked}
+do_test doltlite_recover_locking_2-2.8 {
+  execsql {BEGIN; INSERT INTO file2.t1f VALUES(1,2);} db2
+} {}
+do_test doltlite_recover_locking_2-2.9 {
+  execsql {SELECT count(*) FROM file2.t1f}
+} {0}
+do_test doltlite_recover_locking_2-2.10 {
+  list [execsql {PRAGMA lock_status}] [execsql {PRAGMA lock_status} db2]
+} {{main unlocked temp closed file2 unlocked} {main unlocked temp closed file2 unlocked}}
+do_test doltlite_recover_locking_2-2.11 {
+  catchsql {UPDATE file2.t1f SET a=0}
+} {1 {database is locked}}
+do_test doltlite_recover_locking_2-2.12 {
+  catchsql {INSERT INTO t1 VALUES(3,4)} db2
+} {0 {}}
+do_test doltlite_recover_locking_2-2.13 {
+  execsql {SELECT a,b FROM t1 ORDER BY a} db2
+} {1 2 3 4}
+do_test doltlite_recover_locking_2-2.14 {
+  catchsql {INSERT INTO t1 VALUES(5,6)}
+} {1 {database is locked}}
+do_test doltlite_recover_locking_2-2.15 {
+  catchsql {COMMIT} db2
+} {0 {}}
+do_test doltlite_recover_locking_2-2.16 {
+  catchsql {COMMIT}
+} {0 {}}
+do_test doltlite_recover_locking_2-2.17 {
+  list [execsql {PRAGMA lock_status}] [execsql {PRAGMA lock_status} db2]
+} {{main unlocked temp closed file2 unlocked} {main unlocked temp closed file2 unlocked}}
+do_test doltlite_recover_locking_2-2.18 {
+  catchsql {INSERT INTO t1 VALUES(5,6)}
+} {0 {}}
+do_test doltlite_recover_locking_2-2.19 {
+  execsql {SELECT a,b FROM t1 ORDER BY a}
+} {1 2 3 4 5 6}
+do_test doltlite_recover_locking_2-2.20 {
+  execsql {SELECT a,b FROM t1 ORDER BY a} db2
+} {1 2 3 4 5 6}
+do_test doltlite_recover_locking_2-2.21 {
+  execsql {SELECT a,b FROM file2.t1f ORDER BY a} db2
+} {1 2}
+do_test doltlite_recover_locking_2-2.22 {
+  execsql {SELECT a,b FROM file2.t1f ORDER BY a}
+} {1 2}
+
+#-------------------------------------------------------------------------
+# 3.* savepoint-3: savepoint writes hold no pager locks.
+#
+do_execsql_test doltlite_recover_locking_2-3.1 {
+  CREATE TABLE ts(a,b,c);
+  SAVEPOINT "transaction";
+  INSERT INTO ts VALUES(1,2,3);
+  PRAGMA lock_status;
+} {main unlocked temp closed file2 unlocked}
+do_execsql_test doltlite_recover_locking_2-3.2 {
+  ROLLBACK TO "transaction";
+  SELECT count(*) FROM ts;
+  PRAGMA lock_status;
+} {0 main unlocked temp closed file2 unlocked}
+do_execsql_test doltlite_recover_locking_2-3.3 {
+  INSERT INTO ts VALUES(4,5,6);
+  PRAGMA lock_status;
+} {main unlocked temp closed file2 unlocked}
+do_execsql_test doltlite_recover_locking_2-3.4 {
+  RELEASE "transaction";
+  SELECT * FROM ts;
+  PRAGMA lock_status;
+} {4 5 6 main unlocked temp closed file2 unlocked}
+do_catchsql_test doltlite_recover_locking_2-3.5 {
+  COMMIT
+} {1 {cannot commit - no transaction is active}}
+
+#-------------------------------------------------------------------------
+# 4.* savepoint-5.4: RELEASE not blocked by a second connection's read txn.
+#
+do_execsql_test doltlite_recover_locking_2-4.1 {
+  CREATE TABLE blobs(x);
+  INSERT INTO blobs VALUES('blob one');
+} {}
+do_test doltlite_recover_locking_2-4.2 {
+  execsql {SAVEPOINT main; INSERT INTO blobs VALUES('another blob');}
+  execsql {BEGIN; SELECT count(*) FROM blobs;} db2
+} {1}
+do_test doltlite_recover_locking_2-4.3 {
+  catchsql {RELEASE main}
+} {0 {}}
+do_test doltlite_recover_locking_2-4.4 {
+  execsql {SELECT count(*) FROM blobs} db2
+} {1}
+do_test doltlite_recover_locking_2-4.5 {
+  execsql {COMMIT} db2
+  execsql {SELECT count(*) FROM blobs} db2
+} {2}
+do_test doltlite_recover_locking_2-4.6 {
+  execsql {SELECT count(*) FROM blobs}
+} {2}
+
+#-------------------------------------------------------------------------
+# 5.* savepoint-14: savepoint release/rollback with a concurrent reader.
+#
+do_test doltlite_recover_locking_2-5.1 {
+  execsql {
+    CREATE TABLE foo(x);
+    INSERT INTO foo VALUES(1);
+    INSERT INTO foo VALUES(2);
+  }
+  execsql {BEGIN; SELECT x FROM foo ORDER BY x;} db2
+} {1 2}
+do_test doltlite_recover_locking_2-5.2 {
+  execsql {SAVEPOINT one; INSERT INTO foo VALUES(1);}
+  catchsql {RELEASE one}
+} {0 {}}
+do_catchsql_test doltlite_recover_locking_2-5.3 {
+  ROLLBACK TO one
+} {1 {no such savepoint: one}}
+do_test doltlite_recover_locking_2-5.4 {
+  execsql {COMMIT} db2
+  execsql {SELECT x FROM foo ORDER BY x} db2
+} {1 1 2}
+do_test doltlite_recover_locking_2-5.5 {
+  execsql {BEGIN; SELECT count(*) FROM foo;} db2
+  execsql {SAVEPOINT one; INSERT INTO foo VALUES(9);}
+  execsql {ROLLBACK TO one}
+  execsql {
+    INSERT INTO foo VALUES(3);
+    INSERT INTO foo VALUES(4);
+    INSERT INTO foo VALUES(5);
+    RELEASE one;
+  }
+  execsql {COMMIT} db2
+  execsql {SELECT x FROM foo ORDER BY x} db2
+} {1 1 2 3 4 5}
+do_test doltlite_recover_locking_2-5.6 {
+  execsql {CREATE INDEX fooidx ON foo(x)} db2
+  execsql {PRAGMA integrity_check}
+} {ok}
+
+#-------------------------------------------------------------------------
+# 6.* savepoint-15: locking_mode=EXCLUSIVE commit not blocked by reader.
+#
+do_test doltlite_recover_locking_2-6.1 {
+  execsql {BEGIN; SELECT count(*) FROM foo;} db2
+} {6}
+do_test doltlite_recover_locking_2-6.2 {
+  execsql {PRAGMA locking_mode=EXCLUSIVE}
+} {exclusive}
+do_test doltlite_recover_locking_2-6.3 {
+  execsql {BEGIN; INSERT INTO foo VALUES(6);}
+  catchsql {COMMIT}
+} {0 {}}
+do_test doltlite_recover_locking_2-6.4 {
+  execsql {SELECT count(*) FROM foo} db2
+} {6}
+do_test doltlite_recover_locking_2-6.5 {
+  execsql {COMMIT} db2
+  execsql {SELECT count(*) FROM foo} db2
+} {7}
+do_test doltlite_recover_locking_2-6.6 {
+  execsql {PRAGMA locking_mode=NORMAL}
+} {normal}
+do_test doltlite_recover_locking_2-6.7 {
+  execsql {INSERT INTO foo VALUES(7)}
+  list [execsql {SELECT count(*) FROM foo}] \
+       [execsql {SELECT count(*) FROM foo} db2] \
+       [execsql {PRAGMA integrity_check} db2]
+} {8 8 ok}
+
+#-------------------------------------------------------------------------
+# 8.* pragma2: pager metrics read 0/unlocked; row outcomes match stock.
+#
+do_execsql_test doltlite_recover_locking_2-8.1 {
+  CREATE TABLE abc(a, b, c);
+  PRAGMA freelist_count;
+} {0}
+do_execsql_test doltlite_recover_locking_2-8.2 {
+  DROP TABLE abc;
+  PRAGMA freelist_count;
+} {0}
+do_execsql_test doltlite_recover_locking_2-8.3 {
+  PRAGMA main.freelist_count;
+} {0}
+do_test doltlite_recover_locking_2-8.4 {
+  execsql {ATTACH 'rlk2p.db' AS paux}
+  set v [string repeat 0123456789 1000]
+  execsql {CREATE TABLE paux.pabc(a, b, c)}
+  db eval {INSERT INTO paux.pabc VALUES(1, 2, $v)}
+  execsql {
+    DELETE FROM paux.pabc;
+    PRAGMA paux.freelist_count;
+  }
+} {0}
+do_execsql_test doltlite_recover_locking_2-8.5 {
+  PRAGMA paux.freelist_count;
+  PRAGMA main.freelist_count;
+  PRAGMA freelist_count;
+} {0 0 0}
+do_execsql_test doltlite_recover_locking_2-8.6 {
+  PRAGMA freelist_count = 500;
+  PRAGMA freelist_count;
+} {0 0}
+do_execsql_test doltlite_recover_locking_2-8.7 {
+  PRAGMA paux.freelist_count = 500;
+  PRAGMA paux.freelist_count;
+} {0 0}
+do_execsql_test doltlite_recover_locking_2-8.8 {
+  PRAGMA main.cache_size=2000;
+  PRAGMA main.cache_size;
+  PRAGMA cache_spill;
+} {2000 0}
+do_test doltlite_recover_locking_2-8.9 {
+  execsql {
+    CREATE TABLE p2(a INTEGER PRIMARY KEY, b);
+    INSERT INTO p2 VALUES(1,'x'),(2,'y');
+  }
+  execsql {BEGIN; UPDATE p2 SET b=b||'1';}
+  set mainState [lindex [execsql {PRAGMA lock_status}] 1]
+  execsql {ROLLBACK}
+  list $mainState [execsql {SELECT a,b FROM p2 ORDER BY a}]
+} {unlocked {1 x 2 y}}
+do_execsql_test doltlite_recover_locking_2-8.10 {
+  PRAGMA cache_spill=OFF;
+  PRAGMA cache_spill;
+} {0}
+do_execsql_test doltlite_recover_locking_2-8.11 {
+  PRAGMA cache_spill=100000;
+  PRAGMA cache_spill;
+} {0}
+do_execsql_test doltlite_recover_locking_2-8.12 {
+  PRAGMA cache_spill=25;
+  PRAGMA main.cache_spill;
+} {0}
+do_execsql_test doltlite_recover_locking_2-8.13 {
+  PRAGMA cache_spill(-25);
+  PRAGMA main.cache_spill;
+} {0}
+do_execsql_test doltlite_recover_locking_2-8.14 {
+  PRAGMA cache_spill=ON;
+  PRAGMA cache_spill;
+} {0}
+do_test doltlite_recover_locking_2-8.15 {
+  execsql {INSERT INTO paux.pabc VALUES(3, 4, 'z')}
+  execsql {BEGIN; UPDATE paux.pabc SET a=a+1;}
+  set ls [execsql {PRAGMA lock_status}]
+  execsql {COMMIT}
+  list [lindex $ls 1] [lindex $ls end] [execsql {SELECT a FROM paux.pabc}]
+} {unlocked unlocked 4}
+do_test doltlite_recover_locking_2-8.16 {
+  sqlite3 dbp rlk2q.db
+  dbp eval {
+    PRAGMA page_size=16384;
+    CREATE TABLE q1(x);
+    PRAGMA cache_size=2;
+    PRAGMA cache_spill=YES;
+  }
+  set a [dbp eval {PRAGMA cache_spill}]
+  dbp eval {PRAGMA cache_spill(-51)}
+  set b [dbp eval {PRAGMA cache_spill}]
+  dbp close
+  list $a $b
+} {0 0}
+
+#-------------------------------------------------------------------------
+# 9.* memdb2 recast: writer COMMIT not blocked by reader holding SHARED.
+#
+do_test doltlite_recover_locking_2-9.1 {
+  execsql {CREATE TABLE m(x, y); INSERT INTO m VALUES(1, 2);}
+  execsql {BEGIN; SELECT * FROM m;} db2
+} {1 2}
+do_test doltlite_recover_locking_2-9.2 {
+  execsql {BEGIN; INSERT INTO m VALUES(3, 4);}
+} {}
+do_catchsql_test doltlite_recover_locking_2-9.3 {
+  COMMIT
+} {0 {}}
+do_test doltlite_recover_locking_2-9.4 {
+  execsql {SELECT * FROM m; END;} db2
+} {1 2}
+do_test doltlite_recover_locking_2-9.5 {
+  execsql {SELECT x, y FROM m ORDER BY x} db2
+} {1 2 3 4}
+
+#-------------------------------------------------------------------------
+# 10.* nolock/immutable URI params: accepted, data correct and durable.
+#
+do_test doltlite_recover_locking_2-10.1 {
+  sqlite3 dbn file:rlk2n.db?nolock=1 -uri 1
+  dbn eval {
+    CREATE TABLE n(x);
+    INSERT INTO n VALUES('youngling');
+    SELECT * FROM n;
+  }
+} {youngling}
+do_test doltlite_recover_locking_2-10.2 {
+  dbn close
+  sqlite3 dbn rlk2n.db
+  set r [dbn eval {SELECT * FROM n}]
+  dbn close
+  set r
+} {youngling}
+do_test doltlite_recover_locking_2-10.3 {
+  sqlite3 dbn file:rlk2n.db?nolock=0 -uri 1 -readonly 1
+  set r [dbn eval {SELECT * FROM n}]
+  dbn close
+  set r
+} {youngling}
+do_test doltlite_recover_locking_2-10.4 {
+  sqlite3 dbn rlk2n.db
+  sqlite3 dbn2 rlk2n.db
+  set r [list [dbn eval {SELECT * FROM n}] [dbn2 eval {SELECT * FROM n}]]
+  dbn close
+  dbn2 close
+  set r
+} {youngling youngling}
+do_test doltlite_recover_locking_2-10.5 {
+  sqlite3 dbn file:rlk2n.db?immutable=1 -uri 1
+  set r [dbn eval {SELECT * FROM n}]
+  dbn close
+  sqlite3 dbn file:rlk2n.db?immutable=1 -uri 1 -readonly 1
+  lappend r [dbn eval {SELECT * FROM n}]
+  dbn close
+  set r
+} {youngling youngling}
+do_test doltlite_recover_locking_2-10.6 {
+  sqlite3 dbn rlk2w.db
+  dbn eval {PRAGMA journal_mode=WAL}
+  dbn eval {CREATE TABLE t1(x); INSERT INTO t1 VALUES('catbird');}
+  dbn close
+  sqlite3 dbn file:rlk2w.db?nolock=1 -uri 1
+  set r [catch {dbn eval {SELECT * FROM t1}} msg]
+  dbn close
+  list $r $msg
+} {0 catbird}
+
+#-------------------------------------------------------------------------
+# 11.* shared8 recast: schema visible across connections, stable across
+# closing sibling connections.
+#
+do_test doltlite_recover_locking_2-11.1 {
+  sqlite3 dba rlk2s.db
+  sqlite3 dbb rlk2s.db
+  dba eval {
+    CREATE TABLE st(a, b);
+    INSERT INTO st VALUES(1, 1);
+    INSERT INTO st VALUES(2, 2);
+    INSERT INTO st VALUES(3, 3);
+    INSERT INTO st VALUES(4, 4);
+    CREATE VIEW sv AS SELECT a, b+10 AS b10 FROM st;
+  }
+  dbb eval {SELECT a, b10 FROM sv ORDER BY a}
+} {1 11 2 12 3 13 4 14}
+do_test doltlite_recover_locking_2-11.2 {
+  dba close
+  dbb eval {SELECT a, b10 FROM sv ORDER BY a}
+} {1 11 2 12 3 13 4 14}
+do_test doltlite_recover_locking_2-11.3 {
+  sqlite3 dbc rlk2s.db
+  dbc eval {SELECT a, b10 FROM sv ORDER BY a}
+} {1 11 2 12 3 13 4 14}
+do_test doltlite_recover_locking_2-11.4 {
+  dbb eval {SELECT count(*) FROM sv}
+} {4}
+do_test doltlite_recover_locking_2-11.5 {
+  dbb close
+  set r [dbc eval {SELECT a, b10 FROM sv ORDER BY a}]
+  dbc close
+  set r
+} {1 11 2 12 3 13 4 14}
+
+#-------------------------------------------------------------------------
+# 12.* shared9: custom-collation index rejection; commit not blocked by
+# a second connection's read transaction.
+#
+do_test doltlite_recover_locking_2-12.1 {
+  sqlite3 dba rlk2t.db
+  sqlite3 dbb rlk2t.db
+  proc coll9 {a b} {string compare $a $b}
+  dba collate collate1 coll9
+  dbb collate collate1 coll9
+  dba eval {CREATE TABLE ct(a, b, c COLLATE collate1)}
+  set rc [catch {dba eval {CREATE INDEX ci ON ct(a COLLATE collate1, c, b)}} msg]
+  list $rc $msg
+} {1 {doltlite does not support indexes with custom collation 'collate1'}}
+do_test doltlite_recover_locking_2-12.2 {
+  dba close
+  dbb eval {INSERT INTO ct VALUES('abc','def','ghi'); SELECT * FROM ct}
+} {abc def ghi}
+do_test doltlite_recover_locking_2-12.3 {
+  sqlite3 dba rlk2t.db
+  dba eval {
+    CREATE TABLE s3a(a, b);
+    CREATE TABLE s3b(a, b);
+    INSERT INTO s3a VALUES(1, 2);
+    INSERT INTO s3b VALUES(1, 2);
+  }
+  dba eval {BEGIN; INSERT INTO s3a VALUES(3, 4);}
+  dbb eval {BEGIN; SELECT * FROM s3a;}
+} {1 2}
+do_test doltlite_recover_locking_2-12.4 {
+  dbb eval {SELECT * FROM s3b}
+} {1 2}
+do_test doltlite_recover_locking_2-12.5 {
+  set rc [catch {dba eval COMMIT} msg]
+  list $rc $msg
+} {0 {}}
+do_test doltlite_recover_locking_2-12.6 {
+  dbb eval {SELECT * FROM s3a}
+} {1 2}
+do_test doltlite_recover_locking_2-12.7 {
+  dbb eval {COMMIT}
+  set r [dbb eval {SELECT a, b FROM s3a ORDER BY a}]
+  dba close
+  dbb close
+  set r
+} {1 2 3 4}
+
+#-------------------------------------------------------------------------
+# 13.* tkt4018: writes from other connections succeed against an open read
+# txn; snapshot isolation; readonly connections still rejected.
+#
+do_test doltlite_recover_locking_2-13.1 {
+  execsql {CREATE TABLE tk(a, b); BEGIN; SELECT * FROM tk;}
+  catchsql {INSERT INTO tk VALUES(3, 4)} db2
+} {0 {}}
+do_test doltlite_recover_locking_2-13.2 {
+  execsql {SELECT * FROM tk}
+} {}
+do_test doltlite_recover_locking_2-13.3 {
+  execsql {COMMIT}
+  execsql {SELECT a, b FROM tk ORDER BY a}
+} {3 4}
+do_test doltlite_recover_locking_2-13.4 {
+  execsql {BEGIN; SELECT a, b FROM tk ORDER BY a;}
+} {3 4}
+do_test doltlite_recover_locking_2-13.5 {
+  execsql {COMMIT}
+  sqlite3 dbr rlk2.db -readonly 1
+  set r [catchsql {INSERT INTO tk VALUES(5, 6)} dbr]
+  dbr close
+  set r
+} {1 {attempt to write a readonly database}}
+
+#-------------------------------------------------------------------------
+# 14.* shared-1.7.2 + capi2-6.5: open scans keep their snapshot while a
+# second connection deletes a sibling table and inserts into the scanned one.
+#
+do_test doltlite_recover_locking_2-14.1 {
+  execsql {
+    CREATE TABLE t1s(a INTEGER PRIMARY KEY, b);
+    CREATE TABLE t2s(a INTEGER PRIMARY KEY, b);
+    WITH RECURSIVE c(i) AS (SELECT 1 UNION ALL SELECT i+1 FROM c WHERE i<20)
+      INSERT INTO t1s SELECT i, 'v'||i FROM c;
+    INSERT INTO t2s SELECT * FROM t1s;
+  }
+  set seen {}
+  set fired 0
+  db eval {SELECT a FROM t2s ORDER BY a} {
+    if {$a==3 && !$fired} {
+      set fired 1
+      set ::midDel [catchsql {DELETE FROM t1s} db2]
+      set ::midIns [catchsql {INSERT INTO t2s VALUES(999, 'mid')} db2]
+    }
+    lappend seen $a
+  }
+  list [llength $seen] [lindex $seen end] $::midDel $::midIns
+} {20 20 {0 {}} {0 {}}}
+do_test doltlite_recover_locking_2-14.2 {
+  execsql {SELECT count(*) FROM t1s}
+} {0}
+do_test doltlite_recover_locking_2-14.3 {
+  execsql {SELECT count(*) FROM t2s}
+} {21}
+
+#-------------------------------------------------------------------------
+# 15.* both connections healthy after all conflict scenarios.
+#
+do_test doltlite_recover_locking_2-15.1 {
+  list [execsql {PRAGMA integrity_check}] [execsql {PRAGMA integrity_check} db2]
+} {ok ok}
+
+db2 close
+finish_test

--- a/test/doltlite_recover_rejections.test
+++ b/test/doltlite_recover_rejections.test
@@ -1,0 +1,316 @@
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+# Recovered coverage for explicit-rejection divergences (#1313, shard "rejections").
+# In doltlite VACUUM is a runtime-detected no-op on prolly storage (#322/#991),
+# VACUUM INTO is explicitly rejected, and the deserialize page-image API is
+# rejected (#1225). These tests pin the doltlite-native contract: rejections
+# fire with the exact message, no-op VACUUM never disturbs committed data or
+# in-progress statements, and the database stays fully usable afterward.
+#
+# covers: vacuum vacuum-5.1 — table-swap txn (DROP/CREATE/copy + view) then VACUUM succeeds; data/view intact and integrity ok across reopen (1.x)
+# covers: vacuum2 vacuum2-5.2 — VACUUM mid-scan: doltlite no-op VACUUM succeeds inside an active SELECT without disturbing the scan (2.2)
+# covers: vacuum2 vacuum2-5.3 — VACUUM inside a trivial active statement succeeds as a no-op (2.3)
+# covers: vacuum2 vacuum2-5.4 — VACUUM fired mid-scan: full row set still returned in order, db consistent after (2.4/2.5)
+# covers-class: crash7 (83 entries: crash7-1.1.crash..crash7-1.63.crash, crash7-2.1.1..crash7-2.20.1): stock crash-during-VACUUM recovery — represented by doltlite-native durability: content hash and rows unchanged across page_size+VACUUM+close+reopen for each page-size variant, repeated VACUUM/reopen cycles after bulk delete, integrity_check ok every time (3.x)
+# covers: pragma6 pragma6-1.0 — db deserialize page-image API rejected with exact message; connection remains fully usable (4.x)
+# covers: vacuum-into vacuum-into-110 — VACUUM main INTO 'file' rejected with exact doltlite message (5.1)
+# covers: vacuum-into vacuum-into-120 — rejected VACUUM INTO creates no output file to read back (5.2)
+# covers: vacuum-into vacuum-into-130 — bare VACUUM INTO 'file' rejected identically (5.3)
+# covers: vacuum-into vacuum-into-140 — VACUUM INTO a fresh nonexistent path still rejected (5.4)
+# covers: vacuum-into vacuum-into-150 — second attempt at same path rejected identically (5.4)
+# covers: vacuum-into vacuum-into-200 — VACUUM main INTO ':memory:' rejected (5.5)
+# covers: vacuum-into vacuum-into-300 — expression target (SELECT name FROM t2) evaluates, then rejection fires (5.6)
+# covers: vacuum-into vacuum-into-310 — VACUUM INTO null rejected (doltlite rejects before stock's non-text filename check) (5.7)
+# covers: vacuum-into vacuum-into-410 — function-valued target evaluates, rejection fires, no file created (5.8)
+# covers: vacuum-into vacuum-into-500 — rejection leaves source db untouched (hash unchanged) and writable (5.9; stock's read-only-source aspect is moot since no copy is ever made)
+# covers: vacuum-into vacuum-into-510 — source schema/data fully intact and queryable after rejection (5.9/5.10)
+# covers: vacuum-into vacuum-into-620 — PRAGMA page_size change does not alter the rejection (5.11)
+# covers: vacuum-into vacuum-into-630 — no output db exists to inspect after page_size+VACUUM INTO attempt (5.11)
+# covers: vacuum-into vacuum-into-710.1 — PRAGMA synchronous=normal then VACUUM INTO rejected (5.12)
+# covers: vacuum-into vacuum-into-710.2 — source hash unchanged after rejected attempt under synchronous=normal (5.12)
+# covers: vacuum-into vacuum-into-720.1 — PRAGMA synchronous=full then VACUUM INTO rejected (5.12)
+# covers: vacuum-into vacuum-into-720.2 — source hash unchanged after rejected attempt under synchronous=full (5.12)
+# covers: vacuum-into vacuum-into-730.1 — PRAGMA synchronous=off then VACUUM INTO rejected (5.12)
+# covers: vacuum-into vacuum-into-740.1 — PRAGMA synchronous=extra then VACUUM INTO rejected (5.12)
+# covers: vacuum-into vacuum-into-740.2 — source hash unchanged after rejected attempt under synchronous=extra (5.12)
+# covers: vacuum-into vacuum-into-750.1 — fullfsync=1 + synchronous=full then VACUUM INTO rejected (5.12)
+# covers: vacuum-into vacuum-into-750.2 — source hash unchanged after rejected attempt under fullfsync (5.12)
+# (5.13/5.14 additionally pin: rejection stable across close/reopen, data intact, integrity ok)
+# not-covered: (none)
+
+#-------------------------------------------------------------------------
+# 1.x: vacuum-5.1 — VACUUM after a table-swap transaction with a dependent
+# view succeeds and leaves a consistent database.
+#
+do_test doltlite_recover_rejections-1.1 {
+  db close
+  forcedelete test.db
+  sqlite3 db test.db
+  catchsql {
+    CREATE TABLE Test (TestID int primary key);
+    INSERT INTO Test VALUES (1);
+    CREATE VIEW viewTest AS SELECT * FROM Test;
+
+    BEGIN;
+    CREATE TABLE tempTest (TestID int primary key, Test2 int NULL);
+    INSERT INTO tempTest SELECT TestID, 1 FROM Test;
+    DROP TABLE Test;
+    CREATE TABLE Test(TestID int primary key, Test2 int NULL);
+    INSERT INTO Test SELECT * FROM tempTest;
+    DROP TABLE tempTest;
+    COMMIT;
+    VACUUM;
+  }
+} {0 {}}
+do_test doltlite_recover_rejections-1.2 {
+  catchsql {VACUUM}
+} {0 {}}
+do_test doltlite_recover_rejections-1.3 {
+  execsql {SELECT TestID, Test2 FROM Test ORDER BY TestID}
+} {1 1}
+do_test doltlite_recover_rejections-1.4 {
+  execsql {SELECT TestID, Test2 FROM viewTest ORDER BY TestID}
+} {1 1}
+do_test doltlite_recover_rejections-1.5 {
+  db close
+  sqlite3 db test.db
+  list [execsql {SELECT TestID, Test2 FROM Test ORDER BY TestID}] \
+       [execsql {PRAGMA integrity_check}]
+} {{1 1} ok}
+
+#-------------------------------------------------------------------------
+# 2.x: vacuum2-5.2/5.3/5.4 — stock errors "cannot VACUUM - SQL statements in
+# progress"; doltlite's no-op VACUUM succeeds mid-statement. The recovered
+# intent: a VACUUM fired while a scan is active must not disturb the scan or
+# the database.
+#
+do_test doltlite_recover_rejections-2.1 {
+  execsql {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT);
+    WITH RECURSIVE c(x) AS (VALUES(1) UNION ALL SELECT x+1 FROM c WHERE x<16)
+    INSERT INTO t1 SELECT x, printf('row-%02d', x) FROM c;
+    SELECT count(*) FROM t1;
+  }
+} {16}
+do_test doltlite_recover_rejections-2.2 {
+  set rows {}
+  set vres {}
+  db eval {SELECT a FROM t1 ORDER BY a} {
+    if {$a == 8} { set vres [catchsql VACUUM] }
+    lappend rows $a
+  }
+  list $rows $vres
+} {{1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16} {0 {}}}
+do_test doltlite_recover_rejections-2.3 {
+  list [catch {
+    db eval {SELECT 1, 2, 3} { execsql VACUUM }
+  } msg] $msg
+} {0 {}}
+do_test doltlite_recover_rejections-2.4 {
+  set res {}
+  set res2 {}
+  db eval {SELECT a, b FROM t1 WHERE a<=10 ORDER BY a} {
+    if {$a==6} { set res [catchsql VACUUM] }
+    lappend res2 $a
+  }
+  lappend res2 $res
+} {1 2 3 4 5 6 7 8 9 10 {0 {}}}
+do_test doltlite_recover_rejections-2.5 {
+  list [execsql {SELECT count(*), min(a), max(a) FROM t1}] \
+       [execsql {PRAGMA integrity_check}]
+} {{16 1 16} ok}
+
+#-------------------------------------------------------------------------
+# 3.x: crash7 class — stock crashed mid-VACUUM at varied page sizes and
+# verified recovery. doltlite-native: VACUUM (with page_size changes) never
+# perturbs committed content: hash and rows identical across VACUUM and
+# close/reopen, integrity ok each time.
+#
+do_test doltlite_recover_rejections-3.0 {
+  db close
+  forcedelete test.db
+  sqlite3 db test.db
+  execsql {
+    CREATE TABLE abc(a PRIMARY KEY, b, c);
+    WITH RECURSIVE n(x) AS (VALUES(1) UNION ALL SELECT x+1 FROM n WHERE x<48)
+    INSERT INTO abc
+      SELECT printf('key-%03d', x),
+             zeroblob(200 + (x%7)*100),
+             printf('%.*c', 500 + (x%5)*900, 'z')
+      FROM n;
+    SELECT count(*) FROM abc;
+  }
+} {48}
+
+set ::sig3 [execsql {SELECT dolt_hashof_table('abc')}]
+set tn 0
+foreach psz {1024 2048 4096 8192} {
+  incr tn
+  do_test doltlite_recover_rejections-3.$tn.1 {
+    execsql "PRAGMA page_size = $psz"
+    catchsql {VACUUM}
+  } {0 {}}
+  do_test doltlite_recover_rejections-3.$tn.2 {
+    db close
+    sqlite3 db test.db
+    list [string equal $::sig3 [execsql {SELECT dolt_hashof_table('abc')}]] \
+         [execsql {SELECT count(*) FROM abc}] \
+         [execsql {PRAGMA integrity_check}]
+  } {1 48 ok}
+}
+
+# crash7-2 analogue: UNIQUE index + bulk delete, then repeated VACUUM/reopen.
+do_test doltlite_recover_rejections-3.5 {
+  execsql {
+    CREATE TABLE t2(a, b, UNIQUE(a, b));
+    WITH RECURSIVE n(x) AS (VALUES(1) UNION ALL SELECT x+1 FROM n WHERE x<64)
+    INSERT INTO t2 SELECT printf('a%03d', x), printf('b%03d', x) FROM n;
+    DELETE FROM t2 WHERE rowid%2;
+    SELECT count(*) FROM t2;
+  }
+} {32}
+set ::sig3b [execsql {SELECT dolt_hashof_table('t2')}]
+for {set i 1} {$i <= 5} {incr i} {
+  do_test doltlite_recover_rejections-3.6.$i {
+    set v [catchsql {VACUUM}]
+    db close
+    sqlite3 db test.db
+    list $v \
+         [string equal $::sig3b [execsql {SELECT dolt_hashof_table('t2')}]] \
+         [execsql {PRAGMA integrity_check}]
+  } {{0 {}} 1 ok}
+}
+do_test doltlite_recover_rejections-3.7 {
+  execsql {SELECT a, b FROM t2 WHERE rowid<=4 ORDER BY a}
+} {a002 b002 a004 b004}
+
+#-------------------------------------------------------------------------
+# 4.x: pragma6-1.0 — the deserialize page-image API is rejected cleanly and
+# the connection stays usable.
+#
+do_test doltlite_recover_rejections-4.1 {
+  sqlite3 dbm {}
+  list [catch {dbm deserialize [decode_hexdb {
+    .open --hexdb
+    | size 4096 pagesize 4096 filename x.db
+    | page 1 offset 0
+    |      0: 53 51 4c 69 74 65 20 66 6f 72 6d 61 74 20 33 00   SQLite format 3.
+    | end x.db
+  }]} msg] $msg
+} {1 {unable to set MEMDB content}}
+do_test doltlite_recover_rejections-4.2 {
+  set res [dbm eval {
+    CREATE TABLE z(a INTEGER PRIMARY KEY, b TEXT);
+    INSERT INTO z VALUES(5,'five');
+    SELECT a, b FROM z ORDER BY a;
+  }]
+  dbm close
+  set res
+} {5 five}
+
+#-------------------------------------------------------------------------
+# 5.x: vacuum-into — every form of VACUUM INTO is rejected with the exact
+# message, no output file is ever produced, the source database is untouched
+# and fully usable, and the rejection is stable across reopen.
+#
+do_test doltlite_recover_rejections-5.0 {
+  db close
+  forcedelete test.db
+  forcedelete out.db
+  forcedelete out2.db
+  forcedelete test.db2
+  sqlite3 db test.db
+  execsql {
+    CREATE TABLE t1(
+      a INTEGER PRIMARY KEY,
+      b ANY,
+      c INT AS (b+1),
+      CHECK( typeof(b)!='integer' OR b>a-5 )
+    );
+    WITH RECURSIVE c(x) AS (VALUES(1) UNION ALL SELECT x+1 FROM c WHERE x<100)
+    INSERT INTO t1(a,b) SELECT x, zeroblob(600) FROM c;
+    CREATE INDEX t1b ON t1(b);
+    DELETE FROM t1 WHERE a%2;
+    SELECT count(*), sum(a), sum(length(b)) FROM t1;
+  }
+} {50 2550 30000}
+set ::sig5 [execsql {SELECT dolt_hashof_table('t1')}]
+
+do_catchsql_test doltlite_recover_rejections-5.1 {
+  VACUUM main INTO 'out.db';
+} {1 {VACUUM INTO is not supported for doltlite databases}}
+do_test doltlite_recover_rejections-5.2 {
+  file exists out.db
+} {0}
+do_catchsql_test doltlite_recover_rejections-5.3 {
+  VACUUM INTO 'out.db';
+} {1 {VACUUM INTO is not supported for doltlite databases}}
+do_test doltlite_recover_rejections-5.4 {
+  list [catchsql {VACUUM INTO 'out2.db'}] \
+       [catchsql {VACUUM INTO 'out2.db'}] \
+       [file exists out2.db]
+} {{1 {VACUUM INTO is not supported for doltlite databases}} {1 {VACUUM INTO is not supported for doltlite databases}} 0}
+do_catchsql_test doltlite_recover_rejections-5.5 {
+  VACUUM main INTO ':memory:';
+} {1 {VACUUM INTO is not supported for doltlite databases}}
+do_test doltlite_recover_rejections-5.6 {
+  execsql {
+    CREATE TABLE t2(name TEXT);
+    INSERT INTO t2 VALUES(':memory:');
+  }
+  catchsql {VACUUM main INTO (SELECT name FROM t2)}
+} {1 {VACUUM INTO is not supported for doltlite databases}}
+do_catchsql_test doltlite_recover_rejections-5.7 {
+  VACUUM INTO null;
+} {1 {VACUUM INTO is not supported for doltlite databases}}
+do_test doltlite_recover_rejections-5.8 {
+  db func target target
+  proc target {} { return "test.db2" }
+  list [catchsql {VACUUM INTO target()}] [file exists test.db2]
+} {{1 {VACUUM INTO is not supported for doltlite databases}} 0}
+do_test doltlite_recover_rejections-5.9 {
+  list [string equal $::sig5 [execsql {SELECT dolt_hashof_table('t1')}]] \
+       [execsql {SELECT count(*), sum(a), sum(length(b)) FROM t1}]
+} {1 {50 2550 30000}}
+do_test doltlite_recover_rejections-5.10 {
+  execsql {SELECT name FROM sqlite_master WHERE name IN ('t1','t1b','t2') ORDER BY 1}
+} {t1 t1b t2}
+do_test doltlite_recover_rejections-5.11 {
+  execsql {PRAGMA page_size=1024}
+  list [catchsql {VACUUM INTO 'test.db2'}] [file exists test.db2]
+} {{1 {VACUUM INTO is not supported for doltlite databases}} 0}
+
+set tn 0
+foreach pragma {
+  {PRAGMA synchronous = normal}
+  {PRAGMA synchronous = full}
+  {PRAGMA synchronous = off}
+  {PRAGMA synchronous = extra}
+  {PRAGMA fullfsync = 1; PRAGMA synchronous = full}
+} {
+  incr tn
+  do_test doltlite_recover_rejections-5.12.$tn {
+    forcedelete test.db2
+    db eval $pragma
+    list [catchsql {VACUUM INTO 'test.db2'}] \
+         [file exists test.db2] \
+         [string equal $::sig5 [execsql {SELECT dolt_hashof_table('t1')}]]
+  } {{1 {VACUUM INTO is not supported for doltlite databases}} 0 1}
+}
+
+do_test doltlite_recover_rejections-5.13 {
+  db close
+  sqlite3 db test.db
+  catchsql {VACUUM INTO 'out.db'}
+} {1 {VACUUM INTO is not supported for doltlite databases}}
+do_test doltlite_recover_rejections-5.14 {
+  execsql {
+    INSERT INTO t1(a,b) VALUES(101, 200);
+  }
+  list [execsql {SELECT count(*) FROM t1}] \
+       [execsql {SELECT b, c FROM t1 WHERE a=101}] \
+       [execsql {PRAGMA integrity_check}]
+} {51 {200 201} ok}
+
+finish_test

--- a/test/regression-buckets/ddl-schema.txt
+++ b/test/regression-buckets/ddl-schema.txt
@@ -49,6 +49,9 @@ delete
 delete3
 delete4
 descidx3
+doltlite_recover_locking_1
+doltlite_recover_locking_2
+doltlite_recover_rejections
 e_changes
 e_createtable
 e_delete


### PR DESCRIPTION
Part of #1313. **223 assertions covering 311 gated entries.**

- doltlite's concurrency contract asserted directly: concurrent readers during writes, blocking/erroring writes with exact messages, DROP TABLE mid-scan, and that both connections recover after conflicts.
- Every explicitly rejected feature (VACUUM INTO etc.) pinned to its exact error with the database verified fully usable afterward and across reopen.
- Gated in the **ddl-schema** bucket as zero-divergence files; adversarially verified as in PR 1/4.

Surfaced 2 suspected bugs (cross-connection savepoint data loss; memdb VFS half-open) — filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)