### PR TITLE
Remove verbatim-duplicate ref-error, chunker-empty, and cursor-row-copy helpers

### DIFF
--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -30,21 +30,6 @@ static int branchNameEmpty(const char *zName){
   return zName==0 || zName[0]==0;
 }
 
-static void branchResultError(
-  sqlite3_context *ctx,
-  int rc,
-  const char *zNotFound,
-  const char *zExists
-){
-  if( rc==SQLITE_NOTFOUND ){
-    sqlite3_result_error(ctx, zNotFound, -1);
-  }else if( rc==SQLITE_ERROR && zExists ){
-    sqlite3_result_error(ctx, zExists, -1);
-  }else{
-    sqlite3_result_error(ctx, sqlite3_errstr(rc), -1);
-  }
-}
-
 static void branchSealSavepointsOnError(sqlite3_context *ctx, int bHadSavepoint){
   if( bHadSavepoint ){
     sqlite3 *db = sqlite3_context_db_handle(ctx);
@@ -70,7 +55,7 @@ static void branchNamedResultError(
   const char *zExists
 ){
   branchSealSavepointsOnError(ctx, bHadSavepoint);
-  branchResultError(ctx, rc, zNotFound, zExists);
+  doltliteRefResultError(ctx, rc, zNotFound, zExists);
 }
 
 static int mutateBranchRef(sqlite3 *db, ChunkStore *cs, void *pArg){

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -430,6 +430,21 @@ static SQLITE_INLINE void doltliteResultTimestamp(sqlite3_context *ctx, i64 time
   }
 }
 
+static SQLITE_INLINE void doltliteRefResultError(
+  sqlite3_context *ctx,
+  int rc,
+  const char *zNotFound,
+  const char *zExists
+){
+  if( rc==SQLITE_NOTFOUND ){
+    sqlite3_result_error(ctx, zNotFound, -1);
+  }else if( rc==SQLITE_ERROR && zExists ){
+    sqlite3_result_error(ctx, zExists, -1);
+  }else{
+    sqlite3_result_error(ctx, sqlite3_errstr(rc), -1);
+  }
+}
+
 static SQLITE_INLINE int doltliteVtabDisconnect(sqlite3_vtab *pVtab){
   sqlite3_free(pVtab);
   return SQLITE_OK;

--- a/src/doltlite_merge_constraints.c
+++ b/src/doltlite_merge_constraints.c
@@ -12,65 +12,6 @@
 
 #include <string.h>
 
-static int fetchRowByRowid(
-  ChunkStore *cs,
-  ProllyCache *pCache,
-  const ProllyHash *pRoot,
-  u8 flags,
-  i64 targetRowid,
-  u8 **ppKey, int *pnKey,
-  u8 **ppVal, int *pnVal
-){
-  ProllyCursor cur;
-  int res, rc;
-
-  *ppKey = 0; *pnKey = 0;
-  *ppVal = 0; *pnVal = 0;
-
-  if( prollyHashIsEmpty(pRoot) ) return SQLITE_NOTFOUND;
-
-  prollyCursorInit(&cur, cs, pCache, pRoot, flags);
-  rc = prollyCursorSeekInt(&cur, targetRowid, &res);
-  if( rc!=SQLITE_OK ){
-    prollyCursorClose(&cur);
-    return rc;
-  }
-  if( res!=0 ){
-    prollyCursorClose(&cur);
-    return SQLITE_NOTFOUND;
-  }
-
-  {
-    const u8 *pKey, *pVal;
-    int nKey, nVal;
-    prollyCursorKey(&cur, &pKey, &nKey);
-    prollyCursorValue(&cur, &pVal, &nVal);
-    if( pKey && nKey > 0 ){
-      *ppKey = sqlite3_malloc(nKey);
-      if( !*ppKey ){
-        prollyCursorClose(&cur);
-        return SQLITE_NOMEM;
-      }
-      memcpy(*ppKey, pKey, nKey);
-      *pnKey = nKey;
-    }
-    if( pVal && nVal > 0 ){
-      *ppVal = sqlite3_malloc(nVal);
-      if( !*ppVal ){
-        sqlite3_free(*ppKey);
-        *ppKey = 0; *pnKey = 0;
-        prollyCursorClose(&cur);
-        return SQLITE_NOMEM;
-      }
-      memcpy(*ppVal, pVal, nVal);
-      *pnVal = nVal;
-    }
-  }
-
-  prollyCursorClose(&cur);
-  return SQLITE_OK;
-}
-
 static int copyCursorRow(
   ProllyCursor *pCur,
   u8 **ppKey, int *pnKey,
@@ -101,6 +42,38 @@ static int copyCursorRow(
     *pnVal = nVal;
   }
   return SQLITE_OK;
+}
+
+static int fetchRowByRowid(
+  ChunkStore *cs,
+  ProllyCache *pCache,
+  const ProllyHash *pRoot,
+  u8 flags,
+  i64 targetRowid,
+  u8 **ppKey, int *pnKey,
+  u8 **ppVal, int *pnVal
+){
+  ProllyCursor cur;
+  int res, rc;
+
+  *ppKey = 0; *pnKey = 0;
+  *ppVal = 0; *pnVal = 0;
+
+  if( prollyHashIsEmpty(pRoot) ) return SQLITE_NOTFOUND;
+
+  prollyCursorInit(&cur, cs, pCache, pRoot, flags);
+  rc = prollyCursorSeekInt(&cur, targetRowid, &res);
+  if( rc!=SQLITE_OK ){
+    prollyCursorClose(&cur);
+    return rc;
+  }
+  if( res!=0 ){
+    prollyCursorClose(&cur);
+    return SQLITE_NOTFOUND;
+  }
+  rc = copyCursorRow(&cur, ppKey, pnKey, ppVal, pnVal);
+  prollyCursorClose(&cur);
+  return rc;
 }
 
 static int fetchRowByBlobKey(

--- a/src/doltlite_tag.c
+++ b/src/doltlite_tag.c
@@ -20,21 +20,6 @@ struct TagMutationCtx {
   const char *zMessage;
 };
 
-static void tagResultError(
-  sqlite3_context *ctx,
-  int rc,
-  const char *zNotFound,
-  const char *zExists
-){
-  if( rc==SQLITE_NOTFOUND ){
-    sqlite3_result_error(ctx, zNotFound, -1);
-  }else if( rc==SQLITE_ERROR && zExists ){
-    sqlite3_result_error(ctx, zExists, -1);
-  }else{
-    sqlite3_result_error(ctx, sqlite3_errstr(rc), -1);
-  }
-}
-
 static void tagSealSavepointError(sqlite3_context *ctx){
   sqlite3 *db = sqlite3_context_db_handle(ctx);
   (void)doltliteVcSealSavepointError(db);
@@ -84,7 +69,7 @@ static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
     rc = doltliteMutateRefs(db, mutateTagRef, &m);
     if( rc!=SQLITE_OK ){
       tagSealSavepointError(ctx);
-      tagResultError(ctx, rc, "tag not found", 0);
+      doltliteRefResultError(ctx, rc, "tag not found", 0);
       return;
     }
     rc = doltliteVcSealActiveSavepoints(db);
@@ -172,7 +157,7 @@ static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
   sqlite3_free(zParsedEmail);
   if( rc!=SQLITE_OK ){
     tagSealSavepointError(ctx);
-    tagResultError(ctx, rc, "tag not found", "tag already exists");
+    doltliteRefResultError(ctx, rc, "tag not found", "tag already exists");
     return;
   }
   rc = doltliteVcSealActiveSavepoints(db);

--- a/src/prolly_chunker.c
+++ b/src/prolly_chunker.c
@@ -325,4 +325,12 @@ void prollyChunkerFree(ProllyChunker *ch){
   ch->nLevels = 0;
 }
 
+int prollyChunkerLevelsBelowEmpty(const ProllyChunker *ch, int level){
+  int i;
+  for(i = 0; i < level && i < ch->nLevels; i++){
+    if( ch->aLevel[i].builder.nItems > 0 ) return 0;
+  }
+  return 1;
+}
+
 #endif

--- a/src/prolly_chunker.h
+++ b/src/prolly_chunker.h
@@ -57,4 +57,6 @@ int prollyChunkerAddAtLevelWithCount(ProllyChunker *ch, int level,
                                      const u8 *pVal, int nVal,
                                      u64 subtreeCount);
 
+int prollyChunkerLevelsBelowEmpty(const ProllyChunker *ch, int level);
+
 #endif

--- a/src/prolly_mutate.c
+++ b/src/prolly_mutate.c
@@ -74,19 +74,6 @@ static int subtreeHasEdits(
   return (cmp <= 0);
 }
 
-static int chunkerLevelsBelowEmpty(
-  const ProllyChunker *pChunker,
-  int level
-){
-  int i;
-  for( i = 0; i < level && i < pChunker->nLevels; i++ ){
-    if( pChunker->aLevel[i].builder.nItems > 0 ){
-      return 0;
-    }
-  }
-  return 1;
-}
-
 static int mergeLeaf(
   ProllyMutator *pMut,
   ProllyNode *pLeaf,
@@ -213,7 +200,7 @@ static int streamingMergeNode(
 
     if( !forceDescend
      && !subtreeHasEdits(pIter, pBoundKey, nBoundKey)
-     && chunkerLevelsBelowEmpty(pChunker, pNode->level) ){
+     && prollyChunkerLevelsBelowEmpty(pChunker, pNode->level) ){
       u64 childCount = 0;
       rc = parentChildSubtreeCount(pMut->pStore, pMut->pCache,
                                    pNode, i, &childCount);

--- a/src/prolly_three_way_merge.c
+++ b/src/prolly_three_way_merge.c
@@ -13,14 +13,6 @@
 ** fall back to the full row-wise merge path without treating it as an error. */
 #define FM_FALLBACK  SQLITE_DONE
 
-static int fmChunkerLevelsBelowEmpty(const ProllyChunker *pCh, int level){
-  int i;
-  for( i = 0; i < level && i < pCh->nLevels; i++ ){
-    if( pCh->aLevel[i].builder.nItems > 0 ) return 0;
-  }
-  return 1;
-}
-
 typedef struct FmCtx {
   ChunkStore *pStore;
   ProllyCache *pCache;
@@ -373,7 +365,7 @@ static int fmEmitChild(
   if( pSplice ){
     /* Preserve structural sharing only when the chunker is exactly aligned at
     ** this parent level; otherwise emit rows so the rebuilt tree stays sorted. */
-    if( fmChunkerLevelsBelowEmpty(pCh, parentLevel) ){
+    if( prollyChunkerLevelsBelowEmpty(pCh, parentLevel) ){
       u64 spliceCount = 0;
       rc = prollySubtreeCount(fm->pStore, fm->pCache, pSplice, &spliceCount);
       if( rc != SQLITE_OK ) return rc;


### PR DESCRIPTION
## Summary

Three independent verbatim-duplicate helpers folded into one shared definition each. Behavior byte-identical.

1. **Ref-error mapper** — `branchResultError` (doltlite_branch.c) and `tagResultError` (doltlite_tag.c) were byte-for-byte identical. Replaced with one `doltliteRefResultError` (SQLITE_INLINE in doltlite_internal.h). Branch's savepoint-sealing wrapper now delegates to it. (3 call sites)
2. **Chunker-levels-empty** — `chunkerLevelsBelowEmpty` (prolly_mutate.c) and `fmChunkerLevelsBelowEmpty` (prolly_three_way_merge.c) were the same loop. Replaced with one exported `prollyChunkerLevelsBelowEmpty` in prolly_chunker.c/.h. (2 call sites)
3. **Cursor-row copy** — `fetchRowByRowid` (doltlite_merge_constraints.c) re-inlined the `copyCursorRow` body that its two siblings already delegate to. Now calls `copyCursorRow`; the seek/positioning before the copy is preserved exactly.

## Test plan

- Clean build, no warnings.
- `test/run_doltlite_tests.sh`: **80/80 suites pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
