### PR TITLE
Fix txn composite index prefix scans

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -8053,6 +8053,7 @@ static int prollyBtCursorIndexMoveto(
         if( mutFromCursorMap ){
           setCursorToMutMapEntryPhys(
               pCur, (int)(mutE - pCur->pMutMap->aEntries));
+          pCur->deferredTreeSeek = 1;
         }else{
           rc = cacheCursorPayloadCopy(pCur, mutKey, mutNKey);
           if( rc!=SQLITE_OK ){

--- a/test/doltlite_index_prefix.sh
+++ b/test/doltlite_index_prefix.sh
@@ -239,6 +239,45 @@ run_test "mixed_10k_2prefix" \
   "SELECT count(*) FROM mixed WHERE tag='tag-5' AND seq=500;" \
   "1" "$DB7"
 
-rm -f "$DB1" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7"
+DB8=/tmp/test_idx8_$$.db; rm -f "$DB8"
+echo "CREATE TABLE block_groups (
+  id BLOB PRIMARY KEY NOT NULL,
+  collection_name TEXT NOT NULL,
+  sample_name TEXT NOT NULL,
+  name TEXT NOT NULL,
+  created_on INTEGER NOT NULL,
+  parent_block_group_id BLOB,
+  is_default INTEGER NOT NULL DEFAULT 0 CHECK (is_default IN (0, 1))
+) STRICT;
+CREATE UNIQUE INDEX block_group_uidx
+ON block_groups(collection_name, sample_name, name,
+  IFNULL(hex(parent_block_group_id), ''));
+INSERT INTO block_groups VALUES (
+  X'1111111100000000000000000000000000000000000000000000000000000001',
+  'simple', 'simple', 'm123', 1000, NULL, 1
+);
+SELECT dolt_commit('-am','load');" | $DOLTLITE "$DB8" > /dev/null 2>&1
+
+run_test "txn_composite_prefix_seek_excludes_stale_tree_row" \
+  "BEGIN;
+INSERT INTO block_groups VALUES (
+  X'6666666600000000000000000000000000000000000000000000000000000001',
+  'simple', 'unknown', 'm123', 1001,
+  X'1111111100000000000000000000000000000000000000000000000000000001',
+  1
+);
+SELECT count(*) FROM block_groups
+ WHERE collection_name='simple'
+   AND sample_name='unknown'
+   AND name='m123';
+SELECT sample_name FROM block_groups
+ WHERE collection_name='simple'
+   AND sample_name='unknown'
+   AND name='m123';
+END;" \
+  "1
+unknown" "$DB8"
+
+rm -f "$DB1" "$DB2" "$DB3" "$DB4" "$DB5" "$DB6" "$DB7" "$DB8"
 
 dltest_finish

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -4286,7 +4286,6 @@ fts4langid fts4langid-3.3.4.7
 # in-transaction langid UPDATE then integrity-check: false malformed
 # report (same stale shadow-read family)
 fts4langid fts4langid-6.1
-fts4langid fts4langid-6.2
 
 # REAL BUG pinned (issue: stale shadow-table reads during multi-write fts
 # statements corrupt automerge bookkeeping): automerge after a multi-row


### PR DESCRIPTION
## Summary
- reseek the tree cursor after prefix index seeks return a transactional mutmap entry
- add a regression for a composite index prefix lookup that previously leaked a committed row from the stale tree cursor

## Tests
- rm -f /tmp/composite_index_repro.db /tmp/composite_index_repro.db-wal /tmp/composite_index_repro.db-shm; ./build/doltlite /tmp/composite_index_repro.db < /tmp/composite_index_repro.sql
- DOLTLITE=./build/doltlite bash test/doltlite_index_prefix.sh
- DOLTLITE=./build/doltlite bash test/doltlite_unique_index_delete.sh
- DOLTLITE=./build/doltlite bash test/doltlite_nocase_index.sh
- DOLTLITE=./build/doltlite bash test/doltlite_record_format.sh
- bash test/correctness_test.sh ./build/doltlite

Note: cd build && bash ../test/run_doltlite_tests.sh could not run locally on macOS because /bin/bash does not provide mapfile.