### PR TITLE
Fix dolt_at tables outside current branch

### DIFF
--- a/src/doltlite_at.c
+++ b/src/doltlite_at.c
@@ -47,6 +47,46 @@ struct AtCursor {
   DoltlitePkRange pkRange;
 };
 
+typedef struct AtSeenTable AtSeenTable;
+struct AtSeenTable {
+  char **azName;
+  int nName;
+  int nAlloc;
+};
+
+static void atSeenTableClear(AtSeenTable *pSeen){
+  int i;
+  for(i=0; i<pSeen->nName; i++) sqlite3_free(pSeen->azName[i]);
+  sqlite3_free(pSeen->azName);
+  memset(pSeen, 0, sizeof(*pSeen));
+}
+
+static int atSeenTableHas(AtSeenTable *pSeen, const char *zName){
+  int i;
+  for(i=0; i<pSeen->nName; i++){
+    if( strcmp(pSeen->azName[i], zName)==0 ) return 1;
+  }
+  return 0;
+}
+
+static int atSeenTableAdd(AtSeenTable *pSeen, const char *zName){
+  char *zCopy;
+  if( atSeenTableHas(pSeen, zName) ) return SQLITE_OK;
+  if( pSeen->nName>=pSeen->nAlloc ){
+    int nNew = pSeen->nAlloc ? pSeen->nAlloc*2 : 16;
+    char **azNew;
+    if( nNew > 0x7fffffff/(int)sizeof(char*) ) return SQLITE_NOMEM;
+    azNew = sqlite3_realloc(pSeen->azName, nNew*(int)sizeof(char*));
+    if( !azNew ) return SQLITE_NOMEM;
+    pSeen->azName = azNew;
+    pSeen->nAlloc = nNew;
+  }
+  zCopy = sqlite3_mprintf("%s", zName);
+  if( !zCopy ) return SQLITE_NOMEM;
+  pSeen->azName[pSeen->nName++] = zCopy;
+  return SQLITE_OK;
+}
+
 static void atCursorReset(AtCursor *c){
   doltliteVtabCommonReset(&c->common);
   sqlite3_free(c->zCommitRef);
@@ -65,10 +105,127 @@ static int atRowMatchesUpper(AtCursor *c){
 
 static int atConnect(sqlite3 *db, void *pAux, int argc,
     const char *const*argv, sqlite3_vtab **ppVtab, char **pzErr){
+  DoltliteVtabCommon *v;
+  const char *zMod = argv[0];
+  size_t nPrefix = strlen("dolt_at_");
+  char *zSchema;
+  int rc;
   (void)pAux;
-  return doltliteVtabConnectUserTable(db, argc, argv, "dolt_at_",
-                                      sizeof(AtVtab), atBuildSchema,
-                                      ppVtab, pzErr);
+
+  v = sqlite3_malloc(sizeof(AtVtab));
+  if( !v ) return SQLITE_NOMEM;
+  memset(v, 0, sizeof(AtVtab));
+  v->db = db;
+
+  if( zMod && strncmp(zMod, "dolt_at_", nPrefix)==0 ){
+    v->zTableName = sqlite3_mprintf("%s", zMod + nPrefix);
+  }else if( argc > 3 ){
+    v->zTableName = sqlite3_mprintf("%s", argv[3]);
+  }else{
+    v->zTableName = sqlite3_mprintf("");
+  }
+  if( !v->zTableName ){
+    doltliteVtabCommonDisconnect(&v->base);
+    return SQLITE_NOMEM;
+  }
+
+  if( sqlite3FindTable(db, v->zTableName, "main") ){
+    rc = doltliteGetColumnNames(db, v->zTableName, &v->cols);
+  }else{
+    rc = SQLITE_NOTFOUND;
+  }
+  if( rc==SQLITE_OK && v->cols.nCol<=0 ){
+    doltliteFreeColInfo(&v->cols);
+    rc = SQLITE_NOTFOUND;
+  }
+  if( rc==SQLITE_NOTFOUND ){
+    rc = SQLITE_OK;
+  }
+  if( rc==SQLITE_OK && v->cols.nCol<=0 ){
+    ChunkStore *cs = doltliteGetChunkStore(db);
+    ProllyCache *pCache = doltliteGetCache(db);
+    const BranchRef *aBr = 0;
+    const TagRef *aTag = 0;
+    int nBr = 0, nTag = 0, i, has;
+    DoltliteCommitQueue q;
+    ProllyHash cur;
+    ProllyHash head;
+    memset(&q, 0, sizeof(q));
+    memset(&cur, 0, sizeof(cur));
+    memset(&head, 0, sizeof(head));
+    rc = doltliteCommitQueueInit(&q, &cur);
+    if( rc==SQLITE_OK && cs ){
+      doltliteGetSessionHead(db, &head);
+      rc = doltliteCommitQueueEnqueue(&q, &head);
+    }
+    if( rc==SQLITE_OK && cs ){
+      refsTableGetBranches(&cs->refs, &nBr, &aBr);
+      for(i=0; i<nBr && rc==SQLITE_OK; i++){
+        rc = doltliteCommitQueueEnqueue(&q, &aBr[i].commitHash);
+      }
+      refsTableGetTags(&cs->refs, &nTag, &aTag);
+      for(i=0; i<nTag && rc==SQLITE_OK; i++){
+        rc = doltliteCommitQueueEnqueue(&q, &aTag[i].commitHash);
+      }
+    }
+    while( rc==SQLITE_OK && v->cols.nCol<=0 ){
+      DoltliteCommit commit;
+      SchemaEntry entry;
+      int found = 0;
+      sqlite3 *tmp = 0;
+      memset(&entry, 0, sizeof(entry));
+      rc = doltliteCommitQueueNext(&q, &cur, &has);
+      if( rc!=SQLITE_OK || !has ) break;
+      rc = doltliteLoadCommit(db, &cur, &commit);
+      if( rc!=SQLITE_OK ) break;
+      rc = doltliteCommitQueueEnqueueParents(&q, &commit);
+      if( rc==SQLITE_OK ){
+        rc = loadSchemaEntryFromCatalog(db, cs, pCache, &commit.catalogHash,
+                                        v->zTableName, &entry, &found);
+      }
+      if( rc==SQLITE_OK && found && entry.zSql ){
+        rc = sqlite3_open(":memory:", &tmp);
+        if( rc==SQLITE_OK ){
+          rc = sqlite3_exec(tmp, entry.zSql, 0, 0, 0);
+        }
+        if( rc==SQLITE_OK ){
+          rc = doltliteGetColumnNames(tmp, v->zTableName, &v->cols);
+          if( rc==SQLITE_OK && v->cols.nCol<=0 ){
+            doltliteFreeColInfo(&v->cols);
+            rc = SQLITE_NOTFOUND;
+          }
+        }
+      }
+      if( tmp ) sqlite3_close(tmp);
+      clearSchemaEntry(&entry);
+      doltliteCommitClear(&commit);
+      if( rc==SQLITE_NOTFOUND ) rc = SQLITE_OK;
+    }
+    doltliteCommitQueueClear(&q);
+  }
+
+  if( rc==SQLITE_OK && v->cols.nCol<=0 ){
+    rc = SQLITE_ERROR;
+    if( pzErr ){
+      *pzErr = sqlite3_mprintf("table not found in reachable refs: %s",
+                               v->zTableName);
+    }
+  }
+  if( rc==SQLITE_OK ){
+    zSchema = atBuildSchema(&v->cols);
+    if( !zSchema ){
+      rc = SQLITE_NOMEM;
+    }else{
+      rc = sqlite3_declare_vtab(db, zSchema);
+      sqlite3_free(zSchema);
+    }
+  }
+  if( rc!=SQLITE_OK ){
+    doltliteVtabCommonDisconnect(&v->base);
+    return rc;
+  }
+  *ppVtab = &v->base;
+  return SQLITE_OK;
 }
 
 static int atOpen(sqlite3_vtab *pVtab, sqlite3_vtab_cursor **pp){
@@ -336,8 +493,87 @@ static sqlite3_module atModule = {
   0,0,0,0,0,0,0,0,0,0,0,0
 };
 
+static int atRegisterOne(sqlite3 *db, AtSeenTable *pSeen, const char *zName){
+  char *zMod;
+  int rc;
+  if( !zName || atSeenTableHas(pSeen, zName) ) return SQLITE_OK;
+  zMod = sqlite3_mprintf("dolt_at_%s", zName);
+  if( !zMod ) return SQLITE_NOMEM;
+  rc = sqlite3_create_module(db, zMod, &atModule, 0);
+  sqlite3_free(zMod);
+  if( rc!=SQLITE_OK ) return rc;
+  return atSeenTableAdd(pSeen, zName);
+}
+
+static int atRegisterCatalogTables(
+  sqlite3 *db,
+  const ProllyHash *pCatHash,
+  AtSeenTable *pSeen
+){
+  struct TableEntry *aTables = 0;
+  int nTables = 0;
+  int i, rc;
+  if( prollyHashIsEmpty(pCatHash) ) return SQLITE_OK;
+  rc = doltliteLoadCatalog(db, pCatHash, &aTables, &nTables, 0);
+  if( rc!=SQLITE_OK ) return rc;
+  for(i=0; i<nTables && rc==SQLITE_OK; i++){
+    if( aTables[i].zName && aTables[i].iTable > 1 ){
+      rc = atRegisterOne(db, pSeen, aTables[i].zName);
+    }
+  }
+  doltliteFreeCatalog(aTables, nTables);
+  return rc;
+}
+
 int doltliteRegisterAtTables(sqlite3 *db){
-  return doltliteForEachUserTable(db, "dolt_at_", &atModule);
+  ChunkStore *cs = doltliteGetChunkStore(db);
+  const BranchRef *aBr = 0;
+  const TagRef *aTag = 0;
+  int nBr = 0, nTag = 0;
+  int i, has, rc;
+  DoltliteCommitQueue q;
+  ProllyHash cur;
+  ProllyHash head;
+  AtSeenTable seen;
+
+  memset(&q, 0, sizeof(q));
+  memset(&cur, 0, sizeof(cur));
+  memset(&head, 0, sizeof(head));
+  memset(&seen, 0, sizeof(seen));
+
+  if( !cs ) return SQLITE_OK;
+
+  rc = doltliteCommitQueueInit(&q, &cur);
+  if( rc!=SQLITE_OK ) return rc;
+
+  doltliteGetSessionHead(db, &head);
+  rc = doltliteCommitQueueEnqueue(&q, &head);
+
+  refsTableGetBranches(&cs->refs, &nBr, &aBr);
+  for(i=0; i<nBr && rc==SQLITE_OK; i++){
+    rc = doltliteCommitQueueEnqueue(&q, &aBr[i].commitHash);
+  }
+  refsTableGetTags(&cs->refs, &nTag, &aTag);
+  for(i=0; i<nTag && rc==SQLITE_OK; i++){
+    rc = doltliteCommitQueueEnqueue(&q, &aTag[i].commitHash);
+  }
+
+  while( rc==SQLITE_OK ){
+    DoltliteCommit commit;
+    rc = doltliteCommitQueueNext(&q, &cur, &has);
+    if( rc!=SQLITE_OK || !has ) break;
+    rc = doltliteLoadCommit(db, &cur, &commit);
+    if( rc!=SQLITE_OK ) break;
+    rc = atRegisterCatalogTables(db, &commit.catalogHash, &seen);
+    if( rc==SQLITE_OK ){
+      rc = doltliteCommitQueueEnqueueParents(&q, &commit);
+    }
+    doltliteCommitClear(&commit);
+  }
+
+  doltliteCommitQueueClear(&q);
+  atSeenTableClear(&seen);
+  return rc;
 }
 
 #endif

--- a/test/vc_oracle_at_test.sh
+++ b/test/vc_oracle_at_test.sh
@@ -79,13 +79,19 @@ oracle_error() {
 
 oracle_table_after_reopen() {
   local name="$1" setup="$2" table="$3" ref="$4"
+  local dl_q="SELECT 'A' || char(9) || coalesce(id,'') || char(9) || coalesce(v,'') FROM dolt_at_${table} WHERE commit_ref = '${ref}' ORDER BY id"
+  local dt_q="SELECT concat('A', char(9), coalesce(id,''), char(9), coalesce(v,'')) FROM ${table} AS OF '${ref}' ORDER BY id"
+  oracle_query_after_reopen "$name" "$setup" "$dl_q" "$dt_q"
+}
+
+oracle_query_after_reopen() {
+  local name="$1" setup="$2" dl_q="$3" dt_q="$4"
   local dir="$TMPROOT/$name"
   mkdir -p "$dir/dl" "$dir/dt"
 
   vc_oracle_run_doltlite_script "$dir/dl/db" "$dir/dl.setup.out" \
     "$dir/dl.setup.err" "$setup"
 
-  local dl_q="SELECT 'A' || char(9) || coalesce(id,'') || char(9) || coalesce(v,'') FROM dolt_at_${table} WHERE commit_ref = '${ref}' ORDER BY id"
   local dl_out
   dl_out=$(printf ".headers off\n.mode list\n.separator '\t'\n%s;\n" "$dl_q" \
            | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
@@ -95,7 +101,6 @@ oracle_table_after_reopen() {
 
   local dolt_setup
   dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
-  local dt_q="SELECT concat('A', char(9), coalesce(id,''), char(9), coalesce(v,'')) FROM ${table} AS OF '${ref}' ORDER BY id"
 
   local dt_out
   dt_out=$(
@@ -183,6 +188,82 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'feature table');
 SELECT dolt_checkout('main');
 " "feature_only" "feature"
+
+echo "--- branch-only table schema shapes after reopen ---"
+
+oracle_query_after_reopen "at_branch_only_text_pk" "
+$SEED
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+CREATE TABLE text_pk_only(code VARCHAR(32) PRIMARY KEY, v TEXT);
+INSERT INTO text_pk_only VALUES ('b', 'text-two');
+INSERT INTO text_pk_only VALUES ('a', 'text-one');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'text pk table');
+SELECT dolt_checkout('main');
+" \
+"SELECT 'A' || char(9) || coalesce(code,'') || char(9) || coalesce(v,'') FROM dolt_at_text_pk_only WHERE commit_ref = 'feature' ORDER BY code" \
+"SELECT concat('A', char(9), coalesce(code,''), char(9), coalesce(v,'')) FROM text_pk_only AS OF 'feature' ORDER BY code"
+
+oracle_query_after_reopen "at_branch_only_composite_pk" "
+$SEED
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+CREATE TABLE comp_only(org VARCHAR(32), id INT, v TEXT, PRIMARY KEY(org, id));
+INSERT INTO comp_only VALUES ('org-b', 2, 'comp-two');
+INSERT INTO comp_only VALUES ('org-a', 1, 'comp-one');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'composite pk table');
+SELECT dolt_checkout('main');
+" \
+"SELECT 'A' || char(9) || coalesce(org,'') || char(9) || coalesce(id,'') || char(9) || coalesce(v,'') FROM dolt_at_comp_only WHERE commit_ref = 'feature' ORDER BY org, id" \
+"SELECT concat('A', char(9), coalesce(org,''), char(9), coalesce(id,''), char(9), coalesce(v,'')) FROM comp_only AS OF 'feature' ORDER BY org, id"
+
+oracle_query_after_reopen "at_branch_only_extra_columns" "
+$SEED
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+CREATE TABLE extra_only(id INT PRIMARY KEY, v TEXT, n INT, note TEXT);
+INSERT INTO extra_only VALUES (1, 'extra-one', 42, NULL);
+INSERT INTO extra_only VALUES (2, 'extra-two', NULL, 'has-note');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'extra column table');
+SELECT dolt_checkout('main');
+" \
+"SELECT 'A' || char(9) || coalesce(id,'') || char(9) || coalesce(v,'') || char(9) || CASE WHEN n IS NULL THEN 'NULL' ELSE CAST(n AS CHAR) END || char(9) || coalesce(note,'NULL') FROM dolt_at_extra_only WHERE commit_ref = 'feature' ORDER BY id" \
+"SELECT concat('A', char(9), coalesce(id,''), char(9), coalesce(v,''), char(9), CASE WHEN n IS NULL THEN 'NULL' ELSE CAST(n AS CHAR) END, char(9), coalesce(note,'NULL')) FROM extra_only AS OF 'feature' ORDER BY id"
+
+oracle_query_after_reopen "at_branch_schema_changed_common_columns" "
+$SEED
+CREATE TABLE changing(id INT PRIMARY KEY, v TEXT);
+INSERT INTO changing VALUES (1, 'main-one');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'changing base');
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+ALTER TABLE changing ADD COLUMN extra TEXT;
+UPDATE changing SET v = 'feature-one', extra = 'feature-extra' WHERE id = 1;
+INSERT INTO changing VALUES (2, 'feature-two', 'feature-extra-two');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'changing feature schema');
+SELECT dolt_checkout('main');
+" \
+"SELECT 'A' || char(9) || coalesce(id,'') || char(9) || coalesce(v,'') FROM dolt_at_changing WHERE commit_ref = 'feature' ORDER BY id" \
+"SELECT concat('A', char(9), coalesce(id,''), char(9), coalesce(v,'')) FROM changing AS OF 'feature' ORDER BY id"
+
+oracle_query_after_reopen "at_branch_only_quoted_table_name" "
+$SEED
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+CREATE TABLE \`feature only\`(id INT PRIMARY KEY, v TEXT);
+INSERT INTO \`feature only\` VALUES (1, 'quoted-one');
+INSERT INTO \`feature only\` VALUES (2, 'quoted-two');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'quoted table');
+SELECT dolt_checkout('main');
+" \
+"SELECT 'A' || char(9) || coalesce(id,'') || char(9) || coalesce(v,'') FROM \"dolt_at_feature only\" WHERE commit_ref = 'feature' ORDER BY id" \
+"SELECT concat('A', char(9), coalesce(id,''), char(9), coalesce(v,'')) FROM \`feature only\` AS OF 'feature' ORDER BY id"
 
 echo "--- tag ref ---"
 

--- a/test/vc_oracle_at_test.sh
+++ b/test/vc_oracle_at_test.sh
@@ -77,6 +77,39 @@ oracle_error() {
   fi
 }
 
+oracle_table_after_reopen() {
+  local name="$1" setup="$2" table="$3" ref="$4"
+  local dir="$TMPROOT/$name"
+  mkdir -p "$dir/dl" "$dir/dt"
+
+  vc_oracle_run_doltlite_script "$dir/dl/db" "$dir/dl.setup.out" \
+    "$dir/dl.setup.err" "$setup"
+
+  local dl_q="SELECT 'A' || char(9) || coalesce(id,'') || char(9) || coalesce(v,'') FROM dolt_at_${table} WHERE commit_ref = '${ref}' ORDER BY id"
+  local dl_out
+  dl_out=$(printf ".headers off\n.mode list\n.separator '\t'\n%s;\n" "$dl_q" \
+           | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
+           | grep -v '^[0-9]*$' \
+           | grep -v '^[0-9a-f]\{40\}$' \
+           | normalize)
+
+  local dolt_setup
+  dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
+  local dt_q="SELECT concat('A', char(9), coalesce(id,''), char(9), coalesce(v,'')) FROM ${table} AS OF '${ref}' ORDER BY id"
+
+  local dt_out
+  dt_out=$(
+    cd "$dir/dt" || exit 1
+    vc_oracle_init_repo
+    {
+      printf '%s\n' "$dolt_setup"
+      printf '%s;\n' "$dt_q"
+    } | "$DOLT" sql -c -r csv 2>"$dir/dt.err" | tr -d '"' | normalize
+  )
+
+  vc_oracle_assert_match "$name" "$dl_out" "$dt_out"
+}
+
 echo "=== Version Control Oracle Tests: dolt_at_<table> ==="
 echo ""
 
@@ -139,6 +172,18 @@ SELECT dolt_commit('-m', 'feat1');
 SELECT dolt_checkout('main');
 " "feature"
 
+oracle_table_after_reopen "at_table_only_on_sibling_branch" "
+$SEED
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+CREATE TABLE feature_only(id INT PRIMARY KEY, v TEXT);
+INSERT INTO feature_only VALUES (1, 'feature-one');
+INSERT INTO feature_only VALUES (2, 'feature-two');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'feature table');
+SELECT dolt_checkout('main');
+" "feature_only" "feature"
+
 echo "--- tag ref ---"
 
 oracle "at_tag" "
@@ -158,6 +203,19 @@ SELECT dolt_tag('v1', 'HEAD~1');
 SELECT dolt_branch('from_tag', 'v1');
 " "from_tag"
 
+oracle_table_after_reopen "at_table_only_at_tag" "
+$SEED
+CREATE TABLE tagged_only(id INT PRIMARY KEY, v TEXT);
+INSERT INTO tagged_only VALUES (1, 'tagged-one');
+INSERT INTO tagged_only VALUES (2, 'tagged-two');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'tagged table');
+SELECT dolt_tag('has_tagged_only');
+DROP TABLE tagged_only;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'drop tagged table');
+" "tagged_only" "has_tagged_only"
+
 echo "--- bare commit hash ref ---"
 
 oracle "at_recent_commit_via_head" "
@@ -173,6 +231,18 @@ INSERT INTO t VALUES (3, 30);
 SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'c2');
 " "HEAD~1"
+
+oracle_table_after_reopen "at_dropped_table_at_head_minus_1" "
+$SEED
+CREATE TABLE dropped_only(id INT PRIMARY KEY, v TEXT);
+INSERT INTO dropped_only VALUES (1, 'dropped-one');
+INSERT INTO dropped_only VALUES (2, 'dropped-two');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'dropped table');
+DROP TABLE dropped_only;
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'drop dropped table');
+" "dropped_only" "HEAD~1"
 
 echo "--- working set is NOT visible at any ref ---"
 


### PR DESCRIPTION
Fixes #1603.

This changes dolt_at_<table> registration to include user tables found in reachable branch/tag history, not only the current HEAD catalog. It also lets dolt_at_<table> connect using historical schema metadata when the table is absent from the current live SQLite schema.

Coverage added to vc_oracle_at_test.sh for:
- a table that exists only on a sibling branch after reopening on main
- a table that exists only at a tag after being dropped
- a table that exists at HEAD~1 after being dropped from HEAD

Verified:
- make -C build doltlite
- exact issue repro returns 1|visible on feature
- test/vc_oracle_at_test.sh build/doltlite /opt/homebrew/bin/dolt (21 passed)
- bash test/doltlite_at.sh build/doltlite (46 passed)
- git diff --check