### PR TITLE
Extract shared virtual-table boilerplate (cursor, vtab, connect)

### DIFF
--- a/main.mk
+++ b/main.mk
@@ -614,6 +614,7 @@ ifeq ($(DOLTLITE_PROLLY),1)
     $(TOP)/src/doltlite_commit.h $(TOP)/src/doltlite_constraint_violations.h \
     $(TOP)/src/doltlite_ignore.h $(TOP)/src/doltlite_internal.h \
     $(TOP)/src/doltlite_record.h $(TOP)/src/doltlite_remote.h $(TOP)/src/doltlite_remotesrv.h \
+    $(TOP)/src/doltlite_vtab_util.h \
     $(TOP)/src/btree_orig_prefix.h $(TOP)/src/btree_orig_api.h $(TOP)/src/btree_orig_api.c \
     $(TOP)/ext/blake3/blake3.c $(TOP)/ext/blake3/blake3_portable.c \
     $(TOP)/ext/blake3/blake3_dispatch.c $(TOP)/ext/blake3/blake3.h \

--- a/src/doltlite_at.c
+++ b/src/doltlite_at.c
@@ -1,13 +1,8 @@
 
 #ifdef DOLTLITE_PROLLY
 
-#include "sqliteInt.h"
-#include "prolly_hash.h"
-#include "prolly_cursor.h"
-#include "prolly_cache.h"
-#include "chunk_store.h"
+#include "doltlite_vtab_util.h"
 #include "doltlite_commit.h"
-#include "doltlite_record.h"
 #include "doltlite_internal.h"
 
 #include <string.h>
