### PR TITLE
Optimize targeted schema entry lookups

### DIFF
--- a/src/doltlite_diff_stat.c
+++ b/src/doltlite_diff_stat.c
@@ -19,9 +19,8 @@ static int dsLoadColNames(sqlite3 *db,
                           char ***pazOut, int *pnOut){
   ChunkStore *cs = doltliteGetChunkStore(db);
   ProllyCache *pCache = doltliteGetCache(db);
-  SchemaEntry *aSchemas = 0;
-  int nSchemas = 0;
-  SchemaEntry *pEntry;
+  SchemaEntry entry;
+  int found = 0;
   sqlite3 *tmp = 0;
   sqlite3_stmt *pStmt = 0;
   char *zPragma = 0;
@@ -33,17 +32,17 @@ static int dsLoadColNames(sqlite3 *db,
   *pnOut = 0;
   if( prollyHashIsEmpty(pCatHash) ) return SQLITE_OK;
 
-  rc = loadSchemaFromCatalog(db, cs, pCache, pCatHash, &aSchemas, &nSchemas);
+  rc = loadSchemaEntryFromCatalog(db, cs, pCache, pCatHash, zTableName,
+                                  &entry, &found);
   if( rc!=SQLITE_OK ) return rc;
-  pEntry = findSchemaEntry(aSchemas, nSchemas, zTableName);
-  if( !pEntry || !pEntry->zSql ){
-    freeSchemaEntries(aSchemas, nSchemas);
+  if( !found || !entry.zSql ){
+    clearSchemaEntry(&entry);
     return SQLITE_OK;
   }
 
   rc = sqlite3_open(":memory:", &tmp);
   if( rc!=SQLITE_OK ) goto cleanup;
-  rc = sqlite3_exec(tmp, pEntry->zSql, 0, 0, 0);
+  rc = sqlite3_exec(tmp, entry.zSql, 0, 0, 0);
   if( rc!=SQLITE_OK ) goto cleanup;
 
   zPragma = sqlite3_mprintf("PRAGMA table_info(\"%w\")", zTableName);
@@ -69,7 +68,7 @@ cleanup:
   if( pStmt ) sqlite3_finalize(pStmt);
   sqlite3_free(zPragma);
   if( tmp ) sqlite3_close(tmp);
-  freeSchemaEntries(aSchemas, nSchemas);
+  clearSchemaEntry(&entry);
   if( rc!=SQLITE_OK && rc!=SQLITE_DONE ){
     int k;
     for(k=0; k<n; k++) sqlite3_free(az[k]);
@@ -89,25 +88,24 @@ static int dsLoadCreateSql(
 ){
   ChunkStore *cs = doltliteGetChunkStore(db);
   ProllyCache *pCache = doltliteGetCache(db);
-  SchemaEntry *aSchemas = 0;
-  int nSchemas = 0;
-  SchemaEntry *pEntry;
+  SchemaEntry entry;
+  int found = 0;
   int rc;
 
   *pzSqlOut = 0;
   if( prollyHashIsEmpty(pCatHash) ) return SQLITE_OK;
 
-  rc = loadSchemaFromCatalog(db, cs, pCache, pCatHash, &aSchemas, &nSchemas);
+  rc = loadSchemaEntryFromCatalog(db, cs, pCache, pCatHash, zTableName,
+                                  &entry, &found);
   if( rc!=SQLITE_OK ) return rc;
-  pEntry = findSchemaEntry(aSchemas, nSchemas, zTableName);
-  if( pEntry && pEntry->zSql ){
-    *pzSqlOut = sqlite3_mprintf("%s", pEntry->zSql);
+  if( found && entry.zSql ){
+    *pzSqlOut = sqlite3_mprintf("%s", entry.zSql);
     if( !*pzSqlOut ){
-      freeSchemaEntries(aSchemas, nSchemas);
+      clearSchemaEntry(&entry);
       return SQLITE_NOMEM;
     }
   }
-  freeSchemaEntries(aSchemas, nSchemas);
+  clearSchemaEntry(&entry);
   return SQLITE_OK;
 }
 

--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -712,26 +712,25 @@ static int loadColInfoAtCatalog(
 ){
   ChunkStore *cs = doltliteGetChunkStore(db);
   ProllyCache *pCache = doltliteGetCache(db);
-  SchemaEntry *aSchemas = 0;
-  int nSchemas = 0;
-  SchemaEntry *pEntry;
+  SchemaEntry entry;
+  int found = 0;
   sqlite3 *tmp = 0;
   int rc;
 
   memset(pOut, 0, sizeof(*pOut));
   if( prollyHashIsEmpty(pCatHash) ) return SQLITE_NOTFOUND;
 
-  rc = loadSchemaFromCatalog(db, cs, pCache, pCatHash, &aSchemas, &nSchemas);
+  rc = loadSchemaEntryFromCatalog(db, cs, pCache, pCatHash, zTableName,
+                                  &entry, &found);
   if( rc!=SQLITE_OK ) return rc;
-  pEntry = findSchemaEntry(aSchemas, nSchemas, zTableName);
-  if( !pEntry || !pEntry->zSql ){
-    freeSchemaEntries(aSchemas, nSchemas);
+  if( !found || !entry.zSql ){
+    clearSchemaEntry(&entry);
     return SQLITE_NOTFOUND;
   }
 
   rc = sqlite3_open(":memory:", &tmp);
   if( rc!=SQLITE_OK ) goto cleanup;
-  rc = sqlite3_exec(tmp, pEntry->zSql, 0, 0, 0);
+  rc = sqlite3_exec(tmp, entry.zSql, 0, 0, 0);
   if( rc!=SQLITE_OK ) goto cleanup;
 
   rc = doltliteGetColumnNames(tmp, zTableName, pOut);
@@ -740,7 +739,7 @@ static int loadColInfoAtCatalog(
 
 cleanup:
   if( tmp ) sqlite3_close(tmp);
-  freeSchemaEntries(aSchemas, nSchemas);
+  clearSchemaEntry(&entry);
   if( rc!=SQLITE_OK ){
     doltliteFreeColInfo(pOut);
   }

--- a/src/doltlite_hashof.c
+++ b/src/doltlite_hashof.c
@@ -56,10 +56,9 @@ static int hashofTableInCatalog(
   struct TableEntry *pTE = 0;
   ChunkStore *cs;
   ProllyCache *cache;
-  SchemaEntry *aSchema = 0;
-  SchemaEntry *pSchema = 0;
+  SchemaEntry schemaEntry;
   int nTables = 0;
-  int nSchema = 0;
+  int foundSchema = 0;
   ProllyHash schemaHash;
   ProllyHash tableHash;
   u8 aBuf[PROLLY_HASH_SIZE*2];
@@ -80,16 +79,17 @@ static int hashofTableInCatalog(
     return SQLITE_ERROR;
   }
 
-  rc = loadSchemaFromCatalog(db, cs, cache, pCatHash, &aSchema, &nSchema);
+  rc = loadSchemaEntryFromCatalog(db, cs, cache, pCatHash, zTable,
+                                  &schemaEntry, &foundSchema);
   if( rc!=SQLITE_OK ){
     doltliteFreeCatalog(aTables, nTables);
     return rc;
   }
-  pSchema = findSchemaEntry(aSchema, nSchema, zTable);
-  if( pSchema ){
-    char *zCanon = doltliteCanonicalizeSchemaSql(pSchema->zSql, pSchema->zName);
+  if( foundSchema ){
+    char *zCanon = doltliteCanonicalizeSchemaSql(schemaEntry.zSql,
+                                                 schemaEntry.zName);
     if( !zCanon ){
-      freeSchemaEntries(aSchema, nSchema);
+      clearSchemaEntry(&schemaEntry);
       doltliteFreeCatalog(aTables, nTables);
       return SQLITE_NOMEM;
     }
@@ -102,7 +102,7 @@ static int hashofTableInCatalog(
   memcpy(aBuf, pTE->root.data, PROLLY_HASH_SIZE);
   memcpy(aBuf + PROLLY_HASH_SIZE, schemaHash.data, PROLLY_HASH_SIZE);
   prollyHashCompute(aBuf, sizeof(aBuf), &tableHash);
-  freeSchemaEntries(aSchema, nSchema);
+  clearSchemaEntry(&schemaEntry);
   doltliteFreeCatalog(aTables, nTables);
   doltliteHashToHex(&tableHash, pHex);
   return SQLITE_OK;

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -897,7 +897,11 @@ struct SchemaEntry {
 int loadSchemaFromCatalog(sqlite3 *db, ChunkStore *cs, ProllyCache *pCache,
                           const ProllyHash *pCatHash,
                           SchemaEntry **ppEntries, int *pnEntries);
+int loadSchemaEntryFromCatalog(sqlite3 *db, ChunkStore *cs, ProllyCache *pCache,
+                               const ProllyHash *pCatHash, const char *zName,
+                               SchemaEntry *pEntry, int *pFound);
 SchemaEntry *findSchemaEntry(SchemaEntry *a, int n, const char *zName);
+void clearSchemaEntry(SchemaEntry *pEntry);
 void freeSchemaEntries(SchemaEntry *a, int n);
 char *doltliteCanonicalizeSchemaSql(const char *zSql, const char *zName);
 int doltliteLoadLiveSchemaSql(sqlite3 *db, const char *zType, const char *zDb,

--- a/src/doltlite_schema_diff.c
+++ b/src/doltlite_schema_diff.c
@@ -211,7 +211,8 @@ int loadSchemaFromCatalog(
   if( rc!=SQLITE_OK || res ){ prollyCursorClose(&cur); *ppEntries = 0; *pnEntries = 0; return rc; }
 
   while( prollyCursorIsValid(&cur) ){
-    const u8 *pVal; int nVal;
+    const u8 *pVal;
+    int nVal;
     DoltliteRecordInfo ri;
 
     prollyCursorValue(&cur, &pVal, &nVal);
@@ -282,13 +283,117 @@ load_schema_done:
   return rc;
 }
 
+int loadSchemaEntryFromCatalog(
+  sqlite3 *db,
+  ChunkStore *cs,
+  ProllyCache *pCache,
+  const ProllyHash *pCatHash,
+  const char *zName,
+  SchemaEntry *pEntry,
+  int *pFound
+){
+  struct TableEntry *aTables = 0;
+  int nTables = 0;
+  ProllyHash masterRoot;
+  u8 masterFlags = 0;
+  ProllyCursor cur;
+  int res, rc, i;
+
+  memset(pEntry, 0, sizeof(*pEntry));
+  *pFound = 0;
+  if( !zName || prollyHashIsEmpty(pCatHash) ) return SQLITE_OK;
+
+  rc = doltliteLoadCatalog(db, pCatHash, &aTables, &nTables, 0);
+  if( rc!=SQLITE_OK ) return rc;
+
+  memset(&masterRoot, 0, sizeof(masterRoot));
+  for(i=0; i<nTables; i++){
+    if( aTables[i].iTable==1 ){
+      memcpy(&masterRoot, &aTables[i].root, sizeof(ProllyHash));
+      masterFlags = aTables[i].flags;
+      break;
+    }
+  }
+  doltliteFreeCatalog(aTables, nTables);
+
+  if( prollyHashIsEmpty(&masterRoot) ) return SQLITE_OK;
+
+  prollyCursorInit(&cur, cs, pCache, &masterRoot, masterFlags);
+  rc = prollyCursorFirst(&cur, &res);
+  if( rc!=SQLITE_OK || res ){
+    prollyCursorClose(&cur);
+    return rc;
+  }
+
+  while( prollyCursorIsValid(&cur) ){
+    const u8 *pVal; int nVal;
+    DoltliteRecordInfo ri;
+
+    prollyCursorValue(&cur, &pVal, &nVal);
+    if( pVal && nVal > 0 ){
+      char *zType = 0, *zEntryName = 0, *zTblName = 0, *zSql = 0;
+      i64 iRootpage = 0;
+
+      doltliteParseRecord(pVal, nVal, &ri);
+      if( ri.nField < 5 ){
+        rc = SQLITE_CORRUPT;
+        goto load_schema_entry_done;
+      }
+
+      rc = schemaTextField(pVal, nVal, &ri, 1, &zEntryName);
+      if( rc!=SQLITE_OK ) goto load_schema_entry_done;
+      if( zEntryName && strcmp(zEntryName, zName)==0 ){
+        rc = schemaTextField(pVal, nVal, &ri, 0, &zType);
+        if( rc==SQLITE_OK ){
+          rc = schemaTextField(pVal, nVal, &ri, 2, &zTblName);
+        }
+        if( rc==SQLITE_OK ){
+          iRootpage = schemaIntField(pVal, nVal, &ri, 3);
+          rc = schemaTextField(pVal, nVal, &ri, 4, &zSql);
+        }
+        if( rc!=SQLITE_OK ){
+          sqlite3_free(zType);
+          sqlite3_free(zEntryName);
+          sqlite3_free(zTblName);
+          sqlite3_free(zSql);
+          goto load_schema_entry_done;
+        }
+        pEntry->zName = zEntryName;
+        pEntry->zTblName = zTblName;
+        pEntry->zSql = zSql;
+        pEntry->zType = zType;
+        pEntry->iRootpage = (Pgno)iRootpage;
+        *pFound = 1;
+        break;
+      }
+      sqlite3_free(zEntryName);
+    }
+
+    rc = prollyCursorNext(&cur);
+    if( rc!=SQLITE_OK ) break;
+  }
+
+load_schema_entry_done:
+  prollyCursorClose(&cur);
+  if( rc!=SQLITE_OK ){
+    clearSchemaEntry(pEntry);
+    *pFound = 0;
+  }
+  return rc;
+}
+
+void clearSchemaEntry(SchemaEntry *pEntry){
+  sqlite3_free(pEntry->zName);
+  sqlite3_free(pEntry->zTblName);
+  sqlite3_free(pEntry->zSql);
+  sqlite3_free(pEntry->zType);
+  memset(pEntry, 0, sizeof(*pEntry));
+}
+
 void freeSchemaEntries(SchemaEntry *a, int n){
   int i;
   for(i=0; i<n; i++){
-    sqlite3_free(a[i].zName);
-    sqlite3_free(a[i].zTblName);
-    sqlite3_free(a[i].zSql);
-    sqlite3_free(a[i].zType);
+    clearSchemaEntry(&a[i]);
   }
   sqlite3_free(a);
 }
@@ -653,6 +758,105 @@ static int computeSchemaDiffFiltered(
   return SQLITE_OK;
 }
 
+static int sdAppendSchemaEntryByName(
+  sqlite3 *db,
+  ChunkStore *cs,
+  ProllyCache *pCache,
+  const ProllyHash *pCatHash,
+  const char *zName,
+  SchemaEntry **paEntry,
+  int *pnEntry
+){
+  SchemaEntry entry;
+  SchemaEntry *aNew;
+  int found = 0;
+  int i, rc;
+
+  if( !zName ) return SQLITE_OK;
+  for(i=0; i<*pnEntry; i++){
+    if( (*paEntry)[i].zName && strcmp((*paEntry)[i].zName, zName)==0 ){
+      return SQLITE_OK;
+    }
+  }
+
+  rc = loadSchemaEntryFromCatalog(db, cs, pCache, pCatHash, zName,
+                                  &entry, &found);
+  if( rc!=SQLITE_OK ) return rc;
+  if( !found ) return SQLITE_OK;
+
+  aNew = sqlite3_realloc(*paEntry,
+                         (*pnEntry + 1) * (int)sizeof(SchemaEntry));
+  if( !aNew ){
+    clearSchemaEntry(&entry);
+    return SQLITE_NOMEM;
+  }
+  *paEntry = aNew;
+  (*paEntry)[*pnEntry] = entry;
+  (*pnEntry)++;
+  return SQLITE_OK;
+}
+
+static int sdLoadFilteredSchemas(
+  sqlite3 *db,
+  ChunkStore *cs,
+  ProllyCache *pCache,
+  const ProllyHash *pFromCatHash,
+  const ProllyHash *pToCatHash,
+  struct TableEntry *aFromTables,
+  int nFromTables,
+  struct TableEntry *aToTables,
+  int nToTables,
+  const char *zFilter,
+  SchemaEntry **paFrom,
+  int *pnFrom,
+  SchemaEntry **paTo,
+  int *pnTo
+){
+  struct TableEntry *pFrom;
+  struct TableEntry *pTo;
+  int rc;
+
+  *paFrom = 0;
+  *pnFrom = 0;
+  *paTo = 0;
+  *pnTo = 0;
+
+  rc = sdAppendSchemaEntryByName(db, cs, pCache, pFromCatHash, zFilter,
+                                 paFrom, pnFrom);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = sdAppendSchemaEntryByName(db, cs, pCache, pToCatHash, zFilter,
+                                 paTo, pnTo);
+  if( rc!=SQLITE_OK ) return rc;
+
+  pTo = doltliteFindTableByName(aToTables, nToTables, zFilter);
+  if( pTo && pTo->iTable!=0 ){
+    pFrom = doltliteFindTableByNumber(aFromTables, nFromTables, pTo->iTable);
+    if( pFrom && pFrom->zName && strcmp(pFrom->zName, zFilter)!=0 ){
+      rc = sdAppendSchemaEntryByName(db, cs, pCache, pFromCatHash,
+                                     pFrom->zName, paFrom, pnFrom);
+      if( rc!=SQLITE_OK ) return rc;
+      rc = sdAppendSchemaEntryByName(db, cs, pCache, pToCatHash,
+                                     pFrom->zName, paTo, pnTo);
+      if( rc!=SQLITE_OK ) return rc;
+    }
+  }
+
+  pFrom = doltliteFindTableByName(aFromTables, nFromTables, zFilter);
+  if( pFrom && pFrom->iTable!=0 ){
+    pTo = doltliteFindTableByNumber(aToTables, nToTables, pFrom->iTable);
+    if( pTo && pTo->zName && strcmp(pTo->zName, zFilter)!=0 ){
+      rc = sdAppendSchemaEntryByName(db, cs, pCache, pFromCatHash,
+                                     pTo->zName, paFrom, pnFrom);
+      if( rc!=SQLITE_OK ) return rc;
+      rc = sdAppendSchemaEntryByName(db, cs, pCache, pToCatHash,
+                                     pTo->zName, paTo, pnTo);
+      if( rc!=SQLITE_OK ) return rc;
+    }
+  }
+
+  return SQLITE_OK;
+}
+
 static const char *sdSchema =
   "CREATE TABLE x("
   "  from_table_name TEXT,"
@@ -854,14 +1058,21 @@ static int sdFilter(sqlite3_vtab_cursor *cur,
   rc = sdResolveRefs(db, &v->base, zFromRef, zToRef, &fromCatHash, &toCatHash);
   if( rc!=SQLITE_OK ) goto sd_filter_done;
 
-  rc = loadSchemaFromCatalog(db, cs, pCache, &fromCatHash, &aFrom, &nFrom);
-  if( rc!=SQLITE_OK ) goto sd_filter_done;
-  rc = loadSchemaFromCatalog(db, cs, pCache, &toCatHash, &aTo, &nTo);
-  if( rc!=SQLITE_OK ) goto sd_filter_done;
-
   rc = doltliteLoadCatalog(db, &fromCatHash, &aFromTables, &nFromTables, 0);
   if( rc!=SQLITE_OK ) goto sd_filter_done;
   rc = doltliteLoadCatalog(db, &toCatHash, &aToTables, &nToTables, 0);
+  if( rc!=SQLITE_OK ) goto sd_filter_done;
+
+  if( zTableFilter ){
+    rc = sdLoadFilteredSchemas(db, cs, pCache, &fromCatHash, &toCatHash,
+                               aFromTables, nFromTables, aToTables, nToTables,
+                               zTableFilter, &aFrom, &nFrom, &aTo, &nTo);
+  }else{
+    rc = loadSchemaFromCatalog(db, cs, pCache, &fromCatHash, &aFrom, &nFrom);
+    if( rc==SQLITE_OK ){
+      rc = loadSchemaFromCatalog(db, cs, pCache, &toCatHash, &aTo, &nTo);
+    }
+  }
   if( rc!=SQLITE_OK ) goto sd_filter_done;
 
   rc = computeSchemaDiffFiltered(c, aFrom, nFrom, aTo, nTo,


### PR DESCRIPTION
## Summary
- add a targeted sqlite_master schema entry loader for single-table VC lookups
- use it in dolt_diff_stat, dolt_diff_<table>, and dolt_hashof_table
- keep filtered dolt_schema_diff rename-aware while avoiding full schema catalog loads for table filters

## Tests
- make sqlite3
- git diff --check
- DOLTLITE=./sqlite3 bash test/doltlite_schema_diff.sh
- DOLTLITE=./sqlite3 bash test/doltlite_diff_table.sh
- bash test/doltlite_diff_stat_scale.sh ./sqlite3
- hashof_table smoke test

Note: make devtest still fails locally before relevant TCL tests run due existing out-of-tree amalgamation/btree wrapper build conflicts and one missing tommath link dependency.