### PR TITLE
Reject custom collations in the UNIQUE/PK COLLATE retrofit path

### DIFF
--- a/src/btree.h
+++ b/src/btree.h
@@ -271,8 +271,6 @@ int sqlite3BtreeProllyCachedIndexKeyCompare(
 int sqlite3BtreeProllyIndexRowid(BtCursor*, i64*);
 void sqlite3BtreeProllyClearCompareKey(BtCursor*);
 int sqlite3BtreeIncrblobCursorReseek(BtCursor*);
-#endif
-#if defined(DOLTLITE_PROLLY) && !defined(SQLITE_TEST)
 int sqlite3BtreeUsesOrig(Btree*);
 #endif
 int sqlite3BtreeCursorHasMoved(BtCursor*);

--- a/src/build.c
+++ b/src/build.c
@@ -1976,6 +1976,22 @@ void sqlite3AddCollateType(Parse *pParse, Token *pToken){
     for(pIdx=p->pIndex; pIdx; pIdx=pIdx->pNext){
       assert( pIdx->nKeyCol==1 );
       if( pIdx->aiColumn[0]==i ){
+#ifdef DOLTLITE_PROLLY
+        /* This retrofit would persist a custom-collated index, which
+        ** prolly-tree sort keys cannot support. Apply the same rejection
+        ** as sqlite3CreateIndex. */
+        if( sqlite3StrICmp(zColl, "BINARY")!=0
+         && sqlite3StrICmp(zColl, "NOCASE")!=0
+         && sqlite3StrICmp(zColl, "RTRIM")!=0 ){
+          Btree *pColBt = db->aDb[sqlite3SchemaToIndex(db, p->pSchema)].pBt;
+          if( pColBt && !sqlite3BtreeUsesOrig(pColBt) ){
+            sqlite3ErrorMsg(pParse,
+              "doltlite does not support indexes with custom collation '%s'",
+              zColl);
+            break;
+          }
+        }
+#endif
         pIdx->azColl[0] = sqlite3ColumnColl(&p->aCol[i]);
       }
     }

--- a/test/doltlite_recover_collation.test
+++ b/test/doltlite_recover_collation.test
@@ -17,7 +17,8 @@ source $testdir/tester.tcl
 # covers: collate4 collate4-1.1.0 — table with NOCASE+custom-TEXT columns; NOCASE index accepted (1.1), custom-TEXT index rejected verbatim (1.2)
 # covers: collate4 collate4-1.1.4 — ORDER BY custom-TEXT column returns binary order via registered collation, sorter not index (1.4)
 # covers: collate4 collate4-1.1.5 — ORDER BY b COLLATE TEXT same result through explicit custom collate (1.5)
-# covers: collate4 collate4-1.1.8 — NOCASE PK iterates in case-insensitive order, nosort (1.8); NULL PK rejected is the doltlite divergence that gated the family (1.7)
+# covers: collate4 collate4-1.1.7 — column-level "b UNIQUE COLLATE TEXT" rejected verbatim since #1343 (12.1)
+# covers: collate4 collate4-1.1.8 — NOCASE PK iterates in case-insensitive order, nosort (1.8)
 # covers: collate4 collate4-1.1.9 — ORDER BY a COLLATE NOCASE == PK order, nosort (1.8)
 # covers: collate4 collate4-1.1.10 — binary (upstream TEXT) order over NOCASE PK needs a sort, correct result (1.9)
 # covers: collate4 collate4-1.1.11 — column-level UNIQUE index drives ORDER BY, nosort (1.11)
@@ -91,17 +92,15 @@ source $testdir/tester.tcl
 # covers: collate3 collate3-4.6 — explicit COLLATE-in-index form rejected before it can persist (11.3)
 # not-covered: (none)
 #
-# SUSPECTED BUG: "CREATE TABLE t(b UNIQUE COLLATE custom)" bypasses the
-# custom-collation index rejection.  sqlite3AddCollateType (src/build.c:1976)
-# retrofits the collation onto the already-created implicit UNIQUE index
-# without the DOLTLITE_PROLLY check that sqlite3CreateIndex applies
-# (src/build.c:4387).  The persisted index then uses the custom collation
-# (PRAGMA index_list shows it; ORDER BY b COLLATE custom scans it nosort), and
-# after reopen without the collation registered PRAGMA integrity_check fails
-# with "no such collation sequence" — exactly the state the rejection exists
-# to prevent.  This is why collate4-1.1.7's table (a PRIMARY KEY COLLATE
-# NOCASE, b UNIQUE COLLATE TEXT) is creatable here; tests below use built-in
-# collation equivalents instead of relying on the buggy path.
+# Section 12 pins the #1343 fix: "CREATE TABLE t(b UNIQUE COLLATE custom)"
+# used to bypass the custom-collation index rejection because
+# sqlite3AddCollateType retrofitted the collation onto the already-created
+# implicit UNIQUE/PK autoindex without the DOLTLITE_PROLLY check that
+# sqlite3CreateIndex applies.  The persisted index then used the custom
+# collation, and after reopen without the collation registered PRAGMA
+# integrity_check failed with "no such collation sequence" — exactly the
+# state the rejection exists to prevent.  The retrofit path now rejects
+# identically; built-in BINARY/NOCASE/RTRIM retrofits still work.
 
 proc cksort {sql} {
   set ::sqlite_sort_count 0
@@ -565,5 +564,50 @@ do_test doltlite_recover_collation-11.15 {
 do_test doltlite_recover_collation-11.16 {
   execsql { SELECT count(*) FROM ct1 }
 } {0}
+
+#-------------------------------------------------------------------------
+# 12.* — #1343: column-level UNIQUE/PRIMARY KEY COLLATE <custom> must hit
+# the same rejection as CREATE INDEX instead of retrofitting the custom
+# collation onto the implicit autoindex.
+#
+db collate TEXT text_collate2
+proc text_collate2 {a b} { return [string compare $a $b] }
+do_test doltlite_recover_collation-12.1 {
+  catchsql {
+    CREATE TABLE rt1(a PRIMARY KEY COLLATE NOCASE, b UNIQUE COLLATE TEXT)
+  }
+} {1 {doltlite does not support indexes with custom collation 'TEXT'}}
+do_test doltlite_recover_collation-12.2 {
+  catchsql { CREATE TABLE rt2(a TEXT PRIMARY KEY COLLATE TEXT) }
+} {1 {doltlite does not support indexes with custom collation 'TEXT'}}
+do_test doltlite_recover_collation-12.3 {
+  catchsql { CREATE TABLE rt3(a PRIMARY KEY COLLATE TEXT, b) WITHOUT ROWID }
+} {1 {doltlite does not support indexes with custom collation 'TEXT'}}
+do_test doltlite_recover_collation-12.4 {
+  execsql {
+    SELECT name FROM sqlite_master WHERE name LIKE 'rt%' OR name LIKE '%autoindex%'
+  }
+} {}
+do_test doltlite_recover_collation-12.5 {
+  execsql {
+    CREATE TABLE rt4(a TEXT PRIMARY KEY COLLATE NOCASE, b UNIQUE COLLATE RTRIM,
+                     c UNIQUE COLLATE BINARY);
+    INSERT INTO rt4 VALUES('a','a ','a');
+    INSERT INTO rt4 VALUES('B','B','B');
+    SELECT a FROM rt4 ORDER BY a;
+  }
+} {a B}
+do_test doltlite_recover_collation-12.6 {
+  catchsql { INSERT INTO rt4 VALUES('x','a','y') }
+} {1 {UNIQUE constraint failed: rt4.b}}
+do_test doltlite_recover_collation-12.7 {
+  execsql {
+    CREATE TABLE rt5(c TEXT COLLATE TEXT);
+    INSERT INTO rt5 VALUES('z');
+  }
+  db close
+  sqlite3 db test.db
+  execsql { PRAGMA integrity_check }
+} {ok}
 
 finish_test

--- a/test/doltlite_recover_collation.test
+++ b/test/doltlite_recover_collation.test
@@ -17,7 +17,7 @@ source $testdir/tester.tcl
 # covers: collate4 collate4-1.1.0 — table with NOCASE+custom-TEXT columns; NOCASE index accepted (1.1), custom-TEXT index rejected verbatim (1.2)
 # covers: collate4 collate4-1.1.4 — ORDER BY custom-TEXT column returns binary order via registered collation, sorter not index (1.4)
 # covers: collate4 collate4-1.1.5 — ORDER BY b COLLATE TEXT same result through explicit custom collate (1.5)
-# covers: collate4 collate4-1.1.7 — column-level "b UNIQUE COLLATE TEXT" rejected verbatim since #1343 (12.1)
+# covers: collate4 collate4-1.1.7 — column-level "b UNIQUE COLLATE TEXT" rejected verbatim (12.1)
 # covers: collate4 collate4-1.1.8 — NOCASE PK iterates in case-insensitive order, nosort (1.8)
 # covers: collate4 collate4-1.1.9 — ORDER BY a COLLATE NOCASE == PK order, nosort (1.8)
 # covers: collate4 collate4-1.1.10 — binary (upstream TEXT) order over NOCASE PK needs a sort, correct result (1.9)
@@ -92,7 +92,7 @@ source $testdir/tester.tcl
 # covers: collate3 collate3-4.6 — explicit COLLATE-in-index form rejected before it can persist (11.3)
 # not-covered: (none)
 #
-# Section 12 pins the #1343 fix: "CREATE TABLE t(b UNIQUE COLLATE custom)"
+# Section 12 pins the custom-collation rejection: "CREATE TABLE t(b UNIQUE COLLATE custom)"
 # used to bypass the custom-collation index rejection because
 # sqlite3AddCollateType retrofitted the collation onto the already-created
 # implicit UNIQUE/PK autoindex without the DOLTLITE_PROLLY check that
@@ -566,7 +566,7 @@ do_test doltlite_recover_collation-11.16 {
 } {0}
 
 #-------------------------------------------------------------------------
-# 12.* — #1343: column-level UNIQUE/PRIMARY KEY COLLATE <custom> must hit
+# 12.* — column-level UNIQUE/PRIMARY KEY COLLATE <custom> must hit
 # the same rejection as CREATE INDEX instead of retrofitting the custom
 # collation onto the implicit autoindex.
 #

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -87,7 +87,7 @@ intpkey intpkey-1.1  # tests INTEGER vs INT primary key alias semantics
 collate1 collate1-6.7  # collation on the rowid column
 
 # ── collate4 ──
-collate4 collate4-1.1.7   # b UNIQUE COLLATE TEXT rejected since #1343 (was NULL-PK rejection)
+collate4 collate4-1.1.7   # b UNIQUE COLLATE TEXT now rejected at CREATE (was NULL-PK rejection)
 collate4 collate4-1.1.8
 collate4 collate4-1.1.9
 collate4 collate4-1.1.10
@@ -460,7 +460,7 @@ select9 select9-3.1    # depends on index dropped in select9-2.X
 select9 select9-4.1
 # Column-level "<col> PRIMARY KEY/UNIQUE COLLATE <custom>" used to bypass the
 # custom-collation index rejection because sqlite3AddCollateType retrofitted
-# the collation onto the already-created autoindex (#1343). The rejection now
+# the collation onto the already-created autoindex. The rejection now
 # fires there too, so CREATE TABLEs that upstream expects to succeed error
 # with "doltlite does not support indexes with custom collation", and their
 # downstream assertions fail on the missing table.

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -87,7 +87,7 @@ intpkey intpkey-1.1  # tests INTEGER vs INT primary key alias semantics
 collate1 collate1-6.7  # collation on the rowid column
 
 # ── collate4 ──
-collate4 collate4-1.1.7   # collation interacting with rowid ordering
+collate4 collate4-1.1.7   # b UNIQUE COLLATE TEXT rejected since #1343 (was NULL-PK rejection)
 collate4 collate4-1.1.8
 collate4 collate4-1.1.9
 collate4 collate4-1.1.10
@@ -458,6 +458,28 @@ select9 select9-2.1.1  # CREATE INDEX with COLLATE REVERSE
 select9 select9-2.X
 select9 select9-3.1    # depends on index dropped in select9-2.X
 select9 select9-4.1
+# Column-level "<col> PRIMARY KEY/UNIQUE COLLATE <custom>" used to bypass the
+# custom-collation index rejection because sqlite3AddCollateType retrofitted
+# the collation onto the already-created autoindex (#1343). The rejection now
+# fires there too, so CREATE TABLEs that upstream expects to succeed error
+# with "doltlite does not support indexes with custom collation", and their
+# downstream assertions fail on the missing table.
+collate1 collate1-6.5   # CREATE TABLE p1(a PRIMARY KEY COLLATE '"""') rejected
+collate1 collate1-6.6   # depends on p1/c1 from 6.5
+collate1 collate1-6.8   # depends on p1/c1 from 6.5
+without_rowid7 without_rowid7-3.0    # PRIMARY KEY COLLATE mysort rejected
+without_rowid7 without_rowid7-3.1.1  # depends on t1 from 3.0
+without_rowid7 without_rowid7-3.1.2
+without_rowid7 without_rowid7-3.2.1
+without_rowid7 without_rowid7-3.2.2
+without_rowid7 without_rowid7-3.3.1
+without_rowid7 without_rowid7-3.3.2
+without_rowid7 without_rowid7-3.4.1
+without_rowid7 without_rowid7-3.4.2
+without_rowid7 without_rowid7-3.5.1
+without_rowid7 without_rowid7-3.5.2
+without_rowid7 without_rowid7-3.6
+vacuum2 vacuum2-6.0  # PRIMARY KEY COLLATE cmp WITHOUT ROWID rejected
 
 # ---------------------------------------------------------------------------
 # Real-doltlite divergences surfaced when the amalgamation became genuine


### PR DESCRIPTION
Fixes #1343.

`sqlite3CreateIndex` rejects indexes that depend on custom collations on doltlite-format databases, but `sqlite3AddCollateType` retrofitted a custom collation onto the already-created implicit UNIQUE/PRIMARY KEY autoindex without that check. `CREATE TABLE t(b UNIQUE COLLATE <custom>)` therefore persisted a custom-collated index; after reopening without the collation registered, `PRAGMA integrity_check` fails with `no such collation sequence` — exactly the state the rejection exists to prevent.

## Fix

Apply the same rejection (same error message) in the retrofit loop in `sqlite3AddCollateType`, gated to doltlite-format Btrees via `sqlite3BtreeUsesOrig` so orig-format and stock temp/in-memory paths keep stock behavior. Built-in BINARY/NOCASE/RTRIM retrofits keep working. `sqlite3BtreeUsesOrig`'s declaration is widened to testfixture (`SQLITE_TEST`) builds; it was already compiled there.

## Fail-before / pass-after

Repro (tcl-registered `TEXT` collation, `CREATE TABLE t1(a PRIMARY KEY COLLATE NOCASE, b UNIQUE COLLATE TEXT)`, reopen without the collation):

Before:
```
! repro1343-1.1 expected: [1 {doltlite does not support indexes with custom collation 'TEXT'}]
! repro1343-1.1 got:      [0 {}]
! repro1343-1.2 got:      [0 sqlite_autoindex_t1_2]
! repro1343-1.3 expected: [0 ok]
! repro1343-1.3 got:      [1 {no such collation sequence: TEXT}]
3 errors out of 4 tests
```

After: `0 errors out of 4 tests`. The repro is pinned permanently as `doltlite_recover_collation-12.*`.

## Tests

- `test/doltlite_recover_collation.test`: SUSPECTED BUG header (which documented this bug) replaced with the fixed contract; new section 12 asserts the verbatim rejection for `UNIQUE COLLATE custom`, `PRIMARY KEY COLLATE custom` (rowid and WITHOUT ROWID), that no autoindex leaks, that BINARY/NOCASE/RTRIM retrofits still create working unique indexes, and that integrity_check stays ok across reopen. `0 errors out of 96 tests`.
- `test/known_testfixture_divergences.txt`: new entries only for the rejection class — upstream CREATE TABLEs that relied on the bypass now error, cascading to their dependents: `collate1-6.5/6.6/6.8`, `without_rowid7-3.0..3.6`, `vacuum2-6.0`. `collate4-1.1.7`'s comment updated (now fails at CREATE TABLE instead of the NULL-PK insert); no collate4 entries added or removed — its 51 known divergences all still fail and nothing new fails.

## Gate runs (docker, non-root `tester`, `DOLTLITE_PROLLY_CHECK=1` testfixture)

```
OK: collate1        (149 tests, 4 known divergences)
OK: collate3        (73 tests, 18 known divergences)
OK: collate4        (108 tests, 51 known divergences)
OK: without_rowid7  (22 tests, 13 known divergences)
OK: vacuum2         (31 tests, 14 known divergences)
OK: enc / select9 / window6 / windowE — unchanged
doltlite_recover_collation: 0 errors out of 96 tests
```

Note: `reindex.test` also uses the bypass construct (`a TEXT PRIMARY KEY COLLATE c1, b TEXT UNIQUE COLLATE c2`) and now hits the rejection, but it is not in any CI regression bucket (never swept in under #1208), so no divergence entries were added for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
