### PR TITLE
Publish @dolthub/doltlite-wasm to npm from the release workflow

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -84,6 +84,11 @@ jobs:
       run: |
         node ext/wasm/test-doltlite-export-roundtrip.mjs
 
+    - name: Smoke test the @dolthub/doltlite-wasm npm package
+      run: |
+        chmod +x packaging/npm/assemble.sh packaging/npm/test-package.sh
+        bash packaging/npm/test-package.sh
+
     - name: Build wasm distribution zip
       run: |
         source "$EMSDK/emsdk_env.sh"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -677,3 +677,97 @@ jobs:
 
         git tag "${VERSION}"
         git push origin "${VERSION}"
+
+  # ── Publish WASM package to npm ──────────────────────────
+  # Unlike the node/python bindings (which live in their own repos and are
+  # triggered by release-bindings), the wasm "binding" is pure build output:
+  # the JS API lives in ext/wasm/api and is assembled by the build, so there
+  # is no separate repo to maintain. We publish @dolthub/doltlite-wasm straight
+  # from here — build the canonical npm distributables (make -C ext/wasm npm),
+  # stage them with packaging/npm, and npm publish. Requires the NPM_TOKEN
+  # secret: an npm automation token with publish rights to the @dolthub scope.
+  publish-wasm-npm:
+    if: github.event_name != 'workflow_dispatch'
+    needs: release
+    runs-on: ubuntu-latest
+    env:
+      EMSDK_VERSION: 3.1.74
+      WABT_VERSION: 1.0.36
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Check npm token
+      run: |
+        if [ -z "${NPM_TOKEN}" ]; then
+          echo "NPM_TOKEN is required to publish @dolthub/doltlite-wasm"
+          exit 1
+        fi
+
+    - name: Cache Emscripten SDK
+      uses: actions/cache@v4
+      with:
+        path: ${{ runner.tool_cache }}/emsdk
+        key: emsdk-${{ runner.os }}-${{ env.EMSDK_VERSION }}
+
+    - name: Install Emscripten SDK
+      run: |
+        EMSDK_DIR="${RUNNER_TOOL_CACHE}/emsdk"
+        if [ ! -d "$EMSDK_DIR/.git" ]; then
+          rm -rf "$EMSDK_DIR"
+          git clone https://github.com/emscripten-core/emsdk.git "$EMSDK_DIR"
+        fi
+        cd "$EMSDK_DIR"
+        git fetch --tags --quiet
+        ./emsdk install "$EMSDK_VERSION"
+        ./emsdk activate "$EMSDK_VERSION"
+        echo "EMSDK=$EMSDK_DIR" >> "$GITHUB_ENV"
+
+    - name: Cache WABT
+      uses: actions/cache@v4
+      with:
+        path: ${{ runner.tool_cache }}/wabt-${{ env.WABT_VERSION }}
+        key: wabt-${{ runner.os }}-${{ env.WABT_VERSION }}
+
+    - name: Install WABT
+      run: |
+        WABT_DIR="${RUNNER_TOOL_CACHE}/wabt-${WABT_VERSION}"
+        if [ ! -x "$WABT_DIR/bin/wasm-strip" ]; then
+          rm -rf "$WABT_DIR"
+          mkdir -p "$WABT_DIR"
+          curl -fsSL "https://github.com/WebAssembly/wabt/releases/download/${WABT_VERSION}/wabt-${WABT_VERSION}-ubuntu-20.04.tar.gz" \
+            | tar -xz --strip-components=1 -C "$WABT_DIR"
+        fi
+        echo "$WABT_DIR/bin" >> "$GITHUB_PATH"
+
+    - name: Build wasm npm distributables
+      run: |
+        source "$EMSDK/emsdk_env.sh"
+        ./configure
+        make sqlite3.c sqlite3.h sqlite3ext.h
+        make -C ext/wasm npm
+
+    - name: Set up Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        registry-url: https://registry.npmjs.org
+
+    - name: Stage package
+      run: |
+        VERSION=${GITHUB_REF_NAME#v}
+        bash packaging/npm/assemble.sh "$VERSION" dist/npm
+
+    - name: Publish to npm
+      working-directory: dist/npm
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      run: |
+        VERSION=${GITHUB_REF_NAME#v}
+        # Idempotent: skip if this version is already on the registry so a
+        # re-run of the release workflow doesn't fail on a duplicate publish.
+        if npm view "@dolthub/doltlite-wasm@${VERSION}" version >/dev/null 2>&1; then
+          echo "@dolthub/doltlite-wasm@${VERSION} already published; skipping"
+          exit 0
+        fi
+        npm publish --access public

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Language-specific wrappers around `libdoltlite`. Each one exposes the full `sqli
 |---|---|---|
 | Node.js / Bun | `@dolthub/doltlite` | [dolthub/doltlite-node](https://github.com/dolthub/doltlite-node) |
 | Python | `doltlite` (`pip install doltlite`) | [dolthub/doltlite-python](https://github.com/dolthub/doltlite-python) |
+| Browser / WASM | `@dolthub/doltlite-wasm` | this repo ([`packaging/npm`](packaging/npm), built from [`ext/wasm`](ext/wasm)) |
 
 ## Building
 

--- a/packaging/npm/README.md
+++ b/packaging/npm/README.md
@@ -1,0 +1,74 @@
+# @dolthub/doltlite-wasm
+
+[DoltLite](https://github.com/dolthub/doltlite) compiled to WebAssembly: a
+drop-in SQLite build with Dolt-style version control — `dolt_commit`,
+`dolt_branch`, `dolt_merge`, `dolt_diff`, and the rest — that runs in the
+browser and in any JS runtime.
+
+This is the WebAssembly distribution. For a native Node/Bun addon, use
+[`@dolthub/doltlite`](https://github.com/dolthub/doltlite-node) instead.
+
+## Install
+
+```bash
+npm install @dolthub/doltlite-wasm
+```
+
+## Browser (OPFS-backed, persistent)
+
+OPFS persistence requires the page be served cross-origin isolated (the
+`COOP`/`COEP` headers below); without them you still get an in-memory database.
+
+```js
+import { sqlite3InitModule } from '@dolthub/doltlite-wasm';
+
+const sqlite3 = await sqlite3InitModule();
+
+// Persistent across reloads when OPFS is available, in-memory otherwise.
+const db = ('opfs' in sqlite3)
+  ? new sqlite3.oo1.OpfsDb('/app.db')
+  : new sqlite3.oo1.DB(':memory:');
+
+db.exec(`CREATE TABLE IF NOT EXISTS t(id INTEGER PRIMARY KEY, msg TEXT)`);
+db.exec(`INSERT INTO t(msg) VALUES('hello')`);
+db.exec(`SELECT dolt_commit('-A', '-m', 'first commit')`);
+
+for (const row of db.selectObjects(`SELECT * FROM dolt_log`)) {
+  console.log(row.commit_hash, row.message);
+}
+```
+
+Required headers for OPFS (cross-origin isolation):
+
+```
+Cross-Origin-Opener-Policy: same-origin
+Cross-Origin-Embedder-Policy: require-corp
+```
+
+## Node / Bun
+
+```js
+import { sqlite3InitModule } from '@dolthub/doltlite-wasm';
+
+const sqlite3 = await sqlite3InitModule();
+const db = new sqlite3.oo1.DB('/tmp/app.db');
+db.exec(`CREATE TABLE t(x)`);
+db.exec(`SELECT dolt_commit('-A', '-m', 'init')`);
+```
+
+## Entry points
+
+| Import | Use |
+| --- | --- |
+| `@dolthub/doltlite-wasm` | Default; bundler-friendly ESM init |
+| `@dolthub/doltlite-wasm/sqlite3.mjs` | Plain ESM (no bundler) |
+| `@dolthub/doltlite-wasm/sqlite3-node.mjs` | Node-specific entry |
+| `@dolthub/doltlite-wasm/sqlite3-worker1-promiser.mjs` | Worker promiser API |
+
+The JavaScript API is the upstream SQLite WASM API — see the
+[sqlite3-wasm docs](https://sqlite.org/wasm). Everything there works; DoltLite
+adds the `dolt_*` version-control functions and virtual tables on top.
+
+## License
+
+Apache-2.0. See [LICENSE.md](./LICENSE.md). SQLite itself is public domain.

--- a/packaging/npm/assemble.sh
+++ b/packaging/npm/assemble.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+#
+# Stage the @dolthub/doltlite-wasm npm package into an output directory ready
+# for `npm publish`. Copies the WASM distributables produced by
+# `make -C ext/wasm npm` (they land in ext/wasm/jswasm) alongside this
+# directory's package.json/index.mjs/README, stamps the version, and drops in
+# the repo LICENSE.
+#
+# Usage: assemble.sh <version> <out_dir>
+#   version  release version without the leading "v" (e.g. 0.11.15)
+#   out_dir  directory to create and populate (e.g. dist/npm)
+
+set -euo pipefail
+
+VERSION="${1:?usage: assemble.sh <version> <out_dir>}"
+OUT_DIR="${2:?usage: assemble.sh <version> <out_dir>}"
+
+PKG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$PKG_DIR/../.." && pwd)"
+JSWASM="$ROOT/ext/wasm/jswasm"
+
+# The distributables `make -C ext/wasm npm` produces (see the npm_files list
+# in ext/wasm/GNUmakefile). Keep this in sync with package.json "files".
+ARTIFACTS=(
+  sqlite3.mjs
+  sqlite3.wasm
+  sqlite3-bundler-friendly.mjs
+  sqlite3-node.mjs
+  sqlite3-opfs-async-proxy.js
+  sqlite3-worker1.mjs
+  sqlite3-worker1-bundler-friendly.mjs
+  sqlite3-worker1-promiser.mjs
+)
+
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR"
+
+missing=0
+for f in "${ARTIFACTS[@]}"; do
+  if [ ! -f "$JSWASM/$f" ]; then
+    echo "ERROR: missing wasm artifact: $JSWASM/$f (did 'make -C ext/wasm npm' run?)" >&2
+    missing=1
+    continue
+  fi
+  cp "$JSWASM/$f" "$OUT_DIR/$f"
+done
+[ "$missing" = 0 ] || exit 1
+
+cp "$PKG_DIR/index.mjs" "$OUT_DIR/index.mjs"
+cp "$PKG_DIR/README.md" "$OUT_DIR/README.md"
+cp "$ROOT/LICENSE.md"   "$OUT_DIR/LICENSE.md"
+cp "$PKG_DIR/package.json" "$OUT_DIR/package.json"
+
+# Stamp the version into the staged package.json without depending on jq.
+node -e '
+  const fs = require("fs");
+  const p = process.argv[1], v = process.argv[2];
+  const j = JSON.parse(fs.readFileSync(p, "utf8"));
+  j.version = v;
+  fs.writeFileSync(p, JSON.stringify(j, null, 2) + "\n");
+' "$OUT_DIR/package.json" "$VERSION"
+
+echo "Staged @dolthub/doltlite-wasm@$VERSION in $OUT_DIR:"
+ls -la "$OUT_DIR"

--- a/packaging/npm/index.mjs
+++ b/packaging/npm/index.mjs
@@ -1,0 +1,10 @@
+// Entry point for @dolthub/doltlite-wasm.
+//
+// Mirrors @sqlite.org/sqlite-wasm: the default export is the async module
+// initializer. Await it to get the sqlite3 namespace, which has the dolt_*
+// version-control functions already registered (the wasm build wires
+// doltliteInstallAutoExt() into sqlite3_wasm_extra_init).
+import sqlite3InitModule from './sqlite3-bundler-friendly.mjs';
+
+export default sqlite3InitModule;
+export { sqlite3InitModule };

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "@dolthub/doltlite-wasm",
+  "version": "0.0.0",
+  "description": "DoltLite compiled to WebAssembly: SQLite with Dolt-style version control (branches, commits, merge, diff) for the browser and any JS runtime.",
+  "type": "module",
+  "main": "index.mjs",
+  "module": "index.mjs",
+  "exports": {
+    ".": "./index.mjs",
+    "./sqlite3.mjs": "./sqlite3.mjs",
+    "./sqlite3.wasm": "./sqlite3.wasm",
+    "./sqlite3-bundler-friendly.mjs": "./sqlite3-bundler-friendly.mjs",
+    "./sqlite3-node.mjs": "./sqlite3-node.mjs",
+    "./sqlite3-opfs-async-proxy.js": "./sqlite3-opfs-async-proxy.js",
+    "./sqlite3-worker1.mjs": "./sqlite3-worker1.mjs",
+    "./sqlite3-worker1-bundler-friendly.mjs": "./sqlite3-worker1-bundler-friendly.mjs",
+    "./sqlite3-worker1-promiser.mjs": "./sqlite3-worker1-promiser.mjs",
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "index.mjs",
+    "sqlite3.mjs",
+    "sqlite3.wasm",
+    "sqlite3-bundler-friendly.mjs",
+    "sqlite3-node.mjs",
+    "sqlite3-opfs-async-proxy.js",
+    "sqlite3-worker1.mjs",
+    "sqlite3-worker1-bundler-friendly.mjs",
+    "sqlite3-worker1-promiser.mjs",
+    "README.md",
+    "LICENSE.md"
+  ],
+  "keywords": [
+    "sqlite",
+    "wasm",
+    "webassembly",
+    "dolt",
+    "doltlite",
+    "version-control",
+    "database",
+    "opfs",
+    "local-first",
+    "git-for-data"
+  ],
+  "homepage": "https://github.com/dolthub/doltlite#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dolthub/doltlite.git",
+    "directory": "packaging/npm"
+  },
+  "bugs": {
+    "url": "https://github.com/dolthub/doltlite/issues"
+  },
+  "author": "DoltHub, Inc.",
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packaging/npm/smoke-test.mjs
+++ b/packaging/npm/smoke-test.mjs
@@ -1,0 +1,48 @@
+// Smoke test for the installed @dolthub/doltlite-wasm package.
+//
+// Run from a directory where the package has been `npm install`ed. Resolves the
+// Node entry and the wasm binary through the package's exports map (so a broken
+// "exports" subpath or a file missing from "files" fails here), instantiates
+// the module, and exercises a real dolt_commit -> dolt_log round-trip to prove
+// the dolt_* functions are registered in the published artifact.
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
+import fs from 'node:fs';
+
+// Resolve from the consumer's cwd (where node_modules lives), not this script's
+// location, so it works when invoked by absolute path from a temp consumer dir.
+const require = createRequire(pathToFileURL(process.cwd() + '/'));
+
+const nodeEntry = require.resolve('@dolthub/doltlite-wasm/sqlite3-node.mjs');
+const wasmPath = require.resolve('@dolthub/doltlite-wasm/sqlite3.wasm');
+
+const { default: sqlite3InitModule } = await import(pathToFileURL(nodeEntry).href);
+
+const sqlite3 = await sqlite3InitModule({
+  locateFile: (name) => (name === 'sqlite3.wasm' ? wasmPath : name),
+  wasmBinary: fs.readFileSync(wasmPath),
+});
+
+function fail(msg) {
+  throw new Error(msg);
+}
+
+const db = new sqlite3.oo1.DB(':memory:', 'c');
+try {
+  const version = db.selectValue('select dolt_version()');
+  const engine = db.selectValue('select doltlite_engine()');
+  if (!version || typeof version !== 'string') fail('dolt_version() returned no version');
+  if (engine !== 'prolly') fail(`doltlite_engine() returned ${engine}`);
+
+  db.exec('create table t(id integer primary key, v text)');
+  db.exec("insert into t values(1, 'a')");
+  db.exec("select dolt_commit('-A', '-m', 'c1')");
+
+  // Initial commit plus c1 => 2 rows in dolt_log, matching the native smoke test.
+  const commits = db.selectValue('select count(*) from dolt_log');
+  if (commits !== 2) fail(`expected 2 commits in dolt_log, got ${commits}`);
+
+  console.log(`@dolthub/doltlite-wasm package smoke OK: version=${version}, engine=${engine}, commits=${commits}`);
+} finally {
+  db.close();
+}

--- a/packaging/npm/test-package.sh
+++ b/packaging/npm/test-package.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Package-level smoke test for @dolthub/doltlite-wasm. Stages the package from
+# the freshly built wasm distributables (ext/wasm/jswasm, produced by
+# `make -C ext/wasm npm`), packs it the way `npm publish` would (honoring the
+# "files" allowlist), installs the tarball into a throwaway consumer project,
+# and runs smoke-test.mjs against it. This exercises the real package metadata
+# -- exports map, files list, index.mjs -- not just the raw jswasm files.
+#
+# Assumes `make -C ext/wasm npm` has already run.
+
+set -euo pipefail
+
+PKG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$PKG_DIR/../.." && pwd)"
+
+STAGE="$(mktemp -d)"
+CONSUMER="$(mktemp -d)"
+trap 'rm -rf "$STAGE" "$CONSUMER"' EXIT
+
+# Stage the package (version is irrelevant for the smoke test).
+bash "$PKG_DIR/assemble.sh" "0.0.0-ci" "$STAGE/pkg"
+
+# Pack exactly what would be published, then install that tarball.
+TGZ="$(cd "$STAGE/pkg" && npm pack --silent)"
+cd "$CONSUMER"
+npm init -y >/dev/null 2>&1
+npm install --no-audit --no-fund --silent "$STAGE/pkg/$TGZ"
+
+# Run the smoke test from the consumer so it resolves the installed package.
+node "$PKG_DIR/smoke-test.mjs"


### PR DESCRIPTION
Closes #627.

## What

Adds the **`@dolthub/doltlite-wasm`** npm package — the WebAssembly distribution of DoltLite (SQLite + Dolt version control) for the browser and any JS runtime — and publishes it directly from this repo's release workflow.

### Why publish from here (no separate repo)

The other bindings (`doltlite-node`, `doltlite-python`) live in their own repos because they contain real hand-written binding code (N-API glue, a Python loader). The **WASM binding has none** — the JS API already lives in `ext/wasm/api/` and is assembled into the artifacts by the build, and the `dolt_*` functions are auto-registered via `doltliteInstallAutoExt()` in `sqlite3_wasm_extra_init`. So the package is just the build output + a `package.json` + README. A second repo would only be a place to copy artifacts into; publishing from the canonical repo keeps the npm version locked to the engine version automatically. (Mirrors `@sqlite.org/sqlite-wasm`, except upstream needs a downstream repo only because their source is Fossil, not GitHub.)

## Changes

- **`packaging/npm/`** — `package.json` (`@dolthub/doltlite-wasm`, ESM, scoped public), `index.mjs` re-exporting the bundler-friendly init (matches `@sqlite.org/sqlite-wasm`'s `sqlite3InitModule` API), a README with browser-OPFS + Node examples, and `assemble.sh` which stages the 8 distributables from `make -C ext/wasm npm` alongside a version-stamped `package.json` and the repo LICENSE.
- **`.github/workflows/release.yml`** — a `publish-wasm-npm` job (tag push, `needs: release`) that builds the distributables, stages with `assemble.sh`, and `npm publish`es. Idempotent (skips if the version is already on the registry).
- **`README.md`** — WASM row added to the Bindings table.

## Action required before this can publish

Add an **`NPM_TOKEN`** repo secret — an npm **automation** token with publish rights to the **`@dolthub`** scope. The job fails fast with a clear message if it's missing. (First publish of a brand-new package name may need a one-time manual `npm publish` or scope/access setup, depending on org settings.)

## Validation

Local (the wasm compile itself runs in CI, which needs emsdk):
- `package.json` parses; `exports`/`files` consistent with the GNUmakefile `npm_files` list.
- `assemble.sh` stages correctly and stamps the version.
- `npm pack --dry-run` produces the expected 12-file tarball.
- `release.yml` parses as valid YAML; new job wired as `needs: release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)