### PR TITLE
Gate fast formerly slow testfixtures

### DIFF
--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -63,6 +63,64 @@ index index-16.4  # explicit rowid reference
 index index-16.5  # explicit rowid reference
 index index-17.1  # rowid-order assumption
 
+# ── bestindex4 ──
+bestindex4 bestindex4-2.1  # EQP names the table PRIMARY KEY instead of sqlite_autoindex_t1_1
+
+# ── avtrans ──
+# avtrans is trans.test under auto_vacuum=full. DoltLite intentionally rejects
+# auto_vacuum on prolly-format databases, so the first setup block runs in
+# normal mode and cascades into schema/content/checksum differences.
+avtrans avtrans-1.0
+avtrans avtrans-1.0.1
+avtrans avtrans-1.9
+avtrans avtrans-2.10
+avtrans avtrans-3.1
+avtrans avtrans-3.3
+avtrans avtrans-3.4
+avtrans avtrans-3.6
+avtrans avtrans-3.9
+avtrans avtrans-3.12
+avtrans avtrans-3.14
+avtrans avtrans-4.5
+avtrans avtrans-4.8
+avtrans avtrans-4.11
+avtrans avtrans-4.98
+avtrans avtrans-5.1
+avtrans avtrans-5.2
+avtrans avtrans-5.3
+avtrans avtrans-5.6
+avtrans avtrans-5.8
+avtrans avtrans-5.9
+avtrans avtrans-5.10
+avtrans avtrans-5.11
+avtrans avtrans-5.12
+avtrans avtrans-5.13
+avtrans avtrans-5.14
+avtrans avtrans-5.15
+avtrans avtrans-5.16
+avtrans avtrans-5.17
+avtrans avtrans-5.20
+avtrans avtrans-5.22
+avtrans avtrans-9.2.5-1024
+avtrans avtrans-9.4.5-1224
+avtrans avtrans-9.6.5-1480
+avtrans avtrans-9.8.5-1766
+avtrans avtrans-9.10.5-2112
+avtrans avtrans-9.12.5-2544
+avtrans avtrans-9.14.5-3089
+avtrans avtrans-9.16.5-3802
+avtrans avtrans-9.18.5-4593
+avtrans avtrans-9.20.5-5551
+avtrans avtrans-9.22.5-6736
+avtrans avtrans-9.24.5-8156
+avtrans avtrans-9.26.5-9897
+avtrans avtrans-9.28.5-11982
+avtrans avtrans-9.30.5-14544
+avtrans avtrans-9.32.5-17576
+avtrans avtrans-9.34.5-21225
+avtrans avtrans-9.36.5-25685
+avtrans avtrans-9.38.5-30883
+
 # ── alter ──
 alter alter-1.2  # ALTER TABLE rowid-preservation semantics
 alter alter-1.5  # ALTER TABLE rowid-preservation semantics

--- a/test/regression-buckets/core-sql.txt
+++ b/test/regression-buckets/core-sql.txt
@@ -16,6 +16,7 @@ basexx1
 bestindex1
 bestindex2
 bestindex3
+bestindex4
 bestindex5
 bestindex6
 bestindex7

--- a/test/regression-buckets/fault-fuzz.txt
+++ b/test/regression-buckets/fault-fuzz.txt
@@ -5,6 +5,7 @@ autovacuum_ioerr2
 backup_malloc
 carrayfault
 cffault
+checkfault
 default
 exprfault
 exprfault2

--- a/test/regression-buckets/storage.txt
+++ b/test/regression-buckets/storage.txt
@@ -1,6 +1,7 @@
 atomic
 atomic2
 autovacuum2
+avtrans
 backup2
 backup4
 backup5


### PR DESCRIPTION
## Summary
- add `checkfault`, `bestindex4`, and `avtrans` to the existing SQLite regression buckets
- record the `bestindex4` EQP naming divergence
- record the `avtrans` auto-vacuum cascade divergences so the file is now gated instead of excluded

## Local timing notes
Measured with the newest existing local testfixture available on this machine (`build-fts3-shadow-fix/testfixture`). A fresh `DOLTLITE_PROLLY_CHECK=1 testfixture` rebuild failed locally because this checkout is missing `libtommath`, so CI remains the authoritative measurement.

Current-timeout candidates from the slow list:
- `checkfault`: 0.025s, clean
- `avtrans`: 3.045s, 50 known divergences
- `bestindex4`: 0.157s, 1 known divergence
- `misc7`: exceeded 300s; not added
- `sqllimits1`: hit 300s timeout; not added
- `tkt2686`: hit 300s timeout; not added

## Verification
- bucket disjointness check
- isolated `run_testfixture.sh` probes for `checkfault`, `bestindex4`, and `avtrans`
- neighboring-file bucket slices for core-sql, fault-fuzz, and storage
