### PR TITLE
Push down status staged filters

### DIFF
--- a/src/doltlite_status.c
+++ b/src/doltlite_status.c
@@ -10,6 +10,8 @@
 #include "doltlite_ignore.h"
 #include "prolly_cursor.h"
 
+#define STATUS_IDX_STAGED_EQ 0x01
+
 typedef struct StatusRow StatusRow;
 struct StatusRow {
   char *zName;
@@ -516,14 +518,18 @@ static int statusFilter(sqlite3_vtab_cursor *pCursor,
   ChunkStore *cs = doltliteGetChunkStore(db);
   ProllyHash headCatHash, stagedCatHash, workingCatHash;
   struct TableEntry *aHead = 0, *aStaged = 0, *aWorking = 0;
-  int nHead = 0, nStaged = 0, nWorking = 0, rc;
-  (void)idxNum;
+  int nHead = 0, nStaged = 0, nWorking = 0, rc = SQLITE_OK;
+  int iStagedOnly = -1;
   (void)idxStr;
-  (void)argc;
-  (void)argv;
 
   statusFreeRows(pCur);
   pCur->iRow = 0;
+  if( idxNum & STATUS_IDX_STAGED_EQ ){
+    if( argc<1 ) return SQLITE_OK;
+    iStagedOnly = sqlite3_value_int(argv[0]);
+    if( iStagedOnly!=0 && iStagedOnly!=1 ) return SQLITE_OK;
+  }
+
   if( !cs ){
     if( doltliteIsStockSqliteDb(db) ){
       pCursor->pVtab->zErrMsg = sqlite3_mprintf("%s",
@@ -533,28 +539,34 @@ static int statusFilter(sqlite3_vtab_cursor *pCursor,
     return SQLITE_OK;
   }
 
+  doltliteGetSessionStaged(db, &stagedCatHash);
+  if( iStagedOnly==1 && prollyHashIsEmpty(&stagedCatHash) ){
+    goto status_done;
+  }
+
   rc = doltliteGetHeadCatalogHash(db, &headCatHash);
   if( rc != SQLITE_OK ) goto status_done;
   rc = doltliteLoadCatalog(db, &headCatHash, &aHead, &nHead, 0);
   if( rc != SQLITE_OK ) goto status_done;
 
-  doltliteGetSessionStaged(db, &stagedCatHash);
   if( !prollyHashIsEmpty(&stagedCatHash) ){
     rc = doltliteLoadCatalog(db, &stagedCatHash, &aStaged, &nStaged, 0);
     if( rc != SQLITE_OK ) goto status_done;
   }
 
-  rc = doltliteFlushCatalogToHash(db, &workingCatHash);
-  if( rc == SQLITE_OK ){
-    rc = doltliteLoadCatalog(db, &workingCatHash, &aWorking, &nWorking, 0);
+  if( iStagedOnly!=1 ){
+    rc = doltliteFlushCatalogToHash(db, &workingCatHash);
+    if( rc == SQLITE_OK ){
+      rc = doltliteLoadCatalog(db, &workingCatHash, &aWorking, &nWorking, 0);
+    }
+    if( rc != SQLITE_OK ) goto status_done;
   }
-  if( rc != SQLITE_OK ) goto status_done;
 
-  if( aStaged ){
+  if( aStaged && iStagedOnly!=0 ){
     rc = compareCatalogs(pCur, db, aHead, nHead, aStaged, nStaged, 1);
     if( rc != SQLITE_OK ) goto status_done;
   }
-  {
+  if( iStagedOnly!=1 ){
     struct TableEntry *aBase = aStaged ? aStaged : aHead;
     int nBase = aStaged ? nStaged : nHead;
     if( aWorking && aBase ){
@@ -603,8 +615,28 @@ static int statusRowid(sqlite3_vtab_cursor *pCursor, sqlite3_int64 *pRowid){
   return SQLITE_OK;
 }
 static int statusBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
+  int i;
+  int iStagedEq = -1;
   (void)pVtab;
-  pInfo->estimatedCost = 100.0;
+
+  for(i=0; i<pInfo->nConstraint; i++){
+    const struct sqlite3_index_constraint *pC = &pInfo->aConstraint[i];
+    if( !pC->usable ) continue;
+    if( pC->iColumn==1 && pC->op==SQLITE_INDEX_CONSTRAINT_EQ ){
+      iStagedEq = i;
+      break;
+    }
+  }
+
+  if( iStagedEq>=0 ){
+    pInfo->aConstraintUsage[iStagedEq].argvIndex = 1;
+    pInfo->idxNum = STATUS_IDX_STAGED_EQ;
+    pInfo->estimatedCost = 50.0;
+    pInfo->estimatedRows = 10;
+  }else{
+    pInfo->idxNum = 0;
+    pInfo->estimatedCost = 100.0;
+  }
   return SQLITE_OK;
 }
 


### PR DESCRIPTION
## Summary
- add `staged = ?` constraint pushdown for `dolt_status`
- skip staged comparison for `staged = 0` queries and skip working-tree flush/load/comparison for `staged = 1` queries
- short-circuit `staged = 1` when there is no staged catalog

## Performance
Benchmark database: 1200 tables with staged modifications. Query shape:

```sql
SELECT count(*) FROM dolt_status WHERE staged = 1;
```

50 repeated constrained lookups in one SQLite process:

| Build | Run 1 | Run 2 | Run 3 | Run 4 | Run 5 |
| --- | ---: | ---: | ---: | ---: | ---: |
| baseline `origin/master` | 0.93s | 1.01s | 0.92s | 0.94s | 0.95s |
| optimized | 0.40s | 0.40s | 0.40s | 0.40s | 0.42s |

This is a stable ~2.2-2.5x speedup for staged-only status queries, well beyond run-to-run noise.

## Tests
- `rm -f sqlite3 sqlite3.c .target_source && make sqlite3`
- `bash test/vc_oracle_status_test.sh ./sqlite3`
- `bash test/vc_oracle_add_test.sh ./sqlite3`
- `bash test/vc_oracle_reset_test.sh ./sqlite3`
- direct checks on benchmark DB:
  - `staged=1` -> `1200`
  - `staged=0` -> `0`
  - `staged=2` -> `0`
  - `staged='abc'` -> `0`
- `git diff --check`

`make devtest` still fails in this environment during early debug/O0 build setup, before VC tests run. Extracted failures match the existing pattern: conflicting `sqlite3BtreeSeekCount` types, missing `sqlite3BtreeLeave*` / `sqlite3BtreeHolds*` declarations, `sqlite3SchemaMutexHeld` redefinition, and a linker failure in the O0 fuzzcheck path.
