### PR TITLE
Optimize filtered dolt_diff catalog lookups

### DIFF
--- a/src/doltlite_diff.c
+++ b/src/doltlite_diff.c
@@ -335,6 +335,83 @@ static int diffCatalogPairOne(
                      dataChange, schemaChange);
 }
 
+static int diffCatalogHashesOne(
+  DoltliteDiffCursor *pCur, sqlite3 *db,
+  const ProllyHash *pChildCat,
+  const ProllyHash *pParentCat,
+  const char *zHex, const DoltliteCommit *pCommit
+){
+  struct TableEntry childEntry, parentEntry;
+  int foundChild = 0, foundParent = 0;
+  int rc;
+  u8 dataChange;
+  u8 schemaChange;
+
+  if( !pCur->zFilterTable ) return SQLITE_OK;
+  memset(&childEntry, 0, sizeof(childEntry));
+  memset(&parentEntry, 0, sizeof(parentEntry));
+
+  if( strcmp(pCur->zFilterTable, "dolt_schemas")==0 ){
+    ProllyHash emptyRoot;
+    const ProllyHash *pOldRoot;
+
+    memset(&emptyRoot, 0, sizeof(emptyRoot));
+    rc = doltliteLoadCatalogRootByPage(db, pChildCat, 1, &childEntry.root,
+                                       &childEntry.flags,
+                                       &childEntry.schemaHash);
+    if( rc==SQLITE_NOTFOUND ) return SQLITE_OK;
+    if( rc!=SQLITE_OK ) return rc;
+
+    rc = doltliteLoadCatalogRootByPage(db, pParentCat, 1, &parentEntry.root,
+                                       &parentEntry.flags,
+                                       &parentEntry.schemaHash);
+    if( rc!=SQLITE_OK && rc!=SQLITE_NOTFOUND ) return rc;
+
+    pOldRoot = rc==SQLITE_OK ? &parentEntry.root : &emptyRoot;
+    if( schemaHasViewOrTriggerDiff(db, pOldRoot, &childEntry.root,
+                                   childEntry.flags) ){
+      u8 schemaChangeFlag =
+        schemaHasAnyViewOrTrigger(db, pOldRoot, childEntry.flags) ? 0 : 1;
+      return batchAppend(pCur, zHex, "dolt_schemas", pCommit,
+                         1, schemaChangeFlag);
+    }
+    return SQLITE_OK;
+  }
+
+  rc = doltliteLoadTableRootByName(db, pChildCat, pCur->zFilterTable,
+                                   &childEntry.root, &childEntry.flags,
+                                   &childEntry.schemaHash);
+  if( rc==SQLITE_OK ){
+    foundChild = 1;
+  }else if( rc!=SQLITE_NOTFOUND ){
+    return rc;
+  }
+
+  rc = doltliteLoadTableRootByName(db, pParentCat, pCur->zFilterTable,
+                                   &parentEntry.root, &parentEntry.flags,
+                                   &parentEntry.schemaHash);
+  if( rc==SQLITE_OK ){
+    foundParent = 1;
+  }else if( rc!=SQLITE_NOTFOUND ){
+    return rc;
+  }
+
+  if( !foundChild && !foundParent ) return SQLITE_OK;
+  if( !foundChild || !foundParent ){
+    dataChange = 1;
+    schemaChange = 1;
+  }else{
+    dataChange =
+      (prollyHashCompare(&childEntry.root, &parentEntry.root) != 0) ? 1 : 0;
+    schemaChange =
+      (prollyHashCompare(&childEntry.schemaHash,
+                         &parentEntry.schemaHash) != 0) ? 1 : 0;
+    if( !dataChange && !schemaChange ) return SQLITE_OK;
+  }
+  return batchAppend(pCur, zHex, pCur->zFilterTable, pCommit,
+                     dataChange, schemaChange);
+}
+
 /* Diff child against parent catalogs, emitting one batch row per changed table
 ** (plus the dolt_schemas view/trigger special case and reverse scan for
 ** drops). zHex/pCommit label the rows: "WORKING"+null for the working set, the
@@ -424,6 +501,13 @@ static int computeWorkingBatch(DoltliteDiffCursor *pCur, sqlite3 *db){
 
   if( prollyHashCompare(&headCat, &workCat)==0 ) return SQLITE_OK;
 
+  memset(zHexBuf, 0, sizeof(zHexBuf));
+  memcpy(zHexBuf, zWorkingHex, sizeof(zWorkingHex));
+
+  if( pCur->zFilterTable ){
+    return diffCatalogHashesOne(pCur, db, &workCat, &headCat, zHexBuf, 0);
+  }
+
   rc = doltliteLoadCatalog(db, &headCat, &aHead, &nHead, 0);
   if( rc!=SQLITE_OK ) return rc;
   rc = doltliteLoadCatalog(db, &workCat, &aWork, &nWork, 0);
@@ -431,9 +515,6 @@ static int computeWorkingBatch(DoltliteDiffCursor *pCur, sqlite3 *db){
     doltliteFreeCatalog(aHead, nHead);
     return rc;
   }
-
-  memset(zHexBuf, 0, sizeof(zHexBuf));
-  memcpy(zHexBuf, zWorkingHex, sizeof(zWorkingHex));
 
   rc = diffCatalogPair(pCur, db, aWork, nWork, aHead, nHead, zHexBuf, 0);
 
@@ -450,6 +531,17 @@ static int computeCommitBatch(DoltliteDiffCursor *pCur, sqlite3 *db,
   int rc;
   const ProllyHash *pParentHash = doltliteCommitParentHash(pCommit, 0);
   int hasParent = (pParentHash && !prollyHashIsEmpty(pParentHash));
+
+  if( pCur->zFilterTable ){
+    ProllyHash parentCat;
+    memset(&parentCat, 0, sizeof(parentCat));
+    if( hasParent ){
+      rc = doltliteCommitCatalogHash(db, pParentHash, &parentCat);
+      if( rc!=SQLITE_OK ) return rc;
+    }
+    return diffCatalogHashesOne(pCur, db, &pCommit->catalogHash, &parentCat,
+                                zCommitHex, pCommit);
+  }
 
   rc = doltliteLoadCatalog(db, &pCommit->catalogHash, &aChild, &nChild, 0);
   if( rc!=SQLITE_OK ) return rc;


### PR DESCRIPTION
## Summary
- Add a targeted catalog-hash comparison path for `dolt_diff` scans constrained by `table_name = ?`.
- Avoid loading and materializing full child/parent catalogs for filtered working-tree and commit diff summaries.
- Preserve the `dolt_schemas` view/trigger special case using targeted page-1 catalog root lookups.

## Validation
- `make sqlite3`
- Regenerated the amalgamation locally with `make -B sqlite3.c && make sqlite3` for smoke/perf testing; generated files are not committed.
- Smoke-tested filtered working-tree diffs for ordinary tables and `dolt_schemas`.
- Smoke-tested filtered committed diffs, including first-commit table additions.

## Performance
1000-table fixture, one changed table, repeated filtered `dolt_diff` scans on copied DBs after warmup.

Working-tree query, 200 repetitions of `SELECT count(*) FROM dolt_diff WHERE table_name='t0500'`:
- before: 1.64s, 1.78s, 1.60s
- after: 1.56s, 1.54s, 1.53s

Committed-history query, 500 repetitions of `SELECT count(*) FROM dolt_diff WHERE commit_hash=? AND table_name='t0500'`:
- before: 0.26s, 0.26s, 0.26s
- after: 0.11s, 0.11s, 0.11s

## Notes
- `make testfixture` remains blocked in this local environment by the pre-existing `ld: library 'tommath' not found` link failure.