### PR TITLE
Share prefixed diff column schema generation

### DIFF
--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -12,41 +12,24 @@
 #include <time.h>
 
 static char *buildDiffSchema(const DoltliteColInfo *ci){
-  int i;
   sqlite3_str *pStr = sqlite3_str_new(0);
   char *z;
-  char *zColName;
   if( !pStr ) return 0;
 
   sqlite3_str_appendall(pStr, "CREATE TABLE x(");
-  for(i=0; i<ci->nCol; i++){
-    if( i>0 ) sqlite3_str_appendall(pStr, ", ");
-    zColName = sqlite3_mprintf("to_%s", ci->azName[i] ? ci->azName[i] : "");
-    if( !zColName ){
-      sqlite3_str_reset(pStr);
-      return 0;
-    }
-    if( doltliteAppendQuotedIdent(pStr, zColName)!=SQLITE_OK ){
-      sqlite3_free(zColName);
-      sqlite3_str_reset(pStr);
-      return 0;
-    }
-    sqlite3_free(zColName);
+  if( doltliteAppendQuotedColumnList(pStr, ci->azName, ci->nCol,
+                                     "to_", ", ")!=SQLITE_OK ){
+    sqlite3_str_reset(pStr);
+    return 0;
   }
   sqlite3_str_appendall(pStr, ", to_commit TEXT, to_commit_date TEXT");
-  for(i=0; i<ci->nCol; i++){
+  if( ci->nCol>0 ){
     sqlite3_str_appendall(pStr, ", ");
-    zColName = sqlite3_mprintf("from_%s", ci->azName[i] ? ci->azName[i] : "");
-    if( !zColName ){
+    if( doltliteAppendQuotedColumnList(pStr, ci->azName, ci->nCol,
+                                       "from_", ", ")!=SQLITE_OK ){
       sqlite3_str_reset(pStr);
       return 0;
     }
-    if( doltliteAppendQuotedIdent(pStr, zColName)!=SQLITE_OK ){
-      sqlite3_free(zColName);
-      sqlite3_str_reset(pStr);
-      return 0;
-    }
-    sqlite3_free(zColName);
   }
   sqlite3_str_appendall(pStr, ", from_commit TEXT, from_commit_date TEXT"
                               ", diff_type TEXT"

--- a/src/doltlite_workspace.c
+++ b/src/doltlite_workspace.c
@@ -55,30 +55,23 @@ static void wsClearCache(WorkspaceVtab *p){
 static char *wsBuildSchema(const DoltliteColInfo *ci){
   sqlite3_str *pStr = sqlite3_str_new(0);
   char *z;
-  int i;
   if( !pStr ) return 0;
   sqlite3_str_appendall(pStr, "CREATE TABLE x(id INTEGER, staged INTEGER, diff_type TEXT");
-  for(i=0; i<ci->nCol; i++){
-    char *z = sqlite3_mprintf("to_%s", ci->azName[i] ? ci->azName[i] : "");
-    if( !z ){ sqlite3_str_reset(pStr); return 0; }
+  if( ci->nCol>0 ){
     sqlite3_str_appendall(pStr, ", ");
-    if( doltliteAppendQuotedIdent(pStr, z)!=SQLITE_OK ){
-      sqlite3_free(z);
+    if( doltliteAppendQuotedColumnList(pStr, ci->azName, ci->nCol,
+                                       "to_", ", ")!=SQLITE_OK ){
       sqlite3_str_reset(pStr);
       return 0;
     }
-    sqlite3_free(z);
   }
-  for(i=0; i<ci->nCol; i++){
-    char *z = sqlite3_mprintf("from_%s", ci->azName[i] ? ci->azName[i] : "");
-    if( !z ){ sqlite3_str_reset(pStr); return 0; }
+  if( ci->nCol>0 ){
     sqlite3_str_appendall(pStr, ", ");
-    if( doltliteAppendQuotedIdent(pStr, z)!=SQLITE_OK ){
-      sqlite3_free(z);
+    if( doltliteAppendQuotedColumnList(pStr, ci->azName, ci->nCol,
+                                       "from_", ", ")!=SQLITE_OK ){
       sqlite3_str_reset(pStr);
       return 0;
     }
-    sqlite3_free(z);
   }
   sqlite3_str_appendall(pStr, ")");
   z = sqlite3_str_finish(pStr);


### PR DESCRIPTION
## Summary
- Reuse the existing quoted column-list helper for `to_` and `from_` virtual table schema columns
- Remove duplicate schema-column construction loops from workspace and diff table vtabs

## Tests
- `git diff --check`
- `make -B doltlite_workspace.o doltlite_diff_table.o` from `build/`

Note: the targeted build still reports the existing unused `wsPatchCatalogRoot` warning in `src/doltlite_workspace.c`.