### PR TITLE
Speed up blob-key node searches

### DIFF
--- a/src/prolly_node.c
+++ b/src/prolly_node.c
@@ -199,6 +199,24 @@ static SQLITE_INLINE int prollyKeyComparePrefix(
   const u8 *pRight,
   int n
 ){
+  /* Blob-key node searches compare many short keys. Check the first word
+  ** inline before calling memcmp() for any remaining suffix. */
+  if( n>=8 ){
+    u64 left = ((u64)pLeft[0]<<56) | ((u64)pLeft[1]<<48)
+             | ((u64)pLeft[2]<<40) | ((u64)pLeft[3]<<32)
+             | ((u64)pLeft[4]<<24) | ((u64)pLeft[5]<<16)
+             | ((u64)pLeft[6]<<8) | (u64)pLeft[7];
+    u64 right = ((u64)pRight[0]<<56) | ((u64)pRight[1]<<48)
+              | ((u64)pRight[2]<<40) | ((u64)pRight[3]<<32)
+              | ((u64)pRight[4]<<24) | ((u64)pRight[5]<<16)
+              | ((u64)pRight[6]<<8) | (u64)pRight[7];
+    if( left<right ) return -1;
+    if( left>right ) return 1;
+    pLeft += 8;
+    pRight += 8;
+    n -= 8;
+    if( n==0 ) return 0;
+  }
   return memcmp(pLeft, pRight, n);
 }
 


### PR DESCRIPTION
## Summary

Speed up blob-key searches in prolly nodes by checking the first encoded 8-byte word inline before falling back to `memcmp()` for the remaining suffix.

This is a general node-search optimization. It is not specific to sysbench or int-key tables; int-key sysbench benefits because secondary indexes are searched as blob-key prolly trees.

## Benchmarking

Baseline was `master` at `288f2857cd`; candidate is this branch. Timers were built from `test/sysbench_timer.c` with `-O2 -DNDEBUG -DDOLTLITE_PROLLY=1` and run with workload-only `.print BENCH_START` / `.print BENCH_END` timing.

Targeted paired A/B, 50k rows, 15 paired runs, alternating baseline/candidate order:

```text
oltp_write_only        mem  pair_med= -0.29% wins=11/15
oltp_write_only        file pair_med=  0.15% wins=7/15
oltp_update_index      mem  pair_med= -1.76% wins=9/15
oltp_update_index      file pair_med= -0.89% wins=10/15
oltp_index_scan        mem  pair_med= -1.06% wins=8/15
oltp_index_scan        file pair_med= -4.31% wins=12/15
index_join_scan        mem  pair_med=-16.67% wins=15/15
index_join_scan        file pair_med=-17.01% wins=14/15
select_random_points   mem  pair_med=  0.97% wins=6/15
select_random_points   file pair_med= -0.69% wins=8/15
oltp_point_select      mem  pair_med=  2.68% wins=4/15
oltp_point_select      file pair_med= -0.27% wins=8/15
```

The `oltp_point_select` in-memory control was rerun with 31 pairs at 50k rows because it should not exercise blob-key search. That rerun did not reproduce a stable regression:

```text
select_random_points   mem  pair_med=-0.36% wins=16/31
select_random_points   file pair_med= 1.34% wins=10/31
oltp_point_select      mem  pair_med= 0.77% wins=12/31
oltp_point_select      file pair_med=-0.48% wins=19/31
```

Standard `test/sysbench_compare.sh`, 20k rows, median of 5 invocations, changed DoltLite timer:

```text
In-memory average multipliers: reads 0.97, writes 0.99
File-backed average multipliers: reads 0.99, writes 1.00
index_join_scan: 0.89x in-memory, 0.87x file-backed
All tests within ceilings.
```

## Validation

- `make doltlite`
- focused SQL smoke test for integer primary key table with secondary index
- `bash test/review_regression_test.sh` - 120 passed, 0 failed
- `make devtest` attempted, but local generated debug/O0 build targets fail before the suite runs. First errors include conflicting `sqlite3BtreeSeekCount` declarations and missing `sqlite3BtreeLeave*`/`sqlite3BtreeHoldsMutex` symbols in generated `sqlite3.c`.
