### PR TITLE
Close dead-code gate gap on src/doltlite.c; remove dead VcResultErrorCode

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -651,11 +651,6 @@ void doltliteVcResultError(sqlite3_context *ctx, sqlite3 *db, const char *zMsg){
   sqlite3_result_error(ctx, zMsg, -1);
 }
 
-void doltliteVcResultErrorCode(sqlite3_context *ctx, sqlite3 *db, int rc){
-  (void)doltliteVcSealSavepointError(db);
-  sqlite3_result_error(ctx, sqlite3_errstr(rc), -1);
-}
-
 int doltliteVcSealBranchStyleTxn(sqlite3 *db){
   int rc;
   if( db->autoCommit ) return SQLITE_OK;

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -872,7 +872,6 @@ DoltliteVcTxnMode doltliteVcTxnMode(sqlite3 *db);
 int doltliteVcSealActiveSavepoints(sqlite3 *db);
 int doltliteVcSealSavepointError(sqlite3 *db);
 void doltliteVcResultError(sqlite3_context *ctx, sqlite3 *db, const char *zMsg);
-void doltliteVcResultErrorCode(sqlite3_context *ctx, sqlite3 *db, int rc);
 int doltliteVcSealBranchStyleTxn(sqlite3 *db);
 
 typedef int (*DoltliteRefsMutation)(sqlite3 *db, ChunkStore *cs, void *pArg);

--- a/test/dead_code_check.sh
+++ b/test/dead_code_check.sh
@@ -21,7 +21,7 @@ cd "$ROOT"
 BUILD_DIR="${DOLTLITE_BUILD_DIR:-$ROOT/build}"
 CC="${CC:-cc}"
 
-SRCS=(src/doltlite_*.c src/chunk_*.c src/prolly_*.c src/remotesrv_main.c)
+SRCS=(src/doltlite.c src/doltlite_*.c src/chunk_*.c src/prolly_*.c src/remotesrv_main.c)
 
 CFLAGS=(
   -DNDEBUG -O1 -g


### PR DESCRIPTION
## What

The dead-code gate (`test/dead_code_check.sh`) globbed `src/doltlite_*.c` (with the underscore), which silently **excluded `src/doltlite.c`** — the largest doltlite source file (~5,100 lines) — from scanning. The gate passed while a dead function lived in the one file it never looked at.

This PR:
1. Adds `src/doltlite.c` to the gate's `SRCS`, closing the coverage gap.
2. Removes `doltliteVcResultErrorCode`, which the now-widened gate flags as dead: it has **no caller anywhere in the tree** (def + a single header decl). Its sibling `doltliteVcResultError` is the one actually used (60+ call sites).

## Verification (fail-before / pass-after)

- With the glob fixed but the function still present, the gate **fails**: `dead (no caller): doltliteVcResultErrorCode` — proving the gap was real and the gate now catches it.
- After removing the function (def in `doltlite.c` + decl in `doltlite_internal.h`), the gate **passes** and `doltlite.c` recompiles clean.

Found during a dead/duplicate-code review of the doltlite sources; this was the only genuinely dead function across the ~1,600 doltlite functions scanned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)