### PR TITLE
Push down ref name filters

### DIFF
--- a/src/doltlite_branch.c
+++ b/src/doltlite_branch.c
@@ -1232,6 +1232,8 @@ typedef struct BrCur BrCur;
 struct BrCur {
   sqlite3_vtab_cursor base;
   int iRow;
+  int bSingle;
+  int iSingle;
   int iCommitRow;
   DoltliteCommit commit;
 };
@@ -1280,9 +1282,23 @@ static int brClose(sqlite3_vtab_cursor *cur){
   return SQLITE_OK;
 }
 static int brFilter(sqlite3_vtab_cursor *c, int n, const char *s, int a, sqlite3_value **v){
-  (void)n;(void)s;(void)a;(void)v;
-  brClearCommit((BrCur*)c);
-  ((BrCur*)c)->iRow = 0; return SQLITE_OK;
+  BrVtab *pVtab = (BrVtab*)c->pVtab;
+  BrCur *pCur = (BrCur*)c;
+  (void)s;
+  (void)a;
+  brClearCommit(pCur);
+  pCur->iRow = 0;
+  pCur->bSingle = 0;
+  pCur->iSingle = -1;
+  if( n==1 ){
+    ChunkStore *cs = doltliteGetChunkStore(pVtab->db);
+    const char *zName = (const char*)sqlite3_value_text(v[0]);
+    pCur->bSingle = 1;
+    pCur->iSingle = cs ? csFindNamedRef(cs->refs.aBranches, cs->refs.nBranches,
+                                        (int)sizeof(BranchRef), zName) : -1;
+    pCur->iRow = pCur->iSingle;
+  }
+  return SQLITE_OK;
 }
 static int brNext(sqlite3_vtab_cursor *c){
   brClearCommit((BrCur*)c);
@@ -1291,8 +1307,11 @@ static int brNext(sqlite3_vtab_cursor *c){
 }
 static int brEof(sqlite3_vtab_cursor *c){
   BrVtab *v = (BrVtab*)c->pVtab;
+  BrCur *pCur = (BrCur*)c;
   ChunkStore *cs = doltliteGetChunkStore(v->db);
-  return !cs || ((BrCur*)c)->iRow >= refsTableBranchCount(&cs->refs);
+  if( !cs ) return 1;
+  if( pCur->bSingle ) return pCur->iSingle<0 || pCur->iRow!=pCur->iSingle;
+  return pCur->iRow >= refsTableBranchCount(&cs->refs);
 }
 
 static int brIsDirty(
@@ -1428,7 +1447,10 @@ static int brRowid(sqlite3_vtab_cursor *c, sqlite3_int64 *r){
   *r=((BrCur*)c)->iRow; return SQLITE_OK;
 }
 static int brBestIndex(sqlite3_vtab *v, sqlite3_index_info *p){
-  (void)v; p->estimatedCost=10; p->estimatedRows=5; return SQLITE_OK;
+  (void)v;
+  p->estimatedCost=10;
+  p->estimatedRows=5;
+  return doltliteBestIndexEq(p, 0);
 }
 static sqlite3_module brMod = {
   0,0,brConnect,brBestIndex,doltliteVtabDisconnect,0,

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -275,6 +275,26 @@ static SQLITE_INLINE int doltliteBestIndexRefs(
   return SQLITE_OK;
 }
 
+static SQLITE_INLINE int doltliteBestIndexEq(
+  sqlite3_index_info *pInfo,
+  int iColumn
+){
+  int i;
+  for(i=0; i<pInfo->nConstraint; i++){
+    if( !pInfo->aConstraint[i].usable ) continue;
+    if( pInfo->aConstraint[i].op!=SQLITE_INDEX_CONSTRAINT_EQ ) continue;
+    if( pInfo->aConstraint[i].iColumn!=iColumn ) continue;
+    pInfo->aConstraintUsage[i].argvIndex = 1;
+    pInfo->aConstraintUsage[i].omit = 1;
+    pInfo->idxNum = 1;
+    pInfo->estimatedCost = 1.0;
+    pInfo->estimatedRows = 1;
+    return SQLITE_OK;
+  }
+  pInfo->idxNum = 0;
+  return SQLITE_OK;
+}
+
 static SQLITE_INLINE int doltliteBestIndexIntPkRange(
   sqlite3_index_info *pInfo,
   int iPkCol,

--- a/src/doltlite_remote_sql.c
+++ b/src/doltlite_remote_sql.c
@@ -673,7 +673,7 @@ static void doltCloneFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
 typedef struct RemVtab RemVtab;
 struct RemVtab { sqlite3_vtab base; sqlite3 *db; };
 typedef struct RemCur RemCur;
-struct RemCur { sqlite3_vtab_cursor base; int iRow; };
+struct RemCur { sqlite3_vtab_cursor base; int iRow; int bSingle; int iSingle; };
 
 static int remConnect(sqlite3 *db, void *pAux, int argc,
     const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){
@@ -697,14 +697,31 @@ static int remOpen(sqlite3_vtab *v, sqlite3_vtab_cursor **pp){
   return doltliteVtabOpenCursor(pp, sizeof(RemCur));
 }
 static int remFilter(sqlite3_vtab_cursor *c, int n, const char *s, int a, sqlite3_value **v){
-  (void)n;(void)s;(void)a;(void)v;
-  ((RemCur*)c)->iRow = 0; return SQLITE_OK;
+  RemVtab *pVtab = (RemVtab*)c->pVtab;
+  RemCur *pCur = (RemCur*)c;
+  (void)s;
+  (void)a;
+  pCur->iRow = 0;
+  pCur->bSingle = 0;
+  pCur->iSingle = -1;
+  if( n==1 ){
+    ChunkStore *cs = doltliteGetChunkStore(pVtab->db);
+    const char *zName = (const char*)sqlite3_value_text(v[0]);
+    pCur->bSingle = 1;
+    pCur->iSingle = cs ? csFindNamedRef(cs->refs.aRemotes, cs->refs.nRemotes,
+                                        (int)sizeof(RemoteRef), zName) : -1;
+    pCur->iRow = pCur->iSingle;
+  }
+  return SQLITE_OK;
 }
 static int remNext(sqlite3_vtab_cursor *c){ ((RemCur*)c)->iRow++; return SQLITE_OK; }
 static int remEof(sqlite3_vtab_cursor *c){
   RemVtab *v = (RemVtab*)c->pVtab;
+  RemCur *pCur = (RemCur*)c;
   ChunkStore *cs = doltliteGetChunkStore(v->db);
-  return !cs || ((RemCur*)c)->iRow >= refsTableRemoteCount(&cs->refs);
+  if( !cs ) return 1;
+  if( pCur->bSingle ) return pCur->iSingle<0 || pCur->iRow!=pCur->iSingle;
+  return pCur->iRow >= refsTableRemoteCount(&cs->refs);
 }
 static int remColumn(sqlite3_vtab_cursor *c, sqlite3_context *ctx, int col){
   RemVtab *v = (RemVtab*)c->pVtab;
@@ -745,7 +762,10 @@ static int remRowid(sqlite3_vtab_cursor *c, sqlite3_int64 *r){
   *r=((RemCur*)c)->iRow; return SQLITE_OK;
 }
 static int remBestIndex(sqlite3_vtab *v, sqlite3_index_info *p){
-  (void)v; p->estimatedCost=10; p->estimatedRows=5; return SQLITE_OK;
+  (void)v;
+  p->estimatedCost=10;
+  p->estimatedRows=5;
+  return doltliteBestIndexEq(p, 0);
 }
 
 static sqlite3_module remotesModule = {

--- a/src/doltlite_tag.c
+++ b/src/doltlite_tag.c
@@ -171,7 +171,7 @@ static void doltTagFunc(sqlite3_context *ctx, int argc, sqlite3_value **argv){
 typedef struct TagVtab TagVtab;
 struct TagVtab { sqlite3_vtab base; sqlite3 *db; };
 typedef struct TagCur TagCur;
-struct TagCur { sqlite3_vtab_cursor base; int iRow; };
+struct TagCur { sqlite3_vtab_cursor base; int iRow; int bSingle; int iSingle; };
 
 static int tagConnect(sqlite3 *db, void *pAux, int argc,
     const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){
@@ -202,11 +202,20 @@ static int tagOpen(sqlite3_vtab *pVtab, sqlite3_vtab_cursor **ppCursor){
 }
 static int tagFilter(sqlite3_vtab_cursor *pCursor, int idxNum,
     const char *idxStr, int argc, sqlite3_value **argv){
-  (void)idxNum;
+  TagVtab *pVtab = (TagVtab*)pCursor->pVtab;
+  TagCur *pCur = (TagCur*)pCursor;
   (void)idxStr;
-  (void)argc;
-  (void)argv;
-  ((TagCur*)pCursor)->iRow = 0;
+  pCur->iRow = 0;
+  pCur->bSingle = 0;
+  pCur->iSingle = -1;
+  if( idxNum==1 && argc==1 ){
+    ChunkStore *cs = doltliteGetChunkStore(pVtab->db);
+    const char *zName = (const char*)sqlite3_value_text(argv[0]);
+    pCur->bSingle = 1;
+    pCur->iSingle = cs ? csFindNamedRef(cs->refs.aTags, cs->refs.nTags,
+                                        (int)sizeof(TagRef), zName) : -1;
+    pCur->iRow = pCur->iSingle;
+  }
   return SQLITE_OK;
 }
 static int tagNext(sqlite3_vtab_cursor *pCursor){
@@ -215,8 +224,11 @@ static int tagNext(sqlite3_vtab_cursor *pCursor){
 }
 static int tagEof(sqlite3_vtab_cursor *pCursor){
   TagVtab *pVtab = (TagVtab*)pCursor->pVtab;
+  TagCur *pCur = (TagCur*)pCursor;
   ChunkStore *cs = doltliteGetChunkStore(pVtab->db);
-  return !cs || ((TagCur*)pCursor)->iRow >= refsTableTagCount(&cs->refs);
+  if( !cs ) return 1;
+  if( pCur->bSingle ) return pCur->iSingle<0 || pCur->iRow!=pCur->iSingle;
+  return pCur->iRow >= refsTableTagCount(&cs->refs);
 }
 static int tagColumn(sqlite3_vtab_cursor *pCursor, sqlite3_context *ctx, int col){
   TagVtab *pVtab = (TagVtab*)pCursor->pVtab;
@@ -264,7 +276,7 @@ static int tagBestIndex(sqlite3_vtab *pVtab, sqlite3_index_info *pInfo){
   (void)pVtab;
   pInfo->estimatedCost = 10;
   pInfo->estimatedRows = 5;
-  return SQLITE_OK;
+  return doltliteBestIndexEq(pInfo, 0);
 }
 
 static sqlite3_module tagModule = {


### PR DESCRIPTION
## Summary
- add a shared equality best-index helper for simple virtual-table column filters
- push `name = ?` into `dolt_branches` and `dolt_remotes`
- push `tag_name = ?` into `dolt_tags`
- position constrained cursors directly at the matching refs-array entry, or EOF for missing names

## Benchmark
Fixture: 501 branches, 500 tags, 500 remotes. Each workload ran 6000 repeated constrained `count(*)` queries against a late ref name, comparing `/tmp/doltlite_diff_base/doltlite` from `origin/master` to this branch.

`dolt_branches`:

```text
base mean 0.1625 median 0.1600 min 0.1600 max 0.1700
new  mean 0.0737 median 0.0700 min 0.0700 max 0.0900
mean speedup 54.62%
median speedup 56.25%
```

`dolt_tags`:

```text
base mean 0.1638 median 0.1600 min 0.1600 max 0.1900
new  mean 0.0750 median 0.0700 min 0.0700 max 0.0900
mean speedup 54.20%
median speedup 56.25%
```

`dolt_remotes`:

```text
base mean 0.1600 median 0.1600 min 0.1600 max 0.1600
new  mean 0.0725 median 0.0700 min 0.0700 max 0.0800
mean speedup 54.69%
median speedup 56.25%
```

`EXPLAIN QUERY PLAN` reports `VIRTUAL TABLE INDEX 1` for constrained branch, tag, and remote lookups.

## Tests
- `make doltlite`
- `git diff --check`
- direct constrained/missing-name checks for `dolt_branches`, `dolt_tags`, and `dolt_remotes`
- `bash test/doltlite_branch.sh ./doltlite` - 62 passed
- `bash test/vc_oracle_branches_test.sh ./doltlite` - 15 passed
- `bash test/doltlite_branch_edge.sh ./doltlite` - 76 passed
- `bash test/doltlite_default_branch.sh ./doltlite` - 12 passed
- `bash test/doltlite_tag.sh ./doltlite` - 19 passed
- `bash test/remote_test.sh ./doltlite` - 87 passed
- `bash test/vc_oracle_remotes_test.sh ./doltlite` - 33 passed
- `bash test/vc_oracle_error_recovery_test.sh ./doltlite` - 261 passed

`make devtest` still fails locally in generated `sqlite3.c` build jobs before most tests run, matching the existing local failure mode:

```text
conflicting types for 'sqlite3BtreeSeekCount'
undeclared function 'sqlite3BtreeLeave*' / 'sqlite3BtreeHolds*'
redefinition of 'sqlite3SchemaMutexHeld'
```
