### PR TITLE
Add oracle tests: varied PK shapes, constraints, and triggers through VC ops

### DIFF
--- a/test/vc_oracle_constraints_triggers_replay_test.sh
+++ b/test/vc_oracle_constraints_triggers_replay_test.sh
@@ -1,0 +1,516 @@
+#!/bin/bash
+
+set -u
+set -o pipefail
+
+DOLTLITE="${1:-./doltlite}"
+DOLT="${2:-dolt}"
+TMPROOT=$(mktemp -d)
+trap "rm -rf $TMPROOT" EXIT
+pass=0; fail=0
+FAILED_NAMES=""
+source "$(dirname "$0")/lib/vc_oracle_common.sh"
+
+translate_for_dolt() {
+  sed -E 's/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g'
+}
+
+# oracle: standard R|-prefixed oracle comparison
+oracle() {
+  local name="$1" setup="$2" query="$3" allow_empty="${4:-}"
+  local dir="$TMPROOT/$name"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_out
+  dl_out=$(printf ".bail off\n%s\n.headers off\n.mode list\n%s\n" "$setup" "$query" \
+           | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
+           | tr -d '\r' \
+           | grep '^R|' | sort)
+
+  local dolt_setup dolt_query
+  dolt_setup=$(echo "$setup" | translate_for_dolt)
+  dolt_query=$(echo "$query" | translate_for_dolt)
+
+  (
+    cd "$dir/dt" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    {
+      echo "$dolt_setup"
+      echo "$dolt_query"
+    } | "$DOLT" sql -c -r csv 2>"$dir/dt.err"
+  ) > "$dir/dt.raw"
+  local dt_out
+  dt_out=$(tr -d '"\r' < "$dir/dt.raw" | grep '^R|' | sort)
+
+  if [ "$allow_empty" = "EXPECT_EMPTY" ]; then
+    vc_oracle_assert_match_allow_empty "$name" "$dl_out" "$dt_out"
+  else
+    vc_oracle_assert_match "$name" "$dl_out" "$dt_out"
+  fi
+}
+
+# oracle_replay_fail: run setup then replay (which may fail), then query state.
+# Both doltlite (bail off) and dolt (sql -c) continue past errors.
+oracle_replay_fail() {
+  local name="$1" setup="$2" replay="$3" query="$4"
+  local dir="$TMPROOT/$name"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_out
+  dl_out=$(printf ".bail off\n%s\n%s\n.headers off\n.mode list\n%s\n" \
+                  "$setup" "$replay" "$query" \
+           | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
+           | tr -d '\r' \
+           | grep '^R|' | sort)
+
+  local dolt_setup dolt_replay dolt_query
+  dolt_setup=$(echo "$setup" | translate_for_dolt)
+  dolt_replay=$(echo "$replay" | translate_for_dolt)
+  dolt_query=$(echo "$query" | translate_for_dolt)
+
+  (
+    cd "$dir/dt" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    {
+      echo "$dolt_setup"
+      echo "$dolt_replay"
+      echo "$dolt_query"
+    } | "$DOLT" sql -c -r csv 2>"$dir/dt.err"
+  ) > "$dir/dt.raw"
+  local dt_out
+  dt_out=$(tr -d '"\r' < "$dir/dt.raw" | grep '^R|' | sort)
+
+  vc_oracle_assert_match "$name" "$dl_out" "$dt_out"
+}
+
+# oracle_triggers_dual: separate dl/dt setup for trigger syntax differences.
+# SQLite: AFTER INSERT ON t BEGIN ... END
+# MySQL:  AFTER INSERT ON t FOR EACH ROW ...
+# Setup and query run in ONE session so the active branch after VC ops is visible.
+oracle_triggers_dual() {
+  local name="$1" dl_setup="$2" dt_setup="$3" query="$4" allow_empty="${5:-}"
+  local dir="$TMPROOT/$name"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_out
+  dl_out=$(printf ".bail off\n%s\n.headers off\n.mode list\n%s\n" "$dl_setup" "$query" \
+           | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
+           | grep -v '^[0-9]*$' \
+           | grep -v '^[0-9a-f]\{40\}$' \
+           | grep -v '^$' \
+           | grep -vi 'already up to date' \
+           | grep -vi 'Fast-forward' \
+           | tr -d '"' \
+           | grep '^R|' \
+           | tr -d '\r' | sort)
+
+  local dolt_setup_translated dolt_query_translated
+  dolt_setup_translated=$(vc_oracle_translate_for_dolt "$dt_setup")
+  dolt_query_translated=$(vc_oracle_translate_for_dolt "$query")
+
+  local dt_out
+  dt_out=$(
+    cd "$dir/dt" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    {
+      printf '%s\n' "$dolt_setup_translated"
+      printf '%s\n' "$dolt_query_translated"
+    } | "$DOLT" sql -c -r csv 2>"$dir/dt.err"
+  )
+  dt_out=$(echo "$dt_out" | tr -d '"' | grep '^R|' | tr -d '\r' | sort)
+
+  if [ "$allow_empty" = "EXPECT_EMPTY" ]; then
+    vc_oracle_assert_match_allow_empty "$name" "$dl_out" "$dt_out"
+  else
+    vc_oracle_assert_match "$name" "$dl_out" "$dt_out"
+  fi
+}
+
+echo "=== Version Control Oracle Tests: constraints and triggers through replay ==="
+echo ""
+
+echo "--- Group A: CHECK constraint + cherry-pick ---"
+
+oracle "check_cherrypick_valid" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT CHECK(v>0));
+INSERT INTO t VALUES(1,10);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(2,20);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_add');
+SELECT dolt_checkout('main');
+SELECT dolt_cherry_pick('feat');
+" "SELECT CONCAT('R|',id,'|',v) FROM t ORDER BY id;"
+
+oracle_replay_fail "check_cherrypick_violation" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1,10);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(2,-5);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_bad');
+SELECT dolt_checkout('main');
+CREATE TABLE t2(id INTEGER PRIMARY KEY, v INT CHECK(v>0));
+INSERT INTO t2 SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t2 RENAME TO t;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','main_check');
+" "SELECT dolt_cherry_pick('feat');" \
+  "SELECT CONCAT('R|',id,'|',v) FROM t ORDER BY id;"
+
+echo ""
+echo "--- Group B: UNIQUE constraint + cherry-pick ---"
+
+oracle "unique_cherrypick_valid" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, u INT UNIQUE);
+INSERT INTO t VALUES(1,10);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(2,20);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_add');
+SELECT dolt_checkout('main');
+SELECT dolt_cherry_pick('feat');
+" "SELECT CONCAT('R|',id,'|',u) FROM t ORDER BY id;"
+
+oracle_replay_fail "unique_cherrypick_violation" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, u INT);
+INSERT INTO t VALUES(1,10);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(2,10);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_dup');
+SELECT dolt_checkout('main');
+CREATE TABLE t2(id INTEGER PRIMARY KEY, u INT UNIQUE);
+INSERT INTO t2 SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t2 RENAME TO t;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','main_unique');
+" "SELECT dolt_cherry_pick('feat');" \
+  "SELECT CONCAT('R|',id,'|',u) FROM t ORDER BY id;"
+
+echo ""
+echo "--- Group C: FK constraint + cherry-pick ---"
+
+oracle "fk_cherrypick_valid" "
+CREATE TABLE p(id INTEGER PRIMARY KEY, u INT UNIQUE);
+CREATE TABLE c(id INTEGER PRIMARY KEY, pid INT, FOREIGN KEY(pid) REFERENCES p(id));
+INSERT INTO p VALUES(1,100),(2,200);
+INSERT INTO c VALUES(1,1);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO c VALUES(2,2);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_child');
+SELECT dolt_checkout('main');
+SELECT dolt_cherry_pick('feat');
+" "SELECT CONCAT('R|',id,'|',pid) FROM c ORDER BY id;"
+
+oracle_replay_fail "fk_cherrypick_orphan" "
+CREATE TABLE p(id INTEGER PRIMARY KEY, u INT UNIQUE);
+CREATE TABLE c(id INTEGER PRIMARY KEY, u INT);
+INSERT INTO p VALUES(1,100);
+INSERT INTO c VALUES(1,100);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO c VALUES(2,200);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_orphan');
+SELECT dolt_checkout('main');
+CREATE TABLE c2(id INTEGER PRIMARY KEY, u INT, FOREIGN KEY(u) REFERENCES p(u));
+INSERT INTO c2 SELECT * FROM c;
+DROP TABLE c;
+ALTER TABLE c2 RENAME TO c;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','main_fk');
+" "SELECT dolt_cherry_pick('feat');" \
+  "SELECT CONCAT('R|',id,'|',u) FROM c ORDER BY id;"
+
+echo ""
+echo "--- Group D: CHECK constraint + rebase ---"
+
+oracle "check_rebase_valid" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT CHECK(v>0));
+INSERT INTO t VALUES(1,10);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(2,20);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_add');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(3,30);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','main_advance');
+SELECT dolt_checkout('feat');
+SELECT dolt_rebase('main');
+" "SELECT CONCAT('R|',id,'|',v) FROM t ORDER BY id;"
+
+oracle_replay_fail "check_rebase_violation" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1,10);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(2,-1);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_bad');
+SELECT dolt_checkout('main');
+CREATE TABLE t2(id INTEGER PRIMARY KEY, v INT CHECK(v>0));
+INSERT INTO t2 SELECT * FROM t;
+DROP TABLE t;
+ALTER TABLE t2 RENAME TO t;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','main_check');
+SELECT dolt_checkout('feat');
+" "SELECT dolt_rebase('main');" \
+  "SELECT CONCAT('R|',id,'|',v) FROM t ORDER BY id;"
+
+echo ""
+echo "--- Group E: FK constraint + rebase ---"
+
+oracle "fk_rebase_valid" "
+CREATE TABLE p(id INTEGER PRIMARY KEY, u INT UNIQUE);
+CREATE TABLE c(id INTEGER PRIMARY KEY, pid INT, FOREIGN KEY(pid) REFERENCES p(id));
+INSERT INTO p VALUES(1,100);
+INSERT INTO c VALUES(1,1);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO p VALUES(2,200);
+INSERT INTO c VALUES(2,2);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_add');
+SELECT dolt_checkout('main');
+INSERT INTO p VALUES(3,300);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','main_advance');
+SELECT dolt_checkout('feat');
+SELECT dolt_rebase('main');
+" "SELECT CONCAT('R|',id,'|',pid) FROM c ORDER BY id;"
+
+oracle_replay_fail "fk_rebase_orphan" "
+CREATE TABLE p(id INTEGER PRIMARY KEY, u INT UNIQUE);
+CREATE TABLE c(id INTEGER PRIMARY KEY, u INT);
+INSERT INTO p VALUES(1,100);
+INSERT INTO c VALUES(1,100);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','init');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO c VALUES(2,200);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_orphan');
+SELECT dolt_checkout('main');
+CREATE TABLE c2(id INTEGER PRIMARY KEY, u INT, FOREIGN KEY(u) REFERENCES p(u));
+INSERT INTO c2 SELECT * FROM c;
+DROP TABLE c;
+ALTER TABLE c2 RENAME TO c;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','main_fk');
+SELECT dolt_checkout('feat');
+" "SELECT dolt_rebase('main');" \
+  "SELECT CONCAT('R|',id,'|',u) FROM c ORDER BY id;"
+
+echo ""
+echo "--- Group F: AFTER triggers fire based on commit diff, not replay DML ---"
+
+oracle_triggers_dual "trigger_insert_log_travels_with_cherrypick" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+CREATE TABLE log(id INTEGER PRIMARY KEY);
+CREATE TRIGGER t_ai AFTER INSERT ON t BEGIN INSERT OR IGNORE INTO log VALUES(new.id); END;
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(2,'b');
+INSERT INTO t VALUES(3,'c');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_inserts');
+SELECT dolt_checkout('main');
+SELECT dolt_cherry_pick('feat');
+" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v VARCHAR(16));
+CREATE TABLE log(id INTEGER PRIMARY KEY);
+CREATE TRIGGER t_ai AFTER INSERT ON t FOR EACH ROW INSERT IGNORE INTO log VALUES(new.id);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(2,'b');
+INSERT INTO t VALUES(3,'c');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_inserts');
+SELECT dolt_checkout('main');
+SELECT dolt_cherry_pick('feat');
+" "SELECT CONCAT('R|',id) FROM log ORDER BY id;" "EXPECT_EMPTY"
+
+oracle_triggers_dual "trigger_update_log_travels_with_cherrypick" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+CREATE TABLE log(id INTEGER PRIMARY KEY, delta INT);
+CREATE TRIGGER t_au AFTER UPDATE ON t BEGIN INSERT INTO log VALUES(new.id, new.v - old.v); END;
+INSERT INTO t VALUES(1,10),(2,20);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+UPDATE t SET v=30 WHERE id=1;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_update');
+SELECT dolt_checkout('main');
+SELECT dolt_cherry_pick('feat');
+" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INTEGER);
+CREATE TABLE log(id INTEGER PRIMARY KEY, delta INTEGER);
+CREATE TRIGGER t_au AFTER UPDATE ON t FOR EACH ROW INSERT INTO log VALUES(new.id, new.v - old.v);
+INSERT INTO t VALUES(1,10),(2,20);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+UPDATE t SET v=30 WHERE id=1;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_update');
+SELECT dolt_checkout('main');
+SELECT dolt_cherry_pick('feat');
+" "SELECT CONCAT('R|',id,'|',IFNULL(delta,'')) FROM log ORDER BY id;" "EXPECT_EMPTY"
+
+oracle_triggers_dual "trigger_delete_log_travels_with_cherrypick" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+CREATE TABLE log(id INTEGER PRIMARY KEY);
+CREATE TRIGGER t_ad AFTER DELETE ON t BEGIN INSERT OR IGNORE INTO log VALUES(old.id); END;
+INSERT INTO t VALUES(1,'a'),(2,'b'),(3,'c');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+DELETE FROM t WHERE id>=2;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_delete');
+SELECT dolt_checkout('main');
+SELECT dolt_cherry_pick('feat');
+" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v VARCHAR(8));
+CREATE TABLE log(id INTEGER PRIMARY KEY);
+CREATE TRIGGER t_ad AFTER DELETE ON t FOR EACH ROW INSERT IGNORE INTO log VALUES(old.id);
+INSERT INTO t VALUES(1,'a'),(2,'b'),(3,'c');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+DELETE FROM t WHERE id>=2;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_delete');
+SELECT dolt_checkout('main');
+SELECT dolt_cherry_pick('feat');
+" "SELECT CONCAT('R|',id) FROM log ORDER BY id;" "EXPECT_EMPTY"
+
+echo ""
+echo "--- Group G: trigger schema preserved through rebase, fires on subsequent DML ---"
+
+oracle_triggers_dual "trigger_preserved_after_rebase_fires_on_insert" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+CREATE TABLE log(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+CREATE TRIGGER t_ai AFTER INSERT ON t BEGIN INSERT OR IGNORE INTO log VALUES(new.id); END;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_trigger');
+INSERT INTO t VALUES(2,'b');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_data');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(10,'main');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','main_advance');
+SELECT dolt_checkout('feat');
+SELECT dolt_rebase('main');
+INSERT INTO t VALUES(20,'after_rebase');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','post_rebase');
+" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v VARCHAR(16));
+CREATE TABLE log(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+CREATE TRIGGER t_ai AFTER INSERT ON t FOR EACH ROW INSERT IGNORE INTO log VALUES(new.id);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_trigger');
+INSERT INTO t VALUES(2,'b');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_data');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(10,'main');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','main_advance');
+SELECT dolt_checkout('feat');
+SELECT dolt_rebase('main');
+INSERT INTO t VALUES(20,'after_rebase');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','post_rebase');
+" "SELECT CONCAT('R|',id) FROM log ORDER BY id;"
+
+oracle_triggers_dual "trigger_rebase_multi_commit_post_insert" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+CREATE TABLE log(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+CREATE TRIGGER t_ai AFTER INSERT ON t BEGIN INSERT OR IGNORE INTO log VALUES(new.id); END;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_trigger');
+INSERT INTO t VALUES(2,'b');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_c2');
+INSERT INTO t VALUES(3,'c');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_c3');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(10,'m');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','main_advance');
+SELECT dolt_checkout('feat');
+SELECT dolt_rebase('main');
+INSERT INTO t VALUES(30,'post');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','post_rebase');
+" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v VARCHAR(8));
+CREATE TABLE log(id INTEGER PRIMARY KEY);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+CREATE TRIGGER t_ai AFTER INSERT ON t FOR EACH ROW INSERT IGNORE INTO log VALUES(new.id);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_trigger');
+INSERT INTO t VALUES(2,'b');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_c2');
+INSERT INTO t VALUES(3,'c');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_c3');
+SELECT dolt_checkout('main');
+INSERT INTO t VALUES(10,'m');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','main_advance');
+SELECT dolt_checkout('feat');
+SELECT dolt_rebase('main');
+INSERT INTO t VALUES(30,'post');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','post_rebase');
+" "SELECT CONCAT('R|',id) FROM log ORDER BY id;"
+
+echo ""
+echo "--- Group H: triggers on composite PK tables through cherry-pick ---"
+
+oracle_triggers_dual "trigger_composite_pk_cherrypick_fires_on_target_insert" "
+CREATE TABLE t(a INTEGER, b TEXT, v INT, PRIMARY KEY(a, b));
+CREATE TABLE log(a INTEGER, b TEXT, PRIMARY KEY(a, b));
+CREATE TRIGGER t_ai AFTER INSERT ON t BEGIN INSERT OR IGNORE INTO log VALUES(new.a, new.b); END;
+INSERT INTO t VALUES(1,'x',10);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(2,'y',20);
+INSERT INTO t VALUES(2,'z',30);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_inserts');
+SELECT dolt_checkout('main');
+SELECT dolt_cherry_pick('feat');
+" "
+CREATE TABLE t(a INTEGER, b VARCHAR(4), v INTEGER, PRIMARY KEY(a, b));
+CREATE TABLE log(a INTEGER, b VARCHAR(4), PRIMARY KEY(a, b));
+CREATE TRIGGER t_ai AFTER INSERT ON t FOR EACH ROW INSERT IGNORE INTO log VALUES(new.a, new.b);
+INSERT INTO t VALUES(1,'x',10);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+INSERT INTO t VALUES(2,'y',20);
+INSERT INTO t VALUES(2,'z',30);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_inserts');
+SELECT dolt_checkout('main');
+SELECT dolt_cherry_pick('feat');
+" "SELECT CONCAT('R|',a,'|',b) FROM log ORDER BY a,b;" "EXPECT_EMPTY"
+
+oracle_triggers_dual "trigger_composite_pk_post_merge_fires" "
+CREATE TABLE t(a INTEGER, b TEXT, v INT, PRIMARY KEY(a, b));
+CREATE TABLE log(a INTEGER, b TEXT, PRIMARY KEY(a, b));
+INSERT INTO t VALUES(1,'x',10);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+CREATE TRIGGER t_ai AFTER INSERT ON t BEGIN INSERT OR IGNORE INTO log VALUES(new.a, new.b); END;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_trigger');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+INSERT INTO t VALUES(2,'y',20);
+INSERT INTO t VALUES(2,'z',30);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','post_merge');
+" "
+CREATE TABLE t(a INTEGER, b VARCHAR(4), v INTEGER, PRIMARY KEY(a, b));
+CREATE TABLE log(a INTEGER, b VARCHAR(4), PRIMARY KEY(a, b));
+INSERT INTO t VALUES(1,'x',10);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','base');
+SELECT dolt_checkout('-b','feat');
+CREATE TRIGGER t_ai AFTER INSERT ON t FOR EACH ROW INSERT IGNORE INTO log VALUES(new.a, new.b);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat_trigger');
+SELECT dolt_checkout('main');
+SELECT dolt_merge('feat');
+INSERT INTO t VALUES(2,'y',20);
+INSERT INTO t VALUES(2,'z',30);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','post_merge');
+" "SELECT CONCAT('R|',a,'|',b) FROM log ORDER BY a,b;"
+
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+if [ $fail -gt 0 ]; then
+  echo "Failures:$FAILED_NAMES"
+  exit 1
+fi

