### PR TITLE
Fix catalog serialization OOM leaks

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -1378,6 +1378,10 @@ static int addCatalogEntryMeta(
   aMeta[*pnMeta].zName = sqlite3_mprintf("%s", zName ? zName : "");
   aMeta[*pnMeta].zTblName = sqlite3_mprintf("%s", zTblName ? zTblName : "");
   if( !aMeta[*pnMeta].zType || !aMeta[*pnMeta].zName || !aMeta[*pnMeta].zTblName ){
+    sqlite3_free(aMeta[*pnMeta].zType);
+    sqlite3_free(aMeta[*pnMeta].zName);
+    sqlite3_free(aMeta[*pnMeta].zTblName);
+    memset(&aMeta[*pnMeta], 0, sizeof(CatalogEntryMeta));
     return SQLITE_NOMEM;
   }
   (*pnMeta)++;
@@ -2092,6 +2096,7 @@ static int doltliteSerializeCatalogEntriesForBtreeImpl(
     rc = prollyMutMapInit(&mm, 1);
     if( rc!=SQLITE_OK ){
       freeSchemaCatalogRows(aRows, nRows);
+      freeCatalogEntryMeta(aMeta, nMeta);
       return rc;
     }
     for(i=0; i<nRows; i++){
@@ -2173,6 +2178,7 @@ static int doltliteSerializeCatalogEntriesForBtreeImpl(
     aSorted = sqlite3_malloc(nTables * (int)sizeof(CatalogSerializeEntry));
     if( !aSorted ){
       freeSchemaCatalogRows(aRows, nRows);
+      freeCatalogEntryMeta(aMeta, nMeta);
       return SQLITE_NOMEM;
     }
     memset(aSorted, 0, nTables * (int)sizeof(CatalogSerializeEntry));


### PR DESCRIPTION
## Summary
- free partially allocated `CatalogEntryMeta` string fields when `addCatalogEntryMeta()` hits OOM
- free live catalog metadata on two serializer OOM exits that already freed schema rows

Fixes #1394

## Tests
- `LIBRARY_PATH=/opt/homebrew/lib make testfixture`
- `altermalloc.test`: 0 errors / all memory allocations freed
- `attachmalloc.test`: 0 errors / all memory allocations freed
- `alterfault.test`: 0 errors / all memory allocations freed
