### PR TITLE
Decode clustered PK values in history, at, diff, and workspace tables

### DIFF
--- a/src/doltlite_at.c
+++ b/src/doltlite_at.c
@@ -229,7 +229,7 @@ static int atFilter(sqlite3_vtab_cursor *cur,
       return SQLITE_OK;
     }
     c->common.tblCurOpen = 1;
-    return doltliteVtabCommonCaptureRow(&c->common);
+    return doltliteVtabCommonCaptureRow(&c->common, v->db, v->zTableName);
   }
 
   if( seekable && c->pkRange.hasPkLo ){
@@ -252,7 +252,7 @@ static int atFilter(sqlite3_vtab_cursor *cur,
       return SQLITE_OK;
     }
     c->common.tblCurOpen = 1;
-    return doltliteVtabCommonCaptureRow(&c->common);
+    return doltliteVtabCommonCaptureRow(&c->common, v->db, v->zTableName);
   }
 
   rc = prollyCursorFirst(&c->common.tblCur, &res);
@@ -269,11 +269,12 @@ static int atFilter(sqlite3_vtab_cursor *cur,
     return SQLITE_OK;
   }
   c->common.tblCurOpen = 1;
-  return doltliteVtabCommonCaptureRow(&c->common);
+  return doltliteVtabCommonCaptureRow(&c->common, v->db, v->zTableName);
 }
 
 static int atNext(sqlite3_vtab_cursor *cur){
   AtCursor *c=(AtCursor*)cur;
+  DoltliteVtabCommon *v=(DoltliteVtabCommon*)cur->pVtab;
   int rc;
   c->common.iRowid++;
   if( !c->common.tblCurOpen ){
@@ -305,7 +306,7 @@ static int atNext(sqlite3_vtab_cursor *cur){
     c->common.hasRow = 0;
     return SQLITE_OK;
   }
-  return doltliteVtabCommonCaptureRow(&c->common);
+  return doltliteVtabCommonCaptureRow(&c->common, v->db, v->zTableName);
 }
 
 static int atColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){

--- a/src/doltlite_constraint_violations.c
+++ b/src/doltlite_constraint_violations.c
@@ -802,6 +802,17 @@ static int cvrColumn(sqlite3_vtab_cursor *cur, sqlite3_context *ctx, int col){
   if( col==0 ){
     sqlite3_result_text(ctx, violationTypeName(r->violationType), -1, SQLITE_STATIC);
   }else if( col >= 1 && col <= nUserCols ){
+    if( r->nVal==0 && r->nKey>0 ){
+      /* PK-only clustered rows store an empty value; rebuild the record from
+      ** the key once and keep it as the row's value. */
+      u8 *pRec = 0; int nRec = 0;
+      if( doltliteRecordFromClusteredKey(v->db, v->zTableName,
+              r->pKey, r->nKey, &pRec, &nRec)==SQLITE_OK && pRec ){
+        sqlite3_free(r->pVal);
+        r->pVal = pRec;
+        r->nVal = nRec;
+      }
+    }
     doltliteResultUserCol(ctx, &v->cols, r->pVal, r->nVal, r->intKey, col - 1);
   }else if( col == nUserCols + 1 ){
     sqlite3_result_text(ctx, r->zInfo ? r->zInfo : "", -1, SQLITE_TRANSIENT);

--- a/src/doltlite_diff_table.c
+++ b/src/doltlite_diff_table.c
@@ -45,6 +45,7 @@ struct AuditRow {
   i64 intKey;
   const u8 *pOldVal; int nOldVal;
   const u8 *pNewVal; int nNewVal;
+  u8 *pKeyRec; int nKeyRec;   /* owned record rebuilt from a clustered key */
   char zFromCommit[PROLLY_HASH_SIZE*2+1];
   char zToCommit[PROLLY_HASH_SIZE*2+1];
   i64 fromDate;
@@ -103,6 +104,7 @@ struct DiffTblCursor {
 #define DT_IDX_SLICE         0x02
 
 static void clearAuditRow(AuditRow *r){
+  sqlite3_free(r->pKeyRec);
   memset(r, 0, sizeof(*r));
 }
 
@@ -957,6 +959,31 @@ static int advanceToNextRow(DiffTblCursor *pCur, sqlite3 *db){
         pCur->row.nOldVal = pChange->pOldVal ? pChange->nOldVal : 0;
         pCur->row.pNewVal = pChange->pNewVal;
         pCur->row.nNewVal = pChange->pNewVal ? pChange->nNewVal : 0;
+
+        /* PK-only clustered rows store an empty value; both sides of the
+        ** change share one key, so rebuild the record from it once and let
+        ** each side that exists (per the diff type) present it. */
+        if( (pCur->row.nOldVal==0 && pChange->type!=PROLLY_DIFF_ADD)
+         || (pCur->row.nNewVal==0 && pChange->type!=PROLLY_DIFF_DELETE) ){
+          DiffTblVtab *pV = (DiffTblVtab*)pCur->base.pVtab;
+          sqlite3_free(pCur->row.pKeyRec);
+          pCur->row.pKeyRec = 0;
+          pCur->row.nKeyRec = 0;
+          rc = doltliteRecordFromClusteredKey(db, pV->zTableName,
+                   pChange->pKey, pChange->nKey,
+                   &pCur->row.pKeyRec, &pCur->row.nKeyRec);
+          if( rc!=SQLITE_OK ) return rc;
+          if( pCur->row.pKeyRec ){
+            if( pCur->row.nOldVal==0 && pChange->type!=PROLLY_DIFF_ADD ){
+              pCur->row.pOldVal = pCur->row.pKeyRec;
+              pCur->row.nOldVal = pCur->row.nKeyRec;
+            }
+            if( pCur->row.nNewVal==0 && pChange->type!=PROLLY_DIFF_DELETE ){
+              pCur->row.pNewVal = pCur->row.pKeyRec;
+              pCur->row.nNewVal = pCur->row.nKeyRec;
+            }
+          }
+        }
 
         pCur->hasRow = 1;
         pCur->iRowid++;

--- a/src/doltlite_history.c
+++ b/src/doltlite_history.c
@@ -180,7 +180,7 @@ static int htAdvance(HistCursor *c, sqlite3 *db, const char *zTableName){
         return rc;
       }
       if( prollyCursorIsValid(&c->common.tblCur) && htRowMatchesUpper(c) ){
-        return doltliteVtabCommonCaptureRow(&c->common);
+        return doltliteVtabCommonCaptureRow(&c->common, db, zTableName);
       }
       prollyCursorClose(&c->common.tblCur);
       c->common.tblCurOpen = 0;
@@ -199,7 +199,7 @@ static int htAdvance(HistCursor *c, sqlite3 *db, const char *zTableName){
     if( rc!=SQLITE_OK ) return rc;
 
     if( c->common.tblCurOpen ){
-      return doltliteVtabCommonCaptureRow(&c->common);
+      return doltliteVtabCommonCaptureRow(&c->common, db, zTableName);
     }
   }
 

--- a/src/doltlite_record.c
+++ b/src/doltlite_record.c
@@ -3,6 +3,7 @@
 
 #include "sqliteInt.h"
 #include "doltlite_record.h"
+#include "sortkey.h"
 #include <string.h>
 #include <stdio.h>
 
@@ -507,6 +508,50 @@ void doltliteResultUserCol(
   }
   doltliteResultField(ctx, pRec, nRec,
                       ri.aType[iRecField], ri.aOffset[iRecField]);
+}
+
+/* Reconstruct the row record for a clustered row whose stored value is
+** empty. When the PRIMARY KEY covers every column, the row lives entirely
+** in the sort key and the value record has no fields, so readers that only
+** look at the value (history/at/diff and friends) see NULLs. Decode the
+** sort key back into a record the same way the main read path does
+** (getCursorPayload's non-intkey branch). *ppRec receives a
+** sqlite3_malloc'd record the caller frees; it is left 0 for rowid tables,
+** which have no clustered key to decode. */
+int doltliteRecordFromClusteredKey(
+  sqlite3 *db, const char *zTable,
+  const u8 *pKey, int nKey,
+  u8 **ppRec, int *pnRec
+){
+  Table *pTab;
+  Index *pPk;
+  KeyInfo *pKI;
+  u8 *pBuf = 0;
+  int nAlloc = 0, nRec = 0;
+  int i, rc;
+
+  *ppRec = 0;
+  *pnRec = 0;
+  if( !pKey || nKey<=0 || !zTable ) return SQLITE_OK;
+  pTab = sqlite3FindTable(db, zTable, "main");
+  if( !pTab || HasRowid(pTab) ) return SQLITE_OK;
+  pPk = sqlite3PrimaryKeyIndex(pTab);
+  if( !pPk ) return SQLITE_OK;
+
+  pKI = sqlite3KeyInfoAlloc(db, pPk->nKeyCol, 0);
+  if( !pKI ) return SQLITE_NOMEM;
+  for(i=0; i<pPk->nKeyCol; i++){
+    pKI->aSortFlags[i] = pPk->aSortOrder[i];
+  }
+  rc = recordFromSortKeyBufferColl(pKey, nKey, pKI, &pBuf, &nAlloc, &nRec);
+  sqlite3KeyInfoUnref(pKI);
+  if( rc!=SQLITE_OK ){
+    sqlite3_free(pBuf);
+    return rc;
+  }
+  *ppRec = pBuf;
+  *pnRec = nRec;
+  return SQLITE_OK;
 }
 
 int doltliteBindField(

--- a/src/doltlite_vtab_util.h
+++ b/src/doltlite_vtab_util.h
@@ -56,7 +56,7 @@ static SQLITE_INLINE void doltliteVtabCommonReset(
 }
 
 static SQLITE_INLINE int doltliteVtabCommonCaptureRow(
-  DoltliteVtabCursorCommon *c
+  DoltliteVtabCursorCommon *c, sqlite3 *db, const char *zTableName
 ){
   const u8 *pVal; int nVal;
   sqlite3_free(c->pVal);
@@ -68,6 +68,16 @@ static SQLITE_INLINE int doltliteVtabCommonCaptureRow(
     if( !c->pVal ) return SQLITE_NOMEM;
     memcpy(c->pVal, pVal, nVal);
     c->nVal = nVal;
+  }else{
+    /* Clustered rows whose PRIMARY KEY covers every column store an empty
+    ** value; the row lives in the sort key. Rebuild the record from the key
+    ** so column reads see the PK values instead of NULLs. */
+    const u8 *pKey; int nKey;
+    int rc;
+    prollyCursorKey(&c->tblCur, &pKey, &nKey);
+    rc = doltliteRecordFromClusteredKey(db, zTableName, pKey, nKey,
+                                        &c->pVal, &c->nVal);
+    if( rc!=SQLITE_OK ) return rc;
   }
   c->hasRow = 1;
   return SQLITE_OK;

--- a/src/doltlite_workspace.c
+++ b/src/doltlite_workspace.c
@@ -125,6 +125,31 @@ static int wsAppendRow(
     memcpy(row.pNewVal, pChange->pNewVal, pChange->nNewVal);
     row.nNewVal = pChange->nNewVal;
   }
+  /* PK-only clustered rows store an empty value; rebuild the record from the
+  ** key for each side the diff type says exists. */
+  if( (row.nOldVal==0 && pChange->type!=PROLLY_DIFF_ADD)
+   || (row.nNewVal==0 && pChange->type!=PROLLY_DIFF_DELETE) ){
+    u8 *pRec = 0; int nRec = 0;
+    if( doltliteRecordFromClusteredKey(pVtab->db, pVtab->zTableName,
+            pChange->pKey, pChange->nKey, &pRec, &nRec)!=SQLITE_OK ){
+      goto nomem;
+    }
+    if( pRec ){
+      if( row.nOldVal==0 && pChange->type!=PROLLY_DIFF_ADD ){
+        row.pOldVal = sqlite3_malloc(nRec);
+        if( !row.pOldVal ){ sqlite3_free(pRec); goto nomem; }
+        memcpy(row.pOldVal, pRec, nRec);
+        row.nOldVal = nRec;
+      }
+      if( row.nNewVal==0 && pChange->type!=PROLLY_DIFF_DELETE ){
+        row.pNewVal = sqlite3_malloc(nRec);
+        if( !row.pNewVal ){ sqlite3_free(pRec); goto nomem; }
+        memcpy(row.pNewVal, pRec, nRec);
+        row.nNewVal = nRec;
+      }
+      sqlite3_free(pRec);
+    }
+  }
   if( pVtab->nCache>=pVtab->nCacheAlloc ){
     nNew = pVtab->nCacheAlloc ? pVtab->nCacheAlloc*2 : 16;
     aNew = sqlite3_realloc(pVtab->aCache,

--- a/src/record_codec.h
+++ b/src/record_codec.h
@@ -47,6 +47,8 @@ void doltliteFreeColInfo(DoltliteColInfo *ci);
 void doltliteResultField(sqlite3_context *ctx, const u8 *pData, int nData,
                          int serialType, int offset);
 
+int doltliteRecordFromClusteredKey(sqlite3 *db, const char *zTable,
+    const u8 *pKey, int nKey, u8 **ppRec, int *pnRec);
 void doltliteResultUserCol(sqlite3_context *ctx,
                            const DoltliteColInfo *ci,
                            const u8 *pRec, int nRec,

--- a/test/doltlite_recover_history_pk.test
+++ b/test/doltlite_recover_history_pk.test
@@ -1,0 +1,98 @@
+# 2026-07-13
+#
+# History/at/diff/workspace tables must decode PRIMARY KEY values for every
+# key shape. Rows whose PRIMARY KEY covers all columns store an empty value
+# record (the row lives in the clustered sort key), so readers that only
+# consult the value record returned NULL for every column: single TEXT/BLOB/
+# REAL PKs and composite PKs of any type. Single INTEGER PKs took the intkey
+# path and worked all along.
+#
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+set testprefix doltlite_recover_history_pk
+
+db close
+forcedelete hpk.db
+sqlite3 db hpk.db
+
+do_execsql_test 1.0 {
+  CREATE TABLE t_text(k TEXT PRIMARY KEY);
+  CREATE TABLE t_blob(k BLOB PRIMARY KEY);
+  CREATE TABLE t_real(k REAL PRIMARY KEY);
+  CREATE TABLE t_int (k INTEGER PRIMARY KEY);
+  CREATE TABLE t_comp(p INT, c INT, PRIMARY KEY(p,c));
+  CREATE TABLE t_mix (a TEXT, b REAL, c BLOB, PRIMARY KEY(a,b,c));
+  CREATE TABLE t_desc(a INT, b INT, PRIMARY KEY(a DESC, b));
+  CREATE TABLE t_nc  (k TEXT COLLATE NOCASE PRIMARY KEY);
+  INSERT INTO t_text VALUES('hello');
+  INSERT INTO t_blob VALUES(x'deadbeef');
+  INSERT INTO t_real VALUES(3.25);
+  INSERT INTO t_int  VALUES(42);
+  INSERT INTO t_comp VALUES(1,2),(1,3);
+  INSERT INTO t_mix  VALUES('x',1.5,x'0102');
+  INSERT INTO t_desc VALUES(10,20);
+  INSERT INTO t_nc   VALUES('MiXeD');
+} {}
+do_test 1.1 {
+  regexp {[0-9a-f]{40}} [db one {SELECT dolt_commit('-A','-m','c1')}]
+} {1}
+
+# Point-in-time reads decode the key for every PK shape.
+do_execsql_test 2.1 { SELECT quote(k) FROM dolt_at_t_text('HEAD') } {'hello'}
+do_execsql_test 2.2 { SELECT quote(k) FROM dolt_at_t_blob('HEAD') } {X'DEADBEEF'}
+do_execsql_test 2.3 { SELECT quote(k) FROM dolt_at_t_real('HEAD') } {3.25}
+do_execsql_test 2.4 { SELECT quote(k) FROM dolt_at_t_int('HEAD') } {42}
+do_execsql_test 2.5 {
+  SELECT p, c FROM dolt_at_t_comp('HEAD') ORDER BY p, c
+} {1 2 1 3}
+do_execsql_test 2.6 {
+  SELECT quote(a), quote(b), quote(c) FROM dolt_at_t_mix('HEAD')
+} {'x' 1.5 X'0102'}
+do_execsql_test 2.7 { SELECT a, b FROM dolt_at_t_desc('HEAD') } {10 20}
+do_execsql_test 2.8 { SELECT quote(k) FROM dolt_at_t_nc('HEAD') } {'MiXeD'}
+
+# History tables decode the key.
+do_execsql_test 3.1 { SELECT quote(k) FROM dolt_history_t_text } {'hello'}
+do_execsql_test 3.2 {
+  SELECT p, c FROM dolt_history_t_comp ORDER BY p, c
+} {1 2 1 3}
+
+# Workspace (uncommitted) changes decode the key.
+do_execsql_test 4.0 {
+  INSERT INTO t_comp VALUES(5,6);
+  INSERT INTO t_text VALUES('world');
+} {}
+do_execsql_test 4.1 {
+  SELECT to_p, to_c, diff_type FROM dolt_workspace_t_comp
+} {5 6 added}
+do_execsql_test 4.2 {
+  SELECT quote(to_k), diff_type FROM dolt_workspace_t_text
+} {'world' added}
+
+# Committed diffs decode the key on both sides.
+do_test 5.0 {
+  regexp {[0-9a-f]{40}} [db one {SELECT dolt_commit('-A','-m','c2')}]
+} {1}
+do_execsql_test 5.1 {
+  DELETE FROM t_comp WHERE p=1 AND c=3;
+  DELETE FROM t_text WHERE k='hello';
+} {}
+do_test 5.2 {
+  regexp {[0-9a-f]{40}} [db one {SELECT dolt_commit('-A','-m','c3')}]
+} {1}
+do_execsql_test 5.3 {
+  SELECT from_p, from_c, diff_type FROM dolt_diff_t_comp
+   WHERE diff_type='removed'
+} {1 3 removed}
+do_execsql_test 5.4 {
+  SELECT quote(from_k), diff_type FROM dolt_diff_t_text
+   WHERE diff_type='removed'
+} {'hello' removed}
+do_execsql_test 5.5 {
+  SELECT quote(to_k), diff_type FROM dolt_diff_t_text
+   WHERE to_commit_date IS NOT NULL AND diff_type='added'
+   ORDER BY to_k
+} {'hello' added 'world' added}
+
+db close
+finish_test

--- a/test/regression-buckets/ported.txt
+++ b/test/regression-buckets/ported.txt
@@ -2,6 +2,7 @@ doltlite_recover_collation
 doltlite_recover_corruption
 doltlite_recover_backup_fault
 doltlite_recover_fts3_optimize
+doltlite_recover_history_pk
 doltlite_recover_incrblob
 doltlite_recover_jrnlwal_1
 doltlite_recover_jrnlwal_2

--- a/test/vc_oracle_pk_only_tables_test.sh
+++ b/test/vc_oracle_pk_only_tables_test.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+#
+# Oracle tests for tables whose PRIMARY KEY covers every column. Such rows
+# store an empty value record (the row lives in the clustered key), a shape
+# no other oracle scenario exercises: every diff/history/at oracle table
+# carries a non-PK column, which is exactly what masked the NULL-decode bugs
+# in the history-family tables. Dolt is ground truth for row values in
+# dolt_diff_/dolt_history_ and point-in-time reads.
+
+set -u
+
+DOLTLITE="${1:-./doltlite}"
+DOLT="${2:-dolt}"
+TMPROOT=$(mktemp -d)
+trap "rm -rf $TMPROOT" EXIT
+pass=0; fail=0
+FAILED_NAMES=""
+source "$(dirname "$0")/lib/vc_oracle_common.sh"
+
+translate_for_dolt() {
+  sed -E "
+    s/SELECT[[:space:]]+(dolt_[a-z_]+\()/CALL \1/g
+    s/dolt_diff_([a-zA-Z0-9_]+)\('([^']*)', *'([^']*)'\)/dolt_diff_\1 WHERE to_commit IN (SELECT commit_hash FROM dolt_log('\2..\3'))/g
+  "
+}
+
+oracle() {
+  local name="$1" setup="$2" query="$3" dolt_query_override="${4:-}"
+  local dir="$TMPROOT/$name"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  local dl_out
+  dl_out=$(printf "%s\n.headers off\n.mode list\n%s\n" "$setup" "$query" \
+           | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
+           | tr -d '\r' \
+           | grep '^R|' | sort)
+
+  local dolt_setup dolt_query
+  dolt_setup=$(echo "$setup" | translate_for_dolt)
+  if [ -n "$dolt_query_override" ]; then
+    dolt_query="$dolt_query_override"
+  else
+    dolt_query=$(echo "$query" | translate_for_dolt)
+  fi
+
+  local dt_out
+  (
+    cd "$dir/dt" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    {
+      echo "$dolt_setup"
+      echo "$dolt_query"
+    } | "$DOLT" sql -c -r csv 2>"$dir/dt.err"
+  ) > "$dir/dt.raw"
+  dt_out=$(tr -d '"\r' < "$dir/dt.raw" | grep '^R|' | sort)
+
+  vc_oracle_assert_match "$name" "$dl_out" "$dt_out"
+}
+
+echo "=== Version Control Oracle Tests: PK-covers-all-columns tables ==="
+echo ""
+
+SETUP_LINK="
+CREATE TABLE link(p INTEGER, c INTEGER, PRIMARY KEY(p, c));
+INSERT INTO link VALUES (1, 2), (1, 3), (2, 4);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'seed');
+DELETE FROM link WHERE p = 1 AND c = 3;
+INSERT INTO link VALUES (5, 6);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'c2');
+"
+
+echo "--- Group A: composite INT PK, no other columns ---"
+
+oracle "a_diff_table" "$SETUP_LINK" \
+  "SELECT CONCAT('R|', IFNULL(to_p,''), '|', IFNULL(to_c,''), '|', IFNULL(from_p,''), '|', IFNULL(from_c,''), '|', diff_type) FROM dolt_diff_link;"
+
+oracle "a_diff_range" "$SETUP_LINK" \
+  "SELECT CONCAT('R|', IFNULL(to_p,''), '|', IFNULL(to_c,''), '|', IFNULL(from_p,''), '|', IFNULL(from_c,''), '|', diff_type) FROM dolt_diff_link('HEAD~1', 'HEAD');"
+
+oracle "a_history" "$SETUP_LINK" \
+  "SELECT CONCAT('R|', IFNULL(p,''), '|', IFNULL(c,'')) FROM dolt_history_link;"
+
+oracle "a_as_of" "$SETUP_LINK" \
+  "SELECT CONCAT('R|', p, '|', c) FROM dolt_at_link WHERE commit_ref = 'HEAD~1';" \
+  "SELECT CONCAT('R|', p, '|', c) FROM link AS OF 'HEAD~1';"
+
+echo "--- Group B: single VARCHAR PK, no other columns ---"
+
+SETUP_TAGS="
+CREATE TABLE tags(name VARCHAR(30), PRIMARY KEY(name));
+INSERT INTO tags VALUES ('alpha'), ('beta');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'seed');
+DELETE FROM tags WHERE name = 'beta';
+INSERT INTO tags VALUES ('gamma');
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'c2');
+"
+
+oracle "b_diff_table" "$SETUP_TAGS" \
+  "SELECT CONCAT('R|', IFNULL(to_name,''), '|', IFNULL(from_name,''), '|', diff_type) FROM dolt_diff_tags;"
+
+oracle "b_history" "$SETUP_TAGS" \
+  "SELECT CONCAT('R|', IFNULL(name,'')) FROM dolt_history_tags;"
+
+oracle "b_as_of" "$SETUP_TAGS" \
+  "SELECT CONCAT('R|', name) FROM dolt_at_tags WHERE commit_ref = 'HEAD~1';" \
+  "SELECT CONCAT('R|', name) FROM tags AS OF 'HEAD~1';"
+
+echo "--- Group C: mixed VARCHAR+INT composite PK, no other columns ---"
+
+SETUP_MIX="
+CREATE TABLE ev(kind VARCHAR(20), seq INTEGER, PRIMARY KEY(kind, seq));
+INSERT INTO ev VALUES ('boot', 1), ('boot', 2), ('halt', 1);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'seed');
+DELETE FROM ev WHERE kind = 'boot' AND seq = 2;
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'c2');
+"
+
+oracle "c_diff_table" "$SETUP_MIX" \
+  "SELECT CONCAT('R|', IFNULL(to_kind,''), '|', IFNULL(to_seq,''), '|', IFNULL(from_kind,''), '|', IFNULL(from_seq,''), '|', diff_type) FROM dolt_diff_ev;"
+
+oracle "c_history" "$SETUP_MIX" \
+  "SELECT CONCAT('R|', IFNULL(kind,''), '|', IFNULL(seq,'')) FROM dolt_history_ev;"
+
+echo "--- Group D: workspace (uncommitted) changes ---"
+
+SETUP_WS="
+CREATE TABLE link(p INTEGER, c INTEGER, PRIMARY KEY(p, c));
+INSERT INTO link VALUES (1, 2);
+SELECT dolt_add('-A'); SELECT dolt_commit('-m', 'seed');
+INSERT INTO link VALUES (7, 8);
+DELETE FROM link WHERE p = 1 AND c = 2;
+"
+
+oracle "d_workspace" "$SETUP_WS" \
+  "SELECT CONCAT('R|', IFNULL(to_p,''), '|', IFNULL(to_c,''), '|', IFNULL(from_p,''), '|', IFNULL(from_c,''), '|', diff_type) FROM dolt_workspace_link;"
+
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+if [ -n "$FAILED_NAMES" ]; then
+  echo "Failed:$FAILED_NAMES"
+fi
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## Problem

Rows whose PRIMARY KEY covers every column (composite-PK join tables, single TEXT/BLOB/REAL PK tables) returned **NULL for every column** in `dolt_at_`, `dolt_history_`, `dolt_diff_`, and `dolt_workspace_` tables. Such rows store an empty value record — the row lives entirely in the clustered sort key — and the readers only consulted the value record (plus the intkey fast path, which is why single INTEGER PKs worked).

## Fix

New `doltliteRecordFromClusteredKey`: look up the table's PK index, build a KeyInfo carrying its sort flags (DESC keys invert their sort-key bytes), and decode the key back into a PK-first record via `recordFromSortKeyBufferColl` — the same reconstruction the main read path already does in `getCursorPayload`'s non-intkey branch. Wired into:

| Surface | How |
|---|---|
| `dolt_at_`, `dolt_history_` | `doltliteVtabCommonCaptureRow`: empty captured value → rebuild from cursor key |
| `dolt_diff_` | both sides share one key; rebuild once, present per side the diff type says exists |
| `dolt_workspace_` | same, materialized into the cached row |
| `dolt_constraint_violations_` | rebuild lazily from the stored key |
| `dolt_conflicts_` | **no change needed** — conflict records store full value records, and PK-only tables cannot produce row conflicts (verified with a live merge conflict on a text-PK table) |

## Key-type audit

Verified decode across `dolt_at_`/`dolt_diff_` for: TEXT, BLOB, REAL, INTEGER single PKs; 2- and 3-column composites (mixed types); `PRIMARY KEY(a DESC, b)` (exercises the sort-flag inversion); `COLLATE NOCASE` (original case preserved); explicit `WITHOUT ROWID`. All correct.

## Tests

- **Dolt-oracle, read surfaces**: `vc_oracle_pk_only_tables_test.sh` — every prior diff/history/at oracle scenario used tables with a non-PK column, exactly the shape that masked these bugs. Compares composite-INT, single-VARCHAR, and mixed PK-only tables against real Dolt across `dolt_diff_` (both forms), `dolt_history_`, `AS OF`, and `dolt_workspace_`: **0/10 unfixed → 10/10 fixed**.
- **Dolt-oracle, VC operations**: `vc_oracle_pk_shapes_vc_ops_test.sh` — merge, cherry-pick, revert, rebase, reset --hard, checkout, and status previously had oracle coverage only for `id INT PRIMARY KEY` tables. Each now runs across four key shapes (composite INT, single VARCHAR, mixed VARCHAR+INT, PK-covers-all-columns) with table contents compared against real Dolt: **28/28** — and 28/28 on pre-fix master too, i.e. the op engines already handled clustered keys correctly; this locks that in.
- **Native testfixture**: `doltlite_recover_history_pk` (ported bucket) extends coverage to BLOB/REAL/DESC/NOCASE keys: **11/22 fail unfixed → 22/22 pass**.
- Both issue repro scripts produce expected values end-to-end. C-test gate 16/16; `doltlite_gc.sh` and `run_doltlite_tests.sh` pass.
- Perf: local A/B master-vs-branch on `branch_create_delete`/`checkout_branch_clean` is identical (38/38ms, 87/86ms); the one red vc-perf run was a loaded runner (same-code pass 7 min earlier, flake-family job failing on the same run).

Fixes #1597
Fixes #1599

🤖 Generated with [Claude Code](https://claude.com/claude-code)