### PR TITLE
Propagate mutmap iterator OOM instead of scanning a stale order

### DIFF
--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -7000,9 +7000,8 @@ static int deferredMergedSeekPosition(BtCursor *pCur){
     rc = prollyCursorNext(&pCur->pCur);
     if( rc!=SQLITE_OK ) return rc;
   }
-  rc = ensureCursorMutMapOrder(pCur);
+  rc = prollyMutMapIterSeek(&it, pCur->pMutMap, 0, 0, intKey);
   if( rc!=SQLITE_OK ) return rc;
-  prollyMutMapIterSeek(&it, pCur->pMutMap, 0, 0, intKey);
   pCur->mmIdx = it.idx;
   pCur->mmActive = 1;
   return SQLITE_OK;
@@ -7119,10 +7118,8 @@ static int seedMutMapIterFromCursor(
 ){
   if( pCur->curIntKey ){
     if( pCur->curFlags & (BTCF_ValidNKey|BTCF_DeleteKey) ){
-      int rc = ensureCursorMutMapOrder(pCur);
-      if( rc!=SQLITE_OK ) return rc;
-      prollyMutMapIterSeek(pIt, pCur->pMutMap, 0, 0, pCur->cachedIntKey);
-      return SQLITE_OK;
+      return prollyMutMapIterSeek(pIt, pCur->pMutMap, 0, 0,
+                                  pCur->cachedIntKey);
     }
   }else{
     if( pCur->pCachedPayload && pCur->nCachedPayload > 0 ){
@@ -7138,14 +7135,9 @@ static int seedMutMapIterFromCursor(
                                         nMutKeyField, pCur->pKeyInfo,
                                         &pSortKey, &nSortKey);
       if( rc!=SQLITE_OK ) return rc;
-      rc = ensureCursorMutMapOrder(pCur);
-      if( rc!=SQLITE_OK ){
-        sqlite3_free(pSortKey);
-        return rc;
-      }
-      prollyMutMapIterSeek(pIt, pCur->pMutMap, pSortKey, nSortKey, 0);
+      rc = prollyMutMapIterSeek(pIt, pCur->pMutMap, pSortKey, nSortKey, 0);
       sqlite3_free(pSortKey);
-      return SQLITE_OK;
+      return rc;
     }
   }
   return SQLITE_NOTFOUND;
@@ -7301,21 +7293,21 @@ static int prollyBtCursorNext(BtCursor *pCur, int flags){
       rc = ensureCursorMutMapOrder(pCur);
       if( rc!=SQLITE_OK ) return rc;
       if( pCur->curIntKey && prollyCursorIsValid(&pCur->pCur) ){
-        prollyMutMapIterSeek(&it, pCur->pMutMap, 0, 0,
-                             prollyCursorIntKey(&pCur->pCur));
+        rc = prollyMutMapIterSeek(&it, pCur->pMutMap, 0, 0,
+                                  prollyCursorIntKey(&pCur->pCur));
       }else if( !pCur->curIntKey && prollyCursorIsValid(&pCur->pCur) ){
         const u8 *pK; int nK;
         prollyCursorKey(&pCur->pCur, &pK, &nK);
-        prollyMutMapIterSeek(&it, pCur->pMutMap, pK, nK, 0);
+        rc = prollyMutMapIterSeek(&it, pCur->pMutMap, pK, nK, 0);
       }else if( pCur->eState==CURSOR_VALID ){
         rc = seedMutMapIterFromCursor(pCur, &it);
-        if( rc!=SQLITE_OK && rc!=SQLITE_NOTFOUND ) return rc;
         if( rc==SQLITE_NOTFOUND ){
-          prollyMutMapIterFirst(&it, pCur->pMutMap);
+          rc = prollyMutMapIterFirst(&it, pCur->pMutMap);
         }
       }else{
-        prollyMutMapIterFirst(&it, pCur->pMutMap);
+        rc = prollyMutMapIterFirst(&it, pCur->pMutMap);
       }
+      if( rc!=SQLITE_OK ) return rc;
       pCur->mmIdx = it.idx;
       pCur->mmActive = 1;
 
@@ -7411,8 +7403,9 @@ static int prollyBtCursorPrevious(BtCursor *pCur, int flags){
       rc = ensureCursorMutMapOrder(pCur);
       if( rc!=SQLITE_OK ) return rc;
       if( pCur->curIntKey && prollyCursorIsValid(&pCur->pCur) ){
-        prollyMutMapIterSeek(&it, pCur->pMutMap, 0, 0,
-                             prollyCursorIntKey(&pCur->pCur));
+        rc = prollyMutMapIterSeek(&it, pCur->pMutMap, 0, 0,
+                                  prollyCursorIntKey(&pCur->pCur));
+        if( rc!=SQLITE_OK ) return rc;
         if( it.idx >= pCur->pMutMap->nEntries
          || mergeCompare(pCur, orderedMutMapEntryAt(pCur->pMutMap, it.idx))>=0
          || orderedMutMapEntryAt(pCur->pMutMap, it.idx)->op==PROLLY_EDIT_DELETE
@@ -7422,7 +7415,8 @@ static int prollyBtCursorPrevious(BtCursor *pCur, int flags){
       }else if( !pCur->curIntKey && prollyCursorIsValid(&pCur->pCur) ){
         const u8 *pK; int nK;
         prollyCursorKey(&pCur->pCur, &pK, &nK);
-        prollyMutMapIterSeek(&it, pCur->pMutMap, pK, nK, 0);
+        rc = prollyMutMapIterSeek(&it, pCur->pMutMap, pK, nK, 0);
+        if( rc!=SQLITE_OK ) return rc;
         if( it.idx >= pCur->pMutMap->nEntries
          || mergeCompare(pCur, orderedMutMapEntryAt(pCur->pMutMap, it.idx))>=0
          || orderedMutMapEntryAt(pCur->pMutMap, it.idx)->op==PROLLY_EDIT_DELETE
@@ -7431,15 +7425,15 @@ static int prollyBtCursorPrevious(BtCursor *pCur, int flags){
         }
       }else if( pCur->eState==CURSOR_VALID ){
         rc = seedMutMapIterFromCursor(pCur, &it);
-        if( rc!=SQLITE_OK && rc!=SQLITE_NOTFOUND ) return rc;
         if( rc==SQLITE_NOTFOUND ){
-          prollyMutMapIterLast(&it, pCur->pMutMap);
-        }else{
+          rc = prollyMutMapIterLast(&it, pCur->pMutMap);
+        }else if( rc==SQLITE_OK ){
           it.idx--;
         }
       }else{
-        prollyMutMapIterLast(&it, pCur->pMutMap);
+        rc = prollyMutMapIterLast(&it, pCur->pMutMap);
       }
+      if( rc!=SQLITE_OK ) return rc;
       pCur->mmIdx = it.idx;
       pCur->mmActive = 1;
 

--- a/src/prolly_mutate.c
+++ b/src/prolly_mutate.c
@@ -39,7 +39,11 @@ static int buildFromEdits(
                                   pMut->flags);
   if( rc!=SQLITE_OK ) return rc;
 
-  prollyMutMapIterFirst(&iter, pMut->pEdits);
+  rc = prollyMutMapIterFirst(&iter, pMut->pEdits);
+  if( rc!=SQLITE_OK ){
+    prollyChunkerFree(&chunker);
+    return rc;
+  }
   while( prollyMutMapIterValid(&iter) ){
     ProllyMutMapEntry *pEntry = prollyMutMapIterEntry(&iter);
     if( pEntry->op==PROLLY_EDIT_INSERT ){
@@ -268,9 +272,11 @@ static int streamingMerge(
     }
   }
 
-  prollyMutMapIterFirst(&iter, pMut->pEdits);
-  rc = prollyChunkerInitWithCache(&chunker, pMut->pStore, pMut->pCache,
-                                  pMut->flags);
+  rc = prollyMutMapIterFirst(&iter, pMut->pEdits);
+  if( rc==SQLITE_OK ){
+    rc = prollyChunkerInitWithCache(&chunker, pMut->pStore, pMut->pCache,
+                                    pMut->flags);
+  }
   if( rc!=SQLITE_OK ){
     if( pRootEntry ) prollyCacheRelease(pCache, pRootEntry);
     sqlite3_free(pRootData);
@@ -1294,7 +1300,8 @@ static int tryReplaceBatchNoRechunk(ProllyMutator *pMut){
     }
   }
 
-  prollyMutMapIterFirst(&iter, pMut->pEdits);
+  rc = prollyMutMapIterFirst(&iter, pMut->pEdits);
+  if( rc!=SQLITE_OK ) goto replace_batch_cleanup;
   if( prollyMutMapIterValid(&iter) && pRootNode->nItems>0 ){
     ProllyMutMapEntry *pFirst = prollyMutMapIterEntry(&iter);
     const u8 *pMaxKey;
@@ -1311,7 +1318,9 @@ static int tryReplaceBatchNoRechunk(ProllyMutator *pMut){
     rc = SQLITE_NOTFOUND;
   }
   if( rc==SQLITE_OK ){
-    prollyMutMapIterFirst(&iter, pMut->pEdits);
+    rc = prollyMutMapIterFirst(&iter, pMut->pEdits);
+  }
+  if( rc==SQLITE_OK ){
     rc = replaceBatchNodeNoRechunk(pMut, pRootNode, &iter, 1,
                                    &newRoot, &changed);
   }
@@ -1367,7 +1376,7 @@ int prollyMutateFlush(ProllyMutator *pMut){
      && prollyHashIsEmpty(&pMut->newRoot) ){
       ProllyMutMapIter it;
       int hasInsert = 0;
-      prollyMutMapIterFirst(&it, pMut->pEdits);
+      (void)prollyMutMapIterFirst(&it, pMut->pEdits);
       while( prollyMutMapIterValid(&it) ){
         ProllyMutMapEntry *pEntry = prollyMutMapIterEntry(&it);
         if( pEntry->op==PROLLY_EDIT_INSERT ){

--- a/src/prolly_mutmap.c
+++ b/src/prolly_mutmap.c
@@ -442,9 +442,7 @@ static int ensureOrder(ProllyMutMap *mm){
 }
 
 /* Materialize the sorted iteration order now, propagating an allocation
-** failure. The void iterator-init helpers call ensureOrder() internally and
-** discard its return code, so a caller that must not iterate a stale order
-** under OOM (e.g. a tree build) calls this first and bails on error. */
+** failure. */
 int prollyMutMapEnsureOrder(ProllyMutMap *mm){
   return ensureOrder(mm);
 }
@@ -1025,10 +1023,11 @@ int prollyMutMapIsEmpty(ProllyMutMap *mm){
   return mm->nEntries == 0;
 }
 
-void prollyMutMapIterFirst(ProllyMutMapIter *it, ProllyMutMap *mm){
-  ensureOrder(mm);
+int prollyMutMapIterFirst(ProllyMutMapIter *it, ProllyMutMap *mm){
+  int rc = ensureOrder(mm);
   it->pMap = mm;
-  it->idx = 0;
+  it->idx = rc==SQLITE_OK ? 0 : mm->nEntries;
+  return rc;
 }
 
 void prollyMutMapIterNext(ProllyMutMapIter *it){
@@ -1043,20 +1042,26 @@ ProllyMutMapEntry *prollyMutMapIterEntry(ProllyMutMapIter *it){
   return entryAtOrder(it->pMap, it->idx);
 }
 
-void prollyMutMapIterSeek(ProllyMutMapIter *it, ProllyMutMap *mm,
-                          const u8 *pKey, int nKey, i64 intKey){
+int prollyMutMapIterSeek(ProllyMutMapIter *it, ProllyMutMap *mm,
+                         const u8 *pKey, int nKey, i64 intKey){
   int found = 0;
   u8 keyBuf[8];
-  ensureOrder(mm);
-  prepKey(mm, &pKey, &nKey, intKey, keyBuf);
+  int rc = ensureOrder(mm);
   it->pMap = mm;
+  if( rc!=SQLITE_OK ){
+    it->idx = mm->nEntries;
+    return rc;
+  }
+  prepKey(mm, &pKey, &nKey, intKey, keyBuf);
   it->idx = bsearch_key(mm, pKey, nKey, &found);
+  return SQLITE_OK;
 }
 
-void prollyMutMapIterLast(ProllyMutMapIter *it, ProllyMutMap *mm){
-  ensureOrder(mm);
+int prollyMutMapIterLast(ProllyMutMapIter *it, ProllyMutMap *mm){
+  int rc = ensureOrder(mm);
   it->pMap = mm;
-  it->idx = mm->nEntries>0 ? mm->nEntries - 1 : mm->nEntries;
+  it->idx = (rc==SQLITE_OK && mm->nEntries>0) ? mm->nEntries - 1 : mm->nEntries;
+  return rc;
 }
 
 void prollyMutMapClear(ProllyMutMap *mm){

--- a/src/prolly_mutmap.h
+++ b/src/prolly_mutmap.h
@@ -121,12 +121,14 @@ struct ProllyMutMapIter {
 };
 
 /* Compute the sorted iteration order up front, returning SQLITE_NOMEM on
-** allocation failure. IterFirst/IterLast/IterSeek compute it lazily and
-** discard the error, so callers that must not iterate a stale order on OOM
-** (e.g. a tree build) should call this first and bail on failure. */
+** allocation failure. Useful before a loop of ordered reads that cannot
+** conveniently propagate an error mid-iteration. */
 int prollyMutMapEnsureOrder(ProllyMutMap *mm);
 
-void prollyMutMapIterFirst(ProllyMutMapIter *it, ProllyMutMap *mm);
+/* Iterator initializers materialize the sorted order and return SQLITE_NOMEM
+** if that allocation fails; the iterator is left invalid (past the end) so an
+** unchecked caller iterates nothing rather than a stale order. */
+int prollyMutMapIterFirst(ProllyMutMapIter *it, ProllyMutMap *mm);
 
 void prollyMutMapIterNext(ProllyMutMapIter *it);
 
@@ -134,10 +136,10 @@ int prollyMutMapIterValid(ProllyMutMapIter *it);
 
 ProllyMutMapEntry *prollyMutMapIterEntry(ProllyMutMapIter *it);
 
-void prollyMutMapIterSeek(ProllyMutMapIter *it, ProllyMutMap *mm,
-                          const u8 *pKey, int nKey, i64 intKey);
+int prollyMutMapIterSeek(ProllyMutMapIter *it, ProllyMutMap *mm,
+                         const u8 *pKey, int nKey, i64 intKey);
 
-void prollyMutMapIterLast(ProllyMutMapIter *it, ProllyMutMap *mm);
+int prollyMutMapIterLast(ProllyMutMapIter *it, ProllyMutMap *mm);
 
 int prollyMutMapClone(ProllyMutMap **out, const ProllyMutMap *src);
 

--- a/test/doltlite_recover_cacheflush_oom.test
+++ b/test/doltlite_recover_cacheflush_oom.test
@@ -1,0 +1,81 @@
+# Merged-scan correctness under OOM fault injection.
+#
+# A transient allocation failure inside the mutmap iterator positioning used
+# to be swallowed: the merged base-map+mutmap cursor then ran a binary search
+# over a stale (unsorted) order array and either emitted the same key twice
+# (once with its pre-UPDATE value from the base map and once with its
+# post-UPDATE value from the mutmap) or silently skipped a row — in both
+# cases reporting success. Every fault iteration here must either fail
+# cleanly or return exactly the correct row set.
+#
+# The scenarios mirror upstream cffault.test 2.1/2.4 (sqlite3_db_cacheflush
+# mid-scan over an uncommitted UPDATE), which is where the wrong results
+# were first observed.
+
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+source $testdir/malloc_common.tcl
+
+set testprefix doltlite_recover_cacheflush_oom
+
+do_execsql_test 1.0 {
+  CREATE TABLE t1(a PRIMARY KEY, b, c);
+  CREATE INDEX i1 ON t1(b);
+  CREATE INDEX i2 ON t1(c, b);
+  INSERT INTO t1 VALUES(1, 2,  randomblob(600));
+  INSERT INTO t1 VALUES(3, 4,  randomblob(600));
+  INSERT INTO t1 VALUES(5, 6,  randomblob(600));
+  INSERT INTO t1 VALUES(7, 8,  randomblob(600));
+  INSERT INTO t1 VALUES(9, 10, randomblob(600));
+}
+faultsim_save_and_close
+
+# Scenario 1: unordered full-table scan with a cacheflush fired mid-scan.
+# The unordered merged-cursor row order varies, so sort the (a,b) pairs
+# before comparing; a success must be exactly the five updated rows —
+# never a duplicated or missing key.
+do_faultsim_test 1.1 -faults oom-transient -prep {
+  faultsim_restore_and_reopen
+  db eval {
+    BEGIN;
+      UPDATE t1 SET b=b+1;
+  }
+} -body {
+  set pairs [list]
+  db eval { SELECT * FROM t1 } {
+    if {$a==5} { catch { sqlite3_db_cacheflush db } }
+    lappend pairs [list $a $b]
+  }
+  set result [list]
+  foreach p [lsort -integer -index 0 $pairs] {
+    lappend result {*}$p
+  }
+  set result
+} -test {
+  faultsim_test_result {0 {1 3 3 5 5 7 7 9 9 11}} \
+      {1 {out of memory}} {1 {disk I/O error}}
+  catchsql ROLLBACK
+  faultsim_integrity_check
+}
+
+# Scenario 2: covering-index scan after cacheflush/release-memory calls that
+# swallow the injected fault. A success must include every row.
+do_faultsim_test 1.2 -faults oom-transient -prep {
+  faultsim_restore_and_reopen
+  db eval {
+    BEGIN;
+      UPDATE t1 SET b=b-1;
+  }
+} -body {
+  catch { sqlite3_db_cacheflush db }
+  catch { sqlite3_db_release_memory db }
+  catch { sqlite3_db_cacheflush db }
+  execsql { SELECT a, b FROM t1 ORDER BY a }
+} -test {
+  faultsim_test_result {0 {1 1 3 3 5 5 7 7 9 9}} \
+      {1 {out of memory}} {1 {disk I/O error}}
+  catchsql ROLLBACK
+  faultsim_integrity_check
+}
+
+finish_test

--- a/test/regression-buckets/ported.txt
+++ b/test/regression-buckets/ported.txt
@@ -34,3 +34,4 @@ doltlite_merge_constraint_prune
 doltlite_recover_changes
 doltlite_gc_stop_world
 doltlite_reload_uncommitted_recent
+doltlite_recover_cacheflush_oom


### PR DESCRIPTION
Fixes #1569, fixes #1570.

The mutmap iterator initializers (`prollyMutMapIterFirst/Seek/Last`) computed the sorted iteration order lazily and **discarded the allocation failure** from the sort. Under a transient OOM, the merged base-map+mutmap cursor then ran its binary search over a stale (unsorted) order array and misclassified the merge source, silently returning wrong rows with rc=0:

- **#1569** — the same primary key emitted twice: once with its pre-UPDATE value (base map) and once with its post-UPDATE value (mutmap) — six rows from a five-row table.
- **#1570** — a row silently dropped from a covering-index scan.

Both were hiding behind `cffault` entries in the known-divergence list marked as ordering-only divergences.

## Fix

- The three iterator initializers now return `ensureOrder()`'s result and park the iterator past-the-end on failure, so even an unchecked caller iterates nothing rather than a stale order.
- All consumers propagate the error: the lazy merge-activation blocks in the cursor Next/Prev paths, the deferred merged seek, `seedMutMapIterFromCursor`, and the flush strategies.
- `mergeFirst`/`mergeLast` materialize the order before trusting `mmIdx` — the first ordered entry read would otherwise swallow the same failure.

No allocation is added to the success path, so fault-injection indices elsewhere don't shift.

## Testing

- New `test/doltlite_recover_cacheflush_oom.test` (registered in the ported bucket) mirrors the two cffault scenarios and requires every fault iteration to either fail cleanly or return exactly the correct row set. **Fail-before:** on unfixed code it fails at the duplicate-row fault point (`1.1-oom-transient.28`). **Pass-after:** 0/62.
- Both original issue repros verified fixed (correct rows or clean `out of memory`).
- The two cffault entries covering the wrong-row outcomes are removed from `known_testfixture_divergences.txt`; the remaining nine cffault entries (genuine unordered-scan ordering divergences) still fail as listed.
- Local: ported bucket 2777 tests green, fault-fuzz bucket shows only the pre-existing macOS fault-index drift (oserror/statfault/vtab_err/fkey_malloc/backup_malloc — identical set before the fix), C gating tests 15/15, all 84 doltlite shell suites pass, PROLLY_CHECK build compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)