### PR TITLE
Fix silent 64-field truncation decoding wide-index sortkeys

### DIFF
--- a/src/sortkey.c
+++ b/src/sortkey.c
@@ -1024,12 +1024,20 @@ int recordFromSortKeyBuffer(
   const u8 *pSortKey, int nSortKey,
   u8 **ppBuf, int *pnAlloc, int *pnOut
 ){
-  u32 aType[64];
-  u32 aLen[64];
+  u32 aTypeStk[64];
+  u32 aLenStk[64];
 
-  const u8 *aFieldPtr[64];
-  int aEncLen[64];
-  u8 aIntBuf[64][8];
+  const u8 *aFieldPtrStk[64];
+  int aEncLenStk[64];
+  u8 aIntBufStk[64][8];
+  u32 *aType = aTypeStk;
+  u32 *aLen = aLenStk;
+  const u8 **aFieldPtr = aFieldPtrStk;
+  int *aEncLen = aEncLenStk;
+  u8 (*aIntBuf)[8] = aIntBufStk;
+  u8 *pFieldHeap = 0;
+  int nFieldCap = 64;
+  int rc = SQLITE_OK;
   int nFields = 0;
   int pos = 0;
   u8 *pOut;
@@ -1067,8 +1075,53 @@ int recordFromSortKeyBuffer(
     if( rc!=SQLITE_NOTFOUND ) return rc;
   }
 
-  while( pos < nSortKey && nFields < 64 ){
-    u8 tag = pSortKey[pos++];
+  while( pos < nSortKey ){
+    u8 tag;
+
+    if( nFields==nFieldCap ){
+      /* More fields than the stack arrays hold (e.g. an index on 64+
+      ** columns): regrow all five parallel arrays into a single heap
+      ** carve. Truncating here used to silently drop the trailing
+      ** fields, corrupting every record decoded from a wide index. */
+      sqlite3_int64 nNew = (sqlite3_int64)nFieldCap*2;
+      sqlite3_int64 nByte = nNew*(sizeof(const u8*) + 8
+                                  + sizeof(u32)*2 + sizeof(int));
+      u8 *pNew = (u8*)sqlite3_malloc64((sqlite3_uint64)nByte);
+      const u8 **aNewFieldPtr;
+      u8 (*aNewIntBuf)[8];
+      u32 *aNewType;
+      u32 *aNewLen;
+      int *aNewEncLen;
+      if( !pNew ){
+        rc = SQLITE_NOMEM;
+        goto record_from_sortkey_done;
+      }
+      aNewFieldPtr = (const u8**)pNew;
+      aNewIntBuf = (u8(*)[8])(pNew + nNew*sizeof(const u8*));
+      aNewType = (u32*)(pNew + nNew*(sizeof(const u8*) + 8));
+      aNewLen = aNewType + nNew;
+      aNewEncLen = (int*)(aNewLen + nNew);
+      memcpy(aNewFieldPtr, aFieldPtr, nFields*sizeof(const u8*));
+      memcpy(aNewIntBuf, aIntBuf, nFields*8);
+      memcpy(aNewType, aType, nFields*sizeof(u32));
+      memcpy(aNewLen, aLen, nFields*sizeof(u32));
+      memcpy(aNewEncLen, aEncLen, nFields*sizeof(int));
+      /* aFieldPtr entries that point into the old aIntBuf must follow
+      ** the integer payloads to their new location */
+      for(i = 0; i < nFields; i++){
+        if( aFieldPtr[i]==aIntBuf[i] ) aNewFieldPtr[i] = aNewIntBuf[i];
+      }
+      sqlite3_free(pFieldHeap);
+      pFieldHeap = pNew;
+      aFieldPtr = aNewFieldPtr;
+      aIntBuf = aNewIntBuf;
+      aType = aNewType;
+      aLen = aNewLen;
+      aEncLen = aNewEncLen;
+      nFieldCap = (int)nNew;
+    }
+
+    tag = pSortKey[pos++];
 
     if( tag == SORTKEY_NULL ){
       aType[nFields] = 0;
@@ -1081,7 +1134,10 @@ int recordFromSortKeyBuffer(
       int nNum;
       pos--;
       nNum = numericSortKeyLen(pSortKey + pos, nSortKey - pos);
-      if( nNum==0 ) return SQLITE_CORRUPT;
+      if( nNum==0 ){
+        rc = SQLITE_CORRUPT;
+        goto record_from_sortkey_done;
+      }
       decodeNumericSortKeyToRecord(pSortKey + pos + 1, nNum - 1,
                                    &aType[nFields], &aLen[nFields],
                                    aIntBuf[nFields]);
@@ -1097,13 +1153,19 @@ int recordFromSortKeyBuffer(
       while( pos < nSortKey ){
         const u8 *p0 = pSortKey + pos;
         const u8 *pZero = (const u8*)memchr(p0, 0x00, (size_t)(nSortKey - pos));
-        if( pZero==0 ) return SQLITE_CORRUPT;
+        if( pZero==0 ){
+          rc = SQLITE_CORRUPT;
+          goto record_from_sortkey_done;
+        }
         {
           int gap = (int)(pZero - p0);
           dataLen += gap;
           pos += gap;
         }
-        if( pos + 1 >= nSortKey ) return SQLITE_CORRUPT;
+        if( pos + 1 >= nSortKey ){
+          rc = SQLITE_CORRUPT;
+          goto record_from_sortkey_done;
+        }
         if( pSortKey[pos+1] == 0x00 ){
           pos += 2;
           break;
@@ -1111,7 +1173,8 @@ int recordFromSortKeyBuffer(
           dataLen++;
           pos += 2;
         }else{
-          return SQLITE_CORRUPT;
+          rc = SQLITE_CORRUPT;
+          goto record_from_sortkey_done;
         }
       }
       if( tag == SORTKEY_TEXT ){
@@ -1126,7 +1189,8 @@ int recordFromSortKeyBuffer(
       nFields++;
 
     }else{
-      return SQLITE_CORRUPT;
+      rc = SQLITE_CORRUPT;
+      goto record_from_sortkey_done;
     }
   }
 
@@ -1142,7 +1206,10 @@ int recordFromSortKeyBuffer(
   nTotal = nHdr + nData;
   if( *pnAlloc < nTotal ){
     u8 *pNew = (u8*)sqlite3_realloc(*ppBuf, nTotal);
-    if( !pNew ) return SQLITE_NOMEM;
+    if( !pNew ){
+      rc = SQLITE_NOMEM;
+      goto record_from_sortkey_done;
+    }
     *ppBuf = pNew;
     *pnAlloc = nTotal;
   }
@@ -1197,7 +1264,10 @@ int recordFromSortKeyBuffer(
   }
 
   *pnOut = nTotal;
-  return SQLITE_OK;
+
+record_from_sortkey_done:
+  sqlite3_free(pFieldHeap);
+  return rc;
 }
 
 static int sortKeyHasDescFields(const KeyInfo *pKeyInfo){


### PR DESCRIPTION
## Problem

`recordFromSortKeyBuffer` (src/sortkey.c) decodes a stored sortkey back into a record using five fixed 64-entry parallel arrays, and its parse loop simply stopped at 64 fields, silently dropping the rest of the key. Any index with 64 or more columns was corrupted on decode:

- at exactly 64 index columns, `PRAGMA integrity_check` reports `rowid not at end-of-record for row 1 of index i1` (the appended rowid field is the one dropped);
- at 65+ columns, covering scans return NULL for trailing columns and point lookups through the index can fail with `database disk image is malformed`.

This is what made inherited `widetab1.test` fail 6 of 18 tests (its `t1x1` index has 102 columns; `SELECT sum(c62)` planned as a covering scan returns NULL instead of 45620), found in the testfixture gating sweep.

Minimal repro on master:

```sql
CREATE TABLE t1(c00,...,c64);            -- 65 columns
CREATE INDEX i1 ON t1(c00,...,c64);
INSERT INTO t1 VALUES(0,1,...,64);
SELECT c64 FROM t1 INDEXED BY i1 WHERE c00=0;  -- NULL (should be 64)
PRAGMA integrity_check;                         -- rowid not at end-of-record
```

## Fix

Keep the 64-entry stack arrays as the untouched fast path. When a sortkey has more fields, regrow all five parallel arrays (`aFieldPtr`, `aIntBuf`, `aType`, `aLen`, `aEncLen`) into a single doubling heap carve, remapping the numeric-payload pointers that aliased the old `aIntBuf` block. All exits funnel through one cleanup label that frees the heap block, including the existing CORRUPT/NOMEM paths.

The three shape-specialized fast decoders (`recordFromAllNumeric...`, `...NumericSmallBlob...`, `...NumericVarlen...`) already bail with `SQLITE_NOTFOUND` on wide keys and are unchanged, as is the encode side (no field cap).

## Verification

- fail-before/pass-after: `widetab1.test` 6 failures on master → `0 errors out of 18 tests` with the fix; minimal 63/64/65/70/200-column index repros return correct values with `integrity_check` ok (63 was already clean on master, 64+ broken).
- C regression corpus: 309809/309809.
- core-sql and storage testfixture buckets green on the fixed build in the CI docker layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
