### PR TITLE
Speed up small binary sort-key encoding

### DIFF
--- a/src/sortkey.c
+++ b/src/sortkey.c
@@ -357,6 +357,7 @@ static int sortKeyFromSingleBinaryFieldFast(
   int nSize;
   int nAlloc;
   u8 *pOut;
+  int hasZero;
 
   if( !pRec || nKeyField>1 || nRec<=0 ) return SQLITE_NOTFOUND;
   if( descFromKeyInfo(pKeyInfo, 0) ) return SQLITE_NOTFOUND;
@@ -378,12 +379,15 @@ static int sortKeyFromSingleBinaryFieldFast(
   }else if( tag!=SORTKEY_BLOB ){
     return SQLITE_NOTFOUND;
   }
-  if( fieldLen>0 && memchr(pRec + dataOff, 0, fieldLen)!=0 ){
-    return SQLITE_NOTFOUND;
+  hasZero = fieldLen>0 && memchr(pRec + dataOff, 0, fieldLen)!=0;
+  if( hasZero ){
+    if( fieldLen>64 ) return SQLITE_NOTFOUND;
+    if( fieldLen > (u32)((INT_MAX - 3) / 2) ) return SQLITE_TOOBIG;
+    nSize = (int)fieldLen * 2 + 3;
+  }else{
+    if( fieldLen > (u32)INT_MAX - 3 ) return SQLITE_TOOBIG;
+    nSize = (int)fieldLen + 3;
   }
-  if( fieldLen > (u32)INT_MAX - 3 ) return SQLITE_TOOBIG;
-
-  nSize = (int)fieldLen + 3;
   nAlloc = nSize < 64 ? 64 : nSize;
   if( *pnAlloc < nAlloc ){
     u8 *pNew = (u8*)sqlite3_realloc64(*ppBuf, (sqlite3_uint64)nAlloc);
@@ -393,11 +397,15 @@ static int sortKeyFromSingleBinaryFieldFast(
   }
 
   pOut = *ppBuf;
-  pOut[0] = tag;
-  if( fieldLen>0 ) memcpy(pOut + 1, pRec + dataOff, fieldLen);
-  pOut[1 + fieldLen] = 0x00;
-  pOut[2 + fieldLen] = 0x00;
-  *pnOut = nSize;
+  if( hasZero ){
+    *pnOut = encodeVarLen(pOut, tag, pRec + dataOff, fieldLen);
+  }else{
+    pOut[0] = tag;
+    if( fieldLen>0 ) memcpy(pOut + 1, pRec + dataOff, fieldLen);
+    pOut[1 + fieldLen] = 0x00;
+    pOut[2 + fieldLen] = 0x00;
+    *pnOut = nSize;
+  }
   return SQLITE_OK;
 }
 
@@ -563,6 +571,7 @@ static int sortKeyFromSingleBinaryMemFast(
   int nSize;
   int nAlloc;
   u8 *pOut;
+  int hasZero;
 
   if( !aMem || nMem<1 || nKeyField>1 ) return SQLITE_NOTFOUND;
   if( nKeyField<=0 && nMem!=1 ) return SQLITE_NOTFOUND;
@@ -587,12 +596,15 @@ static int sortKeyFromSingleBinaryMemFast(
     return SQLITE_NOTFOUND;
   }
 
-  if( pMem->n>0 && memchr(pMem->z, 0, (size_t)pMem->n)!=0 ){
-    return SQLITE_NOTFOUND;
+  hasZero = pMem->n>0 && memchr(pMem->z, 0, (size_t)pMem->n)!=0;
+  if( hasZero ){
+    if( pMem->n>64 ) return SQLITE_NOTFOUND;
+    if( pMem->n > (INT_MAX - 3) / 2 ) return SQLITE_TOOBIG;
+    nSize = pMem->n * 2 + 3;
+  }else{
+    if( pMem->n > INT_MAX - 3 ) return SQLITE_TOOBIG;
+    nSize = pMem->n + 3;
   }
-  if( pMem->n > INT_MAX - 3 ) return SQLITE_TOOBIG;
-
-  nSize = pMem->n + 3;
   nAlloc = nSize < 64 ? 64 : nSize;
   if( *pnAlloc < nAlloc ){
     u8 *pNew = (u8*)sqlite3_realloc64(*ppBuf, (sqlite3_uint64)nAlloc);
@@ -602,11 +614,15 @@ static int sortKeyFromSingleBinaryMemFast(
   }
 
   pOut = *ppBuf;
-  pOut[0] = tag;
-  if( pMem->n>0 ) memcpy(pOut + 1, pMem->z, (size_t)pMem->n);
-  pOut[1 + pMem->n] = 0x00;
-  pOut[2 + pMem->n] = 0x00;
-  *pnOut = nSize;
+  if( hasZero ){
+    *pnOut = encodeVarLen(pOut, tag, (const u8*)pMem->z, (u32)pMem->n);
+  }else{
+    pOut[0] = tag;
+    if( pMem->n>0 ) memcpy(pOut + 1, pMem->z, (size_t)pMem->n);
+    pOut[1 + pMem->n] = 0x00;
+    pOut[2 + pMem->n] = 0x00;
+    *pnOut = nSize;
+  }
   return SQLITE_OK;
 }
 


### PR DESCRIPTION
## Summary

Keep small single-field binary sort keys on the fast path even when the value contains embedded NUL bytes.

The existing fast path handled one BLOB/TEXT field only when the raw bytes contained no NULs. BLOB primary keys often contain NULs, so they fell back to the generic two-pass encoder. This change keeps the original memcpy path for no-NUL values and directly emits the escaped varlen sort key for small NUL-containing binary values.

This is a general sort-key encoding improvement for small binary keys, not a sysbench-specific path.

## Benchmarking

Baseline was `master` at `be67d36840`; candidate is this branch. Timers were built from `test/sysbench_timer.c` with `-O2 -DNDEBUG -DDOLTLITE_PROLLY=1` and run with workload-only `.print BENCH_START` / `.print BENCH_END` timing.

Initial BLOB-PK wrapper baseline at 20k rows showed the biggest outlier as in-memory `oltp_index_scan` at 1.27x vs SQLite. I tried key-comparison changes for that read path, but they either measured as noise or regressed `index_join_scan`, so I dropped them.

The change in this PR targets the easier confirmed optimization: BLOB-key write/insert workloads that repeatedly encode small NUL-heavy BLOB keys.

Targeted paired A/B, 50k rows, 25 paired runs, alternating baseline/candidate order:

```text
oltp_insert            mem  pair_med=-0.91% wins=16/25
oltp_insert            file pair_med=-0.73% wins=18/25
oltp_bulk_insert       mem  pair_med=-2.13% wins=23/25
oltp_bulk_insert       file pair_med=-1.20% wins=18/25
oltp_point_select      mem  pair_med=-0.64% wins=14/25
oltp_point_select      file pair_med=-0.49% wins=13/25
index_join_scan        mem  pair_med=-0.28% wins=13/25
index_join_scan        file pair_med=-1.90% wins=15/25
```

After preserving the old memcpy path for no-NUL values, focused confirmation at 50k rows, 15 paired runs:

```text
oltp_insert            mem  pair_med=-0.65% wins=10/15
oltp_insert            file pair_med=-2.95% wins=9/15
oltp_bulk_insert       mem  pair_med=-3.30% wins=14/15
oltp_bulk_insert       file pair_med=-2.06% wins=12/15
index_join_scan        mem  pair_med=-1.67% wins=9/15
index_join_scan        file pair_med=-3.54% wins=9/15
```

Standard `test/sysbench_compare_blobpk.sh`, 20k rows, median of 5 invocations, changed DoltLite timer:

```text
In-memory average multipliers: reads 0.96, writes 0.99
File-backed average multipliers: reads 0.97, writes 0.99
Autocommit average multipliers: reads 0.97, writes 1.05
All tests within ceilings.
```

## Validation

- `make doltlite`
- focused SQL smoke test for BLOB primary key table with secondary index
- `bash test/review_regression_test.sh` - 120 passed, 0 failed
- `make devtest` attempted, but local generated debug/O0 build targets fail before the suite runs. First errors include conflicting `sqlite3BtreeSeekCount` declarations and missing `sqlite3BtreeLeave*`/`sqlite3BtreeHoldsMutex` symbols in generated `sqlite3.c`.
