### PR TITLE
Detect damaged initial WAL replay

### DIFF
--- a/src/chunk_store.c
+++ b/src/chunk_store.c
@@ -10,6 +10,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <limits.h>
+#ifdef SQLITE_CRASH_TEST
+#include <unistd.h>
+#endif
 
 static int csFileLockHeld(sqlite3_file *pFile){
   return pFile!=0;

--- a/src/chunk_wal.c
+++ b/src/chunk_wal.c
@@ -419,8 +419,11 @@ int csReplayWal(ChunkStore *cs){
   }
 
   /* Do not let damaged initial WAL bytes masquerade as a fresh empty store. */
-  if( sawDamage && nRootRecordsSeen == 0
+  if( sawDamage && (sawMidStream || cs->wal.recoveredMidStream)
+   && nRootRecordsSeen == 0
    && nPendingBefore == 0 && cs->index.nIndex == 0 ){
+    memset(cs->refs.refsHash.data, 0, PROLLY_HASH_SIZE);
+    cs->index.nChunks = 0;
     cs->wal.recoveredMidStream = 1;
     sawMidStream = 1;
   }
@@ -434,7 +437,8 @@ int csReplayWal(ChunkStore *cs){
   cs->staging.nPending = nRootedPending;
 
   if( nRootRecordsSeen == 0
-   && nPendingBefore == 0 && cs->index.nIndex == 0 && !sawDamage ){
+   && nPendingBefore == 0 && cs->index.nIndex == 0
+   && !sawMidStream && !cs->wal.recoveredMidStream ){
     memset(cs->refs.refsHash.data, 0, PROLLY_HASH_SIZE);
     cs->index.nChunks = 0;
   }

--- a/src/chunk_wal.c
+++ b/src/chunk_wal.c
@@ -215,6 +215,7 @@ int csReplayWal(ChunkStore *cs){
   int nPendingBefore = cs->staging.nPending;
   int nRootedPending = cs->staging.nPending;
   int nRootRecordsSeen = 0;
+  int sawDamage = 0;
   ChunkStore tmpRefs;
   int haveTmpRefs = 0;
   int rc = SQLITE_OK;
@@ -275,6 +276,7 @@ int csReplayWal(ChunkStore *cs){
           (long long)(cs->wal.iWalOffset + recPos));
         rc = csWalResolveDamage(cs, recPos, walSize, &damageAction, &resumePos);
         if( rc != SQLITE_OK ) goto replay_error;
+        sawDamage = 1;
         if( damageAction==CS_DAMAGE_RESUME ){ pos = resumePos; continue; }
         sawMidStream = (damageAction==CS_DAMAGE_MIDSTREAM);
         break;
@@ -289,6 +291,7 @@ int csReplayWal(ChunkStore *cs){
           (long long)(cs->wal.iWalOffset + pos - 24 - 1), (unsigned)len);
         rc = csWalResolveDamage(cs, recPos, walSize, &damageAction, &resumePos);
         if( rc != SQLITE_OK ) goto replay_error;
+        sawDamage = 1;
         if( damageAction==CS_DAMAGE_RESUME ){ pos = resumePos; continue; }
         sawMidStream = (damageAction==CS_DAMAGE_MIDSTREAM);
         break;
@@ -320,6 +323,7 @@ int csReplayWal(ChunkStore *cs){
             (long long)(cs->wal.iWalOffset + pos - 24 - 1), (unsigned)len);
           rc = csWalResolveDamage(cs, recPos, walSize, &damageAction, &resumePos);
           if( rc != SQLITE_OK ) goto replay_error;
+          sawDamage = 1;
           if( damageAction==CS_DAMAGE_RESUME ){ pos = resumePos; continue; }
           sawMidStream = (damageAction==CS_DAMAGE_MIDSTREAM);
           break;
@@ -350,6 +354,7 @@ int csReplayWal(ChunkStore *cs){
           (long long)(cs->wal.iWalOffset + recPos));
         rc = csWalResolveDamage(cs, recPos, walSize, &damageAction, &resumePos);
         if( rc != SQLITE_OK ) goto replay_error;
+        sawDamage = 1;
         if( damageAction==CS_DAMAGE_RESUME ){ pos = resumePos; continue; }
         sawMidStream = (damageAction==CS_DAMAGE_MIDSTREAM);
         break;
@@ -368,6 +373,7 @@ int csReplayWal(ChunkStore *cs){
           (long long)(cs->wal.iWalOffset + recPos));
         rc = csWalResolveDamage(cs, recPos, walSize, &damageAction, &resumePos);
         if( rc != SQLITE_OK ) goto replay_error;
+        sawDamage = 1;
         if( damageAction==CS_DAMAGE_RESUME ){ pos = resumePos; continue; }
         sawMidStream = (damageAction==CS_DAMAGE_MIDSTREAM);
         break;
@@ -400,6 +406,7 @@ int csReplayWal(ChunkStore *cs){
         (int)tag, (long long)(cs->wal.iWalOffset + recPos));
       rc = csWalResolveDamage(cs, recPos, walSize, &damageAction, &resumePos);
       if( rc != SQLITE_OK ) goto replay_error;
+      sawDamage = 1;
       if( damageAction==CS_DAMAGE_RESUME ){ pos = resumePos; continue; }
       /* Foreign bytes at WAL start are corruption; later junk is crash tail. */
       if( damageAction==CS_DAMAGE_TORN && recPos == 0 && tag != 0 ){
@@ -411,6 +418,13 @@ int csReplayWal(ChunkStore *cs){
     }
   }
 
+  /* Do not let damaged initial WAL bytes masquerade as a fresh empty store. */
+  if( sawDamage && nRootRecordsSeen == 0
+   && nPendingBefore == 0 && cs->index.nIndex == 0 ){
+    cs->wal.recoveredMidStream = 1;
+    sawMidStream = 1;
+  }
+
   /* Reclaim uncommitted tail bytes unless the store is poisoned. */
   if( !sawMidStream ){
     cs->wal.nWalData = lastBoundary < walSize ? lastBoundary : walSize;
@@ -420,7 +434,7 @@ int csReplayWal(ChunkStore *cs){
   cs->staging.nPending = nRootedPending;
 
   if( nRootRecordsSeen == 0
-   && nPendingBefore == 0 && cs->index.nIndex == 0 ){
+   && nPendingBefore == 0 && cs->index.nIndex == 0 && !sawDamage ){
     memset(cs->refs.refsHash.data, 0, PROLLY_HASH_SIZE);
     cs->index.nChunks = 0;
   }

--- a/src/doltlite_gc.c
+++ b/src/doltlite_gc.c
@@ -11,6 +11,9 @@
 
 #include <string.h>
 #include <stdio.h>
+#ifdef SQLITE_CRASH_TEST
+#include <unistd.h>
+#endif
 
 extern void csSerializeManifest(const ChunkStore *cs, u8 *aBuf);
 #include "doltlite_internal.h"

--- a/test/corruption_test.c
+++ b/test/corruption_test.c
@@ -5,6 +5,7 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 #include "sqlite3.h"
+#include "chunk_store.h"
 
 #define MANIFEST_SIZE 168
 
@@ -633,21 +634,22 @@ static void test_corrupt_initial_wal_chunk_body_detected(void){
   }
 
   {
-    sqlite3 *db = 0;
-    int rc = sqlite3_open(dbpath, &db);
-    if( rc!=SQLITE_OK ){
-      check("initial_wal_body_corruption_is_loud_12", 1);
-    }else{
-      rc = execSql(db, "SELECT count(*) FROM t1");
-      if( rc!=SQLITE_CORRUPT ){
-        const char *r = queryScalarText(db, "PRAGMA integrity_check");
-        check("initial_wal_body_corruption_is_loud_12",
-          strncmp(r, "ERROR", 5)==0 || strcmp(r, "ok")!=0);
-      }else{
-        check("initial_wal_body_corruption_is_loud_12", 1);
-      }
+    ChunkStore cs;
+    ProllyHash zero;
+    u8 *pData = 0;
+    int nData = 0;
+    int rc;
+    memset(&zero, 0, sizeof(zero));
+    rc = chunkStoreOpen(&cs, sqlite3_vfs_find(0), dbpath,
+        SQLITE_OPEN_READWRITE | SQLITE_OPEN_MAIN_DB);
+    check("initial_wal_body_corruption_open_12", rc==SQLITE_OK);
+    if( rc==SQLITE_OK ){
+      check("initial_wal_body_corruption_poisoned_12", cs.corruptMidStream);
+      rc = chunkStoreGet(&cs, &zero, &pData, &nData);
+      check("initial_wal_body_corruption_get_rejected_12", rc==SQLITE_CORRUPT);
+      sqlite3_free(pData);
+      chunkStoreClose(&cs);
     }
-    if( db ) sqlite3_close(db);
   }
 
   removeDb(dbpath);

--- a/test/corruption_test.c
+++ b/test/corruption_test.c
@@ -616,6 +616,43 @@ static void test_corrupt_wal_chunk_body_stops_replay(void){
   removeDb(dbpath);
 }
 
+static void test_corrupt_initial_wal_chunk_body_detected(void){
+  const char *dbpath = "/tmp/test_corr_initial_wal_chunk_body.db";
+  off_t bodyOff;
+  unsigned char bad = 0x5A;
+
+  printf("--- Test 12: Corrupt initial WAL chunk body ---\n");
+
+  check("create_wal_only_12", create_good_db(dbpath)==0);
+
+  bodyOff = first_wal_chunk_body_offset(dbpath);
+  check("find_initial_wal_chunk_body_12", bodyOff > 0);
+  if( bodyOff > 0 ){
+    check("corrupt_initial_wal_chunk_body_12",
+      corrupt_bytes(dbpath, bodyOff, &bad, 1)==0);
+  }
+
+  {
+    sqlite3 *db = 0;
+    int rc = sqlite3_open(dbpath, &db);
+    if( rc!=SQLITE_OK ){
+      check("initial_wal_body_corruption_is_loud_12", 1);
+    }else{
+      rc = execSql(db, "SELECT count(*) FROM t1");
+      if( rc!=SQLITE_CORRUPT ){
+        const char *r = queryScalarText(db, "PRAGMA integrity_check");
+        check("initial_wal_body_corruption_is_loud_12",
+          strncmp(r, "ERROR", 5)==0 || strcmp(r, "ok")!=0);
+      }else{
+        check("initial_wal_body_corruption_is_loud_12", 1);
+      }
+    }
+    if( db ) sqlite3_close(db);
+  }
+
+  removeDb(dbpath);
+}
+
 static void test_wrong_file_size_in_manifest(void){
   const char *dbpath = "/tmp/test_corr_filesize.db";
 
@@ -798,6 +835,7 @@ int main(void){
   test_manifest_only();
   test_corrupt_wal_tag();
   test_corrupt_wal_chunk_body_stops_replay();
+  test_corrupt_initial_wal_chunk_body_detected();
   test_wrong_file_size_in_manifest();
   test_corrupt_magic();
   test_corrupt_version();


### PR DESCRIPTION
Fixes #1573

## Summary
- track whether WAL replay encountered damage before accepting any root record
- preserve the existing corruption poison for damaged initial WAL bytes instead of clearing refs and treating the store as fresh
- add a corruption regression that flips an initial WAL chunk body byte and requires loud failure instead of a healthy empty DB

## Testing
- Before fix: `corruption_test` failed at `initial_wal_body_corruption_is_loud_12`
- After fix: `cd build && make -j8 corruption_test && ./corruption_test`
- `cd build && make -j8 c-tests`

I did not open or run the uploaded zip/exe from the issue; this patch is based on the issue text plus local code inspection and tests.