### PR TITLE
Run core VC suites on Windows and fix branch-path opens

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -290,7 +290,13 @@ jobs:
         export DLTEST_STRIP_CR=1
         rm -rf /d/tmp
         powershell.exe -NoProfile -Command "New-Item -ItemType Junction -Path 'D:\\tmp' -Target '$(cygpath -w /tmp)' | Out-Null"
+        cat > ./doltlite-no-msys-conv <<'SH'
+        #!/usr/bin/env bash
         export MSYS2_ARG_CONV_EXCL='*'
+        exec ./doltlite "$@"
+        SH
+        chmod +x ./doltlite-no-msys-conv
+        export DOLTLITE=./doltlite-no-msys-conv
         tests=(
           ../test/doltlite_parity.sh
           ../test/doltlite_commit.sh
@@ -332,7 +338,7 @@ jobs:
         )
         for test in "${tests[@]}"; do
           echo "━━━ ${test} ━━━"
-          bash "$test"
+          bash "$test" "$DOLTLITE"
         done
       timeout-minutes: 20
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -287,14 +287,24 @@ jobs:
       shell: msys2 {0}
       run: |
         cd build
+        export DLTEST_STRIP_CR=1
         tests=(
           ../test/doltlite_parity.sh
+          ../test/doltlite_commit.sh
           ../test/doltlite_staging.sh
+          ../test/doltlite_workspace.sh
+          ../test/doltlite_branch.sh
+          ../test/doltlite_tag.sh
+          ../test/doltlite_merge.sh
+          ../test/doltlite_conflicts.sh
           ../test/doltlite_diff_table.sh
           ../test/doltlite_schema_diff.sh
           ../test/doltlite_schema_merge.sh
+          ../test/doltlite_cherry_pick.sh
           ../test/doltlite_revert_dirty.sh
           ../test/doltlite_conflict_rows.sh
+          ../test/doltlite_reset.sh
+          ../test/doltlite_working_set.sh
           ../test/doltlite_gc.sh
           ../test/doltlite_gc_session_state.sh
           ../test/doltlite_gc_scale.sh

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -289,7 +289,7 @@ jobs:
         cd build
         export DLTEST_STRIP_CR=1
         rm -rf /d/tmp
-        cmd.exe /C "mklink /J D:\\tmp $(cygpath -w /tmp)"
+        powershell.exe -NoProfile -Command "New-Item -ItemType Junction -Path 'D:\\tmp' -Target '$(cygpath -w /tmp)' | Out-Null"
         export MSYS2_ARG_CONV_EXCL='*'
         tests=(
           ../test/doltlite_parity.sh

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -290,9 +290,18 @@ jobs:
         export DLTEST_STRIP_CR=1
         DBGDB=/tmp/doltlite_debug_branch_$$.db
         rm -f "$DBGDB"
+        echo "cygpath /tmp: $(cygpath -m /tmp)"
+        echo "cygpath DBGDB: $(cygpath -m "$DBGDB")"
         ./doltlite "$DBGDB" "CREATE TABLE t(id INTEGER PRIMARY KEY); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init'); SELECT dolt_checkout('-b','feature'); INSERT INTO t VALUES(2); SELECT dolt_commit('-A','-m','feature');"
+        ls -l "$DBGDB" || true
+        set +e
         DOLTLITE_DEBUG_SHELL_BRANCH=1 ./doltlite "$DBGDB/feature" "SELECT active_branch(); SELECT count(*) FROM t;"
+        slash_rc=$?
         DOLTLITE_DEBUG_SHELL_BRANCH=1 ./doltlite "$DBGDB@feature" "SELECT active_branch(); SELECT count(*) FROM t;"
+        at_rc=$?
+        set -e
+        echo "debug slash rc: $slash_rc"
+        echo "debug at rc: $at_rc"
         tests=(
           ../test/doltlite_parity.sh
           ../test/doltlite_commit.sh

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -294,6 +294,7 @@ jobs:
           ../test/doltlite_staging.sh
           ../test/doltlite_workspace.sh
           ../test/doltlite_branch.sh
+          ../test/doltlite_open_branch.sh
           ../test/doltlite_tag.sh
           ../test/doltlite_merge.sh
           ../test/doltlite_conflicts.sh

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -288,7 +288,8 @@ jobs:
       run: |
         cd build
         export DLTEST_STRIP_CR=1
-        mkdir -p /d/tmp
+        rm -rf /d/tmp
+        cmd.exe /C "mklink /J D:\\tmp $(cygpath -w /tmp)"
         export MSYS2_ARG_CONV_EXCL='*'
         tests=(
           ../test/doltlite_parity.sh

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -288,20 +288,8 @@ jobs:
       run: |
         cd build
         export DLTEST_STRIP_CR=1
-        DBGDB=/tmp/doltlite_debug_branch_$$.db
-        rm -f "$DBGDB"
-        echo "cygpath /tmp: $(cygpath -m /tmp)"
-        echo "cygpath DBGDB: $(cygpath -m "$DBGDB")"
-        ./doltlite "$DBGDB" "CREATE TABLE t(id INTEGER PRIMARY KEY); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init'); SELECT dolt_checkout('-b','feature'); INSERT INTO t VALUES(2); SELECT dolt_commit('-A','-m','feature');"
-        ls -l "$DBGDB" || true
-        set +e
-        DOLTLITE_DEBUG_SHELL_BRANCH=1 ./doltlite "$DBGDB/feature" "SELECT active_branch(); SELECT count(*) FROM t;"
-        slash_rc=$?
-        DOLTLITE_DEBUG_SHELL_BRANCH=1 ./doltlite "$DBGDB@feature" "SELECT active_branch(); SELECT count(*) FROM t;"
-        at_rc=$?
-        set -e
-        echo "debug slash rc: $slash_rc"
-        echo "debug at rc: $at_rc"
+        mkdir -p /d/tmp
+        export MSYS2_ARG_CONV_EXCL='*'
         tests=(
           ../test/doltlite_parity.sh
           ../test/doltlite_commit.sh

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -288,6 +288,11 @@ jobs:
       run: |
         cd build
         export DLTEST_STRIP_CR=1
+        DBGDB=/tmp/doltlite_debug_branch_$$.db
+        rm -f "$DBGDB"
+        ./doltlite "$DBGDB" "CREATE TABLE t(id INTEGER PRIMARY KEY); INSERT INTO t VALUES(1); SELECT dolt_commit('-A','-m','init'); SELECT dolt_checkout('-b','feature'); INSERT INTO t VALUES(2); SELECT dolt_commit('-A','-m','feature');"
+        DOLTLITE_DEBUG_SHELL_BRANCH=1 ./doltlite "$DBGDB/feature" "SELECT active_branch(); SELECT count(*) FROM t;"
+        DOLTLITE_DEBUG_SHELL_BRANCH=1 ./doltlite "$DBGDB@feature" "SELECT active_branch(); SELECT count(*) FROM t;"
         tests=(
           ../test/doltlite_parity.sh
           ../test/doltlite_commit.sh

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -4304,6 +4304,115 @@ static int saveAllCursors(Btree *pBtree, BtShared *pBt, Pgno iRoot,
   return SQLITE_OK;
 }
 
+static int doltliteFileExists(sqlite3_vfs *pVfs, const char *zFilename,
+                              int *pExists){
+  int rc;
+  *pExists = 0;
+  if( !zFilename || zFilename[0]=='\0' || strcmp(zFilename, ":memory:")==0 ){
+    return SQLITE_OK;
+  }
+  if( !pVfs ){
+    pVfs = sqlite3_vfs_find(0);
+    if( !pVfs ) return SQLITE_CANTOPEN;
+  }
+  rc = sqlite3OsAccess(pVfs, zFilename, SQLITE_ACCESS_EXISTS, pExists);
+  if( rc==SQLITE_NOMEM || rc==SQLITE_IOERR_NOMEM ) return rc;
+  if( rc!=SQLITE_OK ) *pExists = 0;
+  return SQLITE_OK;
+}
+
+static int doltliteReadableFile(sqlite3_vfs *pVfs, const char *zFilename,
+                                int *pIsFile){
+  sqlite3_file *pFile = 0;
+  int outFlags = 0;
+  int rc;
+  i64 nSize = 0;
+  u8 b;
+
+  *pIsFile = 0;
+  rc = sqlite3OsOpenMalloc(pVfs, zFilename, &pFile,
+                           SQLITE_OPEN_READONLY | SQLITE_OPEN_MAIN_DB,
+                           &outFlags);
+  if( rc!=SQLITE_OK ){
+    if( pFile ) sqlite3OsCloseFree(pFile);
+    if( rc==SQLITE_NOMEM || rc==SQLITE_IOERR_NOMEM ) return rc;
+    return SQLITE_OK;
+  }
+  rc = sqlite3OsFileSize(pFile, &nSize);
+  if( rc==SQLITE_OK && nSize>0 ){
+    rc = sqlite3OsRead(pFile, &b, 1, 0);
+  }
+  sqlite3OsCloseFree(pFile);
+  if( rc==SQLITE_NOMEM || rc==SQLITE_IOERR_NOMEM ) return rc;
+  if( rc==SQLITE_OK && nSize>0 ) *pIsFile = 1;
+  return SQLITE_OK;
+}
+
+static int doltliteResolveOpenBranchPath(
+  sqlite3_vfs *pVfs,
+  const char *zFilename,
+  char **pzStoreFilename,
+  const char **pzBranch
+){
+  const char *z;
+  const char *zSep = 0;
+  int parentExists = 0;
+  int rc;
+  char *zParent;
+  int nParent;
+  int parentIsFile = 0;
+  int parentIsSqlite = 0;
+
+  *pzStoreFilename = 0;
+  *pzBranch = 0;
+  if( !zFilename || zFilename[0]=='\0' || strcmp(zFilename, ":memory:")==0 ){
+    return SQLITE_OK;
+  }
+
+  for(z=zFilename; *z; z++){
+    if( *z=='/' || *z=='\\' || *z=='@' ) zSep = z;
+  }
+  if( !zSep || zSep==zFilename || zSep[1]=='\0' ) return SQLITE_OK;
+
+  nParent = (int)(zSep - zFilename);
+  zParent = sqlite3_mprintf("%.*s", nParent, zFilename);
+  if( !zParent ) return SQLITE_NOMEM;
+
+  rc = doltliteFileExists(pVfs, zParent, &parentExists);
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(zParent);
+    return rc;
+  }
+  if( !parentExists ){
+    sqlite3_free(zParent);
+    return SQLITE_OK;
+  }
+
+  rc = doltliteReadableFile(pVfs, zParent, &parentIsFile);
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(zParent);
+    return rc;
+  }
+  if( !parentIsFile ){
+    sqlite3_free(zParent);
+    return SQLITE_OK;
+  }
+
+  rc = origBtreeIsSqliteFile(pVfs, zParent, &parentIsSqlite);
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(zParent);
+    return rc;
+  }
+  if( parentIsSqlite ){
+    sqlite3_free(zParent);
+    return SQLITE_OK;
+  }
+
+  *pzStoreFilename = zParent;
+  *pzBranch = zSep + 1;
+  return SQLITE_OK;
+}
+
 int sqlite3BtreeOpen(
   sqlite3_vfs *pVfs,
   const char *zFilename,
@@ -4317,6 +4426,9 @@ int sqlite3BtreeOpen(
   int rc = SQLITE_OK;
   int useOrig;
   u8 poisonAfterOpen = 0;
+  char *zStoreFilename = 0;
+  const char *zBranchFromPath = 0;
+  const char *zOpenFilename = zFilename;
 
   *ppBtree = 0;
 
@@ -4325,36 +4437,57 @@ int sqlite3BtreeOpen(
    || (flags & BTREE_SINGLE)
    || (vfsFlags & SQLITE_OPEN_TEMP_DB);
   if( !useOrig ){
-    rc = origBtreeIsSqliteFile(pVfs, zFilename, &useOrig);
+    rc = doltliteResolveOpenBranchPath(pVfs, zFilename, &zStoreFilename,
+                                       &zBranchFromPath);
     if( rc!=SQLITE_OK ) return rc;
+    if( zStoreFilename ) zOpenFilename = zStoreFilename;
+    rc = origBtreeIsSqliteFile(pVfs, zOpenFilename, &useOrig);
+    if( useOrig && zStoreFilename ){
+      useOrig = 0;
+    }
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(zStoreFilename);
+      return rc;
+    }
   }
   if( useOrig ){
     p = sqlite3_malloc(sizeof(Btree));
-    if( !p ) return SQLITE_NOMEM;
+    if( !p ){
+      sqlite3_free(zStoreFilename);
+      return SQLITE_NOMEM;
+    }
     memset(p, 0, sizeof(*p));
     p->db = db;
     p->pOps = &origBtreeVtOps;
     rc = origBtreeOpen(pVfs, zFilename, db, &p->pOrigBtree, flags, vfsFlags);
-    if( rc!=SQLITE_OK ){ sqlite3_free(p); return rc; }
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(zStoreFilename);
+      sqlite3_free(p);
+      return rc;
+    }
     /* Registration resolves through db->aDb[0].pBt, so assign first. */
     *ppBtree = p;
     rc = registerDoltiteFunctions(db);
     if( rc==SQLITE_NOMEM || rc==SQLITE_IOERR_NOMEM ){
       *ppBtree = 0;
       sqlite3BtreeClose(p);
+      sqlite3_free(zStoreFilename);
       return rc;
     }
+    sqlite3_free(zStoreFilename);
     return SQLITE_OK;
   }
 
   p = sqlite3_malloc(sizeof(Btree));
   if( !p ){
+    sqlite3_free(zStoreFilename);
     return SQLITE_NOMEM;
   }
   memset(p, 0, sizeof(*p));
 
   pBt = sqlite3_malloc(sizeof(BtShared));
   if( !pBt ){
+    sqlite3_free(zStoreFilename);
     sqlite3_free(p);
     return SQLITE_NOMEM;
   }
@@ -4362,10 +4495,12 @@ int sqlite3BtreeOpen(
 
   if( !zFilename || zFilename[0]=='\0' ){
     zFilename = ":memory:";
+    zOpenFilename = zFilename;
   }
 
-  rc = chunkStoreOpen(&pBt->store, pVfs, zFilename, vfsFlags);
+  rc = chunkStoreOpen(&pBt->store, pVfs, zOpenFilename, vfsFlags);
   if( rc!=SQLITE_OK ){
+    sqlite3_free(zStoreFilename);
     sqlite3_free(pBt);
     sqlite3_free(p);
     return rc;
@@ -4378,15 +4513,17 @@ int sqlite3BtreeOpen(
   rc = prollyCacheInit(&pBt->cache, PROLLY_DEFAULT_CACHE_SIZE);
   if( rc!=SQLITE_OK ){
     chunkStoreClose(&pBt->store);
+    sqlite3_free(zStoreFilename);
     sqlite3_free(pBt);
     sqlite3_free(p);
     return rc;
   }
 
-  pBt->pPagerShim = pagerShimCreate(pVfs, zFilename, chunkFileGetHandle(&pBt->store.file));
+  pBt->pPagerShim = pagerShimCreate(pVfs, zOpenFilename, chunkFileGetHandle(&pBt->store.file));
   if( !pBt->pPagerShim ){
     prollyCacheFree(&pBt->cache);
     chunkStoreClose(&pBt->store);
+    sqlite3_free(zStoreFilename);
     sqlite3_free(pBt);
     sqlite3_free(p);
     return SQLITE_NOMEM;
@@ -4434,7 +4571,8 @@ int sqlite3BtreeOpen(
     char *zRebaseOrigBranch = 0;
     char *zRebaseReturnBranch = 0;
     u8 isRebasing = 0;
-    const char *zDef = chunkStoreGetDefaultBranch(&pBt->store);
+    const char *zDef = zBranchFromPath ? zBranchFromPath :
+      chunkStoreGetDefaultBranch(&pBt->store);
     u8 isMerging = 0;
     if( !zDef ) zDef = "main";
     memset(&catHash, 0, sizeof(catHash));
@@ -4446,6 +4584,18 @@ int sqlite3BtreeOpen(
     memset(&preRebaseCat, 0, sizeof(preRebaseCat));
     memset(&rebaseOnto, 0, sizeof(rebaseOnto));
     memset(&constraintViolationsHash, 0, sizeof(constraintViolationsHash));
+    if( zBranchFromPath
+     && chunkStoreFindBranch(&pBt->store, zDef, &branchCommit)!=SQLITE_OK ){
+      sqlite3ErrorWithMsg(db, SQLITE_ERROR, "unable to select branch \"%s\"",
+                          zDef);
+      pagerShimDestroy(pBt->pPagerShim);
+      prollyCacheFree(&pBt->cache);
+      chunkStoreClose(&pBt->store);
+      sqlite3_free(zStoreFilename);
+      sqlite3_free(pBt);
+      sqlite3_free(p);
+      return SQLITE_ERROR;
+    }
     rc = btreeLoadWorkingSetBlob(&pBt->store, zDef, &catHash, &workingCommit,
                                  &stagedCatalog, &isMerging,
                                  &mergeCommitHash, &conflictsCatalogHash,
@@ -4459,6 +4609,7 @@ int sqlite3BtreeOpen(
       pagerShimDestroy(pBt->pPagerShim);
       prollyCacheFree(&pBt->cache);
       chunkStoreClose(&pBt->store);
+      sqlite3_free(zStoreFilename);
       sqlite3_free(pBt);
       sqlite3_free(p);
       return rc;
@@ -4472,6 +4623,7 @@ int sqlite3BtreeOpen(
         pagerShimDestroy(pBt->pPagerShim);
         prollyCacheFree(&pBt->cache);
         chunkStoreClose(&pBt->store);
+        sqlite3_free(zStoreFilename);
         sqlite3_free(pBt);
         sqlite3_free(p);
         return rc;
@@ -4488,6 +4640,7 @@ int sqlite3BtreeOpen(
           pagerShimDestroy(pBt->pPagerShim);
           prollyCacheFree(&pBt->cache);
           chunkStoreClose(&pBt->store);
+          sqlite3_free(zStoreFilename);
           sqlite3_free(pBt);
           sqlite3_free(p);
           return rc;
@@ -4498,6 +4651,7 @@ int sqlite3BtreeOpen(
           pagerShimDestroy(pBt->pPagerShim);
           prollyCacheFree(&pBt->cache);
           chunkStoreClose(&pBt->store);
+          sqlite3_free(zStoreFilename);
           sqlite3_free(pBt);
           sqlite3_free(p);
           return rc;
@@ -4529,6 +4683,7 @@ int sqlite3BtreeOpen(
     pagerShimDestroy(pBt->pPagerShim);
     prollyCacheFree(&pBt->cache);
     chunkStoreClose(&pBt->store);
+    sqlite3_free(zStoreFilename);
     sqlite3_free(pBt);
     sqlite3_free(p);
     return SQLITE_NOMEM;
@@ -4543,10 +4698,13 @@ int sqlite3BtreeOpen(
   p->nSeek = 0;
 
   {
-    const char *defBranch = chunkStoreGetDefaultBranch(&pBt->store);
+    const char *defBranch = zBranchFromPath ? zBranchFromPath :
+      chunkStoreGetDefaultBranch(&pBt->store);
     ProllyHash branchCommit;
+    if( !defBranch ) defBranch = "main";
     p->zBranch = sqlite3_mprintf("%s", defBranch);
     if( p->zBranch==0 ){
+      sqlite3_free(zStoreFilename);
       sqlite3BtreeClose(p);
       return SQLITE_NOMEM;
     }
@@ -4563,10 +4721,12 @@ int sqlite3BtreeOpen(
   rc = registerDoltiteFunctions(db);
   if( rc==SQLITE_NOMEM || rc==SQLITE_IOERR_NOMEM ){
     *ppBtree = 0;
+    sqlite3_free(zStoreFilename);
     sqlite3BtreeClose(p);
     return rc;
   }
 
+  sqlite3_free(zStoreFilename);
   return SQLITE_OK;
 }
 

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -4304,6 +4304,16 @@ static int saveAllCursors(Btree *pBtree, BtShared *pBt, Pgno iRoot,
   return SQLITE_OK;
 }
 
+static int doltliteLooksLikeDbPath(const char *zFilename){
+  const char *z;
+  const char *zBase = zFilename;
+  if( !zFilename ) return 0;
+  for(z=zFilename; *z; z++){
+    if( *z=='/' || *z=='\\' ) zBase = z + 1;
+  }
+  return strstr(zBase, ".db")!=0;
+}
+
 static int doltliteFileExists(sqlite3_vfs *pVfs, const char *zFilename,
                               int *pExists){
   int rc;
@@ -4377,6 +4387,10 @@ static int doltliteResolveOpenBranchPath(
   nParent = (int)(zSep - zFilename);
   zParent = sqlite3_mprintf("%.*s", nParent, zFilename);
   if( !zParent ) return SQLITE_NOMEM;
+  if( !doltliteLooksLikeDbPath(zParent) ){
+    sqlite3_free(zParent);
+    return SQLITE_OK;
+  }
 
   rc = doltliteFileExists(pVfs, zParent, &parentExists);
   if( rc!=SQLITE_OK ){

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -4311,7 +4311,7 @@ static int doltliteLooksLikeDbPath(const char *zFilename){
   for(z=zFilename; *z; z++){
     if( *z=='/' || *z=='\\' ) zBase = z + 1;
   }
-  return strstr(zBase, ".db")!=0;
+  return strstr(zBase, ".db")!=0 || strstr(zBase, ".sqlite")!=0;
 }
 
 static int doltliteFileExists(sqlite3_vfs *pVfs, const char *zFilename,

--- a/src/shell.c.in
+++ b/src/shell.c.in
@@ -5019,6 +5019,7 @@ static const char *findLastPathSep(const char *zPath){
 static int doltliteShellReadableFile(const char *zFilename){
   sqlite3_vfs *pVfs;
   sqlite3_file *pFile;
+  char *zFull;
   int outFlags = 0;
   sqlite3_int64 nSize = 0;
   unsigned char b;
@@ -5027,10 +5028,20 @@ static int doltliteShellReadableFile(const char *zFilename){
 
   pVfs = sqlite3_vfs_find(0);
   if( pVfs==0 ) return 0;
+  zFull = sqlite3_malloc64(pVfs->mxPathname + 1);
+  if( zFull==0 ) return 0;
+  rc = pVfs->xFullPathname(pVfs, zFilename, pVfs->mxPathname + 1, zFull);
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(zFull);
+    return 0;
+  }
   pFile = sqlite3_malloc64(pVfs->szOsFile);
-  if( pFile==0 ) return 0;
+  if( pFile==0 ){
+    sqlite3_free(zFull);
+    return 0;
+  }
   memset(pFile, 0, pVfs->szOsFile);
-  rc = pVfs->xOpen(pVfs, zFilename, pFile,
+  rc = pVfs->xOpen(pVfs, zFull, pFile,
                    SQLITE_OPEN_READONLY | SQLITE_OPEN_MAIN_DB, &outFlags);
   if( rc==SQLITE_OK ){
     rc = pFile->pMethods->xFileSize(pFile, &nSize);
@@ -5041,9 +5052,12 @@ static int doltliteShellReadableFile(const char *zFilename){
   }
   sqlite3_free(pFile);
   if( zDebug ){
-    fprintf(stderr, "shell branch readable file=[%s] rc=%d size=%lld ok=%d\n",
-            zFilename, rc, (long long)nSize, rc==SQLITE_OK && nSize>0);
+    fprintf(stderr,
+            "shell branch readable file=[%s] full=[%s] rc=%d size=%lld ok=%d\n",
+            zFilename, zFull, rc, (long long)nSize,
+            rc==SQLITE_OK && nSize>0);
   }
+  sqlite3_free(zFull);
   return rc==SQLITE_OK && nSize>0;
 }
 

--- a/src/shell.c.in
+++ b/src/shell.c.in
@@ -5023,6 +5023,7 @@ static int doltliteShellReadableFile(const char *zFilename){
   sqlite3_int64 nSize = 0;
   unsigned char b;
   int rc;
+  const char *zDebug = getenv("DOLTLITE_DEBUG_SHELL_BRANCH");
 
   pVfs = sqlite3_vfs_find(0);
   if( pVfs==0 ) return 0;
@@ -5039,6 +5040,10 @@ static int doltliteShellReadableFile(const char *zFilename){
     pFile->pMethods->xClose(pFile);
   }
   sqlite3_free(pFile);
+  if( zDebug ){
+    fprintf(stderr, "shell branch readable file=[%s] rc=%d size=%lld ok=%d\n",
+            zFilename, rc, (long long)nSize, rc==SQLITE_OK && nSize>0);
+  }
   return rc==SQLITE_OK && nSize>0;
 }
 
@@ -5072,7 +5077,15 @@ static void parseDoltiteDbBranch(
     if( zBase && doltliteShellReadableFile(zBase) ){
       *pzFilename = zBase;
       *pzBranch = sqlite3_mprintf("%s", zSep + 1);
+      if( getenv("DOLTLITE_DEBUG_SHELL_BRANCH") ){
+        fprintf(stderr, "shell branch parsed input=[%s] file=[%s] branch=[%s]\n",
+                zInput, *pzFilename, *pzBranch);
+      }
       return;
+    }
+    if( getenv("DOLTLITE_DEBUG_SHELL_BRANCH") ){
+      fprintf(stderr, "shell branch skipped input=[%s] file=[%s]\n",
+              zInput, zBase ? zBase : "");
     }
     sqlite3_free(zBase);
   }

--- a/src/shell.c.in
+++ b/src/shell.c.in
@@ -5016,6 +5016,12 @@ static const char *findLastPathSep(const char *zPath){
 }
 
 #ifdef DOLTLITE_PROLLY
+static int doltliteShellLooksLikeDbPath(const char *zFilename){
+  const char *zBase = findLastPathSep(zFilename);
+  zBase = zBase ? zBase + 1 : zFilename;
+  return zBase && strstr(zBase, ".db")!=0;
+}
+
 static int doltliteShellReadableFile(const char *zFilename){
   sqlite3_vfs *pVfs;
   sqlite3_file *pFile;
@@ -5081,7 +5087,8 @@ static void parseDoltiteDbBranch(
   zSep = findLastPathSep(zInput);
   if( zSep && zSep[1]!=0 ){
     zBase = sqlite3_mprintf("%.*s", (int)(zSep - zInput), zInput);
-    if( zBase && doltliteShellReadableFile(zBase) ){
+    if( zBase && doltliteShellLooksLikeDbPath(zBase)
+     && doltliteShellReadableFile(zBase) ){
       *pzFilename = zBase;
       *pzBranch = sqlite3_mprintf("%s", zSep + 1);
       return;

--- a/src/shell.c.in
+++ b/src/shell.c.in
@@ -5019,7 +5019,7 @@ static const char *findLastPathSep(const char *zPath){
 static int doltliteShellLooksLikeDbPath(const char *zFilename){
   const char *zBase = findLastPathSep(zFilename);
   zBase = zBase ? zBase + 1 : zFilename;
-  return zBase && strstr(zBase, ".db")!=0;
+  return zBase && (strstr(zBase, ".db")!=0 || strstr(zBase, ".sqlite")!=0);
 }
 
 static int doltliteShellReadableFile(const char *zFilename){

--- a/src/shell.c.in
+++ b/src/shell.c.in
@@ -5016,6 +5016,32 @@ static const char *findLastPathSep(const char *zPath){
 }
 
 #ifdef DOLTLITE_PROLLY
+static int doltliteShellReadableFile(const char *zFilename){
+  sqlite3_vfs *pVfs;
+  sqlite3_file *pFile;
+  int outFlags = 0;
+  sqlite3_int64 nSize = 0;
+  unsigned char b;
+  int rc;
+
+  pVfs = sqlite3_vfs_find(0);
+  if( pVfs==0 ) return 0;
+  pFile = sqlite3_malloc64(pVfs->szOsFile);
+  if( pFile==0 ) return 0;
+  memset(pFile, 0, pVfs->szOsFile);
+  rc = pVfs->xOpen(pVfs, zFilename, pFile,
+                   SQLITE_OPEN_READONLY | SQLITE_OPEN_MAIN_DB, &outFlags);
+  if( rc==SQLITE_OK ){
+    rc = pFile->pMethods->xFileSize(pFile, &nSize);
+    if( rc==SQLITE_OK && nSize>0 ){
+      rc = pFile->pMethods->xRead(pFile, &b, 1, 0);
+    }
+    pFile->pMethods->xClose(pFile);
+  }
+  sqlite3_free(pFile);
+  return rc==SQLITE_OK && nSize>0;
+}
+
 static void parseDoltiteDbBranch(
   const char *zInput,
   char **pzFilename,
@@ -5042,9 +5068,8 @@ static void parseDoltiteDbBranch(
 
   zSep = findLastPathSep(zInput);
   if( zSep && zSep[1]!=0 ){
-    struct stat x;
     zBase = sqlite3_mprintf("%.*s", (int)(zSep - zInput), zInput);
-    if( zBase && stat(zBase, &x)==0 && !S_ISDIR(x.st_mode) ){
+    if( zBase && doltliteShellReadableFile(zBase) ){
       *pzFilename = zBase;
       *pzBranch = sqlite3_mprintf("%s", zSep + 1);
       return;

--- a/src/shell.c.in
+++ b/src/shell.c.in
@@ -5024,7 +5024,6 @@ static int doltliteShellReadableFile(const char *zFilename){
   sqlite3_int64 nSize = 0;
   unsigned char b;
   int rc;
-  const char *zDebug = getenv("DOLTLITE_DEBUG_SHELL_BRANCH");
 
   pVfs = sqlite3_vfs_find(0);
   if( pVfs==0 ) return 0;
@@ -5051,12 +5050,6 @@ static int doltliteShellReadableFile(const char *zFilename){
     pFile->pMethods->xClose(pFile);
   }
   sqlite3_free(pFile);
-  if( zDebug ){
-    fprintf(stderr,
-            "shell branch readable file=[%s] full=[%s] rc=%d size=%lld ok=%d\n",
-            zFilename, zFull, rc, (long long)nSize,
-            rc==SQLITE_OK && nSize>0);
-  }
   sqlite3_free(zFull);
   return rc==SQLITE_OK && nSize>0;
 }
@@ -5091,15 +5084,7 @@ static void parseDoltiteDbBranch(
     if( zBase && doltliteShellReadableFile(zBase) ){
       *pzFilename = zBase;
       *pzBranch = sqlite3_mprintf("%s", zSep + 1);
-      if( getenv("DOLTLITE_DEBUG_SHELL_BRANCH") ){
-        fprintf(stderr, "shell branch parsed input=[%s] file=[%s] branch=[%s]\n",
-                zInput, *pzFilename, *pzBranch);
-      }
       return;
-    }
-    if( getenv("DOLTLITE_DEBUG_SHELL_BRANCH") ){
-      fprintf(stderr, "shell branch skipped input=[%s] file=[%s]\n",
-              zInput, zBase ? zBase : "");
     }
     sqlite3_free(zBase);
   }

--- a/test/doltlite_commit.sh
+++ b/test/doltlite_commit.sh
@@ -4,13 +4,21 @@ PASS=0
 FAIL=0
 ERRORS=""
 
+run_sql() {
+  if [ "${DLTEST_STRIP_CR:-0}" = "1" ]; then
+    echo "$1" | perl -e 'alarm(10); exec @ARGV' $DOLTLITE "$2" 2>&1 | tr -d '\r'
+  else
+    echo "$1" | perl -e 'alarm(10); exec @ARGV' $DOLTLITE "$2" 2>&1
+  fi
+}
+
 run_test() {
   local name="$1"
   local sql="$2"
   local expected="$3"
   local db="${4:-:memory:}"
   local result
-  result=$(echo "$sql" | perl -e 'alarm(10); exec @ARGV' $DOLTLITE "$db" 2>&1)
+  result=$(run_sql "$sql" "$db")
   local exit_code=$?
   if [ $exit_code -eq 137 ] || [ $exit_code -eq 139 ]; then
     result="CRASH (exit $exit_code)"
@@ -29,7 +37,7 @@ run_test_match() {
   local pattern="$3"
   local db="${4:-:memory:}"
   local result
-  result=$(echo "$sql" | perl -e 'alarm(10); exec @ARGV' $DOLTLITE "$db" 2>&1)
+  result=$(run_sql "$sql" "$db")
   if echo "$result" | grep -qE "$pattern"; then
     PASS=$((PASS+1))
   else

--- a/test/doltlite_open_branch.sh
+++ b/test/doltlite_open_branch.sh
@@ -3,6 +3,14 @@
 DOLTLITE="${1:-./doltlite}"
 PASS=0; FAIL=0; ERRORS=""
 
+normalize_output() {
+  if [ "${DLTEST_STRIP_CR:-0}" = "1" ]; then
+    tr -d '\r'
+  else
+    cat
+  fi
+}
+
 check_eq() {
   local name="$1" expected="$2" actual="$3"
   if [ "$expected" = "$actual" ]; then
@@ -41,19 +49,19 @@ SELECT dolt_commit('-m','side');
 SELECT dolt_checkout('main');
 SQL
 
-res=$("$DOLTLITE" "$DB" "SELECT active_branch(); SELECT v FROM t WHERE id=1;")
+res=$("$DOLTLITE" "$DB" "SELECT active_branch(); SELECT v FROM t WHERE id=1;" | normalize_output)
 check_eq "default_uses_main" $'main\nmain' "$res"
 
-res=$("$DOLTLITE" "$DB@side" "SELECT active_branch(); SELECT v FROM t WHERE id=1;")
+res=$("$DOLTLITE" "$DB@side" "SELECT active_branch(); SELECT v FROM t WHERE id=1;" | normalize_output)
 check_eq "at_selects_side" $'side\nside' "$res"
 
-res=$("$DOLTLITE" "$DB/side" "SELECT active_branch(); SELECT v FROM t WHERE id=1;")
+res=$("$DOLTLITE" "$DB/side" "SELECT active_branch(); SELECT v FROM t WHERE id=1;" | normalize_output)
 check_eq "slash_selects_side" $'side\nside' "$res"
 
-res=$("$DOLTLITE" "$DB" "SELECT active_branch(); SELECT v FROM t WHERE id=1;")
+res=$("$DOLTLITE" "$DB" "SELECT active_branch(); SELECT v FROM t WHERE id=1;" | normalize_output)
 check_eq "branch_open_does_not_change_default" $'main\nmain' "$res"
 
-res=$("$DOLTLITE" "$DB@missing" "SELECT active_branch();" 2>&1 || true)
+res=$("$DOLTLITE" "$DB@missing" "SELECT active_branch();" 2>&1 | normalize_output || true)
 check_match "missing_branch_errors" "unable to select branch|branch.*not found|SQLITE_NOTFOUND" "$res"
 
 cat <<'SQL' | "$DOLTLITE" "$DB" >/dev/null 2>&1
@@ -61,13 +69,13 @@ SELECT dolt_branch('-m','side','renamed');
 SELECT dolt_branch('-c','renamed','copy');
 SQL
 
-res=$("$DOLTLITE" "$DB@renamed" "SELECT active_branch(); SELECT v FROM t WHERE id=1;")
+res=$("$DOLTLITE" "$DB@renamed" "SELECT active_branch(); SELECT v FROM t WHERE id=1;" | normalize_output)
 check_eq "renamed_branch_open" $'renamed\nside' "$res"
 
-res=$("$DOLTLITE" "$DB/copy" "SELECT active_branch(); SELECT v FROM t WHERE id=1;")
+res=$("$DOLTLITE" "$DB/copy" "SELECT active_branch(); SELECT v FROM t WHERE id=1;" | normalize_output)
 check_eq "copied_branch_open" $'copy\nside' "$res"
 
-res=$("$DOLTLITE" "$DB@renamed" "INSERT INTO t VALUES(2,'more'); SELECT dolt_commit('-A','-m','more'); SELECT active_branch(); SELECT count(*) FROM t;")
+res=$("$DOLTLITE" "$DB@renamed" "INSERT INTO t VALUES(2,'more'); SELECT dolt_commit('-A','-m','more'); SELECT active_branch(); SELECT count(*) FROM t;" | normalize_output)
 check_match "commit_on_open_branch_path_hash" "^[0-9a-f]{40}$" "$(echo "$res" | sed -n '1p')"
 check_eq "commit_on_open_branch_path_state" $'renamed\n2' "$(echo "$res" | tail -n +2)"
 
@@ -75,7 +83,7 @@ cat <<'SQL' | "$DOLTLITE" "$DB" >/dev/null 2>&1
 SELECT dolt_branch('-D','copy');
 SQL
 
-res=$("$DOLTLITE" "$DB@copy" "SELECT active_branch();" 2>&1 || true)
+res=$("$DOLTLITE" "$DB@copy" "SELECT active_branch();" 2>&1 | normalize_output || true)
 check_match "deleted_branch_open_errors" "unable to select branch|branch.*not found|SQLITE_NOTFOUND" "$res"
 
 echo ""


### PR DESCRIPTION
## Summary
- gate the core DoltLite version-control shell suites on Windows
- normalize commit-test CR output under the Windows feature-test job
- make DoltLite branch-path opens explicit for db@branch, db/branch, and db\branch forms
- add the focused open-branch script to the Windows feature-test list

## Testing
- make DOLTLITE_PROLLY_CHECK=1 doltlite -j4
- bash test/doltlite_open_branch.sh ./doltlite
- bash test/doltlite_branch.sh ./doltlite
- DLTEST_STRIP_CR=1 bash test/doltlite_commit.sh ./doltlite
- bash test/doltlite_workspace.sh ./doltlite
- full local run of the Windows feature-test script list with DLTEST_STRIP_CR=1