@@ -37,103 +32,77 @@ struct AtVtab {
 
 typedef struct AtCursor AtCursor;
 struct AtCursor {
-  sqlite3_vtab_cursor base;
-  ProllyCursor tblCur;
-  int tblCurOpen;
-  i64 intKey;
-  u8 *pVal; int nVal;
-  int hasRow;
-  i64 iRowid;
+  DoltliteVtabCursorCommon common;
   char *zCommitRef;
 };
 
 static void atCursorReset(AtCursor *c){
-  if( c->tblCurOpen ){
-    prollyCursorClose(&c->tblCur);
-    c->tblCurOpen = 0;
-  }
-  sqlite3_free(c->pVal);
-  c->pVal = 0; c->nVal = 0;
+  doltliteVtabCommonReset(&c->common);
   sqlite3_free(c->zCommitRef);
   c->zCommitRef = 0;
-  c->hasRow = 0;
-  c->iRowid = 0;
-}
-
-static int atCaptureRow(AtCursor *c){
-  const u8 *pVal; int nVal;
-  sqlite3_free(c->pVal);
-  c->pVal = 0; c->nVal = 0;
-  c->intKey = prollyCursorIntKey(&c->tblCur);
-  prollyCursorValue(&c->tblCur, &pVal, &nVal);
-  if( pVal && nVal>0 ){
-    c->pVal = sqlite3_malloc(nVal);
-    if( !c->pVal ) return SQLITE_NOMEM;
-    memcpy(c->pVal, pVal, nVal);
-    c->nVal = nVal;
-  }
-  c->hasRow = 1;
-  return SQLITE_OK;
 }
 
 static int atConnect(sqlite3 *db, void *pAux, int argc,
     const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){
-  AtVtab *pVtab;
+  DoltliteVtabCommon *v;
   int rc;
   const char *zMod;
   char *zSchema;
-  (void)pAux;
 
-  pVtab = sqlite3_malloc(sizeof(*pVtab));
-  if( !pVtab ) return SQLITE_NOMEM;
-  memset(pVtab, 0, sizeof(*pVtab));
-  pVtab->db = db;
+  v = sqlite3_malloc(sizeof(AtVtab));
+  if( !v ) return SQLITE_NOMEM;
+  memset(v, 0, sizeof(AtVtab));
+  v->db = db;
 
   zMod = argv[0];
   if( zMod && strncmp(zMod, "dolt_at_", 8) == 0 ){
-    pVtab->zTableName = sqlite3_mprintf("%s", zMod + 8);
+    v->zTableName = sqlite3_mprintf("%s", zMod + 8);
   }else if( argc > 3 ){
-    pVtab->zTableName = sqlite3_mprintf("%s", argv[3]);
+    v->zTableName = sqlite3_mprintf("%s", argv[3]);
   }else{
-    pVtab->zTableName = sqlite3_mprintf("");
+    v->zTableName = sqlite3_mprintf("");
   }
 
-  rc = doltliteLoadUserTableColumns(db, pVtab->zTableName, &pVtab->cols, pzErr);
+  rc = doltliteLoadUserTableColumns(db, v->zTableName, &v->cols, pzErr);
   if( rc != SQLITE_OK ){
-    sqlite3_free(pVtab->zTableName);
-    doltliteFreeColInfo(&pVtab->cols);
-    sqlite3_free(pVtab);
+    sqlite3_free(v->zTableName);
+    doltliteFreeColInfo(&v->cols);
+    sqlite3_free(v);
     return rc;
   }
-  zSchema = atBuildSchema(&pVtab->cols);
+  zSchema = atBuildSchema(&v->cols);
   if( !zSchema ){
-    sqlite3_free(pVtab->zTableName);
-    doltliteFreeColInfo(&pVtab->cols);
-    sqlite3_free(pVtab);
+    sqlite3_free(v->zTableName);
+    doltliteFreeColInfo(&v->cols);
+    sqlite3_free(v);
     return SQLITE_NOMEM;
   }
 
   rc = sqlite3_declare_vtab(db, zSchema);
   sqlite3_free(zSchema);
   if( rc != SQLITE_OK ){
-    sqlite3_free(pVtab->zTableName);
-    doltliteFreeColInfo(&pVtab->cols);
-    sqlite3_free(pVtab);
+    sqlite3_free(v->zTableName);
+    doltliteFreeColInfo(&v->cols);
+    sqlite3_free(v);
     return rc;
   }
 
-  *ppVtab = &pVtab->base;
+  *ppVtab = &v->base;
   return SQLITE_OK;
 }
 
-static int atDisconnect(sqlite3_vtab *pVtab){
-  AtVtab *v=(AtVtab*)pVtab;
-  sqlite3_free(v->zTableName); doltliteFreeColInfo(&v->cols);
-  sqlite3_free(v); return SQLITE_OK;
+static int atOpen(sqlite3_vtab *pVtab, sqlite3_vtab_cursor **pp){
+  (void)pVtab;
+  return doltliteVtabOpenCursor(pp, sizeof(AtCursor));
+}
+
+static int atClose(sqlite3_vtab_cursor *cur){
+  AtCursor *c=(AtCursor*)cur;
+  atCursorReset(c); sqlite3_free(c); return SQLITE_OK;
 }
 
 static int atBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
-  AtVtab *v=(AtVtab*)pVtab;
+  DoltliteVtabCommon *v=(DoltliteVtabCommon*)pVtab;
   int nCols=v->cols.nCol;
   int iRef=-1, i, argvIdx=1;
 
@@ -157,20 +126,10 @@ static int atBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
   return SQLITE_OK;
 }
 
-static int atOpen(sqlite3_vtab *pVtab, sqlite3_vtab_cursor **pp){
-  (void)pVtab;
-  return doltliteVtabOpenCursor(pp, sizeof(AtCursor));
-}
-
-static int atClose(sqlite3_vtab_cursor *cur){
-  AtCursor *c=(AtCursor*)cur;
-  atCursorReset(c); sqlite3_free(c); return SQLITE_OK;
-}
-
 static int atFilter(sqlite3_vtab_cursor *cur,
     int idxNum, const char *idxStr, int argc, sqlite3_value **argv){
   AtCursor *c=(AtCursor*)cur;
-  AtVtab *v=(AtVtab*)cur->pVtab;
+  DoltliteVtabCommon *v=(DoltliteVtabCommon*)cur->pVtab;
   sqlite3 *db=v->db;
   ChunkStore *cs=doltliteGetChunkStore(db);
   void *pBt; ProllyCache *pCache;
@@ -229,72 +188,68 @@ static int atFilter(sqlite3_vtab_cursor *cur,
 
   if( prollyHashIsEmpty(&tableRoot) ) return SQLITE_OK;
 
-  prollyCursorInit(&c->tblCur, cs, pCache, &tableRoot, flags);
-  rc = prollyCursorFirst(&c->tblCur, &res);
+  prollyCursorInit(&c->common.tblCur, cs, pCache, &tableRoot, flags);
+  rc = prollyCursorFirst(&c->common.tblCur, &res);
   if( rc!=SQLITE_OK ){
-    prollyCursorClose(&c->tblCur);
+    prollyCursorClose(&c->common.tblCur);
     return rc;
   }
   if( res ){
-    prollyCursorClose(&c->tblCur);
+    prollyCursorClose(&c->common.tblCur);
     return SQLITE_OK;
   }
-  c->tblCurOpen = 1;
-  return atCaptureRow(c);
+  c->common.tblCurOpen = 1;
+  return doltliteVtabCommonCaptureRow(&c->common);
 }
 
 static int atNext(sqlite3_vtab_cursor *cur){
   AtCursor *c=(AtCursor*)cur;
   int rc;
-  c->iRowid++;
-  if( !c->tblCurOpen ){
-    c->hasRow = 0;
+  c->common.iRowid++;
+  if( !c->common.tblCurOpen ){
+    c->common.hasRow = 0;
     return SQLITE_OK;
   }
-  rc = prollyCursorNext(&c->tblCur);
+  rc = prollyCursorNext(&c->common.tblCur);
   if( rc!=SQLITE_OK ){
-    prollyCursorClose(&c->tblCur);
-    c->tblCurOpen = 0;
-    c->hasRow = 0;
+    prollyCursorClose(&c->common.tblCur);
+    c->common.tblCurOpen = 0;
+    c->common.hasRow = 0;
     return rc;
   }
-  if( !prollyCursorIsValid(&c->tblCur) ){
-    prollyCursorClose(&c->tblCur);
-    c->tblCurOpen = 0;
-    c->hasRow = 0;
+  if( !prollyCursorIsValid(&c->common.tblCur) ){
+    prollyCursorClose(&c->common.tblCur);
+    c->common.tblCurOpen = 0;
+    c->common.hasRow = 0;
     return SQLITE_OK;
   }
-  return atCaptureRow(c);
-}
-
-static int atEof(sqlite3_vtab_cursor *cur){
-  return !((AtCursor*)cur)->hasRow;
+  return doltliteVtabCommonCaptureRow(&c->common);
 }
 
 static int atColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
   AtCursor *c=(AtCursor*)cur;
-  AtVtab *v=(AtVtab*)cur->pVtab;
+  DoltliteVtabCommon *v=(DoltliteVtabCommon*)cur->pVtab;
   int nCols=v->cols.nCol;
 
-  if( !c->hasRow ) return SQLITE_OK;
+  if( !c->common.hasRow ) return SQLITE_OK;
 
   if( col==nCols ){
     sqlite3_result_text(ctx, c->zCommitRef ? c->zCommitRef : "",
                         -1, SQLITE_TRANSIENT);
   }else if(nCols>0 && col<nCols){
-    doltliteResultUserCol(ctx, &v->cols, c->pVal, c->nVal, c->intKey, col);
+    doltliteResultUserCol(ctx, &v->cols, c->common.pVal, c->common.nVal,
+                          c->common.intKey, col);
   }
 
   return SQLITE_OK;
 }
 
-static int atRowid(sqlite3_vtab_cursor *cur, sqlite3_int64 *r){
-  *r=((AtCursor*)cur)->iRowid; return SQLITE_OK;
-}
-
 static sqlite3_module atModule = {
-  0, atConnect, atConnect, atBestIndex, atDisconnect, atDisconnect,
-  atOpen, atClose, atFilter, atNext, atEof, atColumn, atRowid,
+  0, atConnect, atConnect, atBestIndex,
+  doltliteVtabCommonDisconnect, doltliteVtabCommonDisconnect,
+  atOpen, atClose,
+  atFilter, atNext,
+  doltliteVtabCommonEof, atColumn, doltliteVtabCommonRowid,
   0,0,0,0,0,0,0,0,0,0,0,0
 };
 

--- a/src/doltlite_at.c
+++ b/src/doltlite_at.c
@@ -44,51 +44,10 @@ static void atCursorReset(AtCursor *c){
 
 static int atConnect(sqlite3 *db, void *pAux, int argc,
     const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){
-  DoltliteVtabCommon *v;
-  int rc;
-  const char *zMod;
-  char *zSchema;
-
-  v = sqlite3_malloc(sizeof(AtVtab));
-  if( !v ) return SQLITE_NOMEM;
-  memset(v, 0, sizeof(AtVtab));
-  v->db = db;
-
-  zMod = argv[0];
-  if( zMod && strncmp(zMod, "dolt_at_", 8) == 0 ){
-    v->zTableName = sqlite3_mprintf("%s", zMod + 8);
-  }else if( argc > 3 ){
-    v->zTableName = sqlite3_mprintf("%s", argv[3]);
-  }else{
-    v->zTableName = sqlite3_mprintf("");
-  }
-
-  rc = doltliteLoadUserTableColumns(db, v->zTableName, &v->cols, pzErr);
-  if( rc != SQLITE_OK ){
-    sqlite3_free(v->zTableName);
-    doltliteFreeColInfo(&v->cols);
-    sqlite3_free(v);
-    return rc;
-  }
-  zSchema = atBuildSchema(&v->cols);
-  if( !zSchema ){
-    sqlite3_free(v->zTableName);
-    doltliteFreeColInfo(&v->cols);
-    sqlite3_free(v);
-    return SQLITE_NOMEM;
-  }
-
-  rc = sqlite3_declare_vtab(db, zSchema);
-  sqlite3_free(zSchema);
-  if( rc != SQLITE_OK ){
-    sqlite3_free(v->zTableName);
-    doltliteFreeColInfo(&v->cols);
-    sqlite3_free(v);
-    return rc;
-  }
-
-  *ppVtab = &v->base;
-  return SQLITE_OK;
+  (void)pAux;
+  return doltliteVtabConnectUserTable(db, argc, argv, "dolt_at_",
+                                      sizeof(AtVtab), atBuildSchema,
+                                      ppVtab, pzErr);
 }
 
 static int atOpen(sqlite3_vtab *pVtab, sqlite3_vtab_cursor **pp){

--- a/src/doltlite_at.c
+++ b/src/doltlite_at.c
@@ -8,7 +8,7 @@
 #include <string.h>
 #include <time.h>
 
-static char *atBuildSchema(DoltliteColInfo *ci){
+static char *atBuildSchema(const DoltliteColInfo *ci){
   sqlite3_str *pStr = sqlite3_str_new(0);
   char *z;
   if( !pStr ) return 0;

--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -1,10 +1,7 @@
 
 #ifdef DOLTLITE_PROLLY
 
-#include "sqliteInt.h"
-#include "prolly_hash.h"
-#include "chunk_store.h"
-#include "doltlite_record.h"
+#include "doltlite_vtab_util.h"
 #include "doltlite_internal.h"
 #include <string.h>
 
@@ -334,64 +331,10 @@ static char *cfrBuildSchema(const DoltliteColInfo *ci){
 
 static int cfrConnect(sqlite3 *db, void *pAux, int argc,
     const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){
-  CfRowVtab *v;
-  int rc;
-  const char *zModuleName;
-  char *zSchema;
   (void)pAux;
-
-  v = sqlite3_malloc(sizeof(*v));
-  if(!v) return SQLITE_NOMEM;
-  memset(v,0,sizeof(*v));
-  v->db = db;
-
-  zModuleName = argv[0];
-  if( zModuleName && strncmp(zModuleName, "dolt_conflicts_", 15)==0 ){
-    v->zTableName = sqlite3_mprintf("%s", zModuleName + 15);
-  }else if( argc > 3 ){
-    v->zTableName = sqlite3_mprintf("%s", argv[3]);
-  }else{
-    v->zTableName = sqlite3_mprintf("");
-  }
-  if( !v->zTableName ){
-    sqlite3_free(v);
-    return SQLITE_NOMEM;
-  }
-
-  rc = doltliteLoadUserTableColumns(db, v->zTableName, &v->cols, pzErr);
-  if( rc!=SQLITE_OK ){
-    sqlite3_free(v->zTableName);
-    doltliteFreeColInfo(&v->cols);
-    sqlite3_free(v);
-    return rc;
-  }
-
-  zSchema = cfrBuildSchema(&v->cols);
-  if( !zSchema ){
-    sqlite3_free(v->zTableName);
-    doltliteFreeColInfo(&v->cols);
-    sqlite3_free(v);
-    return SQLITE_NOMEM;
-  }
-  rc = sqlite3_declare_vtab(db, zSchema);
-  sqlite3_free(zSchema);
-  if( rc!=SQLITE_OK ){
-    sqlite3_free(v->zTableName);
-    doltliteFreeColInfo(&v->cols);
-    sqlite3_free(v);
-    return rc;
-  }
-
-  *ppVtab = &v->base;
-  return SQLITE_OK;
-}
-
-static int cfrDisconnect(sqlite3_vtab *pVtab){
-  CfRowVtab *v = (CfRowVtab*)pVtab;
-  sqlite3_free(v->zTableName);
-  doltliteFreeColInfo(&v->cols);
-  sqlite3_free(v);
-  return SQLITE_OK;
+  return doltliteVtabConnectUserTable(db, argc, argv, "dolt_conflicts_",
+                                      sizeof(CfRowVtab), cfrBuildSchema,
+                                      ppVtab, pzErr);
 }
 
 static int cfrOpen(sqlite3_vtab *pVtab, sqlite3_vtab_cursor **pp){
@@ -597,8 +540,8 @@ static sqlite3_module cfRowModule = {
   cfrConnect,
   cfrConnect,
   cfrBestIndex,
-  cfrDisconnect,
-  cfrDisconnect,
+  doltliteVtabCommonDisconnect,
+  doltliteVtabCommonDisconnect,
   cfrOpen,
   cfrClose,
   cfrFilter,

--- a/src/doltlite_constraint_violations.c
+++ b/src/doltlite_constraint_violations.c
@@ -1,10 +1,7 @@
 
 #ifdef DOLTLITE_PROLLY
 
-#include "sqliteInt.h"
-#include "prolly_hash.h"
-#include "chunk_store.h"
-#include "doltlite_record.h"
+#include "doltlite_vtab_util.h"
 #include "doltlite_internal.h"
 #include "doltlite_constraint_violations.h"
 
@@ -424,61 +421,11 @@ static char *cvrBuildSchema(const DoltliteColInfo *ci){
 
 static int cvrConnect(sqlite3 *db, void *pAux, int argc,
     const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){
-  CvRowVtab *v;
-  int rc;
-  const char *zMod;
-  char *zSchema;
   (void)pAux;
-
-  v = sqlite3_malloc(sizeof(*v));
-  if( !v ) return SQLITE_NOMEM;
-  memset(v, 0, sizeof(*v));
-  v->db = db;
-
-  zMod = argv[0];
-  if( zMod && strncmp(zMod, "dolt_constraint_violations_", 27)==0 ){
-    v->zTableName = sqlite3_mprintf("%s", zMod + 27);
-  }else if( argc > 3 ){
-    v->zTableName = sqlite3_mprintf("%s", argv[3]);
-  }else{
-    v->zTableName = sqlite3_mprintf("");
-  }
-  if( !v->zTableName ){ sqlite3_free(v); return SQLITE_NOMEM; }
-
-  rc = doltliteLoadUserTableColumns(db, v->zTableName, &v->cols, pzErr);
-  if( rc!=SQLITE_OK ){
-    sqlite3_free(v->zTableName);
-    doltliteFreeColInfo(&v->cols);
-    sqlite3_free(v);
-    return rc;
-  }
-
-  zSchema = cvrBuildSchema(&v->cols);
-  if( !zSchema ){
-    sqlite3_free(v->zTableName);
-    doltliteFreeColInfo(&v->cols);
-    sqlite3_free(v);
-    return SQLITE_NOMEM;
-  }
-  rc = sqlite3_declare_vtab(db, zSchema);
-  sqlite3_free(zSchema);
-  if( rc!=SQLITE_OK ){
-    sqlite3_free(v->zTableName);
-    doltliteFreeColInfo(&v->cols);
-    sqlite3_free(v);
-    return rc;
-  }
-
-  *ppVtab = &v->base;
-  return SQLITE_OK;
-}
-
-static int cvrDisconnect(sqlite3_vtab *pVtab){
-  CvRowVtab *v = (CvRowVtab*)pVtab;
-  sqlite3_free(v->zTableName);
-  doltliteFreeColInfo(&v->cols);
-  sqlite3_free(v);
-  return SQLITE_OK;
+  return doltliteVtabConnectUserTable(db, argc, argv,
+                                      "dolt_constraint_violations_",
+                                      sizeof(CvRowVtab), cvrBuildSchema,
+                                      ppVtab, pzErr);
 }
 
 static int cvrOpen(sqlite3_vtab *pVtab, sqlite3_vtab_cursor **pp){
@@ -649,8 +596,8 @@ static sqlite3_module cvRowModule = {
   cvrConnect,
   cvrConnect,
   cvrBestIndex,
-  cvrDisconnect,
-  cvrDisconnect,
+  doltliteVtabCommonDisconnect,
+  doltliteVtabCommonDisconnect,
   cvrOpen,
   cvrClose,
   cvrFilter,

--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -11,7 +11,7 @@
 #include <string.h>
 #include <time.h>
 
-static char *buildDiffSchema(DoltliteColInfo *ci){
+static char *buildDiffSchema(const DoltliteColInfo *ci){
   int i;
   sqlite3_str *pStr = sqlite3_str_new(0);
   char *z;

--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -1,14 +1,10 @@
 
 #ifdef DOLTLITE_PROLLY
 
-#include "sqliteInt.h"
-#include "prolly_hash.h"
+#include "doltlite_vtab_util.h"
 #include "prolly_hashset.h"
 #include "prolly_diff.h"
-#include "prolly_cache.h"
-#include "chunk_store.h"
 #include "doltlite_commit.h"
-#include "doltlite_record.h"
 #include "doltlite_internal.h"
 
 #include <assert.h>
@@ -858,61 +854,10 @@ static int advanceToNextRow(DiffTblCursor *pCur, sqlite3 *db){
 
 static int dtConnect(sqlite3 *db, void *pAux, int argc,
     const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){
-  DiffTblVtab *pVtab;
-  int rc;
-  const char *zModName;
-  char *zSchema;
-  (void)pAux; (void)pzErr;
-
-  pVtab = sqlite3_malloc(sizeof(*pVtab));
-  if( !pVtab ) return SQLITE_NOMEM;
-  memset(pVtab, 0, sizeof(*pVtab));
-  pVtab->db = db;
-
-  zModName = argv[0];
-  if( zModName && strncmp(zModName, "dolt_diff_", 10)==0 ){
-    pVtab->zTableName = sqlite3_mprintf("%s", zModName + 10);
-  }else if( argc > 3 ){
-    pVtab->zTableName = sqlite3_mprintf("%s", argv[3]);
-  }else{
-    pVtab->zTableName = sqlite3_mprintf("");
-  }
-
-  rc = doltliteLoadUserTableColumns(db, pVtab->zTableName, &pVtab->cols, pzErr);
-  if( rc!=SQLITE_OK ){
-    sqlite3_free(pVtab->zTableName);
-    doltliteFreeColInfo(&pVtab->cols);
-    sqlite3_free(pVtab);
-    return rc;
-  }
-  zSchema = buildDiffSchema(&pVtab->cols);
-
-  if( !zSchema ){
-    sqlite3_free(pVtab->zTableName);
-    doltliteFreeColInfo(&pVtab->cols);
-    sqlite3_free(pVtab);
-    return SQLITE_NOMEM;
-  }
-
-  rc = sqlite3_declare_vtab(db, zSchema);
-  sqlite3_free(zSchema);
-  if( rc!=SQLITE_OK ){
-    sqlite3_free(pVtab->zTableName);
-    doltliteFreeColInfo(&pVtab->cols);
-    sqlite3_free(pVtab);
-    return rc;
-  }
-
-  *ppVtab = &pVtab->base;
-  return SQLITE_OK;
-}
-
-static int dtDisconnect(sqlite3_vtab *pBase){
-  DiffTblVtab *pVtab = (DiffTblVtab*)pBase;
-  sqlite3_free(pVtab->zTableName);
-  doltliteFreeColInfo(&pVtab->cols);
-  sqlite3_free(pVtab);
-  return SQLITE_OK;
+  (void)pAux;
+  return doltliteVtabConnectUserTable(db, argc, argv, "dolt_diff_",
+                                      sizeof(DiffTblVtab), buildDiffSchema,
+                                      ppVtab, pzErr);
 }
 
 static int dtBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
@@ -1076,7 +1021,8 @@ static int dtRowid(sqlite3_vtab_cursor *cur, sqlite3_int64 *r){
 }
 
 static sqlite3_module diffTableModule = {
-  0, dtConnect, dtConnect, dtBestIndex, dtDisconnect, dtDisconnect,
+  0, dtConnect, dtConnect, dtBestIndex,
+  doltliteVtabCommonDisconnect, doltliteVtabCommonDisconnect,
   dtOpen, dtClose, dtFilter, dtNext, dtEof, dtColumn, dtRowid,
   0,0,0,0,0,0,0,0,0,0,0,0
 };

--- a/src/doltlite_history.c
+++ b/src/doltlite_history.c
@@ -250,40 +250,10 @@ static int htAdvance(HistCursor *c, sqlite3 *db, const char *zTableName){
 
 static int htConnect(sqlite3 *db, void *pAux, int argc,
     const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){
-  DoltliteVtabCommon *v; int rc; const char *zMod; char *zSchema;
   (void)pAux;
-
-  v = sqlite3_malloc(sizeof(HistVtab));
-  if( !v ) return SQLITE_NOMEM;
-  memset(v, 0, sizeof(HistVtab));
-  v->db = db;
-
-  zMod = argv[0];
-  if( zMod && strncmp(zMod, "dolt_history_", 13) == 0 )
-    v->zTableName = sqlite3_mprintf("%s", zMod + 13);
-  else if( argc > 3 ) v->zTableName = sqlite3_mprintf("%s", argv[3]);
-  else v->zTableName = sqlite3_mprintf("");
-
-  rc = doltliteLoadUserTableColumns(db, v->zTableName, &v->cols, pzErr);
-  if( rc!=SQLITE_OK ){
-    sqlite3_free(v->zTableName); doltliteFreeColInfo(&v->cols); sqlite3_free(v);
-    return rc;
-  }
-  zSchema = htBuildSchema(&v->cols);
-  if( !zSchema ){
-    sqlite3_free(v->zTableName); doltliteFreeColInfo(&v->cols); sqlite3_free(v);
-    return SQLITE_NOMEM;
-  }
-
-  rc = sqlite3_declare_vtab(db, zSchema);
-  sqlite3_free(zSchema);
-  if( rc!=SQLITE_OK ){
-    sqlite3_free(v->zTableName); doltliteFreeColInfo(&v->cols); sqlite3_free(v);
-    return rc;
-  }
-
-  *ppVtab = &v->base;
-  return SQLITE_OK;
+  return doltliteVtabConnectUserTable(db, argc, argv, "dolt_history_",
+                                      sizeof(HistVtab), htBuildSchema,
+                                      ppVtab, pzErr);
 }
 
 static int htBestIndex(sqlite3_vtab *v, sqlite3_index_info *p){

--- a/src/doltlite_history.c
+++ b/src/doltlite_history.c
@@ -8,7 +8,7 @@
 #include <string.h>
 #include <time.h>
 
-static char *htBuildSchema(DoltliteColInfo *ci){
+static char *htBuildSchema(const DoltliteColInfo *ci){
   sqlite3_str *pStr = sqlite3_str_new(0);
   char *z;
   if( !pStr ) return 0;

--- a/src/doltlite_history.c
+++ b/src/doltlite_history.c
@@ -1,15 +1,9 @@
 
 #ifdef DOLTLITE_PROLLY
 
-#include "sqliteInt.h"
-#include "prolly_hash.h"
-#include "prolly_cursor.h"
-#include "prolly_cache.h"
+#include "doltlite_vtab_util.h"
 #include "prolly_hashset.h"
-#include "chunk_store.h"
 #include "doltlite_commit.h"
-
-#include "doltlite_record.h"
 #include "doltlite_internal.h"
 #include <string.h>
 #include <time.h>
@@ -45,7 +39,7 @@ struct HistVtab {
 
 typedef struct HistCursor HistCursor;
 struct HistCursor {
-  sqlite3_vtab_cursor base;
+  DoltliteVtabCursorCommon common;
   ProllyHash *aQueue;
   int qHead, qTail, qAlloc;
   ProllyHashSet visited, queued;
@@ -53,12 +47,6 @@ struct HistCursor {
   char zCommitHex[PROLLY_HASH_SIZE*2+1];
   char *zCommitter;
   i64 commitDate;
-  ProllyCursor tblCur;
-  int tblCurOpen;
-  i64 intKey;
-  u8 *pVal; int nVal;
-  int hasRow;
-  i64 iRowid;
   int idxNum;
   i64 pkLo;
   i64 pkHi;
@@ -69,12 +57,7 @@ struct HistCursor {
 };
 
 static void htCursorReset(HistCursor *c){
-  if( c->tblCurOpen ){
-    prollyCursorClose(&c->tblCur);
-    c->tblCurOpen = 0;
-  }
-  sqlite3_free(c->pVal);
-  c->pVal = 0; c->nVal = 0;
+  doltliteVtabCommonReset(&c->common);
   sqlite3_free(c->zCommitter);
   c->zCommitter = 0;
   sqlite3_free(c->aQueue);
@@ -88,30 +71,12 @@ static void htCursorReset(HistCursor *c){
     prollyHashSetFree(&c->queued);
     c->queuedInit = 0;
   }
-  c->hasRow = 0;
-  c->iRowid = 0;
-}
-
-static int htCaptureRow(HistCursor *c){
-  const u8 *pVal; int nVal;
-  sqlite3_free(c->pVal);
-  c->pVal = 0; c->nVal = 0;
-  c->intKey = prollyCursorIntKey(&c->tblCur);
-  prollyCursorValue(&c->tblCur, &pVal, &nVal);
-  if( pVal && nVal>0 ){
-    c->pVal = sqlite3_malloc(nVal);
-    if( !c->pVal ) return SQLITE_NOMEM;
-    memcpy(c->pVal, pVal, nVal);
-    c->nVal = nVal;
-  }
-  c->hasRow = 1;
-  return SQLITE_OK;
 }
 
 static int htRowMatchesUpper(HistCursor *c){
   i64 k;
   if( !c->hasPkHi ) return 1;
-  k = prollyCursorIntKey(&c->tblCur);
+  k = prollyCursorIntKey(&c->common.tblCur);
   if( c->pkHiStrict ){
     return k < c->pkHi;
   }
@@ -183,84 +148,84 @@ static int htOpenTableAtCommit(HistCursor *c, sqlite3 *db,
   }
   doltliteFreeCatalog(aT, nT);
 
-  prollyCursorInit(&c->tblCur, cs, pCache, &tableRoot, flags);
+  prollyCursorInit(&c->common.tblCur, cs, pCache, &tableRoot, flags);
 
   seekable = (flags & PROLLY_NODE_INTKEY) != 0
           && (c->idxNum & HIST_IDX_PK_ANY) != 0;
 
   if( seekable && (c->idxNum & HIST_IDX_PK_EQ) ){
-    rc = prollyCursorSeekInt(&c->tblCur, c->pkLo, &res);
+    rc = prollyCursorSeekInt(&c->common.tblCur, c->pkLo, &res);
     if( rc!=SQLITE_OK ){
-      prollyCursorClose(&c->tblCur);
+      prollyCursorClose(&c->common.tblCur);
       return rc;
     }
-    if( res!=0 || !prollyCursorIsValid(&c->tblCur) ){
-      prollyCursorClose(&c->tblCur);
+    if( res!=0 || !prollyCursorIsValid(&c->common.tblCur) ){
+      prollyCursorClose(&c->common.tblCur);
       return SQLITE_OK;
     }
-    c->tblCurOpen = 1;
+    c->common.tblCurOpen = 1;
     return SQLITE_OK;
   }
 
   if( seekable && c->hasPkLo ){
     i64 startKey = c->pkLo;
     if( c->pkLoStrict ) startKey++;
-    rc = prollyCursorSeekInt(&c->tblCur, startKey, &res);
+    rc = prollyCursorSeekInt(&c->common.tblCur, startKey, &res);
     if( rc!=SQLITE_OK ){
-      prollyCursorClose(&c->tblCur);
+      prollyCursorClose(&c->common.tblCur);
       return rc;
     }
     if( res<0 ){
-      rc = prollyCursorNext(&c->tblCur);
+      rc = prollyCursorNext(&c->common.tblCur);
       if( rc!=SQLITE_OK ){
-        prollyCursorClose(&c->tblCur);
+        prollyCursorClose(&c->common.tblCur);
         return rc;
       }
     }
-    if( !prollyCursorIsValid(&c->tblCur) || !htRowMatchesUpper(c) ){
-      prollyCursorClose(&c->tblCur);
+    if( !prollyCursorIsValid(&c->common.tblCur) || !htRowMatchesUpper(c) ){
+      prollyCursorClose(&c->common.tblCur);
       return SQLITE_OK;
     }
-    c->tblCurOpen = 1;
+    c->common.tblCurOpen = 1;
     return SQLITE_OK;
   }
 
-  rc = prollyCursorFirst(&c->tblCur, &res);
+  rc = prollyCursorFirst(&c->common.tblCur, &res);
   if( rc!=SQLITE_OK ){
-    prollyCursorClose(&c->tblCur);
+    prollyCursorClose(&c->common.tblCur);
     return rc;
   }
   if( res ){
-    prollyCursorClose(&c->tblCur);
+    prollyCursorClose(&c->common.tblCur);
     return SQLITE_OK;
   }
   if( seekable && c->hasPkHi && !htRowMatchesUpper(c) ){
-    prollyCursorClose(&c->tblCur);
+    prollyCursorClose(&c->common.tblCur);
     return SQLITE_OK;
   }
-  c->tblCurOpen = 1;
+  c->common.tblCurOpen = 1;
   return SQLITE_OK;
 }
 
 static int htAdvance(HistCursor *c, sqlite3 *db, const char *zTableName){
   int rc;
 
-  if( c->tblCurOpen ){
+  if( c->common.tblCurOpen ){
     if( c->idxNum & HIST_IDX_PK_EQ ){
-      prollyCursorClose(&c->tblCur);
-      c->tblCurOpen = 0;
+      prollyCursorClose(&c->common.tblCur);
+      c->common.tblCurOpen = 0;
     }else{
-      rc = prollyCursorNext(&c->tblCur);
+      rc = prollyCursorNext(&c->common.tblCur);
       if( rc!=SQLITE_OK ){
-        prollyCursorClose(&c->tblCur);
-        c->tblCurOpen = 0;
+        prollyCursorClose(&c->common.tblCur);
+        c->common.tblCurOpen = 0;
         return rc;
       }
-      if( prollyCursorIsValid(&c->tblCur) && htRowMatchesUpper(c) ){
-        return htCaptureRow(c);
+      if( prollyCursorIsValid(&c->common.tblCur) && htRowMatchesUpper(c) ){
+        return doltliteVtabCommonCaptureRow(&c->common);
       }
-      prollyCursorClose(&c->tblCur);
-      c->tblCurOpen = 0;
+      prollyCursorClose(&c->common.tblCur);
+      c->common.tblCurOpen = 0;
     }
   }
 
@@ -274,51 +239,55 @@ static int htAdvance(HistCursor *c, sqlite3 *db, const char *zTableName){
     rc = htOpenTableAtCommit(c, db, zTableName, &cur);
     if( rc!=SQLITE_OK ) return rc;
 
-    if( c->tblCurOpen ){
-      return htCaptureRow(c);
+    if( c->common.tblCurOpen ){
+      return doltliteVtabCommonCaptureRow(&c->common);
     }
   }
 
-  c->hasRow = 0;
+  c->common.hasRow = 0;
   return SQLITE_OK;
 }
 
 static int htConnect(sqlite3 *db, void *pAux, int argc,
     const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){
-  HistVtab *v; int rc; const char *zMod; char *zSchema;
+  DoltliteVtabCommon *v; int rc; const char *zMod; char *zSchema;
   (void)pAux;
 
-  v=sqlite3_malloc(sizeof(*v)); if(!v) return SQLITE_NOMEM;
-  memset(v,0,sizeof(*v)); v->db=db;
+  v = sqlite3_malloc(sizeof(HistVtab));
+  if( !v ) return SQLITE_NOMEM;
+  memset(v, 0, sizeof(HistVtab));
+  v->db = db;
 
-  zMod=argv[0];
-  if(zMod&&strncmp(zMod,"dolt_history_",13)==0)
-    v->zTableName=sqlite3_mprintf("%s",zMod+13);
-  else if(argc>3) v->zTableName=sqlite3_mprintf("%s",argv[3]);
-  else v->zTableName=sqlite3_mprintf("");
+  zMod = argv[0];
+  if( zMod && strncmp(zMod, "dolt_history_", 13) == 0 )
+    v->zTableName = sqlite3_mprintf("%s", zMod + 13);
+  else if( argc > 3 ) v->zTableName = sqlite3_mprintf("%s", argv[3]);
+  else v->zTableName = sqlite3_mprintf("");
 
   rc = doltliteLoadUserTableColumns(db, v->zTableName, &v->cols, pzErr);
   if( rc!=SQLITE_OK ){
-    sqlite3_free(v->zTableName);doltliteFreeColInfo(&v->cols);sqlite3_free(v);
+    sqlite3_free(v->zTableName); doltliteFreeColInfo(&v->cols); sqlite3_free(v);
     return rc;
   }
-  zSchema=htBuildSchema(&v->cols);
-  if(!zSchema){sqlite3_free(v->zTableName);doltliteFreeColInfo(&v->cols);sqlite3_free(v);return SQLITE_NOMEM;}
+  zSchema = htBuildSchema(&v->cols);
+  if( !zSchema ){
+    sqlite3_free(v->zTableName); doltliteFreeColInfo(&v->cols); sqlite3_free(v);
+    return SQLITE_NOMEM;
+  }
 
-  rc=sqlite3_declare_vtab(db,zSchema); sqlite3_free(zSchema);
-  if(rc!=SQLITE_OK){sqlite3_free(v->zTableName);doltliteFreeColInfo(&v->cols);sqlite3_free(v);return rc;}
+  rc = sqlite3_declare_vtab(db, zSchema);
+  sqlite3_free(zSchema);
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(v->zTableName); doltliteFreeColInfo(&v->cols); sqlite3_free(v);
+    return rc;
+  }
 
-  *ppVtab=&v->base; return SQLITE_OK;
-}
-
-static int htDisconnect(sqlite3_vtab *pVtab){
-  HistVtab *v=(HistVtab*)pVtab;
-  sqlite3_free(v->zTableName); doltliteFreeColInfo(&v->cols);
-  sqlite3_free(v); return SQLITE_OK;
+  *ppVtab = &v->base;
+  return SQLITE_OK;
 }
 
 static int htBestIndex(sqlite3_vtab *v, sqlite3_index_info *p){
-  HistVtab *vt = (HistVtab*)v;
+  DoltliteVtabCommon *vt = (DoltliteVtabCommon*)v;
   int iEq = -1, iGe = -1, iLe = -1, iGt = -1, iLt = -1;
   int i, nArg = 0, idxNum = 0;
   int iPk = vt->cols.iPkCol;
@@ -395,7 +364,7 @@ static int htClose(sqlite3_vtab_cursor *cur){
 static int htFilter(sqlite3_vtab_cursor *cur,
     int idxNum, const char *idxStr, int argc, sqlite3_value **argv){
   HistCursor *c=(HistCursor*)cur;
-  HistVtab *v=(HistVtab*)cur->pVtab;
+  DoltliteVtabCommon *v=(DoltliteVtabCommon*)cur->pVtab;
   ProllyHash head;
   ChunkStore *cs;
   int rc;
@@ -478,24 +447,21 @@ static int htFilter(sqlite3_vtab_cursor *cur,
 
 static int htNext(sqlite3_vtab_cursor *cur){
   HistCursor *c=(HistCursor*)cur;
-  HistVtab *v=(HistVtab*)cur->pVtab;
-  c->iRowid++;
+  DoltliteVtabCommon *v=(DoltliteVtabCommon*)cur->pVtab;
+  c->common.iRowid++;
   return htAdvance(c, v->db, v->zTableName);
-}
-
-static int htEof(sqlite3_vtab_cursor *cur){
-  return !((HistCursor*)cur)->hasRow;
 }
 
 static int htColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
   HistCursor *c=(HistCursor*)cur;
-  HistVtab *v=(HistVtab*)cur->pVtab;
+  DoltliteVtabCommon *v=(DoltliteVtabCommon*)cur->pVtab;
   int nCols;
-  if( !c->hasRow ) return SQLITE_OK;
+  if( !c->common.hasRow ) return SQLITE_OK;
   nCols=v->cols.nCol;
 
   if(nCols>0 && col<nCols){
-    doltliteResultUserCol(ctx, &v->cols, c->pVal, c->nVal, c->intKey, col);
+    doltliteResultUserCol(ctx, &v->cols, c->common.pVal, c->common.nVal,
+                          c->common.intKey, col);
   }else{
     int fixedCol=col-nCols;
     switch(fixedCol){
@@ -513,13 +479,11 @@ static int htColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
   return SQLITE_OK;
 }
 
-static int htRowid(sqlite3_vtab_cursor *cur, sqlite3_int64 *r){
-  *r=((HistCursor*)cur)->iRowid; return SQLITE_OK;
-}
-
 static sqlite3_module historyModule = {
-  0, htConnect, htConnect, htBestIndex, htDisconnect, htDisconnect,
-  htOpen, htClose, htFilter, htNext, htEof, htColumn, htRowid,
+  0, htConnect, htConnect, htBestIndex,
+  doltliteVtabCommonDisconnect, doltliteVtabCommonDisconnect,
+  htOpen, htClose, htFilter, htNext,
+  doltliteVtabCommonEof, htColumn, doltliteVtabCommonRowid,
   0,0,0,0,0,0,0,0,0,0,0,0
 };
 

--- a/src/doltlite_vtab_util.h
+++ b/src/doltlite_vtab_util.h
@@ -1,0 +1,111 @@
+#ifndef DOLTLITE_VTAB_UTIL_H
+#define DOLTLITE_VTAB_UTIL_H
+
+#include "sqliteInt.h"
+#include "prolly_hash.h"
+#include "prolly_cursor.h"
+#include "prolly_cache.h"
+#include "chunk_store.h"
+#include "doltlite_record.h"
+#include "record_codec.h"
+
+/*
+ * Shared prefix for virtual table instances whose per-table metadata
+ * consist of (db, zTableName, cols) immediately after the base vtab.
+ * AtVtab and HistVtab both start with this exact layout, so a pointer
+ * to either can safely be cast to DoltliteVtabCommon*.
+ */
+typedef struct DoltliteVtabCommon DoltliteVtabCommon;
+struct DoltliteVtabCommon {
+  sqlite3_vtab base;
+  sqlite3 *db;
+  char *zTableName;
+  DoltliteColInfo cols;
+};
+
+/*
+ * Shared prefix for virtual table cursors whose per-row state includes
+ * a prolly cursor, intKey, pVal/nVal, hasRow, and iRowid.  Both
+ * AtCursor and HistCursor embed this as their first member so that
+ * the shared inline helpers below can operate through a
+ * DoltliteVtabCursorCommon pointer.
+ */
+typedef struct DoltliteVtabCursorCommon DoltliteVtabCursorCommon;
+struct DoltliteVtabCursorCommon {
+  sqlite3_vtab_cursor base;
+  ProllyCursor tblCur;
+  int tblCurOpen;
+  i64 intKey;
+  u8 *pVal;
+  int nVal;
+  int hasRow;
+  i64 iRowid;
+};
+
+static SQLITE_INLINE void doltliteVtabCommonReset(
+  DoltliteVtabCursorCommon *c
+){
+  if( c->tblCurOpen ){
+    prollyCursorClose(&c->tblCur);
+    c->tblCurOpen = 0;
+  }
+  sqlite3_free(c->pVal);
+  c->pVal = 0;
+  c->nVal = 0;
+  c->hasRow = 0;
+  c->iRowid = 0;
+}
+
+static SQLITE_INLINE int doltliteVtabCommonCaptureRow(
+  DoltliteVtabCursorCommon *c
+){
+  const u8 *pVal; int nVal;
+  sqlite3_free(c->pVal);
+  c->pVal = 0; c->nVal = 0;
+  c->intKey = prollyCursorIntKey(&c->tblCur);
+  prollyCursorValue(&c->tblCur, &pVal, &nVal);
+  if( pVal && nVal>0 ){
+    c->pVal = sqlite3_malloc(nVal);
+    if( !c->pVal ) return SQLITE_NOMEM;
+    memcpy(c->pVal, pVal, nVal);
+    c->nVal = nVal;
+  }
+  c->hasRow = 1;
+  return SQLITE_OK;
+}
+
+static SQLITE_INLINE int doltliteVtabCommonClose(
+  sqlite3_vtab_cursor *cur
+){
+  DoltliteVtabCursorCommon *c = (DoltliteVtabCursorCommon*)cur;
+  doltliteVtabCommonReset(c);
+  sqlite3_free(c);
+  return SQLITE_OK;
+}
+
+static SQLITE_INLINE int doltliteVtabCommonDisconnect(
+  sqlite3_vtab *pVtab
+){
+  DoltliteVtabCommon *v = (DoltliteVtabCommon*)pVtab;
+  sqlite3_free(v->zTableName);
+  doltliteFreeColInfo(&v->cols);
+  sqlite3_free(v);
+  return SQLITE_OK;
+}
+
+static SQLITE_INLINE int doltliteVtabCommonEof(
+  sqlite3_vtab_cursor *cur
+){
+  DoltliteVtabCursorCommon *c = (DoltliteVtabCursorCommon*)cur;
+  return !c->hasRow;
+}
+
+static SQLITE_INLINE int doltliteVtabCommonRowid(
+  sqlite3_vtab_cursor *cur,
+  sqlite3_int64 *r
+){
+  *r = ((DoltliteVtabCursorCommon*)cur)->iRowid;
+  return SQLITE_OK;
+}
+
+#endif /* DOLTLITE_VTAB_UTIL_H */

--- a/src/doltlite_vtab_util.h
+++ b/src/doltlite_vtab_util.h
@@ -98,4 +98,55 @@ static SQLITE_INLINE int doltliteVtabCommonRowid(
   return SQLITE_OK;
 }
 
+/*
+ * xConnect/xCreate body for a per-user-table vtab whose instance begins with
+ * DoltliteVtabCommon: derive the table name from the module name (zPrefix) or
+ * argv[3], load its columns, build the schema via xBuildSchema, and declare
+ * the vtab. Allocates nByte (>= sizeof(DoltliteVtabCommon)) so callers with
+ * trailing fields can use it and fill them in after success. On any failure
+ * the partial instance is freed through doltliteVtabCommonDisconnect.
+ */
+static SQLITE_INLINE int doltliteVtabConnectUserTable(
+  sqlite3 *db, int argc, const char *const *argv,
+  const char *zPrefix, int nByte,
+  char *(*xBuildSchema)(DoltliteColInfo*),
+  sqlite3_vtab **ppVtab, char **pzErr
+){
+  DoltliteVtabCommon *v;
+  const char *zMod = argv[0];
+  size_t nPrefix = strlen(zPrefix);
+  char *zSchema;
+  int rc;
+
+  v = sqlite3_malloc(nByte);
+  if( !v ) return SQLITE_NOMEM;
+  memset(v, 0, nByte);
+  v->db = db;
+
+  if( zMod && strncmp(zMod, zPrefix, nPrefix)==0 ){
+    v->zTableName = sqlite3_mprintf("%s", zMod + nPrefix);
+  }else if( argc > 3 ){
+    v->zTableName = sqlite3_mprintf("%s", argv[3]);
+  }else{
+    v->zTableName = sqlite3_mprintf("");
+  }
+
+  rc = doltliteLoadUserTableColumns(db, v->zTableName, &v->cols, pzErr);
+  if( rc==SQLITE_OK ){
+    zSchema = xBuildSchema(&v->cols);
+    if( !zSchema ){
+      rc = SQLITE_NOMEM;
+    }else{
+      rc = sqlite3_declare_vtab(db, zSchema);
+      sqlite3_free(zSchema);
+    }
+  }
+  if( rc!=SQLITE_OK ){
+    doltliteVtabCommonDisconnect(&v->base);
+    return rc;
+  }
+  *ppVtab = &v->base;
+  return SQLITE_OK;
+}
+
 #endif /* DOLTLITE_VTAB_UTIL_H */

--- a/src/doltlite_vtab_util.h
+++ b/src/doltlite_vtab_util.h
@@ -109,7 +109,7 @@ static SQLITE_INLINE int doltliteVtabCommonRowid(
 static SQLITE_INLINE int doltliteVtabConnectUserTable(
   sqlite3 *db, int argc, const char *const *argv,
   const char *zPrefix, int nByte,
-  char *(*xBuildSchema)(DoltliteColInfo*),
+  char *(*xBuildSchema)(const DoltliteColInfo*),
   sqlite3_vtab **ppVtab, char **pzErr
 ){
   DoltliteVtabCommon *v;

--- a/src/doltlite_vtab_util.h
+++ b/src/doltlite_vtab_util.h
@@ -7,7 +7,6 @@
 #include "prolly_cache.h"
 #include "chunk_store.h"
 #include "doltlite_record.h"
-#include "record_codec.h"
 
 /*
  * Shared prefix for virtual table instances whose per-table metadata
@@ -71,15 +70,6 @@ static SQLITE_INLINE int doltliteVtabCommonCaptureRow(
     c->nVal = nVal;
   }
   c->hasRow = 1;
-  return SQLITE_OK;
-}
-
-static SQLITE_INLINE int doltliteVtabCommonClose(
-  sqlite3_vtab_cursor *cur
-){
-  DoltliteVtabCursorCommon *c = (DoltliteVtabCursorCommon*)cur;
-  doltliteVtabCommonReset(c);
-  sqlite3_free(c);
   return SQLITE_OK;
 }
 

--- a/src/doltlite_workspace.c
+++ b/src/doltlite_workspace.c
@@ -1,14 +1,10 @@
 
 #ifdef DOLTLITE_PROLLY
 
-#include "sqliteInt.h"
-#include "prolly_hash.h"
+#include "doltlite_vtab_util.h"
 #include "prolly_diff.h"
 #include "prolly_mutate.h"
-#include "prolly_cache.h"
-#include "chunk_store.h"
 #include "doltlite_commit.h"
-#include "doltlite_record.h"
 #include "doltlite_internal.h"
 
 #include <string.h>
@@ -56,7 +52,7 @@ static void wsClearCache(WorkspaceVtab *p){
   p->nCache = 0;
 }
 
-static char *wsBuildSchema(DoltliteColInfo *ci){
+static char *wsBuildSchema(const DoltliteColInfo *ci){
   sqlite3_str *pStr = sqlite3_str_new(0);
   char *z;
   int i;
@@ -231,47 +227,14 @@ static int wsLoadRows(WorkspaceVtab *pVtab){
 
 static int wsConnect(sqlite3 *db, void *pAux, int argc,
     const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){
-  WorkspaceVtab *pVtab;
-  const char *zModName;
-  char *zSchema;
-  int rc;
   (void)pAux;
-
-  pVtab = sqlite3_malloc(sizeof(*pVtab));
-  if( !pVtab ) return SQLITE_NOMEM;
-  memset(pVtab, 0, sizeof(*pVtab));
-  pVtab->db = db;
-  zModName = argv[0];
-  if( zModName && strncmp(zModName, "dolt_workspace_", 15)==0 ){
-    pVtab->zTableName = sqlite3_mprintf("%s", zModName + 15);
-  }else if( argc>3 ){
-    pVtab->zTableName = sqlite3_mprintf("%s", argv[3]);
-  }else{
-    pVtab->zTableName = sqlite3_mprintf("");
-  }
-  rc = doltliteLoadUserTableColumns(db, pVtab->zTableName, &pVtab->cols, pzErr);
-  if( rc!=SQLITE_OK ){
-    sqlite3_free(pVtab->zTableName);
-    sqlite3_free(pVtab);
-    return rc;
-  }
-  zSchema = wsBuildSchema(&pVtab->cols);
-  if( !zSchema ){
-    doltliteFreeColInfo(&pVtab->cols);
-    sqlite3_free(pVtab->zTableName);
-    sqlite3_free(pVtab);
-    return SQLITE_NOMEM;
-  }
-  rc = sqlite3_declare_vtab(db, zSchema);
-  sqlite3_free(zSchema);
-  if( rc!=SQLITE_OK ){
-    doltliteFreeColInfo(&pVtab->cols);
-    sqlite3_free(pVtab->zTableName);
-    sqlite3_free(pVtab);
-    return rc;
-  }
-  *ppVtab = &pVtab->base;
-  return SQLITE_OK;
+  /* WorkspaceVtab has trailing aCache/nCache fields, but they start zeroed
+  ** and only fill in during xFilter, so the shared Connect (which inits the
+  ** common prefix and cleans up via the common disconnect on failure) is
+  ** safe here; wsDisconnect still frees the cache at teardown. */
+  return doltliteVtabConnectUserTable(db, argc, argv, "dolt_workspace_",
+                                      sizeof(WorkspaceVtab), wsBuildSchema,
+                                      ppVtab, pzErr);
 }
 
 static int wsDisconnect(sqlite3_vtab *pBase){

--- a/tool/mksqlite3c.tcl
+++ b/tool/mksqlite3c.tcl
@@ -238,7 +238,7 @@ if {$doltlite} {
     prolly_three_way_merge.h prolly_xxhash.h
     doltlite_ancestor.h doltlite_chunk_walk.h doltlite_commit.h
     doltlite_constraint_violations.h doltlite_ignore.h doltlite_internal.h
-    doltlite_record.h doltlite_remote.h doltlite_remotesrv.h
+    doltlite_record.h doltlite_remote.h doltlite_remotesrv.h doltlite_vtab_util.h
   } {
     set available_hdr($hdr) 1
   }


### PR DESCRIPTION
Collapses the duplicated virtual-table boilerplate across the doltlite vtabs into one shared header, `src/doltlite_vtab_util.h`.

## What's shared

**`DoltliteVtabCursorCommon`** — the prolly-scan cursor state (`tblCur`, `intKey`, `pVal/nVal`, `hasRow`, `iRowid`) embedded as the first member of `AtCursor`/`HistCursor`, with shared `Reset`/`CaptureRow`/`Eof`/`Rowid` helpers. Retires 6 pairs of identical functions between `dolt_at` and `dolt_history`.

**`DoltliteVtabCommon`** — the per-table vtab prefix (`base, db, zTableName, cols`) plus a shared `Disconnect`. `dolt_diff_table`, `dolt_conflicts`, and `dolt_constraint_violations` (exact same struct shape) adopt it directly.

**`doltliteVtabConnectUserTable`** — the column-loading `xConnect` body (derive table name from the module prefix or `argv[3]`, load columns, build schema via a callback, declare, with the triple free-on-error cleanup) factored once. All six per-table vtabs — `dolt_at`, `dolt_history`, `dolt_diff_table`, `dolt_conflicts`, `dolt_constraint_violations`, `dolt_workspace` — now have a one-line `xConnect`. (`dolt_workspace` keeps a custom disconnect since it also frees a row cache.) All six schema builders are made `const`-correct to match the callback.

Net effect: each vtab's lifecycle boilerplate lives in one place, so a fix or change happens once instead of drifting across files.

## Build wiring

`doltlite_vtab_util.h` is a new internal header, so it's registered for the amalgamation: copied into `tsrc/` (`main.mk`) and inlined by `tool/mksqlite3c.tcl`. Without both, the generated `sqlite3.c` keeps a literal `#include` that fails to compile standalone (sqllogictest/wasm/release).

## Validation

- Builds warning-free; amalgamation regenerates and `sqlite3.c` compiles standalone (sqllogictest's build).
- Suites green: `doltlite_at` 46/46, `doltlite_history` 40/40, `doltlite_diff` 40/40, `doltlite_conflicts` 40/40, `doltlite_conflict_rows` 29/29, `doltlite_workspace` 7/7, `doltlite_merge` 91/91.
- Converted paths clean under `-fsanitize=address,undefined` with leak detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)