### PR TITLE
Guard reload with uncommitted recent chunks

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -95,12 +95,20 @@ static int csCrashWriteInjectionActive(void){
 #endif
 }
 
+#if defined(SQLITE_TEST) || defined(DOLTLITE_MECH_REPRO)
+/* Test hook: force one mid-commit reload after pending chunks drain. */
+static int csReloadInjectionActive(void){
+  const char *zEnv = getenv("DOLTLITE_RELOAD_INJECT");
+  return zEnv && atoi(zEnv)>0;
+}
+#endif
+
 #define CS_RECENT_FAST_PATH_MAX 16384
 #define CS_WRITEBUF_RETAIN_MAX (64*1024)
 #define CS_PENDING_DRAIN_LIMIT (64*1024*1024)
 
 static i64 csPendingDrainLimit(void){
-#ifdef SQLITE_TEST
+#if defined(SQLITE_TEST) || defined(DOLTLITE_MECH_REPRO)
   const char *zEnv = getenv("DOLTLITE_CHUNK_PENDING_DRAIN_LIMIT");
   if( zEnv && zEnv[0] ){
     int n = atoi(zEnv);
@@ -262,12 +270,18 @@ int chunkStoreEnsureRefsFresh(ChunkStore *cs){
 
 static int csReloadFromDiskPreservingLocalRefs(ChunkStore *cs){
   int rc;
-  int preserveRefs = cs->staging.nPending > 0
-                  && prollyHashCompare(&cs->refs.refsHash,
-                                       &cs->refs.committedRefsHash)!=0;
+  int preserveRefs;
   ProllyHash savedRefsHash;
   SavedRefsState savedRefs;
 
+  /* Reloading drops aRecent; never do that with uncommitted refs to it. */
+  if( cs->staging.nRecentUncommitted > 0 ){
+    return SQLITE_BUSY_SNAPSHOT;
+  }
+
+  preserveRefs = cs->staging.nPending > 0
+              && prollyHashCompare(&cs->refs.refsHash,
+                                   &cs->refs.committedRefsHash)!=0;
   memset(&savedRefs, 0, sizeof(savedRefs));
   if( preserveRefs ){
     savedRefsHash = cs->refs.refsHash;
@@ -1595,6 +1609,17 @@ static int csCommitToFile(ChunkStore *cs){
     if( rc != SQLITE_OK ) goto commit_done;
     fileSize = cs->file.iFileSize;
   }
+#if defined(SQLITE_TEST) || defined(DOLTLITE_MECH_REPRO)
+  if( hadFile && cs->staging.nRecentUncommitted>0 && csReloadInjectionActive() ){
+    static int csReloadInjected = 0;
+    if( !csReloadInjected ){
+      csReloadInjected = 1;
+      rc = csReloadFromDiskPreservingLocalRefs(cs);
+      if( rc != SQLITE_OK ) goto commit_done;
+      fileSize = cs->file.iFileSize;
+    }
+  }
+#endif
   /* Append at logical EOF and truncate crash garbage beyond it. */
   if( hadFile && cs->file.iFileSize > fileSize ){
     fileSize = cs->file.iFileSize;
@@ -2129,8 +2154,13 @@ static int csReloadFromDisk(ChunkStore *cs){
   ChunkStore tmp;
   ChunkStoreReloadState saved;
   char *zOldFilename;
-  int rc = chunkStoreOpen(&tmp, cs->file.pVfs, cs->file.zFilename,
-                          SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB);
+  int rc;
+  /* Direct refresh also reaches the reload path. */
+  if( cs->staging.nRecentUncommitted > 0 ){
+    return SQLITE_BUSY_SNAPSHOT;
+  }
+  rc = chunkStoreOpen(&tmp, cs->file.pVfs, cs->file.zFilename,
+                      SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_MAIN_DB);
   if( rc!=SQLITE_OK ) return rc;
 
   /* Reload must not replace a writable store with a fallback read-only one. */

--- a/test/doltlite_reload_uncommitted_recent.test
+++ b/test/doltlite_reload_uncommitted_recent.test
@@ -1,0 +1,96 @@
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+set testprefix doltlite-reload-uncommitted-recent
+
+set saved_pending_drain_limit [expr {[info exists env(DOLTLITE_CHUNK_PENDING_DRAIN_LIMIT)] ? $env(DOLTLITE_CHUNK_PENDING_DRAIN_LIMIT) : ""}]
+set had_pending_drain_limit [info exists env(DOLTLITE_CHUNK_PENDING_DRAIN_LIMIT)]
+set saved_reload_inject [expr {[info exists env(DOLTLITE_RELOAD_INJECT)] ? $env(DOLTLITE_RELOAD_INJECT) : ""}]
+set had_reload_inject [info exists env(DOLTLITE_RELOAD_INJECT)]
+
+execsql {
+  CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT);
+  INSERT INTO t1 VALUES(1, 'seed');
+  SELECT dolt_commit('-A', '-m', 'seed');
+}
+
+set env(DOLTLITE_CHUNK_PENDING_DRAIN_LIMIT) 1
+set env(DOLTLITE_RELOAD_INJECT) 1
+
+do_catchsql_test 1.0 {
+  BEGIN;
+  WITH RECURSIVE data(i) AS (
+    VALUES(2)
+    UNION ALL
+    SELECT i+1 FROM data WHERE i < 300
+  )
+  INSERT INTO t1 SELECT i, hex(randomblob(4096)) FROM data;
+  COMMIT;
+} {1 {database is locked}}
+
+do_test 1.1 {
+  catchsql { ROLLBACK }
+  set res [catchsql {
+    PRAGMA integrity_check;
+    SELECT dolt_gc();
+    PRAGMA integrity_check;
+    SELECT count(*) FROM t1;
+  }]
+  expr {[lindex $res 0]==0
+        && [lindex [lindex $res 1] 0] eq "ok"
+        && [lindex [lindex $res 1] 2] eq "ok"
+        && [lindex [lindex $res 1] 3]==1}
+} {1}
+
+db close
+sqlite3 db test.db
+
+do_test 1.2 {
+  set res [catchsql {
+    PRAGMA integrity_check;
+    SELECT dolt_gc();
+    PRAGMA integrity_check;
+    SELECT count(*) FROM t1;
+  }]
+  expr {[lindex $res 0]==0
+        && [lindex [lindex $res 1] 0] eq "ok"
+        && [lindex [lindex $res 1] 2] eq "ok"
+        && [lindex [lindex $res 1] 3]==1}
+} {1}
+
+do_execsql_test 1.3 {
+  BEGIN;
+  WITH RECURSIVE data(i) AS (
+    VALUES(2)
+    UNION ALL
+    SELECT i+1 FROM data WHERE i < 300
+  )
+  INSERT INTO t1 SELECT i, hex(randomblob(4096)) FROM data;
+  COMMIT;
+  SELECT count(*), max(length(b)) FROM t1;
+  PRAGMA integrity_check;
+} {300 8192 ok}
+
+do_test 1.4 {
+  set res [catchsql {
+    SELECT dolt_gc();
+    PRAGMA integrity_check;
+    SELECT count(*) FROM t1;
+  }]
+  expr {[lindex $res 0]==0
+        && [lindex [lindex $res 1] 1] eq "ok"
+        && [lindex [lindex $res 1] 2]==300}
+} {1}
+
+if {$had_pending_drain_limit} {
+  set env(DOLTLITE_CHUNK_PENDING_DRAIN_LIMIT) $saved_pending_drain_limit
+} else {
+  unset env(DOLTLITE_CHUNK_PENDING_DRAIN_LIMIT)
+}
+if {$had_reload_inject} {
+  set env(DOLTLITE_RELOAD_INJECT) $saved_reload_inject
+} else {
+  unset env(DOLTLITE_RELOAD_INJECT)
+}
+
+finish_test


### PR DESCRIPTION
## Summary
- refuse disk reloads while the connection has uncommitted recent chunks
- keep the deterministic reload-injection hook from #1540, with shorter comments
- add a regression test covering failed commit, rollback/reopen safety, GC, and retry

## Before / after
Negative control: `origin/master` plus only the test hook and this test, without the guard:
- `test/doltlite_reload_uncommitted_recent.test` fails at `1.0`
- injected commit returns success instead of `database is locked`

Patched branch:
- injected commit returns `database is locked`
- post-failure `PRAGMA integrity_check` is `ok`
- `dolt_gc()` succeeds before and after reopen
- retry commits all 300 rows and GC still succeeds

## Tests
- Docker Ubuntu build: `configure && make testfixture`
- `./testfixture test/doltlite_reload_uncommitted_recent.test`
- `./testfixture test/doltlite_chunk_pending_drain.test`
- `DOLTLITE=/build/doltlite bash test/doltlite_gc_session_state.sh`
- `DOLTLITE=/build/doltlite bash test/doltlite_gc.sh`
- `DOLTLITE=/build/doltlite bash test/doltlite_branch_gc_stress.sh`
- `DOLTLITE_BUILD_DIR=/build bash test/run_doltlite_regression_case.sh all`
- `DOLTLITE=/build/doltlite bash test/doltlite_gc_scale.sh`

Note: I also attempted `test/crash_injection_test.sh`; the normal CLI correctly is not built with the required `SQLITE_TEST` crash hook, and forcing `SQLITE_TEST` onto the CLI target failed to pick up Tcl include flags in that target.
