### PR TITLE
Uniform journal_mode rejection on attached dbs; fix six error-surface gaps

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -346,7 +346,8 @@ int chunkStoreOpen(
   cs->lockDepth = 0;
 
   if( zFilename==0 || zFilename[0]=='\0'
-   || strcmp(zFilename, ":memory:")==0 ){
+   || strcmp(zFilename, ":memory:")==0
+   || (flags & SQLITE_OPEN_MEMORY)!=0 ){
     cs->isMemory = 1;
     cs->file.zFilename = sqlite3_mprintf(":memory:");
     if( cs->file.zFilename==0 ){
@@ -359,6 +360,15 @@ int chunkStoreOpen(
     cs->wal.iWalOffset = CHUNK_MANIFEST_SIZE;
     cs->file.pFile = 0;
     return SQLITE_OK;
+  }
+
+  /* A file-backed chunk store needs the full VFS file API (the GC's
+  ** atomic-replace deletes files, lock refresh probes HAS_MOVED). VFSes
+  ** without xDelete, like memdb, would half-open: the open succeeds but
+  ** every statement fails. Fail the open instead. */
+  if( pVfs->xDelete==0 ){
+    chunkStoreClose(cs);
+    return SQLITE_CANTOPEN;
   }
 
   rc = csCanonicalFilename(pVfs, zFilename, &cs->file.zFilename);

--- a/src/main.c
+++ b/src/main.c
@@ -1023,6 +1023,18 @@ int sqlite3_db_config(sqlite3 *db, int op, ...){
           int onoff = va_arg(ap, int);
           int *pRes = va_arg(ap, int*);
           u64 oldFlags = db->flags;
+#ifdef DOLTLITE_PROLLY
+          /* VACUUM does not implement the reset for doltlite-format
+          ** databases, so enabling the flag would silently no-op.
+          ** Refuse it instead of pretending the next VACUUM will reset. */
+          if( op==SQLITE_DBCONFIG_RESET_DATABASE && onoff>0
+           && sqlite3BtreeIsDoltliteFormat(db->aDb[0].pBt)
+          ){
+            if( pRes ) *pRes = 0;
+            rc = SQLITE_ERROR;
+            break;
+          }
+#endif
           if( onoff>0 ){
             db->flags |= aFlagOp[i].mask;
           }else if( onoff==0 ){

--- a/src/pager_shim.c
+++ b/src/pager_shim.c
@@ -926,14 +926,34 @@ sqlite3_backup *sqlite3_backup_init(sqlite3 *pDest, const char *zDestDb,
   ChunkStore *destCs;
   int iSrc, iDest;
 
-  if( !pDest || !pSrc || pDest==pSrc ) return 0;
+  if( !pDest || !pSrc ) return 0;
+  if( pDest==pSrc ){
+    sqlite3ErrorWithMsg(pDest, SQLITE_ERROR,
+                        "source and destination must be distinct");
+    return 0;
+  }
 
   iSrc = sqlite3FindDbName(pSrc, zSrcDb);
   iDest = sqlite3FindDbName(pDest, zDestDb);
-  if( iSrc < 0 || iDest < 0 ) return 0;
+  if( iSrc < 0 || iDest < 0 ){
+    sqlite3ErrorWithMsg(pDest, SQLITE_ERROR, "unknown database %s",
+                        iSrc<0 ? zSrcDb : zDestDb);
+    return 0;
+  }
 
   if( iSrc != 0 || iDest != 0 ){
-    return orig_sqlite3_backup_init(pDest, zDestDb, pSrc, zSrcDb);
+    /* The original backup engine can only run when neither side is a
+    ** doltlite-format btree; otherwise it would push SQLite pages through
+    ** the prolly pager shim. */
+    if( !sqlite3BtreeIsDoltliteFormat(pSrc->aDb[iSrc].pBt)
+     && !sqlite3BtreeIsDoltliteFormat(pDest->aDb[iDest].pBt)
+    ){
+      return orig_sqlite3_backup_init(pDest, zDestDb, pSrc, zSrcDb);
+    }
+    sqlite3ErrorWithMsg(pDest, SQLITE_ERROR,
+        "backup of non-main databases is not supported on doltlite-format "
+        "databases");
+    return 0;
   }
 
   srcCs = doltliteGetChunkStore(pSrc);

--- a/src/pager_shim.c
+++ b/src/pager_shim.c
@@ -379,7 +379,7 @@ static int shimPagerCheckpoint(Pager *p, sqlite3 *db, int eMode,
   return SQLITE_OK;
 }
 static int shimPagerWalSupported(Pager *p){
-  (void)p; return 1;
+  return !shimPagerIsMemdb(p);
 }
 static int shimPagerOpenWal(Pager *p, int *pisOpen){
   if( !shimPagerIsMemdb(p) ){

--- a/src/pragma.c
+++ b/src/pragma.c
@@ -858,6 +858,13 @@ void sqlite3Pragma(
 #ifndef SQLITE_OMIT_AUTOVACUUM
   case PragTyp_INCREMENTAL_VACUUM: {
     int iLimit = 0, addr;
+#ifdef DOLTLITE_PROLLY
+    if( sqlite3BtreeIsDoltliteFormat(pDb->pBt) ){
+      sqlite3ErrorMsg(pParse,
+        "incremental_vacuum is not supported on doltlite-format databases");
+      goto pragma_out;
+    }
+#endif
     if( zRight==0 || !sqlite3GetInt32(zRight, &iLimit) || iLimit<=0 ){
       iLimit = 0x7fffffff;
     }

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -4598,7 +4598,9 @@ int sqlite3BtreeSetPagerFlags(Btree *p, unsigned pgFlags){
 
 static int prollyBtreeSetPageSize(Btree *p, int nPagesize, int nReserve, int eFix){
   (void)nReserve; (void)eFix;
-  if( nPagesize>=512 && nPagesize<=65536 ){
+  /* Same validation as the stock btree: ignore values that are not a power
+  ** of two in [512,65536]. The value is layout-inert either way. */
+  if( nPagesize>=512 && nPagesize<=65536 && ((nPagesize-1)&nPagesize)==0 ){
     p->pBt->pageSize = (u32)nPagesize;
   }
   return SQLITE_OK;

--- a/src/vdbe.c
+++ b/src/vdbe.c
@@ -8513,10 +8513,20 @@ case OP_JournalMode: {    /* out2 */
 
 #ifdef DOLTLITE_PROLLY
   if( eNew!=eOld && sqlite3BtreeIsDoltliteFormat(pBt) ){
-    rc = SQLITE_ERROR;
-    sqlite3VdbeError(p,
-      "journal_mode is not configurable on doltlite-format databases");
-    goto abort_due_to_error;
+#ifndef SQLITE_OMIT_WAL
+    if( eNew==PAGER_JOURNALMODE_WAL && !sqlite3PagerWalSupported(pPager) ){
+      /* Stock treats a wal request on a db that cannot support WAL (e.g. an
+      ** in-memory db) as a no-op rather than an error; match that so main
+      ** and attached doltlite dbs behave identically. */
+      eNew = eOld;
+    }else
+#endif
+    {
+      rc = SQLITE_ERROR;
+      sqlite3VdbeError(p,
+        "journal_mode is not configurable on doltlite-format databases");
+      goto abort_due_to_error;
+    }
   }
 #endif
 

--- a/test/doltlite_recover_jrnlwal_2.test
+++ b/test/doltlite_recover_jrnlwal_2.test
@@ -735,7 +735,7 @@ do_test doltlite_recover_jrnlwal_2-13.1 {
 } {1 {auto_vacuum is not supported on doltlite-format databases}}
 do_test doltlite_recover_jrnlwal_2-13.2 {
   catchsql {PRAGMA incremental_vacuum(4)} dbm
-} {1 {SQL logic error}}
+} {1 {incremental_vacuum is not supported on doltlite-format databases}}
 do_test doltlite_recover_jrnlwal_2-13.3 {
   execsql {
     CREATE TABLE v1(k INTEGER PRIMARY KEY, x);

--- a/test/doltlite_recover_jrnlwal_3.test
+++ b/test/doltlite_recover_jrnlwal_3.test
@@ -345,10 +345,10 @@ do_catchsql_test doltlite_recover_jrnlwal_3-1.11 {
 } {1 {auto_vacuum is not supported on doltlite-format databases}}
 do_catchsql_test doltlite_recover_jrnlwal_3-1.12 {
   PRAGMA incremental_vacuum;
-} {1 {SQL logic error}}
+} {1 {incremental_vacuum is not supported on doltlite-format databases}}
 do_catchsql_test doltlite_recover_jrnlwal_3-1.13 {
   PRAGMA incremental_vacuum(5);
-} {1 {SQL logic error}}
+} {1 {incremental_vacuum is not supported on doltlite-format databases}}
 do_execsql_test doltlite_recover_jrnlwal_3-1.14 {
   PRAGMA incr_vacuum;
 } {}
@@ -772,7 +772,7 @@ do_test doltlite_recover_jrnlwal_3-7.1 {
   list [catchsql {PRAGMA incremental_vacuum(1)}] \
        [execsql {SELECT count(*) FROM iv}] \
        [execsql {PRAGMA integrity_check}]
-} {{1 {SQL logic error}} 0 ok}
+} {{1 {incremental_vacuum is not supported on doltlite-format databases}} 0 ok}
 do_test doltlite_recover_jrnlwal_3-7.2 {
   forcedelete test2.db test2.db-wal
   execsql {
@@ -785,7 +785,7 @@ do_test doltlite_recover_jrnlwal_3-7.2 {
   }
   list [catchsql {PRAGMA aux.incremental_vacuum(1)}] \
        [execsql {SELECT count(*) FROM iv; SELECT count(*) FROM aux.iv2}]
-} {{1 {SQL logic error}} {0 0}}
+} {{1 {incremental_vacuum is not supported on doltlite-format databases}} {0 0}}
 do_test doltlite_recover_jrnlwal_3-7.3 {
   execsql { DETACH aux }
   execsql {

--- a/test/doltlite_recover_jrnlwal_4.test
+++ b/test/doltlite_recover_jrnlwal_4.test
@@ -683,7 +683,7 @@ do_test doltlite_recover_jrnlwal_4-10.4 {
 do_test doltlite_recover_jrnlwal_4-10.5 {
   list [catchsql {PRAGMA incremental_vacuum}] \
        [execsql {SELECT count(*) FROM t1}]
-} {{1 {SQL logic error}} 5}
+} {{1 {incremental_vacuum is not supported on doltlite-format databases}} 5}
 do_execsql_test doltlite_recover_jrnlwal_4-10.6 {
   PRAGMA cache_size = 1;
   CREATE TABLE abc(a, b, c);

--- a/test/doltlite_recover_jrnlwal_4.test
+++ b/test/doltlite_recover_jrnlwal_4.test
@@ -182,7 +182,7 @@ source $testdir/tester.tcl
 # covers: walmode walmode-4.16 — every connection reports wal; concurrent second connection reads fine (1.12,1.13,4.1)
 # covers: walmode walmode-4.17 — every connection reports wal; concurrent second connection reads fine (1.12,1.13,4.1)
 # covers: walmode walmode-4.18 — every connection reports wal; concurrent second connection reads fine (1.12,1.13,4.1)
-# covers: walmode walmode-5.1.2 — :memory: db cannot become wal: setter errors, stays memory, db usable (8.1,8.2)
+# covers: walmode walmode-5.1.2 — :memory: db cannot become wal: setter no-ops like stock, stays memory, db usable (8.1,8.2)
 # covers: walmode walmode-5.1.4 — :memory: db cannot become wal: setter errors, stays memory, db usable (8.1,8.2)
 # covers: walmode walmode-6.1 — per-mode-to-wal loop collapses: =wal echoes wal, other modes rejected (1.8,1.3-1.7)
 # covers: walmode walmode-6.2 — per-mode-to-wal loop collapses: =wal echoes wal, other modes rejected (1.8,1.3-1.7)
@@ -575,8 +575,9 @@ do_test doltlite_recover_jrnlwal_4-7.9 {
 do_test doltlite_recover_jrnlwal_4-8.1 {
   sqlite3 db3 :memory:
   list [execsql {PRAGMA main.journal_mode} db3] \
-       [catchsql {PRAGMA main.journal_mode = wal} db3]
-} [list memory [list 1 $JM_ERR]]
+       [catchsql {PRAGMA main.journal_mode = wal} db3] \
+       [catchsql {PRAGMA main.journal_mode = delete} db3]
+} [list memory {0 memory} [list 1 $JM_ERR]]
 do_test doltlite_recover_jrnlwal_4-8.2 {
   execsql {
     CREATE TABLE m(x);

--- a/test/doltlite_recover_locking_2.test
+++ b/test/doltlite_recover_locking_2.test
@@ -77,7 +77,7 @@ source $testdir/tester.tcl
 # covers: pragma2 pragma2-4.8 — cache_spill=ON accepted, reads 0; no exclusive lock state (8.14)
 # covers: pragma2 pragma2-5.1 — fresh db: page_size+cache_size+cache_spill=YES accepted, cache_spill reads 0 (8.16)
 # covers: pragma2 pragma2-5.3 — cache_spill(-51) accepted, reads 0 (8.16)
-# covers: memdb2 memdb2-1.1.1 — two-connection shared-db scenario recast on doltlite's shared surface (a db file); memdb VFS statements are unsupported (9.1)
+# covers: memdb2 memdb2-1.1.1 — two-connection shared-db scenario recast on doltlite's shared surface (a db file); the memdb VFS cannot back a chunk store so the open is refused outright (9.0, 9.1)
 # covers: memdb2 memdb2-1.1.2 — reader opens txn, sees initial rows (9.1)
 # covers: memdb2 memdb2-1.1.3 — writer opens txn + insert while reader open (9.2)
 # covers: memdb2 memdb2-1.1.4 — writer COMMIT succeeds instead of "database is locked" (9.3)
@@ -461,6 +461,13 @@ do_test doltlite_recover_locking_2-8.16 {
 #-------------------------------------------------------------------------
 # 9.* memdb2 recast: writer COMMIT not blocked by reader holding SHARED.
 #
+# The memdb VFS has no xDelete, which the chunk store requires; the open is
+# refused instead of half-opening a connection whose statements all fail
+# 'unknown operation'.
+do_test doltlite_recover_locking_2-9.0 {
+  list [catch {sqlite3 dbmem file:/x.db?vfs=memdb -uri 1} msg] $msg
+} {1 {unable to open database file}}
+
 do_test doltlite_recover_locking_2-9.1 {
   execsql {CREATE TABLE m(x, y); INSERT INTO m VALUES(1, 2);}
   execsql {BEGIN; SELECT * FROM m;} db2

--- a/test/doltlite_recover_rawformat_2.test
+++ b/test/doltlite_recover_rawformat_2.test
@@ -194,7 +194,7 @@ do_test doltlite_recover_rawformat_2-1.3 {
   execsql {PRAGMA page_size=65537}
   set c [execsql {PRAGMA page_size}]
   list $a $b $c
-} {2048 1234 1234}
+} {2048 2048 2048}
 
 do_test doltlite_recover_rawformat_2-1.4 {
   set h0 [db one {SELECT dolt_hashof_table('t1')}]
@@ -606,10 +606,10 @@ do_test doltlite_recover_rawformat_2-6.3 {
 } {16 1 ok}
 
 do_test doltlite_recover_rawformat_2-6.4 {
-  set r1 [catch {db restore temp rf2bu1.db}]
-  set r2 [catch {db backup temp rf2bu2.db}]
-  list $r1 $r2 [execsql {SELECT count(*) FROM t2}]
-} {1 1 16}
+  set r1 [catch {db restore temp rf2bu1.db} m1]
+  set r2 [catch {db backup temp rf2bu2.db} m2]
+  list $r1 $m1 $r2 $m2 [execsql {SELECT count(*) FROM t2}]
+} {1 {restore failed: backup of non-main databases is not supported on doltlite-format databases} 1 {backup failed: backup of non-main databases is not supported on doltlite-format databases} 16}
 
 do_test doltlite_recover_rawformat_2-6.5 {
   rf2_garbage_file rf2bug.db "This is not a valid database file"
@@ -618,9 +618,9 @@ do_test doltlite_recover_rawformat_2-6.5 {
 } {1 {cannot open target database: disk I/O error} 16}
 
 do_test doltlite_recover_rawformat_2-6.6 {
-  set rc [catch {db backup aux1 rf2bu3.db}]
-  list $rc [execsql {SELECT count(*) FROM t2}]
-} {1 16}
+  set rc [catch {db backup aux1 rf2bu3.db} msg]
+  list $rc $msg [execsql {SELECT count(*) FROM t2}]
+} {1 {backup failed: unknown database aux1} 16}
 
 do_test doltlite_recover_rawformat_2-6.7 {
   set rc [catch {db restore rf2bug.db} msg]
@@ -628,9 +628,9 @@ do_test doltlite_recover_rawformat_2-6.7 {
 } {1 {cannot open source database: disk I/O error} 16}
 
 do_test doltlite_recover_rawformat_2-6.8 {
-  set rc [catch {db restore aux1 rf2bu1.db}]
-  list $rc [execsql {SELECT count(*) FROM t2}]
-} {1 16}
+  set rc [catch {db restore aux1 rf2bu1.db} msg]
+  list $rc $msg [execsql {SELECT count(*) FROM t2}]
+} {1 {restore failed: unknown database aux1} 16}
 
 do_test doltlite_recover_rawformat_2-6.9 {
   sqlite3 dbm :memory:

--- a/test/doltlite_recover_rawformat_2.test
+++ b/test/doltlite_recover_rawformat_2.test
@@ -283,6 +283,14 @@ do_test doltlite_recover_rawformat_2-3.1 {
   catchsql {PRAGMA main.journal_mode = delete}
 } {1 {journal_mode is not configurable on doltlite-format databases}}
 
+# The rejection applies identically to the attached db, and a wal request
+# (already the reported mode) is an accepted no-op on both.
+do_test doltlite_recover_rawformat_2-3.1b {
+  list [catchsql {PRAGMA aux.journal_mode = delete}] \
+      [execsql {PRAGMA main.journal_mode = wal}] \
+      [execsql {PRAGMA aux.journal_mode = wal}]
+} {{1 {journal_mode is not configurable on doltlite-format databases}} wal wal}
+
 do_test doltlite_recover_rawformat_2-3.2 {
   execsql {
     BEGIN;

--- a/test/doltlite_recover_rawformat_3.test
+++ b/test/doltlite_recover_rawformat_3.test
@@ -81,9 +81,9 @@ source $testdir/tester.tcl
 #   modified') so the db is NEVER corrupted: quick_check ok on both
 #   connections afterwards (5.4, 5.5)
 # covers-class: resetdb resetdb-{210,400,500,740} (4 entries): RESET_DB
-#   dbconfig is accepted and VACUUM under it succeeds; since no corruption is
-#   possible the db stays intact and both connections agree on content and
-#   quick_check (doltlite's current no-reset contract, see suspected bug note)
+#   dbconfig is refused on doltlite-format dbs (no silent no-op) and VACUUM
+#   still succeeds; since no corruption is possible the db stays intact and
+#   both connections agree on content and quick_check (see feature-gap note)
 #   (5.6)
 # covers-class: resetdb resetdb-{300,310} (2 entries): journal_mode reports
 #   'wal' on both connections; setting WAL is accepted (already wal) and
@@ -170,16 +170,15 @@ source $testdir/tester.tcl
 #   stays usable (15.6)
 # covers: gencol1 gencol1-15.20 — REPLACE INTO a table with a generated column
 #   computes the column (15.7)
-# not-covered: attach attach-11.1 — SUSPECTED BUG: ATTACH of a ~9000-char URI
-#   filename fails 'unable to open database: file:000...' (stock supports
-#   arbitrarily long URI filenames; likely a fixed-size path buffer in the
-#   chunk-store open path). Test 6.6 only asserts the connection survives the
-#   attempt either way.
-# not-covered: resetdb resetdb-630 — SUSPECTED BUG (feature gap):
-#   SQLITE_DBCONFIG_RESET_DATABASE is accepted but VACUUM under it does not
-#   reset the database (sqlite_master keeps its rows), so the original's
-#   "reset during another connection's scan empties the schema" assertion has
-#   no doltlite equivalent today.
+# covers: attach attach-11.1 — ATTACH of a ~9000-char mode=memory URI opens an
+#   in-memory chunk store (no path canonicalization), is usable, and detaches
+#   cleanly (6.6)
+# not-covered: resetdb resetdb-630 — feature gap:
+#   SQLITE_DBCONFIG_RESET_DATABASE is not implemented for doltlite-format
+#   databases; enabling it is now refused (SQLITE_ERROR, flag stays clear,
+#   see 5.6) instead of silently no-opping, so the original's "reset during
+#   another connection's scan empties the schema" assertion still has no
+#   doltlite equivalent.
 
 proc sig {} {
   return [db eval {SELECT count(*), md5sum(a), md5sum(b), md5sum(c) FROM abc}]
@@ -588,16 +587,18 @@ do_test doltlite_recover_rawformat_3-5.4 {
 do_test doltlite_recover_rawformat_3-5.5 {
   list [execsql {PRAGMA quick_check}] [execsql {PRAGMA quick_check} db2]
 } {ok ok}
+# RESET_DB is refused on doltlite-format dbs (read-back value stays 0, the
+# C call returns SQLITE_ERROR), so VACUUM never silently skips a reset.
 do_test doltlite_recover_rawformat_3-5.6 {
-  sqlite3_db_config db RESET_DB 1
+  set r1 [sqlite3_db_config db RESET_DB 1]
   db eval VACUUM
-  sqlite3_db_config db RESET_DB 0
-  execsql {
+  set r2 [sqlite3_db_config db RESET_DB 0]
+  list $r1 $r2 [execsql {
     SELECT count(*) FROM rt1;
     SELECT count(*) FROM sqlite_master WHERE name LIKE 'rt1%';
     PRAGMA quick_check;
-  } db2
-} {20 3 ok}
+  } db2]
+} {0 0 {20 3 ok}}
 do_test doltlite_recover_rawformat_3-5.7 {
   list [execsql {PRAGMA journal_mode=WAL}] \
        [catchsql {PRAGMA journal_mode=DELETE}] \
@@ -668,10 +669,19 @@ do_test doltlite_recover_rawformat_3-6.5 {
   list $res $rows
 } {{noname {} inmem {}} 7}
 do_test doltlite_recover_rawformat_3-6.6 {
-  catch {execsql {ATTACH printf('file:%09000x/x.db?mode=memory&cache=shared',1) AS auxlong}}
-  catch {execsql {DETACH auxlong}}
-  db one {SELECT 1}
-} {1}
+  db close
+  sqlite3 db test.db -uri 1
+  execsql {ATTACH printf('file:%09000x/x.db?mode=memory&cache=shared',1) AS auxlong}
+  execsql {
+    CREATE TABLE auxlong.lt(x);
+    INSERT INTO auxlong.lt VALUES(42);
+  }
+  set r [execsql {SELECT x FROM auxlong.lt}]
+  execsql {DETACH auxlong}
+  db close
+  sqlite3 db test.db
+  list $r [db one {SELECT 1}]
+} {42 1}
 
 #-------------------------------------------------------------------------
 # 7.* securedel: secure_delete pragma inert; DELETE itself correct

--- a/test/known_testfixture_crashes.txt
+++ b/test/known_testfixture_crashes.txt
@@ -130,6 +130,7 @@ incrblob         # incrblob API on a PK (WITHOUT ROWID) table: "cannot open tabl
 pager1           # journal/txn-model cascade: "cannot commit - no transaction is active"
 backup           # sqlite3_backup_init: page-image backup unsupported
 mallocAll        # failed open -> "db" command never created (test-harness footgun)
+memdb2           # chunk store intentionally refuses the memdb VFS at open (it half-opened before) -> uncaught open error, "db" never created
 walthread        # multi-threaded WAL stress: nondeterministic class (same as thread*)
 win32heap        # windows-only: silent platform return, no summary line
 win32lock        # windows-only: silent platform return, no summary line

--- a/test/known_testfixture_crashes.txt
+++ b/test/known_testfixture_crashes.txt
@@ -31,7 +31,6 @@
 # Additional crash/timeout files from the full capture (issue #1119):
 crash8        # crash-recovery simulation; incompatible with prolly format / times out
 fuzz3         # raw byte-corruption fuzz mutates test.db offsets; prolly storage aborts after restore/checksum
-shared        # shared-cache semantics unsupported under doltlite; setup aborts
 
 # Raw-format/WAL divergences whose failed open cascades into an uncaught Tcl
 # error before the summary line. doltlite validates the chunk-store manifest at

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -2766,8 +2766,6 @@ walmode walmode-4.12  # journal_mode fixed; -wal sidecar absent; file sizes
 walmode walmode-4.16  # journal_mode fixed; -wal sidecar absent; file sizes
 walmode walmode-4.17  # journal_mode fixed; -wal sidecar absent; file sizes
 walmode walmode-4.18  # journal_mode fixed; -wal sidecar absent; file sizes
-walmode walmode-5.1.2  # journal_mode fixed; -wal sidecar absent; file sizes
-walmode walmode-5.1.4  # journal_mode fixed; -wal sidecar absent; file sizes
 walmode walmode-6.1  # journal_mode fixed; -wal sidecar absent; file sizes
 walmode walmode-6.2  # journal_mode fixed; -wal sidecar absent; file sizes
 walmode walmode-6.3  # journal_mode fixed; -wal sidecar absent; file sizes

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -332,12 +332,100 @@ pragma pragma-8.2.4.3
 pragma pragma-8.2.8
 
 # ── shared ──
+# Connections to the same file don't share a pager cache: each gets its own
+# file descriptor, so sqlite_open_file_count and sqlite3_shared_cache_report
+# don't match the shared-cache expectations.
+shared shared-1.1.1
+shared shared-1.2.1
+shared shared-1.4.1.2
+shared shared-1.4.1.3
+shared shared-1.11.9
+shared shared-2.1.1
+shared shared-2.2.1
+shared shared-2.4.1.1
+shared shared-2.4.1.2
+shared shared-2.4.1.3
+shared shared-2.11.9
+# Shared-cache table/schema locks are not raised: snapshot reads and writes
+# proceed where stock expects "database table is locked" / "database schema
+# is locked", and later assertions cascade off that (extra tables created,
+# transactions committing earlier than stock).
+shared shared-1.1.4
+shared shared-1.1.5
+shared shared-1.1.6
+shared shared-1.1.7
+shared shared-1.2.2
+shared shared-1.2.3
+shared shared-1.2.4
+shared shared-1.4.3.2
+shared shared-1.4.3.3
+shared shared-1.4.4.1.2
+shared shared-1.4.4.2
+shared shared-1.4.4.3
+shared shared-1.4.4.4
+shared shared-1.4.4.5
+shared shared-1.6.1.3
+shared shared-1.6.1.4
+shared shared-1.10.6
+shared shared-1.10.9
+shared shared-1.11.2
+shared shared-1.11.5
+shared shared-2.1.4
+shared shared-2.1.5
+shared shared-2.1.6
+shared shared-2.1.7
+shared shared-2.2.2
+shared shared-2.2.3
+shared shared-2.2.4
+shared shared-2.4.3.2
+shared shared-2.4.3.3
+shared shared-2.4.4.1.2
+shared shared-2.4.4.2
+shared shared-2.4.4.3
+shared shared-2.4.4.4
+shared shared-2.4.4.5
+shared shared-2.6.1.3
+shared shared-2.6.1.4
+shared shared-2.10.6
+shared shared-2.10.9
+shared shared-2.11.2
+shared shared-2.11.5
+# PRAGMA read_uncommitted has no effect: cursors read a snapshot, so another
+# connection's uncommitted rows never appear mid-scan.
+shared shared-1.3.1.1
+shared shared-1.3.1.2
+shared shared-1.11.8
+shared shared-2.3.1.1
+shared shared-2.3.1.2
+shared shared-2.11.8
 shared shared-1.7.2    # shared-cache + rowid-order assumption
 shared shared-1.10.5   # rowid-order on unordered SELECT
 shared shared-1.10.7
+shared shared-1.14.1
+shared shared-1.14.2
 shared shared-2.7.2
 shared shared-2.10.5
 shared shared-2.10.7
+shared shared-2.14.1
+shared shared-2.14.2
+# doltlite-format ignores non-UTF-8 database encodings
+shared shared-1.8.1.2
+shared shared-1.8.2.2
+shared shared-2.8.1.2
+shared shared-2.8.2.2
+# In-memory databases are per-connection: cache=shared / mode=memory URIs do
+# not share one store, so a second handle never sees the first one's tables.
+shared shared-1-16.1
+shared shared-1-16.2
+shared shared-1-16.4
+shared shared-1-16.5
+shared shared-1-16.8.1
+shared shared-2-16.1
+shared shared-2-16.2
+shared shared-2-16.4
+shared shared-2-16.5
+shared shared-2-16.8.1
+shared shared-2.1.0    # auto_vacuum rejected on doltlite-format databases
 
 # ── shared2 ──
 shared2 shared2-1.1  # shared-cache rowid-order assumption

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -548,7 +548,6 @@ vacuum2 vacuum2-6.0  # PRIMARY KEY COLLATE cmp WITHOUT ROWID rejected
 # review in https://github.com/dolthub/doltlite/issues/1119
 # ---------------------------------------------------------------------------
 attach attach-10.2
-attach attach-11.1
 attach attach-2.15
 attach attach-2.16
 attach attach-8.1
@@ -1608,7 +1607,6 @@ dbpage dbpage-820  # sqlite_dbpage raw page access; chunk store has no SQLite pa
 pagesize pagesize-1.1  # page_size not configurable on the chunk store
 pagesize pagesize-1.3  # page_size not configurable on the chunk store
 pagesize pagesize-1.4  # page_size not configurable on the chunk store
-pagesize pagesize-1.8  # page_size not configurable on the chunk store
 pagesize pagesize-2.512.2  # page_size not configurable on the chunk store
 pagesize pagesize-2.512.3  # page_size not configurable on the chunk store
 pagesize pagesize-2.512.6  # page_size not configurable on the chunk store
@@ -2149,7 +2147,6 @@ backup2 backup2-4  # backup format/file hash and error-text differ; in-memory ba
 backup2 backup2-5  # backup format/file hash and error-text differ; in-memory backup rejected
 backup2 backup2-6  # backup format/file hash and error-text differ; in-memory backup rejected
 backup2 backup2-7  # backup format/file hash and error-text differ; in-memory backup rejected
-backup2 backup2-8  # backup format/file hash and error-text differ; in-memory backup rejected
 backup2 backup2-11  # backup format/file hash and error-text differ; in-memory backup rejected
 backup2 backup2-12  # backup format/file hash and error-text differ; in-memory backup rejected
 backup4 backup4-1.1  # chunk-store file sizes; in-memory doltlite backup rejected
@@ -2566,20 +2563,6 @@ mallocI mallocI-4.transient.21  # OOM fault-point shift
 mallocI mallocI-4.transient.30  # OOM fault-point shift
 mallocI mallocI-4.transient.31  # OOM fault-point shift
 mallocI mallocI-4.transient.32  # OOM fault-point shift
-memdb2 memdb2-1.1.1  # shared in-memory db locking model: write not blocked
-memdb2 memdb2-1.1.2  # shared in-memory db locking model: write not blocked
-memdb2 memdb2-1.1.3  # shared in-memory db locking model: write not blocked
-memdb2 memdb2-1.1.4  # shared in-memory db locking model: write not blocked
-memdb2 memdb2-1.1.5  # shared in-memory db locking model: write not blocked
-memdb2 memdb2-1.1.6  # shared in-memory db locking model: write not blocked
-memdb2 memdb2-1.1.7  # shared in-memory db locking model: write not blocked
-memdb2 memdb2-1.2.1  # shared in-memory db locking model: write not blocked
-memdb2 memdb2-1.2.2  # shared in-memory db locking model: write not blocked
-memdb2 memdb2-1.2.3  # shared in-memory db locking model: write not blocked
-memdb2 memdb2-1.2.4  # shared in-memory db locking model: write not blocked
-memdb2 memdb2-1.2.5  # shared in-memory db locking model: write not blocked
-memdb2 memdb2-1.2.6  # shared in-memory db locking model: write not blocked
-memdb2 memdb2-1.2.7  # shared in-memory db locking model: write not blocked
 mmap3 mmap3-1.0  # mmap read statistics zero: chunk store does not mmap pages
 mmap3 mmap3-1.2  # mmap read statistics zero: chunk store does not mmap pages
 mmap3 mmap3-1.3  # mmap read statistics zero: chunk store does not mmap pages
@@ -2629,6 +2612,7 @@ resetdb resetdb-630  # sqlite_dbpage writes rejected; page counts/journal-mode r
 resetdb resetdb-700  # sqlite_dbpage writes rejected; page counts/journal-mode reporting differ
 resetdb resetdb-710  # sqlite_dbpage writes rejected; page counts/journal-mode reporting differ
 resetdb resetdb-740  # sqlite_dbpage writes rejected; page counts/journal-mode reporting differ
+resetdb resetdb-820  # RESET_DATABASE dbconfig is refused on doltlite-format dbs (was a silent no-op): read-back value stays 0
 resetdb resetdb-840  # sqlite_dbpage writes rejected; page counts/journal-mode reporting differ
 resetdb resetdb-850  # sqlite_dbpage writes rejected; page counts/journal-mode reporting differ
 resetdb resetdb-860  # sqlite_dbpage writes rejected; page counts/journal-mode reporting differ


### PR DESCRIPTION
Closes #1345. Closes #1346.

Two commits, one per issue.

## #1345 — journal_mode rejection asymmetry (commit 1)

The rejection in `OP_JournalMode` was never actually attached-path-specific: it fired whenever the requested mode differed from the pager shim's synthetic current mode. File-backed doltlite dbs report `wal`, so `= wal` no-opped; an in-memory main reports `memory`, so the same pragma errored. That made the error depend on the db's backing, which read as "the attached path skips the rejection."

Fix: in-memory pager shims now report WAL as unsupported (`shimPagerWalSupported`), and `OP_JournalMode` takes stock's wal-unavailable no-op path before the doltlite rejection. Every doltlite db now behaves identically — `journal_mode = wal` is an accepted no-op everywhere (this matches stock for `:memory:` dbs and keeps the universal `PRAGMA journal_mode=WAL` startup idiom working, which jrnlwal_1/jrnlwal_2 pin as contract), and any real mode-change request is rejected verbatim on main and attached dbs alike. Resolving the asymmetry by rejecting `= wal` everywhere would have broken those pinned contracts and every app that runs `PRAGMA journal_mode=WAL` at startup.

- fail-before: `:memory:` main `= wal` → `journal_mode is not configurable on doltlite-format databases`; attached file db `= wal` → silently echoes `wal`
- pass-after: both no-op (`memory` / `wal` echo); `= delete` rejects identically on main and aux (new pin rawformat_2-3.1b, updated jrnlwal_4-8.1)
- upstream: `walmode-5.1.2`, `walmode-5.1.4` now pass — removed from the divergence list

## #1346 — error-surface grab bag (commit 2)

| item | fail-before | pass-after |
|---|---|---|
| a) `PRAGMA incremental_vacuum` | bare `SQL logic error` | `incremental_vacuum is not supported on doltlite-format databases` (parse-time, mirrors auto_vacuum) |
| b) `db backup/restore` unknown/temp names | `backup failed: not an error` | `unknown database aux1` (stock parity), explicit rejection for temp/aux sides, `source and destination must be distinct` for same-connection misuse |
| c) `PRAGMA page_size=1234` | accepted and echoed for the session | ignored like stock (power-of-2 in [512,65536] required); value stays unchanged |
| d) ATTACH ~9000-char `mode=memory` URI | `unable to open database` (path canonicalization on a fake path) | opens an in-memory chunk store; usable and detachable (stock attach-11.1 form) |
| e) `SQLITE_DBCONFIG_RESET_DATABASE` | accepted, silently no-opped | returns `SQLITE_ERROR`, read-back value stays 0 |
| f) `file:?vfs=memdb` | open succeeded, every statement failed `unknown operation` | open fails cleanly (`unable to open database file`) |

Notes on judgment calls:
- (b) backup between doltlite-format and non-main databases is explicitly rejected rather than delegated to the stock backup engine — the stock engine would push SQLite pages through the prolly pager shim. Delegation still happens when neither side is doltlite-format. `backup2-8` now passes upstream and left the divergence list.
- (d) the root cause was not buffer sizing: `csCanonicalFilename` already allocates dynamically, but `mode=memory` URIs were treated as real file paths and died in `xFullPathname` (whose `mxPathname` cap matches stock for real files — paths >PATH_MAX can't exist on disk anyway). The fix honors `SQLITE_OPEN_MEMORY` in `chunkStoreOpen`, which is what stock does. `attach-11.1` now passes upstream and left the divergence list, as did `pagesize-1.8` for (c).
- (e) chose the error over implementing reset: a real reset would need new wipe-the-chunk-store machinery (there is no existing branch/catalog primitive that discards all branches, history, and refs), so refusing is the honest contract. `resetdb-820` gained a divergence entry (intentional rejection of an upstream-passing assertion), with a reason comment.
- (f) the chunk store now refuses VFSes without `xDelete` at open (memdb also lacks `SQLITE_FCNTL_HAS_MOVED`, which lock-refresh needs; GC calls `sqlite3OsDelete`, which would call through a null pointer). `memdb2` moved from the divergence list (14 entries) to the crash list: its first `vfs=memdb` open is now an uncaught script error so the file never reaches its summary line. The deserialize path is unaffected — `db deserialize` still reports `unable to set MEMDB content` (pinned in rawformat_2-7.1/7.2, passing).

## Gates

- Touched recover files all end `0 errors out of N tests`: jrnlwal_2 (74), jrnlwal_3 (82), jrnlwal_4 (75), rawformat_2 (71→ now includes the new 3.1b pin), rawformat_3 (102), locking_2 (101); full doltlite_*.test sweep (17 files) green.
- Non-root gated upstream run over attach/attach2/attach3/autovacuum2/backup_malloc/backup2/backup4/backup5/incrvacuum2/jrnlmode/jrnlmode2/jrnlmode3/memdb/memdb2/memjournal/pagesize/pragma/pragma2/pragma6/resetdb/securedel/temptable2/vacuum4/vacuum6/wal5/walmode: all OK, `memdb2` CRASH (expected, listed), 3899 passing, 721 known divergences still failing, 0 unexpected.
- Divergence list: removed `attach-11.1`, `backup2-8`, `pagesize-1.8`, `walmode-5.1.2`, `walmode-5.1.4`, and the 14 `memdb2` entries; added `resetdb-820` with a reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
