### PR TITLE
Share refs blob install path

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -1044,6 +1044,31 @@ int chunkStoreLoadRefsFromBlob(ChunkStore *cs, const u8 *data, int nData){
   return csReplaceRefsStateFromBlob(cs, data, nData, 1);
 }
 
+int chunkStoreInstallRefsBlob(ChunkStore *cs, const u8 *data, int nData){
+  ChunkStore refsView;
+  ProllyHash refsHash;
+  int rc;
+
+  if( !data || nData<=0 ) return SQLITE_ERROR;
+  rc = csDeserializeRefsIntoTemp(&refsView, data, nData);
+  if( rc!=SQLITE_OK ){
+    csFreeRefsState(&refsView);
+    return rc;
+  }
+
+  rc = chunkStorePut(cs, data, nData, &refsHash);
+  if( rc!=SQLITE_OK ){
+    csFreeRefsState(&refsView);
+    return rc;
+  }
+
+  csFreeRefsState(cs);
+  csAdoptRefsState(cs, &refsView);
+  refsTableSetHash(&cs->refs, &refsHash);
+  cs->bRefsStale = 0;
+  return SQLITE_OK;
+}
+
 int chunkStoreSerializeRefsToBlob(ChunkStore *cs, u8 **ppOut, int *pnOut){
   return csSerializeRefsBlob(cs, ppOut, pnOut);
 }

