### PR TITLE
Avoid remote writes for no-op dolt_push

### DIFF
--- a/src/doltlite_remote.c
+++ b/src/doltlite_remote.c
@@ -574,23 +574,26 @@ int doltlitePush(
     return rc;
   }
 
-  if( !bForce ){
-    if( rc==SQLITE_OK && refsData ){
-      rc = remoteFindBranchFromRefsBlob(refsData, nRefsData, zBranch, &remoteCommit);
-      if( rc==SQLITE_OK && !prollyHashIsEmpty(&remoteCommit)
-          && prollyHashCompare(&remoteCommit, &localCommit)!=0 ){
+  if( refsData ){
+    rc = remoteFindBranchFromRefsBlob(refsData, nRefsData, zBranch, &remoteCommit);
+    if( rc==SQLITE_OK && !prollyHashIsEmpty(&remoteCommit) ){
+      int cmp = prollyHashCompare(&remoteCommit, &localCommit);
+      if( cmp==0 ){
+        sqlite3_free(refsData);
+        return SQLITE_OK;
+      }else if( !bForce ){
         int isAnc = syncIsAncestor(pLocal, &remoteCommit, &localCommit);
         if( isAnc <= 0 ){
           sqlite3_free(refsData);
           return isAnc<0 ? SQLITE_NOMEM : SQLITE_ERROR;
         }
       }
-      if( rc==SQLITE_NOTFOUND ){
-        rc = SQLITE_OK;
-      }else if( rc!=SQLITE_OK ){
-        sqlite3_free(refsData);
-        return rc;
-      }
+    }
+    if( rc==SQLITE_NOTFOUND ){
+      rc = SQLITE_OK;
+    }else if( rc!=SQLITE_OK ){
+      sqlite3_free(refsData);
+      return rc;
     }
   }
   sqlite3_free(refsData);

--- a/test/remote_test.sh
+++ b/test/remote_test.sh
@@ -31,6 +31,10 @@ check_match() {
   fi
 }
 
+file_size() {
+  wc -c < "$1" | tr -d ' '
+}
+
 DB="$DOLTLITE"
 R="file://$TMPDIR"
 
@@ -225,8 +229,17 @@ check "clone has 6 users after multi-commit pull" "0
 6" "$result"
 
 echo "=== 11. Already up-to-date ==="
+remote_size_before=$(file_size "$TMPDIR/remote.db")
 result=$("$DB" "$TMPDIR/src.db" "SELECT dolt_push('origin','main');")
 check "push when up-to-date returns 0" "0" "$result"
+remote_size_after=$(file_size "$TMPDIR/remote.db")
+check "up-to-date push does not grow remote" "$remote_size_before" "$remote_size_after"
+
+remote_size_before=$(file_size "$TMPDIR/remote.db")
+result=$("$DB" "$TMPDIR/src.db" "SELECT dolt_push('origin','main','--force');")
+check "force push when up-to-date returns 0" "0" "$result"
+remote_size_after=$(file_size "$TMPDIR/remote.db")
+check "up-to-date force push does not grow remote" "$remote_size_before" "$remote_size_after"
 
 result=$("$DB" "$TMPDIR/src.db" "SELECT dolt_pull('origin','main');")
 check "pull when up-to-date returns 0" "0" "$result"


### PR DESCRIPTION
Fixes #1598.

This makes dolt_push return before chunk sync/ref writes when the remote branch already points at the local branch commit. That also applies to --force pushes, since force should bypass fast-forward validation rather than force a useless write when the branch is already synchronized.

Before the fix, the issue repro grew a file remote from 1,539 bytes to 35,339 bytes after 100 no-op pushes. After the fix, the same 100 no-op pushes leave it at 1,539 bytes.

Tests:
- Minimal 100 no-op push repro: before=1539 after=1539 delta=0
- bash test/remote_test.sh build/doltlite: 93 passed, 0 failed
- git diff --check

Note: I also tried make -C build devtest. The local run broadly failed/stalled in the All-O0 lane, including unrelated build/testfixture/fuzzcheck failures and Tcl-side poll-loop tests sharedA/lock4. I killed that run after it was clearly non-local to this change.