### PR TITLE
Fix dead-code gate blindness under GCC; remove dead conflict functions

### DIFF
--- a/src/doltlite_conflicts.c
+++ b/src/doltlite_conflicts.c
@@ -30,12 +30,6 @@ static void freeConflictRow(DoltliteConflictRow *pRow){
   memset(pRow, 0, sizeof(*pRow));
 }
 
-static void removeConflictTable(ConflictTableInfo *aTables, int *pnTables, int iTable){
-  if( !aTables || !pnTables || iTable<0 || iTable>=*pnTables ) return;
-  freeConflictTable(&aTables[iTable]);
-  doltliteArrayRemoveAt(aTables, pnTables, iTable, (int)sizeof(ConflictTableInfo));
-}
-
 #define DOLTLITE_CONFLICTS_MAGIC0 'D'
 #define DOLTLITE_CONFLICTS_MAGIC1 'L'
 #define DOLTLITE_CONFLICTS_MAGIC2 'C'
@@ -291,41 +285,6 @@ static void freeConflictTables(ConflictTableInfo *aTables, int nTables){
     freeConflictTable(&aTables[i]);
   }
   sqlite3_free(aTables);
-}
-
-static int storeUpdatedConflicts(
-  sqlite3 *db,
-  ChunkStore *cs,
-  ConflictTableInfo *aTables, int nTables
-){
-  int totalConflicts = 0;
-  int i;
-  DoltliteVcTxnMode mode;
-  for(i=0; i<nTables; i++) totalConflicts += aTables[i].nConflicts;
-
-  {
-    int rc;
-    extern void doltliteSetSessionConflictsCatalog(sqlite3*, const ProllyHash*);
-    extern void doltliteSetSessionMergeState(sqlite3*, u8, const ProllyHash*, const ProllyHash*);
-    rc = doltliteEnsureWriteTxnAndSavepoints(db);
-    if( rc!=SQLITE_OK ) return rc;
-    if( totalConflicts==0 ){
-      doltliteSetSessionConflictsCatalog(db, &(ProllyHash){{0}});
-    }else{
-      ProllyHash newHash;
-      rc = doltliteSerializeConflicts(cs, aTables, nTables, &newHash);
-      if( rc!=SQLITE_OK ) return rc;
-      doltliteSetSessionConflictsCatalog(db, &newHash);
-      doltliteSetSessionMergeState(db, 1, 0, &newHash);
-    }
-    mode = doltliteVcTxnMode(db);
-    if( mode==DOLTLITE_VC_TXN_AUTOCOMMIT_LIKE ){
-      rc = doltlitePersistWorkingSet(db);
-      if( rc!=SQLITE_OK ) return rc;
-      return doltliteVcSealActiveSavepoints(db);
-    }
-    return doltliteSaveWorkingSet(db);
-  }
 }
 
 static int storeConflictBytes(

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -161,22 +161,6 @@ static SQLITE_INLINE u64 doltliteFnv1aSep(u64 h){
   return h * DOLTLITE_FNV1A_PRIME;
 }
 
-/* Remove element iElem from a packed array of *pn elements of elemSize bytes:
-** shift the tail down, decrement *pn, and zero the freed slot. The caller must
-** release any memory the element owns first. */
-static SQLITE_INLINE void doltliteArrayRemoveAt(void *aBase, int *pn,
-                                                int iElem, int elemSize){
-  unsigned char *a = (unsigned char*)aBase;
-  int n = *pn;
-  if( !a || iElem<0 || iElem>=n ) return;
-  if( iElem < n-1 ){
-    memmove(a + (size_t)iElem*elemSize, a + (size_t)(iElem+1)*elemSize,
-            (size_t)(n-iElem-1)*elemSize);
-  }
-  *pn = n-1;
-  memset(a + (size_t)(n-1)*elemSize, 0, elemSize);
-}
-
 /* Catalog entry. This layout is shared with prolly_btree.c (which owns the
 ** catalog load/serialize routines); both definitions are guarded so a single
 ** translation unit (the amalgamation) emits it once. The version-control code

--- a/test/dead_code_check.sh
+++ b/test/dead_code_check.sh
@@ -41,9 +41,13 @@ fail=0
 
 echo "== Part A: unused static functions / locals =="
 for f in "${SRCS[@]}"; do
+  # A real compile (not -fsyntax-only): GCC only runs its unused-function
+  # pass during code generation, so -fsyntax-only silently suppresses the
+  # warning under GCC (the CI compiler) while Clang still emits it. Compiling
+  # to /dev/null keeps the check compiler-portable.
   if ! "$CC" "${CFLAGS[@]}" \
         -Werror=unused-function -Werror=unused-variable \
-        -Werror=unused-but-set-variable -fsyntax-only -c "$f" 2>/tmp/dc_err.$$; then
+        -Werror=unused-but-set-variable -c -o /dev/null "$f" 2>/tmp/dc_err.$$; then
     grep -iE 'error:' /tmp/dc_err.$$ | sed "s|^|  |"
     fail=1
   fi


### PR DESCRIPTION
## Problem

The `no-dead-code` CI check was **green on master while genuinely dead code sat in the tree**. `src/doltlite_conflicts.c` has two `static` functions with zero callers anywhere in the tree — `removeConflictTable` and `storeUpdatedConflicts` — yet CI never flagged them.

## Root cause

`test/dead_code_check.sh` Part A compiled each source with `-fsyntax-only`. **GCC only runs its `-Wunused-function` pass during code generation**, which `-fsyntax-only` skips — so under GCC the warning is silently suppressed. The CI `no-dead-code` job (in `sanitizers.yml`) runs with `cc=gcc` (build-essential, no `CC=clang` override), so Part A was blind. Clang detects unused static functions from semantic analysis, so the gate only ever worked for people running it locally with clang.

A green-but-blind gate is worse than no gate.

## Fix

1. **Gate**: compile to `/dev/null` (real codegen) instead of `-fsyntax-only`, so the unused-function pass runs under any compiler. Landed as a separate first commit so CI demonstrates the gate now catches the two functions.
2. **Dead code**: remove `removeConflictTable` and `storeUpdatedConflicts` (zero callers tree-wide).

## Verification
- Before fix, the gate passed on CI (gcc) with the dead functions present.
- After the gate fix alone, CI `no-dead-code` goes red flagging both functions.
- After removal, `no-dead-code` is green; full `make doltlite` still builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)