### PR TITLE
dolt_diff_<table>(from, to): per-commit attribution over the range (#1581)

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -92,6 +92,7 @@ jobs:
       run: |
         cd build
         for s in doltlite_at doltlite_history doltlite_diff doltlite_diff_table \
+                 doltlite_diff_table_range \
                  doltlite_schema_diff doltlite_workspace doltlite_conflicts \
                  doltlite_conflict_rows doltlite_comparison doltlite_merge; do
           echo "=== $s ==="

--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -608,94 +608,172 @@ static int buildCommitDiffPair(
   return rc;
 }
 
-static int buildSliceDiffPair(
+/* Add pHash and all of its ancestors (its reachable set) to pSet. Used to
+** identify from_ref's history so a range walk can tell in-range commits (which
+** get attributed) from the out-of-range parents that only supply the "from"
+** side of a boundary change. */
+static int addReachableToSet(
+  sqlite3 *db,
+  ProllyHashSet *pSet,
+  const ProllyHash *pHash
+){
+  DoltliteCommitQueue q;
+  int rc;
+
+  memset(&q, 0, sizeof(q));
+  rc = doltliteCommitQueueInit(&q, pHash);
+  if( rc!=SQLITE_OK ) return rc;
+
+  while( rc==SQLITE_OK ){
+    ProllyHash cur;
+    DoltliteCommit c;
+    int has = 0;
+    rc = doltliteCommitQueueNext(&q, &cur, &has);
+    if( rc!=SQLITE_OK || !has ) break;
+    rc = prollyHashSetAdd(pSet, &cur);
+    if( rc!=SQLITE_OK ) break;
+    memset(&c, 0, sizeof(c));
+    rc = doltliteLoadCommit(db, &cur, &c);
+    if( rc!=SQLITE_OK ) break;
+    rc = doltliteCommitQueueEnqueueParents(&q, &c);
+    doltliteCommitClear(&c);
+  }
+
+  doltliteCommitQueueClear(&q);
+  return rc;
+}
+
+/* Range diff: emit, for every commit in from_ref..to_ref (reachable from
+** to_ref but not from from_ref), the change it introduced against its parent,
+** attributed to that commit -- the same per-commit walk as the unfiltered
+** dolt_diff_<table>, restricted to the range. Equivalent to the unfiltered
+** system table filtered by "to_commit IN (commits of from_ref..to_ref)". The
+** walk starts at to_ref and descends parent-ward, but only expands a commit's
+** parents when the commit is itself in range; an out-of-range parent is still
+** visited once to supply the "from" side of the boundary change (so a merge
+** parent's own history is attributed correctly). to_ref may be WORKING, in
+** which case the HEAD->working change is included and attributed to WORKING.
+** The net two-dot diff between two refs lives in the dolt_diff() function.
+**
+** Cost is O(history reachable from to_ref) plus from_ref's reachable set, the
+** same order as the unfiltered table; a range near the tip does not shortcut
+** the reachability computation. */
+static int buildRangeDiffPairs(
   DiffTblCursor *pCur,
   sqlite3 *db,
   const char *zTableName,
   const char *zFromRef,
   const char *zToRef
 ){
-  ProllyHash fromHash, toHash;
-  ProllyHash fromTblRoot, toTblRoot;
-  ProllyHash fromCatHash, toCatHash;
-  ProllyHash fromSchemaHash, toSchemaHash;
-  DoltliteCommit fromCommit;
-  u8 fromFlags = 0;
-  u8 toFlags = 0;
-  i64 fromDate = 0;
-  i64 toDate = 0;
-  int toIsWorking = 0;
-  char zToLabel[PROLLY_HASH_SIZE*2+1];
-  int rc;
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  ProllyHash fromHash;
+  CmTblMap map;
+  ProllyHash *aStack = 0;
+  int nStack = 0, nStackAlloc = 0;
+  ProllyHashSet seen;
+  ProllyHashSet reachFrom;
+  int seenInit = 0;
+  int reachInit = 0;
+  int currInited = 0;
+  ProllyHash curr;
+  int rc = SQLITE_OK;
 
-  memset(&fromHash, 0, sizeof(fromHash));
-  memset(&toHash, 0, sizeof(toHash));
-  memset(&fromTblRoot, 0, sizeof(fromTblRoot));
-  memset(&toTblRoot, 0, sizeof(toTblRoot));
-  memset(&fromCatHash, 0, sizeof(fromCatHash));
-  memset(&toCatHash, 0, sizeof(toCatHash));
-  memset(&fromSchemaHash, 0, sizeof(fromSchemaHash));
-  memset(&toSchemaHash, 0, sizeof(toSchemaHash));
-  memset(&fromCommit, 0, sizeof(fromCommit));
-  memset(zToLabel, 0, sizeof(zToLabel));
-
+  if( !cs ) return SQLITE_OK;
   if( !zFromRef || !zToRef ) return SQLITE_OK;
+  memset(&map, 0, sizeof(map));
+  memset(&fromHash, 0, sizeof(fromHash));
 
+  /* An unresolvable from_ref leaves the range unbounded below; treat it as an
+  ** empty result rather than an error, matching the vtable's other ref paths. */
   rc = doltliteResolveRef(db, zFromRef, &fromHash);
   if( rc!=SQLITE_OK ) return SQLITE_OK;
-  rc = doltliteLoadCommit(db, &fromHash, &fromCommit);
-  if( rc!=SQLITE_OK ) return rc;
-  memcpy(&fromCatHash, &fromCommit.catalogHash, sizeof(ProllyHash));
-  fromDate = fromCommit.timestamp;
-  doltliteCommitClear(&fromCommit);
 
-  rc = doltliteLoadTableRootByName(db, &fromCatHash, zTableName,
-                                   &fromTblRoot, &fromFlags, &fromSchemaHash);
-  if( rc!=SQLITE_OK && rc!=SQLITE_NOTFOUND ) return rc;
+  rc = prollyHashSetInit(&seen, 64);
+  if( rc!=SQLITE_OK ) return rc;
+  seenInit = 1;
+  rc = prollyHashSetInit(&reachFrom, 64);
+  if( rc!=SQLITE_OK ) goto walk_done;
+  reachInit = 1;
+
+  /* from_ref and everything behind it are out of range (a commit is in range
+  ** iff reachable from to_ref and NOT in this set). */
+  rc = addReachableToSet(db, &reachFrom, &fromHash);
+  if( rc!=SQLITE_OK ) goto walk_done;
 
   if( sqlite3_stricmp(zToRef, "WORKING")==0 ){
-    toIsWorking = 1;
-    rc = doltliteGetWorkingTableState(db, zTableName,
-                                      &toTblRoot, &toFlags,
-                                      &toSchemaHash);
-    if( rc==SQLITE_NOTFOUND ) rc = SQLITE_OK;
-    if( rc!=SQLITE_OK ) return rc;
-    rc = doltliteFlushCatalogToHash(db, &toCatHash);
-    if( rc!=SQLITE_OK ) return rc;
-    memcpy(zToLabel, "WORKING", 7);
-    toDate = 0;
+    ProllyHash headHash;
+    doltliteGetSessionHead(db, &headHash);
+    if( prollyHashIsEmpty(&headHash) ) goto walk_done;
+    rc = seedWorkingChildInfo(db, &headHash, zTableName, &map);
+    if( rc!=SQLITE_OK ) goto walk_done;
+    rc = stackPushUnique(&seen, &aStack, &nStack, &nStackAlloc, &headHash);
+    if( rc!=SQLITE_OK ) goto walk_done;
   }else{
-    DoltliteCommit toCommit;
-    memset(&toCommit, 0, sizeof(toCommit));
+    ProllyHash toHash;
+    memset(&toHash, 0, sizeof(toHash));
     rc = doltliteResolveRef(db, zToRef, &toHash);
-    if( rc!=SQLITE_OK ) return SQLITE_OK;
-    rc = doltliteLoadCommit(db, &toHash, &toCommit);
-    if( rc!=SQLITE_OK ) return rc;
-    memcpy(&toCatHash, &toCommit.catalogHash, sizeof(ProllyHash));
-    toDate = toCommit.timestamp;
-    doltliteCommitClear(&toCommit);
-    rc = doltliteLoadTableRootByName(db, &toCatHash, zTableName,
-                                     &toTblRoot, &toFlags, &toSchemaHash);
-    if( rc!=SQLITE_OK && rc!=SQLITE_NOTFOUND ) return rc;
-    doltliteHashToHex(&toHash, zToLabel);
+    if( rc!=SQLITE_OK ){ rc = SQLITE_OK; goto walk_done; }
+    /* to_ref is visited but never seeded with a child, so it emits no change
+    ** of its own; visiting it registers parent(to_ref)->to_ref. */
+    rc = stackPushUnique(&seen, &aStack, &nStack, &nStackAlloc, &toHash);
+    if( rc!=SQLITE_OK ) goto walk_done;
   }
 
-  if( !toIsWorking
-   && prollyHashCompare(&fromHash, &toHash)==0 ){
-    return SQLITE_OK;
-  }
-  if( prollyHashCompare(&fromTblRoot, &toTblRoot)==0
-   && prollyHashCompare(&fromSchemaHash, &toSchemaHash)==0 ){
-    return SQLITE_OK;
+  if( nStack>0 ){
+    curr = aStack[--nStack];
+    currInited = 1;
   }
 
-  if( !fromFlags ) fromFlags = toFlags;
-  if( !toFlags ) toFlags = fromFlags;
+  while( currInited ){
+    DoltliteCommit commit;
+    ProllyHash curTblRoot;
+    ProllyHash curSchemaHash;
+    u8 curFlags = 0;
+    char curHex[PROLLY_HASH_SIZE*2+1];
 
-  return pairsAppend(pCur, &fromHash, &fromTblRoot, &fromCatHash,
-                     &fromSchemaHash, fromFlags, fromDate,
-                     zToLabel, &toTblRoot, &toCatHash, &toSchemaHash,
-                     toFlags, toDate);
+    memset(&commit, 0, sizeof(commit));
+    memset(&curTblRoot, 0, sizeof(curTblRoot));
+    memset(&curSchemaHash, 0, sizeof(curSchemaHash));
+
+    rc = doltliteLoadCommit(db, &curr, &commit);
+    if( rc!=SQLITE_OK ) break;
+
+    rc = doltliteLoadTableRootByNameOrEmpty(db, &commit.catalogHash,
+                                            zTableName, &curTblRoot,
+                                            &curFlags, &curSchemaHash);
+    if( rc!=SQLITE_OK ){
+      doltliteCommitClear(&commit);
+      break;
+    }
+
+    doltliteHashToHex(&curr, curHex);
+    /* Emit curr -> its registered child (only in-range commits ever get
+    ** registered as a child, so any emitted pair is attributed in-range). */
+    rc = appendCurrentDiffPair(pCur, &curr, &commit, &curTblRoot,
+                               &curSchemaHash, curFlags, &map);
+    /* Expand parents only for in-range commits; an out-of-range parent is a
+    ** boundary from-side and must not drag its own history into the range. */
+    if( rc==SQLITE_OK && !prollyHashSetContains(&reachFrom, &curr) ){
+      rc = registerCommitParents(&map, &seen, &aStack, &nStack, &nStackAlloc,
+                                 &commit, &curTblRoot,
+                                 &curSchemaHash, curFlags, curHex);
+    }
+    doltliteCommitClear(&commit);
+    if( rc!=SQLITE_OK ) break;
+
+    if( nStack==0 ){
+      currInited = 0;
+    }else{
+      curr = aStack[--nStack];
+    }
+  }
+
+walk_done:
+  cmMapFree(&map);
+  sqlite3_free(aStack);
+  if( seenInit ) prollyHashSetFree(&seen);
+  if( reachInit ) prollyHashSetFree(&reachFrom);
+  return rc;
 }
 
 static void freePairCols(DiffTblCursor *pCur){
@@ -997,7 +1075,7 @@ static int dtFilter(sqlite3_vtab_cursor *cur,
   if( (idxNum & DT_IDX_SLICE)!=0 && argc>=2 ){
     const char *zFromRef = (const char*)sqlite3_value_text(argv[0]);
     const char *zToRef = (const char*)sqlite3_value_text(argv[1]);
-    rc = buildSliceDiffPair(c, db, pVtab->zTableName, zFromRef, zToRef);
+    rc = buildRangeDiffPairs(c, db, pVtab->zTableName, zFromRef, zToRef);
   }else if( (idxNum & DT_IDX_TO_COMMIT_EQ)!=0 && argc>=1 ){
     const char *zToCommit = (const char*)sqlite3_value_text(argv[0]);
     if( zToCommit && sqlite3_stricmp(zToCommit, "WORKING")==0 ){

--- a/test/doltlite_diff_table_range.sh
+++ b/test/doltlite_diff_table_range.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
+
+# dolt_diff_<table>(from_ref, to_ref) must attribute each changed row to the
+# commit inside the range that actually made the change -- the same per-commit
+# audit the unfiltered dolt_diff_<table> gives -- rather than collapsing the
+# range into a single net two-dot diff labelled with the range endpoints.
+# (The net two-dot diff lives in the dolt_diff() table function.)
+
+echo "=== Doltlite dolt_diff_<table> ranged attribution tests ==="
+echo ""
+
+DB=/tmp/test_dt_range_$$.db; rm -f "$DB"
+
+# c1 adds id=1; c2 adds id=2; c3 modifies id=1; c4 deletes id=2;
+# c5 modifies id=1 again (a repeated change to the same row).
+echo "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES(1,'a');
+SELECT dolt_commit('-A','-m','c1');
+INSERT INTO t VALUES(2,'b');
+SELECT dolt_commit('-A','-m','c2');
+UPDATE t SET v='a2' WHERE id=1;
+SELECT dolt_commit('-A','-m','c3');
+DELETE FROM t WHERE id=2;
+SELECT dolt_commit('-A','-m','c4');
+UPDATE t SET v='a3' WHERE id=1;
+SELECT dolt_commit('-A','-m','c5');" | $DOLTLITE "$DB" > /dev/null 2>&1
+
+C1=$(echo "SELECT commit_hash FROM dolt_log WHERE message='c1';" | $DOLTLITE "$DB")
+C2=$(echo "SELECT commit_hash FROM dolt_log WHERE message='c2';" | $DOLTLITE "$DB")
+C3=$(echo "SELECT commit_hash FROM dolt_log WHERE message='c3';" | $DOLTLITE "$DB")
+C4=$(echo "SELECT commit_hash FROM dolt_log WHERE message='c4';" | $DOLTLITE "$DB")
+C5=$(echo "SELECT commit_hash FROM dolt_log WHERE message='c5';" | $DOLTLITE "$DB")
+
+# Range c2..c5 = commits c3 (modify id1), c4 (delete id2), c5 (modify id1).
+# c2's own change (adding id=2) is the lower boundary and excluded.
+run_test "range_count" \
+  "SELECT count(*) FROM dolt_diff_t('$C2','$C5');" "3" "$DB"
+
+# The core of the feature: three distinct attributing commits, not one.
+run_test "range_distinct_commits" \
+  "SELECT count(DISTINCT to_commit) FROM dolt_diff_t('$C2','$C5');" "3" "$DB"
+
+# Each change is attributed to the commit that made it, not the endpoint.
+run_test "range_attribution_c3" \
+  "SELECT to_v FROM dolt_diff_t('$C2','$C5') WHERE to_commit='$C3';" "a2" "$DB"
+run_test "range_attribution_c5" \
+  "SELECT to_v FROM dolt_diff_t('$C2','$C5') WHERE to_commit='$C5';" "a3" "$DB"
+
+# Deletions inside the range are shown, attributed to the deleting commit.
+run_test "range_delete_shown" \
+  "SELECT diff_type || ':' || from_id FROM dolt_diff_t('$C2','$C5') WHERE to_commit='$C4';" \
+  "removed:2" "$DB"
+
+# Repeated changes to one row appear once per commit that touched it.
+run_test "range_repeated_change" \
+  "SELECT count(*) FROM dolt_diff_t('$C2','$C5') WHERE diff_type='modified' AND to_id=1;" \
+  "2" "$DB"
+
+# Lower bound excludes from_ref's own change: adding id=2 happened at c2 and
+# must not appear in c2..c5.
+run_test "range_excludes_from_boundary" \
+  "SELECT count(*) FROM dolt_diff_t('$C2','$C5') WHERE diff_type='added';" "0" "$DB"
+
+# ...but the commit immediately after from_ref is included: c1..c3 covers c2's
+# add of id=2 and c3's modify of id=1, while c1's add of id=1 is excluded.
+run_test "range_lower_neighbor_count" \
+  "SELECT count(*) FROM dolt_diff_t('$C1','$C3');" "2" "$DB"
+run_test "range_lower_neighbor_add" \
+  "SELECT to_commit FROM dolt_diff_t('$C1','$C3') WHERE diff_type='added' AND to_id=2;" \
+  "$C2" "$DB"
+run_test "range_lower_neighbor_excludes_c1" \
+  "SELECT count(*) FROM dolt_diff_t('$C1','$C3') WHERE to_id=1 AND diff_type='added';" \
+  "0" "$DB"
+
+# A range is a subset of the full per-commit history and preserves the same
+# attribution the unfiltered table gives for those commits.
+run_test "range_matches_full_attribution" \
+  "SELECT (SELECT to_v FROM dolt_diff_t('$C2','$C5') WHERE to_commit='$C3')
+        = (SELECT to_v FROM dolt_diff_t WHERE to_commit='$C3' AND to_id=1);" \
+  "1" "$DB"
+
+# Reversed / empty range yields nothing.
+run_test "range_reversed_empty" \
+  "SELECT count(*) FROM dolt_diff_t('$C5','$C2');" "0" "$DB"
+run_test "range_identical_empty" \
+  "SELECT count(*) FROM dolt_diff_t('$C3','$C3');" "0" "$DB"
+
+# to_ref = WORKING bounds the range at the tip and includes the working change,
+# attributed to WORKING; c5's committed change to id=1 is also in c4..WORKING.
+echo "UPDATE t SET v='a4' WHERE id=1;" | $DOLTLITE "$DB" > /dev/null 2>&1
+run_test "range_working_has_working_row" \
+  "SELECT to_v FROM dolt_diff_t('$C4','WORKING') WHERE to_commit='WORKING';" "a4" "$DB"
+run_test "range_working_includes_c5" \
+  "SELECT to_v FROM dolt_diff_t('$C4','WORKING') WHERE to_commit='$C5';" "a3" "$DB"
+
+rm -f "$DB"
+dltest_finish

--- a/test/lib/doltlite_suite_manifest.sh
+++ b/test/lib/doltlite_suite_manifest.sh
@@ -24,6 +24,7 @@ doltlite_rebase.sh
 doltlite_rebase_schema.sh
 doltlite_open_branch.sh
 doltlite_diff_table.sh
+doltlite_diff_table_range.sh
 doltlite_diff_stat_scale.sh
 doltlite_history.sh
 doltlite_log.sh
@@ -101,6 +102,7 @@ doltlite_tag.sh
 doltlite_merge.sh
 doltlite_conflicts.sh
 doltlite_diff_table.sh
+doltlite_diff_table_range.sh
 doltlite_schema_diff.sh
 doltlite_schema_merge.sh
 doltlite_cherry_pick.sh

--- a/test/vc_oracle_diff_multi_pk_test.sh
+++ b/test/vc_oracle_diff_multi_pk_test.sh
@@ -10,13 +10,18 @@ pass=0; fail=0
 FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
+# doltlite's dolt_diff_<tbl>(from, to) is a ranged, per-commit-attributed diff;
+# Dolt's equivalent is the dolt_diff_<tbl> system table filtered to the commits
+# in the from..to range. dolt_diff_stat/summary stay net-range functions and are
+# shielded from the row-diff rewrite.
 translate_for_dolt() {
-  sed -E '
+  sed -E "
     s/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g
     s/dolt_diff_(stat|summary)([^a-zA-Z0-9_])/@@DOLT_DIFF_\1@@\2/g
-    s/dolt_diff_([a-zA-Z0-9_]+)\(([^)]*)\)/dolt_diff(\2, "\1")/g
+    s/dolt_diff_([a-zA-Z0-9_]+)\('([^']*)', *'WORKING'\)/dolt_diff_\1 WHERE to_commit = 'WORKING' OR to_commit IN (SELECT commit_hash FROM dolt_log('\2..HEAD'))/g
+    s/dolt_diff_([a-zA-Z0-9_]+)\('([^']*)', *'([^']*)'\)/dolt_diff_\1 WHERE to_commit IN (SELECT commit_hash FROM dolt_log('\2..\3'))/g
     s/@@DOLT_DIFF_(stat|summary)@@/dolt_diff_\1/g
-  '
+  "
 }
 
 oracle() {

--- a/test/vc_oracle_diff_tvf_test.sh
+++ b/test/vc_oracle_diff_tvf_test.sh
@@ -10,11 +10,17 @@ pass=0; fail=0
 FAILED_NAMES=""
 source "$(dirname "$0")/lib/vc_oracle_common.sh"
 
+# doltlite's dolt_diff_<tbl>(from, to) is a ranged, per-commit-attributed diff
+# (each changed row tagged with the commit inside from..to that made it). Dolt
+# has no arg form of the dolt_diff_<tbl> system table; its equivalent is that
+# same system table filtered to the commits in the from..to range, so that is
+# what we compare against. to=WORKING additionally includes the working-set row.
 translate_for_dolt() {
-  sed -E '
+  sed -E "
     s/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g
-    s/dolt_diff_([a-zA-Z0-9_]+)\(([^)]*)\)/dolt_diff(\2, "\1")/g
-  '
+    s/dolt_diff_([a-zA-Z0-9_]+)\('([^']*)', *'WORKING'\)/dolt_diff_\1 WHERE to_commit = 'WORKING' OR to_commit IN (SELECT commit_hash FROM dolt_log('\2..HEAD'))/g
+    s/dolt_diff_([a-zA-Z0-9_]+)\('([^']*)', *'([^']*)'\)/dolt_diff_\1 WHERE to_commit IN (SELECT commit_hash FROM dolt_log('\2..\3'))/g
+  "
 }
 
 oracle() {


### PR DESCRIPTION
Closes #1581.

## Problem

Calling the `dolt_diff_<table>` vtable with `from`/`to` args collapsed the range into a single **net two-dot diff** and labelled every row's `from_commit`/`to_commit` with the two endpoints you passed. As the reporter put it, that tells you nothing you didn't already know — you can't see *which commit between from and to* actually changed each row. `dolt_blame` doesn't fill the gap (no range, doesn't show deletions or repeated changes). Meanwhile the unfiltered `dolt_diff_<table>` already attributes every change to its commit.

## Fix

`dolt_diff_<table>(from, to)` now performs the **same per-commit walk** as the unfiltered form, bounded to the range: for every commit reachable from `to` but not from `from`, it emits the change that commit introduced against its parent, attributed to that commit.

This is exactly Dolt's `dolt_diff_<table>` system table filtered to the commits of `from..to` — Dolt has no arg form of that system table, so this is the faithful equivalent. The net two-dot diff stays available via the `dolt_diff('from','to','table')` table function (its correct home).

- **Deletes** and **repeated changes** to the same row are each shown, attributed to their commit — the cases `dolt_blame` can't cover.
- **`to = WORKING`** bounds the range at the tip and includes the working change attributed to `WORKING`.
- **Merge commits**: the walk starts at `to` and descends parent-ward, expanding a commit's parents only when the commit is itself in range; an out-of-range parent is still visited once to supply the "from" side of a boundary change, so a merge parent's own in-range history is attributed correctly (verified against live Dolt, which shows the row added both on the feature branch and at the merge).

## Parity & tests

- Re-pointed the two Dolt-parity oracle tests (`vc_oracle_diff_tvf_test`, `vc_oracle_diff_multi_pk_test`) to translate the arg form to Dolt's system table filtered by `dolt_log('from..to')` — the true equivalent of the new semantics — instead of the net-diff function. Both pass against live Dolt (`dolt 2.1.8`), including the merge-commit case.
- New `test/doltlite_diff_table_range.sh` (registered in the suite manifest and the sanitizer job): asserts per-commit attribution, deletes, repeated changes, lower/upper range bounds, reversed/empty ranges, and `WORKING`. **Fail-before** (9/15 fail on the old collapse behaviour) / **pass-after** (15/15).
- Full local sweep green: 24 diff/VC/oracle suites (incl. all live-Dolt oracle tests), C gating 16/16, testfixture builds.

Note: the walk is O(history reachable from `to_ref`) plus `from_ref`'s reachable set — same order as the unfiltered table; a range near the tip doesn't shortcut the reachability computation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)