### PR TITLE
Honor SQLITE_OPEN_READONLY for :memory: chunk stores

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -439,6 +439,9 @@ int chunkStoreOpen(
    || strcmp(zFilename, ":memory:")==0
    || (flags & SQLITE_OPEN_MEMORY)!=0 ){
     cs->isMemory = 1;
+    /* Honor SQLITE_OPEN_READONLY for in-memory stores too; otherwise a
+    ** read-only :memory: connection silently accepts writes. */
+    cs->readOnly = (flags & SQLITE_OPEN_READONLY)!=0;
     cs->file.zFilename = sqlite3_mprintf(":memory:");
     if( cs->file.zFilename==0 ){
       chunkStoreClose(cs);

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -177,6 +177,31 @@ static void run_create_collation_unsupported(void){
   sqlite3_close(db);
 }
 
+static void run_memory_readonly_open(void){
+  sqlite3 *db = 0;
+  int rc;
+
+  check("memory_readonly_open",
+        sqlite3_open_v2(":memory:", &db, SQLITE_OPEN_READONLY, 0)==SQLITE_OK);
+  if( db==0 ) return;
+  rc = sqlite3_exec(db, "CREATE TABLE t1(x)", 0, 0, 0);
+  check("memory_readonly_write_rejected", rc==SQLITE_READONLY);
+  check("memory_readonly_errmsg",
+        strcmp(sqlite3_errmsg(db), "attempt to write a readonly database")==0);
+  check("memory_readonly_read_ok",
+        strcmp(queryScalarText(db, "SELECT count(*) FROM sqlite_master"), "0")==0);
+  sqlite3_close(db);
+  db = 0;
+
+  check("memory_readwrite_open",
+        sqlite3_open_v2(":memory:", &db,
+            SQLITE_OPEN_READWRITE|SQLITE_OPEN_CREATE, 0)==SQLITE_OK);
+  if( db==0 ) return;
+  check("memory_readwrite_write_ok",
+        sqlite3_exec(db, "CREATE TABLE t1(x)", 0, 0, 0)==SQLITE_OK);
+  sqlite3_close(db);
+}
+
 static void run_rowid_in_integer_literals_uses_rowset(void){
   sqlite3 *db = 0;
   sqlite3_stmt *stmt = 0;
@@ -7697,6 +7722,7 @@ static const RegressionCase aCases[] = {
   { "backup_safety", "Backup Safety Test", run_backup_safety },
   { "integer_pk_autocommit_append_correctness", "Integer PK Autocommit Append Correctness Test", run_integer_pk_autocommit_append_correctness },
   { "create_collation_unsupported", "Create Collation Unsupported Test", run_create_collation_unsupported },
+  { "memory_readonly_open", "Memory Read-Only Open Test", run_memory_readonly_open },
   { "rowid_in_integer_literals_uses_rowset", "Rowid IN Integer Literals RowSet Test", run_rowid_in_integer_literals_uses_rowset },
   { "concurrent_refs", "Concurrent Refs Test", run_concurrent_refs },
   { "checkout_persist_failure", "Checkout Persist Failure Test", run_checkout_persist_failure },


### PR DESCRIPTION
Found during the inherited-testfixture sweep (openv2.test).

## Bug
`sqlite3_open_v2(":memory:", &db, SQLITE_OPEN_READONLY, 0)` returned a writable connection: the `:memory:` branch of `chunkStoreOpen` returns before the read-only flag handling that file-backed stores got, so `cs->readOnly` was never set and writes were silently accepted. Stock SQLite honors READONLY even on in-memory databases (upstream ticket #3908, pinned by openv2-2.2: expected `attempt to write a readonly database`, doltlite returned success).

## Fix
Set `cs->readOnly` from the open flags in the memory branch of `chunkStoreOpen`. The existing `BTS_READ_ONLY` plumbing (prolly_btree open copies `store.readOnly`) surfaces the write as `SQLITE_READONLY` with the stock message, same as the file-backed path proven by openv2-1.4.

## Testing
- Fail-before/pass-after: `openv2.test` goes 1 error -> 0 errors with the fix; new `memory_readonly_open` C regression case fails 3/6 checks when linked against the unfixed master library, 6/6 with the fix.
- Full C corpus: 309815/309815 passed.
- Storage regression bucket (179 files, docker CI layout): all clean, rc=0.

Note for the sweep orchestrator: the shard verdict pins `openv2 openv2-2.2` as a GATE entry against current master; when this merges, the runner's fixed-but-still-listed check will demand that entry's removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)