### PR TITLE
Honor max_page_count for DoltLite writes

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -303,6 +303,7 @@ struct Btree {
   u8 bCatalogDropped;     /* OOM rollback dropped the catalog; reload before
                           ** treating an empty committedCatalogHash as a
                           ** fresh database */
+  Pgno mxPageCount;       /* Synthetic max_page_count limit */
 
   int nSavepoint;
   int nSavepointAlloc;
@@ -719,6 +720,33 @@ static int btreeDeleteImmediate(BtCursor *pCur);
 static int mutMapShouldDrain(BtCursor *pCur){
   return pCur && pCur->pMutMap
       && prollyMutMapCount(pCur->pMutMap) >= PROLLY_MUTMAP_PENDING_FLUSH_LIMIT;
+}
+
+static i64 prollyBtreeSyntheticPageCount(Btree *p){
+  ChunkStore *cs;
+  i64 n;
+  if( !p || !p->pBt ) return 0;
+  cs = &p->pBt->store;
+  n = (i64)chunkIndexCount(&cs->index)
+    + (i64)chunkStagingPendingCount(&cs->staging)
+    + (i64)chunkStagingRecentCount(&cs->staging);
+  if( n < 0 ) n = 0;
+  if( n > (i64)0xfffffffe ) n = (i64)0xfffffffe;
+  if( p->aMeta[BTREE_LARGEST_ROOT_PAGE]>(Pgno)n ){
+    n = p->aMeta[BTREE_LARGEST_ROOT_PAGE];
+  }
+  return n;
+}
+
+static int prollyBtreeCheckMaxPageCount(Btree *p){
+  if( !p ) return SQLITE_OK;
+  if( p->mxPageCount==0 || p->mxPageCount>=SQLITE_MAX_PAGE_COUNT ){
+    return SQLITE_OK;
+  }
+  if( prollyBtreeSyntheticPageCount(p) > (i64)p->mxPageCount ){
+    return SQLITE_FULL;
+  }
+  return SQLITE_OK;
 }
 
 static int prollyBtreeClose(Btree*);
@@ -4304,6 +4332,7 @@ int sqlite3BtreeOpen(
   p->bSchemaChangedTxn = 0;
   p->bMasterRootChangedTxn = 0;
   p->bFilterSchemaPlaceholders = 0;
+  p->mxPageCount = SQLITE_MAX_PAGE_COUNT;
 
   if( pBt->store.readOnly ){
     pBt->btsFlags |= BTS_READ_ONLY;
@@ -4591,8 +4620,18 @@ int sqlite3BtreeGetPageSize(Btree *p){
 }
 
 static Pgno prollyBtreeMaxPageCount(Btree *p, Pgno mxPage){
-  (void)p; (void)mxPage;
-  return (Pgno)0x7FFFFFFF;
+  Pgno nCurrent;
+  if( !p ) return 0;
+  nCurrent = (Pgno)prollyBtreeSyntheticPageCount(p);
+  if( mxPage>0 ){
+    if( mxPage<nCurrent ){
+      mxPage = nCurrent;
+    }
+    p->mxPageCount = mxPage;
+  }else if( p->mxPageCount<nCurrent ){
+    p->mxPageCount = nCurrent;
+  }
+  return p->mxPageCount;
 }
 Pgno sqlite3BtreeMaxPageCount(Btree *p, Pgno mxPage){
   if( !p ) return 0;
@@ -4600,22 +4639,7 @@ Pgno sqlite3BtreeMaxPageCount(Btree *p, Pgno mxPage){
 }
 
 static Pgno prollyBtreeLastPage(Btree *p){
-  ChunkStore *cs;
-  i64 n;
-  if( !p || !p->pBt ) return 0;
-  cs = &p->pBt->store;
-  n = (i64)chunkIndexCount(&cs->index)
-    + (i64)chunkStagingPendingCount(&cs->staging)
-    + (i64)chunkStagingRecentCount(&cs->staging);
-  if( n < 0 ) n = 0;
-  if( n > (i64)0xfffffffe ) n = (i64)0xfffffffe;
-  /* SQLite uses LastPage as an upper bound when validating schema rootpages.
-  ** Doltlite's physical page count is a chunk count, which GC can reduce
-  ** below stable sqlite_master rootpage numbers. */
-  if( p->aMeta[BTREE_LARGEST_ROOT_PAGE]>(Pgno)n ){
-    n = p->aMeta[BTREE_LARGEST_ROOT_PAGE];
-  }
-  return (Pgno)n;
+  return (Pgno)prollyBtreeSyntheticPageCount(p);
 }
 Pgno sqlite3BtreeLastPage(Btree *p){
   return p->pOps->xLastPage(p);
@@ -8372,6 +8396,11 @@ static int prollyBtCursorInsert(
     }
   }
 
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(pIntKeyBuf);
+    return rc;
+  }
+  rc = prollyBtreeCheckMaxPageCount(pCur->pBtree);
   if( rc!=SQLITE_OK ){
     sqlite3_free(pIntKeyBuf);
     return rc;

--- a/test/doltlite_recover_rawformat_3.test
+++ b/test/doltlite_recover_rawformat_3.test
@@ -125,9 +125,9 @@ source $testdir/tester.tcl
 #   aux.schema_version around ALTER TABLE aux.t ADD COLUMN d DEFAULT 1000,
 #   with the default applied to existing rows (9.2)
 # covers-class: tkt2920 tkt2920-1.{1,3,5} (3 entries): PRAGMA max_page_count
-#   is ignored (reads 2147483647) — the chunk store has no page cap, so the
-#   original's disk-full path is unreachable; the same blob volume inserts
-#   fine with integrity ok (10.1, 10.2)
+#   uses DoltLite's synthetic page metric. Attempts to lower below the current
+#   metric clamp to the current value; the cap can be raised again and the same
+#   blob volume inserts fine with integrity ok (10.1, 10.2)
 # covers: tkt2920 tkt2920-1.9 — after the txn is rolled back, COMMIT errors
 #   'cannot commit - no transaction is active' verbatim (10.3)
 # covers: enc enc-12.1 — PRAGMA encoding='UTF-16le' on a fresh db is ignored:
@@ -768,11 +768,14 @@ do_test doltlite_recover_rawformat_3-9.2 {
 } {{1 one 1000 2 two 1000} 1 0}
 
 #-------------------------------------------------------------------------
-# 10.* tkt2920: no page cap / disk-full path; rollback then COMMIT error
+# 10.* tkt2920: synthetic page cap clamp; rollback then COMMIT error
 #
 do_test doltlite_recover_rawformat_3-10.1 {
-  execsql {PRAGMA max_page_count=40}
-} {2147483647}
+  set before [db one {PRAGMA page_count}]
+  set capped [db one {PRAGMA max_page_count=40}]
+  execsql {PRAGMA max_page_count=2147483647}
+  list [expr {$before>40}] [expr {$capped==$before}]
+} {1 1}
 do_test doltlite_recover_rawformat_3-10.2 {
   execsql {CREATE TABLE filler(fill)}
   execsql BEGIN

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -5341,3 +5341,7 @@ pagerfault3 pagerfault3-1-ioerr-transient.21  # VACUUM=dolt_gc reports phase-pre
 pagerfault3 pagerfault3-1-ioerr-transient.22  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
 fts4aa fts4aa-1.9  # FTS4 deferral heuristic reads the synthetic 4096 page size; stock at page_size=4096 returns identical values
 fts3malloc fts3_malloc-2.1.transient.100000.18  # expected count bakes in a master row stock leaks from a faulted CREATE; doltlite's CREATE stays atomic (clean replay = 4 on both engines) — #1333
+
+# ── sqllimits1 ──
+sqllimits1 sqllimits1-7.7.1  # max_page_count/page_count use DoltLite synthetic chunk counts, not stock file pages
+sqllimits1 sqllimits1-7.7.3  # max_page_count/page_count use DoltLite synthetic chunk counts, not stock file pages

--- a/test/regression-buckets/core-sql.txt
+++ b/test/regression-buckets/core-sql.txt
@@ -330,6 +330,7 @@ spellfix3
 spellfix4
 sqldiff1
 sqllog
+sqllimits1
 starschema1
 stat
 strict1


### PR DESCRIPTION
## Summary
- store and return DoltLite's synthetic `max_page_count` instead of always reporting SQLite's default maximum
- fail DoltLite inserts with `SQLITE_FULL` once pending synthetic page growth exceeds the configured cap
- gate `sqllimits1.test`, leaving only the documented synthetic page-count display divergences

Fixes #1359.

## Verification
- `LIBRARY_PATH=/opt/homebrew/lib make DOLTLITE_PROLLY_CHECK=1 testfixture`
- isolated `run_testfixture.sh 'probe sqllimits1' 300 sqllimits1` -> `OK: sqllimits1 (3117 tests, 2 known divergences)`
- temp-dir `test/doltlite_recover_pragma_output.test` -> `0 errors out of 72 tests`
- regression bucket disjointness check -> `disjoint-ok`

Note: local build needs `LIBRARY_PATH=/opt/homebrew/lib` because this machine's Homebrew Tcl link flags include `-ltommath`.
