### PR TITLE
Share the magic+version framed-blob header read/write

### DIFF
--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -77,11 +77,8 @@ int doltliteSerializeConflicts(
   if( !buf ) return SQLITE_NOMEM;
   w.p = buf;
 
-  dlWriteU8(&w, DOLTLITE_CONFLICTS_MAGIC0);
-  dlWriteU8(&w, DOLTLITE_CONFLICTS_MAGIC1);
-  dlWriteU8(&w, DOLTLITE_CONFLICTS_MAGIC2);
-  dlWriteU8(&w, DOLTLITE_CONFLICTS_VERSION);
-  dlWriteU16(&w, nTables);
+  dlWriteFramedHeader(&w, DOLTLITE_CONFLICTS_MAGIC0, DOLTLITE_CONFLICTS_MAGIC1,
+                      DOLTLITE_CONFLICTS_MAGIC2, DOLTLITE_CONFLICTS_VERSION, nTables);
   for(i=0; i<nTables; i++){
     int nl = aTables[i].zName ? (int)strlen(aTables[i].zName) : 0;
     dlWriteU16Name(&w, aTables[i].zName, nl);
@@ -121,14 +118,12 @@ static int loadAllConflicts(
   if( nData<(4+2) ){ sqlite3_free(data); return SQLITE_CORRUPT; }
 
   dlReaderInit(&r, data, nData);
-  if( dlReadU8(&r)!=DOLTLITE_CONFLICTS_MAGIC0
-   || dlReadU8(&r)!=DOLTLITE_CONFLICTS_MAGIC1
-   || dlReadU8(&r)!=DOLTLITE_CONFLICTS_MAGIC2
-   || dlReadU8(&r)!=DOLTLITE_CONFLICTS_VERSION ){
+  if( dlReadFramedHeader(&r, DOLTLITE_CONFLICTS_MAGIC0, DOLTLITE_CONFLICTS_MAGIC1,
+                         DOLTLITE_CONFLICTS_MAGIC2, DOLTLITE_CONFLICTS_VERSION,
+                         &nTables)!=SQLITE_OK ){
     sqlite3_free(data);
     return SQLITE_CORRUPT;
   }
-  nTables = dlReadU16(&r);
 
   aTables = sqlite3_malloc(nTables * (int)sizeof(ConflictTableInfo));
   if( !aTables ){ sqlite3_free(data); return SQLITE_NOMEM; }

--- a/src/doltlite_constraint_violations.c
+++ b/src/doltlite_constraint_violations.c
@@ -103,11 +103,7 @@ static int serializeViolations(
   if( !buf ) return SQLITE_NOMEM;
   w.p = buf;
 
-  dlWriteU8(&w, DCV_MAGIC0);
-  dlWriteU8(&w, DCV_MAGIC1);
-  dlWriteU8(&w, DCV_MAGIC2);
-  dlWriteU8(&w, DCV_VERSION);
-  dlWriteU16(&w, nTables);
+  dlWriteFramedHeader(&w, DCV_MAGIC0, DCV_MAGIC1, DCV_MAGIC2, DCV_VERSION, nTables);
 
   for(i=0; i<nTables; i++){
     int nl = aTables[i].zName ? (int)strlen(aTables[i].zName) : 0;
@@ -151,15 +147,11 @@ static int loadAllViolations(
   if( nData<(4+2) ){ sqlite3_free(data); return SQLITE_CORRUPT; }
 
   dlReaderInit(&rd, data, nData);
-  if( dlReadU8(&rd)!=DCV_MAGIC0
-   || dlReadU8(&rd)!=DCV_MAGIC1
-   || dlReadU8(&rd)!=DCV_MAGIC2
-   || dlReadU8(&rd)!=DCV_VERSION ){
+  if( dlReadFramedHeader(&rd, DCV_MAGIC0, DCV_MAGIC1, DCV_MAGIC2, DCV_VERSION,
+                         &nTables)!=SQLITE_OK ){
     sqlite3_free(data);
     return SQLITE_CORRUPT;
   }
-  nTables = dlReadU16(&rd);
-  if( nTables<0 ){ sqlite3_free(data); return SQLITE_CORRUPT; }
 
   aTables = sqlite3_malloc(nTables ? nTables * (int)sizeof(*aTables) : 1);
   if( !aTables ){ sqlite3_free(data); return SQLITE_NOMEM; }

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -715,6 +715,26 @@ static SQLITE_INLINE void dlWriteU16Name(DlByteWriter *w, const char *z, int n){
   w->p += n;
 }
 
+/* Magic (3 bytes) + version + a u16 table count: the framed header shared by
+** the conflicts and constraint-violation session blobs. */
+static SQLITE_INLINE void dlWriteFramedHeader(DlByteWriter *w, u8 m0, u8 m1,
+                                              u8 m2, u8 ver, int nTables){
+  dlWriteU8(w, m0);
+  dlWriteU8(w, m1);
+  dlWriteU8(w, m2);
+  dlWriteU8(w, ver);
+  dlWriteU16(w, nTables);
+}
+
+static SQLITE_INLINE int dlReadFramedHeader(DlByteReader *r, u8 m0, u8 m1,
+                                            u8 m2, u8 ver, int *pnTables){
+  int a = dlReadU8(r), b = dlReadU8(r), c = dlReadU8(r), v = dlReadU8(r);
+  int n = dlReadU16(r);
+  if( r->err || a!=m0 || b!=m1 || c!=m2 || v!=ver ) return SQLITE_CORRUPT;
+  *pnTables = n;
+  return SQLITE_OK;
+}
+
 ChunkStore *doltliteGetChunkStore(sqlite3 *db);
 BtShared *doltliteGetBtShared(sqlite3 *db);
 int doltliteIsStockSqliteDb(sqlite3 *db);


### PR DESCRIPTION
## Summary

`doltlite_conflicts.c` and `doltlite_constraint_violations.c` write/read the same framed-blob header: a 3-byte magic + version byte + a u16 table count. Factor that into `dlWriteFramedHeader` / `dlReadFramedHeader` (in `doltlite_internal.h`, beside the existing `dl*` byte helpers). Both serialize and load paths now share it.

Scope is deliberately just the header. The two blobs' **per-row payloads genuinely differ** (conflicts: key + intKey + base/our/their values; violations: type + key + intKey + value + info string), as do their table structs, cursors, and vtab column layouts — so a generic descriptor/callback codec would be a readability loss for two callers. The shared low-level pieces (the `dl*` byte primitives, `DoltliteConflictRow`, `doltliteArrayRemoveAt`) were already factored in earlier passes; this is the last clean verbatim bit.

`dlReadFramedHeader` returns `SQLITE_CORRUPT` on a magic/version mismatch or short read (it checks the reader's `err`), folding away the now-redundant `nTables<0` guard on the violations side (a `u16` is never negative).

## Test plan

- Clean build, no new warnings.
- `test/run_doltlite_tests.sh`: **80/80** (conflict + constraint-violation serialize/load round-trips run through the merge suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
