### PR TITLE
Bucket walsetlk recovery divergence

### DIFF
--- a/test/doltlite_recover_jrnlwal_2.test
+++ b/test/doltlite_recover_jrnlwal_2.test
@@ -1,5 +1,6 @@
 set testdir [file dirname $argv0]
 source $testdir/tester.tcl
+source $testdir/lock_common.tcl
 
 
 
@@ -387,5 +388,52 @@ do_test doltlite_recover_jrnlwal_2-13.4 {
   dbm close
   execsql {PRAGMA integrity_check}
 } {ok}
+
+do_test doltlite_recover_jrnlwal_2-14.1 {
+  catch {db close}
+  forcedelete jw_nohang.db .jw_nohang.db-lock jw_nohang.db-wal jw_nohang.db-shm
+  sqlite3 db jw_nohang.db
+  execsql {
+    PRAGMA journal_mode = wal;
+    CREATE TABLE wh(a, b);
+    INSERT INTO wh VALUES(1, 2), (3, 4), (5, 6);
+  }
+  db close
+
+  unset -nocomplain childDone
+  testfixture_nb childDone {
+    testvfs tvfs -fullshm 1
+    sqlite3 db jw_nohang.db -vfs tvfs
+    tvfs script wh_callback
+    tvfs filter xRead
+    set ::sawWalRead 0
+    proc wh_callback {method file args} {
+      if {[string match *-wal $file] || [string match *wal $file]} {
+        set ::sawWalRead 1
+        after 4000
+      }
+      return SQLITE_OK
+    }
+    set rows [db eval {SELECT * FROM wh ORDER BY a}]
+    db close
+    tvfs delete
+    list $rows $::sawWalRead
+  }
+
+  testvfs tvfs -fullshm 1
+  sqlite3 db jw_nohang.db -vfs tvfs
+  set parentRows [db eval {SELECT * FROM wh ORDER BY a}]
+  db close
+  tvfs delete
+
+  for {set i 0} {$i<200 && ![info exists childDone]} {incr i} {
+    after 10 {set ::wh_tick 1}
+    vwait ::wh_tick
+    unset -nocomplain ::wh_tick
+  }
+  set childResult [expr {[info exists childDone] ? $childDone : "timeout"}]
+  list $childResult $parentRows \
+      [file exists jw_nohang.db-wal] [file exists jw_nohang.db-shm]
+} {{{1 2 3 4 5 6} 0} {1 2 3 4 5 6} 0 0}
 
 finish_test

--- a/test/known_testfixture_crashes.txt
+++ b/test/known_testfixture_crashes.txt
@@ -149,7 +149,6 @@ wal3           # copies test.db-wal: no -wal sidecar
 walbig         # aborts at line 72 on ORDER BY rowid over a PK-clustered table ("no such column: rowid"), before any WAL size poke
 walro2         # reads test.db-shm: no shm sidecar
 walsetlk       # opens test.db-shm: no shm sidecar
-walsetlk_recover # expects a -shm sidecar that doltlite does not produce; hangs opening test.db-shm during recovery (stock: 6 tests in ~4s)
 ioerr2         # fault loop runs tens of thousands of iterations; exceeds the per-file timeout on STOCK sqlite too (verified), so inherent test size, not a doltlite slowdown
 lock4          # expects a rollback-journal (test2.db-journal) that doltlite does not produce, so its `while {![file exists ...]}` poll never terminates (stock: 5 tests in <1s); native cross-process lock ordering covered in doltlite_recover_locking_2-17.1 (#1365)
 sharedA        # expects a rollback-journal that doltlite does not produce: the test hangs waiting for a journal xRead during shared-cache rollback (stock: 9 tests in ~1s). doltlite_recover_locking_2-18.* ports the OUTCOME (ROLLBACK restores state; a cross-connection prepared stmt still steps to SQLITE_DONE; integrity ok) but NOT the tvfs xRead-on-journal hook. Partial coverage. (#1366)

