### PR TITLE
Add HTTPS + credential auth to doltlite-remotesrv, with e2e tests

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -131,7 +131,7 @@ jobs:
       uses: msys2/setup-msys2@v2
       with:
         msystem: MINGW64
-        install: mingw-w64-x86_64-gcc mingw-w64-x86_64-python mingw-w64-x86_64-tcl mingw-w64-x86_64-zlib make perl tcl
+        install: mingw-w64-x86_64-gcc mingw-w64-x86_64-python mingw-w64-x86_64-tcl mingw-w64-x86_64-zlib make perl tcl openssl
 
     - name: Install dependencies (macOS)
       if: matrix.platform == 'macos'
@@ -195,7 +195,7 @@ jobs:
       shell: msys2 {0}
       run: |
         cd build
-        make -j$(nproc) DOLTLITE_PROLLY_CHECK=1 doltlite.exe doltlite-lib
+        make -j$(nproc) DOLTLITE_PROLLY_CHECK=1 doltlite.exe doltlite-remotesrv.exe doltlite-lib
         DOLTLITE_CHECK_AMALGAMATION=0 DOLTLITE_CHECK_SHARED=0 bash ../test/assert_doltlite_artifacts.sh .
         cp -f "$(command -v sqlite3)" sqlite3
 
@@ -355,6 +355,18 @@ jobs:
         bash ../test/config_test.sh ./doltlite
         bash ../test/blake3_kat_test.sh ./doltlite
       timeout-minutes: 20
