### PR TITLE
Add cross-version database compatibility gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -463,10 +463,50 @@ jobs:
         name: benchmark
         path: /tmp/bench_results.md
 
+  # ── Cross-version compatibility gate ──────────────────────
+  # Databases created by prior releases must open and pass feature smoke
+  # tests when the on-disk format signature is unchanged, and must be
+  # refused cleanly when it differs. A format change without a minor
+  # version bump fails this job, which blocks the release.
+  compat:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Install dependencies
+      run: sudo apt-get update && sudo apt-get install -y tcl-dev build-essential zlib1g-dev
+
+    - name: Cache old-version binaries
+      uses: actions/cache@v4
+      with:
+        path: .compat-cache
+        key: compat-bins-${{ runner.os }}-${{ github.ref_name }}
+        restore-keys: |
+          compat-bins-${{ runner.os }}-
+
+    - name: Configure
+      run: |
+        mkdir -p build && cd build
+        TCL_CONFIG=$(find /usr -path '/usr/share/miniconda/*' -prune -o -name tclConfig.sh -print 2>/dev/null | head -1)
+        if [ -n "$TCL_CONFIG" ]; then
+          ../configure --with-tcl=$(dirname $TCL_CONFIG)
+        else
+          ../configure
+        fi
+
+    - name: Build doltlite
+      run: cd build && make -j4 doltlite
+
+    - name: Cross-version compatibility tests
+      run: bash test/doltlite_compat_test.sh build/doltlite
+
   # ── Create GitHub release ─────────────────────────────────
   release:
     if: github.event_name != 'workflow_dispatch'
-    needs: [source, build, benchmark]
+    needs: [source, build, benchmark, compat]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -248,3 +248,44 @@ jobs:
         cd build
         bash ../test/run_testfixture.sh "SQLite regression ${{ matrix.bucket }}" 300 \
           $(tr '\n' ' ' < ../test/regression-buckets/${{ matrix.bucket }}.txt)
+
+  # Cross-version database compatibility: fixtures built by pinned old
+  # release tags must open + pass feature smoke tests when the on-disk
+  # format signature is unchanged, and must be refused cleanly when it
+  # differs. Format changes without a minor version bump fail the suite.
+  compat:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y tcl-dev build-essential zlib1g-dev
+
+    - name: Cache old-version binaries
+      uses: actions/cache@v4
+      with:
+        path: .compat-cache
+        key: compat-bins-${{ runner.os }}-${{ github.base_ref || github.ref_name }}
+        restore-keys: |
+          compat-bins-${{ runner.os }}-
+
+    - name: Configure
+      run: |
+        mkdir -p build && cd build
+        TCL_CONFIG=$(find /usr -path '/usr/share/miniconda/*' -prune -o -name tclConfig.sh -print 2>/dev/null | head -1)
+        if [ -n "$TCL_CONFIG" ]; then
+          ../configure --with-tcl=$(dirname $TCL_CONFIG)
+        else
+          ../configure
+        fi
+
+    - name: Build doltlite
+      run: cd build && make -j4 doltlite
+
+    - name: Cross-version compatibility tests
+      run: bash test/doltlite_compat_test.sh build/doltlite

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build-fuzz/
 .logs/
 __pycache__/
 state.json
+.compat-cache/

