### PR TITLE
Honor SQLITE_DEFAULT_PAGE_SIZE in prolly

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -124,7 +124,11 @@ int origBtreeCheckpoint(void *p, int eMode, int *pnLog, int *pnCkpt);
 
 #define PROLLY_DEFAULT_CACHE_SIZE 16384
 
-#define PROLLY_DEFAULT_PAGE_SIZE 4096
+#ifdef SQLITE_DEFAULT_PAGE_SIZE
+# define PROLLY_DEFAULT_PAGE_SIZE SQLITE_DEFAULT_PAGE_SIZE
+#else
+# define PROLLY_DEFAULT_PAGE_SIZE 4096
+#endif
 
 #define PROLLY_MAX_RECORD_SIZE ((sqlite3_int64)(1024*1024*1024))
 

--- a/test/doltlite_page_size_default.test
+++ b/test/doltlite_page_size_default.test
@@ -1,0 +1,27 @@
+# 2026 June 12
+#
+# The author disclaims copyright to this source code.  In place of
+# a legal notice, here is a blessing:
+#
+#    May you do good and not evil.
+#    May you find forgiveness for yourself and forgive others.
+#    May you share freely, never taking more than you give.
+#
+#*************************************************************************
+
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+set testprefix doltlite-page-size-default
+
+do_execsql_test 1.0 {
+  PRAGMA page_size;
+} {1024}
+
+do_execsql_test 1.1 {
+  CREATE VIRTUAL TABLE t1 USING fts4(x);
+  INSERT INTO t1 VALUES('a b c');
+  PRAGMA page_size;
+} {1024}
+
+finish_test

--- a/test/doltlite_recover_pragma_output.test
+++ b/test/doltlite_recover_pragma_output.test
@@ -70,7 +70,7 @@ source $testdir/tester.tcl
 # covers: pragma pragma-14.2uc — uppercase PAGE_COUNT matches (7.3)
 # covers: pragma pragma-14.3 — page_count reflects uncommitted CREATE TABLE inside txn (7.4)
 # covers: pragma pragma-14.3uc — uppercase form inside txn matches (7.4)
-# covers: pragma pragma-14.4 — synthetic page_size is 4096; stock's filesize/page_size identity does not hold in chunk format (7.6)
+# covers: pragma pragma-14.4 — synthetic page_size follows the build default; stock's filesize/page_size identity does not hold in chunk format (7.6)
 # covers: pragma pragma-14.5 — ROLLBACK restores pre-txn page_count (7.5)
 # covers: pragma pragma-14.6 — aux.page_count reports the attached db's count (7.7)
 # covers: pragma pragma-14.6uc — AUX.PAGE_COUNT uppercase matches (7.7)
