### PR TITLE
Share name-keyed find and grow-by-one across chunk ref arrays

### DIFF
--- a/src/chunk_refs.c
+++ b/src/chunk_refs.c
@@ -5,6 +5,25 @@
 #include "chunk_store.h"
 #include <string.h>
 
+int csFindNamedRef(const void *aBase, int n, int stride, const char *zName){
+  const char *p = (const char*)aBase;
+  int i;
+  if( !zName ) return -1;
+  for(i=0; i<n; i++){
+    const char *zHave = *(const char *const*)(p + (size_t)i*stride);
+    if( zHave && strcmp(zHave, zName)==0 ) return i;
+  }
+  return -1;
+}
+
+int csRefArrayGrow(void **paBase, int n, int stride){
+  void *aNew = sqlite3_realloc(*paBase, (n+1)*stride);
+  if( !aNew ) return SQLITE_NOMEM;
+  *paBase = aNew;
+  memset((char*)aNew + (size_t)n*stride, 0, stride);
+  return SQLITE_OK;
+}
+
 void refsTableGetBranches(const RefsTable *rt, int *pn, const BranchRef **par){
   *pn = rt->nBranches;
   *par = rt->aBranches;
@@ -31,15 +50,9 @@ void refsTableGetSequences(const RefsTable *rt, int *pn, const SequenceRef **par
 }
 
 i64 refsTableGetSequence(const RefsTable *rt, const char *zTableName){
-  int i;
-  if( !zTableName ) return 0;
-  for(i=0; i<rt->nSequences; i++){
-    if( rt->aSequences[i].zTableName
-     && strcmp(rt->aSequences[i].zTableName, zTableName)==0 ){
-      return rt->aSequences[i].iSeq;
-    }
-  }
-  return 0;
+  int i = csFindNamedRef(rt->aSequences, rt->nSequences,
+                         (int)sizeof(SequenceRef), zTableName);
+  return i<0 ? 0 : rt->aSequences[i].iSeq;
 }
 
 const ProllyHash *refsTableGetHash(const RefsTable *rt){
@@ -122,28 +135,23 @@ i64 chunkStoreGetSequenceValue(ChunkStore *cs, const char *zTableName){
 
 int chunkStoreBumpSequence(ChunkStore *cs, const char *zTableName,
                            i64 newSeq){
-  int i;
-  SequenceRef *aNew;
+  int i, n;
   char *zCopy;
   if( !cs || !zTableName ) return SQLITE_MISUSE;
-  for(i=0; i<cs->refs.nSequences; i++){
-    if( cs->refs.aSequences[i].zTableName
-     && strcmp(cs->refs.aSequences[i].zTableName, zTableName)==0 ){
-      if( newSeq > cs->refs.aSequences[i].iSeq ){
-        cs->refs.aSequences[i].iSeq = newSeq;
-      }
-      return SQLITE_OK;
+  i = csFindNamedRef(cs->refs.aSequences, cs->refs.nSequences,
+                     (int)sizeof(SequenceRef), zTableName);
+  if( i>=0 ){
+    if( newSeq > cs->refs.aSequences[i].iSeq ){
+      cs->refs.aSequences[i].iSeq = newSeq;
     }
+    return SQLITE_OK;
   }
-  aNew = sqlite3_realloc(cs->refs.aSequences,
-                         (cs->refs.nSequences+1)*(int)sizeof(SequenceRef));
-  if( !aNew ) return SQLITE_NOMEM;
-  cs->refs.aSequences = aNew;
-  memset(&aNew[cs->refs.nSequences], 0, sizeof(SequenceRef));
+  n = cs->refs.nSequences;
+  if( csRefArrayGrow((void**)&cs->refs.aSequences, n, (int)sizeof(SequenceRef)) ) return SQLITE_NOMEM;
   zCopy = sqlite3_mprintf("%s", zTableName);
   if( !zCopy ) return SQLITE_NOMEM;
-  aNew[cs->refs.nSequences].zTableName = zCopy;
-  aNew[cs->refs.nSequences].iSeq = newSeq;
+  cs->refs.aSequences[n].zTableName = zCopy;
+  cs->refs.aSequences[n].iSeq = newSeq;
   cs->refs.nSequences++;
   return SQLITE_OK;
 }
@@ -151,34 +159,29 @@ int chunkStoreBumpSequence(ChunkStore *cs, const char *zTableName,
 void chunkStoreDropSequence(ChunkStore *cs, const char *zTableName){
   int i;
   if( !cs || !zTableName ) return;
-  for(i=0; i<cs->refs.nSequences; i++){
-    if( cs->refs.aSequences[i].zTableName
-     && strcmp(cs->refs.aSequences[i].zTableName, zTableName)==0 ){
-      sqlite3_free(cs->refs.aSequences[i].zTableName);
-      if( i < cs->refs.nSequences-1 ){
-        memmove(&cs->refs.aSequences[i], &cs->refs.aSequences[i+1],
-                (cs->refs.nSequences-i-1)*sizeof(SequenceRef));
-      }
-      cs->refs.nSequences--;
-      return;
-    }
+  i = csFindNamedRef(cs->refs.aSequences, cs->refs.nSequences,
+                     (int)sizeof(SequenceRef), zTableName);
+  if( i<0 ) return;
+  sqlite3_free(cs->refs.aSequences[i].zTableName);
+  if( i < cs->refs.nSequences-1 ){
+    memmove(&cs->refs.aSequences[i], &cs->refs.aSequences[i+1],
+            (cs->refs.nSequences-i-1)*sizeof(SequenceRef));
   }
+  cs->refs.nSequences--;
 }
 
 int chunkStoreRenameSequence(ChunkStore *cs, const char *zOld,
                              const char *zNew){
   int i;
+  char *zCopy;
   if( !cs || !zOld || !zNew ) return SQLITE_MISUSE;
-  for(i=0; i<cs->refs.nSequences; i++){
-    if( cs->refs.aSequences[i].zTableName
-     && strcmp(cs->refs.aSequences[i].zTableName, zOld)==0 ){
-      char *zCopy = sqlite3_mprintf("%s", zNew);
-      if( !zCopy ) return SQLITE_NOMEM;
-      sqlite3_free(cs->refs.aSequences[i].zTableName);
-      cs->refs.aSequences[i].zTableName = zCopy;
-      return SQLITE_OK;
-    }
-  }
+  i = csFindNamedRef(cs->refs.aSequences, cs->refs.nSequences,
+                     (int)sizeof(SequenceRef), zOld);
+  if( i<0 ) return SQLITE_OK;
+  zCopy = sqlite3_mprintf("%s", zNew);
+  if( !zCopy ) return SQLITE_NOMEM;
+  sqlite3_free(cs->refs.aSequences[i].zTableName);
+  cs->refs.aSequences[i].zTableName = zCopy;
   return SQLITE_OK;
 }
 

--- a/src/chunk_refs.h
+++ b/src/chunk_refs.h
@@ -66,6 +66,12 @@ void refsTableGetRemotes(const RefsTable *rt, int *pn, const RemoteRef **par);
 void refsTableGetTracking(const RefsTable *rt, int *pn, const TrackingBranch **par);
 void refsTableGetSequences(const RefsTable *rt, int *pn, const SequenceRef **par);
 
+/* Index of the ref whose leading char* name field equals zName, or -1. */
+int csFindNamedRef(const void *aBase, int n, int stride, const char *zName);
+
+/* Grow a packed ref array by one zeroed element; returns SQLITE_OK/NOMEM. */
+int csRefArrayGrow(void **paBase, int n, int stride);
+
 int refsTableBranchCount(const RefsTable *rt);
 int refsTableTagCount(const RefsTable *rt);
 int refsTableRemoteCount(const RefsTable *rt);

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -640,27 +640,18 @@ int chunkStoreSetDefaultBranch(ChunkStore *cs, const char *zName){
 }
 
 static int findBranchIdx(ChunkStore *cs, const char *zName){
-  int i;
-  for(i=0; i<cs->refs.nBranches; i++){
-    if( strcmp(cs->refs.aBranches[i].zName, zName)==0 ) return i;
-  }
-  return -1;
+  return csFindNamedRef(cs->refs.aBranches, cs->refs.nBranches,
+                        (int)sizeof(struct BranchRef), zName);
 }
 
 static int findTagIdx(ChunkStore *cs, const char *zName){
-  int i;
-  for(i=0; i<cs->refs.nTags; i++){
-    if( strcmp(cs->refs.aTags[i].zName, zName)==0 ) return i;
-  }
-  return -1;
+  return csFindNamedRef(cs->refs.aTags, cs->refs.nTags,
+                        (int)sizeof(struct TagRef), zName);
 }
 
 static int findRemoteIdx(ChunkStore *cs, const char *zName){
-  int i;
-  for(i=0; i<cs->refs.nRemotes; i++){
-    if( strcmp(cs->refs.aRemotes[i].zName, zName)==0 ) return i;
-  }
-  return -1;
+  return csFindNamedRef(cs->refs.aRemotes, cs->refs.nRemotes,
+                        (int)sizeof(struct RemoteRef), zName);
 }
 
 static int findTrackingIdx(ChunkStore *cs, const char *zRemote, const char *zBranch){
@@ -680,15 +671,12 @@ int chunkStoreFindBranch(ChunkStore *cs, const char *zName, ProllyHash *pCommit)
 }
 
 int chunkStoreAddBranch(ChunkStore *cs, const char *zName, const ProllyHash *pCommit){
-  struct BranchRef *aNew;
+  int n = cs->refs.nBranches;
   if( chunkStoreFindBranch(cs, zName, 0)==SQLITE_OK ) return SQLITE_ERROR;
-  aNew = sqlite3_realloc(cs->refs.aBranches, (cs->refs.nBranches+1)*(int)sizeof(struct BranchRef));
-  if( !aNew ) return SQLITE_NOMEM;
-  cs->refs.aBranches = aNew;
-  memset(&aNew[cs->refs.nBranches], 0, sizeof(struct BranchRef));
-  aNew[cs->refs.nBranches].zName = sqlite3_mprintf("%s", zName);
-  if( !aNew[cs->refs.nBranches].zName ) return SQLITE_NOMEM;
-  memcpy(&aNew[cs->refs.nBranches].commitHash, pCommit, sizeof(ProllyHash));
+  if( csRefArrayGrow((void**)&cs->refs.aBranches, n, (int)sizeof(struct BranchRef)) ) return SQLITE_NOMEM;
+  cs->refs.aBranches[n].zName = sqlite3_mprintf("%s", zName);
+  if( !cs->refs.aBranches[n].zName ) return SQLITE_NOMEM;
+  memcpy(&cs->refs.aBranches[n].commitHash, pCommit, sizeof(ProllyHash));
   cs->refs.nBranches++;
   return SQLITE_OK;
 }
@@ -746,27 +734,26 @@ int chunkStoreAddTagFull(
   i64 timestamp,
   const char *zMessage
 ){
-  struct TagRef *aNew;
+  struct TagRef *t;
+  int n = cs->refs.nTags;
   if( chunkStoreFindTag(cs, zName, 0)==SQLITE_OK ) return SQLITE_ERROR;
-  aNew = sqlite3_realloc(cs->refs.aTags, (cs->refs.nTags+1)*(int)sizeof(struct TagRef));
-  if( !aNew ) return SQLITE_NOMEM;
-  cs->refs.aTags = aNew;
-  memset(&aNew[cs->refs.nTags], 0, sizeof(struct TagRef));
-  aNew[cs->refs.nTags].zName = sqlite3_mprintf("%s", zName);
-  if( !aNew[cs->refs.nTags].zName ) return SQLITE_NOMEM;
-  memcpy(&aNew[cs->refs.nTags].commitHash, pCommit, sizeof(ProllyHash));
-  aNew[cs->refs.nTags].zTagger  = sqlite3_mprintf("%s", zTagger  ? zTagger  : "");
-  aNew[cs->refs.nTags].zEmail   = sqlite3_mprintf("%s", zEmail   ? zEmail   : "");
-  aNew[cs->refs.nTags].zMessage = sqlite3_mprintf("%s", zMessage ? zMessage : "");
-  if( !aNew[cs->refs.nTags].zTagger || !aNew[cs->refs.nTags].zEmail || !aNew[cs->refs.nTags].zMessage ){
-    sqlite3_free(aNew[cs->refs.nTags].zName);
-    sqlite3_free(aNew[cs->refs.nTags].zTagger);
-    sqlite3_free(aNew[cs->refs.nTags].zEmail);
-    sqlite3_free(aNew[cs->refs.nTags].zMessage);
-    memset(&aNew[cs->refs.nTags], 0, sizeof(struct TagRef));
+  if( csRefArrayGrow((void**)&cs->refs.aTags, n, (int)sizeof(struct TagRef)) ) return SQLITE_NOMEM;
+  t = &cs->refs.aTags[n];
+  t->zName = sqlite3_mprintf("%s", zName);
+  if( !t->zName ) return SQLITE_NOMEM;
+  memcpy(&t->commitHash, pCommit, sizeof(ProllyHash));
+  t->zTagger  = sqlite3_mprintf("%s", zTagger  ? zTagger  : "");
+  t->zEmail   = sqlite3_mprintf("%s", zEmail   ? zEmail   : "");
+  t->zMessage = sqlite3_mprintf("%s", zMessage ? zMessage : "");
+  if( !t->zTagger || !t->zEmail || !t->zMessage ){
+    sqlite3_free(t->zName);
+    sqlite3_free(t->zTagger);
+    sqlite3_free(t->zEmail);
+    sqlite3_free(t->zMessage);
+    memset(t, 0, sizeof(struct TagRef));
     return SQLITE_NOMEM;
   }
-  aNew[cs->refs.nTags].timestamp = timestamp;
+  t->timestamp = timestamp;
   cs->refs.nTags++;
   return SQLITE_OK;
 }
@@ -788,16 +775,14 @@ int chunkStoreFindRemote(ChunkStore *cs, const char *zName, const char **pzUrl){
 }
 
 int chunkStoreAddRemote(ChunkStore *cs, const char *zName, const char *zUrl){
-  struct RemoteRef *aNew;
+  int n = cs->refs.nRemotes;
   if( chunkStoreFindRemote(cs, zName, 0)==SQLITE_OK ) return SQLITE_ERROR;
-  aNew = sqlite3_realloc(cs->refs.aRemotes, (cs->refs.nRemotes+1)*(int)sizeof(struct RemoteRef));
-  if( !aNew ) return SQLITE_NOMEM;
-  cs->refs.aRemotes = aNew;
-  aNew[cs->refs.nRemotes].zName = sqlite3_mprintf("%s", zName);
-  if( !aNew[cs->refs.nRemotes].zName ) return SQLITE_NOMEM;
-  aNew[cs->refs.nRemotes].zUrl = sqlite3_mprintf("%s", zUrl);
-  if( !aNew[cs->refs.nRemotes].zUrl ){
-    sqlite3_free(aNew[cs->refs.nRemotes].zName);
+  if( csRefArrayGrow((void**)&cs->refs.aRemotes, n, (int)sizeof(struct RemoteRef)) ) return SQLITE_NOMEM;
+  cs->refs.aRemotes[n].zName = sqlite3_mprintf("%s", zName);
+  if( !cs->refs.aRemotes[n].zName ) return SQLITE_NOMEM;
+  cs->refs.aRemotes[n].zUrl = sqlite3_mprintf("%s", zUrl);
+  if( !cs->refs.aRemotes[n].zUrl ){
+    sqlite3_free(cs->refs.aRemotes[n].zName);
     return SQLITE_NOMEM;
   }
   cs->refs.nRemotes++;
@@ -843,18 +828,16 @@ int chunkStoreUpdateTracking(ChunkStore *cs, const char *zRemote,
   }
 
   {
-    struct TrackingBranch *aNew;
-    aNew = sqlite3_realloc(cs->refs.aTracking, (cs->refs.nTracking+1)*(int)sizeof(struct TrackingBranch));
-    if( !aNew ) return SQLITE_NOMEM;
-    cs->refs.aTracking = aNew;
-    aNew[cs->refs.nTracking].zRemote = sqlite3_mprintf("%s", zRemote);
-    if( !aNew[cs->refs.nTracking].zRemote ) return SQLITE_NOMEM;
-    aNew[cs->refs.nTracking].zBranch = sqlite3_mprintf("%s", zBranch);
-    if( !aNew[cs->refs.nTracking].zBranch ){
-      sqlite3_free(aNew[cs->refs.nTracking].zRemote);
+    int n = cs->refs.nTracking;
+    if( csRefArrayGrow((void**)&cs->refs.aTracking, n, (int)sizeof(struct TrackingBranch)) ) return SQLITE_NOMEM;
+    cs->refs.aTracking[n].zRemote = sqlite3_mprintf("%s", zRemote);
+    if( !cs->refs.aTracking[n].zRemote ) return SQLITE_NOMEM;
+    cs->refs.aTracking[n].zBranch = sqlite3_mprintf("%s", zBranch);
+    if( !cs->refs.aTracking[n].zBranch ){
+      sqlite3_free(cs->refs.aTracking[n].zRemote);
       return SQLITE_NOMEM;
     }
-    memcpy(&aNew[cs->refs.nTracking].commitHash, pCommit, sizeof(ProllyHash));
+    memcpy(&cs->refs.aTracking[n].commitHash, pCommit, sizeof(ProllyHash));
     cs->refs.nTracking++;
   }
   return SQLITE_OK;


### PR DESCRIPTION
## Summary

The branch / tag / remote / sequence ref arrays each open-coded the same two idioms:
- a **linear search by name** (`findBranchIdx`/`findTagIdx`/`findRemoteIdx` in chunk_store.c, plus the four sequence-name scans in chunk_refs.c) — every ref struct stores its name as the leading `char*`;
- a **realloc-grow-by-one-and-zero** block before appending (the five `chunkStoreAdd*`/`BumpSequence` paths).

Factored into two helpers in `chunk_refs.c` (declared in `chunk_refs.h`):
- `int csFindNamedRef(const void *aBase, int n, int stride, const char *zName)` — returns the index whose leading name field equals `zName`, else -1.
- `int csRefArrayGrow(void **paBase, int n, int stride)` — realloc by one element, zero the new slot; SQLITE_OK/NOMEM.

Left as-is (deliberately): `findTrackingIdx` (two-key match), and the swap-with-last vs. order-preserving deletes (different strategies, per-type field frees — explicit teardown reads better than a forced helper).

## Behavior

Identical. The grow helper zeroes the new slot (matching the previous `memset`); the name search adds a defensive null-name guard already implied by every caller. NOMEM paths unchanged.

## Test plan

- Clean build, no warnings.
- `test/run_doltlite_tests.sh`: **80/80 suites pass** (branch/tag/remote/default-branch/sequence add/find/delete are heavily exercised).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
