### PR TITLE
Build and push the Ruby gem on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -884,3 +884,77 @@ jobs:
 
         git tag "${VERSION}"
         git push origin "${VERSION}"
+
+  # ── Release the Ruby gem ─────────────────────────────────
+  # Builds precompiled platform gems for dolthub/doltlite-ruby from this
+  # release's per-platform libdoltlite zips and pushes them to RubyGems, then
+  # bumps + tags the repo. Like the other bindings it is post-release and
+  # non-blocking. Needs RUBYGEMS_API_KEY (a RubyGems API key with push rights to
+  # the doltlite gem) and RELEASE_BOT_TOKEN.
+  release-ruby:
+    if: github.event_name != 'workflow_dispatch'
+    needs: release
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
+      VERSION: ${{ github.ref_name }}
+      GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+    steps:
+    - name: Check tokens
+      run: |
+        if [ -z "${GH_TOKEN}" ]; then
+          echo "RELEASE_BOT_TOKEN is required to push commits and tags to doltlite-ruby"
+          exit 1
+        fi
+        if [ -z "${GEM_HOST_API_KEY}" ]; then
+          echo "RUBYGEMS_API_KEY is required to push gems to RubyGems"
+          exit 1
+        fi
+        gh auth status
+        gh auth setup-git
+
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: "3.2"
+
+    - name: Configure git identity
+      run: |
+        git config --global user.name "DoltHub Release Bot"
+        git config --global user.email "releases@dolthub.com"
+
+    - name: Build and push gems, tag doltlite-ruby
+      run: |
+        set -euo pipefail
+        version="${VERSION#v}"
+
+        if gh api "repos/dolthub/doltlite-ruby/git/ref/tags/${VERSION}" >/dev/null 2>&1; then
+          echo "doltlite-ruby ${VERSION} already exists; skipping"
+          exit 0
+        fi
+
+        gh repo clone dolthub/doltlite-ruby doltlite-ruby
+        cd doltlite-ruby
+        git checkout main
+        git pull --ff-only origin main
+
+        sed -i "s/VERSION = \"[^\"]*\"/VERSION = \"${version}\"/" lib/doltlite/version.rb
+
+        # Per-platform libdoltlite zips from this release feed the gem build.
+        mkdir -p ../libs
+        gh release download "${VERSION}" --repo dolthub/doltlite \
+          --pattern 'doltlite-lib-*.zip' --dir ../libs
+        bash script/build-gems.sh "${version}" ../libs
+
+        for g in pkg/*.gem; do
+          echo "pushing $g"
+          gem push "$g"
+        done
+
+        if ! git diff --quiet; then
+          git add lib/doltlite/version.rb
+          git commit -m "Bump version to ${version}"
+          git push origin main
+        fi
+
+        git tag "${VERSION}"
+        git push origin "${VERSION}"

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Language-specific wrappers around `libdoltlite`. Each one exposes the full `sqli
 | Language | Distribution | Source |
 |---|---|---|
 | Python | `pip install doltlite` | [dolthub/doltlite-python](https://github.com/dolthub/doltlite-python) |
+| Ruby | `gem install doltlite` | [dolthub/doltlite-ruby](https://github.com/dolthub/doltlite-ruby) |
 | Node.js / Bun | `npm install @dolthub/doltlite` | [dolthub/doltlite-node](https://github.com/dolthub/doltlite-node) |
 | Browser / WASM | `npm install @dolthub/doltlite-wasm` | this repo ([`packaging/npm`](packaging/npm), built from [`ext/wasm`](ext/wasm)) |
 | Swift (iOS / macOS) | SwiftPM: `https://github.com/dolthub/doltlite-swift` | [dolthub/doltlite-swift](https://github.com/dolthub/doltlite-swift) (XCFramework built by [`packaging/swift`](packaging/swift)) |


### PR DESCRIPTION
Closes #630.

## What

Ships the **Ruby gem** for DoltLite, the last of the three packaging issues. Like the Python binding, it's a **thin FFI layer over a bundled `libdoltlite`** (not a hand-written native extension) — far less C to maintain, and it reuses the per-platform `libdoltlite` the release already builds.

The gem lives in its own repo, **[dolthub/doltlite-ruby](https://github.com/dolthub/doltlite-ruby)** (already seeded), consistent with node/python/swift.

## Changes (this repo)

- **`.github/workflows/release.yml`** — a `release-ruby` job (post-release, non-blocking): downloads this release's `doltlite-lib-<target>` zips, builds **precompiled platform gems** (linux x64/arm64, macOS arm64/x64) via the gem's `script/build-gems.sh`, `gem push`es them to RubyGems, then bumps + tags `doltlite-ruby` (mirrors `release-bindings`).
- **`README.md`** — Ruby row in the Bindings table (`gem install doltlite`).

## Companion repo (already seeded on `main`)

`dolthub/doltlite-ruby`: FFI bindings to the `sqlite3_*` C API + a `Doltlite::Database` class (`open`/`execute`/`query`/`commit`); `dolt_*` reached through SQL. Includes a gemspec that honors `GEM_PLATFORM` for platform gems, `script/build-gems.sh`, a minitest suite, and CI that runs the suite against the latest release's `libdoltlite` on Linux + macOS.

## ⚠️ Action required before this can publish

Add a **`RUBYGEMS_API_KEY`** repo secret — a RubyGems API key with push rights to the `doltlite` gem. The job fails fast with a clear message if it's missing. (First push of a brand-new gem name may need a one-time manual `gem push`, depending on RubyGems ownership settings.)

## Validation

No Ruby/FFI runtime on the dev box, so the FFI behavior runs in `doltlite-ruby` CI (against the real `libdoltlite`). Verified locally what's possible:
- all Ruby files **syntax-check** (`ruby -c`);
- the **gemspec loads** as a valid `Gem::Specification` and honors `GEM_PLATFORM` (`platform=ruby` → `x86_64-linux`);
- `script/build-gems.sh` passes `bash -n`;
- both workflow YAMLs parse; `release-ruby` wired `needs: release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)