### PR TITLE
Prune unchanged table merge constraint scans

### DIFF
--- a/src/doltlite_merge_constraints.c
+++ b/src/doltlite_merge_constraints.c
@@ -137,74 +137,60 @@ static int fetchRowByBlobKey(
 
 static int tableHasRowid(sqlite3 *db, const char *zTable);
 
-static int fkRefreshAppendName(char ***pazNames, int *pnNames, const char *zName){
-  char **azNames = *pazNames;
-  int nNames = *pnNames;
-  int i;
-  char **azNew;
-
-  if( !zName || !zName[0] ) return SQLITE_OK;
-  for(i=0; i<nNames; i++){
-    if( strcmp(azNames[i], zName)==0 ) return SQLITE_OK;
-  }
-
-  azNew = sqlite3_realloc64(azNames, (sqlite3_uint64)(nNames+1) * sizeof(char*));
-  if( !azNew ) return SQLITE_NOMEM;
-  azNames = azNew;
-  azNames[nNames] = sqlite3_mprintf("%s", zName);
-  if( !azNames[nNames] ) return SQLITE_NOMEM;
-  *pazNames = azNames;
-  *pnNames = nNames + 1;
-  return SQLITE_OK;
+static int tableEntryDiffers(
+  const struct TableEntry *a,
+  const struct TableEntry *b
+){
+  if( !a && !b ) return 0;
+  if( !a || !b ) return 1;
+  if( prollyHashCompare(&a->root, &b->root)!=0 ) return 1;
+  if( prollyHashCompare(&a->schemaHash, &b->schemaHash)!=0 ) return 1;
+  return 0;
 }
 
-static int fkRefreshCandidateTables(sqlite3 *db, int *pChanged){
-  sqlite3_stmt *pStmt = 0;
-  char **azNames = 0;
-  int nNames = 0;
-  int rc, stepRc, i;
+static int catalogTableChanged(
+  struct TableEntry *aAnc, int nAnc,
+  struct TableEntry *aCur, int nCur,
+  const char *zTable
+){
+  return tableEntryDiffers(
+      doltliteFindTableByName(aAnc, nAnc, zTable),
+      doltliteFindTableByName(aCur, nCur, zTable));
+}
 
-  if( pChanged ) *pChanged = 0;
+static int loadAncestorAndCurrentCatalogs(
+  sqlite3 *db,
+  const ProllyHash *pAncCatHash,
+  struct TableEntry **paAnc, int *pnAnc,
+  struct TableEntry **paCur, int *pnCur
+){
+  ProllyHash curHash;
+  int rc;
 
-  rc = sqlite3_prepare_v2(db, "PRAGMA main.foreign_key_check", -1, &pStmt, 0);
-  if( rc!=SQLITE_OK ) return rc;
-  while( (stepRc = sqlite3_step(pStmt))==SQLITE_ROW ){
-    const char *zChild = (const char*)sqlite3_column_text(pStmt, 0);
-    const char *zParent = (const char*)sqlite3_column_text(pStmt, 2);
-    rc = fkRefreshAppendName(&azNames, &nNames, zChild);
-    if( rc==SQLITE_OK ) rc = fkRefreshAppendName(&azNames, &nNames, zParent);
-    if( rc!=SQLITE_OK ){
-      sqlite3_finalize(pStmt);
-      doltliteFreeStringArray(azNames, nNames);
-      return rc;
-    }
-  }
-  sqlite3_finalize(pStmt);
-  if( stepRc!=SQLITE_DONE ){
-    doltliteFreeStringArray(azNames, nNames);
-    return stepRc;
+  *paAnc = 0;
+  *pnAnc = 0;
+  *paCur = 0;
+  *pnCur = 0;
+
+  if( pAncCatHash && !prollyHashIsEmpty(pAncCatHash) ){
+    rc = doltliteLoadCatalog(db, pAncCatHash, paAnc, pnAnc, 0);
+    if( rc!=SQLITE_OK ) return rc;
   }
 
-  for(i=0; i<nNames; i++){
-    char *zSql;
-    if( !tableHasRowid(db, azNames[i]) ){
-      continue;
-    }
-    zSql = sqlite3_mprintf("REINDEX \"%w\"", azNames[i]);
-    if( !zSql ){
-      doltliteFreeStringArray(azNames, nNames);
-      return SQLITE_NOMEM;
-    }
-    rc = sqlite3_exec(db, zSql, 0, 0, 0);
-    sqlite3_free(zSql);
-    if( rc!=SQLITE_OK ){
-      doltliteFreeStringArray(azNames, nNames);
-      return rc;
-    }
+  rc = doltliteFlushCatalogToHash(db, &curHash);
+  if( rc!=SQLITE_OK ){
+    doltliteFreeCatalog(*paAnc, *pnAnc);
+    *paAnc = 0;
+    *pnAnc = 0;
+    return rc;
   }
-  doltliteFreeStringArray(azNames, nNames);
-  if( pChanged ) *pChanged = (nNames>0);
-  return SQLITE_OK;
+  rc = doltliteLoadCatalog(db, &curHash, paCur, pnCur, 0);
+  if( rc!=SQLITE_OK ){
+    doltliteFreeCatalog(*paAnc, *pnAnc);
+    *paAnc = 0;
+    *pnAnc = 0;
+  }
+  return rc;
 }
 
 typedef struct MergePkInfo MergePkInfo;
@@ -996,24 +982,23 @@ int doltliteDetectMergeUniqueViolations(
   sqlite3_stmt *pTbls = 0;
   struct TableEntry *aAnc = 0;
   int nAnc = 0;
-  Pgno iNextAnc = 0;
-  int haveAnc = 0;
+  struct TableEntry *aCur = 0;
+  int nCur = 0;
   int rc;
 
   if( pnFound ) *pnFound = 0;
 
-  if( pAncCatHash && !prollyHashIsEmpty(pAncCatHash) ){
-    if( doltliteLoadCatalog(db, pAncCatHash, &aAnc, &nAnc, &iNextAnc)==SQLITE_OK ){
-      haveAnc = 1;
-    }
-  }
+  rc = loadAncestorAndCurrentCatalogs(db, pAncCatHash, &aAnc, &nAnc,
+                                      &aCur, &nCur);
+  if( rc!=SQLITE_OK ) return rc;
 
   rc = sqlite3_prepare_v2(db,
       "SELECT name FROM main.sqlite_master WHERE type='table' "
       "AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'dolt_%'",
       -1, &pTbls, 0);
   if( rc != SQLITE_OK ){
-    if( haveAnc ) doltliteFreeCatalog(aAnc, nAnc);
+    doltliteFreeCatalog(aAnc, nAnc);
+    doltliteFreeCatalog(aCur, nCur);
     return rc;
   }
 
@@ -1028,6 +1013,10 @@ int doltliteDetectMergeUniqueViolations(
     if( !zTableRaw ) continue;
     zTable = sqlite3_mprintf("%s", zTableRaw);
     if( !zTable ){ rc = SQLITE_NOMEM; break; }
+    if( !catalogTableChanged(aAnc, nAnc, aCur, nCur, zTable) ){
+      sqlite3_free(zTable);
+      continue;
+    }
     memset(&pkInfo, 0, sizeof(pkInfo));
     hasRowid = tableHasRowid(db, zTable);
     if( !hasRowid ){
@@ -1109,7 +1098,8 @@ int doltliteDetectMergeUniqueViolations(
   }
   if( rc == SQLITE_DONE ) rc = SQLITE_OK;
   sqlite3_finalize(pTbls);
-  if( haveAnc ) doltliteFreeCatalog(aAnc, nAnc);
+  doltliteFreeCatalog(aAnc, nAnc);
+  doltliteFreeCatalog(aCur, nCur);
   return rc;
 }
 
@@ -1212,25 +1202,24 @@ int doltliteDetectMergeCheckViolations(
   sqlite3_stmt *pTbls = 0;
   struct TableEntry *aAnc = 0;
   int nAnc = 0;
-  Pgno iNextAnc = 0;
-  int haveAnc = 0;
+  struct TableEntry *aCur = 0;
+  int nCur = 0;
   int rc;
   int stepRc;
 
   if( pnFound ) *pnFound = 0;
 
-  if( pAncCatHash && !prollyHashIsEmpty(pAncCatHash) ){
-    if( doltliteLoadCatalog(db, pAncCatHash, &aAnc, &nAnc, &iNextAnc)==SQLITE_OK ){
-      haveAnc = 1;
-    }
-  }
+  rc = loadAncestorAndCurrentCatalogs(db, pAncCatHash, &aAnc, &nAnc,
+                                      &aCur, &nCur);
+  if( rc!=SQLITE_OK ) return rc;
 
   rc = sqlite3_prepare_v2(db,
       "SELECT name, sql FROM main.sqlite_master WHERE type='table' "
       "AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'dolt_%'",
       -1, &pTbls, 0);
   if( rc != SQLITE_OK ){
-    if( haveAnc ) doltliteFreeCatalog(aAnc, nAnc);
+    doltliteFreeCatalog(aAnc, nAnc);
+    doltliteFreeCatalog(aCur, nCur);
     return rc;
   }
 
@@ -1251,6 +1240,11 @@ int doltliteDetectMergeCheckViolations(
       sqlite3_free(zSql);
       rc = SQLITE_NOMEM;
       break;
+    }
+    if( !catalogTableChanged(aAnc, nAnc, aCur, nCur, zTable) ){
+      sqlite3_free(zTable);
+      sqlite3_free(zSql);
+      continue;
     }
     memset(&pkInfo, 0, sizeof(pkInfo));
     hasRowid = tableHasRowid(db, zTable);
@@ -1325,7 +1319,7 @@ int doltliteDetectMergeCheckViolations(
           break;
         }
 
-        if( haveAnc ){
+        if( aAnc ){
           u8 *pAncVal = 0; int nAncVal = 0;
           int ancRc = hasRowid
               ? fetchAncestorRowByName(db, aAnc, nAnc, zTable,
@@ -1369,7 +1363,8 @@ int doltliteDetectMergeCheckViolations(
     rc = stepRc;
   }
   sqlite3_finalize(pTbls);
-  if( haveAnc ) doltliteFreeCatalog(aAnc, nAnc);
+  doltliteFreeCatalog(aAnc, nAnc);
+  doltliteFreeCatalog(aCur, nCur);
   return rc;
 }
 
@@ -1479,12 +1474,11 @@ int doltliteDetectMergeFkViolations(
   char **pzErrMsg,
   int *pnFound
 ){
-  sqlite3_stmt *pQuick = 0;
   sqlite3_stmt *pTbls = 0;
   struct TableEntry *aAnc = 0;
   int nAnc = 0;
-  Pgno iNextAnc = 0;
-  int haveAnc = 0;
+  struct TableEntry *aCur = 0;
+  int nCur = 0;
   int rc;
   int nFound = 0;
   int stepRc;
@@ -1493,55 +1487,17 @@ int doltliteDetectMergeFkViolations(
 
   if( pnFound ) *pnFound = 0;
 
-  rc = sqlite3_prepare_v2(db, "PRAGMA main.foreign_key_check", -1, &pQuick, 0);
-  if( rc!=SQLITE_OK ){
-    return rc;
-  }
-  stepRc = sqlite3_step(pQuick);
-  sqlite3_finalize(pQuick);
-  pQuick = 0;
-  if( stepRc==SQLITE_DONE ){
-    return SQLITE_OK;
-  }
-  if( stepRc!=SQLITE_ROW ){
-    return stepRc;
-  }
-
-  {
-    int didRefresh = 0;
-    rc = fkRefreshCandidateTables(db, &didRefresh);
-    if( rc!=SQLITE_OK ){
-      return rc;
-    }
-    if( didRefresh ){
-      rc = sqlite3_prepare_v2(db, "PRAGMA main.foreign_key_check", -1, &pQuick, 0);
-      if( rc!=SQLITE_OK ){
-        return rc;
-      }
-      stepRc = sqlite3_step(pQuick);
-      sqlite3_finalize(pQuick);
-      pQuick = 0;
-      if( stepRc==SQLITE_DONE ){
-        return SQLITE_OK;
-      }
-      if( stepRc!=SQLITE_ROW ){
-        return stepRc;
-      }
-    }
-  }
-
-  if( pAncCatHash && !prollyHashIsEmpty(pAncCatHash) ){
-    if( doltliteLoadCatalog(db, pAncCatHash, &aAnc, &nAnc, &iNextAnc)==SQLITE_OK ){
-      haveAnc = 1;
-    }
-  }
+  rc = loadAncestorAndCurrentCatalogs(db, pAncCatHash, &aAnc, &nAnc,
+                                      &aCur, &nCur);
+  if( rc!=SQLITE_OK ) return rc;
 
   rc = sqlite3_prepare_v2(db,
       "SELECT name FROM main.sqlite_master WHERE type='table' "
       "AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'dolt_%'",
       -1, &pTbls, 0);
   if( rc != SQLITE_OK ){
-    if( haveAnc ) doltliteFreeCatalog(aAnc, nAnc);
+    doltliteFreeCatalog(aAnc, nAnc);
+    doltliteFreeCatalog(aCur, nCur);
     return rc;
   }
 
@@ -1558,10 +1514,12 @@ int doltliteDetectMergeFkViolations(
     char **azTo = 0;
     int nCol = 0;
     int nAlloc = 0;
+    int childChanged;
 
     if( !zTableRaw ) continue;
     zTable = sqlite3_mprintf("%s", zTableRaw);
     if( !zTable ){ rc = SQLITE_NOMEM; break; }
+    childChanged = catalogTableChanged(aAnc, nAnc, aCur, nCur, zTable);
     memset(&childPk, 0, sizeof(childPk));
     hasRowid = tableHasRowid(db, zTable);
     if( !hasRowid ){
@@ -1594,12 +1552,16 @@ int doltliteDetectMergeFkViolations(
       const char *zToRaw = (const char*)sqlite3_column_text(pFk, 4);
 
       if( curId>=0 && id!=curId ){
-        rc = backfillParentPk(db, zParent, azTo, nCol);
-        if( rc != SQLITE_OK ) break;
-        rc = detectFkViolationsForSpec(db,
-            haveAnc ? aAnc : 0, haveAnc ? nAnc : 0,
-            zTable, hasRowid, &childPk, zParent, curId,
-            azFrom, azTo, nCol, &nFound);
+        int parentChanged = catalogTableChanged(aAnc, nAnc, aCur, nCur, zParent);
+        if( childChanged || parentChanged ){
+          struct TableEntry *aCheckAnc = parentChanged ? 0 : aAnc;
+          int nCheckAnc = parentChanged ? 0 : nAnc;
+          rc = backfillParentPk(db, zParent, azTo, nCol);
+          if( rc != SQLITE_OK ) break;
+          rc = detectFkViolationsForSpec(db, aCheckAnc, nCheckAnc,
+              zTable, hasRowid, &childPk, zParent, curId,
+              azFrom, azTo, nCol, &nFound);
+        }
         doltliteFreeStringArray(azFrom, nCol);
         doltliteFreeStringArray(azTo, nCol);
         azFrom = 0; azTo = 0; nCol = 0; nAlloc = 0;
@@ -1644,12 +1606,16 @@ int doltliteDetectMergeFkViolations(
       rc = SQLITE_OK;
     }
     if( rc==SQLITE_OK && curId>=0 ){
-      rc = backfillParentPk(db, zParent, azTo, nCol);
-      if( rc==SQLITE_OK ){
-        rc = detectFkViolationsForSpec(db,
-            haveAnc ? aAnc : 0, haveAnc ? nAnc : 0,
-            zTable, hasRowid, &childPk, zParent, curId,
-            azFrom, azTo, nCol, &nFound);
+      int parentChanged = catalogTableChanged(aAnc, nAnc, aCur, nCur, zParent);
+      if( childChanged || parentChanged ){
+        struct TableEntry *aCheckAnc = parentChanged ? 0 : aAnc;
+        int nCheckAnc = parentChanged ? 0 : nAnc;
+        rc = backfillParentPk(db, zParent, azTo, nCol);
+        if( rc==SQLITE_OK ){
+          rc = detectFkViolationsForSpec(db, aCheckAnc, nCheckAnc,
+              zTable, hasRowid, &childPk, zParent, curId,
+              azFrom, azTo, nCol, &nFound);
+        }
       }
     }
 
@@ -1666,7 +1632,8 @@ int doltliteDetectMergeFkViolations(
     rc = stepRc;
   }
   sqlite3_finalize(pTbls);
-  if( haveAnc ) doltliteFreeCatalog(aAnc, nAnc);
+  doltliteFreeCatalog(aAnc, nAnc);
+  doltliteFreeCatalog(aCur, nCur);
   if( pnFound ) *pnFound = nFound;
   return rc;
 }

--- a/src/doltlite_merge_constraints.c
+++ b/src/doltlite_merge_constraints.c
@@ -407,6 +407,135 @@ static int recordPrefixEquals(
   return 1;
 }
 
+static int tableColumnIndex(const DoltliteColInfo *pCols, const char *zName){
+  int i;
+  for(i=0; i<pCols->nCol; i++){
+    if( pCols->azName[i] && sqlite3_stricmp(pCols->azName[i], zName)==0 ){
+      return i;
+    }
+  }
+  return -1;
+}
+
+static int recordFieldEqualsInt64(
+  const u8 *pRec,
+  int nRec,
+  int serialType,
+  int off,
+  i64 v
+){
+  i64 got;
+  int nByte;
+  if( serialType==8 ) return v==0;
+  if( serialType==9 ) return v==1;
+  if( serialType<1 || serialType>6 ) return 0;
+  nByte = dlSerialTypeLen((u64)serialType);
+  if( off<0 || off+nByte>nRec ) return 0;
+  got = dlReadIntBytes(pRec + off, nByte);
+  return got==v;
+}
+
+static int fkParentExistsInCatalog(
+  sqlite3 *db,
+  struct TableEntry *aCur, int nCur,
+  const char *zParentTable,
+  char **azTo,
+  int nCol,
+  const u8 *pChildFkRec,
+  int nChildFkRec,
+  int *pExists
+){
+  ChunkStore *cs;
+  ProllyCache *pCache;
+  struct TableEntry *pParent;
+  DoltliteColInfo parentCols;
+  DoltliteRecordInfo childInfo;
+  int *aiParentCol = 0;
+  ProllyCursor cur;
+  int res = 0;
+  int rc;
+  int i;
+
+  *pExists = 0;
+  if( !aCur || nCur==0 ) return SQLITE_OK;
+  pParent = doltliteFindTableByName(aCur, nCur, zParentTable);
+  if( !pParent || prollyHashIsEmpty(&pParent->root) ) return SQLITE_OK;
+
+  rc = doltliteParseRecordStrict(pChildFkRec, nChildFkRec, &childInfo);
+  if( rc!=SQLITE_OK ) return rc;
+  if( childInfo.nField<nCol ) return SQLITE_CORRUPT;
+
+  memset(&parentCols, 0, sizeof(parentCols));
+  rc = doltliteGetColumnNames(db, zParentTable, &parentCols);
+  if( rc!=SQLITE_OK ) return rc;
+
+  aiParentCol = sqlite3_malloc64((sqlite3_int64)nCol * sizeof(int));
+  if( !aiParentCol ){
+    doltliteFreeColInfo(&parentCols);
+    return SQLITE_NOMEM;
+  }
+  for(i=0; i<nCol; i++){
+    aiParentCol[i] = tableColumnIndex(&parentCols, azTo[i]);
+    if( aiParentCol[i]<0 ){
+      sqlite3_free(aiParentCol);
+      doltliteFreeColInfo(&parentCols);
+      return SQLITE_ERROR;
+    }
+  }
+
+  cs = doltliteGetChunkStore(db);
+  pCache = doltliteGetCache(db);
+  if( !cs || !pCache ){
+    sqlite3_free(aiParentCol);
+    doltliteFreeColInfo(&parentCols);
+    return SQLITE_ERROR;
+  }
+
+  prollyCursorInit(&cur, cs, pCache, &pParent->root, pParent->flags);
+  rc = prollyCursorFirst(&cur, &res);
+  while( rc==SQLITE_OK && res==0 && prollyCursorIsValid(&cur) ){
+    const u8 *pParentVal = 0;
+    int nParentVal = 0;
+    DoltliteRecordInfo parentInfo;
+    int match = 1;
+
+    prollyCursorValue(&cur, &pParentVal, &nParentVal);
+    rc = doltliteParseRecordStrict(pParentVal, nParentVal, &parentInfo);
+    if( rc!=SQLITE_OK ) break;
+
+    for(i=0; i<nCol && match; i++){
+      int iParent = aiParentCol[i];
+      int iParentRec = parentCols.aColToRec[iParent];
+      if( (pParent->flags & PROLLY_NODE_INTKEY)
+       && parentCols.iPkCol==iParent ){
+        match = recordFieldEqualsInt64(
+            pChildFkRec, nChildFkRec,
+            childInfo.aType[i], childInfo.aOffset[i],
+            prollyCursorIntKey(&cur));
+      }else{
+        if( iParentRec<0 || iParentRec>=parentInfo.nField ){
+          match = 0;
+        }else{
+          match = doltliteFieldValuesEqual(
+              childInfo.aType[i], pChildFkRec, nChildFkRec,
+              childInfo.aOffset[i],
+              parentInfo.aType[iParentRec], pParentVal, nParentVal,
+              parentInfo.aOffset[iParentRec]);
+        }
+      }
+    }
+    if( match ){
+      *pExists = 1;
+      break;
+    }
+    rc = prollyCursorNext(&cur);
+  }
+  prollyCursorClose(&cur);
+  sqlite3_free(aiParentCol);
+  doltliteFreeColInfo(&parentCols);
+  return rc==SQLITE_DONE ? SQLITE_OK : rc;
+}
+
 static int fetchRowByPkRecord(
   ChunkStore *cs,
   ProllyCache *pCache,
@@ -1370,6 +1499,7 @@ int doltliteDetectMergeCheckViolations(
 
 static int detectFkViolationsForSpec(
   sqlite3 *db,
+  struct TableEntry *aCur, int nCur,
   struct TableEntry *aAnc, int nAnc,
   const char *zChildTable,
   int hasRowid,
@@ -1384,11 +1514,15 @@ static int detectFkViolationsForSpec(
   sqlite3_str *pSql = 0;
   char *zQuery = 0;
   sqlite3_stmt *pStmt = 0;
+  int nKeyCol;
   int rc;
 
   pSql = sqlite3_str_new(0);
-  sqlite3_str_appendf(pSql, "SELECT %s FROM main.\"%w\" AS c WHERE ",
-      hasRowid ? "rowid" : pChildPk->zPkCols, zChildTable);
+  sqlite3_str_appendf(pSql, "SELECT %s", hasRowid ? "rowid" : pChildPk->zPkCols);
+  for(int i=0; i<nCol; i++){
+    sqlite3_str_appendf(pSql, ", c.\"%w\"", azFrom[i]);
+  }
+  sqlite3_str_appendf(pSql, " FROM main.\"%w\" AS c WHERE ", zChildTable);
   for(int i=0; i<nCol; i++){
     if( i>0 ) sqlite3_str_appendall(pSql, " AND ");
     sqlite3_str_appendf(pSql, "c.\"%w\" IS NOT NULL", azFrom[i]);
@@ -1406,10 +1540,12 @@ static int detectFkViolationsForSpec(
   rc = sqlite3_prepare_v2(db, zQuery, -1, &pStmt, 0);
   sqlite3_free(zQuery);
   if( rc!=SQLITE_OK ) return rc;
+  nKeyCol = hasRowid ? 1 : pChildPk->nPk;
 
   while( sqlite3_step(pStmt)==SQLITE_ROW ){
     u8 *pKey = 0; int nKey = 0;
     u8 *pVal = 0; int nVal = 0;
+    u8 *pChildFkRec = 0; int nChildFkRec = 0;
     i64 intKey = 0;
     char *zInfo;
     int appendRc;
@@ -1430,6 +1566,32 @@ static int detectFkViolationsForSpec(
       sqlite3_free(pKey);
       sqlite3_free(pVal);
       break;
+    }
+
+    pChildFkRec = buildRecordFromStmtCols(pStmt, nKeyCol, nCol, &nChildFkRec);
+    if( !pChildFkRec ){
+      sqlite3_free(pKey);
+      sqlite3_free(pVal);
+      rc = SQLITE_NOMEM;
+      break;
+    }
+    {
+      int parentExists = 0;
+      rc = fkParentExistsInCatalog(db, aCur, nCur, zParentTable,
+                                   azTo, nCol, pChildFkRec, nChildFkRec,
+                                   &parentExists);
+      sqlite3_free(pChildFkRec);
+      pChildFkRec = 0;
+      if( rc!=SQLITE_OK ){
+        sqlite3_free(pKey);
+        sqlite3_free(pVal);
+        break;
+      }
+      if( parentExists ){
+        sqlite3_free(pKey);
+        sqlite3_free(pVal);
+        continue;
+      }
     }
 
     if( aAnc ){
@@ -1558,7 +1720,7 @@ int doltliteDetectMergeFkViolations(
           int nCheckAnc = parentChanged ? 0 : nAnc;
           rc = backfillParentPk(db, zParent, azTo, nCol);
           if( rc != SQLITE_OK ) break;
-          rc = detectFkViolationsForSpec(db, aCheckAnc, nCheckAnc,
+          rc = detectFkViolationsForSpec(db, aCur, nCur, aCheckAnc, nCheckAnc,
               zTable, hasRowid, &childPk, zParent, curId,
               azFrom, azTo, nCol, &nFound);
         }
@@ -1612,7 +1774,7 @@ int doltliteDetectMergeFkViolations(
         int nCheckAnc = parentChanged ? 0 : nAnc;
         rc = backfillParentPk(db, zParent, azTo, nCol);
         if( rc==SQLITE_OK ){
-          rc = detectFkViolationsForSpec(db, aCheckAnc, nCheckAnc,
+          rc = detectFkViolationsForSpec(db, aCur, nCur, aCheckAnc, nCheckAnc,
               zTable, hasRowid, &childPk, zParent, curId,
               azFrom, azTo, nCol, &nFound);
         }

--- a/test/doltlite_merge_constraint_prune.test
+++ b/test/doltlite_merge_constraint_prune.test
@@ -1,0 +1,80 @@
+# 2026-06-16
+#
+# The author disclaims copyright to this source code.  In place of
+# a legal notice, here is a blessing:
+#
+#    May you do good and not evil.
+#    May you find forgiveness for yourself and forgive others.
+#    May you share freely, never taking more than you give.
+#
+#***********************************************************************
+
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+proc dlt_check_probe {x} {
+  incr ::dlt_check_probe_calls
+  return 1
+}
+
+db function dlt_check_probe dlt_check_probe
+set ::dlt_check_probe_calls 0
+
+do_test doltlite_merge_constraint_prune-1.1 {
+  execsql {
+    CREATE TABLE big(
+      id INTEGER PRIMARY KEY,
+      v INTEGER CHECK(dlt_check_probe(v))
+    );
+    CREATE TABLE small(id INTEGER PRIMARY KEY, v TEXT);
+    WITH RECURSIVE c(i) AS (
+      SELECT 1 UNION ALL SELECT i+1 FROM c WHERE i<100
+    )
+    INSERT INTO big SELECT i, i FROM c;
+    INSERT INTO small VALUES(1,'base');
+    SELECT dolt_commit('-A','-m','init');
+    SELECT dolt_branch('feature');
+    SELECT dolt_checkout('feature');
+    INSERT INTO small VALUES(2,'feature');
+    SELECT dolt_commit('-A','-m','feature');
+    SELECT dolt_checkout('main');
+    INSERT INTO small VALUES(3,'main');
+    SELECT dolt_commit('-A','-m','main');
+  }
+  set ::dlt_check_probe_calls 0
+  execsql { SELECT length(dolt_merge('feature')) }
+  set ::dlt_check_probe_calls
+} {0}
+
+reset_db
+
+do_test doltlite_merge_constraint_prune-2.1 {
+  execsql {
+    PRAGMA foreign_keys=ON;
+    CREATE TABLE parent(id INTEGER PRIMARY KEY);
+    CREATE TABLE child(id INTEGER PRIMARY KEY, parent_id INTEGER REFERENCES parent(id));
+    INSERT INTO parent VALUES(1),(2);
+    INSERT INTO child VALUES(1,1);
+    SELECT dolt_commit('-A','-m','init');
+    SELECT dolt_branch('feature');
+    SELECT dolt_checkout('feature');
+    UPDATE child SET parent_id=2 WHERE id=1;
+    SELECT dolt_commit('-A','-m','move child');
+  }
+  db close
+  sqlite3 db test.db
+  execsql {
+    PRAGMA foreign_keys=ON;
+    SELECT dolt_checkout('main');
+    DELETE FROM parent WHERE id=2;
+    SELECT dolt_commit('-A','-m','delete parent');
+  }
+  db close
+  sqlite3 db test.db
+  catchsql {
+    PRAGMA foreign_keys=ON;
+    SELECT dolt_merge('feature');
+  }
+} {1 {Committing this transaction resulted in a working set with constraint violations, transaction rolled back.}}
+
+finish_test

--- a/test/regression-buckets/ported.txt
+++ b/test/regression-buckets/ported.txt
@@ -30,3 +30,4 @@ doltlite_data_version
 doltlite_page_size_default
 doltlite_savepoint_release
 doltlite_default_materialization
+doltlite_merge_constraint_prune


### PR DESCRIPTION
## Summary
- load ancestor/current catalogs once during merge constraint validation
- skip unique and CHECK scans for tables unchanged by the merge
- skip FK specs where neither child nor parent changed, while still checking changed-parent cases conservatively
- add a targeted TCL regression for unchanged CHECK tables and changed-parent FK violations

## Tests
- git diff --check -- src/doltlite_merge_constraints.c test/doltlite_merge_constraint_prune.test test/regression-buckets/ported.txt
- make doltlite -j4
- ./testfixture test/doltlite_merge_constraint_prune.test --testdir=$tmpdir