### PR TITLE
Fix pending deletes in reverse prolly scans

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -7097,15 +7097,29 @@ static int prollyBtCursorPrevious(BtCursor *pCur, int flags){
       if( pCur->curIntKey && prollyCursorIsValid(&pCur->pCur) ){
         prollyMutMapIterSeek(&it, pCur->pMutMap, 0, 0,
                              prollyCursorIntKey(&pCur->pCur));
+        if( it.idx >= pCur->pMutMap->nEntries
+         || mergeCompare(pCur, orderedMutMapEntryAt(pCur->pMutMap, it.idx))>=0
+         || orderedMutMapEntryAt(pCur->pMutMap, it.idx)->op==PROLLY_EDIT_DELETE
+        ){
+          it.idx--;
+        }
       }else if( !pCur->curIntKey && prollyCursorIsValid(&pCur->pCur) ){
         const u8 *pK; int nK;
         prollyCursorKey(&pCur->pCur, &pK, &nK);
         prollyMutMapIterSeek(&it, pCur->pMutMap, pK, nK, 0);
+        if( it.idx >= pCur->pMutMap->nEntries
+         || mergeCompare(pCur, orderedMutMapEntryAt(pCur->pMutMap, it.idx))>=0
+         || orderedMutMapEntryAt(pCur->pMutMap, it.idx)->op==PROLLY_EDIT_DELETE
+        ){
+          it.idx--;
+        }
       }else if( pCur->eState==CURSOR_VALID ){
         rc = seedMutMapIterFromCursor(pCur, &it);
         if( rc!=SQLITE_OK && rc!=SQLITE_NOTFOUND ) return rc;
         if( rc==SQLITE_NOTFOUND ){
           prollyMutMapIterLast(&it, pCur->pMutMap);
+        }else{
+          it.idx--;
         }
       }else{
         prollyMutMapIterLast(&it, pCur->pMutMap);

--- a/test/doltlite_fts_reverse_pending_delete.test
+++ b/test/doltlite_fts_reverse_pending_delete.test
@@ -1,0 +1,51 @@
+# 2026 June 12
+#
+# The author disclaims copyright to this source code.  In place of
+# a legal notice, here is a blessing:
+#
+#    May you do good and not evil.
+#    May you find forgiveness for yourself and forgive others.
+#    May you share freely, never taking more than you give.
+#
+#*************************************************************************
+
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+source $testdir/fts3_common.tcl
+set ::testprefix doltlite_fts_reverse_pending_delete
+
+ifcapable !fts3 {
+  finish_test
+  return
+}
+
+do_test 1.0 {
+  fts3_build_db_1 5000
+} {}
+
+do_execsql_test 1.1 {
+  CREATE VIRTUAL TABLE terms USING fts4term(t1);
+  SELECT count(*) FROM terms;
+} {40000}
+
+do_execsql_test 1.2 {
+  BEGIN;
+  DELETE FROM t1_segdir WHERE level=0;
+  SELECT level, idx FROM t1_segdir
+    WHERE level BETWEEN 0 AND 1023
+    ORDER BY level DESC, idx ASC;
+} {3 0 2 0 2 1 2 2 1 0 1 1 1 2 1 3 1 4 1 5 1 6 1 7}
+
+do_execsql_test 1.3 {
+  SELECT count(*) FROM terms;
+} {39936}
+
+do_catchsql_test 1.4 {
+  INSERT INTO t1(t1) VALUES('integrity-check');
+} {1 {database disk image is malformed}}
+
+do_execsql_test 1.5 {
+  ROLLBACK;
+}
+
+finish_test

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -6545,16 +6545,6 @@ fts3shared fts3shared-2.5.2
 fts3shared fts3shared-2.5.3
 fts3shared fts3shared-2.5.5
 
-# REAL BUG pinned (issue: fts shadow-table reads inside an open
-# transaction see stale pre-transaction state through the vtab's cached
-# statements): deleting a %_segdir row in-txn is invisible to
-# integrity-check, which reports ok where upstream detects malformed.
-# Disruptions 1/2 (content-table edits) are detected fine.
-fts4check fts4check-1.2.2.3
-fts4check fts4check-1.2.3.3
-fts4check fts4check-2.2.2.3
-fts4check fts4check-2.2.3.3
-
 # doltlite does not materialize sqlite_autoindex_* rows for the
 # WITHOUT-ROWID-converted %_segdir shadow table (fordelete class)
 fts4content fts4content-5.1.1
@@ -6738,13 +6728,6 @@ fts4onepass fts4onepass-1.1.3
 # statement flushes errors "database disk image is malformed"
 fts4onepass fts4onepass-3.2.4.c
 fts4onepass fts4onepass-3.2.5.c
-
-# REAL BUG pinned (issue: stale shadow-table reads during multi-write fts
-# statements): bulk INSERT...SELECT across langid partitions aborts with
-# "constraint failed" when a stale max(idx) read collides on the
-# %_segdir (level,idx) primary key
-fts4opt fts4opt-1.8
-fts4opt fts4opt-2.8
 
 # ── incrblob2 ──
 # Shared-cache table-level locking does not exist in doltlite. A blob

--- a/test/regression-buckets/ported.txt
+++ b/test/regression-buckets/ported.txt
@@ -25,3 +25,4 @@ doltlite_recover_withoutrowid
 doltlite_fts_stmt_savepoint
 doltlite_chunk_pending_drain
 doltlite_returningfault_issue1390
+doltlite_fts_reverse_pending_delete


### PR DESCRIPTION
Fixes #1398.

## Summary
- Seed the pending mutmap iterator strictly before the current tree key when a cursor enters merge mode through sqlite3BtreePrevious().
- Add a targeted doltlite FTS regression for reverse %_segdir scans after same-transaction deletes and the warmed fts4term visibility symptom.
- Remove now-fixed fts4check and fts4opt divergence entries.

## Verification
- LIBRARY_PATH=/opt/homebrew/lib make testfixture
- testfixture test/doltlite_fts_reverse_pending_delete.test
- run_testfixture fts4check
- run_testfixture ported bucket
- run_testfixture affected FTS files: fts4langid fts4opt fts4merge4 fts4merge5 fts4onepass fts4merge
