### PR TITLE
Collapse per-table schema-hash queries into one sqlite_master scan

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -235,63 +235,31 @@ int doltliteHasUncommittedChanges(sqlite3 *db){
 }
 
 void doltliteUpdateSchemaHashes(sqlite3 *db){
-  int idx = 0;
-  Pgno iTable;
-  const char *zName;
-  while( (zName = doltliteNextTableForSchema(db, &idx, &iTable)) != 0 ){
-    sqlite3_stmt *pStmt = 0;
-    /* zName points into the catalog, and stepping the query below can
-    ** begin a transaction that reloads it (cherry-pick refresh). */
-    char *zNameCopy = sqlite3_mprintf("%s", zName);
-    char *zSql = zNameCopy ? sqlite3_mprintf(
-      "SELECT sql FROM sqlite_master WHERE type='table' AND tbl_name='%q'",
-      zNameCopy) : 0;
-    if( zSql ){
-      if( sqlite3_prepare_v2(db, zSql, -1, &pStmt, 0)==SQLITE_OK ){
-        if( sqlite3_step(pStmt)==SQLITE_ROW ){
-          const char *zCreate = (const char*)sqlite3_column_text(pStmt, 0);
-          if( zCreate ){
-            ProllyHash h;
-            char *zCanon = doltliteCanonicalizeSchemaSql(zCreate, zNameCopy);
-            if( zCanon ){
-              prollyHashCompute(zCanon, (int)strlen(zCanon), &h);
-              sqlite3_free(zCanon);
-              doltliteSetTableSchemaHash(db, iTable, &h);
-            }
-          }
-        }
-        sqlite3_finalize(pStmt);
-      }
-      sqlite3_free(zSql);
-    }
-    sqlite3_free(zNameCopy);
-  }
-
-  {
-    sqlite3_stmt *pStmt = 0;
-    if( sqlite3_prepare_v2(
-          db,
-          "SELECT name, rootpage, sql "
-          "FROM main.sqlite_master "
-          "WHERE type='index' AND sql IS NOT NULL",
-          -1, &pStmt, 0
-        )==SQLITE_OK ){
-      while( sqlite3_step(pStmt)==SQLITE_ROW ){
-        const char *zIdxName = (const char*)sqlite3_column_text(pStmt, 0);
-        Pgno iRoot = (Pgno)sqlite3_column_int(pStmt, 1);
-        const char *zCreate = (const char*)sqlite3_column_text(pStmt, 2);
-        if( zIdxName && zCreate ){
-          ProllyHash h;
-          char *zCanon = doltliteCanonicalizeSchemaSql(zCreate, zIdxName);
-          if( zCanon ){
-            prollyHashCompute(zCanon, (int)strlen(zCanon), &h);
-            sqlite3_free(zCanon);
-            doltliteSetTableSchemaHash(db, iRoot, &h);
-          }
+  sqlite3_stmt *pStmt = 0;
+  /* One scan of sqlite_master covers every table and index; both key their
+  ** catalog entry by rootpage and canonicalize by their own name. */
+  if( sqlite3_prepare_v2(
+        db,
+        "SELECT name, rootpage, sql "
+        "FROM main.sqlite_master "
+        "WHERE type IN ('table','index') AND sql IS NOT NULL",
+        -1, &pStmt, 0
+      )==SQLITE_OK ){
+    while( sqlite3_step(pStmt)==SQLITE_ROW ){
+      const char *zName = (const char*)sqlite3_column_text(pStmt, 0);
+      Pgno iRoot = (Pgno)sqlite3_column_int(pStmt, 1);
+      const char *zCreate = (const char*)sqlite3_column_text(pStmt, 2);
+      if( zName && zCreate ){
+        ProllyHash h;
+        char *zCanon = doltliteCanonicalizeSchemaSql(zCreate, zName);
+        if( zCanon ){
+          prollyHashCompute(zCanon, (int)strlen(zCanon), &h);
+          sqlite3_free(zCanon);
+          doltliteSetTableSchemaHash(db, iRoot, &h);
         }
       }
-      sqlite3_finalize(pStmt);
     }
+    sqlite3_finalize(pStmt);
   }
 }
 


### PR DESCRIPTION
`doltliteUpdateSchemaHashes` runs on every commit/persist (from `doltliteFlushAndSerializeCatalog`). It issued a **separate `SELECT ... FROM sqlite_master` per table** — one prepared statement, step, finalize for each — and only then a single bulk query for indexes. So a database with N tables paid N+1 prepared-statement round-trips against `sqlite_master` on every commit, independent of the changeset.

Tables and indexes both key their catalog entry by `rootpage` (via `doltliteSetTableSchemaHash`, which the index branch already relied on) and canonicalize by their own `name`, so this collapses the whole thing into a single scan over both types. **Behavior is unchanged** — same hashes written for the same objects.

### Why not skip the recompute entirely when no DDL happened?

That was the first thing I tried — gate on `bSchemaChangedTxn`. It's wrong: merge / cherry-pick / reset rewrite the catalog directly without going through SQL DDL, so they never set that flag, and the merge result's catalog hash depends on this recompute. It broke `doltlite_merge` (2 failures) and neither `bSchemaChangedTxn` nor `bMasterRootChangedTxn` is set by the VC catalog-rewrite paths. A correct skip needs a schema-dirty signal threaded through every VC catalog-apply site — a bigger, riskier change for its own PR. This PR takes the safe constant-factor win.

### Validation

Local (the suites that caught the bad gate): merge 91/91, schema_diff 49/49, commit 44/44, diff 40/40, staging 31/31, schema_cookie 5/5, branch 62/62, cherry_pick 98/98, reset 49/49, revert_dirty 14/14. Full suite on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)