### PR TITLE
Avoid materializing pending zeroblob incrblob reads

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -8424,12 +8424,39 @@ u32 sqlite3BtreePayloadSize(BtCursor *pCur){
   return pCur->pCurOps->xPayloadSize(pCur);
 }
 
+static int copyZeroTailPayload(
+  ProllyMutMapEntry *e,
+  u32 offset,
+  u32 amt,
+  void *pBuf
+){
+  i64 nTotal = (i64)e->nVal + e->nZeroTail;
+  if( (i64)offset + (i64)amt > nTotal ){
+    return SQLITE_CORRUPT_BKPT;
+  }
+  if( amt>0 ){
+    u32 nPrefix = offset < (u32)e->nVal ? (u32)e->nVal - offset : 0;
+    if( nPrefix>amt ) nPrefix = amt;
+    if( nPrefix>0 ) memcpy(pBuf, e->pVal + offset, nPrefix);
+    if( nPrefix<amt ) memset((u8*)pBuf + nPrefix, 0, amt - nPrefix);
+  }
+  return SQLITE_OK;
+}
+
 static int prollyBtCursorPayload(BtCursor *pCur, u32 offset, u32 amt, void *pBuf){
   const u8 *pData;
   int nData;
   int rc;
 
   assert( pCur->eState==CURSOR_VALID );
+  if( pCur->curIntKey
+   && pCur->mmActive
+   && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
+    ProllyMutMapEntry *e = currentMutMapEntry(pCur);
+    if( e && e->nZeroTail>0 ){
+      return copyZeroTailPayload(e, offset, amt, pBuf);
+    }
+  }
   rc = getCursorPayload(pCur, &pData, &nData);
   if( rc!=SQLITE_OK ){
     return rc;
@@ -8455,6 +8482,15 @@ static const void *prollyBtCursorPayloadFetch(BtCursor *pCur, u32 *pAmt){
   if( pCur->pCachedPayload && pCur->nCachedPayload > 0 ){
     if( pAmt ) *pAmt = (u32)pCur->nCachedPayload;
     return (const void*)pCur->pCachedPayload;
+  }
+  if( pCur->curIntKey
+   && pCur->mmActive
+   && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
+    ProllyMutMapEntry *e = currentMutMapEntry(pCur);
+    if( e && e->nZeroTail>0 && e->nVal>0 ){
+      if( pAmt ) *pAmt = (u32)e->nVal;
+      return (const void*)e->pVal;
+    }
   }
   if( getCursorPayload(pCur, &pData, &nData)!=SQLITE_OK ){
     if( pAmt ) *pAmt = 0;
@@ -9676,6 +9712,15 @@ static int prollyBtCursorPayloadChecked(BtCursor *pCur, u32 offset, u32 amt, voi
 
   if( pCur->eState!=CURSOR_VALID ){
     return SQLITE_ABORT;
+  }
+
+  if( pCur->curIntKey
+   && pCur->mmActive
+   && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
+    ProllyMutMapEntry *e = currentMutMapEntry(pCur);
+    if( e && e->nZeroTail>0 ){
+      return copyZeroTailPayload(e, offset, amt, pBuf);
+    }
   }
 
   rc = getCursorPayload(pCur, &pVal, &nVal);

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -7630,6 +7630,8 @@ static void run_incrblob_chunked_and_multihandle(void){
   sqlite3 *db = 0;
   sqlite3_blob *h1 = 0, *h2 = 0;
   char buf[8];
+  int bigBlobSize = 10 * 1024 * 1024;
+  int memoryCeiling = 5 * 1024 * 1024;
   int rc;
 
   printf("=== Incrblob Chunked Record And Multi-Handle Test ===\n\n");
@@ -7694,6 +7696,25 @@ static void run_incrblob_chunked_and_multihandle(void){
       strcmp(queryScalarText(db,
         "SELECT CAST(substr(v,8,6) AS TEXT) || '/' || length(v) FROM t WHERE k=4"),
         "HELLO!/20")==0);
+
+  check("incrblob_large_pending_setup", execSql(db,
+      "BEGIN; INSERT INTO t VALUES(6, zeroblob(10 * 1024 * 1024));"
+      )==SQLITE_OK);
+  sqlite3_memory_highwater(1);
+  check("incrblob_large_pending_open",
+      sqlite3_blob_open(db, "main", "t", "v", 6, 0, &h1)==SQLITE_OK);
+  check("incrblob_large_pending_open_memory",
+      sqlite3_memory_highwater(0) < memoryCeiling);
+  memset(buf, 1, 4);
+  check("incrblob_large_pending_tail_read",
+      h1 && sqlite3_blob_read(h1, buf, 4, bigBlobSize - 4)==SQLITE_OK);
+  check("incrblob_large_pending_tail_zero",
+      buf[0]==0 && buf[1]==0 && buf[2]==0 && buf[3]==0);
+  check("incrblob_large_pending_read_memory",
+      sqlite3_memory_highwater(0) < memoryCeiling);
+  if( h1 ) sqlite3_blob_close(h1);
+  h1 = 0;
+  check("incrblob_large_pending_rollback", execSql(db, "ROLLBACK;")==SQLITE_OK);
 
   sqlite3_close(db);
   removeDbFiles(dbpath);


### PR DESCRIPTION
## Summary
- Keep pending int-key rows with symbolic zeroblob tails positioned on the mutmap instead of eagerly caching a materialized payload in save-position cases.
- Teach direct payload fetch and checked payload reads to serve sparse zero-tail pending rows without allocating the full logical blob.
- Add a C regression that opens and reads the tail of a pending 10MB zeroblob through incremental blob APIs under a 5MB memory highwater ceiling.

This addresses the pending-row large-zeroblob portion of #1533. The broader shared-cache locking divergences and committed-row large-blob materialization remain separate investigation items.

## Tests
- `make doltlite libdoltlite.a`
- `bash ../test/run_doltlite_regression_case.sh incrblob_chunked_and_multihandle`
- `bash ../test/run_doltlite_regression_case.sh all`
- `make devtest` (fails in local generated build jobs before Tcl tests run: generated amalgamation build errors around `sqlite3BtreeSeekCount` / btree mutex symbols, plus local `ld: library 'tommath' not found`)