### PR TITLE
Share integer primary key range planning

### DIFF
--- a/src/doltlite_blame.c
+++ b/src/doltlite_blame.c
@@ -699,66 +699,18 @@ static int bmDisconnect(sqlite3_vtab *pVtab){
 
 static int bmBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
   BlameVtab *v = (BlameVtab*)pVtab;
-  int iEq = -1, iGe = -1, iLe = -1, iGt = -1, iLt = -1;
-  int i, nArg = 0, idxNum = 0;
-
-  pInfo->estimatedCost = 100000.0;
-  pInfo->estimatedRows = 1000;
 
   if( !blameIntPkEnabled(v) ){
+    pInfo->estimatedCost = 100000.0;
+    pInfo->estimatedRows = 1000;
     pInfo->idxNum = 0;
     return SQLITE_OK;
   }
 
-  for(i=0; i<pInfo->nConstraint; i++){
-    const struct sqlite3_index_constraint *pC = &pInfo->aConstraint[i];
-    if( !pC->usable ) continue;
-    if( pC->iColumn != 0 ) continue;
-    switch( pC->op ){
-      case SQLITE_INDEX_CONSTRAINT_EQ: if( iEq<0 ) iEq = i; break;
-      case SQLITE_INDEX_CONSTRAINT_GE: if( iGe<0 ) iGe = i; break;
-      case SQLITE_INDEX_CONSTRAINT_LE: if( iLe<0 ) iLe = i; break;
-      case SQLITE_INDEX_CONSTRAINT_GT: if( iGt<0 ) iGt = i; break;
-      case SQLITE_INDEX_CONSTRAINT_LT: if( iLt<0 ) iLt = i; break;
-      default: break;
-    }
-  }
-
-  if( iEq >= 0 ){
-    pInfo->aConstraintUsage[iEq].argvIndex = ++nArg;
-    pInfo->aConstraintUsage[iEq].omit = 1;
-    idxNum |= BLAME_IDX_PK_EQ;
-    pInfo->estimatedCost = 100.0;
-    pInfo->estimatedRows = 1;
-  }else{
-    if( iGe >= 0 ){
-      pInfo->aConstraintUsage[iGe].argvIndex = ++nArg;
-      pInfo->aConstraintUsage[iGe].omit = 1;
-      idxNum |= BLAME_IDX_PK_GE;
-    }
-    if( iGt >= 0 ){
-      pInfo->aConstraintUsage[iGt].argvIndex = ++nArg;
-      pInfo->aConstraintUsage[iGt].omit = 1;
-      idxNum |= BLAME_IDX_PK_GT;
-    }
-    if( iLe >= 0 ){
-      pInfo->aConstraintUsage[iLe].argvIndex = ++nArg;
-      pInfo->aConstraintUsage[iLe].omit = 1;
-      idxNum |= BLAME_IDX_PK_LE;
-    }
-    if( iLt >= 0 ){
-      pInfo->aConstraintUsage[iLt].argvIndex = ++nArg;
-      pInfo->aConstraintUsage[iLt].omit = 1;
-      idxNum |= BLAME_IDX_PK_LT;
-    }
-    if( idxNum != 0 ){
-      pInfo->estimatedCost = 1000.0;
-      pInfo->estimatedRows = 100;
-    }
-  }
-
-  pInfo->idxNum = idxNum;
-  return SQLITE_OK;
+  return doltliteBestIndexIntPkRange(pInfo, 0,
+      BLAME_IDX_PK_EQ, BLAME_IDX_PK_GE, BLAME_IDX_PK_LE,
+      BLAME_IDX_PK_GT, BLAME_IDX_PK_LT,
+      100000.0, 1000, 100.0, 1, 1000.0, 100);
 }
 
 static int bmOpen(sqlite3_vtab *pVtab, sqlite3_vtab_cursor **ppCursor){
@@ -785,56 +737,16 @@ static int bmFilter(sqlite3_vtab_cursor *pCursor,
   ProllyHash tableRoot;
   u8 tableFlags = 0;
   int rc;
-  int iArg = 0;
-  i64 pkLo = 0, pkHi = 0;
-  int hasPkLo = 0, hasPkHi = 0;
-  int pkLoStrict = 0, pkHiStrict = 0;
+  DoltlitePkRange pkRange;
   (void)idxStr;
 
   blameFreeRows(c);
   c->iRow = 0;
 
-  if( idxNum & BLAME_IDX_PK_EQ ){
-    if( iArg < argc ){
-      pkLo = sqlite3_value_int64(argv[iArg++]);
-      hasPkLo = 1;
-    }
-  }else{
-    if( idxNum & BLAME_IDX_PK_GE ){
-      if( iArg < argc ){
-        pkLo = sqlite3_value_int64(argv[iArg++]);
-        hasPkLo = 1;
-        pkLoStrict = 0;
-      }
-    }
-    if( idxNum & BLAME_IDX_PK_GT ){
-      if( iArg < argc ){
-        i64 v2 = sqlite3_value_int64(argv[iArg++]);
-        if( !hasPkLo || v2 >= pkLo ){
-          pkLo = v2;
-          hasPkLo = 1;
-          pkLoStrict = 1;
-        }
-      }
-    }
-    if( idxNum & BLAME_IDX_PK_LE ){
-      if( iArg < argc ){
-        pkHi = sqlite3_value_int64(argv[iArg++]);
-        hasPkHi = 1;
-        pkHiStrict = 0;
-      }
-    }
-    if( idxNum & BLAME_IDX_PK_LT ){
-      if( iArg < argc ){
-        i64 v2 = sqlite3_value_int64(argv[iArg++]);
-        if( !hasPkHi || v2 <= pkHi ){
-          pkHi = v2;
-          hasPkHi = 1;
-          pkHiStrict = 1;
-        }
-      }
-    }
-  }
+  doltlitePkRangeFromArgs(idxNum,
+      BLAME_IDX_PK_EQ, BLAME_IDX_PK_GE, BLAME_IDX_PK_LE,
+      BLAME_IDX_PK_GT, BLAME_IDX_PK_LT,
+      argc, argv, &pkRange);
 
   if( !cs || !pCache ) return SQLITE_OK;
 
@@ -853,8 +765,10 @@ static int bmFilter(sqlite3_vtab_cursor *pCursor,
 
   rc = blameCollectLiveRows(c, cs, pCache, &tableRoot, tableFlags,
                             idxNum,
-                            pkLo, hasPkLo, pkLoStrict,
-                            pkHi, hasPkHi, pkHiStrict);
+                            pkRange.pkLo, pkRange.hasPkLo,
+                            pkRange.pkLoStrict,
+                            pkRange.pkHi, pkRange.hasPkHi,
+                            pkRange.pkHiStrict);
   if( rc!=SQLITE_OK ){ blameFreeRows(c); return rc; }
   c->nUnresolved = c->nRows;
 

--- a/src/doltlite_history.c
+++ b/src/doltlite_history.c
@@ -48,12 +48,7 @@ struct HistCursor {
   char *zCommitter;
   i64 commitDate;
   int idxNum;
-  i64 pkLo;
-  i64 pkHi;
-  int hasPkLo;
-  int hasPkHi;
-  int pkLoStrict;
-  int pkHiStrict;
+  DoltlitePkRange pkRange;
 };
 
 static void htCursorReset(HistCursor *c){
@@ -75,12 +70,12 @@ static void htCursorReset(HistCursor *c){
 
 static int htRowMatchesUpper(HistCursor *c){
   i64 k;
-  if( !c->hasPkHi ) return 1;
+  if( !c->pkRange.hasPkHi ) return 1;
   k = prollyCursorIntKey(&c->common.tblCur);
-  if( c->pkHiStrict ){
-    return k < c->pkHi;
+  if( c->pkRange.pkHiStrict ){
+    return k < c->pkRange.pkHi;
   }
-  return k <= c->pkHi;
+  return k <= c->pkRange.pkHi;
 }
 
 static int htOpenTableAtCommit(HistCursor *c, sqlite3 *db,
@@ -154,7 +149,7 @@ static int htOpenTableAtCommit(HistCursor *c, sqlite3 *db,
           && (c->idxNum & HIST_IDX_PK_ANY) != 0;
 
   if( seekable && (c->idxNum & HIST_IDX_PK_EQ) ){
-    rc = prollyCursorSeekInt(&c->common.tblCur, c->pkLo, &res);
+    rc = prollyCursorSeekInt(&c->common.tblCur, c->pkRange.pkLo, &res);
     if( rc!=SQLITE_OK ){
       prollyCursorClose(&c->common.tblCur);
       return rc;
@@ -167,9 +162,9 @@ static int htOpenTableAtCommit(HistCursor *c, sqlite3 *db,
     return SQLITE_OK;
   }
 
-  if( seekable && c->hasPkLo ){
-    i64 startKey = c->pkLo;
-    if( c->pkLoStrict ) startKey++;
+  if( seekable && c->pkRange.hasPkLo ){
+    i64 startKey = c->pkRange.pkLo;
+    if( c->pkRange.pkLoStrict ) startKey++;
     rc = prollyCursorSeekInt(&c->common.tblCur, startKey, &res);
     if( rc!=SQLITE_OK ){
       prollyCursorClose(&c->common.tblCur);
@@ -199,7 +194,7 @@ static int htOpenTableAtCommit(HistCursor *c, sqlite3 *db,
     prollyCursorClose(&c->common.tblCur);
     return SQLITE_OK;
   }
-  if( seekable && c->hasPkHi && !htRowMatchesUpper(c) ){
+  if( seekable && c->pkRange.hasPkHi && !htRowMatchesUpper(c) ){
     prollyCursorClose(&c->common.tblCur);
     return SQLITE_OK;
   }
@@ -258,67 +253,10 @@ static int htConnect(sqlite3 *db, void *pAux, int argc,
 
 static int htBestIndex(sqlite3_vtab *v, sqlite3_index_info *p){
   DoltliteVtabCommon *vt = (DoltliteVtabCommon*)v;
-  int iEq = -1, iGe = -1, iLe = -1, iGt = -1, iLt = -1;
-  int i, nArg = 0, idxNum = 0;
-  int iPk = vt->cols.iPkCol;
-
-  p->estimatedCost = 100000.0;
-  p->estimatedRows = 100000;
-
-  if( iPk < 0 ){
-    p->idxNum = 0;
-    return SQLITE_OK;
-  }
-
-  for(i=0; i<p->nConstraint; i++){
-    const struct sqlite3_index_constraint *pC = &p->aConstraint[i];
-    if( !pC->usable ) continue;
-    if( pC->iColumn != iPk ) continue;
-    switch( pC->op ){
-      case SQLITE_INDEX_CONSTRAINT_EQ: if( iEq<0 ) iEq = i; break;
-      case SQLITE_INDEX_CONSTRAINT_GE: if( iGe<0 ) iGe = i; break;
-      case SQLITE_INDEX_CONSTRAINT_LE: if( iLe<0 ) iLe = i; break;
-      case SQLITE_INDEX_CONSTRAINT_GT: if( iGt<0 ) iGt = i; break;
-      case SQLITE_INDEX_CONSTRAINT_LT: if( iLt<0 ) iLt = i; break;
-      default: break;
-    }
-  }
-
-  if( iEq >= 0 ){
-    p->aConstraintUsage[iEq].argvIndex = ++nArg;
-    p->aConstraintUsage[iEq].omit = 1;
-    idxNum |= HIST_IDX_PK_EQ;
-    p->estimatedCost = 100.0;
-    p->estimatedRows = 100;
-  }else{
-    if( iGe >= 0 ){
-      p->aConstraintUsage[iGe].argvIndex = ++nArg;
-      p->aConstraintUsage[iGe].omit = 1;
-      idxNum |= HIST_IDX_PK_GE;
-    }
-    if( iGt >= 0 ){
-      p->aConstraintUsage[iGt].argvIndex = ++nArg;
-      p->aConstraintUsage[iGt].omit = 1;
-      idxNum |= HIST_IDX_PK_GT;
-    }
-    if( iLe >= 0 ){
-      p->aConstraintUsage[iLe].argvIndex = ++nArg;
-      p->aConstraintUsage[iLe].omit = 1;
-      idxNum |= HIST_IDX_PK_LE;
-    }
-    if( iLt >= 0 ){
-      p->aConstraintUsage[iLt].argvIndex = ++nArg;
-      p->aConstraintUsage[iLt].omit = 1;
-      idxNum |= HIST_IDX_PK_LT;
-    }
-    if( idxNum != 0 ){
-      p->estimatedCost = 1000.0;
-      p->estimatedRows = 1000;
-    }
-  }
-
-  p->idxNum = idxNum;
-  return SQLITE_OK;
+  return doltliteBestIndexIntPkRange(p, vt->cols.iPkCol,
+      HIST_IDX_PK_EQ, HIST_IDX_PK_GE, HIST_IDX_PK_LE,
+      HIST_IDX_PK_GT, HIST_IDX_PK_LT,
+      100000.0, 100000, 100.0, 100, 1000.0, 1000);
 }
 
 static int htOpen(sqlite3_vtab *pVtab, sqlite3_vtab_cursor **pp){
@@ -338,57 +276,15 @@ static int htFilter(sqlite3_vtab_cursor *cur,
   ProllyHash head;
   ChunkStore *cs;
   int rc;
-  int iArg = 0;
-  (void)idxStr;(void)argc;
+  (void)idxStr;
 
   htCursorReset(c);
 
   c->idxNum = idxNum;
-  c->hasPkLo = c->hasPkHi = 0;
-  c->pkLoStrict = c->pkHiStrict = 0;
-  c->pkLo = c->pkHi = 0;
-
-  if( idxNum & HIST_IDX_PK_EQ ){
-    if( iArg < argc ){
-      c->pkLo = sqlite3_value_int64(argv[iArg++]);
-      c->hasPkLo = 1;
-    }
-  }else{
-    if( idxNum & HIST_IDX_PK_GE ){
-      if( iArg < argc ){
-        c->pkLo = sqlite3_value_int64(argv[iArg++]);
-        c->hasPkLo = 1;
-        c->pkLoStrict = 0;
-      }
-    }
-    if( idxNum & HIST_IDX_PK_GT ){
-      if( iArg < argc ){
-        i64 v2 = sqlite3_value_int64(argv[iArg++]);
-        if( !c->hasPkLo || v2 >= c->pkLo ){
-          c->pkLo = v2;
-          c->hasPkLo = 1;
-          c->pkLoStrict = 1;
-        }
-      }
-    }
-    if( idxNum & HIST_IDX_PK_LE ){
-      if( iArg < argc ){
-        c->pkHi = sqlite3_value_int64(argv[iArg++]);
-        c->hasPkHi = 1;
-        c->pkHiStrict = 0;
-      }
-    }
-    if( idxNum & HIST_IDX_PK_LT ){
-      if( iArg < argc ){
-        i64 v2 = sqlite3_value_int64(argv[iArg++]);
-        if( !c->hasPkHi || v2 <= c->pkHi ){
-          c->pkHi = v2;
-          c->hasPkHi = 1;
-          c->pkHiStrict = 1;
-        }
-      }
-    }
-  }
+  doltlitePkRangeFromArgs(idxNum,
+      HIST_IDX_PK_EQ, HIST_IDX_PK_GE, HIST_IDX_PK_LE,
+      HIST_IDX_PK_GT, HIST_IDX_PK_LT,
+      argc, argv, &c->pkRange);
 
   cs = doltliteGetChunkStore(v->db);
   if( !cs ) return SQLITE_OK;

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -12,6 +12,16 @@ typedef struct BtShared BtShared;
 typedef struct ProllyCache ProllyCache;
 typedef struct SchemaEntry SchemaEntry;
 typedef struct DoltliteTxnState DoltliteTxnState;
+typedef struct DoltlitePkRange DoltlitePkRange;
+
+struct DoltlitePkRange {
+  i64 pkLo;
+  i64 pkHi;
+  int hasPkLo;
+  int hasPkHi;
+  int pkLoStrict;
+  int pkHiStrict;
+};
 
 typedef enum DoltliteVcTxnMode DoltliteVcTxnMode;
 enum DoltliteVcTxnMode {
@@ -165,6 +175,140 @@ static SQLITE_INLINE int doltliteBestIndexRefs(
   pInfo->idxNum = (iFrom>=0 ? 1 : 0) | (iTo>=0 ? 2 : 0) | (iTbl>=0 ? 4 : 0);
   pInfo->estimatedCost = 1000.0;
   return SQLITE_OK;
+}
+
+static SQLITE_INLINE int doltliteBestIndexIntPkRange(
+  sqlite3_index_info *pInfo,
+  int iPkCol,
+  int idxEq,
+  int idxGe,
+  int idxLe,
+  int idxGt,
+  int idxLt,
+  double fullCost,
+  sqlite3_int64 fullRows,
+  double eqCost,
+  sqlite3_int64 eqRows,
+  double rangeCost,
+  sqlite3_int64 rangeRows
+){
+  int iEq = -1, iGe = -1, iLe = -1, iGt = -1, iLt = -1;
+  int i, nArg = 0, idxNum = 0;
+
+  pInfo->estimatedCost = fullCost;
+  pInfo->estimatedRows = fullRows;
+
+  if( iPkCol < 0 ){
+    pInfo->idxNum = 0;
+    return SQLITE_OK;
+  }
+
+  for(i=0; i<pInfo->nConstraint; i++){
+    const struct sqlite3_index_constraint *pC = &pInfo->aConstraint[i];
+    if( !pC->usable ) continue;
+    if( pC->iColumn != iPkCol ) continue;
+    switch( pC->op ){
+      case SQLITE_INDEX_CONSTRAINT_EQ: if( iEq<0 ) iEq = i; break;
+      case SQLITE_INDEX_CONSTRAINT_GE: if( iGe<0 ) iGe = i; break;
+      case SQLITE_INDEX_CONSTRAINT_LE: if( iLe<0 ) iLe = i; break;
+      case SQLITE_INDEX_CONSTRAINT_GT: if( iGt<0 ) iGt = i; break;
+      case SQLITE_INDEX_CONSTRAINT_LT: if( iLt<0 ) iLt = i; break;
+      default: break;
+    }
+  }
+
+  if( iEq >= 0 ){
+    pInfo->aConstraintUsage[iEq].argvIndex = ++nArg;
+    pInfo->aConstraintUsage[iEq].omit = 1;
+    idxNum |= idxEq;
+    pInfo->estimatedCost = eqCost;
+    pInfo->estimatedRows = eqRows;
+  }else{
+    if( iGe >= 0 ){
+      pInfo->aConstraintUsage[iGe].argvIndex = ++nArg;
+      pInfo->aConstraintUsage[iGe].omit = 1;
+      idxNum |= idxGe;
+    }
+    if( iGt >= 0 ){
+      pInfo->aConstraintUsage[iGt].argvIndex = ++nArg;
+      pInfo->aConstraintUsage[iGt].omit = 1;
+      idxNum |= idxGt;
+    }
+    if( iLe >= 0 ){
+      pInfo->aConstraintUsage[iLe].argvIndex = ++nArg;
+      pInfo->aConstraintUsage[iLe].omit = 1;
+      idxNum |= idxLe;
+    }
+    if( iLt >= 0 ){
+      pInfo->aConstraintUsage[iLt].argvIndex = ++nArg;
+      pInfo->aConstraintUsage[iLt].omit = 1;
+      idxNum |= idxLt;
+    }
+    if( idxNum != 0 ){
+      pInfo->estimatedCost = rangeCost;
+      pInfo->estimatedRows = rangeRows;
+    }
+  }
+
+  pInfo->idxNum = idxNum;
+  return SQLITE_OK;
+}
+
+static SQLITE_INLINE void doltlitePkRangeFromArgs(
+  int idxNum,
+  int idxEq,
+  int idxGe,
+  int idxLe,
+  int idxGt,
+  int idxLt,
+  int argc,
+  sqlite3_value **argv,
+  DoltlitePkRange *pRange
+){
+  int iArg = 0;
+  memset(pRange, 0, sizeof(*pRange));
+
+  if( idxNum & idxEq ){
+    if( iArg < argc ){
+      pRange->pkLo = sqlite3_value_int64(argv[iArg++]);
+      pRange->hasPkLo = 1;
+    }
+  }else{
+    if( idxNum & idxGe ){
+      if( iArg < argc ){
+        pRange->pkLo = sqlite3_value_int64(argv[iArg++]);
+        pRange->hasPkLo = 1;
+        pRange->pkLoStrict = 0;
+      }
+    }
+    if( idxNum & idxGt ){
+      if( iArg < argc ){
+        i64 v2 = sqlite3_value_int64(argv[iArg++]);
+        if( !pRange->hasPkLo || v2 >= pRange->pkLo ){
+          pRange->pkLo = v2;
+          pRange->hasPkLo = 1;
+          pRange->pkLoStrict = 1;
+        }
+      }
+    }
+    if( idxNum & idxLe ){
+      if( iArg < argc ){
+        pRange->pkHi = sqlite3_value_int64(argv[iArg++]);
+        pRange->hasPkHi = 1;
+        pRange->pkHiStrict = 0;
+      }
+    }
+    if( idxNum & idxLt ){
+      if( iArg < argc ){
+        i64 v2 = sqlite3_value_int64(argv[iArg++]);
+        if( !pRange->hasPkHi || v2 <= pRange->pkHi ){
+          pRange->pkHi = v2;
+          pRange->hasPkHi = 1;
+          pRange->pkHiStrict = 1;
+        }
+      }
+    }
+  }
 }
 
 static SQLITE_INLINE void doltliteResultTimestamp(sqlite3_context *ctx, i64 timestamp){


### PR DESCRIPTION
## Summary
- Add shared helpers for integer primary-key range constraint planning and argument decoding
- Use the helpers from `dolt_history_*` and `dolt_blame_*` while preserving their existing selectivity estimates

## Tests
- `git diff --check`
- `make -B doltlite_history.o doltlite_blame.o` from `build/`