### PR TITLE
Replace brittle insert-count bound in pragma_output max_page_count test

### DIFF
--- a/test/doltlite_recover_pragma_output.test
+++ b/test/doltlite_recover_pragma_output.test
@@ -97,8 +97,10 @@ source $testdir/tester.tcl
 # covers: multiplex4 multiplex4-1.10 — growing data never spawns numbered overflow files (11.2)
 # covers: multiplex4 multiplex4-1.11 — DELETE+VACUUM keeps the single-file layout and data readable (11.3)
 # covers-class: tkt2686 tkt2686-{1..1999}.{1..3}: max_page_count accounts for
-#   unflushed pending writes, so repeated fill-to-full loops hit SQLITE_FULL
-#   quickly, rollback cleanly, and preserve integrity (12.1, 12.2)
+#   unflushed pending writes, so repeated fill-to-full loops hit SQLITE_FULL,
+#   drain cleanly, preserve integrity, and never grow the file unbounded
+#   (12.1, 12.2). The per-iteration insert count depends on the randstr
+#   stream, so the assertion bounds the file size, not the count.
 
 #-----------------------------------------------------------------------
 # 1: cache_size / default_cache_size / synchronous session contract
@@ -657,9 +659,10 @@ do_test doltlite_recover_pragma_output-12.2 {
     }
     catch {execsql COMMIT}
   }
-  list [expr {$maxInsert>0 && $maxInsert<200}] \
+  list [expr {$maxInsert>0}] \
+       [expr {[file size test2686.db] < 50*1024*8}] \
        [execsql {SELECT count(*) FROM filler}] \
        [execsql {PRAGMA integrity_check}]
-} {1 0 ok}
+} {1 1 0 ok}
 
 finish_test


### PR DESCRIPTION
Closes #1370.

## Diagnosis

`doltlite_recover_pragma_output-12.2` (from the tkt2686 port) asserts `maxInsert>0 && maxInsert<200`. The insert count per fill-to-FULL iteration depends on the `randstr(1000,10000)` byte stream, which depends on the PRNG state that sections 1–11 leave behind — and that path varies by environment (observed: reliably failing as non-root on linux/arm64, passing as root in the same container, isolated-section runs landing anywhere from 75 to 223). In **every** observation the engine behavior the test exists to pin is correct: `SQLITE_FULL` fires each of the 20 iterations (enforced inside the loop), the drain empties the table, `integrity_check` is ok, and the file never grows (~2KB against the 50-page cap).

## Fix

The assertion now pins the actual tkt2686 invariants instead of a calibrated count: at least one insert succeeds from empty, and the file size stays bounded relative to the page cap. No engine change needed; `12.1`'s `max_page_count==50` pin and the in-loop SQLITE_FULL requirement are untouched.

Fail-before: 5/5 failing runs as non-root tester (standalone and in two bucket gates). Pass-after: 3/3 standalone as tester plus a full ported-bucket gate — **2,288 passing, 0 unexpected**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)