### PR TITLE
Batch constraint-violation appends across a merge detection pass

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -605,8 +605,11 @@ static int doltliteDetectPostMergeConstraintViolations(
     return SQLITE_OK;
   }
 
-  rc = doltliteDetectMergeFkViolations(db, pAncCatHash,
-                                       &zDetectErrMsg, &nViolations);
+  rc = doltliteConstraintViolationBatchBegin(db);
+  if( rc==SQLITE_OK ){
+    rc = doltliteDetectMergeFkViolations(db, pAncCatHash,
+                                         &zDetectErrMsg, &nViolations);
+  }
   if( rc==SQLITE_OK ){
     rc = doltliteDetectMergeUniqueViolations(db, pAncCatHash,
                                              &zDetectErrMsg, &nUnique);
@@ -614,6 +617,10 @@ static int doltliteDetectPostMergeConstraintViolations(
   if( rc==SQLITE_OK ){
     rc = doltliteDetectMergeCheckViolations(db, pAncCatHash,
                                             &zDetectErrMsg, &nCheck);
+  }
+  {
+    int erc = doltliteConstraintViolationBatchEnd(db, rc==SQLITE_OK);
+    if( rc==SQLITE_OK ) rc = erc;
   }
   sqlite3_free(zDetectErrMsg);
   if( rc!=SQLITE_OK ) return rc;
@@ -2852,8 +2859,11 @@ static void doltliteMergeFunc(
     int nUnique = 0;
     int nCheck = 0;
     char *zDetectErrMsg = 0;
-    int vrc = doltliteDetectMergeFkViolations(db, &ancCatHash,
-                                              &zDetectErrMsg, &nViolations);
+    int vrc = doltliteConstraintViolationBatchBegin(db);
+    if( vrc == SQLITE_OK ){
+      vrc = doltliteDetectMergeFkViolations(db, &ancCatHash,
+                                            &zDetectErrMsg, &nViolations);
+    }
     if( vrc == SQLITE_OK ){
       vrc = doltliteDetectMergeUniqueViolations(db, &ancCatHash,
                                                 &zDetectErrMsg, &nUnique);
@@ -2861,6 +2871,10 @@ static void doltliteMergeFunc(
     if( vrc == SQLITE_OK ){
       vrc = doltliteDetectMergeCheckViolations(db, &ancCatHash,
                                                &zDetectErrMsg, &nCheck);
+    }
+    {
+      int erc = doltliteConstraintViolationBatchEnd(db, vrc==SQLITE_OK);
+      if( vrc==SQLITE_OK ) vrc = erc;
     }
     if( vrc != SQLITE_OK ){
       if( zDetectErrMsg ){
@@ -3137,8 +3151,11 @@ static int applyMergedCatalogAndCommit(
     int nCheck = 0;
     char *zDetectErrMsg = 0;
 
-    rc = doltliteDetectMergeFkViolations(db, ancCatHash,
-                                         &zDetectErrMsg, &nViolations);
+    rc = doltliteConstraintViolationBatchBegin(db);
+    if( rc==SQLITE_OK ){
+      rc = doltliteDetectMergeFkViolations(db, ancCatHash,
+                                           &zDetectErrMsg, &nViolations);
+    }
     if( rc==SQLITE_OK ){
       rc = doltliteDetectMergeUniqueViolations(db, ancCatHash,
                                                &zDetectErrMsg, &nUnique);
@@ -3146,6 +3163,10 @@ static int applyMergedCatalogAndCommit(
     if( rc==SQLITE_OK ){
       rc = doltliteDetectMergeCheckViolations(db, ancCatHash,
                                               &zDetectErrMsg, &nCheck);
+    }
+    {
+      int erc = doltliteConstraintViolationBatchEnd(db, rc==SQLITE_OK);
+      if( rc==SQLITE_OK ) rc = erc;
     }
     if( rc!=SQLITE_OK ){
       if( zDetectErrMsg ){

--- a/src/doltlite_constraint_violations.c
+++ b/src/doltlite_constraint_violations.c
@@ -247,34 +247,23 @@ static int storeUpdatedViolations(
   return doltliteSaveWorkingSet(db);
 }
 
-int doltliteAppendConstraintViolation(
-  sqlite3 *db,
-  const char *zTable,
-  u8 violationType,
-  i64 intKey,
-  const u8 *pKey, int nKey,
-  const u8 *pVal, int nVal,
+/* Append one violation row to an in-memory table set. */
+static int cvAppendRow(
+  ConstraintViolationTable **paTables, int *pnTables,
+  const char *zTable, u8 violationType, i64 intKey,
+  const u8 *pKey, int nKey, const u8 *pVal, int nVal,
   const char *zInfoJson
 ){
-  ChunkStore *cs = doltliteGetChunkStore(db);
-  ConstraintViolationTable *aTables = 0;
-  int nTables = 0;
   ConstraintViolationTable *pT;
-  ConstraintViolationRow *pRow;
+  ConstraintViolationRow *pRow, *aNew;
   int rc;
-  ConstraintViolationRow *aNew;
 
-  if( !cs || !zTable ) return SQLITE_ERROR;
-
-  rc = loadAllViolations(db, cs, &aTables, &nTables);
-  if( rc!=SQLITE_OK ) return rc;
-
-  pT = findOrCreateViolationTable(&aTables, &nTables, zTable);
-  if( !pT ){ freeViolationTables(aTables, nTables); return SQLITE_NOMEM; }
+  pT = findOrCreateViolationTable(paTables, pnTables, zTable);
+  if( !pT ) return SQLITE_NOMEM;
 
   aNew = sqlite3_realloc(pT->aRows,
       (pT->nRows + 1) * (int)sizeof(ConstraintViolationRow));
-  if( !aNew ){ freeViolationTables(aTables, nTables); return SQLITE_NOMEM; }
+  if( !aNew ) return SQLITE_NOMEM;
   pT->aRows = aNew;
   pRow = &pT->aRows[pT->nRows];
   memset(pRow, 0, sizeof(*pRow));
@@ -290,12 +279,84 @@ int doltliteAppendConstraintViolation(
   }
   if( rc!=SQLITE_OK ){
     freeViolationRow(pRow);
-    freeViolationTables(aTables, nTables);
     return rc;
   }
   pT->nRows++;
+  return SQLITE_OK;
+}
 
-  rc = storeUpdatedViolations(db, cs, aTables, nTables);
+typedef struct ConstraintViolationBatch ConstraintViolationBatch;
+struct ConstraintViolationBatch {
+  ConstraintViolationTable *aTables;
+  int nTables;
+  int nAppended;   /* stays 0 when no violation was added, matching the
+                   ** non-batch path, which never stores in that case */
+};
+
+int doltliteConstraintViolationBatchBegin(sqlite3 *db){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  ConstraintViolationBatch *pBatch;
+  int rc;
+  if( !cs ) return SQLITE_ERROR;
+  if( doltliteGetCvBatch(db) ) return SQLITE_MISUSE;  /* not nestable */
+  pBatch = sqlite3_malloc(sizeof(*pBatch));
+  if( !pBatch ) return SQLITE_NOMEM;
+  memset(pBatch, 0, sizeof(*pBatch));
+  rc = loadAllViolations(db, cs, &pBatch->aTables, &pBatch->nTables);
+  if( rc!=SQLITE_OK ){ sqlite3_free(pBatch); return rc; }
+  doltliteSetCvBatch(db, pBatch);
+  return SQLITE_OK;
+}
+
+int doltliteConstraintViolationBatchEnd(sqlite3 *db, int commit){
+  ConstraintViolationBatch *pBatch = (ConstraintViolationBatch*)doltliteGetCvBatch(db);
+  int rc = SQLITE_OK;
+  if( !pBatch ) return SQLITE_OK;
+  doltliteSetCvBatch(db, 0);
+  if( commit && pBatch->nAppended>0 ){
+    ChunkStore *cs = doltliteGetChunkStore(db);
+    rc = cs ? storeUpdatedViolations(db, cs, pBatch->aTables, pBatch->nTables)
+            : SQLITE_ERROR;
+  }
+  freeViolationTables(pBatch->aTables, pBatch->nTables);
+  sqlite3_free(pBatch);
+  return rc;
+}
+
+int doltliteAppendConstraintViolation(
+  sqlite3 *db,
+  const char *zTable,
+  u8 violationType,
+  i64 intKey,
+  const u8 *pKey, int nKey,
+  const u8 *pVal, int nVal,
+  const char *zInfoJson
+){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  ConstraintViolationBatch *pBatch;
+  ConstraintViolationTable *aTables = 0;
+  int nTables = 0;
+  int rc;
+
+  if( !cs || !zTable ) return SQLITE_ERROR;
+
+  /* Inside a batch, accumulate in memory; the single load and store happen
+  ** at Begin/End, turning a per-violation O(total) round-trip into O(1). */
+  pBatch = (ConstraintViolationBatch*)doltliteGetCvBatch(db);
+  if( pBatch ){
+    rc = cvAppendRow(&pBatch->aTables, &pBatch->nTables, zTable,
+                     violationType, intKey, pKey, nKey, pVal, nVal, zInfoJson);
+    if( rc==SQLITE_OK ) pBatch->nAppended++;
+    return rc;
+  }
+
+  rc = loadAllViolations(db, cs, &aTables, &nTables);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = cvAppendRow(&aTables, &nTables, zTable, violationType, intKey,
+                   pKey, nKey, pVal, nVal, zInfoJson);
+  if( rc==SQLITE_OK ){
+    rc = storeUpdatedViolations(db, cs, aTables, nTables);
+  }
   freeViolationTables(aTables, nTables);
   return rc;
 }

--- a/src/doltlite_constraint_violations.h
+++ b/src/doltlite_constraint_violations.h
@@ -36,6 +36,17 @@ int doltliteAppendConstraintViolation(
 
 int doltliteClearAllConstraintViolations(sqlite3 *db);
 
+/* Batch many appends into one load + one store. Begin loads the current
+** violations; while a batch is open doltliteAppendConstraintViolation
+** accumulates in memory; End persists once (commit!=0) or discards.
+** Not nestable. */
+int doltliteConstraintViolationBatchBegin(sqlite3 *db);
+int doltliteConstraintViolationBatchEnd(sqlite3 *db, int commit);
+
 int doltliteConstraintViolationsRegister(sqlite3 *db);
+
+/* Storage for an open batch hangs off the connection's prolly Btree. */
+void *doltliteGetCvBatch(sqlite3 *db);
+void doltliteSetCvBatch(sqlite3 *db, void *pBatch);
 
 #endif

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -425,6 +425,9 @@ int doltliteDetectMergeUniqueViolations(sqlite3 *db, const ProllyHash *pAncCatHa
 int doltliteDetectMergeCheckViolations(sqlite3 *db, const ProllyHash *pAncCatHash,
                                        char **pzErrMsg, int *pnFound);
 
+int doltliteConstraintViolationBatchBegin(sqlite3 *db);
+int doltliteConstraintViolationBatchEnd(sqlite3 *db, int commit);
+
 int doltliteGetWorkingTableState(sqlite3 *db, const char *zTable,
                                  ProllyHash *pRoot, u8 *pFlags,
                                  ProllyHash *pSchemaHash);

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -367,6 +367,10 @@ struct Btree {
   char *zRebaseReturnBranch;
 
   ProllyHash constraintViolationsHash;
+  /* Transient: a constraint-violation batch open across a merge detection
+  ** pass, so appends accumulate in memory and persist once. Owned by
+  ** doltlite_constraint_violations.c. */
+  void *pCvBatch;
 
   const struct BtreeOps *pOps;
   void *pOrigBtree;
@@ -10802,6 +10806,17 @@ void doltliteSetSessionConstraintViolationsCatalog(sqlite3 *db, const ProllyHash
 int doltliteSessionHasConstraintViolations(sqlite3 *db){
   if( !db || db->nDb<=0 || !db->aDb[0].pBt ) return 0;
   return !prollyHashIsEmpty(&db->aDb[0].pBt->constraintViolationsHash);
+}
+
+void *doltliteGetCvBatch(sqlite3 *db){
+  if( !db || db->nDb<=0 || !db->aDb[0].pBt ) return 0;
+  return db->aDb[0].pBt->pCvBatch;
+}
+
+void doltliteSetCvBatch(sqlite3 *db, void *pBatch){
+  if( db && db->nDb>0 && db->aDb[0].pBt ){
+    db->aDb[0].pBt->pCvBatch = pBatch;
+  }
 }
 
 int doltliteSeedSessionHashes(

--- a/test/doltlite_merge.sh
+++ b/test/doltlite_merge.sh
@@ -289,5 +289,36 @@ run_test "fk_chain_delete_cascades_same_session" "PRAGMA foreign_keys=ON; DELETE
 run_test "fk_chain_reopen_state" "PRAGMA foreign_keys=ON; SELECT (SELECT count(*) FROM gp) || '|' || (SELECT count(*) FROM p) || '|' || (SELECT count(*) FROM c);" "1|0|0" "$DB22"
 run_test "fk_chain_reopen_delete_last_root" "PRAGMA foreign_keys=ON; DELETE FROM gp WHERE id=2; SELECT (SELECT count(*) FROM gp) || '|' || (SELECT count(*) FROM p) || '|' || (SELECT count(*) FROM c);" "0|0|0" "$DB22"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB8B" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18" "$DB19" "$DB20" "$DB20B" "$DB21" "$DB22"
+# Many constraint violations in a single merge: feat adds 300 children, main
+# deletes their parent, so the merge orphans all 300 at once. Each is appended
+# to the violation set during one detection pass; the count must reflect every
+# one (exercises batched accumulation at scale, not just a single violation).
+DB23=/tmp/test_merge23_$$.db; rm -f "$DB23"
+echo "CREATE TABLE parent(id INTEGER PRIMARY KEY);
+CREATE TABLE child(id INTEGER PRIMARY KEY, pid INT, FOREIGN KEY(pid) REFERENCES parent(id));
+INSERT INTO parent VALUES(1);
+SELECT dolt_commit('-A','-m','init');
+SELECT dolt_branch('feat'); SELECT dolt_checkout('feat');
+INSERT INTO child(id,pid) WITH RECURSIVE c(i) AS (SELECT 1 UNION ALL SELECT i+1 FROM c WHERE i<300) SELECT i, 1 FROM c;
+SELECT dolt_commit('-A','-m','add 300 children');
+SELECT dolt_checkout('main'); DELETE FROM parent WHERE id=1; SELECT dolt_commit('-A','-m','drop parent');" | $DOLTLITE "$DB23" > /dev/null 2>&1
+TX_OUT=$(echo "BEGIN;
+SELECT dolt_merge('feat');
+SELECT 'TX|' || (SELECT count(*) FROM dolt_constraint_violations) || '|' ||
+       (SELECT num_violations FROM dolt_constraint_violations WHERE \"table\"='child');
+ROLLBACK;" | $DOLTLITE "$DB23" 2>&1 | grep '^TX|')
+if [ "$TX_OUT" = "TX|1|300" ]; then
+  PASS=$((PASS+1))
+else
+  FAIL=$((FAIL+1))
+  ERRORS="$ERRORS\nFAIL: many_fk_violations_all_recorded\n  expected: TX|1|300\n  got:      $TX_OUT"
+fi
+# Autocommit merge with the same violations rolls the whole merge back.
+echo "SELECT dolt_merge('feat');" | $DOLTLITE "$DB23" > /dev/null 2>&1
+run_test "many_fk_violations_autocommit_rolled_back" \
+  "SELECT count(*) FROM dolt_constraint_violations;" "0" "$DB23"
+run_test "many_fk_violations_parent_restored" \
+  "SELECT count(*) FROM parent;" "0" "$DB23"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8" "$DB8B" "$DB9" "$DB10" "$DB11" "$DB12" "$DB13" "$DB14" "$DB15" "$DB16" "$DB17" "$DB18" "$DB19" "$DB20" "$DB20B" "$DB21" "$DB22" "$DB23"
 dltest_finish


### PR DESCRIPTION
## The bug

`doltliteAppendConstraintViolation` was called once per detected merge violation, and each call:
1. `loadAllViolations` — deserialize the **entire** violation set from the chunk store,
2. append one row,
3. `storeUpdatedViolations` — re-serialize the **entire** set and persist the working set.

So a merge producing V violations did **O(V²)** serialize/deserialize work plus V full working-set persists. A merge that orphans N child rows (parent deleted on one branch, N children added on the other) produces N violations and hits this squarely — confirmed: a 200-orphan merge records 200 violations, i.e. 200 load+store round-trips.

## The fix

A session-scoped batch (pointer hung off the connection's prolly `Btree`, logic in `doltlite_constraint_violations.c`):
- `Begin` loads the current violations once and marks the batch active.
- While active, `doltliteAppendConstraintViolation` accumulates in memory only.
- `End(commit)` serializes and persists **once**.

The three merge detection trios (FK / unique / check, at the three call sites in `doltlite.c`) are bracketed with `Begin … End`. `End` is careful in two ways that preserve existing behavior:
- **discards without storing on error** — the merge already rolls back on a detection error, so the batch must not persist a partial set;
- **stores nothing when zero violations were appended** — the old code never touched storage in that case, and storing unconditionally injected a spurious working-set persist into every clean merge (this regressed `mixed_no_conflicts` until gated on an append count — the existing merge suite caught it).

Single appends outside a merge (vtab edits, refresh) keep the original load+append+store path.

## Note on `dolt_constraint_violations`

That vtab is a **summary** (one row per table, with a `num_violations` count) — `count(*)` on it counts *tables*, not violations. The new test asserts `num_violations`.

## Tests

`doltlite_merge.sh`: a 300-orphan FK merge asserting all 300 violations are recorded in one transaction, plus autocommit-rollback and parent-restored checks. Local: merge 94/94, conflicts/conflict_rows/schema_merge/stats_merge/cherry_pick/revert all green. Full suite on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)