### PR TITLE
Tighten GC leaf chunk classification

### DIFF
--- a/src/doltlite_chunk_walk.c
+++ b/src/doltlite_chunk_walk.c
@@ -56,10 +56,11 @@ DoltliteChunkType doltliteClassifyChunk(const u8 *data, int nData){
   ** Both are leaves: they embed whole row payloads and reference no other
   ** chunks. */
   if( nData >= 6
-   && data[0]=='D' && data[1]=='L' && data[2]=='C' && data[3]!='T' ){
+   && data[0]=='D' && data[1]=='L' && data[2]=='C' && data[3]==1 ){
     return CHUNK_CONFLICTS;
   }
-  if( nData >= 6 && data[0]=='D' && data[1]=='C' && data[2]=='V' ){
+  if( nData >= 6
+   && data[0]=='D' && data[1]=='C' && data[2]=='V' && data[3]==1 ){
     return CHUNK_CONSTRAINT_VIOLATIONS;
   }
 

--- a/test/doltlite_regression_test_c.c
+++ b/test/doltlite_regression_test_c.c
@@ -1226,6 +1226,23 @@ static void run_chunk_walk_corruption(void){
   check("truncated_catalog_is_corrupt", rc==SQLITE_CORRUPT);
 
   {
+    static const u8 badConflictFrame[] = {
+      'D','L','C', 2,
+      0, 0
+    };
+    static const u8 badConstraintFrame[] = {
+      'D','C','V', 2,
+      0, 0
+    };
+    rc = doltliteEnumerateChunkChildren(badConflictFrame,
+                                        (int)sizeof(badConflictFrame), 0, 0);
+    check("bad_conflict_frame_version_is_corrupt", rc==SQLITE_CORRUPT);
+    rc = doltliteEnumerateChunkChildren(badConstraintFrame,
+                                        (int)sizeof(badConstraintFrame), 0, 0);
+    check("bad_constraint_frame_version_is_corrupt", rc==SQLITE_CORRUPT);
+  }
+
+  {
     static const u8 legacyCatalogV2[] = {
       0x43,
       1, 0, 0, 0,


### PR DESCRIPTION
## Summary
- require the current framed version byte when classifying conflict and constraint-violation chunks during GC walks
- avoid accepting malformed `DLC*` / `DCV*` chunks as leaf chunks
- add direct C regression checks for malformed framed chunk versions

## Verification
- `make -j8 libdoltlite.a doltlite`
- `DOLTLITE_BUILD_DIR=build bash test/run_doltlite_regression_case.sh chunk_walk_corruption`
- `DOLTLITE=build/doltlite bash test/doltlite_gc_commit_classify.sh`
- `DOLTLITE=build/doltlite bash test/doltlite_gc.sh`
- `DOLTLITE_BUILD_DIR=build bash test/doltlite_regression_test_c.sh`