### PR TITLE
Fix hard-reset untracked preservation: two-domain catalog corruption

### DIFF
--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -2226,10 +2226,35 @@ static int doltlitePreserveUntrackedTablesOnHardReset(
     pStmt = 0;
   }
 
+  /* An untracked table's indexes carry their own catalog entries. */
+  if( rc==SQLITE_OK && nUntracked>0 ){
+    rc = sqlite3_prepare_v2(db,
+        "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name=?",
+        -1, &pStmt, 0);
+    for(j=0; rc==SQLITE_OK && j<nUntracked; j++){
+      sqlite3_bind_text(pStmt, 1, azUntracked[j], -1, SQLITE_STATIC);
+      while( sqlite3_step(pStmt)==SQLITE_ROW ){
+        const char *zIdx = (const char*)sqlite3_column_text(pStmt, 0);
+        char **aNew;
+        if( !zIdx ) continue;
+        aNew = sqlite3_realloc(azUntracked,
+            (nUntracked+1)*(int)sizeof(char*));
+        if( !aNew ){ rc = SQLITE_NOMEM; break; }
+        azUntracked = aNew;
+        azUntracked[nUntracked++] = sqlite3_mprintf("%s", zIdx);
+      }
+      sqlite3_reset(pStmt);
+    }
+    sqlite3_finalize(pStmt);
+    pStmt = 0;
+  }
+
   if( rc==SQLITE_OK && nUntracked>0 ){
     ProllyHash workingHash;
     struct TableEntry *aWorking = 0, *aTarget = 0;
-    int nWorking = 0, nTarget = 0;
+    SchemaEntry *aWorkSchema = 0;
+    int nWorking = 0, nTarget = 0, nWorkSchema = 0;
+    Pgno iNextFree = 2;
 
     rc = doltliteFlushCatalogToHash(db, &workingHash);
     if( rc==SQLITE_OK ){
@@ -2239,34 +2264,56 @@ static int doltlitePreserveUntrackedTablesOnHardReset(
       rc = doltliteLoadCatalog(db, pTargetCatHash, &aTarget, &nTarget, 0);
     }
     if( rc==SQLITE_OK ){
-      for(j=0; j<nWorking; j++){
-        int tgtIdx = -1;
-        if( aWorking[j].iTable==1 ) continue;
-        for(k=0; k<nTarget; k++){
-          if( aTarget[k].zName && aWorking[j].zName
-           && strcmp(aTarget[k].zName, aWorking[j].zName)==0 ){
-            tgtIdx = k;
+      rc = loadSchemaFromCatalog(db, cs, doltliteGetCache(db), &workingHash,
+                                 &aWorkSchema, &nWorkSchema);
+    }
+    /* Build FROM the target so every tracked table -- including ones
+    ** dropped in the working tree -- is restored, then append the
+    ** untracked entries renumbered past the target range (working numbers
+    ** can collide with target numbers for different tables). Loaded index
+    ** entries carry no name, so each untracked object is located through
+    ** the working schema rows (name -> working number -> entry); its
+    ** schema row reaches the blob via the fallback list, which pairs by
+    ** name and stamps the appended number. */
+    if( rc==SQLITE_OK ){
+      for(k=0; k<nTarget; k++){
+        if( aTarget[k].iTable >= iNextFree ) iNextFree = aTarget[k].iTable + 1;
+      }
+      for(j=0; j<nUntracked && rc==SQLITE_OK; j++){
+        SchemaEntry *pSe = findSchemaEntry(aWorkSchema, nWorkSchema,
+                                           azUntracked[j]);
+        struct TableEntry *pWork = 0;
+        struct TableEntry *aNew;
+        char *zDup;
+        if( !pSe || pSe->iRootpage<=1 ) continue;
+        for(k=0; k<nWorking; k++){
+          if( aWorking[k].iTable==pSe->iRootpage ){
+            pWork = &aWorking[k];
             break;
           }
         }
-        if( tgtIdx>=0 ){
-          char *zDup = aTarget[tgtIdx].zName
-                         ? sqlite3_mprintf("%s", aTarget[tgtIdx].zName) : 0;
-          if( aTarget[tgtIdx].zName && !zDup ){
-            rc = SQLITE_NOMEM;
-            break;
-          }
-          sqlite3_free(aWorking[j].zName);
-          aWorking[j] = aTarget[tgtIdx];
-          aWorking[j].zName = zDup;
+        if( !pWork ) continue;
+        zDup = sqlite3_mprintf("%s", azUntracked[j]);
+        aNew = zDup ? sqlite3_realloc(aTarget,
+                        (nTarget+1)*(int)sizeof(struct TableEntry)) : 0;
+        if( !aNew ){
+          sqlite3_free(zDup);
+          rc = SQLITE_NOMEM;
+          break;
         }
+        aTarget = aNew;
+        aTarget[nTarget] = *pWork;
+        aTarget[nTarget].zName = zDup;
+        aTarget[nTarget].iTable = iNextFree++;
+        nTarget++;
       }
     }
     if( rc==SQLITE_OK ){
       u8 *buf = 0;
       int nBuf = 0;
       ProllyHash mergedHash;
-      rc = doltliteSerializeCatalogEntries(db, aWorking, nWorking, &buf, &nBuf);
+      rc = doltliteSerializeCatalogEntriesForeignDomain(
+          db, aTarget, nTarget, aWorkSchema, nWorkSchema, &buf, &nBuf);
       if( rc==SQLITE_OK ){
         rc = chunkStorePut(cs, buf, nBuf, &mergedHash);
       }
@@ -2277,6 +2324,10 @@ static int doltlitePreserveUntrackedTablesOnHardReset(
     }
     doltliteFreeCatalog(aWorking, nWorking);
     doltliteFreeCatalog(aTarget, nTarget);
+    if( aWorkSchema ){
+      for(j=0; j<nWorkSchema; j++) clearSchemaEntry(&aWorkSchema[j]);
+      sqlite3_free(aWorkSchema);
+    }
   }
 
   if( pStmt ) sqlite3_finalize(pStmt);

--- a/src/doltlite.c
+++ b/src/doltlite.c
@@ -2007,9 +2007,11 @@ static int resetStageNamedPaths(
   int nPaths
 ){
   struct TableEntry *aHead = 0, *aStaged = 0;
-  int nHead = 0, nStaged = 0;
+  SchemaEntry *aHeadSchema = 0;
+  int nHead = 0, nStaged = 0, nHeadSchema = 0;
   ProllyHash headCatHash, stagedHash;
-  int p;
+  Pgno iNextFree = 2;
+  int p, k;
   int rc;
 
   rc = doltliteGetHeadCatalogHash(db, &headCatHash);
@@ -2017,15 +2019,22 @@ static int resetStageNamedPaths(
   if( !prollyHashIsEmpty(&headCatHash) ){
     rc = doltliteLoadCatalog(db, &headCatHash, &aHead, &nHead, 0);
     if( rc!=SQLITE_OK ) return rc;
+    rc = loadSchemaFromCatalog(db, cs, doltliteGetCache(db), &headCatHash,
+                               &aHeadSchema, &nHeadSchema);
+    if( rc!=SQLITE_OK ){
+      doltliteFreeCatalog(aHead, nHead);
+      return rc;
+    }
   }
 
   doltliteGetSessionStaged(db, &stagedHash);
   if( !prollyHashIsEmpty(&stagedHash) ){
     rc = doltliteLoadCatalog(db, &stagedHash, &aStaged, &nStaged, 0);
-    if( rc!=SQLITE_OK ){
-      doltliteFreeCatalog(aHead, nHead);
-      return rc;
-    }
+    if( rc!=SQLITE_OK ) goto done;
+  }
+
+  for(k=0; k<nStaged; k++){
+    if( aStaged[k].iTable >= iNextFree ) iNextFree = aStaged[k].iTable + 1;
   }
 
   for(p=0; p<nPaths; p++){
@@ -2045,6 +2054,10 @@ static int resetStageNamedPaths(
       }
       nStaged--;
     }else if( iS<0 ){
+      /* Restoring a staged-dropped table: the HEAD entry is numbered in
+      ** HEAD's domain and its schema row is absent from the staged master
+      ** (and from the live schema -- the table is dropped there), so it
+      ** gets a fresh number and its row comes from the HEAD fallback. */
       struct TableEntry *aNew = sqlite3_realloc(aStaged,
           (nStaged+1)*(int)sizeof(struct TableEntry));
       if( !aNew ){
@@ -2059,8 +2072,12 @@ static int resetStageNamedPaths(
       }
       aStaged[nStaged] = aHead[iH];
       aStaged[nStaged].zName = zDup;
+      aStaged[nStaged].iTable = iNextFree++;
       nStaged++;
     }else{
+      /* Take HEAD's content under the STAGED entry's number so the entry
+      ** keeps pairing with the staged catalog's schema row. */
+      Pgno iKeep = aStaged[iS].iTable;
       zDup = aHead[iH].zName ? sqlite3_mprintf("%s", aHead[iH].zName) : 0;
       if( aHead[iH].zName && !zDup ){
         rc = SQLITE_NOMEM;
@@ -2069,6 +2086,7 @@ static int resetStageNamedPaths(
       sqlite3_free(aStaged[iS].zName);
       aStaged[iS] = aHead[iH];
       aStaged[iS].zName = zDup;
+      aStaged[iS].iTable = iKeep;
     }
   }
 
@@ -2076,7 +2094,8 @@ static int resetStageNamedPaths(
     u8 *buf = 0;
     int nBuf = 0;
     ProllyHash newStagedHash;
-    rc = doltliteSerializeCatalogEntries(db, aStaged, nStaged, &buf, &nBuf);
+    rc = doltliteSerializeCatalogEntriesWithFallbackSchema(
+        db, aStaged, nStaged, aHeadSchema, nHeadSchema, &buf, &nBuf);
     if( rc==SQLITE_OK ){
       rc = chunkStorePut(cs, buf, nBuf, &newStagedHash);
     }
@@ -2089,6 +2108,10 @@ static int resetStageNamedPaths(
 done:
   doltliteFreeCatalog(aHead, nHead);
   doltliteFreeCatalog(aStaged, nStaged);
+  if( aHeadSchema ){
+    for(k=0; k<nHeadSchema; k++) clearSchemaEntry(&aHeadSchema[k]);
+    sqlite3_free(aHeadSchema);
+  }
   return rc;
 }
 

--- a/src/doltlite_internal.h
+++ b/src/doltlite_internal.h
@@ -744,6 +744,10 @@ int doltliteSerializeCatalogEntriesWithFallbackSchema(
     sqlite3 *db, struct TableEntry *aTables, int nTables,
     SchemaEntry *aFallbackSchema, int nFallbackSchema,
     u8 **ppOut, int *pnOut);
+int doltliteSerializeCatalogEntriesForeignDomain(
+    sqlite3 *db, struct TableEntry *aTables, int nTables,
+    SchemaEntry *aFallbackSchema, int nFallbackSchema,
+    u8 **ppOut, int *pnOut);
 int doltliteGetHeadCatalogHash(sqlite3 *db, ProllyHash *pCatHash);
 int doltliteFlushAndSerializeCatalog(sqlite3 *db, u8 **ppOut, int *pnOut);
 int doltliteDeserializeCatalogForTest(sqlite3 *db, const u8 *data, int nData);

--- a/src/prolly_btree.c
+++ b/src/prolly_btree.c
@@ -2085,6 +2085,7 @@ static int doltliteSerializeCatalogEntriesForBtreeImpl(
   int nTables,
   SchemaEntry *aFallbackSchema,
   int nFallbackSchema,
+  int bForeignDomain,
   u8 **ppOut,
   int *pnOut
 ){
@@ -2110,9 +2111,15 @@ static int doltliteSerializeCatalogEntriesForBtreeImpl(
     return rc;
   }
   filterSchemaCatalogRows(aRows, &nRows, aTables, nTables);
-  rc = appendMissingSchemaCatalogRows(db, btreeSchemaName(pBtree),
-                                      &aRows, &nRows, aMeta, nMeta,
-                                      aTables, nTables);
+  /* Live-schema supplementation keys rows by the CONNECTION's table
+  ** numbers. Arrays numbered in a foreign domain (a reset target catalog)
+  ** must not use it -- a live number there can belong to a different table
+  ** entirely, and their missing rows come from the fallback schema. */
+  if( !bForeignDomain ){
+    rc = appendMissingSchemaCatalogRows(db, btreeSchemaName(pBtree),
+                                        &aRows, &nRows, aMeta, nMeta,
+                                        aTables, nTables);
+  }
   if( rc==SQLITE_OK ){
     rc = appendFallbackSchemaCatalogRows(&aRows, &nRows, aTables, nTables,
                                          aFallbackSchema, nFallbackSchema);
@@ -2243,13 +2250,25 @@ static int doltliteSerializeCatalogEntriesForBtreeImpl(
         aSorted[i].zTblName = "";
         continue;
       }
-      /* The table number is the entry's identity; match it first. Cached
-      ** entry names go stale across RENAME, so a name match is only a
-      ** fallback for entries whose number has no schema row. */
-      for(j=0; j<nRows; j++){
-        if( aRows[j].oldPg==aTables[i].iTable ){
-          pRow = &aRows[j];
-          break;
+      /* The table number is the entry's identity; match it first. For the
+      ** LIVE catalog that match is unconditional -- cached entry names go
+      ** stale across RENAME, so a name match is only a fallback for entries
+      ** whose number has no schema row. Constructed arrays (staging, merge,
+      ** reset) carry authoritative loaded names but may mix entries from
+      ** two numbering domains, so a number match that disagrees on name is
+      ** a cross-domain collision and must be rejected. */
+      {
+        int bLiveCatalog = (aTables==pBtree->cat.a);
+        for(j=0; j<nRows; j++){
+          if( aRows[j].oldPg==aTables[i].iTable ){
+            if( !bLiveCatalog
+             && aTables[i].zName && aRows[j].zName
+             && strcmp(aRows[j].zName, aTables[i].zName)!=0 ){
+              continue;
+            }
+            pRow = &aRows[j];
+            break;
+          }
         }
       }
       if( !pRow && aTables[i].zName ){
@@ -2359,7 +2378,23 @@ int doltliteSerializeCatalogEntriesWithFallbackSchema(
   if( db->nDb<=0 || !db->aDb[0].pBt ) return SQLITE_ERROR;
   return doltliteSerializeCatalogEntriesForBtreeImpl(
       db->aDb[0].pBt, aTables, nTables,
-      aFallbackSchema, nFallbackSchema, ppOut, pnOut);
+      aFallbackSchema, nFallbackSchema, 0, ppOut, pnOut);
+}
+
+int doltliteSerializeCatalogEntriesForeignDomain(
+  sqlite3 *db,
+  struct TableEntry *aTables,
+  int nTables,
+  SchemaEntry *aFallbackSchema,
+  int nFallbackSchema,
+  u8 **ppOut,
+  int *pnOut
+){
+  if( !db ) return SQLITE_MISUSE;
+  if( db->nDb<=0 || !db->aDb[0].pBt ) return SQLITE_ERROR;
+  return doltliteSerializeCatalogEntriesForBtreeImpl(
+      db->aDb[0].pBt, aTables, nTables,
+      aFallbackSchema, nFallbackSchema, 1, ppOut, pnOut);
 }
 
 static int serializeCatalogPatchRoots(Btree *pBtree, u8 **ppOut, int *pnOut){
@@ -2470,7 +2505,7 @@ static int serializeCatalogPatchRoots(Btree *pBtree, u8 **ppOut, int *pnOut){
 
 static int serializeCatalog(Btree *pBtree, u8 **ppOut, int *pnOut){
   return doltliteSerializeCatalogEntriesForBtreeImpl(
-      pBtree, pBtree->cat.a, pBtree->cat.n, 0, 0, ppOut, pnOut);
+      pBtree, pBtree->cat.a, pBtree->cat.n, 0, 0, 0, ppOut, pnOut);
 }
 
 static int serializeCatalogForCommit(Btree *pBtree, u8 **ppOut, int *pnOut){

--- a/test/doltlite_reset.sh
+++ b/test/doltlite_reset.sh
@@ -236,6 +236,38 @@ run_test "path_reset_recreated_table_keeps_live_row" \
   "SELECT k || '|' || n FROM a;" \
   "7|70" "$DB10"
 
-rm -f "$DB" "$DB2" "$DB3" "$DB3B" "$DB3C" "$DB4" "$DB5" "$DB5B" "$DB5C" "$DB5C.hash" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10"
+# Hard reset with untracked tables present must restore every tracked
+# table (including ones dropped in the working tree), revert tracked
+# modifications, and preserve the untracked tables with their indexes --
+# with drops and creates having shifted the catalogs' positional numbering
+# so the merged catalog spans two numbering domains.
+DB11=/tmp/test_reset11_$$.db; rm -f "$DB11"
+$DOLTLITE "$DB11" > /dev/null 2>&1 <<'SQL'
+CREATE TABLE t1(a INTEGER PRIMARY KEY, v TEXT);
+CREATE TABLE t2(a INTEGER PRIMARY KEY, v TEXT);
+CREATE TABLE t3(a INTEGER PRIMARY KEY, v TEXT);
+CREATE INDEX i_t2 ON t2(v);
+INSERT INTO t1 VALUES(1,'one'); INSERT INTO t2 VALUES(2,'two'); INSERT INTO t3 VALUES(3,'three');
+SELECT dolt_commit('-A','-m','seed');
+DROP TABLE t1;
+UPDATE t2 SET v='MODIFIED';
+CREATE TABLE u1(x INTEGER PRIMARY KEY, w TEXT);
+CREATE INDEX i_u1 ON u1(w);
+INSERT INTO u1 VALUES(9,'kept');
+SELECT dolt_reset('--hard');
+SQL
+run_test "hard_reset_untracked_restores_dropped_table" \
+  "SELECT v FROM t1;" "one" "$DB11"
+run_test "hard_reset_untracked_reverts_modification" \
+  "SELECT v FROM t2;" "two" "$DB11"
+run_test "hard_reset_untracked_table_survives" \
+  "SELECT w FROM u1 INDEXED BY i_u1 WHERE w='kept';" "kept" "$DB11"
+run_test "hard_reset_untracked_status" \
+  "SELECT group_concat(table_name || ':' || status) FROM dolt_status;" \
+  "u1:new table" "$DB11"
+run_test "hard_reset_untracked_integrity" \
+  "PRAGMA integrity_check;" "ok" "$DB11"
+
+rm -f "$DB" "$DB2" "$DB3" "$DB3B" "$DB3C" "$DB4" "$DB5" "$DB5B" "$DB5C" "$DB5C.hash" "$DB6" "$DB7" "$DB8" "$DB9" "$DB10" "$DB11"
 
 dltest_finish

--- a/test/vc_oracle_reset_test.sh
+++ b/test/vc_oracle_reset_test.sh
@@ -669,6 +669,54 @@ CALL dolt_reset('--hard', 'bogus');
 COMMIT;
 SELECT concat('Q|', count(*)) FROM t;"
 
+echo "--- unstaging a staged drop keeps it in the working tree ---"
+
+oracle "reset_path_staged_dropped_table_unstages_drop" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+CREATE TABLE s(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+INSERT INTO s VALUES (1, 100);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+DROP TABLE s;
+SELECT dolt_add('-A');
+SELECT dolt_reset('s');
+"
+
+oracle "reset_soft_staged_new_table_stays_new" "
+CREATE TABLE t(id INTEGER PRIMARY KEY, v INT);
+INSERT INTO t VALUES (1, 10);
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+CREATE TABLE n(id INTEGER PRIMARY KEY);
+INSERT INTO n VALUES (7);
+SELECT dolt_add('-A');
+SELECT dolt_reset();
+"
+
+echo "--- hard reset preserves untracked tables ---"
+
+UNTRACKED_SEED="
+CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT);
+CREATE TABLE s(id INTEGER PRIMARY KEY, v TEXT);
+INSERT INTO t VALUES (1, 'one');
+INSERT INTO s VALUES (1, 'ess');
+SELECT dolt_add('-A');
+SELECT dolt_commit('-m', 'c1');
+DROP TABLE s;
+UPDATE t SET v = 'modified' WHERE id = 1;
+CREATE TABLE u(x INTEGER PRIMARY KEY, w TEXT);
+INSERT INTO u VALUES (9, 'kept');
+SELECT dolt_reset('--hard');
+"
+
+oracle "reset_hard_preserves_untracked_status" "$UNTRACKED_SEED"
+
+oracle_same_session "reset_hard_preserves_untracked_contents" "$UNTRACKED_SEED" \
+  "SELECT concat('Q|t|', id, '|', v) FROM t;
+SELECT concat('Q|s|', id, '|', v) FROM s;
+SELECT concat('Q|u|', x, '|', w) FROM u;"
+
 echo ""
 echo "=== Results: $pass passed, $fail failed ==="
 if [ $fail -gt 0 ]; then


### PR DESCRIPTION
Fixes hard-reset untracked preservation when reset target and working catalog table-number domains differ.\n\nAdds reset oracle coverage for preserving untracked tables and unstaging staged drops.