### PR TITLE
Add incrblob recovery coverage

### DIFF
--- a/test/doltlite_recover_incrblob.test
+++ b/test/doltlite_recover_incrblob.test
@@ -1,0 +1,87 @@
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+source $testdir/malloc_common.tcl
+
+set testprefix doltlite_recover_incrblob
+
+ifcapable !incrblob {
+  finish_test
+  return
+}
+
+# Recovered coverage for incrblob.test and incrblob_err.test. The full
+# incrblob.test file assumes "PRIMARY KEY" tables still expose rowids for
+# sqlite3_blob_open(); DoltLite's non-integer primary-key tables are implicit
+# WITHOUT ROWID tables, so the native equivalent is to reject blob handles for
+# those tables and keep normal INTEGER PRIMARY KEY blob handles working.
+#
+# covers: incrblob incrblob-1.2.* - direct incrblob open/read/write against a table declared with PRIMARY KEY is rejected as WITHOUT ROWID on DoltLite
+# covers: incrblob incrblob-1.2.* - same blob API succeeds on an INTEGER PRIMARY KEY table and preserves byte-for-byte reads
+# covers: incrblob_err incrblob_err-4 - IO faults while reading through an open incrblob handle are cleaned up without changing database content
+
+do_execsql_test 1.0 {
+  CREATE TABLE pk(a PRIMARY KEY, b BLOB);
+  INSERT INTO pk VALUES('one', X'0102030405060708090A');
+
+  CREATE TABLE ipk(id INTEGER PRIMARY KEY, b BLOB);
+  INSERT INTO ipk VALUES(1, X'0102030405060708090A');
+} {}
+
+do_test 1.1 {
+  set rc [catch {db incrblob pk b 1} msg]
+  list $rc $msg [sqlite3_errmsg db]
+} {1 {cannot open table without rowid: pk} {cannot open table without rowid: pk}}
+
+do_test 1.2 {
+  set rc [catch {db incrblob -readonly pk b 1} msg]
+  list $rc $msg [sqlite3_errmsg db]
+} {1 {cannot open table without rowid: pk} {cannot open table without rowid: pk}}
+
+do_test 1.3 {
+  unset -nocomplain B
+  set rc [catch {sqlite3_blob_open db main pk b 1 0 B} msg]
+  list $rc $msg [sqlite3_errmsg db]
+} {1 SQLITE_ERROR {cannot open table without rowid: pk}}
+
+do_test 1.4 {
+  unset -nocomplain B
+  set rc [catch {sqlite3_blob_open db main pk b 1 1 B} msg]
+  list $rc $msg [sqlite3_errmsg db]
+} {1 SQLITE_ERROR {cannot open table without rowid: pk}}
+
+do_test 1.5 {
+  set blob [db incrblob ipk b 1]
+  fconfigure $blob -translation binary
+  binary scan [read $blob] H* h
+  close $blob
+  set h
+} {0102030405060708090a}
+
+do_test 1.6 {
+  sqlite3_blob_open db main ipk b 1 0 B
+  set n [sqlite3_blob_bytes $B]
+  binary scan [sqlite3_blob_read $B 0 $n] H* h
+  sqlite3_blob_close $B
+  list $n $h
+} {10 0102030405060708090a}
+
+do_execsql_test 1.7 {
+  SELECT a, hex(b) FROM pk;
+  SELECT id, hex(b) FROM ipk;
+  PRAGMA integrity_check;
+} {one 0102030405060708090A 1 0102030405060708090A ok}
+
+do_ioerr_test 2 -count 20 -cksum 1 -sqlprep {
+  CREATE TABLE blobs(k INTEGER PRIMARY KEY, v BLOB);
+  INSERT INTO blobs VALUES(1, zeroblob(4096));
+} -tclbody {
+  set ::blob [db incrblob blobs v 1]
+  fconfigure $::blob -translation binary
+  read $::blob
+  close $::blob
+} -cleanup {
+  catch {close $::blob}
+  unset -nocomplain ::blob
+}
+
+finish_test

--- a/test/known_testfixture_crashes.txt
+++ b/test/known_testfixture_crashes.txt
@@ -140,7 +140,7 @@ corrupt4         # completes or aborts depending on the run; either expectation 
 corruptC         # corruption-injection cascade: setup table never created
 corruptI         # corruption injection: chunk store reports malformed, file aborts
 multiplex2       # multiplex VFS on chunk store: disk I/O error aborts setup
-incrblob         # incrblob API on a PK (WITHOUT ROWID) table: "cannot open table without rowid"
+incrblob         # full file assumes PRIMARY KEY tables expose rowids; direct DoltLite rejection and INTEGER PRIMARY KEY success covered by doltlite_recover_incrblob
 pager1           # journal/txn-model cascade: "cannot commit - no transaction is active"
 backup           # sqlite3_backup_init: page-image backup unsupported
 mallocAll        # failed open -> "db" command never created (test-harness footgun)
@@ -155,7 +155,7 @@ win32nolock      # windows-only: silent platform return, no summary line
 corrupt9       # freelist raw-format probe aborts ("Freelist is empty")
 dbstatus       # dbstat vtable constructor fails on prolly; memory-stat probes differ
 e_walauto      # reads test.db-shm: no shm sidecar
-incrblob_err   # fault harness blob channel dies mid-injection (I/O error)
+incrblob_err   # full fault file still aborts; blob-read IOERR cleanup path covered by doltlite_recover_incrblob
 malloc3        # OOM mid-file leaves setup table missing; uncaught -> aborts
 pendingrace    # copies sv_test.db-journal: no journal sidecar
 shmlock        # shm locking probe: "BUSY false-positive" thrown by the test

--- a/test/regression-buckets/ported.txt
+++ b/test/regression-buckets/ported.txt
@@ -1,5 +1,6 @@
 doltlite_recover_collation
 doltlite_recover_corruption
+doltlite_recover_incrblob
 doltlite_recover_jrnlwal_1
 doltlite_recover_jrnlwal_2
 doltlite_recover_jrnlwal_3


### PR DESCRIPTION
## Summary
- add focused DoltLite incrblob recovery coverage for implicit PRIMARY KEY rejection and INTEGER PRIMARY KEY blob reads
- add an incrblob read IOERR cleanup path to the ported regression bucket
- update crash-list comments to point to the native recovered coverage

Fixes #1384

## Tests
- `cd build-1381-nodebug && ./testfixture ../test/doltlite_recover_incrblob.test`
- `cd build-1381-nodebug && ../test/run_testfixture.sh "SQLite regression ported" 300 $(tr '\\n' ' ' < ../test/regression-buckets/ported.txt)`