### PR TITLE
Ship the extension header (doltliteext.h) in the amalgamation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,11 @@ jobs:
         mkdir doltlite-amalgamation-${VERSION}
         cp sqlite3.c doltlite-amalgamation-${VERSION}/doltlite.c
         cp sqlite3.h doltlite-amalgamation-${VERSION}/doltlite.h
+        # Ship the extension header too, renamed and re-pointed at doltlite.h so
+        # extension authors get a self-contained header matching the amalgamation
+        # instead of having to source the right sqlite3ext.h separately.
+        sed 's/#include "sqlite3.h"/#include "doltlite.h"/' sqlite3ext.h \
+          > doltlite-amalgamation-${VERSION}/doltliteext.h
         zip -r doltlite-amalgamation-${VERSION}.zip doltlite-amalgamation-${VERSION}/
 
     - name: Package autoconf source

--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ to get version control. The build produces `libdoltlite.a` (static) and
 `libdoltlite.dylib`/`.so` (shared) with the full prolly tree engine and all
 Dolt functions included.
 
+Loadable-extension authors use `doltliteext.h` (the rebranded `sqlite3ext.h`,
+shipped in the amalgamation zip alongside `doltlite.c`/`doltlite.h`).
+
 ```bash
 cd build
 ../configure


### PR DESCRIPTION
Reported by a user: the amalgamation zip ships `doltlite.c` + `doltlite.h` but **not** the SQLite extension header, so loadable-extension authors have to go find the matching `sqlite3ext.h` themselves.

## Fix

The `Package amalgamation` step now also includes the extension header as **`doltliteext.h`** — `sqlite3ext.h` with its `#include "sqlite3.h"` re-pointed to `doltlite.h`, matching the existing `sqlite3.c`→`doltlite.c` / `sqlite3.h`→`doltlite.h` rebrand. The zip becomes self-contained for extension development.

```sh
sed 's/#include "sqlite3.h"/#include "doltlite.h"/' sqlite3ext.h > .../doltliteext.h
```

README's "Using as a C Library" section documents it.

## Validation

- The rewritten header **compiles** as an extension header: a TU doing `#include "doltliteext.h"` + `SQLITE_EXTENSION_INIT1` builds clean (`cc -fsyntax-only`).
- `sqlite3ext.h` has exactly one `#include "sqlite3.h"`, so the `sed` is exact.
- Workflow YAML parses.

Takes effect on the next release's amalgamation artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)