### PR TITLE
Add VFS wrapper recovery coverage

### DIFF
--- a/test/doltlite_recover_vfs_wrappers.test
+++ b/test/doltlite_recover_vfs_wrappers.test
@@ -1,0 +1,136 @@
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+set testprefix doltlite_recover_vfs_wrappers
+
+ifcapable !curdir {
+  finish_test
+  return
+}
+
+# Recovered coverage for quota.test, multiplex.test, and multiplex2.test.
+# The full files assert stock page-file byte counts, journal sidecars, and
+# multiplex chunk-file layouts. DoltLite stores table content in its chunk
+# store, so those size and sidecar assertions are not a native contract. The
+# wrapper VFS contract is that initialized wrappers can sit above DoltLite's
+# VFS, ordinary writes remain durable, quota-full failures are clean, and the
+# connection remains usable afterwards.
+#
+# covers: quota quota-1.* - quota wrapper initialization/shutdown succeeds and registers above the default VFS (1.1, 1.6)
+# covers: quota quota-2.* - writes under a generous quota succeed and preserve integrity; tiny quota fails cleanly with SQLITE_FULL (1.2, 2.1)
+# covers: multiplex multiplex-1.* - multiplex wrapper initialization/shutdown succeeds and registers above the default VFS (3.1, 3.5)
+# covers: multiplex multiplex-2.* - normal writes through initialized multiplex wrapper are durable and integrity remains ok (3.2)
+# covers: multiplex2 multiplex-1.* - explicit -vfs multiplex opens after initialization and supports ordinary reads/writes (3.6)
+
+proc cleanup_wrappers {} {
+  catch {db close}
+  catch {db2 close}
+  catch {sqlite3_quota_shutdown}
+  catch {sqlite3_multiplex_shutdown}
+}
+
+proc delete_wrapper_files {name} {
+  foreach f [glob -nocomplain ${name}*] {
+    forcedelete $f
+  }
+}
+
+proc quota_check {filename limitvar size} {
+  upvar $limitvar limit
+  lappend ::quota_events $filename [set limit] $size
+  if {[info exists ::quota_request_ok]} {
+    set limit $size
+  }
+}
+
+cleanup_wrappers
+delete_wrapper_files quota_ok.db
+delete_wrapper_files quota_full.db
+delete_wrapper_files multiplex_ok.db
+delete_wrapper_files multiplex_explicit.db
+
+do_test 1.1 {
+  sqlite3_quota_initialize "" 1
+} {SQLITE_OK}
+
+do_test 1.2 {
+  sqlite3_quota_set *quota_ok.db 104857600 quota_check
+} {SQLITE_OK}
+
+do_test 1.3 {
+  sqlite3 db quota_ok.db
+  string match {quota/*} [file_control_vfsname db]
+} {1}
+
+do_execsql_test 1.4 {
+  CREATE TABLE t1(a PRIMARY KEY, b);
+  INSERT INTO t1 VALUES(1, randomblob(2048));
+  SELECT count(*), length(b) FROM t1;
+  PRAGMA integrity_check;
+} {1 2048 ok}
+
+do_test 1.5 {
+  db close
+  sqlite3_quota_shutdown
+} {SQLITE_OK}
+
+do_test 2.1 {
+  delete_wrapper_files quota_full.db
+  sqlite3_quota_initialize "" 1
+  sqlite3_quota_set *quota_full.db 1 quota_check
+  sqlite3 db quota_full.db
+  catchsql {
+    CREATE TABLE q(a PRIMARY KEY, b);
+    INSERT INTO q VALUES(1, randomblob(2048));
+  }
+} {1 {database or disk is full}}
+
+do_execsql_test 2.2 {
+  PRAGMA integrity_check;
+} {ok}
+
+do_test 2.3 {
+  db close
+  sqlite3_quota_shutdown
+} {SQLITE_OK}
+
+do_test 3.1 {
+  sqlite3_multiplex_initialize "" 1
+} {SQLITE_OK}
+
+do_test 3.2 {
+  sqlite3 db multiplex_ok.db
+  string match {multiplex/*} [file_control_vfsname db]
+} {1}
+
+do_test 3.3 {
+  sqlite3_multiplex_control db main chunk_size 1048576
+} {SQLITE_OK}
+
+do_execsql_test 3.4 {
+  CREATE TABLE m(a PRIMARY KEY, b);
+  INSERT INTO m VALUES(1, randomblob(2048));
+  SELECT count(*), length(b) FROM m;
+  PRAGMA integrity_check;
+} {1 2048 ok}
+
+do_test 3.5 {
+  db close
+  sqlite3 db multiplex_explicit.db -vfs multiplex
+  string match {multiplex/*} [file_control_vfsname db]
+} {1}
+
+do_execsql_test 3.6 {
+  CREATE TABLE mx(a PRIMARY KEY, b);
+  INSERT INTO mx VALUES(1, 'wrapped');
+  SELECT * FROM mx;
+  PRAGMA integrity_check;
+} {1 wrapped ok}
+
+do_test 3.7 {
+  db close
+  sqlite3_multiplex_shutdown
+} {SQLITE_OK}
+
+cleanup_wrappers
+finish_test

--- a/test/known_testfixture_crashes.txt
+++ b/test/known_testfixture_crashes.txt
@@ -139,7 +139,7 @@ rollback         # copies test.db-journal: no rollback-journal sidecar
 corrupt4         # completes or aborts depending on the run; either expectation flaps (not bucket-enforced)
 corruptC         # corruption-injection cascade: setup table never created
 corruptI         # corruption injection: chunk store reports malformed, file aborts
-multiplex2       # multiplex VFS on chunk store: disk I/O error aborts setup
+multiplex2       # full multiclient file still aborts; explicit initialized -vfs multiplex contract covered by doltlite_recover_vfs_wrappers
 incrblob         # incrblob API on a PK (WITHOUT ROWID) table: "cannot open table without rowid"
 pager1           # journal/txn-model cascade: "cannot commit - no transaction is active"
 backup           # sqlite3_backup_init: page-image backup unsupported

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -5462,7 +5462,8 @@ tkt-fc62af4523 tkt-fc62af4523.4
 tkt-fc62af4523 tkt-fc62af4523.6
 
 # quota-VFS byte thresholds trip at chunk-store file sizes, not stock
-# page-file sizes; deterministic under the pinned fd limit.
+# page-file sizes. The native wrapper contract is covered by
+# doltlite_recover_vfs_wrappers.
 quota quota-2.1.2
 quota quota-2.1.3
 quota quota-2.1.4
@@ -5489,7 +5490,8 @@ quota quota-3.3.1
 quota quota-5.3.prep
 
 # multiplex VFS chunk boundaries differ over a chunk store; remaining
-# entries are size/journal-shape expectations. Deterministic.
+# entries are size/journal-shape expectations. The native initialized-wrapper
+# contract is covered by doltlite_recover_vfs_wrappers.
 multiplex multiplex-1.9.2
 multiplex multiplex-2.1.2
 multiplex multiplex-2.1.3

--- a/test/regression-buckets/ported.txt
+++ b/test/regression-buckets/ported.txt
@@ -18,4 +18,5 @@ doltlite_recover_rtree
 doltlite_recover_savepointfault
 doltlite_recover_shared_ioerr
 doltlite_recover_utf16_errtext
+doltlite_recover_vfs_wrappers
 doltlite_recover_withoutrowid


### PR DESCRIPTION
## Summary
- add focused recovery coverage for initialized quota and multiplex VFS wrappers
- pin DoltLite wrapper behavior: normal writes work, tiny quota fails cleanly, integrity remains ok
- document that full quota/multiplex divergences are page-size, sidecar, and chunk-layout expectations rather than the native wrapper contract
- update the multiplex2 crash-list entry to point at explicit initialized `-vfs multiplex` coverage

Fixes #1386

## Tests
- `cd build-1381-nodebug && ./testfixture ../test/doltlite_recover_vfs_wrappers.test`
- `cd build-1381-nodebug && ../test/run_testfixture.sh "SQLite regression ported" 300 $(tr '\\n' ' ' < ../test/regression-buckets/ported.txt)`