### PR TITLE
Preserve SQLITE_FULL from GC sweep

### DIFF
--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -642,12 +642,15 @@ static int gcSweep(
   return rc;
 }
 
-/* Report a gc phase failure without masking an OOM: callers (e.g. the OOM
-** fault harness) must see SQLITE_NOMEM when the underlying failure was an
-** allocation failure, not a generic SQLITE_ERROR message. */
+/* Report a gc phase failure without masking canonical resource errors:
+** callers (e.g. the fault harnesses) must see SQLITE_NOMEM / SQLITE_FULL
+** when the underlying failure was one of those result codes, not a generic
+** SQLITE_ERROR message. */
 static void gcResultError(sqlite3_context *context, int rc, const char *zMsg){
   if( rc==SQLITE_NOMEM || rc==SQLITE_IOERR_NOMEM ){
     sqlite3_result_error_nomem(context);
+  }else if( rc==SQLITE_FULL ){
+    sqlite3_result_error_code(context, rc);
   }else{
     sqlite3_result_error(context, zMsg, -1);
     sqlite3_result_error_code(context, rc);

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -6094,17 +6094,6 @@ descidx2 descidx2-3.24
 descidx2 descidx2-3.25
 descidx2 descidx2-3.26
 
-# do_diskfull_test injects sqlite_diskfull_pending at increasing IO counts
-# during VACUUM. doltlite's VACUUM runs the GC path; when the injected
-# SQLITE_FULL hits during the sweep phase the statement still fails, but
-# with GC's own message ("gc sweep phase failed") instead of SQLITE_FULL's
-# text. Every post-failure integrity_check (2.x.2) passes — no corruption,
-# wording-only divergence.
-diskfull diskfull-2.2.1
-diskfull diskfull-2.3.1
-diskfull diskfull-2.4.1
-diskfull diskfull-2.5.1
-
 # t0 declares PRIMARY KEY(c0,c1) / PRIMARY KEY(c0,c1 NOT NULL); the setup
 # INSERTs leave PK columns NULL, which stock's legacy rowid-PK quirk allows
 # but doltlite rejects ("NOT NULL constraint failed: t0.c0") because the PK


### PR DESCRIPTION
Fixes #1409

## Summary
- preserve `SQLITE_FULL` from the GC sweep path instead of replacing it with the generic phase error text
- remove the four now-fixed `diskfull` divergence entries

## Verification
- `rm -rf tsrc .target_source sqlite3.c testfixture && LIBRARY_PATH=/opt/homebrew/lib make testfixture`
- `DIVERGENCE_FILE=$PWD/../test/known_testfixture_divergences.txt bash ../test/run_testfixture.sh "SQLite regression diskfull" 600 diskfull`

I also ran the full `storage` bucket. `diskfull` passed there too, but the bucket still has unrelated existing failures: `bigfile` crash, `bigfile2` crash, and `corrupt8-2.1199.3`.
