### PR TITLE
Optimize table hash lookups

### DIFF
--- a/src/doltlite_hashof.c
+++ b/src/doltlite_hashof.c
@@ -52,58 +52,19 @@ static int hashofTableInCatalog(
   const char *zTable,
   char *pHex
 ){
-  struct TableEntry *aTables = 0;
-  struct TableEntry *pTE = 0;
-  ChunkStore *cs;
-  ProllyCache *cache;
-  SchemaEntry *aSchema = 0;
-  SchemaEntry *pSchema = 0;
-  int nTables = 0;
-  int nSchema = 0;
   ProllyHash schemaHash;
+  ProllyHash tableRoot;
   ProllyHash tableHash;
   u8 aBuf[PROLLY_HASH_SIZE*2];
   int rc;
 
-  rc = doltliteLoadCatalog(db, pCatHash, &aTables, &nTables, 0);
+  rc = doltliteLoadTableRootByName(db, pCatHash, zTable, &tableRoot, 0,
+                                   &schemaHash);
   if( rc!=SQLITE_OK ) return rc;
-  pTE = doltliteFindTableByName(aTables, nTables, zTable);
-  if( !pTE ){
-    doltliteFreeCatalog(aTables, nTables);
-    return SQLITE_NOTFOUND;
-  }
 
-  cs = doltliteGetChunkStore(db);
-  cache = doltliteGetCache(db);
-  if( !cs || !cache ){
-    doltliteFreeCatalog(aTables, nTables);
-    return SQLITE_ERROR;
-  }
-
-  rc = loadSchemaFromCatalog(db, cs, cache, pCatHash, &aSchema, &nSchema);
-  if( rc!=SQLITE_OK ){
-    doltliteFreeCatalog(aTables, nTables);
-    return rc;
-  }
-  pSchema = findSchemaEntry(aSchema, nSchema, zTable);
-  if( pSchema ){
-    char *zCanon = doltliteCanonicalizeSchemaSql(pSchema->zSql, pSchema->zName);
-    if( !zCanon ){
-      freeSchemaEntries(aSchema, nSchema);
-      doltliteFreeCatalog(aTables, nTables);
-      return SQLITE_NOMEM;
-    }
-    prollyHashCompute(zCanon, (int)strlen(zCanon), &schemaHash);
-    sqlite3_free(zCanon);
-  }else{
-    schemaHash = pTE->schemaHash;
-  }
-
-  memcpy(aBuf, pTE->root.data, PROLLY_HASH_SIZE);
+  memcpy(aBuf, tableRoot.data, PROLLY_HASH_SIZE);
   memcpy(aBuf + PROLLY_HASH_SIZE, schemaHash.data, PROLLY_HASH_SIZE);
   prollyHashCompute(aBuf, sizeof(aBuf), &tableHash);
-  freeSchemaEntries(aSchema, nSchema);
-  doltliteFreeCatalog(aTables, nTables);
   doltliteHashToHex(&tableHash, pHex);
   return SQLITE_OK;
 }

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -610,6 +610,14 @@ int doltliteLoadTableRootByName(
   u8 *pFlags,
   ProllyHash *pSchemaHash
 );
