### PR TITLE
Share prolly fetch-and-parse node helper

### DIFF
--- a/src/prolly_diff.c
+++ b/src/prolly_diff.c
@@ -6,6 +6,23 @@
 
 #include <string.h>
 
+int prollyFetchNode(ChunkStore *pStore, const ProllyHash *pHash,
+                    ProllyNode *pNode, u8 **ppData){
+  u8 *pData = 0;
+  int nData = 0;
+  int rc;
+
+  rc = chunkStoreGet(pStore, pHash, &pData, &nData);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = prollyNodeParse(pNode, pData, nData);
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(pData);
+    return rc;
+  }
+  *ppData = pData;
+  return SQLITE_OK;
+}
+
 static void diffCompareKeys(
   ProllyCursor *pOld,
   ProllyCursor *pNew,
@@ -395,7 +412,6 @@ static int diffNodesOneLevel(
   ProllyHash **ppStack, int *pnStack, int *pnStackAlloc
 ){
   u8 *oldData = 0, *newData = 0;
-  int nOld = 0, nNew = 0;
   ProllyNode oldNode, newNode;
   int rc = SQLITE_OK;
 
@@ -409,15 +425,11 @@ static int diffNodesOneLevel(
     return diffEmitSubtree(pStore, pCache, pOldHash, flags, PROLLY_DIFF_DELETE, xCb, pCtx);
   }
 
-  rc = chunkStoreGet(pStore, pOldHash, &oldData, &nOld);
+  rc = prollyFetchNode(pStore, pOldHash, &oldNode, &oldData);
   if( rc!=SQLITE_OK ) return rc;
-  rc = prollyNodeParse(&oldNode, oldData, nOld);
-  if( rc!=SQLITE_OK ){ sqlite3_free(oldData); return rc; }
 
-  rc = chunkStoreGet(pStore, pNewHash, &newData, &nNew);
+  rc = prollyFetchNode(pStore, pNewHash, &newNode, &newData);
   if( rc!=SQLITE_OK ){ sqlite3_free(oldData); return rc; }
-  rc = prollyNodeParse(&newNode, newData, nNew);
-  if( rc!=SQLITE_OK ){ sqlite3_free(oldData); sqlite3_free(newData); return rc; }
 
   if( oldNode.level==0 && newNode.level==0 ){
     rc = diffLeaves(&oldNode, &newNode, flags, xCb, pCtx);

--- a/src/prolly_diff.h
+++ b/src/prolly_diff.h
@@ -76,4 +76,10 @@ int prollyDiffIterOpen(ProllyDiffIter *pIter, ChunkStore *pStore,
 int prollyDiffIterStep(ProllyDiffIter *pIter, ProllyDiffChange **ppChange);
 void prollyDiffIterClose(ProllyDiffIter *pIter);
 
+/* Fetch pHash from the store and parse it into pNode. On SQLITE_OK *ppData
+** owns the backing buffer the caller must sqlite3_free; on error nothing
+** is left allocated. */
+int prollyFetchNode(ChunkStore *pStore, const ProllyHash *pHash,
+                    ProllyNode *pNode, u8 **ppData);
+
 #endif

--- a/src/prolly_three_way_merge.c
+++ b/src/prolly_three_way_merge.c
@@ -33,15 +33,12 @@ static int fmEmitSubtreeRows(
   const ProllyHash *pSubtreeRoot
 ){
   u8 *pData = 0;
-  int nData = 0;
   ProllyNode node;
   int rc;
   int i;
 
-  rc = chunkStoreGet(fm->pStore, pSubtreeRoot, &pData, &nData);
+  rc = prollyFetchNode(fm->pStore, pSubtreeRoot, &node, &pData);
   if( rc != SQLITE_OK ) return rc;
-  rc = prollyNodeParse(&node, pData, nData);
-  if( rc != SQLITE_OK ){ sqlite3_free(pData); return rc; }
 
   if( node.level == 0 ){
     for( i = 0; i < (int)node.nItems; i++ ){
@@ -354,7 +351,6 @@ static int fmEmitChild(
 ){
   const ProllyHash *pSplice = 0;
   u8 *pAncData = 0, *pOursData = 0, *pTheirsData = 0;
-  int nAncData = 0, nOursData = 0, nTheirsData = 0;
   ProllyNode ancNode, oursNode, theirsNode;
   int rc;
 
@@ -377,19 +373,11 @@ static int fmEmitChild(
     return fmEmitSubtreeRows(fm, pCh, pSplice);
   }
 
-  rc = chunkStoreGet(fm->pStore, pAnc, &pAncData, &nAncData);
-  if( rc != SQLITE_OK ) return rc;
-  rc = prollyNodeParse(&ancNode, pAncData, nAncData);
+  rc = prollyFetchNode(fm->pStore, pAnc, &ancNode, &pAncData);
   if( rc != SQLITE_OK ) goto done;
-
-  rc = chunkStoreGet(fm->pStore, pOurs, &pOursData, &nOursData);
+  rc = prollyFetchNode(fm->pStore, pOurs, &oursNode, &pOursData);
   if( rc != SQLITE_OK ) goto done;
-  rc = prollyNodeParse(&oursNode, pOursData, nOursData);
-  if( rc != SQLITE_OK ) goto done;
-
-  rc = chunkStoreGet(fm->pStore, pTheirs, &pTheirsData, &nTheirsData);
-  if( rc != SQLITE_OK ) goto done;
-  rc = prollyNodeParse(&theirsNode, pTheirsData, nTheirsData);
+  rc = prollyFetchNode(fm->pStore, pTheirs, &theirsNode, &pTheirsData);
   if( rc != SQLITE_OK ) goto done;
 
   if( oursNode.level != ancNode.level || theirsNode.level != ancNode.level ){
@@ -424,7 +412,6 @@ int prollyThreeWayMergeFast(
   FmCtx fm;
   ProllyChunker chunker;
   u8 *pAncData = 0, *pOursData = 0, *pTheirsData = 0;
-  int nAncData = 0, nOursData = 0, nTheirsData = 0;
   ProllyNode ancNode, oursNode, theirsNode;
   int rc = SQLITE_OK;
 
@@ -452,26 +439,12 @@ int prollyThreeWayMergeFast(
     return SQLITE_OK;
   }
 
-  rc = chunkStoreGet(pStore, pAncRoot, &pAncData, &nAncData);
+  rc = prollyFetchNode(pStore, pAncRoot, &ancNode, &pAncData);
   if( rc != SQLITE_OK ) return rc;
-  rc = prollyNodeParse(&ancNode, pAncData, nAncData);
+  rc = prollyFetchNode(pStore, pOursRoot, &oursNode, &pOursData);
   if( rc != SQLITE_OK ){ sqlite3_free(pAncData); return rc; }
-
-  rc = chunkStoreGet(pStore, pOursRoot, &pOursData, &nOursData);
-  if( rc != SQLITE_OK ){ sqlite3_free(pAncData); return rc; }
-  rc = prollyNodeParse(&oursNode, pOursData, nOursData);
+  rc = prollyFetchNode(pStore, pTheirsRoot, &theirsNode, &pTheirsData);
   if( rc != SQLITE_OK ){ sqlite3_free(pAncData); sqlite3_free(pOursData); return rc; }
-
-  rc = chunkStoreGet(pStore, pTheirsRoot, &pTheirsData, &nTheirsData);
-  if( rc != SQLITE_OK ){
-    sqlite3_free(pAncData); sqlite3_free(pOursData);
-    return rc;
-  }
-  rc = prollyNodeParse(&theirsNode, pTheirsData, nTheirsData);
-  if( rc != SQLITE_OK ){
-    sqlite3_free(pAncData); sqlite3_free(pOursData); sqlite3_free(pTheirsData);
-    return rc;
-  }
 
   if( oursNode.level != ancNode.level || theirsNode.level != ancNode.level ){
     sqlite3_free(pAncData); sqlite3_free(pOursData); sqlite3_free(pTheirsData);


### PR DESCRIPTION
## Summary

The non-cached node load — `chunkStoreGet` then `prollyNodeParse` into a stack `ProllyNode`, freeing the raw buffer on any error — was open-coded in five places:
- `prolly_diff.c` (`diffNodesOneLevel`, the old/new pair)
- `prolly_three_way_merge.c`: `fmEmitSubtreeRows` (single), and the anc/ours/theirs triples in `fmEmitChild` and `fmThreeWayMergeRoots`

Factored into `prollyFetchNode(ChunkStore*, const ProllyHash*, ProllyNode*, u8 **ppData)` in `prolly_diff` (both files already include `prolly_diff.h`; no new layering). On success `*ppData` owns the buffer the caller frees; on error the helper leaves nothing allocated, so each call site keeps only its own success-path / prior-node frees.

This is the non-cached sibling of the cache-or-fault `prollyLoadNode` (#1462); the cache-first hybrids in `prolly_mutate.c` are intentionally left alone.

## Behavior

Identical — byte-for-byte the prior fetch/parse/free logic, with the per-site error cascades preserved (a later fetch failing frees only the earlier successful nodes).

## Test plan

- Clean build, no new warnings.
- `test/run_doltlite_tests.sh`: **80/80 suites pass**.
- `three_way_diff_test`: 144/0. `invariant_test`: 856/0 (direct merge/diff coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
