### PR TITLE
Share DoltLite commit traversal queue

### DIFF
--- a/src/doltlite_diff.c
+++ b/src/doltlite_diff.c
@@ -3,7 +3,6 @@
 
 #include "sqliteInt.h"
 #include "prolly_hash.h"
-#include "prolly_hashset.h"
 #include "prolly_diff.h"
 #include "prolly_cache.h"
 #include "chunk_store.h"
@@ -110,10 +109,7 @@ struct DoltliteDiffVtab {
 typedef struct DoltliteDiffCursor DoltliteDiffCursor;
 struct DoltliteDiffCursor {
   sqlite3_vtab_cursor base;
-  ProllyHash *aQueue;
-  int qHead, qTail, qAlloc;
-  ProllyHashSet visited, queued;
-  int visitedInit, queuedInit;
+  DoltliteCommitQueue queue;
   DiffSummaryRow *aBatch;
   int nBatch;
   int iBatch;
@@ -339,15 +335,15 @@ static int diffAdvance(DoltliteDiffCursor *pCur, sqlite3 *db){
     }
   }
 
-  while( pCur->qHead < pCur->qTail ){
-    ProllyHash cur = pCur->aQueue[pCur->qHead++];
+  for(;;){
+    ProllyHash cur;
     DoltliteCommit commit;
     char zHex[PROLLY_HASH_SIZE*2+1];
-    int i;
+    int hasHash;
 
-    if( prollyHashSetContains(&pCur->visited, &cur) ) continue;
-    rc = prollyHashSetAdd(&pCur->visited, &cur);
+    rc = doltliteCommitQueueNext(&pCur->queue, &cur, &hasHash);
     if( rc!=SQLITE_OK ) return rc;
+    if( !hasHash ) break;
 
     memset(&commit, 0, sizeof(commit));
     rc = doltliteLoadCommit(db, &cur, &commit);
@@ -361,33 +357,10 @@ static int diffAdvance(DoltliteDiffCursor *pCur, sqlite3 *db){
     }
 
     if( !pCur->singleCommit ){
-      for(i=0; i<doltliteCommitParentCount(&commit); i++){
-        const ProllyHash *pParent = doltliteCommitParentHash(&commit, i);
-        if( !pParent || prollyHashIsEmpty(pParent) ) continue;
-        if( prollyHashSetContains(&pCur->visited, pParent) ) continue;
-        if( prollyHashSetContains(&pCur->queued,  pParent) ) continue;
-        if( pCur->qTail >= pCur->qAlloc ){
-          i64 nNew = (i64)pCur->qAlloc * 2;
-          i64 nBytes;
-          ProllyHash *tmp;
-          if( nNew > (i64)0x7fffffff/(i64)sizeof(ProllyHash) ){
-            doltliteCommitClear(&commit);
-            return SQLITE_NOMEM;
-          }
-          nBytes = nNew * (i64)sizeof(ProllyHash);
-          tmp = sqlite3_realloc(pCur->aQueue, (int)nBytes);
-          if( !tmp ){
-            doltliteCommitClear(&commit);
-            return SQLITE_NOMEM;
-          }
-          pCur->aQueue = tmp; pCur->qAlloc = (int)nNew;
-        }
-        pCur->aQueue[pCur->qTail++] = *pParent;
-        rc = prollyHashSetAdd(&pCur->queued, pParent);
-        if( rc!=SQLITE_OK ){
-          doltliteCommitClear(&commit);
-          return rc;
-        }
+      rc = doltliteCommitQueueEnqueueParents(&pCur->queue, &commit);
+      if( rc!=SQLITE_OK ){
+        doltliteCommitClear(&commit);
+        return rc;
       }
     }
     doltliteCommitClear(&commit);
@@ -404,17 +377,7 @@ static int diffAdvance(DoltliteDiffCursor *pCur, sqlite3 *db){
 
 static void diffCursorReset(DoltliteDiffCursor *pCur){
   freeBatch(pCur);
-  sqlite3_free(pCur->aQueue);
-  pCur->aQueue = 0;
-  pCur->qHead = pCur->qTail = pCur->qAlloc = 0;
-  if( pCur->visitedInit ){
-    prollyHashSetFree(&pCur->visited);
-    pCur->visitedInit = 0;
-  }
-  if( pCur->queuedInit ){
-    prollyHashSetFree(&pCur->queued);
-    pCur->queuedInit = 0;
-  }
+  doltliteCommitQueueClear(&pCur->queue);
   sqlite3_free(pCur->zFilterTable);
   pCur->zFilterTable = 0;
   pCur->phase = 0;
@@ -565,20 +528,7 @@ static int diffFilter(sqlite3_vtab_cursor *pCursor,
     pCur->singleCommit = 0;
   }
 
-  rc = prollyHashSetInit(&pCur->visited, 64);
-  if( rc!=SQLITE_OK ) return rc;
-  pCur->visitedInit = 1;
-
-  rc = prollyHashSetInit(&pCur->queued, 64);
-  if( rc!=SQLITE_OK ) return rc;
-  pCur->queuedInit = 1;
-
-  pCur->qAlloc = 16;
-  pCur->aQueue = sqlite3_malloc(pCur->qAlloc * (int)sizeof(ProllyHash));
-  if( !pCur->aQueue ) return SQLITE_NOMEM;
-  pCur->aQueue[0] = head;
-  pCur->qTail = 1;
-  rc = prollyHashSetAdd(&pCur->queued, &head);
+  rc = doltliteCommitQueueInit(&pCur->queue, &head);
   if( rc!=SQLITE_OK ) return rc;
 
   if( useStart ){

--- a/src/doltlite_history.c
+++ b/src/doltlite_history.c
@@ -2,7 +2,6 @@
 #ifdef DOLTLITE_PROLLY
 
 #include "doltlite_vtab_util.h"
-#include "prolly_hashset.h"
 #include "doltlite_commit.h"
 #include "doltlite_internal.h"
 #include <string.h>
@@ -40,10 +39,7 @@ struct HistVtab {
 typedef struct HistCursor HistCursor;
 struct HistCursor {
   DoltliteVtabCursorCommon common;
-  ProllyHash *aQueue;
-  int qHead, qTail, qAlloc;
-  ProllyHashSet visited, queued;
-  int visitedInit, queuedInit;
+  DoltliteCommitQueue queue;
   char zCommitHex[PROLLY_HASH_SIZE*2+1];
   char *zCommitter;
   i64 commitDate;
@@ -60,17 +56,7 @@ static void htCursorReset(HistCursor *c){
   doltliteVtabCommonReset(&c->common);
   sqlite3_free(c->zCommitter);
   c->zCommitter = 0;
-  sqlite3_free(c->aQueue);
-  c->aQueue = 0;
-  c->qHead = c->qTail = c->qAlloc = 0;
-  if( c->visitedInit ){
-    prollyHashSetFree(&c->visited);
-    c->visitedInit = 0;
-  }
-  if( c->queuedInit ){
-    prollyHashSetFree(&c->queued);
-    c->queuedInit = 0;
-  }
+  doltliteCommitQueueClear(&c->queue);
 }
 
 static int htRowMatchesUpper(HistCursor *c){
@@ -106,35 +92,10 @@ static int htOpenTableAtCommit(HistCursor *c, sqlite3 *db,
     return SQLITE_NOMEM;
   }
 
-  {
-    int i;
-    for(i=0; i<doltliteCommitParentCount(&commit); i++){
-      const ProllyHash *pParent = doltliteCommitParentHash(&commit, i);
-      if( !pParent || prollyHashIsEmpty(pParent) ) continue;
-      if( prollyHashSetContains(&c->visited, pParent) ) continue;
-      if( prollyHashSetContains(&c->queued, pParent) ) continue;
-      if( c->qTail >= c->qAlloc ){
-        i64 nNew = c->qAlloc ? (i64)c->qAlloc * 2 : (i64)16;
-        ProllyHash *tmp;
-        if( nNew > (i64)0x7fffffff/(i64)sizeof(ProllyHash) ){
-          doltliteCommitClear(&commit);
-          return SQLITE_NOMEM;
-        }
-        tmp = sqlite3_realloc(c->aQueue,
-                              (int)(nNew * (i64)sizeof(ProllyHash)));
-        if( !tmp ){
-          doltliteCommitClear(&commit);
-          return SQLITE_NOMEM;
-        }
-        c->aQueue = tmp; c->qAlloc = (int)nNew;
-      }
-      c->aQueue[c->qTail++] = *pParent;
-      rc = prollyHashSetAdd(&c->queued, pParent);
-      if( rc!=SQLITE_OK ){
-        doltliteCommitClear(&commit);
-        return rc;
-      }
-    }
+  rc = doltliteCommitQueueEnqueueParents(&c->queue, &commit);
+  if( rc!=SQLITE_OK ){
+    doltliteCommitClear(&commit);
+    return rc;
   }
 
   rc = doltliteLoadCatalog(db, &commit.catalogHash, &aT, &nT, 0);
@@ -229,12 +190,13 @@ static int htAdvance(HistCursor *c, sqlite3 *db, const char *zTableName){
     }
   }
 
-  while( c->qHead < c->qTail ){
-    ProllyHash cur = c->aQueue[c->qHead++];
+  for(;;){
+    ProllyHash cur;
+    int hasHash;
 
-    if( prollyHashSetContains(&c->visited, &cur) ) continue;
-    rc = prollyHashSetAdd(&c->visited, &cur);
+    rc = doltliteCommitQueueNext(&c->queue, &cur, &hasHash);
     if( rc!=SQLITE_OK ) return rc;
+    if( !hasHash ) break;
 
     rc = htOpenTableAtCommit(c, db, zTableName, &cur);
     if( rc!=SQLITE_OK ) return rc;
@@ -396,20 +358,7 @@ static int htFilter(sqlite3_vtab_cursor *cur,
   doltliteGetSessionHead(v->db, &head);
   if( prollyHashIsEmpty(&head) ) return SQLITE_OK;
 
-  rc = prollyHashSetInit(&c->visited, 64);
-  if( rc!=SQLITE_OK ) return rc;
-  c->visitedInit = 1;
-
-  rc = prollyHashSetInit(&c->queued, 64);
-  if( rc!=SQLITE_OK ) return rc;
-  c->queuedInit = 1;
-
-  c->qAlloc = 16;
-  c->aQueue = sqlite3_malloc(c->qAlloc * (int)sizeof(ProllyHash));
-  if( !c->aQueue ) return SQLITE_NOMEM;
-  c->aQueue[0] = head;
-  c->qTail = 1;
-  rc = prollyHashSetAdd(&c->queued, &head);
+  rc = doltliteCommitQueueInit(&c->queue, &head);
   if( rc!=SQLITE_OK ) return rc;
 
   return htAdvance(c, v->db, v->zTableName);

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -4,6 +4,8 @@
 
 #include "sqliteInt.h"
 #include "prolly_hash.h"
+#include "prolly_hashset.h"
+#include "doltlite_commit.h"
 #include "chunk_store.h"
 #include <time.h>
 #include <ctype.h>
@@ -12,6 +14,102 @@ typedef struct BtShared BtShared;
 typedef struct ProllyCache ProllyCache;
 typedef struct SchemaEntry SchemaEntry;
 typedef struct DoltliteTxnState DoltliteTxnState;
+typedef struct DoltliteCommitQueue DoltliteCommitQueue;
+
+struct DoltliteCommitQueue {
+  ProllyHash *aQueue;
+  int qHead, qTail, qAlloc;
+  ProllyHashSet visited, queued;
+  int visitedInit, queuedInit;
+};
+
+static SQLITE_INLINE void doltliteCommitQueueClear(DoltliteCommitQueue *q){
+  sqlite3_free(q->aQueue);
+  q->aQueue = 0;
+  q->qHead = q->qTail = q->qAlloc = 0;
+  if( q->visitedInit ){
+    prollyHashSetFree(&q->visited);
+    q->visitedInit = 0;
+  }
+  if( q->queuedInit ){
+    prollyHashSetFree(&q->queued);
+    q->queuedInit = 0;
+  }
+}
+
+static SQLITE_INLINE int doltliteCommitQueueEnqueue(
+  DoltliteCommitQueue *q,
+  const ProllyHash *pHash
+){
+  int rc;
+  if( !pHash || prollyHashIsEmpty(pHash) ) return SQLITE_OK;
+  if( prollyHashSetContains(&q->visited, pHash) ) return SQLITE_OK;
+  if( prollyHashSetContains(&q->queued, pHash) ) return SQLITE_OK;
+  if( q->qTail >= q->qAlloc ){
+    i64 nNew = q->qAlloc ? (i64)q->qAlloc * 2 : (i64)16;
+    ProllyHash *tmp;
+    if( nNew > (i64)0x7fffffff/(i64)sizeof(ProllyHash) ) return SQLITE_NOMEM;
+    tmp = sqlite3_realloc(q->aQueue, (int)(nNew * (i64)sizeof(ProllyHash)));
+    if( !tmp ) return SQLITE_NOMEM;
+    q->aQueue = tmp;
+    q->qAlloc = (int)nNew;
+  }
+  q->aQueue[q->qTail++] = *pHash;
+  rc = prollyHashSetAdd(&q->queued, pHash);
+  return rc;
+}
+
+static SQLITE_INLINE int doltliteCommitQueueInit(
+  DoltliteCommitQueue *q,
+  const ProllyHash *pHead
+){
+  int rc;
+  doltliteCommitQueueClear(q);
+  rc = prollyHashSetInit(&q->visited, 64);
+  if( rc!=SQLITE_OK ) return rc;
+  q->visitedInit = 1;
+  rc = prollyHashSetInit(&q->queued, 64);
+  if( rc!=SQLITE_OK ){
+    doltliteCommitQueueClear(q);
+    return rc;
+  }
+  q->queuedInit = 1;
+  rc = doltliteCommitQueueEnqueue(q, pHead);
+  if( rc!=SQLITE_OK ) doltliteCommitQueueClear(q);
+  return rc;
+}
+
+static SQLITE_INLINE int doltliteCommitQueueNext(
+  DoltliteCommitQueue *q,
+  ProllyHash *pHash,
+  int *pHas
+){
+  int rc;
+  *pHas = 0;
+  while( q->qHead < q->qTail ){
+    ProllyHash cur = q->aQueue[q->qHead++];
+    if( prollyHashSetContains(&q->visited, &cur) ) continue;
+    rc = prollyHashSetAdd(&q->visited, &cur);
+    if( rc!=SQLITE_OK ) return rc;
+    *pHash = cur;
+    *pHas = 1;
+    return SQLITE_OK;
+  }
+  return SQLITE_OK;
+}
+
+static SQLITE_INLINE int doltliteCommitQueueEnqueueParents(
+  DoltliteCommitQueue *q,
+  const DoltliteCommit *pCommit
+){
+  int i, rc;
+  for(i=0; i<doltliteCommitParentCount(pCommit); i++){
+    const ProllyHash *pParent = doltliteCommitParentHash(pCommit, i);
+    rc = doltliteCommitQueueEnqueue(q, pParent);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+  return SQLITE_OK;
+}
 
 typedef enum DoltliteVcTxnMode DoltliteVcTxnMode;
 enum DoltliteVcTxnMode {

--- a/src/doltlite_log.c
+++ b/src/doltlite_log.c
@@ -4,7 +4,6 @@
 #include "sqliteInt.h"
 #include "doltlite_commit.h"
 #include "prolly_hash.h"
-#include "prolly_hashset.h"
 #include "chunk_store.h"
 
 #include "doltlite_internal.h"
@@ -22,10 +21,7 @@ struct DoltliteLogVtab {
 typedef struct DoltliteLogCursor DoltliteLogCursor;
 struct DoltliteLogCursor {
   sqlite3_vtab_cursor base;
-  ProllyHash *aQueue;
-  int qHead, qTail, qAlloc;
-  ProllyHashSet visited;
-  int visitedInit;
+  DoltliteCommitQueue queue;
   char zHex[PROLLY_HASH_SIZE*2+1];
   DoltliteCommit curCommit;
   int hasRow;
@@ -81,13 +77,7 @@ static int doltliteLogOpen(sqlite3_vtab *pVtab, sqlite3_vtab_cursor **ppCursor){
 static void logCursorReset(DoltliteLogCursor *pCur){
   doltliteCommitClear(&pCur->curCommit);
   memset(&pCur->curCommit, 0, sizeof(pCur->curCommit));
-  sqlite3_free(pCur->aQueue);
-  pCur->aQueue = 0;
-  pCur->qHead = pCur->qTail = pCur->qAlloc = 0;
-  if( pCur->visitedInit ){
-    prollyHashSetFree(&pCur->visited);
-    pCur->visitedInit = 0;
-  }
+  doltliteCommitQueueClear(&pCur->queue);
   pCur->hasRow = 0;
   pCur->iRowid = 0;
 }
@@ -100,18 +90,17 @@ static int doltliteLogClose(sqlite3_vtab_cursor *pCursor){
 }
 
 static int logAdvance(DoltliteLogCursor *pCur, sqlite3 *db){
-  int i, rc;
+  int rc, hasHash;
 
   doltliteCommitClear(&pCur->curCommit);
   memset(&pCur->curCommit, 0, sizeof(pCur->curCommit));
   pCur->hasRow = 0;
 
-  while( pCur->qHead < pCur->qTail ){
-    ProllyHash cur = pCur->aQueue[pCur->qHead++];
-
-    if( prollyHashSetContains(&pCur->visited, &cur) ) continue;
-    rc = prollyHashSetAdd(&pCur->visited, &cur);
+  for(;;){
+    ProllyHash cur;
+    rc = doltliteCommitQueueNext(&pCur->queue, &cur, &hasHash);
     if( rc!=SQLITE_OK ) return rc;
+    if( !hasHash ) break;
 
     rc = doltliteLoadCommit(db, &cur, &pCur->curCommit);
     if( rc!=SQLITE_OK ){
@@ -128,21 +117,8 @@ static int logAdvance(DoltliteLogCursor *pCur, sqlite3 *db){
 
     if( pCur->singleCommit ) return SQLITE_OK;
 
-    for(i = 0; i < doltliteCommitParentCount(&pCur->curCommit); i++){
-      const ProllyHash *pParent = doltliteCommitParentHash(&pCur->curCommit, i);
-      if( !pParent || prollyHashIsEmpty(pParent) ) continue;
-      if( pCur->qTail >= pCur->qAlloc ){
-        i64 nNew = pCur->qAlloc ? (i64)pCur->qAlloc * 2 : (i64)16;
-        ProllyHash *tmp;
-        if( nNew > (i64)0x7fffffff/(i64)sizeof(ProllyHash) ) return SQLITE_NOMEM;
-        tmp = sqlite3_realloc(pCur->aQueue,
-                              (int)(nNew * (i64)sizeof(ProllyHash)));
-        if( !tmp ) return SQLITE_NOMEM;
-        pCur->aQueue = tmp;
-        pCur->qAlloc = (int)nNew;
-      }
-      pCur->aQueue[pCur->qTail++] = *pParent;
-    }
+    rc = doltliteCommitQueueEnqueueParents(&pCur->queue, &pCur->curCommit);
+    if( rc!=SQLITE_OK ) return rc;
     return SQLITE_OK;
   }
   return SQLITE_OK;
@@ -201,15 +177,8 @@ static int doltliteLogFilter(
     pCur->singleCommit = 0;
   }
 
-  rc = prollyHashSetInit(&pCur->visited, 64);
+  rc = doltliteCommitQueueInit(&pCur->queue, &head);
   if( rc!=SQLITE_OK ) return rc;
-  pCur->visitedInit = 1;
-
-  pCur->qAlloc = 16;
-  pCur->aQueue = sqlite3_malloc(pCur->qAlloc * (int)sizeof(ProllyHash));
-  if( !pCur->aQueue ) return SQLITE_NOMEM;
-  pCur->aQueue[0] = head;
-  pCur->qTail = 1;
 
   return logAdvance(pCur, pVtab->db);
 }


### PR DESCRIPTION
## Summary
- Add a shared DoltLite commit traversal queue for commit graph walkers
- Use it in dolt_log, dolt_diff, and dolt_history to remove duplicated FIFO/hashset logic

## Tests
- `git diff --check`
- `make -B doltlite_log.o doltlite_diff.o doltlite_history.o` from `build/`
- `make doltlite` from `build/` (reaches existing duplicate `_sqlite3SchemaMutexHeld` link failure between `prolly_btree.o` and `btmutex_orig.o`; compile phase completes)