### PR TITLE
Cache branch commit metadata per row

### DIFF
--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -1229,7 +1229,17 @@ static void doltCheckoutFunc(sqlite3_context *ctx, int argc, sqlite3_value **arg
 typedef struct BrVtab BrVtab;
 struct BrVtab { sqlite3_vtab base; sqlite3 *db; };
 typedef struct BrCur BrCur;
-struct BrCur { sqlite3_vtab_cursor base; int iRow; };
+struct BrCur {
+  sqlite3_vtab_cursor base;
+  int iRow;
+  int iCommitRow;
+  DoltliteCommit commit;
+};
+
+static void brClearCommit(BrCur *c){
+  doltliteCommitClear(&c->commit);
+  c->iCommitRow = -1;
+}
 
 static int brConnect(sqlite3 *db, void *pAux, int argc,
     const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){
@@ -1254,14 +1264,31 @@ static int brConnect(sqlite3 *db, void *pAux, int argc,
   return SQLITE_OK;
 }
 static int brOpen(sqlite3_vtab *v, sqlite3_vtab_cursor **pp){
+  int rc;
+  BrCur *c;
   (void)v;
-  return doltliteVtabOpenCursor(pp, sizeof(BrCur));
+  rc = doltliteVtabOpenCursor(pp, sizeof(BrCur));
+  if( rc!=SQLITE_OK ) return rc;
+  c = (BrCur*)*pp;
+  c->iCommitRow = -1;
+  return SQLITE_OK;
+}
+static int brClose(sqlite3_vtab_cursor *cur){
+  BrCur *c = (BrCur*)cur;
+  brClearCommit(c);
+  sqlite3_free(c);
+  return SQLITE_OK;
 }
 static int brFilter(sqlite3_vtab_cursor *c, int n, const char *s, int a, sqlite3_value **v){
   (void)n;(void)s;(void)a;(void)v;
+  brClearCommit((BrCur*)c);
   ((BrCur*)c)->iRow = 0; return SQLITE_OK;
 }
-static int brNext(sqlite3_vtab_cursor *c){ ((BrCur*)c)->iRow++; return SQLITE_OK; }
+static int brNext(sqlite3_vtab_cursor *c){
+  brClearCommit((BrCur*)c);
+  ((BrCur*)c)->iRow++;
+  return SQLITE_OK;
+}
 static int brEof(sqlite3_vtab_cursor *c){
   BrVtab *v = (BrVtab*)c->pVtab;
   ChunkStore *cs = doltliteGetChunkStore(v->db);
@@ -1309,8 +1336,31 @@ static int brIsDirty(
   return rc;
 }
 
+static int brLoadCommit(
+  BrVtab *v,
+  BrCur *c,
+  const BranchRef *br,
+  DoltliteCommit **ppCommit
+){
+  int rc;
+  if( c->iCommitRow==c->iRow ){
+    *ppCommit = &c->commit;
+    return SQLITE_OK;
+  }
+  brClearCommit(c);
+  rc = doltliteLoadCommit(v->db, &br->commitHash, &c->commit);
+  if( rc!=SQLITE_OK ){
+    brClearCommit(c);
+    return rc;
+  }
+  c->iCommitRow = c->iRow;
+  *ppCommit = &c->commit;
+  return SQLITE_OK;
+}
+
 static int brColumn(sqlite3_vtab_cursor *c, sqlite3_context *ctx, int col){
   BrVtab *v = (BrVtab*)c->pVtab;
+  BrCur *pCur = (BrCur*)c;
   ChunkStore *cs = doltliteGetChunkStore(v->db);
   const BranchRef *br;
   int nBr;
@@ -1346,34 +1396,31 @@ static int brColumn(sqlite3_vtab_cursor *c, sqlite3_context *ctx, int col){
   }
 
   {
-    DoltliteCommit cm;
+    DoltliteCommit *cm;
     int rc;
-    memset(&cm, 0, sizeof(cm));
-    rc = doltliteLoadCommit(v->db, &br->commitHash, &cm);
+    rc = brLoadCommit(v, pCur, br, &cm);
     if( rc!=SQLITE_OK ){
       sqlite3_result_error_code(ctx, rc);
-      doltliteCommitClear(&cm);
       return rc;
     }
     switch(col){
       case 2:
-        sqlite3_result_text(ctx, cm.zName ? cm.zName : "",
+        sqlite3_result_text(ctx, cm->zName ? cm->zName : "",
                             -1, SQLITE_TRANSIENT);
         break;
       case 3:
-        sqlite3_result_text(ctx, cm.zEmail ? cm.zEmail : "",
+        sqlite3_result_text(ctx, cm->zEmail ? cm->zEmail : "",
                             -1, SQLITE_TRANSIENT);
         break;
       case 4: {
-        doltliteResultTimestamp(ctx, cm.timestamp);
+        doltliteResultTimestamp(ctx, cm->timestamp);
         break;
       }
       case 5:
-        sqlite3_result_text(ctx, cm.zMessage ? cm.zMessage : "",
+        sqlite3_result_text(ctx, cm->zMessage ? cm->zMessage : "",
                             -1, SQLITE_TRANSIENT);
         break;
     }
-    doltliteCommitClear(&cm);
   }
   return SQLITE_OK;
 }
@@ -1385,7 +1432,7 @@ static int brBestIndex(sqlite3_vtab *v, sqlite3_index_info *p){
 }
 static sqlite3_module brMod = {
   0,0,brConnect,brBestIndex,doltliteVtabDisconnect,0,
-  brOpen,doltliteVtabClose,brFilter,brNext,brEof,brColumn,brRowid,
+  brOpen,brClose,brFilter,brNext,brEof,brColumn,brRowid,
   0,0,0,0,0,0,0,0,0,0,0,0
 };
 


### PR DESCRIPTION
## Summary
- cache the loaded `DoltliteCommit` on each `dolt_branches` cursor row
- reuse that commit for `latest_committer`, `latest_committer_email`, `latest_commit_date`, and `latest_commit_message`
- clear the cache on cursor reset, advance, and close

## Benchmark
Fixture: 801 branches pointing at the same initialized commit. Query repeated 300 times:

```sql
SELECT sum(
  length(latest_committer) +
  length(latest_committer_email) +
  length(latest_commit_date) +
  length(latest_commit_message)
) FROM dolt_branches;
```

Compared `/tmp/doltlite_diff_base/doltlite` built from `origin/master` to this branch, alternating runs after warmup:

```text
base mean 0.9800 median 0.9700 min 0.9600 max 1.0500
new  mean 0.3587 median 0.3600 min 0.3500 max 0.3600
mean speedup 63.39%
median speedup 62.89%
```

All branch runs were faster than baseline.

## Tests
- `make doltlite`
- `git diff --check`
- `bash test/doltlite_branch.sh ./doltlite` - 62 passed
- `bash test/doltlite_branch_edge.sh ./doltlite` - 76 passed
- `bash test/vc_oracle_branch_test.sh ./doltlite` - 33 passed
- `bash test/vc_oracle_branches_test.sh ./doltlite` - 15 passed
- `bash test/doltlite_branch_gc_stress.sh ./doltlite` - 35 passed
- `bash test/doltlite_default_branch.sh ./doltlite` - 12 passed
- `bash test/doltlite_comparison.sh ./doltlite` - 12 passed
- `bash test/doltlite_advanced.sh ./doltlite` - 140 passed

`make devtest` still fails locally in generated `sqlite3.c` build jobs before most tests run, matching the existing local failure mode:

```text
conflicting types for 'sqlite3BtreeSeekCount'
undeclared function 'sqlite3BtreeLeave*' / 'sqlite3BtreeHolds*'
redefinition of 'sqlite3SchemaMutexHeld'
```
