### PR TITLE
Share table root lookup helpers

### DIFF
--- a/src/doltlite_at.c
+++ b/src/doltlite_at.c
@@ -140,7 +140,7 @@ static int atFilter(sqlite3_vtab_cursor *cur,
   doltliteCommitClear(&commit);
   if(rc!=SQLITE_OK) return rc;
 
-  rc=doltliteFindTableRootByName(aTables,nTables,v->zTableName,&tableRoot,&flags);
+  rc=doltliteFindTableRootByName(aTables,nTables,v->zTableName,&tableRoot,&flags,0);
   doltliteFreeCatalog(aTables,nTables);
   if(rc==SQLITE_NOTFOUND) return SQLITE_OK;
   if(rc!=SQLITE_OK) return rc;

--- a/src/doltlite_blame.c
+++ b/src/doltlite_blame.c
@@ -354,35 +354,6 @@ static int blameRowValueEqual(const u8 *pA, int nA, const u8 *pB, int nB){
   return memcmp(pA, pB, nA)==0;
 }
 
-static int blameLoadTableRoot(
-  sqlite3 *db,
-  const ProllyHash *pCatHash,
-  const char *zTableName,
-  ProllyHash *pOutRoot,
-  u8 *pOutFlags
-){
-  struct TableEntry *aTables = 0;
-  int nTables = 0, rc;
-  struct TableEntry *pEntry;
-
-  memset(pOutRoot, 0, sizeof(*pOutRoot));
-  *pOutFlags = 0;
-
-  if( prollyHashIsEmpty(pCatHash) ) return SQLITE_NOTFOUND;
-  rc = doltliteLoadCatalog(db, pCatHash, &aTables, &nTables, 0);
-  if( rc!=SQLITE_OK ) return rc;
-
-  pEntry = doltliteFindTableByName(aTables, nTables, zTableName);
-  if( !pEntry ){
-    doltliteFreeCatalog(aTables, nTables);
-    return SQLITE_NOTFOUND;
-  }
-  memcpy(pOutRoot, &pEntry->root, sizeof(ProllyHash));
-  *pOutFlags = pEntry->flags;
-  doltliteFreeCatalog(aTables, nTables);
-  return SQLITE_OK;
-}
-
 static int blameAssign(
   BlameRow *pRow,
   const ProllyHash *pCommitHash,
@@ -424,7 +395,8 @@ static int blameCompareAgainstRef(
   int i;
 
   if( pRefCatHash && !prollyHashIsEmpty(pRefCatHash) ){
-    rc = blameLoadTableRoot(db, pRefCatHash, zTableName, &refRoot, &refFlags);
+    rc = doltliteLoadTableRootByName(db, pRefCatHash, zTableName,
+                                     &refRoot, &refFlags, 0);
     if( rc==SQLITE_OK ) haveRef = 1;
     else if( rc!=SQLITE_NOTFOUND ) return rc;
   }
@@ -541,8 +513,8 @@ static int blameWalk(
     rc = doltliteLoadCommit(db, &walk, &commit);
     if( rc!=SQLITE_OK ) return rc;
 
-    rc = blameLoadTableRoot(db, &commit.catalogHash, zTableName,
-                            &curTableRoot, &curFlags);
+    rc = doltliteLoadTableRootByName(db, &commit.catalogHash, zTableName,
+                                     &curTableRoot, &curFlags, 0);
     if( rc==SQLITE_OK ) haveCurTable = 1;
     else if( rc!=SQLITE_NOTFOUND ){
       doltliteCommitClear(&commit);
@@ -845,8 +817,8 @@ static int bmFilter(sqlite3_vtab_cursor *pCursor,
   rc = doltliteLoadCommit(db, &headHash, &headCommit);
   if( rc!=SQLITE_OK ) return rc;
 
-  rc = blameLoadTableRoot(db, &headCommit.catalogHash, v->zTableName,
-                          &tableRoot, &tableFlags);
+  rc = doltliteLoadTableRootByName(db, &headCommit.catalogHash, v->zTableName,
+                                   &tableRoot, &tableFlags, 0);
   doltliteCommitClear(&headCommit);
   if( rc==SQLITE_NOTFOUND ) return SQLITE_OK;
   if( rc!=SQLITE_OK ) return rc;

--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -301,31 +301,6 @@ static int stackPushUnique(ProllyHashSet *pSeen,
   return SQLITE_OK;
 }
 
-static int loadTblRootAtCommit(sqlite3 *db, const ProllyHash *pCatHash,
-                               const char *zTableName,
-                               ProllyHash *pTblRoot, u8 *pFlags,
-                               ProllyHash *pSchemaHash){
-  struct TableEntry *aTables = 0;
-  int nTables = 0;
-  int rc;
-  struct TableEntry *pEntry;
-  memset(pTblRoot, 0, sizeof(*pTblRoot));
-  *pFlags = 0;
-  if( pSchemaHash ) memset(pSchemaHash, 0, sizeof(*pSchemaHash));
-  rc = doltliteLoadCatalog(db, pCatHash, &aTables, &nTables, 0);
-  if( rc!=SQLITE_OK ) return rc;
-  pEntry = doltliteFindTableByName(aTables, nTables, zTableName);
-  if( pEntry ){
-    memcpy(pTblRoot, &pEntry->root, sizeof(ProllyHash));
-    *pFlags = pEntry->flags;
-    if( pSchemaHash ){
-      memcpy(pSchemaHash, &pEntry->schemaHash, sizeof(ProllyHash));
-    }
-  }
-  doltliteFreeCatalog(aTables, nTables);
-  return SQLITE_OK;
-}
-
 static int seedWorkingChildInfo(
   sqlite3 *db,
   const ProllyHash *pHeadHash,
@@ -347,8 +322,9 @@ static int seedWorkingChildInfo(
 
   rc = doltliteFlushCatalogToHash(db, &workingCat);
   if( rc!=SQLITE_OK ) return rc;
-  rc = loadTblRootAtCommit(db, &workingCat, zTableName, &workingTblRoot,
-                           &workingFlags, &workingSchemaHash);
+  rc = doltliteLoadTableRootByNameOrEmpty(db, &workingCat, zTableName,
+                                          &workingTblRoot, &workingFlags,
+                                          &workingSchemaHash);
   if( rc!=SQLITE_OK ) return rc;
   return cmMapPut(pMap, pHeadHash, &workingTblRoot, &workingCat,
                   &workingSchemaHash, workingFlags, zWorking, 0);
@@ -459,8 +435,9 @@ static int buildDiffPairs(DiffTblCursor *pCur, sqlite3 *db,
     rc = doltliteLoadCommit(db, &curr, &commit);
     if( rc!=SQLITE_OK ) break;
 
-    rc = loadTblRootAtCommit(db, &commit.catalogHash, zTableName,
-                             &curTblRoot, &curFlags, &curSchemaHash);
+    rc = doltliteLoadTableRootByNameOrEmpty(db, &commit.catalogHash,
+                                            zTableName, &curTblRoot,
+                                            &curFlags, &curSchemaHash);
     if( rc!=SQLITE_OK ){
       doltliteCommitClear(&commit);
       break;
@@ -532,8 +509,9 @@ static int buildWorkingDiffPair(
 
   rc = doltliteLoadCommit(db, &headHash, &headCommit);
   if( rc!=SQLITE_OK ) return rc;
-  rc = loadTblRootAtCommit(db, &headCommit.catalogHash, zTableName,
-                           &headTblRoot, &headFlags, &headSchemaHash);
+  rc = doltliteLoadTableRootByNameOrEmpty(db, &headCommit.catalogHash,
+                                          zTableName, &headTblRoot,
+                                          &headFlags, &headSchemaHash);
   if( rc==SQLITE_OK ){
     int rootsDiffer = prollyHashCompare(&headTblRoot, &workingTblRoot)!=0;
     int schemasDiffer = prollyHashCompare(&headSchemaHash, &workingSchemaHash)!=0;
@@ -599,8 +577,8 @@ static int buildSliceDiffPair(
   fromDate = fromCommit.timestamp;
   doltliteCommitClear(&fromCommit);
 
-  rc = loadTblRootAtCommit(db, &fromCatHash, zTableName,
-                           &fromTblRoot, &fromFlags, &fromSchemaHash);
+  rc = doltliteLoadTableRootByName(db, &fromCatHash, zTableName,
+                                   &fromTblRoot, &fromFlags, &fromSchemaHash);
   if( rc!=SQLITE_OK && rc!=SQLITE_NOTFOUND ) return rc;
 
   if( sqlite3_stricmp(zToRef, "WORKING")==0 ){
@@ -624,8 +602,8 @@ static int buildSliceDiffPair(
     memcpy(&toCatHash, &toCommit.catalogHash, sizeof(ProllyHash));
     toDate = toCommit.timestamp;
     doltliteCommitClear(&toCommit);
-    rc = loadTblRootAtCommit(db, &toCatHash, zTableName,
-                             &toTblRoot, &toFlags, &toSchemaHash);
+    rc = doltliteLoadTableRootByName(db, &toCatHash, zTableName,
+                                     &toTblRoot, &toFlags, &toSchemaHash);
     if( rc!=SQLITE_OK && rc!=SQLITE_NOTFOUND ) return rc;
     doltliteHashToHex(&toHash, zToLabel);
   }

--- a/src/doltlite_history.c
+++ b/src/doltlite_history.c
@@ -141,7 +141,7 @@ static int htOpenTableAtCommit(HistCursor *c, sqlite3 *db,
   doltliteCommitClear(&commit);
   if( rc!=SQLITE_OK ) return rc;
 
-  if( doltliteFindTableRootByName(aT, nT, zTableName, &tableRoot, &flags)
+  if( doltliteFindTableRootByName(aT, nT, zTableName, &tableRoot, &flags, 0)
       !=SQLITE_OK || prollyHashIsEmpty(&tableRoot) ){
     doltliteFreeCatalog(aT, nT);
     return SQLITE_OK;

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -294,19 +294,64 @@ static SQLITE_INLINE int doltliteDupBytes(const u8 *pIn, int nIn, u8 **ppOut){
   return SQLITE_OK;
 }
 
+int doltliteLoadCatalog(sqlite3 *db, const ProllyHash *catHash,
+                        struct TableEntry **ppTables, int *pnTables,
+                        Pgno *piNextTable);
+void doltliteFreeCatalog(struct TableEntry *a, int n);
+
 static SQLITE_INLINE int doltliteFindTableRootByName(
   struct TableEntry *a, int n, const char *zName,
-  ProllyHash *pRoot, u8 *pFlags
+  ProllyHash *pRoot, u8 *pFlags, ProllyHash *pSchemaHash
 ){
   struct TableEntry *e = doltliteFindTableByName(a, n, zName);
   if( e ){
     memcpy(pRoot, &e->root, sizeof(ProllyHash));
     if( pFlags ) *pFlags = e->flags;
+    if( pSchemaHash ) memcpy(pSchemaHash, &e->schemaHash, sizeof(ProllyHash));
     return SQLITE_OK;
   }
   memset(pRoot, 0, sizeof(ProllyHash));
   if( pFlags ) *pFlags = 0;
+  if( pSchemaHash ) memset(pSchemaHash, 0, sizeof(ProllyHash));
   return SQLITE_NOTFOUND;
+}
+
+static SQLITE_INLINE int doltliteLoadTableRootByName(
+  sqlite3 *db,
+  const ProllyHash *pCatHash,
+  const char *zTableName,
+  ProllyHash *pRoot,
+  u8 *pFlags,
+  ProllyHash *pSchemaHash
+){
+  struct TableEntry *aTables = 0;
+  int nTables = 0;
+  int rc;
+
+  memset(pRoot, 0, sizeof(*pRoot));
+  if( pFlags ) *pFlags = 0;
+  if( pSchemaHash ) memset(pSchemaHash, 0, sizeof(*pSchemaHash));
+  if( !pCatHash || prollyHashIsEmpty(pCatHash) ) return SQLITE_NOTFOUND;
+
+  rc = doltliteLoadCatalog(db, pCatHash, &aTables, &nTables, 0);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = doltliteFindTableRootByName(aTables, nTables, zTableName,
+                                   pRoot, pFlags, pSchemaHash);
+  doltliteFreeCatalog(aTables, nTables);
+  return rc;
+}
+
+static SQLITE_INLINE int doltliteLoadTableRootByNameOrEmpty(
+  sqlite3 *db,
+  const ProllyHash *pCatHash,
+  const char *zTableName,
+  ProllyHash *pRoot,
+  u8 *pFlags,
+  ProllyHash *pSchemaHash
+){
+  int rc = doltliteLoadTableRootByName(db, pCatHash, zTableName,
+                                       pRoot, pFlags, pSchemaHash);
+  return rc==SQLITE_NOTFOUND ? SQLITE_OK : rc;
 }
 
 /* Sticky little-endian cursor for conflicts and constraint-violation codecs. */
@@ -409,10 +454,6 @@ BtShared *doltliteGetBtShared(sqlite3 *db);
 int doltliteIsStockSqliteDb(sqlite3 *db);
 void doltliteInvalidateWorkingState(sqlite3 *db);
 ProllyCache *doltliteGetCache(sqlite3 *db);
-int doltliteLoadCatalog(sqlite3 *db, const ProllyHash *catHash,
-                        struct TableEntry **ppTables, int *pnTables,
-                        Pgno *piNextTable);
-void doltliteFreeCatalog(struct TableEntry *a, int n);
 int doltliteSerializeCatalogEntries(sqlite3 *db, struct TableEntry *aTables,
                                     int nTables, u8 **ppOut, int *pnOut);
 int doltliteSerializeCatalogEntriesWithFallbackSchema(

--- a/src/doltlite_workspace.c
+++ b/src/doltlite_workspace.c
@@ -85,34 +85,6 @@ static char *wsBuildSchema(const DoltliteColInfo *ci){
   return z;
 }
 
-static int wsLoadTableRoot(
-  sqlite3 *db,
-  const ProllyHash *pCatHash,
-  const char *zTableName,
-  ProllyHash *pRoot,
-  u8 *pFlags,
-  ProllyHash *pSchemaHash
-){
-  struct TableEntry *aTables = 0;
-  int nTables = 0;
-  struct TableEntry *pEntry;
-  int rc;
-
-  memset(pRoot, 0, sizeof(*pRoot));
-  if( pFlags ) *pFlags = 0;
-  if( pSchemaHash ) memset(pSchemaHash, 0, sizeof(*pSchemaHash));
-  rc = doltliteLoadCatalog(db, pCatHash, &aTables, &nTables, 0);
-  if( rc!=SQLITE_OK ) return rc;
-  pEntry = doltliteFindTableByName(aTables, nTables, zTableName);
-  if( pEntry ){
-    memcpy(pRoot, &pEntry->root, sizeof(*pRoot));
-    if( pFlags ) *pFlags = pEntry->flags;
-    if( pSchemaHash ) memcpy(pSchemaHash, &pEntry->schemaHash, sizeof(*pSchemaHash));
-  }
-  doltliteFreeCatalog(aTables, nTables);
-  return SQLITE_OK;
-}
-
 static int wsAppendRow(
   WorkspaceVtab *pVtab,
   int staged,
@@ -206,14 +178,14 @@ static int wsLoadRows(WorkspaceVtab *pVtab){
   rc = doltliteFlushCatalogToHash(db, &workingCat);
   if( rc!=SQLITE_OK ) return rc;
 
-  rc = wsLoadTableRoot(db, &headCat, pVtab->zTableName,
-                       &headRoot, &headFlags, &schemaHash);
+  rc = doltliteLoadTableRootByNameOrEmpty(db, &headCat, pVtab->zTableName,
+                                          &headRoot, &headFlags, &schemaHash);
   if( rc!=SQLITE_OK ) return rc;
-  rc = wsLoadTableRoot(db, &stagedCat, pVtab->zTableName,
-                       &stagedRoot, &stagedFlags, &schemaHash);
+  rc = doltliteLoadTableRootByNameOrEmpty(db, &stagedCat, pVtab->zTableName,
+                                          &stagedRoot, &stagedFlags, &schemaHash);
   if( rc!=SQLITE_OK ) return rc;
-  rc = wsLoadTableRoot(db, &workingCat, pVtab->zTableName,
-                       &workingRoot, &workingFlags, &schemaHash);
+  rc = doltliteLoadTableRootByNameOrEmpty(db, &workingCat, pVtab->zTableName,
+                                          &workingRoot, &workingFlags, &schemaHash);
   if( rc!=SQLITE_OK ) return rc;
 
   if( !stagedFlags ) stagedFlags = headFlags ? headFlags : workingFlags;


### PR DESCRIPTION
## Summary
- Add shared helpers for loading user table roots, flags, and schema hashes from catalog hashes
- Replace duplicate table-root lookup code in workspace, diff table, and blame paths
- Update existing catalog-array lookup callers for optional schema-hash output

## Tests
- `git diff --check`
- `make -B doltlite_workspace.o doltlite_diff_table.o doltlite_blame.o doltlite_history.o doltlite_at.o` from `build/`

Note: the targeted build still reports the existing unused `wsPatchCatalogRoot` warning in `src/doltlite_workspace.c`.