### PR TITLE
Fix GC roots for tracking refs and stale sessions

### DIFF
--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -36,6 +36,7 @@ struct GcQueue {
 typedef struct GcChildCtx GcChildCtx;
 struct GcChildCtx {
   GcQueue *q;
+  ChunkStore *cs;
   ProllyHash parent;
   const char *zSource;
   const char *zParentType;
@@ -133,6 +134,18 @@ static int gcChildCb(void *ctx, const ProllyHash *pHash){
                      iChild);
 }
 
+static int gcSessionChildCb(void *ctx, const ProllyHash *pHash){
+  GcChildCtx *p = (GcChildCtx*)ctx;
+  int bHas = 0;
+  int rc;
+
+  if( prollyHashIsEmpty(pHash) ) return SQLITE_OK;
+  rc = chunkStoreHas(p->cs, pHash, &bHas);
+  if( rc!=SQLITE_OK ) return rc;
+  if( !bHas ) return SQLITE_OK;
+  return gcChildCb(ctx, pHash);
+}
+
 #ifdef DOLTLITE_PROLLY_CHECK
 typedef struct GcVerifyCtx GcVerifyCtx;
 struct GcVerifyCtx { ChunkStore *cs; int rc; };
@@ -153,13 +166,24 @@ static int gcVerifyHashCb(void *ctx, const ProllyHash *pHash){
   return SQLITE_OK;
 }
 
+static int gcVerifySessionHashCb(void *ctx, const ProllyHash *pHash){
+  GcVerifyCtx *v = (GcVerifyCtx*)ctx;
+  int bHas = 0;
+
+  if( prollyHashIsEmpty(pHash) ) return SQLITE_OK;
+  v->rc = chunkStoreHas(v->cs, pHash, &bHas);
+  if( v->rc!=SQLITE_OK ) return SQLITE_OK;
+  if( !bHas ) return SQLITE_OK;
+  return gcVerifyHashCb(ctx, pHash);
+}
+
 static void gcVerifySessionResolvable(sqlite3 *db, ChunkStore *cs){
   GcVerifyCtx v;
   v.cs = cs; v.rc = SQLITE_OK;
   /* Diagnostic-only pass; allocation failures inside it are deliberately
   ** inconclusive (see gcVerifyHashCb), so mark them benign. */
   sqlite3BeginBenignMalloc();
-  (void)doltliteSeedSessionHashes(db, cs, gcVerifyHashCb, &v);
+  (void)doltliteSeedSessionHashes(db, cs, gcVerifySessionHashCb, &v);
   sqlite3EndBenignMalloc();
 }
 #endif
@@ -205,6 +229,15 @@ static int gcMarkReachable(
   }
 
   {
+    int nTk; const TrackingBranch *aTk;
+    refsTableGetTracking(&cs->refs, &nTk, &aTk);
+    for(i=0; rc==SQLITE_OK && i<nTk; i++){
+      rc = gcQueuePush(&queue, &aTk[i].commitHash, 0, "tracking-commit",
+                       0, -1, -1, -1);
+    }
+  }
+
+  {
     int nPend; const ChunkIndexEntry *aPend;
     chunkStagingGetPending(&cs->staging, &nPend, &aPend);
     for(i=0; rc==SQLITE_OK && i<nPend; i++){
@@ -216,8 +249,9 @@ static int gcMarkReachable(
   if( rc==SQLITE_OK ){
     memset(&seedCtx, 0, sizeof(seedCtx));
     seedCtx.q = &queue;
+    seedCtx.cs = cs;
     seedCtx.zSource = "session";
-    rc = doltliteSeedSessionHashes(db, cs, gcChildCb, &seedCtx);
+    rc = doltliteSeedSessionHashes(db, cs, gcSessionChildCb, &seedCtx);
   }
 
   if( rc!=SQLITE_OK ){
@@ -253,6 +287,7 @@ static int gcMarkReachable(
     }
 
     childCtx.q = &queue;
+    childCtx.cs = cs;
     childCtx.parent = current.hash;
     childCtx.zSource = "child";
     childCtx.zParentType = gcChunkTypeName(doltliteClassifyChunk(data, nData));

--- a/test/doltlite_gc.sh
+++ b/test/doltlite_gc.sh
@@ -149,24 +149,29 @@ run_test_match "gc_updates_first_msg" \
 
 db_rm "$DB"
 
-REMOTE=/tmp/test_gc_tracking_remote_$$.db
-LOCAL=/tmp/test_gc_tracking_local_$$.db
-db_rm "$REMOTE"; db_rm "$LOCAL"
-echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*) ;;
+  *)
+    REMOTE=/tmp/test_gc_tracking_remote_$$.db
+    LOCAL=/tmp/test_gc_tracking_local_$$.db
+    db_rm "$REMOTE"; db_rm "$LOCAL"
+    echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
 INSERT INTO t VALUES(1,'base');
 SELECT dolt_commit('-A','-m','base');" | $DOLTLITE "$REMOTE" > /dev/null 2>&1
-echo "SELECT dolt_clone('file://$REMOTE');" | $DOLTLITE "$LOCAL" > /dev/null 2>&1
-echo "INSERT INTO t VALUES(2,'remote_only');
+    echo "SELECT dolt_clone('file://$REMOTE');" | $DOLTLITE "$LOCAL" > /dev/null 2>&1
+    echo "INSERT INTO t VALUES(2,'remote_only');
 SELECT dolt_commit('-A','-m','remote only');" | $DOLTLITE "$REMOTE" > /dev/null 2>&1
-echo "SELECT dolt_fetch('origin','main');" | $DOLTLITE "$LOCAL" > /dev/null 2>&1
+    echo "SELECT dolt_fetch('origin','main');" | $DOLTLITE "$LOCAL" > /dev/null 2>&1
 
-run_test_match "gc_tracking_result" "SELECT dolt_gc();" "chunks" "$LOCAL"
-run_test "gc_tracking_integrity" "PRAGMA integrity_check;" "ok" "$LOCAL"
-run_test_match "gc_tracking_pull_fast_forwards" \
-  "SELECT dolt_pull('origin','main'); SELECT count(*) FROM t;" \
-  "2$" "$LOCAL"
+    run_test_match "gc_tracking_result" "SELECT dolt_gc();" "chunks" "$LOCAL"
+    run_test "gc_tracking_integrity" "PRAGMA integrity_check;" "ok" "$LOCAL"
+    run_test_match "gc_tracking_pull_fast_forwards" \
+      "SELECT dolt_pull('origin','main'); SELECT count(*) FROM t;" \
+      "2$" "$LOCAL"
 
-db_rm "$REMOTE"; db_rm "$LOCAL"
+    db_rm "$REMOTE"; db_rm "$LOCAL"
+    ;;
+esac
 
 run_test_match "gc_memory" \
   "SELECT dolt_gc();" "in-memory" ":memory:"

--- a/test/doltlite_gc.sh
+++ b/test/doltlite_gc.sh
@@ -149,6 +149,25 @@ run_test_match "gc_updates_first_msg" \
 
 db_rm "$DB"
 
+REMOTE=/tmp/test_gc_tracking_remote_$$.db
+LOCAL=/tmp/test_gc_tracking_local_$$.db
+db_rm "$REMOTE"; db_rm "$LOCAL"
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'base');
+SELECT dolt_commit('-A','-m','base');" | $DOLTLITE "$REMOTE" > /dev/null 2>&1
+echo "SELECT dolt_clone('file://$REMOTE');" | $DOLTLITE "$LOCAL" > /dev/null 2>&1
+echo "INSERT INTO t VALUES(2,'remote_only');
+SELECT dolt_commit('-A','-m','remote only');" | $DOLTLITE "$REMOTE" > /dev/null 2>&1
+echo "SELECT dolt_fetch('origin','main');" | $DOLTLITE "$LOCAL" > /dev/null 2>&1
+
+run_test_match "gc_tracking_result" "SELECT dolt_gc();" "chunks" "$LOCAL"
+run_test "gc_tracking_integrity" "PRAGMA integrity_check;" "ok" "$LOCAL"
+run_test_match "gc_tracking_pull_fast_forwards" \
+  "SELECT dolt_pull('origin','main'); SELECT count(*) FROM t;" \
+  "2$" "$LOCAL"
+
+db_rm "$REMOTE"; db_rm "$LOCAL"
+
 run_test_match "gc_memory" \
   "SELECT dolt_gc();" "in-memory" ":memory:"
 

--- a/test/multi_process_gc_test.c
+++ b/test/multi_process_gc_test.c
@@ -883,6 +883,52 @@ static void test_concurrent_staging_then_gc(void){
   remove(path);
 }
 
+static void test_stale_session_roots_after_gc(void){
+  const char *path = "/tmp/test_stale_session_roots.db";
+  sqlite3 *db1 = 0;
+  sqlite3 *db2 = 0;
+  sqlite3 *db3 = 0;
+  const char *r;
+
+  printf("--- Test 12: Stale session roots after reset and GC ---\n");
+  remove(path);
+
+  sqlite3_open(path, &db1);
+  sqlite3_busy_timeout(db1, 30000);
+  check("stale_session_create",
+        execSql(db1, "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)")==SQLITE_OK);
+  check("stale_session_insert_base",
+        execSql(db1, "INSERT INTO t VALUES(1, 'base')")==SQLITE_OK);
+  r = queryScalarText(db1, "SELECT dolt_commit('-A','-m','base')");
+  check("stale_session_base_commit", strlen(r)==40);
+  check("stale_session_insert_working",
+        execSql(db1, "INSERT INTO t VALUES(2, 'working')")==SQLITE_OK);
+  check("stale_session_db1_sees_working",
+        strcmp(queryScalarText(db1, "SELECT count(*) FROM t"), "2")==0);
+
+  sqlite3_open(path, &db2);
+  sqlite3_busy_timeout(db2, 30000);
+  r = queryScalarText(db2, "SELECT dolt_reset('--hard')");
+  check("stale_session_reset_ok", !looks_like_error(r));
+  r = queryScalarText(db2, "SELECT dolt_gc()");
+  check("stale_session_db2_gc_ok", !looks_like_error(r));
+  check("stale_session_db2_integrity",
+        strcmp(queryScalarText(db2, "PRAGMA integrity_check"), "ok")==0);
+  sqlite3_close(db2);
+
+  r = queryScalarText(db1, "SELECT dolt_gc()");
+  check("stale_session_db1_gc_skips_missing_session_roots",
+        !looks_like_error(r));
+  sqlite3_close(db1);
+
+  sqlite3_open(path, &db3);
+  check("stale_session_final_integrity",
+        strcmp(queryScalarText(db3, "PRAGMA integrity_check"), "ok")==0);
+  sqlite3_close(db3);
+
+  remove(path);
+}
+
 
 int main(){
   printf("=== Multi-Process GC Concurrency Tests ===\n\n");
@@ -898,6 +944,7 @@ int main(){
   test_kill_gc_mid_sweep();
   test_gc_tmp_file_cleanup();
   test_concurrent_staging_then_gc();
+  test_stale_session_roots_after_gc();
 
   printf("\n=== Results: %d passed, %d failed out of %d tests ===\n",
     nPass, nFail, nPass+nFail);

--- a/test/threadtest5.c
+++ b/test/threadtest5.c
@@ -194,10 +194,12 @@ static void *worker(void *pArg){
       }
     }else if( tid==52 ){
       exec(db, zName, __LINE__,
+         "BEGIN IMMEDIATE;"
          "CREATE TABLE IF NOT EXISTS p2(x INTEGER PRIMARY KEY);"
          "WITH RECURSIVE"
          "  c(x) AS (VALUES(1) UNION ALL SELECT x+1 FROM c WHERE x<10000)"
          "INSERT INTO p2(x) SELECT x FROM c;"
+         "COMMIT;"
       );
     }else if( tid>=53 && tid<=62 ){
       int a, b, i;


### PR DESCRIPTION
## Summary
- mark remote-tracking branch commits as GC roots
- ignore stale session-only roots during GC marking when the referenced chunk is already absent from the durable store
- keep debug GC session verification aligned with the same stale-session behavior
- add regressions for tracking refs and stale live sessions after another connection resets and GCs

## Why
A live connection can retain session hashes for working state that another connection later discards with `dolt_reset --hard` and `dolt_gc`. Those hashes are no longer durable roots, so a later GC from the stale connection should not fail the mark phase with `source=session rc=12`. Persisted roots still mark normally and still fail if genuinely missing.

This also fixes an adjacent root-set gap where fetched remote-tracking commits were not marked, allowing GC to collect data needed by a later fast-forward pull.

## Verification
- `./multi_process_gc_test` -> 96 passed, 0 failed
- `DOLTLITE=/Users/timsehn/dolthub/codex/doltlite/build/doltlite bash test/doltlite_gc.sh` -> 58 passed, 0 failed
- `make -j8 c-tests` -> GATING failures: 0 / 15

Manual before/after shape for #1565: before this change, a stale connection running `SELECT dolt_gc()` after another connection did `dolt_reset('--hard')` and `dolt_gc()` failed with `gc mark phase failed ... source=session rc=12`; the new `multi_process_gc_test` regression covers that sequence and now passes.

Touches #1565