### PR TITLE
Gate walbak as divergences instead of crash-listing it

### DIFF
--- a/test/known_testfixture_crashes.txt
+++ b/test/known_testfixture_crashes.txt
@@ -116,7 +116,6 @@ wal6             # journal_mode no-op now; aborts at wal6-4.4.2 opening a 2nd WA
 walnoshm         # journal_mode no-op now; aborts at walnoshm-2.2.6 opening a 2nd shm connection (db2) -> uncaught "invalid command name db2"
 wal              # reads test.db-wal: doltlite has no -wal sidecar
 wal2             # wal helper reads ::filename of the -wal sidecar
-walbak           # journal_mode no-op now lets it complete (31 err/84, all -wal-sidecar-absence divergences); kept crash-listed and UNBUCKETED rather than gate 31 WAL-specific entries
 walcksum         # copies test.db-wal: no -wal sidecar
 waloverwrite     # copies test.db-wal: no -wal sidecar
 walslow          # copies test.db-wal: no -wal sidecar

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1906,6 +1906,44 @@ wal9 wal9-1.3  # file-size metric + missing -wal/-shm sidecars
 wal9 wal9-1.4  # file-size metric + missing -wal/-shm sidecars
 wal9 wal9-1.5  # file-size metric + missing -wal/-shm sidecars
 wal9 wal9-1.6  # file-size metric + missing -wal/-shm sidecars
+# walbak: backup/restore in WAL mode. Two benign divergence classes; the
+# db2 copies verify integrity-ok with correct data either way:
+#   * snapshot-isolation backup -- doltlite copies an immutable snapshot as
+#     of backup-init, so a source modified mid-backup yields a consistent
+#     older copy (stock restarts to the latest) and never returns BUSY.
+#   * WAL sidecar-absent metrics -- -wal file sizes and frame-byte patterns
+#     a store with no -wal/-shm sidecar cannot reproduce.
+walbak walbak-1.1
+walbak walbak-1.5
+walbak walbak-1.6
+walbak walbak-1.6.1
+walbak walbak-1.7
+walbak walbak-1.8
+walbak walbak-1.9
+walbak walbak-2.10
+walbak walbak-2.4
+walbak walbak-2.5
+walbak walbak-2.6
+walbak walbak-2.8
+walbak walbak-2.9
+walbak walbak-3.1.2
+walbak walbak-3.1.3
+walbak walbak-3.1.4
+walbak walbak-3.1.6
+walbak walbak-3.2.2
+walbak walbak-3.2.3
+walbak walbak-3.2.4
+walbak walbak-3.2.6
+walbak walbak-3.3.6
+walbak walbak-3.3.8
+walbak walbak-3.4.6
+walbak walbak-3.4.8
+walbak walbak-4.1.2
+walbak walbak-4.1.3
+walbak walbak-4.1.5
+walbak walbak-4.1.7
+walbak walbak-4.2.2
+walbak walbak-4.3.3
 walprotocol2 walprotocol2-2.2  # WAL locking protocol: busy not raised; txn-state cascade
 walprotocol2 walprotocol2-2.3  # WAL locking protocol: busy not raised; txn-state cascade
 walprotocol2 walprotocol2-2.4  # WAL locking protocol: busy not raised; txn-state cascade

--- a/test/regression-buckets/storage.txt
+++ b/test/regression-buckets/storage.txt
@@ -179,6 +179,7 @@ wal64k
 wal7
 wal8
 wal9
+walbak
 walbig
 walblock
 walckptnoop


### PR DESCRIPTION
## What

`walbak` was kept on the crash list and UNBUCKETED "rather than gate 31 WAL-specific entries" even though, since the journal_mode no-op, it runs to completion (31 errors / 84 tests) with a deterministic failing set (identical across 3 local runs). That left the file entirely unguarded. This promotes it to the divergence list + storage bucket, matching the precedent set for `e_walckpt` (133) and `wal5` (266).

## Verified the 31 failures are benign, not a hidden bug

Every backed-up `db2` passes `integrity_check` with correct data. The two divergence classes:

- **Snapshot-isolation backup** — doltlite's `sqlite3_backup` copies an immutable snapshot as of backup-init. A source modified mid-backup yields a consistent *older* copy (`dst == src-at-start`), where stock restarts the copy to capture the latest state. The same immutable-snapshot read never returns `SQLITE_BUSY` (walbak-2.6/2.10). Confirmed by direct repro: after a mid-backup `UPDATE`, db2 has all rows, integrity ok, matching the pre-update signature.
- **WAL sidecar-absent metrics** — `-wal` file sizes and frame-byte patterns (`[0202]` vs `[0000]`) a store with no `-wal`/`-shm` sidecar cannot reproduce.

## Changes

- Remove `walbak` from `known_testfixture_crashes.txt`.
- Add `walbak` to the `storage` regression bucket.
- Record its 31 divergences in `known_testfixture_divergences.txt`.

## Validation

- Gate: `OK: walbak (84 tests, 31 known divergences)` — no unexpected failures, no fixed entries.
- Bucket disjointness guard passes.
- The divergence set was captured on macOS; if the Linux oracle differs, the storage bucket will name the delta and I'll reconcile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)