### PR TITLE
Make PRAGMA user_version (btree meta) transactional

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -333,6 +333,7 @@ struct Btree {
     ProllyHash rebaseOntoCommit;
     char *zRebaseOrigBranch;
     char *zRebaseReturnBranch;
+    u32 aMeta[16];
   } *aSavepointTables;
 
   ProllyHash committedCatalogHash;
@@ -341,6 +342,7 @@ struct Btree {
   ProllyHash committedMergeCommitHash;
   ProllyHash committedConflictsCatalogHash;
   ProllyHash committedConstraintViolationsHash;
+  u32 committedAMeta[16];
   ProllyHash catalogCacheHash;
   u8 *pCatalogCache;
   int nCatalogCache;
@@ -2513,6 +2515,13 @@ static int deserializeCatalog(Btree *pBtree, const u8 *data, int nData){
   memset(aMetaNew, 0, sizeof(aMetaNew));
   aMetaNew[BTREE_FILE_FORMAT] = 4;
   aMetaNew[BTREE_TEXT_ENCODING] = SQLITE_UTF8;
+  /* Session-scoped meta is not stored in the catalog; a reload must not
+  ** zero it (user_version was lost on any commit that reloaded the
+  ** catalog, #1344). */
+  aMetaNew[BTREE_DEFAULT_CACHE_SIZE] = pBtree->aMeta[BTREE_DEFAULT_CACHE_SIZE];
+  aMetaNew[BTREE_USER_VERSION] = pBtree->aMeta[BTREE_USER_VERSION];
+  aMetaNew[BTREE_INCR_VACUUM] = pBtree->aMeta[BTREE_INCR_VACUUM];
+  aMetaNew[BTREE_APPLICATION_ID] = pBtree->aMeta[BTREE_APPLICATION_ID];
 
   {
     ProllyHash h;
@@ -3355,6 +3364,7 @@ static void captureSavepointSessionState(
 ){
   pState->iNextTable = pBtree->cat.iNextTable;
   pState->iLargestRootPage = pBtree->aMeta[BTREE_LARGEST_ROOT_PAGE];
+  memcpy(pState->aMeta, pBtree->aMeta, sizeof(pState->aMeta));
   pState->stagedCatalog = pBtree->stagedCatalog;
   pState->isMerging = pBtree->isMerging;
   pState->mergeCommitHash = pBtree->mergeCommitHash;
@@ -3380,6 +3390,7 @@ static void restoreSavepointSessionState(
   pBtree->mergeCommitHash = pState->mergeCommitHash;
   pBtree->conflictsCatalogHash = pState->conflictsCatalogHash;
   pBtree->constraintViolationsHash = pState->constraintViolationsHash;
+  memcpy(pBtree->aMeta, pState->aMeta, sizeof(pBtree->aMeta));
   pBtree->aMeta[BTREE_LARGEST_ROOT_PAGE] = pState->iLargestRootPage;
   pBtree->isRebasing = pState->isRebasing;
   pBtree->preRebaseWorkingCat = pState->preRebaseWorkingCat;
@@ -5130,6 +5141,7 @@ static void btreeStoreCommittedFromCurrent(Btree *p, const ProllyHash *pCatHash)
   p->committedMergeCommitHash = p->mergeCommitHash;
   p->committedConflictsCatalogHash = p->conflictsCatalogHash;
   p->committedConstraintViolationsHash = p->constraintViolationsHash;
+  memcpy(p->committedAMeta, p->aMeta, sizeof(p->committedAMeta));
 }
 
 static void btreeBumpDataVersion(Btree *p){
@@ -5403,6 +5415,7 @@ static int prollyBtreeCommitPhaseTwo(Btree *p, int bCleanup){
       p->committedMergeCommitHash = p->mergeCommitHash;
       p->committedConflictsCatalogHash = p->conflictsCatalogHash;
       p->committedConstraintViolationsHash = p->constraintViolationsHash;
+      memcpy(p->committedAMeta, p->aMeta, sizeof(p->committedAMeta));
       btreeMarkWorkingStateChanged(p);
       if( bReloadSchema ){
         BtCursor *pC;
@@ -5559,6 +5572,7 @@ static int restoreFromCommitted(Btree *p){
       memset(&loadedCatHash, 0, sizeof(loadedCatHash));
       rc = btreeReloadBranchWorkingStateInto(p, 1, &loadedCatHash);
       if( rc!=SQLITE_OK ) return rc;
+      memcpy(p->aMeta, p->committedAMeta, sizeof(p->aMeta));
       btreeStoreCommittedFromCurrent(p, &loadedCatHash);
       p->bCatalogDropped = 0;
       return SQLITE_OK;
@@ -5657,6 +5671,7 @@ static int restoreFromCommitted(Btree *p){
   p->mergeCommitHash = p->committedMergeCommitHash;
   p->conflictsCatalogHash = p->committedConflictsCatalogHash;
   p->constraintViolationsHash = p->committedConstraintViolationsHash;
+  memcpy(p->aMeta, p->committedAMeta, sizeof(p->aMeta));
   return SQLITE_OK;
 }
 
@@ -6273,7 +6288,10 @@ static int prollyBtreeUpdateMeta(Btree *p, int idx, u32 value){
   }
 
   {
-    int rc = ensureStatementSavepointsCaptured(p);
+    /* Btree savepoints push lazily at write time; a meta write is a write,
+    ** so push them here or ROLLBACK TO cannot restore the old value. */
+    int rc = syncBtreeSavepoints(p);
+    if( rc==SQLITE_OK ) rc = ensureStatementSavepointsCaptured(p);
     if( rc!=SQLITE_OK ) return rc;
   }
 

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -2517,7 +2517,7 @@ static int deserializeCatalog(Btree *pBtree, const u8 *data, int nData){
   aMetaNew[BTREE_TEXT_ENCODING] = SQLITE_UTF8;
   /* Session-scoped meta is not stored in the catalog; a reload must not
   ** zero it (user_version was lost on any commit that reloaded the
-  ** catalog, #1344). */
+  ** catalog). */
   aMetaNew[BTREE_DEFAULT_CACHE_SIZE] = pBtree->aMeta[BTREE_DEFAULT_CACHE_SIZE];
   aMetaNew[BTREE_USER_VERSION] = pBtree->aMeta[BTREE_USER_VERSION];
   aMetaNew[BTREE_INCR_VACUUM] = pBtree->aMeta[BTREE_INCR_VACUUM];

--- a/test/doltlite_recover_pragma_output.test
+++ b/test/doltlite_recover_pragma_output.test
@@ -59,7 +59,12 @@ source $testdir/tester.tcl
 # covers: pragma pragma-8.2.4.2 — VACUUM preserves user_version 2, stock-identical (5.8)
 # covers: pragma pragma-8.2.4.3 — doltlite contract: VACUUM is a no-op, schema_version unchanged (5.8)
 # covers: pragma pragma-8.2.8 — main.user_version independent of aux.user_version (6.1)
-# covers: pragma pragma-8.2.3.2 — doltlite contract: user_version is session scoped, reopen reads 0 (6.2)
+# covers: pragma pragma-8.2.9 — user_version set inside a txn on main and aux (6.2)
+# covers: pragma pragma-8.2.10 — in-txn aux.user_version reads back 10 (6.2)
+# covers: pragma pragma-8.2.11 — in-txn main.user_version reads back 11 (6.2)
+# covers: pragma pragma-8.2.12 — ROLLBACK restores aux.user_version to 3 (6.3)
+# covers: pragma pragma-8.2.13 — ROLLBACK restores main.user_version to 2 (6.3)
+# covers: pragma pragma-8.2.3.2 — doltlite contract: user_version is session scoped, reopen reads 0 (6.6)
 # covers: pragma pragma-14.1 — fresh db reports synthetic page_count {4 4} (7.1)
 # covers: pragma pragma-14.2 — CREATE TABLE grows page_count; temp.page_count 0 (7.2)
 # covers: pragma pragma-14.2uc — uppercase PAGE_COUNT matches (7.3)
@@ -91,13 +96,6 @@ source $testdir/tester.tcl
 # covers: multiplex4 multiplex4-1.2 — PRAGMA multiplex_truncate is a no-op returning nothing (11.4)
 # covers: multiplex4 multiplex4-1.10 — growing data never spawns numbered overflow files (11.2)
 # covers: multiplex4 multiplex4-1.11 — DELETE+VACUUM keeps the single-file layout and data readable (11.3)
-# not-covered: pragma pragma-8.2.12 — SUSPECTED BUG: PRAGMA user_version set inside a
-#   transaction is not undone by ROLLBACK for attached dbs (aux stays 10 instead of
-#   reverting to 3), and main reverts only sometimes depending on prior connection
-#   state; behavior is nondeterministic so it cannot be asserted
-# not-covered: pragma pragma-8.2.13 — SUSPECTED BUG: same ROLLBACK scenario, post-rollback
-#   main.user_version is inconsistent across runs (observed both 0 and 11 for the same
-#   script shape)
 
 #-----------------------------------------------------------------------
 # 1: cache_size / default_cache_size / synchronous session contract
@@ -384,7 +382,7 @@ do_test doltlite_recover_pragma_output-5.8 {
 } {1 1 2}
 
 #-----------------------------------------------------------------------
-# 6: user_version is per-database and session scoped
+# 6: user_version is per-database, transactional, and session scoped
 #
 do_test doltlite_recover_pragma_output-6.1 {
   execsql {
@@ -395,6 +393,38 @@ do_test doltlite_recover_pragma_output-6.1 {
   }
 } {0 3 2}
 do_test doltlite_recover_pragma_output-6.2 {
+  execsql {
+    BEGIN;
+    PRAGMA aux.user_version=10;
+    PRAGMA user_version=11;
+    PRAGMA aux.user_version;
+    PRAGMA main.user_version;
+  }
+} {10 11}
+do_test doltlite_recover_pragma_output-6.3 {
+  execsql {
+    ROLLBACK;
+    PRAGMA aux.user_version;
+    PRAGMA main.user_version;
+  }
+} {3 2}
+do_test doltlite_recover_pragma_output-6.4 {
+  execsql {
+    BEGIN;
+    PRAGMA user_version=6;
+    SAVEPOINT sp;
+    PRAGMA user_version=10;
+    ROLLBACK TO sp;
+    PRAGMA user_version;
+  }
+} {6}
+do_test doltlite_recover_pragma_output-6.5 {
+  execsql {
+    COMMIT;
+    PRAGMA user_version;
+  }
+} {6}
+do_test doltlite_recover_pragma_output-6.6 {
   execsql {DETACH aux}
   db close
   sqlite3 db test.db

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -266,7 +266,6 @@ pragma pragma-8.1.3
 pragma pragma-8.1.4
 pragma pragma-8.1.6
 pragma pragma-8.1.9
-pragma pragma-8.2.12
 pragma pragma-8.2.13
 pragma pragma-8.2.3.2
 pragma pragma-8.2.4.1


### PR DESCRIPTION
Fixes #1344.

`PRAGMA user_version` writes inside `BEGIN...ROLLBACK` were not transactional: attached-db changes survived the rollback, and main-db rollback was nondeterministic — a full catalog reload reset it to 0 (deserializeCatalog zeroed the slot), while the catalog-cache fast path left the in-txn value in place. Stock rolls both back.

## Fix

`Btree.aMeta` now participates in the transaction lifecycle, scoped tightly to meta capture/restore (no savepoint/rollback control flow touched, to stay out of the way of the concurrent #1340 work):

- `committedAMeta` snapshots `aMeta` wherever the committed catalog state is captured (`btreeStoreCommittedFromCurrent`, commit phase two); `restoreFromCommitted()` restores it on rollback.
- Savepoints capture `aMeta` in `captureSavepointSessionState` and restore it in `restoreSavepointSessionState`; `prollyBtreeUpdateMeta` pushes lazy btree savepoints first (a meta write is a write), so `ROLLBACK TO` restores meta written after the savepoint.
- `deserializeCatalog` no longer zeroes session-scoped slots (user_version, application_id, default_cache_size, incr_vacuum) — this also lost user_version on any commit whose catalog reload ran (e.g. DDL in the txn).

## Fail-before / pass-after

Issue repro (`ATTACH aux; user_version=2; aux.user_version=3; BEGIN; aux=10; main=11; ROLLBACK`):

| read | before | after | stock |
|---|---|---|---|
| main | 11 | 2 | 2 |
| aux | 10 | 3 | 3 |

Spec script run on a stock-format file through the same testfixture (orig engine) confirms the expected values; doltlite-format before/after: DDL-commit kept user_version 0→5, `ROLLBACK TO sp` 10→6, sp-only rollback 20→6 — all now stock-identical. Session-scoped reopen contract (reads 0) unchanged.

## Tests

- `doltlite_recover_pragma_output.test`: header bug notes replaced with covers entries; new 6.2–6.5 pin ROLLBACK restore (main+aux), `ROLLBACK TO` restore, and COMMIT persistence. `0 errors out of 72 tests`.
- Gated suites (run_testfixture.sh, non-root): `OK: pragma (234 tests, 74 known divergences)`, `OK: pragma2 (27 tests, 16 known divergences)`, `OK: attach (113 tests, 8 known divergences)`. Removed now-passing `pragma pragma-8.2.12` from the divergence list. `pragma-8.2.13` stays gated: it now deterministically reads 0 because the session's pre-txn value is 0 after the 8.2.3 reopen (the session-scoped 8.2.3.2 divergence), not a rollback failure.
- Full core-sql regression bucket: 332707 passing, 700 known divergences, 0 unexpected.
- Shell suites (`test/run_doltlite_tests.sh`): all pass with python3/bc/sqlite3/libdoltlite.a present, including `doltlite_regression_test_c` (309807/309807).
- avtrans/trans2 (not CI-gated) fail identically on master and this branch — pre-existing, untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)