### PR TITLE
Optimize targeted catalog root lookups

### DIFF
--- a/src/doltlite_hashof.c
+++ b/src/doltlite_hashof.c
@@ -52,58 +52,44 @@ static int hashofTableInCatalog(
   const char *zTable,
   char *pHex
 ){
-  struct TableEntry *aTables = 0;
-  struct TableEntry *pTE = 0;
   ChunkStore *cs;
   ProllyCache *cache;
   SchemaEntry schemaEntry;
-  int nTables = 0;
   int foundSchema = 0;
+  ProllyHash tableRoot;
   ProllyHash schemaHash;
   ProllyHash tableHash;
   u8 aBuf[PROLLY_HASH_SIZE*2];
   int rc;
 
-  rc = doltliteLoadCatalog(db, pCatHash, &aTables, &nTables, 0);
+  rc = doltliteLoadTableRootByName(db, pCatHash, zTable, &tableRoot, 0,
+                                   &schemaHash);
   if( rc!=SQLITE_OK ) return rc;
-  pTE = doltliteFindTableByName(aTables, nTables, zTable);
-  if( !pTE ){
-    doltliteFreeCatalog(aTables, nTables);
-    return SQLITE_NOTFOUND;
-  }
 
   cs = doltliteGetChunkStore(db);
   cache = doltliteGetCache(db);
   if( !cs || !cache ){
-    doltliteFreeCatalog(aTables, nTables);
     return SQLITE_ERROR;
   }
 
   rc = loadSchemaEntryFromCatalog(db, cs, cache, pCatHash, zTable,
                                   &schemaEntry, &foundSchema);
-  if( rc!=SQLITE_OK ){
-    doltliteFreeCatalog(aTables, nTables);
-    return rc;
-  }
+  if( rc!=SQLITE_OK ) return rc;
   if( foundSchema ){
     char *zCanon = doltliteCanonicalizeSchemaSql(schemaEntry.zSql,
                                                  schemaEntry.zName);
     if( !zCanon ){
       clearSchemaEntry(&schemaEntry);
-      doltliteFreeCatalog(aTables, nTables);
       return SQLITE_NOMEM;
     }
     prollyHashCompute(zCanon, (int)strlen(zCanon), &schemaHash);
     sqlite3_free(zCanon);
-  }else{
-    schemaHash = pTE->schemaHash;
   }
 
-  memcpy(aBuf, pTE->root.data, PROLLY_HASH_SIZE);
+  memcpy(aBuf, tableRoot.data, PROLLY_HASH_SIZE);
   memcpy(aBuf + PROLLY_HASH_SIZE, schemaHash.data, PROLLY_HASH_SIZE);
   prollyHashCompute(aBuf, sizeof(aBuf), &tableHash);
   clearSchemaEntry(&schemaEntry);
-  doltliteFreeCatalog(aTables, nTables);
   doltliteHashToHex(&tableHash, pHex);
   return SQLITE_OK;
 }

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -611,6 +611,15 @@ int doltliteLoadTableRootByName(
   ProllyHash *pSchemaHash
 );
 
