### PR TITLE
Optimize catalog table root lookup

### DIFF
--- a/src/doltlite_at.c
+++ b/src/doltlite_at.c
@@ -164,7 +164,6 @@ static int atFilter(sqlite3_vtab_cursor *cur,
   void *pBt; ProllyCache *pCache;
   const char *zRef;
   ProllyHash catHash;
-  struct TableEntry *aTables=0; int nTables=0;
   ProllyHash tableRoot; u8 flags=0;
   int rc, res;
   int seekable;
@@ -206,12 +205,9 @@ static int atFilter(sqlite3_vtab_cursor *cur,
     }else{
       memcpy(&effCatHash, &catHash, sizeof(ProllyHash));
     }
-    rc=doltliteLoadCatalog(db,&effCatHash,&aTables,&nTables,0);
+    rc=doltliteLoadTableRootByName(db,&effCatHash,v->zTableName,&tableRoot,
+                                   &flags,0);
   }
-  if(rc!=SQLITE_OK) return rc;
-
-  rc=doltliteFindTableRootByName(aTables,nTables,v->zTableName,&tableRoot,&flags,0);
-  doltliteFreeCatalog(aTables,nTables);
   if(rc==SQLITE_NOTFOUND) return SQLITE_OK;
   if(rc!=SQLITE_OK) return rc;
 

--- a/src/doltlite_history.c
+++ b/src/doltlite_history.c
@@ -71,7 +71,6 @@ static int htOpenTableAtCommit(HistCursor *c, sqlite3 *db,
   ChunkStore *cs = doltliteGetChunkStore(db);
   ProllyCache *pCache = doltliteGetCache(db);
   DoltliteCommit commit;
-  struct TableEntry *aT = 0; int nT = 0;
   ProllyHash tableRoot; u8 flags = 0;
   int rc, res;
   int seekable;
@@ -97,16 +96,15 @@ static int htOpenTableAtCommit(HistCursor *c, sqlite3 *db,
     }
   }
 
-  rc = doltliteLoadCatalog(db, &commit.catalogHash, &aT, &nT, 0);
+  rc = doltliteLoadTableRootByName(db, &commit.catalogHash, zTableName,
+                                   &tableRoot, &flags, 0);
   doltliteCommitClear(&commit);
+  if( rc==SQLITE_NOTFOUND ) return SQLITE_OK;
   if( rc!=SQLITE_OK ) return rc;
 