--- a/test/vc_oracle_pk_shapes_conflicts_test.sh
+++ b/test/vc_oracle_pk_shapes_conflicts_test.sh
@@ -1,0 +1,306 @@
+#!/bin/bash
+
+set -u
+set -o pipefail
+
+DOLTLITE="${1:-./doltlite}"
+DOLT="${2:-dolt}"
+TMPROOT=$(mktemp -d)
+trap "rm -rf $TMPROOT" EXIT
+pass=0; fail=0
+FAILED_NAMES=""
+source "$(dirname "$0")/lib/vc_oracle_common.sh"
+
+translate_for_dolt() {
+  sed -E '
+    s/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g
+    s/dolt_diff_(stat|summary)([^a-zA-Z0-9_])/@@DS\1@@\2/g
+    s/dolt_diff_([a-zA-Z0-9_]+)\(([^)]*)\)/dolt_diff(\2, "\1")/g
+    s/@@DS(stat|summary)@@/dolt_diff_\1/g
+  '
+}
+
+oracle() {
+  local name="$1" setup="$2" query="$3" allow_empty="${4:-}"
+  local dir="$TMPROOT/$name"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_out
+  dl_out=$(printf "%s\n.headers off\n.mode list\n%s\n" "$setup" "$query" \
+           | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
+           | tr -d '\r' \
+           | grep '^R|' | sort)
+
+  local dolt_setup dolt_query
+  dolt_setup=$(echo "$setup" | translate_for_dolt)
+  dolt_query=$(echo "$query" | translate_for_dolt)
+
+  (
+    cd "$dir/dt" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    {
+      echo "$dolt_setup"
+      echo "$dolt_query"
+    } | "$DOLT" sql -c -r csv 2>"$dir/dt.err"
+  ) > "$dir/dt.raw"
+  local dt_out
+  dt_out=$(tr -d '"\r' < "$dir/dt.raw" | grep '^R|' | sort)
+
+  if [ "$allow_empty" = "EXPECT_EMPTY" ]; then
+    vc_oracle_assert_match_allow_empty "$name" "$dl_out" "$dt_out"
+  else
+    vc_oracle_assert_match "$name" "$dl_out" "$dt_out"
+  fi
+}
+
+oracle_conflict() {
+  local name="$1" setup="$2" resolve_and_query="$3"
+  local dir="$TMPROOT/$name"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_script
+  dl_script=$(printf "%s\n%s\n" "$setup" "$resolve_and_query" \
+    | perl -0pe "s/\nSELECT dolt_merge\(/\nBEGIN;\nSELECT dolt_merge\(/")
+
+  local dl_out
+  dl_out=$(printf "%s" "$dl_script" \
+           | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
+           | grep -v '^[0-9]*$' \
+           | grep -v '^[0-9a-f]\{40\}$' \
+           | grep -v '^Merge has' \
+           | grep '^R|' \
+           | tr -d '\r' | sort)
+
+  local dolt_all
+  dolt_all=$(vc_oracle_translate_for_dolt "$(printf '%s\n%s' "$setup" "$resolve_and_query")")
+
+  local dt_out
+  dt_out=$(
+    cd "$dir/dt" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    {
+      printf 'SET @@autocommit = 0;\n'
+      printf 'SET @@dolt_allow_commit_conflicts = 1;\n'
+      printf '%s\n' "$dolt_all"
+    } | "$DOLT" sql -c -r csv 2>"$dir/dt.err"
+  )
+  dt_out=$(echo "$dt_out" | tr -d '"' | grep '^R|' | tr -d '\r' | sort)
+
+  vc_oracle_assert_match "$name" "$dl_out" "$dt_out"
+}
+
+echo "=== Version Control Oracle Tests: varied PK shapes and conflicts ==="
+echo ""
+
+echo "--- Group A: REAL primary key ---"
+
+oracle "a_real_pk_diff" "
+CREATE TABLE t(pk REAL PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1.5,'a'),(2.25,'b'),(3.75,'c');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','seed');
+UPDATE t SET v='B' WHERE pk=2.25;
+DELETE FROM t WHERE pk=1.5;
+INSERT INTO t VALUES(4.5,'d');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','c2');
+" "SELECT CONCAT('R|',IFNULL(to_pk,''),'|',IFNULL(to_v,''),'|',IFNULL(from_pk,''),'|',IFNULL(from_v,''),'|',diff_type)
+   FROM dolt_diff_t('HEAD~1','HEAD') ORDER BY IFNULL(to_pk,from_pk);"
+
+oracle "a_real_pk_pk_move" "
+CREATE TABLE t(pk REAL PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1.5,'one');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','seed');
+UPDATE t SET pk=9.875 WHERE pk=1.5;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','move_pk');
+" "SELECT CONCAT('R|',IFNULL(to_pk,''),'|',IFNULL(to_v,''),'|',IFNULL(from_pk,''),'|',IFNULL(from_v,''),'|',diff_type)
+   FROM dolt_diff_t('HEAD~1','HEAD') ORDER BY diff_type;"
+
+oracle "a_real_pk_history" "
+CREATE TABLE t(pk REAL PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1.5,'x'),(2.25,'y');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','SEED');
+UPDATE t SET v='X' WHERE pk=1.5;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','UPDATE1');
+INSERT INTO t VALUES(3.75,'z');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','INSERT2');
+" "SELECT CONCAT('R|',h.pk,'|',h.v,'|',l.message)
+   FROM dolt_history_t h LEFT JOIN dolt_log l ON l.commit_hash=h.commit_hash
+   ORDER BY h.pk, l.message;"
+
+oracle "a_real_pk_blame" "
+CREATE TABLE t(pk REAL PRIMARY KEY, v INT);
+INSERT INTO t VALUES(1.5,10),(2.25,20);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','SEED');
+UPDATE t SET v=200 WHERE pk=2.25;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','BUMP');
+INSERT INTO t VALUES(3.75,30);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','ADD');
+" "SELECT CONCAT('R|',pk,'|',message) FROM dolt_blame_t ORDER BY pk;"
+
+oracle_conflict "a_real_pk_conflict_ours" "
+CREATE TABLE t(pk REAL PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1.5,'base'),(2.25,'stable');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','seed');
+SELECT dolt_branch('feat');
+UPDATE t SET v='main_val' WHERE pk=1.5;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','main');
+SELECT dolt_checkout('feat');
+UPDATE t SET v='feat_val' WHERE pk=1.5;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+" "
+SELECT dolt_merge('feat');
+SELECT dolt_conflicts_resolve('--ours','t');
+SELECT CONCAT('R|',pk,'|',v) FROM t ORDER BY pk;"
+
+oracle_conflict "a_real_pk_conflict_theirs" "
+CREATE TABLE t(pk REAL PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1.5,'base'),(2.25,'stable');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','seed');
+SELECT dolt_branch('feat');
+UPDATE t SET v='main_val' WHERE pk=1.5;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','main');
+SELECT dolt_checkout('feat');
+UPDATE t SET v='feat_val' WHERE pk=1.5;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+" "
+SELECT dolt_merge('feat');
+SELECT dolt_conflicts_resolve('--theirs','t');
+SELECT CONCAT('R|',pk,'|',v) FROM t ORDER BY pk;"
+
+echo ""
+echo "--- Group B: composite (INT, REAL) primary key ---"
+
+oracle "b_int_real_pk_diff" "
+CREATE TABLE t(a INTEGER, b REAL, v TEXT, PRIMARY KEY(a, b));
+INSERT INTO t VALUES(1,1.5,'one'),(1,2.25,'two'),(2,0.75,'three');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','seed');
+UPDATE t SET v='TWO' WHERE a=1 AND b=2.25;
+INSERT INTO t VALUES(2,1.5,'four');
+DELETE FROM t WHERE a=1 AND b=1.5;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','c2');
+" "SELECT CONCAT('R|',IFNULL(to_a,''),'|',IFNULL(to_b,''),'|',IFNULL(to_v,''),'|',IFNULL(from_a,''),'|',IFNULL(from_b,''),'|',IFNULL(from_v,''),'|',diff_type)
+   FROM dolt_diff_t('HEAD~1','HEAD') ORDER BY IFNULL(to_a,from_a),IFNULL(to_b,from_b);"
+
+oracle "b_int_real_pk_history" "
+CREATE TABLE t(a INTEGER, b REAL, v TEXT, PRIMARY KEY(a, b));
+INSERT INTO t VALUES(1,1.5,'x'),(1,2.25,'y');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','SEED');
+UPDATE t SET v='Y' WHERE a=1 AND b=2.25;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','UPD');
+" "SELECT CONCAT('R|',h.a,'|',h.b,'|',h.v,'|',l.message)
+   FROM dolt_history_t h LEFT JOIN dolt_log l ON l.commit_hash=h.commit_hash
+   ORDER BY h.a, h.b, l.message;"
+
+oracle_conflict "b_int_real_pk_conflict_ours" "
+CREATE TABLE t(a INTEGER, b REAL, v TEXT, PRIMARY KEY(a, b));
+INSERT INTO t VALUES(1,1.5,'base');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','seed');
+SELECT dolt_branch('feat');
+UPDATE t SET v='main_v' WHERE a=1 AND b=1.5;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','main');
+SELECT dolt_checkout('feat');
+UPDATE t SET v='feat_v' WHERE a=1 AND b=1.5;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+" "
+SELECT dolt_merge('feat');
+SELECT dolt_conflicts_resolve('--ours','t');
+SELECT CONCAT('R|',a,'|',b,'|',v) FROM t ORDER BY a,b;"
+
+echo ""
+echo "--- Group C: composite (TEXT, TEXT) primary key ---"
+
+oracle "c_text_text_pk_diff" "
+CREATE TABLE t(cat VARCHAR(32), tag VARCHAR(32), v INT, PRIMARY KEY(cat, tag));
+INSERT INTO t VALUES('alice','math',90),('alice','sci',85),('bob','math',75);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','seed');
+UPDATE t SET v=95 WHERE cat='alice' AND tag='math';
+DELETE FROM t WHERE cat='bob' AND tag='math';
+INSERT INTO t VALUES('bob','sci',80);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','c2');
+" "SELECT CONCAT('R|',IFNULL(to_cat,''),'|',IFNULL(to_tag,''),'|',IFNULL(to_v,''),'|',IFNULL(from_cat,''),'|',IFNULL(from_tag,''),'|',IFNULL(from_v,''),'|',diff_type)
+   FROM dolt_diff_t('HEAD~1','HEAD') ORDER BY diff_type, IFNULL(to_cat,from_cat);"
+
+oracle "c_text_text_pk_blame" "
+CREATE TABLE t(cat VARCHAR(32), tag VARCHAR(32), v INT, PRIMARY KEY(cat, tag));
+INSERT INTO t VALUES('alice','math',90),('bob','math',75);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','SEED');
+UPDATE t SET v=95 WHERE cat='alice' AND tag='math';
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','BUMP');
+" "SELECT CONCAT('R|',cat,'|',tag,'|',message) FROM dolt_blame_t ORDER BY cat,tag;"
+
+oracle_conflict "c_text_text_pk_conflict_ours" "
+CREATE TABLE t(cat VARCHAR(32), tag VARCHAR(32), v INT, PRIMARY KEY(cat, tag));
+INSERT INTO t VALUES('alice','math',90);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','seed');
+SELECT dolt_branch('feat');
+UPDATE t SET v=100 WHERE cat='alice' AND tag='math';
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','main');
+SELECT dolt_checkout('feat');
+UPDATE t SET v=99 WHERE cat='alice' AND tag='math';
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+" "
+SELECT dolt_merge('feat');
+SELECT dolt_conflicts_resolve('--ours','t');
+SELECT CONCAT('R|',cat,'|',tag,'|',v) FROM t ORDER BY cat,tag;"
+
+oracle_conflict "c_text_text_pk_conflict_theirs" "
+CREATE TABLE t(cat VARCHAR(32), tag VARCHAR(32), v INT, PRIMARY KEY(cat, tag));
+INSERT INTO t VALUES('alice','math',90),('bob','sci',70);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','seed');
+SELECT dolt_branch('feat');
+UPDATE t SET v=100 WHERE cat='alice' AND tag='math';
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','main');
+SELECT dolt_checkout('feat');
+UPDATE t SET v=55 WHERE cat='alice' AND tag='math';
+INSERT INTO t VALUES('carol','lang',88);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','feat');
+SELECT dolt_checkout('main');
+" "
+SELECT dolt_merge('feat');
+SELECT dolt_conflicts_resolve('--theirs','t');
+SELECT CONCAT('R|',cat,'|',tag,'|',v) FROM t ORDER BY cat,tag;"
+
+echo ""
+echo "--- Group D: large and negative integer primary keys ---"
+
+oracle "d_large_int_pk_diff" "
+CREATE TABLE t(pk BIGINT PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(4294967296,'a'),(8589934592,'b'),(17179869184,'c');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','seed');
+UPDATE t SET v='B' WHERE pk=8589934592;
+DELETE FROM t WHERE pk=4294967296;
+INSERT INTO t VALUES(34359738368,'d');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','c2');
+" "SELECT CONCAT('R|',IFNULL(to_pk,''),'|',IFNULL(to_v,''),'|',IFNULL(from_pk,''),'|',IFNULL(from_v,''),'|',diff_type)
+   FROM dolt_diff_t('HEAD~1','HEAD') ORDER BY diff_type, IFNULL(to_pk,from_pk);"
+
+oracle "d_negative_int_pk_diff" "
+CREATE TABLE t(pk INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(-300,'a'),(-100,'b'),(0,'c'),(50,'d');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','seed');
+UPDATE t SET v='NEG' WHERE pk=-300;
+INSERT INTO t VALUES(-500,'e');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','c2');
+" "SELECT CONCAT('R|',IFNULL(to_pk,''),'|',IFNULL(to_v,''),'|',IFNULL(from_pk,''),'|',IFNULL(from_v,''),'|',diff_type)
+   FROM dolt_diff_t('HEAD~1','HEAD') ORDER BY diff_type, IFNULL(to_pk,from_pk);"
+
+oracle "d_mixed_sign_pk_history" "
+CREATE TABLE t(pk INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES(-1000,1),(-1,2),(0,3),(1,4),(1000,5);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','SEED');
+UPDATE t SET v=20 WHERE pk=-1;
+UPDATE t SET v=40 WHERE pk=1;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m','UPD');
+" "SELECT CONCAT('R|',h.pk,'|',h.v,'|',l.message)
+   FROM dolt_history_t h LEFT JOIN dolt_log l ON l.commit_hash=h.commit_hash
+   ORDER BY h.pk, l.message;"
+
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+if [ $fail -gt 0 ]; then
+  echo "Failures:$FAILED_NAMES"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- **`test/vc_oracle_pk_shapes_conflicts_test.sh`** (16 tests): REAL PK diff/history/blame/conflict, composite (INT,REAL) PK diff/history/conflict, composite (VARCHAR,VARCHAR) PK diff/blame/conflict, large (>2^32) and negative INT PK diff/history — all compared row-for-row against Dolt
- **`test/vc_oracle_constraints_triggers_replay_test.sh`** (17 tests): CHECK and UNIQUE constraints through valid cherry-pick and rebase, FK valid cherry-pick and rebase, violation/orphan rollback scenarios, AFTER INSERT/UPDATE/DELETE triggers through cherry-pick (verified empty — triggers don't fire during replay DML), and trigger-preserved-through-rebase firing on subsequent DML

Both files are auto-picked up by the CI `vc_oracle_*_test.sh` glob; no manifest update needed.

## Design notes

- Blame uses `commit` (not `commit_hash`) and has `message` directly — no JOIN needed
- History uses `commit_hash` column → LEFT JOIN `dolt_log` for message
- Text PKs require `VARCHAR(n)`, not `TEXT`, for Dolt/MySQL compatibility
- Large INT values (>2^31) require `BIGINT` in Dolt
- Constraint "valid" tests create constraints from the start on both branches to avoid Dolt's schema-tag-mismatch rejection
- `oracle_triggers_dual` runs setup + query in one session so post-rebase branch state is visible

## Test plan

- [ ] Both test files pass locally: 16/16 and 17/17
- [ ] CI `vc-oracle-tests` job green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)