### PR TITLE
Push down dolt_at primary key filters

### DIFF
--- a/src/doltlite_at.c
+++ b/src/doltlite_at.c
@@ -8,6 +8,15 @@
 #include <string.h>
 #include <time.h>
 
+#define AT_IDX_REF    0x01
+#define AT_IDX_PK_EQ  0x02
+#define AT_IDX_PK_GE  0x04
+#define AT_IDX_PK_LE  0x08
+#define AT_IDX_PK_GT  0x10
+#define AT_IDX_PK_LT  0x20
+#define AT_IDX_PK_ANY \
+  (AT_IDX_PK_EQ|AT_IDX_PK_GE|AT_IDX_PK_LE|AT_IDX_PK_GT|AT_IDX_PK_LT)
+
 static char *atBuildSchema(const DoltliteColInfo *ci){
   sqlite3_str *pStr = sqlite3_str_new(0);
   char *z;
@@ -34,12 +43,24 @@ typedef struct AtCursor AtCursor;
 struct AtCursor {
   DoltliteVtabCursorCommon common;
   char *zCommitRef;
+  int idxNum;
+  DoltlitePkRange pkRange;
 };
 
 static void atCursorReset(AtCursor *c){
   doltliteVtabCommonReset(&c->common);
   sqlite3_free(c->zCommitRef);
   c->zCommitRef = 0;
+}
+
+static int atRowMatchesUpper(AtCursor *c){
+  i64 k;
+  if( !c->pkRange.hasPkHi ) return 1;
+  k = prollyCursorIntKey(&c->common.tblCur);
+  if( c->pkRange.pkHiStrict ){
+    return k < c->pkRange.pkHi;
+  }
+  return k <= c->pkRange.pkHi;
 }
 
 static int atConnect(sqlite3 *db, void *pAux, int argc,
@@ -63,23 +84,72 @@ static int atClose(sqlite3_vtab_cursor *cur){
 static int atBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
   DoltliteVtabCommon *v=(DoltliteVtabCommon*)pVtab;
   int nCols=v->cols.nCol;
-  int iRef=-1, i, argvIdx=1;
+  int iRef=-1, iEq=-1, iGe=-1, iLe=-1, iGt=-1, iLt=-1;
+  int i, argvIdx=1, idxNum=0;
+  int iPkCol = v->cols.iPkCol;
 
   int refCol = nCols > 0 ? nCols : 2;
   (void)pVtab;
 
   for(i=0;i<pInfo->nConstraint;i++){
     if(!pInfo->aConstraint[i].usable) continue;
-    if(pInfo->aConstraint[i].op!=SQLITE_INDEX_CONSTRAINT_EQ) continue;
-    if(pInfo->aConstraint[i].iColumn==refCol) iRef=i;
+    if( pInfo->aConstraint[i].iColumn==refCol
+     && pInfo->aConstraint[i].op==SQLITE_INDEX_CONSTRAINT_EQ ){
+      iRef=i;
+    }else if( iPkCol>=0 && pInfo->aConstraint[i].iColumn==iPkCol ){
+      switch( pInfo->aConstraint[i].op ){
+        case SQLITE_INDEX_CONSTRAINT_EQ: if( iEq<0 ) iEq=i; break;
+        case SQLITE_INDEX_CONSTRAINT_GE: if( iGe<0 ) iGe=i; break;
+        case SQLITE_INDEX_CONSTRAINT_LE: if( iLe<0 ) iLe=i; break;
+        case SQLITE_INDEX_CONSTRAINT_GT: if( iGt<0 ) iGt=i; break;
+        case SQLITE_INDEX_CONSTRAINT_LT: if( iLt<0 ) iLt=i; break;
+        default: break;
+      }
+    }
   }
 
   if(iRef>=0){
     pInfo->aConstraintUsage[iRef].argvIndex=argvIdx++;
     pInfo->aConstraintUsage[iRef].omit=1;
-    pInfo->idxNum=1;
+    idxNum |= AT_IDX_REF;
+    if( iEq>=0 ){
+      pInfo->aConstraintUsage[iEq].argvIndex=argvIdx++;
+      pInfo->aConstraintUsage[iEq].omit=1;
+      idxNum |= AT_IDX_PK_EQ;
+    }else{
+      if( iGe>=0 ){
+        pInfo->aConstraintUsage[iGe].argvIndex=argvIdx++;
+        pInfo->aConstraintUsage[iGe].omit=1;
+        idxNum |= AT_IDX_PK_GE;
+      }
+      if( iGt>=0 ){
+        pInfo->aConstraintUsage[iGt].argvIndex=argvIdx++;
+        pInfo->aConstraintUsage[iGt].omit=1;
+        idxNum |= AT_IDX_PK_GT;
+      }
+      if( iLe>=0 ){
+        pInfo->aConstraintUsage[iLe].argvIndex=argvIdx++;
+        pInfo->aConstraintUsage[iLe].omit=1;
+        idxNum |= AT_IDX_PK_LE;
+      }
+      if( iLt>=0 ){
+        pInfo->aConstraintUsage[iLt].argvIndex=argvIdx++;
+        pInfo->aConstraintUsage[iLt].omit=1;
+        idxNum |= AT_IDX_PK_LT;
+      }
+    }
+    pInfo->idxNum=idxNum;
     pInfo->estimatedCost=1000.0;
+    pInfo->estimatedRows=1000;
+    if( idxNum & AT_IDX_PK_EQ ){
+      pInfo->estimatedCost=10.0;
+      pInfo->estimatedRows=1;
+    }else if( idxNum & AT_IDX_PK_ANY ){
+      pInfo->estimatedCost=100.0;
+      pInfo->estimatedRows=100;
+    }
   }else{
+    pInfo->idxNum=0;
     pInfo->estimatedCost=1e12;
   }
   return SQLITE_OK;
@@ -97,10 +167,16 @@ static int atFilter(sqlite3_vtab_cursor *cur,
   struct TableEntry *aTables=0; int nTables=0;
   ProllyHash tableRoot; u8 flags=0;
   int rc, res;
+  int seekable;
   (void)idxStr;
 
   atCursorReset(c);
-  if(!cs||idxNum!=1||argc<1) return SQLITE_OK;
+  c->idxNum = idxNum;
+  if(!cs||(idxNum & AT_IDX_REF)==0||argc<1) return SQLITE_OK;
+  doltlitePkRangeFromArgs(idxNum,
+      AT_IDX_PK_EQ, AT_IDX_PK_GE, AT_IDX_PK_LE,
+      AT_IDX_PK_GT, AT_IDX_PK_LT,
+      argc-1, argv+1, &c->pkRange);
 
   pBt=doltliteGetBtShared(db);
   if(!pBt) return SQLITE_OK;
@@ -142,12 +218,57 @@ static int atFilter(sqlite3_vtab_cursor *cur,
   if( prollyHashIsEmpty(&tableRoot) ) return SQLITE_OK;
 
   prollyCursorInit(&c->common.tblCur, cs, pCache, &tableRoot, flags);
+
+  seekable = (flags & PROLLY_NODE_INTKEY) != 0
+          && (idxNum & AT_IDX_PK_ANY) != 0;
+
+  if( seekable && (idxNum & AT_IDX_PK_EQ) ){
+    rc = prollyCursorSeekInt(&c->common.tblCur, c->pkRange.pkLo, &res);
+    if( rc!=SQLITE_OK ){
+      prollyCursorClose(&c->common.tblCur);
+      return rc;
+    }
+    if( res!=0 || !prollyCursorIsValid(&c->common.tblCur) ){
+      prollyCursorClose(&c->common.tblCur);
+      return SQLITE_OK;
+    }
+    c->common.tblCurOpen = 1;
+    return doltliteVtabCommonCaptureRow(&c->common);
+  }
+
+  if( seekable && c->pkRange.hasPkLo ){
+    i64 startKey = c->pkRange.pkLo;
+    if( c->pkRange.pkLoStrict ) startKey++;
+    rc = prollyCursorSeekInt(&c->common.tblCur, startKey, &res);
+    if( rc!=SQLITE_OK ){
+      prollyCursorClose(&c->common.tblCur);
+      return rc;
+    }
+    if( res<0 ){
+      rc = prollyCursorNext(&c->common.tblCur);
+      if( rc!=SQLITE_OK ){
+        prollyCursorClose(&c->common.tblCur);
+        return rc;
+      }
+    }
+    if( !prollyCursorIsValid(&c->common.tblCur) || !atRowMatchesUpper(c) ){
+      prollyCursorClose(&c->common.tblCur);
+      return SQLITE_OK;
+    }
+    c->common.tblCurOpen = 1;
+    return doltliteVtabCommonCaptureRow(&c->common);
+  }
+
   rc = prollyCursorFirst(&c->common.tblCur, &res);
   if( rc!=SQLITE_OK ){
     prollyCursorClose(&c->common.tblCur);
     return rc;
   }
   if( res ){
+    prollyCursorClose(&c->common.tblCur);
+    return SQLITE_OK;
+  }
+  if( seekable && c->pkRange.hasPkHi && !atRowMatchesUpper(c) ){
     prollyCursorClose(&c->common.tblCur);
     return SQLITE_OK;
   }
@@ -163,6 +284,12 @@ static int atNext(sqlite3_vtab_cursor *cur){
     c->common.hasRow = 0;
     return SQLITE_OK;
   }
+  if( c->idxNum & AT_IDX_PK_EQ ){
+    prollyCursorClose(&c->common.tblCur);
+    c->common.tblCurOpen = 0;
+    c->common.hasRow = 0;
+    return SQLITE_OK;
+  }
   rc = prollyCursorNext(&c->common.tblCur);
   if( rc!=SQLITE_OK ){
     prollyCursorClose(&c->common.tblCur);
@@ -171,6 +298,12 @@ static int atNext(sqlite3_vtab_cursor *cur){
     return rc;
   }
   if( !prollyCursorIsValid(&c->common.tblCur) ){
+    prollyCursorClose(&c->common.tblCur);
+    c->common.tblCurOpen = 0;
+    c->common.hasRow = 0;
+    return SQLITE_OK;
+  }
+  if( (c->idxNum & AT_IDX_PK_ANY) && !atRowMatchesUpper(c) ){
     prollyCursorClose(&c->common.tblCur);
     c->common.tblCurOpen = 0;
     c->common.hasRow = 0;


### PR DESCRIPTION
## Summary
- add integer primary-key equality/range pushdown for `dolt_at_<table>`
- seek directly into the selected historical table root when `commit_ref` and an integer PK constraint are present
- preserve the required `commit_ref` constraint and existing full-scan behavior for unconstrained historical reads

## Performance
Benchmark database: one table with 50,000 integer-primary-key rows committed at `HEAD`. Query shape:

```sql
SELECT v FROM dolt_at_t('HEAD') WHERE id = 25000;
```

5000 repeated point lookups in one SQLite process:

| Build | Run 1 | Run 2 | Run 3 | Run 4 | Run 5 |
| --- | ---: | ---: | ---: | ---: | ---: |
| baseline `origin/master` | 13.95s | 13.97s | 14.03s | 14.05s | 13.92s |
| optimized | 0.03s | 0.03s | 0.04s | 0.03s | 0.03s |

This is a large and stable speedup for point-in-time primary-key lookups, well beyond run-to-run noise.

## Tests
- `rm -f sqlite3 sqlite3.c .target_source && make sqlite3`
- `bash test/doltlite_at.sh ./sqlite3`
- `bash test/vc_oracle_at_test.sh ./sqlite3`
- direct checks on benchmark DB:
  - `id=25000` count -> `1`
  - `id=25000` value -> `v25000`
  - `id BETWEEN 10000 AND 10100` count -> `101`
  - `id='abc'` count -> `0`
- `git diff --check`

`make devtest` still fails in this environment during early debug/O0 build setup, before VC tests run. Extracted failures match the existing pattern: conflicting `sqlite3BtreeSeekCount` types, missing `sqlite3BtreeLeave*` / `sqlite3BtreeHolds*` declarations, `sqlite3SchemaMutexHeld` redefinition, and a linker failure in the O0 fuzzcheck path.
