### PR TITLE
Remove redundant remotesrv warning comment

### DIFF
--- a/src/doltlite_remotesrv.c
+++ b/src/doltlite_remotesrv.c
@@ -621,7 +621,6 @@ static int serverInit(DoltliteServer *pSrv, const char *zDir, int port,
     return SQLITE_ERROR;
   }
 
-  /* Warn loudly when bound non-loopback. */
   if( bindIn.s_addr != htonl(INADDR_LOOPBACK) ){
     fprintf(stderr,
       "WARNING: doltlite-remotesrv bound to %s — the remote protocol "


### PR DESCRIPTION
## Summary
- Remove a redundant comment before the remotesrv warning log; the log message already makes the behavior clear.

## Testing
- Not run (comment-only change).