### PR TITLE
Add vtab1 recovery coverage

### DIFF
--- a/test/doltlite_recover_vtab1.test
+++ b/test/doltlite_recover_vtab1.test
@@ -1,0 +1,161 @@
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+set testprefix doltlite_recover_vtab1
+
+ifcapable !vtab||!schema_pragmas {
+  finish_test
+  return
+}
+
+# Recovered coverage for vtab1.test. The full file is crash-listed because
+# after vtab1-5.x it drops real tables before their echo virtual tables. On
+# DoltLite that reconnects the echo vtab after its backing table is gone, so
+# the DROP batch returns "vtable constructor failed". The vtab1-5.x join
+# behavior itself works over rowid backing tables.
+#
+# vtab1 also uses echo over tables declared with PRIMARY KEY in later sections.
+# DoltLite treats those as implicit WITHOUT ROWID tables. The echo test module
+# hard-codes rowid in its generated SELECT statements, so creating the virtual
+# table succeeds but scanning it is rejected cleanly.
+#
+# covers: vtab1 vtab1-5-1..5-7 - echo joins over rowid backing tables, including indexed constraint pushdown (1.x)
+# covers: vtab1 cleanup after vtab1-5-7 - dropping backing tables before echo vtabs returns a clean error and leaves the connection usable (2.x)
+# covers: vtab1 vtab1-6-2/6-3 shape - echo over an implicit WITHOUT ROWID PRIMARY KEY table creates, but scans fail when echo generates rowid SQL (3.x)
+
+proc filter {log} {
+  set out [list]
+  for {set ii 0} {$ii < [llength $log]} {incr ii} {
+    if {[lindex $log $ii] eq "xFilter"} {
+      lappend out xFilter
+      lappend out [lindex $log [expr $ii+1]]
+    }
+  }
+  return $out
+}
+
+register_echo_module [sqlite3_connection_pointer db]
+
+do_execsql_test 1.0 {
+  CREATE TABLE t1(a, b, c);
+  CREATE TABLE t2(d, e, f);
+  INSERT INTO t1 VALUES(1, 'red', 'green');
+  INSERT INTO t1 VALUES(2, 'blue', 'black');
+  INSERT INTO t2 VALUES(1, 'spades', 'clubs');
+  INSERT INTO t2 VALUES(2, 'hearts', 'diamonds');
+  CREATE VIRTUAL TABLE et1 USING echo(t1);
+  CREATE VIRTUAL TABLE et2 USING echo(t2);
+} {}
+
+do_test 1.1 {
+  set ::echo_module ""
+  execsql {
+    SELECT * FROM et1, et2;
+  }
+} [list \
+  1 red green 1 spades clubs     \
+  1 red green 2 hearts diamonds  \
+  2 blue black 1 spades clubs    \
+  2 blue black 2 hearts diamonds \
+]
+
+do_test 1.2 {
+  filter $::echo_module
+} [list \
+  xFilter {SELECT rowid, a, b, c FROM 't1'} \
+  xFilter {SELECT rowid, d, e, f FROM 't2'} \
+  xFilter {SELECT rowid, d, e, f FROM 't2'} \
+]
+
+do_test 1.3 {
+  set ::echo_module ""
+  execsql {
+    SELECT * FROM et1, et2 WHERE et2.d = 2;
+  }
+} [list \
+  1 red green 2 hearts diamonds  \
+  2 blue black 2 hearts diamonds \
+]
+
+do_test 1.4 {
+  filter $::echo_module
+} [list \
+  xFilter {SELECT rowid, a, b, c FROM 't1'} \
+  xFilter {SELECT rowid, d, e, f FROM 't2'} \
+  xFilter {SELECT rowid, d, e, f FROM 't2'} \
+]
+
+do_test 1.5 {
+  execsql {
+    CREATE INDEX i1 ON t2(d);
+  }
+
+  db close
+  sqlite3 db test.db
+  register_echo_module [sqlite3_connection_pointer db]
+
+  set ::echo_module ""
+  execsql {
+    SELECT * FROM et1, et2 WHERE et2.d = 2;
+  }
+} [list \
+  1 red green 2 hearts diamonds  \
+  2 blue black 2 hearts diamonds \
+]
+
+do_test 1.6 {
+  filter $::echo_module
+} [list \
+  xFilter {SELECT rowid, a, b, c FROM 't1'}             \
+  xFilter {SELECT rowid, d, e, f FROM 't2' WHERE d = ?} \
+  xFilter {SELECT rowid, d, e, f FROM 't2' WHERE d = ?} \
+]
+
+do_catchsql_test 2.1 {
+  DROP TABLE t1;
+  DROP TABLE t2;
+  DROP TABLE et1;
+  DROP TABLE et2;
+} {1 {vtable constructor failed: et1}}
+
+do_execsql_test 2.2 {
+  CREATE TABLE still_ok(x);
+  INSERT INTO still_ok VALUES(1);
+  SELECT * FROM still_ok;
+} {1}
+
+reset_db
+register_echo_module [sqlite3_connection_pointer db]
+
+do_execsql_test 3.0 {
+  CREATE TABLE pkt(a PRIMARY KEY, b, c);
+  INSERT INTO pkt VALUES(1, 2, 3);
+  CREATE VIRTUAL TABLE epkt USING echo(pkt);
+} {}
+
+do_catchsql_test 3.1 {
+  SELECT rowid, a, b, c FROM pkt;
+} {1 {no such column: rowid}}
+
+do_test 3.2 {
+  set ::echo_module ""
+  catchsql {
+    SELECT a FROM epkt WHERE a = 1;
+  }
+} {1 {SQL logic error}}
+
+do_test 3.3 {
+  set ::echo_module
+} [list \
+  xConnect echo main epkt pkt \
+  xBestIndex {SELECT rowid, a, NULL, NULL FROM 'pkt' WHERE a = ?} \
+  xFilter {SELECT rowid, a, NULL, NULL FROM 'pkt' WHERE a = ?} 1 \
+]
+
+do_execsql_test 3.4 {
+  SELECT a, b, c FROM pkt WHERE a = 1;
+  DROP TABLE epkt;
+  DROP TABLE pkt;
+} {1 2 3}
+
+finish_test

