### PR TITLE
Keep v1 statements valid after data rollback

### DIFF
--- a/main.mk
+++ b/main.mk
@@ -2655,6 +2655,7 @@ DOLTLITE_C_TESTS = \
 	multi_process_merge_rebase_test$(T.exe) \
 	invariant_test$(T.exe) \
 	corruption_test$(T.exe) \
+	prepared_stmt_reuse_test$(T.exe) \
 	three_way_diff_test$(T.exe) \
 	sequence_reload_test$(T.exe) \
 	chunk_store_fork_lock_test$(T.exe) \
@@ -2710,6 +2711,10 @@ invariant_test$(T.exe): $(TOP)/test/invariant_test.c libdoltlite$(T.lib)
 
 corruption_test$(T.exe): $(TOP)/test/corruption_test.c libdoltlite$(T.lib)
 	$(T.link) -I. -I$(TOP)/src -o $@ $(TOP)/test/corruption_test.c \
+		libdoltlite$(T.lib) -lz -lpthread -lm
+
+prepared_stmt_reuse_test$(T.exe): $(TOP)/test/prepared_stmt_reuse_test.c libdoltlite$(T.lib)
+	$(T.link) -I. -I$(TOP)/src -o $@ $(TOP)/test/prepared_stmt_reuse_test.c \
 		libdoltlite$(T.lib) -lz -lpthread -lm
 
 # three_way_diff_test pokes prolly internals directly; needs sqliteInt.h

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -1309,6 +1309,46 @@ static void resetConnectionSchema(Btree *pBtree){
   }
 }
 
