### PR TITLE
Fix rebase to linearize merge commits (match Dolt behavior)

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -3621,14 +3621,15 @@ static int doltliteRebaseCollectReplaySet(
   int *pnReplay
 ){
   ProllyHashSet upstreamAncestors;
+  ProllyHashSet visited;
   ProllyHash *queue = 0;
   int qHead = 0, qTail = 0, qAlloc = 0;
   ProllyHash *aReplay = 0;
   int nReplay = 0, nAllocReplay = 0;
   int rc;
   int upstreamInit = 0;
-  ProllyHash walk;
-  int i;
+  int visitedInit = 0;
+  int i, j;
 
   *paReplay = 0;
   *pnReplay = 0;
@@ -3669,31 +3670,55 @@ static int doltliteRebaseCollectReplaySet(
     doltliteCommitClear(&c);
   }
 
-  sqlite3_free(queue);
-  queue = 0;
+  /* BFS from HEAD dissolves merge commits: traverse all parents but only
+  ** include non-merge commits in the replay set, linearizing the history. */
+  qHead = qTail = 0;
+  queue[qTail++] = *pHeadHash;
 
-  walk = *pHeadHash;
-  while( !prollyHashIsEmpty(&walk) && !prollyHashSetContains(&upstreamAncestors, &walk) ){
+  rc = prollyHashSetInit(&visited, 256);
+  if( rc!=SQLITE_OK ) goto cleanup;
+  visitedInit = 1;
+
+  while( qHead < qTail ){
+    ProllyHash cur = queue[qHead++];
     DoltliteCommit c;
-    const ProllyHash *pParent;
+    int nParents;
 
-    if( nReplay >= nAllocReplay ){
-      int nNew = nAllocReplay ? nAllocReplay*2 : 16;
-      ProllyHash *tmp = sqlite3_realloc(aReplay, nNew*(int)sizeof(ProllyHash));
-      if( !tmp ){ rc = SQLITE_NOMEM; goto cleanup; }
-      aReplay = tmp;
-      nAllocReplay = nNew;
-    }
-    aReplay[nReplay++] = walk;
+    if( prollyHashIsEmpty(&cur) ) continue;
+    if( prollyHashSetContains(&upstreamAncestors, &cur) ) continue;
+    if( prollyHashSetContains(&visited, &cur) ) continue;
+    rc = prollyHashSetAdd(&visited, &cur);
+    if( rc!=SQLITE_OK ) goto cleanup;
 
     memset(&c, 0, sizeof(c));
-    rc = doltliteLoadCommit(db, &walk, &c);
+    rc = doltliteLoadCommit(db, &cur, &c);
     if( rc!=SQLITE_OK ) goto cleanup;
-    pParent = doltliteCommitParentHash(&c, 0);
-    if( pParent && !prollyHashIsEmpty(pParent) ){
-      walk = *pParent;
-    }else{
-      memset(&walk, 0, sizeof(walk));
+    nParents = doltliteCommitParentCount(&c);
+
+    if( nParents<=1 ){
+      if( nReplay >= nAllocReplay ){
+        int nNew = nAllocReplay ? nAllocReplay*2 : 16;
+        ProllyHash *tmp = sqlite3_realloc(aReplay, nNew*(int)sizeof(ProllyHash));
+        if( !tmp ){ doltliteCommitClear(&c); rc = SQLITE_NOMEM; goto cleanup; }
+        aReplay = tmp;
+        nAllocReplay = nNew;
+      }
+      aReplay[nReplay++] = cur;
+    }
+
+    for( j=0; j<nParents; j++ ){
+      const ProllyHash *pp = doltliteCommitParentHash(&c, j);
+      if( !pp || prollyHashIsEmpty(pp) ) continue;
+      if( prollyHashSetContains(&upstreamAncestors, pp) ) continue;
+      if( prollyHashSetContains(&visited, pp) ) continue;
+      if( qTail >= qAlloc ){
+        int nNew = qAlloc * 2;
+        ProllyHash *tmp = sqlite3_realloc(queue, nNew*(int)sizeof(ProllyHash));
+        if( !tmp ){ doltliteCommitClear(&c); rc = SQLITE_NOMEM; goto cleanup; }
+        queue = tmp;
+        qAlloc = nNew;
+      }
+      queue[qTail++] = *pp;
     }
     doltliteCommitClear(&c);
   }
@@ -3713,6 +3738,7 @@ cleanup:
   sqlite3_free(queue);
   sqlite3_free(aReplay);
   if( upstreamInit ) prollyHashSetFree(&upstreamAncestors);
+  if( visitedInit ) prollyHashSetFree(&visited);
   return rc;
 }
 

--- a/test/vc_oracle_rebase_test.sh
+++ b/test/vc_oracle_rebase_test.sh
@@ -860,6 +860,35 @@ SELECT CONCAT('LOG|P|', count(*)) FROM dolt_branches WHERE name='dolt_rebase_fea
 SELECT CONCAT('LOG|T|', count(*)) FROM t;
 "
 
+echo "--- rebase dissolves merge commits in range ---"
+
+MERGE_DISSOLVE_SETUP="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'base');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'init');
+SELECT dolt_checkout('-b', 'side');
+INSERT INTO t VALUES (2, 'side_row');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'side-commit');
+SELECT dolt_checkout('main');
+SELECT dolt_checkout('-b', 'feat');
+INSERT INTO t VALUES (10, 'feat1');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'feat1');
+SELECT dolt_merge('side', '-m', 'Merge side into feat');
+INSERT INTO t VALUES (11, 'feat2');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'feat2');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES (100, 'main_new');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'main-new');
+SELECT dolt_checkout('feat');
+SELECT dolt_rebase('main');
+"
+
+oracle "merge_dissolve_log" "$MERGE_DISSOLVE_SETUP" \
+  "SELECT CONCAT('LOG|', message) FROM dolt_log WHERE message NOT LIKE 'Initialize%';"
+
+oracle "merge_dissolve_table" "$MERGE_DISSOLVE_SETUP" \
+  "SELECT CONCAT('LOG|', id, '=', v) FROM t ORDER BY id;"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then


### PR DESCRIPTION
## Summary

- `doltliteRebaseCollectReplaySet` only followed `parent[0]` when walking the rebase range, silently dropping second-parent contributions when the branch contained merge commits
- Replace the linear walk with a BFS over all parents; merge commits (nParents > 1) are excluded from the replay set but their parents are still traversed, so every non-merge ancestor is replayed as a linear sequence — matching Dolt's linearization behavior
- Add an oracle test for this scenario: `merge_dissolve_log` verifies the linearized commit order and `merge_dissolve_table` verifies the data, both compared against Dolt reference output

## Test plan

- [ ] `test/vc_oracle_rebase_test.sh` — 47 pass (2 new assertions: `merge_dissolve_log`, `merge_dissolve_table`)
- [ ] `test/doltlite_rebase.sh` — 8 pass, no regression
- [ ] CI oracle-tests job

🤖 Generated with [Claude Code](https://claude.com/claude-code)