### PR TITLE
Tighten CI timeouts: sanitizers to 10m, cap all others at 20m

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   int-keys:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 20
 
     env:
       BENCH_RUNS: 5
@@ -116,7 +116,7 @@ jobs:
   non-int-keys:
     name: ${{ matrix.suite.name }}-keys
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 20
 
     strategy:
       fail-fast: false

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   wasm:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 20
     env:
       EMSDK_VERSION: 3.1.74
       WABT_VERSION: 1.0.36
@@ -100,7 +100,7 @@ jobs:
   build-and-test:
     name: ${{ matrix.platform }}
     runs-on: ${{ matrix.runs-on }}
-    timeout-minutes: 60
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -330,7 +330,7 @@ jobs:
         bash ../test/diff_test.sh ./doltlite
         bash ../test/config_test.sh ./doltlite
         bash ../test/blake3_kat_test.sh ./doltlite
-      timeout-minutes: 30
+      timeout-minutes: 20
 
     - name: Remote integration tests
       if: matrix.platform == 'ubuntu'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -425,7 +425,7 @@ jobs:
   # ── Run benchmarks ────────────────────────────────────────
   benchmark:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 20
     steps:
     - uses: actions/checkout@v4
 
@@ -470,7 +470,7 @@ jobs:
   # version bump fails this job, which blocks the release.
   compat:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 20
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   asan-ubsan:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 10
 
     steps:
     - uses: actions/checkout@v4
@@ -120,7 +120,7 @@ jobs:
 
   tsan:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 10
 
     env:
       TSAN_CFLAGS: -O1 -g -fsanitize=thread -fno-omit-frame-pointer

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   concurrency-stress:
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 20
 
     steps:
     - uses: actions/checkout@v4
@@ -35,7 +35,7 @@ jobs:
 
   vc-concurrency-stress:
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 20
 
     steps:
     - uses: actions/checkout@v4
@@ -128,7 +128,7 @@ jobs:
 
   sqllogictest:
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 20
 
     steps:
     - uses: actions/checkout@v4
@@ -190,7 +190,7 @@ jobs:
 
   oracle-tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 20
 
     steps:
     - uses: actions/checkout@v4
@@ -242,7 +242,7 @@ jobs:
   sqlite-regression:
     name: sqlite-regression-${{ matrix.bucket }}
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -305,7 +305,7 @@ jobs:
   # differs. Format changes without a minor version bump fail the suite.
   compat:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 20
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
## Summary

GitHub's recent `ubuntu-latest` flakiness exposed that our CI timeouts were far more generous than the jobs need — a stuck/flaky runner could hang for the full window before failing. Every job finishes in under ~15 minutes in practice, so:

- **Sanitizers** (`asan-ubsan`, `tsan`): 45 → **10** minutes.
- **All other jobs** over 20 minutes capped to **20**: `sqllogictest` 120→20, `build-and-test` 60→20, `sqlite-regression` 45→20, plus the various 25/30-minute jobs in test/build-test/benchmark/release.

Jobs already at or below 20 minutes (and `smoke.yml`) are unchanged. No change to what any job builds or runs — only the fail-fast ceiling.
