### PR TITLE
Factor catalogHash extraction and seal-error prologue into shared helpers

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -638,6 +638,16 @@ int doltliteVcSealSavepointError(sqlite3 *db){
   return SQLITE_OK;
 }
 
+void doltliteVcResultError(sqlite3_context *ctx, sqlite3 *db, const char *zMsg){
+  (void)doltliteVcSealSavepointError(db);
+  sqlite3_result_error(ctx, zMsg, -1);
+}
+
+void doltliteVcResultErrorCode(sqlite3_context *ctx, sqlite3 *db, int rc){
+  (void)doltliteVcSealSavepointError(db);
+  sqlite3_result_error(ctx, sqlite3_errstr(rc), -1);
+}
+
 int doltliteVcSealBranchStyleTxn(sqlite3 *db){
   int rc;
   if( db->autoCommit ) return SQLITE_OK;

--- a/src/doltlite_at.c
+++ b/src/doltlite_at.c
@@ -93,8 +93,7 @@ static int atFilter(sqlite3_vtab_cursor *cur,
   ChunkStore *cs=doltliteGetChunkStore(db);
   void *pBt; ProllyCache *pCache;
   const char *zRef;
-  ProllyHash commitHash;
-  DoltliteCommit commit;
+  ProllyHash catHash;
   struct TableEntry *aTables=0; int nTables=0;
   ProllyHash tableRoot; u8 flags=0;
   int rc, res;
@@ -112,16 +111,12 @@ static int atFilter(sqlite3_vtab_cursor *cur,
   c->zCommitRef = sqlite3_mprintf("%s", zRef);
   if( !c->zCommitRef ) return SQLITE_NOMEM;
 
-  rc=doltliteResolveRef(db,zRef,&commitHash);
+  rc=doltliteRefToCatalogHash(db,zRef,&catHash);
   if(rc==SQLITE_NOTFOUND){
     sqlite3_free(cur->pVtab->zErrMsg);
     cur->pVtab->zErrMsg = sqlite3_mprintf("ref not found: %s", zRef);
     return SQLITE_ERROR;
   }
-  if(rc!=SQLITE_OK) return rc;
-
-  memset(&commit,0,sizeof(commit));
-  rc=doltliteLoadCommit(db,&commitHash,&commit);
   if(rc!=SQLITE_OK) return rc;
 
   {
@@ -131,13 +126,12 @@ static int atFilter(sqlite3_vtab_cursor *cur,
                     && !prollyHashIsEmpty(&branchCommit));
     if( isBranch ){
       doltliteResolveBranchEffectiveCatalog(cs, zRef, &branchCommit,
-                                            &commit.catalogHash, &effCatHash);
+                                            &catHash, &effCatHash);
     }else{
-      memcpy(&effCatHash, &commit.catalogHash, sizeof(ProllyHash));
+      memcpy(&effCatHash, &catHash, sizeof(ProllyHash));
     }
     rc=doltliteLoadCatalog(db,&effCatHash,&aTables,&nTables,0);
   }
-  doltliteCommitClear(&commit);
   if(rc!=SQLITE_OK) return rc;
 
   rc=doltliteFindTableRootByName(aTables,nTables,v->zTableName,&tableRoot,&flags,0);

--- a/src/doltlite_blame.c
+++ b/src/doltlite_blame.c
@@ -523,7 +523,6 @@ static int blameWalk(
 
     if( doltliteCommitParentCount(&commit) >= 2 ){
       ProllyHash baseHash;
-      DoltliteCommit baseCommit;
       memset(&baseHash, 0, sizeof(baseHash));
       rc = blameFindAllParentMergeBase(db, &commit, &baseHash);
       if( rc!=SQLITE_OK ){
@@ -532,14 +531,13 @@ static int blameWalk(
       }
 
       if( haveCurTable && !prollyHashIsEmpty(&baseHash) ){
-        memset(&baseCommit, 0, sizeof(baseCommit));
-        rc = doltliteLoadCommit(db, &baseHash, &baseCommit);
+        ProllyHash baseCatHash;
+        rc = doltliteCommitCatalogHash(db, &baseHash, &baseCatHash);
         if( rc==SQLITE_OK ){
           rc = blameCompareAgainstRef(db, pCur, zTableName,
                                       curFlags,
-                                      &baseCommit.catalogHash,
+                                      &baseCatHash,
                                       &walk, &commit);
-          doltliteCommitClear(&baseCommit);
         }
         if( rc!=SQLITE_OK ){
           doltliteCommitClear(&commit);
@@ -557,15 +555,13 @@ static int blameWalk(
     }else{
       const ProllyHash *pParent = doltliteCommitParentHash(&commit, 0);
       if( pParent && !prollyHashIsEmpty(pParent) ){
-        DoltliteCommit parentCommit;
-        memset(&parentCommit, 0, sizeof(parentCommit));
-        rc = doltliteLoadCommit(db, pParent, &parentCommit);
+        ProllyHash parentCatHash;
+        rc = doltliteCommitCatalogHash(db, pParent, &parentCatHash);
         if( rc==SQLITE_OK ){
           rc = blameCompareAgainstRef(db, pCur, zTableName,
                                       curFlags,
-                                      &parentCommit.catalogHash,
+                                      &parentCatHash,
                                       &walk, &commit);
-          doltliteCommitClear(&parentCommit);
         }
         if( rc!=SQLITE_OK ){
           doltliteCommitClear(&commit);
@@ -705,7 +701,7 @@ static int bmFilter(sqlite3_vtab_cursor *pCursor,
   ChunkStore *cs = doltliteGetChunkStore(db);
   ProllyCache *pCache = doltliteGetCache(db);
   ProllyHash headHash;
-  DoltliteCommit headCommit;
+  ProllyHash headCatHash;
   ProllyHash tableRoot;
   u8 tableFlags = 0;
   int rc;
@@ -725,13 +721,11 @@ static int bmFilter(sqlite3_vtab_cursor *pCursor,
   doltliteGetSessionHead(db, &headHash);
   if( prollyHashIsEmpty(&headHash) ) return SQLITE_OK;
 
-  memset(&headCommit, 0, sizeof(headCommit));
-  rc = doltliteLoadCommit(db, &headHash, &headCommit);
+  rc = doltliteCommitCatalogHash(db, &headHash, &headCatHash);
   if( rc!=SQLITE_OK ) return rc;
 
-  rc = doltliteLoadTableRootByName(db, &headCommit.catalogHash, v->zTableName,
+  rc = doltliteLoadTableRootByName(db, &headCatHash, v->zTableName,
                                    &tableRoot, &tableFlags, 0);
-  doltliteCommitClear(&headCommit);
   if( rc==SQLITE_NOTFOUND ) return SQLITE_OK;
   if( rc!=SQLITE_OK ) return rc;
 

--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -539,15 +539,8 @@ static int checkoutLoadAndApply(
   int rc;
   ProllyHash committedCatHash;
 
-  {
-    DoltliteCommit commit;
-
-    rc = doltliteLoadCommit(db, pCommitHash, &commit);
-    if( rc!=SQLITE_OK ) return rc;
-
-    memcpy(&committedCatHash, &commit.catalogHash, sizeof(ProllyHash));
-    doltliteCommitClear(&commit);
-  }
+  rc = doltliteCommitCatalogHash(db, pCommitHash, &committedCatHash);
+  if( rc!=SQLITE_OK ) return rc;
 
   doltliteResolveBranchEffectiveCatalog(cs, zBranch, pCommitHash,
                                         &committedCatHash, pCatHash);
@@ -860,14 +853,10 @@ static int doltliteCheckoutTables(
 
   if( zSourceRef ){
     ProllyHash sourceCommit;
-    DoltliteCommit sourceC;
-    memset(&sourceC, 0, sizeof(sourceC));
     rc = doltliteResolveRef(db, zSourceRef, &sourceCommit);
     if( rc!=SQLITE_OK ) return SQLITE_NOTFOUND;
-    rc = doltliteLoadCommit(db, &sourceCommit, &sourceC);
+    rc = doltliteCommitCatalogHash(db, &sourceCommit, &sourceCatHash);
     if( rc!=SQLITE_OK ) return rc;
-    memcpy(&sourceCatHash, &sourceC.catalogHash, sizeof(ProllyHash));
-    doltliteCommitClear(&sourceC);
   }else{
     doltliteGetSessionStaged(db, &stagedHash);
     if( !prollyHashIsEmpty(&stagedHash) ){
@@ -1339,15 +1328,9 @@ static int brIsDirty(
     return SQLITE_OK;
   }
 
-  {
-    DoltliteCommit c;
-    memset(&c, 0, sizeof(c));
-    rc = doltliteLoadCommit(db, &br->commitHash, &c);
-    if( rc==SQLITE_OK ){
-      memcpy(commitCat.data, c.catalogHash.data, PROLLY_HASH_SIZE);
-      *pDirty = prollyHashCompare(&stagedCat, &commitCat)!=0;
-    }
-    doltliteCommitClear(&c);
+  rc = doltliteCommitCatalogHash(db, &br->commitHash, &commitCat);
+  if( rc==SQLITE_OK ){
+    *pDirty = prollyHashCompare(&stagedCat, &commitCat)!=0;
   }
   return rc;
 }

--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -53,8 +53,8 @@ static void branchSealSavepointsOnError(sqlite3_context *ctx, int bHadSavepoint)
 }
 
 static void branchError(sqlite3_context *ctx, int bHadSavepoint, const char *zErr){
-  branchSealSavepointsOnError(ctx, bHadSavepoint);
-  sqlite3_result_error(ctx, zErr, -1);
+  (void)bHadSavepoint;
+  doltliteVcResultError(ctx, sqlite3_context_db_handle(ctx), zErr);
 }
 
 static void branchErrorCode(sqlite3_context *ctx, int bHadSavepoint, int rc){
@@ -1081,10 +1081,10 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
   int hadExplicitTxn = !db->autoCommit;
   int rc;
 
-  if( !cs ){ (void)doltliteVcSealSavepointError(db); sqlite3_result_error(ctx, doltliteVcUnavailableMessage(db), -1); return; }
-  if( argc<1 ){ (void)doltliteVcSealSavepointError(db); sqlite3_result_error(ctx, "branch name required", -1); return; }
+  if( !cs ){ doltliteVcResultError(ctx, db, doltliteVcUnavailableMessage(db)); return; }
+  if( argc<1 ){ doltliteVcResultError(ctx, db, "branch name required"); return; }
   zBranch = (const char*)sqlite3_value_text(argv[0]);
-  if( !zBranch ){ (void)doltliteVcSealSavepointError(db); sqlite3_result_error(ctx, "branch name required", -1); return; }
+  if( !zBranch ){ doltliteVcResultError(ctx, db, "branch name required"); return; }
 
   memset(&m, 0, sizeof(m));
   memset(&branchCreate, 0, sizeof(branchCreate));
@@ -1093,44 +1093,39 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
     u8 isMerging = 0;
     doltliteGetSessionMergeState(db, &isMerging, 0, 0);
     if( isMerging ){
-      (void)doltliteVcSealSavepointError(db);
-      sqlite3_result_error(ctx, "unresolved merge conflicts \xe2\x80\x94 commit or abort first", -1);
+      doltliteVcResultError(ctx, db, "unresolved merge conflicts \xe2\x80\x94 commit or abort first");
       return;
     }
   }
 
   if( strcmp(zBranch, "-b")==0 ){
-    if( argc<2 ){ (void)doltliteVcSealSavepointError(db); sqlite3_result_error(ctx, "branch name required after -b", -1); return; }
-    if( argc>3 ){ (void)doltliteVcSealSavepointError(db); sqlite3_result_error(ctx, "too many arguments", -1); return; }
+    if( argc<2 ){ doltliteVcResultError(ctx, db, "branch name required after -b"); return; }
+    if( argc>3 ){ doltliteVcResultError(ctx, db, "too many arguments"); return; }
     zBranch = (const char*)sqlite3_value_text(argv[1]);
-    if( branchNameEmpty(zBranch) ){ (void)doltliteVcSealSavepointError(db); sqlite3_result_error(ctx, "branch name required after -b", -1); return; }
+    if( branchNameEmpty(zBranch) ){ doltliteVcResultError(ctx, db, "branch name required after -b"); return; }
 
     if( argc>=3 ){
       const char *zStart = (const char*)sqlite3_value_text(argv[2]);
       if( !zStart ){
-        (void)doltliteVcSealSavepointError(db);
-        sqlite3_result_error(ctx, "start point not found", -1);
+        doltliteVcResultError(ctx, db, "start point not found");
         return;
       }
       rc = doltliteResolveRef(db, zStart, &branchCreate.head);
       if( rc!=SQLITE_OK ){
-        (void)doltliteVcSealSavepointError(db);
-        sqlite3_result_error(ctx, "start point not found", -1);
+        doltliteVcResultError(ctx, db, "start point not found");
         return;
       }
     }else{
       doltliteGetSessionHead(db, &branchCreate.head);
       if( prollyHashIsEmpty(&branchCreate.head) ){
-        (void)doltliteVcSealSavepointError(db);
-        sqlite3_result_error(ctx, "no commits yet — commit first", -1);
+        doltliteVcResultError(ctx, db, "no commits yet — commit first");
         return;
       }
     }
     branchCreate.zName = zBranch;
     rc = doltliteMutateRefs(db, mutateBranchRef, &branchCreate);
     if( rc!=SQLITE_OK ){
-      (void)doltliteVcSealSavepointError(db);
-      sqlite3_result_error(ctx, "branch already exists", -1);
+      doltliteVcResultError(ctx, db, "branch already exists");
       return;
     }
     isCreateAndSwitch = 1;
@@ -1151,8 +1146,7 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
     }
     if( rc==SQLITE_NOTFOUND ){
       char *zErr = sqlite3_mprintf("no such branch or table: %s", zBranch);
-      (void)doltliteVcSealSavepointError(db);
-      sqlite3_result_error(ctx, zErr ? zErr : "no such branch or table", -1);
+      doltliteVcResultError(ctx, db, zErr ? zErr : "no such branch or table");
       sqlite3_free(zErr);
       return;
     }
@@ -1182,8 +1176,7 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
   rc = checkoutCaptureOldCatalog(db, cs, &m.oldCatHash);
   if( rc!=SQLITE_OK ){
     sqlite3_free(zCurrentBranch);
-    (void)doltliteVcSealSavepointError(db);
-    sqlite3_result_error(ctx, "failed to snapshot current branch state", -1);
+    doltliteVcResultError(ctx, db, "failed to snapshot current branch state");
     return;
   }
   m.haveOldState = 1;
@@ -1207,8 +1200,7 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
     if( rc==SQLITE_NOTFOUND ){
       char *zErr = sqlite3_mprintf(
           "no such branch or table: %s", zBranch);
-      (void)doltliteVcSealSavepointError(db);
-      sqlite3_result_error(ctx, zErr ? zErr : "no such branch or table", -1);
+      doltliteVcResultError(ctx, db, zErr ? zErr : "no such branch or table");
       sqlite3_free(zErr);
       return;
     }
@@ -1228,18 +1220,15 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
     return;
   }
   if( rc==SQLITE_EMPTY ){
-    (void)doltliteVcSealSavepointError(db);
-    sqlite3_result_error(ctx, "target branch has no commits", -1);
+    doltliteVcResultError(ctx, db, "target branch has no commits");
     return;
   }
   if( rc==SQLITE_BUSY ){
-    (void)doltliteVcSealSavepointError(db);
-    sqlite3_result_error(ctx, "database is locked by another connection", -1);
+    doltliteVcResultError(ctx, db, "database is locked by another connection");
     return;
   }
   if( rc!=SQLITE_OK ){
-    (void)doltliteVcSealSavepointError(db);
-    sqlite3_result_error(ctx, "checkout failed", -1);
+    doltliteVcResultError(ctx, db, "checkout failed");
     return;
   }
   if( hadExplicitTxn ){

--- a/src/doltlite_commit.c
+++ b/src/doltlite_commit.c
@@ -2,6 +2,7 @@
 #ifdef DOLTLITE_PROLLY
 
 #include "doltlite_commit.h"
+#include "doltlite_internal.h"
 #include <string.h>
 
 #define DLC_PUT_U16(p,v) do{ (p)[0]=(u8)(v); (p)[1]=(u8)((v)>>8); }while(0)
@@ -136,6 +137,24 @@ void doltliteCommitClear(DoltliteCommit *c){
   c->zName = 0;
   c->zEmail = 0;
   c->zMessage = 0;
+}
+
+int doltliteCommitCatalogHash(sqlite3 *db, const ProllyHash *pCommit,
+                              ProllyHash *pCatHash){
+  DoltliteCommit commit;
+  int rc = doltliteLoadCommit(db, pCommit, &commit);
+  if( rc!=SQLITE_OK ) return rc;
+  memcpy(pCatHash, &commit.catalogHash, sizeof(ProllyHash));
+  doltliteCommitClear(&commit);
+  return SQLITE_OK;
+}
+
+int doltliteRefToCatalogHash(sqlite3 *db, const char *zRef,
+                             ProllyHash *pCatHash){
+  ProllyHash commitHash;
+  int rc = doltliteResolveRef(db, zRef, &commitHash);
+  if( rc!=SQLITE_OK ) return rc;
+  return doltliteCommitCatalogHash(db, &commitHash, pCatHash);
 }
 
 static const char hexchars[] = "0123456789abcdef";

--- a/src/doltlite_diff.c
+++ b/src/doltlite_diff.c
@@ -294,12 +294,10 @@ static int computeCommitBatch(DoltliteDiffCursor *pCur, sqlite3 *db,
   if( rc!=SQLITE_OK ) return rc;
 
   if( hasParent ){
-    DoltliteCommit parent;
-    memset(&parent, 0, sizeof(parent));
-    rc = doltliteLoadCommit(db, pParentHash, &parent);
+    ProllyHash parentCat;
+    rc = doltliteCommitCatalogHash(db, pParentHash, &parentCat);
     if( rc==SQLITE_OK ){
-      rc = doltliteLoadCatalog(db, &parent.catalogHash, &aParent, &nParent, 0);
-      doltliteCommitClear(&parent);
+      rc = doltliteLoadCatalog(db, &parentCat, &aParent, &nParent, 0);
     }
     if( rc!=SQLITE_OK ){
       doltliteFreeCatalog(aChild, nChild);

--- a/src/doltlite_diff_stat.c
+++ b/src/doltlite_diff_stat.c
@@ -237,18 +237,8 @@ struct DsSummaryRow {
 
 static int dsResolveCatHash(sqlite3 *db, const char *zRef,
                             ProllyHash *pOut){
-  DoltliteCommit commit;
-  ProllyHash commitHash;
-  int rc;
   if( zRef ){
-    rc = doltliteResolveRef(db, zRef, &commitHash);
-    if( rc!=SQLITE_OK ) return rc;
-    memset(&commit, 0, sizeof(commit));
-    rc = doltliteLoadCommit(db, &commitHash, &commit);
-    if( rc!=SQLITE_OK ) return rc;
-    memcpy(pOut, &commit.catalogHash, sizeof(ProllyHash));
-    doltliteCommitClear(&commit);
-    return SQLITE_OK;
+    return doltliteRefToCatalogHash(db, zRef, pOut);
   }
   return doltliteGetHeadCatalogHash(db, pOut);
 }

--- a/src/doltlite_hashof.c
+++ b/src/doltlite_hashof.c
@@ -545,7 +545,6 @@ static int hashofResolveRefCatalog(
 ){
   const char *zRef;
   ProllyHash commitHash;
-  DoltliteCommit commit;
   char zErr[64];
   int rc;
 
@@ -569,15 +568,12 @@ static int hashofResolveRefCatalog(
     sqlite3_result_error(ctx, zErr, -1);
     return 1;
   }
-  memset(&commit, 0, sizeof(commit));
-  rc = doltliteLoadCommit(db, &commitHash, &commit);
+  rc = doltliteCommitCatalogHash(db, &commitHash, pCatHash);
   if( rc!=SQLITE_OK ){
     sqlite3_snprintf(sizeof(zErr), zErr, "%s: commit load failed", zFn);
     sqlite3_result_error(ctx, zErr, -1);
     return 1;
   }
-  *pCatHash = commit.catalogHash;
-  doltliteCommitClear(&commit);
   return 0;
 }
 

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -741,6 +741,11 @@ typedef struct DoltliteCommit DoltliteCommit;
 int doltliteLoadCommit(sqlite3 *db, const ProllyHash *pHash,
                        DoltliteCommit *pCommit);
 
+int doltliteCommitCatalogHash(sqlite3 *db, const ProllyHash *pCommit,
+                              ProllyHash *pCatHash);
+int doltliteRefToCatalogHash(sqlite3 *db, const char *zRef,
+                             ProllyHash *pCatHash);
+
 int doltliteForEachUserTable(sqlite3 *db, const char *zPrefix,
                              const sqlite3_module *pModule);
 

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -821,6 +821,8 @@ int doltliteCheckoutBranchForRebase(sqlite3 *db, const char *zBranch);
 DoltliteVcTxnMode doltliteVcTxnMode(sqlite3 *db);
 int doltliteVcSealActiveSavepoints(sqlite3 *db);
 int doltliteVcSealSavepointError(sqlite3 *db);
+void doltliteVcResultError(sqlite3_context *ctx, sqlite3 *db, const char *zMsg);
+void doltliteVcResultErrorCode(sqlite3_context *ctx, sqlite3 *db, int rc);
 int doltliteVcSealBranchStyleTxn(sqlite3 *db);
 
 typedef int (*DoltliteRefsMutation)(sqlite3 *db, ChunkStore *cs, void *pArg);

--- a/src/doltlite_ref.c
+++ b/src/doltlite_ref.c
@@ -199,19 +199,17 @@ int doltliteForEachUserTable(
   const sqlite3_module *pModule
 ){
   ProllyHash headCommit;
-  DoltliteCommit commit;
+  ProllyHash headCat;
   struct TableEntry *aTables = 0;
   int nTables = 0, i, rc;
 
   doltliteGetSessionHead(db, &headCommit);
   if( prollyHashIsEmpty(&headCommit) ) return SQLITE_OK;
 
-  memset(&commit, 0, sizeof(commit));
-  rc = doltliteLoadCommit(db, &headCommit, &commit);
+  rc = doltliteCommitCatalogHash(db, &headCommit, &headCat);
   if( rc!=SQLITE_OK ) return rc;
 
-  rc = doltliteLoadCatalog(db, &commit.catalogHash, &aTables, &nTables, 0);
-  doltliteCommitClear(&commit);
+  rc = doltliteLoadCatalog(db, &headCat, &aTables, &nTables, 0);
   if( rc!=SQLITE_OK ) return rc;
 
   for(i=0; i<nTables; i++){

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -116,43 +116,27 @@ static int remoteSqlReportOpenError(
   return 1;
 }
 
-static int remoteSqlLoadCommit(
-  ChunkStore *cs,
-  const ProllyHash *pCommitHash,
-  DoltliteCommit *pCommit
-){
-  u8 *data = 0;
-  int nData = 0;
-  int rc = chunkStoreGet(cs, pCommitHash, &data, &nData);
-  if( rc!=SQLITE_OK ) return rc;
-  rc = doltliteCommitDeserialize(data, nData, pCommit);
-  sqlite3_free(data);
-  return rc;
-}
-
 static int remoteSqlResetSessionToCommit(
   sqlite3 *db,
   const char *zBranch,
   const ProllyHash *pCommitHash
 ){
   ChunkStore *cs = doltliteGetChunkStore(db);
-  DoltliteCommit commit;
+  ProllyHash catHash;
   int rc;
 
   if( !cs ) return SQLITE_ERROR;
-  memset(&commit, 0, sizeof(commit));
-  rc = remoteSqlLoadCommit(cs, pCommitHash, &commit);
+  rc = doltliteCommitCatalogHash(db, pCommitHash, &catHash);
   if( rc!=SQLITE_OK ) return rc;
 
   if( zBranch ){
     doltliteSetSessionBranch(db, zBranch);
   }
-  rc = doltliteHardReset(db, &commit.catalogHash);
+  rc = doltliteHardReset(db, &catHash);
   if( rc==SQLITE_OK ){
     doltliteSetSessionHead(db, pCommitHash);
-    doltliteSetSessionStaged(db, &commit.catalogHash);
+    doltliteSetSessionStaged(db, &catHash);
   }
-  doltliteCommitClear(&commit);
   return rc;
 }
 

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -149,13 +149,11 @@ static void doltRemoteFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
   int rc;
 
   if( !cs ){
-    (void)doltliteVcSealSavepointError(db);
-    sqlite3_result_error(ctx, "no database", -1);
+    doltliteVcResultError(ctx, db, "no database");
     return;
   }
   if( argc<2 ){
-    (void)doltliteVcSealSavepointError(db);
-    sqlite3_result_error(ctx, "usage: dolt_remote(action, name [, url])", -1);
+    doltliteVcResultError(ctx, db, "usage: dolt_remote(action, name [, url])");
     return;
   }
 
@@ -164,27 +162,23 @@ static void doltRemoteFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
   zAction = (const char*)sqlite3_value_text(argv[0]);
   zName = (const char*)sqlite3_value_text(argv[1]);
   if( !zAction || !zName ){
-    (void)doltliteVcSealSavepointError(db);
-    sqlite3_result_error(ctx, "action and name required", -1);
+    doltliteVcResultError(ctx, db, "action and name required");
     return;
   }
 
   if( strcmp(zAction, "add")==0 ){
     const char *zUrl;
     if( argc<3 ){
-      (void)doltliteVcSealSavepointError(db);
-      sqlite3_result_error(ctx, "url required for add", -1);
+      doltliteVcResultError(ctx, db, "url required for add");
       return;
     }
     if( argc>3 ){
-      (void)doltliteVcSealSavepointError(db);
-      sqlite3_result_error(ctx, "too many arguments", -1);
+      doltliteVcResultError(ctx, db, "too many arguments");
       return;
     }
     zUrl = (const char*)sqlite3_value_text(argv[2]);
     if( !zUrl ){
-      (void)doltliteVcSealSavepointError(db);
-      sqlite3_result_error(ctx, "url required for add", -1);
+      doltliteVcResultError(ctx, db, "url required for add");
       return;
     }
     m.zName = zName;
@@ -198,8 +192,7 @@ static void doltRemoteFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
     }
   }else if( strcmp(zAction, "remove")==0 ){
     if( argc>2 ){
-      (void)doltliteVcSealSavepointError(db);
-      sqlite3_result_error(ctx, "too many arguments", -1);
+      doltliteVcResultError(ctx, db, "too many arguments");
       return;
     }
     m.zName = zName;
@@ -212,8 +205,7 @@ static void doltRemoteFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv)
       return;
     }
   }else{
-    (void)doltliteVcSealSavepointError(db);
-    sqlite3_result_error(ctx, "unknown action: use 'add' or 'remove'", -1);
+    doltliteVcResultError(ctx, db, "unknown action: use 'add' or 'remove'");
     return;
   }
 
@@ -235,26 +227,23 @@ static void doltPushFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   int bForce = 0;
   int rc;
 
-  if( !cs ){ (void)doltliteVcSealSavepointError(db); sqlite3_result_error(ctx, "no database", -1); return; }
+  if( !cs ){ doltliteVcResultError(ctx, db, "no database"); return; }
   if( argc<2 ){
-    (void)doltliteVcSealSavepointError(db);
-    sqlite3_result_error(ctx, "usage: dolt_push(remote, branch [, '--force'])", -1);
+    doltliteVcResultError(ctx, db, "usage: dolt_push(remote, branch [, '--force'])");
     return;
   }
 
   zRemoteName = (const char*)sqlite3_value_text(argv[0]);
   zBranch = (const char*)sqlite3_value_text(argv[1]);
   if( !zRemoteName || !zBranch ){
-    (void)doltliteVcSealSavepointError(db);
-    sqlite3_result_error(ctx, "remote and branch required", -1);
+    doltliteVcResultError(ctx, db, "remote and branch required");
     return;
   }
 
   if( argc>=3 ){
     const char *zOpt = (const char*)sqlite3_value_text(argv[2]);
     if( argc>3 ){
-      (void)doltliteVcSealSavepointError(db);
-      sqlite3_result_error(ctx, "too many arguments", -1);
+      doltliteVcResultError(ctx, db, "too many arguments");
       return;
     }
     if( zOpt && strcmp(zOpt, "--force")==0 ){
@@ -262,8 +251,7 @@ static void doltPushFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     }else{
       char *zErr = sqlite3_mprintf("unknown option `%s`", zOpt ? zOpt : "");
       if( zErr ){
-        (void)doltliteVcSealSavepointError(db);
-        sqlite3_result_error(ctx, zErr, -1);
+        doltliteVcResultError(ctx, db, zErr);
         sqlite3_free(zErr);
       }else{
         sqlite3_result_error_nomem(ctx);
@@ -358,22 +346,19 @@ static void doltFetchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   const char *zRemoteName;
   int rc;
 
-  if( !cs ){ (void)doltliteVcSealSavepointError(db); sqlite3_result_error(ctx, "no database", -1); return; }
+  if( !cs ){ doltliteVcResultError(ctx, db, "no database"); return; }
   if( argc<1 ){
-    (void)doltliteVcSealSavepointError(db);
-    sqlite3_result_error(ctx, "usage: dolt_fetch(remote [, branch])", -1);
+    doltliteVcResultError(ctx, db, "usage: dolt_fetch(remote [, branch])");
     return;
   }
 
   zRemoteName = (const char*)sqlite3_value_text(argv[0]);
   if( !zRemoteName ){
-    (void)doltliteVcSealSavepointError(db);
-    sqlite3_result_error(ctx, "remote name required", -1);
+    doltliteVcResultError(ctx, db, "remote name required");
     return;
   }
   if( argc>2 ){
-    (void)doltliteVcSealSavepointError(db);
-    sqlite3_result_error(ctx, "too many arguments", -1);
+    doltliteVcResultError(ctx, db, "too many arguments");
     return;
   }
 
@@ -385,8 +370,7 @@ static void doltFetchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     const char *zBranch = (const char*)sqlite3_value_text(argv[1]);
     if( !zBranch ){
       pRemote->xClose(pRemote);
-      (void)doltliteVcSealSavepointError(db);
-      sqlite3_result_error(ctx, "branch name required", -1);
+      doltliteVcResultError(ctx, db, "branch name required");
       return;
     }
     rc = doltliteFetch(cs, pRemote, zRemoteName, zBranch);
@@ -406,8 +390,7 @@ static void doltFetchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     rc = parseRemoteBranchNames(pRemote, &azNames, &nNames);
     if( rc!=SQLITE_OK ){
       pRemote->xClose(pRemote);
-      (void)doltliteVcSealSavepointError(db);
-      sqlite3_result_error(ctx, "failed to read remote refs", -1);
+      doltliteVcResultError(ctx, db, "failed to read remote refs");
       return;
     }
 
@@ -418,8 +401,7 @@ static void doltFetchFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
       DoltliteRemote *pBrRemote = openRemoteByUrl(chunkFileGetVfs(&cs->file), zUrl);
       if( !pBrRemote ){
         doltliteFreeStringArray(azNames, nNames);
-        (void)doltliteVcSealSavepointError(db);
-        sqlite3_result_error(ctx, "failed to open remote (URL must start with file:// or http://)", -1);
+        doltliteVcResultError(ctx, db, "failed to open remote (URL must start with file:// or http://)");
         return;
       }
       rc = doltliteFetch(cs, pBrRemote, zRemoteName, azNames[i]);
@@ -449,23 +431,20 @@ static void doltPullFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   DoltliteTxnState savedState;
   int rc;
 
-  if( !cs ){ (void)doltliteVcSealSavepointError(db); sqlite3_result_error(ctx, "no database", -1); return; }
+  if( !cs ){ doltliteVcResultError(ctx, db, "no database"); return; }
   if( argc<2 ){
-    (void)doltliteVcSealSavepointError(db);
-    sqlite3_result_error(ctx, "usage: dolt_pull(remote, branch)", -1);
+    doltliteVcResultError(ctx, db, "usage: dolt_pull(remote, branch)");
     return;
   }
 
   zRemoteName = (const char*)sqlite3_value_text(argv[0]);
   zBranch = (const char*)sqlite3_value_text(argv[1]);
   if( !zRemoteName || !zBranch ){
-    (void)doltliteVcSealSavepointError(db);
-    sqlite3_result_error(ctx, "remote and branch required", -1);
+    doltliteVcResultError(ctx, db, "remote and branch required");
     return;
   }
   if( argc>2 ){
-    (void)doltliteVcSealSavepointError(db);
-    sqlite3_result_error(ctx, "too many arguments", -1);
+    doltliteVcResultError(ctx, db, "too many arguments");
     return;
   }
   memset(&savedState, 0, sizeof(savedState));
@@ -572,30 +551,26 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   DoltliteTxnState savedState;
   int rc;
 
-  if( !cs ){ (void)doltliteVcSealSavepointError(db); sqlite3_result_error(ctx, "no database", -1); return; }
+  if( !cs ){ doltliteVcResultError(ctx, db, "no database"); return; }
   if( argc<1 ){
-    (void)doltliteVcSealSavepointError(db);
-    sqlite3_result_error(ctx, "usage: dolt_clone(url)", -1);
+    doltliteVcResultError(ctx, db, "usage: dolt_clone(url)");
     return;
   }
 
   zUrl = (const char*)sqlite3_value_text(argv[0]);
   if( !zUrl ){
-    (void)doltliteVcSealSavepointError(db);
-    sqlite3_result_error(ctx, "url required", -1);
+    doltliteVcResultError(ctx, db, "url required");
     return;
   }
   if( argc>1 ){
-    (void)doltliteVcSealSavepointError(db);
-    sqlite3_result_error(ctx, "too many arguments", -1);
+    doltliteVcResultError(ctx, db, "too many arguments");
     return;
   }
   memset(&savedState, 0, sizeof(savedState));
 
   if( doltliteHasUncommittedChanges(db) ){
-    (void)doltliteVcSealSavepointError(db);
-    sqlite3_result_error(ctx,
-      "database has uncommitted changes — clone into a fresh database", -1);
+    doltliteVcResultError(ctx, db,
+      "database has uncommitted changes — clone into a fresh database");
     return;
   }
 
@@ -614,8 +589,7 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
       doltliteCommitClear(&c);
     }
     if( !virgin ){
-      (void)doltliteVcSealSavepointError(db);
-      sqlite3_result_error(ctx, "database is not empty — clone into a fresh database", -1);
+      doltliteVcResultError(ctx, db, "database is not empty — clone into a fresh database");
       return;
     }
   }

--- a/src/doltlite_schema_diff.c
+++ b/src/doltlite_schema_diff.c
@@ -444,7 +444,6 @@ static int sdResolveOne(
   const char *zWhich,
   ProllyHash *pCatHash
 ){
-  DoltliteCommit commit;
   ProllyHash commitHash;
   int rc;
 
@@ -455,8 +454,7 @@ static int sdResolveOne(
       "dolt_schema_diff: %s '%s' could not be resolved", zWhich, zRef);
     return SQLITE_ERROR;
   }
-  memset(&commit, 0, sizeof(commit));
-  rc = doltliteLoadCommit(db, &commitHash, &commit);
+  rc = doltliteCommitCatalogHash(db, &commitHash, pCatHash);
   if( rc!=SQLITE_OK ){
     sqlite3_free(pVtab->zErrMsg);
     pVtab->zErrMsg = sqlite3_mprintf(
@@ -464,8 +462,6 @@ static int sdResolveOne(
       "commit could not be loaded", zWhich, zRef);
     return SQLITE_ERROR;
   }
-  memcpy(pCatHash, &commit.catalogHash, sizeof(ProllyHash));
-  doltliteCommitClear(&commit);
   return SQLITE_OK;
 }
 

--- a/src/doltlite_tag.c
+++ b/src/doltlite_tag.c
@@ -61,25 +61,24 @@ static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   char *zParsedEmail = 0;
   int rc, i;
 
-  if( !cs ){ tagSealSavepointError(ctx); sqlite3_result_error(ctx, "no database", -1); return; }
-  if( argc<1 ){ tagSealSavepointError(ctx); sqlite3_result_error(ctx, "tag name required", -1); return; }
+  if( !cs ){ doltliteVcResultError(ctx, db, "no database"); return; }
+  if( argc<1 ){ doltliteVcResultError(ctx, db, "tag name required"); return; }
 
   memset(&m, 0, sizeof(m));
 
   arg0 = (const char*)sqlite3_value_text(argv[0]);
-  if( !arg0 ){ tagSealSavepointError(ctx); sqlite3_result_error(ctx, "tag name required", -1); return; }
+  if( !arg0 ){ doltliteVcResultError(ctx, db, "tag name required"); return; }
 
 
   if( strcmp(arg0, "-d")==0 || strcmp(arg0, "--delete")==0 ){
     const char *zName;
-    if( argc<2 ){ tagSealSavepointError(ctx); sqlite3_result_error(ctx, "tag name required for delete", -1); return; }
+    if( argc<2 ){ doltliteVcResultError(ctx, db, "tag name required for delete"); return; }
     if( argc!=2 ){
-      tagSealSavepointError(ctx);
-      sqlite3_result_error(ctx, "too many positional arguments to dolt_tag", -1);
+      doltliteVcResultError(ctx, db, "too many positional arguments to dolt_tag");
       return;
     }
     zName = (const char*)sqlite3_value_text(argv[1]);
-    if( !zName ){ tagSealSavepointError(ctx); sqlite3_result_error(ctx, "tag name required", -1); return; }
+    if( !zName ){ doltliteVcResultError(ctx, db, "tag name required"); return; }
     m.zName = zName;
     m.isDelete = 1;
     rc = doltliteMutateRefs(db, mutateTagRef, &m);
@@ -103,10 +102,10 @@ static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     if( !arg ) continue;
     if( strcmp(arg, "-m")==0 || strcmp(arg, "--message")==0 ){
       if( i+1<argc ) zMessage = (const char*)sqlite3_value_text(argv[++i]);
-      else{ tagSealSavepointError(ctx); sqlite3_result_error(ctx, "-m requires a message", -1); return; }
+      else{ doltliteVcResultError(ctx, db, "-m requires a message"); return; }
     }else if( strcmp(arg, "--author")==0 ){
       if( i+1<argc ) zAuthor = (const char*)sqlite3_value_text(argv[++i]);
-      else{ tagSealSavepointError(ctx); sqlite3_result_error(ctx, "--author requires 'name <email>'", -1); return; }
+      else{ doltliteVcResultError(ctx, db, "--author requires 'name <email>'"); return; }
     }else if( arg[0]=='-' ){
       char *zErr = sqlite3_mprintf("unknown option `%s`", arg);
       if( zErr ){
@@ -120,8 +119,7 @@ static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     }else if( !zCommitRef ){
       zCommitRef = arg;
     }else{
-      tagSealSavepointError(ctx);
-      sqlite3_result_error(ctx, "too many positional arguments to dolt_tag", -1);
+      doltliteVcResultError(ctx, db, "too many positional arguments to dolt_tag");
       return;
     }
   }
@@ -129,15 +127,13 @@ static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   if( zCommitRef ){
     rc = doltliteResolveRef(db, zCommitRef, &m.commitHash);
     if( rc!=SQLITE_OK ){
-      tagSealSavepointError(ctx);
-      sqlite3_result_error(ctx, "commit not found", -1);
+      doltliteVcResultError(ctx, db, "commit not found");
       return;
     }
   }else{
     doltliteGetSessionHead(db, &m.commitHash);
     if( prollyHashIsEmpty(&m.commitHash) ){
-      tagSealSavepointError(ctx);
-      sqlite3_result_error(ctx, "no commits to tag", -1);
+      doltliteVcResultError(ctx, db, "no commits to tag");
       return;
     }
   }

--- a/src/doltlite_workspace.c
+++ b/src/doltlite_workspace.c
@@ -149,22 +149,18 @@ static int wsLoadRows(WorkspaceVtab *pVtab){
   ProllyHash headHash, headCat, stagedCat, workingCat;
   ProllyHash headRoot, stagedRoot, workingRoot;
   ProllyHash schemaHash;
-  DoltliteCommit headCommit;
   u8 headFlags = 0, stagedFlags = 0, workingFlags = 0;
   int rc;
 
   wsClearCache(pVtab);
-  memset(&headCommit, 0, sizeof(headCommit));
   memset(&headCat, 0, sizeof(headCat));
   memset(&stagedCat, 0, sizeof(stagedCat));
   memset(&workingCat, 0, sizeof(workingCat));
 
   doltliteGetSessionHead(db, &headHash);
   if( prollyHashIsEmpty(&headHash) ) return SQLITE_OK;
-  rc = doltliteLoadCommit(db, &headHash, &headCommit);
+  rc = doltliteCommitCatalogHash(db, &headHash, &headCat);
   if( rc!=SQLITE_OK ) return rc;
-  headCat = headCommit.catalogHash;
-  doltliteCommitClear(&headCommit);
 
   doltliteGetSessionStaged(db, &stagedCat);
   if( prollyHashIsEmpty(&stagedCat) ) stagedCat = headCat;
@@ -363,7 +359,6 @@ static int wsApplyRowToStaged(WorkspaceVtab *p, WorkspaceRow *r, int makeStaged)
   ChunkStore *cs = doltliteGetChunkStore(db);
   ProllyCache *pCache = doltliteGetCache(db);
   ProllyHash headHash, headCat, stagedCat, newRoot, newCat;
-  DoltliteCommit headCommit;
   struct TableEntry *aTables = 0;
   int nTables = 0;
   struct TableEntry *pData;
@@ -383,13 +378,10 @@ static int wsApplyRowToStaged(WorkspaceVtab *p, WorkspaceRow *r, int makeStaged)
   int        nTgt = makeStaged ? nWorkVal : nHeadVal;
 
   if( !cs || !pCache ) return SQLITE_ERROR;
-  memset(&headCommit, 0, sizeof(headCommit));
   doltliteGetSessionHead(db, &headHash);
   if( prollyHashIsEmpty(&headHash) ) return SQLITE_ERROR;
-  rc = doltliteLoadCommit(db, &headHash, &headCommit);
+  rc = doltliteCommitCatalogHash(db, &headHash, &headCat);
   if( rc!=SQLITE_OK ) return rc;
-  headCat = headCommit.catalogHash;
-  doltliteCommitClear(&headCommit);
 
   doltliteGetSessionStaged(db, &stagedCat);
   if( prollyHashIsEmpty(&stagedCat) ) stagedCat = headCat;


### PR DESCRIPTION
## Summary

Factor two repeated idioms in the doltlite version-control layer into shared helpers. Behavior-preserving; rebased onto latest master.

| Idiom | Helper(s) | Call sites |
|-------|-----------|-----------|
| ref→commit→`catalogHash` extraction | `doltliteCommitCatalogHash`, `doltliteRefToCatalogHash` (commit.c) | at, blame, branch, diff, diff_stat, hashof, ref, remote_sql, schema_diff, workspace |
| seal-savepoint + `result_error` prologue | `doltliteVcResultError`, `doltliteVcResultErrorCode` (doltlite.c) | branch, remote_sql, tag |

## Scope note

This began as a five-part dedup audit. Three of the findings were **independently implemented and merged to master** while this was open, so those commits were dropped to avoid duplicate abstractions:
- BFS commit-traversal queue → `Share DoltLite commit traversal queue`
- integer-PK range planner → `Share integer primary key range planning`
- static-schema vtab setup → `Factor simple DoltLite vtab setup`

The two remaining helpers are not present in master. They merge cleanly against master's refactors — e.g. blame feeds `doltliteCommitCatalogHash`'s result into master's shared `doltliteLoadTableRootByName`.

## Test plan

- Full build: clean, no new warnings.
- `test/run_doltlite_tests.sh`: **80/80 suites pass, 0 failures** on the rebased tree — includes durability/concurrency/merge regression guards and the 309,815-case incrblob suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