+int doltliteLoadTableRootById(
+  sqlite3 *db,
+  const ProllyHash *pCatHash,
+  Pgno iTable,
+  ProllyHash *pRoot,
+  u8 *pFlags,
+  ProllyHash *pSchemaHash
+);
+
 static SQLITE_INLINE int doltliteLoadTableRootByNameOrEmpty(
   sqlite3 *db,
   const ProllyHash *pCatHash,

--- a/src/doltlite_schema_diff.c
+++ b/src/doltlite_schema_diff.c
@@ -232,30 +232,18 @@ int loadSchemaEntryFromCatalog(
   SchemaEntry *pEntry,
   int *pFound
 ){
-  struct TableEntry *aTables = 0;
-  int nTables = 0;
   ProllyHash masterRoot;
   u8 masterFlags = 0;
   ProllyCursor cur;
-  int res, rc, i;
+  int res, rc;
 
   memset(pEntry, 0, sizeof(*pEntry));
   *pFound = 0;
   if( !zName || prollyHashIsEmpty(pCatHash) ) return SQLITE_OK;
 
-  rc = doltliteLoadCatalog(db, pCatHash, &aTables, &nTables, 0);
+  rc = doltliteLoadTableRootById(db, pCatHash, 1, &masterRoot, &masterFlags, 0);
+  if( rc==SQLITE_NOTFOUND ) return SQLITE_OK;
   if( rc!=SQLITE_OK ) return rc;
-
-  memset(&masterRoot, 0, sizeof(masterRoot));
-  for(i=0; i<nTables; i++){
-    if( aTables[i].iTable==1 ){
-      memcpy(&masterRoot, &aTables[i].root, sizeof(ProllyHash));
-      masterFlags = aTables[i].flags;
-      break;
-    }
-  }
-  doltliteFreeCatalog(aTables, nTables);
-
   if( prollyHashIsEmpty(&masterRoot) ) return SQLITE_OK;
 
   prollyCursorInit(&cur, cs, pCache, &masterRoot, masterFlags);

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -10313,6 +10313,108 @@ int doltliteLoadTableRootByName(
   return SQLITE_OK;
 }
 
+int doltliteLoadTableRootById(
+  sqlite3 *db,
+  const ProllyHash *pCatHash,
+  Pgno iTable,
+  ProllyHash *pRoot,
+  u8 *pFlags,
+  ProllyHash *pSchemaHash
+){
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  u8 *data = 0;
+  int nData = 0;
+  const u8 *q;
+  const u8 *pEntries;
+  int nTables = 0;
+  int iFormat = 0;
+  int i;
+  int rc;
+
+  memset(pRoot, 0, sizeof(*pRoot));
+  if( pFlags ) *pFlags = 0;
+  if( pSchemaHash ) memset(pSchemaHash, 0, sizeof(*pSchemaHash));
+  if( !cs ) return SQLITE_ERROR;
+  if( !pCatHash || iTable==0 || prollyHashIsEmpty(pCatHash) ){
+    return SQLITE_NOTFOUND;
+  }
+
+  rc = chunkStoreGet(cs, pCatHash, &data, &nData);
+  if( rc!=SQLITE_OK ) return rc;
+  if( !catalogParseHeaderEx(data, nData, &iFormat, &nTables, &pEntries) ){
+    sqlite3_free(data);
+    return SQLITE_CORRUPT;
+  }
+
+  q = pEntries;
+  for(i=0; i<nTables; i++){
+    Pgno entryTable;
+    u8 flags;
+    ProllyHash root;
+    ProllyHash schemaHash;
+
+    if( q+CAT_ENTRY_ITABLE_SIZE+CAT_ENTRY_FLAGS_SIZE
+        +PROLLY_HASH_SIZE+PROLLY_HASH_SIZE > data+nData ){
+      sqlite3_free(data);
+      return SQLITE_CORRUPT;
+    }
+    entryTable = (Pgno)(q[0] | (q[1]<<8) | (q[2]<<16) | (q[3]<<24));
+    q += CAT_ENTRY_ITABLE_SIZE;
+    flags = *q++;
+    memcpy(root.data, q, PROLLY_HASH_SIZE);
+    q += PROLLY_HASH_SIZE;
+    memcpy(schemaHash.data, q, PROLLY_HASH_SIZE);
+    q += PROLLY_HASH_SIZE;
+
+    if( iFormat==CATALOG_FORMAT_V4 ){
+      int nType, nName, nTbl;
+      if( q+6 > data+nData ){
+        sqlite3_free(data);
+        return SQLITE_CORRUPT;
+      }
+      nType = q[0] | (q[1]<<8);
+      nName = q[2] | (q[3]<<8);
+      nTbl = q[4] | (q[5]<<8);
+      q += 6;
+      if( q+nType+nName+nTbl > data+nData ){
+        sqlite3_free(data);
+        return SQLITE_CORRUPT;
+      }
+      if( entryTable==iTable ){
+        memcpy(pRoot, &root, sizeof(*pRoot));
+        if( pFlags ) *pFlags = flags;
+        if( pSchemaHash ) memcpy(pSchemaHash, &schemaHash, sizeof(*pSchemaHash));
+        sqlite3_free(data);
+        return SQLITE_OK;
+      }
+      q += nType+nName+nTbl;
+    }else{
+      int nLen;
+      if( q+2 > data+nData ){
+        sqlite3_free(data);
+        return SQLITE_CORRUPT;
+      }
+      nLen = q[0] | (q[1]<<8);
+      q += 2;
+      if( q+nLen > data+nData ){
+        sqlite3_free(data);
+        return SQLITE_CORRUPT;
+      }
+      if( entryTable==iTable ){
+        memcpy(pRoot, &root, sizeof(*pRoot));
+        if( pFlags ) *pFlags = flags;
+        if( pSchemaHash ) memcpy(pSchemaHash, &schemaHash, sizeof(*pSchemaHash));
+        sqlite3_free(data);
+        return SQLITE_OK;
+      }
+      q += nLen;
+    }
+  }
+
+  sqlite3_free(data);
+  return SQLITE_NOTFOUND;
+}
+
 void doltliteFreeCatalog(struct TableEntry *a, int n){
   int i;
   if( !a ) return;


### PR DESCRIPTION
## Summary
- Add a targeted catalog root lookup by table id for callers that already know the catalog table number.
- Use targeted catalog scans in dolt_hashof_table() and schema-entry loading instead of materializing the whole catalog.
- Speeds up table-hash/schema lookup paths used by dolt_hashof_table(), dolt_diff_stat(), and dolt_schema_diff().

## Performance
Benchmark: 2,500-table committed database; 1,000 repeated calls to SELECT dolt_hashof_table('t0000','HEAD'); fresh DB copy per sample.

- origin/master samples: 1.86s, 1.85s, 1.84s, 1.88s, 1.96s; avg 1.878s
- patched samples: 1.24s, 1.06s, 1.07s, 1.07s, 1.06s; avg 1.100s
- improvement: ~41% faster

## Tests
- make sqlite3.c sqlite3
- bash test/vc_oracle_hashof_test.sh
- bash test/vc_oracle_hashof_errors_test.sh
- bash test/vc_oracle_schema_diff_test.sh
- bash test/vc_oracle_diff_stat_test.sh
- bash test/doltlite_schema_diff.sh
- ./testfixture test/doltlite_default_materialization.test from a clean temp dir
- git diff --check

Note: make devtest currently fails during debug/fuzz build setup with amalgamation-level conflicts such as sqlite3BtreeSeekCount conflicting types and sqlite3SchemaMutexHeld redefinition; the failure happens before the TCL tests run and is not in the edited code paths.