### PR TITLE
Factor simple DoltLite vtab setup

### DIFF
--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -1272,7 +1272,7 @@ static int brConnect(sqlite3 *db, void *pAux, int argc,
     const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){
   BrVtab *p; int rc;
   (void)pAux; (void)argc; (void)argv; (void)pzErr;
-  rc = sqlite3_declare_vtab(db,
+  rc = doltliteVtabConnectSimple(db,
     "CREATE TABLE x("
       "name TEXT, "
       "hash TEXT, "
@@ -1283,12 +1283,11 @@ static int brConnect(sqlite3 *db, void *pAux, int argc,
       "remote TEXT, "
       "branch TEXT, "
       "dirty INTEGER"
-    ")");
+    ")",
+    sizeof(*p), ppVtab);
   if( rc!=SQLITE_OK ) return rc;
-  p = sqlite3_malloc(sizeof(*p));
-  if( !p ) return SQLITE_NOMEM;
-  memset(p, 0, sizeof(*p)); p->db = db;
-  *ppVtab = &p->base;
+  p = (BrVtab*)*ppVtab;
+  p->db = db;
   return SQLITE_OK;
 }
 static int brOpen(sqlite3_vtab *v, sqlite3_vtab_cursor **pp){

--- a/src/doltlite_commit_ancestors.c
+++ b/src/doltlite_commit_ancestors.c
@@ -47,31 +47,17 @@ static int caConnect(
   int rc;
   (void)pAux; (void)argc; (void)argv; (void)pzErr;
 
-  rc = sqlite3_declare_vtab(db, commitAncestorsSchema);
+  rc = doltliteVtabConnectSimple(db, commitAncestorsSchema,
+                                 sizeof(*pVtab), ppVtab);
   if( rc!=SQLITE_OK ) return rc;
-
-  pVtab = sqlite3_malloc(sizeof(*pVtab));
-  if( !pVtab ) return SQLITE_NOMEM;
-  memset(pVtab, 0, sizeof(*pVtab));
+  pVtab = (CommitAncestorsVtab*)*ppVtab;
   pVtab->db = db;
-
-  *ppVtab = &pVtab->base;
-  return SQLITE_OK;
-}
-
-static int caDisconnect(sqlite3_vtab *pVtab){
-  sqlite3_free(pVtab);
   return SQLITE_OK;
 }
 
 static int caOpen(sqlite3_vtab *pVtab, sqlite3_vtab_cursor **ppCursor){
-  CommitAncestorsCursor *pCur;
   (void)pVtab;
-  pCur = sqlite3_malloc(sizeof(*pCur));
-  if( !pCur ) return SQLITE_NOMEM;
-  memset(pCur, 0, sizeof(*pCur));
-  *ppCursor = &pCur->base;
-  return SQLITE_OK;
+  return doltliteVtabOpenCursor(ppCursor, sizeof(CommitAncestorsCursor));
 }
 
 static void caCursorReset(CommitAncestorsCursor *pCur){
@@ -270,7 +256,7 @@ static int caBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
 
 static sqlite3_module commitAncestorsModule = {
   0, 0,
-  caConnect, caBestIndex, caDisconnect, 0,
+  caConnect, caBestIndex, doltliteVtabDisconnect, 0,
   caOpen, caClose, caFilter, caNext,
   caEof, caColumn, caRowid,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0

--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -238,10 +238,13 @@ static int cfConnect(sqlite3 *db, void *pAux, int argc,
   ConflictsVtab *v; int rc;
   (void)pAux;(void)argc;(void)argv;(void)pzErr;
 
-  rc = sqlite3_declare_vtab(db, "CREATE TABLE x(\"table\" TEXT, num_conflicts INTEGER)");
+  rc = doltliteVtabConnectSimple(db,
+      "CREATE TABLE x(\"table\" TEXT, num_conflicts INTEGER)",
+      sizeof(*v), ppVtab);
   if(rc!=SQLITE_OK) return rc;
-  v = sqlite3_malloc(sizeof(*v)); if(!v) return SQLITE_NOMEM;
-  memset(v,0,sizeof(*v)); v->db=db; *ppVtab=&v->base; return SQLITE_OK;
+  v = (ConflictsVtab*)*ppVtab;
+  v->db = db;
+  return SQLITE_OK;
 }
 static int cfOpen(sqlite3_vtab *v, sqlite3_vtab_cursor **pp){
   (void)v;

--- a/src/doltlite_constraint_violations.c
+++ b/src/doltlite_constraint_violations.c
@@ -382,14 +382,12 @@ static int cvsConnect(sqlite3 *db, void *pAux, int argc,
   CvSumVtab *v;
   int rc;
   (void)pAux;(void)argc;(void)argv;(void)pzErr;
-  rc = sqlite3_declare_vtab(db,
-      "CREATE TABLE x(\"table\" TEXT, num_violations INTEGER)");
+  rc = doltliteVtabConnectSimple(db,
+      "CREATE TABLE x(\"table\" TEXT, num_violations INTEGER)",
+      sizeof(*v), ppVtab);
   if( rc!=SQLITE_OK ) return rc;
-  v = sqlite3_malloc(sizeof(*v));
-  if( !v ) return SQLITE_NOMEM;
-  memset(v, 0, sizeof(*v));
+  v = (CvSumVtab*)*ppVtab;
   v->db = db;
-  *ppVtab = &v->base;
   return SQLITE_OK;
 }
 static int cvsOpen(sqlite3_vtab *v, sqlite3_vtab_cursor **pp){

--- a/src/doltlite_dbpage.c
+++ b/src/doltlite_dbpage.c
@@ -108,18 +108,10 @@ static int dlDbpageConnect(sqlite3 *db, void *pAux, int argc,
   DbpageVtab *pVtab;
   int rc;
   (void)pAux; (void)argc; (void)argv; (void)pzErr;
-  rc = sqlite3_declare_vtab(db, zDbpageSchema);
+  rc = doltliteVtabConnectSimple(db, zDbpageSchema, sizeof(*pVtab), ppVtab);
   if( rc!=SQLITE_OK ) return rc;
-  pVtab = sqlite3_malloc(sizeof(*pVtab));
-  if( !pVtab ) return SQLITE_NOMEM;
-  memset(pVtab, 0, sizeof(*pVtab));
+  pVtab = (DbpageVtab*)*ppVtab;
   pVtab->db = db;
-  *ppVtab = &pVtab->base;
-  return SQLITE_OK;
-}
-
-static int dlDbpageDisconnect(sqlite3_vtab *pVtab){
-  sqlite3_free(pVtab);
   return SQLITE_OK;
 }
 
@@ -156,18 +148,8 @@ static int dlDbpageBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
 }
 
 static int dlDbpageOpen(sqlite3_vtab *pVtab, sqlite3_vtab_cursor **ppCursor){
-  DlDbpageCursor *pCur;
   (void)pVtab;
-  pCur = sqlite3_malloc(sizeof(*pCur));
-  if( !pCur ) return SQLITE_NOMEM;
-  memset(pCur, 0, sizeof(*pCur));
-  *ppCursor = &pCur->base;
-  return SQLITE_OK;
-}
-
-static int dlDbpageClose(sqlite3_vtab_cursor *pCursor){
-  sqlite3_free(pCursor);
-  return SQLITE_OK;
+  return doltliteVtabOpenCursor(ppCursor, sizeof(DlDbpageCursor));
 }
 
 static int dlDbpageFilter(sqlite3_vtab_cursor *pCursor,
@@ -237,8 +219,8 @@ static int dlDbpageRowid(sqlite3_vtab_cursor *pCursor, sqlite3_int64 *pRowid){
 }
 
 static sqlite3_module doltliteDbpageModule = {
-  0, 0, dlDbpageConnect, dlDbpageBestIndex, dlDbpageDisconnect, 0,
-  dlDbpageOpen, dlDbpageClose, dlDbpageFilter, dlDbpageNext, dlDbpageEof,
+  0, 0, dlDbpageConnect, dlDbpageBestIndex, doltliteVtabDisconnect, 0,
+  dlDbpageOpen, doltliteVtabClose, dlDbpageFilter, dlDbpageNext, dlDbpageEof,
   dlDbpageColumn, dlDbpageRowid,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 };

--- a/src/doltlite_diff.c
+++ b/src/doltlite_diff.c
@@ -486,13 +486,8 @@ static int diffBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
 }
 
 static int diffOpen(sqlite3_vtab *pVtab, sqlite3_vtab_cursor **ppCursor){
-  DoltliteDiffCursor *pCur;
   (void)pVtab;
-  pCur = sqlite3_malloc(sizeof(*pCur));
-  if( !pCur ) return SQLITE_NOMEM;
-  memset(pCur, 0, sizeof(*pCur));
-  *ppCursor = &pCur->base;
-  return SQLITE_OK;
+  return doltliteVtabOpenCursor(ppCursor, sizeof(DoltliteDiffCursor));
 }
 
 static int diffClose(sqlite3_vtab_cursor *pCursor){

--- a/src/doltlite_log.c
+++ b/src/doltlite_log.c
@@ -51,31 +51,17 @@ static int doltliteLogConnect(
   int rc;
   (void)pAux; (void)argc; (void)argv; (void)pzErr;
 
-  rc = sqlite3_declare_vtab(db, doltliteLogSchema);
+  rc = doltliteVtabConnectSimple(db, doltliteLogSchema,
+                                 sizeof(*pVtab), ppVtab);
   if( rc!=SQLITE_OK ) return rc;
-
-  pVtab = sqlite3_malloc(sizeof(*pVtab));
-  if( !pVtab ) return SQLITE_NOMEM;
-  memset(pVtab, 0, sizeof(*pVtab));
+  pVtab = (DoltliteLogVtab*)*ppVtab;
   pVtab->db = db;
-
-  *ppVtab = &pVtab->base;
-  return SQLITE_OK;
-}
-
-static int doltliteLogDisconnect(sqlite3_vtab *pVtab){
-  sqlite3_free(pVtab);
   return SQLITE_OK;
 }
 
 static int doltliteLogOpen(sqlite3_vtab *pVtab, sqlite3_vtab_cursor **ppCursor){
-  DoltliteLogCursor *pCur;
   (void)pVtab;
-  pCur = sqlite3_malloc(sizeof(*pCur));
-  if( !pCur ) return SQLITE_NOMEM;
-  memset(pCur, 0, sizeof(*pCur));
-  *ppCursor = &pCur->base;
-  return SQLITE_OK;
+  return doltliteVtabOpenCursor(ppCursor, sizeof(DoltliteLogCursor));
 }
 
 static void logCursorReset(DoltliteLogCursor *pCur){
@@ -290,7 +276,7 @@ static int doltliteLogBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
 
 static sqlite3_module doltliteLogModule = {
   0, 0,
-  doltliteLogConnect, doltliteLogBestIndex, doltliteLogDisconnect, 0,
+  doltliteLogConnect, doltliteLogBestIndex, doltliteVtabDisconnect, 0,
   doltliteLogOpen, doltliteLogClose, doltliteLogFilter, doltliteLogNext,
   doltliteLogEof, doltliteLogColumn, doltliteLogRowid,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -721,18 +721,17 @@ static int remConnect(sqlite3 *db, void *pAux, int argc,
     const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){
   RemVtab *p; int rc;
   (void)pAux; (void)argc; (void)argv; (void)pzErr;
-  rc = sqlite3_declare_vtab(db,
+  rc = doltliteVtabConnectSimple(db,
     "CREATE TABLE x("
       "name TEXT, "
       "url TEXT, "
       "fetch_specs TEXT, "
       "params TEXT"
-    ")");
+    ")",
+    sizeof(*p), ppVtab);
   if( rc!=SQLITE_OK ) return rc;
-  p = sqlite3_malloc(sizeof(*p));
-  if( !p ) return SQLITE_NOMEM;
-  memset(p, 0, sizeof(*p)); p->db = db;
-  *ppVtab = &p->base;
+  p = (RemVtab*)*ppVtab;
+  p->db = db;
   return SQLITE_OK;
 }
 static int remOpen(sqlite3_vtab *v, sqlite3_vtab_cursor **pp){

--- a/src/doltlite_schemas.c
+++ b/src/doltlite_schemas.c
@@ -43,18 +43,10 @@ static int schemasConnect(sqlite3 *db, void *pAux, int argc,
   SchemasVtab *pVtab;
   int rc;
   (void)pAux; (void)argc; (void)argv; (void)pzErr;
-  rc = sqlite3_declare_vtab(db, zSchemasSchema);
+  rc = doltliteVtabConnectSimple(db, zSchemasSchema, sizeof(*pVtab), ppVtab);
   if( rc!=SQLITE_OK ) return rc;
-  pVtab = sqlite3_malloc(sizeof(*pVtab));
-  if( !pVtab ) return SQLITE_NOMEM;
-  memset(pVtab, 0, sizeof(*pVtab));
+  pVtab = (SchemasVtab*)*ppVtab;
   pVtab->db = db;
-  *ppVtab = &pVtab->base;
-  return SQLITE_OK;
-}
-
-static int schemasDisconnect(sqlite3_vtab *pVtab){
-  sqlite3_free(pVtab);
   return SQLITE_OK;
 }
 
@@ -66,13 +58,8 @@ static int schemasBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
 }
 
 static int schemasOpen(sqlite3_vtab *pVtab, sqlite3_vtab_cursor **ppCursor){
-  SchemasCursor *pCur;
   (void)pVtab;
-  pCur = sqlite3_malloc(sizeof(*pCur));
-  if( !pCur ) return SQLITE_NOMEM;
-  memset(pCur, 0, sizeof(*pCur));
-  *ppCursor = &pCur->base;
-  return SQLITE_OK;
+  return doltliteVtabOpenCursor(ppCursor, sizeof(SchemasCursor));
 }
 
 static void freeRows(SchemasCursor *pCur){
@@ -174,7 +161,7 @@ static int schemasRowid(sqlite3_vtab_cursor *pCursor, sqlite3_int64 *pRowid){
 }
 
 static sqlite3_module doltliteSchemasModule = {
-  0, 0, schemasConnect, schemasBestIndex, schemasDisconnect, 0,
+  0, 0, schemasConnect, schemasBestIndex, doltliteVtabDisconnect, 0,
   schemasOpen, schemasClose, schemasFilter, schemasNext, schemasEof,
   schemasColumn, schemasRowid,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0

--- a/src/doltlite_status.c
+++ b/src/doltlite_status.c
@@ -483,27 +483,15 @@ static int statusConnect(sqlite3 *db, void *pAux, int argc,
   (void)argc;
   (void)argv;
   (void)pzErr;
-  rc = sqlite3_declare_vtab(db, statusSchema);
+  rc = doltliteVtabConnectSimple(db, statusSchema, sizeof(*pVtab), ppVtab);
   if( rc != SQLITE_OK ) return rc;
-  pVtab = sqlite3_malloc(sizeof(*pVtab));
-  if( !pVtab ) return SQLITE_NOMEM;
-  memset(pVtab, 0, sizeof(*pVtab));
+  pVtab = (DoltliteStatusVtab*)*ppVtab;
   pVtab->db = db;
-  *ppVtab = &pVtab->base;
-  return SQLITE_OK;
-}
-static int statusDisconnect(sqlite3_vtab *pVtab){
-  sqlite3_free(pVtab);
   return SQLITE_OK;
 }
 static int statusOpen(sqlite3_vtab *pVtab, sqlite3_vtab_cursor **ppCursor){
-  DoltliteStatusCursor *pCur;
   (void)pVtab;
-  pCur = sqlite3_malloc(sizeof(*pCur));
-  if( !pCur ) return SQLITE_NOMEM;
-  memset(pCur, 0, sizeof(*pCur));
-  *ppCursor = &pCur->base;
-  return SQLITE_OK;
+  return doltliteVtabOpenCursor(ppCursor, sizeof(DoltliteStatusCursor));
 }
 static int statusClose(sqlite3_vtab_cursor *pCursor){
   DoltliteStatusCursor *pCur = (DoltliteStatusCursor*)pCursor;
@@ -613,7 +601,7 @@ static int statusBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
 }
 
 static sqlite3_module doltliteStatusModule = {
-  0,0,statusConnect,statusBestIndex,statusDisconnect,0,
+  0,0,statusConnect,statusBestIndex,doltliteVtabDisconnect,0,
   statusOpen,statusClose,statusFilter,statusNext,statusEof,
   statusColumn,statusRowid,
   0,0,0,0,0,0,0,0,0,0,0,0

--- a/src/doltlite_tag.c
+++ b/src/doltlite_tag.c
@@ -200,7 +200,7 @@ static int tagConnect(sqlite3 *db, void *pAux, int argc,
   (void)argc;
   (void)argv;
   (void)pzErr;
-  rc = sqlite3_declare_vtab(db,
+  rc = doltliteVtabConnectSimple(db,
     "CREATE TABLE x("
       "tag_name TEXT, "
       "tag_hash TEXT, "
@@ -208,31 +208,16 @@ static int tagConnect(sqlite3 *db, void *pAux, int argc,
       "email TEXT, "
       "date TEXT, "
       "message TEXT"
-    ")");
+    ")",
+    sizeof(*pVtab), ppVtab);
   if( rc != SQLITE_OK ) return rc;
-  pVtab = sqlite3_malloc(sizeof(*pVtab));
-  if( !pVtab ) return SQLITE_NOMEM;
-  memset(pVtab, 0, sizeof(*pVtab));
+  pVtab = (TagVtab*)*ppVtab;
   pVtab->db = db;
-  *ppVtab = &pVtab->base;
-  return SQLITE_OK;
-}
-static int tagDisconnect(sqlite3_vtab *pVtab){
-  sqlite3_free(pVtab);
   return SQLITE_OK;
 }
 static int tagOpen(sqlite3_vtab *pVtab, sqlite3_vtab_cursor **ppCursor){
-  TagCur *pCur;
   (void)pVtab;
-  pCur = sqlite3_malloc(sizeof(*pCur));
-  if( !pCur ) return SQLITE_NOMEM;
-  memset(pCur, 0, sizeof(*pCur));
-  *ppCursor = &pCur->base;
-  return SQLITE_OK;
-}
-static int tagClose(sqlite3_vtab_cursor *pCursor){
-  sqlite3_free(pCursor);
-  return SQLITE_OK;
+  return doltliteVtabOpenCursor(ppCursor, sizeof(TagCur));
 }
 static int tagFilter(sqlite3_vtab_cursor *pCursor, int idxNum,
     const char *idxStr, int argc, sqlite3_value **argv){
@@ -302,8 +287,8 @@ static int tagBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
 }
 
 static sqlite3_module tagModule = {
-  0,0,tagConnect,tagBestIndex,tagDisconnect,0,
-  tagOpen,tagClose,tagFilter,tagNext,tagEof,tagColumn,tagRowid,
+  0,0,tagConnect,tagBestIndex,doltliteVtabDisconnect,0,
+  tagOpen,doltliteVtabClose,tagFilter,tagNext,tagEof,tagColumn,tagRowid,
   0,0,0,0,0,0,0,0,0,0,0,0
 };
 


### PR DESCRIPTION
## Summary

This refactors repeated fixed-schema virtual table boilerplate to use existing DoltLite helper functions.

- Replace repeated `sqlite3_declare_vtab` + `sqlite3_malloc` + `memset` setup with `doltliteVtabConnectSimple`.
- Replace repeated zeroed cursor allocation with `doltliteVtabOpenCursor`.
- Reuse `doltliteVtabDisconnect` / `doltliteVtabClose` for vtabs and cursors that do not require custom cleanup.
- Leave custom close/disconnect paths intact where cursors or vtabs own extra allocated state.

## Testing

Passed:

```bash
make doltlite_tag.o doltlite_schemas.o doltlite_log.o doltlite_commit_ancestors.o doltlite_status.o doltlite_branch.o doltlite_remote_sql.o doltlite_dbpage.o doltlite_diff.o doltlite_conflicts.o doltlite_constraint_violations.o
```

`make devtest` did not pass. It failed in build/testfixture variants with existing-looking amalgamation/btree symbol errors and one environment/link issue:

```text
ld: library 'tommath' not found
```

The touched object files compile cleanly.
