### PR TITLE
Gate misc7: fix directory-open error code, pin runner fd limit

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -417,6 +417,18 @@ int chunkStoreOpen(
         chunkStoreClose(cs);
         return rc;
       }
+      /* unixOpen already retries read-only for permission failures, so a
+      ** handle that only this second attempt could open may not be a
+      ** readable database at all: Linux opens a directory O_RDONLY and
+      ** every later read fails SQLITE_IOERR_READ. Probe one byte so that
+      ** shape surfaces as "unable to open database file", like stock. */
+      {
+        u8 probe;
+        if( sqlite3OsRead(cs->file.pFile, &probe, 1, 0)==SQLITE_IOERR_READ ){
+          chunkStoreClose(cs);
+          return SQLITE_CANTOPEN;
+        }
+      }
       cs->readOnly = 1;
     }else if( wantReadOnly || (outFlags & SQLITE_OPEN_READONLY) ){
       /* Either the caller asked for read-only, or a read-write open silently

--- a/test/known_testfixture_crashes.txt
+++ b/test/known_testfixture_crashes.txt
@@ -157,4 +157,5 @@ ioerr          # giant IO-fault loop: runtime load-sensitive, exceeds per-file t
 malloc         # giant OOM-fault loop: runtime load-sensitive, exceeds per-file timeout under CI load
 backup_ioerr   # divergences exceed the 1000-error cap mid-file; capped list is order-fragile
 malloc6        # OOM fault-point set varies run to run: failure list nondeterministic
+misc7          # WHERE rowid=? on a PK table errors (intentional rowid-on-PK divergence); do_eqp_test 14.1 throws uncaught -> aborts pre-summary
 multiplex      # multiplex-VFS fault set varies run to run: failure list nondeterministic

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -2159,7 +2159,6 @@ memjournal memjournal-1.1  # journal_mode pragma rejected + cascade
 memjournal memjournal-1.2  # journal_mode pragma rejected + cascade
 mmapcorrupt mmapcorrupt-2.1  # mmap stock-page corruption: offset misses chunk-store structures
 mmapwarm mmapwarm-1.0  # PRAGMA page_count: chunk store has no SQLite page count
-oserror oserror-1.2.1  # open-path differs: lock-file opened first; no -wal to unlink
 oserror oserror-1.3.1  # open-path differs: lock-file opened first; no -wal to unlink
 oserror oserror-1.3.2  # open-path differs: lock-file opened first; no -wal to unlink
 oserror oserror-2.1.1  # open-path differs: lock-file opened first; no -wal to unlink

--- a/test/regression-buckets/core-sql.txt
+++ b/test/regression-buckets/core-sql.txt
@@ -201,6 +201,7 @@ misc2
 misc3
 misc5
 misc6
+misc7
 misc8
 misuse
 mutex2

--- a/test/run_testfixture.sh
+++ b/test/run_testfixture.sh
@@ -32,6 +32,12 @@ LABEL="${1:?Usage: run_testfixture.sh <label> <timeout_secs> test1 test2 ...}"
 TIMEOUT="${2:?Missing timeout}"
 shift 2
 
+# Several inherited tests (misc7-6.*) exhaust all file descriptors one tcl
+# channel at a time, so runtime scales with the fd limit: at CI's default
+# soft limit (1024) they take seconds, but dev machines and docker commonly
+# raise it to ~1M, which looks like a hang. Pin the soft limit to match CI.
+ulimit -Sn 1024 2>/dev/null || true
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 DIVERGENCE_FILE="${DIVERGENCE_FILE:-$SCRIPT_DIR/known_testfixture_divergences.txt}"
 CRASH_FILE="${CRASH_FILE:-$SCRIPT_DIR/known_testfixture_crashes.txt}"


### PR DESCRIPTION
Part of #1357 (misc7 triage).

## The "timeout" was never an engine hang

`misc7-6.*` exhausts **every available file descriptor** (one Tcl channel each) before each open attempt, so runtime scales with `ulimit -n`: at CI's default soft limit (1024) the sections finish in seconds; this Mac and docker default to **1,048,576**, which takes minutes per `use_up_files` call — identically for stock sqlite built from any tree. SQLite's suite isn't broken; it assumes a classic fd limit. `run_testfixture.sh` now pins `ulimit -Sn 1024` so local runs match CI. With that, misc7-6.1/6.2 **pass** (doltlite converges in the same 2–3 iterations as stock).

## Real bug fixed (misc7-4)

Opening a directory as a database returned `disk I/O error` instead of stock's `unable to open database file`. Mechanism: `unixOpen` already retries read-only internally for permission failures, so the chunk store's read-only fallback only ever "succeeds" where that retry refused — Linux opens a directory `O_RDONLY` — and `csReadManifest` then fails `SQLITE_IOERR_READ`. The fallback now probes one byte and returns `SQLITE_CANTOPEN` when the handle can't be read. misc7-4 passes; fail-before/pass-after via the in-file assertion.

## Remaining file shape (all mechanism-verified)

- `misc7-5`: stock fails when a directory squats on the `-journal` path; doltlite has no journal sidecar, open succeeds — intentional.
- `misc7-10/11/12.x/13`: the `echo` vtab generates rowid-based SQL against a PK table → doltlite's intentional rowid-on-PK divergence cascades (`SELECT rowid FROM <pk-table>` → "no such column", verified directly).
- `misc7-14.1`: `WHERE rowid=?` EQP on a PK table throws uncaught from `do_eqp_test` → file aborts pre-summary. misc7 joins the **crash list** with that reason and the **core-sql bucket**, so sections 1–14.0 are CI-covered as of this PR.
- Sections 14.2–23 (post-abort) are recoverable coverage for the ported-bucket convention — left as #1357 campaign work.

## Verification

- C corpus 309807/309807 (chunk_store.c touched)
- core-sql + storage + ported buckets through the strict gate: **343,303 passing, 0 unexpected**, `CRASH (expected): misc7`

🤖 Generated with [Claude Code](https://claude.com/claude-code)