### PR TITLE
Port lock4 cross-process locking coverage

### DIFF
--- a/test/doltlite_recover_locking_2.test
+++ b/test/doltlite_recover_locking_2.test
@@ -107,6 +107,12 @@ source $testdir/tester.tcl
 # covers: tkt4018 tkt4018-2.2 — BEGIN; SELECT ORDER BY sees all committed rows; readonly conn write rejected (13.3-13.5)
 # covers: shared shared-1.7.2 — open scan unaffected by concurrent delete of sibling table; full contents returned (14.1-14.3)
 # covers: capi2 capi2-6.5 — 2nd-conn INSERT into table mid-scan succeeds; running statement keeps its snapshot (14.1, 14.3)
+# covers-class: lock4 lock4-{1.1,1.2,1.3,999.1}: the inherited test waits
+#   for a rollback-journal sidecar as its cross-process synchronization point.
+#   DoltLite has no journal sidecar, so the native contract uses an explicit
+#   marker: the child holds a write txn on test2, the parent is locked out,
+#   parent commit unblocks the child write to test1, and both dbs converge
+#   (17.1).
 #
 # not-covered: (none)
 
@@ -693,6 +699,69 @@ do_execsql_test doltlite_recover_locking_2-16.2 {
 do_test doltlite_recover_locking_2-16.3 {
   execsql {PRAGMA integrity_check}
 } {ok}
+
+#-------------------------------------------------------------------------
+# 17.* lock4: cross-process write-lock ordering without journal sidecars.
+#
+do_test doltlite_recover_locking_2-17.1 {
+  foreach f {
+    lk4a.db lk4b.db lk4.ready lk4.done lk4.write lk4.commit lk4-child.tcl
+  } {
+    forcedelete $f
+  }
+  sqlite3 lk4a lk4a.db
+  lk4a eval {CREATE TABLE t1(x)}
+  sqlite3 lk4b lk4b.db
+  lk4b eval {CREATE TABLE t2(x)}
+  lk4b close
+
+  set out [open lk4-child.tcl w]
+  puts $out "sqlite3_test_control_pending_byte [set sqlite_pending_byte]"
+  puts $out {
+    sqlite3 child2 lk4b.db
+    child2 timeout 1000
+    child2 eval {BEGIN; INSERT INTO t2 VALUES(2)}
+    set f [open lk4.ready w]; puts $f ready; close $f
+
+    sqlite3 child1 lk4a.db
+    child1 timeout 1000
+    set r [catch {child1 eval {INSERT INTO t1 VALUES(2)}} msg]
+    set f [open lk4.write w]; puts $f [list $r $msg]; close $f
+    catch {child1 close}
+
+    set r [catch {child2 eval COMMIT} msg]
+    set f [open lk4.commit w]; puts $f [list $r $msg]; close $f
+    catch {child2 close}
+    set f [open lk4.done w]; puts $f done; close $f
+    exit
+  }
+  close $out
+
+  lk4a eval {BEGIN EXCLUSIVE; INSERT INTO t1 VALUES(1)}
+  exec [info nameofexec] ./lk4-child.tcl &
+  set n 0
+  while {![file exists lk4.ready] && $n<200} { after 10; incr n }
+
+  sqlite3 lk4b lk4b.db
+  set parentWrite [catchsql {INSERT INTO t2 VALUES(1)} lk4b]
+  set parentCommit [catchsql {COMMIT} lk4a]
+  set n2 0
+  while {![file exists lk4.done] && $n2<200} { after 10; incr n2 }
+
+  set f [open lk4.write]; set childWrite [read $f]; close $f
+  set f [open lk4.commit]; set childCommit [read $f]; close $f
+  set out [list \
+      [expr {$n<200}] \
+      $parentWrite \
+      $parentCommit \
+      [string trim $childWrite] \
+      [string trim $childCommit] \
+      [lk4a eval {SELECT * FROM t1 ORDER BY x}] \
+      [lk4b eval {SELECT * FROM t2 ORDER BY x}]]
+  lk4a close
+  lk4b close
+  set out
+} {1 {1 {database is locked}} {0 {}} {0 {}} {0 {}} {1 2} 2}
 
 db2 close
 finish_test

--- a/test/known_testfixture_crashes.txt
+++ b/test/known_testfixture_crashes.txt
@@ -150,7 +150,7 @@ walro2         # reads test.db-shm: no shm sidecar
 walsetlk       # opens test.db-shm: no shm sidecar
 walsetlk_recover # shm/recovery locks: no shm sidecar
 ioerr2         # fault loop runs tens of thousands of iterations; exceeds any per-file timeout
-lock4          # waits on a cross-process lock that never materializes under chunk-store locking
+lock4          # waits on test2.db-journal sidecar; native cross-process lock ordering covered in doltlite_recover_locking_2-17.1 (#1365)
 sharedA        # shared-cache scenario hangs awaiting a lock state doltlite never enters
 quota          # quota-VFS thresholds trip at run-varying chunk-store sizes: failure set nondeterministic
 ioerr          # giant IO-fault loop: runtime load-sensitive, exceeds per-file timeout under CI load


### PR DESCRIPTION
## Summary
- add DoltLite-native coverage for the `lock4.test` cross-process lock-ordering scenario
- use an explicit marker file instead of the inherited test's rollback-journal sidecar synchronization
- update the expected-crash comment for inherited `lock4` to point at the native coverage

Fixes #1365.

## Details
The inherited `lock4.test` waits for `test2.db-journal` to appear before the parent attempts the conflicting write. DoltLite has no rollback-journal sidecar, so the inherited file hangs before it can test the actual lock-ordering behavior.

The new `doltlite_recover_locking_2-17.1` case asserts the same useful contract with a DoltLite-compatible marker:
- child starts a write transaction on the second database
- parent is locked out of that second database
- parent commits the first database
- child completes its write to the first database and commits the second
- both databases converge on the expected rows

## Verification
- `doltlite_recover_locking_2.test` -> `0 errors out of 105 tests`
- `run_testfixture.sh 'probe ported' 300 ...` -> green, `2289` passing
- regression bucket disjointness check -> `disjoint-ok`
