### PR TITLE
Share SQLite record assembly in doltliteBuildRecord

### DIFF
--- a/src/doltlite_merge.c
+++ b/src/doltlite_merge.c
@@ -1429,13 +1429,8 @@ static u8 *mergeBuildSchemaCatalogRecord(
   int *pnOut
 ){
   DoltliteSerialValue aMem[5];
-  u32 aType[5];
-  u32 aLen[5];
-  int i, hdrSize = 0, bodySize = 0, pos;
-  u8 *pOut, *pHdr, *pBody;
 
   memset(aMem, 0, sizeof(aMem));
-  *pnOut = 0;
 
   aMem[0].eType = SQLITE_TEXT;    aMem[0].p = zType;    aMem[0].n = (int)strlen(zType);
   aMem[1].eType = SQLITE_TEXT;    aMem[1].p = zName;    aMem[1].n = (int)strlen(zName);
@@ -1451,28 +1446,7 @@ static u8 *mergeBuildSchemaCatalogRecord(
     aMem[4].n = 0;
   }
 
-  for(i=0; i<5; i++){
-    aType[i] = doltliteSerialTypeOf(&aMem[i], &aLen[i]);
-    hdrSize += sqlite3VarintLen(aType[i]);
-    bodySize += (int)aLen[i];
-  }
-  hdrSize += sqlite3VarintLen(hdrSize);
-
-  pOut = sqlite3_malloc(hdrSize + bodySize);
-  if( !pOut ) return 0;
-
-  pos = sqlite3PutVarint(pOut, hdrSize);
-  pHdr = pOut + pos;
-  pBody = pOut + hdrSize;
-  for(i=0; i<5; i++){
-    pHdr += sqlite3PutVarint(pHdr, aType[i]);
-    if( aLen[i]>0 ){
-      doltliteSerialPut(pBody, &aMem[i], aType[i]);
-      pBody += aLen[i];
-    }
-  }
-  *pnOut = hdrSize + bodySize;
-  return pOut;
+  return doltliteBuildRecord(aMem, 5, pnOut);
 }
 
 static SchemaEntry *mergedSchemaChoice(

--- a/src/doltlite_merge_constraints.c
+++ b/src/doltlite_merge_constraints.c
@@ -311,22 +311,14 @@ static u8 *buildRecordFromStmtCols(
   int *pnOut
 ){
   DoltliteSerialValue *aMem = 0;
-  u32 *aType = 0;
-  u32 *aLen = 0;
-  u8 *pOut = 0;
-  int hdrSize = 0, bodySize = 0, i, pos;
-  u8 *pHdr, *pBody;
+  u8 *pOut;
+  int i;
 
   *pnOut = 0;
   if( nField<=0 ) return 0;
 
   aMem = sqlite3_malloc64((sqlite3_int64)nField * sizeof(DoltliteSerialValue));
-  aType = sqlite3_malloc64((sqlite3_int64)nField * sizeof(u32));
-  aLen = sqlite3_malloc64((sqlite3_int64)nField * sizeof(u32));
-  if( !aMem || !aType || !aLen ){
-    sqlite3_free(aMem); sqlite3_free(aType); sqlite3_free(aLen);
-    return 0;
-  }
+  if( !aMem ) return 0;
   memset(aMem, 0, (size_t)nField * sizeof(DoltliteSerialValue));
 
   for(i=0; i<nField; i++){
@@ -352,33 +344,10 @@ static u8 *buildRecordFromStmtCols(
       default:
         break;
     }
-    aType[i] = doltliteSerialTypeOf(&aMem[i], &aLen[i]);
-    hdrSize += sqlite3VarintLen(aType[i]);
-    bodySize += (int)aLen[i];
-  }
-  hdrSize += sqlite3VarintLen(hdrSize);
-
-  pOut = sqlite3_malloc(hdrSize + bodySize);
-  if( !pOut ){
-    sqlite3_free(aMem); sqlite3_free(aType); sqlite3_free(aLen);
-    return 0;
   }
 
-  pos = sqlite3PutVarint(pOut, hdrSize);
-  pHdr = pOut + pos;
-  pBody = pOut + hdrSize;
-  for(i=0; i<nField; i++){
-    pHdr += sqlite3PutVarint(pHdr, aType[i]);
-    if( aLen[i]>0 ){
-      doltliteSerialPut(pBody, &aMem[i], aType[i]);
-      pBody += aLen[i];
-    }
-  }
-
-  *pnOut = hdrSize + bodySize;
+  pOut = doltliteBuildRecord(aMem, nField, pnOut);
   sqlite3_free(aMem);
-  sqlite3_free(aType);
-  sqlite3_free(aLen);
   return pOut;
 }
 

--- a/src/doltlite_record.c
+++ b/src/doltlite_record.c
@@ -530,4 +530,50 @@ int doltliteBindField(
   return sqlite3_bind_null(pStmt, iParam);
 }
 
+u8 *doltliteBuildRecord(const DoltliteSerialValue *aMem, int nField, int *pnOut){
+  u32 *aType, *aLen;
+  u8 *pOut, *pHdr, *pBody;
+  int i, hdrSize = 0, bodySize = 0, pos;
+
+  *pnOut = 0;
+  if( nField<=0 ) return 0;
+
+  aType = sqlite3_malloc64((sqlite3_int64)nField * sizeof(u32));
+  aLen = sqlite3_malloc64((sqlite3_int64)nField * sizeof(u32));
+  if( !aType || !aLen ){
+    sqlite3_free(aType);
+    sqlite3_free(aLen);
+    return 0;
+  }
+
+  for(i=0; i<nField; i++){
+    aType[i] = doltliteSerialTypeOf(&aMem[i], &aLen[i]);
+    hdrSize += sqlite3VarintLen(aType[i]);
+    bodySize += (int)aLen[i];
+  }
+  hdrSize += sqlite3VarintLen(hdrSize);
+
+  pOut = sqlite3_malloc(hdrSize + bodySize);
+  if( !pOut ){
+    sqlite3_free(aType);
+    sqlite3_free(aLen);
+    return 0;
+  }
+
+  pos = sqlite3PutVarint(pOut, hdrSize);
+  pHdr = pOut + pos;
+  pBody = pOut + hdrSize;
+  for(i=0; i<nField; i++){
+    pHdr += sqlite3PutVarint(pHdr, aType[i]);
+    if( aLen[i]>0 ){
+      doltliteSerialPut(pBody, &aMem[i], aType[i]);
+      pBody += aLen[i];
+    }
+  }
+  *pnOut = hdrSize + bodySize;
+  sqlite3_free(aType);
+  sqlite3_free(aLen);
+  return pOut;
+}
+
 #endif

--- a/src/record_codec.h
+++ b/src/record_codec.h
@@ -75,4 +75,9 @@ struct DoltliteSerialValue {
 u32 doltliteSerialTypeOf(const DoltliteSerialValue *pVal, u32 *pLen);
 void doltliteSerialPut(u8 *pOut, const DoltliteSerialValue *pVal, u32 serialType);
 
+/* Assemble an SQLite-format record (header varints + body) from nField
+** serial values. Returns a sqlite3_malloc'd buffer of *pnOut bytes, or 0
+** on OOM or nField<=0. */
+u8 *doltliteBuildRecord(const DoltliteSerialValue *aMem, int nField, int *pnOut);
+
 #endif


### PR DESCRIPTION
## Summary

`mergeBuildSchemaCatalogRecord` (doltlite_merge.c) and `buildRecordFromStmtCols` (doltlite_merge_constraints.c) both built an SQLite-format record from a `DoltliteSerialValue` array, open-coding the identical assembly loop around the shared `doltliteSerialTypeOf`/`doltliteSerialPut` primitives: compute each field's serial type and length, size the header and body, `malloc`, then write the varint header and body.

Factored that loop into `doltliteBuildRecord(const DoltliteSerialValue *aMem, int nField, int *pnOut)` in `doltlite_record.c` (declared in `record_codec.h`, beside the serial primitives). Each caller now only populates the value array — fixed 5 fields for the schema catalog record; per-column from a stmt for the PK/FK records — and calls the helper.

## Behavior

Identical record bytes. `nField<=0` returns NULL (preserving `buildRecordFromStmtCols`'s prior guard); the stmt builder still frees its value array after the call.

## Test plan

- Clean build, no new warnings.
- `test/run_doltlite_tests.sh`: **80/80 suites pass** (merge, schema-merge, and constraint-violation paths build these records).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
