### PR TITLE
Fix RTree DROP after shadow-table corruption

### DIFF
--- a/ext/rtree/rtree.c
+++ b/ext/rtree/rtree.c
@@ -3590,10 +3590,9 @@ static int getNodeSize(
     if( rc!=SQLITE_OK ){
       *pzErr = sqlite3_mprintf("%s", sqlite3_errmsg(db));
     }else if( pRtree->iNodeSize<(512-64) ){
-      rc = SQLITE_CORRUPT_VTAB;
       RTREE_IS_CORRUPT(pRtree);
-      *pzErr = sqlite3_mprintf("undersize RTree blobs in \"%q_node\"",
-                               pRtree->zName);
+      /* Allow xConnect to succeed so xDestroy can drop corrupt shadow tables. */
+      pRtree->iNodeSize = 512-64;
     }
   }
 

--- a/test/doltlite_recover_rtree.test
+++ b/test/doltlite_recover_rtree.test
@@ -1,0 +1,67 @@
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+database_may_be_corrupt
+
+set testprefix doltlite_recover_rtree
+
+ifcapable !rtree { finish_test ; return }
+
+# RTree shadow-table corruption must surface on access, but it must not make
+# schema reload fail before DROP TABLE can invoke xDestroy and clean up the
+# shadow tables.
+#
+# covers: rtree rtree8-2.1.6 -- after the %_node table is emptied and a table
+#   access reports corruption, DROP TABLE still succeeds and the virtual table
+#   name can be recreated (1.1-1.6)
+# covers: rtree reopen-before-drop -- the same cleanup path works if the schema
+#   is reloaded by a fresh connection before DROP TABLE (2.1-2.4)
+# not-covered: full rtree wrapper divergences; this file only gates the
+#   shadow-table cleanup contract that previously aborted test/rtree.test
+
+do_execsql_test 1.1 {
+  CREATE VIRTUAL TABLE t1 USING rtree_i32(id, x1, x2);
+}
+do_test 1.2 {
+  for {set i 1} {$i<=50} {incr i} {
+    execsql { INSERT INTO t1 VALUES($i, $i, $i+2) }
+  }
+} {}
+do_execsql_test 1.3 {
+  SELECT count(*) FROM t1;
+} {50}
+do_execsql_test 1.4 {
+  DELETE FROM t1_node;
+}
+do_catchsql_test 1.5 {
+  DELETE FROM t1 WHERE id=1;
+} {1 {database disk image is malformed}}
+do_execsql_test 1.6 {
+  DROP TABLE t1;
+  CREATE VIRTUAL TABLE t1 USING rtree_i32(id, x1, x2);
+  INSERT INTO t1 VALUES(1, 1, 3);
+  SELECT * FROM t1;
+} {1 1 3}
+
+db close
+forcedelete test.db
+sqlite3 db test.db
+
+do_execsql_test 2.1 {
+  CREATE VIRTUAL TABLE t1 USING rtree_i32(id, x1, x2);
+  INSERT INTO t1 VALUES(1, 1, 3), (2, 2, 4), (3, 3, 5);
+  DELETE FROM t1_node;
+}
+do_test 2.2 {
+  db close
+  sqlite3 db test.db
+} {}
+do_execsql_test 2.3 {
+  DROP TABLE t1;
+  CREATE VIRTUAL TABLE t1 USING rtree_i32(id, x1, x2);
+}
+do_execsql_test 2.4 {
+  INSERT INTO t1 VALUES(7, 7, 9);
+  SELECT * FROM t1;
+} {7 7 9}
+
+finish_test

--- a/test/known_testfixture_crashes.txt
+++ b/test/known_testfixture_crashes.txt
@@ -18,9 +18,6 @@
 #   ioerr2, lock4, sharedA, walsetlk_recover -- run past the per-file
 #     timeout; enforcing them would add dead minutes to every CI run and
 #     flap on faster runners.
-#   rtree -- crashes only under rtree-enabled builds (vtab shadow-table
-#     reload abort) and completes vacuously without the capability, so the
-#     expectation depends on build flags.
 
 # trigger2 used to be here but was fixed by commit 5cd33a12a
 # (removed obsolete DOLTLITE_PROLLY UPDATE codegen branches; see issue #361).
@@ -108,8 +105,6 @@ memdb1        # sqlite3_serialize/deserialize page-image API unsupported on prol
 # footgun exposed by the intentional PRAGMA divergence, like alter2/walro.
 # (createtab additionally diverges on read-cursor-abort-across-DDL; see triggerC-12.2.)
 createtab     # PRAGMA auto_vacuum errors (intentional) -> failed prepare -> stale stmt var -> UAF
-rtree         # rtree vtab shadow-table reload aborts under rtree-enabled builds; vacuous without the capability (not bucket-enforced)
-
 tkt2565        # auto_vacuum unsupported -> setup aborts (pre-summary)
 savepoint6     # auto_vacuum unsupported -> uncaught setup error aborts pre-summary
 vtab1          # echo constructor over a PK (WITHOUT ROWID) table fails at vtab1-5.x; uncaught -> aborts pre-summary

--- a/test/regression-buckets/ported.txt
+++ b/test/regression-buckets/ported.txt
@@ -13,6 +13,7 @@ doltlite_recover_rawformat_1
 doltlite_recover_rawformat_2
 doltlite_recover_rawformat_3
 doltlite_recover_rejections
+doltlite_recover_rtree
 doltlite_recover_savepointfault
 doltlite_recover_utf16_errtext
 doltlite_recover_withoutrowid


### PR DESCRIPTION
Fixes #1381

## Summary
- allow RTree xConnect to succeed after an undersized or missing root node by marking the vtab corrupt and using the minimum node size, so DROP TABLE can reach xDestroy and clean up shadow tables
- add targeted DoltLite coverage for corrupt RTree access followed by DROP/recreate, including a fresh-connection schema reload path
- remove rtree from known testfixture crashes and add the focused regression to the ported bucket

## Tests
- LIBRARY_PATH=/opt/homebrew/lib make DOLTLITE_PROLLY_CHECK=1 testfixture
- ./testfixture ../test/doltlite_recover_rtree.test
- ./testfixture ../ext/rtree/rtree8.test
- ./testfixture ../test/rtree.test (completes with summary: 27 existing failures out of 46886 tests)
- bash ../test/run_testfixture.sh "SQLite regression ported" 300 $(tr "\n" " " < ../test/regression-buckets/ported.txt)