### PR TITLE
Port savepointfault's runnable coverage; leave the upstream file verbatim

### DIFF
--- a/test/doltlite_recover_savepointfault.test
+++ b/test/doltlite_recover_savepointfault.test
@@ -1,0 +1,81 @@
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+source $testdir/malloc_common.tcl
+
+set testprefix doltlite_recover_savepointfault
+
+# Recovered coverage for savepointfault.test, which cannot run as a whole
+# file: malloc-4's -sqlprep opens with "PRAGMA auto_vacuum = incremental"
+# (and later runs "PRAGMA incremental_vacuum"), both rejected by design on
+# doltlite-format databases. The prep failure happens before the malloc
+# fault is armed, so it is deterministic, and do_malloc_test's loop never
+# reaches its stop condition (nFail>0): the file repeats the identical
+# failure until the tester's error cap aborts it. The fault scenarios that
+# do not depend on auto_vacuum are ported here verbatim.
+#
+# covers: savepointfault savepointfault-malloc-1 — OOM at every allocation point through nested savepoints with INSERT/DELETE, ROLLBACK TO, RELEASE; each iteration either fails with OOM or completes (malloc-1)
+# covers: savepointfault savepointfault-malloc-2 — same contract under cache pressure: multi-hundred-row table, nested savepoints with DELETEs, double ROLLBACK TO, RELEASE (malloc-2)
+# covers: savepointfault savepointfault-ioerr-3 — IO errors at every point through BEGIN/UPDATE/SAVEPOINT/UPDATE/COMMIT; database checksum verified intact after each recovery (ioerr-3)
+# not-covered: savepointfault savepointfault-malloc-4 — prep requires auto_vacuum=incremental and PRAGMA incremental_vacuum, both intentionally rejected on doltlite-format databases; the page-freelist savepoint rollback it targets has no doltlite equivalent
+
+do_malloc_test 1 -sqlprep {
+  CREATE TABLE t1(a, b, c);
+  INSERT INTO t1 VALUES(1, 2, 3);
+} -sqlbody {
+  SAVEPOINT one;
+    INSERT INTO t1 VALUES(4, 5, 6);
+    SAVEPOINT two;
+      DELETE FROM t1;
+    ROLLBACK TO two;
+  RELEASE one;
+}
+
+do_malloc_test 2 -sqlprep {
+  PRAGMA cache_size = 10;
+  CREATE TABLE t1(a, b, c);
+  INSERT INTO t1 VALUES(randstr(400,400), randstr(400,400), randstr(400,400));
+  INSERT INTO t1 SELECT
+    randstr(400,400), randstr(400,400), randstr(400,400) FROM t1;
+  INSERT INTO t1
+    SELECT randstr(400,400), randstr(400,400), randstr(400,400) FROM t1;
+  INSERT INTO t1
+    SELECT randstr(400,400), randstr(400,400), randstr(400,400) FROM t1;
+  INSERT INTO t1
+    SELECT randstr(400,400), randstr(400,400), randstr(400,400) FROM t1;
+  INSERT INTO t1
+    SELECT randstr(400,400), randstr(400,400), randstr(400,400) FROM t1;
+  INSERT INTO t1
+    SELECT randstr(400,400), randstr(400,400), randstr(400,400) FROM t1;
+  INSERT INTO t1
+    SELECT randstr(400,400), randstr(400,400), randstr(400,400) FROM t1;
+  INSERT INTO t1
+    SELECT randstr(400,400), randstr(400,400), randstr(400,400) FROM t1;
+} -sqlbody {
+  PRAGMA cache_size = 10;
+  SAVEPOINT one;
+    DELETE FROM t1 WHERE rowid < 5;
+    SAVEPOINT two;
+      DELETE FROM t1 WHERE rowid > 10;
+    ROLLBACK TO two;
+  ROLLBACK TO one;
+  RELEASE one;
+}
+
+do_ioerr_test 3 -sqlprep {
+  CREATE TABLE t1(a, b, c);
+  INSERT INTO t1 VALUES(1, randstr(1000,1000), randstr(1000,1000));
+  INSERT INTO t1 VALUES(2, randstr(1000,1000), randstr(1000,1000));
+} -sqlbody {
+  BEGIN;
+    UPDATE t1 SET a = 3 WHERE a = 1;
+    SAVEPOINT one;
+      UPDATE t1 SET a = 4 WHERE a = 2;
+  COMMIT;
+} -cleanup {
+  db eval {
+    SAVEPOINT one;
+    RELEASE one;
+  }
+}
+
+finish_test

--- a/test/regression-buckets/ported.txt
+++ b/test/regression-buckets/ported.txt
@@ -12,5 +12,6 @@ doltlite_recover_rawformat_1
 doltlite_recover_rawformat_2
 doltlite_recover_rawformat_3
 doltlite_recover_rejections
+doltlite_recover_savepointfault
 doltlite_recover_utf16_errtext
 doltlite_recover_withoutrowid


### PR DESCRIPTION
Closes #1354.

Reworked per review: no modifications to inherited tcl files.

## Diagnosis (unchanged)

Not an OOM-recovery bug. `savepointfault-malloc-4`'s `-sqlprep` opens with `PRAGMA auto_vacuum = incremental` (and later `PRAGMA incremental_vacuum`) — both intentionally rejected on doltlite-format databases. The prep runs **before** the fault point is armed, so the failure is deterministic, and `do_malloc_test`'s unguarded prep throws past the loop's stop condition: the identical failure repeats from `.7` until the tester's 1000-error cap aborts the file. The actual fault-injection scenarios all pass.

## Resolution

The ported-coverage convention (same as the #1313 files): upstream `savepointfault.test` stays byte-for-byte verbatim and excluded from buckets; new `test/doltlite_recover_savepointfault.test` carries the runnable coverage —

- `malloc-1` (nested savepoints, INSERT/DELETE, ROLLBACK TO, RELEASE under OOM at every allocation)
- `malloc-2` (same under cache pressure, double ROLLBACK TO)
- `ioerr-3` (BEGIN/UPDATE/SAVEPOINT/UPDATE/COMMIT under IO errors, checksum-verified)

ported verbatim with `covers:` mapping, and `malloc-4` documented as not-covered with the mechanism (its page-freelist vacuum rollback has no doltlite equivalent). File joins the `ported` bucket: **459 tests, 0 divergence entries**.

Full ported bucket through the strict gate: 2,286 passing, 0 unexpected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)