### PR TITLE
Fix savepoint release mutmap levels

### DIFF
--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -838,7 +838,8 @@ void prollyMutMapReleaseSavepoint(ProllyMutMap *mm, int level){
   if( !mm ) return;
   target = level - 1;
 
-  if( level==1 && target==0 ){
+  /* The levelBase shortcut is only safe when no nested edits exist. */
+  if( level==1 && target==0 && mm->currentSavepointLevel<=1 ){
     for(i=0; i<mm->nUndo; i++){
       sqlite3_free(mm->aUndo[i].prevVal);
       mm->aUndo[i].prevVal = 0;

--- a/test/doltlite_savepoint_release.test
+++ b/test/doltlite_savepoint_release.test
@@ -1,0 +1,39 @@
+# 2026-06-12
+#
+# The author disclaims copyright to this source code.  In place of
+# a legal notice, here is a blessing:
+#
+#    May you do good and not evil.
+#    May you find forgiveness for yourself and forgive others.
+#    May you share freely, never taking more than you give.
+#
+#***********************************************************************
+# Focused coverage for RELEASE of a middle savepoint followed by a later
+# ROLLBACK TO. This is the deterministic savepoint6 failure behind #1414.
+#
+
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+do_execsql_test doltlite_savepoint_release-1.1 {
+  CREATE TABLE t1(x, y);
+  INSERT INTO t1 VALUES(231,'aaa');
+  SAVEPOINT four;
+  SAVEPOINT five;
+  SAVEPOINT three;
+  DELETE FROM t1 WHERE x = 231;
+  RELEASE five;
+  SAVEPOINT nine;
+  INSERT INTO t1 VALUES(662,'bbb');
+  ROLLBACK TO nine;
+  SELECT count(*) FROM t1;
+} {0}
+
+do_execsql_test doltlite_savepoint_release-1.2 {
+  RELEASE nine;
+  RELEASE four;
+  SELECT count(*) FROM t1;
+  PRAGMA integrity_check;
+} {0 ok}
+
+finish_test

--- a/test/known_testfixture_crashes.txt
+++ b/test/known_testfixture_crashes.txt
@@ -198,8 +198,3 @@ superlock  # sqlite3demo_superlock cannot acquire its byte-range/WAL superlock o
 # would churn a 1000-line block on every fts fix; revisit when the fts
 # shadow-table stale-read bug is fixed and the count drops below the cap.
 #
-# savepoint6: a randomized savepoint fuzz workload sitting on an open
-# savepoint-state bug (deleted rows resurrected after a RELEASE-collapsed
-# ROLLBACK TO), so its failure set differs between builds; re-bucket and
-# gate once the bug is fixed and the file runs clean.
-

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -6695,18 +6695,6 @@ savepoint savepoint-15.1.3
 savepoint savepoint-15.2.2
 savepoint savepoint-15.2.3
 
-# ── savepoint6 ──
-# REAL BUG (#1414), not an intentional divergence: a write under two
-# savepoints collapsed by one RELEASE of the middle name, followed by a
-# new savepoint and a write with no intervening read, makes ROLLBACK TO
-# restore a stale pre-DELETE state (deleted row resurrected); under the
-# file's continued random load the connection then throws 'database disk
-# image is malformed'. First divergence at savepoint6-normal.997.1,
-# deterministic 3/3; everything from there is the same root cause
-# cascading through the shared shadow-array harness until the tester's
-# 1000-error cap aborts the file. Remove this whole block when #1414 is
-# fixed.
-
 # shared3: shared-cache cache_size cross-connection visibility (2.4) and pager
 # exclusive-lock "database is locked" on cache spill (2.8) — doltlite's MVCC
 # lock model takes no page-level exclusive lock. Row outcomes match stock.

--- a/test/regression-buckets/ported.txt
+++ b/test/regression-buckets/ported.txt
@@ -27,3 +27,4 @@ doltlite_chunk_pending_drain
 doltlite_returningfault_issue1390
 doltlite_fts_reverse_pending_delete
 doltlite_page_size_default
+doltlite_savepoint_release

--- a/test/regression-buckets/storage.txt
+++ b/test/regression-buckets/storage.txt
@@ -124,6 +124,7 @@ reservebytes
 resetdb
 rollback
 rollback2
+savepoint6
 schema6
 securedel
 securedel2

--- a/test/run_testfixture.sh
+++ b/test/run_testfixture.sh
@@ -94,7 +94,7 @@ is_crash_expected() {
 is_in_set() {
   local needle="$1"
   local haystack="$2"
-  printf '%s\n' "$haystack" | grep -Fxq -- "$needle"
+  grep -Fxq -- "$needle" <<< "$haystack"
 }
 
 count_lines() {


### PR DESCRIPTION
Fixes #1414

## Summary
- remove the level-1 mutmap RELEASE shortcut so released pending entries are rewritten to the surviving savepoint level
- add focused regression coverage for the middle-savepoint RELEASE / later ROLLBACK TO resurrection case
- gate savepoint6 now that it runs clean and remove the stale known-bug notes

## Tests
- `LIBRARY_PATH=/opt/homebrew/lib make testfixture`
- `DIVERGENCE_FILE=$PWD/../test/known_testfixture_divergences.txt bash ../test/run_testfixture.sh "1414 target" 600 doltlite_savepoint_release savepoint6`
- `DIVERGENCE_FILE=$PWD/../test/known_testfixture_divergences.txt bash ../test/run_testfixture.sh "ported bucket" 600 $(tr "\n" " " < ../test/regression-buckets/ported.txt)`
- `DIVERGENCE_FILE=$PWD/../test/known_testfixture_divergences.txt bash ../test/run_testfixture.sh "storage bucket" 1200 $(tr "\n" " " < ../test/regression-buckets/storage.txt)`

Storage bucket note: savepoint6 passed in-bucket with 8007 tests. The full local storage run exited nonzero due to pre-existing unexpected crashes in bigfile and bigfile2, before the savepoint section, plus stale fixed vacuum3 divergence entries.