### PR TITLE
Add fetch/pull convergence oracle; file dolt_pull auto-merge gap (#1611)

### DIFF
--- a/test/vc_oracle_fetch_pull_convergence_test.sh
+++ b/test/vc_oracle_fetch_pull_convergence_test.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+#
+# Oracle: after cloning a remote, fetching/pulling later pushes must converge
+# the consumer to the remote the same way real Dolt does -- fast-forward
+# pulls, divergent (merge) pulls, and multi-branch fetch + tracking checkout.
+# The existing vc_oracle_remotes suite covers a single fetch/checkout; this
+# adds the incremental "remote advances, consumer catches up" surface.
+#
+# doltlite consumes with dolt_clone/dolt_fetch/dolt_pull against a file:// .db
+# remote; Dolt clones a directory remote and fetches/pulls there. Commit
+# hashes and wall-clock dates differ by design and are never compared; row
+# sets, counts, commit messages, branch lists, and active branch are.
+
+set -u
+
+DOLTLITE="${1:-./doltlite}"
+DOLT="${2:-dolt}"
+TMPROOT=$(mktemp -d)
+trap 'rm -rf "$TMPROOT"' EXIT
+pass=0; fail=0
+FAILED_NAMES=""
+source "$(dirname "$0")/lib/vc_oracle_common.sh"
+
+# Run a full doltlite-vs-dolt remote flow and compare one query. The flow is
+# expressed as three phases of engine-agnostic SQL (SELECT dolt_*; the dolt
+# side is auto-translated to CALL): $seed builds+pushes the source, $advance
+# pushes more from the source, $consume runs on the freshly cloned consumer.
+# The remote URL/dir is substituted for the token @REMOTE@.
+remote_flow() {
+  local name="$1" seed="$2" advance="$3" consume="$4" dl_query="$5" dt_query="$6"
+  local dir="$TMPROOT/$name"; mkdir -p "$dir"
+
+  # ---------- doltlite ----------
+  local dl_remote="file://$dir/remote.db"
+  local dl_src="$dir/src.db" dl_con="$dir/con.db"
+  printf '%s\n' "${seed//@REMOTE@/$dl_remote}" \
+    | "$DOLTLITE" "$dl_src" >/dev/null 2>"$dir/dl_seed.err"
+  printf 'SELECT dolt_clone('"'"'%s'"'"');\n' "$dl_remote" \
+    | "$DOLTLITE" "$dl_con" >/dev/null 2>"$dir/dl_clone.err"
+  if [ -n "$advance" ]; then
+    printf '%s\n' "${advance//@REMOTE@/$dl_remote}" \
+      | "$DOLTLITE" "$dl_src" >/dev/null 2>"$dir/dl_advance.err"
+  fi
+  printf '%s\n' "$consume" | "$DOLTLITE" "$dl_con" >/dev/null 2>"$dir/dl_consume.err"
+  local dl_out
+  dl_out=$(printf '.headers off\n.mode list\n%s\n' "$dl_query" \
+           | "$DOLTLITE" "$dl_con" 2>"$dir/dl.err" | tr -d '\r' | grep '^R|' | sort)
+
+  # ---------- dolt ----------
+  local dt_remote="$dir/dt_remote"
+  local dt_seed dt_advance dt_consume dt_q
+  dt_seed=$(vc_oracle_translate_for_dolt "${seed//@REMOTE@/file://$dt_remote}")
+  dt_advance=$(vc_oracle_translate_for_dolt "${advance//@REMOTE@/file://$dt_remote}")
+  dt_consume=$(vc_oracle_translate_for_dolt "$consume")
+  dt_q=$(vc_oracle_translate_for_dolt "$dt_query")
+  local dt_out
+  (
+    mkdir -p "$dir/dsrc" "$dt_remote"
+    cd "$dir/dsrc" || exit 1
+    "$DOLT" init --name oracle --email oracle@test >/dev/null 2>&1
+    printf '%s\n' "$dt_seed" | "$DOLT" sql -c >/dev/null 2>"$dir/dt_seed.err"
+    cd "$dir" || exit 1
+    "$DOLT" clone "file://$dt_remote" dcon >/dev/null 2>"$dir/dt_clone.err"
+    if [ -n "$dt_advance" ]; then
+      ( cd "$dir/dsrc" && printf '%s\n' "$dt_advance" | "$DOLT" sql -c >/dev/null 2>"$dir/dt_advance.err" )
+    fi
+    cd "$dir/dcon" || exit 1
+    printf '%s\n' "$dt_consume" | "$DOLT" sql -c >/dev/null 2>"$dir/dt_consume.err"
+    printf '%s\n' "$dt_q" | "$DOLT" sql -r csv 2>"$dir/dt.err"
+  ) > "$dir/dt.raw"
+  dt_out=$(tr -d '"\r' < "$dir/dt.raw" | grep '^R|' | sort)
+
+  vc_oracle_assert_match "$name" "$dl_out" "$dt_out"
+}
+
+echo "=== Version Control Oracle Test: fetch/pull convergence ==="
+echo ""
+
+# ---- fast-forward pull: remote gains two commits, consumer pulls ----
+FF_SEED="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1,'one');
+SELECT dolt_commit('-A','-m','c1');
+SELECT dolt_remote('add','origin','@REMOTE@');
+SELECT dolt_push('origin','main');
+"
+FF_ADVANCE="
+INSERT INTO t VALUES (2,'two');
+SELECT dolt_commit('-A','-m','c2');
+INSERT INTO t VALUES (3,'three');
+SELECT dolt_commit('-A','-m','c3');
+SELECT dolt_push('origin','main');
+"
+FF_PULL="SELECT dolt_pull('origin','main');"
+
+echo "--- fast-forward pull ---"
+remote_flow "ff_contents" "$FF_SEED" "$FF_ADVANCE" "$FF_PULL" \
+  "SELECT 'R|'||id||'|'||v FROM t;" \
+  "SELECT CONCAT('R|',id,'|',v) FROM t;"
+remote_flow "ff_log_messages" "$FF_SEED" "$FF_ADVANCE" "$FF_PULL" \
+  "SELECT 'R|'||message FROM dolt_log;" \
+  "SELECT CONCAT('R|',message) FROM dolt_log;"
+remote_flow "ff_log_count" "$FF_SEED" "$FF_ADVANCE" "$FF_PULL" \
+  "SELECT 'R|'||count(*) FROM dolt_log;" \
+  "SELECT CONCAT('R|',count(*)) FROM dolt_log;"
+
+# ---- fetch (no merge): remote advances, consumer fetches; working stays put,
+#      origin/main advances. Compare the tracked-ref row count via a topic
+#      branch off origin/main. ----
+echo "--- fetch then track origin/main ---"
+FETCH_TRACK="
+SELECT dolt_fetch('origin','main');
+SELECT dolt_checkout('-b','topic','origin/main');
+"
+remote_flow "fetch_track_contents" "$FF_SEED" "$FF_ADVANCE" "$FETCH_TRACK" \
+  "SELECT 'R|'||active_branch()||'|'||count(*) FROM t;" \
+  "SELECT CONCAT('R|',active_branch(),'|',count(*)) FROM t;"
+
+# ---- divergent fetch+merge: consumer commits a disjoint row locally while
+#      the remote gains a disjoint row; fetch + merge('origin/main') unifies
+#      them. (doltlite's dolt_pull is fast-forward-only and errors on
+#      divergence -- issue #1611; fetch+merge is the supported
+#      convergence path and is what both engines are compared on here.) ----
+echo "--- divergent fetch + merge (no conflict) ---"
+MERGE_SEED="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1,'base');
+SELECT dolt_commit('-A','-m','c1');
+SELECT dolt_remote('add','origin','@REMOTE@');
+SELECT dolt_push('origin','main');
+"
+MERGE_ADVANCE="
+INSERT INTO t VALUES (200,'from-remote');
+SELECT dolt_commit('-A','-m','remote row');
+SELECT dolt_push('origin','main');
+"
+MERGE_PULL="
+INSERT INTO t VALUES (100,'from-local');
+SELECT dolt_commit('-A','-m','local row');
+SELECT dolt_fetch('origin','main');
+SELECT dolt_merge('origin/main');
+"
+remote_flow "merge_contents" "$MERGE_SEED" "$MERGE_ADVANCE" "$MERGE_PULL" \
+  "SELECT 'R|'||id||'|'||v FROM t;" \
+  "SELECT CONCAT('R|',id,'|',v) FROM t;"
+remote_flow "merge_rowcount" "$MERGE_SEED" "$MERGE_ADVANCE" "$MERGE_PULL" \
+  "SELECT 'R|'||count(*) FROM t;" \
+  "SELECT CONCAT('R|',count(*)) FROM t;"
+
+# ---- multi-branch fetch: two branches pushed; consumer fetches and tracks
+#      each; compare contents per tracked branch. ----
+echo "--- multi-branch fetch + tracking ---"
+MB_SEED="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1,'base');
+SELECT dolt_commit('-A','-m','c1');
+SELECT dolt_remote('add','origin','@REMOTE@');
+SELECT dolt_push('origin','main');
+SELECT dolt_checkout('-b','featA');
+INSERT INTO t VALUES (2,'a');
+SELECT dolt_commit('-A','-m','a');
+SELECT dolt_push('origin','featA');
+SELECT dolt_checkout('main');
+SELECT dolt_checkout('-b','featB');
+INSERT INTO t VALUES (3,'b');
+SELECT dolt_commit('-A','-m','b');
+SELECT dolt_push('origin','featB');
+SELECT dolt_checkout('main');
+"
+remote_flow "mb_featA" "$MB_SEED" "" \
+  "SELECT dolt_fetch('origin','featA'); SELECT dolt_checkout('-b','ta','origin/featA');" \
+  "SELECT 'R|'||id||'|'||v FROM t;" \
+  "SELECT CONCAT('R|',id,'|',v) FROM t;"
+remote_flow "mb_featB" "$MB_SEED" "" \
+  "SELECT dolt_fetch('origin','featB'); SELECT dolt_checkout('-b','tb','origin/featB');" \
+  "SELECT 'R|'||id||'|'||v FROM t;" \
+  "SELECT CONCAT('R|',id,'|',v) FROM t;"
+
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+if [ -n "$FAILED_NAMES" ]; then
+  echo "Failed:$FAILED_NAMES"
+fi
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## What

New Dolt-oracle suite `vc_oracle_fetch_pull_convergence_test.sh` built on the consume-once remote harness, covering the incremental "remote advances, consumer catches up" surface that the existing `vc_oracle_remotes` suite (single fetch/checkout) didn't:

| Scenario | Asserts |
|---|---|
| fast-forward pull | table contents, log messages, log count after `dolt_pull` |
| fetch + track `origin/main` | active branch + row count on a topic branch off the fetched ref |
| divergent fetch + merge | merged row set + count (disjoint local vs remote rows) |
| multi-branch fetch | contents on each of two tracked branches (`origin/featA`, `origin/featB`) |

8 assertions, deterministic across repeated runs. Hashes/dates excluded; row sets, counts, commit messages, branch lists, and active branch compared against Dolt 2.1.8.

## Divergence found + filed: #1611

The oracle caught that **doltlite's `dolt_pull` is fast-forward-only** — on divergent histories it errors (`cannot fast-forward — use dolt_merge with the tracking branch instead`) where Dolt's pull auto-merges. Verified the documented workaround `dolt_fetch` + `dolt_merge('origin/main')` converges identically to Dolt's pulled result (3 rows), so the oracle locks in that supported path for both engines and #1611 tracks giving `dolt_pull` its fetch-then-merge fallback.

CI auto-discovers `vc_oracle_*`; this runs in `oracle-tests` from here on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)