### PR TITLE
Dedup SQLite record field decoders into prolly_record.h

### DIFF
--- a/src/doltlite_schema_diff.c
+++ b/src/doltlite_schema_diff.c
@@ -34,66 +34,6 @@ struct SdCursor {
   int iRow;
 };
 
-static int schemaTextField(
-  const u8 *pVal,
-  int nVal,
-  DoltliteRecordInfo *pRi,
-  int iField,
-  char **pzOut
-){
-  int st, off, len;
-  char *zOut;
-
-  *pzOut = 0;
-  if( iField>=pRi->nField ) return SQLITE_CORRUPT;
-  st = pRi->aType[iField];
-  off = pRi->aOffset[iField];
-  if( st==0 ) return SQLITE_OK;
-  if( st<13 || (st&1)==0 ) return SQLITE_CORRUPT;
-  len = (st-13)/2;
-  if( off<0 || off+len>nVal ) return SQLITE_CORRUPT;
-  zOut = sqlite3_malloc(len+1);
-  if( !zOut ) return SQLITE_NOMEM;
-  memcpy(zOut, pVal+off, len);
-  zOut[len] = 0;
-  *pzOut = zOut;
-  return SQLITE_OK;
-}
-
-static i64 schemaIntField(
-  const u8 *pVal,
-  int nVal,
-  DoltliteRecordInfo *pRi,
-  int iField
-){
-  const u8 *pBody;
-  int st, off, nByte, i;
-  i64 v;
-
-  if( iField>=pRi->nField ) return 0;
-  st = pRi->aType[iField];
-  off = pRi->aOffset[iField];
-  switch( st ){
-    case 0:
-    case 8: return 0;
-    case 9: return 1;
-    case 1: nByte = 1; break;
-    case 2: nByte = 2; break;
-    case 3: nByte = 3; break;
-    case 4: nByte = 4; break;
-    case 5: nByte = 6; break;
-    case 6: nByte = 8; break;
-    default: return 0;
-  }
-  if( off<0 || off+nByte>nVal ) return 0;
-  pBody = pVal + off;
-  v = (pBody[0] & 0x80) ? -1 : 0;
-  for(i=0; i<nByte; i++){
-    v = (v << 8) | pBody[i];
-  }
-  return v;
-}
-
 static void freeSchemaDiffRows(SdCursor *c){
   int i;
   for(i=0; i<c->nRows; i++){
@@ -227,21 +167,21 @@ int loadSchemaFromCatalog(
         char *zType = 0, *zName = 0, *zTblName = 0, *zSql = 0;
         i64 iRootpage = 0;
 
-        rc = schemaTextField(pVal, nVal, &ri, 0, &zType);
+        rc = dlRecordTextField(pVal, nVal, &ri, 0, &zType);
         if( rc!=SQLITE_OK ) goto load_schema_done;
-        rc = schemaTextField(pVal, nVal, &ri, 1, &zName);
+        rc = dlRecordTextField(pVal, nVal, &ri, 1, &zName);
         if( rc!=SQLITE_OK ){
           sqlite3_free(zType);
           goto load_schema_done;
         }
-        rc = schemaTextField(pVal, nVal, &ri, 2, &zTblName);
+        rc = dlRecordTextField(pVal, nVal, &ri, 2, &zTblName);
         if( rc!=SQLITE_OK ){
           sqlite3_free(zType);
           sqlite3_free(zName);
           goto load_schema_done;
         }
-        iRootpage = schemaIntField(pVal, nVal, &ri, 3);
-        rc = schemaTextField(pVal, nVal, &ri, 4, &zSql);
+        iRootpage = dlRecordIntField(pVal, nVal, &ri, 3);
+        rc = dlRecordTextField(pVal, nVal, &ri, 4, &zSql);
         if( rc!=SQLITE_OK ){
           sqlite3_free(zType);
           sqlite3_free(zName);
@@ -340,16 +280,16 @@ int loadSchemaEntryFromCatalog(
         goto load_schema_entry_done;
       }
 
-      rc = schemaTextField(pVal, nVal, &ri, 1, &zEntryName);
+      rc = dlRecordTextField(pVal, nVal, &ri, 1, &zEntryName);
       if( rc!=SQLITE_OK ) goto load_schema_entry_done;
       if( zEntryName && strcmp(zEntryName, zName)==0 ){
-        rc = schemaTextField(pVal, nVal, &ri, 0, &zType);
+        rc = dlRecordTextField(pVal, nVal, &ri, 0, &zType);
         if( rc==SQLITE_OK ){
-          rc = schemaTextField(pVal, nVal, &ri, 2, &zTblName);
+          rc = dlRecordTextField(pVal, nVal, &ri, 2, &zTblName);
         }
         if( rc==SQLITE_OK ){
-          iRootpage = schemaIntField(pVal, nVal, &ri, 3);
-          rc = schemaTextField(pVal, nVal, &ri, 4, &zSql);
+          iRootpage = dlRecordIntField(pVal, nVal, &ri, 3);
+          rc = dlRecordTextField(pVal, nVal, &ri, 4, &zSql);
         }
         if( rc!=SQLITE_OK ){
           sqlite3_free(zType);

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -1503,55 +1503,6 @@ static int schemaCatalogHasPgno(SchemaCatalogRow *aRows, int nRows, Pgno iTable)
   return 0;
 }
 
-static int schemaCatalogTextField(
-  const u8 *pVal, int nVal, DoltliteRecordInfo *pRi, int iField, char **pzOut
-){
-  int st, off, len;
-  char *zOut;
-  *pzOut = 0;
-  if( iField>=pRi->nField ) return SQLITE_CORRUPT;
-  st = pRi->aType[iField];
-  off = pRi->aOffset[iField];
-  if( st==0 ) return SQLITE_OK;
-  if( st<13 || (st&1)==0 ) return SQLITE_CORRUPT;
-  len = (st-13)/2;
-  if( off<0 || off+len>nVal ) return SQLITE_CORRUPT;
-  zOut = sqlite3_malloc(len+1);
-  if( !zOut ) return SQLITE_NOMEM;
-  memcpy(zOut, pVal+off, len);
-  zOut[len] = 0;
-  *pzOut = zOut;
-  return SQLITE_OK;
-}
-
-static i64 schemaCatalogIntField(
-  const u8 *pVal, int nVal, DoltliteRecordInfo *pRi, int iField
-){
-  const u8 *pBody;
-  int st, off, nByte, i;
-  i64 v;
-  if( iField>=pRi->nField ) return 0;
-  st = pRi->aType[iField];
-  off = pRi->aOffset[iField];
-  switch( st ){
-    case 0:
-    case 8: return 0;
-    case 9: return 1;
-    case 1: nByte = 1; break;
-    case 2: nByte = 2; break;
-    case 3: nByte = 3; break;
-    case 4: nByte = 4; break;
-    case 5: nByte = 6; break;
-    case 6: nByte = 8; break;
-    default: return 0;
-  }
-  if( off<0 || off+nByte>nVal ) return 0;
-  pBody = pVal + off;
-  v = (pBody[0] & 0x80) ? -1 : 0;
-  for(i=0; i<nByte; i++) v = (v << 8) | pBody[i];
-  return v;
-}
-
 static void freeSchemaCatalogRows(SchemaCatalogRow *aRows, int nRows){
   int i;
   for(i=0; i<nRows; i++){
@@ -1752,14 +1703,14 @@ static int loadSchemaCatalogRows(
       i64 iRootpage = 0;
       doltliteParseRecord(pVal, nVal, &ri);
       if( ri.nField<5 ){ rc = SQLITE_CORRUPT; break; }
-      rc = schemaCatalogTextField(pVal, nVal, &ri, 0, &zType);
+      rc = dlRecordTextField(pVal, nVal, &ri, 0, &zType);
       if( rc!=SQLITE_OK ) break;
-      rc = schemaCatalogTextField(pVal, nVal, &ri, 1, &zName);
+      rc = dlRecordTextField(pVal, nVal, &ri, 1, &zName);
       if( rc!=SQLITE_OK ){ sqlite3_free(zType); break; }
-      rc = schemaCatalogTextField(pVal, nVal, &ri, 2, &zTblName);
+      rc = dlRecordTextField(pVal, nVal, &ri, 2, &zTblName);
       if( rc!=SQLITE_OK ){ sqlite3_free(zType); sqlite3_free(zName); break; }
-      iRootpage = schemaCatalogIntField(pVal, nVal, &ri, 3);
-      rc = schemaCatalogTextField(pVal, nVal, &ri, 4, &zSql);
+      iRootpage = dlRecordIntField(pVal, nVal, &ri, 3);
+      rc = dlRecordTextField(pVal, nVal, &ri, 4, &zSql);
       if( rc!=SQLITE_OK ){
         sqlite3_free(zType); sqlite3_free(zName); sqlite3_free(zTblName); break;
       }

--- a/src/prolly_record.h
+++ b/src/prolly_record.h
@@ -75,4 +75,70 @@ int doltliteParseRecordStrict(const u8 *pData, int nData,
 
 void doltliteParseRecord(const u8 *pData, int nData, DoltliteRecordInfo *pInfo);
 
+/* Decode field iField of a parsed record as text into a freshly sqlite3_malloc'd
+** NUL-terminated string (*pzOut, NULL for a SQL NULL field). Returns SQLITE_OK,
+** SQLITE_CORRUPT on a malformed/non-text serial type, or SQLITE_NOMEM. */
+static inline int dlRecordTextField(
+  const u8 *pVal,
+  int nVal,
+  const DoltliteRecordInfo *pRi,
+  int iField,
+  char **pzOut
+){
+  int st, off, len;
+  char *zOut;
+
+  *pzOut = 0;
+  if( iField>=pRi->nField ) return SQLITE_CORRUPT;
+  st = pRi->aType[iField];
+  off = pRi->aOffset[iField];
+  if( st==0 ) return SQLITE_OK;
+  if( st<13 || (st&1)==0 ) return SQLITE_CORRUPT;
+  len = (st-13)/2;
+  if( off<0 || off+len>nVal ) return SQLITE_CORRUPT;
+  zOut = sqlite3_malloc(len+1);
+  if( !zOut ) return SQLITE_NOMEM;
+  memcpy(zOut, pVal+off, len);
+  zOut[len] = 0;
+  *pzOut = zOut;
+  return SQLITE_OK;
+}
+
+/* Decode field iField of a parsed record as a signed integer. Returns 0 for a
+** NULL, non-integer, or out-of-bounds field (serial type 8 is the constant 0,
+** type 9 the constant 1). */
+static inline i64 dlRecordIntField(
+  const u8 *pVal,
+  int nVal,
+  const DoltliteRecordInfo *pRi,
+  int iField
+){
+  const u8 *pBody;
+  int st, off, nByte, i;
+  i64 v;
+
+  if( iField>=pRi->nField ) return 0;
+  st = pRi->aType[iField];
+  off = pRi->aOffset[iField];
+  switch( st ){
+    case 0:
+    case 8: return 0;
+    case 9: return 1;
+    case 1: nByte = 1; break;
+    case 2: nByte = 2; break;
+    case 3: nByte = 3; break;
+    case 4: nByte = 4; break;
+    case 5: nByte = 6; break;
+    case 6: nByte = 8; break;
+    default: return 0;
+  }
+  if( off<0 || off+nByte>nVal ) return 0;
+  pBody = pVal + off;
+  v = (pBody[0] & 0x80) ? -1 : 0;
+  for(i=0; i<nByte; i++){
+    v = (v << 8) | pBody[i];
+  }
+  return v;
+}
+
 #endif


### PR DESCRIPTION
## What

`doltlite_schema_diff.c` and `prolly_btree.c` each carried a **byte-identical** pair of static helpers that decode a parsed record field as text or as a signed integer:

- `schemaTextField` / `schemaIntField` (schema_diff.c)
- `schemaCatalogTextField` / `schemaCatalogIntField` (prolly_btree.c)

This lifts them verbatim into `prolly_record.h` — which already owns `DoltliteRecordInfo` and the sibling record-decode inlines (`dlReadVarint`, `dlDecodeSerialInt`, …) — as `dlRecordTextField` / `dlRecordIntField`, and points both files' call sites at the shared versions.

- `prolly_record.h` is already transitively included by both TUs (via `record_codec.h`), so no new includes.
- The helpers are `static inline`, so TUs that include the header without calling them incur no cost or unused-function warning.
- **Bodies are moved, not rewritten** — behavior is identical by construction.

Net −43 lines.

## Verification

- Full C regression suite: **309815 passed, 0 failed**.
- `dolt_schema_diff` shell suite: **49 passed**; schema-diff oracle suite: **49 passed**.
- Dead-code gate: **PASS**.
- Functional smoke test of both consumers — catalog reload (negative, large, and NULL fields roundtrip) and `dolt_schema_diff` (type/name/create-statement text decode) — correct.

## Scope note

This was the only **true** duplication of the four cross-file candidates flagged in the review. The other three were structural echoes, not extractable without hurting readability, and are deliberately left as-is:
- cursor-seek in `doltlite_at.c` vs `doltlite_history.c` — differs in the upper-bound predicate and the post-seek action (would need callbacks);
- `aMem[]` catalog-row build in `doltlite_merge.c` vs `prolly_btree.c` — different value structs and serialization paths;
- table-list hash serialization in `doltlite_conflicts.c` vs `doltlite_constraint_violations.c` — only the size-accumulation prologue matches; row payloads differ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)