### PR TITLE
Fix SEGV in OP_IntegrityCk when prolly integrity check errors out (alterfault)

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -9470,7 +9470,11 @@ int sqlite3BtreeIntegrityCheck(
   ctx.mxErr = mxErr;
   ctx.pnErr = &nErr;
   rc = prollyHashSetInit(&ctx.seen, 256);
-  if( rc!=SQLITE_OK ) return rc;
+  if( rc!=SQLITE_OK ){
+    if( pnErr ) *pnErr = 1;
+    if( pzOut ) *pzOut = 0;
+    return rc;
+  }
 
   for(i=0; i<nRoot; i++){
 
@@ -9494,7 +9498,14 @@ int sqlite3BtreeIntegrityCheck(
 
 integrity_done:
   prollyHashSetFree(&ctx.seen);
-  if( rc!=SQLITE_OK ) return rc;
+  if( rc!=SQLITE_OK ){
+    /* OP_IntegrityCk reads *pnErr and frees *pzOut even when an error is
+    ** returned, so the outputs must be set on every path.  Count the failed
+    ** check itself as an error, as the stock btree does for OOM. */
+    if( pnErr ) *pnErr = nErr+1;
+    if( pzOut ) *pzOut = 0;
+    return rc;
+  }
 
   if( pnErr ) *pnErr = nErr;
   if( pzOut ){


### PR DESCRIPTION
## Bug

`OP_IntegrityCk` (src/vdbe.c) declares `int nErr; char *z;` uninitialized and after

```c
rc = sqlite3BtreeIntegrityCheck(db, ..., &nErr, &z);
```

does `if( nErr==0 ){...} else if( rc ){ sqlite3_free(z); ... }`. The stock btree always sets `*pnErr`/`*pzOut` before returning (its `checkOom` even counts the OOM as an error), but the prolly implementation of `sqlite3BtreeIntegrityCheck` (src/prolly_btree.c) had two early error returns — `prollyHashSetInit` failure and the `integrity_done` error path — that returned a nonzero rc with **both outputs unset**. The opcode then calls `sqlite3_free()` on an uninitialized stack pointer.

Hit deterministically by the unswept inherited `alterfault.test` (issue triage sweep): `ALTER TABLE ... ADD COLUMN ... CHECK` runs `PRAGMA quick_check` internally, and persistent-OOM injection makes the integrity check error out. SEGV reproduced 3/3 at `alterfault-1.1-oom-persistent.481` on the linux CI build (gdb: crash in `sqlite3MemSize` via `sqlite3_free` at the `OP_IntegrityCk` case), and as a malloc abort (rc=134) on macOS. Reachable through any internal error during `PRAGMA integrity_check`/`quick_check`, not just OOM.

## Fix

Set `*pnErr`/`*pzOut` on every error path, counting the failed check itself as an error (mirrors stock `checkOom`), so the caller takes `abort_due_to_error` with a NULL message. The init-failure path intentionally does not go through `prollyHashSetFree` because `prollyHashSetInit` leaves dangling pointers when it fails.

## Verification

- fail-before: master testfixture segfaults/aborts on `alterfault.test` 3/3 (linux rc=139 at oom-persistent.481, macOS rc=134 at .477)
- pass-after: `alterfault.test` completes **0 errors out of 5185 tests** 3/3 on the linux CI-image build (`ulimit -Sn 1024`, docker linux/arm64) and 0/5195 on macOS
- C regression corpus: **309809/309809**
- fault-fuzz regression bucket run against the fixed build in the CI docker image passed: 269775 passing tests, 329 known divergences still failing, 0 unexpected failures/crashes, exit 0
- `make DOLTLITE_PROLLY_CHECK=1 testfixture` warning-free on linux/gcc

🤖 Generated with [Claude Code](https://claude.com/claude-code)
