### PR TITLE
Harden dolt_at historical table oracle coverage

### DIFF
--- a/test/vc_oracle_at_test.sh
+++ b/test/vc_oracle_at_test.sh
@@ -79,13 +79,19 @@ oracle_error() {
 
 oracle_table_after_reopen() {
   local name="$1" setup="$2" table="$3" ref="$4"
+  local dl_q="SELECT 'A' || char(9) || coalesce(id,'') || char(9) || coalesce(v,'') FROM dolt_at_${table} WHERE commit_ref = '${ref}' ORDER BY id"
+  local dt_q="SELECT concat('A', char(9), coalesce(id,''), char(9), coalesce(v,'')) FROM ${table} AS OF '${ref}' ORDER BY id"
+  oracle_query_after_reopen "$name" "$setup" "$dl_q" "$dt_q"
+}
+
+oracle_query_after_reopen() {
+  local name="$1" setup="$2" dl_q="$3" dt_q="$4"
   local dir="$TMPROOT/$name"
   mkdir -p "$dir/dl" "$dir/dt"
 
   vc_oracle_run_doltlite_script "$dir/dl/db" "$dir/dl.setup.out" \
     "$dir/dl.setup.err" "$setup"
 
-  local dl_q="SELECT 'A' || char(9) || coalesce(id,'') || char(9) || coalesce(v,'') FROM dolt_at_${table} WHERE commit_ref = '${ref}' ORDER BY id"
   local dl_out
   dl_out=$(printf ".headers off\n.mode list\n.separator '\t'\n%s;\n" "$dl_q" \
            | "$DOLTLITE" "$dir/dl/db" 2>"$dir/dl.err" \
@@ -95,7 +101,6 @@ oracle_table_after_reopen() {
 
   local dolt_setup
   dolt_setup=$(vc_oracle_translate_for_dolt "$setup")
-  local dt_q="SELECT concat('A', char(9), coalesce(id,''), char(9), coalesce(v,'')) FROM ${table} AS OF '${ref}' ORDER BY id"
 
   local dt_out
   dt_out=$(
@@ -183,6 +188,82 @@ SELECT dolt_add('-A');
 SELECT dolt_commit('-m', 'feature table');
 SELECT dolt_checkout('main');
 " "feature_only" "feature"
+
+echo "--- branch-only table schema shapes after reopen ---"
+
+oracle_query_after_reopen "at_branch_only_text_pk" "
+$SEED
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+CREATE TABLE text_pk_only(code VARCHAR(32) PRIMARY KEY, v TEXT);
+INSERT INTO text_pk_only VALUES ('b', 'text-two');
+INSERT INTO text_pk_only VALUES ('a', 'text-one');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'text pk table');
+SELECT dolt_checkout('main');
+" \
+"SELECT 'A' || char(9) || coalesce(code,'') || char(9) || coalesce(v,'') FROM dolt_at_text_pk_only WHERE commit_ref = 'feature' ORDER BY code" \
+"SELECT concat('A', char(9), coalesce(code,''), char(9), coalesce(v,'')) FROM text_pk_only AS OF 'feature' ORDER BY code"
+
+oracle_query_after_reopen "at_branch_only_composite_pk" "
+$SEED
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+CREATE TABLE comp_only(org VARCHAR(32), id INT, v TEXT, PRIMARY KEY(org, id));
+INSERT INTO comp_only VALUES ('org-b', 2, 'comp-two');
+INSERT INTO comp_only VALUES ('org-a', 1, 'comp-one');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'composite pk table');
+SELECT dolt_checkout('main');
+" \
+"SELECT 'A' || char(9) || coalesce(org,'') || char(9) || coalesce(id,'') || char(9) || coalesce(v,'') FROM dolt_at_comp_only WHERE commit_ref = 'feature' ORDER BY org, id" \
+"SELECT concat('A', char(9), coalesce(org,''), char(9), coalesce(id,''), char(9), coalesce(v,'')) FROM comp_only AS OF 'feature' ORDER BY org, id"
+
+oracle_query_after_reopen "at_branch_only_extra_columns" "
+$SEED
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+CREATE TABLE extra_only(id INT PRIMARY KEY, v TEXT, n INT, note TEXT);
+INSERT INTO extra_only VALUES (1, 'extra-one', 42, NULL);
+INSERT INTO extra_only VALUES (2, 'extra-two', NULL, 'has-note');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'extra column table');
+SELECT dolt_checkout('main');
+" \
+"SELECT 'A' || char(9) || coalesce(id,'') || char(9) || coalesce(v,'') || char(9) || CASE WHEN n IS NULL THEN 'NULL' ELSE CAST(n AS CHAR) END || char(9) || coalesce(note,'NULL') FROM dolt_at_extra_only WHERE commit_ref = 'feature' ORDER BY id" \
+"SELECT concat('A', char(9), coalesce(id,''), char(9), coalesce(v,''), char(9), CASE WHEN n IS NULL THEN 'NULL' ELSE CAST(n AS CHAR) END, char(9), coalesce(note,'NULL')) FROM extra_only AS OF 'feature' ORDER BY id"
+
+oracle_query_after_reopen "at_branch_schema_changed_common_columns" "
+$SEED
+CREATE TABLE changing(id INT PRIMARY KEY, v TEXT);
+INSERT INTO changing VALUES (1, 'main-one');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'changing base');
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+ALTER TABLE changing ADD COLUMN extra TEXT;
+UPDATE changing SET v = 'feature-one', extra = 'feature-extra' WHERE id = 1;
+INSERT INTO changing VALUES (2, 'feature-two', 'feature-extra-two');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'changing feature schema');
+SELECT dolt_checkout('main');
+" \
+"SELECT 'A' || char(9) || coalesce(id,'') || char(9) || coalesce(v,'') FROM dolt_at_changing WHERE commit_ref = 'feature' ORDER BY id" \
+"SELECT concat('A', char(9), coalesce(id,''), char(9), coalesce(v,'')) FROM changing AS OF 'feature' ORDER BY id"
+
+oracle_query_after_reopen "at_branch_only_quoted_table_name" "
+$SEED
+SELECT dolt_branch('feature');
+SELECT dolt_checkout('feature');
+CREATE TABLE \`feature only\`(id INT PRIMARY KEY, v TEXT);
+INSERT INTO \`feature only\` VALUES (1, 'quoted-one');
+INSERT INTO \`feature only\` VALUES (2, 'quoted-two');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'quoted table');
+SELECT dolt_checkout('main');
+" \
+"SELECT 'A' || char(9) || coalesce(id,'') || char(9) || coalesce(v,'') FROM \"dolt_at_feature only\" WHERE commit_ref = 'feature' ORDER BY id" \
+"SELECT concat('A', char(9), coalesce(id,''), char(9), coalesce(v,'')) FROM \`feature only\` AS OF 'feature' ORDER BY id"
 
 echo "--- tag ref ---"
 


### PR DESCRIPTION
Stacked on #1605.

Adds VC oracle coverage for adjacent dolt_at_<table> cases after reopening on a branch where the table/schema is not current:
- non-INTEGER primary key table
- composite primary key table
- extra non-PK columns including NULLs
- same table name with schema changed on another branch, reading common columns
- quoted table name

These cases compare actual row data against Dolt, not just table existence.

Verified:
- test/vc_oracle_at_test.sh build/doltlite /opt/homebrew/bin/dolt (26 passed)
- bash test/doltlite_at.sh build/doltlite (46 passed)
- git diff --check