### PR TITLE
Fix unique index deletes after prefix seeks

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -8866,6 +8866,7 @@ static int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
       }
     } else {
       if( pCur->nSeekSortKey>0
+       && pCur->nSeekKeyField==0
        && ((flags & BTREE_AUXDELETE) || cachedSeekKeyMatchesCurrent(pCur)) ){
         pSavedDelKey = pCur->pSeekSortKey;
         nSavedDelKey = pCur->nSeekSortKey;

--- a/test/doltlite_unique_index_delete.sh
+++ b/test/doltlite_unique_index_delete.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+source "$(dirname "$0")/lib/doltlite_test_common.sh"
+
+db_rm() {
+  rm -rf "$1" "${1}-wal"
+}
+
+echo "=== UNIQUE secondary index delete ==="
+echo ""
+
+DB=/tmp/test_unique_index_delete_$$.db; db_rm "$DB"
+
+run_test "blob_pk_unique_index_delete_index_scan" \
+  "CREATE TABLE t(id BLOB PRIMARY KEY NOT NULL, a BLOB NOT NULL, b BLOB NOT NULL, c INTEGER NOT NULL) STRICT;
+   CREATE UNIQUE INDEX t_uidx ON t(a, b, c);
+   INSERT INTO t VALUES (x'01', x'70', x'65', 0);
+   DELETE FROM t WHERE id=x'01';
+   SELECT changes();
+   SELECT count(*) FROM t INDEXED BY t_uidx;" \
+  "1
+0" \
+  "$DB"
+
+db_rm "$DB"
+
+run_test "blob_pk_unique_index_update_removes_old_entry" \
+  "CREATE TABLE t(id BLOB PRIMARY KEY NOT NULL, a BLOB NOT NULL, b BLOB NOT NULL, c INTEGER NOT NULL) STRICT;
+   CREATE UNIQUE INDEX t_uidx ON t(a, b, c);
+   INSERT INTO t VALUES (x'01', x'70', x'65', 0);
+   UPDATE t SET a=x'71' WHERE id=x'01';
+   SELECT changes();
+   SELECT count(*) FROM t INDEXED BY t_uidx WHERE a=x'70';
+   SELECT count(*) FROM t INDEXED BY t_uidx WHERE a=x'71';" \
+  "1
+0
+1" \
+  "$DB"
+
+db_rm "$DB"
+
+run_test "blob_pk_unique_index_driven_delete" \
+  "CREATE TABLE t(id BLOB PRIMARY KEY NOT NULL, a BLOB NOT NULL, b BLOB NOT NULL, c INTEGER NOT NULL) STRICT;
+   CREATE UNIQUE INDEX t_uidx ON t(a, b, c);
+   INSERT INTO t VALUES (x'01', x'70', x'65', 0), (x'02', x'70', x'66', 0);
+   DELETE FROM t WHERE a=x'70';
+   SELECT changes();
+   SELECT count(*) FROM t;
+   SELECT count(*) FROM t INDEXED BY t_uidx;" \
+  "2
+0
+0" \
+  "$DB"
+
+db_rm "$DB"
+
+run_test "blob_pk_fk_unique_index_delete_index_scan" \
+  "PRAGMA foreign_keys=ON;
+   CREATE TABLE edges (id BLOB PRIMARY KEY NOT NULL) STRICT;
+   CREATE TABLE paths (id BLOB PRIMARY KEY NOT NULL) STRICT;
+   CREATE TABLE path_edges (
+     id BLOB PRIMARY KEY NOT NULL,
+     path_id BLOB NOT NULL,
+     edge_id BLOB NOT NULL,
+     index_in_path INTEGER NOT NULL,
+     FOREIGN KEY(edge_id) REFERENCES edges(id),
+     FOREIGN KEY(path_id) REFERENCES paths(id)
+   ) STRICT;
+   CREATE UNIQUE INDEX path_edges_uidx ON path_edges(path_id, edge_id, index_in_path);
+   INSERT INTO edges VALUES (x'65');
+   INSERT INTO paths VALUES (x'70');
+   INSERT INTO path_edges VALUES (x'01', x'70', x'65', 0);
+   DELETE FROM path_edges WHERE id=x'01';
+   SELECT changes();
+   SELECT count(*) FROM path_edges INDEXED BY path_edges_uidx;" \
+  "1
+0" \
+  "$DB"
+
+db_rm "$DB"
+
+dltest_finish

--- a/test/lib/doltlite_suite_manifest.sh
+++ b/test/lib/doltlite_suite_manifest.sh
@@ -44,6 +44,7 @@ doltlite_rollback_durability.sh
 doltlite_delete_or.sh
 doltlite_nocase_index.sh
 doltlite_update_replace_trigger.sh
+doltlite_unique_index_delete.sh
 doltlite_trigger_visibility.sh
 doltlite_schema_merge.sh
 doltlite_branch_gc_stress.sh
@@ -113,6 +114,7 @@ doltlite_memory_db.sh
 doltlite_dbpage.sh
 doltlite_record_format.sh
 doltlite_rollback_durability.sh
+doltlite_unique_index_delete.sh
 doltlite_storage_locking.sh
 chunk_physical_dups_test.sh
 doltlite_open_sqlite_file.sh


### PR DESCRIPTION
## Summary
- fix `OP_IdxDelete` on UNIQUE secondary indexes when the cursor was positioned by a prefix seek
- avoid using a cached prefix seek key as the physical delete key; fall back to the cursor's current full key
- add a regression for BLOB primary-key STRICT tables with UNIQUE secondary indexes, including the reported foreign-key schema shape

## Root cause
For UNIQUE secondary indexes, SQLite may call `IdxDelete` with only the unique key columns. DoltLite stores the secondary-index entry under the full physical key, including appended primary-key fields for BLOB-key/WITHOUT ROWID tables. The delete path reused the cached prefix seek key as the delete key when `BTREE_AUXDELETE` was set, so it deleted a non-existent prefix key and left the full secondary-index entry behind.

The table row was deleted, but later covering-index scans could still return the stale row.

## Verification
- `cd build && make doltlite`
- `DOLTLITE=./build/doltlite bash test/doltlite_unique_index_delete.sh`
- direct repro with the reported `path_edges` schema: `changes() = 1`, table count `0`, explicit `path_edges_uidx` scan count `0`, reopen index scan count `0`
- `DOLTLITE=./build/doltlite bash test/doltlite_index_prefix.sh`
- `DOLTLITE=./build/doltlite bash test/doltlite_nocase_index.sh`
- `DOLTLITE=./build/doltlite bash test/doltlite_delete_or.sh`