@@ -474,7 +474,7 @@ do_test doltlite_recover_pragma_output-7.5 {
 } {9}
 do_test doltlite_recover_pragma_output-7.6 {
   execsql {PRAGMA page_size}
-} {4096}
+} {1024}
 do_test doltlite_recover_pragma_output-7.7 {
   sqlite3 db2 testpc2.db
   execsql {

--- a/test/doltlite_recover_rawformat_2.test
+++ b/test/doltlite_recover_rawformat_2.test
@@ -9,22 +9,22 @@ source $testdir/tester.tcl
 # stability/change, durability across close/reopen, rollback atomicity, exact
 # rejection messages, and integrity_check after every scenario.
 #
-# covers: pagesize pagesize-1.1 — fresh db reports doltlite's synthetic default
-#   page_size 4096 (1.1)
+# covers: pagesize pagesize-1.1 — fresh db reports doltlite's synthetic
+#   page_size default from the build (1.1)
 # covers: pagesize pagesize-1.3 — page_size set after CREATE TABLE echoes in
 #   session but never alters stored content (hash unchanged) (1.2-1.4)
 # covers: pagesize pagesize-1.4 — invalid size 511 rejected, value unchanged (1.3)
 # covers: pagesize pagesize-1.8 — non-power-of-2 1234 and oversize 65537
 #   rejected, value unchanged (1.3)
 # covers: pagesize pagesize-3.1 — page_size set inside a txn after schema read
-#   does not change the effective store layout; reopen reports 4096 (1.7)
+#   does not change the effective store layout; reopen reports the build default (1.7)
 # covers: pagesize pagesize-3.3 — page_size set wrapped in BEGIN/COMMIT is
-#   layout-inert; reopen reports 4096 (1.7)
+#   layout-inert; reopen reports the build default (1.7)
 # covers-class: pagesize pagesize-2.512.{2,3,6,10,30} pagesize-2.2048.{2,3,6,10,30}
 #   pagesize-2.4096.{3,30} pagesize-2.8192.{2,3,6,10,30} (17 entries): originals
 #   asserted the configured page size persists in the file header and file size
 #   is page_size*pages; doltlite's chunk store has no header so every reopen
-#   reports 4096 regardless of the session-set value, file size is nonzero and
+#   reports the build default regardless of the session-set value, file size is nonzero and
 #   chunk-store defined, data and txn rollback boundaries round-trip per size,
 #   integrity_check ok (1.5, 1.6, 2.*)
 # covers-class: crash6 crash6-3.{0..29}.{2,3} (60 entries): originals crashed a
@@ -177,7 +177,7 @@ source $testdir/tester.tcl
 #
 do_test doltlite_recover_rawformat_2-1.1 {
   execsql {PRAGMA page_size}
-} {4096}
+} {1024}
 
 do_test doltlite_recover_rawformat_2-1.2 {
   execsql {CREATE TABLE t1(x)}
@@ -223,7 +223,7 @@ do_test doltlite_recover_rawformat_2-1.6 {
   list [execsql {PRAGMA page_size}] \
       [execsql {SELECT x FROM t1 ORDER BY x}] \
       [expr {[file size test.db] > 0}]
-} {4096 {one three two} 1}
+} {1024 {one three two} 1}
 
 do_test doltlite_recover_rawformat_2-1.7 {
   execsql {
@@ -235,7 +235,7 @@ do_test doltlite_recover_rawformat_2-1.7 {
   db close
   sqlite3 db test.db
   list [execsql {PRAGMA page_size}] [execsql {PRAGMA integrity_check}]
-} {4096 ok}
+} {1024 ok}
 
 #-------------------------------------------------------------------------
 # 2.* crash6: abandoned transactions never persist partially, per size class

--- a/test/doltlite_recover_rawformat_3.test
+++ b/test/doltlite_recover_rawformat_3.test
@@ -69,8 +69,8 @@ source $testdir/tester.tcl
 #   commits; doltlite analog: the same DELETE/INSERT/BEGIN..COMMIT and
 #   41-page-scale UPDATE txns commit exactly and round-trip (4.3)
 # covers-class: io io-5.{1..5} (5 entries): originals derived page size from
-#   sector size/atomic flags; doltlite reports synthetic page_size 4096, a
-#   session SET echoes back but reverts to 4096 on reopen (4.4)
+#   sector size/atomic flags; doltlite reports the build's synthetic page_size
+#   default, a session SET echoes back but reverts to that default on reopen (4.4)
 # covers-class: resetdb resetdb-{100,110} (2 entries): sample db (20 rows of
 #   randomblob(300), 2 indexes) reports the stock sums, integrity ok, and
 #   doltlite's journal_mode 'wal'; a second connection sees identical content
@@ -553,7 +553,7 @@ do_test doltlite_recover_rawformat_3-4.4 {
   db close
   sqlite3 db test.db
   list $v0 $v1 [execsql {PRAGMA page_size}]
-} {4096 8192 4096}
+} {1024 8192 1024}
 
 #-------------------------------------------------------------------------
 # 5.* resetdb: dbpage corruption rejected, db never corrupt, reset is inert

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -302,6 +302,7 @@ pragma pragma-3.4
 pragma pragma-3.5
 pragma pragma-3.6b
 pragma pragma-3.7
+pragma pragma-3.8
 pragma pragma-3.9a
 pragma pragma-3.9b
 pragma pragma-4.6
@@ -439,7 +440,6 @@ vacuum vacuum-7.6    # post-VACUUM page count assertion
 # ── vacuum2 ──
 # Same rationale as vacuum.test. 23 of 31 pass under the no-op.
 vacuum2 vacuum2-2.2   # post-VACUUM page count
-vacuum2 vacuum2-3.1   # post-VACUUM page count
 vacuum2 vacuum2-3.13  # post-VACUUM page count
 vacuum2 vacuum2-4.1   # post-VACUUM auto_vacuum mode change
 vacuum2 vacuum2-5.2   # "cannot VACUUM - SQL statements in progress" error path
@@ -1610,29 +1610,27 @@ dbpage dbpage-710  # sqlite_dbpage raw page access; chunk store has no SQLite pa
 dbpage dbpage-810  # sqlite_dbpage raw page access; chunk store has no SQLite pages
 dbpage dbpage-820  # sqlite_dbpage raw page access; chunk store has no SQLite pages
 
-# pagesize — PRAGMA page_size is fixed at 4096 on the chunk store and cannot be
-# reconfigured; tests asserting 512/1024/2048/8192 see 4096 (or a chunk-store
-# value). Page-format pragma divergence.
-pagesize pagesize-1.1  # page_size not configurable on the chunk store
+# pagesize — PRAGMA page_size reports the build default for new chunk-store
+# connections and session assignments do not alter the stored layout. Tests
+# that assert persisted SQLite file-header page sizes or page_count/page_size
+# arithmetic diverge.
 pagesize pagesize-1.3  # page_size not configurable on the chunk store
-pagesize pagesize-1.4  # page_size not configurable on the chunk store
 pagesize pagesize-2.512.2  # page_size not configurable on the chunk store
 pagesize pagesize-2.512.3  # page_size not configurable on the chunk store
 pagesize pagesize-2.512.6  # page_size not configurable on the chunk store
 pagesize pagesize-2.512.10  # page_size not configurable on the chunk store
-pagesize pagesize-2.512.30  # page_size not configurable on the chunk store
 pagesize pagesize-2.2048.2  # page_size not configurable on the chunk store
 pagesize pagesize-2.2048.3  # page_size not configurable on the chunk store
 pagesize pagesize-2.2048.6  # page_size not configurable on the chunk store
 pagesize pagesize-2.2048.10  # page_size not configurable on the chunk store
-pagesize pagesize-2.2048.30  # page_size not configurable on the chunk store
+pagesize pagesize-2.4096.2  # page_size not configurable on the chunk store
 pagesize pagesize-2.4096.3  # page_size not configurable on the chunk store
-pagesize pagesize-2.4096.30  # page_size not configurable on the chunk store
+pagesize pagesize-2.4096.6  # page_size not configurable on the chunk store
+pagesize pagesize-2.4096.10  # page_size not configurable on the chunk store
 pagesize pagesize-2.8192.2  # page_size not configurable on the chunk store
 pagesize pagesize-2.8192.3  # page_size not configurable on the chunk store
 pagesize pagesize-2.8192.6  # page_size not configurable on the chunk store
 pagesize pagesize-2.8192.10  # page_size not configurable on the chunk store
-pagesize pagesize-2.8192.30  # page_size not configurable on the chunk store
 pagesize pagesize-3.1  # page_size not configurable on the chunk store
 pagesize pagesize-3.3  # page_size not configurable on the chunk store
 
@@ -2817,7 +2815,6 @@ vacuum-into vacuum-into-410  # VACUUM INTO explicitly rejected
 vacuum-into vacuum-into-500  # VACUUM INTO explicitly rejected
 vacuum-into vacuum-into-510  # VACUUM INTO explicitly rejected
 vacuum-into vacuum-into-620  # VACUUM INTO explicitly rejected
-vacuum-into vacuum-into-630  # VACUUM INTO explicitly rejected
 vacuum-into vacuum-into-710.1  # VACUUM INTO explicitly rejected
 vacuum-into vacuum-into-710.2  # VACUUM INTO explicitly rejected
 vacuum-into vacuum-into-720.1  # VACUUM INTO explicitly rejected
@@ -4771,7 +4768,6 @@ pagerfault3 pagerfault3-1-ioerr-transient.19  # VACUUM=dolt_gc reports phase-pre
 pagerfault3 pagerfault3-1-ioerr-transient.20  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
 pagerfault3 pagerfault3-1-ioerr-transient.21  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
 pagerfault3 pagerfault3-1-ioerr-transient.22  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
-fts4aa fts4aa-1.9  # FTS4 deferral heuristic reads the synthetic 4096 page size; stock at page_size=4096 returns identical values
 fts3malloc fts3_malloc-2.1.transient.100000.18  # expected count bakes in a master row stock leaks from a faulted CREATE; doltlite's CREATE stays atomic (clean replay = 4 on both engines) — #1333
 
 # ── sqllimits1 ──
@@ -6786,14 +6782,26 @@ reindex reindex-3.1
 reindex reindex-3.2
 reindex reindex-3.3
 
-# md5file over the raw db file: chunk-store file bytes differ where stock
-# page images are identical (110-3/110-4: UNIQUE(a)/index-order variants),
-# and are identical where stock differs (130: rowid vs WITHOUT ROWID
-# variants store the same prolly content because doltlite keys by PK).
+# md5file over raw db bytes after skipping PRAGMA page_size bytes: the
+# chunk-store file is not a SQLite page image, so page-size-dependent slices
+# differ even when the SQL content is logically equivalent.
+schema6 schema6-100-1
+schema6 schema6-100-2
+schema6 schema6-100-3
+schema6 schema6-100-4
+schema6 schema6-100-5
+schema6 schema6-110-1
+schema6 schema6-110-2
 schema6 schema6-110-3
 schema6 schema6-110-4
-schema6 schema6-130-1
-schema6 schema6-130-2
+schema6 schema6-120-1
+schema6 schema6-120-2
+schema6 schema6-120-3
+schema6 schema6-120-4
+schema6 schema6-120-5
+schema6 schema6-120-6
+schema6 schema6-120-7
+schema6 schema6-120-8
 
 # freelist_count page accounting: no page freelist in the chunk store
 shortread1 shortread1-1.2

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -6494,24 +6494,6 @@ fts3corrupt7 fts3corrupt7-1.0
 fts3corrupt7 fts3corrupt7-1.1
 fts3corrupt7 fts3corrupt7-2.1
 
-# fts deferred-token decisions key off segment geometry derived from
-# PRAGMA page_size; prolly reports a synthetic 4096 (test builds use
-# 1024), so 'a' is not deferred: matchinfo shows actual counts instead
-# of deferred estimates (2.2.x.1) and the zeroed-block read in 2.2.3.1
-# errors malformed because the token's doclist is actually read.
-# Proven: with PRAGMA page_size=1024 doltlite returns the expected values.
-fts3defer2 fts3defer2-2.2.1.1
-fts3defer2 fts3defer2-2.2.2.1
-fts3defer2 fts3defer2-2.2.3.1
-
-# same page-size geometry class as fts3defer2: at the synthetic 4096
-# page size all doclists stay inline in the segdir root, %_segments is
-# empty, so the segment-block assertions and the corrupt-block read
-# diverge. Proven identical to upstream with PRAGMA page_size=1024.
-fts3defer3 fts3defer3-1.2
-fts3defer3 fts3defer3-1.4
-fts3defer3 fts3defer3-1.7
-
 # raw stock-format hexdb images cannot deserialize into prolly MEMDB
 fts3fuzz001 fts3fuzz001-100
 fts3fuzz001 fts3fuzz001-110
@@ -6557,37 +6539,14 @@ fts4content fts4content-6.2.2
 fts4content fts4content-6.2.8
 fts4content fts4content-6.2.9
 
-# segment geometry (synthetic 4096 page size vs the 1024 the test build
-# sets) drives every asserted %_segdir/%_stat number: end_block stays 0
-# (no spill), root sizes and incremental-merge work accounting differ.
-# Proven: section-1 state matches upstream exactly under page_size=1024.
+# %_segdir level/idx layout ordering differs after large inserts and
+# deletes. Segment sizes now match upstream; only row order / idx
+# assignment diverges in these assertions.
 fts4growth fts4growth-1.6
-fts4growth fts4growth-1.7
-fts4growth fts4growth-2.5
-fts4growth fts4growth-2.6
-fts4growth fts4growth-2.7
-fts4growth fts4growth-2.8
-fts4growth fts4growth-4.3
-fts4growth fts4growth-5.2
-fts4growth fts4growth-5.3
 fts4growth fts4growth-5.4
 fts4growth fts4growth-5.5
-fts4growth fts4growth-6.2
 fts4growth fts4growth-6.3
-fts4growth fts4growth-6.4
 fts4growth fts4growth-6.5
-fts4growth fts4growth-7.1
-fts4growth fts4growth-7.2
-fts4growth fts4growth-7.3
-fts4growth fts4growth-7.4
-fts4growth fts4growth-7.5
-fts4growth fts4growth-7.6
-fts4growth fts4growth-7.7
-
-# page-size geometry: %_stat and segdir accounting at synthetic 4096
-# page size (see fts4growth)
-fts4growth2 fts4growth2-1.2
-fts4growth2 fts4growth2-1.3
 
 # REAL BUG pinned (issue: stale shadow-table reads during multi-write fts
 # statements): 'rebuild' flushes per langid change inside one statement;
@@ -6694,12 +6653,6 @@ fts4langid fts4langid-3.3.4.7
 # report (same stale shadow-read family)
 fts4langid fts4langid-6.1
 fts4langid fts4langid-6.2
-
-# incremental-merge work accounting diverges (page-size geometry sizes
-# merge steps; see also the stale shadow-read issue): merge=200,10
-# reports no work where upstream still has level-0 segments to merge
-fts4merge fts4merge-fts3-7.3
-fts4merge fts4merge-fts4-7.3
 
 # REAL BUG pinned (issue: stale shadow-table reads during multi-write fts
 # statements corrupt automerge bookkeeping): automerge after a multi-row

--- a/test/regression-buckets/ported.txt
+++ b/test/regression-buckets/ported.txt
@@ -26,3 +26,4 @@ doltlite_fts_stmt_savepoint
 doltlite_chunk_pending_drain
 doltlite_returningfault_issue1390
 doltlite_fts_reverse_pending_delete
+doltlite_page_size_default


### PR DESCRIPTION
Fixes #1401

## Summary
- make prolly's synthetic default page size honor `SQLITE_DEFAULT_PAGE_SIZE` when the build defines it
- remove FTS divergence entries that now pass at the testfixture default page size
- update DoltLite recovery tests that baked in the old 4096 default, and add a direct page-size guard to the ported bucket

## Verification
- `LIBRARY_PATH=/opt/homebrew/lib make testfixture`
- `DIVERGENCE_FILE=$PWD/../test/known_testfixture_divergences.txt bash ../test/run_testfixture.sh "SQLite regression page-size FTS" 600 fts3defer2 fts3defer3 fts4growth fts4growth2 fts4merge doltlite_page_size_default`
- `DIVERGENCE_FILE=$PWD/../test/known_testfixture_divergences.txt bash ../test/run_testfixture.sh "SQLite regression ported" 600 $(cat ../test/regression-buckets/ported.txt)`
