### PR TITLE
Fix stale merged-cursor positioning over in-transaction mut-map edits

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -433,6 +433,7 @@ struct BtCursor {
   u8 mmActive;
   u8 mmPhysActive;
   u8 deferredTreeSeek;
+  u8 deferredMergedSeek;
 #define MERGE_SRC_TREE  0
 #define MERGE_SRC_MUT   1
 #define MERGE_SRC_BOTH  2
@@ -3024,6 +3025,7 @@ static void clearMergeCursorState(BtCursor *pCur){
   pCur->mmActive = 0;
   pCur->mmPhysActive = 0;
   pCur->deferredTreeSeek = 0;
+  pCur->deferredMergedSeek = 0;
   pCur->mergeSrc = MERGE_SRC_TREE;
 }
 
@@ -6967,9 +6969,65 @@ static int materializeDeferredTreeSeek(BtCursor *pCur, int dir){
   return rc;
 }
 
+/* Complete a table moveto whose merged repositioning was deferred: place
+** the merged cursor on the first live row >= cachedIntKey. When nothing at
+** or above the key survives, the cursor is left CURSOR_INVALID with the
+** merge state primed one past the end, so a backward step from here lands
+** on the last live row. */
+static int deferredMergedSeekPosition(BtCursor *pCur){
+  ProllyMutMapIter it;
+  int res = 0;
+  int rc;
+  i64 intKey;
+  pCur->deferredMergedSeek = 0;
+  intKey = pCur->cachedIntKey;
+  refreshCursorRoot(pCur);
+  rc = prollyCursorCheckInterrupt(pCur);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = prollyCursorSeekInt(&pCur->pCur, intKey, &res);
+  if( rc!=SQLITE_OK ) return rc;
+  if( res<0 && prollyCursorIsValid(&pCur->pCur) ){
+    rc = prollyCursorNext(&pCur->pCur);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+  prollyMutMapIterSeek(&it, pCur->pMutMap, 0, 0, intKey);
+  pCur->mmIdx = it.idx;
+  pCur->mmActive = 1;
+  return SQLITE_OK;
+}
+
+static int materializeDeferredMergedSeek(BtCursor *pCur){
+  int res = 0;
+  int rc;
+  if( !pCur->deferredMergedSeek ) return SQLITE_OK;
+  rc = deferredMergedSeekPosition(pCur);
+  if( rc!=SQLITE_OK ) return rc;
+  rc = mergeScan(pCur, 1, &res);
+  if( rc!=SQLITE_OK ) return rc;
+  if( res==0 ){
+    pCur->eState = CURSOR_VALID;
+    if( pCur->mergeSrc!=MERGE_SRC_MUT ){
+      cacheCurrentTreePayloadIfIntKey(pCur);
+    }
+  }else{
+    /* Nothing live at or above the key: leave the merge state primed one
+    ** past the end so a backward step lands on the last live row. */
+    pCur->mergeSrc = MERGE_SRC_BOTH;
+    pCur->eState = CURSOR_INVALID;
+  }
+  return SQLITE_OK;
+}
+
 static int mergeStepForward(BtCursor *pCur){
   int rc = SQLITE_OK;
   cursorNormalizeMmPhys(pCur);
+  if( pCur->deferredMergedSeek ){
+    /* The cursor conceptually sits on the hole left at cachedIntKey, so a
+    ** forward step means landing on the first live row above it. */
+    rc = materializeDeferredMergedSeek(pCur);
+    if( rc!=SQLITE_OK ) return rc;
+    return pCur->eState==CURSOR_VALID ? SQLITE_OK : SQLITE_DONE;
+  }
   rc = materializeDeferredTreeSeek(pCur, 1);
   if( rc!=SQLITE_OK ) return rc;
   if( pCur->mergeSrc==MERGE_SRC_TREE || pCur->mergeSrc==MERGE_SRC_BOTH ){
@@ -6986,6 +7044,14 @@ static int mergeStepForward(BtCursor *pCur){
 static int mergeStepBackward(BtCursor *pCur){
   int rc = SQLITE_OK;
   cursorNormalizeMmPhys(pCur);
+  if( pCur->deferredMergedSeek ){
+    /* The cursor conceptually sits on the hole left at cachedIntKey. Seed
+    ** both sides at the first entries >= the key so the normal backward
+    ** step below retreats onto the last live row underneath it. */
+    rc = deferredMergedSeekPosition(pCur);
+    if( rc!=SQLITE_OK ) return rc;
+    pCur->mergeSrc = MERGE_SRC_BOTH;
+  }
   rc = materializeDeferredTreeSeek(pCur, -1);
   if( rc!=SQLITE_OK ) return rc;
   if( pCur->mergeSrc==MERGE_SRC_TREE || pCur->mergeSrc==MERGE_SRC_BOTH ){
@@ -7358,6 +7424,14 @@ int sqlite3BtreePrevious(BtCursor *pCur, int flags){
 }
 
 static int prollyBtCursorEof(BtCursor *pCur){
+  if( pCur->deferredMergedSeek ){
+    int rc = materializeDeferredMergedSeek(pCur);
+    if( rc!=SQLITE_OK ){
+      pCur->eState = CURSOR_FAULT;
+      pCur->skipNext = rc;
+      return 1;
+    }
+  }
   return (pCur->eState!=CURSOR_VALID);
 }
 int sqlite3BtreeEof(BtCursor *pCur){
@@ -7418,9 +7492,7 @@ static int prollyBtCursorTableMoveto(
      && intKey > prollyMutMapEntryIntKey(
                   &pCur->pMutMap->aEntries[pCur->pMutMap->nEntries-1])
     ){
-      *pRes = 1;
-      pCur->eState = CURSOR_INVALID;
-      return SQLITE_OK;
+      goto table_moveto_deferred_miss;
     }
     if( canUseAppendSeekFloor
      && pTE
@@ -7432,30 +7504,66 @@ static int prollyBtCursorTableMoveto(
      && intKey > prollyMutMapEntryIntKey(
                   &pCur->pMutMap->aEntries[pCur->pMutMap->nEntries-1])
     ){
-      *pRes = 1;
-      pCur->eState = CURSOR_INVALID;
-      return SQLITE_OK;
+      goto table_moveto_deferred_miss;
     }
     rc = prollyMutMapFindRc(pCur->pMutMap, 0, 0, intKey, &pEntry);
     if( rc!=SQLITE_OK ) return rc;
-    if( pEntry ){
-      if( pEntry->op == PROLLY_EDIT_INSERT ){
-        if( pCur->isPinned ){
-          return SQLITE_CONSTRAINT_PINNED;
-        }
-        *pRes = 0;
-        setCursorToMutMapEntryPhys(pCur, (int)(pEntry - pCur->pMutMap->aEntries));
-        pCur->deferredTreeSeek = 1;
-        return SQLITE_OK;
-      } else {
+    if( pEntry && pEntry->op==PROLLY_EDIT_INSERT ){
+      if( pCur->isPinned ){
+        return SQLITE_CONSTRAINT_PINNED;
+      }
+      *pRes = 0;
+      setCursorToMutMapEntryPhys(pCur, (int)(pEntry - pCur->pMutMap->aEntries));
+      pCur->deferredTreeSeek = 1;
+      return SQLITE_OK;
+    }
 
-        *pRes = 1;
-        setCursorToMutMapMissingEntryPhys(
-            pCur, (int)(pEntry - pCur->pMutMap->aEntries));
-        return SQLITE_OK;
+    /* intKey is delete-masked or absent from the mut map. Probe the tree
+    ** for a live exact hit first so equality lookups stay on the fast
+    ** path. */
+    if( !pEntry ){
+      refreshCursorRoot(pCur);
+      if( !prollyHashIsEmpty(&pCur->pCur.root) ){
+        int res = 0;
+        rc = prollyCursorSeekInt(&pCur->pCur, intKey, &res);
+        if( rc!=SQLITE_OK ) return rc;
+        if( res==0 ){
+          *pRes = 0;
+          pCur->eState = CURSOR_VALID;
+          pCur->curFlags |= BTCF_ValidNKey;
+          pCur->cachedIntKey = intKey;
+          CLEAR_CACHED_PAYLOAD(pCur);
+          cacheCurrentTreePayloadIfIntKey(pCur);
+          return SQLITE_OK;
+        }
+        if( res<0 && canUseAppendSeekFloor && pTE ){
+          if( !pTE->appendSeekFloorValid
+           || prollyHashCompare(&pTE->root, &pTE->appendSeekRoot)!=0
+           || intKey < pTE->appendSeekFloor
+          ){
+            pTE->appendSeekFloor = intKey;
+          }
+          pTE->appendSeekRoot = pTE->root;
+          pTE->appendSeekFloorValid = 1;
+        }
       }
     }
 
+    /* No live exact match. Report "not found" now but defer the merged
+    ** repositioning (which materializes the mut-map order) until something
+    ** actually consumes the cursor position: equality probes on write paths
+    ** never do, while range seeks consume it immediately via Eof/Next/Prev.
+    ** The raw tree position must not leak out of this path: it can sit on a
+    ** delete-masked row, skip mut-map-only rows, or see an empty root when
+    ** every live row is in the mut map. */
+table_moveto_deferred_miss:
+    pCur->deferredMergedSeek = 1;
+    pCur->mmActive = 1;
+    pCur->cachedIntKey = intKey;
+    pCur->curFlags &= ~BTCF_ValidNKey;
+    pCur->eState = CURSOR_VALID;
+    *pRes = 1;
+    return SQLITE_OK;
   }
 
   if( rootIsEmpty ){
@@ -7936,18 +8044,17 @@ static int prollyBtCursorIndexMoveto(
     if( pCur->pCur.eState==PROLLY_CURSOR_VALID ){
       int iLevel = pCur->pCur.iLevel;
       ProllyCacheEntry *pLeaf = pCur->pCur.aLevel[iLevel].pEntry;
-      int seekIdx = pCur->pCur.aLevel[iLevel].idx;
+      int lo = pCur->pCur.aLevel[iLevel].idx;
       int nItems = pLeaf->node.nItems;
 
       int bestIdx = -1;
       int bestCmp = 0;
       {
-
-        int lo = seekIdx;
         u8 *pRecBuf = pCur->pMovetoRec;
         int nRecBufAlloc = pCur->nMovetoRecAlloc;
         int i;
 
+       for(;;){
         for( i = lo; i < nItems; i++ ){
           const u8 *pSK; int nSK;
           const u8 *pVal; int nVal;
@@ -7959,31 +8066,32 @@ static int prollyBtCursorIndexMoveto(
             int prefixCmp = memcmp(pSK, pSortKey, cmpLen);
             if( prefixCmp > 0 ){
               if( bestIdx < 0 ){
-                int isDeleted = 0;
                 if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
                   ProllyMutMapEntry *mmE = 0;
                   rc = prollyMutMapFindRc(pCur->pMutMap, pSK, nSK, 0, &mmE);
                   if( rc!=SQLITE_OK ) break;
-                  if( mmE && mmE->op==PROLLY_EDIT_DELETE ) isDeleted = 1;
-                }
-                if( !isDeleted ){
-                  bestIdx = i;
-                  if( nSeekKeyField>0 ){
-                    pIdxKey->eqSeen = 0;
-                    bestCmp = 1;
-                  }else{
-                    const u8 *pVal2; int nVal2;
-                    prollyNodeValue(&pLeaf->node, i, &pVal2, &nVal2);
-                    if( nVal2==0 ){
-                      rc = recordFromSortKeyBufferColl(
-                          pSK, nSK, pCur->pKeyInfo,
-                          &pRecBuf, &nRecBufAlloc, &nVal2);
-                      if( rc!=SQLITE_OK ) break;
-                      pVal2 = pRecBuf;
-                    }
-                    pIdxKey->eqSeen = 0;
-                    bestCmp = sqlite3VdbeRecordCompare(nVal2, pVal2, pIdxKey);
+                  if( mmE && mmE->op==PROLLY_EDIT_DELETE ){
+                    /* Delete-masked row past the seek key: the next live row
+                    ** is still the positioning answer, so keep scanning. */
+                    continue;
                   }
+                }
+                bestIdx = i;
+                if( nSeekKeyField>0 ){
+                  pIdxKey->eqSeen = 0;
+                  bestCmp = 1;
+                }else{
+                  const u8 *pVal2; int nVal2;
+                  prollyNodeValue(&pLeaf->node, i, &pVal2, &nVal2);
+                  if( nVal2==0 ){
+                    rc = recordFromSortKeyBufferColl(
+                        pSK, nSK, pCur->pKeyInfo,
+                        &pRecBuf, &nRecBufAlloc, &nVal2);
+                    if( rc!=SQLITE_OK ) break;
+                    pVal2 = pRecBuf;
+                  }
+                  pIdxKey->eqSeen = 0;
+                  bestCmp = sqlite3VdbeRecordCompare(nVal2, pVal2, pIdxKey);
                 }
               }
               break;
@@ -8047,6 +8155,19 @@ static int prollyBtCursorIndexMoveto(
             }
           }
         }
+        if( rc!=SQLITE_OK || treeFound || bestIdx>=0 ) break;
+        if( !(pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap)) ) break;
+        /* Everything from the seek point through the end of this leaf was
+        ** delete-masked; the first live row may sit in a later leaf. */
+        if( nItems>0 ) pCur->pCur.aLevel[pCur->pCur.iLevel].idx = nItems-1;
+        rc = prollyCursorNext(&pCur->pCur);
+        if( rc!=SQLITE_OK ) break;
+        if( pCur->pCur.eState!=PROLLY_CURSOR_VALID ) break;
+        iLevel = pCur->pCur.iLevel;
+        pLeaf = pCur->pCur.aLevel[iLevel].pEntry;
+        nItems = pLeaf->node.nItems;
+        lo = 0;
+       }
         pCur->pMovetoRec = pRecBuf;
         pCur->nMovetoRecAlloc = nRecBufAlloc;
         if( rc!=SQLITE_OK ) return rc;
@@ -8157,10 +8278,20 @@ static int prollyBtCursorIndexMoveto(
     int lastRes = 0;
     rc = prollyCursorLast(&pCur->pCur, &lastRes);
     if( rc!=SQLITE_OK ) return rc;
+    if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
+      /* No live row at or above the seek key on either side. Land on the
+      ** merged last row so delete-masked tree rows are never exposed and
+      ** mut-map-only rows are still reachable. */
+      pCur->mmActive = 1;
+      rc = mergeLast(pCur, &lastRes);
+      if( rc!=SQLITE_OK ) return rc;
+    }
     if( lastRes==0 ){
       pCur->eState = CURSOR_VALID;
       *pRes = -1;
-      cacheCurrentTreeStoredPayloadNonIntKey(pCur);
+      if( !pCur->mmActive || pCur->mergeSrc!=MERGE_SRC_MUT ){
+        cacheCurrentTreeStoredPayloadNonIntKey(pCur);
+      }
     } else {
       pCur->eState = CURSOR_INVALID;
       *pRes = -1;
@@ -8356,6 +8487,9 @@ prolly_idx_rowid_corruption:
 }
 
 static i64 prollyBtCursorIntegerKey(BtCursor *pCur){
+  if( pCur->deferredMergedSeek && materializeDeferredMergedSeek(pCur) ){
+    return 0;
+  }
   assert( pCur->eState==CURSOR_VALID );
   assert( pCur->curIntKey );
 
@@ -8488,6 +8622,9 @@ static int getCursorPayload(BtCursor *pCur, const u8 **ppData, int *pnData){
 static u32 prollyBtCursorPayloadSize(BtCursor *pCur){
   const u8 *pData;
   int nData;
+  if( pCur->deferredMergedSeek && materializeDeferredMergedSeek(pCur) ){
+    return 0;
+  }
   assert( pCur->eState==CURSOR_VALID );
   if( pCur->pCachedPayload && pCur->nCachedPayload > 0 ){
     return (u32)pCur->nCachedPayload;
@@ -8544,6 +8681,10 @@ static int prollyBtCursorPayload(BtCursor *pCur, u32 offset, u32 amt, void *pBuf
   int nData;
   int rc;
 
+  if( pCur->deferredMergedSeek ){
+    rc = materializeDeferredMergedSeek(pCur);
+    if( rc!=SQLITE_OK ) return rc;
+  }
   assert( pCur->eState==CURSOR_VALID );
   if( pCur->curIntKey
    && pCur->mmActive
@@ -8590,6 +8731,10 @@ static const void *prollyBtCursorPayloadFetch(BtCursor *pCur, u32 *pAmt){
   const u8 *pData;
   int nData;
 
+  if( pCur->deferredMergedSeek && materializeDeferredMergedSeek(pCur) ){
+    if( pAmt ) *pAmt = 0;
+    return 0;
+  }
   assert( pCur->eState==CURSOR_VALID );
   if( pCur->pCachedPayload && pCur->nCachedPayload > 0 ){
     if( pAmt ) *pAmt = (u32)pCur->nCachedPayload;
@@ -8662,6 +8807,7 @@ static int prollyBtCursorInsert(
   const u8 *pSortKey = 0;
   int nSortKey = 0;
   (void)seekResult;
+  pCur->deferredMergedSeek = 0;
 
   if( flags & BTREE_PREFORMAT ){
     return SQLITE_OK;
@@ -8999,6 +9145,8 @@ static int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
   i64 savedIntKey = 0;
   int hasSavedKey = 0;
 
+  pCur->deferredMergedSeek = 0;
+
   assert( pCur->pBtree->inTrans==TRANS_WRITE );
   assert( pCur->curFlags & BTCF_WriteFlag );
 
@@ -9155,6 +9303,20 @@ static int prollyBtCursorDelete(BtCursor *pCur, u8 flags){
          && ((flags & BTREE_AUXDELETE) || cursorIsShadowTableRoot(pCur)) ){
           pCur->cachedIntKey = iKey;
           pCur->curFlags |= BTCF_DeleteKey;
+        }else if( !pCur->curIntKey && hasSavedKey && nKey>0 ){
+          /* Park the cursor on the mut-map tombstone of the deleted key so
+          ** the next step resumes the scan from there. Re-seeding from a
+          ** stale or unset position can restart the scan at an unrelated
+          ** row, making a delete loop re-visit (and delete) live rows that
+          ** never matched its constraint. */
+          ProllyMutMapEntry *pEntry = 0;
+          rc = prollyMutMapFindRc(pCur->pMutMap, pKey, nKey, 0, &pEntry);
+          if( rc!=SQLITE_OK ) goto delete_cleanup;
+          if( pEntry ){
+            setCursorToMutMapMissingEntryPhys(
+                pCur, (int)(pEntry - pCur->pMutMap->aEntries));
+            pCur->deferredTreeSeek = 1;
+          }
         }
         pCur->eState = CURSOR_SKIPNEXT;
         pCur->skipNext = 0;

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -6996,6 +6996,8 @@ static int deferredMergedSeekPosition(BtCursor *pCur){
   return SQLITE_OK;
 }
 
+/* Complete a deferred merged seek forward: land on the first live row above
+** cachedIntKey (the key itself is known dead). */
 static int materializeDeferredMergedSeek(BtCursor *pCur){
   int res = 0;
   int rc;
@@ -7013,6 +7015,38 @@ static int materializeDeferredMergedSeek(BtCursor *pCur){
     /* Nothing live at or above the key: leave the merge state primed one
     ** past the end so a backward step lands on the last live row. */
     pCur->mergeSrc = MERGE_SRC_BOTH;
+    pCur->eState = CURSOR_INVALID;
+  }
+  return SQLITE_OK;
+}
+
+/* Complete a deferred merged seek backward: land on the last live row below
+** cachedIntKey, matching the res<0 contract the deferred moveto reported.
+** Used by the passive consumers (Eof and the payload/rowid readers), which
+** read the current position rather than stepping. */
+static int materializeDeferredMergedSeekBackward(BtCursor *pCur){
+  int res = 0;
+  int rc;
+  if( !pCur->deferredMergedSeek ) return SQLITE_OK;
+  rc = deferredMergedSeekPosition(pCur);
+  if( rc!=SQLITE_OK ) return rc;
+  pCur->mergeSrc = MERGE_SRC_BOTH;
+  if( pCur->pCur.eState==PROLLY_CURSOR_VALID ){
+    rc = advanceTreeCursor(pCur, -1);
+    if( rc!=SQLITE_OK ) return rc;
+  }else if( pCur->pCur.eState==PROLLY_CURSOR_EOF ){
+    rc = prollyCursorPrev(&pCur->pCur);
+    if( rc!=SQLITE_OK ) return rc;
+  }
+  pCur->mmIdx--;
+  rc = mergeScan(pCur, -1, &res);
+  if( rc!=SQLITE_OK ) return rc;
+  if( res==0 ){
+    pCur->eState = CURSOR_VALID;
+    if( pCur->mergeSrc!=MERGE_SRC_MUT ){
+      cacheCurrentTreePayloadIfIntKey(pCur);
+    }
+  }else{
     pCur->eState = CURSOR_INVALID;
   }
   return SQLITE_OK;
@@ -7425,7 +7459,7 @@ int sqlite3BtreePrevious(BtCursor *pCur, int flags){
 
 static int prollyBtCursorEof(BtCursor *pCur){
   if( pCur->deferredMergedSeek ){
-    int rc = materializeDeferredMergedSeek(pCur);
+    int rc = materializeDeferredMergedSeekBackward(pCur);
     if( rc!=SQLITE_OK ){
       pCur->eState = CURSOR_FAULT;
       pCur->skipNext = rc;
@@ -7555,14 +7589,20 @@ static int prollyBtCursorTableMoveto(
     ** never do, while range seeks consume it immediately via Eof/Next/Prev.
     ** The raw tree position must not leak out of this path: it can sit on a
     ** delete-masked row, skip mut-map-only rows, or see an empty root when
-    ** every live row is in the mut map. */
+    ** every live row is in the mut map.
+    **
+    ** The result must be -1, not +1: the VDBE treats res>0 as "the cursor
+    ** sits on a row above the key" and reads it with no Eof check, which a
+    ** deferred position cannot honor when nothing at or above the key
+    ** survives. With res<0 every consumer either steps forward through the
+    ** merge machinery or checks Eof before reading. */
 table_moveto_deferred_miss:
     pCur->deferredMergedSeek = 1;
     pCur->mmActive = 1;
     pCur->cachedIntKey = intKey;
     pCur->curFlags &= ~BTCF_ValidNKey;
     pCur->eState = CURSOR_VALID;
-    *pRes = 1;
+    *pRes = -1;
     return SQLITE_OK;
   }
 
@@ -8505,7 +8545,9 @@ prolly_idx_rowid_corruption:
 }
 
 static i64 prollyBtCursorIntegerKey(BtCursor *pCur){
-  if( pCur->deferredMergedSeek && materializeDeferredMergedSeek(pCur) ){
+  if( pCur->deferredMergedSeek
+   && (materializeDeferredMergedSeekBackward(pCur)
+       || pCur->eState!=CURSOR_VALID) ){
     return 0;
   }
   assert( pCur->eState==CURSOR_VALID );
@@ -8640,7 +8682,9 @@ static int getCursorPayload(BtCursor *pCur, const u8 **ppData, int *pnData){
 static u32 prollyBtCursorPayloadSize(BtCursor *pCur){
   const u8 *pData;
   int nData;
-  if( pCur->deferredMergedSeek && materializeDeferredMergedSeek(pCur) ){
+  if( pCur->deferredMergedSeek
+   && (materializeDeferredMergedSeekBackward(pCur)
+       || pCur->eState!=CURSOR_VALID) ){
     return 0;
   }
   assert( pCur->eState==CURSOR_VALID );
@@ -8700,8 +8744,9 @@ static int prollyBtCursorPayload(BtCursor *pCur, u32 offset, u32 amt, void *pBuf
   int rc;
 
   if( pCur->deferredMergedSeek ){
-    rc = materializeDeferredMergedSeek(pCur);
+    rc = materializeDeferredMergedSeekBackward(pCur);
     if( rc!=SQLITE_OK ) return rc;
+    if( pCur->eState!=CURSOR_VALID ) return SQLITE_ABORT;
   }
   assert( pCur->eState==CURSOR_VALID );
   if( pCur->curIntKey
@@ -8749,7 +8794,9 @@ static const void *prollyBtCursorPayloadFetch(BtCursor *pCur, u32 *pAmt){
   const u8 *pData;
   int nData;
 
-  if( pCur->deferredMergedSeek && materializeDeferredMergedSeek(pCur) ){
+  if( pCur->deferredMergedSeek
+   && (materializeDeferredMergedSeekBackward(pCur)
+       || pCur->eState!=CURSOR_VALID) ){
     if( pAmt ) *pAmt = 0;
     return 0;
   }

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -8268,6 +8268,24 @@ static int prollyBtCursorIndexMoveto(
     }
     if( treeFound ){
       *pRes = treeCmp;
+      /* A prefix seek can land on a tree row whose value was overwritten in
+      ** this transaction (full-key seeks catch this in the exact-match fast
+      ** path above). Serve the row from the mut map, or the caller reads the
+      ** stale tree payload. */
+      if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
+        const u8 *pTreeKey = 0;
+        int nTreeKey = 0;
+        ProllyMutMapEntry *mmE = 0;
+        prollyCursorKey(&pCur->pCur, &pTreeKey, &nTreeKey);
+        rc = prollyMutMapFindRc(pCur->pMutMap, pTreeKey, nTreeKey, 0, &mmE);
+        if( rc!=SQLITE_OK ) return rc;
+        if( mmE && mmE->op==PROLLY_EDIT_INSERT ){
+          setCursorToMutMapEntryPhys(
+              pCur, (int)(mmE - pCur->pMutMap->aEntries));
+          pCur->deferredTreeSeek = 1;
+          return SQLITE_OK;
+        }
+      }
       pCur->eState = CURSOR_VALID;
       cacheCurrentTreeStoredPayloadNonIntKey(pCur);
       return SQLITE_OK;

--- a/test/doltlite_txn_seek_visibility.sh
+++ b/test/doltlite_txn_seek_visibility.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+
+source "$(dirname "$0")/lib/doltlite_test_common.sh"
+
+db_rm() {
+  rm -rf "$1" "${1}-wal"
+}
+
+echo "=== In-transaction seek visibility over mut-map edits ==="
+echo ""
+
+DB=/tmp/test_txn_seek_visibility_$$.db; db_rm "$DB"
+
+run_test "intkey_range_seek_skips_deleted_finds_insert" \
+  "CREATE TABLE d(k INTEGER PRIMARY KEY, v);
+   INSERT INTO d VALUES (5, 'old');
+   BEGIN;
+   DELETE FROM d WHERE k = 5;
+   INSERT INTO d VALUES (3, 'new');
+   SELECT k FROM d WHERE k >= 0 ORDER BY k;
+   SELECT k FROM d WHERE k <= 4 ORDER BY k DESC;
+   SELECT max(k) FROM d WHERE k <= 4;
+   ROLLBACK;" \
+  "3
+3
+3" \
+  "$DB"
+
+db_rm "$DB"
+
+run_test "intkey_truncate_reinsert_range_seeks" \
+  "CREATE TABLE d(k INTEGER PRIMARY KEY, v);
+   INSERT INTO d VALUES (5, 'old');
+   BEGIN;
+   DELETE FROM d;
+   INSERT INTO d VALUES (3, 'new');
+   SELECT k FROM d WHERE k >= 0 ORDER BY k;
+   SELECT k FROM d WHERE k <= 4 ORDER BY k DESC;
+   SELECT max(k) FROM d WHERE k BETWEEN 0 AND 10;
+   SELECT max(k) FROM d WHERE k <= 4;
+   ROLLBACK;" \
+  "3
+3
+3
+3" \
+  "$DB"
+
+db_rm "$DB"
+
+run_test "intkey_uncommitted_insert_visible_to_range_seeks" \
+  "CREATE TABLE t(k INTEGER PRIMARY KEY, v);
+   INSERT INTO t VALUES (10, 'old');
+   BEGIN;
+   INSERT INTO t VALUES (7, 'new');
+   SELECT min(k) FROM t WHERE k >= 5;
+   SELECT k FROM t WHERE k >= 5 ORDER BY k;
+   SELECT max(k) FROM t WHERE k <= 8;
+   ROLLBACK;" \
+  "7
+7
+10
+7" \
+  "$DB"
+
+db_rm "$DB"
+
+run_test "intkey_seek_above_deleted_key" \
+  "CREATE TABLE t(k INTEGER PRIMARY KEY, v);
+   INSERT INTO t VALUES (5, 'a'), (7, 'b');
+   BEGIN;
+   DELETE FROM t WHERE k = 5;
+   SELECT min(k) FROM t WHERE k >= 5;
+   ROLLBACK;" \
+  "7" \
+  "$DB"
+
+db_rm "$DB"
+
+run_test "composite_pk_prefix_max_over_masked_rows" \
+  "CREATE TABLE e(a INTEGER, b INTEGER, PRIMARY KEY(a, b)) WITHOUT ROWID;
+   INSERT INTO e VALUES (5, 1);
+   BEGIN;
+   DELETE FROM e;
+   INSERT INTO e VALUES (3, 1);
+   SELECT max(a) FROM e WHERE a BETWEEN 0 AND 10;
+   SELECT max(b) FROM e WHERE a = 3;
+   ROLLBACK;" \
+  "3
+1" \
+  "$DB"
+
+db_rm "$DB"
+
+run_test "composite_pk_segdir_shape_max_reads" \
+  "CREATE TABLE d(level INTEGER, idx INTEGER, val, PRIMARY KEY(level, idx));
+   INSERT INTO d VALUES (1,0,'old');
+   INSERT INTO d SELECT 0, value, 'old' FROM generate_series(0,15);
+   INSERT INTO d VALUES (1025,0,'old');
+   INSERT INTO d SELECT 1024, value, 'old' FROM generate_series(0,15);
+   BEGIN;
+   DELETE FROM d;
+   INSERT INTO d SELECT 0, value, 'new' FROM generate_series(0,15);
+   SELECT coalesce((SELECT max(idx) FROM d WHERE level = 1) + 1, 0);
+   SELECT max(level) FROM d WHERE level BETWEEN 0 AND 1023;
+   INSERT INTO d SELECT 1024, value, 'new' FROM generate_series(0,15);
+   SELECT max(level) FROM d WHERE level BETWEEN 1024 AND 2047;
+   SELECT coalesce((SELECT max(idx) FROM d WHERE level = 1025) + 1, 0);
+   ROLLBACK;" \
+  "0
+0
+1024
+0" \
+  "$DB"
+
+db_rm "$DB"
+
+run_test "ranged_delete_spares_rows_outside_range" \
+  "CREATE TABLE d(a INTEGER, b INTEGER, c, PRIMARY KEY(a, b));
+   INSERT INTO d VALUES (0,0,'x'),(0,1,'x'),(2,0,'x'),(2,1,'x');
+   BEGIN;
+   DELETE FROM d;
+   INSERT INTO d VALUES (0,0,'x'),(0,1,'x'),(2,0,'x'),(2,1,'x');
+   DELETE FROM d WHERE a = 0;
+   INSERT INTO d VALUES (1, 0, 'x');
+   DELETE FROM d WHERE a = 2;
+   SELECT a, b FROM d;
+   ROLLBACK;" \
+  "1|0" \
+  "$DB"
+
+db_rm "$DB"
+
+run_test "fts4_langid_rebuild_preserves_partitions" \
+  "CREATE VIRTUAL TABLE t2 USING fts4(x, languageid=l);
+   INSERT INTO t2(docid, x, l) SELECT value, 'w' || value || ' common', value % 2 FROM generate_series(0,39);
+   INSERT INTO t2(t2) VALUES('rebuild');
+   SELECT count(*) FROM t2 WHERE t2 MATCH 'common' AND l = 0;
+   SELECT count(*) FROM t2 WHERE t2 MATCH 'common' AND l = 1;" \
+  "20
+20" \
+  "$DB"
+
+db_rm "$DB"
+
+dltest_finish

--- a/test/doltlite_txn_seek_visibility.sh
+++ b/test/doltlite_txn_seek_visibility.sh
@@ -130,6 +130,19 @@ run_test "ranged_delete_spares_rows_outside_range" \
 
 db_rm "$DB"
 
+run_test "prefix_seek_sees_updated_row_value" \
+  "CREATE TABLE d(a INTEGER, b INTEGER, v, PRIMARY KEY(a,b));
+   INSERT INTO d VALUES (1,0,'old'),(1,1,'old2'),(2,0,'oldx');
+   BEGIN;
+   UPDATE d SET v='new' WHERE a=1 AND b=0;
+   SELECT b, v FROM d WHERE a=1;
+   ROLLBACK;" \
+  "0|new
+1|old2" \
+  "$DB"
+
+db_rm "$DB"
+
 run_test "fts4_langid_rebuild_preserves_partitions" \
   "CREATE VIRTUAL TABLE t2 USING fts4(x, languageid=l);
    INSERT INTO t2(docid, x, l) SELECT value, 'w' || value || ' common', value % 2 FROM generate_series(0,39);

--- a/test/doltlite_txn_seek_visibility.sh
+++ b/test/doltlite_txn_seek_visibility.sh
@@ -130,6 +130,20 @@ run_test "ranged_delete_spares_rows_outside_range" \
 
 db_rm "$DB"
 
+run_test "no_phantom_row_after_all_rows_deleted" \
+  "CREATE TABLE d(k INTEGER PRIMARY KEY, v);
+   INSERT INTO d VALUES (5, 'x');
+   BEGIN;
+   DELETE FROM d WHERE k = 5;
+   SELECT count(*) FROM d WHERE k >= 0;
+   SELECT coalesce(max(k), 'none') FROM d WHERE k >= 0;
+   ROLLBACK;" \
+  "0
+none" \
+  "$DB"
+
+db_rm "$DB"
+
 run_test "prefix_seek_sees_updated_row_value" \
   "CREATE TABLE d(a INTEGER, b INTEGER, v, PRIMARY KEY(a,b));
    INSERT INTO d VALUES (1,0,'old'),(1,1,'old2'),(2,0,'oldx');

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -4183,105 +4183,8 @@ fts4growth fts4growth-6.5
 # stale max(idx) reads make REPLACE INTO %_segdir overwrite live
 # segments, losing most documents from each language partition (queries
 # return one docid instead of 31).
-fts4langid fts4langid-2.3.1.0
-fts4langid fts4langid-2.3.1.1
-fts4langid fts4langid-2.3.1.2
-fts4langid fts4langid-2.3.1.3
-fts4langid fts4langid-2.3.1.4
-fts4langid fts4langid-2.3.1.5
-fts4langid fts4langid-2.3.1.6
-fts4langid fts4langid-2.3.1.7
-fts4langid fts4langid-2.3.2.0
-fts4langid fts4langid-2.3.2.1
-fts4langid fts4langid-2.3.2.2
-fts4langid fts4langid-2.3.2.3
-fts4langid fts4langid-2.3.2.4
-fts4langid fts4langid-2.3.2.5
-fts4langid fts4langid-2.3.2.6
-fts4langid fts4langid-2.3.2.7
-fts4langid fts4langid-2.3.3.0
-fts4langid fts4langid-2.3.3.1
-fts4langid fts4langid-2.3.3.2
-fts4langid fts4langid-2.3.3.3
-fts4langid fts4langid-2.3.3.4
-fts4langid fts4langid-2.3.3.5
-fts4langid fts4langid-2.3.3.6
-fts4langid fts4langid-2.3.3.7
-fts4langid fts4langid-2.3.4.0
-fts4langid fts4langid-2.3.4.1
-fts4langid fts4langid-2.3.4.2
-fts4langid fts4langid-2.3.4.3
-fts4langid fts4langid-2.3.4.4
-fts4langid fts4langid-2.3.4.5
-fts4langid fts4langid-2.3.4.6
-fts4langid fts4langid-2.3.4.7
-fts4langid fts4langid-3.1.1.0
-fts4langid fts4langid-3.1.1.1
-fts4langid fts4langid-3.1.1.2
-fts4langid fts4langid-3.1.1.3
-fts4langid fts4langid-3.1.1.4
-fts4langid fts4langid-3.1.1.5
-fts4langid fts4langid-3.1.1.6
-fts4langid fts4langid-3.1.1.7
-fts4langid fts4langid-3.1.2.0
-fts4langid fts4langid-3.1.2.1
-fts4langid fts4langid-3.1.2.2
-fts4langid fts4langid-3.1.2.3
-fts4langid fts4langid-3.1.2.4
-fts4langid fts4langid-3.1.2.5
-fts4langid fts4langid-3.1.2.6
-fts4langid fts4langid-3.1.2.7
-fts4langid fts4langid-3.1.3.0
-fts4langid fts4langid-3.1.3.1
-fts4langid fts4langid-3.1.3.2
-fts4langid fts4langid-3.1.3.3
-fts4langid fts4langid-3.1.3.4
-fts4langid fts4langid-3.1.3.5
-fts4langid fts4langid-3.1.3.6
-fts4langid fts4langid-3.1.3.7
-fts4langid fts4langid-3.1.4.0
-fts4langid fts4langid-3.1.4.1
-fts4langid fts4langid-3.1.4.2
-fts4langid fts4langid-3.1.4.3
-fts4langid fts4langid-3.1.4.4
-fts4langid fts4langid-3.1.4.5
-fts4langid fts4langid-3.1.4.6
-fts4langid fts4langid-3.1.4.7
-fts4langid fts4langid-3.3.1.0
-fts4langid fts4langid-3.3.1.1
-fts4langid fts4langid-3.3.1.2
-fts4langid fts4langid-3.3.1.3
-fts4langid fts4langid-3.3.1.4
-fts4langid fts4langid-3.3.1.5
-fts4langid fts4langid-3.3.1.6
-fts4langid fts4langid-3.3.1.7
-fts4langid fts4langid-3.3.2.0
-fts4langid fts4langid-3.3.2.1
-fts4langid fts4langid-3.3.2.2
-fts4langid fts4langid-3.3.2.3
-fts4langid fts4langid-3.3.2.4
-fts4langid fts4langid-3.3.2.5
-fts4langid fts4langid-3.3.2.6
-fts4langid fts4langid-3.3.2.7
-fts4langid fts4langid-3.3.3.0
-fts4langid fts4langid-3.3.3.1
-fts4langid fts4langid-3.3.3.2
-fts4langid fts4langid-3.3.3.3
-fts4langid fts4langid-3.3.3.4
-fts4langid fts4langid-3.3.3.5
-fts4langid fts4langid-3.3.3.6
-fts4langid fts4langid-3.3.3.7
-fts4langid fts4langid-3.3.4.0
-fts4langid fts4langid-3.3.4.1
-fts4langid fts4langid-3.3.4.2
-fts4langid fts4langid-3.3.4.3
-fts4langid fts4langid-3.3.4.4
-fts4langid fts4langid-3.3.4.5
-fts4langid fts4langid-3.3.4.6
-fts4langid fts4langid-3.3.4.7
 # in-transaction langid UPDATE then integrity-check: false malformed
 # report (same stale shadow-read family)
-fts4langid fts4langid-6.1
 
 # REAL BUG pinned (issue: stale shadow-table reads during multi-write fts
 # statements corrupt automerge bookkeeping): automerge after a multi-row
@@ -4297,8 +4200,6 @@ fts4onepass fts4onepass-1.1.3
 # REAL BUG pinned (issue: stale shadow-table reads during multi-write fts
 # statements): onepass-or-not UPDATE/DELETE over MATCH with intra-
 # statement flushes errors "database disk image is malformed"
-fts4onepass fts4onepass-3.2.4.c
-fts4onepass fts4onepass-3.2.5.c
 
 # ── incrblob2 ──
 # Shared-cache table-level locking does not exist in doltlite. A blob

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -4189,8 +4189,6 @@ fts4growth fts4growth-6.5
 # REAL BUG pinned (issue: stale shadow-table reads during multi-write fts
 # statements corrupt automerge bookkeeping): automerge after a multi-row
 # DELETE leaves wrong segdir level/idx layout and malformed index reports
-fts4merge4 fts4merge4-2.2.1.1
-fts4merge4 fts4merge4-2.2.1.2
 
 # sql_uses_stmt instrumentation: doltlite deliberately opens statement
 # scope for every vtab write (hasVUpdate), upstream's onepass docid=?

--- a/test/lib/doltlite_suite_manifest.sh
+++ b/test/lib/doltlite_suite_manifest.sh
@@ -81,6 +81,7 @@ doltlite_branch_edge.sh
 doltlite_diff_alter.sh
 doltlite_gc_scale.sh
 doltlite_index_prefix.sh
+doltlite_txn_seek_visibility.sh
 doltlite_row_count_estimate.sh
 doltlite_regression_test_c.sh
 review_regression_test.sh


### PR DESCRIPTION
Fixes #1551, fixes #1552, fixes #1553, fixes #1554.

## Root cause

Cursor positioning and payload reads after a seek consulted only the tree side of the merged (tree + mut-map) cursor. Five holes, all one family:

1. **Intkey moveto miss** did a raw tree seek: it could expose a delete-masked tree row, report an in-transaction-truncated table as empty, and made uncommitted inserts invisible to range seeks (`SELECT min(k) FROM t WHERE k>=5` missed an uncommitted `7` and returned a committed `10`).
2. The **append-sorted fast paths** returned `CURSOR_INVALID`, which made `SeekLE → Previous` report not-found even when live mut-map rows existed below the key.
3. **Index moveto**'s leaf scan stopped at the first delete-masked greater row and never crossed leaf boundaries over masked runs; its final fallback landed on the *raw tree* last row, invisible to mut-map-only rows. This is what fed FTS4 stale `max(idx)` / `max(level)` segdir reads.
4. **Non-intkey delete with SAVEPOSITION** left no resumable position (`mmActive=0`, no saved key), so the next step re-seeded the scan from the first live row of the table — a ranged `DELETE WHERE a=2` could re-visit and **delete rows outside its constraint** (this is what destroyed FTS langid segdir rows during rebuild).
5. **Prefix seeks landing on a tree row cached the stale tree payload** even when the same transaction had overwritten the row (full-key seeks catch this in the exact-match fast path). FTS4 `automerge=N` tripped this: after chomping consumed input blocks, re-reading the segment list returned a stale `start_block`, and the merge followed it into just-deleted `%_segments` rows, failing the commit with `SQLITE_CORRUPT` (#1553).

## Fix

- Table moveto misses now **defer** the merged repositioning to the first consumer of the cursor position (`Eof`/`Next`/`Prev`/payload reads). Equality probes on write paths (`OP_NotExists` → jump) never consume it, so bulk-write transactions do not pay the mut-map ordering cost — measured flat vs master on 100k random-key and sequential single-txn inserts, and interleaved REPLACE loops (per the mut-map perf concern).
- Index moveto keeps scanning past delete-masked runs across leaf boundaries and falls back to the merged last row.
- Index moveto landings on tree rows check the mut map (O(1) hash) for a same-key overwrite and serve the row from the mut side when present.
- Non-intkey SAVEPOSITION deletes park the cursor on the mut-map tombstone of the deleted key with a deferred tree reseek, so delete loops resume exactly where they were.

## Testing

- New `test/doltlite_txn_seek_visibility.sh` (registered in the suite manifest): 9 native cases distilled from the bug family, including the pure-SQL 12-line ranged-delete repro, the prefix-seek stale-payload repro, and an FTS4 langid rebuild case. **0/8 pass on master (9th case added later, also fails on master), all pass with the fix.**
- `fts4langid`: 309 passing, 0 failures (was 97) — removed all 97 divergence entries. #1552's repro returns `ok`.
- `fts4merge4-2.2.1.1`/`2.2.1.2` fixed — removed both entries. The #1553 40-batch `automerge=2` repro now produces a **byte-identical per-batch `%_segdir` + `%_stat` trace to stock SQLite** (previously failed commits with `database disk image is malformed` from batch 36 on).
- `fts4onepass-3.2.4.c` / `3.2.5.c` fixed — removed both entries (1.1.2/1.1.3 remain, instrumentation-only per #1554). `fts4merge5` passes.
- Full FTS sweep (langid/merge/merge2/merge3/merge4/merge5/onepass/growth/content/aa/check/docid/incr): 7107 passing, remaining known divergences unchanged (growth/content — pre-existing, outside this family).
- Core testfixture subset (select/where/delete/update/insert/index/savepoint/trans/intpkey/rowid): green. `correctness_test.sh`: 44/44. index-prefix/unique-index-delete/nocase-index/record-format suites: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)