### PR TITLE
Don't expire mid-scan statements on a data-only rollback

### DIFF
--- a/ext/fts3/fts3.c
+++ b/ext/fts3/fts3.c
@@ -3563,7 +3563,7 @@ static int fts3SyncMethod(sqlite3_vtab *pVtab){
 ** to 0 or 1). Return SQLITE_OK if successful, or an SQLite error code
 ** if an error occurs.
 */
-static int fts3SetHasStat(Fts3Table *p){
+int sqlite3Fts3SetHasStat(Fts3Table *p){
   int rc = SQLITE_OK;
   if( p->bHasStat==2 ){
     char *zTbl = sqlite3_mprintf("%s_stat", p->zName);
@@ -3589,7 +3589,7 @@ static int fts3BeginMethod(sqlite3_vtab *pVtab){
   assert( p->nPendingData==0 );
   assert( p->inTransaction!=1 );
   p->nLeafAdd = 0;
-  rc = fts3SetHasStat(p);
+  rc = sqlite3Fts3SetHasStat(p);
 #ifdef SQLITE_DEBUG
   if( rc==SQLITE_OK ){
     p->inTransaction = 1;
@@ -3872,7 +3872,7 @@ static int fts3RenameMethod(
 
   /* At this point it must be known if the %_stat table exists or not.
   ** So bHasStat may not be 2.  */
-  rc = fts3SetHasStat(p);
+  rc = sqlite3Fts3SetHasStat(p);
   
   /* As it happens, the pending terms table is always empty here. This is
   ** because an "ALTER TABLE RENAME TABLE" statement inside a transaction 

--- a/ext/fts3/fts3Int.h
+++ b/ext/fts3/fts3Int.h
@@ -524,6 +524,7 @@ struct Fts3Expr {
 /* fts3_write.c */
 int sqlite3Fts3UpdateMethod(sqlite3_vtab*,int,sqlite3_value**,sqlite3_int64*);
 int sqlite3Fts3PendingTermsFlush(Fts3Table *);
+int sqlite3Fts3SetHasStat(Fts3Table *);
 void sqlite3Fts3PendingTermsClear(Fts3Table *);
 int sqlite3Fts3Optimize(Fts3Table *);
 int sqlite3Fts3SegReaderNew(int, int, sqlite3_int64,

--- a/ext/fts3/fts3_write.c
+++ b/ext/fts3/fts3_write.c
@@ -5838,6 +5838,12 @@ int sqlite3Fts3UpdateMethod(
 */
 int sqlite3Fts3Optimize(Fts3Table *p){
   int rc;
+  /* This is the one write path with no xBegin (the writes happen inside the
+  ** optimize() SQL function), so bHasStat may still be unresolved (==2) on a
+  ** connection that has never written to the table. Resolve it here; the
+  ** code below and PendingTermsFlush treat bHasStat as a boolean. */
+  rc = sqlite3Fts3SetHasStat(p);
+  if( rc!=SQLITE_OK ) return rc;
   rc = sqlite3_exec(p->db, "SAVEPOINT fts3", 0, 0, 0);
   if( rc==SQLITE_OK ){
     rc = fts3DoOptimize(p, 1);

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -1309,16 +1309,6 @@ static void resetConnectionSchema(Btree *pBtree){
   }
 }
 
-static void expireActiveStatements(Btree *pBtree){
-  Vdbe *pVdbe;
-  if( !pBtree->db ) return;
-  for(pVdbe=pBtree->db->pVdbe; pVdbe; pVdbe=pVdbe->pVNext){
-    if( pVdbe->eVdbeState==VDBE_RUN_STATE ){
-      pVdbe->expired = 1;
-    }
-  }
-}
-
 static int hasActiveSchemaProgram(Btree *pBtree){
   Vdbe *pVdbe;
   if( !pBtree->db ) return 0;
@@ -6110,8 +6100,6 @@ static int prollyBtreeRollback(Btree *p, int tripCode, int writeOnly){
     }
     if( bSchemaChangedRollback ){
       resetConnectionSchema(p);
-    }else if( writeOnly ){
-      expireActiveStatements(p);
     }
     chunkStoreRollback(&pBt->store);
     if( bAutocommitOomRollback ){

--- a/test/doltlite_recover_fts3_optimize.test
+++ b/test/doltlite_recover_fts3_optimize.test
@@ -1,0 +1,41 @@
+# 2026-07-09
+#
+# The optimize() SQL function is the one fts3 write path with no xBegin (its
+# writes happen inside the function, so the compiler emits no OP_VBegin). On a
+# connection that has never written to the table, bHasStat can therefore stay
+# unresolved and the pending-terms flush tries to read a nonexistent %_stat
+# table ("no such table" -> SQL logic error) on the second optimize. Upstream
+# sqlite carries this latent bug; doltlite reaches it whenever a
+# connection-schema reset (e.g. OOM rollback recovery) reconnects the vtab.
+#
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+ifcapable !fts3 { finish_test ; return }
+
+do_execsql_test doltlite_recover_fts3_optimize-1.0 {
+  CREATE VIRTUAL TABLE t1 USING fts3(x);
+  INSERT INTO t1 VALUES('one two three');
+  INSERT INTO t1 VALUES('four five six');
+} {}
+
+# Reopen so the vtab is freshly connected and no write statement (hence no
+# xBegin) ever runs on this connection before optimize() does.
+do_test doltlite_recover_fts3_optimize-1.1 {
+  db close
+  sqlite3 db test.db
+  execsql { SELECT * FROM (SELECT optimize(t1) FROM t1 LIMIT 1) }
+} {{Index optimized}}
+
+do_test doltlite_recover_fts3_optimize-1.2 {
+  execsql { SELECT * FROM (SELECT optimize(t1) FROM t1 LIMIT 1) }
+} {{Index already optimal}}
+
+do_test doltlite_recover_fts3_optimize-1.3 {
+  execsql { SELECT * FROM (SELECT optimize(t1) FROM t1 LIMIT 1) }
+} {{Index already optimal}}
+
+do_execsql_test doltlite_recover_fts3_optimize-1.4 {
+  SELECT count(*) FROM t1 WHERE t1 MATCH 'five';
+} {1}
+
+finish_test

--- a/test/doltlite_recover_locking_1.test
+++ b/test/doltlite_recover_locking_1.test
@@ -468,12 +468,15 @@ do_test doltlite_recover_locking_1-10.4 {
 do_test doltlite_recover_locking_1-10.5 {
   list [sqlite3_step $::STMT] [sqlite3_step $::STMT] [sqlite3_step $::STMT]
 } {SQLITE_ROW SQLITE_ROW SQLITE_DONE}
+# A data-only ROLLBACK no longer expires the statement (matches stock): after
+# the scan drains at 10.5, re-stepping auto-resets and reseeks the restored
+# tree, and finalize succeeds.
 do_test doltlite_recover_locking_1-10.6 {
   sqlite3_step $::STMT
-} {SQLITE_ERROR}
+} {SQLITE_ROW}
 do_test doltlite_recover_locking_1-10.7 {
   sqlite3_finalize $::STMT
-} {SQLITE_SCHEMA}
+} {SQLITE_OK}
 do_test doltlite_recover_locking_1-10.8 {
   execsql {SELECT a FROM t2 ORDER BY a}
 } {1 2}

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1155,8 +1155,6 @@ capi3 capi3-11.3.4 # PRAGMA lock_status reports doltlite's locking model ("main 
 # scan survives the commit flush and re-seeks. capi3-11.10/11.11 (step after
 # ROLLBACK-during-active-read) pass since the read cursor survives a writeOnly
 # ROLLBACK.
-capi3 capi3-11.12  # step after ROLLBACK-during-active-read: SQLITE_ERROR vs SQLITE_ROW
-capi3 capi3-11.13  # finalize of that statement: SQLITE_SCHEMA vs SQLITE_OK
 
 # fordelete — doltlite doesn't materialize named sqlite_autoindex_* rows for
 # WITHOUT-ROWID/implicit unique indexes, so PRAGMA index_list reports just the

--- a/test/regression-buckets/ported.txt
+++ b/test/regression-buckets/ported.txt
@@ -1,6 +1,7 @@
 doltlite_recover_collation
 doltlite_recover_corruption
 doltlite_recover_backup_fault
+doltlite_recover_fts3_optimize
 doltlite_recover_incrblob
 doltlite_recover_jrnlwal_1
 doltlite_recover_jrnlwal_2


### PR DESCRIPTION
## Problem

A **data-only** ROLLBACK (no schema change) expires prepared statements suspended mid-scan, so a v1-API caller sees `SQLITE_ERROR` on the next step and `SQLITE_SCHEMA` on finalize. Stock only expires prepared statements when the rolled-back transaction changed the schema. (#1571, reopened — the earlier fix covered the reset case but not the mid-scan case.)

## Commit 1 — remove the expiry (stock-conformant rollback)

Remove `expireActiveStatements` from `prollyBtreeRollback` entirely. The cursor loop already handles rollback the stock way — read cursors save to `CURSOR_REQUIRESEEK` and reseek the restored tree, write cursors fault with the trip code — so no statement expiry is needed on a data-only rollback, matching stock byte-for-byte.

The native `doltlite_recover_locking_1-10.4..10.8` exercises this exact sequence and had captured the pre-fix codes; its 10.6/10.7 assertions are updated to the corrected, stock-matching `SQLITE_ROW`/`SQLITE_OK` — the native test **fails on master, passes with the fix**.

## Commit 2 — the bug the expiry was masking (latent *upstream* fts3 bug)

Removing the expiry deterministically exposed `fts3cov-5.6.persistent`: `SELECT optimize(t)` failing with a bare "SQL logic error". Root cause (traced via probes + a stock-build oracle):

- The optimize() SQL function is the **one fts3 write path with no xBegin** (its writes happen inside the function — no `OP_VBegin` is emitted).
- On a connection that never wrote to an fts3 (non-fts4) table, `bHasStat` stays at the unresolved sentinel `2`, which downstream checks treat as "%_stat exists". The second optimize() reaches the pending-terms flush with `nLeafAdd>0` and queries the nonexistent `%_stat` → "no such table" → bare `SQLITE_ERROR`.
- **This reproduces on stock SQLite**: `SELECT optimize(t)` twice on a fresh connection fails identically on an unmodified upstream build. doltlite just reaches the state far more often (OOM-recovery schema resets reconnect vtabs, resetting `bHasStat` to 2).
- The old blanket expiry never fixed this — it only shifted malloc-fault alignment in fts3cov so the failing iteration wasn't hit.

Fix: export `fts3SetHasStat` and call it at the top of `sqlite3Fts3Optimize`, enforcing the invariant the code itself documents ("bHasStat may not be 2") on the one entry path that lacked it.

New native test `doltlite_recover_fts3_optimize` ports the deterministic repro (fails 2/6 on an unfixed build, passes with the fix; added to the ported bucket).

## Validation

- `rollback.test` 1.1–1.9: Ok. `doltlite_recover_locking_1`: OK (75).
- `fts3cov`: **0 errors / 8666 tests** (previously hung behind the expiry).
- `capi3-11.12/11.13` now **pass** — removed from the divergence list (the fix deletes divergences, not adds them).
- Full gated fts3/fts4 family sweep (94 files): no unexpected failures, no stale entries.
- `trans*`/`savepoint*`/`conflict*` gate clean. C-test gate: 16/16.

Fixes #1571

🤖 Generated with [Claude Code](https://claude.com/claude-code)