### PR TITLE
Re-triage ioerr.test: gate 155 stable divergences, move off crash list into fault-fuzz

### DIFF
--- a/test/known_testfixture_crashes.txt
+++ b/test/known_testfixture_crashes.txt
@@ -153,7 +153,6 @@ ioerr2         # fault loop runs tens of thousands of iterations; exceeds any pe
 lock4          # waits on test2.db-journal sidecar; native cross-process lock ordering covered in doltlite_recover_locking_2-17.1 (#1365)
 sharedA        # shared-cache scenario hangs awaiting a lock state doltlite never enters
 quota          # quota-VFS thresholds trip at run-varying chunk-store sizes: failure set nondeterministic
-ioerr          # giant IO-fault loop: runtime load-sensitive, exceeds per-file timeout under CI load
 malloc         # giant OOM-fault loop: runtime load-sensitive, exceeds per-file timeout under CI load
 backup_ioerr   # divergences exceed the 1000-error cap mid-file; capped list is order-fragile
 malloc6        # OOM fault-point set varies run to run: failure list nondeterministic

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -2467,6 +2467,174 @@ incrvacuum2 incrvacuum2-4.1  # auto_vacuum rejected; -wal sidecar absent
 incrvacuum2 incrvacuum2-4.2  # auto_vacuum rejected; -wal sidecar absent
 incrvacuum2 incrvacuum2-4.2.1  # auto_vacuum rejected; -wal sidecar absent
 incrvacuum2 incrvacuum2-4.3  # auto_vacuum rejected; -wal sidecar absent
+# ioerr: doltlite VACUUM maps to dolt_gc. Under DOLTLITE_PROLLY_CHECK (the
+# CI testfixture build) gc runs a post-sweep session-resolvability check
+# that re-reads chunks and deliberately treats injected IO faults as
+# inconclusive (only NOTFOUND aborts), so the final fault points record a
+# hit while the VACUUM statement still succeeds. A non-CHECK build passes
+# these three.
+ioerr ioerr-2.31.3  # PROLLY_CHECK gc verify ignores injected read faults
+ioerr ioerr-2.32.3  # PROLLY_CHECK gc verify ignores injected read faults
+ioerr ioerr-2.33.3  # PROLLY_CHECK gc verify ignores injected read faults
+# ioerr: the chunk store journals inside the single database file, so a
+# -journal sidecar never exists. Preps that crash a child on journal sync
+# (ioerr-6) or copy the journal aside (ioerr-7/9) fail before fault
+# injection starts; recovery itself passes once the prep error clears.
+ioerr ioerr-6.1.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.2.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.3.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.4.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.5.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.6.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.7.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.8.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.9.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.10.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.11.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.12.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.13.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.14.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.15.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.16.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.17.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.18.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.19.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.20.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.21.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.22.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.23.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.24.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.25.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.26.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.27.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.28.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.29.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.30.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.31.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.32.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.33.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.34.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.35.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.36.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.37.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.38.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.39.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.40.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.41.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.42.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.43.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.44.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.45.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.46.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.47.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.48.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.49.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.50.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.51.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.52.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.53.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.54.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.55.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.56.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.57.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.58.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.59.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.60.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.61.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.62.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.63.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.64.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.65.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.66.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.67.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.68.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.69.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.70.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.71.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.72.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.73.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.74.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.75.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.76.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.77.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.78.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.79.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.80.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.81.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.82.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.83.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.84.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.85.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.86.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.87.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-7.2.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.3.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.4.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.5.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.6.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.7.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.8.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.9.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.10.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.11.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.12.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.13.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.14.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.15.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.16.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.17.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.18.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.19.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.20.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.21.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.22.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.23.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.24.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.25.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.26.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.27.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.28.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.29.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.30.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.31.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.32.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.33.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.34.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.35.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.36.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.37.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.38.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.39.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.40.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.41.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.42.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.43.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.44.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.45.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.46.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.47.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.48.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.49.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.50.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.51.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.52.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.53.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.54.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.55.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-9.1.1  # master-journal prep copies absent -journal sidecar
+# ioerr: auto_vacuum rejected on doltlite-format databases; the prep
+# aborts before creating its tables and the body then errors without an
+# IO fault, breaking the hit-XOR-success invariant (cascade).
+ioerr ioerr-12.1.1  # auto_vacuum rejected; prep aborts, body fails without fault
+ioerr ioerr-12.1.3  # auto_vacuum rejected; prep aborts, body fails without fault
+ioerr ioerr-13.1.1  # auto_vacuum rejected; prep aborts, body fails without fault
+ioerr ioerr-13.2.1  # auto_vacuum rejected; prep aborts, body fails without fault
+ioerr ioerr-13.2.3  # auto_vacuum rejected; prep aborts, body fails without fault
+ioerr ioerr-14.1.1  # auto_vacuum rejected; prep aborts, body fails without fault
+ioerr ioerr-14.2.1  # auto_vacuum rejected; prep aborts, body fails without fault
+ioerr ioerr-14.2.3  # auto_vacuum rejected; prep aborts, body fails without fault
+ioerr ioerr-16.1.1  # auto_vacuum rejected; prep aborts, body fails without fault
+ioerr ioerr-16.1.3  # auto_vacuum rejected; prep aborts, body fails without fault
 ioerr3 ioerr3-2.3.3  # IO-fault point shift
 ioerr3 ioerr3-2.4.3  # IO-fault point shift
 ioerr3 ioerr3-2.5.3  # IO-fault point shift