+
+    - name: Windows credential + TLS + remote tests
+      if: matrix.platform == 'windows'
+      shell: msys2 {0}
+      run: |
+        cd build
+        bash ../test/creds_kat_test.sh
+        bash ../test/tls_test.sh
+        bash ../test/creds_verify_test.sh
+        bash ../test/remote_test.sh ./doltlite
+        bash ../test/remote_https_auth_test.sh ./doltlite.exe ./doltlite-remotesrv.exe
+      timeout-minutes: 15
 
     - name: Remote integration tests
       if: matrix.platform != 'windows'

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -163,6 +163,7 @@ jobs:
         set -o pipefail
         {
           make DOLTLITE_PROLLY_CHECK=1 doltlite
+          make DOLTLITE_PROLLY_CHECK=1 doltlite-remotesrv
           make DOLTLITE_PROLLY_CHECK=1 doltlite-lib
           # doltlite_parity.sh compares against the package-built stock
           # SQLite CLI instead of whatever sqlite3 the runner image provides.
@@ -345,6 +346,16 @@ jobs:
     - name: Remote integration tests
       if: matrix.platform == 'ubuntu'
       run: cd build && bash ../test/remote_test.sh ./doltlite
+      timeout-minutes: 5
+
+    - name: Credential verify known-answer test
+      if: matrix.platform == 'ubuntu'
+      run: cd build && bash ../test/creds_verify_test.sh
+      timeout-minutes: 5
+
+    - name: Remote HTTPS + credential auth tests
+      if: matrix.platform == 'ubuntu'
+      run: cd build && bash ../test/remote_https_auth_test.sh ./doltlite ./doltlite-remotesrv
       timeout-minutes: 5
 
     # -- C/Python/Go integration tests -----------------------

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -114,6 +114,8 @@ jobs:
             runs-on: ubuntu-latest
           - platform: windows
             runs-on: windows-latest
+          - platform: macos
+            runs-on: macos-latest
 
     steps:
     - uses: actions/checkout@v4
@@ -130,6 +132,10 @@ jobs:
       with:
         msystem: MINGW64
         install: mingw-w64-x86_64-gcc mingw-w64-x86_64-python mingw-w64-x86_64-tcl mingw-w64-x86_64-zlib make perl tcl
+
+    - name: Install dependencies (macOS)
+      if: matrix.platform == 'macos'
+      run: brew install tcl-tk
 
     - name: Install Dolt
       if: matrix.platform == 'ubuntu'
@@ -156,8 +162,15 @@ jobs:
         mkdir -p build && cd build
         ../configure
 
+    - name: Configure (macOS)
+      if: matrix.platform == 'macos'
+      run: |
+        mkdir -p build && cd build
+        export PATH="$(brew --prefix tcl-tk)/bin:$PATH"
+        ../configure
+
     - name: Build
-      if: matrix.platform == 'ubuntu'
+      if: matrix.platform != 'windows'
       run: |
         cd build
         set -o pipefail
@@ -187,12 +200,12 @@ jobs:
         cp -f "$(command -v sqlite3)" sqlite3
 
     - name: Lint
-      if: matrix.platform == 'ubuntu'
+      if: matrix.platform != 'windows'
       run: cd build && make lint
       timeout-minutes: 1
 
     - name: Basic smoke tests
-      if: matrix.platform == 'ubuntu'
+      if: matrix.platform != 'windows'
       run: |
         cd build
         rm -f /tmp/build_test_smoke_basic.db /tmp/build_test_smoke_basic.db-wal /tmp/build_test_smoke_basic.db-lock
@@ -217,7 +230,7 @@ jobs:
       timeout-minutes: 2
 
     - name: GC smoke tests
-      if: matrix.platform == 'ubuntu'
+      if: matrix.platform != 'windows'
       run: |
         cd build
         rm -f /tmp/build_test_smoke_gc.db /tmp/build_test_smoke_gc.db-wal /tmp/build_test_smoke_gc.db-lock
@@ -242,59 +255,59 @@ jobs:
     # -- Doltlite feature tests ------------------------------
 
     - name: Doltlite feature tests
-      if: matrix.platform == 'ubuntu'
+      if: matrix.platform != 'windows'
       run: cd build && bash ../test/run_doltlite_tests.sh
       timeout-minutes: 20
 
     - name: Correctness regression tests
-      if: matrix.platform == 'ubuntu'
+      if: matrix.platform != 'windows'
       run: cd build && bash ../test/correctness_test.sh ./doltlite
       timeout-minutes: 10
 
     - name: Index operation tests
-      if: matrix.platform == 'ubuntu'
+      if: matrix.platform != 'windows'
       run: cd build && bash ../test/index_test.sh ./doltlite
       timeout-minutes: 5
 
     # All oracle tests (vc + sql) run in the parallel oracle-tests job
 
     - name: Large-scale test (10K rows)
-      if: matrix.platform == 'ubuntu'
+      if: matrix.platform != 'windows'
       run: cd build && bash ../test/large_scale_test.sh ./doltlite --quick
       timeout-minutes: 5
 
     - name: Chunk size distribution
-      if: matrix.platform == 'ubuntu'
+      if: matrix.platform != 'windows'
       run: cd build && bash ../test/chunk_distribution_test.sh ./doltlite
       timeout-minutes: 5
 
     - name: Multi-table test
-      if: matrix.platform == 'ubuntu'
+      if: matrix.platform != 'windows'
       run: cd build && bash ../test/multi_table_test.sh ./doltlite --quick
       timeout-minutes: 5
 
     - name: Diff tests
-      if: matrix.platform == 'ubuntu'
+      if: matrix.platform != 'windows'
       run: cd build && bash ../test/diff_test.sh ./doltlite
       timeout-minutes: 10
 
     - name: Config tests
-      if: matrix.platform == 'ubuntu'
+      if: matrix.platform != 'windows'
       run: cd build && bash ../test/config_test.sh ./doltlite
       timeout-minutes: 2
 
     - name: BLAKE3 known-answer test
-      if: matrix.platform == 'ubuntu'
+      if: matrix.platform != 'windows'
       run: cd build && bash ../test/blake3_kat_test.sh ./doltlite
       timeout-minutes: 2
 
     - name: Credential known-answer test
-      if: matrix.platform == 'ubuntu'
+      if: matrix.platform != 'windows'
       run: cd build && bash ../test/creds_kat_test.sh
       timeout-minutes: 2
 
     - name: TLS client test
-      if: matrix.platform == 'ubuntu'
+      if: matrix.platform != 'windows'
       run: cd build && bash ../test/tls_test.sh
       timeout-minutes: 2
 
@@ -344,24 +357,24 @@ jobs:
       timeout-minutes: 20
 
     - name: Remote integration tests
-      if: matrix.platform == 'ubuntu'
+      if: matrix.platform != 'windows'
       run: cd build && bash ../test/remote_test.sh ./doltlite
       timeout-minutes: 5
 
     - name: Credential verify known-answer test
-      if: matrix.platform == 'ubuntu'
+      if: matrix.platform != 'windows'
       run: cd build && bash ../test/creds_verify_test.sh
       timeout-minutes: 5
 
     - name: Remote HTTPS + credential auth tests
-      if: matrix.platform == 'ubuntu'
+      if: matrix.platform != 'windows'
       run: cd build && bash ../test/remote_https_auth_test.sh ./doltlite ./doltlite-remotesrv
       timeout-minutes: 5
 
     # -- C/Python/Go integration tests -----------------------
 
     - name: C integration tests
-      if: matrix.platform == 'ubuntu'
+      if: matrix.platform != 'windows'
       run: |
         cd build
         # Quickstart
@@ -374,7 +387,7 @@ jobs:
         ./concurrent_branch_test
 
     - name: Concurrent write test
-      if: matrix.platform == 'ubuntu'
+      if: matrix.platform != 'windows'
       run: |
         cd build
         gcc -g -O0 -I. -o concurrent_write_test ../test/concurrent_write_test.c \
@@ -391,7 +404,7 @@ jobs:
       timeout-minutes: 10
 
     - name: Prepared statement reuse test
-      if: matrix.platform == 'ubuntu'
+      if: matrix.platform != 'windows'
       run: |
         cd build
         gcc -g -O0 -I. -o prepared_stmt_reuse_test ../test/prepared_stmt_reuse_test.c \

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ tsrc/
 /mksourceid
 /src-verify
 /doltlite
+/doltlite-remotesrv
 /doltlite_regression_test_c
 /*_test
 /probe_wr.test

--- a/main.mk
+++ b/main.mk
@@ -582,17 +582,15 @@ ED25519_SRC = fe.c ge.c sc.c sha512.c keypair.c sign.c verify.c
 ED25519_OBJS = $(ED25519_SRC:%.c=ed25519_%.o)
 MBEDTLS_SRC = $(notdir $(wildcard $(TOP)/ext/mbedtls/library/*.c))
 MBEDTLS_OBJS = $(MBEDTLS_SRC:%.c=mbedtls_%.o)
-# The credential/TLS stack (ed25519 + mbedtls) is Unix-only: the HTTP remote
-# client and test server are stubbed on Windows and mbedtls's socket/entropy
-# layer needs Win32 libraries we don't link. Detect a Windows-esque build via
-# the DLL suffix
-# (autosetup resolves T.dll to .dll there) or the OS env var, and drop the
-# stack. The source uses are gated on DOLTLITE_HAVE_AUTH to match.
+# The credential/TLS stack (ed25519 + mbedtls) is built on every platform. On
+# Windows, mbedtls's socket and entropy layers plus our own server sockets and
+# BCryptGenRandom need ws2_32 and bcrypt linked (the MSVC #pragma comment(lib)
+# in mbedtls doesn't apply under MinGW). Detect a Windows-esque build via the
+# DLL suffix (autosetup resolves T.dll to .dll there) or the OS env var.
+DOLTLITE_AUTH_OBJS = doltlite_creds.o doltlite_tls.o $(ED25519_OBJS) $(MBEDTLS_OBJS)
 DOLTLITE_IS_WINDOWS := $(filter .dll,$(T.dll))$(filter Windows_NT,$(OS))
-ifeq ($(DOLTLITE_IS_WINDOWS),)
-  DOLTLITE_AUTH_OBJS = doltlite_creds.o doltlite_tls.o $(ED25519_OBJS) $(MBEDTLS_OBJS)
-else
-  DOLTLITE_AUTH_OBJS =
+ifneq ($(DOLTLITE_IS_WINDOWS),)
+  LDFLAGS.libsqlite3 += -lws2_32 -lbcrypt
 endif
 
 PROLLY_OBJS = $(DOLTLITE_AUTH_OBJS) \

--- a/main.mk
+++ b/main.mk
@@ -578,7 +578,7 @@ else
   BLAKE3_SIMD_OBJS =
 endif
 
-ED25519_SRC = fe.c ge.c sc.c sha512.c keypair.c sign.c
+ED25519_SRC = fe.c ge.c sc.c sha512.c keypair.c sign.c verify.c
 ED25519_OBJS = $(ED25519_SRC:%.c=ed25519_%.o)
 MBEDTLS_SRC = $(notdir $(wildcard $(TOP)/ext/mbedtls/library/*.c))
 MBEDTLS_OBJS = $(MBEDTLS_SRC:%.c=mbedtls_%.o)

--- a/main.mk
+++ b/main.mk
@@ -583,8 +583,9 @@ ED25519_OBJS = $(ED25519_SRC:%.c=ed25519_%.o)
 MBEDTLS_SRC = $(notdir $(wildcard $(TOP)/ext/mbedtls/library/*.c))
 MBEDTLS_OBJS = $(MBEDTLS_SRC:%.c=mbedtls_%.o)
 # The credential/TLS stack (ed25519 + mbedtls) is Unix-only: the HTTP remote
-# client is stubbed on Windows and mbedtls's socket/entropy layer needs Win32
-# libraries we don't link. Detect a Windows-esque build via the DLL suffix
+# client and test server are stubbed on Windows and mbedtls's socket/entropy
+# layer needs Win32 libraries we don't link. Detect a Windows-esque build via
+# the DLL suffix
 # (autosetup resolves T.dll to .dll there) or the OS env var, and drop the
 # stack. The source uses are gated on DOLTLITE_HAVE_AUTH to match.
 DOLTLITE_IS_WINDOWS := $(filter .dll,$(T.dll))$(filter Windows_NT,$(OS))

--- a/main.mk
+++ b/main.mk
@@ -590,7 +590,7 @@ MBEDTLS_OBJS = $(MBEDTLS_SRC:%.c=mbedtls_%.o)
 DOLTLITE_AUTH_OBJS = doltlite_creds.o doltlite_tls.o $(ED25519_OBJS) $(MBEDTLS_OBJS)
 DOLTLITE_IS_WINDOWS := $(filter .dll,$(T.dll))$(filter Windows_NT,$(OS))
 ifneq ($(DOLTLITE_IS_WINDOWS),)
-  LDFLAGS.libsqlite3 += -lws2_32 -lbcrypt
+  LDFLAGS.libsqlite3 += -lws2_32 -lbcrypt -lcrypt32
 endif
 
 PROLLY_OBJS = $(DOLTLITE_AUTH_OBJS) \

--- a/src/doltlite_creds.c
+++ b/src/doltlite_creds.c
@@ -1,4 +1,3 @@
-
 #include "doltlite_creds.h"
 
 #include "ed25519.h"
@@ -166,7 +165,6 @@ int doltliteCredsFromSeed(const unsigned char seed[DOLTLITE_SEED_LEN],
   DoltliteCreds *c = (DoltliteCreds *)calloc(1, sizeof(*c));
   if (!c) return 1;
   memcpy(c->seed, seed, DOLTLITE_SEED_LEN);
-
   ed25519_create_keypair(c->pub, c->expanded, c->seed);
   *out = c;
   return 0;
@@ -329,6 +327,46 @@ static char *jsonFindString(const char *json, const char *key) {
   return NULL;
 }
 
+static int jsonFindLong(const char *json, const char *key, long *out) {
+  size_t keylen = strlen(key);
+  const char *p = json;
+  while ((p = strchr(p, '"')) != NULL) {
+    const char *kstart = p + 1;
+    if (strncmp(kstart, key, keylen) == 0 && kstart[keylen] == '"') {
+      const char *q = kstart + keylen + 1;
+      char *end;
+      long v;
+      while (*q == ' ' || *q == ':' || *q == '\t') q++;
+      v = strtol(q, &end, 10);
+      if (end == q) return 0;
+      *out = v;
+      return 1;
+    }
+    p = kstart;
+  }
+  return 0;
+}
+
+static char *decodeSegZ(const char *seg, size_t seglen) {
+  char *z = (char *)malloc(seglen + 1);
+  unsigned char *raw = NULL;
+  size_t rawlen = 0;
+  char *s = NULL;
+  if (!z) return NULL;
+  memcpy(z, seg, seglen);
+  z[seglen] = '\0';
+  if (doltliteBase64UrlDecode(z, &raw, &rawlen) == 0) {
+    s = (char *)malloc(rawlen + 1);
+    if (s) {
+      memcpy(s, raw, rawlen);
+      s[rawlen] = '\0';
+    }
+  }
+  free(z);
+  free(raw);
+  return s;
+}
+
 int doltliteCredsFromJwk(const char *json, DoltliteCreds **out) {
   char *dstr = jsonFindString(json, "d");
   unsigned char *seed = NULL;
@@ -421,7 +459,6 @@ int doltliteCredsSave(const DoltliteCreds *c, const char *dir) {
 
   fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0600);
   if (fd < 0) goto done;
-
   (void)fchmod(fd, 0600);
   {
     size_t len = strlen(json), off = 0;
@@ -542,7 +579,6 @@ int doltliteCredsList(const char *dir, char ***out, int *n) {
 
   d = opendir(dir);
   if (!d) {
-
     free(owned);
     return 0;
   }
@@ -600,5 +636,144 @@ int doltliteCredsRemove(const char *dir, const char *kid) {
   rc = (unlink(path) == 0) ? 0 : 1;
   free(path);
   free(owned);
+  return rc;
+}
+
+int doltliteCredsLoadPubKey(const char *dir, const char *kid,
+                            unsigned char pub[DOLTLITE_PUBKEY_LEN]) {
+  char *owned = NULL;
+  char *path = NULL;
+  FILE *f = NULL;
+  char *json = NULL;
+  char *xstr = NULL;
+  unsigned char *raw = NULL;
+  size_t rawlen = 0;
+  long sz;
+  int rc = 1;
+
+  if (!dir) {
+    owned = doltliteCredsDir();
+    dir = owned;
+  }
+  if (!dir) return 1;
+  path = credsFilePath(dir, kid);
+  if (!path) goto done;
+
+  f = fopen(path, "rb");
+  if (!f) goto done;
+  if (fseek(f, 0, SEEK_END) != 0) goto done;
+  sz = ftell(f);
+  if (sz < 0 || sz > 1 << 20) goto done;
+  if (fseek(f, 0, SEEK_SET) != 0) goto done;
+  json = (char *)malloc((size_t)sz + 1);
+  if (!json) goto done;
+  if (fread(json, 1, (size_t)sz, f) != (size_t)sz) goto done;
+  json[sz] = '\0';
+
+  xstr = jsonFindString(json, "x");
+  if (!xstr) goto done;
+  if (doltliteBase64UrlDecode(xstr, &raw, &rawlen)) goto done;
+  if (rawlen != DOLTLITE_PUBKEY_LEN) goto done;
+  memcpy(pub, raw, DOLTLITE_PUBKEY_LEN);
+  rc = 0;
+
+done:
+  if (f) fclose(f);
+  free(json);
+  free(path);
+  free(owned);
+  free(xstr);
+  free(raw);
+  return rc;
+}
+
+#define JWT_ISSUER_EXPECTED   "dolt-client.dolthub.com"
+#define JWT_SUBJECT_PREFIX_V  "doltClientCredentials/"
+#define JWT_TOKEN_VERSION_V   "2023.01"
+
+int doltliteCredsVerifyBearer(const char *authValue, const char *expectedAudience,
+                              const char *authKeysDir, long now, char **kidOut) {
+  const char *jwt;
+  const char *dot1, *dot2;
+  char *hdr = NULL, *claims = NULL;
+  char *alg = NULL, *ver = NULL, *kid = NULL;
+  char *iss = NULL, *sub = NULL, *aud = NULL, *expectSub = NULL;
+  char *sigStr = NULL;
+  unsigned char *sig = NULL;
+  size_t siglen = 0;
+  unsigned char pub[DOLTLITE_PUBKEY_LEN];
+  long exp = 0;
+  int rc = 1;
+
+  if (kidOut) *kidOut = NULL;
+  if (!authValue) return 1;
+
+  jwt = authValue;
+  if (strncmp(jwt, "Bearer ", 7) == 0) jwt += 7;
+  while (*jwt == ' ') jwt++;
+
+  dot1 = strchr(jwt, '.');
+  if (!dot1) return 1;
+  dot2 = strchr(dot1 + 1, '.');
+  if (!dot2) return 1;
+
+  hdr = decodeSegZ(jwt, (size_t)(dot1 - jwt));
+  claims = decodeSegZ(dot1 + 1, (size_t)(dot2 - (dot1 + 1)));
+  if (!hdr || !claims) goto done;
+
+  alg = jsonFindString(hdr, "alg");
+  ver = jsonFindString(hdr, "dolt_token_version");
+  kid = jsonFindString(hdr, "kid");
+  if (!alg || strcmp(alg, "EdDSA") != 0) goto done;
+  if (!ver || strcmp(ver, JWT_TOKEN_VERSION_V) != 0) goto done;
+  if (!kid) goto done;
+
+  if (doltliteCredsLoadPubKey(authKeysDir, kid, pub) != 0) goto done;
+
+  sigStr = (char *)malloc(strlen(dot2 + 1) + 1);
+  if (!sigStr) goto done;
+  strcpy(sigStr, dot2 + 1);
+  if (doltliteBase64UrlDecode(sigStr, &sig, &siglen)) goto done;
+  if (siglen != DOLTLITE_SIG_LEN) goto done;
+  if (ed25519_verify(sig, (const unsigned char *)jwt, (size_t)(dot2 - jwt), pub) != 1) {
+    goto done;
+  }
+
+  iss = jsonFindString(claims, "iss");
+  sub = jsonFindString(claims, "sub");
+  aud = jsonFindString(claims, "aud");
+  if (!iss || strcmp(iss, JWT_ISSUER_EXPECTED) != 0) goto done;
+
+  expectSub = (char *)malloc(strlen(JWT_SUBJECT_PREFIX_V) + strlen(kid) + 1);
+  if (!expectSub) goto done;
+  strcpy(expectSub, JWT_SUBJECT_PREFIX_V);
+  strcat(expectSub, kid);
+  if (!sub || strcmp(sub, expectSub) != 0) goto done;
+
+  if (expectedAudience && *expectedAudience) {
+    if (!aud || strcmp(aud, expectedAudience) != 0) goto done;
+  }
+
+  if (!jsonFindLong(claims, "exp", &exp)) goto done;
+  if (now >= exp) goto done;
+
+  rc = 0;
+  if (kidOut) {
+    *kidOut = kid;
+    kid = NULL;
+  }
+
+done:
+  free(hdr);
+  free(claims);
+  free(alg);
+  free(ver);
+  free(kid);
+  free(iss);
+  free(sub);
+  free(aud);
+  free(expectSub);
+  free(sigStr);
+  free(sig);
   return rc;
 }

--- a/src/doltlite_creds.c
+++ b/src/doltlite_creds.c
@@ -3,16 +3,23 @@
 #include "ed25519.h"
 #include "sha512.h"
 
-#include <dirent.h>
 #include <errno.h>
-#include <fcntl.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/stat.h>
 #include <time.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#include <bcrypt.h>
+#include <direct.h>
+#else
+#include <dirent.h>
+#include <fcntl.h>
+#include <sys/stat.h>
 #include <unistd.h>
+#endif
 
 struct DoltliteCreds {
   unsigned char seed[DOLTLITE_SEED_LEN];
@@ -144,6 +151,12 @@ int doltliteBase64UrlDecode(const char *in, unsigned char **out, size_t *outlen)
 }
 
 static int randomBytes(unsigned char *p, size_t n) {
+#ifdef _WIN32
+  return BCryptGenRandom(NULL, p, (ULONG)n,
+                         BCRYPT_USE_SYSTEM_PREFERRED_RNG) == 0
+             ? 0
+             : 1;
+#else
   int fd = open("/dev/urandom", O_RDONLY);
   size_t got = 0;
   if (fd < 0) return 1;
@@ -158,6 +171,7 @@ static int randomBytes(unsigned char *p, size_t n) {
   }
   close(fd);
   return 0;
+#endif
 }
 
 int doltliteCredsFromSeed(const unsigned char seed[DOLTLITE_SEED_LEN],
@@ -395,6 +409,10 @@ char *doltliteCredsDir(void) {
     return strdup(override);
   }
   home = getenv("HOME");
+#ifdef _WIN32
+  if (!home || !*home) home = getenv("USERPROFILE");
+  if (!home || !*home) home = getenv("APPDATA");
+#endif
   if (!home || !*home) return NULL;
   {
     size_t n = strlen(home) + strlen("/.doltlite/creds") + 1;
@@ -405,22 +423,32 @@ char *doltliteCredsDir(void) {
   return dir;
 }
 
+static int makeDir(const char *path) {
+#ifdef _WIN32
+  return _mkdir(path);
+#else
+  return mkdir(path, 0700);
+#endif
+}
+
 static int mkdirp(const char *path) {
   char *tmp = strdup(path);
   size_t len, i;
   if (!tmp) return 1;
   len = strlen(tmp);
   for (i = 1; i < len; i++) {
-    if (tmp[i] == '/') {
+    if (tmp[i] == '/' || tmp[i] == '\\') {
+      char sep = tmp[i];
       tmp[i] = '\0';
-      if (mkdir(tmp, 0700) != 0 && errno != EEXIST) {
+      /* Skip a Windows drive prefix like "C:" which cannot be created. */
+      if (tmp[i - 1] != ':' && makeDir(tmp) != 0 && errno != EEXIST) {
         free(tmp);
         return 1;
       }
-      tmp[i] = '/';
+      tmp[i] = sep;
     }
   }
