### PR TITLE
Persist PRAGMA user_version across DoltLite connections

### DIFF
--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -117,7 +117,10 @@
 
 #define CATALOG_FORMAT_V3       0x44
 #define CATALOG_FORMAT_V4       0x45
+#define CATALOG_FORMAT_V5       0x46
 #define CAT_HEADER_SIZE_V3      5
+#define CAT_HEADER_META_SIZE_V5 8
+#define CAT_HEADER_SIZE_V5      (CAT_HEADER_SIZE_V3 + CAT_HEADER_META_SIZE_V5)
 #define CAT_ENTRY_ITABLE_SIZE   4
 #define CAT_ENTRY_FLAGS_SIZE    1
 #define CAT_ENTRY_FIXED_SIZE_V3 (CAT_ENTRY_ITABLE_SIZE + CAT_ENTRY_FLAGS_SIZE + PROLLY_HASH_SIZE + PROLLY_HASH_SIZE + 2)
@@ -128,13 +131,17 @@ static SQLITE_INLINE int catalogParseHeaderEx(
 ){
   const u8 *q;
   if( nData < CAT_HEADER_SIZE_V3 ) return 0;
-  if( data[0] != CATALOG_FORMAT_V3 && data[0] != CATALOG_FORMAT_V4 ){
+  if( data[0] != CATALOG_FORMAT_V3
+   && data[0] != CATALOG_FORMAT_V4
+   && data[0] != CATALOG_FORMAT_V5 ){
     return 0;
   }
+  if( data[0]==CATALOG_FORMAT_V5 && nData < CAT_HEADER_SIZE_V5 ) return 0;
   if( pVersion ) *pVersion = data[0];
   q = data + CAT_HEADER_SIZE_V3 - 4;
   *pnTables = (int)(q[0] | (q[1]<<8) | (q[2]<<16) | (q[3]<<24));
-  *ppEntries = data + CAT_HEADER_SIZE_V3;
+  *ppEntries = data + (data[0]==CATALOG_FORMAT_V5 ?
+                       CAT_HEADER_SIZE_V5 : CAT_HEADER_SIZE_V3);
   return 1;
 }
 

--- a/src/doltlite_chunk_walk.c
+++ b/src/doltlite_chunk_walk.c
@@ -111,7 +111,7 @@ static int enumerateCatalogChildren(
     ProllyHash tableRoot;
     const u8 *pEnd = data + nData;
 
-    if( p + (iFormat==CATALOG_FORMAT_V4 ? CAT_ENTRY_FIXED_SIZE_V4 : CAT_ENTRY_FIXED_SIZE_V3) > pEnd ){
+    if( p + (iFormat!=CATALOG_FORMAT_V3 ? CAT_ENTRY_FIXED_SIZE_V4 : CAT_ENTRY_FIXED_SIZE_V3) > pEnd ){
       return SQLITE_CORRUPT;
     }
 
@@ -123,7 +123,7 @@ static int enumerateCatalogChildren(
 
     p += CAT_ENTRY_ITABLE_SIZE + CAT_ENTRY_FLAGS_SIZE
        + PROLLY_HASH_SIZE + PROLLY_HASH_SIZE;
-    if( iFormat==CATALOG_FORMAT_V4 ){
+    if( iFormat!=CATALOG_FORMAT_V3 ){
       int nType, nName, nTbl;
       if( p + 6 > pEnd ) return SQLITE_CORRUPT;
       nType = p[0] | (p[1]<<8); p += 2;

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -70,6 +70,17 @@ int doltliteSerializeCatalogEntriesWithFallbackSchema(
 );
 int origBtreeCheckpoint(void *p, int eMode, int *pnLog, int *pnCkpt);
 
+static u32 getU32LE(const u8 *p){
+  return ((u32)p[0]) | ((u32)p[1]<<8) | ((u32)p[2]<<16) | ((u32)p[3]<<24);
+}
+
+static void putU32LE(u8 *p, u32 v){
+  p[0] = (u8)v;
+  p[1] = (u8)(v>>8);
+  p[2] = (u8)(v>>16);
+  p[3] = (u8)(v>>24);
+}
+
 #ifndef TRANS_NONE
 #define TRANS_NONE  0
 #define TRANS_READ  1
@@ -2005,7 +2016,7 @@ static int doltliteSerializeCatalogEntriesForBtreeImpl(
   u8 **ppOut,
   int *pnOut
 ){
-  int sz = CAT_HEADER_SIZE_V3;
+  int sz = CAT_HEADER_SIZE_V5;
   u8 *buf, *q;
   sqlite3 *db;
   SchemaCatalogRow *aRows = 0;
@@ -2220,9 +2231,13 @@ static int doltliteSerializeCatalogEntriesForBtreeImpl(
   }
   q = buf;
 
-  *q++ = CATALOG_FORMAT_V4;
+  *q++ = CATALOG_FORMAT_V5;
   q[0]=(u8)nTables; q[1]=(u8)(nTables>>8);
   q[2]=(u8)(nTables>>16); q[3]=(u8)(nTables>>24);
+  q += 4;
+  putU32LE(q, pBtree->aMeta[BTREE_USER_VERSION]);
+  q += 4;
+  putU32LE(q, pBtree->aMeta[BTREE_APPLICATION_ID]);
   q += 4;
 
   for(i=0; i<nTables; i++){
@@ -2308,6 +2323,12 @@ static int serializeCatalogPatchRoots(Btree *pBtree, u8 **ppOut, int *pnOut){
     sqlite3_free(buf);
     return SQLITE_NOTFOUND;
   }
+  if( iFormat!=CATALOG_FORMAT_V5 ){
+    sqlite3_free(buf);
+    return SQLITE_NOTFOUND;
+  }
+  putU32LE(buf + CAT_HEADER_SIZE_V3, pBtree->aMeta[BTREE_USER_VERSION]);
+  putU32LE(buf + CAT_HEADER_SIZE_V3 + 4, pBtree->aMeta[BTREE_APPLICATION_ID]);
 
   q = buf + (pEntries - (const u8*)buf);
   for(i=0; i<nTables; i++){
@@ -2336,7 +2357,7 @@ static int serializeCatalogPatchRoots(Btree *pBtree, u8 **ppOut, int *pnOut){
     q += PROLLY_HASH_SIZE + PROLLY_HASH_SIZE;
     nPatched++;
 
-    if( iFormat==CATALOG_FORMAT_V4 ){
+    if( iFormat!=CATALOG_FORMAT_V3 ){
       int nType, nName, nTbl;
       if( q + 6 > buf + nData ){
         sqlite3_free(buf);
@@ -2535,18 +2556,25 @@ static int deserializeCatalog(Btree *pBtree, const u8 *data, int nData){
   memset(aMetaNew, 0, sizeof(aMetaNew));
   aMetaNew[BTREE_FILE_FORMAT] = 4;
   aMetaNew[BTREE_TEXT_ENCODING] = SQLITE_UTF8;
-  /* Session-scoped meta is not stored in the catalog; a reload must not
-  ** zero it (user_version was lost on any commit that reloaded the
-  ** catalog). */
+  /* Keep session-scoped meta across in-connection catalog reloads. V5
+  ** catalogs persist user-visible header meta so new connections see it too. */
   aMetaNew[BTREE_DEFAULT_CACHE_SIZE] = pBtree->aMeta[BTREE_DEFAULT_CACHE_SIZE];
   aMetaNew[BTREE_USER_VERSION] = pBtree->aMeta[BTREE_USER_VERSION];
   aMetaNew[BTREE_INCR_VACUUM] = pBtree->aMeta[BTREE_INCR_VACUUM];
   aMetaNew[BTREE_APPLICATION_ID] = pBtree->aMeta[BTREE_APPLICATION_ID];
+  if( iFormat==CATALOG_FORMAT_V5 ){
+    aMetaNew[BTREE_USER_VERSION] = getU32LE(data + CAT_HEADER_SIZE_V3);
+    aMetaNew[BTREE_APPLICATION_ID] = getU32LE(data + CAT_HEADER_SIZE_V3 + 4);
+  }
 
   {
     ProllyHash h;
     u32 schemaHash;
-    prollyHashCompute(data, nData, &h);
+    if( iFormat==CATALOG_FORMAT_V5 ){
+      prollyHashCompute(q, (int)(nData - (q - data)), &h);
+    }else{
+      prollyHashCompute(data, nData, &h);
+    }
     schemaHash = ((u32)h.data[0])
                | ((u32)h.data[1] << 8)
                | ((u32)h.data[2] << 16)
@@ -2575,7 +2603,7 @@ static int deserializeCatalog(Btree *pBtree, const u8 *data, int nData){
     q += PROLLY_HASH_SIZE;
     memcpy(pTE->schemaHash.data, q, PROLLY_HASH_SIZE);
     q += PROLLY_HASH_SIZE;
-    if( iFormat==CATALOG_FORMAT_V4 ){
+    if( iFormat!=CATALOG_FORMAT_V3 ){
       int nType, nName, nTbl;
       const u8 *pType, *pName, *pTbl;
       if( q+6 > data+nData ){
@@ -5846,7 +5874,7 @@ static int restoreFromCommitted(Btree *p){
           q += PROLLY_HASH_SIZE;
           memcpy(pTE->schemaHash.data, q, PROLLY_HASH_SIZE);
           q += PROLLY_HASH_SIZE;
-          if( iFormat==CATALOG_FORMAT_V4 ){
+          if( iFormat!=CATALOG_FORMAT_V3 ){
             int nType, nName, nTbl;
             if( q + 6 > p->pCatalogCache + p->nCatalogCache ){
               rc = SQLITE_CORRUPT;
@@ -10249,7 +10277,7 @@ int doltliteLoadTableRootByName(
     memcpy(schemaHash.data, q, PROLLY_HASH_SIZE);
     q += PROLLY_HASH_SIZE;
 
-    if( iFormat==CATALOG_FORMAT_V4 ){
+    if( iFormat!=CATALOG_FORMAT_V3 ){
       int nType, nName, nTbl;
       const u8 *pType;
       const u8 *pName;
@@ -10366,7 +10394,7 @@ int doltliteLoadTableRootById(
     memcpy(schemaHash.data, q, PROLLY_HASH_SIZE);
     q += PROLLY_HASH_SIZE;
 
-    if( iFormat==CATALOG_FORMAT_V4 ){
+    if( iFormat!=CATALOG_FORMAT_V3 ){
       int nType, nName, nTbl;
       if( q+6 > data+nData ){
         sqlite3_free(data);

--- a/test/doltlite_pragma_user_version.sh
+++ b/test/doltlite_pragma_user_version.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+source "$(dirname "$0")/lib/doltlite_test_common.sh"
+
+db_rm() {
+  rm -rf "$1" "${1}-wal"
+}
+
+echo "=== PRAGMA user_version/application_id persistence ==="
+echo ""
+
+DB=/tmp/test_user_version_$$.db; db_rm "$DB"
+
+run_test "user_version_default" \
+  "PRAGMA user_version;" \
+  "0" \
+  "$DB"
+
+run_test "user_version_same_connection" \
+  "PRAGMA user_version=7; PRAGMA user_version;" \
+  "7" \
+  "$DB"
+
+run_test "user_version_reopen" \
+  "PRAGMA user_version;" \
+  "7" \
+  "$DB"
+
+run_test "user_version_with_deferred_txn" \
+  "BEGIN DEFERRED; CREATE TABLE t(id INTEGER PRIMARY KEY); PRAGMA user_version=11; COMMIT; PRAGMA user_version;" \
+  "11" \
+  "$DB"
+
+run_test "user_version_deferred_txn_reopen" \
+  "PRAGMA user_version; SELECT name FROM sqlite_master WHERE type='table' AND name='t';" \
+  "11
+t" \
+  "$DB"
+
+run_test "user_version_rollback" \
+  "BEGIN; PRAGMA user_version=12; ROLLBACK; PRAGMA user_version;" \
+  "11" \
+  "$DB"
+
+run_test "user_version_rollback_reopen" \
+  "PRAGMA user_version;" \
+  "11" \
+  "$DB"
+
+run_test "application_id_reopen" \
+  "PRAGMA application_id=123456; PRAGMA application_id;" \
+  "123456" \
+  "$DB"
+
+run_test "application_id_reopen_again" \
+  "PRAGMA application_id;" \
+  "123456" \
+  "$DB"
+
+db_rm "$DB"
+
+dltest_finish

--- a/test/doltlite_recover_pragma_output.test
+++ b/test/doltlite_recover_pragma_output.test
@@ -316,7 +316,7 @@ do_test doltlite_recover_pragma_output-6.6 {
   db close
   sqlite3 db test.db
   execsql {PRAGMA user_version}
-} {0}
+} {6}
 
 do_test doltlite_recover_pragma_output-7.1 {
   db close

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -5008,6 +5008,11 @@ avtrans avtrans-9.34.5-21225  # sqlite_fullsync_count stays 0 (chunk-store sync 
 avtrans avtrans-9.36.5-25685  # sqlite_fullsync_count stays 0 (chunk-store sync path)
 avtrans avtrans-9.38.5-30883  # sqlite_fullsync_count stays 0 (chunk-store sync path)
 
+# corrupt8 pokes stock pointer-map page bytes by offset. DoltLite's chunk-store
+# file does not use SQLite pointer-map pages, so the raw write is not a valid
+# corruption of DoltLite's logical b-tree.
+corrupt8 corrupt8-2.1024.6
+
 # corruptB pokes stock b-tree page structures by offset. On a chunk-store
 # file the offsets read back garbage: .1 steps that compute child-page
 # offsets from in-file values die with tcl "integer value too large to
@@ -5015,10 +5020,16 @@ avtrans avtrans-9.38.5-30883  # sqlite_fullsync_count stays 0 (chunk-store sync 
 # differently ("no such table: t1" instead of "malformed", 1.3.2/2.1.2),
 # or never land at all so the read returns the intact row (1.9.2).
 corruptB corruptB-1.3.2
+corruptB corruptB-1.6.2
+corruptB corruptB-1.7.2
 corruptB corruptB-1.8.1
+corruptB corruptB-1.8.2
 corruptB corruptB-1.9.1
 corruptB corruptB-1.9.2
+corruptB corruptB-2.1.1
 corruptB corruptB-2.1.2
+corruptB corruptB-3.1.1
+corruptB corruptB-3.1.2
 
 # createtab: raw-format file-size compare; the doltlite chunk file is not
 # sized in 1024-byte pages and does not grow with auto_vacuum pointer-map

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -255,12 +255,8 @@ pragma pragma-8.1.3
 pragma pragma-8.1.4
 pragma pragma-8.1.6
 pragma pragma-8.1.9
-pragma pragma-8.2.13
-pragma pragma-8.2.3.2
 pragma pragma-8.2.4.1
-pragma pragma-8.2.4.2
 pragma pragma-8.2.4.3
-pragma pragma-8.2.8
 
 # ── shared ──
 # Connections to the same file don't share a pager cache: each gets its own
@@ -1177,14 +1173,6 @@ altercol altercol-11.1      # sqlite_schema row order (multiset equal)
 altercons altercons-3.7.2   # trailing space in rewritten DDL after DROP COLUMN
 altercons altercons-3.8.2   # trailing space in rewritten DDL after DROP COLUMN
 altercons altercons-6.4.1   # DDL normalizes "CHECK (" to "CHECK("
-
-# index5 — index5-1.3 records the on-disk page WRITE ORDER during CREATE INDEX
-# via a custom test VFS (forward/backward/non-contiguous page offsets) and
-# asserts a mostly-sequential pattern. DoltLite's chunk store writes
-# content-addressed chunks, not sequential btree pages, so the write-offset
-# pattern does not apply. Raw storage-layout divergence; the index is built
-# correctly (index5-1.2 passes).
-index5 index5-1.3  # page write-order via test VFS; chunk store is not page-sequential
 
 # limit2 — limit2-110.3 compares sqlite_search_count between an indexed and an
 # unindexed ORDER BY ... LIMIT, asserting the indexed plan scans <2% as many

--- a/test/lib/doltlite_suite_manifest.sh
+++ b/test/lib/doltlite_suite_manifest.sh
@@ -67,6 +67,7 @@ doltlite_pragma_encoding.sh
 doltlite_pragma_journal_mode.sh
 doltlite_pragma_memory_journal_mode.sh
 doltlite_pragma_page_count.sh
+doltlite_pragma_user_version.sh
 doltlite_pragma_wal_checkpoint.sh
 doltlite_merge_ignore_corners.sh
 doltlite_record_format.sh
@@ -121,6 +122,7 @@ doltlite_pragma_auto_vacuum.sh
 doltlite_pragma_journal_mode.sh
 doltlite_pragma_memory_journal_mode.sh
 doltlite_pragma_page_count.sh
+doltlite_pragma_user_version.sh
 doltlite_pragma_wal_checkpoint.sh
 doltlite_row_count_estimate.sh
 doltlite_schema_cookie.sh


### PR DESCRIPTION
## Summary
- persist DoltLite catalog header metadata for `PRAGMA user_version` and `PRAGMA application_id` in a new catalog format
- keep V3/V4 catalog reads backward-compatible and rewrite to V5 on the next catalog write
- keep `schema_version` stable across `user_version` changes by hashing only catalog entries for V5 schema-cookie derivation
- add a regression test for reopen persistence, deferred transaction commit, rollback, and application_id
- refresh regression expectations for `user_version` persistence and raw-format corruption tests that do not apply to DoltLite's chunk-store layout

## Repro
Before this change, a connection could set `PRAGMA user_version=1` and read back `1`, but a new connection read `0` while table changes persisted.

## Verification
- `cd build && make doltlite`
- direct repro: new connection now reads `PRAGMA user_version` as `1`
- `cd build && bash ../test/doltlite_pragma_user_version.sh`
- `cd build && bash ../test/doltlite_pragma_journal_mode.sh && bash ../test/doltlite_pragma_encoding.sh`
- `cd build && bash ../test/doltlite_gc.sh`
- old-format smoke: DB created by stale `DoltLite v0.11.17-1-gdf678bcd84` opens and rewrites user_version correctly
- CI on the original PR showed `sqlite-regression-ported` passing after the expectation update; follow-up commits address the later storage and ddl-schema divergence-gate failures

`make devtest` was attempted but this local environment fails linking generated testfixture builds with missing `libtommath`; no TCL tests ran after that build failure.
