### PR TITLE
Avoid raw xfer for indexed prolly tables

### DIFF
--- a/src/insert.c
+++ b/src/insert.c
@@ -3323,9 +3323,18 @@ static int xferOptimization(
     extern int pagerShimIsShim(const Pager*);
     Btree *pSrcBt = db->aDb[iDbSrc].pBt;
     Btree *pDestBt = db->aDb[iDbDest].pBt;
+    int srcIsProlly = pSrcBt && pagerShimIsShim(sqlite3BtreePager(pSrcBt));
+    int destIsProlly = pDestBt && pagerShimIsShim(sqlite3BtreePager(pDestBt));
     if( pSrcBt && pDestBt
-     && pagerShimIsShim(sqlite3BtreePager(pSrcBt))
-          != pagerShimIsShim(sqlite3BtreePager(pDestBt)) ){
+     && srcIsProlly!=destIsProlly ){
+      return 0;
+    }
+    /* Raw index-cell transfer trusts parsed sqlite_schema metadata. Under
+    ** writable_schema, that metadata can be made inconsistent with an existing
+    ** prolly index root. Fall back to row-by-row insert so destination indexes
+    ** are rebuilt from table rows instead of copied from possibly retagged
+    ** source index storage. */
+    if( (srcIsProlly || destIsProlly) && (pSrc->pIndex || pDest->pIndex) ){
       return 0;
     }
   }

--- a/test/doltlite_writable_schema.sh
+++ b/test/doltlite_writable_schema.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+. "$(dirname "$0")/lib/doltlite_test_common.sh"
+
+echo "=== Doltlite writable_schema catalog poke tests ==="
+echo ""
+
+DB=/tmp/test_dl_writable_schema_root_$$.db; rm -f "$DB"
+cat <<'SQL' | "$DOLTLITE" "$DB" >/dev/null
+CREATE TABLE t1(oid INTEGER PRIMARY KEY, a INT);
+CREATE INDEX t1i1 ON t1(a);
+WITH RECURSIVE c(x) AS (
+  SELECT 1 UNION ALL SELECT x+1 FROM c WHERE x<98
+)
+INSERT INTO t1 SELECT x, x FROM c;
+.dbconfig defensive off
+PRAGMA writable_schema=1;
+UPDATE sqlite_master
+SET rootpage = CASE name
+  WHEN 't1' THEN (SELECT rootpage FROM sqlite_master WHERE name='t1i1')
+  WHEN 't1i1' THEN (SELECT rootpage FROM sqlite_master WHERE name='t1')
+  ELSE rootpage END
+WHERE name IN ('t1','t1i1');
+PRAGMA writable_schema=0;
+PRAGMA schema_version=123;
+SQL
+
+run_test_match "rootpage_swap_fails_loudly" \
+  "SELECT count(*) FROM t1 WHERE oid=10;" \
+  "malformed database schema" "$DB"
+rm -f "$DB"
+
+DB=/tmp/test_dl_writable_schema_xfer_$$.db; rm -f "$DB"
+cat <<'SQL' | "$DOLTLITE" "$DB" >/dev/null
+CREATE TABLE t1(a, b, c, d INTEGER PRIMARY KEY);
+CREATE TABLE t2(a, b, c, d INTEGER PRIMARY KEY);
+INSERT INTO t1 VALUES (1,2,3,100),(4,5,6,101);
+INSERT INTO t2 VALUES (1,100,3,1000),(4,101,6,1001);
+CREATE INDEX t1a ON t1(a);
+CREATE INDEX t2a ON t2(a, b, c);
+.dbconfig defensive off
+PRAGMA writable_schema = 1;
+UPDATE sqlite_master SET sql = 'CREATE INDEX t2a ON t2(a)' WHERE name='t2a';
+PRAGMA writable_schema = 0;
+PRAGMA schema_version=321;
+SQL
+
+run_test "xfer_from_poked_index_keeps_dest_index_consistent" \
+  "INSERT INTO t1 SELECT * FROM t2;
+   SELECT count(*) FROM pragma_integrity_check WHERE integrity_check LIKE '%t1a%';" \
+  "0" "$DB"
+
+run_test_match "poked_source_index_still_reported" \
+  "SELECT group_concat(integrity_check, '|') FROM pragma_integrity_check;" \
+  "missing from index t2a" "$DB"
+rm -f "$DB"
+
+dltest_finish

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1915,7 +1915,7 @@ corruptL corruptL-1.4  # stock index-page corruption: store rejects at schema le
 corruptL corruptL-2.0  # stock index-page corruption: store rejects at schema level
 corruptL corruptL-2.1  # stock index-page corruption: store rejects at schema level
 corruptL corruptL-2.2  # stock index-page corruption: store rejects at schema level
-corruptL corruptL-3.1  # writable_schema index-SQL poke ACCEPTED; INSERT..SELECT then leaves the untouched index t1a flagged by integrity_check while reads stay correct (tracked layer disagreement; REINDEX repairs)
+corruptL corruptL-3.1  # writable_schema index-SQL poke tolerated instead of malformed; row-by-row INSERT..SELECT keeps unrelated indexes consistent
 corruptL corruptL-4.0  # stock index-page corruption: store rejects at schema level
 corruptL corruptL-4.1  # stock index-page corruption: store rejects at schema level
 corruptL corruptL-5.0  # stock index-page corruption: store rejects at schema level

--- a/test/lib/doltlite_suite_manifest.sh
+++ b/test/lib/doltlite_suite_manifest.sh
@@ -75,6 +75,7 @@ doltlite_pragma_wal_checkpoint.sh
 doltlite_merge_ignore_corners.sh
 doltlite_record_format.sh
 doltlite_schema_cookie.sh
+doltlite_writable_schema.sh
 doltlite_snapshot_isolation.sh
 doltlite_storage_locking.sh
 doltlite_unknown_table_cursor.sh


### PR DESCRIPTION
Closes #1575.

## Summary
- disable raw transfer optimization for indexed prolly-backed INSERT INTO ... SELECT paths
- keep cross-backend xfer fallback behavior scoped to prolly tables
- add writable_schema regression coverage for rootpage swaps and rewritten index SQL
- update the corruptL-3.1 known-divergence reason to reflect the remaining tolerated writable_schema poke

## Tests
- make -C build doltlite
- LIBRARY_PATH=/opt/homebrew/lib make -C build testfixture
- cd build && DOLTLITE=./doltlite bash ../test/doltlite_writable_schema.sh
- cd build && DOLTLITE=./doltlite bash ../test/doltlite_comparison.sh
- cd build && DOLTLITE=./doltlite bash ../test/doltlite_index_prefix.sh
- cd build && DOLTLITE=./doltlite bash ../test/doltlite_attach_sqlite.sh
- cd build && DOLTLITE=./doltlite bash ../test/doltlite_parity.sh
- cd build && bash ../test/run_testfixture.sh "xfer targeted" 300 insert insert2 insert3 autoinc e_vacuum corruptL
- cd build && bash ../test/run_testfixture.sh "corruptL divergence check" 300 corruptL
- git diff --check