### PR TITLE
Push down diff stat table filters

### DIFF
--- a/src/doltlite_diff_stat.c
+++ b/src/doltlite_diff_stat.c
@@ -699,6 +699,18 @@ static int dsFilterInit(
   if( rc!=SQLITE_OK ) return rc;
   rc = dsResolveCatHash(db, pCtx->zToRef, &pCtx->toCat);
   if( rc!=SQLITE_OK ) return rc;
+  if( pCtx->zTblFilter ){
+    pCtx->azNames = sqlite3_malloc((int)sizeof(char*));
+    if( !pCtx->azNames ) return SQLITE_NOMEM;
+    pCtx->azNames[0] = sqlite3_mprintf("%s", pCtx->zTblFilter);
+    if( !pCtx->azNames[0] ){
+      sqlite3_free(pCtx->azNames);
+      pCtx->azNames = 0;
+      return SQLITE_NOMEM;
+    }
+    pCtx->nNames = 1;
+    return SQLITE_OK;
+  }
   return dsCollectTableNames(db, &pCtx->fromCat, &pCtx->toCat,
                              &pCtx->azNames, &pCtx->nNames);
 }
@@ -730,17 +742,24 @@ static int dstFilter(sqlite3_vtab_cursor *cur,
   if( rc!=SQLITE_OK ) goto done;
   rc = doltliteLoadCatalog(db, &fctx.toCat, &aToCat, &nToCat, 0);
   if( rc!=SQLITE_OK ) goto done;
-  rc = dsNameIndexInit(&fromIdx, aFromCat, nFromCat);
-  if( rc!=SQLITE_OK ) goto done;
-  rc = dsNameIndexInit(&toIdx, aToCat, nToCat);
-  if( rc!=SQLITE_OK ) goto done;
+  if( !fctx.zTblFilter ){
+    rc = dsNameIndexInit(&fromIdx, aFromCat, nFromCat);
+    if( rc!=SQLITE_OK ) goto done;
+    rc = dsNameIndexInit(&toIdx, aToCat, nToCat);
+    if( rc!=SQLITE_OK ) goto done;
+  }
 
   for(i=0; i<fctx.nNames; i++){
     DsStatRow row;
     struct TableEntry *pFromEntry, *pToEntry;
     if( !dsTableNameMatchesFilter(&fctx, fctx.azNames[i]) ) continue;
-    pFromEntry = dsNameIndexFind(&fromIdx, fctx.azNames[i]);
-    pToEntry = dsNameIndexFind(&toIdx, fctx.azNames[i]);
+    if( fctx.zTblFilter ){
+      pFromEntry = doltliteFindTableByName(aFromCat, nFromCat, fctx.azNames[i]);
+      pToEntry = doltliteFindTableByName(aToCat, nToCat, fctx.azNames[i]);
+    }else{
+      pFromEntry = dsNameIndexFind(&fromIdx, fctx.azNames[i]);
+      pToEntry = dsNameIndexFind(&toIdx, fctx.azNames[i]);
+    }
     rc = dsComputeTableStats(db, fctx.azNames[i], &fctx.fromCat, &fctx.toCat,
                              pFromEntry, pToEntry, &row);
     if( rc!=SQLITE_OK ){
@@ -977,18 +996,25 @@ static int dssFilter(sqlite3_vtab_cursor *cur,
   if( rc!=SQLITE_OK ) goto done;
   rc = doltliteLoadCatalog(db, &fctx.toCat, &aToCat, &nToCat, 0);
   if( rc!=SQLITE_OK ) goto done;
-  rc = dsNameIndexInit(&fromIdx, aFromCat, nFromCat);
-  if( rc!=SQLITE_OK ) goto done;
-  rc = dsNameIndexInit(&toIdx, aToCat, nToCat);
-  if( rc!=SQLITE_OK ) goto done;
+  if( !fctx.zTblFilter ){
+    rc = dsNameIndexInit(&fromIdx, aFromCat, nFromCat);
+    if( rc!=SQLITE_OK ) goto done;
+    rc = dsNameIndexInit(&toIdx, aToCat, nToCat);
+    if( rc!=SQLITE_OK ) goto done;
+  }
 
   for(i=0; i<fctx.nNames; i++){
     struct TableEntry *pFromEntry, *pToEntry;
 
     if( !dsTableNameMatchesFilter(&fctx, fctx.azNames[i]) ) continue;
 
-    pFromEntry = dsNameIndexFind(&fromIdx, fctx.azNames[i]);
-    pToEntry = dsNameIndexFind(&toIdx, fctx.azNames[i]);
+    if( fctx.zTblFilter ){
+      pFromEntry = doltliteFindTableByName(aFromCat, nFromCat, fctx.azNames[i]);
+      pToEntry = doltliteFindTableByName(aToCat, nToCat, fctx.azNames[i]);
+    }else{
+      pFromEntry = dsNameIndexFind(&fromIdx, fctx.azNames[i]);
+      pToEntry = dsNameIndexFind(&toIdx, fctx.azNames[i]);
+    }
     rc = dssAppendTableChange(c, db, fctx.azNames[i], pFromEntry, pToEntry);
 
     if( rc!=SQLITE_OK ) goto done;


### PR DESCRIPTION
## Summary
- avoid collecting the full from/to table-name union when `dolt_diff_stat` or `dolt_diff_summary` has a constrained hidden `tbl` argument
- skip building full catalog name indexes for constrained scans and directly look up the requested table in the loaded catalogs
- keep the existing full-union/indexed path for unconstrained scans

## Benchmark
Fixture: 600 tracked tables, 26 commits.

`dolt_diff_stat`, 200 repeated queries:

```sql
SELECT rows_added + rows_deleted + rows_modified
FROM dolt_diff_stat('HEAD~1','HEAD','t500');
```

```text
base mean 0.3863 median 0.3900 min 0.3800 max 0.3900
new  mean 0.3375 median 0.3400 min 0.3300 max 0.3500
mean speedup 12.62%
median speedup 12.82%
```

`dolt_diff_summary`, 500 repeated queries:

```sql
SELECT data_change + schema_change
FROM dolt_diff_summary('HEAD~1','HEAD','t500');
```

```text
base mean 0.2225 median 0.2200 min 0.2200 max 0.2300
new  mean 0.1100 median 0.1100 min 0.1100 max 0.1100
mean speedup 50.56%
median speedup 50.00%
```

All branch runs were faster than baseline for both workloads.

## Tests
- `make doltlite`
- `git diff --check`
- `bash test/vc_oracle_diff_stat_test.sh ./doltlite` - 49 passed
- `bash test/vc_oracle_diff_multi_pk_test.sh ./doltlite` - 29 passed
- `bash test/doltlite_diff.sh ./doltlite` - 40 passed
- `bash test/doltlite_diff_stat_scale.sh ./doltlite` - 8 passed

`make devtest` still fails locally in generated `sqlite3.c` build jobs before most tests run, matching the existing local failure mode:

```text
conflicting types for 'sqlite3BtreeSeekCount'
undeclared function 'sqlite3BtreeLeave*' / 'sqlite3BtreeHolds*'
redefinition of 'sqlite3SchemaMutexHeld'
```
