### PR TITLE
Optimize dolt_diff to_commit lookups

### DIFF
--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -519,6 +519,89 @@ static int buildWorkingDiffPair(
   return rc;
 }
 
+static int buildCommitDiffPair(
+  DiffTblCursor *pCur,
+  sqlite3 *db,
+  const char *zTableName,
+  const char *zToCommit
+){
+  ProllyHash toHash;
+  ProllyHash fromHash;
+  ProllyHash fromTblRoot, toTblRoot;
+  ProllyHash fromCatHash, toCatHash;
+  ProllyHash fromSchemaHash, toSchemaHash;
+  DoltliteCommit toCommit;
+  u8 fromFlags = 0;
+  u8 toFlags = 0;
+  i64 fromDate = 0;
+  char zToLabel[PROLLY_HASH_SIZE*2+1];
+  const ProllyHash *pParent;
+  int rc;
+
+  if( !zToCommit ) return SQLITE_OK;
+
+  memset(&toHash, 0, sizeof(toHash));
+  memset(&fromHash, 0, sizeof(fromHash));
+  memset(&fromTblRoot, 0, sizeof(fromTblRoot));
+  memset(&toTblRoot, 0, sizeof(toTblRoot));
+  memset(&fromCatHash, 0, sizeof(fromCatHash));
+  memset(&toCatHash, 0, sizeof(toCatHash));
+  memset(&fromSchemaHash, 0, sizeof(fromSchemaHash));
+  memset(&toSchemaHash, 0, sizeof(toSchemaHash));
+  memset(&toCommit, 0, sizeof(toCommit));
+  memset(zToLabel, 0, sizeof(zToLabel));
+
+  rc = doltliteResolveRef(db, zToCommit, &toHash);
+  if( rc!=SQLITE_OK ) return SQLITE_OK;
+
+  rc = doltliteLoadCommit(db, &toHash, &toCommit);
+  if( rc!=SQLITE_OK ) return rc;
+  memcpy(&toCatHash, &toCommit.catalogHash, sizeof(ProllyHash));
+  rc = doltliteLoadTableRootByNameOrEmpty(db, &toCatHash, zTableName,
+                                          &toTblRoot, &toFlags,
+                                          &toSchemaHash);
+  if( rc!=SQLITE_OK ){
+    doltliteCommitClear(&toCommit);
+    return rc;
+  }
+
+  pParent = doltliteCommitParentHash(&toCommit, 0);
+  if( pParent && !prollyHashIsEmpty(pParent) ){
+    DoltliteCommit fromCommit;
+    memset(&fromCommit, 0, sizeof(fromCommit));
+    fromHash = *pParent;
+    rc = doltliteLoadCommit(db, &fromHash, &fromCommit);
+    if( rc==SQLITE_OK ){
+      memcpy(&fromCatHash, &fromCommit.catalogHash, sizeof(ProllyHash));
+      fromDate = fromCommit.timestamp;
+      rc = doltliteLoadTableRootByNameOrEmpty(db, &fromCatHash, zTableName,
+                                              &fromTblRoot, &fromFlags,
+                                              &fromSchemaHash);
+    }
+    doltliteCommitClear(&fromCommit);
+    if( rc!=SQLITE_OK ){
+      doltliteCommitClear(&toCommit);
+      return rc;
+    }
+  }
+
+  if( prollyHashCompare(&fromTblRoot, &toTblRoot)==0
+   && prollyHashCompare(&fromSchemaHash, &toSchemaHash)==0 ){
+    doltliteCommitClear(&toCommit);
+    return SQLITE_OK;
+  }
+
+  if( !fromFlags ) fromFlags = toFlags;
+  if( !toFlags ) toFlags = fromFlags;
+  doltliteHashToHex(&toHash, zToLabel);
+  rc = pairsAppend(pCur, &fromHash, &fromTblRoot, &fromCatHash,
+                   &fromSchemaHash, fromFlags, fromDate,
+                   zToLabel, &toTblRoot, &toCatHash, &toSchemaHash,
+                   toFlags, toCommit.timestamp);
+  doltliteCommitClear(&toCommit);
+  return rc;
+}
+
 static int buildSliceDiffPair(
   DiffTblCursor *pCur,
   sqlite3 *db,
@@ -914,7 +997,7 @@ static int dtFilter(sqlite3_vtab_cursor *cur,
     if( zToCommit && sqlite3_stricmp(zToCommit, "WORKING")==0 ){
       rc = buildWorkingDiffPair(c, db, pVtab->zTableName);
     }else{
-      rc = buildDiffPairs(c, db, pVtab->zTableName);
+      rc = buildCommitDiffPair(c, db, pVtab->zTableName, zToCommit);
     }
   }else{
 

--- a/test/doltlite_diff_table.sh
+++ b/test/doltlite_diff_table.sh
@@ -33,6 +33,8 @@ run_test_match "multi_has_added" "SELECT count(*) FROM dolt_diff_t WHERE diff_ty
 run_test_match "multi_has_modified" "SELECT count(*) FROM dolt_diff_t WHERE diff_type='modified';" "^1$" "$DB"
 
 run_test "multi_commits" "SELECT count(DISTINCT to_commit) FROM dolt_diff_t;" "3" "$DB"
+run_test "multi_to_commit_count" "SELECT count(*) FROM dolt_diff_t WHERE to_commit=(SELECT commit_hash FROM dolt_log WHERE message='c2');" "1" "$DB"
+run_test "multi_to_commit_row" "SELECT diff_type || ':' || coalesce(to_id, from_id) FROM dolt_diff_t WHERE to_commit=(SELECT commit_hash FROM dolt_log WHERE message='c2');" "added:2" "$DB"
 
 rm -f "$DB"
 


### PR DESCRIPTION
## Summary
- Add a direct commit-to-parent diff path for dolt_diff_<table> when to_commit is constrained.
- Avoid walking the full history for non-WORKING to_commit equality lookups.
- Add regression coverage for filtering to a middle commit.

## Performance
Synthetic 301-commit history, 200 repeated queries of:

```sql
SELECT count(*) FROM dolt_diff_t
WHERE to_commit=(SELECT commit_hash FROM dolt_log WHERE message='c150');
```

- Baseline median: 220.165 ms
- Optimized median: 39.909 ms
- Approximately 5.5x faster for this access pattern.

## Tests
- make sqlite3
- bash test/doltlite_diff_table.sh: 41 passed, 0 failed
- git diff --check

Note: make devtest currently fails in unrelated debug/testfixture build setup with btree symbol conflicts and missing tommath linkage before this test path runs.