--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -222,6 +222,8 @@ int chunkStoreFindTracking(ChunkStore *cs, const char *zRemote,
 
 int chunkStoreLoadRefsFromBlob(ChunkStore *cs, const u8 *data, int nData);
 
+int chunkStoreInstallRefsBlob(ChunkStore *cs, const u8 *data, int nData);
+
 int chunkStoreSerializeRefsToBlob(ChunkStore *cs, u8 **ppOut, int *pnOut);
 
 int chunkStoreHasMany(ChunkStore *cs, const ProllyHash *aHash, int nHash, u8 *aResult);

--- a/src/doltlite_remote.c
+++ b/src/doltlite_remote.c
@@ -320,23 +320,7 @@ static int remoteGetRefs(DoltliteRemote *pRemote, u8 **ppData, int *pnData){
 
 static int fsSetRefs(DoltliteRemote *pRemote, const u8 *pData, int nData){
   FsRemote *p = (FsRemote*)pRemote;
-  ProllyHash oldRefsHash;
-  ProllyHash refsHash;
-  int rc = chunkStorePut(&p->store, pData, nData, &refsHash);
-  if( rc==SQLITE_OK ){
-    memcpy(&oldRefsHash, refsTableGetHash(&p->store.refs), sizeof(ProllyHash));
-    refsTableSetHash(&p->store.refs, &refsHash);
-
-    rc = chunkStoreReloadRefs(&p->store);
-    if( rc!=SQLITE_OK ){
-      refsTableSetHash(&p->store.refs, &oldRefsHash);
-      if( !prollyHashIsEmpty(&oldRefsHash) ){
-        int restoreRc = chunkStoreReloadRefs(&p->store);
-        if( restoreRc!=SQLITE_OK ) return restoreRc;
-      }
-    }
-  }
-  return rc;
+  return chunkStoreInstallRefsBlob(&p->store, pData, nData);
 }
 
 static int fsSetRefsIf(
@@ -422,12 +406,7 @@ struct LocalAsRemote {
 
 static int localSetRefs(DoltliteRemote *pRemote, const u8 *pData, int nData){
   LocalAsRemote *p = (LocalAsRemote*)pRemote;
-  ProllyHash refsHash;
-  int rc = chunkStorePut(p->pStore, pData, nData, &refsHash);
-  if( rc==SQLITE_OK ){
-    refsTableSetHash(&p->pStore->refs, &refsHash);
-  }
-  return rc;
+  return chunkStoreInstallRefsBlob(p->pStore, pData, nData);
 }
 
 static int localSetRefsIf(
@@ -781,9 +760,17 @@ int doltliteClone(ChunkStore *pLocal, DoltliteRemote *pRemote){
   int nRoots = 0;
   DoltliteRemote *pLocalDst = 0;
   ProllyHash oldRefsHash;
+  ProllyHash oldCommittedRefsHash;
+  SavedRefsState savedRefs;
+  int refsDetached = 0;
+  u8 oldRefsStale;
   int rc;
 
   memcpy(&oldRefsHash, refsTableGetHash(&pLocal->refs), sizeof(ProllyHash));
+  memcpy(&oldCommittedRefsHash, &pLocal->refs.committedRefsHash,
+         sizeof(ProllyHash));
+  memset(&savedRefs, 0, sizeof(savedRefs));
+  oldRefsStale = pLocal->bRefsStale;
 
   rc = pRemote->xGetRefs(pRemote, &refsData, &nRefsData);
   if( rc!=SQLITE_OK ) return rc;
@@ -820,30 +807,33 @@ int doltliteClone(ChunkStore *pLocal, DoltliteRemote *pRemote){
   }
 
   if( refsData && nRefsData > 0 ){
-    ProllyHash refsHash;
-    rc = chunkStorePut(pLocal, refsData, nRefsData, &refsHash);
-    if( rc==SQLITE_OK ){
-      refsTableSetHash(&pLocal->refs, &refsHash);
-    }
+    csDetachSavedRefsState(pLocal, &savedRefs);
+    refsDetached = 1;
+    rc = chunkStoreInstallRefsBlob(pLocal, refsData, nRefsData);
   }
   sqlite3_free(refsData);
-  if( rc!=SQLITE_OK ) return rc;
+  refsData = 0;
+  if( rc!=SQLITE_OK ) goto clone_restore_refs;
 
   rc = chunkStoreCommit(pLocal);
   if( rc!=SQLITE_OK ){
-    refsTableSetHash(&pLocal->refs, &oldRefsHash);
-    return rc;
+    goto clone_restore_refs;
   }
 
-  rc = chunkStoreReloadRefs(pLocal);
-  if( rc!=SQLITE_OK ){
-    refsTableSetHash(&pLocal->refs, &oldRefsHash);
-    if( !prollyHashIsEmpty(&oldRefsHash) ){
-      int restoreRc = chunkStoreReloadRefs(pLocal);
-      if( restoreRc!=SQLITE_OK ) return restoreRc;
-    }
-  }
+  if( refsDetached ) csFreeSavedRefsState(&savedRefs);
+  return rc;
 
+clone_restore_refs:
+  sqlite3_free(refsData);
+  if( refsDetached ){
+    csFreeRefsState(pLocal);
+    csRestoreSavedRefsState(pLocal, &savedRefs);
+    memset(&savedRefs, 0, sizeof(savedRefs));
+  }
+  refsTableSetHash(&pLocal->refs, &oldRefsHash);
+  memcpy(&pLocal->refs.committedRefsHash, &oldCommittedRefsHash,
+         sizeof(ProllyHash));
+  pLocal->bRefsStale = oldRefsStale;
   return rc;
 }
 

--- a/src/doltlite_remotesrv.c
+++ b/src/doltlite_remotesrv.c
@@ -393,15 +393,10 @@ static int remoteSrvPersistRefs(ChunkStore *pStore){
 }
 
 static int remoteSrvApplyRefs(ChunkStore *pStore, const u8 *pBody, int nBody){
-  ProllyHash hash;
   int rc;
 
   if( nBody<=0 ) return SQLITE_ERROR;
-  rc = chunkStorePut(pStore, pBody, nBody, &hash);
-  if( rc==SQLITE_OK ){
-    refsTableSetHash(&pStore->refs, &hash);
-    rc = chunkStoreReloadRefs(pStore);
-  }
+  rc = chunkStoreInstallRefsBlob(pStore, pBody, nBody);
   if( rc!=SQLITE_OK ){
     chunkStoreRollback(pStore);
     return rc;


### PR DESCRIPTION
## Summary
- Add a shared chunk-store helper for installing refs blobs.
- Use the helper from filesystem, local, clone, and remote-server refs update paths so refs parsing/hash installation stays consistent.
- Preserve clone rollback behavior by saving and restoring prior refs state on install or commit failure.

## Testing
- `git diff --check`
- `make -B chunk_store.o doltlite_remote.o doltlite_remotesrv.o`
- `make doltlite` compiled touched files, then failed at final link due to existing duplicate symbol `_sqlite3SchemaMutexHeld` between `prolly_btree.o` and `btmutex_orig.o` in the current build configuration.