### PR TITLE
Free orig cursor allocation on failed open

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -11010,12 +11010,18 @@ static int origBtreeLockTableVt(Btree *p, int iTab, u8 isWriteLock){
 static int origBtreeCursorVt(Btree *p, Pgno iTable, int wrFlag,
                              struct KeyInfo *pKeyInfo, BtCursor *pCur){
   void *pOC = sqlite3_malloc(origBtreeCursorSize());
+  int rc;
   if( !pOC ) return SQLITE_NOMEM;
   memset(pOC, 0, origBtreeCursorSize());
   pCur->pOrigCursor = pOC;
   pCur->pCurOps = &origCursorVtOps;
   pCur->pBtree = p;
-  return origBtreeCursor(p->pOrigBtree, iTable, wrFlag, pKeyInfo, pOC);
+  rc = origBtreeCursor(p->pOrigBtree, iTable, wrFlag, pKeyInfo, pOC);
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(pOC);
+    pCur->pOrigCursor = 0;
+  }
+  return rc;
 }
 static void origBtreeEnterVt(Btree *p){
   origBtreeEnter(p->pOrigBtree);
@@ -11038,9 +11044,11 @@ static int origCursorClearTableOfCursorVt(BtCursor *pCur){
 }
 static int origCursorCloseCursorVt(BtCursor *pCur){
   Btree *pWrapper = pCur->pBtree;
-  int willAutoCloseInner =
-      origBtreeCursorIsLastOnSingle(pCur->pOrigCursor);
-  int rc = origBtreeCloseCursor(pCur->pOrigCursor);
+  int willAutoCloseInner;
+  int rc;
+  if( pCur->pOrigCursor==0 ) return SQLITE_OK;
+  willAutoCloseInner = origBtreeCursorIsLastOnSingle(pCur->pOrigCursor);
+  rc = origBtreeCloseCursor(pCur->pOrigCursor);
   sqlite3_free(pCur->pOrigCursor);
   pCur->pOrigCursor = 0;
   if( willAutoCloseInner && pWrapper ){

--- a/test/doltlite_returningfault_issue1390.test
+++ b/test/doltlite_returningfault_issue1390.test
@@ -1,0 +1,66 @@
+# 2026 June 11
+#
+# The author disclaims copyright to this source code.  In place of
+# a legal notice, here is a blessing:
+#
+#    May you do good and not evil.
+#    May you find forgiveness for yourself and forgive others.
+#    May you share freely, never taking more than you give.
+#
+#***********************************************************************
+#
+
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+source $testdir/malloc_common.tcl
+
+set testprefix doltlite_returningfault_issue1390
+
+ifcapable vtab {
+  reset_db
+  do_execsql_test 1.0 {
+    CREATE TABLE t1(x);
+  } {}
+
+  proc eponymous_cmd {method args} {
+    switch -- $method {
+      xConnect {
+        db eval { SELECT * FROM sqlite_schema }
+        return "CREATE TABLE t1 (a, b)"
+      }
+      xBestIndex {
+        return "idxnum 555"
+      }
+      xFilter {
+        return [list sql {SELECT 123, 'A', 'B'}]
+      }
+      xUpdate {
+        return 123
+      }
+    }
+    return {}
+  }
+
+  faultsim_save_and_close
+
+  do_test 1.1 {
+    set nBase [sqlite3_memory_used]
+    do_faultsim_test 1.1 -faults oom* -start 2251 -end 2251 -prep {
+      faultsim_restore_and_reopen
+      register_tcl_module db eponymous_cmd
+      db eval { SELECT * FROM t1 }
+      sqlite3 db2 test.db
+      db2 eval { CREATE TABLE t2(y) }
+      db2 close
+    } -body {
+      db eval { INSERT INTO tcl VALUES('hello', 'world') RETURNING * }
+    } -test {
+      faultsim_test_result \
+          {0 {hello world}} {1 {vtable constructor failed: tcl}}
+    }
+    catch { db close }
+    expr {[sqlite3_memory_used] <= $nBase}
+  } {1}
+}
+
+finish_test

--- a/test/regression-buckets/ported.txt
+++ b/test/regression-buckets/ported.txt
@@ -22,3 +22,4 @@ doltlite_recover_utf16_errtext
 doltlite_recover_vtab1
 doltlite_recover_withoutrowid
 doltlite_fts_stmt_savepoint
+doltlite_returningfault_issue1390


### PR DESCRIPTION
## Summary
- free the wrapper orig-cursor allocation if `origBtreeCursor()` fails
- make orig cursor close tolerate a failed-open cursor with no inner cursor
- add a focused `doltlite_` OOM regression in the ported regression bucket

Fixes #1390.

## Tests
- `make testfixture`
- `./testfixture ../test/doltlite_returningfault_issue1390.test`
- `./testfixture ../test/returningfault.test`