### PR TITLE
Remote: batch chunk download + pin TLS 1.3 (closes #228)

### DIFF
--- a/src/doltlite_http_remote.c
+++ b/src/doltlite_http_remote.c
@@ -351,6 +351,61 @@ static int httpPutChunk(DoltliteRemote *pRemote, const ProllyHash *pHash,
   return rc;
 }
 
+/* Batched fetch: POST the concatenated hashes to /get-chunks and parse the
+** framed reply (per requested hash: a 4-byte big-endian length then that many
+** payload bytes; length 0xFFFFFFFF marks an absent chunk). One round trip
+** replaces one GET /chunk per hash. */
+static int httpGetChunks(DoltliteRemote *pRemote, const ProllyHash *aHash,
+                         int nHash, u8 **apData, int *anData){
+  HttpRemote *p = (HttpRemote*)pRemote;
+  char *zPath;
+  u8 *pReq = 0;
+  u8 *pResp = 0;
+  int nResp = 0;
+  int status = 0;
+  int rc;
+  int i;
+  i64 poff;
+
+  for(i=0; i<nHash; i++){ apData[i] = 0; anData[i] = 0; }
+  if( nHash <= 0 ) return SQLITE_OK;
+
+  pReq = sqlite3_malloc(nHash * PROLLY_HASH_SIZE);
+  if( !pReq ) return SQLITE_NOMEM;
+  for(i=0; i<nHash; i++){
+    memcpy(pReq + (i * PROLLY_HASH_SIZE), aHash[i].data, PROLLY_HASH_SIZE);
+  }
+
+  zPath = buildPath(p, "/get-chunks");
+  if( !zPath ){ sqlite3_free(pReq); return SQLITE_NOMEM; }
+
+  rc = httpRequest(p, "POST", zPath, pReq, nHash * PROLLY_HASH_SIZE,
+                   &status, &pResp, &nResp);
+  sqlite3_free(zPath);
+  sqlite3_free(pReq);
+  if( rc != SQLITE_OK ){ sqlite3_free(pResp); return rc; }
+  if( status != 200 ){ sqlite3_free(pResp); return SQLITE_ERROR; }
+
+  poff = 0;
+  for(i=0; i<nHash; i++){
+    u32 len;
+    if( poff + 4 > nResp ){ rc = SQLITE_ERROR; break; }
+    len = ((u32)pResp[poff] << 24) | ((u32)pResp[poff+1] << 16)
+        | ((u32)pResp[poff+2] << 8) | (u32)pResp[poff+3];
+    poff += 4;
+    if( len == 0xFFFFFFFFu ) continue;            /* absent */
+    if( poff + (i64)len > nResp ){ rc = SQLITE_ERROR; break; }
+    apData[i] = sqlite3_malloc(len ? (int)len : 1);
+    if( !apData[i] ){ rc = SQLITE_NOMEM; break; }
+    memcpy(apData[i], pResp + poff, len);
+    anData[i] = (int)len;
+    poff += len;
+  }
+
+  sqlite3_free(pResp);
+  return rc;   /* caller frees any apData[i] set before an error */
+}
+
 static int httpGetRefs(DoltliteRemote *pRemote, u8 **ppData, int *pnData){
   HttpRemote *p = (HttpRemote*)pRemote;
   char *zPath;
@@ -627,6 +682,7 @@ DoltliteRemote *doltliteHttpRemoteOpen(const char *zUrl){
   p->base.xGetChunk = httpGetChunk;
   p->base.xPutChunk = httpPutChunk;
   p->base.xHasChunks = httpHasChunks;
+  p->base.xGetChunks = httpGetChunks;
   p->base.xGetRefs = httpGetRefs;
   p->base.xSetRefs = httpSetRefs;
   p->base.xSetRefsIf = httpSetRefsIf;

--- a/src/doltlite_remote.c
+++ b/src/doltlite_remote.c
@@ -220,26 +220,45 @@ int doltliteSyncChunks(
     rc = pDst->xHasChunks(pDst, aBatch, nBatch, aPresent);
     if( rc!=SQLITE_OK ) break;
 
-    for(i=0; i<nBatch && rc==SQLITE_OK; i++){
-      u8 *data = 0;
-      int nData = 0;
+    /* Collect the chunks the destination is missing, then fetch them from the
+    ** source. A source that provides xGetChunks pulls the whole batch in one
+    ** round trip; otherwise fall back to one fetch per chunk. */
+    {
+      ProllyHash aMissing[SYNC_BATCH_SIZE];
+      int nMissing = 0;
 
-      if( aPresent[i] ){
-
-        continue;
+      for(i=0; i<nBatch; i++){
+        if( !aPresent[i] ) aMissing[nMissing++] = aBatch[i];
       }
+      if( nMissing==0 ) continue;
 
-      rc = pSrc->xGetChunk(pSrc, &aBatch[i], &data, &nData);
-      if( rc!=SQLITE_OK ) break;
+      if( pSrc->xGetChunks ){
+        u8 *apData[SYNC_BATCH_SIZE];
+        int anData[SYNC_BATCH_SIZE];
 
-      rc = pDst->xPutChunk(pDst, &aBatch[i], data, nData);
-      if( rc!=SQLITE_OK ){
-        sqlite3_free(data);
-        break;
+        memset(apData, 0, sizeof(apData[0]) * nMissing);
+        rc = pSrc->xGetChunks(pSrc, aMissing, nMissing, apData, anData);
+        for(i=0; i<nMissing && rc==SQLITE_OK; i++){
+          if( !apData[i] ){ rc = SQLITE_NOTFOUND; break; }
+          rc = pDst->xPutChunk(pDst, &aMissing[i], apData[i], anData[i]);
+          if( rc==SQLITE_OK ){
+            rc = syncEnqueueChildren(apData[i], anData[i], &queue, &seen);
+          }
+        }
+        for(i=0; i<nMissing; i++) sqlite3_free(apData[i]);
+      }else{
+        for(i=0; i<nMissing && rc==SQLITE_OK; i++){
+          u8 *data = 0;
+          int nData = 0;
+          rc = pSrc->xGetChunk(pSrc, &aMissing[i], &data, &nData);
+          if( rc!=SQLITE_OK ) break;
+          rc = pDst->xPutChunk(pDst, &aMissing[i], data, nData);
+          if( rc==SQLITE_OK ){
+            rc = syncEnqueueChildren(data, nData, &queue, &seen);
+          }
+          sqlite3_free(data);
+        }
       }
-
-      rc = syncEnqueueChildren(data, nData, &queue, &seen);
-      sqlite3_free(data);
     }
   }
 

--- a/src/doltlite_remote.h
+++ b/src/doltlite_remote.h
@@ -8,6 +8,12 @@ struct DoltliteRemote {
   int (*xGetChunk)(DoltliteRemote*, const ProllyHash*, u8**, int*);
   int (*xPutChunk)(DoltliteRemote*, const ProllyHash*, const u8*, int);
   int (*xHasChunks)(DoltliteRemote*, const ProllyHash*, int nHash, u8 *aResult);
+  /* Optional batched fetch: retrieve nHash chunks in one round trip. On
+  ** SQLITE_OK, apData[i]/anData[i] hold each chunk (caller frees every
+  ** non-NULL apData[i]); a NULL apData[i] means that chunk was absent. May be
+  ** NULL, in which case callers fall back to per-chunk xGetChunk. */
+  int (*xGetChunks)(DoltliteRemote*, const ProllyHash *aHash, int nHash,
+                    u8 **apData, int *anData);
   int (*xGetRefs)(DoltliteRemote*, u8**, int*);
   int (*xSetRefs)(DoltliteRemote*, const u8*, int);
   int (*xSetRefsIf)(DoltliteRemote*, const ProllyHash*, const u8*, int);

--- a/src/doltlite_remotesrv.c
+++ b/src/doltlite_remotesrv.c
@@ -320,6 +320,68 @@ static void handleHasChunks(ChunkStore *pStore, DoltliteConn *fd,
   sqlite3_free(aResult);
 }
 
+/* Batched read: body is N concatenated hashes; reply is the framed form
+** httpGetChunks parses -- per requested hash, a 4-byte big-endian length then
+** that many payload bytes, with length 0xFFFFFFFF marking an absent chunk. */
+static void handleGetChunks(ChunkStore *pStore, DoltliteConn *fd,
+                            const u8 *pBody, int nBody){
+  int nHashes, i, rc;
+  u8 *pOut = 0;
+  i64 nOut = 0, nAlloc = 0;
+
+  if( nBody % PROLLY_HASH_SIZE != 0 ){
+    sendBadRequest(fd);
+    return;
+  }
+  nHashes = nBody / PROLLY_HASH_SIZE;
+
+  for(i=0; i<nHashes; i++){
+    const ProllyHash *pHash = (const ProllyHash*)(pBody + (i * PROLLY_HASH_SIZE));
+    u8 *pData = 0;
+    int nData = 0;
+    u32 len;
+    i64 need;
+
+    rc = pStore ? chunkStoreGet(pStore, pHash, &pData, &nData) : SQLITE_NOTFOUND;
+    if( rc!=SQLITE_OK && rc!=SQLITE_NOTFOUND ){
+      sqlite3_free(pData);
+      sqlite3_free(pOut);
+      sendError(fd);
+      return;
+    }
+    len = (rc==SQLITE_NOTFOUND) ? 0xFFFFFFFFu : (u32)nData;
+
+    need = nOut + 4 + (rc==SQLITE_OK ? nData : 0);
+    if( need > nAlloc ){
+      i64 nNew = nAlloc ? nAlloc*2 : 4096;
+      u8 *pTmp;
+      while( nNew < need ) nNew *= 2;
+      pTmp = sqlite3_realloc(pOut, (int)nNew);
+      if( !pTmp ){
+        sqlite3_free(pData);
+        sqlite3_free(pOut);
+        sendError(fd);
+        return;
+      }
+      pOut = pTmp;
+      nAlloc = nNew;
+    }
+
+    pOut[nOut++] = (u8)(len >> 24);
+    pOut[nOut++] = (u8)(len >> 16);
+    pOut[nOut++] = (u8)(len >> 8);
+    pOut[nOut++] = (u8)len;
+    if( rc==SQLITE_OK ){
+      memcpy(pOut + nOut, pData, nData);
+      nOut += nData;
+    }
+    sqlite3_free(pData);
+  }
+
+  sendOk(fd, pOut, (int)nOut);
+  sqlite3_free(pOut);
+}
+
 static void handleGetChunk(ChunkStore *pStore, DoltliteConn *fd, const char *zHexHash){
   ProllyHash hash;
   u8 *pData = 0;
@@ -534,6 +596,7 @@ static void handleRequest(DoltliteServer *pSrv, DoltliteConn *fd){
   int flags;
   int isReadOnlyEndpoint = 0;
   int isHasChunksEndpoint = 0;
+  int isGetChunksEndpoint = 0;
   int exists = 0;
   sqlite3_vfs *pVfs;
 
@@ -573,7 +636,10 @@ static void handleRequest(DoltliteServer *pSrv, DoltliteConn *fd){
   sqlite3_snprintf(sizeof(zDbPath), zDbPath, "%s/%s", pSrv->zDir, zDbName);
   isHasChunksEndpoint = strcmp(zMethod, "POST")==0
                      && strcmp(zEndpoint, "has-chunks")==0;
-  isReadOnlyEndpoint = strcmp(zMethod, "GET")==0 || isHasChunksEndpoint;
+  isGetChunksEndpoint = strcmp(zMethod, "POST")==0
+                     && strcmp(zEndpoint, "get-chunks")==0;
+  isReadOnlyEndpoint = strcmp(zMethod, "GET")==0
+                     || isHasChunksEndpoint || isGetChunksEndpoint;
   pVfs = sqlite3_vfs_find(0);
   rc = pVfs->xAccess(pVfs, zDbPath, SQLITE_ACCESS_EXISTS, &exists);
   if( rc!=SQLITE_OK ){
@@ -616,6 +682,8 @@ static void handleRequest(DoltliteServer *pSrv, DoltliteConn *fd){
   }else if( strcmp(zMethod, "POST")==0 ){
     if( strcmp(zEndpoint, "has-chunks")==0 ){
       handleHasChunks(&store, fd, pBody, nBody);
+    }else if( strcmp(zEndpoint, "get-chunks")==0 ){
+      handleGetChunks(&store, fd, pBody, nBody);
     }else if( strcmp(zEndpoint, "chunks")==0 ){
       handlePostChunks(&store, fd, pBody, nBody);
     }else if( strcmp(zEndpoint, "commit")==0 ){

--- a/src/doltlite_tls.c
+++ b/src/doltlite_tls.c
@@ -117,6 +117,7 @@ DoltliteConn *doltliteConnOpen(const char *host, int port, int useTls) {
                                   MBEDTLS_SSL_PRESET_DEFAULT) != 0) {
     goto fail_tls;
   }
+  mbedtls_ssl_conf_min_tls_version(&c->conf, MBEDTLS_SSL_VERSION_TLS1_3);
   mbedtls_ssl_conf_authmode(&c->conf, MBEDTLS_SSL_VERIFY_REQUIRED);
   mbedtls_ssl_conf_ca_chain(&c->conf, &c->cacert, NULL);
   mbedtls_ssl_conf_rng(&c->conf, mbedtls_ctr_drbg_random, &c->drbg);
@@ -220,6 +221,7 @@ DoltliteTlsServer *doltliteTlsServerNew(const char *certFile, const char *keyFil
                                   MBEDTLS_SSL_PRESET_DEFAULT) != 0) {
     goto fail;
   }
+  mbedtls_ssl_conf_min_tls_version(&s->conf, MBEDTLS_SSL_VERSION_TLS1_3);
   mbedtls_ssl_conf_rng(&s->conf, mbedtls_ctr_drbg_random, &s->drbg);
 
   mbedtls_ssl_conf_authmode(&s->conf, MBEDTLS_SSL_VERIFY_NONE);

--- a/test/remote_https_auth_test.sh
+++ b/test/remote_https_auth_test.sh
@@ -115,6 +115,28 @@ else
 fi
 kill "$SRV2_PID" 2>/dev/null
 
+echo "=== 6. Multi-chunk clone integrity (batched /get-chunks) ==="
+# Enough rows with blob payloads to span many chunks, so the pull fans out
+# across the batched download path rather than a single chunk. A fresh repo
+# path avoids the section-1 history.
+BIGURL="https://localhost:$PORT/bigrepo.db"
+"$DOLTLITE" "$TMP/big.db" <<ENDSQL >/dev/null 2>&1
+CREATE TABLE blobs(id INTEGER PRIMARY KEY, payload BLOB);
+WITH RECURSIVE c(i) AS (SELECT 1 UNION ALL SELECT i+1 FROM c WHERE i<2000)
+  INSERT INTO blobs SELECT i, randomblob(400) FROM c;
+SELECT dolt_commit('-A','-m','big');
+SELECT dolt_remote('add','bigorigin','$BIGURL');
+ENDSQL
+src_hash=$("$DOLTLITE" "$TMP/big.db" "SELECT dolt_hashof_table('blobs');" 2>&1)
+result=$(DOLTLITE_CREDS_DIR="$TMP/cc" "$DOLTLITE" "$TMP/big.db" "SELECT dolt_push('bigorigin','main');" 2>&1)
+check "large push returns 0" "0" "$result"
+result=$(DOLTLITE_CREDS_DIR="$TMP/cc" "$DOLTLITE" "$TMP/bigclone.db" "SELECT dolt_clone('$BIGURL');" 2>&1)
+check "large clone returns 0" "0" "$result"
+clone_rows=$(DOLTLITE_CREDS_DIR="$TMP/cc" "$DOLTLITE" "$TMP/bigclone.db" "SELECT count(*) FROM blobs;" 2>&1)
+check "large clone round-trips 2000 rows" "2000" "$clone_rows"
+clone_hash=$(DOLTLITE_CREDS_DIR="$TMP/cc" "$DOLTLITE" "$TMP/bigclone.db" "SELECT dolt_hashof_table('blobs');" 2>&1)
+check "clone table hash matches source (chunks intact)" "$src_hash" "$clone_hash"
+
 echo ""
 echo "======================================="
 echo "Results: $pass passed, $fail failed"


### PR DESCRIPTION
Closes #228. Compression, the one remaining bullet, is split out to #1584.

#228 asked for TLS 1.3, authentication, batching, and compression on the remote protocol. Auth (bearer JWT) and **upload** batching already landed in the `bh/remote-auth` stack. This PR finishes the batching (download) and the TLS-1.3 requirement.

## Batched chunk download
Chunk pulls issued one `GET /chunk/<hash>` per chunk, so a clone of N chunks cost N round trips — the "10K chunks = 10K round trips" complaint. The sync loop already batched the presence probe (256 per `POST /has-chunks`); it now fetches the missing chunks from that batch in **one request**:

- New optional `xGetChunks` vtable method. The HTTP client `POST`s the missing hashes to `/get-chunks` and parses a framed reply (per hash: a 4-byte big-endian length, then the payload; `0xFFFFFFFF` marks an absent chunk). The server answers with a new read-only `handleGetChunks`.
- Sources without `xGetChunks` (the `file://`/local remotes) fall back to per-chunk `xGetChunk` — unchanged.
- Batch size is the existing `SYNC_BATCH_SIZE` (256), satisfying "100+ chunks per request".

## TLS 1.3
Client and server SSL configs now call `mbedtls_ssl_conf_min_tls_version(..., MBEDTLS_SSL_VERSION_TLS1_3)`, so all remote traffic negotiates TLS 1.3 (mbedtls previously floored at 1.2). TLS 1.3 is already compiled into the bundled mbedtls.

## Tests
- `remote_https_auth_test.sh` gains a 2000-row blob clone over authenticated HTTPS whose `dolt_hashof_table` matches the source — exercises the batched `/get-chunks` path end to end and proves the chunk graph round-trips byte-for-byte. (Fails-before if the `/get-chunks` route is missing, since the client now depends on it.)
- `remote_test.sh` (file:// fallback) stays green at 90/90; `tls_test.sh` passes with the 1.3 floor; C gating 16/16; testfixture builds.

## Scope note
Compression (#1584) is deliberately not here. It needs `Content-Encoding` negotiation and either vendoring zstd or using the already-linked zlib — its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)