+int doltliteLoadCatalogRootByPage(
+  sqlite3 *db,
+  const ProllyHash *pCatHash,
+  Pgno iTable,
+  ProllyHash *pRoot,
+  u8 *pFlags,
+  ProllyHash *pSchemaHash
+);
 
 static SQLITE_INLINE int doltliteLoadTableRootByNameOrEmpty(
   sqlite3 *db,

--- a/src/doltlite_schema_diff.c
+++ b/src/doltlite_schema_diff.c
@@ -179,32 +179,22 @@ int loadSchemaFromCatalog(
   const ProllyHash *pCatHash,
   SchemaEntry **ppEntries, int *pnEntries
 ){
-  struct TableEntry *aTables = 0;
-  int nTables = 0;
   ProllyHash masterRoot;
   u8 masterFlags = 0;
   ProllyCursor cur;
-  int res, rc, i;
+  int res, rc;
   SchemaEntry *aEntries = 0;
   int nEntries = 0, nAlloc = 0;
 
-  rc = doltliteLoadCatalog(db, pCatHash, &aTables, &nTables, 0);
-  if( rc!=SQLITE_OK ){ *ppEntries = 0; *pnEntries = 0; return rc; }
-
-  memset(&masterRoot, 0, sizeof(masterRoot));
-  for(i=0; i<nTables; i++){
-    if( aTables[i].iTable==1 ){
-      memcpy(&masterRoot, &aTables[i].root, sizeof(ProllyHash));
-      masterFlags = aTables[i].flags;
-      break;
-    }
-  }
-  doltliteFreeCatalog(aTables, nTables);
-
-  if( prollyHashIsEmpty(&masterRoot) ){
-    *ppEntries = 0; *pnEntries = 0;
+  *ppEntries = 0;
+  *pnEntries = 0;
+  rc = doltliteLoadCatalogRootByPage(db, pCatHash, 1, &masterRoot,
+                                     &masterFlags, 0);
+  if( rc==SQLITE_NOTFOUND ){
     return SQLITE_OK;
   }
+  if( rc!=SQLITE_OK ) return rc;
+  if( prollyHashIsEmpty(&masterRoot) ) return SQLITE_OK;
 
   prollyCursorInit(&cur, cs, pCache, &masterRoot, masterFlags);
   rc = prollyCursorFirst(&cur, &res);

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -10241,10 +10241,11 @@ int doltliteLoadCatalog(sqlite3 *db, const ProllyHash *catHash,
   return SQLITE_OK;
 }
 
-int doltliteLoadTableRootByName(
+static int doltliteLoadCatalogRoot(
   sqlite3 *db,
   const ProllyHash *pCatHash,
   const char *zTableName,
+  Pgno iWantTable,
   ProllyHash *pRoot,
   u8 *pFlags,
   ProllyHash *pSchemaHash
@@ -10256,7 +10257,8 @@ int doltliteLoadTableRootByName(
   const u8 *pEntries;
   int nTables = 0;
   int iFormat = 0;
-  int nWant;
+  int nWant = 0;
+  int bByName = zTableName!=0;
   int found = 0;
   ProllyHash foundRoot;
   ProllyHash foundSchemaHash;
@@ -10268,10 +10270,14 @@ int doltliteLoadTableRootByName(
   if( pFlags ) *pFlags = 0;
   if( pSchemaHash ) memset(pSchemaHash, 0, sizeof(*pSchemaHash));
   if( !cs ) return SQLITE_ERROR;
-  if( !zTableName || !pCatHash || prollyHashIsEmpty(pCatHash) ){
+  if( !pCatHash || prollyHashIsEmpty(pCatHash) ){
     return SQLITE_NOTFOUND;
   }
-  nWant = (int)strlen(zTableName);
+  if( bByName ){
+    nWant = (int)strlen(zTableName);
+  }else if( iWantTable==0 ){
+    return SQLITE_NOTFOUND;
+  }
 
   rc = chunkStoreGet(cs, pCatHash, &data, &nData);
   if( rc!=SQLITE_OK ) return rc;
@@ -10282,6 +10288,7 @@ int doltliteLoadTableRootByName(
 
   q = pEntries;
   for(i=0; i<nTables; i++){
+    Pgno iTable;
     u8 flags;
     ProllyHash root;
     ProllyHash schemaHash;
@@ -10291,6 +10298,7 @@ int doltliteLoadTableRootByName(
       sqlite3_free(data);
       return SQLITE_CORRUPT;
     }
+    iTable = (Pgno)(q[0] | (q[1]<<8) | (q[2]<<16) | (q[3]<<24));
     q += CAT_ENTRY_ITABLE_SIZE;
     flags = *q++;
     memcpy(root.data, q, PROLLY_HASH_SIZE);
@@ -10319,8 +10327,14 @@ int doltliteLoadTableRootByName(
       pName = q;
       q += nName+nTbl;
       if( !found
+       && bByName
        && nType==5 && memcmp(pType, "table", 5)==0
        && nName==nWant && memcmp(pName, zTableName, nName)==0 ){
+        found = 1;
+        memcpy(&foundRoot, &root, sizeof(foundRoot));
+        memcpy(&foundSchemaHash, &schemaHash, sizeof(foundSchemaHash));
+        foundFlags = flags;
+      }else if( !found && !bByName && iTable==iWantTable ){
         found = 1;
         memcpy(&foundRoot, &root, sizeof(foundRoot));
         memcpy(&foundSchemaHash, &schemaHash, sizeof(foundSchemaHash));
@@ -10341,7 +10355,13 @@ int doltliteLoadTableRootByName(
       }
       pName = q;
       q += nLen;
-      if( !found && nLen==nWant && memcmp(pName, zTableName, nLen)==0 ){
+      if( !found && bByName
+       && nLen==nWant && memcmp(pName, zTableName, nLen)==0 ){
+        found = 1;
+        memcpy(&foundRoot, &root, sizeof(foundRoot));
+        memcpy(&foundSchemaHash, &schemaHash, sizeof(foundSchemaHash));
+        foundFlags = flags;
+      }else if( !found && !bByName && iTable==iWantTable ){
         found = 1;
         memcpy(&foundRoot, &root, sizeof(foundRoot));
         memcpy(&foundSchemaHash, &schemaHash, sizeof(foundSchemaHash));
@@ -10360,6 +10380,30 @@ int doltliteLoadTableRootByName(
   if( pFlags ) *pFlags = foundFlags;
   if( pSchemaHash ) memcpy(pSchemaHash, &foundSchemaHash, sizeof(*pSchemaHash));
   return SQLITE_OK;
+}
+
+int doltliteLoadTableRootByName(
+  sqlite3 *db,
+  const ProllyHash *pCatHash,
+  const char *zTableName,
+  ProllyHash *pRoot,
+  u8 *pFlags,
+  ProllyHash *pSchemaHash
+){
+  return doltliteLoadCatalogRoot(db, pCatHash, zTableName, 0,
+                                 pRoot, pFlags, pSchemaHash);
+}
+
+int doltliteLoadCatalogRootByPage(
+  sqlite3 *db,
+  const ProllyHash *pCatHash,
+  Pgno iTable,
+  ProllyHash *pRoot,
+  u8 *pFlags,
+  ProllyHash *pSchemaHash
+){
+  return doltliteLoadCatalogRoot(db, pCatHash, 0, iTable,
+                                 pRoot, pFlags, pSchemaHash);
 }
 
 void doltliteFreeCatalog(struct TableEntry *a, int n){


### PR DESCRIPTION
## Summary
- use the catalog entry's stored canonical schema hash for `dolt_hashof_table()` instead of loading and canonicalizing the full schema catalog
- extend the catalog-entry parser from #1495 to support page-number lookups
- use the page lookup in `loadSchemaFromCatalog()` so schema readers can fetch `sqlite_master` without materializing the full table catalog

## Performance
Synthetic repo: 800 tables, 200 repeated committed-ref calls to `SELECT dolt_hashof_table('t800','HEAD');`. Baseline is #1495 (`perf/targeted-catalog-lookup`); candidate is this branch.

- base: 0.17, 0.16, 0.16, 0.16, 0.16 sec
- candidate: 0.05, 0.05, 0.06, 0.05, 0.05 sec

Warm median: ~0.16s -> ~0.05s, about 69% faster.

For the one-argument working-set form, repeated `SELECT dolt_hashof_table('t800');` is mostly catalog-flush cost, but still improved from ~1.49-1.61s to ~1.37-1.45s in the same repo.

## Testing
- `make doltlite`
- `git diff --check`
- `sh test/vc_oracle_hashof_test.sh ./doltlite` (26 passed)
- `test/vc_oracle_hashof_errors_test.sh ./doltlite` (4 passed)
- `sh test/doltlite_schema_diff.sh ./doltlite` (49 passed)
- `test/vc_oracle_schema_diff_test.sh ./doltlite` (48 passed)
- `sh test/vc_oracle_diff_stat_test.sh ./doltlite` (49 passed)

`make devtest` still fails in the generated-build matrix before TCL tests run, with the existing `sqlite3BtreeSeekCount` conflicting types, undeclared `sqlite3BtreeLeave*`/mutex helper declarations, `sqlite3SchemaMutexHeld` redefinition, and missing `tommath` failures.
