### PR TITLE
Use rowid lookup for workspace cache

### DIFF
--- a/src/doltlite_workspace.c
+++ b/src/doltlite_workspace.c
@@ -407,9 +407,9 @@ static int wsRowid(sqlite3_vtab_cursor *cur, sqlite3_int64 *pRowid){
 }
 
 static WorkspaceRow *wsFindCachedRow(WorkspaceVtab *p, i64 rowid){
-  int i;
-  for(i=0; i<p->nCache; i++){
-    if( p->aCache[i].rowid==rowid ) return &p->aCache[i];
+  if( rowid>=1 && rowid<=p->nCache ){
+    WorkspaceRow *r = &p->aCache[rowid - 1];
+    if( r->rowid==rowid ) return r;
   }
   return 0;
 }


### PR DESCRIPTION
## Summary
- use the dense workspace cache rowid to find cached rows directly during `dolt_workspace_<table>` updates
- replaces the linear scan over cached workspace rows in `wsFindCachedRow()`
- preserves the existing row cache and staging behavior

## Performance
Workload: 30,000 modified workspace rows, 5x fresh DB copies:
`UPDATE dolt_workspace_t SET staged=FALSE;`

This no-op update isolates cached-row lookup cost while still exercising the normal workspace update path.

- master: 0.34-0.36s
- branch: 0.05s

For full `UPDATE dolt_workspace_t SET staged=TRUE` on 5,000 indexed rows, branch output and integrity matched master; that path is dominated by root mutation/catalog writes, so the row lookup change is mostly hidden there.

## Tests
- `make sqlite3` after regenerating local amalgamation build inputs
- `git diff --check`
- `DOLTLITE=./sqlite3 bash test/doltlite_workspace.sh`
- `DOLTLITE=./sqlite3 bash test/vc_oracle_workspace_test.sh`
- `bash test/doltlite_dolt_table_pushdown.sh ./sqlite3`
- `bash test/review_regression_test.sh ./sqlite3`
- `DOLTLITE=./sqlite3 bash test/doltlite_comparison.sh`