### PR TITLE
Unify duplicate conflict-row struct across merge and conflicts

### DIFF
--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -9,23 +9,22 @@ typedef struct ConflictTableInfo ConflictTableInfo;
 struct ConflictTableInfo {
   char *zName;
   int nConflicts;
-  struct ConflictRow {
-    i64 intKey;
-    u8 *pKey; int nKey;
-    u8 *pBaseVal; int nBaseVal;
-    u8 *pOurVal; int nOurVal;
-    u8 *pTheirVal; int nTheirVal;
-  } *aRows;
+  DoltliteConflictRow *aRows;
 };
 
 static void freeConflictTables(ConflictTableInfo *aTables, int nTables);
 
-static void freeConflictRow(struct ConflictRow *pRow){
+void doltliteConflictRowFree(DoltliteConflictRow *pRow){
   if( !pRow ) return;
   sqlite3_free(pRow->pKey);
   sqlite3_free(pRow->pBaseVal);
   sqlite3_free(pRow->pOurVal);
   sqlite3_free(pRow->pTheirVal);
+}
+
+static void freeConflictRow(DoltliteConflictRow *pRow){
+  if( !pRow ) return;
+  doltliteConflictRowFree(pRow);
   memset(pRow, 0, sizeof(*pRow));
 }
 
@@ -33,7 +32,7 @@ static void removeConflictRow(ConflictTableInfo *pTable, int iRow){
   if( !pTable || iRow<0 || iRow>=pTable->nConflicts ) return;
   freeConflictRow(&pTable->aRows[iRow]);
   doltliteArrayRemoveAt(pTable->aRows, &pTable->nConflicts, iRow,
-                        (int)sizeof(struct ConflictRow));
+                        (int)sizeof(DoltliteConflictRow));
 }
 
 static void removeConflictTable(ConflictTableInfo *aTables, int *pnTables, int iTable){
@@ -88,7 +87,7 @@ int doltliteSerializeConflicts(
     dlWriteU16Name(&w, aTables[i].zName, nl);
     dlWriteU32(&w, aTables[i].nConflicts);
     for(j=0; j<aTables[i].nConflicts; j++){
-      struct ConflictRow *cr = &aTables[i].aRows[j];
+      DoltliteConflictRow *cr = &aTables[i].aRows[j];
       dlWriteU32Blob(&w, cr->pKey, cr->nKey);
       dlWriteI64(&w, cr->intKey);
       dlWriteU32Blob(&w, cr->pBaseVal, cr->nBaseVal);
@@ -147,12 +146,12 @@ static int loadAllConflicts(
       rc = SQLITE_CORRUPT; goto conflicts_cleanup;
     }
     aTables[i].nConflicts = nc;
-    aTables[i].aRows = sqlite3_malloc64((sqlite3_uint64)nc * sizeof(struct ConflictRow));
+    aTables[i].aRows = sqlite3_malloc64((sqlite3_uint64)nc * sizeof(DoltliteConflictRow));
     if( !aTables[i].aRows ){ rc = SQLITE_NOMEM; goto conflicts_cleanup; }
-    memset(aTables[i].aRows, 0, (sqlite3_uint64)nc * sizeof(struct ConflictRow));
+    memset(aTables[i].aRows, 0, (sqlite3_uint64)nc * sizeof(DoltliteConflictRow));
 
     for(j=0; j<nc; j++){
-      struct ConflictRow *cr = &aTables[i].aRows[j];
+      DoltliteConflictRow *cr = &aTables[i].aRows[j];
       rc = dlReadU32Blob(&r, &cr->pKey, &cr->nKey);
       if( rc!=SQLITE_OK ) goto conflicts_cleanup;
       cr->intKey = dlReadI64(&r);
@@ -406,7 +405,7 @@ static const char *cfrDiffType(const u8 *pBase, int nBase,
   return doltliteDiffTypeNameFromPresence(baseHas, sideHas);
 }
 
-static sqlite3_int64 cfrConflictRowid(const struct ConflictRow *cr){
+static sqlite3_int64 cfrConflictRowid(const DoltliteConflictRow *cr){
   u64 h = DOLTLITE_FNV1A_OFFSET;
   h = doltliteFnv1aBytes(h, cr->pKey, cr->nKey);
   h = doltliteFnv1aSep(h);
@@ -423,7 +422,7 @@ static sqlite3_int64 cfrConflictRowid(const struct ConflictRow *cr){
 static int cfrColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
   CfRowCur *c = (CfRowCur*)cur;
   CfRowVtab *v = (CfRowVtab*)cur->pVtab;
-  struct ConflictRow *cr;
+  DoltliteConflictRow *cr;
   int nUserCols;
   int colBaseStart, colOurStart, colOurDiff;
   int colTheirStart, colTheirDiff, colConflictId;
@@ -672,7 +671,7 @@ static void conflictsResolveFunc(sqlite3_context *ctx, int argc, sqlite3_value *
       found = 1;
 
       for(j=0; j<aTables[i].nConflicts; j++){
-        struct ConflictRow *cr = &aTables[i].aRows[j];
+        DoltliteConflictRow *cr = &aTables[i].aRows[j];
         rc = doltliteApplyRawRowMutation(db, zTable,
                                          cr->pKey, cr->nKey, cr->intKey,
                                          cr->pTheirVal, cr->nTheirVal);

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -755,6 +755,17 @@ int doltliteApplyRawRowMutation(sqlite3 *db, const char *zTable,
                                 const u8 *pKey, int nKey, i64 intKey,
                                 const u8 *pVal, int nVal);
 
+typedef struct DoltliteConflictRow DoltliteConflictRow;
+struct DoltliteConflictRow {
+  i64 intKey;
+  u8 *pKey; int nKey;
+  u8 *pBaseVal; int nBaseVal;
+  u8 *pOurVal; int nOurVal;
+  u8 *pTheirVal; int nTheirVal;
+};
+
+void doltliteConflictRowFree(DoltliteConflictRow *pRow);
+
 /* Index key construction helpers (see doltlite_merge.c). Exposed for
 ** dolt_conflicts_resolve --theirs to maintain secondary indexes when
 ** writing theirs's row directly via the raw-row mutation path. */

--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -197,13 +197,7 @@ struct RowMergeCtx {
   int nIndexes;
   int nConflicts;
 
-  struct MergeConflictRow {
-    i64 intKey;
-    u8 *pKey; int nKey;
-    u8 *pBaseVal; int nBaseVal;
-    u8 *pOurVal; int nOurVal;
-    u8 *pTheirVal; int nTheirVal;
-  } *aConflicts;
+  DoltliteConflictRow *aConflicts;
   int nConflictsAlloc;
 };
 
@@ -590,7 +584,7 @@ static int rowMergeCallback(void *pCtx, const ThreeWayChange *pChange){
                                 ctx->nConflicts + 1, 16);
       if( rc!=SQLITE_OK ) return rc;
       {
-        struct MergeConflictRow *cr = &ctx->aConflicts[ctx->nConflicts];
+        DoltliteConflictRow *cr = &ctx->aConflicts[ctx->nConflicts];
         memset(cr, 0, sizeof(*cr));
         cr->intKey = pChange->intKey;
         if( pChange->pKey && pChange->nKey>0 ){
@@ -673,10 +667,7 @@ static int canFastMerge(
 static void freeRowMergeCtx(RowMergeCtx *ctx){
   int i;
   for(i=0; i<ctx->nConflicts; i++){
-    sqlite3_free(ctx->aConflicts[i].pKey);
-    sqlite3_free(ctx->aConflicts[i].pBaseVal);
-    sqlite3_free(ctx->aConflicts[i].pOurVal);
-    sqlite3_free(ctx->aConflicts[i].pTheirVal);
+    doltliteConflictRowFree(&ctx->aConflicts[i]);
   }
   sqlite3_free(ctx->aConflicts);
   if( ctx->pEdits ){
@@ -693,7 +684,7 @@ static int mergeTableRows(
   u8 flags,
   ProllyHash *pMergedRoot,
   int *pnConflicts,
-  struct MergeConflictRow **ppConflicts,
+  DoltliteConflictRow **ppConflicts,
   MergeIndexInfo *aIndexes,
   int nIndexes
 ){
@@ -1156,16 +1147,13 @@ typedef struct MergeConflictTable MergeConflictTable;
 struct MergeConflictTable {
   char *zName;
   int nConflicts;
-  struct MergeConflictRow *aRows;
+  DoltliteConflictRow *aRows;
 };
 
-static void freeConflictRows(struct MergeConflictRow *aRows, int nRows){
+static void freeConflictRows(DoltliteConflictRow *aRows, int nRows){
   int i;
   for(i=0; i<nRows; i++){
-    sqlite3_free(aRows[i].pKey);
-    sqlite3_free(aRows[i].pBaseVal);
-    sqlite3_free(aRows[i].pOurVal);
-    sqlite3_free(aRows[i].pTheirVal);
+    doltliteConflictRowFree(&aRows[i]);
   }
   sqlite3_free(aRows);
 }
@@ -1181,7 +1169,7 @@ static int appendConflictTable(
   int *pnConflictTables,
   const char *zName,
   int nConflicts,
-  struct MergeConflictRow *aConflictRows
+  DoltliteConflictRow *aConflictRows
 ){
   MergeConflictTable *aNew;
   aNew = sqlite3_realloc(*ppConflictTables,
@@ -1971,7 +1959,7 @@ do_merge_entry:
 
             ProllyHash mergedTableRoot;
             int nConflicts = 0;
-            struct MergeConflictRow *aConflictRows = 0;
+            DoltliteConflictRow *aConflictRows = 0;
 
             MergeIndexInfo *aIdxInfo = 0;
             int nIdxInfo = 0;
@@ -2132,7 +2120,7 @@ post_merge_table_rows:;
 
         ProllyHash mergedTableRoot;
         int nConflicts = 0;
-        struct MergeConflictRow *aConflictRows = 0;
+        DoltliteConflictRow *aConflictRows = 0;
         int theirSchemaChanged2 = prollyHashCompare(
             &theirsEntry->schemaHash, &ancEntry->schemaHash)!=0;
 


### PR DESCRIPTION
## Summary

`struct ConflictRow` (doltlite_conflicts.c) and `struct MergeConflictRow` (doltlite_merge.c) were field-for-field identical conflict-row payloads. They are also **cast across a translation-unit boundary** — `doltliteSerializeConflicts(ConflictTableInfo*)` (defined in conflicts.c) is called from merge.c with a `MergeConflictTable*` whose row array is the merge struct — so the two layouts had to stay bit-identical by hand. This unifies them into one shared `DoltliteConflictRow` (in `doltlite_internal.h`), removing the duplication and the silent layout coupling.

Also factors the open-coded 4-field free into `doltliteConflictRowFree`, now backing `freeConflictRow`, `freeConflictRows`, and the row-merge ctx teardown.

The `ThreeWayChange`→row copy in `rowMergeCallback` was left as-is (single site, bespoke incremental NOMEM rollback — not a clean extraction).

## Behavior

No format/field-order/semantic change. `ConflictTableInfo` and `MergeConflictTable` now share the identical layout `{ char *zName; int nConflicts; DoltliteConflictRow *aRows; }`, so the cross-TU cast remains type-correct.

## Test plan

- Clean build, no warnings.
- `test/run_doltlite_tests.sh`: **80/80 suites pass** (covers merge/conflict serialization round-trips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
