### PR TITLE
Share prolly cache-or-fault node load helper

### DIFF
--- a/src/prolly_cursor.c
+++ b/src/prolly_cursor.c
@@ -5,15 +5,14 @@
 #include <string.h>
 #include <assert.h>
 
-int prollySubtreeCount(ChunkStore *pStore, ProllyCache *pCache,
-                       const ProllyHash *pHash, u64 *pCount){
-  ProllyCacheEntry *pEntry = 0;
+int prollyLoadNode(ChunkStore *pStore, ProllyCache *pCache,
+                   const ProllyHash *pHash, ProllyCacheEntry **ppEntry){
+  ProllyCacheEntry *pEntry;
   u8 *pData = 0;
   int nData = 0;
-  int rc = SQLITE_OK;
-  int i;
-  u64 sum = 0;
+  int rc;
 
+  *ppEntry = 0;
   pEntry = prollyCacheGet(pCache, pHash);
   if( !pEntry ){
     rc = chunkStoreGet(pStore, pHash, &pData, &nData);
@@ -21,6 +20,19 @@ int prollySubtreeCount(ChunkStore *pStore, ProllyCache *pCache,
     pEntry = prollyCachePutOwned(pCache, pHash, pData, nData, &rc);
     if( !pEntry ) return rc;
   }
+  *ppEntry = pEntry;
+  return SQLITE_OK;
+}
+
+int prollySubtreeCount(ChunkStore *pStore, ProllyCache *pCache,
+                       const ProllyHash *pHash, u64 *pCount){
+  ProllyCacheEntry *pEntry = 0;
+  int rc;
+  int i;
+  u64 sum = 0;
+
+  rc = prollyLoadNode(pStore, pCache, pHash, &pEntry);
+  if( rc!=SQLITE_OK ) return rc;
 
   if( pEntry->node.level==0 ){
     sum = (u64)pEntry->node.nItems;
@@ -49,31 +61,7 @@ int prollySubtreeCount(ChunkStore *pStore, ProllyCache *pCache,
 
 static int loadNode(ProllyCursor *cur, const ProllyHash *hash,
                     ProllyCacheEntry **ppEntry){
-  ProllyCacheEntry *pEntry;
-  int rc;
-  u8 *pData = 0;
-  int nData = 0;
-
-  *ppEntry = 0;
-
-  pEntry = prollyCacheGet(cur->pCache, hash);
-  if( pEntry ){
-    *ppEntry = pEntry;
-    return SQLITE_OK;
-  }
-
-  rc = chunkStoreGet(cur->pStore, hash, &pData, &nData);
-  if( rc!=SQLITE_OK ){
-    return rc;
-  }
-
-  pEntry = prollyCachePutOwned(cur->pCache, hash, pData, nData, &rc);
-  if( pEntry==0 ){
-    return rc;
-  }
-
-  *ppEntry = pEntry;
-  return SQLITE_OK;
+  return prollyLoadNode(cur->pStore, cur->pCache, hash, ppEntry);
 }
 
 static int initCursorAtRoot(ProllyCursor *cur, ProllyCacheEntry **ppRoot){

--- a/src/prolly_cursor.h
+++ b/src/prolly_cursor.h
@@ -65,4 +65,9 @@ void prollyCursorClose(ProllyCursor *cur);
 int prollySubtreeCount(ChunkStore *pStore, ProllyCache *pCache,
                        const ProllyHash *pHash, u64 *pCount);
 
+/* Get pHash's node from cache, faulting it in from the store on a miss.
+** On SQLITE_OK *ppEntry is a held entry the caller must release. */
+int prollyLoadNode(ChunkStore *pStore, ProllyCache *pCache,
+                   const ProllyHash *pHash, ProllyCacheEntry **ppEntry);
+
 #endif

--- a/src/prolly_mutate.c
+++ b/src/prolly_mutate.c
@@ -2,6 +2,7 @@
 #ifdef DOLTLITE_PROLLY
 
 #include "prolly_mutate.h"
+#include "prolly_cursor.h"
 #include "prolly_check.h"
 #include "prolly_xxhash.h"
 #include <stdio.h>
@@ -226,19 +227,11 @@ static int streamingMergeNode(
     }else{
       ProllyHash childHash;
       ProllyCacheEntry *pChildEntry;
-      u8 *pChildData = 0;
-      int nChildData = 0;
 
       assert( nChildVal == PROLLY_HASH_SIZE );
       memcpy(&childHash, pChildVal, PROLLY_HASH_SIZE);
-      pChildEntry = prollyCacheGet(pCache, &childHash);
-      if( !pChildEntry ){
-        rc = chunkStoreGet(pMut->pStore, &childHash, &pChildData, &nChildData);
-        if( rc!=SQLITE_OK ) return rc;
-        pChildEntry = prollyCachePutOwned(pCache, &childHash,
-                                          pChildData, nChildData, &rc);
-        if( !pChildEntry ) return rc;
-      }
+      rc = prollyLoadNode(pMut->pStore, pCache, &childHash, &pChildEntry);
+      if( rc!=SQLITE_OK ) return rc;
 
 #ifdef DOLTLITE_PROLLY_CHECK
       if( pChildEntry->node.level != pNode->level - 1 ){
@@ -1185,19 +1178,10 @@ static int validateReplaceBatchNode(
     if( forceDescend || subtreeHasEdits(pIter, pBoundKey, nBoundKey) ){
       ProllyHash childHash;
       ProllyCacheEntry *pChildEntry;
-      u8 *pChildData = 0;
-      int nChildData = 0;
 
       memcpy(&childHash, pChildVal, PROLLY_HASH_SIZE);
-      pChildEntry = prollyCacheGet(pMut->pCache, &childHash);
-      if( !pChildEntry ){
-        rc = chunkStoreGet(pMut->pStore, &childHash,
-                           &pChildData, &nChildData);
-        if( rc!=SQLITE_OK ) return rc;
-        pChildEntry = prollyCachePutOwned(pMut->pCache, &childHash,
-                                          pChildData, nChildData, &rc);
-        if( !pChildEntry ) return rc;
-      }
+      rc = prollyLoadNode(pMut->pStore, pMut->pCache, &childHash, &pChildEntry);
+      if( rc!=SQLITE_OK ) return rc;
       rc = validateReplaceBatchNode(pMut, &pChildEntry->node, pIter,
                                     childIsLast);
       prollyCacheRelease(pMut->pCache, pChildEntry);
@@ -1255,23 +1239,11 @@ static int replaceBatchNodeNoRechunk(
 
     if( forceDescend || subtreeHasEdits(pIter, pBoundKey, nBoundKey) ){
       ProllyCacheEntry *pChildEntry;
-      u8 *pChildData = 0;
-      int nChildData = 0;
 
-      pChildEntry = prollyCacheGet(pMut->pCache, &childHash);
-      if( !pChildEntry ){
-        rc = chunkStoreGet(pMut->pStore, &childHash,
-                           &pChildData, &nChildData);
-        if( rc!=SQLITE_OK ){
-          prollyNodeBuilderFree(&b);
-          return rc;
-        }
-        pChildEntry = prollyCachePutOwned(pMut->pCache, &childHash,
-                                          pChildData, nChildData, &rc);
-        if( !pChildEntry ){
-          prollyNodeBuilderFree(&b);
-          return rc;
-        }
+      rc = prollyLoadNode(pMut->pStore, pMut->pCache, &childHash, &pChildEntry);
+      if( rc!=SQLITE_OK ){
+        prollyNodeBuilderFree(&b);
+        return rc;
       }
       rc = replaceBatchNodeNoRechunk(pMut, &pChildEntry->node, pIter,
                                      childIsLast, &newChildHash,


### PR DESCRIPTION
## Summary

The cache-or-fault node load — `prollyCacheGet`; on miss `chunkStoreGet` + `prollyCachePutOwned`, propagating rc — was open-coded identically in five places:
- `prollySubtreeCount` preamble and the cursor's `loadNode` (prolly_cursor.c)
- three descent loops in prolly_mutate.c (`streamingMergeNode`, `validateReplaceBatchNode`, `replaceBatchNodeNoRechunk`)

Promoted to a shared `prollyLoadNode(ChunkStore*, ProllyCache*, const ProllyHash*, ProllyCacheEntry**)` in prolly_cursor (next to its twin `prollySubtreeCount`); all five sites now call it. `loadNode` stays as a one-line cursor-typed wrapper. The `replaceBatchNodeNoRechunk` site keeps its `prollyNodeBuilderFree(&b)` on the error return.

Out of scope: the separate "fetch-and-parse into a stack node" pattern (the cache-first root loads, three-way-merge, prolly_diff) — that one manages a raw buffer + stack `ProllyNode` rather than a held cache entry, so it's a different helper for a later change.

## Behavior

Identical — `prollyLoadNode` is byte-for-byte the prior inline logic; callers still release the returned entry.

## Test plan

- Clean build, no new warnings.
- `test/run_doltlite_tests.sh`: **80/80 suites pass**.
- `invariant_test`: 856/0. `three_way_diff_test`: 144/0 (direct prolly write/diff coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
