### PR TITLE
Accept auto_vacuum and incremental_vacuum as no-ops on doltlite format

### DIFF
--- a/src/pragma.c
+++ b/src/pragma.c
@@ -814,11 +814,14 @@ void sqlite3Pragma(
       ** as an auto-vacuum capable db.
       */
       rc = sqlite3BtreeSetAutoVacuum(pBt, eAuto);
-      if( rc==SQLITE_ERROR ){
-        sqlite3ErrorMsg(pParse,
-          "auto_vacuum is not supported on doltlite-format databases");
-        goto pragma_out;
-      }
+#ifdef DOLTLITE_PROLLY
+      /* Accepted as a no-op on doltlite-format databases: there is no
+      ** page freelist for any mode to act on, and the meta write below
+      ** would start a write transaction just to record a setting the
+      ** format ignores. LARGEST_ROOT_PAGE is the max table id here, so
+      ** stock'"'"'s capability probe would wrongly pass. */
+      if( sqlite3BtreeIsDoltliteFormat(pBt) ) break;
+#endif
       if( rc==SQLITE_OK && (eAuto==1 || eAuto==2) ){
         /* When setting the auto_vacuum mode to either "full" or
         ** "incremental", write the value of meta[6] in the database
@@ -858,13 +861,6 @@ void sqlite3Pragma(
 #ifndef SQLITE_OMIT_AUTOVACUUM
   case PragTyp_INCREMENTAL_VACUUM: {
     int iLimit = 0, addr;
-#ifdef DOLTLITE_PROLLY
-    if( sqlite3BtreeIsDoltliteFormat(pDb->pBt) ){
-      sqlite3ErrorMsg(pParse,
-        "incremental_vacuum is not supported on doltlite-format databases");
-      goto pragma_out;
-    }
-#endif
     if( zRight==0 || !sqlite3GetInt32(zRight, &iLimit) || iLimit<=0 ){
       iLimit = 0x7fffffff;
     }

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -4761,9 +4761,13 @@ int sqlite3BtreeIsDoltliteFormat(Btree *p){
 }
 
 static int prollyBtreeSetAutoVacuum(Btree *p, int autoVacuum){
-  (void)p;
-  if( autoVacuum==BTREE_AUTOVACUUM_NONE ) return SQLITE_OK;
-  return SQLITE_ERROR;
+  /* Prolly storage has no page freelist, so auto_vacuum can never apply.
+  ** Stock accepts the pragma on databases that cannot support it and the
+  ** read-back reports the file's actual mode (none); match that instead
+  ** of erroring, since setting auto_vacuum at startup is a common app
+  ** idiom. */
+  (void)p; (void)autoVacuum;
+  return SQLITE_OK;
 }
 int sqlite3BtreeSetAutoVacuum(Btree *p, int autoVacuum){
   if( !p ) return SQLITE_OK;
@@ -4780,8 +4784,10 @@ int sqlite3BtreeGetAutoVacuum(Btree *p){
 }
 
 static int prollyBtreeIncrVacuum(Btree *p){
+  /* No freelist pages to reclaim: report completion immediately, exactly
+  ** like stock on a database whose auto_vacuum is none. */
   (void)p;
-  return SQLITE_ERROR;
+  return SQLITE_DONE;
 }
 int sqlite3BtreeIncrVacuum(Btree *p){
   if( !p ) return SQLITE_DONE;

--- a/test/doltlite_pragma_auto_vacuum.sh
+++ b/test/doltlite_pragma_auto_vacuum.sh
@@ -21,6 +21,8 @@ PASS=0; FAIL=0; ERRORS=""
 
 run_test() {
   local n="$1" got="$2" want="$3"
+  # msys2 emits CRLF; normalize before comparing multi-line output
+  got=$(printf '%s' "$got" | tr -d '\r')
   if [ "$got" = "$want" ]; then
     PASS=$((PASS+1))
   else

--- a/test/doltlite_pragma_auto_vacuum.sh
+++ b/test/doltlite_pragma_auto_vacuum.sh
@@ -2,23 +2,18 @@
 # P7 (auto_vacuum slice). Doltlite has no page layout, no allocator,
 # and no concept of vacuum at the storage level. Stock SQLite's
 # `PRAGMA auto_vacuum = FULL|INCR` and `PRAGMA incremental_vacuum`
-# both presume a paged store with a free-page list. doltlite used
-# to silently no-op these, which made `auto_vacuum=1` appear to
-# succeed and lulled users into expecting space reclamation that
-# never happened.
+# both presume a paged store with a free-page list. On doltlite-format
+# databases these are accepted as silent no-ops, matching stock
+# SQLite's behavior on a database that cannot change auto_vacuum mode:
 #
-# Contract after this PR:
-#
-#   - PRAGMA auto_vacuum;          -> reads back 0 (NONE) — read is
-#                                     a query of the catalog-level
-#                                     flag and is supported.
-#   - PRAGMA auto_vacuum = 0;      -> silently OK (it's already NONE).
-#   - PRAGMA auto_vacuum = 1|2;    -> ERROR with clear message naming
-#                                     doltlite-format incompatibility.
-#   - PRAGMA incremental_vacuum;   -> ERROR at runtime.
+#   - PRAGMA auto_vacuum;          -> reads back 0 (NONE).
+#   - PRAGMA auto_vacuum = <any>;  -> silently OK, never applied;
+#                                     read-back stays 0.
+#   - PRAGMA incremental_vacuum;   -> silent no-op, no output rows.
+#   - Data is unaffected by any of the above.
 #
 # Stock-SQLite-format files opened via the orig route keep the
-# upstream behavior (the prolly-route reject doesn't fire).
+# upstream behavior.
 
 DOLTLITE=./doltlite
 SQLITE3=$(command -v sqlite3 2>/dev/null || echo /usr/bin/sqlite3)
@@ -34,16 +29,6 @@ run_test() {
   fi
 }
 
-run_test_match() {
-  local n="$1" got="$2" pat="$3"
-  if echo "$got" | grep -qE "$pat"; then
-    PASS=$((PASS+1))
-  else
-    FAIL=$((FAIL+1))
-    ERRORS="$ERRORS\nFAIL: $n\n  pattern: $pat\n  got:     $got"
-  fi
-}
-
 db_rm() { rm -f "$1" "${1}-wal"; }
 
 echo "=== PRAGMA auto_vacuum / incremental_vacuum (doltlite-format) ==="
@@ -51,7 +36,7 @@ echo ""
 
 # Doltlite-format database (created by doltlite).
 DB=/tmp/test_av_dl_$$.db; db_rm "$DB"
-$DOLTLITE "$DB" "CREATE TABLE t(id INTEGER PRIMARY KEY);" > /dev/null 2>&1
+$DOLTLITE "$DB" "CREATE TABLE t(id INTEGER PRIMARY KEY); INSERT INTO t VALUES(1),(2),(3);" > /dev/null 2>&1
 
 # Read is always supported, returns 0.
 run_test "av_dl_read" \
@@ -61,17 +46,29 @@ run_test "av_dl_read" \
 out=$($DOLTLITE "$DB" "PRAGMA auto_vacuum = 0;" 2>&1)
 run_test "av_dl_set_none_ok" "$out" ""
 
-# Set to FULL: clear error.
-out=$($DOLTLITE "$DB" "PRAGMA auto_vacuum = 1;" 2>&1)
-run_test_match "av_dl_set_full_rejected" "$out" "auto_vacuum is not supported"
+# Set to FULL: accepted as a no-op, read-back stays 0.
+out=$($DOLTLITE "$DB" "PRAGMA auto_vacuum = 1; PRAGMA auto_vacuum;" 2>&1)
+run_test "av_dl_set_full_noop" "$out" "0"
 
-# Set to INCR: clear error.
-out=$($DOLTLITE "$DB" "PRAGMA auto_vacuum = 2;" 2>&1)
-run_test_match "av_dl_set_incr_rejected" "$out" "auto_vacuum is not supported"
+# Set to INCR: accepted as a no-op, read-back stays 0.
+out=$($DOLTLITE "$DB" "PRAGMA auto_vacuum = 2; PRAGMA auto_vacuum;" 2>&1)
+run_test "av_dl_set_incr_noop" "$out" "0"
 
-# Incremental vacuum: runtime error.
+# Named forms behave the same.
+out=$($DOLTLITE "$DB" "PRAGMA auto_vacuum = FULL; PRAGMA auto_vacuum = incremental; PRAGMA auto_vacuum;" 2>&1)
+run_test "av_dl_set_named_noop" "$out" "0"
+
+# Incremental vacuum: silent no-op, no output rows.
 out=$($DOLTLITE "$DB" "PRAGMA incremental_vacuum;" 2>&1)
-run_test_match "av_dl_incr_rejected" "$out" "error|SQL logic"
+run_test "av_dl_incr_noop" "$out" ""
+out=$($DOLTLITE "$DB" "PRAGMA incremental_vacuum(4);" 2>&1)
+run_test "av_dl_incr_n_noop" "$out" ""
+
+# No-op setting never sticks across reopen and data is unaffected.
+out=$($DOLTLITE "$DB" "PRAGMA auto_vacuum; SELECT count(*) FROM t; PRAGMA integrity_check;" 2>&1)
+run_test "av_dl_data_intact" "$out" "0
+3
+ok"
 
 db_rm "$DB"
 
@@ -90,16 +87,10 @@ if [ -x "$SQLITE3" ]; then
   run_test "av_stock_read" \
     "$($DOLTLITE "$DB" "PRAGMA auto_vacuum;" 2>&1)" "1"
 
-  # Stock SQLite returns SQLITE_READONLY for changing the mode
-  # of an existing page-size-fixed db. doltlite shouldn't surface
-  # that as the doltlite-specific error.
-  out=$($DOLTLITE "$DB" "PRAGMA auto_vacuum = 0;" 2>&1)
-  if echo "$out" | grep -qi "auto_vacuum is not supported"; then
-    FAIL=$((FAIL+1))
-    ERRORS="$ERRORS\nFAIL: av_stock_no_doltlite_msg_leaked\n  doltlite error msg leaked into stock-format route\n  got: $out"
-  else
-    PASS=$((PASS+1))
-  fi
+  # The stock route keeps upstream set semantics: auto_vacuum can be
+  # reconfigured on a stock-format file and reads back the new value.
+  out=$($DOLTLITE "$DB" "PRAGMA auto_vacuum = 2; PRAGMA auto_vacuum;" 2>&1)
+  run_test "av_stock_set_applies" "$out" "2"
 
   db_rm "$DB"
 fi

--- a/test/doltlite_recover_jrnlwal_2.test
+++ b/test/doltlite_recover_jrnlwal_2.test
@@ -299,7 +299,7 @@ source $testdir/tester.tcl
 # covers: tkt3457 tkt3457-1.5 — sec 10: no -journal file exists; db-file snapshot taken mid-transaction opens clean with only committed rows; original connection commits all rows
 # covers: where where-1.1.1 — sec 12: SELECT x,y,w WHERE w=10 -> {3 121 10} and EXPLAIN QUERY PLAN proves SEARCH via index i1w (search-count metric re-expressed as plan assertion)
 # covers: tkt-2d1a5c67d tkt-2d1a5c67d-3.6 — sec 11: committed db file copied to a new name opens clean and returns 'xyz' (chunk-store analog of WAL-file recovery)
-# covers: tkt3761 tkt3761-1.1 — sec 13: auto_vacuum=INCREMENTAL rejected verbatim on :memory:, incremental_vacuum errors, DELETE+ROLLBACK in-memory leaves rows and integrity intact
+# covers: tkt3761 tkt3761-1.1 — sec 13: auto_vacuum=INCREMENTAL accepted as a no-op on :memory: (reads back 0), incremental_vacuum no-ops, DELETE+ROLLBACK in-memory leaves rows and integrity intact
 
 # Recovered intent for the jrnlwal_2 shard: journal/WAL pragma surface,
 # checkpoint semantics, and durability. doltlite has no WAL sidecar or
@@ -725,17 +725,19 @@ do_test doltlite_recover_jrnlwal_2-12.4 {
 } {SCAN wt1}
 
 #-------------------------------------------------------------------------
-# Section 13: tkt3761. auto_vacuum/incremental_vacuum are rejected; the
-# rollback-integrity intent (DELETE inside a transaction, then ROLLBACK,
-# database intact) holds on an in-memory database.
+# Section 13: tkt3761. auto_vacuum/incremental_vacuum are accepted as
+# no-ops (auto_vacuum reads back 0); the rollback-integrity intent
+# (DELETE inside a transaction, then ROLLBACK, database intact) holds
+# on an in-memory database.
 #
 do_test doltlite_recover_jrnlwal_2-13.1 {
   sqlite3 dbm :memory:
-  catchsql {PRAGMA auto_vacuum=INCREMENTAL} dbm
-} {1 {auto_vacuum is not supported on doltlite-format databases}}
+  list [catchsql {PRAGMA auto_vacuum=INCREMENTAL} dbm] \
+       [execsql {PRAGMA auto_vacuum} dbm]
+} {{0 {}} 0}
 do_test doltlite_recover_jrnlwal_2-13.2 {
   catchsql {PRAGMA incremental_vacuum(4)} dbm
-} {1 {incremental_vacuum is not supported on doltlite-format databases}}
+} {0 {}}
 do_test doltlite_recover_jrnlwal_2-13.3 {
   execsql {
     CREATE TABLE v1(k INTEGER PRIMARY KEY, x);

--- a/test/doltlite_recover_jrnlwal_3.test
+++ b/test/doltlite_recover_jrnlwal_3.test
@@ -201,9 +201,9 @@
 # covers: wal4 wal4-2-oom-transient.93 — no -wal sidecar after writes (2.1-2.3); zero-byte db beside stray garbage -wal opens to empty schema, the stray wal is ignored and left byte-identical, db fully usable after (3.1-3.5); uncommitted txn never surfaces and integrity holds after reopen (4.2-4.3)
 # covers: wal4 wal4-2-shmerr-persistent.1 — no -wal sidecar after writes (2.1-2.3); zero-byte db beside stray garbage -wal opens to empty schema, the stray wal is ignored and left byte-identical, db fully usable after (3.1-3.5); uncommitted txn never surfaces and integrity holds after reopen (4.2-4.3)
 # covers: wal4 wal4-2-shmerr-transient.1 — no -wal sidecar after writes (2.1-2.3); zero-byte db beside stray garbage -wal opens to empty schema, the stray wal is ignored and left byte-identical, db fully usable after (3.1-3.5); uncommitted txn never surfaces and integrity holds after reopen (4.2-4.3)
-# covers: savepoint savepoint-6.1 — auto_vacuum=incremental rejection (1.9); indexed nested-savepoint txn setup/outcome (6.1)
+# covers: savepoint savepoint-6.1 — auto_vacuum=incremental no-op (1.9); indexed nested-savepoint txn setup/outcome (6.1)
 # covers: savepoint savepoint-6.3 — nested savepoints + ROLLBACK TO under cache pressure keep the outer UPDATE and discard savepoint work, integrity ok (6.1)
-# covers: savepoint savepoint-7.1 — auto_vacuum rejection (1.9); growing-db txn setup outcome (6.2)
+# covers: savepoint savepoint-7.1 — auto_vacuum no-op (1.9); growing-db txn setup outcome (6.2)
 # covers: savepoint savepoint-7.2.1 — CREATE TABLE inside savepoint rolled back cleanly, integrity ok (6.2)
 # covers: savepoint savepoint-7.3.1 — table repopulation from existing data (6.3)
 # covers: savepoint savepoint-7.3.2 — DELETE + vacuum pragma + nested savepoint ROLLBACK TO leaves empty table, integrity ok (6.3)
@@ -224,22 +224,22 @@
 # covers: savepoint savepoint-10.2.12 — re-insert then second ROLLBACK TO two gives identical state (6.10.3)
 # covers: savepoint savepoint-10.2.13 — full ROLLBACK after nested cross-db savepoint traffic empties all three dbs (6.10, 6.10.4)
 # covers: savepoint savepoint-10.2.14 — lock_status unlocked after full ROLLBACK (6.16)
-# covers: savepoint savepoint-11.1 — auto_vacuum=full rejection (1.10); UNIQUE-table setup (6.18)
+# covers: savepoint savepoint-11.1 — auto_vacuum=full no-op (1.10); UNIQUE-table setup (6.18)
 # covers: savepoint savepoint-11.8 — ROLLBACK discards savepoint-created tables; wal_checkpoint no-op reports 0 0 0; data + integrity intact (6.18); DROP-in-savepoint rollback + reopen (6.19-6.20)
 # covers: savepoint savepoint-13.1 — journal_mode=off rejection (1.6); the journal-off block's savepoint/rollback data outcome (6.21)
-# covers: incrvacuum2 incrvacuum2-1.1 — incremental_vacuum rejected with stable error (1.12-1.13, 7.1); 30000-byte blob insert/delete workload correct + integrity ok (7.1)
-# covers: incrvacuum2 incrvacuum2-1.2 — incremental_vacuum rejected with stable error (1.12-1.13, 7.1); 30000-byte blob insert/delete workload correct + integrity ok (7.1)
-# covers: incrvacuum2 incrvacuum2-1.3 — incremental_vacuum rejected with stable error (1.12-1.13, 7.1); 30000-byte blob insert/delete workload correct + integrity ok (7.1)
-# covers: incrvacuum2 incrvacuum2-1.4 — incremental_vacuum rejected with stable error (1.12-1.13, 7.1); 30000-byte blob insert/delete workload correct + integrity ok (7.1)
-# covers: incrvacuum2 incrvacuum2-2.1 — aux.incremental_vacuum rejected; cross-db blob insert/copy/delete outcomes correct (7.2)
-# covers: incrvacuum2 incrvacuum2-2.2 — aux.incremental_vacuum rejected; cross-db blob insert/copy/delete outcomes correct (7.2)
-# covers: incrvacuum2 incrvacuum2-2.3 — aux.incremental_vacuum rejected; cross-db blob insert/copy/delete outcomes correct (7.2)
-# covers: incrvacuum2 incrvacuum2-2.4 — aux.incremental_vacuum rejected; cross-db blob insert/copy/delete outcomes correct (7.2)
-# covers: incrvacuum2 incrvacuum2-2.5 — aux.incremental_vacuum rejected; cross-db blob insert/copy/delete outcomes correct (7.2)
-# covers: incrvacuum2 incrvacuum2-2.6 — aux.incremental_vacuum rejected; cross-db blob insert/copy/delete outcomes correct (7.2)
-# covers: incrvacuum2 incrvacuum2-3.1 — auto_vacuum='full' rejected (1.10); txn create+insert outcome (7.3)
+# covers: incrvacuum2 incrvacuum2-1.1 — incremental_vacuum accepted as a no-op (1.12-1.13, 7.1); 30000-byte blob insert/delete workload correct + integrity ok (7.1)
+# covers: incrvacuum2 incrvacuum2-1.2 — incremental_vacuum accepted as a no-op (1.12-1.13, 7.1); 30000-byte blob insert/delete workload correct + integrity ok (7.1)
+# covers: incrvacuum2 incrvacuum2-1.3 — incremental_vacuum accepted as a no-op (1.12-1.13, 7.1); 30000-byte blob insert/delete workload correct + integrity ok (7.1)
+# covers: incrvacuum2 incrvacuum2-1.4 — incremental_vacuum accepted as a no-op (1.12-1.13, 7.1); 30000-byte blob insert/delete workload correct + integrity ok (7.1)
+# covers: incrvacuum2 incrvacuum2-2.1 — aux.incremental_vacuum no-ops; cross-db blob insert/copy/delete outcomes correct (7.2)
+# covers: incrvacuum2 incrvacuum2-2.2 — aux.incremental_vacuum no-ops; cross-db blob insert/copy/delete outcomes correct (7.2)
+# covers: incrvacuum2 incrvacuum2-2.3 — aux.incremental_vacuum no-ops; cross-db blob insert/copy/delete outcomes correct (7.2)
+# covers: incrvacuum2 incrvacuum2-2.4 — aux.incremental_vacuum no-ops; cross-db blob insert/copy/delete outcomes correct (7.2)
+# covers: incrvacuum2 incrvacuum2-2.5 — aux.incremental_vacuum no-ops; cross-db blob insert/copy/delete outcomes correct (7.2)
+# covers: incrvacuum2 incrvacuum2-2.6 — aux.incremental_vacuum no-ops; cross-db blob insert/copy/delete outcomes correct (7.2)
+# covers: incrvacuum2 incrvacuum2-3.1 — auto_vacuum='full' no-op (1.10); txn create+insert outcome (7.3)
 # covers: incrvacuum2 incrvacuum2-3.2 — txn DELETE + vacuum-pragma no-op commits cleanly, integrity ok (7.3)
-# covers: incrvacuum2 incrvacuum2-4.1 — auto_vacuum=2 rejected (1.11); 512-row blob churn workload (7.4)
+# covers: incrvacuum2 incrvacuum2-4.1 — auto_vacuum=2 no-op (1.11); 512-row blob churn workload (7.4)
 # covers: incrvacuum2 incrvacuum2-4.2 — journal_mode remains wal after churn (7.4)
 # covers: incrvacuum2 incrvacuum2-4.2.1 — no wal sidecar to checkpoint/size; durability proven via reopen (7.5)
 # covers: incrvacuum2 incrvacuum2-4.3 — reopen after churn: data correct, integrity ok (7.5)
@@ -279,12 +279,12 @@
 # covers: walpersist walpersist-3.1 — wal_autocheckpoint/journal_size_limit echo doltlite's values (1.16-1.19)
 # covers: walpersist walpersist-3.3 — no wal file after close (2.3)
 # covers: walpersist walpersist-4.1 — journal-mode switching rejected with stable error; wal accepted (1.2-1.7)
-# covers: vacuum2 vacuum2-4.1 — AUTOINCREMENT table drop + VACUUM ok (7.7); auto_vacuum=1 rejected, stays 0 (7.9)
+# covers: vacuum2 vacuum2-4.1 — AUTOINCREMENT table drop + VACUUM ok (7.7); auto_vacuum=1 no-op, stays 0 (7.9)
 # covers: vacuum2 vacuum2-2.1 — change-counter intent: content hash stable across VACUUM no-op, data intact (7.8)
-# covers: vacuum2 vacuum2-3.3 — auto_vacuum=FULL rejected (1.10); data + hash unchanged by VACUUM (7.8)
-# covers: vacuum2 vacuum2-4.2 — auto_vacuum remains 0 after rejected set + VACUUM (7.9)
+# covers: vacuum2 vacuum2-3.3 — auto_vacuum=FULL no-op (1.10); data + hash unchanged by VACUUM (7.8)
+# covers: vacuum2 vacuum2-4.2 — auto_vacuum remains 0 after no-op set + VACUUM (7.9)
 # covers: vacuum2 vacuum2-4.4 — auto_vacuum reports 0 across reopen (7.10)
-# covers: vacuum2 vacuum2-4.5 — auto_vacuum=2 rejected (1.11, 7.9)
+# covers: vacuum2 vacuum2-4.5 — auto_vacuum=2 no-op (1.11, 7.9)
 # covers: vacuum2 vacuum2-4.7 — auto_vacuum 0 across reopen, data + integrity ok (7.10)
 # covers: walprotocol walprotocol-1.1 — shm-lock sequences inapplicable; cold open + read returns committed data (5.1-5.2)
 # covers: walprotocol walprotocol-1.2 — shm-lock sequences inapplicable; cold open + read returns committed data (5.1-5.2)
@@ -300,7 +300,7 @@
 # covers: interrupt2 interrupt2-2.0 — temp INSERT..SELECT copies exactly: matching counts and zero NULL rows (10.1-10.2)
 # covers: interrupt2 interrupt2-3.1.2 — close leaves no -wal artifact; reopen consistent (10.3)
 # covers: interrupt2 interrupt2-4.1 — no SQLite wal frame counter; autocheckpoint-sized writes durable with integrity ok (10.4)
-# covers: tkt3762 tkt3762-1.1 — auto_vacuum=INCREMENTAL rejected (1.9); zeroblob(900) churn under cache_size=10 reopens clean (7.6)
+# covers: tkt3762 tkt3762-1.1 — auto_vacuum=INCREMENTAL no-op (1.9); zeroblob(900) churn under cache_size=10 reopens clean (7.6)
 
 set testdir [file dirname $argv0]
 source $testdir/tester.tcl
@@ -308,7 +308,8 @@ source $testdir/tester.tcl
 #-------------------------------------------------------------------------
 # Section 1: journal/WAL/vacuum pragma contract. doltlite-format databases
 # are permanently journal_mode=wal, reject reconfiguration with stable
-# error text, and reject auto_vacuum / incremental_vacuum.
+# error text, and accept auto_vacuum / incremental_vacuum as no-ops
+# (auto_vacuum always reads back 0).
 #
 do_execsql_test doltlite_recover_jrnlwal_3-1.1 {
   PRAGMA journal_mode;
@@ -334,21 +335,24 @@ do_execsql_test doltlite_recover_jrnlwal_3-1.7 {
 do_execsql_test doltlite_recover_jrnlwal_3-1.8 {
   PRAGMA auto_vacuum;
 } {0}
-do_catchsql_test doltlite_recover_jrnlwal_3-1.9 {
-  PRAGMA auto_vacuum=incremental;
-} {1 {auto_vacuum is not supported on doltlite-format databases}}
-do_catchsql_test doltlite_recover_jrnlwal_3-1.10 {
-  PRAGMA auto_vacuum=full;
-} {1 {auto_vacuum is not supported on doltlite-format databases}}
-do_catchsql_test doltlite_recover_jrnlwal_3-1.11 {
-  PRAGMA auto_vacuum=2;
-} {1 {auto_vacuum is not supported on doltlite-format databases}}
+do_test doltlite_recover_jrnlwal_3-1.9 {
+  list [catchsql {PRAGMA auto_vacuum=incremental}] \
+       [execsql {PRAGMA auto_vacuum}]
+} {{0 {}} 0}
+do_test doltlite_recover_jrnlwal_3-1.10 {
+  list [catchsql {PRAGMA auto_vacuum=full}] \
+       [execsql {PRAGMA auto_vacuum}]
+} {{0 {}} 0}
+do_test doltlite_recover_jrnlwal_3-1.11 {
+  list [catchsql {PRAGMA auto_vacuum=2}] \
+       [execsql {PRAGMA auto_vacuum}]
+} {{0 {}} 0}
 do_catchsql_test doltlite_recover_jrnlwal_3-1.12 {
   PRAGMA incremental_vacuum;
-} {1 {incremental_vacuum is not supported on doltlite-format databases}}
+} {0 {}}
 do_catchsql_test doltlite_recover_jrnlwal_3-1.13 {
   PRAGMA incremental_vacuum(5);
-} {1 {incremental_vacuum is not supported on doltlite-format databases}}
+} {0 {}}
 do_execsql_test doltlite_recover_jrnlwal_3-1.14 {
   PRAGMA incr_vacuum;
 } {}
@@ -555,7 +559,8 @@ do_test doltlite_recover_jrnlwal_3-5.9 {
 
 #-------------------------------------------------------------------------
 # Section 6: savepoint semantics that the originals exercised under
-# auto_vacuum / journal_mode permutations doltlite rejects. The savepoint
+# auto_vacuum / journal_mode permutations doltlite does not honor
+# (auto_vacuum sets no-op; journal_mode is fixed at wal). The savepoint
 # data outcomes themselves must match stock exactly.
 #
 do_test doltlite_recover_jrnlwal_3-6.1 {
@@ -830,7 +835,7 @@ do_test doltlite_recover_jrnlwal_3-7.1 {
   list [catchsql {PRAGMA incremental_vacuum(1)}] \
        [execsql {SELECT count(*) FROM iv}] \
        [execsql {PRAGMA integrity_check}]
-} {{1 {incremental_vacuum is not supported on doltlite-format databases}} 0 ok}
+} {{0 {}} 0 ok}
 do_test doltlite_recover_jrnlwal_3-7.2 {
   forcedelete test2.db test2.db-wal
   execsql {
@@ -843,7 +848,7 @@ do_test doltlite_recover_jrnlwal_3-7.2 {
   }
   list [catchsql {PRAGMA aux.incremental_vacuum(1)}] \
        [execsql {SELECT count(*) FROM iv; SELECT count(*) FROM aux.iv2}]
-} {{1 {incremental_vacuum is not supported on doltlite-format databases}} {0 0}}
+} {{0 {}} {0 0}}
 do_test doltlite_recover_jrnlwal_3-7.3 {
   execsql { DETACH aux }
   execsql {
@@ -916,7 +921,7 @@ do_test doltlite_recover_jrnlwal_3-7.8 {
 do_test doltlite_recover_jrnlwal_3-7.9 {
   list [catchsql {PRAGMA auto_vacuum=1; VACUUM}] \
        [execsql {PRAGMA auto_vacuum}]
-} {{1 {auto_vacuum is not supported on doltlite-format databases}} 0}
+} {{0 {}} 0}
 do_test doltlite_recover_jrnlwal_3-7.10 {
   db close
   sqlite3 db test.db

--- a/test/doltlite_recover_jrnlwal_4.test
+++ b/test/doltlite_recover_jrnlwal_4.test
@@ -116,10 +116,10 @@ source $testdir/tester.tcl
 # covers: jrnlmode jrnlmode-2.4 — cross-db txn commits atomically, rows visible, no -journal sidecars (7.4,3.1,3.2)
 # covers: jrnlmode jrnlmode-2.5 — cross-db txn commits atomically, rows visible, no -journal sidecars (7.4,3.1,3.2)
 # covers: jrnlmode jrnlmode-3.2 — BEGIN IMMEDIATE + INSERT OR IGNORE across attached dbs commits (7.5)
-# covers: jrnlmode jrnlmode-4.1 — cache_size=1 + blob insert/delete + integrity_check ok; auto_vacuum rejected (10.6,10.4,2.8)
-# covers: jrnlmode jrnlmode-4.2 — cache_size=1 + blob insert/delete + integrity_check ok; auto_vacuum rejected (10.6,10.4,2.8)
-# covers: jrnlmode jrnlmode-4.3 — cache_size=1 + blob insert/delete + integrity_check ok; auto_vacuum rejected (10.6,10.4,2.8)
-# covers: jrnlmode jrnlmode-4.4 — cache_size=1 + blob insert/delete + integrity_check ok; auto_vacuum rejected (10.6,10.4,2.8)
+# covers: jrnlmode jrnlmode-4.1 — cache_size=1 + blob insert/delete + integrity_check ok; auto_vacuum no-op (10.6,10.4,2.8)
+# covers: jrnlmode jrnlmode-4.2 — cache_size=1 + blob insert/delete + integrity_check ok; auto_vacuum no-op (10.6,10.4,2.8)
+# covers: jrnlmode jrnlmode-4.3 — cache_size=1 + blob insert/delete + integrity_check ok; auto_vacuum no-op (10.6,10.4,2.8)
+# covers: jrnlmode jrnlmode-4.4 — cache_size=1 + blob insert/delete + integrity_check ok; auto_vacuum no-op (10.6,10.4,2.8)
 # covers: jrnlmode jrnlmode-5.1 — journal_size_limit fixed at -1, set echoes -1 incl. aux (6.1-6.3,7.3)
 # covers: jrnlmode jrnlmode-5.3 — journal_size_limit fixed at -1, set echoes -1 incl. aux (6.1-6.3,7.3)
 # covers: jrnlmode jrnlmode-5.4.1 — journal_size_limit fixed at -1, set echoes -1 incl. aux (6.1-6.3,7.3)
@@ -292,9 +292,9 @@ source $testdir/tester.tcl
 # covers: journal3 journal3-1.2.4.4 — no -journal sidecar is ever created during an open txn; rollback intact (3.1,2.2)
 # covers: shared3 shared3-2.4 — cache_size echoes per connection; cross-connection reads consistent (10.1,10.2)
 # covers: shared3 shared3-2.8 — no pager-lock cache spill: concurrent write conflict is deterministic 'database is locked' (4.2)
-# covers: shared3 shared3-3.1 — auto_vacuum=2 rejected with exact error (10.4)
+# covers: shared3 shared3-3.1 — auto_vacuum=2 accepted as a no-op, reads back 0 (10.4)
 # covers: shared3 shared3-3.2 — uncommitted schema change invisible to second connection (4.7)
-# covers: shared3 shared3-3.3 — incremental_vacuum errors; database unaffected (10.5)
+# covers: shared3 shared3-3.3 — incremental_vacuum no-ops; database unaffected (10.5)
 # covers: shared3 shared3-3.4 — uncommitted schema change invisible to second connection (4.7)
 # covers: tkt-f3e5abed55 tkt-f3e5abed55-1.4 — multi-db COMMIT succeeds under snapshot isolation (no pager write-lock); atomic visibility (7.4)
 # covers: tkt-f3e5abed55 tkt-f3e5abed55-1.5 — both connections continue to commit cleanly; rows from both dbs visible (4.3,7.4,7.5)
@@ -302,13 +302,12 @@ source $testdir/tester.tcl
 # covers: tkt-f3e5abed55 tkt-f3e5abed55-2.4 — both connections continue to commit cleanly; rows from both dbs visible (4.3,7.4,7.5)
 # covers: tkt-f3e5abed55 tkt-f3e5abed55-2.5 — multi-db txn durable across reopen; no master-journal files (7.8,7.4)
 # covers: vacuum vacuum-7.1 — freelist_count is 0 in prolly storage even after DROP TABLE (10.3)
-# covers: vacuum vacuum-7.5 — auto_vacuum=1 rejected; auto_vacuum reads 0 (10.4)
+# covers: vacuum vacuum-7.5 — auto_vacuum=1 no-op; auto_vacuum reads 0 (10.4)
 # covers: misc1 misc1-14.2b — no -journal sidecar during open write transaction (3.1)
 # not-covered: (none)
 
 set JM_ERR {journal_mode is not configurable on doltlite-format databases}
 set CKPT_ERR {wal_checkpoint mode is not configurable on doltlite-format databases; use the default (PASSIVE) form}
-set AV_ERR {auto_vacuum is not supported on doltlite-format databases}
 
 #-------------------------------------------------------------------------
 # 1.*: PRAGMA journal_mode contract: fixed at wal, setters rejected.
@@ -656,7 +655,7 @@ do_test doltlite_recover_jrnlwal_4-9.5 {
 
 #-------------------------------------------------------------------------
 # 10.*: pager-metric pragmas: cache_size echo, freelist_count, auto_vacuum
-# and incremental_vacuum rejection, user_version, lock_status.
+# and incremental_vacuum no-ops, user_version, lock_status.
 #
 do_execsql_test doltlite_recover_jrnlwal_4-10.1 {
   PRAGMA main.cache_size = 10;
@@ -678,12 +677,13 @@ do_execsql_test doltlite_recover_jrnlwal_4-10.3 {
 do_test doltlite_recover_jrnlwal_4-10.4 {
   list [execsql {PRAGMA auto_vacuum}] \
        [catchsql {PRAGMA auto_vacuum = 1}] \
-       [catchsql {PRAGMA auto_vacuum = 2}]
-} [list 0 [list 1 $AV_ERR] [list 1 $AV_ERR]]
+       [catchsql {PRAGMA auto_vacuum = 2}] \
+       [execsql {PRAGMA auto_vacuum}]
+} {0 {0 {}} {0 {}} 0}
 do_test doltlite_recover_jrnlwal_4-10.5 {
   list [catchsql {PRAGMA incremental_vacuum}] \
        [execsql {SELECT count(*) FROM t1}]
-} {{1 {incremental_vacuum is not supported on doltlite-format databases}} 5}
+} {{0 {}} 5}
 do_execsql_test doltlite_recover_jrnlwal_4-10.6 {
   PRAGMA cache_size = 1;
   CREATE TABLE abc(a, b, c);

--- a/test/doltlite_recover_pragma_output.test
+++ b/test/doltlite_recover_pragma_output.test
@@ -7,7 +7,7 @@ source $testdir/tester.tcl
 # scoped cache/synchronous/user_version pragmas, content-derived schema_version
 # that no-ops on write but invalidates prepared statements on real DDL,
 # integrity_check argument forms with stock-identical error text, synthetic
-# page_size/page_count, auto_vacuum rejection, corrupted files refused at
+# page_size/page_count, auto_vacuum no-ops, corrupted files refused at
 # open/ATTACH, single-file storage (multiplex intent), and shrink_memory /
 # sqlite3_db_release_memory as safe no-ops.
 #
@@ -74,12 +74,12 @@ source $testdir/tester.tcl
 # covers: pragma pragma-14.5 — ROLLBACK restores pre-txn page_count (7.5)
 # covers: pragma pragma-14.6 — aux.page_count reports the attached db's count (7.7)
 # covers: pragma pragma-14.6uc — AUX.PAGE_COUNT uppercase matches (7.7)
-# covers: pragma pragma-17.1.1 — auto_vacuum=1 rejected with exact doltlite message (8.1)
-# covers: pragma pragma-17.1.2 — auto_vacuum=2 rejected (8.2)
-# covers: pragma pragma-17.1.full — auto_vacuum=full rejected (8.3)
-# covers: pragma pragma-17.1.FULL — auto_vacuum=FULL rejected (8.3)
-# covers: pragma pragma-17.1.incremental — auto_vacuum=incremental rejected (8.4)
-# covers: pragma pragma-17.1.INCREMENTAL — auto_vacuum=INCREMENTAL rejected (8.4)
+# covers: pragma pragma-17.1.1 — auto_vacuum=1 accepted as a no-op, reads back 0 (8.1)
+# covers: pragma pragma-17.1.2 — auto_vacuum=2 no-op, reads back 0 (8.2)
+# covers: pragma pragma-17.1.full — auto_vacuum=full no-op, reads back 0 (8.3)
+# covers: pragma pragma-17.1.FULL — auto_vacuum=FULL no-op, reads back 0 (8.3)
+# covers: pragma pragma-17.1.incremental — auto_vacuum=incremental no-op, reads back 0 (8.4)
+# covers: pragma pragma-17.1.INCREMENTAL — auto_vacuum=INCREMENTAL no-op, reads back 0 (8.4)
 # covers: pragma pragma-22.2 — corruption never silently served: opening a corrupted file errors {file is not a database} (3.1)
 # covers: pragma pragma-22.3.1 — ATTACHing a corrupted file errors {unable to open database: testerr.db}; healthy main unaffected (3.2)
 # covers: pragma pragma-22.3.3 — aux.integrity_check scopes to the attached db (3.3)
@@ -493,27 +493,26 @@ do_test doltlite_recover_pragma_output-7.7 {
 execsql {DETACH aux}
 
 #-----------------------------------------------------------------------
-# 8: auto_vacuum settings are rejected, never half-applied
+# 8: auto_vacuum settings are accepted as no-ops, never applied
 #
-set avmsg {auto_vacuum is not supported on doltlite-format databases}
-do_catchsql_test doltlite_recover_pragma_output-8.1 {
-  PRAGMA auto_vacuum=1
-} [list 1 $avmsg]
-do_catchsql_test doltlite_recover_pragma_output-8.2 {
-  PRAGMA auto_vacuum=2
-} [list 1 $avmsg]
-do_catchsql_test doltlite_recover_pragma_output-8.3a {
-  PRAGMA auto_vacuum=full
-} [list 1 $avmsg]
-do_catchsql_test doltlite_recover_pragma_output-8.3b {
-  PRAGMA auto_vacuum=FULL
-} [list 1 $avmsg]
-do_catchsql_test doltlite_recover_pragma_output-8.4a {
-  PRAGMA auto_vacuum=incremental
-} [list 1 $avmsg]
-do_catchsql_test doltlite_recover_pragma_output-8.4b {
-  PRAGMA auto_vacuum=INCREMENTAL
-} [list 1 $avmsg]
+do_test doltlite_recover_pragma_output-8.1 {
+  list [catchsql {PRAGMA auto_vacuum=1}] [execsql {PRAGMA auto_vacuum}]
+} {{0 {}} 0}
+do_test doltlite_recover_pragma_output-8.2 {
+  list [catchsql {PRAGMA auto_vacuum=2}] [execsql {PRAGMA auto_vacuum}]
+} {{0 {}} 0}
+do_test doltlite_recover_pragma_output-8.3a {
+  list [catchsql {PRAGMA auto_vacuum=full}] [execsql {PRAGMA auto_vacuum}]
+} {{0 {}} 0}
+do_test doltlite_recover_pragma_output-8.3b {
+  list [catchsql {PRAGMA auto_vacuum=FULL}] [execsql {PRAGMA auto_vacuum}]
+} {{0 {}} 0}
+do_test doltlite_recover_pragma_output-8.4a {
+  list [catchsql {PRAGMA auto_vacuum=incremental}] [execsql {PRAGMA auto_vacuum}]
+} {{0 {}} 0}
+do_test doltlite_recover_pragma_output-8.4b {
+  list [catchsql {PRAGMA auto_vacuum=INCREMENTAL}] [execsql {PRAGMA auto_vacuum}]
+} {{0 {}} 0}
 do_test doltlite_recover_pragma_output-8.5 {
   execsql {
     PRAGMA auto_vacuum=0;

--- a/test/doltlite_recover_rawformat_2.test
+++ b/test/doltlite_recover_rawformat_2.test
@@ -120,10 +120,10 @@ source $testdir/tester.tcl
 #   (hash-stable) rather than rewriting the file header (8.1)
 # covers: vacuum2 vacuum2-3.1 — data state (not page count) is the contract:
 #   rows correct before/after VACUUM with a second attached schema (8.1-8.2)
-# covers: vacuum2 vacuum2-3.13 — auto_vacuum cannot be reconfigured: set errors
-#   verbatim, value stays 0, VACUUM still succeeds (8.4)
+# covers: vacuum2 vacuum2-3.13 — auto_vacuum cannot be reconfigured: set is a
+#   silent no-op, value stays 0, VACUUM still succeeds (8.4)
 # covers: vacuum vacuum-7.6 — PRAGMA auto_vacuum=1 + VACUUM does not switch the
-#   db to auto_vacuum; doltlite rejects the set and reports 0 (8.4)
+#   db to auto_vacuum; doltlite no-ops the set and reports 0 (8.4)
 # covers-class: securedel2 securedel2-1.4.{1,3} securedel2-1.5.2
 #   securedel2-1.6.2 (4 entries): freed-byte zeroing is N/A on the
 #   content-addressed store (GC reclaims); recovered row-level intent: the
@@ -708,7 +708,7 @@ do_test doltlite_recover_rawformat_2-8.4 {
   set c [execsql {PRAGMA auto_vacuum}]
   set d [catchsql {VACUUM}]
   list $a $b $c $d
-} {0 {1 {auto_vacuum is not supported on doltlite-format databases}} 0 {0 {}}}
+} {0 {0 {}} 0 {0 {}}}
 
 do_test doltlite_recover_rawformat_2-8.5 {
   execsql {DELETE FROM v1}

--- a/test/doltlite_recover_savepointfault.test
+++ b/test/doltlite_recover_savepointfault.test
@@ -4,19 +4,19 @@ source $testdir/malloc_common.tcl
 
 set testprefix doltlite_recover_savepointfault
 
-# Recovered coverage for savepointfault.test, which cannot run as a whole
-# file: malloc-4's -sqlprep opens with "PRAGMA auto_vacuum = incremental"
-# (and later runs "PRAGMA incremental_vacuum"), both rejected by design on
-# doltlite-format databases. The prep failure happens before the malloc
-# fault is armed, so it is deterministic, and do_malloc_test's loop never
-# reaches its stop condition (nFail>0): the file repeats the identical
-# failure until the tester's error cap aborts it. The fault scenarios that
-# do not depend on auto_vacuum are ported here verbatim.
+# Recovered coverage for savepointfault.test. malloc-4's -sqlprep opens
+# with "PRAGMA auto_vacuum = incremental" (and later runs "PRAGMA
+# incremental_vacuum"); doltlite accepts both as no-ops, so the upstream
+# file now completes. But because incremental_vacuum no-ops, the savepoint
+# in malloc-4's prep records no freelist changes and its ROLLBACK TO body
+# has nothing real to roll back — the page-freelist rollback path it
+# targets still has no doltlite equivalent. The fault scenarios that do
+# not depend on auto_vacuum are ported here verbatim.
 #
 # covers: savepointfault savepointfault-malloc-1 — OOM at every allocation point through nested savepoints with INSERT/DELETE, ROLLBACK TO, RELEASE; each iteration either fails with OOM or completes (malloc-1)
 # covers: savepointfault savepointfault-malloc-2 — same contract under cache pressure: multi-hundred-row table, nested savepoints with DELETEs, double ROLLBACK TO, RELEASE (malloc-2)
 # covers: savepointfault savepointfault-ioerr-3 — IO errors at every point through BEGIN/UPDATE/SAVEPOINT/UPDATE/COMMIT; database checksum verified intact after each recovery (ioerr-3)
-# not-covered: savepointfault savepointfault-malloc-4 — prep requires auto_vacuum=incremental and PRAGMA incremental_vacuum, both intentionally rejected on doltlite-format databases; the page-freelist savepoint rollback it targets has no doltlite equivalent
+# not-covered: savepointfault savepointfault-malloc-4 — prep's auto_vacuum=incremental and PRAGMA incremental_vacuum are accepted as no-ops, so the upstream file runs whole; with incremental_vacuum a no-op the savepoint holds no freelist changes and the ROLLBACK TO under OOM exercises only an empty-savepoint rollback — the page-freelist rollback it targets has no doltlite equivalent
 
 do_malloc_test 1 -sqlprep {
   CREATE TABLE t1(a, b, c);

--- a/test/known_testfixture_crashes.txt
+++ b/test/known_testfixture_crashes.txt
@@ -104,24 +104,13 @@ memdb1        # sqlite3_serialize/deserialize page-image API unsupported on prol
 # It is undetectable defensively (a freed stmt pointer looks valid) and is a test
 # footgun exposed by the intentional PRAGMA divergence, like alter2/walro.
 # (createtab additionally diverges on read-cursor-abort-across-DDL; see triggerC-12.2.)
-createtab     # PRAGMA auto_vacuum errors (intentional) -> failed prepare -> stale stmt var -> UAF
-tkt2565        # auto_vacuum unsupported -> setup aborts (pre-summary)
-savepoint6     # auto_vacuum unsupported -> uncaught setup error aborts pre-summary
 vtab1          # post-vtab1-5 cleanup drops echo backing tables before vtabs; clean error + implicit-PK echo behavior covered by doltlite_recover_vtab1
 
 # ── feature-gap sweep wave 1 (#1208): files whose setup aborts pre-summary on
 # an intentional rejection or a stock-only artifact. Reasons captured from a
 # per-file non-root run.
-autovacuum       # auto_vacuum unsupported -> uncaught setup error
 corrupt2         # auto_vacuum unsupported -> uncaught setup error
-e_vacuum         # auto_vacuum unsupported -> uncaught setup error
-incrvacuum       # auto_vacuum unsupported -> uncaught setup error
 incrvacuum3      # auto_vacuum unsupported -> uncaught setup error
-incrvacuum_ioerr # auto_vacuum unsupported -> uncaught setup error
-ioerr4           # auto_vacuum unsupported -> uncaught setup error
-mallocC          # auto_vacuum unsupported -> uncaught setup error
-mmap1            # auto_vacuum unsupported -> uncaught setup error
-vacuum3          # auto_vacuum unsupported -> uncaught setup error
 pager2           # journal_mode not configurable -> uncaught setup error
 pagerfault       # journal_mode not configurable -> uncaught setup error
 pagerfault2      # journal_mode rejection cascades into the faultsim harness; abort point varies run to run (not bucket-enforced)
@@ -155,7 +144,6 @@ win32nolock      # windows-only: silent platform return, no summary line
 corrupt9       # freelist raw-format probe aborts ("Freelist is empty")
 dbstatus       # dbstat vtable constructor fails on prolly; memory-stat probes differ
 e_walauto      # reads test.db-shm: no shm sidecar
-incrblob_err   # full fault file still aborts; blob-read IOERR cleanup path covered by doltlite_recover_incrblob
 malloc3        # OOM mid-file leaves setup table missing; uncaught -> aborts
 pendingrace    # copies sv_test.db-journal: no journal sidecar
 shmlock        # shm locking probe: "BUSY false-positive" thrown by the test
@@ -180,10 +168,8 @@ filefmt  # raw-format pokes (16-byte "SQLite format 3" header, page-size at offs
 fts3  # fts3.test is a suite-runner (permutations.test run_test_suite fts3) that re-sources the whole fts3 family inline; it aborts deterministically (3/3, only Time: lines differ) inside the fts3corrupt2 portion at "SELECT rowid, length(root), root FROM t2_segdir" — same rowid-on-WITHOUT-ROWID-%_segdir mechanism as the standalone fts3corrupt2 crash
 fts3corrupt2  # stable 3/3 abort after fts3corrupt2-1.163.5 at line 90: "db eval {SELECT rowid, length(root), root FROM t2_segdir}" — %_segdir has composite PRIMARY KEY(level,idx), doltlite auto-converts it to WITHOUT ROWID so rowid does not exist; uncaught tcl error (all 163 corruption loops before it pass)
 pragma3  # aborts at line 263 when execsql {PRAGMA journal_mode = PERSIST; PRAGMA locking_mode = EXCLUSIVE} raises doltlite's intentional "journal_mode is not configurable on doltlite-format databases" outside any catch. Stable abort, 3/3 runs. Masked underneath: every data_version expectation diverges because doltlite bumps data_version on same-connection commits too (each commit installs a new root; verified: CREATE+INSERT moves it 1->4 on one connection), where stock only bumps it for other-connection changes.
-pragma4  # aborts at the first foreach (line 30, test 1.3.2) when do_pragma_ncol_test calls an uncaught sqlite3_prepare_v2 on "PRAGMA auto_vacuum = 1" and doltlite's intentional auto_vacuum rejection fails the prepare ("auto_vacuum is not supported on doltlite-format databases"). Stable abort, 3/3 runs; only 5 tests run before the abort.
 qrf04  # upstream qrf04.test has no finish_test call; its single do_test (qrf01-1.0, db format -splitcolumn) runs and passes but the summary line is never printed (rc=0, deterministic 3/3), so the harness sees it as a crash
 superlock  # sqlite3demo_superlock cannot acquire its byte-range/WAL superlock on doltlite chunk-store files (PRAGMA journal_mode=DELETE is rejected with "journal_mode is not configurable on doltlite-format databases" and the lock demo fails with disk I/O error), so the `unlock` proc it registers on success never exists; the bare `unlock` call after test 5.$tn.12 inside do_multiclient_test (superlock.test line 91, body line 64) is outside any do_test and the tcl error aborts the file before finish_test; deterministic 3/3
-tkt2686  # bare top-level `db eval {... PRAGMA auto_vacuum=1 ...}` at tkt2686.test line 55 (not wrapped in do_test) hits doltlite's intentional "auto_vacuum is not supported on doltlite-format databases" error and the uncaught tcl error aborts the file before finish_test; all 1997 prior tests pass; deterministic 3/3
 
 # == permanently excluded classes (1357 sweep close-out) ==
 #
@@ -211,4 +197,9 @@ tkt2686  # bare top-level `db eval {... PRAGMA auto_vacuum=1 ...}` at tkt2686.te
 # whenever fts behavior changes (observed across one merge wave). Gating it
 # would churn a 1000-line block on every fts fix; revisit when the fts
 # shadow-table stale-read bug is fixed and the count drops below the cap.
+#
+# savepoint6: a randomized savepoint fuzz workload sitting on an open
+# savepoint-state bug (deleted rows resurrected after a RELEASE-collapsed
+# ROLLBACK TO), so its failure set differs between builds; re-bucket and
+# gate once the bug is fixed and the file runs clean.
 

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -66,61 +66,6 @@ index index-17.1  # rowid-order assumption
 # ── bestindex4 ──
 bestindex4 bestindex4-2.1  # EQP names the table PRIMARY KEY instead of sqlite_autoindex_t1_1
 
-# ── avtrans ──
-# avtrans is trans.test under auto_vacuum=full. DoltLite intentionally rejects
-# auto_vacuum on prolly-format databases, so the first setup block runs in
-# normal mode and cascades into schema/content/checksum differences.
-avtrans avtrans-1.0
-avtrans avtrans-1.0.1
-avtrans avtrans-1.9
-avtrans avtrans-2.10
-avtrans avtrans-3.1
-avtrans avtrans-3.3
-avtrans avtrans-3.4
-avtrans avtrans-3.6
-avtrans avtrans-3.9
-avtrans avtrans-3.12
-avtrans avtrans-3.14
-avtrans avtrans-4.5
-avtrans avtrans-4.8
-avtrans avtrans-4.11
-avtrans avtrans-4.98
-avtrans avtrans-5.1
-avtrans avtrans-5.2
-avtrans avtrans-5.3
-avtrans avtrans-5.6
-avtrans avtrans-5.8
-avtrans avtrans-5.9
-avtrans avtrans-5.10
-avtrans avtrans-5.11
-avtrans avtrans-5.12
-avtrans avtrans-5.13
-avtrans avtrans-5.14
-avtrans avtrans-5.15
-avtrans avtrans-5.16
-avtrans avtrans-5.17
-avtrans avtrans-5.20
-avtrans avtrans-5.22
-avtrans avtrans-9.2.5-1024
-avtrans avtrans-9.4.5-1224
-avtrans avtrans-9.6.5-1480
-avtrans avtrans-9.8.5-1766
-avtrans avtrans-9.10.5-2112
-avtrans avtrans-9.12.5-2544
-avtrans avtrans-9.14.5-3089
-avtrans avtrans-9.16.5-3802
-avtrans avtrans-9.18.5-4593
-avtrans avtrans-9.20.5-5551
-avtrans avtrans-9.22.5-6736
-avtrans avtrans-9.24.5-8156
-avtrans avtrans-9.26.5-9897
-avtrans avtrans-9.28.5-11982
-avtrans avtrans-9.30.5-14544
-avtrans avtrans-9.32.5-17576
-avtrans avtrans-9.34.5-21225
-avtrans avtrans-9.36.5-25685
-avtrans avtrans-9.38.5-30883
-
 # ── alter ──
 alter alter-1.2  # ALTER TABLE rowid-preservation semantics
 alter alter-1.5  # ALTER TABLE rowid-preservation semantics
@@ -226,12 +171,6 @@ e_createtable e_createtable-5.4.2.4
 e_createtable e_createtable-5.4.3
 e_createtable e_createtable-5.6.1
 
-# ── e_update ──
-# cross-db (ATTACHed) UPDATE: doltlite's attached-db schema reload diverges
-# (reports a reload "index i1 already exists" where stock reports a different
-# error). The cross-db write itself now works; the reload bug is tracked
-# separately.
-
 # ── e_select ──
 e_select e_select-4.9.4  # rowid-order vs PK-order on unordered SELECT
 
@@ -252,8 +191,6 @@ e_fkey e_fkey-51.3
 e_fkey e_fkey-52.6
 e_fkey e_fkey-57.7
 e_fkey e_fkey-58.3
-
-# ── pragma ──
 
 # ── pragma ── (completes now that attached-db writes work; PRAGMA output / attached-db / integrity divergences)
 pragma pragma-1.10
@@ -424,27 +361,6 @@ shared shared-2.1.0    # auto_vacuum rejected on doltlite-format databases
 shared2 shared2-1.1  # shared-cache rowid-order assumption
 shared2 shared2-1.2
 shared2 shared2-1.3
-
-# ── pragma (extra: VACUUM no-op) ──
-
-# ── vacuum ──
-# VACUUM aliases dolt_gc() in the doltlite shell (#991). In the
-# testfixture build the doltlite SQL functions aren't linked, so
-# VACUUM there is a runtime-detected no-op. Either way, page-layout
-# side effects that stock SQLite VACUUM produces don't apply to
-# prolly storage. 6 of 47 tests still verify those side effects.
-vacuum vacuum-5.1    # post-VACUUM NOT NULL constraint propagation (no-op never re-runs constraints)
-vacuum vacuum-7.6    # post-VACUUM page count assertion
-
-# ── vacuum2 ──
-# Same rationale as vacuum.test. 23 of 31 pass under the no-op.
-vacuum2 vacuum2-2.2   # post-VACUUM page count
-vacuum2 vacuum2-3.1   # post-VACUUM page count
-vacuum2 vacuum2-3.13  # post-VACUUM page count
-vacuum2 vacuum2-4.1   # post-VACUUM auto_vacuum mode change
-vacuum2 vacuum2-5.2   # "cannot VACUUM - SQL statements in progress" error path
-vacuum2 vacuum2-5.3   # error path
-vacuum2 vacuum2-5.4   # error path
 
 # ── crash7 ──
 # crash7 verifies crash recovery during VACUUM. Since VACUUM is a no-op
@@ -617,7 +533,6 @@ without_rowid7 without_rowid7-3.4.2
 without_rowid7 without_rowid7-3.5.1
 without_rowid7 without_rowid7-3.5.2
 without_rowid7 without_rowid7-3.6
-vacuum2 vacuum2-6.0  # PRIMARY KEY COLLATE cmp WITHOUT ROWID rejected
 
 # ---------------------------------------------------------------------------
 # Real-doltlite divergences surfaced when the amalgamation became genuine
@@ -966,79 +881,10 @@ minmax3 minmax3-4.5
 minmax3 minmax3-4.6
 quote quote-2.5  # DQS: doltlite keeps SQLITE_DQS=3 default (main.mk); oracle built DQS=0, so double-quoted-string DDL is accepted vs rejected
 rowid rowid-4.5  # sqlite_search_count metric; joined row result (4) matches stock
-# savepoint: the core SAVEPOINT/ROLLBACK semantics now pass. Remaining
-# failures are stock pager/file-format behavior that DoltLite intentionally
-# does not emulate, plus downstream labels reached after those divergences.
-#
-# PRAGMA lock_status expects stock rollback-journal RESERVED locks. DoltLite's
-# prolly storage does not expose those pager locks, so writes stay "unlocked".
-savepoint savepoint-3.2
-savepoint savepoint-3.3
-savepoint savepoint-3.4
-
-# Second connection read locks do not block DoltLite savepoint release the way
-# stock rollback-journal pager locks do; savepoint-5.4.4 is the follow-on after
-# RELEASE succeeds instead of returning "database is locked".
-savepoint savepoint-5.4.3
-savepoint savepoint-5.4.4
-
-# auto_vacuum / incremental_vacuum are unsupported on DoltLite-format
-# databases. Later labels in these blocks cascade from setup that stock SQLite
-# completes by growing/shrinking page files.
-savepoint savepoint-6.1
-savepoint savepoint-6.3
-savepoint savepoint-7.1
-savepoint savepoint-7.2.1
-savepoint savepoint-7.3.1
-savepoint savepoint-7.3.2
-savepoint savepoint-7.4.1
-savepoint savepoint-7.5.1
-savepoint savepoint-7.5.2
-
-# ATTACH + savepoint data operations pass independently, but this block runs
-# after the unsupported auto_vacuum setup above leaves the expected tables
-# absent. The lock_status assertions also expect stock pager lock states for
-# attached page files.
-savepoint savepoint-10.2.1
-savepoint savepoint-10.2.2
-savepoint savepoint-10.2.3
-savepoint savepoint-10.2.4
-savepoint savepoint-10.2.5
-savepoint savepoint-10.2.6
-savepoint savepoint-10.2.7
-savepoint savepoint-10.2.8
-savepoint savepoint-10.2.9
-savepoint savepoint-10.2.10
-savepoint savepoint-10.2.11
-savepoint savepoint-10.2.12
-savepoint savepoint-10.2.13
-savepoint savepoint-10.2.14
-
-# auto_vacuum=full is unsupported; the remaining failure in this block is a
-# stock page-file size assertion after wal_checkpoint.
-savepoint savepoint-11.1
-savepoint savepoint-11.8
-
-# journal_mode=off is not configurable for DoltLite-format databases.
-savepoint savepoint-13.1
 
 # Multi-client tests that assert stock rollback-journal lock failures.
 # DoltLite lets the write/release complete, so the following rollback/transaction
 # labels see different savepoint state.
-savepoint savepoint-14.1.2
-savepoint savepoint-14.1.3
-savepoint savepoint-14.1.4
-savepoint savepoint-14.1.5
-savepoint savepoint-14.1.6
-savepoint savepoint-14.2.2
-savepoint savepoint-14.2.3
-savepoint savepoint-14.2.4
-savepoint savepoint-14.2.5
-savepoint savepoint-14.2.6
-savepoint savepoint-15.1.2
-savepoint savepoint-15.1.3
-savepoint savepoint-15.2.2
-savepoint savepoint-15.2.3
 select2 select2-3.3  # sqlite_search_count metric; SELECT f1 WHERE f2==2000 returns 1000 on both
 # trans-9.*: the ".5" labels assert sqlite_fullsync_count/sqlite_sync_count > 0 —
 # SQLite-pager fsync instrumentation that doltlite's prolly backend never drives
@@ -1185,12 +1031,6 @@ shared2 shared2-3.2
 # incremental_vacuum which doltlite rejects (3.1/3.3). Row outcomes (DELETE counts,
 # master visibility) match stock; divergences are pager-lock / shared-cache /
 # auto_vacuum artifacts.
-shared3 shared3-2.4
-shared3 shared3-2.8
-shared3 shared3-3.1
-shared3 shared3-3.2
-shared3 shared3-3.3
-shared3 shared3-3.4
 # tkt-2d1a5c67d-3.6: WAL-checkpoint/recovery test driven by ~99 open incrblob
 # handles + raw test.db-wal file copy; computed value ('xyz') matches stock.
 tkt-2d1a5c67d tkt-2d1a5c67d-3.6
@@ -1203,14 +1043,6 @@ tkt-f3e5abed55 tkt-f3e5abed55-1.5
 tkt-f3e5abed55 tkt-f3e5abed55-2.3
 tkt-f3e5abed55 tkt-f3e5abed55-2.4
 tkt-f3e5abed55 tkt-f3e5abed55-2.5
-vacuum vacuum-7.1
-vacuum vacuum-7.5
-vacuum2 vacuum2-2.1
-vacuum2 vacuum2-3.3
-vacuum2 vacuum2-4.2
-vacuum2 vacuum2-4.4
-vacuum2 vacuum2-4.5
-vacuum2 vacuum2-4.7
 
 # capi3 — C-API behaviors that diverge from stock sqlite at the error-code,
 # open-timing, locking, and catalog level (not row data). Recovered into the
@@ -1297,88 +1129,6 @@ shared9 shared9-3.6  # shared-cache locking-model divergence
 interrupt2 interrupt2-2.0     # temp INSERT...SELECT into z1 has extra NULL rows
 interrupt2 interrupt2-3.1.2   # close-time WAL file artifact differs
 interrupt2 interrupt2-4.1     # no SQLite WAL frame growth/autocheckpoint metric
-
-# jrnlmode — DoltLite-format databases do not expose SQLite's rollback-journal
-# mode switching semantics; PRAGMA journal_mode either remains fixed or returns
-# "journal_mode is not configurable on doltlite-format databases". The xfer
-# crash from #1226 is fixed on current master; enabling the whole file keeps
-# jrnlmode-5.11 covered while documenting the remaining feature divergence.
-jrnlmode jrnlmode-1.0  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-1.1  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-1.2  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-1.4a  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-1.4b  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-1.5  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-1.6  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-1.7  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-1.7.1  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-1.7.2  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-1.8  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-1.9  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-1.10  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-1.11  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-1.12  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-1.13  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-1.14  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-1.15  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-1.16  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-1.99  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-2.1  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-2.2  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-2.3  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-2.4  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-2.5  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-3.2  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-4.1  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-4.2  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-4.3  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-4.4  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-5.1  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-5.3  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-5.4.1  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-5.4.2  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-5.5  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-5.6  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-5.7  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-5.8  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-5.10  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-5.11  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-5.12  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-5.13  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-5.14  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-5.15  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-5.16  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-5.17  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-5.18  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-5.19  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-5.20  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-5.21  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-5.22  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-6.1  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-6.2  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-6.3  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-6.4  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-6.5  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-6.7  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-6.9  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-7.1  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-7.2  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-8.5  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-8.6  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-8.7  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-8.8  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-8.13  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-8.14  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-8.15  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-8.16  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-8.17  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-8.21  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-8.23  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-8.24  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-8.28  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-8.30  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-9.1  # journal_mode unsupported on doltlite-format databases
-jrnlmode jrnlmode-9.2  # journal_mode unsupported on doltlite-format databases
 
 # descidx3 — descidx3-1.1 reads the SQLite file-format version byte via
 # get_file_format (hexio_read test.db offset 44). DoltLite stores a chunk store,
@@ -1655,9 +1405,6 @@ securedel2 securedel2-1.4.3  # freed space not zeroed in place (content-addresse
 securedel2 securedel2-1.5.2  # freed space not zeroed in place (content-addressed; GC reclaims)
 securedel2 securedel2-1.6.2  # freed space not zeroed in place (content-addressed; GC reclaims)
 
-# reclaims old chunks), so the freed-byte scans find old data. Not applicable to
-# the chunk store.
-
 # reservebytes — the per-page reserved-bytes header field does not exist in the
 # chunk store; reads return 00. Page-format divergence.
 reservebytes reservebytes-1.3.5  # no per-page reserved-bytes field in the chunk store
@@ -1794,19 +1541,11 @@ tkt3457 tkt3457-1.3  # no rollback-journal file to back up
 tkt3457 tkt3457-1.4  # no rollback-journal file to back up
 tkt3457 tkt3457-1.5  # no rollback-journal file to back up
 
-# tkt2332 — unordered SELECT returns PK-order rows instead of rowid/insertion order;
-# the multiset is identical (random-data ordering test). rowid-order divergence.
-
 # tkt3810 — a TEMP TRIGGER whose base table is dropped becomes an orphan in stock
 # (still listed in temp.sqlite_master). DoltLite cascades the trigger drop with
 # the table, so the orphan is gone. Schema-catalog cascade divergence.
 tkt3810 tkt3810-3  # orphan temp-trigger dropped with its table (catalog cascade)
 tkt3810 tkt3810-4  # orphan temp-trigger dropped with its table (catalog cascade)
-
-# tkt3761 / tkt3762 — single PRAGMA auto_vacuum assertion; auto_vacuum is
-# intentionally unsupported on doltlite-format databases.
-tkt3761 tkt3761-1.1  # auto_vacuum unsupported
-tkt3762 tkt3762-1.1  # auto_vacuum unsupported
 
 # where4 / whereD / whereG / whereL — query-planner and storage-model
 # divergences; in every case the result rows are correct, only a plan metric,
@@ -2095,10 +1834,6 @@ unixexcl unixexcl-1.1.4.multiproc  # multiproc locking model; wal_checkpoint fra
 unixexcl unixexcl-3.1.1.multiproc  # multiproc locking model; wal_checkpoint frame counters zero (no-op checkpoint); data assertions pass
 unixexcl unixexcl-3.2.3  # multiproc locking model; wal_checkpoint frame counters zero (no-op checkpoint); data assertions pass
 unixexcl unixexcl-3.2.7  # multiproc locking model; wal_checkpoint frame counters zero (no-op checkpoint); data assertions pass
-vacuum4 vacuum4-1.1  # auto_vacuum pragma rejected + cascade
-vacuum6 vacuum6-4.1.2.1  # auto_vacuum pragma rejected + cascade
-vacuum6 vacuum6-4.1.4.1  # auto_vacuum pragma rejected + cascade
-vacuum6 vacuum6-4.1.6.1  # auto_vacuum pragma rejected + cascade
 wal64k wal64k-1.1  # reads test.db-shm: no shm sidecar
 wal64k wal64k-1.2  # reads test.db-shm: no shm sidecar
 wal9 wal9-1.3  # file-size metric + missing -wal/-shm sidecars
@@ -2120,23 +1855,6 @@ walshared walshared-1.3  # shared-cache WAL table locks not raised; snapshot rea
 # -- feature-gap sweep wave 3 (#1208): 44 completing files (6-100 failures),
 # every file's failure set reproduced and classified by verified mechanism;
 # incrblob2 held out as a real bug.
-autovacuum_ioerr2 autovacuum-ioerr2-1.1.1  # auto_vacuum rejected under IO fault injection + cascade
-autovacuum_ioerr2 autovacuum-ioerr2-1.2.1  # auto_vacuum rejected under IO fault injection + cascade
-autovacuum_ioerr2 autovacuum-ioerr2-1.3.1  # auto_vacuum rejected under IO fault injection + cascade
-autovacuum_ioerr2 autovacuum-ioerr2-1.4.1  # auto_vacuum rejected under IO fault injection + cascade
-autovacuum_ioerr2 autovacuum-ioerr2-1.5.1  # auto_vacuum rejected under IO fault injection + cascade
-autovacuum_ioerr2 autovacuum-ioerr2-1.6.1  # auto_vacuum rejected under IO fault injection + cascade
-autovacuum_ioerr2 autovacuum-ioerr2-1.7.1  # auto_vacuum rejected under IO fault injection + cascade
-autovacuum_ioerr2 autovacuum-ioerr2-1.8.1  # auto_vacuum rejected under IO fault injection + cascade
-autovacuum_ioerr2 autovacuum-ioerr2-1.8.3  # auto_vacuum rejected under IO fault injection + cascade
-autovacuum_ioerr2 autovacuum-ioerr2-2.1.1  # auto_vacuum rejected under IO fault injection + cascade
-autovacuum_ioerr2 autovacuum-ioerr2-2.2.1  # auto_vacuum rejected under IO fault injection + cascade
-autovacuum_ioerr2 autovacuum-ioerr2-2.2.3  # auto_vacuum rejected under IO fault injection + cascade
-autovacuum_ioerr2 autovacuum-ioerr2-3.1.1  # auto_vacuum rejected under IO fault injection + cascade
-autovacuum_ioerr2 autovacuum-ioerr2-3.2.1  # auto_vacuum rejected under IO fault injection + cascade
-autovacuum_ioerr2 autovacuum-ioerr2-3.2.3  # auto_vacuum rejected under IO fault injection + cascade
-autovacuum_ioerr2 autovacuum-ioerr2-4.1.1  # auto_vacuum rejected under IO fault injection + cascade
-autovacuum_ioerr2 autovacuum-ioerr2-4.2.3  # auto_vacuum rejected under IO fault injection + cascade
 backup2 backup2-2  # backup format/file hash and error-text differ; in-memory backup rejected
 backup2 backup2-3.2  # backup format/file hash and error-text differ; in-memory backup rejected
 backup2 backup2-4  # backup format/file hash and error-text differ; in-memory backup rejected
@@ -2191,23 +1909,6 @@ corrupt6 corrupt6-1.8.3  # stock freelist/page corruption: offsets land outside 
 corrupt6 corrupt6-1.8.4  # stock restores the original byte; in the chunk store the same write is fresh mid-stream corruption, so integrity_check errors instead of ok
 corrupt6 corrupt6-1.9.3  # stock freelist/page corruption: offsets land outside chunk-store structures
 corrupt6 corrupt6-1.9.4  # stock restores the original byte; in the chunk store the same write is fresh mid-stream corruption, so integrity_check errors instead of ok
-corruptB corruptB-1.1  # stock overflow-page corruption: store rejects differently; harness offset vars unset
-corruptB corruptB-1.3.1  # stock overflow-page corruption: store rejects differently; harness offset vars unset
-corruptB corruptB-1.3.2  # stock overflow-page corruption: store rejects differently; harness offset vars unset
-corruptB corruptB-1.4.1  # stock overflow-page corruption: store rejects differently; harness offset vars unset
-corruptB corruptB-1.4.2  # stock overflow-page corruption: store rejects differently; harness offset vars unset
-corruptB corruptB-1.5.1  # stock overflow-page corruption: store rejects differently; harness offset vars unset
-corruptB corruptB-1.6.1  # stock overflow-page corruption: store rejects differently; harness offset vars unset
-corruptB corruptB-1.6.2  # stock overflow-page corruption: store rejects differently; harness offset vars unset
-corruptB corruptB-1.7.1  # stock overflow-page corruption: store rejects differently; harness offset vars unset
-corruptB corruptB-1.7.2  # stock overflow-page corruption: store rejects differently; harness offset vars unset
-corruptB corruptB-1.8.1  # stock overflow-page corruption: store rejects differently; harness offset vars unset
-corruptB corruptB-1.8.2  # stock overflow-page corruption: store rejects differently; harness offset vars unset
-corruptB corruptB-1.9.1  # stock overflow-page corruption: store rejects differently; harness offset vars unset
-corruptB corruptB-1.9.2  # stock overflow-page corruption: store rejects differently; harness offset vars unset
-corruptB corruptB-2.1.1  # stock overflow-page corruption: store rejects differently; harness offset vars unset
-corruptB corruptB-2.1.2  # stock overflow-page corruption: store rejects differently; harness offset vars unset
-corruptB corruptB-3.1.2  # stock overflow-page corruption: store rejects differently; harness offset vars unset
 corruptE corruptE-2.1  # stock cell-order corruption not representable in chunk store
 corruptE corruptE-2.2  # stock cell-order corruption not representable in chunk store
 corruptE corruptE-2.3  # stock cell-order corruption not representable in chunk store
@@ -2364,198 +2065,19 @@ exclusive2 exclusive2-3.3  # exclusive-mode read-marks; chunk store has no page 
 exclusive2 exclusive2-3.4  # exclusive-mode read-marks; chunk store has no page cache to count
 exclusive2 exclusive2-3.5  # exclusive-mode read-marks; chunk store has no page cache to count
 exclusive2 exclusive2-3.6  # exclusive-mode read-marks; chunk store has no page cache to count
-incrvacuum2 incrvacuum2-1.1  # auto_vacuum rejected; -wal sidecar absent
-incrvacuum2 incrvacuum2-1.2  # auto_vacuum rejected; -wal sidecar absent
-incrvacuum2 incrvacuum2-1.3  # auto_vacuum rejected; -wal sidecar absent
-incrvacuum2 incrvacuum2-1.4  # auto_vacuum rejected; -wal sidecar absent
-incrvacuum2 incrvacuum2-2.1  # auto_vacuum rejected; -wal sidecar absent
-incrvacuum2 incrvacuum2-2.2  # auto_vacuum rejected; -wal sidecar absent
-incrvacuum2 incrvacuum2-2.3  # auto_vacuum rejected; -wal sidecar absent
-incrvacuum2 incrvacuum2-2.4  # auto_vacuum rejected; -wal sidecar absent
-incrvacuum2 incrvacuum2-2.5  # auto_vacuum rejected; -wal sidecar absent
-incrvacuum2 incrvacuum2-2.6  # auto_vacuum rejected; -wal sidecar absent
-incrvacuum2 incrvacuum2-3.1  # auto_vacuum rejected; -wal sidecar absent
-incrvacuum2 incrvacuum2-3.2  # auto_vacuum rejected; -wal sidecar absent
-incrvacuum2 incrvacuum2-4.1  # auto_vacuum rejected; -wal sidecar absent
-incrvacuum2 incrvacuum2-4.2  # auto_vacuum rejected; -wal sidecar absent
-incrvacuum2 incrvacuum2-4.2.1  # auto_vacuum rejected; -wal sidecar absent
-incrvacuum2 incrvacuum2-4.3  # auto_vacuum rejected; -wal sidecar absent
 # ioerr: doltlite VACUUM maps to dolt_gc. Under DOLTLITE_PROLLY_CHECK (the
 # CI testfixture build) gc runs a post-sweep session-resolvability check
 # that re-reads chunks and deliberately treats injected IO faults as
 # inconclusive (only NOTFOUND aborts), so the final fault points record a
 # hit while the VACUUM statement still succeeds. A non-CHECK build passes
 # these three.
-ioerr ioerr-2.31.3  # PROLLY_CHECK gc verify ignores injected read faults
-ioerr ioerr-2.32.3  # PROLLY_CHECK gc verify ignores injected read faults
-ioerr ioerr-2.33.3  # PROLLY_CHECK gc verify ignores injected read faults
 # ioerr: the chunk store journals inside the single database file, so a
 # -journal sidecar never exists. Preps that crash a child on journal sync
 # (ioerr-6) or copy the journal aside (ioerr-7/9) fail before fault
 # injection starts; recovery itself passes once the prep error clears.
-ioerr ioerr-6.1.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.2.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.3.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.4.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.5.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.6.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.7.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.8.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.9.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.10.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.11.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.12.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.13.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.14.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.15.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.16.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.17.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.18.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.19.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.20.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.21.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.22.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.23.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.24.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.25.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.26.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.27.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.28.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.29.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.30.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.31.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.32.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.33.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.34.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.35.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.36.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.37.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.38.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.39.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.40.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.41.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.42.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.43.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.44.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.45.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.46.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.47.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.48.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.49.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.50.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.51.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.52.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.53.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.54.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.55.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.56.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.57.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.58.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.59.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.60.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.61.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.62.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.63.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.64.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.65.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.66.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.67.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.68.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.69.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.70.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.71.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.72.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.73.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.74.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.75.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.76.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.77.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.78.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.79.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.80.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.81.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.82.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.83.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.84.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.85.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.86.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.87.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.88.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.89.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.90.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.91.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.92.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.93.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.94.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-6.95.1  # crashsql trigger on absent -journal never fires
-ioerr ioerr-7.2.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.3.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.4.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.5.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.6.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.7.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.8.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.9.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.10.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.11.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.12.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.13.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.14.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.15.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.16.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.17.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.18.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.19.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.20.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.21.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.22.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.23.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.24.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.25.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.26.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.27.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.28.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.29.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.30.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.31.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.32.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.33.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.34.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.35.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.36.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.37.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.38.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.39.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.40.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.41.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.42.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.43.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.44.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.45.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.46.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.47.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.48.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.49.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.50.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.51.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.52.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.53.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.54.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-7.55.1  # hot-journal prep copies absent -journal sidecar
-ioerr ioerr-9.1.1  # master-journal prep copies absent -journal sidecar
 # ioerr: auto_vacuum rejected on doltlite-format databases; the prep
 # aborts before creating its tables and the body then errors without an
 # IO fault, breaking the hit-XOR-success invariant (cascade).
-ioerr ioerr-12.1.1  # auto_vacuum rejected; prep aborts, body fails without fault
-ioerr ioerr-12.1.3  # auto_vacuum rejected; prep aborts, body fails without fault
-ioerr ioerr-13.1.1  # auto_vacuum rejected; prep aborts, body fails without fault
-ioerr ioerr-13.2.1  # auto_vacuum rejected; prep aborts, body fails without fault
-ioerr ioerr-13.2.3  # auto_vacuum rejected; prep aborts, body fails without fault
-ioerr ioerr-14.1.1  # auto_vacuum rejected; prep aborts, body fails without fault
-ioerr ioerr-14.2.1  # auto_vacuum rejected; prep aborts, body fails without fault
-ioerr ioerr-14.2.3  # auto_vacuum rejected; prep aborts, body fails without fault
-ioerr ioerr-16.1.1  # auto_vacuum rejected; prep aborts, body fails without fault
-ioerr ioerr-16.1.3  # auto_vacuum rejected; prep aborts, body fails without fault
 ioerr3 ioerr3-2.3.3  # IO-fault point shift
 ioerr3 ioerr3-2.4.3  # IO-fault point shift
 ioerr3 ioerr3-2.5.3  # IO-fault point shift
@@ -2907,1006 +2429,6 @@ walprotocol walprotocol-2.8  # WAL locking protocol: recovery-lock contention no
 
 # -- feature-gap sweep final (#1208): fault-saturated heavies; failure sets
 # captured per-file, classes as recorded.
-corrupt8 corrupt8-1.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1024.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1024.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1024.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1024.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1024.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1024.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1024.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1029.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1029.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1029.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1029.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1029.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1029.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1029.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1034.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1034.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1034.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1034.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1034.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1034.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1034.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1039.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1039.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1039.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1039.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1039.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1039.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1039.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1044.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1044.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1044.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1044.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1044.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1044.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1044.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1049.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1049.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1049.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1049.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1049.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1049.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1049.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1054.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1054.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1054.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1054.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1054.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1054.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1054.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1059.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1059.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1059.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1059.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1059.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1059.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1059.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1064.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1064.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1064.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1064.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1064.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1064.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1064.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1069.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1069.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1069.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1069.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1069.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1069.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1069.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1074.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1074.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1074.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1074.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1074.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1074.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1074.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1079.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1079.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1079.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1079.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1079.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1079.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1079.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1084.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1084.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1084.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1084.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1084.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1084.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1084.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1089.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1089.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1089.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1089.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1089.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1089.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1089.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1094.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1094.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1094.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1094.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1094.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1094.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1094.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1099.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1099.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1099.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1099.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1099.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1099.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1099.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1104.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1104.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1104.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1104.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1104.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1104.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1104.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1109.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1109.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1109.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1109.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1109.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1109.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1109.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1114.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1114.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1114.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1114.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1114.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1114.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1114.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1119.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1119.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1119.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1119.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1119.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1119.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1119.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1124.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1124.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1124.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1124.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1124.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1124.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1124.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1129.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1129.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1129.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1129.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1129.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1129.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1129.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1134.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1134.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1134.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1134.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1134.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1134.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1134.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1139.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1139.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1139.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1139.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1139.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1139.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1139.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1144.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1144.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1144.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1144.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1144.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1144.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1144.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1149.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1149.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1149.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1149.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1149.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1149.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1149.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1154.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1154.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1154.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1154.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1154.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1154.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1154.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1159.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1159.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1159.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1159.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1159.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1159.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1159.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1164.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1164.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1164.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1164.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1164.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1164.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1164.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1169.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1169.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1169.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1169.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1169.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1169.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1169.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1174.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1174.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1174.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1174.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1174.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1174.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1174.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1179.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1179.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1179.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1179.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1179.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1179.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1179.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1184.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1184.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1184.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1184.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1184.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1184.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1184.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1189.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1189.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1189.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1189.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1189.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1189.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1189.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1194.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1194.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1194.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1194.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1194.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1194.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1194.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1199.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1199.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1199.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1199.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1199.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1199.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1199.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1204.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1204.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1204.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1204.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1204.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1204.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1204.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1209.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1209.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1209.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1209.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1209.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1209.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1209.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1214.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1214.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1214.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1214.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1214.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1214.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1214.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1219.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1219.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1219.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1219.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1219.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1219.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1219.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1224.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1224.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1224.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1224.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1224.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1224.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1224.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1229.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1229.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1229.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1229.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1229.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1229.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1229.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1234.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1234.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1234.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1234.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1234.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1234.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1234.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1239.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1239.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1239.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1239.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1239.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1239.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1239.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1244.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1244.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1244.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1244.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1244.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1244.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1244.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1249.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1249.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1249.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1249.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1249.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1249.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1249.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1254.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1254.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1254.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1254.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1254.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1254.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1254.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1259.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1259.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1259.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1259.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1259.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1259.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1259.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1264.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1264.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1264.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1264.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1264.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1264.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1264.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1269.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1269.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1269.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1269.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1269.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1269.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1269.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1274.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1274.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1274.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1274.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1274.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1274.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1274.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1279.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1279.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1279.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1279.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1279.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1279.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1279.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1284.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1284.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1284.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1284.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1284.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1284.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1284.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1289.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1289.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1289.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1289.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1289.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1289.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1289.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1294.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1294.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1294.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1294.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1294.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1294.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1294.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1299.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1299.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1299.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1299.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1299.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1299.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1299.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1304.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1304.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1304.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1304.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1304.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1304.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1304.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1309.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1309.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1309.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1309.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1309.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1309.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1309.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1314.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1314.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1314.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1314.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1314.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1314.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1314.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1319.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1319.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1319.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1319.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1319.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1319.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1319.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1324.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1324.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1324.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1324.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1324.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1324.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1324.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1329.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1329.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1329.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1329.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1329.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1329.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1329.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1334.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1334.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1334.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1334.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1334.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1334.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1334.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1339.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1339.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1339.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1339.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1339.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1339.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1339.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1344.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1344.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1344.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1344.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1344.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1344.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1344.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1349.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1349.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1349.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1349.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1349.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1349.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1349.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1354.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1354.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1354.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1354.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1354.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1354.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1354.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1359.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1359.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1359.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1359.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1359.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1359.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1359.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1364.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1364.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1364.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1364.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1364.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1364.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1364.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1369.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1369.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1369.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1369.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1369.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1369.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1369.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1374.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1374.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1374.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1374.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1374.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1374.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1374.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1379.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1379.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1379.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1379.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1379.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1379.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1379.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1384.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1384.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1384.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1384.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1384.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1384.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1384.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1389.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1389.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1389.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1389.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1389.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1389.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1389.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1394.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1394.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1394.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1394.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1394.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1394.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1394.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1399.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1399.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1399.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1399.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1399.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1399.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1399.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1404.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1404.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1404.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1404.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1404.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1404.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1404.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1409.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1409.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1409.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1409.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1409.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1409.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1409.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1414.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1414.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1414.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1414.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1414.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1414.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1414.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1419.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1419.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1419.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1419.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1419.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1419.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1419.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1424.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1424.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1424.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1424.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1424.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1424.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1424.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1429.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1429.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1429.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1429.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1429.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1429.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1429.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1434.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1434.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1434.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1434.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1434.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1434.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1434.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1439.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1439.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1439.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1439.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1439.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1439.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1439.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1444.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1444.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1444.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1444.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1444.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1444.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1444.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1449.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1449.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1449.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1449.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1449.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1449.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1449.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1454.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1454.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1454.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1454.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1454.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1454.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1454.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1459.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1459.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1459.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1459.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1459.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1459.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1459.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1464.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1464.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1464.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1464.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1464.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1464.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1464.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1469.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1469.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1469.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1469.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1469.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1469.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1469.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1474.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1474.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1474.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1474.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1474.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1474.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1474.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1479.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1479.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1479.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1479.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1479.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1479.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1479.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1484.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1484.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1484.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1484.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1484.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1484.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1484.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1489.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1489.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1489.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1489.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1489.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1489.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1489.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1494.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1494.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1494.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1494.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1494.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1494.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1494.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1499.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1499.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1499.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1499.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1499.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1499.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1499.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1504.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1504.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1504.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1504.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1504.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1504.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1504.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1509.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1509.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1509.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1509.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1509.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1509.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1509.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1514.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1514.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1514.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1514.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1514.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1514.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1514.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1519.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1519.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1519.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1519.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1519.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1519.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1519.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1524.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1524.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1524.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1524.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1524.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1524.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1524.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1529.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1529.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1529.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1529.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1529.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1529.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1529.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1534.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1534.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1534.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1534.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1534.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1534.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1534.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1539.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1539.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1539.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1539.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1539.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1539.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1539.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1544.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1544.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1544.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1544.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1544.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1544.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1544.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1549.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1549.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1549.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1549.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1549.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1549.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1549.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1554.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1554.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1554.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1554.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1554.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1554.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1554.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1559.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1559.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1559.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1559.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1559.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1559.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1559.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1564.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1564.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1564.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1564.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1564.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1564.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1564.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1569.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1569.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1569.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1569.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1569.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1569.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1569.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1574.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1574.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1574.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1574.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1574.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1574.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1574.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1579.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1579.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1579.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1579.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1579.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1579.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1579.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1584.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1584.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1584.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1584.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1584.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1584.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1584.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1589.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1589.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1589.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1589.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1589.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1589.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1589.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1594.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1594.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1594.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1594.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1594.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1594.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1594.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1599.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1599.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1599.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1599.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1599.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1599.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1599.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1604.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1604.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1604.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1604.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1604.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1604.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1604.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1609.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1609.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1609.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1609.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1609.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1609.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1609.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1614.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1614.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1614.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1614.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1614.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1614.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1614.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1619.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1619.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1619.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1619.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1619.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1619.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1619.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1624.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1624.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1624.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1624.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1624.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1624.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1624.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1629.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1629.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1629.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1629.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1629.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1629.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1629.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1634.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1634.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1634.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1634.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1634.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1634.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1634.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1639.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1639.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1639.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1639.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1639.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1639.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1639.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1644.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1644.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1644.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1644.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1644.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1644.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1644.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1649.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1649.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1649.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1649.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1649.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1649.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1649.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1654.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1654.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1654.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1654.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1654.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1654.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1654.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1659.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1659.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1659.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1659.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1659.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1659.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1659.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1664.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1664.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1664.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1664.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1664.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1664.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1664.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1669.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1669.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1669.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1669.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1669.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1669.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1669.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1674.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1674.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1674.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1674.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1674.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1674.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1674.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1679.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1679.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1679.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1679.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1679.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1679.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1679.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1684.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1684.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1684.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1684.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1684.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1684.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1684.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1689.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1689.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1689.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1689.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1689.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1689.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1689.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1694.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1694.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1694.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1694.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1694.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1694.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1694.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1699.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1699.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1699.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1699.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1699.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1699.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1699.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1704.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1704.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1704.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1704.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1704.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1704.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1704.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1709.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1709.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1709.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1709.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1709.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1709.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1709.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1714.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1714.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1714.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1714.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1714.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1714.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1714.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1719.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1719.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1719.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1719.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1719.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1719.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1719.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1724.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1724.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1724.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1724.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1724.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1724.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1724.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1729.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1729.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1729.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1729.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1729.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1729.5  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1729.6  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1734.0  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1734.1  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1734.2  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1734.3  # stock-page corruption injection: near-total divergence, chunk store has no page images
-corrupt8 corrupt8-2.1734.4  # stock-page corruption injection: near-total divergence, chunk store has no page images
 corruptF corruptF-1.2  # stock-page corruption injection: offsets land outside chunk-store structures
 corruptF corruptF-1.3  # stock-page corruption injection: offsets land outside chunk-store structures
 corruptF corruptF-1.4  # stock-page corruption injection: offsets land outside chunk-store structures
@@ -4778,8 +3300,6 @@ fts3malloc fts3_malloc-2.1.transient.100000.18  # expected count bakes in a mast
 sqllimits1 sqllimits1-7.7.1  # max_page_count/page_count use DoltLite synthetic chunk counts, not stock file pages
 sqllimits1 sqllimits1-7.7.3  # max_page_count/page_count use DoltLite synthetic chunk counts, not stock file pages
 
-# == reclaimed from the crash list: these files complete deterministically ==
-
 # Raw byte-corruption probes that land inside checksummed chunk-store
 # structures; recovery rolls back or surfaces malformed where stock walks
 # damaged pages.
@@ -4798,655 +3318,6 @@ nan nan-3.4
 nan nan-3.5
 nan nan-3.6
 
-# incrblob handles on PK-keyed tables plus corruption pokes: incrblob is
-# rejected on PK (WITHOUT ROWID-equivalent) tables and the corruption
-# offsets miss chunk-store structures.
-incrcorrupt incrcorrupt-1.0
-incrcorrupt incrcorrupt-1.1
-incrcorrupt incrcorrupt-1.2
-incrcorrupt incrcorrupt-1.3
-incrcorrupt incrcorrupt-1.4
-incrcorrupt incrcorrupt-1.5
-incrcorrupt incrcorrupt-1.6
-incrcorrupt incrcorrupt-1.7
-incrcorrupt incrcorrupt-1.8
-incrcorrupt incrcorrupt-1.9
-incrcorrupt incrcorrupt-1.10
-incrcorrupt incrcorrupt-1.11
-incrcorrupt incrcorrupt-1.15
-incrcorrupt incrcorrupt-1.16
-incrcorrupt incrcorrupt-1.17
-incrcorrupt incrcorrupt-2.1
-incrcorrupt incrcorrupt-2.2
-incrcorrupt incrcorrupt-2.3
-incrcorrupt incrcorrupt-2.4
-incrcorrupt incrcorrupt-2.5
-incrcorrupt incrcorrupt-2.6
-incrcorrupt incrcorrupt-2.7
-incrcorrupt incrcorrupt-2.8
-incrcorrupt incrcorrupt-2.9
-incrcorrupt incrcorrupt-2.10
-incrcorrupt incrcorrupt-2.11
-incrcorrupt incrcorrupt-2.15
-incrcorrupt incrcorrupt-2.16
-incrcorrupt incrcorrupt-2.17
-
-# auto_vacuum is rejected on doltlite-format databases, so the prep
-# schema is never created and every subtest fails "no such table" --
-# one intentional feature gap cascading, not independent divergences.
-tkt1667 tkt1667-1
-tkt1667 tkt1667-2.0.1
-tkt1667 tkt1667-2.1.1
-tkt1667 tkt1667-2.2.1
-tkt1667 tkt1667-2.3.1
-tkt1667 tkt1667-2.4.1
-tkt1667 tkt1667-2.5.1
-tkt1667 tkt1667-2.6.1
-tkt1667 tkt1667-2.7.1
-tkt1667 tkt1667-2.8.1
-tkt1667 tkt1667-2.9.1
-tkt1667 tkt1667-2.10.1
-tkt1667 tkt1667-2.11.1
-tkt1667 tkt1667-2.12.1
-tkt1667 tkt1667-2.13.1
-tkt1667 tkt1667-2.14.1
-tkt1667 tkt1667-2.15.1
-tkt1667 tkt1667-2.16.1
-tkt1667 tkt1667-2.17.1
-tkt1667 tkt1667-2.18.1
-tkt1667 tkt1667-2.19.1
-tkt1667 tkt1667-2.20.1
-tkt1667 tkt1667-2.21.1
-tkt1667 tkt1667-2.22.1
-tkt1667 tkt1667-2.23.1
-tkt1667 tkt1667-2.24.1
-tkt1667 tkt1667-2.25.1
-tkt1667 tkt1667-2.26.1
-tkt1667 tkt1667-2.27.1
-tkt1667 tkt1667-2.28.1
-tkt1667 tkt1667-2.29.1
-tkt1667 tkt1667-2.30.1
-tkt1667 tkt1667-2.31.1
-tkt1667 tkt1667-2.32.1
-tkt1667 tkt1667-2.33.1
-tkt1667 tkt1667-2.34.1
-tkt1667 tkt1667-2.35.1
-tkt1667 tkt1667-2.36.1
-tkt1667 tkt1667-2.37.1
-tkt1667 tkt1667-2.38.1
-tkt1667 tkt1667-2.39.1
-tkt1667 tkt1667-2.40.1
-tkt1667 tkt1667-2.41.1
-tkt1667 tkt1667-2.42.1
-tkt1667 tkt1667-2.43.1
-tkt1667 tkt1667-2.44.1
-tkt1667 tkt1667-2.45.1
-tkt1667 tkt1667-2.46.1
-tkt1667 tkt1667-2.47.1
-tkt1667 tkt1667-2.48.1
-tkt1667 tkt1667-2.49.1
-tkt1667 tkt1667-2.50.1
-tkt1667 tkt1667-2.51.1
-tkt1667 tkt1667-2.52.1
-tkt1667 tkt1667-2.53.1
-tkt1667 tkt1667-2.54.1
-tkt1667 tkt1667-2.55.1
-tkt1667 tkt1667-2.56.1
-tkt1667 tkt1667-2.57.1
-tkt1667 tkt1667-2.58.1
-tkt1667 tkt1667-2.59.1
-tkt1667 tkt1667-2.60.1
-tkt1667 tkt1667-2.61.1
-tkt1667 tkt1667-2.62.1
-tkt1667 tkt1667-2.63.1
-tkt1667 tkt1667-2.64.1
-tkt1667 tkt1667-2.65.1
-tkt1667 tkt1667-2.66.1
-tkt1667 tkt1667-2.67.1
-tkt1667 tkt1667-2.68.1
-tkt1667 tkt1667-2.69.1
-tkt1667 tkt1667-2.70.1
-tkt1667 tkt1667-2.71.1
-tkt1667 tkt1667-2.72.1
-tkt1667 tkt1667-2.73.1
-tkt1667 tkt1667-2.74.1
-tkt1667 tkt1667-2.75.1
-tkt1667 tkt1667-2.76.1
-tkt1667 tkt1667-2.77.1
-tkt1667 tkt1667-2.78.1
-tkt1667 tkt1667-2.79.1
-tkt1667 tkt1667-2.80.1
-tkt1667 tkt1667-2.81.1
-tkt1667 tkt1667-2.82.1
-tkt1667 tkt1667-2.83.1
-tkt1667 tkt1667-2.84.1
-tkt1667 tkt1667-2.85.1
-tkt1667 tkt1667-2.86.1
-tkt1667 tkt1667-2.87.1
-tkt1667 tkt1667-2.88.1
-tkt1667 tkt1667-2.89.1
-tkt1667 tkt1667-2.90.1
-tkt1667 tkt1667-2.91.1
-tkt1667 tkt1667-2.92.1
-tkt1667 tkt1667-2.93.1
-tkt1667 tkt1667-2.94.1
-tkt1667 tkt1667-2.95.1
-tkt1667 tkt1667-2.96.1
-tkt1667 tkt1667-2.97.1
-tkt1667 tkt1667-2.98.1
-tkt1667 tkt1667-2.99.1
-tkt1667 tkt1667-2.100.1
-tkt1667 tkt1667-2.101.1
-tkt1667 tkt1667-2.102.1
-tkt1667 tkt1667-2.103.1
-tkt1667 tkt1667-2.104.1
-tkt1667 tkt1667-2.105.1
-tkt1667 tkt1667-2.106.1
-tkt1667 tkt1667-2.107.1
-tkt1667 tkt1667-2.108.1
-tkt1667 tkt1667-2.109.1
-tkt1667 tkt1667-2.110.1
-tkt1667 tkt1667-2.111.1
-tkt1667 tkt1667-2.112.1
-tkt1667 tkt1667-2.113.1
-tkt1667 tkt1667-2.114.1
-tkt1667 tkt1667-2.115.1
-tkt1667 tkt1667-2.116.1
-tkt1667 tkt1667-2.117.1
-tkt1667 tkt1667-2.118.1
-tkt1667 tkt1667-2.119.1
-tkt1667 tkt1667-2.120.1
-tkt1667 tkt1667-2.121.1
-tkt1667 tkt1667-2.122.1
-tkt1667 tkt1667-2.123.1
-tkt1667 tkt1667-2.124.1
-tkt1667 tkt1667-2.125.1
-tkt1667 tkt1667-2.126.1
-tkt1667 tkt1667-2.127.1
-tkt1667 tkt1667-2.128.1
-tkt1667 tkt1667-2.129.1
-tkt1667 tkt1667-2.130.1
-tkt1667 tkt1667-2.131.1
-tkt1667 tkt1667-2.132.1
-tkt1667 tkt1667-2.133.1
-tkt1667 tkt1667-2.134.1
-tkt1667 tkt1667-2.135.1
-tkt1667 tkt1667-2.136.1
-tkt1667 tkt1667-2.137.1
-tkt1667 tkt1667-2.138.1
-tkt1667 tkt1667-2.139.1
-tkt1667 tkt1667-2.140.1
-tkt1667 tkt1667-2.141.1
-tkt1667 tkt1667-2.142.1
-tkt1667 tkt1667-2.143.1
-tkt1667 tkt1667-2.144.1
-tkt1667 tkt1667-2.145.1
-tkt1667 tkt1667-2.146.1
-tkt1667 tkt1667-2.147.1
-tkt1667 tkt1667-2.148.1
-tkt1667 tkt1667-2.149.1
-tkt1667 tkt1667-2.150.1
-tkt1667 tkt1667-2.151.1
-tkt1667 tkt1667-2.152.1
-tkt1667 tkt1667-2.153.1
-tkt1667 tkt1667-2.154.1
-tkt1667 tkt1667-2.155.1
-tkt1667 tkt1667-2.156.1
-tkt1667 tkt1667-2.157.1
-tkt1667 tkt1667-2.158.1
-tkt1667 tkt1667-2.159.1
-tkt1667 tkt1667-2.160.1
-tkt1667 tkt1667-2.161.1
-tkt1667 tkt1667-2.162.1
-tkt1667 tkt1667-2.163.1
-tkt1667 tkt1667-2.164.1
-tkt1667 tkt1667-2.165.1
-tkt1667 tkt1667-2.166.1
-tkt1667 tkt1667-2.167.1
-tkt1667 tkt1667-2.168.1
-tkt1667 tkt1667-2.169.1
-tkt1667 tkt1667-2.170.1
-tkt1667 tkt1667-2.171.1
-tkt1667 tkt1667-2.172.1
-tkt1667 tkt1667-2.173.1
-tkt1667 tkt1667-2.174.1
-tkt1667 tkt1667-2.175.1
-tkt1667 tkt1667-2.176.1
-tkt1667 tkt1667-2.177.1
-tkt1667 tkt1667-2.178.1
-tkt1667 tkt1667-2.179.1
-tkt1667 tkt1667-2.180.1
-tkt1667 tkt1667-2.181.1
-tkt1667 tkt1667-2.182.1
-tkt1667 tkt1667-2.183.1
-tkt1667 tkt1667-2.184.1
-tkt1667 tkt1667-2.185.1
-tkt1667 tkt1667-2.186.1
-tkt1667 tkt1667-2.187.1
-tkt1667 tkt1667-2.188.1
-tkt1667 tkt1667-2.189.1
-tkt1667 tkt1667-2.190.1
-tkt1667 tkt1667-2.191.1
-tkt1667 tkt1667-2.192.1
-tkt1667 tkt1667-2.193.1
-tkt1667 tkt1667-2.194.1
-tkt1667 tkt1667-2.195.1
-tkt1667 tkt1667-2.196.1
-tkt1667 tkt1667-2.197.1
-tkt1667 tkt1667-2.198.1
-tkt1667 tkt1667-2.199.1
-tkt1667 tkt1667-2.200.1
-tkt1667 tkt1667-2.201.1
-tkt1667 tkt1667-2.202.1
-tkt1667 tkt1667-2.203.1
-tkt1667 tkt1667-2.204.1
-tkt1667 tkt1667-2.205.1
-tkt1667 tkt1667-2.206.1
-tkt1667 tkt1667-2.207.1
-tkt1667 tkt1667-2.208.1
-tkt1667 tkt1667-2.209.1
-tkt1667 tkt1667-2.210.1
-tkt1667 tkt1667-2.211.1
-tkt1667 tkt1667-2.212.1
-tkt1667 tkt1667-2.213.1
-tkt1667 tkt1667-2.214.1
-tkt1667 tkt1667-2.215.1
-tkt1667 tkt1667-2.216.1
-tkt1667 tkt1667-2.217.1
-tkt1667 tkt1667-2.218.1
-tkt1667 tkt1667-2.219.1
-tkt1667 tkt1667-2.220.1
-tkt1667 tkt1667-2.221.1
-tkt1667 tkt1667-2.222.1
-tkt1667 tkt1667-2.223.1
-tkt1667 tkt1667-2.224.1
-tkt1667 tkt1667-2.225.1
-tkt1667 tkt1667-2.226.1
-tkt1667 tkt1667-2.227.1
-tkt1667 tkt1667-2.228.1
-tkt1667 tkt1667-2.229.1
-tkt1667 tkt1667-2.230.1
-tkt1667 tkt1667-2.231.1
-tkt1667 tkt1667-2.232.1
-tkt1667 tkt1667-2.233.1
-tkt1667 tkt1667-2.234.1
-tkt1667 tkt1667-2.235.1
-tkt1667 tkt1667-2.236.1
-tkt1667 tkt1667-2.237.1
-tkt1667 tkt1667-2.238.1
-tkt1667 tkt1667-2.239.1
-tkt1667 tkt1667-2.240.1
-tkt1667 tkt1667-2.241.1
-tkt1667 tkt1667-2.242.1
-tkt1667 tkt1667-2.243.1
-tkt1667 tkt1667-2.244.1
-tkt1667 tkt1667-2.245.1
-tkt1667 tkt1667-2.246.1
-tkt1667 tkt1667-2.247.1
-tkt1667 tkt1667-2.248.1
-tkt1667 tkt1667-2.249.1
-tkt1667 tkt1667-2.250.1
-tkt1667 tkt1667-2.251.1
-tkt1667 tkt1667-2.252.1
-tkt1667 tkt1667-2.253.1
-tkt1667 tkt1667-2.254.1
-tkt1667 tkt1667-2.255.1
-tkt1667 tkt1667-2.256.1
-tkt1667 tkt1667-2.257.1
-tkt1667 tkt1667-2.258.1
-tkt1667 tkt1667-2.259.1
-tkt1667 tkt1667-2.260.1
-tkt1667 tkt1667-2.261.1
-tkt1667 tkt1667-2.262.1
-tkt1667 tkt1667-2.263.1
-tkt1667 tkt1667-2.264.1
-tkt1667 tkt1667-2.265.1
-tkt1667 tkt1667-2.266.1
-tkt1667 tkt1667-2.267.1
-tkt1667 tkt1667-2.268.1
-tkt1667 tkt1667-2.269.1
-tkt1667 tkt1667-2.270.1
-tkt1667 tkt1667-2.271.1
-tkt1667 tkt1667-2.272.1
-tkt1667 tkt1667-2.273.1
-tkt1667 tkt1667-2.274.1
-tkt1667 tkt1667-2.275.1
-tkt1667 tkt1667-2.276.1
-tkt1667 tkt1667-2.277.1
-tkt1667 tkt1667-2.278.1
-tkt1667 tkt1667-2.279.1
-tkt1667 tkt1667-2.280.1
-tkt1667 tkt1667-2.281.1
-tkt1667 tkt1667-2.282.1
-tkt1667 tkt1667-2.283.1
-tkt1667 tkt1667-2.284.1
-tkt1667 tkt1667-2.285.1
-tkt1667 tkt1667-2.286.1
-tkt1667 tkt1667-2.287.1
-tkt1667 tkt1667-2.288.1
-tkt1667 tkt1667-2.289.1
-tkt1667 tkt1667-2.290.1
-tkt1667 tkt1667-2.291.1
-tkt1667 tkt1667-2.292.1
-tkt1667 tkt1667-2.293.1
-tkt1667 tkt1667-2.294.1
-tkt1667 tkt1667-2.295.1
-tkt1667 tkt1667-2.296.1
-tkt1667 tkt1667-2.297.1
-tkt1667 tkt1667-2.298.1
-tkt1667 tkt1667-2.299.1
-tkt1667 tkt1667-2.300.1
-tkt1667 tkt1667-2.301.1
-tkt1667 tkt1667-2.302.1
-tkt1667 tkt1667-2.303.1
-tkt1667 tkt1667-2.304.1
-tkt1667 tkt1667-2.305.1
-tkt1667 tkt1667-2.306.1
-tkt1667 tkt1667-2.307.1
-tkt1667 tkt1667-2.308.1
-tkt1667 tkt1667-2.309.1
-tkt1667 tkt1667-2.310.1
-tkt1667 tkt1667-2.311.1
-tkt1667 tkt1667-2.312.1
-tkt1667 tkt1667-2.313.1
-tkt1667 tkt1667-2.314.1
-tkt1667 tkt1667-2.315.1
-tkt1667 tkt1667-2.316.1
-tkt1667 tkt1667-2.317.1
-tkt1667 tkt1667-2.318.1
-tkt1667 tkt1667-2.319.1
-tkt1667 tkt1667-2.320.1
-tkt1667 tkt1667-2.321.1
-tkt1667 tkt1667-2.322.1
-tkt1667 tkt1667-2.323.1
-tkt1667 tkt1667-2.324.1
-tkt1667 tkt1667-2.325.1
-tkt1667 tkt1667-2.326.1
-tkt1667 tkt1667-2.327.1
-tkt1667 tkt1667-2.328.1
-tkt1667 tkt1667-2.329.1
-tkt1667 tkt1667-2.330.1
-tkt1667 tkt1667-2.331.1
-tkt1667 tkt1667-2.332.1
-tkt1667 tkt1667-2.333.1
-tkt1667 tkt1667-2.334.1
-tkt1667 tkt1667-2.335.1
-tkt1667 tkt1667-2.336.1
-tkt1667 tkt1667-2.337.1
-tkt1667 tkt1667-2.338.1
-tkt1667 tkt1667-2.339.1
-tkt1667 tkt1667-2.340.1
-tkt1667 tkt1667-2.341.1
-tkt1667 tkt1667-2.342.1
-tkt1667 tkt1667-2.343.1
-tkt1667 tkt1667-2.344.1
-tkt1667 tkt1667-2.345.1
-tkt1667 tkt1667-2.346.1
-tkt1667 tkt1667-2.347.1
-tkt1667 tkt1667-2.348.1
-tkt1667 tkt1667-2.349.1
-tkt1667 tkt1667-2.350.1
-tkt1667 tkt1667-2.351.1
-tkt1667 tkt1667-2.352.1
-tkt1667 tkt1667-2.353.1
-tkt1667 tkt1667-2.354.1
-tkt1667 tkt1667-2.355.1
-tkt1667 tkt1667-2.356.1
-tkt1667 tkt1667-2.357.1
-tkt1667 tkt1667-2.358.1
-tkt1667 tkt1667-2.359.1
-tkt1667 tkt1667-2.360.1
-tkt1667 tkt1667-2.361.1
-tkt1667 tkt1667-2.362.1
-tkt1667 tkt1667-2.363.1
-tkt1667 tkt1667-2.364.1
-tkt1667 tkt1667-2.365.1
-tkt1667 tkt1667-2.366.1
-tkt1667 tkt1667-2.367.1
-tkt1667 tkt1667-2.368.1
-tkt1667 tkt1667-2.369.1
-tkt1667 tkt1667-2.370.1
-tkt1667 tkt1667-2.371.1
-tkt1667 tkt1667-2.372.1
-tkt1667 tkt1667-2.373.1
-tkt1667 tkt1667-2.374.1
-tkt1667 tkt1667-2.375.1
-tkt1667 tkt1667-2.376.1
-tkt1667 tkt1667-2.377.1
-tkt1667 tkt1667-2.378.1
-tkt1667 tkt1667-2.379.1
-tkt1667 tkt1667-2.380.1
-tkt1667 tkt1667-2.381.1
-tkt1667 tkt1667-2.382.1
-tkt1667 tkt1667-2.383.1
-tkt1667 tkt1667-2.384.1
-tkt1667 tkt1667-2.385.1
-tkt1667 tkt1667-2.386.1
-tkt1667 tkt1667-2.387.1
-tkt1667 tkt1667-2.388.1
-tkt1667 tkt1667-2.389.1
-tkt1667 tkt1667-2.390.1
-tkt1667 tkt1667-2.391.1
-tkt1667 tkt1667-2.392.1
-tkt1667 tkt1667-2.393.1
-tkt1667 tkt1667-2.394.1
-tkt1667 tkt1667-2.395.1
-tkt1667 tkt1667-2.396.1
-tkt1667 tkt1667-2.397.1
-tkt1667 tkt1667-2.398.1
-tkt1667 tkt1667-2.399.1
-tkt1667 tkt1667-2.400.1
-tkt1667 tkt1667-2.401.1
-tkt1667 tkt1667-2.402.1
-tkt1667 tkt1667-2.403.1
-tkt1667 tkt1667-2.404.1
-tkt1667 tkt1667-2.405.1
-tkt1667 tkt1667-2.406.1
-tkt1667 tkt1667-2.407.1
-tkt1667 tkt1667-2.408.1
-tkt1667 tkt1667-2.409.1
-tkt1667 tkt1667-2.410.1
-tkt1667 tkt1667-2.411.1
-tkt1667 tkt1667-2.412.1
-tkt1667 tkt1667-2.413.1
-tkt1667 tkt1667-2.414.1
-tkt1667 tkt1667-2.415.1
-tkt1667 tkt1667-2.416.1
-tkt1667 tkt1667-2.417.1
-tkt1667 tkt1667-2.418.1
-tkt1667 tkt1667-2.419.1
-tkt1667 tkt1667-2.420.1
-tkt1667 tkt1667-2.421.1
-tkt1667 tkt1667-2.422.1
-tkt1667 tkt1667-2.423.1
-tkt1667 tkt1667-2.424.1
-tkt1667 tkt1667-2.425.1
-tkt1667 tkt1667-2.426.1
-tkt1667 tkt1667-2.427.1
-tkt1667 tkt1667-2.428.1
-tkt1667 tkt1667-2.429.1
-tkt1667 tkt1667-2.430.1
-tkt1667 tkt1667-2.431.1
-tkt1667 tkt1667-2.432.1
-tkt1667 tkt1667-2.433.1
-tkt1667 tkt1667-2.434.1
-tkt1667 tkt1667-2.435.1
-tkt1667 tkt1667-2.436.1
-tkt1667 tkt1667-2.437.1
-tkt1667 tkt1667-2.438.1
-tkt1667 tkt1667-2.439.1
-tkt1667 tkt1667-2.440.1
-tkt1667 tkt1667-2.441.1
-tkt1667 tkt1667-2.442.1
-tkt1667 tkt1667-2.443.1
-tkt1667 tkt1667-2.444.1
-tkt1667 tkt1667-2.445.1
-tkt1667 tkt1667-2.446.1
-tkt1667 tkt1667-2.447.1
-tkt1667 tkt1667-2.448.1
-tkt1667 tkt1667-2.449.1
-tkt1667 tkt1667-2.450.1
-tkt1667 tkt1667-2.451.1
-tkt1667 tkt1667-2.452.1
-tkt1667 tkt1667-2.453.1
-tkt1667 tkt1667-2.454.1
-tkt1667 tkt1667-2.455.1
-tkt1667 tkt1667-2.456.1
-tkt1667 tkt1667-2.457.1
-tkt1667 tkt1667-2.458.1
-tkt1667 tkt1667-2.459.1
-tkt1667 tkt1667-2.460.1
-tkt1667 tkt1667-2.461.1
-tkt1667 tkt1667-2.462.1
-tkt1667 tkt1667-2.463.1
-tkt1667 tkt1667-2.464.1
-tkt1667 tkt1667-2.465.1
-tkt1667 tkt1667-2.466.1
-tkt1667 tkt1667-2.467.1
-tkt1667 tkt1667-2.468.1
-tkt1667 tkt1667-2.469.1
-tkt1667 tkt1667-2.470.1
-tkt1667 tkt1667-2.471.1
-tkt1667 tkt1667-2.472.1
-tkt1667 tkt1667-2.473.1
-tkt1667 tkt1667-2.474.1
-tkt1667 tkt1667-2.475.1
-tkt1667 tkt1667-2.476.1
-tkt1667 tkt1667-2.477.1
-tkt1667 tkt1667-2.478.1
-tkt1667 tkt1667-2.479.1
-tkt1667 tkt1667-2.480.1
-tkt1667 tkt1667-2.481.1
-tkt1667 tkt1667-2.482.1
-tkt1667 tkt1667-2.483.1
-tkt1667 tkt1667-2.484.1
-tkt1667 tkt1667-2.485.1
-tkt1667 tkt1667-2.486.1
-tkt1667 tkt1667-2.487.1
-tkt1667 tkt1667-2.488.1
-tkt1667 tkt1667-2.489.1
-tkt1667 tkt1667-2.490.1
-tkt1667 tkt1667-2.491.1
-tkt1667 tkt1667-2.492.1
-tkt1667 tkt1667-2.493.1
-tkt1667 tkt1667-2.494.1
-tkt1667 tkt1667-2.495.1
-tkt1667 tkt1667-2.496.1
-tkt1667 tkt1667-2.497.1
-tkt1667 tkt1667-2.498.1
-tkt1667 tkt1667-2.499.1
-tkt1667 tkt1667-3
-tkt1667 tkt1667-4.1
-
-# auto_vacuum rejection cascade (see tkt1667).
-tkt-9d68c883 tkt-9d68c88-1.1
-tkt-9d68c883 tkt-9d68c88-2.0
-tkt-9d68c883 tkt-9d68c88-2.1
-tkt-9d68c883 tkt-9d68c88-2.2
-tkt-9d68c883 tkt-9d68c88-2.3
-tkt-9d68c883 tkt-9d68c88-2.4
-tkt-9d68c883 tkt-9d68c88-2.5
-tkt-9d68c883 tkt-9d68c88-2.6
-tkt-9d68c883 tkt-9d68c88-2.7
-tkt-9d68c883 tkt-9d68c88-2.8
-tkt-9d68c883 tkt-9d68c88-2.9
-tkt-9d68c883 tkt-9d68c88-2.10
-tkt-9d68c883 tkt-9d68c88-2.11
-tkt-9d68c883 tkt-9d68c88-2.12
-tkt-9d68c883 tkt-9d68c88-2.13
-tkt-9d68c883 tkt-9d68c88-2.14
-tkt-9d68c883 tkt-9d68c88-2.15
-tkt-9d68c883 tkt-9d68c88-2.16
-tkt-9d68c883 tkt-9d68c88-2.17
-tkt-9d68c883 tkt-9d68c88-2.18
-tkt-9d68c883 tkt-9d68c88-2.19
-tkt-9d68c883 tkt-9d68c88-2.20
-tkt-9d68c883 tkt-9d68c88-2.21
-tkt-9d68c883 tkt-9d68c88-2.22
-tkt-9d68c883 tkt-9d68c88-2.23
-tkt-9d68c883 tkt-9d68c88-2.24
-tkt-9d68c883 tkt-9d68c88-2.25
-tkt-9d68c883 tkt-9d68c88-2.26
-tkt-9d68c883 tkt-9d68c88-2.27
-tkt-9d68c883 tkt-9d68c88-2.28
-tkt-9d68c883 tkt-9d68c88-2.29
-tkt-9d68c883 tkt-9d68c88-2.30
-tkt-9d68c883 tkt-9d68c88-2.31
-tkt-9d68c883 tkt-9d68c88-2.32
-tkt-9d68c883 tkt-9d68c88-2.33
-tkt-9d68c883 tkt-9d68c88-2.34
-tkt-9d68c883 tkt-9d68c88-2.35
-tkt-9d68c883 tkt-9d68c88-2.36
-tkt-9d68c883 tkt-9d68c88-2.37
-tkt-9d68c883 tkt-9d68c88-2.38
-tkt-9d68c883 tkt-9d68c88-2.39
-tkt-9d68c883 tkt-9d68c88-2.40
-tkt-9d68c883 tkt-9d68c88-2.41
-tkt-9d68c883 tkt-9d68c88-2.42
-tkt-9d68c883 tkt-9d68c88-2.43
-tkt-9d68c883 tkt-9d68c88-2.44
-tkt-9d68c883 tkt-9d68c88-2.45
-tkt-9d68c883 tkt-9d68c88-2.46
-tkt-9d68c883 tkt-9d68c88-2.47
-tkt-9d68c883 tkt-9d68c88-2.48
-tkt-9d68c883 tkt-9d68c88-2.49
-tkt-9d68c883 tkt-9d68c88-2.50
-tkt-9d68c883 tkt-9d68c88-2.51
-tkt-9d68c883 tkt-9d68c88-2.52
-tkt-9d68c883 tkt-9d68c88-2.53
-tkt-9d68c883 tkt-9d68c88-2.54
-tkt-9d68c883 tkt-9d68c88-2.55
-tkt-9d68c883 tkt-9d68c88-2.56
-tkt-9d68c883 tkt-9d68c88-2.57
-tkt-9d68c883 tkt-9d68c88-2.58
-tkt-9d68c883 tkt-9d68c88-2.59
-tkt-9d68c883 tkt-9d68c88-2.60
-tkt-9d68c883 tkt-9d68c88-2.61
-tkt-9d68c883 tkt-9d68c88-2.62
-tkt-9d68c883 tkt-9d68c88-2.63
-tkt-9d68c883 tkt-9d68c88-2.64
-tkt-9d68c883 tkt-9d68c88-2.65
-tkt-9d68c883 tkt-9d68c88-2.66
-tkt-9d68c883 tkt-9d68c88-2.67
-tkt-9d68c883 tkt-9d68c88-2.68
-tkt-9d68c883 tkt-9d68c88-2.69
-tkt-9d68c883 tkt-9d68c88-2.70
-tkt-9d68c883 tkt-9d68c88-2.71
-tkt-9d68c883 tkt-9d68c88-2.72
-tkt-9d68c883 tkt-9d68c88-2.73
-tkt-9d68c883 tkt-9d68c88-2.74
-tkt-9d68c883 tkt-9d68c88-2.75
-tkt-9d68c883 tkt-9d68c88-2.76
-tkt-9d68c883 tkt-9d68c88-2.77
-tkt-9d68c883 tkt-9d68c88-2.78
-tkt-9d68c883 tkt-9d68c88-2.79
-tkt-9d68c883 tkt-9d68c88-2.80
-tkt-9d68c883 tkt-9d68c88-2.81
-tkt-9d68c883 tkt-9d68c88-2.82
-tkt-9d68c883 tkt-9d68c88-2.83
-tkt-9d68c883 tkt-9d68c88-2.84
-tkt-9d68c883 tkt-9d68c88-2.85
-tkt-9d68c883 tkt-9d68c88-2.86
-tkt-9d68c883 tkt-9d68c88-2.87
-tkt-9d68c883 tkt-9d68c88-2.88
-tkt-9d68c883 tkt-9d68c88-2.89
-tkt-9d68c883 tkt-9d68c88-2.90
-tkt-9d68c883 tkt-9d68c88-2.91
-tkt-9d68c883 tkt-9d68c88-2.92
-tkt-9d68c883 tkt-9d68c88-2.93
-tkt-9d68c883 tkt-9d68c88-2.94
-tkt-9d68c883 tkt-9d68c88-2.95
-tkt-9d68c883 tkt-9d68c88-2.96
-tkt-9d68c883 tkt-9d68c88-2.97
-tkt-9d68c883 tkt-9d68c88-2.98
-tkt-9d68c883 tkt-9d68c88-2.99
-
-# auto_vacuum rejection cascade (see tkt1667).
-tkt-5e10420e8d tkt-5e10420e8d.1
-tkt-5e10420e8d tkt-5e10420e8d.2
-tkt-5e10420e8d tkt-5e10420e8d.3
-tkt-5e10420e8d tkt-5e10420e8d.4
-
 # journal_mode is not configurable on doltlite-format databases; setup
 # rejection cascades.
 tkt-5d863f876e tkt-5d863f876e-1.1
@@ -5460,168 +3331,6 @@ tkt-fc62af4523 tkt-fc62af4523.2
 tkt-fc62af4523 tkt-fc62af4523.3
 tkt-fc62af4523 tkt-fc62af4523.4
 tkt-fc62af4523 tkt-fc62af4523.6
-
-# quota-VFS byte thresholds trip at chunk-store file sizes, not stock
-# page-file sizes. The native wrapper contract is covered by
-# doltlite_recover_vfs_wrappers.
-quota quota-2.1.2
-quota quota-2.1.3
-quota quota-2.1.4
-quota quota-2.1.5
-quota quota-2.2.1
-quota quota-2.2.2
-quota quota-2.2.3
-quota quota-2.4.2
-quota quota-2.4.3
-quota quota-2.4.4
-quota quota-3.1.2
-quota quota-3.1.4
-quota quota-3.1.5
-quota quota-3.2.1
-quota quota-3.2.2
-quota quota-3.2.3
-quota quota-3.2.4
-quota quota-3.2.5
-quota quota-3.2.6
-quota quota-3.2.7
-quota quota-3.2.8
-quota quota-3.2.9
-quota quota-3.3.1
-quota quota-5.3.prep
-
-# multiplex VFS chunk boundaries differ over a chunk store; remaining
-# entries are size/journal-shape expectations. The native initialized-wrapper
-# contract is covered by doltlite_recover_vfs_wrappers.
-multiplex multiplex-1.9.2
-multiplex multiplex-2.1.2
-multiplex multiplex-2.1.3
-multiplex multiplex-2.1.4
-multiplex multiplex-2.2.1
-multiplex multiplex-2.2.3
-multiplex multiplex-2.4.2
-multiplex multiplex-2.4.4
-multiplex multiplex-2.5.2
-multiplex multiplex-2.5.3
-multiplex multiplex-2.5.4
-multiplex multiplex-2.5.5
-multiplex multiplex-2.5.6
-multiplex multiplex-2.5.7
-multiplex multiplex-2.5.8
-multiplex multiplex-2.5.9
-multiplex multiplex-2.5.10
-multiplex multiplex-2.5.11
-multiplex multiplex-2.5.12
-multiplex multiplex-2.6.2.151.delete
-multiplex multiplex-2.6.2.570.delete
-multiplex multiplex-2.6.2.989.delete
-multiplex multiplex-2.6.2.1408.delete
-multiplex multiplex-2.6.2.1827.delete
-multiplex multiplex-2.6.2.2246.delete
-multiplex multiplex-2.6.2.2665.delete
-multiplex multiplex-2.6.2.3084.delete
-multiplex multiplex-2.6.2.3503.delete
-multiplex multiplex-2.6.2.3922.delete
-multiplex multiplex-2.6.2.4341.delete
-multiplex multiplex-2.6.2.4760.delete
-multiplex multiplex-2.6.2.5179.delete
-multiplex multiplex-2.6.2.5598.delete
-multiplex multiplex-2.6.2.6017.delete
-multiplex multiplex-2.6.2.6436.delete
-multiplex multiplex-2.6.2.6855.delete
-multiplex multiplex-2.6.2.7274.delete
-multiplex multiplex-2.6.2.7693.delete
-multiplex multiplex-2.6.2.151.persist
-multiplex multiplex-2.6.2.570.persist
-multiplex multiplex-2.6.2.989.persist
-multiplex multiplex-2.6.2.1408.persist
-multiplex multiplex-2.6.2.1827.persist
-multiplex multiplex-2.6.2.2246.persist
-multiplex multiplex-2.6.2.2665.persist
-multiplex multiplex-2.6.2.3084.persist
-multiplex multiplex-2.6.2.3503.persist
-multiplex multiplex-2.6.2.3922.persist
-multiplex multiplex-2.6.2.4341.persist
-multiplex multiplex-2.6.2.4760.persist
-multiplex multiplex-2.6.2.5179.persist
-multiplex multiplex-2.6.2.5598.persist
-multiplex multiplex-2.6.2.6017.persist
-multiplex multiplex-2.6.2.6436.persist
-multiplex multiplex-2.6.2.6855.persist
-multiplex multiplex-2.6.2.7274.persist
-multiplex multiplex-2.6.2.7693.persist
-multiplex multiplex-2.6.2.151.truncate
-multiplex multiplex-2.6.2.570.truncate
-multiplex multiplex-2.6.2.989.truncate
-multiplex multiplex-2.6.2.1408.truncate
-multiplex multiplex-2.6.2.1827.truncate
-multiplex multiplex-2.6.2.2246.truncate
-multiplex multiplex-2.6.2.2665.truncate
-multiplex multiplex-2.6.2.3084.truncate
-multiplex multiplex-2.6.2.3503.truncate
-multiplex multiplex-2.6.2.3922.truncate
-multiplex multiplex-2.6.2.4341.truncate
-multiplex multiplex-2.6.2.4760.truncate
-multiplex multiplex-2.6.2.5179.truncate
-multiplex multiplex-2.6.2.5598.truncate
-multiplex multiplex-2.6.2.6017.truncate
-multiplex multiplex-2.6.2.6436.truncate
-multiplex multiplex-2.6.2.6855.truncate
-multiplex multiplex-2.6.2.7274.truncate
-multiplex multiplex-2.6.2.7693.truncate
-multiplex multiplex-2.6.2.151.memory
-multiplex multiplex-2.6.2.570.memory
-multiplex multiplex-2.6.2.989.memory
-multiplex multiplex-2.6.2.1408.memory
-multiplex multiplex-2.6.2.1827.memory
-multiplex multiplex-2.6.2.2246.memory
-multiplex multiplex-2.6.2.2665.memory
-multiplex multiplex-2.6.2.3084.memory
-multiplex multiplex-2.6.2.3503.memory
-multiplex multiplex-2.6.2.3922.memory
-multiplex multiplex-2.6.2.4341.memory
-multiplex multiplex-2.6.2.4760.memory
-multiplex multiplex-2.6.2.5179.memory
-multiplex multiplex-2.6.2.5598.memory
-multiplex multiplex-2.6.2.6017.memory
-multiplex multiplex-2.6.2.6436.memory
-multiplex multiplex-2.6.2.6855.memory
-multiplex multiplex-2.6.2.7274.memory
-multiplex multiplex-2.6.2.7693.memory
-multiplex multiplex-2.6.2.151.off
-multiplex multiplex-2.6.2.570.off
-multiplex multiplex-2.6.2.989.off
-multiplex multiplex-2.6.2.1408.off
-multiplex multiplex-2.6.2.1827.off
-multiplex multiplex-2.6.2.2246.off
-multiplex multiplex-2.6.2.2665.off
-multiplex multiplex-2.6.2.3084.off
-multiplex multiplex-2.6.2.3503.off
-multiplex multiplex-2.6.2.3922.off
-multiplex multiplex-2.6.2.4341.off
-multiplex multiplex-2.6.2.4760.off
-multiplex multiplex-2.6.2.5179.off
-multiplex multiplex-2.6.2.5598.off
-multiplex multiplex-2.6.2.6017.off
-multiplex multiplex-2.6.2.6436.off
-multiplex multiplex-2.6.2.6855.off
-multiplex multiplex-2.6.2.7274.off
-multiplex multiplex-2.6.2.7693.off
-multiplex multiplex-2.7.3
-multiplex multiplex-3.1.2
-multiplex multiplex-3.2.1a
-multiplex multiplex-3.2.2
-multiplex multiplex-3.2.3
-multiplex multiplex-3.2.4
-multiplex multiplex-3.2.5
-multiplex multiplex-3.2.6
-multiplex multiplex-3.2.7
-multiplex multiplex-3.2.8
-multiplex multiplex-3.2.9
-multiplex multiplex-3.3.1
-multiplex multiplex-5.3.prep
-multiplex multiplex-6.1.0
-multiplex multiplex-6.2.1
-multiplex multiplex-6.2.2
 
 # e_walckpt: WAL checkpoint API contract over a store with no -wal/-shm
 # sidecars. The remaining entries assert sidecar file sizes, checkpoint
@@ -5779,8 +3488,6 @@ e_walckpt e_walckpt-5.3.2
 e_walckpt e_walckpt-6.1
 e_walckpt e_walckpt-6.2
 e_walckpt e_walckpt-6.4
-
-# == 1357 sweep: formerly-unswept files, every list verified identical over three runs ==
 
 # raw stock-SQLite corrupt page images injected via `db deserialize`; doltlite's
 # chunk format cannot host raw page images, so setup fails and the ALTERs see
@@ -6354,29 +4061,6 @@ expridx2 expridx2-1.7
 # bExternal=0) and all other steps pass.
 external_reader external_reader-1.1.4
 
-# ── fallocate ──
-# The test sizes the db file via SQLITE_FCNTL_CHUNK_SIZE rounding and
-# page bookkeeping. doltlite's file is a content-addressed chunk store:
-# [file size] reflects chunk payload (e.g. 1896 bytes after CREATE
-# TABLE), never page images rounded up to the chunk size, so every
-# size expectation differs. fallocate-1.1 fails on the intentional
-# auto_vacuum rejection, which also kills the CREATE TABLE in the same
-# execsql batch; 1.2-1.5 and 1.7 cascade with "no such table: t1".
-fallocate fallocate-1.1  # auto_vacuum rejected; CREATE TABLE in same batch lost
-fallocate fallocate-1.2  # cascade: no such table t1
-fallocate fallocate-1.3  # cascade: no such table t1
-fallocate fallocate-1.4  # cascade: no such table t1
-fallocate fallocate-1.5  # cascade: no such table t1
-fallocate fallocate-1.7  # cascade: no such table t1
-fallocate fallocate-1.8  # file not chunk-size padded, nFile>100 false
-fallocate fallocate-2.1  # file size = chunk payload, not 32KB chunk rounding
-fallocate fallocate-2.2  # file size = chunk payload
-fallocate fallocate-2.3  # file size = chunk payload
-fallocate fallocate-2.4  # file size = chunk payload
-fallocate fallocate-2.5  # file size = chunk payload
-fallocate fallocate-2.6  # file size = chunk payload
-fallocate fallocate-2.8  # file size = chunk payload
-
 # doltlite-format ignores non-UTF-8 database encodings
 fts3ai fts3ai-1.0  # PRAGMA encoding=UTF-16le reports UTF-8
 
@@ -6517,12 +4201,6 @@ fts3fuzz001 fts3fuzz001-100
 fts3fuzz001 fts3fuzz001-110
 fts3fuzz001 fts3fuzz001-120
 fts3fuzz001 fts3fuzz001-121
-
-# order=DESC fts4 config: global matchinfo hit/doc counts are off by one
-# document (one doc's terms missing from index stats; same fts index
-# consistency family as the stale shadow-read issue). The returned row
-# sets match; only the aggregate stats diverge. The file stops at the
-# 1000-error tester cap; the capped list is md5-stable across runs.
 
 # shared-cache table locks are not surfaced by prolly storage: reads and
 # writes proceed where stock expects "database table is locked"
@@ -7053,11 +4731,6 @@ sidedelete sidedelete-3.98.1
 sidedelete sidedelete-3.99.1
 sidedelete sidedelete-3.100.1
 
-# auto_vacuum rejection on doltlite-format databases
-softheap1 softheap1-2.1
-
-# raw file size and max_page_count page accounting on chunk-store files
-
 # dbstat vtable (per-page b-tree stats) empty on chunk store: the no-fault
 # result is 0, never the expected 8 pages
 statfault statfault-1-cantopen-persistent.1
@@ -7220,12 +4893,6 @@ sysfault sysfault-3-vfsfault-transient.4
 tclsqlite tcl-10.18
 tclsqlite tcl-10.22
 
-# auto_vacuum/incremental_vacuum intentionally unsupported + cascade
-tkt3918 tkt3918.1
-tkt3918 tkt3918.2
-tkt3918 tkt3918.3
-tkt3918 tkt3918.4
-
 # VACUUM's internal "-- SELECT dolt_gc()" shows up in the trace output
 trace trace-2.6
 
@@ -7334,3 +5001,1838 @@ zerodamage zerodamage-2.0
 zerodamage zerodamage-2.1
 zerodamage zerodamage-3.0
 zerodamage zerodamage-3.1
+
+# == auto_vacuum/incremental_vacuum no-op: re-derived entry sets ==
+
+# ── autovacuum ──
+# auto_vacuum is an accepted no-op on prolly storage: no page reclamation
+# (file_pages expectations), sqlite_master rootpage numbers are prolly
+# table ids with no sqlite_autoindex shadow entries for PK-keyed tables,
+# the pragma reads back 0 and is not persisted across reopen, and a
+# second connection's pragma read is not blocked by BEGIN EXCLUSIVE
+# (doltlite takes no page-level exclusive lock).
+autovacuum autovacuum-1.1.3  # file_pages: chunk-store size, no page reclamation
+autovacuum autovacuum-1.2.3  # file_pages: chunk-store size, no page reclamation
+autovacuum autovacuum-1.3.3  # file_pages: chunk-store size, no page reclamation
+autovacuum autovacuum-1.4.3  # file_pages: chunk-store size, no page reclamation
+autovacuum autovacuum-1.5.3  # file_pages: chunk-store size, no page reclamation
+autovacuum autovacuum-1.6.3  # file_pages: chunk-store size, no page reclamation
+autovacuum autovacuum-2.1.2  # file_pages: chunk-store size, no page reclamation
+autovacuum autovacuum-2.2.1  # sqlite_master rootpage numbering / no autoindex shadow
+autovacuum autovacuum-2.2.2  # file_pages: chunk-store size, no page reclamation
+autovacuum autovacuum-2.2.3  # sqlite_master rootpage numbering / no autoindex shadow
+autovacuum autovacuum-2.2.4  # file_pages: chunk-store size, no page reclamation
+autovacuum autovacuum-2.2.5  # sqlite_master rootpage numbering / no autoindex shadow
+autovacuum autovacuum-2.2.6  # file_pages: chunk-store size, no page reclamation
+autovacuum autovacuum-2.2.7  # sqlite_master rootpage numbering / no autoindex shadow
+autovacuum autovacuum-2.2.8  # file_pages: chunk-store size, no page reclamation
+autovacuum autovacuum-2.3.1  # file_pages: chunk-store size, no page reclamation
+autovacuum autovacuum-2.3.2  # file_pages: chunk-store size, no page reclamation
+autovacuum autovacuum-2.3.3  # file_pages: chunk-store size, no page reclamation
+autovacuum autovacuum-2.4.1  # file_pages: chunk-store size, no page reclamation
+autovacuum autovacuum-2.4.2  # file_pages: chunk-store size, no page reclamation
+autovacuum autovacuum-2.4.5  # file_pages: chunk-store size, no page reclamation
+autovacuum autovacuum-2.4.6  # file_pages: chunk-store size, no page reclamation
+autovacuum autovacuum-2.4.7  # file_pages: chunk-store size, no page reclamation
+autovacuum autovacuum-2.5.2  # sqlite_master rootpage numbering / no autoindex shadow
+autovacuum autovacuum-2.5.3  # sqlite_master rootpage numbering / no autoindex shadow
+autovacuum autovacuum-2.5.4  # sqlite_master rootpage numbering / no autoindex shadow
+autovacuum autovacuum-2.5.5  # sqlite_master rootpage numbering / no autoindex shadow
+autovacuum autovacuum-3.1  # auto_vacuum reads back 0 / not persisted
+autovacuum autovacuum-3.2  # auto_vacuum reads back 0 / not persisted
+autovacuum autovacuum-3.3  # auto_vacuum reads back 0 / not persisted
+autovacuum autovacuum-4.0  # auto_vacuum reads back 0 / not persisted
+autovacuum autovacuum-7.1  # file_pages: chunk-store size, no page reclamation
+autovacuum autovacuum-7.2  # file_pages: chunk-store size, no page reclamation
+autovacuum autovacuum-7.3  # file_pages: chunk-store size, no page reclamation
+autovacuum autovacuum-8.1  # auto_vacuum reads back 0 / not persisted
+autovacuum autovacuum-8.2  # no "database is locked" for cross-connection pragma during BEGIN EXCLUSIVE
+autovacuum autovacuum-9.1  # file_pages: chunk-store size, no page reclamation
+autovacuum autovacuum-9.2  # file_pages: chunk-store size, no page reclamation
+autovacuum autovacuum-9.3  # file_pages: chunk-store size, no page reclamation
+autovacuum autovacuum-9.5  # file_pages: chunk-store size, no page reclamation
+
+# ── avtrans ──
+# avtrans is trans.test under auto_vacuum=full (now an accepted no-op, so
+# the old setup-cascade entries are gone). Remaining: the read-back probe
+# and the fullsync counter — the chunk store commits through its own sync
+# path, so the stock pager fullsync instrumentation counter stays 0.
+avtrans avtrans-1.0.1  # PRAGMA auto_vacuum reads back 0, not 1
+avtrans avtrans-9.2.5-1024  # sqlite_fullsync_count stays 0 (chunk-store sync path)
+avtrans avtrans-9.4.5-1224  # sqlite_fullsync_count stays 0 (chunk-store sync path)
+avtrans avtrans-9.6.5-1480  # sqlite_fullsync_count stays 0 (chunk-store sync path)
+avtrans avtrans-9.8.5-1766  # sqlite_fullsync_count stays 0 (chunk-store sync path)
+avtrans avtrans-9.10.5-2112  # sqlite_fullsync_count stays 0 (chunk-store sync path)
+avtrans avtrans-9.12.5-2544  # sqlite_fullsync_count stays 0 (chunk-store sync path)
+avtrans avtrans-9.14.5-3089  # sqlite_fullsync_count stays 0 (chunk-store sync path)
+avtrans avtrans-9.16.5-3802  # sqlite_fullsync_count stays 0 (chunk-store sync path)
+avtrans avtrans-9.18.5-4593  # sqlite_fullsync_count stays 0 (chunk-store sync path)
+avtrans avtrans-9.20.5-5551  # sqlite_fullsync_count stays 0 (chunk-store sync path)
+avtrans avtrans-9.22.5-6736  # sqlite_fullsync_count stays 0 (chunk-store sync path)
+avtrans avtrans-9.24.5-8156  # sqlite_fullsync_count stays 0 (chunk-store sync path)
+avtrans avtrans-9.26.5-9897  # sqlite_fullsync_count stays 0 (chunk-store sync path)
+avtrans avtrans-9.28.5-11982  # sqlite_fullsync_count stays 0 (chunk-store sync path)
+avtrans avtrans-9.30.5-14544  # sqlite_fullsync_count stays 0 (chunk-store sync path)
+avtrans avtrans-9.32.5-17576  # sqlite_fullsync_count stays 0 (chunk-store sync path)
+avtrans avtrans-9.34.5-21225  # sqlite_fullsync_count stays 0 (chunk-store sync path)
+avtrans avtrans-9.36.5-25685  # sqlite_fullsync_count stays 0 (chunk-store sync path)
+avtrans avtrans-9.38.5-30883  # sqlite_fullsync_count stays 0 (chunk-store sync path)
+
+# corruptB pokes stock b-tree page structures by offset. On a chunk-store
+# file the offsets read back garbage: .1 steps that compute child-page
+# offsets from in-file values die with tcl "integer value too large to
+# represent" (1.8.1/1.9.1), pokes land in places the store rejects
+# differently ("no such table: t1" instead of "malformed", 1.3.2/2.1.2),
+# or never land at all so the read returns the intact row (1.9.2).
+corruptB corruptB-1.3.2
+corruptB corruptB-1.8.1
+corruptB corruptB-1.9.1
+corruptB corruptB-1.9.2
+corruptB corruptB-2.1.2
+
+# createtab: raw-format file-size compare; the doltlite chunk file is not
+# sized in 1024-byte pages and does not grow with auto_vacuum pointer-map
+# pages (auto_vacuum is a no-op on doltlite format).
+createtab createtab-0.2
+createtab createtab-1.2
+createtab createtab-2.2
+
+# ── e_vacuum ──
+# VACUUM on doltlite format runs the chunk-store GC instead of a page
+# rebuild, and auto_vacuum/incremental_vacuum are accepted no-ops:
+# page_count/freelist_count/file-size expectations, the mid-statement
+# VACUUM error path, rowid renumbering, and VACUUM INTO all diverge.
+e_vacuum e_vacuum-1.1.1.3  # page_count after delete: no page reclamation on chunk store
+e_vacuum e_vacuum-1.1.1.5  # page_count after VACUUM (gc, no page rebuild)
+e_vacuum e_vacuum-1.1.2.5  # page_count after VACUUM (gc, no page rebuild)
+e_vacuum e_vacuum-1.1.3.3  # page_count after delete
+e_vacuum e_vacuum-1.1.3.5  # page_count after VACUUM (gc, no page rebuild)
+e_vacuum e_vacuum-1.2.2.1  # freelist_count: no freelist on chunk store
+e_vacuum e_vacuum-1.2.2.2  # freelist_count
+e_vacuum e_vacuum-1.2.2.3  # freelist_count
+e_vacuum e_vacuum-1.2.4.1  # freelist_count
+e_vacuum e_vacuum-1.2.4.2  # freelist_count
+e_vacuum e_vacuum-1.2.4.3  # freelist_count
+e_vacuum e_vacuum-1.3.1.1  # page_size/page_count pair after VACUUM (gc, no page rebuild)
+e_vacuum e_vacuum-1.3.1.2  # page_size/page_count pair
+e_vacuum e_vacuum-1.3.2.1  # PRAGMA journal_mode errors: not configurable on doltlite format
+e_vacuum e_vacuum-1.3.3.2  # page_size/page_count pair
+e_vacuum e_vacuum-2.1.8  # VACUUM INTO-style size comparison: file not rebuilt smaller
+e_vacuum e_vacuum-3.1.2  # VACUUM-as-gc does not renumber free rowids (stock expectation predates rowid preservation)
+e_vacuum e_vacuum-3.1.6  # VACUUM INTO is not supported for doltlite databases (intentional error)
+e_vacuum e_vacuum-3.2.2.1  # "cannot VACUUM - SQL statements in progress" never raised (gc path skips the nVdbeActive check)
+e_vacuum e_vacuum-3.3.1  # PRAGMA auto_vacuum reads back 0 (accepted as no-op)
+e_vacuum e_vacuum-3.3.2.1  # file size after auto_vacuum=FULL deletes: no reclamation
+e_vacuum e_vacuum-3.3.2.2  # file size after incremental_vacuum no-op
+
+# ── fallocate ──
+# The test sizes the db file via SQLITE_FCNTL_CHUNK_SIZE rounding and page
+# bookkeeping. doltlite's file is a content-addressed chunk store: [file
+# size] reflects chunk payload, never page images rounded up to the chunk
+# size, and there is no rollback-journal sidecar to inspect.
+fallocate fallocate-1.1  # file size = chunk payload (1896), not 1MB CHUNK_SIZE rounding
+fallocate fallocate-1.2  # file size = chunk payload
+fallocate fallocate-1.3  # file size = chunk payload
+fallocate fallocate-1.4  # file size = chunk payload
+fallocate fallocate-1.5  # file size = chunk payload
+fallocate fallocate-1.7  # reads test.db-journal sidecar that doltlite never creates
+fallocate fallocate-2.1  # file size = chunk payload, not 32KB chunk rounding
+fallocate fallocate-2.2  # file size = chunk payload
+fallocate fallocate-2.3  # file size = chunk payload
+fallocate fallocate-2.4  # file size = chunk payload
+fallocate fallocate-2.5  # file size = chunk payload
+fallocate fallocate-2.6  # file size = chunk payload
+fallocate fallocate-2.8  # file size = chunk payload
+
+# incrcorrupt pokes the stock header freelist fields (e.g. byte 36) and
+# expects PRAGMA incremental_vacuum / incrblob reads to detect corruption.
+# On doltlite the pokes miss chunk-store structures, incremental_vacuum is
+# a no-op that never reads a freelist (succeeds where stock reports
+# malformed / SQLITE_CORRUPT), and page_count reflects chunk pages.
+incrcorrupt incrcorrupt-1.0
+incrcorrupt incrcorrupt-1.2
+incrcorrupt incrcorrupt-1.3
+incrcorrupt incrcorrupt-1.4
+incrcorrupt incrcorrupt-1.5
+incrcorrupt incrcorrupt-1.6
+incrcorrupt incrcorrupt-1.7
+incrcorrupt incrcorrupt-1.8
+incrcorrupt incrcorrupt-1.9
+incrcorrupt incrcorrupt-1.10
+incrcorrupt incrcorrupt-1.11
+incrcorrupt incrcorrupt-1.15
+incrcorrupt incrcorrupt-1.16
+incrcorrupt incrcorrupt-1.17
+incrcorrupt incrcorrupt-2.1
+incrcorrupt incrcorrupt-2.2
+incrcorrupt incrcorrupt-2.3
+incrcorrupt incrcorrupt-2.4
+incrcorrupt incrcorrupt-2.5
+incrcorrupt incrcorrupt-2.6
+incrcorrupt incrcorrupt-2.7
+incrcorrupt incrcorrupt-2.8
+incrcorrupt incrcorrupt-2.9
+incrcorrupt incrcorrupt-2.10
+incrcorrupt incrcorrupt-2.11
+incrcorrupt incrcorrupt-2.15
+incrcorrupt incrcorrupt-2.16
+incrcorrupt incrcorrupt-2.17
+
+# ── incrvacuum ──
+# The whole file exercises incremental-vacuum semantics prolly storage
+# doesn't have: auto_vacuum mode read-back round-trips (always 0 here),
+# freelist_count, and file-shrink-after-vacuum sizes. Section 7 is a
+# `while 1` loop that only breaks when `db eval {PRAGMA incremental_vacuum}`
+# steps its body ($nRow == $iWrite); the no-op returns zero rows, so the
+# loop repeats (3 failures per lap, incl. a cascading 'no such table:
+# tbl1') until the tester's 1000-error cap aborts the file. The cap also
+# means sections 8-15 never run. Entry list pinned to the cap-truncated,
+# 3/3-stable failure set.
+incrvacuum incrvacuum-1.2.0
+incrvacuum incrvacuum-1.2
+incrvacuum incrvacuum-1.3
+incrvacuum incrvacuum-1.4
+incrvacuum incrvacuum-1.5
+incrvacuum incrvacuum-1.6
+incrvacuum incrvacuum-1.7
+incrvacuum incrvacuum-2.2
+incrvacuum incrvacuum-2.2.1
+incrvacuum incrvacuum-2.3
+incrvacuum incrvacuum-2.4
+incrvacuum incrvacuum-3.1
+incrvacuum incrvacuum-3.2
+incrvacuum incrvacuum-3.4
+incrvacuum incrvacuum-4.1
+incrvacuum incrvacuum-4.2
+incrvacuum incrvacuum-4.3
+incrvacuum incrvacuum-5.1.1
+incrvacuum incrvacuum-5.1.2
+incrvacuum incrvacuum-5.2.1
+incrvacuum incrvacuum-5.2.2
+incrvacuum incrvacuum-5.2.3
+incrvacuum incrvacuum-5.2.5
+incrvacuum incrvacuum-6.0.1
+incrvacuum incrvacuum-6.0.2
+incrvacuum incrvacuum-6.1.1
+incrvacuum incrvacuum-6.1.2
+incrvacuum incrvacuum-6.2.1
+incrvacuum incrvacuum-6.2.2
+incrvacuum incrvacuum-6.3.1
+incrvacuum incrvacuum-6.3.2
+incrvacuum incrvacuum-6.4.1
+incrvacuum incrvacuum-6.4.2
+incrvacuum incrvacuum-6.5.1
+incrvacuum incrvacuum-6.5.2
+incrvacuum incrvacuum-6.6.1
+incrvacuum incrvacuum-6.6.2
+incrvacuum incrvacuum-6.7.1
+incrvacuum incrvacuum-6.7.2
+incrvacuum incrvacuum-6.8.1
+incrvacuum incrvacuum-6.8.2
+incrvacuum incrvacuum-6.9.1
+incrvacuum incrvacuum-6.9.2
+incrvacuum incrvacuum-7.1.1
+incrvacuum incrvacuum-7.1.2
+incrvacuum incrvacuum-7.1.3
+incrvacuum incrvacuum-7.2.1
+incrvacuum incrvacuum-7.2.2
+incrvacuum incrvacuum-7.2.3
+incrvacuum incrvacuum-7.3.1
+incrvacuum incrvacuum-7.3.2
+incrvacuum incrvacuum-7.3.3
+incrvacuum incrvacuum-7.4.1
+incrvacuum incrvacuum-7.4.2
+incrvacuum incrvacuum-7.4.3
+incrvacuum incrvacuum-7.5.1
+incrvacuum incrvacuum-7.5.2
+incrvacuum incrvacuum-7.5.3
+incrvacuum incrvacuum-7.6.1
+incrvacuum incrvacuum-7.6.2
+incrvacuum incrvacuum-7.6.3
+incrvacuum incrvacuum-7.7.1
+incrvacuum incrvacuum-7.7.2
+incrvacuum incrvacuum-7.7.3
+incrvacuum incrvacuum-7.8.1
+incrvacuum incrvacuum-7.8.2
+incrvacuum incrvacuum-7.8.3
+incrvacuum incrvacuum-7.9.1
+incrvacuum incrvacuum-7.9.2
+incrvacuum incrvacuum-7.9.3
+incrvacuum incrvacuum-7.10.1
+incrvacuum incrvacuum-7.10.2
+incrvacuum incrvacuum-7.10.3
+incrvacuum incrvacuum-7.11.1
+incrvacuum incrvacuum-7.11.2
+incrvacuum incrvacuum-7.11.3
+incrvacuum incrvacuum-7.12.1
+incrvacuum incrvacuum-7.12.2
+incrvacuum incrvacuum-7.12.3
+incrvacuum incrvacuum-7.13.1
+incrvacuum incrvacuum-7.13.2
+incrvacuum incrvacuum-7.13.3
+incrvacuum incrvacuum-7.14.1
+incrvacuum incrvacuum-7.14.2
+incrvacuum incrvacuum-7.14.3
+incrvacuum incrvacuum-7.15.1
+incrvacuum incrvacuum-7.15.2
+incrvacuum incrvacuum-7.15.3
+incrvacuum incrvacuum-7.16.1
+incrvacuum incrvacuum-7.16.2
+incrvacuum incrvacuum-7.16.3
+incrvacuum incrvacuum-7.17.1
+incrvacuum incrvacuum-7.17.2
+incrvacuum incrvacuum-7.17.3
+incrvacuum incrvacuum-7.18.1
+incrvacuum incrvacuum-7.18.2
+incrvacuum incrvacuum-7.18.3
+incrvacuum incrvacuum-7.19.1
+incrvacuum incrvacuum-7.19.2
+incrvacuum incrvacuum-7.19.3
+incrvacuum incrvacuum-7.20.1
+incrvacuum incrvacuum-7.20.2
+incrvacuum incrvacuum-7.20.3
+incrvacuum incrvacuum-7.21.1
+incrvacuum incrvacuum-7.21.2
+incrvacuum incrvacuum-7.21.3
+incrvacuum incrvacuum-7.22.1
+incrvacuum incrvacuum-7.22.2
+incrvacuum incrvacuum-7.22.3
+incrvacuum incrvacuum-7.23.1
+incrvacuum incrvacuum-7.23.2
+incrvacuum incrvacuum-7.23.3
+incrvacuum incrvacuum-7.24.1
+incrvacuum incrvacuum-7.24.2
+incrvacuum incrvacuum-7.24.3
+incrvacuum incrvacuum-7.25.1
+incrvacuum incrvacuum-7.25.2
+incrvacuum incrvacuum-7.25.3
+incrvacuum incrvacuum-7.26.1
+incrvacuum incrvacuum-7.26.2
+incrvacuum incrvacuum-7.26.3
+incrvacuum incrvacuum-7.27.1
+incrvacuum incrvacuum-7.27.2
+incrvacuum incrvacuum-7.27.3
+incrvacuum incrvacuum-7.28.1
+incrvacuum incrvacuum-7.28.2
+incrvacuum incrvacuum-7.28.3
+incrvacuum incrvacuum-7.29.1
+incrvacuum incrvacuum-7.29.2
+incrvacuum incrvacuum-7.29.3
+incrvacuum incrvacuum-7.30.1
+incrvacuum incrvacuum-7.30.2
+incrvacuum incrvacuum-7.30.3
+incrvacuum incrvacuum-7.31.1
+incrvacuum incrvacuum-7.31.2
+incrvacuum incrvacuum-7.31.3
+incrvacuum incrvacuum-7.32.1
+incrvacuum incrvacuum-7.32.2
+incrvacuum incrvacuum-7.32.3
+incrvacuum incrvacuum-7.33.1
+incrvacuum incrvacuum-7.33.2
+incrvacuum incrvacuum-7.33.3
+incrvacuum incrvacuum-7.34.1
+incrvacuum incrvacuum-7.34.2
+incrvacuum incrvacuum-7.34.3
+incrvacuum incrvacuum-7.35.1
+incrvacuum incrvacuum-7.35.2
+incrvacuum incrvacuum-7.35.3
+incrvacuum incrvacuum-7.36.1
+incrvacuum incrvacuum-7.36.2
+incrvacuum incrvacuum-7.36.3
+incrvacuum incrvacuum-7.37.1
+incrvacuum incrvacuum-7.37.2
+incrvacuum incrvacuum-7.37.3
+incrvacuum incrvacuum-7.38.1
+incrvacuum incrvacuum-7.38.2
+incrvacuum incrvacuum-7.38.3
+incrvacuum incrvacuum-7.39.1
+incrvacuum incrvacuum-7.39.2
+incrvacuum incrvacuum-7.39.3
+incrvacuum incrvacuum-7.40.1
+incrvacuum incrvacuum-7.40.2
+incrvacuum incrvacuum-7.40.3
+incrvacuum incrvacuum-7.41.1
+incrvacuum incrvacuum-7.41.2
+incrvacuum incrvacuum-7.41.3
+incrvacuum incrvacuum-7.42.1
+incrvacuum incrvacuum-7.42.2
+incrvacuum incrvacuum-7.42.3
+incrvacuum incrvacuum-7.43.1
+incrvacuum incrvacuum-7.43.2
+incrvacuum incrvacuum-7.43.3
+incrvacuum incrvacuum-7.44.1
+incrvacuum incrvacuum-7.44.2
+incrvacuum incrvacuum-7.44.3
+incrvacuum incrvacuum-7.45.1
+incrvacuum incrvacuum-7.45.2
+incrvacuum incrvacuum-7.45.3
+incrvacuum incrvacuum-7.46.1
+incrvacuum incrvacuum-7.46.2
+incrvacuum incrvacuum-7.46.3
+incrvacuum incrvacuum-7.47.1
+incrvacuum incrvacuum-7.47.2
+incrvacuum incrvacuum-7.47.3
+incrvacuum incrvacuum-7.48.1
+incrvacuum incrvacuum-7.48.2
+incrvacuum incrvacuum-7.48.3
+incrvacuum incrvacuum-7.49.1
+incrvacuum incrvacuum-7.49.2
+incrvacuum incrvacuum-7.49.3
+incrvacuum incrvacuum-7.50.1
+incrvacuum incrvacuum-7.50.2
+incrvacuum incrvacuum-7.50.3
+incrvacuum incrvacuum-7.51.1
+incrvacuum incrvacuum-7.51.2
+incrvacuum incrvacuum-7.51.3
+incrvacuum incrvacuum-7.52.1
+incrvacuum incrvacuum-7.52.2
+incrvacuum incrvacuum-7.52.3
+incrvacuum incrvacuum-7.53.1
+incrvacuum incrvacuum-7.53.2
+incrvacuum incrvacuum-7.53.3
+incrvacuum incrvacuum-7.54.1
+incrvacuum incrvacuum-7.54.2
+incrvacuum incrvacuum-7.54.3
+incrvacuum incrvacuum-7.55.1
+incrvacuum incrvacuum-7.55.2
+incrvacuum incrvacuum-7.55.3
+incrvacuum incrvacuum-7.56.1
+incrvacuum incrvacuum-7.56.2
+incrvacuum incrvacuum-7.56.3
+incrvacuum incrvacuum-7.57.1
+incrvacuum incrvacuum-7.57.2
+incrvacuum incrvacuum-7.57.3
+incrvacuum incrvacuum-7.58.1
+incrvacuum incrvacuum-7.58.2
+incrvacuum incrvacuum-7.58.3
+incrvacuum incrvacuum-7.59.1
+incrvacuum incrvacuum-7.59.2
+incrvacuum incrvacuum-7.59.3
+incrvacuum incrvacuum-7.60.1
+incrvacuum incrvacuum-7.60.2
+incrvacuum incrvacuum-7.60.3
+incrvacuum incrvacuum-7.61.1
+incrvacuum incrvacuum-7.61.2
+incrvacuum incrvacuum-7.61.3
+incrvacuum incrvacuum-7.62.1
+incrvacuum incrvacuum-7.62.2
+incrvacuum incrvacuum-7.62.3
+incrvacuum incrvacuum-7.63.1
+incrvacuum incrvacuum-7.63.2
+incrvacuum incrvacuum-7.63.3
+incrvacuum incrvacuum-7.64.1
+incrvacuum incrvacuum-7.64.2
+incrvacuum incrvacuum-7.64.3
+incrvacuum incrvacuum-7.65.1
+incrvacuum incrvacuum-7.65.2
+incrvacuum incrvacuum-7.65.3
+incrvacuum incrvacuum-7.66.1
+incrvacuum incrvacuum-7.66.2
+incrvacuum incrvacuum-7.66.3
+incrvacuum incrvacuum-7.67.1
+incrvacuum incrvacuum-7.67.2
+incrvacuum incrvacuum-7.67.3
+incrvacuum incrvacuum-7.68.1
+incrvacuum incrvacuum-7.68.2
+incrvacuum incrvacuum-7.68.3
+incrvacuum incrvacuum-7.69.1
+incrvacuum incrvacuum-7.69.2
+incrvacuum incrvacuum-7.69.3
+incrvacuum incrvacuum-7.70.1
+incrvacuum incrvacuum-7.70.2
+incrvacuum incrvacuum-7.70.3
+incrvacuum incrvacuum-7.71.1
+incrvacuum incrvacuum-7.71.2
+incrvacuum incrvacuum-7.71.3
+incrvacuum incrvacuum-7.72.1
+incrvacuum incrvacuum-7.72.2
+incrvacuum incrvacuum-7.72.3
+incrvacuum incrvacuum-7.73.1
+incrvacuum incrvacuum-7.73.2
+incrvacuum incrvacuum-7.73.3
+incrvacuum incrvacuum-7.74.1
+incrvacuum incrvacuum-7.74.2
+incrvacuum incrvacuum-7.74.3
+incrvacuum incrvacuum-7.75.1
+incrvacuum incrvacuum-7.75.2
+incrvacuum incrvacuum-7.75.3
+incrvacuum incrvacuum-7.76.1
+incrvacuum incrvacuum-7.76.2
+incrvacuum incrvacuum-7.76.3
+incrvacuum incrvacuum-7.77.1
+incrvacuum incrvacuum-7.77.2
+incrvacuum incrvacuum-7.77.3
+incrvacuum incrvacuum-7.78.1
+incrvacuum incrvacuum-7.78.2
+incrvacuum incrvacuum-7.78.3
+incrvacuum incrvacuum-7.79.1
+incrvacuum incrvacuum-7.79.2
+incrvacuum incrvacuum-7.79.3
+incrvacuum incrvacuum-7.80.1
+incrvacuum incrvacuum-7.80.2
+incrvacuum incrvacuum-7.80.3
+incrvacuum incrvacuum-7.81.1
+incrvacuum incrvacuum-7.81.2
+incrvacuum incrvacuum-7.81.3
+incrvacuum incrvacuum-7.82.1
+incrvacuum incrvacuum-7.82.2
+incrvacuum incrvacuum-7.82.3
+incrvacuum incrvacuum-7.83.1
+incrvacuum incrvacuum-7.83.2
+incrvacuum incrvacuum-7.83.3
+incrvacuum incrvacuum-7.84.1
+incrvacuum incrvacuum-7.84.2
+incrvacuum incrvacuum-7.84.3
+incrvacuum incrvacuum-7.85.1
+incrvacuum incrvacuum-7.85.2
+incrvacuum incrvacuum-7.85.3
+incrvacuum incrvacuum-7.86.1
+incrvacuum incrvacuum-7.86.2
+incrvacuum incrvacuum-7.86.3
+incrvacuum incrvacuum-7.87.1
+incrvacuum incrvacuum-7.87.2
+incrvacuum incrvacuum-7.87.3
+incrvacuum incrvacuum-7.88.1
+incrvacuum incrvacuum-7.88.2
+incrvacuum incrvacuum-7.88.3
+incrvacuum incrvacuum-7.89.1
+incrvacuum incrvacuum-7.89.2
+incrvacuum incrvacuum-7.89.3
+incrvacuum incrvacuum-7.90.1
+incrvacuum incrvacuum-7.90.2
+incrvacuum incrvacuum-7.90.3
+incrvacuum incrvacuum-7.91.1
+incrvacuum incrvacuum-7.91.2
+incrvacuum incrvacuum-7.91.3
+incrvacuum incrvacuum-7.92.1
+incrvacuum incrvacuum-7.92.2
+incrvacuum incrvacuum-7.92.3
+incrvacuum incrvacuum-7.93.1
+incrvacuum incrvacuum-7.93.2
+incrvacuum incrvacuum-7.93.3
+incrvacuum incrvacuum-7.94.1
+incrvacuum incrvacuum-7.94.2
+incrvacuum incrvacuum-7.94.3
+incrvacuum incrvacuum-7.95.1
+incrvacuum incrvacuum-7.95.2
+incrvacuum incrvacuum-7.95.3
+incrvacuum incrvacuum-7.96.1
+incrvacuum incrvacuum-7.96.2
+incrvacuum incrvacuum-7.96.3
+incrvacuum incrvacuum-7.97.1
+incrvacuum incrvacuum-7.97.2
+incrvacuum incrvacuum-7.97.3
+incrvacuum incrvacuum-7.98.1
+incrvacuum incrvacuum-7.98.2
+incrvacuum incrvacuum-7.98.3
+incrvacuum incrvacuum-7.99.1
+incrvacuum incrvacuum-7.99.2
+incrvacuum incrvacuum-7.99.3
+incrvacuum incrvacuum-7.100.1
+incrvacuum incrvacuum-7.100.2
+incrvacuum incrvacuum-7.100.3
+incrvacuum incrvacuum-7.101.1
+incrvacuum incrvacuum-7.101.2
+incrvacuum incrvacuum-7.101.3
+incrvacuum incrvacuum-7.102.1
+incrvacuum incrvacuum-7.102.2
+incrvacuum incrvacuum-7.102.3
+incrvacuum incrvacuum-7.103.1
+incrvacuum incrvacuum-7.103.2
+incrvacuum incrvacuum-7.103.3
+incrvacuum incrvacuum-7.104.1
+incrvacuum incrvacuum-7.104.2
+incrvacuum incrvacuum-7.104.3
+incrvacuum incrvacuum-7.105.1
+incrvacuum incrvacuum-7.105.2
+incrvacuum incrvacuum-7.105.3
+incrvacuum incrvacuum-7.106.1
+incrvacuum incrvacuum-7.106.2
+incrvacuum incrvacuum-7.106.3
+incrvacuum incrvacuum-7.107.1
+incrvacuum incrvacuum-7.107.2
+incrvacuum incrvacuum-7.107.3
+incrvacuum incrvacuum-7.108.1
+incrvacuum incrvacuum-7.108.2
+incrvacuum incrvacuum-7.108.3
+incrvacuum incrvacuum-7.109.1
+incrvacuum incrvacuum-7.109.2
+incrvacuum incrvacuum-7.109.3
+incrvacuum incrvacuum-7.110.1
+incrvacuum incrvacuum-7.110.2
+incrvacuum incrvacuum-7.110.3
+incrvacuum incrvacuum-7.111.1
+incrvacuum incrvacuum-7.111.2
+incrvacuum incrvacuum-7.111.3
+incrvacuum incrvacuum-7.112.1
+incrvacuum incrvacuum-7.112.2
+incrvacuum incrvacuum-7.112.3
+incrvacuum incrvacuum-7.113.1
+incrvacuum incrvacuum-7.113.2
+incrvacuum incrvacuum-7.113.3
+incrvacuum incrvacuum-7.114.1
+incrvacuum incrvacuum-7.114.2
+incrvacuum incrvacuum-7.114.3
+incrvacuum incrvacuum-7.115.1
+incrvacuum incrvacuum-7.115.2
+incrvacuum incrvacuum-7.115.3
+incrvacuum incrvacuum-7.116.1
+incrvacuum incrvacuum-7.116.2
+incrvacuum incrvacuum-7.116.3
+incrvacuum incrvacuum-7.117.1
+incrvacuum incrvacuum-7.117.2
+incrvacuum incrvacuum-7.117.3
+incrvacuum incrvacuum-7.118.1
+incrvacuum incrvacuum-7.118.2
+incrvacuum incrvacuum-7.118.3
+incrvacuum incrvacuum-7.119.1
+incrvacuum incrvacuum-7.119.2
+incrvacuum incrvacuum-7.119.3
+incrvacuum incrvacuum-7.120.1
+incrvacuum incrvacuum-7.120.2
+incrvacuum incrvacuum-7.120.3
+incrvacuum incrvacuum-7.121.1
+incrvacuum incrvacuum-7.121.2
+incrvacuum incrvacuum-7.121.3
+incrvacuum incrvacuum-7.122.1
+incrvacuum incrvacuum-7.122.2
+incrvacuum incrvacuum-7.122.3
+incrvacuum incrvacuum-7.123.1
+incrvacuum incrvacuum-7.123.2
+incrvacuum incrvacuum-7.123.3
+incrvacuum incrvacuum-7.124.1
+incrvacuum incrvacuum-7.124.2
+incrvacuum incrvacuum-7.124.3
+incrvacuum incrvacuum-7.125.1
+incrvacuum incrvacuum-7.125.2
+incrvacuum incrvacuum-7.125.3
+incrvacuum incrvacuum-7.126.1
+incrvacuum incrvacuum-7.126.2
+incrvacuum incrvacuum-7.126.3
+incrvacuum incrvacuum-7.127.1
+incrvacuum incrvacuum-7.127.2
+incrvacuum incrvacuum-7.127.3
+incrvacuum incrvacuum-7.128.1
+incrvacuum incrvacuum-7.128.2
+incrvacuum incrvacuum-7.128.3
+incrvacuum incrvacuum-7.129.1
+incrvacuum incrvacuum-7.129.2
+incrvacuum incrvacuum-7.129.3
+incrvacuum incrvacuum-7.130.1
+incrvacuum incrvacuum-7.130.2
+incrvacuum incrvacuum-7.130.3
+incrvacuum incrvacuum-7.131.1
+incrvacuum incrvacuum-7.131.2
+incrvacuum incrvacuum-7.131.3
+incrvacuum incrvacuum-7.132.1
+incrvacuum incrvacuum-7.132.2
+incrvacuum incrvacuum-7.132.3
+incrvacuum incrvacuum-7.133.1
+incrvacuum incrvacuum-7.133.2
+incrvacuum incrvacuum-7.133.3
+incrvacuum incrvacuum-7.134.1
+incrvacuum incrvacuum-7.134.2
+incrvacuum incrvacuum-7.134.3
+incrvacuum incrvacuum-7.135.1
+incrvacuum incrvacuum-7.135.2
+incrvacuum incrvacuum-7.135.3
+incrvacuum incrvacuum-7.136.1
+incrvacuum incrvacuum-7.136.2
+incrvacuum incrvacuum-7.136.3
+incrvacuum incrvacuum-7.137.1
+incrvacuum incrvacuum-7.137.2
+incrvacuum incrvacuum-7.137.3
+incrvacuum incrvacuum-7.138.1
+incrvacuum incrvacuum-7.138.2
+incrvacuum incrvacuum-7.138.3
+incrvacuum incrvacuum-7.139.1
+incrvacuum incrvacuum-7.139.2
+incrvacuum incrvacuum-7.139.3
+incrvacuum incrvacuum-7.140.1
+incrvacuum incrvacuum-7.140.2
+incrvacuum incrvacuum-7.140.3
+incrvacuum incrvacuum-7.141.1
+incrvacuum incrvacuum-7.141.2
+incrvacuum incrvacuum-7.141.3
+incrvacuum incrvacuum-7.142.1
+incrvacuum incrvacuum-7.142.2
+incrvacuum incrvacuum-7.142.3
+incrvacuum incrvacuum-7.143.1
+incrvacuum incrvacuum-7.143.2
+incrvacuum incrvacuum-7.143.3
+incrvacuum incrvacuum-7.144.1
+incrvacuum incrvacuum-7.144.2
+incrvacuum incrvacuum-7.144.3
+incrvacuum incrvacuum-7.145.1
+incrvacuum incrvacuum-7.145.2
+incrvacuum incrvacuum-7.145.3
+incrvacuum incrvacuum-7.146.1
+incrvacuum incrvacuum-7.146.2
+incrvacuum incrvacuum-7.146.3
+incrvacuum incrvacuum-7.147.1
+incrvacuum incrvacuum-7.147.2
+incrvacuum incrvacuum-7.147.3
+incrvacuum incrvacuum-7.148.1
+incrvacuum incrvacuum-7.148.2
+incrvacuum incrvacuum-7.148.3
+incrvacuum incrvacuum-7.149.1
+incrvacuum incrvacuum-7.149.2
+incrvacuum incrvacuum-7.149.3
+incrvacuum incrvacuum-7.150.1
+incrvacuum incrvacuum-7.150.2
+incrvacuum incrvacuum-7.150.3
+incrvacuum incrvacuum-7.151.1
+incrvacuum incrvacuum-7.151.2
+incrvacuum incrvacuum-7.151.3
+incrvacuum incrvacuum-7.152.1
+incrvacuum incrvacuum-7.152.2
+incrvacuum incrvacuum-7.152.3
+incrvacuum incrvacuum-7.153.1
+incrvacuum incrvacuum-7.153.2
+incrvacuum incrvacuum-7.153.3
+incrvacuum incrvacuum-7.154.1
+incrvacuum incrvacuum-7.154.2
+incrvacuum incrvacuum-7.154.3
+incrvacuum incrvacuum-7.155.1
+incrvacuum incrvacuum-7.155.2
+incrvacuum incrvacuum-7.155.3
+incrvacuum incrvacuum-7.156.1
+incrvacuum incrvacuum-7.156.2
+incrvacuum incrvacuum-7.156.3
+incrvacuum incrvacuum-7.157.1
+incrvacuum incrvacuum-7.157.2
+incrvacuum incrvacuum-7.157.3
+incrvacuum incrvacuum-7.158.1
+incrvacuum incrvacuum-7.158.2
+incrvacuum incrvacuum-7.158.3
+incrvacuum incrvacuum-7.159.1
+incrvacuum incrvacuum-7.159.2
+incrvacuum incrvacuum-7.159.3
+incrvacuum incrvacuum-7.160.1
+incrvacuum incrvacuum-7.160.2
+incrvacuum incrvacuum-7.160.3
+incrvacuum incrvacuum-7.161.1
+incrvacuum incrvacuum-7.161.2
+incrvacuum incrvacuum-7.161.3
+incrvacuum incrvacuum-7.162.1
+incrvacuum incrvacuum-7.162.2
+incrvacuum incrvacuum-7.162.3
+incrvacuum incrvacuum-7.163.1
+incrvacuum incrvacuum-7.163.2
+incrvacuum incrvacuum-7.163.3
+incrvacuum incrvacuum-7.164.1
+incrvacuum incrvacuum-7.164.2
+incrvacuum incrvacuum-7.164.3
+incrvacuum incrvacuum-7.165.1
+incrvacuum incrvacuum-7.165.2
+incrvacuum incrvacuum-7.165.3
+incrvacuum incrvacuum-7.166.1
+incrvacuum incrvacuum-7.166.2
+incrvacuum incrvacuum-7.166.3
+incrvacuum incrvacuum-7.167.1
+incrvacuum incrvacuum-7.167.2
+incrvacuum incrvacuum-7.167.3
+incrvacuum incrvacuum-7.168.1
+incrvacuum incrvacuum-7.168.2
+incrvacuum incrvacuum-7.168.3
+incrvacuum incrvacuum-7.169.1
+incrvacuum incrvacuum-7.169.2
+incrvacuum incrvacuum-7.169.3
+incrvacuum incrvacuum-7.170.1
+incrvacuum incrvacuum-7.170.2
+incrvacuum incrvacuum-7.170.3
+incrvacuum incrvacuum-7.171.1
+incrvacuum incrvacuum-7.171.2
+incrvacuum incrvacuum-7.171.3
+incrvacuum incrvacuum-7.172.1
+incrvacuum incrvacuum-7.172.2
+incrvacuum incrvacuum-7.172.3
+incrvacuum incrvacuum-7.173.1
+incrvacuum incrvacuum-7.173.2
+incrvacuum incrvacuum-7.173.3
+incrvacuum incrvacuum-7.174.1
+incrvacuum incrvacuum-7.174.2
+incrvacuum incrvacuum-7.174.3
+incrvacuum incrvacuum-7.175.1
+incrvacuum incrvacuum-7.175.2
+incrvacuum incrvacuum-7.175.3
+incrvacuum incrvacuum-7.176.1
+incrvacuum incrvacuum-7.176.2
+incrvacuum incrvacuum-7.176.3
+incrvacuum incrvacuum-7.177.1
+incrvacuum incrvacuum-7.177.2
+incrvacuum incrvacuum-7.177.3
+incrvacuum incrvacuum-7.178.1
+incrvacuum incrvacuum-7.178.2
+incrvacuum incrvacuum-7.178.3
+incrvacuum incrvacuum-7.179.1
+incrvacuum incrvacuum-7.179.2
+incrvacuum incrvacuum-7.179.3
+incrvacuum incrvacuum-7.180.1
+incrvacuum incrvacuum-7.180.2
+incrvacuum incrvacuum-7.180.3
+incrvacuum incrvacuum-7.181.1
+incrvacuum incrvacuum-7.181.2
+incrvacuum incrvacuum-7.181.3
+incrvacuum incrvacuum-7.182.1
+incrvacuum incrvacuum-7.182.2
+incrvacuum incrvacuum-7.182.3
+incrvacuum incrvacuum-7.183.1
+incrvacuum incrvacuum-7.183.2
+incrvacuum incrvacuum-7.183.3
+incrvacuum incrvacuum-7.184.1
+incrvacuum incrvacuum-7.184.2
+incrvacuum incrvacuum-7.184.3
+incrvacuum incrvacuum-7.185.1
+incrvacuum incrvacuum-7.185.2
+incrvacuum incrvacuum-7.185.3
+incrvacuum incrvacuum-7.186.1
+incrvacuum incrvacuum-7.186.2
+incrvacuum incrvacuum-7.186.3
+incrvacuum incrvacuum-7.187.1
+incrvacuum incrvacuum-7.187.2
+incrvacuum incrvacuum-7.187.3
+incrvacuum incrvacuum-7.188.1
+incrvacuum incrvacuum-7.188.2
+incrvacuum incrvacuum-7.188.3
+incrvacuum incrvacuum-7.189.1
+incrvacuum incrvacuum-7.189.2
+incrvacuum incrvacuum-7.189.3
+incrvacuum incrvacuum-7.190.1
+incrvacuum incrvacuum-7.190.2
+incrvacuum incrvacuum-7.190.3
+incrvacuum incrvacuum-7.191.1
+incrvacuum incrvacuum-7.191.2
+incrvacuum incrvacuum-7.191.3
+incrvacuum incrvacuum-7.192.1
+incrvacuum incrvacuum-7.192.2
+incrvacuum incrvacuum-7.192.3
+incrvacuum incrvacuum-7.193.1
+incrvacuum incrvacuum-7.193.2
+incrvacuum incrvacuum-7.193.3
+incrvacuum incrvacuum-7.194.1
+incrvacuum incrvacuum-7.194.2
+incrvacuum incrvacuum-7.194.3
+incrvacuum incrvacuum-7.195.1
+incrvacuum incrvacuum-7.195.2
+incrvacuum incrvacuum-7.195.3
+incrvacuum incrvacuum-7.196.1
+incrvacuum incrvacuum-7.196.2
+incrvacuum incrvacuum-7.196.3
+incrvacuum incrvacuum-7.197.1
+incrvacuum incrvacuum-7.197.2
+incrvacuum incrvacuum-7.197.3
+incrvacuum incrvacuum-7.198.1
+incrvacuum incrvacuum-7.198.2
+incrvacuum incrvacuum-7.198.3
+incrvacuum incrvacuum-7.199.1
+incrvacuum incrvacuum-7.199.2
+incrvacuum incrvacuum-7.199.3
+incrvacuum incrvacuum-7.200.1
+incrvacuum incrvacuum-7.200.2
+incrvacuum incrvacuum-7.200.3
+incrvacuum incrvacuum-7.201.1
+incrvacuum incrvacuum-7.201.2
+incrvacuum incrvacuum-7.201.3
+incrvacuum incrvacuum-7.202.1
+incrvacuum incrvacuum-7.202.2
+incrvacuum incrvacuum-7.202.3
+incrvacuum incrvacuum-7.203.1
+incrvacuum incrvacuum-7.203.2
+incrvacuum incrvacuum-7.203.3
+incrvacuum incrvacuum-7.204.1
+incrvacuum incrvacuum-7.204.2
+incrvacuum incrvacuum-7.204.3
+incrvacuum incrvacuum-7.205.1
+incrvacuum incrvacuum-7.205.2
+incrvacuum incrvacuum-7.205.3
+incrvacuum incrvacuum-7.206.1
+incrvacuum incrvacuum-7.206.2
+incrvacuum incrvacuum-7.206.3
+incrvacuum incrvacuum-7.207.1
+incrvacuum incrvacuum-7.207.2
+incrvacuum incrvacuum-7.207.3
+incrvacuum incrvacuum-7.208.1
+incrvacuum incrvacuum-7.208.2
+incrvacuum incrvacuum-7.208.3
+incrvacuum incrvacuum-7.209.1
+incrvacuum incrvacuum-7.209.2
+incrvacuum incrvacuum-7.209.3
+incrvacuum incrvacuum-7.210.1
+incrvacuum incrvacuum-7.210.2
+incrvacuum incrvacuum-7.210.3
+incrvacuum incrvacuum-7.211.1
+incrvacuum incrvacuum-7.211.2
+incrvacuum incrvacuum-7.211.3
+incrvacuum incrvacuum-7.212.1
+incrvacuum incrvacuum-7.212.2
+incrvacuum incrvacuum-7.212.3
+incrvacuum incrvacuum-7.213.1
+incrvacuum incrvacuum-7.213.2
+incrvacuum incrvacuum-7.213.3
+incrvacuum incrvacuum-7.214.1
+incrvacuum incrvacuum-7.214.2
+incrvacuum incrvacuum-7.214.3
+incrvacuum incrvacuum-7.215.1
+incrvacuum incrvacuum-7.215.2
+incrvacuum incrvacuum-7.215.3
+incrvacuum incrvacuum-7.216.1
+incrvacuum incrvacuum-7.216.2
+incrvacuum incrvacuum-7.216.3
+incrvacuum incrvacuum-7.217.1
+incrvacuum incrvacuum-7.217.2
+incrvacuum incrvacuum-7.217.3
+incrvacuum incrvacuum-7.218.1
+incrvacuum incrvacuum-7.218.2
+incrvacuum incrvacuum-7.218.3
+incrvacuum incrvacuum-7.219.1
+incrvacuum incrvacuum-7.219.2
+incrvacuum incrvacuum-7.219.3
+incrvacuum incrvacuum-7.220.1
+incrvacuum incrvacuum-7.220.2
+incrvacuum incrvacuum-7.220.3
+incrvacuum incrvacuum-7.221.1
+incrvacuum incrvacuum-7.221.2
+incrvacuum incrvacuum-7.221.3
+incrvacuum incrvacuum-7.222.1
+incrvacuum incrvacuum-7.222.2
+incrvacuum incrvacuum-7.222.3
+incrvacuum incrvacuum-7.223.1
+incrvacuum incrvacuum-7.223.2
+incrvacuum incrvacuum-7.223.3
+incrvacuum incrvacuum-7.224.1
+incrvacuum incrvacuum-7.224.2
+incrvacuum incrvacuum-7.224.3
+incrvacuum incrvacuum-7.225.1
+incrvacuum incrvacuum-7.225.2
+incrvacuum incrvacuum-7.225.3
+incrvacuum incrvacuum-7.226.1
+incrvacuum incrvacuum-7.226.2
+incrvacuum incrvacuum-7.226.3
+incrvacuum incrvacuum-7.227.1
+incrvacuum incrvacuum-7.227.2
+incrvacuum incrvacuum-7.227.3
+incrvacuum incrvacuum-7.228.1
+incrvacuum incrvacuum-7.228.2
+incrvacuum incrvacuum-7.228.3
+incrvacuum incrvacuum-7.229.1
+incrvacuum incrvacuum-7.229.2
+incrvacuum incrvacuum-7.229.3
+incrvacuum incrvacuum-7.230.1
+incrvacuum incrvacuum-7.230.2
+incrvacuum incrvacuum-7.230.3
+incrvacuum incrvacuum-7.231.1
+incrvacuum incrvacuum-7.231.2
+incrvacuum incrvacuum-7.231.3
+incrvacuum incrvacuum-7.232.1
+incrvacuum incrvacuum-7.232.2
+incrvacuum incrvacuum-7.232.3
+incrvacuum incrvacuum-7.233.1
+incrvacuum incrvacuum-7.233.2
+incrvacuum incrvacuum-7.233.3
+incrvacuum incrvacuum-7.234.1
+incrvacuum incrvacuum-7.234.2
+incrvacuum incrvacuum-7.234.3
+incrvacuum incrvacuum-7.235.1
+incrvacuum incrvacuum-7.235.2
+incrvacuum incrvacuum-7.235.3
+incrvacuum incrvacuum-7.236.1
+incrvacuum incrvacuum-7.236.2
+incrvacuum incrvacuum-7.236.3
+incrvacuum incrvacuum-7.237.1
+incrvacuum incrvacuum-7.237.2
+incrvacuum incrvacuum-7.237.3
+incrvacuum incrvacuum-7.238.1
+incrvacuum incrvacuum-7.238.2
+incrvacuum incrvacuum-7.238.3
+incrvacuum incrvacuum-7.239.1
+incrvacuum incrvacuum-7.239.2
+incrvacuum incrvacuum-7.239.3
+incrvacuum incrvacuum-7.240.1
+incrvacuum incrvacuum-7.240.2
+incrvacuum incrvacuum-7.240.3
+incrvacuum incrvacuum-7.241.1
+incrvacuum incrvacuum-7.241.2
+incrvacuum incrvacuum-7.241.3
+incrvacuum incrvacuum-7.242.1
+incrvacuum incrvacuum-7.242.2
+incrvacuum incrvacuum-7.242.3
+incrvacuum incrvacuum-7.243.1
+incrvacuum incrvacuum-7.243.2
+incrvacuum incrvacuum-7.243.3
+incrvacuum incrvacuum-7.244.1
+incrvacuum incrvacuum-7.244.2
+incrvacuum incrvacuum-7.244.3
+incrvacuum incrvacuum-7.245.1
+incrvacuum incrvacuum-7.245.2
+incrvacuum incrvacuum-7.245.3
+incrvacuum incrvacuum-7.246.1
+incrvacuum incrvacuum-7.246.2
+incrvacuum incrvacuum-7.246.3
+incrvacuum incrvacuum-7.247.1
+incrvacuum incrvacuum-7.247.2
+incrvacuum incrvacuum-7.247.3
+incrvacuum incrvacuum-7.248.1
+incrvacuum incrvacuum-7.248.2
+incrvacuum incrvacuum-7.248.3
+incrvacuum incrvacuum-7.249.1
+incrvacuum incrvacuum-7.249.2
+incrvacuum incrvacuum-7.249.3
+incrvacuum incrvacuum-7.250.1
+incrvacuum incrvacuum-7.250.2
+incrvacuum incrvacuum-7.250.3
+incrvacuum incrvacuum-7.251.1
+incrvacuum incrvacuum-7.251.2
+incrvacuum incrvacuum-7.251.3
+incrvacuum incrvacuum-7.252.1
+incrvacuum incrvacuum-7.252.2
+incrvacuum incrvacuum-7.252.3
+incrvacuum incrvacuum-7.253.1
+incrvacuum incrvacuum-7.253.2
+incrvacuum incrvacuum-7.253.3
+incrvacuum incrvacuum-7.254.1
+incrvacuum incrvacuum-7.254.2
+incrvacuum incrvacuum-7.254.3
+incrvacuum incrvacuum-7.255.1
+incrvacuum incrvacuum-7.255.2
+incrvacuum incrvacuum-7.255.3
+incrvacuum incrvacuum-7.256.1
+incrvacuum incrvacuum-7.256.2
+incrvacuum incrvacuum-7.256.3
+incrvacuum incrvacuum-7.257.1
+incrvacuum incrvacuum-7.257.2
+incrvacuum incrvacuum-7.257.3
+incrvacuum incrvacuum-7.258.1
+incrvacuum incrvacuum-7.258.2
+incrvacuum incrvacuum-7.258.3
+incrvacuum incrvacuum-7.259.1
+incrvacuum incrvacuum-7.259.2
+incrvacuum incrvacuum-7.259.3
+incrvacuum incrvacuum-7.260.1
+incrvacuum incrvacuum-7.260.2
+incrvacuum incrvacuum-7.260.3
+incrvacuum incrvacuum-7.261.1
+incrvacuum incrvacuum-7.261.2
+incrvacuum incrvacuum-7.261.3
+incrvacuum incrvacuum-7.262.1
+incrvacuum incrvacuum-7.262.2
+incrvacuum incrvacuum-7.262.3
+incrvacuum incrvacuum-7.263.1
+incrvacuum incrvacuum-7.263.2
+incrvacuum incrvacuum-7.263.3
+incrvacuum incrvacuum-7.264.1
+incrvacuum incrvacuum-7.264.2
+incrvacuum incrvacuum-7.264.3
+incrvacuum incrvacuum-7.265.1
+incrvacuum incrvacuum-7.265.2
+incrvacuum incrvacuum-7.265.3
+incrvacuum incrvacuum-7.266.1
+incrvacuum incrvacuum-7.266.2
+incrvacuum incrvacuum-7.266.3
+incrvacuum incrvacuum-7.267.1
+incrvacuum incrvacuum-7.267.2
+incrvacuum incrvacuum-7.267.3
+incrvacuum incrvacuum-7.268.1
+incrvacuum incrvacuum-7.268.2
+incrvacuum incrvacuum-7.268.3
+incrvacuum incrvacuum-7.269.1
+incrvacuum incrvacuum-7.269.2
+incrvacuum incrvacuum-7.269.3
+incrvacuum incrvacuum-7.270.1
+incrvacuum incrvacuum-7.270.2
+incrvacuum incrvacuum-7.270.3
+incrvacuum incrvacuum-7.271.1
+incrvacuum incrvacuum-7.271.2
+incrvacuum incrvacuum-7.271.3
+incrvacuum incrvacuum-7.272.1
+incrvacuum incrvacuum-7.272.2
+incrvacuum incrvacuum-7.272.3
+incrvacuum incrvacuum-7.273.1
+incrvacuum incrvacuum-7.273.2
+incrvacuum incrvacuum-7.273.3
+incrvacuum incrvacuum-7.274.1
+incrvacuum incrvacuum-7.274.2
+incrvacuum incrvacuum-7.274.3
+incrvacuum incrvacuum-7.275.1
+incrvacuum incrvacuum-7.275.2
+incrvacuum incrvacuum-7.275.3
+incrvacuum incrvacuum-7.276.1
+incrvacuum incrvacuum-7.276.2
+incrvacuum incrvacuum-7.276.3
+incrvacuum incrvacuum-7.277.1
+incrvacuum incrvacuum-7.277.2
+incrvacuum incrvacuum-7.277.3
+incrvacuum incrvacuum-7.278.1
+incrvacuum incrvacuum-7.278.2
+incrvacuum incrvacuum-7.278.3
+incrvacuum incrvacuum-7.279.1
+incrvacuum incrvacuum-7.279.2
+incrvacuum incrvacuum-7.279.3
+incrvacuum incrvacuum-7.280.1
+incrvacuum incrvacuum-7.280.2
+incrvacuum incrvacuum-7.280.3
+incrvacuum incrvacuum-7.281.1
+incrvacuum incrvacuum-7.281.2
+incrvacuum incrvacuum-7.281.3
+incrvacuum incrvacuum-7.282.1
+incrvacuum incrvacuum-7.282.2
+incrvacuum incrvacuum-7.282.3
+incrvacuum incrvacuum-7.283.1
+incrvacuum incrvacuum-7.283.2
+incrvacuum incrvacuum-7.283.3
+incrvacuum incrvacuum-7.284.1
+incrvacuum incrvacuum-7.284.2
+incrvacuum incrvacuum-7.284.3
+incrvacuum incrvacuum-7.285.1
+incrvacuum incrvacuum-7.285.2
+incrvacuum incrvacuum-7.285.3
+incrvacuum incrvacuum-7.286.1
+incrvacuum incrvacuum-7.286.2
+incrvacuum incrvacuum-7.286.3
+incrvacuum incrvacuum-7.287.1
+incrvacuum incrvacuum-7.287.2
+incrvacuum incrvacuum-7.287.3
+incrvacuum incrvacuum-7.288.1
+incrvacuum incrvacuum-7.288.2
+incrvacuum incrvacuum-7.288.3
+incrvacuum incrvacuum-7.289.1
+incrvacuum incrvacuum-7.289.2
+incrvacuum incrvacuum-7.289.3
+incrvacuum incrvacuum-7.290.1
+incrvacuum incrvacuum-7.290.2
+incrvacuum incrvacuum-7.290.3
+incrvacuum incrvacuum-7.291.1
+incrvacuum incrvacuum-7.291.2
+incrvacuum incrvacuum-7.291.3
+incrvacuum incrvacuum-7.292.1
+incrvacuum incrvacuum-7.292.2
+incrvacuum incrvacuum-7.292.3
+incrvacuum incrvacuum-7.293.1
+incrvacuum incrvacuum-7.293.2
+incrvacuum incrvacuum-7.293.3
+incrvacuum incrvacuum-7.294.1
+incrvacuum incrvacuum-7.294.2
+incrvacuum incrvacuum-7.294.3
+incrvacuum incrvacuum-7.295.1
+incrvacuum incrvacuum-7.295.2
+incrvacuum incrvacuum-7.295.3
+incrvacuum incrvacuum-7.296.1
+incrvacuum incrvacuum-7.296.2
+incrvacuum incrvacuum-7.296.3
+incrvacuum incrvacuum-7.297.1
+incrvacuum incrvacuum-7.297.2
+incrvacuum incrvacuum-7.297.3
+incrvacuum incrvacuum-7.298.1
+incrvacuum incrvacuum-7.298.2
+incrvacuum incrvacuum-7.298.3
+incrvacuum incrvacuum-7.299.1
+incrvacuum incrvacuum-7.299.2
+incrvacuum incrvacuum-7.299.3
+incrvacuum incrvacuum-7.300.1
+incrvacuum incrvacuum-7.300.2
+incrvacuum incrvacuum-7.300.3
+incrvacuum incrvacuum-7.301.1
+incrvacuum incrvacuum-7.301.2
+incrvacuum incrvacuum-7.301.3
+incrvacuum incrvacuum-7.302.1
+incrvacuum incrvacuum-7.302.2
+incrvacuum incrvacuum-7.302.3
+incrvacuum incrvacuum-7.303.1
+incrvacuum incrvacuum-7.303.2
+incrvacuum incrvacuum-7.303.3
+incrvacuum incrvacuum-7.304.1
+incrvacuum incrvacuum-7.304.2
+incrvacuum incrvacuum-7.304.3
+incrvacuum incrvacuum-7.305.1
+incrvacuum incrvacuum-7.305.2
+incrvacuum incrvacuum-7.305.3
+incrvacuum incrvacuum-7.306.1
+incrvacuum incrvacuum-7.306.2
+incrvacuum incrvacuum-7.306.3
+incrvacuum incrvacuum-7.307.1
+incrvacuum incrvacuum-7.307.2
+incrvacuum incrvacuum-7.307.3
+incrvacuum incrvacuum-7.308.1
+incrvacuum incrvacuum-7.308.2
+incrvacuum incrvacuum-7.308.3
+incrvacuum incrvacuum-7.309.1
+incrvacuum incrvacuum-7.309.2
+incrvacuum incrvacuum-7.309.3
+incrvacuum incrvacuum-7.310.1
+incrvacuum incrvacuum-7.310.2
+incrvacuum incrvacuum-7.310.3
+incrvacuum incrvacuum-7.311.1
+incrvacuum incrvacuum-7.311.2
+incrvacuum incrvacuum-7.311.3
+incrvacuum incrvacuum-7.312.1
+incrvacuum incrvacuum-7.312.2
+incrvacuum incrvacuum-7.312.3
+incrvacuum incrvacuum-7.313.1
+incrvacuum incrvacuum-7.313.2
+incrvacuum incrvacuum-7.313.3
+incrvacuum incrvacuum-7.314.1
+incrvacuum incrvacuum-7.314.2
+incrvacuum incrvacuum-7.314.3
+incrvacuum incrvacuum-7.315.1
+incrvacuum incrvacuum-7.315.2
+incrvacuum incrvacuum-7.315.3
+incrvacuum incrvacuum-7.316.1
+incrvacuum incrvacuum-7.316.2
+incrvacuum incrvacuum-7.316.3
+incrvacuum incrvacuum-7.317.1
+incrvacuum incrvacuum-7.317.2
+incrvacuum incrvacuum-7.317.3
+incrvacuum incrvacuum-7.318.1
+incrvacuum incrvacuum-7.318.2
+incrvacuum incrvacuum-7.318.3
+incrvacuum incrvacuum-7.319.1
+incrvacuum incrvacuum-7.319.2
+incrvacuum incrvacuum-7.319.3
+
+# incrvacuum2: PRAGMA incremental_vacuum is a no-op on prolly storage (no
+# freelist), so post-vacuum file-size shrink expectations differ, and the
+# wal-mode subtests read a test.db-wal sidecar that doltlite never creates
+# (chunk WAL is internal).
+incrvacuum2 incrvacuum2-1.1  # file size: no shrink from incremental_vacuum
+incrvacuum2 incrvacuum2-1.2  # file size
+incrvacuum2 incrvacuum2-1.3  # file size
+incrvacuum2 incrvacuum2-1.4  # file size
+incrvacuum2 incrvacuum2-2.1  # file size
+incrvacuum2 incrvacuum2-2.2  # file size
+incrvacuum2 incrvacuum2-2.3  # file size
+incrvacuum2 incrvacuum2-2.4  # file size
+incrvacuum2 incrvacuum2-2.5  # file size
+incrvacuum2 incrvacuum2-2.6  # file size
+incrvacuum2 incrvacuum2-4.2.1  # reads test.db-wal sidecar that doltlite never creates
+incrvacuum2 incrvacuum2-4.3  # -wal sidecar absent
+
+# ioerr: doltlite VACUUM maps to dolt_gc. Under DOLTLITE_PROLLY_CHECK (the
+# CI testfixture build) gc runs a post-sweep session-resolvability check
+# that re-reads chunks and deliberately treats injected IO faults as
+# inconclusive (only NOTFOUND aborts), so the final fault points record a
+# hit while the VACUUM statement still succeeds. A non-CHECK build passes
+# these three.
+ioerr ioerr-2.31.3  # PROLLY_CHECK gc verify ignores injected read faults
+ioerr ioerr-2.32.3  # PROLLY_CHECK gc verify ignores injected read faults
+ioerr ioerr-2.33.3  # PROLLY_CHECK gc verify ignores injected read faults
+# ioerr: the chunk store journals inside the single database file, so a
+# -journal sidecar never exists. Preps that crash a child on journal sync
+# (ioerr-6) or copy the journal aside (ioerr-7/9) fail before fault
+# injection starts; recovery itself passes once the prep error clears.
+ioerr ioerr-6.1.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.2.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.3.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.4.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.5.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.6.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.7.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.8.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.9.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.10.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.11.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.12.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.13.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.14.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.15.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.16.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.17.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.18.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.19.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.20.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.21.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.22.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.23.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.24.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.25.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.26.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.27.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.28.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.29.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.30.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.31.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.32.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.33.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.34.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.35.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.36.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.37.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.38.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.39.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.40.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.41.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.42.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.43.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.44.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.45.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.46.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.47.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.48.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.49.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.50.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.51.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.52.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.53.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.54.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.55.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.56.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.57.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.58.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.59.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.60.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.61.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.62.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.63.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.64.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.65.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.66.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.67.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.68.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.69.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.70.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.71.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.72.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.73.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.74.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.75.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.76.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.77.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.78.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.79.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.80.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.81.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.82.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.83.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.84.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.85.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.86.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.87.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.88.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.89.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.90.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.91.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.92.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.93.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.94.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-6.95.1  # crashsql trigger on absent -journal never fires
+ioerr ioerr-7.2.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.3.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.4.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.5.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.6.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.7.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.8.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.9.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.10.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.11.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.12.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.13.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.14.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.15.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.16.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.17.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.18.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.19.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.20.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.21.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.22.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.23.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.24.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.25.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.26.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.27.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.28.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.29.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.30.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.31.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.32.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.33.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.34.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.35.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.36.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.37.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.38.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.39.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.40.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.41.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.42.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.43.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.44.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.45.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.46.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.47.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.48.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.49.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.50.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.51.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.52.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.53.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.54.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-7.55.1  # hot-journal prep copies absent -journal sidecar
+ioerr ioerr-9.1.1  # master-journal prep copies absent -journal sidecar
+
+# ioerr4: PRAGMA auto_vacuum=INCREMENTAL is a silent no-op on doltlite
+# format (read-back 0, not 2), and the chunk store has no page freelist,
+# so freelist_count stays 0 after the mass DELETE instead of 64.
+ioerr4 ioerr4-1.3  # auto_vacuum no-op reads back 0
+ioerr4 ioerr4-1.6  # no page freelist; freelist_count always 0
+
+# jrnlmode — doltlite-format databases do not expose SQLite's journal-mode
+# switching: the default mode reports as the chunk WAL ('wal' where stock
+# says 'delete'), PRAGMA journal_mode=<x> errors with "journal_mode is not
+# configurable on doltlite-format databases", and journal_size_limit /
+# sidecar-size probes cascade from that.
+jrnlmode jrnlmode-1.0
+jrnlmode jrnlmode-1.1
+jrnlmode jrnlmode-1.2
+jrnlmode jrnlmode-1.4a
+jrnlmode jrnlmode-1.4b
+jrnlmode jrnlmode-1.5
+jrnlmode jrnlmode-1.6
+jrnlmode jrnlmode-1.7
+jrnlmode jrnlmode-1.7.1
+jrnlmode jrnlmode-1.7.2
+jrnlmode jrnlmode-1.8
+jrnlmode jrnlmode-1.9
+jrnlmode jrnlmode-1.10
+jrnlmode jrnlmode-1.11
+jrnlmode jrnlmode-1.12
+jrnlmode jrnlmode-1.13
+jrnlmode jrnlmode-1.14
+jrnlmode jrnlmode-1.15
+jrnlmode jrnlmode-1.16
+jrnlmode jrnlmode-1.99
+jrnlmode jrnlmode-2.1
+jrnlmode jrnlmode-2.2
+jrnlmode jrnlmode-2.3
+jrnlmode jrnlmode-2.4
+jrnlmode jrnlmode-2.5
+jrnlmode jrnlmode-3.2
+jrnlmode jrnlmode-4.1
+jrnlmode jrnlmode-4.2
+jrnlmode jrnlmode-5.1
+jrnlmode jrnlmode-5.3
+jrnlmode jrnlmode-5.4.1
+jrnlmode jrnlmode-5.4.2
+jrnlmode jrnlmode-5.5
+jrnlmode jrnlmode-5.6
+jrnlmode jrnlmode-5.7
+jrnlmode jrnlmode-5.8
+jrnlmode jrnlmode-5.10
+jrnlmode jrnlmode-5.11
+jrnlmode jrnlmode-5.12
+jrnlmode jrnlmode-5.13
+jrnlmode jrnlmode-5.14
+jrnlmode jrnlmode-5.15
+jrnlmode jrnlmode-5.16
+jrnlmode jrnlmode-5.17
+jrnlmode jrnlmode-5.18
+jrnlmode jrnlmode-5.19
+jrnlmode jrnlmode-5.20
+jrnlmode jrnlmode-5.21
+jrnlmode jrnlmode-5.22
+jrnlmode jrnlmode-6.1
+jrnlmode jrnlmode-6.2
+jrnlmode jrnlmode-6.3
+jrnlmode jrnlmode-6.4
+jrnlmode jrnlmode-6.5
+jrnlmode jrnlmode-6.7
+jrnlmode jrnlmode-6.9
+jrnlmode jrnlmode-7.1
+jrnlmode jrnlmode-7.2
+jrnlmode jrnlmode-8.5
+jrnlmode jrnlmode-8.6
+jrnlmode jrnlmode-8.7
+jrnlmode jrnlmode-8.8
+jrnlmode jrnlmode-8.13
+jrnlmode jrnlmode-8.14
+jrnlmode jrnlmode-8.15
+jrnlmode jrnlmode-8.16
+jrnlmode jrnlmode-8.17
+jrnlmode jrnlmode-8.21
+jrnlmode jrnlmode-8.23
+jrnlmode jrnlmode-8.24
+jrnlmode jrnlmode-8.28
+jrnlmode jrnlmode-8.30
+jrnlmode jrnlmode-9.1
+jrnlmode jrnlmode-9.2
+
+# ── mmap1 ──
+# prollyBtreeSetMmapLimit is a no-op (the chunk-store pager never maps the
+# file), so PRAGMA mmap_size reads back 0 and mmap'd-page statistics stay
+# 0; PRAGMA page_count reflects chunk pages, not stock page images; the
+# .5 subtests read btree_pager_stats(read), instrumentation the chunk
+# store doesn't feed. count(*)/integrity_check pass throughout.
+mmap1 mmap1-1.1.1.1  # page_count: chunk-page accounting
+mmap1 mmap1-1.1.1.2  # page_count: chunk-page accounting
+mmap1 mmap1-1.1.1.3  # page_count: chunk-page accounting
+mmap1 mmap1-1.1.1.4  # page_count: chunk-page accounting
+mmap1 mmap1-1.1.1.5  # nRead pager-stats instrumentation
+mmap1 mmap1-1.1.2.1  # page_count: chunk-page accounting
+mmap1 mmap1-1.1.2.2  # page_count: chunk-page accounting
+mmap1 mmap1-1.1.2.3  # page_count: chunk-page accounting
+mmap1 mmap1-1.1.2.4  # page_count: chunk-page accounting
+mmap1 mmap1-1.1.2.5  # nRead pager-stats instrumentation
+mmap1 mmap1-1.2.1.1  # page_count: chunk-page accounting
+mmap1 mmap1-1.2.1.2  # page_count: chunk-page accounting
+mmap1 mmap1-1.2.1.3  # page_count: chunk-page accounting
+mmap1 mmap1-1.2.1.4  # page_count: chunk-page accounting
+mmap1 mmap1-1.2.1.5  # nRead pager-stats instrumentation
+mmap1 mmap1-1.2.2.1  # page_count: chunk-page accounting
+mmap1 mmap1-1.2.2.2  # page_count: chunk-page accounting
+mmap1 mmap1-1.2.2.3  # page_count: chunk-page accounting
+mmap1 mmap1-1.2.2.4  # page_count: chunk-page accounting
+mmap1 mmap1-1.2.2.5  # nRead pager-stats instrumentation
+mmap1 mmap1-1.3.1.1  # page_count: chunk-page accounting
+mmap1 mmap1-1.3.1.2  # page_count: chunk-page accounting
+mmap1 mmap1-1.3.1.3  # page_count: chunk-page accounting
+mmap1 mmap1-1.3.1.4  # page_count: chunk-page accounting
+mmap1 mmap1-1.3.1.5  # nRead pager-stats instrumentation
+mmap1 mmap1-1.3.2.1  # page_count: chunk-page accounting
+mmap1 mmap1-1.3.2.2  # page_count: chunk-page accounting
+mmap1 mmap1-1.3.2.3  # page_count: chunk-page accounting
+mmap1 mmap1-1.3.2.4  # page_count: chunk-page accounting
+mmap1 mmap1-1.3.2.5  # nRead pager-stats instrumentation
+mmap1 mmap1-1.4.1.1  # page_count: chunk-page accounting
+mmap1 mmap1-1.4.1.2  # page_count: chunk-page accounting
+mmap1 mmap1-1.4.1.3  # page_count: chunk-page accounting
+mmap1 mmap1-1.4.1.4  # page_count: chunk-page accounting
+mmap1 mmap1-1.4.1.5  # nRead pager-stats instrumentation
+mmap1 mmap1-1.4.2.1  # page_count: chunk-page accounting
+mmap1 mmap1-1.4.2.2  # page_count: chunk-page accounting
+mmap1 mmap1-1.4.2.3  # page_count: chunk-page accounting
+mmap1 mmap1-1.4.2.4  # page_count: chunk-page accounting
+mmap1 mmap1-1.4.2.5  # nRead pager-stats instrumentation
+mmap1 mmap1-1.5.1.1  # page_count: chunk-page accounting
+mmap1 mmap1-1.5.1.2  # page_count: chunk-page accounting
+mmap1 mmap1-1.5.1.3  # page_count: chunk-page accounting
+mmap1 mmap1-1.5.1.4  # page_count: chunk-page accounting
+mmap1 mmap1-1.5.1.5  # nRead pager-stats instrumentation
+mmap1 mmap1-1.5.2.1  # page_count: chunk-page accounting
+mmap1 mmap1-1.5.2.2  # page_count: chunk-page accounting
+mmap1 mmap1-1.5.2.3  # page_count: chunk-page accounting
+mmap1 mmap1-1.5.2.4  # page_count: chunk-page accounting
+mmap1 mmap1-1.5.2.5  # nRead pager-stats instrumentation
+mmap1 mmap1-1.6.1.1  # page_count: chunk-page accounting
+mmap1 mmap1-1.6.1.2  # page_count: chunk-page accounting
+mmap1 mmap1-1.6.1.3  # page_count: chunk-page accounting
+mmap1 mmap1-1.6.1.4  # page_count: chunk-page accounting
+mmap1 mmap1-1.6.1.5  # nRead pager-stats instrumentation
+mmap1 mmap1-1.6.2.1  # page_count: chunk-page accounting
+mmap1 mmap1-1.6.2.2  # page_count: chunk-page accounting
+mmap1 mmap1-1.6.2.3  # page_count: chunk-page accounting
+mmap1 mmap1-1.6.2.4  # page_count: chunk-page accounting
+mmap1 mmap1-1.6.2.5  # nRead pager-stats instrumentation
+mmap1 mmap1-2.1  # mmap_size reads back 0 / mmap stats 0
+mmap1 mmap1-2.2  # mmap_size reads back 0 / mmap stats 0
+mmap1 mmap1-2.4  # page_count: chunk-page accounting
+mmap1 mmap1-5.1  # auto_vacuum reads back 0 (row data matches)
+mmap1 mmap1-6.2  # mmap_size reads back 0 / mmap stats 0
+
+# multiplex VFS over a chunk store: journal_mode is not configurable on
+# doltlite-format databases (dominant failure: the multiplex tests set
+# journal_mode=delete/truncate per cycle), multiplex chunk-boundary and
+# size/journal-shape expectations differ, and 1.9.2 surfaces residual
+# SQLITE_MISUSE warnings from the wrapper open path. The native
+# initialized-wrapper contract is covered by doltlite_recover_vfs_wrappers.
+multiplex multiplex-1.9.2
+multiplex multiplex-2.1.2
+multiplex multiplex-2.1.3
+multiplex multiplex-2.1.4
+multiplex multiplex-2.2.1
+multiplex multiplex-2.2.3
+multiplex multiplex-2.4.2
+multiplex multiplex-2.4.4
+multiplex multiplex-2.5.2
+multiplex multiplex-2.5.3
+multiplex multiplex-2.5.4
+multiplex multiplex-2.5.5
+multiplex multiplex-2.5.6
+multiplex multiplex-2.5.7
+multiplex multiplex-2.5.8
+multiplex multiplex-2.5.9
+multiplex multiplex-2.5.10
+multiplex multiplex-2.5.11
+multiplex multiplex-2.5.12
+multiplex multiplex-2.6.2.151.delete
+multiplex multiplex-2.6.2.570.delete
+multiplex multiplex-2.6.2.989.delete
+multiplex multiplex-2.6.2.1408.delete
+multiplex multiplex-2.6.2.1827.delete
+multiplex multiplex-2.6.2.2246.delete
+multiplex multiplex-2.6.2.2665.delete
+multiplex multiplex-2.6.2.3084.delete
+multiplex multiplex-2.6.2.3503.delete
+multiplex multiplex-2.6.2.3922.delete
+multiplex multiplex-2.6.2.4341.delete
+multiplex multiplex-2.6.2.4760.delete
+multiplex multiplex-2.6.2.5179.delete
+multiplex multiplex-2.6.2.5598.delete
+multiplex multiplex-2.6.2.6017.delete
+multiplex multiplex-2.6.2.6436.delete
+multiplex multiplex-2.6.2.6855.delete
+multiplex multiplex-2.6.2.7274.delete
+multiplex multiplex-2.6.2.7693.delete
+multiplex multiplex-2.6.2.151.persist
+multiplex multiplex-2.6.2.570.persist
+multiplex multiplex-2.6.2.989.persist
+multiplex multiplex-2.6.2.1408.persist
+multiplex multiplex-2.6.2.1827.persist
+multiplex multiplex-2.6.2.2246.persist
+multiplex multiplex-2.6.2.2665.persist
+multiplex multiplex-2.6.2.3084.persist
+multiplex multiplex-2.6.2.3503.persist
+multiplex multiplex-2.6.2.3922.persist
+multiplex multiplex-2.6.2.4341.persist
+multiplex multiplex-2.6.2.4760.persist
+multiplex multiplex-2.6.2.5179.persist
+multiplex multiplex-2.6.2.5598.persist
+multiplex multiplex-2.6.2.6017.persist
+multiplex multiplex-2.6.2.6436.persist
+multiplex multiplex-2.6.2.6855.persist
+multiplex multiplex-2.6.2.7274.persist
+multiplex multiplex-2.6.2.7693.persist
+multiplex multiplex-2.6.2.151.truncate
+multiplex multiplex-2.6.2.570.truncate
+multiplex multiplex-2.6.2.989.truncate
+multiplex multiplex-2.6.2.1408.truncate
+multiplex multiplex-2.6.2.1827.truncate
+multiplex multiplex-2.6.2.2246.truncate
+multiplex multiplex-2.6.2.2665.truncate
+multiplex multiplex-2.6.2.3084.truncate
+multiplex multiplex-2.6.2.3503.truncate
+multiplex multiplex-2.6.2.3922.truncate
+multiplex multiplex-2.6.2.4341.truncate
+multiplex multiplex-2.6.2.4760.truncate
+multiplex multiplex-2.6.2.5179.truncate
+multiplex multiplex-2.6.2.5598.truncate
+multiplex multiplex-2.6.2.6017.truncate
+multiplex multiplex-2.6.2.6436.truncate
+multiplex multiplex-2.6.2.6855.truncate
+multiplex multiplex-2.6.2.7274.truncate
+multiplex multiplex-2.6.2.7693.truncate
+multiplex multiplex-2.6.2.151.memory
+multiplex multiplex-2.6.2.570.memory
+multiplex multiplex-2.6.2.989.memory
+multiplex multiplex-2.6.2.1408.memory
+multiplex multiplex-2.6.2.1827.memory
+multiplex multiplex-2.6.2.2246.memory
+multiplex multiplex-2.6.2.2665.memory
+multiplex multiplex-2.6.2.3084.memory
+multiplex multiplex-2.6.2.3503.memory
+multiplex multiplex-2.6.2.3922.memory
+multiplex multiplex-2.6.2.4341.memory
+multiplex multiplex-2.6.2.4760.memory
+multiplex multiplex-2.6.2.5179.memory
+multiplex multiplex-2.6.2.5598.memory
+multiplex multiplex-2.6.2.6017.memory
+multiplex multiplex-2.6.2.6436.memory
+multiplex multiplex-2.6.2.6855.memory
+multiplex multiplex-2.6.2.7274.memory
+multiplex multiplex-2.6.2.7693.memory
+multiplex multiplex-2.6.2.151.off
+multiplex multiplex-2.6.2.570.off
+multiplex multiplex-2.6.2.989.off
+multiplex multiplex-2.6.2.1408.off
+multiplex multiplex-2.6.2.1827.off
+multiplex multiplex-2.6.2.2246.off
+multiplex multiplex-2.6.2.2665.off
+multiplex multiplex-2.6.2.3084.off
+multiplex multiplex-2.6.2.3503.off
+multiplex multiplex-2.6.2.3922.off
+multiplex multiplex-2.6.2.4341.off
+multiplex multiplex-2.6.2.4760.off
+multiplex multiplex-2.6.2.5179.off
+multiplex multiplex-2.6.2.5598.off
+multiplex multiplex-2.6.2.6017.off
+multiplex multiplex-2.6.2.6436.off
+multiplex multiplex-2.6.2.6855.off
+multiplex multiplex-2.6.2.7274.off
+multiplex multiplex-2.6.2.7693.off
+multiplex multiplex-2.7.3
+multiplex multiplex-3.1.2
+multiplex multiplex-3.2.1a
+multiplex multiplex-3.2.2
+multiplex multiplex-3.2.3
+multiplex multiplex-3.2.4
+multiplex multiplex-3.2.5
+multiplex multiplex-3.2.6
+multiplex multiplex-3.2.7
+multiplex multiplex-3.2.8
+multiplex multiplex-3.2.9
+multiplex multiplex-3.3.1
+multiplex multiplex-6.1.0
+multiplex multiplex-6.2.1
+multiplex multiplex-6.2.2
+
+# pragma4: doltlite stores non-INTEGER-PK tables PK-keyed (WITHOUT
+# ROWID-equivalent), so PRAGMA table_list reports wr=1 for them.
+pragma4 pragma4-6.2
+
+# quota-VFS byte thresholds trip at chunk-store file sizes, not stock
+# page-file sizes, and the journal_mode pragma the suite issues errors
+# ("journal_mode is not configurable on doltlite-format databases"),
+# cascading into "no such table: t1" for the rest of the batch. The
+# native wrapper contract is covered by doltlite_recover_vfs_wrappers.
+quota quota-2.1.2
+quota quota-2.1.3
+quota quota-2.1.4
+quota quota-2.1.5
+quota quota-2.2.1
+quota quota-2.2.2
+quota quota-2.2.3
+quota quota-2.4.2
+quota quota-2.4.3
+quota quota-2.4.4
+quota quota-3.1.2
+quota quota-3.1.4
+quota quota-3.1.5
+quota quota-3.2.1
+quota quota-3.2.2
+quota quota-3.2.3
+quota quota-3.2.4
+quota quota-3.2.5
+quota quota-3.2.6
+quota quota-3.2.7
+quota quota-3.2.8
+quota quota-3.2.9
+quota quota-3.3.1
+
+# PRAGMA lock_status expects stock rollback-journal RESERVED locks. DoltLite's
+# prolly storage does not expose those pager locks, so writes stay "unlocked".
+savepoint savepoint-3.2
+savepoint savepoint-3.3
+savepoint savepoint-3.4
+
+# Second connection read locks do not block DoltLite savepoint release the way
+# stock rollback-journal pager locks do; savepoint-5.4.4 is the follow-on after
+# RELEASE succeeds instead of returning "database is locked".
+savepoint savepoint-5.4.3
+savepoint savepoint-5.4.4
+
+# auto_vacuum=incremental is accepted as a no-op and the section's workload
+# completes with data intact, but savepoint-7.1 asserts PRAGMA page_count > 20 —
+# stock 1024-byte-pager file-growth instrumentation. DoltLite reports a fixed
+# 4096-byte page_size with page_count derived from the chunk-format file
+# (reproduced: page_count 15, 11 rows intact, auto_vacuum reads back 0).
+savepoint savepoint-7.1
+
+# ATTACH + savepoint data operations pass; the remaining 10.2.* labels are
+# PRAGMA lock_status assertions expecting stock RESERVED pager locks on the
+# main/attached page files mid-transaction. DoltLite reports "unlocked".
+savepoint savepoint-10.2.3
+savepoint savepoint-10.2.4
+savepoint savepoint-10.2.5
+savepoint savepoint-10.2.8
+
+# savepoint-11.8 asserts `file size test.db` == 8192 after wal_checkpoint, a
+# stock page-format size; the doltlite chunk-format file is 5354 bytes. The
+# rollback/data assertions around it (11.2-11.7, 11.9-11.10) pass.
+savepoint savepoint-11.8
+
+# journal_mode=off is not configurable for DoltLite-format databases.
+savepoint savepoint-13.1
+
+# Multi-client tests that assert stock rollback-journal lock failures.
+# DoltLite lets the write/release complete, so the following rollback/transaction
+# labels see different savepoint state.
+savepoint savepoint-14.1.2
+savepoint savepoint-14.1.3
+savepoint savepoint-14.1.4
+savepoint savepoint-14.1.5
+savepoint savepoint-14.1.6
+savepoint savepoint-14.2.2
+savepoint savepoint-14.2.3
+savepoint savepoint-14.2.4
+savepoint savepoint-14.2.5
+savepoint savepoint-14.2.6
+savepoint savepoint-15.1.2
+savepoint savepoint-15.1.3
+savepoint savepoint-15.2.2
+savepoint savepoint-15.2.3
+
+# ── savepoint6 ──
+# REAL BUG (#1414), not an intentional divergence: a write under two
+# savepoints collapsed by one RELEASE of the middle name, followed by a
+# new savepoint and a write with no intervening read, makes ROLLBACK TO
+# restore a stale pre-DELETE state (deleted row resurrected); under the
+# file's continued random load the connection then throws 'database disk
+# image is malformed'. First divergence at savepoint6-normal.997.1,
+# deterministic 3/3; everything from there is the same root cause
+# cascading through the shared shadow-array harness until the tester's
+# 1000-error cap aborts the file. Remove this whole block when #1414 is
+# fixed.
+
+# shared3: shared-cache cache_size cross-connection visibility (2.4) and pager
+# exclusive-lock "database is locked" on cache spill (2.8) — doltlite's MVCC
+# lock model takes no page-level exclusive lock. Row outcomes match stock.
+shared3 shared3-2.4
+shared3 shared3-2.8
+
+# ── vacuum ──
+# VACUUM on doltlite format runs the chunk-store GC (dolt_gc) instead of
+# rebuilding page images, so stock page-layout side effects don't apply.
+vacuum vacuum-5.1    # INSERT NULL into `int primary key` errors: doltlite PK tables enforce NOT NULL where stock's rowid-table quirk allows it
+vacuum vacuum-7.1    # PRAGMA freelist_count is 0 — no freelist on a chunk store
+vacuum vacuum-7.6    # PRAGMA auto_vacuum reads back 0 after set (accepted as no-op, mode not persisted)
+
+# ── vacuum2 ──
+# VACUUM on doltlite format runs the chunk-store GC instead of a page
+# rebuild, and the file is a content-addressed chunk store: stock page-1
+# header reads, file-size/page-count arithmetic, and the
+# in-progress-statement VACUUM error path all diverge.
+vacuum2 vacuum2-2.1   # hexio read of page-1 change counter (offset 24) — no stock header in a chunk file
+vacuum2 vacuum2-2.2   # same header-poke arithmetic
+vacuum2 vacuum2-3.1   # file size / page_size expectation
+vacuum2 vacuum2-3.3   # file size / page_size expectation
+vacuum2 vacuum2-3.13  # file size / page_size expectation
+vacuum2 vacuum2-4.2   # auto_vacuum reads back 0 (no-op, not persisted)
+vacuum2 vacuum2-4.4   # auto_vacuum reads back 0
+vacuum2 vacuum2-4.5   # auto_vacuum reads back 0
+vacuum2 vacuum2-4.7   # auto_vacuum reads back 0
+vacuum2 vacuum2-5.2   # "cannot VACUUM - SQL statements in progress" never raised (gc path skips the nVdbeActive check)
+vacuum2 vacuum2-5.3   # error path
+vacuum2 vacuum2-5.4   # error path
+vacuum2 vacuum2-6.0   # PRIMARY KEY with custom collation rejected: "doltlite does not support indexes with custom collation 'cmp'"
+
+# ── vacuum3 ──
+# vacuum3 changes database page size via VACUUM. doltlite VACUUM runs the
+# chunk-store GC, never a page-size rebuild, and [file size] is chunk payload, so every file-size
+# expectation differs. On the :memory: db (5.2) PRAGMA page_size reads
+# back the requested value where stock retains the original (a memdb
+# can't be rebuilt). The do_ioerr_test .31-.33 step-3 failures are injected errors that
+# land on gc-finalization IO ops the GC deliberately treats as
+# best-effort (gcRewriteFile's stale-tmp delete is explicitly
+# "must not fail the GC"; post-replace cleanup likewise): the error is
+# consumed but the statement succeeds, failing the harness's hit/fail
+# parity check. The follow-up cksum/integrity steps (.4/.6) pass, so no
+# data is lost; verified by direct probe (errors at earlier indexes
+# surface properly as "gc sweep phase failed").
+vacuum3 vacuum3-1.3  # file size = chunk payload
+vacuum3 vacuum3-1.4.2  # file size = chunk payload
+vacuum3 vacuum3-1.5.2  # file size = chunk payload
+vacuum3 vacuum3-1.6.2  # file size = chunk payload
+vacuum3 vacuum3-1.7.2  # file size = chunk payload
+vacuum3 vacuum3-1.8.2  # file size = chunk payload
+vacuum3 vacuum3-1.9.2  # file size = chunk payload
+vacuum3 vacuum3-1.10.2  # file size = chunk payload
+vacuum3 vacuum3-2.1  # file size = chunk payload
+vacuum3 vacuum3-2.4.2  # file size = chunk payload
+vacuum3 vacuum3-2.5.2  # file size = chunk payload
+vacuum3 vacuum3-2.6.2  # file size = chunk payload
+vacuum3 vacuum3-2.7.2  # file size = chunk payload
+vacuum3 vacuum3-2.8.2  # file size = chunk payload
+vacuum3 vacuum3-2.9.2  # file size = chunk payload
+vacuum3 vacuum3-2.10.2  # file size = chunk payload
+vacuum3 vacuum3-5.2  # memdb page_size read-back after VACUUM (no rebuild)
+vacuum3 vacuum3-ioerr-1.31.3  # injected error consumed by best-effort gc finalization; parity check fails, data intact
+vacuum3 vacuum3-ioerr-1.32.3  # injected error consumed by best-effort gc finalization; parity check fails, data intact
+vacuum3 vacuum3-ioerr-1.33.3  # injected error consumed by best-effort gc finalization; parity check fails, data intact
+vacuum3 vacuum3-ioerr-2.31.3  # injected error consumed by best-effort gc finalization; parity check fails, data intact
+vacuum3 vacuum3-ioerr-2.32.3  # injected error consumed by best-effort gc finalization; parity check fails, data intact
+vacuum3 vacuum3-ioerr-2.33.3  # injected error consumed by best-effort gc finalization; parity check fails, data intact
+vacuum3 vacuum3-ioerr-3.31.3  # injected error consumed by best-effort gc finalization; parity check fails, data intact
+vacuum3 vacuum3-ioerr-3.32.3  # injected error consumed by best-effort gc finalization; parity check fails, data intact
+vacuum3 vacuum3-ioerr-3.33.3  # injected error consumed by best-effort gc finalization; parity check fails, data intact
+vacuum3 vacuum3-ioerr-4.31.3  # injected error consumed by best-effort gc finalization; parity check fails, data intact
+vacuum3 vacuum3-ioerr-4.32.3  # injected error consumed by best-effort gc finalization; parity check fails, data intact
+vacuum3 vacuum3-ioerr-4.33.3  # injected error consumed by best-effort gc finalization; parity check fails, data intact

--- a/test/regression-buckets/fault-fuzz.txt
+++ b/test/regression-buckets/fault-fuzz.txt
@@ -71,6 +71,7 @@ pragmafault
 returningfault
 rollbackfault
 rowvaluefault
+savepointfault
 schemafault
 shared_err
 snapshot_fault

--- a/test/regression-buckets/storage.txt
+++ b/test/regression-buckets/storage.txt
@@ -124,7 +124,6 @@ reservebytes
 resetdb
 rollback
 rollback2
-savepoint6
 schema6
 securedel
 securedel2


### PR DESCRIPTION
The policy flip discussed in the divergence review: doltlite errored on `PRAGMA auto_vacuum=...` and `PRAGMA incremental_vacuum`; stock accepts both on databases that cannot support them and silently does nothing. The rejection broke the common set-auto_vacuum-at-startup idiom and was the single largest cascade source in the inherited corpus.

## Engine (±18 lines)
- `PRAGMA auto_vacuum = <any>` accepted and ignored on doltlite-format databases; read-back reports the actual mode (0/none), exactly like stock on a non-capable database. The meta write stock performs for capable databases is skipped (`LARGEST_ROOT_PAGE` is the max table id here, so stock's capability probe would wrongly pass and start a write transaction for an ignored setting).
- `PRAGMA incremental_vacuum` runs the stock opcode path; `prollyBtreeIncrVacuum` reports immediate completion (no freelist to reclaim). Zero rows, no error — stock-identical.
- Stock-format files routed through the orig engine are untouched (the shell suite now asserts the setting still applies there).

## Test-corpus consequences (every list re-derived 3×, no inherited reasons)
- **14 files off the crash list**: autovacuum, e_vacuum, incrblob_err, incrvacuum, incrvacuum_ioerr, mmap1, vacuum3, tkt2686, savepoint6, createtab, mallocC, ioerr4, pragma4, tkt2565
- **Cascades evaporate**: `tkt1667` −503 entries (passes 1,005 tests), `tkt-9d68c883` −101, `corrupt8` −1,000 (its ptrmap poke loop exits immediately on a chunk file), `autovacuum_ioerr2` −17 and clean, `tkt2686` clean at 11,998 tests
- **Upstream `savepointfault.test` completes whole-file** (0/432 ×3) and joins fault-fuzz — the file is fully reclaimed
- **Both old stale-statement UAFs (createtab, incrcorrupt) verified unreachable**: they required the rejection to fail a prepare
- Ported-test pins and `doltlite_pragma_auto_vacuum.sh` re-asserted to the no-op contract (18/18 clean runs)
- `savepoint6` stays documented-unenforced: randomized fuzz over open bug #1414 (found during this re-triage — deleted rows resurrected after a RELEASE-collapsed ROLLBACK TO; pre-existing, exposed not caused); re-buckets when fixed
- `conflict3` pins removed as already-passing (#1405 merged)

## Verification
C corpus 309,815/309,815 on the flip; all five buckets green through the strict gate on the final lists (2,659 re-derived entries across 38 files, each verified byte-identical over three runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)