--- a/test/doltlite_compat_test.sh
+++ b/test/doltlite_compat_test.sh
@@ -1,0 +1,288 @@
+#!/bin/bash
+#
+# Cross-version database compatibility gate.
+#
+# The on-disk format may only change with a minor version bump
+# (vMAJOR.MINOR.PATCH tags). For each pinned historical tag this suite
+# builds that tag's doltlite (cached under $DOLTLITE_COMPAT_CACHE) and
+# creates a fixture database with versioned history, then asserts:
+#
+#   - If the tag's format signature (CHUNK_STORE_VERSION, WS_FORMAT_VERSION,
+#     on-disk magics) matches the current tree's, the current binary MUST
+#     open the fixture and version-control features must work against it:
+#     reads, indexed lookups, dolt_log, new commits, branch checkout,
+#     merge, and tags.
+#
+#   - If CHUNK_STORE_VERSION differs, the current binary MUST refuse the
+#     fixture with a clean not-a-database error: no crash, no silent
+#     misread. A format break is only legal alongside a minor bump, so a
+#     differing signature with an unchanged minor version fails the suite.
+#
+#   - Any other piece of the format signature changing without a
+#     CHUNK_STORE_VERSION bump fails the suite outright: old databases
+#     would open and then silently misparse the changed structure.
+#
+# Usage: doltlite_compat_test.sh [path-to-current-doltlite]
+#   DOLTLITE_COMPAT_TAGS   override the tag list (default: computed from
+#                          git history — the latest patch of the two most
+#                          recent prior minor series, plus the first and
+#                          latest tags of the current series; the exact
+#                          tag being released, if HEAD is tagged, is
+#                          excluded since it would test itself)
+#   DOLTLITE_COMPAT_CACHE  cache dir for old-version binaries
+#   DOLTLITE_COMPAT_JOBS   make -j for old-version builds (default 4)
+
+DOLTLITE="${1:-$(dirname "$0")/../build/doltlite}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CACHE_DIR="${DOLTLITE_COMPAT_CACHE:-$REPO_ROOT/.compat-cache}"
+JOBS="${DOLTLITE_COMPAT_JOBS:-4}"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+set -o pipefail
+
+pass=0
+fail=0
+
+ok()   { echo "PASS: $1"; pass=$((pass+1)); }
+bad()  { echo "FAIL: $1"; fail=$((fail+1)); }
+check(){ if [ "$2" = "0" ]; then ok "$1"; else bad "$1${3:+ — $3}"; fi; }
+
+DOLTLITE="$(cd "$(dirname "$DOLTLITE")" && pwd)/$(basename "$DOLTLITE")"
+if [ ! -x "$DOLTLITE" ]; then
+  echo "ERROR: current doltlite binary not found: $DOLTLITE"
+  exit 1
+fi
+if ! git -C "$REPO_ROOT" rev-parse v0.11.0 >/dev/null 2>&1; then
+  echo "ERROR: git tags unavailable (shallow clone?); fetch tags first:"
+  echo "  git fetch --tags --unshallow"
+  exit 1
+fi
+
+# The on-disk format signature: the open-time version gate plus every
+# structural constant whose meaning a reader bakes in. Add new format
+# constants to the grep when they are introduced.
+format_signature() {
+  local ref="$1" f content
+  for f in src/chunk_store.h src/prolly_node.h; do
+    if [ "$ref" = "WORKTREE" ]; then
+      content=$(cat "$REPO_ROOT/$f" 2>/dev/null)
+    else
+      content=$(git -C "$REPO_ROOT" show "$ref:$f" 2>/dev/null)
+    fi
+    printf '%s\n' "$content" | grep -E \
+      '^#define +(CHUNK_STORE_VERSION|CHUNK_STORE_MAGIC|WS_FORMAT_VERSION|PROLLY_NODE_MAGIC) ' \
+      | tr -s ' '
+  done
+}
+
+chunk_store_version() {
+  printf '%s\n' "$1" | sed -n 's/^#define CHUNK_STORE_VERSION \([0-9]*\)$/\1/p'
+}
+
+series_of() {  # v0.11.12[-g...] -> 0.11
+  printf '%s\n' "$1" | sed -n 's/^v\([0-9]*\.[0-9]*\)\..*/\1/p'
+}
+
+# Latest patch of the two most recent prior minor series, plus the latest
+# and first tags of the current series. A tag pointing at HEAD (the tag a
+# release run is building) is skipped: it would test against itself.
+compute_default_tags() {
+  local cur_series="$1"
+  local exact t series out="" priors=""
+  local cur_first="" cur_last=""
+  exact=$(git -C "$REPO_ROOT" describe --tags --exact-match 2>/dev/null)
+  while read -r t; do
+    [ "$t" = "$exact" ] && continue
+    series=$(series_of "$t")
+    [ -z "$series" ] && continue
+    if [ "$series" = "$cur_series" ]; then
+      # Newest-first scan: the first hit is the series tip, the last
+      # assignment leaves the earliest tag.
+      [ -z "$cur_last" ] && cur_last="$t"
+      cur_first="$t"
+    else
+      case " $priors " in
+        *" $series "*) ;;
+        *)
+          if [ "$(printf '%s' "$priors" | wc -w)" -lt 2 ]; then
+            out="$out $t"
+            priors="$priors $series"
+          fi
+          ;;
+      esac
+    fi
+  done <<EOF
+$(git -C "$REPO_ROOT" tag --list 'v*' --sort=-v:refname)
+EOF
+  [ -n "$cur_last" ] && out="$out $cur_last"
+  if [ -n "$cur_first" ] && [ "$cur_first" != "$cur_last" ]; then
+    out="$out $cur_first"
+  fi
+  printf '%s' "$out"
+}
+
+sql() {  # sql <binary> <db> <sql...>
+  local bin="$1" db="$2"; shift 2
+  printf '%s\n' "$*" | "$bin" "$db" 2>&1
+}
+
+build_old() {  # build_old <tag> -> echoes binary path, rc!=0 on failure
+  local tag="$1"
+  local bin="$CACHE_DIR/$tag/doltlite"
+  if [ -x "$bin" ]; then echo "$bin"; return 0; fi
+  local wt="$CACHE_DIR/src-$tag"
+  mkdir -p "$CACHE_DIR/$tag"
+  rm -rf "$wt"
+  git -C "$REPO_ROOT" worktree add --force --detach "$wt" "$tag" \
+      >"$CACHE_DIR/$tag/build.log" 2>&1 || return 1
+  ( cd "$wt" && ./configure && make -j"$JOBS" doltlite ) \
+      >>"$CACHE_DIR/$tag/build.log" 2>&1
+  local rc=$?
+  if [ $rc -eq 0 ] && [ -x "$wt/doltlite" ]; then
+    cp "$wt/doltlite" "$bin"
+  else
+    rc=1
+  fi
+  git -C "$REPO_ROOT" worktree remove --force "$wt" >/dev/null 2>&1
+  [ $rc -eq 0 ] && echo "$bin"
+  return $rc
+}
+
+make_fixture() {  # make_fixture <old-binary> <db>
+  local bin="$1" db="$2"
+  sql "$bin" "$db" "
+    CREATE TABLE people(id INTEGER PRIMARY KEY, name TEXT, data BLOB);
+    INSERT INTO people
+      WITH RECURSIVE n(i) AS (SELECT 1 UNION ALL SELECT i+1 FROM n WHERE i<40)
+      SELECT i, 'name'||i, randomblob(32) FROM n;
+    CREATE INDEX idx_people_name ON people(name);
+    SELECT dolt_commit('-A','-m','initial data');
+    INSERT INTO people
+      WITH RECURSIVE n(i) AS (SELECT 41 UNION ALL SELECT i+1 FROM n WHERE i<60)
+      SELECT i, 'name'||i, randomblob(32) FROM n;
+    SELECT dolt_commit('-A','-m','second batch');
+    SELECT dolt_branch('fixture-branch');
+    SELECT dolt_tag('fixture-tag');
+  " >/dev/null 2>&1
+  # The fixture must be readable by its own creator before it proves anything.
+  local n
+  n=$(sql "$bin" "$db" "SELECT count(*) FROM people;")
+  [ "$n" = "60" ]
+}
+
+smoke_current() {  # smoke_current <db> <tag>
+  local db="$1" tag="$2" out
+
+  out=$(sql "$DOLTLITE" "$db" "SELECT count(*) FROM people;")
+  check "$tag: open + full scan" "$([ "$out" = "60" ]; echo $?)" "got '$out'"
+
+  out=$(sql "$DOLTLITE" "$db" "SELECT id FROM people WHERE name='name37';")
+  check "$tag: indexed lookup" "$([ "$out" = "37" ]; echo $?)" "got '$out'"
+
+  out=$(sql "$DOLTLITE" "$db" "SELECT count(*) FROM dolt_log;")
+  check "$tag: dolt_log readable" "$([ "${out:-0}" -ge 2 ] 2>/dev/null; echo $?)" "got '$out'"
+
+  out=$(sql "$DOLTLITE" "$db" "SELECT count(*) FROM dolt_tags;")
+  check "$tag: dolt_tags readable" "$([ "${out:-0}" -ge 1 ] 2>/dev/null; echo $?)" "got '$out'"
+
+  out=$(sql "$DOLTLITE" "$db" "
+    INSERT INTO people VALUES(9001,'new-row',x'00');
+    SELECT dolt_commit('-A','-m','commit from current version');")
+  check "$tag: new commit on old db" \
+    "$(printf '%s' "$out" | grep -qE '^[0-9a-f]{40}$'; echo $?)" "got '$out'"
+
+  out=$(sql "$DOLTLITE" "$db" "SELECT dolt_checkout('fixture-branch');
+    INSERT INTO people VALUES(9002,'branch-row',x'00');
+    SELECT dolt_commit('-A','-m','branch commit');
+    SELECT dolt_checkout('main');
+    SELECT dolt_merge('fixture-branch');
+    SELECT count(*) FROM people WHERE id=9002;")
+  check "$tag: checkout + merge on old db" \
+    "$(printf '%s' "$out" | tail -1 | grep -qx '1'; echo $?)" "got '$out'"
+}
+
+assert_refused() {  # assert_refused <db> <tag>
+  local db="$1" tag="$2" out rc
+  out=$(sql "$DOLTLITE" "$db" "SELECT count(*) FROM people;")
+  rc=$?
+  if [ $rc -ge 126 ]; then
+    bad "$tag: refusal must be a clean error, not a crash (rc=$rc)"
+    return
+  fi
+  if [ $rc -eq 0 ]; then
+    bad "$tag: incompatible-format db opened without error — output '$out'"
+    return
+  fi
+  if printf '%s' "$out" | grep -qiE 'not a database|notadb'; then
+    ok "$tag: incompatible format refused cleanly"
+  else
+    bad "$tag: refused, but without the not-a-database error — output '$out'"
+  fi
+}
+
+cur_sig=$(format_signature WORKTREE)
+cur_csv=$(chunk_store_version "$cur_sig")
+cur_desc=$(git -C "$REPO_ROOT" describe --tags 2>/dev/null)
+cur_series=$(series_of "$cur_desc")
+
+if [ -z "$cur_csv" ] || [ -z "$cur_series" ]; then
+  echo "ERROR: cannot determine current CHUNK_STORE_VERSION ('$cur_csv')"
+  echo "       or version series from git describe ('$cur_desc')"
+  exit 1
+fi
+
+TAGS="${DOLTLITE_COMPAT_TAGS:-$(compute_default_tags "$cur_series")}"
+if [ -z "${TAGS// }" ]; then
+  echo "ERROR: no historical tags to test against"
+  exit 1
+fi
+echo "current: $cur_desc (series $cur_series, chunk store v$cur_csv)"
+echo "tags: $TAGS"
+echo
+
+for tag in $TAGS; do
+  old_sig=$(format_signature "$tag")
+  old_csv=$(chunk_store_version "$old_sig")
+  old_series=$(series_of "$tag")
+  if [ -z "$old_csv" ] || [ -z "$old_series" ]; then
+    bad "$tag: cannot read format signature from tag"
+    continue
+  fi
+
+  # Release policy: a format change of any kind requires a minor bump, and
+  # any signature change beyond that requires bumping the open-time gate.
+  if [ "$old_series" = "$cur_series" ] && [ "$old_sig" != "$cur_sig" ]; then
+    bad "$tag: format signature changed inside minor series $cur_series — bump the minor version"
+    continue
+  fi
+  if [ "$old_csv" = "$cur_csv" ] && [ "$old_sig" != "$cur_sig" ]; then
+    bad "$tag: format signature changed without a CHUNK_STORE_VERSION bump — old databases would open and misparse"
+    continue
+  fi
+
+  echo "-- $tag (series $old_series, chunk store v$old_csv): building fixture"
+  bin=$(build_old "$tag")
+  if [ $? -ne 0 ] || [ ! -x "$bin" ]; then
+    bad "$tag: failed to build old doltlite (see $CACHE_DIR/$tag/build.log)"
+    continue
+  fi
+
+  db="$TMPDIR/compat-$tag.db"
+  if ! make_fixture "$bin" "$db"; then
+    bad "$tag: failed to create fixture database with old binary"
+    continue
+  fi
+  ok "$tag: fixture created with old binary"
+
+  if [ "$old_sig" = "$cur_sig" ]; then
+    smoke_current "$db" "$tag"
+  else
+    assert_refused "$db" "$tag"
+  fi
+  echo
+done
+
+echo "Results: $pass passed, $fail failed"
+[ $fail -eq 0 ]


### PR DESCRIPTION
Databases created by old doltlite releases are now gated for compatibility on every PR and at release time.

## What it does

\`test/doltlite_compat_test.sh\` picks tags from git history — the latest patch of the two most recent prior minor series, plus the first and latest tags of the current series (a tag pointing at HEAD is skipped: it would test itself). For each tag it builds that version's doltlite (cached), creates a fixture database with real versioned history (tables, index, blobs, commits, a branch, a tag), and asserts by policy:

- **Format signature unchanged** (\`CHUNK_STORE_VERSION\`, \`WS_FORMAT_VERSION\`, on-disk magics): the current binary **must open the fixture** and pass feature smoke tests — full scan, indexed lookup, \`dolt_log\`, \`dolt_tags\`, a new commit, branch checkout + merge.
- **\`CHUNK_STORE_VERSION\` differs**: the current binary **must refuse cleanly** — the not-a-database error, nonzero exit, no crash.
- **Policy gates**: changing any part of the format signature within a minor series fails the suite ("bump the minor version"), as does changing the signature without bumping the open-time \`CHUNK_STORE_VERSION\` gate (old databases would open and misparse).

## Wiring

- \`test.yml\`: new \`compat\` job on every PR (\`fetch-depth: 0\` for tags + old source, \`actions/cache\` for old binaries — 7.8MB, cold build ~8 min, warm ~1 min).
- \`release.yml\`: new \`compat\` job, added to the \`release\` job's \`needs\`, so **a compatibility violation blocks publishing**.

## Verification

- 18/18 locally: v0.9.3 (chunk store v10) and v0.10.11 (v11) fixtures refused cleanly; v0.11.0 and v0.11.12 (v12) fixtures pass the full feature smoke.
- Negative test: temporarily bumping \`CHUNK_STORE_VERSION\` to 13 fails with "format signature changed inside minor series 11 — bump the minor version".
- Historical sanity: every minor bump so far (0.7→0.11) bumped the chunk store version (8→12); the 0.11 series is stable at 12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)