--- a/test/known_testfixture_crashes.txt
+++ b/test/known_testfixture_crashes.txt
@@ -107,7 +107,7 @@ memdb1        # sqlite3_serialize/deserialize page-image API unsupported on prol
 createtab     # PRAGMA auto_vacuum errors (intentional) -> failed prepare -> stale stmt var -> UAF
 tkt2565        # auto_vacuum unsupported -> setup aborts (pre-summary)
 savepoint6     # auto_vacuum unsupported -> uncaught setup error aborts pre-summary
-vtab1          # echo constructor over a PK (WITHOUT ROWID) table fails at vtab1-5.x; uncaught -> aborts pre-summary
+vtab1          # post-vtab1-5 cleanup drops echo backing tables before vtabs; clean error + implicit-PK echo behavior covered by doltlite_recover_vtab1
 
 # ── feature-gap sweep wave 1 (#1208): files whose setup aborts pre-summary on
 # an intentional rejection or a stock-only artifact. Reasons captured from a

--- a/test/regression-buckets/ported.txt
+++ b/test/regression-buckets/ported.txt
@@ -18,4 +18,5 @@ doltlite_recover_rtree
 doltlite_recover_savepointfault
 doltlite_recover_shared_ioerr
 doltlite_recover_utf16_errtext
+doltlite_recover_vtab1
 doltlite_recover_withoutrowid


### PR DESCRIPTION
## Summary
- add focused vtab1 recovery coverage for echo joins over rowid backing tables
- pin DoltLite behavior when vtab1 cleanup drops echo backing tables before virtual tables
- cover echo over implicit PRIMARY KEY tables: construction succeeds, scans reject cleanly when echo generates rowid SQL
- update the vtab1 crash-list entry to point at the targeted coverage

Fixes #1385

## Tests
- `cd build-1381-nodebug && ./testfixture ../test/doltlite_recover_vtab1.test`
- `cd build-1381-nodebug && ../test/run_testfixture.sh "SQLite regression ported" 300 $(tr '\\n' ' ' < ../test/regression-buckets/ported.txt)`