### PR TITLE
Account for pending writes in max_page_count

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -738,12 +738,50 @@ static i64 prollyBtreeSyntheticPageCount(Btree *p){
   return n;
 }
 
+static i64 prollyBtreePendingPageEstimate(Btree *p, i64 nLimit){
+  i64 nBytes = 0;
+  i64 nInsert = 0;
+  i64 nBytePages;
+  i64 nRowPages;
+  i64 nPageSize;
+  int i;
+  if( !p || !p->pBt ) return 0;
+  nPageSize = p->pBt->pageSize>0 ? (i64)p->pBt->pageSize : 1024;
+  for(i=0; i<p->cat.n; i++){
+    if( p->cat.a[i].pPending ){
+      ProllyMutMap *pMap = (ProllyMutMap*)p->cat.a[i].pPending;
+      int j;
+      for(j=0; j<pMap->nEntries; j++){
+        ProllyMutMapEntry *pEntry = &pMap->aEntries[j];
+        if( pEntry->op==PROLLY_EDIT_INSERT ){
+          nInsert++;
+          nBytes += (i64)pEntry->nKey + (i64)pEntry->nVal + 16;
+          if( nLimit>0 && nInsert/16 + nBytes/(2*nPageSize) > nLimit ){
+            return nLimit + 1;
+          }
+        }
+      }
+    }
+  }
+  nBytePages = (nBytes + 2*nPageSize - 1)/(2*nPageSize);
+  nRowPages = (nInsert + 15)/16;
+  return nBytePages > nRowPages ? nBytePages : nRowPages;
+}
+
 static int prollyBtreeCheckMaxPageCount(Btree *p){
+  i64 nCurrent;
+  i64 nPending;
   if( !p ) return SQLITE_OK;
   if( p->mxPageCount==0 || p->mxPageCount>=SQLITE_MAX_PAGE_COUNT ){
     return SQLITE_OK;
   }
-  if( prollyBtreeSyntheticPageCount(p) > (i64)p->mxPageCount ){
+  nCurrent = prollyBtreeSyntheticPageCount(p);
+  if( nCurrent > (i64)p->mxPageCount ){
+    return SQLITE_FULL;
+  }
+  nPending = prollyBtreePendingPageEstimate(
+      p, (i64)p->mxPageCount - nCurrent);
+  if( nCurrent + nPending > (i64)p->mxPageCount ){
     return SQLITE_FULL;
   }
   return SQLITE_OK;

--- a/test/doltlite_recover_pragma_output.test
+++ b/test/doltlite_recover_pragma_output.test
@@ -96,6 +96,9 @@ source $testdir/tester.tcl
 # covers: multiplex4 multiplex4-1.2 — PRAGMA multiplex_truncate is a no-op returning nothing (11.4)
 # covers: multiplex4 multiplex4-1.10 — growing data never spawns numbered overflow files (11.2)
 # covers: multiplex4 multiplex4-1.11 — DELETE+VACUUM keeps the single-file layout and data readable (11.3)
+# covers-class: tkt2686 tkt2686-{1..1999}.{1..3}: max_page_count accounts for
+#   unflushed pending writes, so repeated fill-to-full loops hit SQLITE_FULL
+#   quickly, rollback cleanly, and preserve integrity (12.1, 12.2)
 
 #-----------------------------------------------------------------------
 # 1: cache_size / default_cache_size / synchronous session contract
@@ -614,5 +617,49 @@ do_test doltlite_recover_pragma_output-11.4 {
        [execsql {PRAGMA multiplex_truncate=off}] \
        [execsql {PRAGMA multiplex_truncate=on}]
 } {{} {} {}}
+
+#-----------------------------------------------------------------------
+# 12: max_page_count includes pending writes before mutmap drain
+#
+do_test doltlite_recover_pragma_output-12.1 {
+  db close
+  forcedelete test2686.db
+  sqlite3 db test2686.db
+  execsql {
+    PRAGMA page_size=1024;
+    PRAGMA max_page_count=50;
+    PRAGMA auto_vacuum=0;
+    CREATE TABLE filler(fill);
+  }
+  expr {[db one {PRAGMA max_page_count}]==50}
+} {1}
+do_test doltlite_recover_pragma_output-12.2 {
+  set maxInsert 0
+  for {set i 0} {$i<20} {incr i} {
+    execsql BEGIN
+    set nInsert 0
+    set rc [catch {
+      while 1 {
+        execsql {INSERT INTO filler(fill) VALUES(randstr(1000,10000))}
+        incr nInsert
+      }
+    } msg]
+    if {$rc!=1 || $msg ne "database or disk is full"} {
+      error "expected SQLITE_FULL, got rc=$rc msg=$msg"
+    }
+    if {$nInsert>$maxInsert} { set maxInsert $nInsert }
+    execsql {
+      DELETE FROM filler
+       WHERE rowid <= (SELECT MAX(rowid) FROM filler LIMIT 20)
+    }
+    if {[execsql {PRAGMA integrity_check}] ne "ok"} {
+      error "integrity_check failed"
+    }
+    catch {execsql COMMIT}
+  }
+  list [expr {$maxInsert>0 && $maxInsert<200}] \
+       [execsql {SELECT count(*) FROM filler}] \
+       [execsql {PRAGMA integrity_check}]
+} {1 0 ok}
 
 finish_test


### PR DESCRIPTION
## Summary
- include unflushed pending mutmap inserts in DoltLite's synthetic `max_page_count` enforcement
- keep the check scoped to databases with a lowered page cap; default `SQLITE_MAX_PAGE_COUNT` path still returns immediately
- add a focused ported regression for the `tkt2686` fill-to-full/delete/integrity pattern

Fixes #1360.

## Details
After #1361, `tkt2686.test` no longer hung forever, but each fill-to-full loop still inserted 65,536 rows before DoltLite noticed the page cap. Stock SQLite hits `SQLITE_FULL` after roughly page-cap-scale growth. This PR estimates pending write growth before mutmap drain, so the loop now trips after 75 inserts locally.

The inherited `tkt2686.test` itself now reaches its second half in under a second, then aborts at `PRAGMA auto_vacuum=1`, which is an intentional DoltLite feature gap. I did not add the whole inherited file as an expected crash because that would mask future timeout regressions. The new regression lives in the already-gated `doltlite_recover_pragma_output.test` ported bucket instead.

## Verification
- `LIBRARY_PATH=/opt/homebrew/lib make DOLTLITE_PROLLY_CHECK=1 testfixture`
- `doltlite_recover_pragma_output.test` -> `0 errors out of 74 tests`
- `run_testfixture.sh 'probe ported' 300 ...` -> green, `1858` passing
- `run_testfixture.sh 'probe tkt2920' 300 tkt2920` -> `6` passing, `4` known divergences
- `run_testfixture.sh 'probe sqllimits1' 300 sqllimits1` -> `3115` passing, `2` known divergences
- local `tkt2686.test` now reaches intentional `auto_vacuum=1` abort in `real 0.76s`
- regression bucket disjointness check -> `disjoint-ok`
