### PR TITLE
Fix all-NULL rows from INSERT INTO temp SELECT * FROM main table (#1539)

### DIFF
--- a/src/insert.c
+++ b/src/insert.c
@@ -3312,6 +3312,24 @@ static int xferOptimization(
   sqlite3_xferopt_count++;
 #endif
   iDbSrc = sqlite3SchemaToIndex(db, pSrc->pSchema);
+#if defined(DOLTLITE_PROLLY) && !defined(SQLITE_TEST)
+  /* The xfer optimization copies raw btree cells (OP_RowCell + a preformatted
+  ** OP_Insert), which is only valid when the source and destination tables
+  ** share a storage backend. In doltlite the temp database is not a prolly
+  ** store, so a raw cell copy between a prolly table and a temp table inserts
+  ** empty (all-NULL) rows. Fall back to the row-by-row path when the two sides
+  ** use different backends. */
+  {
+    extern int pagerShimIsShim(const Pager*);
+    Btree *pSrcBt = db->aDb[iDbSrc].pBt;
+    Btree *pDestBt = db->aDb[iDbDest].pBt;
+    if( pSrcBt && pDestBt
+     && pagerShimIsShim(sqlite3BtreePager(pSrcBt))
+          != pagerShimIsShim(sqlite3BtreePager(pDestBt)) ){
+      return 0;
+    }
+  }
+#endif
   v = sqlite3GetVdbe(pParse);
   sqlite3CodeVerifySchema(pParse, iDbSrc);
   iSrc = pParse->nTab++;

--- a/src/insert.c
+++ b/src/insert.c
@@ -3312,7 +3312,7 @@ static int xferOptimization(
   sqlite3_xferopt_count++;
 #endif
   iDbSrc = sqlite3SchemaToIndex(db, pSrc->pSchema);
-#if defined(DOLTLITE_PROLLY) && !defined(SQLITE_TEST)
+#if defined(DOLTLITE_PROLLY)
   /* The xfer optimization copies raw btree cells (OP_RowCell + a preformatted
   ** OP_Insert), which is only valid when the source and destination tables
   ** share a storage backend. In doltlite the temp database is not a prolly

--- a/test/correctness_test.sh
+++ b/test/correctness_test.sh
@@ -281,6 +281,18 @@ for N in 100 2000; do
 done
 
 echo ""
+echo "--- 16. Temp INSERT...SELECT * from main table (xfer-opt cross-backend) ---"
+# Regression: INSERT INTO <temp> SELECT * FROM <main table> must not use the
+# raw btree-cell xfer copy across the temp/prolly backend boundary, which
+# inserted extra all-NULL rows. The row-by-row path must run instead.
+xfer=$(query_value :memory: "CREATE TABLE m(a,b);
+  INSERT INTO m VALUES(1,2),(3,4);
+  CREATE TEMP TABLE z(a,b);
+  INSERT INTO z SELECT * FROM m;
+  SELECT count(*)||':'||group_concat(a||'|'||b) FROM (SELECT a,b FROM z ORDER BY a);")
+check "temp INSERT SELECT * from main" "2:1|2,3|4" "$xfer"
+
+echo ""
 echo "======================================="
 echo "Results: $pass passed, $fail failed"
 echo "======================================="

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1110,11 +1110,9 @@ shared9 shared9-3.5  # shared-cache locking-model divergence
 shared9 shared9-3.6  # shared-cache locking-model divergence
 
 # interrupt2 — checkpoint and cursor-step interrupts are honored after #1228.
-# The remaining failures are separate WAL/temp-db behavior gaps exposed by the
-# same fixture: temp INSERT...SELECT materializes extra NULL rows, close-time
-# WAL artifact handling differs, and DoltLite does not maintain SQLite WAL frame
-# counts for autocheckpoint growth assertions.
-interrupt2 interrupt2-2.0     # temp INSERT...SELECT into z1 has extra NULL rows
+# The remaining failures are separate WAL behavior gaps exposed by the same
+# fixture: close-time WAL artifact handling differs, and DoltLite does not
+# maintain SQLite WAL frame counts for autocheckpoint growth assertions.
 interrupt2 interrupt2-3.1.2   # close-time WAL file artifact differs
 interrupt2 interrupt2-4.1     # no SQLite WAL frame growth/autocheckpoint metric
 


### PR DESCRIPTION
Closes #1539.

## Bug

`INSERT INTO <temp table> SELECT * FROM <main-schema table>` inserted the wrong number of rows, **all NULL** — silent data corruption. Found while auditing the known-divergence list, where it was mis-filed as a cosmetic "temp behavior gap" (`interrupt2-2.0`).

## Root cause

Unqualified `SELECT * FROM <single table>` with no WHERE triggers SQLite's **xfer optimization**, which copies raw btree cells (`OP_RowCell` + a preformatted `OP_Insert`). That raw copy is only valid when source and destination share a storage backend. DoltLite's **temp database is not a prolly store**, so a cell copy between a prolly (main) table and a temp table produced empty, all-NULL rows.

Verified via `EXPLAIN`: the broken and working cases emit identical opcodes, so it's an execution mismatch at the temp↔prolly boundary — confirmed by `WHERE 1=1` / qualified `m.*` / explicit columns (all of which disable xfer-opt) working correctly.

## Fix

Bail out of `xferOptimization` when source and destination databases use different backends (`pagerShimIsShim(src) != pagerShimIsShim(dest)`), falling back to the row-by-row path (already correct). Same-backend copies keep the fast path.

| case | before | after |
|---|---|---|
| temp ← main `SELECT *` | 3 all-NULL rows | **2 rows: 1\|2, 3\|4** ✓ |
| main ← main | ✓ (xfer) | ✓ (xfer) |
| temp ← temp | ✓ | ✓ |
| attached aux ← main | ✓ | ✓ |

## Validation
- New `correctness_test.sh` regression case (`temp INSERT SELECT * from main`): PASS.
- C regression suite: **309828 passed, 0 failed**.
- Removes the now-fixed `interrupt2-2.0` divergence entry (the gate re-verifies fixed entries).

(The `no-dead-code` gate flags two pre-existing unused statics in `doltlite_conflicts.c` locally — unrelated to this change, which is only in `insert.c`; master CI is green there.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)