### PR TITLE
Index VC diff catalog comparisons

### DIFF
--- a/src/doltlite_diff.c
+++ b/src/doltlite_diff.c
@@ -112,6 +112,7 @@ struct DoltliteDiffCursor {
   DoltliteCommitQueue queue;
   DiffSummaryRow *aBatch;
   int nBatch;
+  int nBatchAlloc;
   int iBatch;
   char *zFilterTable;
   int phase;
@@ -141,6 +142,89 @@ static const char *diffSchema =
 #define DIFF_COL_SCHEMA_CHANGE 6
 #define DIFF_COL_TABLE_NAME    7
 
+typedef struct DiffNameSlot DiffNameSlot;
+struct DiffNameSlot {
+  const char *zName;
+  int iEntry;
+};
+
+typedef struct DiffNameIndex DiffNameIndex;
+struct DiffNameIndex {
+  struct TableEntry *aEntry;
+  DiffNameSlot *aSlot;
+  int nSlot;
+};
+
+static u32 diffStringHash(const char *z){
+  u32 h = 2166136261u;
+  while( z && *z ){
+    h ^= (unsigned char)*z;
+    h *= 16777619u;
+    z++;
+  }
+  return h;
+}
+
+static int diffNameIndexInit(
+  DiffNameIndex *pIdx,
+  struct TableEntry *aEntry,
+  int nEntry
+){
+  int i;
+  int nSlot = 16;
+
+  memset(pIdx, 0, sizeof(*pIdx));
+  pIdx->aEntry = aEntry;
+  if( nEntry<=0 ) return SQLITE_OK;
+
+  while( nSlot < nEntry*2 ) nSlot *= 2;
+  pIdx->aSlot = sqlite3_malloc(nSlot * (int)sizeof(DiffNameSlot));
+  if( !pIdx->aSlot ) return SQLITE_NOMEM;
+  memset(pIdx->aSlot, 0, nSlot * (int)sizeof(DiffNameSlot));
+  pIdx->nSlot = nSlot;
+
+  for(i=0; i<nEntry; i++){
+    u32 slot;
+    if( !aEntry[i].zName ) continue;
+    slot = diffStringHash(aEntry[i].zName) & (u32)(nSlot - 1);
+    while( pIdx->aSlot[slot].zName ){
+      if( strcmp(pIdx->aSlot[slot].zName, aEntry[i].zName)==0 ){
+        break;
+      }
+      slot = (slot + 1) & (u32)(nSlot - 1);
+    }
+    if( !pIdx->aSlot[slot].zName ){
+      pIdx->aSlot[slot].zName = aEntry[i].zName;
+      pIdx->aSlot[slot].iEntry = i + 1;
+    }
+  }
+  return SQLITE_OK;
+}
+
+static void diffNameIndexFree(DiffNameIndex *pIdx){
+  sqlite3_free(pIdx->aSlot);
+  memset(pIdx, 0, sizeof(*pIdx));
+}
+
+static struct TableEntry *diffNameIndexFind(
+  const DiffNameIndex *pIdx,
+  const char *zName
+){
+  u32 slot;
+  int i;
+  if( !zName || pIdx->nSlot==0 ) return 0;
+  slot = diffStringHash(zName) & (u32)(pIdx->nSlot - 1);
+  for(i=0; i<pIdx->nSlot; i++){
+    DiffNameSlot *pSlot = &pIdx->aSlot[slot];
+    if( !pSlot->zName ) return 0;
+    if( strcmp(pSlot->zName, zName)==0 ){
+      return &pIdx->aEntry[pSlot->iEntry - 1];
+    }
+    slot = (slot + 1) & (u32)(pIdx->nSlot - 1);
+  }
+  return 0;
+}
+
 static void freeBatch(DoltliteDiffCursor *pCur){
   int i;
   for(i=0; i<pCur->nBatch; i++){
@@ -152,6 +236,7 @@ static void freeBatch(DoltliteDiffCursor *pCur){
   sqlite3_free(pCur->aBatch);
   pCur->aBatch = 0;
   pCur->nBatch = 0;
+  pCur->nBatchAlloc = 0;
   pCur->iBatch = 0;
 }
 
@@ -161,14 +246,19 @@ static int batchAppend(DoltliteDiffCursor *pCur,
                        const DoltliteCommit *pCommit,
                        u8 dataChange, u8 schemaChange){
   DiffSummaryRow *aNew, *r;
+  int nNew;
   if( pCur->zFilterTable && strcmp(pCur->zFilterTable, zTableName)!=0 ){
     return SQLITE_OK;
   }
-  aNew = sqlite3_realloc(pCur->aBatch,
-                         (pCur->nBatch+1)*(int)sizeof(DiffSummaryRow));
-  if( !aNew ) return SQLITE_NOMEM;
-  pCur->aBatch = aNew;
-  r = &aNew[pCur->nBatch];
+  if( pCur->nBatch>=pCur->nBatchAlloc ){
+    nNew = pCur->nBatchAlloc ? pCur->nBatchAlloc*2 : 16;
+    aNew = sqlite3_realloc(pCur->aBatch,
+                           nNew*(int)sizeof(DiffSummaryRow));
+    if( !aNew ) return SQLITE_NOMEM;
+    pCur->aBatch = aNew;
+    pCur->nBatchAlloc = nNew;
+  }
+  r = &pCur->aBatch[pCur->nBatch];
   memset(r, 0, sizeof(*r));
   memcpy(r->zCommitHex, zCommitHex, PROLLY_HASH_SIZE*2+1);
   r->zTableName = sqlite3_mprintf("%s", zTableName ? zTableName : "");
@@ -203,6 +293,16 @@ static int diffCatalogPair(
   const char *zHex, const DoltliteCommit *pCommit
 ){
   int rc = SQLITE_OK, i;
+  DiffNameIndex childIdx;
+  DiffNameIndex parentIdx;
+  memset(&childIdx, 0, sizeof(childIdx));
+  memset(&parentIdx, 0, sizeof(parentIdx));
+
+  rc = diffNameIndexInit(&childIdx, aChild, nChild);
+  if( rc!=SQLITE_OK ) goto diff_done;
+  rc = diffNameIndexInit(&parentIdx, aParent, nParent);
+  if( rc!=SQLITE_OK ) goto diff_done;
+
   for(i=0; i<nChild; i++){
     struct TableEntry *e = &aChild[i];
     struct TableEntry *p;
@@ -219,11 +319,11 @@ static int diffCatalogPair(
           schemaHasAnyViewOrTrigger(db, pOldRoot, e->flags) ? 0 : 1;
         rc = batchAppend(pCur, zHex, "dolt_schemas", pCommit,
                          1, schemaChangeFlag);
-        if( rc!=SQLITE_OK ) return rc;
+        if( rc!=SQLITE_OK ) goto diff_done;
       }
       continue;
     }
-    p = doltliteFindTableByName(aParent, nParent, e->zName);
+    p = diffNameIndexFind(&parentIdx, e->zName);
     if( !p ){
       dataChange = 1;
       schemaChange = 1;
@@ -233,15 +333,18 @@ static int diffCatalogPair(
       if( !dataChange && !schemaChange ) continue;
     }
     rc = batchAppend(pCur, zHex, e->zName, pCommit, dataChange, schemaChange);
-    if( rc!=SQLITE_OK ) return rc;
+    if( rc!=SQLITE_OK ) goto diff_done;
   }
   for(i=0; i<nParent; i++){
     struct TableEntry *p = &aParent[i];
     if( !p->zName ) continue;
-    if( doltliteFindTableByName(aChild, nChild, p->zName) ) continue;
+    if( diffNameIndexFind(&childIdx, p->zName) ) continue;
     rc = batchAppend(pCur, zHex, p->zName, pCommit, 1, 1);
-    if( rc!=SQLITE_OK ) return rc;
+    if( rc!=SQLITE_OK ) goto diff_done;
   }
+diff_done:
+  diffNameIndexFree(&childIdx);
+  diffNameIndexFree(&parentIdx);
   return rc;
 }
 

--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -83,6 +83,7 @@ struct DiffTblCursor {
 
   DiffPair *aPairs;
   int nPairs;
+  int nPairsAlloc;
   int iPair;
   int pairsDone;
 
@@ -245,11 +246,16 @@ static int pairsAppend(DiffTblCursor *pCur,
                        const ProllyHash *pToSchemaHash,
                        u8 toFlags, i64 toDate){
   DiffPair *aNew, *r;
-  aNew = sqlite3_realloc(pCur->aPairs,
-                         (pCur->nPairs+1)*(int)sizeof(DiffPair));
-  if( !aNew ) return SQLITE_NOMEM;
-  pCur->aPairs = aNew;
-  r = &aNew[pCur->nPairs++];
+  int nNew;
+  if( pCur->nPairs>=pCur->nPairsAlloc ){
+    nNew = pCur->nPairsAlloc ? pCur->nPairsAlloc*2 : 16;
+    aNew = sqlite3_realloc(pCur->aPairs,
+                           nNew*(int)sizeof(DiffPair));
+    if( !aNew ) return SQLITE_NOMEM;
+    pCur->aPairs = aNew;
+    pCur->nPairsAlloc = nNew;
+  }
+  r = &pCur->aPairs[pCur->nPairs++];
   memset(r, 0, sizeof(*r));
   r->fromHash       = *pFromHash;
   r->fromTblRoot    = *pFromTblRoot;
@@ -891,6 +897,7 @@ static int dtFilter(sqlite3_vtab_cursor *cur,
   sqlite3_free(c->aPairs);
   c->aPairs = 0;
   c->nPairs = 0;
+  c->nPairsAlloc = 0;
   c->iPair = 0;
   c->pairsDone = 0;
   c->hasRow = 0;

--- a/src/doltlite_status.c
+++ b/src/doltlite_status.c
@@ -44,7 +44,7 @@ struct DoltliteStatusVtab { sqlite3_vtab base; sqlite3 *db; };
 typedef struct DoltliteStatusCursor DoltliteStatusCursor;
 struct DoltliteStatusCursor {
   sqlite3_vtab_cursor base;
-  StatusRow *aRows; int nRows; int iRow;
+  StatusRow *aRows; int nRows; int nRowsAlloc; int iRow;
 };
 
 static void statusFreeRows(DoltliteStatusCursor *pCur){
@@ -55,6 +55,7 @@ static void statusFreeRows(DoltliteStatusCursor *pCur){
   sqlite3_free(pCur->aRows);
   pCur->aRows = 0;
   pCur->nRows = 0;
+  pCur->nRowsAlloc = 0;
 }
 
 static const char *statusSchema =
@@ -201,14 +202,21 @@ static int statusTableName(sqlite3 *db, const struct TableEntry *pEntry, char **
 
 static int addRow(DoltliteStatusCursor *pCur, const char *zName,
                   int staged, const char *zStatus){
-  StatusRow *aNew = sqlite3_realloc(pCur->aRows,
-      (pCur->nRows+1)*(int)sizeof(StatusRow));
-  if( !aNew ) return SQLITE_NOMEM;
-  pCur->aRows = aNew;
-  aNew[pCur->nRows].zName = sqlite3_mprintf("%s", zName);
-  if( !aNew[pCur->nRows].zName ) return SQLITE_NOMEM;
-  aNew[pCur->nRows].staged = staged;
-  aNew[pCur->nRows].zStatus = zStatus;
+  StatusRow *aNew;
+  StatusRow *pRow;
+  int nNew;
+  if( pCur->nRows>=pCur->nRowsAlloc ){
+    nNew = pCur->nRowsAlloc ? pCur->nRowsAlloc*2 : 16;
+    aNew = sqlite3_realloc(pCur->aRows, nNew*(int)sizeof(StatusRow));
+    if( !aNew ) return SQLITE_NOMEM;
+    pCur->aRows = aNew;
+    pCur->nRowsAlloc = nNew;
+  }
+  pRow = &pCur->aRows[pCur->nRows];
+  pRow->zName = sqlite3_mprintf("%s", zName);
+  if( !pRow->zName ) return SQLITE_NOMEM;
+  pRow->staged = staged;
+  pRow->zStatus = zStatus;
   pCur->nRows++;
   return SQLITE_OK;
 }


### PR DESCRIPTION
## Summary
- Add temporary catalog name indexes while building dolt_diff summary rows.
- Avoid repeated linear name scans when comparing child and parent catalogs.
- Grow VC result buffers geometrically for dolt_diff, dolt_diff_<table>, and dolt_status.

## Performance
Synthetic repo with 1200 tables, one modified working table, 100 repeated queries of:

```sql
SELECT count(*) FROM dolt_diff WHERE commit_hash='WORKING';
```

- Baseline median: 1524.839 ms
- Optimized median: 1175.742 ms
- About 23% faster for this many-table catalog diff workload.

## Tests
- make sqlite3
- bash test/doltlite_diff.sh: 40 passed, 0 failed
- bash test/doltlite_diff_table.sh: 39 passed, 0 failed
- bash test/vc_oracle_status_test.sh: 23 passed, 0 failed
- git diff --check

Note: make devtest still fails in unrelated debug/testfixture setup with btree symbol conflicts and missing tommath linkage before these tests run.