### PR TITLE
Re-seek the tree side after an exact mutmap hit in index moveto

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -6662,7 +6662,12 @@ static int materializeDeferredTreeSeek(BtCursor *pCur, int dir){
   refreshCursorRoot(pCur);
   rc = prollyCursorCheckInterrupt(pCur);
   if( rc!=SQLITE_OK ) return rc;
-  rc = prollyCursorSeekInt(&pCur->pCur, pCur->cachedIntKey, &res);
+  if( pCur->curIntKey ){
+    rc = prollyCursorSeekInt(&pCur->pCur, pCur->cachedIntKey, &res);
+  }else{
+    ProllyMutMapEntry *e = orderedMutMapEntryAt(pCur->pMutMap, pCur->mmIdx);
+    rc = prollyCursorSeekBlob(&pCur->pCur, e->pKey, e->nKey, &res);
+  }
   if( rc!=SQLITE_OK ) return rc;
   if( res==0 ){
     pCur->mergeSrc = MERGE_SRC_BOTH;
@@ -7565,6 +7570,10 @@ static int prollyBtCursorIndexMoveto(
         if( pEntry && pEntry->op==PROLLY_EDIT_INSERT ){
           setCursorToMutMapEntryPhys(
               pCur, (int)(pEntry - pCur->pMutMap->aEntries));
+          /* The tree side is still wherever the last operation left it. A
+          ** later step must re-seek it to this key before merging, or it
+          ** feeds stale entries into the merge scan. */
+          pCur->deferredTreeSeek = 1;
           *pRes = 0;
           pIdxKey->eqSeen = 1;
           return SQLITE_OK;
@@ -7575,14 +7584,10 @@ static int prollyBtCursorIndexMoveto(
         rc = prollyMutMapFindRc(pPending, pSortKey, nSortKey, 0, &pEntry);
         if( rc!=SQLITE_OK ) return rc;
         if( pEntry && pEntry->op==PROLLY_EDIT_INSERT ){
-          if( pEntry->nVal>0 && pEntry->pVal ){
-            rc = cacheCursorPayloadCopy(pCur, pEntry->pVal, pEntry->nVal);
-          }else{
-            rc = cacheCursorPayloadReconstructed(
-                pCur, pEntry->pKey, pEntry->nKey);
-          }
-          if( rc!=SQLITE_OK ) return rc;
-          pCur->eState = CURSOR_VALID;
+          pCur->pMutMap = pPending;
+          setCursorToMutMapEntryPhys(
+              pCur, (int)(pEntry - pPending->aEntries));
+          pCur->deferredTreeSeek = 1;
           *pRes = 0;
           pIdxKey->eqSeen = 1;
           return SQLITE_OK;

--- a/test/regression-buckets/core-sql.txt
+++ b/test/regression-buckets/core-sql.txt
@@ -348,6 +348,7 @@ tpch01
 trace2
 trace3
 trans
+trans2
 trans3
 transitive1
 types


### PR DESCRIPTION
Closes #1353.

## Bug

`prollyBtCursorIndexMoveto`'s exact-match fast paths (key found in the pending mutmap) position the cursor on the map entry and return — without seeking the prolly tree cursor, which keeps whatever position the previous operation left. The next `Next`/`Prev` merges that stale tree position into the scan and yields out-of-order entries.

`integrity_check` is the main consumer that steps right after an exact seek: its UNIQUE probe seeks each row's index key, steps `Next`, and expects strictly-greater. With committed rows in the index tree + fresh inserts pending in the map, the stale tree entry compared `<=` the current key → "non-unique entry in index" on fully distinct keys. Repro needs only committed tree content + in-txn inserts (blob size / flushes irrelevant); fresh tables are immune because the empty tree side never produces a stale candidate.

## Fix

The int-key moveto already solved this with `deferredTreeSeek` — `materializeDeferredTreeSeek` now handles non-int cursors too (seeks the tree to the positioned map entry's sort key; same `res` conventions), and both index exact-match fast paths arm it. The stale-alias path additionally adopted the table's live pending map instead of faking the position with a cached payload (it left even the map side unpositioned).

## Evidence

Fail-before (master): minimal repro reports 15–100 spurious non-unique entries across 4 scenario shapes; `trans2.test`: 3 failures (2.4/3.4/4.4).
Pass-after: all repro shapes `ok`; **`trans2`: 0 errors out of 408** → added to the core-sql bucket so it stays covered (it was in no bucket, which is how this stayed invisible — found while blast-radius testing #1340).

- C corpus: **309807/309807**
- core-sql + ported buckets: 335,535 passing, 0 unexpected
- Targeted gate: trans2, trans, trans3, index, where, savepoint, fts3malloc — all OK (16,391 passing)
- avtrans: 50 failures on both master and this branch (pre-existing, byte-identical, auto_vacuum-dominated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)