-  if (mkdir(tmp, 0700) != 0 && errno != EEXIST) {
+  if (makeDir(tmp) != 0 && errno != EEXIST) {
     free(tmp);
     return 1;
   }
@@ -441,7 +469,7 @@ int doltliteCredsSave(const DoltliteCreds *c, const char *dir) {
   char *kid = NULL;
   char *path = NULL;
   char *json = NULL;
-  int fd = -1, rc = 1;
+  int rc = 1;
 
   if (!dir) {
     owned = doltliteCredsDir();
@@ -457,24 +485,36 @@ int doltliteCredsSave(const DoltliteCreds *c, const char *dir) {
   json = doltliteCredsToJwk(c);
   if (!json) goto done;
 
-  fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0600);
-  if (fd < 0) goto done;
-  (void)fchmod(fd, 0600);
   {
-    size_t len = strlen(json), off = 0;
+    size_t len = strlen(json);
+#ifdef _WIN32
+    FILE *f = fopen(path, "wb");
+    if (!f) goto done;
+    if (fwrite(json, 1, len, f) != len) {
+      fclose(f);
+      goto done;
+    }
+    if (fclose(f) != 0) goto done;
+#else
+    size_t off = 0;
+    int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+    if (fd < 0) goto done;
+    (void)fchmod(fd, 0600);
     while (off < len) {
       ssize_t w = write(fd, json + off, len - off);
       if (w <= 0) {
         if (w < 0 && errno == EINTR) continue;
+        close(fd);
         goto done;
       }
       off += (size_t)w;
     }
+    close(fd);
+#endif
   }
   rc = 0;
 
 done:
-  if (fd >= 0) close(fd);
   free(json);
   free(path);
   free(kid);
@@ -522,10 +562,59 @@ done:
   return rc;
 }
 
+/* Minimal cross-platform directory iteration over the creds dir. */
+typedef struct DirIter {
+#ifdef _WIN32
+  HANDLE h;
+  WIN32_FIND_DATAA fd;
+  int first;
+#else
+  DIR *d;
+#endif
+} DirIter;
+
+static int dirOpen(DirIter *it, const char *dir) {
+#ifdef _WIN32
+  size_t n = strlen(dir) + 3;
+  char *pat = (char *)malloc(n);
+  if (!pat) return 1;
+  snprintf(pat, n, "%s\\*", dir);
+  it->h = FindFirstFileA(pat, &it->fd);
+  free(pat);
+  if (it->h == INVALID_HANDLE_VALUE) return 1;
+  it->first = 1;
+  return 0;
+#else
+  it->d = opendir(dir);
+  return it->d ? 0 : 1;
+#endif
+}
+
+static const char *dirNext(DirIter *it) {
+#ifdef _WIN32
+  if (it->first) {
+    it->first = 0;
+    return it->fd.cFileName;
+  }
+  return FindNextFileA(it->h, &it->fd) ? it->fd.cFileName : NULL;
+#else
+  struct dirent *e = readdir(it->d);
+  return e ? e->d_name : NULL;
+#endif
+}
+
+static void dirClose(DirIter *it) {
+#ifdef _WIN32
+  FindClose(it->h);
+#else
+  closedir(it->d);
+#endif
+}
+
 int doltliteCredsLoadDefault(const char *dir, DoltliteCreds **out) {
   char *owned = NULL;
-  DIR *d;
-  struct dirent *e;
+  DirIter it;
+  const char *name;
   char *kid = NULL;
   int count = 0, rc = 1;
 
@@ -534,25 +623,24 @@ int doltliteCredsLoadDefault(const char *dir, DoltliteCreds **out) {
     dir = owned;
   }
   if (!dir) return 1;
-  d = opendir(dir);
-  if (!d) {
+  if (dirOpen(&it, dir)) {
     free(owned);
     return 1;
   }
-  while ((e = readdir(d)) != NULL) {
-    size_t n = strlen(e->d_name);
-    if (n > 4 && strcmp(e->d_name + n - 4, ".jwk") == 0) {
+  while ((name = dirNext(&it)) != NULL) {
+    size_t n = strlen(name);
+    if (n > 4 && strcmp(name + n - 4, ".jwk") == 0) {
       count++;
       if (count == 1) {
         kid = (char *)malloc(n - 4 + 1);
         if (kid) {
-          memcpy(kid, e->d_name, n - 4);
+          memcpy(kid, name, n - 4);
           kid[n - 4] = '\0';
         }
       }
     }
   }
-  closedir(d);
+  dirClose(&it);
 
   if (count == 1 && kid) {
     rc = doltliteCredsLoad(dir, kid, out);
@@ -564,8 +652,8 @@ int doltliteCredsLoadDefault(const char *dir, DoltliteCreds **out) {
 
 int doltliteCredsList(const char *dir, char ***out, int *n) {
   char *owned = NULL;
-  DIR *d;
-  struct dirent *e;
+  DirIter it;
+  const char *name;
   char **arr = NULL;
   int cap = 0, cnt = 0;
 
@@ -577,15 +665,14 @@ int doltliteCredsList(const char *dir, char ***out, int *n) {
   }
   if (!dir) return 1;
 
-  d = opendir(dir);
-  if (!d) {
+  if (dirOpen(&it, dir)) {
     free(owned);
     return 0;
   }
-  while ((e = readdir(d)) != NULL) {
-    size_t ln = strlen(e->d_name);
+  while ((name = dirNext(&it)) != NULL) {
+    size_t ln = strlen(name);
     char *kid;
-    if (!(ln > 4 && strcmp(e->d_name + ln - 4, ".jwk") == 0)) continue;
+    if (!(ln > 4 && strcmp(name + ln - 4, ".jwk") == 0)) continue;
     if (cnt == cap) {
       int nc = cap ? cap * 2 : 8;
       char **na = (char **)realloc(arr, (size_t)nc * sizeof(char *));
@@ -595,18 +682,18 @@ int doltliteCredsList(const char *dir, char ***out, int *n) {
     }
     kid = (char *)malloc(ln - 4 + 1);
     if (!kid) goto oom;
-    memcpy(kid, e->d_name, ln - 4);
+    memcpy(kid, name, ln - 4);
     kid[ln - 4] = '\0';
     arr[cnt++] = kid;
   }
-  closedir(d);
+  dirClose(&it);
   free(owned);
   *out = arr;
   *n = cnt;
   return 0;
 
 oom:
-  closedir(d);
+  dirClose(&it);
   free(owned);
   doltliteCredsFreeList(arr, cnt);
   return 1;
@@ -633,7 +720,7 @@ int doltliteCredsRemove(const char *dir, const char *kid) {
     free(owned);
     return 1;
   }
-  rc = (unlink(path) == 0) ? 0 : 1;
+  rc = (remove(path) == 0) ? 0 : 1;
   free(path);
   free(owned);
   return rc;

--- a/src/doltlite_creds.h
+++ b/src/doltlite_creds.h
@@ -8,11 +8,11 @@
 #define DOLTLITE_SIG_LEN    64
 #define DOLTLITE_KID_RAW_LEN 28
 
-/* The credential + TLS stack (ed25519, mbedtls) is compiled only where it is
- * both supported and linked: off-Windows and outside the single-file
- * amalgamation, which links neither library. Callers gate their use of the
- * credential/remote-client API on this. */
-#if !defined(_WIN32) && !defined(SQLITE_AMALGAMATION)
+/* The credential + TLS stack (ed25519, mbedtls) is compiled everywhere it is
+ * linked: it is excluded only from the single-file amalgamation, which links
+ * neither library. Callers gate their use of the credential/remote-client API
+ * on this. */
+#if !defined(SQLITE_AMALGAMATION)
 #define DOLTLITE_HAVE_AUTH 1
 #endif
 

--- a/src/doltlite_creds.h
+++ b/src/doltlite_creds.h
@@ -28,11 +28,9 @@ void doltliteSha512_224(const unsigned char *in, size_t inlen,
 char *doltliteBase32Encode(const unsigned char *in, size_t inlen);
 
 char *doltliteBase64UrlEncode(const unsigned char *in, size_t inlen);
-
 int doltliteBase64UrlDecode(const char *in, unsigned char **out, size_t *outlen);
 
 int doltliteCredsGenerate(DoltliteCreds **out);
-
 int doltliteCredsFromSeed(const unsigned char seed[DOLTLITE_SEED_LEN],
                           DoltliteCreds **out);
 void doltliteCredsFree(DoltliteCreds *cred);
@@ -41,7 +39,6 @@ const unsigned char *doltliteCredsPubKey(const DoltliteCreds *cred);
 const unsigned char *doltliteCredsSeed(const DoltliteCreds *cred);
 
 char *doltliteCredsKid(const DoltliteCreds *cred);
-
 char *doltliteCredsPubKeyB32(const DoltliteCreds *cred);
 
 void doltliteCredsSign(const DoltliteCreds *cred, const unsigned char *msg,
@@ -49,26 +46,27 @@ void doltliteCredsSign(const DoltliteCreds *cred, const unsigned char *msg,
 
 int doltliteCredsBearerToken(const DoltliteCreds *cred, const char *audience,
                              char **jwtOut);
-
 int doltliteCredsBearerTokenAt(const DoltliteCreds *cred, const char *audience,
                                long iat, char **jwtOut);
 
 char *doltliteCredsToJwk(const DoltliteCreds *cred);
-
 int doltliteCredsFromJwk(const char *json, DoltliteCreds **out);
 
 char *doltliteCredsDir(void);
-
 int doltliteCredsSave(const DoltliteCreds *cred, const char *dir);
-
 int doltliteCredsLoad(const char *dir, const char *kid, DoltliteCreds **out);
-
 int doltliteCredsLoadDefault(const char *dir, DoltliteCreds **out);
 
 int doltliteCredsList(const char *dir, char ***out, int *n);
 void doltliteCredsFreeList(char **list, int n);
 
 int doltliteCredsRemove(const char *dir, const char *kid);
+
+int doltliteCredsLoadPubKey(const char *dir, const char *kid,
+                            unsigned char pub[DOLTLITE_PUBKEY_LEN]);
+
+int doltliteCredsVerifyBearer(const char *authValue, const char *expectedAudience,
+                              const char *authKeysDir, long now, char **kidOut);
 
 #ifdef __cplusplus
 }

--- a/src/doltlite_http_remote.c
+++ b/src/doltlite_http_remote.c
@@ -17,10 +17,7 @@
 
 DoltliteRemote *doltliteHttpRemoteOpen(const char *zUrl){ (void)zUrl; return 0; }
 #else
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <netdb.h>
-#include <unistd.h>
+#include "doltlite_net.h"
 
 typedef struct HttpRemote HttpRemote;
 struct HttpRemote {

--- a/src/doltlite_net.h
+++ b/src/doltlite_net.h
@@ -1,0 +1,46 @@
+#ifndef DOLTLITE_NET_H
+#define DOLTLITE_NET_H
+
+/* Thin cross-platform socket shim shared by doltlite_tls.c and
+ * doltlite_remotesrv.c. Socket handles are kept as int to match
+ * mbedtls_net_context, which stores its fd as int on Windows too. */
+
+#ifdef _WIN32
+
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <windows.h>
+
+typedef WSAPOLLFD doltlite_pollfd;
+#define doltliteCloseSocket closesocket
+#define doltlitePoll(fds, n, ms) WSAPoll((fds), (n), (ms))
+
+/* WSAStartup is refcounted and never torn down here; process exit reclaims
+ * it. Idempotent enough for a CLI and the test server. */
+static inline int doltliteNetInit(void) {
+  static int done = 0;
+  WSADATA wsa;
+  if (done) return 0;
+  if (WSAStartup(MAKEWORD(2, 2), &wsa) != 0) return 1;
+  done = 1;
+  return 0;
+}
+
+#else
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <poll.h>
+#include <unistd.h>
+
+typedef struct pollfd doltlite_pollfd;
+#define doltliteCloseSocket close
+#define doltlitePoll(fds, n, ms) poll((fds), (n), (ms))
+
+static inline int doltliteNetInit(void) { return 0; }
+
+#endif
+
+#endif

--- a/src/doltlite_remote.c
+++ b/src/doltlite_remote.c
@@ -13,23 +13,6 @@
 #include <unistd.h>
 #endif
 
-#ifndef _WIN32
-int doltliteWriteAll(int fd, const void *pBuf, int nBuf){
-  int nWritten = 0;
-  const u8 *p = (const u8*)pBuf;
-  while( nWritten < nBuf ){
-    ssize_t n = write(fd, p + nWritten, nBuf - nWritten);
-    if( n<0 ){
-      if( errno==EINTR ) continue;
-      return SQLITE_IOERR_WRITE;
-    }
-    if( n==0 ) return SQLITE_IOERR_WRITE;
-    nWritten += (int)n;
-  }
-  return SQLITE_OK;
-}
-#endif
-
 typedef struct SyncQueue SyncQueue;
 struct SyncQueue {
   ProllyHash *aItems;

--- a/src/doltlite_remote.h
+++ b/src/doltlite_remote.h
@@ -42,8 +42,4 @@ DoltliteRemote *doltliteLocalAsRemote(ChunkStore *pLocal);
 
 DoltliteRemote *doltliteHttpRemoteOpen(const char *zUrl);
 
-#ifndef _WIN32
-int doltliteWriteAll(int fd, const void *pBuf, int nBuf);
-#endif
-
 #endif

--- a/src/doltlite_remotesrv.c
+++ b/src/doltlite_remotesrv.c
@@ -7,9 +7,13 @@
 #include "doltlite_remotesrv.h"
 #include "doltlite_remote.h"
 #include "doltlite_commit.h"
+#include "doltlite_tls.h"
+#include "doltlite_creds.h"
 
 #include <string.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
 
 #ifdef _WIN32
 
@@ -29,9 +33,13 @@ struct DoltliteServer {
   volatile int running;
   char *zDir;
   pthread_t thread;
+
+  DoltliteTlsServer *tls;
+  char *authKeysDir;
+  char *audience;
 };
 
-static void sendResponse(int fd, int status, const char *zStatus,
+static void sendResponse(DoltliteConn *fd, int status, const char *zStatus,
                          const u8 *pBody, int nBody){
   char zHeader[256];
   int nHeader;
@@ -42,36 +50,40 @@ static void sendResponse(int fd, int status, const char *zStatus,
     "\r\n",
     status, zStatus, nBody);
   nHeader = (int)strlen(zHeader);
-  if( doltliteWriteAll(fd, zHeader, nHeader)!=SQLITE_OK ) return;
+  if( doltliteConnWriteAll(fd, zHeader, nHeader)!=0 ) return;
   if( pBody && nBody>0 ){
-    doltliteWriteAll(fd, pBody, nBody);
+    doltliteConnWriteAll(fd, pBody, nBody);
   }
 }
 
-static void sendOk(int fd, const u8 *pBody, int nBody){
+static void sendOk(DoltliteConn *fd, const u8 *pBody, int nBody){
   sendResponse(fd, 200, "OK", pBody, nBody);
 }
 
-static void sendNotFound(int fd){
+static void sendNotFound(DoltliteConn *fd){
   sendResponse(fd, 404, "Not Found", (const u8*)"Not Found", 9);
 }
 
-static void sendBadRequest(int fd){
+static void sendBadRequest(DoltliteConn *fd){
   sendResponse(fd, 400, "Bad Request", (const u8*)"Bad Request", 11);
 }
 
-static void sendError(int fd){
+static void sendError(DoltliteConn *fd){
   sendResponse(fd, 500, "Internal Server Error",
                (const u8*)"Internal Server Error", 21);
 }
 
-static void sendPayloadTooLarge(int fd){
+static void sendPayloadTooLarge(DoltliteConn *fd){
   sendResponse(fd, 413, "Payload Too Large",
                (const u8*)"Payload Too Large", 17);
 }
 
-static void sendConflict(int fd){
+static void sendConflict(DoltliteConn *fd){
   sendResponse(fd, 409, "Conflict", (const u8*)"Conflict", 8);
+}
+
+static void sendUnauthorized(DoltliteConn *fd){
+  sendResponse(fd, 401, "Unauthorized", (const u8*)"Unauthorized", 12);
 }
 
 static int remoteSrvCommitPending(ChunkStore *pStore){
@@ -88,10 +100,10 @@ static int remoteSrvCommitPending(ChunkStore *pStore){
 #define MAX_CHUNK_BYTES   (64 * 1024 * 1024)   /* 64 MiB single chunk */
 #define MAX_REQUEST_BYTES (128 * 1024 * 1024)  /* 128 MiB total body */
 
-static int readExact(int fd, u8 *pBuf, int nBytes){
+static int readExact(DoltliteConn *fd, u8 *pBuf, int nBytes){
   int nRead = 0;
   while( nRead < nBytes ){
-    int n = (int)read(fd, pBuf + nRead, nBytes - nRead);
+    int n = doltliteConnRead(fd, pBuf + nRead, nBytes - nRead);
     if( n <= 0 ) return -1;
     nRead += n;
   }
@@ -99,9 +111,10 @@ static int readExact(int fd, u8 *pBuf, int nBytes){
 }
 
 static int parseRequest(
-  int fd,
+  DoltliteConn *fd,
   char *zMethod, int nMethodMax,
   char *zPath, int nPathMax,
+  char *zAuth, int nAuthMax,
   u8 **ppBody, int *pnBody
 ){
   char aBuf[MAX_HEADER_SIZE];
@@ -112,9 +125,10 @@ static int parseRequest(
 
   *ppBody = 0;
   *pnBody = 0;
+  if( zAuth && nAuthMax>0 ) zAuth[0] = '\0';
 
   while( nBuf < MAX_HEADER_SIZE-1 ){
-    int n = (int)read(fd, &aBuf[nBuf], 1);
+    int n = doltliteConnRead(fd, &aBuf[nBuf], 1);
     if( n <= 0 ) return -1;
     nBuf++;
     if( nBuf>=4
@@ -162,6 +176,27 @@ static int parseRequest(
       pLine += nCL;
       while( *pLine==' ' || *pLine=='\t' ) pLine++;
       contentLength = atoi(pLine);
+    }
+  }
+
+  if( zAuth && nAuthMax>0 ){
+    const char *zH = "Authorization:";
+    char *pLine = strstr(aBuf, zH);
+    if( !pLine ){
+      zH = "authorization:";
+      pLine = strstr(aBuf, zH);
+    }
+    if( pLine ){
+      char *pEnd;
+      int len;
+      pLine += (int)strlen("Authorization:");
+      while( *pLine==' ' || *pLine=='\t' ) pLine++;
+      pEnd = pLine;
+      while( *pEnd && *pEnd!='\r' && *pEnd!='\n' ) pEnd++;
+      len = (int)(pEnd - pLine);
+      if( len >= nAuthMax ) len = nAuthMax - 1;
+      memcpy(zAuth, pLine, len);
+      zAuth[len] = '\0';
     }
   }
 
@@ -239,7 +274,7 @@ static int isSafeDbName(const char *zDbName){
   return 1;
 }
 
-static void handleGetRoot(ChunkStore *pStore, int fd){
+static void handleGetRoot(ChunkStore *pStore, DoltliteConn *fd){
   ProllyHash root;
   const char *zDef = chunkStoreGetDefaultBranch(pStore);
   if( zDef && chunkStoreFindBranch(pStore, zDef, &root)==SQLITE_OK ){
@@ -250,7 +285,7 @@ static void handleGetRoot(ChunkStore *pStore, int fd){
   }
 }
 
-static void handleHasChunks(ChunkStore *pStore, int fd,
+static void handleHasChunks(ChunkStore *pStore, DoltliteConn *fd,
                             const u8 *pBody, int nBody){
   int nHashes;
   u8 *aResult;
@@ -289,7 +324,7 @@ static void handleHasChunks(ChunkStore *pStore, int fd,
   sqlite3_free(aResult);
 }
 
-static void handleGetChunk(ChunkStore *pStore, int fd, const char *zHexHash){
+static void handleGetChunk(ChunkStore *pStore, DoltliteConn *fd, const char *zHexHash){
   ProllyHash hash;
   u8 *pData = 0;
   int nData = 0;
@@ -319,7 +354,7 @@ static void handleGetChunk(ChunkStore *pStore, int fd, const char *zHexHash){
   sqlite3_free(pData);
 }
 
-static void handlePostChunks(ChunkStore *pStore, int fd,
+static void handlePostChunks(ChunkStore *pStore, DoltliteConn *fd,
                              const u8 *pBody, int nBody){
   int offset = 0;
   int rc;
@@ -361,7 +396,7 @@ static void handlePostChunks(ChunkStore *pStore, int fd,
   sendOk(fd, 0, 0);
 }
 
-static void handleGetRefs(ChunkStore *pStore, int fd){
+static void handleGetRefs(ChunkStore *pStore, DoltliteConn *fd){
   u8 *pData = 0;
   int nData = 0;
   int rc;
@@ -423,7 +458,7 @@ static int remoteSrvApplyRefsIf(
   return rc;
 }
 
-static void handlePutRefs(ChunkStore *pStore, int fd,
+static void handlePutRefs(ChunkStore *pStore, DoltliteConn *fd,
                           const u8 *pBody, int nBody){
   int rc;
 
@@ -441,7 +476,7 @@ static void handlePutRefs(ChunkStore *pStore, int fd,
   sendOk(fd, 0, 0);
 }
 
-static void handlePutRefsIf(ChunkStore *pStore, int fd,
+static void handlePutRefsIf(ChunkStore *pStore, DoltliteConn *fd,
                             const u8 *pBody, int nBody){
   ProllyHash expectedRefsHash;
   int rc;
@@ -477,7 +512,7 @@ int doltliteRemoteSrvApplyRefsForTest(
   return remoteSrvApplyRefs(pStore, pBody, nBody);
 }
 
-static void handleCommit(ChunkStore *pStore, int fd){
+static void handleCommit(ChunkStore *pStore, DoltliteConn *fd){
   int rc;
 
   rc = remoteSrvPersistRefs(pStore);
@@ -489,11 +524,12 @@ static void handleCommit(ChunkStore *pStore, int fd){
   sendOk(fd, 0, 0);
 }
 
-static void handleRequest(DoltliteServer *pSrv, int fd){
+static void handleRequest(DoltliteServer *pSrv, DoltliteConn *fd){
   char zMethod[16];
   char zPath[512];
   char zDbName[256];
   char zEndpoint[256];
+  char zAuth[1024];
   u8 *pBody = 0;
   int nBody = 0;
   ChunkStore store;
@@ -506,7 +542,8 @@ static void handleRequest(DoltliteServer *pSrv, int fd){
   sqlite3_vfs *pVfs;
 
   rc = parseRequest(fd, zMethod, sizeof(zMethod),
-                    zPath, sizeof(zPath), &pBody, &nBody);
+                    zPath, sizeof(zPath),
+                    zAuth, sizeof(zAuth), &pBody, &nBody);
   if( rc!=0 ){
     if( rc==-2 ){
       sendPayloadTooLarge(fd);
@@ -514,6 +551,15 @@ static void handleRequest(DoltliteServer *pSrv, int fd){
       sendBadRequest(fd);
     }
     return;
+  }
+
+  if( pSrv->authKeysDir ){
+    if( doltliteCredsVerifyBearer(zAuth, pSrv->audience, pSrv->authKeysDir,
+                                  (long)time(NULL), 0)!=0 ){
+      sendUnauthorized(fd);
+      sqlite3_free(pBody);
+      return;
+    }
   }
 
   if( parsePath(zPath, zDbName, sizeof(zDbName),
@@ -597,18 +643,28 @@ static void handleRequest(DoltliteServer *pSrv, int fd){
   sqlite3_free(pBody);
 }
 
-static int serverInit(DoltliteServer *pSrv, const char *zDir, int port,
-                      const char *zBindAddr){
+static void serverCleanup(DoltliteServer *pSrv);
+
+static char *dupStr(const char *z){
+  int n;
+  char *s;
+  if( !z ) return 0;
+  n = (int)strlen(z);
+  s = sqlite3_malloc(n + 1);
+  if( s ) memcpy(s, z, n + 1);
+  return s;
+}
+
+static int serverInit(DoltliteServer *pSrv, const DoltliteServeOpts *o){
   struct sockaddr_in addr;
   socklen_t addrLen;
   struct in_addr bindIn;
   int opt = 1;
-  int nDir;
+  const char *zBindAddr = o->zBindAddr;
 
   memset(pSrv, 0, sizeof(*pSrv));
   pSrv->listenFd = -1;
 
-  /* Default to loopback: the protocol has no auth or TLS. */
   if( zBindAddr==0 || zBindAddr[0]=='\0' ){
     zBindAddr = "127.0.0.1";
   }
@@ -616,41 +672,46 @@ static int serverInit(DoltliteServer *pSrv, const char *zDir, int port,
     return SQLITE_ERROR;
   }
 
-  if( bindIn.s_addr != htonl(INADDR_LOOPBACK) ){
+  pSrv->zDir = dupStr(o->zDir);
+  if( !pSrv->zDir ) return SQLITE_NOMEM;
+
+  if( o->authKeysDir && o->authKeysDir[0] ){
+    pSrv->authKeysDir = dupStr(o->authKeysDir);
+    if( !pSrv->authKeysDir ){ serverCleanup(pSrv); return SQLITE_NOMEM; }
+  }
+  if( o->audience && o->audience[0] ){
+    pSrv->audience = dupStr(o->audience);
+    if( !pSrv->audience ){ serverCleanup(pSrv); return SQLITE_NOMEM; }
+  }
+  if( o->certFile && o->keyFile ){
+    pSrv->tls = doltliteTlsServerNew(o->certFile, o->keyFile);
+    if( !pSrv->tls ){ serverCleanup(pSrv); return SQLITE_ERROR; }
+  }
+
+  if( bindIn.s_addr != htonl(INADDR_LOOPBACK) && pSrv->tls==0 ){
     fprintf(stderr,
-      "WARNING: doltlite-remotesrv bound to %s — the remote protocol "
-      "has no authentication or TLS yet. Only do this "
-      "on trusted networks or behind a reverse proxy.\n",
+      "WARNING: doltlite-remotesrv bound to %s without TLS — traffic is "
+      "unencrypted and unauthenticated. Use --cert/--key/--auth-keys, or "
+      "only do this on trusted networks or behind a reverse proxy.\n",
       zBindAddr);
   }
 
-  nDir = (int)strlen(zDir);
-  pSrv->zDir = sqlite3_malloc(nDir + 1);
-  if( !pSrv->zDir ) return SQLITE_NOMEM;
-  memcpy(pSrv->zDir, zDir, nDir + 1);
-
   pSrv->listenFd = socket(AF_INET, SOCK_STREAM, 0);
-  if( pSrv->listenFd < 0 ){
-    sqlite3_free(pSrv->zDir);
-    return SQLITE_ERROR;
-  }
+  if( pSrv->listenFd < 0 ){ serverCleanup(pSrv); return SQLITE_ERROR; }
 
   setsockopt(pSrv->listenFd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
 
   memset(&addr, 0, sizeof(addr));
   addr.sin_family = AF_INET;
   addr.sin_addr = bindIn;
-  addr.sin_port = htons((u16)port);
+  addr.sin_port = htons((u16)o->port);
 
   if( bind(pSrv->listenFd, (struct sockaddr*)&addr, sizeof(addr)) < 0 ){
-    close(pSrv->listenFd);
-    sqlite3_free(pSrv->zDir);
+    serverCleanup(pSrv);
     return SQLITE_ERROR;
   }
-
   if( listen(pSrv->listenFd, 5) < 0 ){
-    close(pSrv->listenFd);
-    sqlite3_free(pSrv->zDir);
+    serverCleanup(pSrv);
     return SQLITE_ERROR;
   }
 
@@ -658,7 +719,7 @@ static int serverInit(DoltliteServer *pSrv, const char *zDir, int port,
   if( getsockname(pSrv->listenFd, (struct sockaddr*)&addr, &addrLen)==0 ){
     pSrv->port = ntohs(addr.sin_port);
   }else{
-    pSrv->port = port;
+    pSrv->port = o->port;
   }
 
   pSrv->running = 1;
@@ -669,6 +730,7 @@ static void serverLoop(DoltliteServer *pSrv){
   while( pSrv->running ){
     struct pollfd pfd;
     int clientFd;
+    DoltliteConn *conn;
 
     pfd.fd = pSrv->listenFd;
     pfd.events = POLLIN;
@@ -679,8 +741,12 @@ static void serverLoop(DoltliteServer *pSrv){
     clientFd = accept(pSrv->listenFd, NULL, NULL);
     if( clientFd < 0 ) continue;
 
-    handleRequest(pSrv, clientFd);
-    close(clientFd);
+    conn = pSrv->tls ? doltliteConnServerAccept(pSrv->tls, clientFd)
+                     : doltliteConnFromFd(clientFd);
+    if( !conn ) continue;
+
+    handleRequest(pSrv, conn);
+    doltliteConnClose(conn);
   }
 }
 
@@ -689,20 +755,37 @@ static void serverCleanup(DoltliteServer *pSrv){
     close(pSrv->listenFd);
     pSrv->listenFd = -1;
   }
+  if( pSrv->tls ){
+    doltliteTlsServerFree(pSrv->tls);
+    pSrv->tls = 0;
+  }
   sqlite3_free(pSrv->zDir);
   pSrv->zDir = 0;
+  sqlite3_free(pSrv->authKeysDir);
+  pSrv->authKeysDir = 0;
+  sqlite3_free(pSrv->audience);
+  pSrv->audience = 0;
 }
 
-int doltliteServe(const char *zDir, int port, const char *zBindAddr){
+int doltliteServeOpts(const DoltliteServeOpts *o){
   DoltliteServer server;
   int rc;
 
-  rc = serverInit(&server, zDir, port, zBindAddr);
+  rc = serverInit(&server, o);
   if( rc!=SQLITE_OK ) return rc;
 
   serverLoop(&server);
   serverCleanup(&server);
   return SQLITE_OK;
+}
+
+int doltliteServe(const char *zDir, int port, const char *zBindAddr){
+  DoltliteServeOpts o;
+  memset(&o, 0, sizeof(o));
+  o.zDir = zDir;
+  o.port = port;
+  o.zBindAddr = zBindAddr;
+  return doltliteServeOpts(&o);
 }
 
 static void *serverThreadEntry(void *pArg){
@@ -712,15 +795,14 @@ static void *serverThreadEntry(void *pArg){
   return 0;
 }
 
-DoltliteServer *doltliteServeAsync(const char *zDir, int port,
-                                   const char *zBindAddr){
+DoltliteServer *doltliteServeAsyncOpts(const DoltliteServeOpts *o){
   DoltliteServer *pSrv;
   int rc;
 
   pSrv = (DoltliteServer*)sqlite3_malloc(sizeof(DoltliteServer));
   if( !pSrv ) return 0;
 
-  rc = serverInit(pSrv, zDir, port, zBindAddr);
+  rc = serverInit(pSrv, o);
   if( rc!=SQLITE_OK ){
     sqlite3_free(pSrv);
     return 0;
@@ -733,6 +815,16 @@ DoltliteServer *doltliteServeAsync(const char *zDir, int port,
   }
 
   return pSrv;
+}
+
+DoltliteServer *doltliteServeAsync(const char *zDir, int port,
+                                   const char *zBindAddr){
+  DoltliteServeOpts o;
+  memset(&o, 0, sizeof(o));
+  o.zDir = zDir;
+  o.port = port;
+  o.zBindAddr = zBindAddr;
+  return doltliteServeAsyncOpts(&o);
 }
 
 void doltliteServerStop(DoltliteServer *pServer){

--- a/src/doltlite_remotesrv.c
+++ b/src/doltlite_remotesrv.c
@@ -696,7 +696,7 @@ static int serverInit(DoltliteServer *pSrv, const DoltliteServeOpts *o){
   pSrv->listenFd = (int)socket(AF_INET, SOCK_STREAM, 0);
   if( pSrv->listenFd < 0 ){ serverCleanup(pSrv); return SQLITE_ERROR; }
 
-  setsockopt(pSrv->listenFd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+  setsockopt(pSrv->listenFd, SOL_SOCKET, SO_REUSEADDR, (const char*)&opt, sizeof(opt));
 
   memset(&addr, 0, sizeof(addr));
   addr.sin_family = AF_INET;

--- a/src/doltlite_remotesrv.c
+++ b/src/doltlite_remotesrv.c
@@ -15,7 +15,7 @@
 #include <stdlib.h>
 #include <time.h>
 
-#ifdef _WIN32
+#ifndef DOLTLITE_HAVE_AUTH
 
 int doltliteServerPort(DoltliteServer *s){ (void)s; return 0; }
 #else

--- a/src/doltlite_remotesrv.c
+++ b/src/doltlite_remotesrv.c
@@ -19,12 +19,8 @@
 
 int doltliteServerPort(DoltliteServer *s){ (void)s; return 0; }
 #else
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <arpa/inet.h>
-#include <unistd.h>
+#include "doltlite_net.h"
 #include <pthread.h>
-#include <poll.h>
 #include <errno.h>
 
 struct DoltliteServer {
@@ -696,7 +692,8 @@ static int serverInit(DoltliteServer *pSrv, const DoltliteServeOpts *o){
       zBindAddr);
   }
 
-  pSrv->listenFd = socket(AF_INET, SOCK_STREAM, 0);
+  if( doltliteNetInit()!=0 ){ serverCleanup(pSrv); return SQLITE_ERROR; }
+  pSrv->listenFd = (int)socket(AF_INET, SOCK_STREAM, 0);
   if( pSrv->listenFd < 0 ){ serverCleanup(pSrv); return SQLITE_ERROR; }
 
   setsockopt(pSrv->listenFd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
@@ -728,7 +725,7 @@ static int serverInit(DoltliteServer *pSrv, const DoltliteServeOpts *o){
 
 static void serverLoop(DoltliteServer *pSrv){
   while( pSrv->running ){
-    struct pollfd pfd;
+    doltlite_pollfd pfd;
     int clientFd;
     DoltliteConn *conn;
 
@@ -736,9 +733,9 @@ static void serverLoop(DoltliteServer *pSrv){
     pfd.events = POLLIN;
     pfd.revents = 0;
 
-    if( poll(&pfd, 1, 1000) <= 0 ) continue;
+    if( doltlitePoll(&pfd, 1, 1000) <= 0 ) continue;
 
-    clientFd = accept(pSrv->listenFd, NULL, NULL);
+    clientFd = (int)accept(pSrv->listenFd, NULL, NULL);
     if( clientFd < 0 ) continue;
 
     conn = pSrv->tls ? doltliteConnServerAccept(pSrv->tls, clientFd)
@@ -752,7 +749,7 @@ static void serverLoop(DoltliteServer *pSrv){
 
 static void serverCleanup(DoltliteServer *pSrv){
   if( pSrv->listenFd >= 0 ){
-    close(pSrv->listenFd);
+    doltliteCloseSocket(pSrv->listenFd);
     pSrv->listenFd = -1;
   }
   if( pSrv->tls ){
@@ -832,7 +829,7 @@ void doltliteServerStop(DoltliteServer *pServer){
   pServer->running = 0;
 
   if( pServer->listenFd >= 0 ){
-    close(pServer->listenFd);
+    doltliteCloseSocket(pServer->listenFd);
     pServer->listenFd = -1;
   }
   pthread_join(pServer->thread, 0);

--- a/src/doltlite_remotesrv.h
+++ b/src/doltlite_remotesrv.h
@@ -3,14 +3,23 @@
 
 typedef struct DoltliteServer DoltliteServer;
 
-/* Listens on the given dotted-quad IPv4 address (e.g. "0.0.0.0",
-** "127.0.0.1", "192.168.1.5"). If zBindAddr is NULL or empty,
-** defaults to "127.0.0.1". The protocol has no auth or TLS.
-*/
-int doltliteServe(const char *zDir, int port, const char *zBindAddr);
+typedef struct DoltliteServeOpts {
+  const char *zDir;
+  int port;
+  const char *zBindAddr;
+  const char *certFile;
+  const char *keyFile;
+  const char *authKeysDir;
+  const char *audience;
+} DoltliteServeOpts;
 
+int doltliteServe(const char *zDir, int port, const char *zBindAddr);
 DoltliteServer *doltliteServeAsync(const char *zDir, int port,
                                    const char *zBindAddr);
+
+int doltliteServeOpts(const DoltliteServeOpts *opts);
+DoltliteServer *doltliteServeAsyncOpts(const DoltliteServeOpts *opts);
+
 void doltliteServerStop(DoltliteServer *pServer);
 int doltliteServerPort(DoltliteServer *pServer);
 

--- a/src/doltlite_tls.c
+++ b/src/doltlite_tls.c
@@ -9,6 +9,9 @@
 #include "mbedtls/x509_crt.h"
 
 #include "doltlite_net.h"
+#ifdef _WIN32
+#include <wincrypt.h>
+#endif
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -34,6 +37,21 @@ struct DoltliteTlsServer {
   mbedtls_entropy_context entropy;
 };
 
+#ifdef _WIN32
+static int loadSystemRoots(mbedtls_x509_crt *ca) {
+  HCERTSTORE store = CertOpenSystemStoreW(0, L"ROOT");
+  PCCERT_CONTEXT ctx = NULL;
+  int loaded = 0;
+  if (!store) return 1;
+  while ((ctx = CertEnumCertificatesInStore(store, ctx)) != NULL) {
+    if (mbedtls_x509_crt_parse_der(ca, ctx->pbCertEncoded, ctx->cbCertEncoded) == 0) {
+      loaded++;
+    }
+  }
+  CertCloseStore(store, 0);
+  return loaded > 0 ? 0 : 1;
+}
+#else
 static const char *const CA_PATHS[] = {
     "/etc/ssl/cert.pem",
     "/etc/ssl/certs/ca-certificates.crt",
@@ -41,20 +59,26 @@ static const char *const CA_PATHS[] = {
     "/etc/ssl/ca-bundle.pem",
     NULL,
 };
+#endif
 
 static int loadTrustRoots(mbedtls_x509_crt *ca) {
   const char *env = getenv("DOLTLITE_CA_FILE");
-  int i;
   if (env && *env) {
-
     return (mbedtls_x509_crt_parse_file(ca, env) >= 0 && ca->version != 0) ? 0 : 1;
   }
-  for (i = 0; CA_PATHS[i] != NULL; i++) {
-    if (mbedtls_x509_crt_parse_file(ca, CA_PATHS[i]) >= 0 && ca->version != 0) {
-      return 0;
+#ifdef _WIN32
+  return loadSystemRoots(ca);
+#else
+  {
+    int i;
+    for (i = 0; CA_PATHS[i] != NULL; i++) {
+      if (mbedtls_x509_crt_parse_file(ca, CA_PATHS[i]) >= 0 && ca->version != 0) {
+        return 0;
+      }
     }
+    return 1;
   }
-  return 1;
+#endif
 }
 
 DoltliteConn *doltliteConnOpen(const char *host, int port, int useTls) {

--- a/src/doltlite_tls.c
+++ b/src/doltlite_tls.c
@@ -8,10 +8,11 @@
 #include "mbedtls/ssl.h"
 #include "mbedtls/x509_crt.h"
 
+#include "doltlite_net.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
 struct DoltliteConn {
   int useTls;
@@ -221,7 +222,7 @@ DoltliteConn *doltliteConnServerAccept(DoltliteTlsServer *s, int clientFd) {
   DoltliteConn *c = (DoltliteConn *)calloc(1, sizeof(*c));
   int ret;
   if (!c) {
-    close(clientFd);
+    doltliteCloseSocket(clientFd);
     return NULL;
   }
   c->useTls = 1;
@@ -248,7 +249,7 @@ fail:
 DoltliteConn *doltliteConnFromFd(int clientFd) {
   DoltliteConn *c = (DoltliteConn *)calloc(1, sizeof(*c));
   if (!c) {
-    close(clientFd);
+    doltliteCloseSocket(clientFd);
     return NULL;
   }
   c->useTls = 0;

--- a/src/doltlite_tls.c
+++ b/src/doltlite_tls.c
@@ -4,20 +4,31 @@
 #include "mbedtls/ctr_drbg.h"
 #include "mbedtls/entropy.h"
 #include "mbedtls/net_sockets.h"
+#include "mbedtls/pk.h"
 #include "mbedtls/ssl.h"
 #include "mbedtls/x509_crt.h"
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 struct DoltliteConn {
   int useTls;
+  int ownsConf;
   mbedtls_net_context net;
 
   mbedtls_ssl_context ssl;
   mbedtls_ssl_config conf;
   mbedtls_x509_crt cacert;
+  mbedtls_ctr_drbg_context drbg;
+  mbedtls_entropy_context entropy;
+};
+
+struct DoltliteTlsServer {
+  mbedtls_x509_crt cert;
+  mbedtls_pk_context key;
+  mbedtls_ssl_config conf;
   mbedtls_ctr_drbg_context drbg;
   mbedtls_entropy_context entropy;
 };
@@ -52,6 +63,7 @@ DoltliteConn *doltliteConnOpen(const char *host, int port, int useTls) {
 
   if (!c) return NULL;
   c->useTls = useTls;
+  c->ownsConf = 1;
   mbedtls_net_init(&c->net);
 
   snprintf(portstr, sizeof(portstr), "%d", port);
@@ -147,11 +159,101 @@ void doltliteConnClose(DoltliteConn *c) {
   if (c->useTls) {
     mbedtls_ssl_close_notify(&c->ssl);
     mbedtls_ssl_free(&c->ssl);
-    mbedtls_ssl_config_free(&c->conf);
-    mbedtls_x509_crt_free(&c->cacert);
-    mbedtls_ctr_drbg_free(&c->drbg);
-    mbedtls_entropy_free(&c->entropy);
+
+    if (c->ownsConf) {
+      mbedtls_ssl_config_free(&c->conf);
+      mbedtls_x509_crt_free(&c->cacert);
+      mbedtls_ctr_drbg_free(&c->drbg);
+      mbedtls_entropy_free(&c->entropy);
+    }
   }
   mbedtls_net_free(&c->net);
   free(c);
+}
+
+DoltliteTlsServer *doltliteTlsServerNew(const char *certFile, const char *keyFile) {
+  DoltliteTlsServer *s = (DoltliteTlsServer *)calloc(1, sizeof(*s));
+  if (!s) return NULL;
+
+  mbedtls_x509_crt_init(&s->cert);
+  mbedtls_pk_init(&s->key);
+  mbedtls_ssl_config_init(&s->conf);
+  mbedtls_ctr_drbg_init(&s->drbg);
+  mbedtls_entropy_init(&s->entropy);
+
+  if (mbedtls_ctr_drbg_seed(&s->drbg, mbedtls_entropy_func, &s->entropy,
+                            (const unsigned char *)"doltlite-tls-srv", 16) != 0) {
+    goto fail;
+  }
+  if (mbedtls_x509_crt_parse_file(&s->cert, certFile) != 0) goto fail;
+  if (mbedtls_pk_parse_keyfile(&s->key, keyFile, NULL,
+                               mbedtls_ctr_drbg_random, &s->drbg) != 0) {
+    goto fail;
+  }
+  if (mbedtls_ssl_config_defaults(&s->conf, MBEDTLS_SSL_IS_SERVER,
+                                  MBEDTLS_SSL_TRANSPORT_STREAM,
+                                  MBEDTLS_SSL_PRESET_DEFAULT) != 0) {
+    goto fail;
+  }
+  mbedtls_ssl_conf_rng(&s->conf, mbedtls_ctr_drbg_random, &s->drbg);
+
+  mbedtls_ssl_conf_authmode(&s->conf, MBEDTLS_SSL_VERIFY_NONE);
+  if (mbedtls_ssl_conf_own_cert(&s->conf, &s->cert, &s->key) != 0) goto fail;
+
+  return s;
+
+fail:
+  doltliteTlsServerFree(s);
+  return NULL;
+}
+
+void doltliteTlsServerFree(DoltliteTlsServer *s) {
+  if (!s) return;
+  mbedtls_ssl_config_free(&s->conf);
+  mbedtls_x509_crt_free(&s->cert);
+  mbedtls_pk_free(&s->key);
+  mbedtls_ctr_drbg_free(&s->drbg);
+  mbedtls_entropy_free(&s->entropy);
+  free(s);
+}
+
+DoltliteConn *doltliteConnServerAccept(DoltliteTlsServer *s, int clientFd) {
+  DoltliteConn *c = (DoltliteConn *)calloc(1, sizeof(*c));
+  int ret;
+  if (!c) {
+    close(clientFd);
+    return NULL;
+  }
+  c->useTls = 1;
+  c->ownsConf = 0;
+  mbedtls_net_init(&c->net);
+  c->net.fd = clientFd;
+  mbedtls_ssl_init(&c->ssl);
+
+  if (mbedtls_ssl_setup(&c->ssl, &s->conf) != 0) goto fail;
+  mbedtls_ssl_set_bio(&c->ssl, &c->net, mbedtls_net_send, mbedtls_net_recv, NULL);
+  do {
+    ret = mbedtls_ssl_handshake(&c->ssl);
+  } while (ret == MBEDTLS_ERR_SSL_WANT_READ || ret == MBEDTLS_ERR_SSL_WANT_WRITE);
+  if (ret != 0) goto fail;
+  return c;
+
+fail:
+  mbedtls_ssl_free(&c->ssl);
+  mbedtls_net_free(&c->net);
+  free(c);
+  return NULL;
+}
+
+DoltliteConn *doltliteConnFromFd(int clientFd) {
+  DoltliteConn *c = (DoltliteConn *)calloc(1, sizeof(*c));
+  if (!c) {
+    close(clientFd);
+    return NULL;
+  }
+  c->useTls = 0;
+  c->ownsConf = 0;
+  mbedtls_net_init(&c->net);
+  c->net.fd = clientFd;
+  return c;
 }

--- a/src/doltlite_tls.h
+++ b/src/doltlite_tls.h
@@ -11,6 +11,14 @@ typedef struct DoltliteConn DoltliteConn;
 
 DoltliteConn *doltliteConnOpen(const char *host, int port, int useTls);
 
+typedef struct DoltliteTlsServer DoltliteTlsServer;
+
+DoltliteTlsServer *doltliteTlsServerNew(const char *certFile, const char *keyFile);
+void doltliteTlsServerFree(DoltliteTlsServer *s);
+
+DoltliteConn *doltliteConnServerAccept(DoltliteTlsServer *s, int clientFd);
+DoltliteConn *doltliteConnFromFd(int clientFd);
+
 int doltliteConnWriteAll(DoltliteConn *conn, const void *buf, int nbuf);
 
 int doltliteConnRead(DoltliteConn *conn, void *buf, int nbuf);

--- a/src/remotesrv_main.c
+++ b/src/remotesrv_main.c
@@ -1,54 +1,60 @@
-/*
-** doltlite-remotesrv: standalone HTTP server for doltlite remotes.
-**
-** Usage:
-**   doltlite-remotesrv [-p PORT] [--bind ADDR] DIRECTORY
-**
-** Serves all .doltlite/.db files in DIRECTORY over HTTP.
-** Each database is accessible at http://host:port/FILENAME
-**
-** Options:
-**   -p PORT       Listen port (default: 8080)
-**   --bind ADDR   IPv4 bind address (default: 127.0.0.1)
-**   -h            Show help
-*/
+
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 #include "doltlite_remotesrv.h"
 
 static void usage(const char *prog){
   fprintf(stderr,
-    "Usage: %s [-p PORT] [--bind ADDR] DIRECTORY\n"
+    "Usage: %s [-p PORT] [--bind ADDR] [--cert FILE --key FILE]\n"
+    "          [--auth-keys DIR] [--audience AUD] DIRECTORY\n"
     "\n"
-    "Serve doltlite databases over HTTP.\n"
+    "Serve doltlite databases over HTTP/HTTPS.\n"
     "\n"
     "Options:\n"
-    "  -p PORT       Listen port (default: 8080)\n"
-    "  --bind ADDR   IPv4 bind address (default: 127.0.0.1; pass 0.0.0.0\n"
-    "                to listen on all interfaces — note that the remote\n"
-    "                protocol has no auth/TLS yet, see issue #228)\n"
-    "  -h            Show this help\n"
+    "  -p PORT         Listen port (default: 8080; 0 = pick a free port)\n"
+    "  --bind ADDR     IPv4 bind address (default: 127.0.0.1)\n"
+    "  --cert FILE     PEM certificate chain (enables TLS; requires --key)\n"
+    "  --key FILE      PEM private key (requires --cert)\n"
+    "  --auth-keys DIR Require a bearer credential; authorized public keys are\n"
+    "                  <kid>.jwk files in DIR\n"
+    "  --audience AUD  Expected JWT audience (default: none)\n"
+    "  -h              Show this help\n"
     "\n"
     "Example:\n"
-    "  %s -p 9000 /var/lib/doltlite\n"
-    "  # Databases at http://localhost:9000/mydb.db\n",
+    "  %s --cert server.crt --key server.key --auth-keys ./keys \\\n"
+    "     --audience 127.0.0.1 -p 9000 /var/lib/doltlite\n",
     prog, prog
   );
 }
 
+static volatile sig_atomic_t g_stop = 0;
+static void onSignal(int sig){ (void)sig; g_stop = 1; }
+
 int main(int argc, char **argv){
-  int port = 8080;
-  const char *zDir = 0;
-  const char *zBind = 0;  /* NULL → library default (127.0.0.1) */
+  DoltliteServeOpts o;
+  DoltliteServer *srv;
+  const char *zBindShown;
   int i;
-  int rc;
+
+  memset(&o, 0, sizeof(o));
+  o.port = 8080;
 
   for(i=1; i<argc; i++){
     if( strcmp(argv[i], "-p")==0 && i+1<argc ){
-      port = atoi(argv[++i]);
+      o.port = atoi(argv[++i]);
     }else if( strcmp(argv[i], "--bind")==0 && i+1<argc ){
-      zBind = argv[++i];
+      o.zBindAddr = argv[++i];
+    }else if( strcmp(argv[i], "--cert")==0 && i+1<argc ){
+      o.certFile = argv[++i];
+    }else if( strcmp(argv[i], "--key")==0 && i+1<argc ){
+      o.keyFile = argv[++i];
+    }else if( strcmp(argv[i], "--auth-keys")==0 && i+1<argc ){
+      o.authKeysDir = argv[++i];
+    }else if( strcmp(argv[i], "--audience")==0 && i+1<argc ){
+      o.audience = argv[++i];
     }else if( strcmp(argv[i], "-h")==0 || strcmp(argv[i], "--help")==0 ){
       usage(argv[0]);
       return 0;
@@ -57,20 +63,42 @@ int main(int argc, char **argv){
       usage(argv[0]);
       return 1;
     }else{
-      zDir = argv[i];
+      o.zDir = argv[i];
     }
   }
 
-  if( !zDir ){
+  if( !o.zDir ){
     fprintf(stderr, "Error: directory argument required\n\n");
     usage(argv[0]);
     return 1;
   }
+  if( (o.certFile!=0) != (o.keyFile!=0) ){
+    fprintf(stderr, "Error: --cert and --key must be given together\n");
+    return 1;
+  }
 
-  printf("doltlite-remotesrv serving %s on %s:%d\n",
-         zDir, zBind ? zBind : "127.0.0.1", port);
-  printf("Press Ctrl+C to stop.\n\n");
+  signal(SIGINT, onSignal);
+  signal(SIGTERM, onSignal);
 
-  rc = doltliteServe(zDir, port, zBind);
-  return rc==0 ? 0 : 1;
+  srv = doltliteServeAsyncOpts(&o);
+  if( !srv ){
+    fprintf(stderr, "Error: failed to start server "
+                    "(check DIRECTORY, --cert/--key, and the bind address)\n");
+    return 1;
+  }
+
+  zBindShown = o.zBindAddr ? o.zBindAddr : "127.0.0.1";
+  printf("doltlite-remotesrv serving %s on %s://%s:%d\n",
+         o.zDir, o.certFile ? "https" : "http",
+         zBindShown, doltliteServerPort(srv));
+  if( o.authKeysDir ){
+    printf("credential auth enabled (authorized keys: %s)\n", o.authKeysDir);
+  }
+  printf("Press Ctrl+C to stop.\n");
+  fflush(stdout);
+
+  while( !g_stop ) sleep(1);
+
+  doltliteServerStop(srv);
+  return 0;
 }

--- a/src/remotesrv_main.c
+++ b/src/remotesrv_main.c
@@ -3,7 +3,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifdef _WIN32
+#include <windows.h>
+#else
 #include <unistd.h>
+#endif
 #include "doltlite_remotesrv.h"
 
 static void usage(const char *prog){
@@ -97,7 +101,13 @@ int main(int argc, char **argv){
   printf("Press Ctrl+C to stop.\n");
   fflush(stdout);
 
-  while( !g_stop ) sleep(1);
+  while( !g_stop ){
+#ifdef _WIN32
+    Sleep(1000);
+#else
+    sleep(1);
+#endif
+  }
 
   doltliteServerStop(srv);
   return 0;

--- a/test/assert_doltlite_artifacts.sh
+++ b/test/assert_doltlite_artifacts.sh
@@ -10,6 +10,7 @@ probe_cflags=(-w)
 probe_libs=(-lz -lpthread -lm)
 case "$(uname -s)" in
   Linux*) probe_libs+=(-ldl) ;;
+  MINGW*|MSYS*|CYGWIN*) probe_libs+=(-lws2_32 -lbcrypt) ;;
 esac
 
 check_value() {

--- a/test/assert_doltlite_artifacts.sh
+++ b/test/assert_doltlite_artifacts.sh
@@ -10,7 +10,7 @@ probe_cflags=(-w)
 probe_libs=(-lz -lpthread -lm)
 case "$(uname -s)" in
   Linux*) probe_libs+=(-ldl) ;;
-  MINGW*|MSYS*|CYGWIN*) probe_libs+=(-lws2_32 -lbcrypt) ;;
+  MINGW*|MSYS*|CYGWIN*) probe_libs+=(-lws2_32 -lbcrypt -lcrypt32) ;;
 esac
 
 check_value() {

--- a/test/creds_kat_test.sh
+++ b/test/creds_kat_test.sh
@@ -4,6 +4,8 @@ set -o pipefail
 
 HERE=$(cd "$(dirname "$0")/.." && pwd)
 CC="${CC:-cc}"
+DOLTLITE_EXTRA_LIBS=""
+case "$(uname -s)" in MINGW*|MSYS*|CYGWIN*) DOLTLITE_EXTRA_LIBS="-lws2_32 -lbcrypt";; esac
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
 
@@ -22,6 +24,7 @@ echo "=== doltlite creds KAT ==="
   "$HERE/ext/ed25519/sign.c" \
   "$HERE/ext/ed25519/verify.c" \
   "$HERE/ext/ed25519/add_scalar.c" \
+  $DOLTLITE_EXTRA_LIBS \
   -o "$BIN" 2>"$TMP/build.err" || {
   echo "  build failed:"
   cat "$TMP/build.err"

--- a/test/creds_kat_test.sh
+++ b/test/creds_kat_test.sh
@@ -5,7 +5,7 @@ set -o pipefail
 HERE=$(cd "$(dirname "$0")/.." && pwd)
 CC="${CC:-cc}"
 DOLTLITE_EXTRA_LIBS=""
-case "$(uname -s)" in MINGW*|MSYS*|CYGWIN*) DOLTLITE_EXTRA_LIBS="-lws2_32 -lbcrypt";; esac
+case "$(uname -s)" in MINGW*|MSYS*|CYGWIN*) DOLTLITE_EXTRA_LIBS="-lws2_32 -lbcrypt -lcrypt32";; esac
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
 

--- a/test/creds_verify_kat.c
+++ b/test/creds_verify_kat.c
@@ -1,0 +1,91 @@
+
+#include "doltlite_creds.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int failures = 0;
+
+static void check(const char *name, int ok) {
+  if (ok) {
+    printf("  PASS  %s\n", name);
+  } else {
+    failures++;
+    printf("  FAIL  %s\n", name);
+  }
+}
+
+#define AUD "doltremoteapi.dolthub.com"
+#define IAT 1700000000L
+#define MID 1700000015L
+#define LATE 1700001000L
+
+int main(int argc, char **argv) {
+  const char *authDir = argc > 1 ? argv[1] : ".";
+  const char *emptyDir = argc > 2 ? argv[2] : ".";
+  unsigned char seed[32];
+  DoltliteCreds *c = NULL;
+  char *jwt = NULL, *kid = NULL, *kidOut = NULL;
+  char *bearer = NULL, *tampered = NULL;
+  int i;
+
+  for (i = 0; i < 32; i++) seed[i] = (unsigned char)i;
+  if (doltliteCredsFromSeed(seed, &c) != 0) {
+    printf("  FAIL  creds from seed\n");
+    return 1;
+  }
+  kid = doltliteCredsKid(c);
+
+  if (doltliteCredsSave(c, authDir) != 0) {
+    printf("  FAIL  save authorized key\n");
+    return 1;
+  }
+
+  if (doltliteCredsBearerTokenAt(c, AUD, IAT, &jwt) != 0 || !jwt) {
+    printf("  FAIL  build bearer token\n");
+    return 1;
+  }
+
+  kidOut = NULL;
+  check("valid token accepted",
+        doltliteCredsVerifyBearer(jwt, AUD, authDir, MID, &kidOut) == 0);
+  check("kidOut matches", kidOut && kid && strcmp(kidOut, kid) == 0);
+  free(kidOut);
+
+  bearer = (char *)malloc(strlen(jwt) + 8);
+  sprintf(bearer, "Bearer %s", jwt);
+  check("\"Bearer \" prefix accepted",
+        doltliteCredsVerifyBearer(bearer, AUD, authDir, MID, NULL) == 0);
+
+  check("null expected-audience accepted",
+        doltliteCredsVerifyBearer(jwt, NULL, authDir, MID, NULL) == 0);
+
+  check("expired token rejected",
+        doltliteCredsVerifyBearer(jwt, AUD, authDir, LATE, NULL) != 0);
+  check("wrong audience rejected",
+        doltliteCredsVerifyBearer(jwt, "evil.example.com", authDir, MID, NULL) != 0);
+  check("unknown key (empty authorized dir) rejected",
+        doltliteCredsVerifyBearer(jwt, AUD, emptyDir, MID, NULL) != 0);
+  check("missing token rejected", doltliteCredsVerifyBearer(NULL, AUD, authDir, MID, NULL) != 0);
+  check("malformed token rejected",
+        doltliteCredsVerifyBearer("not-a-jwt", AUD, authDir, MID, NULL) != 0);
+
+  tampered = (char *)malloc(strlen(jwt) + 1);
+  strcpy(tampered, jwt);
+  {
+    size_t n = strlen(tampered);
+    tampered[n - 1] = (tampered[n - 1] == 'A') ? 'B' : 'A';
+  }
+  check("tampered signature rejected",
+        doltliteCredsVerifyBearer(tampered, AUD, authDir, MID, NULL) != 0);
+
+  free(jwt);
+  free(kid);
+  free(bearer);
+  free(tampered);
+  doltliteCredsFree(c);
+
+  printf("\n%s: %d failure(s)\n", failures ? "FAILED" : "OK", failures);
+  return failures ? 1 : 0;
+}

--- a/test/creds_verify_test.sh
+++ b/test/creds_verify_test.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -u
+set -o pipefail
+
+HERE=$(cd "$(dirname "$0")/.." && pwd)
+CC="${CC:-cc}"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+BIN="$TMP/creds_verify_kat"
+mkdir -p "$TMP/authkeys" "$TMP/empty"
+
+echo "=== doltlite credential-verify KAT ==="
+"$CC" -O2 -Wall \
+  -I "$HERE/src" -I "$HERE/ext/ed25519" \
+  "$HERE/test/creds_verify_kat.c" \
+  "$HERE/src/doltlite_creds.c" \
+  "$HERE/ext/ed25519/fe.c" \
+  "$HERE/ext/ed25519/ge.c" \
+  "$HERE/ext/ed25519/sc.c" \
+  "$HERE/ext/ed25519/sha512.c" \
+  "$HERE/ext/ed25519/keypair.c" \
+  "$HERE/ext/ed25519/sign.c" \
+  "$HERE/ext/ed25519/verify.c" \
+  "$HERE/ext/ed25519/add_scalar.c" \
+  -o "$BIN" 2>"$TMP/build.err" || {
+  echo "  build failed:"
+  cat "$TMP/build.err"
+  exit 1
+}
+
+"$BIN" "$TMP/authkeys" "$TMP/empty"

--- a/test/creds_verify_test.sh
+++ b/test/creds_verify_test.sh
@@ -5,7 +5,7 @@ set -o pipefail
 HERE=$(cd "$(dirname "$0")/.." && pwd)
 CC="${CC:-cc}"
 DOLTLITE_EXTRA_LIBS=""
-case "$(uname -s)" in MINGW*|MSYS*|CYGWIN*) DOLTLITE_EXTRA_LIBS="-lws2_32 -lbcrypt";; esac
+case "$(uname -s)" in MINGW*|MSYS*|CYGWIN*) DOLTLITE_EXTRA_LIBS="-lws2_32 -lbcrypt -lcrypt32";; esac
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
 

--- a/test/creds_verify_test.sh
+++ b/test/creds_verify_test.sh
@@ -4,6 +4,8 @@ set -o pipefail
 
 HERE=$(cd "$(dirname "$0")/.." && pwd)
 CC="${CC:-cc}"
+DOLTLITE_EXTRA_LIBS=""
+case "$(uname -s)" in MINGW*|MSYS*|CYGWIN*) DOLTLITE_EXTRA_LIBS="-lws2_32 -lbcrypt";; esac
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
 
@@ -23,6 +25,7 @@ echo "=== doltlite credential-verify KAT ==="
   "$HERE/ext/ed25519/sign.c" \
   "$HERE/ext/ed25519/verify.c" \
   "$HERE/ext/ed25519/add_scalar.c" \
+  $DOLTLITE_EXTRA_LIBS \
   -o "$BIN" 2>"$TMP/build.err" || {
   echo "  build failed:"
   cat "$TMP/build.err"

--- a/test/dead_code_check.sh
+++ b/test/dead_code_check.sh
@@ -35,7 +35,7 @@ CFLAGS=(
 
 # Intentional exports that have no in-tree caller (documented/embeddable API,
 # or build-glue entry points reached from outside this tree).
-ALLOW="doltliteServeAsync doltliteServerStop"
+ALLOW="doltliteServe doltliteServeAsync doltliteServerStop"
 
 fail=0
 

--- a/test/doltlite_tls_test_main.c
+++ b/test/doltlite_tls_test_main.c
@@ -5,6 +5,14 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef _WIN32
+static int setenv(const char *n, const char *v, int overwrite) {
+  (void)overwrite;
+  return _putenv_s(n, v);
+}
+static int unsetenv(const char *n) { return _putenv_s(n, ""); }
+#endif
+
 static const char *testHost(void) {
   const char *h = getenv("DOLTLITE_TLS_TEST_HOST");
   return (h && *h) ? h : "dolthub.com";

--- a/test/remote_https_auth_test.sh
+++ b/test/remote_https_auth_test.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+set -u
+
+DOLTLITE="${1:-$(dirname "$0")/../build/doltlite}"
+REMOTESRV="${2:-$(dirname "$0")/../build/doltlite-remotesrv}"
+TMP=$(mktemp -d)
+SRV_PID=""
+cleanup() {
+  [ -n "$SRV_PID" ] && kill "$SRV_PID" 2>/dev/null
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+pass=0
+fail=0
+check() {
+  if [ "$2" = "$3" ]; then echo "  PASS: $1"; pass=$((pass+1));
+  else echo "  FAIL: $1"; echo "    expected: |$2|"; echo "    actual:   |$3|"; fail=$((fail+1)); fi
+}
+check_ne() {
+  if [ "$2" != "$3" ]; then echo "  PASS: $1"; pass=$((pass+1));
+  else echo "  FAIL: $1 (got the not-allowed value |$3|)"; fail=$((fail+1)); fi
+}
+
+if ! command -v openssl >/dev/null 2>&1; then
+  echo "SKIP: openssl not available"; exit 0
+fi
+if [ ! -x "$DOLTLITE" ] || [ ! -x "$REMOTESRV" ]; then
+  echo "SKIP: doltlite/doltlite-remotesrv binaries not found ($DOLTLITE, $REMOTESRV)"; exit 0
+fi
+
+openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
+  -keyout "$TMP/key.pem" -out "$TMP/cert.pem" \
+  -subj "/CN=localhost" -addext "subjectAltName=DNS:localhost,IP:127.0.0.1" \
+  >/dev/null 2>&1 || { echo "SKIP: openssl cert generation failed"; exit 0; }
+openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
+  -keyout /dev/null -out "$TMP/other_ca.pem" -subj "/CN=other" >/dev/null 2>&1
+
+mkdir -p "$TMP/cc" "$TMP/cc_unauth" "$TMP/empty" "$TMP/authkeys" "$TMP/srv" "$TMP/srv2"
+DOLTLITE_CREDS_DIR="$TMP/cc" "$DOLTLITE" "$TMP/throwaway.db" "SELECT dolt_creds_new();" >/dev/null 2>&1
+cp "$TMP"/cc/*.jwk "$TMP/authkeys/" 2>/dev/null || { echo "FAIL: no credential generated"; exit 1; }
+DOLTLITE_CREDS_DIR="$TMP/cc_unauth" "$DOLTLITE" "$TMP/throwaway2.db" "SELECT dolt_creds_new();" >/dev/null 2>&1
+
+"$REMOTESRV" --cert "$TMP/cert.pem" --key "$TMP/key.pem" \
+  --auth-keys "$TMP/authkeys" --audience localhost \
+  -p 0 --bind 127.0.0.1 "$TMP/srv" >"$TMP/srv.log" 2>&1 &
+SRV_PID=$!
+PORT=""
+for _ in $(seq 1 50); do
+  PORT=$(sed -n 's#.*://127.0.0.1:\([0-9][0-9]*\).*#\1#p' "$TMP/srv.log" | head -1)
+  [ -n "$PORT" ] && break
+  sleep 0.1
+done
+if [ -z "$PORT" ]; then echo "FAIL: server did not start"; cat "$TMP/srv.log"; exit 1; fi
+URL="https://localhost:$PORT/repo.db"
+echo "server on port $PORT"
+
+export DOLTLITE_CA_FILE="$TMP/cert.pem"
+export DOLT_OVERRIDE_GRPC_JWT_AUDIENCE="localhost"
+
+"$DOLTLITE" "$TMP/src.db" <<ENDSQL >/dev/null 2>&1
+CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT);
+INSERT INTO users VALUES(1,'alice'),(2,'bob'),(3,'charlie');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m','initial');
+SELECT dolt_remote('add','origin','$URL');
+.quit
+ENDSQL
+
+echo "=== 1. Authenticated HTTPS push ==="
+result=$(DOLTLITE_CREDS_DIR="$TMP/cc" "$DOLTLITE" "$TMP/src.db" "SELECT dolt_push('origin','main');" 2>&1)
+check "authenticated push returns 0" "0" "$result"
+
+src_head=$("$DOLTLITE" "$TMP/src.db" "SELECT commit_hash FROM dolt_log LIMIT 1;" 2>&1)
+srv_head=$("$DOLTLITE" "$TMP/srv/repo.db" "SELECT commit_hash FROM dolt_log LIMIT 1;" 2>&1)
+check "server head matches pushed head" "$src_head" "$srv_head"
+
+echo "=== 2. Authenticated HTTPS clone ==="
+result=$(DOLTLITE_CREDS_DIR="$TMP/cc" "$DOLTLITE" "$TMP/clone.db" "SELECT dolt_clone('$URL');" 2>&1)
+check "authenticated clone returns 0" "0" "$result"
+result=$(DOLTLITE_CREDS_DIR="$TMP/cc" "$DOLTLITE" "$TMP/clone.db" "SELECT count(*) FROM users;" 2>&1)
+check "clone round-trips 3 users" "3" "$result"
+
+echo "=== 3. Auth is enforced ==="
+result=$(DOLTLITE_CREDS_DIR="$TMP/empty" "$DOLTLITE" "$TMP/src.db" "SELECT dolt_push('origin','main');" 2>&1)
+check_ne "push without a credential is rejected" "0" "$result"
+result=$(DOLTLITE_CREDS_DIR="$TMP/cc_unauth" "$DOLTLITE" "$TMP/src.db" "SELECT dolt_push('origin','main');" 2>&1)
+check_ne "push with an unauthorized key is rejected" "0" "$result"
+
+echo "=== 4. TLS is enforced ==="
+"$DOLTLITE" "$TMP/src.db" "SELECT dolt_remote('add','plain','http://localhost:$PORT/repo.db');" >/dev/null 2>&1
+result=$(DOLTLITE_CREDS_DIR="$TMP/cc" "$DOLTLITE" "$TMP/src.db" "SELECT dolt_push('plain','main');" 2>&1)
+check_ne "plaintext http to the TLS server is rejected" "0" "$result"
+result=$(DOLTLITE_CA_FILE="$TMP/other_ca.pem" DOLTLITE_CREDS_DIR="$TMP/cc" \
+  "$DOLTLITE" "$TMP/src.db" "SELECT dolt_push('origin','main');" 2>&1)
+check_ne "push with the wrong CA is rejected" "0" "$result"
+
+echo "=== 5. Backward-compat: plaintext server, no auth ==="
+"$REMOTESRV" -p 0 --bind 127.0.0.1 "$TMP/srv2" >"$TMP/srv2.log" 2>&1 &
+SRV2_PID=$!
+PORT2=""
+for _ in $(seq 1 50); do
+  PORT2=$(sed -n 's#.*://127.0.0.1:\([0-9][0-9]*\).*#\1#p' "$TMP/srv2.log" | head -1)
+  [ -n "$PORT2" ] && break
+  sleep 0.1
+done
+if [ -n "$PORT2" ]; then
+  "$DOLTLITE" "$TMP/src.db" "SELECT dolt_remote('add','plainsrv','http://localhost:$PORT2/repo.db');" >/dev/null 2>&1
+  result=$("$DOLTLITE" "$TMP/src.db" "SELECT dolt_push('plainsrv','main');" 2>&1)
+  check "plaintext push to a plaintext server still works" "0" "$result"
+else
+  echo "  SKIP: plaintext server did not start"
+fi
+kill "$SRV2_PID" 2>/dev/null
+
+echo ""
+echo "======================================="
+echo "Results: $pass passed, $fail failed"
+echo "======================================="
+[ "$fail" -eq 0 ] && exit 0 || exit 1

--- a/test/remote_https_auth_test.sh
+++ b/test/remote_https_auth_test.sh
@@ -14,12 +14,14 @@ trap cleanup EXIT
 pass=0
 fail=0
 check() {
-  if [ "$2" = "$3" ]; then echo "  PASS: $1"; pass=$((pass+1));
-  else echo "  FAIL: $1"; echo "    expected: |$2|"; echo "    actual:   |$3|"; fail=$((fail+1)); fi
+  local a="${2//$'\r'/}" b="${3//$'\r'/}"
+  if [ "$a" = "$b" ]; then echo "  PASS: $1"; pass=$((pass+1));
+  else echo "  FAIL: $1"; echo "    expected: |$a|"; echo "    actual:   |$b|"; fail=$((fail+1)); fi
 }
 check_ne() {
-  if [ "$2" != "$3" ]; then echo "  PASS: $1"; pass=$((pass+1));
-  else echo "  FAIL: $1 (got the not-allowed value |$3|)"; fail=$((fail+1)); fi
+  local a="${2//$'\r'/}" b="${3//$'\r'/}"
+  if [ "$a" != "$b" ]; then echo "  PASS: $1"; pass=$((pass+1));
+  else echo "  FAIL: $1 (got the not-allowed value |$b|)"; fail=$((fail+1)); fi
 }
 
 if ! command -v openssl >/dev/null 2>&1; then

--- a/test/remote_test.sh
+++ b/test/remote_test.sh
@@ -8,7 +8,7 @@ pass=0
 fail=0
 
 check() {
-  local desc="$1" expected="$2" actual="$3"
+  local desc="$1" expected="${2//$'\r'/}" actual="${3//$'\r'/}"
   if [ "$expected" = "$actual" ]; then
     echo "  PASS: $desc"; pass=$((pass+1))
   else
@@ -20,7 +20,7 @@ check() {
 }
 
 check_match() {
-  local desc="$1" pattern="$2" actual="$3"
+  local desc="$1" pattern="$2" actual="${3//$'\r'/}"
   if echo "$actual" | grep -qE "$pattern"; then
     echo "  PASS: $desc"; pass=$((pass+1))
   else

--- a/test/run_doltlite_tests.sh
+++ b/test/run_doltlite_tests.sh
@@ -20,7 +20,8 @@ if [ ! -x "$BUILD_DIR/doltlite" ]; then
   exit 1
 fi
 
-mapfile -t TESTS < <(doltlite_all_suites)
+TESTS=()
+while IFS= read -r line; do TESTS+=("$line"); done < <(doltlite_all_suites)
 
 total_pass=0
 total_fail=0

--- a/test/tls_test.sh
+++ b/test/tls_test.sh
@@ -4,6 +4,8 @@ set -o pipefail
 
 HERE=$(cd "$(dirname "$0")/.." && pwd)
 CC="${CC:-cc}"
+DOLTLITE_EXTRA_LIBS=""
+case "$(uname -s)" in MINGW*|MSYS*|CYGWIN*) DOLTLITE_EXTRA_LIBS="-lws2_32 -lbcrypt";; esac
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
 
@@ -21,6 +23,7 @@ echo "=== doltlite TLS test ==="
   "$HERE/test/doltlite_tls_test_main.c" \
   "$HERE/src/doltlite_tls.c" \
   "$HERE"/ext/mbedtls/library/*.c \
+  $DOLTLITE_EXTRA_LIBS \
   -o "$TMP/tls_test" 2>"$TMP/build.err" || {
   echo "  build failed:"
   cat "$TMP/build.err"

--- a/test/tls_test.sh
+++ b/test/tls_test.sh
@@ -5,7 +5,7 @@ set -o pipefail
 HERE=$(cd "$(dirname "$0")/.." && pwd)
 CC="${CC:-cc}"
 DOLTLITE_EXTRA_LIBS=""
-case "$(uname -s)" in MINGW*|MSYS*|CYGWIN*) DOLTLITE_EXTRA_LIBS="-lws2_32 -lbcrypt";; esac
+case "$(uname -s)" in MINGW*|MSYS*|CYGWIN*) DOLTLITE_EXTRA_LIBS="-lws2_32 -lbcrypt -lcrypt32";; esac
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
 


### PR DESCRIPTION
The test remote server can now serve HTTPS and verify DoltHub-compatible bearer credentials, so the client's auth support can be exercised end to end. TLS and auth are flag-gated; plaintext no-auth still works.

Server:
- doltlite_tls: server-side TLS (DoltliteTlsServer, doltliteConnServerAccept, doltliteConnFromFd), reusing DoltliteConn; connections own their fd.
- doltlite_creds: doltliteCredsVerifyBearer (ed25519 sig + issuer + subject + audience + expiry, mirroring ld's remoteauth) and doltliteCredsLoadPubKey, which reads authorized <kid>.jwk public keys.
- doltlite_remotesrv: route request I/O through DoltliteConn (TLS or plain), extract the Authorization header, and require a valid bearer on every endpoint when an authorized-keys dir is configured (401 otherwise). New DoltliteServeOpts + doltliteServe{,Async}Opts; old entry points kept as plaintext/no-auth wrappers.
- remotesrv_main: --cert/--key/--auth-keys/--audience flags; prints the actual bound port (supports -p 0) and stops on SIGINT/SIGTERM.
- main.mk: build ext/ed25519/verify.c (server needs ed25519_verify).

Tests:
- test/creds_verify_kat.c + creds_verify_test.sh: hermetic KAT for the verifier (valid accepted; expired / wrong-audience / unknown-key / tampered / malformed rejected).
- test/remote_https_auth_test.sh: real client <-> real server over https with auth — push + clone round-trip, and negative cases (no credential, unauthorized key, plaintext-to-TLS, wrong CA) all rejected, plus a plaintext-server backward-compat check.
- CI: build doltlite-remotesrv and run both new suites.