### PR TITLE
Keep committed zeroblob incrblob reads sparse

### DIFF
--- a/src/chunk_staging.c
+++ b/src/chunk_staging.c
@@ -270,12 +270,18 @@ int csGrowRecent(ChunkStore *cs, int nAdd){
   if( nNeed > cs->staging.nRecentAlloc ){
     int nNew = cs->staging.nRecentAlloc ? cs->staging.nRecentAlloc * 2 : CS_INIT_PENDING_ALLOC;
     ChunkIndexEntry *aNew;
+    i64 *aNewZ;
     while( nNew < nNeed ) nNew *= 2;
     aNew = (ChunkIndexEntry *)sqlite3_realloc(
       cs->staging.aRecent, nNew * (int)sizeof(ChunkIndexEntry)
     );
     if( aNew == 0 ) return SQLITE_NOMEM;
     cs->staging.aRecent = aNew;
+    aNewZ = (i64 *)sqlite3_realloc(
+      cs->staging.aRecentZeroTail, nNew * (int)sizeof(i64)
+    );
+    if( aNewZ == 0 ) return SQLITE_NOMEM;
+    cs->staging.aRecentZeroTail = aNewZ;
     cs->staging.nRecentAlloc = nNew;
   }
   return SQLITE_OK;

--- a/src/chunk_staging.h
+++ b/src/chunk_staging.h
@@ -14,6 +14,9 @@ struct ChunkStaging {
   /* Parallel to aPending: symbolic trailing zero bytes per staged chunk. */
   i64 *aPendingZeroTail;
   ChunkIndexEntry *aRecent;
+  /* Parallel to aRecent: symbolic trailing zero bytes preserved for chunks
+  ** committed by this connection and still in the recent table. */
+  i64 *aRecentZeroTail;
   int nRecent;
   int nRecentAlloc;
   int nRecentUncommitted;

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -613,6 +613,7 @@ int chunkStoreClose(ChunkStore *cs){
   sqlite3_free(cs->staging.aPending);
   sqlite3_free(cs->staging.aPendingZeroTail);
   sqlite3_free(cs->staging.aRecent);
+  sqlite3_free(cs->staging.aRecentZeroTail);
   csPendHTClear(cs);
   csRecentHTClear(cs);
   sqlite3_free(cs->staging.pWriteBuf);
@@ -1200,6 +1201,66 @@ int chunkStoreGet(
   return SQLITE_OK;
 }
 
+int chunkStoreGetSparse(
+  ChunkStore *cs,
+  const ProllyHash *hash,
+  u8 **ppData,
+  int *pnData,
+  int *pnDataPhys
+){
+  int idx;
+  int rc;
+
+  *ppData = 0;
+  *pnData = 0;
+  *pnDataPhys = 0;
+
+  if( cs->corruptMidStream ) return SQLITE_CORRUPT;
+
+  rc = csSearchRecent(cs, hash, &idx);
+  if( rc!=SQLITE_OK ) return rc;
+  if( idx>=0 && cs->staging.aRecentZeroTail
+   && cs->staging.aRecentZeroTail[idx]>0 ){
+    ChunkIndexEntry *e = &cs->staging.aRecent[idx];
+    i64 zeroTail = cs->staging.aRecentZeroTail[idx];
+    int nPhys;
+    u8 *pBuf;
+    u32 storedLen;
+
+    if( zeroTail<0 || zeroTail>(i64)e->size ) return SQLITE_CORRUPT;
+    nPhys = e->size - (int)zeroTail;
+    pBuf = (u8*)sqlite3_malloc(nPhys + 4);
+    if( !pBuf ) return SQLITE_NOMEM;
+    rc = sqlite3OsRead(cs->file.pFile, pBuf, nPhys + 4, e->offset);
+    if( rc!=SQLITE_OK ){
+      sqlite3_free(pBuf);
+      return rc;
+    }
+    storedLen = CS_READ_U32(pBuf);
+    if( (int)storedLen != e->size ){
+      sqlite3_free(pBuf);
+      return SQLITE_CORRUPT;
+    }
+    memmove(pBuf, pBuf + 4, nPhys);
+    {
+      ProllyHash h;
+      prollyHashComputeZeroTail(pBuf, nPhys, zeroTail, &h);
+      if( memcmp(&h, hash, sizeof(ProllyHash))!=0 ){
+        sqlite3_free(pBuf);
+        return SQLITE_CORRUPT;
+      }
+    }
+    *ppData = pBuf;
+    *pnData = e->size;
+    *pnDataPhys = nPhys;
+    return SQLITE_OK;
+  }
+
+  rc = chunkStoreGet(cs, hash, ppData, pnData);
+  if( rc==SQLITE_OK ) *pnDataPhys = *pnData;
+  return rc;
+}
+
 static void csFillChunkHdr(u8 *p, const ProllyHash *pHash, u32 size){
   p[0] = CS_WAL_TAG_CHUNK;
   memcpy(p + CS_WAL_CHUNK_HASH_OFF, pHash, PROLLY_HASH_SIZE);
@@ -1264,6 +1325,8 @@ static int csDrainPendingToWal(ChunkStore *cs){
 
     *pr = *pe;
     pr->offset = writeOff + CS_WAL_CHUNK_LEN_OFF;
+    cs->staging.aRecentZeroTail[cs->staging.nRecent+i] =
+      cs->staging.aPendingZeroTail[i];
 
     csFillChunkHdr(recHdr, &pe->hash, (u32)pe->size);
 
@@ -1768,6 +1831,10 @@ commit_done:
     if( useRecent ){
       memcpy(cs->staging.aRecent + cs->staging.nRecent, aCommittedPending,
              cs->staging.nPending * sizeof(ChunkIndexEntry));
+      for( i=0; i<cs->staging.nPending; i++ ){
+        cs->staging.aRecentZeroTail[cs->staging.nRecent+i] =
+          cs->staging.aPendingZeroTail[i];
+      }
       cs->staging.nRecent += cs->staging.nPending;
       sqlite3_free(aMerged);
     }else{
@@ -1777,6 +1844,10 @@ commit_done:
       cs->index.aIndexMmapBase = 0;
       cs->index.aIndexMmapSize = 0;
       cs->staging.nRecent = 0;
+      if( cs->staging.aRecentZeroTail ){
+        memset(cs->staging.aRecentZeroTail, 0,
+               cs->staging.nRecentAlloc * sizeof(i64));
+      }
       csRecentHTClear(cs);
     }
   }else{

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -1217,6 +1217,28 @@ int chunkStoreGetSparse(
 
   if( cs->corruptMidStream ) return SQLITE_CORRUPT;
 
+  rc = csSearchPending(cs, hash, &idx);
+  if( rc!=SQLITE_OK ) return rc;
+  if( idx>=0 && cs->staging.aPendingZeroTail
+   && cs->staging.aPendingZeroTail[idx]>0 ){
+    ChunkIndexEntry *e = &cs->staging.aPending[idx];
+    i64 zeroTail = cs->staging.aPendingZeroTail[idx];
+    int nPhys;
+    u8 *pBuf;
+
+    if( zeroTail<0 || zeroTail>(i64)e->size ) return SQLITE_CORRUPT;
+    nPhys = e->size - (int)zeroTail;
+    pBuf = (u8*)sqlite3_malloc(nPhys>0 ? nPhys : 1);
+    if( !pBuf ) return SQLITE_NOMEM;
+    if( nPhys>0 ){
+      memcpy(pBuf, cs->staging.pWriteBuf + e->offset + 4, nPhys);
+    }
+    *ppData = pBuf;
+    *pnData = e->size;
+    *pnDataPhys = nPhys;
+    return SQLITE_OK;
+  }
+
   rc = csSearchRecent(cs, hash, &idx);
   if( rc!=SQLITE_OK ) return rc;
   if( idx>=0 && cs->staging.aRecentZeroTail

--- a/src/chunk_store.h
+++ b/src/chunk_store.h
@@ -241,6 +241,8 @@ int chunkStoreHas(ChunkStore *cs, const ProllyHash *hash, int *pHas);
 
 int chunkStoreGet(ChunkStore *cs, const ProllyHash *hash,
                   u8 **ppData, int *pnData);
+int chunkStoreGetSparse(ChunkStore *cs, const ProllyHash *hash,
+                        u8 **ppData, int *pnData, int *pnDataPhys);
 
 int chunkStorePut(ChunkStore *cs, const u8 *pData, int nData,
                   ProllyHash *pHash);

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -3335,6 +3335,10 @@ static int restoreCursorPosition(BtCursor *pCur, int *pDifferentRow){
   if( pCur->curIntKey ){
     rc = prollyBtCursorTableMoveto(pCur, pCur->nKey, 0, &res);
   } else {
+    struct TableEntry *pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
+    if( pTE && pTE->pPending && pCur->pMutMap!=(ProllyMutMap*)pTE->pPending ){
+      pCur->pMutMap = (ProllyMutMap*)pTE->pPending;
+    }
     if( pCur->pKey && pCur->nKey>0 ){
       rc = prollyCursorSeekBlob(&pCur->pCur,
                                  (const u8*)pCur->pKey, (int)pCur->nKey,

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -566,6 +566,41 @@ static SQLITE_INLINE void cursorCurrentTreeValue(
   *pnData = (int)(off1 - off0);
 }
 
+static SQLITE_INLINE void cursorCurrentTreeValueSpan(
+  BtCursor *pCur,
+  const u8 **ppData,
+  int *pnData,
+  int *pnAvail
+){
+  ProllyCursor *pProllyCur = &pCur->pCur;
+  ProllyCacheEntry *pLeaf = pProllyCur->aLevel[pProllyCur->iLevel].pEntry;
+  ProllyNode *pNode = &pLeaf->node;
+  int i = pProllyCur->aLevel[pProllyCur->iLevel].idx;
+  prollyNodeValueSpan(pNode, i, ppData, pnData, pnAvail);
+}
+
+static int cursorCurrentTreeValueCopy(
+  BtCursor *pCur,
+  u32 offset,
+  u32 amt,
+  void *pBuf
+){
+  const u8 *pData;
+  int nData;
+  int nAvail;
+  cursorCurrentTreeValueSpan(pCur, &pData, &nData, &nAvail);
+  if( (i64)offset + (i64)amt > (i64)nData ){
+    return SQLITE_CORRUPT_BKPT;
+  }
+  if( amt>0 ){
+    u32 nPrefix = offset < (u32)nAvail ? (u32)nAvail - offset : 0;
+    if( nPrefix>amt ) nPrefix = amt;
+    if( nPrefix>0 ) memcpy(pBuf, pData + offset, nPrefix);
+    if( nPrefix<amt ) memset((u8*)pBuf + nPrefix, 0, amt - nPrefix);
+  }
+  return SQLITE_OK;
+}
+
 static SQLITE_INLINE u64 cursorCurrentTreeKeyPrefixInt(BtCursor *pCur){
   ProllyCursor *pProllyCur = &pCur->pCur;
   ProllyCacheEntry *pLeaf = pProllyCur->aLevel[pProllyCur->iLevel].pEntry;
@@ -6644,6 +6679,7 @@ static int prollyBtreeCursor(
 
   prollyCursorInit(&pCur->pCur, &pBt->store, &pBt->cache,
                     &pTE->root, pTE->flags);
+  prollyCursorAllowSparse(&pCur->pCur, 1);
 
   pCur->pNext = pBt->pCursor;
   pBt->pCursor = pCur;
@@ -8413,6 +8449,15 @@ static u32 prollyBtCursorPayloadSize(BtCursor *pCur){
       return (u32)((i64)e->nVal + e->nZeroTail);
     }
   }
+  if( pCur->curIntKey && pCur->pCur.eState==PROLLY_CURSOR_VALID ){
+    const u8 *pVal;
+    int nVal;
+    int nAvail;
+    cursorCurrentTreeValueSpan(pCur, &pVal, &nVal, &nAvail);
+    if( nAvail<nVal ){
+      return (u32)nVal;
+    }
+  }
   if( getCursorPayload(pCur, &pData, &nData)!=SQLITE_OK ){
     return 0;
   }
@@ -8458,6 +8503,15 @@ static int prollyBtCursorPayload(BtCursor *pCur, u32 offset, u32 amt, void *pBuf
       return copyZeroTailPayload(e, offset, amt, pBuf);
     }
   }
+  if( pCur->curIntKey && pCur->pCur.eState==PROLLY_CURSOR_VALID ){
+    const u8 *pVal;
+    int nVal;
+    int nAvail;
+    cursorCurrentTreeValueSpan(pCur, &pVal, &nVal, &nAvail);
+    if( nAvail<nVal ){
+      return cursorCurrentTreeValueCopy(pCur, offset, amt, pBuf);
+    }
+  }
   rc = getCursorPayload(pCur, &pData, &nData);
   if( rc!=SQLITE_OK ){
     return rc;
@@ -8491,6 +8545,15 @@ static const void *prollyBtCursorPayloadFetch(BtCursor *pCur, u32 *pAmt){
     if( e && e->nZeroTail>0 && e->nVal>0 ){
       if( pAmt ) *pAmt = (u32)e->nVal;
       return (const void*)e->pVal;
+    }
+  }
+  if( pCur->curIntKey && pCur->pCur.eState==PROLLY_CURSOR_VALID ){
+    int nLogical;
+    int nAvail;
+    cursorCurrentTreeValueSpan(pCur, &pData, &nLogical, &nAvail);
+    if( nAvail<nLogical ){
+      if( pAmt ) *pAmt = (u32)nAvail;
+      return (const void*)pData;
     }
   }
   if( getCursorPayload(pCur, &pData, &nData)!=SQLITE_OK ){
@@ -8722,6 +8785,7 @@ static int prollyBtCursorInsert(
       prollyCursorClose(&pCur->pCur);
       prollyCursorInit(&pCur->pCur, &pCur->pBt->store, &pCur->pBt->cache,
                        &pTE2->root, pTE2->flags);
+      prollyCursorAllowSparse(&pCur->pCur, 1);
     }
   }
   if( pCur->curIntKey ){
@@ -8788,6 +8852,7 @@ static int flushIfNeeded(BtCursor *pCur){
     prollyCursorClose(&pCur->pCur);
     prollyCursorInit(&pCur->pCur, &pCur->pBt->store, &pCur->pBt->cache,
                      &pTE->root, pTE->flags);
+    prollyCursorAllowSparse(&pCur->pCur, 1);
   }
   /* The flush emptied the map; a saved cursor restoring with a stale
   ** mmActive/mmIdx would consult it at a dead index. */
@@ -8844,6 +8909,7 @@ static int btreeDeleteImmediate(BtCursor *pCur){
       prollyCursorClose(&pCur->pCur);
       prollyCursorInit(&pCur->pCur, &pCur->pBt->store, &pCur->pBt->cache,
                        &pTE2->root, pTE2->flags);
+      prollyCursorAllowSparse(&pCur->pCur, 1);
     }
   }
 
@@ -9721,6 +9787,16 @@ static int prollyBtCursorPayloadChecked(BtCursor *pCur, u32 offset, u32 amt, voi
     ProllyMutMapEntry *e = currentMutMapEntry(pCur);
     if( e && e->nZeroTail>0 ){
       return copyZeroTailPayload(e, offset, amt, pBuf);
+    }
+  }
+
+  if( pCur->curIntKey && pCur->pCur.eState==PROLLY_CURSOR_VALID ){
+    const u8 *pVal;
+    int nVal;
+    int nAvail;
+    cursorCurrentTreeValueSpan(pCur, &pVal, &nVal, &nAvail);
+    if( nAvail<nVal ){
+      return cursorCurrentTreeValueCopy(pCur, offset, amt, pBuf);
     }
   }
 

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -626,9 +626,9 @@ static int prollyBtCursorPrevious(BtCursor *pCur, int flags);
 
 static SQLITE_INLINE void cacheCurrentTreePayloadIfIntKey(BtCursor *pCur){
   if( pCur->curIntKey ){
-    const u8 *pVal; int nVal;
-    cursorCurrentTreeValue(pCur, &pVal, &nVal);
-    if( nVal > 0 ){
+    const u8 *pVal; int nVal; int nAvail;
+    cursorCurrentTreeValueSpan(pCur, &pVal, &nVal, &nAvail);
+    if( nVal > 0 && nAvail==nVal ){
       pCur->pCachedPayload = (u8*)pVal;
       pCur->nCachedPayload = nVal;
       pCur->cachedPayloadOwned = 0;
@@ -710,6 +710,8 @@ static int flushDeferredEdits(Btree *pBtree, BtShared *pBt);
 static int ensureMutMap(BtCursor *pCur);
 static int saveCursorPosition(BtCursor *pCur);
 static int restoreCursorPosition(BtCursor *pCur, int *pDifferentRow);
+static int prollyBtCursorTableMoveto(BtCursor *pCur, i64 intKey, int bias,
+                                     int *pRes);
 static int pushSavepoint(Btree *pBtree, int bStatement);
 static void btreeDiscardAllSavepoints(Btree *pBtree);
 static int findTableIndexInArray(struct TableEntry *aTables, int nTables, Pgno iTable);
@@ -3329,7 +3331,7 @@ static int restoreCursorPosition(BtCursor *pCur, int *pDifferentRow){
   refreshCursorRoot(pCur);
 
   if( pCur->curIntKey ){
-    rc = prollyCursorSeekInt(&pCur->pCur, pCur->nKey, &res);
+    rc = prollyBtCursorTableMoveto(pCur, pCur->nKey, 0, &res);
   } else {
     if( pCur->pKey && pCur->nKey>0 ){
       rc = prollyCursorSeekBlob(&pCur->pCur,
@@ -6773,7 +6775,12 @@ static int prollyBtCursorCursorHasMoved(BtCursor *pCur){
 **     never move and restore themselves in accessPayloadChecked. */
 int sqlite3BtreeIncrblobCursorReseek(BtCursor *pCur){
   if( pCur->pCurOps!=&prollyCursorOps ) return 0;
-  if( pCur->eState==CURSOR_VALID ) return 0;
+  if( pCur->eState==CURSOR_VALID ){
+    if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
+      return 1;
+    }
+    return 0;
+  }
   if( pCur->eState==CURSOR_FAULT ) return -1;
   return 1;
 }
@@ -8402,8 +8409,17 @@ static int getCursorPayload(BtCursor *pCur, const u8 **ppData, int *pnData){
   }
 
   if( pCur->curIntKey ){
-    cursorCurrentTreeValue(pCur, ppData, pnData);
-    if( *pnData > 0 ){
+    int nAvail;
+    cursorCurrentTreeValueSpan(pCur, ppData, pnData, &nAvail);
+    if( nAvail<*pnData ){
+      int rc = cacheCursorPayloadZeroTail(pCur, *ppData, nAvail,
+                                          (i64)*pnData - nAvail);
+      if( rc!=SQLITE_OK ){
+        return cursorPayloadFault(pCur, rc, ppData, pnData);
+      }
+      *ppData = pCur->pCachedPayload;
+      *pnData = pCur->nCachedPayload;
+    }else if( *pnData > 0 ){
       pCur->pCachedPayload = (u8*)*ppData;
       pCur->nCachedPayload = *pnData;
       pCur->cachedPayloadOwned = 0;
@@ -9821,6 +9837,8 @@ static int prollyBtCursorPutData(BtCursor *pCur, u32 offset, u32 amt, void *pBuf
   const u8 *pVal;
   int nVal;
   u8 *pNew;
+  i64 savedIntKey = 0;
+  int hasSavedIntKey = 0;
   BtreePayload payload;
 
   if( pCur->eState!=CURSOR_VALID ){
@@ -9856,6 +9874,8 @@ static int prollyBtCursorPutData(BtCursor *pCur, u32 offset, u32 amt, void *pBuf
     }else{
       payload.nKey = prollyCursorIntKey(&pCur->pCur);
     }
+    savedIntKey = payload.nKey;
+    hasSavedIntKey = 1;
     payload.pData = pNew;
     payload.nData = nVal;
   } else {
@@ -9870,6 +9890,16 @@ static int prollyBtCursorPutData(BtCursor *pCur, u32 offset, u32 amt, void *pBuf
 
   rc = sqlite3BtreeInsert(pCur, &payload, 0, 0);
   sqlite3_free(pNew);
+  if( rc==SQLITE_OK && hasSavedIntKey ){
+    rc = flushMutMap(pCur);
+    if( rc==SQLITE_OK ){
+      pCur->nKey = savedIntKey;
+      pCur->pKey = 0;
+      pCur->cachedIntKey = savedIntKey;
+      pCur->curFlags |= BTCF_ValidNKey;
+      pCur->eState = CURSOR_REQUIRESEEK;
+    }
+  }
   return rc;
 }
 int sqlite3BtreePutData(BtCursor *pCur, u32 offset, u32 amt, void *pBuf){

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -627,6 +627,7 @@ static int prollyBtCursorPrevious(BtCursor *pCur, int flags);
 static SQLITE_INLINE void cacheCurrentTreePayloadIfIntKey(BtCursor *pCur){
   if( pCur->curIntKey ){
     const u8 *pVal; int nVal; int nAvail;
+    CLEAR_CACHED_PAYLOAD(pCur);
     cursorCurrentTreeValueSpan(pCur, &pVal, &nVal, &nAvail);
     if( nVal > 0 && nAvail==nVal ){
       pCur->pCachedPayload = (u8*)pVal;
@@ -688,6 +689,7 @@ static int skipDegenerateSchemaRows(BtCursor *pCur, int dir, int *pRes){
 
 static void cacheCurrentTreeStoredPayloadNonIntKey(BtCursor *pCur){
   const u8 *pVal; int nVal;
+  CLEAR_CACHED_PAYLOAD(pCur);
   cursorCurrentTreeValue(pCur, &pVal, &nVal);
   if( nVal > 0 ){
     pCur->pCachedPayload = (u8*)pVal;
@@ -3352,7 +3354,11 @@ static int restoreCursorPosition(BtCursor *pCur, int *pDifferentRow){
   if( rc==SQLITE_OK ){
     if( res==0 ){
       pCur->eState = CURSOR_VALID;
-      if( pDifferentRow ) *pDifferentRow = 0;
+      if( pDifferentRow ){
+        *pDifferentRow = pCur->mmActive
+                       && (pCur->mergeSrc==MERGE_SRC_MUT
+                           || pCur->mergeSrc==MERGE_SRC_BOTH);
+      }
     } else if( pCur->pCur.eState==PROLLY_CURSOR_VALID ){
       pCur->skipNext = res;
       pCur->eState = CURSOR_SKIPNEXT;
@@ -6776,7 +6782,12 @@ static int prollyBtCursorCursorHasMoved(BtCursor *pCur){
 int sqlite3BtreeIncrblobCursorReseek(BtCursor *pCur){
   if( pCur->pCurOps!=&prollyCursorOps ) return 0;
   if( pCur->eState==CURSOR_VALID ){
+    struct TableEntry *pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
     if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
+      return 1;
+    }
+    if( pTE && pTE->pPending
+     && !prollyMutMapIsEmpty((ProllyMutMap*)pTE->pPending) ){
       return 1;
     }
     return 0;
@@ -6954,7 +6965,9 @@ static int mergeStepForward(BtCursor *pCur){
   }
   if( pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH )
     pCur->mmIdx++;
-  return mergeScan(pCur, 1, 0);
+  rc = mergeScan(pCur, 1, 0);
+  CLEAR_CACHED_PAYLOAD(pCur);
+  return rc;
 }
 
 static int mergeStepBackward(BtCursor *pCur){
@@ -6968,7 +6981,9 @@ static int mergeStepBackward(BtCursor *pCur){
   }
   if( pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH )
     pCur->mmIdx--;
-  return mergeScan(pCur, -1, 0);
+  rc = mergeScan(pCur, -1, 0);
+  CLEAR_CACHED_PAYLOAD(pCur);
+  return rc;
 }
 
 static int seedMutMapIterFromCursor(
@@ -7306,6 +7321,11 @@ static int prollyBtCursorPrevious(BtCursor *pCur, int flags){
       if( rc==SQLITE_OK ){
         if( pCur->pCur.eState==PROLLY_CURSOR_VALID ){
           pCur->eState = CURSOR_VALID;
+          if( pCur->curIntKey ){
+            cacheCurrentTreePayloadIfIntKey(pCur);
+          }else{
+            cacheCurrentTreeStoredPayloadNonIntKey(pCur);
+          }
         } else {
           pCur->eState = CURSOR_INVALID;
           return SQLITE_DONE;
@@ -7369,6 +7389,9 @@ static int prollyBtCursorTableMoveto(
   CLEAR_CACHED_COMPARE_KEY(pCur);
 
   pTE = findTable(pCur->pBtree, pCur->pgnoRoot);
+  if( pTE && pTE->pPending && pCur->pMutMap!=(ProllyMutMap*)pTE->pPending ){
+    pCur->pMutMap = (ProllyMutMap*)pTE->pPending;
+  }
   canUseAppendSeekFloor = pCur->pBtree
     && pCur->pBtree->db
     && !pCur->pBtree->db->autoCommit
@@ -8459,11 +8482,9 @@ static u32 prollyBtCursorPayloadSize(BtCursor *pCur){
   if( pCur->curIntKey && pCur->mmActive
    && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
     ProllyMutMapEntry *e = currentMutMapEntry(pCur);
-    if( e && e->nZeroTail > 0 ){
-      /* Answer from the symbolic form; fetching would materialize the
-      ** zero tail. */
-      return (u32)((i64)e->nVal + e->nZeroTail);
-    }
+    /* Answer from the pending row before consulting the tree. The tree cursor
+    ** may still be valid for MERGE_SRC_BOTH, but its value is stale. */
+    return (u32)((i64)e->nVal + e->nZeroTail);
   }
   if( pCur->curIntKey && pCur->pCur.eState==PROLLY_CURSOR_VALID ){
     const u8 *pVal;
@@ -8518,6 +8539,13 @@ static int prollyBtCursorPayload(BtCursor *pCur, u32 offset, u32 amt, void *pBuf
     if( e && e->nZeroTail>0 ){
       return copyZeroTailPayload(e, offset, amt, pBuf);
     }
+    if( e ){
+      if( (i64)offset + (i64)amt > (i64)e->nVal ){
+        return SQLITE_CORRUPT_BKPT;
+      }
+      memcpy(pBuf, e->pVal + offset, amt);
+      return SQLITE_OK;
+    }
   }
   if( pCur->curIntKey && pCur->pCur.eState==PROLLY_CURSOR_VALID ){
     const u8 *pVal;
@@ -8559,6 +8587,10 @@ static const void *prollyBtCursorPayloadFetch(BtCursor *pCur, u32 *pAmt){
    && (pCur->mergeSrc==MERGE_SRC_MUT || pCur->mergeSrc==MERGE_SRC_BOTH) ){
     ProllyMutMapEntry *e = currentMutMapEntry(pCur);
     if( e && e->nZeroTail>0 && e->nVal>0 ){
+      if( pAmt ) *pAmt = (u32)e->nVal;
+      return (const void*)e->pVal;
+    }
+    if( e && e->nVal>0 ){
       if( pAmt ) *pAmt = (u32)e->nVal;
       return (const void*)e->pVal;
     }
@@ -9804,6 +9836,13 @@ static int prollyBtCursorPayloadChecked(BtCursor *pCur, u32 offset, u32 amt, voi
     if( e && e->nZeroTail>0 ){
       return copyZeroTailPayload(e, offset, amt, pBuf);
     }
+    if( e ){
+      if( (i64)offset + (i64)amt > (i64)e->nVal ){
+        return SQLITE_CORRUPT_BKPT;
+      }
+      memcpy(pBuf, e->pVal + offset, amt);
+      return SQLITE_OK;
+    }
   }
 
   if( pCur->curIntKey && pCur->pCur.eState==PROLLY_CURSOR_VALID ){
@@ -9891,8 +9930,15 @@ static int prollyBtCursorPutData(BtCursor *pCur, u32 offset, u32 amt, void *pBuf
   rc = sqlite3BtreeInsert(pCur, &payload, 0, 0);
   sqlite3_free(pNew);
   if( rc==SQLITE_OK && hasSavedIntKey ){
-    rc = flushMutMap(pCur);
-    if( rc==SQLITE_OK ){
+    ProllyMutMapEntry *pEntry = 0;
+    if( pCur->pMutMap ){
+      rc = prollyMutMapFindRc(pCur->pMutMap, 0, 0, savedIntKey, &pEntry);
+    }
+    if( rc==SQLITE_OK && pEntry && pEntry->op==PROLLY_EDIT_INSERT ){
+      setCursorToMutMapEntryPhys(
+          pCur, (int)(pEntry - pCur->pMutMap->aEntries));
+      pCur->deferredTreeSeek = 1;
+    }else if( rc==SQLITE_OK ){
       pCur->nKey = savedIntKey;
       pCur->pKey = 0;
       pCur->cachedIntKey = savedIntKey;

--- a/src/prolly_cache.c
+++ b/src/prolly_cache.c
@@ -50,6 +50,56 @@ static void cacheEntryFree(ProllyCacheEntry *pEntry){
   }
 }
 
+static ProllyCacheEntry *cacheEntryNewOwned(
+  const ProllyHash *hash,
+  u8 *pData,
+  int nData,
+  int nDataPhys,
+  int bTransient,
+  int *pRc
+){
+  ProllyCacheEntry *pEntry;
+  int rc;
+
+  if( pRc ) *pRc = SQLITE_OK;
+  pEntry = (ProllyCacheEntry *)sqlite3_malloc(sizeof(ProllyCacheEntry));
+  if( pEntry==0 ){
+    sqlite3_free(pData);
+    if( pRc ) *pRc = SQLITE_NOMEM;
+    return 0;
+  }
+  memset(pEntry, 0, sizeof(*pEntry));
+
+  {
+    u8 *pPadded = (u8*)sqlite3_realloc(
+        pData, nDataPhys + PROLLY_NODE_BUFFER_SLOP);
+    if( pPadded==0 ){
+      sqlite3_free(pData);
+      sqlite3_free(pEntry);
+      if( pRc ) *pRc = SQLITE_NOMEM;
+      return 0;
+    }
+    pData = pPadded;
+    memset(pData + nDataPhys, 0, PROLLY_NODE_BUFFER_SLOP);
+  }
+
+  memcpy(pEntry->hash.data, hash->data, PROLLY_HASH_SIZE);
+  pEntry->pData = pData;
+  pEntry->nData = nData;
+  pEntry->nDataPhys = nDataPhys;
+  pEntry->nRef = 1;
+  pEntry->bTransient = bTransient ? 1 : 0;
+
+  rc = prollyNodeParseSparse(&pEntry->node, pData, nData, nDataPhys);
+  if( rc!=SQLITE_OK ){
+    if( pRc ) *pRc = rc;
+    cacheEntryFree(pEntry);
+    return 0;
+  }
+
+  return pEntry;
+}
+
 int prollyCacheInit(ProllyCache *cache, int nCapacity){
   int nBucket;
 
@@ -170,7 +220,9 @@ ProllyCacheEntry *prollyCachePutOwned(
   memcpy(pEntry->hash.data, hash->data, PROLLY_HASH_SIZE);
   pEntry->pData = pData;
   pEntry->nData = nData;
+  pEntry->nDataPhys = nData;
   pEntry->nRef = 1;
+  pEntry->bTransient = 0;
 
   rc = prollyNodeParse(&pEntry->node, pData, nData);
   if( rc!=SQLITE_OK ){
@@ -190,10 +242,23 @@ ProllyCacheEntry *prollyCachePutOwned(
   return pEntry;
 }
 
+ProllyCacheEntry *prollyCachePutTransientOwned(
+  const ProllyHash *hash,
+  u8 *pData,
+  int nData,
+  int nDataPhys,
+  int *pRc
+){
+  return cacheEntryNewOwned(hash, pData, nData, nDataPhys, 1, pRc);
+}
+
 void prollyCacheRelease(ProllyCache *cache, ProllyCacheEntry *entry){
   (void)cache;
   assert( entry->nRef>0 );
   entry->nRef--;
+  if( entry->nRef==0 && entry->bTransient ){
+    cacheEntryFree(entry);
+  }
 }
 
 void prollyCacheFree(ProllyCache *cache){

--- a/src/prolly_cache.h
+++ b/src/prolly_cache.h
@@ -13,8 +13,10 @@ struct ProllyCacheEntry {
   ProllyHash hash;
   u8 *pData;
   int nData;
+  int nDataPhys;
   ProllyNode node;
   int nRef;
+  u8 bTransient;
   ProllyCacheEntry *pLruNext;
   ProllyCacheEntry *pLruPrev;
   ProllyCacheEntry *pHashNext;
@@ -36,6 +38,11 @@ ProllyCacheEntry *prollyCacheGet(ProllyCache *cache, const ProllyHash *hash);
 ProllyCacheEntry *prollyCachePutOwned(ProllyCache *cache,
                                       const ProllyHash *hash,
                                       u8 *pData, int nData,
+                                      int *pRc);
+
+ProllyCacheEntry *prollyCachePutTransientOwned(
+                                      const ProllyHash *hash,
+                                      u8 *pData, int nData, int nDataPhys,
                                       int *pRc);
 
 void prollyCacheRelease(ProllyCache *cache, ProllyCacheEntry *entry);

--- a/src/prolly_check.c
+++ b/src/prolly_check.c
@@ -21,6 +21,7 @@ static int checkSubtree(
 ){
   u8 *pData = 0;
   int nData = 0;
+  int nDataPhys = 0;
   ProllyNode node;
   int rc;
   int i;
@@ -29,10 +30,10 @@ static int checkSubtree(
   i64 iPrevKey = 0;
   u8 isInt = (flags & PROLLY_NODE_INTKEY) ? 1 : 0;
 
-  rc = chunkStoreGet(pStore, pHash, &pData, &nData);
+  rc = chunkStoreGetSparse(pStore, pHash, &pData, &nData, &nDataPhys);
   if( rc!=SQLITE_OK ){
     *pzErr = sqlite3_mprintf(
-      "chunkStoreGet failed rc=%d hash=%02x%02x%02x%02x%02x%02x%02x%02x",
+      "chunkStoreGetSparse failed rc=%d hash=%02x%02x%02x%02x%02x%02x%02x%02x",
       rc, pHash->data[0], pHash->data[1], pHash->data[2], pHash->data[3],
       pHash->data[4], pHash->data[5], pHash->data[6], pHash->data[7]);
     return rc;
@@ -41,7 +42,12 @@ static int checkSubtree(
   /* Re-hash cached chunks too; chunkStoreGet verifies only disk reads. */
   {
     ProllyHash computed;
-    prollyHashCompute(pData, nData, &computed);
+    if( nDataPhys<nData ){
+      prollyHashComputeZeroTail(pData, nDataPhys,
+                                (sqlite3_int64)nData - nDataPhys, &computed);
+    }else{
+      prollyHashCompute(pData, nData, &computed);
+    }
     if( prollyHashCompare(&computed, pHash) != 0 ){
       *pzErr = sqlite3_mprintf(
         "chunk content does not hash to its store key: "
@@ -57,12 +63,12 @@ static int checkSubtree(
     }
   }
 
-  rc = prollyNodeParse(&node, pData, nData);
+  rc = prollyNodeParseSparse(&node, pData, nData, nDataPhys);
   if( rc!=SQLITE_OK ){
     *pzErr = sqlite3_mprintf(
-      "prollyNodeParse failed rc=%d nData=%d level=%d count=%u flags=0x%02x"
+      "prollyNodeParseSparse failed rc=%d nData=%d nDataPhys=%d level=%d count=%u flags=0x%02x"
       " hash=%02x%02x%02x%02x%02x%02x%02x%02x",
-      rc, nData,
+      rc, nData, nDataPhys,
       nData>=5 ? (int)pData[4] : -1,
       nData>=7 ? (unsigned)(pData[5] | (pData[6]<<8)) : 0u,
       nData>=8 ? (unsigned)pData[7] : 0u,

--- a/src/prolly_cursor.c
+++ b/src/prolly_cursor.c
@@ -24,6 +24,42 @@ int prollyLoadNode(ChunkStore *pStore, ProllyCache *pCache,
   return SQLITE_OK;
 }
 
+static int prollyLoadNodeMaybeSparse(
+  ChunkStore *pStore,
+  ProllyCache *pCache,
+  const ProllyHash *pHash,
+  int bAllowSparse,
+  ProllyCacheEntry **ppEntry
+){
+  ProllyCacheEntry *pEntry;
+  u8 *pData = 0;
+  int nData = 0;
+  int nDataPhys = 0;
+  int rc;
+
+  if( !bAllowSparse ){
+    return prollyLoadNode(pStore, pCache, pHash, ppEntry);
+  }
+
+  *ppEntry = 0;
+  pEntry = prollyCacheGet(pCache, pHash);
+  if( pEntry ){
+    *ppEntry = pEntry;
+    return SQLITE_OK;
+  }
+
+  rc = chunkStoreGetSparse(pStore, pHash, &pData, &nData, &nDataPhys);
+  if( rc!=SQLITE_OK ) return rc;
+  if( nDataPhys==nData ){
+    pEntry = prollyCachePutOwned(pCache, pHash, pData, nData, &rc);
+  }else{
+    pEntry = prollyCachePutTransientOwned(pHash, pData, nData, nDataPhys, &rc);
+  }
+  if( !pEntry ) return rc;
+  *ppEntry = pEntry;
+  return SQLITE_OK;
+}
+
 int prollySubtreeCount(ChunkStore *pStore, ProllyCache *pCache,
                        const ProllyHash *pHash, u64 *pCount){
   ProllyCacheEntry *pEntry = 0;
@@ -61,7 +97,8 @@ int prollySubtreeCount(ChunkStore *pStore, ProllyCache *pCache,
 
 static int loadNode(ProllyCursor *cur, const ProllyHash *hash,
                     ProllyCacheEntry **ppEntry){
-  return prollyLoadNode(cur->pStore, cur->pCache, hash, ppEntry);
+  return prollyLoadNodeMaybeSparse(
+      cur->pStore, cur->pCache, hash, cur->bAllowSparse, ppEntry);
 }
 
 static int initCursorAtRoot(ProllyCursor *cur, ProllyCacheEntry **ppRoot){
@@ -180,6 +217,10 @@ void prollyCursorInit(ProllyCursor *cur, ChunkStore *pStore,
   memcpy(&cur->root, pRoot, sizeof(ProllyHash));
   cur->flags = flags;
   cur->eState = PROLLY_CURSOR_INVALID;
+}
+
+void prollyCursorAllowSparse(ProllyCursor *cur, int bAllowSparse){
+  cur->bAllowSparse = bAllowSparse ? 1 : 0;
 }
 
 int prollyCursorFirst(ProllyCursor *cur, int *pRes){

--- a/src/prolly_cursor.h
+++ b/src/prolly_cursor.h
@@ -23,6 +23,7 @@ struct ProllyCursor {
   ProllyCache *pCache;
   ProllyHash root;
   u8 flags;
+  u8 bAllowSparse;
 
   int iLevel;
   ProllyCursorLevel aLevel[PROLLY_CURSOR_MAX_DEPTH];
@@ -36,6 +37,7 @@ struct ProllyCursor {
 
 void prollyCursorInit(ProllyCursor *cur, ChunkStore *pStore,
                       ProllyCache *pCache, const ProllyHash *pRoot, u8 flags);
+void prollyCursorAllowSparse(ProllyCursor *cur, int bAllowSparse);
 
 int prollyCursorFirst(ProllyCursor *cur, int *pRes);
 

--- a/src/prolly_node.c
+++ b/src/prolly_node.c
@@ -11,7 +11,8 @@
 #define PROLLY_COUNT_OFF      5
 #define PROLLY_FLAGS_OFF      7
 
-int prollyNodeParse(ProllyNode *pNode, const u8 *pData, int nData){
+int prollyNodeParseSparse(ProllyNode *pNode, const u8 *pData, int nData,
+                          int nDataPhys){
   u32 magic;
   u16 count;
   int nOffsets;
@@ -26,7 +27,7 @@ int prollyNodeParse(ProllyNode *pNode, const u8 *pData, int nData){
 
   memset(pNode, 0, sizeof(*pNode));
 
-  if( nData<PROLLY_HDR_SIZE ){
+  if( nData<PROLLY_HDR_SIZE || nDataPhys<PROLLY_HDR_SIZE || nDataPhys>nData ){
     return SQLITE_CORRUPT;
   }
 
@@ -37,6 +38,7 @@ int prollyNodeParse(ProllyNode *pNode, const u8 *pData, int nData){
 
   pNode->pData = pData;
   pNode->nData = nData;
+  pNode->nDataPhys = nDataPhys;
   pNode->level = pData[PROLLY_LEVEL_OFF];
   count = PROLLY_GET_U16(pData + PROLLY_COUNT_OFF);
   if( count > PROLLY_NODE_MAX_ITEMS ){
@@ -67,7 +69,7 @@ int prollyNodeParse(ProllyNode *pNode, const u8 *pData, int nData){
 
   nOffsets = (int)(count + 1) * 4 * 2;
   minSize = PROLLY_HDR_SIZE + nOffsets;
-  if( nData<minSize ){
+  if( nDataPhys<minSize ){
     return SQLITE_CORRUPT;
   }
 
@@ -89,6 +91,16 @@ int prollyNodeParse(ProllyNode *pNode, const u8 *pData, int nData){
   }
   if( totalKeyBytes > (u32)nData || totalValBytes > (u32)nData
    || expectedSize != nData ){
+    return SQLITE_CORRUPT;
+  }
+  if( nDataPhys<nData ){
+    if( pNode->level!=0 || hasCounts ){
+      return SQLITE_CORRUPT;
+    }
+    if( nDataPhys < minSize + (int)totalKeyBytes ){
+      return SQLITE_CORRUPT;
+    }
+  }else if( nDataPhys!=nData ){
     return SQLITE_CORRUPT;
   }
 
@@ -120,6 +132,10 @@ int prollyNodeParse(ProllyNode *pNode, const u8 *pData, int nData){
   return SQLITE_OK;
 }
 
+int prollyNodeParse(ProllyNode *pNode, const u8 *pData, int nData){
+  return prollyNodeParseSparse(pNode, pData, nData, nData);
+}
+
 void prollyNodeKey(const ProllyNode *pNode, int i, const u8 **ppKey, int *pnKey){
   u32 off0;
   u32 off1;
@@ -131,13 +147,29 @@ void prollyNodeKey(const ProllyNode *pNode, int i, const u8 **ppKey, int *pnKey)
 }
 
 void prollyNodeValue(const ProllyNode *pNode, int i, const u8 **ppVal, int *pnVal){
+  int nAvail;
+  prollyNodeValueSpan(pNode, i, ppVal, pnVal, &nAvail);
+}
+
+void prollyNodeValueSpan(const ProllyNode *pNode, int i, const u8 **ppVal,
+                         int *pnVal, int *pnAvail){
   u32 off0;
   u32 off1;
+  int nValPhys;
   assert( i >= 0 && i < (int)pNode->nItems );
   off0 = PROLLY_GET_U32((const u8*)&pNode->aValOff[i]);
   off1 = PROLLY_GET_U32((const u8*)&pNode->aValOff[i+1]);
-  *ppVal = pNode->pValData + off0;
   *pnVal = (int)(off1 - off0);
+  nValPhys = pNode->nDataPhys - (int)(pNode->pValData - pNode->pData);
+  if( nValPhys<0 ) nValPhys = 0;
+  if( (int)off0 < nValPhys ){
+    *ppVal = pNode->pValData + off0;
+    *pnAvail = nValPhys - (int)off0;
+    if( *pnAvail > *pnVal ) *pnAvail = *pnVal;
+  }else{
+    *ppVal = pNode->pValData + nValPhys;
+    *pnAvail = 0;
+  }
 }
 
 void prollyEncodeIntKey(i64 v, u8 buf[8]){

--- a/src/prolly_node.h
+++ b/src/prolly_node.h
@@ -31,6 +31,7 @@ typedef struct ProllyNode ProllyNode;
 struct ProllyNode {
   const u8 *pData;
   int nData;
+  int nDataPhys;
   u8 level;
   u16 nItems;
   u8 flags;
@@ -42,10 +43,14 @@ struct ProllyNode {
 };
 
 int prollyNodeParse(ProllyNode *pNode, const u8 *pData, int nData);
+int prollyNodeParseSparse(ProllyNode *pNode, const u8 *pData, int nData,
+                          int nDataPhys);
 
 void prollyNodeKey(const ProllyNode *pNode, int i, const u8 **ppKey, int *pnKey);
 
 void prollyNodeValue(const ProllyNode *pNode, int i, const u8 **ppVal, int *pnVal);
+void prollyNodeValueSpan(const ProllyNode *pNode, int i, const u8 **ppVal,
+                         int *pnVal, int *pnAvail);
 
 i64 prollyNodeIntKey(const ProllyNode *pNode, int i);
 

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -7697,6 +7697,24 @@ static void run_incrblob_chunked_and_multihandle(void){
         "SELECT CAST(substr(v,8,6) AS TEXT) || '/' || length(v) FROM t WHERE k=4"),
         "HELLO!/20")==0);
 
+  check("incrblob_large_committed_setup", execSql(db,
+      "INSERT INTO t VALUES(5, zeroblob(10 * 1024 * 1024));"
+      )==SQLITE_OK);
+  sqlite3_memory_highwater(1);
+  check("incrblob_large_committed_open",
+      sqlite3_blob_open(db, "main", "t", "v", 5, 0, &h1)==SQLITE_OK);
+  check("incrblob_large_committed_open_memory",
+      sqlite3_memory_highwater(0) < memoryCeiling);
+  memset(buf, 1, 4);
+  check("incrblob_large_committed_tail_read",
+      h1 && sqlite3_blob_read(h1, buf, 4, bigBlobSize - 4)==SQLITE_OK);
+  check("incrblob_large_committed_tail_zero",
+      buf[0]==0 && buf[1]==0 && buf[2]==0 && buf[3]==0);
+  check("incrblob_large_committed_read_memory",
+      sqlite3_memory_highwater(0) < memoryCeiling);
+  if( h1 ) sqlite3_blob_close(h1);
+  h1 = 0;
+
   check("incrblob_large_pending_setup", execSql(db,
       "BEGIN; INSERT INTO t VALUES(6, zeroblob(10 * 1024 * 1024));"
       )==SQLITE_OK);

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -4317,16 +4317,11 @@ fts4onepass fts4onepass-3.2.5.c
 # another connection holds an open write txn succeeds where stock
 # errors (5.5), and PRAGMA read_uncommitted cannot expose another
 # connection's uncommitted row (5.6: "no such rowid: 4", which leaves
-# $blob stale so 5.8's close cascades). 7.2/7.4 are sparse-zeroblob
-# performance gaps: pending rows keep zero tails symbolic, but once the
-# leaf chunk is committed, sqlite3_blob_open/read loads the dense chunk
-# through the normal node cache.
+# $blob stale so 5.8's close cascades).
 incrblob2 incrblob2-5.3  # db-level lock message, not table-level
 incrblob2 incrblob2-5.5  # readonly blob open succeeds; no shared-cache table lock
 incrblob2 incrblob2-5.6  # no dirty read of other connection's uncommitted row
 incrblob2 incrblob2-5.8  # cascade from 5.6: stale $blob channel
-incrblob2 incrblob2-7.2  # committed 10MB zeroblob chunk materialized on open, highwater >5MB
-incrblob2 incrblob2-7.4  # committed 10MB zeroblob chunk materialized on read, highwater >5MB
 
 # ── index3 ──
 # PRIMARY KEY('a') becomes the clustered prolly storage key, so no

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1672,7 +1672,6 @@ temptable2 temptable2-8.6  # sqlite3_backup_init: page-image backup unsupported 
 # Value semantics are correct (indexed/unindexed lookups, UNIQUE, BLOB
 # round-trip all match stock).
 zeroblob zeroblob-1.1.1  # sqlite3_max_blobsize allocation metric (zeroblob materialized)
-zeroblob zeroblob-1.1.2  # memory-highwater bound assumes lazy zeroblob
 
 # echo-vtab cluster — the echo test module (src/test8.c) reads its backing
 # table via "SELECT rowid, * FROM <real-table>". Any echo vtab over a table

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -4317,20 +4317,16 @@ fts4onepass fts4onepass-3.2.5.c
 # another connection holds an open write txn succeeds where stock
 # errors (5.5), and PRAGMA read_uncommitted cannot expose another
 # connection's uncommitted row (5.6: "no such rowid: 4", which leaves
-# $blob stale so 5.8's close cascades). 7.x: the insert path keeps a
-# zeroblob's zero tail symbolic (~673KB peak on production builds), but
-# the DOLTLITE_PROLLY_CHECK build CI gates with re-reads the committed
-# chunk densely to verify it (7.1), and opening an incrblob handle on a
-# committed 10MB row materializes the chunk on read (7.2/7.4), so
-# sqlite3_memory_highwater()<5MB is false until the verify pass and
-# payload reads stream in windows.
+# $blob stale so 5.8's close cascades). 7.2/7.4 are sparse-zeroblob
+# performance gaps: pending rows keep zero tails symbolic, but once the
+# leaf chunk is committed, sqlite3_blob_open/read loads the dense chunk
+# through the normal node cache.
 incrblob2 incrblob2-5.3  # db-level lock message, not table-level
 incrblob2 incrblob2-5.5  # readonly blob open succeeds; no shared-cache table lock
 incrblob2 incrblob2-5.6  # no dirty read of other connection's uncommitted row
 incrblob2 incrblob2-5.8  # cascade from 5.6: stale $blob channel
-incrblob2 incrblob2-7.1  # PROLLY_CHECK verify re-read materializes the chunk, highwater >5MB
-incrblob2 incrblob2-7.2  # 10MB zeroblob chunk materialized on read, highwater >5MB
-incrblob2 incrblob2-7.4  # 10MB zeroblob chunk materialized on read, highwater >5MB
+incrblob2 incrblob2-7.2  # committed 10MB zeroblob chunk materialized on open, highwater >5MB
+incrblob2 incrblob2-7.4  # committed 10MB zeroblob chunk materialized on read, highwater >5MB
 
 # ── index3 ──
 # PRIMARY KEY('a') becomes the clustered prolly storage key, so no


### PR DESCRIPTION
## Summary
- preserve sparse zero-tail metadata when pending chunks move into this connection's recent chunk table
- let btree cursors load recent sparse leaf chunks as transient prefix-only nodes
- make payload size/fetch/read handle the physical prefix plus symbolic zero tail for committed large `zeroblob` rows
- remove fixed `incrblob2-7.2` and `incrblob2-7.4` from known testfixture divergences

## Verification
- `LIBRARY_PATH=/opt/homebrew/lib CPATH=/opt/homebrew/include make testfixture`
- `LIBRARY_PATH=/opt/homebrew/lib ./testfixture test/incrblob2.test --testdir=testdir-incrblob2-sparse2` -> only `5.3`, `5.5`, `5.6`, `5.8` fail; `7.2`/`7.4` pass; max memory 459216 bytes
- `(cd testdir-incrblob2-runner2 && LIBRARY_PATH=/opt/homebrew/lib bash ../test/run_testfixture.sh local 60 incrblob2)` -> `OK: incrblob2 (82 tests, 4 known divergences)`
- `LIBRARY_PATH=/opt/homebrew/lib bash test/run_doltlite_regression_case.sh incrblob_chunked_and_multihandle` -> `39 passed, 0 failed`
- `LIBRARY_PATH=/opt/homebrew/lib bash test/run_doltlite_regression_case.sh all` -> `309828 passed, 0 failed`

Refs #1533