### PR TITLE
Fix signed-int decoder UB and run VC vtab read paths under ASan/UBSan

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -83,6 +83,21 @@ jobs:
     - name: Correctness regression tests
       run: cd build && bash ../test/correctness_test.sh ./doltlite
 
+    # Version-control virtual tables decode stored values and rebuild rows
+    # through the prolly record codec — exactly where signed-int / value
+    # decode UB lives (the left-shift-of-negative this PR fixes surfaced
+    # here). The oracle suites above are stock-SQL semantics and the C
+    # corpus is C-API level; neither exercises these SQL vtab read paths.
+    - name: VC virtual-table read suites
+      run: |
+        cd build
+        for s in doltlite_at doltlite_history doltlite_diff doltlite_diff_table \
+                 doltlite_schema_diff doltlite_workspace doltlite_conflicts \
+                 doltlite_conflict_rows doltlite_comparison doltlite_merge; do
+          echo "=== $s ==="
+          bash ../test/$s.sh ./doltlite || exit 1
+        done
+
     # The C regression corpus (~310k checks) under ASan/UBSan with leak
     # detection — where the #1325/#1328 use-after-frees and leaks lived.
     # Reuses the objects built above; only the archive and link are new.

--- a/src/prolly_record.h
+++ b/src/prolly_record.h
@@ -43,10 +43,12 @@ static inline int dlSerialIsInt(int st){
 }
 
 static inline i64 dlReadIntBytes(const u8 *p, int nBytes){
-  i64 v = (nBytes>0 && (p[0] & 0x80)) ? -1 : 0;
+  /* Accumulate in unsigned: a left shift of a sign-extended negative i64 is
+  ** undefined behavior. Two's-complement makes the unsigned result identical. */
+  u64 v = (nBytes>0 && (p[0] & 0x80)) ? ~(u64)0 : 0;
   int i;
   for(i=0; i<nBytes; i++) v = (v<<8) | p[i];
-  return v;
+  return (i64)v;
 }
 
 static inline i64 dlDecodeSerialInt(int st, const u8 *p, int n){

--- a/test/correctness_test.sh
+++ b/test/correctness_test.sh
@@ -156,17 +156,22 @@ for N in 100 2000; do
 done
 
 echo ""
-echo "--- 8. Diff accuracy ---"
+echo "--- 8. Diff accuracy (incl. negative values: reads route through the
+#       signed-int decoder, which must not shift a negative value) ---"
 for N in 100 2000; do
   rm -f "$TMPDIR/t.db"
   "$DB" "$TMPDIR/t.db" "CREATE TABLE t(id INTEGER PRIMARY KEY, a INT, b INT);
     WITH RECURSIVE c(x) AS (VALUES(1) UNION ALL SELECT x+1 FROM c WHERE x<$N)
     INSERT INTO t SELECT x,x,0 FROM c;
     SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');
-    UPDATE t SET b=1 WHERE id%2=0;
+    UPDATE t SET b=-1 WHERE id%2=0;
     SELECT dolt_add('-A'); SELECT dolt_commit('-m','update');" > /dev/null 2>&1
   result=$(query_value "$TMPDIR/t.db" "SELECT count(*) FROM dolt_diff_t WHERE diff_type='modified';")
   check "diff accuracy N=$N" "$((N/2))" "$result"
+  # Explicit-ref diff decodes stored values via the signed-int reader; a
+  # negative here would shift a negative value (UB) before the fix.
+  negval=$(query_value "$TMPDIR/t.db" "SELECT DISTINCT to_b FROM dolt_diff_t('HEAD^','HEAD') WHERE diff_type='modified';")
+  check "diff negative readback N=$N" "-1" "$negval"
 done
 
 echo ""


### PR DESCRIPTION
## The bug

`dlReadIntBytes` (`src/prolly_record.h`) reconstructed a signed integer by sign-extending into an `i64` and shifting: `for(...) v=(v<<8)|p[i]` with `v` possibly `-1`. Left-shifting a negative signed value is undefined behavior; UBSan with `-fno-sanitize-recover` aborts on it whenever a stored **negative integer** is read back through a value-decode path (`dolt_diff_t('a','b')`, `dolt_workspace_t`, `dolt_diff_stat`). Pre-existing and latent — it computes correctly on two's-complement, so normal builds never noticed.

## The fix

Accumulate in `u64` (well-defined shift) and reinterpret to `i64` — byte-for-byte identical on two's-complement. The two sibling shifts in that header were already unsigned; only this one was signed.

## Why it hid, and the coverage fix

The `asan-ubsan` CI job ran the oracle suites (stock-SQL semantics), correctness, and the C-API corpus — **none** exercise the doltlite VC virtual-table read paths, which is where the prolly value decoders run. So this UB was unreachable by the sanitizer build. This PR:

1. Extends `correctness_test.sh` (already in the asan job) to update a column to a negative value and read it back through the explicit-ref `dolt_diff_t('HEAD^','HEAD')`, which routes through the decoder — a direct fail-before/pass-after guard.
2. Adds the VC vtab read suites (`dolt_at`, `dolt_history`, `dolt_diff`, `dolt_diff_table`, `dolt_schema_diff`, `dolt_workspace`, `dolt_conflicts`, `dolt_conflict_rows`, comparison, merge) to the asan-ubsan job, so the whole class of value-decode / vtab-lifecycle UB is covered going forward.

## Validation

- Fail-before / pass-after under `-fsanitize=address,undefined` on clean builds: buggy decoder → new checks abort with the runtime error and FAIL; fixed → correctness_test 43/43, values correct (incl. `INT64_MIN`).
- All ten VC read suites pass clean under ASan/UBSan with the fix (and the negative-shift was the only error they surfaced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)