-  if( doltliteFindTableRootByName(aT, nT, zTableName, &tableRoot, &flags, 0)
-      !=SQLITE_OK || prollyHashIsEmpty(&tableRoot) ){
-    doltliteFreeCatalog(aT, nT);
+  if( prollyHashIsEmpty(&tableRoot) ){
     return SQLITE_OK;
   }
-  doltliteFreeCatalog(aT, nT);
 
   prollyCursorInit(&c->common.tblCur, cs, pCache, &tableRoot, flags);
 

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -602,30 +602,14 @@ static SQLITE_INLINE int doltliteFindTableRootByName(
   return SQLITE_NOTFOUND;
 }
 
-static SQLITE_INLINE int doltliteLoadTableRootByName(
+int doltliteLoadTableRootByName(
   sqlite3 *db,
   const ProllyHash *pCatHash,
   const char *zTableName,
   ProllyHash *pRoot,
   u8 *pFlags,
   ProllyHash *pSchemaHash
-){
-  struct TableEntry *aTables = 0;
-  int nTables = 0;
-  int rc;
-
-  memset(pRoot, 0, sizeof(*pRoot));
-  if( pFlags ) *pFlags = 0;
-  if( pSchemaHash ) memset(pSchemaHash, 0, sizeof(*pSchemaHash));
-  if( !pCatHash || prollyHashIsEmpty(pCatHash) ) return SQLITE_NOTFOUND;
-
-  rc = doltliteLoadCatalog(db, pCatHash, &aTables, &nTables, 0);
-  if( rc!=SQLITE_OK ) return rc;
-  rc = doltliteFindTableRootByName(aTables, nTables, zTableName,
-                                   pRoot, pFlags, pSchemaHash);
-  doltliteFreeCatalog(aTables, nTables);
-  return rc;
-}
+);
 
 static SQLITE_INLINE int doltliteLoadTableRootByNameOrEmpty(
   sqlite3 *db,

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -10241,6 +10241,127 @@ int doltliteLoadCatalog(sqlite3 *db, const ProllyHash *catHash,
   return SQLITE_OK;
 }
 
+int doltliteLoadTableRootByName(
+  sqlite3 *db,
+  const ProllyHash *pCatHash,
+  const char *zTableName,
+  ProllyHash *pRoot,
+  u8 *pFlags,
+  ProllyHash *pSchemaHash
+){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  u8 *data = 0;
+  int nData = 0;
+  const u8 *q;
+  const u8 *pEntries;
+  int nTables = 0;
+  int iFormat = 0;
+  int nWant;
+  int found = 0;
+  ProllyHash foundRoot;
+  ProllyHash foundSchemaHash;
+  u8 foundFlags = 0;
+  int i;
+  int rc;
+
+  memset(pRoot, 0, sizeof(*pRoot));
+  if( pFlags ) *pFlags = 0;
+  if( pSchemaHash ) memset(pSchemaHash, 0, sizeof(*pSchemaHash));
+  if( !cs ) return SQLITE_ERROR;
+  if( !zTableName || !pCatHash || prollyHashIsEmpty(pCatHash) ){
+    return SQLITE_NOTFOUND;
+  }
+  nWant = (int)strlen(zTableName);
+
+  rc = chunkStoreGet(cs, pCatHash, &data, &nData);
+  if( rc!=SQLITE_OK ) return rc;
+  if( !catalogParseHeaderEx(data, nData, &iFormat, &nTables, &pEntries) ){
+    sqlite3_free(data);
+    return SQLITE_CORRUPT;
+  }
+
+  q = pEntries;
+  for(i=0; i<nTables; i++){
+    u8 flags;
+    ProllyHash root;
+    ProllyHash schemaHash;
+
+    if( q+CAT_ENTRY_ITABLE_SIZE+CAT_ENTRY_FLAGS_SIZE
+        +PROLLY_HASH_SIZE+PROLLY_HASH_SIZE > data+nData ){
+      sqlite3_free(data);
+      return SQLITE_CORRUPT;
+    }
+    q += CAT_ENTRY_ITABLE_SIZE;
+    flags = *q++;
+    memcpy(root.data, q, PROLLY_HASH_SIZE);
+    q += PROLLY_HASH_SIZE;
+    memcpy(schemaHash.data, q, PROLLY_HASH_SIZE);
+    q += PROLLY_HASH_SIZE;
+
+    if( iFormat==CATALOG_FORMAT_V4 ){
+      int nType, nName, nTbl;
+      const u8 *pType;
+      const u8 *pName;
+      if( q+6 > data+nData ){
+        sqlite3_free(data);
+        return SQLITE_CORRUPT;
+      }
+      nType = q[0] | (q[1]<<8);
+      nName = q[2] | (q[3]<<8);
+      nTbl = q[4] | (q[5]<<8);
+      q += 6;
+      if( q+nType+nName+nTbl > data+nData ){
+        sqlite3_free(data);
+        return SQLITE_CORRUPT;
+      }
+      pType = q;
+      q += nType;
+      pName = q;
+      q += nName+nTbl;
+      if( !found
+       && nType==5 && memcmp(pType, "table", 5)==0
+       && nName==nWant && memcmp(pName, zTableName, nName)==0 ){
+        found = 1;
+        memcpy(&foundRoot, &root, sizeof(foundRoot));
+        memcpy(&foundSchemaHash, &schemaHash, sizeof(foundSchemaHash));
+        foundFlags = flags;
+      }
+    }else{
+      int nLen;
+      const u8 *pName;
+      if( q+2 > data+nData ){
+        sqlite3_free(data);
+        return SQLITE_CORRUPT;
+      }
+      nLen = q[0] | (q[1]<<8);
+      q += 2;
+      if( q+nLen > data+nData ){
+        sqlite3_free(data);
+        return SQLITE_CORRUPT;
+      }
+      pName = q;
+      q += nLen;
+      if( !found && nLen==nWant && memcmp(pName, zTableName, nLen)==0 ){
+        found = 1;
+        memcpy(&foundRoot, &root, sizeof(foundRoot));
+        memcpy(&foundSchemaHash, &schemaHash, sizeof(foundSchemaHash));
+        foundFlags = flags;
+      }
+    }
+  }
+
+  if( q!=data+nData ){
+    sqlite3_free(data);
+    return SQLITE_CORRUPT;
+  }
+  sqlite3_free(data);
+  if( !found ) return SQLITE_NOTFOUND;
+  memcpy(pRoot, &foundRoot, sizeof(*pRoot));
+  if( pFlags ) *pFlags = foundFlags;
+  if( pSchemaHash ) memcpy(pSchemaHash, &foundSchemaHash, sizeof(*pSchemaHash));
+  return SQLITE_OK;
+}
+
 void doltliteFreeCatalog(struct TableEntry *a, int n){
   int i;
   if( !a ) return;


### PR DESCRIPTION
## Summary
- replace doltliteLoadTableRootByName's full catalog materialization with direct catalog-entry parsing
- preserve full catalog stream validation while avoiding TableEntry array/name allocation for table-root lookups
- route dolt_at_<table> and dolt_history_<table> through the shared lookup helper

## Performance
Synthetic repo: 500 tables, 21 commits, 200 repeated `SELECT count(*) FROM dolt_history_t500 WHERE id=1;` queries. Baseline built from master in a clean worktree; candidate built from this branch.

- master: 0.58, 0.37, 0.36, 0.40, 0.40 sec
- candidate: 0.13, 0.14, 0.13, 0.14, 0.14 sec

Warm median: ~0.40s -> ~0.14s, about 65% faster.

## Testing
- `make doltlite`
- `git diff --check`
- `test/vc_oracle_at_test.sh ./doltlite` (18 passed)
- `test/vc_oracle_history_test.sh ./doltlite` (27 passed)
- `test/vc_oracle_blame_test.sh ./doltlite` (23 passed)
- `sh test/doltlite_diff_table.sh ./doltlite` (41 passed)
- `sh test/doltlite_at.sh ./doltlite` (46 passed)
- `sh test/doltlite_history.sh ./doltlite` (40 passed)

`make devtest` still fails in the generated-build matrix before TCL tests run, with existing failures around `sqlite3BtreeSeekCount` conflicting types, undeclared `sqlite3BtreeLeave*`/mutex helpers, `sqlite3SchemaMutexHeld` redefinition, and missing `tommath`.
