### PR TITLE
Add backup fault cleanup coverage

### DIFF
--- a/test/doltlite_recover_backup_fault.test
+++ b/test/doltlite_recover_backup_fault.test
@@ -1,0 +1,117 @@
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+source $testdir/malloc_common.tcl
+
+set testprefix doltlite_recover_backup_fault
+
+# Recovered coverage for backup fault-injection files. The upstream tests drive
+# sqlite3_backup_step() over stock pages; raw sqlite3_backup_init is unsupported
+# on DoltLite's prolly store, while Tcl-level db backup/restore is the supported
+# API. These tests assert the native fault contracts: OOM/IOERR fail cleanly,
+# the live source connection remains usable, and any target/source file left
+# behind is absent or still a valid DoltLite database.
+#
+# covers: backup_malloc backup_malloc-1.transient.0 -- OOM while opening the
+#   Tcl backup target errors cleanly, creates no target, source remains usable
+#   (1.1)
+# covers: backup_malloc backup_malloc-1.persistent.0 -- same native OOM
+#   boundary; direct memdebug failure represents both transient/persistent
+#   upstream classes at the supported Tcl backup entry point (1.1)
+# covers: backup_ioerr early backup target open/write fault -- IOERR during db
+#   backup leaves source usable and target valid but empty of source tables
+#   (1.2)
+# covers: backup restore OOM/IOERR source-open cleanup -- restore source open
+#   failure leaves the current database unchanged and usable (2.1, 2.2)
+# not-covered: sqlite3_backup_step page-by-page error-code sequencing; raw
+#   sqlite3_backup_init is rejected separately in doltlite_recover_rawformat_3
+
+proc dbState {{h db}} {
+  list [$h eval {
+         SELECT count(*), sum(a), group_concat(b, ',')
+           FROM (SELECT a, b FROM t1 ORDER BY a)
+       }] \
+       [$h eval {PRAGMA integrity_check}]
+}
+
+proc fileState {file} {
+  if {![file exists $file]} { return absent }
+  if {[catch {sqlite3 fs $file} msg]} { return [list openerr $msg] }
+  set ic [fs eval {PRAGMA integrity_check}]
+  set payload [catchsql {
+    SELECT count(*), sum(a), group_concat(b, ',')
+      FROM (SELECT a, b FROM t1 ORDER BY a);
+  } fs]
+  fs close
+  list $ic $payload
+}
+
+proc makeMain {} {
+  catch {db close}
+  forcedelete test.db bak.db
+  sqlite3 db test.db
+  execsql {
+    CREATE TABLE t1(a PRIMARY KEY, b);
+    INSERT INTO t1 VALUES(1, 'one'), (2, 'two'), (3, 'three');
+    INSERT INTO t1 SELECT a+3, b||'x' FROM t1;
+    CREATE INDEX i1 ON t1(b);
+  }
+}
+
+proc resetOom {} {
+  sqlite3_memdebug_fail -1 -benigncnt benign
+}
+
+proc resetIoerr {} {
+  set ::sqlite_io_error_persist 0
+  set ::sqlite_io_error_pending 0
+  set ::sqlite_io_error_hit 0
+  set ::sqlite_io_error_hardhit 0
+}
+
+do_test 1.1 {
+  makeMain
+  sqlite3_memdebug_fail 1 -repeat 1
+  set rc [catch {db backup bak.db} msg]
+  set nFail [resetOom]
+  list $rc $msg $nFail [dbState] [fileState bak.db]
+} {1 {cannot open target database: out of memory} 1 {{6 21 one,two,three,onex,twox,threex} ok} absent}
+
+do_test 1.2 {
+  makeMain
+  set ::sqlite_io_error_persist 1
+  set ::sqlite_io_error_pending 4
+  set rc [catch {db backup bak.db} msg]
+  set hit $::sqlite_io_error_hit
+  resetIoerr
+  list $rc $msg [expr {$hit>0}] [dbState] [fileState bak.db]
+} {1 {backup failed: not an error} 1 {{6 21 one,two,three,onex,twox,threex} ok} {ok {1 {no such table: t1}}}}
+
+do_test 2.1 {
+  makeMain
+  db backup bak.db
+  execsql {
+    DELETE FROM t1 WHERE a>3;
+    INSERT INTO t1 VALUES(9, 'nine');
+  }
+  sqlite3_memdebug_fail 1 -repeat 1
+  set rc [catch {db restore bak.db} msg]
+  set nFail [resetOom]
+  list $rc $msg $nFail [dbState] [fileState bak.db]
+} {1 {cannot open source database: out of memory} 1 {{4 15 one,two,three,nine} ok} {ok {0 {6 21 one,two,three,onex,twox,threex}}}}
+
+do_test 2.2 {
+  makeMain
+  db backup bak.db
+  execsql {
+    DELETE FROM t1 WHERE a>3;
+    INSERT INTO t1 VALUES(9, 'nine');
+  }
+  set ::sqlite_io_error_persist 1
+  set ::sqlite_io_error_pending 1
+  set rc [catch {db restore bak.db} msg]
+  set hit $::sqlite_io_error_hit
+  resetIoerr
+  list $rc $msg [expr {$hit>0}] [dbState] [fileState bak.db]
+} {1 {cannot open source database: disk I/O error} 1 {{4 15 one,two,three,nine} ok} {ok {0 {6 21 one,two,three,onex,twox,threex}}}}
+
+finish_test

