### PR TITLE
Fix duplicate _sqlite3SchemaMutexHeld in debug builds

### DIFF
--- a/src/btree_orig_prefix.h
+++ b/src/btree_orig_prefix.h
@@ -3,12 +3,6 @@
 #ifndef BTREE_ORIG_PREFIX_H
 #define BTREE_ORIG_PREFIX_H
 
-/* sqlite3SchemaMutexHeld is a debug-only mutex-assertion helper defined by both
-** btmutex_orig.c (stock) and prolly_btree.c (a stub, under !NDEBUG). Its sibling
-** helpers (sqlite3Btree{Holds,HoldsAll}Mutex) are already prefixed below; this
-** one was missing, so both copies were emitted unprefixed and collided at link
-** time in debug (--dev) builds. Prefix the stock copy so the prolly definition
-** stays canonical. */
 #define sqlite3SchemaMutexHeld orig_sqlite3SchemaMutexHeld
 
 #define sqlite3BtreeBeginStmt orig_sqlite3BtreeBeginStmt

--- a/src/btree_orig_prefix.h
+++ b/src/btree_orig_prefix.h
@@ -3,6 +3,14 @@
 #ifndef BTREE_ORIG_PREFIX_H
 #define BTREE_ORIG_PREFIX_H
 
+/* sqlite3SchemaMutexHeld is a debug-only mutex-assertion helper defined by both
+** btmutex_orig.c (stock) and prolly_btree.c (a stub, under !NDEBUG). Its sibling
+** helpers (sqlite3Btree{Holds,HoldsAll}Mutex) are already prefixed below; this
+** one was missing, so both copies were emitted unprefixed and collided at link
+** time in debug (--dev) builds. Prefix the stock copy so the prolly definition
+** stays canonical. */
+#define sqlite3SchemaMutexHeld orig_sqlite3SchemaMutexHeld
+
 #define sqlite3BtreeBeginStmt orig_sqlite3BtreeBeginStmt
 #define sqlite3BtreeBeginTrans orig_sqlite3BtreeBeginTrans
 #define sqlite3BtreeCheckpoint orig_sqlite3BtreeCheckpoint


### PR DESCRIPTION
prolly_btree.c provides a stub sqlite3SchemaMutexHeld under !NDEBUG, and the renamed-original btmutex_orig.c also defines it. Unlike its sibling helpers (sqlite3Btree{Holds,HoldsAll}Mutex), it was missing from btree_orig_prefix.h, so both copies were emitted unprefixed and collided at link time in debug (--dev) builds (make doltlite: duplicate symbol _sqlite3SchemaMutexHeld). Release builds were unaffected (the prolly stub is compiled out under NDEBUG).

Prefix the stock copy with orig_ like the sibling helpers, making the prolly definition canonical. make doltlite --dev now links.