### PR TITLE
Port sharedA rollback coverage

### DIFF
--- a/test/doltlite_recover_locking_2.test
+++ b/test/doltlite_recover_locking_2.test
@@ -107,11 +107,14 @@ source $testdir/tester.tcl
 # covers: tkt4018 tkt4018-2.2 — BEGIN; SELECT ORDER BY sees all committed rows; readonly conn write rejected (13.3-13.5)
 # covers: shared shared-1.7.2 — open scan unaffected by concurrent delete of sibling table; full contents returned (14.1-14.3)
 # covers: capi2 capi2-6.5 — 2nd-conn INSERT into table mid-scan succeeds; running statement keeps its snapshot (14.1, 14.3)
+# covers: sharedA sharedA-2.1 — shared-cache setup with attached db and peer reader works (17.1, 17.2)
+# covers: sharedA sharedA-2.2 — schema+attached writes inside txn roll back atomically enough for peer statement reuse (17.3, 17.4)
+# covers: sharedA sharedA-2.3 — after rollback, main and attached dbs keep pre-rollback rows and integrity ok (17.5)
 #
 # not-covered: (none)
 
 db close
-foreach f {rlk2.db rlk2b.db rlk2p.db rlk2q.db rlk2n.db rlk2w.db rlk2s.db rlk2t.db} {
+foreach f {rlk2.db rlk2b.db rlk2p.db rlk2q.db rlk2n.db rlk2w.db rlk2s.db rlk2t.db rlk2u.db rlk2u.db2} {
   forcedelete $f
   forcedelete .${f}-lock
 }
@@ -693,6 +696,54 @@ do_execsql_test doltlite_recover_locking_2-16.2 {
 do_test doltlite_recover_locking_2-16.3 {
   execsql {PRAGMA integrity_check}
 } {ok}
+
+#-------------------------------------------------------------------------
+# 17.* sharedA recast: upstream waits for an xRead on test.db2-journal during
+# rollback.  doltlite has no rollback-journal sidecar, so cover the durable
+# contract after that rollback point instead.
+#
+do_test doltlite_recover_locking_2-17.1 {
+  set ::rlk2_shared_cache [sqlite3_enable_shared_cache 1]
+  sqlite3 dba rlk2u.db
+  dba eval {ATTACH 'rlk2u.db2' AS two}
+  dba eval {
+    CREATE TABLE t1(x);
+    INSERT INTO t1 VALUES(1);
+    INSERT INTO t1 VALUES(2);
+    INSERT INTO t1 VALUES(3);
+    CREATE TABLE two.t2(x);
+    INSERT INTO t2 SELECT * FROM t1;
+  }
+  sqlite3 dbb rlk2u.db
+  dbb eval {SELECT x FROM t1 ORDER BY x}
+} {1 2 3}
+do_test doltlite_recover_locking_2-17.2 {
+  set ::rlk2_stmt [sqlite3_prepare dbb "CREATE INDEX i1 ON t1(x)" -1 tail]
+  expr {[string length $::rlk2_stmt] > 0}
+} {1}
+do_test doltlite_recover_locking_2-17.3 {
+  dba eval {
+    BEGIN;
+      CREATE INDEX i1 ON t1(x);
+      INSERT INTO t2 VALUES('value!');
+    ROLLBACK;
+  }
+} {}
+do_test doltlite_recover_locking_2-17.4 {
+  list [sqlite3_step $::rlk2_stmt] [sqlite3_finalize $::rlk2_stmt] [sqlite3_errmsg dbb]
+} {SQLITE_DONE SQLITE_OK {not an error}}
+do_test doltlite_recover_locking_2-17.5 {
+  set r [list \
+    [dba eval {PRAGMA integrity_check}] \
+    [dbb eval {SELECT x FROM t1 ORDER BY x}] \
+    [dba eval {SELECT x FROM two.t2 ORDER BY x}] \
+  ]
+  dbb close
+  dba close
+  sqlite3_enable_shared_cache $::rlk2_shared_cache
+  unset -nocomplain ::rlk2_stmt ::rlk2_shared_cache
+  set r
+} {ok {1 2 3} {1 2 3}}
 
 db2 close
 finish_test

--- a/test/known_testfixture_crashes.txt
+++ b/test/known_testfixture_crashes.txt
@@ -151,7 +151,7 @@ walsetlk       # opens test.db-shm: no shm sidecar
 walsetlk_recover # shm/recovery locks: no shm sidecar
 ioerr2         # fault loop runs tens of thousands of iterations; exceeds any per-file timeout
 lock4          # waits on a cross-process lock that never materializes under chunk-store locking
-sharedA        # shared-cache scenario hangs awaiting a lock state doltlite never enters
+sharedA        # waits for a rollback-journal xRead during shared-cache rollback; native contract covered by doltlite_recover_locking_2-17.*
 quota          # quota-VFS thresholds trip at run-varying chunk-store sizes: failure set nondeterministic
 ioerr          # giant IO-fault loop: runtime load-sensitive, exceeds per-file timeout under CI load
 malloc         # giant OOM-fault loop: runtime load-sensitive, exceeds per-file timeout under CI load


### PR DESCRIPTION
## Summary

Fixes #1366.

`sharedA.test` hangs because the inherited test waits for a `testvfs` `xRead` callback on `test.db2-journal` during rollback. DoltLite does not create rollback-journal sidecars, so that callback never creates `::thread_result` and the upstream file blocks waiting for it.

This ports the relevant durable contract into `doltlite_recover_locking_2`:

- shared-cache setup with an attached database and peer reader works
- a schema change plus attached-table write inside a transaction rolls back cleanly
- the peer prepared schema-change statement remains usable after rollback
- main and attached tables retain only pre-rollback rows and integrity remains ok

It also updates `known_testfixture_crashes.txt` so future triage knows why the inherited file stays excluded.

## Tests

- `/Users/timsehn/dolthub/codex/doltlite/build-1359/testfixture /Users/timsehn/dolthub/codex/doltlite/test/doltlite_recover_locking_2.test`
- `bash test/run_testfixture.sh 'probe ported' 300 $(tr '\n' ' ' < test/regression-buckets/ported.txt)`
- `cat test/regression-buckets/*.txt | sort | uniq -d`
