### PR TITLE
Confirm branch tip from disk in commit/merge head CAS (fixes concurrent lost update)

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -670,6 +670,31 @@ int chunkStoreFindBranch(ChunkStore *cs, const char *zName, ProllyHash *pCommit)
   return SQLITE_OK;
 }
 
+/* Read zName's committed tip straight from disk into *pTip, leaving this
+** store's in-memory state untouched. Opens a throwaway view of the file (as
+** csReloadFromDisk does) so a commit/merge head-CAS sees a peer's advance even
+** when its force-refresh is suppressed (a reentrant lock holder, or a WAL-reuse
+** commit the file-size heuristic misses). *pFound is 0 if the branch is absent.
+** Caller must hold the chunk-store lock. */
+int chunkStoreReadDiskBranchTip(ChunkStore *cs, const char *zName,
+                                ProllyHash *pTip, int *pFound){
+  ChunkStore tmp;
+  int rc;
+
+  *pFound = 0;
+  if( cs->isMemory || !cs->file.zFilename ){
+    if( chunkStoreFindBranch(cs, zName, pTip)==SQLITE_OK ) *pFound = 1;
+    return SQLITE_OK;
+  }
+
+  rc = chunkStoreOpen(&tmp, cs->file.pVfs, cs->file.zFilename,
+                      SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB);
+  if( rc!=SQLITE_OK ) return rc;
+  if( chunkStoreFindBranch(&tmp, zName, pTip)==SQLITE_OK ) *pFound = 1;
+  chunkStoreClose(&tmp);
+  return SQLITE_OK;
+}
+
 int chunkStoreAddBranch(ChunkStore *cs, const char *zName, const ProllyHash *pCommit){
   int n = cs->refs.nBranches;
   if( chunkStoreFindBranch(cs, zName, 0)==SQLITE_OK ) return SQLITE_ERROR;

--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -198,6 +198,8 @@ int chunkStoreSetDefaultBranch(ChunkStore *cs, const char *zName);
 int chunkStoreAddBranch(ChunkStore *cs, const char *zName, const ProllyHash *pCommit);
 int chunkStoreDeleteBranch(ChunkStore *cs, const char *zName);
 int chunkStoreFindBranch(ChunkStore *cs, const char *zName, ProllyHash *pCommit);
+int chunkStoreReadDiskBranchTip(ChunkStore *cs, const char *zName,
+                                ProllyHash *pTip, int *pFound);
 int chunkStoreUpdateBranch(ChunkStore *cs, const char *zName, const ProllyHash *pCommit);
 int chunkStoreSerializeRefs(ChunkStore *cs);
 

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -164,24 +164,33 @@ static int doltliteRefreshAndConfirmHead(
 ){
   const char *zBranch;
   ProllyHash branchTip;
+  int found = 0;
   int rc;
 
   rc = chunkStoreLockAndRefresh(cs);
   if( rc!=SQLITE_OK ) return rc;
 
-  /* Reload persisted refs so this CAS compares against the true on-disk branch
-  ** tip. The lock-time change heuristic can miss a peer commit (WAL reuse
-  ** leaves the file size unchanged), and a stale tip would let a fast-forward
-  ** clobber the peer's advance. */
+  /* Refresh in-memory state so a subsequent advance builds on the current
+  ** view. This is a no-op when we hold the lock reentrantly (a VC op already
+  ** in a write transaction), so it cannot be the basis of the CAS below. */
   rc = chunkStoreForceRefresh(cs);
   if( rc!=SQLITE_OK ){
     chunkStoreUnlock(cs);
     return rc;
   }
 
+  /* Compare against the authoritative on-disk tip, read directly rather than
+  ** from the in-memory refs. The in-memory tip can be stale here: force-refresh
+  ** above is suppressed under a reentrant lock, and even the lock-time heuristic
+  ** can miss a peer commit when WAL reuse leaves the file size unchanged. A
+  ** stale tip would let this advance clobber the peer's commit (lost update). */
   zBranch = doltliteGetSessionBranch(db);
-  if( chunkStoreFindBranch(cs, zBranch, &branchTip)==SQLITE_OK
-   && prollyHashCompare(&branchTip, pExpectedHead)!=0 ){
+  rc = chunkStoreReadDiskBranchTip(cs, zBranch, &branchTip, &found);
+  if( rc!=SQLITE_OK ){
+    chunkStoreUnlock(cs);
+    return rc;
+  }
+  if( found && prollyHashCompare(&branchTip, pExpectedHead)!=0 ){
     chunkStoreUnlock(cs);
     return SQLITE_BUSY;
   }


### PR DESCRIPTION
## Summary (DRAFT — needs CI/Linux validation)

Fixes a rare concurrent-commit **lost update**: a peer's commit/merge to a branch can be silently clobbered, dropping its rows. Surfaced as the ~1/20 `merge_race_feat_rows_present` flake in `multi_process_merge_rebase_test` (the merged `feat` rows vanish from `main` while both the merger and the racing writer report success).

### Root cause

`dolt_commit` and `dolt_merge` re-confirm the branch tip under the lock right before advancing the ref (the CAS added in e6949dfc65). But that re-confirm read the **in-memory** tip, which can be stale at that point:

- The op already holds the chunk-store graph lock from inside its write transaction, so the re-confirm's `chunkStoreForceRefresh` runs **reentrantly** and hits its `lockDepth != 1` guard — it does **not** reload from disk.
- Even the lock-acquire-time refresh is heuristic (file-size / HAS_MOVED) and **misses a peer commit when WAL reuse leaves the file size unchanged**.

So the CAS compared a stale in-memory tip against itself and passed spuriously; the advance then overwrote the peer's tip. (Writes use the cached `cs->file.iFileSize`, so a passing-but-stale CAS is also where corruption could start.)

### Fix

Make the head-CAS read the **authoritative on-disk tip** instead of the in-memory refs. New `chunkStoreReadDiskBranchTip()` opens a throwaway view of the file (the same open `csReloadFromDisk` already trusts under the lock) and reads the committed branch tip without touching live state. `doltliteRefreshAndConfirmHead` now compares against that, so a peer advance is detected regardless of lock reentrancy or the size heuristic → returns `SQLITE_BUSY` → the caller retries on a freshly reloaded view. The existing `chunkStoreForceRefresh` is kept (it still updates in-memory state at depth 1).

This covers all 7 `doltliteRefreshAndConfirmHead` call sites (commit, 3-way merge, the shared cherry-pick/revert/pull helper, etc.).

### Validation

- Clean build; VC suite 80/80; corruption 70/0; multi_process 21/0; merge-race loop 40/40 locally.
- **Caveat:** the race is CI-Linux-specific (does not reproduce on macOS in ~180 local runs), so local green does **not** prove the race is closed — this needs the Sanitizers + Orphan-C-tests jobs on Linux, ideally several reruns, to confirm. Reviewing the lock/reentrancy reasoning is worthwhile before merge.

### Open follow-up (not in this PR)

A peer commit to a *different* branch via WAL-reuse could still leave a stale in-memory file view for the subsequent write (cached `iFileSize`). A complete fix would make the reentrant refresh reload committed state while preserving in-flight staged chunks; that's a heavier change worth evaluating separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
