### PR TITLE
Speed up prolly int-key reads

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -560,8 +560,8 @@ static SQLITE_INLINE u64 cursorCurrentTreeKeyPrefixInt(BtCursor *pCur){
   ProllyCacheEntry *pLeaf = pProllyCur->aLevel[pProllyCur->iLevel].pEntry;
   ProllyNode *pNode = &pLeaf->node;
   int i = pProllyCur->aLevel[pProllyCur->iLevel].idx;
-  u32 off = PROLLY_GET_U32((const u8*)&pNode->aKeyOff[i]);
-  const u8 *p = pNode->pKeyData + off;
+  const u8 *p = pNode->pKeyData + i*8;
+  assert( (pNode->flags & PROLLY_NODE_INTKEY)!=0 );
   return ((u64)p[0]<<56) | ((u64)p[1]<<48) | ((u64)p[2]<<40)
        | ((u64)p[3]<<32) | ((u64)p[4]<<24) | ((u64)p[5]<<16)
        | ((u64)p[6]<<8) | (u64)p[7];

--- a/src/prolly_node.c
+++ b/src/prolly_node.c
@@ -159,10 +159,11 @@ i64 prollyDecodeIntKey(const u8 *p){
 }
 
 i64 prollyNodeIntKey(const ProllyNode *pNode, int i){
-  u32 off;
+  const u8 *p;
   assert( i >= 0 && i < (int)pNode->nItems );
-  off = PROLLY_GET_U32((const u8*)&pNode->aKeyOff[i]);
-  return prollyDecodeIntKey(pNode->pKeyData + off);
+  assert( (pNode->flags & PROLLY_NODE_INTKEY)!=0 );
+  p = pNode->pKeyData + i*8;
+  return prollyDecodeIntKey(p);
 }
 
 void prollyNodeChildHash(const ProllyNode *pNode, int i, ProllyHash *pHash){


### PR DESCRIPTION
## Summary

Use direct `i*8` addressing for prolly int-key node entries instead of reading the key offset table. Prolly node parsing already verifies that int-key entries are fixed-width 8 byte keys, so this avoids an unnecessary offset load in int-key search/current-key paths.

## Benchmark

Local sysbench-style int-key benchmark, `BENCH_ROWS=20000`, 30 alternating samples of the targeted `select_random_points` workload:

- in-memory: baseline median 5083.5 us, patched median 4812.5 us (`-5.33%`)
- file-backed: baseline median 6618.5 us, patched median 6387.0 us (`-3.50%`)

I also ran the full wrapped int-key suite with `BENCH_ROWS=20000 BENCH_RUNS=7`; the largest improvement was on in-memory `select_random_points` (`5115 us` to `4759 us`, `-6.96%`). Some unrelated write tests moved in both directions, so the proof point is the targeted random point read workload.

## Validation

- `make doltlite`
- CLI int-key smoke test covering negative/positive rowids, IN lookup, range count, indexed lookup, update, and delete
- `bash test/review_regression_test.sh` (`120 passed, 0 failed`)

`make testfixture && ./testfixture test/main.test` could not run locally because the linker cannot find `libtommath` in this environment.