--- a/test/regression-buckets/fault-fuzz.txt
+++ b/test/regression-buckets/fault-fuzz.txt
@@ -29,6 +29,7 @@ incrblobfault
 indexfault
 insertfault
 instrfault
+ioerr
 ioerr3
 ioerr5
 ioerr6


### PR DESCRIPTION
## Summary

`ioerr` was on `test/known_testfixture_crashes.txt` with the reason "giant IO-fault loop: runtime load-sensitive, exceeds per-file timeout under CI load". That was a misdiagnosis: the file completes in **~2 seconds** (1202 tests, 155 errors) on the CI-equivalent build (docker linux/arm64, `make DOLTLITE_PROLLY_CHECK=1 testfixture`, `ulimit -Sn 1024`), and three consecutive runs produce **byte-identical** failure lists. This PR re-triages all 155 failures mechanism-by-mechanism, gates them as known divergences, removes `ioerr` from the crash list, and adds it to the fault-fuzz CI bucket.

## Mechanism classification (155 failures, all repro-verified)

| Mechanism | Tests | Count |
|---|---|---|
| No `-journal` sidecar: the chunk store journals inside the single database file, so crashsql's crash-on-journal-sync trigger never fires (`Wrong error message: 0 {}`) and journal-copy preps fail (`error copying "test*.db-journal": no such file or directory`). Verified directly: no `test.db-journal` exists mid-transaction. Recovery itself is unaffected. | ioerr-6.{1-87}.1, ioerr-7.{2-55}.1, ioerr-9.1.1 | 142 |
| `auto_vacuum` rejected on doltlite-format databases: the prep aborts before creating its tables, then the body errors without an IO fault (`incremental_vacuum is not supported...` / `no such table`), breaking do_ioerr_test's hit-XOR-success invariant. Same cascade class as the existing `autovacuum_ioerr2` entries. | ioerr-12.1.{1,3}, ioerr-13.{1.1,2.1,2.3}, ioerr-14.{1.1,2.1,2.3}, ioerr-16.1.{1,3} | 10 |
| `DOLTLITE_PROLLY_CHECK`-only: VACUUM maps to `dolt_gc()`; after a successful sweep the debug session-resolvability check re-reads chunks and deliberately treats injected IO faults as inconclusive (only NOTFOUND aborts), so fault points 31-33 record a hit while VACUUM still succeeds. Cross-checked with a non-CHECK build: exactly these three failures disappear (152 vs 155). | ioerr-2.{31,32,33}.3 | 3 |

Everything else in the file passes: all faulted iterations roll back consistently (ioerr-2's before/after cksum checks pass on every iteration), page refcounts stay clean, and no "database disk image is malformed" or wrong-data outcomes appeared anywhere.

## Real-bug findings

No row-level or recovery bugs. One error-code fidelity finding, **filed as #1373 instead of fixed here**: when an injected IO fault aborts the gc sweep proper (fault points 29-30), VACUUM fails with generic `SQLITE_ERROR` / `gc sweep phase failed` instead of `SQLITE_IOERR`. The fix belongs in gc error propagation, which is being reworked on `fix/oom-swallow-gc`; not touching `src/doltlite_gc.c` here to avoid collision.

## Changes

- `test/known_testfixture_crashes.txt`: removed the `ioerr` entry (its stated reason was false).
- `test/known_testfixture_divergences.txt`: 155 entries grouped under one mechanism comment per class.
- `test/regression-buckets/fault-fuzz.txt`: added `ioerr` (alphabetical).

## Gate (full fault-fuzz bucket, non-root tester user, `ulimit -Sn 1024`, CI layout)

```
OK: ioerr (1202 tests, 155 known divergences)

=== ioerrtriage ===
  passing tests:                     268005
  known divergences (still failing): 803
GATE EXIT=0
```

All 74 bucket files OK (fuzz3 expected crash), exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)