### PR TITLE
Expand merge constraint oracle coverage

### DIFF
--- a/test/vc_oracle_fk_merge_test.sh
+++ b/test/vc_oracle_fk_merge_test.sh
@@ -8,6 +8,7 @@ TMPROOT=$(mktemp -d)
 trap "rm -rf $TMPROOT" EXIT
 pass=0; fail=0
 FAILED_NAMES=""
+source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
 dl() {
   local db="$1" sql="$2" tag="$3"
@@ -94,7 +95,315 @@ run_tx_expected_case() {
   expect_eq "${name}_expected_state" "$expected" "$out"
 }
 
-echo "=== Version Control Oracle Tests: merge constraint rollback ==="
+run_success_expected_case() {
+  local name="$1" setup_sql="$2" query="$3" expected="$4" op="${5:-merge}"
+  local db="$TMPROOT/${name}.db"
+  rm -f "$db"
+
+  printf '%s\n' "$setup_sql" | dl_setup "$db" "${name}_setup"
+  local out
+  out=$("$DOLTLITE" "$db" "$query" 2>"$TMPROOT/${name}_query.err" | tr -d '\r')
+  expect_eq "${name}_${op}_expected_state" "$expected" "$out"
+}
+
+run_success_oracle_case() {
+  local name="$1" setup_sql="$2" query="$3" op="${4:-merge}"
+  local dl_db="$TMPROOT/${name}_dl.db"
+  local dt_dir="$TMPROOT/${name}_dt"
+  rm -f "$dl_db"
+  rm -rf "$dt_dir"
+  mkdir -p "$dt_dir"
+
+  printf '%s\n' "$setup_sql" | dl_setup "$dl_db" "${name}_dl_setup"
+  local dl_out
+  dl_out=$("$DOLTLITE" "$dl_db" "$query" 2>"$TMPROOT/${name}_dl_query.err" | tr -d '\r')
+
+  local dolt_setup
+  dolt_setup=$(vc_oracle_translate_for_dolt "$setup_sql")
+  (
+    cd "$dt_dir" || exit 1
+    vc_oracle_init_repo
+    printf '%s\n' "$dolt_setup" | "$DOLT" sql -c >/dev/null 2>"$TMPROOT/${name}_dt_setup.err"
+    "$DOLT" sql -r csv -q "$query" 2>"$TMPROOT/${name}_dt_query.err"
+  ) > "$TMPROOT/${name}_dt.out"
+  local dt_out
+  dt_out=$(tail -n 1 "$TMPROOT/${name}_dt.out" | tr -d '"\r')
+
+  expect_eq "${name}_${op}_matches_dolt" "$dt_out" "$dl_out"
+}
+
+echo "=== Version Control Oracle Tests: merge/cherry-pick constraints ==="
+echo ""
+
+STATE_COUNTS="SELECT concat(
+  (SELECT count(*) FROM p), '|',
+  (SELECT count(*) FROM c), '|',
+  (SELECT group_concat(concat(id, ':', u) order by id) FROM p), '|',
+  (SELECT group_concat(concat(id, ':', u) order by id) FROM c));"
+
+echo "--- success: feature adds FK table family with non-PK parent key ---"
+run_success_oracle_case \
+  "merge_add_fk_family_unique_parent" \
+"CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1,10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+CREATE TABLE p(id INTEGER PRIMARY KEY, u INT UNIQUE);
+CREATE TABLE c(id INTEGER PRIMARY KEY, u INT, FOREIGN KEY(u) REFERENCES p(u));
+INSERT INTO p VALUES (1,100);
+INSERT INTO c VALUES (1,100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat_fk_tables');
+SELECT dolt_checkout('main');
+CREATE TABLE t2(id INTEGER PRIMARY KEY, v INT CHECK(v>0));
+INSERT INTO t2 SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t2 RENAME TO t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main_check');
+SELECT dolt_merge('feat');" \
+  "$STATE_COUNTS" \
+  "merge"
+echo ""
+
+echo "--- success: cherry-pick adds FK table family with non-PK parent key ---"
+run_success_oracle_case \
+  "cherry_pick_add_fk_family_unique_parent" \
+"CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1,10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+CREATE TABLE p(id INTEGER PRIMARY KEY, u INT UNIQUE);
+CREATE TABLE c(id INTEGER PRIMARY KEY, u INT, FOREIGN KEY(u) REFERENCES p(u));
+INSERT INTO p VALUES (1,100);
+INSERT INTO c VALUES (1,100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat_fk_tables');
+SELECT dolt_checkout('main');
+CREATE TABLE t2(id INTEGER PRIMARY KEY, v INT CHECK(v>0));
+INSERT INTO t2 SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t2 RENAME TO t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main_check');
+SELECT dolt_cherry_pick('feat');" \
+  "$STATE_COUNTS" \
+  "cherry_pick"
+echo ""
+
+echo "--- success: parent table changes only ---"
+run_success_oracle_case \
+  "merge_fk_parent_changed_only" \
+"CREATE TABLE p(id INTEGER PRIMARY KEY, u INT UNIQUE, label TEXT);
+CREATE TABLE c(id INTEGER PRIMARY KEY, u INT, FOREIGN KEY(u) REFERENCES p(u));
+INSERT INTO p VALUES (1,100,'base');
+INSERT INTO c VALUES (1,100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+UPDATE p SET label='feat' WHERE id=1;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat_parent');
+SELECT dolt_checkout('main');
+CREATE TABLE marker(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO marker VALUES (1,1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main_marker');
+SELECT dolt_merge('feat');" \
+  "SELECT concat((SELECT label FROM p WHERE id=1), '|',
+    (SELECT count(*) FROM c WHERE u=100));" \
+  "merge"
+echo ""
+
+echo "--- success: child table changes only ---"
+run_success_oracle_case \
+  "merge_fk_child_changed_only" \
+"CREATE TABLE p(id INTEGER PRIMARY KEY, u INT UNIQUE);
+CREATE TABLE c(id INTEGER PRIMARY KEY, u INT, FOREIGN KEY(u) REFERENCES p(u));
+INSERT INTO p VALUES (1,100),(2,200);
+INSERT INTO c VALUES (1,100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO c VALUES (2,200);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat_child');
+SELECT dolt_checkout('main');
+CREATE TABLE marker(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO marker VALUES (1,1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main_marker');
+SELECT dolt_merge('feat');" \
+  "$STATE_COUNTS" \
+  "merge"
+echo ""
+
+echo "--- success: parent and child both change ---"
+run_success_oracle_case \
+  "merge_fk_parent_and_child_changed" \
+"CREATE TABLE p(id INTEGER PRIMARY KEY, u INT UNIQUE);
+CREATE TABLE c(id INTEGER PRIMARY KEY, u INT, FOREIGN KEY(u) REFERENCES p(u));
+INSERT INTO p VALUES (1,100);
+INSERT INTO c VALUES (1,100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO p VALUES (3,300);
+INSERT INTO c VALUES (3,300);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat_parent_child');
+SELECT dolt_checkout('main');
+INSERT INTO p VALUES (2,200);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main_parent');
+SELECT dolt_merge('feat');" \
+  "$STATE_COUNTS" \
+  "merge"
+echo ""
+
+echo "--- success: CHECK introduced while valid row arrives ---"
+run_success_expected_case \
+  "merge_check_introduced_valid_row" \
+"CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1,10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES (2,20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat_row');
+SELECT dolt_checkout('main');
+CREATE TABLE t2(id INTEGER PRIMARY KEY, v INT CHECK(v>0));
+INSERT INTO t2 SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t2 RENAME TO t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main_check');
+SELECT dolt_merge('feat');" \
+  "SELECT group_concat(concat(id, ':', v) order by id) FROM t;" \
+  "1:10,2:20" \
+  "merge"
+echo ""
+
+echo "--- success: UNIQUE introduced while non-duplicate row arrives ---"
+run_success_expected_case \
+  "merge_unique_introduced_valid_row" \
+"CREATE TABLE t(id INTEGER PRIMARY KEY, u INT);
+INSERT INTO t VALUES (1,10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO t VALUES (2,20);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat_row');
+SELECT dolt_checkout('main');
+CREATE TABLE t2(id INTEGER PRIMARY KEY, u INT UNIQUE);
+INSERT INTO t2 SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t2 RENAME TO t;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main_unique');
+SELECT dolt_merge('feat');" \
+  "SELECT group_concat(concat(id, ':', u) order by id) FROM t;" \
+  "1:10,2:20" \
+  "merge"
+echo ""
+
+echo "--- success: FK introduced while valid child row arrives ---"
+run_success_expected_case \
+  "merge_fk_introduced_valid_child" \
+"CREATE TABLE p(id INTEGER PRIMARY KEY, u INT UNIQUE);
+CREATE TABLE c(id INTEGER PRIMARY KEY, u INT);
+INSERT INTO p VALUES (1,100),(2,200);
+INSERT INTO c VALUES (1,100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO c VALUES (2,200);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat_child');
+SELECT dolt_checkout('main');
+CREATE TABLE c2(id INTEGER PRIMARY KEY, u INT, FOREIGN KEY(u) REFERENCES p(u));
+INSERT INTO c2 SELECT * FROM c;
+DROP TABLE c;
+ALTER TABLE c2 RENAME TO c;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main_fk');
+SELECT dolt_merge('feat');" \
+  "$STATE_COUNTS" \
+  "2|2|1:100,2:200|1:100,2:200" \
+  "merge"
+echo ""
+
+echo "--- success: text primary keys ---"
+run_success_oracle_case \
+  "merge_text_pk_fk" \
+"CREATE TABLE p(id VARCHAR(16) PRIMARY KEY, u INT UNIQUE);
+CREATE TABLE c(id VARCHAR(16) PRIMARY KEY, u INT, FOREIGN KEY(u) REFERENCES p(u));
+INSERT INTO p VALUES ('p1',100);
+INSERT INTO c VALUES ('c1',100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO p VALUES ('p2',200);
+INSERT INTO c VALUES ('c2',200);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+CREATE TABLE marker(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO marker VALUES (1,1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main_marker');
+SELECT dolt_merge('feat');" \
+  "SELECT concat(
+    (SELECT count(*) FROM p), '|',
+    (SELECT count(*) FROM c), '|',
+    (SELECT group_concat(concat(id, ':', u) order by id) FROM p), '|',
+    (SELECT group_concat(concat(id, ':', u) order by id) FROM c));" \
+  "merge"
+echo ""
+
+echo "--- success: composite primary keys ---"
+run_success_oracle_case \
+  "merge_composite_pk_fk" \
+"CREATE TABLE p(a INT, b INT, u INT UNIQUE, PRIMARY KEY(a,b));
+CREATE TABLE c(a INT, b INT, u INT, PRIMARY KEY(a,b), FOREIGN KEY(u) REFERENCES p(u));
+INSERT INTO p VALUES (1,1,100);
+INSERT INTO c VALUES (1,1,100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','init');
+SELECT dolt_branch('feat');
+SELECT dolt_checkout('feat');
+INSERT INTO p VALUES (2,2,200);
+INSERT INTO c VALUES (2,2,200);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+CREATE TABLE marker(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO marker VALUES (1,1);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','main_marker');
+SELECT dolt_merge('feat');" \
+  "SELECT concat(
+    (SELECT count(*) FROM p), '|',
+    (SELECT count(*) FROM c), '|',
+    (SELECT group_concat(concat(a, ':', b, ':', u) order by a,b) FROM p), '|',
+    (SELECT group_concat(concat(a, ':', b, ':', u) order by a,b) FROM c));" \
+  "merge"
+echo ""
+
+echo "--- rollback: failed merges restore DoltLite state ---"
 echo ""
 
 run_rollback_case() {


### PR DESCRIPTION
## Summary
- expand the merge/cherry-pick constraint oracle with successful FK/CHECK/UNIQUE merge cases
- cover parent-only, child-only, parent+child, text PK, composite PK, and FK-family creation scenarios
- keep DoltLite-only expected-state checks for schema-introduced constraints where Dolt merge semantics differ

## Tests
- make DOLTLITE_PROLLY_CHECK=1 doltlite -j4
- bash ../test/vc_oracle_fk_merge_test.sh ./doltlite dolt