### PR TITLE
Don't capture statement savepoints during vtab xSavepoint flushes (fts index loses committed rows on statement abort)

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -3133,7 +3133,16 @@ static int flushPendingForTable(
 }
 static int syncBtreeSavepoints(Btree *pBtree){
   sqlite3 *db = pBtree ? pBtree->db : 0;
-  if( db ){
+  /* Writes made inside a vtab xSavepoint callback (e.g. fts3 flushing its
+  ** pending-terms hash when a statement journal opens) belong to the scope
+  ** being entered's PARENT: the pager engine only starts journaling at
+  ** sqlite3BtreeBeginStmt, which runs after the callback returns. By that
+  ** point db->nStatement already counts the new statement, so pushing
+  ** savepoints here would capture pre-flush state and a later statement
+  ** rollback would erase the flush while fts3 also clears its hash --
+  ** losing committed rows from the index. Let the writes land in the
+  ** current deepest scope instead. */
+  if( db && db->nVtabSavepoint==0 ){
     int target = db->nSavepoint + db->nStatement;
     while( pBtree->nSavepoint < target ){
       int rc = pushSavepoint(pBtree, pBtree->nSavepoint >= db->nSavepoint);

--- a/test/doltlite_fts_stmt_savepoint.test
+++ b/test/doltlite_fts_stmt_savepoint.test
@@ -1,0 +1,76 @@
+# Statement-scope savepoints vs vtab xSavepoint flushes.
+#
+# When a statement journal opens, fts3's xSavepoint callback flushes its
+# pending-terms hash to the shadow tables via nested SQL. The pager engine
+# only starts journaling at sqlite3BtreeBeginStmt, which runs after the
+# callback, so upstream those flush writes survive a statement rollback.
+# Prolly captures statement savepoints lazily at write time keyed off
+# db->nStatement, which already counts the new statement during the
+# callback — so the flush itself used to trigger a pre-flush capture and a
+# constraint abort then erased the flush while fts3 also cleared its hash,
+# silently dropping committed rows from the index (upstream fts3conf-1.7.3
+# and 1.17.3, and 214 fts3fault3 OOM-recovery integrity failures).
+#
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+ifcapable !fts3 { finish_test ; return }
+set testprefix doltlite-fts-stmtsvpt
+
+do_execsql_test 1.0 {
+  CREATE VIRTUAL TABLE t1 USING fts3(x);
+  INSERT INTO t1(rowid, x) VALUES(1, 'a b c d');
+  INSERT INTO t1(rowid, x) VALUES(2, 'e f g h');
+  CREATE TABLE source(a, b);
+  INSERT INTO source VALUES(4, 'z');
+  INSERT INTO source VALUES(2, 'y');
+}
+
+# INSERT OR ABORT: rowid 4 is inserted, then rowid 2 conflicts; the
+# statement rolls back. Rowid 3 was pending when the statement began and
+# is flushed by xSavepoint as the statement journal opens.
+do_execsql_test 1.1 {
+  BEGIN;
+  INSERT INTO t1(rowid, x) VALUES(3, 'i j k l');
+}
+do_catchsql_test 1.2 {
+  INSERT OR ABORT INTO t1(rowid, x) SELECT * FROM source;
+} {1 {constraint failed}}
+do_execsql_test 1.3 { COMMIT }
+do_execsql_test 1.4 {
+  SELECT rowid FROM t1 WHERE x MATCH 'i';
+} {3}
+do_execsql_test 1.5 {
+  SELECT rowid FROM t1 WHERE x MATCH 'z';
+} {}
+do_execsql_test 1.6 {
+  SELECT rowid, x FROM t1;
+} {1 {a b c d} 2 {e f g h} 3 {i j k l}}
+
+# UPDATE OR ABORT flavor (upstream fts3conf-1.17.3).
+do_execsql_test 2.0 {
+  BEGIN;
+  INSERT INTO t1(rowid, x) VALUES(5, 'm n o p');
+}
+do_catchsql_test 2.1 {
+  UPDATE OR ABORT t1 SET docid = CASE WHEN docid = 1 THEN 8 ELSE 3 END
+  WHERE docid <= 2;
+} {1 {constraint failed}}
+do_execsql_test 2.2 { COMMIT }
+do_execsql_test 2.3 {
+  SELECT rowid FROM t1 WHERE x MATCH 'm';
+} {5}
+do_execsql_test 2.4 {
+  SELECT rowid FROM t1 WHERE x MATCH 'a';
+} {1}
+
+# The index must agree with a from-scratch rebuild of the same content.
+do_execsql_test 3.0 {
+  CREATE VIRTUAL TABLE tcheck USING fts4term(t1);
+  CREATE VIRTUAL TABLE t2 USING fts3(x);
+  INSERT INTO t2(rowid, x) SELECT rowid, x FROM t1;
+  CREATE VIRTUAL TABLE t2check USING fts4term(t2);
+  SELECT (SELECT md5sum(term, docid, col, pos) FROM tcheck) =
+         (SELECT md5sum(term, docid, col, pos) FROM t2check);
+} {1}
+
+finish_test

--- a/test/regression-buckets/ported.txt
+++ b/test/regression-buckets/ported.txt
@@ -16,3 +16,4 @@ doltlite_recover_rejections
 doltlite_recover_savepointfault
 doltlite_recover_utf16_errtext
 doltlite_recover_withoutrowid
+doltlite_fts_stmt_savepoint


### PR DESCRIPTION
## Bug

When a statement journal opens, OP_Transaction increments `db->nStatement` and then calls `sqlite3VtabSavepoint(SAVEPOINT_BEGIN)`, which makes fts3 flush its pending-terms hash to the shadow tables via nested SQL. The pager engine only starts journaling at `sqlite3BtreeBeginStmt`, *after* the callback returns, so upstream those flush writes sit below the statement journal and survive a statement rollback.

Prolly captures statement savepoints lazily at write time (`syncBtreeSavepoints`, keyed off `db->nSavepoint + db->nStatement`), so the flush writes themselves pushed the statement savepoint and captured pre-flush state. A constraint or OOM abort then rolled the shadow tables back past the flush while `fts3RollbackToMethod` cleared the pending hash — silently dropping previously-inserted rows from the fts index. Content stayed intact, so MATCH simply stopped finding committed rows:

```sql
CREATE VIRTUAL TABLE t1 USING fts3(x);
BEGIN;
  INSERT INTO t1(rowid, x) VALUES(3, 'i j k l');
  INSERT OR ABORT INTO t1(rowid, x) SELECT * FROM source;  -- conflicts mid-statement
COMMIT;
SELECT rowid FROM t1 WHERE x MATCH 'i';   -- was empty; now returns 3
```

## Fix

`syncBtreeSavepoints` skips pushing new savepoints while inside a vtab savepoint callback (`db->nVtabSavepoint > 0`), so the flush lands in the enclosing scope — the same ordering the pager engine gets for free. Non-vtab flows always run with `nVtabSavepoint == 0`, so there is no behavior change outside vtab savepoint callbacks.

## Effect on the unswept fts shard (#1357)

* fts3conf: 2 failures (1.7.3, 1.17.3) → 0
* fts3fault3: 219 failures → 5 (the 214 were OOM-recovery "malformed inverted index" integrity failures; the residual 5 are a distinct OOM-swallow, filed as #1400)

If this merges before the sweep's gate lands, fts3conf gates clean and fts3fault3 needs only the 5 residual entries; otherwise the sweep pins the current failures and this PR's rebase removes them.

## Test

New native `test/doltlite_fts_stmt_savepoint.test` (ported bucket): both OR ABORT flavors (INSERT and UPDATE, mirroring fts3conf-1.7/1.17) plus an index-vs-rebuild md5 checksum. Fails 3/14 on unfixed master, passes 14/14 with the fix.

## Validation (linux/arm64 CI image, DOLTLITE_PROLLY_CHECK=1, warning-free build)

* C regression corpus: 309809/309809
* Orphan c-tests: 14/14 gating pass
* Correctness suite: 41/41
* All five testfixture regression buckets green — no unexpected failures, no flipped divergence entries (core-sql 336853 passing / 717 known, ddl-schema 40698/918, storage 19233/3262, fault-fuzz 269775/329, ported 2535/0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)