### PR TITLE
Fix OOM handling for pending index scans

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -6932,13 +6932,23 @@ static int mergeScan(BtCursor *pCur, int dir, int *pRes){
   }
 }
 
-static void cursorNormalizeMmPhys(BtCursor *pCur){
+static int ensureCursorMutMapOrder(BtCursor *pCur){
+  if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
+    return prollyMutMapEnsureOrder(pCur->pMutMap);
+  }
+  return SQLITE_OK;
+}
+
+static int cursorNormalizeMmPhys(BtCursor *pCur){
   if( pCur->mmPhysActive ){
+    int rc = ensureCursorMutMapOrder(pCur);
+    if( rc!=SQLITE_OK ) return rc;
     pCur->mmIdx = prollyMutMapOrderIndexFromEntry(
         pCur->pMutMap, &pCur->pMutMap->aEntries[pCur->mmPhysIdx]);
     pCur->mmPhysIdx = -1;
     pCur->mmPhysActive = 0;
   }
+  return SQLITE_OK;
 }
 
 static int materializeDeferredTreeSeek(BtCursor *pCur, int dir){
@@ -6990,6 +7000,8 @@ static int deferredMergedSeekPosition(BtCursor *pCur){
     rc = prollyCursorNext(&pCur->pCur);
     if( rc!=SQLITE_OK ) return rc;
   }
+  rc = ensureCursorMutMapOrder(pCur);
+  if( rc!=SQLITE_OK ) return rc;
   prollyMutMapIterSeek(&it, pCur->pMutMap, 0, 0, intKey);
   pCur->mmIdx = it.idx;
   pCur->mmActive = 1;
@@ -7054,7 +7066,8 @@ static int materializeDeferredMergedSeekBackward(BtCursor *pCur){
 
 static int mergeStepForward(BtCursor *pCur){
   int rc = SQLITE_OK;
-  cursorNormalizeMmPhys(pCur);
+  rc = cursorNormalizeMmPhys(pCur);
+  if( rc!=SQLITE_OK ) return rc;
   if( pCur->deferredMergedSeek ){
     /* The cursor conceptually sits on the hole left at cachedIntKey, so a
     ** forward step means landing on the first live row above it. */
@@ -7077,7 +7090,8 @@ static int mergeStepForward(BtCursor *pCur){
 
 static int mergeStepBackward(BtCursor *pCur){
   int rc = SQLITE_OK;
-  cursorNormalizeMmPhys(pCur);
+  rc = cursorNormalizeMmPhys(pCur);
+  if( rc!=SQLITE_OK ) return rc;
   if( pCur->deferredMergedSeek ){
     /* The cursor conceptually sits on the hole left at cachedIntKey. Seed
     ** both sides at the first entries >= the key so the normal backward
@@ -7105,6 +7119,8 @@ static int seedMutMapIterFromCursor(
 ){
   if( pCur->curIntKey ){
     if( pCur->curFlags & (BTCF_ValidNKey|BTCF_DeleteKey) ){
+      int rc = ensureCursorMutMapOrder(pCur);
+      if( rc!=SQLITE_OK ) return rc;
       prollyMutMapIterSeek(pIt, pCur->pMutMap, 0, 0, pCur->cachedIntKey);
       return SQLITE_OK;
     }
@@ -7122,6 +7138,11 @@ static int seedMutMapIterFromCursor(
                                         nMutKeyField, pCur->pKeyInfo,
                                         &pSortKey, &nSortKey);
       if( rc!=SQLITE_OK ) return rc;
+      rc = ensureCursorMutMapOrder(pCur);
+      if( rc!=SQLITE_OK ){
+        sqlite3_free(pSortKey);
+        return rc;
+      }
       prollyMutMapIterSeek(pIt, pCur->pMutMap, pSortKey, nSortKey, 0);
       sqlite3_free(pSortKey);
       return SQLITE_OK;
@@ -7131,12 +7152,16 @@ static int seedMutMapIterFromCursor(
 }
 
 static int mergeFirst(BtCursor *pCur, int *pRes){
+  int rc = ensureCursorMutMapOrder(pCur);
+  if( rc!=SQLITE_OK ) return rc;
   pCur->mergeSrc = MERGE_SRC_TREE;
   pCur->mmIdx = 0;
   return mergeScan(pCur, 1, pRes);
 }
 
 static int mergeLast(BtCursor *pCur, int *pRes){
+  int rc = ensureCursorMutMapOrder(pCur);
+  if( rc!=SQLITE_OK ) return rc;
   pCur->mmIdx = pCur->pMutMap->nEntries - 1;
   pCur->mergeSrc = MERGE_SRC_TREE;
   return mergeScan(pCur, -1, pRes);
@@ -7157,6 +7182,7 @@ static int prollyBtCursorFirst(BtCursor *pCur, int *pRes){
   if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
     pCur->mmActive = 1;
     rc = mergeFirst(pCur, pRes);
+    if( rc!=SQLITE_OK ) return rc;
   }else{
     pCur->mmActive = 0;
   }
@@ -7187,6 +7213,7 @@ static int prollyBtCursorLast(BtCursor *pCur, int *pRes){
   if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
     pCur->mmActive = 1;
     rc = mergeLast(pCur, pRes);
+    if( rc!=SQLITE_OK ) return rc;
   }else{
     pCur->mmActive = 0;
   }
@@ -7271,7 +7298,8 @@ static int prollyBtCursorNext(BtCursor *pCur, int flags){
 
     if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
       ProllyMutMapIter it;
-      rc = SQLITE_OK;
+      rc = ensureCursorMutMapOrder(pCur);
+      if( rc!=SQLITE_OK ) return rc;
       if( pCur->curIntKey && prollyCursorIsValid(&pCur->pCur) ){
         prollyMutMapIterSeek(&it, pCur->pMutMap, 0, 0,
                              prollyCursorIntKey(&pCur->pCur));
@@ -7380,7 +7408,8 @@ static int prollyBtCursorPrevious(BtCursor *pCur, int flags){
   }else{
     if( pCur->pMutMap && !prollyMutMapIsEmpty(pCur->pMutMap) ){
       ProllyMutMapIter it;
-      rc = SQLITE_OK;
+      rc = ensureCursorMutMapOrder(pCur);
+      if( rc!=SQLITE_OK ) return rc;
       if( pCur->curIntKey && prollyCursorIsValid(&pCur->pCur) ){
         prollyMutMapIterSeek(&it, pCur->pMutMap, 0, 0,
                              prollyCursorIntKey(&pCur->pCur));

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1083,11 +1083,9 @@ cffault cffault-2.1-full.1                 # cacheflush fault during unordered s
 cffault cffault-2.1-ioerr-persistent.1     # cacheflush fault during unordered scan
 cffault cffault-2.1-ioerr-transient.1      # cacheflush fault during unordered scan
 cffault cffault-2.1-oom-persistent.31      # cacheflush fault during unordered scan
-cffault cffault-2.1-oom-transient.28       # cacheflush fault during unordered scan
 cffault cffault-2.1-oom-transient.31       # cacheflush fault during unordered scan
 cffault cffault-2.1-shmerr-persistent.1    # cacheflush fault during unordered scan
 cffault cffault-2.1-shmerr-transient.1     # cacheflush fault during unordered scan
-cffault cffault-2.4-oom-transient.22       # cacheflush/release-memory unordered scan
 # vacuum5 — VACUUM file-size / page-count metrics; doltlite has no SQLite page
 # format so the byte/page counts differ (the data is correct). Recovered into
 # the gate once the cross-backend TransferRow SEGV was fixed.


### PR DESCRIPTION
## Summary
- force pending mutmaps into sorted order before merged cursor scans or seeks use ordered indexes
- propagate OOM from that ordering step instead of scanning stale append order
- remove the now-fixed cffault divergence entries for #1570

Fixes #1570.

## Tests
- LDFLAGS="-L/opt/homebrew/lib" CPPFLAGS="-I/opt/homebrew/include" LIBRARY_PATH="/opt/homebrew/lib:${LIBRARY_PATH:-}" ./testfixture /tmp/repro1570.tcl
- bash ../test/run_testfixture.sh "SQLite regression fault-fuzz subset" 300 cffault
- make -j8 c-tests