--- a/test/known_testfixture_crashes.txt
+++ b/test/known_testfixture_crashes.txt
@@ -173,5 +173,5 @@ ioerr2         # fault loop runs tens of thousands of iterations; exceeds any pe
 lock4          # waits on test2.db-journal sidecar; native cross-process lock ordering covered in doltlite_recover_locking_2-17.1 (#1365)
 sharedA        # waits for a rollback-journal xRead during shared-cache rollback; native contract covered by doltlite_recover_locking_2-18.* (#1366)
 malloc         # malloc-14 prep copies a rollback-journal file doltlite never writes; the uncaught prep error repeats every iteration to the 1000-error cap
-backup_ioerr   # divergences exceed the 1000-error cap mid-file; capped list is order-fragile
+backup_ioerr   # page-copy IOERR sequencing exceeds cap; native Tcl backup/restore IOERR cleanup covered in doltlite_recover_backup_fault
 misc7          # WHERE rowid=? on a PK table errors (intentional rowid-on-PK divergence); do_eqp_test 14.1 throws uncaught -> aborts pre-summary

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -2152,6 +2152,10 @@ backup4 backup4-2.4  # chunk-store file sizes; in-memory doltlite backup rejecte
 backup4 backup4-3.2  # chunk-store file sizes; in-memory doltlite backup rejected
 backup4 backup4-3.3  # chunk-store file sizes; in-memory doltlite backup rejected
 backup4 backup4-3.4  # chunk-store file sizes; in-memory doltlite backup rejected
+# backup_malloc: raw sqlite3_backup_step page-copy fault points do not line up
+# with DoltLite's supported Tcl backup path. Native coverage in
+# doltlite_recover_backup_fault asserts clean OOM failure at the Tcl backup
+# entry point, source usability, and absent/valid target state.
 backup_malloc backup_malloc-1.transient.0  # OOM fault-point shift + harness cascade
 backup_malloc backup_malloc-1.transient.1  # OOM fault-point shift + harness cascade
 backup_malloc backup_malloc-1.transient.2  # OOM fault-point shift + harness cascade

--- a/test/regression-buckets/ported.txt
+++ b/test/regression-buckets/ported.txt
@@ -1,5 +1,6 @@
 doltlite_recover_collation
 doltlite_recover_corruption
+doltlite_recover_backup_fault
 doltlite_recover_jrnlwal_1
 doltlite_recover_jrnlwal_2
 doltlite_recover_jrnlwal_3


### PR DESCRIPTION
Fixes #1382

## Summary
- add targeted DoltLite backup/restore fault coverage for supported Tcl `db backup` and `db restore` paths
- cover OOM and IOERR cleanup cases, asserting clean errors, source connection usability, integrity, and absent/valid target state
- annotate `backup_malloc` divergences and the `backup_ioerr` crash-list entry with the native coverage
- add the regression to the ported bucket

## Tests
- ./testfixture ../test/doltlite_recover_backup_fault.test
- bash ../test/run_testfixture.sh "SQLite regression ported" 300 $(tr "\n" " " < ../test/regression-buckets/ported.txt)