### PR TITLE
Speed up blob key node searches

### DIFF
--- a/src/prolly_node.c
+++ b/src/prolly_node.c
@@ -198,6 +198,24 @@ static SQLITE_INLINE int prollyKeyComparePrefix(
   const u8 *pRight,
   int n
 ){
+  /* Blob-key node searches compare many short keys. Check the first word
+  ** inline before calling memcmp() for any remaining suffix. */
+  if( n>=8 ){
+    u64 left = ((u64)pLeft[0]<<56) | ((u64)pLeft[1]<<48)
+             | ((u64)pLeft[2]<<40) | ((u64)pLeft[3]<<32)
+             | ((u64)pLeft[4]<<24) | ((u64)pLeft[5]<<16)
+             | ((u64)pLeft[6]<<8) | (u64)pLeft[7];
+    u64 right = ((u64)pRight[0]<<56) | ((u64)pRight[1]<<48)
+              | ((u64)pRight[2]<<40) | ((u64)pRight[3]<<32)
+              | ((u64)pRight[4]<<24) | ((u64)pRight[5]<<16)
+              | ((u64)pRight[6]<<8) | (u64)pRight[7];
+    if( left<right ) return -1;
+    if( left>right ) return 1;
+    pLeft += 8;
+    pRight += 8;
+    n -= 8;
+    if( n==0 ) return 0;
+  }
   return memcmp(pLeft, pRight, n);
 }
 


### PR DESCRIPTION
## Summary
- speed up prolly blob-key node binary search by comparing the first 8 bytes inline before falling back to memcmp() for the suffix
- improves composite-key sysbench workloads without special-casing composite key widths or sysbench SQL shapes

## Benchmark evidence
Baseline timer: /tmp/bench_timer_composite_base built from master. Candidate timer: /tmp/bench_timer_composite_prefixcmp built from this branch. Each row below alternated baseline/candidate against the same deterministic composite-PK sysbench SQL on fresh DBs.

20k rows, 21 paired runs:
- oltp_update_index: mem -2.34% median, wins 14/21; file -2.27%, wins 19/21
- select_random_points: mem -3.50%, wins 21/21; file -2.56%, wins 18/21
- index_join_scan: mem -10.09%, wins 21/21; file -8.50%, wins 20/21
- oltp_point_select: mem -2.67%, wins 19/21; file -1.16%, wins 13/21
- oltp_index_scan: mem -4.99%, wins 19/21; file -2.62%, wins 17/21

50k rows, 17 paired runs:
- oltp_update_index: mem -4.10%, wins 15/17; file -3.13%, wins 14/17
- select_random_points: mem -3.94%, wins 14/17; file -5.06%, wins 15/17
- index_join_scan: mem -15.41%, wins 17/17; file -14.32%, wins 17/17
- oltp_index_scan: mem -4.62%, wins 14/17; file -3.42%, wins 15/17

## Tests
- make doltlite
- focused composite PK SQL smoke
- bash test/review_regression_test.sh: 120 passed
- make devtest attempted, but local debug/testfixture/fuzz builds fail before running tests with existing amalgamation debug-build errors (for example conflicting sqlite3BtreeSeekCount and missing orig/sqlite3BtreeLeave* declarations in testrunner.log).