### PR TITLE
Skip unchanged commits in blame walks

### DIFF
--- a/src/doltlite_blame.c
+++ b/src/doltlite_blame.c
@@ -377,6 +377,7 @@ static int blameCompareAgainstRef(
   sqlite3 *db,
   BlameCursor *pCur,
   const char *zTableName,
+  const ProllyHash *pCurRoot,
   u8 curFlags,
   const ProllyHash *pRefCatHash,
   const ProllyHash *pCommitHash,
@@ -399,6 +400,12 @@ static int blameCompareAgainstRef(
                                      &refRoot, &refFlags, 0);
     if( rc==SQLITE_OK ) haveRef = 1;
     else if( rc!=SQLITE_NOTFOUND ) return rc;
+  }
+
+  if( haveRef && pCurRoot
+   && curFlags==refFlags
+   && prollyHashCompare(pCurRoot, &refRoot)==0 ){
+    return SQLITE_OK;
   }
 
   canScanRef = haveRef
@@ -535,6 +542,7 @@ static int blameWalk(
         rc = doltliteCommitCatalogHash(db, &baseHash, &baseCatHash);
         if( rc==SQLITE_OK ){
           rc = blameCompareAgainstRef(db, pCur, zTableName,
+                                      &curTableRoot,
                                       curFlags,
                                       &baseCatHash,
                                       &walk, &commit);
@@ -545,6 +553,7 @@ static int blameWalk(
         }
       }else if( haveCurTable ){
         rc = blameCompareAgainstRef(db, pCur, zTableName,
+                                    &curTableRoot,
                                     curFlags,
                                     0, &walk, &commit);
         if( rc!=SQLITE_OK ){
@@ -559,6 +568,7 @@ static int blameWalk(
         rc = doltliteCommitCatalogHash(db, pParent, &parentCatHash);
         if( rc==SQLITE_OK ){
           rc = blameCompareAgainstRef(db, pCur, zTableName,
+                                      haveCurTable ? &curTableRoot : 0,
                                       curFlags,
                                       &parentCatHash,
                                       &walk, &commit);
@@ -569,6 +579,7 @@ static int blameWalk(
         }
       }else if( haveCurTable ){
         rc = blameCompareAgainstRef(db, pCur, zTableName,
+                                    &curTableRoot,
                                     curFlags,
                                     0, &walk, &commit);
         if( rc!=SQLITE_OK ){


### PR DESCRIPTION
## Summary
- skip `dolt_blame_<table>` commit comparisons when the table root is unchanged from the comparison root
- avoids scanning unresolved blame rows for commits that did not change the blamed table
- keeps existing parent and merge-base comparison semantics unchanged

## Performance
Workload: 50,000 live rows in `target`, 500 commits changing only an unrelated table, then:
`SELECT count(*) FROM dolt_blame_target;`

- master: 0.22-0.23s over 5 runs
- branch: 0.02-0.03s over 5 runs
- sampled blame output matched master

## Tests
- `make sqlite3` after regenerating local amalgamation build inputs
- `git diff --check`
- `bash test/review_regression_test.sh ./sqlite3`
- `DOLTLITE=./sqlite3 bash test/doltlite_comparison.sh`
- `DOLTLITE=./sqlite3 bash test/vc_oracle_blame_test.sh`
- `bash test/doltlite_dolt_table_pushdown.sh ./sqlite3`