--- a/test/known_testfixture_divergences.txt
+++ b/test/known_testfixture_divergences.txt
@@ -1915,6 +1915,9 @@ walrestart walrestart-1.1  # wal_checkpoint frame counters zero (no-op checkpoin
 walrestart walrestart-1.2  # wal_checkpoint frame counters zero (no-op checkpoint)
 walrestart walrestart-1.4  # wal_checkpoint frame counters zero (no-op checkpoint)
 walseh1 walseh1-6-seh.1  # wal_checkpoint mode explicitly rejected under fault injection
+walsetlk_recover walsetlk_recover-1.2  # WAL recovery blocking lock not raised; snapshot read proceeds
+walsetlk_recover walsetlk_recover-1.3  # WAL recovery blocking lock not raised; no wait
+walsetlk_recover walsetlk_recover-1.5.2  # no WAL lock wait, so xSleep is not called
 walshared walshared-1.2  # shared-cache WAL table locks not raised; snapshot reads proceed
 walshared walshared-1.3  # shared-cache WAL table locks not raised; snapshot reads proceed
 

--- a/test/regression-buckets/storage.txt
+++ b/test/regression-buckets/storage.txt
@@ -195,6 +195,7 @@ walro
 walro2
 walseh1
 walsetlk
+walsetlk_recover
 walsetlk_snapshot
 walsetlk2
 walsetlk3

--- a/test/walsetlk_recover.test
+++ b/test/walsetlk_recover.test
@@ -20,6 +20,11 @@ set testprefix walsetlk_recover
 ifcapable !wal {finish_test ; return }
 # ifcapable !setlk_timeout {finish_test ; return }
 
+catch {db close}
+forcedelete test.db test.db-wal test.db-shm .test.db-lock \
+            sv_test.db sv_test.db-wal sv_test.db-shm .sv_test.db-lock
+sqlite3 db test.db
+
 do_execsql_test 1.0 {
   PRAGMA journal_mode = wal;
   CREATE TABLE t1(a, b);
@@ -77,9 +82,11 @@ set tm [lindex [time {
 }] 0]
 
 do_test 1.2         { set ::msg } {database is locked}
-do_test 1.3.($::tm) { expr $::tm>400000 && $::tm<2000000 } 1
+do_test 1.3 { expr $::tm>400000 && $::tm<2000000 } 1
 
-vwait myvar
+while {![info exists myvar]} {
+  vwait myvar
+}
 
 do_execsql_test 1.4 {
   SELECT * FROM t1
@@ -101,4 +108,3 @@ if {$::sqlite_options(setlk_timeout)==1} {
 }
 
 finish_test
-


### PR DESCRIPTION
## Summary
- make walsetlk_recover complete instead of hanging when the background worker finishes before vwait
- move walsetlk_recover from the crash list into the storage regression bucket
- record its DoltLite WAL-lock semantic differences as known divergences
- add a DoltLite-native no-hang guard covering the same fullshm concurrent-read shape

## Investigation
The hang was not sqlite3_open blocking forever. Under DoltLite, the background worker does not enter SQLite WAL recovery lock path, so it can finish before the parent reaches vwait. A bare vwait on an already-set variable then waits forever. With the wait guarded, the file completes and reports ordinary divergences: the parent read succeeds immediately, the timing assertion observes no wait, and xSleep is not called.

## Tests
- LIBRARY_PATH=/opt/homebrew/lib make testfixture
- bash ../test/run_testfixture.sh "walsetlk recover bucket" 300 walsetlk_recover
- bash ../test/run_testfixture.sh "walsetlk storage group" 300 walsetlk walsetlk_recover walsetlk_snapshot walsetlk2 walsetlk3
- bash ../test/run_testfixture.sh "SQLite regression ported" 300 <ported bucket tests>
- Full local storage bucket reached and passed walsetlk_recover; the overall local Mac run still had unrelated bigfile/bigfile2 missing-summary crashes.