### PR TITLE
Share diff type name helpers

### DIFF
--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -400,9 +400,7 @@ static const char *cfrDiffType(const u8 *pBase, int nBase,
                                const u8 *pSide, int nSide){
   int baseHas = (pBase && nBase>0);
   int sideHas = (pSide && nSide>0);
-  if( !sideHas ) return "removed";
-  if( !baseHas ) return "added";
-  return "modified";
+  return doltliteDiffTypeNameFromPresence(baseHas, sideHas);
 }
 
 static sqlite3_int64 cfrConflictRowid(const struct ConflictRow *cr){

--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -964,11 +964,9 @@ static int dtColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
   }else if( nCols > 0 && col == 2*nCols+3 ){
     doltliteResultTimestamp(ctx, r->fromDate);
   }else if( nCols > 0 && col == 2*nCols+4 ){
-    switch( r->diffType ){
-      case PROLLY_DIFF_ADD:    sqlite3_result_text(ctx,"added",-1,SQLITE_STATIC); break;
-      case PROLLY_DIFF_DELETE: sqlite3_result_text(ctx,"removed",-1,SQLITE_STATIC); break;
-      case PROLLY_DIFF_MODIFY: sqlite3_result_text(ctx,"modified",-1,SQLITE_STATIC); break;
-    }
+    const char *zType = prollyDiffTypeName(r->diffType);
+    if( zType ) sqlite3_result_text(ctx, zType, -1, SQLITE_STATIC);
+    else sqlite3_result_null(ctx);
   }else{
     sqlite3_result_null(ctx);
   }

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -409,6 +409,15 @@ static SQLITE_INLINE void doltlitePkRangeFromArgs(
   }
 }
 
+static SQLITE_INLINE const char *doltliteDiffTypeNameFromPresence(
+  int baseHas,
+  int sideHas
+){
+  if( !sideHas ) return "removed";
+  if( !baseHas ) return "added";
+  return "modified";
+}
+
 static SQLITE_INLINE void doltliteResultTimestamp(sqlite3_context *ctx, i64 timestamp){
   time_t t = (time_t)timestamp;
   struct tm *tm = gmtime(&t);

--- a/src/doltlite_workspace.c
+++ b/src/doltlite_workspace.c
@@ -257,12 +257,9 @@ static int wsColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
   }else if( col==1 ){
     sqlite3_result_int(ctx, r->staged);
   }else if( col==2 ){
-    switch( r->diffType ){
-      case PROLLY_DIFF_ADD:    sqlite3_result_text(ctx,"added",-1,SQLITE_STATIC); break;
-      case PROLLY_DIFF_DELETE: sqlite3_result_text(ctx,"removed",-1,SQLITE_STATIC); break;
-      case PROLLY_DIFF_MODIFY: sqlite3_result_text(ctx,"modified",-1,SQLITE_STATIC); break;
-      default: sqlite3_result_null(ctx); break;
-    }
+    const char *zType = prollyDiffTypeName(r->diffType);
+    if( zType ) sqlite3_result_text(ctx, zType, -1, SQLITE_STATIC);
+    else sqlite3_result_null(ctx);
   }else if( col>=3 && col<3+nCols ){
     doltliteResultUserCol(ctx, &p->cols, r->pNewVal, r->nNewVal,
                           r->intKey, col-3);

--- a/src/prolly_diff.h
+++ b/src/prolly_diff.h
@@ -13,6 +13,15 @@
 #define PROLLY_DIFF_DELETE  2
 #define PROLLY_DIFF_MODIFY  3
 
+static SQLITE_INLINE const char *prollyDiffTypeName(u8 type){
+  switch( type ){
+    case PROLLY_DIFF_ADD:    return "added";
+    case PROLLY_DIFF_DELETE: return "removed";
+    case PROLLY_DIFF_MODIFY: return "modified";
+  }
+  return 0;
+}
+
 typedef struct ProllyDiffChange ProllyDiffChange;
 
 struct ProllyDiffChange {


### PR DESCRIPTION
## Summary
- Add shared helpers for prolly diff type names and presence-based diff names
- Replace duplicate `added`/`removed`/`modified` mappings in workspace, diff table, and conflicts code

## Tests
- `git diff --check`
- `make -B doltlite_workspace.o doltlite_diff_table.o doltlite_conflicts.o` from `build/`

Note: the targeted build still reports the existing unused `wsPatchCatalogRoot` warning in `src/doltlite_workspace.c`.