### PR TITLE
Fix GC classification of commit chunks

### DIFF
--- a/src/doltlite_chunk_walk.c
+++ b/src/doltlite_chunk_walk.c
@@ -55,7 +55,8 @@ DoltliteChunkType doltliteClassifyChunk(const u8 *data, int nData){
   ** the catalog check reads their magic bytes as an absurd table count.
   ** Both are leaves: they embed whole row payloads and reference no other
   ** chunks. */
-  if( nData >= 6 && data[0]=='D' && data[1]=='L' && data[2]=='C' ){
+  if( nData >= 6
+   && data[0]=='D' && data[1]=='L' && data[2]=='C' && data[3]!='T' ){
     return CHUNK_CONFLICTS;
   }
   if( nData >= 6 && data[0]=='D' && data[1]=='C' && data[2]=='V' ){

--- a/src/doltlite_chunk_walk.c
+++ b/src/doltlite_chunk_walk.c
@@ -50,6 +50,18 @@ DoltliteChunkType doltliteClassifyChunk(const u8 *data, int nData){
     return CHUNK_COMMIT;
   }
 
+  /* The conflicts ("DLC") and constraint-violations ("DCV") framed blobs
+  ** lead with 'D' == CATALOG_FORMAT_V3, so they must be recognized before
+  ** the catalog check reads their magic bytes as an absurd table count.
+  ** Both are leaves: they embed whole row payloads and reference no other
+  ** chunks. */
+  if( nData >= 6 && data[0]=='D' && data[1]=='L' && data[2]=='C' ){
+    return CHUNK_CONFLICTS;
+  }
+  if( nData >= 6 && data[0]=='D' && data[1]=='C' && data[2]=='V' ){
+    return CHUNK_CONSTRAINT_VIOLATIONS;
+  }
+
   if( (data[0] == WS_FORMAT_VERSION_V5 && nData == WS_TOTAL_SIZE)
    || (data[0] == WS_FORMAT_VERSION_V4 && nData == WS_TOTAL_SIZE_V4)
    || (data[0] == WS_FORMAT_VERSION_V3 && nData == WS_TOTAL_SIZE_V3)
@@ -387,6 +399,9 @@ int doltliteEnumerateChunkChildren(
       return enumerateWorkingSetChildren(data, nData, xChild, ctx);
     case CHUNK_REFS:
       return enumerateRefsChildren(data, nData, xChild, ctx);
+    case CHUNK_CONFLICTS:
+    case CHUNK_CONSTRAINT_VIOLATIONS:
+      return SQLITE_OK;
     case CHUNK_UNKNOWN:
     default:
       return SQLITE_CORRUPT;

--- a/src/doltlite_chunk_walk.c
+++ b/src/doltlite_chunk_walk.c
@@ -10,6 +10,31 @@
 
 #include <string.h>
 
+static int isCommitChunk(const u8 *data, int nData){
+  const u8 *p = data;
+  const u8 *pEnd = data + nData;
+  int nPar;
+  int i;
+
+  if( nData < 1 || *p++ != DOLTLITE_COMMIT_V2 ) return 0;
+  if( p >= pEnd ) return 0;
+  nPar = *p++;
+  if( nPar > DOLTLITE_MAX_PARENTS ) return 0;
+  if( pEnd - p < nPar*PROLLY_HASH_SIZE + PROLLY_HASH_SIZE + 8 + 6 ){
+    return 0;
+  }
+  p += nPar*PROLLY_HASH_SIZE + PROLLY_HASH_SIZE + 8;
+  for(i=0; i<3; i++){
+    int n;
+    if( pEnd - p < 2 ) return 0;
+    n = p[0] | (p[1]<<8);
+    p += 2;
+    if( pEnd - p < n ) return 0;
+    p += n;
+  }
+  return p == pEnd;
+}
+
 DoltliteChunkType doltliteClassifyChunk(const u8 *data, int nData){
   u32 m;
 
@@ -19,6 +44,10 @@ DoltliteChunkType doltliteClassifyChunk(const u8 *data, int nData){
       ((u32)data[2]<<16) | ((u32)data[3]<<24);
   if( m == PROLLY_NODE_MAGIC && nData >= 8 ){
     return CHUNK_PROLLY_NODE;
+  }
+
+  if( isCommitChunk(data, nData) ){
+    return CHUNK_COMMIT;
   }
 
   if( (data[0] == WS_FORMAT_VERSION_V5 && nData == WS_TOTAL_SIZE)
@@ -33,10 +62,6 @@ DoltliteChunkType doltliteClassifyChunk(const u8 *data, int nData){
     if( catalogParseHeaderEx(data, nData, &iFormat, &nTables, &pEntries) ){
       return CHUNK_CATALOG;
     }
-  }
-
-  if( nData >= 30 && data[0] == DOLTLITE_COMMIT_V2 ){
-    return CHUNK_COMMIT;
   }
 
   if( nData >= 5 && data[0] == 7 ){

--- a/src/prolly_chunk_walk.h
+++ b/src/prolly_chunk_walk.h
@@ -11,7 +11,9 @@ typedef enum {
   CHUNK_PROLLY_NODE,
   CHUNK_CATALOG,
   CHUNK_WORKING_SET,
-  CHUNK_REFS
+  CHUNK_REFS,
+  CHUNK_CONFLICTS,
+  CHUNK_CONSTRAINT_VIOLATIONS
 } DoltliteChunkType;
 
 typedef int (*DoltliteChildCb)(void *ctx, const ProllyHash *pHash);

--- a/test/doltlite_gc.sh
+++ b/test/doltlite_gc.sh
@@ -50,6 +50,19 @@ run_test "gc_multi_reopen_log" "SELECT count(*) FROM dolt_log;" "4" "$DB"
 
 db_rm "$DB"
 
+DB=/tmp/test_gc_102_byte_commit_$$.db; db_rm "$DB"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_commit('-A','-m','init','--author','beads <beads@local>');
+UPDATE t SET v='b' WHERE id=1;
+SELECT dolt_commit('-A','-m','gc update bead td-wisp-gmg4agp','--author','beads <beads@local>');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+run_test_match "gc_102_byte_commit" "SELECT dolt_gc();" "chunks" "$DB"
+run_test "gc_102_byte_commit_integrity" "PRAGMA integrity_check;" "ok" "$DB"
+run_test "gc_102_byte_commit_log" "SELECT count(*) FROM dolt_log;" "3" "$DB"
+
+db_rm "$DB"
+
 DB=/tmp/test_gc_branch_$$.db; db_rm "$DB"
 echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'a');

--- a/test/doltlite_gc_commit_classify.sh
+++ b/test/doltlite_gc_commit_classify.sh
@@ -81,4 +81,39 @@ run_test_lastline "integrity_ok_with_102_byte_merge_commit" \
 
 db_rm "$DB"
 
+# The conflicts ("DLC") and constraint-violations ("DCV") blobs lead with
+# 'D' == CATALOG_FORMAT_V3, so an unresolved merge conflict in the working
+# set made the walker read them as catalogs with an absurd table count and
+# fail the mark phase the same way. Committing the conflicted transaction
+# persists the conflict, so the blob stays reachable across connections.
+run_test_match "gc_ok_with_unresolved_conflict" \
+  "CREATE TABLE t(k INTEGER PRIMARY KEY, v TEXT);
+   INSERT INTO t VALUES (1,'base');
+   SELECT dolt_commit('-A','-m','seed') IS NOT NULL;
+   SELECT dolt_branch('feat');
+   UPDATE t SET v='ours' WHERE k=1;
+   SELECT dolt_commit('-A','-m','ours') IS NOT NULL;
+   SELECT dolt_checkout('feat');
+   UPDATE t SET v='theirs' WHERE k=1;
+   SELECT dolt_commit('-A','-m','theirs') IS NOT NULL;
+   SELECT dolt_checkout('main');
+   BEGIN;
+   SELECT dolt_merge('feat');
+   COMMIT;
+   SELECT dolt_gc();" \
+  "chunks removed" \
+  "$DB"
+
+run_test_lastline "integrity_ok_with_unresolved_conflict" \
+  "PRAGMA integrity_check;" \
+  "ok" \
+  "$DB"
+
+run_test_lastline "conflict_survives_gc" \
+  "SELECT count(*) FROM dolt_conflicts;" \
+  "1" \
+  "$DB"
+
+db_rm "$DB"
+
 dltest_finish

--- a/test/doltlite_gc_commit_classify.sh
+++ b/test/doltlite_gc_commit_classify.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+source "$(dirname "$0")/lib/doltlite_test_common.sh"
+
+db_rm() {
+  rm -rf "$1" "${1}-wal" "${1}-lock"
+}
+
+echo "=== GC/integrity over commits that collide with the V2 working-set size ==="
+echo ""
+
+# A DOLTLITE_COMMIT_V2 chunk and a WS_FORMAT_VERSION_V2 working set both
+# start with the byte 2. A one-parent commit whose author + email + message
+# total 46 bytes serializes to exactly WS_TOTAL_SIZE_V2 (102) bytes; the
+# chunk walker used to classify it as a working set and chase misaligned
+# bytes as child hashes, so dolt_gc's mark phase and integrity_check both
+# failed on a perfectly healthy store, permanently (the commit is history).
+
+DB=/tmp/test_gc_commit_classify_$$.db; db_rm "$DB"
+
+# author 'beads <beads@local>' (5+11) + 30-char message = 46 string bytes.
+run_test_match "gc_ok_with_102_byte_commit" \
+  "CREATE TABLE t(k INTEGER PRIMARY KEY, v TEXT);
+   INSERT INTO t VALUES (1,'x');
+   SELECT dolt_commit('-A', '-m', 'seed') IS NOT NULL;
+   UPDATE t SET v='y' WHERE k=1;
+   SELECT dolt_commit('-A', '-m', 'gc update bead td-wisp-gmg4agp', '--author', 'beads <beads@local>') IS NOT NULL;
+   SELECT dolt_gc();" \
+  "chunks removed" \
+  "$DB"
+
+run_test_lastline "integrity_ok_with_102_byte_commit" \
+  "PRAGMA integrity_check;" \
+  "ok" \
+  "$DB"
+
+db_rm "$DB"
+
+# The neighboring sizes (101 and 103 bytes) must classify as commits too.
+run_test_match "gc_ok_at_neighboring_commit_sizes" \
+  "CREATE TABLE t(k INTEGER PRIMARY KEY, v TEXT);
+   INSERT INTO t VALUES (1,'x');
+   SELECT dolt_commit('-A', '-m', 'seed') IS NOT NULL;
+   UPDATE t SET v='a' WHERE k=1;
+   SELECT dolt_commit('-A', '-m', 'gc update bead td-wisp-gmg4ag', '--author', 'beads <beads@local>') IS NOT NULL;
+   UPDATE t SET v='b' WHERE k=1;
+   SELECT dolt_commit('-A', '-m', 'gc update bead td-wisp-gmg4agpx', '--author', 'beads <beads@local>') IS NOT NULL;
+   SELECT dolt_gc();" \
+  "chunks removed" \
+  "$DB"
+
+run_test_lastline "integrity_ok_at_neighboring_commit_sizes" \
+  "PRAGMA integrity_check;" \
+  "ok" \
+  "$DB"
+
+db_rm "$DB"
+
+# A two-parent merge commit at the colliding size: 26 string bytes
+# (default author 'doltlite' + empty email = 8, plus an 18-char message).
+run_test_match "gc_ok_with_102_byte_merge_commit" \
+  "CREATE TABLE t(k INTEGER PRIMARY KEY, v TEXT);
+   INSERT INTO t VALUES (1,'x');
+   SELECT dolt_commit('-A', '-m', 'seed') IS NOT NULL;
+   SELECT dolt_branch('feat');
+   UPDATE t SET v='main' WHERE k=1;
+   SELECT dolt_commit('-A', '-m', 'main change') IS NOT NULL;
+   SELECT dolt_checkout('feat');
+   INSERT INTO t VALUES (2,'feat');
+   SELECT dolt_commit('-A', '-m', 'feat change') IS NOT NULL;
+   SELECT dolt_checkout('main');
+   SELECT dolt_merge('feat', '--no-ff', '-m', 'merge msg 18 chars') IS NOT NULL;
+   SELECT dolt_gc();" \
+  "chunks removed" \
+  "$DB"
+
+run_test_lastline "integrity_ok_with_102_byte_merge_commit" \
+  "PRAGMA integrity_check;" \
+  "ok" \
+  "$DB"
+
+db_rm "$DB"
+
+dltest_finish

--- a/test/lib/doltlite_suite_manifest.sh
+++ b/test/lib/doltlite_suite_manifest.sh
@@ -35,6 +35,7 @@ doltlite_attach_write_matrix.sh
 doltlite_branding.sh
 doltlite_memory_db.sh
 doltlite_gc.sh
+doltlite_gc_commit_classify.sh
 doltlite_gc_session_state.sh
 doltlite_vacuum.sh
 doltlite_structural.sh


### PR DESCRIPTION
## Summary
- classify exact v2 commit chunks before working-set blobs during GC chunk walking
- avoid treating a 102-byte commit as a v2 working set and chasing a bogus child hash
- add a GC regression for the 102-byte commit shape seen in the downloaded artifact

## Root cause
The artifact from issue #1547 reported a missing chunk `010a8957...` with parent `2b5f0fcf...`. Decoding the parent showed it was a 102-byte v2 commit. The classifier checked v2 working-set shape first, so GC read bytes at offset 1 as a working-set child. The actual commit parent starts at offset 2: `0a8957ec809ff2614a5659d40f327ec989fc999d`, and that chunk is present.

## Verification
- `make doltlite`
- `bash test/doltlite_gc.sh ./doltlite`
- fresh copy of `~/Downloads/corrupt-static-copy.db`:
  - `PRAGMA integrity_check;` -> `ok`
  - `SELECT dolt_gc();` -> `21978 chunks removed, 51494 chunks kept`
  - `PRAGMA integrity_check;` -> `ok`

Closes #1547.