+static void expireActiveStatements(Btree *pBtree){
+  Vdbe *pVdbe;
+  if( !pBtree->db ) return;
+  for(pVdbe=pBtree->db->pVdbe; pVdbe; pVdbe=pVdbe->pVNext){
+    if( pVdbe->eVdbeState==VDBE_RUN_STATE ){
+      pVdbe->expired = 1;
+    }
+  }
+}
+
+static int hasActiveSchemaProgram(Btree *pBtree){
+  Vdbe *pVdbe;
+  if( !pBtree->db ) return 0;
+  for(pVdbe=pBtree->db->pVdbe; pVdbe; pVdbe=pVdbe->pVNext){
+    int i;
+    if( pVdbe->eVdbeState!=VDBE_RUN_STATE ) continue;
+    for(i=0; i<pVdbe->nOp; i++){
+      int op = pVdbe->aOp[i].opcode;
+      if( op==OP_SetCookie
+       || op==OP_ParseSchema
+       || op==OP_CreateBtree
+       || op==OP_Destroy
+       || op==OP_DropTable
+       || op==OP_DropIndex ){
+        return 1;
+      }
+    }
+  }
+  return 0;
+}
+
+static int rollbackNeedsSchemaReset(Btree *pBtree){
+  return pBtree->bSchemaChangedTxn
+      || pBtree->bMasterRootChangedTxn
+      || (pBtree->db
+          && pBtree->db->init.busy==0
+          && (pBtree->db->mDbFlags & DBFLAG_SchemaChange)!=0)
+      || hasActiveSchemaProgram(pBtree);
+}
+
 static void invalidateCursors(BtShared *pBt, Pgno iTable, int errCode){
   BtCursor *p;
   for(p=pBt->pCursor; p; p=p->pNext){
@@ -5983,8 +6023,7 @@ static int restoreFromCommitted(Btree *p){
 static int prollyBtreeRollback(Btree *p, int tripCode, int writeOnly){
   BtShared *pBt = p->pBt;
   int rc = SQLITE_OK;
-  int bSchemaChangedRollback = p->bSchemaChangedTxn
-      || p->bMasterRootChangedTxn;
+  int bSchemaChangedRollback = rollbackNeedsSchemaReset(p);
   int bAutocommitOomRollback = writeOnly
       && p->db
       && p->db->autoCommit
@@ -6045,7 +6084,11 @@ static int prollyBtreeRollback(Btree *p, int tripCode, int writeOnly){
       pBt->store.snapshotPinned = 0;
       return rc;
     }
-    if( bSchemaChangedRollback ) resetConnectionSchema(p);
+    if( bSchemaChangedRollback ){
+      resetConnectionSchema(p);
+    }else if( writeOnly ){
+      expireActiveStatements(p);
+    }
     chunkStoreRollback(&pBt->store);
     if( bAutocommitOomRollback ){
       p->bFilterSchemaPlaceholders = 1;
@@ -6156,8 +6199,7 @@ int doltliteBtreeCaptureStatement(void *pArg){
 
 static int rollbackCommittedState(Btree *p, BtShared *pBt){
   BtCursor *pC;
-  int bSchemaChangedRollback = p->bSchemaChangedTxn
-      || p->bMasterRootChangedTxn;
+  int bSchemaChangedRollback = rollbackNeedsSchemaReset(p);
   int rc = restoreFromCommitted(p);
   if( rc!=SQLITE_OK ){
     /* The reload OOM'd partway; the catalog may still point at staged
@@ -6243,6 +6285,7 @@ static int rollbackNamedSavepoint(Btree *p, BtShared *pBt, int iSavepoint){
   BtCursor *pC;
   int j;
   int rc;
+  int bSchemaChangedRollback = rollbackNeedsSchemaReset(p);
   /* Save cursors so parent statements survive nested-statement rollback. */
   if( p->db && p->db->mallocFailed ){
     for(pC=pBt->pCursor; pC; pC=pC->pNext){
@@ -6288,7 +6331,11 @@ static int rollbackNamedSavepoint(Btree *p, BtShared *pBt, int iSavepoint){
     pC->mmIdx = -1;
     pC->mmPhysIdx = -1;
   }
-  invalidateSchema(p);
+  if( bSchemaChangedRollback ){
+    resetConnectionSchema(p);
+  }else{
+    invalidateSchema(p);
+  }
   return SQLITE_OK;
 }
 

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -5983,6 +5983,8 @@ static int restoreFromCommitted(Btree *p){
 static int prollyBtreeRollback(Btree *p, int tripCode, int writeOnly){
   BtShared *pBt = p->pBt;
   int rc = SQLITE_OK;
+  int bSchemaChangedRollback = p->bSchemaChangedTxn
+      || p->bMasterRootChangedTxn;
   int bAutocommitOomRollback = writeOnly
       && p->db
       && p->db->autoCommit
@@ -6043,7 +6045,7 @@ static int prollyBtreeRollback(Btree *p, int tripCode, int writeOnly){
       pBt->store.snapshotPinned = 0;
       return rc;
     }
-    resetConnectionSchema(p);
+    if( bSchemaChangedRollback ) resetConnectionSchema(p);
     chunkStoreRollback(&pBt->store);
     if( bAutocommitOomRollback ){
       p->bFilterSchemaPlaceholders = 1;
@@ -6154,6 +6156,8 @@ int doltliteBtreeCaptureStatement(void *pArg){
 
 static int rollbackCommittedState(Btree *p, BtShared *pBt){
   BtCursor *pC;
+  int bSchemaChangedRollback = p->bSchemaChangedTxn
+      || p->bMasterRootChangedTxn;
   int rc = restoreFromCommitted(p);
   if( rc!=SQLITE_OK ){
     /* The reload OOM'd partway; the catalog may still point at staged
@@ -6179,7 +6183,7 @@ static int rollbackCommittedState(Btree *p, BtShared *pBt){
     pC->mmActive = 0;
     prollyCursorReleaseAll(&pC->pCur);
   }
-  resetConnectionSchema(p);
+  if( bSchemaChangedRollback ) resetConnectionSchema(p);
   return SQLITE_OK;
 }
 

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -558,7 +558,6 @@ capi2 capi2-6.5  # 2nd-connection write expects "database is locked"; doltlite h
 # verbatim source. check-4.6 (same error string) passes because it runs before the
 # reload that check-4.8's integrity_check/ignore_check_constraints forces. Rows and
 # enforcement are correct; this is schema-text fidelity only. Tracked: #1200.
-check check-4.9
 collate4 collate4-2.1.2  # sqlite_search_count plan metric; rows match
 # date-14 writes raw IEEE754 bytes directly into SQLite page offsets with
 # hexio_write, then verifies date/time behavior through that mutated record.

--- a/test/prepared_stmt_reuse_test.c
+++ b/test/prepared_stmt_reuse_test.c
@@ -461,6 +461,46 @@ static void test_partial_step(void){
   unlink("test_partial.db");
 }
 
+static void test_v1_stmt_survives_data_rollback(void){
+  sqlite3 *db = 0;
+  sqlite3_stmt *pSel = 0;
+  const char *zTail = 0;
+  int rc;
+
+  unlink("test_v1_rollback.db");
+  rc = sqlite3_open("test_v1_rollback.db", &db);
+  check("v1_rollback: open", rc==SQLITE_OK);
+
+  execSql(db,
+    "CREATE TABLE t1(a);"
+    "INSERT INTO t1 VALUES(1);"
+    "INSERT INTO t1 VALUES(2);");
+
+  rc = sqlite3_prepare(db, "SELECT a FROM t1 ORDER BY a", -1, &pSel, &zTail);
+  check("v1_rollback: prepare", rc==SQLITE_OK);
+
+  rc = sqlite3_step(pSel);
+  check("v1_rollback: pre-step", rc==SQLITE_ROW);
+  check_int("v1_rollback: pre-step row", sqlite3_column_int(pSel, 0), 1);
+
+  rc = sqlite3_reset(pSel);
+  check("v1_rollback: reset", rc==SQLITE_OK);
+
+  execSql(db, "BEGIN; INSERT INTO t1 VALUES(3); ROLLBACK;");
+
+  rc = sqlite3_step(pSel);
+  check("v1_rollback: step after data rollback", rc==SQLITE_ROW);
+  if( rc==SQLITE_ROW ){
+    check_int("v1_rollback: row after rollback", sqlite3_column_int(pSel, 0), 1);
+  }
+
+  rc = sqlite3_finalize(pSel);
+  check("v1_rollback: finalize", rc==SQLITE_OK);
+
+  sqlite3_close(db);
+  unlink("test_v1_rollback.db");
+}
+
 
 int main(int argc, char **argv){
   (void)argc; (void)argv;
@@ -490,6 +530,9 @@ int main(int argc, char **argv){
 
   printf("--- partial step + reset ---\n");
   test_partial_step();
+
+  printf("--- v1 statement survives data rollback ---\n");
+  test_v1_stmt_survives_data_rollback();
 
   printf("\n=== Results: %d passed, %d failed ===\n", nPass, nFail);
   return nFail > 0 ? 1 : 0;

--- a/test/run_c_tests.sh
+++ b/test/run_c_tests.sh
@@ -19,6 +19,7 @@ GATING=(
   oom_dolt_fault_test
   cross_branch_test
   corruption_test
+  prepared_stmt_reuse_test
   sequence_reload_test
   chunk_store_fork_lock_test
 )


### PR DESCRIPTION
Fixes #1571

## Summary
- stop expiring prepared statements on rollback when the rolled-back transaction only changed data
- preserve schema reset/statement expiry for rollback paths that actually touched schema metadata
- add a v1 `sqlite3_prepare()` regression and move `prepared_stmt_reuse_test` into C gating

## Testing
- Before fix: minimal testfixture repro returned `post-step=SQLITE_ERROR` and `finalize=SQLITE_SCHEMA`
- After fix: minimal testfixture repro returns `post-step=SQLITE_ROW` and `finalize=SQLITE_OK`
- `cd build && make -j8 prepared_stmt_reuse_test && ./prepared_stmt_reuse_test`
- `cd build && make -j8 c-tests`
- `cd build && ./testfixture ../test/rollback.test` now passes rollback-1.7/1.8/1.9, then stops at the pre-existing rollback-2.1 missing journal sidecar divergence