### PR TITLE
Push down conflict summary table filters

### DIFF
--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -367,8 +367,31 @@ static int cfClose(sqlite3_vtab_cursor *cur){
 static int cfFilter(sqlite3_vtab_cursor *cur, int n, const char *s, int a, sqlite3_value **v){
   ConflictsCur *c=(ConflictsCur*)cur;
   ConflictsVtab *vt=(ConflictsVtab*)cur->pVtab;
-  (void)n;(void)s;(void)a;(void)v;
+  int rc;
+  (void)s;
   c->iRow=0;
+  freeConflictTables(c->aTables, c->nTables);
+  c->aTables = 0;
+  c->nTables = 0;
+  if( n==1 && a>=1 ){
+    const char *zTable = (const char*)sqlite3_value_text(v[0]);
+    ConflictTableInfo table;
+    int found = 0;
+    if( !zTable ) return SQLITE_OK;
+    rc = loadConflictTable(vt->db, doltliteGetChunkStore(vt->db),
+                           zTable, &table, &found);
+    if( rc!=SQLITE_OK ) return rc;
+    if( found ){
+      c->aTables = sqlite3_malloc(sizeof(*c->aTables));
+      if( !c->aTables ){
+        freeConflictTable(&table);
+        return SQLITE_NOMEM;
+      }
+      c->aTables[0] = table;
+      c->nTables = 1;
+    }
+    return SQLITE_OK;
+  }
   return loadAllConflicts(vt->db, doltliteGetChunkStore(vt->db), &c->aTables, &c->nTables);
 }
 static int cfNext(sqlite3_vtab_cursor *cur){ ((ConflictsCur*)cur)->iRow++; return SQLITE_OK; }
@@ -382,7 +405,11 @@ static int cfColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
   return SQLITE_OK;
 }
 static int cfRowid(sqlite3_vtab_cursor *cur, sqlite3_int64 *r){ *r=((ConflictsCur*)cur)->iRow; return SQLITE_OK; }
-static int cfBestIndex(sqlite3_vtab *v, sqlite3_index_info *p){ (void)v; p->estimatedCost=10; return SQLITE_OK; }
+static int cfBestIndex(sqlite3_vtab *v, sqlite3_index_info *p){
+  (void)v;
+  p->estimatedCost = 10;
+  return doltliteBestIndexEq(p, 0);
+}
 
 static sqlite3_module conflictsModule = {
   0,0,cfConnect,cfBestIndex,doltliteVtabDisconnect,0,cfOpen,cfClose,cfFilter,cfNext,cfEof,

--- a/src/doltlite_constraint_violations.c
+++ b/src/doltlite_constraint_violations.c
@@ -496,11 +496,31 @@ static int cvsClose(sqlite3_vtab_cursor *cur){
 static int cvsFilter(sqlite3_vtab_cursor *cur, int n, const char *s, int a, sqlite3_value **v){
   CvSumCur *c = (CvSumCur*)cur;
   CvSumVtab *vt = (CvSumVtab*)cur->pVtab;
-  (void)n;(void)s;(void)a;(void)v;
+  int rc;
+  (void)s;
   freeViolationTables(c->aTables, c->nTables);
   c->aTables = 0;
   c->nTables = 0;
   c->iRow = 0;
+  if( n==1 && a>=1 ){
+    const char *zTable = (const char*)sqlite3_value_text(v[0]);
+    ConstraintViolationTable table;
+    int found = 0;
+    if( !zTable ) return SQLITE_OK;
+    rc = loadViolationTable(vt->db, doltliteGetChunkStore(vt->db),
+                            zTable, &table, &found);
+    if( rc!=SQLITE_OK ) return rc;
+    if( found ){
+      c->aTables = sqlite3_malloc(sizeof(*c->aTables));
+      if( !c->aTables ){
+        freeViolationTable(&table);
+        return SQLITE_NOMEM;
+      }
+      c->aTables[0] = table;
+      c->nTables = 1;
+    }
+    return SQLITE_OK;
+  }
   return loadAllViolations(vt->db, doltliteGetChunkStore(vt->db),
                            &c->aTables, &c->nTables);
 }
@@ -528,7 +548,7 @@ static int cvsRowid(sqlite3_vtab_cursor *cur, sqlite3_int64 *r){
 static int cvsBestIndex(sqlite3_vtab *v, sqlite3_index_info *p){
   (void)v;
   p->estimatedCost = 10;
-  return SQLITE_OK;
+  return doltliteBestIndexEq(p, 0);
 }
 
 static sqlite3_module cvSummaryModule = {


### PR DESCRIPTION
## Summary
- push `WHERE "table" = ?` into the `dolt_conflicts` summary table
- push `WHERE "table" = ?` into the `dolt_constraint_violations` summary table
- reuse the existing single-table loaders so filtered summary scans avoid materializing unrelated table rows

## Performance
Workload: 300 conflicted tables, 2000 filtered summary lookups in the same conflict transaction:
`SELECT num_conflicts FROM dolt_conflicts WHERE "table"='t250';`

- master: 1.01-1.03s over 3 runs
- branch: 0.85-0.86s over 3 runs
- summary count and filtered `t250:1` output matched master
- `EXPLAIN QUERY PLAN` shows virtual table index 1 for filtered `dolt_conflicts` and `dolt_constraint_violations` scans

## Tests
- `make sqlite3` after regenerating local amalgamation build inputs
- `git diff --check`
- `DOLTLITE=./sqlite3 bash test/vc_oracle_conflicts_table_test.sh`
- `DOLTLITE=./sqlite3 bash test/vc_oracle_conflicts_test.sh`
- `DOLTLITE=./sqlite3 bash test/doltlite_merge.sh`
- `DOLTLITE=./sqlite3 bash test/vc_oracle_merge_test.sh`
- `bash test/review_regression_test.sh ./sqlite3`
- `DOLTLITE=./sqlite3 bash test/doltlite_comparison.sh`