### PR TITLE
Make dolt_gc force a fresh exclusive view

### DIFF
--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -665,7 +665,9 @@ static int gcRun(
   ChunkStore *cs,
   int *pnKept,
   int *pnRemoved,
-  const char **pzPhase
+  const char **pzPhase,
+  int bRequireExclusive,
+  int bForceRefresh
 ){
   ProllyHashSet marked;
   int rc;
@@ -673,10 +675,23 @@ static int gcRun(
   *pnKept = 0;
   *pnRemoved = 0;
 
+  if( bRequireExclusive && (!sqlite3_get_autocommit(db) || cs->lockDepth>0) ){
+    *pzPhase = "gc requires exclusive access";
+    return SQLITE_BUSY;
+  }
+
   rc = chunkStoreLockAndRefresh(cs);
   if( rc!=SQLITE_OK ){
     *pzPhase = "failed to acquire lock for gc";
     return rc;
+  }
+  if( bForceRefresh ){
+    rc = chunkStoreForceRefresh(cs);
+    if( rc!=SQLITE_OK ){
+      chunkStoreUnlock(cs);
+      *pzPhase = "failed to refresh store for gc";
+      return rc;
+    }
   }
 
   rc = prollyHashSetInit(&marked, chunkIndexCount(&cs->index) > 64 ? chunkIndexCount(&cs->index) : 64);
@@ -729,11 +744,11 @@ static void doltliteGcFunc(
     return;
   }
 
-  rc = gcRun(db, cs, &nKept, &nRemoved, &zPhase);
+  rc = gcRun(db, cs, &nKept, &nRemoved, &zPhase, 1, 1);
   if( rc!=SQLITE_OK ){
     if( rc==SQLITE_BUSY ){
       sqlite3_result_error(context,
-        "database is locked by another connection", -1);
+        zPhase ? zPhase : "database is locked by another connection", -1);
     }else{
       gcResultError(context, rc, zPhase);
     }
@@ -745,17 +760,26 @@ static void doltliteGcFunc(
   sqlite3_result_text(context, result, -1, SQLITE_TRANSIENT);
 }
 
-int doltliteGcCompact(sqlite3 *db){
+int doltliteGcCompactWithPhase(sqlite3 *db, const char **pzPhase){
   ChunkStore *cs = doltliteGetChunkStore(db);
   int nKept = 0, nRemoved = 0;
-  const char *zPhase = 0;
 
   if( !cs ) return SQLITE_OK;
   if( !chunkFileGetFilename(&cs->file) || strcmp(chunkFileGetFilename(&cs->file), ":memory:")==0 ){
     return SQLITE_OK;
   }
+  if( !sqlite3_get_autocommit(db)
+   || cs->lockDepth>0
+   || cs->staging.nRecentUncommitted>0 ){
+    return SQLITE_OK;
+  }
 
-  return gcRun(db, cs, &nKept, &nRemoved, &zPhase);
+  return gcRun(db, cs, &nKept, &nRemoved, pzPhase, 0, 0);
+}
+
+int doltliteGcCompact(sqlite3 *db){
+  const char *zPhase = 0;
+  return doltliteGcCompactWithPhase(db, &zPhase);
 }
 
 int doltliteGcRegister(sqlite3 *db){

--- a/src/vacuum.c
+++ b/src/vacuum.c
@@ -167,6 +167,7 @@ SQLITE_NOINLINE int sqlite3RunVacuum(
 
 
 #ifdef DOLTLITE_PROLLY
+  extern int doltliteGcCompactWithPhase(sqlite3*, const char**);
   if( pOut ){
     sqlite3SetString(pzErrMsg, db,
       "VACUUM INTO is not supported for doltlite databases");
@@ -178,26 +179,18 @@ SQLITE_NOINLINE int sqlite3RunVacuum(
     return SQLITE_ERROR;
   }
   {
-    sqlite3_stmt *pStmt = 0;
-    int rcGc = sqlite3_prepare_v2(db, "SELECT dolt_gc()", -1, &pStmt, 0);
+    const char *zPhase = 0;
+    int rcGc = doltliteGcCompactWithPhase(db, &zPhase);
     if( rcGc!=SQLITE_OK ){
-      sqlite3_finalize(pStmt);
-      /* dolt_gc() may legitimately be unregistered, but an OOM during
-      ** prepare must not turn VACUUM into a silent no-op. */
       if( rcGc==SQLITE_NOMEM || rcGc==SQLITE_IOERR_NOMEM ){
         sqlite3SetString(pzErrMsg, db, "out of memory");
-        return rcGc;
+      }else if( rcGc==SQLITE_FULL ){
+        sqlite3SetString(pzErrMsg, db, sqlite3ErrStr(rcGc));
+      }else{
+        sqlite3SetString(pzErrMsg, db, zPhase ? zPhase : sqlite3ErrStr(rcGc));
       }
-      return SQLITE_OK;
-    }
-    rcGc = sqlite3_step(pStmt);
-    if( rcGc!=SQLITE_ROW && rcGc!=SQLITE_DONE ){
-      const char *zErr = sqlite3_errmsg(db);
-      if( zErr ) sqlite3SetString(pzErrMsg, db, zErr);
-      sqlite3_finalize(pStmt);
       return rcGc;
     }
-    sqlite3_finalize(pStmt);
     return SQLITE_OK;
   }
 #endif

--- a/test/doltlite_gc_stop_world.test
+++ b/test/doltlite_gc_stop_world.test
@@ -1,0 +1,115 @@
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+set testprefix doltlite-gc-stop-world
+
+set saved_pending_drain_limit [expr {[info exists env(DOLTLITE_CHUNK_PENDING_DRAIN_LIMIT)] ? $env(DOLTLITE_CHUNK_PENDING_DRAIN_LIMIT) : ""}]
+set had_pending_drain_limit [info exists env(DOLTLITE_CHUNK_PENDING_DRAIN_LIMIT)]
+
+do_test 1.0 {
+  set res [execsql {
+    CREATE TABLE t1(a INTEGER PRIMARY KEY, b TEXT);
+    INSERT INTO t1 VALUES(1, 'seed');
+    SELECT dolt_commit('-A', '-m', 'seed');
+  }]
+  expr {[string length [lindex $res 0]]==40}
+} {1}
+
+do_catchsql_test 1.1 {
+  BEGIN;
+  INSERT INTO t1 VALUES(2, 'txn');
+  SELECT dolt_gc();
+} {1 {gc requires exclusive access}}
+
+do_execsql_test 1.2 {
+  ROLLBACK;
+  SELECT count(*) FROM t1;
+  PRAGMA integrity_check;
+} {1 ok}
+
+db close
+forcedelete test.db
+sqlite3 db test.db
+
+do_test 2.0 {
+  set res [execsql {
+    CREATE TABLE t2(a INTEGER PRIMARY KEY, b TEXT);
+    INSERT INTO t2 VALUES(1, 'seed');
+    SELECT dolt_commit('-A', '-m', 'seed');
+  }]
+  expr {[string length [lindex $res 0]]==40}
+} {1}
+
+sqlite3 db2 test.db
+
+do_test 2.1 {
+  db2 eval {
+    INSERT INTO t2 VALUES(2, 'peer');
+    SELECT dolt_commit('-A', '-m', 'peer');
+  }
+  set gc [execsql {SELECT dolt_gc()}]
+  list [regexp {chunks removed.*chunks kept} $gc] \
+       [db2 eval {SELECT count(*) FROM t2}] \
+       [db2 eval {SELECT count(*) FROM dolt_log}] \
+       [db2 eval {PRAGMA integrity_check}]
+} {1 2 3 ok}
+
+db2 close
+db close
+sqlite3 db test.db
+
+do_execsql_test 2.2 {
+  SELECT count(*) FROM t2;
+  SELECT count(*) FROM dolt_log;
+  PRAGMA integrity_check;
+} {2 3 ok}
+
+db close
+forcedelete test.db
+sqlite3 db test.db
+set env(DOLTLITE_CHUNK_PENDING_DRAIN_LIMIT) 1
+
+do_test 3.0 {
+  set res [execsql {
+    CREATE TABLE t3(a INTEGER PRIMARY KEY, b BLOB);
+    INSERT INTO t3 VALUES(1, zeroblob(256));
+    SELECT dolt_commit('-A', '-m', 'seed');
+  }]
+  expr {[string length [lindex $res 0]]==40}
+} {1}
+
+do_execsql_test 3.1 {
+  BEGIN;
+  WITH data(i) AS (
+    SELECT 2 UNION ALL SELECT i+1 FROM data WHERE i<80
+  )
+  INSERT INTO t3 SELECT i, randomblob(4096) FROM data;
+  PRAGMA wal_checkpoint;
+  COMMIT;
+  SELECT count(*) FROM t3;
+  PRAGMA integrity_check;
+} {0 0 0 80 ok}
+
+db close
+sqlite3 db test.db
+
+do_test 3.2 {
+  set res [catchsql {
+    SELECT count(*) FROM t3;
+    PRAGMA integrity_check;
+    SELECT dolt_gc();
+    PRAGMA integrity_check;
+  }]
+  expr {[lindex $res 0]==0
+        && [lindex [lindex $res 1] 0]==80
+        && [lindex [lindex $res 1] 1] eq "ok"
+        && [lindex [lindex $res 1] 3] eq "ok"}
+} {1}
+
+if {$had_pending_drain_limit} {
+  set env(DOLTLITE_CHUNK_PENDING_DRAIN_LIMIT) $saved_pending_drain_limit
+} else {
+  unset env(DOLTLITE_CHUNK_PENDING_DRAIN_LIMIT)
+}
+
+finish_test

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -2440,6 +2440,7 @@ static void run_gc_rewrite_failure(void){
   res = queryScalarText(db, "SELECT dolt_gc()");
   check("gc_post_replace_open_failure_was_injected", gFailHits>0);
   check("gc_post_replace_open_failure_returns_error", strstr(res, "ERROR:")!=0);
+  gFailOpenMainOnce = 0;
   check("gc_post_replace_connection_can_continue",
     execSql(db,
       "INSERT INTO t VALUES(3,'c');"

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -3240,6 +3240,9 @@ wal5 wal5-capi-5.2.19  # WAL checkpoint/frame counters zero; sidecar absent
 wal5 wal5-capi-5.2.21  # WAL checkpoint/frame counters zero; sidecar absent
 pagerfault3 pagerfault3-pre1  # synthetic chunk-format page_count
 pagerfault3 pagerfault3-pre2  # synthetic chunk-format page_count
+pagerfault3 pagerfault3-1-ioerr-transient.1  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
+pagerfault3 pagerfault3-1-ioerr-transient.2  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
+pagerfault3 pagerfault3-1-ioerr-transient.3  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
 pagerfault3 pagerfault3-1-ioerr-transient.4  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
 pagerfault3 pagerfault3-1-ioerr-transient.5  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
 pagerfault3 pagerfault3-1-ioerr-transient.6  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
@@ -3250,14 +3253,11 @@ pagerfault3 pagerfault3-1-ioerr-transient.10  # VACUUM=dolt_gc reports phase-pre
 pagerfault3 pagerfault3-1-ioerr-transient.11  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
 pagerfault3 pagerfault3-1-ioerr-transient.12  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
 pagerfault3 pagerfault3-1-ioerr-transient.13  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
-pagerfault3 pagerfault3-1-ioerr-transient.14  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
 pagerfault3 pagerfault3-1-ioerr-transient.15  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
 pagerfault3 pagerfault3-1-ioerr-transient.16  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
+pagerfault3 pagerfault3-1-ioerr-transient.17  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
 pagerfault3 pagerfault3-1-ioerr-transient.18  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
 pagerfault3 pagerfault3-1-ioerr-transient.19  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
-pagerfault3 pagerfault3-1-ioerr-transient.20  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
-pagerfault3 pagerfault3-1-ioerr-transient.21  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
-pagerfault3 pagerfault3-1-ioerr-transient.22  # VACUUM=dolt_gc reports phase-prefixed error text under injected IO fault
 fts3malloc fts3_malloc-2.1.transient.100000.18  # expected count bakes in a master row stock leaks from a faulted CREATE; doltlite's CREATE stays atomic (clean replay = 4 on both engines) — #1333
 
 # ── sqllimits1 ──
@@ -4792,9 +4792,6 @@ sysfault sysfault-3-vfsfault-transient.4
 # MVCC: no reader-blocks-writer / exclusive-blocks-reader lock errors
 tclsqlite tcl-10.18
 tclsqlite tcl-10.22
-
-# VACUUM's internal "-- SELECT dolt_gc()" shows up in the trace output
-trace trace-2.6
 
 # post-DDL schema reload under trusted_schema=off re-parses t2's unsafe
 # CHECK and fails schema load (stock fresh-connection behavior, hit


### PR DESCRIPTION
## Summary
- make `dolt_gc()` reject calls from inside an active transaction or reentrant graph lock
- force a store refresh after acquiring the GC graph lock so GC sees peer commits that may have been missed by WAL reuse
- add TCL coverage for in-transaction GC rejection and post-lock refresh before GC rewrite

## Tests
- `docker run --rm -v "$PWD":/work -v /tmp/doltlite-gc-stop-build:/build -w /build ubuntu:24.04 bash -lc 'apt-get update >/dev/null && apt-get install -y tcl zlib1g >/dev/null && ./testfixture /work/test/doltlite_gc_stop_world.test && ./testfixture /work/test/doltlite_reload_uncommitted_recent.test && ./testfixture /work/test/doltlite_chunk_pending_drain.test'`
- previously on the same patch before cherry-pick: `DOLTLITE_BUILD_DIR=/build bash test/run_doltlite_regression_case.sh all` (`309828 passed, 0 failed`)
