### PR TITLE
Fix savepoint rollback over-reverting earlier transaction writes

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -308,7 +308,6 @@ struct Btree {
   int nSavepointAlloc;
 
   struct SavepointTableState {
-    ProllyHash catalogHash;
     SavepointTableEntry *aTables;
     SavepointCatalogEntry *aCatalogSnapshot;
     u8 bCatalogSnapshot;
@@ -3303,7 +3302,6 @@ static void freeSavepointTables(struct SavepointTableState *pState){
     sqlite3_free(pState->aTables);
     pState->aTables = 0;
   }
-  memset(&pState->catalogHash, 0, sizeof(pState->catalogHash));
   memset(&pState->stagedCatalog, 0, sizeof(pState->stagedCatalog));
   pState->isMerging = 0;
   memset(&pState->mergeCommitHash, 0, sizeof(pState->mergeCommitHash));
@@ -3405,13 +3403,10 @@ static void restoreSavepointSessionState(
 
 static int captureSavepointTables(
   Btree *pBtree,
-  struct SavepointTableState *pState,
-  int bStatement
+  struct SavepointTableState *pState
 ){
   int k;
   int rc;
-  u8 *catData = 0;
-  int nCatData = 0;
   if( pState->bTablesCaptured ) return SQLITE_OK;
   if( pState->aCatalogSnapshot ){
     for(k=0; k<pState->nTables; k++){
@@ -3421,17 +3416,12 @@ static int captureSavepointTables(
     pState->aCatalogSnapshot = 0;
     pState->bCatalogSnapshot = 0;
   }
-  memset(&pState->catalogHash, 0, sizeof(pState->catalogHash));
-  if( bStatement ){
-    rc = captureSavepointCatalogSnapshot(pBtree, pState);
-    if( rc!=SQLITE_OK ) return rc;
-  }else{
-    rc = serializeCatalog(pBtree, &catData, &nCatData);
-    if( rc!=SQLITE_OK ) return rc;
-    rc = chunkStorePut(&pBtree->pBt->store, catData, nCatData, &pState->catalogHash);
-    sqlite3_free(catData);
-    if( rc!=SQLITE_OK ) return rc;
-  }
+  /* Snapshot the live catalog entries verbatim. The commit-form catalog
+  ** serializer canonicalizes (sorts rows and renumbers roots), so a
+  ** round-trip through it reassigns iTable numbers and rebuilds the master
+  ** root, scrambling tables created inside the transaction. */
+  rc = captureSavepointCatalogSnapshot(pBtree, pState);
+  if( rc!=SQLITE_OK ) return rc;
   if( pBtree->cat.n<=0 ){
     pState->bTablesCaptured = 1;
     return SQLITE_OK;
@@ -3465,7 +3455,7 @@ static int ensureSavepointTablesCaptured(
   struct SavepointTableState *pState
 ){
   if( pState->bTablesCaptured ) return SQLITE_OK;
-  return captureSavepointTables(pBtree, pState, pState->bStatement);
+  return captureSavepointTables(pBtree, pState);
 }
 
 static int ensureStatementSavepointsCaptured(Btree *pBtree){
@@ -3772,84 +3762,70 @@ static int restoreTablesFromSavepoint(
     aCurrent[k].pPending = 0;
   }
 
-  if( prollyHashIsEmpty(&pState->catalogHash) ){
-    if( pState->bCatalogSnapshot ){
-      if( pBtree->cat.n==pState->nTables ){
-        int bSameShape = 1;
+  if( pState->bCatalogSnapshot ){
+    if( pBtree->cat.n==pState->nTables ){
+      int bSameShape = 1;
+      for(k=0; k<pState->nTables; k++){
+        if( pBtree->cat.a[k].iTable!=pState->aCatalogSnapshot[k].iTable ){
+          bSameShape = 0;
+          break;
+        }
+      }
+      if( bSameShape ){
         for(k=0; k<pState->nTables; k++){
-          if( pBtree->cat.a[k].iTable!=pState->aCatalogSnapshot[k].iTable ){
-            bSameShape = 0;
-            break;
-          }
+          struct TableEntry *pDst = &pBtree->cat.a[k];
+          SavepointCatalogEntry *pSrc = &pState->aCatalogSnapshot[k];
+          pDst->root = pSrc->root;
+          pDst->schemaHash = pSrc->schemaHash;
+          pDst->flags = pSrc->flags;
+          pDst->pendingFlushSeekEdits = pSrc->pendingFlushSeekEdits;
+          pDst->tableRootKnown = pSrc->tableRootKnown;
+          pDst->isTableRoot = pSrc->isTableRoot;
         }
-        if( bSameShape ){
-          for(k=0; k<pState->nTables; k++){
-            struct TableEntry *pDst = &pBtree->cat.a[k];
-            SavepointCatalogEntry *pSrc = &pState->aCatalogSnapshot[k];
-            pDst->root = pSrc->root;
-            pDst->schemaHash = pSrc->schemaHash;
-            pDst->flags = pSrc->flags;
-            pDst->pendingFlushSeekEdits = pSrc->pendingFlushSeekEdits;
-            pDst->tableRootKnown = pSrc->tableRootKnown;
-            pDst->isTableRoot = pSrc->isTableRoot;
-          }
-          bRestoredCatalogInPlace = 1;
-        }
+        bRestoredCatalogInPlace = 1;
       }
-      if( !bRestoredCatalogInPlace ){
-        btreeFreeCatalogTables(pBtree);
-        initDefaultMeta(pBtree);
-        if( pState->nTables>0 ){
-          if( pBtree->cat.nAlloc < pState->nTables ){
-            struct TableEntry *aNew = sqlite3_realloc(
-                pBtree->cat.a, pState->nTables * (int)sizeof(struct TableEntry));
-            if( !aNew ){
-              return SQLITE_NOMEM;
-            }
-            pBtree->cat.a = aNew;
-            pBtree->cat.nAlloc = pState->nTables;
-          }
-          memset(pBtree->cat.a, 0, pState->nTables * sizeof(struct TableEntry));
-          for(k=0; k<pState->nTables; k++){
-            struct TableEntry *pDst = &pBtree->cat.a[k];
-            SavepointCatalogEntry *pSrc = &pState->aCatalogSnapshot[k];
-            pDst->iTable = pSrc->iTable;
-            pDst->root = pSrc->root;
-            pDst->schemaHash = pSrc->schemaHash;
-            pDst->flags = pSrc->flags;
-            pDst->pendingFlushSeekEdits = pSrc->pendingFlushSeekEdits;
-            pDst->tableRootKnown = pSrc->tableRootKnown;
-            pDst->isTableRoot = pSrc->isTableRoot;
-            if( pSrc->zName ){
-              pDst->zName = sqlite3_mprintf("%s", pSrc->zName);
-              if( !pDst->zName ){
-                btreeFreeCatalogTables(pBtree);
-                initDefaultMeta(pBtree);
-                return SQLITE_NOMEM;
-              }
-            }
-          }
-        }
-        pBtree->cat.n = pState->nTables;
-      }
-      pBtree->cat.iNextTable = pState->iNextTable;
-    }else{
+    }
+    if( !bRestoredCatalogInPlace ){
       btreeFreeCatalogTables(pBtree);
       initDefaultMeta(pBtree);
-      pBtree->cat.iNextTable = 2;
+      if( pState->nTables>0 ){
+        if( pBtree->cat.nAlloc < pState->nTables ){
+          struct TableEntry *aNew = sqlite3_realloc(
+              pBtree->cat.a, pState->nTables * (int)sizeof(struct TableEntry));
+          if( !aNew ){
+            return SQLITE_NOMEM;
+          }
+          pBtree->cat.a = aNew;
+          pBtree->cat.nAlloc = pState->nTables;
+        }
+        memset(pBtree->cat.a, 0, pState->nTables * sizeof(struct TableEntry));
+        for(k=0; k<pState->nTables; k++){
+          struct TableEntry *pDst = &pBtree->cat.a[k];
+          SavepointCatalogEntry *pSrc = &pState->aCatalogSnapshot[k];
+          pDst->iTable = pSrc->iTable;
+          pDst->root = pSrc->root;
+          pDst->schemaHash = pSrc->schemaHash;
+          pDst->flags = pSrc->flags;
+          pDst->pendingFlushSeekEdits = pSrc->pendingFlushSeekEdits;
+          pDst->tableRootKnown = pSrc->tableRootKnown;
+          pDst->isTableRoot = pSrc->isTableRoot;
+          if( pSrc->zName ){
+            pDst->zName = sqlite3_mprintf("%s", pSrc->zName);
+            if( !pDst->zName ){
+              btreeFreeCatalogTables(pBtree);
+              initDefaultMeta(pBtree);
+              return SQLITE_NOMEM;
+            }
+          }
+        }
+      }
+      pBtree->cat.n = pState->nTables;
     }
+    pBtree->cat.iNextTable = pState->iNextTable;
   }else{
-    u8 *catData = 0;
-    int nCatData = 0;
-    rc = chunkStoreGet(&pBtree->pBt->store, &pState->catalogHash, &catData, &nCatData);
-    if( rc!=SQLITE_OK ){
-      return rc;
-    }
-    rc = deserializeCatalog(pBtree, catData, nCatData);
-    sqlite3_free(catData);
-    if( rc!=SQLITE_OK ){
-      return rc;
-    }
+    btreeFreeCatalogTables(pBtree);
+    initDefaultMeta(pBtree);
+    pBtree->cat.iNextTable = 2;
   }
 
   if( pState->nTables>0 ){
@@ -3908,7 +3884,6 @@ static int pushSavepoint(Btree *pBtree, int bStatement){
   }
 
   pState = &pBtree->aSavepointTables[pBtree->nSavepoint];
-  memset(&pState->catalogHash, 0, sizeof(pState->catalogHash));
   pState->aTables = 0;
   pState->aCatalogSnapshot = 0;
   pState->bCatalogSnapshot = 0;
@@ -3928,7 +3903,7 @@ static int pushSavepoint(Btree *pBtree, int bStatement){
   pState->zRebaseReturnBranch = 0;
   captureSavepointSessionState(pBtree, pState);
   if( !bStatement ){
-    int rc = captureSavepointTables(pBtree, pState, bStatement);
+    int rc = captureSavepointTables(pBtree, pState);
     if( rc!=SQLITE_OK ) return rc;
   }
 
@@ -5701,7 +5676,7 @@ static int prollyBtreeRollback(Btree *p, int tripCode, int writeOnly){
     ** saveCursorPosition(), which copies out the key it needs first. We only
     ** null the alias — catFree owns the map, and a prior savepoint rollback may
     ** already have freed the one this cursor points at, so clearing it would be
-    ** a use-after-free (the #1207/#1213 fix). ensureMutMap re-aliases on reuse. */
+    ** a use-after-free. ensureMutMap re-aliases on reuse. */
     {
       BtCursor *pC;
       int tc = tripCode ? tripCode : SQLITE_ABORT;
@@ -6047,7 +6022,12 @@ static int prollyBtreeSavepoint(Btree *p, int op, int iSavepoint){
      && p->aSavepointTables ){
       return rollbackNamedSavepoint(p, pBt, iSavepoint);
     } else if( iSavepoint>=0 && iSavepoint>=p->nSavepoint ){
-      return rollbackCommittedState(p, pBt);
+      /* Savepoints push lazily at write time (syncBtreeSavepoints,
+      ** BeginTrans), so no savepoint at this level means this btree wrote
+      ** nothing since the SQL savepoint was created. Stock's pager no-ops
+      ** here; restoring committed state would wipe the btree's earlier
+      ** in-transaction writes. */
+      return SQLITE_OK;
     } else if( iSavepoint<0 ){
       return rollbackAllSavepoints(p, pBt);
     }
@@ -10448,8 +10428,17 @@ void doltliteGetSessionStaged(sqlite3 *db, ProllyHash *pStaged){
   }
 }
 
+/* Session VC state is captured per savepoint level by
+** captureSavepointSessionState when a level is pushed, and levels push
+** lazily at write time. Mutating this state is a write: push any pending
+** levels first so ROLLBACK TO restores the pre-mutation values. */
+static void sessionStateSyncSavepoints(Btree *p){
+  if( p->inTrans==TRANS_WRITE ) syncBtreeSavepoints(p);
+}
+
 void doltliteSetSessionStaged(sqlite3 *db, const ProllyHash *pStaged){
   if( db && db->nDb>0 && db->aDb[0].pBt ){
+    sessionStateSyncSavepoints(db->aDb[0].pBt);
     memcpy(&db->aDb[0].pBt->stagedCatalog, pStaged, sizeof(ProllyHash));
   }
 }
@@ -10474,6 +10463,7 @@ void doltliteSetSessionMergeState(sqlite3 *db, u8 isMerging,
                                    const ProllyHash *pConflictsCatalog){
   if( db && db->nDb>0 && db->aDb[0].pBt ){
     Btree *p = db->aDb[0].pBt;
+    sessionStateSyncSavepoints(p);
     p->isMerging = isMerging;
     if( pMergeCommit ) memcpy(&p->mergeCommitHash, pMergeCommit, sizeof(ProllyHash));
     else memset(&p->mergeCommitHash, 0, sizeof(ProllyHash));
@@ -10514,6 +10504,7 @@ void doltliteSetSessionRebaseState(sqlite3 *db, u8 isRebasing,
                                     const char *zReturnBranch){
   if( db && db->nDb>0 && db->aDb[0].pBt ){
     Btree *p = db->aDb[0].pBt;
+    sessionStateSyncSavepoints(p);
     p->isRebasing = isRebasing;
     if( pPreRebaseCat ) memcpy(&p->preRebaseWorkingCat, pPreRebaseCat, sizeof(ProllyHash));
     else memset(&p->preRebaseWorkingCat, 0, sizeof(ProllyHash));

--- a/test/doltlite_recover_jrnlwal_3.test
+++ b/test/doltlite_recover_jrnlwal_3.test
@@ -207,7 +207,7 @@
 # covers: savepoint savepoint-7.2.1 — CREATE TABLE inside savepoint rolled back cleanly, integrity ok (6.2)
 # covers: savepoint savepoint-7.3.1 — table repopulation from existing data (6.3)
 # covers: savepoint savepoint-7.3.2 — DELETE + vacuum pragma + nested savepoint ROLLBACK TO leaves empty table, integrity ok (6.3)
-# not-covered: savepoint savepoint-7.4.1 — SUSPECTED BUG: ROLLBACK TO a savepoint with no subsequent writes resurrects the transaction's earlier DELETE/UPDATE (BEGIN; DELETE; SAVEPOINT s; ROLLBACK TO s; COMMIT leaves the deleted row present)
+# covers: savepoint savepoint-7.4.1 — ROLLBACK TO a savepoint with no subsequent writes keeps the transaction's earlier DELETE (6.4.1)
 # covers: savepoint savepoint-7.5.1 — t5 nested-rollback outcome x={3,4,5}, integrity ok (6.5)
 # covers: savepoint savepoint-7.5.2 — DROP TABLE t5 succeeds after the scenario (6.6)
 # covers: savepoint savepoint-10.2.1 — two ATTACH-ed dbs created, per-db schema visible (6.7)
@@ -218,11 +218,11 @@
 # covers: savepoint savepoint-10.2.6 — aux write visible inside savepoint (6.8)
 # covers: savepoint savepoint-10.2.7 — ROLLBACK TO two reverts only the aux1 write (6.9)
 # covers: savepoint savepoint-10.2.8 — stock pager lock states inapplicable; doltlite lock_status at rest (6.16)
-# not-covered: savepoint savepoint-10.2.9 — SUSPECTED BUG: ROLLBACK TO an inner savepoint reverts other attached databases' writes made under the outer savepoint (SAVEPOINT one; INSERT main; SAVEPOINT two; INSERT aux; ROLLBACK TO two loses the main insert)
-# not-covered: savepoint savepoint-10.2.10 — SUSPECTED BUG: cross-db savepoint rollback over-reverts, so triple-nested savepoints across three dbs cannot be asserted; was: triple-nested savepoints across three dbs (6.12)
-# not-covered: savepoint savepoint-10.2.11 — SUSPECTED BUG: cross-db savepoint rollback over-reverts, so ROLLBACK TO two reverting aux writes only cannot be asserted; was: ROLLBACK TO two reverts aux writes only (6.13)
-# not-covered: savepoint savepoint-10.2.12 — SUSPECTED BUG: cross-db savepoint rollback over-reverts, so repeat ROLLBACK TO two cannot be asserted; was: re-insert then second ROLLBACK TO two gives identical state (6.14)
-# not-covered: savepoint savepoint-10.2.13 — SUSPECTED BUG: cross-db savepoint rollback over-reverts the RELEASE-committed state; full ROLLBACK of the never-released txn is still asserted correct (6.10)
+# covers: savepoint savepoint-10.2.9 — ROLLBACK TO an inner savepoint keeps other attached databases' writes made under the outer savepoint (6.9.1)
+# covers: savepoint savepoint-10.2.10 — triple-nested savepoints across three dbs, all writes visible (6.10.1)
+# covers: savepoint savepoint-10.2.11 — ROLLBACK TO two reverts only writes made after it, outer main-db write survives (6.10.2)
+# covers: savepoint savepoint-10.2.12 — re-insert then second ROLLBACK TO two gives identical state (6.10.3)
+# covers: savepoint savepoint-10.2.13 — full ROLLBACK after nested cross-db savepoint traffic empties all three dbs (6.10, 6.10.4)
 # covers: savepoint savepoint-10.2.14 — lock_status unlocked after full ROLLBACK (6.16)
 # covers: savepoint savepoint-11.1 — auto_vacuum=full rejection (1.10); UNIQUE-table setup (6.18)
 # covers: savepoint savepoint-11.8 — ROLLBACK discards savepoint-created tables; wal_checkpoint no-op reports 0 0 0; data + integrity intact (6.18); DROP-in-savepoint rollback + reopen (6.19-6.20)
@@ -612,9 +612,25 @@ do_test doltlite_recover_jrnlwal_3-6.3 {
     PRAGMA integrity_check;
   }
 } {0 ok}
-# savepoint-7.4.1's flow (BEGIN; DELETE; SAVEPOINT; ROLLBACK TO; COMMIT)
-# is NOT asserted here: doltlite currently resurrects the deleted row.
-# See "SUSPECTED BUG" in the not-covered header lines.
+# savepoint-7.4.1's flow: a savepoint with no subsequent writes must not
+# resurrect the transaction's earlier DELETE when rolled back to.
+do_test doltlite_recover_jrnlwal_3-6.4.1 {
+  execsql {
+    CREATE TABLE s741(a);
+    INSERT INTO s741 VALUES(1);
+    INSERT INTO s741 VALUES(2);
+    BEGIN;
+      DELETE FROM s741 WHERE a=1;
+      SAVEPOINT s;
+      ROLLBACK TO s;
+    COMMIT;
+    SELECT a FROM s741;
+    PRAGMA integrity_check;
+  }
+} {2 ok}
+do_test doltlite_recover_jrnlwal_3-6.4.2 {
+  execsql { DROP TABLE s741 }
+} {}
 do_test doltlite_recover_jrnlwal_3-6.5 {
   execsql {
     CREATE TABLE t5(x, y);
@@ -669,13 +685,55 @@ do_test doltlite_recover_jrnlwal_3-6.9 {
   execsql { ROLLBACK TO two }
   execsql { SELECT * FROM tb ORDER BY x }
 } {}
-# The rest of savepoint-10.2's flow (cross-db state after ROLLBACK TO two,
-# RELEASE one, and the triple-nested block) is NOT asserted: doltlite
-# currently rolls back other databases' outer-savepoint writes when an
-# inner savepoint with no subsequent writes on them is rolled back.
-# See "SUSPECTED BUG" in the not-covered header lines. Full ROLLBACK of
-# the whole savepoint transaction is still correct:
+# Writes made under the outer savepoint in other databases survive the
+# inner rollback.
+do_test doltlite_recover_jrnlwal_3-6.9.1 {
+  execsql {
+    SELECT 'a', * FROM ta;
+    SELECT 'c', * FROM tc;
+  }
+} {a 1 2 c 3 4}
 do_test doltlite_recover_jrnlwal_3-6.10 {
+  execsql {
+    ROLLBACK;
+    SELECT count(*) FROM ta;
+    SELECT count(*) FROM tb;
+    SELECT count(*) FROM tc;
+  }
+} {0 0 0}
+# Triple-nested savepoints across the three databases: ROLLBACK TO an inner
+# savepoint reverts only writes made after it, repeatably.
+do_test doltlite_recover_jrnlwal_3-6.10.1 {
+  execsql {
+    SAVEPOINT one;
+      INSERT INTO ta VALUES('a', 'b');
+      SAVEPOINT two;
+        INSERT INTO tb VALUES('c', 'd');
+        SAVEPOINT three;
+          INSERT INTO tc VALUES('e', 'f');
+    SELECT * FROM ta;
+    SELECT * FROM tb;
+    SELECT * FROM tc;
+  }
+} {a b c d e f}
+do_test doltlite_recover_jrnlwal_3-6.10.2 {
+  execsql {
+    ROLLBACK TO two;
+    SELECT count(*) FROM ta;
+    SELECT count(*) FROM tb;
+    SELECT count(*) FROM tc;
+  }
+} {1 0 0}
+do_test doltlite_recover_jrnlwal_3-6.10.3 {
+  execsql {
+    INSERT INTO tc VALUES('g', 'h');
+    ROLLBACK TO two;
+    SELECT count(*) FROM ta;
+    SELECT count(*) FROM tb;
+    SELECT count(*) FROM tc;
+  }
+} {1 0 0}
+do_test doltlite_recover_jrnlwal_3-6.10.4 {
   execsql {
     ROLLBACK;
     SELECT count(*) FROM ta;

--- a/test/doltlite_recover_locking_2.test
+++ b/test/doltlite_recover_locking_2.test
@@ -51,16 +51,6 @@ source $testdir/tester.tcl
 # covers: savepoint savepoint-15.2.2 — same contract, second permutation (6.2-6.5)
 # covers: savepoint savepoint-15.2.3 — locking_mode back to NORMAL, writes work, integrity ok (6.6, 6.7)
 # covers: savepoint savepoint-17.1 — schema-cache rollback scenario verbatim, no upstream lock-state pollution (7.1, 7.2)
-# SUSPECTED BUG (separate, not asserted here): after another connection
-# commits a data write (INSERT, or CREATE INDEX on a populated table), a txn
-# doing CREATE TABLE; INSERT; SAVEPOINT; ROLLBACK TO loses the pre-savepoint
-# row (SELECT returns empty; should return it). Repro:
-#   conn2: CREATE TABLE w(x); INSERT INTO w VALUES(1);
-#   conn1: BEGIN; CREATE TABLE tc(a,b); INSERT INTO tc VALUES(1,2);
-#          SAVEPOINT one; INSERT INTO tc VALUES(3,4); ROLLBACK TO one;
-#          SELECT * FROM tc;  -- returns {} instead of {1 2}
-# Pure cross-connection CREATE TABLE (no row writes) does not trigger it.
-# Section 7 therefore runs before any second-connection writes.
 # covers: pragma2 pragma2-1.3 — DROP works; freelist_count reads 0 (no freelist pages in prolly) (8.1, 8.2)
 # covers: pragma2 pragma2-1.4 — main.freelist_count reads 0 (8.3)
 # covers: pragma2 pragma2-2.5 — DELETE on attached db works; aux freelist_count reads 0 (8.4)
@@ -150,8 +140,7 @@ do_test doltlite_recover_locking_2-1.3 {
 } {{0 {}} {0 text2}}
 
 #-------------------------------------------------------------------------
-# 7.* savepoint-17.1: schema rollback leaves a clean schema cache. Runs
-# before any second-connection writes (see SUSPECTED BUG above).
+# 7.* savepoint-17.1: schema rollback leaves a clean schema cache.
 #
 do_execsql_test doltlite_recover_locking_2-7.1 {
   BEGIN;
@@ -675,6 +664,28 @@ do_test doltlite_recover_locking_2-14.3 {
 do_test doltlite_recover_locking_2-15.1 {
   list [execsql {PRAGMA integrity_check}] [execsql {PRAGMA integrity_check} db2]
 } {ok ok}
+
+#-------------------------------------------------------------------------
+# 16.* ROLLBACK TO inside a txn that created its own table, run after the
+# second connection has committed writes; formerly the rollback lost the
+# pre-savepoint row.
+#
+do_execsql_test doltlite_recover_locking_2-16.1 {
+  BEGIN;
+    CREATE TABLE t7(a, b);
+    INSERT INTO t7 VALUES(1, 2);
+    SAVEPOINT one;
+      INSERT INTO t7 VALUES(3, 4);
+    ROLLBACK TO one;
+    SELECT * FROM t7;
+} {1 2}
+do_execsql_test doltlite_recover_locking_2-16.2 {
+  COMMIT;
+  SELECT * FROM t7;
+} {1 2}
+do_test doltlite_recover_locking_2-16.3 {
+  execsql {PRAGMA integrity_check}
+} {ok}
 
 db2 close
 finish_test

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -901,10 +901,6 @@ savepoint savepoint-15.1.2
 savepoint savepoint-15.1.3
 savepoint savepoint-15.2.2
 savepoint savepoint-15.2.3
-
-# Isolated savepoint-17.1 passes. In the full file it observes state left by
-# the earlier lock-divergent multi-client blocks.
-savepoint savepoint-17.1
 select2 select2-3.3  # sqlite_search_count metric; SELECT f1 WHERE f2==2000 returns 1000 on both
 # trans-9.*: the ".5" labels assert sqlite_fullsync_count/sqlite_sync_count > 0 —
 # SQLite-pager fsync instrumentation that doltlite's prolly backend never drives


### PR DESCRIPTION
Closes #1340.

## Bugs

**1. Missing-level rollback wiped the transaction.** `prollyBtreeSavepoint(ROLLBACK)` with `iSavepoint >= nSavepoint` called `rollbackCommittedState`. Btree savepoint levels push lazily at write time, so a btree that wrote nothing since the savepoint has no level — and the "rollback" wiped its earlier in-transaction writes to committed state. Stock's pager no-ops here. Shapes: `BEGIN; DELETE; SAVEPOINT s; ROLLBACK TO s` resurrected the deleted rows; an inner cross-db `ROLLBACK TO` reverted other databases' outer-savepoint writes (savepoint-10.2.9–13).

**2. Named rollback scrambled in-txn-created tables.** Savepoint capture serialized the catalog with the commit-form serializer, which canonicalizes — sorts schema rows, renumbers roots (`newPg = i+2`), rebuilds the master root. Restoring that form reassigned iTable numbers whenever a table created inside the txn didn't sort last among live tables, re-attaching pending edit maps to the wrong tables: `conn2: CREATE TABLE w + INSERT; conn1: BEGIN; CREATE TABLE tc; INSERT (1,2); SAVEPOINT one; INSERT (3,4); ROLLBACK TO one` left `tc` empty instead of `{1 2}`. Capture now snapshots the live catalog verbatim (the statement-savepoint path, already proven); the chunk-store form and `catalogHash` field are deleted.

**3. Session VC state setters didn't sync savepoints.** With the no-op arm in place, `doltliteSetSessionStaged` / `SetSessionMergeState` / `SetSessionRebaseState` mutations were unprotected (they'd relied on the committed-state wipe). They now push pending levels first, like every other write path — caught by `doltlite_regression_test_c` `rollback_to_savepoint_*`.

## Evidence

Fail-before (all repro shapes, unfixed build) → pass-after, stock-verified byte-identical: shapes 1/1b/2 (no-write rollback after DELETE/UPDATE, cross-db), shape 3 (cross-connection prior commit + in-txn CREATE), nested + same-conn variants.

- `doltlite_regression_test_c all`: **309807/309807** (was 4 failures)
- Gate (non-root docker): savepoint, savepoint2/4/5/7, trans, trans3, transitive1, fts3malloc + all 16 ported recover files — **17,794 passing, 0 unexpected**; savepoint6 expected-crash unchanged
- `savepoint-17.1` newly passes full-file → divergence entry removed (–1, no additions)
- New coverage: jrnlwal_3 +7 assertions (savepoint-7.4.1 flow, 10.2.9–13 triple-nested cross-db flows, formerly not-covered SUSPECTED BUG markers), locking_2 +3 (cross-connection shape, ordering workaround dropped)
- Shell suites: doltlite_savepoint, doltlite_structural rollback_to_savepoint_* pass; remaining local suite failures reproduce byte-identically on master (environmental, filed separately)
- Pre-existing CI-invisible failures found during blast-radius testing filed as #1353 (trans2) and #1354 (savepointfault)

🤖 Generated with [Claude Code](https://claude.com/claude-code)