### PR TITLE
Build and release a Swift XCFramework for doltlite-swift

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -771,3 +771,116 @@ jobs:
           exit 0
         fi
         npm publish --access public
+
+  # ── Build the Swift XCFramework ──────────────────────────
+  # Compiles the doltlite amalgamation for the Apple platform slices (iOS,
+  # iOS Simulator, macOS, Mac Catalyst) and packs them into doltlite.xcframework.
+  # The zip is uploaded as an artifact so the `release` job attaches it to the
+  # GitHub release; the SwiftPM checksum is exposed as a job output for
+  # release-swift. Needs full Xcode, so it runs on macOS.
+  swift-xcframework:
+    if: github.event_name != 'workflow_dispatch'
+    runs-on: macos-latest
+    outputs:
+      checksum: ${{ steps.build.outputs.checksum }}
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Build generated SQLite files
+      run: |
+        ./configure
+        make sqlite3.c sqlite3.h sqlite3ext.h
+
+    - name: Build XCFramework
+      id: build
+      run: |
+        VERSION=${GITHUB_REF_NAME#v}
+        bash packaging/swift/build-xcframework.sh "$VERSION" build-swift
+
+    - name: Upload XCFramework artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: swift-xcframework
+        path: build-swift/doltlite-*.xcframework.zip
+
+  # ── Tag the Swift package ────────────────────────────────
+  # After the release exists, attach the XCFramework zip as a release asset,
+  # then point dolthub/doltlite-swift's Package.swift at it (url + checksum) and
+  # tag it, the same way release-bindings tags the node/python repos. Kept off
+  # the `release` job's critical path so a flaky Xcode build can't block the
+  # core release; re-running this job alone recovers it.
+  release-swift:
+    if: github.event_name != 'workflow_dispatch'
+    needs: [release, swift-xcframework]
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
+      VERSION: ${{ github.ref_name }}
+      CHECKSUM: ${{ needs.swift-xcframework.outputs.checksum }}
+    steps:
+    - name: Check release bot token
+      run: |
+        if [ -z "${GH_TOKEN}" ]; then
+          echo "RELEASE_BOT_TOKEN is required to push commits and tags to doltlite-swift"
+          exit 1
+        fi
+        gh auth status
+        gh auth setup-git
+
+    - name: Configure git identity
+      run: |
+        git config --global user.name "DoltHub Release Bot"
+        git config --global user.email "releases@dolthub.com"
+
+    - name: Download XCFramework artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: swift-xcframework
+        path: swift-dist
+
+    - name: Attach XCFramework to the release
+      run: |
+        version="${VERSION#v}"
+        gh release upload "${VERSION}" "swift-dist/doltlite-${version}.xcframework.zip" \
+          --repo dolthub/doltlite --clobber
+
+    - name: Tag doltlite-swift
+      run: |
+        set -euo pipefail
+        version="${VERSION#v}"
+
+        if gh api "repos/dolthub/doltlite-swift/git/ref/tags/${VERSION}" >/dev/null 2>&1; then
+          echo "doltlite-swift ${VERSION} already exists; skipping"
+          exit 0
+        fi
+        if [ -z "${CHECKSUM}" ]; then
+          echo "missing XCFramework checksum from swift-xcframework job"
+          exit 1
+        fi
+
+        gh repo clone dolthub/doltlite-swift doltlite-swift
+        cd doltlite-swift
+        git checkout main
+        git pull --ff-only origin main
+
+        python3 - "$version" "$CHECKSUM" <<'PY'
+        import re, sys
+        from pathlib import Path
+        version, checksum = sys.argv[1], sys.argv[2]
+        url = (f"https://github.com/dolthub/doltlite/releases/download/"
+               f"v{version}/doltlite-{version}.xcframework.zip")
+        p = Path("Package.swift")
+        text = p.read_text()
+        text = re.sub(r'url: "[^"]*"', f'url: "{url}"', text, count=1)
+        text = re.sub(r'checksum: "[0-9a-f]*"', f'checksum: "{checksum}"', text, count=1)
+        p.write_text(text)
+        PY
+
+        if ! git diff --quiet; then
+          git add Package.swift
+          git commit -m "Release ${version}: point XCFramework at this release"
+          git push origin main
+        fi
+
+        git tag "${VERSION}"
+        git push origin "${VERSION}"

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Language-specific wrappers around `libdoltlite`. Each one exposes the full `sqli
 | Python | `pip install doltlite` | [dolthub/doltlite-python](https://github.com/dolthub/doltlite-python) |
 | Node.js / Bun | `npm install @dolthub/doltlite` | [dolthub/doltlite-node](https://github.com/dolthub/doltlite-node) |
 | Browser / WASM | `npm install @dolthub/doltlite-wasm` | this repo ([`packaging/npm`](packaging/npm), built from [`ext/wasm`](ext/wasm)) |
+| Swift (iOS / macOS) | SwiftPM: `https://github.com/dolthub/doltlite-swift` | [dolthub/doltlite-swift](https://github.com/dolthub/doltlite-swift) (XCFramework built by [`packaging/swift`](packaging/swift)) |
 
 ## Building
 

--- a/packaging/swift/build-xcframework.sh
+++ b/packaging/swift/build-xcframework.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+#
+# Build doltlite.xcframework from the doltlite amalgamation for the Apple
+# platforms a Swift Package needs: iOS device, iOS simulator, macOS, and Mac
+# Catalyst. Each slice compiles sqlite3.c (the doltlite-woven amalgamation, so
+# the dolt_* version-control functions are built in and auto-registered) as a
+# single translation unit and archives it into a static library; the slices are
+# combined with `xcodebuild -create-xcframework`. Emits a zipped xcframework and
+# its SwiftPM checksum (the zip's SHA-256).
+#
+# Requires full Xcode (xcodebuild + the iOS SDKs) -- it does not run with the
+# Command Line Tools alone. Run from the repo root after the amalgamation exists
+# (`make sqlite3.c sqlite3.h`).
+#
+# Usage: build-xcframework.sh <version> [out_dir]
+#   version  release version without the leading "v" (e.g. 0.11.17)
+#   out_dir  directory for the .xcframework and zip (default: ./build-swift)
+
+set -euo pipefail
+
+VERSION="${1:?usage: build-xcframework.sh <version> [out_dir]}"
+OUT_DIR="${2:-build-swift}"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+if [ ! -f sqlite3.c ] || [ ! -f sqlite3.h ]; then
+  echo "ERROR: sqlite3.c/sqlite3.h not found; run 'make sqlite3.c sqlite3.h' first" >&2
+  exit 1
+fi
+
+WORK="$OUT_DIR/work"
+rm -rf "$OUT_DIR"
+mkdir -p "$WORK"
+
+# Feature flags: keep in step with the release build's amalgamation. zlib and
+# libm are part of the Apple platform SDKs, so SQLITE_HAVE_ZLIB stays on and the
+# module map links z.
+CFLAGS_COMMON=(
+  -O2 -fembed-bitcode-marker
+  -DNDEBUG
+  -DSQLITE_ENABLE_MATH_FUNCTIONS -DSQLITE_THREADSAFE=1
+  -DDOLTLITE_PROLLY=1 -DDOLTLITE_VERSION="\"v${VERSION}\""
+  -DSQLITE_ENABLE_FTS5 -DSQLITE_ENABLE_RTREE -DSQLITE_ENABLE_DBSTAT_VTAB
+  -Wno-comment
+)
+
+# compile_slice <label> <sdk> <min-flag> <arch...>
+# Compiles one static lib (one object per arch, lipo'd) for a platform slice.
+compile_slice() {
+  local label="$1" sdk="$2" minflag="$3"; shift 3
+  local sysroot; sysroot="$(xcrun --sdk "$sdk" --show-sdk-path)"
+  local objs=()
+  local arch
+  for arch in "$@"; do
+    local obj="$WORK/${label}-${arch}.o"
+    # Catalyst uses an explicit -target triple rather than -arch + min flag.
+    if [ "$label" = "maccatalyst" ]; then
+      clang -target "${arch}-apple-ios14.0-macabi" -isysroot "$sysroot" \
+        "${CFLAGS_COMMON[@]}" -c sqlite3.c -o "$obj"
+    else
+      clang -arch "$arch" -isysroot "$sysroot" "$minflag" \
+        "${CFLAGS_COMMON[@]}" -c sqlite3.c -o "$obj"
+    fi
+    objs+=("$obj")
+  done
+  local lib="$WORK/libdoltlite-${label}.a"
+  if [ "${#objs[@]}" -gt 1 ]; then
+    local archlibs=()
+    for obj in "${objs[@]}"; do
+      local al="${obj%.o}.a"; ar rcs "$al" "$obj"; archlibs+=("$al")
+    done
+    lipo -create "${archlibs[@]}" -output "$lib"
+  else
+    ar rcs "$lib" "${objs[0]}"
+  fi
+  echo "$lib"
+}
+
+IOS_DEVICE_LIB="$(compile_slice ios        iphoneos        -mios-version-min=14.0           arm64)"
+IOS_SIM_LIB="$(compile_slice    iossim     iphonesimulator -mios-simulator-version-min=14.0 arm64 x86_64)"
+MACOS_LIB="$(compile_slice      macos      macosx          -mmacosx-version-min=11.0        arm64 x86_64)"
+CATALYST_LIB="$(compile_slice   maccatalyst macosx         ''                               arm64 x86_64)"
+
+# Shared headers + module map for every slice. The C module is CDoltlite; it
+# exposes the sqlite3_* C API (the dolt_* functions are reached through SQL).
+HDRS="$WORK/headers"
+mkdir -p "$HDRS"
+cp sqlite3.h "$HDRS/doltlite.h"
+cat > "$HDRS/module.modulemap" <<'EOF'
+module CDoltlite {
+    header "doltlite.h"
+    link "z"
+    export *
+}
+EOF
+
+XCF="$OUT_DIR/doltlite.xcframework"
+xcodebuild -create-xcframework \
+  -library "$IOS_DEVICE_LIB" -headers "$HDRS" \
+  -library "$IOS_SIM_LIB"    -headers "$HDRS" \
+  -library "$MACOS_LIB"      -headers "$HDRS" \
+  -library "$CATALYST_LIB"   -headers "$HDRS" \
+  -output "$XCF"
+
+ZIP="$OUT_DIR/doltlite-${VERSION}.xcframework.zip"
+# Zip the .xcframework directory itself (not its parent path) so the archive
+# unpacks to doltlite.xcframework/ at its root, as SwiftPM expects.
+( cd "$OUT_DIR" && zip -ryq "doltlite-${VERSION}.xcframework.zip" "doltlite.xcframework" )
+
+# SwiftPM's binaryTarget checksum is the zip's SHA-256.
+CHECKSUM="$(shasum -a 256 "$ZIP" | awk '{print $1}')"
+
+echo "xcframework: $XCF"
+echo "zip:         $ZIP"
+echo "checksum:    $CHECKSUM"
+# Machine-readable outputs for CI.
+echo "$CHECKSUM" > "$OUT_DIR/checksum.txt"
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  echo "checksum=$CHECKSUM" >> "$GITHUB_OUTPUT"
+  echo "zip=$ZIP" >> "$GITHUB_OUTPUT"
+fi


### PR DESCRIPTION
The "real iOS story" for the Swift binding (#631): a prebuilt **XCFramework** (iOS device, iOS Simulator, macOS, Mac Catalyst) consumed by the new [dolthub/doltlite-swift](https://github.com/dolthub/doltlite-swift) SwiftPM package.

## How it works

DoltLite is a *replacement* engine, so the usual Swift path (link Apple's system `libsqlite3` à la GRDB/SQLite.swift) can't deliver `dolt_*`. Instead we vendor our own engine: compile the doltlite **amalgamation** per Apple slice (single TU — the `dolt_*` functions are woven in and auto-registered), archive each into a static lib, and combine with `xcodebuild -create-xcframework`. SwiftPM consumes it via a `.binaryTarget`.

The package lives in its **own repo** (like `doltlite-node`/`doltlite-python`, since it has real wrapper code), already seeded. This repo builds the XCFramework and tags `doltlite-swift` per release.

## Changes (this repo)

- **`packaging/swift/build-xcframework.sh`** — per-slice `clang` compile + `ar` + `lipo` + `create-xcframework`; emits the zip and its SwiftPM checksum (the zip's SHA-256).
- **`.github/workflows/release.yml`**:
  - `swift-xcframework` (macOS) — builds the framework, uploads the zip artifact, exposes the checksum as a job output.
  - `release-swift` — attaches the zip to the GitHub release, rewrites `doltlite-swift`'s `Package.swift` (`url` + `checksum`), commits, and tags it (uses `RELEASE_BOT_TOKEN`, mirroring `release-bindings`).
  - Both are **off the core release's critical path** — a flaky Xcode build can't block binaries/.deb/wasm; re-running `release-swift` recovers it.
- **`README.md`** — Swift (iOS / macOS) row added to the Bindings table.

## Companion repo (already seeded)

`dolthub/doltlite-swift` `main` has `Package.swift` (CDoltlite binaryTarget + a `Doltlite` Swift wrapper), the wrapper, a test, README, license. The url/checksum on `main` are placeholders; the first release (≥ v0.11.17) tags a resolvable version.

## Validation

This box has only Command Line Tools (no iOS SDK / `xcodebuild`), so the iOS slices and `create-xcframework` run in CI. Verified locally what's possible:
- The amalgamation **compiles as a single TU** for the macOS arm64 slice with the release flags, archives, and a probe linked against it runs `dolt_commit` → **`engine=prolly commits=2`**.
- The `Doltlite` Swift wrapper **typechecks against the real `doltlite.h`** (`swiftc -typecheck`, exit 0).
- `Package.swift` parses (`swift package dump-package`), and the `release-swift` patch rewrites it to a still-valid manifest.
- Workflow YAML parses; jobs wired `release-swift needs [release, swift-xcframework]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)