### PR TITLE
Treat all-zero WAL tail as absent, fixing SIZE_HINT corruption (#1342)

### DIFF
--- a/src/chunk_wal.c
+++ b/src/chunk_wal.c
@@ -292,7 +292,7 @@ int csReplayWal(ChunkStore *cs){
     } else if( tag == 0 && csWalTailIsZero(cs, recPos, walSize) ){
       /* SQLITE_FCNTL_SIZE_HINT (or filesystem preallocation) zero-extends the
       ** file past the last commit. Treat the all-zero tail as absent: rewind
-      ** the logical end of file so the next append reclaims it (#1342). */
+      ** the logical end of file so the next append reclaims it. */
       cs->wal.nWalData = recPos;
       cs->file.iFileSize = cs->wal.iWalOffset + recPos;
       break;

--- a/src/chunk_wal.c
+++ b/src/chunk_wal.c
@@ -115,6 +115,23 @@ void csFreeReloadState(ChunkStoreReloadState *pSaved){
   memset(pSaved, 0, sizeof(*pSaved));
 }
 
+/* True if the WAL region from pos to walSize is all zero bytes. */
+static int csWalTailIsZero(ChunkStore *cs, i64 pos, i64 walSize){
+  u8 buf[4096];
+  i64 off = cs->wal.iWalOffset + pos;
+  i64 end = cs->wal.iWalOffset + walSize;
+  while( off < end ){
+    int n = (end - off) > (i64)sizeof(buf) ? (int)sizeof(buf) : (int)(end - off);
+    int i;
+    if( sqlite3OsRead(cs->file.pFile, buf, n, off) != SQLITE_OK ) return 0;
+    for(i=0; i<n; i++){
+      if( buf[i] ) return 0;
+    }
+    off += n;
+  }
+  return 1;
+}
+
 int csReplayWal(ChunkStore *cs){
   i64 walSize;
   ChunkStoreReplayState saved;
@@ -271,6 +288,14 @@ int csReplayWal(ChunkStore *cs){
       pos = recPos + 1 + CHUNK_MANIFEST_SIZE;
       nRootedPending = cs->staging.nPending;
       nRootRecordsSeen++;
+
+    } else if( tag == 0 && csWalTailIsZero(cs, recPos, walSize) ){
+      /* SQLITE_FCNTL_SIZE_HINT (or filesystem preallocation) zero-extends the
+      ** file past the last commit. Treat the all-zero tail as absent: rewind
+      ** the logical end of file so the next append reclaims it (#1342). */
+      cs->wal.nWalData = recPos;
+      cs->file.iFileSize = cs->wal.iWalOffset + recPos;
+      break;
 
     } else {
       rc = SQLITE_CORRUPT;

--- a/test/doltlite_recover_rawformat_2.test
+++ b/test/doltlite_recover_rawformat_2.test
@@ -164,13 +164,13 @@ source $testdir/tester.tcl
 #   fails with a permission error; the CI container runs as root, which bypasses
 #   file permissions, so the readonly condition cannot be created in this
 #   environment (verified: backup onto a 0400 file succeeds as root)
-# not-covered: syscall syscall-8.4.1 syscall-8.4.2 syscall-8.4.3 syscall-8.4.4
-#   syscall-8.4.5 — SUSPECTED BUG: SQLITE_FCNTL_SIZE_HINT that extends the file
-#   after SQLITE_FCNTL_CHUNK_SIZE (e.g. chunksize 4096 then sizehint 8192 on a
-#   fresh db) appends chunk-rounded zero bytes the chunk store cannot parse; the
-#   next INSERT fails with 'database disk image is malformed'. The originals
-#   exist to assert exactly this extension behavior, so they cannot be
-#   recovered until the size-hint path is fixed.
+# covers-class: syscall syscall-8.4.{1..5} (5 entries): originals assert exact
+#   chunk-rounded byte sizes from SIZE_HINT after a 16-byte CHUNK_SIZE; a fresh
+#   doltlite chunk store already exceeds those sizes so the byte counts can
+#   never match. Recovered invariant (#1342, formerly a bug here): an extending
+#   size hint zero-pads the file to the chunk-rounded size and the chunk store
+#   treats the all-zero tail as absent — the next INSERT, close/reopen, and
+#   integrity_check all succeed (3.8)
 
 #-------------------------------------------------------------------------
 # 1.* pagesize
@@ -358,6 +358,21 @@ do_test doltlite_recover_rawformat_2-3.7 {
   list $res [execsql {SELECT * FROM s8 ORDER BY a}] \
       [execsql {PRAGMA integrity_check}]
 } {{} {1 2 3 4} ok}
+
+do_test doltlite_recover_rawformat_2-3.8 {
+  db close
+  forcedelete test.db
+  sqlite3 db test.db
+  execsql {CREATE TABLE s9(a, b); INSERT INTO s9 VALUES(1, 2);}
+  file_control_chunksize_test db main 4096
+  file_control_sizehint_test db main 8192
+  set sz [file size test.db]
+  execsql {INSERT INTO s9 VALUES(3, 4)}
+  db close
+  sqlite3 db test.db
+  list $sz [execsql {SELECT * FROM s9 ORDER BY a}] \
+      [execsql {PRAGMA integrity_check}]
+} {8192 {1 2 3 4} ok}
 
 #-------------------------------------------------------------------------
 # 4.* encodings: e_expr-27/28/29/30/33, enc3, enc4

--- a/test/doltlite_recover_rawformat_2.test
+++ b/test/doltlite_recover_rawformat_2.test
@@ -167,7 +167,7 @@ source $testdir/tester.tcl
 # covers-class: syscall syscall-8.4.{1..5} (5 entries): originals assert exact
 #   chunk-rounded byte sizes from SIZE_HINT after a 16-byte CHUNK_SIZE; a fresh
 #   doltlite chunk store already exceeds those sizes so the byte counts can
-#   never match. Recovered invariant (#1342, formerly a bug here): an extending
+#   never match. Recovered invariant (formerly a bug here): an extending
 #   size hint zero-pads the file to the chunk-rounded size and the chunk store
 #   treats the all-zero tail as absent — the next INSERT, close/reopen, and
 #   integrity_check all succeed (3.8)


### PR DESCRIPTION
Fixes #1342.

## Bug

On a fresh db, `file_control_chunksize_test db main 4096` followed by `file_control_sizehint_test db main 8192` made the next INSERT fail with `database disk image is malformed`. `sqlite3_file_control` forwards both verbs straight to the unix file backing the chunk store; with `szChunk` set, `fcntlSizeHint` zero-extends the file to the chunk-rounded size. The chunk store's next commit saw the physical size exceed its cached size, reloaded, and WAL replay read a `0x00` tag byte at the record boundary in the padded region — an unknown tag, so it returned `SQLITE_CORRUPT`.

## Why tolerate the zeros instead of ignoring the hints

Swallowing the two fcntls for chunk-store databases was the other candidate, but upstream `syscall-8.2.1–8.2.5` assert the exact chunk-rounded file extension and **pass today** on doltlite; ignoring the hints would turn those into new divergences. Tolerating the zero tail is also the more robust posture: filesystem-level preallocation produces the same shape, and "zeros after the valid manifest/WAL region are absent data" is a well-defined recovery rule. Corruption detection is preserved — a zero tag followed by any nonzero byte before EOF is still `SQLITE_CORRUPT`.

## Fix

In `csReplayWal`, a tag-0 record whose remaining bytes to EOF are all zero is treated as preallocated padding: replay rewinds the logical end of file (`iFileSize`, `nWalData`) to the last valid record boundary and stops. The next append reclaims the padded region (writes land at the rewound offset, overwriting zeros), so readers and writers across processes converge on the same logical tail.

## Tests

Fail-before (minimal repro, unfixed build):
```
! repro-1342-1.1 expected: [0 {}]
! repro-1342-1.1 got:      [1 {database disk image is malformed}]
```

Pass-after: `0 errors out of 3 tests`.

`test/doltlite_recover_rawformat_2.test`: replaced the `not-covered … SUSPECTED BUG` block for `syscall-8.4.{1..5}` with a recovered native invariant and new test 3.8 (chunksize 4096 + sizehint 8192 pads the file to exactly 8192, then INSERT, close/reopen, and `integrity_check` succeed). File ends `0 errors out of 71 tests`.

Gated run (non-root in docker, `run_testfixture.sh` with `DIVERGENCE_FILE`/`CRASH_FILE`):
```
OK: doltlite_recover_rawformat_2 (71 tests)
OK: filectrl (7 tests)
OK: syscall (81 tests, 28 known divergences)
  passing tests:                     131
  known divergences (still failing): 28
```
The syscall divergence set is byte-identical before/after (remaining 8.1/8.3/8.4.* failures are intentional raw file-size divergences — a fresh doltlite store is already larger than the 16-byte-chunk-rounded sizes), so no divergence-list entries were added or removed.

Replay-adjacent sanity (non-root): `doltlite_recover_rawformat_1/3`, `doltlite_recover_corruption`, `doltlite_recover_jrnlwal_1–4` — all OK, 1044 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)