### PR TITLE
Add GC dangling chunk diagnostics

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -337,6 +337,11 @@ jobs:
       run: cd build && bash ../test/remote_test.sh ./doltlite
       timeout-minutes: 5
 
+    - name: GC concurrent commit stress
+      if: matrix.platform == 'ubuntu'
+      run: cd build && bash ../test/gc_concurrent_commit_stress.sh ./doltlite
+      timeout-minutes: 5
+
     # -- C/Python/Go integration tests -----------------------
 
     - name: C integration tests

--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -11,6 +11,13 @@
 #include <stdlib.h>
 #include <limits.h>
 
+#if defined(SQLITE_TEST) || defined(DOLTLITE_MECH_REPRO)
+static sqlite3_int64 csDebugReloadGuardPreserve = 0;
+static sqlite3_int64 csDebugReloadGuardDirect = 0;
+static sqlite3_int64 csDebugPendingDrains = 0;
+static sqlite3_int64 csDebugPendingDrainChunks = 0;
+#endif
+
 static int csFileLockHeld(sqlite3_file *pFile){
   return pFile!=0;
 }
@@ -276,6 +283,9 @@ static int csReloadFromDiskPreservingLocalRefs(ChunkStore *cs){
 
   /* Reloading drops aRecent; never do that with uncommitted refs to it. */
   if( cs->staging.nRecentUncommitted > 0 ){
+#if defined(SQLITE_TEST) || defined(DOLTLITE_MECH_REPRO)
+    csDebugReloadGuardPreserve++;
+#endif
     return SQLITE_BUSY_SNAPSHOT;
   }
 
@@ -1318,6 +1328,11 @@ static int csDrainPendingToWal(ChunkStore *cs){
     return SQLITE_OK;
   }
 
+#if defined(SQLITE_TEST) || defined(DOLTLITE_MECH_REPRO)
+  csDebugPendingDrains++;
+  csDebugPendingDrainChunks += cs->staging.nPending;
+#endif
+
   if( cs->file.pFile == 0 ){
     int openFlags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE
                   | SQLITE_OPEN_MAIN_DB;
@@ -2157,6 +2172,9 @@ static int csReloadFromDisk(ChunkStore *cs){
   int rc;
   /* Direct refresh also reaches the reload path. */
   if( cs->staging.nRecentUncommitted > 0 ){
+#if defined(SQLITE_TEST) || defined(DOLTLITE_MECH_REPRO)
+    csDebugReloadGuardDirect++;
+#endif
     return SQLITE_BUSY_SNAPSHOT;
   }
   rc = chunkStoreOpen(&tmp, cs->file.pVfs, cs->file.zFilename,
@@ -2183,5 +2201,48 @@ static int csReloadFromDisk(ChunkStore *cs){
 
   return SQLITE_OK;
 }
+
+#if defined(SQLITE_TEST) || defined(DOLTLITE_MECH_REPRO)
+extern ChunkStore *doltliteGetChunkStore(sqlite3 *db);
+
+static void doltliteChunkStoreDebugFunc(
+  sqlite3_context *ctx,
+  int argc,
+  sqlite3_value **argv
+){
+  sqlite3 *db = sqlite3_context_db_handle(ctx);
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  char zBuf[256];
+  const char *zArg = 0;
+
+  if( argc>0 && sqlite3_value_type(argv[0])!=SQLITE_NULL ){
+    zArg = (const char*)sqlite3_value_text(argv[0]);
+  }
+  if( zArg && sqlite3_stricmp(zArg, "reset")==0 ){
+    csDebugReloadGuardPreserve = 0;
+    csDebugReloadGuardDirect = 0;
+    csDebugPendingDrains = 0;
+    csDebugPendingDrainChunks = 0;
+  }
+
+  sqlite3_snprintf(sizeof(zBuf), zBuf,
+    "reload_guard_preserve=%lld reload_guard_direct=%lld "
+    "pending_drains=%lld pending_drain_chunks=%lld "
+    "recent=%d recent_uncommitted=%d pending=%d lock_depth=%d",
+    csDebugReloadGuardPreserve, csDebugReloadGuardDirect,
+    csDebugPendingDrains, csDebugPendingDrainChunks,
+    cs ? cs->staging.nRecent : 0,
+    cs ? cs->staging.nRecentUncommitted : 0,
+    cs ? cs->staging.nPending : 0,
+    cs ? cs->lockDepth : 0);
+  sqlite3_result_text(ctx, zBuf, -1, SQLITE_TRANSIENT);
+}
+
+int doltliteChunkStoreDebugRegister(sqlite3 *db){
+  return sqlite3_create_function(db, "dolt_debug_chunk_store", -1,
+                                 SQLITE_UTF8, 0,
+                                 doltliteChunkStoreDebugFunc, 0, 0);
+}
+#endif
 
 #endif

--- a/src/doltlite_chunk_walk.c
+++ b/src/doltlite_chunk_walk.c
@@ -10,6 +10,31 @@
 
 #include <string.h>
 
+static int isCommitChunk(const u8 *data, int nData){
+  const u8 *p = data;
+  const u8 *pEnd = data + nData;
+  int nPar;
+  int i;
+
+  if( nData < 1 || *p++ != DOLTLITE_COMMIT_V2 ) return 0;
+  if( p >= pEnd ) return 0;
+  nPar = *p++;
+  if( nPar > DOLTLITE_MAX_PARENTS ) return 0;
+  if( pEnd - p < nPar*PROLLY_HASH_SIZE + PROLLY_HASH_SIZE + 8 + 6 ){
+    return 0;
+  }
+  p += nPar*PROLLY_HASH_SIZE + PROLLY_HASH_SIZE + 8;
+  for(i=0; i<3; i++){
+    int n;
+    if( pEnd - p < 2 ) return 0;
+    n = p[0] | (p[1]<<8);
+    p += 2;
+    if( pEnd - p < n ) return 0;
+    p += n;
+  }
+  return p == pEnd;
+}
+
 DoltliteChunkType doltliteClassifyChunk(const u8 *data, int nData){
   u32 m;
 
@@ -19,6 +44,10 @@ DoltliteChunkType doltliteClassifyChunk(const u8 *data, int nData){
       ((u32)data[2]<<16) | ((u32)data[3]<<24);
   if( m == PROLLY_NODE_MAGIC && nData >= 8 ){
     return CHUNK_PROLLY_NODE;
+  }
+
+  if( isCommitChunk(data, nData) ){
+    return CHUNK_COMMIT;
   }
 
   if( (data[0] == WS_FORMAT_VERSION_V5 && nData == WS_TOTAL_SIZE)
@@ -33,10 +62,6 @@ DoltliteChunkType doltliteClassifyChunk(const u8 *data, int nData){
     if( catalogParseHeaderEx(data, nData, &iFormat, &nTables, &pEntries) ){
       return CHUNK_CATALOG;
     }
-  }
-
-  if( nData >= 30 && data[0] == DOLTLITE_COMMIT_V2 ){
-    return CHUNK_COMMIT;
   }
 
   if( nData >= 5 && data[0] == 7 ){

--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -21,6 +21,10 @@ struct GcQueueItem {
   ProllyHash hash;
   ProllyHash parent;
   const char *zSource;
+  const char *zParentType;
+  int iParentLevel;
+  int nParentItems;
+  int iChild;
 };
 struct GcQueue {
   GcQueueItem *aItems;
@@ -34,6 +38,10 @@ struct GcChildCtx {
   GcQueue *q;
   ProllyHash parent;
   const char *zSource;
+  const char *zParentType;
+  int iParentLevel;
+  int nParentItems;
+  int iNextChild;
 };
 
 typedef struct GcMarkTrace GcMarkTrace;
@@ -43,7 +51,23 @@ struct GcMarkTrace {
   ProllyHash missing;
   ProllyHash parent;
   const char *zSource;
+  const char *zParentType;
+  int iParentLevel;
+  int nParentItems;
+  int iChild;
 };
+
+static const char *gcChunkTypeName(DoltliteChunkType type){
+  switch( type ){
+    case CHUNK_COMMIT: return "commit";
+    case CHUNK_PROLLY_NODE: return "prolly-node";
+    case CHUNK_CATALOG: return "catalog";
+    case CHUNK_WORKING_SET: return "working-set";
+    case CHUNK_REFS: return "refs";
+    case CHUNK_UNKNOWN:
+    default: return "unknown";
+  }
+}
 
 static int gcQueueInit(GcQueue *q){
   q->nAlloc = 256;
@@ -63,7 +87,11 @@ static int gcQueuePush(
   GcQueue *q,
   const ProllyHash *h,
   const ProllyHash *pParent,
-  const char *zSource
+  const char *zSource,
+  const char *zParentType,
+  int iParentLevel,
+  int nParentItems,
+  int iChild
 ){
   if( prollyHashIsEmpty(h) ) return SQLITE_OK;
   if( q->nItems >= q->nAlloc ){
@@ -80,6 +108,10 @@ static int gcQueuePush(
     memset(&q->aItems[q->nItems].parent, 0, sizeof(ProllyHash));
   }
   q->aItems[q->nItems].zSource = zSource;
+  q->aItems[q->nItems].zParentType = zParentType;
+  q->aItems[q->nItems].iParentLevel = iParentLevel;
+  q->aItems[q->nItems].nParentItems = nParentItems;
+  q->aItems[q->nItems].iChild = iChild;
   q->nItems++;
   return SQLITE_OK;
 }
@@ -93,7 +125,10 @@ static int gcQueuePop(GcQueue *q, GcQueueItem *pItem){
 
 static int gcChildCb(void *ctx, const ProllyHash *pHash){
   GcChildCtx *p = (GcChildCtx*)ctx;
-  return gcQueuePush(p->q, pHash, &p->parent, p->zSource);
+  int iChild = p->iNextChild++;
+  return gcQueuePush(p->q, pHash, &p->parent, p->zSource,
+                     p->zParentType, p->iParentLevel, p->nParentItems,
+                     iChild);
 }
 
 #ifdef DOLTLITE_PROLLY_CHECK
@@ -142,16 +177,18 @@ static int gcMarkReachable(
   rc = gcQueueInit(&queue);
   if( rc!=SQLITE_OK ) return rc;
 
-  rc = gcQueuePush(&queue, refsTableGetHash(&cs->refs), 0, "refs-table");
+  rc = gcQueuePush(&queue, refsTableGetHash(&cs->refs), 0, "refs-table",
+                   0, -1, -1, -1);
 
   {
     int nBr; const BranchRef *aBr;
     refsTableGetBranches(&cs->refs, &nBr, &aBr);
     for(i=0; rc==SQLITE_OK && i<nBr; i++){
-      rc = gcQueuePush(&queue, &aBr[i].commitHash, 0, "branch-commit");
+      rc = gcQueuePush(&queue, &aBr[i].commitHash, 0, "branch-commit",
+                       0, -1, -1, -1);
       if( rc==SQLITE_OK ){
         rc = gcQueuePush(&queue, &aBr[i].workingSetHash, 0,
-                         "branch-working-set");
+                         "branch-working-set", 0, -1, -1, -1);
       }
     }
   }
@@ -160,7 +197,8 @@ static int gcMarkReachable(
     int nTg; const TagRef *aTg;
     refsTableGetTags(&cs->refs, &nTg, &aTg);
     for(i=0; rc==SQLITE_OK && i<nTg; i++){
-      rc = gcQueuePush(&queue, &aTg[i].commitHash, 0, "tag-commit");
+      rc = gcQueuePush(&queue, &aTg[i].commitHash, 0, "tag-commit",
+                       0, -1, -1, -1);
     }
   }
 
@@ -168,7 +206,8 @@ static int gcMarkReachable(
     int nPend; const ChunkIndexEntry *aPend;
     chunkStagingGetPending(&cs->staging, &nPend, &aPend);
     for(i=0; rc==SQLITE_OK && i<nPend; i++){
-      rc = gcQueuePush(&queue, &aPend[i].hash, 0, "pending");
+      rc = gcQueuePush(&queue, &aPend[i].hash, 0, "pending",
+                       0, -1, -1, -1);
     }
   }
 
@@ -203,6 +242,10 @@ static int gcMarkReachable(
         memcpy(&pTrace->missing, &current.hash, sizeof(ProllyHash));
         memcpy(&pTrace->parent, &current.parent, sizeof(ProllyHash));
         pTrace->zSource = current.zSource;
+        pTrace->zParentType = current.zParentType;
+        pTrace->iParentLevel = current.iParentLevel;
+        pTrace->nParentItems = current.nParentItems;
+        pTrace->iChild = current.iChild;
       }
       break;
     }
@@ -210,6 +253,17 @@ static int gcMarkReachable(
     childCtx.q = &queue;
     childCtx.parent = current.hash;
     childCtx.zSource = "child";
+    childCtx.zParentType = gcChunkTypeName(doltliteClassifyChunk(data, nData));
+    childCtx.iParentLevel = -1;
+    childCtx.nParentItems = -1;
+    childCtx.iNextChild = 0;
+    if( strcmp(childCtx.zParentType, "prolly-node")==0 ){
+      ProllyNode node;
+      if( prollyNodeParse(&node, data, nData)==SQLITE_OK ){
+        childCtx.iParentLevel = node.level;
+        childCtx.nParentItems = (int)node.nItems;
+      }
+    }
     rc = doltliteEnumerateChunkChildren(data, nData, gcChildCb, &childCtx);
 
     sqlite3_free(data);
@@ -237,10 +291,21 @@ static void gcFormatMarkFailure(
       zMissing, pTrace->zSource ? pTrace->zSource : "unknown", pTrace->rc);
   }else{
     doltliteHashToHex(&pTrace->parent, zParent);
-    sqlite3_snprintf(nBuf, zBuf,
-      "gc mark phase failed: missing chunk %s parent=%s source=%s rc=%d",
-      zMissing, zParent, pTrace->zSource ? pTrace->zSource : "unknown",
-      pTrace->rc);
+    if( pTrace->zParentType && strcmp(pTrace->zParentType, "prolly-node")==0 ){
+      sqlite3_snprintf(nBuf, zBuf,
+        "gc mark phase failed: missing chunk %s parent=%s source=%s "
+        "parent_type=%s parent_level=%d parent_items=%d child_index=%d rc=%d",
+        zMissing, zParent, pTrace->zSource ? pTrace->zSource : "unknown",
+        pTrace->zParentType, pTrace->iParentLevel, pTrace->nParentItems,
+        pTrace->iChild, pTrace->rc);
+    }else{
+      sqlite3_snprintf(nBuf, zBuf,
+        "gc mark phase failed: missing chunk %s parent=%s source=%s "
+        "parent_type=%s child_index=%d rc=%d",
+        zMissing, zParent, pTrace->zSource ? pTrace->zSource : "unknown",
+        pTrace->zParentType ? pTrace->zParentType : "unknown",
+        pTrace->iChild, pTrace->rc);
+    }
   }
 }
 

--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -16,16 +16,38 @@ extern void csSerializeManifest(const ChunkStore *cs, u8 *aBuf);
 #include "doltlite_internal.h"
 
 typedef struct GcQueue GcQueue;
+typedef struct GcQueueItem GcQueueItem;
+struct GcQueueItem {
+  ProllyHash hash;
+  ProllyHash parent;
+  const char *zSource;
+};
 struct GcQueue {
-  ProllyHash *aItems;
+  GcQueueItem *aItems;
   int nItems;
   int nAlloc;
   int iHead;
 };
 
+typedef struct GcChildCtx GcChildCtx;
+struct GcChildCtx {
+  GcQueue *q;
+  ProllyHash parent;
+  const char *zSource;
+};
+
+typedef struct GcMarkTrace GcMarkTrace;
+struct GcMarkTrace {
+  int hasMissing;
+  int rc;
+  ProllyHash missing;
+  ProllyHash parent;
+  const char *zSource;
+};
+
 static int gcQueueInit(GcQueue *q){
   q->nAlloc = 256;
-  q->aItems = sqlite3_malloc(q->nAlloc * sizeof(ProllyHash));
+  q->aItems = sqlite3_malloc(q->nAlloc * sizeof(GcQueueItem));
   if( !q->aItems ) return SQLITE_NOMEM;
   q->nItems = 0;
   q->iHead = 0;
@@ -37,30 +59,41 @@ static void gcQueueFree(GcQueue *q){
   memset(q, 0, sizeof(*q));
 }
 
-static int gcQueuePush(GcQueue *q, const ProllyHash *h){
+static int gcQueuePush(
+  GcQueue *q,
+  const ProllyHash *h,
+  const ProllyHash *pParent,
+  const char *zSource
+){
   if( prollyHashIsEmpty(h) ) return SQLITE_OK;
   if( q->nItems >= q->nAlloc ){
     int newAlloc = q->nAlloc * 2;
-    ProllyHash *aNew = sqlite3_realloc(q->aItems, newAlloc * sizeof(ProllyHash));
+    GcQueueItem *aNew = sqlite3_realloc(q->aItems, newAlloc * sizeof(GcQueueItem));
     if( !aNew ) return SQLITE_NOMEM;
     q->aItems = aNew;
     q->nAlloc = newAlloc;
   }
-  memcpy(&q->aItems[q->nItems], h, sizeof(ProllyHash));
+  memcpy(&q->aItems[q->nItems].hash, h, sizeof(ProllyHash));
+  if( pParent ){
+    memcpy(&q->aItems[q->nItems].parent, pParent, sizeof(ProllyHash));
+  }else{
+    memset(&q->aItems[q->nItems].parent, 0, sizeof(ProllyHash));
+  }
+  q->aItems[q->nItems].zSource = zSource;
   q->nItems++;
   return SQLITE_OK;
 }
 
-static int gcQueuePop(GcQueue *q, ProllyHash *h){
+static int gcQueuePop(GcQueue *q, GcQueueItem *pItem){
   if( q->iHead >= q->nItems ) return 0;
-  memcpy(h, &q->aItems[q->iHead], sizeof(ProllyHash));
+  *pItem = q->aItems[q->iHead];
   q->iHead++;
   return 1;
 }
 
 static int gcChildCb(void *ctx, const ProllyHash *pHash){
-  GcQueue *q = (GcQueue*)ctx;
-  return gcQueuePush(q, pHash);
+  GcChildCtx *p = (GcChildCtx*)ctx;
+  return gcQueuePush(p->q, pHash, &p->parent, p->zSource);
 }
 
 #ifdef DOLTLITE_PROLLY_CHECK
@@ -97,23 +130,29 @@ static void gcVerifySessionResolvable(sqlite3 *db, ChunkStore *cs){
 static int gcMarkReachable(
   sqlite3 *db,
   ChunkStore *cs,
-  ProllyHashSet *marked
+  ProllyHashSet *marked,
+  GcMarkTrace *pTrace
 ){
   GcQueue queue;
-  ProllyHash current;
+  GcQueueItem current;
+  GcChildCtx seedCtx;
   int rc, i;
 
+  memset(pTrace, 0, sizeof(*pTrace));
   rc = gcQueueInit(&queue);
   if( rc!=SQLITE_OK ) return rc;
 
-  rc = gcQueuePush(&queue, refsTableGetHash(&cs->refs));
+  rc = gcQueuePush(&queue, refsTableGetHash(&cs->refs), 0, "refs-table");
 
   {
     int nBr; const BranchRef *aBr;
     refsTableGetBranches(&cs->refs, &nBr, &aBr);
     for(i=0; rc==SQLITE_OK && i<nBr; i++){
-      rc = gcQueuePush(&queue, &aBr[i].commitHash);
-      if( rc==SQLITE_OK ) rc = gcQueuePush(&queue, &aBr[i].workingSetHash);
+      rc = gcQueuePush(&queue, &aBr[i].commitHash, 0, "branch-commit");
+      if( rc==SQLITE_OK ){
+        rc = gcQueuePush(&queue, &aBr[i].workingSetHash, 0,
+                         "branch-working-set");
+      }
     }
   }
 
@@ -121,7 +160,7 @@ static int gcMarkReachable(
     int nTg; const TagRef *aTg;
     refsTableGetTags(&cs->refs, &nTg, &aTg);
     for(i=0; rc==SQLITE_OK && i<nTg; i++){
-      rc = gcQueuePush(&queue, &aTg[i].commitHash);
+      rc = gcQueuePush(&queue, &aTg[i].commitHash, 0, "tag-commit");
     }
   }
 
@@ -129,12 +168,15 @@ static int gcMarkReachable(
     int nPend; const ChunkIndexEntry *aPend;
     chunkStagingGetPending(&cs->staging, &nPend, &aPend);
     for(i=0; rc==SQLITE_OK && i<nPend; i++){
-      rc = gcQueuePush(&queue, &aPend[i].hash);
+      rc = gcQueuePush(&queue, &aPend[i].hash, 0, "pending");
     }
   }
 
   if( rc==SQLITE_OK ){
-    rc = doltliteSeedSessionHashes(db, cs, gcChildCb, &queue);
+    memset(&seedCtx, 0, sizeof(seedCtx));
+    seedCtx.q = &queue;
+    seedCtx.zSource = "session";
+    rc = doltliteSeedSessionHashes(db, cs, gcChildCb, &seedCtx);
   }
 
   if( rc!=SQLITE_OK ){
@@ -145,19 +187,30 @@ static int gcMarkReachable(
   while( gcQueuePop(&queue, &current) ){
     u8 *data = 0;
     int nData = 0;
+    GcChildCtx childCtx;
 
-    if( prollyHashIsEmpty(&current) ) continue;
-    if( prollyHashSetContains(marked, &current) ) continue;
+    if( prollyHashIsEmpty(&current.hash) ) continue;
+    if( prollyHashSetContains(marked, &current.hash) ) continue;
 
-    rc = prollyHashSetAdd(marked, &current);
+    rc = prollyHashSetAdd(marked, &current.hash);
     if( rc!=SQLITE_OK ) break;
 
-    rc = chunkStoreGet(cs, &current, &data, &nData);
+    rc = chunkStoreGet(cs, &current.hash, &data, &nData);
     if( rc!=SQLITE_OK ){
+      if( rc==SQLITE_NOTFOUND || rc==SQLITE_CORRUPT ){
+        pTrace->hasMissing = 1;
+        pTrace->rc = rc;
+        memcpy(&pTrace->missing, &current.hash, sizeof(ProllyHash));
+        memcpy(&pTrace->parent, &current.parent, sizeof(ProllyHash));
+        pTrace->zSource = current.zSource;
+      }
       break;
     }
 
-    rc = doltliteEnumerateChunkChildren(data, nData, gcChildCb, &queue);
+    childCtx.q = &queue;
+    childCtx.parent = current.hash;
+    childCtx.zSource = "child";
+    rc = doltliteEnumerateChunkChildren(data, nData, gcChildCb, &childCtx);
 
     sqlite3_free(data);
     if( rc!=SQLITE_OK ) break;
@@ -165,6 +218,30 @@ static int gcMarkReachable(
 
   gcQueueFree(&queue);
   return rc;
+}
+
+static void gcFormatMarkFailure(
+  char *zBuf,
+  int nBuf,
+  const GcMarkTrace *pTrace
+){
+  char zMissing[PROLLY_HASH_SIZE*2+1];
+  char zParent[PROLLY_HASH_SIZE*2+1];
+  if( !zBuf || nBuf<=0 || !pTrace || !pTrace->hasMissing ){
+    return;
+  }
+  doltliteHashToHex(&pTrace->missing, zMissing);
+  if( prollyHashIsEmpty(&pTrace->parent) ){
+    sqlite3_snprintf(nBuf, zBuf,
+      "gc mark phase failed: missing chunk %s source=%s rc=%d",
+      zMissing, pTrace->zSource ? pTrace->zSource : "unknown", pTrace->rc);
+  }else{
+    doltliteHashToHex(&pTrace->parent, zParent);
+    sqlite3_snprintf(nBuf, zBuf,
+      "gc mark phase failed: missing chunk %s parent=%s source=%s rc=%d",
+      zMissing, zParent, pTrace->zSource ? pTrace->zSource : "unknown",
+      pTrace->rc);
+  }
 }
 
 static int gcAppendMarkedChunk(
@@ -666,10 +743,13 @@ static int gcRun(
   int *pnKept,
   int *pnRemoved,
   const char **pzPhase,
+  char *zPhaseBuf,
+  int nPhaseBuf,
   int bRequireExclusive,
   int bForceRefresh
 ){
   ProllyHashSet marked;
+  GcMarkTrace markTrace;
   int rc;
 
   *pnKept = 0;
@@ -701,11 +781,16 @@ static int gcRun(
     return rc;
   }
 
-  rc = gcMarkReachable(db, cs, &marked);
+  rc = gcMarkReachable(db, cs, &marked, &markTrace);
   if( rc!=SQLITE_OK ){
     prollyHashSetFree(&marked);
     chunkStoreUnlock(cs);
-    *pzPhase = "gc mark phase failed";
+    if( markTrace.hasMissing && zPhaseBuf && nPhaseBuf>0 ){
+      gcFormatMarkFailure(zPhaseBuf, nPhaseBuf, &markTrace);
+      *pzPhase = zPhaseBuf;
+    }else{
+      *pzPhase = "gc mark phase failed";
+    }
     return rc;
   }
 
@@ -729,6 +814,7 @@ static void doltliteGcFunc(
   int nKept = 0, nRemoved = 0;
   int rc;
   const char *zPhase = 0;
+  char zPhaseBuf[256];
   char result[128];
 
   (void)argc;
@@ -744,7 +830,8 @@ static void doltliteGcFunc(
     return;
   }
 
-  rc = gcRun(db, cs, &nKept, &nRemoved, &zPhase, 1, 1);
+  rc = gcRun(db, cs, &nKept, &nRemoved, &zPhase, zPhaseBuf,
+             sizeof(zPhaseBuf), 1, 1);
   if( rc!=SQLITE_OK ){
     if( rc==SQLITE_BUSY ){
       sqlite3_result_error(context,
@@ -774,7 +861,7 @@ int doltliteGcCompactWithPhase(sqlite3 *db, const char **pzPhase){
     return SQLITE_OK;
   }
 
-  return gcRun(db, cs, &nKept, &nRemoved, pzPhase, 0, 0);
+  return gcRun(db, cs, &nKept, &nRemoved, pzPhase, 0, 0, 0, 0);
 }
 
 int doltliteGcCompact(sqlite3 *db){
@@ -783,8 +870,13 @@ int doltliteGcCompact(sqlite3 *db){
 }
 
 int doltliteGcRegister(sqlite3 *db){
-  return sqlite3_create_function(db, "dolt_gc", 0, SQLITE_UTF8, 0,
-                                  doltliteGcFunc, 0, 0);
+  int rc = sqlite3_create_function(db, "dolt_gc", 0, SQLITE_UTF8, 0,
+                                   doltliteGcFunc, 0, 0);
+#if defined(SQLITE_TEST) || defined(DOLTLITE_MECH_REPRO)
+  extern int doltliteChunkStoreDebugRegister(sqlite3*);
+  if( rc==SQLITE_OK ) rc = doltliteChunkStoreDebugRegister(db);
+#endif
+  return rc;
 }
 
 #endif

--- a/src/prolly_check.c
+++ b/src/prolly_check.c
@@ -7,7 +7,58 @@
 #include "prolly_hash.h"
 #include "prolly_check.h"
 #include "chunk_store.h"
+#include <stdio.h>
 #include <string.h>
+
+static void checkHashToHex(const ProllyHash *pHash, char *zHex){
+  static const char zDig[] = "0123456789abcdef";
+  int i;
+  for(i=0; i<PROLLY_HASH_SIZE; i++){
+    zHex[i*2] = zDig[pHash->data[i] >> 4];
+    zHex[i*2+1] = zDig[pHash->data[i] & 0x0f];
+  }
+  zHex[PROLLY_HASH_SIZE*2] = 0;
+}
+
+int prollyCheckNodeChildrenPresent(
+  ChunkStore *pStore,
+  const u8 *pData,
+  int nData,
+  const char *zContext
+){
+  ProllyNode node;
+  ProllyHash parentHash;
+  int rc;
+  int i;
+
+  rc = prollyNodeParse(&node, pData, nData);
+  if( rc!=SQLITE_OK ) return rc;
+  if( node.level==0 ) return SQLITE_OK;
+
+  prollyHashCompute(pData, nData, &parentHash);
+  for(i=0; i<(int)node.nItems; i++){
+    ProllyHash childHash;
+    int has = 0;
+    prollyNodeChildHash(&node, i, &childHash);
+    rc = chunkStoreHas(pStore, &childHash, &has);
+    if( rc!=SQLITE_OK ) return rc;
+    if( !has ){
+      char zParent[PROLLY_HASH_SIZE*2+1];
+      char zChild[PROLLY_HASH_SIZE*2+1];
+      checkHashToHex(&parentHash, zParent);
+      checkHashToHex(&childHash, zChild);
+      fprintf(stderr,
+              "doltlite: prolly parent publish with missing child "
+              "context=%s parent=%s child=%s parent_level=%d "
+              "parent_items=%d child_index=%d\n",
+              zContext ? zContext : "unknown", zParent, zChild,
+              (int)node.level, (int)node.nItems, i);
+      return SQLITE_CORRUPT;
+    }
+  }
+
+  return SQLITE_OK;
+}
 
 static int checkSubtree(
   ChunkStore *pStore,

--- a/src/prolly_check.h
+++ b/src/prolly_check.h
@@ -17,6 +17,13 @@ int prollyCheckTree(
   char **pzErr
 );
 
+int prollyCheckNodeChildrenPresent(
+  ChunkStore *pStore,
+  const u8 *pData,
+  int nData,
+  const char *zContext
+);
+
 #else
 
 static SQLITE_INLINE int prollyCheckTree(
@@ -27,6 +34,16 @@ static SQLITE_INLINE int prollyCheckTree(
 ){
   (void)pStore; (void)pRoot; (void)flags;
   if( pzErr ) *pzErr = 0;
+  return SQLITE_OK;
+}
+
+static SQLITE_INLINE int prollyCheckNodeChildrenPresent(
+  ChunkStore *pStore,
+  const u8 *pData,
+  int nData,
+  const char *zContext
+){
+  (void)pStore; (void)pData; (void)nData; (void)zContext;
   return SQLITE_OK;
 }
 

--- a/src/prolly_chunker.c
+++ b/src/prolly_chunker.c
@@ -3,6 +3,7 @@
 
 #include "prolly_chunker.h"
 #include "prolly_cursor.h"
+#include "prolly_check.h"
 #include "prolly_xxhash.h"
 
 #include <stdio.h>
@@ -107,7 +108,11 @@ static int finishFlushLevel(ProllyChunker *ch, int level,
     return rc;
   }
 
-  rc = chunkStorePut(ch->pStore, pData, nData, pHash);
+  rc = prollyCheckNodeChildrenPresent(ch->pStore, pData, nData,
+                                      "prolly_chunker");
+  if( rc==SQLITE_OK ){
+    rc = chunkStorePut(ch->pStore, pData, nData, pHash);
+  }
   if( rc==SQLITE_OK && ch->pCache ){
     ProllyCacheEntry *pEntry;
     /* The cache adopts the finished node; copying it doubled the peak for

--- a/src/prolly_mutate.c
+++ b/src/prolly_mutate.c
@@ -417,12 +417,16 @@ static int appendNodeEntryToBuilder(
 }
 
 static int writeBuilderNode(ChunkStore *pStore, ProllyNodeBuilder *pBuilder,
-                            ProllyHash *pHash){
+                            ProllyHash *pHash, const char *zContext){
   u8 *pData = 0;
   int nData = 0;
   int rc = prollyNodeBuilderFinish(pBuilder, &pData, &nData);
   if( rc!=SQLITE_OK ) return rc;
-  rc = chunkStorePut(pStore, pData, nData, pHash);
+  rc = prollyCheckNodeChildrenPresent(pStore, pData, nData,
+                                      zContext);
+  if( rc==SQLITE_OK ){
+    rc = chunkStorePut(pStore, pData, nData, pHash);
+  }
   sqlite3_free(pData);
   return rc;
 }
@@ -440,6 +444,10 @@ static int finishAndWriteBuilderNode(ChunkStore *pStore,
   rc = prollyNodeParse(&node, pData, nData);
   if( rc==SQLITE_OK && !nodeHasSameChunkShape(&node, requireBoundary) ){
     rc = SQLITE_NOTFOUND;
+  }
+  if( rc==SQLITE_OK ){
+    rc = prollyCheckNodeChildrenPresent(pStore, pData, nData,
+                                        "prolly_mutate_shape");
   }
   if( rc==SQLITE_OK ){
     rc = chunkStorePut(pStore, pData, nData, pHash);
@@ -510,7 +518,8 @@ static int rewriteAncestorSpine(
         return rc;
       }
     }
-    rc = writeBuilderNode(pMut->pStore, &b, &parentHash);
+    rc = writeBuilderNode(pMut->pStore, &b, &parentHash,
+                          "rewriteAncestorSpine");
     prollyNodeBuilderFree(&b);
     if( rc!=SQLITE_OK ) return rc;
     *pChildHash = parentHash;
@@ -589,7 +598,8 @@ static int tryInsertOrReplaceSingleNoRechunk(ProllyMutator *pMut){
       }
     }
     if( sameSize ){
-      rc = writeBuilderNode(pMut->pStore, &b, &childHash);
+      rc = writeBuilderNode(pMut->pStore, &b, &childHash,
+                            "insertOrReplaceSingleNoRechunk.leaf");
     }else{
       rc = finishAndWriteBuilderNode(pMut->pStore, &b,
                                      !cursorLeafIsRightmost(&cur),
@@ -828,7 +838,8 @@ static int tryAppendSingleNoSplit(ProllyMutator *pMut){
         rc = prollyNodeBuilderAdd(&b, pNewKey, nNewKey,
                                   pEdit->pVal, pEdit->nVal);
         if( rc==SQLITE_OK ){
-          rc = writeBuilderNode(pMut->pStore, &b, &childHash);
+          rc = writeBuilderNode(pMut->pStore, &b, &childHash,
+                                "tryAppendSingleNoSplit.newLeaf");
         }
         prollyNodeBuilderFree(&b);
         if( rc!=SQLITE_OK ){
@@ -854,7 +865,8 @@ static int tryAppendSingleNoSplit(ProllyMutator *pMut){
           prollyCursorClose(&cur);
           return rc;
         }
-        rc = writeBuilderNode(pMut->pStore, &b, &childHash);
+        rc = writeBuilderNode(pMut->pStore, &b, &childHash,
+                              "tryAppendSingleNoSplit.newRoot");
         prollyNodeBuilderFree(&b);
         if( rc!=SQLITE_OK ){
           prollyCursorClose(&cur);
@@ -889,7 +901,8 @@ static int tryAppendSingleNoSplit(ProllyMutator *pMut){
         rc = prollyNodeBuilderAddWithCount(&b, pNewKey, nNewKey,
                                            childHash.data, PROLLY_HASH_SIZE, 1);
         if( rc==SQLITE_OK ){
-          rc = writeBuilderNode(pMut->pStore, &b, &parentHash);
+          rc = writeBuilderNode(pMut->pStore, &b, &parentHash,
+                                "tryAppendSingleNoSplit.parentAppend");
         }
         prollyNodeBuilderFree(&b);
         if( rc!=SQLITE_OK ){
@@ -920,7 +933,8 @@ static int tryAppendSingleNoSplit(ProllyMutator *pMut){
         rc = prollyNodeBuilderAdd(&b, pNewKey, nNewKey,
                                   pEdit->pVal, pEdit->nVal);
         if( rc==SQLITE_OK ){
-          rc = writeBuilderNode(pMut->pStore, &b, &childHash);
+          rc = writeBuilderNode(pMut->pStore, &b, &childHash,
+                                "tryAppendSingleNoSplit.leafAppend");
         }
         prollyNodeBuilderFree(&b);
         if( rc!=SQLITE_OK ){
@@ -965,7 +979,8 @@ static int tryAppendSingleNoSplit(ProllyMutator *pMut){
         return rc;
       }
     }
-    rc = writeBuilderNode(pMut->pStore, &b, &parentHash);
+    rc = writeBuilderNode(pMut->pStore, &b, &parentHash,
+                          "tryAppendSingleNoSplit.rewriteAncestor");
     prollyNodeBuilderFree(&b);
     if( rc!=SQLITE_OK ){
       prollyCursorClose(&cur);
@@ -1101,7 +1116,8 @@ static int replaceBatchLeafNoRechunk(
   }
 
   if( changed ){
-    rc = writeBuilderNode(pMut->pStore, &b, pHash);
+    rc = writeBuilderNode(pMut->pStore, &b, pHash,
+                          "replaceBatchLeafNoRechunk");
   }
   prollyNodeBuilderFree(&b);
   if( rc!=SQLITE_OK ) return rc;
@@ -1254,7 +1270,8 @@ static int replaceBatchNodeNoRechunk(
   }
 
   if( changed ){
-    rc = writeBuilderNode(pMut->pStore, &b, pHash);
+    rc = writeBuilderNode(pMut->pStore, &b, pHash,
+                          "replaceBatchNodeNoRechunk");
   }
   prollyNodeBuilderFree(&b);
   if( rc!=SQLITE_OK ) return rc;

--- a/test/doltlite_gc.sh
+++ b/test/doltlite_gc.sh
@@ -50,6 +50,19 @@ run_test "gc_multi_reopen_log" "SELECT count(*) FROM dolt_log;" "4" "$DB"
 
 db_rm "$DB"
 
+DB=/tmp/test_gc_102_byte_commit_$$.db; db_rm "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_commit('-A','-m','init','--author','beads <beads@local>');
+UPDATE t SET v='b' WHERE id=1;
+SELECT dolt_commit('-A','-m','gc update bead td-wisp-gmg4agp','--author','beads <beads@local>');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test_match "gc_102_byte_commit" "SELECT dolt_gc();" "chunks" "$DB"
+run_test "gc_102_byte_commit_integrity" "PRAGMA integrity_check;" "ok" "$DB"
+run_test "gc_102_byte_commit_log" "SELECT count(*) FROM dolt_log;" "3" "$DB"
+
+db_rm "$DB"
+
 DB=/tmp/test_gc_branch_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');

--- a/test/gc_concurrent_commit_stress.sh
+++ b/test/gc_concurrent_commit_stress.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+set -u
+set -o pipefail
+
+DOLTLITE="${1:-./doltlite}"
+TMPDIR=$(mktemp -d)
+trap "rm -rf $TMPDIR" EXIT
+
+DB="$TMPDIR/gc-concurrent.db"
+WORKERS="${DOLTLITE_GC_STRESS_WORKERS:-4}"
+OPS="${DOLTLITE_GC_STRESS_OPS:-40}"
+GC_OPS="${DOLTLITE_GC_STRESS_GC_OPS:-30}"
+FAILED=0
+
+run_sql() {
+  "$DOLTLITE" "$DB" "$1"
+}
+
+run_sql "
+PRAGMA busy_timeout=10000;
+CREATE TABLE t(id INTEGER PRIMARY KEY, worker INTEGER, step INTEGER, payload BLOB);
+INSERT INTO t VALUES(0, 0, 0, randomblob(16384));
+" >/dev/null || exit 1
+
+writer() {
+  local w="$1"
+  local i id
+  for i in $(seq 1 "$OPS"); do
+    id=$((w*100000+i))
+    if ! DOLTLITE_CHUNK_PENDING_DRAIN_LIMIT=4096 "$DOLTLITE" "$DB" "
+      PRAGMA busy_timeout=10000;
+      INSERT OR REPLACE INTO t VALUES($id, $w, $i, randomblob(16384));
+    " >/dev/null 2>"$TMPDIR/writer-$w-$i.err"; then
+      cat "$TMPDIR/writer-$w-$i.err"
+      exit 1
+    fi
+  done
+}
+
+gc_loop() {
+  local i out rc
+  for i in $(seq 1 "$GC_OPS"); do
+    out=$(DOLTLITE_CHUNK_PENDING_DRAIN_LIMIT=4096 "$DOLTLITE" "$DB" "
+      PRAGMA busy_timeout=10000;
+      SELECT dolt_gc();
+    " 2>&1)
+    rc=$?
+    if [ "$rc" -ne 0 ]; then
+      if echo "$out" | grep -qE 'database is locked|gc requires exclusive access|failed to acquire lock for gc'; then
+        sleep 0.05
+        continue
+      fi
+      echo "$out"
+      exit 1
+    fi
+    sleep 0.02
+  done
+}
+
+pids=""
+gc_loop &
+pids="$pids $!"
+for w in $(seq 1 "$WORKERS"); do
+  writer "$w" &
+  pids="$pids $!"
+done
+
+for pid in $pids; do
+  if ! wait "$pid"; then
+    FAILED=1
+  fi
+done
+
+if [ "$FAILED" -ne 0 ]; then
+  exit 1
+fi
+
+actual=$(run_sql "SELECT count(*) FROM t;" 2>&1) || {
+  echo "$actual"
+  exit 1
+}
+expected=$((WORKERS*OPS+1))
+if [ "$actual" != "$expected" ]; then
+  echo "wrong final row count: expected $expected got $actual"
+  exit 1
+fi
+
+integrity=$(run_sql "PRAGMA integrity_check;" 2>&1) || {
+  echo "$integrity"
+  exit 1
+}
+if [ "$integrity" != "ok" ]; then
+  echo "$integrity"
+  exit 1
+fi
+
+gc=$(run_sql "SELECT dolt_gc();" 2>&1) || {
+  echo "$gc"
+  exit 1
+}
+if echo "$gc" | grep -q 'gc mark phase failed'; then
+  echo "$gc"
+  exit 1
+fi
+
+echo "PASS gc concurrent commit stress"


### PR DESCRIPTION
## Summary
- add missing-hash context to `dolt_gc()` mark-phase failures, including the missing chunk hash, parent hash when known, traversal source, and rc
- add test-build chunk-store counters for reload-guard hits and pending WAL drains via `dolt_debug_chunk_store()`
- add a bounded concurrent CLI commit + GC stress test and run it in Ubuntu CI

## Notes
This is an instrumentation/stress-gate PR for #1547, not a claimed full fix. The goal is to make the next persisted dangling-chunk report point at the exact missing hash and traversal edge, while also increasing coverage around concurrent commits with forced pending drains.

## Testing
- `make doltlite`
- `bash test/doltlite_gc.sh ./doltlite`
- `bash test/gc_concurrent_commit_stress.sh ./doltlite`
- `./doltlite :memory: "SELECT dolt_gc();"`

`make testfixture` compiled through the amalgamation/test sources but failed at local link because this machine is missing `libtommath` (`ld: library 'tommath' not found`).
