### PR TITLE
Add ThreadSanitizer job to sanitizers workflow

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -2,6 +2,7 @@ name: Sanitizers
 
 on:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   asan-ubsan:
@@ -117,3 +118,52 @@ jobs:
           libdoltlite.a -lz -lpthread -lm
         ./doltlite_regression_test_c all
 
+  tsan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    env:
+      TSAN_CFLAGS: -O1 -g -fsanitize=thread -fno-omit-frame-pointer
+      TSAN_LDFLAGS: -fsanitize=thread
+      TSAN_OPTIONS: halt_on_error=1:second_deadlock_stack=1:history_size=7
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y clang build-essential zlib1g-dev
+
+    - name: Configure
+      run: |
+        mkdir -p build && cd build
+        CC=clang ../configure
+
+    - name: Build DoltLite amalgamation with TSan
+      run: |
+        cd build
+        make \
+          CC=clang \
+          CFLAGS="$TSAN_CFLAGS" \
+          LDFLAGS="$TSAN_LDFLAGS" \
+          sqlite3.c sqlite3.h
+
+    - name: Build pthread stress tests
+      run: |
+        cd build
+        clang $TSAN_CFLAGS -I. -I../src \
+          -o threadtest4 ../test/threadtest4.c sqlite3.c \
+          $TSAN_LDFLAGS -ldl -lpthread -lm -lz
+
+    - name: Run threadtest4 serialized
+      run: |
+        cd build
+        rm -f tt4-test1.db tt4-test2.db tt4-test3.db
+        ./threadtest4 --serialized 6
+
+    - name: Run threadtest4 multithread
+      run: |
+        cd build
+        rm -f tt4-test1.db tt4-test2.db tt4-test3.db
+        ./threadtest4 --multithread 6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,6 +76,56 @@ jobs:
         ./vc_ref_mutation_stress_test
       timeout-minutes: 9
 
+  thread-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y build-essential zlib1g-dev
+
+    - name: Configure
+      run: |
+        mkdir -p build && cd build
+        ../configure
+
+    - name: Build DoltLite amalgamation
+      run: |
+        cd build
+        make sqlite3.c sqlite3.h
+
+    - name: Build pthread stress tests
+      run: |
+        cd build
+        cc -O2 -g -I. -I../src \
+          -o threadtest4 ../test/threadtest4.c sqlite3.c \
+          -ldl -lpthread -lm -lz
+        cc -O2 -g -I. -I../src \
+          -o threadtest5 ../test/threadtest5.c sqlite3.c \
+          -ldl -lpthread -lm -lz
+
+    - name: Run threadtest4 serialized
+      run: |
+        cd build
+        rm -f tt4-test1.db tt4-test2.db tt4-test3.db
+        ./threadtest4 --serialized 6
+
+    - name: Run threadtest4 multithread
+      run: |
+        cd build
+        rm -f tt4-test1.db tt4-test2.db tt4-test3.db
+        ./threadtest4 --multithread 6
+
+    - name: Run threadtest5
+      run: |
+        cd build
+        rm -f /tmp/doltlite-threadtest5.db
+        ./threadtest5 'file:/tmp/doltlite-threadtest5.db?mode=rwc' -num-workers 8
+
   sqllogictest:
     runs-on: ubuntu-latest
     timeout-minutes: 120


### PR DESCRIPTION
## Summary
- Add a ThreadSanitizer job to the existing Sanitizers workflow
- Build the DoltLite amalgamation with Clang TSan instrumentation
- Run SQLite pthread stress coverage via threadtest4 in serialized and multithread modes under TSan
- Add a separate non-sanitized Test Suite worker for threadtest4 and threadtest5 so threadtest5 gets correctness coverage outside TSan

## Testing
- Parsed .github/workflows/sanitizers.yml, .github/workflows/test.yml, and .github/workflows/build-test.yml locally
- Previous CI run showed threadtest4 passed under TSan; threadtest5 was removed from TSan because it failed its own semantic check under sanitizer slowdown rather than reporting a TSan race