### PR TITLE
Drop stale incrblob2 divergence-list comment

### DIFF
--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1819,8 +1819,7 @@ walshared walshared-1.2  # shared-cache WAL table locks not raised; snapshot rea
 walshared walshared-1.3  # shared-cache WAL table locks not raised; snapshot reads proceed
 
 # -- feature-gap sweep wave 3 (#1208): 44 completing files (6-100 failures),
-# every file's failure set reproduced and classified by verified mechanism;
-# incrblob2 held out as a real bug.
+# every file's failure set reproduced and classified by verified mechanism.
 backup2 backup2-2  # backup format/file hash and error-text differ; in-memory backup rejected
 backup2 backup2-3.2  # backup format/file hash and error-text differ; in-memory backup rejected
 backup2 backup2-4  # backup format/file hash and error-text differ; in-memory backup rejected


### PR DESCRIPTION
The `#1208` wave-3 sweep comment in `test/known_testfixture_divergences.txt` states *"incrblob2 held out as a real bug."* That bug has since been fixed — `incrblob2` now completes with only the four benign lock/MVCC divergences (`5.3/5.5/5.6/5.8`), which are already listed. It is no longer held out, so the clause is stale and misleading.

Comment-only change (no code/test impact); verified `incrblob2.test` fails only on those four already-listed entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)